### PR TITLE
feat: expose terminal engineer surface on simard CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "simard"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simard"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2024"
 default-run = "simard"
 

--- a/docs/howto/configure-bootstrap-and-inspect-reflection.md
+++ b/docs/howto/configure-bootstrap-and-inspect-reflection.md
@@ -24,7 +24,7 @@ Use this guide when you need to answer two questions:
 
 The canonical bootstrap surface is now `simard bootstrap run ...`.
 
-The old zero-argument `simard` bootstrap fallback is gone. Operators must pass the runtime selection explicitly. The terminal-backed engineer substrate still lives on the compatibility binary because that subcommand has not moved onto the canonical CLI yet.
+The old zero-argument `simard` bootstrap fallback is gone. Operators must pass the runtime selection explicitly. The terminal-backed engineer substrate now also lives on the canonical CLI through `simard engineer terminal ...`, while `simard_operator_probe terminal-run ...` remains as a compatibility alias.
 
 ## Prerequisites
 
@@ -135,12 +135,12 @@ If you launched with `copilot-sdk`, `snapshot.selected_base_type` still shows th
 
 ## 3. Exercise the terminal-backed engineer substrate
 
-The terminal-backed engineer substrate is still compatibility-only:
+Use the canonical CLI when you want the real local PTY-backed engineer substrate:
 
 ```bash
-cargo run --quiet --bin simard_operator_probe --   terminal-run single-process   $'working-directory: .
+cargo run --quiet --   engineer terminal single-process   $'working-directory: .
 command: pwd
-command: printf "terminal-foundation-ok\n"'
+command: printf "terminal-foundation-ok\n"'   "$PWD/target/simard-state"
 ```
 
 Look for:

--- a/docs/reference/runtime-contracts.md
+++ b/docs/reference/runtime-contracts.md
@@ -32,7 +32,7 @@ Simard does **not** expose:
 | --- | --- | --- |
 | explicit bootstrap | `simard bootstrap run ...` | `simard_operator_probe bootstrap-run ...` |
 | bounded engineer loop | `simard engineer run ...` | `simard_operator_probe engineer-loop-run ...` |
-| terminal-backed engineer substrate | compatibility only | `simard_operator_probe terminal-run ...` |
+| terminal-backed engineer substrate | `simard engineer terminal ...` | `simard_operator_probe terminal-run ...` |
 | meeting mode | `simard meeting run ...` | `simard_operator_probe meeting-run ...` |
 | goal-curation mode | `simard goal-curation run ...` | `simard_operator_probe goal-curation-run ...` |
 | improvement-curation mode | `simard improvement-curation run ...` | `simard_operator_probe improvement-curation-run ...` |
@@ -44,6 +44,7 @@ Simard does **not** expose:
 The shipped operator-facing command tree is:
 
 - `simard engineer run <topology> <workspace-root> <objective> [state-root]`
+- `simard engineer terminal <topology> <objective> [state-root]`
 - `simard meeting run <base-type> <topology> <structured-objective> [state-root]`
 - `simard goal-curation run <base-type> <topology> <structured-objective> [state-root]`
 - `simard improvement-curation run <base-type> <topology> <structured-objective> [state-root]`
@@ -101,6 +102,19 @@ That structured edit path is intentionally narrow:
 - the repo must start clean so Simard does not overwrite unrelated user changes
 - only one expected changed file is allowed
 - verification must confirm both file content and git-visible change state
+
+### Terminal-backed engineer substrate
+
+Canonical entrypoint: `simard engineer terminal <topology> <objective> [state-root]`
+
+Compatibility surface: `simard_operator_probe terminal-run <topology> <objective> [state-root]`
+
+This substrate exposes the real `terminal-shell` base type on the primary CLI:
+
+- the selected base type remains `terminal-shell`
+- reflection still reports `terminal-shell::local-pty` as the adapter implementation
+- terminal evidence lines remain operator-visible
+- unsupported topology and invalid state-root choices still fail explicitly
 
 ### Meeting mode
 

--- a/docs/reference/simard-cli.md
+++ b/docs/reference/simard-cli.md
@@ -24,7 +24,8 @@ The legacy `simard_operator_probe` and `simard-gym` binaries still ship for comp
 ```text
 simard
 |- engineer
-|  `- run <topology> <workspace-root> <objective> [state-root]
+|  |- run <topology> <workspace-root> <objective> [state-root]
+|  `- terminal <topology> <objective> [state-root]
 |- meeting
 |  `- run <base-type> <topology> <structured-objective> [state-root]
 |- goal-curation
@@ -50,6 +51,7 @@ Bare `simard` prints this unified help surface.
 | Canonical command | Compatibility surface |
 | --- | --- |
 | `simard engineer run ...` | `simard_operator_probe engineer-loop-run ...` |
+| `simard engineer terminal ...` | `simard_operator_probe terminal-run ...` |
 | `simard meeting run ...` | `simard_operator_probe meeting-run ...` |
 | `simard goal-curation run ...` | `simard_operator_probe goal-curation-run ...` |
 | `simard improvement-curation run ...` | `simard_operator_probe improvement-curation-run ...` |
@@ -93,6 +95,28 @@ verify the outcome explicitly
 persist truthful local evidence and memory'
 
 simard engineer run single-process "$PWD" "$ENGINEER_OBJECTIVE" "$STATE_ROOT"
+```
+
+### `simard engineer terminal <topology> <objective> [state-root]`
+
+Runs the terminal-backed engineer substrate on the canonical CLI instead of
+requiring the legacy probe binary.
+
+Key behavior:
+
+- selects the `terminal-shell` base type explicitly
+- preserves truthful adapter reflection and terminal evidence output
+- fails visibly for unsupported topology and invalid state-root inputs
+- keeps `simard_operator_probe terminal-run ...` available for compatibility
+
+Example:
+
+```bash
+STATE_ROOT="$(mktemp -d /tmp/simard-terminal.XXXXXX)"
+
+simard engineer terminal single-process $'working-directory: .
+command: pwd
+command: printf "terminal-foundation-ok\n"' "$STATE_ROOT"
 ```
 
 ### `simard meeting run <base-type> <topology> <structured-objective> [state-root]`

--- a/docs/tutorials/run-your-first-local-session.md
+++ b/docs/tutorials/run-your-first-local-session.md
@@ -22,7 +22,7 @@ This tutorial exercises the shipped local-session flows through the canonical `s
 Today:
 
 - `simard` is the primary operator-facing CLI
-- `simard_operator_probe` remains available for compatibility-only flows such as `terminal-run`
+- `simard_operator_probe` remains available for older compatibility scripts
 - `simard-gym` remains available for compatibility with legacy benchmark scripts, although `simard gym ...` is the canonical benchmark surface
 
 ## What you'll learn
@@ -167,7 +167,7 @@ Look for:
 
 **Checkpoint**: reviewed evidence is now feeding durable priorities through the same runtime contract the CLI exposes elsewhere.
 
-## Step 7: Know where bootstrap and terminal compatibility fit
+## Step 7: Exercise bootstrap and the terminal-backed engineer substrate
 
 Bootstrap and benchmark execution both live on the canonical CLI:
 
@@ -177,12 +177,12 @@ cargo run --quiet --   bootstrap run simard-engineer local-harness single-proces
 cargo run --quiet -- gym list
 ```
 
-The terminal-backed engineer substrate is still compatibility-only:
+The terminal-backed engineer substrate now lives on the canonical CLI too:
 
 ```bash
-cargo run --quiet --bin simard_operator_probe --   terminal-run single-process   $'working-directory: .
+cargo run --quiet --   engineer terminal single-process   $'working-directory: .
 command: pwd
-command: printf "terminal-foundation-ok\n"'
+command: printf "terminal-foundation-ok\n"'   "$STATE_ROOT"
 ```
 
 ## Summary
@@ -193,7 +193,7 @@ You now know how to:
 - carry meeting decisions into later engineer runs
 - curate durable goals directly
 - turn review findings into durable improvement priorities
-- use compatibility binaries only where the canonical CLI has not absorbed a niche surface yet
+- keep compatibility binaries reserved for older scripts or exact legacy output
 
 ## Next steps
 

--- a/src/operator_cli.rs
+++ b/src/operator_cli.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use crate::operator_commands::{
     run_bootstrap_probe, run_engineer_loop_probe, run_goal_curation_probe, run_gym_compare,
     run_gym_list, run_gym_scenario, run_gym_suite, run_improvement_curation_probe,
-    run_meeting_probe, run_review_probe, run_review_read_probe,
+    run_meeting_probe, run_review_probe, run_review_read_probe, run_terminal_probe,
 };
 
 const OPERATOR_CLI_HELP: &str = "\
@@ -11,6 +11,7 @@ Simard unified operator CLI
 
 Product modes:
   engineer run <topology> <workspace-root> <objective> [state-root]
+  engineer terminal <topology> <objective> [state-root]
   meeting run <base-type> <topology> <objective> [state-root]
   goal-curation run <base-type> <topology> <objective> [state-root]
   improvement-curation run <base-type> <topology> <objective> [state-root]
@@ -79,6 +80,13 @@ fn dispatch_engineer_command(
                 &objective,
                 state_root,
             )
+        }
+        "terminal" => {
+            let topology = next_required(&mut args, "topology")?;
+            let objective = next_required(&mut args, "objective")?;
+            let state_root = next_optional_path(&mut args);
+            reject_extra_args(args)?;
+            run_terminal_probe(&topology, &objective, state_root)
         }
         other => Err(format!("unsupported command 'engineer {other}'").into()),
     }

--- a/src/operator_commands.rs
+++ b/src/operator_commands.rs
@@ -55,8 +55,9 @@ where
         "terminal-run" => {
             let topology = next_required(&mut args, "topology")?;
             let objective = next_required(&mut args, "objective")?;
+            let state_root = next_optional_path(&mut args);
             reject_extra_args(args)?;
-            run_terminal_probe(&topology, &objective)?;
+            run_terminal_probe(&topology, &objective, state_root)?;
         }
         "engineer-loop-run" => {
             let topology = next_required(&mut args, "topology")?;
@@ -374,18 +375,20 @@ pub fn run_goal_curation_probe(
 pub fn run_terminal_probe(
     topology: &str,
     objective: &str,
+    state_root_override: Option<PathBuf>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let identity = "simard-engineer";
     let base_type = "terminal-shell";
     let config = BootstrapConfig::resolve(BootstrapInputs {
         prompt_root: Some(prompt_root()),
         objective: Some(objective.to_string()),
-        state_root: Some(validate_state_root(state_root(
+        state_root: Some(resolved_state_root(
+            state_root_override,
             identity,
             base_type,
             topology,
             "terminal-run",
-        ))?),
+        )?),
         identity: Some(identity.to_string()),
         base_type: Some(base_type.to_string()),
         topology: Some(topology.to_string()),

--- a/tests/simard_cli.rs
+++ b/tests/simard_cli.rs
@@ -1,12 +1,10 @@
 //! Outside-in contract tests for the next product block after the bounded
 //! engineer loop landed in PR #55.
 //!
-//! `Specs/ProductArchitecture.md` defines five operator-visible modes
-//! (engineer, meeting, goal-curation, improvement-curation, gym). The current
-//! implementation still fragments those modes across `simard`,
-//! `simard_operator_probe`, and `simard-gym`. These tests lock the next block
-//! as one primary `simard` CLI while preserving the legacy specialist binaries
-//! as compatibility surfaces.
+//! `Specs/ProductArchitecture.md` defines five operator-visible modes plus a
+//! terminal-backed engineer substrate. The canonical `simard` CLI is now the
+//! primary surface for those shipped behaviors, while `simard_operator_probe`
+//! and `simard-gym` remain compatibility surfaces for older scripts.
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -71,6 +69,7 @@ fn simard_help_surfaces_the_five_product_modes_and_operator_utilities() {
     );
     for expected in [
         "engineer",
+        "terminal",
         "meeting",
         "goal-curation",
         "improvement-curation",
@@ -153,6 +152,51 @@ fn simard_engineer_run_drives_the_bounded_engineer_loop_from_the_primary_cli() {
     assert!(
         state_root.path().join("latest_handoff.json").is_file(),
         "engineer mode should persist the latest handoff under the chosen state root"
+    );
+}
+
+#[test]
+fn simard_engineer_terminal_exposes_the_terminal_backed_engineer_surface() {
+    let objective = "working-directory: .\ncommand: pwd\ncommand: printf \"terminal-cli-ok\\n\"";
+    let simard_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("engineer")
+        .arg("terminal")
+        .arg("single-process")
+        .arg(objective)
+        .output()
+        .expect("simard engineer terminal should launch");
+    let simard_rendered = rendered_output(&simard_output);
+
+    assert!(
+        simard_output.status.success(),
+        "simard engineer terminal should expose the terminal-backed engineer substrate through the canonical CLI:\n{simard_rendered}"
+    );
+    for expected in [
+        "Selected base type: terminal-shell",
+        "Adapter implementation: terminal-shell::local-pty",
+        "terminal-cli-ok",
+    ] {
+        assert!(
+            simard_rendered.contains(expected),
+            "terminal engineer mode should surface '{expected}' for operators:\n{simard_rendered}"
+        );
+    }
+
+    let legacy_output = Command::new(env!("CARGO_BIN_EXE_simard_operator_probe"))
+        .arg("terminal-run")
+        .arg("single-process")
+        .arg(objective)
+        .output()
+        .expect("legacy terminal-run should launch");
+    let legacy_rendered = rendered_output(&legacy_output);
+
+    assert!(
+        legacy_output.status.success(),
+        "legacy terminal-run should remain functional while operators migrate:\n{legacy_rendered}"
+    );
+    assert_eq!(
+        simard_rendered, legacy_rendered,
+        "the canonical terminal engineer surface should preserve the legacy terminal-run output exactly until operators migrate"
     );
 }
 


### PR DESCRIPTION
## Summary
- compare the current post-PR-55 implementation back to `Specs/ProductArchitecture.md` and pick the next missing operator-visible block
- move the remaining terminal-backed engineer substrate from legacy `simard_operator_probe terminal-run` onto canonical `simard engineer terminal`
- keep the legacy probe path working, update the CLI docs, and extend outside-in contract coverage

## Validation
- `python3 -m pre_commit run --all-files --hook-stage pre-commit`
- `python3 -m pre_commit run --all-files --hook-stage pre-push`
- `cargo test --all-features --locked`

## Step 16b: Outside-In Testing Results

### Scenario 1 — canonical terminal engineer command from branch install
Command: `cargo install --git https://github.com/rysweet/Simard.git --branch feat/issue-56-implement-next-simard-block-after-bounded-engineer-loop simard --root /tmp/simard-install-XXXXXX --locked --force --quiet` then `simard engineer terminal single-process '<objective with pwd + terminal-branch-ok>' /tmp/simard-terminal-pass-XXXXXX`
Result: PASS
Output: `Selected base type: terminal-shell`, `Adapter implementation: terminal-shell::local-pty`, `terminal-branch-ok`

### Scenario 2 — unsupported topology stays visible from branch install
Command: `simard engineer terminal multi-process '<objective with pwd>' /tmp/simard-terminal-fail-XXXXXX`
Result: PASS (expected explicit failure)
Output: `Error: UnsupportedTopology { base_type: "terminal-shell", topology: MultiProcess }`

Fix iterations: 0
