### PR TITLE
Implement the Simard durable memory foundation

### DIFF
--- a/docs/howto/configure-bootstrap-and-inspect-reflection.md
+++ b/docs/howto/configure-bootstrap-and-inspect-reflection.md
@@ -26,13 +26,14 @@ Use this guide when you need to answer two questions:
 
 ## 1. Use explicit configuration by default
 
-Provide both the prompt root and objective yourself.
+Provide the prompt root, objective, and state root yourself.
 
 For the builtin identities in this repo, the current scaffold accepts `local-harness`, `rusty-clawd`, or `copilot-sdk` as explicit base-type choices. `rusty-clawd` is a distinct session backend, while `copilot-sdk` remains an explicit alias of `local-harness`. The bootstrap path now injects either the in-process runtime services for `single-process` or the loopback mesh services for `multi-process`, so unsupported topology/base-type pairs fail explicitly instead of being rewritten.
 
 ```bash
 SIMARD_PROMPT_ROOT="$PWD/prompt_assets" \
 SIMARD_OBJECTIVE="verify current reflection metadata" \
+SIMARD_STATE_ROOT="$PWD/target/simard-state" \
 SIMARD_IDENTITY="simard-engineer" \
 SIMARD_BASE_TYPE="local-harness" \
 SIMARD_RUNTIME_TOPOLOGY="single-process" \
@@ -43,6 +44,7 @@ In the current repo:
 
 - missing `SIMARD_PROMPT_ROOT` fails bootstrap
 - missing `SIMARD_OBJECTIVE` fails bootstrap
+- missing `SIMARD_STATE_ROOT` fails bootstrap
 - missing `SIMARD_IDENTITY` fails bootstrap
 - missing `SIMARD_BASE_TYPE` fails bootstrap
 - missing `SIMARD_RUNTIME_TOPOLOGY` fails bootstrap
@@ -61,6 +63,7 @@ Use this when you want to prove that bootstrap is not silently snapping back to 
 ```bash
 SIMARD_PROMPT_ROOT="$PWD/prompt_assets" \
 SIMARD_OBJECTIVE="verify copilot-sdk bootstrap selection" \
+SIMARD_STATE_ROOT="$PWD/target/simard-state" \
 SIMARD_IDENTITY="simard-engineer" \
 SIMARD_BASE_TYPE="copilot-sdk" \
 SIMARD_RUNTIME_TOPOLOGY="single-process" \
@@ -90,6 +93,7 @@ In the current repo:
 
 - `SIMARD_PROMPT_ROOT` resolves to the repository `prompt_assets/` directory
 - `SIMARD_OBJECTIVE` resolves to the builtin engineer-loop objective
+- `SIMARD_STATE_ROOT` resolves to the repository `target/simard-state` directory
 - `SIMARD_IDENTITY` resolves to `simard-engineer`
 - `SIMARD_BASE_TYPE` resolves to `local-harness`
 - `SIMARD_RUNTIME_TOPOLOGY` resolves to the topology you selected, with builtin defaults still opting into `single-process`
@@ -132,13 +136,13 @@ assert_eq!(
 assert_eq!(snapshot.runtime_node.to_string(), "node-local");
 assert_eq!(snapshot.mailbox_address.to_string(), "inmemory://node-local");
 assert_eq!(snapshot.agent_program_backend.identity, "agent-program::objective-relay");
-assert_eq!(snapshot.handoff_backend.identity, "handoff::in-memory");
+assert_eq!(snapshot.handoff_backend.identity, "handoff::json-file-store");
 assert_eq!(snapshot.adapter_backend.identity, "local-harness");
 assert_eq!(snapshot.topology_backend.identity, "topology::in-process");
 assert_eq!(snapshot.transport_backend.identity, "transport::in-memory-mailbox");
 assert_eq!(snapshot.supervisor_backend.identity, "supervisor::in-process");
-assert_eq!(snapshot.memory_backend.identity, "memory::session-cache");
-assert_eq!(snapshot.evidence_backend.identity, "evidence::append-only-log");
+assert_eq!(snapshot.memory_backend.identity, "memory::json-file-store");
+assert_eq!(snapshot.evidence_backend.identity, "evidence::json-file-store");
 ```
 
 If you launched with `SIMARD_BASE_TYPE="copilot-sdk"`, `snapshot.selected_base_type` still shows the alias you chose while `snapshot.adapter_backend.identity` remains `local-harness`. If you launched with `SIMARD_BASE_TYPE="rusty-clawd"`, reflection truthfully reports `snapshot.adapter_backend.identity == "rusty-clawd::session-backend"`. Composite identities also surface `snapshot.identity_components` so operator tooling can see which roles were assembled.
@@ -178,6 +182,7 @@ Set `SIMARD_IDENTITY` before startup:
 ```bash
 SIMARD_PROMPT_ROOT="$PWD/prompt_assets" \
 SIMARD_OBJECTIVE="run custom identity" \
+SIMARD_STATE_ROOT="$PWD/target/simard-state" \
 SIMARD_IDENTITY="simard-engineer" \
 SIMARD_BASE_TYPE="local-harness" \
 SIMARD_RUNTIME_TOPOLOGY="single-process" \
@@ -210,6 +215,7 @@ Invalid values fail with `SimardError::InvalidSessionId`.
 ```bash
 export SIMARD_PROMPT_ROOT="$PWD/prompt_assets"
 export SIMARD_OBJECTIVE="verify current reflection metadata"
+export SIMARD_STATE_ROOT="$PWD/target/simard-state"
 export SIMARD_IDENTITY="simard-engineer"
 export SIMARD_BASE_TYPE="local-harness"
 export SIMARD_RUNTIME_TOPOLOGY="single-process"

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,7 @@ This docs set describes the runtime behavior that exists in this repository toda
 Today Simard provides:
 
 - explicit bootstrap configuration, with `builtin-defaults` available only through opt-in startup mode
+- a durable local state root selected through `SIMARD_STATE_ROOT` in `explicit-config` or defaulted through `builtin-defaults`
 - explicit base-type and topology selection at bootstrap, with opt-in defaults only in `builtin-defaults`
 - builtin manifest-advertised base types selectable at startup today: `local-harness`, `rusty-clawd`, and `copilot-sdk`, with `rusty-clawd` wired as a distinct session backend and `copilot-sdk` still aliased to the local harness implementation
 - builtin identities selectable at startup today: `simard-engineer`, `simard-meeting`, `simard-gym`, and the composite `simard-composite-engineer`
@@ -34,6 +35,7 @@ Today Simard provides:
 - `ManifestContract { entrypoint, composition, precedence, provenance, freshness }`
 - `ReflectionSnapshot { manifest_contract, runtime_node, mailbox_address, agent_program_backend, adapter_backend, topology_backend, transport_backend, supervisor_backend, memory_backend, evidence_backend }`
 - truthful memory and evidence backend descriptors
+- file-backed memory, evidence, and handoff stores on the bootstrap path, with persisted local state under the configured state root
 - truthful runtime service metadata from the runtime-selected wiring, including the injected agent program, handoff store, and the canonical backend identities behind each selected base type
 - persisted scratch, summary, and reflection text that records objective metadata instead of raw objective text
 - handoff snapshots that preserve runtime/session continuity while redacting the persisted session objective down to objective metadata
@@ -57,6 +59,7 @@ Those hooks enforce `cargo fmt --all -- --check`, `cargo clippy --all-targets --
 
 - `src/main.rs` is the thin CLI wrapper; `bootstrap::run_local_session` owns the run loop and `simard::bootstrap::assemble_local_runtime` remains the reflected assembly boundary
 - `src/bin/simard_gym.rs` is the operator-facing benchmark CLI for the starter gym suite
+- `bootstrap::run_local_session` now persists durable memory/evidence records and the latest handoff snapshot under the configured state root
 - defaults are startup choices, never silent runtime recovery
 - reflection metadata is derived from the active runtime wiring, not placeholder labels
 - post-stop `start()`, `run()`, and repeated `stop()` surface `SimardError::RuntimeStopped`

--- a/docs/reference/runtime-contracts.md
+++ b/docs/reference/runtime-contracts.md
@@ -60,6 +60,7 @@ Artifacts are written under `target/simard-gym/` as JSON and text reports.
 | --- | --- | --- | --- |
 | `SIMARD_PROMPT_ROOT` | Yes in `explicit-config` | none | Root directory for prompt assets. |
 | `SIMARD_OBJECTIVE` | Yes in `explicit-config` | none | Objective passed to `run()`. Live execution keeps the real objective in memory while persisted scratch, summary, reflection, and exported handoff session text store objective metadata instead of the raw objective text. |
+| `SIMARD_STATE_ROOT` | Yes in `explicit-config` | none in `explicit-config`; `target/simard-state` in `builtin-defaults` | Root directory for the durable local memory, evidence, and latest handoff snapshot files written by the bootstrap path. |
 | `SIMARD_BOOTSTRAP_MODE` | No | `explicit-config` | Startup mode. Accepted values: `explicit-config`, `builtin-defaults`. |
 | `SIMARD_IDENTITY` | Yes in `explicit-config` | none in `explicit-config`; `simard-engineer` in `builtin-defaults` | Identity to load before runtime composition. Non-UTF-8 values fail bootstrap instead of being treated as missing. |
 | `SIMARD_BASE_TYPE` | Yes in `explicit-config` | none in `explicit-config`; `local-harness` in `builtin-defaults` | Base type selected for the runtime request. Unsupported or unregistered choices fail explicitly. |
@@ -90,8 +91,8 @@ Notes:
 
 | Mode | Behavior |
 | --- | --- |
-| `explicit-config` | Requires prompt root, objective, identity, base type, and topology from configuration. |
-| `builtin-defaults` | Allows builtin prompt root, builtin objective, builtin identity, builtin base type (`local-harness`), and builtin topology (`single-process`), but only because startup opted in explicitly. |
+| `explicit-config` | Requires prompt root, objective, state root, identity, base type, and topology from configuration. |
+| `builtin-defaults` | Allows builtin prompt root, builtin objective, builtin state root (`target/simard-state`), builtin identity, builtin base type (`local-harness`), and builtin topology (`single-process`), but only because startup opted in explicitly. |
 
 ### Config value sources
 
@@ -109,6 +110,7 @@ This is the canonical non-default base-type example for the current scaffold:
 ```bash
 SIMARD_PROMPT_ROOT="$PWD/prompt_assets" \
 SIMARD_OBJECTIVE="inspect copilot-sdk bootstrap wiring" \
+SIMARD_STATE_ROOT="$PWD/target/simard-state" \
 SIMARD_IDENTITY="simard-engineer" \
 SIMARD_BASE_TYPE="copilot-sdk" \
 SIMARD_RUNTIME_TOPOLOGY="single-process" \
@@ -120,7 +122,7 @@ Expected output shape:
 ```text
 Simard local runtime executed successfully.
 Bootstrap mode: explicit-config
-Config sources: prompt_root=env:SIMARD_PROMPT_ROOT, objective=env:SIMARD_OBJECTIVE, base_type=env:SIMARD_BASE_TYPE, topology=env:SIMARD_RUNTIME_TOPOLOGY
+Config sources: prompt_root=env:SIMARD_PROMPT_ROOT, objective=env:SIMARD_OBJECTIVE, state_root=env:SIMARD_STATE_ROOT, base_type=env:SIMARD_BASE_TYPE, topology=env:SIMARD_RUNTIME_TOPOLOGY
 Bootstrap selection: identity=simard-engineer, base_type=copilot-sdk, topology=single-process
 Adapter implementation: local-harness
 ...
@@ -142,6 +144,7 @@ Simard keeps the live objective available while the run is executing, but persis
 - reflection summaries describe completion with objective metadata instead of raw objective text
 - persisted session summaries reuse sanitized plan and execution strings rather than copying the raw objective back out
 - exported handoff snapshots preserve the session boundary while replacing `RuntimeHandoffSnapshot.session.objective` with the same objective metadata string
+- bootstrap persists the latest exported handoff snapshot under `SIMARD_STATE_ROOT/latest_handoff.json`
 
 ## Identity metadata
 
@@ -177,10 +180,11 @@ identity:simard-engineer
 base-type:local-harness
 topology:single-process
 prompt-root:env:SIMARD_PROMPT_ROOT
+state-root:env:SIMARD_STATE_ROOT
 objective:env:SIMARD_OBJECTIVE
 ```
 
-If builtin defaults are used intentionally, the prompt-root and objective entries record `opt-in:SIMARD_BOOTSTRAP_MODE`.
+If builtin defaults are used intentionally, the prompt-root, state-root, and objective entries record `opt-in:SIMARD_BOOTSTRAP_MODE`.
 
 ## Provenance and freshness
 
@@ -364,7 +368,7 @@ Reflection rules:
 | --- | --- |
 | `PromptAssetMissing` | A referenced prompt asset was not found. |
 | `PromptAssetRead` | A prompt asset could not be read. |
-| `StoragePoisoned` | An in-memory store lock was poisoned. |
+| `StoragePoisoned` | A durable store lock was poisoned before Simard could read or persist state. |
 ## Example: truthful fields
 
 ```rust
@@ -382,12 +386,13 @@ assert_eq!(snapshot.manifest_contract.freshness.state, FreshnessState::Current);
 assert_eq!(snapshot.runtime_node.to_string(), "node-local");
 assert_eq!(snapshot.mailbox_address.to_string(), "inmemory://node-local");
 assert_eq!(snapshot.agent_program_backend.identity, "agent-program::objective-relay");
-assert_eq!(snapshot.handoff_backend.identity, "handoff::in-memory");
+assert_eq!(snapshot.handoff_backend.identity, "handoff::json-file-store");
 assert_eq!(snapshot.adapter_backend.identity, "local-harness");
 assert_eq!(snapshot.topology_backend.identity, "topology::in-process");
 assert_eq!(snapshot.transport_backend.identity, "transport::in-memory-mailbox");
 assert_eq!(snapshot.supervisor_backend.identity, "supervisor::in-process");
-assert_eq!(snapshot.memory_backend.identity, "memory::session-cache");
+assert_eq!(snapshot.memory_backend.identity, "memory::json-file-store");
+assert_eq!(snapshot.evidence_backend.identity, "evidence::json-file-store");
 ```
 
 ## See also

--- a/docs/tutorials/run-your-first-local-session.md
+++ b/docs/tutorials/run-your-first-local-session.md
@@ -30,13 +30,14 @@ This tutorial follows the runtime path that exists in the repository today.
 
 ## Step 1: Run the current local runtime with explicit configuration
 
-From the repository root, start Simard with a real prompt asset directory and an explicit objective.
+From the repository root, start Simard with a real prompt asset directory, an explicit objective, and an explicit durable state root.
 
 For the builtin identities in this repo, you can currently choose `local-harness`, `rusty-clawd`, or `copilot-sdk` here. `rusty-clawd` is a distinct backend, while `copilot-sdk` remains an explicit alias of the local harness implementation. The default bootstrap path still opts into `single-process`, but the runtime can now inject a loopback `multi-process` topology when you request a supported pairing such as `rusty-clawd + multi-process`.
 
 ```bash
 SIMARD_PROMPT_ROOT="$PWD/prompt_assets" \
 SIMARD_OBJECTIVE="exercise the local runtime" \
+SIMARD_STATE_ROOT="$PWD/target/simard-state" \
 SIMARD_IDENTITY="simard-engineer" \
 SIMARD_BASE_TYPE="local-harness" \
 SIMARD_RUNTIME_TOPOLOGY="single-process" \
@@ -48,8 +49,9 @@ You should see output shaped like this:
 ```text
 Simard local runtime executed successfully.
 Bootstrap mode: explicit-config
-Config sources: prompt_root=env:SIMARD_PROMPT_ROOT, objective=env:SIMARD_OBJECTIVE, base_type=env:SIMARD_BASE_TYPE, topology=env:SIMARD_RUNTIME_TOPOLOGY
+Config sources: prompt_root=env:SIMARD_PROMPT_ROOT, objective=env:SIMARD_OBJECTIVE, state_root=env:SIMARD_STATE_ROOT, base_type=env:SIMARD_BASE_TYPE, topology=env:SIMARD_RUNTIME_TOPOLOGY
 Bootstrap selection: identity=simard-engineer, base_type=local-harness, topology=single-process
+State root: /.../target/simard-state
 Snapshot: state=ready, topology=single-process, base_type=local-harness
 Adapter implementation: local-harness
 Shutdown: stopped
@@ -64,6 +66,7 @@ Run the same bootstrap path again, but select `copilot-sdk` explicitly.
 ```bash
 SIMARD_PROMPT_ROOT="$PWD/prompt_assets" \
 SIMARD_OBJECTIVE="exercise the copilot-sdk runtime path" \
+SIMARD_STATE_ROOT="$PWD/target/simard-state" \
 SIMARD_IDENTITY="simard-engineer" \
 SIMARD_BASE_TYPE="copilot-sdk" \
 SIMARD_RUNTIME_TOPOLOGY="single-process" \
@@ -122,6 +125,7 @@ You should see:
 - `Bootstrap mode: builtin-defaults`
 - `prompt_root=opt-in:SIMARD_BOOTSTRAP_MODE`
 - `objective=opt-in:SIMARD_BOOTSTRAP_MODE`
+- `state_root=opt-in:SIMARD_BOOTSTRAP_MODE`
 - `base_type=opt-in:SIMARD_BOOTSTRAP_MODE`
 - `topology=opt-in:SIMARD_BOOTSTRAP_MODE`
 - the builtin identity `simard-engineer`
@@ -171,9 +175,11 @@ assert_eq!(snapshot.manifest_contract.freshness.state, FreshnessState::Current);
 assert_eq!(snapshot.runtime_node.to_string(), "node-local");
 assert_eq!(snapshot.mailbox_address.to_string(), "inmemory://node-local");
 assert_eq!(snapshot.agent_program_backend.identity, "agent-program::objective-relay");
-assert_eq!(snapshot.handoff_backend.identity, "handoff::in-memory");
+assert_eq!(snapshot.handoff_backend.identity, "handoff::json-file-store");
 assert_eq!(snapshot.adapter_backend.identity, "local-harness");
 assert_eq!(snapshot.transport_backend.identity, "transport::in-memory-mailbox");
+assert_eq!(snapshot.memory_backend.identity, "memory::json-file-store");
+assert_eq!(snapshot.evidence_backend.identity, "evidence::json-file-store");
 ```
 
 If you launched with `SIMARD_BASE_TYPE="copilot-sdk"`, `snapshot.selected_base_type` still shows the explicit selection while `snapshot.adapter_backend.identity` remains `local-harness`. If you launched with `SIMARD_BASE_TYPE="rusty-clawd"`, reflection now reports `rusty-clawd::session-backend`. The runtime-side wiring is explicit too: single-process runs report `node-local` / `inmemory://node-local`, while loopback multi-process runs report `node-loopback-mesh` / `loopback://node-loopback-mesh`. Composite identities also expose `snapshot.identity_components`.
@@ -188,6 +194,7 @@ You now know:
 - how composite identities surface their assembled components explicitly
 - how loopback multi-process execution reuses the same runtime contracts
 - how opt-in defaults are recorded
+- how the bootstrap path persists durable local state under the configured state root
 - how reflection reports truthful runtime metadata
 - how stop semantics behave after shutdown
 

--- a/src/base_types.rs
+++ b/src/base_types.rs
@@ -1,6 +1,8 @@
 use std::collections::BTreeSet;
 use std::fmt::{self, Display, Formatter};
 
+use serde::{Deserialize, Serialize};
+
 use crate::error::{SimardError, SimardResult};
 use crate::identity::OperatingMode;
 use crate::metadata::{BackendDescriptor, Freshness};
@@ -9,7 +11,7 @@ use crate::runtime::{RuntimeAddress, RuntimeNodeId, RuntimeTopology};
 use crate::sanitization::objective_metadata;
 use crate::session::SessionId;
 
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub struct BaseTypeId(String);
 
 impl BaseTypeId {

--- a/src/bin/simard_operator_probe.rs
+++ b/src/bin/simard_operator_probe.rs
@@ -1,12 +1,8 @@
 use std::path::PathBuf;
-use std::sync::Arc;
 
 use simard::{
-    BootstrapConfig, BootstrapInputs, BuiltinIdentityLoader, CoordinatedSupervisor,
-    FilePromptAssetStore, IdentityLoadRequest, IdentityLoader, InMemoryEvidenceStore,
-    InMemoryMemoryStore, LoopbackMailboxTransport, LoopbackMeshTopologyDriver, ManifestContract,
-    Provenance, ReflectiveRuntime, RuntimePorts, RuntimeRequest, RuntimeTopology,
-    UuidSessionIdGenerator, bootstrap_entrypoint, builtin_base_type_registry_for_manifest,
+    BootstrapConfig, BootstrapInputs, ReflectiveRuntime, assemble_local_runtime_from_handoff,
+    latest_local_handoff,
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -38,6 +34,15 @@ fn prompt_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("prompt_assets")
 }
 
+fn state_root(identity: &str, base_type: &str, topology: &str, probe: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("target/operator-probe-state")
+        .join(probe)
+        .join(identity)
+        .join(base_type)
+        .join(topology)
+}
+
 fn run_bootstrap_probe(
     identity: &str,
     base_type: &str,
@@ -47,6 +52,7 @@ fn run_bootstrap_probe(
     let config = BootstrapConfig::resolve(BootstrapInputs {
         prompt_root: Some(prompt_root()),
         objective: Some(objective.to_string()),
+        state_root: Some(state_root(identity, base_type, topology, "bootstrap-run")),
         identity: Some(identity.to_string()),
         base_type: Some(base_type.to_string()),
         topology: Some(topology.to_string()),
@@ -81,6 +87,7 @@ fn run_bootstrap_probe(
         "Transport backend: {}",
         execution.snapshot.transport_backend.identity
     );
+    println!("State root: {}", config.state_root_path().display());
     println!("Session phase: {}", execution.outcome.session.phase);
     println!("Shutdown: {}", execution.stopped_snapshot.runtime_state);
     println!("Execution summary: {}", execution.outcome.execution_summary);
@@ -97,52 +104,28 @@ fn run_handoff_probe(
     topology: &str,
     objective: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let topology = parse_topology(topology)?;
-    let contract = ManifestContract::new(
-        bootstrap_entrypoint(),
-        "bootstrap-config -> identity-loader -> runtime-ports -> local-runtime",
-        vec![
-            "probe:handoff-roundtrip".to_string(),
-            format!("identity:{identity}"),
-            format!("base-type:{base_type}"),
-            format!("topology:{topology}"),
-        ],
-        Provenance::new("probe", "simard_operator_probe"),
-        simard::Freshness::now()?,
-    )?;
-    let manifest = BuiltinIdentityLoader.load(&IdentityLoadRequest::new(
-        identity.to_string(),
-        env!("CARGO_PKG_VERSION"),
-        contract,
-    ))?;
-    let request = RuntimeRequest::new(
-        manifest.clone(),
-        simard::BaseTypeId::new(base_type),
-        topology,
-    );
+    let config = BootstrapConfig::resolve(BootstrapInputs {
+        prompt_root: Some(prompt_root()),
+        objective: Some(objective.to_string()),
+        state_root: Some(state_root(
+            identity,
+            base_type,
+            topology,
+            "handoff-roundtrip",
+        )),
+        identity: Some(identity.to_string()),
+        base_type: Some(base_type.to_string()),
+        topology: Some(topology.to_string()),
+        ..BootstrapInputs::default()
+    })?;
 
-    let mut runtime = simard::LocalRuntime::compose(
-        assemble_loopback_ports(
-            Arc::new(FilePromptAssetStore::new(prompt_root())),
-            builtin_base_type_registry_for_manifest(&manifest)?,
-        )?,
-        request.clone(),
-    )?;
-    runtime.start()?;
-    let outcome = runtime.run(objective.to_string())?;
-    let exported = runtime.export_handoff()?;
-
-    let restored = simard::LocalRuntime::compose_from_handoff(
-        assemble_loopback_ports(
-            Arc::new(FilePromptAssetStore::new(prompt_root())),
-            builtin_base_type_registry_for_manifest(&manifest)?,
-        )?,
-        request,
-        exported.clone(),
-    )?;
+    let execution = simard::run_local_session(&config)?;
+    let exported = latest_local_handoff(&config)?.ok_or("expected durable handoff snapshot")?;
+    let restored = assemble_local_runtime_from_handoff(&config, exported.clone())?;
     let restored_snapshot = restored.snapshot()?;
 
     println!("Probe mode: handoff-roundtrip");
+    println!("State root: {}", config.state_root_path().display());
     println!("Identity: {}", restored_snapshot.identity_name);
     println!(
         "Identity components: {}",
@@ -184,31 +167,6 @@ fn run_handoff_probe(
         "Restored transport backend: {}",
         restored_snapshot.transport_backend.identity
     );
-    println!("Execution summary: {}", outcome.execution_summary);
+    println!("Execution summary: {}", execution.outcome.execution_summary);
     Ok(())
-}
-
-fn assemble_loopback_ports(
-    prompt_store: Arc<FilePromptAssetStore>,
-    base_types: simard::BaseTypeRegistry,
-) -> Result<RuntimePorts, Box<dyn std::error::Error>> {
-    Ok(RuntimePorts::with_runtime_services(
-        prompt_store,
-        Arc::new(InMemoryMemoryStore::try_default()?),
-        Arc::new(InMemoryEvidenceStore::try_default()?),
-        base_types,
-        Arc::new(LoopbackMeshTopologyDriver::try_default()?),
-        Arc::new(LoopbackMailboxTransport::try_default()?),
-        Arc::new(CoordinatedSupervisor::try_default()?),
-        Arc::new(UuidSessionIdGenerator),
-    ))
-}
-
-fn parse_topology(value: &str) -> Result<RuntimeTopology, Box<dyn std::error::Error>> {
-    match value {
-        "single-process" => Ok(RuntimeTopology::SingleProcess),
-        "multi-process" => Ok(RuntimeTopology::MultiProcess),
-        "distributed" => Ok(RuntimeTopology::Distributed),
-        other => Err(format!("unsupported topology '{other}'").into()),
-    }
 }

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -1,17 +1,20 @@
 use std::ffi::OsString;
 use std::fmt::{self, Display, Formatter};
+use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use crate::agent_program::ObjectiveRelayProgram;
 use crate::base_types::{BaseTypeId, LocalProcessHarnessAdapter, RustyClawdAdapter};
 use crate::error::{SimardError, SimardResult};
-use crate::evidence::InMemoryEvidenceStore;
+use crate::evidence::{EvidenceStore, FileBackedEvidenceStore};
+use crate::handoff::{FileBackedHandoffStore, RuntimeHandoffSnapshot, RuntimeHandoffStore};
 use crate::identity::{
     BuiltinIdentityLoader, IdentityLoadRequest, IdentityLoader, IdentityManifest, ManifestContract,
 };
-use crate::memory::InMemoryMemoryStore;
+use crate::memory::{FileBackedMemoryStore, MemoryStore};
 use crate::metadata::{Freshness, Provenance};
-use crate::prompt_assets::FilePromptAssetStore;
+use crate::prompt_assets::{FilePromptAssetStore, PromptAssetStore};
 use crate::reflection::{ReflectionSnapshot, ReflectiveRuntime};
 use crate::runtime::{
     BaseTypeRegistry, CoordinatedSupervisor, LocalRuntime, LoopbackMailboxTransport,
@@ -21,6 +24,7 @@ use crate::session::UuidSessionIdGenerator;
 
 const DEFAULT_IDENTITY: &str = "simard-engineer";
 const DEFAULT_OBJECTIVE: &str = "bootstrap the Simard engineer loop";
+const DEFAULT_STATE_ROOT: &str = "target/simard-state";
 const LOCAL_BASE_TYPE: &str = "local-harness";
 const RUSTY_CLAWD_BASE_TYPE: &str = "rusty-clawd";
 const COPILOT_SDK_BASE_TYPE: &str = "copilot-sdk";
@@ -81,6 +85,7 @@ pub struct ConfigValue<T> {
 pub struct BootstrapInputs {
     pub prompt_root: Option<PathBuf>,
     pub objective: Option<String>,
+    pub state_root: Option<PathBuf>,
     pub mode: Option<String>,
     pub identity: Option<String>,
     pub base_type: Option<String>,
@@ -92,6 +97,7 @@ impl BootstrapInputs {
         Ok(Self {
             prompt_root: std::env::var_os("SIMARD_PROMPT_ROOT").map(PathBuf::from),
             objective: read_optional_utf8_env("SIMARD_OBJECTIVE")?,
+            state_root: std::env::var_os("SIMARD_STATE_ROOT").map(PathBuf::from),
             mode: read_optional_utf8_env("SIMARD_BOOTSTRAP_MODE")?,
             identity: read_optional_utf8_env("SIMARD_IDENTITY")?,
             base_type: read_optional_utf8_env("SIMARD_BASE_TYPE")?,
@@ -106,6 +112,7 @@ pub struct BootstrapConfig {
     pub identity: String,
     pub prompt_root: ConfigValue<PathBuf>,
     pub objective: ConfigValue<String>,
+    pub state_root: ConfigValue<PathBuf>,
     pub selected_base_type: ConfigValue<BaseTypeId>,
     pub topology: ConfigValue<RuntimeTopology>,
 }
@@ -160,7 +167,6 @@ impl BootstrapConfig {
                 });
             }
         };
-
         let selected_base_type = match inputs.base_type {
             Some(value) => ConfigValue {
                 value: BaseTypeId::new(value),
@@ -197,6 +203,23 @@ impl BootstrapConfig {
                 });
             }
         };
+        let state_root = match inputs.state_root {
+            Some(path) => ConfigValue {
+                value: path,
+                source: ConfigValueSource::Environment("SIMARD_STATE_ROOT"),
+            },
+            None if mode == BootstrapMode::BuiltinDefaults => ConfigValue {
+                value: PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(DEFAULT_STATE_ROOT),
+                source: ConfigValueSource::ExplicitOptIn("SIMARD_BOOTSTRAP_MODE"),
+            },
+            None => {
+                return Err(SimardError::MissingRequiredConfig {
+                    key: "SIMARD_STATE_ROOT".to_string(),
+                    help: "set SIMARD_STATE_ROOT or opt in with SIMARD_BOOTSTRAP_MODE=builtin-defaults"
+                        .to_string(),
+                });
+            }
+        };
 
         Ok(Self {
             mode,
@@ -214,6 +237,7 @@ impl BootstrapConfig {
             },
             prompt_root,
             objective,
+            state_root,
             selected_base_type,
             topology,
         })
@@ -226,6 +250,7 @@ impl BootstrapConfig {
             format!("base-type:{}", self.selected_base_type.value),
             format!("topology:{}", self.topology.value),
             format!("prompt-root:{}", self.prompt_root.source),
+            format!("state-root:{}", self.state_root.source),
             format!("objective:{}", self.objective.source),
         ]
     }
@@ -233,8 +258,13 @@ impl BootstrapConfig {
 
 pub fn assemble_local_runtime(config: &BootstrapConfig) -> SimardResult<LocalRuntime> {
     let prompt_store = Arc::new(FilePromptAssetStore::new(config.prompt_root.value.clone()));
-    let memory_store = Arc::new(InMemoryMemoryStore::try_default()?);
-    let evidence_store = Arc::new(InMemoryEvidenceStore::try_default()?);
+    let memory_store = Arc::new(FileBackedMemoryStore::try_new(config.memory_store_path())?);
+    let evidence_store = Arc::new(FileBackedEvidenceStore::try_new(
+        config.evidence_store_path(),
+    )?);
+    let handoff_store = Arc::new(FileBackedHandoffStore::try_new(
+        config.handoff_store_path(),
+    )?);
 
     let contract = ManifestContract::new(
         bootstrap_entrypoint(),
@@ -265,10 +295,61 @@ pub fn assemble_local_runtime(config: &BootstrapConfig) -> SimardResult<LocalRun
             prompt_store,
             memory_store,
             evidence_store,
+            handoff_store,
             base_types,
             config.topology.value,
         )?,
         request,
+    )
+}
+
+pub fn assemble_local_runtime_from_handoff(
+    config: &BootstrapConfig,
+    snapshot: RuntimeHandoffSnapshot,
+) -> SimardResult<LocalRuntime> {
+    let prompt_store = Arc::new(FilePromptAssetStore::new(config.prompt_root.value.clone()));
+    let memory_store = Arc::new(FileBackedMemoryStore::try_new(config.memory_store_path())?);
+    let evidence_store = Arc::new(FileBackedEvidenceStore::try_new(
+        config.evidence_store_path(),
+    )?);
+    let handoff_store = Arc::new(FileBackedHandoffStore::try_new(
+        config.handoff_store_path(),
+    )?);
+
+    let contract = ManifestContract::new(
+        bootstrap_entrypoint(),
+        "bootstrap-config -> identity-loader -> runtime-ports -> local-runtime",
+        config.manifest_precedence(),
+        Provenance::new(
+            "bootstrap",
+            format!("{}:{}", bootstrap_entrypoint(), config.identity),
+        ),
+        Freshness::now()?,
+    )?;
+
+    let manifest = BuiltinIdentityLoader.load(&IdentityLoadRequest::new(
+        config.identity.clone(),
+        env!("CARGO_PKG_VERSION"),
+        contract,
+    ))?;
+    let base_types = builtin_base_type_registry_for_manifest(&manifest)?;
+    let request = RuntimeRequest::new(
+        manifest,
+        config.selected_base_type.value.clone(),
+        config.topology.value,
+    );
+
+    LocalRuntime::compose_from_handoff(
+        runtime_ports_for_topology(
+            prompt_store,
+            memory_store,
+            evidence_store,
+            handoff_store,
+            base_types,
+            config.topology.value,
+        )?,
+        request,
+        snapshot,
     )
 }
 
@@ -277,6 +358,7 @@ pub fn run_local_session(config: &BootstrapConfig) -> SimardResult<LocalSessionE
     runtime.start()?;
 
     let outcome = runtime.run(config.objective.value.clone())?;
+    let _ = runtime.export_handoff()?;
     let snapshot = runtime.snapshot()?;
     runtime.stop()?;
     let stopped_snapshot = runtime.snapshot()?;
@@ -286,6 +368,12 @@ pub fn run_local_session(config: &BootstrapConfig) -> SimardResult<LocalSessionE
         snapshot,
         stopped_snapshot,
     })
+}
+
+pub fn latest_local_handoff(
+    config: &BootstrapConfig,
+) -> SimardResult<Option<RuntimeHandoffSnapshot>> {
+    FileBackedHandoffStore::try_new(config.handoff_store_path())?.latest()
 }
 
 pub fn bootstrap_entrypoint() -> &'static str {
@@ -332,22 +420,28 @@ pub fn builtin_base_type_registry_for_manifest(
 }
 
 fn runtime_ports_for_topology(
-    prompt_store: Arc<FilePromptAssetStore>,
-    memory_store: Arc<InMemoryMemoryStore>,
-    evidence_store: Arc<InMemoryEvidenceStore>,
+    prompt_store: Arc<dyn PromptAssetStore>,
+    memory_store: Arc<dyn MemoryStore>,
+    evidence_store: Arc<dyn EvidenceStore>,
+    handoff_store: Arc<dyn RuntimeHandoffStore>,
     base_types: BaseTypeRegistry,
     topology: RuntimeTopology,
 ) -> SimardResult<RuntimePorts> {
     match topology {
-        RuntimeTopology::SingleProcess => Ok(RuntimePorts::new(
+        RuntimeTopology::SingleProcess => Ok(RuntimePorts::with_runtime_services_and_program(
             prompt_store,
             memory_store,
             evidence_store,
             base_types,
+            Arc::new(crate::runtime::InProcessTopologyDriver::try_default()?),
+            Arc::new(crate::runtime::InMemoryMailboxTransport::try_default()?),
+            Arc::new(crate::runtime::InProcessSupervisor::try_default()?),
+            Arc::new(ObjectiveRelayProgram::try_default()?),
+            handoff_store,
             Arc::new(UuidSessionIdGenerator),
         )),
         RuntimeTopology::MultiProcess | RuntimeTopology::Distributed => {
-            Ok(RuntimePorts::with_runtime_services(
+            Ok(RuntimePorts::with_runtime_services_and_program(
                 prompt_store,
                 memory_store,
                 evidence_store,
@@ -355,9 +449,29 @@ fn runtime_ports_for_topology(
                 Arc::new(LoopbackMeshTopologyDriver::try_default()?),
                 Arc::new(LoopbackMailboxTransport::try_default()?),
                 Arc::new(CoordinatedSupervisor::try_default()?),
+                Arc::new(ObjectiveRelayProgram::try_default()?),
+                handoff_store,
                 Arc::new(UuidSessionIdGenerator),
             ))
         }
+    }
+}
+
+impl BootstrapConfig {
+    pub fn memory_store_path(&self) -> PathBuf {
+        self.state_root.value.join("memory_records.json")
+    }
+
+    pub fn evidence_store_path(&self) -> PathBuf {
+        self.state_root.value.join("evidence_records.json")
+    }
+
+    pub fn handoff_store_path(&self) -> PathBuf {
+        self.state_root.value.join("latest_handoff.json")
+    }
+
+    pub fn state_root_path(&self) -> &Path {
+        &self.state_root.value
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -104,6 +104,12 @@ pub enum SimardError {
         field: String,
         reason: String,
     },
+    PersistentStoreIo {
+        store: String,
+        action: String,
+        path: PathBuf,
+        reason: String,
+    },
     BenchmarkScenarioNotFound {
         scenario_id: String,
     },
@@ -238,6 +244,15 @@ impl Display for SimardError {
             Self::InvalidHandoffSnapshot { field, reason } => {
                 write!(f, "invalid handoff snapshot field '{field}': {reason}")
             }
+            Self::PersistentStoreIo {
+                store,
+                action,
+                path: _,
+                reason,
+            } => write!(
+                f,
+                "persistent store '{store}' failed during '{action}': {reason}"
+            ),
             Self::BenchmarkScenarioNotFound { scenario_id } => {
                 write!(f, "benchmark scenario '{scenario_id}' is not registered")
             }

--- a/src/evidence.rs
+++ b/src/evidence.rs
@@ -1,17 +1,23 @@
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
+
+use serde::{Deserialize, Serialize};
 
 use crate::base_types::BaseTypeId;
 use crate::error::{SimardError, SimardResult};
 use crate::metadata::{BackendDescriptor, Freshness};
+use crate::persistence::{load_json_or_default, persist_json};
 use crate::session::{SessionId, SessionPhase};
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+const EVIDENCE_STORE_NAME: &str = "evidence";
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum EvidenceSource {
     Runtime,
     BaseType(BaseTypeId),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct EvidenceRecord {
     pub id: String,
     pub session_id: SessionId,
@@ -53,6 +59,44 @@ impl InMemoryEvidenceStore {
     }
 }
 
+#[derive(Debug)]
+pub struct FileBackedEvidenceStore {
+    records: Mutex<Vec<EvidenceRecord>>,
+    path: PathBuf,
+    descriptor: BackendDescriptor,
+}
+
+impl FileBackedEvidenceStore {
+    pub fn new(path: impl Into<PathBuf>, descriptor: BackendDescriptor) -> SimardResult<Self> {
+        let path = path.into();
+        Ok(Self {
+            records: Mutex::new(load_json_or_default(EVIDENCE_STORE_NAME, &path)?),
+            path,
+            descriptor,
+        })
+    }
+
+    pub fn try_new(path: impl Into<PathBuf>) -> SimardResult<Self> {
+        let path = path.into();
+        Self::new(
+            path,
+            BackendDescriptor::for_runtime_type::<Self>(
+                "evidence::json-file-store",
+                "runtime-port:evidence-store:file-json",
+                Freshness::now()?,
+            ),
+        )
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn persist(&self, records: &[EvidenceRecord]) -> SimardResult<()> {
+        persist_json(EVIDENCE_STORE_NAME, &self.path, &records)
+    }
+}
+
 impl EvidenceStore for InMemoryEvidenceStore {
     fn descriptor(&self) -> BackendDescriptor {
         self.descriptor.clone()
@@ -87,6 +131,52 @@ impl EvidenceStore for InMemoryEvidenceStore {
             .lock()
             .map_err(|_| SimardError::StoragePoisoned {
                 store: "evidence".to_string(),
+            })?
+            .iter()
+            .filter(|record| &record.session_id == session_id)
+            .count())
+    }
+}
+
+impl EvidenceStore for FileBackedEvidenceStore {
+    fn descriptor(&self) -> BackendDescriptor {
+        self.descriptor.clone()
+    }
+
+    fn record(&self, record: EvidenceRecord) -> SimardResult<()> {
+        let mut records = self
+            .records
+            .lock()
+            .map_err(|_| SimardError::StoragePoisoned {
+                store: EVIDENCE_STORE_NAME.to_string(),
+            })?;
+        if let Some(existing) = records.iter_mut().find(|existing| existing.id == record.id) {
+            *existing = record;
+        } else {
+            records.push(record);
+        }
+        self.persist(&records)
+    }
+
+    fn list_for_session(&self, session_id: &SessionId) -> SimardResult<Vec<EvidenceRecord>> {
+        Ok(self
+            .records
+            .lock()
+            .map_err(|_| SimardError::StoragePoisoned {
+                store: EVIDENCE_STORE_NAME.to_string(),
+            })?
+            .iter()
+            .filter(|record| &record.session_id == session_id)
+            .cloned()
+            .collect())
+    }
+
+    fn count_for_session(&self, session_id: &SessionId) -> SimardResult<usize> {
+        Ok(self
+            .records
+            .lock()
+            .map_err(|_| SimardError::StoragePoisoned {
+                store: EVIDENCE_STORE_NAME.to_string(),
             })?
             .iter()
             .filter(|record| &record.session_id == session_id)

--- a/src/handoff.rs
+++ b/src/handoff.rs
@@ -1,14 +1,20 @@
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
+
+use serde::{Deserialize, Serialize};
 
 use crate::base_types::BaseTypeId;
 use crate::error::{SimardError, SimardResult};
 use crate::evidence::EvidenceRecord;
 use crate::memory::MemoryRecord;
 use crate::metadata::{BackendDescriptor, Freshness};
+use crate::persistence::{load_json_or_default, persist_json};
 use crate::runtime::{RuntimeAddress, RuntimeNodeId, RuntimeState, RuntimeTopology};
 use crate::session::SessionRecord;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+const HANDOFF_STORE_NAME: &str = "handoff";
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct RuntimeHandoffSnapshot {
     pub exported_state: RuntimeState,
     pub identity_name: String,
@@ -52,6 +58,44 @@ impl InMemoryHandoffStore {
     }
 }
 
+#[derive(Debug)]
+pub struct FileBackedHandoffStore {
+    state: Mutex<Option<RuntimeHandoffSnapshot>>,
+    path: PathBuf,
+    descriptor: BackendDescriptor,
+}
+
+impl FileBackedHandoffStore {
+    pub fn new(path: impl Into<PathBuf>, descriptor: BackendDescriptor) -> SimardResult<Self> {
+        let path = path.into();
+        Ok(Self {
+            state: Mutex::new(load_json_or_default(HANDOFF_STORE_NAME, &path)?),
+            path,
+            descriptor,
+        })
+    }
+
+    pub fn try_new(path: impl Into<PathBuf>) -> SimardResult<Self> {
+        let path = path.into();
+        Self::new(
+            path,
+            BackendDescriptor::for_runtime_type::<Self>(
+                "handoff::json-file-store",
+                "runtime-port:handoff-store:file-json",
+                Freshness::now()?,
+            ),
+        )
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn persist(&self, snapshot: &Option<RuntimeHandoffSnapshot>) -> SimardResult<()> {
+        persist_json(HANDOFF_STORE_NAME, &self.path, snapshot)
+    }
+}
+
 impl RuntimeHandoffStore for InMemoryHandoffStore {
     fn descriptor(&self) -> BackendDescriptor {
         self.descriptor.clone()
@@ -74,6 +118,33 @@ impl RuntimeHandoffStore for InMemoryHandoffStore {
             .lock()
             .map_err(|_| SimardError::StoragePoisoned {
                 store: "handoff".to_string(),
+            })?;
+        Ok(state.clone())
+    }
+}
+
+impl RuntimeHandoffStore for FileBackedHandoffStore {
+    fn descriptor(&self) -> BackendDescriptor {
+        self.descriptor.clone()
+    }
+
+    fn save(&self, snapshot: RuntimeHandoffSnapshot) -> SimardResult<()> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| SimardError::StoragePoisoned {
+                store: HANDOFF_STORE_NAME.to_string(),
+            })?;
+        *state = Some(snapshot);
+        self.persist(&state)
+    }
+
+    fn latest(&self) -> SimardResult<Option<RuntimeHandoffSnapshot>> {
+        let state = self
+            .state
+            .lock()
+            .map_err(|_| SimardError::StoragePoisoned {
+                store: HANDOFF_STORE_NAME.to_string(),
             })?;
         Ok(state.clone())
     }

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -1,13 +1,16 @@
 use std::collections::BTreeSet;
 use std::fmt::{self, Display, Formatter};
 
+use serde::{Deserialize, Serialize};
+
 use crate::base_types::{BaseTypeCapability, BaseTypeId, capability_set};
 use crate::error::{SimardError, SimardResult};
 use crate::memory::MemoryScope;
 use crate::metadata::{Freshness, Provenance};
 use crate::prompt_assets::PromptAssetRef;
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum OperatingMode {
     Engineer,
     Meeting,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod handoff;
 pub mod identity;
 pub mod memory;
 pub mod metadata;
+mod persistence;
 pub mod prompt_assets;
 pub mod reflection;
 pub mod runtime;
@@ -22,22 +23,29 @@ pub use base_types::{
 };
 pub use bootstrap::{
     BootstrapConfig, BootstrapInputs, BootstrapMode, ConfigValue, ConfigValueSource,
-    LocalSessionExecution, assemble_local_runtime, bootstrap_entrypoint,
-    builtin_base_type_registry_for_manifest, run_local_session,
+    LocalSessionExecution, assemble_local_runtime, assemble_local_runtime_from_handoff,
+    bootstrap_entrypoint, builtin_base_type_registry_for_manifest, latest_local_handoff,
+    run_local_session,
 };
 pub use error::{SimardError, SimardResult};
-pub use evidence::{EvidenceRecord, EvidenceSource, EvidenceStore, InMemoryEvidenceStore};
+pub use evidence::{
+    EvidenceRecord, EvidenceSource, EvidenceStore, FileBackedEvidenceStore, InMemoryEvidenceStore,
+};
 pub use gym::{
     BenchmarkArtifactPaths, BenchmarkCheckResult, BenchmarkRunReport, BenchmarkScenario,
     BenchmarkSuiteReport, BenchmarkSuiteScenarioSummary, benchmark_scenarios, default_output_root,
     run_benchmark_scenario, run_benchmark_suite,
 };
-pub use handoff::{InMemoryHandoffStore, RuntimeHandoffSnapshot, RuntimeHandoffStore};
+pub use handoff::{
+    FileBackedHandoffStore, InMemoryHandoffStore, RuntimeHandoffSnapshot, RuntimeHandoffStore,
+};
 pub use identity::{
     BuiltinIdentityLoader, IdentityLoadRequest, IdentityLoader, IdentityManifest, ManifestContract,
     MemoryPolicy, OperatingMode,
 };
-pub use memory::{InMemoryMemoryStore, MemoryRecord, MemoryScope, MemoryStore};
+pub use memory::{
+    FileBackedMemoryStore, InMemoryMemoryStore, MemoryRecord, MemoryScope, MemoryStore,
+};
 pub use metadata::{BackendDescriptor, Freshness, FreshnessState, Provenance};
 pub use prompt_assets::{
     FilePromptAssetStore, InMemoryPromptAssetStore, PromptAsset, PromptAssetId, PromptAssetRef,

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,9 +7,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Simard local runtime executed successfully.");
     println!("Bootstrap mode: {}", config.mode);
     println!(
-        "Config sources: prompt_root={}, objective={}, base_type={}, topology={}",
+        "Config sources: prompt_root={}, objective={}, state_root={}, base_type={}, topology={}",
         config.prompt_root.source,
         config.objective.source,
+        config.state_root.source,
         config.selected_base_type.source,
         config.topology.source
     );
@@ -17,6 +18,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "Bootstrap selection: identity={}, base_type={}, topology={}",
         config.identity, config.selected_base_type.value, config.topology.value
     );
+    println!("State root: {}", config.state_root.value.display());
     if !execution.snapshot.identity_components.is_empty() {
         println!(
             "Identity components: {}",

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,10 +1,17 @@
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
+
+use serde::{Deserialize, Serialize};
 
 use crate::error::{SimardError, SimardResult};
 use crate::metadata::{BackendDescriptor, Freshness};
+use crate::persistence::{load_json_or_default, persist_json};
 use crate::session::{SessionId, SessionPhase};
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+const MEMORY_STORE_NAME: &str = "memory";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum MemoryScope {
     SessionScratch,
     SessionSummary,
@@ -12,7 +19,7 @@ pub enum MemoryScope {
     Benchmark,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct MemoryRecord {
     pub key: String,
     pub scope: MemoryScope,
@@ -53,6 +60,44 @@ impl InMemoryMemoryStore {
             "runtime-port:memory-store",
             Freshness::now()?,
         )))
+    }
+}
+
+#[derive(Debug)]
+pub struct FileBackedMemoryStore {
+    records: Mutex<Vec<MemoryRecord>>,
+    path: PathBuf,
+    descriptor: BackendDescriptor,
+}
+
+impl FileBackedMemoryStore {
+    pub fn new(path: impl Into<PathBuf>, descriptor: BackendDescriptor) -> SimardResult<Self> {
+        let path = path.into();
+        Ok(Self {
+            records: Mutex::new(load_json_or_default(MEMORY_STORE_NAME, &path)?),
+            path,
+            descriptor,
+        })
+    }
+
+    pub fn try_new(path: impl Into<PathBuf>) -> SimardResult<Self> {
+        let path = path.into();
+        Self::new(
+            path,
+            BackendDescriptor::for_runtime_type::<Self>(
+                "memory::json-file-store",
+                "runtime-port:memory-store:file-json",
+                Freshness::now()?,
+            ),
+        )
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn persist(&self, records: &[MemoryRecord]) -> SimardResult<()> {
+        persist_json(MEMORY_STORE_NAME, &self.path, &records)
     }
 }
 
@@ -103,6 +148,68 @@ impl MemoryStore for InMemoryMemoryStore {
             .lock()
             .map_err(|_| SimardError::StoragePoisoned {
                 store: "memory".to_string(),
+            })?
+            .iter()
+            .filter(|record| &record.session_id == session_id)
+            .count())
+    }
+}
+
+impl MemoryStore for FileBackedMemoryStore {
+    fn descriptor(&self) -> BackendDescriptor {
+        self.descriptor.clone()
+    }
+
+    fn put(&self, record: MemoryRecord) -> SimardResult<()> {
+        let mut records = self
+            .records
+            .lock()
+            .map_err(|_| SimardError::StoragePoisoned {
+                store: MEMORY_STORE_NAME.to_string(),
+            })?;
+        if let Some(existing) = records
+            .iter_mut()
+            .find(|existing| existing.key == record.key)
+        {
+            *existing = record;
+        } else {
+            records.push(record);
+        }
+        self.persist(&records)
+    }
+
+    fn list(&self, scope: MemoryScope) -> SimardResult<Vec<MemoryRecord>> {
+        Ok(self
+            .records
+            .lock()
+            .map_err(|_| SimardError::StoragePoisoned {
+                store: MEMORY_STORE_NAME.to_string(),
+            })?
+            .iter()
+            .filter(|record| record.scope == scope)
+            .cloned()
+            .collect())
+    }
+
+    fn list_for_session(&self, session_id: &SessionId) -> SimardResult<Vec<MemoryRecord>> {
+        Ok(self
+            .records
+            .lock()
+            .map_err(|_| SimardError::StoragePoisoned {
+                store: MEMORY_STORE_NAME.to_string(),
+            })?
+            .iter()
+            .filter(|record| &record.session_id == session_id)
+            .cloned()
+            .collect())
+    }
+
+    fn count_for_session(&self, session_id: &SessionId) -> SimardResult<usize> {
+        Ok(self
+            .records
+            .lock()
+            .map_err(|_| SimardError::StoragePoisoned {
+                store: MEMORY_STORE_NAME.to_string(),
             })?
             .iter()
             .filter(|record| &record.session_id == session_id)

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -1,0 +1,73 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+use crate::error::{SimardError, SimardResult};
+
+pub fn load_json_or_default<T>(store: &str, path: &Path) -> SimardResult<T>
+where
+    T: DeserializeOwned + Default,
+{
+    if !path.exists() {
+        return Ok(T::default());
+    }
+
+    let contents = fs::read(path).map_err(|error| SimardError::PersistentStoreIo {
+        store: store.to_string(),
+        action: "read".to_string(),
+        path: path.to_path_buf(),
+        reason: error.to_string(),
+    })?;
+    serde_json::from_slice(&contents).map_err(|error| SimardError::PersistentStoreIo {
+        store: store.to_string(),
+        action: "deserialize".to_string(),
+        path: path.to_path_buf(),
+        reason: error.to_string(),
+    })
+}
+
+pub fn persist_json<T>(store: &str, path: &Path, value: &T) -> SimardResult<()>
+where
+    T: Serialize,
+{
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|error| SimardError::PersistentStoreIo {
+            store: store.to_string(),
+            action: "create-dir".to_string(),
+            path: parent.to_path_buf(),
+            reason: error.to_string(),
+        })?;
+    }
+
+    let payload =
+        serde_json::to_vec_pretty(value).map_err(|error| SimardError::PersistentStoreIo {
+            store: store.to_string(),
+            action: "serialize".to_string(),
+            path: path.to_path_buf(),
+            reason: error.to_string(),
+        })?;
+    let temp_path = temp_path(path);
+    fs::write(&temp_path, payload).map_err(|error| SimardError::PersistentStoreIo {
+        store: store.to_string(),
+        action: "write".to_string(),
+        path: temp_path.clone(),
+        reason: error.to_string(),
+    })?;
+    fs::rename(&temp_path, path).map_err(|error| SimardError::PersistentStoreIo {
+        store: store.to_string(),
+        action: "rename".to_string(),
+        path: path.to_path_buf(),
+        reason: error.to_string(),
+    })
+}
+
+fn temp_path(path: &Path) -> PathBuf {
+    match (path.parent(), path.file_name()) {
+        (Some(parent), Some(file_name)) => {
+            parent.join(format!("{}.tmp", file_name.to_string_lossy()))
+        }
+        _ => PathBuf::from(format!("{}.tmp", path.to_string_lossy())),
+    }
+}

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::fmt::{self, Display, Formatter};
 use std::sync::Arc;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::agent_program::{AgentProgram, AgentProgramContext, ObjectiveRelayProgram};
 use crate::base_types::{BaseTypeFactory, BaseTypeId, BaseTypeOutcome, BaseTypeSessionRequest};
@@ -17,7 +17,7 @@ use crate::reflection::{ReflectionReport, ReflectionSnapshot, ReflectiveRuntime}
 use crate::sanitization::objective_metadata;
 use crate::session::{SessionIdGenerator, SessionPhase, SessionRecord};
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum RuntimeTopology {
     SingleProcess,
@@ -36,7 +36,8 @@ impl Display for RuntimeTopology {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum RuntimeState {
     Initializing,
     Ready,
@@ -89,7 +90,7 @@ impl RuntimeState {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub struct RuntimeNodeId(String);
 
 impl RuntimeNodeId {
@@ -108,7 +109,7 @@ impl Display for RuntimeNodeId {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub struct RuntimeAddress(String);
 
 impl RuntimeAddress {

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,5 +1,6 @@
 use std::fmt::{self, Display, Formatter};
 
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::base_types::BaseTypeId;
@@ -7,7 +8,7 @@ use crate::error::{SimardError, SimardResult};
 use crate::identity::OperatingMode;
 use crate::sanitization::objective_metadata;
 
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub struct SessionId(String);
 
 impl SessionId {
@@ -63,7 +64,8 @@ impl SessionIdGenerator for UuidSessionIdGenerator {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum SessionPhase {
     Intake,
     Preparation,
@@ -106,7 +108,7 @@ impl SessionPhase {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SessionRecord {
     pub id: SessionId,
     pub mode: OperatingMode,

--- a/tests/bootstrap.rs
+++ b/tests/bootstrap.rs
@@ -1,11 +1,19 @@
+use std::fs;
 use std::path::PathBuf;
 
 use simard::{
     BaseTypeId, BootstrapConfig, BootstrapInputs, BootstrapMode, BuiltinIdentityLoader,
     ConfigValueSource, IdentityLoadRequest, IdentityLoader, ManifestContract, Provenance,
     ReflectiveRuntime, RuntimeState, RuntimeTopology, SimardError, assemble_local_runtime,
-    bootstrap_entrypoint, run_local_session,
+    assemble_local_runtime_from_handoff, bootstrap_entrypoint, latest_local_handoff,
+    run_local_session,
 };
+
+fn state_root(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("target/test-state")
+        .join(name)
+}
 
 #[test]
 fn bootstrap_requires_explicit_prompt_root_and_objective_by_default() {
@@ -40,6 +48,10 @@ fn bootstrap_builtin_defaults_are_only_used_with_explicit_opt_in() {
         ConfigValueSource::ExplicitOptIn("SIMARD_BOOTSTRAP_MODE")
     );
     assert_eq!(
+        config.state_root.source,
+        ConfigValueSource::ExplicitOptIn("SIMARD_BOOTSTRAP_MODE")
+    );
+    assert_eq!(
         config.selected_base_type.source,
         ConfigValueSource::ExplicitOptIn("SIMARD_BOOTSTRAP_MODE")
     );
@@ -50,6 +62,10 @@ fn bootstrap_builtin_defaults_are_only_used_with_explicit_opt_in() {
     assert_eq!(
         config.prompt_root.value,
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("prompt_assets")
+    );
+    assert_eq!(
+        config.state_root.value,
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("target/simard-state")
     );
     assert_eq!(config.objective.value, "bootstrap the Simard engineer loop");
     assert_eq!(
@@ -66,6 +82,7 @@ fn bootstrap_requires_explicit_identity_without_builtin_defaults() {
         objective: Some("exercise bootstrap identity handling".to_string()),
         base_type: Some("local-harness".to_string()),
         topology: Some("single-process".to_string()),
+        state_root: Some(state_root("missing-identity")),
         ..BootstrapInputs::default()
     })
     .unwrap_err();
@@ -87,6 +104,7 @@ fn bootstrap_requires_explicit_base_type_without_builtin_defaults() {
         objective: Some("exercise bootstrap base type handling".to_string()),
         identity: Some("simard-engineer".to_string()),
         topology: Some("single-process".to_string()),
+        state_root: Some(state_root("missing-base-type")),
         ..BootstrapInputs::default()
     })
     .unwrap_err();
@@ -108,6 +126,7 @@ fn bootstrap_requires_explicit_topology_without_builtin_defaults() {
         objective: Some("exercise bootstrap topology handling".to_string()),
         identity: Some("simard-engineer".to_string()),
         base_type: Some("local-harness".to_string()),
+        state_root: Some(state_root("missing-topology")),
         ..BootstrapInputs::default()
     })
     .unwrap_err();
@@ -131,6 +150,7 @@ fn bootstrap_rejects_invalid_topology_values() {
         identity: Some("simard-engineer".to_string()),
         base_type: Some("local-harness".to_string()),
         topology: Some("mystery-mesh".to_string()),
+        state_root: Some(state_root("invalid-topology")),
         ..BootstrapInputs::default()
     })
     .unwrap_err();
@@ -193,6 +213,7 @@ fn bootstrap_assembly_produces_truthful_manifest_metadata() {
         identity: Some("simard-engineer".to_string()),
         base_type: Some("local-harness".to_string()),
         topology: Some("single-process".to_string()),
+        state_root: Some(state_root("assembly")),
         ..BootstrapInputs::default()
     })
     .expect("explicit bootstrap config should resolve");
@@ -296,6 +317,7 @@ fn bootstrap_run_local_session_executes_the_cli_lifecycle() {
         identity: Some("simard-engineer".to_string()),
         base_type: Some("local-harness".to_string()),
         topology: Some("single-process".to_string()),
+        state_root: Some(state_root("run-loop")),
         ..BootstrapInputs::default()
     })
     .expect("explicit bootstrap config should resolve");
@@ -314,6 +336,69 @@ fn bootstrap_run_local_session_executes_the_cli_lifecycle() {
 }
 
 #[test]
+fn bootstrap_persists_durable_state_and_restores_latest_handoff() {
+    let state_root = state_root("durable-restore");
+    if state_root.exists() {
+        fs::remove_dir_all(&state_root).expect("old test state should be removable");
+    }
+
+    let config = BootstrapConfig::resolve(BootstrapInputs {
+        prompt_root: Some(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("prompt_assets")),
+        objective: Some("exercise durable bootstrap persistence".to_string()),
+        state_root: Some(state_root.clone()),
+        identity: Some("simard-engineer".to_string()),
+        base_type: Some("local-harness".to_string()),
+        topology: Some("single-process".to_string()),
+        ..BootstrapInputs::default()
+    })
+    .expect("explicit bootstrap config should resolve");
+
+    let execution = run_local_session(&config).expect("bootstrap run loop should succeed");
+    assert!(config.memory_store_path().is_file());
+    assert!(config.evidence_store_path().is_file());
+    assert!(config.handoff_store_path().is_file());
+
+    let snapshot = latest_local_handoff(&config)
+        .expect("durable handoff lookup should succeed")
+        .expect("a durable handoff snapshot should exist after the run");
+    assert_eq!(
+        snapshot.session.as_ref().map(|session| session.phase),
+        Some(simard::SessionPhase::Complete)
+    );
+    assert_eq!(snapshot.memory_records.len(), 2);
+    assert_eq!(snapshot.evidence_records.len(), 4);
+
+    let restored = assemble_local_runtime_from_handoff(&config, snapshot)
+        .expect("restored runtime should compose");
+    let restored_snapshot = restored
+        .snapshot()
+        .expect("restored snapshot should succeed");
+    assert_eq!(restored_snapshot.runtime_state, RuntimeState::Initializing);
+    assert_eq!(
+        restored_snapshot.session_phase,
+        Some(simard::SessionPhase::Complete)
+    );
+    assert_eq!(restored_snapshot.memory_records, 2);
+    assert_eq!(restored_snapshot.evidence_records, 4);
+    assert_eq!(
+        restored_snapshot.memory_backend.identity,
+        "memory::json-file-store"
+    );
+    assert_eq!(
+        restored_snapshot.evidence_backend.identity,
+        "evidence::json-file-store"
+    );
+    assert_eq!(
+        restored_snapshot.handoff_backend.identity,
+        "handoff::json-file-store"
+    );
+    assert_eq!(
+        execution.stopped_snapshot.runtime_state,
+        RuntimeState::Stopped
+    );
+}
+
+#[test]
 fn bootstrap_supports_composite_identity_execution() {
     let config = BootstrapConfig::resolve(BootstrapInputs {
         prompt_root: Some(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("prompt_assets")),
@@ -321,6 +406,7 @@ fn bootstrap_supports_composite_identity_execution() {
         identity: Some("simard-composite-engineer".to_string()),
         base_type: Some("local-harness".to_string()),
         topology: Some("single-process".to_string()),
+        state_root: Some(state_root("composite")),
         ..BootstrapInputs::default()
     })
     .expect("explicit composite bootstrap config should resolve");
@@ -356,6 +442,7 @@ fn bootstrap_assembly_supports_multiple_builtin_manifest_base_types() {
             identity: Some("simard-engineer".to_string()),
             base_type: Some(base_type.to_string()),
             topology: Some("single-process".to_string()),
+            state_root: Some(state_root(base_type)),
             ..BootstrapInputs::default()
         })
         .expect("explicit bootstrap config should resolve");
@@ -410,6 +497,7 @@ fn bootstrap_supports_rusty_clawd_multi_process_execution() {
         identity: Some("simard-engineer".to_string()),
         base_type: Some("rusty-clawd".to_string()),
         topology: Some("multi-process".to_string()),
+        state_root: Some(state_root("rusty-clawd-multi-process")),
         ..BootstrapInputs::default()
     })
     .expect("multi-process bootstrap config should resolve");
@@ -452,6 +540,7 @@ fn bootstrap_assembly_surfaces_identity_base_type_mismatches_explicitly() {
         identity: Some("simard-engineer".to_string()),
         base_type: Some("meeting-bot".to_string()),
         topology: Some("single-process".to_string()),
+        state_root: Some(state_root("identity-base-mismatch")),
         ..BootstrapInputs::default()
     })
     .expect("explicit bootstrap config should resolve");
@@ -478,6 +567,7 @@ fn bootstrap_assembly_surfaces_unsupported_topologies_explicitly() {
         identity: Some("simard-engineer".to_string()),
         base_type: Some("local-harness".to_string()),
         topology: Some("distributed".to_string()),
+        state_root: Some(state_root("unsupported-topology")),
         ..BootstrapInputs::default()
     })
     .expect("explicit bootstrap config should resolve");

--- a/tests/gadugi/handoff-roundtrip.sh
+++ b/tests/gadugi/handoff-roundtrip.sh
@@ -12,6 +12,13 @@ OUTPUT="$(
 
 printf '%s\n' "$OUTPUT"
 
+STATE_ROOT="$(printf '%s\n' "$OUTPUT" | sed -n 's/^State root: //p')"
+[ -n "$STATE_ROOT" ]
+[ -d "$STATE_ROOT" ]
+[ -f "$STATE_ROOT/memory_records.json" ]
+[ -f "$STATE_ROOT/evidence_records.json" ]
+[ -f "$STATE_ROOT/latest_handoff.json" ]
+
 printf '%s\n' "$OUTPUT" | grep -F "Probe mode: handoff-roundtrip" >/dev/null
 printf '%s\n' "$OUTPUT" | grep -F "Identity: simard-composite-engineer" >/dev/null
 printf '%s\n' "$OUTPUT" | grep -F "Identity components: simard-engineer, simard-meeting, simard-gym" >/dev/null


### PR DESCRIPTION
## Summary
- add file-backed JSON persistence for memory, evidence, and latest handoff snapshots under `SIMARD_STATE_ROOT`
- wire the operator probe and bootstrap helpers through durable export/restore so the product exercises real continuity behavior
- update runtime docs and outside-in coverage to match the shipped durable state contract

## Validation
- `cargo test --all-features --locked`
- `tests/gadugi/smoke-explicit-local.sh`
- `tests/gadugi/smoke-explicit-rusty-clawd.sh`
- `tests/gadugi/smoke-builtin-defaults.sh`
- `tests/gadugi/composite-identity.sh`
- `tests/gadugi/handoff-roundtrip.sh`
- `tests/gadugi/gym-suite.sh`
- `python3 -m pre_commit run --all-files --hook-stage pre-commit`
- `python3 -m pre_commit run --all-files --hook-stage pre-push`

## Prompt/spec reconciliation
This block closes one of the clearest remaining v1 gaps against the original Simard prompt and `Specs/ProductArchitecture.md`: Simard now has one honest durable memory path for local runtime continuity and handoff restore. The implementation stays intentionally minimal and truthful by using inspectable JSON files instead of pretending a richer memory database already exists.

Closes #28
