### PR TITLE
Implement the Simard meeting-mode foundation

### DIFF
--- a/docs/howto/configure-bootstrap-and-inspect-reflection.md
+++ b/docs/howto/configure-bootstrap-and-inspect-reflection.md
@@ -149,6 +149,33 @@ If you launched with `SIMARD_BASE_TYPE="copilot-sdk"`, `snapshot.selected_base_t
 
 The same redaction rule applies to persisted session text: scratch memory, session summaries, and reflection summaries record `objective-metadata(...)` instead of the raw `SIMARD_OBJECTIVE` string.
 
+## 5. Exercise meeting mode without switching into engineer mode
+
+Use the operator probe when you want to validate facilitator behavior directly:
+
+```bash
+cargo run --quiet --bin simard_operator_probe -- \
+  meeting-run local-harness single-process \
+  "$(cat <<'EOF'
+agenda: align the next Simard block
+update: durable memory is now merged
+decision: prioritize meeting-mode validation before remote orchestration
+risk: workflow automation is still unreliable in clean worktrees
+next-step: ship operator-visible meeting coverage
+open-question: when should meeting decisions influence engineer planning?
+EOF
+)"
+```
+
+Look for:
+
+- `Probe mode: meeting-run`
+- `Identity: simard-meeting`
+- `Decision records: 1`
+- a durable decision record containing the decision, risk, next step, and open question
+
+This is the current honest v1 behavior: meeting mode captures structured planning output and writes concise decision memory, but it does not mutate code.
+
 ## 4. Validate stopped-state behavior
 
 Stopping the runtime is already observable.

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,7 @@ Today Simard provides:
 - explicit base-type and topology selection at bootstrap, with opt-in defaults only in `builtin-defaults`
 - builtin manifest-advertised base types selectable at startup today: `local-harness`, `rusty-clawd`, and `copilot-sdk`, with `rusty-clawd` wired as a distinct session backend and `copilot-sdk` still aliased to the local harness implementation
 - builtin identities selectable at startup today: `simard-engineer`, `simard-meeting`, `simard-gym`, and the composite `simard-composite-engineer`
+- a facilitator-backed `simard-meeting` identity that captures structured decisions, risks, next steps, and open questions without mutating code
 - `single-process` for all builtin base types plus loopback `multi-process` execution for `rusty-clawd`, with unsupported pairs failing explicitly
 - a starter benchmark gym suite that exercises all current builtin base-type selections plus a composite identity session through `cargo run --quiet --bin simard-gym -- run-suite starter`
 - benchmark artifacts written under `target/simard-gym/`, including per-scenario JSON and text summaries plus a suite summary
@@ -36,6 +37,7 @@ Today Simard provides:
 - `ReflectionSnapshot { manifest_contract, runtime_node, mailbox_address, agent_program_backend, adapter_backend, topology_backend, transport_backend, supervisor_backend, memory_backend, evidence_backend }`
 - truthful memory and evidence backend descriptors
 - file-backed memory, evidence, and handoff stores on the bootstrap path, with persisted local state under the configured state root
+- durable meeting decision records persisted under the configured state root so later sessions can inspect concise planning outcomes
 - truthful runtime service metadata from the runtime-selected wiring, including the injected agent program, handoff store, and the canonical backend identities behind each selected base type
 - persisted scratch, summary, and reflection text that records objective metadata instead of raw objective text
 - handoff snapshots that preserve runtime/session continuity while redacting the persisted session objective down to objective metadata

--- a/docs/reference/runtime-contracts.md
+++ b/docs/reference/runtime-contracts.md
@@ -34,6 +34,27 @@ Simard v1 does **not** currently expose:
 
 The stable contract in this repository is the bootstrap/runtime and benchmark-gym behavior described below.
 
+## Meeting-mode operator flow
+
+The shipped operator probe also supports a meeting-specific path:
+
+- `cargo run --quiet --bin simard_operator_probe -- meeting-run <base-type> <topology> <structured-objective>`
+
+Use a structured objective with lines such as:
+
+- `agenda: ...`
+- `update: ...`
+- `decision: ...`
+- `risk: ...`
+- `next-step: ...`
+- `open-question: ...`
+
+The v1 meeting contract is intentionally narrow:
+
+- meeting mode uses the facilitator agent program backend `agent-program::meeting-facilitator`
+- it persists concise decision memory under the durable state root
+- it does not mutate code paths or pretend implementation work happened
+
 ## Benchmark gym CLI
 
 The shipped benchmark CLI currently supports:
@@ -305,6 +326,8 @@ pub struct ReflectionSnapshot {
     pub evidence_backend: BackendDescriptor,
 }
 ```
+
+For `simard-meeting`, reflection also reports `agent_program_backend.identity == "agent-program::meeting-facilitator"`.
 
 ### Backend descriptors
 

--- a/docs/tutorials/run-your-first-local-session.md
+++ b/docs/tutorials/run-your-first-local-session.md
@@ -191,6 +191,7 @@ You now know:
 - how to run the local runtime with explicit config
 - how to switch between built-in base types without hidden inference
 - how `copilot-sdk` still aliases `local-harness` while `rusty-clawd` now reports a distinct backend honestly
+- how `simard-meeting` uses a facilitator program to persist concise decision records instead of acting like an engineer session
 - how composite identities surface their assembled components explicitly
 - how loopback multi-process execution reuses the same runtime contracts
 - how opt-in defaults are recorded

--- a/prompt_assets/simard/meeting_system.md
+++ b/prompt_assets/simard/meeting_system.md
@@ -1,1 +1,31 @@
 # Simard Meeting System Prompt
+
+You are Simard in meeting mode.
+
+Your job is alignment, synthesis, and decision capture.
+
+## Boundaries
+
+- Do not mutate code or pretend you executed implementation work.
+- Surface disagreement, trade-offs, and uncertainty explicitly.
+- Prefer concise durable decision records over transcript-like output.
+
+## Structured meeting brief
+
+Use structured operator input whenever possible:
+
+- `agenda: ...`
+- `update: ...`
+- `decision: ...`
+- `risk: ...`
+- `next-step: ...`
+- `open-question: ...`
+
+Repeated lines are allowed for updates, decisions, risks, next steps, and open questions.
+
+## Expected outcomes
+
+- clarify the agenda
+- capture decisions and scoped action items
+- record explicit risks and open questions
+- preserve concise meeting artifacts that later engineer sessions can inspect

--- a/src/agent_program.rs
+++ b/src/agent_program.rs
@@ -1,6 +1,7 @@
 use crate::base_types::{BaseTypeId, BaseTypeOutcome, BaseTypeTurnInput};
 use crate::error::SimardResult;
 use crate::identity::OperatingMode;
+use crate::memory::MemoryScope;
 use crate::metadata::{BackendDescriptor, Freshness};
 use crate::runtime::{RuntimeAddress, RuntimeNodeId, RuntimeTopology};
 use crate::sanitization::objective_metadata;
@@ -16,6 +17,13 @@ pub struct AgentProgramContext {
     pub runtime_node: RuntimeNodeId,
     pub mailbox_address: RuntimeAddress,
     pub objective: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AgentProgramMemoryRecord {
+    pub key_suffix: String,
+    pub scope: MemoryScope,
+    pub value: String,
 }
 
 pub trait AgentProgram: Send + Sync {
@@ -34,6 +42,14 @@ pub trait AgentProgram: Send + Sync {
         context: &AgentProgramContext,
         outcome: &BaseTypeOutcome,
     ) -> SimardResult<String>;
+
+    fn additional_memory_records(
+        &self,
+        _context: &AgentProgramContext,
+        _outcome: &BaseTypeOutcome,
+    ) -> SimardResult<Vec<AgentProgramMemoryRecord>> {
+        Ok(Vec::new())
+    }
 }
 
 #[derive(Debug)]
@@ -92,5 +108,189 @@ impl AgentProgram for ObjectiveRelayProgram {
             outcome.plan,
             outcome.execution_summary,
         ))
+    }
+}
+
+#[derive(Debug)]
+pub struct MeetingFacilitatorProgram {
+    descriptor: BackendDescriptor,
+}
+
+impl MeetingFacilitatorProgram {
+    pub fn try_default() -> SimardResult<Self> {
+        Ok(Self {
+            descriptor: BackendDescriptor::for_runtime_type::<Self>(
+                "agent-program::meeting-facilitator",
+                "runtime-port:agent-program",
+                Freshness::now()?,
+            ),
+        })
+    }
+}
+
+impl AgentProgram for MeetingFacilitatorProgram {
+    fn descriptor(&self) -> BackendDescriptor {
+        self.descriptor.clone()
+    }
+
+    fn plan_turn(&self, context: &AgentProgramContext) -> SimardResult<BaseTypeTurnInput> {
+        let notes = StructuredMeetingNotes::parse(&context.objective);
+        Ok(BaseTypeTurnInput {
+            objective: notes.turn_objective(),
+        })
+    }
+
+    fn reflection_summary(
+        &self,
+        context: &AgentProgramContext,
+        outcome: &BaseTypeOutcome,
+    ) -> SimardResult<String> {
+        let notes = StructuredMeetingNotes::parse(&context.objective);
+        Ok(format!(
+            "Meeting facilitator '{}' captured {} decisions, {} risks, {} next steps, and {} open questions for agenda '{}' through '{}' on '{}' from '{}'. Outcome summary: {}.",
+            self.descriptor.identity,
+            notes.decisions.len(),
+            notes.risks.len(),
+            notes.next_steps.len(),
+            notes.open_questions.len(),
+            notes.agenda,
+            context.selected_base_type,
+            context.topology,
+            context.runtime_node,
+            outcome.execution_summary,
+        ))
+    }
+
+    fn persistence_summary(
+        &self,
+        context: &AgentProgramContext,
+        outcome: &BaseTypeOutcome,
+    ) -> SimardResult<String> {
+        let notes = StructuredMeetingNotes::parse(&context.objective);
+        Ok(format!(
+            "meeting-record | {} | selected-base-type={} | topology={} | outcome={}",
+            notes.concise_record(),
+            context.selected_base_type,
+            context.topology,
+            outcome.execution_summary,
+        ))
+    }
+
+    fn additional_memory_records(
+        &self,
+        context: &AgentProgramContext,
+        _outcome: &BaseTypeOutcome,
+    ) -> SimardResult<Vec<AgentProgramMemoryRecord>> {
+        let notes = StructuredMeetingNotes::parse(&context.objective);
+        if !notes.has_persistable_outputs() {
+            return Ok(Vec::new());
+        }
+
+        Ok(vec![AgentProgramMemoryRecord {
+            key_suffix: "decision-record".to_string(),
+            scope: MemoryScope::Decision,
+            value: notes.concise_record(),
+        }])
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+struct StructuredMeetingNotes {
+    agenda: String,
+    updates: Vec<String>,
+    decisions: Vec<String>,
+    risks: Vec<String>,
+    next_steps: Vec<String>,
+    open_questions: Vec<String>,
+}
+
+impl StructuredMeetingNotes {
+    fn parse(raw: &str) -> Self {
+        let mut notes = Self::default();
+        let mut agenda_fragments = Vec::new();
+
+        for line in raw.lines().map(str::trim).filter(|line| !line.is_empty()) {
+            let Some((label, value)) = line.split_once(':') else {
+                agenda_fragments.push(line.to_string());
+                continue;
+            };
+
+            let label = label.trim().to_ascii_lowercase();
+            let value = value.trim();
+            if value.is_empty() {
+                continue;
+            }
+
+            match label.as_str() {
+                "agenda" | "topic" | "goal" => {
+                    if notes.agenda.is_empty() {
+                        notes.agenda = value.to_string();
+                    } else {
+                        notes.agenda.push_str(" / ");
+                        notes.agenda.push_str(value);
+                    }
+                }
+                "update" | "status" => notes.updates.push(value.to_string()),
+                "decision" => notes.decisions.push(value.to_string()),
+                "risk" => notes.risks.push(value.to_string()),
+                "next-step" | "next_step" | "action" | "action-item" => {
+                    notes.next_steps.push(value.to_string())
+                }
+                "open-question" | "open_question" | "question" => {
+                    notes.open_questions.push(value.to_string())
+                }
+                _ => agenda_fragments.push(line.to_string()),
+            }
+        }
+
+        if notes.agenda.is_empty() {
+            notes.agenda = if agenda_fragments.is_empty() {
+                objective_metadata(raw)
+            } else {
+                agenda_fragments.join(" / ")
+            };
+        }
+
+        notes
+    }
+
+    fn has_persistable_outputs(&self) -> bool {
+        !self.updates.is_empty()
+            || !self.decisions.is_empty()
+            || !self.risks.is_empty()
+            || !self.next_steps.is_empty()
+            || !self.open_questions.is_empty()
+    }
+
+    fn turn_objective(&self) -> String {
+        format!(
+            "Facilitate meeting agenda '{}' and preserve concise updates={}, decisions={}, risks={}, next_steps={}, open_questions={}.",
+            self.agenda,
+            self.updates.len(),
+            self.decisions.len(),
+            self.risks.len(),
+            self.next_steps.len(),
+            self.open_questions.len(),
+        )
+    }
+
+    fn concise_record(&self) -> String {
+        format!(
+            "agenda={}; updates={}; decisions={}; risks={}; next_steps={}; open_questions={}",
+            self.agenda,
+            format_items(&self.updates),
+            format_items(&self.decisions),
+            format_items(&self.risks),
+            format_items(&self.next_steps),
+            format_items(&self.open_questions),
+        )
+    }
+}
+
+fn format_items(items: &[String]) -> String {
+    if items.is_empty() {
+        "[]".to_string()
+    } else {
+        format!("[{}]", items.join(" | "))
     }
 }

--- a/src/bin/simard_operator_probe.rs
+++ b/src/bin/simard_operator_probe.rs
@@ -1,8 +1,8 @@
 use std::path::PathBuf;
 
 use simard::{
-    BootstrapConfig, BootstrapInputs, ReflectiveRuntime, assemble_local_runtime_from_handoff,
-    latest_local_handoff,
+    BootstrapConfig, BootstrapInputs, MemoryScope, ReflectiveRuntime,
+    assemble_local_runtime_from_handoff, latest_local_handoff,
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -23,6 +23,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let topology = args.next().ok_or("expected topology")?;
             let objective = args.next().ok_or("expected objective")?;
             run_handoff_probe(&identity, &base_type, &topology, &objective)?;
+        }
+        "meeting-run" => {
+            let base_type = args.next().ok_or("expected base type")?;
+            let topology = args.next().ok_or("expected topology")?;
+            let objective = args.next().ok_or("expected objective")?;
+            run_meeting_probe(&base_type, &topology, &objective)?;
         }
         other => return Err(format!("unsupported probe command '{other}'").into()),
     }
@@ -168,5 +174,51 @@ fn run_handoff_probe(
         restored_snapshot.transport_backend.identity
     );
     println!("Execution summary: {}", execution.outcome.execution_summary);
+    Ok(())
+}
+
+fn run_meeting_probe(
+    base_type: &str,
+    topology: &str,
+    objective: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let identity = "simard-meeting";
+    let config = BootstrapConfig::resolve(BootstrapInputs {
+        prompt_root: Some(prompt_root()),
+        objective: Some(objective.to_string()),
+        state_root: Some(state_root(identity, base_type, topology, "meeting-run")),
+        identity: Some(identity.to_string()),
+        base_type: Some(base_type.to_string()),
+        topology: Some(topology.to_string()),
+        ..BootstrapInputs::default()
+    })?;
+
+    let execution = simard::run_local_session(&config)?;
+    let exported = latest_local_handoff(&config)?.ok_or("expected durable meeting handoff")?;
+    let decision_records = exported
+        .memory_records
+        .iter()
+        .filter(|record| record.scope == MemoryScope::Decision)
+        .map(|record| record.value.clone())
+        .collect::<Vec<_>>();
+
+    println!("Probe mode: meeting-run");
+    println!("Identity: {}", execution.snapshot.identity_name);
+    println!(
+        "Selected base type: {}",
+        execution.snapshot.selected_base_type
+    );
+    println!("Topology: {}", execution.snapshot.topology);
+    println!("State root: {}", config.state_root_path().display());
+    println!("Session phase: {}", execution.outcome.session.phase);
+    println!("Decision records: {}", decision_records.len());
+    for (index, value) in decision_records.iter().enumerate() {
+        println!("Decision record {}: {}", index + 1, value);
+    }
+    println!("Execution summary: {}", execution.outcome.execution_summary);
+    println!(
+        "Reflection summary: {}",
+        execution.outcome.reflection.summary
+    );
     Ok(())
 }

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -4,13 +4,14 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use crate::agent_program::ObjectiveRelayProgram;
+use crate::agent_program::{AgentProgram, MeetingFacilitatorProgram, ObjectiveRelayProgram};
 use crate::base_types::{BaseTypeId, LocalProcessHarnessAdapter, RustyClawdAdapter};
 use crate::error::{SimardError, SimardResult};
 use crate::evidence::{EvidenceStore, FileBackedEvidenceStore};
 use crate::handoff::{FileBackedHandoffStore, RuntimeHandoffSnapshot, RuntimeHandoffStore};
 use crate::identity::{
     BuiltinIdentityLoader, IdentityLoadRequest, IdentityLoader, IdentityManifest, ManifestContract,
+    OperatingMode,
 };
 use crate::memory::{FileBackedMemoryStore, MemoryStore};
 use crate::metadata::{Freshness, Provenance};
@@ -289,6 +290,7 @@ pub fn assemble_local_runtime(config: &BootstrapConfig) -> SimardResult<LocalRun
         config.selected_base_type.value.clone(),
         config.topology.value,
     );
+    let agent_program = agent_program_for_manifest(&request.manifest)?;
 
     LocalRuntime::compose(
         runtime_ports_for_topology(
@@ -298,6 +300,7 @@ pub fn assemble_local_runtime(config: &BootstrapConfig) -> SimardResult<LocalRun
             handoff_store,
             base_types,
             config.topology.value,
+            agent_program,
         )?,
         request,
     )
@@ -338,6 +341,7 @@ pub fn assemble_local_runtime_from_handoff(
         config.selected_base_type.value.clone(),
         config.topology.value,
     );
+    let agent_program = agent_program_for_manifest(&request.manifest)?;
 
     LocalRuntime::compose_from_handoff(
         runtime_ports_for_topology(
@@ -347,6 +351,7 @@ pub fn assemble_local_runtime_from_handoff(
             handoff_store,
             base_types,
             config.topology.value,
+            agent_program,
         )?,
         request,
         snapshot,
@@ -426,6 +431,7 @@ fn runtime_ports_for_topology(
     handoff_store: Arc<dyn RuntimeHandoffStore>,
     base_types: BaseTypeRegistry,
     topology: RuntimeTopology,
+    agent_program: Arc<dyn AgentProgram>,
 ) -> SimardResult<RuntimePorts> {
     match topology {
         RuntimeTopology::SingleProcess => Ok(RuntimePorts::with_runtime_services_and_program(
@@ -436,7 +442,7 @@ fn runtime_ports_for_topology(
             Arc::new(crate::runtime::InProcessTopologyDriver::try_default()?),
             Arc::new(crate::runtime::InMemoryMailboxTransport::try_default()?),
             Arc::new(crate::runtime::InProcessSupervisor::try_default()?),
-            Arc::new(ObjectiveRelayProgram::try_default()?),
+            Arc::clone(&agent_program),
             handoff_store,
             Arc::new(UuidSessionIdGenerator),
         )),
@@ -449,10 +455,19 @@ fn runtime_ports_for_topology(
                 Arc::new(LoopbackMeshTopologyDriver::try_default()?),
                 Arc::new(LoopbackMailboxTransport::try_default()?),
                 Arc::new(CoordinatedSupervisor::try_default()?),
-                Arc::new(ObjectiveRelayProgram::try_default()?),
+                agent_program,
                 handoff_store,
                 Arc::new(UuidSessionIdGenerator),
             ))
+        }
+    }
+}
+
+fn agent_program_for_manifest(manifest: &IdentityManifest) -> SimardResult<Arc<dyn AgentProgram>> {
+    match manifest.default_mode {
+        OperatingMode::Meeting => Ok(Arc::new(MeetingFacilitatorProgram::try_default()?)),
+        OperatingMode::Engineer | OperatingMode::Gym => {
+            Ok(Arc::new(ObjectiveRelayProgram::try_default()?))
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,10 @@ pub mod runtime;
 mod sanitization;
 pub mod session;
 
-pub use agent_program::{AgentProgram, AgentProgramContext, ObjectiveRelayProgram};
+pub use agent_program::{
+    AgentProgram, AgentProgramContext, AgentProgramMemoryRecord, MeetingFacilitatorProgram,
+    ObjectiveRelayProgram,
+};
 pub use base_types::{
     BaseTypeCapability, BaseTypeDescriptor, BaseTypeFactory, BaseTypeId, BaseTypeOutcome,
     BaseTypeSession, BaseTypeSessionRequest, BaseTypeTurnInput, LocalProcessHarnessAdapter,

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -15,6 +15,7 @@ const MEMORY_STORE_NAME: &str = "memory";
 pub enum MemoryScope {
     SessionScratch,
     SessionSummary,
+    Decision,
     Project,
     Benchmark,
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -834,6 +834,22 @@ impl RuntimeKernel {
             recorded_in: SessionPhase::Persistence,
         })?;
         session.attach_memory(summary_key);
+
+        for record in self
+            .ports
+            .agent_program
+            .additional_memory_records(&self.agent_program_context(session), outcome)?
+        {
+            let key = format!("{}-{}", session.id, record.key_suffix);
+            self.ports.memory_store.put(MemoryRecord {
+                key: key.clone(),
+                scope: record.scope,
+                value: record.value,
+                session_id: session.id.clone(),
+                recorded_in: SessionPhase::Persistence,
+            })?;
+            session.attach_memory(key);
+        }
         self.remember_session(session);
 
         Ok(())

--- a/tests/bootstrap.rs
+++ b/tests/bootstrap.rs
@@ -3,10 +3,10 @@ use std::path::PathBuf;
 
 use simard::{
     BaseTypeId, BootstrapConfig, BootstrapInputs, BootstrapMode, BuiltinIdentityLoader,
-    ConfigValueSource, IdentityLoadRequest, IdentityLoader, ManifestContract, Provenance,
-    ReflectiveRuntime, RuntimeState, RuntimeTopology, SimardError, assemble_local_runtime,
-    assemble_local_runtime_from_handoff, bootstrap_entrypoint, latest_local_handoff,
-    run_local_session,
+    ConfigValueSource, IdentityLoadRequest, IdentityLoader, ManifestContract, MemoryScope,
+    Provenance, ReflectiveRuntime, RuntimeState, RuntimeTopology, SimardError,
+    assemble_local_runtime, assemble_local_runtime_from_handoff, bootstrap_entrypoint,
+    latest_local_handoff, run_local_session,
 };
 
 fn state_root(name: &str) -> PathBuf {
@@ -430,6 +430,66 @@ fn bootstrap_supports_composite_identity_execution() {
     assert_eq!(
         execution.outcome.session.phase,
         simard::SessionPhase::Complete
+    );
+}
+
+#[test]
+fn bootstrap_meeting_mode_persists_structured_decision_memory() {
+    let config = BootstrapConfig::resolve(BootstrapInputs {
+        prompt_root: Some(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("prompt_assets")),
+        objective: Some(
+            "agenda: review next Simard milestone\nupdate: durable memory shipped in PR 29\ndecision: prioritize meeting mode before remote orchestration\nrisk: workflow runner keeps drifting worktrees\nnext-step: add outside-in meeting probe\nopen-question: when should meeting decisions auto-influence engineer planning?"
+                .to_string(),
+        ),
+        identity: Some("simard-meeting".to_string()),
+        base_type: Some("local-harness".to_string()),
+        topology: Some("single-process".to_string()),
+        state_root: Some(state_root("meeting-mode")),
+        ..BootstrapInputs::default()
+    })
+    .expect("meeting bootstrap config should resolve");
+
+    let execution = run_local_session(&config).expect("meeting mode should execute");
+    let exported = latest_local_handoff(&config)
+        .expect("meeting handoff lookup should succeed")
+        .expect("meeting handoff should exist");
+    let decision_records = exported
+        .memory_records
+        .iter()
+        .filter(|record| record.scope == MemoryScope::Decision)
+        .collect::<Vec<_>>();
+
+    assert_eq!(execution.snapshot.identity_name, "simard-meeting");
+    assert_eq!(
+        execution.snapshot.agent_program_backend.identity,
+        "agent-program::meeting-facilitator"
+    );
+    assert_eq!(decision_records.len(), 1);
+    assert!(
+        decision_records[0]
+            .value
+            .contains("prioritize meeting mode before remote orchestration"),
+        "decision memory should keep the explicit decision"
+    );
+    assert!(
+        decision_records[0]
+            .value
+            .contains("workflow runner keeps drifting worktrees"),
+        "decision memory should keep the explicit risk"
+    );
+    assert!(
+        decision_records[0]
+            .value
+            .contains("add outside-in meeting probe"),
+        "decision memory should keep the next step"
+    );
+    assert!(
+        execution
+            .outcome
+            .reflection
+            .summary
+            .contains("captured 1 decisions, 1 risks, 1 next steps, and 1 open questions"),
+        "meeting reflection should expose the structured capture counts"
     );
 }
 

--- a/tests/gadugi/meeting-mode.sh
+++ b/tests/gadugi/meeting-mode.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+OBJECTIVE="$(cat <<'EOF'
+agenda: align the next Simard product block
+update: durable memory foundation merged in PR 29
+decision: prioritize facilitator behavior before remote orchestration
+risk: workflow automation is still unreliable in clean worktrees
+next-step: ship operator-visible meeting validation
+open-question: how should meeting decisions influence engineer planning?
+EOF
+)"
+
+OUTPUT="$(
+  cargo run --quiet --bin simard_operator_probe -- \
+    meeting-run local-harness single-process \
+    "$OBJECTIVE"
+)"
+
+printf '%s\n' "$OUTPUT"
+
+printf '%s\n' "$OUTPUT" | grep -F "Probe mode: meeting-run" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "Identity: simard-meeting" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "Selected base type: local-harness" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "Topology: single-process" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "Decision records: 1" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "prioritize facilitator behavior before remote orchestration" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "workflow automation is still unreliable in clean worktrees" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "ship operator-visible meeting validation" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "captured 1 decisions, 1 risks, 1 next steps, and 1 open questions" >/dev/null

--- a/tests/gadugi/simard-cli-smoke.yaml
+++ b/tests/gadugi/simard-cli-smoke.yaml
@@ -1,5 +1,5 @@
 name: "Simard Operator Runtime Behavior"
-description: "Outside-in operator coverage for base-type selection, composite identity execution, loopback multi-process runtime wiring, handoff restore behavior, and the shipped benchmark gym starter suite."
+description: "Outside-in operator coverage for base-type selection, composite identity execution, meeting-mode decision capture, loopback multi-process runtime wiring, handoff restore behavior, and the shipped benchmark gym starter suite."
 version: "1.0.0"
 
 config:
@@ -55,6 +55,13 @@ steps:
       command: "tests/gadugi/composite-identity.sh"
     timeout: 300000
 
+  - name: "Meeting mode decision capture"
+    agent: "cli-agent"
+    action: "execute_command"
+    params:
+      command: "tests/gadugi/meeting-mode.sh"
+    timeout: 300000
+
   - name: "Composite handoff roundtrip"
     agent: "cli-agent"
     action: "execute_command"
@@ -82,6 +89,7 @@ metadata:
     - "behavior"
     - "simard"
     - "bootstrap"
+    - "meeting"
     - "handoff"
     - "composite"
     - "benchmark-gym"


### PR DESCRIPTION
## Summary
- add a facilitator-backed meeting agent program for `simard-meeting`
- persist concise structured decision records through the durable state path instead of storing transcript-like output
- expose and validate the operator-facing meeting flow through the probe, docs, and outside-in coverage

## Validation
- `cargo test --all-features --locked`
- `tests/gadugi/smoke-explicit-local.sh`
- `tests/gadugi/smoke-explicit-rusty-clawd.sh`
- `tests/gadugi/smoke-builtin-defaults.sh`
- `tests/gadugi/composite-identity.sh`
- `tests/gadugi/meeting-mode.sh`
- `tests/gadugi/handoff-roundtrip.sh`
- `tests/gadugi/gym-suite.sh`
- `python3 -m pre_commit run --all-files --hook-stage pre-commit`
- `python3 -m pre_commit run --all-files --hook-stage pre-push`

## Prompt/spec reconciliation
This block closes the meeting-mode gap called out in the original Simard prompt and `Specs/ProductArchitecture.md`: Simard can now meet with the operator in a dedicated facilitator mode, capture structured decisions/risks/next steps/open questions, and persist concise decision memory without silently mutating code paths or pretending a richer planning system already exists.

Closes #30
