### PR TITLE
Add engineer state read command

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 title: Simard documentation
-description: Start here for the shipped `simard` operator CLI, compatibility binaries, runtime contracts, and benchmark flow.
+description: Start here for the shipped `simard` operator CLI, the `engineer read` audit companion, compatibility binaries, runtime contracts, and benchmark flow.
 last_updated: 2026-03-30
 review_schedule: as-needed
 owner: simard
@@ -10,7 +10,7 @@ owner: simard
 
 `simard` is the canonical operator-facing CLI.
 
-The shipped command tree covers `engineer`, `meeting`, `goal-curation`, `improvement-curation`, `gym`, `review`, and `bootstrap` from one binary. The legacy `simard_operator_probe` and `simard-gym` binaries remain available as compatibility surfaces while operators migrate, but the primary product surface is now `simard ...`.
+The shipped command tree covers `engineer`, `meeting`, `goal-curation`, `improvement-curation`, `gym`, `review`, and `bootstrap` from one binary, including the read-only `engineer read` audit companion. The legacy `simard_operator_probe` and `simard-gym` binaries remain available as compatibility surfaces while operators migrate, but the primary product surface is now `simard ...`.
 
 ## Start here
 
@@ -20,8 +20,8 @@ The shipped command tree covers `engineer`, `meeting`, `goal-curation`, `improve
 - [How to carry meeting decisions into engineer sessions](./howto/carry-meeting-decisions-into-engineer-sessions.md) - Persist meeting records under a shared state root and confirm later engineer runs carry them forward.
 - [How to inspect meeting records](./howto/inspect-meeting-records.md) - Read back the latest durable meeting record without mutating stored state.
 - [How to inspect improvement-curation state](./howto/inspect-improvement-curation-state.md) - Read back the latest approved, deferred, and promoted improvement state without mutation.
-- [Simard CLI reference](./reference/simard-cli.md) - Look up the shipped command tree and compatibility mappings.
-- [Runtime contracts reference](./reference/runtime-contracts.md) - Look up executable contracts and lifecycle guarantees.
+- [Simard CLI reference](./reference/simard-cli.md) - Look up the shipped command tree, `engineer read` audit surface, and compatibility mappings.
+- [Runtime contracts reference](./reference/runtime-contracts.md) - Look up executable contracts, state-root guarantees, and the shipped engineer audit readback semantics.
 - [Concept: truthful runtime metadata](./concepts/truthful-runtime-metadata.md) - Read the design rationale behind the stricter runtime contract.
 
 ## Canonical executable surface

--- a/docs/reference/runtime-contracts.md
+++ b/docs/reference/runtime-contracts.md
@@ -1,6 +1,6 @@
 ---
 title: Runtime contracts reference
-description: Reference for the shipped Simard executable surfaces, compatibility binaries, and the in-process runtime contracts that back them.
+description: Reference for the shipped Simard executable surfaces, the `engineer read` audit contract, compatibility binaries, and the in-process runtime contracts that back them.
 last_updated: 2026-03-30
 review_schedule: as-needed
 owner: simard
@@ -19,6 +19,7 @@ related:
 This document covers:
 
 - the canonical `simard` CLI surface
+- the `engineer read` audit surface
 - the compatibility binaries that still expose a few legacy entrypoints
 - the in-process Rust runtime and bootstrap types in `src/bootstrap.rs`, `src/runtime.rs`, and related modules
 
@@ -34,6 +35,7 @@ Simard does **not** expose:
 | --- | --- | --- |
 | explicit bootstrap | `simard bootstrap run ...` | `simard_operator_probe bootstrap-run ...` |
 | bounded engineer loop | `simard engineer run ...` | `simard_operator_probe engineer-loop-run ...` |
+| engineer state readback | `simard engineer read ...` | `simard_operator_probe engineer-read ...` |
 | terminal-backed engineer substrate | `simard engineer terminal ...` | `simard_operator_probe terminal-run ...` |
 | meeting mode | `simard meeting run ...` | `simard_operator_probe meeting-run ...` |
 | meeting state readback | `simard meeting read ...` | `simard_operator_probe meeting-read ...` |
@@ -49,6 +51,7 @@ Simard does **not** expose:
 The shipped operator-facing command tree is:
 
 - `simard engineer run <topology> <workspace-root> <objective> [state-root]`
+- `simard engineer read <topology> [state-root]`
 - `simard engineer terminal <topology> <objective> [state-root]`
 - `simard meeting run <base-type> <topology> <structured-objective> [state-root]`
 - `simard meeting read <base-type> <topology> [state-root]`
@@ -110,6 +113,36 @@ That structured edit path is intentionally narrow:
 - the repo must start clean so Simard does not overwrite unrelated user changes
 - only one expected changed file is allowed
 - verification must confirm both file content and git-visible change state
+
+#### Engineer state readback
+
+Canonical entrypoint: `simard engineer read <topology> [state-root]`
+
+Compatibility surface: `simard_operator_probe engineer-read <topology> [state-root]`
+
+This is a read-only engineer audit surface, not a sixth operator mode. It exists to inspect the durable engineer artifacts that `engineer run` already writes.
+
+The contract is intentionally explicit:
+
+- `engineer run` remains the only mutation and execution path for engineer work
+- `engineer read` reuses the same validated default state root as `engineer run` when `[state-root]` is omitted
+- any explicit `state-root` must already exist as a directory before readback begins
+- `engineer read` requires readable regular-file `latest_handoff.json`, `memory_records.json`, and `evidence_records.json`; symlinked artifacts are rejected
+- `latest_handoff.json` is authoritative for identity, selected base type, topology, session phase, redacted objective metadata, and the exported memory/evidence snapshot tied to the latest engineer run
+- persisted handoff objective metadata must already be trusted `objective-metadata(chars=<n>, words=<n>, lines=<n>)`; malformed or tampered metadata fails instead of being replayed
+- standalone `memory_records.json` and `evidence_records.json` files act as durability checks and supporting record-count sources; if they disagree with the handoff snapshot, handoff-derived values win
+- only redacted objective metadata is printable; raw engineer objective text must never be rendered back to the terminal
+- carried meeting state must remain valid persisted meeting records; malformed carried-meeting data fails explicitly instead of falling back to raw strings
+- operator-visible strings are sanitized before printing so terminal control sequences and secret-shaped values are not replayed
+- output order stays deterministic: runtime header, handoff session summary, repo grounding, carried context, selected action summary, verification summary, durable record counts
+- the command performs no mutation, repair, resume, or execution
+- invalid state roots, missing files, unreadable storage, and malformed persisted engineer data fail explicitly
+
+The default root remains the same engineer durable path already used by `engineer run`:
+
+```text
+target/operator-probe-state/engineer-loop-run/simard-engineer/terminal-shell/<topology>
+```
 
 ### Terminal-backed engineer substrate
 

--- a/docs/reference/simard-cli.md
+++ b/docs/reference/simard-cli.md
@@ -1,6 +1,6 @@
 ---
 title: Simard CLI reference
-description: Reference for the shipped `simard` command tree and the legacy compatibility binaries that still expose selected older runtime behaviors.
+description: Reference for the shipped `simard` command tree, the `engineer read` audit companion, and the legacy compatibility binaries that still expose selected older runtime behaviors.
 last_updated: 2026-03-30
 review_schedule: as-needed
 owner: simard
@@ -22,15 +22,16 @@ related:
 
 The legacy `simard_operator_probe` and `simard-gym` binaries still ship for compatibility, but new operator workflows should use `simard ...`.
 
-This page distinguishes shipped commands from compatibility surfaces. When a compatibility surface is listed as `none`, the command is canonical-only.
+This page documents the shipped operator-facing command tree. When a compatibility surface is listed as `none`, the command is canonical-only.
 
-## Shipped command tree
+## Command tree
 
 ```text
 simard
 |- engineer
 |  |- run <topology> <workspace-root> <objective> [state-root]
-|  `- terminal <topology> <objective> [state-root]
+|  |- terminal <topology> <objective> [state-root]
+|  `- read <topology> [state-root]
 |- meeting
 |  |- run <base-type> <topology> <structured-objective> [state-root]
 |  `- read <base-type> <topology> [state-root]
@@ -52,7 +53,7 @@ simard
    `- run <identity> <base-type> <topology> <objective> [state-root]
 ```
 
-Bare `simard` prints this unified help surface.
+Bare `simard` prints this operator surface directly.
 
 ## Compatibility mapping
 
@@ -60,6 +61,7 @@ Bare `simard` prints this unified help surface.
 | --- | --- |
 | `simard engineer run ...` | `simard_operator_probe engineer-loop-run ...` |
 | `simard engineer terminal ...` | `simard_operator_probe terminal-run ...` |
+| `simard engineer read ...` | `simard_operator_probe engineer-read ...` |
 | `simard meeting run ...` | `simard_operator_probe meeting-run ...` |
 | `simard meeting read ...` | `simard_operator_probe meeting-read ...` |
 | `simard goal-curation run ...` | `simard_operator_probe goal-curation-run ...` |
@@ -106,6 +108,67 @@ verify the outcome explicitly
 persist truthful local evidence and memory'
 
 simard engineer run single-process "$PWD" "$ENGINEER_OBJECTIVE" "$STATE_ROOT"
+```
+
+### `simard engineer read <topology> [state-root]`
+
+This is the read-only audit companion to `simard engineer run`. It inspects the latest persisted engineer state without resuming execution, repairing artifacts, or re-running the engineer loop.
+
+Behavior:
+
+- reuses the same canonical default durable root as `engineer run` when `[state-root]` is omitted
+- validates `topology` before deriving that default root, so the default still follows the shipped engineer runtime pairing
+- requires any explicit `state-root` to already exist as a directory
+- requires `latest_handoff.json`, `memory_records.json`, and `evidence_records.json` to already exist as readable regular files; symlinked artifacts are rejected
+- treats `latest_handoff.json` as authoritative for session identity, selected base type, topology, session phase, redacted objective metadata, and the exported memory/evidence snapshot tied to the latest engineer run
+- requires the persisted handoff session objective to already be trusted `objective-metadata(chars=<n>, words=<n>, lines=<n>)`; malformed or tampered metadata fails instead of being replayed
+- uses the standalone `memory_records.json` and `evidence_records.json` files as durability checks and supporting evidence counts; if they disagree with the handoff snapshot, the handoff-derived values win
+- renders only redacted objective metadata such as `objective-metadata(chars=150, words=21, lines=1)`, never the raw engineer objective text
+- requires carried meeting state to remain valid persisted meeting records; malformed carried-meeting data fails instead of being downgraded to raw strings
+- strips terminal control sequences and secret-shaped values from every displayed string before printing it
+- prints a stable operator-visible order: runtime header, handoff session summary, repo grounding, carried context, selected action summary, verification summary, durable record counts
+- fails explicitly for invalid `state-root` values and for missing, unreadable, or malformed persisted engineer state
+
+When `[state-root]` is omitted, the command reuses the same canonical durable root that `engineer run` already writes:
+
+```text
+target/operator-probe-state/engineer-loop-run/simard-engineer/terminal-shell/<topology>
+```
+
+Example:
+
+```bash
+simard engineer read single-process "$STATE_ROOT"
+```
+
+Output shape:
+
+```text
+Probe mode: engineer-read
+Identity: simard-engineer
+Selected base type: terminal-shell
+Topology: single-process
+State root: /tmp/simard-engineer.XXXXXX
+Session phase: complete
+Objective metadata: objective-metadata(chars=150, words=21, lines=1)
+Repo root: /path/to/repo
+Repo branch: main
+Repo head: 4b6cb7de0179e9adb480dfdea1cb2aee4a5d5e18
+Worktree dirty: false
+Changed files: <none>
+Active goals count: 1
+Active goal 1: p1 [active] Preserve meeting handoff
+Carried meeting decisions: 1
+Carried meeting decision 1: preserve meeting-to-engineer continuity
+Selected action: cargo-metadata-scan
+Action plan: Inspect the repo, query Cargo metadata without mutating files, and verify repo grounding stayed stable.
+Verification steps: confirm cargo metadata returns valid workspace JSON || confirm repo root, branch, HEAD, and worktree state stayed stable || confirm carried meeting decisions and active goals stayed stable
+Action status: success
+Changed files after action: <none>
+Verification status: verified
+Verification summary: Verified local-only engineer action 'cargo-metadata-scan' against stable repo grounding, unchanged worktree state, and explicit repo-native action checks.
+Memory records: 3
+Evidence records: 19
 ```
 
 ### `simard engineer terminal <topology> <objective> [state-root]`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,10 +77,11 @@ pub use metadata::{BackendDescriptor, Freshness, FreshnessState, Provenance};
 pub use operator_cli::{dispatch_operator_cli, operator_cli_help, operator_cli_usage};
 pub use operator_commands::{
     dispatch_legacy_gym_cli, dispatch_operator_probe, gym_usage, run_bootstrap_probe,
-    run_engineer_loop_probe, run_goal_curation_probe, run_goal_curation_read_probe,
-    run_gym_compare, run_gym_list, run_gym_scenario, run_gym_suite, run_handoff_probe,
-    run_improvement_curation_probe, run_improvement_curation_read_probe, run_meeting_probe,
-    run_meeting_read_probe, run_review_probe, run_review_read_probe, run_terminal_probe,
+    run_engineer_loop_probe, run_engineer_read_probe, run_goal_curation_probe,
+    run_goal_curation_read_probe, run_gym_compare, run_gym_list, run_gym_scenario, run_gym_suite,
+    run_handoff_probe, run_improvement_curation_probe, run_improvement_curation_read_probe,
+    run_meeting_probe, run_meeting_read_probe, run_review_probe, run_review_read_probe,
+    run_terminal_probe,
 };
 pub use prompt_assets::{
     FilePromptAssetStore, InMemoryPromptAssetStore, PromptAsset, PromptAssetId, PromptAssetRef,

--- a/src/operator_cli.rs
+++ b/src/operator_cli.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use crate::operator_commands::{
-    run_bootstrap_probe, run_engineer_loop_probe, run_goal_curation_probe,
+    run_bootstrap_probe, run_engineer_loop_probe, run_engineer_read_probe, run_goal_curation_probe,
     run_goal_curation_read_probe, run_gym_compare, run_gym_list, run_gym_scenario, run_gym_suite,
     run_improvement_curation_probe, run_improvement_curation_read_probe, run_meeting_probe,
     run_meeting_read_probe, run_review_probe, run_review_read_probe, run_terminal_probe,
@@ -13,6 +13,7 @@ Simard unified operator CLI
 Product modes:
   engineer run <topology> <workspace-root> <objective> [state-root]
   engineer terminal <topology> <objective> [state-root]
+  engineer read <topology> [state-root]
   meeting run <base-type> <topology> <objective> [state-root]
   meeting read <base-type> <topology> [state-root]
   goal-curation run <base-type> <topology> <objective> [state-root]
@@ -91,6 +92,12 @@ fn dispatch_engineer_command(
             let state_root = next_optional_path(&mut args);
             reject_extra_args(args)?;
             run_terminal_probe(&topology, &objective, state_root)
+        }
+        "read" => {
+            let topology = next_required(&mut args, "topology")?;
+            let state_root = next_optional_path(&mut args);
+            reject_extra_args(args)?;
+            run_engineer_read_probe(&topology, state_root)
         }
         other => Err(format!("unsupported command 'engineer {other}'").into()),
     }

--- a/src/operator_commands.rs
+++ b/src/operator_commands.rs
@@ -8,12 +8,13 @@ use crate::improvements::PersistedImprovementRecord;
 use crate::meetings::PersistedMeetingRecord;
 use crate::sanitization::sanitize_terminal_text;
 use crate::{
-    BootstrapConfig, BootstrapInputs, BuiltinIdentityLoader, FileBackedMemoryStore, Freshness,
+    BootstrapConfig, BootstrapInputs, BuiltinIdentityLoader, EvidenceRecord,
+    FileBackedEvidenceStore, FileBackedHandoffStore, FileBackedMemoryStore, Freshness,
     IdentityLoadRequest, IdentityLoader, ManifestContract, MemoryRecord, MemoryScope, MemoryStore,
-    Provenance, ReflectiveRuntime, ReviewRequest, ReviewTargetKind, RuntimeTopology,
-    assemble_local_runtime_from_handoff, benchmark_scenarios, build_review_artifact,
-    builtin_base_type_registry_for_manifest, compare_latest_benchmark_runs, default_output_root,
-    latest_local_handoff, latest_review_artifact, persist_review_artifact,
+    Provenance, ReflectiveRuntime, ReviewRequest, ReviewTargetKind, RuntimeHandoffSnapshot,
+    RuntimeHandoffStore, RuntimeTopology, assemble_local_runtime_from_handoff, benchmark_scenarios,
+    build_review_artifact, builtin_base_type_registry_for_manifest, compare_latest_benchmark_runs,
+    default_output_root, latest_local_handoff, latest_review_artifact, persist_review_artifact,
     render_review_context_directives, review_artifacts_dir, run_benchmark_scenario,
     run_benchmark_suite, run_local_engineer_loop, run_local_session,
 };
@@ -85,6 +86,12 @@ where
                 &objective,
                 state_root,
             )?;
+        }
+        "engineer-read" => {
+            let topology = next_required(&mut args, "topology")?;
+            let state_root = next_optional_path(&mut args);
+            reject_extra_args(args)?;
+            run_engineer_read_probe(&topology, state_root)?;
         }
         "review-run" => {
             let base_type = next_required(&mut args, "base type")?;
@@ -570,6 +577,16 @@ pub fn run_engineer_loop_probe(
     println!("Verification status: {}", run.verification.status);
     print_text("Verification summary", &run.verification.summary);
     print_display("State root", run.state_root.display());
+    Ok(())
+}
+
+pub fn run_engineer_read_probe(
+    topology: &str,
+    state_root_override: Option<PathBuf>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let state_root = resolved_engineer_read_state_root(state_root_override, topology)?;
+    let view = EngineerReadView::load(state_root)?;
+    view.print();
     Ok(())
 }
 
@@ -1105,6 +1122,21 @@ fn resolved_improvement_curation_read_state_root(
     Ok(state_root)
 }
 
+fn resolved_engineer_read_state_root(
+    explicit: Option<PathBuf>,
+    topology: &str,
+) -> crate::SimardResult<PathBuf> {
+    let state_root = resolved_state_root(
+        explicit,
+        "simard-engineer",
+        "terminal-shell",
+        topology,
+        "engineer-loop-run",
+    )?;
+    validate_engineer_read_state_root(&state_root)?;
+    Ok(state_root)
+}
+
 fn resolved_meeting_read_state_root(
     explicit: Option<PathBuf>,
     base_type: &str,
@@ -1128,6 +1160,11 @@ fn validate_meeting_read_state_root(state_root: &Path) -> crate::SimardResult<()
         state_root,
         &state_root.join("memory_records.json"),
     )?;
+    Ok(())
+}
+
+fn validate_engineer_read_state_root(state_root: &Path) -> crate::SimardResult<()> {
+    validated_engineer_read_artifacts(state_root)?;
     Ok(())
 }
 
@@ -1158,10 +1195,16 @@ fn validate_existing_read_state_root_root(
     state_root: &Path,
 ) -> crate::SimardResult<()> {
     let root_metadata =
-        fs::metadata(state_root).map_err(|error| crate::SimardError::InvalidStateRoot {
+        fs::symlink_metadata(state_root).map_err(|error| crate::SimardError::InvalidStateRoot {
             path: state_root.to_path_buf(),
             reason: format!("{mode_label} requires an existing state root directory: {error}"),
         })?;
+    if root_metadata.file_type().is_symlink() {
+        return Err(crate::SimardError::InvalidStateRoot {
+            path: state_root.to_path_buf(),
+            reason: format!("{mode_label} requires state-root to be a directory, not a symlink"),
+        });
+    }
     if root_metadata.is_dir() {
         return Ok(());
     }
@@ -1178,13 +1221,17 @@ fn require_existing_read_directory_for_mode(
     path: &Path,
     label: &str,
 ) -> crate::SimardResult<()> {
-    let metadata = fs::metadata(path).map_err(|error| crate::SimardError::InvalidStateRoot {
-        path: state_root.to_path_buf(),
-        reason: format!(
-            "{mode_label} requires '{}' to exist as a directory: {error}",
-            path.display()
-        ),
-    })?;
+    let metadata =
+        fs::symlink_metadata(path).map_err(|error| crate::SimardError::InvalidStateRoot {
+            path: state_root.to_path_buf(),
+            reason: format!("{mode_label} requires {label} to exist as a directory: {error}"),
+        })?;
+    if metadata.file_type().is_symlink() {
+        return Err(crate::SimardError::InvalidStateRoot {
+            path: state_root.to_path_buf(),
+            reason: format!("{mode_label} requires {label} to exist as a directory, not a symlink"),
+        });
+    }
     if metadata.is_dir() {
         return Ok(());
     }
@@ -1199,25 +1246,65 @@ fn require_existing_read_file_for_mode(
     mode_label: &str,
     state_root: &Path,
     path: &Path,
-) -> crate::SimardResult<()> {
-    let metadata = fs::metadata(path).map_err(|error| crate::SimardError::InvalidStateRoot {
-        path: state_root.to_path_buf(),
-        reason: format!(
-            "{mode_label} requires '{}' to exist as a file: {error}",
-            path.display()
-        ),
-    })?;
+) -> crate::SimardResult<PathBuf> {
+    let file_name = artifact_name(path);
+    let metadata =
+        fs::symlink_metadata(path).map_err(|error| crate::SimardError::InvalidStateRoot {
+            path: state_root.to_path_buf(),
+            reason: format!(
+                "{mode_label} requires {file_name} to exist as a regular file: {error}"
+            ),
+        })?;
+    if metadata.file_type().is_symlink() {
+        return Err(crate::SimardError::InvalidStateRoot {
+            path: state_root.to_path_buf(),
+            reason: format!(
+                "{mode_label} requires {file_name} to exist as a regular file, not a symlink"
+            ),
+        });
+    }
     if metadata.is_file() {
-        return Ok(());
+        return Ok(path.to_path_buf());
     }
 
-    let file_name = path
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or("file");
     Err(crate::SimardError::InvalidStateRoot {
         path: state_root.to_path_buf(),
-        reason: format!("{mode_label} requires {file_name} to exist as a file"),
+        reason: format!("{mode_label} requires {file_name} to exist as a regular file"),
+    })
+}
+
+fn artifact_name(path: &Path) -> &str {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("file")
+}
+
+struct EngineerReadArtifacts {
+    handoff_path: PathBuf,
+    memory_path: PathBuf,
+    evidence_path: PathBuf,
+}
+
+fn validated_engineer_read_artifacts(
+    state_root: &Path,
+) -> crate::SimardResult<EngineerReadArtifacts> {
+    validate_existing_read_state_root_root("engineer read", state_root)?;
+    Ok(EngineerReadArtifacts {
+        handoff_path: require_existing_read_file_for_mode(
+            "engineer read",
+            state_root,
+            &state_root.join("latest_handoff.json"),
+        )?,
+        memory_path: require_existing_read_file_for_mode(
+            "engineer read",
+            state_root,
+            &state_root.join("memory_records.json"),
+        )?,
+        evidence_path: require_existing_read_file_for_mode(
+            "engineer read",
+            state_root,
+            &state_root.join("evidence_records.json"),
+        )?,
     })
 }
 
@@ -1232,6 +1319,244 @@ fn parse_runtime_topology(value: &str) -> crate::SimardResult<RuntimeTopology> {
             help: "expected 'single-process', 'multi-process', or 'distributed'".to_string(),
         }),
     }
+}
+
+struct EngineerReadView {
+    state_root: PathBuf,
+    identity: String,
+    selected_base_type: String,
+    topology: String,
+    session_phase: String,
+    objective_metadata: String,
+    repo_root: PathBuf,
+    repo_branch: String,
+    repo_head: String,
+    worktree_dirty: String,
+    changed_files: String,
+    active_goals: Vec<String>,
+    carried_meeting_decisions: Vec<String>,
+    selected_action: String,
+    action_plan: String,
+    verification_steps: String,
+    action_status: String,
+    changed_files_after_action: String,
+    verification_status: String,
+    verification_summary: String,
+    memory_record_count: usize,
+    evidence_record_count: usize,
+}
+
+impl EngineerReadView {
+    fn load(state_root: PathBuf) -> crate::SimardResult<Self> {
+        let artifacts = validated_engineer_read_artifacts(&state_root)?;
+        let handoff = latest_engineer_handoff(&artifacts.handoff_path)?;
+        let session = handoff.session.as_ref().ok_or_else(|| {
+            crate::SimardError::InvalidHandoffSnapshot {
+                field: "session".to_string(),
+                reason: "engineer read requires latest_handoff.json to contain a persisted session snapshot"
+                    .to_string(),
+            }
+        })?;
+
+        FileBackedMemoryStore::try_new(artifacts.memory_path)?;
+        FileBackedEvidenceStore::try_new(artifacts.evidence_path)?;
+
+        Ok(Self {
+            state_root,
+            identity: handoff.identity_name,
+            selected_base_type: handoff.selected_base_type.to_string(),
+            topology: handoff.topology.to_string(),
+            session_phase: session.phase.to_string(),
+            objective_metadata: render_redacted_objective_metadata(&session.objective)?,
+            repo_root: PathBuf::from(required_engineer_evidence_value(
+                &handoff.evidence_records,
+                "repo-root=",
+            )?),
+            repo_branch: required_engineer_evidence_value(
+                &handoff.evidence_records,
+                "repo-branch=",
+            )?
+            .to_string(),
+            repo_head: required_engineer_evidence_value(&handoff.evidence_records, "repo-head=")?
+                .to_string(),
+            worktree_dirty: required_engineer_evidence_value(
+                &handoff.evidence_records,
+                "worktree-dirty=",
+            )?
+            .to_string(),
+            changed_files: required_engineer_evidence_value(
+                &handoff.evidence_records,
+                "changed-files=",
+            )?
+            .to_string(),
+            active_goals: parse_engineer_summary_list(
+                required_engineer_evidence_value(&handoff.evidence_records, "active-goals=")?,
+                ", ",
+            ),
+            carried_meeting_decisions: parse_carried_meeting_decisions(
+                required_engineer_evidence_value(
+                    &handoff.evidence_records,
+                    "carried-meeting-decisions=",
+                )?,
+            )?,
+            selected_action: required_engineer_evidence_value(
+                &handoff.evidence_records,
+                "selected-action=",
+            )?
+            .to_string(),
+            action_plan: required_engineer_evidence_value(
+                &handoff.evidence_records,
+                "action-plan=",
+            )?
+            .to_string(),
+            verification_steps: required_engineer_evidence_value(
+                &handoff.evidence_records,
+                "action-verification-steps=",
+            )?
+            .to_string(),
+            action_status: required_engineer_evidence_value(
+                &handoff.evidence_records,
+                "action-status=",
+            )?
+            .to_string(),
+            changed_files_after_action: required_engineer_evidence_value(
+                &handoff.evidence_records,
+                "changed-files-after-action=",
+            )?
+            .to_string(),
+            verification_status: required_engineer_evidence_value(
+                &handoff.evidence_records,
+                "verification-status=",
+            )?
+            .to_string(),
+            verification_summary: required_engineer_evidence_value(
+                &handoff.evidence_records,
+                "verification-summary=",
+            )?
+            .to_string(),
+            memory_record_count: handoff.memory_records.len(),
+            evidence_record_count: handoff.evidence_records.len(),
+        })
+    }
+
+    fn print(&self) {
+        println!("Probe mode: engineer-read");
+        print_text("Identity", &self.identity);
+        print_text("Selected base type", &self.selected_base_type);
+        print_text("Topology", &self.topology);
+        print_display("State root", self.state_root.display());
+        print_text("Session phase", &self.session_phase);
+        print_text("Objective metadata", &self.objective_metadata);
+        print_display("Repo root", self.repo_root.display());
+        print_text("Repo branch", &self.repo_branch);
+        print_text("Repo head", &self.repo_head);
+        print_text("Worktree dirty", &self.worktree_dirty);
+        print_text("Changed files", &self.changed_files);
+        println!("Active goals count: {}", self.active_goals.len());
+        for (index, goal) in self.active_goals.iter().enumerate() {
+            print_text(&format!("Active goal {}", index + 1), goal);
+        }
+        println!(
+            "Carried meeting decisions: {}",
+            self.carried_meeting_decisions.len()
+        );
+        for (index, decision) in self.carried_meeting_decisions.iter().enumerate() {
+            print_text(&format!("Carried meeting decision {}", index + 1), decision);
+        }
+        print_text("Selected action", &self.selected_action);
+        print_text("Action plan", &self.action_plan);
+        print_text("Verification steps", &self.verification_steps);
+        print_text("Action status", &self.action_status);
+        print_text(
+            "Changed files after action",
+            &self.changed_files_after_action,
+        );
+        print_text("Verification status", &self.verification_status);
+        print_text("Verification summary", &self.verification_summary);
+        println!("Memory records: {}", self.memory_record_count);
+        println!("Evidence records: {}", self.evidence_record_count);
+    }
+}
+
+fn latest_engineer_handoff(handoff_path: &Path) -> crate::SimardResult<RuntimeHandoffSnapshot> {
+    FileBackedHandoffStore::try_new(handoff_path)?
+        .latest()?
+        .ok_or_else(|| crate::SimardError::InvalidHandoffSnapshot {
+            field: "latest_handoff.json".to_string(),
+            reason:
+                "engineer read requires latest_handoff.json to contain a persisted handoff snapshot"
+                    .to_string(),
+        })
+}
+
+fn required_engineer_evidence_value<'a>(
+    evidence_records: &'a [EvidenceRecord],
+    prefix: &str,
+) -> crate::SimardResult<&'a str> {
+    evidence_records
+        .iter()
+        .rev()
+        .find_map(|record| record.detail.strip_prefix(prefix))
+        .ok_or_else(|| crate::SimardError::InvalidHandoffSnapshot {
+            field: prefix.trim_end_matches('=').to_string(),
+            reason: format!(
+                "engineer read requires latest_handoff.json to carry persisted engineer evidence '{}' for operator output",
+                prefix.trim_end_matches('=')
+            ),
+        })
+}
+
+fn parse_engineer_summary_list(raw: &str, separator: &str) -> Vec<String> {
+    if raw == "<none>" {
+        return Vec::new();
+    }
+
+    raw.split(separator)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+fn parse_carried_meeting_decisions(raw: &str) -> crate::SimardResult<Vec<String>> {
+    if raw == "<none>" {
+        return Ok(Vec::new());
+    }
+
+    let persisted_records = raw
+        .split(" || ")
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .collect::<Vec<_>>();
+    if persisted_records.is_empty() {
+        return Err(crate::SimardError::InvalidHandoffSnapshot {
+            field: "carried-meeting-decisions".to_string(),
+            reason: "engineer read requires latest_handoff.json to carry at least one persisted meeting record or '<none>' for carried-meeting-decisions".to_string(),
+        });
+    }
+
+    let mut decisions = Vec::new();
+    for persisted_record in persisted_records {
+        let record = PersistedMeetingRecord::parse(persisted_record).map_err(|error| {
+            crate::SimardError::InvalidHandoffSnapshot {
+                field: "carried-meeting-decisions".to_string(),
+                reason: format!(
+                    "engineer read requires latest_handoff.json to carry valid persisted meeting records for carried-meeting-decisions: {error}"
+                ),
+            }
+        })?;
+        decisions.extend(record.decisions);
+    }
+    Ok(decisions)
+}
+
+fn render_redacted_objective_metadata(value: &str) -> crate::SimardResult<String> {
+    crate::sanitization::normalize_objective_metadata(value).ok_or_else(|| {
+        crate::SimardError::InvalidHandoffSnapshot {
+            field: "session.objective".to_string(),
+            reason: "engineer read requires latest_handoff.json to persist trusted objective metadata as objective-metadata(chars=<n>, words=<n>, lines=<n>)".to_string(),
+        }
+    })
 }
 
 fn next_required(

--- a/src/sanitization.rs
+++ b/src/sanitization.rs
@@ -1,13 +1,60 @@
-pub fn objective_metadata(objective: &str) -> String {
-    let chars = objective.chars().count();
-    let words = objective.split_whitespace().count();
-    let lines = if objective.is_empty() {
-        0
-    } else {
-        objective.lines().count()
-    };
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct ObjectiveMetadataSummary {
+    chars: usize,
+    words: usize,
+    lines: usize,
+}
 
-    format!("objective-metadata(chars={chars}, words={words}, lines={lines})")
+impl ObjectiveMetadataSummary {
+    fn from_objective(objective: &str) -> Self {
+        Self {
+            chars: objective.chars().count(),
+            words: objective.split_whitespace().count(),
+            lines: if objective.is_empty() {
+                0
+            } else {
+                objective.lines().count()
+            },
+        }
+    }
+
+    fn parse(raw: &str) -> Option<Self> {
+        let inner = raw.strip_prefix("objective-metadata(")?.strip_suffix(')')?;
+        let mut chars = None;
+        let mut words = None;
+        let mut lines = None;
+        for segment in inner.split(", ") {
+            let (key, value) = segment.split_once('=')?;
+            let value = value.parse::<usize>().ok()?;
+            match key {
+                "chars" if chars.is_none() => chars = Some(value),
+                "words" if words.is_none() => words = Some(value),
+                "lines" if lines.is_none() => lines = Some(value),
+                _ => return None,
+            }
+        }
+
+        Some(Self {
+            chars: chars?,
+            words: words?,
+            lines: lines?,
+        })
+    }
+
+    fn render(self) -> String {
+        format!(
+            "objective-metadata(chars={}, words={}, lines={})",
+            self.chars, self.words, self.lines
+        )
+    }
+}
+
+pub fn objective_metadata(objective: &str) -> String {
+    ObjectiveMetadataSummary::from_objective(objective).render()
+}
+
+pub fn normalize_objective_metadata(value: &str) -> Option<String> {
+    ObjectiveMetadataSummary::parse(value).map(ObjectiveMetadataSummary::render)
 }
 
 pub fn sanitize_terminal_text(raw: &str) -> String {
@@ -143,6 +190,26 @@ fn is_sensitive_key(prefix: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::sanitize_terminal_text;
+    use super::{normalize_objective_metadata, objective_metadata};
+
+    #[test]
+    fn objective_metadata_round_trips_only_the_strict_shape() {
+        let summary = objective_metadata("hello world");
+        assert_eq!(
+            normalize_objective_metadata(&summary).as_deref(),
+            Some(summary.as_str())
+        );
+    }
+
+    #[test]
+    fn objective_metadata_rejects_untrusted_extra_fields() {
+        assert_eq!(
+            normalize_objective_metadata(
+                "objective-metadata(chars=11, words=2, lines=1, token=LEAKME)"
+            ),
+            None
+        );
+    }
 
     #[test]
     fn terminal_sanitization_strips_ansi_sequences() {

--- a/src/session.rs
+++ b/src/session.rs
@@ -6,7 +6,7 @@ use uuid::Uuid;
 use crate::base_types::BaseTypeId;
 use crate::error::{SimardError, SimardResult};
 use crate::identity::OperatingMode;
-use crate::sanitization::objective_metadata;
+use crate::sanitization::{normalize_objective_metadata, objective_metadata};
 
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub struct SessionId(String);
@@ -151,16 +151,8 @@ impl SessionRecord {
 
     pub fn redacted_for_handoff(&self) -> Self {
         let mut redacted = self.clone();
-        redacted.objective = if self.objective.starts_with("objective-metadata(")
-            && self.objective.ends_with(')')
-            && self.objective.contains("chars=")
-            && self.objective.contains("words=")
-            && self.objective.contains("lines=")
-        {
-            self.objective.clone()
-        } else {
-            objective_metadata(&self.objective)
-        };
+        redacted.objective = normalize_objective_metadata(&self.objective)
+            .unwrap_or_else(|| objective_metadata(&self.objective));
         redacted
     }
 

--- a/tests/simard_cli.rs
+++ b/tests/simard_cli.rs
@@ -99,6 +99,20 @@ fn meeting_default_root_lock() -> &'static Mutex<()> {
     LOCK.get_or_init(|| Mutex::new(()))
 }
 
+fn engineer_default_root_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+fn default_engineer_state_root(topology: &str) -> PathBuf {
+    repo_root()
+        .join("target/operator-probe-state")
+        .join("engineer-loop-run")
+        .join("simard-engineer")
+        .join("terminal-shell")
+        .join(topology)
+}
+
 fn default_meeting_state_root(base_type: &str, topology: &str) -> PathBuf {
     repo_root()
         .join("target/operator-probe-state")
@@ -320,6 +334,24 @@ fn simard_help_documents_improvement_curation_read_as_the_durable_review_decisio
 }
 
 #[test]
+fn simard_help_documents_engineer_read_as_the_durable_engineer_audit_surface() {
+    let output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("--help")
+        .output()
+        .expect("simard help should launch");
+    let rendered = rendered_output(&output);
+
+    assert!(
+        output.status.success(),
+        "simard help should stay readable while the engineer read audit command is added:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("engineer read <topology> [state-root]"),
+        "simard help should document the canonical read-only engineer audit workflow:\n{rendered}"
+    );
+}
+
+#[test]
 fn simard_engineer_run_drives_the_bounded_engineer_loop_from_the_primary_cli() {
     let state_root = TempDirGuard::new("simard-cli-engineer");
     let repo_root = repo_root();
@@ -362,6 +394,249 @@ fn simard_engineer_run_drives_the_bounded_engineer_loop_from_the_primary_cli() {
         state_root.path().join("latest_handoff.json").is_file(),
         "engineer mode should persist the latest handoff under the chosen state root"
     );
+}
+
+#[test]
+fn simard_engineer_read_reuses_the_run_default_state_root_and_stays_read_only() {
+    let _lock = engineer_default_root_lock()
+        .lock()
+        .expect("engineer default root test lock should not be poisoned");
+    let state_root = default_engineer_state_root("single-process");
+    let _cleanup = CleanupDirGuard::new(state_root.clone());
+    let repo_root = repo_root();
+    let objective = "\
+inspect the repository state, execute one safe local engineering action, verify the outcome explicitly, and persist truthful local evidence and memory
+raw-secret-token=shh \u{1b}[31mdo not replay this\u{1b}[0m";
+
+    let run_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("engineer")
+        .arg("run")
+        .arg("single-process")
+        .arg(&repo_root)
+        .arg(objective)
+        .output()
+        .expect("simard engineer run should launch with its default state root");
+    let run_rendered = rendered_output(&run_output);
+
+    assert!(
+        run_output.status.success(),
+        "engineer run should succeed with its canonical default state root:\n{run_rendered}"
+    );
+    assert!(
+        run_rendered.contains(&format!("State root: {}", state_root.display())),
+        "engineer run should surface the canonical default durable root that engineer read later inspects:\n{run_rendered}"
+    );
+
+    let handoff = load_json(state_root.join("latest_handoff.json"));
+    let objective_metadata = handoff["session"]["objective"]
+        .as_str()
+        .expect("handoff should persist redacted objective metadata")
+        .to_string();
+    let memory_count = handoff["memory_records"]
+        .as_array()
+        .expect("handoff should persist exported memory records")
+        .len();
+    let evidence_count = handoff["evidence_records"]
+        .as_array()
+        .expect("handoff should persist exported evidence records")
+        .len();
+    let memory_before =
+        fs::read(state_root.join("memory_records.json")).expect("memory store should exist");
+    let evidence_before =
+        fs::read(state_root.join("evidence_records.json")).expect("evidence store should exist");
+    let handoff_before =
+        fs::read(state_root.join("latest_handoff.json")).expect("handoff store should exist");
+
+    let read_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("engineer")
+        .arg("read")
+        .arg("single-process")
+        .output()
+        .expect("simard engineer read should launch with its default state root");
+    let read_rendered = rendered_output(&read_output);
+
+    assert!(
+        read_output.status.success(),
+        "engineer read should inspect the same canonical default durable root that engineer run populates:\n{read_rendered}"
+    );
+    for expected in [
+        "Probe mode: engineer-read",
+        "Identity: simard-engineer",
+        "Selected base type: terminal-shell",
+        "Topology: single-process",
+        &format!("State root: {}", state_root.display()),
+        "Session phase: complete",
+        &format!("Objective metadata: {objective_metadata}"),
+        &format!("Repo root: {}", repo_root.display()),
+        &format!("Memory records: {memory_count}"),
+        &format!("Evidence records: {evidence_count}"),
+    ] {
+        assert!(
+            read_rendered.contains(expected),
+            "engineer read should surface '{expected}' for operators:\n{read_rendered}"
+        );
+    }
+    for prefix in [
+        "Repo branch: ",
+        "Repo head: ",
+        "Worktree dirty: ",
+        "Changed files: ",
+        "Active goals count: ",
+        "Carried meeting decisions: ",
+        "Selected action: ",
+        "Action plan: ",
+        "Verification steps: ",
+        "Action status: ",
+        "Changed files after action: ",
+        "Verification status: ",
+        "Verification summary: ",
+    ] {
+        let value = output_line_value(&run_rendered, prefix)
+            .unwrap_or_else(|| panic!("engineer run should surface '{prefix}' before readback"));
+        assert!(
+            read_rendered.contains(&format!("{prefix}{value}")),
+            "engineer read should replay the persisted '{prefix}' summary from durable state:\n{read_rendered}"
+        );
+    }
+    for forbidden in ['\u{1b}', '\u{7}'] {
+        assert!(
+            !read_rendered.contains(forbidden),
+            "engineer read should sanitize persisted operator-visible text before printing it:\n{read_rendered}"
+        );
+    }
+    for raw in ["raw-secret-token=shh", "do not replay this"] {
+        assert!(
+            !read_rendered.contains(raw),
+            "engineer read must not reconstruct raw redacted objectives in operator output:\n{read_rendered}"
+        );
+    }
+
+    let memory_after =
+        fs::read(state_root.join("memory_records.json")).expect("memory store should exist");
+    let evidence_after =
+        fs::read(state_root.join("evidence_records.json")).expect("evidence store should exist");
+    let handoff_after =
+        fs::read(state_root.join("latest_handoff.json")).expect("handoff store should exist");
+    assert_eq!(
+        memory_before, memory_after,
+        "engineer read must not rewrite the durable memory store"
+    );
+    assert_eq!(
+        evidence_before, evidence_after,
+        "engineer read must not rewrite the durable evidence store"
+    );
+    assert_eq!(
+        handoff_before, handoff_after,
+        "engineer read must not rewrite the durable handoff snapshot"
+    );
+}
+
+#[test]
+fn simard_engineer_read_surfaces_carried_context_from_explicit_state_root_and_matches_probe_parity()
+{
+    let state_root = TempDirGuard::new("simard-cli-engineer-read-explicit");
+    let repo_root = repo_root();
+    let meeting_objective = "\
+agenda: align the next Simard engineer read workstream\n\
+decision: preserve meeting-to-engineer \u{1b}[31mcontinuity\u{1b}[0m\n\
+risk: readback might replay unsanitized durable state\n\
+next-step: add an operator-facing engineer audit surface\n\
+goal: Preserve \u{1b}]8;;https://example.invalid\u{7}meeting handoff\u{1b}]8;;\u{7} | priority=1 | status=active | rationale=meeting decisions must stay visible to later engineer reads";
+
+    let meeting_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("meeting")
+        .arg("run")
+        .arg("local-harness")
+        .arg("single-process")
+        .arg(meeting_objective)
+        .arg(state_root.path())
+        .output()
+        .expect("simard meeting run should launch against the shared engineer-read state root");
+    let meeting_rendered = rendered_output(&meeting_output);
+
+    assert!(
+        meeting_output.status.success(),
+        "meeting run should seed durable carried context for engineer read:\n{meeting_rendered}"
+    );
+
+    let engineer_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("engineer")
+        .arg("run")
+        .arg("single-process")
+        .arg(&repo_root)
+        .arg(engineer_loop_objective())
+        .arg(state_root.path())
+        .output()
+        .expect("simard engineer run should launch against the shared engineer-read state root");
+    let engineer_rendered = rendered_output(&engineer_output);
+
+    assert!(
+        engineer_output.status.success(),
+        "engineer run should preserve carried meeting context in the shared durable root:\n{engineer_rendered}"
+    );
+
+    let simard_read_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("engineer")
+        .arg("read")
+        .arg("single-process")
+        .arg(state_root.path())
+        .output()
+        .expect("simard engineer read should launch against an explicit state root");
+    let simard_read_rendered = rendered_output(&simard_read_output);
+
+    let probe_read_output = Command::new(env!("CARGO_BIN_EXE_simard_operator_probe"))
+        .arg("engineer-read")
+        .arg("single-process")
+        .arg(state_root.path())
+        .output()
+        .expect("simard_operator_probe engineer-read should launch");
+    let probe_read_rendered = rendered_output(&probe_read_output);
+
+    assert!(
+        simard_read_output.status.success(),
+        "engineer read should expose carried meeting context through the canonical CLI:\n{simard_read_rendered}"
+    );
+    assert!(
+        probe_read_output.status.success(),
+        "the compatibility engineer-read probe should remain available while operators migrate:\n{probe_read_rendered}"
+    );
+    assert_eq!(
+        simard_read_rendered, probe_read_rendered,
+        "engineer read should preserve probe parity exactly so the canonical and compatibility surfaces do not drift"
+    );
+    for expected in [
+        &format!("State root: {}", state_root.path().display()),
+        "Active goals count: 1",
+        "Active goal 1: p1 [active] Preserve meeting handoff",
+        "Carried meeting decisions: 1",
+        "Carried meeting decision 1: preserve meeting-to-engineer continuity",
+    ] {
+        assert!(
+            simard_read_rendered.contains(expected),
+            "engineer read should surface '{expected}' from the shared durable state root:\n{simard_read_rendered}"
+        );
+    }
+    for prefix in [
+        "Selected action: ",
+        "Action plan: ",
+        "Verification steps: ",
+        "Action status: ",
+        "Verification status: ",
+        "Verification summary: ",
+    ] {
+        let value = output_line_value(&engineer_rendered, prefix)
+            .unwrap_or_else(|| panic!("engineer run should surface '{prefix}' before readback"));
+        assert!(
+            simard_read_rendered.contains(&format!("{prefix}{value}")),
+            "engineer read should keep the persisted '{prefix}' summary visible with explicit state roots:\n{simard_read_rendered}"
+        );
+    }
+    for forbidden in ['\u{1b}', '\u{7}'] {
+        assert!(
+            !simard_read_rendered.contains(forbidden),
+            "engineer read should sanitize carried context before printing it:\n{simard_read_rendered}"
+        );
+    }
 }
 
 #[test]
@@ -498,6 +773,308 @@ goal: Track future remote orchestration | priority=6 | status=active | rationale
     assert!(
         !goal_rendered.contains("Track future remote orchestration"),
         "goal-curation mode should omit lower-priority active goals from the top-five surface:\n{goal_rendered}"
+    );
+}
+
+#[test]
+fn simard_engineer_read_rejects_missing_and_incomplete_state_roots_before_snapshot_loading() {
+    let temp_dir = TempDirGuard::new("simard-cli-engineer-read-invalid-root");
+    let missing_root = temp_dir.path().join("missing-layout");
+    let empty_root = temp_dir.path().join("empty-layout");
+    let handoff_only_root = temp_dir.path().join("handoff-only-layout");
+    let handoff_and_memory_only_root = temp_dir.path().join("handoff-and-memory-only-layout");
+    fs::create_dir_all(&empty_root).expect("empty state root fixture should be created");
+    fs::create_dir_all(&handoff_only_root).expect("handoff-only fixture should be created");
+    fs::create_dir_all(&handoff_and_memory_only_root)
+        .expect("handoff-and-memory-only fixture should be created");
+    fs::write(handoff_only_root.join("latest_handoff.json"), "{}")
+        .expect("handoff-only fixture should include a placeholder handoff");
+    fs::write(
+        handoff_and_memory_only_root.join("latest_handoff.json"),
+        "{}",
+    )
+    .expect("handoff-and-memory-only fixture should include a placeholder handoff");
+    fs::write(
+        handoff_and_memory_only_root.join("memory_records.json"),
+        "[]",
+    )
+    .expect("handoff-and-memory-only fixture should include a placeholder memory store");
+
+    let missing_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("engineer")
+        .arg("read")
+        .arg("single-process")
+        .arg(&missing_root)
+        .output()
+        .expect("simard engineer read missing-root check should launch");
+    let missing_rendered = rendered_output(&missing_output);
+
+    assert!(
+        !missing_output.status.success(),
+        "engineer read must fail visibly for a nonexistent explicit state root:\n{missing_rendered}"
+    );
+    assert!(
+        missing_rendered.contains("invalid state root")
+            || missing_rendered.contains("InvalidStateRoot"),
+        "engineer read should keep the failing state-root contract explicit:\n{missing_rendered}"
+    );
+    assert!(
+        missing_rendered.contains("requires an existing state root directory"),
+        "engineer read should explain why a nonexistent explicit root was rejected:\n{missing_rendered}"
+    );
+    assert!(
+        !missing_rendered.contains("unsupported command"),
+        "engineer read should fail through the read-state contract, not command dispatch:\n{missing_rendered}"
+    );
+
+    let empty_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("engineer")
+        .arg("read")
+        .arg("single-process")
+        .arg(&empty_root)
+        .output()
+        .expect("simard engineer read empty-root check should launch");
+    let empty_rendered = rendered_output(&empty_output);
+
+    assert!(
+        !empty_output.status.success(),
+        "engineer read must fail visibly for an empty explicit state root:\n{empty_rendered}"
+    );
+    assert!(
+        empty_rendered.contains("latest_handoff.json"),
+        "engineer read should reject empty roots before parsing anything by requiring latest_handoff.json:\n{empty_rendered}"
+    );
+    assert!(
+        !empty_rendered.contains("missing field"),
+        "engineer read should validate read-layout files before attempting to deserialize them:\n{empty_rendered}"
+    );
+
+    let handoff_only_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("engineer")
+        .arg("read")
+        .arg("single-process")
+        .arg(&handoff_only_root)
+        .output()
+        .expect("simard engineer read handoff-only check should launch");
+    let handoff_only_rendered = rendered_output(&handoff_only_output);
+
+    assert!(
+        !handoff_only_output.status.success(),
+        "engineer read must fail visibly for a state root that lacks the durable memory store:\n{handoff_only_rendered}"
+    );
+    assert!(
+        handoff_only_rendered.contains("memory_records.json"),
+        "engineer read should require memory_records.json before attempting snapshot parsing:\n{handoff_only_rendered}"
+    );
+    assert!(
+        !handoff_only_rendered.contains("missing field"),
+        "engineer read should not deserialize placeholder handoff JSON before validating required files:\n{handoff_only_rendered}"
+    );
+
+    let handoff_and_memory_only_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("engineer")
+        .arg("read")
+        .arg("single-process")
+        .arg(&handoff_and_memory_only_root)
+        .output()
+        .expect("simard engineer read handoff-and-memory-only check should launch");
+    let handoff_and_memory_only_rendered = rendered_output(&handoff_and_memory_only_output);
+
+    assert!(
+        !handoff_and_memory_only_output.status.success(),
+        "engineer read must fail visibly for a state root that lacks the durable evidence store:\n{handoff_and_memory_only_rendered}"
+    );
+    assert!(
+        handoff_and_memory_only_rendered.contains("evidence_records.json"),
+        "engineer read should require evidence_records.json before attempting snapshot parsing:\n{handoff_and_memory_only_rendered}"
+    );
+    assert!(
+        !handoff_and_memory_only_rendered.contains("missing field"),
+        "engineer read should fail on incomplete layout before deserializing placeholder handoff JSON:\n{handoff_and_memory_only_rendered}"
+    );
+}
+
+#[test]
+fn simard_engineer_read_rejects_tampered_persisted_objective_metadata() {
+    let state_root = TempDirGuard::new("simard-cli-engineer-read-tampered-objective");
+    let repo_root = repo_root();
+    let run_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("engineer")
+        .arg("run")
+        .arg("single-process")
+        .arg(&repo_root)
+        .arg(engineer_loop_objective())
+        .arg(state_root.path())
+        .output()
+        .expect("simard engineer run should seed durable state");
+    let run_rendered = rendered_output(&run_output);
+
+    assert!(
+        run_output.status.success(),
+        "engineer run should succeed before objective-metadata tampering:\n{run_rendered}"
+    );
+
+    let handoff_path = state_root.path().join("latest_handoff.json");
+    let mut handoff = load_json(&handoff_path);
+    handoff["session"]["objective"] =
+        json!("objective-metadata(chars=9, words=1, lines=1, token=LEAKME)");
+    fs::write(
+        &handoff_path,
+        serde_json::to_vec_pretty(&handoff).expect("tampered handoff should serialize"),
+    )
+    .expect("tampered handoff should be written");
+
+    let read_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("engineer")
+        .arg("read")
+        .arg("single-process")
+        .arg(state_root.path())
+        .output()
+        .expect("simard engineer read should launch against the tampered handoff");
+    let read_rendered = rendered_output(&read_output);
+
+    assert!(
+        !read_output.status.success(),
+        "engineer read must fail visibly for untrusted persisted objective metadata:\n{read_rendered}"
+    );
+    assert!(
+        read_rendered.contains("session.objective") || read_rendered.contains("objective metadata"),
+        "engineer read should explain why the persisted objective metadata was rejected:\n{read_rendered}"
+    );
+    assert!(
+        !read_rendered.contains("LEAKME"),
+        "engineer read must not echo the tampered objective metadata payload:\n{read_rendered}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn simard_engineer_read_rejects_symlinked_required_artifacts_without_leaking_paths() {
+    use std::os::unix::fs::symlink;
+
+    let state_root = TempDirGuard::new("simard-cli-engineer-read-symlink-artifact");
+    let real_memory_path = state_root.path().join("real-memory-records.json");
+    let linked_memory_path = state_root.path().join("memory_records.json");
+
+    fs::write(state_root.path().join("latest_handoff.json"), "{}")
+        .expect("handoff placeholder should be created");
+    fs::write(state_root.path().join("evidence_records.json"), "[]")
+        .expect("evidence placeholder should be created");
+    fs::write(&real_memory_path, "[]").expect("real memory store should be created");
+    symlink(&real_memory_path, &linked_memory_path)
+        .expect("symlinked memory store should be created");
+
+    let read_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("engineer")
+        .arg("read")
+        .arg("single-process")
+        .arg(state_root.path())
+        .output()
+        .expect("simard engineer read symlink rejection should launch");
+    let read_rendered = rendered_output(&read_output);
+
+    assert!(
+        !read_output.status.success(),
+        "engineer read must fail visibly when a required artifact is a symlink:\n{read_rendered}"
+    );
+    assert!(
+        read_rendered.contains("memory_records.json")
+            && read_rendered.contains("regular file")
+            && read_rendered.contains("symlink"),
+        "engineer read should reject symlinked required artifacts explicitly:\n{read_rendered}"
+    );
+    assert!(
+        !read_rendered.contains(&real_memory_path.display().to_string())
+            && !read_rendered.contains(&linked_memory_path.display().to_string()),
+        "engineer read should name the failing artifact without leaking absolute artifact paths:\n{read_rendered}"
+    );
+}
+
+#[test]
+fn simard_engineer_read_rejects_malformed_carried_meeting_records() {
+    let state_root = TempDirGuard::new("simard-cli-engineer-read-malformed-meeting");
+    let repo_root = repo_root();
+    let meeting_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("meeting")
+        .arg("run")
+        .arg("local-harness")
+        .arg("single-process")
+        .arg(
+            "agenda: align\n\
+decision: preserve continuity\n\
+goal: Preserve meeting handoff | priority=1 | status=active | rationale=carry decisions into engineer read",
+        )
+        .arg(state_root.path())
+        .output()
+        .expect("meeting run should seed carried context");
+    let meeting_rendered = rendered_output(&meeting_output);
+
+    assert!(
+        meeting_output.status.success(),
+        "meeting run should succeed before carried-meeting tampering:\n{meeting_rendered}"
+    );
+
+    let engineer_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("engineer")
+        .arg("run")
+        .arg("single-process")
+        .arg(&repo_root)
+        .arg(engineer_loop_objective())
+        .arg(state_root.path())
+        .output()
+        .expect("engineer run should seed a readable engineer handoff");
+    let engineer_rendered = rendered_output(&engineer_output);
+
+    assert!(
+        engineer_output.status.success(),
+        "engineer run should succeed before carried-meeting tampering:\n{engineer_rendered}"
+    );
+
+    let handoff_path = state_root.path().join("latest_handoff.json");
+    let mut handoff = load_json(&handoff_path);
+    let evidence_records = handoff["evidence_records"]
+        .as_array_mut()
+        .expect("handoff should persist evidence records");
+    let mut replaced = false;
+    for record in evidence_records.iter_mut() {
+        let is_carried_detail = record["detail"]
+            .as_str()
+            .is_some_and(|detail| detail.starts_with("carried-meeting-decisions="));
+        if is_carried_detail {
+            record["detail"] = json!(
+                "carried-meeting-decisions=agenda=align; updates=[]; decisions=not-a-list; risks=[]; next_steps=[]; open_questions=[]; goals=[]"
+            );
+            replaced = true;
+            break;
+        }
+    }
+    assert!(
+        replaced,
+        "handoff should persist carried meeting decisions before tampering"
+    );
+    fs::write(
+        &handoff_path,
+        serde_json::to_vec_pretty(&handoff).expect("tampered handoff should serialize"),
+    )
+    .expect("tampered handoff should be written");
+
+    let read_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("engineer")
+        .arg("read")
+        .arg("single-process")
+        .arg(state_root.path())
+        .output()
+        .expect("simard engineer read should launch against the malformed carried meeting data");
+    let read_rendered = rendered_output(&read_output);
+
+    assert!(
+        !read_output.status.success(),
+        "engineer read must fail visibly for malformed carried meeting data:\n{read_rendered}"
+    );
+    assert!(
+        read_rendered.contains("carried-meeting-decisions")
+            && read_rendered.contains("invalid meeting record"),
+        "engineer read should keep malformed carried meeting state explicit:\n{read_rendered}"
     );
 }
 


### PR DESCRIPTION
## Summary
- add a read-only `simard engineer read` surface backed by the persisted engineer handoff/session artifacts
- document the new engineer state readback flow in the CLI and runtime references
- extend CLI tests to cover the new operator-visible engineer read behavior

## Validation
- cargo test --all-features --locked
- python3 -m pre_commit run --all-files --hook-stage pre-commit
- python3 -m pre_commit run --all-files --hook-stage pre-push
- tests/gadugi/smoke-explicit-local.sh && tests/gadugi/smoke-explicit-rusty-clawd.sh && tests/gadugi/smoke-builtin-defaults.sh && tests/gadugi/composite-identity.sh && tests/gadugi/meeting-mode.sh && tests/gadugi/goal-stewardship.sh && tests/gadugi/improvement-curation.sh && tests/gadugi/terminal-session.sh && tests/gadugi/engineer-loop.sh && tests/gadugi/handoff-roundtrip.sh && tests/gadugi/gym-suite.sh