### PR TITLE
Add low-space Rust build tooling and disk reclaim scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
+/target-shared
 /.claude/runtime/

--- a/docs/howto/reclaim-disk-space-and-run-low-space-rust-builds.md
+++ b/docs/howto/reclaim-disk-space-and-run-low-space-rust-builds.md
@@ -1,0 +1,122 @@
+---
+title: "How to reclaim disk space and run low-space Rust builds"
+description: Preview and remove stale Rust build artifacts, then run Cargo through one shared low-space target directory across Simard worktrees.
+last_updated: 2026-03-31
+review_schedule: as-needed
+owner: simard
+doc_type: howto
+related:
+  - ../index.md
+  - ../tutorials/run-your-first-local-session.md
+  - ../reference/runtime-contracts.md
+---
+
+# How to reclaim disk space and run low-space Rust builds
+
+Simard worktrees can consume a lot of disk because each worktree can accumulate its own `target/` tree.
+
+This repository now ships two explicit helpers:
+
+- `scripts/reclaim-build-space` previews or deletes Rust build artifact directories under the shared Simard git common dir
+- `scripts/cargo-low-space` runs Cargo through one shared `target-shared/` directory, disables incremental builds by default, and strips debug info unless you opt back in
+
+These helpers are local build tooling only. They do not change the runtime contract or the shipped `simard` CLI surface.
+
+## When to use this
+
+Use this guide when:
+
+- `/home` or your workspace disk is filling up
+- you have many Simard worktrees
+- you want one shared Rust target dir instead of per-worktree duplication
+- you need to keep building, testing, or running Simard on a tighter disk budget
+
+## Step 1: Preview reclaimable build artifacts
+
+From any Simard worktree:
+
+```bash
+scripts/reclaim-build-space
+```
+
+By default this prints:
+
+- the repo-level `target/`
+- the repo-level `target-shared/`
+- every per-worktree `target/`
+- except the current worktree `target/`, which it keeps by default
+
+This is preview-only.
+
+## Step 2: Remove the previewed build artifacts
+
+If the preview looks right:
+
+```bash
+scripts/reclaim-build-space --apply
+```
+
+If you also want to remove the current worktree `target/`:
+
+```bash
+scripts/reclaim-build-space --apply --include-current
+```
+
+This only deletes build artifact directories. It does **not** remove whole worktrees, branches, or tracked source files.
+
+## Step 3: Run Cargo through the low-space wrapper
+
+Use the wrapper instead of raw Cargo when you want a shared lower-disk build path:
+
+```bash
+scripts/cargo-low-space test --quiet
+scripts/cargo-low-space run --quiet -- engineer terminal-recipe-list
+```
+
+Default behavior:
+
+- shared target dir: `target-shared/` under the Simard git common root
+- `CARGO_INCREMENTAL=0` unless you already set it explicitly
+- `RUSTFLAGS` gains `-C debuginfo=0` unless you opt back in
+
+That means multiple worktrees can reuse one build output tree instead of each storing their own separate `target/`.
+
+## Optional overrides
+
+Choose a different shared target dir:
+
+```bash
+SIMARD_CARGO_TARGET_DIR=/tmp/simard-target scripts/cargo-low-space test --quiet
+```
+
+Keep debug info:
+
+```bash
+SIMARD_LOW_SPACE_DEBUGINFO=1 scripts/cargo-low-space test --quiet
+```
+
+Show the wrapper's resolved settings:
+
+```bash
+SIMARD_LOW_SPACE_VERBOSE=1 scripts/cargo-low-space test --quiet
+```
+
+## What this does not automate
+
+This guide does **not** automatically remove old worktrees.
+
+Whole-worktree cleanup still needs a judgment call about:
+
+- whether the worktree is clean
+- whether its branch has already been merged or is otherwise no longer needed
+- whether nested dirty worktrees exist underneath it
+
+Use `git worktree list --porcelain`, `git status --porcelain`, and branch/merge checks before removing whole worktrees.
+
+## Suggested operating pattern
+
+For routine low-space work:
+
+1. reclaim stale build artifacts with `scripts/reclaim-build-space`
+2. use `scripts/cargo-low-space ...` for new builds/tests
+3. remove old clean merged worktrees separately when you no longer need them

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,7 @@ Terminal sessions and repo-grounded engineer runs now bridge through one explici
 - [How to move from terminal recipes into engineer runs](./howto/move-from-terminal-recipes-into-engineer-runs.md) - Start with a discoverable terminal recipe, then continue into the repo-grounded engineer loop through the same explicit state root.
 - [Tutorial: Run your first benchmark gym suite](./tutorials/run-your-first-benchmark-gym.md) - Run the shipped starter benchmark suite.
 - [How to configure bootstrap and inspect reflection](./howto/configure-bootstrap-and-inspect-reflection.md) - Bootstrap an explicit runtime selection and inspect the truthful runtime snapshot.
+- [How to reclaim disk space and run low-space Rust builds](./howto/reclaim-disk-space-and-run-low-space-rust-builds.md) - Reclaim stale build artifacts and run Cargo through one shared low-space target dir across worktrees.
 - [How to carry meeting decisions into engineer sessions](./howto/carry-meeting-decisions-into-engineer-sessions.md) - Persist meeting records under a shared state root and confirm later engineer runs carry them forward.
 - [How to inspect meeting records](./howto/inspect-meeting-records.md) - Read back the latest durable meeting record without mutating stored state.
 - [How to inspect improvement-curation state](./howto/inspect-improvement-curation-state.md) - Read back the latest approved, deferred, and promoted improvement state without mutation.
@@ -57,6 +58,8 @@ From the repository root, the corresponding Cargo commands are:
 - `cargo run --quiet -- ...` for `simard`
 - `cargo run --quiet --bin simard_operator_probe -- ...` for `simard_operator_probe`
 - `cargo run --quiet --bin simard-gym -- ...` for `simard-gym`
+
+If you are tight on disk or working across many Simard worktrees, prefer `scripts/cargo-low-space ...` for local builds and use `scripts/reclaim-build-space` to preview or delete stale build artifact directories.
 
 ## Contributor verification
 

--- a/docs/tutorials/run-your-first-local-session.md
+++ b/docs/tutorials/run-your-first-local-session.md
@@ -39,6 +39,8 @@ Use `simard` as the canonical operator-facing CLI. `simard_operator_probe` and `
 
 All runnable examples below use Cargo so they match the current executable surface exactly.
 
+If disk is tight or you are juggling many Simard worktrees, you can swap `cargo ...` for `scripts/cargo-low-space ...`. That wrapper reuses one shared `target-shared/` directory across worktrees and disables the heaviest debug/incremental defaults unless you opt back in. See [How to reclaim disk space and run low-space Rust builds](../howto/reclaim-disk-space-and-run-low-space-rust-builds.md).
+
 ## Step 1: Create one explicit durable state root
 
 Use one state root for the whole tutorial so later steps can read the same meeting, goal, evidence, and review state.

--- a/scripts/cargo-low-space
+++ b/scripts/cargo-low-space
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: scripts/cargo-low-space <cargo-args...>" >&2
+  echo "example: scripts/cargo-low-space test --quiet" >&2
+  exit 64
+fi
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "${script_dir}/.." && pwd)"
+common_dir="$(git -C "${repo_root}" rev-parse --git-common-dir 2>/dev/null || printf '%s/.git' "${repo_root}")"
+common_dir="$(python3 -c 'import os, sys; print(os.path.abspath(sys.argv[1]))' "${common_dir}")"
+common_root="$(dirname -- "${common_dir}")"
+shared_target_dir="${SIMARD_CARGO_TARGET_DIR:-${common_root}/target-shared}"
+
+if [ -z "${CARGO_TARGET_DIR:-}" ]; then
+  export CARGO_TARGET_DIR="${shared_target_dir}"
+fi
+
+if [ -z "${CARGO_INCREMENTAL:-}" ]; then
+  export CARGO_INCREMENTAL=0
+fi
+
+if [ "${SIMARD_LOW_SPACE_DEBUGINFO:-0}" = "0" ]; then
+  case " ${RUSTFLAGS:-} " in
+    *" -C debuginfo=0 "*) ;;
+    *)
+      export RUSTFLAGS="${RUSTFLAGS:+${RUSTFLAGS} }-C debuginfo=0"
+      ;;
+  esac
+fi
+
+if [ "${SIMARD_LOW_SPACE_VERBOSE:-0}" = "1" ]; then
+  {
+    echo "cargo-low-space:"
+    echo "  repo-root: ${repo_root}"
+    echo "  common-root: ${common_root}"
+    echo "  CARGO_TARGET_DIR: ${CARGO_TARGET_DIR}"
+    echo "  CARGO_INCREMENTAL: ${CARGO_INCREMENTAL}"
+    echo "  RUSTFLAGS: ${RUSTFLAGS:-<unset>}"
+  } >&2
+fi
+
+exec cargo "$@"

--- a/scripts/reclaim-build-space
+++ b/scripts/reclaim-build-space
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+usage: scripts/reclaim-build-space [--apply] [--include-current]
+
+Preview or remove Rust build artifact directories under the shared Simard git common dir.
+
+By default this script:
+  - previews candidate directories only
+  - includes the repo-level target/ and target-shared/
+  - includes per-worktree target/ directories
+  - keeps the current worktree target/ unless --include-current is passed
+
+Use --apply to delete the listed directories.
+EOF
+}
+
+apply=0
+include_current=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --apply)
+      apply=1
+      ;;
+    --include-current)
+      include_current=1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 64
+      ;;
+  esac
+  shift
+done
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "${script_dir}/.." && pwd)"
+common_dir="$(git -C "${repo_root}" rev-parse --git-common-dir 2>/dev/null || printf '%s/.git' "${repo_root}")"
+common_dir="$(python3 -c 'import os, sys; print(os.path.abspath(sys.argv[1]))' "${common_dir}")"
+common_root="$(dirname -- "${common_dir}")"
+current_root="$(git -C "${repo_root}" rev-parse --show-toplevel 2>/dev/null || printf '%s' "${repo_root}")"
+
+mapfile -t candidates < <(
+  {
+    printf '%s\n' "${common_root}/target"
+    printf '%s\n' "${common_root}/target-shared"
+    find "${common_root}/worktrees" -type d -name target -print 2>/dev/null
+  } | awk '!seen[$0]++'
+)
+
+selected=()
+total_k=0
+for path in "${candidates[@]}"; do
+  [ -d "${path}" ] || continue
+  if [ "${include_current}" -ne 1 ] && [ "${path}" = "${current_root}/target" ]; then
+    continue
+  fi
+  size_k="$(du -sk "${path}" | awk '{print $1}')"
+  total_k=$((total_k + size_k))
+  selected+=("${path}")
+done
+
+if [ "${#selected[@]}" -eq 0 ]; then
+  echo "No build artifact directories matched the current selection." >&2
+  exit 0
+fi
+
+echo "Build artifact directories:"
+for path in "${selected[@]}"; do
+  printf '  %8s  %s\n' "$(du -sh "${path}" | awk '{print $1}')" "${path}"
+done
+printf '  %8s  total\n' "$(numfmt --to=iec --suffix=B "$((total_k * 1024))")"
+
+if [ "${apply}" -ne 1 ]; then
+  echo
+  echo "Preview only. Re-run with --apply to delete these directories." >&2
+  exit 0
+fi
+
+for path in "${selected[@]}"; do
+  rm -rf -- "${path}"
+done
+
+echo
+echo "Removed ${#selected[@]} build artifact director$( [ "${#selected[@]}" -eq 1 ] && printf 'y' || printf 'ies' )." >&2


### PR DESCRIPTION
## Summary

- Add `scripts/cargo-low-space` — runs Cargo through one shared `target-shared/` directory across worktrees, disables incremental builds and debug info by default to save disk
- Add `scripts/reclaim-build-space` — previews or deletes stale Rust build artifact directories under the shared Simard git common dir
- Add howto doc and update docs index + first-session tutorial with cross-references
- Update `.gitignore` for `/target-shared`

Resolves #86 disk recovery follow-up: these scripts codify the manual cleanup that recovered `/home` from 92% used (16G free) to 51% used (92G free).

## Test plan

- [x] `SIMARD_LOW_SPACE_VERBOSE=1 scripts/cargo-low-space test --quiet` passes and uses shared target dir
- [x] `scripts/reclaim-build-space` previews candidate directories correctly
- [x] All existing tests pass with shared target dir
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)