### PR TITLE
fix: Phase 3 review findings — command validation, parser fix

### DIFF
--- a/src/base_type_copilot.rs
+++ b/src/base_type_copilot.rs
@@ -56,7 +56,11 @@ impl CopilotSdkAdapter {
     }
 
     /// Create a new CopilotSdkAdapter with explicit configuration.
+    ///
+    /// The `config.command` is validated to reject shell metacharacters
+    /// (`;`, `|`, `&`, `` ` ``, `$`) for defense-in-depth.
     pub fn with_config(id: impl Into<String>, config: CopilotAdapterConfig) -> SimardResult<Self> {
+        validate_command(&config.command)?;
         let id = BaseTypeId::new(id);
         Ok(Self {
             descriptor: BaseTypeDescriptor {
@@ -279,6 +283,33 @@ pub fn parse_copilot_response(raw: &str) -> SimardResult<crate::base_type_turn::
     parse_turn_output(raw)
 }
 
+/// Validate that a command string does not contain shell metacharacters.
+///
+/// This is a defense-in-depth check. The command is an operator-configured
+/// value, not user input, but we reject obvious injection patterns to
+/// prevent accidental misconfiguration.
+fn validate_command(command: &str) -> SimardResult<()> {
+    const FORBIDDEN: &[char] = &[';', '|', '&', '`', '$'];
+    if let Some(ch) = command.chars().find(|c| FORBIDDEN.contains(c)) {
+        return Err(SimardError::InvalidConfigValue {
+            key: "command".to_string(),
+            value: command.to_string(),
+            help: format!(
+                "command contains forbidden shell metacharacter '{ch}'; \
+                 use a simple command without shell operators"
+            ),
+        });
+    }
+    if command.trim().is_empty() {
+        return Err(SimardError::InvalidConfigValue {
+            key: "command".to_string(),
+            value: command.to_string(),
+            help: "command must not be empty".to_string(),
+        });
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -342,6 +373,27 @@ mod tests {
         let mut request = test_request();
         request.topology = RuntimeTopology::MultiProcess;
         let result = adapter.open_session(request);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn copilot_adapter_rejects_command_with_shell_metacharacters() {
+        let config = CopilotAdapterConfig {
+            command: "echo; rm -rf /".to_string(),
+            working_directory: None,
+        };
+        let result = CopilotSdkAdapter::with_config("copilot-inject", config);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("forbidden"));
+    }
+
+    #[test]
+    fn copilot_adapter_rejects_empty_command() {
+        let config = CopilotAdapterConfig {
+            command: "  ".to_string(),
+            working_directory: None,
+        };
+        let result = CopilotSdkAdapter::with_config("copilot-empty", config);
         assert!(result.is_err());
     }
 

--- a/src/base_type_turn.rs
+++ b/src/base_type_turn.rs
@@ -203,7 +203,7 @@ pub fn parse_turn_output(raw: &str) -> SimardResult<TurnOutput> {
 
         if let Some(rest) = strip_prefix_case_insensitive(line, ACTION_PREFIX) {
             let rest = rest.trim();
-            if let Some((kind, desc)) = rest.split_once('—').or_else(|| rest.split_once('-')) {
+            if let Some((kind, desc)) = rest.split_once('—').or_else(|| rest.split_once(" - ")) {
                 let kind = kind.trim().to_string();
                 let desc = desc.trim().to_string();
                 if !kind.is_empty() && !desc.is_empty() {


### PR DESCRIPTION
## Summary

- Add `validate_command()` rejecting shell metacharacters in adapter config
- Fix action parser hyphen fallback: ` - ` instead of bare `-`
- Add feral tests for command injection and empty command

Resolves #106

## Test plan
- [x] All tests pass locally (cargo test --quiet)
- [x] Clippy clean
- [x] New tests: metacharacter rejection, empty command rejection
- [ ] CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)