### PR TITLE
test: expand terminal-shell validation coverage

### DIFF
--- a/src/terminal_session.rs
+++ b/src/terminal_session.rs
@@ -287,6 +287,45 @@ mod tests {
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
 
+    enum TempPathKind {
+        File,
+        Directory,
+    }
+
+    struct TempPathGuard {
+        path: PathBuf,
+        kind: TempPathKind,
+    }
+
+    impl TempPathGuard {
+        fn directory(path: PathBuf) -> Self {
+            Self {
+                path,
+                kind: TempPathKind::Directory,
+            }
+        }
+
+        fn file(path: PathBuf) -> Self {
+            Self {
+                path,
+                kind: TempPathKind::File,
+            }
+        }
+    }
+
+    impl Drop for TempPathGuard {
+        fn drop(&mut self) {
+            match self.kind {
+                TempPathKind::File => {
+                    let _ = fs::remove_file(&self.path);
+                }
+                TempPathKind::Directory => {
+                    let _ = fs::remove_dir(&self.path);
+                }
+            }
+        }
+    }
+
     fn assert_invalid_shell(shell: &str, expected: &str) {
         let error = normalize_shell(shell, "terminal-shell").unwrap_err();
         assert!(
@@ -359,8 +398,8 @@ mod tests {
     fn normalize_shell_rejects_directories() {
         let directory = unique_test_path("dir");
         fs::create_dir(&directory).unwrap();
+        let _guard = TempPathGuard::directory(directory.clone());
         let result = normalize_shell(directory.to_string_lossy().as_ref(), "terminal-shell");
-        fs::remove_dir(&directory).unwrap();
 
         let error = result.unwrap_err();
         assert!(
@@ -374,13 +413,13 @@ mod tests {
     fn normalize_shell_rejects_non_executable_files() {
         let file = unique_test_path("file");
         fs::write(&file, "#!/bin/sh\nexit 0\n").unwrap();
+        let _guard = TempPathGuard::file(file.clone());
 
         let mut permissions = fs::metadata(&file).unwrap().permissions();
         permissions.set_mode(0o644);
         fs::set_permissions(&file, permissions).unwrap();
 
         let result = normalize_shell(file.to_string_lossy().as_ref(), "terminal-shell");
-        fs::remove_file(&file).unwrap();
 
         let error = result.unwrap_err();
         assert!(

--- a/src/terminal_session.rs
+++ b/src/terminal_session.rs
@@ -280,6 +280,31 @@ fn transcript_preview(transcript: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::normalize_shell;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
+    fn assert_invalid_shell(shell: &str, expected: &str) {
+        let error = normalize_shell(shell, "terminal-shell").unwrap_err();
+        assert!(
+            error.to_string().contains(expected),
+            "unexpected error for {shell:?}: {error}"
+        );
+    }
+
+    fn unique_test_path(label: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "simard-terminal-shell-{label}-{}-{nanos}",
+            std::process::id()
+        ))
+    }
 
     #[test]
     fn normalize_shell_accepts_known_safe_absolute_shell() {
@@ -291,22 +316,75 @@ mod tests {
 
     #[test]
     fn normalize_shell_rejects_metacharacters() {
-        let error = normalize_shell("/usr/bin/bash$(printf-pwned)", "terminal-shell").unwrap_err();
-        assert!(
-            error.to_string().contains(
-                "only accepts an absolute shell executable path using safe path characters"
-            ),
-            "unexpected error: {error}"
-        );
+        for shell in [
+            "/usr/bin/bash$(printf-pwned)",
+            "/usr/bin/bash;whoami",
+            "/usr/bin/bash&",
+            "/usr/bin/bash|cat",
+            "/usr/bin/bash>file",
+            "/usr/bin/bash`whoami`",
+        ] {
+            assert_invalid_shell(
+                shell,
+                "only accepts an absolute shell executable path using safe path characters",
+            );
+        }
     }
 
     #[test]
     fn normalize_shell_rejects_relative_paths() {
-        let error = normalize_shell("bash", "terminal-shell").unwrap_err();
+        assert_invalid_shell(
+            "bash",
+            "only accepts an absolute shell executable path using safe path characters",
+        );
+    }
+
+    #[test]
+    fn normalize_shell_rejects_empty_or_whitespace_only_values() {
+        for shell in ["", "   ", "\t", "/usr/bin/bash whoami"] {
+            assert_invalid_shell(
+                shell,
+                "only accepts an absolute shell executable path using safe path characters",
+            );
+        }
+    }
+
+    #[test]
+    fn normalize_shell_rejects_missing_files() {
+        let missing = unique_test_path("missing");
+        assert_invalid_shell(missing.to_string_lossy().as_ref(), "could not be inspected");
+    }
+
+    #[test]
+    fn normalize_shell_rejects_directories() {
+        let directory = unique_test_path("dir");
+        fs::create_dir(&directory).unwrap();
+        let result = normalize_shell(directory.to_string_lossy().as_ref(), "terminal-shell");
+        fs::remove_dir(&directory).unwrap();
+
+        let error = result.unwrap_err();
         assert!(
-            error.to_string().contains(
-                "only accepts an absolute shell executable path using safe path characters"
-            ),
+            error.to_string().contains("must be an executable file"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn normalize_shell_rejects_non_executable_files() {
+        let file = unique_test_path("file");
+        fs::write(&file, "#!/bin/sh\nexit 0\n").unwrap();
+
+        let mut permissions = fs::metadata(&file).unwrap().permissions();
+        permissions.set_mode(0o644);
+        fs::set_permissions(&file, permissions).unwrap();
+
+        let result = normalize_shell(file.to_string_lossy().as_ref(), "terminal-shell");
+        fs::remove_file(&file).unwrap();
+
+        let error = result.unwrap_err();
+        assert!(
+            error.to_string().contains("must be an executable file"),
             "unexpected error: {error}"
         );
     }


### PR DESCRIPTION
## Summary
- expand explicit regression coverage for `terminal-shell` shell validation
- add unit tests for additional metacharacters, empty/whitespace input, missing files, directories, and non-executable files
- keep the existing operator-level regression proving malicious `shell:` input is rejected without side effects

## Why
PR #39 fixed the actual shell-path injection bug, but the validation was security-critical and under-tested. This follow-up makes the rejection matrix explicit so later edits to `normalize_shell()` have a tighter safety net.

## Validation
- `cargo fmt --all`
- `cargo test --all-features --locked terminal_session`
- `cargo test --all-features --locked`
- `tests/gadugi/terminal-session.sh`
- `python3 -m pre_commit run --all-files --hook-stage pre-commit`
- `python3 -m pre_commit run --all-files --hook-stage pre-push`

Closes #40.
