### PR TITLE
feat: add local engineer loop

### DIFF
--- a/docs/howto/configure-bootstrap-and-inspect-reflection.md
+++ b/docs/howto/configure-bootstrap-and-inspect-reflection.md
@@ -199,6 +199,27 @@ Look for:
 
 This is the honest v1 terminal slice: Simard can drive a real local PTY-backed shell session through the runtime, but it does not claim remote hosts, Azlin orchestration, or distributed terminal control yet.
 
+## 7. Exercise the local-first engineer loop
+
+Use the operator probe when you want Simard to inspect a repo, choose one safe local engineering action, verify the outcome, and persist truthful local artifacts:
+
+```bash
+cargo run --quiet --bin simard_operator_probe -- \
+  engineer-loop-run single-process . \
+  $'inspect the repository state\nrun one safe local engineering action\nverify the outcome explicitly\npersist truthful local evidence and memory'
+```
+
+Look for:
+
+- `Probe mode: engineer-loop-run`
+- `Repo root: ...`
+- `Execution scope: local-only`
+- `Selected action: cargo-metadata-scan` (or another explicit local-first action)
+- `Action status: success`
+- `Verification status: verified`
+
+This is the current honest v1 engineer-loop slice: Simard inspects the local repo, performs one bounded repo-native action, verifies that the repo grounding stayed stable, and persists durable memory/evidence, but it does not claim remote execution or autonomous multi-step coding yet.
+
 ## 4. Validate stopped-state behavior
 
 Stopping the runtime is already observable.

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,7 @@ Today Simard provides:
 - builtin identities selectable at startup today: `simard-engineer`, `simard-meeting`, `simard-gym`, and the composite `simard-composite-engineer`
 - a facilitator-backed `simard-meeting` identity that captures structured decisions, risks, next steps, and open questions without mutating code
 - `single-process` for all builtin base types plus loopback `multi-process` execution for `rusty-clawd`, with `terminal-shell` intentionally limited to local single-process runs and unsupported pairs failing explicitly
+- a local-first engineer loop probe that inspects repo state, runs one explicit safe engineering action, verifies the outcome, and persists truthful local evidence/memory without pretending remote orchestration already exists
 - a starter benchmark gym suite that exercises all current builtin base-type selections plus a composite identity session through `cargo run --quiet --bin simard-gym -- run-suite starter`
 - benchmark artifacts written under `target/simard-gym/`, including per-scenario JSON and text summaries, a dedicated review artifact, and a suite summary
 - `ManifestContract { entrypoint, composition, precedence, provenance, freshness }`
@@ -62,7 +63,7 @@ Those hooks enforce `cargo fmt --all -- --check`, `cargo clippy --all-targets --
 
 - `src/main.rs` is the thin CLI wrapper; `bootstrap::run_local_session` owns the run loop and `simard::bootstrap::assemble_local_runtime` remains the reflected assembly boundary
 - `src/bin/simard_gym.rs` is the operator-facing benchmark CLI for the starter gym suite
-- `src/bin/simard_operator_probe.rs` now exposes `review-run` so operators can run a bounded session, inspect the exported handoff, and persist evidence-linked review proposals
+- `src/bin/simard_operator_probe.rs` now exposes `terminal-run`, `engineer-loop-run`, and `review-run` so operators can inspect bounded shell execution, the local-first engineer loop, and evidence-linked review proposals through public surfaces
 - `bootstrap::run_local_session` now persists durable memory/evidence records and the latest handoff snapshot under the configured state root
 - defaults are startup choices, never silent runtime recovery
 - reflection metadata is derived from the active runtime wiring, not placeholder labels

--- a/docs/reference/runtime-contracts.md
+++ b/docs/reference/runtime-contracts.md
@@ -19,11 +19,12 @@ This file describes the API shape that exists in the repository today.
 
 ## Public surfaces
 
-Simard v1 currently exposes four surfaces:
+Simard v1 currently exposes five surfaces:
 
 - the local CLI bootstrap path through `cargo run --quiet`
 - the benchmark gym CLI through `cargo run --quiet --bin simard-gym -- ...`
 - the operator/runtime probe through `cargo run --quiet --bin simard_operator_probe -- ...`
+- the local-first engineer loop probe through `cargo run --quiet --bin simard_operator_probe -- engineer-loop-run <topology> <workspace-root> <objective>`
 - the in-process Rust runtime/bootstrap types in `src/bootstrap.rs`, `src/runtime.rs`, and related modules
 
 Simard v1 does **not** currently expose:
@@ -36,9 +37,10 @@ The stable contract in this repository is the bootstrap/runtime and benchmark-gy
 
 ## Meeting-mode operator flow
 
-The shipped operator probe also supports meeting-specific and terminal-session-specific paths:
+The shipped operator probe also supports meeting-specific, terminal-session-specific, and engineer-loop-specific paths:
 
 - `cargo run --quiet --bin simard_operator_probe -- meeting-run <base-type> <topology> <structured-objective>`
+- `cargo run --quiet --bin simard_operator_probe -- engineer-loop-run <topology> <workspace-root> <objective>`
 - `cargo run --quiet --bin simard_operator_probe -- review-run <base-type> <topology> <objective>`
 - `cargo run --quiet --bin simard_operator_probe -- review-read <base-type> <topology>`
 

--- a/docs/tutorials/run-your-first-local-session.md
+++ b/docs/tutorials/run-your-first-local-session.md
@@ -104,6 +104,28 @@ Terminal evidence: terminal-command-count=2
 
 **Checkpoint**: this path is no longer synthetic. The runtime is actually allocating a local PTY-backed shell session and preserving a transcript preview in evidence, while still honestly limiting the feature to local single-process execution.
 
+### Variation: exercise the local-first engineer loop
+
+Use the shipped operator probe to inspect the repo, run one explicit safe engineering action, and verify the result:
+
+```bash
+cargo run --quiet --bin simard_operator_probe -- \
+  engineer-loop-run single-process . \
+  $'inspect the repository state\nrun one safe local engineering action\nverify the outcome explicitly\npersist truthful local evidence and memory'
+```
+
+Look for these lines:
+
+```text
+Probe mode: engineer-loop-run
+Repo root: /path/to/repo
+Execution scope: local-only
+Selected action: cargo-metadata-scan
+Verification status: verified
+```
+
+**Checkpoint**: Simard is now doing more than opening a shell. It is inspecting repo state, choosing a bounded repo-native action, verifying that repo grounding stayed stable, and persisting truthful memory/evidence for the loop.
+
 ## Step 3: Exercise a composite identity and loopback multi-process runtime
 
 Use the shipped operator probe to validate the broader runtime seams like an operator would.

--- a/src/bin/simard_operator_probe.rs
+++ b/src/bin/simard_operator_probe.rs
@@ -1,10 +1,10 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use simard::{
     BootstrapConfig, BootstrapInputs, FileBackedMemoryStore, MemoryRecord, MemoryScope,
-    MemoryStore, ReflectiveRuntime, ReviewRequest, ReviewTargetKind,
+    MemoryStore, ReflectiveRuntime, ReviewRequest, ReviewTargetKind, RuntimeTopology,
     assemble_local_runtime_from_handoff, build_review_artifact, latest_local_handoff,
-    latest_review_artifact, persist_review_artifact,
+    latest_review_artifact, persist_review_artifact, run_local_engineer_loop,
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -36,6 +36,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let topology = args.next().ok_or("expected topology")?;
             let objective = args.next().ok_or("expected objective")?;
             run_terminal_probe(&topology, &objective)?;
+        }
+        "engineer-loop-run" => {
+            let topology = args.next().ok_or("expected topology")?;
+            let workspace_root = args.next().ok_or("expected workspace root")?;
+            let objective = args.next().ok_or("expected objective")?;
+            run_engineer_loop_probe(&topology, Path::new(&workspace_root), &objective)?;
         }
         "review-run" => {
             let base_type = args.next().ok_or("expected base type")?;
@@ -296,6 +302,46 @@ fn run_terminal_probe(topology: &str, objective: &str) -> Result<(), Box<dyn std
     Ok(())
 }
 
+fn run_engineer_loop_probe(
+    topology: &str,
+    workspace_root: &Path,
+    objective: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let runtime_topology = parse_runtime_topology(topology)?;
+    let state_root = state_root(
+        "simard-engineer",
+        "terminal-shell",
+        topology,
+        "engineer-loop-run",
+    );
+    let run = run_local_engineer_loop(workspace_root, objective, runtime_topology, &state_root)
+        .map_err(|error| format!("{error}"))?;
+
+    println!("Probe mode: engineer-loop-run");
+    println!("Repo root: {}", run.inspection.repo_root.display());
+    println!("Repo branch: {}", run.inspection.branch);
+    println!("Repo head: {}", run.inspection.head);
+    println!("Worktree dirty: {}", run.inspection.worktree_dirty);
+    println!(
+        "Changed files: {}",
+        if run.inspection.changed_files.is_empty() {
+            "<none>".to_string()
+        } else {
+            run.inspection.changed_files.join(", ")
+        }
+    );
+    println!("Gap summary: {}", run.inspection.architecture_gap_summary);
+    println!("Execution scope: {}", run.execution_scope);
+    println!("Selected action: {}", run.action.selected.label);
+    println!("Action rationale: {}", run.action.selected.rationale);
+    println!("Action command: {}", run.action.selected.argv.join(" "));
+    println!("Action status: success");
+    println!("Verification status: {}", run.verification.status);
+    println!("Verification summary: {}", run.verification.summary);
+    println!("State root: {}", run.state_root.display());
+    Ok(())
+}
+
 fn run_review_probe(
     base_type: &str,
     topology: &str,
@@ -411,4 +457,16 @@ fn run_review_read_probe(
         println!("Latest decision review record: {}", record.value);
     }
     Ok(())
+}
+
+fn parse_runtime_topology(value: &str) -> Result<RuntimeTopology, Box<dyn std::error::Error>> {
+    match value {
+        "single-process" => Ok(RuntimeTopology::SingleProcess),
+        "multi-process" => Ok(RuntimeTopology::MultiProcess),
+        "distributed" => Ok(RuntimeTopology::Distributed),
+        other => Err(format!(
+            "unsupported runtime topology '{other}'; expected single-process, multi-process, or distributed"
+        )
+        .into()),
+    }
 }

--- a/src/engineer_loop.rs
+++ b/src/engineer_loop.rs
@@ -1,0 +1,580 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+use crate::base_types::BaseTypeId;
+use crate::error::{SimardError, SimardResult};
+use crate::evidence::{EvidenceRecord, EvidenceSource, EvidenceStore, FileBackedEvidenceStore};
+use crate::handoff::{FileBackedHandoffStore, RuntimeHandoffSnapshot, RuntimeHandoffStore};
+use crate::memory::{FileBackedMemoryStore, MemoryRecord, MemoryScope, MemoryStore};
+use crate::runtime::{RuntimeAddress, RuntimeNodeId, RuntimeState, RuntimeTopology};
+use crate::sanitization::{objective_metadata, sanitize_terminal_text};
+use crate::session::{SessionPhase, SessionRecord, UuidSessionIdGenerator};
+
+const ENGINEER_IDENTITY: &str = "simard-engineer";
+const ENGINEER_BASE_TYPE: &str = "terminal-shell";
+const EXECUTION_SCOPE: &str = "local-only";
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RepoInspection {
+    pub workspace_root: PathBuf,
+    pub repo_root: PathBuf,
+    pub branch: String,
+    pub head: String,
+    pub worktree_dirty: bool,
+    pub changed_files: Vec<String>,
+    pub architecture_gap_summary: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SelectedEngineerAction {
+    pub label: String,
+    pub rationale: String,
+    pub argv: Vec<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ExecutedEngineerAction {
+    pub selected: SelectedEngineerAction,
+    pub exit_code: i32,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VerificationReport {
+    pub status: String,
+    pub summary: String,
+    pub checks: Vec<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EngineerLoopRun {
+    pub state_root: PathBuf,
+    pub execution_scope: String,
+    pub inspection: RepoInspection,
+    pub action: ExecutedEngineerAction,
+    pub verification: VerificationReport,
+}
+
+pub fn run_local_engineer_loop(
+    workspace_root: impl AsRef<Path>,
+    objective: &str,
+    topology: RuntimeTopology,
+    state_root: impl Into<PathBuf>,
+) -> SimardResult<EngineerLoopRun> {
+    let state_root = state_root.into();
+    let inspection = inspect_workspace(workspace_root.as_ref())?;
+    let selected_action = select_engineer_action(&inspection)?;
+    let action = execute_engineer_action(&inspection.repo_root, selected_action)?;
+    let verification = verify_engineer_action(&inspection, &action)?;
+    persist_engineer_loop_artifacts(
+        &state_root,
+        topology,
+        objective,
+        &inspection,
+        &action,
+        &verification,
+    )?;
+
+    Ok(EngineerLoopRun {
+        state_root,
+        execution_scope: EXECUTION_SCOPE.to_string(),
+        inspection,
+        action,
+        verification,
+    })
+}
+
+fn inspect_workspace(workspace_root: &Path) -> SimardResult<RepoInspection> {
+    let workspace_root =
+        fs::canonicalize(workspace_root).map_err(|error| SimardError::NotARepo {
+            path: workspace_root.to_path_buf(),
+            reason: format!("workspace path could not be resolved: {error}"),
+        })?;
+    let repo_root_output = run_command(&workspace_root, &["git", "rev-parse", "--show-toplevel"])?;
+    let repo_root = PathBuf::from(trimmed_stdout(&repo_root_output)?);
+    let repo_root = fs::canonicalize(&repo_root).map_err(|error| SimardError::NotARepo {
+        path: repo_root,
+        reason: format!("git worktree root could not be canonicalized: {error}"),
+    })?;
+
+    let branch_output = run_command(&repo_root, &["git", "branch", "--show-current"])?;
+    let branch = trimmed_stdout_allow_empty(&branch_output);
+    let head = trimmed_stdout(&run_command(&repo_root, &["git", "rev-parse", "HEAD"])?)?;
+    let status_output = run_command(
+        &repo_root,
+        &["git", "status", "--short", "--untracked-files=all"],
+    )?;
+    let changed_files = parse_status_paths(&status_output.stdout);
+    let worktree_dirty = !changed_files.is_empty();
+
+    Ok(RepoInspection {
+        workspace_root,
+        repo_root: repo_root.clone(),
+        branch: if branch.is_empty() {
+            "HEAD".to_string()
+        } else {
+            branch
+        },
+        head,
+        worktree_dirty,
+        changed_files,
+        architecture_gap_summary: architecture_gap_summary(&repo_root)?,
+    })
+}
+
+fn architecture_gap_summary(repo_root: &Path) -> SimardResult<String> {
+    let architecture_path = repo_root.join("Specs/ProductArchitecture.md");
+    let probe_path = repo_root.join("src/bin/simard_operator_probe.rs");
+    let runtime_contracts_path = repo_root.join("docs/reference/runtime-contracts.md");
+
+    let architecture_exists = architecture_path.is_file();
+    let probe_exists = probe_path.is_file();
+    let operator_surface = if probe_exists {
+        let source = fs::read_to_string(&probe_path).map_err(|error| SimardError::ArtifactIo {
+            path: probe_path.clone(),
+            reason: error.to_string(),
+        })?;
+        if source.contains("\"engineer-loop-run\"") {
+            "operator probe already exposes engineer-loop-run".to_string()
+        } else if source.contains("\"terminal-run\"") {
+            "operator probe exposes terminal-run but not a repo-grounded engineer-loop-run"
+                .to_string()
+        } else {
+            "operator probe exists but does not yet expose a terminal engineer loop".to_string()
+        }
+    } else {
+        "operator probe file is missing".to_string()
+    };
+
+    let review_trace = if runtime_contracts_path.is_file() {
+        "runtime contracts docs mention operator/runtime public surfaces and prior spec reconciliation"
+    } else {
+        "runtime contracts docs are absent, so gap trace comes only from code and architecture files"
+    };
+
+    Ok(match architecture_exists {
+        true => format!(
+            "Compared current operator/runtime surfaces against Specs/ProductArchitecture.md: the architecture requires inspect -> act -> verify -> persist in engineer mode, and {operator_surface}; {review_trace}."
+        ),
+        false => format!(
+            "Repository is missing Specs/ProductArchitecture.md, so the gap trace falls back to current operator/runtime surfaces only; {operator_surface}; {review_trace}."
+        ),
+    })
+}
+
+fn select_engineer_action(inspection: &RepoInspection) -> SimardResult<SelectedEngineerAction> {
+    if inspection.repo_root.join("Cargo.toml").is_file() {
+        return Ok(SelectedEngineerAction {
+            label: "cargo-metadata-scan".to_string(),
+            rationale: "Detected a Rust workspace via Cargo.toml, so the next honest v1 action is a local argv-only cargo metadata scan that inspects the workspace graph without pretending remote orchestration exists.".to_string(),
+            argv: vec![
+                "cargo".to_string(),
+                "metadata".to_string(),
+                "--format-version".to_string(),
+                "1".to_string(),
+                "--no-deps".to_string(),
+            ],
+        });
+    }
+
+    if inspection.repo_root.join(".git").exists() {
+        return Ok(SelectedEngineerAction {
+            label: "git-tracked-file-scan".to_string(),
+            rationale: "No repo-native language manifest was detected, so the loop falls back to a local argv-only scan of tracked files instead of inventing unsupported tooling.".to_string(),
+            argv: vec!["git".to_string(), "ls-files".to_string(), "--cached".to_string()],
+        });
+    }
+
+    Err(SimardError::UnsupportedEngineerAction {
+        reason: format!(
+            "workspace '{}' is repo-grounded but exposes no supported local-first action policy",
+            inspection.repo_root.display()
+        ),
+    })
+}
+
+fn execute_engineer_action(
+    repo_root: &Path,
+    selected: SelectedEngineerAction,
+) -> SimardResult<ExecutedEngineerAction> {
+    let argv = selected.argv.iter().map(String::as_str).collect::<Vec<_>>();
+    let output = run_command(repo_root, &argv)?;
+    Ok(ExecutedEngineerAction {
+        selected,
+        exit_code: output.status.code().unwrap_or_default(),
+        stdout: sanitize_terminal_text(&output.stdout),
+        stderr: sanitize_terminal_text(&output.stderr),
+    })
+}
+
+fn verify_engineer_action(
+    inspection: &RepoInspection,
+    action: &ExecutedEngineerAction,
+) -> SimardResult<VerificationReport> {
+    if action.exit_code != 0 {
+        return Err(SimardError::VerificationFailed {
+            reason: format!(
+                "selected action '{}' exited with code {}",
+                action.selected.label, action.exit_code
+            ),
+        });
+    }
+
+    let post = inspect_workspace(&inspection.repo_root)?;
+    let mut checks = Vec::new();
+
+    if post.repo_root != inspection.repo_root {
+        return Err(SimardError::VerificationFailed {
+            reason: format!(
+                "repo root changed from '{}' to '{}'",
+                inspection.repo_root.display(),
+                post.repo_root.display()
+            ),
+        });
+    }
+    checks.push(format!("repo-root={}", post.repo_root.display()));
+
+    if post.head != inspection.head {
+        return Err(SimardError::VerificationFailed {
+            reason: format!("HEAD changed from '{}' to '{}'", inspection.head, post.head),
+        });
+    }
+    checks.push(format!("repo-head={}", post.head));
+
+    if post.branch != inspection.branch {
+        return Err(SimardError::VerificationFailed {
+            reason: format!(
+                "branch changed from '{}' to '{}'",
+                inspection.branch, post.branch
+            ),
+        });
+    }
+    checks.push(format!("repo-branch={}", post.branch));
+
+    if post.worktree_dirty != inspection.worktree_dirty
+        || post.changed_files != inspection.changed_files
+    {
+        return Err(SimardError::VerificationFailed {
+            reason: "worktree state changed during a non-mutating local engineer action"
+                .to_string(),
+        });
+    }
+    checks.push(format!("worktree-dirty={}", post.worktree_dirty));
+
+    match action.selected.label.as_str() {
+        "cargo-metadata-scan" => {
+            verify_cargo_metadata(&inspection.repo_root, &action.stdout, &mut checks)?
+        }
+        "git-tracked-file-scan" => {
+            if action.stdout.lines().next().is_none() {
+                return Err(SimardError::VerificationFailed {
+                    reason: "git tracked-file scan returned no tracked files".to_string(),
+                });
+            }
+            checks.push("tracked-files-present=true".to_string());
+        }
+        other => {
+            return Err(SimardError::VerificationFailed {
+                reason: format!("verification rules are missing for selected action '{other}'"),
+            });
+        }
+    }
+
+    Ok(VerificationReport {
+        status: "verified".to_string(),
+        summary: format!(
+            "Verified local-only engineer action '{}' against stable repo grounding, unchanged worktree state, and explicit repo-native action checks.",
+            action.selected.label
+        ),
+        checks,
+    })
+}
+
+fn verify_cargo_metadata(
+    repo_root: &Path,
+    stdout: &str,
+    checks: &mut Vec<String>,
+) -> SimardResult<()> {
+    let payload: Value =
+        serde_json::from_str(stdout).map_err(|error| SimardError::VerificationFailed {
+            reason: format!("cargo metadata output was not valid JSON: {error}"),
+        })?;
+    let workspace_root = payload
+        .get("workspace_root")
+        .and_then(Value::as_str)
+        .ok_or_else(|| SimardError::VerificationFailed {
+            reason: "cargo metadata output did not include workspace_root".to_string(),
+        })?;
+    let workspace_root =
+        fs::canonicalize(workspace_root).map_err(|error| SimardError::VerificationFailed {
+            reason: format!("cargo metadata workspace_root could not be canonicalized: {error}"),
+        })?;
+    if workspace_root != repo_root {
+        return Err(SimardError::VerificationFailed {
+            reason: format!(
+                "cargo metadata reported workspace_root '{}' instead of '{}'",
+                workspace_root.display(),
+                repo_root.display()
+            ),
+        });
+    }
+    checks.push(format!(
+        "metadata-workspace-root={}",
+        workspace_root.display()
+    ));
+
+    let packages = payload
+        .get("packages")
+        .and_then(Value::as_array)
+        .ok_or_else(|| SimardError::VerificationFailed {
+            reason: "cargo metadata output did not include packages".to_string(),
+        })?;
+    if packages.is_empty() {
+        return Err(SimardError::VerificationFailed {
+            reason: "cargo metadata reported an empty package list".to_string(),
+        });
+    }
+    checks.push(format!("metadata-packages={}", packages.len()));
+    Ok(())
+}
+
+fn persist_engineer_loop_artifacts(
+    state_root: &Path,
+    topology: RuntimeTopology,
+    objective: &str,
+    inspection: &RepoInspection,
+    action: &ExecutedEngineerAction,
+    verification: &VerificationReport,
+) -> SimardResult<()> {
+    let memory_store = FileBackedMemoryStore::try_new(state_root.join("memory_records.json"))?;
+    let evidence_store =
+        FileBackedEvidenceStore::try_new(state_root.join("evidence_records.json"))?;
+    let handoff_store = FileBackedHandoffStore::try_new(state_root.join("latest_handoff.json"))?;
+
+    let session_ids = UuidSessionIdGenerator;
+    let mut session = SessionRecord::new(
+        crate::identity::OperatingMode::Engineer,
+        objective.to_string(),
+        BaseTypeId::new(ENGINEER_BASE_TYPE),
+        &session_ids,
+    );
+    session.advance(SessionPhase::Preparation)?;
+
+    let scratch_key = format!("{}-engineer-loop-scratch", session.id);
+    memory_store.put(MemoryRecord {
+        key: scratch_key.clone(),
+        scope: MemoryScope::SessionScratch,
+        value: objective_metadata(objective),
+        session_id: session.id.clone(),
+        recorded_in: SessionPhase::Preparation,
+    })?;
+    session.attach_memory(scratch_key);
+
+    session.advance(SessionPhase::Planning)?;
+    session.advance(SessionPhase::Execution)?;
+    let evidence_details = vec![
+        format!("repo-root={}", inspection.repo_root.display()),
+        format!("repo-branch={}", inspection.branch),
+        format!("repo-head={}", inspection.head),
+        format!("worktree-dirty={}", inspection.worktree_dirty),
+        format!(
+            "changed-files={}",
+            if inspection.changed_files.is_empty() {
+                "<none>".to_string()
+            } else {
+                inspection.changed_files.join(", ")
+            }
+        ),
+        format!("architecture-gap={}", inspection.architecture_gap_summary),
+        format!("execution-scope={EXECUTION_SCOPE}"),
+        format!("selected-action={}", action.selected.label),
+        format!("selected-action-rationale={}", action.selected.rationale),
+        format!("action-command={}", action.selected.argv.join(" ")),
+        "action-status=success".to_string(),
+        format!("action-exit-code={}", action.exit_code),
+        format!("verification-status={}", verification.status),
+        format!("verification-summary={}", verification.summary),
+    ];
+
+    for (index, detail) in evidence_details.into_iter().enumerate() {
+        let evidence_id = format!("{}-engineer-loop-evidence-{}", session.id, index + 1);
+        evidence_store.record(EvidenceRecord {
+            id: evidence_id.clone(),
+            session_id: session.id.clone(),
+            phase: SessionPhase::Execution,
+            detail,
+            source: EvidenceSource::Runtime,
+        })?;
+        session.attach_evidence(evidence_id);
+    }
+
+    session.advance(SessionPhase::Reflection)?;
+    session.advance(SessionPhase::Persistence)?;
+
+    let summary_key = format!("{}-engineer-loop-summary", session.id);
+    memory_store.put(MemoryRecord {
+        key: summary_key.clone(),
+        scope: MemoryScope::SessionSummary,
+        value: format!(
+            "engineer-loop-summary | repo-root={} | repo-branch={} | worktree-dirty={} | selected-action={} | verification-status={} | execution-scope={EXECUTION_SCOPE}",
+            inspection.repo_root.display(),
+            inspection.branch,
+            inspection.worktree_dirty,
+            action.selected.label,
+            verification.status
+        ),
+        session_id: session.id.clone(),
+        recorded_in: SessionPhase::Persistence,
+    })?;
+    session.attach_memory(summary_key);
+
+    let decision_key = format!("{}-engineer-loop-decision", session.id);
+    memory_store.put(MemoryRecord {
+        key: decision_key.clone(),
+        scope: MemoryScope::Decision,
+        value: format!(
+            "engineer-loop-decision | {} | {}",
+            action.selected.rationale, verification.summary
+        ),
+        session_id: session.id.clone(),
+        recorded_in: SessionPhase::Persistence,
+    })?;
+    session.attach_memory(decision_key);
+
+    session.advance(SessionPhase::Complete)?;
+
+    let handoff = RuntimeHandoffSnapshot {
+        exported_state: RuntimeState::Ready,
+        identity_name: ENGINEER_IDENTITY.to_string(),
+        selected_base_type: BaseTypeId::new(ENGINEER_BASE_TYPE),
+        topology,
+        source_runtime_node: RuntimeNodeId::local(),
+        source_mailbox_address: RuntimeAddress::local(&RuntimeNodeId::local()),
+        session: Some(session.redacted_for_handoff()),
+        memory_records: memory_store.list_for_session(&session.id)?,
+        evidence_records: evidence_store.list_for_session(&session.id)?,
+    };
+    handoff_store.save(handoff)?;
+    Ok(())
+}
+
+struct CommandOutput {
+    status: std::process::ExitStatus,
+    stdout: String,
+    stderr: String,
+}
+
+fn run_command(cwd: &Path, argv: &[&str]) -> SimardResult<CommandOutput> {
+    let (program, args) = argv
+        .split_first()
+        .ok_or_else(|| SimardError::ActionExecutionFailed {
+            action: "<empty>".to_string(),
+            reason: "argv command list cannot be empty".to_string(),
+        })?;
+    if argv
+        .iter()
+        .any(|segment| segment.is_empty() || segment.contains('\n') || segment.contains('\r'))
+    {
+        return Err(SimardError::ActionExecutionFailed {
+            action: argv.join(" "),
+            reason: "argv-only command segments must be non-empty single-line values".to_string(),
+        });
+    }
+
+    let output = Command::new(program)
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .map_err(|error| SimardError::ActionExecutionFailed {
+            action: argv.join(" "),
+            reason: error.to_string(),
+        })?;
+    if !output.status.success() {
+        let stderr = sanitize_terminal_text(&String::from_utf8_lossy(&output.stderr));
+        let stdout = sanitize_terminal_text(&String::from_utf8_lossy(&output.stdout));
+        let reason = if stderr.trim().is_empty() {
+            format!(
+                "command exited with status {} and stdout='{}'",
+                output.status,
+                stdout.trim()
+            )
+        } else {
+            format!(
+                "command exited with status {} and stderr='{}'",
+                output.status,
+                stderr.trim()
+            )
+        };
+        let error = if argv.starts_with(&["git", "rev-parse", "--show-toplevel"]) {
+            SimardError::NotARepo {
+                path: cwd.to_path_buf(),
+                reason,
+            }
+        } else {
+            SimardError::ActionExecutionFailed {
+                action: argv.join(" "),
+                reason,
+            }
+        };
+        return Err(error);
+    }
+
+    Ok(CommandOutput {
+        status: output.status,
+        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+    })
+}
+
+fn trimmed_stdout(output: &CommandOutput) -> SimardResult<String> {
+    let trimmed = output.stdout.trim();
+    if trimmed.is_empty() {
+        return Err(SimardError::VerificationFailed {
+            reason: "expected a non-empty command result while inspecting repo state".to_string(),
+        });
+    }
+
+    Ok(trimmed.to_string())
+}
+
+fn trimmed_stdout_allow_empty(output: &CommandOutput) -> String {
+    output.stdout.trim().to_string()
+}
+
+fn parse_status_paths(stdout: &str) -> Vec<String> {
+    stdout
+        .lines()
+        .map(str::trim_end)
+        .filter(|line| !line.is_empty())
+        .map(|line| {
+            if line.len() > 3 {
+                line[3..].trim().to_string()
+            } else {
+                line.to_string()
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_status_paths;
+
+    #[test]
+    fn git_status_paths_strip_status_prefixes() {
+        let paths =
+            parse_status_paths(" M src/lib.rs\nA  tests/engineer_loop.rs\n?? docs/index.md\n");
+        assert_eq!(
+            paths,
+            vec![
+                "src/lib.rs".to_string(),
+                "tests/engineer_loop.rs".to_string(),
+                "docs/index.md".to_string()
+            ]
+        );
+    }
+}

--- a/src/engineer_loop.rs
+++ b/src/engineer_loop.rs
@@ -16,6 +16,15 @@ use crate::session::{SessionPhase, SessionRecord, UuidSessionIdGenerator};
 const ENGINEER_IDENTITY: &str = "simard-engineer";
 const ENGINEER_BASE_TYPE: &str = "terminal-shell";
 const EXECUTION_SCOPE: &str = "local-only";
+const CLEARED_GIT_ENV_VARS: &[&str] = &[
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_COMMON_DIR",
+    "GIT_PREFIX",
+];
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RepoInspection {
@@ -485,9 +494,12 @@ fn run_command(cwd: &Path, argv: &[&str]) -> SimardResult<CommandOutput> {
         });
     }
 
-    let output = Command::new(program)
-        .args(args)
-        .current_dir(cwd)
+    let mut command = Command::new(program);
+    command.args(args).current_dir(cwd);
+    for key in CLEARED_GIT_ENV_VARS {
+        command.env_remove(key);
+    }
+    let output = command
         .output()
         .map_err(|error| SimardError::ActionExecutionFailed {
             action: argv.join(" "),
@@ -525,8 +537,8 @@ fn run_command(cwd: &Path, argv: &[&str]) -> SimardResult<CommandOutput> {
 
     Ok(CommandOutput {
         status: output.status,
-        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
-        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+        stdout: sanitize_terminal_text(&String::from_utf8_lossy(&output.stdout)),
+        stderr: sanitize_terminal_text(&String::from_utf8_lossy(&output.stderr)),
     })
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -104,6 +104,20 @@ pub enum SimardError {
         field: String,
         reason: String,
     },
+    NotARepo {
+        path: PathBuf,
+        reason: String,
+    },
+    UnsupportedEngineerAction {
+        reason: String,
+    },
+    ActionExecutionFailed {
+        action: String,
+        reason: String,
+    },
+    VerificationFailed {
+        reason: String,
+    },
     PersistentStoreIo {
         store: String,
         action: String,
@@ -243,6 +257,25 @@ impl Display for SimardError {
             }
             Self::InvalidHandoffSnapshot { field, reason } => {
                 write!(f, "invalid handoff snapshot field '{field}': {reason}")
+            }
+            Self::NotARepo { path, reason } => {
+                write!(
+                    f,
+                    "NOT_A_REPO: '{}' is not inside a valid git worktree: {reason}",
+                    path.display()
+                )
+            }
+            Self::UnsupportedEngineerAction { reason } => {
+                write!(
+                    f,
+                    "no supported local engineer action is available: {reason}"
+                )
+            }
+            Self::ActionExecutionFailed { action, reason } => {
+                write!(f, "engineer action '{action}' failed: {reason}")
+            }
+            Self::VerificationFailed { reason } => {
+                write!(f, "engineer loop verification failed: {reason}")
             }
             Self::PersistentStoreIo {
                 store,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod agent_program;
 pub mod base_types;
 pub mod bootstrap;
+pub mod engineer_loop;
 pub mod error;
 pub mod evidence;
 pub mod gym;
@@ -31,6 +32,10 @@ pub use bootstrap::{
     LocalSessionExecution, assemble_local_runtime, assemble_local_runtime_from_handoff,
     bootstrap_entrypoint, builtin_base_type_registry_for_manifest, latest_local_handoff,
     run_local_session,
+};
+pub use engineer_loop::{
+    EngineerLoopRun, ExecutedEngineerAction, RepoInspection, SelectedEngineerAction,
+    VerificationReport, run_local_engineer_loop,
 };
 pub use error::{SimardError, SimardResult};
 pub use evidence::{

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -55,12 +55,14 @@ where
         path: temp_path.clone(),
         reason: error.to_string(),
     })?;
+    set_owner_only_permissions(store, &temp_path)?;
     fs::rename(&temp_path, path).map_err(|error| SimardError::PersistentStoreIo {
         store: store.to_string(),
         action: "rename".to_string(),
         path: path.to_path_buf(),
         reason: error.to_string(),
-    })
+    })?;
+    set_owner_only_permissions(store, path)
 }
 
 fn temp_path(path: &Path) -> PathBuf {
@@ -70,4 +72,22 @@ fn temp_path(path: &Path) -> PathBuf {
         }
         _ => PathBuf::from(format!("{}.tmp", path.to_string_lossy())),
     }
+}
+
+#[cfg(unix)]
+fn set_owner_only_permissions(store: &str, path: &Path) -> SimardResult<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let permissions = fs::Permissions::from_mode(0o600);
+    fs::set_permissions(path, permissions).map_err(|error| SimardError::PersistentStoreIo {
+        store: store.to_string(),
+        action: "chmod".to_string(),
+        path: path.to_path_buf(),
+        reason: error.to_string(),
+    })
+}
+
+#[cfg(not(unix))]
+fn set_owner_only_permissions(_store: &str, _path: &Path) -> SimardResult<()> {
+    Ok(())
 }

--- a/src/sanitization.rs
+++ b/src/sanitization.rs
@@ -9,3 +9,83 @@ pub fn objective_metadata(objective: &str) -> String {
 
     format!("objective-metadata(chars={chars}, words={words}, lines={lines})")
 }
+
+pub fn sanitize_terminal_text(raw: &str) -> String {
+    redact_secret_values(&strip_ansi_sequences(raw))
+}
+
+fn strip_ansi_sequences(raw: &str) -> String {
+    let mut sanitized = String::with_capacity(raw.len());
+    let mut chars = raw.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if ch == '\u{1b}'
+            && let Some('[') = chars.peek().copied()
+        {
+            chars.next();
+            for next in chars.by_ref() {
+                if ('@'..='~').contains(&next) {
+                    break;
+                }
+            }
+            continue;
+        }
+
+        if ch != '\r' {
+            sanitized.push(ch);
+        }
+    }
+
+    sanitized
+}
+
+fn redact_secret_values(raw: &str) -> String {
+    let markers = [
+        "token",
+        "secret",
+        "password",
+        "passwd",
+        "api_key",
+        "apikey",
+        "authorization",
+        "bearer ",
+    ];
+
+    raw.lines()
+        .map(|line| {
+            let lowered = line.to_ascii_lowercase();
+            if markers.iter().any(|marker| lowered.contains(marker)) {
+                if let Some((prefix, _)) = line.split_once('=') {
+                    return format!("{prefix}=[REDACTED]");
+                }
+                if let Some((prefix, _)) = line.split_once(':') {
+                    return format!("{prefix}: [REDACTED]");
+                }
+                return "[REDACTED]".to_string();
+            }
+
+            line.to_string()
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sanitize_terminal_text;
+
+    #[test]
+    fn terminal_sanitization_strips_ansi_sequences() {
+        let raw = "\u{1b}[32mgreen\u{1b}[0m\r\nplain";
+        assert_eq!(sanitize_terminal_text(raw), "green\nplain");
+    }
+
+    #[test]
+    fn terminal_sanitization_redacts_secret_like_lines() {
+        let raw = "token=abc123\nAuthorization: Bearer secret-value\nplain";
+        assert_eq!(
+            sanitize_terminal_text(raw),
+            "token=[REDACTED]\nAuthorization: [REDACTED]\nplain"
+        );
+    }
+}

--- a/tests/engineer_loop.rs
+++ b/tests/engineer_loop.rs
@@ -1,0 +1,190 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn engineer_loop_objective() -> &'static str {
+    "inspect the repository state, execute one safe local engineering action, verify the outcome explicitly, and persist truthful local evidence and memory"
+}
+
+fn run_engineer_loop_probe(workspace_root: &Path, objective: &str) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_simard_operator_probe"))
+        .arg("engineer-loop-run")
+        .arg("single-process")
+        .arg(workspace_root)
+        .arg(objective)
+        .output()
+        .expect("engineer-loop probe should launch")
+}
+
+fn worktree_dirty(path: &Path) -> bool {
+    let output = Command::new("git")
+        .args(["status", "--short", "--untracked-files=all"])
+        .current_dir(path)
+        .output()
+        .expect("git status should launch");
+    assert!(
+        output.status.success(),
+        "git status should succeed in repo-rooted engineer-loop tests"
+    );
+    !String::from_utf8_lossy(&output.stdout).trim().is_empty()
+}
+
+fn rendered_output(output: &Output) -> String {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    format!("{stdout}{stderr}")
+}
+
+fn output_field<'a>(output: &'a str, label: &str) -> &'a str {
+    output
+        .lines()
+        .find_map(|line| line.strip_prefix(label).map(str::trim))
+        .unwrap_or_else(|| panic!("missing output field '{label}' in:\n{output}"))
+}
+
+struct TempDirGuard {
+    path: PathBuf,
+}
+
+impl TempDirGuard {
+    fn new(label: &str) -> Self {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after unix epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("{label}-{unique}"));
+        fs::create_dir_all(&path).expect("temp dir should be created");
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempDirGuard {
+    fn drop(&mut self) {
+        if self.path.exists() {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+}
+
+#[test]
+fn engineer_loop_probe_rejects_non_repo_workspaces_with_explicit_not_a_repo_signal() {
+    let non_repo = TempDirGuard::new("simard-engineer-loop-not-a-repo");
+    let output = run_engineer_loop_probe(non_repo.path(), engineer_loop_objective());
+    let rendered = rendered_output(&output);
+
+    assert!(
+        !output.status.success(),
+        "non-repo engineer loop should fail visibly instead of pretending success:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("NOT_A_REPO"),
+        "non-repo engineer loop should surface a NOT_A_REPO signal:\n{rendered}"
+    );
+    assert!(
+        rendered.contains(&non_repo.path().display().to_string()),
+        "non-repo failure should identify the rejected workspace path:\n{rendered}"
+    );
+}
+
+#[test]
+fn engineer_loop_probe_reports_repo_state_runs_verified_action_and_persists_truthful_artifacts() {
+    let expected_dirty = worktree_dirty(&repo_root());
+    let output = run_engineer_loop_probe(&repo_root(), engineer_loop_objective());
+    let rendered = rendered_output(&output);
+
+    assert!(
+        output.status.success(),
+        "repo-grounded engineer loop should succeed once implemented:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("Probe mode: engineer-loop-run"),
+        "engineer-loop probe should report its explicit mode:\n{rendered}"
+    );
+    assert!(
+        rendered.contains(&format!("Repo root: {}", repo_root().display())),
+        "engineer-loop probe should expose the repo root it inspected:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("Repo branch: "),
+        "engineer-loop probe should expose current branch state:\n{rendered}"
+    );
+    assert!(
+        rendered.contains(&format!("Worktree dirty: {expected_dirty}")),
+        "engineer-loop probe should expose actual worktree dirtiness before acting:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("Execution scope: local-only"),
+        "v1 engineer loop must stay honest about local-only execution:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("Selected action: "),
+        "engineer-loop probe should report the grounded engineering action it chose:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("Action status: success"),
+        "engineer-loop probe should report the action result explicitly:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("Verification status: verified"),
+        "engineer-loop probe should only claim verified outcomes after explicit checks:\n{rendered}"
+    );
+    assert!(
+        !rendered.contains("Azlin"),
+        "local-first v1 should not imply unavailable remote orchestration:\n{rendered}"
+    );
+
+    let state_root = PathBuf::from(output_field(&rendered, "State root:"));
+    let memory_path = state_root.join("memory_records.json");
+    let evidence_path = state_root.join("evidence_records.json");
+    let handoff_path = state_root.join("latest_handoff.json");
+
+    assert!(
+        memory_path.is_file(),
+        "engineer-loop probe should persist durable memory records under the reported state root"
+    );
+    assert!(
+        evidence_path.is_file(),
+        "engineer-loop probe should persist durable evidence records under the reported state root"
+    );
+    assert!(
+        handoff_path.is_file(),
+        "engineer-loop probe should persist the latest handoff snapshot under the reported state root"
+    );
+
+    let memory_payload =
+        fs::read_to_string(&memory_path).expect("persisted memory payload should be readable");
+    let evidence_payload =
+        fs::read_to_string(&evidence_path).expect("persisted evidence payload should be readable");
+    let handoff_payload =
+        fs::read_to_string(&handoff_path).expect("persisted handoff payload should be readable");
+
+    assert!(
+        evidence_payload.contains("repo-root="),
+        "evidence payload should preserve the inspected repo root:\n{evidence_payload}"
+    );
+    assert!(
+        evidence_payload.contains("selected-action="),
+        "evidence payload should preserve the chosen engineering action:\n{evidence_payload}"
+    );
+    assert!(
+        evidence_payload.contains("verification-status=verified"),
+        "evidence payload should preserve verification status:\n{evidence_payload}"
+    );
+    assert!(
+        memory_payload.contains("engineer-loop-summary"),
+        "memory payload should preserve a durable engineer-loop summary:\n{memory_payload}"
+    );
+    assert!(
+        handoff_payload.contains("verification-status=verified"),
+        "handoff payload should preserve verified outcome status for truthful resume behavior:\n{handoff_payload}"
+    );
+}

--- a/tests/gadugi/engineer-loop.sh
+++ b/tests/gadugi/engineer-loop.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+if [ -n "$(git status --short --untracked-files=all)" ]; then
+  EXPECTED_DIRTY=true
+else
+  EXPECTED_DIRTY=false
+fi
+
+OBJECTIVE=$'inspect the repository state\nrun one safe local engineering action\nverify the outcome explicitly\npersist truthful local evidence and memory'
+
+OUTPUT="$(
+  cargo run --quiet --bin simard_operator_probe -- \
+    engineer-loop-run single-process "$ROOT" "$OBJECTIVE"
+)"
+
+printf '%s\n' "$OUTPUT"
+
+printf '%s\n' "$OUTPUT" | grep -F "Probe mode: engineer-loop-run" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "Repo root: $ROOT" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "Repo branch: " >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "Worktree dirty: $EXPECTED_DIRTY" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "Execution scope: local-only" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "Selected action: " >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "Action status: success" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "Verification status: verified" >/dev/null
+! printf '%s\n' "$OUTPUT" | grep -F "Azlin" >/dev/null
+
+NON_REPO="$(mktemp -d /tmp/simard-engineer-loop-not-a-repo.XXXXXX)"
+trap 'rm -rf "$NON_REPO"' EXIT
+
+set +e
+BAD_OUTPUT="$(
+  cargo run --quiet --bin simard_operator_probe -- \
+    engineer-loop-run single-process "$NON_REPO" "$OBJECTIVE" 2>&1
+)"
+BAD_STATUS=$?
+set -e
+
+[ "$BAD_STATUS" -ne 0 ]
+printf '%s\n' "$BAD_OUTPUT" | grep -F "NOT_A_REPO" >/dev/null
+printf '%s\n' "$BAD_OUTPUT" | grep -F "$NON_REPO" >/dev/null

--- a/tests/gadugi/simard-cli-smoke.yaml
+++ b/tests/gadugi/simard-cli-smoke.yaml
@@ -69,6 +69,13 @@ steps:
       command: "tests/gadugi/terminal-session.sh"
     timeout: 300000
 
+  - name: "Terminal-native engineer loop"
+    agent: "cli-agent"
+    action: "execute_command"
+    params:
+      command: "tests/gadugi/engineer-loop.sh"
+    timeout: 300000
+
   - name: "Composite handoff roundtrip"
     agent: "cli-agent"
     action: "execute_command"
@@ -98,6 +105,7 @@ metadata:
     - "bootstrap"
     - "meeting"
     - "terminal"
+    - "engineer-loop"
     - "handoff"
     - "composite"
     - "benchmark-gym"


### PR DESCRIPTION
## Summary
- add a local-first `engineer-loop-run` operator path that inspects repo state, selects one safe repo-native action, verifies the outcome, and persists truthful memory/evidence/handoff artifacts
- expose the engineer loop through `simard_operator_probe`, add dedicated Rust and Gadugi outside-in coverage, and wire it into the operator smoke suite
- update docs/runtime contracts to describe the shipped v1 engineer-loop boundary honestly

## Why
After landing `terminal-shell`, the next missing block from the original Simard prompt and `Specs/ProductArchitecture.md` was the real engineer loop: inspect -> act -> verify -> persist. This PR delivers the next honest local-first slice without pretending remote orchestration, Azlin control, or autonomous multi-step coding already exists.

## Original-prompt / spec alignment
This PR advances the following requirements:
- terminal-native engineer behavior beyond a bounded shell turn
- repo-grounded inspection and action selection
- explicit verification rather than success-shaped output
- durable evidence/memory/handoff persistence for later sessions

It intentionally does **not** claim:
- remote hosts / Azlin
- distributed terminal orchestration
- unconstrained autonomous code mutation loops
- full amplihack/copilot interactive session driving yet

## Validation
- `cargo fmt --all`
- `cargo test --all-features --locked`
- `tests/gadugi/smoke-explicit-local.sh`
- `tests/gadugi/smoke-explicit-rusty-clawd.sh`
- `tests/gadugi/smoke-builtin-defaults.sh`
- `tests/gadugi/composite-identity.sh`
- `tests/gadugi/meeting-mode.sh`
- `tests/gadugi/terminal-session.sh`
- `tests/gadugi/engineer-loop.sh`
- `tests/gadugi/handoff-roundtrip.sh`
- `tests/gadugi/review-mode.sh`
- `tests/gadugi/gym-suite.sh`
- `python3 -m pre_commit run --all-files --hook-stage pre-commit`
- `python3 -m pre_commit run --all-files --hook-stage pre-push`

## Workflow recovery note
The initial workflow run for this block exhibited another hollow-context failure and created a nested issue/worktree under the target worktree. The useful code was recovered into this clean issue-42 branch, and the new repro was documented upstream in `amplihack#3769`.

Closes #42.
