### PR TITLE
Add named terminal session recipes

### DIFF
--- a/Specs/ProductArchitecture.md
+++ b/Specs/ProductArchitecture.md
@@ -248,6 +248,7 @@ The current shipped v1 engineer-loop slice stays intentionally narrow:
 - the terminal-backed engineer substrate now also has a read-only audit companion so operators can inspect persisted shell details, ordered terminal steps, satisfied wait checkpoints, last output lines, and transcript summaries after a terminal-backed session completes
 - the primary terminal-run surface now renders that same structured audit trail during execution so operators can follow bounded copilot-style terminal driving without dropping to raw evidence lines
 - operators can now author those bounded interactive terminal sessions either inline or from reusable file-backed recipes, while staying on the same truthful local PTY substrate
+- Simard now also ships named built-in terminal recipes so operators can discover, inspect, and rerun common interactive session flows without inventing ad hoc shell strings or temp files each time
 
 ## Memory Architecture
 

--- a/docs/reference/runtime-contracts.md
+++ b/docs/reference/runtime-contracts.md
@@ -38,6 +38,7 @@ Simard does **not** expose:
 | engineer state readback | `simard engineer read ...` | `simard_operator_probe engineer-read ...` |
 | terminal-backed engineer substrate | `simard engineer terminal ...` | `simard_operator_probe terminal-run ...` |
 | file-backed terminal engineer substrate | `simard engineer terminal-file ...` | `simard_operator_probe terminal-run-file ...` |
+| named terminal recipe execution | `simard engineer terminal-recipe ...` | `simard_operator_probe terminal-recipe-run ...` |
 | terminal session readback | `simard engineer terminal-read ...` | `simard_operator_probe terminal-read ...` |
 | meeting mode | `simard meeting run ...` | `simard_operator_probe meeting-run ...` |
 | meeting state readback | `simard meeting read ...` | `simard_operator_probe meeting-read ...` |
@@ -56,6 +57,9 @@ The shipped operator-facing command tree is:
 - `simard engineer read <topology> [state-root]`
 - `simard engineer terminal <topology> <objective> [state-root]`
 - `simard engineer terminal-file <topology> <objective-file> [state-root]`
+- `simard engineer terminal-recipe-list`
+- `simard engineer terminal-recipe-show <recipe-name>`
+- `simard engineer terminal-recipe <topology> <recipe-name> [state-root]`
 - `simard engineer terminal-read <topology> [state-root]`
 - `simard meeting run <base-type> <topology> <structured-objective> [state-root]`
 - `simard meeting read <base-type> <topology> [state-root]`
@@ -196,6 +200,28 @@ This is the reusable authoring companion to `simard engineer terminal`.
 - `<objective-file>` must exist as a readable UTF-8 regular file; symlinks and other file kinds are rejected explicitly
 - the loaded file contents remain subject to the same shell validation, wait-checkpoint behavior, sanitization, and durable state contracts as inline terminal objectives
 - the run surface and `terminal-read` continue to present the same structured terminal audit trail
+
+#### Named terminal recipe execution
+
+Canonical entrypoints:
+
+- `simard engineer terminal-recipe-list`
+- `simard engineer terminal-recipe-show <recipe-name>`
+- `simard engineer terminal-recipe <topology> <recipe-name> [state-root]`
+
+Compatibility surface:
+
+- `simard_operator_probe terminal-recipe-list`
+- `simard_operator_probe terminal-recipe-show <recipe-name>`
+- `simard_operator_probe terminal-recipe-run <topology> <recipe-name> [state-root]`
+
+This is the discoverable built-in recipe companion to inline and file-backed terminal execution.
+
+- recipes live under `prompt_assets/simard/terminal_recipes/*.simard-terminal`
+- recipe names are limited to lowercase ASCII letters, digits, and hyphens
+- unknown or invalid recipe names fail explicitly
+- `terminal-recipe-show` is read-only and prints the shipped recipe asset contents
+- `terminal-recipe` executes the same bounded `terminal-shell` substrate as `engineer terminal` and `engineer terminal-file`
 
 ### Meeting mode
 

--- a/docs/reference/simard-cli.md
+++ b/docs/reference/simard-cli.md
@@ -62,6 +62,7 @@ Bare `simard` prints this operator surface directly.
 | `simard engineer run ...` | `simard_operator_probe engineer-loop-run ...` |
 | `simard engineer terminal ...` | `simard_operator_probe terminal-run ...` |
 | `simard engineer terminal-file ...` | `simard_operator_probe terminal-run-file ...` |
+| `simard engineer terminal-recipe ...` | `simard_operator_probe terminal-recipe-run ...` |
 | `simard engineer terminal-read ...` | `simard_operator_probe terminal-read ...` |
 | `simard engineer read ...` | `simard_operator_probe engineer-read ...` |
 | `simard meeting run ...` | `simard_operator_probe meeting-run ...` |
@@ -220,6 +221,33 @@ input: printf "terminal-file-ok\n"
 EOF
 
 simard engineer terminal-file single-process /tmp/simard-terminal.recipe "$STATE_ROOT"
+```
+
+### `simard engineer terminal-recipe-list`
+
+Lists the built-in named terminal session recipes shipped under `prompt_assets/simard/terminal_recipes/`.
+
+### `simard engineer terminal-recipe-show <recipe-name>`
+
+Prints the selected built-in terminal recipe asset and its bounded session contents before execution.
+
+### `simard engineer terminal-recipe <topology> <recipe-name> [state-root]`
+
+Runs one of the built-in named terminal session recipes through the same bounded PTY-backed substrate as `engineer terminal` and `engineer terminal-file`.
+
+Behavior:
+
+- loads a named recipe from `prompt_assets/simard/terminal_recipes/*.simard-terminal`
+- preserves the same structured terminal audit trail on the run surface and through `terminal-read`
+- fails explicitly when the requested recipe name is unknown or invalid
+- keeps `simard_operator_probe terminal-recipe-run ...` available for compatibility
+
+Example:
+
+```bash
+simard engineer terminal-recipe-list
+simard engineer terminal-recipe-show foundation-check
+simard engineer terminal-recipe single-process foundation-check "$STATE_ROOT"
 ```
 
 ### `simard engineer terminal-read <topology> [state-root]`

--- a/docs/tutorials/run-your-first-local-session.md
+++ b/docs/tutorials/run-your-first-local-session.md
@@ -236,6 +236,14 @@ cargo run --quiet -- \
   engineer terminal-file single-process /tmp/simard-terminal.recipe "$STATE_ROOT"
 ```
 
+Simard also ships named built-in terminal recipes when you want reusable sessions without managing your own temp file:
+
+```bash
+cargo run --quiet -- engineer terminal-recipe-list
+cargo run --quiet -- engineer terminal-recipe-show foundation-check
+cargo run --quiet -- engineer terminal-recipe single-process foundation-check "$STATE_ROOT"
+```
+
 ## Summary
 
 You now know how to:

--- a/prompt_assets/simard/terminal_recipes/copilot-status-check.simard-terminal
+++ b/prompt_assets/simard/terminal_recipes/copilot-status-check.simard-terminal
@@ -1,0 +1,7 @@
+working-directory: .
+command: sh -c 'printf "copilot-ready\n"; while IFS= read -r line; do if [ "$line" = "/status" ]; then printf "mode: ready\n"; elif [ "$line" = "/exit" ]; then printf "bye\n"; break; else printf "echo:%s\n" "$line"; fi; done'
+wait-for: copilot-ready
+input: /status
+wait-for: mode: ready
+input: /exit
+wait-for: bye

--- a/prompt_assets/simard/terminal_recipes/foundation-check.simard-terminal
+++ b/prompt_assets/simard/terminal_recipes/foundation-check.simard-terminal
@@ -1,0 +1,4 @@
+working-directory: .
+command: printf "terminal-recipe-ready\n"
+wait-for: terminal-recipe-ready
+input: printf "terminal-recipe-ok\n"

--- a/src/operator_cli.rs
+++ b/src/operator_cli.rs
@@ -5,7 +5,8 @@ use crate::operator_commands::{
     run_goal_curation_read_probe, run_gym_compare, run_gym_list, run_gym_scenario, run_gym_suite,
     run_improvement_curation_probe, run_improvement_curation_read_probe, run_meeting_probe,
     run_meeting_read_probe, run_review_probe, run_review_read_probe, run_terminal_probe,
-    run_terminal_probe_from_file, run_terminal_read_probe,
+    run_terminal_probe_from_file, run_terminal_read_probe, run_terminal_recipe_list_probe,
+    run_terminal_recipe_probe, run_terminal_recipe_show_probe,
 };
 
 const OPERATOR_CLI_HELP: &str = "\
@@ -15,6 +16,9 @@ Product modes:
   engineer run <topology> <workspace-root> <objective> [state-root]
   engineer terminal <topology> <objective> [state-root]
   engineer terminal-file <topology> <objective-file> [state-root]
+  engineer terminal-recipe-list
+  engineer terminal-recipe-show <recipe-name>
+  engineer terminal-recipe <topology> <recipe-name> [state-root]
   engineer terminal-read <topology> [state-root]
   engineer read <topology> [state-root]
   meeting run <base-type> <topology> <objective> [state-root]
@@ -108,6 +112,22 @@ fn dispatch_engineer_command(
             let state_root = next_optional_path(&mut args);
             reject_extra_args(args)?;
             run_terminal_read_probe(&topology, state_root)
+        }
+        "terminal-recipe-list" => {
+            reject_extra_args(args)?;
+            run_terminal_recipe_list_probe()
+        }
+        "terminal-recipe-show" => {
+            let recipe_name = next_required(&mut args, "recipe name")?;
+            reject_extra_args(args)?;
+            run_terminal_recipe_show_probe(&recipe_name)
+        }
+        "terminal-recipe" => {
+            let topology = next_required(&mut args, "topology")?;
+            let recipe_name = next_required(&mut args, "recipe name")?;
+            let state_root = next_optional_path(&mut args);
+            reject_extra_args(args)?;
+            run_terminal_recipe_probe(&topology, &recipe_name, state_root)
         }
         "read" => {
             let topology = next_required(&mut args, "topology")?;

--- a/src/operator_commands.rs
+++ b/src/operator_commands.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -6,6 +7,7 @@ use crate::bootstrap::validate_state_root;
 use crate::goals::{FileBackedGoalStore, GoalRecord, GoalStatus, GoalStore};
 use crate::improvements::PersistedImprovementRecord;
 use crate::meetings::PersistedMeetingRecord;
+use crate::prompt_assets::{FilePromptAssetStore, PromptAsset, PromptAssetRef, PromptAssetStore};
 use crate::sanitization::sanitize_terminal_text;
 use crate::{
     BootstrapConfig, BootstrapInputs, BuiltinIdentityLoader, EvidenceRecord,
@@ -86,6 +88,22 @@ where
             let state_root = next_optional_path(&mut args);
             reject_extra_args(args)?;
             run_terminal_read_probe(&topology, state_root)?;
+        }
+        "terminal-recipe-list" => {
+            reject_extra_args(args)?;
+            run_terminal_recipe_list_probe()?;
+        }
+        "terminal-recipe-show" => {
+            let recipe_name = next_required(&mut args, "recipe name")?;
+            reject_extra_args(args)?;
+            run_terminal_recipe_show_probe(&recipe_name)?;
+        }
+        "terminal-recipe-run" => {
+            let topology = next_required(&mut args, "topology")?;
+            let recipe_name = next_required(&mut args, "recipe name")?;
+            let state_root = next_optional_path(&mut args);
+            reject_extra_args(args)?;
+            run_terminal_recipe_probe(&topology, &recipe_name, state_root)?;
         }
         "engineer-loop-run" => {
             let topology = next_required(&mut args, "topology")?;
@@ -516,6 +534,37 @@ pub fn run_terminal_read_probe(
     let view = TerminalReadView::load(state_root)?;
     view.print();
     Ok(())
+}
+
+pub fn run_terminal_recipe_list_probe() -> Result<(), Box<dyn std::error::Error>> {
+    let recipes = list_terminal_recipe_descriptors()?;
+    println!("Terminal recipes: {}", recipes.len());
+    for (index, recipe) in recipes.iter().enumerate() {
+        print_text(
+            &format!("Terminal recipe {}", index + 1),
+            format!(
+                "{} ({})",
+                recipe.name,
+                recipe.reference.relative_path.display()
+            ),
+        );
+    }
+    Ok(())
+}
+
+pub fn run_terminal_recipe_show_probe(recipe_name: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let recipe = load_terminal_recipe(recipe_name)?;
+    print_terminal_recipe(recipe_name, &recipe);
+    Ok(())
+}
+
+pub fn run_terminal_recipe_probe(
+    topology: &str,
+    recipe_name: &str,
+    state_root_override: Option<PathBuf>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let recipe = load_terminal_recipe(recipe_name)?;
+    run_terminal_probe(topology, &recipe.contents, state_root_override)
 }
 
 pub fn run_engineer_loop_probe(
@@ -1004,6 +1053,86 @@ pub fn run_gym_suite(suite_id: &str) -> Result<(), Box<dyn std::error::Error>> {
 
 fn prompt_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("prompt_assets")
+}
+
+const TERMINAL_RECIPE_DIRECTORY: &str = "simard/terminal_recipes";
+const TERMINAL_RECIPE_EXTENSION: &str = "simard-terminal";
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct TerminalRecipeDescriptor {
+    name: String,
+    reference: PromptAssetRef,
+}
+
+fn list_terminal_recipe_descriptors() -> crate::SimardResult<Vec<TerminalRecipeDescriptor>> {
+    let recipe_root = prompt_root().join(TERMINAL_RECIPE_DIRECTORY);
+    let entries =
+        fs::read_dir(&recipe_root).map_err(|error| crate::SimardError::PromptAssetRead {
+            path: recipe_root.clone(),
+            reason: error.to_string(),
+        })?;
+    let mut recipes = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|error| crate::SimardError::PromptAssetRead {
+            path: recipe_root.clone(),
+            reason: error.to_string(),
+        })?;
+        let entry_path = entry.path();
+        let file_type = entry
+            .file_type()
+            .map_err(|error| crate::SimardError::PromptAssetRead {
+                path: entry_path.clone(),
+                reason: error.to_string(),
+            })?;
+        if !file_type.is_file()
+            || entry_path.extension() != Some(OsStr::new(TERMINAL_RECIPE_EXTENSION))
+        {
+            continue;
+        }
+        let Some(stem) = entry_path.file_stem().and_then(|value| value.to_str()) else {
+            continue;
+        };
+        recipes.push(TerminalRecipeDescriptor {
+            name: stem.to_string(),
+            reference: terminal_recipe_reference(stem)?,
+        });
+    }
+    recipes.sort_by(|left, right| left.name.cmp(&right.name));
+    Ok(recipes)
+}
+
+fn load_terminal_recipe(recipe_name: &str) -> crate::SimardResult<PromptAsset> {
+    let reference = terminal_recipe_reference(recipe_name)?;
+    FilePromptAssetStore::new(prompt_root()).load(&reference)
+}
+
+fn terminal_recipe_reference(recipe_name: &str) -> crate::SimardResult<PromptAssetRef> {
+    if recipe_name.is_empty()
+        || !recipe_name
+            .chars()
+            .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '-')
+    {
+        return Err(crate::SimardError::InvalidPromptAssetPath {
+            asset_id: format!("terminal-recipe:{recipe_name}"),
+            path: PathBuf::from(recipe_name),
+            reason: "recipe names may only use lowercase ASCII letters, digits, and hyphens"
+                .to_string(),
+        });
+    }
+    Ok(PromptAssetRef::new(
+        format!("terminal-recipe:{recipe_name}"),
+        PathBuf::from(TERMINAL_RECIPE_DIRECTORY)
+            .join(format!("{recipe_name}.{TERMINAL_RECIPE_EXTENSION}")),
+    ))
+}
+
+fn print_terminal_recipe(recipe_name: &str, recipe: &PromptAsset) {
+    print_text("Terminal recipe", recipe_name);
+    print_display("Recipe asset", recipe.relative_path.display());
+    println!("Recipe contents:");
+    for line in sanitize_terminal_text(&recipe.contents).lines() {
+        println!("{line}");
+    }
 }
 
 fn state_root(

--- a/tests/gadugi/terminal-session.sh
+++ b/tests/gadugi/terminal-session.sh
@@ -47,6 +47,24 @@ printf '%s\n' "$FILE_OUTPUT" | grep -F "Terminal steps count: 3" >/dev/null
 printf '%s\n' "$FILE_OUTPUT" | grep -F "Terminal checkpoint 1: terminal-file-ready" >/dev/null
 printf '%s\n' "$FILE_OUTPUT" | grep -F "Terminal last output line: terminal-file-ok" >/dev/null
 
+RECIPE_LIST_OUTPUT="$(
+  cargo run --quiet --bin simard -- \
+    engineer terminal-recipe-list
+)"
+
+printf '%s\n' "$RECIPE_LIST_OUTPUT"
+printf '%s\n' "$RECIPE_LIST_OUTPUT" | grep -F "foundation-check" >/dev/null
+printf '%s\n' "$RECIPE_LIST_OUTPUT" | grep -F "copilot-status-check" >/dev/null
+
+RECIPE_RUN_OUTPUT="$(
+  cargo run --quiet --bin simard -- \
+    engineer terminal-recipe single-process foundation-check
+)"
+
+printf '%s\n' "$RECIPE_RUN_OUTPUT"
+printf '%s\n' "$RECIPE_RUN_OUTPUT" | grep -F "Terminal checkpoint 1: terminal-recipe-ready" >/dev/null
+printf '%s\n' "$RECIPE_RUN_OUTPUT" | grep -F "Terminal last output line: terminal-recipe-ok" >/dev/null
+
 READ_OUTPUT="$(
   cargo run --quiet --bin simard -- \
     engineer terminal-read single-process
@@ -59,9 +77,9 @@ printf '%s\n' "$READ_OUTPUT" | grep -F "Selected base type: terminal-shell" >/de
 printf '%s\n' "$READ_OUTPUT" | grep -F "Terminal command count: 2" >/dev/null
 printf '%s\n' "$READ_OUTPUT" | grep -F "Terminal wait count: 1" >/dev/null
 printf '%s\n' "$READ_OUTPUT" | grep -F "Terminal steps count: 3" >/dev/null
-printf '%s\n' "$READ_OUTPUT" | grep -F "Terminal checkpoint 1: terminal-foundation-ready" >/dev/null
-printf '%s\n' "$READ_OUTPUT" | grep -F "Terminal last output line: terminal-foundation-ok" >/dev/null
-printf '%s\n' "$READ_OUTPUT" | grep -F "terminal-foundation-ok" >/dev/null
+printf '%s\n' "$READ_OUTPUT" | grep -F "Terminal checkpoint 1: terminal-recipe-ready" >/dev/null
+printf '%s\n' "$READ_OUTPUT" | grep -F "Terminal last output line: terminal-recipe-ok" >/dev/null
+printf '%s\n' "$READ_OUTPUT" | grep -F "terminal-recipe-ok" >/dev/null
 
 MARKER="$(mktemp /tmp/simard-terminal-injection.XXXXXX)"
 rm -f "$MARKER"

--- a/tests/simard_cli.rs
+++ b/tests/simard_cli.rs
@@ -357,6 +357,18 @@ fn simard_help_documents_engineer_read_as_the_durable_engineer_audit_surface() {
         rendered.contains("engineer terminal-file <topology> <objective-file> [state-root]"),
         "simard help should document the file-backed terminal session workflow:\n{rendered}"
     );
+    assert!(
+        rendered.contains("engineer terminal-recipe-list"),
+        "simard help should document terminal recipe discovery:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("engineer terminal-recipe-show <recipe-name>"),
+        "simard help should document terminal recipe inspection:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("engineer terminal-recipe <topology> <recipe-name> [state-root]"),
+        "simard help should document named terminal recipe execution:\n{rendered}"
+    );
 }
 
 #[test]
@@ -704,8 +716,18 @@ command: printf \"terminal-cli-ok\\n\"";
         legacy_output.status.success(),
         "legacy terminal-run should remain functional while operators migrate:\n{legacy_rendered}"
     );
+    let simard_normalized = replace_output_line_value(
+        &simard_rendered,
+        "Terminal transcript preview: ",
+        "<preview>",
+    );
+    let legacy_normalized = replace_output_line_value(
+        &legacy_rendered,
+        "Terminal transcript preview: ",
+        "<preview>",
+    );
     assert_eq!(
-        simard_rendered, legacy_rendered,
+        simard_normalized, legacy_normalized,
         "the canonical terminal engineer surface should preserve the legacy terminal-run output exactly until operators migrate"
     );
     for expected in [
@@ -771,8 +793,18 @@ fn simard_engineer_terminal_file_runs_a_bounded_terminal_session_from_a_recipe_f
         legacy_output.status.success(),
         "terminal-run-file compatibility path should remain available while operators migrate:\n{legacy_rendered}"
     );
+    let simard_normalized = replace_output_line_value(
+        &simard_rendered,
+        "Terminal transcript preview: ",
+        "<preview>",
+    );
+    let legacy_normalized = replace_output_line_value(
+        &legacy_rendered,
+        "Terminal transcript preview: ",
+        "<preview>",
+    );
     assert_eq!(
-        simard_rendered, legacy_rendered,
+        simard_normalized, legacy_normalized,
         "terminal-file should preserve terminal-run-file parity so canonical and compatibility surfaces stay aligned"
     );
 }
@@ -798,6 +830,141 @@ fn simard_engineer_terminal_file_rejects_missing_or_unreadable_recipe_files() {
     assert!(
         rendered.contains("terminal objective file") && rendered.contains("could not be inspected"),
         "terminal-file should explain why the requested recipe file could not be loaded:\n{rendered}"
+    );
+}
+
+#[test]
+fn simard_engineer_terminal_recipe_list_and_show_surface_builtin_named_recipes() {
+    let list_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("engineer")
+        .arg("terminal-recipe-list")
+        .output()
+        .expect("simard engineer terminal-recipe-list should launch");
+    let list_rendered = rendered_output(&list_output);
+
+    assert!(
+        list_output.status.success(),
+        "terminal-recipe-list should expose built-in named session recipes:\n{list_rendered}"
+    );
+    for expected in [
+        "Terminal recipes: 2",
+        "foundation-check",
+        "copilot-status-check",
+        "simard/terminal_recipes/foundation-check.simard-terminal",
+    ] {
+        assert!(
+            list_rendered.contains(expected),
+            "terminal-recipe-list should surface '{expected}':\n{list_rendered}"
+        );
+    }
+    let legacy_list_output = Command::new(env!("CARGO_BIN_EXE_simard_operator_probe"))
+        .arg("terminal-recipe-list")
+        .output()
+        .expect("simard_operator_probe terminal-recipe-list should launch");
+    let legacy_list_rendered = rendered_output(&legacy_list_output);
+    assert!(
+        legacy_list_output.status.success(),
+        "terminal-recipe-list compatibility path should remain available:\n{legacy_list_rendered}"
+    );
+    assert_eq!(
+        list_rendered, legacy_list_rendered,
+        "terminal-recipe-list should preserve parity with the compatibility probe"
+    );
+
+    let show_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("engineer")
+        .arg("terminal-recipe-show")
+        .arg("foundation-check")
+        .output()
+        .expect("simard engineer terminal-recipe-show should launch");
+    let show_rendered = rendered_output(&show_output);
+
+    assert!(
+        show_output.status.success(),
+        "terminal-recipe-show should print the selected recipe asset and contents:\n{show_rendered}"
+    );
+    for expected in [
+        "Terminal recipe: foundation-check",
+        "Recipe asset: simard/terminal_recipes/foundation-check.simard-terminal",
+        "command: printf \"terminal-recipe-ready\\n\"",
+        "wait-for: terminal-recipe-ready",
+    ] {
+        assert!(
+            show_rendered.contains(expected),
+            "terminal-recipe-show should surface '{expected}':\n{show_rendered}"
+        );
+    }
+    let legacy_show_output = Command::new(env!("CARGO_BIN_EXE_simard_operator_probe"))
+        .arg("terminal-recipe-show")
+        .arg("foundation-check")
+        .output()
+        .expect("simard_operator_probe terminal-recipe-show should launch");
+    let legacy_show_rendered = rendered_output(&legacy_show_output);
+    assert!(
+        legacy_show_output.status.success(),
+        "terminal-recipe-show compatibility path should remain available:\n{legacy_show_rendered}"
+    );
+    assert_eq!(
+        show_rendered, legacy_show_rendered,
+        "terminal-recipe-show should preserve parity with the compatibility probe"
+    );
+}
+
+#[test]
+fn simard_engineer_terminal_recipe_runs_builtin_named_recipe_with_probe_parity() {
+    let state_root = TempDirGuard::new("simard-cli-terminal-recipe");
+    let simard_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("engineer")
+        .arg("terminal-recipe")
+        .arg("single-process")
+        .arg("foundation-check")
+        .arg(state_root.path())
+        .output()
+        .expect("simard engineer terminal-recipe should launch");
+    let simard_rendered = rendered_output(&simard_output);
+
+    assert!(
+        simard_output.status.success(),
+        "terminal-recipe should execute the built-in named recipe through the canonical CLI:\n{simard_rendered}"
+    );
+    for expected in [
+        "Selected base type: terminal-shell",
+        "Terminal checkpoint 1: terminal-recipe-ready",
+        "Terminal last output line: terminal-recipe-ok",
+        "terminal-recipe-ok",
+    ] {
+        assert!(
+            simard_rendered.contains(expected),
+            "terminal-recipe should surface '{expected}':\n{simard_rendered}"
+        );
+    }
+
+    let legacy_output = Command::new(env!("CARGO_BIN_EXE_simard_operator_probe"))
+        .arg("terminal-recipe-run")
+        .arg("single-process")
+        .arg("foundation-check")
+        .arg(state_root.path())
+        .output()
+        .expect("legacy terminal-recipe-run should launch");
+    let legacy_rendered = rendered_output(&legacy_output);
+
+    assert!(
+        legacy_output.status.success(),
+        "terminal-recipe-run compatibility path should remain available:\n{legacy_rendered}"
+    );
+    let simard_normalized = replace_output_line_value(
+        &simard_rendered,
+        "Terminal transcript preview: ",
+        "<preview>",
+    );
+    let legacy_normalized = replace_output_line_value(
+        &legacy_rendered,
+        "Terminal transcript preview: ",
+        "<preview>",
+    );
+    assert_eq!(
+        simard_normalized, legacy_normalized,
+        "terminal-recipe should preserve compatibility parity with terminal-recipe-run"
     );
 }
 


### PR DESCRIPTION
## Summary
- add discoverable built-in named terminal recipes for the canonical Simard CLI and legacy probe parity
- ship list/show/run surfaces backed by prompt assets under `prompt_assets/simard/terminal_recipes/`
- extend docs and outside-in coverage for named recipe operator flows

## Validation
- cargo fmt --all
- cargo test --all-features --locked
- tests/gadugi/terminal-session.sh
- cargo run --quiet --bin simard -- engineer terminal-recipe-list
- cargo run --quiet --bin simard -- engineer terminal-recipe-show foundation-check
- cargo run --quiet --bin simard -- engineer terminal-recipe single-process foundation-check <tmp-state-root>
- cargo run --quiet --bin simard_operator_probe -- terminal-recipe-run single-process foundation-check <tmp-state-root>
- cargo run --quiet --bin simard -- engineer terminal-read single-process <tmp-state-root>
- python3 -m pre_commit run --all-files --hook-stage pre-commit
- python3 -m pre_commit run --all-files --hook-stage pre-push