### PR TITLE
feat: Phase 4 — Gym & Benchmark integration via amplihack-agent-eval bridge

### DIFF
--- a/python/simard_gym_bridge.py
+++ b/python/simard_gym_bridge.py
@@ -1,0 +1,282 @@
+"""Simard gym evaluation bridge server.
+
+Extends BridgeServer to expose amplihack-agent-eval's progressive test suite
+and long-horizon memory evaluation over the Simard bridge protocol.
+
+Methods: gym.list_scenarios, gym.run_scenario, gym.run_suite
+
+Usage: python3 simard_gym_bridge.py [--output-dir ./eval_output] [--sdk mini]
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+if str(_SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPT_DIR))
+
+from bridge_server import BridgeServer  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+ALL_DIMENSIONS = [
+    "factual_accuracy", "specificity", "temporal_awareness",
+    "source_attribution", "confidence_calibration",
+]
+
+
+def _zero_dims() -> dict[str, float]:
+    return {d: 0.0 for d in ALL_DIMENSIONS}
+
+
+def _fail_result(scenario_id: str, msg: str, source: str = "") -> dict[str, Any]:
+    """Build a failed GymScenarioResult."""
+    return {
+        "scenario_id": scenario_id, "success": False, "score": 0.0,
+        "dimensions": _zero_dims(), "question_count": 0, "questions_answered": 0,
+        "error_message": msg,
+        "degraded_sources": [source] if source else [],
+    }
+
+
+def _try_import_progressive():
+    try:
+        from amplihack.eval.progressive_test_suite import (
+            ProgressiveConfig, run_progressive_suite, run_single_level,
+        )
+        from amplihack_eval.data.progressive_levels import (  # type: ignore[import-not-found]
+            ADVANCED_LEVELS, ALL_LEVELS, NOVEL_SKILL_LEVELS,
+            TEACHER_STUDENT_LEVELS, TRANSFER_LEVELS,
+        )
+        return {
+            "run_progressive_suite": run_progressive_suite,
+            "run_single_level": run_single_level,
+            "ProgressiveConfig": ProgressiveConfig,
+            "ALL_LEVELS": ALL_LEVELS, "ADVANCED_LEVELS": ADVANCED_LEVELS,
+            "TEACHER_STUDENT_LEVELS": TEACHER_STUDENT_LEVELS,
+            "NOVEL_SKILL_LEVELS": NOVEL_SKILL_LEVELS,
+            "TRANSFER_LEVELS": TRANSFER_LEVELS,
+        }, None
+    except ImportError as exc:
+        return None, str(exc)
+
+
+def _try_import_long_horizon():
+    try:
+        from amplihack.eval.long_horizon_memory import LongHorizonMemoryEval
+        return {"LongHorizonMemoryEval": LongHorizonMemoryEval}, None
+    except ImportError as exc:
+        return None, str(exc)
+
+
+def _level_to_scenario(level: Any) -> dict[str, Any]:
+    return {
+        "id": level.level_id, "name": level.level_name,
+        "description": getattr(level, "description", ""),
+        "level": level.level_id,
+        "question_count": len(level.questions),
+        "article_count": len(level.articles),
+    }
+
+
+def _extract_dimensions(grades: list[dict]) -> dict[str, float]:
+    if not grades:
+        return _zero_dims()
+    avg = sum(g.get("score", 0.0) for g in grades) / len(grades)
+    dims = _zero_dims()
+    dims["factual_accuracy"] = avg
+    dims["specificity"] = avg
+    metacog = [
+        g["metacognition"]["overall"]
+        for g in grades
+        if g.get("metacognition") and "overall" in g["metacognition"]
+    ]
+    if metacog:
+        dims["confidence_calibration"] = sum(metacog) / len(metacog)
+    return dims
+
+
+def _level_result_to_scenario(result: Any) -> dict[str, Any]:
+    if result.success and result.scores:
+        details = result.scores.get("details", [])
+        return {
+            "scenario_id": result.level_id, "success": True,
+            "score": result.scores.get("average", 0.0),
+            "dimensions": _extract_dimensions(details),
+            "question_count": len(details), "questions_answered": len(details),
+            "error_message": None, "degraded_sources": [],
+        }
+    return _fail_result(
+        result.level_id,
+        result.error_message or "unknown error",
+        "progressive_test_suite",
+    )
+
+
+class GymBridgeServer(BridgeServer):
+    """Bridge server exposing amplihack-agent-eval to Simard."""
+
+    def __init__(self, output_dir: str | None = None, sdk: str = "mini",
+                 agent_name: str = "simard-gym-eval") -> None:
+        super().__init__("simard-gym-eval")
+        self._output_dir = output_dir or tempfile.mkdtemp(prefix="simard-gym-")
+        self._sdk = sdk
+        self._agent_name = agent_name
+        self._progressive, self._progressive_err = _try_import_progressive()
+        self._long_horizon, self._long_horizon_err = _try_import_long_horizon()
+        self.register("gym.list_scenarios", self._handle_list_scenarios)
+        self.register("gym.run_scenario", self._handle_run_scenario)
+        self.register("gym.run_suite", self._handle_run_suite)
+
+    def _all_levels(self) -> list[Any]:
+        if self._progressive is None:
+            return []
+        levels = list(self._progressive["ALL_LEVELS"])
+        for key in ["TEACHER_STUDENT_LEVELS", "ADVANCED_LEVELS",
+                     "NOVEL_SKILL_LEVELS", "TRANSFER_LEVELS"]:
+            levels.extend(self._progressive.get(key, []))
+        return levels
+
+    def _find_level(self, level_id: str) -> Any | None:
+        for level in self._all_levels():
+            if level.level_id == level_id:
+                return level
+        return None
+
+    def _handle_list_scenarios(self, _params: dict[str, Any]) -> list[dict]:
+        scenarios = [_level_to_scenario(l) for l in self._all_levels()]
+        if self._long_horizon is not None:
+            scenarios.append({
+                "id": "long-horizon-memory",
+                "name": "Long-horizon memory stress test",
+                "description": "1000-turn dialogue testing memory at scale",
+                "level": "long-horizon", "question_count": 0, "article_count": 0,
+            })
+        if self._progressive is None:
+            logger.warning("Degraded: progressive suite unavailable: %s",
+                           self._progressive_err)
+        if self._long_horizon is None:
+            logger.warning("Degraded: long_horizon unavailable: %s",
+                           self._long_horizon_err)
+        return scenarios
+
+    def _handle_run_scenario(self, params: dict[str, Any]) -> dict[str, Any]:
+        sid = params.get("scenario_id", "")
+        if sid == "long-horizon-memory":
+            return self._run_long_horizon()
+        if self._progressive is None:
+            return _fail_result(sid, f"progressive unavailable: {self._progressive_err}",
+                                "progressive_test_suite")
+        level = self._find_level(sid)
+        if level is None:
+            return _fail_result(sid, f"scenario '{sid}' not found")
+        config = self._progressive["ProgressiveConfig"](
+            output_dir=os.path.join(self._output_dir, sid),
+            agent_name=f"{self._agent_name}-{sid}", sdk=self._sdk,
+        )
+        level_dir = Path(config.output_dir) / sid
+        level_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            result = self._progressive["run_single_level"](level, config, level_dir)
+            out = _level_result_to_scenario(result)
+            out["question_count"] = len(level.questions)
+            return out
+        except Exception as exc:
+            logger.exception("Scenario %s failed", sid)
+            return _fail_result(sid, str(exc), "progressive_test_suite")
+
+    def _handle_run_suite(self, params: dict[str, Any]) -> dict[str, Any]:
+        suite_id = params.get("suite_id", "progressive")
+        if self._progressive is None:
+            return {
+                "suite_id": suite_id, "success": False, "overall_score": 0.0,
+                "dimensions": _zero_dims(), "scenario_results": [],
+                "scenarios_passed": 0, "scenarios_total": 0,
+                "error_message": f"progressive unavailable: {self._progressive_err}",
+                "degraded_sources": ["progressive_test_suite"],
+            }
+        config = self._progressive["ProgressiveConfig"](
+            output_dir=os.path.join(self._output_dir, suite_id),
+            agent_name=self._agent_name, sdk=self._sdk,
+        )
+        try:
+            result = self._progressive["run_progressive_suite"](config)
+        except Exception as exc:
+            logger.exception("Suite %s failed", suite_id)
+            return {
+                "suite_id": suite_id, "success": False, "overall_score": 0.0,
+                "dimensions": _zero_dims(), "scenario_results": [],
+                "scenarios_passed": 0, "scenarios_total": 0,
+                "error_message": str(exc), "degraded_sources": ["progressive_test_suite"],
+            }
+        srs = [_level_result_to_scenario(lr) for lr in result.level_results]
+        passed = sum(1 for s in srs if s["success"])
+        ok_scores = [s["score"] for s in srs if s["success"]]
+        overall = sum(ok_scores) / len(ok_scores) if ok_scores else 0.0
+        agg = _zero_dims()
+        if ok_scores:
+            for d in ALL_DIMENSIONS:
+                vals = [s["dimensions"][d] for s in srs if s["success"]]
+                agg[d] = sum(vals) / len(vals) if vals else 0.0
+        return {
+            "suite_id": suite_id, "success": result.success,
+            "overall_score": overall, "dimensions": agg,
+            "scenario_results": srs, "scenarios_passed": passed,
+            "scenarios_total": len(srs),
+            "error_message": None if result.success else result.error_message,
+            "degraded_sources": [],
+        }
+
+    def _run_long_horizon(self) -> dict[str, Any]:
+        if self._long_horizon is None:
+            return _fail_result("long-horizon-memory",
+                                f"unavailable: {self._long_horizon_err}",
+                                "long_horizon_memory")
+        try:
+            ev = self._long_horizon["LongHorizonMemoryEval"](
+                agent_name=f"{self._agent_name}-lh", num_turns=100,
+                num_questions=20,
+                output_dir=os.path.join(self._output_dir, "long-horizon"),
+            )
+            report = ev.run()
+            dims = _zero_dims()
+            for cb in (report.category_breakdown or []):
+                for dn, dv in cb.dimension_averages.items():
+                    if dn in dims:
+                        dims[dn] = max(dims[dn], dv)
+            return {
+                "scenario_id": "long-horizon-memory", "success": True,
+                "score": report.overall_score, "dimensions": dims,
+                "question_count": report.num_questions,
+                "questions_answered": len(report.results),
+                "error_message": None, "degraded_sources": [],
+            }
+        except Exception as exc:
+            logger.exception("Long-horizon eval failed")
+            return _fail_result("long-horizon-memory", str(exc),
+                                "long_horizon_memory")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Simard gym evaluation bridge")
+    parser.add_argument("--output-dir", default=None)
+    parser.add_argument("--sdk", default="mini",
+                        choices=["mini", "claude", "copilot", "microsoft"])
+    parser.add_argument("--agent-name", default="simard-gym-eval")
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.INFO,
+                        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+                        stream=sys.stderr)
+    GymBridgeServer(output_dir=args.output_dir, sdk=args.sdk,
+                    agent_name=args.agent_name).run()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/gym_bridge.rs
+++ b/src/gym_bridge.rs
@@ -1,0 +1,300 @@
+//! Gym evaluation bridge connecting Simard to the amplihack-agent-eval suite.
+//!
+//! [`GymBridge`] wraps a [`BridgeTransport`] to communicate with a Python
+//! bridge server that runs progressive test levels (L1-L12) and long-horizon
+//! memory evaluations. All results are typed and serializable so they can
+//! feed the scoring pipeline in [`crate::gym_scoring`].
+//!
+//! If the bridge is unavailable or a call fails, errors are surfaced with
+//! full context (Pillar 11: honest degradation). Callers can inspect the
+//! error to decide whether to continue with degraded results or abort.
+
+use serde::{Deserialize, Serialize};
+
+use crate::bridge::{BridgeRequest, BridgeTransport, new_request_id, unpack_bridge_response};
+use crate::error::{SimardError, SimardResult};
+
+const BRIDGE_NAME: &str = "simard-gym-eval";
+
+/// Five scoring dimensions aligned with amplihack-agent-eval's
+/// `long_horizon_memory.ALL_DIMENSIONS`.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct ScoreDimensions {
+    pub factual_accuracy: f64,
+    pub specificity: f64,
+    pub temporal_awareness: f64,
+    pub source_attribution: f64,
+    pub confidence_calibration: f64,
+}
+
+impl ScoreDimensions {
+    /// Arithmetic mean of all five dimensions.
+    pub fn mean(&self) -> f64 {
+        (self.factual_accuracy
+            + self.specificity
+            + self.temporal_awareness
+            + self.source_attribution
+            + self.confidence_calibration)
+            / 5.0
+    }
+}
+
+/// Metadata describing a single evaluation scenario.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct GymScenario {
+    pub id: String,
+    pub name: String,
+    pub description: String,
+    pub level: String,
+    pub question_count: usize,
+    pub article_count: usize,
+}
+
+/// Result of running a single evaluation scenario.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct GymScenarioResult {
+    pub scenario_id: String,
+    pub success: bool,
+    pub score: f64,
+    pub dimensions: ScoreDimensions,
+    pub question_count: usize,
+    pub questions_answered: usize,
+    /// Present when the scenario failed. Provides context per Pillar 11.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_message: Option<String>,
+    /// Sources that degraded during the run.
+    #[serde(default)]
+    pub degraded_sources: Vec<String>,
+}
+
+/// Result of running an entire evaluation suite.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct GymSuiteResult {
+    pub suite_id: String,
+    pub success: bool,
+    pub overall_score: f64,
+    pub dimensions: ScoreDimensions,
+    pub scenario_results: Vec<GymScenarioResult>,
+    pub scenarios_passed: usize,
+    pub scenarios_total: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_message: Option<String>,
+    #[serde(default)]
+    pub degraded_sources: Vec<String>,
+}
+
+/// Bridge client for gym evaluations.
+///
+/// Wraps a [`BridgeTransport`] to call the Python gym bridge server.
+/// Each method maps to a single bridge RPC call.
+pub struct GymBridge {
+    transport: Box<dyn BridgeTransport>,
+}
+
+impl GymBridge {
+    pub fn new(transport: Box<dyn BridgeTransport>) -> Self {
+        Self { transport }
+    }
+
+    /// List all scenarios available from the evaluation server.
+    pub fn list_scenarios(&self) -> SimardResult<Vec<GymScenario>> {
+        let request = BridgeRequest {
+            id: new_request_id(),
+            method: "gym.list_scenarios".to_string(),
+            params: serde_json::json!({}),
+        };
+        let response = self
+            .transport
+            .call(request)
+            .map_err(|e| SimardError::BridgeCallFailed {
+                bridge: BRIDGE_NAME.to_string(),
+                method: "gym.list_scenarios".to_string(),
+                reason: format!("transport error: {e}"),
+            })?;
+        unpack_bridge_response(BRIDGE_NAME, "gym.list_scenarios", response)
+    }
+
+    /// Run a single evaluation scenario by id.
+    pub fn run_scenario(&self, scenario_id: &str) -> SimardResult<GymScenarioResult> {
+        let request = BridgeRequest {
+            id: new_request_id(),
+            method: "gym.run_scenario".to_string(),
+            params: serde_json::json!({"scenario_id": scenario_id}),
+        };
+        let response = self
+            .transport
+            .call(request)
+            .map_err(|e| SimardError::BridgeCallFailed {
+                bridge: BRIDGE_NAME.to_string(),
+                method: "gym.run_scenario".to_string(),
+                reason: format!("transport error: {e}"),
+            })?;
+        unpack_bridge_response(BRIDGE_NAME, "gym.run_scenario", response)
+    }
+
+    /// Run all scenarios in a suite by suite id.
+    pub fn run_suite(&self, suite_id: &str) -> SimardResult<GymSuiteResult> {
+        let request = BridgeRequest {
+            id: new_request_id(),
+            method: "gym.run_suite".to_string(),
+            params: serde_json::json!({"suite_id": suite_id}),
+        };
+        let response = self
+            .transport
+            .call(request)
+            .map_err(|e| SimardError::BridgeCallFailed {
+                bridge: BRIDGE_NAME.to_string(),
+                method: "gym.run_suite".to_string(),
+                reason: format!("transport error: {e}"),
+            })?;
+        unpack_bridge_response(BRIDGE_NAME, "gym.run_suite", response)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bridge::BridgeErrorPayload;
+    use crate::bridge_subprocess::InMemoryBridgeTransport;
+
+    fn fixed_result_transport(result: serde_json::Value) -> InMemoryBridgeTransport {
+        InMemoryBridgeTransport::new("gym-test", move |_method, _params| Ok(result.clone()))
+    }
+
+    fn fixed_error_transport(code: i32, message: &str) -> InMemoryBridgeTransport {
+        let msg = message.to_string();
+        InMemoryBridgeTransport::new("gym-test", move |_method, _params| {
+            Err(BridgeErrorPayload {
+                code,
+                message: msg.clone(),
+            })
+        })
+    }
+
+    #[test]
+    fn score_dimensions_mean_is_average_of_five() {
+        let dims = ScoreDimensions {
+            factual_accuracy: 1.0,
+            specificity: 0.8,
+            temporal_awareness: 0.6,
+            source_attribution: 0.4,
+            confidence_calibration: 0.2,
+        };
+        let mean = dims.mean();
+        assert!((mean - 0.6).abs() < 1e-9);
+    }
+
+    #[test]
+    fn list_scenarios_deserializes_response() {
+        let scenarios = serde_json::json!([
+            {
+                "id": "L1",
+                "name": "Single source direct recall",
+                "description": "Baseline recall test",
+                "level": "L1",
+                "question_count": 5,
+                "article_count": 1
+            }
+        ]);
+        let transport = fixed_result_transport(scenarios);
+        let bridge = GymBridge::new(Box::new(transport));
+        let result = bridge.list_scenarios().unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].id, "L1");
+    }
+
+    #[test]
+    fn run_scenario_deserializes_success() {
+        let result_json = serde_json::json!({
+            "scenario_id": "L1",
+            "success": true,
+            "score": 0.85,
+            "dimensions": {
+                "factual_accuracy": 0.9,
+                "specificity": 0.8,
+                "temporal_awareness": 0.85,
+                "source_attribution": 0.8,
+                "confidence_calibration": 0.9
+            },
+            "question_count": 5,
+            "questions_answered": 5,
+            "degraded_sources": []
+        });
+        let transport = fixed_result_transport(result_json);
+        let bridge = GymBridge::new(Box::new(transport));
+        let result = bridge.run_scenario("L1").unwrap();
+        assert!(result.success);
+        assert_eq!(result.scenario_id, "L1");
+        assert!((result.score - 0.85).abs() < 1e-9);
+    }
+
+    #[test]
+    fn run_scenario_deserializes_failure_with_error() {
+        let result_json = serde_json::json!({
+            "scenario_id": "L12",
+            "success": false,
+            "score": 0.0,
+            "dimensions": {
+                "factual_accuracy": 0.0,
+                "specificity": 0.0,
+                "temporal_awareness": 0.0,
+                "source_attribution": 0.0,
+                "confidence_calibration": 0.0
+            },
+            "question_count": 10,
+            "questions_answered": 0,
+            "error_message": "Learning phase timed out after 600 seconds",
+            "degraded_sources": ["progressive_test_suite"]
+        });
+        let transport = fixed_result_transport(result_json);
+        let bridge = GymBridge::new(Box::new(transport));
+        let result = bridge.run_scenario("L12").unwrap();
+        assert!(!result.success);
+        assert_eq!(
+            result.error_message.as_deref(),
+            Some("Learning phase timed out after 600 seconds")
+        );
+        assert_eq!(result.degraded_sources, vec!["progressive_test_suite"]);
+    }
+
+    #[test]
+    fn run_suite_deserializes_result() {
+        let suite_json = serde_json::json!({
+            "suite_id": "progressive",
+            "success": true,
+            "overall_score": 0.72,
+            "dimensions": {
+                "factual_accuracy": 0.8,
+                "specificity": 0.7,
+                "temporal_awareness": 0.65,
+                "source_attribution": 0.7,
+                "confidence_calibration": 0.75
+            },
+            "scenario_results": [],
+            "scenarios_passed": 6,
+            "scenarios_total": 6,
+            "degraded_sources": []
+        });
+        let transport = fixed_result_transport(suite_json);
+        let bridge = GymBridge::new(Box::new(transport));
+        let result = bridge.run_suite("progressive").unwrap();
+        assert!(result.success);
+        assert_eq!(result.scenarios_passed, 6);
+    }
+
+    #[test]
+    fn bridge_error_surfaces_with_context() {
+        let transport = fixed_error_transport(-32603, "eval server crashed");
+        let bridge = GymBridge::new(Box::new(transport));
+        let err = bridge.list_scenarios().unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("simard-gym-eval"),
+            "error should name the bridge: {msg}"
+        );
+        assert!(
+            msg.contains("eval server crashed"),
+            "error should contain reason: {msg}"
+        );
+    }
+}

--- a/src/gym_scoring.rs
+++ b/src/gym_scoring.rs
@@ -1,0 +1,299 @@
+//! Score aggregation, regression detection, and improvement tracking for gym results.
+
+use serde::{Deserialize, Serialize};
+
+use crate::gym_bridge::{GymScenarioResult, GymSuiteResult, ScoreDimensions};
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct GymSuiteScore {
+    pub suite_id: String,
+    pub overall: f64,
+    pub dimensions: ScoreDimensions,
+    pub scenario_count: usize,
+    pub scenarios_passed: usize,
+    pub pass_rate: f64,
+    pub recorded_at_unix_ms: Option<u128>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Regression {
+    pub dimension: String,
+    pub baseline_score: f64,
+    pub current_score: f64,
+    pub delta: f64,
+    pub severity: RegressionSeverity,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RegressionSeverity {
+    Minor,
+    Moderate,
+    Severe,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum TrendDirection {
+    Improving,
+    Stable,
+    Declining,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct DimensionTrend {
+    pub dimension: String,
+    pub direction: TrendDirection,
+    pub total_delta: f64,
+    pub average: f64,
+    pub history: Vec<f64>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ImprovementTrend {
+    pub run_count: usize,
+    pub overall_direction: TrendDirection,
+    pub overall_delta: f64,
+    pub dimension_trends: Vec<DimensionTrend>,
+}
+
+/// Aggregate scenario results into a suite-level score. Empty input yields zeroed score.
+pub fn aggregate_suite_scores(suite_id: &str, results: &[GymScenarioResult]) -> GymSuiteScore {
+    if results.is_empty() {
+        return GymSuiteScore {
+            suite_id: suite_id.to_string(),
+            overall: 0.0,
+            dimensions: ScoreDimensions::default(),
+            scenario_count: 0,
+            scenarios_passed: 0,
+            pass_rate: 0.0,
+            recorded_at_unix_ms: None,
+        };
+    }
+
+    let n = results.len() as f64;
+    let passed = results.iter().filter(|r| r.success).count();
+    let avg = |f: fn(&ScoreDimensions) -> f64| -> f64 {
+        results.iter().map(|r| f(&r.dimensions)).sum::<f64>() / n
+    };
+    let dims = ScoreDimensions {
+        factual_accuracy: avg(|d| d.factual_accuracy),
+        specificity: avg(|d| d.specificity),
+        temporal_awareness: avg(|d| d.temporal_awareness),
+        source_attribution: avg(|d| d.source_attribution),
+        confidence_calibration: avg(|d| d.confidence_calibration),
+    };
+    let overall = results.iter().map(|r| r.score).sum::<f64>() / n;
+
+    GymSuiteScore {
+        suite_id: suite_id.to_string(),
+        overall,
+        dimensions: dims,
+        scenario_count: results.len(),
+        scenarios_passed: passed,
+        pass_rate: passed as f64 / n,
+        recorded_at_unix_ms: None,
+    }
+}
+
+/// Build a [`GymSuiteScore`] from a [`GymSuiteResult`], preferring suite-level values.
+pub fn suite_score_from_result(result: &GymSuiteResult) -> GymSuiteScore {
+    let mut score = aggregate_suite_scores(&result.suite_id, &result.scenario_results);
+    // Prefer the suite-level values when present since they may differ from
+    // a naive average of scenario results (e.g. weighted scoring).
+    score.overall = result.overall_score;
+    score.dimensions = result.dimensions.clone();
+    score
+}
+
+/// Return regressions where a dimension dropped by more than 0.01 vs baseline.
+pub fn detect_regression(current: &GymSuiteScore, baseline: &GymSuiteScore) -> Vec<Regression> {
+    const THRESHOLD: f64 = 0.01;
+    let c = &current.dimensions;
+    let b = &baseline.dimensions;
+    let pairs: [(&str, f64, f64); 6] = [
+        ("factual_accuracy", c.factual_accuracy, b.factual_accuracy),
+        ("specificity", c.specificity, b.specificity),
+        (
+            "temporal_awareness",
+            c.temporal_awareness,
+            b.temporal_awareness,
+        ),
+        (
+            "source_attribution",
+            c.source_attribution,
+            b.source_attribution,
+        ),
+        (
+            "confidence_calibration",
+            c.confidence_calibration,
+            b.confidence_calibration,
+        ),
+        ("overall", current.overall, baseline.overall),
+    ];
+
+    pairs
+        .into_iter()
+        .filter_map(|(name, curr, base)| {
+            let delta = curr - base;
+            if delta < -THRESHOLD {
+                let severity = if delta.abs() > 0.15 {
+                    RegressionSeverity::Severe
+                } else if delta.abs() > 0.05 {
+                    RegressionSeverity::Moderate
+                } else {
+                    RegressionSeverity::Minor
+                };
+                Some(Regression {
+                    dimension: name.to_string(),
+                    baseline_score: base,
+                    current_score: curr,
+                    delta,
+                    severity,
+                })
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+/// Analyze a chronological series of suite scores. Requires >= 2 entries for a trend.
+pub fn track_improvement(history: &[GymSuiteScore]) -> ImprovementTrend {
+    if history.len() < 2 {
+        return ImprovementTrend {
+            run_count: history.len(),
+            overall_direction: TrendDirection::Stable,
+            overall_delta: 0.0,
+            dimension_trends: Vec::new(),
+        };
+    }
+
+    let extract_dim = |name: &str, getter: fn(&ScoreDimensions) -> f64| -> DimensionTrend {
+        let scores: Vec<f64> = history.iter().map(|s| getter(&s.dimensions)).collect();
+        let total_delta = scores.last().unwrap_or(&0.0) - scores.first().unwrap_or(&0.0);
+        let average = scores.iter().sum::<f64>() / scores.len() as f64;
+        let direction = classify_trend(total_delta);
+        DimensionTrend {
+            dimension: name.to_string(),
+            direction,
+            total_delta,
+            average,
+            history: scores,
+        }
+    };
+
+    let dimension_trends = vec![
+        extract_dim("factual_accuracy", |d| d.factual_accuracy),
+        extract_dim("specificity", |d| d.specificity),
+        extract_dim("temporal_awareness", |d| d.temporal_awareness),
+        extract_dim("source_attribution", |d| d.source_attribution),
+        extract_dim("confidence_calibration", |d| d.confidence_calibration),
+    ];
+
+    let overall_scores: Vec<f64> = history.iter().map(|s| s.overall).collect();
+    let overall_delta =
+        overall_scores.last().unwrap_or(&0.0) - overall_scores.first().unwrap_or(&0.0);
+
+    ImprovementTrend {
+        run_count: history.len(),
+        overall_direction: classify_trend(overall_delta),
+        overall_delta,
+        dimension_trends,
+    }
+}
+
+fn classify_trend(delta: f64) -> TrendDirection {
+    const STABILITY_BAND: f64 = 0.02;
+    if delta > STABILITY_BAND {
+        TrendDirection::Improving
+    } else if delta < -STABILITY_BAND {
+        TrendDirection::Declining
+    } else {
+        TrendDirection::Stable
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dims(v: f64) -> ScoreDimensions {
+        ScoreDimensions {
+            factual_accuracy: v,
+            specificity: v * 0.9,
+            temporal_awareness: v * 0.8,
+            source_attribution: v * 0.7,
+            confidence_calibration: v * 0.85,
+        }
+    }
+
+    fn sr(id: &str, s: f64, ok: bool) -> GymScenarioResult {
+        GymScenarioResult {
+            scenario_id: id.into(),
+            success: ok,
+            score: s,
+            dimensions: dims(s),
+            question_count: 5,
+            questions_answered: if ok { 5 } else { 0 },
+            error_message: None,
+            degraded_sources: vec![],
+        }
+    }
+
+    fn ss(v: f64) -> GymSuiteScore {
+        GymSuiteScore {
+            suite_id: "s".into(),
+            overall: v,
+            dimensions: dims(v),
+            scenario_count: 6,
+            scenarios_passed: 6,
+            pass_rate: 1.0,
+            recorded_at_unix_ms: None,
+        }
+    }
+
+    #[test]
+    fn aggregate_and_regression_and_trend() {
+        // Aggregate: empty
+        assert_eq!(aggregate_suite_scores("t", &[]).scenario_count, 0);
+        // Aggregate: averages
+        let r = vec![
+            sr("L1", 0.8, true),
+            sr("L2", 0.6, true),
+            sr("L3", 0.0, false),
+        ];
+        let s = aggregate_suite_scores("p", &r);
+        assert!((s.overall - (0.8 + 0.6) / 3.0).abs() < 1e-9);
+        assert_eq!(s.scenarios_passed, 2);
+        // Regression: improved = empty
+        assert!(detect_regression(&ss(0.9), &ss(0.5)).is_empty());
+        // Regression: severe
+        assert!(
+            detect_regression(&ss(0.5), &ss(0.8))
+                .iter()
+                .any(|r| r.severity == RegressionSeverity::Severe)
+        );
+        // Regression: minor
+        assert!(
+            detect_regression(&ss(0.77), &ss(0.8))
+                .iter()
+                .any(|r| r.severity == RegressionSeverity::Minor)
+        );
+        // Regression: below threshold
+        assert!(detect_regression(&ss(0.795), &ss(0.8)).is_empty());
+        // Trend: single = stable
+        assert_eq!(
+            track_improvement(&[ss(0.7)]).overall_direction,
+            TrendDirection::Stable
+        );
+        // Trend: improving
+        let t = track_improvement(&[ss(0.5), ss(0.6), ss(0.8)]);
+        assert_eq!(t.overall_direction, TrendDirection::Improving);
+        // Trend: declining
+        assert_eq!(
+            track_improvement(&[ss(0.9), ss(0.7), ss(0.5)]).overall_direction,
+            TrendDirection::Declining
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,8 @@ pub mod error;
 pub mod evidence;
 pub mod goals;
 pub mod gym;
+pub mod gym_bridge;
+pub mod gym_scoring;
 pub mod handoff;
 pub mod identity;
 pub mod improvements;
@@ -82,6 +84,12 @@ pub use gym::{
     BenchmarkComparisonStatus, BenchmarkRunReport, BenchmarkScenario, BenchmarkSuiteReport,
     BenchmarkSuiteScenarioSummary, benchmark_scenarios, compare_latest_benchmark_runs,
     default_output_root, run_benchmark_scenario, run_benchmark_suite,
+};
+pub use gym_bridge::{GymBridge, GymScenario, GymScenarioResult, GymSuiteResult, ScoreDimensions};
+pub use gym_scoring::{
+    DimensionTrend, GymSuiteScore, ImprovementTrend, Regression, RegressionSeverity,
+    TrendDirection, aggregate_suite_scores, detect_regression, suite_score_from_result,
+    track_improvement,
 };
 pub use handoff::{
     CopilotSubmitAudit, FileBackedHandoffStore, InMemoryHandoffStore, RuntimeHandoffSnapshot,

--- a/tests/gym_eval.rs
+++ b/tests/gym_eval.rs
@@ -1,0 +1,374 @@
+//! Integration tests for gym evaluation bridge and scoring.
+//!
+//! These tests use an in-memory bridge transport to validate the full
+//! pipeline: bridge call -> deserialization -> scoring -> regression
+//! detection -> improvement tracking, without requiring a running Python
+//! bridge server.
+
+use simard::bridge::BridgeErrorPayload;
+use simard::bridge_subprocess::InMemoryBridgeTransport;
+use simard::gym_bridge::{GymBridge, GymScenarioResult, GymSuiteResult, ScoreDimensions};
+use simard::gym_scoring::{
+    GymSuiteScore, RegressionSeverity, TrendDirection, aggregate_suite_scores, detect_regression,
+    suite_score_from_result, track_improvement,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn scenario_result(id: &str, score: f64, success: bool) -> GymScenarioResult {
+    GymScenarioResult {
+        scenario_id: id.to_string(),
+        success,
+        score,
+        dimensions: ScoreDimensions {
+            factual_accuracy: score,
+            specificity: score * 0.9,
+            temporal_awareness: score * 0.8,
+            source_attribution: score * 0.7,
+            confidence_calibration: score * 0.85,
+        },
+        question_count: 5,
+        questions_answered: if success { 5 } else { 0 },
+        error_message: if success {
+            None
+        } else {
+            Some("test failure".to_string())
+        },
+        degraded_sources: vec![],
+    }
+}
+
+fn suite_score(overall: f64, accuracy: f64) -> GymSuiteScore {
+    GymSuiteScore {
+        suite_id: "test".to_string(),
+        overall,
+        dimensions: ScoreDimensions {
+            factual_accuracy: accuracy,
+            specificity: overall * 0.9,
+            temporal_awareness: overall * 0.8,
+            source_attribution: overall * 0.7,
+            confidence_calibration: overall * 0.85,
+        },
+        scenario_count: 6,
+        scenarios_passed: 6,
+        pass_rate: 1.0,
+        recorded_at_unix_ms: None,
+    }
+}
+
+fn mock_bridge_with_scenarios() -> GymBridge {
+    let transport = InMemoryBridgeTransport::new("gym-eval", |method, params| match method {
+        "gym.list_scenarios" => Ok(serde_json::json!([
+            {
+                "id": "L1",
+                "name": "Single source direct recall",
+                "description": "Baseline recall test",
+                "level": "L1",
+                "question_count": 5,
+                "article_count": 1
+            },
+            {
+                "id": "L2",
+                "name": "Multi-source synthesis",
+                "description": "Cross-source reasoning",
+                "level": "L2",
+                "question_count": 8,
+                "article_count": 3
+            }
+        ])),
+        "gym.run_scenario" => {
+            let scenario_id = params
+                .get("scenario_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown");
+            Ok(serde_json::json!({
+                "scenario_id": scenario_id,
+                "success": true,
+                "score": 0.85,
+                "dimensions": {
+                    "factual_accuracy": 0.9,
+                    "specificity": 0.8,
+                    "temporal_awareness": 0.85,
+                    "source_attribution": 0.75,
+                    "confidence_calibration": 0.8
+                },
+                "question_count": 5,
+                "questions_answered": 5,
+                "degraded_sources": []
+            }))
+        }
+        "gym.run_suite" => Ok(serde_json::json!({
+            "suite_id": "progressive",
+            "success": true,
+            "overall_score": 0.78,
+            "dimensions": {
+                "factual_accuracy": 0.85,
+                "specificity": 0.75,
+                "temporal_awareness": 0.72,
+                "source_attribution": 0.7,
+                "confidence_calibration": 0.78
+            },
+            "scenario_results": [
+                {
+                    "scenario_id": "L1",
+                    "success": true,
+                    "score": 0.9,
+                    "dimensions": {
+                        "factual_accuracy": 0.95,
+                        "specificity": 0.85,
+                        "temporal_awareness": 0.9,
+                        "source_attribution": 0.8,
+                        "confidence_calibration": 0.85
+                    },
+                    "question_count": 5,
+                    "questions_answered": 5,
+                    "degraded_sources": []
+                },
+                {
+                    "scenario_id": "L2",
+                    "success": true,
+                    "score": 0.66,
+                    "dimensions": {
+                        "factual_accuracy": 0.75,
+                        "specificity": 0.65,
+                        "temporal_awareness": 0.55,
+                        "source_attribution": 0.6,
+                        "confidence_calibration": 0.7
+                    },
+                    "question_count": 8,
+                    "questions_answered": 8,
+                    "degraded_sources": []
+                }
+            ],
+            "scenarios_passed": 2,
+            "scenarios_total": 2,
+            "degraded_sources": []
+        })),
+        _ => Err(BridgeErrorPayload {
+            code: -32601,
+            message: format!("unknown method: {method}"),
+        }),
+    });
+    GymBridge::new(Box::new(transport))
+}
+
+// ---------------------------------------------------------------------------
+// Bridge integration tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn bridge_list_scenarios_returns_typed_results() {
+    let bridge = mock_bridge_with_scenarios();
+    let scenarios = bridge.list_scenarios().unwrap();
+    assert_eq!(scenarios.len(), 2);
+    assert_eq!(scenarios[0].id, "L1");
+    assert_eq!(scenarios[0].question_count, 5);
+    assert_eq!(scenarios[1].id, "L2");
+    assert_eq!(scenarios[1].article_count, 3);
+}
+
+#[test]
+fn bridge_run_scenario_returns_scored_result() {
+    let bridge = mock_bridge_with_scenarios();
+    let result = bridge.run_scenario("L1").unwrap();
+    assert!(result.success);
+    assert_eq!(result.scenario_id, "L1");
+    assert!((result.score - 0.85).abs() < 1e-9);
+    assert!((result.dimensions.factual_accuracy - 0.9).abs() < 1e-9);
+}
+
+#[test]
+fn bridge_run_suite_returns_aggregate_result() {
+    let bridge = mock_bridge_with_scenarios();
+    let result = bridge.run_suite("progressive").unwrap();
+    assert!(result.success);
+    assert_eq!(result.scenarios_passed, 2);
+    assert_eq!(result.scenarios_total, 2);
+    assert!((result.overall_score - 0.78).abs() < 1e-9);
+    assert_eq!(result.scenario_results.len(), 2);
+}
+
+#[test]
+fn bridge_error_propagates_as_simard_error() {
+    let transport = InMemoryBridgeTransport::new("gym-eval", |_method, _params| {
+        Err(BridgeErrorPayload {
+            code: -32603,
+            message: "eval backend crashed".to_string(),
+        })
+    });
+    let bridge = GymBridge::new(Box::new(transport));
+    let err = bridge.list_scenarios().unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("eval backend crashed"));
+}
+
+// ---------------------------------------------------------------------------
+// Scoring aggregation tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn aggregate_suite_scores_averages_scenario_results() {
+    let results = vec![
+        scenario_result("L1", 0.9, true),
+        scenario_result("L2", 0.7, true),
+        scenario_result("L3", 0.5, true),
+    ];
+    let score = aggregate_suite_scores("progressive", &results);
+    assert_eq!(score.scenario_count, 3);
+    assert_eq!(score.scenarios_passed, 3);
+    let expected_overall = (0.9 + 0.7 + 0.5) / 3.0;
+    assert!((score.overall - expected_overall).abs() < 1e-9);
+}
+
+#[test]
+fn aggregate_handles_mix_of_pass_and_fail() {
+    let results = vec![
+        scenario_result("L1", 0.9, true),
+        scenario_result("L2", 0.0, false),
+    ];
+    let score = aggregate_suite_scores("progressive", &results);
+    assert_eq!(score.scenarios_passed, 1);
+    assert!((score.pass_rate - 0.5).abs() < 1e-9);
+}
+
+#[test]
+fn suite_score_from_result_preserves_suite_level_values() {
+    let result = GymSuiteResult {
+        suite_id: "test".to_string(),
+        success: true,
+        overall_score: 0.77,
+        dimensions: ScoreDimensions {
+            factual_accuracy: 0.8,
+            specificity: 0.75,
+            temporal_awareness: 0.7,
+            source_attribution: 0.65,
+            confidence_calibration: 0.95,
+        },
+        scenario_results: vec![scenario_result("L1", 0.9, true)],
+        scenarios_passed: 1,
+        scenarios_total: 1,
+        error_message: None,
+        degraded_sources: vec![],
+    };
+    let score = suite_score_from_result(&result);
+    // suite-level overall should win over naive average of scenario results.
+    assert!((score.overall - 0.77).abs() < 1e-9);
+    assert!((score.dimensions.confidence_calibration - 0.95).abs() < 1e-9);
+}
+
+// ---------------------------------------------------------------------------
+// Regression detection tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn detect_regression_catches_significant_drops() {
+    let baseline = suite_score(0.85, 0.9);
+    let current = suite_score(0.6, 0.5);
+    let regressions = detect_regression(&current, &baseline);
+    assert!(!regressions.is_empty());
+
+    let accuracy = regressions
+        .iter()
+        .find(|r| r.dimension == "factual_accuracy")
+        .expect("should detect factual_accuracy regression");
+    assert!(accuracy.delta < 0.0);
+    assert_eq!(accuracy.severity, RegressionSeverity::Severe);
+}
+
+#[test]
+fn detect_regression_ignores_improvements() {
+    let baseline = suite_score(0.5, 0.5);
+    let current = suite_score(0.9, 0.9);
+    let regressions = detect_regression(&current, &baseline);
+    assert!(regressions.is_empty());
+}
+
+#[test]
+fn detect_regression_ignores_small_fluctuations() {
+    let baseline = suite_score(0.80, 0.80);
+    let current = suite_score(0.795, 0.795);
+    let regressions = detect_regression(&current, &baseline);
+    assert!(
+        regressions.is_empty(),
+        "tiny drops below threshold should not trigger: {regressions:?}"
+    );
+}
+
+// Improvement trend tests
+
+#[test]
+fn track_improvement_directions() {
+    // Single entry: stable
+    let t = track_improvement(&[suite_score(0.8, 0.8)]);
+    assert_eq!(t.overall_direction, TrendDirection::Stable);
+    assert!(t.dimension_trends.is_empty());
+    // Stable when flat
+    let t = track_improvement(&[suite_score(0.75, 0.75), suite_score(0.76, 0.76)]);
+    assert_eq!(t.overall_direction, TrendDirection::Stable);
+    // Improving
+    let h = vec![
+        suite_score(0.5, 0.5),
+        suite_score(0.65, 0.65),
+        suite_score(0.8, 0.8),
+    ];
+    let t = track_improvement(&h);
+    assert_eq!(t.overall_direction, TrendDirection::Improving);
+    assert_eq!(t.run_count, 3);
+    for dt in &t.dimension_trends {
+        assert_eq!(dt.history.len(), 3);
+    }
+    // Declining
+    let h = vec![
+        suite_score(0.9, 0.9),
+        suite_score(0.7, 0.7),
+        suite_score(0.5, 0.5),
+    ];
+    assert_eq!(
+        track_improvement(&h).overall_direction,
+        TrendDirection::Declining
+    );
+}
+
+// End-to-end pipeline: bridge -> scoring -> regression -> trend
+
+#[test]
+fn full_pipeline_bridge_to_trend() {
+    let bridge = mock_bridge_with_scenarios();
+    let current_score = suite_score_from_result(&bridge.run_suite("progressive").unwrap());
+    let baseline = suite_score(0.90, 0.95);
+    let regressions = detect_regression(&current_score, &baseline);
+    assert!(!regressions.is_empty(), "0.78 should regress vs 0.90");
+    let trend = track_improvement(&[baseline, current_score]);
+    assert_eq!(trend.overall_direction, TrendDirection::Declining);
+}
+
+// Degradation visibility and serialization (Pillar 11)
+
+#[test]
+fn degradation_and_serialization() {
+    let r = GymScenarioResult {
+        scenario_id: "L5".into(),
+        success: false,
+        score: 0.0,
+        dimensions: ScoreDimensions::default(),
+        question_count: 10,
+        questions_answered: 0,
+        error_message: Some("timeout".into()),
+        degraded_sources: vec!["progressive_test_suite".into()],
+    };
+    assert_eq!(r.degraded_sources.len(), 1);
+    assert!(r.error_message.is_some());
+    // Roundtrip serialization
+    let dims = ScoreDimensions {
+        factual_accuracy: 0.91,
+        specificity: 0.82,
+        temporal_awareness: 0.73,
+        source_attribution: 0.64,
+        confidence_calibration: 0.55,
+    };
+    let back: ScoreDimensions =
+        serde_json::from_str(&serde_json::to_string(&dims).unwrap()).unwrap();
+    assert_eq!(dims, back);
+}


### PR DESCRIPTION
## Summary

- Add `GymBridge` (Rust) wrapping `BridgeTransport` to call the Python gym eval server with typed RPC methods: `list_scenarios`, `run_scenario`, `run_suite`
- Add `gym_scoring` module with `aggregate_suite_scores`, `detect_regression`, and `track_improvement` operating on five scoring dimensions (factual_accuracy, specificity, temporal_awareness, source_attribution, confidence_calibration)
- Add `simard_gym_bridge.py` extending `BridgeServer` to wrap amplihack-agent-eval's progressive test suite (L1-L12) and long-horizon memory evaluation
- Integration tests validate the full pipeline: bridge call -> deserialization -> scoring -> regression detection -> improvement trend tracking

## Design decisions

- Five scoring dimensions align with `long_horizon_memory.ALL_DIMENSIONS` from amplihack-agent-eval
- Python bridge imports progressive suite and long-horizon eval lazily; missing components are logged as degraded sources (Pillar 11)
- Regression detection uses a 0.01 threshold with Minor/Moderate/Severe severity classification
- Improvement tracking requires >= 2 data points; single entry returns Stable

## File sizes

| File | LOC |
|------|-----|
| `src/gym_bridge.rs` | 300 |
| `src/gym_scoring.rs` | 299 |
| `python/simard_gym_bridge.py` | 282 |
| `tests/gym_eval.rs` | 374 |

## Test plan

- [x] `cargo test` — all 128 unit tests + 70 integration tests + 13 gym_eval tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [ ] Manual: verify `simard_gym_bridge.py` runs against live amplihack-agent-eval (requires eval package installed)

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)