### PR TITLE
Add review-backed improvement curation

### DIFF
--- a/Specs/ProductArchitecture.md
+++ b/Specs/ProductArchitecture.md
@@ -90,7 +90,7 @@ The following are explicitly out of scope for v1.
 
 ## Product Shape
 
-Simard should be treated as a focused engineering runtime with four user-visible modes:
+Simard should be treated as a focused engineering runtime with five user-visible modes:
 
 1. Engineer mode
    Simard accepts a concrete task, inspects the local repo, plans the work, executes through terminal actions, and reports outcomes with evidence.
@@ -101,7 +101,10 @@ Simard should be treated as a focused engineering runtime with four user-visible
 3. Goal-curation mode
    Simard curates durable backlog state and an explicit active top 5 goals list without pretending implementation work happened.
 
-4. Gym mode
+4. Improvement-curation mode
+   Simard consumes persisted review findings, requires explicit operator approval or deferral, and promotes accepted improvements into durable active or proposed priorities without mutating code.
+
+5. Gym mode
    Simard runs controlled benchmark tasks to measure capability, regressions, and improvement over time.
 
 These are not cosmetic personas.
@@ -640,7 +643,7 @@ Simard should improve through controlled loops tied to evidence.
 - Improvements should be small and attributable.
 - If a change cannot be evaluated, it should not be promoted automatically.
 
-For v1, self-improvement should remain a reviewable offline loop, not an autonomous production feature.
+For v1, self-improvement should remain a reviewable offline loop, not an autonomous production feature. The shipped slice is explicit review artifact generation plus operator-driven improvement curation and promotion into durable priorities.
 
 ## Rust Implementation Direction
 
@@ -767,6 +770,13 @@ Before implementation expands past scaffolding, the project should explicitly ch
 - revisit UI surfaces only after terminal-native behavior is reliable
 - support sibling identities that reuse the same runtime substrate
 - **Exit criteria:** improvements can be proposed, evaluated, and accepted without destabilizing the core engineer loop
+
+Current shipped v1 slice:
+
+- review artifacts already emit concrete evidence-linked proposals
+- an explicit improvement-curation mode can now promote approved proposals into durable active or proposed priorities
+- deferred proposals remain visible in durable decision memory instead of triggering silent self-modification
+- broader automatic evaluation and promotion still remain post-v1 work
 
 ## Open Questions for Iteration
 

--- a/docs/howto/configure-bootstrap-and-inspect-reflection.md
+++ b/docs/howto/configure-bootstrap-and-inspect-reflection.md
@@ -115,6 +115,8 @@ Builtin defaults are startup choices. They are not recovery behavior.
 - `adapter_supported_topologies`
 - `active_goal_count`
 - `active_goals`
+- `proposed_goal_count`
+- `proposed_goals`
 - `topology_backend`
 - `transport_backend`
 - `supervisor_backend`
@@ -152,7 +154,7 @@ assert_eq!(snapshot.evidence_backend.identity, "evidence::json-file-store");
 
 If you launched with `SIMARD_BASE_TYPE="copilot-sdk"`, `snapshot.selected_base_type` still shows the alias you chose while `snapshot.adapter_backend.identity` remains `local-harness`. If you launched with `SIMARD_BASE_TYPE="rusty-clawd"`, reflection truthfully reports `snapshot.adapter_backend.identity == "rusty-clawd::session-backend"`. If you launch the engineer identity with `SIMARD_BASE_TYPE="terminal-shell"`, reflection reports `snapshot.adapter_backend.identity == "terminal-shell::local-pty"`, `snapshot.adapter_capabilities` includes `terminal-session`, and `snapshot.adapter_supported_topologies == ["single-process"]`. Composite identities also surface `snapshot.identity_components` so operator tooling can see which roles were assembled.
 
-If you have persisted goal state in the selected `SIMARD_STATE_ROOT`, reflection also reports the active top 5 goals directly through `snapshot.active_goal_count` and `snapshot.active_goals`, and `snapshot.goal_backend.identity` shows the live goal-store backend.
+If you have persisted goal state in the selected `SIMARD_STATE_ROOT`, reflection also reports the active top 5 goals directly through `snapshot.active_goal_count` and `snapshot.active_goals`, reports durable proposed priorities through `snapshot.proposed_goal_count` and `snapshot.proposed_goals`, and `snapshot.goal_backend.identity` shows the live goal-store backend.
 
 The same redaction rule applies to persisted session text: scratch memory, session summaries, and reflection summaries record `objective-metadata(...)` instead of the raw `SIMARD_OBJECTIVE` string.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,20 +28,21 @@ Today Simard provides:
 - a durable local state root selected through `SIMARD_STATE_ROOT` in `explicit-config` or defaulted through `builtin-defaults`
 - explicit base-type and topology selection at bootstrap, with opt-in defaults only in `builtin-defaults`
 - builtin manifest-advertised base types selectable at startup today: `local-harness`, `terminal-shell`, `rusty-clawd`, and `copilot-sdk`, with `terminal-shell` wired as a real local PTY-backed shell session for `simard-engineer`, `rusty-clawd` wired as a distinct session backend, and `copilot-sdk` still aliased to the local harness implementation
-- builtin identities selectable at startup today: `simard-engineer`, `simard-meeting`, `simard-goal-curator`, `simard-gym`, and the composite `simard-composite-engineer`
+- builtin identities selectable at startup today: `simard-engineer`, `simard-meeting`, `simard-goal-curator`, `simard-improvement-curator`, `simard-gym`, and the composite `simard-composite-engineer`
 - a facilitator-backed `simard-meeting` identity that captures structured decisions, risks, next steps, open questions, and optional structured `goal:` updates without mutating code
 - a dedicated `simard-goal-curator` identity that persists durable backlog entries and exposes the active top 5 goals through reflection
+- a dedicated `simard-improvement-curator` identity that consumes persisted review artifacts, promotes explicitly approved proposals into durable active or proposed priorities, and keeps the loop operator-reviewable
 - `single-process` for all builtin base types plus loopback `multi-process` execution for `rusty-clawd`, with `terminal-shell` intentionally limited to local single-process runs and unsupported pairs failing explicitly
 - a local-first engineer loop probe that inspects repo state, runs one explicit safe engineering action, verifies the outcome, persists truthful local evidence/memory, and reports the active goal set without pretending remote orchestration already exists
 - a starter benchmark gym suite that exercises all current builtin base-type selections plus a composite identity session through `cargo run --quiet --bin simard-gym -- run-suite starter`
 - benchmark artifacts written under `target/simard-gym/`, including per-scenario JSON and text summaries, a dedicated review artifact, and a suite summary
 - `ManifestContract { entrypoint, composition, precedence, provenance, freshness }`
-- `ReflectionSnapshot { manifest_contract, runtime_node, mailbox_address, active_goal_count, active_goals, agent_program_backend, adapter_backend, adapter_capabilities, adapter_supported_topologies, topology_backend, transport_backend, supervisor_backend, memory_backend, evidence_backend, goal_backend }`
+- `ReflectionSnapshot { manifest_contract, runtime_node, mailbox_address, active_goal_count, active_goals, proposed_goal_count, proposed_goals, agent_program_backend, adapter_backend, adapter_capabilities, adapter_supported_topologies, topology_backend, transport_backend, supervisor_backend, memory_backend, evidence_backend, goal_backend }`
 - truthful memory and evidence backend descriptors
 - file-backed memory, evidence, and handoff stores on the bootstrap path, with persisted local state under the configured state root
 - durable meeting decision records and active-goal updates persisted under the configured state root so later sessions can inspect concise planning outcomes
 - a durable goal register persisted under the configured state root, with the active top 5 goals surfaced directly in runtime reflection and operator probes
-- offline review artifacts and concise decision records persisted under the configured state root when the operator runs the review probe
+- offline review artifacts and concise decision records persisted under the configured state root when the operator runs the review probe, plus a follow-on improvement-curation path that promotes approved proposals into durable priorities
 - truthful runtime service metadata from the runtime-selected wiring, including the injected agent program, handoff store, the canonical backend identities behind each selected base type, and adapter capability/topology limits surfaced directly in reflection
 - persisted scratch, summary, and reflection text that records objective metadata instead of raw objective text
 - handoff snapshots that preserve runtime/session continuity while redacting the persisted session objective down to objective metadata
@@ -65,7 +66,7 @@ Those hooks enforce `cargo fmt --all -- --check`, `cargo clippy --all-targets --
 
 - `src/main.rs` is the thin CLI wrapper; `bootstrap::run_local_session` owns the run loop and `simard::bootstrap::assemble_local_runtime` remains the reflected assembly boundary
 - `src/bin/simard_gym.rs` is the operator-facing benchmark CLI for the starter gym suite
-- `src/bin/simard_operator_probe.rs` now exposes `meeting-run`, `goal-curation-run`, `terminal-run`, `engineer-loop-run`, and `review-run` so operators can inspect meeting capture, durable goal stewardship, bounded shell execution, the local-first engineer loop, and evidence-linked review proposals through public surfaces
+- `src/bin/simard_operator_probe.rs` now exposes `meeting-run`, `goal-curation-run`, `improvement-curation-run`, `terminal-run`, `engineer-loop-run`, `review-run`, and `review-read` so operators can inspect meeting capture, durable goal stewardship, review-backed improvement promotion, bounded shell execution, the local-first engineer loop, and evidence-linked review proposals through public surfaces
 - `bootstrap::run_local_session` now persists durable memory/evidence records and the latest handoff snapshot under the configured state root
 - defaults are startup choices, never silent runtime recovery
 - reflection metadata is derived from the active runtime wiring, not placeholder labels

--- a/docs/reference/runtime-contracts.md
+++ b/docs/reference/runtime-contracts.md
@@ -37,13 +37,14 @@ The stable contract in this repository is the bootstrap/runtime and benchmark-gy
 
 ## Meeting-mode operator flow
 
-The shipped operator probe also supports meeting-specific, goal-curation-specific, terminal-session-specific, and engineer-loop-specific paths:
+The shipped operator probe also supports meeting-specific, goal-curation-specific, improvement-curation-specific, terminal-session-specific, and engineer-loop-specific paths:
 
 - `cargo run --quiet --bin simard_operator_probe -- meeting-run <base-type> <topology> <structured-objective>`
 - `cargo run --quiet --bin simard_operator_probe -- goal-curation-run <base-type> <topology> <structured-objective>`
+- `cargo run --quiet --bin simard_operator_probe -- improvement-curation-run <base-type> <topology> <structured-objective> [state-root]`
 - `cargo run --quiet --bin simard_operator_probe -- engineer-loop-run <topology> <workspace-root> <objective> [state-root]`
-- `cargo run --quiet --bin simard_operator_probe -- review-run <base-type> <topology> <objective>`
-- `cargo run --quiet --bin simard_operator_probe -- review-read <base-type> <topology>`
+- `cargo run --quiet --bin simard_operator_probe -- review-run <base-type> <topology> <objective> [state-root]`
+- `cargo run --quiet --bin simard_operator_probe -- review-read <base-type> <topology> [state-root]`
 
 Use a structured objective with lines such as:
 
@@ -54,6 +55,8 @@ Use a structured objective with lines such as:
 - `next-step: ...`
 - `open-question: ...`
 - `goal: title | priority=1 | status=active | rationale=why this belongs in Simard's top 5`
+- `approve: proposal title | priority=1 | status=proposed|active | rationale=why this should be tracked now`
+- `defer: proposal title | rationale=why this should wait`
 
 The v1 meeting contract is intentionally narrow:
 
@@ -69,6 +72,14 @@ The goal-curation path is intentionally narrow too:
 - reflection and later operator probes expose the active top 5 goals directly
 - it does not claim implementation work or remote orchestration
 
+The improvement-curation path is intentionally narrow as well:
+
+- it uses the dedicated `simard-improvement-curator` identity and the `agent-program::improvement-curator` backend
+- it reads the latest persisted review artifact from the selected durable state root and turns explicit operator approvals into durable active or proposed priorities
+- it preserves deferred proposals as durable decision memory rather than silently discarding them
+- reflection and later operator probes expose both active and proposed improvement priorities directly
+- it does not mutate code or silently promote unreviewed changes
+
 The review path is also intentionally narrow:
 
 - it runs an ordinary bounded session first, then inspects the exported handoff offline
@@ -83,7 +94,7 @@ The current review foundation is the explicit v1 reconciliation between `Specs/P
 
 - `src/review.rs` owns the offline review contract: it consumes exported handoff state plus normalized benchmark/session signals, then emits concrete improvement proposals instead of generic summaries.
 - `src/gym.rs` converts benchmark checks and measurement notes into the same `ReviewRequest` shape, so benchmark evidence and session evidence flow through one review surface.
-- `src/bin/simard_operator_probe.rs` exercises the operator path end-to-end: `review-run` persists the durable artifact and concise decision record, while `review-read` proves that a later process can retrieve them again from `SIMARD_STATE_ROOT`.
+- `src/bin/simard_operator_probe.rs` exercises the operator path end-to-end: `review-run` persists the durable artifact and concise decision record, `review-read` proves that a later process can retrieve them again from `SIMARD_STATE_ROOT`, and `improvement-curation-run` turns approved proposals into durable priorities in that same state root.
 - `src/runtime.rs`, `src/memory.rs`, `src/evidence.rs`, and the exported handoff snapshot remain the architecture seams from the product spec; the review layer reads those seams rather than inventing a parallel persistence stack.
 - The implementation stays inside the product constraints: the loop is offline, evidence-linked, operator-reviewable, and limited to concise durable artifacts instead of raw transcript dumps or silent self-modification.
 
@@ -122,7 +133,7 @@ Artifacts are written under `target/simard-gym/` as JSON and text reports plus a
 
 ### Current builtin base-type registrations
 
-The builtin identities currently advertised by the loader are `simard-engineer`, `simard-meeting`, `simard-goal-curator`, `simard-gym`, and the composite `simard-composite-engineer`. All of them accept `local-harness`, `rusty-clawd`, and `copilot-sdk`; `simard-engineer` additionally accepts `terminal-shell` for the local terminal-backed path:
+The builtin identities currently advertised by the loader are `simard-engineer`, `simard-meeting`, `simard-goal-curator`, `simard-improvement-curator`, `simard-gym`, and the composite `simard-composite-engineer`. All of them accept `local-harness`, `rusty-clawd`, and `copilot-sdk`; `simard-engineer` additionally accepts `terminal-shell` for the local terminal-backed path:
 
 | Base type selection | Current session backend implementation | Supported topologies in this scaffold |
 | --- | --- | --- |
@@ -201,6 +212,7 @@ Simard keeps the live objective available while the run is executing, but persis
 - exported handoff snapshots preserve the session boundary while replacing `RuntimeHandoffSnapshot.session.objective` with the same objective metadata string
 - bootstrap persists the latest exported handoff snapshot under `SIMARD_STATE_ROOT/latest_handoff.json`
 - bootstrap persists durable goal state under `SIMARD_STATE_ROOT/goal_records.json`
+- runtime reflection now reports both `active_goal_count` / `active_goals` and `proposed_goal_count` / `proposed_goals`
 
 ## Identity metadata
 
@@ -353,6 +365,8 @@ pub struct ReflectionSnapshot {
     pub memory_records: usize,
     pub active_goal_count: usize,
     pub active_goals: Vec<String>,
+    pub proposed_goal_count: usize,
+    pub proposed_goals: Vec<String>,
     pub agent_program_backend: BackendDescriptor,
     pub handoff_backend: BackendDescriptor,
     pub adapter_backend: BackendDescriptor,
@@ -367,7 +381,7 @@ pub struct ReflectionSnapshot {
 }
 ```
 
-For `simard-meeting`, reflection also reports `agent_program_backend.identity == "agent-program::meeting-facilitator"`. For `simard-goal-curator`, it reports `agent_program_backend.identity == "agent-program::goal-curator"`.
+For `simard-meeting`, reflection also reports `agent_program_backend.identity == "agent-program::meeting-facilitator"`. For `simard-goal-curator`, it reports `agent_program_backend.identity == "agent-program::goal-curator"`. For `simard-improvement-curator`, it reports `agent_program_backend.identity == "agent-program::improvement-curator"`.
 
 ### Backend descriptors
 
@@ -391,6 +405,7 @@ Reflection rules:
 - `evidence_backend` comes from the live evidence store descriptor
 - `goal_backend` comes from the live goal store descriptor
 - `active_goal_count` and `active_goals` expose the active top-goal state derived from the durable goal store
+- `proposed_goal_count` and `proposed_goals` expose durable proposed priorities, including approved improvement proposals that have not been activated yet
 - reflection reports live wiring, not placeholder labels
 - stopped or failed snapshots mark manifest freshness as `Stale`
 

--- a/docs/tutorials/run-your-first-local-session.md
+++ b/docs/tutorials/run-your-first-local-session.md
@@ -183,7 +183,7 @@ cargo run --quiet --bin simard_operator_probe -- \
 
 Look for:
 
-- `Identity components: simard-engineer, simard-meeting, simard-gym, simard-goal-curator`
+- `Identity components: simard-engineer, simard-meeting, simard-gym, simard-goal-curator, simard-improvement-curator`
 - `Topology: multi-process`
 - `Topology backend: topology::loopback-mesh`
 - `Transport backend: transport::loopback-mailbox`
@@ -191,7 +191,43 @@ Look for:
 
 **Checkpoint**: composition and topology are now visible runtime facts, not just architecture aspirations.
 
-## Step 5: Opt in to builtin defaults
+## Step 5: Promote a persisted review into durable improvement priorities
+
+First, generate a persisted review artifact:
+
+```bash
+STATE_ROOT="$PWD/target/simard-improvement-demo"
+
+cargo run --quiet --bin simard_operator_probe -- \
+  review-run local-harness single-process \
+  "inspect the current Simard review surface and preserve concrete proposals" \
+  "$STATE_ROOT"
+```
+
+Then promote explicit operator-approved proposals into durable priorities in the same state root:
+
+```bash
+cargo run --quiet --bin simard_operator_probe -- \
+  improvement-curation-run local-harness single-process \
+  "$(cat <<'EOF'
+approve: Capture denser execution evidence | priority=1 | status=active | rationale=operators need denser execution evidence now
+approve: Promote this pattern into a repeatable benchmark | priority=2 | status=proposed | rationale=carry this into the next benchmark planning pass
+EOF
+)" \
+  "$STATE_ROOT"
+```
+
+Look for:
+
+- `Probe mode: improvement-curation-run`
+- `Identity: simard-improvement-curator`
+- `Approved proposals: 2`
+- `Active goal 1: p1 [active] Capture denser execution evidence`
+- `Proposed goal 1: p2 [proposed] Promote this pattern into a repeatable benchmark`
+
+**Checkpoint**: Simard now has an honest evidence-to-priority loop. Review findings stay operator-reviewable, and approved improvements become durable backlog state instead of dead-end artifacts.
+
+## Step 6: Opt in to builtin defaults
 
 Builtin defaults exist for local bootstrap convenience, but they are only used when startup opts in.
 
@@ -212,7 +248,7 @@ You should see:
 
 **Checkpoint**: defaults are a startup choice, not a recovery path. This part of the audited contract already exists.
 
-## Step 6: Observe stopped-state behavior
+## Step 7: Observe stopped-state behavior
 
 The runtime preserves its snapshot after shutdown and surfaces a dedicated stopped-state error:
 

--- a/prompt_assets/simard/improvement_curator_system.md
+++ b/prompt_assets/simard/improvement_curator_system.md
@@ -1,0 +1,31 @@
+# Simard Improvement Curator System Prompt
+
+You are Simard in improvement-curation mode.
+
+Your job is to turn persisted review findings into explicit, reviewable priority decisions.
+
+## Boundaries
+
+- Do not mutate code or pretend implementation work happened.
+- Work only from persisted review evidence and explicit operator approval/defer decisions.
+- Promote approved proposals into durable priorities; keep deferred proposals visible and inspectable.
+
+## Structured input
+
+The runtime provides review context with lines such as:
+
+- `review-id: ...`
+- `review-target: ...`
+- `proposal: title | category=... | rationale=... | suggested_change=... | evidence=...`
+
+The operator should add explicit decisions:
+
+- `approve: title | priority=1 | status=proposed|active | rationale=why this should be tracked now`
+- `defer: title | rationale=why this should wait`
+
+## Expected outcomes
+
+- keep review-to-priority promotion operator-reviewable
+- preserve durable proposed or active improvement goals
+- surface which proposals were approved vs deferred
+- avoid silent self-modification

--- a/src/agent_program.rs
+++ b/src/agent_program.rs
@@ -2,6 +2,7 @@ use crate::base_types::{BaseTypeId, BaseTypeOutcome, BaseTypeTurnInput};
 use crate::error::{SimardError, SimardResult};
 use crate::goals::{GoalRecord, GoalStatus, GoalUpdate};
 use crate::identity::OperatingMode;
+use crate::improvements::ImprovementPromotionPlan;
 use crate::memory::MemoryScope;
 use crate::metadata::{BackendDescriptor, Freshness};
 use crate::runtime::{RuntimeAddress, RuntimeNodeId, RuntimeTopology};
@@ -314,6 +315,137 @@ impl AgentProgram for GoalCuratorProgram {
     }
 }
 
+#[derive(Debug)]
+pub struct ImprovementCuratorProgram {
+    descriptor: BackendDescriptor,
+}
+
+impl ImprovementCuratorProgram {
+    pub fn try_default() -> SimardResult<Self> {
+        Ok(Self {
+            descriptor: BackendDescriptor::for_runtime_type::<Self>(
+                "agent-program::improvement-curator",
+                "runtime-port:agent-program",
+                Freshness::now()?,
+            ),
+        })
+    }
+}
+
+impl AgentProgram for ImprovementCuratorProgram {
+    fn descriptor(&self) -> BackendDescriptor {
+        self.descriptor.clone()
+    }
+
+    fn plan_turn(&self, context: &AgentProgramContext) -> SimardResult<BaseTypeTurnInput> {
+        let plan = ImprovementPromotionPlan::parse(&context.objective)?;
+        Ok(BaseTypeTurnInput {
+            objective: format!(
+                "Review '{}' for '{}' contains {} proposal(s). Approve {} proposal(s), defer {} proposal(s), keep the promotion loop operator-reviewable, and preserve truthful durable priorities. Existing active goals in runtime state: {}.",
+                plan.review_id,
+                if plan.review_target.trim().is_empty() {
+                    "unknown-target".to_string()
+                } else {
+                    plan.review_target.clone()
+                },
+                plan.proposals.len(),
+                plan.approvals.len(),
+                plan.deferrals.len(),
+                if context.active_goals.is_empty() {
+                    "<none>".to_string()
+                } else {
+                    context
+                        .active_goals
+                        .iter()
+                        .map(GoalRecord::concise_label)
+                        .collect::<Vec<_>>()
+                        .join(" | ")
+                },
+            ),
+        })
+    }
+
+    fn reflection_summary(
+        &self,
+        context: &AgentProgramContext,
+        outcome: &BaseTypeOutcome,
+    ) -> SimardResult<String> {
+        let plan = ImprovementPromotionPlan::parse(&context.objective)?;
+        Ok(format!(
+            "Improvement curator '{}' reviewed '{}' for target '{}' through '{}' on '{}' from '{}'. Approved {} proposal(s), deferred {}, and preserved {} active runtime goals in scope. Outcome summary: {}.",
+            self.descriptor.identity,
+            plan.review_id,
+            if plan.review_target.trim().is_empty() {
+                "unknown-target".to_string()
+            } else {
+                plan.review_target.clone()
+            },
+            context.selected_base_type,
+            context.topology,
+            context.runtime_node,
+            plan.approvals.len(),
+            plan.deferrals.len(),
+            context.active_goals.len(),
+            outcome.execution_summary,
+        ))
+    }
+
+    fn persistence_summary(
+        &self,
+        context: &AgentProgramContext,
+        outcome: &BaseTypeOutcome,
+    ) -> SimardResult<String> {
+        let plan = ImprovementPromotionPlan::parse(&context.objective)?;
+        Ok(format!(
+            "improvement-curation-record | review={} | target={} | approvals={} | deferrals={} | approved_goals=[{}] | deferred=[{}] | selected-base-type={} | topology={} | outcome={}",
+            plan.review_id,
+            if plan.review_target.trim().is_empty() {
+                "unknown-target".to_string()
+            } else {
+                plan.review_target.clone()
+            },
+            plan.approvals.len(),
+            plan.deferrals.len(),
+            plan.approval_summaries().join(" | "),
+            plan.deferral_summaries().join(" | "),
+            context.selected_base_type,
+            context.topology,
+            outcome.execution_summary,
+        ))
+    }
+
+    fn additional_memory_records(
+        &self,
+        context: &AgentProgramContext,
+        _outcome: &BaseTypeOutcome,
+    ) -> SimardResult<Vec<AgentProgramMemoryRecord>> {
+        let plan = ImprovementPromotionPlan::parse(&context.objective)?;
+        Ok(vec![AgentProgramMemoryRecord {
+            key_suffix: "improvement-curation-record".to_string(),
+            scope: MemoryScope::Decision,
+            value: format!(
+                "review={} target={} approvals=[{}] deferred=[{}]",
+                plan.review_id,
+                if plan.review_target.trim().is_empty() {
+                    "unknown-target".to_string()
+                } else {
+                    plan.review_target.clone()
+                },
+                plan.approval_summaries().join(" | "),
+                plan.deferral_summaries().join(" | "),
+            ),
+        }])
+    }
+
+    fn goal_updates(
+        &self,
+        context: &AgentProgramContext,
+        _outcome: &BaseTypeOutcome,
+    ) -> SimardResult<Vec<GoalUpdate>> {
+        ImprovementPromotionPlan::parse(&context.objective)?.approved_goal_updates()
+    }
+}
+
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 struct StructuredMeetingNotes {
     agenda: String,
@@ -545,11 +677,10 @@ fn parse_goal_directive(raw: &str, default_priority: u8) -> SimardResult<GoalUpd
 
 fn parse_goal_status(value: &str) -> SimardResult<GoalStatus> {
     match value.trim().to_ascii_lowercase().as_str() {
-        "active" => Ok(GoalStatus::Active),
-        "proposed" | "candidate" => Ok(GoalStatus::Proposed),
-        "paused" | "hold" | "holding" => Ok(GoalStatus::Paused),
-        "completed" | "done" => Ok(GoalStatus::Completed),
-        other => Err(SimardError::InvalidGoalRecord {
+        "candidate" => Ok(GoalStatus::Proposed),
+        "hold" | "holding" => Ok(GoalStatus::Paused),
+        "done" => Ok(GoalStatus::Completed),
+        other => GoalStatus::parse(other).ok_or_else(|| SimardError::InvalidGoalRecord {
             field: "status".to_string(),
             reason: format!(
                 "unsupported goal status '{other}'; expected active, proposed, paused, or completed"

--- a/src/bin/simard_operator_probe.rs
+++ b/src/bin/simard_operator_probe.rs
@@ -4,7 +4,8 @@ use simard::{
     BootstrapConfig, BootstrapInputs, FileBackedMemoryStore, MemoryRecord, MemoryScope,
     MemoryStore, ReflectiveRuntime, ReviewRequest, ReviewTargetKind, RuntimeTopology,
     assemble_local_runtime_from_handoff, build_review_artifact, latest_local_handoff,
-    latest_review_artifact, persist_review_artifact, run_local_engineer_loop,
+    latest_review_artifact, persist_review_artifact, render_review_context_directives,
+    run_local_engineer_loop,
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -61,12 +62,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let base_type = args.next().ok_or("expected base type")?;
             let topology = args.next().ok_or("expected topology")?;
             let objective = args.next().ok_or("expected objective")?;
-            run_review_probe(&base_type, &topology, &objective)?;
+            let state_root = args.next().map(PathBuf::from);
+            run_review_probe(&base_type, &topology, &objective, state_root)?;
         }
         "review-read" => {
             let base_type = args.next().ok_or("expected base type")?;
             let topology = args.next().ok_or("expected topology")?;
-            run_review_read_probe(&base_type, &topology)?;
+            let state_root = args.next().map(PathBuf::from);
+            run_review_read_probe(&base_type, &topology, state_root)?;
+        }
+        "improvement-curation-run" => {
+            let base_type = args.next().ok_or("expected base type")?;
+            let topology = args.next().ok_or("expected topology")?;
+            let objective = args.next().ok_or("expected objective")?;
+            let state_root = args.next().map(PathBuf::from);
+            run_improvement_curation_probe(&base_type, &topology, &objective, state_root)?;
         }
         other => return Err(format!("unsupported probe command '{other}'").into()),
     }
@@ -95,6 +105,20 @@ fn resolved_state_root(
     probe: &str,
 ) -> PathBuf {
     explicit.unwrap_or_else(|| state_root(identity, base_type, topology, probe))
+}
+
+fn resolved_review_state_root(
+    explicit: Option<PathBuf>,
+    base_type: &str,
+    topology: &str,
+) -> PathBuf {
+    resolved_state_root(
+        explicit,
+        "simard-engineer",
+        base_type,
+        topology,
+        "review-run",
+    )
 }
 
 fn run_bootstrap_probe(
@@ -438,12 +462,17 @@ fn run_review_probe(
     base_type: &str,
     topology: &str,
     objective: &str,
+    state_root_override: Option<PathBuf>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let identity = "simard-engineer";
     let config = BootstrapConfig::resolve(BootstrapInputs {
         prompt_root: Some(prompt_root()),
         objective: Some(objective.to_string()),
-        state_root: Some(state_root(identity, base_type, topology, "review-run")),
+        state_root: Some(resolved_review_state_root(
+            state_root_override,
+            base_type,
+            topology,
+        )),
         identity: Some(identity.to_string()),
         base_type: Some(base_type.to_string()),
         topology: Some(topology.to_string()),
@@ -514,9 +543,9 @@ fn run_review_probe(
 fn run_review_read_probe(
     base_type: &str,
     topology: &str,
+    state_root_override: Option<PathBuf>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let identity = "simard-engineer";
-    let state_root = state_root(identity, base_type, topology, "review-run");
+    let state_root = resolved_review_state_root(state_root_override, base_type, topology);
     let (review_artifact_path, review) =
         latest_review_artifact(&state_root)?.ok_or("expected persisted review artifact")?;
     let memory_store = FileBackedMemoryStore::try_new(state_root.join("memory_records.json"))?;
@@ -548,6 +577,96 @@ fn run_review_read_probe(
     if let Some(record) = decision_records.last() {
         println!("Latest decision review record: {}", record.value);
     }
+    Ok(())
+}
+
+fn run_improvement_curation_probe(
+    base_type: &str,
+    topology: &str,
+    operator_objective: &str,
+    state_root_override: Option<PathBuf>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let state_root = resolved_review_state_root(state_root_override, base_type, topology);
+    let (review_artifact_path, review) =
+        latest_review_artifact(&state_root)?.ok_or("expected persisted review artifact")?;
+    let objective = format!(
+        "{}\n{}",
+        render_review_context_directives(&review),
+        operator_objective
+    );
+    let config = BootstrapConfig::resolve(BootstrapInputs {
+        prompt_root: Some(prompt_root()),
+        objective: Some(objective.clone()),
+        state_root: Some(state_root.clone()),
+        identity: Some("simard-improvement-curator".to_string()),
+        base_type: Some(base_type.to_string()),
+        topology: Some(topology.to_string()),
+        ..BootstrapInputs::default()
+    })?;
+
+    let execution = simard::run_local_session(&config)?;
+    let plan = simard::ImprovementPromotionPlan::parse(&objective)?;
+    let memory_store = FileBackedMemoryStore::try_new(config.memory_store_path())?;
+    let improvement_records = memory_store
+        .list(MemoryScope::Decision)?
+        .into_iter()
+        .filter(|record| record.key.ends_with("improvement-curation-record"))
+        .collect::<Vec<_>>();
+
+    println!("Probe mode: improvement-curation-run");
+    println!("Identity: {}", execution.snapshot.identity_name);
+    println!(
+        "Selected base type: {}",
+        execution.snapshot.selected_base_type
+    );
+    println!("Topology: {}", execution.snapshot.topology);
+    println!("State root: {}", config.state_root_path().display());
+    println!("Review artifact: {}", review_artifact_path.display());
+    println!("Review id: {}", review.review_id);
+    println!("Review target: {}", review.target_label);
+    println!("Review proposals: {}", review.proposals.len());
+    println!("Approved proposals: {}", plan.approvals.len());
+    for (index, approval) in plan.approvals.iter().enumerate() {
+        println!(
+            "Approved proposal {}: p{} [{}] {}",
+            index + 1,
+            approval.priority,
+            approval.status,
+            approval.title
+        );
+    }
+    println!("Deferred proposals: {}", plan.deferrals.len());
+    for (index, deferral) in plan.deferrals.iter().enumerate() {
+        println!(
+            "Deferred proposal {}: {} ({})",
+            index + 1,
+            deferral.title,
+            deferral.rationale
+        );
+    }
+    println!(
+        "Active goals count: {}",
+        execution.snapshot.active_goal_count
+    );
+    for (index, goal) in execution.snapshot.active_goals.iter().enumerate() {
+        println!("Active goal {}: {}", index + 1, goal);
+    }
+    println!(
+        "Proposed goals count: {}",
+        execution.snapshot.proposed_goal_count
+    );
+    for (index, goal) in execution.snapshot.proposed_goals.iter().enumerate() {
+        println!("Proposed goal {}: {}", index + 1, goal);
+    }
+    println!("Decision records: {}", improvement_records.len());
+    if let Some(record) = improvement_records.last() {
+        println!("Latest improvement record: {}", record.value);
+    }
+    println!("Execution summary: {}", execution.outcome.execution_summary);
+    println!(
+        "Reflection summary: {}",
+        execution.outcome.reflection.summary
+    );
     Ok(())
 }
 

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -5,7 +5,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::agent_program::{
-    AgentProgram, GoalCuratorProgram, MeetingFacilitatorProgram, ObjectiveRelayProgram,
+    AgentProgram, GoalCuratorProgram, ImprovementCuratorProgram, MeetingFacilitatorProgram,
+    ObjectiveRelayProgram,
 };
 use crate::base_types::{
     BaseTypeId, LocalProcessHarnessAdapter, RustyClawdAdapter, TerminalShellAdapter,
@@ -484,6 +485,7 @@ fn agent_program_for_manifest(manifest: &IdentityManifest) -> SimardResult<Arc<d
     match manifest.default_mode {
         OperatingMode::Meeting => Ok(Arc::new(MeetingFacilitatorProgram::try_default()?)),
         OperatingMode::Curator => Ok(Arc::new(GoalCuratorProgram::try_default()?)),
+        OperatingMode::Improvement => Ok(Arc::new(ImprovementCuratorProgram::try_default()?)),
         OperatingMode::Engineer | OperatingMode::Gym => {
             Ok(Arc::new(ObjectiveRelayProgram::try_default()?))
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,6 +35,10 @@ pub enum SimardError {
         field: String,
         reason: String,
     },
+    InvalidImprovementRecord {
+        field: String,
+        reason: String,
+    },
     InvalidSessionId {
         value: String,
         reason: String,
@@ -175,6 +179,9 @@ impl Display for SimardError {
             }
             Self::InvalidGoalRecord { field, reason } => {
                 write!(f, "invalid goal record field '{field}': {reason}")
+            }
+            Self::InvalidImprovementRecord { field, reason } => {
+                write!(f, "invalid improvement record field '{field}': {reason}")
             }
             Self::InvalidSessionId { value, reason } => {
                 write!(f, "invalid session id '{value}': {reason}")

--- a/src/goals.rs
+++ b/src/goals.rs
@@ -22,6 +22,16 @@ pub enum GoalStatus {
 }
 
 impl GoalStatus {
+    pub fn parse(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "proposed" => Some(Self::Proposed),
+            "active" => Some(Self::Active),
+            "paused" => Some(Self::Paused),
+            "completed" => Some(Self::Completed),
+            _ => None,
+        }
+    }
+
     fn rank(self) -> u8 {
         match self {
             Self::Active => 0,
@@ -122,6 +132,12 @@ pub trait GoalStore: Send + Sync {
 
     fn list(&self) -> SimardResult<Vec<GoalRecord>>;
 
+    fn top_goals_by_status(
+        &self,
+        status: GoalStatus,
+        limit: usize,
+    ) -> SimardResult<Vec<GoalRecord>>;
+
     fn active_top_goals(&self, limit: usize) -> SimardResult<Vec<GoalRecord>>;
 }
 
@@ -212,13 +228,21 @@ impl GoalStore for InMemoryGoalStore {
             .clone())
     }
 
-    fn active_top_goals(&self, limit: usize) -> SimardResult<Vec<GoalRecord>> {
+    fn top_goals_by_status(
+        &self,
+        status: GoalStatus,
+        limit: usize,
+    ) -> SimardResult<Vec<GoalRecord>> {
         let records = self.list()?;
         Ok(sorted_goal_records(records)
             .into_iter()
-            .filter(|record| record.status.is_active())
+            .filter(|record| record.status == status)
             .take(limit)
             .collect())
+    }
+
+    fn active_top_goals(&self, limit: usize) -> SimardResult<Vec<GoalRecord>> {
+        self.top_goals_by_status(GoalStatus::Active, limit)
     }
 }
 
@@ -248,13 +272,21 @@ impl GoalStore for FileBackedGoalStore {
             .clone())
     }
 
-    fn active_top_goals(&self, limit: usize) -> SimardResult<Vec<GoalRecord>> {
+    fn top_goals_by_status(
+        &self,
+        status: GoalStatus,
+        limit: usize,
+    ) -> SimardResult<Vec<GoalRecord>> {
         let records = self.list()?;
         Ok(sorted_goal_records(records)
             .into_iter()
-            .filter(|record| record.status.is_active())
+            .filter(|record| record.status == status)
             .take(limit)
             .collect())
+    }
+
+    fn active_top_goals(&self, limit: usize) -> SimardResult<Vec<GoalRecord>> {
+        self.top_goals_by_status(GoalStatus::Active, limit)
     }
 }
 

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -15,6 +15,7 @@ pub enum OperatingMode {
     Engineer,
     Meeting,
     Curator,
+    Improvement,
     Gym,
 }
 
@@ -24,6 +25,7 @@ impl Display for OperatingMode {
             Self::Engineer => "engineer",
             Self::Meeting => "meeting",
             Self::Curator => "curator",
+            Self::Improvement => "improvement",
             Self::Gym => "gym",
         };
         f.write_str(label)
@@ -455,6 +457,29 @@ impl IdentityLoader for BuiltinIdentityLoader {
                 MemoryPolicy::default(),
                 request.contract.clone(),
             ),
+            "simard-improvement-curator" => IdentityManifest::new(
+                "simard-improvement-curator",
+                request.package_version.clone(),
+                vec![PromptAssetRef::new(
+                    "improvement-curator-system",
+                    "simard/improvement_curator_system.md",
+                )],
+                vec![
+                    BaseTypeId::new("local-harness"),
+                    BaseTypeId::new("rusty-clawd"),
+                    BaseTypeId::new("copilot-sdk"),
+                ],
+                capability_set([
+                    BaseTypeCapability::PromptAssets,
+                    BaseTypeCapability::SessionLifecycle,
+                    BaseTypeCapability::Memory,
+                    BaseTypeCapability::Evidence,
+                    BaseTypeCapability::Reflection,
+                ]),
+                OperatingMode::Improvement,
+                MemoryPolicy::default(),
+                request.contract.clone(),
+            ),
             "simard-composite-engineer" => IdentityManifest::compose(
                 "simard-composite-engineer",
                 request.package_version.clone(),
@@ -476,6 +501,11 @@ impl IdentityLoader for BuiltinIdentityLoader {
                     ))?,
                     self.load(&IdentityLoadRequest::new(
                         "simard-goal-curator",
+                        request.package_version.clone(),
+                        request.contract.clone(),
+                    ))?,
+                    self.load(&IdentityLoadRequest::new(
+                        "simard-improvement-curator",
                         request.package_version.clone(),
                         request.contract.clone(),
                     ))?,

--- a/src/improvements.rs
+++ b/src/improvements.rs
@@ -1,0 +1,498 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::error::{SimardError, SimardResult};
+use crate::goals::{GoalStatus, GoalUpdate};
+use crate::review::{ImprovementProposal, ReviewArtifact};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ImprovementDirective {
+    pub title: String,
+    pub priority: u8,
+    pub status: GoalStatus,
+    pub rationale: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DeferredImprovement {
+    pub title: String,
+    pub rationale: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ImprovementProposalRecord {
+    pub category: String,
+    pub title: String,
+    pub rationale: String,
+    pub suggested_change: String,
+    pub evidence: Vec<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ImprovementPromotionPlan {
+    pub review_id: String,
+    pub review_target: String,
+    pub proposals: Vec<ImprovementProposalRecord>,
+    pub approvals: Vec<ImprovementDirective>,
+    pub deferrals: Vec<DeferredImprovement>,
+}
+
+impl ImprovementPromotionPlan {
+    pub fn parse(raw: &str) -> SimardResult<Self> {
+        let mut review_id = String::new();
+        let mut review_target = String::new();
+        let mut proposals = Vec::new();
+        let mut approvals = Vec::new();
+        let mut deferrals = Vec::new();
+
+        for line in raw.lines().map(str::trim).filter(|line| !line.is_empty()) {
+            let Some((label, value)) = line.split_once(':') else {
+                continue;
+            };
+            let label = label.trim().to_ascii_lowercase();
+            let value = value.trim();
+            if value.is_empty() {
+                continue;
+            }
+
+            match label.as_str() {
+                "review-id" => review_id = required_improvement_field("review-id", value)?,
+                "review-target" => {
+                    review_target = required_improvement_field("review-target", value)?
+                }
+                "proposal" => proposals.push(parse_proposal_record(value)?),
+                "approve" | "promote" => approvals.push(parse_approval_directive(
+                    value,
+                    (approvals.len() + 1) as u8,
+                )?),
+                "defer" => deferrals.push(parse_deferral_directive(value)?),
+                _ => {}
+            }
+        }
+
+        if review_id.is_empty() {
+            return Err(SimardError::InvalidImprovementRecord {
+                field: "review-id".to_string(),
+                reason: "a review-id line is required".to_string(),
+            });
+        }
+        if proposals.is_empty() {
+            return Err(SimardError::InvalidImprovementRecord {
+                field: "proposal".to_string(),
+                reason: "at least one proposal line is required".to_string(),
+            });
+        }
+        if approvals.is_empty() && deferrals.is_empty() {
+            return Err(SimardError::InvalidImprovementRecord {
+                field: "decision".to_string(),
+                reason: "at least one approve: or defer: line is required".to_string(),
+            });
+        }
+
+        let proposal_titles = proposals
+            .iter()
+            .map(|proposal| proposal.title.clone())
+            .collect::<BTreeSet<_>>();
+        let mut decided_titles = BTreeSet::new();
+        for title in approvals
+            .iter()
+            .map(|directive| directive.title.clone())
+            .chain(deferrals.iter().map(|directive| directive.title.clone()))
+        {
+            if !proposal_titles.contains(&title) {
+                return Err(SimardError::InvalidImprovementRecord {
+                    field: "decision".to_string(),
+                    reason: format!("decision references unknown proposal '{title}'"),
+                });
+            }
+            if !decided_titles.insert(title.clone()) {
+                return Err(SimardError::InvalidImprovementRecord {
+                    field: "decision".to_string(),
+                    reason: format!("proposal '{title}' cannot be decided more than once"),
+                });
+            }
+        }
+
+        Ok(Self {
+            review_id,
+            review_target,
+            proposals,
+            approvals,
+            deferrals,
+        })
+    }
+
+    pub fn approved_goal_updates(&self) -> SimardResult<Vec<GoalUpdate>> {
+        let proposals = self
+            .proposals
+            .iter()
+            .map(|proposal| (proposal.title.clone(), proposal))
+            .collect::<BTreeMap<_, _>>();
+
+        self.approvals
+            .iter()
+            .map(|directive| {
+                let proposal = proposals.get(&directive.title).ok_or_else(|| {
+                    SimardError::InvalidImprovementRecord {
+                        field: "approve".to_string(),
+                        reason: format!(
+                            "approved proposal '{}' was not supplied in the review context",
+                            directive.title
+                        ),
+                    }
+                })?;
+                GoalUpdate::new(
+                    proposal.title.clone(),
+                    format!(
+                        "{}; review={} target={} category={} suggested_change={}",
+                        directive.rationale,
+                        self.review_id,
+                        fallback_value(&self.review_target, "unknown-target"),
+                        proposal.category,
+                        proposal.suggested_change
+                    ),
+                    directive.status,
+                    directive.priority,
+                )
+            })
+            .collect()
+    }
+
+    pub fn approval_summaries(&self) -> Vec<String> {
+        self.approvals
+            .iter()
+            .map(|approval| {
+                format!(
+                    "p{} [{}] {}",
+                    approval.priority, approval.status, approval.title
+                )
+            })
+            .collect()
+    }
+
+    pub fn deferral_summaries(&self) -> Vec<String> {
+        self.deferrals
+            .iter()
+            .map(|deferral| format!("{} ({})", deferral.title, deferral.rationale))
+            .collect()
+    }
+}
+
+pub fn render_review_context_directives(review: &ReviewArtifact) -> String {
+    let mut lines = vec![
+        format!("review-id: {}", sanitize_directive_value(&review.review_id)),
+        format!(
+            "review-target: {}",
+            sanitize_directive_value(&review.target_label)
+        ),
+    ];
+    for proposal in &review.proposals {
+        lines.push(render_proposal_directive(proposal));
+    }
+    lines.join("\n")
+}
+
+fn render_proposal_directive(proposal: &ImprovementProposal) -> String {
+    let evidence = if proposal.evidence.is_empty() {
+        "none".to_string()
+    } else {
+        proposal
+            .evidence
+            .iter()
+            .map(|item| sanitize_directive_value(item))
+            .collect::<Vec<_>>()
+            .join(" ;; ")
+    };
+    format!(
+        "proposal: {} | category={} | rationale={} | suggested_change={} | evidence={}",
+        sanitize_directive_value(&proposal.title),
+        sanitize_directive_value(&proposal.category),
+        sanitize_directive_value(&proposal.rationale),
+        sanitize_directive_value(&proposal.suggested_change),
+        evidence
+    )
+}
+
+fn parse_proposal_record(raw: &str) -> SimardResult<ImprovementProposalRecord> {
+    let mut segments = raw
+        .split('|')
+        .map(str::trim)
+        .filter(|segment| !segment.is_empty());
+    let title = required_improvement_field(
+        "proposal.title",
+        segments
+            .next()
+            .ok_or_else(|| SimardError::InvalidImprovementRecord {
+                field: "proposal".to_string(),
+                reason: "proposal entries must include a title before attributes".to_string(),
+            })?,
+    )?;
+    let mut category = String::new();
+    let mut rationale = String::new();
+    let mut suggested_change = String::new();
+    let mut evidence = Vec::new();
+
+    for segment in segments {
+        let (key, value) =
+            segment
+                .split_once('=')
+                .ok_or_else(|| SimardError::InvalidImprovementRecord {
+                    field: "proposal".to_string(),
+                    reason: format!("proposal attribute '{segment}' must look like key=value"),
+                })?;
+        let key = key.trim().to_ascii_lowercase();
+        let value = value.trim();
+        match key.as_str() {
+            "category" => category = required_improvement_field("proposal.category", value)?,
+            "rationale" => rationale = required_improvement_field("proposal.rationale", value)?,
+            "suggested_change" | "suggested-change" => {
+                suggested_change = required_improvement_field("proposal.suggested_change", value)?
+            }
+            "evidence" => {
+                evidence = value
+                    .split(";;")
+                    .map(str::trim)
+                    .filter(|entry| !entry.is_empty())
+                    .map(str::to_string)
+                    .collect()
+            }
+            _ => {
+                return Err(SimardError::InvalidImprovementRecord {
+                    field: key,
+                    reason: "unsupported proposal attribute".to_string(),
+                });
+            }
+        }
+    }
+
+    Ok(ImprovementProposalRecord {
+        category: required_improvement_field("proposal.category", &category)?,
+        title,
+        rationale: required_improvement_field("proposal.rationale", &rationale)?,
+        suggested_change: required_improvement_field(
+            "proposal.suggested_change",
+            &suggested_change,
+        )?,
+        evidence,
+    })
+}
+
+fn parse_approval_directive(raw: &str, default_priority: u8) -> SimardResult<ImprovementDirective> {
+    let mut segments = raw
+        .split('|')
+        .map(str::trim)
+        .filter(|segment| !segment.is_empty());
+    let title = required_improvement_field(
+        "approve.title",
+        segments
+            .next()
+            .ok_or_else(|| SimardError::InvalidImprovementRecord {
+                field: "approve".to_string(),
+                reason: "approve entries must include a proposal title".to_string(),
+            })?,
+    )?;
+    let mut priority = default_priority.max(1);
+    let mut status = GoalStatus::Proposed;
+    let mut rationale =
+        "operator approved this improvement proposal for durable tracking".to_string();
+
+    for segment in segments {
+        let (key, value) =
+            segment
+                .split_once('=')
+                .ok_or_else(|| SimardError::InvalidImprovementRecord {
+                    field: "approve".to_string(),
+                    reason: format!("approve attribute '{segment}' must look like key=value"),
+                })?;
+        let key = key.trim().to_ascii_lowercase();
+        let value = value.trim();
+        match key.as_str() {
+            "priority" => {
+                priority =
+                    value
+                        .parse::<u8>()
+                        .map_err(|_| SimardError::InvalidImprovementRecord {
+                            field: "approve.priority".to_string(),
+                            reason: "priority must be a positive integer".to_string(),
+                        })?;
+                if priority == 0 {
+                    return Err(SimardError::InvalidImprovementRecord {
+                        field: "approve.priority".to_string(),
+                        reason: "priority must be at least 1".to_string(),
+                    });
+                }
+            }
+            "status" => {
+                status = GoalStatus::parse(value).ok_or_else(|| {
+                    SimardError::InvalidImprovementRecord {
+                        field: "approve.status".to_string(),
+                        reason: "status must be active, proposed, paused, or completed".to_string(),
+                    }
+                })?
+            }
+            "rationale" => rationale = required_improvement_field("approve.rationale", value)?,
+            _ => {
+                return Err(SimardError::InvalidImprovementRecord {
+                    field: key,
+                    reason: "unsupported approve attribute".to_string(),
+                });
+            }
+        }
+    }
+
+    Ok(ImprovementDirective {
+        title,
+        priority,
+        status,
+        rationale,
+    })
+}
+
+fn parse_deferral_directive(raw: &str) -> SimardResult<DeferredImprovement> {
+    let mut segments = raw
+        .split('|')
+        .map(str::trim)
+        .filter(|segment| !segment.is_empty());
+    let title = required_improvement_field(
+        "defer.title",
+        segments
+            .next()
+            .ok_or_else(|| SimardError::InvalidImprovementRecord {
+                field: "defer".to_string(),
+                reason: "defer entries must include a proposal title".to_string(),
+            })?,
+    )?;
+    let mut rationale = "operator deferred this proposal for later review".to_string();
+
+    for segment in segments {
+        let (key, value) =
+            segment
+                .split_once('=')
+                .ok_or_else(|| SimardError::InvalidImprovementRecord {
+                    field: "defer".to_string(),
+                    reason: format!("defer attribute '{segment}' must look like key=value"),
+                })?;
+        let key = key.trim().to_ascii_lowercase();
+        let value = value.trim();
+        match key.as_str() {
+            "rationale" => rationale = required_improvement_field("defer.rationale", value)?,
+            _ => {
+                return Err(SimardError::InvalidImprovementRecord {
+                    field: key,
+                    reason: "unsupported defer attribute".to_string(),
+                });
+            }
+        }
+    }
+
+    Ok(DeferredImprovement { title, rationale })
+}
+
+fn required_improvement_field(field: &str, value: impl AsRef<str>) -> SimardResult<String> {
+    let trimmed = value.as_ref().trim();
+    if trimmed.is_empty() {
+        return Err(SimardError::InvalidImprovementRecord {
+            field: field.to_string(),
+            reason: "value cannot be empty".to_string(),
+        });
+    }
+    Ok(trimmed.to_string())
+}
+
+fn sanitize_directive_value(value: &str) -> String {
+    value
+        .replace('\n', " ")
+        .replace('|', "/")
+        .replace(";;", ";")
+        .trim()
+        .to_string()
+}
+
+fn fallback_value<'a>(value: &'a str, fallback: &'a str) -> &'a str {
+    if value.trim().is_empty() {
+        fallback
+    } else {
+        value
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::review::{ReviewArtifact, ReviewEvidenceSummary, ReviewTargetKind};
+
+    #[test]
+    fn parses_review_context_and_operator_decisions() {
+        let raw = "\
+review-id: session-1-review\n\
+review-target: operator-review\n\
+proposal: Capture denser execution evidence | category=evidence-capture | rationale=thin trail | suggested_change=record more phases | evidence=phase-1 ;; phase-2\n\
+proposal: Promote this pattern into a repeatable benchmark | category=benchmark-coverage | rationale=one-off session | suggested_change=make a scenario | evidence=target=operator-review\n\
+approve: Capture denser execution evidence | priority=1 | status=active | rationale=make this visible now\n\
+defer: Promote this pattern into a repeatable benchmark | rationale=wait for the next planning pass";
+
+        let plan = ImprovementPromotionPlan::parse(raw).expect("plan should parse");
+
+        assert_eq!(plan.review_id, "session-1-review");
+        assert_eq!(plan.proposals.len(), 2);
+        assert_eq!(plan.approvals.len(), 1);
+        assert_eq!(plan.deferrals.len(), 1);
+        assert_eq!(plan.approvals[0].status, GoalStatus::Active);
+    }
+
+    #[test]
+    fn rejects_decisions_for_unknown_proposals() {
+        let raw = "\
+review-id: session-1-review\n\
+proposal: Capture denser execution evidence | category=evidence-capture | rationale=thin trail | suggested_change=record more phases | evidence=phase-1\n\
+approve: Missing proposal | priority=1 | status=active | rationale=bad";
+
+        let error = ImprovementPromotionPlan::parse(raw).unwrap_err();
+        assert_eq!(
+            error,
+            SimardError::InvalidImprovementRecord {
+                field: "decision".to_string(),
+                reason: "decision references unknown proposal 'Missing proposal'".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn renders_review_context_directives_for_operator_curator_sessions() {
+        let review = ReviewArtifact {
+            review_id: "session-1-review".to_string(),
+            reviewed_at_unix_ms: 1,
+            target_kind: ReviewTargetKind::Session,
+            target_label: "operator-review".to_string(),
+            identity_name: "simard-engineer".to_string(),
+            session_id: "session-1".to_string(),
+            selected_base_type: "local-harness".to_string(),
+            topology: "single-process".to_string(),
+            objective_metadata: "objective-metadata(chars=10, words=2, lines=1)".to_string(),
+            execution_summary: "done".to_string(),
+            reflection_summary: "reflect".to_string(),
+            summary: "summary".to_string(),
+            measurement_notes: Vec::new(),
+            evidence_summary: ReviewEvidenceSummary {
+                memory_records: 1,
+                evidence_records: 1,
+                decision_records: 1,
+                benchmark_records: 0,
+                exported_state: "ready".to_string(),
+                session_phase: Some("complete".to_string()),
+                failed_signals: Vec::new(),
+            },
+            proposals: vec![ImprovementProposal {
+                category: "evidence-capture".to_string(),
+                title: "Capture denser execution evidence".to_string(),
+                rationale: "thin trail".to_string(),
+                suggested_change: "record more phases".to_string(),
+                evidence: vec!["phase-1".to_string(), "phase-2".to_string()],
+            }],
+        };
+
+        let directives = render_review_context_directives(&review);
+        assert!(directives.contains("review-id: session-1-review"));
+        assert!(directives.contains("proposal: Capture denser execution evidence"));
+        assert!(directives.contains("evidence=phase-1 ;; phase-2"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod goals;
 pub mod gym;
 pub mod handoff;
 pub mod identity;
+pub mod improvements;
 pub mod memory;
 pub mod metadata;
 mod persistence;
@@ -20,8 +21,8 @@ pub mod session;
 mod terminal_session;
 
 pub use agent_program::{
-    AgentProgram, AgentProgramContext, AgentProgramMemoryRecord, MeetingFacilitatorProgram,
-    ObjectiveRelayProgram,
+    AgentProgram, AgentProgramContext, AgentProgramMemoryRecord, ImprovementCuratorProgram,
+    MeetingFacilitatorProgram, ObjectiveRelayProgram,
 };
 pub use base_types::{
     BaseTypeCapability, BaseTypeDescriptor, BaseTypeFactory, BaseTypeId, BaseTypeOutcome,
@@ -57,6 +58,7 @@ pub use identity::{
     BuiltinIdentityLoader, IdentityLoadRequest, IdentityLoader, IdentityManifest, ManifestContract,
     MemoryPolicy, OperatingMode,
 };
+pub use improvements::{ImprovementPromotionPlan, render_review_context_directives};
 pub use memory::{
     FileBackedMemoryStore, InMemoryMemoryStore, MemoryRecord, MemoryScope, MemoryStore,
 };

--- a/src/reflection.rs
+++ b/src/reflection.rs
@@ -22,6 +22,8 @@ pub struct ReflectionSnapshot {
     pub memory_records: usize,
     pub active_goal_count: usize,
     pub active_goals: Vec<String>,
+    pub proposed_goal_count: usize,
+    pub proposed_goals: Vec<String>,
     pub agent_program_backend: BackendDescriptor,
     pub handoff_backend: BackendDescriptor,
     pub adapter_backend: BackendDescriptor,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -936,6 +936,10 @@ impl RuntimeKernel {
             None => 0,
         };
         let active_goals = self.ports.goal_store.active_top_goals(5)?;
+        let proposed_goals = self
+            .ports
+            .goal_store
+            .top_goals_by_status(crate::goals::GoalStatus::Proposed, 5)?;
         let manifest_freshness = match self.state {
             RuntimeState::Stopped | RuntimeState::Failed => {
                 Freshness::observed(FreshnessState::Stale)?
@@ -966,6 +970,11 @@ impl RuntimeKernel {
             memory_records,
             active_goal_count: active_goals.len(),
             active_goals: active_goals.iter().map(GoalRecord::concise_label).collect(),
+            proposed_goal_count: proposed_goals.len(),
+            proposed_goals: proposed_goals
+                .iter()
+                .map(GoalRecord::concise_label)
+                .collect(),
             agent_program_backend: self.ports.agent_program.descriptor(),
             handoff_backend: self.ports.handoff_store.descriptor(),
             adapter_backend: self.factory.descriptor().backend.clone(),

--- a/tests/bootstrap.rs
+++ b/tests/bootstrap.rs
@@ -424,6 +424,7 @@ fn bootstrap_supports_composite_identity_execution() {
             "simard-meeting".to_string(),
             "simard-gym".to_string(),
             "simard-goal-curator".to_string(),
+            "simard-improvement-curator".to_string(),
         ]
     );
     assert_eq!(execution.snapshot.topology, RuntimeTopology::SingleProcess);
@@ -530,6 +531,63 @@ fn bootstrap_goal_curator_mode_persists_top_five_goal_state() {
             .iter()
             .any(|goal| goal.contains("Keep Simard's top 5 goals current")),
         "goal curator reflection should surface active top-goal state"
+    );
+}
+
+#[test]
+fn bootstrap_improvement_curator_mode_promotes_review_findings_into_durable_priorities() {
+    let config = BootstrapConfig::resolve(BootstrapInputs {
+        prompt_root: Some(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("prompt_assets")),
+        objective: Some(
+            "review-id: session-42-review\nreview-target: operator-review\nproposal: Capture denser execution evidence | category=evidence-capture | rationale=thin trail | suggested_change=record one evidence item per major phase | evidence=phase-a ;; phase-b\nproposal: Promote this pattern into a repeatable benchmark | category=benchmark-coverage | rationale=one-off flow | suggested_change=turn it into a named scenario | evidence=target=operator-review\napprove: Capture denser execution evidence | priority=1 | status=active | rationale=operators need denser evidence now\ndefer: Promote this pattern into a repeatable benchmark | rationale=wait until the next benchmark planning pass"
+                .to_string(),
+        ),
+        identity: Some("simard-improvement-curator".to_string()),
+        base_type: Some("local-harness".to_string()),
+        topology: Some("single-process".to_string()),
+        state_root: Some(state_root("improvement-curator")),
+        ..BootstrapInputs::default()
+    })
+    .expect("improvement curator bootstrap config should resolve");
+
+    let execution =
+        run_local_session(&config).expect("improvement curator mode should execute cleanly");
+    let exported = latest_local_handoff(&config)
+        .expect("improvement curator handoff lookup should succeed")
+        .expect("improvement curator handoff should exist");
+    let decision_records = exported
+        .memory_records
+        .iter()
+        .filter(|record| record.scope == MemoryScope::Decision)
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        execution.snapshot.identity_name,
+        "simard-improvement-curator"
+    );
+    assert_eq!(
+        execution.snapshot.agent_program_backend.identity,
+        "agent-program::improvement-curator"
+    );
+    assert_eq!(execution.snapshot.active_goal_count, 1);
+    assert_eq!(
+        execution.snapshot.active_goals,
+        vec!["p1 [active] Capture denser execution evidence".to_string()]
+    );
+    assert_eq!(execution.snapshot.proposed_goal_count, 0);
+    assert!(
+        decision_records
+            .iter()
+            .any(|record| record.key.ends_with("improvement-curation-record")),
+        "improvement curation should persist a durable decision-scoped record"
+    );
+    assert!(
+        execution
+            .outcome
+            .reflection
+            .summary
+            .contains("Approved 1 proposal(s), deferred 1"),
+        "reflection should summarize the promotion decisions"
     );
 }
 

--- a/tests/gadugi/composite-identity.sh
+++ b/tests/gadugi/composite-identity.sh
@@ -14,7 +14,7 @@ printf '%s\n' "$OUTPUT"
 
 printf '%s\n' "$OUTPUT" | grep -F "Probe mode: bootstrap-run" >/dev/null
 printf '%s\n' "$OUTPUT" | grep -F "Identity: simard-composite-engineer" >/dev/null
-printf '%s\n' "$OUTPUT" | grep -F "Identity components: simard-engineer, simard-meeting, simard-gym, simard-goal-curator" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "Identity components: simard-engineer, simard-meeting, simard-gym, simard-goal-curator, simard-improvement-curator" >/dev/null
 printf '%s\n' "$OUTPUT" | grep -F "Selected base type: local-harness" >/dev/null
 printf '%s\n' "$OUTPUT" | grep -F "Topology: single-process" >/dev/null
 printf '%s\n' "$OUTPUT" | grep -F "Adapter implementation: local-harness" >/dev/null

--- a/tests/gadugi/handoff-roundtrip.sh
+++ b/tests/gadugi/handoff-roundtrip.sh
@@ -21,7 +21,7 @@ STATE_ROOT="$(printf '%s\n' "$OUTPUT" | sed -n 's/^State root: //p')"
 
 printf '%s\n' "$OUTPUT" | grep -F "Probe mode: handoff-roundtrip" >/dev/null
 printf '%s\n' "$OUTPUT" | grep -F "Identity: simard-composite-engineer" >/dev/null
-printf '%s\n' "$OUTPUT" | grep -F "Identity components: simard-engineer, simard-meeting, simard-gym, simard-goal-curator" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "Identity components: simard-engineer, simard-meeting, simard-gym, simard-goal-curator, simard-improvement-curator" >/dev/null
 printf '%s\n' "$OUTPUT" | grep -F "Selected base type: rusty-clawd" >/dev/null
 printf '%s\n' "$OUTPUT" | grep -F "Topology: multi-process" >/dev/null
 printf '%s\n' "$OUTPUT" | grep -F "Runtime node: node-loopback-mesh" >/dev/null

--- a/tests/gadugi/improvement-curation.sh
+++ b/tests/gadugi/improvement-curation.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+STATE_ROOT="$(mktemp -d /tmp/simard-improvement-curation.XXXXXX)"
+trap 'rm -rf "$STATE_ROOT"' EXIT
+
+REVIEW_OUTPUT="$(
+  cargo run --quiet --bin simard_operator_probe -- \
+    review-run local-harness single-process \
+    "inspect the current Simard review surface and preserve concrete proposals" \
+    "$STATE_ROOT"
+)"
+
+printf '%s\n' "$REVIEW_OUTPUT"
+
+printf '%s\n' "$REVIEW_OUTPUT" | grep -F "Probe mode: review-run" >/dev/null
+printf '%s\n' "$REVIEW_OUTPUT" | grep -F "Review proposals: 2" >/dev/null
+
+IMPROVEMENT_OBJECTIVE="$(cat <<'EOF'
+approve: Capture denser execution evidence | priority=1 | status=active | rationale=operators need denser execution evidence now
+approve: Promote this pattern into a repeatable benchmark | priority=2 | status=proposed | rationale=carry this into the next benchmark planning pass
+EOF
+)"
+
+IMPROVEMENT_OUTPUT="$(
+  cargo run --quiet --bin simard_operator_probe -- \
+    improvement-curation-run local-harness single-process \
+    "$IMPROVEMENT_OBJECTIVE" \
+    "$STATE_ROOT"
+)"
+
+printf '%s\n' "$IMPROVEMENT_OUTPUT"
+
+printf '%s\n' "$IMPROVEMENT_OUTPUT" | grep -F "Probe mode: improvement-curation-run" >/dev/null
+printf '%s\n' "$IMPROVEMENT_OUTPUT" | grep -F "Identity: simard-improvement-curator" >/dev/null
+printf '%s\n' "$IMPROVEMENT_OUTPUT" | grep -F "Approved proposals: 2" >/dev/null
+printf '%s\n' "$IMPROVEMENT_OUTPUT" | grep -F "Active goals count: 1" >/dev/null
+printf '%s\n' "$IMPROVEMENT_OUTPUT" | grep -F "Active goal 1: p1 [active] Capture denser execution evidence" >/dev/null
+printf '%s\n' "$IMPROVEMENT_OUTPUT" | grep -F "Proposed goals count: 1" >/dev/null
+printf '%s\n' "$IMPROVEMENT_OUTPUT" | grep -F "Proposed goal 1: p2 [proposed] Promote this pattern into a repeatable benchmark" >/dev/null
+
+ENGINEER_OUTPUT="$(
+  cargo run --quiet --bin simard_operator_probe -- \
+    engineer-loop-run single-process "$ROOT" \
+    "inspect the repo and preserve explicit improvement context" \
+    "$STATE_ROOT"
+)"
+
+printf '%s\n' "$ENGINEER_OUTPUT"
+
+printf '%s\n' "$ENGINEER_OUTPUT" | grep -F "Probe mode: engineer-loop-run" >/dev/null
+printf '%s\n' "$ENGINEER_OUTPUT" | grep -F "Active goals count: 1" >/dev/null
+printf '%s\n' "$ENGINEER_OUTPUT" | grep -F "Active goal 1: p1 [active] Capture denser execution evidence" >/dev/null
+printf '%s\n' "$ENGINEER_OUTPUT" | grep -F "Verification status: verified" >/dev/null

--- a/tests/gadugi/simard-cli-smoke.yaml
+++ b/tests/gadugi/simard-cli-smoke.yaml
@@ -69,6 +69,13 @@ steps:
       command: "tests/gadugi/goal-stewardship.sh"
     timeout: 300000
 
+  - name: "Improvement curation promotion loop"
+    agent: "cli-agent"
+    action: "execute_command"
+    params:
+      command: "tests/gadugi/improvement-curation.sh"
+    timeout: 300000
+
   - name: "Terminal session foundation"
     agent: "cli-agent"
     action: "execute_command"
@@ -112,6 +119,7 @@ metadata:
     - "bootstrap"
     - "meeting"
     - "goal-stewardship"
+    - "improvement-curation"
     - "terminal"
     - "engineer-loop"
     - "handoff"

--- a/tests/improvement_curation.rs
+++ b/tests/improvement_curation.rs
@@ -1,0 +1,116 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn rendered_output(output: &Output) -> String {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    format!("{stdout}{stderr}")
+}
+
+struct TempDirGuard {
+    path: PathBuf,
+}
+
+impl TempDirGuard {
+    fn new(label: &str) -> Self {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after unix epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("{label}-{unique}"));
+        fs::create_dir_all(&path).expect("temp dir should be created");
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempDirGuard {
+    fn drop(&mut self) {
+        if self.path.exists() {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+}
+
+#[test]
+fn review_artifacts_can_be_promoted_into_durable_improvement_goals() {
+    let state_root = TempDirGuard::new("simard-improvement-curation-state");
+
+    let review_output = Command::new(env!("CARGO_BIN_EXE_simard_operator_probe"))
+        .arg("review-run")
+        .arg("local-harness")
+        .arg("single-process")
+        .arg("inspect the current Simard review surface and preserve concrete proposals")
+        .arg(state_root.path())
+        .output()
+        .expect("review probe should launch");
+    let review_rendered = rendered_output(&review_output);
+
+    assert!(
+        review_output.status.success(),
+        "review probe should succeed:\n{review_rendered}"
+    );
+    assert!(review_rendered.contains("Probe mode: review-run"));
+    assert!(review_rendered.contains("Review proposals: 2"));
+
+    let improvement_objective = "\
+approve: Capture denser execution evidence | priority=1 | status=active | rationale=operators need denser execution evidence now\n\
+approve: Promote this pattern into a repeatable benchmark | priority=2 | status=proposed | rationale=carry this into the next benchmark planning pass";
+
+    let improvement_output = Command::new(env!("CARGO_BIN_EXE_simard_operator_probe"))
+        .arg("improvement-curation-run")
+        .arg("local-harness")
+        .arg("single-process")
+        .arg(improvement_objective)
+        .arg(state_root.path())
+        .output()
+        .expect("improvement curation probe should launch");
+    let improvement_rendered = rendered_output(&improvement_output);
+
+    assert!(
+        improvement_output.status.success(),
+        "improvement curation probe should succeed:\n{improvement_rendered}"
+    );
+    assert!(improvement_rendered.contains("Probe mode: improvement-curation-run"));
+    assert!(improvement_rendered.contains("Identity: simard-improvement-curator"));
+    assert!(improvement_rendered.contains("Approved proposals: 2"));
+    assert!(improvement_rendered.contains("Deferred proposals: 0"));
+    assert!(improvement_rendered.contains("Active goals count: 1"));
+    assert!(
+        improvement_rendered
+            .contains("Active goal 1: p1 [active] Capture denser execution evidence")
+    );
+    assert!(improvement_rendered.contains("Proposed goals count: 1"));
+    assert!(improvement_rendered.contains(
+        "Proposed goal 1: p2 [proposed] Promote this pattern into a repeatable benchmark"
+    ));
+
+    let engineer_output = Command::new(env!("CARGO_BIN_EXE_simard_operator_probe"))
+        .arg("engineer-loop-run")
+        .arg("single-process")
+        .arg(repo_root())
+        .arg("inspect the repo and preserve explicit improvement context")
+        .arg(state_root.path())
+        .output()
+        .expect("engineer loop probe should launch");
+    let engineer_rendered = rendered_output(&engineer_output);
+
+    assert!(
+        engineer_output.status.success(),
+        "engineer loop probe should succeed with promoted improvement goals:\n{engineer_rendered}"
+    );
+    assert!(engineer_rendered.contains("Active goals count: 1"));
+    assert!(
+        engineer_rendered.contains("Active goal 1: p1 [active] Capture denser execution evidence")
+    );
+    assert!(engineer_rendered.contains("Verification status: verified"));
+}


### PR DESCRIPTION
## Summary
- add a first-class review-backed improvement-curation mode with a dedicated identity, prompt asset, and runtime agent program
- let `simard_operator_probe` promote approved review proposals into durable active or proposed priorities through a new `improvement-curation-run` surface
- surface proposed priorities in runtime reflection, update docs/spec text, and extend Rust plus outside-in operator coverage for the review -> promotion -> engineer loop

## Validation
- cargo test --all-features --locked
- tests/gadugi/smoke-explicit-local.sh
- tests/gadugi/smoke-explicit-rusty-clawd.sh
- tests/gadugi/smoke-builtin-defaults.sh
- tests/gadugi/composite-identity.sh
- tests/gadugi/meeting-mode.sh
- tests/gadugi/goal-stewardship.sh
- tests/gadugi/improvement-curation.sh
- tests/gadugi/terminal-session.sh
- tests/gadugi/engineer-loop.sh
- tests/gadugi/handoff-roundtrip.sh
- tests/gadugi/gym-suite.sh
- python3 -m pre_commit run --all-files --hook-stage pre-commit
- python3 -m pre_commit run --all-files --hook-stage pre-push
