### PR TITLE
Add goal-curation read operator command

### DIFF
--- a/docs/howto/inspect-durable-goal-register.md
+++ b/docs/howto/inspect-durable-goal-register.md
@@ -1,0 +1,157 @@
+---
+title: How to inspect the durable goal register
+description: Use `simard goal-curation read` to inspect the stored durable goal register across `active`, `proposed`, `paused`, and `completed` under one state root.
+last_updated: 2026-03-30
+review_schedule: as-needed
+owner: simard
+doc_type: howto
+related:
+  - ../index.md
+  - ../reference/simard-cli.md
+  - ../reference/runtime-contracts.md
+  - ../tutorials/run-your-first-local-session.md
+  - ./carry-meeting-decisions-into-engineer-sessions.md
+---
+
+# How to inspect the durable goal register
+
+Use this guide to inspect the full stored goal ledger, not just the active top-five summary that `simard goal-curation run ...` prints after a curation update.
+
+## Prerequisites
+
+- [ ] You are in the repository root
+- [ ] `cargo run --quiet -- ...` works locally
+- [ ] You have a state root you want to inspect, or you are willing to create one for this walkthrough
+
+## 1. Pick one explicit state root
+
+The read workflow only sees durable state stored under the selected root.
+
+```bash
+STATE_ROOT="$(mktemp -d /tmp/simard-goal-register.XXXXXX)"
+```
+
+Keep that shell variable for the rest of this guide.
+
+## 2. Populate realistic goal state through the public CLI
+
+If you already have a durable state root, reuse it. If not, create one through `goal-curation run` with a realistic mix of goal statuses.
+
+```bash
+GOAL_OBJECTIVE="$(cat <<'EOF'
+goal: Keep Simard's top 5 goals current | priority=1 | status=active | rationale=long-horizon stewardship is a shipped product responsibility
+goal: Preserve meeting-to-engineer continuity | priority=2 | status=active | rationale=meeting outputs should shape later engineer sessions
+goal: Promote benchmark drift alerts | priority=3 | status=proposed | rationale=operators should see drift candidates before they become active work
+goal: Expand multi-process orchestration carefully | priority=4 | status=paused | rationale=the architecture matters, but current local reliability is still more urgent
+goal: Ship the canonical bootstrap contract | priority=5 | status=completed | rationale=bootstrap no longer depends on a hidden environment-only fallback
+EOF
+)"
+
+cargo run --quiet --   goal-curation run local-harness single-process   "$GOAL_OBJECTIVE"   "$STATE_ROOT"
+```
+
+Look for output like this:
+
+```text
+Identity: simard-goal-curator
+Active goals count: 2
+Active goal 1: p1 [active] Keep Simard's top 5 goals current
+Active goal 2: p2 [active] Preserve meeting-to-engineer continuity
+```
+
+That mutation path still focuses on curation plus the active top-five summary. It does not replace the dedicated read workflow below.
+
+## 3. Read the durable goal register
+
+```bash
+cargo run --quiet --   goal-curation read local-harness single-process "$STATE_ROOT"
+```
+
+The output shape is:
+
+```text
+Goal register: durable
+Selected base type: local-harness
+Topology: single-process
+State root: /tmp/simard-goal-register.XXXXXX
+Active goals count: 2
+Active goal 1: p1 [active] Keep Simard's top 5 goals current
+Active goal 2: p2 [active] Preserve meeting-to-engineer continuity
+Proposed goals count: 1
+Proposed goal 1: p3 [proposed] Promote benchmark drift alerts
+Paused goals count: 1
+Paused goal 1: p4 [paused] Expand multi-process orchestration carefully
+Completed goals count: 1
+Completed goal 1: p5 [completed] Ship the canonical bootstrap contract
+```
+
+The important contract is structural:
+
+- the command is read-only
+- sections always appear in `active`, `proposed`, `paused`, `completed` order
+- the output is grouped for operator inspection rather than raw file browsing
+- when `[state-root]` is omitted, the command reuses the same canonical durable root that `goal-curation run` writes for the validated runtime pairing
+- persisted goal text is sanitized at render time so terminal escape/control sequences are not replayed
+- the stored goal ledger is read from the same validated `state-root` used by other durable Simard flows
+
+## 4. Read an empty register honestly
+
+```bash
+EMPTY_STATE_ROOT="$(mktemp -d /tmp/simard-goal-register-empty.XXXXXX)"
+
+cargo run --quiet --   goal-curation read local-harness single-process "$EMPTY_STATE_ROOT"
+```
+
+The empty-state output is:
+
+```text
+Goal register: durable
+Selected base type: local-harness
+Topology: single-process
+State root: /tmp/simard-goal-register-empty.XXXXXX
+Active goals count: 0
+Active goals: <none>
+Proposed goals count: 0
+Proposed goals: <none>
+Paused goals count: 0
+Paused goals: <none>
+Completed goals count: 0
+Completed goals: <none>
+```
+
+This is the honest zero-state contract. Empty durable state is visible as empty durable state, not inferred success.
+
+## 5. Configuration rules that matter
+
+For predictable future goal-register inspection, keep these rules in mind:
+
+- pass the exact same explicit `state-root` you used for earlier `meeting`, `goal-curation`, or `improvement-curation` activity when you want to inspect that stored ledger
+- if you omit `[state-root]`, keep the same shipped `base-type` and `topology` pairing you used for `goal-curation run` so Simard resolves the same canonical durable root
+- keep using a supported operator runtime pairing such as `local-harness single-process` unless your environment intentionally exercises another shipped base type
+- use `goal-curation run` when you want to curate or reprioritize durable goal state
+- use `goal-curation read` when you want to inspect durable goal state without mutating it
+- expect invalid `state-root` values, unreadable storage, and malformed durable goal data to fail explicitly rather than silently rendering an empty register
+
+## 6. Troubleshoot the common failure shapes
+
+### You only see active goals
+
+That usually means the stored register only contains active records so far. `goal-curation read` is still working as designed if it prints the other sections with `0` and `<none>`.
+
+### The output is empty, but you expected stored goals
+
+Usually one of these is true:
+
+- you passed a different `STATE_ROOT` than the one used to curate or carry goals earlier
+- the selected state root is valid but has no persisted goal ledger yet
+- earlier durable state came from another workspace or another temporary directory
+
+### The command fails instead of printing a register
+
+That is the intended contract for invalid or unreadable operator state. Fix the selected `state-root` or the underlying storage rather than assuming Simard should guess.
+
+## Related reading
+
+- For the exact command tree and example syntax, see [Simard CLI reference](../reference/simard-cli.md).
+- For the executable contract behind the read and run paths, see [Runtime contracts reference](../reference/runtime-contracts.md).
+- For a broader learning flow that also exercises engineer, meeting, review, and benchmark modes, see [Tutorial: Run your first local session](../tutorials/run-your-first-local-session.md).

--- a/docs/reference/simard-cli.md
+++ b/docs/reference/simard-cli.md
@@ -1,6 +1,6 @@
 ---
 title: Simard CLI reference
-description: Reference for the shipped `simard` command tree and the legacy compatibility binaries that still expose the same runtime behaviors.
+description: Reference for the shipped `simard` command tree and the legacy compatibility binaries that still expose selected older runtime behaviors.
 last_updated: 2026-03-30
 review_schedule: as-needed
 owner: simard
@@ -8,6 +8,7 @@ doc_type: reference
 related:
   - ../index.md
   - ./runtime-contracts.md
+  - ../howto/inspect-durable-goal-register.md
   - ../howto/configure-bootstrap-and-inspect-reflection.md
   - ../howto/carry-meeting-decisions-into-engineer-sessions.md
   - ../tutorials/run-your-first-local-session.md
@@ -19,7 +20,9 @@ related:
 
 The legacy `simard_operator_probe` and `simard-gym` binaries still ship for compatibility, but new operator workflows should use `simard ...`.
 
-## Command tree
+This page distinguishes shipped commands from compatibility surfaces. When a compatibility surface is listed as `none`, the command is canonical-only.
+
+## Shipped command tree
 
 ```text
 simard
@@ -29,7 +32,8 @@ simard
 |- meeting
 |  `- run <base-type> <topology> <structured-objective> [state-root]
 |- goal-curation
-|  `- run <base-type> <topology> <structured-objective> [state-root]
+|  |- run <base-type> <topology> <structured-objective> [state-root]
+|  `- read <base-type> <topology> [state-root]
 |- improvement-curation
 |  `- run <base-type> <topology> <structured-objective> [state-root]
 |- gym
@@ -54,6 +58,7 @@ Bare `simard` prints this unified help surface.
 | `simard engineer terminal ...` | `simard_operator_probe terminal-run ...` |
 | `simard meeting run ...` | `simard_operator_probe meeting-run ...` |
 | `simard goal-curation run ...` | `simard_operator_probe goal-curation-run ...` |
+| `simard goal-curation read ...` | none |
 | `simard improvement-curation run ...` | `simard_operator_probe improvement-curation-run ...` |
 | `simard review run ...` | `simard_operator_probe review-run ...` |
 | `simard review read ...` | `simard_operator_probe review-read ...` |
@@ -162,6 +167,51 @@ Example:
 
 ```bash
 simard goal-curation run local-harness single-process   "goal: Keep Simard's top 5 goals current | priority=1 | status=active | rationale=long-horizon stewardship is a shipped product responsibility"   "$STATE_ROOT"
+```
+
+`goal-curation run` is the mutation path. It curates durable goal state and still surfaces the active top-five summary for quick operator feedback.
+
+When `[state-root]` is omitted, `goal-curation run` writes under the canonical durable root for the selected shipped runtime pairing:
+
+```text
+target/operator-probe-state/goal-curation-run/simard-goal-curator/<base-type>/<topology>
+```
+
+### `simard goal-curation read <base-type> <topology> [state-root]`
+
+Reads the stored durable goal register without mutating it.
+
+Key behavior:
+
+- loads the stored goal register from the validated `state-root`
+- reuses the same canonical default durable root as `goal-curation run` when `[state-root]` is omitted
+- validates `base-type` and `topology` before deriving that default root
+- prints sections in this fixed order: `active`, `proposed`, `paused`, `completed`
+- includes explicit zero-state lines for empty sections
+- strips terminal control sequences from persisted goal text before printing it
+- preserves `goal-curation run` as the only curation workflow
+- fails explicitly for invalid `state-root` values and unreadable or malformed durable goal state
+
+Example:
+
+```bash
+simard goal-curation read local-harness single-process "$STATE_ROOT"
+```
+
+You should see output shaped like:
+
+```text
+Goal register: durable
+State root: /tmp/simard-goal-register.XXXXXX
+Active goals count: 2
+Active goal 1: p1 [active] Keep Simard's top 5 goals current
+Active goal 2: p2 [active] Preserve meeting-to-engineer continuity
+Proposed goals count: 1
+Proposed goal 1: p3 [proposed] Promote benchmark drift alerts
+Paused goals count: 1
+Paused goal 1: p4 [paused] Expand multi-process orchestration carefully
+Completed goals count: 1
+Completed goal 1: p5 [completed] Ship the canonical bootstrap contract
 ```
 
 ### `simard improvement-curation run <base-type> <topology> <structured-objective> [state-root]`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,9 +70,10 @@ pub use metadata::{BackendDescriptor, Freshness, FreshnessState, Provenance};
 pub use operator_cli::{dispatch_operator_cli, operator_cli_help, operator_cli_usage};
 pub use operator_commands::{
     dispatch_legacy_gym_cli, dispatch_operator_probe, gym_usage, run_bootstrap_probe,
-    run_engineer_loop_probe, run_goal_curation_probe, run_gym_compare, run_gym_list,
-    run_gym_scenario, run_gym_suite, run_handoff_probe, run_improvement_curation_probe,
-    run_meeting_probe, run_review_probe, run_review_read_probe, run_terminal_probe,
+    run_engineer_loop_probe, run_goal_curation_probe, run_goal_curation_read_probe,
+    run_gym_compare, run_gym_list, run_gym_scenario, run_gym_suite, run_handoff_probe,
+    run_improvement_curation_probe, run_meeting_probe, run_review_probe, run_review_read_probe,
+    run_terminal_probe,
 };
 pub use prompt_assets::{
     FilePromptAssetStore, InMemoryPromptAssetStore, PromptAsset, PromptAssetId, PromptAssetRef,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,11 @@
 use simard::dispatch_operator_cli;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    dispatch_operator_cli(std::env::args().skip(1))
+fn main() -> std::process::ExitCode {
+    match dispatch_operator_cli(std::env::args().skip(1)) {
+        Ok(()) => std::process::ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("Error: {error}");
+            std::process::ExitCode::FAILURE
+        }
+    }
 }

--- a/src/operator_cli.rs
+++ b/src/operator_cli.rs
@@ -1,9 +1,10 @@
 use std::path::PathBuf;
 
 use crate::operator_commands::{
-    run_bootstrap_probe, run_engineer_loop_probe, run_goal_curation_probe, run_gym_compare,
-    run_gym_list, run_gym_scenario, run_gym_suite, run_improvement_curation_probe,
-    run_meeting_probe, run_review_probe, run_review_read_probe, run_terminal_probe,
+    run_bootstrap_probe, run_engineer_loop_probe, run_goal_curation_probe,
+    run_goal_curation_read_probe, run_gym_compare, run_gym_list, run_gym_scenario, run_gym_suite,
+    run_improvement_curation_probe, run_meeting_probe, run_review_probe, run_review_read_probe,
+    run_terminal_probe,
 };
 
 const OPERATOR_CLI_HELP: &str = "\
@@ -14,6 +15,7 @@ Product modes:
   engineer terminal <topology> <objective> [state-root]
   meeting run <base-type> <topology> <objective> [state-root]
   goal-curation run <base-type> <topology> <objective> [state-root]
+  goal-curation read <base-type> <topology> [state-root]
   improvement-curation run <base-type> <topology> <objective> [state-root]
   gym list
   gym run <scenario-id>
@@ -121,6 +123,13 @@ fn dispatch_goal_curation_command(
             let state_root = next_optional_path(&mut args);
             reject_extra_args(args)?;
             run_goal_curation_probe(&base_type, &topology, &objective, state_root)
+        }
+        "read" => {
+            let base_type = next_required(&mut args, "base type")?;
+            let topology = next_required(&mut args, "topology")?;
+            let state_root = next_optional_path(&mut args);
+            reject_extra_args(args)?;
+            run_goal_curation_read_probe(&base_type, &topology, state_root)
         }
         other => Err(format!("unsupported command 'goal-curation {other}'").into()),
     }

--- a/src/operator_commands.rs
+++ b/src/operator_commands.rs
@@ -1,14 +1,18 @@
 use std::path::{Path, PathBuf};
 
+use crate::base_types::BaseTypeId;
 use crate::bootstrap::validate_state_root;
+use crate::goals::{FileBackedGoalStore, GoalRecord, GoalStatus, GoalStore};
 use crate::sanitization::sanitize_terminal_text;
 use crate::{
-    BootstrapConfig, BootstrapInputs, FileBackedMemoryStore, MemoryRecord, MemoryScope,
-    MemoryStore, ReflectiveRuntime, ReviewRequest, ReviewTargetKind, RuntimeTopology,
+    BootstrapConfig, BootstrapInputs, BuiltinIdentityLoader, FileBackedMemoryStore, Freshness,
+    IdentityLoadRequest, IdentityLoader, ManifestContract, MemoryRecord, MemoryScope, MemoryStore,
+    Provenance, ReflectiveRuntime, ReviewRequest, ReviewTargetKind, RuntimeTopology,
     assemble_local_runtime_from_handoff, benchmark_scenarios, build_review_artifact,
-    compare_latest_benchmark_runs, default_output_root, latest_local_handoff,
-    latest_review_artifact, persist_review_artifact, render_review_context_directives,
-    run_benchmark_scenario, run_benchmark_suite, run_local_engineer_loop, run_local_session,
+    builtin_base_type_registry_for_manifest, compare_latest_benchmark_runs, default_output_root,
+    latest_local_handoff, latest_review_artifact, persist_review_artifact,
+    render_review_context_directives, run_benchmark_scenario, run_benchmark_suite,
+    run_local_engineer_loop, run_local_session,
 };
 
 pub fn dispatch_operator_probe<I>(args: I) -> Result<(), Box<dyn std::error::Error>>
@@ -206,12 +210,13 @@ pub fn run_handoff_probe(
     let config = BootstrapConfig::resolve(BootstrapInputs {
         prompt_root: Some(prompt_root()),
         objective: Some(objective.to_string()),
-        state_root: Some(validate_state_root(state_root(
+        state_root: Some(resolved_state_root(
+            None,
             identity,
             base_type,
             topology,
             "handoff-roundtrip",
-        ))?),
+        )?),
         identity: Some(identity.to_string()),
         base_type: Some(base_type.to_string()),
         topology: Some(topology.to_string()),
@@ -337,12 +342,10 @@ pub fn run_goal_curation_probe(
     let config = BootstrapConfig::resolve(BootstrapInputs {
         prompt_root: Some(prompt_root()),
         objective: Some(objective.to_string()),
-        state_root: Some(resolved_state_root(
+        state_root: Some(resolved_goal_curation_state_root(
             state_root_override,
-            identity,
             base_type,
             topology,
-            "goal-curation-run",
         )?),
         identity: Some(identity.to_string()),
         base_type: Some(base_type.to_string()),
@@ -369,6 +372,24 @@ pub fn run_goal_curation_probe(
     }
     print_text("Execution summary", &execution.outcome.execution_summary);
     print_text("Reflection summary", &execution.outcome.reflection.summary);
+    Ok(())
+}
+
+pub fn run_goal_curation_read_probe(
+    base_type: &str,
+    topology: &str,
+    state_root_override: Option<PathBuf>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let state_root = resolved_goal_curation_state_root(state_root_override, base_type, topology)?;
+    let goal_store = FileBackedGoalStore::try_new(state_root.join("goal_records.json"))?;
+    let goal_records = goal_store.list()?;
+    let register = GoalRegisterView::from_records(goal_records);
+
+    println!("Goal register: durable");
+    print_text("Selected base type", base_type);
+    print_text("Topology", topology);
+    print_display("State root", state_root.display());
+    register.print();
     Ok(())
 }
 
@@ -837,13 +858,79 @@ fn prompt_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("prompt_assets")
 }
 
-fn state_root(identity: &str, base_type: &str, topology: &str, probe: &str) -> PathBuf {
+fn state_root(
+    identity: &str,
+    base_type: &BaseTypeId,
+    topology: RuntimeTopology,
+    probe: &str,
+) -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("target/operator-probe-state")
         .join(probe)
         .join(identity)
-        .join(base_type)
-        .join(topology)
+        .join(base_type.as_str())
+        .join(topology.to_string())
+}
+
+fn resolved_goal_curation_state_root(
+    explicit: Option<PathBuf>,
+    base_type: &str,
+    topology: &str,
+) -> crate::SimardResult<PathBuf> {
+    resolved_state_root(
+        explicit,
+        "simard-goal-curator",
+        base_type,
+        topology,
+        "goal-curation-run",
+    )
+}
+
+struct ValidatedRuntimeSegments {
+    base_type: BaseTypeId,
+    topology: RuntimeTopology,
+}
+
+fn validated_runtime_segments(
+    identity: &str,
+    base_type: &str,
+    topology: &str,
+) -> crate::SimardResult<ValidatedRuntimeSegments> {
+    let topology = parse_runtime_topology(topology)?;
+    let contract = ManifestContract::new(
+        concat!(module_path!(), "::validated_runtime_segments"),
+        "operator-cli -> identity-loader -> base-type-registry",
+        vec![
+            format!("identity:{identity}"),
+            format!("base-type:{base_type}"),
+            format!("topology:{topology}"),
+        ],
+        Provenance::runtime(format!("operator-cli/default-state-root/{identity}")),
+        Freshness::now()?,
+    )?;
+    let manifest = BuiltinIdentityLoader.load(&IdentityLoadRequest::new(
+        identity,
+        env!("CARGO_PKG_VERSION"),
+        contract,
+    ))?;
+    let base_types = builtin_base_type_registry_for_manifest(&manifest)?;
+    let requested_base_type = BaseTypeId::new(base_type);
+    let factory = base_types.get(&requested_base_type).ok_or_else(|| {
+        crate::SimardError::AdapterNotRegistered {
+            base_type: base_type.to_string(),
+        }
+    })?;
+    if !factory.descriptor().supports_topology(topology) {
+        return Err(crate::SimardError::UnsupportedTopology {
+            base_type: base_type.to_string(),
+            topology,
+        });
+    }
+
+    Ok(ValidatedRuntimeSegments {
+        base_type: factory.descriptor().id.clone(),
+        topology,
+    })
 }
 
 fn resolved_state_root(
@@ -853,9 +940,18 @@ fn resolved_state_root(
     topology: &str,
     probe: &str,
 ) -> crate::SimardResult<PathBuf> {
-    validate_state_root(
-        explicit.unwrap_or_else(|| state_root(identity, base_type, topology, probe)),
-    )
+    match explicit {
+        Some(path) => validate_state_root(path),
+        None => {
+            let segments = validated_runtime_segments(identity, base_type, topology)?;
+            validate_state_root(state_root(
+                identity,
+                &segments.base_type,
+                segments.topology,
+                probe,
+            ))
+        }
+    }
 }
 
 fn resolved_review_state_root(
@@ -872,15 +968,16 @@ fn resolved_review_state_root(
     )
 }
 
-fn parse_runtime_topology(value: &str) -> Result<RuntimeTopology, Box<dyn std::error::Error>> {
+fn parse_runtime_topology(value: &str) -> crate::SimardResult<RuntimeTopology> {
     match value {
         "single-process" => Ok(RuntimeTopology::SingleProcess),
         "multi-process" => Ok(RuntimeTopology::MultiProcess),
         "distributed" => Ok(RuntimeTopology::Distributed),
-        other => Err(format!(
-            "unsupported runtime topology '{other}'; expected single-process, multi-process, or distributed"
-        )
-        .into()),
+        other => Err(crate::SimardError::InvalidConfigValue {
+            key: "SIMARD_RUNTIME_TOPOLOGY".to_string(),
+            value: other.to_string(),
+            help: "expected 'single-process', 'multi-process', or 'distributed'".to_string(),
+        }),
     }
 }
 
@@ -913,4 +1010,85 @@ fn print_text(label: &str, value: impl AsRef<str>) {
 
 fn print_display(label: &str, value: impl std::fmt::Display) {
     println!("{label}: {}", sanitize_terminal_text(&value.to_string()));
+}
+
+struct GoalRegisterView {
+    sections: [GoalRegisterSection; 4],
+}
+
+impl GoalRegisterView {
+    fn from_records(records: Vec<GoalRecord>) -> Self {
+        let mut active = Vec::new();
+        let mut proposed = Vec::new();
+        let mut paused = Vec::new();
+        let mut completed = Vec::new();
+
+        for record in records {
+            match record.status {
+                GoalStatus::Active => active.push(record),
+                GoalStatus::Proposed => proposed.push(record),
+                GoalStatus::Paused => paused.push(record),
+                GoalStatus::Completed => completed.push(record),
+            }
+        }
+
+        Self {
+            sections: [
+                GoalRegisterSection::new(GoalStatus::Active, active),
+                GoalRegisterSection::new(GoalStatus::Proposed, proposed),
+                GoalRegisterSection::new(GoalStatus::Paused, paused),
+                GoalRegisterSection::new(GoalStatus::Completed, completed),
+            ],
+        }
+    }
+
+    fn print(&self) {
+        for section in &self.sections {
+            section.print();
+        }
+    }
+}
+
+struct GoalRegisterSection {
+    heading: &'static str,
+    label: &'static str,
+    goals: Vec<GoalRecord>,
+}
+
+impl GoalRegisterSection {
+    fn new(status: GoalStatus, mut goals: Vec<GoalRecord>) -> Self {
+        goals.sort_by(|left, right| {
+            left.priority
+                .cmp(&right.priority)
+                .then(left.title.cmp(&right.title))
+                .then(left.slug.cmp(&right.slug))
+        });
+        let (heading, label) = match status {
+            GoalStatus::Active => ("Active", "Active goals"),
+            GoalStatus::Proposed => ("Proposed", "Proposed goals"),
+            GoalStatus::Paused => ("Paused", "Paused goals"),
+            GoalStatus::Completed => ("Completed", "Completed goals"),
+        };
+
+        Self {
+            heading,
+            label,
+            goals,
+        }
+    }
+
+    fn print(&self) {
+        println!("{} count: {}", self.label, self.goals.len());
+        if self.goals.is_empty() {
+            println!("{}: <none>", self.label);
+            return;
+        }
+
+        for (index, goal) in self.goals.iter().enumerate() {
+            print_text(
+                &format!("{} goal {}", self.heading, index + 1),
+                goal.concise_label(),
+            );
+        }
+    }
 }

--- a/src/sanitization.rs
+++ b/src/sanitization.rs
@@ -11,32 +11,75 @@ pub fn objective_metadata(objective: &str) -> String {
 }
 
 pub fn sanitize_terminal_text(raw: &str) -> String {
-    redact_secret_values(&strip_ansi_sequences(raw))
+    redact_secret_values(&strip_terminal_control_sequences(raw))
 }
 
-fn strip_ansi_sequences(raw: &str) -> String {
+fn strip_terminal_control_sequences(raw: &str) -> String {
     let mut sanitized = String::with_capacity(raw.len());
     let mut chars = raw.chars().peekable();
 
     while let Some(ch) = chars.next() {
-        if ch == '\u{1b}'
-            && let Some('[') = chars.peek().copied()
-        {
-            chars.next();
-            for next in chars.by_ref() {
-                if ('@'..='~').contains(&next) {
-                    break;
+        if ch == '\u{1b}' {
+            match chars.peek().copied() {
+                Some('[') => {
+                    chars.next();
+                    for next in chars.by_ref() {
+                        if ('@'..='~').contains(&next) {
+                            break;
+                        }
+                    }
+                    continue;
                 }
+                Some(']') => {
+                    chars.next();
+                    strip_string_terminator_sequence(&mut chars);
+                    continue;
+                }
+                Some('P' | 'X' | '^' | '_') => {
+                    chars.next();
+                    strip_escape_terminated_sequence(&mut chars);
+                    continue;
+                }
+                Some(_) => {
+                    chars.next();
+                    continue;
+                }
+                None => continue,
             }
+        }
+
+        if matches!(ch, '\n' | '\t') {
+            sanitized.push(ch);
             continue;
         }
 
-        if ch != '\r' {
+        if !ch.is_control() {
             sanitized.push(ch);
         }
     }
 
     sanitized
+}
+
+fn strip_string_terminator_sequence(chars: &mut std::iter::Peekable<std::str::Chars<'_>>) {
+    while let Some(next) = chars.next() {
+        if next == '\u{7}' {
+            break;
+        }
+        if next == '\u{1b}' && matches!(chars.peek().copied(), Some('\\')) {
+            chars.next();
+            break;
+        }
+    }
+}
+
+fn strip_escape_terminated_sequence(chars: &mut std::iter::Peekable<std::str::Chars<'_>>) {
+    while let Some(next) = chars.next() {
+        if next == '\u{1b}' && matches!(chars.peek().copied(), Some('\\')) {
+            chars.next();
+            break;
+        }
+    }
 }
 
 fn redact_secret_values(raw: &str) -> String {
@@ -78,6 +121,12 @@ mod tests {
     fn terminal_sanitization_strips_ansi_sequences() {
         let raw = "\u{1b}[32mgreen\u{1b}[0m\r\nplain";
         assert_eq!(sanitize_terminal_text(raw), "green\nplain");
+    }
+
+    #[test]
+    fn terminal_sanitization_strips_osc_and_other_controls() {
+        let raw = "\u{1b}]8;;https://example.invalid\u{7}linked\u{1b}]8;;\u{7}\u{1} text";
+        assert_eq!(sanitize_terminal_text(raw), "linked text");
     }
 
     #[test]

--- a/src/sanitization.rs
+++ b/src/sanitization.rs
@@ -90,16 +90,16 @@ fn redact_secret_values(raw: &str) -> String {
 }
 
 fn redact_secret_line(line: &str) -> String {
-    if let Some((prefix, _)) = line.split_once('=') {
-        if is_sensitive_key(prefix) {
-            return format!("{prefix}=[REDACTED]");
-        }
+    if let Some((prefix, _)) = line.split_once('=')
+        && is_sensitive_key(prefix)
+    {
+        return format!("{prefix}=[REDACTED]");
     }
 
-    if let Some((prefix, _)) = line.split_once(':') {
-        if is_sensitive_key(prefix) {
-            return format!("{prefix}: [REDACTED]");
-        }
+    if let Some((prefix, _)) = line.split_once(':')
+        && is_sensitive_key(prefix)
+    {
+        return format!("{prefix}: [REDACTED]");
     }
 
     if line

--- a/src/sanitization.rs
+++ b/src/sanitization.rs
@@ -83,34 +83,61 @@ fn strip_escape_terminated_sequence(chars: &mut std::iter::Peekable<std::str::Ch
 }
 
 fn redact_secret_values(raw: &str) -> String {
-    let markers = [
-        "token",
-        "secret",
-        "password",
-        "passwd",
-        "api_key",
-        "apikey",
-        "authorization",
-        "bearer ",
-    ];
-
     raw.lines()
-        .map(|line| {
-            let lowered = line.to_ascii_lowercase();
-            if markers.iter().any(|marker| lowered.contains(marker)) {
-                if let Some((prefix, _)) = line.split_once('=') {
-                    return format!("{prefix}=[REDACTED]");
-                }
-                if let Some((prefix, _)) = line.split_once(':') {
-                    return format!("{prefix}: [REDACTED]");
-                }
-                return "[REDACTED]".to_string();
-            }
-
-            line.to_string()
-        })
+        .map(redact_secret_line)
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+fn redact_secret_line(line: &str) -> String {
+    if let Some((prefix, _)) = line.split_once('=') {
+        if is_sensitive_key(prefix) {
+            return format!("{prefix}=[REDACTED]");
+        }
+    }
+
+    if let Some((prefix, _)) = line.split_once(':') {
+        if is_sensitive_key(prefix) {
+            return format!("{prefix}: [REDACTED]");
+        }
+    }
+
+    if line
+        .trim_start()
+        .to_ascii_lowercase()
+        .starts_with("bearer ")
+    {
+        return "[REDACTED]".to_string();
+    }
+
+    line.to_string()
+}
+
+fn is_sensitive_key(prefix: &str) -> bool {
+    let normalized = prefix
+        .trim()
+        .chars()
+        .filter_map(|ch| {
+            if ch.is_ascii_alphanumeric() {
+                Some(ch.to_ascii_lowercase())
+            } else if matches!(ch, '_' | '-' | ' ') {
+                Some('_')
+            } else {
+                None
+            }
+        })
+        .collect::<String>();
+
+    matches!(
+        normalized.as_str(),
+        "token" | "secret" | "password" | "passwd" | "api_key" | "apikey" | "authorization"
+    ) || normalized.ends_with("_token")
+        || normalized.ends_with("_secret")
+        || normalized.ends_with("_password")
+        || normalized.ends_with("_passwd")
+        || normalized.ends_with("_api_key")
+        || normalized.ends_with("_apikey")
+        || normalized.ends_with("_authorization")
 }
 
 #[cfg(test)]
@@ -136,5 +163,14 @@ mod tests {
             sanitize_terminal_text(raw),
             "token=[REDACTED]\nAuthorization: [REDACTED]\nplain"
         );
+    }
+
+    #[test]
+    fn terminal_sanitization_keeps_normal_operator_text_with_security_words() {
+        let raw = "\
+State root: /tmp/simard-secret-path.12345
+Active goal 1: p1 [active] Secret scanning follow-up
+Rationale: operators need inspectable paths and titles";
+        assert_eq!(sanitize_terminal_text(raw), raw);
     }
 }

--- a/tests/simard_cli.rs
+++ b/tests/simard_cli.rs
@@ -9,6 +9,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
+use std::sync::{Mutex, OnceLock};
 use std::thread;
 use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -88,6 +89,20 @@ fn normalize_benchmark_run_output(rendered: &str) -> String {
     )
 }
 
+fn goal_curation_default_root_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+fn default_goal_curation_state_root(base_type: &str, topology: &str) -> PathBuf {
+    repo_root()
+        .join("target/operator-probe-state")
+        .join("goal-curation-run")
+        .join("simard-goal-curator")
+        .join(base_type)
+        .join(topology)
+}
+
 fn write_legacy_benchmark_report(command_dir: &Path, scenario_id: &str, session_id: &str) {
     let report_dir = command_dir
         .join("target/simard-gym")
@@ -140,7 +155,26 @@ impl TempDirGuard {
     }
 }
 
+struct CleanupDirGuard {
+    path: PathBuf,
+}
+
+impl CleanupDirGuard {
+    fn new(path: PathBuf) -> Self {
+        let _ = fs::remove_dir_all(&path);
+        Self { path }
+    }
+}
+
 impl Drop for TempDirGuard {
+    fn drop(&mut self) {
+        if self.path.exists() {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+}
+
+impl Drop for CleanupDirGuard {
     fn drop(&mut self) {
         if self.path.exists() {
             let _ = fs::remove_dir_all(&self.path);
@@ -200,6 +234,24 @@ fn bare_simard_shows_unified_help_instead_of_bootstrap_env_errors() {
     assert!(
         !rendered.contains("SIMARD_PROMPT_ROOT"),
         "bare simard should not fall back to the legacy env-only bootstrap path:\n{rendered}"
+    );
+}
+
+#[test]
+fn simard_help_documents_goal_curation_read_as_the_durable_register_inspection_surface() {
+    let output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("--help")
+        .output()
+        .expect("simard help should launch");
+    let rendered = rendered_output(&output);
+
+    assert!(
+        output.status.success(),
+        "simard help should stay readable while the durable goal register command is added:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("goal-curation read <base-type> <topology> [state-root]"),
+        "simard help should document the canonical read-only goal register workflow:\n{rendered}"
     );
 }
 
@@ -382,6 +434,343 @@ goal: Track future remote orchestration | priority=6 | status=active | rationale
     assert!(
         !goal_rendered.contains("Track future remote orchestration"),
         "goal-curation mode should omit lower-priority active goals from the top-five surface:\n{goal_rendered}"
+    );
+}
+
+#[test]
+fn simard_goal_curation_read_reuses_the_run_default_state_root_and_sanitizes_control_sequences() {
+    let _lock = goal_curation_default_root_lock()
+        .lock()
+        .expect("goal-curation default root test lock should not be poisoned");
+    let state_root = default_goal_curation_state_root("local-harness", "single-process");
+    let _cleanup = CleanupDirGuard::new(state_root.clone());
+    let goal_objective = "goal: Keep \u{1b}]8;;https://example.invalid\u{7}active\u{1b}]8;;\u{7}\u{1} priorities inspectable | priority=1 | status=active | rationale=operators need a safe register view";
+
+    let run_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("goal-curation")
+        .arg("run")
+        .arg("local-harness")
+        .arg("single-process")
+        .arg(goal_objective)
+        .output()
+        .expect("simard goal-curation run should launch with its default state root");
+    let run_rendered = rendered_output(&run_output);
+
+    assert!(
+        run_output.status.success(),
+        "goal-curation run should succeed with its canonical default state root:\n{run_rendered}"
+    );
+    assert!(
+        run_rendered.contains(&format!("State root: {}", state_root.display())),
+        "goal-curation run should surface the canonical default durable root it writes:\n{run_rendered}"
+    );
+
+    let read_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("goal-curation")
+        .arg("read")
+        .arg("local-harness")
+        .arg("single-process")
+        .output()
+        .expect("simard goal-curation read should launch with its default state root");
+    let read_rendered = rendered_output(&read_output);
+
+    assert!(
+        read_output.status.success(),
+        "goal-curation read should inspect the same canonical default durable root that run populates:\n{read_rendered}"
+    );
+    assert!(
+        read_rendered.contains(&format!("State root: {}", state_root.display())),
+        "goal-curation read should reuse the canonical default durable root from goal-curation run:\n{read_rendered}"
+    );
+    assert!(
+        read_rendered.contains("Active goals count: 1")
+            && read_rendered
+                .contains("Active goal 1: p1 [active] Keep active priorities inspectable"),
+        "goal-curation read should surface the record persisted by goal-curation run even when no explicit state root is passed:\n{read_rendered}"
+    );
+    for forbidden in ['\u{1b}', '\u{7}', '\u{1}'] {
+        assert!(
+            !read_rendered.contains(forbidden),
+            "goal-curation read should strip terminal control characters before printing persisted goal text:\n{read_rendered}"
+        );
+    }
+}
+
+#[test]
+fn simard_goal_curation_read_lists_the_durable_register_across_all_statuses() {
+    let state_root = TempDirGuard::new("simard-cli-goal-curation-read");
+    let goal_objective = "\
+goal: Keep \u{1b}[31mactive\u{1b}[0m priorities inspectable | priority=1 | status=active | rationale=operators need a safe register view\n\
+goal: Stage the next backlog slice | priority=2 | status=proposed | rationale=show backlog shape across statuses\n\
+goal: Pause brittle experiments | priority=3 | status=paused | rationale=work is blocked pending better infra\n\
+goal: Close shipped benchmark truthfulness work | priority=4 | status=completed | rationale=done work should remain inspectable\n\
+goal: Preserve operator-visible stewardship | priority=5 | status=active | rationale=active priorities still need top-five carryover";
+
+    let run_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("goal-curation")
+        .arg("run")
+        .arg("local-harness")
+        .arg("single-process")
+        .arg(goal_objective)
+        .arg(state_root.path())
+        .output()
+        .expect("simard goal-curation run should launch");
+    let run_rendered = rendered_output(&run_output);
+
+    assert!(
+        run_output.status.success(),
+        "goal-curation run should remain available for durable state setup:\n{run_rendered}"
+    );
+    assert!(
+        run_rendered.contains("Active goals count: 2"),
+        "goal-curation run should keep its shipped active-only top-five summary:\n{run_rendered}"
+    );
+    assert!(
+        !run_rendered.contains("Stage the next backlog slice"),
+        "goal-curation run should stay focused on the active top-five surface instead of becoming the inspection workflow:\n{run_rendered}"
+    );
+
+    let read_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("goal-curation")
+        .arg("read")
+        .arg("local-harness")
+        .arg("single-process")
+        .arg(state_root.path())
+        .output()
+        .expect("simard goal-curation read should launch");
+    let read_rendered = rendered_output(&read_output);
+
+    assert!(
+        read_output.status.success(),
+        "goal-curation read should expose the durable goal register through the canonical CLI:\n{read_rendered}"
+    );
+    assert!(
+        read_rendered.contains("Goal register: durable"),
+        "goal-curation read should identify the durable register it is surfacing:\n{read_rendered}"
+    );
+    assert!(
+        read_rendered.contains(&format!("State root: {}", state_root.path().display())),
+        "goal-curation read should tell operators which state root was inspected:\n{read_rendered}"
+    );
+    for expected in [
+        "Active goals count: 2",
+        "Proposed goals count: 1",
+        "Paused goals count: 1",
+        "Completed goals count: 1",
+        "Active goal 1: p1 [active] Keep active priorities inspectable",
+        "Active goal 2: p5 [active] Preserve operator-visible stewardship",
+        "Proposed goal 1: p2 [proposed] Stage the next backlog slice",
+        "Paused goal 1: p3 [paused] Pause brittle experiments",
+        "Completed goal 1: p4 [completed] Close shipped benchmark truthfulness work",
+    ] {
+        assert!(
+            read_rendered.contains(expected),
+            "goal-curation read should surface '{expected}' for operators:\n{read_rendered}"
+        );
+    }
+    assert!(
+        !read_rendered.contains('\u{1b}'),
+        "goal-curation read should sanitize persisted goal text before printing it:\n{read_rendered}"
+    );
+
+    let active_index = read_rendered
+        .find("Active goals count: 2")
+        .expect("active section should be present");
+    let proposed_index = read_rendered
+        .find("Proposed goals count: 1")
+        .expect("proposed section should be present");
+    let paused_index = read_rendered
+        .find("Paused goals count: 1")
+        .expect("paused section should be present");
+    let completed_index = read_rendered
+        .find("Completed goals count: 1")
+        .expect("completed section should be present");
+    assert!(
+        active_index < proposed_index
+            && proposed_index < paused_index
+            && paused_index < completed_index,
+        "goal-curation read should present statuses in fixed operator order active -> proposed -> paused -> completed:\n{read_rendered}"
+    );
+}
+
+#[test]
+fn simard_goal_curation_read_rejects_absolute_base_type_and_topology_segments() {
+    let absolute_base_type = repo_root().join("absolute-base-type-segment");
+    let base_type_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("goal-curation")
+        .arg("read")
+        .arg(&absolute_base_type)
+        .arg("single-process")
+        .output()
+        .expect("goal-curation read absolute-base-type check should launch");
+    let base_type_rendered = rendered_output(&base_type_output);
+
+    assert!(
+        !base_type_output.status.success(),
+        "goal-curation read must fail when an absolute base-type segment is used to derive the default state root:\n{base_type_rendered}"
+    );
+    assert!(
+        base_type_rendered.contains("no adapter is registered for base type"),
+        "goal-curation read should reject absolute base-type segments through base-type validation instead of treating them like filesystem paths:\n{base_type_rendered}"
+    );
+    assert!(
+        !base_type_rendered.contains("Goal register: durable"),
+        "goal-curation read must fail before any register rendering when the default path inputs are invalid:\n{base_type_rendered}"
+    );
+
+    let absolute_topology = repo_root().join("absolute-topology-segment");
+    let topology_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("goal-curation")
+        .arg("read")
+        .arg("local-harness")
+        .arg(&absolute_topology)
+        .output()
+        .expect("goal-curation read absolute-topology check should launch");
+    let topology_rendered = rendered_output(&topology_output);
+
+    assert!(
+        !topology_output.status.success(),
+        "goal-curation read must fail when an absolute topology segment is used to derive the default state root:\n{topology_rendered}"
+    );
+    assert!(
+        topology_rendered.contains("expected 'single-process', 'multi-process', or 'distributed'"),
+        "goal-curation read should reject absolute topology segments through topology validation instead of treating them like filesystem paths:\n{topology_rendered}"
+    );
+    assert!(
+        !topology_rendered.contains("Goal register: durable"),
+        "goal-curation read must fail before any register rendering when the default topology is invalid:\n{topology_rendered}"
+    );
+}
+
+#[test]
+fn simard_goal_curation_read_shows_explicit_zero_state_sections_for_an_empty_register() {
+    let state_root = TempDirGuard::new("simard-cli-goal-curation-read-empty");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("goal-curation")
+        .arg("read")
+        .arg("local-harness")
+        .arg("single-process")
+        .arg(state_root.path())
+        .output()
+        .expect("simard goal-curation read should launch");
+    let rendered = rendered_output(&output);
+
+    assert!(
+        output.status.success(),
+        "goal-curation read should treat a missing durable goal file as an empty register, not a crash:\n{rendered}"
+    );
+    for expected in [
+        "Goal register: durable",
+        "Active goals count: 0",
+        "Proposed goals count: 0",
+        "Paused goals count: 0",
+        "Completed goals count: 0",
+        "Active goals: <none>",
+        "Proposed goals: <none>",
+        "Paused goals: <none>",
+        "Completed goals: <none>",
+    ] {
+        assert!(
+            rendered.contains(expected),
+            "goal-curation read should make empty sections explicit with '{expected}':\n{rendered}"
+        );
+    }
+}
+
+#[test]
+fn simard_goal_curation_read_rejects_invalid_state_roots_before_any_store_access() {
+    let temp_dir = TempDirGuard::new("simard-cli-goal-curation-read-invalid-root");
+    let bad_parent_dir_root = temp_dir.path().join("../escape");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("goal-curation")
+        .arg("read")
+        .arg("local-harness")
+        .arg("single-process")
+        .arg(&bad_parent_dir_root)
+        .output()
+        .expect("goal-curation read invalid-state-root check should launch");
+    let rendered = rendered_output(&output);
+
+    assert!(
+        !output.status.success(),
+        "goal-curation read must fail visibly for invalid state roots:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("must not contain '..'"),
+        "goal-curation read should explain why a traversal root was rejected:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("InvalidStateRoot") || rendered.contains("invalid state root"),
+        "goal-curation read should keep state-root validation explicit:\n{rendered}"
+    );
+}
+
+#[test]
+fn simard_goal_curation_read_fails_closed_for_malformed_goal_store_contents() {
+    let state_root = TempDirGuard::new("simard-cli-goal-curation-read-malformed-store");
+    fs::write(
+        state_root.path().join("goal_records.json"),
+        "{ not-valid-json",
+    )
+    .expect("malformed goal store fixture should be written");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("goal-curation")
+        .arg("read")
+        .arg("local-harness")
+        .arg("single-process")
+        .arg(state_root.path())
+        .output()
+        .expect("goal-curation read malformed-store check should launch");
+    let rendered = rendered_output(&output);
+
+    assert!(
+        !output.status.success(),
+        "goal-curation read must fail closed when the durable goal store is malformed:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("persistent store 'goals' failed during 'deserialize'"),
+        "goal-curation read should surface the durable store boundary instead of silently pretending the register is empty:\n{rendered}"
+    );
+    assert!(
+        !rendered.contains("Active goals count: 0"),
+        "goal-curation read should not quietly degrade malformed state into an empty success:\n{rendered}"
+    );
+}
+
+#[test]
+fn simard_goal_curation_read_sanitizes_explicit_runtime_labels_before_printing() {
+    let state_root = TempDirGuard::new("simard-cli-goal-curation-read-sanitized-labels");
+    let base_type = "local-harness\u{1b}[31m-injected";
+    let topology = "single-process\u{1b}]8;;https://example.invalid\u{7}-linked\u{1b}]8;;\u{7}";
+
+    let output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("goal-curation")
+        .arg("read")
+        .arg(base_type)
+        .arg(topology)
+        .arg(state_root.path())
+        .output()
+        .expect("goal-curation read sanitization check should launch");
+    let rendered = rendered_output(&output);
+
+    assert!(
+        output.status.success(),
+        "goal-curation read should still succeed with an explicit state root while sanitizing operator-visible labels:\n{rendered}"
+    );
+    assert!(
+        !rendered.contains('\u{1b}'),
+        "goal-curation read should strip terminal control sequences from explicit runtime labels:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("Selected base type: local-harness-injected"),
+        "goal-curation read should sanitize the base-type label before printing it:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("Topology: single-process-linked"),
+        "goal-curation read should sanitize the topology label before printing it:\n{rendered}"
     );
 }
 
@@ -886,9 +1275,8 @@ fn simard_gym_rejects_unregistered_scenarios_before_accessing_artifacts() {
             "gym {subcommand} must reject unregistered scenario ids visibly:\n{rendered}"
         );
         assert!(
-            rendered.contains("BenchmarkScenarioNotFound")
-                && rendered.contains("../repo-exploration-local"),
-            "gym {subcommand} should reject invalid scenario ids with an explicit registry lookup failure:\n{rendered}"
+            rendered.contains("benchmark scenario '../repo-exploration-local' is not registered"),
+            "gym {subcommand} should reject invalid scenario ids with the restored single-line operator-facing error contract:\n{rendered}"
         );
     }
 

--- a/tests/simard_cli.rs
+++ b/tests/simard_cli.rs
@@ -594,6 +594,55 @@ goal: Preserve operator-visible stewardship | priority=5 | status=active | ratio
 }
 
 #[test]
+fn simard_goal_curation_read_keeps_operator_visible_paths_and_titles_with_security_words() {
+    let state_root = TempDirGuard::new("simard-cli-goal-curation-read-secret");
+    let goal_objective = "goal: Secret scanning follow-up | priority=1 | status=active | rationale=operators still need readable titles and paths";
+
+    let run_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("goal-curation")
+        .arg("run")
+        .arg("local-harness")
+        .arg("single-process")
+        .arg(goal_objective)
+        .arg(state_root.path())
+        .output()
+        .expect("simard goal-curation run should launch");
+    let run_rendered = rendered_output(&run_output);
+
+    assert!(
+        run_output.status.success(),
+        "goal-curation run should succeed when goal text contains routine security vocabulary:\n{run_rendered}"
+    );
+
+    let read_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("goal-curation")
+        .arg("read")
+        .arg("local-harness")
+        .arg("single-process")
+        .arg(state_root.path())
+        .output()
+        .expect("simard goal-curation read should launch");
+    let read_rendered = rendered_output(&read_output);
+
+    assert!(
+        read_output.status.success(),
+        "goal-curation read should still succeed when operator-visible text contains routine security vocabulary:\n{read_rendered}"
+    );
+    assert!(
+        read_rendered.contains(&format!("State root: {}", state_root.path().display())),
+        "goal-curation read should keep the inspected state root visible even when the path contains 'secret':\n{read_rendered}"
+    );
+    assert!(
+        read_rendered.contains("Active goal 1: p1 [active] Secret scanning follow-up"),
+        "goal-curation read should not redact ordinary goal titles that happen to contain the word 'secret':\n{read_rendered}"
+    );
+    assert!(
+        !read_rendered.contains("[REDACTED]"),
+        "goal-curation read should reserve redaction for actual secret-bearing fields, not normal operator data:\n{read_rendered}"
+    );
+}
+
+#[test]
 fn simard_goal_curation_read_rejects_absolute_base_type_and_topology_segments() {
     let absolute_base_type = repo_root().join("absolute-base-type-segment");
     let base_type_output = Command::new(env!("CARGO_BIN_EXE_simard"))


### PR DESCRIPTION
## Summary
- add `goal-curation read` to the unified operator CLI and document how to inspect the durable goal register
- reuse the existing durable goal store while sanitizing operator-visible runtime labels on the read path
- cover empty, malformed, invalid-root, canonical-root, and sanitized-output cases in the CLI suite

## Testing
- cargo test --quiet