### PR TITLE
Add terminal driving audit trail

### DIFF
--- a/Specs/ProductArchitecture.md
+++ b/Specs/ProductArchitecture.md
@@ -245,7 +245,7 @@ The current shipped v1 engineer-loop slice stays intentionally narrow:
 - a bounded mutating path exists only for explicit structured objectives with `edit-file:`, `replace:`, `with:`, and `verify-contains:` directives
 - the mutating path requires a clean repo, exactly one expected changed file, and explicit content verification before success is reported
 - the terminal-backed engineer substrate now supports bounded interactive checkpoints with `wait-for:` / `expect:` directives so a local PTY session can pause for expected output before sending the next terminal line
-- the terminal-backed engineer substrate now also has a read-only audit companion so operators can inspect persisted shell details and transcript summaries after a terminal-backed session completes
+- the terminal-backed engineer substrate now also has a read-only audit companion so operators can inspect persisted shell details, ordered terminal steps, satisfied wait checkpoints, last output lines, and transcript summaries after a terminal-backed session completes
 
 ## Memory Architecture
 

--- a/docs/reference/runtime-contracts.md
+++ b/docs/reference/runtime-contracts.md
@@ -176,8 +176,9 @@ The contract is intentionally explicit:
 - any explicit `state-root` must already exist as a directory before readback begins
 - `terminal-read` requires readable regular-file `latest_handoff.json`, `memory_records.json`, and `evidence_records.json`; symlinked artifacts are rejected
 - `latest_handoff.json` is authoritative for identity, selected base type, topology, session phase, redacted objective metadata, and the persisted terminal evidence summary tied to the latest terminal session
+- persisted terminal evidence may include ordered terminal step lines, satisfied wait checkpoints, and the last observed output line so operators can inspect how a bounded interactive session was driven instead of relying only on aggregate counters
 - operator-visible strings are sanitized before printing so persisted terminal control sequences and secret-shaped values are not replayed
-- output order stays deterministic: runtime header, handoff session summary, adapter details, shell details, transcript summary, durable record counts
+- output order stays deterministic: runtime header, handoff session summary, adapter details, shell details, step/checkpoint audit trail, transcript summary, durable record counts
 - the command performs no mutation, replay, resume, or execution
 - invalid state roots, missing files, unreadable storage, and malformed persisted terminal data fail explicitly
 

--- a/docs/reference/simard-cli.md
+++ b/docs/reference/simard-cli.md
@@ -181,7 +181,7 @@ Key behavior:
 
 - selects the `terminal-shell` base type explicitly
 - accepts bounded terminal objectives with `command:`/`input:` lines plus `wait-for:` or `expect:` checkpoints so a run can pause for expected output before sending the next line
-- preserves truthful adapter reflection and terminal evidence output
+- preserves truthful adapter reflection and terminal evidence output, including ordered terminal steps, satisfied checkpoints, and the last visible output line
 - fails visibly for unsupported topology and invalid state-root inputs
 - fails explicitly if a requested wait checkpoint never appears instead of pretending the terminal interaction succeeded
 - keeps `simard_operator_probe terminal-run ...` available for compatibility
@@ -207,7 +207,7 @@ Behavior:
 - requires any explicit `state-root` to already exist as a directory
 - requires `latest_handoff.json`, `memory_records.json`, and `evidence_records.json` to already exist as readable regular files; symlinked artifacts are rejected
 - treats `latest_handoff.json` as authoritative for session identity, selected base type, topology, session phase, redacted objective metadata, and the persisted terminal evidence summary
-- renders terminal shell, working directory, command count, wait count, and transcript preview in stable operator-visible order
+- renders terminal shell, working directory, command count, wait count, ordered terminal steps, satisfied wait checkpoints, last output line, and transcript preview in stable operator-visible order
 - strips terminal control sequences and secret-shaped values from displayed output before printing it
 - fails explicitly for invalid `state-root` values and for missing, unreadable, or malformed persisted terminal state
 

--- a/src/operator_commands.rs
+++ b/src/operator_commands.rs
@@ -1417,6 +1417,10 @@ struct TerminalReadView {
     working_directory: String,
     command_count: String,
     wait_count: String,
+    step_count: usize,
+    steps: Vec<String>,
+    checkpoints: Vec<String>,
+    last_output_line: Option<String>,
     transcript_preview: String,
     memory_record_count: usize,
     evidence_record_count: usize,
@@ -1599,6 +1603,17 @@ impl TerminalReadView {
             )
             .unwrap_or("0")
             .to_string(),
+            step_count: terminal_evidence_values(&handoff.evidence_records, "terminal-step-").len(),
+            steps: terminal_evidence_values(&handoff.evidence_records, "terminal-step-"),
+            checkpoints: terminal_evidence_values(
+                &handoff.evidence_records,
+                "terminal-checkpoint-",
+            ),
+            last_output_line: optional_terminal_evidence_value(
+                &handoff.evidence_records,
+                "terminal-last-output-line=",
+            )
+            .map(ToOwned::to_owned),
             transcript_preview: required_terminal_evidence_value(
                 &handoff.evidence_records,
                 "terminal-transcript-preview=",
@@ -1622,6 +1637,25 @@ impl TerminalReadView {
         print_text("Working directory", &self.working_directory);
         print_text("Terminal command count", &self.command_count);
         print_text("Terminal wait count", &self.wait_count);
+        println!("Terminal steps count: {}", self.step_count);
+        if self.steps.is_empty() {
+            println!("Terminal steps: <none>");
+        } else {
+            for (index, step) in self.steps.iter().enumerate() {
+                print_text(&format!("Terminal step {}", index + 1), step);
+            }
+        }
+        println!("Terminal checkpoints count: {}", self.checkpoints.len());
+        if self.checkpoints.is_empty() {
+            println!("Terminal checkpoints: <none>");
+        } else {
+            for (index, checkpoint) in self.checkpoints.iter().enumerate() {
+                print_text(&format!("Terminal checkpoint {}", index + 1), checkpoint);
+            }
+        }
+        if let Some(last_output_line) = &self.last_output_line {
+            print_text("Terminal last output line", last_output_line);
+        }
         print_text("Terminal transcript preview", &self.transcript_preview);
         println!("Memory records: {}", self.memory_record_count);
         println!("Evidence records: {}", self.evidence_record_count);
@@ -1681,6 +1715,21 @@ fn optional_terminal_evidence_value<'a>(
         .iter()
         .rev()
         .find_map(|record| record.detail.strip_prefix(prefix))
+}
+
+fn terminal_evidence_values(evidence_records: &[EvidenceRecord], prefix: &str) -> Vec<String> {
+    evidence_records
+        .iter()
+        .filter_map(|record| record.detail.split_once('='))
+        .filter(|(label, _)| {
+            label.starts_with(prefix)
+                && label[prefix.len()..]
+                    .chars()
+                    .next()
+                    .is_some_and(|ch| ch.is_ascii_digit())
+        })
+        .map(|(_, value)| value.to_string())
+        .collect()
 }
 
 fn parse_engineer_summary_list(raw: &str, separator: &str) -> Vec<String> {

--- a/src/terminal_session.rs
+++ b/src/terminal_session.rs
@@ -9,7 +9,7 @@ use crate::base_types::{
     BaseTypeDescriptor, BaseTypeOutcome, BaseTypeSessionRequest, BaseTypeTurnInput,
 };
 use crate::error::{SimardError, SimardResult};
-use crate::sanitization::objective_metadata;
+use crate::sanitization::{objective_metadata, sanitize_terminal_text};
 
 const DEFAULT_SHELL: &str = "/usr/bin/bash";
 const PTY_LAUNCHER: &str = "script";
@@ -120,6 +120,26 @@ pub fn execute_terminal_turn(
     let objective_summary = objective_metadata(&input.objective);
     let input_count = spec.input_count();
     let wait_count = spec.wait_count();
+    let step_evidence = terminal_step_evidence(&spec.steps);
+    let checkpoint_evidence = terminal_checkpoint_evidence(&spec.steps);
+    let last_output_line = terminal_last_output_line(&transcript, &spec.steps);
+    let mut evidence = vec![
+        format!("selected-base-type={}", descriptor.id),
+        format!("backend-implementation={}", descriptor.backend.identity),
+        format!("shell={}", spec.shell),
+        format!("terminal-working-directory={}", working_directory.display()),
+        format!("terminal-command-count={input_count}"),
+        format!("terminal-wait-count={wait_count}"),
+        format!("terminal-step-count={}", spec.steps.len()),
+        format!("terminal-transcript-preview={transcript_preview}"),
+        format!("runtime-node={}", request.runtime_node),
+        format!("mailbox-address={}", request.mailbox_address),
+    ];
+    evidence.extend(step_evidence);
+    evidence.extend(checkpoint_evidence);
+    if let Some(last_output_line) = last_output_line {
+        evidence.push(format!("terminal-last-output-line={last_output_line}"));
+    }
 
     Ok(BaseTypeOutcome {
         plan: format!(
@@ -143,17 +163,7 @@ pub fn execute_terminal_turn(
             input_count,
             wait_count,
         ),
-        evidence: vec![
-            format!("selected-base-type={}", descriptor.id),
-            format!("backend-implementation={}", descriptor.backend.identity),
-            format!("shell={}", spec.shell),
-            format!("terminal-working-directory={}", working_directory.display()),
-            format!("terminal-command-count={input_count}"),
-            format!("terminal-wait-count={wait_count}"),
-            format!("terminal-transcript-preview={transcript_preview}"),
-            format!("runtime-node={}", request.runtime_node),
-            format!("mailbox-address={}", request.mailbox_address),
-        ],
+        evidence,
     })
 }
 
@@ -403,16 +413,7 @@ fn open_exclusive_temp_file(path: &Path, base_type: &str) -> SimardResult<File> 
 }
 
 fn transcript_preview(transcript: &str) -> String {
-    let mut normalized = transcript
-        .lines()
-        .map(str::trim)
-        .filter(|line| {
-            !line.is_empty()
-                && !line.starts_with("Script started on ")
-                && !line.starts_with("Script done on ")
-        })
-        .collect::<Vec<_>>()
-        .join(" | ");
+    let mut normalized = transcript_content_lines(transcript).join(" | ");
 
     if normalized.len() > 512 {
         normalized.truncate(512);
@@ -422,9 +423,107 @@ fn transcript_preview(transcript: &str) -> String {
     normalized
 }
 
+fn terminal_step_evidence(steps: &[TerminalStep]) -> Vec<String> {
+    steps
+        .iter()
+        .enumerate()
+        .map(|(index, step)| {
+            format!(
+                "terminal-step-{}={}",
+                index + 1,
+                compact_terminal_evidence_value(&render_terminal_step(step), 160)
+            )
+        })
+        .collect()
+}
+
+fn terminal_checkpoint_evidence(steps: &[TerminalStep]) -> Vec<String> {
+    steps
+        .iter()
+        .filter_map(|step| match step {
+            TerminalStep::WaitFor(expected) => Some(expected.as_str()),
+            TerminalStep::Input(_) => None,
+        })
+        .enumerate()
+        .map(|(index, expected)| {
+            format!(
+                "terminal-checkpoint-{}={}",
+                index + 1,
+                compact_terminal_evidence_value(expected, 160)
+            )
+        })
+        .collect()
+}
+
+fn terminal_last_output_line(transcript: &str, steps: &[TerminalStep]) -> Option<String> {
+    let input_commands = steps
+        .iter()
+        .filter_map(|step| match step {
+            TerminalStep::Input(command) => Some(sanitize_terminal_text(command)),
+            TerminalStep::WaitFor(_) => None,
+        })
+        .collect::<Vec<_>>();
+    transcript_content_lines(transcript)
+        .into_iter()
+        .rev()
+        .map(sanitize_terminal_text)
+        .find(|line| is_meaningful_terminal_output(line, &input_commands))
+        .map(|line| compact_terminal_evidence_value(&line, 160))
+}
+
+fn is_meaningful_terminal_output(line: &str, input_commands: &[String]) -> bool {
+    let trimmed = line.trim();
+    if trimmed.is_empty()
+        || trimmed == "exit"
+        || trimmed.ends_with("$ exit")
+        || trimmed.ends_with("# exit")
+    {
+        return false;
+    }
+
+    !input_commands.iter().any(|command| {
+        trimmed == command
+            || trimmed.ends_with(&format!("$ {command}"))
+            || trimmed.ends_with(&format!("# {command}"))
+    })
+}
+
+fn transcript_content_lines(transcript: &str) -> Vec<&str> {
+    transcript
+        .lines()
+        .map(str::trim)
+        .filter(|line| {
+            !line.is_empty()
+                && !line.starts_with("Script started on ")
+                && !line.starts_with("Script done on ")
+        })
+        .collect()
+}
+
+fn render_terminal_step(step: &TerminalStep) -> String {
+    match step {
+        TerminalStep::Input(command) => format!("input: {command}"),
+        TerminalStep::WaitFor(expected) => format!("wait-for: {expected}"),
+    }
+}
+
+fn compact_terminal_evidence_value(raw: &str, limit: usize) -> String {
+    let mut normalized = sanitize_terminal_text(raw)
+        .replace('\n', "\\n")
+        .replace('\t', "\\t");
+    if normalized.len() > limit {
+        normalized.truncate(limit);
+        normalized.push_str("...");
+    }
+    normalized
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{TerminalStep, TerminalTurnSpec, normalize_shell};
+    use super::{
+        TerminalStep, TerminalTurnSpec, compact_terminal_evidence_value, normalize_shell,
+        terminal_checkpoint_evidence, terminal_last_output_line, terminal_step_evidence,
+    };
     use std::fs;
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -591,5 +690,55 @@ mod tests {
         );
         assert_eq!(spec.input_count(), 2);
         assert_eq!(spec.wait_count(), 1);
+    }
+
+    #[test]
+    fn terminal_step_and_checkpoint_evidence_preserve_operator_visible_flow() {
+        let steps = vec![
+            TerminalStep::Input("printf \"ready\\n\"".to_string()),
+            TerminalStep::WaitFor("ready".to_string()),
+            TerminalStep::Input("/status".to_string()),
+        ];
+
+        assert_eq!(
+            terminal_step_evidence(&steps),
+            vec![
+                "terminal-step-1=input: printf \"ready\\n\"".to_string(),
+                "terminal-step-2=wait-for: ready".to_string(),
+                "terminal-step-3=input: /status".to_string(),
+            ]
+        );
+        assert_eq!(
+            terminal_checkpoint_evidence(&steps),
+            vec!["terminal-checkpoint-1=ready".to_string()]
+        );
+    }
+
+    #[test]
+    fn terminal_last_output_line_ignores_script_preamble_and_sanitizes_control_text() {
+        let transcript = "Script started on 2025-03-29 12:00:00+00:00 [COMMAND=\"/usr/bin/bash --noprofile --norc -i\" <not executed on terminal>]\nterminal-ready\n\u{1b}[32mterminal-ok\u{1b}[0m\nScript done on 2025-03-29 12:00:01+00:00 [COMMAND_EXIT_CODE=\"0\"]";
+        assert_eq!(
+            terminal_last_output_line(transcript, &[]),
+            Some("terminal-ok".to_string())
+        );
+    }
+
+    #[test]
+    fn terminal_last_output_line_ignores_prompt_wrapped_inputs_and_exit() {
+        let transcript = "pwd\nprintf \"terminal-foundation-ok\\n\"\nbash-5.2$ pwd\n/home/azureuser/src/Simard\nbash-5.2$ printf \"terminal-foundation-ok\\n\"\nterminal-foundation-ok\nbash-5.2$ exit";
+        let steps = vec![
+            TerminalStep::Input("pwd".to_string()),
+            TerminalStep::Input("printf \"terminal-foundation-ok\\n\"".to_string()),
+        ];
+        assert_eq!(
+            terminal_last_output_line(transcript, &steps),
+            Some("terminal-foundation-ok".to_string())
+        );
+    }
+
+    #[test]
+    fn compact_terminal_evidence_value_replaces_newlines_and_truncates() {
+        let raw = "line1\nline2\tline3";
+        assert_eq!(compact_terminal_evidence_value(raw, 12), "line1\\nline2...");
     }
 }

--- a/tests/bootstrap.rs
+++ b/tests/bootstrap.rs
@@ -715,6 +715,18 @@ fn bootstrap_supports_terminal_shell_execution() {
     assert!(
         terminal_evidence
             .iter()
+            .any(|detail| detail == &"terminal-step-count=2"),
+        "terminal evidence should report the terminal step count"
+    );
+    assert!(
+        terminal_evidence
+            .iter()
+            .any(|detail| detail == &"terminal-last-output-line=terminal-foundation-ok"),
+        "terminal evidence should preserve the last visible terminal output line"
+    );
+    assert!(
+        terminal_evidence
+            .iter()
             .any(|detail| detail.contains("terminal-foundation-ok")),
         "terminal transcript evidence should keep a preview of real terminal output"
     );

--- a/tests/gadugi/terminal-session.sh
+++ b/tests/gadugi/terminal-session.sh
@@ -20,8 +20,11 @@ printf '%s\n' "$OUTPUT" | grep -F "Topology: single-process" >/dev/null
 printf '%s\n' "$OUTPUT" | grep -F "Adapter implementation: terminal-shell::local-pty" >/dev/null
 printf '%s\n' "$OUTPUT" | grep -F "Adapter capabilities: prompt-assets, session-lifecycle, memory, evidence, reflection, terminal-session" >/dev/null
 printf '%s\n' "$OUTPUT" | grep -F "Session phase: complete" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "Terminal evidence: terminal-step-count=3" >/dev/null
 printf '%s\n' "$OUTPUT" | grep -F "Terminal evidence: terminal-command-count=2" >/dev/null
 printf '%s\n' "$OUTPUT" | grep -F "Terminal evidence: terminal-wait-count=1" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "Terminal evidence: terminal-checkpoint-1=terminal-foundation-ready" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "Terminal evidence: terminal-last-output-line=terminal-foundation-ok" >/dev/null
 printf '%s\n' "$OUTPUT" | grep -F "terminal-foundation-ok" >/dev/null
 
 READ_OUTPUT="$(
@@ -35,6 +38,9 @@ printf '%s\n' "$READ_OUTPUT" | grep -F "Probe mode: terminal-read" >/dev/null
 printf '%s\n' "$READ_OUTPUT" | grep -F "Selected base type: terminal-shell" >/dev/null
 printf '%s\n' "$READ_OUTPUT" | grep -F "Terminal command count: 2" >/dev/null
 printf '%s\n' "$READ_OUTPUT" | grep -F "Terminal wait count: 1" >/dev/null
+printf '%s\n' "$READ_OUTPUT" | grep -F "Terminal steps count: 3" >/dev/null
+printf '%s\n' "$READ_OUTPUT" | grep -F "Terminal checkpoint 1: terminal-foundation-ready" >/dev/null
+printf '%s\n' "$READ_OUTPUT" | grep -F "Terminal last output line: terminal-foundation-ok" >/dev/null
 printf '%s\n' "$READ_OUTPUT" | grep -F "terminal-foundation-ok" >/dev/null
 
 MARKER="$(mktemp /tmp/simard-terminal-injection.XXXXXX)"

--- a/tests/simard_cli.rs
+++ b/tests/simard_cli.rs
@@ -668,6 +668,10 @@ command: printf \"terminal-cli-ok\\n\"";
     for expected in [
         "Selected base type: terminal-shell",
         "Adapter implementation: terminal-shell::local-pty",
+        "Terminal evidence: terminal-step-count=3",
+        "Terminal evidence: terminal-step-2=wait-for: terminal-cli-ready",
+        "Terminal evidence: terminal-checkpoint-1=terminal-cli-ready",
+        "Terminal evidence: terminal-last-output-line=terminal-cli-ok",
         "Terminal evidence: terminal-wait-count=1",
         "terminal-cli-ok",
         &format!("State root: {}", state_root.path().display()),
@@ -769,6 +773,13 @@ input: printf \"terminal-read-ok\\n\"";
         "Adapter implementation: terminal-shell::local-pty",
         "Terminal command count: 2",
         "Terminal wait count: 1",
+        "Terminal steps count: 3",
+        "Terminal step 1: input: printf \"terminal-read-ready\\n\"",
+        "Terminal step 2: wait-for: terminal-read-ready",
+        "Terminal step 3: input: printf \"terminal-read-ok\\n\"",
+        "Terminal checkpoints count: 1",
+        "Terminal checkpoint 1: terminal-read-ready",
+        "Terminal last output line: terminal-read-ok",
         "terminal-read-ok",
     ] {
         assert!(


### PR DESCRIPTION
## Summary
- persist ordered terminal step evidence, satisfied wait checkpoints, and the last meaningful output line for terminal-backed engineer sessions
- expose that richer audit trail through `simard engineer terminal-read` without pretending real external copilot integration
- extend bootstrap, CLI, shell-level, and docs coverage so the operator-facing contract stays truthful

## Validation
- cargo fmt --all
- cargo test --all-features --locked
- tests/gadugi/terminal-session.sh
- cargo run --quiet --bin simard -- engineer terminal single-process ...
- cargo run --quiet --bin simard -- engineer terminal-read single-process ...
- python3 -m pre_commit run --all-files --hook-stage pre-commit
- python3 -m pre_commit run --all-files --hook-stage pre-push