### PR TITLE
Add terminal session readback

### DIFF
--- a/Specs/ProductArchitecture.md
+++ b/Specs/ProductArchitecture.md
@@ -245,6 +245,7 @@ The current shipped v1 engineer-loop slice stays intentionally narrow:
 - a bounded mutating path exists only for explicit structured objectives with `edit-file:`, `replace:`, `with:`, and `verify-contains:` directives
 - the mutating path requires a clean repo, exactly one expected changed file, and explicit content verification before success is reported
 - the terminal-backed engineer substrate now supports bounded interactive checkpoints with `wait-for:` / `expect:` directives so a local PTY session can pause for expected output before sending the next terminal line
+- the terminal-backed engineer substrate now also has a read-only audit companion so operators can inspect persisted shell details and transcript summaries after a terminal-backed session completes
 
 ## Memory Architecture
 

--- a/docs/reference/runtime-contracts.md
+++ b/docs/reference/runtime-contracts.md
@@ -37,6 +37,7 @@ Simard does **not** expose:
 | bounded engineer loop | `simard engineer run ...` | `simard_operator_probe engineer-loop-run ...` |
 | engineer state readback | `simard engineer read ...` | `simard_operator_probe engineer-read ...` |
 | terminal-backed engineer substrate | `simard engineer terminal ...` | `simard_operator_probe terminal-run ...` |
+| terminal session readback | `simard engineer terminal-read ...` | `simard_operator_probe terminal-read ...` |
 | meeting mode | `simard meeting run ...` | `simard_operator_probe meeting-run ...` |
 | meeting state readback | `simard meeting read ...` | `simard_operator_probe meeting-read ...` |
 | goal-curation mode | `simard goal-curation run ...` | `simard_operator_probe goal-curation-run ...` |
@@ -53,6 +54,7 @@ The shipped operator-facing command tree is:
 - `simard engineer run <topology> <workspace-root> <objective> [state-root]`
 - `simard engineer read <topology> [state-root]`
 - `simard engineer terminal <topology> <objective> [state-root]`
+- `simard engineer terminal-read <topology> [state-root]`
 - `simard meeting run <base-type> <topology> <structured-objective> [state-root]`
 - `simard meeting read <base-type> <topology> [state-root]`
 - `simard goal-curation run <base-type> <topology> <structured-objective> [state-root]`
@@ -158,6 +160,26 @@ This substrate exposes the real `terminal-shell` base type on the primary CLI:
 - terminal evidence lines remain operator-visible
 - unsatisfied wait checkpoints fail explicitly instead of silently replaying the rest of the objective and claiming success
 - unsupported topology and invalid state-root choices still fail explicitly
+
+#### Terminal session readback
+
+Canonical entrypoint: `simard engineer terminal-read <topology> [state-root]`
+
+Compatibility surface: `simard_operator_probe terminal-read <topology> [state-root]`
+
+This is the read-only audit companion to `simard engineer terminal`. It exists to inspect the durable terminal-session artifacts that `engineer terminal` already writes.
+
+The contract is intentionally explicit:
+
+- `engineer terminal` remains the only execution path for terminal-backed engineer work
+- `terminal-read` reuses the same validated default state root as `engineer terminal` when `[state-root]` is omitted
+- any explicit `state-root` must already exist as a directory before readback begins
+- `terminal-read` requires readable regular-file `latest_handoff.json`, `memory_records.json`, and `evidence_records.json`; symlinked artifacts are rejected
+- `latest_handoff.json` is authoritative for identity, selected base type, topology, session phase, redacted objective metadata, and the persisted terminal evidence summary tied to the latest terminal session
+- operator-visible strings are sanitized before printing so persisted terminal control sequences and secret-shaped values are not replayed
+- output order stays deterministic: runtime header, handoff session summary, adapter details, shell details, transcript summary, durable record counts
+- the command performs no mutation, replay, resume, or execution
+- invalid state roots, missing files, unreadable storage, and malformed persisted terminal data fail explicitly
 
 ### Meeting mode
 

--- a/docs/reference/simard-cli.md
+++ b/docs/reference/simard-cli.md
@@ -61,6 +61,7 @@ Bare `simard` prints this operator surface directly.
 | --- | --- |
 | `simard engineer run ...` | `simard_operator_probe engineer-loop-run ...` |
 | `simard engineer terminal ...` | `simard_operator_probe terminal-run ...` |
+| `simard engineer terminal-read ...` | `simard_operator_probe terminal-read ...` |
 | `simard engineer read ...` | `simard_operator_probe engineer-read ...` |
 | `simard meeting run ...` | `simard_operator_probe meeting-run ...` |
 | `simard meeting read ...` | `simard_operator_probe meeting-read ...` |
@@ -194,6 +195,32 @@ simard engineer terminal single-process $'working-directory: .
 command: printf "terminal-foundation-ready\n"
 wait-for: terminal-foundation-ready
 command: printf "terminal-foundation-ok\n"' "$STATE_ROOT"
+```
+
+### `simard engineer terminal-read <topology> [state-root]`
+
+This is the read-only audit companion to `simard engineer terminal`. It inspects the latest persisted terminal session state without replaying commands or resuming the PTY session.
+
+Behavior:
+
+- reuses the same canonical default durable root as `engineer terminal` when `[state-root]` is omitted
+- requires any explicit `state-root` to already exist as a directory
+- requires `latest_handoff.json`, `memory_records.json`, and `evidence_records.json` to already exist as readable regular files; symlinked artifacts are rejected
+- treats `latest_handoff.json` as authoritative for session identity, selected base type, topology, session phase, redacted objective metadata, and the persisted terminal evidence summary
+- renders terminal shell, working directory, command count, wait count, and transcript preview in stable operator-visible order
+- strips terminal control sequences and secret-shaped values from displayed output before printing it
+- fails explicitly for invalid `state-root` values and for missing, unreadable, or malformed persisted terminal state
+
+When `[state-root]` is omitted, the command reuses the same canonical durable root that `engineer terminal` already writes:
+
+```text
+target/operator-probe-state/terminal-run/simard-engineer/terminal-shell/<topology>
+```
+
+Example:
+
+```bash
+simard engineer terminal-read single-process "$STATE_ROOT"
 ```
 
 ### `simard meeting run <base-type> <topology> <structured-objective> [state-root]`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ pub use operator_commands::{
     run_goal_curation_read_probe, run_gym_compare, run_gym_list, run_gym_scenario, run_gym_suite,
     run_handoff_probe, run_improvement_curation_probe, run_improvement_curation_read_probe,
     run_meeting_probe, run_meeting_read_probe, run_review_probe, run_review_read_probe,
-    run_terminal_probe,
+    run_terminal_probe, run_terminal_read_probe,
 };
 pub use prompt_assets::{
     FilePromptAssetStore, InMemoryPromptAssetStore, PromptAsset, PromptAssetId, PromptAssetRef,

--- a/src/operator_cli.rs
+++ b/src/operator_cli.rs
@@ -5,6 +5,7 @@ use crate::operator_commands::{
     run_goal_curation_read_probe, run_gym_compare, run_gym_list, run_gym_scenario, run_gym_suite,
     run_improvement_curation_probe, run_improvement_curation_read_probe, run_meeting_probe,
     run_meeting_read_probe, run_review_probe, run_review_read_probe, run_terminal_probe,
+    run_terminal_read_probe,
 };
 
 const OPERATOR_CLI_HELP: &str = "\
@@ -13,6 +14,7 @@ Simard unified operator CLI
 Product modes:
   engineer run <topology> <workspace-root> <objective> [state-root]
   engineer terminal <topology> <objective> [state-root]
+  engineer terminal-read <topology> [state-root]
   engineer read <topology> [state-root]
   meeting run <base-type> <topology> <objective> [state-root]
   meeting read <base-type> <topology> [state-root]
@@ -92,6 +94,12 @@ fn dispatch_engineer_command(
             let state_root = next_optional_path(&mut args);
             reject_extra_args(args)?;
             run_terminal_probe(&topology, &objective, state_root)
+        }
+        "terminal-read" => {
+            let topology = next_required(&mut args, "topology")?;
+            let state_root = next_optional_path(&mut args);
+            reject_extra_args(args)?;
+            run_terminal_read_probe(&topology, state_root)
         }
         "read" => {
             let topology = next_required(&mut args, "topology")?;

--- a/src/operator_commands.rs
+++ b/src/operator_commands.rs
@@ -74,6 +74,12 @@ where
             reject_extra_args(args)?;
             run_terminal_probe(&topology, &objective, state_root)?;
         }
+        "terminal-read" => {
+            let topology = next_required(&mut args, "topology")?;
+            let state_root = next_optional_path(&mut args);
+            reject_extra_args(args)?;
+            run_terminal_read_probe(&topology, state_root)?;
+        }
         "engineer-loop-run" => {
             let topology = next_required(&mut args, "topology")?;
             let workspace_root = next_required(&mut args, "workspace root")?;
@@ -511,6 +517,16 @@ pub fn run_terminal_probe(
     }
     print_text("Execution summary", &execution.outcome.execution_summary);
     print_text("Reflection summary", &execution.outcome.reflection.summary);
+    Ok(())
+}
+
+pub fn run_terminal_read_probe(
+    topology: &str,
+    state_root_override: Option<PathBuf>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let state_root = resolved_terminal_read_state_root(state_root_override, topology)?;
+    let view = TerminalReadView::load(state_root)?;
+    view.print();
     Ok(())
 }
 
@@ -1137,6 +1153,21 @@ fn resolved_engineer_read_state_root(
     Ok(state_root)
 }
 
+fn resolved_terminal_read_state_root(
+    explicit: Option<PathBuf>,
+    topology: &str,
+) -> crate::SimardResult<PathBuf> {
+    let state_root = resolved_state_root(
+        explicit,
+        "simard-engineer",
+        "terminal-shell",
+        topology,
+        "terminal-run",
+    )?;
+    validate_terminal_read_state_root(&state_root)?;
+    Ok(state_root)
+}
+
 fn resolved_meeting_read_state_root(
     explicit: Option<PathBuf>,
     base_type: &str,
@@ -1165,6 +1196,11 @@ fn validate_meeting_read_state_root(state_root: &Path) -> crate::SimardResult<()
 
 fn validate_engineer_read_state_root(state_root: &Path) -> crate::SimardResult<()> {
     validated_engineer_read_artifacts(state_root)?;
+    Ok(())
+}
+
+fn validate_terminal_read_state_root(state_root: &Path) -> crate::SimardResult<()> {
+    validated_terminal_read_artifacts(state_root)?;
     Ok(())
 }
 
@@ -1308,6 +1344,29 @@ fn validated_engineer_read_artifacts(
     })
 }
 
+fn validated_terminal_read_artifacts(
+    state_root: &Path,
+) -> crate::SimardResult<EngineerReadArtifacts> {
+    validate_existing_read_state_root_root("terminal read", state_root)?;
+    Ok(EngineerReadArtifacts {
+        handoff_path: require_existing_read_file_for_mode(
+            "terminal read",
+            state_root,
+            &state_root.join("latest_handoff.json"),
+        )?,
+        memory_path: require_existing_read_file_for_mode(
+            "terminal read",
+            state_root,
+            &state_root.join("memory_records.json"),
+        )?,
+        evidence_path: require_existing_read_file_for_mode(
+            "terminal read",
+            state_root,
+            &state_root.join("evidence_records.json"),
+        )?,
+    })
+}
+
 fn parse_runtime_topology(value: &str) -> crate::SimardResult<RuntimeTopology> {
     match value {
         "single-process" => Ok(RuntimeTopology::SingleProcess),
@@ -1342,6 +1401,23 @@ struct EngineerReadView {
     changed_files_after_action: String,
     verification_status: String,
     verification_summary: String,
+    memory_record_count: usize,
+    evidence_record_count: usize,
+}
+
+struct TerminalReadView {
+    state_root: PathBuf,
+    identity: String,
+    selected_base_type: String,
+    topology: String,
+    session_phase: String,
+    objective_metadata: String,
+    adapter_implementation: String,
+    shell: String,
+    working_directory: String,
+    command_count: String,
+    wait_count: String,
+    transcript_preview: String,
     memory_record_count: usize,
     evidence_record_count: usize,
 }
@@ -1478,6 +1554,80 @@ impl EngineerReadView {
     }
 }
 
+impl TerminalReadView {
+    fn load(state_root: PathBuf) -> crate::SimardResult<Self> {
+        let artifacts = validated_terminal_read_artifacts(&state_root)?;
+        let handoff = latest_engineer_handoff(&artifacts.handoff_path)?;
+        let session = handoff.session.as_ref().ok_or_else(|| {
+            crate::SimardError::InvalidHandoffSnapshot {
+                field: "session".to_string(),
+                reason: "terminal read requires latest_handoff.json to contain a persisted session snapshot"
+                    .to_string(),
+            }
+        })?;
+
+        FileBackedMemoryStore::try_new(artifacts.memory_path)?;
+        FileBackedEvidenceStore::try_new(artifacts.evidence_path)?;
+
+        Ok(Self {
+            state_root,
+            identity: handoff.identity_name,
+            selected_base_type: handoff.selected_base_type.to_string(),
+            topology: handoff.topology.to_string(),
+            session_phase: session.phase.to_string(),
+            objective_metadata: render_redacted_objective_metadata(&session.objective)?,
+            adapter_implementation: required_terminal_evidence_value(
+                &handoff.evidence_records,
+                "backend-implementation=",
+            )?
+            .to_string(),
+            shell: required_terminal_evidence_value(&handoff.evidence_records, "shell=")?
+                .to_string(),
+            working_directory: required_terminal_evidence_value(
+                &handoff.evidence_records,
+                "terminal-working-directory=",
+            )?
+            .to_string(),
+            command_count: required_terminal_evidence_value(
+                &handoff.evidence_records,
+                "terminal-command-count=",
+            )?
+            .to_string(),
+            wait_count: optional_terminal_evidence_value(
+                &handoff.evidence_records,
+                "terminal-wait-count=",
+            )
+            .unwrap_or("0")
+            .to_string(),
+            transcript_preview: required_terminal_evidence_value(
+                &handoff.evidence_records,
+                "terminal-transcript-preview=",
+            )?
+            .to_string(),
+            memory_record_count: handoff.memory_records.len(),
+            evidence_record_count: handoff.evidence_records.len(),
+        })
+    }
+
+    fn print(&self) {
+        println!("Probe mode: terminal-read");
+        print_text("Identity", &self.identity);
+        print_text("Selected base type", &self.selected_base_type);
+        print_text("Topology", &self.topology);
+        print_display("State root", self.state_root.display());
+        print_text("Session phase", &self.session_phase);
+        print_text("Objective metadata", &self.objective_metadata);
+        print_text("Adapter implementation", &self.adapter_implementation);
+        print_text("Shell", &self.shell);
+        print_text("Working directory", &self.working_directory);
+        print_text("Terminal command count", &self.command_count);
+        print_text("Terminal wait count", &self.wait_count);
+        print_text("Terminal transcript preview", &self.transcript_preview);
+        println!("Memory records: {}", self.memory_record_count);
+        println!("Evidence records: {}", self.evidence_record_count);
+    }
+}
+
 fn latest_engineer_handoff(handoff_path: &Path) -> crate::SimardResult<RuntimeHandoffSnapshot> {
     FileBackedHandoffStore::try_new(handoff_path)?
         .latest()?
@@ -1504,6 +1654,33 @@ fn required_engineer_evidence_value<'a>(
                 prefix.trim_end_matches('=')
             ),
         })
+}
+
+fn required_terminal_evidence_value<'a>(
+    evidence_records: &'a [EvidenceRecord],
+    prefix: &str,
+) -> crate::SimardResult<&'a str> {
+    evidence_records
+        .iter()
+        .rev()
+        .find_map(|record| record.detail.strip_prefix(prefix))
+        .ok_or_else(|| crate::SimardError::InvalidHandoffSnapshot {
+            field: prefix.trim_end_matches('=').to_string(),
+            reason: format!(
+                "terminal read requires latest_handoff.json to carry persisted terminal evidence '{}' for operator output",
+                prefix.trim_end_matches('=')
+            ),
+        })
+}
+
+fn optional_terminal_evidence_value<'a>(
+    evidence_records: &'a [EvidenceRecord],
+    prefix: &str,
+) -> Option<&'a str> {
+    evidence_records
+        .iter()
+        .rev()
+        .find_map(|record| record.detail.strip_prefix(prefix))
 }
 
 fn parse_engineer_summary_list(raw: &str, separator: &str) -> Vec<String> {

--- a/tests/gadugi/terminal-session.sh
+++ b/tests/gadugi/terminal-session.sh
@@ -24,6 +24,19 @@ printf '%s\n' "$OUTPUT" | grep -F "Terminal evidence: terminal-command-count=2" 
 printf '%s\n' "$OUTPUT" | grep -F "Terminal evidence: terminal-wait-count=1" >/dev/null
 printf '%s\n' "$OUTPUT" | grep -F "terminal-foundation-ok" >/dev/null
 
+READ_OUTPUT="$(
+  cargo run --quiet --bin simard -- \
+    engineer terminal-read single-process
+)"
+
+printf '%s\n' "$READ_OUTPUT"
+
+printf '%s\n' "$READ_OUTPUT" | grep -F "Probe mode: terminal-read" >/dev/null
+printf '%s\n' "$READ_OUTPUT" | grep -F "Selected base type: terminal-shell" >/dev/null
+printf '%s\n' "$READ_OUTPUT" | grep -F "Terminal command count: 2" >/dev/null
+printf '%s\n' "$READ_OUTPUT" | grep -F "Terminal wait count: 1" >/dev/null
+printf '%s\n' "$READ_OUTPUT" | grep -F "terminal-foundation-ok" >/dev/null
+
 MARKER="$(mktemp /tmp/simard-terminal-injection.XXXXXX)"
 rm -f "$MARKER"
 BAD_OBJECTIVE="$(printf 'shell: /usr/bin/bash$(printf pwned>%s)\ncommand: pwd\n' "$MARKER")"

--- a/tests/simard_cli.rs
+++ b/tests/simard_cli.rs
@@ -349,6 +349,10 @@ fn simard_help_documents_engineer_read_as_the_durable_engineer_audit_surface() {
         rendered.contains("engineer read <topology> [state-root]"),
         "simard help should document the canonical read-only engineer audit workflow:\n{rendered}"
     );
+    assert!(
+        rendered.contains("engineer terminal-read <topology> [state-root]"),
+        "simard help should document the canonical read-only terminal audit workflow:\n{rendered}"
+    );
 }
 
 #[test]
@@ -699,6 +703,83 @@ command: printf \"terminal-cli-ok\\n\"";
         assert!(
             state_root.path().join(expected).is_file(),
             "terminal engineer mode should persist {expected} under the selected state root"
+        );
+    }
+}
+
+#[test]
+fn simard_engineer_terminal_read_replays_persisted_terminal_state_and_matches_probe_parity() {
+    let state_root = TempDirGuard::new("simard-cli-terminal-read");
+    let objective = "\
+working-directory: .\n\
+command: printf \"terminal-read-ready\\n\"\n\
+wait-for: terminal-read-ready\n\
+input: printf \"terminal-read-ok\\n\"";
+    let run_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("engineer")
+        .arg("terminal")
+        .arg("single-process")
+        .arg(objective)
+        .arg(state_root.path())
+        .output()
+        .expect("simard engineer terminal should seed durable terminal state");
+    let run_rendered = rendered_output(&run_output);
+
+    assert!(
+        run_output.status.success(),
+        "terminal engineer mode should succeed before terminal readback:\n{run_rendered}"
+    );
+
+    let simard_read_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("engineer")
+        .arg("terminal-read")
+        .arg("single-process")
+        .arg(state_root.path())
+        .output()
+        .expect("simard engineer terminal-read should launch");
+    let simard_read_rendered = rendered_output(&simard_read_output);
+
+    let probe_read_output = Command::new(env!("CARGO_BIN_EXE_simard_operator_probe"))
+        .arg("terminal-read")
+        .arg("single-process")
+        .arg(state_root.path())
+        .output()
+        .expect("simard_operator_probe terminal-read should launch");
+    let probe_read_rendered = rendered_output(&probe_read_output);
+
+    assert!(
+        simard_read_output.status.success(),
+        "terminal-read should expose persisted terminal session state through the canonical CLI:\n{simard_read_rendered}"
+    );
+    assert!(
+        probe_read_output.status.success(),
+        "the compatibility terminal-read probe should remain available while operators migrate:\n{probe_read_rendered}"
+    );
+    assert_eq!(
+        simard_read_rendered, probe_read_rendered,
+        "terminal-read should preserve probe parity so the canonical and compatibility surfaces do not drift"
+    );
+    for expected in [
+        "Probe mode: terminal-read",
+        "Identity: simard-engineer",
+        "Selected base type: terminal-shell",
+        "Topology: single-process",
+        &format!("State root: {}", state_root.path().display()),
+        "Session phase: complete",
+        "Adapter implementation: terminal-shell::local-pty",
+        "Terminal command count: 2",
+        "Terminal wait count: 1",
+        "terminal-read-ok",
+    ] {
+        assert!(
+            simard_read_rendered.contains(expected),
+            "terminal-read should surface '{expected}' for operators:\n{simard_read_rendered}"
+        );
+    }
+    for forbidden in ['\u{1b}', '\u{7}'] {
+        assert!(
+            !simard_read_rendered.contains(forbidden),
+            "terminal-read should sanitize persisted terminal output before printing it:\n{simard_read_rendered}"
         );
     }
 }


### PR DESCRIPTION
## Summary
- add a read-only `terminal-read` audit companion on both the canonical `simard` CLI and the compatibility probe
- expose persisted shell, working directory, command/wait counts, and transcript preview from durable terminal session state
- cover the new surface with CLI parity tests, Gadugi validation, and truthful docs/spec updates

## Validation
- cargo run --quiet --bin simard -- engineer terminal ...
- cargo run --quiet --bin simard -- engineer terminal-read ...
- cargo test --all-features --locked
- python3 -m pre_commit run --all-files --hook-stage pre-commit
- python3 -m pre_commit run --all-files --hook-stage pre-push
- tests/gadugi/smoke-explicit-local.sh && tests/gadugi/smoke-explicit-rusty-clawd.sh && tests/gadugi/smoke-builtin-defaults.sh && tests/gadugi/composite-identity.sh && tests/gadugi/meeting-mode.sh && tests/gadugi/goal-stewardship.sh && tests/gadugi/improvement-curation.sh && tests/gadugi/terminal-session.sh && tests/gadugi/engineer-loop.sh && tests/gadugi/handoff-roundtrip.sh && tests/gadugi/gym-suite.sh