### PR TITLE
Bridge terminal sessions into engineer flow

### DIFF
--- a/Specs/ProductArchitecture.md
+++ b/Specs/ProductArchitecture.md
@@ -95,6 +95,13 @@ Simard should be treated as a focused engineering runtime with five user-visible
 1. Engineer mode
    Simard accepts a concrete task, inspects the local repo, forms a bounded plan with explicit verification steps, executes through terminal actions, and reports outcomes with evidence. The shipped v1 slice now supports both read-only repo inspection actions and one narrow structured file edit on a clean repo.
 
+   Under the `simard engineer ...` namespace, v1 now exposes two distinct operator-visible surfaces that must stay honest about their boundary:
+
+   - `engineer terminal`, `engineer terminal-file`, `engineer terminal-recipe`, and `engineer terminal-read` are bounded local terminal session surfaces with checkpointed transcript audit
+   - `engineer run` and `engineer read` are the separate repo-grounded engineer loop and its read-only audit companion
+
+   Reusing the same explicit `state-root` bridges those surfaces through local persisted summaries only. That bridge must never imply hidden orchestration, automatic continuation, or unsupported external Copilot/amplihack execution.
+
 2. Meeting mode
    Simard helps humans think, decide, and record architecture or planning outcomes, but does not silently drift into implementation without an explicit handoff.
 
@@ -121,6 +128,8 @@ The terminal is the primary execution surface, and conversational text exists to
 
 Every meaningful run should have explicit session metadata, a live task objective, a working memory area, and a durable output trail that stores sanitized objective metadata rather than raw task text.
 If a future developer cannot explain why Simard took an action by inspecting session records, the architecture is too opaque.
+
+That rule now applies across the terminal-to-engineer bridge too. If a bounded terminal session is later reused as continuity for engineer mode, the continuity must come from explicit local persisted artifacts under the same operator-chosen `state-root`, with mode-scoped handoff records and readback that shows what was reused. Any bridged terminal fields that survive into persisted handoff state or operator-visible readback must be sanitized before persist and sanitized again before render so control sequences, secret-shaped values, and raw objective text are not replayed as product truth.
 
 ### 3. Roles Must Be Separated
 
@@ -249,6 +258,8 @@ The current shipped v1 engineer-loop slice stays intentionally narrow:
 - the primary terminal-run surface now renders that same structured audit trail during execution so operators can follow bounded copilot-style terminal driving without dropping to raw evidence lines
 - operators can now author those bounded interactive terminal sessions either inline or from reusable file-backed recipes, while staying on the same truthful local PTY substrate
 - Simard now also ships named built-in terminal recipes so operators can discover, inspect, and rerun common interactive session flows without inventing ad hoc shell strings or temp files each time
+- those terminal surfaces are now an explicit on-ramp into the repo-grounded engineer loop when operators reuse the same `state-root`, but the later engineer run must still inspect the repository, form its own short plan, execute bounded local work, and verify explicitly
+- the bridge is descriptive continuity only: terminal-derived working directory, transcript snippets, or recipe metadata may inform operator readback, but they must not become authority for engineer action selection or workspace targeting
 
 ## Memory Architecture
 
@@ -265,6 +276,16 @@ This is disposable and should be cheap to reset.
 
 A compact record written at the end of the session: sanitized objective metadata, key actions, outcomes, changed artifacts, and follow-up items.
 This is the primary bridge between one session and the next.
+
+When one explicit `state-root` is reused across the terminal session surfaces and the repo-grounded engineer loop, that bridge should be represented by mode-scoped handoff summaries rather than one ambiguous catch-all artifact.
+
+The concrete v1 handoff contract is:
+
+- `latest_terminal_handoff.json` is authoritative for `engineer terminal`, `engineer terminal-file`, `engineer terminal-recipe`, and `engineer terminal-read`
+- `latest_engineer_handoff.json` is authoritative for `engineer run` and `engineer read`
+- `latest_handoff.json` exists only as a compatibility fallback when the relevant mode-scoped handoff file is absent
+- mode-scoped readback must report which artifact it used and render in a deterministic operator-visible order: runtime header, handoff session summary, adapter details, shell or repo details, action/checkpoint audit, transcript or continuity summary, explicit next-step guidance, durable record counts
+- malformed mode-scoped state fails closed instead of silently falling back
 
 #### 3. Project Memory
 

--- a/docs/howto/carry-meeting-decisions-into-engineer-sessions.md
+++ b/docs/howto/carry-meeting-decisions-into-engineer-sessions.md
@@ -17,10 +17,6 @@ related:
 
 Use this guide when you want to prove one specific product seam: a meeting run captures durable meeting memory, and a later engineer run against the same state root carries that planning context forward without pretending code changed during the meeting.
 
-## Status
-
-The handoff behavior is shipped on the canonical `simard` CLI.
-
 ## Prerequisites
 
 - [ ] You are in the repository root

--- a/docs/howto/configure-bootstrap-and-inspect-reflection.md
+++ b/docs/howto/configure-bootstrap-and-inspect-reflection.md
@@ -20,11 +20,7 @@ Use this guide when you need to answer two questions:
 - what bootstrap inputs did Simard actually use?
 - what does the live runtime report through reflection?
 
-## Status
-
-The canonical bootstrap surface is now `simard bootstrap run ...`.
-
-The old zero-argument `simard` bootstrap fallback is gone. Operators must pass the runtime selection explicitly. The terminal-backed engineer substrate now also lives on the canonical CLI through `simard engineer terminal ...`, while `simard_operator_probe terminal-run ...` remains as a compatibility alias.
+Use the canonical surfaces `simard bootstrap run ...` and `simard engineer terminal ...`. The old zero-argument `simard` bootstrap fallback is gone, and `simard_operator_probe terminal-run ...` remains only as a compatibility alias.
 
 ## Prerequisites
 

--- a/docs/howto/move-from-terminal-recipes-into-engineer-runs.md
+++ b/docs/howto/move-from-terminal-recipes-into-engineer-runs.md
@@ -1,0 +1,196 @@
+---
+title: "How to move from terminal recipes into engineer runs"
+description: Start with a discoverable bounded terminal recipe, inspect the truthful terminal audit trail, and then continue into the repo-grounded engineer loop through the same explicit local state root.
+last_updated: 2026-03-30
+review_schedule: as-needed
+owner: simard
+doc_type: howto
+related:
+  - ../index.md
+  - ../reference/simard-cli.md
+  - ../reference/runtime-contracts.md
+  - ../tutorials/run-your-first-local-session.md
+---
+
+# How to move from terminal recipes into engineer runs
+
+Use this guide when you want one specific operator workflow:
+
+1. discover a shipped bounded terminal recipe
+2. run it locally
+3. inspect the truthful terminal audit trail
+4. continue into the existing repo-grounded engineer loop with the same explicit `state-root`
+
+This bridge is local and file-backed. It is not hidden orchestration, remote continuation, or an automatic resume system.
+
+## Prerequisites
+
+- [ ] You are in the repository root
+- [ ] `cargo run --quiet -- ...` works locally
+- [ ] You want a local file-backed bridge, not a network service or remote orchestrator
+
+## 1. Create one explicit durable state root
+
+The bridge only works when the terminal and engineer commands point at the same durable state root.
+
+```bash
+STATE_ROOT="$(mktemp -d /tmp/simard-terminal-engineer.XXXXXX)"
+```
+
+Keep that shell variable for the rest of this guide.
+
+## 2. Discover a shipped terminal recipe
+
+List the built-in recipes and inspect one before running it.
+
+```bash
+cargo run --quiet -- engineer terminal-recipe-list
+cargo run --quiet -- engineer terminal-recipe-show foundation-check
+```
+
+The important contract here is visibility:
+
+- `terminal-recipe-list` shows what Simard ships today
+- `terminal-recipe-show` prints the real bounded recipe contents
+- neither command starts engineer mode or claims repo-grounded verification happened
+
+## 3. Run the terminal recipe through the canonical CLI
+
+```bash
+cargo run --quiet -- engineer terminal-recipe single-process foundation-check "$STATE_ROOT"
+```
+
+Look for output shaped like this:
+
+```text
+Mode boundary: terminal
+Terminal recipe source: foundation-check
+Terminal steps count: 2
+Terminal last output line: terminal-recipe-ok
+Engineer next step: simard engineer run <topology> <workspace-root> <objective> <same-state-root>
+```
+
+That output matters because it tells the truth:
+
+- this was a bounded local terminal session
+- Simard persisted local terminal artifacts under `STATE_ROOT`
+- the next step into engineer mode is explicit; nothing resumed automatically
+
+## 4. Read back the persisted terminal audit trail
+
+```bash
+cargo run --quiet -- engineer terminal-read single-process "$STATE_ROOT"
+```
+
+Look for output shaped like this:
+
+```text
+Probe mode: terminal-read
+Mode boundary: terminal
+Terminal handoff source: latest_terminal_handoff.json
+Terminal recipe source: foundation-check
+Terminal last output line: terminal-recipe-ok
+Terminal transcript preview:
+Engineer next step: simard engineer run <topology> <workspace-root> <objective> <same-state-root>
+```
+
+This confirms the readback contract:
+
+- `terminal-read` is read-only
+- the terminal audit comes from a terminal-scoped handoff artifact
+- the printed bridge guidance stays explicit and local
+
+## 5. Continue into the repo-grounded engineer loop
+
+Now run the real engineer loop against the repository with the same `STATE_ROOT`.
+
+```bash
+ENGINEER_OBJECTIVE=$'inspect the repository state
+run one safe local engineering action
+verify the outcome explicitly
+persist truthful local evidence and memory'
+
+cargo run --quiet -- engineer run single-process "$PWD" "$ENGINEER_OBJECTIVE" "$STATE_ROOT"
+```
+
+Look for output shaped like this:
+
+```text
+Mode boundary: engineer
+Repo root: /path/to/repo
+Terminal continuity available: yes
+Terminal continuity source: latest_terminal_handoff.json
+Terminal recipe source: foundation-check
+Action plan: Inspect the repo ...
+Verification status: verified
+```
+
+The contract is additive:
+
+- the terminal summary is descriptive continuity only
+- the engineer loop still inspects the repository before acting
+- the engineer loop still forms its own short plan
+- the engineer loop still verifies explicitly
+
+The terminal recipe does **not** choose the engineer action, set `workspace-root`, or replace the engineer objective.
+
+## 6. Read back the persisted engineer audit trail
+
+```bash
+cargo run --quiet -- engineer read single-process "$STATE_ROOT"
+```
+
+Look for output shaped like this:
+
+```text
+Probe mode: engineer-read
+Engineer handoff source: latest_engineer_handoff.json
+Mode boundary: engineer
+Repo root: /path/to/repo
+Terminal continuity available: yes
+Terminal continuity source: latest_terminal_handoff.json
+Selected action: cargo-metadata-scan
+Verification status: verified
+```
+
+This proves the bridge stayed honest after execution:
+
+- engineer readback prefers the engineer-scoped handoff
+- the carried terminal summary remains a separate section
+- persisted terminal continuity does not replace repo grounding, planning, or verification
+
+## 7. Configuration rules that matter
+
+For predictable bridge behavior, keep these rules in mind:
+
+- pass the same explicit `state-root` argument to both the terminal command and the later engineer command
+- treat `engineer terminal*` and `engineer run/read` as separate operator-visible modes even though they share the `simard engineer ...` namespace
+- expect `terminal-read` to prefer `latest_terminal_handoff.json`
+- expect `engineer read` to prefer `latest_engineer_handoff.json`
+- expect compatibility fallback to `latest_handoff.json` only when the mode-specific file is absent
+- expect a malformed mode-specific handoff to fail explicitly instead of silently falling back
+- keep `workspace-root` and engineer `objective` explicit on every engineer run
+
+## 8. Troubleshoot the common failure shapes
+
+### `Terminal continuity available: no`
+
+Usually one of these is true:
+
+- the earlier terminal run used a different `STATE_ROOT`
+- you ran `engineer run` before any terminal session wrote state into this root
+- the terminal-scoped handoff was deleted
+
+### `terminal-read` or `engineer read` fails on malformed handoff data
+
+That is the intended fail-closed behavior. If `latest_terminal_handoff.json` or `latest_engineer_handoff.json` exists but is malformed, Simard does not silently downgrade to `latest_handoff.json`.
+
+### The engineer loop ignored the terminal recipe and still inspected the repo
+
+That is correct. The bridge is descriptive continuity, not authority transfer. Engineer mode must remain repo-grounded, planned, bounded, and explicitly verified.
+
+## Related reading
+
+- For the exact command tree and help text, see [Simard CLI reference](../reference/simard-cli.md).
+- For the file and readback contracts, see [Runtime contracts reference](../reference/runtime-contracts.md).
+- For a broader end-to-end tour of the local operator flows, see [Tutorial: Run your first local session](../tutorials/run-your-first-local-session.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 title: Simard documentation
-description: Start here for the shipped `simard` operator CLI, the `engineer read` audit companion, compatibility binaries, runtime contracts, and benchmark flow.
+description: Start here for the shipped `simard` operator CLI, the shared-state-root bridge from bounded terminal sessions into the repo-grounded engineer loop, the `engineer read` audit companion, compatibility binaries, runtime contracts, and benchmark flow.
 last_updated: 2026-03-30
 review_schedule: as-needed
 owner: simard
@@ -10,11 +10,14 @@ owner: simard
 
 `simard` is the canonical operator-facing CLI.
 
-The shipped command tree covers `engineer`, `meeting`, `goal-curation`, `improvement-curation`, `gym`, `review`, and `bootstrap` from one binary, including the read-only `engineer read` audit companion. The legacy `simard_operator_probe` and `simard-gym` binaries remain available as compatibility surfaces while operators migrate, but the primary product surface is now `simard ...`.
+The shipped command tree covers `engineer`, `meeting`, `goal-curation`, `improvement-curation`, `gym`, `review`, and `bootstrap` from one binary, including the read-only `engineer read` audit companion and the bounded `engineer terminal*` session surfaces. The legacy `simard_operator_probe` and `simard-gym` binaries remain available as compatibility surfaces while operators migrate, but the primary product surface is now `simard ...`.
+
+Terminal sessions and repo-grounded engineer runs now bridge through one explicit local `state-root`. That bridge is file-backed and operator-visible. It does not imply hidden resume logic, external orchestration, or automatic continuation.
 
 ## Start here
 
 - [Tutorial: Run your first local session](./tutorials/run-your-first-local-session.md) - Exercise the local runtime through the primary CLI.
+- [How to move from terminal recipes into engineer runs](./howto/move-from-terminal-recipes-into-engineer-runs.md) - Start with a discoverable terminal recipe, then continue into the repo-grounded engineer loop through the same explicit state root.
 - [Tutorial: Run your first benchmark gym suite](./tutorials/run-your-first-benchmark-gym.md) - Run the shipped starter benchmark suite.
 - [How to configure bootstrap and inspect reflection](./howto/configure-bootstrap-and-inspect-reflection.md) - Bootstrap an explicit runtime selection and inspect the truthful runtime snapshot.
 - [How to carry meeting decisions into engineer sessions](./howto/carry-meeting-decisions-into-engineer-sessions.md) - Persist meeting records under a shared state root and confirm later engineer runs carry them forward.

--- a/docs/reference/runtime-contracts.md
+++ b/docs/reference/runtime-contracts.md
@@ -1,6 +1,6 @@
 ---
 title: Runtime contracts reference
-description: Reference for the shipped Simard executable surfaces, the `engineer read` audit contract, compatibility binaries, and the in-process runtime contracts that back them.
+description: Reference for the shipped Simard executable surfaces, the shared-state-root bridge between bounded terminal sessions and the repo-grounded engineer loop, the `engineer read` audit contract, compatibility binaries, and the in-process runtime contracts that back them.
 last_updated: 2026-03-30
 review_schedule: as-needed
 owner: simard
@@ -11,6 +11,7 @@ related:
   - ../howto/inspect-meeting-records.md
   - ../howto/inspect-improvement-curation-state.md
   - ../howto/configure-bootstrap-and-inspect-reflection.md
+  - ../howto/move-from-terminal-recipes-into-engineer-runs.md
   - ../tutorials/run-your-first-local-session.md
 ---
 
@@ -89,6 +90,29 @@ Rejected inputs include:
 
 Safe roots are canonicalized once and then reused throughout the command.
 
+## Mode-scoped handoff artifacts
+
+When terminal session surfaces and the repo-grounded engineer loop reuse one explicit `state-root`, Simard keeps readback truthful by writing mode-scoped handoff artifacts:
+
+- `latest_terminal_handoff.json`
+- `latest_engineer_handoff.json`
+- `latest_handoff.json` as the compatibility fallback
+
+Those files have different jobs:
+
+- terminal session surfaces write the latest bounded terminal continuity summary
+- engineer runs write the latest repo-grounded engineer summary
+- compatibility readers can still inspect `latest_handoff.json` when a mode-scoped file has not been written yet
+
+Fail-closed rules:
+
+- `terminal-read` prefers `latest_terminal_handoff.json`
+- `engineer read` prefers `latest_engineer_handoff.json`
+- fallback to `latest_handoff.json` is allowed only when the mode-specific file is absent
+- if a mode-specific handoff exists but is malformed, the command fails explicitly instead of silently replaying stale compatibility data
+
+The bridge is descriptive continuity only. Terminal-derived data must never override `workspace-root`, the engineer objective, action selection, or verification.
+
 ## Mode contracts
 
 ### Engineer mode
@@ -105,6 +129,7 @@ The bounded engineer loop is intentionally narrow:
 - it verifies the result explicitly
 - it persists concise evidence and memory under the selected state root
 - it surfaces active goals and up to the three most recent carried meeting records from the same state root
+- it may surface a separate terminal continuity summary when the same state root already contains a valid terminal-scoped handoff
 
 The bounded engineer loop supports two honest action shapes:
 
@@ -135,14 +160,17 @@ The contract is intentionally explicit:
 - `engineer run` remains the only mutation and execution path for engineer work
 - `engineer read` reuses the same validated default state root as `engineer run` when `[state-root]` is omitted
 - any explicit `state-root` must already exist as a directory before readback begins
-- `engineer read` requires readable regular-file `latest_handoff.json`, `memory_records.json`, and `evidence_records.json`; symlinked artifacts are rejected
-- `latest_handoff.json` is authoritative for identity, selected base type, topology, session phase, redacted objective metadata, and the exported memory/evidence snapshot tied to the latest engineer run
+- `engineer read` requires readable regular-file `memory_records.json` and `evidence_records.json`; symlinked artifacts are rejected
+- `latest_engineer_handoff.json` is authoritative for identity, selected base type, topology, session phase, redacted objective metadata, and the exported memory/evidence snapshot tied to the latest engineer run
+- `latest_handoff.json` is used only as a compatibility fallback when the engineer-scoped handoff is absent
+- the rendered output includes which handoff file was used
 - persisted handoff objective metadata must already be trusted `objective-metadata(chars=<n>, words=<n>, lines=<n>)`; malformed or tampered metadata fails instead of being replayed
 - standalone `memory_records.json` and `evidence_records.json` files act as durability checks and supporting record-count sources; if they disagree with the handoff snapshot, handoff-derived values win
 - only redacted objective metadata is printable; raw engineer objective text must never be rendered back to the terminal
 - carried meeting state must remain valid persisted meeting records; malformed carried-meeting data fails explicitly instead of falling back to raw strings
+- when the same state root contains a valid terminal-scoped handoff, `engineer read` renders a distinct terminal continuity section with sanitized fields such as recipe source, working directory, last output line, and transcript preview
 - operator-visible strings are sanitized before printing so terminal control sequences and secret-shaped values are not replayed
-- output order stays deterministic: runtime header, handoff session summary, repo grounding, carried context, selected action summary, verification summary, durable record counts
+- output order stays deterministic: runtime header, handoff session summary, repo grounding, carried context, terminal continuity, selected action summary, verification summary, durable record counts
 - the command performs no mutation, repair, resume, or execution
 - invalid state roots, missing files, unreadable storage, and malformed persisted engineer data fail explicitly
 
@@ -164,6 +192,8 @@ This substrate exposes the real `terminal-shell` base type on the primary CLI:
 - reflection still reports `terminal-shell::local-pty` as the adapter implementation
 - terminal objectives may include `command:` / `input:` lines and explicit `wait-for:` / `expect:` checkpoints so bounded interactive terminal turns can pause for expected output before sending the next line
 - the run surface now renders the same structured terminal audit shape as `terminal-read`: shell details, command/wait counts, ordered steps, satisfied checkpoints, last meaningful output line, and sanitized transcript preview
+- the run surface prints explicit boundary guidance showing that terminal mode is a bounded local session surface and that continuing into engineer mode still requires an explicit later `engineer run`
+- the run persists `latest_terminal_handoff.json` plus compatibility `latest_handoff.json` under the shared root
 - unsatisfied wait checkpoints fail explicitly instead of silently replaying the rest of the objective and claiming success
 - unsupported topology and invalid state-root choices still fail explicitly
 
@@ -180,11 +210,14 @@ The contract is intentionally explicit:
 - `engineer terminal` remains the only execution path for terminal-backed engineer work
 - `terminal-read` reuses the same validated default state root as `engineer terminal` when `[state-root]` is omitted
 - any explicit `state-root` must already exist as a directory before readback begins
-- `terminal-read` requires readable regular-file `latest_handoff.json`, `memory_records.json`, and `evidence_records.json`; symlinked artifacts are rejected
-- `latest_handoff.json` is authoritative for identity, selected base type, topology, session phase, redacted objective metadata, and the persisted terminal evidence summary tied to the latest terminal session
+- `terminal-read` requires readable regular-file `memory_records.json` and `evidence_records.json`; symlinked artifacts are rejected
+- `latest_terminal_handoff.json` is authoritative for identity, selected base type, topology, session phase, redacted objective metadata, and the persisted terminal evidence summary tied to the latest terminal session
+- `latest_handoff.json` is used only as a compatibility fallback when the terminal-scoped handoff is absent
+- the rendered output includes which handoff file was used
 - persisted terminal evidence may include ordered terminal step lines, satisfied wait checkpoints, and the last observed output line so operators can inspect how a bounded interactive session was driven instead of relying only on aggregate counters
+- the rendered output also includes explicit engineer-next-step guidance so the bridge into repo-grounded engineer work stays operator-visible
 - operator-visible strings are sanitized before printing so persisted terminal control sequences and secret-shaped values are not replayed
-- output order stays deterministic: runtime header, handoff session summary, adapter details, shell details, step/checkpoint audit trail, transcript summary, durable record counts
+- output order stays deterministic: runtime header, handoff session summary, adapter details, shell details, step/checkpoint audit trail, transcript summary, continuation guidance, durable record counts
 - the command performs no mutation, replay, resume, or execution
 - invalid state roots, missing files, unreadable storage, and malformed persisted terminal data fail explicitly
 
@@ -222,6 +255,7 @@ This is the discoverable built-in recipe companion to inline and file-backed ter
 - unknown or invalid recipe names fail explicitly
 - `terminal-recipe-show` is read-only and prints the shipped recipe asset contents
 - `terminal-recipe` executes the same bounded `terminal-shell` substrate as `engineer terminal` and `engineer terminal-file`
+- the selected recipe name is preserved into the terminal continuity summary that later engineer surfaces may render from the same state root
 
 ### Meeting mode
 

--- a/docs/reference/simard-cli.md
+++ b/docs/reference/simard-cli.md
@@ -1,6 +1,6 @@
 ---
 title: Simard CLI reference
-description: Reference for the shipped `simard` command tree, the `engineer read` audit companion, and the legacy compatibility binaries that still expose selected older runtime behaviors.
+description: Reference for the shipped `simard` command tree, the shared-state-root bridge between bounded terminal sessions and the repo-grounded engineer loop, the `engineer read` audit companion, and the legacy compatibility binaries that still expose selected older runtime behaviors.
 last_updated: 2026-03-30
 review_schedule: as-needed
 owner: simard
@@ -13,6 +13,7 @@ related:
   - ../howto/inspect-improvement-curation-state.md
   - ../howto/configure-bootstrap-and-inspect-reflection.md
   - ../howto/carry-meeting-decisions-into-engineer-sessions.md
+  - ../howto/move-from-terminal-recipes-into-engineer-runs.md
   - ../tutorials/run-your-first-local-session.md
 ---
 
@@ -30,8 +31,13 @@ This page documents the shipped operator-facing command tree. When a compatibili
 simard
 |- engineer
 |  |- run <topology> <workspace-root> <objective> [state-root]
+|  |- read <topology> [state-root]
 |  |- terminal <topology> <objective> [state-root]
-|  `- read <topology> [state-root]
+|  |- terminal-file <topology> <objective-file> [state-root]
+|  |- terminal-recipe-list
+|  |- terminal-recipe-show <recipe-name>
+|  |- terminal-recipe <topology> <recipe-name> [state-root]
+|  `- terminal-read <topology> [state-root]
 |- meeting
 |  |- run <base-type> <topology> <structured-objective> [state-root]
 |  `- read <base-type> <topology> [state-root]
@@ -88,18 +94,48 @@ Rejected inputs include:
 
 Safe state roots are canonicalized once and then reused for the rest of the command.
 
+## Terminal-to-engineer bridge
+
+The `simard engineer ...` namespace now exposes two distinct operator-visible surfaces:
+
+- `engineer terminal`, `engineer terminal-file`, `engineer terminal-recipe`, and `engineer terminal-read` are bounded local terminal session surfaces
+- `engineer run` and `engineer read` are the repo-grounded engineer loop and its read-only audit companion
+
+The bridge between them is explicit and local-only:
+
+- reuse the same explicit `state-root`
+- inspect the persisted terminal summary through `terminal-read`
+- invoke `engineer run` explicitly with a real `workspace-root` and engineer objective
+
+Simard writes mode-scoped handoffs under the shared root:
+
+- `latest_terminal_handoff.json`
+- `latest_engineer_handoff.json`
+- `latest_handoff.json` as the compatibility fallback
+
+Readback is fail-closed:
+
+- `terminal-read` prefers `latest_terminal_handoff.json`
+- `engineer read` prefers `latest_engineer_handoff.json`
+- fallback to `latest_handoff.json` happens only when the mode-scoped file is absent
+- if a mode-scoped handoff exists but is malformed, the command fails instead of silently replaying older data
+
+The bridge is descriptive continuity only. It does not auto-resume, auto-launch engineer mode, infer a repo path, or replace the engineer loop's inspect -> plan -> act -> verify contract.
+
 ## Mode reference
 
 ### `simard engineer run <topology> <workspace-root> <objective> [state-root]`
 
-Runs the bounded local engineer loop against the selected repository.
+Runs the repo-grounded bounded engineer loop against the selected repository.
 
 Key behavior:
 
 - inspects the selected repo before acting
 - prints the chosen bounded action and explicit verification steps
-- persists memory, evidence, and latest handoff under `state-root`
+- may render a separate terminal continuity section when the same `state-root` already contains a valid terminal-scoped handoff
+- persists memory, evidence, `latest_engineer_handoff.json`, and compatibility `latest_handoff.json` under `state-root`
 - surfaces active goals and carried meeting decisions from the same durable state
+- keeps terminal continuity descriptive only; it does not override `workspace-root`, the engineer objective, planning, or verification
 
 Example:
 
@@ -113,6 +149,8 @@ persist truthful local evidence and memory'
 simard engineer run single-process "$PWD" "$ENGINEER_OBJECTIVE" "$STATE_ROOT"
 ```
 
+To continue from a terminal recipe or terminal session, reuse the same `STATE_ROOT`. The terminal bridge stays local and explicit; Simard does not infer the engineer objective for you.
+
 ### `simard engineer read <topology> [state-root]`
 
 This is the read-only audit companion to `simard engineer run`. It inspects the latest persisted engineer state without resuming execution, repairing artifacts, or re-running the engineer loop.
@@ -122,14 +160,16 @@ Behavior:
 - reuses the same canonical default durable root as `engineer run` when `[state-root]` is omitted
 - validates `topology` before deriving that default root, so the default still follows the shipped engineer runtime pairing
 - requires any explicit `state-root` to already exist as a directory
-- requires `latest_handoff.json`, `memory_records.json`, and `evidence_records.json` to already exist as readable regular files; symlinked artifacts are rejected
-- treats `latest_handoff.json` as authoritative for session identity, selected base type, topology, session phase, redacted objective metadata, and the exported memory/evidence snapshot tied to the latest engineer run
+- requires `memory_records.json` and `evidence_records.json` to already exist as readable regular files; symlinked artifacts are rejected
+- prefers `latest_engineer_handoff.json` as the authoritative engineer readback artifact and falls back to `latest_handoff.json` only when the engineer-scoped handoff is absent
+- prints which handoff artifact was used so mode-scoped readback stays operator-visible
 - requires the persisted handoff session objective to already be trusted `objective-metadata(chars=<n>, words=<n>, lines=<n>)`; malformed or tampered metadata fails instead of being replayed
 - uses the standalone `memory_records.json` and `evidence_records.json` files as durability checks and supporting evidence counts; if they disagree with the handoff snapshot, the handoff-derived values win
 - renders only redacted objective metadata such as `objective-metadata(chars=150, words=21, lines=1)`, never the raw engineer objective text
 - requires carried meeting state to remain valid persisted meeting records; malformed carried-meeting data fails instead of being downgraded to raw strings
+- when the same state root contains a valid terminal-scoped handoff, renders a separate terminal continuity section with sanitized terminal summary fields
 - strips terminal control sequences and secret-shaped values from every displayed string before printing it
-- prints a stable operator-visible order: runtime header, handoff session summary, repo grounding, carried context, selected action summary, verification summary, durable record counts
+- prints a stable operator-visible order: runtime header, handoff session summary, repo grounding, carried context, terminal continuity, selected action summary, verification summary, durable record counts
 - fails explicitly for invalid `state-root` values and for missing, unreadable, or malformed persisted engineer state
 
 When `[state-root]` is omitted, the command reuses the same canonical durable root that `engineer run` already writes:
@@ -148,12 +188,14 @@ Output shape:
 
 ```text
 Probe mode: engineer-read
+Engineer handoff source: latest_engineer_handoff.json
 Identity: simard-engineer
 Selected base type: terminal-shell
 Topology: single-process
 State root: /tmp/simard-engineer.XXXXXX
 Session phase: complete
 Objective metadata: objective-metadata(chars=150, words=21, lines=1)
+Mode boundary: engineer
 Repo root: /path/to/repo
 Repo branch: main
 Repo head: 4b6cb7de0179e9adb480dfdea1cb2aee4a5d5e18
@@ -163,6 +205,11 @@ Active goals count: 1
 Active goal 1: p1 [active] Preserve meeting handoff
 Carried meeting decisions: 1
 Carried meeting decision 1: preserve meeting-to-engineer continuity
+Terminal continuity available: yes
+Terminal continuity source: latest_terminal_handoff.json
+Terminal recipe source: foundation-check
+Terminal working directory: .
+Terminal last output line: terminal-recipe-ok
 Selected action: cargo-metadata-scan
 Action plan: Inspect the repo, query Cargo metadata without mutating files, and verify repo grounding stayed stable.
 Verification steps: confirm cargo metadata returns valid workspace JSON || confirm repo root, branch, HEAD, and worktree state stayed stable || confirm carried meeting decisions and active goals stayed stable
@@ -176,14 +223,17 @@ Evidence records: 19
 
 ### `simard engineer terminal <topology> <objective> [state-root]`
 
-Runs the terminal-backed engineer substrate on the canonical CLI instead of
-requiring the legacy probe binary.
+Runs one bounded local terminal session on the canonical CLI instead of requiring the legacy probe binary.
+
+This is not the repo-grounded engineer loop. It is the honest terminal-session surface that operators can use before deciding to launch `engineer run`.
 
 Key behavior:
 
 - selects the `terminal-shell` base type explicitly
 - accepts bounded terminal objectives with `command:`/`input:` lines plus `wait-for:` or `expect:` checkpoints so a run can pause for expected output before sending the next line
 - preserves truthful adapter reflection and now renders the terminal audit trail directly on the run surface, including ordered terminal steps, satisfied checkpoints, the last visible output line, and a sanitized transcript preview
+- prints explicit next-step guidance for continuing into `engineer run` with the same `state-root`
+- persists `latest_terminal_handoff.json` and compatibility `latest_handoff.json` under the shared root
 - fails visibly for unsupported topology and invalid state-root inputs
 - fails explicitly if a requested wait checkpoint never appears instead of pretending the terminal interaction succeeded
 - keeps `simard_operator_probe terminal-run ...` available for compatibility
@@ -207,7 +257,7 @@ Behavior:
 
 - reuses the same `terminal-shell` base type and bounded wait/send terminal semantics as `engineer terminal`
 - requires `<objective-file>` to exist as a readable regular file; symlinks and non-files fail explicitly
-- preserves the same structured terminal audit trail on the run surface and through `terminal-read`
+- preserves the same structured terminal audit trail, mode-scoped terminal handoff, and engineer-next-step guidance as `engineer terminal`
 - keeps `simard_operator_probe terminal-run-file ...` available for compatibility
 
 Example:
@@ -238,7 +288,7 @@ Runs one of the built-in named terminal session recipes through the same bounded
 Behavior:
 
 - loads a named recipe from `prompt_assets/simard/terminal_recipes/*.simard-terminal`
-- preserves the same structured terminal audit trail on the run surface and through `terminal-read`
+- preserves the same structured terminal audit trail, mode-scoped terminal handoff, and engineer-next-step guidance as the other terminal session surfaces
 - fails explicitly when the requested recipe name is unknown or invalid
 - keeps `simard_operator_probe terminal-recipe-run ...` available for compatibility
 
@@ -258,9 +308,10 @@ Behavior:
 
 - reuses the same canonical default durable root as `engineer terminal` when `[state-root]` is omitted
 - requires any explicit `state-root` to already exist as a directory
-- requires `latest_handoff.json`, `memory_records.json`, and `evidence_records.json` to already exist as readable regular files; symlinked artifacts are rejected
-- treats `latest_handoff.json` as authoritative for session identity, selected base type, topology, session phase, redacted objective metadata, and the persisted terminal evidence summary
-- renders terminal shell, working directory, command count, wait count, ordered terminal steps, satisfied wait checkpoints, last output line, and transcript preview in stable operator-visible order
+- requires `memory_records.json` and `evidence_records.json` to already exist as readable regular files; symlinked artifacts are rejected
+- prefers `latest_terminal_handoff.json` as the authoritative terminal readback artifact and falls back to `latest_handoff.json` only when the terminal-scoped handoff is absent
+- prints which handoff artifact was used so terminal readback stays operator-visible
+- renders mode boundary, terminal shell, working directory, command count, wait count, ordered terminal steps, satisfied wait checkpoints, last output line, transcript preview, and engineer-next-step guidance in stable operator-visible order
 - strips terminal control sequences and secret-shaped values from displayed output before printing it
 - fails explicitly for invalid `state-root` values and for missing, unreadable, or malformed persisted terminal state
 
@@ -274,6 +325,22 @@ Example:
 
 ```bash
 simard engineer terminal-read single-process "$STATE_ROOT"
+```
+
+Output shape:
+
+```text
+Probe mode: terminal-read
+Terminal handoff source: latest_terminal_handoff.json
+Mode boundary: terminal
+Selected base type: terminal-shell
+Topology: single-process
+Terminal working directory: .
+Terminal recipe source: foundation-check
+Terminal steps count: 2
+Terminal last output line: terminal-recipe-ok
+Terminal transcript preview:
+Engineer next step: simard engineer run <topology> <workspace-root> <objective> <same-state-root>
 ```
 
 ### `simard meeting run <base-type> <topology> <structured-objective> [state-root]`

--- a/docs/tutorials/run-your-first-local-session.md
+++ b/docs/tutorials/run-your-first-local-session.md
@@ -1,6 +1,6 @@
 ---
 title: "Tutorial: Run your first local session"
-description: Exercise the shipped local-session flows through the canonical `simard` CLI and understand where the legacy compatibility binaries still fit.
+description: Exercise the shipped local-session flows through the canonical `simard` CLI, starting with discoverable terminal recipes and then continuing into the repo-grounded engineer loop through one explicit state root.
 last_updated: 2026-03-30
 review_schedule: as-needed
 owner: simard
@@ -9,6 +9,7 @@ related:
   - ../index.md
   - ../reference/simard-cli.md
   - ../reference/runtime-contracts.md
+  - ../howto/move-from-terminal-recipes-into-engineer-runs.md
   - ../howto/carry-meeting-decisions-into-engineer-sessions.md
   - ../howto/inspect-meeting-records.md
   - ../howto/configure-bootstrap-and-inspect-reflection.md
@@ -18,17 +19,14 @@ related:
 
 This tutorial exercises the shipped local-session flows through the canonical `simard` CLI.
 
-## Status
+The first half focuses on the honest bridge from bounded terminal recipes into the repo-grounded engineer loop. The later steps show how meeting, goal, review, improvement, bootstrap, and gym surfaces still fit into the same local operator story.
 
-Today:
-
-- `simard` is the primary operator-facing CLI
-- `simard_operator_probe` remains available for older compatibility scripts
-- `simard-gym` remains available for compatibility with legacy benchmark scripts, although `simard gym ...` is the canonical benchmark surface
+Use `simard` as the canonical operator-facing CLI. `simard_operator_probe` and `simard-gym` remain compatibility surfaces for older scripts, and `engineer terminal*` plus `engineer run/read` still share one honest local state model while remaining separate operator-visible modes.
 
 ## What you'll learn
 
 - how to run the bounded engineer loop against a local repo
+- how to start from a discoverable terminal recipe and continue into the engineer loop through the same explicit `state-root`
 - how meeting mode carries durable decision context into later engineer runs
 - how goal curation, review, and improvement curation reuse explicit durable state roots
 - how bootstrap and benchmark flows fit into the same operator-facing CLI story
@@ -49,7 +47,60 @@ Use one state root for the whole tutorial so later steps can read the same meeti
 STATE_ROOT="$(mktemp -d /tmp/simard-local-session.XXXXXX)"
 ```
 
-## Step 2: Run engineer mode through the canonical CLI
+## Step 2: Discover the shipped terminal recipe surface
+
+Start on the bounded local terminal surface, not the engineer loop.
+
+```bash
+cargo run --quiet -- engineer terminal-recipe-list
+cargo run --quiet -- engineer terminal-recipe-show foundation-check
+```
+
+Look for:
+
+- `foundation-check`
+- a real bounded recipe asset with `working-directory:`, `command:`, and `wait-for:` lines
+
+**Checkpoint**: you can discover and inspect the shipped terminal recipes without claiming repo-grounded planning or verification happened yet.
+
+## Step 3: Run the terminal recipe through the canonical CLI
+
+```bash
+cargo run --quiet -- \
+  engineer terminal-recipe single-process foundation-check "$STATE_ROOT"
+```
+
+Look for output shaped like this:
+
+```text
+Mode boundary: terminal
+Terminal recipe source: foundation-check
+Terminal steps count: 2
+Terminal last output line: terminal-recipe-ok
+Engineer next step: simard engineer run <topology> <workspace-root> <objective> <same-state-root>
+```
+
+**Checkpoint**: Simard ran one bounded local terminal session, persisted truthful terminal artifacts, and showed an explicit next-step path into the engineer loop without pretending that transition happened automatically.
+
+## Step 4: Read back the stored terminal session
+
+```bash
+cargo run --quiet -- \
+  engineer terminal-read single-process "$STATE_ROOT"
+```
+
+Look for:
+
+- `Probe mode: terminal-read`
+- `Terminal handoff source: latest_terminal_handoff.json`
+- `Mode boundary: terminal`
+- `Terminal recipe source: foundation-check`
+- `Terminal last output line: terminal-recipe-ok`
+- `Engineer next step: simard engineer run <topology> <workspace-root> <objective> <same-state-root>`
+
+**Checkpoint**: the terminal readback stays read-only, and the bridge guidance is coming from durable local state rather than from a hidden resume system.
+
+## Step 5: Continue into engineer mode through the same state root
 
 ```bash
 ENGINEER_OBJECTIVE=$'inspect the repository state
@@ -63,17 +114,37 @@ cargo run --quiet --   engineer run single-process "$PWD" "$ENGINEER_OBJECTIVE" 
 Look for output shaped like this:
 
 ```text
+Mode boundary: engineer
 Repo root: /path/to/repo
-Active goals count: 0
-Execution scope: local-only
+Terminal continuity available: yes
+Terminal continuity source: latest_terminal_handoff.json
+Terminal recipe source: foundation-check
 Action plan: Inspect the repo ...
 Selected action: cargo-metadata-scan
 Verification status: verified
 ```
 
-**Checkpoint**: Simard inspected the repo, chose one bounded action, and verified the result.
+**Checkpoint**: Simard inspected the repo, preserved the v1 engineer contract, and rendered terminal continuity as descriptive context only.
 
-## Step 3: Capture a meeting record in the same state root
+## Step 6: Read back the engineer audit trail
+
+```bash
+cargo run --quiet -- \
+  engineer read single-process "$STATE_ROOT"
+```
+
+Look for:
+
+- `Probe mode: engineer-read`
+- `Engineer handoff source: latest_engineer_handoff.json`
+- `Mode boundary: engineer`
+- `Terminal continuity available: yes`
+- `Terminal continuity source: latest_terminal_handoff.json`
+- `Verification status: verified`
+
+**Checkpoint**: `engineer read` prefers the engineer-scoped handoff, keeps the terminal continuity section separate, and never replays raw objective text.
+
+## Step 7: Capture a meeting record in the same state root
 
 ```bash
 MEETING_OBJECTIVE="$(cat <<'EOF'
@@ -115,7 +186,7 @@ Look for:
 - `Decision 1: preserve meeting-to-engineer continuity`
 - `Goal update 1: p1 [active] Preserve meeting handoff`
 
-## Step 4: Re-run engineer mode and confirm carryover
+## Step 8: Re-run engineer mode and confirm carryover
 
 Use the same repo and the same state root again.
 
@@ -135,7 +206,7 @@ Verification status: verified
 
 **Checkpoint**: meeting mode and engineer mode now share durable planning context through one explicit state root.
 
-## Step 5: Curate durable goals directly
+## Step 9: Curate durable goals directly
 
 You can also update the goal register without running a meeting first.
 
@@ -155,7 +226,7 @@ Look for:
 
 **Checkpoint**: durable backlog stewardship is its own operator-visible mode, not an engineer-loop side effect.
 
-## Step 6: Generate a review artifact, curate one approval and one deferral, then read the stored improvement state
+## Step 10: Generate a review artifact, curate one approval and one deferral, then read the stored improvement state
 
 First persist the latest review artifact:
 
@@ -196,7 +267,7 @@ Look for:
 - `Deferred proposal 1: Promote this pattern into a repeatable benchmark (hold this until the next benchmark planning pass)`
 - `Latest improvement record: review=`
 
-## Step 7: Exercise bootstrap and the terminal-backed engineer substrate
+## Step 11: Exercise bootstrap and benchmark discovery
 
 Bootstrap and benchmark execution both live on the canonical CLI:
 
@@ -206,48 +277,13 @@ cargo run --quiet --   bootstrap run simard-engineer local-harness single-proces
 cargo run --quiet -- gym list
 ```
 
-The terminal-backed engineer substrate now lives on the canonical CLI too:
-
-```bash
-cargo run --quiet --   engineer terminal single-process   $'working-directory: .
-command: pwd
-command: printf "terminal-foundation-ok\n"'   "$STATE_ROOT"
-```
-
-Look for:
-
-- `Adapter implementation: terminal-shell::local-pty`
-- `Terminal steps count: 2`
-- `Terminal step 1: input: pwd`
-- `Terminal last output line: terminal-foundation-ok`
-- `Terminal transcript preview:`
-
-If you want to keep a reusable interactive session recipe on disk instead of packing it into one CLI string, use the file-backed entrypoint:
-
-```bash
-cat > /tmp/simard-terminal.recipe <<'EOF'
-working-directory: .
-command: printf "terminal-file-ready\n"
-wait-for: terminal-file-ready
-input: printf "terminal-file-ok\n"
-EOF
-
-cargo run --quiet -- \
-  engineer terminal-file single-process /tmp/simard-terminal.recipe "$STATE_ROOT"
-```
-
-Simard also ships named built-in terminal recipes when you want reusable sessions without managing your own temp file:
-
-```bash
-cargo run --quiet -- engineer terminal-recipe-list
-cargo run --quiet -- engineer terminal-recipe-show foundation-check
-cargo run --quiet -- engineer terminal-recipe single-process foundation-check "$STATE_ROOT"
-```
-
 ## Summary
 
 You now know how to:
 
+- discover a shipped terminal recipe on the canonical CLI
+- run a bounded local terminal session and read back its truthful audit trail
+- continue from that terminal surface into the repo-grounded engineer loop through the same explicit `state-root`
 - run the shipped engineer flow through `simard`
 - carry meeting decisions into later engineer runs
 - curate durable goals directly
@@ -257,6 +293,7 @@ You now know how to:
 ## Next steps
 
 - Use [How to configure bootstrap and inspect reflection](../howto/configure-bootstrap-and-inspect-reflection.md) when you need the bootstrap contract in more detail.
+- Use [How to move from terminal recipes into engineer runs](../howto/move-from-terminal-recipes-into-engineer-runs.md) when you want the narrow terminal-to-engineer bridge workflow only.
 - Use [How to carry meeting decisions into engineer sessions](../howto/carry-meeting-decisions-into-engineer-sessions.md) when you need a narrower handoff-focused workflow.
 - Use [How to inspect meeting records](../howto/inspect-meeting-records.md) when you need the read-only meeting audit flow.
 - Use [How to inspect improvement-curation state](../howto/inspect-improvement-curation-state.md) when you need the read-only review-to-priority audit flow.

--- a/src/engineer_loop.rs
+++ b/src/engineer_loop.rs
@@ -8,11 +8,15 @@ use crate::base_types::BaseTypeId;
 use crate::error::{SimardError, SimardResult};
 use crate::evidence::{EvidenceRecord, EvidenceSource, EvidenceStore, FileBackedEvidenceStore};
 use crate::goals::{FileBackedGoalStore, GoalRecord, GoalStore};
-use crate::handoff::{FileBackedHandoffStore, RuntimeHandoffSnapshot, RuntimeHandoffStore};
+use crate::handoff::RuntimeHandoffSnapshot;
 use crate::memory::{FileBackedMemoryStore, MemoryRecord, MemoryScope, MemoryStore};
 use crate::runtime::{RuntimeAddress, RuntimeNodeId, RuntimeState, RuntimeTopology};
 use crate::sanitization::{objective_metadata, sanitize_terminal_text};
 use crate::session::{SessionPhase, SessionRecord, UuidSessionIdGenerator};
+use crate::terminal_engineer_bridge::{
+    SHARED_EXPLICIT_STATE_ROOT_SOURCE, ScopedHandoffMode, TerminalBridgeContext,
+    persist_handoff_artifacts,
+};
 
 const ENGINEER_IDENTITY: &str = "simard-engineer";
 const ENGINEER_BASE_TYPE: &str = "terminal-shell";
@@ -89,6 +93,7 @@ pub struct EngineerLoopRun {
     pub inspection: RepoInspection,
     pub action: ExecutedEngineerAction,
     pub verification: VerificationReport,
+    pub terminal_bridge_context: Option<TerminalBridgeContext>,
 }
 
 pub fn run_local_engineer_loop(
@@ -99,6 +104,10 @@ pub fn run_local_engineer_loop(
 ) -> SimardResult<EngineerLoopRun> {
     let state_root = state_root.into();
     let inspection = inspect_workspace(workspace_root.as_ref(), &state_root)?;
+    let terminal_bridge_context = TerminalBridgeContext::load_from_state_root(
+        &state_root,
+        SHARED_EXPLICIT_STATE_ROOT_SOURCE,
+    )?;
     let selected_action = select_engineer_action(&inspection, objective)?;
     let action = execute_engineer_action(&inspection.repo_root, selected_action)?;
     let verification = verify_engineer_action(&inspection, &action, &state_root)?;
@@ -109,6 +118,7 @@ pub fn run_local_engineer_loop(
         &inspection,
         &action,
         &verification,
+        terminal_bridge_context.as_ref(),
     )?;
 
     Ok(EngineerLoopRun {
@@ -117,6 +127,7 @@ pub fn run_local_engineer_loop(
         inspection,
         action,
         verification,
+        terminal_bridge_context,
     })
 }
 
@@ -674,11 +685,11 @@ fn persist_engineer_loop_artifacts(
     inspection: &RepoInspection,
     action: &ExecutedEngineerAction,
     verification: &VerificationReport,
+    terminal_bridge_context: Option<&TerminalBridgeContext>,
 ) -> SimardResult<()> {
     let memory_store = FileBackedMemoryStore::try_new(state_root.join("memory_records.json"))?;
     let evidence_store =
         FileBackedEvidenceStore::try_new(state_root.join("evidence_records.json"))?;
-    let handoff_store = FileBackedHandoffStore::try_new(state_root.join("latest_handoff.json"))?;
 
     let session_ids = UuidSessionIdGenerator;
     let mut session = SessionRecord::new(
@@ -758,6 +769,10 @@ fn persist_engineer_loop_artifacts(
         format!("verification-status={}", verification.status),
         format!("verification-summary={}", verification.summary),
     ];
+    let mut evidence_details = evidence_details;
+    if let Some(terminal_bridge_context) = terminal_bridge_context {
+        evidence_details.extend(terminal_bridge_context.engineer_evidence_details());
+    }
 
     for (index, detail) in evidence_details.into_iter().enumerate() {
         let evidence_id = format!("{}-engineer-loop-evidence-{}", session.id, index + 1);
@@ -830,7 +845,7 @@ fn persist_engineer_loop_artifacts(
         memory_records: memory_store.list_for_session(&session.id)?,
         evidence_records: evidence_store.list_for_session(&session.id)?,
     };
-    handoff_store.save(handoff)?;
+    persist_handoff_artifacts(state_root, ScopedHandoffMode::Engineer, &handoff)?;
     Ok(())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub mod review;
 pub mod runtime;
 mod sanitization;
 pub mod session;
+pub mod terminal_engineer_bridge;
 mod terminal_session;
 
 pub use agent_program::{
@@ -102,4 +103,9 @@ pub use runtime::{
 };
 pub use session::{
     SessionId, SessionIdGenerator, SessionPhase, SessionRecord, UuidSessionIdGenerator,
+};
+pub use terminal_engineer_bridge::{
+    ENGINEER_HANDOFF_FILE_NAME, ENGINEER_MODE_BOUNDARY, SHARED_DEFAULT_STATE_ROOT_SOURCE,
+    SHARED_EXPLICIT_STATE_ROOT_SOURCE, TERMINAL_HANDOFF_FILE_NAME, TERMINAL_MODE_BOUNDARY,
+    TerminalBridgeContext,
 };

--- a/src/operator_commands.rs
+++ b/src/operator_commands.rs
@@ -9,14 +9,20 @@ use crate::improvements::PersistedImprovementRecord;
 use crate::meetings::PersistedMeetingRecord;
 use crate::prompt_assets::{FilePromptAssetStore, PromptAsset, PromptAssetRef, PromptAssetStore};
 use crate::sanitization::sanitize_terminal_text;
+use crate::terminal_engineer_bridge::{
+    ENGINEER_HANDOFF_FILE_NAME, ENGINEER_MODE_BOUNDARY, SHARED_DEFAULT_STATE_ROOT_SOURCE,
+    SHARED_EXPLICIT_STATE_ROOT_SOURCE, ScopedHandoffMode, TERMINAL_HANDOFF_FILE_NAME,
+    TERMINAL_MODE_BOUNDARY, TerminalBridgeContext, load_runtime_handoff_snapshot,
+    persist_handoff_artifacts, scoped_handoff_path, select_handoff_artifact_for_read,
+};
 use crate::{
     BootstrapConfig, BootstrapInputs, BuiltinIdentityLoader, EvidenceRecord,
-    FileBackedEvidenceStore, FileBackedHandoffStore, FileBackedMemoryStore, Freshness,
-    IdentityLoadRequest, IdentityLoader, ManifestContract, MemoryRecord, MemoryScope, MemoryStore,
-    Provenance, ReflectiveRuntime, ReviewRequest, ReviewTargetKind, RuntimeHandoffSnapshot,
-    RuntimeHandoffStore, RuntimeTopology, assemble_local_runtime_from_handoff, benchmark_scenarios,
-    build_review_artifact, builtin_base_type_registry_for_manifest, compare_latest_benchmark_runs,
-    default_output_root, latest_local_handoff, latest_review_artifact, persist_review_artifact,
+    FileBackedEvidenceStore, FileBackedMemoryStore, Freshness, IdentityLoadRequest, IdentityLoader,
+    ManifestContract, MemoryRecord, MemoryScope, MemoryStore, Provenance, ReflectiveRuntime,
+    ReviewRequest, ReviewTargetKind, RuntimeHandoffSnapshot, RuntimeTopology,
+    assemble_local_runtime_from_handoff, benchmark_scenarios, build_review_artifact,
+    builtin_base_type_registry_for_manifest, compare_latest_benchmark_runs, default_output_root,
+    latest_local_handoff, latest_review_artifact, persist_review_artifact,
     render_review_context_directives, review_artifacts_dir, run_benchmark_scenario,
     run_benchmark_suite, run_local_engineer_loop, run_local_session,
 };
@@ -490,6 +496,7 @@ pub fn run_terminal_probe(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let identity = "simard-engineer";
     let base_type = "terminal-shell";
+    let state_root_was_explicit = state_root_override.is_some();
     let config = BootstrapConfig::resolve(BootstrapInputs {
         prompt_root: Some(prompt_root()),
         objective: Some(objective.to_string()),
@@ -508,7 +515,27 @@ pub fn run_terminal_probe(
 
     let execution = run_local_session(&config)?;
     let exported = latest_local_handoff(&config)?.ok_or("expected durable terminal handoff")?;
-    let view = TerminalReadView::from_handoff(config.state_root_path().to_path_buf(), exported)?;
+    persist_handoff_artifacts(
+        config.state_root_path(),
+        ScopedHandoffMode::Terminal,
+        &exported,
+    )?;
+    let handoff_source = scoped_handoff_path(config.state_root_path(), ScopedHandoffMode::Terminal)
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or("latest_terminal_handoff.json")
+        .to_string();
+    let continuity_source = if state_root_was_explicit {
+        SHARED_EXPLICIT_STATE_ROOT_SOURCE
+    } else {
+        SHARED_DEFAULT_STATE_ROOT_SOURCE
+    };
+    let view = TerminalReadView::from_handoff(
+        config.state_root_path().to_path_buf(),
+        exported,
+        handoff_source,
+        Some(continuity_source.to_string()),
+    )?;
     view.print_terminal_run(
         &execution.snapshot.adapter_capabilities,
         &execution.outcome.execution_summary,
@@ -574,6 +601,7 @@ pub fn run_engineer_loop_probe(
     state_root_override: Option<PathBuf>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let runtime_topology = parse_runtime_topology(topology)?;
+    let state_root_was_explicit = state_root_override.is_some();
     let state_root = resolved_state_root(
         state_root_override,
         "simard-engineer",
@@ -585,6 +613,7 @@ pub fn run_engineer_loop_probe(
         .map_err(|error| format!("{error}"))?;
 
     println!("Probe mode: engineer-loop-run");
+    print_text("Mode boundary", ENGINEER_MODE_BOUNDARY);
     print_display("Repo root", run.inspection.repo_root.display());
     print_text("Repo branch", &run.inspection.branch);
     print_text("Repo head", &run.inspection.head);
@@ -608,6 +637,14 @@ pub fn run_engineer_loop_probe(
     for (index, decision) in run.inspection.carried_meeting_decisions.iter().enumerate() {
         print_text(&format!("Carried meeting decision {}", index + 1), decision);
     }
+    print_terminal_bridge_section(
+        run.terminal_bridge_context.as_ref(),
+        if state_root_was_explicit {
+            SHARED_EXPLICIT_STATE_ROOT_SOURCE
+        } else {
+            SHARED_DEFAULT_STATE_ROOT_SOURCE
+        },
+    );
     print_text("Gap summary", &run.inspection.architecture_gap_summary);
     print_text("Execution scope", &run.execution_scope);
     print_text("Selected action", &run.action.selected.label);
@@ -1434,6 +1471,7 @@ fn artifact_name(path: &Path) -> &str {
 
 struct EngineerReadArtifacts {
     handoff_path: PathBuf,
+    handoff_file_name: String,
     memory_path: PathBuf,
     evidence_path: PathBuf,
 }
@@ -1442,12 +1480,11 @@ fn validated_engineer_read_artifacts(
     state_root: &Path,
 ) -> crate::SimardResult<EngineerReadArtifacts> {
     validate_existing_read_state_root_root("engineer read", state_root)?;
+    let selected_handoff =
+        select_handoff_artifact_for_read(state_root, ScopedHandoffMode::Engineer, "engineer read")?;
     Ok(EngineerReadArtifacts {
-        handoff_path: require_existing_read_file_for_mode(
-            "engineer read",
-            state_root,
-            &state_root.join("latest_handoff.json"),
-        )?,
+        handoff_path: selected_handoff.path,
+        handoff_file_name: selected_handoff.file_name.to_string(),
         memory_path: require_existing_read_file_for_mode(
             "engineer read",
             state_root,
@@ -1465,12 +1502,11 @@ fn validated_terminal_read_artifacts(
     state_root: &Path,
 ) -> crate::SimardResult<EngineerReadArtifacts> {
     validate_existing_read_state_root_root("terminal read", state_root)?;
+    let selected_handoff =
+        select_handoff_artifact_for_read(state_root, ScopedHandoffMode::Terminal, "terminal read")?;
     Ok(EngineerReadArtifacts {
-        handoff_path: require_existing_read_file_for_mode(
-            "terminal read",
-            state_root,
-            &state_root.join("latest_handoff.json"),
-        )?,
+        handoff_path: selected_handoff.path,
+        handoff_file_name: selected_handoff.file_name.to_string(),
         memory_path: require_existing_read_file_for_mode(
             "terminal read",
             state_root,
@@ -1499,6 +1535,7 @@ fn parse_runtime_topology(value: &str) -> crate::SimardResult<RuntimeTopology> {
 
 struct EngineerReadView {
     state_root: PathBuf,
+    handoff_source: String,
     identity: String,
     selected_base_type: String,
     topology: String,
@@ -1518,12 +1555,14 @@ struct EngineerReadView {
     changed_files_after_action: String,
     verification_status: String,
     verification_summary: String,
+    terminal_bridge_context: Option<TerminalBridgeContext>,
     memory_record_count: usize,
     evidence_record_count: usize,
 }
 
 struct TerminalReadView {
     state_root: PathBuf,
+    handoff_source: String,
     identity: String,
     selected_base_type: String,
     topology: String,
@@ -1539,6 +1578,7 @@ struct TerminalReadView {
     checkpoints: Vec<String>,
     last_output_line: Option<String>,
     transcript_preview: String,
+    continuity_source: Option<String>,
     memory_record_count: usize,
     evidence_record_count: usize,
 }
@@ -1546,20 +1586,36 @@ struct TerminalReadView {
 impl EngineerReadView {
     fn load(state_root: PathBuf) -> crate::SimardResult<Self> {
         let artifacts = validated_engineer_read_artifacts(&state_root)?;
-        let handoff = latest_engineer_handoff(&artifacts.handoff_path)?;
-        let session = handoff.session.as_ref().ok_or_else(|| {
-            crate::SimardError::InvalidHandoffSnapshot {
-                field: "session".to_string(),
-                reason: "engineer read requires latest_handoff.json to contain a persisted session snapshot"
+        let handoff_source = artifacts.handoff_file_name.clone();
+        let handoff = load_runtime_handoff_snapshot(
+            &crate::terminal_engineer_bridge::SelectedHandoffArtifact {
+                path: artifacts.handoff_path.clone(),
+                file_name: match handoff_source.as_str() {
+                    ENGINEER_HANDOFF_FILE_NAME => ENGINEER_HANDOFF_FILE_NAME,
+                    _ => crate::terminal_engineer_bridge::COMPATIBILITY_HANDOFF_FILE_NAME,
+                },
+            },
+            "engineer read",
+        )?;
+        let session =
+            handoff
+                .session
+                .as_ref()
+                .ok_or_else(|| crate::SimardError::InvalidHandoffSnapshot {
+                    field: "session".to_string(),
+                    reason: format!(
+                        "engineer read requires {} to contain a persisted session snapshot",
+                        artifacts.handoff_file_name
+                    )
                     .to_string(),
-            }
-        })?;
+                })?;
 
         FileBackedMemoryStore::try_new(artifacts.memory_path)?;
         FileBackedEvidenceStore::try_new(artifacts.evidence_path)?;
 
         Ok(Self {
             state_root,
+            handoff_source: handoff_source.clone(),
             identity: handoff.identity_name,
             selected_base_type: handoff.selected_base_type.to_string(),
             topology: handoff.topology.to_string(),
@@ -1568,69 +1624,92 @@ impl EngineerReadView {
             repo_root: PathBuf::from(required_engineer_evidence_value(
                 &handoff.evidence_records,
                 "repo-root=",
+                &handoff_source,
             )?),
             repo_branch: required_engineer_evidence_value(
                 &handoff.evidence_records,
                 "repo-branch=",
+                &handoff_source,
             )?
             .to_string(),
-            repo_head: required_engineer_evidence_value(&handoff.evidence_records, "repo-head=")?
-                .to_string(),
+            repo_head: required_engineer_evidence_value(
+                &handoff.evidence_records,
+                "repo-head=",
+                &handoff_source,
+            )?
+            .to_string(),
             worktree_dirty: required_engineer_evidence_value(
                 &handoff.evidence_records,
                 "worktree-dirty=",
+                &handoff_source,
             )?
             .to_string(),
             changed_files: required_engineer_evidence_value(
                 &handoff.evidence_records,
                 "changed-files=",
+                &handoff_source,
             )?
             .to_string(),
             active_goals: parse_engineer_summary_list(
-                required_engineer_evidence_value(&handoff.evidence_records, "active-goals=")?,
+                required_engineer_evidence_value(
+                    &handoff.evidence_records,
+                    "active-goals=",
+                    &handoff_source,
+                )?,
                 ", ",
             ),
             carried_meeting_decisions: parse_carried_meeting_decisions(
                 required_engineer_evidence_value(
                     &handoff.evidence_records,
                     "carried-meeting-decisions=",
+                    &handoff_source,
                 )?,
             )?,
             selected_action: required_engineer_evidence_value(
                 &handoff.evidence_records,
                 "selected-action=",
+                &handoff_source,
             )?
             .to_string(),
             action_plan: required_engineer_evidence_value(
                 &handoff.evidence_records,
                 "action-plan=",
+                &handoff_source,
             )?
             .to_string(),
             verification_steps: required_engineer_evidence_value(
                 &handoff.evidence_records,
                 "action-verification-steps=",
+                &handoff_source,
             )?
             .to_string(),
             action_status: required_engineer_evidence_value(
                 &handoff.evidence_records,
                 "action-status=",
+                &handoff_source,
             )?
             .to_string(),
             changed_files_after_action: required_engineer_evidence_value(
                 &handoff.evidence_records,
                 "changed-files-after-action=",
+                &handoff_source,
             )?
             .to_string(),
             verification_status: required_engineer_evidence_value(
                 &handoff.evidence_records,
                 "verification-status=",
+                &handoff_source,
             )?
             .to_string(),
             verification_summary: required_engineer_evidence_value(
                 &handoff.evidence_records,
                 "verification-summary=",
+                &handoff_source,
             )?
             .to_string(),
+            terminal_bridge_context: TerminalBridgeContext::from_engineer_evidence(
+                &handoff.evidence_records,
+            )?,
             memory_record_count: handoff.memory_records.len(),
             evidence_record_count: handoff.evidence_records.len(),
         })
@@ -1638,6 +1717,8 @@ impl EngineerReadView {
 
     fn print(&self) {
         println!("Probe mode: engineer-read");
+        print_text("Engineer handoff source", &self.handoff_source);
+        print_text("Mode boundary", ENGINEER_MODE_BOUNDARY);
         print_text("Identity", &self.identity);
         print_text("Selected base type", &self.selected_base_type);
         print_text("Topology", &self.topology);
@@ -1660,6 +1741,13 @@ impl EngineerReadView {
         for (index, decision) in self.carried_meeting_decisions.iter().enumerate() {
             print_text(&format!("Carried meeting decision {}", index + 1), decision);
         }
+        print_terminal_bridge_section(
+            self.terminal_bridge_context.as_ref(),
+            self.terminal_bridge_context
+                .as_ref()
+                .map(|context| context.continuity_source.as_str())
+                .unwrap_or(SHARED_DEFAULT_STATE_ROOT_SOURCE),
+        );
         print_text("Selected action", &self.selected_action);
         print_text("Action plan", &self.action_plan);
         print_text("Verification steps", &self.verification_steps);
@@ -1678,28 +1766,43 @@ impl EngineerReadView {
 impl TerminalReadView {
     fn load(state_root: PathBuf) -> crate::SimardResult<Self> {
         let artifacts = validated_terminal_read_artifacts(&state_root)?;
-        let handoff = latest_engineer_handoff(&artifacts.handoff_path)?;
+        let handoff = load_runtime_handoff_snapshot(
+            &crate::terminal_engineer_bridge::SelectedHandoffArtifact {
+                path: artifacts.handoff_path.clone(),
+                file_name: match artifacts.handoff_file_name.as_str() {
+                    TERMINAL_HANDOFF_FILE_NAME => TERMINAL_HANDOFF_FILE_NAME,
+                    _ => crate::terminal_engineer_bridge::COMPATIBILITY_HANDOFF_FILE_NAME,
+                },
+            },
+            "terminal read",
+        )?;
 
         FileBackedMemoryStore::try_new(artifacts.memory_path)?;
         FileBackedEvidenceStore::try_new(artifacts.evidence_path)?;
 
-        Self::from_handoff(state_root, handoff)
+        Self::from_handoff(state_root, handoff, artifacts.handoff_file_name, None)
     }
 
     fn from_handoff(
         state_root: PathBuf,
         handoff: RuntimeHandoffSnapshot,
+        handoff_source: String,
+        continuity_source: Option<String>,
     ) -> crate::SimardResult<Self> {
+        let handoff_source_label = handoff_source.clone();
         let session = handoff.session.as_ref().ok_or_else(|| {
             crate::SimardError::InvalidHandoffSnapshot {
                 field: "session".to_string(),
-                reason: "terminal read requires latest_handoff.json to contain a persisted session snapshot"
+                reason: format!(
+                    "terminal read requires {handoff_source} to contain a persisted session snapshot"
+                )
                     .to_string(),
             }
         })?;
 
         Ok(Self {
             state_root,
+            handoff_source,
             identity: handoff.identity_name,
             selected_base_type: handoff.selected_base_type.to_string(),
             topology: handoff.topology.to_string(),
@@ -1708,18 +1811,25 @@ impl TerminalReadView {
             adapter_implementation: required_terminal_evidence_value(
                 &handoff.evidence_records,
                 "backend-implementation=",
+                &handoff_source_label,
             )?
             .to_string(),
-            shell: required_terminal_evidence_value(&handoff.evidence_records, "shell=")?
-                .to_string(),
+            shell: required_terminal_evidence_value(
+                &handoff.evidence_records,
+                "shell=",
+                &handoff_source_label,
+            )?
+            .to_string(),
             working_directory: required_terminal_evidence_value(
                 &handoff.evidence_records,
                 "terminal-working-directory=",
+                &handoff_source_label,
             )?
             .to_string(),
             command_count: required_terminal_evidence_value(
                 &handoff.evidence_records,
                 "terminal-command-count=",
+                &handoff_source_label,
             )?
             .to_string(),
             wait_count: optional_terminal_evidence_value(
@@ -1742,8 +1852,10 @@ impl TerminalReadView {
             transcript_preview: required_terminal_evidence_value(
                 &handoff.evidence_records,
                 "terminal-transcript-preview=",
+                &handoff_source_label,
             )?
             .to_string(),
+            continuity_source,
             memory_record_count: handoff.memory_records.len(),
             evidence_record_count: handoff.evidence_records.len(),
         })
@@ -1770,6 +1882,8 @@ impl TerminalReadView {
     }
 
     fn print_terminal_audit_header(&self) {
+        print_text("Terminal handoff source", &self.handoff_source);
+        print_text("Mode boundary", TERMINAL_MODE_BOUNDARY);
         print_text("Identity", &self.identity);
         print_text("Selected base type", &self.selected_base_type);
         print_text("Topology", &self.topology);
@@ -1804,25 +1918,23 @@ impl TerminalReadView {
             print_text("Terminal last output line", last_output_line);
         }
         print_text("Terminal transcript preview", &self.transcript_preview);
+        if let Some(continuity_source) = &self.continuity_source {
+            print_text("Next step source", continuity_source);
+        }
+        println!("Next steps count: 1");
+        println!(
+            "Next step 1: run 'simard engineer run <topology> <workspace-root> <objective> {}' to start the separate repo-grounded bounded loop",
+            self.state_root.display()
+        );
         println!("Memory records: {}", self.memory_record_count);
         println!("Evidence records: {}", self.evidence_record_count);
     }
 }
 
-fn latest_engineer_handoff(handoff_path: &Path) -> crate::SimardResult<RuntimeHandoffSnapshot> {
-    FileBackedHandoffStore::try_new(handoff_path)?
-        .latest()?
-        .ok_or_else(|| crate::SimardError::InvalidHandoffSnapshot {
-            field: "latest_handoff.json".to_string(),
-            reason:
-                "engineer read requires latest_handoff.json to contain a persisted handoff snapshot"
-                    .to_string(),
-        })
-}
-
 fn required_engineer_evidence_value<'a>(
     evidence_records: &'a [EvidenceRecord],
     prefix: &str,
+    handoff_source: &str,
 ) -> crate::SimardResult<&'a str> {
     evidence_records
         .iter()
@@ -1831,7 +1943,7 @@ fn required_engineer_evidence_value<'a>(
         .ok_or_else(|| crate::SimardError::InvalidHandoffSnapshot {
             field: prefix.trim_end_matches('=').to_string(),
             reason: format!(
-                "engineer read requires latest_handoff.json to carry persisted engineer evidence '{}' for operator output",
+                "engineer read requires {handoff_source} to carry persisted engineer evidence '{}' for operator output",
                 prefix.trim_end_matches('=')
             ),
         })
@@ -1840,6 +1952,7 @@ fn required_engineer_evidence_value<'a>(
 fn required_terminal_evidence_value<'a>(
     evidence_records: &'a [EvidenceRecord],
     prefix: &str,
+    handoff_source: &str,
 ) -> crate::SimardResult<&'a str> {
     evidence_records
         .iter()
@@ -1848,7 +1961,7 @@ fn required_terminal_evidence_value<'a>(
         .ok_or_else(|| crate::SimardError::InvalidHandoffSnapshot {
             field: prefix.trim_end_matches('=').to_string(),
             reason: format!(
-                "terminal read requires latest_handoff.json to carry persisted terminal evidence '{}' for operator output",
+                "terminal read requires {handoff_source} to carry persisted terminal evidence '{}' for operator output",
                 prefix.trim_end_matches('=')
             ),
         })
@@ -1904,7 +2017,10 @@ fn parse_carried_meeting_decisions(raw: &str) -> crate::SimardResult<Vec<String>
     if persisted_records.is_empty() {
         return Err(crate::SimardError::InvalidHandoffSnapshot {
             field: "carried-meeting-decisions".to_string(),
-            reason: "engineer read requires latest_handoff.json to carry at least one persisted meeting record or '<none>' for carried-meeting-decisions".to_string(),
+            reason: format!(
+                "engineer read requires {ENGINEER_HANDOFF_FILE_NAME} or {} to carry at least one persisted meeting record or '<none>' for carried-meeting-decisions",
+                crate::terminal_engineer_bridge::COMPATIBILITY_HANDOFF_FILE_NAME
+            ),
         });
     }
 
@@ -1914,7 +2030,7 @@ fn parse_carried_meeting_decisions(raw: &str) -> crate::SimardResult<Vec<String>
             crate::SimardError::InvalidHandoffSnapshot {
                 field: "carried-meeting-decisions".to_string(),
                 reason: format!(
-                    "engineer read requires latest_handoff.json to carry valid persisted meeting records for carried-meeting-decisions: {error}"
+                    "engineer read requires valid persisted meeting records for carried-meeting-decisions: {error}"
                 ),
             }
         })?;
@@ -1927,9 +2043,38 @@ fn render_redacted_objective_metadata(value: &str) -> crate::SimardResult<String
     crate::sanitization::normalize_objective_metadata(value).ok_or_else(|| {
         crate::SimardError::InvalidHandoffSnapshot {
             field: "session.objective".to_string(),
-            reason: "engineer read requires latest_handoff.json to persist trusted objective metadata as objective-metadata(chars=<n>, words=<n>, lines=<n>)".to_string(),
+            reason: "engineer read requires a trusted handoff artifact to persist objective metadata as objective-metadata(chars=<n>, words=<n>, lines=<n>)".to_string(),
         }
     })
+}
+
+fn print_terminal_bridge_section(
+    terminal_bridge_context: Option<&TerminalBridgeContext>,
+    default_source: &str,
+) {
+    match terminal_bridge_context {
+        Some(context) => {
+            print_text("Mode boundary", TERMINAL_MODE_BOUNDARY);
+            print_text("Terminal continuity available", "yes");
+            print_text("Terminal continuity source", &context.continuity_source);
+            print_text("Terminal continuity handoff", &context.handoff_file_name);
+            print_text(
+                "Terminal continuity working directory",
+                &context.working_directory,
+            );
+            print_text("Terminal continuity command count", &context.command_count);
+            print_text("Terminal continuity wait count", &context.wait_count);
+            if let Some(last_output_line) = &context.last_output_line {
+                print_text("Terminal continuity last output line", last_output_line);
+            } else {
+                print_text("Terminal continuity last output line", "<none>");
+            }
+        }
+        None => {
+            print_text("Terminal continuity available", "no");
+            print_text("Terminal continuity source", default_source);
+        }
+    }
 }
 
 fn next_required(

--- a/src/terminal_engineer_bridge.rs
+++ b/src/terminal_engineer_bridge.rs
@@ -1,0 +1,384 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::error::{SimardError, SimardResult};
+use crate::evidence::EvidenceRecord;
+use crate::handoff::{FileBackedHandoffStore, RuntimeHandoffSnapshot, RuntimeHandoffStore};
+use crate::sanitization::sanitize_terminal_text;
+
+pub const COMPATIBILITY_HANDOFF_FILE_NAME: &str = "latest_handoff.json";
+pub const TERMINAL_HANDOFF_FILE_NAME: &str = "latest_terminal_handoff.json";
+pub const ENGINEER_HANDOFF_FILE_NAME: &str = "latest_engineer_handoff.json";
+pub const TERMINAL_MODE_BOUNDARY: &str = "terminal is a bounded local terminal session surface";
+pub const ENGINEER_MODE_BOUNDARY: &str = "engineer is a separate repo-grounded bounded loop";
+pub const SHARED_EXPLICIT_STATE_ROOT_SOURCE: &str = "shared explicit state-root";
+pub const SHARED_DEFAULT_STATE_ROOT_SOURCE: &str = "shared default state-root";
+
+const BRIDGE_SOURCE_PREFIX: &str = "terminal-continuity-source=";
+const BRIDGE_HANDOFF_PREFIX: &str = "terminal-continuity-handoff=";
+const BRIDGE_WORKING_DIRECTORY_PREFIX: &str = "terminal-continuity-working-directory=";
+const BRIDGE_COMMAND_COUNT_PREFIX: &str = "terminal-continuity-command-count=";
+const BRIDGE_WAIT_COUNT_PREFIX: &str = "terminal-continuity-wait-count=";
+const BRIDGE_LAST_OUTPUT_LINE_PREFIX: &str = "terminal-continuity-last-output-line=";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ScopedHandoffMode {
+    Terminal,
+    Engineer,
+}
+
+impl ScopedHandoffMode {
+    pub fn scoped_file_name(self) -> &'static str {
+        match self {
+            Self::Terminal => TERMINAL_HANDOFF_FILE_NAME,
+            Self::Engineer => ENGINEER_HANDOFF_FILE_NAME,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SelectedHandoffArtifact {
+    pub path: PathBuf,
+    pub file_name: &'static str,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TerminalBridgeContext {
+    pub continuity_source: String,
+    pub handoff_file_name: String,
+    pub working_directory: String,
+    pub command_count: String,
+    pub wait_count: String,
+    pub last_output_line: Option<String>,
+}
+
+impl TerminalBridgeContext {
+    pub fn load_from_state_root(
+        state_root: &Path,
+        continuity_source: &str,
+    ) -> SimardResult<Option<Self>> {
+        let Some(selection) = select_optional_handoff_artifact(
+            state_root,
+            ScopedHandoffMode::Terminal,
+            "engineer run",
+        )?
+        else {
+            return Ok(None);
+        };
+
+        let snapshot = load_runtime_handoff_snapshot(&selection, "engineer run")?;
+        Self::from_terminal_handoff(
+            &snapshot,
+            selection.file_name,
+            continuity_source.to_string(),
+            "engineer run",
+        )
+    }
+
+    pub fn from_engineer_evidence(
+        evidence_records: &[EvidenceRecord],
+    ) -> SimardResult<Option<Self>> {
+        let Some(continuity_source) =
+            optional_evidence_value(evidence_records, BRIDGE_SOURCE_PREFIX)
+        else {
+            return Ok(None);
+        };
+        if continuity_source != SHARED_EXPLICIT_STATE_ROOT_SOURCE
+            && continuity_source != SHARED_DEFAULT_STATE_ROOT_SOURCE
+        {
+            return Err(SimardError::InvalidHandoffSnapshot {
+                field: "terminal-continuity-source".to_string(),
+                reason: "engineer read requires terminal continuity evidence to use a shipped shared-state-root label".to_string(),
+            });
+        }
+
+        let handoff_file_name =
+            required_evidence_value(evidence_records, BRIDGE_HANDOFF_PREFIX, "engineer read")?;
+        if handoff_file_name != TERMINAL_HANDOFF_FILE_NAME
+            && handoff_file_name != COMPATIBILITY_HANDOFF_FILE_NAME
+        {
+            return Err(SimardError::InvalidHandoffSnapshot {
+                field: "terminal-continuity-handoff".to_string(),
+                reason: "engineer read requires terminal continuity evidence to name latest_terminal_handoff.json or latest_handoff.json".to_string(),
+            });
+        }
+
+        Ok(Some(Self {
+            continuity_source: continuity_source.to_string(),
+            handoff_file_name: handoff_file_name.to_string(),
+            working_directory: sanitize_terminal_text(required_evidence_value(
+                evidence_records,
+                BRIDGE_WORKING_DIRECTORY_PREFIX,
+                "engineer read",
+            )?),
+            command_count: sanitize_terminal_text(required_evidence_value(
+                evidence_records,
+                BRIDGE_COMMAND_COUNT_PREFIX,
+                "engineer read",
+            )?),
+            wait_count: sanitize_terminal_text(
+                optional_evidence_value(evidence_records, BRIDGE_WAIT_COUNT_PREFIX).unwrap_or("0"),
+            ),
+            last_output_line: optional_evidence_value(
+                evidence_records,
+                BRIDGE_LAST_OUTPUT_LINE_PREFIX,
+            )
+            .map(sanitize_terminal_text),
+        }))
+    }
+
+    pub fn engineer_evidence_details(&self) -> Vec<String> {
+        let mut details = vec![
+            format!("{BRIDGE_SOURCE_PREFIX}{}", self.continuity_source),
+            format!("{BRIDGE_HANDOFF_PREFIX}{}", self.handoff_file_name),
+            format!(
+                "{BRIDGE_WORKING_DIRECTORY_PREFIX}{}",
+                self.working_directory
+            ),
+            format!("{BRIDGE_COMMAND_COUNT_PREFIX}{}", self.command_count),
+            format!("{BRIDGE_WAIT_COUNT_PREFIX}{}", self.wait_count),
+        ];
+        if let Some(last_output_line) = &self.last_output_line {
+            details.push(format!(
+                "{BRIDGE_LAST_OUTPUT_LINE_PREFIX}{last_output_line}"
+            ));
+        }
+        details
+    }
+
+    fn from_terminal_handoff(
+        handoff: &RuntimeHandoffSnapshot,
+        handoff_file_name: &str,
+        continuity_source: String,
+        consumer_label: &str,
+    ) -> SimardResult<Option<Self>> {
+        if !contains_terminal_evidence(&handoff.evidence_records) {
+            return Ok(None);
+        }
+
+        if handoff.session.is_none() {
+            return Err(SimardError::InvalidHandoffSnapshot {
+                field: "session".to_string(),
+                reason: format!(
+                    "{consumer_label} requires {handoff_file_name} to contain a persisted session snapshot before terminal continuity can be bridged"
+                ),
+            });
+        }
+
+        Ok(Some(Self {
+            continuity_source,
+            handoff_file_name: handoff_file_name.to_string(),
+            working_directory: sanitize_terminal_text(required_evidence_value(
+                &handoff.evidence_records,
+                "terminal-working-directory=",
+                consumer_label,
+            )?),
+            command_count: sanitize_terminal_text(required_evidence_value(
+                &handoff.evidence_records,
+                "terminal-command-count=",
+                consumer_label,
+            )?),
+            wait_count: sanitize_terminal_text(
+                optional_evidence_value(&handoff.evidence_records, "terminal-wait-count=")
+                    .unwrap_or("0"),
+            ),
+            last_output_line: optional_evidence_value(
+                &handoff.evidence_records,
+                "terminal-last-output-line=",
+            )
+            .map(sanitize_terminal_text),
+        }))
+    }
+}
+
+pub fn compatibility_handoff_path(state_root: &Path) -> PathBuf {
+    state_root.join(COMPATIBILITY_HANDOFF_FILE_NAME)
+}
+
+pub fn scoped_handoff_path(state_root: &Path, mode: ScopedHandoffMode) -> PathBuf {
+    state_root.join(mode.scoped_file_name())
+}
+
+pub fn persist_handoff_artifacts(
+    state_root: &Path,
+    mode: ScopedHandoffMode,
+    snapshot: &RuntimeHandoffSnapshot,
+) -> SimardResult<()> {
+    FileBackedHandoffStore::try_new(compatibility_handoff_path(state_root))?
+        .save(snapshot.clone())?;
+    FileBackedHandoffStore::try_new(scoped_handoff_path(state_root, mode))?
+        .save(snapshot.clone())?;
+    Ok(())
+}
+
+pub fn select_handoff_artifact_for_read(
+    state_root: &Path,
+    mode: ScopedHandoffMode,
+    mode_label: &str,
+) -> SimardResult<SelectedHandoffArtifact> {
+    if let Some(path) = validate_optional_regular_file(
+        state_root,
+        &scoped_handoff_path(state_root, mode),
+        mode.scoped_file_name(),
+        mode_label,
+    )? {
+        return Ok(SelectedHandoffArtifact {
+            path,
+            file_name: mode.scoped_file_name(),
+        });
+    }
+
+    Ok(SelectedHandoffArtifact {
+        path: require_regular_file(
+            state_root,
+            &compatibility_handoff_path(state_root),
+            COMPATIBILITY_HANDOFF_FILE_NAME,
+            mode_label,
+        )?,
+        file_name: COMPATIBILITY_HANDOFF_FILE_NAME,
+    })
+}
+
+pub fn select_optional_handoff_artifact(
+    state_root: &Path,
+    mode: ScopedHandoffMode,
+    mode_label: &str,
+) -> SimardResult<Option<SelectedHandoffArtifact>> {
+    if let Some(path) = validate_optional_regular_file(
+        state_root,
+        &scoped_handoff_path(state_root, mode),
+        mode.scoped_file_name(),
+        mode_label,
+    )? {
+        return Ok(Some(SelectedHandoffArtifact {
+            path,
+            file_name: mode.scoped_file_name(),
+        }));
+    }
+
+    if let Some(path) = validate_optional_regular_file(
+        state_root,
+        &compatibility_handoff_path(state_root),
+        COMPATIBILITY_HANDOFF_FILE_NAME,
+        mode_label,
+    )? {
+        return Ok(Some(SelectedHandoffArtifact {
+            path,
+            file_name: COMPATIBILITY_HANDOFF_FILE_NAME,
+        }));
+    }
+
+    Ok(None)
+}
+
+pub fn load_runtime_handoff_snapshot(
+    artifact: &SelectedHandoffArtifact,
+    consumer_label: &str,
+) -> SimardResult<RuntimeHandoffSnapshot> {
+    let store = FileBackedHandoffStore::try_new(&artifact.path).map_err(|error| {
+        SimardError::InvalidHandoffSnapshot {
+            field: artifact.file_name.to_string(),
+            reason: format!(
+                "{consumer_label} could not load {} cleanly: {error}",
+                artifact.file_name
+            ),
+        }
+    })?;
+
+    store
+        .latest()
+        .map_err(|error| SimardError::InvalidHandoffSnapshot {
+            field: artifact.file_name.to_string(),
+            reason: format!(
+                "{consumer_label} could not read {} cleanly: {error}",
+                artifact.file_name
+            ),
+        })?
+        .ok_or_else(|| SimardError::InvalidHandoffSnapshot {
+            field: artifact.file_name.to_string(),
+            reason: format!(
+                "{consumer_label} requires {} to contain a persisted handoff snapshot",
+                artifact.file_name
+            ),
+        })
+}
+
+fn contains_terminal_evidence(evidence_records: &[EvidenceRecord]) -> bool {
+    evidence_records
+        .iter()
+        .any(|record| record.detail.starts_with("terminal-working-directory="))
+}
+
+fn validate_optional_regular_file(
+    state_root: &Path,
+    path: &Path,
+    file_name: &str,
+    mode_label: &str,
+) -> SimardResult<Option<PathBuf>> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) => {
+            if metadata.file_type().is_symlink() {
+                return Err(SimardError::InvalidStateRoot {
+                    path: state_root.to_path_buf(),
+                    reason: format!(
+                        "{mode_label} requires {file_name} to exist as a regular file, not a symlink"
+                    ),
+                });
+            }
+            if metadata.is_file() {
+                return Ok(Some(path.to_path_buf()));
+            }
+            Err(SimardError::InvalidStateRoot {
+                path: state_root.to_path_buf(),
+                reason: format!("{mode_label} requires {file_name} to exist as a regular file"),
+            })
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(SimardError::InvalidStateRoot {
+            path: state_root.to_path_buf(),
+            reason: format!(
+                "{mode_label} requires {file_name} to exist as a regular file: {error}"
+            ),
+        }),
+    }
+}
+
+fn require_regular_file(
+    state_root: &Path,
+    path: &Path,
+    file_name: &str,
+    mode_label: &str,
+) -> SimardResult<PathBuf> {
+    validate_optional_regular_file(state_root, path, file_name, mode_label)?.ok_or_else(|| {
+        SimardError::InvalidStateRoot {
+            path: state_root.to_path_buf(),
+            reason: format!("{mode_label} requires {file_name} to exist as a regular file"),
+        }
+    })
+}
+
+fn required_evidence_value<'a>(
+    evidence_records: &'a [EvidenceRecord],
+    prefix: &str,
+    consumer_label: &str,
+) -> SimardResult<&'a str> {
+    optional_evidence_value(evidence_records, prefix).ok_or_else(|| {
+        SimardError::InvalidHandoffSnapshot {
+            field: prefix.trim_end_matches('=').to_string(),
+            reason: format!(
+                "{consumer_label} requires persisted evidence '{}' for operator-visible terminal continuity",
+                prefix.trim_end_matches('=')
+            ),
+        }
+    })
+}
+
+fn optional_evidence_value<'a>(
+    evidence_records: &'a [EvidenceRecord],
+    prefix: &str,
+) -> Option<&'a str> {
+    evidence_records
+        .iter()
+        .rev()
+        .find_map(|record| record.detail.strip_prefix(prefix))
+}

--- a/tests/simard_cli.rs
+++ b/tests/simard_cli.rs
@@ -41,6 +41,35 @@ fn load_json(path: impl AsRef<Path>) -> Value {
         .expect("artifact should deserialize as JSON")
 }
 
+fn write_json(path: impl AsRef<Path>, value: &Value) {
+    fs::write(
+        path.as_ref(),
+        serde_json::to_vec_pretty(value).expect("artifact should serialize"),
+    )
+    .expect("artifact should be written");
+}
+
+fn replace_handoff_evidence_detail(handoff: &mut Value, prefix: &str, replacement: &str) {
+    let evidence_records = handoff["evidence_records"]
+        .as_array_mut()
+        .expect("handoff should persist evidence records");
+    let mut replaced = false;
+    for record in evidence_records.iter_mut() {
+        let matches_prefix = record["detail"]
+            .as_str()
+            .is_some_and(|detail| detail.starts_with(prefix));
+        if matches_prefix {
+            record["detail"] = json!(format!("{prefix}{replacement}"));
+            replaced = true;
+            break;
+        }
+    }
+    assert!(
+        replaced,
+        "handoff should persist an evidence detail starting with '{prefix}' before test tampering"
+    );
+}
+
 fn command_in_dir(binary_path: &str, dir: &Path) -> Command {
     let mut command = Command::new(binary_path);
     command.current_dir(dir);
@@ -1053,6 +1082,292 @@ input: printf \"terminal-read-ok\\n\"";
 }
 
 #[test]
+fn simard_engineer_run_persists_mode_scoped_engineer_handoff_alongside_compatibility_handoff() {
+    let state_root = TempDirGuard::new("simard-cli-engineer-mode-handoff");
+    let repo_root = repo_root();
+    let output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("engineer")
+        .arg("run")
+        .arg("single-process")
+        .arg(&repo_root)
+        .arg(engineer_loop_objective())
+        .arg(state_root.path())
+        .output()
+        .expect("simard engineer run should launch");
+    let rendered = rendered_output(&output);
+
+    assert!(
+        output.status.success(),
+        "engineer run should succeed before mode-scoped handoff assertions:\n{rendered}"
+    );
+    assert!(
+        state_root.path().join("latest_handoff.json").is_file(),
+        "engineer run should keep writing the compatibility handoff snapshot"
+    );
+    assert!(
+        state_root
+            .path()
+            .join("latest_engineer_handoff.json")
+            .is_file(),
+        "engineer run should also persist a mode-scoped engineer handoff so engineer readback stays truthful when a shared state root also contains terminal artifacts"
+    );
+}
+
+#[test]
+fn simard_engineer_terminal_persists_mode_scoped_terminal_handoff_alongside_compatibility_handoff()
+{
+    let state_root = TempDirGuard::new("simard-cli-terminal-mode-handoff");
+    let objective = "\
+working-directory: .\n\
+command: printf \"terminal-mode-scope-ready\\n\"\n\
+wait-for: terminal-mode-scope-ready\n\
+input: printf \"terminal-mode-scope-ok\\n\"";
+    let output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("engineer")
+        .arg("terminal")
+        .arg("single-process")
+        .arg(objective)
+        .arg(state_root.path())
+        .output()
+        .expect("simard engineer terminal should launch");
+    let rendered = rendered_output(&output);
+
+    assert!(
+        output.status.success(),
+        "terminal run should succeed before mode-scoped handoff assertions:\n{rendered}"
+    );
+    assert!(
+        state_root.path().join("latest_handoff.json").is_file(),
+        "terminal run should keep writing the compatibility handoff snapshot"
+    );
+    assert!(
+        state_root
+            .path()
+            .join("latest_terminal_handoff.json")
+            .is_file(),
+        "terminal run should also persist a mode-scoped terminal handoff so terminal readback stays truthful when the same state root later carries engineer artifacts"
+    );
+}
+
+#[test]
+fn simard_engineer_run_and_read_surface_honest_terminal_bridge_context_from_shared_state_root() {
+    let state_root = TempDirGuard::new("simard-cli-terminal-engineer-bridge");
+    let repo_root = repo_root();
+    let terminal_objective = "\
+working-directory: .\n\
+command: printf \"bridge-session-ready\\n\"\n\
+wait-for: bridge-session-ready\n\
+input: printf \"bridge-session-ok\\n\"";
+    let terminal_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("engineer")
+        .arg("terminal")
+        .arg("single-process")
+        .arg(terminal_objective)
+        .arg(state_root.path())
+        .output()
+        .expect("simard engineer terminal should seed a shared state root");
+    let terminal_rendered = rendered_output(&terminal_output);
+
+    assert!(
+        terminal_output.status.success(),
+        "terminal run should succeed before the bridge flow is exercised:\n{terminal_rendered}"
+    );
+
+    let engineer_run_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("engineer")
+        .arg("run")
+        .arg("single-process")
+        .arg(&repo_root)
+        .arg(engineer_loop_objective())
+        .arg(state_root.path())
+        .output()
+        .expect("simard engineer run should launch against the shared state root");
+    let engineer_run_rendered = rendered_output(&engineer_run_output);
+
+    assert!(
+        engineer_run_output.status.success(),
+        "engineer run should succeed before bridge assertions:\n{engineer_run_rendered}"
+    );
+
+    let engineer_read_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("engineer")
+        .arg("read")
+        .arg("single-process")
+        .arg(state_root.path())
+        .output()
+        .expect("simard engineer read should launch against the shared state root");
+    let engineer_read_rendered = rendered_output(&engineer_read_output);
+
+    assert!(
+        engineer_read_output.status.success(),
+        "engineer read should succeed before bridge assertions:\n{engineer_read_rendered}"
+    );
+    for expected in [
+        "Mode boundary: terminal is a bounded local terminal session surface",
+        "Mode boundary: engineer is a separate repo-grounded bounded loop",
+        "Terminal continuity source: shared explicit state-root",
+        "Terminal continuity last output line: bridge-session-ok",
+    ] {
+        assert!(
+            engineer_run_rendered.contains(expected),
+            "engineer run should surface '{expected}' when it picks up terminal continuity from the same local state root:\n{engineer_run_rendered}"
+        );
+        assert!(
+            engineer_read_rendered.contains(expected),
+            "engineer read should keep '{expected}' visible in truthful persisted readback:\n{engineer_read_rendered}"
+        );
+    }
+}
+
+#[test]
+fn simard_engineer_read_prefers_latest_engineer_handoff_over_compatibility_handoff() {
+    let state_root = TempDirGuard::new("simard-cli-engineer-read-prefers-mode-handoff");
+    let repo_root = repo_root();
+    let run_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("engineer")
+        .arg("run")
+        .arg("single-process")
+        .arg(&repo_root)
+        .arg(engineer_loop_objective())
+        .arg(state_root.path())
+        .output()
+        .expect("simard engineer run should seed durable state");
+    let run_rendered = rendered_output(&run_output);
+
+    assert!(
+        run_output.status.success(),
+        "engineer run should succeed before mode-specific readback preference is checked:\n{run_rendered}"
+    );
+
+    let generic_handoff_path = state_root.path().join("latest_handoff.json");
+    let mode_handoff_path = state_root.path().join("latest_engineer_handoff.json");
+    let mut mode_handoff = load_json(&generic_handoff_path);
+    replace_handoff_evidence_detail(
+        &mut mode_handoff,
+        "verification-summary=",
+        "mode-scoped engineer handoff wins",
+    );
+    write_json(&mode_handoff_path, &mode_handoff);
+
+    let read_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("engineer")
+        .arg("read")
+        .arg("single-process")
+        .arg(state_root.path())
+        .output()
+        .expect("simard engineer read should launch against a mode-scoped handoff fixture");
+    let read_rendered = rendered_output(&read_output);
+
+    assert!(
+        read_output.status.success(),
+        "engineer read should succeed when a valid mode-scoped handoff is present:\n{read_rendered}"
+    );
+    assert!(
+        read_rendered.contains("Verification summary: mode-scoped engineer handoff wins"),
+        "engineer read should prefer latest_engineer_handoff.json over the compatibility handoff when both are present:\n{read_rendered}"
+    );
+}
+
+#[test]
+fn simard_engineer_read_fails_closed_on_malformed_mode_scoped_handoff_before_fallback() {
+    let state_root = TempDirGuard::new("simard-cli-engineer-read-malformed-mode-handoff");
+    let repo_root = repo_root();
+    let run_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("engineer")
+        .arg("run")
+        .arg("single-process")
+        .arg(&repo_root)
+        .arg(engineer_loop_objective())
+        .arg(state_root.path())
+        .output()
+        .expect("simard engineer run should seed durable state");
+    let run_rendered = rendered_output(&run_output);
+
+    assert!(
+        run_output.status.success(),
+        "engineer run should succeed before malformed mode-scoped handoff assertions:\n{run_rendered}"
+    );
+
+    fs::write(
+        state_root.path().join("latest_engineer_handoff.json"),
+        "{ not-valid-json",
+    )
+    .expect("malformed mode-scoped handoff fixture should be written");
+
+    let read_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("engineer")
+        .arg("read")
+        .arg("single-process")
+        .arg(state_root.path())
+        .output()
+        .expect("simard engineer read should launch against a malformed mode-scoped handoff");
+    let read_rendered = rendered_output(&read_output);
+
+    assert!(
+        !read_output.status.success(),
+        "engineer read must fail visibly when latest_engineer_handoff.json is malformed instead of silently falling back:\n{read_rendered}"
+    );
+    assert!(
+        read_rendered.contains("latest_engineer_handoff.json"),
+        "engineer read should identify the malformed mode-scoped handoff artifact explicitly:\n{read_rendered}"
+    );
+}
+
+#[test]
+fn simard_engineer_terminal_read_prefers_latest_terminal_handoff_over_compatibility_handoff() {
+    let state_root = TempDirGuard::new("simard-cli-terminal-read-prefers-mode-handoff");
+    let objective = "\
+working-directory: .\n\
+command: printf \"terminal-mode-read-ready\\n\"\n\
+wait-for: terminal-mode-read-ready\n\
+input: printf \"terminal-mode-read-generic\\n\"";
+    let run_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("engineer")
+        .arg("terminal")
+        .arg("single-process")
+        .arg(objective)
+        .arg(state_root.path())
+        .output()
+        .expect("simard engineer terminal should seed durable state");
+    let run_rendered = rendered_output(&run_output);
+
+    assert!(
+        run_output.status.success(),
+        "terminal run should succeed before mode-specific readback preference is checked:\n{run_rendered}"
+    );
+
+    let generic_handoff_path = state_root.path().join("latest_handoff.json");
+    let mode_handoff_path = state_root.path().join("latest_terminal_handoff.json");
+    let mut mode_handoff = load_json(&generic_handoff_path);
+    replace_handoff_evidence_detail(
+        &mut mode_handoff,
+        "terminal-last-output-line=",
+        "terminal-mode-read-mode-scoped",
+    );
+    write_json(&mode_handoff_path, &mode_handoff);
+
+    let read_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("engineer")
+        .arg("terminal-read")
+        .arg("single-process")
+        .arg(state_root.path())
+        .output()
+        .expect(
+            "simard engineer terminal-read should launch against a mode-scoped handoff fixture",
+        );
+    let read_rendered = rendered_output(&read_output);
+
+    assert!(
+        read_output.status.success(),
+        "terminal-read should succeed when a valid mode-scoped handoff is present:\n{read_rendered}"
+    );
+    assert!(
+        read_rendered.contains("Terminal last output line: terminal-mode-read-mode-scoped"),
+        "terminal-read should prefer latest_terminal_handoff.json over the compatibility handoff when both are present:\n{read_rendered}"
+    );
+}
+
+#[test]
 fn simard_engineer_terminal_fails_closed_when_wait_for_output_never_arrives() {
     let state_root = TempDirGuard::new("simard-cli-terminal-wait-timeout");
     let objective = "\
@@ -1297,7 +1612,7 @@ fn simard_engineer_read_rejects_tampered_persisted_objective_metadata() {
         "engineer run should succeed before objective-metadata tampering:\n{run_rendered}"
     );
 
-    let handoff_path = state_root.path().join("latest_handoff.json");
+    let handoff_path = state_root.path().join("latest_engineer_handoff.json");
     let mut handoff = load_json(&handoff_path);
     handoff["session"]["objective"] =
         json!("objective-metadata(chars=9, words=1, lines=1, token=LEAKME)");
@@ -1413,7 +1728,7 @@ goal: Preserve meeting handoff | priority=1 | status=active | rationale=carry de
         "engineer run should succeed before carried-meeting tampering:\n{engineer_rendered}"
     );
 
-    let handoff_path = state_root.path().join("latest_handoff.json");
+    let handoff_path = state_root.path().join("latest_engineer_handoff.json");
     let mut handoff = load_json(&handoff_path);
     let evidence_records = handoff["evidence_records"]
         .as_array_mut()


### PR DESCRIPTION
## Summary
- add a truthful terminal-to-engineer bridge with mode-scoped handoff artifacts
- surface shared state-root continuity in engineer run/read output and document the contract
- cover the new behavior with CLI tests and keep compatibility handoffs in place

## Validation
- cargo test --all-features --locked
- tests/gadugi/terminal-session.sh
- cargo run --quiet --bin simard -- engineer terminal-recipe single-process foundation-check <state-root>
- cargo run --quiet --bin simard -- engineer terminal-read single-process <state-root>
- cargo run --quiet --bin simard -- engineer run single-process . "Continue the bounded local engineer flow honestly after a terminal recipe run" <state-root>
- cargo run --quiet --bin simard -- engineer read single-process <state-root>
- python3 -m pre_commit run --all-files --hook-stage pre-commit
- python3 -m pre_commit run --all-files --hook-stage pre-push