### PR TITLE
Make copilot recipe a real status probe

### DIFF
--- a/Specs/ProductArchitecture.md
+++ b/Specs/ProductArchitecture.md
@@ -258,6 +258,7 @@ The current shipped v1 engineer-loop slice stays intentionally narrow:
 - the primary terminal-run surface now renders that same structured audit trail during execution so operators can follow bounded copilot-style terminal driving without dropping to raw evidence lines
 - operators can now author those bounded interactive terminal sessions either inline or from reusable file-backed recipes, while staying on the same truthful local PTY substrate
 - Simard now also ships named built-in terminal recipes so operators can discover, inspect, and rerun common interactive session flows without inventing ad hoc shell strings or temp files each time
+- the shipped `copilot-status-check` recipe is a truthful bounded local status probe: it only runs `amplihack copilot -- --version`, requires the `GitHub Copilot CLI` version signal, and fails closed instead of simulating an interactive Copilot session
 - those terminal surfaces are now an explicit on-ramp into the repo-grounded engineer loop when operators reuse the same `state-root`, but the later engineer run must still inspect the repository, form its own short plan, execute bounded local work, and verify explicitly
 - the bridge is descriptive continuity only: terminal-derived working directory, transcript snippets, or recipe metadata may inform operator readback, but they must not become authority for engineer action selection or workspace targeting
 

--- a/docs/howto/move-from-terminal-recipes-into-engineer-runs.md
+++ b/docs/howto/move-from-terminal-recipes-into-engineer-runs.md
@@ -53,6 +53,8 @@ The important contract here is visibility:
 - `terminal-recipe-list` shows what Simard ships today
 - `terminal-recipe-show` prints the real bounded recipe contents
 - neither command starts engineer mode or claims repo-grounded verification happened
+- today that includes a minimal `foundation-check` recipe and a bounded `copilot-status-check` recipe that only probes local `amplihack copilot -- --version`
+- the Copilot probe is deliberately fail-closed: missing `amplihack`, a non-zero probe exit, or a missing `GitHub Copilot CLI` version line stops the recipe instead of pretending an interactive Copilot session exists
 
 ## 3. Run the terminal recipe through the canonical CLI
 

--- a/docs/reference/runtime-contracts.md
+++ b/docs/reference/runtime-contracts.md
@@ -255,6 +255,9 @@ This is the discoverable built-in recipe companion to inline and file-backed ter
 - unknown or invalid recipe names fail explicitly
 - `terminal-recipe-show` is read-only and prints the shipped recipe asset contents
 - `terminal-recipe` executes the same bounded `terminal-shell` substrate as `engineer terminal` and `engineer terminal-file`
+- the shipped built-ins currently include `foundation-check` and `copilot-status-check`
+- `copilot-status-check` is a bounded local availability probe only: it runs `amplihack copilot -- --version`, requires the expected `GitHub Copilot CLI` version signal, and fails closed when that signal cannot be produced
+- `copilot-status-check` must not claim interactive Copilot control, remote orchestration, or authenticated GitHub state inspection
 - the selected recipe name is preserved into the terminal continuity summary that later engineer surfaces may render from the same state root
 
 ### Meeting mode

--- a/docs/reference/simard-cli.md
+++ b/docs/reference/simard-cli.md
@@ -288,8 +288,11 @@ Runs one of the built-in named terminal session recipes through the same bounded
 Behavior:
 
 - loads a named recipe from `prompt_assets/simard/terminal_recipes/*.simard-terminal`
+- currently ships `foundation-check` for the minimal bounded PTY sanity path and `copilot-status-check` for a bounded local Copilot wrapper availability probe
 - preserves the same structured terminal audit trail, mode-scoped terminal handoff, and engineer-next-step guidance as the other terminal session surfaces
 - fails explicitly when the requested recipe name is unknown or invalid
+- `copilot-status-check` is intentionally narrow: it only runs the fixed local argv `amplihack copilot -- --version`
+- `copilot-status-check` does not inspect GitHub auth state, does not open an interactive Copilot session, and fails closed when `amplihack` is missing or the expected version signal is absent
 - keeps `simard_operator_probe terminal-recipe-run ...` available for compatibility
 
 Example:
@@ -297,6 +300,7 @@ Example:
 ```bash
 simard engineer terminal-recipe-list
 simard engineer terminal-recipe-show foundation-check
+simard engineer terminal-recipe-show copilot-status-check
 simard engineer terminal-recipe single-process foundation-check "$STATE_ROOT"
 ```
 

--- a/docs/tutorials/run-your-first-local-session.md
+++ b/docs/tutorials/run-your-first-local-session.md
@@ -59,6 +59,7 @@ cargo run --quiet -- engineer terminal-recipe-show foundation-check
 Look for:
 
 - `foundation-check`
+- `copilot-status-check`
 - a real bounded recipe asset with `working-directory:`, `command:`, and `wait-for:` lines
 
 **Checkpoint**: you can discover and inspect the shipped terminal recipes without claiming repo-grounded planning or verification happened yet.

--- a/prompt_assets/simard/terminal_recipes/copilot-status-check.simard-terminal
+++ b/prompt_assets/simard/terminal_recipes/copilot-status-check.simard-terminal
@@ -1,7 +1,5 @@
 working-directory: .
-command: sh -c 'printf "copilot-ready\n"; while IFS= read -r line; do if [ "$line" = "/status" ]; then printf "mode: ready\n"; elif [ "$line" = "/exit" ]; then printf "bye\n"; break; else printf "echo:%s\n" "$line"; fi; done'
-wait-for: copilot-ready
-input: /status
-wait-for: mode: ready
-input: /exit
-wait-for: bye
+wait-timeout-seconds: 30
+command: amplihack copilot -- --version
+wait-for: GitHub Copilot CLI
+input: exit

--- a/src/copilot_status_probe.rs
+++ b/src/copilot_status_probe.rs
@@ -1,0 +1,81 @@
+use std::process::Command;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum CopilotStatusProbeResult {
+    Available {
+        version_line: String,
+    },
+    Unavailable {
+        reason_code: &'static str,
+        detail: String,
+    },
+    Unsupported {
+        reason_code: &'static str,
+        detail: String,
+    },
+}
+
+pub(crate) const COPILOT_STATUS_RECIPE_NAME: &str = "copilot-status-check";
+pub(crate) const COPILOT_STATUS_SIGNAL: &str = "GitHub Copilot CLI";
+const COPILOT_STATUS_COMMAND: &str = "amplihack copilot -- --version";
+
+pub(crate) fn is_copilot_status_recipe(recipe_name: &str) -> bool {
+    recipe_name == COPILOT_STATUS_RECIPE_NAME
+}
+
+pub(crate) fn probe_local_copilot_status() -> CopilotStatusProbeResult {
+    let output = match Command::new("amplihack")
+        .args(["copilot", "--", "--version"])
+        .output()
+    {
+        Ok(output) => output,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return CopilotStatusProbeResult::Unavailable {
+                reason_code: "amplihack-binary-missing",
+                detail: "required executable 'amplihack' is not available on PATH".to_string(),
+            };
+        }
+        Err(error) => {
+            return CopilotStatusProbeResult::Unavailable {
+                reason_code: "copilot-probe-launch-failed",
+                detail: format!("failed to launch '{COPILOT_STATUS_COMMAND}': {error}"),
+            };
+        }
+    };
+
+    let combined_output = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    if !output.status.success() {
+        return CopilotStatusProbeResult::Unavailable {
+            reason_code: "copilot-probe-exit-nonzero",
+            detail: format!(
+                "'{COPILOT_STATUS_COMMAND}' exited with status {}",
+                output
+                    .status
+                    .code()
+                    .map_or_else(|| "signal".to_string(), |code| code.to_string())
+            ),
+        };
+    }
+
+    if let Some(version_line) = combined_output
+        .lines()
+        .map(str::trim)
+        .find(|line| line.contains(COPILOT_STATUS_SIGNAL))
+    {
+        return CopilotStatusProbeResult::Available {
+            version_line: version_line.to_string(),
+        };
+    }
+
+    CopilotStatusProbeResult::Unsupported {
+        reason_code: "copilot-version-signal-missing",
+        detail: format!(
+            "'{COPILOT_STATUS_COMMAND}' succeeded but did not emit the expected '{COPILOT_STATUS_SIGNAL}' version signal"
+        ),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod agent_program;
 pub mod base_types;
 pub mod bootstrap;
+mod copilot_status_probe;
 pub mod engineer_loop;
 pub mod error;
 pub mod evidence;

--- a/src/operator_commands.rs
+++ b/src/operator_commands.rs
@@ -4,6 +4,9 @@ use std::path::{Path, PathBuf};
 
 use crate::base_types::BaseTypeId;
 use crate::bootstrap::validate_state_root;
+use crate::copilot_status_probe::{
+    CopilotStatusProbeResult, is_copilot_status_recipe, probe_local_copilot_status,
+};
 use crate::goals::{FileBackedGoalStore, GoalRecord, GoalStatus, GoalStore};
 use crate::improvements::PersistedImprovementRecord;
 use crate::meetings::PersistedMeetingRecord;
@@ -590,6 +593,7 @@ pub fn run_terminal_recipe_probe(
     recipe_name: &str,
     state_root_override: Option<PathBuf>,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    ensure_terminal_recipe_is_runnable(recipe_name)?;
     let recipe = load_terminal_recipe(recipe_name)?;
     run_terminal_probe(topology, &recipe.contents, state_root_override)
 }
@@ -1092,6 +1096,27 @@ fn prompt_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("prompt_assets")
 }
 
+fn ensure_terminal_recipe_is_runnable(recipe_name: &str) -> crate::SimardResult<()> {
+    if !is_copilot_status_recipe(recipe_name) {
+        return Ok(());
+    }
+
+    match probe_local_copilot_status() {
+        CopilotStatusProbeResult::Available { .. } => Ok(()),
+        CopilotStatusProbeResult::Unavailable {
+            reason_code,
+            detail,
+        }
+        | CopilotStatusProbeResult::Unsupported {
+            reason_code,
+            detail,
+        } => Err(crate::SimardError::ActionExecutionFailed {
+            action: recipe_name.to_string(),
+            reason: format!("{reason_code}: {detail}"),
+        }),
+    }
+}
+
 const TERMINAL_RECIPE_DIRECTORY: &str = "simard/terminal_recipes";
 const TERMINAL_RECIPE_EXTENSION: &str = "simard-terminal";
 
@@ -1573,6 +1598,7 @@ struct TerminalReadView {
     working_directory: String,
     command_count: String,
     wait_count: String,
+    wait_timeout_seconds: String,
     step_count: usize,
     steps: Vec<String>,
     checkpoints: Vec<String>,
@@ -1838,6 +1864,12 @@ impl TerminalReadView {
             )
             .unwrap_or("0")
             .to_string(),
+            wait_timeout_seconds: optional_terminal_evidence_value(
+                &handoff.evidence_records,
+                "terminal-wait-timeout-seconds=",
+            )
+            .unwrap_or("5")
+            .to_string(),
             step_count: terminal_evidence_values(&handoff.evidence_records, "terminal-step-").len(),
             steps: terminal_evidence_values(&handoff.evidence_records, "terminal-step-"),
             checkpoints: terminal_evidence_values(
@@ -1898,6 +1930,7 @@ impl TerminalReadView {
         print_text("Working directory", &self.working_directory);
         print_text("Terminal command count", &self.command_count);
         print_text("Terminal wait count", &self.wait_count);
+        print_text("Terminal wait timeout seconds", &self.wait_timeout_seconds);
         println!("Terminal steps count: {}", self.step_count);
         if self.steps.is_empty() {
             println!("Terminal steps: <none>");

--- a/src/terminal_session.rs
+++ b/src/terminal_session.rs
@@ -25,6 +25,7 @@ enum TerminalStep {
 struct TerminalTurnSpec {
     shell: String,
     working_directory: Option<PathBuf>,
+    wait_timeout: Duration,
     steps: Vec<TerminalStep>,
 }
 
@@ -48,6 +49,7 @@ impl TerminalTurnSpec {
     fn parse(raw: &str, base_type: &str) -> SimardResult<Self> {
         let mut shell = None;
         let mut working_directory = None;
+        let mut wait_timeout = WAIT_STEP_TIMEOUT;
         let mut steps = Vec::new();
 
         for line in raw.lines().map(str::trim).filter(|line| !line.is_empty()) {
@@ -66,6 +68,9 @@ impl TerminalTurnSpec {
                 "shell" => shell = Some(normalize_shell(value, base_type)?),
                 "working-directory" | "working_directory" | "cwd" => {
                     working_directory = Some(PathBuf::from(value))
+                }
+                "wait-timeout-seconds" | "wait_timeout_seconds" | "wait-timeout" => {
+                    wait_timeout = parse_wait_timeout(value, base_type)?
                 }
                 "command" | "input" => steps.push(TerminalStep::Input(value.to_string())),
                 "wait-for" | "wait_for" | "expect" => {
@@ -88,6 +93,7 @@ impl TerminalTurnSpec {
         Ok(Self {
             shell: shell.unwrap_or_else(|| DEFAULT_SHELL.to_string()),
             working_directory,
+            wait_timeout,
             steps,
         })
     }
@@ -130,6 +136,10 @@ pub fn execute_terminal_turn(
         format!("terminal-working-directory={}", working_directory.display()),
         format!("terminal-command-count={input_count}"),
         format!("terminal-wait-count={wait_count}"),
+        format!(
+            "terminal-wait-timeout-seconds={}",
+            spec.wait_timeout.as_secs()
+        ),
         format!("terminal-step-count={}", spec.steps.len()),
         format!("terminal-transcript-preview={transcript_preview}"),
         format!("runtime-node={}", request.runtime_node),
@@ -143,16 +153,17 @@ pub fn execute_terminal_turn(
 
     Ok(BaseTypeOutcome {
         plan: format!(
-            "Open local PTY shell '{}' in '{}' and run {} terminal input line(s) with {} wait checkpoint(s) for '{}' on '{}'.",
+            "Open local PTY shell '{}' in '{}' and run {} terminal input line(s) with {} wait checkpoint(s) and a {}s wait timeout for '{}' on '{}'.",
             spec.shell,
             working_directory.display(),
             input_count,
             wait_count,
+            spec.wait_timeout.as_secs(),
             request.mode,
             request.topology,
         ),
         execution_summary: format!(
-            "Terminal shell session executed {} via selected base type '{}' on implementation '{}' from node '{}' at '{}' with shell '{}' in '{}' across {} terminal input line(s) and {} wait checkpoint(s).",
+            "Terminal shell session executed {} via selected base type '{}' on implementation '{}' from node '{}' at '{}' with shell '{}' in '{}' across {} terminal input line(s), {} wait checkpoint(s), and a {}s wait timeout.",
             objective_summary,
             descriptor.id,
             descriptor.backend.identity,
@@ -162,9 +173,28 @@ pub fn execute_terminal_turn(
             working_directory.display(),
             input_count,
             wait_count,
+            spec.wait_timeout.as_secs(),
         ),
         evidence,
     })
+}
+
+fn parse_wait_timeout(value: &str, base_type: &str) -> SimardResult<Duration> {
+    let seconds = value
+        .parse::<u64>()
+        .map_err(|error| SimardError::AdapterInvocationFailed {
+            base_type: base_type.to_string(),
+            reason: format!("terminal-shell wait timeout '{value}' is invalid: {error}"),
+        })?;
+    if !(1..=60).contains(&seconds) {
+        return Err(SimardError::AdapterInvocationFailed {
+            base_type: base_type.to_string(),
+            reason: format!(
+                "terminal-shell wait timeout '{value}' must be between 1 and 60 seconds"
+            ),
+        });
+    }
+    Ok(Duration::from_secs(seconds))
 }
 
 fn normalize_shell(value: &str, base_type: &str) -> SimardResult<String> {
@@ -303,7 +333,7 @@ fn run_terminal_script(
                     &mut child,
                     &transcript_path,
                     expected,
-                    WAIT_STEP_TIMEOUT,
+                    spec.wait_timeout,
                 )?,
             }
         }
@@ -690,6 +720,17 @@ mod tests {
         );
         assert_eq!(spec.input_count(), 2);
         assert_eq!(spec.wait_count(), 1);
+    }
+
+    #[test]
+    fn parse_terminal_turn_supports_wait_timeout_override() {
+        let spec = TerminalTurnSpec::parse(
+            "working-directory: .\nwait-timeout-seconds: 30\ncommand: printf \"ready\\n\"\nwait-for: ready",
+            "terminal-shell",
+        )
+        .expect("terminal turn should parse");
+
+        assert_eq!(spec.wait_timeout, std::time::Duration::from_secs(30));
     }
 
     #[test]

--- a/tests/simard_cli.rs
+++ b/tests/simard_cli.rs
@@ -7,6 +7,8 @@
 //! and `simard-gym` remain compatibility surfaces for older scripts.
 
 use std::fs;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 use std::sync::{Mutex, OnceLock};
@@ -251,6 +253,31 @@ impl Drop for CleanupDirGuard {
             let _ = fs::remove_dir_all(&self.path);
         }
     }
+}
+
+fn path_with_prepend(prepend: &Path) -> String {
+    let existing = std::env::var_os("PATH").unwrap_or_default();
+    let mut parts = vec![prepend.to_path_buf()];
+    parts.extend(std::env::split_paths(&existing));
+    std::env::join_paths(parts)
+        .expect("PATH entries should be joinable")
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn write_fake_amplihack(binary_dir: &Path, body: &str) -> PathBuf {
+    let binary_path = binary_dir.join("amplihack");
+    fs::write(&binary_path, body).expect("fake amplihack should be written");
+    #[cfg(unix)]
+    {
+        let mut permissions = fs::metadata(&binary_path)
+            .expect("fake amplihack metadata should be readable")
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&binary_path, permissions)
+            .expect("fake amplihack should be executable");
+    }
+    binary_path
 }
 
 #[test]
@@ -994,6 +1021,129 @@ fn simard_engineer_terminal_recipe_runs_builtin_named_recipe_with_probe_parity()
     assert_eq!(
         simard_normalized, legacy_normalized,
         "terminal-recipe should preserve compatibility parity with terminal-recipe-run"
+    );
+}
+
+#[test]
+fn simard_engineer_terminal_recipe_show_surfaces_truthful_copilot_probe_contents() {
+    let output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("engineer")
+        .arg("terminal-recipe-show")
+        .arg("copilot-status-check")
+        .output()
+        .expect("simard engineer terminal-recipe-show copilot-status-check should launch");
+    let rendered = rendered_output(&output);
+
+    assert!(
+        output.status.success(),
+        "terminal-recipe-show should print the truthful Copilot status probe recipe:\n{rendered}"
+    );
+    for expected in [
+        "Terminal recipe: copilot-status-check",
+        "Recipe asset: simard/terminal_recipes/copilot-status-check.simard-terminal",
+        "wait-timeout-seconds: 30",
+        "command: amplihack copilot -- --version",
+        "wait-for: GitHub Copilot CLI",
+    ] {
+        assert!(
+            rendered.contains(expected),
+            "terminal-recipe-show should surface '{expected}':\n{rendered}"
+        );
+    }
+}
+
+#[test]
+fn simard_engineer_terminal_recipe_runs_truthful_copilot_status_probe_with_probe_parity() {
+    let fake_bin = TempDirGuard::new("simard-cli-fake-amplihack");
+    write_fake_amplihack(
+        fake_bin.path(),
+        "#!/usr/bin/env bash\nset -euo pipefail\nif [ \"$#\" -eq 3 ] && [ \"$1\" = \"copilot\" ] && [ \"$2\" = \"--\" ] && [ \"$3\" = \"--version\" ]; then\n  printf 'GitHub Copilot CLI 9.9.9-test.\\n'\n  exit 0\nfi\nprintf 'unexpected args:' >&2\nprintf ' %s' \"$@\" >&2\nprintf '\\n' >&2\nexit 64\n",
+    );
+    let path = path_with_prepend(fake_bin.path());
+    let state_root = TempDirGuard::new("simard-cli-copilot-recipe");
+    let simard_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("engineer")
+        .arg("terminal-recipe")
+        .arg("single-process")
+        .arg("copilot-status-check")
+        .arg(state_root.path())
+        .env("PATH", &path)
+        .output()
+        .expect("simard engineer terminal-recipe copilot-status-check should launch");
+    let simard_rendered = rendered_output(&simard_output);
+
+    assert!(
+        simard_output.status.success(),
+        "copilot-status-check should execute a truthful bounded Copilot version probe:\n{simard_rendered}"
+    );
+    for expected in [
+        "Selected base type: terminal-shell",
+        "Terminal checkpoint 1: GitHub Copilot CLI",
+        "Terminal wait timeout seconds: 30",
+        "GitHub Copilot CLI 9.9.9-test.",
+    ] {
+        assert!(
+            simard_rendered.contains(expected),
+            "copilot-status-check should surface '{expected}':\n{simard_rendered}"
+        );
+    }
+
+    let legacy_output = Command::new(env!("CARGO_BIN_EXE_simard_operator_probe"))
+        .arg("terminal-recipe-run")
+        .arg("single-process")
+        .arg("copilot-status-check")
+        .arg(state_root.path())
+        .env("PATH", &path)
+        .output()
+        .expect("legacy terminal-recipe-run copilot-status-check should launch");
+    let legacy_rendered = rendered_output(&legacy_output);
+
+    assert!(
+        legacy_output.status.success(),
+        "legacy copilot-status-check compatibility path should remain available:\n{legacy_rendered}"
+    );
+    let simard_normalized = replace_output_line_value(
+        &simard_rendered,
+        "Terminal transcript preview: ",
+        "<preview>",
+    );
+    let legacy_normalized = replace_output_line_value(
+        &legacy_rendered,
+        "Terminal transcript preview: ",
+        "<preview>",
+    );
+    assert_eq!(
+        simard_normalized, legacy_normalized,
+        "copilot-status-check should preserve compatibility parity with terminal-recipe-run"
+    );
+}
+
+#[test]
+fn simard_engineer_terminal_recipe_fails_closed_when_amplihack_is_missing() {
+    let empty_bin = TempDirGuard::new("simard-cli-empty-path");
+    let state_root = TempDirGuard::new("simard-cli-copilot-recipe-missing");
+    let output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("engineer")
+        .arg("terminal-recipe")
+        .arg("single-process")
+        .arg("copilot-status-check")
+        .arg(state_root.path())
+        .env("PATH", empty_bin.path())
+        .output()
+        .expect("simard engineer terminal-recipe missing amplihack should launch");
+    let rendered = rendered_output(&output);
+
+    assert!(
+        !output.status.success(),
+        "copilot-status-check must fail closed when amplihack is unavailable:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("amplihack-binary-missing"),
+        "copilot-status-check should explain why the bounded status probe cannot run:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("required executable 'amplihack' is not available on PATH"),
+        "copilot-status-check should preserve the explicit absence detail:\n{rendered}"
     );
 }
 


### PR DESCRIPTION
## Summary
- replace the fake copilot terminal recipe with a bounded real `amplihack copilot -- --version` probe
- add fail-closed preflight checks plus per-recipe terminal wait timeout support
- update tests, docs, and spec text to describe the probe honestly

## Validation
- cargo test --all-features --locked
- python3 -m pre_commit run --all-files --hook-stage pre-commit
- python3 -m pre_commit run --all-files --hook-stage pre-push
- cargo run --quiet -- engineer terminal-recipe single-process copilot-status-check <state-root>
- cargo run --quiet -- engineer terminal-read single-process <same-state-root>