### PR TITLE
Add operator state read commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "simard"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simard"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 default-run = "simard"
 

--- a/docs/howto/inspect-improvement-curation-state.md
+++ b/docs/howto/inspect-improvement-curation-state.md
@@ -1,0 +1,164 @@
+---
+title: How to inspect improvement-curation state
+description: Use `simard improvement-curation read` to inspect the latest review-driven priority decisions without mutating stored state.
+last_updated: 2026-03-30
+review_schedule: as-needed
+owner: simard
+doc_type: howto
+related:
+  - ../index.md
+  - ../reference/simard-cli.md
+  - ../reference/runtime-contracts.md
+  - ../tutorials/run-your-first-local-session.md
+  - ./inspect-durable-goal-register.md
+---
+
+# How to inspect improvement-curation state
+
+This guide shows how to use `simard improvement-curation read <base-type> <topology> [state-root]` as the read-only audit companion to `improvement-curation run`.
+
+## Prerequisites
+
+- [ ] You are in the repository root
+- [ ] `cargo run --quiet -- ...` works locally
+- [ ] You are willing to use one explicit state root for `review run`, `improvement-curation run`, and `improvement-curation read`
+
+## 1. Pick one explicit state root
+
+The read workflow only sees durable state stored under the selected root.
+
+```bash
+STATE_ROOT="$(mktemp -d /tmp/simard-improvement-curation.XXXXXX)"
+```
+
+Keep that shell variable for the rest of this guide.
+
+## 2. Persist a real review artifact first
+
+`improvement-curation read` is intentionally not a synthetic report. It reads real persisted review state plus the later improvement decision state built on top of it.
+
+```bash
+cargo run --quiet -- \
+  review run local-harness single-process \
+  "inspect the current Simard review surface and preserve concrete proposals" \
+  "$STATE_ROOT"
+```
+
+Look for output like this:
+
+```text
+Probe mode: review-run
+Review proposals: 2
+Review artifact: ...
+```
+
+## 3. Approve one proposal and defer one proposal
+
+Curate the review findings through the public CLI before you try to read them back.
+
+```bash
+cargo run --quiet -- \
+  improvement-curation run local-harness single-process \
+  "$(cat <<'EOF'
+approve: Capture denser execution evidence | priority=1 | status=active | rationale=operators need denser execution evidence now
+defer: Promote this pattern into a repeatable benchmark | rationale=hold this until the next benchmark planning pass
+EOF
+)" \
+  "$STATE_ROOT"
+```
+
+Look for:
+
+- `Identity: simard-improvement-curator`
+- `Approved proposals: 1`
+- `Deferred proposals: 1`
+- `Active goals count: 1`
+- `Active goal 1: p1 [active] Capture denser execution evidence`
+
+That mutation path is still the only place where approval and deferral decisions are made. The dedicated read workflow below is audit-only.
+
+## 4. Read the durable improvement-curation state
+
+```bash
+cargo run --quiet -- \
+  improvement-curation read local-harness single-process "$STATE_ROOT"
+```
+
+Expected output shape:
+
+```text
+Probe mode: improvement-curation-read
+Identity: simard-improvement-curator
+Selected base type: local-harness
+Topology: single-process
+State root: /tmp/simard-improvement-curation.XXXXXX
+Latest review artifact: /tmp/simard-improvement-curation.XXXXXX/review_artifacts/review-....json
+Review id: review-...
+Review target: operator-review
+Review proposals: 2
+Approved proposals: 1
+Approved proposal 1: p1 [active] Capture denser execution evidence
+Deferred proposals: 1
+Deferred proposal 1: Promote this pattern into a repeatable benchmark (hold this until the next benchmark planning pass)
+Active goals count: 1
+Active goal 1: p1 [active] Capture denser execution evidence
+Proposed goals count: 0
+Proposed goals: <none>
+Latest improvement record: review=review-... target=operator-review approvals=[p1 [active] Capture denser execution evidence] deferred=[Promote this pattern into a repeatable benchmark (hold this until the next benchmark planning pass)]
+```
+
+The important contract is structural:
+
+- the command is read-only
+- it reads the latest persisted review artifact from the same validated `state-root`, where "latest" means the artifact with the highest `reviewed_at_unix_ms`
+- it reads the latest persisted improvement decision record from that same root, where "latest" means the last decision memory record whose key ends with `improvement-curation-record`
+- sections always appear in this order: latest review metadata, approved proposals, deferred proposals, active goals, proposed goals, latest improvement record
+- empty approved, deferred, active-goal, or proposed-goal sections render explicit `0` and `<none>` lines instead of disappearing
+- persisted proposal titles, rationales, goal text, and decision records are sanitized before printing so stored terminal control sequences are not replayed
+- when `[state-root]` is omitted, the command reuses the same canonical durable root that `review run` and `improvement-curation run` use for the validated runtime pairing
+
+## 5. Configuration rules that matter
+
+For predictable future improvement-state inspection, keep these rules in mind:
+
+- pass the exact same explicit `state-root` you used for earlier `review run` and `improvement-curation run` activity when you want to inspect that stored decision state
+- if you omit `[state-root]`, keep the same shipped `base-type` and `topology` pairing you used for `review run` or `improvement-curation run` so Simard resolves the same canonical durable root
+- the canonical default root for the shared review/improvement state is `target/operator-probe-state/review-run/simard-engineer/<base-type>/<topology>`
+- use `improvement-curation run` when you want to approve or defer proposals
+- use `improvement-curation read` when you want a read-only operator summary of the latest decisions and promoted goals
+- expect invalid `state-root` values, missing review artifacts, missing improvement records, unreadable storage, and malformed decision data to fail explicitly rather than silently rendering a partial report
+
+## 6. Troubleshoot the common failure shapes
+
+### The command fails because no persisted review artifact exists
+
+That usually means one of these is true:
+
+- you passed a different `STATE_ROOT` than the one used for `review run`
+- the selected state root is valid but no review artifact was persisted there yet
+- you expected the command to synthesize review context from goal state alone
+
+Fix the durable state first by running `review run` against the same root.
+
+### The command fails because no persisted improvement record exists
+
+That means no improvement-curation decision has been written under the selected root yet, or you are looking at the wrong durable state.
+
+Run `improvement-curation run` first, then use the read command against the same root.
+
+### The command prints no proposed goals
+
+That is fine when the approved proposals were promoted as `active` priorities instead of `proposed` priorities. `improvement-curation read` should still print:
+
+- `Proposed goals count: 0`
+- `Proposed goals: <none>`
+
+### The command fails instead of printing a summary
+
+That is the intended contract for invalid or unreadable operator state. Fix the selected `state-root` or the underlying storage rather than assuming Simard should guess.
+
+## Related reading
+
+- For the exact command tree and example syntax, see [Simard CLI reference](../reference/simard-cli.md).
+- For the executable contract behind the read and run paths, see [Runtime contracts reference](../reference/runtime-contracts.md).
+- For the wider tutorial flow that also exercises engineer, meeting, goal-curation, and bootstrap modes, see [Tutorial: Run your first local session](../tutorials/run-your-first-local-session.md).

--- a/docs/howto/inspect-meeting-records.md
+++ b/docs/howto/inspect-meeting-records.md
@@ -1,0 +1,132 @@
+---
+title: How to inspect meeting records
+description: Use `simard meeting read` to inspect the latest durable meeting record without mutating stored planning state.
+last_updated: 2026-03-30
+review_schedule: as-needed
+owner: simard
+doc_type: howto
+related:
+  - ../index.md
+  - ../reference/simard-cli.md
+  - ../reference/runtime-contracts.md
+  - ../tutorials/run-your-first-local-session.md
+  - ./carry-meeting-decisions-into-engineer-sessions.md
+---
+
+# How to inspect meeting records
+
+This guide shows how to use `simard meeting read <base-type> <topology> [state-root]` as the read-only audit companion to `meeting run`.
+
+## Prerequisites
+
+- [ ] You are in the repository root
+- [ ] `cargo run --quiet -- ...` works locally
+- [ ] You are willing to use one explicit state root for `meeting run` and `meeting read`
+
+## 1. Pick one explicit state root
+
+```bash
+STATE_ROOT="$(mktemp -d /tmp/simard-meeting-read.XXXXXX)"
+```
+
+Keep that shell variable for the rest of this guide.
+
+## 2. Persist a real meeting record first
+
+```bash
+MEETING_OBJECTIVE="$(cat <<'EOF'
+agenda: align the next Simard workstream
+update: durable memory foundation merged in PR 29
+decision: preserve meeting-to-engineer continuity
+risk: workflow routing is still unreliable
+next-step: keep durable priorities visible
+open-question: how aggressively should Simard reprioritize?
+goal: Preserve meeting handoff | priority=1 | status=active | rationale=meeting decisions must shape later work
+EOF
+)"
+
+cargo run --quiet -- \
+  meeting run local-harness single-process \
+  "$MEETING_OBJECTIVE" \
+  "$STATE_ROOT"
+```
+
+Look for output like:
+
+```text
+Identity: simard-meeting
+Decision records: 1
+Active goals count: 1
+Active goal 1: p1 [active] Preserve meeting handoff
+```
+
+## 3. Read the latest durable meeting record
+
+```bash
+cargo run --quiet -- \
+  meeting read local-harness single-process "$STATE_ROOT"
+```
+
+Expected output shape:
+
+```text
+Probe mode: meeting-read
+Identity: simard-meeting
+Selected base type: local-harness
+Topology: single-process
+State root: /tmp/simard-meeting-read.XXXXXX
+Meeting records: 1
+Latest agenda: align the next Simard workstream
+Updates count: 1
+Update 1: durable memory foundation merged in PR 29
+Decisions count: 1
+Decision 1: preserve meeting-to-engineer continuity
+Risks count: 1
+Risk 1: workflow routing is still unreliable
+Next steps count: 1
+Next step 1: keep durable priorities visible
+Open questions count: 1
+Open question 1: how aggressively should Simard reprioritize?
+Goal updates count: 1
+Goal update 1: p1 [active] Preserve meeting handoff
+Latest meeting record: agenda=align the next Simard workstream; ...
+```
+
+The important contract is structural:
+
+- the command is read-only
+- it reads the latest persisted meeting decision record from the selected validated `state-root`
+- sections always appear in this order: agenda, updates, decisions, risks, next steps, open questions, goal updates, latest raw meeting record
+- empty sections render explicit `0` and `<none>` lines instead of disappearing
+- persisted meeting text is sanitized before printing so stored terminal control sequences are not replayed
+- when `[state-root]` is omitted, the command reuses the same canonical durable root that `meeting run` writes for the validated runtime pairing
+
+## 4. Configuration rules that matter
+
+- pass the exact same explicit `state-root` you used for `meeting run` when you want to inspect that stored planning record later
+- if you omit `[state-root]`, keep the same shipped `base-type` and `topology` pairing you used for `meeting run` so Simard resolves the same canonical durable root
+- use `meeting run` when you want to capture new durable planning state
+- use `meeting read` when you want to inspect the latest durable meeting state without mutating it
+- expect invalid `state-root` values, missing memory state, and malformed persisted meeting records to fail explicitly rather than silently rendering a synthetic summary
+
+## 5. Troubleshoot the common failure shapes
+
+### The command fails because no persisted meeting record exists
+
+That usually means one of these is true:
+
+- you passed a different `STATE_ROOT` than the one used for `meeting run`
+- the selected state root is valid but no meeting record was persisted there yet
+- you expected Simard to synthesize meeting state from current goals alone
+
+Run `meeting run` first against the same root, then use `meeting read`.
+
+### The command fails before any record is printed
+
+That is the intended contract for invalid or unreadable operator state. Fix the selected `state-root` or the underlying storage rather than assuming Simard should guess.
+
+## Related reading
+
+- For the exact command tree and example syntax, see [Simard CLI reference](../reference/simard-cli.md).
+- For the executable contract behind the read and run paths, see [Runtime contracts reference](../reference/runtime-contracts.md).
+- For the wider learning flow that also exercises engineer, goal-curation, review, and improvement-curation modes, see [Tutorial: Run your first local session](../tutorials/run-your-first-local-session.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,8 @@ The shipped command tree covers `engineer`, `meeting`, `goal-curation`, `improve
 - [Tutorial: Run your first benchmark gym suite](./tutorials/run-your-first-benchmark-gym.md) - Run the shipped starter benchmark suite.
 - [How to configure bootstrap and inspect reflection](./howto/configure-bootstrap-and-inspect-reflection.md) - Bootstrap an explicit runtime selection and inspect the truthful runtime snapshot.
 - [How to carry meeting decisions into engineer sessions](./howto/carry-meeting-decisions-into-engineer-sessions.md) - Persist meeting records under a shared state root and confirm later engineer runs carry them forward.
+- [How to inspect meeting records](./howto/inspect-meeting-records.md) - Read back the latest durable meeting record without mutating stored state.
+- [How to inspect improvement-curation state](./howto/inspect-improvement-curation-state.md) - Read back the latest approved, deferred, and promoted improvement state without mutation.
 - [Simard CLI reference](./reference/simard-cli.md) - Look up the shipped command tree and compatibility mappings.
 - [Runtime contracts reference](./reference/runtime-contracts.md) - Look up executable contracts and lifecycle guarantees.
 - [Concept: truthful runtime metadata](./concepts/truthful-runtime-metadata.md) - Read the design rationale behind the stricter runtime contract.

--- a/docs/reference/runtime-contracts.md
+++ b/docs/reference/runtime-contracts.md
@@ -8,6 +8,8 @@ doc_type: reference
 related:
   - ../index.md
   - ./simard-cli.md
+  - ../howto/inspect-meeting-records.md
+  - ../howto/inspect-improvement-curation-state.md
   - ../howto/configure-bootstrap-and-inspect-reflection.md
   - ../tutorials/run-your-first-local-session.md
 ---
@@ -34,8 +36,11 @@ Simard does **not** expose:
 | bounded engineer loop | `simard engineer run ...` | `simard_operator_probe engineer-loop-run ...` |
 | terminal-backed engineer substrate | `simard engineer terminal ...` | `simard_operator_probe terminal-run ...` |
 | meeting mode | `simard meeting run ...` | `simard_operator_probe meeting-run ...` |
+| meeting state readback | `simard meeting read ...` | `simard_operator_probe meeting-read ...` |
 | goal-curation mode | `simard goal-curation run ...` | `simard_operator_probe goal-curation-run ...` |
+| goal-curation state readback | `simard goal-curation read ...` | none |
 | improvement-curation mode | `simard improvement-curation run ...` | `simard_operator_probe improvement-curation-run ...` |
+| improvement-curation state readback | `simard improvement-curation read ...` | `simard_operator_probe improvement-curation-read ...` |
 | review artifact persistence and readback | `simard review ...` | `simard_operator_probe review-run ...` and `review-read ...` |
 | benchmark scenarios and suites | `simard gym ...` | `simard-gym ...` |
 
@@ -46,8 +51,11 @@ The shipped operator-facing command tree is:
 - `simard engineer run <topology> <workspace-root> <objective> [state-root]`
 - `simard engineer terminal <topology> <objective> [state-root]`
 - `simard meeting run <base-type> <topology> <structured-objective> [state-root]`
+- `simard meeting read <base-type> <topology> [state-root]`
 - `simard goal-curation run <base-type> <topology> <structured-objective> [state-root]`
+- `simard goal-curation read <base-type> <topology> [state-root]`
 - `simard improvement-curation run <base-type> <topology> <structured-objective> [state-root]`
+- `simard improvement-curation read <base-type> <topology> [state-root]`
 - `simard gym list`
 - `simard gym run <scenario-id>`
 - `simard gym compare <scenario-id>`
@@ -118,9 +126,12 @@ This substrate exposes the real `terminal-shell` base type on the primary CLI:
 
 ### Meeting mode
 
-Canonical entrypoint: `simard meeting run <base-type> <topology> <structured-objective> [state-root]`
+Canonical entrypoints:
 
-Compatibility surface: `simard_operator_probe meeting-run <base-type> <topology> <structured-objective> [state-root]`
+- `simard meeting run <base-type> <topology> <structured-objective> [state-root]`
+- `simard meeting read <base-type> <topology> [state-root]`
+
+Compatibility surface: `simard_operator_probe meeting-run ...` and `simard_operator_probe meeting-read ...`
 
 Meeting mode persists concise durable planning data without touching repository contents. Structured lines may include:
 
@@ -132,21 +143,52 @@ Meeting mode persists concise durable planning data without touching repository 
 - `open-question: ...`
 - `goal: title | priority=1 | status=active | rationale=...`
 
+The shipped contract is intentionally explicit:
+
+- `meeting run` remains the only mutation path for agenda, update, decision, risk, next-step, open-question, and goal-update capture
+- `meeting read` is the read-only audit surface for the latest persisted meeting decision state
+- both commands reuse the same validated state root, and both default to the same canonical durable root for `simard-meeting`
+- `meeting read` loads the latest persisted meeting decision record, where "latest" means the last decision memory record whose value matches the shipped meeting record shape
+- `meeting read` renders agenda, updates, decisions, risks, next steps, open questions, goal updates, and the latest raw meeting record in a stable operator-visible order
+- operator-visible strings are sanitized before printing so persisted terminal control sequences are not replayed
+- invalid state roots, missing memory state, unreadable storage, and malformed persisted meeting data fail explicitly
+
 ### Goal-curation mode
 
-Canonical entrypoint: `simard goal-curation run <base-type> <topology> <structured-objective> [state-root]`
+Canonical entrypoints:
+
+- `simard goal-curation run <base-type> <topology> <structured-objective> [state-root]`
+- `simard goal-curation read <base-type> <topology> [state-root]`
 
 Compatibility surface: `simard_operator_probe goal-curation-run <base-type> <topology> <structured-objective> [state-root]`
 
-Goal-curation mode maintains durable backlog records and the active top five goals.
+Goal-curation mode maintains durable backlog records and the active top five goals. The readback command exposes the stored goal register from the same validated state root without mutating it.
 
 ### Improvement-curation mode
 
-Canonical entrypoint: `simard improvement-curation run <base-type> <topology> <structured-objective> [state-root]`
+Canonical entrypoints:
 
-Compatibility surface: `simard_operator_probe improvement-curation-run <base-type> <topology> <structured-objective> [state-root]`
+- `simard improvement-curation run <base-type> <topology> <structured-objective> [state-root]`
+- `simard improvement-curation read <base-type> <topology> [state-root]`
 
-Improvement-curation mode promotes approved review proposals into durable priorities.
+Compatibility surface: `simard_operator_probe improvement-curation-run ...` and `simard_operator_probe improvement-curation-read ...`
+
+Improvement-curation mode promotes approved review proposals into durable priorities and keeps deferred proposals inspectable instead of silently self-modifying.
+
+The shipped contract is intentionally explicit:
+
+- `improvement-curation run` remains the only mutation path for approving or deferring proposals
+- `improvement-curation read` is the read-only audit surface for the latest review-to-priority promotion state
+- both commands reuse the same validated state root, and both default to the same canonical durable root as `review run`
+- `improvement-curation read` loads the latest persisted review artifact, where "latest" means the artifact with the highest `reviewed_at_unix_ms`
+- `improvement-curation read` loads the latest persisted improvement decision record, where "latest" means the last decision memory record whose key ends with `improvement-curation-record`
+- `improvement-curation read` renders approved proposals, deferred proposals, active goals, proposed goals, and the latest improvement decision record in a stable operator-visible order
+- operator-visible strings are sanitized before printing so persisted terminal control sequences are not replayed
+- invalid state roots, missing review artifacts, missing improvement records, unreadable storage, and malformed persisted decision data fail explicitly
+
+```text
+target/operator-probe-state/review-run/simard-engineer/<base-type>/<topology>
+```
 
 ### Review mode
 
@@ -229,6 +271,7 @@ That shared state root is what allows:
 - carried meeting decisions to appear in later engineer runs
 - durable goals to stay visible across operator modes
 - review artifacts to feed improvement-curation
+- improvement-curation decisions to stay durable and remain auditable through the shipped `improvement-curation read` surface
 
 The contract depends on passing the same validated state root across commands, not on hidden global state.
 

--- a/docs/reference/simard-cli.md
+++ b/docs/reference/simard-cli.md
@@ -8,7 +8,9 @@ doc_type: reference
 related:
   - ../index.md
   - ./runtime-contracts.md
+  - ../howto/inspect-meeting-records.md
   - ../howto/inspect-durable-goal-register.md
+  - ../howto/inspect-improvement-curation-state.md
   - ../howto/configure-bootstrap-and-inspect-reflection.md
   - ../howto/carry-meeting-decisions-into-engineer-sessions.md
   - ../tutorials/run-your-first-local-session.md
@@ -30,12 +32,14 @@ simard
 |  |- run <topology> <workspace-root> <objective> [state-root]
 |  `- terminal <topology> <objective> [state-root]
 |- meeting
-|  `- run <base-type> <topology> <structured-objective> [state-root]
+|  |- run <base-type> <topology> <structured-objective> [state-root]
+|  `- read <base-type> <topology> [state-root]
 |- goal-curation
 |  |- run <base-type> <topology> <structured-objective> [state-root]
 |  `- read <base-type> <topology> [state-root]
 |- improvement-curation
-|  `- run <base-type> <topology> <structured-objective> [state-root]
+|  |- run <base-type> <topology> <structured-objective> [state-root]
+|  `- read <base-type> <topology> [state-root]
 |- gym
 |  |- list
 |  |- run <scenario-id>
@@ -57,9 +61,11 @@ Bare `simard` prints this unified help surface.
 | `simard engineer run ...` | `simard_operator_probe engineer-loop-run ...` |
 | `simard engineer terminal ...` | `simard_operator_probe terminal-run ...` |
 | `simard meeting run ...` | `simard_operator_probe meeting-run ...` |
+| `simard meeting read ...` | `simard_operator_probe meeting-read ...` |
 | `simard goal-curation run ...` | `simard_operator_probe goal-curation-run ...` |
 | `simard goal-curation read ...` | none |
 | `simard improvement-curation run ...` | `simard_operator_probe improvement-curation-run ...` |
+| `simard improvement-curation read ...` | `simard_operator_probe improvement-curation-read ...` |
 | `simard review run ...` | `simard_operator_probe review-run ...` |
 | `simard review read ...` | `simard_operator_probe review-read ...` |
 | `simard bootstrap run ...` | `simard_operator_probe bootstrap-run ...` |
@@ -155,6 +161,53 @@ EOF2
 simard meeting run local-harness single-process "$MEETING_OBJECTIVE" "$STATE_ROOT"
 ```
 
+### `simard meeting read <base-type> <topology> [state-root]`
+
+Reads the latest durable meeting record without mutating it.
+
+Key behavior:
+
+- loads the latest persisted meeting decision record from the validated `state-root`
+- reuses the same canonical default durable root as `meeting run` when `[state-root]` is omitted
+- validates `base-type` and `topology` before deriving that default root
+- requires explicit read-layout inputs before probing: the state root itself must already exist as a directory and `memory_records.json` must already be present
+- prints sections in this fixed order: latest agenda, updates, decisions, risks, next steps, open questions, goal updates, latest meeting record
+- includes explicit zero-state lines for empty update, decision, risk, next-step, open-question, and goal-update sections
+- strips terminal control sequences from persisted meeting text before printing it
+- preserves `meeting run` as the only meeting-state mutation workflow
+- fails explicitly for invalid `state-root` values and for missing, unreadable, or malformed persisted meeting state
+
+Example:
+
+```bash
+simard meeting read local-harness single-process "$STATE_ROOT"
+```
+
+Output shape:
+
+```text
+Probe mode: meeting-read
+Identity: simard-meeting
+Selected base type: local-harness
+Topology: single-process
+State root: /tmp/simard-meeting.XXXXXX
+Meeting records: 1
+Latest agenda: align the next Simard workstream
+Updates count: 1
+Update 1: durable memory foundation merged in PR 29
+Decisions count: 1
+Decision 1: preserve meeting-to-engineer continuity
+Risks count: 1
+Risk 1: workflow routing is still unreliable
+Next steps count: 1
+Next step 1: keep durable priorities visible
+Open questions count: 1
+Open question 1: how aggressively should Simard reprioritize?
+Goal updates count: 1
+Goal update 1: p1 [active] Preserve meeting handoff
+Latest meeting record: agenda=align the next Simard workstream; ...
+```
+
 ### `simard goal-curation run <base-type> <topology> <structured-objective> [state-root]`
 
 Maintains durable backlog records and the active top five goals.
@@ -227,6 +280,70 @@ Example:
 
 ```bash
 simard improvement-curation run local-harness single-process   "approve: Capture denser execution evidence | priority=1 | status=active | rationale=operators need denser execution evidence now"   "$STATE_ROOT"
+```
+
+When `[state-root]` is omitted, `improvement-curation run` reuses the same canonical durable root that `review run` uses for the validated runtime pairing:
+
+```text
+target/operator-probe-state/review-run/simard-engineer/<base-type>/<topology>
+```
+
+### `simard improvement-curation read <base-type> <topology> [state-root]`
+
+Reads the latest durable improvement-curation state without mutating it.
+
+Key behavior:
+
+- loads the latest persisted review artifact from the validated `state-root`, where "latest" means the review artifact with the highest `reviewed_at_unix_ms`
+- loads the latest persisted improvement-curation decision record from the same root, where "latest" means the last decision memory record whose key ends with `improvement-curation-record`
+- reuses the same canonical default durable root as `review run` and `improvement-curation run` when `[state-root]` is omitted
+- validates `base-type` and `topology` before deriving that default root
+- requires explicit read-layout inputs before probing: the state root itself must already exist as a directory, `review-artifacts/` must exist, and both `memory_records.json` and `goal_records.json` must already be present
+- prints sections in this fixed order: latest review metadata, approved proposals, deferred proposals, active goals, proposed goals, latest improvement record
+- includes explicit zero-state lines for empty approved, deferred, active-goal, and proposed-goal sections
+- strips terminal control sequences from persisted proposal titles, rationales, goal text, review metadata, and decision records before printing them
+- preserves `improvement-curation run` as the only curation workflow
+- fails explicitly for invalid `state-root` values and for missing, unreadable, or malformed persisted review or improvement state
+
+Example:
+
+```bash
+simard review run local-harness single-process \
+  "inspect the current Simard review surface and preserve concrete proposals" \
+  "$STATE_ROOT"
+
+simard improvement-curation run local-harness single-process \
+  "$(cat <<'EOF'
+approve: Capture denser execution evidence | priority=1 | status=active | rationale=operators need denser execution evidence now
+defer: Promote this pattern into a repeatable benchmark | rationale=hold this until the next benchmark planning pass
+EOF
+)" \
+  "$STATE_ROOT"
+
+simard improvement-curation read local-harness single-process "$STATE_ROOT"
+```
+
+Output shape:
+
+```text
+Probe mode: improvement-curation-read
+Identity: simard-improvement-curator
+Selected base type: local-harness
+Topology: single-process
+State root: /tmp/simard-improvement-curation.XXXXXX
+Latest review artifact: /tmp/simard-improvement-curation.XXXXXX/review_artifacts/review-....json
+Review id: review-...
+Review target: operator-review
+Review proposals: 2
+Approved proposals: 1
+Approved proposal 1: p1 [active] Capture denser execution evidence
+Deferred proposals: 1
+Deferred proposal 1: Promote this pattern into a repeatable benchmark (hold this until the next benchmark planning pass)
+Active goals count: 1
+Active goal 1: p1 [active] Capture denser execution evidence
+Proposed goals count: 0
+Proposed goals: <none>
+Latest improvement record: review=review-... target=operator-review approvals=[p1 [active] Capture denser execution evidence] deferred=[Promote this pattern into a repeatable benchmark (hold this until the next benchmark planning pass)]
 ```
 
 ### `simard gym list`
@@ -402,5 +519,6 @@ Simard fails explicitly for these common operator-facing cases:
 - unsupported base type for the selected identity
 - unsupported topology for the selected base type
 - missing or invalid workspace root
+- missing persisted review state for `review read`
 - nested-worktree or repo-root drift detected during engineer-mode execution
 - structured edit requested on a dirty repo

--- a/docs/tutorials/run-your-first-local-session.md
+++ b/docs/tutorials/run-your-first-local-session.md
@@ -10,6 +10,7 @@ related:
   - ../reference/simard-cli.md
   - ../reference/runtime-contracts.md
   - ../howto/carry-meeting-decisions-into-engineer-sessions.md
+  - ../howto/inspect-meeting-records.md
   - ../howto/configure-bootstrap-and-inspect-reflection.md
 ---
 
@@ -29,7 +30,7 @@ Today:
 
 - how to run the bounded engineer loop against a local repo
 - how meeting mode carries durable decision context into later engineer runs
-- how goal curation and improvement curation reuse the same durable state root
+- how goal curation, review, and improvement curation reuse explicit durable state roots
 - how bootstrap and benchmark flows fit into the same operator-facing CLI story
 
 ## Prerequisites
@@ -100,6 +101,20 @@ Active goal 1: p1 [active] Preserve meeting handoff
 
 **Checkpoint**: the meeting run persisted one concise decision record and durable goal updates, but it did not mutate the repository.
 
+If you want to inspect the stored meeting state directly before moving on, run:
+
+```bash
+cargo run --quiet -- \
+  meeting read local-harness single-process "$STATE_ROOT"
+```
+
+Look for:
+
+- `Probe mode: meeting-read`
+- `Latest agenda: align the next Simard workstream`
+- `Decision 1: preserve meeting-to-engineer continuity`
+- `Goal update 1: p1 [active] Preserve meeting handoff`
+
 ## Step 4: Re-run engineer mode and confirm carryover
 
 Use the same repo and the same state root again.
@@ -140,7 +155,7 @@ Look for:
 
 **Checkpoint**: durable backlog stewardship is its own operator-visible mode, not an engineer-loop side effect.
 
-## Step 6: Generate a review artifact and promote one approved improvement
+## Step 6: Generate a review artifact, curate one approval and one deferral, then read the stored improvement state
 
 First persist the latest review artifact:
 
@@ -153,7 +168,7 @@ Then curate explicit approvals into durable priorities:
 ```bash
 cargo run --quiet --   improvement-curation run local-harness single-process   "$(cat <<'EOF'
 approve: Capture denser execution evidence | priority=1 | status=active | rationale=operators need denser execution evidence now
-approve: Promote this pattern into a repeatable benchmark | priority=2 | status=proposed | rationale=carry this into the next benchmark planning pass
+defer: Promote this pattern into a repeatable benchmark | rationale=hold this until the next benchmark planning pass
 EOF
 )"   "$STATE_ROOT"
 ```
@@ -161,11 +176,25 @@ EOF
 Look for:
 
 - `Identity: simard-improvement-curator`
-- `Approved proposals: 2`
+- `Approved proposals: 1`
+- `Deferred proposals: 1`
 - `Active goal 1: p1 [active] Capture denser execution evidence`
-- `Proposed goal 1: p2 [proposed] Promote this pattern into a repeatable benchmark`
 
-**Checkpoint**: reviewed evidence is now feeding durable priorities through the same runtime contract the CLI exposes elsewhere.
+**Checkpoint**: reviewed evidence is now feeding durable priorities, and deferred proposals stay in durable state instead of vanishing into session output.
+
+Now read the durable audit state through the same public CLI:
+
+```bash
+cargo run --quiet -- \
+  improvement-curation read local-harness single-process "$STATE_ROOT"
+```
+
+Look for:
+
+- `Probe mode: improvement-curation-read`
+- `Latest review artifact:`
+- `Deferred proposal 1: Promote this pattern into a repeatable benchmark (hold this until the next benchmark planning pass)`
+- `Latest improvement record: review=`
 
 ## Step 7: Exercise bootstrap and the terminal-backed engineer substrate
 
@@ -199,4 +228,6 @@ You now know how to:
 
 - Use [How to configure bootstrap and inspect reflection](../howto/configure-bootstrap-and-inspect-reflection.md) when you need the bootstrap contract in more detail.
 - Use [How to carry meeting decisions into engineer sessions](../howto/carry-meeting-decisions-into-engineer-sessions.md) when you need a narrower handoff-focused workflow.
+- Use [How to inspect meeting records](../howto/inspect-meeting-records.md) when you need the read-only meeting audit flow.
+- Use [How to inspect improvement-curation state](../howto/inspect-improvement-curation-state.md) when you need the read-only review-to-priority audit flow.
 - Use [Simard CLI reference](../reference/simard-cli.md) when you need the exact command tree and compatibility mapping.

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,6 +35,10 @@ pub enum SimardError {
         field: String,
         reason: String,
     },
+    InvalidMeetingRecord {
+        field: String,
+        reason: String,
+    },
     InvalidImprovementRecord {
         field: String,
         reason: String,
@@ -187,6 +191,9 @@ impl Display for SimardError {
             }
             Self::InvalidGoalRecord { field, reason } => {
                 write!(f, "invalid goal record field '{field}': {reason}")
+            }
+            Self::InvalidMeetingRecord { field, reason } => {
+                write!(f, "invalid meeting record field '{field}': {reason}")
             }
             Self::InvalidImprovementRecord { field, reason } => {
                 write!(f, "invalid improvement record field '{field}': {reason}")

--- a/src/improvements.rs
+++ b/src/improvements.rs
@@ -177,6 +177,164 @@ impl ImprovementPromotionPlan {
     }
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PersistedImprovementApproval {
+    pub priority: u8,
+    pub status: GoalStatus,
+    pub title: String,
+}
+
+impl PersistedImprovementApproval {
+    pub fn concise_label(&self) -> String {
+        format!("p{} [{}] {}", self.priority, self.status, self.title)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PersistedImprovementRecord {
+    pub review_id: String,
+    pub review_target: String,
+    pub approved_proposals: Vec<PersistedImprovementApproval>,
+    pub deferred_proposals: Vec<DeferredImprovement>,
+    pub selected_base_type: Option<String>,
+    pub topology: Option<String>,
+    pub outcome: Option<String>,
+}
+
+impl PersistedImprovementRecord {
+    pub fn parse(raw: &str) -> SimardResult<Self> {
+        let pairs = parse_persisted_record_pairs(raw)?;
+        let mut seen = BTreeSet::new();
+        let mut review_id = None;
+        let mut review_target = None;
+        let mut approved_proposals = None;
+        let mut approval_count = None;
+        let mut deferred_proposals = None;
+        let mut deferral_count = None;
+        let mut selected_base_type = None;
+        let mut topology = None;
+        let mut outcome = None;
+
+        for (field, value) in pairs {
+            if !seen.insert(field) {
+                return Err(SimardError::InvalidImprovementRecord {
+                    field: field.to_string(),
+                    reason: "field cannot appear more than once".to_string(),
+                });
+            }
+
+            match field {
+                "review" => review_id = Some(required_improvement_field("review", value)?),
+                "target" => review_target = Some(required_improvement_field("target", value)?),
+                "approvals" => {
+                    if value.trim_start().starts_with('[') {
+                        approved_proposals =
+                            Some(parse_persisted_approval_list("approvals", value)?);
+                    } else {
+                        approval_count = Some(parse_non_negative_count("approvals", value)?);
+                    }
+                }
+                "approved_goals" => {
+                    approved_proposals =
+                        Some(parse_persisted_approval_list("approved_goals", value)?);
+                }
+                "deferred" => {
+                    deferred_proposals = Some(parse_persisted_deferral_list("deferred", value)?);
+                }
+                "deferrals" => {
+                    deferral_count = Some(parse_non_negative_count("deferrals", value)?);
+                }
+                "selected-base-type" => {
+                    selected_base_type =
+                        Some(required_improvement_field("selected-base-type", value)?)
+                }
+                "topology" => topology = Some(required_improvement_field("topology", value)?),
+                "outcome" => outcome = Some(required_improvement_field("outcome", value)?),
+                other => {
+                    return Err(SimardError::InvalidImprovementRecord {
+                        field: other.to_string(),
+                        reason: "unsupported persisted improvement field".to_string(),
+                    });
+                }
+            }
+        }
+
+        let approved_proposals =
+            approved_proposals.ok_or_else(|| SimardError::InvalidImprovementRecord {
+                field: "approvals".to_string(),
+                reason: "approved proposal list is required".to_string(),
+            })?;
+        let deferred_proposals =
+            deferred_proposals.ok_or_else(|| SimardError::InvalidImprovementRecord {
+                field: "deferred".to_string(),
+                reason: "deferred proposal list is required".to_string(),
+            })?;
+
+        if let Some(expected_count) = approval_count
+            && expected_count != approved_proposals.len()
+        {
+            return Err(SimardError::InvalidImprovementRecord {
+                field: "approvals".to_string(),
+                reason: format!(
+                    "approval count {expected_count} does not match approved proposal list length {}",
+                    approved_proposals.len()
+                ),
+            });
+        }
+        if let Some(expected_count) = deferral_count
+            && expected_count != deferred_proposals.len()
+        {
+            return Err(SimardError::InvalidImprovementRecord {
+                field: "deferrals".to_string(),
+                reason: format!(
+                    "deferral count {expected_count} does not match deferred proposal list length {}",
+                    deferred_proposals.len()
+                ),
+            });
+        }
+
+        Ok(Self {
+            review_id: review_id.ok_or_else(|| SimardError::InvalidImprovementRecord {
+                field: "review".to_string(),
+                reason: "review id is required".to_string(),
+            })?,
+            review_target: review_target.ok_or_else(|| SimardError::InvalidImprovementRecord {
+                field: "target".to_string(),
+                reason: "review target is required".to_string(),
+            })?,
+            approved_proposals,
+            deferred_proposals,
+            selected_base_type,
+            topology,
+            outcome,
+        })
+    }
+
+    pub fn concise_record(&self) -> String {
+        format!(
+            "review={} target={} approvals=[{}] deferred=[{}]",
+            self.review_id,
+            self.review_target,
+            self.approved_proposal_summaries().join(" | "),
+            self.deferred_proposal_summaries().join(" | "),
+        )
+    }
+
+    pub fn approved_proposal_summaries(&self) -> Vec<String> {
+        self.approved_proposals
+            .iter()
+            .map(PersistedImprovementApproval::concise_label)
+            .collect()
+    }
+
+    pub fn deferred_proposal_summaries(&self) -> Vec<String> {
+        self.deferred_proposals
+            .iter()
+            .map(|deferral| format!("{} ({})", deferral.title, deferral.rationale))
+            .collect()
+    }
+}
+
 pub fn render_review_context_directives(review: &ReviewArtifact) -> String {
     let mut lines = vec![
         format!("review-id: {}", sanitize_directive_value(&review.review_id)),
@@ -387,6 +545,365 @@ fn parse_deferral_directive(raw: &str) -> SimardResult<DeferredImprovement> {
     Ok(DeferredImprovement { title, rationale })
 }
 
+fn parse_persisted_record_pairs(raw: &str) -> SimardResult<Vec<(&str, &str)>> {
+    let mut trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(SimardError::InvalidImprovementRecord {
+            field: "record".to_string(),
+            reason: "persisted improvement record cannot be empty".to_string(),
+        });
+    }
+    if let Some(stripped) = trimmed.strip_prefix("improvement-curation-record") {
+        trimmed = stripped.trim_start();
+        if let Some(stripped) = trimmed.strip_prefix('|') {
+            trimmed = stripped.trim_start();
+        }
+    }
+
+    let mut pairs = Vec::new();
+    let mut cursor = 0;
+    while cursor < trimmed.len() {
+        cursor = skip_record_separators(trimmed, cursor);
+        if cursor >= trimmed.len() {
+            break;
+        }
+
+        let key_start = cursor;
+        while cursor < trimmed.len() {
+            let ch = trimmed[cursor..]
+                .chars()
+                .next()
+                .expect("cursor should remain on a valid char boundary");
+            if ch == '=' || ch.is_whitespace() || ch == '|' {
+                break;
+            }
+            cursor += ch.len_utf8();
+        }
+        if cursor >= trimmed.len() || !trimmed[cursor..].starts_with('=') {
+            return Err(SimardError::InvalidImprovementRecord {
+                field: "record".to_string(),
+                reason: format!(
+                    "expected key=value segment near '{}'",
+                    trimmed[key_start..].trim()
+                ),
+            });
+        }
+
+        let field = trimmed[key_start..cursor].trim();
+        cursor += 1;
+        let value_start = cursor;
+        let value;
+        if trimmed[value_start..].starts_with('[') {
+            let (parsed, next_cursor) = read_bracketed_value(trimmed, value_start)?;
+            value = parsed;
+            cursor = next_cursor;
+        } else {
+            while cursor < trimmed.len() {
+                let ch = trimmed[cursor..]
+                    .chars()
+                    .next()
+                    .expect("cursor should remain on a valid char boundary");
+                if ch == '|' {
+                    break;
+                }
+                if ch.is_whitespace() {
+                    let next_cursor = skip_spaces(trimmed, cursor);
+                    if looks_like_field_start(trimmed, next_cursor) {
+                        break;
+                    }
+                    cursor = next_cursor;
+                    continue;
+                }
+                cursor += ch.len_utf8();
+            }
+            value = trimmed[value_start..cursor].trim();
+        }
+
+        if field.is_empty() {
+            return Err(SimardError::InvalidImprovementRecord {
+                field: "record".to_string(),
+                reason: "persisted improvement record contains an empty field name".to_string(),
+            });
+        }
+        if value.is_empty() {
+            return Err(SimardError::InvalidImprovementRecord {
+                field: field.to_string(),
+                reason: "value cannot be empty".to_string(),
+            });
+        }
+        pairs.push((field, value));
+    }
+
+    if pairs.is_empty() {
+        return Err(SimardError::InvalidImprovementRecord {
+            field: "record".to_string(),
+            reason: "persisted improvement record contained no key=value fields".to_string(),
+        });
+    }
+
+    Ok(pairs)
+}
+
+fn parse_persisted_approval_list(
+    field: &str,
+    raw: &str,
+) -> SimardResult<Vec<PersistedImprovementApproval>> {
+    parse_bracketed_list(field, raw)?
+        .into_iter()
+        .map(|entry| parse_persisted_approval_entry(field, &entry))
+        .collect()
+}
+
+fn parse_persisted_approval_entry(
+    field: &str,
+    raw: &str,
+) -> SimardResult<PersistedImprovementApproval> {
+    let trimmed = raw.trim();
+    let Some(rest) = trimmed.strip_prefix('p') else {
+        return Err(SimardError::InvalidImprovementRecord {
+            field: field.to_string(),
+            reason: format!(
+                "approval entry '{trimmed}' must start with p<priority> [status] title"
+            ),
+        });
+    };
+    let digit_count = rest.chars().take_while(|ch| ch.is_ascii_digit()).count();
+    if digit_count == 0 {
+        return Err(SimardError::InvalidImprovementRecord {
+            field: field.to_string(),
+            reason: format!("approval entry '{trimmed}' is missing a numeric priority"),
+        });
+    }
+    let priority =
+        rest[..digit_count]
+            .parse::<u8>()
+            .map_err(|_| SimardError::InvalidImprovementRecord {
+                field: field.to_string(),
+                reason: format!("approval entry '{trimmed}' has an invalid priority"),
+            })?;
+    if priority == 0 {
+        return Err(SimardError::InvalidImprovementRecord {
+            field: field.to_string(),
+            reason: format!("approval entry '{trimmed}' must use priority 1 or greater"),
+        });
+    }
+
+    let rest = rest[digit_count..].trim_start();
+    let Some(status_rest) = rest.strip_prefix('[') else {
+        return Err(SimardError::InvalidImprovementRecord {
+            field: field.to_string(),
+            reason: format!("approval entry '{trimmed}' is missing [status]"),
+        });
+    };
+    let Some((status_raw, title_raw)) = status_rest.split_once(']') else {
+        return Err(SimardError::InvalidImprovementRecord {
+            field: field.to_string(),
+            reason: format!("approval entry '{trimmed}' has an unterminated [status]"),
+        });
+    };
+    let status = GoalStatus::parse(status_raw.trim()).ok_or_else(|| {
+        SimardError::InvalidImprovementRecord {
+            field: field.to_string(),
+            reason: format!("approval entry '{trimmed}' uses an unsupported status"),
+        }
+    })?;
+
+    Ok(PersistedImprovementApproval {
+        priority,
+        status,
+        title: required_improvement_field(field, title_raw)?,
+    })
+}
+
+fn parse_persisted_deferral_list(field: &str, raw: &str) -> SimardResult<Vec<DeferredImprovement>> {
+    parse_bracketed_list(field, raw)?
+        .into_iter()
+        .map(|entry| parse_persisted_deferral_entry(field, &entry))
+        .collect()
+}
+
+fn parse_persisted_deferral_entry(field: &str, raw: &str) -> SimardResult<DeferredImprovement> {
+    let trimmed = raw.trim();
+    let Some(stripped) = trimmed.strip_suffix(')') else {
+        return Err(SimardError::InvalidImprovementRecord {
+            field: field.to_string(),
+            reason: format!("deferred entry '{trimmed}' must end with '(rationale)'"),
+        });
+    };
+    let Some((title, rationale)) = stripped.rsplit_once(" (") else {
+        return Err(SimardError::InvalidImprovementRecord {
+            field: field.to_string(),
+            reason: format!("deferred entry '{trimmed}' must include a rationale"),
+        });
+    };
+    Ok(DeferredImprovement {
+        title: required_improvement_field(field, title)?,
+        rationale: required_improvement_field(field, rationale)?,
+    })
+}
+
+fn parse_bracketed_list(field: &str, raw: &str) -> SimardResult<Vec<String>> {
+    let trimmed = raw.trim();
+    let Some(inner) = trimmed
+        .strip_prefix('[')
+        .and_then(|value| value.strip_suffix(']'))
+    else {
+        return Err(SimardError::InvalidImprovementRecord {
+            field: field.to_string(),
+            reason: "value must use bracketed list syntax".to_string(),
+        });
+    };
+    let inner = inner.trim();
+    if inner.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut items = Vec::new();
+    let mut current = String::new();
+    let mut bracket_depth = 0usize;
+    let chars = inner.chars().peekable();
+    for ch in chars {
+        match ch {
+            '[' => {
+                bracket_depth += 1;
+                current.push(ch);
+            }
+            ']' => {
+                if bracket_depth == 0 {
+                    return Err(SimardError::InvalidImprovementRecord {
+                        field: field.to_string(),
+                        reason: "list contains an unexpected closing bracket".to_string(),
+                    });
+                }
+                bracket_depth -= 1;
+                current.push(ch);
+            }
+            '|' if bracket_depth == 0 => {
+                let item = current.trim();
+                if item.is_empty() {
+                    return Err(SimardError::InvalidImprovementRecord {
+                        field: field.to_string(),
+                        reason: "list contains an empty item".to_string(),
+                    });
+                }
+                items.push(item.to_string());
+                current.clear();
+            }
+            _ => current.push(ch),
+        }
+    }
+
+    if bracket_depth != 0 {
+        return Err(SimardError::InvalidImprovementRecord {
+            field: field.to_string(),
+            reason: "list contains an unterminated bracket".to_string(),
+        });
+    }
+
+    let item = current.trim();
+    if item.is_empty() {
+        return Err(SimardError::InvalidImprovementRecord {
+            field: field.to_string(),
+            reason: "list contains an empty item".to_string(),
+        });
+    }
+    items.push(item.to_string());
+    Ok(items)
+}
+
+fn parse_non_negative_count(field: &str, raw: &str) -> SimardResult<usize> {
+    raw.trim()
+        .parse::<usize>()
+        .map_err(|_| SimardError::InvalidImprovementRecord {
+            field: field.to_string(),
+            reason: "value must be a non-negative integer or bracketed list".to_string(),
+        })
+}
+
+fn read_bracketed_value(raw: &str, start: usize) -> SimardResult<(&str, usize)> {
+    let mut cursor = start;
+    let mut depth = 0usize;
+    while cursor < raw.len() {
+        let ch = raw[cursor..]
+            .chars()
+            .next()
+            .expect("cursor should remain on a valid char boundary");
+        match ch {
+            '[' => depth += 1,
+            ']' => {
+                depth =
+                    depth
+                        .checked_sub(1)
+                        .ok_or_else(|| SimardError::InvalidImprovementRecord {
+                            field: "record".to_string(),
+                            reason:
+                                "persisted improvement record has an unexpected closing bracket"
+                                    .to_string(),
+                        })?;
+                if depth == 0 {
+                    cursor += ch.len_utf8();
+                    return Ok((&raw[start..cursor], cursor));
+                }
+            }
+            _ => {}
+        }
+        cursor += ch.len_utf8();
+    }
+
+    Err(SimardError::InvalidImprovementRecord {
+        field: "record".to_string(),
+        reason: "persisted improvement record has an unterminated bracketed list".to_string(),
+    })
+}
+
+fn skip_record_separators(raw: &str, mut cursor: usize) -> usize {
+    while cursor < raw.len() {
+        let ch = raw[cursor..]
+            .chars()
+            .next()
+            .expect("cursor should remain on a valid char boundary");
+        if ch == '|' || ch.is_whitespace() {
+            cursor += ch.len_utf8();
+            continue;
+        }
+        break;
+    }
+    cursor
+}
+
+fn skip_spaces(raw: &str, mut cursor: usize) -> usize {
+    while cursor < raw.len() {
+        let ch = raw[cursor..]
+            .chars()
+            .next()
+            .expect("cursor should remain on a valid char boundary");
+        if ch.is_whitespace() {
+            cursor += ch.len_utf8();
+            continue;
+        }
+        break;
+    }
+    cursor
+}
+
+fn looks_like_field_start(raw: &str, cursor: usize) -> bool {
+    let tail = &raw[cursor..];
+    let mut seen_any = false;
+    for ch in tail.chars() {
+        if ch == '=' {
+            return seen_any;
+        }
+        if ch == '|' || ch.is_whitespace() {
+            return false;
+        }
+        if !ch.is_ascii_alphanumeric() && ch != '-' {
+            return false;
+        }
+        seen_any = true;
+    }
+    false
+}
+
 fn required_improvement_field(field: &str, value: impl AsRef<str>) -> SimardResult<String> {
     let trimmed = value.as_ref().trim();
     if trimmed.is_empty() {
@@ -494,5 +1011,47 @@ approve: Missing proposal | priority=1 | status=active | rationale=bad";
         assert!(directives.contains("review-id: session-1-review"));
         assert!(directives.contains("proposal: Capture denser execution evidence"));
         assert!(directives.contains("evidence=phase-1 ;; phase-2"));
+    }
+
+    #[test]
+    fn parses_persisted_improvement_record_for_readback() {
+        let record = PersistedImprovementRecord::parse(
+            "review=session-42-review target=operator-review approvals=[p1 [active] Capture denser execution evidence] deferred=[Promote this pattern into a repeatable benchmark (wait for the next benchmark planning pass)]",
+        )
+        .expect("persisted improvement record should parse");
+
+        assert_eq!(record.review_id, "session-42-review");
+        assert_eq!(record.review_target, "operator-review");
+        assert_eq!(record.approved_proposals.len(), 1);
+        assert_eq!(
+            record.approved_proposals[0].concise_label(),
+            "p1 [active] Capture denser execution evidence"
+        );
+        assert_eq!(
+            record.deferred_proposal_summaries(),
+            vec![
+                "Promote this pattern into a repeatable benchmark (wait for the next benchmark planning pass)"
+            ]
+        );
+        assert_eq!(
+            record.concise_record(),
+            "review=session-42-review target=operator-review approvals=[p1 [active] Capture denser execution evidence] deferred=[Promote this pattern into a repeatable benchmark (wait for the next benchmark planning pass)]"
+        );
+    }
+
+    #[test]
+    fn rejects_persisted_improvement_record_with_malformed_approvals() {
+        let error = PersistedImprovementRecord::parse(
+            "review=session-42-review target=operator-review approvals=not-a-list deferred=[]",
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            error,
+            SimardError::InvalidImprovementRecord {
+                field: "approvals".to_string(),
+                reason: "value must be a non-negative integer or bracketed list".to_string(),
+            }
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod gym;
 pub mod handoff;
 pub mod identity;
 pub mod improvements;
+pub mod meetings;
 pub mod memory;
 pub mod metadata;
 pub mod operator_cli;
@@ -62,7 +63,13 @@ pub use identity::{
     BuiltinIdentityLoader, IdentityLoadRequest, IdentityLoader, IdentityManifest, ManifestContract,
     MemoryPolicy, OperatingMode,
 };
-pub use improvements::{ImprovementPromotionPlan, render_review_context_directives};
+pub use improvements::{
+    ImprovementPromotionPlan, PersistedImprovementApproval, PersistedImprovementRecord,
+    render_review_context_directives,
+};
+pub use meetings::{
+    PersistedMeetingGoalUpdate, PersistedMeetingRecord, looks_like_persisted_meeting_record,
+};
 pub use memory::{
     FileBackedMemoryStore, InMemoryMemoryStore, MemoryRecord, MemoryScope, MemoryStore,
 };
@@ -72,8 +79,8 @@ pub use operator_commands::{
     dispatch_legacy_gym_cli, dispatch_operator_probe, gym_usage, run_bootstrap_probe,
     run_engineer_loop_probe, run_goal_curation_probe, run_goal_curation_read_probe,
     run_gym_compare, run_gym_list, run_gym_scenario, run_gym_suite, run_handoff_probe,
-    run_improvement_curation_probe, run_meeting_probe, run_review_probe, run_review_read_probe,
-    run_terminal_probe,
+    run_improvement_curation_probe, run_improvement_curation_read_probe, run_meeting_probe,
+    run_meeting_read_probe, run_review_probe, run_review_read_probe, run_terminal_probe,
 };
 pub use prompt_assets::{
     FilePromptAssetStore, InMemoryPromptAssetStore, PromptAsset, PromptAssetId, PromptAssetRef,

--- a/src/meetings.rs
+++ b/src/meetings.rs
@@ -1,0 +1,292 @@
+use crate::error::{SimardError, SimardResult};
+use crate::goals::GoalStatus;
+use crate::sanitization::sanitize_terminal_text;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PersistedMeetingGoalUpdate {
+    pub priority: u8,
+    pub status: GoalStatus,
+    pub title: String,
+    pub rationale: String,
+}
+
+impl PersistedMeetingGoalUpdate {
+    pub fn concise_label(&self) -> String {
+        format!("p{} [{}] {}", self.priority, self.status, self.title)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PersistedMeetingRecord {
+    pub agenda: String,
+    pub updates: Vec<String>,
+    pub decisions: Vec<String>,
+    pub risks: Vec<String>,
+    pub next_steps: Vec<String>,
+    pub open_questions: Vec<String>,
+    pub goals: Vec<PersistedMeetingGoalUpdate>,
+}
+
+impl PersistedMeetingRecord {
+    pub fn parse(raw: &str) -> SimardResult<Self> {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            return Err(SimardError::InvalidMeetingRecord {
+                field: "record".to_string(),
+                reason: "persisted meeting record cannot be empty".to_string(),
+            });
+        }
+
+        let (agenda_raw, remainder) =
+            take_scalar_field(trimmed, "agenda=", "; updates=", "agenda")?;
+        let (updates_raw, remainder) =
+            take_bracketed_field(remainder, "updates=", "; decisions=", "updates")?;
+        let (decisions_raw, remainder) =
+            take_bracketed_field(remainder, "decisions=", "; risks=", "decisions")?;
+        let (risks_raw, remainder) =
+            take_bracketed_field(remainder, "risks=", "; next_steps=", "risks")?;
+        let (next_steps_raw, remainder) =
+            take_bracketed_field(remainder, "next_steps=", "; open_questions=", "next_steps")?;
+        let (open_questions_raw, goals_raw) =
+            take_bracketed_field(remainder, "open_questions=", "; goals=", "open_questions")?;
+        let goals_raw = goals_raw.trim();
+        let Some(goals_raw) = goals_raw.strip_prefix("goals=") else {
+            return Err(SimardError::InvalidMeetingRecord {
+                field: "goals".to_string(),
+                reason: "expected goals=[...] after open_questions".to_string(),
+            });
+        };
+
+        Ok(Self {
+            agenda: required_meeting_field("agenda", agenda_raw)?.to_string(),
+            updates: parse_bracketed_text_list("updates", updates_raw)?,
+            decisions: parse_bracketed_text_list("decisions", decisions_raw)?,
+            risks: parse_bracketed_text_list("risks", risks_raw)?,
+            next_steps: parse_bracketed_text_list("next_steps", next_steps_raw)?,
+            open_questions: parse_bracketed_text_list("open_questions", open_questions_raw)?,
+            goals: parse_goal_update_list("goals", goals_raw)?,
+        })
+    }
+}
+
+pub fn looks_like_persisted_meeting_record(value: &str) -> bool {
+    [
+        "agenda=",
+        "updates=",
+        "decisions=",
+        "risks=",
+        "next_steps=",
+        "open_questions=",
+        "goals=",
+    ]
+    .into_iter()
+    .all(|fragment| value.contains(fragment))
+}
+
+fn take_scalar_field<'a>(
+    raw: &'a str,
+    prefix: &str,
+    next_marker: &str,
+    field: &str,
+) -> SimardResult<(&'a str, &'a str)> {
+    let Some(value_and_rest) = raw.strip_prefix(prefix) else {
+        return Err(SimardError::InvalidMeetingRecord {
+            field: field.to_string(),
+            reason: format!("expected '{prefix}' at the start of the persisted meeting record"),
+        });
+    };
+    let Some(next_index) = value_and_rest.find(next_marker) else {
+        return Err(SimardError::InvalidMeetingRecord {
+            field: field.to_string(),
+            reason: format!("expected '{next_marker}' after {field}"),
+        });
+    };
+    let value = &value_and_rest[..next_index];
+    let rest = &value_and_rest[next_index + 2..];
+    Ok((value.trim(), rest.trim()))
+}
+
+fn take_bracketed_field<'a>(
+    raw: &'a str,
+    prefix: &str,
+    next_marker: &str,
+    field: &str,
+) -> SimardResult<(&'a str, &'a str)> {
+    let Some(value_and_rest) = raw.strip_prefix(prefix) else {
+        return Err(SimardError::InvalidMeetingRecord {
+            field: field.to_string(),
+            reason: format!("expected '{prefix}' in the persisted meeting record"),
+        });
+    };
+    let Some(next_index) = value_and_rest.find(next_marker) else {
+        return Err(SimardError::InvalidMeetingRecord {
+            field: field.to_string(),
+            reason: format!("expected '{next_marker}' after {field}"),
+        });
+    };
+    let value = &value_and_rest[..next_index];
+    let rest = &value_and_rest[next_index + 2..];
+    if !(value.trim_start().starts_with('[') && value.trim_end().ends_with(']')) {
+        return Err(SimardError::InvalidMeetingRecord {
+            field: field.to_string(),
+            reason: "value must use bracketed list syntax".to_string(),
+        });
+    }
+    Ok((value.trim(), rest.trim()))
+}
+
+fn parse_bracketed_text_list(field: &str, raw: &str) -> SimardResult<Vec<String>> {
+    parse_bracketed_items(field, raw)
+}
+
+fn parse_goal_update_list(field: &str, raw: &str) -> SimardResult<Vec<PersistedMeetingGoalUpdate>> {
+    parse_bracketed_items(field, raw)?
+        .into_iter()
+        .map(|item| parse_goal_update(field, &item))
+        .collect()
+}
+
+fn parse_bracketed_items(field: &str, raw: &str) -> SimardResult<Vec<String>> {
+    let trimmed = raw.trim();
+    let Some(inner) = trimmed
+        .strip_prefix('[')
+        .and_then(|value| value.strip_suffix(']'))
+    else {
+        return Err(SimardError::InvalidMeetingRecord {
+            field: field.to_string(),
+            reason: "value must use bracketed list syntax".to_string(),
+        });
+    };
+    let inner = inner.trim();
+    if inner.is_empty() {
+        return Ok(Vec::new());
+    }
+    Ok(inner
+        .split(" | ")
+        .map(str::trim)
+        .map(ToOwned::to_owned)
+        .collect())
+}
+
+fn parse_goal_update(field: &str, raw: &str) -> SimardResult<PersistedMeetingGoalUpdate> {
+    let sanitized = sanitize_terminal_text(raw);
+    let segments = sanitized.splitn(4, ':').collect::<Vec<_>>();
+    if segments.len() != 4 {
+        return Err(SimardError::InvalidMeetingRecord {
+            field: field.to_string(),
+            reason: format!(
+                "goal update '{}' must use p<priority>:<status>:<title>:<rationale>",
+                sanitized.trim()
+            ),
+        });
+    }
+
+    let Some(priority_raw) = segments[0].trim().strip_prefix('p') else {
+        return Err(SimardError::InvalidMeetingRecord {
+            field: field.to_string(),
+            reason: format!(
+                "goal update '{}' must start with p<priority>",
+                sanitized.trim()
+            ),
+        });
+    };
+    let priority = priority_raw
+        .parse::<u8>()
+        .map_err(|_| SimardError::InvalidMeetingRecord {
+            field: field.to_string(),
+            reason: format!("goal update '{}' has an invalid priority", sanitized.trim()),
+        })?;
+    if priority == 0 {
+        return Err(SimardError::InvalidMeetingRecord {
+            field: field.to_string(),
+            reason: format!(
+                "goal update '{}' must use priority 1 or greater",
+                sanitized.trim()
+            ),
+        });
+    }
+
+    let status =
+        GoalStatus::parse(segments[1]).ok_or_else(|| SimardError::InvalidMeetingRecord {
+            field: field.to_string(),
+            reason: format!(
+                "goal update '{}' uses an unsupported status",
+                sanitized.trim()
+            ),
+        })?;
+
+    Ok(PersistedMeetingGoalUpdate {
+        priority,
+        status,
+        title: required_meeting_field(field, segments[2])?.to_string(),
+        rationale: required_meeting_field(field, segments[3])?.to_string(),
+    })
+}
+
+fn required_meeting_field<'a>(field: &str, value: &'a str) -> SimardResult<&'a str> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(SimardError::InvalidMeetingRecord {
+            field: field.to_string(),
+            reason: "value cannot be empty".to_string(),
+        });
+    }
+    Ok(trimmed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PersistedMeetingGoalUpdate, PersistedMeetingRecord};
+    use crate::error::SimardError;
+    use crate::goals::GoalStatus;
+
+    #[test]
+    fn parses_persisted_meeting_record_for_readback() {
+        let record = PersistedMeetingRecord::parse(
+            "agenda=align the next Simard workstream; updates=[durable memory merged]; decisions=[preserve meeting-to-engineer continuity]; risks=[workflow routing is still unreliable]; next_steps=[keep durable priorities visible]; open_questions=[how aggressively should Simard reprioritize?]; goals=[p1:active:Preserve meeting handoff:meeting decisions must shape later work]",
+        )
+        .expect("persisted meeting record should parse");
+
+        assert_eq!(record.agenda, "align the next Simard workstream");
+        assert_eq!(record.updates, vec!["durable memory merged"]);
+        assert_eq!(
+            record.decisions,
+            vec!["preserve meeting-to-engineer continuity"]
+        );
+        assert_eq!(record.risks, vec!["workflow routing is still unreliable"]);
+        assert_eq!(record.next_steps, vec!["keep durable priorities visible"]);
+        assert_eq!(
+            record.open_questions,
+            vec!["how aggressively should Simard reprioritize?"]
+        );
+        assert_eq!(
+            record.goals,
+            vec![PersistedMeetingGoalUpdate {
+                priority: 1,
+                status: GoalStatus::Active,
+                title: "Preserve meeting handoff".to_string(),
+                rationale: "meeting decisions must shape later work".to_string(),
+            }]
+        );
+        assert_eq!(
+            record.goals[0].concise_label(),
+            "p1 [active] Preserve meeting handoff"
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_persisted_meeting_goal_update() {
+        let error = PersistedMeetingRecord::parse(
+            "agenda=align the next Simard workstream; updates=[]; decisions=[preserve meeting-to-engineer continuity]; risks=[]; next_steps=[]; open_questions=[]; goals=[p0:active:Preserve meeting handoff:meeting decisions must shape later work]",
+        )
+        .expect_err("malformed goal update should fail");
+
+        assert_eq!(
+            error,
+            SimardError::InvalidMeetingRecord {
+                field: "goals".to_string(),
+                reason: "goal update 'p0:active:Preserve meeting handoff:meeting decisions must shape later work' must use priority 1 or greater".to_string(),
+            }
+        );
+    }
+}

--- a/src/operator_cli.rs
+++ b/src/operator_cli.rs
@@ -3,8 +3,8 @@ use std::path::PathBuf;
 use crate::operator_commands::{
     run_bootstrap_probe, run_engineer_loop_probe, run_goal_curation_probe,
     run_goal_curation_read_probe, run_gym_compare, run_gym_list, run_gym_scenario, run_gym_suite,
-    run_improvement_curation_probe, run_meeting_probe, run_review_probe, run_review_read_probe,
-    run_terminal_probe,
+    run_improvement_curation_probe, run_improvement_curation_read_probe, run_meeting_probe,
+    run_meeting_read_probe, run_review_probe, run_review_read_probe, run_terminal_probe,
 };
 
 const OPERATOR_CLI_HELP: &str = "\
@@ -14,9 +14,11 @@ Product modes:
   engineer run <topology> <workspace-root> <objective> [state-root]
   engineer terminal <topology> <objective> [state-root]
   meeting run <base-type> <topology> <objective> [state-root]
+  meeting read <base-type> <topology> [state-root]
   goal-curation run <base-type> <topology> <objective> [state-root]
   goal-curation read <base-type> <topology> [state-root]
   improvement-curation run <base-type> <topology> <objective> [state-root]
+  improvement-curation read <base-type> <topology> [state-root]
   gym list
   gym run <scenario-id>
   gym compare <scenario-id>
@@ -107,6 +109,13 @@ fn dispatch_meeting_command(
             reject_extra_args(args)?;
             run_meeting_probe(&base_type, &topology, &objective, state_root)
         }
+        "read" => {
+            let base_type = next_required(&mut args, "base type")?;
+            let topology = next_required(&mut args, "topology")?;
+            let state_root = next_optional_path(&mut args);
+            reject_extra_args(args)?;
+            run_meeting_read_probe(&base_type, &topology, state_root)
+        }
         other => Err(format!("unsupported command 'meeting {other}'").into()),
     }
 }
@@ -147,6 +156,13 @@ fn dispatch_improvement_curation_command(
             let state_root = next_optional_path(&mut args);
             reject_extra_args(args)?;
             run_improvement_curation_probe(&base_type, &topology, &objective, state_root)
+        }
+        "read" => {
+            let base_type = next_required(&mut args, "base type")?;
+            let topology = next_required(&mut args, "topology")?;
+            let state_root = next_optional_path(&mut args);
+            reject_extra_args(args)?;
+            run_improvement_curation_read_probe(&base_type, &topology, state_root)
         }
         other => Err(format!("unsupported command 'improvement-curation {other}'").into()),
     }

--- a/src/operator_commands.rs
+++ b/src/operator_commands.rs
@@ -1,8 +1,11 @@
+use std::fs;
 use std::path::{Path, PathBuf};
 
 use crate::base_types::BaseTypeId;
 use crate::bootstrap::validate_state_root;
 use crate::goals::{FileBackedGoalStore, GoalRecord, GoalStatus, GoalStore};
+use crate::improvements::PersistedImprovementRecord;
+use crate::meetings::PersistedMeetingRecord;
 use crate::sanitization::sanitize_terminal_text;
 use crate::{
     BootstrapConfig, BootstrapInputs, BuiltinIdentityLoader, FileBackedMemoryStore, Freshness,
@@ -11,8 +14,8 @@ use crate::{
     assemble_local_runtime_from_handoff, benchmark_scenarios, build_review_artifact,
     builtin_base_type_registry_for_manifest, compare_latest_benchmark_runs, default_output_root,
     latest_local_handoff, latest_review_artifact, persist_review_artifact,
-    render_review_context_directives, run_benchmark_scenario, run_benchmark_suite,
-    run_local_engineer_loop, run_local_session,
+    render_review_context_directives, review_artifacts_dir, run_benchmark_scenario,
+    run_benchmark_suite, run_local_engineer_loop, run_local_session,
 };
 
 pub fn dispatch_operator_probe<I>(args: I) -> Result<(), Box<dyn std::error::Error>>
@@ -47,6 +50,13 @@ where
             let state_root = next_optional_path(&mut args);
             reject_extra_args(args)?;
             run_meeting_probe(&base_type, &topology, &objective, state_root)?;
+        }
+        "meeting-read" => {
+            let base_type = next_required(&mut args, "base type")?;
+            let topology = next_required(&mut args, "topology")?;
+            let state_root = next_optional_path(&mut args);
+            reject_extra_args(args)?;
+            run_meeting_read_probe(&base_type, &topology, state_root)?;
         }
         "goal-curation-run" => {
             let base_type = next_required(&mut args, "base type")?;
@@ -98,6 +108,13 @@ where
             let state_root = next_optional_path(&mut args);
             reject_extra_args(args)?;
             run_improvement_curation_probe(&base_type, &topology, &objective, state_root)?;
+        }
+        "improvement-curation-read" => {
+            let base_type = next_required(&mut args, "base type")?;
+            let topology = next_required(&mut args, "topology")?;
+            let state_root = next_optional_path(&mut args);
+            reject_extra_args(args)?;
+            run_improvement_curation_read_probe(&base_type, &topology, state_root)?;
         }
         other => return Err(format!("unsupported probe command '{other}'").into()),
     }
@@ -329,6 +346,41 @@ pub fn run_meeting_probe(
     }
     print_text("Execution summary", &execution.outcome.execution_summary);
     print_text("Reflection summary", &execution.outcome.reflection.summary);
+    Ok(())
+}
+
+pub fn run_meeting_read_probe(
+    base_type: &str,
+    topology: &str,
+    state_root_override: Option<PathBuf>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let state_root = resolved_meeting_read_state_root(state_root_override, base_type, topology)?;
+    let memory_store = FileBackedMemoryStore::try_new(state_root.join("memory_records.json"))?;
+    let meeting_records = memory_store
+        .list(MemoryScope::Decision)?
+        .into_iter()
+        .filter(|record| crate::looks_like_persisted_meeting_record(&record.value))
+        .collect::<Vec<_>>();
+    let latest_record = meeting_records
+        .last()
+        .ok_or("expected persisted meeting decision record")?;
+    let parsed_record =
+        PersistedMeetingRecord::parse(&latest_record.value).map_err(|error| format!("{error}"))?;
+
+    println!("Probe mode: meeting-read");
+    println!("Identity: simard-meeting");
+    print_text("Selected base type", base_type);
+    print_text("Topology", topology);
+    print_display("State root", state_root.display());
+    println!("Meeting records: {}", meeting_records.len());
+    print_text("Latest agenda", &parsed_record.agenda);
+    print_string_section("Updates", &parsed_record.updates);
+    print_string_section("Decisions", &parsed_record.decisions);
+    print_string_section("Risks", &parsed_record.risks);
+    print_string_section("Next steps", &parsed_record.next_steps);
+    print_string_section("Open questions", &parsed_record.open_questions);
+    print_meeting_goal_section(&parsed_record.goals);
+    print_text("Latest meeting record", &latest_record.value);
     Ok(())
 }
 
@@ -727,6 +779,81 @@ pub fn run_improvement_curation_probe(
     Ok(())
 }
 
+pub fn run_improvement_curation_read_probe(
+    base_type: &str,
+    topology: &str,
+    state_root_override: Option<PathBuf>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let state_root =
+        resolved_improvement_curation_read_state_root(state_root_override, base_type, topology)?;
+    let (review_artifact_path, review) =
+        latest_review_artifact(&state_root)?.ok_or("expected persisted review artifact")?;
+    let memory_store = FileBackedMemoryStore::try_new(state_root.join("memory_records.json"))?;
+    let latest_record = memory_store
+        .list(MemoryScope::Decision)?
+        .into_iter()
+        .rfind(|record| record.key.ends_with("improvement-curation-record"))
+        .ok_or("expected persisted improvement decision record")?;
+    let parsed_record = PersistedImprovementRecord::parse(&latest_record.value)
+        .map_err(|error| format!("{error}"))?;
+    let goal_store = FileBackedGoalStore::try_new(state_root.join("goal_records.json"))?;
+    let goal_records = goal_store.list()?;
+
+    println!("Probe mode: improvement-curation-read");
+    println!("Identity: simard-improvement-curator");
+    print_text(
+        "Selected base type",
+        parsed_record
+            .selected_base_type
+            .as_deref()
+            .unwrap_or(&review.selected_base_type),
+    );
+    print_text(
+        "Topology",
+        parsed_record
+            .topology
+            .as_deref()
+            .unwrap_or(&review.topology),
+    );
+    print_display("State root", state_root.display());
+    print_display("Latest review artifact", review_artifact_path.display());
+    print_text("Review id", &review.review_id);
+    print_text("Review target", &review.target_label);
+    println!("Review proposals: {}", review.proposals.len());
+    println!(
+        "Approved proposals: {}",
+        parsed_record.approved_proposals.len()
+    );
+    if parsed_record.approved_proposals.is_empty() {
+        println!("Approved proposals: <none>");
+    } else {
+        for (index, approval) in parsed_record.approved_proposals.iter().enumerate() {
+            print_text(
+                &format!("Approved proposal {}", index + 1),
+                approval.concise_label(),
+            );
+        }
+    }
+    println!(
+        "Deferred proposals: {}",
+        parsed_record.deferred_proposals.len()
+    );
+    if parsed_record.deferred_proposals.is_empty() {
+        println!("Deferred proposals: <none>");
+    } else {
+        for (index, deferral) in parsed_record.deferred_proposals.iter().enumerate() {
+            print_text(
+                &format!("Deferred proposal {}", index + 1),
+                format!("{} ({})", deferral.title, deferral.rationale),
+            );
+        }
+    }
+    print_goal_section(&goal_records, GoalStatus::Active, "Active");
+    print_goal_section(&goal_records, GoalStatus::Proposed, "Proposed");
+    print_text("Latest improvement record", parsed_record.concise_record());
+    Ok(())
+}
+
 pub fn run_gym_list() -> Result<(), Box<dyn std::error::Error>> {
     println!("Simard benchmark scenarios:");
     for scenario in benchmark_scenarios() {
@@ -968,6 +1095,132 @@ fn resolved_review_state_root(
     )
 }
 
+fn resolved_improvement_curation_read_state_root(
+    explicit: Option<PathBuf>,
+    base_type: &str,
+    topology: &str,
+) -> crate::SimardResult<PathBuf> {
+    let state_root = resolved_review_state_root(explicit, base_type, topology)?;
+    validate_improvement_curation_read_state_root(&state_root)?;
+    Ok(state_root)
+}
+
+fn resolved_meeting_read_state_root(
+    explicit: Option<PathBuf>,
+    base_type: &str,
+    topology: &str,
+) -> crate::SimardResult<PathBuf> {
+    let state_root = resolved_state_root(
+        explicit,
+        "simard-meeting",
+        base_type,
+        topology,
+        "meeting-run",
+    )?;
+    validate_meeting_read_state_root(&state_root)?;
+    Ok(state_root)
+}
+
+fn validate_meeting_read_state_root(state_root: &Path) -> crate::SimardResult<()> {
+    validate_existing_read_state_root_root("meeting read", state_root)?;
+    require_existing_read_file_for_mode(
+        "meeting read",
+        state_root,
+        &state_root.join("memory_records.json"),
+    )?;
+    Ok(())
+}
+
+fn validate_improvement_curation_read_state_root(state_root: &Path) -> crate::SimardResult<()> {
+    validate_existing_read_state_root_root("improvement-curation read", state_root)?;
+
+    require_existing_read_directory_for_mode(
+        "improvement-curation read",
+        state_root,
+        &review_artifacts_dir(state_root),
+        "review-artifacts/",
+    )?;
+    require_existing_read_file_for_mode(
+        "improvement-curation read",
+        state_root,
+        &state_root.join("memory_records.json"),
+    )?;
+    require_existing_read_file_for_mode(
+        "improvement-curation read",
+        state_root,
+        &state_root.join("goal_records.json"),
+    )?;
+    Ok(())
+}
+
+fn validate_existing_read_state_root_root(
+    mode_label: &str,
+    state_root: &Path,
+) -> crate::SimardResult<()> {
+    let root_metadata =
+        fs::metadata(state_root).map_err(|error| crate::SimardError::InvalidStateRoot {
+            path: state_root.to_path_buf(),
+            reason: format!("{mode_label} requires an existing state root directory: {error}"),
+        })?;
+    if root_metadata.is_dir() {
+        return Ok(());
+    }
+
+    Err(crate::SimardError::InvalidStateRoot {
+        path: state_root.to_path_buf(),
+        reason: format!("{mode_label} requires state-root to resolve to a directory"),
+    })
+}
+
+fn require_existing_read_directory_for_mode(
+    mode_label: &str,
+    state_root: &Path,
+    path: &Path,
+    label: &str,
+) -> crate::SimardResult<()> {
+    let metadata = fs::metadata(path).map_err(|error| crate::SimardError::InvalidStateRoot {
+        path: state_root.to_path_buf(),
+        reason: format!(
+            "{mode_label} requires '{}' to exist as a directory: {error}",
+            path.display()
+        ),
+    })?;
+    if metadata.is_dir() {
+        return Ok(());
+    }
+
+    Err(crate::SimardError::InvalidStateRoot {
+        path: state_root.to_path_buf(),
+        reason: format!("{mode_label} requires {label} to exist as a directory"),
+    })
+}
+
+fn require_existing_read_file_for_mode(
+    mode_label: &str,
+    state_root: &Path,
+    path: &Path,
+) -> crate::SimardResult<()> {
+    let metadata = fs::metadata(path).map_err(|error| crate::SimardError::InvalidStateRoot {
+        path: state_root.to_path_buf(),
+        reason: format!(
+            "{mode_label} requires '{}' to exist as a file: {error}",
+            path.display()
+        ),
+    })?;
+    if metadata.is_file() {
+        return Ok(());
+    }
+
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("file");
+    Err(crate::SimardError::InvalidStateRoot {
+        path: state_root.to_path_buf(),
+        reason: format!("{mode_label} requires {file_name} to exist as a file"),
+    })
+}
+
 fn parse_runtime_topology(value: &str) -> crate::SimardResult<RuntimeTopology> {
     match value {
         "single-process" => Ok(RuntimeTopology::SingleProcess),
@@ -1010,6 +1263,56 @@ fn print_text(label: &str, value: impl AsRef<str>) {
 
 fn print_display(label: &str, value: impl std::fmt::Display) {
     println!("{label}: {}", sanitize_terminal_text(&value.to_string()));
+}
+
+fn print_string_section(label: &str, values: &[String]) {
+    println!("{label} count: {}", values.len());
+    if values.is_empty() {
+        println!("{label}: <none>");
+        return;
+    }
+
+    let singular = label.strip_suffix('s').unwrap_or(label);
+    for (index, value) in values.iter().enumerate() {
+        print_text(&format!("{singular} {}", index + 1), value);
+    }
+}
+
+fn print_meeting_goal_section(goals: &[crate::PersistedMeetingGoalUpdate]) {
+    println!("Goal updates count: {}", goals.len());
+    if goals.is_empty() {
+        println!("Goal updates: <none>");
+        return;
+    }
+
+    for (index, goal) in goals.iter().enumerate() {
+        print_text(&format!("Goal update {}", index + 1), goal.concise_label());
+    }
+}
+
+fn print_goal_section(records: &[GoalRecord], status: GoalStatus, heading: &'static str) {
+    let mut matching = records
+        .iter()
+        .filter(|record| record.status == status)
+        .collect::<Vec<_>>();
+    matching.sort_by(|left, right| {
+        left.priority
+            .cmp(&right.priority)
+            .then(left.title.cmp(&right.title))
+            .then(left.slug.cmp(&right.slug))
+    });
+    println!("{} goals count: {}", heading, matching.len());
+    if matching.is_empty() {
+        println!("{} goals: <none>", heading);
+        return;
+    }
+
+    for (index, goal) in matching.iter().enumerate() {
+        print_text(
+            &format!("{heading} goal {}", index + 1),
+            goal.concise_label(),
+        );
+    }
 }
 
 struct GoalRegisterView {

--- a/tests/gadugi/meeting-mode.sh
+++ b/tests/gadugi/meeting-mode.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 cd "$ROOT"
+STATE_ROOT="$(mktemp -d /tmp/simard-meeting-mode.XXXXXX)"
+trap 'rm -rf "$STATE_ROOT"' EXIT
 
 OBJECTIVE="$(cat <<'EOF'
 agenda: align the next Simard product block
@@ -18,7 +20,8 @@ EOF
 OUTPUT="$(
   cargo run --quiet --bin simard_operator_probe -- \
     meeting-run local-harness single-process \
-    "$OBJECTIVE"
+    "$OBJECTIVE" \
+    "$STATE_ROOT"
 )"
 
 printf '%s\n' "$OUTPUT"
@@ -33,3 +36,18 @@ printf '%s\n' "$OUTPUT" | grep -F "prioritize facilitator behavior before remote
 printf '%s\n' "$OUTPUT" | grep -F "workflow automation is still unreliable in clean worktrees" >/dev/null
 printf '%s\n' "$OUTPUT" | grep -F "ship operator-visible meeting validation" >/dev/null
 printf '%s\n' "$OUTPUT" | grep -F "captured 1 decisions, 1 risks, 1 next steps, and 1 open questions" >/dev/null
+
+READ_OUTPUT="$(
+  cargo run --quiet --bin simard_operator_probe -- \
+    meeting-read local-harness single-process \
+    "$STATE_ROOT"
+)"
+
+printf '%s\n' "$READ_OUTPUT"
+
+printf '%s\n' "$READ_OUTPUT" | grep -F "Probe mode: meeting-read" >/dev/null
+printf '%s\n' "$READ_OUTPUT" | grep -F "Identity: simard-meeting" >/dev/null
+printf '%s\n' "$READ_OUTPUT" | grep -F "Meeting records: 1" >/dev/null
+printf '%s\n' "$READ_OUTPUT" | grep -F "Latest agenda: align the next Simard product block" >/dev/null
+printf '%s\n' "$READ_OUTPUT" | grep -F "Decision 1: prioritize facilitator behavior before remote orchestration" >/dev/null
+printf '%s\n' "$READ_OUTPUT" | grep -F "Goal update 1: p1 [active] Preserve meeting-to-engineer handoff" >/dev/null

--- a/tests/improvement_curation.rs
+++ b/tests/improvement_curation.rs
@@ -3,6 +3,8 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use serde_json::Value;
+
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 }
@@ -39,6 +41,11 @@ impl Drop for TempDirGuard {
             let _ = fs::remove_dir_all(&self.path);
         }
     }
+}
+
+fn load_json(path: impl AsRef<Path>) -> Value {
+    serde_json::from_str(&fs::read_to_string(path.as_ref()).expect("artifact should be readable"))
+        .expect("artifact should deserialize as JSON")
 }
 
 #[test]
@@ -113,4 +120,245 @@ approve: Promote this pattern into a repeatable benchmark | priority=2 | status=
         engineer_rendered.contains("Active goal 1: p1 [active] Capture denser execution evidence")
     );
     assert!(engineer_rendered.contains("Verification status: verified"));
+}
+
+#[test]
+fn improvement_curation_read_probe_surfaces_persisted_review_decisions_without_mutating_state() {
+    let state_root = TempDirGuard::new("simard-improvement-curation-read-probe");
+
+    let review_output = Command::new(env!("CARGO_BIN_EXE_simard_operator_probe"))
+        .arg("review-run")
+        .arg("local-harness")
+        .arg("single-process")
+        .arg("inspect the current Simard review surface and preserve concrete proposals")
+        .arg(state_root.path())
+        .output()
+        .expect("review probe should launch");
+    let review_rendered = rendered_output(&review_output);
+
+    assert!(
+        review_output.status.success(),
+        "review probe should prepare durable review state for readback:\n{review_rendered}"
+    );
+
+    let improvement_objective = "\
+approve: Capture denser execution evidence | priority=1 | status=active | rationale=operators need denser execution evidence now\n\
+defer: Promote this pattern into a repeatable benchmark | rationale=wait for the next benchmark planning pass";
+    let improvement_output = Command::new(env!("CARGO_BIN_EXE_simard_operator_probe"))
+        .arg("improvement-curation-run")
+        .arg("local-harness")
+        .arg("single-process")
+        .arg(improvement_objective)
+        .arg(state_root.path())
+        .output()
+        .expect("improvement curation probe should launch");
+    let improvement_rendered = rendered_output(&improvement_output);
+
+    assert!(
+        improvement_output.status.success(),
+        "improvement curation probe should persist the decisions that readback inspects:\n{improvement_rendered}"
+    );
+
+    let memory_before =
+        fs::read(state_root.path().join("memory_records.json")).expect("memory store should exist");
+    let goals_before =
+        fs::read(state_root.path().join("goal_records.json")).expect("goal store should exist");
+
+    let read_output = Command::new(env!("CARGO_BIN_EXE_simard_operator_probe"))
+        .arg("improvement-curation-read")
+        .arg("local-harness")
+        .arg("single-process")
+        .arg(state_root.path())
+        .output()
+        .expect("improvement curation read probe should launch");
+    let read_rendered = rendered_output(&read_output);
+
+    assert!(
+        read_output.status.success(),
+        "improvement curation read should expose durable review/improvement state through the read probe:\n{read_rendered}"
+    );
+    for expected in [
+        "Probe mode: improvement-curation-read",
+        &format!("State root: {}", state_root.path().display()),
+        "Latest review artifact:",
+        "Review id:",
+        "Review target:",
+        "Approved proposals: 1",
+        "Approved proposal 1: p1 [active] Capture denser execution evidence",
+        "Deferred proposals: 1",
+        "Deferred proposal 1: Promote this pattern into a repeatable benchmark (wait for the next benchmark planning pass)",
+        "Active goals count: 1",
+        "Active goal 1: p1 [active] Capture denser execution evidence",
+        "Proposed goals count: 0",
+        "Latest improvement record: review=",
+    ] {
+        assert!(
+            read_rendered.contains(expected),
+            "improvement curation read should surface '{expected}' for operators:\n{read_rendered}"
+        );
+    }
+
+    let memory_after =
+        fs::read(state_root.path().join("memory_records.json")).expect("memory store should exist");
+    let goals_after =
+        fs::read(state_root.path().join("goal_records.json")).expect("goal store should exist");
+    assert_eq!(
+        memory_before, memory_after,
+        "improvement curation read must stay read-only with respect to persisted decision state"
+    );
+    assert_eq!(
+        goals_before, goals_after,
+        "improvement curation read must not rewrite the durable goal register"
+    );
+}
+
+#[test]
+fn improvement_curation_read_probe_rejects_nonexistent_and_empty_state_roots_before_probe_access() {
+    let temp_dir = TempDirGuard::new("simard-improvement-curation-read-invalid-root");
+    let missing_root = temp_dir.path().join("missing-layout");
+    let empty_root = temp_dir.path().join("empty-layout");
+    fs::create_dir_all(&empty_root).expect("empty state root fixture should be created");
+
+    let missing_output = Command::new(env!("CARGO_BIN_EXE_simard_operator_probe"))
+        .arg("improvement-curation-read")
+        .arg("local-harness")
+        .arg("single-process")
+        .arg(&missing_root)
+        .output()
+        .expect("improvement curation read probe missing-root check should launch");
+    let missing_rendered = rendered_output(&missing_output);
+
+    assert!(
+        !missing_output.status.success(),
+        "improvement curation read must fail visibly for a nonexistent explicit state root:\n{missing_rendered}"
+    );
+    assert!(
+        missing_rendered.contains("invalid state root")
+            || missing_rendered.contains("InvalidStateRoot"),
+        "improvement curation read should keep the failing state-root contract explicit:\n{missing_rendered}"
+    );
+    assert!(
+        missing_rendered.contains("requires an existing state root directory"),
+        "improvement curation read should explain why a nonexistent explicit root was rejected:\n{missing_rendered}"
+    );
+    assert!(
+        !missing_rendered.contains("expected persisted review artifact"),
+        "improvement curation read should reject a nonexistent root before probing for artifacts:\n{missing_rendered}"
+    );
+
+    let empty_output = Command::new(env!("CARGO_BIN_EXE_simard_operator_probe"))
+        .arg("improvement-curation-read")
+        .arg("local-harness")
+        .arg("single-process")
+        .arg(&empty_root)
+        .output()
+        .expect("improvement curation read probe empty-root check should launch");
+    let empty_rendered = rendered_output(&empty_output);
+
+    assert!(
+        !empty_output.status.success(),
+        "improvement curation read must fail visibly for an empty explicit state root:\n{empty_rendered}"
+    );
+    assert!(
+        empty_rendered.contains("invalid state root")
+            || empty_rendered.contains("InvalidStateRoot"),
+        "improvement curation read should keep empty-root failures in the state-root contract:\n{empty_rendered}"
+    );
+    assert!(
+        empty_rendered.contains("review-artifacts"),
+        "improvement curation read should pinpoint the missing read-only layout entry for an empty root:\n{empty_rendered}"
+    );
+    assert!(
+        !empty_rendered.contains("expected persisted review artifact"),
+        "improvement curation read should reject an empty root before probing for review artifacts:\n{empty_rendered}"
+    );
+}
+
+#[test]
+fn improvement_curation_read_probe_fails_closed_on_malformed_latest_improvement_record() {
+    let state_root = TempDirGuard::new("simard-improvement-curation-read-malformed");
+
+    let review_output = Command::new(env!("CARGO_BIN_EXE_simard_operator_probe"))
+        .arg("review-run")
+        .arg("local-harness")
+        .arg("single-process")
+        .arg("inspect the current Simard review surface and preserve concrete proposals")
+        .arg(state_root.path())
+        .output()
+        .expect("review probe should launch");
+    let review_rendered = rendered_output(&review_output);
+
+    assert!(
+        review_output.status.success(),
+        "review probe should prepare durable state for the malformed-record failure case:\n{review_rendered}"
+    );
+
+    let improvement_objective = "\
+approve: Capture denser execution evidence | priority=1 | status=active | rationale=operators need denser execution evidence now\n\
+defer: Promote this pattern into a repeatable benchmark | rationale=wait for the next benchmark planning pass";
+    let improvement_output = Command::new(env!("CARGO_BIN_EXE_simard_operator_probe"))
+        .arg("improvement-curation-run")
+        .arg("local-harness")
+        .arg("single-process")
+        .arg(improvement_objective)
+        .arg(state_root.path())
+        .output()
+        .expect("improvement curation probe should launch");
+    let improvement_rendered = rendered_output(&improvement_output);
+
+    assert!(
+        improvement_output.status.success(),
+        "improvement curation probe should persist an initial valid record:\n{improvement_rendered}"
+    );
+
+    let memory_path = state_root.path().join("memory_records.json");
+    let mut memory_records = load_json(&memory_path);
+    let records = memory_records
+        .as_array_mut()
+        .expect("memory store should remain a JSON array");
+    let latest_improvement_record = records
+        .iter_mut()
+        .find(|record| {
+            record["key"]
+                .as_str()
+                .map(|key| key.ends_with("improvement-curation-record"))
+                .unwrap_or(false)
+        })
+        .expect("improvement curation should persist a decision record");
+    latest_improvement_record["value"] = Value::String(
+        "review=session-42-review target=operator-review approvals=not-a-list deferred=[]"
+            .to_string(),
+    );
+    fs::write(
+        &memory_path,
+        serde_json::to_string_pretty(&memory_records)
+            .expect("corrupted memory store should serialize"),
+    )
+    .expect("corrupted memory store should be written");
+
+    let read_output = Command::new(env!("CARGO_BIN_EXE_simard_operator_probe"))
+        .arg("improvement-curation-read")
+        .arg("local-harness")
+        .arg("single-process")
+        .arg(state_root.path())
+        .output()
+        .expect("improvement curation read probe should launch");
+    let read_rendered = rendered_output(&read_output);
+
+    assert!(
+        !read_output.status.success(),
+        "improvement curation read must fail closed when the persisted improvement record is malformed:\n{read_rendered}"
+    );
+    assert!(
+        read_rendered.contains("invalid improvement record field"),
+        "improvement curation read should surface the parser failure instead of silently degrading:\n{read_rendered}"
+    );
+    assert!(
+        read_rendered.contains("approvals"),
+        "improvement curation read should pinpoint the malformed approvals section:\n{read_rendered}"
+    );
+    assert!(
+        !read_rendered.contains("Approved proposals:"),
+        "improvement curation read should not print a success-shaped summary after malformed-state failure:\n{read_rendered}"
+    );
 }

--- a/tests/simard_cli.rs
+++ b/tests/simard_cli.rs
@@ -94,11 +94,39 @@ fn goal_curation_default_root_lock() -> &'static Mutex<()> {
     LOCK.get_or_init(|| Mutex::new(()))
 }
 
+fn meeting_default_root_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+fn default_meeting_state_root(base_type: &str, topology: &str) -> PathBuf {
+    repo_root()
+        .join("target/operator-probe-state")
+        .join("meeting-run")
+        .join("simard-meeting")
+        .join(base_type)
+        .join(topology)
+}
+
 fn default_goal_curation_state_root(base_type: &str, topology: &str) -> PathBuf {
     repo_root()
         .join("target/operator-probe-state")
         .join("goal-curation-run")
         .join("simard-goal-curator")
+        .join(base_type)
+        .join(topology)
+}
+
+fn review_default_root_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+fn default_review_state_root(base_type: &str, topology: &str) -> PathBuf {
+    repo_root()
+        .join("target/operator-probe-state")
+        .join("review-run")
+        .join("simard-engineer")
         .join(base_type)
         .join(topology)
 }
@@ -238,6 +266,24 @@ fn bare_simard_shows_unified_help_instead_of_bootstrap_env_errors() {
 }
 
 #[test]
+fn simard_help_documents_meeting_read_as_the_durable_meeting_audit_surface() {
+    let output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("--help")
+        .output()
+        .expect("simard help should launch");
+    let rendered = rendered_output(&output);
+
+    assert!(
+        output.status.success(),
+        "simard help should stay readable while the durable meeting read command is added:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("meeting read <base-type> <topology> [state-root]"),
+        "simard help should document the canonical read-only meeting workflow:\n{rendered}"
+    );
+}
+
+#[test]
 fn simard_help_documents_goal_curation_read_as_the_durable_register_inspection_surface() {
     let output = Command::new(env!("CARGO_BIN_EXE_simard"))
         .arg("--help")
@@ -252,6 +298,24 @@ fn simard_help_documents_goal_curation_read_as_the_durable_register_inspection_s
     assert!(
         rendered.contains("goal-curation read <base-type> <topology> [state-root]"),
         "simard help should document the canonical read-only goal register workflow:\n{rendered}"
+    );
+}
+
+#[test]
+fn simard_help_documents_improvement_curation_read_as_the_durable_review_decision_surface() {
+    let output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("--help")
+        .output()
+        .expect("simard help should launch");
+    let rendered = rendered_output(&output);
+
+    assert!(
+        output.status.success(),
+        "simard help should stay readable while the durable improvement readback command is added:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("improvement-curation read <base-type> <topology> [state-root]"),
+        "simard help should document the canonical read-only improvement curation workflow:\n{rendered}"
     );
 }
 
@@ -434,6 +498,105 @@ goal: Track future remote orchestration | priority=6 | status=active | rationale
     assert!(
         !goal_rendered.contains("Track future remote orchestration"),
         "goal-curation mode should omit lower-priority active goals from the top-five surface:\n{goal_rendered}"
+    );
+}
+
+#[test]
+fn simard_meeting_read_reuses_the_run_default_state_root_and_stays_read_only() {
+    let _lock = meeting_default_root_lock()
+        .lock()
+        .expect("meeting default root test lock should not be poisoned");
+    let state_root = default_meeting_state_root("local-harness", "single-process");
+    let _cleanup = CleanupDirGuard::new(state_root.clone());
+    let meeting_objective = "\
+agenda: align the next Simard workstream\n\
+update: durable \u{1b}[31mmemory\u{1b}[0m merged\n\
+decision: preserve meeting-to-engineer continuity\n\
+risk: workflow routing is still unreliable\n\
+next-step: keep durable priorities visible\n\
+open-question: how aggressively should Simard reprioritize?\n\
+goal: Preserve \u{1b}]8;;https://example.invalid\u{7}meeting handoff\u{1b}]8;;\u{7} | priority=1 | status=active | rationale=meeting decisions must shape later work";
+
+    let run_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("meeting")
+        .arg("run")
+        .arg("local-harness")
+        .arg("single-process")
+        .arg(meeting_objective)
+        .output()
+        .expect("simard meeting run should launch with its default state root");
+    let run_rendered = rendered_output(&run_output);
+
+    assert!(
+        run_output.status.success(),
+        "meeting run should succeed with its canonical default state root:\n{run_rendered}"
+    );
+    assert!(
+        run_rendered.contains(&format!("State root: {}", state_root.display())),
+        "meeting run should surface the canonical default durable root it writes:\n{run_rendered}"
+    );
+
+    let memory_before =
+        fs::read(state_root.join("memory_records.json")).expect("memory store should exist");
+    let goals_before =
+        fs::read(state_root.join("goal_records.json")).expect("goal store should exist");
+
+    let read_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("meeting")
+        .arg("read")
+        .arg("local-harness")
+        .arg("single-process")
+        .output()
+        .expect("simard meeting read should launch with its default state root");
+    let read_rendered = rendered_output(&read_output);
+
+    assert!(
+        read_output.status.success(),
+        "meeting read should inspect the same canonical default durable root that run populates:\n{read_rendered}"
+    );
+    for expected in [
+        "Probe mode: meeting-read",
+        "Identity: simard-meeting",
+        &format!("State root: {}", state_root.display()),
+        "Meeting records: 1",
+        "Latest agenda: align the next Simard workstream",
+        "Updates count: 1",
+        "Update 1: durable memory merged",
+        "Decisions count: 1",
+        "Decision 1: preserve meeting-to-engineer continuity",
+        "Risks count: 1",
+        "Risk 1: workflow routing is still unreliable",
+        "Next steps count: 1",
+        "Next step 1: keep durable priorities visible",
+        "Open questions count: 1",
+        "Open question 1: how aggressively should Simard reprioritize?",
+        "Goal updates count: 1",
+        "Goal update 1: p1 [active] Preserve meeting handoff",
+        "Latest meeting record: agenda=align the next Simard workstream;",
+    ] {
+        assert!(
+            read_rendered.contains(expected),
+            "meeting read should surface '{expected}' for operators:\n{read_rendered}"
+        );
+    }
+    for forbidden in ['\u{1b}', '\u{7}'] {
+        assert!(
+            !read_rendered.contains(forbidden),
+            "meeting read should sanitize persisted operator-visible text before printing it:\n{read_rendered}"
+        );
+    }
+
+    let memory_after =
+        fs::read(state_root.join("memory_records.json")).expect("memory store should exist");
+    let goals_after =
+        fs::read(state_root.join("goal_records.json")).expect("goal store should exist");
+    assert_eq!(
+        memory_before, memory_after,
+        "meeting read must not rewrite the durable memory store"
+    );
+    assert_eq!(
+        goals_before, goals_after,
+        "meeting read must not rewrite the durable goal store"
     );
 }
 
@@ -728,6 +891,70 @@ fn simard_goal_curation_read_shows_explicit_zero_state_sections_for_an_empty_reg
 }
 
 #[test]
+fn simard_meeting_read_rejects_nonexistent_and_empty_state_roots_before_store_access() {
+    let temp_dir = TempDirGuard::new("simard-cli-meeting-read-invalid-root");
+    let missing_root = temp_dir.path().join("missing-layout");
+    let empty_root = temp_dir.path().join("empty-layout");
+    fs::create_dir_all(&empty_root).expect("empty state root fixture should be created");
+
+    let missing_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("meeting")
+        .arg("read")
+        .arg("local-harness")
+        .arg("single-process")
+        .arg(&missing_root)
+        .output()
+        .expect("simard meeting read missing-root check should launch");
+    let missing_rendered = rendered_output(&missing_output);
+
+    assert!(
+        !missing_output.status.success(),
+        "meeting read must fail visibly for a nonexistent explicit state root:\n{missing_rendered}"
+    );
+    assert!(
+        missing_rendered.contains("invalid state root")
+            || missing_rendered.contains("InvalidStateRoot"),
+        "meeting read should keep the failing state-root contract explicit:\n{missing_rendered}"
+    );
+    assert!(
+        missing_rendered.contains("requires an existing state root directory"),
+        "meeting read should explain why a nonexistent explicit root was rejected:\n{missing_rendered}"
+    );
+    assert!(
+        !missing_rendered.contains("expected persisted meeting decision record"),
+        "meeting read should reject a nonexistent root before probing for persisted meeting records:\n{missing_rendered}"
+    );
+
+    let empty_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("meeting")
+        .arg("read")
+        .arg("local-harness")
+        .arg("single-process")
+        .arg(&empty_root)
+        .output()
+        .expect("simard meeting read empty-root check should launch");
+    let empty_rendered = rendered_output(&empty_output);
+
+    assert!(
+        !empty_output.status.success(),
+        "meeting read must fail visibly for an empty explicit state root:\n{empty_rendered}"
+    );
+    assert!(
+        empty_rendered.contains("invalid state root")
+            || empty_rendered.contains("InvalidStateRoot"),
+        "meeting read should keep empty-root failures in the state-root contract:\n{empty_rendered}"
+    );
+    assert!(
+        empty_rendered.contains("memory_records.json"),
+        "meeting read should pinpoint the missing persisted meeting store entry for an empty root:\n{empty_rendered}"
+    );
+    assert!(
+        !empty_rendered.contains("expected persisted meeting decision record"),
+        "meeting read should reject an empty root before probing for meeting records:\n{empty_rendered}"
+    );
+}
+
+#[test]
 fn simard_goal_curation_read_rejects_invalid_state_roots_before_any_store_access() {
     let temp_dir = TempDirGuard::new("simard-cli-goal-curation-read-invalid-root");
     let bad_parent_dir_root = temp_dir.path().join("../escape");
@@ -1007,6 +1234,175 @@ approve: Promote this pattern into a repeatable benchmark | priority=2 | status=
     assert!(
         improvement_rendered.contains("Active goals count: 1"),
         "approved active improvements should become durable active goals:\n{improvement_rendered}"
+    );
+}
+
+#[test]
+fn simard_improvement_curation_read_reuses_the_review_default_state_root_and_stays_read_only() {
+    let _lock = review_default_root_lock()
+        .lock()
+        .expect("review default root test lock should not be poisoned");
+    let state_root = default_review_state_root("local-harness", "single-process");
+    let _cleanup = CleanupDirGuard::new(state_root.clone());
+
+    let review_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("review")
+        .arg("run")
+        .arg("local-harness")
+        .arg("single-process")
+        .arg("inspect the current Simard review surface and preserve concrete proposals")
+        .output()
+        .expect("simard review run should launch with its default state root");
+    let review_rendered = rendered_output(&review_output);
+
+    assert!(
+        review_output.status.success(),
+        "review run should succeed with its canonical default state root:\n{review_rendered}"
+    );
+    assert!(
+        review_rendered.contains(&format!("State root: {}", state_root.display())),
+        "review run should surface the canonical durable root that improvement read later inspects:\n{review_rendered}"
+    );
+
+    let improvement_objective = "\
+approve: Capture denser execution evidence | priority=1 | status=active | rationale=operators need denser execution evidence now\n\
+defer: Promote this pattern into a repeatable benchmark | rationale=wait for the next benchmark planning pass";
+    let improvement_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("improvement-curation")
+        .arg("run")
+        .arg("local-harness")
+        .arg("single-process")
+        .arg(improvement_objective)
+        .output()
+        .expect("simard improvement-curation run should launch with the review default state root");
+    let improvement_rendered = rendered_output(&improvement_output);
+
+    assert!(
+        improvement_output.status.success(),
+        "improvement-curation run should share the canonical review/improvement durable root:\n{improvement_rendered}"
+    );
+    assert!(
+        improvement_rendered.contains(&format!("State root: {}", state_root.display())),
+        "improvement-curation run should surface the shared durable root that readback reuses:\n{improvement_rendered}"
+    );
+
+    let memory_before =
+        fs::read(state_root.join("memory_records.json")).expect("memory store should exist");
+    let goals_before =
+        fs::read(state_root.join("goal_records.json")).expect("goal store should exist");
+
+    let read_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("improvement-curation")
+        .arg("read")
+        .arg("local-harness")
+        .arg("single-process")
+        .output()
+        .expect(
+            "simard improvement-curation read should launch with the review default state root",
+        );
+    let read_rendered = rendered_output(&read_output);
+
+    assert!(
+        read_output.status.success(),
+        "improvement-curation read should expose durable review and promotion state through the primary CLI:\n{read_rendered}"
+    );
+    for expected in [
+        "Probe mode: improvement-curation-read",
+        &format!("State root: {}", state_root.display()),
+        "Latest review artifact:",
+        "Review id:",
+        "Review target:",
+        "Approved proposals: 1",
+        "Approved proposal 1: p1 [active] Capture denser execution evidence",
+        "Deferred proposals: 1",
+        "Deferred proposal 1: Promote this pattern into a repeatable benchmark (wait for the next benchmark planning pass)",
+        "Active goals count: 1",
+        "Active goal 1: p1 [active] Capture denser execution evidence",
+        "Proposed goals count: 0",
+        "Latest improvement record: review=",
+    ] {
+        assert!(
+            read_rendered.contains(expected),
+            "improvement-curation read should surface '{expected}' for operators:\n{read_rendered}"
+        );
+    }
+
+    let memory_after =
+        fs::read(state_root.join("memory_records.json")).expect("memory store should exist");
+    let goals_after =
+        fs::read(state_root.join("goal_records.json")).expect("goal store should exist");
+    assert_eq!(
+        memory_before, memory_after,
+        "improvement-curation read must not rewrite the durable memory store"
+    );
+    assert_eq!(
+        goals_before, goals_after,
+        "improvement-curation read must not rewrite the durable goal store"
+    );
+}
+
+#[test]
+fn simard_improvement_curation_read_rejects_nonexistent_and_empty_state_roots_before_probe_access()
+{
+    let temp_dir = TempDirGuard::new("simard-cli-improvement-curation-read-invalid-root");
+    let missing_root = temp_dir.path().join("missing-layout");
+    let empty_root = temp_dir.path().join("empty-layout");
+    fs::create_dir_all(&empty_root).expect("empty state root fixture should be created");
+
+    let missing_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("improvement-curation")
+        .arg("read")
+        .arg("local-harness")
+        .arg("single-process")
+        .arg(&missing_root)
+        .output()
+        .expect("simard improvement-curation read missing-root check should launch");
+    let missing_rendered = rendered_output(&missing_output);
+
+    assert!(
+        !missing_output.status.success(),
+        "improvement-curation read must fail visibly for a nonexistent explicit state root:\n{missing_rendered}"
+    );
+    assert!(
+        missing_rendered.contains("invalid state root")
+            || missing_rendered.contains("InvalidStateRoot"),
+        "improvement-curation read should keep the failing state-root contract explicit:\n{missing_rendered}"
+    );
+    assert!(
+        missing_rendered.contains("requires an existing state root directory"),
+        "improvement-curation read should explain why a nonexistent explicit root was rejected:\n{missing_rendered}"
+    );
+    assert!(
+        !missing_rendered.contains("expected persisted review artifact"),
+        "improvement-curation read should reject a nonexistent root before probing for artifacts:\n{missing_rendered}"
+    );
+
+    let empty_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("improvement-curation")
+        .arg("read")
+        .arg("local-harness")
+        .arg("single-process")
+        .arg(&empty_root)
+        .output()
+        .expect("simard improvement-curation read empty-root check should launch");
+    let empty_rendered = rendered_output(&empty_output);
+
+    assert!(
+        !empty_output.status.success(),
+        "improvement-curation read must fail visibly for an empty explicit state root:\n{empty_rendered}"
+    );
+    assert!(
+        empty_rendered.contains("invalid state root")
+            || empty_rendered.contains("InvalidStateRoot"),
+        "improvement-curation read should keep empty-root failures in the state-root contract:\n{empty_rendered}"
+    );
+    assert!(
+        empty_rendered.contains("review-artifacts"),
+        "improvement-curation read should pinpoint the missing read-only layout entry for an empty root:\n{empty_rendered}"
+    );
+    assert!(
+        !empty_rendered.contains("expected persisted review artifact"),
+        "improvement-curation read should reject an empty root before probing for review artifacts:\n{empty_rendered}"
     );
 }
 


### PR DESCRIPTION
## Summary
- add operator read commands for durable meeting and improvement-curation state on the unified `simard` CLI
- preserve operator-visible goal and meeting text while parsing durable state safely
- document and test the new read surfaces outside-in

## Validation
- cargo test --all-features --locked
- python3 -m pre_commit run --all-files --hook-stage pre-commit
- python3 -m pre_commit run --all-files --hook-stage pre-push
- tests/gadugi/smoke-explicit-local.sh && tests/gadugi/smoke-explicit-rusty-clawd.sh && tests/gadugi/smoke-builtin-defaults.sh && tests/gadugi/composite-identity.sh && tests/gadugi/meeting-mode.sh && tests/gadugi/goal-stewardship.sh && tests/gadugi/improvement-curation.sh && tests/gadugi/terminal-session.sh && tests/gadugi/engineer-loop.sh && tests/gadugi/handoff-roundtrip.sh && tests/gadugi/gym-suite.sh