### PR TITLE
feat: recover topology-neutral runtime contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "simard"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simard"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2024"
 
 [dependencies]

--- a/Specs/ProductArchitecture.md
+++ b/Specs/ProductArchitecture.md
@@ -7,7 +7,7 @@ It is intentionally opinionated, directional, and lightweight enough to guide ea
 
 ## Current Codebase Context
 
-Simard now contains an initial Rust architecture scaffold organized around explicit contracts for prompt assets, base-type adapters, identity manifests, runtime control, sessions, memory, evidence, and reflection.
+Simard now contains an initial Rust architecture scaffold organized around explicit contracts for prompt assets, base-type factories and sessions, identity manifests, runtime control, topology services, memory, evidence, and reflection.
 The codebase is still early, but it is no longer a blank crate.
 This specification therefore serves two jobs at once: it defines the intended operating model and it sets the architectural constraints that the scaffold must keep preserving as implementation breadth expands.
 
@@ -16,7 +16,7 @@ This specification therefore serves two jobs at once: it defines the intended op
 The document uses the following terms with strict meanings:
 
 - **Prompt Asset**: a file-based prompt or prompt fragment that is versioned separately from runtime code.
-- **Agent Base Type**: the backend execution substrate an identity builds on, such as RustyClawd or a Copilot/Claude SDK adapter.
+- **Agent Base Type**: the backend execution substrate an identity builds on, such as RustyClawd or a Copilot/Claude SDK integration, normalized through a Simard base-type factory/session contract.
 - **Agent Identity**: the durable definition of an agent's purpose, prompts, policies, composition, and allowed behaviors.
 - **Agent Runtime**: the control plane that instantiates identities, runs sessions, manages lifecycle, and wires components together.
 - **Role**: a sub-function inside an identity, such as engineer, reviewer, or facilitator.
@@ -53,14 +53,14 @@ For delivery purposes, v1 should be interpreted narrowly:
 
 - one primary engineer loop
 - one default local single-process deployment path
-- one initially shipped adapter implementation
+- three builtin manifest-advertised base-type selections in the local scaffold: `local-harness`, `rusty-clawd`, and `copilot-sdk`, with the latter two behaving as explicit v1 aliases of the local harness implementation
 - one durable memory path
 - one small benchmark set
 
 Meeting mode, sibling identities, broader distributed execution, and self-improvement remain part of the architecture direction, but they are not v1 ship blockers.
 
 Phased delivery does **not** permit a local-only or single-base-type architecture.
-From day one, the runtime must be written for dependency injection, topology-aware composition, and multiple base types even if the first runnable path is local and only one adapter ships initially.
+From day one, the runtime must be written for dependency injection, topology-aware composition, and multiple base types even if the first runnable path is local and only a single-process harness implementation ships underneath the initial builtin selections.
 
 ## Day-One Architectural Constraints
 
@@ -68,7 +68,7 @@ The following are hard constraints for the first implementation, not deferred as
 
 - **Dependency injection from the outset**: runtime composition must happen through explicit ports, traits, and typed configuration rather than hidden globals or direct construction buried inside the core loop.
 - **Distributed-readiness from the outset**: runtime, session, memory, and reflection contracts must not assume in-process execution even when the first deployment path is single-process.
-- **Multiple base types from the outset**: identity manifests and runtime selection logic must support multiple base types immediately, even if only one concrete adapter is shipped and used in v1.
+- **Multiple base types from the outset**: identity manifests and runtime selection logic must support multiple base types immediately. In the current v1 scaffold, `local-harness`, `rusty-clawd`, and `copilot-sdk` are all selectable builtin base types, but `rusty-clawd` and `copilot-sdk` are still explicit aliases of the same local single-process harness implementation.
 - **Visible failures from the outset**: unsupported capabilities, missing prompt assets, invalid lifecycle transitions, and unsupported topologies must fail explicitly through typed errors instead of silent fallbacks.
 
 ## Non-Goals
@@ -83,7 +83,7 @@ The following are explicitly out of scope for v1.
 - Multi-user enterprise collaboration features such as permissions, shared inboxes, or hosted tenancy.
 - Detailed low-level plugin APIs before the core session, memory, and evaluation loops have proven value.
 - Shipping full distributed infrastructure, remote transport, clustering, or cross-host scheduling in v1.
-- Shipping every planned base-type adapter in v1.
+- Shipping every planned base-type backend integration in v1.
 - Shipping sibling identities such as `Cumulona` or `Victoria` in v1.
 - Automatic self-modification or autonomous promotion of changes in production paths.
 - A marketplace or plugin ecosystem for third-party identities before the core loop is proven.
@@ -113,7 +113,7 @@ The terminal is the primary execution surface, and conversational text exists to
 
 ### 2. Explicit State Over Hidden Magic
 
-Every meaningful run should have explicit session metadata, a task objective, a working memory area, and a durable output trail.
+Every meaningful run should have explicit session metadata, a live task objective, a working memory area, and a durable output trail that stores sanitized objective metadata rather than raw task text.
 If a future developer cannot explain why Simard took an action by inspecting session records, the architecture is too opaque.
 
 ### 3. Roles Must Be Separated
@@ -246,7 +246,7 @@ This is disposable and should be cheap to reset.
 
 #### 2. Session Summary
 
-A compact record written at the end of the session: objective, key actions, outcomes, changed artifacts, and follow-up items.
+A compact record written at the end of the session: sanitized objective metadata, key actions, outcomes, changed artifacts, and follow-up items.
 This is the primary bridge between one session and the next.
 
 #### 3. Project Memory
@@ -265,6 +265,7 @@ This memory is for evaluation and tuning, not for contaminating normal project c
 - Session scratch should not automatically become long-term memory.
 - Benchmark outcomes should be queryable separately from project execution history.
 - Meeting outputs should write decisions, not entire raw conversations, into durable memory.
+- V1 manifests must keep `MemoryPolicy.allow_project_writes=false` until there is an explicit project-write contract.
 
 ## Platform Architecture Layers
 
@@ -298,6 +299,14 @@ Candidate base types include:
 - GitHub Copilot SDK
 - Claude Code SDK
 - the amplihack / amplihack-rs goal-seeking agent and its OODA loop
+
+The current Simard scaffold already publishes builtin manifest-facing base-type identifiers for:
+
+- `local-harness`
+- `rusty-clawd`
+- `copilot-sdk`
+
+Those identifiers are intentionally explicit at bootstrap time. Unsupported or unregistered base-type/topology pairs must fail visibly rather than collapsing into a hidden local default, and the v1 aliases must still report the honest `local-harness` implementation identity behind them.
 
 Each base type should ideally have a Rust wrapper or adapter so the rest of the platform can interact with them through a more uniform model.
 
@@ -370,7 +379,7 @@ Without an explicit manifest and precedence model, composition will drift into h
 
 There should be a reusable starter shape for new identities.
 At the simplest end, an identity could be created from a prompt file plus a small amount of metadata.
-At the richer end, an identity could compose multiple prompts, skills, recipes, tools, subordinate identities, and multiple base-type adapters.
+At the richer end, an identity could compose multiple prompts, skills, recipes, tools, subordinate identities, and multiple base-type backend integrations.
 
 This suggests Simard should not be a one-off snowflake.
 It should help define a general identity template or starter repository that can also support sibling identities.
@@ -414,6 +423,8 @@ The runtime is responsible for:
 - transferring or attaching durable memory when work moves between machines
 - exposing reflection interfaces so the active agent can inspect its own runtime state
 
+For the current Simard repo, that runtime contract is exposed as a local CLI/bootstrap surface and in-process Rust APIs. It is not an HTTP API and it does not currently publish a database schema contract.
+
 #### Runtime Lifecycle and Control Plane
 
 The runtime needs a concrete control model, not just a responsibility list.
@@ -451,6 +462,9 @@ The identity should not need different business logic just because its internals
 
 That does not mean every topology has identical semantics.
 Ordering, latency, freshness, and partial-failure behavior may differ across deployment shapes, and the runtime must expose those guarantees honestly.
+
+In the current v1 scaffold, the default CLI bootstrap path still injects `single-process`, so builtin terminal runs fail early on `UnsupportedRuntimeTopology` if you request `multi-process` or `distributed`.
+The runtime core now also ships a second injected topology path for mesh-style runs, proving that agent logic can stay unchanged while topology services vary. That is still an internal/runtime seam, not a full distributed product feature.
 
 This is close to the hive-mind idea in amplihack:
 agent communication and memory semantics should be fundamentally the same whether the system is local or distributed.
@@ -602,8 +616,8 @@ This repository is Rust-based, so the architecture should lean into Rust where i
 - prompt assets stored as files, not embedded strings
 - typed adapters around supported base types
 - a typed identity model distinct from runtime configuration
-- a small core runtime for session state and orchestration
-- typed domain models for session records, memory entries, and benchmark results
+- a small core runtime for session state, orchestration, topology services, and handoff
+- typed domain models for session records, memory entries, evidence, and handoff snapshots
 - dependency injection through explicit runtime ports rather than hidden globals
 - clear module boundaries between control plane, execution plane, and persistence
 - minimal external dependencies until product shape stabilizes
@@ -619,9 +633,9 @@ These are directional module seams, not a frozen package layout.
 The first scaffold should keep them concrete enough to code against immediately:
 
 - `prompt_assets`: prompt asset identifiers, file-backed loading, and store contracts
-- `base_types`: adapter identifiers, capability contracts, topology support, and concrete adapter implementations
+- `base_types`: backend identifiers, capability contracts, topology support, and concrete factory/session implementations
 - `identity`: identity manifests, memory policy, mode definitions, and base-type eligibility
-- `runtime`: control-plane composition, lifecycle state, startup validation, topology, and local single-process runtime
+- `runtime`: control-plane composition, lifecycle state, startup validation, topology, handoff, and local runtime kernels
 - `session`: typed session identity, ordered lifecycle phases, and transition validation
 - `memory`: layered memory scopes, write/read contracts, and storage implementations
 - `evidence`: evidence records, provenance, and evidence sinks
@@ -637,7 +651,7 @@ The long-term architecture likely spans multiple repos, but the dependency direc
 ### Target Split
 
 - **Simard repo**: Simard identity definition, prompt assets, Simard-specific recipes, policies, and tests
-- **Shared runtime repo**: base-type adapters, lifecycle control plane, reflection, topology management, and orchestration substrate
+- **Shared runtime repo**: base-type factories/session backends, lifecycle control plane, reflection, topology management, and orchestration substrate
 - **Shared benchmark repo**: benchmark task schema, scoring, replay, and shared harness logic used by Simard and related projects such as Skwaq
 - **Shared memory repo**: durable memory primitives and storage libraries, likely continuing to live in `amplihack-memory-lib`
 
@@ -671,7 +685,7 @@ Before implementation expands past scaffolding, the project should explicitly ch
 
 - establish this specification as the product baseline
 - replace placeholder project context with Simard-specific context
-- create the minimal Rust module skeleton for prompt assets, base-type adapters, identity, runtime, session, memory, and modes
+- create the minimal Rust module skeleton for prompt assets, base-type factories/sessions, identity, runtime, session, memory, and modes
 - define benchmark task record formats and session summary formats
 - define the first identity template shape, even if initially backed by simple files
 - decide the first external prompt-file layout and loading model
@@ -684,7 +698,7 @@ Before implementation expands past scaffolding, the project should explicitly ch
 - support local repository inspection and bounded file edits
 - add durable session summaries and project memory writes
 - prove the loop on documentation and simple code-change tasks
-- implement the first base-type adapter, most likely around RustyClawd
+- implement the first real base-type factory/session backend around RustyClawd
 - keep runtime local and single-process
 - **Exit criteria:** one bounded repository task can be completed end to end with evidence and repeatable verification
 
@@ -742,7 +756,7 @@ These are deliberate next-iteration questions, not omissions in this document.
 
 ## Decision Summary
 
-Simard v1 should be built as a narrow, local, terminal-native engineering identity with one primary loop, one initial base type, explicit evidence, and disciplined session orchestration.
+Simard v1 should be built as a narrow, local, terminal-native engineering identity with one primary loop, explicit evidence, disciplined session orchestration, and multiple manifest-advertised builtin base types selectable from day one.
 It should preserve clean seams between prompt assets, agent base types, agent identities, and agent runtime so that a broader platform can emerge without corrupting the first implementation.
 The first implementation should stay small, Rust-native, and highly inspectable.
 The product wins if it can repeatedly behave like a trustworthy engineer on bounded tasks, not if it accumulates flashy but ungrounded features.

--- a/docs/concepts/topology-neutral-runtime-kernel.md
+++ b/docs/concepts/topology-neutral-runtime-kernel.md
@@ -1,0 +1,146 @@
+---
+title: "Concept: topology-neutral runtime kernel"
+description: Why Simard separates runtime requests from injected runtime services, and how that split enables truthful base-type selection, alternate topologies, and handoff restore.
+last_updated: 2026-03-29
+review_schedule: as-needed
+owner: simard
+doc_type: explanation
+related:
+  - ../index.md
+  - ../reference/runtime-contracts.md
+  - ../howto/export-and-restore-runtime-handoff.md
+  - ../tutorials/run-rusty-clawd-on-loopback-mesh.md
+  - ./truthful-runtime-metadata.md
+---
+
+# Concept: topology-neutral runtime kernel
+
+Simard uses a topology-neutral runtime kernel so the runtime can tell the truth about what was requested, what was injected, and what actually ran.
+
+## Contents
+
+- [What the runtime kernel separates](#what-the-runtime-kernel-separates)
+- [Why topology is injected instead of assumed](#why-topology-is-injected-instead-of-assumed)
+- [Why selected base type and backend identity are both visible](#why-selected-base-type-and-backend-identity-are-both-visible)
+- [Why handoff belongs inside the kernel](#why-handoff-belongs-inside-the-kernel)
+- [Why handoff payloads are sensitive before handoff redaction lands](#why-handoff-payloads-are-sensitive-before-handoff-redaction-lands)
+- [What stays out of scope](#what-stays-out-of-scope)
+
+## What the runtime kernel separates
+
+The runtime kernel splits one concern into two explicit objects:
+
+- `RuntimeRequest` answers **what** should run: identity, selected base type, and topology
+- `RuntimePorts` answers **how** it should run: prompt assets, memory, evidence, topology driver, mailbox transport, supervisor, agent program, handoff store, and session ID strategy
+
+That separation matters because Simard needs to preserve both caller intent and concrete implementation truth.
+
+Without that split, the runtime would be tempted to hide important facts such as:
+
+- whether the caller asked for `copilot-sdk` or `local-harness`
+- whether the runtime used the default in-process topology or an injected loopback mesh
+- whether a handoff store was part of the runtime boundary or bolted on afterward
+
+## Why topology is injected instead of assumed
+
+The default CLI path is intentionally narrow:
+
+- it reads bootstrap config from environment variables
+- it assembles `RuntimePorts::new(...)`
+- it runs a local `single-process` session
+
+That path is useful, but it is not the whole runtime model.
+
+Simard also supports in-process composition with caller-injected runtime services. That makes room for a second topology path built from:
+
+- `LoopbackMeshTopologyDriver`
+- `LoopbackMailboxTransport`
+- explicit supervision
+- a base type that supports the requested topology
+
+Because topology is injected, Simard can fail honestly when a driver or backend does not support the requested combination. It never has to fake support by silently changing the topology behind the caller's back.
+
+Today that practical path stops at `multi-process` for repository-provided end-to-end examples. The loopback mesh driver can advertise `distributed`, but callers still need to inject a compatible base type and the rest of the runtime services before that becomes a real run path.
+
+## Why selected base type and backend identity are both visible
+
+The runtime carries two related but different truths:
+
+- `selected_base_type` is the contract choice the caller made
+- `adapter_backend.identity` is the implementation identity that actually executed
+
+That distinction matters today.
+
+For example:
+
+- `rusty-clawd` is a real backend and reflects as `rusty-clawd::session-backend`
+- `copilot-sdk` is still an explicit alias and reflects as `local-harness`
+
+If Simard collapsed those into one field, it would either lose the caller's choice or lie about the implementation. The current kernel does neither.
+
+## Why handoff belongs inside the kernel
+
+Handoff is not a side channel.
+
+`RuntimeKernel::export_handoff()` exports the latest runtime boundary from the same runtime that owns:
+
+- session identity
+- selected base type
+- runtime node and mailbox address
+- memory records
+- evidence records
+- the injected handoff-store descriptor reported through reflection
+
+`RuntimeKernel::compose_from_handoff(...)` restores that same boundary into fresh runtime ports.
+
+Putting handoff inside the kernel gives Simard a single place to enforce restore rules:
+
+- identity must match
+- selected base type must match
+- topology is preserved in the snapshot, but current restore does not yet enforce snapshot-topology equality
+- records are rehydrated before the runtime starts
+- restored runtimes stay in `Initializing` until the caller explicitly starts them
+
+## Why handoff payloads are sensitive before handoff redaction lands
+
+Live execution and persisted memory already narrow objective text down to `objective-metadata(...)`. Handoff export does not yet.
+
+`RuntimeKernel::export_handoff()` currently clones `self.last_session` into `RuntimeHandoffSnapshot`, and `SessionRecord.objective` is stored as raw text.
+
+So the current rule is:
+
+- [PLANNED] handoff hardening should apply the same objective-metadata rule to exported session text
+- until that change lands, exported payloads must be handled as fully sensitive runtime artifacts
+
+A handoff snapshot still contains:
+
+- session IDs
+- execution phase
+- selected base type and topology
+- runtime-node and mailbox-address data
+- memory summaries
+- evidence records
+
+That payload should be handled like a runtime artifact, not like public documentation or disposable log text.
+
+## What stays out of scope
+
+This feature deliberately does **not** define:
+
+- an HTTP API
+- a remote auth or token model
+- TLS or transport-security rules for a public network protocol
+- a database schema
+- project-write behavior through memory policy
+
+Those are separate contracts.
+
+The runtime/base-type feature in this repository is a local CLI and in-process Rust contract. That narrower scope is a strength because it keeps the guarantees concrete and testable.
+
+## See also
+
+- [Runtime contracts reference](../reference/runtime-contracts.md)
+- [How to export and restore runtime handoff](../howto/export-and-restore-runtime-handoff.md)
+- [Tutorial: Run RustyClawd on the loopback mesh](../tutorials/run-rusty-clawd-on-loopback-mesh.md)
+- [Concept: truthful runtime metadata](./truthful-runtime-metadata.md)
+- [Documentation index](../index.md)

--- a/docs/concepts/truthful-runtime-metadata.md
+++ b/docs/concepts/truthful-runtime-metadata.md
@@ -32,7 +32,8 @@ The current repo guarantees:
 - prompt loading failures stay failures
 - `ManifestContract` carries `entrypoint`, `provenance`, and `freshness`
 - freshness acquisition fails explicitly instead of fabricating an epoch timestamp
-- reflection reports `adapter_backend`, `memory_backend`, and `evidence_backend` from live wiring
+- reflection reports `agent_program_backend`, `handoff_backend`, `adapter_backend`, `topology_backend`, `transport_backend`, `supervisor_backend`, `memory_backend`, and `evidence_backend` from live wiring
+- reflection reports `runtime_node` and `mailbox_address` from the injected topology and transport services
 - memory and evidence stores already report truthful backend descriptors
 - `simard::bootstrap::assemble_local_runtime` is the assembly boundary reflected by the CLI path
 - `stop()` moves the runtime into `Stopped`
@@ -61,7 +62,7 @@ Session IDs appear in:
 
 - memory records
 - evidence records
-- adapter requests
+- base-type session requests
 - reflection output
 
 The runtime addresses that boundary in two ways:
@@ -108,7 +109,7 @@ Keeping those answers together makes reflection harder to fake accidentally and 
 - keep the current explicit-default bootstrap behavior
 - keep composition behind the bootstrap assembly boundary
 - validate session IDs at parsing and injection boundaries
-- preserve truthful store descriptors and extend the same rule to adapters
+- preserve truthful store descriptors and extend the same rule to handoff stores, base-type backends, topology drivers, transports, and supervisors
 - keep session ID allocation explicit at composition boundaries
 - surface stopped runtimes with a dedicated lifecycle error
 

--- a/docs/howto/configure-bootstrap-and-inspect-reflection.md
+++ b/docs/howto/configure-bootstrap-and-inspect-reflection.md
@@ -1,7 +1,7 @@
 ---
 title: "How to configure bootstrap and inspect reflection"
 description: Verify the Simard bootstrap path and inspect the truthful reflection snapshot exposed by the runtime.
-last_updated: 2026-03-27
+last_updated: 2026-03-28
 review_schedule: as-needed
 owner: simard
 doc_type: howto
@@ -28,10 +28,14 @@ Use this guide when you need to answer two questions:
 
 Provide both the prompt root and objective yourself.
 
+For the builtin `simard-engineer` identity, the current local scaffold accepts `local-harness`, `rusty-clawd`, or `copilot-sdk` as explicit base-type choices. `rusty-clawd` is now a distinct session backend, while `copilot-sdk` remains an explicit alias of `local-harness`. The default local bootstrap path still injects `single-process`, so CLI runs must keep `SIMARD_RUNTIME_TOPOLOGY=single-process`.
+
 ```bash
 SIMARD_PROMPT_ROOT="$PWD/prompt_assets" \
 SIMARD_OBJECTIVE="verify current reflection metadata" \
 SIMARD_IDENTITY="simard-engineer" \
+SIMARD_BASE_TYPE="local-harness" \
+SIMARD_RUNTIME_TOPOLOGY="single-process" \
 cargo run --quiet
 ```
 
@@ -40,9 +44,38 @@ In the current repo:
 - missing `SIMARD_PROMPT_ROOT` fails bootstrap
 - missing `SIMARD_OBJECTIVE` fails bootstrap
 - missing `SIMARD_IDENTITY` fails bootstrap
+- missing `SIMARD_BASE_TYPE` fails bootstrap
+- missing `SIMARD_RUNTIME_TOPOLOGY` fails bootstrap
 - unknown `SIMARD_IDENTITY` fails identity loading
+- invalid `SIMARD_RUNTIME_TOPOLOGY` values fail bootstrap config resolution
+- identity/base-type mismatches fail runtime composition with `UnsupportedBaseType`
+- manifest-supported but unregistered `SIMARD_BASE_TYPE` values fail runtime composition with `AdapterNotRegistered`
+- valid but unsupported `SIMARD_RUNTIME_TOPOLOGY` values fail runtime composition explicitly, usually with `UnsupportedRuntimeTopology` on the local bootstrap path and `UnsupportedTopology` if a runtime driver supports the topology but the selected base type does not
 
 No missing value is replaced after startup.
+
+### Variation: exercise a non-default builtin base type
+
+Use this when you want to prove that bootstrap is not silently snapping back to `local-harness`.
+
+```bash
+SIMARD_PROMPT_ROOT="$PWD/prompt_assets" \
+SIMARD_OBJECTIVE="verify copilot-sdk bootstrap selection" \
+SIMARD_IDENTITY="simard-engineer" \
+SIMARD_BASE_TYPE="copilot-sdk" \
+SIMARD_RUNTIME_TOPOLOGY="single-process" \
+cargo run --quiet
+```
+
+In the current repo, you should see output shaped like:
+
+```text
+Bootstrap selection: identity=simard-engineer, base_type=copilot-sdk, topology=single-process
+Snapshot: state=ready, topology=single-process, base_type=copilot-sdk
+Adapter implementation: local-harness
+```
+
+That is the important contract boundary: the runtime records the explicit selection you asked for, and it also reports the honest v1 implementation identity. Simard does not silently rewrite your selection, but it also does not pretend the alias is already a distinct backend.
 
 ## 2. Opt in to builtin defaults only when you mean it
 
@@ -58,6 +91,8 @@ In the current repo:
 - `SIMARD_PROMPT_ROOT` resolves to the repository `prompt_assets/` directory
 - `SIMARD_OBJECTIVE` resolves to the builtin engineer-loop objective
 - `SIMARD_IDENTITY` resolves to `simard-engineer`
+- `SIMARD_BASE_TYPE` resolves to `local-harness`
+- `SIMARD_RUNTIME_TOPOLOGY` resolves to `single-process`
 - the configuration source is recorded as `opt-in:SIMARD_BOOTSTRAP_MODE`
 
 Builtin defaults are startup choices. They are not recovery behavior.
@@ -67,7 +102,14 @@ Builtin defaults are startup choices. They are not recovery behavior.
 `ReflectionSnapshot` exposes the truth-bearing runtime metadata directly:
 
 - `manifest_contract`
+- `runtime_node`
+- `mailbox_address`
+- `agent_program_backend`
+- `handoff_backend`
 - `adapter_backend`
+- `topology_backend`
+- `transport_backend`
+- `supervisor_backend`
 - `memory_backend`
 - `evidence_backend`
 
@@ -87,10 +129,21 @@ assert_eq!(
     snapshot.manifest_contract.freshness.state,
     FreshnessState::Current
 );
+assert_eq!(snapshot.runtime_node.to_string(), "node-local");
+assert_eq!(snapshot.mailbox_address.to_string(), "inmemory://node-local");
+assert_eq!(snapshot.agent_program_backend.identity, "agent-program::objective-relay");
+assert_eq!(snapshot.handoff_backend.identity, "handoff::in-memory");
 assert_eq!(snapshot.adapter_backend.identity, "local-harness");
+assert_eq!(snapshot.topology_backend.identity, "topology::in-process");
+assert_eq!(snapshot.transport_backend.identity, "transport::in-memory-mailbox");
+assert_eq!(snapshot.supervisor_backend.identity, "supervisor::in-process");
 assert_eq!(snapshot.memory_backend.identity, "memory::session-cache");
 assert_eq!(snapshot.evidence_backend.identity, "evidence::append-only-log");
 ```
+
+If you launched with `SIMARD_BASE_TYPE="copilot-sdk"`, `snapshot.selected_base_type` still shows the alias you chose while `snapshot.adapter_backend.identity` remains `local-harness`. If you launched with `SIMARD_BASE_TYPE="rusty-clawd"`, reflection now truthfully reports `snapshot.adapter_backend.identity == "rusty-clawd::session-backend"`.
+
+The same redaction rule applies to scratch memory, session summaries, and live reflection summaries: they use `objective-metadata(...)` instead of the raw `SIMARD_OBJECTIVE` string. `export_handoff()` is a separate contract and currently clones the last `SessionRecord`, so exported handoff snapshots should still be treated as carrying sensitive objective text until handoff redaction lands.
 
 ## 4. Validate stopped-state behavior
 
@@ -126,6 +179,8 @@ Set `SIMARD_IDENTITY` before startup:
 SIMARD_PROMPT_ROOT="$PWD/prompt_assets" \
 SIMARD_OBJECTIVE="run custom identity" \
 SIMARD_IDENTITY="simard-engineer" \
+SIMARD_BASE_TYPE="local-harness" \
+SIMARD_RUNTIME_TOPOLOGY="single-process" \
 cargo run --quiet
 ```
 
@@ -156,6 +211,8 @@ Invalid values fail with `SimardError::InvalidSessionId`.
 export SIMARD_PROMPT_ROOT="$PWD/prompt_assets"
 export SIMARD_OBJECTIVE="verify current reflection metadata"
 export SIMARD_IDENTITY="simard-engineer"
+export SIMARD_BASE_TYPE="local-harness"
+export SIMARD_RUNTIME_TOPOLOGY="single-process"
 ```
 
 Or opt in explicitly:
@@ -169,6 +226,20 @@ export SIMARD_BOOTSTRAP_MODE=builtin-defaults
 **Symptom**: `PromptAssetMissing` or `PromptAssetRead`.
 
 **Solution**: fix the asset path or contents. Simard does not continue with a different prompt asset.
+
+### Base type or topology selection fails
+
+**Symptom**: bootstrap resolves, but runtime composition returns `UnsupportedBaseType`, `AdapterNotRegistered`, `UnsupportedRuntimeTopology`, or `UnsupportedTopology`.
+
+**Solution**: pick a base type the identity allows, make sure the base-type factory is registered for that identity, and choose a topology supported by both the injected runtime services and the selected base-type backend. Simard does not substitute a different base type or downgrade the topology silently.
+
+Today, the local CLI bootstrap path still requires `SIMARD_RUNTIME_TOPOLOGY=single-process` for all builtin base types because it injects the in-process topology driver. `copilot-sdk` still reports `Adapter implementation: local-harness`, while `rusty-clawd` now reports `Adapter implementation: rusty-clawd::session-backend`.
+
+### Project writes are rejected in v1
+
+**Symptom**: manifest construction or runtime composition returns `UnsupportedMemoryPolicy`.
+
+**Solution**: keep `MemoryPolicy.allow_project_writes=false` until Simard ships an explicit project-write contract. The current runtime accepts summary scope selection, but not repository mutation through memory policy.
 
 ### Reflection metadata is truthful but incomplete
 

--- a/docs/howto/export-and-restore-runtime-handoff.md
+++ b/docs/howto/export-and-restore-runtime-handoff.md
@@ -1,0 +1,232 @@
+---
+title: "How to export and restore runtime handoff"
+description: Export the latest Simard session boundary and restore it into fresh runtime ports without losing memory, evidence, or truthful reflection.
+last_updated: 2026-03-29
+review_schedule: as-needed
+owner: simard
+doc_type: howto
+related:
+  - ../index.md
+  - ../reference/runtime-contracts.md
+  - ../tutorials/run-rusty-clawd-on-loopback-mesh.md
+  - ../concepts/topology-neutral-runtime-kernel.md
+---
+
+# How to export and restore runtime handoff
+
+Use this guide when you need to carry the latest Simard session boundary into a fresh runtime instance.
+
+## Prerequisites
+
+- [ ] You are working in-process with the Rust API, not only through `cargo run --quiet`
+- [ ] You can already compose a runtime with the selected identity, base type, and topology
+- [ ] You understand that exported handoff payloads are sensitive, and that exported session-objective redaction is planned rather than shipped today
+
+## Steps
+
+### 1. Compose a source runtime with an explicit handoff store
+
+Handoff is part of the runtime kernel, so inject it at composition time.
+
+```rust
+use std::sync::Arc;
+
+use simard::{
+    BaseTypeCapability, BaseTypeId, BaseTypeRegistry, Freshness, IdentityManifest,
+    InMemoryEvidenceStore, InMemoryHandoffStore, InMemoryMemoryStore, InMemoryPromptAssetStore,
+    InProcessSupervisor, LocalRuntime, LoopbackMailboxTransport, LoopbackMeshTopologyDriver,
+    ManifestContract, MemoryPolicy, ObjectiveRelayProgram, OperatingMode, PromptAsset,
+    PromptAssetRef, Provenance, RuntimePorts, RuntimeRequest, RuntimeTopology,
+    RustyClawdAdapter, UuidSessionIdGenerator, capability_set,
+};
+
+let prompts = Arc::new(InMemoryPromptAssetStore::new([PromptAsset::new(
+    "engineer-system",
+    "simard/engineer_system.md",
+    "You are Simard.",
+)]));
+let memory = Arc::new(InMemoryMemoryStore::try_default()?);
+let evidence = Arc::new(InMemoryEvidenceStore::try_default()?);
+let handoff = Arc::new(InMemoryHandoffStore::try_default()?);
+let mut base_types = BaseTypeRegistry::default();
+base_types.register(RustyClawdAdapter::registered("rusty-clawd")?);
+
+let request = RuntimeRequest::new(
+    IdentityManifest::new(
+        "simard-engineer",
+        env!("CARGO_PKG_VERSION"),
+        vec![PromptAssetRef::new("engineer-system", "simard/engineer_system.md")],
+        vec![BaseTypeId::new("rusty-clawd")],
+        capability_set([
+            BaseTypeCapability::PromptAssets,
+            BaseTypeCapability::SessionLifecycle,
+            BaseTypeCapability::Memory,
+            BaseTypeCapability::Evidence,
+            BaseTypeCapability::Reflection,
+        ]),
+        OperatingMode::Engineer,
+        MemoryPolicy::default(),
+        ManifestContract::new(
+            simard::bootstrap_entrypoint(),
+            "bootstrap-config -> identity-loader -> runtime-ports -> local-runtime",
+            vec!["docs:handoff-howto".to_string()],
+            Provenance::new("docs", "howto::handoff"),
+            Freshness::now()?,
+        )?,
+    )?,
+    BaseTypeId::new("rusty-clawd"),
+    RuntimeTopology::MultiProcess,
+);
+
+let mut runtime = LocalRuntime::compose(
+    RuntimePorts::with_runtime_services_and_program(
+        prompts,
+        memory.clone(),
+        evidence.clone(),
+        base_types,
+        Arc::new(LoopbackMeshTopologyDriver::try_default()?),
+        Arc::new(LoopbackMailboxTransport::try_default()?),
+        Arc::new(InProcessSupervisor::try_default()?),
+        Arc::new(ObjectiveRelayProgram::try_default()?),
+        handoff.clone(),
+        Arc::new(UuidSessionIdGenerator),
+    ),
+    request.clone(),
+)?;
+```
+
+### 2. Run a session and export the snapshot
+
+```rust
+runtime.start()?;
+runtime.run("handoff the current session boundary")?;
+let snapshot = runtime.export_handoff()?;
+```
+
+Check these facts immediately:
+
+```rust
+assert_eq!(snapshot.identity_name, "simard-engineer");
+assert_eq!(snapshot.selected_base_type, BaseTypeId::new("rusty-clawd"));
+assert_eq!(snapshot.topology, RuntimeTopology::MultiProcess);
+assert_eq!(snapshot.source_runtime_node.to_string(), "node-loopback-mesh");
+assert_eq!(snapshot.source_mailbox_address.to_string(), "loopback://node-loopback-mesh");
+assert!(snapshot.session.is_some());
+assert!(!snapshot.memory_records.is_empty());
+assert!(!snapshot.evidence_records.is_empty());
+```
+
+### 3. Treat the snapshot as sensitive, not as disposable debug text
+
+A handoff snapshot is not disposable debug output.
+
+Today, `export_handoff()` clones the current `SessionRecord` into `RuntimeHandoffSnapshot`. That means `snapshot.session` can still carry the original objective text.
+
+[PLANNED] handoff hardening will narrow exported session text to `objective-metadata(...)`, but until that lands you should treat the whole snapshot as a fully sensitive runtime artifact.
+
+The exported payload includes:
+
+- session identifiers and phase data
+- selected base type and topology
+- runtime-node and mailbox-address metadata
+- memory records
+- evidence records
+- the current stored session boundary, including the objective string
+
+### 4. Restore into fresh runtime ports
+
+Use fresh memory, evidence, and handoff stores for the destination runtime. Restore does not mutate the source runtime in place.
+
+```rust
+let restored_memory = Arc::new(InMemoryMemoryStore::try_default()?);
+let restored_evidence = Arc::new(InMemoryEvidenceStore::try_default()?);
+let restored_handoff = Arc::new(InMemoryHandoffStore::try_default()?);
+let mut restored_base_types = BaseTypeRegistry::default();
+restored_base_types.register(RustyClawdAdapter::registered("rusty-clawd")?);
+
+let restored = LocalRuntime::compose_from_handoff(
+    RuntimePorts::with_runtime_services_and_program(
+        Arc::new(InMemoryPromptAssetStore::new([PromptAsset::new(
+            "engineer-system",
+            "simard/engineer_system.md",
+            "You are Simard.",
+        )])),
+        restored_memory.clone(),
+        restored_evidence.clone(),
+        restored_base_types,
+        Arc::new(LoopbackMeshTopologyDriver::try_default()?),
+        Arc::new(LoopbackMailboxTransport::try_default()?),
+        Arc::new(InProcessSupervisor::try_default()?),
+        Arc::new(ObjectiveRelayProgram::try_default()?),
+        restored_handoff.clone(),
+        Arc::new(UuidSessionIdGenerator),
+    ),
+    request,
+    snapshot,
+)?;
+```
+
+### 5. Verify the restored runtime before you start it
+
+A restored runtime should already expose the carried-over session boundary, but it stays in `Initializing` until you call `start()`.
+
+```rust
+let restored_snapshot = restored.snapshot()?;
+
+assert_eq!(restored_snapshot.runtime_state, simard::RuntimeState::Initializing);
+assert_eq!(restored_snapshot.session_phase, Some(simard::SessionPhase::Complete));
+assert_eq!(restored_snapshot.memory_records, 2);
+assert_eq!(restored_snapshot.evidence_records, 5);
+assert_eq!(restored_snapshot.handoff_backend.identity, "handoff::in-memory");
+```
+
+## Variations
+
+### For a single-process local runtime
+
+Use `RuntimePorts::new(...)` or `RuntimePorts::with_session_ids(...)`, keep `RuntimeTopology::SingleProcess`, and register `local-harness` or `rusty-clawd` for single-process execution.
+
+### For a custom handoff store
+
+Inject your own `RuntimeHandoffStore` through `RuntimePorts::with_runtime_services_and_program(...)`. Reflection will report its `handoff_backend` descriptor directly.
+
+## Troubleshooting
+
+### `InvalidHandoffSnapshot`
+
+**Symptom**: restore fails before composition completes.
+
+**Cause**: `snapshot.identity_name` or `snapshot.selected_base_type` does not match the destination `RuntimeRequest`.
+
+**Fix**: restore with the same identity/base-type pair that produced the snapshot.
+
+### Snapshot topology does not match the restore request
+
+**Symptom**: you expected restore to reject a topology mismatch, but `compose_from_handoff(...)` did not fail at the handoff-validation step.
+
+**Cause**: current restore validates identity and selected base type, then composes with the destination request. It does not yet enforce `snapshot.topology == request.topology`.
+
+**Fix**: compare `snapshot.topology` with the destination request in caller code until the kernel adds topology-equality enforcement.
+
+### `UnsupportedRuntimeTopology` or `UnsupportedTopology`
+
+**Symptom**: restore fails even though the handoff snapshot looks valid.
+
+**Cause**: the destination topology driver or base-type adapter does not support the requested topology.
+
+**Fix**: inject runtime services and a base-type backend that support the topology you are restoring into. In this repository, end-to-end examples cover `single-process` and `multi-process`; `distributed` still needs a compatible injected base type/runtime combination.
+
+### Restored runtime looks empty
+
+**Symptom**: `snapshot()` works, but `memory_records` or `evidence_records` are zero.
+
+**Cause**: the source runtime exported before any session completed, or the destination stores were not wired through `compose_from_handoff(...)`.
+
+**Fix**: export after a successful run, and restore through fresh injected stores instead of trying to rebuild the snapshot manually.
+
+## See also
+
+- [Runtime contracts reference](../reference/runtime-contracts.md)
+- [Tutorial: Run RustyClawd on the loopback mesh](../tutorials/run-rusty-clawd-on-loopback-mesh.md)
+- [Concept: topology-neutral runtime kernel](../concepts/topology-neutral-runtime-kernel.md)
+- [Documentation index](../index.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,50 +1,55 @@
 ---
 title: Simard documentation
-description: Start here for the current Simard runtime contracts, bootstrap flow, and reflection metadata.
-last_updated: 2026-03-27
+description: Start here for Simard runtime bootstrap, base-type selection, topology-neutral runtime composition, handoff, and reflection contracts.
+last_updated: 2026-03-29
 review_schedule: as-needed
 owner: simard
 ---
 
 # Simard documentation
 
-Simard is a DI-first runtime shell for agent execution, reflection, memory, and evidence capture.
+Simard is a DI-first runtime shell for local CLI execution and in-process Rust runtime composition.
 
-This docs set describes the runtime behavior that exists in this repository today.
+This docs set describes the runtime/base-type feature as a local contract in this repository. It covers the CLI bootstrap path, the topology-neutral runtime kernel, the base-type/session interfaces, truthful reflection, and runtime handoff export and restore. It does not define an HTTP API, a remote service contract, or a database schema.
 
 ## Start here
 
-- [Tutorial: Run your first local session](./tutorials/run-your-first-local-session.md) - Walk the local runtime flow end to end.
-- [How to configure bootstrap and inspect reflection](./howto/configure-bootstrap-and-inspect-reflection.md) - Verify bootstrap inputs and inspect the truthful reflection surface.
-- [Runtime contracts reference](./reference/runtime-contracts.md) - Look up the current public API and error contracts.
-- [Concept: truthful runtime metadata](./concepts/truthful-runtime-metadata.md) - Read the design rationale behind the stricter contract.
+- [Tutorial: Run your first local session](./tutorials/run-your-first-local-session.md) - Walk the default CLI runtime flow end to end.
+- [Tutorial: Run RustyClawd on the loopback mesh](./tutorials/run-rusty-clawd-on-loopback-mesh.md) - Learn the second topology path and the real `rusty-clawd` backend.
+- [How to configure bootstrap and inspect reflection](./howto/configure-bootstrap-and-inspect-reflection.md) - Verify startup inputs and inspect truthful runtime metadata.
+- [How to export and restore runtime handoff](./howto/export-and-restore-runtime-handoff.md) - Move the latest session boundary into fresh runtime ports while preserving carried-over memory and evidence records.
+- [Runtime contracts reference](./reference/runtime-contracts.md) - Look up the public CLI and in-process Rust contracts.
+- [Concept: topology-neutral runtime kernel](./concepts/topology-neutral-runtime-kernel.md) - Understand why runtime topology, transport, handoff, and supervision are injected instead of hardcoded.
+- [Concept: truthful runtime metadata](./concepts/truthful-runtime-metadata.md) - Read the design rationale behind the reflection contract.
 
 ## Current guarantees
 
 Today Simard provides:
 
 - explicit bootstrap configuration, with `builtin-defaults` available only through opt-in startup mode
-- `ManifestContract { entrypoint, composition, precedence, provenance, freshness }`
-- `ReflectionSnapshot { manifest_contract, adapter_backend, memory_backend, evidence_backend }`
-- truthful memory and evidence backend descriptors
-- truthful adapter backend metadata from the runtime-selected base type
+- explicit base-type and topology selection at bootstrap, with no silent fallback after startup
+- builtin base-type registrations for `local-harness`, `rusty-clawd`, and `copilot-sdk`, with `rusty-clawd` reflected as a distinct backend and `copilot-sdk` reflected honestly as the current `local-harness` alias
+- a topology-neutral runtime kernel built around `RuntimePorts`, `RuntimeRequest`, and `RuntimeKernel`
+- the default CLI path through `cargo run --quiet`, which assembles the in-process runtime services and runs a single-process session locally
+- a second injected topology path through `LoopbackMeshTopologyDriver` and `LoopbackMailboxTransport` for `multi-process` execution in the in-process Rust API
+- a `distributed` topology value in the bootstrap/runtime contract, with explicit failure unless callers inject a compatible topology/base-type combination
+- truthful reflection through `ReflectionSnapshot`, including manifest, runtime node, mailbox address, base-type backend, topology backend, transport backend, supervisor backend, memory backend, evidence backend, and handoff backend
+- runtime handoff export/import through `RuntimeHandoffSnapshot` and `RuntimeKernel::compose_from_handoff(...)`, with restore currently validating identity and selected base type before rehydrating memory and evidence
+- persisted scratch and summary memory plus live reflection summaries that record objective metadata instead of raw objective text
+- [PLANNED] exported handoff session text should follow the same objective-metadata rule; current `export_handoff()` clones the latest session record, so snapshots remain fully sensitive runtime artifacts
 - canonical session IDs shaped as `session-<uuid-v7>`, with validation at parsing boundaries
-- a real stopped runtime state whose snapshot remains inspectable after shutdown
-- explicit `RuntimeStopped`, `InvalidSessionId`, and `InvalidManifestContract` errors
-
-## Key runtime facts
-
-- `src/main.rs` is the thin CLI wrapper; `bootstrap::run_local_session` owns the run loop and `simard::bootstrap::assemble_local_runtime` remains the reflected assembly boundary
-- defaults are startup choices, never silent runtime recovery
-- reflection metadata is derived from the active runtime wiring, not placeholder labels
-- post-stop `start()`, `run()`, and repeated `stop()` surface `SimardError::RuntimeStopped`
+- explicit lifecycle errors for stopped runtimes, failed runtimes, invalid handoff snapshots, unsupported topologies, and invalid session IDs
+- explicit rejection of `MemoryPolicy.allow_project_writes=true` in v1
+- a local CLI/runtime contract, not a networked API surface
 
 ## Reading paths
 
 If you are new to Simard, start with the [local session tutorial](./tutorials/run-your-first-local-session.md).
 
-If you need to wire configuration or debug reflection output, jump to the [bootstrap and reflection how-to](./howto/configure-bootstrap-and-inspect-reflection.md).
+If you need the non-default runtime path, continue with [Tutorial: Run RustyClawd on the loopback mesh](./tutorials/run-rusty-clawd-on-loopback-mesh.md).
 
-If you need exact field names or error contracts, use the [runtime contracts reference](./reference/runtime-contracts.md).
+If you need a task-focused guide for moving work between runtime instances, use [How to export and restore runtime handoff](./howto/export-and-restore-runtime-handoff.md).
 
-If you are changing architecture, read the [truthful runtime metadata concept guide](./concepts/truthful-runtime-metadata.md) first.
+If you need exact field names, constructors, or error meanings, use the [runtime contracts reference](./reference/runtime-contracts.md).
+
+If you are changing architecture or reviewing the topology/base-type split, read [Concept: topology-neutral runtime kernel](./concepts/topology-neutral-runtime-kernel.md) and [Concept: truthful runtime metadata](./concepts/truthful-runtime-metadata.md).

--- a/docs/reference/runtime-contracts.md
+++ b/docs/reference/runtime-contracts.md
@@ -1,142 +1,244 @@
 ---
 title: Runtime contracts reference
-description: Reference for the current Simard runtime surface, reflection contracts, and lifecycle errors.
-last_updated: 2026-03-27
+description: Reference for Simard bootstrap configuration, runtime/base-type APIs, topology support, handoff restore, and reflection/error contracts.
+last_updated: 2026-03-29
 review_schedule: as-needed
 owner: simard
 doc_type: reference
 related:
   - ../index.md
   - ../howto/configure-bootstrap-and-inspect-reflection.md
+  - ../howto/export-and-restore-runtime-handoff.md
+  - ../tutorials/run-rusty-clawd-on-loopback-mesh.md
+  - ../concepts/topology-neutral-runtime-kernel.md
   - ../concepts/truthful-runtime-metadata.md
 ---
 
 # Runtime contracts reference
 
-## Status
+## Overview
 
-This file describes the API shape that exists in the repository today.
+Simard v1 exposes two supported surfaces in this repository:
 
-## Configuration
+- the local CLI bootstrap path through `cargo run --quiet`
+- the in-process Rust runtime/bootstrap types re-exported from `src/lib.rs`
+
+Simard v1 does **not** currently expose:
+
+- an HTTP API
+- a remote service contract
+- a database schema contract
+
+The stable contract in this repository is the local CLI/bootstrap behavior and the in-process Rust runtime/kernel API described below.
+
+## Contents
+
+- [CLI configuration](#cli-configuration)
+- [Supported base types and topology combinations](#supported-base-types-and-topology-combinations)
+- [Bootstrap and runtime APIs](#bootstrap-and-runtime-apis)
+- [Lifecycle and state](#lifecycle-and-state)
+- [Base-type session contract](#base-type-session-contract)
+- [Handoff contract](#handoff-contract)
+- [Reflection contract](#reflection-contract)
+- [Errors](#errors)
+- [Security and non-goals](#security-and-non-goals)
+
+## CLI configuration
 
 ### Environment variables
 
 | Variable | Required | Default | Description |
 | --- | --- | --- | --- |
 | `SIMARD_PROMPT_ROOT` | Yes in `explicit-config` | none | Root directory for prompt assets. |
-| `SIMARD_OBJECTIVE` | Yes in `explicit-config` | none | Objective passed to `run()`. |
+| `SIMARD_OBJECTIVE` | Yes in `explicit-config` | none | Objective passed to `run()`. Live execution uses the real objective. Persisted scratch/summary memory and live reflection summaries use redacted `objective-metadata(...)`. Current handoff export still clones the latest `SessionRecord`, so `RuntimeHandoffSnapshot.session` may contain the raw objective until handoff redaction lands. |
 | `SIMARD_BOOTSTRAP_MODE` | No | `explicit-config` | Startup mode. Accepted values: `explicit-config`, `builtin-defaults`. |
 | `SIMARD_IDENTITY` | Yes in `explicit-config` | none in `explicit-config`; `simard-engineer` in `builtin-defaults` | Identity to load before runtime composition. Non-UTF-8 values fail bootstrap instead of being treated as missing. |
+| `SIMARD_BASE_TYPE` | Yes in `explicit-config` | none in `explicit-config`; `local-harness` in `builtin-defaults` | Base type selected for the runtime request. Unsupported or unregistered selections fail explicitly. |
+| `SIMARD_RUNTIME_TOPOLOGY` | Yes in `explicit-config` | none in `explicit-config`; `single-process` in `builtin-defaults` | Runtime topology selected for the runtime request. Accepted values: `single-process`, `multi-process`, `distributed`. Parsing a value does not guarantee the assembled runtime currently supports it end to end. |
 
 ### Bootstrap modes
 
 | Mode | Behavior |
 | --- | --- |
-| `explicit-config` | Requires prompt root, objective, and identity from configuration. |
-| `builtin-defaults` | Allows builtin prompt root, builtin objective, and builtin identity, but only because startup opted in explicitly. |
+| `explicit-config` | Requires prompt root, objective, identity, base type, and topology from configuration. |
+| `builtin-defaults` | Allows builtin prompt root, builtin objective, builtin identity, builtin base type (`local-harness`), and builtin topology (`single-process`), but only because startup opted in explicitly. |
 
-### Config value sources
+### Example: explicit CLI run with the real `rusty-clawd` backend
 
-`ConfigValueSource` records where a resolved value came from.
-
-| Variant | Meaning |
-| --- | --- |
-| `Environment(&'static str)` | The value came directly from an environment variable. |
-| `ExplicitOptIn(&'static str)` | The value came from an explicit startup mode that permits builtin defaults. |
-
-## Identity metadata
-
-### `IdentityManifest`
-
-`IdentityManifest` stores contract truth in `contract: ManifestContract`.
-
-### `ManifestContract`
-
-```rust
-pub struct ManifestContract {
-    pub entrypoint: String,
-    pub composition: String,
-    pub precedence: Vec<String>,
-    pub provenance: Provenance,
-    pub freshness: Freshness,
-}
+```bash
+SIMARD_PROMPT_ROOT="$PWD/prompt_assets" SIMARD_OBJECTIVE="exercise the rusty-clawd runtime path" SIMARD_IDENTITY="simard-engineer" SIMARD_BASE_TYPE="rusty-clawd" SIMARD_RUNTIME_TOPOLOGY="single-process" cargo run --quiet
 ```
 
-Notes:
-
-- the CLI bootstrap path uses `simard::bootstrap::assemble_local_runtime` as the entrypoint
-- provenance and freshness stay inside the contract so reflection carries a single source of truth
-- invalid empty fields fail with `SimardError::InvalidManifestContract`
-
-### Current precedence rules
-
-`precedence` is ordered from highest to lowest influence within the bootstrap path. A typical local sequence is:
+Expected output shape:
 
 ```text
-mode:explicit-config
-identity:simard-engineer
-prompt-root:env:SIMARD_PROMPT_ROOT
-objective:env:SIMARD_OBJECTIVE
+Simard local runtime executed successfully.
+Bootstrap mode: explicit-config
+Config sources: prompt_root=env:SIMARD_PROMPT_ROOT, objective=env:SIMARD_OBJECTIVE, base_type=env:SIMARD_BASE_TYPE, topology=env:SIMARD_RUNTIME_TOPOLOGY
+Bootstrap selection: identity=simard-engineer, base_type=rusty-clawd, topology=single-process
+Snapshot: state=ready, topology=single-process, base_type=rusty-clawd
+Adapter implementation: rusty-clawd::session-backend
+Shutdown: stopped
 ```
 
-If builtin defaults are used intentionally, the prompt-root and objective entries record `opt-in:SIMARD_BOOTSTRAP_MODE`.
+### Example: opt in to builtin defaults
 
-## Provenance and freshness
-
-### `Provenance`
-
-```rust
-pub struct Provenance {
-    pub source: String,
-    pub locator: String,
-}
+```bash
+SIMARD_BOOTSTRAP_MODE=builtin-defaults cargo run --quiet
 ```
 
-Helpers currently provided:
+Expected output shape:
 
-| Helper | Meaning |
+```text
+Bootstrap mode: builtin-defaults
+Bootstrap selection: identity=simard-engineer, base_type=local-harness, topology=single-process
+```
+
+Defaults are startup choices, not runtime recovery behavior.
+
+## Supported base types and topology combinations
+
+### Builtin base-type registrations
+
+| Base type selection | Reflected backend implementation | CLI topology support | In-process runtime support | Notes |
+| --- | --- | --- | --- | --- |
+| `local-harness` | `local-harness` | `single-process` | `single-process` | Default local scaffold. |
+| `rusty-clawd` | `rusty-clawd::session-backend` | `single-process` | `single-process`, `multi-process` | Real backend with a second topology path in the runtime API. |
+| `copilot-sdk` | `local-harness` | `single-process` | `single-process` | Explicit alias. Selection remains `copilot-sdk`; implementation remains `local-harness` until a distinct backend is registered. |
+
+### Runtime topology drivers
+
+| Runtime assembly path | Topology driver | Transport | Supervisor | Supported topologies |
+| --- | --- | --- | --- | --- |
+| `RuntimePorts::new(...)` | `topology::in-process` | `transport::in-memory-mailbox` | `supervisor::in-process` | `single-process` |
+| `RuntimePorts::with_runtime_services(...)` | caller-injected | caller-injected | caller-injected | whatever the injected services advertise |
+| `RuntimePorts::with_runtime_services_and_program(...)` | caller-injected | caller-injected | caller-injected | whatever the injected services advertise |
+
+Repository-provided runtime services currently include:
+
+- `InProcessTopologyDriver` for `single-process`
+- `LoopbackMeshTopologyDriver` for `multi-process`, and for `distributed` requests when callers inject the rest of a compatible runtime
+- `InMemoryMailboxTransport` for `inmemory://...` addresses
+- `LoopbackMailboxTransport` for `loopback://...` addresses
+- `InProcessSupervisor` and `CoordinatedSupervisor`
+
+Important boundaries:
+
+- the default CLI path always uses `RuntimePorts::new(...)`, so CLI runs remain `single-process` even though the in-process runtime API can inject alternate topology services
+- repository-provided registered base types cover `single-process` and `multi-process` end to end today; `distributed` remains a contract/configuration value until callers inject a compatible base type and runtime service set
+
+## Bootstrap and runtime APIs
+
+### Primary bootstrap types
+
+| Surface | Purpose |
 | --- | --- |
-| `Provenance::new(source, locator)` | Build an explicit provenance value. |
-| `Provenance::builtin(locator)` | Mark a builtin metadata source. |
-| `Provenance::injected(locator)` | Mark an injected metadata source. |
-| `Provenance::runtime(locator)` | Mark runtime-derived metadata. |
+| `BootstrapInputs::from_env()` | Reads the CLI bootstrap inputs from environment variables. |
+| `BootstrapConfig::from_env()` | Resolves validated bootstrap config for the CLI path. |
+| `assemble_local_runtime(&BootstrapConfig)` | Composes the local runtime for CLI execution. |
+| `run_local_session(&BootstrapConfig)` | Starts, runs, snapshots, stops, and returns the local session execution bundle. |
+| `bootstrap_entrypoint()` | Returns the reflected bootstrap assembly boundary: `simard::bootstrap::assemble_local_runtime`. |
 
-### `Freshness`
+### Runtime assembly types
+
+| Surface | Purpose |
+| --- | --- |
+| `BaseTypeRegistry` | Registers `BaseTypeFactory` implementations by `BaseTypeId`. |
+| `RuntimePorts` | Injects prompt assets, memory, evidence, base-type factories, topology driver, transport, supervisor, agent program, handoff store, and session ID strategy. |
+| `RuntimeRequest::new(manifest, selected_base_type, topology)` | Describes the identity/base-type/topology request to compose. |
+| `RuntimeKernel::compose(ports, request)` | Composes a fresh runtime from injected ports and a validated runtime request. |
+| `RuntimeKernel::compose_from_handoff(ports, request, snapshot)` | Rehydrates a fresh runtime from a previously exported `RuntimeHandoffSnapshot`. |
+| `LocalRuntime` | Type alias for `RuntimeKernel` used by the local runtime path. |
+
+### `RuntimePorts` constructors
+
+| Constructor | Behavior |
+| --- | --- |
+| `RuntimePorts::new(...)` | Injects `InProcessTopologyDriver`, `InMemoryMailboxTransport`, `InProcessSupervisor`, `ObjectiveRelayProgram`, and `InMemoryHandoffStore`. |
+| `RuntimePorts::with_session_ids(...)` | Same runtime-service defaults as `new(...)`, but makes session-ID injection explicit at the call site. |
+| `RuntimePorts::with_runtime_services(...)` | Lets callers inject topology, transport, and supervisor while keeping the default objective-relay agent program and in-memory handoff store. |
+| `RuntimePorts::with_runtime_services_and_program(...)` | Lets callers inject all runtime services, including the agent program and handoff store. Use this for alternate topologies, migration tests, and custom orchestration. |
+
+### Example: compose the alternate topology path in-process
 
 ```rust
-pub enum FreshnessState {
-    Current,
-    Stale,
-}
+use std::sync::Arc;
 
-pub struct Freshness {
-    pub state: FreshnessState,
-    pub observed_at_unix_ms: u64,
-}
+use simard::{
+    BaseTypeId, BaseTypeRegistry, IdentityManifest, InMemoryEvidenceStore, InMemoryHandoffStore,
+    InMemoryMemoryStore, InMemoryPromptAssetStore, InProcessSupervisor,
+    LoopbackMailboxTransport, LoopbackMeshTopologyDriver, LocalRuntime, ManifestContract,
+    MemoryPolicy, OperatingMode, PromptAsset, PromptAssetRef, Provenance, RuntimePorts,
+    RuntimeRequest, RuntimeTopology, RustyClawdAdapter, UuidSessionIdGenerator,
+    capability_set, BaseTypeCapability, Freshness,
+};
+
+let prompts = Arc::new(InMemoryPromptAssetStore::new([PromptAsset::new(
+    "engineer-system",
+    "simard/engineer_system.md",
+    "You are Simard.",
+)]));
+let memory = Arc::new(InMemoryMemoryStore::try_default()?);
+let evidence = Arc::new(InMemoryEvidenceStore::try_default()?);
+let handoff = Arc::new(InMemoryHandoffStore::try_default()?);
+let mut base_types = BaseTypeRegistry::default();
+base_types.register(RustyClawdAdapter::registered("rusty-clawd")?);
+
+let request = RuntimeRequest::new(
+    IdentityManifest::new(
+        "simard-engineer",
+        env!("CARGO_PKG_VERSION"),
+        vec![PromptAssetRef::new("engineer-system", "simard/engineer_system.md")],
+        vec![BaseTypeId::new("rusty-clawd")],
+        capability_set([
+            BaseTypeCapability::PromptAssets,
+            BaseTypeCapability::SessionLifecycle,
+            BaseTypeCapability::Memory,
+            BaseTypeCapability::Evidence,
+            BaseTypeCapability::Reflection,
+        ]),
+        OperatingMode::Engineer,
+        MemoryPolicy::default(),
+        ManifestContract::new(
+            simard::bootstrap_entrypoint(),
+            "bootstrap-config -> identity-loader -> runtime-ports -> local-runtime",
+            vec!["docs:runtime-contracts".to_string()],
+            Provenance::new("docs", "reference::runtime-contracts"),
+            Freshness::now()?,
+        )?,
+    )?,
+    BaseTypeId::new("rusty-clawd"),
+    RuntimeTopology::MultiProcess,
+);
+
+let runtime = LocalRuntime::compose(
+    RuntimePorts::with_runtime_services_and_program(
+        prompts,
+        memory,
+        evidence,
+        base_types,
+        Arc::new(LoopbackMeshTopologyDriver::try_default()?),
+        Arc::new(LoopbackMailboxTransport::try_default()?),
+        Arc::new(InProcessSupervisor::try_default()?),
+        Arc::new(simard::ObjectiveRelayProgram::try_default()?),
+        handoff,
+        Arc::new(UuidSessionIdGenerator),
+    ),
+    request,
+)?;
 ```
 
-Notes:
+## Lifecycle and state
 
-- `Freshness::now()` returns `SimardResult<Freshness>` and fails explicitly if the system clock is before the Unix epoch
-- freshness can explicitly represent stale metadata when a caller needs to surface it
+### `RuntimeKernel` lifecycle methods
 
-## Session identity
-
-### `SessionId`
-
-```rust
-pub struct SessionId(String);
-```
-
-Rules:
-
-- `UuidSessionIdGenerator` emits `session-<uuid-v7>`
-- `SessionId::parse(...)` accepts a bare UUID or a `session-<uuid>` value and canonicalizes to `session-<uuid>`
-- invalid values fail with `SimardError::InvalidSessionId`
-- custom `SessionIdGenerator` implementations must return valid `SessionId` values
-- the session ID strategy is injected through `RuntimePorts`; the local bootstrap path opts into `UuidSessionIdGenerator` explicitly
-
-## Runtime lifecycle
+| Method | Meaning |
+| --- | --- |
+| `start()` | Loads prompt assets and transitions the runtime into `Ready`. |
+| `run(objective)` | Executes a session for the selected base type. On success the runtime returns to `Ready`. On failure the runtime becomes `Failed`. |
+| `snapshot()` | Returns the current `ReflectionSnapshot`. Snapshot inspection remains valid after failure and after stop. |
+| `export_handoff()` | Exports the latest session boundary as currently stored, plus memory records and evidence records, into a `RuntimeHandoffSnapshot` and persists it through the injected handoff store. |
+| `stop()` | Transitions the runtime into `Stopped`. After stop, `start()`, `run()`, and repeated `stop()` calls fail explicitly. |
 
 ### `RuntimeState`
 
@@ -144,24 +246,21 @@ Rules:
 | --- | --- |
 | `Initializing` | Runtime has been composed but not started. |
 | `Ready` | Prompt assets are loaded and the runtime can execute. |
-| `Active` | Adapter invocation is in progress. |
+| `Active` | Base-type session work is in progress. |
 | `Reflecting` | Reflection metadata is being assembled. |
 | `Persisting` | Memory and evidence summaries are being persisted. |
 | `Failed` | Execution failed before completion. |
 | `Stopping` | Shutdown is in progress. |
 | `Stopped` | Runtime has been shut down and cannot accept more work. |
 
-### Stopped-state behavior
+### Stopped and failed behavior
 
 After `stop()` succeeds:
 
 - `snapshot()` remains valid
 - `run()` fails with `RuntimeStopped { action: "run" }`
 - `start()` fails with `RuntimeStopped { action: "start" }`
-- a repeated `stop()` fails with `RuntimeStopped { action: "stop" }`
-- callers must compose a new runtime instead of reusing the stopped one
-
-### Failed-state behavior
+- repeated `stop()` fails with `RuntimeStopped { action: "stop" }`
 
 After `run()` fails:
 
@@ -172,7 +271,66 @@ After `run()` fails:
 - `run()` fails with `RuntimeFailed`
 - `stop()` is still the explicit way to close the lifecycle boundary
 
-## Reflection snapshot
+## Base-type session contract
+
+### Core types
+
+| Type | Meaning |
+| --- | --- |
+| `BaseTypeDescriptor` | Describes the selected base type, the reflected backend descriptor, required capabilities, and supported topologies. |
+| `BaseTypeFactory` | Opens base-type sessions for a given runtime request. |
+| `BaseTypeSessionRequest` | Carries the session ID, operating mode, topology, prompt assets, runtime node, and mailbox address into the base-type session. |
+| `BaseTypeTurnInput` | Carries the objective for the next turn. |
+| `BaseTypeOutcome` | Returns `plan`, `execution_summary`, and execution-time evidence lines. |
+
+### Contract rules
+
+- identity selection and backend implementation are distinct facts
+- `selected_base_type` preserves what the caller asked for
+- `adapter_backend.identity` reports the implementation that actually ran
+- topology support is checked twice: once against the injected runtime topology driver, then against the selected base-type descriptor
+- unsupported combinations fail explicitly; Simard does not silently change the base type or topology for you
+
+## Handoff contract
+
+### `RuntimeHandoffSnapshot`
+
+| Field | Meaning |
+| --- | --- |
+| `exported_state` | Runtime state at export time. |
+| `identity_name` | Identity name that must match the restore request. |
+| `selected_base_type` | Base type that must match the restore request. |
+| `topology` | Topology of the source runtime. |
+| `source_runtime_node` | Runtime node reported by the source topology driver. |
+| `source_mailbox_address` | Mailbox address reported by the source transport. |
+| `session` | Latest session boundary. Current export clones the stored `SessionRecord`, so `session.objective` remains verbatim until handoff redaction is implemented. |
+| `memory_records` | Session-scoped memory records rehydrated into the destination runtime. |
+| `evidence_records` | Session-scoped evidence records rehydrated into the destination runtime. |
+
+### Restore behavior
+
+`RuntimeKernel::compose_from_handoff(...)` enforces these rules:
+
+- `snapshot.identity_name` must match `request.manifest.name`
+- `snapshot.selected_base_type` must match `request.selected_base_type`
+- `snapshot.topology` is preserved in the snapshot, but current restore does not reject a request solely because the topology differs
+- memory and evidence records are copied into the destination stores before the runtime starts
+- the last session boundary is restored so `snapshot()` can report the carried-over session phase immediately
+- the restored runtime remains in `Initializing` until `start()` is called
+
+### Example: export and restore
+
+```rust
+let snapshot = source_runtime.export_handoff()?;
+let restored = simard::LocalRuntime::compose_from_handoff(restored_ports, request, snapshot)?;
+
+assert_eq!(restored.snapshot()?.runtime_state, simard::RuntimeState::Initializing);
+assert_eq!(restored.snapshot()?.session_phase, Some(simard::SessionPhase::Complete));
+```
+
+Treat exported handoff payloads as sensitive. They contain session identifiers, memory summaries, evidence records, runtime-node data, mailbox addresses, and today the stored session objective as well.
+
+## Reflection contract
 
 ### `ReflectionSnapshot`
 
@@ -182,34 +340,33 @@ pub struct ReflectionSnapshot {
     pub selected_base_type: BaseTypeId,
     pub topology: RuntimeTopology,
     pub runtime_state: RuntimeState,
+    pub runtime_node: RuntimeNodeId,
+    pub mailbox_address: RuntimeAddress,
     pub session_phase: Option<SessionPhase>,
     pub prompt_assets: Vec<PromptAssetId>,
     pub manifest_contract: ManifestContract,
     pub evidence_records: usize,
     pub memory_records: usize,
+    pub agent_program_backend: BackendDescriptor,
+    pub handoff_backend: BackendDescriptor,
     pub adapter_backend: BackendDescriptor,
+    pub topology_backend: BackendDescriptor,
+    pub transport_backend: BackendDescriptor,
+    pub supervisor_backend: BackendDescriptor,
     pub memory_backend: BackendDescriptor,
     pub evidence_backend: BackendDescriptor,
 }
 ```
 
-### Backend descriptors
-
-```rust
-pub struct BackendDescriptor {
-    pub identity: String,
-    pub provenance: Provenance,
-    pub freshness: Freshness,
-}
-```
-
 Reflection rules:
 
-- `manifest_contract` carries entrypoint, provenance, and freshness together
-- `adapter_backend` comes from the runtime-selected adapter descriptor
-- `memory_backend` comes from the live memory store descriptor
-- `evidence_backend` comes from the live evidence store descriptor
-- reflection reports live wiring, not placeholder labels
+- `manifest_contract` carries entrypoint, provenance, precedence, composition, and freshness together
+- `runtime_node` and `mailbox_address` come from the injected topology and transport services
+- `agent_program_backend` comes from the injected agent-program contract, not from hardcoded runtime logic
+- `handoff_backend` comes from the injected handoff store used for export/import
+- `adapter_backend` comes from the selected base-type factory/session descriptor, not from a bootstrap shortcut
+- `topology_backend`, `transport_backend`, and `supervisor_backend` come from the live runtime services
+- `memory_backend` and `evidence_backend` come from the live stores
 - stopped or failed snapshots mark manifest freshness as `Stale`
 
 ## Errors
@@ -224,46 +381,47 @@ Reflection rules:
 | `UnknownIdentity` | Requested identity is not registered. |
 | `InvalidManifestContract` | Manifest contract metadata is incomplete or untruthful. |
 | `ClockBeforeUnixEpoch` | Runtime metadata could not record a truthful observation time. |
-| `InvalidSessionId` | A supplied session ID is not a valid distributed-safe identifier. |
+| `InvalidSessionId` | A supplied session ID is not a valid UUID-based Simard session ID. |
+| `UnsupportedBaseType` | The chosen identity does not allow the requested base type. |
+| `AdapterNotRegistered` | No base-type factory has been registered for the requested base type. |
+| `MissingCapability` | The selected base-type backend exists but does not satisfy the manifest's required capabilities. |
+| `UnsupportedRuntimeTopology` | The injected topology driver does not support the requested topology. |
+| `UnsupportedTopology` | The selected base-type backend does not support the requested topology. |
+| `UnsupportedMemoryPolicy` | The manifest asked for a memory policy Simard v1 does not allow, including `allow_project_writes=true`. |
 
-### Lifecycle and session errors
+### Lifecycle, handoff, and session errors
 
 | Error | Meaning |
 | --- | --- |
 | `InvalidRuntimeTransition` | A runtime lifecycle transition is invalid. |
+| `InvalidBaseTypeSessionState` | A base-type session was opened, used, or closed out of order. |
+| `AdapterInvocationFailed` | The selected base-type backend failed while executing a turn. |
+| `InvalidHandoffSnapshot` | A handoff snapshot could not be restored into the requested runtime. |
 | `RuntimeStopped` | Caller attempted `start`, `run`, or `stop` after shutdown was already in effect. |
 | `RuntimeFailed` | Caller attempted `start` or `run` after a failed execution but before shutdown. |
 | `InvalidSessionTransition` | A session phase transition is invalid. |
+| `StoragePoisoned` | An in-memory store lock was poisoned. |
 
-### Prompt and storage errors
+### Prompt and asset errors
 
 | Error | Meaning |
 | --- | --- |
 | `PromptAssetMissing` | A referenced prompt asset was not found. |
 | `PromptAssetRead` | A prompt asset could not be read. |
-| `StoragePoisoned` | An in-memory store lock was poisoned. |
-## Example: truthful fields
+| `InvalidPromptAssetPath` | A prompt asset path was rejected because it escaped the allowed prompt root contract. |
 
-```rust
-use simard::{FreshnessState, ReflectiveRuntime};
+## Security and non-goals
 
-let snapshot = runtime.snapshot()?;
-
-assert_eq!(snapshot.runtime_state.to_string(), "ready");
-assert_eq!(
-    snapshot.manifest_contract.entrypoint,
-    "simard::bootstrap::assemble_local_runtime"
-);
-assert_eq!(snapshot.manifest_contract.provenance.source, "bootstrap");
-assert_eq!(snapshot.manifest_contract.freshness.state, FreshnessState::Current);
-assert_eq!(snapshot.adapter_backend.identity, "local-harness");
-assert_eq!(snapshot.memory_backend.identity, "memory::session-cache");
-```
+- Simard documents a local CLI and in-process Rust contract only. There is no HTTP, auth-token, TLS, or database contract in this feature.
+- Exported handoff payloads are sensitive. [PLANNED] objective redaction for exported session text has not landed yet, so store and transfer them as full runtime artifacts.
+- `MemoryPolicy.allow_project_writes=true` is rejected explicitly in v1.
+- Unsupported identities, base types, and topologies fail explicitly. Simard does not downgrade or substitute behind the caller's back.
 
 ## See also
 
 - [How to configure bootstrap and inspect reflection](../howto/configure-bootstrap-and-inspect-reflection.md)
+- [How to export and restore runtime handoff](../howto/export-and-restore-runtime-handoff.md)
+- [Tutorial: Run RustyClawd on the loopback mesh](../tutorials/run-rusty-clawd-on-loopback-mesh.md)
+- [Concept: topology-neutral runtime kernel](../concepts/topology-neutral-runtime-kernel.md)
 - [Concept: truthful runtime metadata](../concepts/truthful-runtime-metadata.md)
-- [Tutorial: Run your first local session](../tutorials/run-your-first-local-session.md)
-
-See the [documentation index](../index.md) for the full set of Simard docs.
+- [Documentation index](../index.md)

--- a/docs/tutorials/run-rusty-clawd-on-loopback-mesh.md
+++ b/docs/tutorials/run-rusty-clawd-on-loopback-mesh.md
@@ -1,0 +1,167 @@
+---
+title: "Tutorial: Run RustyClawd on the loopback mesh"
+description: Learn the alternate Simard runtime path by composing the topology-neutral runtime kernel with the RustyClawd backend and the loopback mesh services.
+last_updated: 2026-03-29
+review_schedule: as-needed
+owner: simard
+doc_type: tutorial
+related:
+  - ../index.md
+  - ../reference/runtime-contracts.md
+  - ../howto/export-and-restore-runtime-handoff.md
+  - ../concepts/topology-neutral-runtime-kernel.md
+---
+
+# Tutorial: Run RustyClawd on the loopback mesh
+
+This tutorial walks the second runtime path in Simard: a multi-process style runtime assembled in-process with `rusty-clawd`, `LoopbackMeshTopologyDriver`, and `LoopbackMailboxTransport`.
+
+It intentionally uses `RuntimeTopology::MultiProcess`. Although the runtime contract also includes `Distributed`, the repository's registered base types and examples do not yet provide an end-to-end distributed run.
+
+## What you'll learn
+
+- how the topology-neutral runtime kernel is composed without the CLI bootstrap shortcut
+- how to select `rusty-clawd` as a real backend instead of an alias
+- what reflection reports for the loopback mesh runtime
+- why the alternate topology path is available through the Rust API but not through the default CLI path
+
+## Prerequisites
+
+- Rust and Cargo installed
+- A shell in the repository root
+- Familiarity with the [local session tutorial](./run-your-first-local-session.md)
+
+## Step 1: Compose the alternate runtime services
+
+The default CLI path always assembles `single-process` services. For the loopback mesh path, inject the topology, transport, supervisor, and handoff services yourself.
+
+```rust
+use std::sync::Arc;
+
+use simard::{
+    BaseTypeCapability, BaseTypeId, BaseTypeRegistry, Freshness, IdentityManifest,
+    InMemoryEvidenceStore, InMemoryHandoffStore, InMemoryMemoryStore, InMemoryPromptAssetStore,
+    InProcessSupervisor, LoopbackMailboxTransport, LoopbackMeshTopologyDriver, LocalRuntime,
+    ManifestContract, MemoryPolicy, ObjectiveRelayProgram, OperatingMode, PromptAsset,
+    PromptAssetRef, Provenance, RuntimePorts, RuntimeRequest, RuntimeTopology,
+    RustyClawdAdapter, UuidSessionIdGenerator, capability_set,
+};
+
+let prompts = Arc::new(InMemoryPromptAssetStore::new([PromptAsset::new(
+    "engineer-system",
+    "simard/engineer_system.md",
+    "You are Simard.",
+)]));
+let memory = Arc::new(InMemoryMemoryStore::try_default()?);
+let evidence = Arc::new(InMemoryEvidenceStore::try_default()?);
+let handoff = Arc::new(InMemoryHandoffStore::try_default()?);
+let mut base_types = BaseTypeRegistry::default();
+base_types.register(RustyClawdAdapter::registered("rusty-clawd")?);
+
+let request = RuntimeRequest::new(
+    IdentityManifest::new(
+        "simard-engineer",
+        env!("CARGO_PKG_VERSION"),
+        vec![PromptAssetRef::new("engineer-system", "simard/engineer_system.md")],
+        vec![BaseTypeId::new("rusty-clawd")],
+        capability_set([
+            BaseTypeCapability::PromptAssets,
+            BaseTypeCapability::SessionLifecycle,
+            BaseTypeCapability::Memory,
+            BaseTypeCapability::Evidence,
+            BaseTypeCapability::Reflection,
+        ]),
+        OperatingMode::Engineer,
+        MemoryPolicy::default(),
+        ManifestContract::new(
+            simard::bootstrap_entrypoint(),
+            "bootstrap-config -> identity-loader -> runtime-ports -> local-runtime",
+            vec!["docs:loopback-tutorial".to_string()],
+            Provenance::new("docs", "tutorial::loopback-mesh"),
+            Freshness::now()?,
+        )?,
+    )?,
+    BaseTypeId::new("rusty-clawd"),
+    RuntimeTopology::MultiProcess,
+);
+
+let mut runtime = LocalRuntime::compose(
+    RuntimePorts::with_runtime_services_and_program(
+        prompts,
+        memory,
+        evidence,
+        base_types,
+        Arc::new(LoopbackMeshTopologyDriver::try_default()?),
+        Arc::new(LoopbackMailboxTransport::try_default()?),
+        Arc::new(InProcessSupervisor::try_default()?),
+        Arc::new(ObjectiveRelayProgram::try_default()?),
+        handoff,
+        Arc::new(UuidSessionIdGenerator),
+    ),
+    request,
+)?;
+```
+
+**Checkpoint**: you now have a runtime that requested `RuntimeTopology::MultiProcess` instead of the CLI default `single-process` path.
+
+## Step 2: Start the runtime and run a session
+
+```rust
+runtime.start()?;
+let outcome = runtime.run("exercise the loopback mesh runtime")?;
+```
+
+Inspect the high-level result:
+
+```rust
+assert_eq!(outcome.session.selected_base_type, BaseTypeId::new("rusty-clawd"));
+assert_eq!(outcome.reflection.snapshot.topology, RuntimeTopology::MultiProcess);
+assert!(outcome.reflection.summary.contains("rusty-clawd"));
+```
+
+**Checkpoint**: the runtime executed with the selected base type you asked for. It did not silently fall back to `local-harness`.
+
+## Step 3: Inspect truthful reflection
+
+The reflected metadata should come from the live runtime wiring.
+
+```rust
+let snapshot = runtime.snapshot()?;
+
+assert_eq!(snapshot.topology, RuntimeTopology::MultiProcess);
+assert_eq!(snapshot.runtime_node.to_string(), "node-loopback-mesh");
+assert_eq!(snapshot.mailbox_address.to_string(), "loopback://node-loopback-mesh");
+assert_eq!(snapshot.adapter_backend.identity, "rusty-clawd::session-backend");
+assert_eq!(snapshot.topology_backend.identity, "topology::loopback-mesh");
+assert_eq!(snapshot.transport_backend.identity, "transport::loopback-mailbox");
+assert_eq!(snapshot.supervisor_backend.identity, "supervisor::in-process");
+assert_eq!(snapshot.handoff_backend.identity, "handoff::in-memory");
+```
+
+**Checkpoint**: reflection is reporting the actual runtime services, not inferred labels.
+
+## Step 4: Stop the runtime cleanly
+
+```rust
+runtime.stop()?;
+let stopped = runtime.snapshot()?;
+assert_eq!(stopped.runtime_state, simard::RuntimeState::Stopped);
+```
+
+After stop, the runtime remains inspectable, but it is no longer reusable.
+
+## Summary
+
+You now know:
+
+- how to compose Simard without the default CLI topology shortcut
+- how to run the real `rusty-clawd` backend on the loopback mesh path
+- how topology, mailbox, handoff, and adapter identities appear in reflection
+- why the alternate topology path lives in the in-process Rust API instead of the default CLI path
+
+## Next steps
+
+- Use [How to export and restore runtime handoff](../howto/export-and-restore-runtime-handoff.md) to move this runtime boundary into fresh ports.
+- Use the [runtime contracts reference](../reference/runtime-contracts.md) when you need exact field names and constructor behavior.
+- Read [Concept: topology-neutral runtime kernel](../concepts/topology-neutral-runtime-kernel.md) for the design rationale.
+- Return to the [documentation index](../index.md) for the rest of the Simard docs.

--- a/docs/tutorials/run-your-first-local-session.md
+++ b/docs/tutorials/run-your-first-local-session.md
@@ -1,7 +1,7 @@
 ---
 title: "Tutorial: Run your first local session"
 description: Learn the Simard local runtime flow, from bootstrap through reflection and shutdown.
-last_updated: 2026-03-27
+last_updated: 2026-03-28
 review_schedule: as-needed
 owner: simard
 doc_type: tutorial
@@ -20,6 +20,7 @@ This tutorial follows the runtime path that exists in the repository today.
 - How the local runtime starts with explicit configuration
 - How explicit opt-in defaults behave
 - What reflection reports after a run
+- How runtime node, mailbox, and backend wiring appear in reflection
 - What stop semantics look like in practice
 
 ## Prerequisites
@@ -31,10 +32,14 @@ This tutorial follows the runtime path that exists in the repository today.
 
 From the repository root, start Simard with a real prompt asset directory and an explicit objective.
 
+For the builtin `simard-engineer` identity, you can currently choose `local-harness`, `rusty-clawd`, or `copilot-sdk` here. `rusty-clawd` is now a distinct backend, while `copilot-sdk` remains an explicit alias of the local harness implementation. The CLI bootstrap path still keeps `SIMARD_RUNTIME_TOPOLOGY="single-process"` because it injects the in-process topology driver.
+
 ```bash
 SIMARD_PROMPT_ROOT="$PWD/prompt_assets" \
 SIMARD_OBJECTIVE="exercise the local runtime" \
 SIMARD_IDENTITY="simard-engineer" \
+SIMARD_BASE_TYPE="local-harness" \
+SIMARD_RUNTIME_TOPOLOGY="single-process" \
 cargo run --quiet
 ```
 
@@ -43,17 +48,39 @@ You should see output shaped like this:
 ```text
 Simard local runtime executed successfully.
 Bootstrap mode: explicit-config
-Config sources: prompt_root=env:SIMARD_PROMPT_ROOT, objective=env:SIMARD_OBJECTIVE
-Plan: ...
-Execution: ...
-Reflection: ...
+Config sources: prompt_root=env:SIMARD_PROMPT_ROOT, objective=env:SIMARD_OBJECTIVE, base_type=env:SIMARD_BASE_TYPE, topology=env:SIMARD_RUNTIME_TOPOLOGY
+Bootstrap selection: identity=simard-engineer, base_type=local-harness, topology=single-process
 Snapshot: state=ready, topology=single-process, base_type=local-harness
+Adapter implementation: local-harness
 Shutdown: stopped
 ```
 
 **Checkpoint**: this is the real CLI path. `src/main.rs` is the thin wrapper; `bootstrap::run_local_session` owns the run loop, and `simard::bootstrap::assemble_local_runtime` remains the reflected assembly boundary.
 
-## Step 2: Opt in to builtin defaults
+## Step 2: Switch to another built-in base type
+
+Run the same bootstrap path again, but select `copilot-sdk` explicitly.
+
+```bash
+SIMARD_PROMPT_ROOT="$PWD/prompt_assets" \
+SIMARD_OBJECTIVE="exercise the copilot-sdk runtime path" \
+SIMARD_IDENTITY="simard-engineer" \
+SIMARD_BASE_TYPE="copilot-sdk" \
+SIMARD_RUNTIME_TOPOLOGY="single-process" \
+cargo run --quiet
+```
+
+Look for these lines:
+
+```text
+Bootstrap selection: identity=simard-engineer, base_type=copilot-sdk, topology=single-process
+Snapshot: state=ready, topology=single-process, base_type=copilot-sdk
+Adapter implementation: local-harness
+```
+
+**Checkpoint**: the runtime contract is explicit. `copilot-sdk` is selectable now, but the v1 scaffold still only supports `single-process`, and the underlying implementation stays `local-harness`. Simard preserves the selected base type without pretending it is already a distinct backend integration.
+
+## Step 3: Opt in to builtin defaults
 
 Builtin defaults exist for local bootstrap convenience, but they are only used when startup opts in.
 
@@ -67,11 +94,13 @@ You should see:
 - `Bootstrap mode: builtin-defaults`
 - `prompt_root=opt-in:SIMARD_BOOTSTRAP_MODE`
 - `objective=opt-in:SIMARD_BOOTSTRAP_MODE`
+- `base_type=opt-in:SIMARD_BOOTSTRAP_MODE`
+- `topology=opt-in:SIMARD_BOOTSTRAP_MODE`
 - the builtin identity `simard-engineer`
 
 **Checkpoint**: defaults are a startup choice, not a recovery path. This part of the audited contract already exists.
 
-## Step 3: Observe stopped-state behavior
+## Step 4: Observe stopped-state behavior
 
 The runtime preserves its snapshot after shutdown and surfaces a dedicated stopped-state error:
 
@@ -96,7 +125,7 @@ assert_eq!(
 
 After shutdown, the reflected manifest freshness becomes `Stale` so callers can tell they are looking at post-stop metadata instead of a live runtime.
 
-## Step 4: Inspect truthful reflection metadata
+## Step 5: Inspect truthful reflection metadata
 
 After a successful run, reflection reports the assembled contract and backend descriptors:
 
@@ -111,14 +140,23 @@ assert_eq!(
 );
 assert_eq!(snapshot.manifest_contract.provenance.source, "bootstrap");
 assert_eq!(snapshot.manifest_contract.freshness.state, FreshnessState::Current);
+assert_eq!(snapshot.runtime_node.to_string(), "node-local");
+assert_eq!(snapshot.mailbox_address.to_string(), "inmemory://node-local");
+assert_eq!(snapshot.agent_program_backend.identity, "agent-program::objective-relay");
+assert_eq!(snapshot.handoff_backend.identity, "handoff::in-memory");
 assert_eq!(snapshot.adapter_backend.identity, "local-harness");
+assert_eq!(snapshot.transport_backend.identity, "transport::in-memory-mailbox");
 ```
+
+If you launched with `SIMARD_BASE_TYPE="copilot-sdk"`, `snapshot.selected_base_type` still shows the explicit selection while `snapshot.adapter_backend.identity` remains `local-harness`. If you launched with `SIMARD_BASE_TYPE="rusty-clawd"`, reflection now reports `rusty-clawd::session-backend`. The runtime-side wiring is also explicit: the current scaffold reports `node-local`, `inmemory://node-local`, `handoff::in-memory`, and the injected in-process topology, transport, and supervisor backends instead of implying future distributed support.
 
 ## Summary
 
 You now know:
 
 - how to run the local runtime with explicit config
+- how to switch between built-in base types without hidden inference
+- how `copilot-sdk` still aliases `local-harness` while `rusty-clawd` now reports a distinct backend honestly
 - how opt-in defaults are recorded
 - how reflection reports truthful runtime metadata
 - how stop semantics behave after shutdown

--- a/src/agent_program.rs
+++ b/src/agent_program.rs
@@ -1,0 +1,96 @@
+use crate::base_types::{BaseTypeId, BaseTypeOutcome, BaseTypeTurnInput};
+use crate::error::SimardResult;
+use crate::identity::OperatingMode;
+use crate::metadata::{BackendDescriptor, Freshness};
+use crate::runtime::{RuntimeAddress, RuntimeNodeId, RuntimeTopology};
+use crate::sanitization::objective_metadata;
+use crate::session::SessionId;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AgentProgramContext {
+    pub session_id: SessionId,
+    pub identity_name: String,
+    pub mode: OperatingMode,
+    pub selected_base_type: BaseTypeId,
+    pub topology: RuntimeTopology,
+    pub runtime_node: RuntimeNodeId,
+    pub mailbox_address: RuntimeAddress,
+    pub objective: String,
+}
+
+pub trait AgentProgram: Send + Sync {
+    fn descriptor(&self) -> BackendDescriptor;
+
+    fn plan_turn(&self, context: &AgentProgramContext) -> SimardResult<BaseTypeTurnInput>;
+
+    fn reflection_summary(
+        &self,
+        context: &AgentProgramContext,
+        outcome: &BaseTypeOutcome,
+    ) -> SimardResult<String>;
+
+    fn persistence_summary(
+        &self,
+        context: &AgentProgramContext,
+        outcome: &BaseTypeOutcome,
+    ) -> SimardResult<String>;
+}
+
+#[derive(Debug)]
+pub struct ObjectiveRelayProgram {
+    descriptor: BackendDescriptor,
+}
+
+impl ObjectiveRelayProgram {
+    pub fn try_default() -> SimardResult<Self> {
+        Ok(Self {
+            descriptor: BackendDescriptor::for_runtime_type::<Self>(
+                "agent-program::objective-relay",
+                "runtime-port:agent-program",
+                Freshness::now()?,
+            ),
+        })
+    }
+}
+
+impl AgentProgram for ObjectiveRelayProgram {
+    fn descriptor(&self) -> BackendDescriptor {
+        self.descriptor.clone()
+    }
+
+    fn plan_turn(&self, context: &AgentProgramContext) -> SimardResult<BaseTypeTurnInput> {
+        Ok(BaseTypeTurnInput {
+            objective: context.objective.clone(),
+        })
+    }
+
+    fn reflection_summary(
+        &self,
+        context: &AgentProgramContext,
+        outcome: &BaseTypeOutcome,
+    ) -> SimardResult<String> {
+        let objective_summary = objective_metadata(&context.objective);
+        Ok(format!(
+            "Agent program '{}' completed '{}' through '{}' on '{}' from '{}' with {}.",
+            self.descriptor.identity,
+            context.mode,
+            context.selected_base_type,
+            context.topology,
+            context.runtime_node,
+            objective_summary,
+        ) + &format!(" Outcome summary: {}.", outcome.execution_summary))
+    }
+
+    fn persistence_summary(
+        &self,
+        context: &AgentProgramContext,
+        outcome: &BaseTypeOutcome,
+    ) -> SimardResult<String> {
+        Ok(format!(
+            "{} | {} | {}",
+            objective_metadata(&context.objective),
+            outcome.plan,
+            outcome.execution_summary,
+        ))
+    }
+}

--- a/src/base_types.rs
+++ b/src/base_types.rs
@@ -5,7 +5,8 @@ use crate::error::{SimardError, SimardResult};
 use crate::identity::OperatingMode;
 use crate::metadata::{BackendDescriptor, Freshness};
 use crate::prompt_assets::PromptAssetRef;
-use crate::runtime::RuntimeTopology;
+use crate::runtime::{RuntimeAddress, RuntimeNodeId, RuntimeTopology};
+use crate::sanitization::objective_metadata;
 use crate::session::SessionId;
 
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
@@ -61,6 +62,16 @@ pub fn capability_set(
     capabilities.into_iter().collect()
 }
 
+fn standard_session_capabilities() -> BTreeSet<BaseTypeCapability> {
+    capability_set([
+        BaseTypeCapability::PromptAssets,
+        BaseTypeCapability::SessionLifecycle,
+        BaseTypeCapability::Memory,
+        BaseTypeCapability::Evidence,
+        BaseTypeCapability::Reflection,
+    ])
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct BaseTypeDescriptor {
     pub id: BaseTypeId,
@@ -76,12 +87,18 @@ impl BaseTypeDescriptor {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct BaseTypeRequest {
+pub struct BaseTypeSessionRequest {
     pub session_id: SessionId,
-    pub objective: String,
     pub mode: OperatingMode,
     pub topology: RuntimeTopology,
     pub prompt_assets: Vec<PromptAssetRef>,
+    pub runtime_node: RuntimeNodeId,
+    pub mailbox_address: RuntimeAddress,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BaseTypeTurnInput {
+    pub objective: String,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -91,10 +108,23 @@ pub struct BaseTypeOutcome {
     pub evidence: Vec<String>,
 }
 
-pub trait BaseTypeAdapter: Send + Sync {
+pub trait BaseTypeSession: Send {
     fn descriptor(&self) -> &BaseTypeDescriptor;
 
-    fn invoke(&self, request: BaseTypeRequest) -> SimardResult<BaseTypeOutcome>;
+    fn open(&mut self) -> SimardResult<()>;
+
+    fn run_turn(&mut self, input: BaseTypeTurnInput) -> SimardResult<BaseTypeOutcome>;
+
+    fn close(&mut self) -> SimardResult<()>;
+}
+
+pub trait BaseTypeFactory: Send + Sync {
+    fn descriptor(&self) -> &BaseTypeDescriptor;
+
+    fn open_session(
+        &self,
+        request: BaseTypeSessionRequest,
+    ) -> SimardResult<Box<dyn BaseTypeSession>>;
 }
 
 #[derive(Debug)]
@@ -105,13 +135,15 @@ pub struct LocalProcessHarnessAdapter {
 impl LocalProcessHarnessAdapter {
     pub fn new(
         id: impl Into<String>,
+        implementation_identity: impl Into<String>,
         capabilities: impl IntoIterator<Item = BaseTypeCapability>,
         supported_topologies: impl IntoIterator<Item = RuntimeTopology>,
     ) -> SimardResult<Self> {
         let id = BaseTypeId::new(id);
+        let implementation_identity = implementation_identity.into();
         let backend = BackendDescriptor::for_runtime_type::<Self>(
-            id.to_string(),
-            format!("registered-base-type:{id}"),
+            implementation_identity.clone(),
+            format!("registered-base-type:{id}::implementation:{implementation_identity}"),
             Freshness::now()?,
         );
         Ok(Self {
@@ -125,26 +157,32 @@ impl LocalProcessHarnessAdapter {
     }
 
     pub fn single_process(id: impl Into<String>) -> SimardResult<Self> {
+        let id = id.into();
+        Self::single_process_alias(id.clone(), id)
+    }
+
+    pub fn single_process_alias(
+        id: impl Into<String>,
+        implementation_identity: impl Into<String>,
+    ) -> SimardResult<Self> {
         Self::new(
             id,
-            [
-                BaseTypeCapability::PromptAssets,
-                BaseTypeCapability::SessionLifecycle,
-                BaseTypeCapability::Memory,
-                BaseTypeCapability::Evidence,
-                BaseTypeCapability::Reflection,
-            ],
+            implementation_identity,
+            standard_session_capabilities(),
             [RuntimeTopology::SingleProcess],
         )
     }
 }
 
-impl BaseTypeAdapter for LocalProcessHarnessAdapter {
+impl BaseTypeFactory for LocalProcessHarnessAdapter {
     fn descriptor(&self) -> &BaseTypeDescriptor {
         &self.descriptor
     }
 
-    fn invoke(&self, request: BaseTypeRequest) -> SimardResult<BaseTypeOutcome> {
+    fn open_session(
+        &self,
+        request: BaseTypeSessionRequest,
+    ) -> SimardResult<Box<dyn BaseTypeSession>> {
         if !self.descriptor.supports_topology(request.topology) {
             return Err(SimardError::UnsupportedTopology {
                 base_type: self.descriptor.id.to_string(),
@@ -152,26 +190,263 @@ impl BaseTypeAdapter for LocalProcessHarnessAdapter {
             });
         }
 
-        let prompt_ids = request
+        Ok(Box::new(LocalProcessHarnessSession {
+            descriptor: self.descriptor.clone(),
+            request,
+            is_open: false,
+            is_closed: false,
+        }))
+    }
+}
+
+#[derive(Debug)]
+pub struct RustyClawdAdapter {
+    descriptor: BaseTypeDescriptor,
+}
+
+impl RustyClawdAdapter {
+    pub fn registered(id: impl Into<String>) -> SimardResult<Self> {
+        let id = BaseTypeId::new(id);
+        Ok(Self {
+            descriptor: BaseTypeDescriptor {
+                id,
+                backend: BackendDescriptor::for_runtime_type::<Self>(
+                    "rusty-clawd::session-backend",
+                    "registered-base-type:rusty-clawd",
+                    Freshness::now()?,
+                ),
+                capabilities: standard_session_capabilities(),
+                supported_topologies: [
+                    RuntimeTopology::SingleProcess,
+                    RuntimeTopology::MultiProcess,
+                ]
+                .into_iter()
+                .collect(),
+            },
+        })
+    }
+}
+
+impl BaseTypeFactory for RustyClawdAdapter {
+    fn descriptor(&self) -> &BaseTypeDescriptor {
+        &self.descriptor
+    }
+
+    fn open_session(
+        &self,
+        request: BaseTypeSessionRequest,
+    ) -> SimardResult<Box<dyn BaseTypeSession>> {
+        if !self.descriptor.supports_topology(request.topology) {
+            return Err(SimardError::UnsupportedTopology {
+                base_type: self.descriptor.id.to_string(),
+                topology: request.topology,
+            });
+        }
+
+        Ok(Box::new(RustyClawdSession {
+            descriptor: self.descriptor.clone(),
+            request,
+            is_open: false,
+            is_closed: false,
+        }))
+    }
+}
+
+#[derive(Debug)]
+struct RustyClawdSession {
+    descriptor: BaseTypeDescriptor,
+    request: BaseTypeSessionRequest,
+    is_open: bool,
+    is_closed: bool,
+}
+
+impl RustyClawdSession {
+    fn ensure_can(&self, action: &str) -> SimardResult<()> {
+        if self.is_closed {
+            return Err(SimardError::InvalidBaseTypeSessionState {
+                base_type: self.descriptor.id.to_string(),
+                action: action.to_string(),
+                reason: "session is already closed".to_string(),
+            });
+        }
+
+        Ok(())
+    }
+}
+
+impl BaseTypeSession for RustyClawdSession {
+    fn descriptor(&self) -> &BaseTypeDescriptor {
+        &self.descriptor
+    }
+
+    fn open(&mut self) -> SimardResult<()> {
+        self.ensure_can("open")?;
+        if self.is_open {
+            return Err(SimardError::InvalidBaseTypeSessionState {
+                base_type: self.descriptor.id.to_string(),
+                action: "open".to_string(),
+                reason: "session is already open".to_string(),
+            });
+        }
+        self.is_open = true;
+        Ok(())
+    }
+
+    fn run_turn(&mut self, input: BaseTypeTurnInput) -> SimardResult<BaseTypeOutcome> {
+        self.ensure_can("run_turn")?;
+        if !self.is_open {
+            return Err(SimardError::InvalidBaseTypeSessionState {
+                base_type: self.descriptor.id.to_string(),
+                action: "run_turn".to_string(),
+                reason: "session must be opened before turns can run".to_string(),
+            });
+        }
+
+        let prompt_ids = self
+            .request
             .prompt_assets
             .iter()
             .map(|asset| asset.id.to_string())
             .collect::<Vec<_>>()
             .join(", ");
+        let objective_summary = objective_metadata(&input.objective);
 
         Ok(BaseTypeOutcome {
             plan: format!(
-                "Run {:?} session '{}' with prompt assets [{}].",
-                request.mode, request.objective, prompt_ids
+                "Launch RustyClawd backend '{}' for '{}' on '{}' and bind prompt assets [{}] with {}.",
+                self.descriptor.backend.identity,
+                self.request.mode,
+                self.request.topology,
+                prompt_ids,
+                objective_summary
             ),
             execution_summary: format!(
-                "Local single-process harness executed '{}' via '{}'.",
-                request.objective, self.descriptor.id
+                "RustyClawd session backend executed {} via selected base type '{}' on implementation '{}' from node '{}' at '{}'.",
+                objective_summary,
+                self.descriptor.id,
+                self.descriptor.backend.identity,
+                self.request.runtime_node,
+                self.request.mailbox_address,
+            ),
+            evidence: vec![
+                format!("selected-base-type={}", self.descriptor.id),
+                format!(
+                    "backend-implementation={}",
+                    self.descriptor.backend.identity
+                ),
+                format!("prompt-assets=[{}]", prompt_ids),
+                format!("runtime-node={}", self.request.runtime_node),
+                format!("mailbox-address={}", self.request.mailbox_address),
+            ],
+        })
+    }
+
+    fn close(&mut self) -> SimardResult<()> {
+        self.ensure_can("close")?;
+        if !self.is_open {
+            return Err(SimardError::InvalidBaseTypeSessionState {
+                base_type: self.descriptor.id.to_string(),
+                action: "close".to_string(),
+                reason: "session was never opened".to_string(),
+            });
+        }
+        self.is_closed = true;
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct LocalProcessHarnessSession {
+    descriptor: BaseTypeDescriptor,
+    request: BaseTypeSessionRequest,
+    is_open: bool,
+    is_closed: bool,
+}
+
+impl LocalProcessHarnessSession {
+    fn ensure_can(&self, action: &str) -> SimardResult<()> {
+        if self.is_closed {
+            return Err(SimardError::InvalidBaseTypeSessionState {
+                base_type: self.descriptor.id.to_string(),
+                action: action.to_string(),
+                reason: "session is already closed".to_string(),
+            });
+        }
+
+        Ok(())
+    }
+}
+
+impl BaseTypeSession for LocalProcessHarnessSession {
+    fn descriptor(&self) -> &BaseTypeDescriptor {
+        &self.descriptor
+    }
+
+    fn open(&mut self) -> SimardResult<()> {
+        self.ensure_can("open")?;
+        if self.is_open {
+            return Err(SimardError::InvalidBaseTypeSessionState {
+                base_type: self.descriptor.id.to_string(),
+                action: "open".to_string(),
+                reason: "session is already open".to_string(),
+            });
+        }
+        self.is_open = true;
+        Ok(())
+    }
+
+    fn run_turn(&mut self, input: BaseTypeTurnInput) -> SimardResult<BaseTypeOutcome> {
+        self.ensure_can("run_turn")?;
+        if !self.is_open {
+            return Err(SimardError::InvalidBaseTypeSessionState {
+                base_type: self.descriptor.id.to_string(),
+                action: "run_turn".to_string(),
+                reason: "session must be opened before turns can run".to_string(),
+            });
+        }
+
+        let prompt_ids = self
+            .request
+            .prompt_assets
+            .iter()
+            .map(|asset| asset.id.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let objective_summary = objective_metadata(&input.objective);
+        let implementation_identity = &self.descriptor.backend.identity;
+
+        Ok(BaseTypeOutcome {
+            plan: format!(
+                "Open '{}' session on '{}' via {} and run prompt assets [{}].",
+                self.request.mode, self.request.topology, objective_summary, prompt_ids
+            ),
+            execution_summary: format!(
+                "Local single-process harness session executed {} via selected base type '{}' on implementation '{}' from node '{}' at '{}'.",
+                objective_summary,
+                self.descriptor.id,
+                implementation_identity,
+                self.request.runtime_node,
+                self.request.mailbox_address,
             ),
             evidence: vec![
                 format!("selected-base-type={}", self.descriptor.id),
                 format!("prompt-assets=[{}]", prompt_ids),
+                format!("runtime-node={}", self.request.runtime_node),
+                format!("mailbox-address={}", self.request.mailbox_address),
             ],
         })
+    }
+
+    fn close(&mut self) -> SimardResult<()> {
+        self.ensure_can("close")?;
+        if !self.is_open {
+            return Err(SimardError::InvalidBaseTypeSessionState {
+                base_type: self.descriptor.id.to_string(),
+                action: "close".to_string(),
+                reason: "session was never opened".to_string(),
+            });
+        }
+        self.is_closed = true;
+        Ok(())
     }
 }

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -3,11 +3,11 @@ use std::fmt::{self, Display, Formatter};
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use crate::base_types::{BaseTypeId, LocalProcessHarnessAdapter};
+use crate::base_types::{BaseTypeId, LocalProcessHarnessAdapter, RustyClawdAdapter};
 use crate::error::{SimardError, SimardResult};
 use crate::evidence::InMemoryEvidenceStore;
 use crate::identity::{
-    BuiltinIdentityLoader, IdentityLoadRequest, IdentityLoader, ManifestContract,
+    BuiltinIdentityLoader, IdentityLoadRequest, IdentityLoader, IdentityManifest, ManifestContract,
 };
 use crate::memory::InMemoryMemoryStore;
 use crate::metadata::{Freshness, Provenance};
@@ -21,6 +21,8 @@ use crate::session::UuidSessionIdGenerator;
 const DEFAULT_IDENTITY: &str = "simard-engineer";
 const DEFAULT_OBJECTIVE: &str = "bootstrap the Simard engineer loop";
 const LOCAL_BASE_TYPE: &str = "local-harness";
+const RUSTY_CLAWD_BASE_TYPE: &str = "rusty-clawd";
+const COPILOT_SDK_BASE_TYPE: &str = "copilot-sdk";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum BootstrapMode {
@@ -80,6 +82,8 @@ pub struct BootstrapInputs {
     pub objective: Option<String>,
     pub mode: Option<String>,
     pub identity: Option<String>,
+    pub base_type: Option<String>,
+    pub topology: Option<String>,
 }
 
 impl BootstrapInputs {
@@ -89,6 +93,8 @@ impl BootstrapInputs {
             objective: read_optional_utf8_env("SIMARD_OBJECTIVE")?,
             mode: read_optional_utf8_env("SIMARD_BOOTSTRAP_MODE")?,
             identity: read_optional_utf8_env("SIMARD_IDENTITY")?,
+            base_type: read_optional_utf8_env("SIMARD_BASE_TYPE")?,
+            topology: read_optional_utf8_env("SIMARD_RUNTIME_TOPOLOGY")?,
         })
     }
 }
@@ -99,6 +105,8 @@ pub struct BootstrapConfig {
     pub identity: String,
     pub prompt_root: ConfigValue<PathBuf>,
     pub objective: ConfigValue<String>,
+    pub selected_base_type: ConfigValue<BaseTypeId>,
+    pub topology: ConfigValue<RuntimeTopology>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -152,6 +160,43 @@ impl BootstrapConfig {
             }
         };
 
+        let selected_base_type = match inputs.base_type {
+            Some(value) => ConfigValue {
+                value: BaseTypeId::new(value),
+                source: ConfigValueSource::Environment("SIMARD_BASE_TYPE"),
+            },
+            None if mode == BootstrapMode::BuiltinDefaults => ConfigValue {
+                value: BaseTypeId::new(LOCAL_BASE_TYPE),
+                source: ConfigValueSource::ExplicitOptIn("SIMARD_BOOTSTRAP_MODE"),
+            },
+            None => {
+                return Err(SimardError::MissingRequiredConfig {
+                    key: "SIMARD_BASE_TYPE".to_string(),
+                    help:
+                        "set SIMARD_BASE_TYPE or opt in with SIMARD_BOOTSTRAP_MODE=builtin-defaults"
+                            .to_string(),
+                });
+            }
+        };
+
+        let topology = match inputs.topology {
+            Some(value) => ConfigValue {
+                value: parse_runtime_topology(value)?,
+                source: ConfigValueSource::Environment("SIMARD_RUNTIME_TOPOLOGY"),
+            },
+            None if mode == BootstrapMode::BuiltinDefaults => ConfigValue {
+                value: RuntimeTopology::SingleProcess,
+                source: ConfigValueSource::ExplicitOptIn("SIMARD_BOOTSTRAP_MODE"),
+            },
+            None => {
+                return Err(SimardError::MissingRequiredConfig {
+                    key: "SIMARD_RUNTIME_TOPOLOGY".to_string(),
+                    help: "set SIMARD_RUNTIME_TOPOLOGY or opt in with SIMARD_BOOTSTRAP_MODE=builtin-defaults"
+                        .to_string(),
+                });
+            }
+        };
+
         Ok(Self {
             mode,
             identity: match inputs.identity {
@@ -168,6 +213,8 @@ impl BootstrapConfig {
             },
             prompt_root,
             objective,
+            selected_base_type,
+            topology,
         })
     }
 
@@ -175,6 +222,8 @@ impl BootstrapConfig {
         vec![
             format!("mode:{}", self.mode),
             format!("identity:{}", self.identity),
+            format!("base-type:{}", self.selected_base_type.value),
+            format!("topology:{}", self.topology.value),
             format!("prompt-root:{}", self.prompt_root.source),
             format!("objective:{}", self.objective.source),
         ]
@@ -185,9 +234,6 @@ pub fn assemble_local_runtime(config: &BootstrapConfig) -> SimardResult<LocalRun
     let prompt_store = Arc::new(FilePromptAssetStore::new(config.prompt_root.value.clone()));
     let memory_store = Arc::new(InMemoryMemoryStore::try_default()?);
     let evidence_store = Arc::new(InMemoryEvidenceStore::try_default()?);
-
-    let mut base_types = BaseTypeRegistry::default();
-    base_types.register(LocalProcessHarnessAdapter::single_process(LOCAL_BASE_TYPE)?);
 
     let contract = ManifestContract::new(
         bootstrap_entrypoint(),
@@ -205,11 +251,12 @@ pub fn assemble_local_runtime(config: &BootstrapConfig) -> SimardResult<LocalRun
         env!("CARGO_PKG_VERSION"),
         contract,
     ))?;
+    let base_types = base_type_registry_for_manifest(&manifest)?;
 
     let request = RuntimeRequest::new(
         manifest,
-        BaseTypeId::new(LOCAL_BASE_TYPE),
-        RuntimeTopology::SingleProcess,
+        config.selected_base_type.value.clone(),
+        config.topology.value,
     );
 
     LocalRuntime::compose(
@@ -260,6 +307,54 @@ fn decode_utf8_env_value(key: &'static str, value: OsString) -> SimardResult<Opt
         })
 }
 
+fn parse_runtime_topology(value: String) -> SimardResult<RuntimeTopology> {
+    match value.as_str() {
+        "single-process" => Ok(RuntimeTopology::SingleProcess),
+        "multi-process" => Ok(RuntimeTopology::MultiProcess),
+        "distributed" => Ok(RuntimeTopology::Distributed),
+        _ => Err(SimardError::InvalidConfigValue {
+            key: "SIMARD_RUNTIME_TOPOLOGY".to_string(),
+            value,
+            help: "expected 'single-process', 'multi-process', or 'distributed'".to_string(),
+        }),
+    }
+}
+
+fn base_type_registry_for_manifest(manifest: &IdentityManifest) -> SimardResult<BaseTypeRegistry> {
+    let mut base_types = BaseTypeRegistry::default();
+    for base_type in &manifest.supported_base_types {
+        register_builtin_base_type(&mut base_types, base_type)?;
+    }
+    Ok(base_types)
+}
+
+fn register_builtin_base_type(
+    base_types: &mut BaseTypeRegistry,
+    base_type: &BaseTypeId,
+) -> SimardResult<()> {
+    match base_type.as_str() {
+        LOCAL_BASE_TYPE => {
+            base_types.register(LocalProcessHarnessAdapter::single_process_alias(
+                base_type.as_str(),
+                LOCAL_BASE_TYPE,
+            )?);
+            Ok(())
+        }
+        RUSTY_CLAWD_BASE_TYPE => {
+            base_types.register(RustyClawdAdapter::registered(base_type.as_str())?);
+            Ok(())
+        }
+        COPILOT_SDK_BASE_TYPE => {
+            base_types.register(LocalProcessHarnessAdapter::single_process_alias(
+                base_type.as_str(),
+                LOCAL_BASE_TYPE,
+            )?);
+            Ok(())
+        }
+        _ => Ok(()),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #[cfg(unix)]
@@ -267,8 +362,13 @@ mod tests {
     #[cfg(unix)]
     use std::os::unix::ffi::OsStringExt;
 
-    use super::decode_utf8_env_value;
+    use super::{LOCAL_BASE_TYPE, base_type_registry_for_manifest, decode_utf8_env_value};
+    use crate::base_types::{BaseTypeFactory, BaseTypeId, RustyClawdAdapter};
     use crate::error::SimardError;
+    use crate::identity::{
+        BuiltinIdentityLoader, IdentityLoadRequest, IdentityLoader, ManifestContract,
+    };
+    use crate::metadata::{Freshness, Provenance};
 
     #[cfg(unix)]
     #[test]
@@ -281,6 +381,46 @@ mod tests {
             SimardError::NonUnicodeConfigValue {
                 key: "SIMARD_IDENTITY".to_string(),
             }
+        );
+    }
+
+    #[test]
+    fn builtin_adapter_catalog_covers_manifest_advertised_base_types() {
+        let manifest = BuiltinIdentityLoader
+            .load(&IdentityLoadRequest::new(
+                "simard-engineer",
+                env!("CARGO_PKG_VERSION"),
+                ManifestContract::new(
+                    crate::bootstrap_entrypoint(),
+                    "bootstrap-config -> identity-loader -> runtime-ports -> local-runtime",
+                    vec!["tests:bootstrap-catalog".to_string()],
+                    Provenance::new("test", "bootstrap::catalog"),
+                    Freshness::now().expect("freshness should be observable"),
+                )
+                .expect("contract should be valid"),
+            ))
+            .expect("builtin identity should load");
+
+        let registry = base_type_registry_for_manifest(&manifest).expect("registry should build");
+        let local = registry
+            .get(&BaseTypeId::new("local-harness"))
+            .expect("local harness should be registered");
+        let rusty = registry
+            .get(&BaseTypeId::new("rusty-clawd"))
+            .expect("rusty-clawd should be registered");
+        let copilot = registry
+            .get(&BaseTypeId::new("copilot-sdk"))
+            .expect("copilot-sdk should be registered");
+
+        assert_eq!(local.descriptor().backend.identity, LOCAL_BASE_TYPE);
+        assert_eq!(copilot.descriptor().backend.identity, LOCAL_BASE_TYPE);
+        assert_eq!(
+            rusty.descriptor().backend.identity,
+            RustyClawdAdapter::registered("rusty-clawd")
+                .expect("rusty-clawd adapter should initialize")
+                .descriptor()
+                .backend
+                .identity
         );
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -44,6 +44,10 @@ pub enum SimardError {
         path: PathBuf,
         reason: String,
     },
+    UnsupportedMemoryPolicy {
+        field: String,
+        reason: String,
+    },
     UnsupportedBaseType {
         identity: String,
         base_type: String,
@@ -55,6 +59,11 @@ pub enum SimardError {
         base_type: String,
         reason: String,
     },
+    InvalidBaseTypeSessionState {
+        base_type: String,
+        action: String,
+        reason: String,
+    },
     MissingCapability {
         base_type: String,
         capability: BaseTypeCapability,
@@ -62,6 +71,10 @@ pub enum SimardError {
     UnsupportedTopology {
         base_type: String,
         topology: RuntimeTopology,
+    },
+    UnsupportedRuntimeTopology {
+        topology: RuntimeTopology,
+        driver: String,
     },
     InvalidRuntimeTransition {
         from: RuntimeState,
@@ -76,6 +89,10 @@ pub enum SimardError {
     InvalidSessionTransition {
         from: SessionPhase,
         to: SessionPhase,
+    },
+    InvalidHandoffSnapshot {
+        field: String,
+        reason: String,
     },
     StoragePoisoned {
         store: String,
@@ -96,11 +113,12 @@ impl Display for SimardError {
             Self::NonUnicodeConfigValue { key } => {
                 write!(f, "configuration '{key}' must be valid UTF-8")
             }
-            Self::InvalidConfigValue { key, value, help } => {
-                write!(
-                    f,
-                    "invalid value '{value}' for configuration '{key}': {help}"
-                )
+            Self::InvalidConfigValue {
+                key,
+                value: _,
+                help,
+            } => {
+                write!(f, "invalid value for configuration '{key}': {help}")
             }
             Self::UnknownIdentity { requested } => {
                 write!(f, "identity '{requested}' is not registered")
@@ -111,29 +129,23 @@ impl Display for SimardError {
             Self::InvalidSessionId { value, reason } => {
                 write!(f, "invalid session id '{value}': {reason}")
             }
-            Self::PromptAssetMissing { asset_id, path } => {
+            Self::PromptAssetMissing { asset_id, path: _ } => {
                 write!(
                     f,
-                    "prompt asset '{asset_id}' was not found at {}",
-                    path.display()
+                    "prompt asset '{asset_id}' was not found under the configured prompt root"
                 )
             }
-            Self::PromptAssetRead { path, reason } => {
-                write!(
-                    f,
-                    "failed to read prompt asset {}: {reason}",
-                    path.display()
-                )
+            Self::PromptAssetRead { path: _, reason } => {
+                write!(f, "failed to read configured prompt asset: {reason}")
             }
             Self::InvalidPromptAssetPath {
                 asset_id,
-                path,
+                path: _,
                 reason,
-            } => write!(
-                f,
-                "invalid prompt asset path for '{asset_id}' at {}: {reason}",
-                path.display()
-            ),
+            } => write!(f, "invalid prompt asset path for '{asset_id}': {reason}"),
+            Self::UnsupportedMemoryPolicy { field, reason } => {
+                write!(f, "unsupported memory policy '{field}': {reason}")
+            }
             Self::UnsupportedBaseType {
                 identity,
                 base_type,
@@ -145,8 +157,19 @@ impl Display for SimardError {
                 write!(f, "no adapter is registered for base type '{base_type}'")
             }
             Self::AdapterInvocationFailed { base_type, reason } => {
-                write!(f, "base type '{base_type}' failed during invocation: {reason}")
+                write!(
+                    f,
+                    "base type '{base_type}' failed during invocation: {reason}"
+                )
             }
+            Self::InvalidBaseTypeSessionState {
+                base_type,
+                action,
+                reason,
+            } => write!(
+                f,
+                "base type session '{base_type}' cannot '{action}': {reason}"
+            ),
             Self::MissingCapability {
                 base_type,
                 capability,
@@ -161,6 +184,10 @@ impl Display for SimardError {
                 f,
                 "base type '{base_type}' does not support topology '{topology}'"
             ),
+            Self::UnsupportedRuntimeTopology { topology, driver } => write!(
+                f,
+                "runtime topology driver '{driver}' does not support topology '{topology}'"
+            ),
             Self::InvalidRuntimeTransition { from, to } => {
                 write!(f, "invalid runtime transition from '{from}' to '{to}'")
             }
@@ -168,10 +195,16 @@ impl Display for SimardError {
                 write!(f, "runtime is stopped and cannot '{action}'")
             }
             Self::RuntimeFailed { action } => {
-                write!(f, "runtime is failed and cannot '{action}' until it is stopped")
+                write!(
+                    f,
+                    "runtime is failed and cannot '{action}' until it is stopped"
+                )
             }
             Self::InvalidSessionTransition { from, to } => {
                 write!(f, "invalid session transition from '{from}' to '{to}'")
+            }
+            Self::InvalidHandoffSnapshot { field, reason } => {
+                write!(f, "invalid handoff snapshot field '{field}': {reason}")
             }
             Self::StoragePoisoned { store } => {
                 write!(f, "storage lock for '{store}' is poisoned")

--- a/src/evidence.rs
+++ b/src/evidence.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Mutex;
 
 use crate::base_types::BaseTypeId;
@@ -32,14 +33,20 @@ pub trait EvidenceStore: Send + Sync {
 
 #[derive(Debug)]
 pub struct InMemoryEvidenceStore {
-    records: Mutex<Vec<EvidenceRecord>>,
+    state: Mutex<EvidenceStoreState>,
     descriptor: BackendDescriptor,
+}
+
+#[derive(Debug, Default)]
+struct EvidenceStoreState {
+    records: Vec<EvidenceRecord>,
+    session_counts: HashMap<SessionId, usize>,
 }
 
 impl InMemoryEvidenceStore {
     pub fn new(descriptor: BackendDescriptor) -> Self {
         Self {
-            records: Mutex::new(Vec::new()),
+            state: Mutex::new(EvidenceStoreState::default()),
             descriptor,
         }
     }
@@ -59,22 +66,28 @@ impl EvidenceStore for InMemoryEvidenceStore {
     }
 
     fn record(&self, record: EvidenceRecord) -> SimardResult<()> {
-        self.records
+        let mut state = self
+            .state
             .lock()
             .map_err(|_| SimardError::StoragePoisoned {
                 store: "evidence".to_string(),
-            })?
-            .push(record);
+            })?;
+        *state
+            .session_counts
+            .entry(record.session_id.clone())
+            .or_insert(0) += 1;
+        state.records.push(record);
         Ok(())
     }
 
     fn list_for_session(&self, session_id: &SessionId) -> SimardResult<Vec<EvidenceRecord>> {
-        Ok(self
-            .records
+        let state = self
+            .state
             .lock()
             .map_err(|_| SimardError::StoragePoisoned {
                 store: "evidence".to_string(),
-            })?
+            })?;
+        Ok(state
             .iter()
             .filter(|record| &record.session_id == session_id)
             .cloned()
@@ -82,14 +95,73 @@ impl EvidenceStore for InMemoryEvidenceStore {
     }
 
     fn count_for_session(&self, session_id: &SessionId) -> SimardResult<usize> {
-        Ok(self
-            .records
+        let state = self
+            .state
             .lock()
             .map_err(|_| SimardError::StoragePoisoned {
                 store: "evidence".to_string(),
-            })?
-            .iter()
-            .filter(|record| &record.session_id == session_id)
-            .count())
+            })?;
+        Ok(state
+            .session_counts
+            .get(session_id)
+            .copied()
+            .unwrap_or_default())
+    }
+}
+
+impl EvidenceStoreState {
+    fn iter(&self) -> impl Iterator<Item = &EvidenceRecord> {
+        self.records.iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{EvidenceRecord, EvidenceSource, EvidenceStore, InMemoryEvidenceStore};
+    use crate::session::{SessionId, SessionPhase};
+
+    #[test]
+    fn cached_session_counts_match_recorded_evidence() {
+        let store = InMemoryEvidenceStore::try_default().expect("store should initialize");
+        let hot = SessionId::parse("session-00000000-0000-0000-0000-000000000001")
+            .expect("session id should parse");
+        let cold = SessionId::parse("session-00000000-0000-0000-0000-000000000002")
+            .expect("session id should parse");
+
+        for (id, session_id) in [
+            ("ev-1", hot.clone()),
+            ("ev-2", cold.clone()),
+            ("ev-3", hot.clone()),
+        ] {
+            store
+                .record(EvidenceRecord {
+                    id: id.to_string(),
+                    session_id,
+                    phase: SessionPhase::Execution,
+                    detail: "recorded".to_string(),
+                    source: EvidenceSource::Runtime,
+                })
+                .expect("record should persist");
+        }
+
+        assert_eq!(
+            store
+                .count_for_session(&hot)
+                .expect("hot session count should be indexed"),
+            2
+        );
+        assert_eq!(
+            store
+                .count_for_session(&cold)
+                .expect("cold session count should be indexed"),
+            1
+        );
+        assert_eq!(
+            store
+                .list_for_session(&hot)
+                .expect("session listing should still work")
+                .len(),
+            2
+        );
     }
 }

--- a/src/handoff.rs
+++ b/src/handoff.rs
@@ -1,0 +1,80 @@
+use std::sync::Mutex;
+
+use crate::base_types::BaseTypeId;
+use crate::error::{SimardError, SimardResult};
+use crate::evidence::EvidenceRecord;
+use crate::memory::MemoryRecord;
+use crate::metadata::{BackendDescriptor, Freshness};
+use crate::runtime::{RuntimeAddress, RuntimeNodeId, RuntimeState, RuntimeTopology};
+use crate::session::SessionRecord;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RuntimeHandoffSnapshot {
+    pub exported_state: RuntimeState,
+    pub identity_name: String,
+    pub selected_base_type: BaseTypeId,
+    pub topology: RuntimeTopology,
+    pub source_runtime_node: RuntimeNodeId,
+    pub source_mailbox_address: RuntimeAddress,
+    pub session: Option<SessionRecord>,
+    pub memory_records: Vec<MemoryRecord>,
+    pub evidence_records: Vec<EvidenceRecord>,
+}
+
+pub trait RuntimeHandoffStore: Send + Sync {
+    fn descriptor(&self) -> BackendDescriptor;
+
+    fn save(&self, snapshot: RuntimeHandoffSnapshot) -> SimardResult<()>;
+
+    fn latest(&self) -> SimardResult<Option<RuntimeHandoffSnapshot>>;
+}
+
+#[derive(Debug)]
+pub struct InMemoryHandoffStore {
+    state: Mutex<Option<RuntimeHandoffSnapshot>>,
+    descriptor: BackendDescriptor,
+}
+
+impl InMemoryHandoffStore {
+    pub fn new(descriptor: BackendDescriptor) -> Self {
+        Self {
+            state: Mutex::new(None),
+            descriptor,
+        }
+    }
+
+    pub fn try_default() -> SimardResult<Self> {
+        Ok(Self::new(BackendDescriptor::for_runtime_type::<Self>(
+            "handoff::in-memory",
+            "runtime-port:handoff-store",
+            Freshness::now()?,
+        )))
+    }
+}
+
+impl RuntimeHandoffStore for InMemoryHandoffStore {
+    fn descriptor(&self) -> BackendDescriptor {
+        self.descriptor.clone()
+    }
+
+    fn save(&self, snapshot: RuntimeHandoffSnapshot) -> SimardResult<()> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| SimardError::StoragePoisoned {
+                store: "handoff".to_string(),
+            })?;
+        *state = Some(snapshot);
+        Ok(())
+    }
+
+    fn latest(&self) -> SimardResult<Option<RuntimeHandoffSnapshot>> {
+        let state = self
+            .state
+            .lock()
+            .map_err(|_| SimardError::StoragePoisoned {
+                store: "handoff".to_string(),
+            })?;
+        Ok(state.clone())
+    }
+}

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeSet;
+use std::fmt::{self, Display, Formatter};
 
 use crate::base_types::{BaseTypeCapability, BaseTypeId, capability_set};
 use crate::error::{SimardError, SimardResult};
@@ -13,6 +14,17 @@ pub enum OperatingMode {
     Gym,
 }
 
+impl Display for OperatingMode {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let label = match self {
+            Self::Engineer => "engineer",
+            Self::Meeting => "meeting",
+            Self::Gym => "gym",
+        };
+        f.write_str(label)
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MemoryPolicy {
     pub allow_project_writes: bool,
@@ -25,6 +37,19 @@ impl Default for MemoryPolicy {
             allow_project_writes: false,
             summary_scope: MemoryScope::SessionSummary,
         }
+    }
+}
+
+impl MemoryPolicy {
+    pub fn validate(&self) -> SimardResult<()> {
+        if self.allow_project_writes {
+            return Err(SimardError::UnsupportedMemoryPolicy {
+                field: "memory_policy.allow_project_writes".to_string(),
+                reason: "v1 only supports read-only project boundaries".to_string(),
+            });
+        }
+
+        Ok(())
     }
 }
 
@@ -161,6 +186,10 @@ pub struct IdentityManifest {
 }
 
 impl IdentityManifest {
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "identity manifests are explicit contract values with distinct fields"
+    )]
     pub fn new(
         name: impl Into<String>,
         version: impl Into<String>,
@@ -171,6 +200,8 @@ impl IdentityManifest {
         memory_policy: MemoryPolicy,
         contract: ManifestContract,
     ) -> SimardResult<Self> {
+        memory_policy.validate()?;
+
         Ok(Self {
             name: name.into(),
             version: version.into(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,18 +1,23 @@
+pub mod agent_program;
 pub mod base_types;
 pub mod bootstrap;
 pub mod error;
 pub mod evidence;
+pub mod handoff;
 pub mod identity;
 pub mod memory;
 pub mod metadata;
 pub mod prompt_assets;
 pub mod reflection;
 pub mod runtime;
+mod sanitization;
 pub mod session;
 
+pub use agent_program::{AgentProgram, AgentProgramContext, ObjectiveRelayProgram};
 pub use base_types::{
-    BaseTypeAdapter, BaseTypeCapability, BaseTypeDescriptor, BaseTypeId, BaseTypeOutcome,
-    BaseTypeRequest, LocalProcessHarnessAdapter, capability_set,
+    BaseTypeCapability, BaseTypeDescriptor, BaseTypeFactory, BaseTypeId, BaseTypeOutcome,
+    BaseTypeSession, BaseTypeSessionRequest, BaseTypeTurnInput, LocalProcessHarnessAdapter,
+    RustyClawdAdapter, capability_set,
 };
 pub use bootstrap::{
     BootstrapConfig, BootstrapInputs, BootstrapMode, ConfigValue, ConfigValueSource,
@@ -20,6 +25,7 @@ pub use bootstrap::{
 };
 pub use error::{SimardError, SimardResult};
 pub use evidence::{EvidenceRecord, EvidenceSource, EvidenceStore, InMemoryEvidenceStore};
+pub use handoff::{InMemoryHandoffStore, RuntimeHandoffSnapshot, RuntimeHandoffStore};
 pub use identity::{
     BuiltinIdentityLoader, IdentityLoadRequest, IdentityLoader, IdentityManifest, ManifestContract,
     MemoryPolicy, OperatingMode,
@@ -32,7 +38,10 @@ pub use prompt_assets::{
 };
 pub use reflection::{ReflectionReport, ReflectionSnapshot, ReflectiveRuntime};
 pub use runtime::{
-    BaseTypeRegistry, LocalRuntime, RuntimePorts, RuntimeRequest, RuntimeState, RuntimeTopology,
+    BaseTypeRegistry, CoordinatedSupervisor, InMemoryMailboxTransport, InProcessSupervisor,
+    InProcessTopologyDriver, LocalRuntime, LoopbackMailboxTransport, LoopbackMeshTopologyDriver,
+    RuntimeAddress, RuntimeKernel, RuntimeMailboxTransport, RuntimeNodeId, RuntimePorts,
+    RuntimeRequest, RuntimeState, RuntimeSupervisor, RuntimeTopology, RuntimeTopologyDriver,
     SessionOutcome,
 };
 pub use session::{

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,17 +7,25 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Simard local runtime executed successfully.");
     println!("Bootstrap mode: {}", config.mode);
     println!(
-        "Config sources: prompt_root={}, objective={}",
-        config.prompt_root.source, config.objective.source
+        "Config sources: prompt_root={}, objective={}, base_type={}, topology={}",
+        config.prompt_root.source,
+        config.objective.source,
+        config.selected_base_type.source,
+        config.topology.source
     );
-    println!("Plan: {}", execution.outcome.plan);
-    println!("Execution: {}", execution.outcome.execution_summary);
-    println!("Reflection: {}", execution.outcome.reflection.summary);
+    println!(
+        "Bootstrap selection: identity={}, base_type={}, topology={}",
+        config.identity, config.selected_base_type.value, config.topology.value
+    );
     println!(
         "Snapshot: state={}, topology={}, base_type={}",
         execution.snapshot.runtime_state,
         execution.snapshot.topology,
         execution.snapshot.selected_base_type
+    );
+    println!(
+        "Adapter implementation: {}",
+        execution.snapshot.adapter_backend.identity
     );
     println!("Shutdown: {}", execution.stopped_snapshot.runtime_state);
 

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Mutex;
 
 use crate::error::{SimardError, SimardResult};
@@ -35,14 +36,20 @@ pub trait MemoryStore: Send + Sync {
 
 #[derive(Debug)]
 pub struct InMemoryMemoryStore {
-    records: Mutex<Vec<MemoryRecord>>,
+    state: Mutex<MemoryStoreState>,
     descriptor: BackendDescriptor,
+}
+
+#[derive(Debug, Default)]
+struct MemoryStoreState {
+    records: Vec<MemoryRecord>,
+    session_counts: HashMap<SessionId, usize>,
 }
 
 impl InMemoryMemoryStore {
     pub fn new(descriptor: BackendDescriptor) -> Self {
         Self {
-            records: Mutex::new(Vec::new()),
+            state: Mutex::new(MemoryStoreState::default()),
             descriptor,
         }
     }
@@ -62,22 +69,28 @@ impl MemoryStore for InMemoryMemoryStore {
     }
 
     fn put(&self, record: MemoryRecord) -> SimardResult<()> {
-        self.records
+        let mut state = self
+            .state
             .lock()
             .map_err(|_| SimardError::StoragePoisoned {
                 store: "memory".to_string(),
-            })?
-            .push(record);
+            })?;
+        *state
+            .session_counts
+            .entry(record.session_id.clone())
+            .or_insert(0) += 1;
+        state.records.push(record);
         Ok(())
     }
 
     fn list(&self, scope: MemoryScope) -> SimardResult<Vec<MemoryRecord>> {
-        Ok(self
-            .records
+        let state = self
+            .state
             .lock()
             .map_err(|_| SimardError::StoragePoisoned {
                 store: "memory".to_string(),
-            })?
+            })?;
+        Ok(state
             .iter()
             .filter(|record| record.scope == scope)
             .cloned()
@@ -85,12 +98,13 @@ impl MemoryStore for InMemoryMemoryStore {
     }
 
     fn list_for_session(&self, session_id: &SessionId) -> SimardResult<Vec<MemoryRecord>> {
-        Ok(self
-            .records
+        let state = self
+            .state
             .lock()
             .map_err(|_| SimardError::StoragePoisoned {
                 store: "memory".to_string(),
-            })?
+            })?;
+        Ok(state
             .iter()
             .filter(|record| &record.session_id == session_id)
             .cloned()
@@ -98,14 +112,92 @@ impl MemoryStore for InMemoryMemoryStore {
     }
 
     fn count_for_session(&self, session_id: &SessionId) -> SimardResult<usize> {
-        Ok(self
-            .records
+        let state = self
+            .state
             .lock()
             .map_err(|_| SimardError::StoragePoisoned {
                 store: "memory".to_string(),
-            })?
-            .iter()
-            .filter(|record| &record.session_id == session_id)
-            .count())
+            })?;
+        Ok(state
+            .session_counts
+            .get(session_id)
+            .copied()
+            .unwrap_or_default())
+    }
+}
+
+impl MemoryStoreState {
+    fn iter(&self) -> impl Iterator<Item = &MemoryRecord> {
+        self.records.iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{InMemoryMemoryStore, MemoryRecord, MemoryScope, MemoryStore};
+    use crate::session::{SessionId, SessionPhase};
+
+    #[test]
+    fn cached_session_counts_stay_in_sync_with_records() {
+        let store = InMemoryMemoryStore::try_default().expect("store should initialize");
+        let hot = SessionId::parse("session-00000000-0000-0000-0000-000000000001")
+            .expect("session id should parse");
+        let cold = SessionId::parse("session-00000000-0000-0000-0000-000000000002")
+            .expect("session id should parse");
+
+        store
+            .put(MemoryRecord {
+                key: "hot-scratch".to_string(),
+                scope: MemoryScope::SessionScratch,
+                value: "x".to_string(),
+                session_id: hot.clone(),
+                recorded_in: SessionPhase::Preparation,
+            })
+            .expect("first record should persist");
+        store
+            .put(MemoryRecord {
+                key: "cold-summary".to_string(),
+                scope: MemoryScope::SessionSummary,
+                value: "y".to_string(),
+                session_id: cold.clone(),
+                recorded_in: SessionPhase::Persistence,
+            })
+            .expect("second record should persist");
+        store
+            .put(MemoryRecord {
+                key: "hot-summary".to_string(),
+                scope: MemoryScope::SessionSummary,
+                value: "z".to_string(),
+                session_id: hot.clone(),
+                recorded_in: SessionPhase::Persistence,
+            })
+            .expect("third record should persist");
+
+        assert_eq!(
+            store
+                .count_for_session(&hot)
+                .expect("hot session count should be indexed"),
+            2
+        );
+        assert_eq!(
+            store
+                .count_for_session(&cold)
+                .expect("cold session count should be indexed"),
+            1
+        );
+        assert_eq!(
+            store
+                .list(MemoryScope::SessionSummary)
+                .expect("scope listing should still work")
+                .len(),
+            2
+        );
+        assert_eq!(
+            store
+                .list_for_session(&hot)
+                .expect("session listing should still scan full records")
+                .len(),
+            2
+        );
     }
 }

--- a/src/reflection.rs
+++ b/src/reflection.rs
@@ -3,7 +3,7 @@ use crate::error::SimardResult;
 use crate::identity::ManifestContract;
 use crate::metadata::BackendDescriptor;
 use crate::prompt_assets::PromptAssetId;
-use crate::runtime::{RuntimeState, RuntimeTopology};
+use crate::runtime::{RuntimeAddress, RuntimeNodeId, RuntimeState, RuntimeTopology};
 use crate::session::SessionPhase;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -12,12 +12,19 @@ pub struct ReflectionSnapshot {
     pub selected_base_type: BaseTypeId,
     pub topology: RuntimeTopology,
     pub runtime_state: RuntimeState,
+    pub runtime_node: RuntimeNodeId,
+    pub mailbox_address: RuntimeAddress,
     pub session_phase: Option<SessionPhase>,
     pub prompt_assets: Vec<PromptAssetId>,
     pub manifest_contract: ManifestContract,
     pub evidence_records: usize,
     pub memory_records: usize,
+    pub agent_program_backend: BackendDescriptor,
+    pub handoff_backend: BackendDescriptor,
     pub adapter_backend: BackendDescriptor,
+    pub topology_backend: BackendDescriptor,
+    pub transport_backend: BackendDescriptor,
+    pub supervisor_backend: BackendDescriptor,
     pub memory_backend: BackendDescriptor,
     pub evidence_backend: BackendDescriptor,
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2,14 +2,17 @@ use std::collections::BTreeMap;
 use std::fmt::{self, Display, Formatter};
 use std::sync::Arc;
 
-use crate::base_types::{BaseTypeAdapter, BaseTypeId, BaseTypeRequest};
+use crate::agent_program::{AgentProgram, AgentProgramContext, ObjectiveRelayProgram};
+use crate::base_types::{BaseTypeFactory, BaseTypeId, BaseTypeOutcome, BaseTypeSessionRequest};
 use crate::error::{SimardError, SimardResult};
 use crate::evidence::{EvidenceRecord, EvidenceSource, EvidenceStore};
+use crate::handoff::{InMemoryHandoffStore, RuntimeHandoffSnapshot, RuntimeHandoffStore};
 use crate::identity::IdentityManifest;
 use crate::memory::{MemoryRecord, MemoryScope, MemoryStore};
-use crate::metadata::{Freshness, FreshnessState};
+use crate::metadata::{BackendDescriptor, Freshness, FreshnessState};
 use crate::prompt_assets::{PromptAssetRef, PromptAssetStore};
 use crate::reflection::{ReflectionReport, ReflectionSnapshot, ReflectiveRuntime};
+use crate::sanitization::objective_metadata;
 use crate::session::{SessionIdGenerator, SessionPhase, SessionRecord};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
@@ -83,22 +86,243 @@ impl RuntimeState {
     }
 }
 
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct RuntimeNodeId(String);
+
+impl RuntimeNodeId {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    pub fn local() -> Self {
+        Self::new("node-local")
+    }
+}
+
+impl Display for RuntimeNodeId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct RuntimeAddress(String);
+
+impl RuntimeAddress {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    pub fn local(node: &RuntimeNodeId) -> Self {
+        Self::new(format!("inmemory://{node}"))
+    }
+}
+
+impl Display for RuntimeAddress {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
 #[derive(Default)]
 pub struct BaseTypeRegistry {
-    adapters: BTreeMap<BaseTypeId, Arc<dyn BaseTypeAdapter>>,
+    factories: BTreeMap<BaseTypeId, Arc<dyn BaseTypeFactory>>,
 }
 
 impl BaseTypeRegistry {
-    pub fn register<A>(&mut self, adapter: A)
+    pub fn register<F>(&mut self, factory: F)
     where
-        A: BaseTypeAdapter + 'static,
+        F: BaseTypeFactory + 'static,
     {
-        self.adapters
-            .insert(adapter.descriptor().id.clone(), Arc::new(adapter));
+        self.factories
+            .insert(factory.descriptor().id.clone(), Arc::new(factory));
     }
 
-    pub fn get(&self, id: &BaseTypeId) -> Option<Arc<dyn BaseTypeAdapter>> {
-        self.adapters.get(id).map(Arc::clone)
+    pub fn get(&self, id: &BaseTypeId) -> Option<Arc<dyn BaseTypeFactory>> {
+        self.factories.get(id).map(Arc::clone)
+    }
+}
+
+pub trait RuntimeTopologyDriver: Send + Sync {
+    fn descriptor(&self) -> BackendDescriptor;
+
+    fn supports_topology(&self, topology: RuntimeTopology) -> bool;
+
+    fn local_node(&self) -> SimardResult<RuntimeNodeId>;
+}
+
+pub trait RuntimeMailboxTransport: Send + Sync {
+    fn descriptor(&self) -> BackendDescriptor;
+
+    fn mailbox_for(&self, node: &RuntimeNodeId) -> SimardResult<RuntimeAddress>;
+}
+
+pub trait RuntimeSupervisor: Send + Sync {
+    fn descriptor(&self) -> BackendDescriptor;
+}
+
+#[derive(Debug)]
+pub struct InProcessTopologyDriver {
+    descriptor: BackendDescriptor,
+}
+
+impl InProcessTopologyDriver {
+    pub fn try_default() -> SimardResult<Self> {
+        Ok(Self {
+            descriptor: BackendDescriptor::for_runtime_type::<Self>(
+                "topology::in-process",
+                "runtime-port:topology-driver",
+                Freshness::now()?,
+            ),
+        })
+    }
+}
+
+impl RuntimeTopologyDriver for InProcessTopologyDriver {
+    fn descriptor(&self) -> BackendDescriptor {
+        self.descriptor.clone()
+    }
+
+    fn supports_topology(&self, topology: RuntimeTopology) -> bool {
+        matches!(topology, RuntimeTopology::SingleProcess)
+    }
+
+    fn local_node(&self) -> SimardResult<RuntimeNodeId> {
+        Ok(RuntimeNodeId::local())
+    }
+}
+
+#[derive(Debug)]
+pub struct InMemoryMailboxTransport {
+    descriptor: BackendDescriptor,
+}
+
+impl InMemoryMailboxTransport {
+    pub fn try_default() -> SimardResult<Self> {
+        Ok(Self {
+            descriptor: BackendDescriptor::for_runtime_type::<Self>(
+                "transport::in-memory-mailbox",
+                "runtime-port:mailbox-transport",
+                Freshness::now()?,
+            ),
+        })
+    }
+}
+
+impl RuntimeMailboxTransport for InMemoryMailboxTransport {
+    fn descriptor(&self) -> BackendDescriptor {
+        self.descriptor.clone()
+    }
+
+    fn mailbox_for(&self, node: &RuntimeNodeId) -> SimardResult<RuntimeAddress> {
+        Ok(RuntimeAddress::local(node))
+    }
+}
+
+#[derive(Debug)]
+pub struct LoopbackMeshTopologyDriver {
+    descriptor: BackendDescriptor,
+}
+
+impl LoopbackMeshTopologyDriver {
+    pub fn try_default() -> SimardResult<Self> {
+        Ok(Self {
+            descriptor: BackendDescriptor::for_runtime_type::<Self>(
+                "topology::loopback-mesh",
+                "runtime-port:topology-driver",
+                Freshness::now()?,
+            ),
+        })
+    }
+}
+
+impl RuntimeTopologyDriver for LoopbackMeshTopologyDriver {
+    fn descriptor(&self) -> BackendDescriptor {
+        self.descriptor.clone()
+    }
+
+    fn supports_topology(&self, topology: RuntimeTopology) -> bool {
+        matches!(
+            topology,
+            RuntimeTopology::MultiProcess | RuntimeTopology::Distributed
+        )
+    }
+
+    fn local_node(&self) -> SimardResult<RuntimeNodeId> {
+        Ok(RuntimeNodeId::new("node-loopback-mesh"))
+    }
+}
+
+#[derive(Debug)]
+pub struct LoopbackMailboxTransport {
+    descriptor: BackendDescriptor,
+}
+
+impl LoopbackMailboxTransport {
+    pub fn try_default() -> SimardResult<Self> {
+        Ok(Self {
+            descriptor: BackendDescriptor::for_runtime_type::<Self>(
+                "transport::loopback-mailbox",
+                "runtime-port:mailbox-transport",
+                Freshness::now()?,
+            ),
+        })
+    }
+}
+
+impl RuntimeMailboxTransport for LoopbackMailboxTransport {
+    fn descriptor(&self) -> BackendDescriptor {
+        self.descriptor.clone()
+    }
+
+    fn mailbox_for(&self, node: &RuntimeNodeId) -> SimardResult<RuntimeAddress> {
+        Ok(RuntimeAddress::new(format!("loopback://{node}")))
+    }
+}
+
+#[derive(Debug)]
+pub struct InProcessSupervisor {
+    descriptor: BackendDescriptor,
+}
+
+impl InProcessSupervisor {
+    pub fn try_default() -> SimardResult<Self> {
+        Ok(Self {
+            descriptor: BackendDescriptor::for_runtime_type::<Self>(
+                "supervisor::in-process",
+                "runtime-port:supervisor",
+                Freshness::now()?,
+            ),
+        })
+    }
+}
+
+impl RuntimeSupervisor for InProcessSupervisor {
+    fn descriptor(&self) -> BackendDescriptor {
+        self.descriptor.clone()
+    }
+}
+
+#[derive(Debug)]
+pub struct CoordinatedSupervisor {
+    descriptor: BackendDescriptor,
+}
+
+impl CoordinatedSupervisor {
+    pub fn try_default() -> SimardResult<Self> {
+        Ok(Self {
+            descriptor: BackendDescriptor::for_runtime_type::<Self>(
+                "supervisor::coordinated",
+                "runtime-port:supervisor",
+                Freshness::now()?,
+            ),
+        })
+    }
+}
+
+impl RuntimeSupervisor for CoordinatedSupervisor {
+    fn descriptor(&self) -> BackendDescriptor {
+        self.descriptor.clone()
     }
 }
 
@@ -107,6 +331,11 @@ pub struct RuntimePorts {
     memory_store: Arc<dyn MemoryStore>,
     evidence_store: Arc<dyn EvidenceStore>,
     base_types: BaseTypeRegistry,
+    topology_driver: Arc<dyn RuntimeTopologyDriver>,
+    transport: Arc<dyn RuntimeMailboxTransport>,
+    supervisor: Arc<dyn RuntimeSupervisor>,
+    agent_program: Arc<dyn AgentProgram>,
+    handoff_store: Arc<dyn RuntimeHandoffStore>,
     session_ids: Arc<dyn SessionIdGenerator>,
 }
 
@@ -118,11 +347,23 @@ impl RuntimePorts {
         base_types: BaseTypeRegistry,
         session_ids: Arc<dyn SessionIdGenerator>,
     ) -> Self {
-        Self::with_session_ids(
+        Self::with_runtime_services(
             prompt_store,
             memory_store,
             evidence_store,
             base_types,
+            Arc::new(
+                InProcessTopologyDriver::try_default()
+                    .expect("in-process topology driver should initialize"),
+            ),
+            Arc::new(
+                InMemoryMailboxTransport::try_default()
+                    .expect("in-memory transport should initialize"),
+            ),
+            Arc::new(
+                InProcessSupervisor::try_default()
+                    .expect("in-process supervisor should initialize"),
+            ),
             session_ids,
         )
     }
@@ -134,11 +375,75 @@ impl RuntimePorts {
         base_types: BaseTypeRegistry,
         session_ids: Arc<dyn SessionIdGenerator>,
     ) -> Self {
+        Self::new(
+            prompt_store,
+            memory_store,
+            evidence_store,
+            base_types,
+            session_ids,
+        )
+    }
+
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "runtime assembly requires explicit injected ports for topology neutrality"
+    )]
+    pub fn with_runtime_services(
+        prompt_store: Arc<dyn PromptAssetStore>,
+        memory_store: Arc<dyn MemoryStore>,
+        evidence_store: Arc<dyn EvidenceStore>,
+        base_types: BaseTypeRegistry,
+        topology_driver: Arc<dyn RuntimeTopologyDriver>,
+        transport: Arc<dyn RuntimeMailboxTransport>,
+        supervisor: Arc<dyn RuntimeSupervisor>,
+        session_ids: Arc<dyn SessionIdGenerator>,
+    ) -> Self {
+        Self::with_runtime_services_and_program(
+            prompt_store,
+            memory_store,
+            evidence_store,
+            base_types,
+            topology_driver,
+            transport,
+            supervisor,
+            Arc::new(
+                ObjectiveRelayProgram::try_default()
+                    .expect("default agent program should initialize"),
+            ),
+            Arc::new(
+                InMemoryHandoffStore::try_default()
+                    .expect("default handoff store should initialize"),
+            ),
+            session_ids,
+        )
+    }
+
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "runtime assembly requires explicit injected ports for topology-neutral execution"
+    )]
+    pub fn with_runtime_services_and_program(
+        prompt_store: Arc<dyn PromptAssetStore>,
+        memory_store: Arc<dyn MemoryStore>,
+        evidence_store: Arc<dyn EvidenceStore>,
+        base_types: BaseTypeRegistry,
+        topology_driver: Arc<dyn RuntimeTopologyDriver>,
+        transport: Arc<dyn RuntimeMailboxTransport>,
+        supervisor: Arc<dyn RuntimeSupervisor>,
+        agent_program: Arc<dyn AgentProgram>,
+        handoff_store: Arc<dyn RuntimeHandoffStore>,
+        session_ids: Arc<dyn SessionIdGenerator>,
+    ) -> Self {
         Self {
             prompt_store,
             memory_store,
             evidence_store,
             base_types,
+            topology_driver,
+            transport,
+            supervisor,
+            agent_program,
+            handoff_store,
             session_ids,
         }
     }
@@ -173,17 +478,30 @@ pub struct SessionOutcome {
     pub reflection: ReflectionReport,
 }
 
-pub struct LocalRuntime {
+pub struct RuntimeKernel {
     ports: RuntimePorts,
     request: RuntimeRequest,
     state: RuntimeState,
-    adapter: Arc<dyn BaseTypeAdapter>,
+    factory: Arc<dyn BaseTypeFactory>,
     prompt_assets: Vec<PromptAssetRef>,
     last_session: Option<SessionRecord>,
+    runtime_node: RuntimeNodeId,
+    mailbox_address: RuntimeAddress,
 }
 
-impl LocalRuntime {
+pub type LocalRuntime = RuntimeKernel;
+
+impl RuntimeKernel {
     pub fn compose(ports: RuntimePorts, request: RuntimeRequest) -> SimardResult<Self> {
+        request.manifest.memory_policy.validate()?;
+
+        if !ports.topology_driver.supports_topology(request.topology) {
+            return Err(SimardError::UnsupportedRuntimeTopology {
+                topology: request.topology,
+                driver: ports.topology_driver.descriptor().identity,
+            });
+        }
+
         if !request
             .manifest
             .supports_base_type(&request.selected_base_type)
@@ -194,14 +512,14 @@ impl LocalRuntime {
             });
         }
 
-        let adapter = ports
+        let factory = ports
             .base_types
             .get(&request.selected_base_type)
             .ok_or_else(|| SimardError::AdapterNotRegistered {
                 base_type: request.selected_base_type.to_string(),
             })?;
 
-        let descriptor = adapter.descriptor();
+        let descriptor = factory.descriptor();
         for capability in &request.manifest.required_capabilities {
             if !descriptor.capabilities.contains(capability) {
                 return Err(SimardError::MissingCapability {
@@ -218,18 +536,59 @@ impl LocalRuntime {
             });
         }
 
+        let runtime_node = ports.topology_driver.local_node()?;
+        let mailbox_address = ports.transport.mailbox_for(&runtime_node)?;
+
         Ok(Self {
             ports,
             request,
             state: RuntimeState::Initializing,
-            adapter,
+            factory,
             prompt_assets: Vec::new(),
             last_session: None,
+            runtime_node,
+            mailbox_address,
         })
     }
 
     pub fn state(&self) -> RuntimeState {
         self.state
+    }
+
+    pub fn compose_from_handoff(
+        ports: RuntimePorts,
+        request: RuntimeRequest,
+        snapshot: RuntimeHandoffSnapshot,
+    ) -> SimardResult<Self> {
+        if snapshot.identity_name != request.manifest.name {
+            return Err(SimardError::InvalidHandoffSnapshot {
+                field: "identity_name".to_string(),
+                reason: format!(
+                    "snapshot identity '{}' does not match request identity '{}'",
+                    snapshot.identity_name, request.manifest.name
+                ),
+            });
+        }
+        if snapshot.selected_base_type != request.selected_base_type {
+            return Err(SimardError::InvalidHandoffSnapshot {
+                field: "selected_base_type".to_string(),
+                reason: format!(
+                    "snapshot base type '{}' does not match request base type '{}'",
+                    snapshot.selected_base_type, request.selected_base_type
+                ),
+            });
+        }
+
+        let mut runtime = Self::compose(ports, request)?;
+        for record in &snapshot.memory_records {
+            runtime.ports.memory_store.put(record.clone())?;
+        }
+        for record in &snapshot.evidence_records {
+            runtime.ports.evidence_store.record(record.clone())?;
+        }
+        runtime.last_session = snapshot.session.clone();
+        runtime.ports.handoff_store.save(snapshot)?;
+        Ok(runtime)
     }
 
     pub fn start(&mut self) -> SimardResult<()> {
@@ -257,92 +616,9 @@ impl LocalRuntime {
 
     pub fn run(&mut self, objective: impl Into<String>) -> SimardResult<SessionOutcome> {
         self.ensure_available("run")?;
+        let objective = objective.into();
 
-        let result = (|| {
-            self.transition(RuntimeState::Active)?;
-
-            let mut session = SessionRecord::new(
-                self.request.manifest.default_mode,
-                objective.into(),
-                self.request.selected_base_type.clone(),
-                self.ports.session_ids.as_ref(),
-            );
-            self.remember_session(&session);
-
-            session.advance(SessionPhase::Preparation)?;
-            self.remember_session(&session);
-            let scratch_key = format!("{}-scratch", session.id);
-            self.ports.memory_store.put(MemoryRecord {
-                key: scratch_key.clone(),
-                scope: MemoryScope::SessionScratch,
-                value: format!("objective={}", session.objective),
-                session_id: session.id.clone(),
-                recorded_in: SessionPhase::Preparation,
-            })?;
-            session.attach_memory(scratch_key);
-            self.remember_session(&session);
-
-            session.advance(SessionPhase::Planning)?;
-            self.remember_session(&session);
-            let outcome = self.adapter.invoke(BaseTypeRequest {
-                session_id: session.id.clone(),
-                objective: session.objective.clone(),
-                mode: session.mode,
-                topology: self.request.topology,
-                prompt_assets: self.prompt_assets.clone(),
-            })?;
-
-            session.advance(SessionPhase::Execution)?;
-            self.remember_session(&session);
-            for (index, detail) in outcome.evidence.iter().enumerate() {
-                let evidence_id = format!("{}-evidence-{}", session.id, index + 1);
-                self.ports.evidence_store.record(EvidenceRecord {
-                    id: evidence_id.clone(),
-                    session_id: session.id.clone(),
-                    phase: SessionPhase::Execution,
-                    detail: detail.clone(),
-                    source: EvidenceSource::BaseType(self.request.selected_base_type.clone()),
-                })?;
-                session.attach_evidence(evidence_id);
-            }
-            self.remember_session(&session);
-
-            self.transition(RuntimeState::Reflecting)?;
-            session.advance(SessionPhase::Reflection)?;
-            self.remember_session(&session);
-            let reflection = ReflectionReport {
-                summary: format!(
-                    "Session '{}' completed through '{}' on '{}'.",
-                    session.objective, self.request.selected_base_type, self.request.topology
-                ),
-                snapshot: self.snapshot_for(Some(&session))?,
-            };
-
-            self.transition(RuntimeState::Persisting)?;
-            session.advance(SessionPhase::Persistence)?;
-            self.remember_session(&session);
-            let summary_key = format!("{}-summary", session.id);
-            self.ports.memory_store.put(MemoryRecord {
-                key: summary_key.clone(),
-                scope: self.request.manifest.memory_policy.summary_scope,
-                value: format!("{} | {}", outcome.plan, outcome.execution_summary),
-                session_id: session.id.clone(),
-                recorded_in: SessionPhase::Persistence,
-            })?;
-            session.attach_memory(summary_key);
-            self.remember_session(&session);
-
-            session.advance(SessionPhase::Complete)?;
-            self.remember_session(&session);
-            self.transition(RuntimeState::Ready)?;
-
-            Ok(SessionOutcome {
-                session,
-                plan: outcome.plan,
-                execution_summary: outcome.execution_summary,
-                reflection,
-            })
-        })();
+        let result = self.execute_session(objective);
 
         if result.is_err() && !matches!(self.state, RuntimeState::Stopped | RuntimeState::Stopping)
         {
@@ -351,6 +627,43 @@ impl LocalRuntime {
         }
 
         result
+    }
+
+    pub fn export_handoff(&self) -> SimardResult<RuntimeHandoffSnapshot> {
+        let memory_records = match self.last_session.as_ref() {
+            Some(session) => self.ports.memory_store.list_for_session(&session.id)?,
+            None => Vec::new(),
+        };
+        let evidence_records = match self.last_session.as_ref() {
+            Some(session) => self.ports.evidence_store.list_for_session(&session.id)?,
+            None => Vec::new(),
+        };
+
+        let snapshot = RuntimeHandoffSnapshot {
+            exported_state: self.state,
+            identity_name: self.request.manifest.name.clone(),
+            selected_base_type: self.request.selected_base_type.clone(),
+            topology: self.request.topology,
+            source_runtime_node: self.runtime_node.clone(),
+            source_mailbox_address: self.mailbox_address.clone(),
+            session: self.last_session.clone(),
+            memory_records,
+            evidence_records,
+        };
+        self.ports.handoff_store.save(snapshot.clone())?;
+        Ok(snapshot)
+    }
+
+    fn execute_session(&mut self, objective: String) -> SimardResult<SessionOutcome> {
+        self.transition(RuntimeState::Active)?;
+
+        let mut session = self.new_session(objective);
+        self.persist_session_scratch(&mut session)?;
+        let outcome = self.run_selected_base_type_session(&mut session)?;
+        self.record_execution_evidence(&mut session, &outcome)?;
+        let reflection = self.build_reflection(&mut session, &outcome)?;
+        self.persist_session_summary(&mut session, &outcome)?;
+        self.complete_session(session, outcome, reflection)
     }
 
     fn ensure_available(&self, action: &str) -> SimardResult<()> {
@@ -381,11 +694,162 @@ impl LocalRuntime {
         self.last_session = Some(session.clone());
     }
 
+    fn new_session(&mut self, objective: String) -> SessionRecord {
+        let session = SessionRecord::new(
+            self.request.manifest.default_mode,
+            objective,
+            self.request.selected_base_type.clone(),
+            self.ports.session_ids.as_ref(),
+        );
+        self.remember_session(&session);
+        session
+    }
+
+    fn persist_session_scratch(&mut self, session: &mut SessionRecord) -> SimardResult<()> {
+        session.advance(SessionPhase::Preparation)?;
+        self.remember_session(session);
+
+        let scratch_key = format!("{}-scratch", session.id);
+        self.ports.memory_store.put(MemoryRecord {
+            key: scratch_key.clone(),
+            scope: MemoryScope::SessionScratch,
+            value: objective_metadata(&session.objective),
+            session_id: session.id.clone(),
+            recorded_in: SessionPhase::Preparation,
+        })?;
+        session.attach_memory(scratch_key);
+        self.remember_session(session);
+
+        Ok(())
+    }
+
+    fn run_selected_base_type_session(
+        &mut self,
+        session: &mut SessionRecord,
+    ) -> SimardResult<BaseTypeOutcome> {
+        session.advance(SessionPhase::Planning)?;
+        self.remember_session(session);
+
+        let context = self.agent_program_context(session);
+
+        let mut base_type_session = self.factory.open_session(BaseTypeSessionRequest {
+            session_id: session.id.clone(),
+            mode: session.mode,
+            topology: self.request.topology,
+            prompt_assets: self.prompt_assets.clone(),
+            runtime_node: self.runtime_node.clone(),
+            mailbox_address: self.mailbox_address.clone(),
+        })?;
+        base_type_session.open()?;
+        let outcome = base_type_session.run_turn(self.ports.agent_program.plan_turn(&context)?)?;
+        base_type_session.close()?;
+        Ok(outcome)
+    }
+
+    fn record_execution_evidence(
+        &mut self,
+        session: &mut SessionRecord,
+        outcome: &BaseTypeOutcome,
+    ) -> SimardResult<()> {
+        session.advance(SessionPhase::Execution)?;
+        self.remember_session(session);
+
+        for (index, detail) in outcome.evidence.iter().enumerate() {
+            let evidence_id = format!("{}-evidence-{}", session.id, index + 1);
+            self.ports.evidence_store.record(EvidenceRecord {
+                id: evidence_id.clone(),
+                session_id: session.id.clone(),
+                phase: SessionPhase::Execution,
+                detail: detail.clone(),
+                source: EvidenceSource::BaseType(self.request.selected_base_type.clone()),
+            })?;
+            session.attach_evidence(evidence_id);
+        }
+        self.remember_session(session);
+
+        Ok(())
+    }
+
+    fn build_reflection(
+        &mut self,
+        session: &mut SessionRecord,
+        outcome: &BaseTypeOutcome,
+    ) -> SimardResult<ReflectionReport> {
+        self.transition(RuntimeState::Reflecting)?;
+        session.advance(SessionPhase::Reflection)?;
+        self.remember_session(session);
+
+        Ok(ReflectionReport {
+            summary: self
+                .ports
+                .agent_program
+                .reflection_summary(&self.agent_program_context(session), outcome)?,
+            snapshot: self.snapshot_for(Some(session))?,
+        })
+    }
+
+    fn persist_session_summary(
+        &mut self,
+        session: &mut SessionRecord,
+        outcome: &BaseTypeOutcome,
+    ) -> SimardResult<()> {
+        self.transition(RuntimeState::Persisting)?;
+        session.advance(SessionPhase::Persistence)?;
+        self.remember_session(session);
+
+        let summary_key = format!("{}-summary", session.id);
+        self.ports.memory_store.put(MemoryRecord {
+            key: summary_key.clone(),
+            scope: self.request.manifest.memory_policy.summary_scope,
+            value: self
+                .ports
+                .agent_program
+                .persistence_summary(&self.agent_program_context(session), outcome)?,
+            session_id: session.id.clone(),
+            recorded_in: SessionPhase::Persistence,
+        })?;
+        session.attach_memory(summary_key);
+        self.remember_session(session);
+
+        Ok(())
+    }
+
+    fn complete_session(
+        &mut self,
+        mut session: SessionRecord,
+        outcome: BaseTypeOutcome,
+        reflection: ReflectionReport,
+    ) -> SimardResult<SessionOutcome> {
+        session.advance(SessionPhase::Complete)?;
+        self.remember_session(&session);
+        self.transition(RuntimeState::Ready)?;
+
+        Ok(SessionOutcome {
+            session,
+            plan: outcome.plan,
+            execution_summary: outcome.execution_summary,
+            reflection,
+        })
+    }
+
     fn mark_last_session_failed(&mut self) {
-        if let Some(session) = self.last_session.as_mut() {
-            if session.phase != SessionPhase::Failed {
-                session.phase = SessionPhase::Failed;
-            }
+        if let Some(session) = self.last_session.as_mut()
+            && session.phase != SessionPhase::Failed
+        {
+            session.phase = SessionPhase::Failed;
+        }
+    }
+
+    fn agent_program_context(&self, session: &SessionRecord) -> AgentProgramContext {
+        AgentProgramContext {
+            session_id: session.id.clone(),
+            identity_name: self.request.manifest.name.clone(),
+            mode: session.mode,
+            selected_base_type: self.request.selected_base_type.clone(),
+            topology: self.request.topology,
+            runtime_node: self.runtime_node.clone(),
+            mailbox_address: self.mailbox_address.clone(),
+            objective: session.objective.clone(),
         }
     }
 
@@ -416,6 +880,8 @@ impl LocalRuntime {
             selected_base_type: self.request.selected_base_type.clone(),
             topology: self.request.topology,
             runtime_state: self.state,
+            runtime_node: self.runtime_node.clone(),
+            mailbox_address: self.mailbox_address.clone(),
             session_phase: session.map(|active_session| active_session.phase),
             prompt_assets: self
                 .prompt_assets
@@ -429,14 +895,19 @@ impl LocalRuntime {
                 .with_freshness(manifest_freshness),
             evidence_records,
             memory_records,
-            adapter_backend: self.adapter.descriptor().backend.clone(),
+            agent_program_backend: self.ports.agent_program.descriptor(),
+            handoff_backend: self.ports.handoff_store.descriptor(),
+            adapter_backend: self.factory.descriptor().backend.clone(),
+            topology_backend: self.ports.topology_driver.descriptor(),
+            transport_backend: self.ports.transport.descriptor(),
+            supervisor_backend: self.ports.supervisor.descriptor(),
             memory_backend: self.ports.memory_store.descriptor(),
             evidence_backend: self.ports.evidence_store.descriptor(),
         })
     }
 }
 
-impl ReflectiveRuntime for LocalRuntime {
+impl ReflectiveRuntime for RuntimeKernel {
     fn snapshot(&self) -> SimardResult<ReflectionSnapshot> {
         self.snapshot_for(self.last_session.as_ref())
     }

--- a/src/sanitization.rs
+++ b/src/sanitization.rs
@@ -1,0 +1,11 @@
+pub fn objective_metadata(objective: &str) -> String {
+    let chars = objective.chars().count();
+    let words = objective.split_whitespace().count();
+    let lines = if objective.is_empty() {
+        0
+    } else {
+        objective.lines().count()
+    };
+
+    format!("objective-metadata(chars={chars}, words={words}, lines={lines})")
+}

--- a/tests/bootstrap.rs
+++ b/tests/bootstrap.rs
@@ -1,9 +1,10 @@
 use std::path::PathBuf;
 
 use simard::{
-    BootstrapConfig, BootstrapInputs, BootstrapMode, BuiltinIdentityLoader, ConfigValueSource,
-    IdentityLoadRequest, IdentityLoader, ManifestContract, Provenance, ReflectiveRuntime,
-    RuntimeState, assemble_local_runtime, bootstrap_entrypoint, run_local_session,
+    BaseTypeId, BootstrapConfig, BootstrapInputs, BootstrapMode, BuiltinIdentityLoader,
+    ConfigValueSource, IdentityLoadRequest, IdentityLoader, ManifestContract, Provenance,
+    ReflectiveRuntime, RuntimeState, RuntimeTopology, SimardError, assemble_local_runtime,
+    bootstrap_entrypoint, run_local_session,
 };
 
 #[test]
@@ -39,10 +40,23 @@ fn bootstrap_builtin_defaults_are_only_used_with_explicit_opt_in() {
         ConfigValueSource::ExplicitOptIn("SIMARD_BOOTSTRAP_MODE")
     );
     assert_eq!(
+        config.selected_base_type.source,
+        ConfigValueSource::ExplicitOptIn("SIMARD_BOOTSTRAP_MODE")
+    );
+    assert_eq!(
+        config.topology.source,
+        ConfigValueSource::ExplicitOptIn("SIMARD_BOOTSTRAP_MODE")
+    );
+    assert_eq!(
         config.prompt_root.value,
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("prompt_assets")
     );
     assert_eq!(config.objective.value, "bootstrap the Simard engineer loop");
+    assert_eq!(
+        config.selected_base_type.value,
+        BaseTypeId::new("local-harness")
+    );
+    assert_eq!(config.topology.value, RuntimeTopology::SingleProcess);
 }
 
 #[test]
@@ -50,6 +64,8 @@ fn bootstrap_requires_explicit_identity_without_builtin_defaults() {
     let error = BootstrapConfig::resolve(BootstrapInputs {
         prompt_root: Some(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("prompt_assets")),
         objective: Some("exercise bootstrap identity handling".to_string()),
+        base_type: Some("local-harness".to_string()),
+        topology: Some("single-process".to_string()),
         ..BootstrapInputs::default()
     })
     .unwrap_err();
@@ -62,6 +78,85 @@ fn bootstrap_requires_explicit_identity_without_builtin_defaults() {
                 .to_string(),
         }
     );
+}
+
+#[test]
+fn bootstrap_requires_explicit_base_type_without_builtin_defaults() {
+    let error = BootstrapConfig::resolve(BootstrapInputs {
+        prompt_root: Some(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("prompt_assets")),
+        objective: Some("exercise bootstrap base type handling".to_string()),
+        identity: Some("simard-engineer".to_string()),
+        topology: Some("single-process".to_string()),
+        ..BootstrapInputs::default()
+    })
+    .unwrap_err();
+
+    assert_eq!(
+        error,
+        SimardError::MissingRequiredConfig {
+            key: "SIMARD_BASE_TYPE".to_string(),
+            help: "set SIMARD_BASE_TYPE or opt in with SIMARD_BOOTSTRAP_MODE=builtin-defaults"
+                .to_string(),
+        }
+    );
+}
+
+#[test]
+fn bootstrap_requires_explicit_topology_without_builtin_defaults() {
+    let error = BootstrapConfig::resolve(BootstrapInputs {
+        prompt_root: Some(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("prompt_assets")),
+        objective: Some("exercise bootstrap topology handling".to_string()),
+        identity: Some("simard-engineer".to_string()),
+        base_type: Some("local-harness".to_string()),
+        ..BootstrapInputs::default()
+    })
+    .unwrap_err();
+
+    assert_eq!(
+        error,
+        SimardError::MissingRequiredConfig {
+            key: "SIMARD_RUNTIME_TOPOLOGY".to_string(),
+            help:
+                "set SIMARD_RUNTIME_TOPOLOGY or opt in with SIMARD_BOOTSTRAP_MODE=builtin-defaults"
+                    .to_string(),
+        }
+    );
+}
+
+#[test]
+fn bootstrap_rejects_invalid_topology_values() {
+    let error = BootstrapConfig::resolve(BootstrapInputs {
+        prompt_root: Some(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("prompt_assets")),
+        objective: Some("exercise invalid topology handling".to_string()),
+        identity: Some("simard-engineer".to_string()),
+        base_type: Some("local-harness".to_string()),
+        topology: Some("mystery-mesh".to_string()),
+        ..BootstrapInputs::default()
+    })
+    .unwrap_err();
+
+    assert_eq!(
+        error,
+        SimardError::InvalidConfigValue {
+            key: "SIMARD_RUNTIME_TOPOLOGY".to_string(),
+            value: "mystery-mesh".to_string(),
+            help: "expected 'single-process', 'multi-process', or 'distributed'".to_string(),
+        }
+    );
+}
+
+#[test]
+fn invalid_config_display_redacts_raw_values() {
+    let error = SimardError::InvalidConfigValue {
+        key: "SIMARD_RUNTIME_TOPOLOGY".to_string(),
+        value: "mystery-mesh".to_string(),
+        help: "expected 'single-process', 'multi-process', or 'distributed'".to_string(),
+    };
+
+    let rendered = error.to_string();
+    assert!(rendered.contains("SIMARD_RUNTIME_TOPOLOGY"));
+    assert!(rendered.contains("expected 'single-process'"));
+    assert!(!rendered.contains("mystery-mesh"));
 }
 
 #[test]
@@ -95,6 +190,8 @@ fn bootstrap_assembly_produces_truthful_manifest_metadata() {
         prompt_root: Some(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("prompt_assets")),
         objective: Some("exercise bootstrap assembly".to_string()),
         identity: Some("simard-engineer".to_string()),
+        base_type: Some("local-harness".to_string()),
+        topology: Some("single-process".to_string()),
         ..BootstrapInputs::default()
     })
     .expect("explicit bootstrap config should resolve");
@@ -112,6 +209,11 @@ fn bootstrap_assembly_produces_truthful_manifest_metadata() {
         config.manifest_precedence()
     );
     assert_eq!(snapshot.manifest_contract.provenance.source, "bootstrap");
+    assert_eq!(
+        snapshot.selected_base_type,
+        BaseTypeId::new("local-harness")
+    );
+    assert_eq!(snapshot.topology, RuntimeTopology::SingleProcess);
     assert!(
         snapshot
             .manifest_contract
@@ -158,11 +260,40 @@ fn main_is_thin_and_bootstrap_owns_identity_and_runtime_assembly() {
 }
 
 #[test]
+fn main_does_not_print_objective_derived_runtime_details() {
+    let main_rs = include_str!("../src/main.rs");
+
+    for forbidden in [
+        "println!(\"Plan:",
+        "println!(\"Execution:",
+        "println!(\"Reflection:",
+        "execution.outcome.plan",
+        "execution.outcome.execution_summary",
+        "execution.outcome.reflection.summary",
+    ] {
+        assert!(
+            !main_rs.contains(forbidden),
+            "main.rs should not print objective-derived runtime details like {forbidden}"
+        );
+    }
+}
+
+#[test]
+fn main_reports_selected_base_type_and_runtime_implementation_separately() {
+    let main_rs = include_str!("../src/main.rs");
+
+    assert!(main_rs.contains("Bootstrap selection:"));
+    assert!(main_rs.contains("Adapter implementation:"));
+}
+
+#[test]
 fn bootstrap_run_local_session_executes_the_cli_lifecycle() {
     let config = BootstrapConfig::resolve(BootstrapInputs {
         prompt_root: Some(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("prompt_assets")),
         objective: Some("exercise the bootstrap run loop".to_string()),
         identity: Some("simard-engineer".to_string()),
+        base_type: Some("local-harness".to_string()),
+        topology: Some("single-process".to_string()),
         ..BootstrapInputs::default()
     })
     .expect("explicit bootstrap config should resolve");
@@ -177,5 +308,112 @@ fn bootstrap_run_local_session_executes_the_cli_lifecycle() {
     assert_eq!(
         execution.stopped_snapshot.manifest_contract.freshness.state,
         simard::FreshnessState::Stale
+    );
+}
+
+#[test]
+fn bootstrap_assembly_supports_multiple_builtin_manifest_base_types() {
+    for base_type in ["local-harness", "rusty-clawd", "copilot-sdk"] {
+        let config = BootstrapConfig::resolve(BootstrapInputs {
+            prompt_root: Some(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("prompt_assets")),
+            objective: Some(format!("exercise base type handling for {base_type}")),
+            identity: Some("simard-engineer".to_string()),
+            base_type: Some(base_type.to_string()),
+            topology: Some("single-process".to_string()),
+            ..BootstrapInputs::default()
+        })
+        .expect("explicit bootstrap config should resolve");
+
+        let execution =
+            run_local_session(&config).expect("builtin manifest base type should execute");
+
+        assert_eq!(
+            execution.snapshot.selected_base_type,
+            BaseTypeId::new(base_type)
+        );
+        let expected_backend = match base_type {
+            "rusty-clawd" => "rusty-clawd::session-backend",
+            _ => "local-harness",
+        };
+        assert_eq!(
+            execution.snapshot.adapter_backend.identity,
+            expected_backend
+        );
+        assert_eq!(execution.snapshot.topology, RuntimeTopology::SingleProcess);
+        assert!(
+            execution
+                .snapshot
+                .adapter_backend
+                .provenance
+                .locator
+                .contains(base_type),
+            "adapter provenance should keep the selected alias visible"
+        );
+        assert!(
+            execution
+                .outcome
+                .execution_summary
+                .contains(expected_backend),
+            "execution summary should describe the canonical v1 implementation"
+        );
+        assert!(
+            !execution
+                .outcome
+                .execution_summary
+                .contains(config.objective.value.as_str()),
+            "execution summaries should not persist the raw objective"
+        );
+    }
+}
+
+#[test]
+fn bootstrap_assembly_surfaces_identity_base_type_mismatches_explicitly() {
+    let config = BootstrapConfig::resolve(BootstrapInputs {
+        prompt_root: Some(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("prompt_assets")),
+        objective: Some("exercise identity base type validation".to_string()),
+        identity: Some("simard-engineer".to_string()),
+        base_type: Some("meeting-bot".to_string()),
+        topology: Some("single-process".to_string()),
+        ..BootstrapInputs::default()
+    })
+    .expect("explicit bootstrap config should resolve");
+
+    let error = match assemble_local_runtime(&config) {
+        Ok(_) => panic!("identity/base type mismatches should fail runtime assembly"),
+        Err(error) => error,
+    };
+
+    assert_eq!(
+        error,
+        SimardError::UnsupportedBaseType {
+            identity: "simard-engineer".to_string(),
+            base_type: "meeting-bot".to_string(),
+        }
+    );
+}
+
+#[test]
+fn bootstrap_assembly_surfaces_unsupported_topologies_explicitly() {
+    let config = BootstrapConfig::resolve(BootstrapInputs {
+        prompt_root: Some(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("prompt_assets")),
+        objective: Some("exercise unsupported topology handling".to_string()),
+        identity: Some("simard-engineer".to_string()),
+        base_type: Some("local-harness".to_string()),
+        topology: Some("distributed".to_string()),
+        ..BootstrapInputs::default()
+    })
+    .expect("explicit bootstrap config should resolve");
+
+    let error = match assemble_local_runtime(&config) {
+        Ok(_) => panic!("unsupported topology should fail runtime assembly"),
+        Err(error) => error,
+    };
+
+    assert_eq!(
+        error,
+        SimardError::UnsupportedRuntimeTopology {
+            topology: RuntimeTopology::Distributed,
+            driver: "topology::in-process".to_string(),
+        }
     );
 }

--- a/tests/contracts.rs
+++ b/tests/contracts.rs
@@ -3,9 +3,9 @@ use std::sync::Arc;
 use simard::{
     BaseTypeCapability, BaseTypeId, BaseTypeRegistry, IdentityManifest, InMemoryEvidenceStore,
     InMemoryMemoryStore, InMemoryPromptAssetStore, LocalProcessHarnessAdapter, LocalRuntime,
-    ManifestContract, MemoryPolicy, OperatingMode, PromptAsset, PromptAssetRef, Provenance,
-    RuntimePorts, RuntimeRequest, RuntimeTopology, SessionId, SessionIdGenerator, SessionPhase,
-    SessionRecord, SimardError, UuidSessionIdGenerator, capability_set,
+    ManifestContract, MemoryPolicy, MemoryScope, OperatingMode, PromptAsset, PromptAssetRef,
+    Provenance, RuntimePorts, RuntimeRequest, RuntimeTopology, SessionId, SessionIdGenerator,
+    SessionPhase, SessionRecord, SimardError, UuidSessionIdGenerator, capability_set,
 };
 use uuid::Uuid;
 
@@ -18,6 +18,10 @@ fn prompt_store() -> Arc<InMemoryPromptAssetStore> {
 }
 
 fn manifest(base_type: &str) -> IdentityManifest {
+    manifest_with_policy(base_type, MemoryPolicy::default())
+}
+
+fn manifest_with_policy(base_type: &str, memory_policy: MemoryPolicy) -> IdentityManifest {
     IdentityManifest::new(
         "simard-engineer",
         "0.1.0",
@@ -37,7 +41,7 @@ fn manifest(base_type: &str) -> IdentityManifest {
             BaseTypeCapability::Reflection,
         ]),
         OperatingMode::Engineer,
-        MemoryPolicy::default(),
+        memory_policy,
         ManifestContract::new(
             simard::bootstrap_entrypoint(),
             "bootstrap-config -> identity-loader -> runtime-ports -> local-runtime",
@@ -58,6 +62,7 @@ fn compose_rejects_missing_capability() {
     let mut base_types = BaseTypeRegistry::default();
     base_types.register(
         LocalProcessHarnessAdapter::new(
+            "limited-harness",
             "limited-harness",
             [
                 BaseTypeCapability::PromptAssets,
@@ -133,6 +138,149 @@ fn start_rejects_missing_prompt_asset() {
         SimardError::PromptAssetMissing {
             asset_id: "engineer-system".to_string(),
             path: "simard/engineer_system.md".into(),
+        }
+    );
+}
+
+#[test]
+fn prompt_asset_error_display_redacts_absolute_paths() {
+    let missing = SimardError::PromptAssetMissing {
+        asset_id: "engineer-system".to_string(),
+        path: "/tmp/private/prompt.md".into(),
+    };
+    assert!(!missing.to_string().contains("/tmp/private/prompt.md"));
+
+    let invalid = SimardError::InvalidPromptAssetPath {
+        asset_id: "engineer-system".to_string(),
+        path: "/tmp/private/prompt.md".into(),
+        reason: "expected a relative path inside the configured prompt root".to_string(),
+    };
+    assert!(!invalid.to_string().contains("/tmp/private/prompt.md"));
+}
+
+#[test]
+fn compose_rejects_manifest_supported_base_types_without_registered_adapters() {
+    let prompts = prompt_store();
+    let memory = Arc::new(InMemoryMemoryStore::try_default().expect("store should initialize"));
+    let evidence = Arc::new(InMemoryEvidenceStore::try_default().expect("store should initialize"));
+    let mut base_types = BaseTypeRegistry::default();
+    base_types.register(
+        LocalProcessHarnessAdapter::single_process("local-harness")
+            .expect("adapter should initialize"),
+    );
+
+    let request = RuntimeRequest::new(
+        manifest("future-distributed-adapter"),
+        BaseTypeId::new("future-distributed-adapter"),
+        RuntimeTopology::SingleProcess,
+    );
+
+    let error = match LocalRuntime::compose(
+        RuntimePorts::new(
+            prompts,
+            memory,
+            evidence,
+            base_types,
+            Arc::new(UuidSessionIdGenerator),
+        ),
+        request,
+    ) {
+        Ok(_) => panic!("composition should have failed"),
+        Err(error) => error,
+    };
+
+    assert_eq!(
+        error,
+        SimardError::AdapterNotRegistered {
+            base_type: "future-distributed-adapter".to_string(),
+        }
+    );
+}
+
+#[test]
+fn manifest_rejects_project_write_policy_in_v1() {
+    let error = IdentityManifest::new(
+        "simard-engineer",
+        "0.1.0",
+        vec![PromptAssetRef::new(
+            "engineer-system",
+            "simard/engineer_system.md",
+        )],
+        vec![BaseTypeId::new("local-harness")],
+        capability_set([
+            BaseTypeCapability::PromptAssets,
+            BaseTypeCapability::SessionLifecycle,
+            BaseTypeCapability::Memory,
+            BaseTypeCapability::Evidence,
+            BaseTypeCapability::Reflection,
+        ]),
+        OperatingMode::Engineer,
+        MemoryPolicy {
+            allow_project_writes: true,
+            summary_scope: MemoryScope::SessionSummary,
+        },
+        ManifestContract::new(
+            simard::bootstrap_entrypoint(),
+            "bootstrap-config -> identity-loader -> runtime-ports -> local-runtime",
+            vec!["tests:contracts".to_string()],
+            Provenance::new("test", "contracts::project-writes"),
+            simard::Freshness::now().expect("freshness should be observable"),
+        )
+        .expect("contract should be valid"),
+    )
+    .expect_err("v1 should reject project-write policies");
+
+    assert_eq!(
+        error,
+        SimardError::UnsupportedMemoryPolicy {
+            field: "memory_policy.allow_project_writes".to_string(),
+            reason: "v1 only supports read-only project boundaries".to_string(),
+        }
+    );
+}
+
+#[test]
+fn runtime_compose_rejects_project_write_policy_even_if_manifest_is_mutated() {
+    let prompts = prompt_store();
+    let memory = Arc::new(InMemoryMemoryStore::try_default().expect("store should initialize"));
+    let evidence = Arc::new(InMemoryEvidenceStore::try_default().expect("store should initialize"));
+    let mut base_types = BaseTypeRegistry::default();
+    base_types.register(
+        LocalProcessHarnessAdapter::single_process("local-harness")
+            .expect("adapter should initialize"),
+    );
+
+    let mut mutated_manifest = manifest("local-harness");
+    mutated_manifest.memory_policy = MemoryPolicy {
+        allow_project_writes: true,
+        summary_scope: MemoryScope::SessionSummary,
+    };
+
+    let request = RuntimeRequest::new(
+        mutated_manifest,
+        BaseTypeId::new("local-harness"),
+        RuntimeTopology::SingleProcess,
+    );
+
+    let error = match LocalRuntime::compose(
+        RuntimePorts::new(
+            prompts,
+            memory,
+            evidence,
+            base_types,
+            Arc::new(UuidSessionIdGenerator),
+        ),
+        request,
+    ) {
+        Ok(_) => panic!("runtime composition should reject unsupported memory policies"),
+        Err(error) => error,
+    };
+
+    assert_eq!(
+        error,
+        SimardError::UnsupportedMemoryPolicy {
+            field: "memory_policy.allow_project_writes".to_string(),
+            reason: "v1 only supports read-only project boundaries".to_string(),
         }
     );
 }
@@ -229,6 +377,26 @@ fn reflection_snapshot_exposes_resolved_adapter_backend_descriptor() {
     assert!(
         reflection_rs.contains("pub adapter_backend: BackendDescriptor"),
         "reflection snapshots need an adapter_backend descriptor so backend identity comes from the runtime-selected adapter"
+    );
+}
+
+#[test]
+fn reflection_snapshot_exposes_agent_program_backend_descriptor() {
+    let reflection_rs = include_str!("../src/reflection.rs");
+
+    assert!(
+        reflection_rs.contains("pub agent_program_backend: BackendDescriptor"),
+        "reflection snapshots need an agent_program_backend descriptor so agent logic wiring stays inspectable"
+    );
+}
+
+#[test]
+fn reflection_snapshot_exposes_handoff_backend_descriptor() {
+    let reflection_rs = include_str!("../src/reflection.rs");
+
+    assert!(
+        reflection_rs.contains("pub handoff_backend: BackendDescriptor"),
+        "reflection snapshots need a handoff_backend descriptor so export/import wiring stays inspectable"
     );
 }
 

--- a/tests/gadugi/simard-cli-runtime.yaml
+++ b/tests/gadugi/simard-cli-runtime.yaml
@@ -1,0 +1,67 @@
+name: "Simard CLI Runtime Smoke"
+description: "Outside-in CLI coverage for the documented bootstrap modes and base-type selections."
+version: "1.0.0"
+
+config:
+  timeout: 300000
+  retries: 1
+  parallel: false
+
+environment:
+  requires: []
+
+agents:
+  - name: "cli-agent"
+    type: "cli"
+    config:
+      workingDirectory: "."
+      defaultTimeout: 300000
+      executionMode: "spawn"
+      captureOutput: true
+      ioConfig:
+        encoding: "utf8"
+        handleInteractivePrompts: false
+      logConfig:
+        logCommands: true
+        logOutput: true
+        logLevel: "info"
+
+steps:
+  - name: "Builtin-default bootstrap"
+    agent: "cli-agent"
+    action: "execute_command"
+    params:
+      command: "tests/gadugi/smoke-builtin-defaults.sh"
+    timeout: 300000
+
+  - name: "Explicit local-harness bootstrap"
+    agent: "cli-agent"
+    action: "execute_command"
+    params:
+      command: "tests/gadugi/smoke-explicit-local.sh"
+    timeout: 300000
+
+  - name: "Explicit rusty-clawd bootstrap"
+    agent: "cli-agent"
+    action: "execute_command"
+    params:
+      command: "tests/gadugi/smoke-explicit-rusty-clawd.sh"
+    timeout: 300000
+
+assertions: []
+
+cleanup:
+  - name: "CLI agent cleanup"
+    agent: "cli-agent"
+    action: "cleanup"
+
+metadata:
+  tags:
+    - "cli"
+    - "behavior"
+    - "simard"
+    - "bootstrap"
+    - "runtime"
+  priority: "high"
+  author: "copilot"
+  test_type: "outside-in"

--- a/tests/gadugi/smoke-builtin-defaults.sh
+++ b/tests/gadugi/smoke-builtin-defaults.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+unset SIMARD_PROMPT_ROOT SIMARD_OBJECTIVE SIMARD_IDENTITY SIMARD_BASE_TYPE SIMARD_RUNTIME_TOPOLOGY
+export SIMARD_BOOTSTRAP_MODE=builtin-defaults
+
+OUTPUT="$(cargo run --quiet)"
+
+printf '%s\n' "$OUTPUT"
+
+printf '%s\n' "$OUTPUT" | grep -F "Simard local runtime executed successfully." >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "Bootstrap mode: builtin-defaults" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "Config sources: prompt_root=opt-in:SIMARD_BOOTSTRAP_MODE, objective=opt-in:SIMARD_BOOTSTRAP_MODE, base_type=opt-in:SIMARD_BOOTSTRAP_MODE, topology=opt-in:SIMARD_BOOTSTRAP_MODE" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "Bootstrap selection: identity=simard-engineer, base_type=local-harness, topology=single-process" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "Snapshot: state=ready, topology=single-process, base_type=local-harness" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "Adapter implementation: local-harness" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "Shutdown: stopped" >/dev/null

--- a/tests/gadugi/smoke-explicit-local.sh
+++ b/tests/gadugi/smoke-explicit-local.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+export SIMARD_PROMPT_ROOT="$ROOT/prompt_assets"
+export SIMARD_OBJECTIVE="verify explicit local runtime path"
+export SIMARD_IDENTITY="simard-engineer"
+export SIMARD_BASE_TYPE="local-harness"
+export SIMARD_RUNTIME_TOPOLOGY="single-process"
+unset SIMARD_BOOTSTRAP_MODE
+
+OUTPUT="$(cargo run --quiet)"
+
+printf '%s\n' "$OUTPUT"
+
+printf '%s\n' "$OUTPUT" | grep -F "Simard local runtime executed successfully." >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "Bootstrap mode: explicit-config" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "Config sources: prompt_root=env:SIMARD_PROMPT_ROOT, objective=env:SIMARD_OBJECTIVE, base_type=env:SIMARD_BASE_TYPE, topology=env:SIMARD_RUNTIME_TOPOLOGY" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "Bootstrap selection: identity=simard-engineer, base_type=local-harness, topology=single-process" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "Snapshot: state=ready, topology=single-process, base_type=local-harness" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "Adapter implementation: local-harness" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "Shutdown: stopped" >/dev/null

--- a/tests/gadugi/smoke-explicit-rusty-clawd.sh
+++ b/tests/gadugi/smoke-explicit-rusty-clawd.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+export SIMARD_PROMPT_ROOT="$ROOT/prompt_assets"
+export SIMARD_OBJECTIVE="verify explicit rusty-clawd runtime path"
+export SIMARD_IDENTITY="simard-engineer"
+export SIMARD_BASE_TYPE="rusty-clawd"
+export SIMARD_RUNTIME_TOPOLOGY="single-process"
+unset SIMARD_BOOTSTRAP_MODE
+
+OUTPUT="$(cargo run --quiet)"
+
+printf '%s\n' "$OUTPUT"
+
+printf '%s\n' "$OUTPUT" | grep -F "Simard local runtime executed successfully." >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "Bootstrap mode: explicit-config" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "Config sources: prompt_root=env:SIMARD_PROMPT_ROOT, objective=env:SIMARD_OBJECTIVE, base_type=env:SIMARD_BASE_TYPE, topology=env:SIMARD_RUNTIME_TOPOLOGY" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "Bootstrap selection: identity=simard-engineer, base_type=rusty-clawd, topology=single-process" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "Snapshot: state=ready, topology=single-process, base_type=rusty-clawd" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "Adapter implementation: rusty-clawd::session-backend" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "Shutdown: stopped" >/dev/null

--- a/tests/lifecycle.rs
+++ b/tests/lifecycle.rs
@@ -1,12 +1,15 @@
 use std::sync::Arc;
 
 use simard::{
-    BackendDescriptor, BaseTypeAdapter, BaseTypeCapability, BaseTypeDescriptor, BaseTypeId,
-    BaseTypeOutcome, BaseTypeRegistry, BaseTypeRequest, EvidenceStore, Freshness, FreshnessState,
-    IdentityManifest, InMemoryEvidenceStore, InMemoryMemoryStore, InMemoryPromptAssetStore,
-    LocalProcessHarnessAdapter, LocalRuntime, ManifestContract, MemoryPolicy, MemoryScope,
-    MemoryStore, OperatingMode, PromptAsset, PromptAssetRef, Provenance, ReflectiveRuntime,
-    RuntimePorts, RuntimeRequest, RuntimeState, RuntimeTopology, SessionPhase, SimardError,
+    AgentProgram, AgentProgramContext, BackendDescriptor, BaseTypeCapability, BaseTypeDescriptor,
+    BaseTypeFactory, BaseTypeId, BaseTypeOutcome, BaseTypeRegistry, BaseTypeSession,
+    BaseTypeSessionRequest, BaseTypeTurnInput, EvidenceStore, Freshness, FreshnessState,
+    IdentityManifest, InMemoryEvidenceStore, InMemoryHandoffStore, InMemoryMailboxTransport,
+    InMemoryMemoryStore, InMemoryPromptAssetStore, InProcessSupervisor, InProcessTopologyDriver,
+    LocalProcessHarnessAdapter, LocalRuntime, LoopbackMailboxTransport, LoopbackMeshTopologyDriver,
+    ManifestContract, MemoryPolicy, MemoryScope, MemoryStore, OperatingMode, PromptAsset,
+    PromptAssetRef, Provenance, ReflectiveRuntime, RuntimeHandoffStore, RuntimePorts,
+    RuntimeRequest, RuntimeState, RuntimeTopology, RustyClawdAdapter, SessionPhase, SimardError,
     SimardResult, UuidSessionIdGenerator, capability_set,
 };
 
@@ -71,16 +74,107 @@ impl FailingHarnessAdapter {
     }
 }
 
-impl BaseTypeAdapter for FailingHarnessAdapter {
+impl BaseTypeFactory for FailingHarnessAdapter {
     fn descriptor(&self) -> &BaseTypeDescriptor {
         &self.descriptor
     }
 
-    fn invoke(&self, _request: BaseTypeRequest) -> SimardResult<BaseTypeOutcome> {
+    fn open_session(
+        &self,
+        _request: BaseTypeSessionRequest,
+    ) -> SimardResult<Box<dyn BaseTypeSession>> {
+        Ok(Box::new(FailingHarnessSession {
+            descriptor: self.descriptor.clone(),
+            is_open: false,
+        }))
+    }
+}
+
+#[derive(Debug)]
+struct FailingHarnessSession {
+    descriptor: BaseTypeDescriptor,
+    is_open: bool,
+}
+
+impl BaseTypeSession for FailingHarnessSession {
+    fn descriptor(&self) -> &BaseTypeDescriptor {
+        &self.descriptor
+    }
+
+    fn open(&mut self) -> SimardResult<()> {
+        self.is_open = true;
+        Ok(())
+    }
+
+    fn run_turn(&mut self, _input: BaseTypeTurnInput) -> SimardResult<BaseTypeOutcome> {
+        if !self.is_open {
+            return Err(SimardError::InvalidBaseTypeSessionState {
+                base_type: self.descriptor.id.to_string(),
+                action: "run_turn".to_string(),
+                reason: "session must be opened before turns can run".to_string(),
+            });
+        }
+
         Err(SimardError::AdapterInvocationFailed {
             base_type: self.descriptor.id.to_string(),
             reason: "simulated adapter failure".to_string(),
         })
+    }
+
+    fn close(&mut self) -> SimardResult<()> {
+        self.is_open = false;
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct TaggingAgentProgram {
+    descriptor: BackendDescriptor,
+}
+
+impl TaggingAgentProgram {
+    fn new(identity: &str) -> Self {
+        Self {
+            descriptor: BackendDescriptor::new(
+                identity,
+                Provenance::injected("test:agent-program"),
+                Freshness::now().expect("freshness should be observable"),
+            ),
+        }
+    }
+}
+
+impl AgentProgram for TaggingAgentProgram {
+    fn descriptor(&self) -> BackendDescriptor {
+        self.descriptor.clone()
+    }
+
+    fn plan_turn(&self, context: &AgentProgramContext) -> SimardResult<BaseTypeTurnInput> {
+        Ok(BaseTypeTurnInput {
+            objective: format!("agent-program-turn::{}", context.objective),
+        })
+    }
+
+    fn reflection_summary(
+        &self,
+        context: &AgentProgramContext,
+        _outcome: &BaseTypeOutcome,
+    ) -> SimardResult<String> {
+        Ok(format!(
+            "reflection-by={}::{}",
+            self.descriptor.identity, context.selected_base_type
+        ))
+    }
+
+    fn persistence_summary(
+        &self,
+        context: &AgentProgramContext,
+        _outcome: &BaseTypeOutcome,
+    ) -> SimardResult<String> {
+        Ok(format!(
+            "persistence-by={}::{}",
+            self.descriptor.identity, context.topology
+        ))
     }
 }
 
@@ -148,12 +242,12 @@ fn local_runtime_runs_session_and_persists_boundaries() {
     let evidence_records = evidence
         .list_for_session(&outcome.session.id)
         .expect("evidence should be queryable");
-    assert_eq!(evidence_records.len(), 2);
+    assert_eq!(evidence_records.len(), 4);
     assert_eq!(
         evidence
             .count_for_session(&outcome.session.id)
             .expect("evidence counts should be queryable"),
-        2
+        4
     );
     assert!(
         evidence_records
@@ -172,6 +266,24 @@ fn local_runtime_runs_session_and_persists_boundaries() {
         .expect("summary memory should be queryable");
     assert_eq!(summary_records.len(), 1);
     assert_eq!(summary_records[0].recorded_in, SessionPhase::Persistence);
+    assert!(scratch_records[0].value.contains("objective-metadata("));
+    assert!(
+        !scratch_records[0]
+            .value
+            .contains("exercise the local runtime")
+    );
+    assert!(
+        !summary_records[0]
+            .value
+            .contains("exercise the local runtime")
+    );
+    assert!(
+        !outcome
+            .reflection
+            .summary
+            .contains("exercise the local runtime")
+    );
+    assert!(outcome.reflection.summary.contains("objective-metadata("));
     assert_eq!(
         memory
             .count_for_session(&outcome.session.id)
@@ -182,8 +294,13 @@ fn local_runtime_runs_session_and_persists_boundaries() {
     let snapshot = runtime.snapshot().expect("snapshot should succeed");
     assert_eq!(snapshot.runtime_state, RuntimeState::Ready);
     assert_eq!(snapshot.session_phase, Some(SessionPhase::Complete));
-    assert_eq!(snapshot.evidence_records, 2);
+    assert_eq!(snapshot.evidence_records, 4);
     assert_eq!(snapshot.memory_records, 2);
+    assert_eq!(
+        snapshot.agent_program_backend.identity,
+        "agent-program::objective-relay"
+    );
+    assert_eq!(snapshot.handoff_backend.identity, "handoff::in-memory");
     assert_eq!(snapshot.adapter_backend.identity, "local-harness");
     assert!(
         snapshot
@@ -401,6 +518,14 @@ fn failed_runs_preserve_failed_session_metadata_until_shutdown() {
     assert_eq!(failed_snapshot.memory_records, 1);
     assert_eq!(failed_snapshot.evidence_records, 0);
     assert_eq!(
+        failed_snapshot.agent_program_backend.identity,
+        "agent-program::objective-relay"
+    );
+    assert_eq!(
+        failed_snapshot.handoff_backend.identity,
+        "handoff::in-memory"
+    );
+    assert_eq!(
         failed_snapshot.adapter_backend.provenance,
         Provenance::injected("test:failing-adapter")
     );
@@ -428,11 +553,308 @@ fn failed_runs_preserve_failed_session_metadata_until_shutdown() {
     runtime
         .stop()
         .expect("failed runtimes should still allow an explicit stop boundary");
-    let stopped_snapshot = runtime.snapshot().expect("stopped snapshot should remain visible");
+    let stopped_snapshot = runtime
+        .snapshot()
+        .expect("stopped snapshot should remain visible");
     assert_eq!(stopped_snapshot.runtime_state, RuntimeState::Stopped);
     assert_eq!(stopped_snapshot.session_phase, Some(SessionPhase::Failed));
     assert_eq!(
         stopped_snapshot.manifest_contract.freshness.state,
         FreshnessState::Stale
+    );
+}
+
+#[test]
+fn runtime_uses_injected_agent_program_for_reflection_and_persistence() {
+    let prompts = Arc::new(InMemoryPromptAssetStore::new([PromptAsset::new(
+        "engineer-system",
+        "simard/engineer_system.md",
+        "You are Simard.",
+    )]));
+    let memory = Arc::new(InMemoryMemoryStore::try_default().expect("store should initialize"));
+    let evidence = Arc::new(InMemoryEvidenceStore::try_default().expect("store should initialize"));
+    let mut base_types = BaseTypeRegistry::default();
+    base_types.register(
+        LocalProcessHarnessAdapter::single_process("local-harness")
+            .expect("adapter should initialize"),
+    );
+
+    let request = RuntimeRequest::new(
+        manifest(),
+        BaseTypeId::new("local-harness"),
+        RuntimeTopology::SingleProcess,
+    );
+
+    let mut runtime = LocalRuntime::compose(
+        RuntimePorts::with_runtime_services_and_program(
+            prompts,
+            memory.clone(),
+            evidence,
+            base_types,
+            Arc::new(InProcessTopologyDriver::try_default().expect("driver should initialize")),
+            Arc::new(InMemoryMailboxTransport::try_default().expect("transport should initialize")),
+            Arc::new(InProcessSupervisor::try_default().expect("supervisor should initialize")),
+            Arc::new(TaggingAgentProgram::new("agent-program::tagging")),
+            Arc::new(InMemoryHandoffStore::try_default().expect("handoff should initialize")),
+            Arc::new(UuidSessionIdGenerator),
+        ),
+        request,
+    )
+    .expect("composition should succeed");
+
+    runtime.start().expect("startup should succeed");
+    let outcome = runtime
+        .run("exercise custom agent program")
+        .expect("run should succeed");
+
+    assert_eq!(
+        outcome.reflection.summary,
+        "reflection-by=agent-program::tagging::local-harness"
+    );
+
+    let summary_records = memory
+        .list(MemoryScope::SessionSummary)
+        .expect("summary memory should be queryable");
+    assert_eq!(summary_records.len(), 1);
+    assert_eq!(
+        summary_records[0].value,
+        "persistence-by=agent-program::tagging::single-process"
+    );
+
+    let snapshot = runtime.snapshot().expect("snapshot should succeed");
+    assert_eq!(
+        snapshot.agent_program_backend.identity,
+        "agent-program::tagging"
+    );
+    assert_eq!(
+        snapshot.agent_program_backend.provenance,
+        Provenance::injected("test:agent-program")
+    );
+    assert_eq!(snapshot.handoff_backend.identity, "handoff::in-memory");
+}
+
+#[test]
+fn runtime_runs_same_agent_program_on_multi_process_mesh_driver() {
+    let prompts = Arc::new(InMemoryPromptAssetStore::new([PromptAsset::new(
+        "engineer-system",
+        "simard/engineer_system.md",
+        "You are Simard.",
+    )]));
+    let memory = Arc::new(InMemoryMemoryStore::try_default().expect("store should initialize"));
+    let evidence = Arc::new(InMemoryEvidenceStore::try_default().expect("store should initialize"));
+    let mut base_types = BaseTypeRegistry::default();
+    base_types.register(
+        RustyClawdAdapter::registered("rusty-clawd").expect("rusty-clawd should initialize"),
+    );
+
+    let request = RuntimeRequest::new(
+        IdentityManifest::new(
+            "simard-engineer",
+            "0.1.0",
+            vec![PromptAssetRef::new(
+                "engineer-system",
+                "simard/engineer_system.md",
+            )],
+            vec![BaseTypeId::new("rusty-clawd")],
+            capability_set([
+                BaseTypeCapability::PromptAssets,
+                BaseTypeCapability::SessionLifecycle,
+                BaseTypeCapability::Memory,
+                BaseTypeCapability::Evidence,
+                BaseTypeCapability::Reflection,
+            ]),
+            OperatingMode::Engineer,
+            MemoryPolicy::default(),
+            ManifestContract::new(
+                simard::bootstrap_entrypoint(),
+                "bootstrap-config -> identity-loader -> runtime-ports -> local-runtime",
+                vec!["tests:lifecycle-multiprocess".to_string()],
+                Provenance::new("test", "lifecycle::multiprocess"),
+                Freshness::now().expect("freshness should be observable"),
+            )
+            .expect("contract should be valid"),
+        )
+        .expect("manifest should be valid"),
+        BaseTypeId::new("rusty-clawd"),
+        RuntimeTopology::MultiProcess,
+    );
+
+    let mut runtime = LocalRuntime::compose(
+        RuntimePorts::with_runtime_services_and_program(
+            prompts,
+            memory,
+            evidence,
+            base_types,
+            Arc::new(LoopbackMeshTopologyDriver::try_default().expect("driver should initialize")),
+            Arc::new(LoopbackMailboxTransport::try_default().expect("transport should initialize")),
+            Arc::new(InProcessSupervisor::try_default().expect("supervisor should initialize")),
+            Arc::new(TaggingAgentProgram::new("agent-program::tagging")),
+            Arc::new(InMemoryHandoffStore::try_default().expect("handoff should initialize")),
+            Arc::new(UuidSessionIdGenerator),
+        ),
+        request,
+    )
+    .expect("composition should succeed");
+
+    runtime.start().expect("startup should succeed");
+    let outcome = runtime
+        .run("exercise mesh runtime")
+        .expect("run should succeed");
+
+    assert_eq!(
+        outcome.reflection.summary,
+        "reflection-by=agent-program::tagging::rusty-clawd"
+    );
+    let snapshot = runtime.snapshot().expect("snapshot should succeed");
+    assert_eq!(snapshot.topology, RuntimeTopology::MultiProcess);
+    assert_eq!(snapshot.runtime_node.to_string(), "node-loopback-mesh");
+    assert_eq!(
+        snapshot.mailbox_address.to_string(),
+        "loopback://node-loopback-mesh"
+    );
+    assert_eq!(
+        snapshot.adapter_backend.identity,
+        "rusty-clawd::session-backend"
+    );
+    assert_eq!(
+        snapshot.topology_backend.identity,
+        "topology::loopback-mesh"
+    );
+    assert_eq!(
+        snapshot.transport_backend.identity,
+        "transport::loopback-mailbox"
+    );
+}
+
+#[test]
+fn runtime_can_export_and_restore_handoff_snapshot() {
+    let prompts = Arc::new(InMemoryPromptAssetStore::new([PromptAsset::new(
+        "engineer-system",
+        "simard/engineer_system.md",
+        "You are Simard.",
+    )]));
+    let memory = Arc::new(InMemoryMemoryStore::try_default().expect("store should initialize"));
+    let evidence = Arc::new(InMemoryEvidenceStore::try_default().expect("store should initialize"));
+    let handoff = Arc::new(InMemoryHandoffStore::try_default().expect("handoff should initialize"));
+    let mut base_types = BaseTypeRegistry::default();
+    base_types.register(
+        RustyClawdAdapter::registered("rusty-clawd").expect("rusty-clawd should initialize"),
+    );
+
+    let request = RuntimeRequest::new(
+        IdentityManifest::new(
+            "simard-engineer",
+            "0.1.0",
+            vec![PromptAssetRef::new(
+                "engineer-system",
+                "simard/engineer_system.md",
+            )],
+            vec![BaseTypeId::new("rusty-clawd")],
+            capability_set([
+                BaseTypeCapability::PromptAssets,
+                BaseTypeCapability::SessionLifecycle,
+                BaseTypeCapability::Memory,
+                BaseTypeCapability::Evidence,
+                BaseTypeCapability::Reflection,
+            ]),
+            OperatingMode::Engineer,
+            MemoryPolicy::default(),
+            ManifestContract::new(
+                simard::bootstrap_entrypoint(),
+                "bootstrap-config -> identity-loader -> runtime-ports -> local-runtime",
+                vec!["tests:lifecycle-handoff".to_string()],
+                Provenance::new("test", "lifecycle::handoff"),
+                Freshness::now().expect("freshness should be observable"),
+            )
+            .expect("contract should be valid"),
+        )
+        .expect("manifest should be valid"),
+        BaseTypeId::new("rusty-clawd"),
+        RuntimeTopology::MultiProcess,
+    );
+
+    let mut runtime = LocalRuntime::compose(
+        RuntimePorts::with_runtime_services_and_program(
+            prompts.clone(),
+            memory,
+            evidence,
+            base_types,
+            Arc::new(LoopbackMeshTopologyDriver::try_default().expect("driver should initialize")),
+            Arc::new(LoopbackMailboxTransport::try_default().expect("transport should initialize")),
+            Arc::new(InProcessSupervisor::try_default().expect("supervisor should initialize")),
+            Arc::new(TaggingAgentProgram::new("agent-program::tagging")),
+            handoff.clone(),
+            Arc::new(UuidSessionIdGenerator),
+        ),
+        request.clone(),
+    )
+    .expect("composition should succeed");
+
+    runtime.start().expect("startup should succeed");
+    let outcome = runtime.run("export handoff").expect("run should succeed");
+    let snapshot = runtime.export_handoff().expect("handoff should export");
+
+    assert_eq!(snapshot.selected_base_type, BaseTypeId::new("rusty-clawd"));
+    assert_eq!(snapshot.topology, RuntimeTopology::MultiProcess);
+    assert_eq!(snapshot.memory_records.len(), 2);
+    assert_eq!(snapshot.evidence_records.len(), 5);
+    assert_eq!(
+        handoff.latest().expect("handoff latest should work"),
+        Some(snapshot.clone())
+    );
+
+    let restored_memory =
+        Arc::new(InMemoryMemoryStore::try_default().expect("store should initialize"));
+    let restored_evidence =
+        Arc::new(InMemoryEvidenceStore::try_default().expect("store should initialize"));
+    let restored_handoff =
+        Arc::new(InMemoryHandoffStore::try_default().expect("handoff should initialize"));
+    let mut restored_base_types = BaseTypeRegistry::default();
+    restored_base_types.register(
+        RustyClawdAdapter::registered("rusty-clawd").expect("rusty-clawd should initialize"),
+    );
+
+    let restored = LocalRuntime::compose_from_handoff(
+        RuntimePorts::with_runtime_services_and_program(
+            prompts,
+            restored_memory.clone(),
+            restored_evidence.clone(),
+            restored_base_types,
+            Arc::new(LoopbackMeshTopologyDriver::try_default().expect("driver should initialize")),
+            Arc::new(LoopbackMailboxTransport::try_default().expect("transport should initialize")),
+            Arc::new(InProcessSupervisor::try_default().expect("supervisor should initialize")),
+            Arc::new(TaggingAgentProgram::new("agent-program::tagging")),
+            restored_handoff.clone(),
+            Arc::new(UuidSessionIdGenerator),
+        ),
+        request,
+        snapshot,
+    )
+    .expect("restored runtime should compose");
+
+    let restored_snapshot = restored.snapshot().expect("snapshot should succeed");
+    assert_eq!(restored_snapshot.runtime_state, RuntimeState::Initializing);
+    assert_eq!(
+        restored_snapshot.session_phase,
+        Some(SessionPhase::Complete)
+    );
+    assert_eq!(restored_snapshot.memory_records, 2);
+    assert_eq!(restored_snapshot.evidence_records, 5);
+    assert_eq!(
+        restored_snapshot.handoff_backend.identity,
+        "handoff::in-memory"
+    );
+
+    assert_eq!(
+        restored_memory
+            .count_for_session(&outcome.session.id)
+            .expect("restored memory should be hydrated"),
+        2
+    );
+    assert_eq!(
+        restored_evidence
+            .count_for_session(&outcome.session.id)
+            .expect("restored evidence should be hydrated"),
+        5
     );
 }


### PR DESCRIPTION
## Summary
- recover the runtime/base-type work onto a clean `feat/issue-13-implement-the-simard-runtime-kernel-and-base-type` branch instead of polluted `main`
- make the runtime kernel topology-neutral with factory/session semantics, truthful reflection, explicit backend/topology descriptors, and handoff support
- update docs and tests for the local CLI path, the real `rusty-clawd` backend, and the loopback-mesh runtime path

## Issue linkage
Refs #12.
Closes #13.

## Validation
- `cargo fmt --all --check`
- `cargo test --all-features --locked`
- explicit CLI run with `local-harness`
- explicit CLI run with `rusty-clawd`
- builtin-defaults CLI run
- gadugi outside-in scenarios against a fresh clone of the pushed branch

## Step 13: Local Testing Results

### Scenario 1 — builtin-defaults CLI smoke path
Command: `cd /tmp/gadugi-agentic-test-2992585 && node dist/cli.js run -d /home/azureuser/.copilot/session-state/916bf841-fd95-4689-9e8d-d3130f19ba7f/files/gadugi-scenarios -s "Simard CLI builtin-defaults smoke" --verbose`
Result: PASS
Output: `Simard local runtime executed successfully.`; `Bootstrap mode: builtin-defaults`; `Bootstrap selection: identity=simard-engineer, base_type=local-harness, topology=single-process`; `Adapter implementation: local-harness`

### Scenario 2 — explicit rusty-clawd backend path
Command: `cd /tmp/gadugi-agentic-test-2992585 && node dist/cli.js run -d /home/azureuser/.copilot/session-state/916bf841-fd95-4689-9e8d-d3130f19ba7f/files/gadugi-scenarios -s "Simard CLI explicit rusty-clawd backend" --verbose`
Result: PASS
Output: `Simard local runtime executed successfully.`; `Bootstrap mode: explicit-config`; `Bootstrap selection: identity=simard-engineer, base_type=rusty-clawd, topology=single-process`; `Adapter implementation: rusty-clawd::session-backend`

## Workflow / tooling notes
- `smart-orchestrator` and direct `default-workflow` both failed at `step-02b-analyze-codebase` by recursing back into orchestrator logic instead of analyzing the repository.
- The requested generic `uvx --from git+<repo>@<branch> amplihack ...` pattern is not applicable to this Rust repository, so outside-in testing was executed from a fresh clone of the pushed PR branch via gadugi's CLI runner instead.
- An always-installed pre-commit/pre-push hook expected `.pre-commit-config.yaml` even on the clean branch. Push/commit succeeded with the hook's documented `PRE_COMMIT_ALLOW_NO_CONFIG=1` allowance after explicit cargo validation had already passed.

## Step 16b: Outside-In Testing Results

### Scenario 1 — builtin-defaults CLI smoke path
Command: `cd /tmp/simard-pr19-outsidein && node /tmp/gadugi-agentic-test/dist/cli.js run -d .qa-step16b/simple --verbose`
Result: PASS
Output: `Simard local runtime executed successfully.`; `Bootstrap mode: builtin-defaults`; `Bootstrap selection: identity=simard-engineer, base_type=local-harness, topology=single-process`; `Adapter implementation: local-harness`

### Scenario 2 — runtime matrix including rusty-clawd integration
Command: `cd /tmp/simard-pr19-outsidein && node /tmp/gadugi-agentic-test/dist/cli.js run -d .qa-step16b/complex --verbose`
Result: PASS
Output: `Simard local runtime executed successfully.`; `Bootstrap selection: identity=simard-engineer, base_type=local-harness, topology=single-process`; `Bootstrap selection: identity=simard-engineer, base_type=rusty-clawd, topology=single-process`; `Adapter implementation: rusty-clawd::session-backend`

Fix iterations: 0
