### PR TITLE
Add interactive terminal benchmark

### DIFF
--- a/docs/tutorials/run-your-first-benchmark-gym.md
+++ b/docs/tutorials/run-your-first-benchmark-gym.md
@@ -38,20 +38,23 @@ The starter suite is intentionally small and curated.
 cargo run --quiet -- gym list
 ```
 
-You should see four scenarios:
+You should see five scenarios:
 
 - `repo-exploration-local`
 - `docs-refresh-copilot`
 - `safe-code-change-rusty-clawd`
 - `composite-session-review`
+- `interactive-terminal-driving`
 
 Together they cover:
 
 - the dedicated `simard-gym` identity
 - the composite `simard-composite-engineer` identity
+- the primary `simard-engineer` identity on the terminal-backed substrate
 - `local-harness`
 - `copilot-sdk`
 - `rusty-clawd`
+- `terminal-shell`
 - both `single-process` and loopback `multi-process`
 
 If you need exact legacy output for an older script, `cargo run --quiet --bin simard-gym -- list` still works as a compatibility surface.
@@ -73,6 +76,7 @@ Suite passed: true
 - docs-refresh-copilot: passed (target/simard-gym/...)
 - safe-code-change-rusty-clawd: passed (target/simard-gym/...)
 - composite-session-review: passed (target/simard-gym/...)
+- interactive-terminal-driving: passed (target/simard-gym/...)
 Suite artifact report: target/simard-gym/suites/starter.json
 ```
 
@@ -107,7 +111,7 @@ Fresh runs now populate `scorecard.unnecessary_action_count` and `scorecard.retr
 You can also run a single scenario:
 
 ```bash
-cargo run --quiet -- gym run safe-code-change-rusty-clawd
+cargo run --quiet -- gym run interactive-terminal-driving
 ```
 
 That command prints the scenario result and the persisted artifact paths directly on the operator-facing CLI.
@@ -115,16 +119,16 @@ That command prints the scenario result and the persisted artifact paths directl
 You should see output shaped like:
 
 ```text
-Scenario: safe-code-change-rusty-clawd
+Scenario: interactive-terminal-driving
 Suite: starter
 Session: session-...
 Passed: true
 Checks passed: 8/8
 Unnecessary actions: 0
 Retry count: 0
-Artifact report: target/simard-gym/safe-code-change-rusty-clawd/.../report.json
-Artifact summary: target/simard-gym/safe-code-change-rusty-clawd/.../report.txt
-Review artifact: target/simard-gym/safe-code-change-rusty-clawd/.../review.json
+Artifact report: target/simard-gym/interactive-terminal-driving/.../report.json
+Artifact summary: target/simard-gym/interactive-terminal-driving/.../report.txt
+Review artifact: target/simard-gym/interactive-terminal-driving/.../review.json
 ```
 
 The detailed text artifact at `Artifact summary:` contains the full benchmark report, including identity, base type, topology, plan, execution summary, reflection summary, and the same metric values.

--- a/src/gym.rs
+++ b/src/gym.rs
@@ -328,7 +328,7 @@ impl BenchmarkMetricFacts {
     }
 }
 
-const BENCHMARK_SCENARIOS: [BenchmarkScenario; 4] = [
+const BENCHMARK_SCENARIOS: [BenchmarkScenario; 5] = [
     BenchmarkScenario {
         id: "repo-exploration-local",
         title: "Repo exploration on local harness",
@@ -372,6 +372,17 @@ const BENCHMARK_SCENARIOS: [BenchmarkScenario; 4] = [
         topology: RuntimeTopology::SingleProcess,
         objective: "Run a disciplined bounded engineering session, preserve evidence, and produce a concise operator-facing summary of what happened.",
         expected_min_runtime_evidence: 3,
+    },
+    BenchmarkScenario {
+        id: "interactive-terminal-driving",
+        title: "Interactive terminal driving on terminal-shell",
+        description: "Exercise the engineer identity through the terminal-shell base type by launching a nested interactive child process, waiting for prompts, and sending bounded follow-up inputs like an operator driving a copilot-style terminal tool.",
+        class: BenchmarkClass::SessionQuality,
+        identity: "simard-engineer",
+        base_type: "terminal-shell",
+        topology: RuntimeTopology::SingleProcess,
+        objective: "working-directory: .\ncommand: sh -c 'printf \"copilot-ready\\n\"; while IFS= read -r line; do if [ \"$line\" = \"/status\" ]; then printf \"mode: ready\\n\"; elif [ \"$line\" = \"/exit\" ]; then printf \"bye\\n\"; break; else printf \"echo:%s\\n\" \"$line\"; fi; done'\nwait-for: copilot-ready\ninput: /status\nwait-for: mode: ready\ninput: /exit\nwait-for: bye",
+        expected_min_runtime_evidence: 6,
     },
 ];
 

--- a/tests/gadugi/gym-suite.sh
+++ b/tests/gadugi/gym-suite.sh
@@ -13,6 +13,7 @@ printf '%s\n' "$LIST_OUTPUT" | grep -F "repo-exploration-local" >/dev/null
 printf '%s\n' "$LIST_OUTPUT" | grep -F "docs-refresh-copilot" >/dev/null
 printf '%s\n' "$LIST_OUTPUT" | grep -F "safe-code-change-rusty-clawd" >/dev/null
 printf '%s\n' "$LIST_OUTPUT" | grep -F "composite-session-review" >/dev/null
+printf '%s\n' "$LIST_OUTPUT" | grep -F "interactive-terminal-driving" >/dev/null
 
 SUITE_OUTPUT="$(
   cargo run --quiet --bin simard-gym -- run-suite starter
@@ -25,6 +26,7 @@ printf '%s\n' "$SUITE_OUTPUT" | grep -F "repo-exploration-local: passed" >/dev/n
 printf '%s\n' "$SUITE_OUTPUT" | grep -F "docs-refresh-copilot: passed" >/dev/null
 printf '%s\n' "$SUITE_OUTPUT" | grep -F "safe-code-change-rusty-clawd: passed" >/dev/null
 printf '%s\n' "$SUITE_OUTPUT" | grep -F "composite-session-review: passed" >/dev/null
+printf '%s\n' "$SUITE_OUTPUT" | grep -F "interactive-terminal-driving: passed" >/dev/null
 
 SUITE_REPORT="$(printf '%s\n' "$SUITE_OUTPUT" | sed -n 's/^Suite artifact report: //p')"
 [ -n "$SUITE_REPORT" ]

--- a/tests/simard_cli.rs
+++ b/tests/simard_cli.rs
@@ -2115,7 +2115,8 @@ fn simard_gym_list_matches_the_legacy_benchmark_binary_for_compatibility() {
         simard_rendered.contains("repo-exploration-local")
             && simard_rendered.contains("docs-refresh-copilot")
             && simard_rendered.contains("safe-code-change-rusty-clawd")
-            && simard_rendered.contains("composite-session-review"),
+            && simard_rendered.contains("composite-session-review")
+            && simard_rendered.contains("interactive-terminal-driving"),
         "gym list should surface the shipped benchmark scenarios:\n{simard_rendered}"
     );
 
@@ -2132,6 +2133,51 @@ fn simard_gym_list_matches_the_legacy_benchmark_binary_for_compatibility() {
     assert_eq!(
         simard_rendered, legacy_rendered,
         "the unified gym surface should preserve the legacy list output exactly until operators migrate"
+    );
+}
+
+#[test]
+fn simard_gym_run_exercises_the_interactive_terminal_driving_scenario() {
+    let artifact_root = TempDirGuard::new("simard-cli-gym-interactive-terminal");
+    let output = command_in_dir(env!("CARGO_BIN_EXE_simard"), artifact_root.path())
+        .arg("gym")
+        .arg("run")
+        .arg("interactive-terminal-driving")
+        .output()
+        .expect("simard interactive terminal benchmark should launch");
+    let rendered = rendered_output(&output);
+
+    assert!(
+        output.status.success(),
+        "interactive terminal benchmark should succeed on the canonical CLI:\n{rendered}"
+    );
+    for expected in [
+        "Scenario: interactive-terminal-driving",
+        "Passed: true",
+        "Checks passed:",
+        "Artifact report:",
+        "Review artifact:",
+    ] {
+        assert!(
+            rendered.contains(expected),
+            "interactive terminal benchmark should surface '{expected}' for operators:\n{rendered}"
+        );
+    }
+
+    let report_path = output_line_value(&rendered, "Artifact report: ")
+        .expect("interactive terminal benchmark should surface the report.json artifact path");
+    let report = load_json(resolve_cli_artifact_path(artifact_root.path(), report_path));
+    assert_eq!(
+        report["runtime"]["selected_base_type"].as_str(),
+        Some("terminal-shell"),
+        "interactive terminal benchmark should report terminal-shell as the selected base type:\n{}",
+        serde_json::to_string_pretty(&report).expect("report should render")
+    );
+    assert_eq!(
+        report["scenario"]["identity"].as_str(),
+        Some("simard-engineer"),
+        "interactive terminal benchmark should exercise the engineer identity rather than the gym harness identity:\n{}",
+        serde_json::to_string_pretty(&report).expect("report should render")
     );
 }
 


### PR DESCRIPTION
## Summary
- add an `interactive-terminal-driving` benchmark that exercises the terminal-shell substrate against a nested interactive child process with bounded wait/send checkpoints
- include the new scenario in the starter suite and the operator-facing CLI coverage
- update the benchmark tutorial so the shipped gym documentation matches the new benchmark surface

## Validation
- cargo run --quiet --bin simard -- gym run interactive-terminal-driving
- cargo test --all-features --locked
- python3 -m pre_commit run --all-files --hook-stage pre-commit
- python3 -m pre_commit run --all-files --hook-stage pre-push
- tests/gadugi/smoke-explicit-local.sh && tests/gadugi/smoke-explicit-rusty-clawd.sh && tests/gadugi/smoke-builtin-defaults.sh && tests/gadugi/composite-identity.sh && tests/gadugi/meeting-mode.sh && tests/gadugi/goal-stewardship.sh && tests/gadugi/improvement-curation.sh && tests/gadugi/terminal-session.sh && tests/gadugi/engineer-loop.sh && tests/gadugi/handoff-roundtrip.sh && tests/gadugi/gym-suite.sh