### PR TITLE
fix: harden terminal-shell shell validation

### DIFF
--- a/src/terminal_session.rs
+++ b/src/terminal_session.rs
@@ -1,3 +1,4 @@
+use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -108,17 +109,53 @@ pub fn execute_terminal_turn(
 
 fn normalize_shell(value: &str, base_type: &str) -> SimardResult<String> {
     let shell = value.trim();
+    let shell_path = Path::new(shell);
     if shell.is_empty()
         || shell.contains('\n')
         || shell.contains('\r')
-        || shell.contains('\'')
         || shell.chars().any(char::is_whitespace)
+        || !shell_path.is_absolute()
+        || !shell
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '/' | '.' | '_' | '-'))
     {
         return Err(SimardError::AdapterInvocationFailed {
             base_type: base_type.to_string(),
-            reason:
-                "terminal-shell only accepts a single shell path token without quotes or whitespace"
-                    .to_string(),
+            reason: "terminal-shell only accepts an absolute shell executable path using safe path characters"
+                .to_string(),
+        });
+    }
+
+    let metadata =
+        fs::metadata(shell_path).map_err(|error| SimardError::AdapterInvocationFailed {
+            base_type: base_type.to_string(),
+            reason: format!(
+                "terminal-shell shell path '{}' could not be inspected: {error}",
+                shell_path.display()
+            ),
+        })?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        if !metadata.is_file() || metadata.permissions().mode() & 0o111 == 0 {
+            return Err(SimardError::AdapterInvocationFailed {
+                base_type: base_type.to_string(),
+                reason: format!(
+                    "terminal-shell shell path '{}' must be an executable file",
+                    shell_path.display()
+                ),
+            });
+        }
+    }
+    #[cfg(not(unix))]
+    if !metadata.is_file() {
+        return Err(SimardError::AdapterInvocationFailed {
+            base_type: base_type.to_string(),
+            reason: format!(
+                "terminal-shell shell path '{}' must be a file",
+                shell_path.display()
+            ),
         });
     }
 
@@ -238,4 +275,39 @@ fn transcript_preview(transcript: &str) -> String {
     }
 
     normalized
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_shell;
+
+    #[test]
+    fn normalize_shell_accepts_known_safe_absolute_shell() {
+        assert_eq!(
+            normalize_shell("/usr/bin/bash", "terminal-shell").unwrap(),
+            "/usr/bin/bash"
+        );
+    }
+
+    #[test]
+    fn normalize_shell_rejects_metacharacters() {
+        let error = normalize_shell("/usr/bin/bash$(printf-pwned)", "terminal-shell").unwrap_err();
+        assert!(
+            error.to_string().contains(
+                "only accepts an absolute shell executable path using safe path characters"
+            ),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn normalize_shell_rejects_relative_paths() {
+        let error = normalize_shell("bash", "terminal-shell").unwrap_err();
+        assert!(
+            error.to_string().contains(
+                "only accepts an absolute shell executable path using safe path characters"
+            ),
+            "unexpected error: {error}"
+        );
+    }
 }

--- a/tests/gadugi/terminal-session.sh
+++ b/tests/gadugi/terminal-session.sh
@@ -22,3 +22,19 @@ printf '%s\n' "$OUTPUT" | grep -F "Adapter capabilities: prompt-assets, session-
 printf '%s\n' "$OUTPUT" | grep -F "Session phase: complete" >/dev/null
 printf '%s\n' "$OUTPUT" | grep -F "Terminal evidence: terminal-command-count=2" >/dev/null
 printf '%s\n' "$OUTPUT" | grep -F "terminal-foundation-ok" >/dev/null
+
+MARKER="$(mktemp /tmp/simard-terminal-injection.XXXXXX)"
+rm -f "$MARKER"
+BAD_OBJECTIVE="$(printf 'shell: /usr/bin/bash$(printf pwned>%s)\ncommand: pwd\n' "$MARKER")"
+
+set +e
+BAD_OUTPUT="$(
+  cargo run --quiet --bin simard_operator_probe -- \
+    terminal-run single-process "$BAD_OBJECTIVE" 2>&1
+)"
+BAD_STATUS=$?
+set -e
+
+[ "$BAD_STATUS" -ne 0 ]
+[ ! -e "$MARKER" ]
+printf '%s\n' "$BAD_OUTPUT" | grep -F "terminal-shell only accepts an absolute shell executable path using safe path characters" >/dev/null


### PR DESCRIPTION
## Summary
- harden `terminal-shell` so `shell:` only accepts an absolute executable path made of safe path characters
- reject non-absolute and metacharacter-bearing shell values before they reach the `script -c` launch string
- add an outside-in regression that proves malicious `shell:` input is rejected without creating the injected side-effect file

## Why
PR #37 introduced `terminal-shell`, but the initial shell normalization logic still allowed command-substitution-style metacharacters such as `$()` to flow into the `script -c` launch command. That made command injection possible through the operator-facing objective.

## Validation
- `cargo fmt --all`
- `cargo test --all-features --locked`
- `tests/gadugi/terminal-session.sh`
- `tests/gadugi/smoke-explicit-local.sh`
- `tests/gadugi/smoke-explicit-rusty-clawd.sh`
- `tests/gadugi/smoke-builtin-defaults.sh`
- `tests/gadugi/composite-identity.sh`
- `tests/gadugi/meeting-mode.sh`
- `tests/gadugi/handoff-roundtrip.sh`
- `tests/gadugi/review-mode.sh`
- `tests/gadugi/gym-suite.sh`
- `python3 -m pre_commit run --all-files --hook-stage pre-commit`
- `python3 -m pre_commit run --all-files --hook-stage pre-push`

Closes #38.
