### PR TITLE
Carry meeting decisions into engineer loop

### DIFF
--- a/docs/howto/carry-meeting-decisions-into-engineer-sessions.md
+++ b/docs/howto/carry-meeting-decisions-into-engineer-sessions.md
@@ -1,0 +1,132 @@
+---
+title: "How to carry meeting decisions into engineer sessions"
+description: Persist concise meeting records under a shared state root and verify that later engineer-loop runs carry them forward through the public operator probe.
+last_updated: 2026-03-30
+review_schedule: as-needed
+owner: simard
+doc_type: howto
+related:
+  - ../index.md
+  - ../reference/runtime-contracts.md
+  - ./configure-bootstrap-and-inspect-reflection.md
+  - ../tutorials/run-your-first-local-session.md
+---
+
+# How to carry meeting decisions into engineer sessions
+
+Use this guide when you want to prove one specific product seam: a meeting run captures durable meeting memory, and a later engineer-loop run against the same state root carries that planning context forward without pretending code changed during the meeting.
+
+## Prerequisites
+
+- [ ] You are in the repository root
+- [ ] `cargo run --quiet --bin simard_operator_probe -- ...` works locally
+- [ ] You want a local file-backed handoff, not a network service or remote orchestrator
+
+## 1. Pick one explicit state root for both commands
+
+The handoff only works when both probes point at the same durable state root.
+
+```bash
+STATE_ROOT="$(mktemp -d /tmp/simard-meeting-handoff.XXXXXX)"
+```
+
+Keep that shell variable for the rest of this guide.
+
+## 2. Capture a structured meeting record through the public operator probe
+
+Run `meeting-run` with a real structured objective. A carried meeting record is persisted when the objective includes any persistable structured output such as `update:`, `decision:`, `risk:`, `next-step:`, `open-question:`, or structured `goal:` lines. This example uses all of them.
+
+```bash
+MEETING_OBJECTIVE="$(cat <<'EOF'
+agenda: align the next Simard workstream
+decision: preserve meeting-to-engineer continuity
+risk: workflow routing is still unreliable
+next-step: keep durable priorities visible
+open-question: how aggressively should Simard reprioritize?
+goal: Preserve meeting handoff | priority=1 | status=active | rationale=meeting decisions must shape later work
+goal: Keep outside-in verification strong | priority=2 | status=active | rationale=operator confidence depends on real product exercise
+EOF
+)"
+
+cargo run --quiet --bin simard_operator_probe -- \
+  meeting-run local-harness single-process \
+  "$MEETING_OBJECTIVE" \
+  "$STATE_ROOT"
+```
+
+Look for output like this:
+
+```text
+Probe mode: meeting-run
+Identity: simard-meeting
+Decision records: 1
+Active goals count: 2
+Active goal 1: p1 [active] Preserve meeting handoff
+```
+
+This run writes one concise meeting record and goal state under `STATE_ROOT`. It does not run code or mutate the repository.
+
+## 3. Reuse the same state root in a later engineer-loop run
+
+Now point `engineer-loop-run` at the same repository and the same `STATE_ROOT`.
+
+```bash
+ENGINEER_OBJECTIVE=$'inspect the repository state\nrun one safe local engineering action\nverify the outcome explicitly\npersist truthful local evidence and memory'
+
+cargo run --quiet --bin simard_operator_probe -- \
+  engineer-loop-run single-process "$PWD" "$ENGINEER_OBJECTIVE" "$STATE_ROOT"
+```
+
+Look for output like this:
+
+```text
+Probe mode: engineer-loop-run
+Repo root: /path/to/repo
+Active goals count: 2
+Active goal 1: p1 [active] Preserve meeting handoff
+Active goal 2: p2 [active] Keep outside-in verification strong
+Carried meeting decisions: 1
+Carried meeting decision 1: agenda=align the next Simard workstream; updates=[]; decisions=[preserve meeting-to-engineer continuity]; risks=[workflow routing is still unreliable]; next_steps=[keep durable priorities visible]; open_questions=[how aggressively should Simard reprioritize?]; goals=[p1:active:Preserve meeting handoff:meeting decisions must shape later work | p2:active:Keep outside-in verification strong:operator confidence depends on real product exercise]
+Verification status: verified
+```
+
+The important contract is additive:
+
+- `Active goals count` and `Active goal N` still describe the durable goal register
+- `Carried meeting decisions` describes separate meeting-decision memory
+- the engineer loop currently surfaces at most the three most recent persisted meeting records from that state root
+- the engineer loop keeps that decision memory visible while choosing one bounded local action
+- `Verification status: verified` still proves the engineer loop performed its normal inspect -> act -> verify cycle
+
+## 4. Configuration rules that matter
+
+For predictable handoff behavior, keep these rules in mind:
+
+- Pass the same explicit `state-root` argument to both `meeting-run` and `engineer-loop-run`
+- Keep `meeting-run` on a supported facilitator pairing such as `local-harness single-process`
+- Keep `engineer-loop-run` pointed at a real repository path for `workspace-root`
+- Expect `engineer-loop-run` to surface at most the three most recent carried meeting records, not an unbounded history dump
+- Treat carried meeting decisions as advisory context only; they do not auto-edit code or silently rewrite goals
+
+## 5. Troubleshoot the common failure shapes
+
+### `Carried meeting decisions: 0`
+
+Usually one of these is true:
+
+- the prior meeting run used a different `STATE_ROOT`
+- the meeting objective only contained agenda text and no persistable structured output such as `update:`, `decision:`, `risk:`, `next-step:`, `open-question:`, or structured `goal:` lines
+- you are looking at a clean state root with no earlier meeting data
+
+### Goals show up, but no carried decision does
+
+That usually means the goal state came from `goal-curation-run` or another earlier flow rather than the shared `meeting-run`, or the engineer loop is reading a different state root. A `meeting-run` that persisted structured output writes both the goal updates and a concise meeting record.
+
+### The engineer loop ran, but nothing was verified
+
+That is outside this feature's contract. The handoff is only complete when the later engineer-loop run still reports `Verification status: verified`.
+
+## Related reading
+
+- For the broader runtime and probe surface, see [Runtime contracts reference](../reference/runtime-contracts.md).
+- For a longer end-to-end walk through the local runtime, see [Tutorial: Run your first local session](../tutorials/run-your-first-local-session.md).

--- a/docs/howto/configure-bootstrap-and-inspect-reflection.md
+++ b/docs/howto/configure-bootstrap-and-inspect-reflection.md
@@ -7,6 +7,7 @@ owner: simard
 doc_type: howto
 related:
   - ../index.md
+  - ./carry-meeting-decisions-into-engineer-sessions.md
   - ../reference/runtime-contracts.md
   - ../concepts/truthful-runtime-metadata.md
 ---
@@ -183,9 +184,11 @@ Look for:
 - `Identity: simard-meeting`
 - `Decision records: 1`
 - `Active goals count: 1`
-- a durable decision record containing the decision, risk, next step, and open question
+- a durable meeting record containing the structured updates, decisions, risks, next steps, open questions, and goal updates from the objective
 
-This is the current honest v1 behavior: meeting mode captures structured planning output, can optionally persist structured goal updates, and writes concise decision memory, but it does not mutate code.
+This is the current honest v1 behavior: meeting mode captures structured planning output, can optionally persist structured goal updates, and writes a concise meeting record whenever the objective includes persistable structured fields, but it does not mutate code.
+
+If you need to prove the later engineer-session handoff rather than meeting capture in isolation, follow [How to carry meeting decisions into engineer sessions](./carry-meeting-decisions-into-engineer-sessions.md).
 
 ## 5. Exercise goal stewardship directly
 
@@ -252,6 +255,8 @@ Look for:
 - `Verification status: verified`
 
 This is the current honest v1 engineer-loop slice: Simard inspects the local repo, reads the active durable goals for context, performs one bounded repo-native action, verifies that the repo grounding stayed stable, and persists durable memory/evidence, but it does not claim remote execution or autonomous multi-step coding yet.
+
+When you pass the same explicit state root that an earlier `meeting-run` used, this same probe also prints `Carried meeting decisions: N` and up to the three most recent `Carried meeting decision <index>:` lines.
 
 ## 8. Validate stopped-state behavior
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,7 @@ This docs set describes the runtime behavior that exists in this repository toda
 - [Tutorial: Run your first local session](./tutorials/run-your-first-local-session.md) - Walk the local runtime flow end to end.
 - [Tutorial: Run your first benchmark gym suite](./tutorials/run-your-first-benchmark-gym.md) - Run the shipped starter benchmark suite and inspect the emitted artifacts.
 - [How to configure bootstrap and inspect reflection](./howto/configure-bootstrap-and-inspect-reflection.md) - Verify bootstrap inputs and inspect the truthful reflection surface.
+- [How to carry meeting decisions into engineer sessions](./howto/carry-meeting-decisions-into-engineer-sessions.md) - Persist meeting records under a shared state root and confirm that later engineer-loop runs carry forward up to the three most recent ones.
 - [Runtime contracts reference](./reference/runtime-contracts.md) - Look up the current public API and error contracts.
 - [Concept: truthful runtime metadata](./concepts/truthful-runtime-metadata.md) - Read the design rationale behind the stricter contract.
 
@@ -33,7 +34,7 @@ Today Simard provides:
 - a dedicated `simard-goal-curator` identity that persists durable backlog entries and exposes the active top 5 goals through reflection
 - a dedicated `simard-improvement-curator` identity that consumes persisted review artifacts, promotes explicitly approved proposals into durable active or proposed priorities, and keeps the loop operator-reviewable
 - `single-process` for all builtin base types plus loopback `multi-process` execution for `rusty-clawd`, with `terminal-shell` intentionally limited to local single-process runs and unsupported pairs failing explicitly
-- a local-first engineer loop probe that inspects repo state, runs one explicit safe engineering action, verifies the outcome, persists truthful local evidence/memory, and reports the active goal set without pretending remote orchestration already exists
+- a local-first engineer loop probe that inspects repo state, runs one explicit safe engineering action, verifies the outcome, persists truthful local evidence/memory, reports the active goal set, and surfaces up to the three most recent carried meeting decisions separately without pretending remote orchestration already exists
 - a starter benchmark gym suite that exercises all current builtin base-type selections plus a composite identity session through `cargo run --quiet --bin simard-gym -- run-suite starter`
 - benchmark artifacts written under `target/simard-gym/`, including per-scenario JSON and text summaries, a dedicated review artifact, and a suite summary
 - `ManifestContract { entrypoint, composition, precedence, provenance, freshness }`

--- a/docs/reference/runtime-contracts.md
+++ b/docs/reference/runtime-contracts.md
@@ -7,6 +7,7 @@ owner: simard
 doc_type: reference
 related:
   - ../index.md
+  - ../howto/carry-meeting-decisions-into-engineer-sessions.md
   - ../howto/configure-bootstrap-and-inspect-reflection.md
   - ../concepts/truthful-runtime-metadata.md
 ---
@@ -24,7 +25,7 @@ Simard v1 currently exposes five surfaces:
 - the local CLI bootstrap path through `cargo run --quiet`
 - the benchmark gym CLI through `cargo run --quiet --bin simard-gym -- ...`
 - the operator/runtime probe through `cargo run --quiet --bin simard_operator_probe -- ...`
-- the local-first engineer loop probe through `cargo run --quiet --bin simard_operator_probe -- engineer-loop-run <topology> <workspace-root> <objective>`
+- the local-first engineer loop probe through `cargo run --quiet --bin simard_operator_probe -- engineer-loop-run <topology> <workspace-root> <objective> [state-root]`
 - the in-process Rust runtime/bootstrap types in `src/bootstrap.rs`, `src/runtime.rs`, and related modules
 
 Simard v1 does **not** currently expose:
@@ -61,9 +62,36 @@ Use a structured objective with lines such as:
 The v1 meeting contract is intentionally narrow:
 
 - meeting mode uses the facilitator agent program backend `agent-program::meeting-facilitator`
-- it persists concise decision memory under the durable state root
+- it persists a concise meeting record under the durable state root when the structured objective contains persistable outputs such as `update:`, `decision:`, `risk:`, `next-step:`, `open-question:`, or structured `goal:` lines
+- later `engineer-loop-run` probes against the same state root surface those carried meeting decisions explicitly, separate from the active top-goal list
 - it can also persist structured goal updates into the durable goal register
 - it does not mutate code paths or pretend implementation work happened
+
+### Meeting-to-engineer handoff contract
+
+The public CLI contract for this feature lives on the operator probe:
+
+- `cargo run --quiet --bin simard_operator_probe -- meeting-run <base-type> <topology> <structured-objective> [state-root]`
+- `cargo run --quiet --bin simard_operator_probe -- engineer-loop-run <topology> <workspace-root> <objective> [state-root]`
+
+For predictable handoff behavior, both commands should use the same explicit `state-root`.
+
+When that shared state root contains prior meeting decisions, `engineer-loop-run` adds these operator-visible lines:
+
+- `Carried meeting decisions: <count>`
+- `Carried meeting decision <index>: <concise record>`
+
+`engineer-loop-run` currently surfaces at most the three most recent persisted meeting records from that state root.
+
+That concise record currently carries the facilitator summary fields `agenda`, `updates`, `decisions`, `risks`, `next_steps`, `open_questions`, and `goals`.
+
+A bare `agenda:` or `topic:` line without any persistable structured outputs does not create a carried meeting record.
+
+That output is additive. It does not replace the existing engineer-loop fields:
+
+- `Active goals count` and `Active goal <index>:` still reflect durable goal stewardship
+- `Selected action`, `Action status`, and `Verification status` still describe the bounded engineer-loop execution
+- carried meeting decisions remain advisory planning context, not implicit code execution
 
 The goal-curation path is intentionally narrow too:
 
@@ -130,6 +158,16 @@ Artifacts are written under `target/simard-gym/` as JSON and text reports plus a
 | `SIMARD_IDENTITY` | Yes in `explicit-config` | none in `explicit-config`; `simard-engineer` in `builtin-defaults` | Identity to load before runtime composition. Non-UTF-8 values fail bootstrap instead of being treated as missing. |
 | `SIMARD_BASE_TYPE` | Yes in `explicit-config` | none in `explicit-config`; `local-harness` in `builtin-defaults` | Base type selected for the runtime request. Unsupported or unregistered choices fail explicitly. |
 | `SIMARD_RUNTIME_TOPOLOGY` | Yes in `explicit-config` | none in `explicit-config`; `single-process` in `builtin-defaults` | Runtime topology selected for the runtime request. Accepted values: `single-process`, `multi-process`, `distributed`. |
+
+### Operator probe carryover configuration
+
+The meeting-to-engineer handoff uses CLI arguments rather than environment variables:
+
+- `meeting-run` accepts an optional trailing `state-root`
+- `engineer-loop-run` accepts an optional trailing `state-root`
+- passing the same explicit directory to both commands is the supported way to make meeting decisions visible in later engineer-loop runs
+- the carryover surface is intentionally bounded: `engineer-loop-run` reports at most the three most recent persisted meeting records from that shared state root
+- if you omit the shared state root, the probes still run, but there is no guaranteed cross-session carryover contract
 
 ### Current builtin base-type registrations
 

--- a/docs/tutorials/run-your-first-local-session.md
+++ b/docs/tutorials/run-your-first-local-session.md
@@ -7,6 +7,7 @@ owner: simard
 doc_type: tutorial
 related:
   - ../index.md
+  - ../howto/carry-meeting-decisions-into-engineer-sessions.md
   - ../howto/configure-bootstrap-and-inspect-reflection.md
   - ../reference/runtime-contracts.md
 ---
@@ -20,6 +21,7 @@ This tutorial follows the runtime path that exists in the repository today.
 - How the local runtime starts with explicit configuration
 - How explicit opt-in defaults behave
 - What reflection reports after a run
+- How meeting decisions flow into later engineer sessions
 - How durable goal stewardship flows into later sessions
 - How runtime node, mailbox, and backend wiring appear in reflection
 - What stop semantics look like in practice
@@ -126,7 +128,56 @@ Selected action: cargo-metadata-scan
 Verification status: verified
 ```
 
-**Checkpoint**: Simard is now doing more than opening a shell. It is inspecting repo state, choosing a bounded repo-native action, verifying that repo grounding stayed stable, and persisting truthful memory/evidence for the loop. When a shared state root already contains durable goals, the same probe also reports the active top-goal set.
+**Checkpoint**: Simard is now doing more than opening a shell. It is inspecting repo state, choosing a bounded repo-native action, verifying that repo grounding stayed stable, and persisting truthful memory/evidence for the loop. When a shared state root already contains durable goals or meeting decision memory, the same probe also reports the active top-goal set and up to the three most recent carried meeting records.
+
+### Variation: carry meeting decisions into the engineer loop
+
+Use the same explicit state root for a facilitator run and a later engineer-loop run:
+
+```bash
+STATE_ROOT="$(mktemp -d /tmp/simard-meeting-handoff.XXXXXX)"
+
+MEETING_OBJECTIVE="$(cat <<'EOF'
+agenda: align the next Simard workstream
+decision: preserve meeting-to-engineer continuity
+risk: workflow routing is still unreliable
+next-step: keep durable priorities visible
+open-question: how aggressively should Simard reprioritize?
+goal: Preserve meeting handoff | priority=1 | status=active | rationale=meeting decisions must shape later work
+goal: Keep outside-in verification strong | priority=2 | status=active | rationale=operator confidence depends on real product exercise
+EOF
+)"
+
+cargo run --quiet --bin simard_operator_probe -- \
+  meeting-run local-harness single-process \
+  "$MEETING_OBJECTIVE" \
+  "$STATE_ROOT"
+
+cargo run --quiet --bin simard_operator_probe -- \
+  engineer-loop-run single-process . \
+  $'inspect the repository state\nrun one safe local engineering action\nverify the outcome explicitly\npersist truthful local evidence and memory' \
+  "$STATE_ROOT"
+```
+
+Look for these lines in the second command output:
+
+```text
+Probe mode: engineer-loop-run
+Repo root: /path/to/repo
+Active goals count: 2
+Active goal 1: p1 [active] Preserve meeting handoff
+Active goal 2: p2 [active] Keep outside-in verification strong
+Carried meeting decisions: 1
+Carried meeting decision 1: agenda=align the next Simard workstream; updates=[]; decisions=[preserve meeting-to-engineer continuity]; risks=[workflow routing is still unreliable]; next_steps=[keep durable priorities visible]; open_questions=[how aggressively should Simard reprioritize?]; goals=[p1:active:Preserve meeting handoff:meeting decisions must shape later work | p2:active:Keep outside-in verification strong:operator confidence depends on real product exercise]
+Execution scope: local-only
+Selected action: cargo-metadata-scan
+Verification status: verified
+State root: /tmp/simard-meeting-handoff.XXXXXX
+```
+
+The probe also prints repo branch and HEAD, worktree state, the architecture-gap summary, the selected action command, and the verification summary between those lines.
+
+**Checkpoint**: this is the Phase 4 product seam now present in the repo. Meeting mode contributes durable decision memory, and the later engineer loop carries that advisory context forward without claiming that the meeting itself performed implementation work. If the shared state root contains more than three meeting records, the engineer loop currently surfaces only the three most recent ones.
 
 ## Step 3: Curate durable top goals and reuse them in later sessions
 

--- a/src/bin/simard_operator_probe.rs
+++ b/src/bin/simard_operator_probe.rs
@@ -446,6 +446,13 @@ fn run_engineer_loop_probe(
     for (index, goal) in run.inspection.active_goals.iter().enumerate() {
         println!("Active goal {}: {}", index + 1, goal.concise_label());
     }
+    println!(
+        "Carried meeting decisions: {}",
+        run.inspection.carried_meeting_decisions.len()
+    );
+    for (index, decision) in run.inspection.carried_meeting_decisions.iter().enumerate() {
+        println!("Carried meeting decision {}: {}", index + 1, decision);
+    }
     println!("Gap summary: {}", run.inspection.architecture_gap_summary);
     println!("Execution scope: {}", run.execution_scope);
     println!("Selected action: {}", run.action.selected.label);

--- a/src/engineer_loop.rs
+++ b/src/engineer_loop.rs
@@ -17,6 +17,7 @@ use crate::session::{SessionPhase, SessionRecord, UuidSessionIdGenerator};
 const ENGINEER_IDENTITY: &str = "simard-engineer";
 const ENGINEER_BASE_TYPE: &str = "terminal-shell";
 const EXECUTION_SCOPE: &str = "local-only";
+const MAX_CARRIED_MEETING_DECISIONS: usize = 3;
 const CLEARED_GIT_ENV_VARS: &[&str] = &[
     "GIT_DIR",
     "GIT_WORK_TREE",
@@ -36,6 +37,7 @@ pub struct RepoInspection {
     pub worktree_dirty: bool,
     pub changed_files: Vec<String>,
     pub active_goals: Vec<GoalRecord>,
+    pub carried_meeting_decisions: Vec<String>,
     pub architecture_gap_summary: String,
 }
 
@@ -123,6 +125,7 @@ fn inspect_workspace(workspace_root: &Path, state_root: &Path) -> SimardResult<R
     let worktree_dirty = !changed_files.is_empty();
     let active_goals =
         FileBackedGoalStore::try_new(state_root.join("goal_records.json"))?.active_top_goals(5)?;
+    let carried_meeting_decisions = load_carried_meeting_decisions(state_root)?;
 
     Ok(RepoInspection {
         workspace_root,
@@ -136,8 +139,41 @@ fn inspect_workspace(workspace_root: &Path, state_root: &Path) -> SimardResult<R
         worktree_dirty,
         changed_files,
         active_goals,
+        carried_meeting_decisions,
         architecture_gap_summary: architecture_gap_summary(&repo_root)?,
     })
+}
+
+fn load_carried_meeting_decisions(state_root: &Path) -> SimardResult<Vec<String>> {
+    let memory_store = FileBackedMemoryStore::try_new(state_root.join("memory_records.json"))?;
+    let mut carried = memory_store
+        .list(MemoryScope::Decision)?
+        .into_iter()
+        .filter_map(|record| match is_meeting_decision_record(&record.value) {
+            true => Some(record.value),
+            false => None,
+        })
+        .collect::<Vec<_>>();
+
+    if carried.len() > MAX_CARRIED_MEETING_DECISIONS {
+        carried = carried.split_off(carried.len() - MAX_CARRIED_MEETING_DECISIONS);
+    }
+
+    Ok(carried)
+}
+
+fn is_meeting_decision_record(value: &str) -> bool {
+    [
+        "agenda=",
+        "updates=",
+        "decisions=",
+        "risks=",
+        "next_steps=",
+        "open_questions=",
+        "goals=",
+    ]
+    .into_iter()
+    .all(|fragment| value.contains(fragment))
 }
 
 fn architecture_gap_summary(repo_root: &Path) -> SimardResult<String> {
@@ -181,10 +217,26 @@ fn architecture_gap_summary(repo_root: &Path) -> SimardResult<String> {
 }
 
 fn select_engineer_action(inspection: &RepoInspection) -> SimardResult<SelectedEngineerAction> {
+    let carry_forward_note = if inspection.carried_meeting_decisions.is_empty() {
+        String::new()
+    } else {
+        format!(
+            " Shared state root also carries {} meeting decision record{}, so the engineer loop keeps that handoff visible while choosing the next safe repo-native action.",
+            inspection.carried_meeting_decisions.len(),
+            if inspection.carried_meeting_decisions.len() == 1 {
+                ""
+            } else {
+                "s"
+            }
+        )
+    };
+
     if inspection.repo_root.join("Cargo.toml").is_file() {
         return Ok(SelectedEngineerAction {
             label: "cargo-metadata-scan".to_string(),
-            rationale: "Detected a Rust workspace via Cargo.toml, so the next honest v1 action is a local argv-only cargo metadata scan that inspects the workspace graph without pretending remote orchestration exists.".to_string(),
+            rationale: format!(
+                "Detected a Rust workspace via Cargo.toml, so the next honest v1 action is a local argv-only cargo metadata scan that inspects the workspace graph without pretending remote orchestration exists.{carry_forward_note}"
+            ),
             argv: vec![
                 "cargo".to_string(),
                 "metadata".to_string(),
@@ -198,8 +250,14 @@ fn select_engineer_action(inspection: &RepoInspection) -> SimardResult<SelectedE
     if inspection.repo_root.join(".git").exists() {
         return Ok(SelectedEngineerAction {
             label: "git-tracked-file-scan".to_string(),
-            rationale: "No repo-native language manifest was detected, so the loop falls back to a local argv-only scan of tracked files instead of inventing unsupported tooling.".to_string(),
-            argv: vec!["git".to_string(), "ls-files".to_string(), "--cached".to_string()],
+            rationale: format!(
+                "No repo-native language manifest was detected, so the loop falls back to a local argv-only scan of tracked files instead of inventing unsupported tooling.{carry_forward_note}"
+            ),
+            argv: vec![
+                "git".to_string(),
+                "ls-files".to_string(),
+                "--cached".to_string(),
+            ],
         });
     }
 
@@ -286,6 +344,17 @@ fn verify_engineer_action(
         });
     }
     checks.push(format!("active-goals={}", post.active_goals.len()));
+
+    if post.carried_meeting_decisions != inspection.carried_meeting_decisions {
+        return Err(SimardError::VerificationFailed {
+            reason: "carried meeting decision memory changed during a non-mutating local engineer action"
+                .to_string(),
+        });
+    }
+    checks.push(format!(
+        "carried-meeting-decisions={}",
+        post.carried_meeting_decisions.len()
+    ));
 
     match action.selected.label.as_str() {
         "cargo-metadata-scan" => {
@@ -424,6 +493,14 @@ fn persist_engineer_loop_artifacts(
                     .join(", ")
             }
         ),
+        format!(
+            "carried-meeting-decisions={}",
+            if inspection.carried_meeting_decisions.is_empty() {
+                "<none>".to_string()
+            } else {
+                inspection.carried_meeting_decisions.join(" || ")
+            }
+        ),
         format!("architecture-gap={}", inspection.architecture_gap_summary),
         format!("execution-scope={EXECUTION_SCOPE}"),
         format!("selected-action={}", action.selected.label),
@@ -455,7 +532,7 @@ fn persist_engineer_loop_artifacts(
         key: summary_key.clone(),
         scope: MemoryScope::SessionSummary,
         value: format!(
-            "engineer-loop-summary | repo-root={} | repo-branch={} | worktree-dirty={} | active-goals={} | selected-action={} | verification-status={} | execution-scope={EXECUTION_SCOPE}",
+            "engineer-loop-summary | repo-root={} | repo-branch={} | worktree-dirty={} | active-goals={} | carried-meeting-decisions={} | selected-action={} | verification-status={} | execution-scope={EXECUTION_SCOPE}",
             inspection.repo_root.display(),
             inspection.branch,
             inspection.worktree_dirty,
@@ -469,6 +546,7 @@ fn persist_engineer_loop_artifacts(
                     .collect::<Vec<_>>()
                     .join(", ")
             },
+            inspection.carried_meeting_decisions.len(),
             action.selected.label,
             verification.status
         ),
@@ -482,8 +560,10 @@ fn persist_engineer_loop_artifacts(
         key: decision_key.clone(),
         scope: MemoryScope::Decision,
         value: format!(
-            "engineer-loop-decision | {} | {}",
-            action.selected.rationale, verification.summary
+            "engineer-loop-decision | carried-meeting-decisions={} | {} | {}",
+            inspection.carried_meeting_decisions.len(),
+            action.selected.rationale,
+            verification.summary
         ),
         session_id: session.id.clone(),
         recorded_in: SessionPhase::Persistence,

--- a/tests/engineer_loop.rs
+++ b/tests/engineer_loop.rs
@@ -126,6 +126,10 @@ fn engineer_loop_probe_reports_repo_state_runs_verified_action_and_persists_trut
         "v1 engineer loop must stay honest about local-only execution:\n{rendered}"
     );
     assert!(
+        rendered.contains("Carried meeting decisions: 0"),
+        "isolated engineer-loop runs should say when no prior meeting decisions were carried forward:\n{rendered}"
+    );
+    assert!(
         rendered.contains("Selected action: "),
         "engineer-loop probe should report the grounded engineering action it chose:\n{rendered}"
     );
@@ -186,5 +190,9 @@ fn engineer_loop_probe_reports_repo_state_runs_verified_action_and_persists_trut
     assert!(
         handoff_payload.contains("verification-status=verified"),
         "handoff payload should preserve verified outcome status for truthful resume behavior:\n{handoff_payload}"
+    );
+    assert!(
+        evidence_payload.contains("carried-meeting-decisions=<none>"),
+        "evidence payload should preserve whether prior meeting decisions were available:\n{evidence_payload}"
     );
 }

--- a/tests/gadugi/engineer-loop.sh
+++ b/tests/gadugi/engineer-loop.sh
@@ -24,6 +24,7 @@ printf '%s\n' "$OUTPUT" | grep -F "Repo root: $ROOT" >/dev/null
 printf '%s\n' "$OUTPUT" | grep -F "Repo branch: " >/dev/null
 printf '%s\n' "$OUTPUT" | grep -F "Worktree dirty: $EXPECTED_DIRTY" >/dev/null
 printf '%s\n' "$OUTPUT" | grep -F "Execution scope: local-only" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "Carried meeting decisions: 0" >/dev/null
 printf '%s\n' "$OUTPUT" | grep -F "Selected action: " >/dev/null
 printf '%s\n' "$OUTPUT" | grep -F "Action status: success" >/dev/null
 printf '%s\n' "$OUTPUT" | grep -F "Verification status: verified" >/dev/null

--- a/tests/gadugi/goal-stewardship.sh
+++ b/tests/gadugi/goal-stewardship.sh
@@ -5,7 +5,8 @@ ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 cd "$ROOT"
 
 STATE_ROOT="$(mktemp -d /tmp/simard-goal-stewardship.XXXXXX)"
-trap 'rm -rf "$STATE_ROOT"' EXIT
+LIMIT_ROOT="$(mktemp -d /tmp/simard-goal-stewardship-limit.XXXXXX)"
+trap 'rm -rf "$STATE_ROOT" "$LIMIT_ROOT"' EXIT
 
 MEETING_OBJECTIVE="$(cat <<'EOF'
 agenda: align the next Simard workstream
@@ -44,4 +45,32 @@ printf '%s\n' "$ENGINEER_OUTPUT" | grep -F "Probe mode: engineer-loop-run" >/dev
 printf '%s\n' "$ENGINEER_OUTPUT" | grep -F "Active goals count: 2" >/dev/null
 printf '%s\n' "$ENGINEER_OUTPUT" | grep -F "Active goal 1: p1 [active] Preserve meeting handoff" >/dev/null
 printf '%s\n' "$ENGINEER_OUTPUT" | grep -F "Active goal 2: p2 [active] Keep outside-in verification strong" >/dev/null
+printf '%s\n' "$ENGINEER_OUTPUT" | grep -F "Carried meeting decisions: 1" >/dev/null
+printf '%s\n' "$ENGINEER_OUTPUT" | grep -F "Carried meeting decision 1: agenda=align the next Simard workstream;" >/dev/null
+printf '%s\n' "$ENGINEER_OUTPUT" | grep -F "decisions=[preserve meeting-to-engineer continuity]" >/dev/null
 printf '%s\n' "$ENGINEER_OUTPUT" | grep -F "Verification status: verified" >/dev/null
+
+for i in 1 2 3 4; do
+  LIMIT_MEETING_OBJECTIVE="$(printf 'agenda: alignment meeting %s\ndecision: preserve priority %s\nrisk: workflow risk %s\nnext-step: verify carryover %s\nopen-question: what changes after meeting %s?\n' "$i" "$i" "$i" "$i" "$i")"
+  cargo run --quiet --bin simard_operator_probe -- \
+    meeting-run local-harness single-process \
+    "$LIMIT_MEETING_OBJECTIVE" \
+    "$LIMIT_ROOT" >/dev/null
+done
+
+LIMIT_ENGINEER_OUTPUT="$(
+  cargo run --quiet --bin simard_operator_probe -- \
+    engineer-loop-run single-process "$ROOT" "$ENGINEER_OBJECTIVE" "$LIMIT_ROOT"
+)"
+
+printf '%s\n' "$LIMIT_ENGINEER_OUTPUT"
+
+printf '%s\n' "$LIMIT_ENGINEER_OUTPUT" | grep -F "Active goals count: 0" >/dev/null
+printf '%s\n' "$LIMIT_ENGINEER_OUTPUT" | grep -F "Carried meeting decisions: 3" >/dev/null
+printf '%s\n' "$LIMIT_ENGINEER_OUTPUT" | grep -F "Carried meeting decision 1: agenda=alignment meeting 2;" >/dev/null
+printf '%s\n' "$LIMIT_ENGINEER_OUTPUT" | grep -F "Carried meeting decision 3: agenda=alignment meeting 4;" >/dev/null
+printf '%s\n' "$LIMIT_ENGINEER_OUTPUT" | grep -F "Verification status: verified" >/dev/null
+if printf '%s\n' "$LIMIT_ENGINEER_OUTPUT" | grep -F "agenda=alignment meeting 1;" >/dev/null; then
+  echo "oldest carried meeting record should be dropped once the cap is exceeded" >&2
+  exit 1
+fi

--- a/tests/goal_stewardship.rs
+++ b/tests/goal_stewardship.rs
@@ -124,8 +124,72 @@ goal: Keep outside-in verification strong | priority=2 | status=active | rationa
         engineer_rendered
             .contains("Active goal 2: p2 [active] Keep outside-in verification strong")
     );
+    assert!(engineer_rendered.contains("Carried meeting decisions: 1"));
+    assert!(
+        engineer_rendered
+            .contains("Carried meeting decision 1: agenda=align the next Simard workstream;")
+    );
+    assert!(engineer_rendered.contains("decisions=[preserve meeting-to-engineer continuity]"));
+    assert!(engineer_rendered.contains("next_steps=[keep durable priorities visible]"));
     assert!(
         engineer_rendered.contains("Verification status: verified"),
         "engineer loop must still verify bounded work while reading curated goals:\n{engineer_rendered}"
     );
+}
+
+#[test]
+fn engineer_loop_only_carries_the_three_most_recent_meeting_records() {
+    let state_root = TempDirGuard::new("simard-meeting-carry-limit");
+
+    for meeting_number in 1..=4 {
+        let meeting_objective = format!(
+            "\
+agenda: alignment meeting {meeting_number}\n\
+decision: preserve priority {meeting_number}\n\
+risk: workflow risk {meeting_number}\n\
+next-step: verify carryover {meeting_number}\n\
+open-question: what changes after meeting {meeting_number}?"
+        );
+
+        let output = Command::new(env!("CARGO_BIN_EXE_simard_operator_probe"))
+            .arg("meeting-run")
+            .arg("local-harness")
+            .arg("single-process")
+            .arg(&meeting_objective)
+            .arg(state_root.path())
+            .output()
+            .expect("meeting probe should launch");
+        let rendered = rendered_output(&output);
+
+        assert!(
+            output.status.success(),
+            "meeting probe should succeed for carry-limit setup:\n{rendered}"
+        );
+        assert!(rendered.contains("Decision records: 1"));
+    }
+
+    let engineer_output = Command::new(env!("CARGO_BIN_EXE_simard_operator_probe"))
+        .arg("engineer-loop-run")
+        .arg("single-process")
+        .arg(repo_root())
+        .arg("inspect the repo and preserve bounded meeting memory")
+        .arg(state_root.path())
+        .output()
+        .expect("engineer loop probe should launch");
+    let engineer_rendered = rendered_output(&engineer_output);
+
+    assert!(
+        engineer_output.status.success(),
+        "engineer loop probe should succeed with bounded meeting carryover:\n{engineer_rendered}"
+    );
+    assert!(engineer_rendered.contains("Active goals count: 0"));
+    assert!(engineer_rendered.contains("Carried meeting decisions: 3"));
+    assert!(
+        !engineer_rendered.contains("agenda=alignment meeting 1;"),
+        "engineer loop should drop the oldest carried meeting record once the cap is exceeded:\n{engineer_rendered}"
+    );
+    assert!(engineer_rendered.contains("Carried meeting decision 1: agenda=alignment meeting 2;"));
+    assert!(engineer_rendered.contains("Carried meeting decision 2: agenda=alignment meeting 3;"));
+    assert!(engineer_rendered.contains("Carried meeting decision 3: agenda=alignment meeting 4;"));
+    assert!(engineer_rendered.contains("Verification status: verified"));
 }


### PR DESCRIPTION
## Summary
- carry concise meeting decision memory into later engineer-loop runs through the shared durable state root
- surface bounded carried meeting decision context through `simard_operator_probe engineer-loop-run` without changing the engineer loop's local-only inspect -> act -> verify contract
- add docs/howto coverage and extend Rust plus outside-in operator tests for meeting -> engineer carryover and the three-record retention cap

## Validation
- cargo test --all-features --locked
- tests/gadugi/smoke-explicit-local.sh
- tests/gadugi/smoke-explicit-rusty-clawd.sh
- tests/gadugi/smoke-builtin-defaults.sh
- tests/gadugi/composite-identity.sh
- tests/gadugi/meeting-mode.sh
- tests/gadugi/goal-stewardship.sh
- tests/gadugi/improvement-curation.sh
- tests/gadugi/terminal-session.sh
- tests/gadugi/engineer-loop.sh
- tests/gadugi/handoff-roundtrip.sh
- tests/gadugi/gym-suite.sh
- python3 -m pre_commit run --all-files --hook-stage pre-commit
- python3 -m pre_commit run --all-files --hook-stage pre-push
