### PR TITLE
Add starter benchmark gym foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -228,6 +229,8 @@ dependencies = [
 name = "simard"
 version = "0.1.1"
 dependencies = [
+ "serde",
+ "serde_json",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,11 @@ version = "0.1.1"
 edition = "2024"
 default-run = "simard"
 
+[[bin]]
+name = "simard-gym"
+path = "src/bin/simard_gym.rs"
+
 [dependencies]
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.145"
 uuid = { version = "1.18.1", features = ["v7"] }

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 title: Simard documentation
-description: Start here for the current Simard runtime contracts, bootstrap flow, and reflection metadata.
+description: Start here for the current Simard runtime contracts, benchmark gym flow, bootstrap behavior, and reflection metadata.
 last_updated: 2026-03-28
 review_schedule: as-needed
 owner: simard
@@ -8,13 +8,14 @@ owner: simard
 
 # Simard documentation
 
-Simard is a DI-first runtime shell for agent execution, reflection, memory, and evidence capture.
+Simard is a DI-first runtime shell for agent execution, reflection, memory, evidence capture, and benchmark-gym validation.
 
 This docs set describes the runtime behavior that exists in this repository today.
 
 ## Start here
 
 - [Tutorial: Run your first local session](./tutorials/run-your-first-local-session.md) - Walk the local runtime flow end to end.
+- [Tutorial: Run your first benchmark gym suite](./tutorials/run-your-first-benchmark-gym.md) - Run the shipped starter benchmark suite and inspect the emitted artifacts.
 - [How to configure bootstrap and inspect reflection](./howto/configure-bootstrap-and-inspect-reflection.md) - Verify bootstrap inputs and inspect the truthful reflection surface.
 - [Runtime contracts reference](./reference/runtime-contracts.md) - Look up the current public API and error contracts.
 - [Concept: truthful runtime metadata](./concepts/truthful-runtime-metadata.md) - Read the design rationale behind the stricter contract.
@@ -28,6 +29,8 @@ Today Simard provides:
 - builtin manifest-advertised base types selectable at startup today: `local-harness`, `rusty-clawd`, and `copilot-sdk`, with `rusty-clawd` wired as a distinct session backend and `copilot-sdk` still aliased to the local harness implementation
 - builtin identities selectable at startup today: `simard-engineer`, `simard-meeting`, `simard-gym`, and the composite `simard-composite-engineer`
 - `single-process` for all builtin base types plus loopback `multi-process` execution for `rusty-clawd`, with unsupported pairs failing explicitly
+- a starter benchmark gym suite that exercises all current builtin base-type selections plus a composite identity session through `cargo run --quiet --bin simard-gym -- run-suite starter`
+- benchmark artifacts written under `target/simard-gym/`, including per-scenario JSON and text summaries plus a suite summary
 - `ManifestContract { entrypoint, composition, precedence, provenance, freshness }`
 - `ReflectionSnapshot { manifest_contract, runtime_node, mailbox_address, agent_program_backend, adapter_backend, topology_backend, transport_backend, supervisor_backend, memory_backend, evidence_backend }`
 - truthful memory and evidence backend descriptors
@@ -53,6 +56,7 @@ Those hooks enforce `cargo fmt --all -- --check`, `cargo clippy --all-targets --
 ## Key runtime facts
 
 - `src/main.rs` is the thin CLI wrapper; `bootstrap::run_local_session` owns the run loop and `simard::bootstrap::assemble_local_runtime` remains the reflected assembly boundary
+- `src/bin/simard_gym.rs` is the operator-facing benchmark CLI for the starter gym suite
 - defaults are startup choices, never silent runtime recovery
 - reflection metadata is derived from the active runtime wiring, not placeholder labels
 - post-stop `start()`, `run()`, and repeated `stop()` surface `SimardError::RuntimeStopped`

--- a/docs/reference/runtime-contracts.md
+++ b/docs/reference/runtime-contracts.md
@@ -19,9 +19,10 @@ This file describes the API shape that exists in the repository today.
 
 ## Public surfaces
 
-Simard v1 currently exposes three surfaces:
+Simard v1 currently exposes four surfaces:
 
 - the local CLI bootstrap path through `cargo run --quiet`
+- the benchmark gym CLI through `cargo run --quiet --bin simard-gym -- ...`
 - the operator/runtime probe through `cargo run --quiet --bin simard_operator_probe -- ...`
 - the in-process Rust runtime/bootstrap types in `src/bootstrap.rs`, `src/runtime.rs`, and related modules
 
@@ -31,7 +32,25 @@ Simard v1 does **not** currently expose:
 - a network service contract
 - a database schema contract
 
-The stable contract in this repository is the bootstrap/runtime behavior described below.
+The stable contract in this repository is the bootstrap/runtime and benchmark-gym behavior described below.
+
+## Benchmark gym CLI
+
+The shipped benchmark CLI currently supports:
+
+- `cargo run --quiet --bin simard-gym -- list`
+- `cargo run --quiet --bin simard-gym -- run <scenario-id>`
+- `cargo run --quiet --bin simard-gym -- run-suite starter`
+
+The starter suite is intentionally small and exercises:
+
+- `local-harness`
+- `copilot-sdk`
+- `rusty-clawd`
+- the dedicated `simard-gym` identity
+- the composite `simard-composite-engineer` identity
+
+Artifacts are written under `target/simard-gym/` as JSON and text reports.
 
 ## Configuration
 

--- a/docs/tutorials/run-your-first-benchmark-gym.md
+++ b/docs/tutorials/run-your-first-benchmark-gym.md
@@ -1,0 +1,145 @@
+---
+title: "Tutorial: Run your first benchmark gym suite"
+description: Exercise the shipped Simard gym scenarios, inspect the generated artifacts, and verify the current benchmark foundation behaves honestly.
+last_updated: 2026-03-29
+review_schedule: as-needed
+owner: simard
+doc_type: tutorial
+related:
+  - ../index.md
+  - ../reference/runtime-contracts.md
+  - ./run-your-first-local-session.md
+---
+
+# Tutorial: Run your first benchmark gym suite
+
+This tutorial exercises the first real Simard gym slice that ships in this repository today.
+
+## What you'll learn
+
+- how to list the shipped benchmark scenarios
+- how to run the starter suite across all current builtin base-type selections
+- where Simard writes benchmark artifacts
+- what the current gym foundation measures and what it still leaves unmeasured
+
+## Prerequisites
+
+- Rust and Cargo installed
+- a shell in the repository root
+
+## Step 1: List the shipped benchmark scenarios
+
+The starter suite is intentionally small and curated.
+
+```bash
+cargo run --quiet --bin simard-gym -- list
+```
+
+You should see four scenarios:
+
+- `repo-exploration-local`
+- `docs-refresh-copilot`
+- `safe-code-change-rusty-clawd`
+- `composite-session-review`
+
+Together they cover:
+
+- the dedicated `simard-gym` identity
+- the composite `simard-composite-engineer` identity
+- `local-harness`
+- `copilot-sdk`
+- `rusty-clawd`
+- both `single-process` and loopback `multi-process`
+
+## Step 2: Run the starter benchmark suite
+
+Run the full shipped suite like an operator would:
+
+```bash
+cargo run --quiet --bin simard-gym -- run-suite starter
+```
+
+You should see output shaped like:
+
+```text
+Suite: starter
+Suite passed: true
+- repo-exploration-local: passed (target/simard-gym/...)
+- docs-refresh-copilot: passed (target/simard-gym/...)
+- safe-code-change-rusty-clawd: passed (target/simard-gym/...)
+- composite-session-review: passed (target/simard-gym/...)
+Suite artifact report: target/simard-gym/suites/starter.json
+```
+
+## Step 3: Inspect the generated artifacts
+
+The gym writes artifacts under `target/simard-gym/`.
+
+Per scenario, Simard currently emits:
+
+- `report.json`
+- `report.txt`
+
+The suite run also writes:
+
+- `target/simard-gym/suites/starter.json`
+
+Those artifacts record:
+
+- scenario metadata
+- the selected identity, base type, and topology
+- runtime and handoff summaries
+- correctness checks and whether they passed
+- measurement notes that explain what the current v1 gym does not yet infer automatically
+
+## Step 4: Inspect one scenario report directly
+
+You can also run a single scenario:
+
+```bash
+cargo run --quiet --bin simard-gym -- run safe-code-change-rusty-clawd
+```
+
+That command prints the scenario result plus the exact artifact paths for the scenario run.
+
+Open the JSON artifact and look for:
+
+- `passed`
+- `checks`
+- `runtime`
+- `handoff`
+- `scorecard.measurement_notes`
+
+## Step 5: Understand the current measurement boundary
+
+The current benchmark foundation is real, but intentionally modest.
+
+Today it verifies:
+
+- bounded session completion
+- runtime reflection and stopped-state behavior
+- benchmark-scoped memory and evidence capture
+- handoff export and restore continuity
+- coverage across all shipped base-type selections and the composite identity
+
+Today it does **not** yet infer:
+
+- a task-specific semantic judge for code correctness
+- automatic unnecessary action counting
+- autonomous retry-and-replan loops inside the gym runner
+
+Those gaps are recorded in the emitted `measurement_notes` instead of being hidden.
+
+## Summary
+
+You now know how to:
+
+- list the shipped benchmark scenarios
+- run the starter benchmark suite
+- inspect the emitted benchmark artifacts
+- understand what the current gym slice measures honestly
+
+## Next steps
+
+- Use the [local session tutorial](./run-your-first-local-session.md) to compare ordinary runtime execution with benchmark execution.
+- Use the [runtime contracts reference](../reference/runtime-contracts.md) when you need the exact public surface details.

--- a/prompt_assets/simard/gym_system.md
+++ b/prompt_assets/simard/gym_system.md
@@ -1,1 +1,26 @@
 # Simard Gym System Prompt
+
+You are Simard operating in gym mode.
+
+Your job is to run bounded engineering benchmark scenarios honestly.
+
+## Rules
+
+- Treat each benchmark as a real engineering session with explicit intake, planning, execution, reflection, and persistence boundaries.
+- Prefer inspectable artifacts over vague claims.
+- Do not inflate scores or hide missing capabilities.
+- Preserve truthful runtime metadata, evidence, and memory boundaries.
+- When the current runtime cannot measure something directly, say so explicitly.
+
+## Benchmark priorities
+
+- Complete the bounded task coherently.
+- Produce evidence an operator can inspect.
+- Preserve the session boundary through handoff artifacts.
+- Surface limitations instead of pretending the benchmark is richer than it is.
+
+## Reporting stance
+
+- Record what was attempted.
+- Record what was verified.
+- Record what is still unmeasured.

--- a/src/bin/simard_gym.rs
+++ b/src/bin/simard_gym.rs
@@ -1,0 +1,62 @@
+use simard::{
+    benchmark_scenarios, default_output_root, run_benchmark_scenario, run_benchmark_suite,
+};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut args = std::env::args().skip(1);
+    let command = args.next().ok_or(usage())?;
+
+    match command.as_str() {
+        "list" => {
+            println!("Simard benchmark scenarios:");
+            for scenario in benchmark_scenarios() {
+                println!(
+                    "- {} | class={} | identity={} | base_type={} | topology={}",
+                    scenario.id,
+                    scenario.class,
+                    scenario.identity,
+                    scenario.base_type,
+                    scenario.topology
+                );
+                println!("  {}", scenario.title);
+            }
+        }
+        "run" => {
+            let scenario_id = args.next().ok_or("expected scenario id")?;
+            let report = run_benchmark_scenario(&scenario_id, default_output_root())?;
+            println!("Scenario: {}", report.scenario.id);
+            println!("Suite: {}", report.suite_id);
+            println!("Session: {}", report.session_id);
+            println!("Passed: {}", report.passed);
+            println!(
+                "Checks passed: {}/{}",
+                report.scorecard.correctness_checks_passed,
+                report.scorecard.correctness_checks_total
+            );
+            println!("Artifact report: {}", report.artifacts.report_json);
+            println!("Artifact summary: {}", report.artifacts.report_txt);
+        }
+        "run-suite" => {
+            let suite_id = args.next().ok_or("expected suite id")?;
+            let report = run_benchmark_suite(&suite_id, default_output_root())?;
+            println!("Suite: {}", report.suite_id);
+            println!("Suite passed: {}", report.passed);
+            for scenario in &report.scenarios {
+                println!(
+                    "- {}: {} ({})",
+                    scenario.scenario_id,
+                    if scenario.passed { "passed" } else { "failed" },
+                    scenario.report_json
+                );
+            }
+            println!("Suite artifact report: {}", report.artifact_path);
+        }
+        _ => return Err(usage().into()),
+    }
+
+    Ok(())
+}
+
+fn usage() -> &'static str {
+    "usage: simard-gym <list|run <scenario-id>|run-suite <suite-id>>"
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -104,6 +104,16 @@ pub enum SimardError {
         field: String,
         reason: String,
     },
+    BenchmarkScenarioNotFound {
+        scenario_id: String,
+    },
+    BenchmarkSuiteNotFound {
+        suite_id: String,
+    },
+    ArtifactIo {
+        path: PathBuf,
+        reason: String,
+    },
     StoragePoisoned {
         store: String,
     },
@@ -227,6 +237,15 @@ impl Display for SimardError {
             }
             Self::InvalidHandoffSnapshot { field, reason } => {
                 write!(f, "invalid handoff snapshot field '{field}': {reason}")
+            }
+            Self::BenchmarkScenarioNotFound { scenario_id } => {
+                write!(f, "benchmark scenario '{scenario_id}' is not registered")
+            }
+            Self::BenchmarkSuiteNotFound { suite_id } => {
+                write!(f, "benchmark suite '{suite_id}' is not registered")
+            }
+            Self::ArtifactIo { path: _, reason } => {
+                write!(f, "failed to read or write benchmark artifact: {reason}")
             }
             Self::StoragePoisoned { store } => {
                 write!(f, "storage lock for '{store}' is poisoned")

--- a/src/gym.rs
+++ b/src/gym.rs
@@ -1,0 +1,602 @@
+use std::fmt::{self, Display, Formatter};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::Serialize;
+
+use crate::bootstrap::builtin_base_type_registry_for_manifest;
+use crate::error::{SimardError, SimardResult};
+use crate::evidence::{EvidenceRecord, EvidenceSource, EvidenceStore, InMemoryEvidenceStore};
+use crate::handoff::RuntimeHandoffSnapshot;
+use crate::identity::{
+    BuiltinIdentityLoader, IdentityLoadRequest, IdentityLoader, ManifestContract,
+};
+use crate::memory::{InMemoryMemoryStore, MemoryRecord, MemoryScope, MemoryStore};
+use crate::metadata::{Freshness, Provenance};
+use crate::prompt_assets::FilePromptAssetStore;
+use crate::reflection::ReflectiveRuntime;
+use crate::runtime::{
+    BaseTypeRegistry, CoordinatedSupervisor, LocalRuntime, LoopbackMailboxTransport,
+    LoopbackMeshTopologyDriver, RuntimePorts, RuntimeRequest, RuntimeState, RuntimeTopology,
+};
+use crate::session::SessionPhase;
+use crate::session::UuidSessionIdGenerator;
+
+const STARTER_SUITE_ID: &str = "starter";
+const DEFAULT_OUTPUT_ROOT: &str = "target/simard-gym";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum BenchmarkClass {
+    RepoExploration,
+    Documentation,
+    SafeCodeChange,
+    SessionQuality,
+}
+
+impl Display for BenchmarkClass {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let label = match self {
+            Self::RepoExploration => "repo-exploration",
+            Self::Documentation => "documentation",
+            Self::SafeCodeChange => "safe-code-change",
+            Self::SessionQuality => "session-quality",
+        };
+        f.write_str(label)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct BenchmarkScenario {
+    pub id: &'static str,
+    pub title: &'static str,
+    pub description: &'static str,
+    pub class: BenchmarkClass,
+    pub identity: &'static str,
+    pub base_type: &'static str,
+    pub topology: RuntimeTopology,
+    pub objective: &'static str,
+    pub expected_min_runtime_evidence: usize,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct BenchmarkCheckResult {
+    pub id: String,
+    pub passed: bool,
+    pub detail: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct BenchmarkArtifactPaths {
+    pub run_dir: String,
+    pub report_json: String,
+    pub report_txt: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct BenchmarkRuntimeReport {
+    pub identity: String,
+    pub selected_base_type: String,
+    pub topology: String,
+    pub adapter_implementation: String,
+    pub topology_backend: String,
+    pub transport_backend: String,
+    pub supervisor_backend: String,
+    pub runtime_node: String,
+    pub mailbox_address: String,
+    pub snapshot_state_before_stop: String,
+    pub snapshot_state_after_stop: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct BenchmarkHandoffReport {
+    pub exported_state: String,
+    pub exported_memory_records: usize,
+    pub exported_evidence_records: usize,
+    pub restored_runtime_state: String,
+    pub restored_session_phase: Option<String>,
+    pub restored_session_objective: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct BenchmarkScorecard {
+    pub task_completed: bool,
+    pub evidence_quality: String,
+    pub correctness_checks_passed: usize,
+    pub correctness_checks_total: usize,
+    pub unnecessary_action_count: Option<u32>,
+    pub retry_count: u32,
+    pub human_review_notes: Vec<String>,
+    pub measurement_notes: Vec<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct BenchmarkRunReport {
+    pub suite_id: String,
+    pub scenario: BenchmarkScenario,
+    pub session_id: String,
+    pub run_started_at_unix_ms: u128,
+    pub passed: bool,
+    pub checks: Vec<BenchmarkCheckResult>,
+    pub scorecard: BenchmarkScorecard,
+    pub plan: String,
+    pub execution_summary: String,
+    pub reflection_summary: String,
+    pub benchmark_memory_key: String,
+    pub benchmark_evidence_id: String,
+    pub runtime: BenchmarkRuntimeReport,
+    pub handoff: BenchmarkHandoffReport,
+    pub artifacts: BenchmarkArtifactPaths,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct BenchmarkSuiteScenarioSummary {
+    pub scenario_id: String,
+    pub passed: bool,
+    pub session_id: String,
+    pub report_json: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct BenchmarkSuiteReport {
+    pub suite_id: String,
+    pub run_started_at_unix_ms: u128,
+    pub passed: bool,
+    pub scenarios: Vec<BenchmarkSuiteScenarioSummary>,
+    pub artifact_path: String,
+}
+
+pub fn benchmark_scenarios() -> Vec<BenchmarkScenario> {
+    vec![
+        BenchmarkScenario {
+            id: "repo-exploration-local",
+            title: "Repo exploration on local harness",
+            description: "Exercise a bounded repo-exploration task through the gym identity on the single-process local harness.",
+            class: BenchmarkClass::RepoExploration,
+            identity: "simard-gym",
+            base_type: "local-harness",
+            topology: RuntimeTopology::SingleProcess,
+            objective: "Inspect repository structure, identify likely extension points, and summarize where benchmark and runtime changes should land.",
+            expected_min_runtime_evidence: 3,
+        },
+        BenchmarkScenario {
+            id: "docs-refresh-copilot",
+            title: "Documentation refresh through copilot-sdk alias",
+            description: "Exercise a documentation-oriented benchmark while preserving the explicit copilot-sdk selection and honest local-harness implementation identity.",
+            class: BenchmarkClass::Documentation,
+            identity: "simard-gym",
+            base_type: "copilot-sdk",
+            topology: RuntimeTopology::SingleProcess,
+            objective: "Produce a concise documentation-oriented execution summary for the current repository state and report the relevant reflected runtime contracts.",
+            expected_min_runtime_evidence: 3,
+        },
+        BenchmarkScenario {
+            id: "safe-code-change-rusty-clawd",
+            title: "Safe code change style task on rusty-clawd",
+            description: "Exercise a bounded safe-change objective on the distinct rusty-clawd backend through the loopback multi-process topology.",
+            class: BenchmarkClass::SafeCodeChange,
+            identity: "simard-gym",
+            base_type: "rusty-clawd",
+            topology: RuntimeTopology::MultiProcess,
+            objective: "Plan a narrow, reviewable runtime change and summarize the exact evidence an operator would inspect before approving it.",
+            expected_min_runtime_evidence: 4,
+        },
+        BenchmarkScenario {
+            id: "composite-session-review",
+            title: "Composite identity session quality review",
+            description: "Exercise the composite engineer identity as a session-quality benchmark so the starter suite covers the shipped composite identity as well as the dedicated gym identity.",
+            class: BenchmarkClass::SessionQuality,
+            identity: "simard-composite-engineer",
+            base_type: "local-harness",
+            topology: RuntimeTopology::SingleProcess,
+            objective: "Run a disciplined bounded engineering session, preserve evidence, and produce a concise operator-facing summary of what happened.",
+            expected_min_runtime_evidence: 3,
+        },
+    ]
+}
+
+pub fn run_benchmark_scenario(
+    scenario_id: &str,
+    output_root: impl AsRef<Path>,
+) -> SimardResult<BenchmarkRunReport> {
+    let scenario = benchmark_scenarios()
+        .into_iter()
+        .find(|candidate| candidate.id == scenario_id)
+        .ok_or_else(|| SimardError::BenchmarkScenarioNotFound {
+            scenario_id: scenario_id.to_string(),
+        })?;
+    execute_scenario(scenario, STARTER_SUITE_ID, output_root.as_ref())
+}
+
+pub fn run_benchmark_suite(
+    suite_id: &str,
+    output_root: impl AsRef<Path>,
+) -> SimardResult<BenchmarkSuiteReport> {
+    if suite_id != STARTER_SUITE_ID {
+        return Err(SimardError::BenchmarkSuiteNotFound {
+            suite_id: suite_id.to_string(),
+        });
+    }
+
+    let output_root = output_root.as_ref();
+    let started_at_unix_ms = now_unix_ms()?;
+    let mut scenario_summaries = Vec::new();
+    let mut suite_passed = true;
+
+    for scenario in benchmark_scenarios() {
+        let report = execute_scenario(scenario, suite_id, output_root)?;
+        suite_passed &= report.passed;
+        scenario_summaries.push(BenchmarkSuiteScenarioSummary {
+            scenario_id: report.scenario.id.to_string(),
+            passed: report.passed,
+            session_id: report.session_id.clone(),
+            report_json: report.artifacts.report_json.clone(),
+        });
+    }
+
+    let suite_dir = output_root.join("suites");
+    create_dir_all(&suite_dir)?;
+    let suite_artifact = suite_dir.join(format!("{suite_id}.json"));
+    let suite_report = BenchmarkSuiteReport {
+        suite_id: suite_id.to_string(),
+        run_started_at_unix_ms: started_at_unix_ms,
+        passed: suite_passed,
+        scenarios: scenario_summaries,
+        artifact_path: display_path(&suite_artifact),
+    };
+    write_json(&suite_artifact, &suite_report)?;
+    Ok(suite_report)
+}
+
+fn execute_scenario(
+    scenario: BenchmarkScenario,
+    suite_id: &str,
+    output_root: &Path,
+) -> SimardResult<BenchmarkRunReport> {
+    let started_at_unix_ms = now_unix_ms()?;
+    let prompt_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("prompt_assets");
+    let prompt_store = Arc::new(FilePromptAssetStore::new(prompt_root));
+    let memory_store = Arc::new(InMemoryMemoryStore::try_default()?);
+    let evidence_store = Arc::new(InMemoryEvidenceStore::try_default()?);
+
+    let contract = ManifestContract::new(
+        "simard::gym::run_benchmark_scenario",
+        "simard-gym-cli -> identity-loader -> runtime-ports -> local-runtime",
+        vec![
+            format!("suite:{suite_id}"),
+            format!("scenario:{}", scenario.id),
+            format!("identity:{}", scenario.identity),
+            format!("base-type:{}", scenario.base_type),
+            format!("topology:{}", scenario.topology),
+        ],
+        Provenance::new("benchmark-gym", format!("simard-gym:{}", scenario.id)),
+        Freshness::now()?,
+    )?;
+    let manifest = BuiltinIdentityLoader.load(&IdentityLoadRequest::new(
+        scenario.identity,
+        env!("CARGO_PKG_VERSION"),
+        contract,
+    ))?;
+    let request = RuntimeRequest::new(
+        manifest.clone(),
+        crate::BaseTypeId::new(scenario.base_type),
+        scenario.topology,
+    );
+    let mut runtime = LocalRuntime::compose(
+        runtime_ports_for_topology(
+            prompt_store,
+            Arc::clone(&memory_store),
+            Arc::clone(&evidence_store),
+            builtin_base_type_registry_for_manifest(&manifest)?,
+            scenario.topology,
+        )?,
+        request.clone(),
+    )?;
+
+    runtime.start()?;
+    let outcome = runtime.run(scenario.objective.to_string())?;
+    let ready_snapshot = runtime.snapshot()?;
+
+    let benchmark_memory_key = format!("{}-benchmark-summary", outcome.session.id);
+    memory_store.put(MemoryRecord {
+        key: benchmark_memory_key.clone(),
+        scope: MemoryScope::Benchmark,
+        value: format!(
+            "suite={suite_id}; scenario={}; class={}; identity={}; base_type={}; topology={}",
+            scenario.id, scenario.class, scenario.identity, scenario.base_type, scenario.topology
+        ),
+        session_id: outcome.session.id.clone(),
+        recorded_in: SessionPhase::Complete,
+    })?;
+
+    let benchmark_evidence_id = format!("{}-benchmark-capture", outcome.session.id);
+    evidence_store.record(EvidenceRecord {
+        id: benchmark_evidence_id.clone(),
+        session_id: outcome.session.id.clone(),
+        phase: SessionPhase::Complete,
+        detail: format!(
+            "benchmark-scenario={} suite={} identity={} base_type={} topology={}",
+            scenario.id, suite_id, scenario.identity, scenario.base_type, scenario.topology
+        ),
+        source: EvidenceSource::Runtime,
+    })?;
+
+    let exported = runtime.export_handoff()?;
+    let restored = restore_from_handoff(&manifest, &request, &exported)?;
+    let restored_snapshot = restored.snapshot()?;
+
+    runtime.stop()?;
+    let stopped_snapshot = runtime.snapshot()?;
+
+    let checks = vec![
+        BenchmarkCheckResult {
+            id: "session-complete".to_string(),
+            passed: outcome.session.phase == SessionPhase::Complete,
+            detail: format!(
+                "session phase after execution was '{}'",
+                outcome.session.phase
+            ),
+        },
+        BenchmarkCheckResult {
+            id: "runtime-ready-before-stop".to_string(),
+            passed: ready_snapshot.runtime_state == RuntimeState::Ready,
+            detail: format!(
+                "runtime state before stop was '{}'",
+                ready_snapshot.runtime_state
+            ),
+        },
+        BenchmarkCheckResult {
+            id: "runtime-stopped-after-stop".to_string(),
+            passed: stopped_snapshot.runtime_state == RuntimeState::Stopped,
+            detail: format!(
+                "runtime state after stop was '{}'",
+                stopped_snapshot.runtime_state
+            ),
+        },
+        BenchmarkCheckResult {
+            id: "reflection-summary-present".to_string(),
+            passed: !outcome.reflection.summary.trim().is_empty(),
+            detail: "reflection summary was non-empty".to_string(),
+        },
+        BenchmarkCheckResult {
+            id: "runtime-evidence-produced".to_string(),
+            passed: ready_snapshot.evidence_records >= scenario.expected_min_runtime_evidence,
+            detail: format!(
+                "runtime recorded {} evidence records before benchmark capture; expected at least {}",
+                ready_snapshot.evidence_records, scenario.expected_min_runtime_evidence
+            ),
+        },
+        BenchmarkCheckResult {
+            id: "exported-benchmark-artifacts".to_string(),
+            passed: exported.memory_records.len() >= 3 && exported.evidence_records.len() >= 4,
+            detail: format!(
+                "exported {} memory records and {} evidence records",
+                exported.memory_records.len(),
+                exported.evidence_records.len()
+            ),
+        },
+        BenchmarkCheckResult {
+            id: "handoff-restores-session-boundary".to_string(),
+            passed: restored_snapshot.session_phase == Some(SessionPhase::Complete),
+            detail: format!(
+                "restored session phase was '{}'",
+                restored_snapshot
+                    .session_phase
+                    .map(|phase| phase.to_string())
+                    .unwrap_or_else(|| "<none>".to_string())
+            ),
+        },
+        BenchmarkCheckResult {
+            id: "handoff-objective-redacted".to_string(),
+            passed: exported
+                .session
+                .as_ref()
+                .map(|session| {
+                    session.objective.starts_with("objective-metadata(")
+                        && session.objective.ends_with(')')
+                })
+                .unwrap_or(false),
+            detail: exported
+                .session
+                .as_ref()
+                .map(|session| format!("exported session objective was '{}'", session.objective))
+                .unwrap_or_else(|| {
+                    "exported handoff did not include a session boundary".to_string()
+                }),
+        },
+    ];
+    let passed = checks.iter().all(|check| check.passed);
+    let run_dir = output_root
+        .join(scenario.id)
+        .join(outcome.session.id.as_str());
+    create_dir_all(&run_dir)?;
+    let report_json = run_dir.join("report.json");
+    let report_txt = run_dir.join("report.txt");
+    let report = BenchmarkRunReport {
+        suite_id: suite_id.to_string(),
+        scenario,
+        session_id: outcome.session.id.to_string(),
+        run_started_at_unix_ms: started_at_unix_ms,
+        passed,
+        scorecard: BenchmarkScorecard {
+            task_completed: passed,
+            evidence_quality: if exported.evidence_records.len() >= 4 {
+                "sufficient".to_string()
+            } else {
+                "thin".to_string()
+            },
+            correctness_checks_passed: checks.iter().filter(|check| check.passed).count(),
+            correctness_checks_total: checks.len(),
+            unnecessary_action_count: None,
+            retry_count: 0,
+            human_review_notes: Vec::new(),
+            measurement_notes: vec![
+                "v1 benchmark foundation derives evidence from runtime, memory, and handoff artifacts rather than a task-specific code-change judge".to_string(),
+                "unnecessary_action_count remains unmeasured until the benchmark runner can classify shell/tool actions directly".to_string(),
+                "retry_count is currently zero because the benchmark runner does not yet re-plan or retry failed scenarios automatically".to_string(),
+            ],
+        },
+        checks,
+        plan: outcome.plan,
+        execution_summary: outcome.execution_summary,
+        reflection_summary: outcome.reflection.summary,
+        benchmark_memory_key,
+        benchmark_evidence_id,
+        runtime: BenchmarkRuntimeReport {
+            identity: ready_snapshot.identity_name,
+            selected_base_type: ready_snapshot.selected_base_type.to_string(),
+            topology: ready_snapshot.topology.to_string(),
+            adapter_implementation: ready_snapshot.adapter_backend.identity,
+            topology_backend: ready_snapshot.topology_backend.identity,
+            transport_backend: ready_snapshot.transport_backend.identity,
+            supervisor_backend: ready_snapshot.supervisor_backend.identity,
+            runtime_node: ready_snapshot.runtime_node.to_string(),
+            mailbox_address: ready_snapshot.mailbox_address.to_string(),
+            snapshot_state_before_stop: ready_snapshot.runtime_state.to_string(),
+            snapshot_state_after_stop: stopped_snapshot.runtime_state.to_string(),
+        },
+        handoff: BenchmarkHandoffReport {
+            exported_state: exported.exported_state.to_string(),
+            exported_memory_records: exported.memory_records.len(),
+            exported_evidence_records: exported.evidence_records.len(),
+            restored_runtime_state: restored_snapshot.runtime_state.to_string(),
+            restored_session_phase: restored_snapshot.session_phase.map(|phase| phase.to_string()),
+            restored_session_objective: exported.session.as_ref().map(|session| session.objective.clone()),
+        },
+        artifacts: BenchmarkArtifactPaths {
+            run_dir: display_path(&run_dir),
+            report_json: display_path(&report_json),
+            report_txt: display_path(&report_txt),
+        },
+    };
+    write_json(&report_json, &report)?;
+    write_text(&report_txt, render_text_report(&report))?;
+    Ok(report)
+}
+
+fn restore_from_handoff(
+    manifest: &crate::IdentityManifest,
+    request: &RuntimeRequest,
+    exported: &RuntimeHandoffSnapshot,
+) -> SimardResult<LocalRuntime> {
+    let prompt_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("prompt_assets");
+    let prompt_store = Arc::new(FilePromptAssetStore::new(prompt_root));
+    let memory_store = Arc::new(InMemoryMemoryStore::try_default()?);
+    let evidence_store = Arc::new(InMemoryEvidenceStore::try_default()?);
+    LocalRuntime::compose_from_handoff(
+        runtime_ports_for_topology(
+            prompt_store,
+            memory_store,
+            evidence_store,
+            builtin_base_type_registry_for_manifest(manifest)?,
+            request.topology,
+        )?,
+        request.clone(),
+        exported.clone(),
+    )
+}
+
+fn runtime_ports_for_topology(
+    prompt_store: Arc<FilePromptAssetStore>,
+    memory_store: Arc<InMemoryMemoryStore>,
+    evidence_store: Arc<InMemoryEvidenceStore>,
+    base_types: BaseTypeRegistry,
+    topology: RuntimeTopology,
+) -> SimardResult<RuntimePorts> {
+    match topology {
+        RuntimeTopology::SingleProcess => Ok(RuntimePorts::new(
+            prompt_store,
+            memory_store,
+            evidence_store,
+            base_types,
+            Arc::new(UuidSessionIdGenerator),
+        )),
+        RuntimeTopology::MultiProcess | RuntimeTopology::Distributed => {
+            Ok(RuntimePorts::with_runtime_services(
+                prompt_store,
+                memory_store,
+                evidence_store,
+                base_types,
+                Arc::new(LoopbackMeshTopologyDriver::try_default()?),
+                Arc::new(LoopbackMailboxTransport::try_default()?),
+                Arc::new(CoordinatedSupervisor::try_default()?),
+                Arc::new(UuidSessionIdGenerator),
+            ))
+        }
+    }
+}
+
+fn render_text_report(report: &BenchmarkRunReport) -> String {
+    let mut lines = vec![
+        format!("Suite: {}", report.suite_id),
+        format!(
+            "Scenario: {} ({})",
+            report.scenario.id, report.scenario.title
+        ),
+        format!("Passed: {}", report.passed),
+        format!("Identity: {}", report.runtime.identity),
+        format!("Base type: {}", report.runtime.selected_base_type),
+        format!("Topology: {}", report.runtime.topology),
+        format!(
+            "Checks passed: {}/{}",
+            report.scorecard.correctness_checks_passed, report.scorecard.correctness_checks_total
+        ),
+        format!("Plan: {}", report.plan),
+        format!("Execution summary: {}", report.execution_summary),
+        format!("Reflection summary: {}", report.reflection_summary),
+        "Checks:".to_string(),
+    ];
+    for check in &report.checks {
+        lines.push(format!(
+            "- {}: {} ({})",
+            check.id,
+            if check.passed { "passed" } else { "failed" },
+            check.detail
+        ));
+    }
+    lines.join("\n")
+}
+
+fn create_dir_all(path: &Path) -> SimardResult<()> {
+    fs::create_dir_all(path).map_err(|error| SimardError::ArtifactIo {
+        path: path.to_path_buf(),
+        reason: error.to_string(),
+    })
+}
+
+fn write_json<T>(path: &Path, value: &T) -> SimardResult<()>
+where
+    T: Serialize,
+{
+    let json = serde_json::to_string_pretty(value).map_err(|error| SimardError::ArtifactIo {
+        path: path.to_path_buf(),
+        reason: error.to_string(),
+    })?;
+    write_text(path, format!("{json}\n"))
+}
+
+fn write_text(path: &Path, contents: String) -> SimardResult<()> {
+    fs::write(path, contents).map_err(|error| SimardError::ArtifactIo {
+        path: path.to_path_buf(),
+        reason: error.to_string(),
+    })
+}
+
+fn display_path(path: &Path) -> String {
+    path.to_string_lossy().into_owned()
+}
+
+fn now_unix_ms() -> SimardResult<u128> {
+    Ok(SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|error| SimardError::ClockBeforeUnixEpoch {
+            reason: error.to_string(),
+        })?
+        .as_millis())
+}
+
+pub fn default_output_root() -> PathBuf {
+    PathBuf::from(DEFAULT_OUTPUT_ROOT)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod base_types;
 pub mod bootstrap;
 pub mod error;
 pub mod evidence;
+pub mod gym;
 pub mod handoff;
 pub mod identity;
 pub mod memory;
@@ -26,6 +27,11 @@ pub use bootstrap::{
 };
 pub use error::{SimardError, SimardResult};
 pub use evidence::{EvidenceRecord, EvidenceSource, EvidenceStore, InMemoryEvidenceStore};
+pub use gym::{
+    BenchmarkArtifactPaths, BenchmarkCheckResult, BenchmarkRunReport, BenchmarkScenario,
+    BenchmarkSuiteReport, BenchmarkSuiteScenarioSummary, benchmark_scenarios, default_output_root,
+    run_benchmark_scenario, run_benchmark_suite,
+};
 pub use handoff::{InMemoryHandoffStore, RuntimeHandoffSnapshot, RuntimeHandoffStore};
 pub use identity::{
     BuiltinIdentityLoader, IdentityLoadRequest, IdentityLoader, IdentityManifest, ManifestContract,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2,6 +2,8 @@ use std::collections::BTreeMap;
 use std::fmt::{self, Display, Formatter};
 use std::sync::Arc;
 
+use serde::Serialize;
+
 use crate::agent_program::{AgentProgram, AgentProgramContext, ObjectiveRelayProgram};
 use crate::base_types::{BaseTypeFactory, BaseTypeId, BaseTypeOutcome, BaseTypeSessionRequest};
 use crate::error::{SimardError, SimardResult};
@@ -15,7 +17,8 @@ use crate::reflection::{ReflectionReport, ReflectionSnapshot, ReflectiveRuntime}
 use crate::sanitization::objective_metadata;
 use crate::session::{SessionIdGenerator, SessionPhase, SessionRecord};
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum RuntimeTopology {
     SingleProcess,
     MultiProcess,

--- a/tests/gadugi/gym-suite.sh
+++ b/tests/gadugi/gym-suite.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+LIST_OUTPUT="$(
+  cargo run --quiet --bin simard-gym -- list
+)"
+
+printf '%s\n' "$LIST_OUTPUT"
+printf '%s\n' "$LIST_OUTPUT" | grep -F "repo-exploration-local" >/dev/null
+printf '%s\n' "$LIST_OUTPUT" | grep -F "docs-refresh-copilot" >/dev/null
+printf '%s\n' "$LIST_OUTPUT" | grep -F "safe-code-change-rusty-clawd" >/dev/null
+printf '%s\n' "$LIST_OUTPUT" | grep -F "composite-session-review" >/dev/null
+
+SUITE_OUTPUT="$(
+  cargo run --quiet --bin simard-gym -- run-suite starter
+)"
+
+printf '%s\n' "$SUITE_OUTPUT"
+printf '%s\n' "$SUITE_OUTPUT" | grep -F "Suite: starter" >/dev/null
+printf '%s\n' "$SUITE_OUTPUT" | grep -F "Suite passed: true" >/dev/null
+printf '%s\n' "$SUITE_OUTPUT" | grep -F "repo-exploration-local: passed" >/dev/null
+printf '%s\n' "$SUITE_OUTPUT" | grep -F "docs-refresh-copilot: passed" >/dev/null
+printf '%s\n' "$SUITE_OUTPUT" | grep -F "safe-code-change-rusty-clawd: passed" >/dev/null
+printf '%s\n' "$SUITE_OUTPUT" | grep -F "composite-session-review: passed" >/dev/null
+
+SUITE_REPORT="$(printf '%s\n' "$SUITE_OUTPUT" | sed -n 's/^Suite artifact report: //p')"
+[ -n "$SUITE_REPORT" ]
+[ -f "$SUITE_REPORT" ]
+
+grep -F '"suite_id": "starter"' "$SUITE_REPORT" >/dev/null
+grep -F '"passed": true' "$SUITE_REPORT" >/dev/null

--- a/tests/gadugi/simard-cli-smoke.yaml
+++ b/tests/gadugi/simard-cli-smoke.yaml
@@ -1,5 +1,5 @@
 name: "Simard Operator Runtime Behavior"
-description: "Outside-in operator coverage for base-type selection, composite identity execution, loopback multi-process runtime wiring, and handoff restore behavior."
+description: "Outside-in operator coverage for base-type selection, composite identity execution, loopback multi-process runtime wiring, handoff restore behavior, and the shipped benchmark gym starter suite."
 version: "1.0.0"
 
 config:
@@ -62,6 +62,13 @@ steps:
       command: "tests/gadugi/handoff-roundtrip.sh"
     timeout: 300000
 
+  - name: "Benchmark gym starter suite"
+    agent: "cli-agent"
+    action: "execute_command"
+    params:
+      command: "tests/gadugi/gym-suite.sh"
+    timeout: 300000
+
 assertions: []
 
 cleanup:
@@ -77,6 +84,7 @@ metadata:
     - "bootstrap"
     - "handoff"
     - "composite"
+    - "benchmark-gym"
   priority: "high"
   author: "copilot"
   test_type: "outside-in"


### PR DESCRIPTION
## Summary
- add the first real Simard benchmark gym foundation with a shipped starter scenario catalog and `simard-gym` CLI
- emit inspectable benchmark artifacts backed by runtime memory, evidence, and handoff data
- extend docs and outside-in operator coverage for the new gym path

## Testing
- `cargo test --all-features --locked`
- `tests/gadugi/smoke-explicit-local.sh`
- `tests/gadugi/smoke-explicit-rusty-clawd.sh`
- `tests/gadugi/smoke-builtin-defaults.sh`
- `tests/gadugi/composite-identity.sh`
- `tests/gadugi/handoff-roundtrip.sh`
- `tests/gadugi/gym-suite.sh`
- `python3 -m pre_commit run --all-files --hook-stage pre-commit`
- `python3 -m pre_commit run --all-files --hook-stage pre-push`

## Scope reconciliation
This PR advances the benchmark gym requirement from the original Simard prompt and `Specs/ProductArchitecture.md` by shipping one small benchmark set, a real gym operating path, inspectable artifacts, and composite/base-type coverage without pretending v1 already has a richer semantic judge or retry loop.
