### PR TITLE
Add file-backed terminal sessions

### DIFF
--- a/Specs/ProductArchitecture.md
+++ b/Specs/ProductArchitecture.md
@@ -247,6 +247,7 @@ The current shipped v1 engineer-loop slice stays intentionally narrow:
 - the terminal-backed engineer substrate now supports bounded interactive checkpoints with `wait-for:` / `expect:` directives so a local PTY session can pause for expected output before sending the next terminal line
 - the terminal-backed engineer substrate now also has a read-only audit companion so operators can inspect persisted shell details, ordered terminal steps, satisfied wait checkpoints, last output lines, and transcript summaries after a terminal-backed session completes
 - the primary terminal-run surface now renders that same structured audit trail during execution so operators can follow bounded copilot-style terminal driving without dropping to raw evidence lines
+- operators can now author those bounded interactive terminal sessions either inline or from reusable file-backed recipes, while staying on the same truthful local PTY substrate
 
 ## Memory Architecture
 

--- a/docs/reference/runtime-contracts.md
+++ b/docs/reference/runtime-contracts.md
@@ -37,6 +37,7 @@ Simard does **not** expose:
 | bounded engineer loop | `simard engineer run ...` | `simard_operator_probe engineer-loop-run ...` |
 | engineer state readback | `simard engineer read ...` | `simard_operator_probe engineer-read ...` |
 | terminal-backed engineer substrate | `simard engineer terminal ...` | `simard_operator_probe terminal-run ...` |
+| file-backed terminal engineer substrate | `simard engineer terminal-file ...` | `simard_operator_probe terminal-run-file ...` |
 | terminal session readback | `simard engineer terminal-read ...` | `simard_operator_probe terminal-read ...` |
 | meeting mode | `simard meeting run ...` | `simard_operator_probe meeting-run ...` |
 | meeting state readback | `simard meeting read ...` | `simard_operator_probe meeting-read ...` |
@@ -54,6 +55,7 @@ The shipped operator-facing command tree is:
 - `simard engineer run <topology> <workspace-root> <objective> [state-root]`
 - `simard engineer read <topology> [state-root]`
 - `simard engineer terminal <topology> <objective> [state-root]`
+- `simard engineer terminal-file <topology> <objective-file> [state-root]`
 - `simard engineer terminal-read <topology> [state-root]`
 - `simard meeting run <base-type> <topology> <structured-objective> [state-root]`
 - `simard meeting read <base-type> <topology> [state-root]`
@@ -181,6 +183,19 @@ The contract is intentionally explicit:
 - output order stays deterministic: runtime header, handoff session summary, adapter details, shell details, step/checkpoint audit trail, transcript summary, durable record counts
 - the command performs no mutation, replay, resume, or execution
 - invalid state roots, missing files, unreadable storage, and malformed persisted terminal data fail explicitly
+
+#### File-backed terminal session execution
+
+Canonical entrypoint: `simard engineer terminal-file <topology> <objective-file> [state-root]`
+
+Compatibility surface: `simard_operator_probe terminal-run-file <topology> <objective-file> [state-root]`
+
+This is the reusable authoring companion to `simard engineer terminal`.
+
+- it executes the same bounded `terminal-shell` substrate as `engineer terminal`
+- `<objective-file>` must exist as a readable UTF-8 regular file; symlinks and other file kinds are rejected explicitly
+- the loaded file contents remain subject to the same shell validation, wait-checkpoint behavior, sanitization, and durable state contracts as inline terminal objectives
+- the run surface and `terminal-read` continue to present the same structured terminal audit trail
 
 ### Meeting mode
 

--- a/docs/reference/simard-cli.md
+++ b/docs/reference/simard-cli.md
@@ -61,6 +61,7 @@ Bare `simard` prints this operator surface directly.
 | --- | --- |
 | `simard engineer run ...` | `simard_operator_probe engineer-loop-run ...` |
 | `simard engineer terminal ...` | `simard_operator_probe terminal-run ...` |
+| `simard engineer terminal-file ...` | `simard_operator_probe terminal-run-file ...` |
 | `simard engineer terminal-read ...` | `simard_operator_probe terminal-read ...` |
 | `simard engineer read ...` | `simard_operator_probe engineer-read ...` |
 | `simard meeting run ...` | `simard_operator_probe meeting-run ...` |
@@ -195,6 +196,30 @@ simard engineer terminal single-process $'working-directory: .
 command: printf "terminal-foundation-ready\n"
 wait-for: terminal-foundation-ready
 command: printf "terminal-foundation-ok\n"' "$STATE_ROOT"
+```
+
+### `simard engineer terminal-file <topology> <objective-file> [state-root]`
+
+Runs the same bounded terminal-backed engineer substrate, but loads the session recipe from a reusable UTF-8 text file instead of requiring the whole objective inline on the command line.
+
+Behavior:
+
+- reuses the same `terminal-shell` base type and bounded wait/send terminal semantics as `engineer terminal`
+- requires `<objective-file>` to exist as a readable regular file; symlinks and non-files fail explicitly
+- preserves the same structured terminal audit trail on the run surface and through `terminal-read`
+- keeps `simard_operator_probe terminal-run-file ...` available for compatibility
+
+Example:
+
+```bash
+cat > /tmp/simard-terminal.recipe <<'EOF'
+working-directory: .
+command: printf "terminal-file-ready\n"
+wait-for: terminal-file-ready
+input: printf "terminal-file-ok\n"
+EOF
+
+simard engineer terminal-file single-process /tmp/simard-terminal.recipe "$STATE_ROOT"
 ```
 
 ### `simard engineer terminal-read <topology> [state-root]`

--- a/docs/tutorials/run-your-first-local-session.md
+++ b/docs/tutorials/run-your-first-local-session.md
@@ -222,6 +222,20 @@ Look for:
 - `Terminal last output line: terminal-foundation-ok`
 - `Terminal transcript preview:`
 
+If you want to keep a reusable interactive session recipe on disk instead of packing it into one CLI string, use the file-backed entrypoint:
+
+```bash
+cat > /tmp/simard-terminal.recipe <<'EOF'
+working-directory: .
+command: printf "terminal-file-ready\n"
+wait-for: terminal-file-ready
+input: printf "terminal-file-ok\n"
+EOF
+
+cargo run --quiet -- \
+  engineer terminal-file single-process /tmp/simard-terminal.recipe "$STATE_ROOT"
+```
+
 ## Summary
 
 You now know how to:

--- a/src/operator_cli.rs
+++ b/src/operator_cli.rs
@@ -5,7 +5,7 @@ use crate::operator_commands::{
     run_goal_curation_read_probe, run_gym_compare, run_gym_list, run_gym_scenario, run_gym_suite,
     run_improvement_curation_probe, run_improvement_curation_read_probe, run_meeting_probe,
     run_meeting_read_probe, run_review_probe, run_review_read_probe, run_terminal_probe,
-    run_terminal_read_probe,
+    run_terminal_probe_from_file, run_terminal_read_probe,
 };
 
 const OPERATOR_CLI_HELP: &str = "\
@@ -14,6 +14,7 @@ Simard unified operator CLI
 Product modes:
   engineer run <topology> <workspace-root> <objective> [state-root]
   engineer terminal <topology> <objective> [state-root]
+  engineer terminal-file <topology> <objective-file> [state-root]
   engineer terminal-read <topology> [state-root]
   engineer read <topology> [state-root]
   meeting run <base-type> <topology> <objective> [state-root]
@@ -94,6 +95,13 @@ fn dispatch_engineer_command(
             let state_root = next_optional_path(&mut args);
             reject_extra_args(args)?;
             run_terminal_probe(&topology, &objective, state_root)
+        }
+        "terminal-file" => {
+            let topology = next_required(&mut args, "topology")?;
+            let objective_path = next_required(&mut args, "objective file")?;
+            let state_root = next_optional_path(&mut args);
+            reject_extra_args(args)?;
+            run_terminal_probe_from_file(&topology, &PathBuf::from(objective_path), state_root)
         }
         "terminal-read" => {
             let topology = next_required(&mut args, "topology")?;

--- a/src/operator_commands.rs
+++ b/src/operator_commands.rs
@@ -74,6 +74,13 @@ where
             reject_extra_args(args)?;
             run_terminal_probe(&topology, &objective, state_root)?;
         }
+        "terminal-run-file" => {
+            let topology = next_required(&mut args, "topology")?;
+            let objective_path = next_required(&mut args, "objective file")?;
+            let state_root = next_optional_path(&mut args);
+            reject_extra_args(args)?;
+            run_terminal_probe_from_file(&topology, Path::new(&objective_path), state_root)?;
+        }
         "terminal-read" => {
             let topology = next_required(&mut args, "topology")?;
             let state_root = next_optional_path(&mut args);
@@ -490,6 +497,15 @@ pub fn run_terminal_probe(
         &execution.outcome.reflection.summary,
     );
     Ok(())
+}
+
+pub fn run_terminal_probe_from_file(
+    topology: &str,
+    objective_path: &Path,
+    state_root_override: Option<PathBuf>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let objective = load_terminal_objective_file(objective_path)?;
+    run_terminal_probe(topology, &objective, state_root_override)
 }
 
 pub fn run_terminal_read_probe(
@@ -1797,6 +1813,37 @@ fn next_required(
 
 fn next_optional_path(args: &mut impl Iterator<Item = String>) -> Option<PathBuf> {
     args.next().map(PathBuf::from)
+}
+
+fn load_terminal_objective_file(path: &Path) -> Result<String, Box<dyn std::error::Error>> {
+    let metadata = fs::symlink_metadata(path).map_err(|error| {
+        format!(
+            "terminal objective file '{}' could not be inspected: {error}",
+            path.display()
+        )
+    })?;
+    if metadata.file_type().is_symlink() {
+        return Err(format!(
+            "terminal objective file '{}' must be a regular file, not a symlink",
+            path.display()
+        )
+        .into());
+    }
+    if !metadata.is_file() {
+        return Err(format!(
+            "terminal objective file '{}' must be a regular file",
+            path.display()
+        )
+        .into());
+    }
+
+    fs::read_to_string(path).map_err(|error| {
+        format!(
+            "terminal objective file '{}' could not be read as UTF-8 text: {error}",
+            path.display()
+        )
+        .into()
+    })
 }
 
 fn reject_extra_args(

--- a/tests/gadugi/terminal-session.sh
+++ b/tests/gadugi/terminal-session.sh
@@ -28,6 +28,25 @@ printf '%s\n' "$OUTPUT" | grep -F "Terminal checkpoint 1: terminal-foundation-re
 printf '%s\n' "$OUTPUT" | grep -F "Terminal last output line: terminal-foundation-ok" >/dev/null
 printf '%s\n' "$OUTPUT" | grep -F "terminal-foundation-ok" >/dev/null
 
+OBJECTIVE_FILE="$(mktemp /tmp/simard-terminal-objective.XXXXXX)"
+cat > "$OBJECTIVE_FILE" <<'EOF'
+working-directory: .
+command: printf "terminal-file-ready\n"
+wait-for: terminal-file-ready
+input: printf "terminal-file-ok\n"
+EOF
+
+FILE_OUTPUT="$(
+  cargo run --quiet --bin simard -- \
+    engineer terminal-file single-process "$OBJECTIVE_FILE"
+)"
+
+printf '%s\n' "$FILE_OUTPUT"
+
+printf '%s\n' "$FILE_OUTPUT" | grep -F "Terminal steps count: 3" >/dev/null
+printf '%s\n' "$FILE_OUTPUT" | grep -F "Terminal checkpoint 1: terminal-file-ready" >/dev/null
+printf '%s\n' "$FILE_OUTPUT" | grep -F "Terminal last output line: terminal-file-ok" >/dev/null
+
 READ_OUTPUT="$(
   cargo run --quiet --bin simard -- \
     engineer terminal-read single-process
@@ -59,3 +78,4 @@ set -e
 [ "$BAD_STATUS" -ne 0 ]
 [ ! -e "$MARKER" ]
 printf '%s\n' "$BAD_OUTPUT" | grep -F "terminal-shell only accepts an absolute shell executable path using safe path characters" >/dev/null
+rm -f "$OBJECTIVE_FILE"

--- a/tests/simard_cli.rs
+++ b/tests/simard_cli.rs
@@ -353,6 +353,10 @@ fn simard_help_documents_engineer_read_as_the_durable_engineer_audit_surface() {
         rendered.contains("engineer terminal-read <topology> [state-root]"),
         "simard help should document the canonical read-only terminal audit workflow:\n{rendered}"
     );
+    assert!(
+        rendered.contains("engineer terminal-file <topology> <objective-file> [state-root]"),
+        "simard help should document the file-backed terminal session workflow:\n{rendered}"
+    );
 }
 
 #[test]
@@ -714,6 +718,87 @@ command: printf \"terminal-cli-ok\\n\"";
             "terminal engineer mode should persist {expected} under the selected state root"
         );
     }
+}
+
+#[test]
+fn simard_engineer_terminal_file_runs_a_bounded_terminal_session_from_a_recipe_file() {
+    let state_root = TempDirGuard::new("simard-cli-terminal-file");
+    let objective_dir = TempDirGuard::new("simard-cli-terminal-file-objective");
+    let objective_path = objective_dir.path().join("session.simard-terminal");
+    fs::write(
+        &objective_path,
+        "working-directory: .\ncommand: printf \"terminal-file-ready\\n\"\nwait-for: terminal-file-ready\ninput: printf \"terminal-file-ok\\n\"",
+    )
+    .expect("terminal objective file should be written");
+
+    let simard_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("engineer")
+        .arg("terminal-file")
+        .arg("single-process")
+        .arg(&objective_path)
+        .arg(state_root.path())
+        .output()
+        .expect("simard engineer terminal-file should launch");
+    let simard_rendered = rendered_output(&simard_output);
+
+    assert!(
+        simard_output.status.success(),
+        "terminal-file should expose the same bounded terminal substrate through a reusable file-backed recipe:\n{simard_rendered}"
+    );
+    for expected in [
+        "Selected base type: terminal-shell",
+        "Terminal steps count: 3",
+        "Terminal checkpoint 1: terminal-file-ready",
+        "Terminal last output line: terminal-file-ok",
+        "terminal-file-ok",
+    ] {
+        assert!(
+            simard_rendered.contains(expected),
+            "terminal-file should surface '{expected}' for operators:\n{simard_rendered}"
+        );
+    }
+
+    let legacy_output = Command::new(env!("CARGO_BIN_EXE_simard_operator_probe"))
+        .arg("terminal-run-file")
+        .arg("single-process")
+        .arg(&objective_path)
+        .arg(state_root.path())
+        .output()
+        .expect("legacy terminal-run-file should launch");
+    let legacy_rendered = rendered_output(&legacy_output);
+
+    assert!(
+        legacy_output.status.success(),
+        "terminal-run-file compatibility path should remain available while operators migrate:\n{legacy_rendered}"
+    );
+    assert_eq!(
+        simard_rendered, legacy_rendered,
+        "terminal-file should preserve terminal-run-file parity so canonical and compatibility surfaces stay aligned"
+    );
+}
+
+#[test]
+fn simard_engineer_terminal_file_rejects_missing_or_unreadable_recipe_files() {
+    let state_root = TempDirGuard::new("simard-cli-terminal-file-missing");
+    let missing_path = state_root.path().join("missing.simard-terminal");
+    let output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("engineer")
+        .arg("terminal-file")
+        .arg("single-process")
+        .arg(&missing_path)
+        .arg(state_root.path())
+        .output()
+        .expect("simard engineer terminal-file missing-path case should launch");
+    let rendered = rendered_output(&output);
+
+    assert!(
+        !output.status.success(),
+        "terminal-file must fail when the recipe file cannot be inspected:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("terminal objective file") && rendered.contains("could not be inspected"),
+        "terminal-file should explain why the requested recipe file could not be loaded:\n{rendered}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add file-backed terminal session entrypoints on both the canonical CLI and the compatibility probe
- keep the same bounded PTY execution, structured audit trail, and terminal-read contract for reusable recipe files
- extend CLI, shell-level, and docs coverage for the new operator convenience path

## Validation
- cargo fmt --all
- cargo test --all-features --locked
- tests/gadugi/terminal-session.sh
- cargo run --quiet --bin simard -- engineer terminal-file single-process ...
- cargo run --quiet --bin simard_operator_probe -- terminal-run-file single-process ...
- cargo run --quiet --bin simard -- engineer terminal-read single-process ...
- python3 -m pre_commit run --all-files --hook-stage pre-commit
- python3 -m pre_commit run --all-files --hook-stage pre-push