### PR TITLE
fix: remediate quality audit findings from Phases 0-2

### DIFF
--- a/python/simard_knowledge_bridge.py
+++ b/python/simard_knowledge_bridge.py
@@ -137,16 +137,16 @@ class KnowledgeBridgeServer(BridgeServer):
             "confidence": confidence,
         }
 
-    def _handle_list_packs(self, _params: dict[str, Any]) -> list[dict[str, Any]]:
+    def _handle_list_packs(self, _params: dict[str, Any]) -> dict[str, Any]:
         """Handle knowledge.list_packs requests.
 
         Returns:
-            List of {name, description, article_count, section_count}.
+            {"packs": [{name, description, article_count, section_count}, ...]}.
         """
         self._ensure_registry()
         self._registry.refresh()
         packs = self._registry.list_packs()
-        return [_pack_info_dict(p) for p in packs]
+        return {"packs": [_pack_info_dict(p) for p in packs]}
 
     def _handle_pack_info(self, params: dict[str, Any]) -> dict[str, Any]:
         """Handle knowledge.pack_info requests.

--- a/src/bridge_subprocess.rs
+++ b/src/bridge_subprocess.rs
@@ -104,7 +104,11 @@ impl SubprocessBridgeTransport {
         if state.child.is_none() {
             state.child = Some(self.spawn_child()?);
         }
-        Ok(state.child.as_mut().unwrap())
+        // Safe: the `if` guard above guarantees `child` is `Some` at this point.
+        Ok(state
+            .child
+            .as_mut()
+            .expect("child was set on the previous line"))
     }
 
     fn send_request(child: &mut ManagedChild, request: &BridgeRequest) -> SimardResult<()> {

--- a/src/bridge_subprocess.rs
+++ b/src/bridge_subprocess.rs
@@ -108,7 +108,7 @@ impl SubprocessBridgeTransport {
         Ok(state
             .child
             .as_mut()
-            .expect("child was set on the previous line"))
+            .expect("child was set in the guard above"))
     }
 
     fn send_request(child: &mut ManagedChild, request: &BridgeRequest) -> SimardResult<()> {

--- a/src/knowledge_bridge.rs
+++ b/src/knowledge_bridge.rs
@@ -16,6 +16,12 @@ use crate::error::SimardResult;
 /// Name used in error messages for this bridge.
 const BRIDGE_NAME: &str = "knowledge";
 
+/// Wire-protocol wrapper for `list_packs` response consistency.
+#[derive(Deserialize)]
+struct ListPacksResponse {
+    packs: Vec<KnowledgePackInfo>,
+}
+
 /// Result of querying a knowledge pack with a natural-language question.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct KnowledgeQueryResult {
@@ -91,7 +97,9 @@ impl KnowledgeBridge {
     /// List all available knowledge packs.
     pub fn list_packs(&self) -> SimardResult<Vec<KnowledgePackInfo>> {
         let response = self.call("knowledge.list_packs", serde_json::json!({}))?;
-        unpack_bridge_response(BRIDGE_NAME, "knowledge.list_packs", response)
+        let wrapper: ListPacksResponse =
+            unpack_bridge_response(BRIDGE_NAME, "knowledge.list_packs", response)?;
+        Ok(wrapper.packs)
     }
 
     /// Get metadata for a specific pack.
@@ -160,20 +168,22 @@ mod tests {
                     "confidence": 0.85,
                 }))
             }
-            "knowledge.list_packs" => Ok(serde_json::json!([
-                {
-                    "name": "rust-expert",
-                    "description": "Rust programming knowledge",
-                    "article_count": 120,
-                    "section_count": 450,
-                },
-                {
-                    "name": "python-expert",
-                    "description": "Python programming knowledge",
-                    "article_count": 200,
-                    "section_count": 800,
-                },
-            ])),
+            "knowledge.list_packs" => Ok(serde_json::json!({
+                "packs": [
+                    {
+                        "name": "rust-expert",
+                        "description": "Rust programming knowledge",
+                        "article_count": 120,
+                        "section_count": 450,
+                    },
+                    {
+                        "name": "python-expert",
+                        "description": "Python programming knowledge",
+                        "article_count": 200,
+                        "section_count": 800,
+                    },
+                ]
+            })),
             "knowledge.pack_info" => {
                 let pack = params
                     .get("pack_name")

--- a/src/knowledge_context.rs
+++ b/src/knowledge_context.rs
@@ -198,6 +198,10 @@ mod tests {
         let ctx = enrich_planning_context("anything", &bridge).unwrap();
         assert!(ctx.is_empty());
         assert!(ctx.pack_sources.is_empty());
+        assert!(
+            ctx.degraded,
+            "context should be marked degraded when bridge is unavailable"
+        );
     }
 
     #[test]
@@ -205,6 +209,7 @@ mod tests {
         let bridge = KnowledgeBridge::new(Box::new(mock_transport()));
         let ctx = enrich_planning_context("xyzzy plugh", &bridge).unwrap();
         assert!(ctx.is_empty());
+        assert!(!ctx.degraded, "no packs matched but bridge was healthy");
     }
 
     #[test]

--- a/src/knowledge_context.rs
+++ b/src/knowledge_context.rs
@@ -21,6 +21,9 @@ pub struct PlanningContext {
     pub relevant_knowledge: Vec<KnowledgeQueryResult>,
     /// Names of packs that contributed knowledge.
     pub pack_sources: Vec<String>,
+    /// True when the knowledge bridge was unavailable or returned an error.
+    /// Distinguishes "no relevant packs" from "bridge was down."
+    pub degraded: bool,
 }
 
 impl PlanningContext {
@@ -50,6 +53,7 @@ pub fn enrich_planning_context(
             return Ok(PlanningContext {
                 relevant_knowledge: vec![],
                 pack_sources: vec![],
+                degraded: true,
             });
         }
     };
@@ -58,6 +62,7 @@ pub fn enrich_planning_context(
         return Ok(PlanningContext {
             relevant_knowledge: vec![],
             pack_sources: vec![],
+            degraded: false,
         });
     }
 
@@ -92,6 +97,7 @@ pub fn enrich_planning_context(
     Ok(PlanningContext {
         relevant_knowledge,
         pack_sources,
+        degraded: false,
     })
 }
 
@@ -126,26 +132,28 @@ mod tests {
                 "server_name": "simard-knowledge",
                 "healthy": true,
             })),
-            "knowledge.list_packs" => Ok(serde_json::json!([
-                {
-                    "name": "rust-expert",
-                    "description": "Rust programming language ownership borrowing",
-                    "article_count": 120,
-                    "section_count": 450,
-                },
-                {
-                    "name": "python-expert",
-                    "description": "Python programming language stdlib",
-                    "article_count": 200,
-                    "section_count": 800,
-                },
-                {
-                    "name": "docker-expert",
-                    "description": "Docker containers images",
-                    "article_count": 80,
-                    "section_count": 300,
-                },
-            ])),
+            "knowledge.list_packs" => Ok(serde_json::json!({
+                "packs": [
+                    {
+                        "name": "rust-expert",
+                        "description": "Rust programming language ownership borrowing",
+                        "article_count": 120,
+                        "section_count": 450,
+                    },
+                    {
+                        "name": "python-expert",
+                        "description": "Python programming language stdlib",
+                        "article_count": 200,
+                        "section_count": 800,
+                    },
+                    {
+                        "name": "docker-expert",
+                        "description": "Docker containers images",
+                        "article_count": 80,
+                        "section_count": 300,
+                    },
+                ]
+            })),
             "knowledge.query" => {
                 let pack = params
                     .get("pack_name")
@@ -228,8 +236,10 @@ mod tests {
         let ctx = PlanningContext {
             relevant_knowledge: vec![],
             pack_sources: vec![],
+            degraded: false,
         };
         assert!(ctx.is_empty());
+        assert!(!ctx.degraded);
     }
 
     #[test]

--- a/src/memory_cognitive.rs
+++ b/src/memory_cognitive.rs
@@ -11,7 +11,10 @@ use serde::{Deserialize, Serialize};
 ///
 /// Maps to Python `SensoryItem`. The `expires_at` field is a Unix timestamp
 /// (seconds) after which the item may be pruned.
+///
+/// Used by future `get_recent_sensory` bridge method (Phase 3+).
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[allow(dead_code)]
 pub struct CognitiveSensoryItem {
     pub node_id: String,
     pub modality: String,
@@ -37,7 +40,10 @@ pub struct CognitiveWorkingSlot {
 ///
 /// Maps to Python `EpisodicMemory`. Episodes can be consolidated into
 /// summaries via `consolidate_episodes`.
+///
+/// Used by future `get_episodes` bridge method (Phase 3+).
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[allow(dead_code)]
 pub struct CognitiveEpisode {
     pub node_id: String,
     pub content: String,

--- a/src/memory_consolidation.rs
+++ b/src/memory_consolidation.rs
@@ -120,8 +120,15 @@ pub fn execution_memory_operations(
     bridge.record_sensory("pty-output", pty_output, 120)?;
 
     // Push a truncated version into working memory for immediate context.
+    // Use char-boundary-safe truncation to avoid panic on multi-byte UTF-8.
     let truncated = if pty_output.len() > 500 {
-        format!("{}...[truncated]", &pty_output[..500])
+        let boundary = pty_output
+            .char_indices()
+            .take_while(|(i, _)| *i < 500)
+            .last()
+            .map(|(i, c)| i + c.len_utf8())
+            .unwrap_or(0);
+        format!("{}...[truncated]", &pty_output[..boundary])
     } else {
         pty_output.to_string()
     };
@@ -263,6 +270,23 @@ mod tests {
         reflection_memory_operations("transcript...", &facts, &test_session_id(), &bridge).unwrap();
         // 1 store_episode + 2 store_fact = 3
         assert_eq!(count.load(Ordering::SeqCst), 3);
+    }
+
+    #[test]
+    fn execution_truncates_multibyte_utf8_safely() {
+        let (bridge, _) = counting_bridge();
+        // Build a string with multi-byte chars that would panic with naive byte slicing.
+        // Each CJK char is 3 bytes; 200 chars = 600 bytes, exceeding the 500-byte threshold.
+        let cjk_output: String = std::iter::repeat_n('漢', 200).collect();
+        assert!(cjk_output.len() > 500);
+        // Must not panic.
+        execution_memory_operations(&cjk_output, &test_session_id(), &bridge).unwrap();
+    }
+
+    #[test]
+    fn execution_does_not_truncate_short_output() {
+        let (bridge, _) = counting_bridge();
+        execution_memory_operations("short", &test_session_id(), &bridge).unwrap();
     }
 
     #[test]

--- a/tests/knowledge.rs
+++ b/tests/knowledge.rs
@@ -54,32 +54,34 @@ fn mock_knowledge_transport() -> InMemoryBridgeTransport {
                 "confidence": 0.82,
             }))
         }
-        "knowledge.list_packs" => Ok(serde_json::json!([
-            {
-                "name": "rust-expert",
-                "description": "Rust programming language ownership borrowing lifetimes",
-                "article_count": 150,
-                "section_count": 520,
-            },
-            {
-                "name": "python-expert",
-                "description": "Python programming language stdlib asyncio",
-                "article_count": 210,
-                "section_count": 890,
-            },
-            {
-                "name": "docker-expert",
-                "description": "Docker containers images Dockerfile",
-                "article_count": 75,
-                "section_count": 280,
-            },
-            {
-                "name": "kubernetes-expert",
-                "description": "Kubernetes k8s pods deployments services",
-                "article_count": 180,
-                "section_count": 650,
-            },
-        ])),
+        "knowledge.list_packs" => Ok(serde_json::json!({
+            "packs": [
+                {
+                    "name": "rust-expert",
+                    "description": "Rust programming language ownership borrowing lifetimes",
+                    "article_count": 150,
+                    "section_count": 520,
+                },
+                {
+                    "name": "python-expert",
+                    "description": "Python programming language stdlib asyncio",
+                    "article_count": 210,
+                    "section_count": 890,
+                },
+                {
+                    "name": "docker-expert",
+                    "description": "Docker containers images Dockerfile",
+                    "article_count": 75,
+                    "section_count": 280,
+                },
+                {
+                    "name": "kubernetes-expert",
+                    "description": "Kubernetes k8s pods deployments services",
+                    "article_count": 180,
+                    "section_count": 650,
+                },
+            ]
+        })),
         "knowledge.pack_info" => {
             let pack = params
                 .get("pack_name")
@@ -308,6 +310,7 @@ fn planning_context_empty_check() {
     let empty = PlanningContext {
         relevant_knowledge: vec![],
         pack_sources: vec![],
+        degraded: false,
     };
     assert!(empty.is_empty());
 }


### PR DESCRIPTION
## Summary

Fix critical, high, and medium findings from the quality audit of Phases 0-2 code.

### Fixes Applied

| Finding | Severity | Fix |
|---------|----------|-----|
| F5 | CRITICAL | `memory_consolidation.rs`: char-boundary-safe UTF-8 truncation replaces byte-offset slice |
| F6 | MEDIUM | `bridge_subprocess.rs`: `unwrap()` → `expect()` with justification |
| F8 | MEDIUM | `knowledge_context.rs`: `PlanningContext.degraded` flag for honest degradation visibility |
| F9 | MEDIUM | `memory_cognitive.rs`: `#[allow(dead_code)]` with Phase 3+ justification |
| F19 | MEDIUM | `knowledge_bridge.rs`: `list_packs` wrapped in `{"packs": [...]}` for protocol consistency |

### Deferred

| Finding | Severity | Reason |
|---------|----------|--------|
| F1 | HIGH | Test file LOC (490) — mock extraction requires test infrastructure refactor, tracked separately |
| F7 | MEDIUM | Python parameter validation — requires coordination with Python bridge changes |
| F21 | MEDIUM | Mock trigger state — test fidelity gap, low risk |

### Step 13: Local Testing Results

**Test Environment**: `fix/quality-audit-remediation`, 2026-03-31
**Tests Executed**:

1. Simple: `execution_does_not_truncate_short_output` → PASS
2. Critical: `execution_truncates_multibyte_utf8_safely` (200 CJK chars = 600 bytes) → PASS
3. Regression: All 126 existing tests → PASS
4. Clippy: Clean (zero warnings)

**Issues Found**: Clippy `manual-repeat-n` lint on new test, fixed immediately.

Resolves #103

## Test plan

- [x] 126 tests pass
- [x] UTF-8 truncation test verifies no panic on multi-byte input
- [x] All mocks updated for wrapped list_packs protocol
- [x] PlanningContext.degraded flag tested
- [x] Pre-push hooks pass (fmt, clippy, tests)
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)