### PR TITLE
fix: harden persistence temp file writes

### DIFF
--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -188,7 +188,10 @@ fn split_existing_prefix(path: &Path) -> SimardResult<(PathBuf, Vec<OsString>)> 
 
     loop {
         match fs::symlink_metadata(&existing) {
-            Ok(_) => return Ok((existing, missing_segments)),
+            Ok(_) => {
+                missing_segments.reverse();
+                return Ok((existing, missing_segments));
+            }
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
                 let segment =
                     existing
@@ -777,6 +780,22 @@ mod tests {
         let resolved =
             validate_state_root(nested.clone()).expect("existing state root should pass");
         let expected = fs::canonicalize(&nested).expect("existing state root should canonicalize");
+
+        assert_eq!(resolved, expected);
+    }
+
+    #[test]
+    fn validate_state_root_preserves_missing_segment_order() {
+        let temp_dir = TestDir::new("simard-state-root-order");
+        let requested = temp_dir.path().join("level1").join("level2").join("level3");
+
+        let resolved =
+            validate_state_root(requested).expect("missing state root path should resolve safely");
+        let expected = fs::canonicalize(temp_dir.path())
+            .expect("existing ancestor should canonicalize")
+            .join("level1")
+            .join("level2")
+            .join("level3");
 
         assert_eq!(resolved, expected);
     }

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -1,10 +1,72 @@
-use std::fs;
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 
 use crate::error::{SimardError, SimardResult};
+
+static TEMP_FILE_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+struct TempFileGuard {
+    path: PathBuf,
+    file: Option<File>,
+    keep: bool,
+}
+
+impl TempFileGuard {
+    fn new(store: &str, destination: &Path) -> SimardResult<Self> {
+        let (path, file) = create_temp_file(store, destination)?;
+        let guard = Self {
+            path,
+            file: Some(file),
+            keep: false,
+        };
+        set_owner_only_permissions(store, guard.path())?;
+        Ok(guard)
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn file_mut(&mut self) -> &mut File {
+        self.file
+            .as_mut()
+            .expect("temporary persistence file should stay open until rename")
+    }
+
+    fn close(&mut self) {
+        if let Some(file) = self.file.take() {
+            drop(file);
+        }
+    }
+
+    fn persist(mut self, store: &str, destination: &Path) -> SimardResult<()> {
+        self.close();
+        fs::rename(self.path(), destination).map_err(|error| SimardError::PersistentStoreIo {
+            store: store.to_string(),
+            action: "rename".to_string(),
+            path: destination.to_path_buf(),
+            reason: error.to_string(),
+        })?;
+        self.keep = true;
+        set_owner_only_permissions(store, destination)
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.keep {
+            return;
+        }
+        self.close();
+        let _ = fs::remove_file(&self.path);
+    }
+}
 
 pub fn load_json_or_default<T>(store: &str, path: &Path) -> SimardResult<T>
 where
@@ -48,30 +110,84 @@ where
             path: path.to_path_buf(),
             reason: error.to_string(),
         })?;
-    let temp_path = temp_path(path);
-    fs::write(&temp_path, payload).map_err(|error| SimardError::PersistentStoreIo {
-        store: store.to_string(),
-        action: "write".to_string(),
-        path: temp_path.clone(),
-        reason: error.to_string(),
-    })?;
-    set_owner_only_permissions(store, &temp_path)?;
-    fs::rename(&temp_path, path).map_err(|error| SimardError::PersistentStoreIo {
-        store: store.to_string(),
-        action: "rename".to_string(),
-        path: path.to_path_buf(),
-        reason: error.to_string(),
-    })?;
-    set_owner_only_permissions(store, path)
+    let mut temp_file = TempFileGuard::new(store, path)?;
+    temp_file
+        .file_mut()
+        .write_all(&payload)
+        .map_err(|error| SimardError::PersistentStoreIo {
+            store: store.to_string(),
+            action: "write-temp".to_string(),
+            path: temp_file.path().to_path_buf(),
+            reason: error.to_string(),
+        })?;
+    temp_file
+        .file_mut()
+        .sync_all()
+        .map_err(|error| SimardError::PersistentStoreIo {
+            store: store.to_string(),
+            action: "sync-temp".to_string(),
+            path: temp_file.path().to_path_buf(),
+            reason: error.to_string(),
+        })?;
+    temp_file.persist(store, path)
 }
 
-fn temp_path(path: &Path) -> PathBuf {
-    match (path.parent(), path.file_name()) {
-        (Some(parent), Some(file_name)) => {
-            parent.join(format!("{}.tmp", file_name.to_string_lossy()))
+fn create_temp_file(store: &str, path: &Path) -> SimardResult<(PathBuf, File)> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = path
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "simard-store".to_string());
+
+    for attempt in 0..32 {
+        let temp_path = unique_temp_path(parent, &file_name, attempt);
+        match open_exclusive_temp_file(&temp_path) {
+            Ok(file) => return Ok((temp_path, file)),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => {
+                return Err(SimardError::PersistentStoreIo {
+                    store: store.to_string(),
+                    action: "create-temp".to_string(),
+                    path: temp_path,
+                    reason: error.to_string(),
+                });
+            }
         }
-        _ => PathBuf::from(format!("{}.tmp", path.to_string_lossy())),
     }
+
+    Err(SimardError::PersistentStoreIo {
+        store: store.to_string(),
+        action: "create-temp".to_string(),
+        path: parent.join(file_name),
+        reason: "unable to allocate a unique temporary file".to_string(),
+    })
+}
+
+fn unique_temp_path(parent: &Path, file_name: &str, attempt: u32) -> PathBuf {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    let sequence = TEMP_FILE_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    parent.join(format!(
+        ".{file_name}.tmp.{}.{}.{}.{}",
+        std::process::id(),
+        timestamp,
+        sequence,
+        attempt
+    ))
+}
+
+fn open_exclusive_temp_file(path: &Path) -> std::io::Result<File> {
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+
+        options.mode(0o600);
+    }
+    options.open(path)
 }
 
 #[cfg(unix)]
@@ -90,4 +206,95 @@ fn set_owner_only_permissions(store: &str, path: &Path) -> SimardResult<()> {
 #[cfg(not(unix))]
 fn set_owner_only_permissions(_store: &str, _path: &Path) -> SimardResult<()> {
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TempFileGuard, persist_json};
+    use std::fs;
+    use std::io::Write;
+    #[cfg(unix)]
+    use std::os::unix::fs::symlink;
+    use std::path::{Path, PathBuf};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    struct TestDir {
+        path: PathBuf,
+    }
+
+    impl TestDir {
+        fn new(label: &str) -> Self {
+            let unique = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system clock should be after unix epoch")
+                .as_nanos();
+            let path = std::env::temp_dir().join(format!("{label}-{unique}"));
+            fs::create_dir_all(&path).expect("test directory should be created");
+            Self { path }
+        }
+
+        fn path(&self) -> &Path {
+            &self.path
+        }
+    }
+
+    impl Drop for TestDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn persist_json_ignores_planted_legacy_temp_symlink() {
+        let temp_dir = TestDir::new("simard-persistence");
+        let victim_path = temp_dir.path().join("victim.txt");
+        let store_path = temp_dir.path().join("memory_records.json");
+        let legacy_temp_path = temp_dir.path().join("memory_records.json.tmp");
+        fs::write(&victim_path, "leave-me-alone").expect("victim file should exist");
+        symlink(&victim_path, &legacy_temp_path).expect("legacy temp symlink should exist");
+
+        persist_json("memory", &store_path, &vec!["fresh"])
+            .expect("persistence should succeed without following the planted symlink");
+
+        let victim_contents =
+            fs::read_to_string(&victim_path).expect("victim file should remain readable");
+        let store_contents =
+            fs::read_to_string(&store_path).expect("store file should be written directly");
+
+        assert_eq!(victim_contents, "leave-me-alone");
+        assert!(
+            store_contents.contains("fresh"),
+            "store payload should be written to the requested destination"
+        );
+    }
+
+    #[test]
+    fn temp_file_guard_removes_uncommitted_temp_file_on_drop() {
+        let temp_dir = TestDir::new("simard-persistence-cleanup");
+        let store_path = temp_dir.path().join("memory_records.json");
+        let temp_path = {
+            let mut temp_file =
+                TempFileGuard::new("memory", &store_path).expect("temp file guard should open");
+            temp_file
+                .file_mut()
+                .write_all(br#"["pending"]"#)
+                .expect("temporary payload should be writable");
+            let temp_path = temp_file.path().to_path_buf();
+            assert!(
+                temp_path.is_file(),
+                "temporary persistence file should exist before the guard drops"
+            );
+            temp_path
+        };
+
+        assert!(
+            !temp_path.exists(),
+            "dropping an uncommitted temp file guard should remove the leaked temp file"
+        );
+        assert!(
+            !store_path.exists(),
+            "cleanup must not create the destination file before rename succeeds"
+        );
+    }
 }

--- a/tests/simard_cli.rs
+++ b/tests/simard_cli.rs
@@ -157,12 +157,14 @@ fn simard_engineer_run_drives_the_bounded_engineer_loop_from_the_primary_cli() {
 
 #[test]
 fn simard_engineer_terminal_exposes_the_terminal_backed_engineer_surface() {
+    let state_root = TempDirGuard::new("simard-cli-terminal");
     let objective = "working-directory: .\ncommand: pwd\ncommand: printf \"terminal-cli-ok\\n\"";
     let simard_output = Command::new(env!("CARGO_BIN_EXE_simard"))
         .arg("engineer")
         .arg("terminal")
         .arg("single-process")
         .arg(objective)
+        .arg(state_root.path())
         .output()
         .expect("simard engineer terminal should launch");
     let simard_rendered = rendered_output(&simard_output);
@@ -175,6 +177,7 @@ fn simard_engineer_terminal_exposes_the_terminal_backed_engineer_surface() {
         "Selected base type: terminal-shell",
         "Adapter implementation: terminal-shell::local-pty",
         "terminal-cli-ok",
+        &format!("State root: {}", state_root.path().display()),
     ] {
         assert!(
             simard_rendered.contains(expected),
@@ -186,6 +189,7 @@ fn simard_engineer_terminal_exposes_the_terminal_backed_engineer_surface() {
         .arg("terminal-run")
         .arg("single-process")
         .arg(objective)
+        .arg(state_root.path())
         .output()
         .expect("legacy terminal-run should launch");
     let legacy_rendered = rendered_output(&legacy_output);
@@ -198,6 +202,16 @@ fn simard_engineer_terminal_exposes_the_terminal_backed_engineer_surface() {
         simard_rendered, legacy_rendered,
         "the canonical terminal engineer surface should preserve the legacy terminal-run output exactly until operators migrate"
     );
+    for expected in [
+        "memory_records.json",
+        "evidence_records.json",
+        "latest_handoff.json",
+    ] {
+        assert!(
+            state_root.path().join(expected).is_file(),
+            "terminal engineer mode should persist {expected} under the selected state root"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- harden persistence writes by creating unique temp files with exclusive semantics before atomic rename
- add regression coverage for planted legacy temp-file symlinks and temp-file cleanup
- preserve missing state-root segment order during validation so canonicalized roots stay faithful

## Validation
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features --locked -- -D warnings
- cargo test --all-features --locked