### PR TITLE
Add truthful copilot prompt recipe

### DIFF
--- a/Specs/ProductArchitecture.md
+++ b/Specs/ProductArchitecture.md
@@ -259,6 +259,7 @@ The current shipped v1 engineer-loop slice stays intentionally narrow:
 - operators can now author those bounded interactive terminal sessions either inline or from reusable file-backed recipes, while staying on the same truthful local PTY substrate
 - Simard now also ships named built-in terminal recipes so operators can discover, inspect, and rerun common interactive session flows without inventing ad hoc shell strings or temp files each time
 - the shipped `copilot-status-check` recipe is a truthful bounded local status probe: it only runs `amplihack copilot -- --version`, requires the `GitHub Copilot CLI` version signal, and fails closed instead of simulating an interactive Copilot session
+- the shipped `copilot-prompt-check` recipe is the first truthful interactive Copilot slice: it starts the real `amplihack copilot` CLI, waits for the visible prompt guidance text, sends `/exit`, and requires the resume hint before success
 - those terminal surfaces are now an explicit on-ramp into the repo-grounded engineer loop when operators reuse the same `state-root`, but the later engineer run must still inspect the repository, form its own short plan, execute bounded local work, and verify explicitly
 - the bridge is descriptive continuity only: terminal-derived working directory, transcript snippets, or recipe metadata may inform operator readback, but they must not become authority for engineer action selection or workspace targeting
 

--- a/docs/howto/move-from-terminal-recipes-into-engineer-runs.md
+++ b/docs/howto/move-from-terminal-recipes-into-engineer-runs.md
@@ -53,8 +53,8 @@ The important contract here is visibility:
 - `terminal-recipe-list` shows what Simard ships today
 - `terminal-recipe-show` prints the real bounded recipe contents
 - neither command starts engineer mode or claims repo-grounded verification happened
-- today that includes a minimal `foundation-check` recipe and a bounded `copilot-status-check` recipe that only probes local `amplihack copilot -- --version`
-- the Copilot probe is deliberately fail-closed: missing `amplihack`, a non-zero probe exit, or a missing `GitHub Copilot CLI` version line stops the recipe instead of pretending an interactive Copilot session exists
+- today that includes a minimal `foundation-check` recipe, a bounded `copilot-status-check` recipe that only probes local `amplihack copilot -- --version`, and a bounded `copilot-prompt-check` recipe that starts the real interactive Copilot CLI, waits for the visible prompt text, then exits cleanly via `/exit`
+- both Copilot recipes are deliberately fail-closed: missing `amplihack`, a non-zero version probe exit, or a missing `GitHub Copilot CLI` version line stops the recipe instead of pretending unsupported interactive control exists
 
 ## 3. Run the terminal recipe through the canonical CLI
 

--- a/docs/reference/runtime-contracts.md
+++ b/docs/reference/runtime-contracts.md
@@ -255,9 +255,11 @@ This is the discoverable built-in recipe companion to inline and file-backed ter
 - unknown or invalid recipe names fail explicitly
 - `terminal-recipe-show` is read-only and prints the shipped recipe asset contents
 - `terminal-recipe` executes the same bounded `terminal-shell` substrate as `engineer terminal` and `engineer terminal-file`
-- the shipped built-ins currently include `foundation-check` and `copilot-status-check`
+- the shipped built-ins currently include `foundation-check`, `copilot-status-check`, and `copilot-prompt-check`
 - `copilot-status-check` is a bounded local availability probe only: it runs `amplihack copilot -- --version`, requires the expected `GitHub Copilot CLI` version signal, and fails closed when that signal cannot be produced
 - `copilot-status-check` must not claim interactive Copilot control, remote orchestration, or authenticated GitHub state inspection
+- `copilot-prompt-check` is a bounded interactive prompt reachability check: it launches `amplihack copilot`, waits for the visible prompt guidance text, sends `/exit`, and requires the resume hint before success
+- `copilot-prompt-check` must not claim task execution, slash-command compatibility beyond `/exit`, remote orchestration, or authenticated GitHub state inspection
 - the selected recipe name is preserved into the terminal continuity summary that later engineer surfaces may render from the same state root
 
 ### Meeting mode

--- a/docs/reference/simard-cli.md
+++ b/docs/reference/simard-cli.md
@@ -288,11 +288,13 @@ Runs one of the built-in named terminal session recipes through the same bounded
 Behavior:
 
 - loads a named recipe from `prompt_assets/simard/terminal_recipes/*.simard-terminal`
-- currently ships `foundation-check` for the minimal bounded PTY sanity path and `copilot-status-check` for a bounded local Copilot wrapper availability probe
+- currently ships `foundation-check` for the minimal bounded PTY sanity path, `copilot-status-check` for a bounded local Copilot wrapper availability probe, and `copilot-prompt-check` for a bounded real interactive prompt-start-and-exit path
 - preserves the same structured terminal audit trail, mode-scoped terminal handoff, and engineer-next-step guidance as the other terminal session surfaces
 - fails explicitly when the requested recipe name is unknown or invalid
 - `copilot-status-check` is intentionally narrow: it only runs the fixed local argv `amplihack copilot -- --version`
 - `copilot-status-check` does not inspect GitHub auth state, does not open an interactive Copilot session, and fails closed when `amplihack` is missing or the expected version signal is absent
+- `copilot-prompt-check` is the first truthful interactive Copilot slice: it starts `amplihack copilot`, waits for the real prompt guidance text, sends `/exit`, and waits for the resume hint before succeeding
+- `copilot-prompt-check` still does not submit a task, inspect auth state, or claim general Copilot orchestration beyond prompt reachability and clean exit
 - keeps `simard_operator_probe terminal-recipe-run ...` available for compatibility
 
 Example:
@@ -300,6 +302,7 @@ Example:
 ```bash
 simard engineer terminal-recipe-list
 simard engineer terminal-recipe-show foundation-check
+simard engineer terminal-recipe-show copilot-prompt-check
 simard engineer terminal-recipe-show copilot-status-check
 simard engineer terminal-recipe single-process foundation-check "$STATE_ROOT"
 ```

--- a/docs/tutorials/run-your-first-benchmark-gym.md
+++ b/docs/tutorials/run-your-first-benchmark-gym.md
@@ -57,6 +57,8 @@ Together they cover:
 - `terminal-shell`
 - both `single-process` and loopback `multi-process`
 
+`interactive-terminal-driving` is intentionally a generic terminal-shell benchmark. It validates PTY-driven prompt/input sequencing without pretending to be a real `amplihack copilot` session.
+
 If you need exact legacy output for an older script, `cargo run --quiet --bin simard-gym -- list` still works as a compatibility surface.
 
 ## Step 2: Run the starter benchmark suite

--- a/docs/tutorials/run-your-first-local-session.md
+++ b/docs/tutorials/run-your-first-local-session.md
@@ -59,8 +59,10 @@ cargo run --quiet -- engineer terminal-recipe-show foundation-check
 Look for:
 
 - `foundation-check`
+- `copilot-prompt-check`
 - `copilot-status-check`
 - a real bounded recipe asset with `working-directory:`, `command:`, and `wait-for:` lines
+- `copilot-prompt-check` should show a real `amplihack copilot` launch plus a bounded `/exit`, while `copilot-status-check` remains the narrower `--version` probe
 
 **Checkpoint**: you can discover and inspect the shipped terminal recipes without claiming repo-grounded planning or verification happened yet.
 

--- a/prompt_assets/simard/terminal_recipes/copilot-prompt-check.simard-terminal
+++ b/prompt_assets/simard/terminal_recipes/copilot-prompt-check.simard-terminal
@@ -1,0 +1,6 @@
+working-directory: .
+wait-timeout-seconds: 45
+command: amplihack copilot
+wait-for: Type @ to mention files
+input: /exit
+wait-for: Resume any session with copilot --resume

--- a/src/copilot_status_probe.rs
+++ b/src/copilot_status_probe.rs
@@ -15,12 +15,17 @@ pub(crate) enum CopilotStatusProbeResult {
     },
 }
 
+pub(crate) const COPILOT_PROMPT_RECIPE_NAME: &str = "copilot-prompt-check";
 pub(crate) const COPILOT_STATUS_RECIPE_NAME: &str = "copilot-status-check";
 pub(crate) const COPILOT_STATUS_SIGNAL: &str = "GitHub Copilot CLI";
 const COPILOT_STATUS_COMMAND: &str = "amplihack copilot -- --version";
 
 pub(crate) fn is_copilot_status_recipe(recipe_name: &str) -> bool {
     recipe_name == COPILOT_STATUS_RECIPE_NAME
+}
+
+pub(crate) fn is_copilot_guarded_recipe(recipe_name: &str) -> bool {
+    is_copilot_status_recipe(recipe_name) || recipe_name == COPILOT_PROMPT_RECIPE_NAME
 }
 
 pub(crate) fn probe_local_copilot_status() -> CopilotStatusProbeResult {

--- a/src/gym.rs
+++ b/src/gym.rs
@@ -376,12 +376,12 @@ const BENCHMARK_SCENARIOS: [BenchmarkScenario; 5] = [
     BenchmarkScenario {
         id: "interactive-terminal-driving",
         title: "Interactive terminal driving on terminal-shell",
-        description: "Exercise the engineer identity through the terminal-shell base type by launching a nested interactive child process, waiting for prompts, and sending bounded follow-up inputs like an operator driving a copilot-style terminal tool.",
+        description: "Exercise the engineer identity through the terminal-shell base type by launching a bounded interactive child process, waiting for prompts, and sending follow-up inputs like an operator validating generic PTY-driven control flow.",
         class: BenchmarkClass::SessionQuality,
         identity: "simard-engineer",
         base_type: "terminal-shell",
         topology: RuntimeTopology::SingleProcess,
-        objective: "working-directory: .\ncommand: sh -c 'printf \"copilot-ready\\n\"; while IFS= read -r line; do if [ \"$line\" = \"/status\" ]; then printf \"mode: ready\\n\"; elif [ \"$line\" = \"/exit\" ]; then printf \"bye\\n\"; break; else printf \"echo:%s\\n\" \"$line\"; fi; done'\nwait-for: copilot-ready\ninput: /status\nwait-for: mode: ready\ninput: /exit\nwait-for: bye",
+        objective: "working-directory: .\ncommand: sh -c 'printf \"terminal-ready\\n\"; while IFS= read -r line; do if [ \"$line\" = \"ack\" ]; then printf \"terminal-ack\\n\"; elif [ \"$line\" = \"exit\" ]; then printf \"terminal-bye\\n\"; break; else printf \"echo:%s\\n\" \"$line\"; fi; done'\nwait-for: terminal-ready\ninput: ack\nwait-for: terminal-ack\ninput: exit\nwait-for: terminal-bye",
         expected_min_runtime_evidence: 6,
     },
 ];

--- a/src/operator_commands.rs
+++ b/src/operator_commands.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use crate::base_types::BaseTypeId;
 use crate::bootstrap::validate_state_root;
 use crate::copilot_status_probe::{
-    CopilotStatusProbeResult, is_copilot_status_recipe, probe_local_copilot_status,
+    CopilotStatusProbeResult, is_copilot_guarded_recipe, probe_local_copilot_status,
 };
 use crate::goals::{FileBackedGoalStore, GoalRecord, GoalStatus, GoalStore};
 use crate::improvements::PersistedImprovementRecord;
@@ -1097,7 +1097,7 @@ fn prompt_root() -> PathBuf {
 }
 
 fn ensure_terminal_recipe_is_runnable(recipe_name: &str) -> crate::SimardResult<()> {
-    if !is_copilot_status_recipe(recipe_name) {
+    if !is_copilot_guarded_recipe(recipe_name) {
         return Ok(());
     }
 

--- a/tests/simard_cli.rs
+++ b/tests/simard_cli.rs
@@ -280,6 +280,32 @@ fn write_fake_amplihack(binary_dir: &Path, body: &str) -> PathBuf {
     binary_path
 }
 
+fn fake_amplihack_with_interactive_copilot_body() -> &'static str {
+    r##"#!/usr/bin/env bash
+set -euo pipefail
+if [ "$#" -eq 3 ] && [ "$1" = "copilot" ] && [ "$2" = "--" ] && [ "$3" = "--version" ]; then
+  printf 'GitHub Copilot CLI 9.9.9-test.\n'
+  exit 0
+fi
+if [ "$#" -eq 1 ] && [ "$1" = "copilot" ]; then
+  printf 'GitHub Copilot v1.0.14-test.\n'
+  printf 'Type @ to mention files, # for issues/PRs, / for commands, or ? for shortcuts\n'
+  while IFS= read -r line; do
+    if [ "$line" = "/exit" ]; then
+      printf 'Resume any session with copilot --resume\n'
+      exit 0
+    fi
+    printf 'Unknown command: %s\n' "$line"
+  done
+  exit 0
+fi
+printf 'unexpected args:' >&2
+printf ' %s' "$@" >&2
+printf '\n' >&2
+exit 64
+"##
+}
+
 #[test]
 fn simard_help_surfaces_the_five_product_modes_and_operator_utilities() {
     let output = Command::new(env!("CARGO_BIN_EXE_simard"))
@@ -903,7 +929,8 @@ fn simard_engineer_terminal_recipe_list_and_show_surface_builtin_named_recipes()
         "terminal-recipe-list should expose built-in named session recipes:\n{list_rendered}"
     );
     for expected in [
-        "Terminal recipes: 2",
+        "Terminal recipes: 3",
+        "copilot-prompt-check",
         "foundation-check",
         "copilot-status-check",
         "simard/terminal_recipes/foundation-check.simard-terminal",
@@ -1115,6 +1142,132 @@ fn simard_engineer_terminal_recipe_runs_truthful_copilot_status_probe_with_probe
     assert_eq!(
         simard_normalized, legacy_normalized,
         "copilot-status-check should preserve compatibility parity with terminal-recipe-run"
+    );
+}
+
+#[test]
+fn simard_engineer_terminal_recipe_show_surfaces_truthful_copilot_prompt_contents() {
+    let output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("engineer")
+        .arg("terminal-recipe-show")
+        .arg("copilot-prompt-check")
+        .output()
+        .expect("simard engineer terminal-recipe-show copilot-prompt-check should launch");
+    let rendered = rendered_output(&output);
+
+    assert!(
+        output.status.success(),
+        "terminal-recipe-show should print the truthful Copilot prompt recipe:\n{rendered}"
+    );
+    for expected in [
+        "Terminal recipe: copilot-prompt-check",
+        "Recipe asset: simard/terminal_recipes/copilot-prompt-check.simard-terminal",
+        "wait-timeout-seconds: 45",
+        "command: amplihack copilot",
+        "wait-for: Type @ to mention files",
+        "input: /exit",
+        "wait-for: Resume any session with copilot --resume",
+    ] {
+        assert!(
+            rendered.contains(expected),
+            "terminal-recipe-show should surface '{expected}':\n{rendered}"
+        );
+    }
+}
+
+#[test]
+fn simard_engineer_terminal_recipe_runs_truthful_copilot_prompt_check_with_probe_parity() {
+    let fake_bin = TempDirGuard::new("simard-cli-fake-amplihack-interactive");
+    write_fake_amplihack(
+        fake_bin.path(),
+        fake_amplihack_with_interactive_copilot_body(),
+    );
+    let path = path_with_prepend(fake_bin.path());
+    let state_root = TempDirGuard::new("simard-cli-copilot-prompt-recipe");
+    let simard_output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("engineer")
+        .arg("terminal-recipe")
+        .arg("single-process")
+        .arg("copilot-prompt-check")
+        .arg(state_root.path())
+        .env("PATH", &path)
+        .output()
+        .expect("simard engineer terminal-recipe copilot-prompt-check should launch");
+    let simard_rendered = rendered_output(&simard_output);
+
+    assert!(
+        simard_output.status.success(),
+        "copilot-prompt-check should execute a truthful bounded Copilot prompt flow:\n{simard_rendered}"
+    );
+    for expected in [
+        "Selected base type: terminal-shell",
+        "Terminal checkpoint 1: Type @ to mention files",
+        "Terminal checkpoint 2: Resume any session with copilot --resume",
+        "Terminal wait timeout seconds: 45",
+        "Resume any session with copilot --resume",
+    ] {
+        assert!(
+            simard_rendered.contains(expected),
+            "copilot-prompt-check should surface '{expected}':\n{simard_rendered}"
+        );
+    }
+
+    let legacy_output = Command::new(env!("CARGO_BIN_EXE_simard_operator_probe"))
+        .arg("terminal-recipe-run")
+        .arg("single-process")
+        .arg("copilot-prompt-check")
+        .arg(state_root.path())
+        .env("PATH", &path)
+        .output()
+        .expect("legacy terminal-recipe-run copilot-prompt-check should launch");
+    let legacy_rendered = rendered_output(&legacy_output);
+
+    assert!(
+        legacy_output.status.success(),
+        "legacy copilot-prompt-check compatibility path should remain available:\n{legacy_rendered}"
+    );
+    let simard_normalized = replace_output_line_value(
+        &simard_rendered,
+        "Terminal transcript preview: ",
+        "<preview>",
+    );
+    let legacy_normalized = replace_output_line_value(
+        &legacy_rendered,
+        "Terminal transcript preview: ",
+        "<preview>",
+    );
+    assert_eq!(
+        simard_normalized, legacy_normalized,
+        "copilot-prompt-check should preserve compatibility parity with terminal-recipe-run"
+    );
+}
+
+#[test]
+fn simard_engineer_terminal_recipe_copilot_prompt_check_fails_closed_when_amplihack_is_missing() {
+    let empty_bin = TempDirGuard::new("simard-cli-empty-path-interactive");
+    let state_root = TempDirGuard::new("simard-cli-copilot-prompt-missing");
+    let output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("engineer")
+        .arg("terminal-recipe")
+        .arg("single-process")
+        .arg("copilot-prompt-check")
+        .arg(state_root.path())
+        .env("PATH", empty_bin.path())
+        .output()
+        .expect("simard engineer terminal-recipe missing amplihack should launch");
+    let rendered = rendered_output(&output);
+
+    assert!(
+        !output.status.success(),
+        "copilot-prompt-check must fail closed when amplihack is unavailable:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("amplihack-binary-missing"),
+        "copilot-prompt-check should explain why the bounded interactive recipe cannot run:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("required executable 'amplihack' is not available on PATH"),
+        "copilot-prompt-check should preserve the explicit absence detail:\n{rendered}"
     );
 }
 


### PR DESCRIPTION
## Summary
- add a truthful built-in `copilot-prompt-check` recipe that launches the real local `amplihack copilot` CLI, waits for the visible prompt text, and exits cleanly with `/exit`
- keep `copilot-status-check` as the narrow `--version` probe while reusing the same fail-closed preflight guard for both Copilot recipes
- remove the remaining fake Copilot framing from the benchmark scenario and update tests/docs/spec text to describe the shipped behavior honestly

## Validation
- cargo fmt
- cargo test --test simard_cli simard_engineer_terminal_recipe_ -- --nocapture
- cargo test --test simard_cli simard_gym_run_exercises_the_interactive_terminal_driving_scenario -- --nocapture
- cargo test --all-features --locked
- python3 -m pre_commit run --all-files --hook-stage pre-commit
- python3 -m pre_commit run --all-files --hook-stage pre-push