### PR TITLE
Add gym benchmark comparison surface

### DIFF
--- a/docs/howto/carry-meeting-decisions-into-engineer-sessions.md
+++ b/docs/howto/carry-meeting-decisions-into-engineer-sessions.md
@@ -1,6 +1,6 @@
 ---
 title: "How to carry meeting decisions into engineer sessions"
-description: Persist concise meeting records under a shared state root and verify that later engineer sessions carry them forward, using today's binaries and the planned unified CLI mapping.
+description: Persist concise meeting records under a shared state root and verify that later engineer sessions carry them forward through the canonical `simard` CLI.
 last_updated: 2026-03-30
 review_schedule: as-needed
 owner: simard
@@ -19,14 +19,12 @@ Use this guide when you want to prove one specific product seam: a meeting run c
 
 ## Status
 
-The handoff behavior is real today through `simard_operator_probe`.
-
-The future `simard meeting run ...` and `simard engineer run ...` entrypoints are planned, not shipped yet.
+The handoff behavior is shipped on the canonical `simard` CLI.
 
 ## Prerequisites
 
 - [ ] You are in the repository root
-- [ ] `cargo run --quiet --bin simard_operator_probe -- ...` works locally
+- [ ] `cargo run --quiet -- ...` works locally
 - [ ] You want a local file-backed handoff, not a network service or remote orchestrator
 
 ## 1. Pick one explicit state root for both commands
@@ -39,9 +37,9 @@ STATE_ROOT="$(mktemp -d /tmp/simard-meeting-handoff.XXXXXX)"
 
 Keep that shell variable for the rest of this guide.
 
-## 2. Capture a structured meeting record through today's operator surface
+## 2. Capture a structured meeting record
 
-Run `meeting-run` with a real structured objective. A carried meeting record is persisted when the objective includes any persistable structured output such as `update:`, `decision:`, `risk:`, `next-step:`, `open-question:`, or structured `goal:` lines. This example uses all of them.
+Run `meeting run` with a real structured objective. A carried meeting record is persisted when the objective includes any persistable structured output such as `update:`, `decision:`, `risk:`, `next-step:`, `open-question:`, or structured `goal:` lines. This example uses all of them.
 
 ```bash
 MEETING_OBJECTIVE="$(cat <<'EOF'
@@ -55,26 +53,16 @@ goal: Keep outside-in verification strong | priority=2 | status=active | rationa
 EOF
 )"
 
-cargo run --quiet --bin simard_operator_probe -- \
-  meeting-run local-harness single-process \
-  "$MEETING_OBJECTIVE" \
-  "$STATE_ROOT"
+cargo run --quiet --   meeting run local-harness single-process   "$MEETING_OBJECTIVE"   "$STATE_ROOT"
 ```
 
 Look for output like this:
 
 ```text
-Mode: meeting
 Identity: simard-meeting
 Decision records: 1
 Active goals count: 2
 Active goal 1: p1 [active] Preserve meeting handoff
-```
-
-Planned unified equivalent:
-
-```bash
-simard meeting run local-harness single-process "$MEETING_OBJECTIVE" "$STATE_ROOT"
 ```
 
 This run writes one concise meeting record and goal state under `STATE_ROOT`. It does not run code or mutate the repository.
@@ -84,29 +72,23 @@ This run writes one concise meeting record and goal state under `STATE_ROOT`. It
 Now point the engineer loop at the same repository and the same `STATE_ROOT`.
 
 ```bash
-ENGINEER_OBJECTIVE=$'inspect the repository state\nrun one safe local engineering action\nverify the outcome explicitly\npersist truthful local evidence and memory'
+ENGINEER_OBJECTIVE=$'inspect the repository state
+run one safe local engineering action
+verify the outcome explicitly
+persist truthful local evidence and memory'
 
-cargo run --quiet --bin simard_operator_probe -- \
-  engineer-loop-run single-process "$PWD" "$ENGINEER_OBJECTIVE" "$STATE_ROOT"
+cargo run --quiet --   engineer run single-process "$PWD" "$ENGINEER_OBJECTIVE" "$STATE_ROOT"
 ```
 
 Look for output like this:
 
 ```text
-Mode: engineer
 Repo root: /path/to/repo
 Active goals count: 2
 Active goal 1: p1 [active] Preserve meeting handoff
 Active goal 2: p2 [active] Keep outside-in verification strong
 Carried meeting decisions: 1
-Carried meeting decision 1: agenda=align the next Simard workstream; updates=[]; decisions=[preserve meeting-to-engineer continuity]; risks=[workflow routing is still unreliable]; next_steps=[keep durable priorities visible]; open_questions=[how aggressively should Simard reprioritize?]; goals=[p1:active:Preserve meeting handoff:meeting decisions must shape later work | p2:active:Keep outside-in verification strong:operator confidence depends on real product exercise]
 Verification status: verified
-```
-
-Planned unified equivalent:
-
-```bash
-simard engineer run single-process "$PWD" "$ENGINEER_OBJECTIVE" "$STATE_ROOT"
 ```
 
 The important contract is additive:
@@ -121,9 +103,9 @@ The important contract is additive:
 
 For predictable handoff behavior, keep these rules in mind:
 
-- pass the same explicit `state-root` argument to both `meeting-run` and `engineer-loop-run`
-- keep `meeting-run` on a supported facilitator pairing such as `local-harness single-process`
-- keep `engineer-loop-run` pointed at a real repository path for `workspace-root`
+- pass the same explicit `state-root` argument to both `meeting run` and `engineer run`
+- keep `meeting run` on a supported facilitator pairing such as `local-harness single-process`
+- keep `engineer run` pointed at a real repository path for `workspace-root`
 - expect the engineer loop to surface at most the three most recent carried meeting records, not an unbounded history dump
 - treat carried meeting decisions as advisory context only; they do not auto-edit code or silently rewrite goals
 
@@ -147,6 +129,6 @@ That is outside this feature's contract. The handoff is only complete when the l
 
 ## Related reading
 
-- For the broader current-to-planned command mapping, see [Simard CLI reference](../reference/simard-cli.md).
+- For the exact command tree and compatibility surfaces, see [Simard CLI reference](../reference/simard-cli.md).
 - For the broader runtime contract, see [Runtime contracts reference](../reference/runtime-contracts.md).
-- For a longer end-to-end walk through the current binaries, see [Tutorial: Run your first local session](../tutorials/run-your-first-local-session.md).
+- For a longer end-to-end walk through the current operator flows, see [Tutorial: Run your first local session](../tutorials/run-your-first-local-session.md).

--- a/docs/howto/configure-bootstrap-and-inspect-reflection.md
+++ b/docs/howto/configure-bootstrap-and-inspect-reflection.md
@@ -1,6 +1,6 @@
 ---
 title: "How to configure bootstrap and inspect reflection"
-description: Verify the current `simard` bootstrap entrypoint, inspect the truthful reflection snapshot exposed by the runtime, and understand the planned bootstrap subcommand.
+description: Bootstrap an explicit runtime selection through `simard bootstrap run`, inspect the truthful reflection snapshot, and validate the bounded engineer surfaces that hang off the same runtime contract.
 last_updated: 2026-03-30
 review_schedule: as-needed
 owner: simard
@@ -22,50 +22,36 @@ Use this guide when you need to answer two questions:
 
 ## Status
 
-Today, the real `simard` binary bootstraps directly from `SIMARD_*` environment variables.
+The canonical bootstrap surface is now `simard bootstrap run ...`.
 
-The future `simard bootstrap run ...` subcommand is planned, not shipped yet.
+The old zero-argument `simard` bootstrap fallback is gone. Operators must pass the runtime selection explicitly. The terminal-backed engineer substrate still lives on the compatibility binary because that subcommand has not moved onto the canonical CLI yet.
 
 ## Prerequisites
 
 - [ ] You are in the repository root
-- [ ] `cargo run --quiet --` works locally when the required `SIMARD_*` variables are set
+- [ ] `cargo run --quiet -- bootstrap run ...` works locally
 - [ ] You know which identity, base type, topology, and state root you want to inspect
 
-## 1. Use explicit bootstrap configuration by default
+## 1. Bootstrap explicitly by default
 
-Provide the prompt root, identity, base type, topology, objective, and state root yourself.
+Provide the identity, base type, topology, objective, and state root yourself.
 
 For the builtin identities in this repo, the current scaffold accepts `local-harness`, `rusty-clawd`, or `copilot-sdk` as explicit base-type choices everywhere, and `simard-engineer` additionally accepts `terminal-shell` for a real local PTY-backed shell session. `rusty-clawd` is a distinct session backend, `terminal-shell` is intentionally local-only, and `copilot-sdk` remains an explicit alias of `local-harness`.
 
 ```bash
-SIMARD_PROMPT_ROOT="$PWD/prompt_assets" \
-SIMARD_IDENTITY=simard-engineer \
-SIMARD_BASE_TYPE=local-harness \
-SIMARD_RUNTIME_TOPOLOGY=single-process \
-SIMARD_OBJECTIVE="verify current reflection metadata" \
-SIMARD_STATE_ROOT="$PWD/target/simard-state" \
-cargo run --quiet --
+cargo run --quiet --   bootstrap run simard-engineer local-harness single-process   "verify current reflection metadata"   "$PWD/target/simard-state"
 ```
 
 Look for output shaped like this:
 
 ```text
-Simard local runtime executed successfully.
-Bootstrap mode: explicit-config
-Bootstrap selection: identity=simard-engineer, base_type=local-harness, topology=single-process
+Probe mode: bootstrap-run
+Identity: simard-engineer
+Selected base type: local-harness
+Topology: single-process
 State root: /.../target/simard-state
-Snapshot: state=ready, topology=single-process, base_type=local-harness
-Adapter implementation: local-harness
-Shutdown: stopped
-```
-
-Planned unified equivalent:
-
-```bash
-simard bootstrap run simard-engineer local-harness single-process \
-  "verify current reflection metadata" \
-  "$PWD/target/simard-state"
+Execution summary: ...
+Reflection summary: ...
 ```
 
 In the current bootstrap contract:
@@ -73,27 +59,22 @@ In the current bootstrap contract:
 - missing required bootstrap inputs fail explicitly
 - unsupported identity and base-type combinations fail explicitly
 - unsupported topology and base-type combinations fail explicitly
-- no missing value is replaced after startup unless you deliberately opted into builtin defaults
+- state roots are validated before persistence is touched
+- no missing value is replaced through a hidden bootstrap fallback
 
 ### Variation: exercise a non-default builtin base type
 
 Use this when you want to prove that bootstrap is not silently snapping back to `local-harness`.
 
 ```bash
-SIMARD_PROMPT_ROOT="$PWD/prompt_assets" \
-SIMARD_IDENTITY=simard-engineer \
-SIMARD_BASE_TYPE=copilot-sdk \
-SIMARD_RUNTIME_TOPOLOGY=single-process \
-SIMARD_OBJECTIVE="verify copilot-sdk bootstrap selection" \
-SIMARD_STATE_ROOT="$PWD/target/simard-state" \
-cargo run --quiet --
+cargo run --quiet --   bootstrap run simard-engineer copilot-sdk single-process   "verify copilot-sdk bootstrap selection"   "$PWD/target/simard-state"
 ```
 
 Look for these lines:
 
 ```text
-Bootstrap selection: identity=simard-engineer, base_type=copilot-sdk, topology=single-process
-Snapshot: state=ready, topology=single-process, base_type=copilot-sdk
+Selected base type: copilot-sdk
+Topology: single-process
 Adapter implementation: local-harness
 ```
 
@@ -152,48 +133,41 @@ assert_eq!(snapshot.evidence_backend.identity, "evidence::json-file-store");
 
 If you launched with `copilot-sdk`, `snapshot.selected_base_type` still shows the alias you chose while `snapshot.adapter_backend.identity` remains `local-harness`. If you launched with `rusty-clawd`, reflection reports `snapshot.adapter_backend.identity == "rusty-clawd::session-backend"`. If you launch the engineer identity with `terminal-shell`, reflection reports `snapshot.adapter_backend.identity == "terminal-shell::local-pty"`, `snapshot.adapter_capabilities` includes `terminal-session`, and `snapshot.adapter_supported_topologies == ["single-process"]`.
 
-## 3. Exercise the terminal-backed engineer path
+## 3. Exercise the terminal-backed engineer substrate
 
-Today, use the compatibility binary when you want to validate the terminal-backed engineer substrate directly:
+The terminal-backed engineer substrate is still compatibility-only:
 
 ```bash
-cargo run --quiet --bin simard_operator_probe -- \
-  terminal-run single-process \
-  $'working-directory: .\ncommand: pwd\ncommand: printf "terminal-foundation-ok\\n"'
+cargo run --quiet --bin simard_operator_probe --   terminal-run single-process   $'working-directory: .
+command: pwd
+command: printf "terminal-foundation-ok\n"'
 ```
 
 Look for:
 
-- `Mode: engineer`
 - `Selected base type: terminal-shell`
 - `Adapter implementation: terminal-shell::local-pty`
-- `Terminal evidence: terminal-command-count=2`
+- `Terminal evidence lines: 2`
 - a transcript preview containing `terminal-foundation-ok`
-
-Planned unified equivalent:
-
-```bash
-simard engineer terminal single-process \
-  $'working-directory: .\ncommand: pwd\ncommand: printf "terminal-foundation-ok\\n"'
-```
 
 This is the honest terminal slice: Simard can drive a real local PTY-backed shell session through the runtime, but it does not claim remote hosts or distributed terminal control.
 
 ## 4. Exercise the bounded engineer path
 
-Today, use the compatibility binary when you want Simard to inspect a repo, print a short plan with explicit verification steps, choose one bounded local engineering action, verify the outcome, and persist truthful local artifacts:
+Use the canonical CLI when you want Simard to inspect a repo, print a short plan with explicit verification steps, choose one bounded local engineering action, verify the outcome, and persist truthful local artifacts:
 
 ```bash
 STATE_ROOT="$PWD/target/simard-state"
-ENGINEER_OBJECTIVE=$'inspect the repository state\nrun one safe local engineering action\nverify the outcome explicitly\npersist truthful local evidence and memory'
+ENGINEER_OBJECTIVE=$'inspect the repository state
+run one safe local engineering action
+verify the outcome explicitly
+persist truthful local evidence and memory'
 
-cargo run --quiet --bin simard_operator_probe -- \
-  engineer-loop-run single-process "$PWD" "$ENGINEER_OBJECTIVE" "$STATE_ROOT"
+cargo run --quiet --   engineer run single-process "$PWD" "$ENGINEER_OBJECTIVE" "$STATE_ROOT"
 ```
 
 Look for:
 
-- `Mode: engineer`
 - `Repo root: ...`
 - `Active goals count: ...`
 - `Execution scope: local-only`
@@ -206,58 +180,26 @@ Look for:
 
 When you pass the same explicit state root that an earlier `meeting` run used, this same command also prints `Carried meeting decisions: N` and up to the three most recent `Carried meeting decision <index>:` lines.
 
-Planned unified equivalent:
+## 5. Builtin defaults are no longer an operator CLI path
 
-```bash
-simard engineer run single-process "$PWD" "$ENGINEER_OBJECTIVE" "$STATE_ROOT"
-```
+`BootstrapConfig` still understands `builtin-defaults` internally, but the operator-facing CLI no longer exposes a hidden zero-argument startup mode. If you want a local session through the CLI, pass the selection explicitly with `simard bootstrap run ...`.
 
-## 5. Opt in to builtin defaults only when you mean it
+That keeps the public surface honest:
 
-For local bootstrap, Simard supports explicit opt-in defaults.
-
-```bash
-SIMARD_BOOTSTRAP_MODE=builtin-defaults cargo run --quiet --
-```
-
-In that mode:
-
-- builtin prompt assets come from the repository prompt asset set
-- builtin state root resolves to `target/simard-state`
-- builtin identity resolves to `simard-engineer`
-- builtin base type resolves to `local-harness`
-- builtin topology resolves to `single-process`
-- configuration sources are recorded as explicit opt-in, not silent recovery
-
-Planned unified equivalent:
-
-```bash
-simard bootstrap run simard-engineer local-harness single-process "bootstrap the Simard engineer loop"
-```
-
-Builtin defaults are startup choices. They are not runtime recovery behavior.
+- startup choices stay visible at the call site
+- durable state roots stay explicit
+- help output remains stable when `simard` is launched with no arguments
 
 ## Troubleshooting
 
 ### Missing required bootstrap config
 
-**Symptom**: startup fails before the runtime is composed.
+**Symptom**: the command fails before the runtime is composed.
 
-**Solution**:
-
-```bash
-export SIMARD_PROMPT_ROOT="$PWD/prompt_assets"
-export SIMARD_IDENTITY=simard-engineer
-export SIMARD_BASE_TYPE=local-harness
-export SIMARD_RUNTIME_TOPOLOGY=single-process
-export SIMARD_OBJECTIVE="verify current reflection metadata"
-cargo run --quiet --
-```
-
-Or opt in explicitly:
+**Solution**: pass the missing positional bootstrap arguments explicitly:
 
 ```bash
-export SIMARD_BOOTSTRAP_MODE=builtin-defaults
+cargo run --quiet --   bootstrap run simard-engineer local-harness single-process   "verify current reflection metadata"   "$PWD/target/simard-state"
 ```
 
 ### Base type or topology selection fails

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 title: Simard documentation
-description: Start here for the current executable surfaces, the planned unified `simard` CLI, runtime contracts, and benchmark flow.
+description: Start here for the shipped `simard` operator CLI, compatibility binaries, runtime contracts, and benchmark flow.
 last_updated: 2026-03-30
 review_schedule: as-needed
 owner: simard
@@ -8,50 +8,23 @@ owner: simard
 
 # Simard documentation
 
-Simard is in a transition state.
+`simard` is the canonical operator-facing CLI.
 
-Today:
-
-- `simard` is a thin bootstrap entrypoint configured through environment variables
-- `simard_operator_probe` exposes the current engineer, meeting, goal-curation, improvement-curation, and review commands
-- `simard-gym` exposes the current benchmark CLI
-
-The product architecture targets a unified `simard` CLI with namespaces for `engineer`, `meeting`, `goal-curation`, `improvement-curation`, `gym`, `review`, and `bootstrap`. The docs below call out clearly whether something is current or planned so they do not overstate what ships today.
+The shipped command tree covers `engineer`, `meeting`, `goal-curation`, `improvement-curation`, `gym`, `review`, and `bootstrap` from one binary. The legacy `simard_operator_probe` and `simard-gym` binaries remain available as compatibility surfaces while operators migrate, but the primary product surface is now `simard ...`.
 
 ## Start here
 
-- [Tutorial: Run your first local session](./tutorials/run-your-first-local-session.md) - Exercise the current local-session flows through today's binaries and see how they map to the planned unified CLI.
-- [Tutorial: Run your first benchmark gym suite](./tutorials/run-your-first-benchmark-gym.md) - Run the shipped starter benchmark suite through `simard-gym` today and see the planned `simard gym` mapping.
-- [How to configure bootstrap and inspect reflection](./howto/configure-bootstrap-and-inspect-reflection.md) - Verify the current bootstrap entrypoint, inspect the truthful runtime snapshot, and see the planned bootstrap subcommand.
+- [Tutorial: Run your first local session](./tutorials/run-your-first-local-session.md) - Exercise the local runtime through the primary CLI.
+- [Tutorial: Run your first benchmark gym suite](./tutorials/run-your-first-benchmark-gym.md) - Run the shipped starter benchmark suite.
+- [How to configure bootstrap and inspect reflection](./howto/configure-bootstrap-and-inspect-reflection.md) - Bootstrap an explicit runtime selection and inspect the truthful runtime snapshot.
 - [How to carry meeting decisions into engineer sessions](./howto/carry-meeting-decisions-into-engineer-sessions.md) - Persist meeting records under a shared state root and confirm later engineer runs carry them forward.
-- [Simard CLI reference](./reference/simard-cli.md) - Look up the planned unified command tree together with the current runnable command mappings.
-- [Runtime contracts reference](./reference/runtime-contracts.md) - Look up the current executable contracts, the in-process runtime contract, and the planned unified CLI surface.
+- [Simard CLI reference](./reference/simard-cli.md) - Look up the shipped command tree and compatibility mappings.
+- [Runtime contracts reference](./reference/runtime-contracts.md) - Look up executable contracts and lifecycle guarantees.
 - [Concept: truthful runtime metadata](./concepts/truthful-runtime-metadata.md) - Read the design rationale behind the stricter runtime contract.
 
-## Current executable surfaces
+## Canonical executable surface
 
-Simard currently guarantees these operator-visible entrypoints:
-
-- `simard` boots a local session from environment variables and prints the reflected startup summary
-- `simard_operator_probe` runs the current multi-mode compatibility commands:
-  - `bootstrap-run`
-  - `engineer-loop-run`
-  - `terminal-run`
-  - `meeting-run`
-  - `goal-curation-run`
-  - `improvement-curation-run`
-  - `review-run`
-  - `review-read`
-- `simard-gym` runs the shipped benchmark commands:
-  - `list`
-  - `run <scenario-id>`
-  - `run-suite <suite-id>`
-
-These binaries already exercise real runtime behavior. They are not placeholders.
-
-## Planned operator surface
-
-The feature Simard is being built toward is a unified CLI shaped like this:
+Simard guarantees these operator-visible namespaces on the primary binary:
 
 - `simard engineer ...`
 - `simard meeting ...`
@@ -61,15 +34,18 @@ The feature Simard is being built toward is a unified CLI shaped like this:
 - `simard review ...`
 - `simard bootstrap ...`
 
-Until `src/main.rs` dispatches that tree directly, the reference and tutorial docs keep both surfaces visible.
+Bare `simard` prints the unified help text instead of attempting a hidden environment-only bootstrap fallback.
+
+## Compatibility binaries
+
+The compatibility binaries remain shipped, but they are no longer the canonical entrypoint:
+
+- `simard_operator_probe` preserves the legacy multi-mode probe commands
+- `simard-gym` preserves the legacy benchmark binary
+
+Use them only when you need compatibility with older scripts or exact legacy output.
 
 ## Running from source
-
-The examples in this docs set use the installed binary names when they refer to current executables:
-
-- `simard`
-- `simard_operator_probe`
-- `simard-gym`
 
 From the repository root, the corresponding Cargo commands are:
 
@@ -91,7 +67,7 @@ Those hooks enforce `cargo fmt --all -- --check`, `cargo clippy --all-targets --
 
 If you are new to Simard, start with the [local session tutorial](./tutorials/run-your-first-local-session.md).
 
-If you need exact current-to-planned command mappings, use the [Simard CLI reference](./reference/simard-cli.md).
+If you need exact commands, use the [Simard CLI reference](./reference/simard-cli.md).
 
 If you need exact field names or lifecycle errors, use the [runtime contracts reference](./reference/runtime-contracts.md).
 

--- a/docs/reference/runtime-contracts.md
+++ b/docs/reference/runtime-contracts.md
@@ -1,6 +1,6 @@
 ---
 title: Runtime contracts reference
-description: Reference for the current Simard executable surfaces, the in-process runtime contract, and the planned unified CLI shape.
+description: Reference for the shipped Simard executable surfaces, compatibility binaries, and the in-process runtime contracts that back them.
 last_updated: 2026-03-30
 review_schedule: as-needed
 owner: simard
@@ -8,36 +8,16 @@ doc_type: reference
 related:
   - ../index.md
   - ./simard-cli.md
-  - ../howto/carry-meeting-decisions-into-engineer-sessions.md
   - ../howto/configure-bootstrap-and-inspect-reflection.md
-  - ../concepts/truthful-runtime-metadata.md
+  - ../tutorials/run-your-first-local-session.md
 ---
 
 # Runtime contracts reference
 
-## Status
+This document covers:
 
-The in-process Rust runtime described here exists today.
-
-The fully unified `simard` CLI described in the product architecture does **not** exist as a complete executable surface yet.
-
-Today:
-
-- `simard` is a bootstrap-from-environment entrypoint
-- `simard_operator_probe` exposes the current operator-mode compatibility commands
-- `simard-gym` exposes the current benchmark CLI
-
-The mode contracts below are still real today because the probe and gym binaries exercise the same runtime code paths that the unified CLI will eventually dispatch.
-
-## Public surfaces
-
-Simard exposes three public surface classes:
-
-- current executables:
-  - `simard`
-  - `simard_operator_probe`
-  - `simard-gym`
-- the planned unified operator CLI rooted at `simard`
+- the canonical `simard` CLI surface
+- the compatibility binaries that still expose a few legacy entrypoints
 - the in-process Rust runtime and bootstrap types in `src/bootstrap.rs`, `src/runtime.rs`, and related modules
 
 Simard does **not** expose:
@@ -46,45 +26,56 @@ Simard does **not** expose:
 - a network service contract
 - a database schema contract
 
-## Current executable mappings
+## Executable surfaces
 
-| Runtime behavior | Current executable surface | Planned unified surface |
+| Runtime behavior | Canonical surface | Compatibility surface |
 | --- | --- | --- |
-| bootstrap-configured local session | `simard` with `SIMARD_*` environment variables | `simard bootstrap run ...` |
-| bounded engineer loop | `simard_operator_probe engineer-loop-run ...` | `simard engineer run ...` |
-| terminal-backed engineer substrate | `simard_operator_probe terminal-run ...` | `simard engineer terminal ...` |
-| meeting mode | `simard_operator_probe meeting-run ...` | `simard meeting run ...` |
-| goal-curation mode | `simard_operator_probe goal-curation-run ...` | `simard goal-curation run ...` |
-| improvement-curation mode | `simard_operator_probe improvement-curation-run ...` | `simard improvement-curation run ...` |
-| review artifact persistence and readback | `simard_operator_probe review-run ...` and `review-read ...` | `simard review ...` |
-| benchmark scenarios and suites | `simard-gym ...` | `simard gym ...` |
+| explicit bootstrap | `simard bootstrap run ...` | `simard_operator_probe bootstrap-run ...` |
+| bounded engineer loop | `simard engineer run ...` | `simard_operator_probe engineer-loop-run ...` |
+| terminal-backed engineer substrate | compatibility only | `simard_operator_probe terminal-run ...` |
+| meeting mode | `simard meeting run ...` | `simard_operator_probe meeting-run ...` |
+| goal-curation mode | `simard goal-curation run ...` | `simard_operator_probe goal-curation-run ...` |
+| improvement-curation mode | `simard improvement-curation run ...` | `simard_operator_probe improvement-curation-run ...` |
+| review artifact persistence and readback | `simard review ...` | `simard_operator_probe review-run ...` and `review-read ...` |
+| benchmark scenarios and suites | `simard gym ...` | `simard-gym ...` |
 
-## [PLANNED] Canonical CLI surface
+## Canonical CLI surface
 
-The canonical operator-facing command tree Simard is being built toward is:
+The shipped operator-facing command tree is:
 
 - `simard engineer run <topology> <workspace-root> <objective> [state-root]`
-- `simard engineer terminal <topology> <structured-objective>`
 - `simard meeting run <base-type> <topology> <structured-objective> [state-root]`
 - `simard goal-curation run <base-type> <topology> <structured-objective> [state-root]`
 - `simard improvement-curation run <base-type> <topology> <structured-objective> [state-root]`
 - `simard gym list`
 - `simard gym run <scenario-id>`
+- `simard gym compare <scenario-id>`
 - `simard gym run-suite <suite-id>`
 - `simard review run <base-type> <topology> <objective> [state-root]`
 - `simard review read <base-type> <topology> [state-root]`
 - `simard bootstrap run <identity> <base-type> <topology> <objective> [state-root]`
 
-Use the [Simard CLI reference](./simard-cli.md) for the exact command tree, examples, and current runnable mappings.
+Bare `simard` prints help for that tree instead of attempting a hidden bootstrap fallback.
+
+## Shared state-root contract
+
+Whenever a command accepts `[state-root]`, Simard validates it before any persistence work tied to durable operator state.
+
+Rejected inputs include:
+
+- any path containing `..`
+- an existing path that is not a directory
+- a symlink root
+
+Safe roots are canonicalized once and then reused throughout the command.
 
 ## Mode contracts
 
 ### Engineer mode
 
-The bounded engineer contract already exists in the runtime today.
+Canonical entrypoint: `simard engineer run <topology> <workspace-root> <objective> [state-root]`
 
-- current operator entrypoint: `simard_operator_probe engineer-loop-run <topology> <workspace-root> <objective> [state-root]`
-- planned unified entrypoint: `simard engineer run <topology> <workspace-root> <objective> [state-root]`
+Compatibility surface: `simard_operator_probe engineer-loop-run <topology> <workspace-root> <objective> [state-root]`
 
 The bounded engineer loop is intentionally narrow:
 
@@ -95,7 +86,7 @@ The bounded engineer loop is intentionally narrow:
 - it persists concise evidence and memory under the selected state root
 - it surfaces active goals and up to the three most recent carried meeting records from the same state root
 
-The current bounded engineer loop supports two honest action shapes:
+The bounded engineer loop supports two honest action shapes:
 
 - a read-only repo-native scan such as `cargo-metadata-scan` or `git-tracked-file-scan`
 - one explicit structured text replacement on a clean repo when the objective includes all of:
@@ -113,402 +104,109 @@ That structured edit path is intentionally narrow:
 
 ### Meeting mode
 
-The meeting-mode contract already exists in the runtime today.
+Canonical entrypoint: `simard meeting run <base-type> <topology> <structured-objective> [state-root]`
 
-- current operator entrypoint: `simard_operator_probe meeting-run <base-type> <topology> <structured-objective> [state-root]`
-- planned unified entrypoint: `simard meeting run <base-type> <topology> <structured-objective> [state-root]`
+Compatibility surface: `simard_operator_probe meeting-run <base-type> <topology> <structured-objective> [state-root]`
 
-Meeting mode uses the facilitator agent program backend `agent-program::meeting-facilitator`.
+Meeting mode persists concise durable planning data without touching repository contents. Structured lines may include:
 
-Its contract is intentionally narrow:
-
-- it persists a concise meeting record under the durable state root when the structured objective contains persistable outputs such as `update:`, `decision:`, `risk:`, `next-step:`, `open-question:`, or structured `goal:` lines
-- later engineer runs against the same state root surface those carried meeting decisions explicitly, separate from the active top-goal list
-- it can also persist structured goal updates into the durable goal register
-- it does not mutate code paths or pretend implementation work happened
+- `agenda: ...`
+- `update: ...`
+- `decision: ...`
+- `risk: ...`
+- `next-step: ...`
+- `open-question: ...`
+- `goal: title | priority=1 | status=active | rationale=...`
 
 ### Goal-curation mode
 
-The goal-curation contract already exists in the runtime today.
+Canonical entrypoint: `simard goal-curation run <base-type> <topology> <structured-objective> [state-root]`
 
-- current operator entrypoint: `simard_operator_probe goal-curation-run <base-type> <topology> <structured-objective> [state-root]`
-- planned unified entrypoint: `simard goal-curation run <base-type> <topology> <structured-objective> [state-root]`
+Compatibility surface: `simard_operator_probe goal-curation-run <base-type> <topology> <structured-objective> [state-root]`
 
-The goal-curation path is intentionally narrow:
-
-- it uses the dedicated `simard-goal-curator` identity and the `agent-program::goal-curator` backend
-- it persists durable goal records under the selected state root
-- reflection and later operator runs expose the active top 5 goals directly
-- it does not claim implementation work or remote orchestration
+Goal-curation mode maintains durable backlog records and the active top five goals.
 
 ### Improvement-curation mode
 
-The improvement-curation contract already exists in the runtime today.
+Canonical entrypoint: `simard improvement-curation run <base-type> <topology> <structured-objective> [state-root]`
 
-- current operator entrypoint: `simard_operator_probe improvement-curation-run <base-type> <topology> <structured-objective> [state-root]`
-- planned unified entrypoint: `simard improvement-curation run <base-type> <topology> <structured-objective> [state-root]`
+Compatibility surface: `simard_operator_probe improvement-curation-run <base-type> <topology> <structured-objective> [state-root]`
 
-The improvement-curation path is intentionally narrow:
-
-- it uses the dedicated `simard-improvement-curator` identity and the `agent-program::improvement-curator` backend
-- it reads the latest persisted review artifact from the selected durable state root and turns explicit operator approvals into durable active or proposed priorities
-- it preserves deferred proposals as durable decision memory rather than silently discarding them
-- reflection and later operator runs expose both active and proposed improvement priorities directly
-- it does not mutate code or silently promote unreviewed changes
+Improvement-curation mode promotes approved review proposals into durable priorities.
 
 ### Review mode
 
-The review contract already exists in the runtime today.
+Canonical entrypoints:
 
-- current operator entrypoint: `simard_operator_probe review-run <base-type> <topology> <objective> [state-root]` and `simard_operator_probe review-read <base-type> <topology> [state-root]`
-- planned unified entrypoint: `simard review run ...` and `simard review read ...`
+- `simard review run <base-type> <topology> <objective> [state-root]`
+- `simard review read <base-type> <topology> [state-root]`
 
-The review path is intentionally narrow:
+Compatibility surface: `simard_operator_probe review-run ...` and `simard_operator_probe review-read ...`
 
-- it runs an ordinary bounded session first, then inspects the exported handoff offline
-- it persists a concise JSON review artifact under `SIMARD_STATE_ROOT/review-artifacts/`
-- it persists a concise decision-scoped review record so later sessions can reuse approved findings
-- it emits concrete proposals tied to persisted evidence instead of silently changing prompts or policies
-- it can read the latest persisted review artifact back in a later operator process through the current `review-read` entrypoint and the planned `simard review read` entrypoint
+Review mode persists a structured review artifact and makes the latest artifact readable from the same durable state root.
 
-### Gym mode
+### Benchmark gym
 
-The gym contract already exists in the runtime today.
+Canonical entrypoints:
 
-- current operator entrypoint: `simard-gym list`, `simard-gym run <scenario-id>`, and `simard-gym run-suite <suite-id>`
-- planned unified entrypoint: `simard gym list`, `simard gym run <scenario-id>`, and `simard gym run-suite <suite-id>`
+- `simard gym list`
+- `simard gym run <scenario-id>`
+- `simard gym run-suite <suite-id>`
 
-The shipped benchmark surface supports:
+Compatibility surface: `simard-gym ...`
 
-- listing the shipped scenarios
-- running one benchmark scenario
-- running the `starter` suite
+The gym currently benchmarks scenarios built around:
 
-The starter suite is intentionally small and exercises:
-
-- `local-harness`
-- `terminal-shell`
-- `copilot-sdk`
-- `rusty-clawd`
-- the dedicated `simard-gym` identity
-- the composite `simard-composite-engineer` identity
+- repo exploration and truthful local inspection
+- docs refresh flow
+- safe code change flow through the `rusty-clawd` identity
+- composite session review
 
 Artifacts are written under `target/simard-gym/` as JSON and text reports plus a `review.json` artifact for each scenario run.
 
-### Bootstrap mode
+The gym also supports persisted run-to-run comparison for a single scenario:
 
-The bootstrap contract already exists in the runtime today, but its current entrypoint differs from the planned CLI shape.
+- `simard gym compare <scenario-id>` compares the latest two completed runs
+- comparison results are classified as `improved`, `unchanged`, or `regressed`
+- comparison artifacts are written under `target/simard-gym/comparisons/<scenario-id>/`
 
-- current operator entrypoint: `simard` with `SIMARD_*` environment variables
-- current compatibility helper: `simard_operator_probe bootstrap-run <identity> <base-type> <topology> <objective> [state-root]`
-- planned unified entrypoint: `simard bootstrap run <identity> <base-type> <topology> <objective> [state-root]`
+### Bootstrap contract
 
-The bootstrap utility exposes explicit runtime assembly rather than hidden defaults:
+Canonical entrypoint: `simard bootstrap run <identity> <base-type> <topology> <objective> [state-root]`
 
-- unsupported or unregistered base types fail explicitly
-- unsupported topology and base-type pairs fail explicitly
-- builtin defaults are only used through explicit opt-in startup mode
+Compatibility surface: `simard_operator_probe bootstrap-run <identity> <base-type> <topology> <objective> [state-root]`
 
-## Configuration
+The operator-facing bootstrap contract is now explicit:
 
-### Environment variables
+- required values are passed positionally
+- identity, base type, and topology mismatches fail explicitly
+- there is no public zero-argument fallback path
+- state-root validation runs before durable artifacts are read or written
 
-| Variable | Required for current `simard` entrypoint | Default | Description |
-| --- | --- | --- | --- |
-| `SIMARD_PROMPT_ROOT` | Yes in `explicit-config` bootstrap flows | none | Root directory for prompt assets. |
-| `SIMARD_OBJECTIVE` | No when `SIMARD_BOOTSTRAP_MODE=builtin-defaults`; otherwise yes | none in `explicit-config`; `bootstrap the Simard engineer loop` in `builtin-defaults` | Objective passed to bootstrapped runs. Live execution keeps the real objective in memory while persisted scratch, summary, reflection, and exported handoff session text store objective metadata instead of the raw objective text. |
-| `SIMARD_STATE_ROOT` | No when `SIMARD_BOOTSTRAP_MODE=builtin-defaults` | none in `explicit-config`; `target/simard-state` in `builtin-defaults` | Root directory for the durable local memory, goals, evidence, and latest handoff snapshot files written by the bootstrap path. |
-| `SIMARD_BOOTSTRAP_MODE` | No | `explicit-config` | Startup mode. Accepted values: `explicit-config`, `builtin-defaults`. |
-| `SIMARD_IDENTITY` | No when `SIMARD_BOOTSTRAP_MODE=builtin-defaults`; otherwise yes | none in `explicit-config`; `simard-engineer` in `builtin-defaults` | Identity to load before runtime composition. |
-| `SIMARD_BASE_TYPE` | No when `SIMARD_BOOTSTRAP_MODE=builtin-defaults`; otherwise yes | none in `explicit-config`; `local-harness` in `builtin-defaults` | Base type selected for the runtime request. Unsupported or unregistered choices fail explicitly. |
-| `SIMARD_RUNTIME_TOPOLOGY` | No when `SIMARD_BOOTSTRAP_MODE=builtin-defaults`; otherwise yes | none in `explicit-config`; `single-process` in `builtin-defaults` | Runtime topology selected for the runtime request. Accepted values: `single-process`, `multi-process`, `distributed`. |
+## Durable carryover contract
 
-### Operator carryover configuration
+Meeting, engineer, goal-curation, review, and improvement-curation commands can all share one explicit state root.
 
-Meeting-to-engineer handoff currently uses the explicit trailing `state-root` argument on the probe commands:
+That shared state root is what allows:
 
-- `simard_operator_probe meeting-run ... [state-root]`
-- `simard_operator_probe engineer-loop-run ... [state-root]`
+- carried meeting decisions to appear in later engineer runs
+- durable goals to stay visible across operator modes
+- review artifacts to feed improvement-curation
 
-The planned unified CLI preserves the same carryover contract:
+The contract depends on passing the same validated state root across commands, not on hidden global state.
 
-- `simard meeting run ... [state-root]`
-- `simard engineer run ... [state-root]`
+## Identity and backend contract
 
-Passing the same explicit directory to both commands is the supported way to make meeting decisions visible in later engineer runs.
+The builtin identities currently advertised by the loader are `simard-engineer`, `simard-meeting`, `simard-goal-curator`, `simard-improvement-curator`, `simard-gym`, and the composite `simard-composite-engineer`. All of them accept `local-harness`, `rusty-clawd`, and `copilot-sdk`; `simard-engineer` additionally accepts `terminal-shell` for the local terminal-backed path.
 
-The carryover surface is intentionally bounded:
+Reflection reports both the selected base type and the honest backend identity. For example:
 
-- engineer mode reports at most the three most recent persisted meeting records from that shared state root
-- if you omit the shared state root, the commands still run, but there is no guaranteed cross-session carryover contract
-
-### Current builtin base-type registrations
-
-The builtin identities currently advertised by the loader are `simard-engineer`, `simard-meeting`, `simard-goal-curator`, `simard-improvement-curator`, `simard-gym`, and the composite `simard-composite-engineer`. All of them accept `local-harness`, `rusty-clawd`, and `copilot-sdk`; `simard-engineer` additionally accepts `terminal-shell` for the local terminal-backed path:
-
-| Base type selection | Current session backend implementation | Supported topologies in this scaffold |
-| --- | --- | --- |
-| `local-harness` | `local-harness` single-process local process harness session backend | `single-process` |
-| `terminal-shell` | `terminal-shell::local-pty` real local PTY-backed shell session backend (`simard-engineer` only) | `single-process` |
-| `rusty-clawd` | `rusty-clawd::session-backend` real session backend | `single-process`, `multi-process` |
-| `copilot-sdk` | `local-harness` single-process local process harness session backend (alias) | `single-process` |
-
-Notes:
-
-- bootstrap registers base-type factories from the manifest-advertised base-type list instead of assuming a single hardcoded local backend
-- unsupported topology and base-type pairs still fail explicitly; for example, `local-harness + multi-process` returns `UnsupportedTopology`
-- descriptors remain truthful: `selected_base_type` preserves the explicit choice, while `adapter_backend.identity` exposes the actual backend
-- `MemoryPolicy.allow_project_writes=true` is rejected explicitly in v1 rather than being ignored
-
-## Persisted session text
-
-Simard keeps the live objective available while the run is executing, but persisted session text is redacted down to objective metadata.
-
-- session scratch records store `objective-metadata(chars=..., words=..., lines=...)`
-- reflection summaries describe completion with objective metadata instead of raw objective text
-- persisted session summaries reuse sanitized plan and execution strings rather than copying the raw objective back out
-- exported handoff snapshots preserve the session boundary while replacing `RuntimeHandoffSnapshot.session.objective` with the same objective metadata string
-- bootstrap persists the latest exported handoff snapshot under `SIMARD_STATE_ROOT/latest_handoff.json`
-- bootstrap persists durable goal state under `SIMARD_STATE_ROOT/goal_records.json`
-- runtime reflection reports both `active_goal_count` / `active_goals` and `proposed_goal_count` / `proposed_goals`
-
-## Identity metadata
-
-### `ManifestContract`
-
-```rust
-pub struct ManifestContract {
-    pub entrypoint: String,
-    pub composition: String,
-    pub precedence: Vec<String>,
-    pub provenance: Provenance,
-    pub freshness: Freshness,
-}
-```
-
-Notes:
-
-- the current CLI bootstrap path uses `simard::bootstrap::assemble_local_runtime` as the entrypoint
-- provenance and freshness stay inside the contract so reflection carries a single source of truth
-- invalid empty fields fail with `SimardError::InvalidManifestContract`
-
-### `Provenance`
-
-```rust
-pub struct Provenance {
-    pub source: String,
-    pub locator: String,
-}
-```
-
-Helpers currently provided:
-
-| Helper | Meaning |
-| --- | --- |
-| `Provenance::new(source, locator)` | Build an explicit provenance value. |
-| `Provenance::builtin(locator)` | Mark a builtin metadata source. |
-| `Provenance::injected(locator)` | Mark an injected metadata source. |
-| `Provenance::runtime(locator)` | Mark runtime-derived metadata. |
-
-### `Freshness`
-
-```rust
-pub enum FreshnessState {
-    Current,
-    Stale,
-}
-
-pub struct Freshness {
-    pub state: FreshnessState,
-    pub observed_at_unix_ms: u64,
-}
-```
-
-Notes:
-
-- `Freshness::now()` returns `SimardResult<Freshness>` and fails explicitly if the system clock is before the Unix epoch
-- freshness can explicitly represent stale metadata when a caller needs to surface it
-
-## Session identity
-
-### `SessionId`
-
-```rust
-pub struct SessionId(String);
-```
-
-Rules:
-
-- `UuidSessionIdGenerator` emits `session-<uuid-v7>`
-- `SessionId::parse(...)` accepts a bare UUID or a `session-<uuid>` value and canonicalizes to `session-<uuid>`
-- invalid values fail with `SimardError::InvalidSessionId`
-- custom `SessionIdGenerator` implementations must return valid `SessionId` values
-- the session ID strategy is injected through `RuntimePorts`; the local bootstrap path opts into `UuidSessionIdGenerator` explicitly
-
-## Runtime lifecycle
-
-### `RuntimeState`
-
-| State | Meaning |
-| --- | --- |
-| `Initializing` | Runtime has been composed but not started. |
-| `Ready` | Prompt assets are loaded and the runtime can execute. |
-| `Active` | Base-type session work is in progress. |
-| `Reflecting` | Reflection metadata is being assembled. |
-| `Persisting` | Memory and evidence summaries are being persisted. |
-| `Failed` | Execution failed before completion. |
-| `Stopping` | Shutdown is in progress. |
-| `Stopped` | Runtime has been shut down and cannot accept more work. |
-
-### Stopped-state behavior
-
-After `stop()` succeeds:
-
-- `snapshot()` remains valid
-- `run()` fails with `RuntimeStopped { action: "run" }`
-- `start()` fails with `RuntimeStopped { action: "start" }`
-- a repeated `stop()` fails with `RuntimeStopped { action: "stop" }`
-- callers must compose a new runtime instead of reusing the stopped one
-
-### Failed-state behavior
-
-After `run()` fails:
-
-- `snapshot()` remains valid
-- the last session remains visible with `session_phase == Some(Failed)`
-- manifest freshness is reported as `Stale`
-- `start()` fails with `RuntimeFailed`
-- `run()` fails with `RuntimeFailed`
-- `stop()` is still the explicit way to close the lifecycle boundary
-
-## Reflection snapshot
-
-### `ReflectionSnapshot`
-
-```rust
-pub struct ReflectionSnapshot {
-    pub identity_name: String,
-    pub identity_components: Vec<String>,
-    pub selected_base_type: BaseTypeId,
-    pub topology: RuntimeTopology,
-    pub runtime_state: RuntimeState,
-    pub runtime_node: RuntimeNodeId,
-    pub mailbox_address: RuntimeAddress,
-    pub session_phase: Option<SessionPhase>,
-    pub prompt_assets: Vec<PromptAssetId>,
-    pub manifest_contract: ManifestContract,
-    pub evidence_records: usize,
-    pub memory_records: usize,
-    pub active_goal_count: usize,
-    pub active_goals: Vec<String>,
-    pub proposed_goal_count: usize,
-    pub proposed_goals: Vec<String>,
-    pub agent_program_backend: BackendDescriptor,
-    pub handoff_backend: BackendDescriptor,
-    pub adapter_backend: BackendDescriptor,
-    pub adapter_capabilities: Vec<String>,
-    pub adapter_supported_topologies: Vec<String>,
-    pub topology_backend: BackendDescriptor,
-    pub transport_backend: BackendDescriptor,
-    pub supervisor_backend: BackendDescriptor,
-    pub memory_backend: BackendDescriptor,
-    pub evidence_backend: BackendDescriptor,
-    pub goal_backend: BackendDescriptor,
-}
-```
-
-For `simard-meeting`, reflection reports `agent_program_backend.identity == "agent-program::meeting-facilitator"`. For `simard-goal-curator`, it reports `agent_program_backend.identity == "agent-program::goal-curator"`. For `simard-improvement-curator`, it reports `agent_program_backend.identity == "agent-program::improvement-curator"`.
-
-### `BackendDescriptor`
-
-```rust
-pub struct BackendDescriptor {
-    pub identity: String,
-    pub provenance: Provenance,
-    pub freshness: Freshness,
-}
-```
-
-Reflection rules:
-
-- `manifest_contract` carries entrypoint, provenance, and freshness together
-- `agent_program_backend` comes from the injected agent-program contract, not from hardcoded runtime logic
-- `handoff_backend` comes from the injected handoff store used for export/import
-- `adapter_backend` comes from the selected base-type factory or session descriptor, not from a bootstrap shortcut
-- `runtime_node` and `mailbox_address` come from the injected topology and transport services
-- `topology_backend`, `transport_backend`, and `supervisor_backend` come from the live runtime services
-- `memory_backend` comes from the live memory store descriptor
-- `evidence_backend` comes from the live evidence store descriptor
-- `goal_backend` comes from the live goal store descriptor
-- `active_goal_count` and `active_goals` expose the active top-goal state derived from the durable goal store
-- `proposed_goal_count` and `proposed_goals` expose durable proposed priorities, including approved improvement proposals that have not been activated yet
-- reflection reports live wiring, not placeholder labels
-- stopped or failed snapshots mark manifest freshness as `Stale`
-
-## Errors
-
-### Configuration and identity errors
-
-| Error | Meaning |
-| --- | --- |
-| `MissingRequiredConfig` | Required startup configuration is absent. |
-| `NonUnicodeConfigValue` | A configuration value exists but cannot be decoded as UTF-8. |
-| `InvalidConfigValue` | A configuration value is present but invalid. |
-| `UnknownIdentity` | Requested identity is not registered. |
-| `InvalidIdentityComposition` | A composite identity definition is internally inconsistent. |
-| `InvalidManifestContract` | Manifest contract metadata is incomplete or untruthful. |
-| `InvalidGoalRecord` | A structured goal update is malformed or incomplete. |
-| `ClockBeforeUnixEpoch` | Runtime metadata could not record a truthful observation time. |
-| `InvalidSessionId` | A supplied session ID is not a valid distributed-safe identifier. |
-| `UnsupportedBaseType` | The chosen identity does not allow the requested base type. |
-| `AdapterNotRegistered` | No base-type factory has been registered for the requested base type. |
-| `MissingCapability` | The selected base-type backend exists but does not satisfy the manifest's required capabilities. |
-| `UnsupportedRuntimeTopology` | The injected topology driver does not support the requested topology. |
-| `UnsupportedTopology` | The selected base-type backend does not support the requested topology. |
-
-### Lifecycle and session errors
-
-| Error | Meaning |
-| --- | --- |
-| `InvalidRuntimeTransition` | A runtime lifecycle transition is invalid. |
-| `InvalidBaseTypeSessionState` | A base-type session was opened, used, or closed out of order. |
-| `AdapterInvocationFailed` | The selected base-type backend failed while executing a turn. |
-| `BaseTypeSessionCleanupFailed` | A base-type session failed during execution and then also failed to close cleanly. |
-| `InvalidHandoffSnapshot` | A handoff snapshot could not be restored into the requested runtime. |
-| `RuntimeStopped` | Caller attempted `start`, `run`, or `stop` after shutdown was already in effect. |
-| `RuntimeFailed` | Caller attempted `start` or `run` after a failed execution but before shutdown. |
-| `InvalidSessionTransition` | A session phase transition is invalid. |
-
-### Prompt and storage errors
-
-| Error | Meaning |
-| --- | --- |
-| `PromptAssetMissing` | A referenced prompt asset was not found. |
-| `PromptAssetRead` | A prompt asset could not be read. |
-| `StoragePoisoned` | A durable store lock was poisoned before Simard could read or persist state. |
-
-## Example: truthful fields
-
-```rust
-use simard::{FreshnessState, ReflectiveRuntime};
-
-let snapshot = runtime.snapshot()?;
-
-assert_eq!(snapshot.runtime_state.to_string(), "ready");
-assert_eq!(
-    snapshot.manifest_contract.entrypoint,
-    "simard::bootstrap::assemble_local_runtime"
-);
-assert_eq!(snapshot.manifest_contract.provenance.source, "bootstrap");
-assert_eq!(snapshot.manifest_contract.freshness.state, FreshnessState::Current);
-assert_eq!(snapshot.runtime_node.to_string(), "node-local");
-assert_eq!(snapshot.mailbox_address.to_string(), "inmemory://node-local");
-assert_eq!(snapshot.adapter_backend.identity, "local-harness");
-```
+- `copilot-sdk` currently resolves to the `local-harness` adapter implementation
+- `terminal-shell` reports `terminal-shell::local-pty`
+- `rusty-clawd` reports `rusty-clawd::session-backend`
 
 ## See also
 
 - [Simard CLI reference](./simard-cli.md)
 - [How to configure bootstrap and inspect reflection](../howto/configure-bootstrap-and-inspect-reflection.md)
-- [How to carry meeting decisions into engineer sessions](../howto/carry-meeting-decisions-into-engineer-sessions.md)
-- [Concept: truthful runtime metadata](../concepts/truthful-runtime-metadata.md)
+- [Tutorial: Run your first local session](../tutorials/run-your-first-local-session.md)

--- a/docs/reference/simard-cli.md
+++ b/docs/reference/simard-cli.md
@@ -1,6 +1,6 @@
 ---
 title: Simard CLI reference
-description: Reference for the planned unified `simard` command tree and the current runnable command mappings that expose the same runtime behaviors today.
+description: Reference for the shipped `simard` command tree and the legacy compatibility binaries that still expose the same runtime behaviors.
 last_updated: 2026-03-30
 review_schedule: as-needed
 owner: simard
@@ -13,45 +13,18 @@ related:
   - ../tutorials/run-your-first-local-session.md
 ---
 
-# [PLANNED - Implementation Pending] Simard CLI reference
+# Simard CLI reference
 
-## Status
+`simard` is the canonical operator-facing CLI.
 
-This document describes the unified operator-facing CLI Simard is intended to ship.
+The legacy `simard_operator_probe` and `simard-gym` binaries still ship for compatibility, but new operator workflows should use `simard ...`.
 
-That full command tree is **not** implemented in `src/main.rs` yet.
-
-Today:
-
-- `simard` is a thin bootstrap entrypoint that reads configuration from environment variables
-- `simard_operator_probe` is the current multi-mode compatibility binary
-- `simard-gym` is the current benchmark binary
-
-Use the current command mappings in this document when you need runnable commands today. Remove the planned markers once `src/main.rs` dispatches the full tree and dedicated CLI tests cover it.
-
-## Current executables
-
-| Executable | Status today | Purpose |
-| --- | --- | --- |
-| `simard` | shipped | Bootstrap-configured local session entrypoint |
-| `simard_operator_probe` | shipped | Current engineer, meeting, goal-curation, improvement-curation, review, and compatibility bootstrap commands |
-| `simard-gym` | shipped | Current benchmark CLI |
-
-## Running from source
-
-From the repository root, use these Cargo forms:
-
-- `cargo run --quiet -- ...` for `simard`
-- `cargo run --quiet --bin simard_operator_probe -- ...` for `simard_operator_probe`
-- `cargo run --quiet --bin simard-gym -- ...` for `simard-gym`
-
-## [PLANNED] Command tree
+## Command tree
 
 ```text
 simard
 |- engineer
-|  |- run <topology> <workspace-root> <objective> [state-root]
-|  `- terminal <topology> <structured-objective>
+|  `- run <topology> <workspace-root> <objective> [state-root]
 |- meeting
 |  `- run <base-type> <topology> <structured-objective> [state-root]
 |- goal-curation
@@ -61,6 +34,7 @@ simard
 |- gym
 |  |- list
 |  |- run <scenario-id>
+|  |- compare <scenario-id>
 |  `- run-suite <suite-id>
 |- review
 |  |- run <base-type> <topology> <objective> [state-root]
@@ -69,99 +43,61 @@ simard
    `- run <identity> <base-type> <topology> <objective> [state-root]
 ```
 
-## Mode summary
+Bare `simard` prints this unified help surface.
 
-| Planned namespace | Current runnable surface | Purpose |
-| --- | --- | --- |
-| `engineer run` | `simard_operator_probe engineer-loop-run ...` | Inspect, plan, act, and verify on a local repo through a bounded engineering loop |
-| `engineer terminal` | `simard_operator_probe terminal-run ...` | Drive the terminal-backed engineer substrate directly |
-| `meeting run` | `simard_operator_probe meeting-run ...` | Capture decisions, risks, next steps, and optional goal updates without editing code |
-| `goal-curation run` | `simard_operator_probe goal-curation-run ...` | Maintain durable backlog records and the active top 5 goals |
-| `improvement-curation run` | `simard_operator_probe improvement-curation-run ...` | Promote approved review proposals into durable priorities |
-| `gym ...` | `simard-gym ...` | Run benchmark scenarios and suites |
-| `review ...` | `simard_operator_probe review-run ...` and `review-read ...` | Persist or read the latest review artifact tied to durable state |
-| `bootstrap run` | `simard` with `SIMARD_*` env vars, or `simard_operator_probe bootstrap-run ...` | Assemble an explicit runtime selection and print the reflected startup summary |
+## Compatibility mapping
 
-## `engineer`
+| Canonical command | Compatibility surface |
+| --- | --- |
+| `simard engineer run ...` | `simard_operator_probe engineer-loop-run ...` |
+| `simard meeting run ...` | `simard_operator_probe meeting-run ...` |
+| `simard goal-curation run ...` | `simard_operator_probe goal-curation-run ...` |
+| `simard improvement-curation run ...` | `simard_operator_probe improvement-curation-run ...` |
+| `simard review run ...` | `simard_operator_probe review-run ...` |
+| `simard review read ...` | `simard_operator_probe review-read ...` |
+| `simard bootstrap run ...` | `simard_operator_probe bootstrap-run ...` |
+| `simard gym ...` | `simard-gym ...` |
 
-### [PLANNED] `simard engineer run <topology> <workspace-root> <objective> [state-root]`
+## Shared state-root contract
 
-Planned unified entrypoint. Today, use `simard_operator_probe engineer-loop-run <topology> <workspace-root> <objective> [state-root]`.
+When a command accepts `[state-root]`, Simard validates it before any persistence write or read that depends on durable operator state.
 
-**Parameters**:
+Rejected inputs include:
 
-| Parameter | Required | Description |
-| --- | --- | --- |
-| `topology` | Yes | Runtime topology for this engineer run. The bounded local-first path is expected to use an honestly supported topology such as `single-process`. |
-| `workspace-root` | Yes | Path to the repository or workspace Simard should inspect. The path must exist and remain inside the selected workspace boundary. |
-| `objective` | Yes | Human task text for the bounded run. |
-| `state-root` | No | Durable state directory for goals, evidence, review artifacts, and carried meeting records. |
+- any path containing `..`
+- an existing path that is not a directory
+- a symlink root
 
-**Behavior**:
+Safe state roots are canonicalized once and then reused for the rest of the command.
+
+## Mode reference
+
+### `simard engineer run <topology> <workspace-root> <objective> [state-root]`
+
+Runs the bounded local engineer loop against the selected repository.
+
+Key behavior:
 
 - inspects the selected repo before acting
-- prints a short action plan and explicit verification steps
-- chooses one bounded local action
-- verifies the result explicitly
-- persists durable evidence and memory under `state-root` when provided
-- surfaces active goals and up to the three most recent carried meeting records from the same state root
+- prints the chosen bounded action and explicit verification steps
+- persists memory, evidence, and latest handoff under `state-root`
+- surfaces active goals and carried meeting decisions from the same durable state
 
-**Structured edit contract**:
-
-The default engineer path is a read-only local scan. To request the narrow structured edit path, the objective must contain all of these lines:
-
-- `edit-file: <repo-relative path>`
-- `replace: <existing text>`
-- `with: <replacement text>`
-- `verify-contains: <required post-edit text>`
-
-That edit path is intentionally narrow:
-
-- the repo must start clean
-- the target path must stay inside the selected repo
-- only one expected changed file is allowed
-- verification must prove both file content and git-visible change state
-
-**Current runnable example**:
+Example:
 
 ```bash
 STATE_ROOT="$(mktemp -d /tmp/simard-engineer.XXXXXX)"
-ENGINEER_OBJECTIVE=$'inspect the repository state\nrun one safe local engineering action\nverify the outcome explicitly\npersist truthful local evidence and memory'
+ENGINEER_OBJECTIVE=$'inspect the repository state
+run one safe local engineering action
+verify the outcome explicitly
+persist truthful local evidence and memory'
 
-cargo run --quiet --bin simard_operator_probe -- \
-  engineer-loop-run single-process "$PWD" "$ENGINEER_OBJECTIVE" "$STATE_ROOT"
-```
-
-**Planned unified equivalent**:
-
-```bash
 simard engineer run single-process "$PWD" "$ENGINEER_OBJECTIVE" "$STATE_ROOT"
 ```
 
-### [PLANNED] `simard engineer terminal <topology> <structured-objective>`
+### `simard meeting run <base-type> <topology> <structured-objective> [state-root]`
 
-Planned unified entrypoint. Today, use `simard_operator_probe terminal-run <topology> <structured-objective>`.
-
-**Current runnable example**:
-
-```bash
-cargo run --quiet --bin simard_operator_probe -- \
-  terminal-run single-process \
-  $'working-directory: .\ncommand: pwd\ncommand: printf "terminal-foundation-ok\\n"'
-```
-
-**Planned unified equivalent**:
-
-```bash
-simard engineer terminal single-process \
-  $'working-directory: .\ncommand: pwd\ncommand: printf "terminal-foundation-ok\\n"'
-```
-
-## `meeting`
-
-### [PLANNED] `simard meeting run <base-type> <topology> <structured-objective> [state-root]`
-
-Planned unified entrypoint. Today, use `simard_operator_probe meeting-run <base-type> <topology> <structured-objective> [state-root]`.
+Captures decisions, risks, next steps, open questions, and optional goal updates without editing code.
 
 Supported structured lines include:
 
@@ -173,210 +109,111 @@ Supported structured lines include:
 - `open-question: ...`
 - `goal: title | priority=1 | status=active | rationale=...`
 
-A concise meeting record is persisted when the structured objective contains persistable outputs such as updates, decisions, risks, next steps, open questions, or structured goals.
-
-**Current runnable example**:
+Example:
 
 ```bash
 STATE_ROOT="$(mktemp -d /tmp/simard-meeting.XXXXXX)"
-MEETING_OBJECTIVE="$(cat <<'EOF'
+MEETING_OBJECTIVE="$(cat <<'EOF2'
 agenda: align the next Simard workstream
 decision: preserve meeting-to-engineer continuity
 risk: workflow routing is still unreliable
 next-step: keep durable priorities visible
 open-question: how aggressively should Simard reprioritize?
 goal: Preserve meeting handoff | priority=1 | status=active | rationale=meeting decisions must shape later work
-EOF
+EOF2
 )"
 
-cargo run --quiet --bin simard_operator_probe -- \
-  meeting-run local-harness single-process "$MEETING_OBJECTIVE" "$STATE_ROOT"
-```
-
-**Planned unified equivalent**:
-
-```bash
 simard meeting run local-harness single-process "$MEETING_OBJECTIVE" "$STATE_ROOT"
 ```
 
-## `goal-curation`
+### `simard goal-curation run <base-type> <topology> <structured-objective> [state-root]`
 
-### [PLANNED] `simard goal-curation run <base-type> <topology> <structured-objective> [state-root]`
-
-Planned unified entrypoint. Today, use `simard_operator_probe goal-curation-run <base-type> <topology> <structured-objective> [state-root]`.
+Maintains durable backlog records and the active top five goals.
 
 Supported structured lines include:
 
 - `goal: title | priority=1 | status=active|proposed|paused|completed | rationale=...`
 
-**Current runnable example**:
+Example:
 
 ```bash
-cargo run --quiet --bin simard_operator_probe -- \
-  goal-curation-run local-harness single-process \
-  "$(cat <<'EOF'
-goal: Keep Simard's top 5 goals current | priority=1 | status=active | rationale=long-horizon stewardship is a shipped product responsibility
-goal: Preserve meeting-to-engineer continuity | priority=2 | status=active | rationale=meeting outputs should shape later engineer sessions
-EOF
-)" \
-  "$STATE_ROOT"
+simard goal-curation run local-harness single-process   "goal: Keep Simard's top 5 goals current | priority=1 | status=active | rationale=long-horizon stewardship is a shipped product responsibility"   "$STATE_ROOT"
 ```
 
-**Planned unified equivalent**:
+### `simard improvement-curation run <base-type> <topology> <structured-objective> [state-root]`
 
-```bash
-simard goal-curation run local-harness single-process "...structured objective..." "$STATE_ROOT"
-```
-
-## `improvement-curation`
-
-### [PLANNED] `simard improvement-curation run <base-type> <topology> <structured-objective> [state-root]`
-
-Planned unified entrypoint. Today, use `simard_operator_probe improvement-curation-run <base-type> <topology> <structured-objective> [state-root]`.
+Promotes approved review proposals into durable priorities.
 
 Supported structured lines include:
 
 - `approve: proposal title | priority=1 | status=active|proposed | rationale=...`
 - `defer: proposal title | rationale=...`
 
-**Current runnable example**:
+Example:
 
 ```bash
-cargo run --quiet --bin simard_operator_probe -- \
-  improvement-curation-run local-harness single-process \
-  "$(cat <<'EOF'
-approve: Capture denser execution evidence | priority=1 | status=active | rationale=operators need denser execution evidence now
-defer: Add autonomous cross-repo execution | rationale=that would overrun the current bounded product contract
-EOF
-)" \
-  "$STATE_ROOT"
+simard improvement-curation run local-harness single-process   "approve: Capture denser execution evidence | priority=1 | status=active | rationale=operators need denser execution evidence now"   "$STATE_ROOT"
 ```
 
-**Planned unified equivalent**:
+### `simard gym list`
 
-```bash
-simard improvement-curation run local-harness single-process "...structured objective..." "$STATE_ROOT"
-```
+Lists the shipped benchmark scenarios.
 
-## `gym`
+### `simard gym run <scenario-id>`
 
-### [PLANNED] `simard gym list`
+Runs one benchmark scenario and prints the generated artifact paths.
 
-Planned unified entrypoint. Today, use `simard-gym list`.
+### `simard gym compare <scenario-id>`
 
-### [PLANNED] `simard gym run <scenario-id>`
+Compares the latest two completed runs for the selected scenario and prints both source report paths plus a persisted comparison artifact.
 
-Planned unified entrypoint. Today, use `simard-gym run <scenario-id>`.
+The comparison contract is intentionally explicit:
 
-### [PLANNED] `simard gym run-suite <suite-id>`
+- it fails visibly if fewer than two completed runs exist for the scenario
+- it classifies the latest run as `improved`, `unchanged`, or `regressed`
+- it writes JSON and text comparison artifacts under `target/simard-gym/comparisons/<scenario-id>/`
 
-Planned unified entrypoint. Today, use `simard-gym run-suite <suite-id>`.
+### `simard gym run-suite <suite-id>`
 
-**Current runnable example**:
-
-```bash
-cargo run --quiet --bin simard-gym -- run-suite starter
-```
-
-**Planned unified equivalent**:
-
-```bash
-simard gym run-suite starter
-```
+Runs a benchmark suite.
 
 Artifacts are written under `target/simard-gym/`.
 
-## `review`
+### `simard review run <base-type> <topology> <objective> [state-root]`
 
-### [PLANNED] `simard review run <base-type> <topology> <objective> [state-root]`
+Builds and persists the latest review artifact tied to the selected durable state.
 
-Planned unified entrypoint. Today, use `simard_operator_probe review-run <base-type> <topology> <objective> [state-root]`.
+### `simard review read <base-type> <topology> [state-root]`
 
-### [PLANNED] `simard review read <base-type> <topology> [state-root]`
+Reads back the latest persisted review artifact from the selected durable state.
 
-Planned unified entrypoint. Today, use `simard_operator_probe review-read <base-type> <topology> [state-root]`.
-
-**Current runnable example**:
+Example:
 
 ```bash
-cargo run --quiet --bin simard_operator_probe -- \
-  review-run local-harness single-process \
-  "inspect the current Simard review surface and preserve concrete proposals" \
-  "$STATE_ROOT"
-
-cargo run --quiet --bin simard_operator_probe -- \
-  review-read local-harness single-process "$STATE_ROOT"
-```
-
-**Planned unified equivalent**:
-
-```bash
-simard review run local-harness single-process \
-  "inspect the current Simard review surface and preserve concrete proposals" \
-  "$STATE_ROOT"
+simard review run local-harness single-process   "inspect the current Simard review surface and preserve concrete proposals"   "$STATE_ROOT"
 
 simard review read local-harness single-process "$STATE_ROOT"
 ```
 
-## `bootstrap`
+### `simard bootstrap run <identity> <base-type> <topology> <objective> [state-root]`
 
-### [PLANNED] `simard bootstrap run <identity> <base-type> <topology> <objective> [state-root]`
+Bootstraps an explicit runtime selection from positional CLI arguments. This is the only supported bootstrap entrypoint on the canonical CLI surface; the old zero-argument environment-only fallback is gone.
 
-Planned unified entrypoint. Today, the real `simard` binary bootstraps directly from `SIMARD_*` environment variables. `simard_operator_probe bootstrap-run ...` exists as a compatibility helper when you want future-style positional arguments.
-
-**Parameters**:
-
-| Parameter | Required | Description |
-| --- | --- | --- |
-| `identity` | Yes | Identity to load, such as `simard-engineer`, `simard-meeting`, `simard-goal-curator`, `simard-improvement-curator`, `simard-gym`, or `simard-composite-engineer`. |
-| `base-type` | Yes | Base type to request. Unsupported or unregistered values fail explicitly. |
-| `topology` | Yes | Runtime topology to request. Unsupported topology or base-type pairings fail explicitly. |
-| `objective` | Yes | Objective text passed into the bootstrapped run. |
-| `state-root` | No | Durable state directory for the bootstrapped run. |
-
-**Current runnable example**:
+Example:
 
 ```bash
-SIMARD_PROMPT_ROOT="$PWD/prompt_assets" \
-SIMARD_IDENTITY=simard-engineer \
-SIMARD_BASE_TYPE=local-harness \
-SIMARD_RUNTIME_TOPOLOGY=single-process \
-SIMARD_OBJECTIVE="verify current reflection metadata" \
-SIMARD_STATE_ROOT="$PWD/target/simard-state" \
-cargo run --quiet --
+simard bootstrap run simard-engineer local-harness single-process   "verify current reflection metadata"   "$PWD/target/simard-state"
 ```
 
-**Compatibility helper**:
+## Running from source
 
-```bash
-cargo run --quiet --bin simard_operator_probe -- \
-  bootstrap-run simard-engineer local-harness single-process \
-  "verify current reflection metadata"
-```
+From the repository root, use these Cargo forms:
 
-**Planned unified equivalent**:
+- `cargo run --quiet -- ...` for `simard`
+- `cargo run --quiet --bin simard_operator_probe -- ...` for `simard_operator_probe`
+- `cargo run --quiet --bin simard-gym -- ...` for `simard-gym`
 
-```bash
-simard bootstrap run simard-engineer local-harness single-process \
-  "verify current reflection metadata" \
-  "$PWD/target/simard-state"
-```
-
-## Configuration
-
-### Environment variables
-
-| Variable | Used by | Required | Default | Description |
-| --- | --- | --- | --- | --- |
-| `SIMARD_PROMPT_ROOT` | current `simard` bootstrap entrypoint | Yes for explicit bootstrap from source | none | Root directory for prompt assets. |
-| `SIMARD_BOOTSTRAP_MODE` | current `simard` bootstrap entrypoint | No | `explicit-config` | Startup mode. Accepted values: `explicit-config`, `builtin-defaults`. |
-| `SIMARD_STATE_ROOT` | current `simard` bootstrap entrypoint and runtime internals | No when builtin defaults are explicitly selected | none in `explicit-config`; `target/simard-state` in `builtin-defaults` | Durable root for memory, goals, evidence, handoff snapshots, and review artifacts. |
-| `SIMARD_IDENTITY` | current `simard` bootstrap entrypoint | No when `SIMARD_BOOTSTRAP_MODE=builtin-defaults` | none in `explicit-config`; `simard-engineer` in `builtin-defaults` | Requested identity. |
-| `SIMARD_BASE_TYPE` | current `simard` bootstrap entrypoint | No when `SIMARD_BOOTSTRAP_MODE=builtin-defaults` | none in `explicit-config`; `local-harness` in `builtin-defaults` | Requested base type. |
-| `SIMARD_RUNTIME_TOPOLOGY` | current `simard` bootstrap entrypoint | No when `SIMARD_BOOTSTRAP_MODE=builtin-defaults` | none in `explicit-config`; `single-process` in `builtin-defaults` | Requested topology. |
-| `SIMARD_OBJECTIVE` | current `simard` bootstrap entrypoint | No when `SIMARD_BOOTSTRAP_MODE=builtin-defaults` | none in `explicit-config`; `bootstrap the Simard engineer loop` in `builtin-defaults` | Objective text for the bootstrapped run. |
-
-### Base types and topology constraints
+## Base types and topology constraints
 
 | Base type selection | Current backend identity | Supported topologies in this scaffold |
 | --- | --- | --- |
@@ -391,42 +228,15 @@ Notes:
 - unsupported topology and base-type pairs fail explicitly instead of degrading silently
 - `copilot-sdk` remains an explicit alias of the local harness implementation in this scaffold
 
-## Current-to-planned command mappings
-
-| Planned unified command | Current runnable command |
-| --- | --- |
-| `simard engineer run <topology> <workspace-root> <objective> [state-root]` | `simard_operator_probe engineer-loop-run <topology> <workspace-root> <objective> [state-root]` |
-| `simard engineer terminal <topology> <structured-objective>` | `simard_operator_probe terminal-run <topology> <structured-objective>` |
-| `simard meeting run <base-type> <topology> <structured-objective> [state-root]` | `simard_operator_probe meeting-run <base-type> <topology> <structured-objective> [state-root]` |
-| `simard goal-curation run <base-type> <topology> <structured-objective> [state-root]` | `simard_operator_probe goal-curation-run <base-type> <topology> <structured-objective> [state-root]` |
-| `simard improvement-curation run <base-type> <topology> <structured-objective> [state-root]` | `simard_operator_probe improvement-curation-run <base-type> <topology> <structured-objective> [state-root]` |
-| `simard review run <base-type> <topology> <objective> [state-root]` | `simard_operator_probe review-run <base-type> <topology> <objective> [state-root]` |
-| `simard review read <base-type> <topology> [state-root]` | `simard_operator_probe review-read <base-type> <topology> [state-root]` |
-| `simard bootstrap run <identity> <base-type> <topology> <objective> [state-root]` | `SIMARD_PROMPT_ROOT=... SIMARD_IDENTITY=... SIMARD_BASE_TYPE=... SIMARD_RUNTIME_TOPOLOGY=... SIMARD_OBJECTIVE=... [SIMARD_STATE_ROOT=...] simard` |
-| `simard gym list` | `simard-gym list` |
-| `simard gym run <scenario-id>` | `simard-gym run <scenario-id>` |
-| `simard gym run-suite <suite-id>` | `simard-gym run-suite <suite-id>` |
-
 ## Operator-visible errors
 
 Simard fails explicitly for these common operator-facing cases:
 
-- unsupported top-level command on the current compatibility binaries
+- unsupported top-level command
 - missing required positional argument, reported as `expected <arg>`
+- invalid `state-root`
 - unsupported base type for the selected identity
 - unsupported topology for the selected base type
 - missing or invalid workspace root
 - nested-worktree or repo-root drift detected during engineer-mode execution
 - structured edit requested on a dirty repo
-- state root outside the allowed filesystem boundary
-- missing latest review artifact for `improvement-curation` or `review read`
-- missing required bootstrap environment for the current `simard` entrypoint
-
-The current binaries do not silently fall back to another mode, another base type, another topology, or another executable. The planned unified CLI should preserve that same failure model.
-
-## See also
-
-- [Runtime contracts reference](./runtime-contracts.md)
-- [How to configure bootstrap and inspect reflection](../howto/configure-bootstrap-and-inspect-reflection.md)
-- [How to carry meeting decisions into engineer sessions](../howto/carry-meeting-decisions-into-engineer-sessions.md)
-- [Tutorial: Run your first local session](../tutorials/run-your-first-local-session.md)

--- a/docs/tutorials/run-your-first-benchmark-gym.md
+++ b/docs/tutorials/run-your-first-benchmark-gym.md
@@ -1,6 +1,6 @@
 ---
 title: "Tutorial: Run your first benchmark gym suite"
-description: Exercise the shipped Simard gym scenarios through `simard-gym` today and understand the planned `simard gym` surface.
+description: Exercise the shipped Simard benchmark scenarios through the canonical `simard gym` surface and understand where the legacy `simard-gym` binary still fits.
 last_updated: 2026-03-30
 review_schedule: as-needed
 owner: simard
@@ -14,28 +14,28 @@ related:
 
 # Tutorial: Run your first benchmark gym suite
 
-This tutorial exercises the benchmark surface as it exists today through `simard-gym`, then maps that flow to the planned `simard gym` namespace.
+This tutorial exercises the benchmark surface through the canonical `simard gym` namespace.
 
 ## What you'll learn
 
-- how to list the shipped benchmark scenarios today
+- how to list the shipped benchmark scenarios
 - how to run the starter suite across the current builtin base-type selections
 - where Simard writes benchmark artifacts
-- how the current `simard-gym` binary maps to the planned unified CLI
+- when you might still reach for the compatibility `simard-gym` binary
 
 ## Prerequisites
 
 - Rust and Cargo installed
 - a shell in the repository root
 
-All runnable examples below use the current benchmark executable surface exactly.
+All runnable examples below use the canonical benchmark surface.
 
 ## Step 1: List the shipped benchmark scenarios
 
 The starter suite is intentionally small and curated.
 
 ```bash
-cargo run --quiet --bin simard-gym -- list
+cargo run --quiet -- gym list
 ```
 
 You should see four scenarios:
@@ -54,18 +54,14 @@ Together they cover:
 - `rusty-clawd`
 - both `single-process` and loopback `multi-process`
 
-**Planned unified equivalent**:
-
-```bash
-simard gym list
-```
+If you need exact legacy output for an older script, `cargo run --quiet --bin simard-gym -- list` still works as a compatibility surface.
 
 ## Step 2: Run the starter benchmark suite
 
-Run the full shipped suite like an operator would today:
+Run the full shipped suite like an operator would:
 
 ```bash
-cargo run --quiet --bin simard-gym -- run-suite starter
+cargo run --quiet -- gym run-suite starter
 ```
 
 You should see output shaped like:
@@ -78,12 +74,6 @@ Suite passed: true
 - safe-code-change-rusty-clawd: passed (target/simard-gym/...)
 - composite-session-review: passed (target/simard-gym/...)
 Suite artifact report: target/simard-gym/suites/starter.json
-```
-
-**Planned unified equivalent**:
-
-```bash
-simard gym run-suite starter
 ```
 
 ## Step 3: Inspect the generated artifacts
@@ -114,7 +104,7 @@ Those artifacts record:
 You can also run a single scenario:
 
 ```bash
-cargo run --quiet --bin simard-gym -- run safe-code-change-rusty-clawd
+cargo run --quiet -- gym run safe-code-change-rusty-clawd
 ```
 
 That command prints the scenario result plus the exact artifact paths for the scenario run.
@@ -129,13 +119,27 @@ Open the JSON artifact and look for:
 - `scorecard.human_review_notes`
 - `scorecard.measurement_notes`
 
-**Planned unified equivalent**:
+## Step 5: Compare the latest two runs for one scenario
+
+Once a scenario has been executed at least twice, you can ask Simard to compare the latest two completed runs directly:
 
 ```bash
-simard gym run safe-code-change-rusty-clawd
+cargo run --quiet -- gym compare safe-code-change-rusty-clawd
 ```
 
-## Step 5: Understand the current measurement boundary
+You should see output shaped like:
+
+```text
+Scenario: safe-code-change-rusty-clawd
+Comparison status: unchanged
+Current report: target/simard-gym/safe-code-change-rusty-clawd/...
+Previous report: target/simard-gym/safe-code-change-rusty-clawd/...
+Comparison artifact report: target/simard-gym/comparisons/safe-code-change-rusty-clawd/...
+```
+
+That surface gives operators a lightweight regression check without manually diffing JSON.
+
+## Step 6: Understand the current measurement boundary
 
 The current benchmark foundation is real, but intentionally modest.
 
@@ -159,13 +163,14 @@ Those gaps are recorded in the emitted `measurement_notes` instead of being hidd
 
 You now know how to:
 
-- list the shipped benchmark scenarios through the current `simard-gym` binary
+- list the shipped benchmark scenarios through `simard gym`
 - run the starter benchmark suite
 - inspect the emitted benchmark artifacts
-- map the current benchmark binary to the planned `simard gym` namespace
+- compare the latest two runs for a shipped scenario
+- use the compatibility `simard-gym` binary only when an older script still depends on it
 
 ## Next steps
 
 - Use the [local session tutorial](./run-your-first-local-session.md) to compare ordinary runtime execution with benchmark execution.
-- Use the [Simard CLI reference](../reference/simard-cli.md) when you need the exact current-to-planned command mapping.
+- Use the [Simard CLI reference](../reference/simard-cli.md) when you need the exact command tree and compatibility mapping.
 - Use the [runtime contracts reference](../reference/runtime-contracts.md) when you need the exact public contract details.

--- a/docs/tutorials/run-your-first-local-session.md
+++ b/docs/tutorials/run-your-first-local-session.md
@@ -1,6 +1,6 @@
 ---
 title: "Tutorial: Run your first local session"
-description: Exercise the current local-session flows through today's binaries and understand how they map onto the planned unified `simard` CLI.
+description: Exercise the shipped local-session flows through the canonical `simard` CLI and understand where the legacy compatibility binaries still fit.
 last_updated: 2026-03-30
 review_schedule: as-needed
 owner: simard
@@ -15,22 +15,22 @@ related:
 
 # Tutorial: Run your first local session
 
-This tutorial exercises the local-session flows as they exist today, then maps each step to the unified `simard` CLI the product architecture intends to ship.
+This tutorial exercises the shipped local-session flows through the canonical `simard` CLI.
 
 ## Status
 
 Today:
 
-- `simard` is the bootstrap entrypoint only
-- `simard_operator_probe` is the current way to run engineer, meeting, goal-curation, improvement-curation, and review flows
-- the unified `simard engineer ...` and `simard meeting ...` forms are planned, not shipped
+- `simard` is the primary operator-facing CLI
+- `simard_operator_probe` remains available for compatibility-only flows such as `terminal-run`
+- `simard-gym` remains available for compatibility with legacy benchmark scripts, although `simard gym ...` is the canonical benchmark surface
 
 ## What you'll learn
 
-- how to run the bounded engineer loop against a local repo today
+- how to run the bounded engineer loop against a local repo
 - how meeting mode carries durable decision context into later engineer runs
 - how goal curation and improvement curation reuse the same durable state root
-- how the current binaries map onto the planned unified CLI
+- how bootstrap and benchmark flows fit into the same operator-facing CLI story
 
 ## Prerequisites
 
@@ -48,19 +48,20 @@ Use one state root for the whole tutorial so later steps can read the same meeti
 STATE_ROOT="$(mktemp -d /tmp/simard-local-session.XXXXXX)"
 ```
 
-## Step 2: Run engineer mode through today's compatibility binary
+## Step 2: Run engineer mode through the canonical CLI
 
 ```bash
-ENGINEER_OBJECTIVE=$'inspect the repository state\nrun one safe local engineering action\nverify the outcome explicitly\npersist truthful local evidence and memory'
+ENGINEER_OBJECTIVE=$'inspect the repository state
+run one safe local engineering action
+verify the outcome explicitly
+persist truthful local evidence and memory'
 
-cargo run --quiet --bin simard_operator_probe -- \
-  engineer-loop-run single-process "$PWD" "$ENGINEER_OBJECTIVE" "$STATE_ROOT"
+cargo run --quiet --   engineer run single-process "$PWD" "$ENGINEER_OBJECTIVE" "$STATE_ROOT"
 ```
 
 Look for output shaped like this:
 
 ```text
-Mode: engineer
 Repo root: /path/to/repo
 Active goals count: 0
 Execution scope: local-only
@@ -69,13 +70,7 @@ Selected action: cargo-metadata-scan
 Verification status: verified
 ```
 
-**Planned unified equivalent**:
-
-```bash
-simard engineer run single-process "$PWD" "$ENGINEER_OBJECTIVE" "$STATE_ROOT"
-```
-
-**Checkpoint**: Simard inspected the repo, chose one bounded action, and verified the result. The contract is already real even though the unified command name is still pending.
+**Checkpoint**: Simard inspected the repo, chose one bounded action, and verified the result.
 
 ## Step 3: Capture a meeting record in the same state root
 
@@ -91,24 +86,16 @@ goal: Keep outside-in verification strong | priority=2 | status=active | rationa
 EOF
 )"
 
-cargo run --quiet --bin simard_operator_probe -- \
-  meeting-run local-harness single-process "$MEETING_OBJECTIVE" "$STATE_ROOT"
+cargo run --quiet --   meeting run local-harness single-process "$MEETING_OBJECTIVE" "$STATE_ROOT"
 ```
 
 Look for output shaped like this:
 
 ```text
-Mode: meeting
 Identity: simard-meeting
 Decision records: 1
 Active goals count: 2
 Active goal 1: p1 [active] Preserve meeting handoff
-```
-
-**Planned unified equivalent**:
-
-```bash
-simard meeting run local-harness single-process "$MEETING_OBJECTIVE" "$STATE_ROOT"
 ```
 
 **Checkpoint**: the meeting run persisted one concise decision record and durable goal updates, but it did not mutate the repository.
@@ -118,25 +105,17 @@ simard meeting run local-harness single-process "$MEETING_OBJECTIVE" "$STATE_ROO
 Use the same repo and the same state root again.
 
 ```bash
-cargo run --quiet --bin simard_operator_probe -- \
-  engineer-loop-run single-process "$PWD" "$ENGINEER_OBJECTIVE" "$STATE_ROOT"
+cargo run --quiet --   engineer run single-process "$PWD" "$ENGINEER_OBJECTIVE" "$STATE_ROOT"
 ```
 
 This time, look for lines like these:
 
 ```text
-Mode: engineer
 Active goals count: 2
 Active goal 1: p1 [active] Preserve meeting handoff
 Active goal 2: p2 [active] Keep outside-in verification strong
 Carried meeting decisions: 1
 Verification status: verified
-```
-
-**Planned unified equivalent**:
-
-```bash
-simard engineer run single-process "$PWD" "$ENGINEER_OBJECTIVE" "$STATE_ROOT"
 ```
 
 **Checkpoint**: meeting mode and engineer mode now share durable planning context through one explicit state root.
@@ -146,28 +125,18 @@ simard engineer run single-process "$PWD" "$ENGINEER_OBJECTIVE" "$STATE_ROOT"
 You can also update the goal register without running a meeting first.
 
 ```bash
-cargo run --quiet --bin simard_operator_probe -- \
-  goal-curation-run local-harness single-process \
-  "$(cat <<'EOF'
+cargo run --quiet --   goal-curation run local-harness single-process   "$(cat <<'EOF'
 goal: Keep Simard's top 5 goals current | priority=1 | status=active | rationale=long-horizon stewardship is a shipped product responsibility
 goal: Preserve meeting-to-engineer continuity | priority=2 | status=active | rationale=meeting outputs should shape later engineer sessions
 EOF
-)" \
-  "$STATE_ROOT"
+)"   "$STATE_ROOT"
 ```
 
 Look for:
 
-- `Mode: goal-curation`
 - `Identity: simard-goal-curator`
 - `Active goals count: 2`
 - `Active goal 1: p1 [active] Keep Simard's top 5 goals current`
-
-**Planned unified equivalent**:
-
-```bash
-simard goal-curation run local-harness single-process "...structured objective..." "$STATE_ROOT"
-```
 
 **Checkpoint**: durable backlog stewardship is its own operator-visible mode, not an engineer-loop side effect.
 
@@ -176,69 +145,58 @@ simard goal-curation run local-harness single-process "...structured objective..
 First persist the latest review artifact:
 
 ```bash
-cargo run --quiet --bin simard_operator_probe -- \
-  review-run local-harness single-process \
-  "inspect the current Simard review surface and preserve concrete proposals" \
-  "$STATE_ROOT"
+cargo run --quiet --   review run local-harness single-process   "inspect the current Simard review surface and preserve concrete proposals"   "$STATE_ROOT"
 ```
 
 Then curate explicit approvals into durable priorities:
 
 ```bash
-cargo run --quiet --bin simard_operator_probe -- \
-  improvement-curation-run local-harness single-process \
-  "$(cat <<'EOF'
+cargo run --quiet --   improvement-curation run local-harness single-process   "$(cat <<'EOF'
 approve: Capture denser execution evidence | priority=1 | status=active | rationale=operators need denser execution evidence now
 approve: Promote this pattern into a repeatable benchmark | priority=2 | status=proposed | rationale=carry this into the next benchmark planning pass
 EOF
-)" \
-  "$STATE_ROOT"
+)"   "$STATE_ROOT"
 ```
 
 Look for:
 
-- `Mode: improvement-curation`
 - `Identity: simard-improvement-curator`
 - `Approved proposals: 2`
 - `Active goal 1: p1 [active] Capture denser execution evidence`
 - `Proposed goal 1: p2 [proposed] Promote this pattern into a repeatable benchmark`
 
-**Planned unified equivalent**:
+**Checkpoint**: reviewed evidence is now feeding durable priorities through the same runtime contract the CLI exposes elsewhere.
+
+## Step 7: Know where bootstrap and terminal compatibility fit
+
+Bootstrap and benchmark execution both live on the canonical CLI:
 
 ```bash
-simard improvement-curation run local-harness single-process "...structured objective..." "$STATE_ROOT"
+cargo run --quiet --   bootstrap run simard-engineer local-harness single-process   "bootstrap the Simard engineer loop"   "$STATE_ROOT"
+
+cargo run --quiet -- gym list
 ```
 
-**Checkpoint**: reviewed evidence is now feeding durable priorities through the same runtime contract the unified CLI will expose.
-
-## Step 7: Know where bootstrap and gym fit today
-
-Today, bootstrap already lives on `simard`, while benchmark execution still lives on `simard-gym`.
+The terminal-backed engineer substrate is still compatibility-only:
 
 ```bash
-SIMARD_BOOTSTRAP_MODE=builtin-defaults cargo run --quiet --
-cargo run --quiet --bin simard-gym -- list
-```
-
-Planned unified equivalents:
-
-```bash
-simard bootstrap run simard-engineer local-harness single-process "bootstrap the Simard engineer loop"
-simard gym list
+cargo run --quiet --bin simard_operator_probe --   terminal-run single-process   $'working-directory: .
+command: pwd
+command: printf "terminal-foundation-ok\n"'
 ```
 
 ## Summary
 
 You now know how to:
 
-- run the current engineer flow through `simard_operator_probe`
+- run the shipped engineer flow through `simard`
 - carry meeting decisions into later engineer runs
 - curate durable goals directly
 - turn review findings into durable improvement priorities
-- distinguish the current binaries from the unified CLI Simard is still building toward
+- use compatibility binaries only where the canonical CLI has not absorbed a niche surface yet
 
 ## Next steps
 
-- Use [How to configure bootstrap and inspect reflection](../howto/configure-bootstrap-and-inspect-reflection.md) when you need the current bootstrap contract in more detail.
+- Use [How to configure bootstrap and inspect reflection](../howto/configure-bootstrap-and-inspect-reflection.md) when you need the bootstrap contract in more detail.
 - Use [How to carry meeting decisions into engineer sessions](../howto/carry-meeting-decisions-into-engineer-sessions.md) when you need a narrower handoff-focused workflow.
-- Use [Simard CLI reference](../reference/simard-cli.md) when you need the exact current-to-planned command mapping.
+- Use [Simard CLI reference](../reference/simard-cli.md) when you need the exact command tree and compatibility mapping.

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -1,7 +1,7 @@
 use std::ffi::OsString;
 use std::fmt::{self, Display, Formatter};
-use std::path::Path;
-use std::path::PathBuf;
+use std::fs;
+use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 
 use crate::agent_program::{
@@ -114,6 +114,111 @@ impl BootstrapInputs {
     }
 }
 
+pub(crate) fn validate_state_root(path: impl AsRef<Path>) -> SimardResult<PathBuf> {
+    let raw_path = path.as_ref();
+    if raw_path.as_os_str().is_empty() {
+        return Err(SimardError::InvalidStateRoot {
+            path: raw_path.to_path_buf(),
+            reason: "state root must not be empty".to_string(),
+        });
+    }
+
+    if raw_path
+        .components()
+        .any(|component| matches!(component, Component::ParentDir))
+    {
+        return Err(SimardError::InvalidStateRoot {
+            path: raw_path.to_path_buf(),
+            reason: "state root must not contain '..' path segments".to_string(),
+        });
+    }
+
+    let absolute_path = if raw_path.is_absolute() {
+        raw_path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map_err(|error| SimardError::InvalidStateRoot {
+                path: raw_path.to_path_buf(),
+                reason: format!("current working directory could not be resolved: {error}"),
+            })?
+            .join(raw_path)
+    };
+
+    let (existing_root, missing_segments) = split_existing_prefix(&absolute_path)?;
+    let metadata =
+        fs::symlink_metadata(&existing_root).map_err(|error| SimardError::InvalidStateRoot {
+            path: raw_path.to_path_buf(),
+            reason: format!(
+                "existing state root ancestor '{}' could not be inspected: {error}",
+                existing_root.display()
+            ),
+        })?;
+
+    if metadata.file_type().is_symlink() {
+        return Err(SimardError::InvalidStateRoot {
+            path: raw_path.to_path_buf(),
+            reason: "state root must not be a symlink".to_string(),
+        });
+    }
+    if !metadata.is_dir() {
+        return Err(SimardError::InvalidStateRoot {
+            path: raw_path.to_path_buf(),
+            reason: "state root must resolve to a directory".to_string(),
+        });
+    }
+
+    let mut canonical =
+        fs::canonicalize(&existing_root).map_err(|error| SimardError::InvalidStateRoot {
+            path: raw_path.to_path_buf(),
+            reason: format!(
+                "state root ancestor '{}' could not be canonicalized: {error}",
+                existing_root.display()
+            ),
+        })?;
+    for segment in missing_segments {
+        canonical.push(segment);
+    }
+
+    Ok(canonical)
+}
+
+fn split_existing_prefix(path: &Path) -> SimardResult<(PathBuf, Vec<OsString>)> {
+    let mut existing = path.to_path_buf();
+    let mut missing_segments = Vec::new();
+
+    loop {
+        match fs::symlink_metadata(&existing) {
+            Ok(_) => return Ok((existing, missing_segments)),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                let segment =
+                    existing
+                        .file_name()
+                        .ok_or_else(|| SimardError::InvalidStateRoot {
+                            path: path.to_path_buf(),
+                            reason: "state root must stay under an existing directory".to_string(),
+                        })?;
+                missing_segments.push(segment.to_os_string());
+                existing = existing
+                    .parent()
+                    .ok_or_else(|| SimardError::InvalidStateRoot {
+                        path: path.to_path_buf(),
+                        reason: "state root must stay under an existing directory".to_string(),
+                    })?
+                    .to_path_buf();
+            }
+            Err(error) => {
+                return Err(SimardError::InvalidStateRoot {
+                    path: path.to_path_buf(),
+                    reason: format!(
+                        "state root '{}' could not be inspected: {error}",
+                        existing.display()
+                    ),
+                });
+            }
+        }
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct BootstrapConfig {
     pub mode: BootstrapMode,
@@ -213,11 +318,13 @@ impl BootstrapConfig {
         };
         let state_root = match inputs.state_root {
             Some(path) => ConfigValue {
-                value: path,
+                value: validate_state_root(path)?,
                 source: ConfigValueSource::Environment("SIMARD_STATE_ROOT"),
             },
             None if mode == BootstrapMode::BuiltinDefaults => ConfigValue {
-                value: PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(DEFAULT_STATE_ROOT),
+                value: validate_state_root(
+                    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(DEFAULT_STATE_ROOT),
+                )?,
                 source: ConfigValueSource::ExplicitOptIn("SIMARD_BOOTSTRAP_MODE"),
             },
             None => {
@@ -549,16 +656,48 @@ fn register_builtin_base_type(
 mod tests {
     #[cfg(unix)]
     use std::ffi::OsString;
+    use std::fs;
     #[cfg(unix)]
     use std::os::unix::ffi::OsStringExt;
+    use std::path::{Path, PathBuf};
+    use std::time::{SystemTime, UNIX_EPOCH};
 
-    use super::{LOCAL_BASE_TYPE, builtin_base_type_registry_for_manifest, decode_utf8_env_value};
+    use super::{
+        LOCAL_BASE_TYPE, builtin_base_type_registry_for_manifest, decode_utf8_env_value,
+        validate_state_root,
+    };
     use crate::base_types::{BaseTypeFactory, BaseTypeId, RustyClawdAdapter};
     use crate::error::SimardError;
     use crate::identity::{
         BuiltinIdentityLoader, IdentityLoadRequest, IdentityLoader, ManifestContract,
     };
     use crate::metadata::{Freshness, Provenance};
+
+    struct TestDir {
+        path: PathBuf,
+    }
+
+    impl TestDir {
+        fn new(label: &str) -> Self {
+            let unique = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system clock should be after unix epoch")
+                .as_nanos();
+            let path = std::env::temp_dir().join(format!("{label}-{unique}"));
+            fs::create_dir_all(&path).expect("test directory should be created");
+            Self { path }
+        }
+
+        fn path(&self) -> &Path {
+            &self.path
+        }
+    }
+
+    impl Drop for TestDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
 
     #[cfg(unix)]
     #[test]
@@ -612,6 +751,74 @@ mod tests {
                 .descriptor()
                 .backend
                 .identity
+        );
+    }
+
+    #[test]
+    fn validate_state_root_rejects_parent_directory_segments() {
+        let error = validate_state_root(PathBuf::from("../outside-state"))
+            .expect_err("state root traversal should fail");
+
+        assert_eq!(
+            error,
+            SimardError::InvalidStateRoot {
+                path: PathBuf::from("../outside-state"),
+                reason: "state root must not contain '..' path segments".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn validate_state_root_canonicalizes_safe_existing_directories() {
+        let temp_dir = TestDir::new("simard-state-root");
+        let nested = temp_dir.path().join("nested");
+        fs::create_dir_all(&nested).expect("nested directory should exist");
+
+        let resolved =
+            validate_state_root(nested.clone()).expect("existing state root should pass");
+        let expected = fs::canonicalize(&nested).expect("existing state root should canonicalize");
+
+        assert_eq!(resolved, expected);
+    }
+
+    #[test]
+    fn validate_state_root_rejects_existing_files() {
+        let temp_dir = TestDir::new("simard-state-root-file");
+        let file_path = temp_dir.path().join("state-root.txt");
+        fs::write(&file_path, "not a directory").expect("file should be written");
+
+        let error =
+            validate_state_root(file_path.clone()).expect_err("state root file should fail");
+
+        assert_eq!(
+            error,
+            SimardError::InvalidStateRoot {
+                path: file_path,
+                reason: "state root must resolve to a directory".to_string(),
+            }
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn validate_state_root_rejects_symlink_roots() {
+        use std::os::unix::fs::symlink;
+
+        let temp_dir = TestDir::new("simard-state-root-symlink");
+        let real_dir = temp_dir.path().join("real");
+        let link_dir = temp_dir.path().join("link");
+        fs::create_dir_all(&real_dir).expect("real directory should exist");
+        symlink(&real_dir, &link_dir).expect("symlink should be created");
+
+        let error =
+            validate_state_root(link_dir.clone()).expect_err("symlink state root should fail");
+
+        assert_eq!(
+            error,
+            SimardError::InvalidStateRoot {
+                path: link_dir,
+                reason: "state root must not be a symlink".to_string(),
+            }
         );
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -126,6 +126,10 @@ pub enum SimardError {
     VerificationFailed {
         reason: String,
     },
+    InvalidStateRoot {
+        path: PathBuf,
+        reason: String,
+    },
     PersistentStoreIo {
         store: String,
         action: String,
@@ -137,6 +141,10 @@ pub enum SimardError {
     },
     BenchmarkSuiteNotFound {
         suite_id: String,
+    },
+    BenchmarkComparisonUnavailable {
+        scenario_id: String,
+        reason: String,
     },
     ArtifactIo {
         path: PathBuf,
@@ -291,6 +299,9 @@ impl Display for SimardError {
             Self::VerificationFailed { reason } => {
                 write!(f, "engineer loop verification failed: {reason}")
             }
+            Self::InvalidStateRoot { path, reason } => {
+                write!(f, "invalid state root '{}': {reason}", path.display())
+            }
             Self::PersistentStoreIo {
                 store,
                 action,
@@ -306,6 +317,13 @@ impl Display for SimardError {
             Self::BenchmarkSuiteNotFound { suite_id } => {
                 write!(f, "benchmark suite '{suite_id}' is not registered")
             }
+            Self::BenchmarkComparisonUnavailable {
+                scenario_id,
+                reason,
+            } => write!(
+                f,
+                "benchmark comparison for scenario '{scenario_id}' is unavailable: {reason}"
+            ),
             Self::ArtifactIo { path: _, reason } => {
                 write!(f, "failed to read or write benchmark artifact: {reason}")
             }

--- a/src/gym.rs
+++ b/src/gym.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::bootstrap::builtin_base_type_registry_for_manifest;
 use crate::error::{SimardError, SimardResult};
@@ -50,7 +50,7 @@ impl Display for BenchmarkClass {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
 pub struct BenchmarkScenario {
     pub id: &'static str,
     pub title: &'static str,
@@ -151,53 +151,149 @@ pub struct BenchmarkSuiteReport {
     pub artifact_path: String,
 }
 
-pub fn benchmark_scenarios() -> Vec<BenchmarkScenario> {
-    vec![
-        BenchmarkScenario {
-            id: "repo-exploration-local",
-            title: "Repo exploration on local harness",
-            description: "Exercise a bounded repo-exploration task through the gym identity on the single-process local harness.",
-            class: BenchmarkClass::RepoExploration,
-            identity: "simard-gym",
-            base_type: "local-harness",
-            topology: RuntimeTopology::SingleProcess,
-            objective: "Inspect repository structure, identify likely extension points, and summarize where benchmark and runtime changes should land.",
-            expected_min_runtime_evidence: 3,
-        },
-        BenchmarkScenario {
-            id: "docs-refresh-copilot",
-            title: "Documentation refresh through copilot-sdk alias",
-            description: "Exercise a documentation-oriented benchmark while preserving the explicit copilot-sdk selection and honest local-harness implementation identity.",
-            class: BenchmarkClass::Documentation,
-            identity: "simard-gym",
-            base_type: "copilot-sdk",
-            topology: RuntimeTopology::SingleProcess,
-            objective: "Produce a concise documentation-oriented execution summary for the current repository state and report the relevant reflected runtime contracts.",
-            expected_min_runtime_evidence: 3,
-        },
-        BenchmarkScenario {
-            id: "safe-code-change-rusty-clawd",
-            title: "Safe code change style task on rusty-clawd",
-            description: "Exercise a bounded safe-change objective on the distinct rusty-clawd backend through the loopback multi-process topology.",
-            class: BenchmarkClass::SafeCodeChange,
-            identity: "simard-gym",
-            base_type: "rusty-clawd",
-            topology: RuntimeTopology::MultiProcess,
-            objective: "Plan a narrow, reviewable runtime change and summarize the exact evidence an operator would inspect before approving it.",
-            expected_min_runtime_evidence: 4,
-        },
-        BenchmarkScenario {
-            id: "composite-session-review",
-            title: "Composite identity session quality review",
-            description: "Exercise the composite engineer identity as a session-quality benchmark so the starter suite covers the shipped composite identity as well as the dedicated gym identity.",
-            class: BenchmarkClass::SessionQuality,
-            identity: "simard-composite-engineer",
-            base_type: "local-harness",
-            topology: RuntimeTopology::SingleProcess,
-            objective: "Run a disciplined bounded engineering session, preserve evidence, and produce a concise operator-facing summary of what happened.",
-            expected_min_runtime_evidence: 3,
-        },
-    ]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum BenchmarkComparisonStatus {
+    Improved,
+    Unchanged,
+    Regressed,
+}
+
+impl Display for BenchmarkComparisonStatus {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let label = match self {
+            Self::Improved => "improved",
+            Self::Unchanged => "unchanged",
+            Self::Regressed => "regressed",
+        };
+        f.write_str(label)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct BenchmarkComparisonRunSummary {
+    pub suite_id: String,
+    pub session_id: String,
+    pub run_started_at_unix_ms: u128,
+    pub passed: bool,
+    pub correctness_checks_passed: usize,
+    pub correctness_checks_total: usize,
+    pub evidence_quality: String,
+    pub exported_memory_records: usize,
+    pub exported_evidence_records: usize,
+    pub report_json: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct BenchmarkComparisonDelta {
+    pub correctness_checks_passed: i64,
+    pub exported_memory_records: i64,
+    pub exported_evidence_records: i64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct BenchmarkComparisonArtifactPaths {
+    pub report_json: String,
+    pub report_txt: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct BenchmarkComparisonReport {
+    pub scenario_id: String,
+    pub scenario_title: String,
+    pub status: BenchmarkComparisonStatus,
+    pub summary: String,
+    pub current: BenchmarkComparisonRunSummary,
+    pub previous: BenchmarkComparisonRunSummary,
+    pub delta: BenchmarkComparisonDelta,
+    pub artifact_paths: BenchmarkComparisonArtifactPaths,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct StoredBenchmarkScenario {
+    id: String,
+    title: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct StoredBenchmarkScorecard {
+    correctness_checks_passed: usize,
+    correctness_checks_total: usize,
+    evidence_quality: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct StoredBenchmarkHandoffReport {
+    exported_memory_records: usize,
+    exported_evidence_records: usize,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct StoredBenchmarkRunReport {
+    suite_id: String,
+    scenario: StoredBenchmarkScenario,
+    session_id: String,
+    run_started_at_unix_ms: u128,
+    passed: bool,
+    scorecard: StoredBenchmarkScorecard,
+    handoff: StoredBenchmarkHandoffReport,
+}
+
+#[derive(Clone, Debug)]
+struct StoredBenchmarkRunArtifact {
+    report_path: PathBuf,
+    report: StoredBenchmarkRunReport,
+}
+
+const BENCHMARK_SCENARIOS: [BenchmarkScenario; 4] = [
+    BenchmarkScenario {
+        id: "repo-exploration-local",
+        title: "Repo exploration on local harness",
+        description: "Exercise a bounded repo-exploration task through the gym identity on the single-process local harness.",
+        class: BenchmarkClass::RepoExploration,
+        identity: "simard-gym",
+        base_type: "local-harness",
+        topology: RuntimeTopology::SingleProcess,
+        objective: "Inspect repository structure, identify likely extension points, and summarize where benchmark and runtime changes should land.",
+        expected_min_runtime_evidence: 3,
+    },
+    BenchmarkScenario {
+        id: "docs-refresh-copilot",
+        title: "Documentation refresh through copilot-sdk alias",
+        description: "Exercise a documentation-oriented benchmark while preserving the explicit copilot-sdk selection and honest local-harness implementation identity.",
+        class: BenchmarkClass::Documentation,
+        identity: "simard-gym",
+        base_type: "copilot-sdk",
+        topology: RuntimeTopology::SingleProcess,
+        objective: "Produce a concise documentation-oriented execution summary for the current repository state and report the relevant reflected runtime contracts.",
+        expected_min_runtime_evidence: 3,
+    },
+    BenchmarkScenario {
+        id: "safe-code-change-rusty-clawd",
+        title: "Safe code change style task on rusty-clawd",
+        description: "Exercise a bounded safe-change objective on the distinct rusty-clawd backend through the loopback multi-process topology.",
+        class: BenchmarkClass::SafeCodeChange,
+        identity: "simard-gym",
+        base_type: "rusty-clawd",
+        topology: RuntimeTopology::MultiProcess,
+        objective: "Plan a narrow, reviewable runtime change and summarize the exact evidence an operator would inspect before approving it.",
+        expected_min_runtime_evidence: 4,
+    },
+    BenchmarkScenario {
+        id: "composite-session-review",
+        title: "Composite identity session quality review",
+        description: "Exercise the composite engineer identity as a session-quality benchmark so the starter suite covers the shipped composite identity as well as the dedicated gym identity.",
+        class: BenchmarkClass::SessionQuality,
+        identity: "simard-composite-engineer",
+        base_type: "local-harness",
+        topology: RuntimeTopology::SingleProcess,
+        objective: "Run a disciplined bounded engineering session, preserve evidence, and produce a concise operator-facing summary of what happened.",
+        expected_min_runtime_evidence: 3,
+    },
+];
+
+pub fn benchmark_scenarios() -> &'static [BenchmarkScenario] {
+    &BENCHMARK_SCENARIOS
 }
 
 pub fn run_benchmark_scenario(
@@ -205,7 +301,8 @@ pub fn run_benchmark_scenario(
     output_root: impl AsRef<Path>,
 ) -> SimardResult<BenchmarkRunReport> {
     let scenario = benchmark_scenarios()
-        .into_iter()
+        .iter()
+        .copied()
         .find(|candidate| candidate.id == scenario_id)
         .ok_or_else(|| SimardError::BenchmarkScenarioNotFound {
             scenario_id: scenario_id.to_string(),
@@ -228,7 +325,7 @@ pub fn run_benchmark_suite(
     let mut scenario_summaries = Vec::new();
     let mut suite_passed = true;
 
-    for scenario in benchmark_scenarios() {
+    for scenario in benchmark_scenarios().iter().copied() {
         let report = execute_scenario(scenario, suite_id, output_root)?;
         suite_passed &= report.passed;
         scenario_summaries.push(BenchmarkSuiteScenarioSummary {
@@ -251,6 +348,66 @@ pub fn run_benchmark_suite(
     };
     write_json(&suite_artifact, &suite_report)?;
     Ok(suite_report)
+}
+
+pub fn compare_latest_benchmark_runs(
+    scenario_id: &str,
+    output_root: impl AsRef<Path>,
+) -> SimardResult<BenchmarkComparisonReport> {
+    let output_root = output_root.as_ref();
+    let mut reports = load_scenario_run_reports(scenario_id, output_root)?;
+    if reports.len() < 2 {
+        return Err(SimardError::BenchmarkComparisonUnavailable {
+            scenario_id: scenario_id.to_string(),
+            reason: format!(
+                "need at least two completed runs under '{}'",
+                display_path(&output_root.join(scenario_id))
+            ),
+        });
+    }
+    reports.sort_by_key(|entry| entry.report.run_started_at_unix_ms);
+    let current = reports.pop().expect("checked length >= 2");
+    let previous = reports.pop().expect("checked length >= 2");
+
+    let current_summary = summarize_stored_run(&current);
+    let previous_summary = summarize_stored_run(&previous);
+    let delta = BenchmarkComparisonDelta {
+        correctness_checks_passed: current_summary.correctness_checks_passed as i64
+            - previous_summary.correctness_checks_passed as i64,
+        exported_memory_records: current_summary.exported_memory_records as i64
+            - previous_summary.exported_memory_records as i64,
+        exported_evidence_records: current_summary.exported_evidence_records as i64
+            - previous_summary.exported_evidence_records as i64,
+    };
+    let status = compare_runs(&current_summary, &previous_summary);
+    let summary = render_comparison_summary(status, &current_summary, &previous_summary, &delta);
+
+    let comparison_dir = output_root
+        .join("comparisons")
+        .join(scenario_id)
+        .join(format!(
+            "{}-vs-{}",
+            current_summary.session_id, previous_summary.session_id
+        ));
+    create_dir_all(&comparison_dir)?;
+    let report_json = comparison_dir.join("report.json");
+    let report_txt = comparison_dir.join("report.txt");
+    let report = BenchmarkComparisonReport {
+        scenario_id: current.report.scenario.id,
+        scenario_title: current.report.scenario.title,
+        status,
+        summary,
+        current: current_summary,
+        previous: previous_summary,
+        delta,
+        artifact_paths: BenchmarkComparisonArtifactPaths {
+            report_json: display_path(&report_json),
+            report_txt: display_path(&report_txt),
+        },
+    };
+    write_json(&report_json, &report)?;
+    write_text(&report_txt, render_text_comparison_report(&report))?;
+    Ok(report)
 }
 
 fn execute_scenario(
@@ -601,6 +758,42 @@ fn render_text_report(report: &BenchmarkRunReport) -> String {
     lines.join("\n")
 }
 
+fn render_text_comparison_report(report: &BenchmarkComparisonReport) -> String {
+    [
+        format!(
+            "Scenario: {} ({})",
+            report.scenario_id, report.scenario_title
+        ),
+        format!("Comparison status: {}", report.status),
+        format!("Summary: {}", report.summary),
+        format!("Current session: {}", report.current.session_id),
+        format!("Current report: {}", report.current.report_json),
+        format!(
+            "Current checks passed: {}/{}",
+            report.current.correctness_checks_passed, report.current.correctness_checks_total
+        ),
+        format!("Previous session: {}", report.previous.session_id),
+        format!("Previous report: {}", report.previous.report_json),
+        format!(
+            "Previous checks passed: {}/{}",
+            report.previous.correctness_checks_passed, report.previous.correctness_checks_total
+        ),
+        format!(
+            "Delta correctness checks passed: {:+}",
+            report.delta.correctness_checks_passed
+        ),
+        format!(
+            "Delta exported memory records: {:+}",
+            report.delta.exported_memory_records
+        ),
+        format!(
+            "Delta exported evidence records: {:+}",
+            report.delta.exported_evidence_records
+        ),
+    ]
+    .join("\n")
+}
+
 fn create_dir_all(path: &Path) -> SimardResult<()> {
     fs::create_dir_all(path).map_err(|error| SimardError::ArtifactIo {
         path: path.to_path_buf(),
@@ -624,6 +817,149 @@ fn write_text(path: &Path, contents: String) -> SimardResult<()> {
         path: path.to_path_buf(),
         reason: error.to_string(),
     })
+}
+
+fn load_scenario_run_reports(
+    scenario_id: &str,
+    output_root: &Path,
+) -> SimardResult<Vec<StoredBenchmarkRunArtifact>> {
+    let scenario_dir = output_root.join(scenario_id);
+    let entries = match fs::read_dir(&scenario_dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(Vec::new());
+        }
+        Err(error) => {
+            return Err(SimardError::ArtifactIo {
+                path: scenario_dir,
+                reason: error.to_string(),
+            });
+        }
+    };
+    let mut reports = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|error| SimardError::ArtifactIo {
+            path: scenario_dir.clone(),
+            reason: error.to_string(),
+        })?;
+        let report_path = entry.path().join("report.json");
+        if !report_path.is_file() {
+            continue;
+        }
+        let report = load_stored_run_report(&report_path)?;
+        if report.scenario.id == scenario_id {
+            reports.push(StoredBenchmarkRunArtifact {
+                report_path,
+                report,
+            });
+        }
+    }
+    Ok(reports)
+}
+
+fn load_stored_run_report(path: &Path) -> SimardResult<StoredBenchmarkRunReport> {
+    let raw = fs::read_to_string(path).map_err(|error| SimardError::ArtifactIo {
+        path: path.to_path_buf(),
+        reason: error.to_string(),
+    })?;
+    serde_json::from_str(&raw).map_err(|error| SimardError::ArtifactIo {
+        path: path.to_path_buf(),
+        reason: format!("invalid benchmark report JSON: {error}"),
+    })
+}
+
+fn summarize_stored_run(run: &StoredBenchmarkRunArtifact) -> BenchmarkComparisonRunSummary {
+    BenchmarkComparisonRunSummary {
+        suite_id: run.report.suite_id.clone(),
+        session_id: run.report.session_id.clone(),
+        run_started_at_unix_ms: run.report.run_started_at_unix_ms,
+        passed: run.report.passed,
+        correctness_checks_passed: run.report.scorecard.correctness_checks_passed,
+        correctness_checks_total: run.report.scorecard.correctness_checks_total,
+        evidence_quality: run.report.scorecard.evidence_quality.clone(),
+        exported_memory_records: run.report.handoff.exported_memory_records,
+        exported_evidence_records: run.report.handoff.exported_evidence_records,
+        report_json: display_path(&run.report_path),
+    }
+}
+
+fn compare_runs(
+    current: &BenchmarkComparisonRunSummary,
+    previous: &BenchmarkComparisonRunSummary,
+) -> BenchmarkComparisonStatus {
+    if current.passed != previous.passed {
+        return if current.passed {
+            BenchmarkComparisonStatus::Improved
+        } else {
+            BenchmarkComparisonStatus::Regressed
+        };
+    }
+    if current.correctness_checks_passed != previous.correctness_checks_passed {
+        return if current.correctness_checks_passed > previous.correctness_checks_passed {
+            BenchmarkComparisonStatus::Improved
+        } else {
+            BenchmarkComparisonStatus::Regressed
+        };
+    }
+    if current.exported_evidence_records != previous.exported_evidence_records {
+        return if current.exported_evidence_records > previous.exported_evidence_records {
+            BenchmarkComparisonStatus::Improved
+        } else {
+            BenchmarkComparisonStatus::Regressed
+        };
+    }
+    if current.exported_memory_records != previous.exported_memory_records {
+        return if current.exported_memory_records > previous.exported_memory_records {
+            BenchmarkComparisonStatus::Improved
+        } else {
+            BenchmarkComparisonStatus::Regressed
+        };
+    }
+    match evidence_quality_rank(&current.evidence_quality)
+        .cmp(&evidence_quality_rank(&previous.evidence_quality))
+    {
+        std::cmp::Ordering::Greater => BenchmarkComparisonStatus::Improved,
+        std::cmp::Ordering::Less => BenchmarkComparisonStatus::Regressed,
+        std::cmp::Ordering::Equal => BenchmarkComparisonStatus::Unchanged,
+    }
+}
+
+fn evidence_quality_rank(value: &str) -> u8 {
+    match value {
+        "sufficient" => 2,
+        "thin" => 1,
+        _ => 0,
+    }
+}
+
+fn render_comparison_summary(
+    status: BenchmarkComparisonStatus,
+    current: &BenchmarkComparisonRunSummary,
+    previous: &BenchmarkComparisonRunSummary,
+    delta: &BenchmarkComparisonDelta,
+) -> String {
+    match status {
+        BenchmarkComparisonStatus::Improved => format!(
+            "latest run improved from session '{}' to '{}' with check delta {:+}, memory delta {:+}, and evidence delta {:+}",
+            previous.session_id,
+            current.session_id,
+            delta.correctness_checks_passed,
+            delta.exported_memory_records,
+            delta.exported_evidence_records
+        ),
+        BenchmarkComparisonStatus::Regressed => format!(
+            "latest run regressed from session '{}' to '{}' with check delta {:+}, memory delta {:+}, and evidence delta {:+}",
+            previous.session_id,
+            current.session_id,
+            delta.correctness_checks_passed,
+            delta.exported_memory_records,
+            delta.exported_evidence_records
+        ),
+        BenchmarkComparisonStatus::Unchanged => format!(
+            "latest run matched session '{}' on pass/fail status, checks, memory, and evidence counts",
+            previous.session_id
+        ),
+    }
 }
 
 fn display_path(path: &Path) -> String {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,9 +49,11 @@ pub use goals::{
     FileBackedGoalStore, GoalRecord, GoalStatus, GoalStore, GoalUpdate, InMemoryGoalStore,
 };
 pub use gym::{
-    BenchmarkArtifactPaths, BenchmarkCheckResult, BenchmarkRunReport, BenchmarkScenario,
-    BenchmarkSuiteReport, BenchmarkSuiteScenarioSummary, benchmark_scenarios, default_output_root,
-    run_benchmark_scenario, run_benchmark_suite,
+    BenchmarkArtifactPaths, BenchmarkCheckResult, BenchmarkComparisonArtifactPaths,
+    BenchmarkComparisonDelta, BenchmarkComparisonReport, BenchmarkComparisonRunSummary,
+    BenchmarkComparisonStatus, BenchmarkRunReport, BenchmarkScenario, BenchmarkSuiteReport,
+    BenchmarkSuiteScenarioSummary, benchmark_scenarios, compare_latest_benchmark_runs,
+    default_output_root, run_benchmark_scenario, run_benchmark_suite,
 };
 pub use handoff::{
     FileBackedHandoffStore, InMemoryHandoffStore, RuntimeHandoffSnapshot, RuntimeHandoffStore,
@@ -68,9 +70,9 @@ pub use metadata::{BackendDescriptor, Freshness, FreshnessState, Provenance};
 pub use operator_cli::{dispatch_operator_cli, operator_cli_help, operator_cli_usage};
 pub use operator_commands::{
     dispatch_legacy_gym_cli, dispatch_operator_probe, gym_usage, run_bootstrap_probe,
-    run_engineer_loop_probe, run_goal_curation_probe, run_gym_list, run_gym_scenario,
-    run_gym_suite, run_handoff_probe, run_improvement_curation_probe, run_meeting_probe,
-    run_review_probe, run_review_read_probe, run_terminal_probe,
+    run_engineer_loop_probe, run_goal_curation_probe, run_gym_compare, run_gym_list,
+    run_gym_scenario, run_gym_suite, run_handoff_probe, run_improvement_curation_probe,
+    run_meeting_probe, run_review_probe, run_review_read_probe, run_terminal_probe,
 };
 pub use prompt_assets::{
     FilePromptAssetStore, InMemoryPromptAssetStore, PromptAsset, PromptAssetId, PromptAssetRef,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,50 +1,5 @@
-use simard::{BootstrapConfig, dispatch_operator_cli, run_local_session};
+use simard::dispatch_operator_cli;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let args = std::env::args().skip(1).collect::<Vec<_>>();
-    if !args.is_empty() {
-        return dispatch_operator_cli(args);
-    }
-
-    run_legacy_bootstrap_entrypoint()
-}
-
-fn run_legacy_bootstrap_entrypoint() -> Result<(), Box<dyn std::error::Error>> {
-    let config = BootstrapConfig::from_env()?;
-    let execution = run_local_session(&config)?;
-
-    println!("Simard local runtime executed successfully.");
-    println!("Bootstrap mode: {}", config.mode);
-    println!(
-        "Config sources: prompt_root={}, objective={}, state_root={}, base_type={}, topology={}",
-        config.prompt_root.source,
-        config.objective.source,
-        config.state_root.source,
-        config.selected_base_type.source,
-        config.topology.source
-    );
-    println!(
-        "Bootstrap selection: identity={}, base_type={}, topology={}",
-        config.identity, config.selected_base_type.value, config.topology.value
-    );
-    println!("State root: {}", config.state_root.value.display());
-    if !execution.snapshot.identity_components.is_empty() {
-        println!(
-            "Identity components: {}",
-            execution.snapshot.identity_components.join(", ")
-        );
-    }
-    println!(
-        "Snapshot: state={}, topology={}, base_type={}",
-        execution.snapshot.runtime_state,
-        execution.snapshot.topology,
-        execution.snapshot.selected_base_type
-    );
-    println!(
-        "Adapter implementation: {}",
-        execution.snapshot.adapter_backend.identity
-    );
-    println!("Shutdown: {}", execution.stopped_snapshot.runtime_state);
-
-    Ok(())
+    dispatch_operator_cli(std::env::args().skip(1))
 }

--- a/src/operator_cli.rs
+++ b/src/operator_cli.rs
@@ -1,19 +1,41 @@
 use std::path::PathBuf;
 
 use crate::operator_commands::{
-    run_bootstrap_probe, run_engineer_loop_probe, run_goal_curation_probe, run_gym_list,
-    run_gym_scenario, run_gym_suite, run_improvement_curation_probe, run_meeting_probe,
-    run_review_probe, run_review_read_probe,
+    run_bootstrap_probe, run_engineer_loop_probe, run_goal_curation_probe, run_gym_compare,
+    run_gym_list, run_gym_scenario, run_gym_suite, run_improvement_curation_probe,
+    run_meeting_probe, run_review_probe, run_review_read_probe,
 };
+
+const OPERATOR_CLI_HELP: &str = "\
+Simard unified operator CLI
+
+Product modes:
+  engineer run <topology> <workspace-root> <objective> [state-root]
+  meeting run <base-type> <topology> <objective> [state-root]
+  goal-curation run <base-type> <topology> <objective> [state-root]
+  improvement-curation run <base-type> <topology> <objective> [state-root]
+  gym list
+  gym run <scenario-id>
+  gym compare <scenario-id>
+  gym run-suite <suite-id>
+
+Operator utilities:
+  review run <base-type> <topology> <objective> [state-root]
+  review read <base-type> <topology> [state-root]
+  bootstrap run <identity> <base-type> <topology> <objective> [state-root]
+
+Compatibility binaries remain available: simard_operator_probe, simard-gym
+";
 
 pub fn dispatch_operator_cli<I>(args: I) -> Result<(), Box<dyn std::error::Error>>
 where
     I: IntoIterator<Item = String>,
 {
     let mut args = args.into_iter();
-    let command = args
-        .next()
-        .ok_or_else(|| operator_cli_usage().to_string())?;
+    let Some(command) = args.next() else {
+        print!("{}", operator_cli_help());
+        return Ok(());
+    };
 
     if matches!(command.as_str(), "--help" | "-h" | "help") {
         print!("{}", operator_cli_help());
@@ -36,28 +58,8 @@ pub fn operator_cli_usage() -> &'static str {
     "usage: simard <engineer|meeting|goal-curation|improvement-curation|gym|review|bootstrap> ..."
 }
 
-pub fn operator_cli_help() -> String {
-    [
-        "Simard unified operator CLI",
-        "",
-        "Product modes:",
-        "  engineer run <topology> <workspace-root> <objective> [state-root]",
-        "  meeting run <base-type> <topology> <objective> [state-root]",
-        "  goal-curation run <base-type> <topology> <objective> [state-root]",
-        "  improvement-curation run <base-type> <topology> <objective> [state-root]",
-        "  gym list",
-        "  gym run <scenario-id>",
-        "  gym run-suite <suite-id>",
-        "",
-        "Operator utilities:",
-        "  review run <base-type> <topology> <objective> [state-root]",
-        "  review read <base-type> <topology> [state-root]",
-        "  bootstrap run <identity> <base-type> <topology> <objective> [state-root]",
-        "",
-        "Compatibility binaries remain available: simard_operator_probe, simard-gym",
-    ]
-    .join("\n")
-        + "\n"
+pub fn operator_cli_help() -> &'static str {
+    OPERATOR_CLI_HELP
 }
 
 fn dispatch_engineer_command(
@@ -170,6 +172,11 @@ fn dispatch_gym_command(
             let scenario_id = next_required(&mut args, "scenario id")?;
             reject_extra_args(args)?;
             run_gym_scenario(&scenario_id)
+        }
+        "compare" => {
+            let scenario_id = next_required(&mut args, "scenario id")?;
+            reject_extra_args(args)?;
+            run_gym_compare(&scenario_id)
         }
         "run-suite" => {
             let suite_id = next_required(&mut args, "suite id")?;

--- a/src/operator_commands.rs
+++ b/src/operator_commands.rs
@@ -1,12 +1,14 @@
 use std::path::{Path, PathBuf};
 
+use crate::bootstrap::validate_state_root;
+use crate::sanitization::sanitize_terminal_text;
 use crate::{
     BootstrapConfig, BootstrapInputs, FileBackedMemoryStore, MemoryRecord, MemoryScope,
     MemoryStore, ReflectiveRuntime, ReviewRequest, ReviewTargetKind, RuntimeTopology,
     assemble_local_runtime_from_handoff, benchmark_scenarios, build_review_artifact,
-    default_output_root, latest_local_handoff, latest_review_artifact, persist_review_artifact,
-    render_review_context_directives, run_benchmark_scenario, run_benchmark_suite,
-    run_local_engineer_loop, run_local_session,
+    compare_latest_benchmark_runs, default_output_root, latest_local_handoff,
+    latest_review_artifact, persist_review_artifact, render_review_context_directives,
+    run_benchmark_scenario, run_benchmark_suite, run_local_engineer_loop, run_local_session,
 };
 
 pub fn dispatch_operator_probe<I>(args: I) -> Result<(), Box<dyn std::error::Error>>
@@ -115,6 +117,11 @@ where
             reject_extra_args(args)?;
             run_gym_scenario(&scenario_id)?;
         }
+        "compare" => {
+            let scenario_id = next_required(&mut args, "scenario id")?;
+            reject_extra_args(args)?;
+            run_gym_compare(&scenario_id)?;
+        }
         "run-suite" => {
             let suite_id = next_required(&mut args, "suite id")?;
             reject_extra_args(args)?;
@@ -127,7 +134,7 @@ where
 }
 
 pub fn gym_usage() -> &'static str {
-    "usage: simard-gym <list|run <scenario-id>|run-suite <suite-id>>"
+    "usage: simard-gym <list|run <scenario-id>|compare <scenario-id>|run-suite <suite-id>>"
 }
 
 pub fn run_bootstrap_probe(
@@ -146,7 +153,7 @@ pub fn run_bootstrap_probe(
             base_type,
             topology,
             "bootstrap-run",
-        )),
+        )?),
         identity: Some(identity.to_string()),
         base_type: Some(base_type.to_string()),
         topology: Some(topology.to_string()),
@@ -181,14 +188,11 @@ pub fn run_bootstrap_probe(
         "Transport backend: {}",
         execution.snapshot.transport_backend.identity
     );
-    println!("State root: {}", config.state_root_path().display());
+    print_display("State root", config.state_root_path().display());
     println!("Session phase: {}", execution.outcome.session.phase);
     println!("Shutdown: {}", execution.stopped_snapshot.runtime_state);
-    println!("Execution summary: {}", execution.outcome.execution_summary);
-    println!(
-        "Reflection summary: {}",
-        execution.outcome.reflection.summary
-    );
+    print_text("Execution summary", &execution.outcome.execution_summary);
+    print_text("Reflection summary", &execution.outcome.reflection.summary);
     Ok(())
 }
 
@@ -201,12 +205,12 @@ pub fn run_handoff_probe(
     let config = BootstrapConfig::resolve(BootstrapInputs {
         prompt_root: Some(prompt_root()),
         objective: Some(objective.to_string()),
-        state_root: Some(state_root(
+        state_root: Some(validate_state_root(state_root(
             identity,
             base_type,
             topology,
             "handoff-roundtrip",
-        )),
+        ))?),
         identity: Some(identity.to_string()),
         base_type: Some(base_type.to_string()),
         topology: Some(topology.to_string()),
@@ -219,7 +223,7 @@ pub fn run_handoff_probe(
     let restored_snapshot = restored.snapshot()?;
 
     println!("Probe mode: handoff-roundtrip");
-    println!("State root: {}", config.state_root_path().display());
+    print_display("State root", config.state_root_path().display());
     println!("Identity: {}", restored_snapshot.identity_name);
     println!(
         "Identity components: {}",
@@ -261,7 +265,7 @@ pub fn run_handoff_probe(
         "Restored transport backend: {}",
         restored_snapshot.transport_backend.identity
     );
-    println!("Execution summary: {}", execution.outcome.execution_summary);
+    print_text("Execution summary", &execution.outcome.execution_summary);
     Ok(())
 }
 
@@ -281,7 +285,7 @@ pub fn run_meeting_probe(
             base_type,
             topology,
             "meeting-run",
-        )),
+        )?),
         identity: Some(identity.to_string()),
         base_type: Some(base_type.to_string()),
         topology: Some(topology.to_string()),
@@ -304,7 +308,7 @@ pub fn run_meeting_probe(
         execution.snapshot.selected_base_type
     );
     println!("Topology: {}", execution.snapshot.topology);
-    println!("State root: {}", config.state_root_path().display());
+    print_display("State root", config.state_root_path().display());
     println!("Session phase: {}", execution.outcome.session.phase);
     println!("Decision records: {}", decision_records.len());
     println!(
@@ -312,16 +316,13 @@ pub fn run_meeting_probe(
         execution.snapshot.active_goal_count
     );
     for (index, goal) in execution.snapshot.active_goals.iter().enumerate() {
-        println!("Active goal {}: {}", index + 1, goal);
+        print_text(&format!("Active goal {}", index + 1), goal);
     }
     for (index, value) in decision_records.iter().enumerate() {
-        println!("Decision record {}: {}", index + 1, value);
+        print_text(&format!("Decision record {}", index + 1), value);
     }
-    println!("Execution summary: {}", execution.outcome.execution_summary);
-    println!(
-        "Reflection summary: {}",
-        execution.outcome.reflection.summary
-    );
+    print_text("Execution summary", &execution.outcome.execution_summary);
+    print_text("Reflection summary", &execution.outcome.reflection.summary);
     Ok(())
 }
 
@@ -341,7 +342,7 @@ pub fn run_goal_curation_probe(
             base_type,
             topology,
             "goal-curation-run",
-        )),
+        )?),
         identity: Some(identity.to_string()),
         base_type: Some(base_type.to_string()),
         topology: Some(topology.to_string()),
@@ -356,20 +357,17 @@ pub fn run_goal_curation_probe(
         execution.snapshot.selected_base_type
     );
     println!("Topology: {}", execution.snapshot.topology);
-    println!("State root: {}", config.state_root_path().display());
+    print_display("State root", config.state_root_path().display());
     println!("Session phase: {}", execution.outcome.session.phase);
     println!(
         "Active goals count: {}",
         execution.snapshot.active_goal_count
     );
     for (index, goal) in execution.snapshot.active_goals.iter().enumerate() {
-        println!("Active goal {}: {}", index + 1, goal);
+        print_text(&format!("Active goal {}", index + 1), goal);
     }
-    println!("Execution summary: {}", execution.outcome.execution_summary);
-    println!(
-        "Reflection summary: {}",
-        execution.outcome.reflection.summary
-    );
+    print_text("Execution summary", &execution.outcome.execution_summary);
+    print_text("Reflection summary", &execution.outcome.reflection.summary);
     Ok(())
 }
 
@@ -382,7 +380,12 @@ pub fn run_terminal_probe(
     let config = BootstrapConfig::resolve(BootstrapInputs {
         prompt_root: Some(prompt_root()),
         objective: Some(objective.to_string()),
-        state_root: Some(state_root(identity, base_type, topology, "terminal-run")),
+        state_root: Some(validate_state_root(state_root(
+            identity,
+            base_type,
+            topology,
+            "terminal-run",
+        ))?),
         identity: Some(identity.to_string()),
         base_type: Some(base_type.to_string()),
         topology: Some(topology.to_string()),
@@ -417,17 +420,14 @@ pub fn run_terminal_probe(
         "Adapter capabilities: {}",
         execution.snapshot.adapter_capabilities.join(", ")
     );
-    println!("State root: {}", config.state_root_path().display());
+    print_display("State root", config.state_root_path().display());
     println!("Session phase: {}", execution.outcome.session.phase);
     println!("Terminal evidence lines: {}", terminal_evidence.len());
     for detail in terminal_evidence {
-        println!("Terminal evidence: {detail}");
+        print_text("Terminal evidence", &detail);
     }
-    println!("Execution summary: {}", execution.outcome.execution_summary);
-    println!(
-        "Reflection summary: {}",
-        execution.outcome.reflection.summary
-    );
+    print_text("Execution summary", &execution.outcome.execution_summary);
+    print_text("Reflection summary", &execution.outcome.reflection.summary);
     Ok(())
 }
 
@@ -444,14 +444,14 @@ pub fn run_engineer_loop_probe(
         "terminal-shell",
         topology,
         "engineer-loop-run",
-    );
+    )?;
     let run = run_local_engineer_loop(workspace_root, objective, runtime_topology, &state_root)
         .map_err(|error| format!("{error}"))?;
 
     println!("Probe mode: engineer-loop-run");
-    println!("Repo root: {}", run.inspection.repo_root.display());
-    println!("Repo branch: {}", run.inspection.branch);
-    println!("Repo head: {}", run.inspection.head);
+    print_display("Repo root", run.inspection.repo_root.display());
+    print_text("Repo branch", &run.inspection.branch);
+    print_text("Repo head", &run.inspection.head);
     println!("Worktree dirty: {}", run.inspection.worktree_dirty);
     println!(
         "Changed files: {}",
@@ -463,25 +463,25 @@ pub fn run_engineer_loop_probe(
     );
     println!("Active goals count: {}", run.inspection.active_goals.len());
     for (index, goal) in run.inspection.active_goals.iter().enumerate() {
-        println!("Active goal {}: {}", index + 1, goal.concise_label());
+        print_text(&format!("Active goal {}", index + 1), goal.concise_label());
     }
     println!(
         "Carried meeting decisions: {}",
         run.inspection.carried_meeting_decisions.len()
     );
     for (index, decision) in run.inspection.carried_meeting_decisions.iter().enumerate() {
-        println!("Carried meeting decision {}: {}", index + 1, decision);
+        print_text(&format!("Carried meeting decision {}", index + 1), decision);
     }
-    println!("Gap summary: {}", run.inspection.architecture_gap_summary);
-    println!("Execution scope: {}", run.execution_scope);
-    println!("Selected action: {}", run.action.selected.label);
-    println!("Action plan: {}", run.action.selected.plan_summary);
-    println!(
-        "Verification steps: {}",
-        run.action.selected.verification_steps.join(" || ")
+    print_text("Gap summary", &run.inspection.architecture_gap_summary);
+    print_text("Execution scope", &run.execution_scope);
+    print_text("Selected action", &run.action.selected.label);
+    print_text("Action plan", &run.action.selected.plan_summary);
+    print_text(
+        "Verification steps",
+        run.action.selected.verification_steps.join(" || "),
     );
-    println!("Action rationale: {}", run.action.selected.rationale);
-    println!("Action command: {}", run.action.selected.argv.join(" "));
+    print_text("Action rationale", &run.action.selected.rationale);
+    print_text("Action command", run.action.selected.argv.join(" "));
     println!("Action status: success");
     println!(
         "Changed files after action: {}",
@@ -492,8 +492,8 @@ pub fn run_engineer_loop_probe(
         }
     );
     println!("Verification status: {}", run.verification.status);
-    println!("Verification summary: {}", run.verification.summary);
-    println!("State root: {}", run.state_root.display());
+    print_text("Verification summary", &run.verification.summary);
+    print_display("State root", run.state_root.display());
     Ok(())
 }
 
@@ -511,7 +511,7 @@ pub fn run_review_probe(
             state_root_override,
             base_type,
             topology,
-        )),
+        )?),
         identity: Some(identity.to_string()),
         base_type: Some(base_type.to_string()),
         topology: Some(topology.to_string()),
@@ -556,26 +556,23 @@ pub fn run_review_probe(
         execution.snapshot.selected_base_type
     );
     println!("Topology: {}", execution.snapshot.topology);
-    println!("State root: {}", config.state_root_path().display());
+    print_display("State root", config.state_root_path().display());
     println!("Session phase: {}", execution.outcome.session.phase);
-    println!("Review artifact: {}", review_artifact_path.display());
+    print_display("Review artifact", review_artifact_path.display());
     println!("Review proposals: {}", review.proposals.len());
     for (index, proposal) in review.proposals.iter().enumerate() {
         println!(
             "Proposal {}: [{}] {} => {}",
             index + 1,
             proposal.category,
-            proposal.title,
-            proposal.suggested_change
+            sanitize_terminal_text(&proposal.title),
+            sanitize_terminal_text(&proposal.suggested_change)
         );
     }
     println!("Decision records: {}", decision_records.len());
-    println!("Review record key: {}", review_key);
-    println!("Execution summary: {}", execution.outcome.execution_summary);
-    println!(
-        "Reflection summary: {}",
-        execution.outcome.reflection.summary
-    );
+    print_text("Review record key", &review_key);
+    print_text("Execution summary", &execution.outcome.execution_summary);
+    print_text("Reflection summary", &execution.outcome.reflection.summary);
     Ok(())
 }
 
@@ -584,7 +581,7 @@ pub fn run_review_read_probe(
     topology: &str,
     state_root_override: Option<PathBuf>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let state_root = resolved_review_state_root(state_root_override, base_type, topology);
+    let state_root = resolved_review_state_root(state_root_override, base_type, topology)?;
     let (review_artifact_path, review) =
         latest_review_artifact(&state_root)?.ok_or("expected persisted review artifact")?;
     let memory_store = FileBackedMemoryStore::try_new(state_root.join("memory_records.json"))?;
@@ -598,23 +595,23 @@ pub fn run_review_read_probe(
     println!("Identity: {}", review.identity_name);
     println!("Selected base type: {}", review.selected_base_type);
     println!("Topology: {}", review.topology);
-    println!("State root: {}", state_root.display());
-    println!("Latest review artifact: {}", review_artifact_path.display());
-    println!("Latest review target: {}", review.target_label);
-    println!("Latest review summary: {}", review.summary);
+    print_display("State root", state_root.display());
+    print_display("Latest review artifact", review_artifact_path.display());
+    print_text("Latest review target", &review.target_label);
+    print_text("Latest review summary", &review.summary);
     println!("Review proposals: {}", review.proposals.len());
     for (index, proposal) in review.proposals.iter().enumerate() {
         println!(
             "Proposal {}: [{}] {} => {}",
             index + 1,
             proposal.category,
-            proposal.title,
-            proposal.suggested_change
+            sanitize_terminal_text(&proposal.title),
+            sanitize_terminal_text(&proposal.suggested_change)
         );
     }
     println!("Decision review records: {}", decision_records.len());
     if let Some(record) = decision_records.last() {
-        println!("Latest decision review record: {}", record.value);
+        print_text("Latest decision review record", &record.value);
     }
     Ok(())
 }
@@ -625,7 +622,7 @@ pub fn run_improvement_curation_probe(
     operator_objective: &str,
     state_root_override: Option<PathBuf>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let state_root = resolved_review_state_root(state_root_override, base_type, topology);
+    let state_root = resolved_review_state_root(state_root_override, base_type, topology)?;
     let (review_artifact_path, review) =
         latest_review_artifact(&state_root)?.ok_or("expected persisted review artifact")?;
     let objective = format!(
@@ -659,10 +656,10 @@ pub fn run_improvement_curation_probe(
         execution.snapshot.selected_base_type
     );
     println!("Topology: {}", execution.snapshot.topology);
-    println!("State root: {}", config.state_root_path().display());
-    println!("Review artifact: {}", review_artifact_path.display());
-    println!("Review id: {}", review.review_id);
-    println!("Review target: {}", review.target_label);
+    print_display("State root", config.state_root_path().display());
+    print_display("Review artifact", review_artifact_path.display());
+    print_text("Review id", &review.review_id);
+    print_text("Review target", &review.target_label);
     println!("Review proposals: {}", review.proposals.len());
     println!("Approved proposals: {}", plan.approvals.len());
     for (index, approval) in plan.approvals.iter().enumerate() {
@@ -671,7 +668,7 @@ pub fn run_improvement_curation_probe(
             index + 1,
             approval.priority,
             approval.status,
-            approval.title
+            sanitize_terminal_text(&approval.title)
         );
     }
     println!("Deferred proposals: {}", plan.deferrals.len());
@@ -679,8 +676,8 @@ pub fn run_improvement_curation_probe(
         println!(
             "Deferred proposal {}: {} ({})",
             index + 1,
-            deferral.title,
-            deferral.rationale
+            sanitize_terminal_text(&deferral.title),
+            sanitize_terminal_text(&deferral.rationale)
         );
     }
     println!(
@@ -688,24 +685,21 @@ pub fn run_improvement_curation_probe(
         execution.snapshot.active_goal_count
     );
     for (index, goal) in execution.snapshot.active_goals.iter().enumerate() {
-        println!("Active goal {}: {}", index + 1, goal);
+        print_text(&format!("Active goal {}", index + 1), goal);
     }
     println!(
         "Proposed goals count: {}",
         execution.snapshot.proposed_goal_count
     );
     for (index, goal) in execution.snapshot.proposed_goals.iter().enumerate() {
-        println!("Proposed goal {}: {}", index + 1, goal);
+        print_text(&format!("Proposed goal {}", index + 1), goal);
     }
     println!("Decision records: {}", improvement_records.len());
     if let Some(record) = improvement_records.last() {
-        println!("Latest improvement record: {}", record.value);
+        print_text("Latest improvement record", &record.value);
     }
-    println!("Execution summary: {}", execution.outcome.execution_summary);
-    println!(
-        "Reflection summary: {}",
-        execution.outcome.reflection.summary
-    );
+    print_text("Execution summary", &execution.outcome.execution_summary);
+    print_text("Reflection summary", &execution.outcome.reflection.summary);
     Ok(())
 }
 
@@ -734,6 +728,48 @@ pub fn run_gym_scenario(scenario_id: &str) -> Result<(), Box<dyn std::error::Err
     println!("Artifact report: {}", report.artifacts.report_json);
     println!("Artifact summary: {}", report.artifacts.report_txt);
     println!("Review artifact: {}", report.artifacts.review_json);
+    Ok(())
+}
+
+pub fn run_gym_compare(scenario_id: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let report = compare_latest_benchmark_runs(scenario_id, default_output_root())?;
+    println!("Scenario: {}", report.scenario_id);
+    println!("Comparison status: {}", report.status);
+    print_text("Comparison summary", &report.summary);
+    println!("Current session: {}", report.current.session_id);
+    println!("Current passed: {}", report.current.passed);
+    println!(
+        "Current checks passed: {}/{}",
+        report.current.correctness_checks_passed, report.current.correctness_checks_total
+    );
+    println!("Current report: {}", report.current.report_json);
+    println!("Previous session: {}", report.previous.session_id);
+    println!("Previous passed: {}", report.previous.passed);
+    println!(
+        "Previous checks passed: {}/{}",
+        report.previous.correctness_checks_passed, report.previous.correctness_checks_total
+    );
+    println!("Previous report: {}", report.previous.report_json);
+    println!(
+        "Delta correctness checks passed: {:+}",
+        report.delta.correctness_checks_passed
+    );
+    println!(
+        "Delta exported memory records: {:+}",
+        report.delta.exported_memory_records
+    );
+    println!(
+        "Delta exported evidence records: {:+}",
+        report.delta.exported_evidence_records
+    );
+    println!(
+        "Comparison artifact report: {}",
+        report.artifact_paths.report_json
+    );
+    println!(
+        "Comparison artifact summary: {}",
+        report.artifact_paths.report_txt
+    );
     Ok(())
 }
 
@@ -772,15 +808,17 @@ fn resolved_state_root(
     base_type: &str,
     topology: &str,
     probe: &str,
-) -> PathBuf {
-    explicit.unwrap_or_else(|| state_root(identity, base_type, topology, probe))
+) -> crate::SimardResult<PathBuf> {
+    validate_state_root(
+        explicit.unwrap_or_else(|| state_root(identity, base_type, topology, probe)),
+    )
 }
 
 fn resolved_review_state_root(
     explicit: Option<PathBuf>,
     base_type: &str,
     topology: &str,
-) -> PathBuf {
+) -> crate::SimardResult<PathBuf> {
     resolved_state_root(
         explicit,
         "simard-engineer",
@@ -823,4 +861,12 @@ fn reject_extra_args(
         return Err(format!("unexpected trailing arguments: {}", extras.join(" ")).into());
     }
     Ok(())
+}
+
+fn print_text(label: &str, value: impl AsRef<str>) {
+    println!("{label}: {}", sanitize_terminal_text(value.as_ref()));
+}
+
+fn print_display(label: &str, value: impl std::fmt::Display) {
+    println!("{label}: {}", sanitize_terminal_text(&value.to_string()));
 }

--- a/tests/bootstrap.rs
+++ b/tests/bootstrap.rs
@@ -302,11 +302,12 @@ fn main_does_not_print_objective_derived_runtime_details() {
 }
 
 #[test]
-fn main_reports_selected_base_type_and_runtime_implementation_separately() {
+fn main_routes_through_the_unified_operator_cli() {
     let main_rs = include_str!("../src/main.rs");
 
-    assert!(main_rs.contains("Bootstrap selection:"));
-    assert!(main_rs.contains("Adapter implementation:"));
+    assert!(main_rs.contains("dispatch_operator_cli"));
+    assert!(!main_rs.contains("Bootstrap selection:"));
+    assert!(!main_rs.contains("Adapter implementation:"));
 }
 
 #[test]

--- a/tests/simard_cli.rs
+++ b/tests/simard_cli.rs
@@ -11,6 +11,8 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
+use std::thread;
+use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 fn repo_root() -> PathBuf {
@@ -73,6 +75,7 @@ fn simard_help_surfaces_the_five_product_modes_and_operator_utilities() {
         "goal-curation",
         "improvement-curation",
         "gym",
+        "compare",
         "review",
         "bootstrap",
     ] {
@@ -84,6 +87,27 @@ fn simard_help_surfaces_the_five_product_modes_and_operator_utilities() {
     assert!(
         !rendered.contains("SIMARD_PROMPT_ROOT"),
         "help should not fall through to the legacy env-only bootstrap entrypoint:\n{rendered}"
+    );
+}
+
+#[test]
+fn bare_simard_shows_unified_help_instead_of_bootstrap_env_errors() {
+    let output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .output()
+        .expect("bare simard should launch");
+    let rendered = rendered_output(&output);
+
+    assert!(
+        output.status.success(),
+        "bare simard should stay on the unified CLI surface:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("Simard unified operator CLI"),
+        "bare simard should show the operator help text:\n{rendered}"
+    );
+    assert!(
+        !rendered.contains("SIMARD_PROMPT_ROOT"),
+        "bare simard should not fall back to the legacy env-only bootstrap path:\n{rendered}"
     );
 }
 
@@ -211,6 +235,118 @@ goal: Track future remote orchestration | priority=6 | status=active | rationale
 }
 
 #[test]
+fn simard_rejects_invalid_state_roots_before_any_persistence_write() {
+    let temp_dir = TempDirGuard::new("simard-cli-invalid-state-root");
+    let bad_parent_dir_root = temp_dir.path().join("../escape");
+    let traversal_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("meeting")
+        .arg("run")
+        .arg("local-harness")
+        .arg("single-process")
+        .arg("decision: keep the state root honest")
+        .arg(&bad_parent_dir_root)
+        .output()
+        .expect("traversal rejection should launch");
+    let traversal_rendered = rendered_output(&traversal_output);
+
+    assert!(
+        !traversal_output.status.success(),
+        "state-root traversal must fail visibly:\n{traversal_rendered}"
+    );
+    assert!(
+        traversal_rendered.contains("must not contain '..'"),
+        "state-root traversal should explain why the path was rejected:\n{traversal_rendered}"
+    );
+    assert!(
+        traversal_rendered.contains("InvalidStateRoot")
+            || traversal_rendered.contains("invalid state root"),
+        "state-root validation should stay explicit about the failing contract:\n{traversal_rendered}"
+    );
+
+    let file_path = temp_dir.path().join("not-a-directory");
+    fs::write(&file_path, "file").expect("state-root file should be created");
+    let file_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("meeting")
+        .arg("run")
+        .arg("local-harness")
+        .arg("single-process")
+        .arg("decision: keep the state root honest")
+        .arg(&file_path)
+        .output()
+        .expect("file rejection should launch");
+    let file_rendered = rendered_output(&file_output);
+
+    assert!(
+        !file_output.status.success(),
+        "non-directory state roots must fail visibly:\n{file_rendered}"
+    );
+    assert!(
+        file_rendered.contains("state root must resolve to a directory"),
+        "existing file state roots should be rejected explicitly:\n{file_rendered}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn simard_rejects_symlink_state_roots() {
+    use std::os::unix::fs::symlink;
+
+    let temp_dir = TempDirGuard::new("simard-cli-symlink-state-root");
+    let real_dir = temp_dir.path().join("real");
+    let link_dir = temp_dir.path().join("link");
+    fs::create_dir_all(&real_dir).expect("real state directory should be created");
+    symlink(&real_dir, &link_dir).expect("symlink state root should be created");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("review")
+        .arg("read")
+        .arg("local-harness")
+        .arg("single-process")
+        .arg(&link_dir)
+        .output()
+        .expect("symlink rejection should launch");
+    let rendered = rendered_output(&output);
+
+    assert!(
+        !output.status.success(),
+        "symlink state roots must fail visibly:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("state root must not be a symlink"),
+        "symlink state roots should be rejected explicitly:\n{rendered}"
+    );
+}
+
+#[test]
+fn simard_sanitizes_persisted_operator_output_before_printing() {
+    let state_root = TempDirGuard::new("simard-cli-sanitized-output");
+    let objective = "decision: keep \u{1b}[31mred\u{1b}[0m output safe";
+    let output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("meeting")
+        .arg("run")
+        .arg("local-harness")
+        .arg("single-process")
+        .arg(objective)
+        .arg(state_root.path())
+        .output()
+        .expect("meeting sanitization check should launch");
+    let rendered = rendered_output(&output);
+
+    assert!(
+        output.status.success(),
+        "meeting mode should still succeed while sanitizing operator output:\n{rendered}"
+    );
+    assert!(
+        !rendered.contains('\u{1b}'),
+        "operator-visible output should strip ANSI escape sequences:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("decisions=[keep red output safe]"),
+        "persisted decision records should be rendered in sanitized form:\n{rendered}"
+    );
+}
+
+#[test]
 fn simard_review_and_improvement_curation_share_one_operator_facing_cli() {
     let state_root = TempDirGuard::new("simard-cli-improvement-curation");
 
@@ -319,6 +455,76 @@ fn simard_gym_list_matches_the_legacy_benchmark_binary_for_compatibility() {
     assert_eq!(
         simard_rendered, legacy_rendered,
         "the unified gym surface should preserve the legacy list output exactly until operators migrate"
+    );
+}
+
+#[test]
+fn simard_gym_compare_reports_the_latest_two_runs_and_matches_legacy_binary() {
+    let first_run = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("gym")
+        .arg("run")
+        .arg("repo-exploration-local")
+        .output()
+        .expect("first gym scenario run should launch");
+    let first_rendered = rendered_output(&first_run);
+    assert!(
+        first_run.status.success(),
+        "first benchmark run should succeed before comparison:\n{first_rendered}"
+    );
+
+    thread::sleep(Duration::from_millis(5));
+
+    let second_run = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("gym")
+        .arg("run")
+        .arg("repo-exploration-local")
+        .output()
+        .expect("second gym scenario run should launch");
+    let second_rendered = rendered_output(&second_run);
+    assert!(
+        second_run.status.success(),
+        "second benchmark run should succeed before comparison:\n{second_rendered}"
+    );
+
+    let simard_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("gym")
+        .arg("compare")
+        .arg("repo-exploration-local")
+        .output()
+        .expect("simard gym compare should launch");
+    let simard_rendered = rendered_output(&simard_output);
+
+    assert!(
+        simard_output.status.success(),
+        "gym compare should surface the latest two scenario runs through the primary CLI:\n{simard_rendered}"
+    );
+    for expected in [
+        "Scenario: repo-exploration-local",
+        "Comparison status: unchanged",
+        "Current report: target/simard-gym/repo-exploration-local/",
+        "Previous report: target/simard-gym/repo-exploration-local/",
+        "Comparison artifact report: target/simard-gym/comparisons/repo-exploration-local/",
+    ] {
+        assert!(
+            simard_rendered.contains(expected),
+            "gym compare should surface '{expected}' for operators:\n{simard_rendered}"
+        );
+    }
+
+    let legacy_output = Command::new(env!("CARGO_BIN_EXE_simard-gym"))
+        .arg("compare")
+        .arg("repo-exploration-local")
+        .output()
+        .expect("legacy simard-gym compare should launch");
+    let legacy_rendered = rendered_output(&legacy_output);
+
+    assert!(
+        legacy_output.status.success(),
+        "legacy simard-gym compare should remain functional while the unified CLI becomes canonical:\n{legacy_rendered}"
+    );
+    assert_eq!(
+        simard_rendered, legacy_rendered,
+        "the unified compare surface should preserve the legacy compare output exactly until operators migrate"
     );
 }
 


### PR DESCRIPTION
## Summary

- add a persisted `simard gym compare <scenario-id>` operator surface that compares the latest two completed runs for one benchmark scenario
- classify benchmark deltas as `improved`, `unchanged`, or `regressed` and write comparison artifacts under `target/simard-gym/comparisons/...`
- document the new gym comparison contract and cover it through unified CLI and legacy `simard-gym` compatibility tests

## Why this block

After comparing the current implementation against `Specs/ProductArchitecture.md`, the next highest-value missing product block after the bounded engineer loop was benchmark replay/regression comparison. Simard could already run benchmark scenarios and suites, but operators still had to diff raw JSON by hand to understand whether a rerun improved or regressed. This PR fills that operator-visible gap without inventing a new mode.

$(cat /home/azureuser/.copilot/session-state/9ac25b85-5290-4a2a-bb96-5cdcc74d1610/files/pr-step13-section.md)
