### PR TITLE
docs: add architecture documentation and mkdocs site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,57 @@
+name: docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'Specs/**'
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'Specs/**'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install mkdocs-material
+        run: pip install mkdocs-material pymdown-extensions
+
+      - name: Build documentation
+        run: mkdocs build --strict
+
+      - name: Upload artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/
+
+  # Deployment is disabled until ready to publish publicly.
+  # Uncomment the deploy job below when ready.
+  #
+  # deploy:
+  #   needs: build
+  #   if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     pages: write
+  #     id-token: write
+  #   environment:
+  #     name: github-pages
+  #     url: ${{ steps.deployment.outputs.page_url }}
+  #   steps:
+  #     - name: Deploy to GitHub Pages
+  #       id: deployment
+  #       uses: actions/deploy-pages@v4

--- a/docs/architecture/agent-composition.md
+++ b/docs/architecture/agent-composition.md
@@ -1,0 +1,174 @@
+---
+title: Agent Composition
+description: How Simard composes multiple agent identities, spawns subordinates, and coordinates work through the hive mind.
+last_updated: 2026-03-31
+owner: simard
+doc_type: concept
+---
+
+# Agent Composition
+
+Simard is not a single monolithic agent. She is a **composite identity** that can spawn subordinate agents, delegate goals, and coordinate work through shared memory.
+
+## Design Principles
+
+1. **Identity and runtime are different things** — what an agent is (identity) vs. how it runs (topology)
+2. **Composition outlives topology** — the same composite identity works local or distributed
+3. **Communication through memory** — agents share knowledge via the hive, not raw IPC
+4. **Explicit supervision** — parent monitors subordinates with heartbeats and crash recovery
+
+## Identity Composition
+
+An `IdentityManifest` defines a single agent's capabilities. A `CompositeIdentity` nests multiple manifests with role delegation:
+
+```mermaid
+graph TB
+    subgraph "Simard (Composite)"
+        SM[simard-main<br/>IdentityManifest]
+        SE[simard-engineer<br/>subordinate]
+        SR[simard-reviewer<br/>subordinate]
+        SG[simard-gym<br/>subordinate]
+    end
+
+    SM -->|delegates engineering| SE
+    SM -->|delegates review| SR
+    SM -->|delegates eval| SG
+```
+
+Each subordinate receives:
+- Its own `agent_name` for memory isolation
+- A specific `OperatingMode` (Engineer, Meeting, Gym)
+- A bounded goal
+- A dedicated git worktree (no shared working directories)
+
+## Supervisor Protocol
+
+### Goal Assignment
+
+Parent assigns goals through semantic memory in the shared hive:
+
+```json
+{
+  "concept": "subordinate_goal:simard-sub-001",
+  "content": "fix the null check in auth.rs and verify with tests",
+  "confidence": 1.0
+}
+```
+
+Subordinate reads its goal on startup via `search_facts("subordinate_goal:{my_id}")`.
+
+### Progress Reporting
+
+Subordinates report progress as semantic facts:
+
+```json
+{
+  "concept": "subordinate_progress:simard-sub-001",
+  "content": {
+    "sub_id": "simard-sub-001",
+    "phase": "execution",
+    "steps_completed": 3,
+    "steps_total": 7,
+    "last_action": "edited src/auth.rs",
+    "heartbeat_epoch": 1743400000,
+    "outcome": null
+  },
+  "confidence": 1.0
+}
+```
+
+### Liveness Detection
+
+```mermaid
+flowchart LR
+    A[Parent polls<br/>heartbeat_epoch] --> B{Stale > 120s?}
+    B -->|No| A
+    B -->|Yes| C[Count: +1]
+    C --> D{3 stale?}
+    D -->|No| A
+    D -->|Yes| E[Kill subprocess]
+    E --> F{Retries < 2?}
+    F -->|Yes| G[Retry with new subordinate]
+    F -->|No| H[Escalate to operator]
+```
+
+- Parent checks `heartbeat_epoch` every 30 seconds
+- 3 consecutive stale heartbeats (>120s each) → kill and mark `abandoned`
+- At most 2 retries per goal, then escalate
+- Subordinate's partial work persists in its memory for forensic inspection
+
+### Crash Recovery
+
+When a subordinate crashes:
+
+1. Parent detects via `waitpid` / SIGCHLD
+2. Marks goal as `crashed` with exit code
+3. Inspects subordinate's episodic memory to understand what happened
+4. Decides: retry, reassign, or escalate
+
+### Recursion Limit
+
+- `SIMARD_MAX_SUBORDINATE_DEPTH=3`
+- Each subordinate inherits `depth + 1`
+- At depth limit, subordinate cannot spawn further subordinates
+
+## File Isolation
+
+Each subordinate works in its own git worktree:
+
+```
+/home/azureuser/src/Simard/
+├── worktrees/
+│   ├── simard-sub-001/    ← subordinate 1's workspace
+│   ├── simard-sub-002/    ← subordinate 2's workspace
+│   └── ...
+```
+
+No two subordinates share a worktree. This prevents merge conflicts and allows concurrent file editing.
+
+## The Self-Building Loop
+
+When Simard reaches Phase 6, composition enables the self-improvement cycle:
+
+```mermaid
+sequenceDiagram
+    participant Main as simard-main
+    participant Gym as simard-gym
+    participant Eng as simard-engineer
+    participant Rev as simard-reviewer
+
+    Main->>Gym: "run L1 benchmark, report score"
+    Gym-->>Main: score: 83%
+    Main->>Main: analyze failures, propose improvement
+    Main->>Eng: "implement improvement in worktree"
+    Eng-->>Main: patch ready, tests pass
+    Main->>Rev: "review the patch"
+    Rev-->>Main: approved, no regressions
+    Main->>Gym: "re-run L1 benchmark"
+    Gym-->>Main: score: 87% (+4%)
+    Main->>Main: commit improvement, self-relaunch
+```
+
+## Future: Distributed Composition
+
+The same composition model works across machines via azlin VMs:
+
+```mermaid
+graph TB
+    subgraph "Local Machine"
+        SM[simard-main]
+    end
+    subgraph "Azure VM 1"
+        S1[simard-sub-001<br/>via azlin]
+    end
+    subgraph "Azure VM 2"
+        S2[simard-sub-002<br/>via azlin]
+    end
+
+    SM -->|"azlin deploy + goal"| S1
+    SM -->|"azlin deploy + goal"| S2
+    S1 -->|"hive facts"| SM
+    S2 -->|"hive facts"| SM
+```
+
+Communication still happens through the hive mind — the parent just deploys the subordinate binary to a remote VM instead of a local process. Memory replication ensures the subordinate can access relevant context.

--- a/docs/architecture/bridge-pattern.md
+++ b/docs/architecture/bridge-pattern.md
@@ -1,0 +1,179 @@
+---
+title: Bridge Pattern
+description: How Simard communicates with the Python ecosystem through subprocess bridges with JSON-line protocol and circuit breaker fault tolerance.
+last_updated: 2026-03-31
+owner: simard
+doc_type: concept
+---
+
+# Bridge Pattern
+
+Simard is Rust. The amplihack ecosystem (memory-lib, kg-packs, agent-eval) is Python. Rather than rewrite the ecosystem in Rust or use FFI, Simard communicates through **subprocess bridges** — Python processes that speak a simple JSON-line protocol on stdin/stdout.
+
+## Why Bridges?
+
+| Approach | Pros | Cons |
+|----------|------|------|
+| **PyO3 FFI** | Zero-copy, native speed | Tight coupling, GIL contention, complex build |
+| **HTTP/gRPC** | Standard, debuggable | Server lifecycle, port management, overhead |
+| **Subprocess bridges** | Simple, isolated, no dependencies | Serialization overhead, process lifecycle |
+
+Bridges win because:
+- The Python ecosystem already works — we don't want to port 3,000+ LOC of production Python code
+- Kuzu and LadybugDB have Python bindings but no Rust bindings
+- Process isolation means a Python crash can't take down Simard
+- The circuit breaker pattern handles intermittent failures gracefully
+
+## Wire Protocol
+
+Each bridge speaks newline-delimited JSON. One request per line on stdin, one response per line on stdout.
+
+### Request Format
+
+```json
+{"id": "01970b2f-...", "method": "memory.store_fact", "params": {"concept": "cargo test", "content": "runs all workspace tests", "confidence": 0.9}}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | string | yes | UUIDv7 for request-response matching |
+| `method` | string | yes | Dotted method name (e.g., `memory.store_fact`) |
+| `params` | object | yes | Method-specific parameters |
+
+### Response Format (success)
+
+```json
+{"id": "01970b2f-...", "result": {"fact_id": "sem_01abc..."}}
+```
+
+### Response Format (error)
+
+```json
+{"id": "01970b2f-...", "error": {"code": -32601, "message": "method 'nonexistent' is not registered"}}
+```
+
+| Error Code | Meaning |
+|-----------|---------|
+| `-32601` | Method not found |
+| `-32603` | Internal server error |
+| `-32000` | Timeout |
+| `-32001` | Transport error |
+
+## Rust-Side Architecture
+
+### BridgeTransport Trait
+
+```rust
+pub trait BridgeTransport: Send + Sync {
+    fn call(&self, request: BridgeRequest) -> SimardResult<BridgeResponse>;
+    fn descriptor(&self) -> BackendDescriptor;
+    fn health(&self) -> SimardResult<BridgeHealth>;  // default implementation
+}
+```
+
+### Implementations
+
+| Type | Purpose |
+|------|---------|
+| `SubprocessBridgeTransport` | Spawns Python, manages stdin/stdout, kills on drop |
+| `InMemoryBridgeTransport` | Handler function for unit tests, no Python needed |
+| `CircuitBreakerTransport<T>` | Wraps any transport with fault tolerance |
+
+### Circuit Breaker
+
+```mermaid
+stateDiagram-v2
+    [*] --> Closed
+    Closed --> Open: 3 consecutive failures
+    Open --> HalfOpen: cooldown elapsed (30s)
+    HalfOpen --> Closed: probe succeeds
+    HalfOpen --> Open: probe fails
+```
+
+- **Closed**: Normal operation, calls pass through
+- **Open**: Calls rejected immediately with `BridgeCircuitOpen`
+- **Half-Open**: One probe call allowed; success closes, failure reopens
+
+Only transport-level errors (code `-32001`) trip the circuit. Application errors (method not found, internal) do not.
+
+## Python-Side Architecture
+
+### BridgeServer Base Class
+
+```python
+class BridgeServer:
+    def __init__(self, server_name: str) -> None
+    def register(self, method: str, handler: Callable) -> None
+    def run(self) -> None  # stdin/stdout loop
+```
+
+Each bridge server extends `BridgeServer` and registers method handlers:
+
+```python
+class SimardMemoryBridge(BridgeServer):
+    def __init__(self, agent_name, db_path):
+        super().__init__("simard-memory")
+        self.adapter = CognitiveAdapter(agent_name, db_path)
+        self.register("memory.store_fact", self.handle_store_fact)
+        # ... register all memory methods
+
+    def handle_store_fact(self, params):
+        fact_id = self.adapter.store_fact(
+            context=params["concept"],
+            fact=params["content"],
+            confidence=params.get("confidence", 0.9),
+        )
+        return {"fact_id": fact_id}
+```
+
+The built-in `bridge.health` method is always registered and returns `{"server_name": "...", "healthy": true}`.
+
+## Error Handling
+
+### Simard-Side Errors
+
+| Error Type | When | Recovery |
+|-----------|------|----------|
+| `BridgeSpawnFailed` | Python binary not found | Check PATH, install python3 |
+| `BridgeTransportError` | Stdin/stdout broken, process exited | Circuit breaker opens, auto-respawn on next call |
+| `BridgeProtocolError` | Malformed JSON, type mismatch | Log and surface to operator |
+| `BridgeCallFailed` | Method returned error payload | Surface to caller with method context |
+| `BridgeCircuitOpen` | Too many recent failures | Wait for cooldown, check bridge health |
+
+### Data Loss Prevention
+
+- Memory writes are idempotent (Kuzu `node_id` is primary key)
+- Python bridge wraps each write in a Kuzu transaction
+- If bridge dies mid-write, the transaction rolls back
+- On reconnect, Simard re-issues the last failed write
+
+## Testing
+
+### Unit Tests (no Python needed)
+
+```rust
+let transport = InMemoryBridgeTransport::echo("test");
+let response = transport.call(health_request()).unwrap();
+assert!(response.result.is_some());
+```
+
+### Integration Tests (real Python subprocess)
+
+```rust
+let transport = SubprocessBridgeTransport::new(
+    "echo-test",
+    "python/bridge_server.py",
+    vec![],
+    Duration::from_secs(5),
+);
+let health = transport.health().expect("bridge should be healthy");
+assert_eq!(health.server_name, "echo");
+```
+
+### Feral Tests
+
+- Kill bridge mid-request → `BridgeTransportError`
+- Send malformed JSON → `BridgeProtocolError`
+- Bridge script doesn't exist → `BridgeSpawnFailed` or `BridgeTransportError`
+- Bridge exits immediately → EOF detection
+- 3 consecutive transport failures → circuit opens

--- a/docs/architecture/cognitive-memory.md
+++ b/docs/architecture/cognitive-memory.md
@@ -1,0 +1,237 @@
+---
+title: Cognitive Memory Architecture
+description: How Simard uses the 6-type cognitive psychology memory model from amplihack-memory-lib, including the hive mind for multi-agent knowledge sharing.
+last_updated: 2026-03-31
+owner: simard
+doc_type: concept
+---
+
+# Cognitive Memory Architecture
+
+Simard's memory is not a flat key-value store. It uses six distinct memory types modeled after cognitive psychology, provided by `amplihack-memory-lib` and accessed through the [bridge pattern](bridge-pattern.md).
+
+## The Six Memory Types
+
+### Sensory Memory
+
+Raw, short-lived observations that auto-expire.
+
+- **Duration**: Configurable TTL (default 300 seconds)
+- **Use**: Buffer incoming PTY output, objective text, error messages
+- **Modalities**: `objective`, `pty_output`, `error`, `log`
+- **Promotion**: Important observations can be "attended to" and promoted to episodic memory
+
+```
+Session starts → record_sensory("objective", "fix the bug in auth.rs", ttl=600)
+PTY output    → record_sensory("pty_output", "cargo test ... 3 failed", ttl=300)
+```
+
+### Working Memory
+
+Bounded active task context with a 20-slot capacity limit.
+
+- **Duration**: Task-scoped (cleared when task completes)
+- **Slot types**: `goal`, `constraint`, `context`, `plan`
+- **Eviction**: When full, lowest-relevance slots are pushed out
+- **Use**: Hold the current task goal, plan steps, and execution state
+
+```
+Intake     → push_working("goal", "fix the bug in auth.rs", task_id, relevance=1.0)
+Planning   → push_working("plan", "1. read auth.rs 2. find the null check", task_id)
+Execution  → push_working("context", "auth.rs:42 has the bad unwrap", task_id)
+Complete   → clear_working(task_id)
+```
+
+### Episodic Memory
+
+Autobiographical events — what happened during each session.
+
+- **Duration**: Long-term (persists across restarts)
+- **Content**: Session transcripts, action logs, outcomes
+- **Temporal ordering**: Monotonically increasing index
+- **Consolidation**: Old episodes can be summarized into `ConsolidatedEpisode` nodes
+
+```
+Reflection → store_episode("Session: fixed auth.rs null check, tests pass", "session")
+Periodic   → consolidate_episodes(batch_size=10)  # summarizes oldest 10 episodes
+```
+
+### Semantic Memory
+
+Extracted facts and knowledge with confidence scores.
+
+- **Duration**: Long-term
+- **Content**: Distilled facts about the codebase, tools, patterns
+- **Confidence**: 0.0-1.0, decays over time (1% per hour)
+- **Edges**: `SIMILAR_TO` edges link related facts (Jaccard similarity ≥ 0.3)
+- **Search**: Keyword-based with n-gram reranking
+
+```
+Reflection → store_fact("auth.rs", "uses unwrap() on line 42 which can panic", 0.9, source_id=episode_id)
+Retrieval  → search_facts("auth error handling", limit=10)
+```
+
+### Procedural Memory
+
+Reusable step-by-step action sequences.
+
+- **Duration**: Long-term, strengthens with use
+- **Content**: Named procedures with ordered steps and prerequisites
+- **Usage tracking**: `usage_count` increments on each recall
+- **Use**: Encode successful patterns for reuse
+
+```
+After success → store_procedure("fix-and-verify", ["read file", "edit", "cargo test", "commit"])
+Before task   → recall_procedure("how to fix a bug", limit=5)
+```
+
+### Prospective Memory
+
+Future-oriented trigger-action pairs.
+
+- **Duration**: Until triggered or resolved
+- **Content**: Description, trigger condition, action, priority
+- **Status**: `pending` → `triggered` → `resolved`
+- **Use**: Schedule future actions based on conditions
+
+```
+Planning   → store_prospective("re-run gym after self-improve", "self_improve_complete", "run_gym_suite", priority=2)
+After work → check_triggers("self_improve_complete: score improved 3%")  # returns triggered items
+```
+
+## Session Lifecycle Mapping
+
+Each session phase maps to specific memory operations:
+
+```mermaid
+flowchart LR
+    subgraph Intake
+        S1[record_sensory<br/>objective]
+        W1[push_working<br/>goal]
+    end
+    subgraph Preparation
+        F1[search_facts]
+        T1[check_triggers]
+        W2[push_working<br/>context]
+    end
+    subgraph Planning
+        P1[recall_procedure]
+        W3[push_working<br/>plan]
+    end
+    subgraph Execution
+        S2[record_sensory<br/>pty_output]
+        W4[push_working<br/>state]
+    end
+    subgraph Reflection
+        E1[store_episode]
+        F2[store_fact]
+        PR1[store_procedure]
+        PS1[store_prospective]
+    end
+    subgraph Persistence
+        C1[consolidate_episodes]
+        CW[clear_working]
+        PE[prune_expired_sensory]
+    end
+
+    Intake --> Preparation --> Planning --> Execution --> Reflection --> Persistence
+```
+
+| Phase | Memory Operations |
+|-------|------------------|
+| **Intake** | `record_sensory(objective)`, `push_working(goal)` |
+| **Preparation** | `search_facts(objective)`, `check_triggers(objective)`, `push_working(context)` |
+| **Planning** | `recall_procedure(task_domain)`, `push_working(plan)` |
+| **Execution** | `record_sensory(pty_output)`, `push_working(state)` |
+| **Reflection** | `store_episode(transcript)`, `store_fact(extracted)`, `store_procedure(successful_sequence)`, `store_prospective(future_intention)` |
+| **Persistence** | `consolidate_episodes(10)`, `clear_working(task_id)`, `prune_expired_sensory()` |
+
+## Hive Mind Integration
+
+When multiple Simard processes run concurrently (parent + subordinates), they share knowledge through the hive mind:
+
+```mermaid
+graph TB
+    subgraph "Agent: simard-main"
+        LM1[Local Memory<br/>Kuzu agent_id=simard-main]
+    end
+    subgraph "Agent: simard-sub-001"
+        LM2[Local Memory<br/>Kuzu agent_id=simard-sub-001]
+    end
+    subgraph "Shared Hive"
+        HG[Hive Graph<br/>Quality Gate ≥ 0.3]
+    end
+
+    LM1 -->|promote_fact| HG
+    LM2 -->|promote_fact| HG
+    HG -->|federated_query| LM1
+    HG -->|federated_query| LM2
+```
+
+- Each agent has its own `agent_name` → row-level isolation in Kuzu
+- Facts are auto-promoted to the shared hive when quality score ≥ 0.3
+- Cross-agent queries merge local + hive results via Reciprocal Rank Fusion (RRF)
+- CRDTs (ORSet, LWWRegister) ensure eventual consistency
+- Gossip protocol disseminates high-confidence facts across agents
+
+### Quality Gates
+
+| Gate | Threshold | Purpose |
+|------|-----------|---------|
+| Quality score | ≥ 0.3 | Prevents low-quality facts from reaching the hive |
+| Confidence gate | ≥ 0.3 | Filters out low-confidence hive results during search |
+| Broadcast threshold | ≥ 0.9 | Only very high confidence facts broadcast to all children |
+
+### Confidence Decay
+
+Fact confidence decays exponentially over time:
+
+```
+confidence_new = confidence_original * exp(-0.01 * elapsed_hours)
+```
+
+This creates a natural recency bias without deleting old knowledge. A fact with confidence 0.8 decays to ~0.72 after 10 hours, ~0.58 after 50 hours.
+
+## Kuzu Graph Schema
+
+The Python `CognitiveMemory` class manages seven node tables and five relationship tables in Kuzu:
+
+### Node Tables
+
+| Table | Key Fields |
+|-------|-----------|
+| `SensoryMemory` | node_id, agent_id, modality, raw_data, observation_order, expires_at |
+| `WorkingMemory` | node_id, agent_id, slot_type, content, relevance, task_id |
+| `EpisodicMemory` | node_id, agent_id, content, source_label, temporal_index, compressed |
+| `SemanticMemory` | node_id, agent_id, concept, content, confidence, source_id, tags |
+| `ProceduralMemory` | node_id, agent_id, name, steps, prerequisites, usage_count |
+| `ProspectiveMemory` | node_id, agent_id, desc_text, trigger_condition, action_on_trigger, status, priority |
+| `ConsolidatedEpisode` | node_id, agent_id, summary, original_count |
+
+### Relationship Tables
+
+| Relationship | From → To | Purpose |
+|-------------|-----------|---------|
+| `SIMILAR_TO` | SemanticMemory → SemanticMemory | Fact similarity edges |
+| `DERIVES_FROM` | SemanticMemory → EpisodicMemory | Provenance tracking |
+| `PROCEDURE_DERIVES_FROM` | ProceduralMemory → EpisodicMemory | Procedure provenance |
+| `CONSOLIDATES` | ConsolidatedEpisode → EpisodicMemory | Consolidation links |
+| `ATTENDED_TO` | SensoryMemory → EpisodicMemory | Sensory promotion |
+
+## Wire Protocol Summary
+
+All memory operations go through the bridge as JSON-RPC-style calls. See [Bridge Wire Protocol](../reference/bridge-wire-protocol.md) for the complete specification.
+
+Key methods:
+
+| Method | Purpose |
+|--------|---------|
+| `memory.record_sensory` | Buffer a raw observation |
+| `memory.push_working` | Add a slot to working memory |
+| `memory.store_episode` | Record a session transcript |
+| `memory.store_fact` | Store a semantic fact with confidence |
+| `memory.search_facts` | Search by keywords with confidence filter |
+| `memory.store_procedure` | Store a reusable action sequence |
+| `memory.store_prospective` | Store a future trigger-action pair |
+| `memory.consolidate_episodes` | Summarize old episodes |
+| `memory.check_triggers` | Check if any prospective memories match |

--- a/docs/architecture/implementation-plan.md
+++ b/docs/architecture/implementation-plan.md
@@ -1,0 +1,82 @@
+---
+title: Implementation Plan
+description: Phased roadmap from current state to Simard building Simard, with parallelism map and quality gates.
+last_updated: 2026-03-31
+owner: simard
+doc_type: reference
+---
+
+# Implementation Plan
+
+The full technical plan lives at [`Specs/IMPLEMENTATION_PLAN.md`](../../Specs/IMPLEMENTATION_PLAN.md) in the repository root. This page provides a high-level overview.
+
+## Parallelism Map
+
+```mermaid
+gantt
+    title Simard Implementation Phases
+    dateFormat YYYY-MM-DD
+    axisFormat %b %d
+
+    section Foundation
+    Phase 0 - Bridge Infrastructure       :done, p0, 2026-03-31, 1d
+
+    section Memory & Knowledge
+    Phase 1 - Cognitive Memory            :active, p1, after p0, 3d
+    Phase 2 - Knowledge Packs             :active, p2, after p0, 3d
+
+    section Adapters
+    Phase 3 - Real Base Type Adapter      :p3, after p1, 3d
+
+    section Eval & Composition
+    Phase 4 - Gym & Benchmarks            :p4, after p3, 3d
+    Phase 5 - Agent Composition           :p5, after p3, 3d
+
+    section Autonomy
+    Phase 6 - Self-Improvement            :p6, after p4, 3d
+    Phase 7 - Remote Orchestration        :p7, after p5, 3d
+    Phase 8 - Meeting/Goals/Identity      :p8, after p5, 3d
+
+    section Continuous
+    Phase 9 - OODA Loop                   :p9, after p6, 3d
+```
+
+## Phase Summary
+
+| Phase | Deliverable | Modules | LOC Budget | Status |
+|-------|------------|---------|-----------|--------|
+| 0 | Bridge infrastructure | 5 | ~1,400 | Merged (PR #89) |
+| 1 | Cognitive memory via amplihack-memory-lib | 6 | ~2,150 | In progress |
+| 2 | Knowledge packs via agent-kgpacks | 4 | ~1,300 | In progress |
+| 3 | Real Copilot/harness adapter | 4 | ~1,450 | Planned (#92) |
+| 4 | Gym/eval via amplihack-agent-eval | 5 | ~1,850 | Planned (#93) |
+| 5 | Agent composition & subordinates | 5 | ~1,800 | Planned (#94) |
+| 6 | Self-improvement & relaunch | 4 | ~1,400 | Planned (#95) |
+| 7 | Remote orchestration via azlin | 4 | ~1,400 | Planned (#96) |
+| 8 | Meeting mode, goals, dual identity | 5 | ~1,650 | Planned (#97) |
+| 9 | OODA loop & autonomous operation | 4 | ~1,450 | Planned (#98) |
+| **Total** | | **46** | **~15,850** | |
+
+## Quality Gates (Every Phase)
+
+1. All modules ≤400 LOC
+2. `cargo test --quiet` passes (existing + new)
+3. `cargo clippy --all-targets -- -D warnings` clean
+4. Outside-in gadugi YAML test scenario
+5. Feral usage tests (adversarial inputs, crash recovery)
+6. Spec alignment check against ProductArchitecture.md
+7. Project-wide quality-audit between phases
+8. merge-ready skill quality gates before merge
+
+## Self-Building Unlock
+
+Minimum viable self-building requires Phases 0-6. At that point, Simard can:
+
+1. **Remember** what she learned (Phase 1)
+2. **Understand** her ecosystem (Phase 2)
+3. **Act** on real coding tasks (Phase 3)
+4. **Measure** her capability (Phase 4)
+5. **Delegate** subtasks (Phase 5)
+6. **Improve** herself (Phase 6)
+
+Phases 7-9 add operational maturity: remote execution, meeting facilitation, and continuous autonomous operation.

--- a/docs/architecture/implementation-plan.md
+++ b/docs/architecture/implementation-plan.md
@@ -8,7 +8,7 @@ doc_type: reference
 
 # Implementation Plan
 
-The full technical plan lives at [`Specs/IMPLEMENTATION_PLAN.md`](../../Specs/IMPLEMENTATION_PLAN.md) in the repository root. This page provides a high-level overview.
+The full technical plan lives at `Specs/IMPLEMENTATION_PLAN.md` in the repository root. This page provides a high-level overview.
 
 ## Parallelism Map
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -67,7 +67,7 @@ graph TB
 
 ## Core Principles
 
-Simard's architecture follows eleven pillars defined in the [ProductArchitecture spec](../../Specs/ProductArchitecture.md):
+Simard's architecture follows eleven pillars defined in the ProductArchitecture spec (`Specs/ProductArchitecture.md` in the repo root):
 
 1. **Terminal First** — not chat first. Simard drives real tools through PTY.
 2. **Explicit State** — no hidden magic. All state is file-backed and operator-visible.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,175 @@
+---
+title: Architecture Overview
+description: How Simard's components fit together — from the runtime kernel to the Python ecosystem bridges, cognitive memory, and agent composition.
+last_updated: 2026-03-31
+owner: simard
+doc_type: concept
+---
+
+# Architecture Overview
+
+Simard is an autonomous engineer built in Rust that drives agentic coding systems through real terminal interaction. She uses the amplihack ecosystem for memory, knowledge, evaluation, and orchestration.
+
+## System Diagram
+
+```mermaid
+graph TB
+    subgraph "Simard Binary (Rust)"
+        CLI[Operator CLI]
+        RT[Runtime Kernel]
+        EL[Engineer Loop]
+        TS[Terminal Session / PTY]
+        BT[Base Type Adapters]
+        ID[Identity System]
+        CB[Circuit Breaker]
+
+        CLI --> RT
+        RT --> EL
+        RT --> BT
+        EL --> TS
+        BT --> TS
+        RT --> ID
+    end
+
+    subgraph "Bridge Layer"
+        MB[Memory Bridge]
+        KB[Knowledge Bridge]
+        GB[Gym Bridge]
+        CB --> MB
+        CB --> KB
+        CB --> GB
+    end
+
+    subgraph "Python Ecosystem"
+        CMA[CognitiveAdapter + Hive Mind]
+        KGA[KnowledgeGraphAgent]
+        EVA[Progressive Test Suite]
+        KUZU[(Kuzu Graph DB)]
+        LDB[(LadybugDB)]
+
+        MB --> CMA
+        KB --> KGA
+        GB --> EVA
+        CMA --> KUZU
+        KGA --> LDB
+    end
+
+    subgraph "External Systems"
+        AMP[amplihack copilot]
+        AZLIN[azlin VMs]
+        GH[GitHub]
+    end
+
+    TS --> AMP
+    RT --> AZLIN
+    EL --> GH
+```
+
+## Core Principles
+
+Simard's architecture follows eleven pillars defined in the [ProductArchitecture spec](../../Specs/ProductArchitecture.md):
+
+1. **Terminal First** — not chat first. Simard drives real tools through PTY.
+2. **Explicit State** — no hidden magic. All state is file-backed and operator-visible.
+3. **Roles Separated** — planner, engineer, reviewer, facilitator are distinct.
+4. **Benchmarks Drive Truth** — measurable improvement, not dashboard theater.
+5. **Memory Must Be Layered** — six cognitive types, not a flat key-value store.
+6. **Improvement Requires Reviewable Loops** — every change is inspectable.
+7. **Prompt Assets Stay Separate** — prompts are files, not embedded strings.
+8. **Identity and Runtime Are Different** — what an agent is vs. how it runs.
+9. **Composition Must Outlive Topology** — same identity runs local or distributed.
+10. **Dependency Injection Is Structural** — all services injected via `RuntimePorts`.
+11. **Honest Degradation** — errors surface explicitly, never hidden.
+
+## Key Components
+
+### Runtime Kernel
+
+The `RuntimeKernel` (aliased as `LocalRuntime`) manages the agent lifecycle through explicit state transitions:
+
+```
+Initializing → Ready → Active → Reflecting → Persisting → Stopped
+                                                         ↘ Failed
+```
+
+All runtime services (memory, evidence, prompts, topology) are injected via `RuntimePorts`, making the kernel topology-neutral. The same code runs single-process, multi-process, or distributed.
+
+### Bridge Infrastructure
+
+Simard communicates with the Python ecosystem through subprocess bridges using newline-delimited JSON on stdin/stdout:
+
+```
+Simard (Rust) ──stdin──→ Python subprocess ──→ amplihack-memory-lib (Kuzu)
+              ←stdout──                    ──→ agent-kgpacks (LadybugDB)
+                                           ──→ amplihack-agent-eval
+```
+
+Each bridge has:
+- A Rust trait (`BridgeTransport`) with typed request/response methods
+- An `InMemoryBridgeTransport` for unit testing
+- A `SubprocessBridgeTransport` for production
+- A `CircuitBreakerTransport` wrapper for fault tolerance
+
+See [Bridge Pattern](bridge-pattern.md) for wire protocol details.
+
+### Cognitive Memory
+
+Simard's memory uses six types modeled after cognitive psychology, provided by `amplihack-memory-lib`:
+
+| Type | Purpose | Duration | Example |
+|------|---------|----------|---------|
+| **Sensory** | Raw observations | Short (TTL) | PTY output, incoming objectives |
+| **Working** | Active task context | Task-scoped | Current goal, plan steps, constraints |
+| **Episodic** | Session transcripts | Long-term | What happened in each session |
+| **Semantic** | Extracted facts | Long-term | "cargo test runs all workspace tests" |
+| **Procedural** | Learned sequences | Long-term | "fix-and-verify: read → edit → test → commit" |
+| **Prospective** | Future intentions | Until triggered | "re-run gym after self-improve completes" |
+
+See [Cognitive Memory](cognitive-memory.md) for the full lifecycle.
+
+### Identity System
+
+An `IdentityManifest` defines what an agent is — its operating mode, memory policy, allowed base types, and prompt assets. Three built-in identities ship:
+
+- **simard-engineer** — repo-grounded engineering work
+- **simard-meeting** — alignment and decision capture
+- **simard-gym** — benchmark evaluation
+
+Identities compose: a `CompositeIdentity` can nest multiple manifests with role delegation, enabling Simard to orchestrate subordinate agents with different specializations.
+
+### Session Orchestration
+
+Every interaction follows a six-phase lifecycle:
+
+1. **Intake** — normalize the request, record sensory observation
+2. **Preparation** — search memory for relevant facts, check triggers
+3. **Planning** — form execution plan, recall procedures
+4. **Execution** — perform actions through PTY, record observations
+5. **Reflection** — extract facts, store episode, evaluate outcome
+6. **Persistence** — consolidate memory, clear working state, export handoff
+
+### Terminal Driving
+
+Simard drives real tools through PTY-backed terminal sessions using the `script` command. She can:
+
+- Launch `amplihack copilot` and interact via typed commands
+- Validate startup checkpoints against checked-in flow contracts
+- Restore workflow-only files that wrappers may contaminate
+- Record transcripts for audit and episodic memory
+
+## Implementation Status
+
+See [Implementation Plan](implementation-plan.md) for the full phased roadmap.
+
+| Phase | Component | Status |
+|-------|-----------|--------|
+| 0 | Bridge Infrastructure | Merged |
+| 1 | Cognitive Memory | In Progress |
+| 2 | Knowledge Packs | In Progress |
+| 3 | Real Base Type Adapter | Planned |
+| 4 | Gym & Benchmarks | Planned |
+| 5 | Agent Composition | Planned |
+| 6 | Self-Improvement | Planned |
+| 7 | Remote Orchestration | Planned |
+| 8 | Meeting/Goals/Identity | Planned |
+| 9 | OODA Loop | Planned |

--- a/docs/reference/bridge-wire-protocol.md
+++ b/docs/reference/bridge-wire-protocol.md
@@ -1,0 +1,391 @@
+---
+title: Bridge Wire Protocol Reference
+description: Complete JSON-RPC-style wire protocol specification for all Simard bridge methods.
+last_updated: 2026-03-31
+owner: simard
+doc_type: reference
+---
+
+# Bridge Wire Protocol Reference
+
+All Simard bridges communicate via newline-delimited JSON on stdin (requests) and stdout (responses). This document specifies every method, its parameters, and its response shape.
+
+## Common Protocol
+
+### Request Envelope
+
+```json
+{"id": "<uuid-v7>", "method": "<dotted.name>", "params": {<method-specific>}}
+```
+
+### Response Envelope (success)
+
+```json
+{"id": "<matching-uuid>", "result": {<method-specific>}}
+```
+
+### Response Envelope (error)
+
+```json
+{"id": "<matching-uuid>", "error": {"code": <int>, "message": "<description>"}}
+```
+
+### Error Codes
+
+| Code | Name | Meaning |
+|------|------|---------|
+| -32601 | Method Not Found | Requested method is not registered |
+| -32603 | Internal Error | Unhandled exception in the bridge server |
+| -32000 | Timeout | Response not received within deadline |
+| -32001 | Transport Error | Stdin/stdout broken, process exited |
+
+---
+
+## Bridge Health (all bridges)
+
+### `bridge.health`
+
+**Params**: `{}`
+
+**Result**:
+```json
+{"server_name": "simard-memory", "healthy": true}
+```
+
+---
+
+## Memory Bridge Methods
+
+### `memory.record_sensory`
+
+Record a raw observation with automatic expiry.
+
+**Params**:
+```json
+{"modality": "pty_output", "raw_data": "cargo test ... ok", "ttl_seconds": 300}
+```
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| modality | string | yes | | Channel: `objective`, `pty_output`, `error`, `log` |
+| raw_data | string | yes | | Raw observation text |
+| ttl_seconds | int | no | 300 | Time-to-live in seconds |
+
+**Result**: `{"sensory_id": "sen_01abc..."}`
+
+---
+
+### `memory.push_working`
+
+Add a slot to working memory (20-slot bounded).
+
+**Params**:
+```json
+{"slot_type": "goal", "content": "fix the auth bug", "task_id": "session-01abc...", "relevance": 1.0}
+```
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| slot_type | string | yes | | One of: `goal`, `constraint`, `context`, `plan` |
+| content | string | yes | | Slot content |
+| task_id | string | yes | | Session/task identifier for scoping |
+| relevance | float | no | 1.0 | Priority weight (higher = more relevant) |
+
+**Result**: `{"slot_id": "wrk_01abc..."}`
+
+---
+
+### `memory.get_working`
+
+Retrieve all working memory slots for a task.
+
+**Params**: `{"task_id": "session-01abc..."}`
+
+**Result**:
+```json
+{"slots": [
+  {"node_id": "wrk_01abc...", "slot_type": "goal", "content": "fix the auth bug", "relevance": 1.0, "task_id": "session-01abc..."}
+]}
+```
+
+---
+
+### `memory.clear_working`
+
+Clear all working memory slots for a task.
+
+**Params**: `{"task_id": "session-01abc..."}`
+
+**Result**: `{"cleared_count": 3}`
+
+---
+
+### `memory.store_episode`
+
+Record a session transcript as an episodic memory.
+
+**Params**:
+```json
+{"content": "Session transcript text...", "source_label": "session", "metadata": {"branch": "main"}}
+```
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| content | string | yes | | Episode content (max 2000 chars recommended) |
+| source_label | string | yes | | Provenance: `session`, `ci-run`, `user-input` |
+| metadata | object | no | {} | Arbitrary key-value metadata |
+
+**Result**: `{"episode_id": "epi_01abc..."}`
+
+---
+
+### `memory.consolidate_episodes`
+
+Summarize the oldest batch of unconsolidated episodes.
+
+**Params**: `{"batch_size": 10}`
+
+**Result (success)**: `{"consolidated_id": "con_01abc..."}`
+
+**Result (not enough episodes)**: `{"consolidated_id": null}`
+
+---
+
+### `memory.store_fact`
+
+Store a semantic fact with confidence and optional tags.
+
+**Params**:
+```json
+{
+  "concept": "cargo test",
+  "content": "runs all tests in the workspace",
+  "confidence": 0.9,
+  "tags": ["rust", "testing"],
+  "source_id": "epi_01abc..."
+}
+```
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| concept | string | yes | | Topic/concept (must not be empty) |
+| content | string | yes | | Factual content |
+| confidence | float | no | 0.9 | Confidence score (0.0-1.0) |
+| tags | string[] | no | [] | Categorization tags |
+| source_id | string | no | "" | Episode ID for provenance linking |
+
+**Result**: `{"fact_id": "sem_01abc..."}`
+
+---
+
+### `memory.search_facts`
+
+Search semantic memory by keywords.
+
+**Params**:
+```json
+{"query": "how to run tests", "limit": 10, "min_confidence": 0.3}
+```
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| query | string | yes | | Search keywords |
+| limit | int | no | 10 | Maximum results |
+| min_confidence | float | no | 0.0 | Minimum confidence threshold |
+
+**Result**:
+```json
+{"facts": [
+  {"node_id": "sem_01abc...", "concept": "cargo test", "content": "runs all tests in the workspace", "confidence": 0.9, "source_id": "epi_01abc...", "tags": ["rust", "testing"]}
+]}
+```
+
+---
+
+### `memory.store_procedure`
+
+Store a reusable action sequence.
+
+**Params**:
+```json
+{"name": "fix-and-verify", "steps": ["read file", "edit", "cargo test", "commit"], "prerequisites": ["git repo"]}
+```
+
+**Result**: `{"procedure_id": "pro_01abc..."}`
+
+---
+
+### `memory.recall_procedure`
+
+Recall procedures matching a query.
+
+**Params**: `{"query": "how to fix a bug", "limit": 5}`
+
+**Result**:
+```json
+{"procedures": [
+  {"node_id": "pro_01abc...", "name": "fix-and-verify", "steps": ["read file", "edit", "cargo test", "commit"], "prerequisites": ["git repo"], "usage_count": 3}
+]}
+```
+
+---
+
+### `memory.store_prospective`
+
+Store a future trigger-action pair.
+
+**Params**:
+```json
+{"description": "re-run gym after self-improve", "trigger_condition": "self_improve_complete", "action_on_trigger": "run_gym_suite", "priority": 2}
+```
+
+**Result**: `{"prospective_id": "psp_01abc..."}`
+
+---
+
+### `memory.check_triggers`
+
+Check if any prospective memories match the given content.
+
+**Params**: `{"content": "self_improve_complete: score improved by 3%"}`
+
+**Result**:
+```json
+{"triggered": [
+  {"node_id": "psp_01abc...", "description": "re-run gym after self-improve", "trigger_condition": "self_improve_complete", "action_on_trigger": "run_gym_suite", "status": "triggered", "priority": 2}
+]}
+```
+
+---
+
+### `memory.get_statistics`
+
+Get counts for all memory types.
+
+**Params**: `{}`
+
+**Result**:
+```json
+{"sensory_count": 12, "working_count": 3, "episodic_count": 45, "semantic_count": 230, "procedural_count": 8, "prospective_count": 2}
+```
+
+---
+
+### `memory.prune_expired_sensory`
+
+Remove expired sensory items.
+
+**Params**: `{}`
+
+**Result**: `{"pruned_count": 7}`
+
+---
+
+## Knowledge Bridge Methods
+
+### `knowledge.query`
+
+Query a knowledge pack for a grounded answer.
+
+**Params**:
+```json
+{"pack_name": "rust-expert", "question": "How do lifetimes work?", "limit": 10}
+```
+
+**Result**:
+```json
+{
+  "answer": "Lifetimes are Rust's way of tracking...",
+  "sources": [
+    {"title": "The Rust Programming Language", "section": "Lifetimes", "url": null}
+  ],
+  "confidence": 0.95
+}
+```
+
+---
+
+### `knowledge.list_packs`
+
+List all available knowledge packs.
+
+**Params**: `{}`
+
+**Result**:
+```json
+{"packs": [
+  {"name": "rust-expert", "description": "Comprehensive Rust knowledge", "article_count": 150, "section_count": 890}
+]}
+```
+
+---
+
+### `knowledge.pack_info`
+
+Get details about a specific pack.
+
+**Params**: `{"pack_name": "rust-expert"}`
+
+**Result**:
+```json
+{"name": "rust-expert", "description": "...", "article_count": 150, "section_count": 890}
+```
+
+---
+
+## Gym Bridge Methods
+
+### `gym.list_scenarios`
+
+List available benchmark scenarios.
+
+**Params**: `{}`
+
+**Result**:
+```json
+{"scenarios": [
+  {"id": "repo-exploration", "description": "Identify repository structure and dependencies", "level": "L1"}
+]}
+```
+
+---
+
+### `gym.run_scenario`
+
+Run a single benchmark scenario.
+
+**Params**: `{"scenario_id": "repo-exploration"}`
+
+**Result**:
+```json
+{
+  "scenario_id": "repo-exploration",
+  "score": 0.83,
+  "dimensions": {
+    "factual_accuracy": 0.9,
+    "specificity": 0.8,
+    "temporal_awareness": 0.75,
+    "source_attribution": 0.85,
+    "confidence_calibration": 0.85
+  },
+  "duration_secs": 45
+}
+```
+
+---
+
+### `gym.run_suite`
+
+Run a complete benchmark suite.
+
+**Params**: `{"suite_id": "progressive-L1-L6"}`
+
+**Result**:
+```json
+{
+  "suite_id": "progressive-L1-L6",
+  "overall_score": 0.87,
+  "level_scores": {"L1": 0.83, "L2": 1.0, "L3": 0.99, "L4": 0.79, "L5": 0.95, "L6": 1.0},
+  "duration_secs": 300
+}
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,70 @@
+site_name: Simard
+site_description: An autonomous engineer who drives and curates agentic coding systems
+site_url: https://rysweet.github.io/Simard/
+repo_url: https://github.com/rysweet/Simard
+repo_name: rysweet/Simard
+
+theme:
+  name: material
+  palette:
+    - scheme: slate
+      primary: teal
+      accent: amber
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+    - scheme: default
+      primary: teal
+      accent: amber
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+  features:
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - search.highlight
+    - content.code.copy
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - tables
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - Architecture:
+    - Overview: architecture/overview.md
+    - Bridge Pattern: architecture/bridge-pattern.md
+    - Cognitive Memory: architecture/cognitive-memory.md
+    - Agent Composition: architecture/agent-composition.md
+    - Implementation Plan: architecture/implementation-plan.md
+  - Concepts:
+    - Truthful Runtime Metadata: concepts/truthful-runtime-metadata.md
+    - Topology-Neutral Runtime: concepts/topology-neutral-runtime-kernel.md
+  - Tutorials:
+    - First Local Session: tutorials/run-your-first-local-session.md
+    - First Benchmark Suite: tutorials/run-your-first-benchmark-gym.md
+    - First Rusty-Clawd Mesh: tutorials/run-rusty-clawd-on-loopback-mesh.md
+  - How-To Guides:
+    - Terminal to Engineer: howto/move-from-terminal-recipes-into-engineer-runs.md
+    - Bootstrap and Reflection: howto/configure-bootstrap-and-inspect-reflection.md
+    - Carry Meeting Decisions: howto/carry-meeting-decisions-into-engineer-sessions.md
+    - Inspect Meeting Records: howto/inspect-meeting-records.md
+    - Inspect Improvements: howto/inspect-improvement-curation-state.md
+    - Reclaim Disk Space: howto/reclaim-disk-space-and-run-low-space-rust-builds.md
+  - Reference:
+    - CLI Reference: reference/simard-cli.md
+    - Runtime Contracts: reference/runtime-contracts.md
+    - Bridge Wire Protocol: reference/bridge-wire-protocol.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,11 +52,9 @@ nav:
     - Implementation Plan: architecture/implementation-plan.md
   - Concepts:
     - Truthful Runtime Metadata: concepts/truthful-runtime-metadata.md
-    - Topology-Neutral Runtime: concepts/topology-neutral-runtime-kernel.md
   - Tutorials:
     - First Local Session: tutorials/run-your-first-local-session.md
     - First Benchmark Suite: tutorials/run-your-first-benchmark-gym.md
-    - First Rusty-Clawd Mesh: tutorials/run-rusty-clawd-on-loopback-mesh.md
   - How-To Guides:
     - Terminal to Engineer: howto/move-from-terminal-recipes-into-engineer-runs.md
     - Bootstrap and Reflection: howto/configure-bootstrap-and-inspect-reflection.md
@@ -64,6 +62,7 @@ nav:
     - Inspect Meeting Records: howto/inspect-meeting-records.md
     - Inspect Improvements: howto/inspect-improvement-curation-state.md
     - Reclaim Disk Space: howto/reclaim-disk-space-and-run-low-space-rust-builds.md
+    - Inspect Goal Register: howto/inspect-durable-goal-register.md
   - Reference:
     - CLI Reference: reference/simard-cli.md
     - Runtime Contracts: reference/runtime-contracts.md


### PR DESCRIPTION
## Summary

- Add comprehensive architecture documentation with mermaid diagrams
- Add mkdocs-material configuration for GitHub Pages (deployment disabled until ready)
- Add docs build CI workflow

## New Documentation

| Document | Description |
|----------|-------------|
| `docs/architecture/overview.md` | System diagram, core principles, key components |
| `docs/architecture/bridge-pattern.md` | Wire protocol, circuit breaker, testing strategy |
| `docs/architecture/cognitive-memory.md` | 6-type memory model, session lifecycle mapping, hive mind |
| `docs/architecture/agent-composition.md` | Subordinate spawning, supervisor protocol, self-building loop |
| `docs/architecture/implementation-plan.md` | Phased roadmap with parallelism map and quality gates |
| `docs/reference/bridge-wire-protocol.md` | Complete method specs for all bridge APIs |
| `mkdocs.yml` | mkdocs-material theme with mermaid support |
| `.github/workflows/docs.yml` | CI workflow for docs validation |

## Test plan

- [x] No Rust code changes — existing tests unaffected
- [x] Pre-push hooks pass
- [ ] Docs build workflow passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)