### PR TITLE
feat: Phase 7 — remote VM orchestration via azlin

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,9 @@ pub mod operator_commands;
 mod persistence;
 pub mod prompt_assets;
 pub mod reflection;
+pub mod remote_azlin;
+pub mod remote_session;
+pub mod remote_transfer;
 pub mod review;
 pub mod runtime;
 mod sanitization;
@@ -153,6 +156,9 @@ pub use prompt_assets::{
     PromptAssetStore,
 };
 pub use reflection::{ReflectionReport, ReflectionSnapshot, ReflectiveRuntime};
+pub use remote_azlin::{AzlinConfig, AzlinExecutor, AzlinVm, RealAzlinExecutor};
+pub use remote_session::{RemoteConfig, RemoteSession, RemoteStatus};
+pub use remote_transfer::MemorySnapshot;
 pub use review::{
     ImprovementProposal, ReviewArtifact, ReviewRequest, ReviewSignal, ReviewTargetKind,
     build_review_artifact, latest_review_artifact, load_review_artifact, persist_review_artifact,

--- a/src/remote_azlin.rs
+++ b/src/remote_azlin.rs
@@ -1,0 +1,334 @@
+//! Wrapper around the `azlin` CLI for VM lifecycle management.
+//!
+//! `azlin` is an external tool that creates, manages, and destroys Azure VMs.
+//! This module shells out to `azlin` commands and parses their output. All
+//! functions return `SimardResult` so callers get consistent error handling.
+//!
+//! In production, `azlin` must be on `$PATH`. Tests inject a mock executor
+//! to avoid real VM creation.
+
+use std::fmt::{self, Display, Formatter};
+use std::process::Command;
+
+use crate::error::{SimardError, SimardResult};
+
+/// Configuration for VM creation via azlin.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct AzlinConfig {
+    /// Azure region (e.g. "eastus2"). None uses azlin's default.
+    pub region: Option<String>,
+    /// VM size (e.g. "Standard_D4s_v3"). None uses azlin's default.
+    pub size: Option<String>,
+    /// Optional SSH public key path. None uses azlin's default (~/.ssh/id_rsa.pub).
+    pub ssh_key_path: Option<String>,
+}
+
+/// Represents a VM managed by azlin.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AzlinVm {
+    /// The name used to identify this VM in azlin commands.
+    pub name: String,
+    /// The public IP address assigned to the VM.
+    pub ip: String,
+    /// Current azlin-reported status (e.g. "running", "creating", "deleted").
+    pub status: String,
+}
+
+impl Display for AzlinVm {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "AzlinVm({}, ip={}, status={})",
+            self.name, self.ip, self.status
+        )
+    }
+}
+
+/// Trait abstracting azlin CLI execution for testability.
+///
+/// Production code uses `RealAzlinExecutor` which shells out to the `azlin`
+/// binary. Tests inject `MockAzlinExecutor` to simulate VM lifecycle without
+/// real infrastructure.
+pub trait AzlinExecutor: Send + Sync {
+    /// Run an azlin command and return stdout on success.
+    fn run(&self, args: &[&str]) -> SimardResult<String>;
+}
+
+/// Production executor that invokes the real `azlin` CLI.
+pub struct RealAzlinExecutor;
+
+impl AzlinExecutor for RealAzlinExecutor {
+    fn run(&self, args: &[&str]) -> SimardResult<String> {
+        let output = Command::new("azlin").args(args).output().map_err(|e| {
+            SimardError::BridgeSpawnFailed {
+                bridge: "azlin".to_string(),
+                reason: format!("failed to execute azlin: {e}"),
+            }
+        })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(SimardError::BridgeTransportError {
+                bridge: "azlin".to_string(),
+                reason: format!(
+                    "azlin {} exited with {}: {}",
+                    args.first().unwrap_or(&"<unknown>"),
+                    output.status,
+                    stderr.trim()
+                ),
+            });
+        }
+
+        String::from_utf8(output.stdout).map_err(|e| SimardError::BridgeProtocolError {
+            bridge: "azlin".to_string(),
+            reason: format!("azlin output was not valid UTF-8: {e}"),
+        })
+    }
+}
+
+/// Create a new VM via `azlin create`.
+///
+/// Parses the azlin output to extract the VM name and IP address.
+/// The VM name is passed directly; azlin assigns the IP.
+pub fn azlin_create(
+    name: &str,
+    config: &AzlinConfig,
+    executor: &dyn AzlinExecutor,
+) -> SimardResult<AzlinVm> {
+    if name.is_empty() {
+        return Err(SimardError::InvalidConfigValue {
+            key: "vm_name".to_string(),
+            value: String::new(),
+            help: "VM name cannot be empty".to_string(),
+        });
+    }
+    // Reject names with characters that could cause shell injection or azlin issues.
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return Err(SimardError::InvalidConfigValue {
+            key: "vm_name".to_string(),
+            value: name.to_string(),
+            help: "VM name must contain only alphanumeric characters, hyphens, and underscores"
+                .to_string(),
+        });
+    }
+
+    let mut args = vec!["create", name];
+    let region_flag;
+    if let Some(ref region) = config.region {
+        region_flag = format!("--region={region}");
+        args.push(&region_flag);
+    }
+    let size_flag;
+    if let Some(ref size) = config.size {
+        size_flag = format!("--size={size}");
+        args.push(&size_flag);
+    }
+
+    let output = executor.run(&args)?;
+    parse_azlin_create_output(name, &output)
+}
+
+/// Get an SSH connection string for a VM via `azlin ssh`.
+///
+/// Returns a connection string like "azureuser@<ip>" that can be used
+/// with `ssh` or `scp` commands.
+pub fn azlin_ssh(vm: &AzlinVm, executor: &dyn AzlinExecutor) -> SimardResult<String> {
+    if vm.status != "running" {
+        return Err(SimardError::BridgeTransportError {
+            bridge: "azlin".to_string(),
+            reason: format!("cannot SSH to VM '{}' in status '{}'", vm.name, vm.status),
+        });
+    }
+
+    let output = executor.run(&["ssh", &vm.name, "--print-command"])?;
+    let trimmed = output.trim().to_string();
+    if trimmed.is_empty() {
+        return Err(SimardError::BridgeProtocolError {
+            bridge: "azlin".to_string(),
+            reason: "azlin ssh returned empty output".to_string(),
+        });
+    }
+    Ok(trimmed)
+}
+
+/// Destroy a VM via `azlin destroy`.
+///
+/// This is idempotent — destroying an already-destroyed VM is not an error
+/// from azlin's perspective, though the caller should track status.
+pub fn azlin_destroy(vm: &AzlinVm, executor: &dyn AzlinExecutor) -> SimardResult<()> {
+    executor.run(&["destroy", &vm.name, "--yes"])?;
+    Ok(())
+}
+
+/// Parse the output of `azlin create` to extract VM details.
+///
+/// Expected format (one key=value per line):
+/// ```text
+/// name=simard-remote-1
+/// ip=20.10.30.40
+/// status=running
+/// ```
+fn parse_azlin_create_output(expected_name: &str, output: &str) -> SimardResult<AzlinVm> {
+    let mut ip = None;
+    let mut status = None;
+
+    for line in output.lines() {
+        let line = line.trim();
+        if let Some(value) = line.strip_prefix("ip=") {
+            ip = Some(value.to_string());
+        } else if let Some(value) = line.strip_prefix("status=") {
+            status = Some(value.to_string());
+        }
+    }
+
+    let ip = ip.ok_or_else(|| SimardError::BridgeProtocolError {
+        bridge: "azlin".to_string(),
+        reason: format!("azlin create output missing 'ip=' field for VM '{expected_name}'"),
+    })?;
+
+    Ok(AzlinVm {
+        name: expected_name.to_string(),
+        ip,
+        status: status.unwrap_or_else(|| "running".to_string()),
+    })
+}
+
+/// Type alias for the mock handler closure to satisfy clippy complexity lint.
+type MockHandler = Box<dyn Fn(&[&str]) -> SimardResult<String> + Send + Sync>;
+
+/// Mock executor for testing. Accepts a closure that handles azlin commands.
+///
+/// Available in all builds so that integration tests (`tests/`) can use it.
+/// The struct has zero cost in production since it is only instantiated in tests.
+pub struct MockAzlinExecutor {
+    handler: MockHandler,
+}
+
+impl MockAzlinExecutor {
+    pub fn new(handler: impl Fn(&[&str]) -> SimardResult<String> + Send + Sync + 'static) -> Self {
+        Self {
+            handler: Box::new(handler),
+        }
+    }
+}
+
+impl AzlinExecutor for MockAzlinExecutor {
+    fn run(&self, args: &[&str]) -> SimardResult<String> {
+        (self.handler)(args)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn success_executor() -> MockAzlinExecutor {
+        MockAzlinExecutor::new(|args| match args.first().copied() {
+            Some("create") => Ok("name=test-vm\nip=10.0.0.1\nstatus=running\n".to_string()),
+            Some("ssh") => Ok("ssh azureuser@10.0.0.1".to_string()),
+            Some("destroy") => Ok(String::new()),
+            _ => Err(SimardError::BridgeTransportError {
+                bridge: "azlin".to_string(),
+                reason: format!("unexpected command: {args:?}"),
+            }),
+        })
+    }
+
+    #[test]
+    fn create_vm_parses_output() {
+        let executor = success_executor();
+        let config = AzlinConfig::default();
+        let vm = azlin_create("test-vm", &config, &executor).unwrap();
+        assert_eq!(vm.name, "test-vm");
+        assert_eq!(vm.ip, "10.0.0.1");
+        assert_eq!(vm.status, "running");
+    }
+
+    #[test]
+    fn create_vm_with_region_and_size() {
+        let executor = success_executor();
+        let config = AzlinConfig {
+            region: Some("westus2".to_string()),
+            size: Some("Standard_D4s_v3".to_string()),
+            ssh_key_path: None,
+        };
+        let vm = azlin_create("test-vm", &config, &executor).unwrap();
+        assert_eq!(vm.status, "running");
+    }
+
+    #[test]
+    fn create_rejects_empty_name() {
+        let executor = success_executor();
+        let err = azlin_create("", &AzlinConfig::default(), &executor).unwrap_err();
+        assert!(matches!(err, SimardError::InvalidConfigValue { .. }));
+    }
+
+    #[test]
+    fn create_rejects_invalid_name_chars() {
+        let executor = success_executor();
+        let err = azlin_create("vm;rm -rf /", &AzlinConfig::default(), &executor).unwrap_err();
+        assert!(matches!(err, SimardError::InvalidConfigValue { .. }));
+    }
+
+    #[test]
+    fn ssh_returns_connection_string() {
+        let executor = success_executor();
+        let vm = AzlinVm {
+            name: "test-vm".to_string(),
+            ip: "10.0.0.1".to_string(),
+            status: "running".to_string(),
+        };
+        let conn = azlin_ssh(&vm, &executor).unwrap();
+        assert!(conn.contains("azureuser@10.0.0.1"));
+    }
+
+    #[test]
+    fn ssh_rejects_non_running_vm() {
+        let executor = success_executor();
+        let vm = AzlinVm {
+            name: "test-vm".to_string(),
+            ip: "10.0.0.1".to_string(),
+            status: "creating".to_string(),
+        };
+        let err = azlin_ssh(&vm, &executor).unwrap_err();
+        assert!(matches!(err, SimardError::BridgeTransportError { .. }));
+    }
+
+    #[test]
+    fn destroy_succeeds() {
+        let executor = success_executor();
+        let vm = AzlinVm {
+            name: "test-vm".to_string(),
+            ip: "10.0.0.1".to_string(),
+            status: "running".to_string(),
+        };
+        azlin_destroy(&vm, &executor).unwrap();
+    }
+
+    #[test]
+    fn parse_output_missing_ip_fails() {
+        let err = parse_azlin_create_output("vm-1", "status=running\n").unwrap_err();
+        assert!(matches!(err, SimardError::BridgeProtocolError { .. }));
+    }
+
+    #[test]
+    fn parse_output_defaults_status_to_running() {
+        let vm = parse_azlin_create_output("vm-1", "ip=1.2.3.4\n").unwrap();
+        assert_eq!(vm.status, "running");
+    }
+
+    #[test]
+    fn vm_display_is_readable() {
+        let vm = AzlinVm {
+            name: "test-vm".to_string(),
+            ip: "10.0.0.1".to_string(),
+            status: "running".to_string(),
+        };
+        let s = vm.to_string();
+        assert!(s.contains("test-vm"));
+        assert!(s.contains("10.0.0.1"));
+    }
+}

--- a/src/remote_session.rs
+++ b/src/remote_session.rs
@@ -1,0 +1,398 @@
+//! Remote session management for distributed agent orchestration.
+//!
+//! A `RemoteSession` represents a coding agent running on a remote VM
+//! provisioned via azlin. Lifecycle: Creating -> Running -> Transferring
+//! -> Completed (or Failed). Each session is isolated by agent_name.
+
+use std::fmt::{self, Display, Formatter};
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::error::{SimardError, SimardResult};
+use crate::remote_azlin::{
+    AzlinConfig, AzlinExecutor, AzlinVm, azlin_create, azlin_destroy, azlin_ssh,
+};
+
+/// Status of a remote session.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RemoteStatus {
+    /// VM is being provisioned.
+    Creating,
+    /// Agent is deployed and operating.
+    Running,
+    /// Memory is being transferred to or from the VM.
+    Transferring,
+    /// Session completed successfully.
+    Completed,
+    /// Session failed with the given reason.
+    Failed(String),
+}
+
+impl Display for RemoteStatus {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Creating => f.write_str("creating"),
+            Self::Running => f.write_str("running"),
+            Self::Transferring => f.write_str("transferring"),
+            Self::Completed => f.write_str("completed"),
+            Self::Failed(reason) => write!(f, "failed: {reason}"),
+        }
+    }
+}
+
+/// Configuration for creating a remote session.
+#[derive(Clone, Debug)]
+pub struct RemoteConfig {
+    /// Name for the remote VM (must be unique across active sessions).
+    pub vm_name: String,
+    /// Agent identity name for this remote session.
+    pub agent_name: String,
+    /// azlin configuration for VM creation.
+    pub azlin_config: AzlinConfig,
+}
+
+/// A remote coding session running on a provisioned VM.
+#[derive(Clone, Debug)]
+pub struct RemoteSession {
+    /// The VM name as registered with azlin.
+    pub vm_name: String,
+    /// The public IP address of the VM.
+    pub ip_address: String,
+    /// The agent identity running on this VM.
+    pub agent_name: String,
+    /// Current lifecycle status.
+    pub status: RemoteStatus,
+    /// When the session was created (unix epoch seconds).
+    pub created_at: u64,
+    /// The underlying azlin VM handle.
+    vm: AzlinVm,
+}
+
+impl Display for RemoteSession {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "RemoteSession(vm={}, agent={}, ip={}, status={})",
+            self.vm_name, self.agent_name, self.ip_address, self.status
+        )
+    }
+}
+
+impl RemoteSession {
+    /// Whether the session is in a terminal state (completed or failed).
+    pub fn is_terminal(&self) -> bool {
+        matches!(
+            self.status,
+            RemoteStatus::Completed | RemoteStatus::Failed(_)
+        )
+    }
+
+    /// Whether the session's VM is reachable (creating or running or transferring).
+    pub fn is_active(&self) -> bool {
+        matches!(
+            self.status,
+            RemoteStatus::Creating | RemoteStatus::Running | RemoteStatus::Transferring
+        )
+    }
+
+    /// Get a reference to the underlying azlin VM.
+    pub fn vm(&self) -> &AzlinVm {
+        &self.vm
+    }
+}
+
+/// Create a new remote session by provisioning a VM via azlin.
+///
+/// On success, the session starts in `Running` status with the VM's IP
+/// address populated. On failure, returns a descriptive error.
+pub fn create_remote_session(
+    config: &RemoteConfig,
+    executor: &dyn AzlinExecutor,
+) -> SimardResult<RemoteSession> {
+    if config.vm_name.is_empty() {
+        return Err(SimardError::InvalidConfigValue {
+            key: "vm_name".to_string(),
+            value: String::new(),
+            help: "remote session VM name cannot be empty".to_string(),
+        });
+    }
+    if config.agent_name.is_empty() {
+        return Err(SimardError::InvalidConfigValue {
+            key: "agent_name".to_string(),
+            value: String::new(),
+            help: "remote session agent name cannot be empty".to_string(),
+        });
+    }
+
+    let vm = azlin_create(&config.vm_name, &config.azlin_config, executor)?;
+    let now = current_epoch_seconds()?;
+
+    Ok(RemoteSession {
+        vm_name: vm.name.clone(),
+        ip_address: vm.ip.clone(),
+        agent_name: config.agent_name.clone(),
+        status: RemoteStatus::Running,
+        created_at: now,
+        vm,
+    })
+}
+
+/// Deploy an agent binary to a remote session via SCP.
+///
+/// Uses the azlin SSH connection to copy the binary and make it executable.
+/// The session must be in `Running` status.
+pub fn deploy_agent(
+    session: &RemoteSession,
+    binary_path: &Path,
+    executor: &dyn AzlinExecutor,
+) -> SimardResult<()> {
+    if session.status != RemoteStatus::Running {
+        return Err(SimardError::BridgeTransportError {
+            bridge: "remote-session".to_string(),
+            reason: format!(
+                "cannot deploy to session '{}' in status '{}'",
+                session.vm_name, session.status
+            ),
+        });
+    }
+
+    if !binary_path
+        .as_os_str()
+        .to_string_lossy()
+        .ends_with("simard")
+    {
+        return Err(SimardError::InvalidConfigValue {
+            key: "binary_path".to_string(),
+            value: binary_path.display().to_string(),
+            help: "binary path must point to a simard binary".to_string(),
+        });
+    }
+
+    // Use scp via the VM's IP to deploy the binary.
+    let remote_dest = format!("azureuser@{}:/usr/local/bin/simard", session.ip_address);
+    executor.run(&["scp", &binary_path.display().to_string(), &remote_dest])?;
+
+    // Make the binary executable.
+    let ssh_target = format!("azureuser@{}", session.ip_address);
+    executor.run(&["ssh", &ssh_target, "chmod", "+x", "/usr/local/bin/simard"])?;
+
+    Ok(())
+}
+
+/// Establish a PTY connection to a remote session.
+///
+/// Returns the SSH command string that can be used to connect to the VM.
+/// The session must be in `Running` status.
+pub fn establish_pty(
+    session: &RemoteSession,
+    executor: &dyn AzlinExecutor,
+) -> SimardResult<String> {
+    if session.status != RemoteStatus::Running {
+        return Err(SimardError::BridgeTransportError {
+            bridge: "remote-session".to_string(),
+            reason: format!(
+                "cannot establish PTY to session '{}' in status '{}'",
+                session.vm_name, session.status
+            ),
+        });
+    }
+
+    azlin_ssh(&session.vm, executor)
+}
+
+/// Destroy a remote session by tearing down its VM.
+///
+/// Transitions the session to `Completed` on success or `Failed` on error.
+/// The session's VM is destroyed regardless of current status (cleanup).
+pub fn destroy_session(
+    session: &mut RemoteSession,
+    executor: &dyn AzlinExecutor,
+) -> SimardResult<()> {
+    if session.is_terminal() {
+        return Err(SimardError::BridgeTransportError {
+            bridge: "remote-session".to_string(),
+            reason: format!(
+                "session '{}' is already in terminal status '{}'",
+                session.vm_name, session.status
+            ),
+        });
+    }
+
+    match azlin_destroy(&session.vm, executor) {
+        Ok(()) => {
+            session.status = RemoteStatus::Completed;
+            Ok(())
+        }
+        Err(e) => {
+            session.status = RemoteStatus::Failed(e.to_string());
+            Err(e)
+        }
+    }
+}
+
+/// Transition a session to the Transferring state.
+///
+/// Used before memory export/import operations to signal that the session
+/// is temporarily busy with data transfer.
+pub fn begin_transfer(session: &mut RemoteSession) -> SimardResult<()> {
+    if session.status != RemoteStatus::Running {
+        return Err(SimardError::BridgeTransportError {
+            bridge: "remote-session".to_string(),
+            reason: format!(
+                "cannot begin transfer for session '{}' in status '{}'",
+                session.vm_name, session.status
+            ),
+        });
+    }
+    session.status = RemoteStatus::Transferring;
+    Ok(())
+}
+
+/// Transition a session back to Running after a transfer completes.
+pub fn end_transfer(session: &mut RemoteSession) -> SimardResult<()> {
+    if session.status != RemoteStatus::Transferring {
+        return Err(SimardError::BridgeTransportError {
+            bridge: "remote-session".to_string(),
+            reason: format!(
+                "cannot end transfer for session '{}' in status '{}'",
+                session.vm_name, session.status
+            ),
+        });
+    }
+    session.status = RemoteStatus::Running;
+    Ok(())
+}
+
+fn current_epoch_seconds() -> SimardResult<u64> {
+    let duration = SystemTime::now().duration_since(UNIX_EPOCH).map_err(|e| {
+        SimardError::ClockBeforeUnixEpoch {
+            reason: e.to_string(),
+        }
+    })?;
+    Ok(duration.as_secs())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::remote_azlin::MockAzlinExecutor;
+
+    fn mock_executor() -> MockAzlinExecutor {
+        MockAzlinExecutor::new(|args| match args.first().copied() {
+            Some("create") => Ok("name=test-vm\nip=10.0.0.1\nstatus=running\n".to_string()),
+            Some("ssh") => Ok("ssh azureuser@10.0.0.1".to_string()),
+            Some("destroy") => Ok(String::new()),
+            Some("scp") => Ok(String::new()),
+            _ => Ok(String::new()),
+        })
+    }
+
+    fn test_config() -> RemoteConfig {
+        RemoteConfig {
+            vm_name: "test-vm".to_string(),
+            agent_name: "remote-engineer-1".to_string(),
+            azlin_config: AzlinConfig::default(),
+        }
+    }
+
+    #[test]
+    fn create_session_succeeds() {
+        let executor = mock_executor();
+        let session = create_remote_session(&test_config(), &executor).unwrap();
+        assert_eq!(session.vm_name, "test-vm");
+        assert_eq!(session.ip_address, "10.0.0.1");
+        assert_eq!(session.agent_name, "remote-engineer-1");
+        assert_eq!(session.status, RemoteStatus::Running);
+        assert!(!session.is_terminal());
+        assert!(session.is_active());
+    }
+
+    #[test]
+    fn create_rejects_empty_vm_name() {
+        let executor = mock_executor();
+        let mut config = test_config();
+        config.vm_name = String::new();
+        let err = create_remote_session(&config, &executor).unwrap_err();
+        assert!(matches!(err, SimardError::InvalidConfigValue { .. }));
+    }
+
+    #[test]
+    fn create_rejects_empty_agent_name() {
+        let executor = mock_executor();
+        let mut config = test_config();
+        config.agent_name = String::new();
+        let err = create_remote_session(&config, &executor).unwrap_err();
+        assert!(matches!(err, SimardError::InvalidConfigValue { .. }));
+    }
+
+    #[test]
+    fn establish_pty_returns_ssh_command() {
+        let executor = mock_executor();
+        let session = create_remote_session(&test_config(), &executor).unwrap();
+        let cmd = establish_pty(&session, &executor).unwrap();
+        assert!(cmd.contains("azureuser@10.0.0.1"));
+    }
+
+    #[test]
+    fn destroy_session_transitions_to_completed() {
+        let executor = mock_executor();
+        let mut session = create_remote_session(&test_config(), &executor).unwrap();
+        destroy_session(&mut session, &executor).unwrap();
+        assert_eq!(session.status, RemoteStatus::Completed);
+        assert!(session.is_terminal());
+    }
+
+    #[test]
+    fn destroy_already_terminal_fails() {
+        let executor = mock_executor();
+        let mut session = create_remote_session(&test_config(), &executor).unwrap();
+        destroy_session(&mut session, &executor).unwrap();
+        let err = destroy_session(&mut session, &executor).unwrap_err();
+        assert!(matches!(err, SimardError::BridgeTransportError { .. }));
+    }
+
+    #[test]
+    fn transfer_lifecycle() {
+        let executor = mock_executor();
+        let mut session = create_remote_session(&test_config(), &executor).unwrap();
+        assert_eq!(session.status, RemoteStatus::Running);
+
+        begin_transfer(&mut session).unwrap();
+        assert_eq!(session.status, RemoteStatus::Transferring);
+        assert!(session.is_active());
+
+        end_transfer(&mut session).unwrap();
+        assert_eq!(session.status, RemoteStatus::Running);
+    }
+
+    #[test]
+    fn begin_transfer_rejects_non_running() {
+        let executor = mock_executor();
+        let mut session = create_remote_session(&test_config(), &executor).unwrap();
+        destroy_session(&mut session, &executor).unwrap();
+        let err = begin_transfer(&mut session).unwrap_err();
+        assert!(matches!(err, SimardError::BridgeTransportError { .. }));
+    }
+
+    #[test]
+    fn status_display_covers_all_variants() {
+        assert_eq!(RemoteStatus::Creating.to_string(), "creating");
+        assert_eq!(RemoteStatus::Running.to_string(), "running");
+        assert_eq!(RemoteStatus::Transferring.to_string(), "transferring");
+        assert_eq!(RemoteStatus::Completed.to_string(), "completed");
+        assert!(
+            RemoteStatus::Failed("oops".to_string())
+                .to_string()
+                .contains("oops")
+        );
+    }
+
+    #[test]
+    fn session_display_is_readable() {
+        let executor = mock_executor();
+        let session = create_remote_session(&test_config(), &executor).unwrap();
+        let s = session.to_string();
+        assert!(s.contains("test-vm"));
+        assert!(s.contains("remote-engineer-1"));
+    }
+}

--- a/src/remote_transfer.rs
+++ b/src/remote_transfer.rs
@@ -1,0 +1,374 @@
+//! Memory snapshot replication for remote agent sessions.
+//!
+//! When an agent migrates to a remote VM, it needs to carry its cognitive
+//! memory state. This module exports facts and procedures from a local
+//! `CognitiveMemoryBridge`, serializes them into a `MemorySnapshot`, and
+//! can import that snapshot into a remote bridge.
+//!
+//! Only facts and procedures are replicated. Sensory and working memory
+//! are ephemeral and session-local. Episodes are too large for migration
+//! and can be re-derived from facts. Prospective memories are local triggers.
+
+use std::fmt::{self, Display, Formatter};
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{SimardError, SimardResult};
+use crate::memory_bridge::CognitiveMemoryBridge;
+use crate::memory_cognitive::{CognitiveFact, CognitiveProcedure};
+
+/// Maximum number of facts to export in a single snapshot.
+const MAX_EXPORT_FACTS: u32 = 1000;
+
+/// Maximum number of procedures to export in a single snapshot.
+const MAX_EXPORT_PROCEDURES: u32 = 200;
+
+/// A portable snapshot of cognitive memory for replication.
+///
+/// Contains the subset of memory types that are worth migrating:
+/// semantic facts (durable knowledge) and procedures (reusable workflows).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MemorySnapshot {
+    /// Semantic facts exported from the source bridge.
+    pub facts: Vec<CognitiveFact>,
+    /// Procedural memories exported from the source bridge.
+    pub procedures: Vec<CognitiveProcedure>,
+    /// Unix epoch seconds when this snapshot was created.
+    pub exported_at: u64,
+    /// The agent name that produced this snapshot.
+    pub source_agent: String,
+}
+
+impl Display for MemorySnapshot {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "MemorySnapshot(facts={}, procedures={}, agent={}, at={})",
+            self.facts.len(),
+            self.procedures.len(),
+            self.source_agent,
+            self.exported_at
+        )
+    }
+}
+
+impl MemorySnapshot {
+    /// Total number of items in the snapshot.
+    pub fn total_items(&self) -> usize {
+        self.facts.len() + self.procedures.len()
+    }
+
+    /// Whether the snapshot is empty (no facts or procedures).
+    pub fn is_empty(&self) -> bool {
+        self.facts.is_empty() && self.procedures.is_empty()
+    }
+}
+
+/// Export a memory snapshot from a cognitive memory bridge.
+///
+/// Queries the bridge for facts (using a broad wildcard query) and all
+/// recallable procedures. The snapshot is written to the given path as
+/// JSON if a path is provided, and always returned in memory.
+pub fn export_memory_snapshot(
+    bridge: &CognitiveMemoryBridge,
+    agent_name: &str,
+    path: Option<&Path>,
+) -> SimardResult<MemorySnapshot> {
+    if agent_name.is_empty() {
+        return Err(SimardError::InvalidConfigValue {
+            key: "agent_name".to_string(),
+            value: String::new(),
+            help: "agent name cannot be empty for memory export".to_string(),
+        });
+    }
+
+    // Query all facts with minimum confidence threshold of 0.0 to get everything.
+    let facts = bridge.search_facts("*", MAX_EXPORT_FACTS, 0.0)?;
+    let procedures = bridge.recall_procedure("*", MAX_EXPORT_PROCEDURES)?;
+
+    let now = current_epoch_seconds()?;
+
+    let snapshot = MemorySnapshot {
+        facts,
+        procedures,
+        exported_at: now,
+        source_agent: agent_name.to_string(),
+    };
+
+    if let Some(path) = path {
+        let json = serde_json::to_string_pretty(&snapshot).map_err(|e| {
+            SimardError::PersistentStoreIo {
+                store: "memory-snapshot".to_string(),
+                action: "serialize".to_string(),
+                path: path.to_path_buf(),
+                reason: e.to_string(),
+            }
+        })?;
+        std::fs::write(path, json).map_err(|e| SimardError::PersistentStoreIo {
+            store: "memory-snapshot".to_string(),
+            action: "write".to_string(),
+            path: path.to_path_buf(),
+            reason: e.to_string(),
+        })?;
+    }
+
+    Ok(snapshot)
+}
+
+/// Import a memory snapshot into a cognitive memory bridge.
+///
+/// Each fact and procedure from the snapshot is stored into the target
+/// bridge. Existing items with the same content are overwritten (the
+/// bridge server handles deduplication by concept/name).
+///
+/// Returns the count of items imported (facts + procedures).
+pub fn import_memory_snapshot(
+    bridge: &CognitiveMemoryBridge,
+    snapshot: &MemorySnapshot,
+) -> SimardResult<usize> {
+    let mut imported = 0;
+
+    for fact in &snapshot.facts {
+        bridge.store_fact(
+            &fact.concept,
+            &fact.content,
+            fact.confidence,
+            &fact.tags,
+            &fact.source_id,
+        )?;
+        imported += 1;
+    }
+
+    for proc in &snapshot.procedures {
+        bridge.store_procedure(&proc.name, &proc.steps, &proc.prerequisites)?;
+        imported += 1;
+    }
+
+    Ok(imported)
+}
+
+/// Load a memory snapshot from a JSON file on disk.
+pub fn load_snapshot_from_file(path: &Path) -> SimardResult<MemorySnapshot> {
+    let content = std::fs::read_to_string(path).map_err(|e| SimardError::PersistentStoreIo {
+        store: "memory-snapshot".to_string(),
+        action: "read".to_string(),
+        path: path.to_path_buf(),
+        reason: e.to_string(),
+    })?;
+
+    serde_json::from_str(&content).map_err(|e| SimardError::PersistentStoreIo {
+        store: "memory-snapshot".to_string(),
+        action: "deserialize".to_string(),
+        path: path.to_path_buf(),
+        reason: e.to_string(),
+    })
+}
+
+fn current_epoch_seconds() -> SimardResult<u64> {
+    let duration = SystemTime::now().duration_since(UNIX_EPOCH).map_err(|e| {
+        SimardError::ClockBeforeUnixEpoch {
+            reason: e.to_string(),
+        }
+    })?;
+    Ok(duration.as_secs())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bridge_subprocess::InMemoryBridgeTransport;
+    use serde_json::json;
+    use std::sync::Mutex;
+
+    struct MockStore {
+        facts: Vec<CognitiveFact>,
+        procedures: Vec<CognitiveProcedure>,
+    }
+
+    fn mock_bridge() -> CognitiveMemoryBridge {
+        let store: &'static Mutex<MockStore> = Box::leak(Box::new(Mutex::new(MockStore {
+            facts: vec![],
+            procedures: vec![],
+        })));
+
+        let transport =
+            InMemoryBridgeTransport::new("test-memory", move |method, params| match method {
+                "memory.search_facts" => {
+                    let s = store.lock().unwrap();
+                    let facts: Vec<serde_json::Value> = s
+                        .facts
+                        .iter()
+                        .map(|f| {
+                            json!({
+                                "node_id": f.node_id, "concept": f.concept,
+                                "content": f.content, "confidence": f.confidence,
+                                "source_id": f.source_id, "tags": f.tags,
+                            })
+                        })
+                        .collect();
+                    Ok(json!({"facts": facts}))
+                }
+                "memory.recall_procedure" => {
+                    let s = store.lock().unwrap();
+                    let procs: Vec<serde_json::Value> = s
+                        .procedures
+                        .iter()
+                        .map(|p| {
+                            json!({
+                                "node_id": p.node_id, "name": p.name,
+                                "steps": p.steps, "prerequisites": p.prerequisites,
+                                "usage_count": p.usage_count,
+                            })
+                        })
+                        .collect();
+                    Ok(json!({"procedures": procs}))
+                }
+                "memory.store_fact" => {
+                    let mut s = store.lock().unwrap();
+                    let id = format!("fact-{}", s.facts.len() + 1);
+                    s.facts.push(CognitiveFact {
+                        node_id: id.clone(),
+                        concept: params["concept"].as_str().unwrap_or("").to_string(),
+                        content: params["content"].as_str().unwrap_or("").to_string(),
+                        confidence: params["confidence"].as_f64().unwrap_or(0.0),
+                        source_id: params["source_id"].as_str().unwrap_or("").to_string(),
+                        tags: params["tags"]
+                            .as_array()
+                            .unwrap_or(&vec![])
+                            .iter()
+                            .filter_map(|v| v.as_str().map(String::from))
+                            .collect(),
+                    });
+                    Ok(json!({"id": id}))
+                }
+                "memory.store_procedure" => {
+                    let mut s = store.lock().unwrap();
+                    let id = format!("proc-{}", s.procedures.len() + 1);
+                    s.procedures.push(CognitiveProcedure {
+                        node_id: id.clone(),
+                        name: params["name"].as_str().unwrap_or("").to_string(),
+                        steps: params["steps"]
+                            .as_array()
+                            .unwrap_or(&vec![])
+                            .iter()
+                            .filter_map(|v| v.as_str().map(String::from))
+                            .collect(),
+                        prerequisites: params["prerequisites"]
+                            .as_array()
+                            .unwrap_or(&vec![])
+                            .iter()
+                            .filter_map(|v| v.as_str().map(String::from))
+                            .collect(),
+                        usage_count: 0,
+                    });
+                    Ok(json!({"id": id}))
+                }
+                _ => Err(crate::bridge::BridgeErrorPayload {
+                    code: -32601,
+                    message: format!("unknown method: {method}"),
+                }),
+            });
+        CognitiveMemoryBridge::new(Box::new(transport))
+    }
+
+    #[test]
+    fn export_empty_bridge_returns_empty_snapshot() {
+        let bridge = mock_bridge();
+        let snapshot = export_memory_snapshot(&bridge, "test-agent", None).unwrap();
+        assert!(snapshot.is_empty());
+        assert_eq!(snapshot.total_items(), 0);
+        assert_eq!(snapshot.source_agent, "test-agent");
+        assert!(snapshot.exported_at > 0);
+    }
+
+    #[test]
+    fn export_rejects_empty_agent_name() {
+        let bridge = mock_bridge();
+        let err = export_memory_snapshot(&bridge, "", None).unwrap_err();
+        assert!(matches!(err, SimardError::InvalidConfigValue { .. }));
+    }
+
+    #[test]
+    fn round_trip_export_import() {
+        let source = mock_bridge();
+        // Store some data in the source bridge.
+        source
+            .store_fact("rust", "systems language", 0.9, &[], "ep-1")
+            .unwrap();
+        source
+            .store_procedure("build", &["compile".to_string(), "test".to_string()], &[])
+            .unwrap();
+
+        let snapshot = export_memory_snapshot(&source, "agent-1", None).unwrap();
+        assert_eq!(snapshot.facts.len(), 1);
+        assert_eq!(snapshot.procedures.len(), 1);
+        assert_eq!(snapshot.total_items(), 2);
+
+        // Import into a fresh target bridge.
+        let target = mock_bridge();
+        let count = import_memory_snapshot(&target, &snapshot).unwrap();
+        assert_eq!(count, 2);
+
+        // Verify the target has the data.
+        let target_snapshot = export_memory_snapshot(&target, "agent-2", None).unwrap();
+        assert_eq!(target_snapshot.facts.len(), 1);
+        assert_eq!(target_snapshot.procedures.len(), 1);
+    }
+
+    #[test]
+    fn snapshot_serializes_to_json() {
+        let snapshot = MemorySnapshot {
+            facts: vec![CognitiveFact {
+                node_id: "f1".to_string(),
+                concept: "test".to_string(),
+                content: "test content".to_string(),
+                confidence: 0.8,
+                source_id: "".to_string(),
+                tags: vec![],
+            }],
+            procedures: vec![],
+            exported_at: 1000,
+            source_agent: "agent-x".to_string(),
+        };
+        let json = serde_json::to_string(&snapshot).unwrap();
+        let parsed: MemorySnapshot = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.facts.len(), 1);
+        assert_eq!(parsed.source_agent, "agent-x");
+    }
+
+    #[test]
+    fn snapshot_display_is_readable() {
+        let snapshot = MemorySnapshot {
+            facts: vec![],
+            procedures: vec![],
+            exported_at: 1000,
+            source_agent: "agent-x".to_string(),
+        };
+        let s = snapshot.to_string();
+        assert!(s.contains("facts=0"));
+        assert!(s.contains("agent-x"));
+    }
+
+    #[test]
+    fn export_to_file_and_load() {
+        let bridge = mock_bridge();
+        bridge
+            .store_fact("rust", "fast language", 0.95, &[], "")
+            .unwrap();
+
+        let dir = std::env::temp_dir().join("simard-test-snapshot");
+        let _ = std::fs::create_dir_all(&dir);
+        let path = dir.join("snapshot.json");
+
+        let snapshot = export_memory_snapshot(&bridge, "file-agent", Some(&path)).unwrap();
+        assert_eq!(snapshot.facts.len(), 1);
+
+        let loaded = load_snapshot_from_file(&path).unwrap();
+        assert_eq!(loaded.facts.len(), 1);
+        assert_eq!(loaded.source_agent, "file-agent");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/tests/remote.rs
+++ b/tests/remote.rs
@@ -1,0 +1,375 @@
+//! Integration tests for Phase 7: Remote VM Orchestration via azlin.
+//!
+//! All tests use a mock azlin executor — no real VMs are created.
+//! Tests verify the full session lifecycle: create, deploy, PTY, transfer,
+//! memory snapshot round-trip, and destroy.
+
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use serde_json::json;
+
+use simard::remote_azlin::{
+    AzlinConfig, AzlinExecutor, AzlinVm, MockAzlinExecutor, azlin_create, azlin_destroy, azlin_ssh,
+};
+use simard::remote_session::{
+    RemoteConfig, RemoteStatus, begin_transfer, create_remote_session, deploy_agent,
+    destroy_session, end_transfer, establish_pty,
+};
+use simard::remote_transfer::{
+    MemorySnapshot, export_memory_snapshot, import_memory_snapshot, load_snapshot_from_file,
+};
+use simard::{
+    BridgeErrorPayload, CognitiveFact, CognitiveMemoryBridge, CognitiveProcedure,
+    InMemoryBridgeTransport, SimardError,
+};
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+fn mock_executor() -> MockAzlinExecutor {
+    MockAzlinExecutor::new(|args| match args.first().copied() {
+        Some("create") => {
+            let name = args.get(1).unwrap_or(&"unknown");
+            Ok(format!("name={name}\nip=10.0.0.42\nstatus=running\n"))
+        }
+        Some("ssh") => Ok("ssh azureuser@10.0.0.42 -t".to_string()),
+        Some("destroy") => Ok(String::new()),
+        Some("scp") => Ok(String::new()),
+        _ => Ok(String::new()),
+    })
+}
+
+fn failing_executor(fail_on: &'static str) -> MockAzlinExecutor {
+    MockAzlinExecutor::new(move |args| {
+        if args.first().copied() == Some(fail_on) {
+            Err(SimardError::BridgeTransportError {
+                bridge: "azlin".to_string(),
+                reason: format!("simulated failure on {fail_on}"),
+            })
+        } else {
+            mock_executor().run(args)
+        }
+    })
+}
+
+struct MockStore {
+    facts: Vec<CognitiveFact>,
+    procedures: Vec<CognitiveProcedure>,
+}
+
+fn mock_bridge() -> CognitiveMemoryBridge {
+    let store: &'static Mutex<MockStore> = Box::leak(Box::new(Mutex::new(MockStore {
+        facts: vec![],
+        procedures: vec![],
+    })));
+
+    let transport =
+        InMemoryBridgeTransport::new("test-memory", move |method, params| match method {
+            "memory.search_facts" => {
+                let s = store.lock().unwrap();
+                let facts: Vec<serde_json::Value> = s
+                    .facts
+                    .iter()
+                    .map(|f| {
+                        json!({
+                            "node_id": f.node_id, "concept": f.concept,
+                            "content": f.content, "confidence": f.confidence,
+                            "source_id": f.source_id, "tags": f.tags,
+                        })
+                    })
+                    .collect();
+                Ok(json!({"facts": facts}))
+            }
+            "memory.recall_procedure" => {
+                let s = store.lock().unwrap();
+                let procs: Vec<serde_json::Value> = s
+                    .procedures
+                    .iter()
+                    .map(|p| {
+                        json!({
+                            "node_id": p.node_id, "name": p.name,
+                            "steps": p.steps, "prerequisites": p.prerequisites,
+                            "usage_count": p.usage_count,
+                        })
+                    })
+                    .collect();
+                Ok(json!({"procedures": procs}))
+            }
+            "memory.store_fact" => {
+                let mut s = store.lock().unwrap();
+                let id = format!("fact-{}", s.facts.len() + 1);
+                s.facts.push(CognitiveFact {
+                    node_id: id.clone(),
+                    concept: params["concept"].as_str().unwrap_or("").to_string(),
+                    content: params["content"].as_str().unwrap_or("").to_string(),
+                    confidence: params["confidence"].as_f64().unwrap_or(0.0),
+                    source_id: params["source_id"].as_str().unwrap_or("").to_string(),
+                    tags: params["tags"]
+                        .as_array()
+                        .unwrap_or(&vec![])
+                        .iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect(),
+                });
+                Ok(json!({"id": id}))
+            }
+            "memory.store_procedure" => {
+                let mut s = store.lock().unwrap();
+                let id = format!("proc-{}", s.procedures.len() + 1);
+                s.procedures.push(CognitiveProcedure {
+                    node_id: id.clone(),
+                    name: params["name"].as_str().unwrap_or("").to_string(),
+                    steps: params["steps"]
+                        .as_array()
+                        .unwrap_or(&vec![])
+                        .iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect(),
+                    prerequisites: params["prerequisites"]
+                        .as_array()
+                        .unwrap_or(&vec![])
+                        .iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect(),
+                    usage_count: 0,
+                });
+                Ok(json!({"id": id}))
+            }
+            _ => Err(BridgeErrorPayload {
+                code: -32601,
+                message: format!("method not found: {method}"),
+            }),
+        });
+    CognitiveMemoryBridge::new(Box::new(transport))
+}
+
+// ---------------------------------------------------------------------------
+// azlin CLI wrapper tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn azlin_create_and_destroy_lifecycle() {
+    let executor = mock_executor();
+    let config = AzlinConfig::default();
+    let vm = azlin_create("int-test-vm", &config, &executor).unwrap();
+    assert_eq!(vm.name, "int-test-vm");
+    assert_eq!(vm.ip, "10.0.0.42");
+    assert_eq!(vm.status, "running");
+
+    azlin_destroy(&vm, &executor).unwrap();
+}
+
+#[test]
+fn azlin_ssh_requires_running_status() {
+    let executor = mock_executor();
+    let vm = AzlinVm {
+        name: "test".to_string(),
+        ip: "10.0.0.1".to_string(),
+        status: "stopped".to_string(),
+    };
+    let err = azlin_ssh(&vm, &executor).unwrap_err();
+    assert!(matches!(err, SimardError::BridgeTransportError { .. }));
+}
+
+#[test]
+fn azlin_create_failure_propagates() {
+    let executor = failing_executor("create");
+    let err = azlin_create("fail-vm", &AzlinConfig::default(), &executor).unwrap_err();
+    assert!(matches!(err, SimardError::BridgeTransportError { .. }));
+}
+
+// ---------------------------------------------------------------------------
+// Remote session lifecycle tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn full_session_lifecycle() {
+    let executor = mock_executor();
+    let config = RemoteConfig {
+        vm_name: "lifecycle-vm".to_string(),
+        agent_name: "remote-agent-1".to_string(),
+        azlin_config: AzlinConfig::default(),
+    };
+
+    // Create session.
+    let mut session = create_remote_session(&config, &executor).unwrap();
+    assert_eq!(session.status, RemoteStatus::Running);
+    assert_eq!(session.ip_address, "10.0.0.42");
+    assert!(session.is_active());
+    assert!(!session.is_terminal());
+
+    // Establish PTY.
+    let pty_cmd = establish_pty(&session, &executor).unwrap();
+    assert!(pty_cmd.contains("azureuser@10.0.0.42"));
+
+    // Deploy agent binary.
+    let binary = PathBuf::from("/tmp/simard");
+    deploy_agent(&session, &binary, &executor).unwrap();
+
+    // Transfer lifecycle.
+    begin_transfer(&mut session).unwrap();
+    assert_eq!(session.status, RemoteStatus::Transferring);
+    end_transfer(&mut session).unwrap();
+    assert_eq!(session.status, RemoteStatus::Running);
+
+    // Destroy session.
+    destroy_session(&mut session, &executor).unwrap();
+    assert_eq!(session.status, RemoteStatus::Completed);
+    assert!(session.is_terminal());
+}
+
+#[test]
+fn session_deploy_rejects_wrong_binary() {
+    let executor = mock_executor();
+    let config = RemoteConfig {
+        vm_name: "deploy-vm".to_string(),
+        agent_name: "agent-d".to_string(),
+        azlin_config: AzlinConfig::default(),
+    };
+    let session = create_remote_session(&config, &executor).unwrap();
+    let bad_binary = PathBuf::from("/tmp/not-simard-binary");
+    let err = deploy_agent(&session, &bad_binary, &executor).unwrap_err();
+    assert!(matches!(err, SimardError::InvalidConfigValue { .. }));
+}
+
+#[test]
+fn session_establish_pty_rejects_non_running() {
+    let executor = mock_executor();
+    let config = RemoteConfig {
+        vm_name: "pty-vm".to_string(),
+        agent_name: "agent-p".to_string(),
+        azlin_config: AzlinConfig::default(),
+    };
+    let mut session = create_remote_session(&config, &executor).unwrap();
+    destroy_session(&mut session, &executor).unwrap();
+    let err = establish_pty(&session, &executor).unwrap_err();
+    assert!(matches!(err, SimardError::BridgeTransportError { .. }));
+}
+
+#[test]
+fn session_destroy_failure_marks_failed() {
+    let executor = failing_executor("destroy");
+    let config = RemoteConfig {
+        vm_name: "fail-destroy-vm".to_string(),
+        agent_name: "agent-fd".to_string(),
+        azlin_config: AzlinConfig::default(),
+    };
+    let mut session = create_remote_session(&config, &executor).unwrap();
+    let err = destroy_session(&mut session, &executor);
+    assert!(err.is_err());
+    assert!(matches!(session.status, RemoteStatus::Failed(_)));
+}
+
+// ---------------------------------------------------------------------------
+// Memory transfer tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn memory_snapshot_export_and_import() {
+    let source = mock_bridge();
+    source
+        .store_fact("architecture", "uses bridge pattern", 0.95, &[], "ep-1")
+        .unwrap();
+    source
+        .store_fact("testing", "mock executors for CLI tools", 0.8, &[], "ep-2")
+        .unwrap();
+    source
+        .store_procedure(
+            "deploy-remote",
+            &["scp binary".to_string(), "chmod +x".to_string()],
+            &[],
+        )
+        .unwrap();
+
+    let snapshot = export_memory_snapshot(&source, "source-agent", None).unwrap();
+    assert_eq!(snapshot.facts.len(), 2);
+    assert_eq!(snapshot.procedures.len(), 1);
+    assert_eq!(snapshot.source_agent, "source-agent");
+
+    let target = mock_bridge();
+    let count = import_memory_snapshot(&target, &snapshot).unwrap();
+    assert_eq!(count, 3);
+
+    // Verify target has the imported data.
+    let target_snapshot = export_memory_snapshot(&target, "target-agent", None).unwrap();
+    assert_eq!(target_snapshot.facts.len(), 2);
+    assert_eq!(target_snapshot.procedures.len(), 1);
+}
+
+#[test]
+fn memory_snapshot_file_round_trip() {
+    let bridge = mock_bridge();
+    bridge
+        .store_fact("serialization", "JSON round-trip works", 0.99, &[], "")
+        .unwrap();
+
+    let dir = std::env::temp_dir().join("simard-int-test-snapshot");
+    let _ = std::fs::create_dir_all(&dir);
+    let path = dir.join("test-snapshot.json");
+
+    let original = export_memory_snapshot(&bridge, "file-agent", Some(&path)).unwrap();
+    let loaded = load_snapshot_from_file(&path).unwrap();
+
+    assert_eq!(original.facts.len(), loaded.facts.len());
+    assert_eq!(original.source_agent, loaded.source_agent);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn empty_snapshot_import_returns_zero() {
+    let target = mock_bridge();
+    let empty = MemorySnapshot {
+        facts: vec![],
+        procedures: vec![],
+        exported_at: 0,
+        source_agent: "empty".to_string(),
+    };
+    let count = import_memory_snapshot(&target, &empty).unwrap();
+    assert_eq!(count, 0);
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end: session + memory migration
+// ---------------------------------------------------------------------------
+
+#[test]
+fn session_with_memory_migration() {
+    let executor = mock_executor();
+
+    // Create a remote session.
+    let config = RemoteConfig {
+        vm_name: "migration-vm".to_string(),
+        agent_name: "migrator".to_string(),
+        azlin_config: AzlinConfig::default(),
+    };
+    let mut session = create_remote_session(&config, &executor).unwrap();
+
+    // Export local memory.
+    let local_bridge = mock_bridge();
+    local_bridge
+        .store_fact("project", "Simard is a self-building agent", 0.99, &[], "")
+        .unwrap();
+
+    begin_transfer(&mut session).unwrap();
+    let snapshot = export_memory_snapshot(&local_bridge, "migrator", None).unwrap();
+    assert_eq!(snapshot.facts.len(), 1);
+
+    // Import into a "remote" bridge.
+    let remote_bridge = mock_bridge();
+    let count = import_memory_snapshot(&remote_bridge, &snapshot).unwrap();
+    assert_eq!(count, 1);
+    end_transfer(&mut session).unwrap();
+
+    // Deploy and establish PTY.
+    let binary = PathBuf::from("/tmp/simard");
+    deploy_agent(&session, &binary, &executor).unwrap();
+    let pty = establish_pty(&session, &executor).unwrap();
+    assert!(!pty.is_empty());
+
+    // Clean up.
+    destroy_session(&mut session, &executor).unwrap();
+    assert!(session.is_terminal());
+}


### PR DESCRIPTION
## Summary

- **remote_azlin.rs** (334 LOC): Wraps the `azlin` CLI with an `AzlinExecutor` trait for VM create/ssh/destroy. Includes `MockAzlinExecutor` for testing without real infrastructure. Input validation rejects empty or injection-prone VM names.
- **remote_session.rs** (398 LOC): `RemoteSession` lifecycle management — create VM, deploy agent binary, establish PTY, transfer memory state, and destroy. Status machine: Creating -> Running -> Transferring -> Completed/Failed.
- **remote_transfer.rs** (374 LOC): `MemorySnapshot` export/import for cognitive state migration. Replicates facts and procedures (durable knowledge) between bridges. Supports file persistence for offline transfer.
- **tests/remote.rs** (375 LOC): 11 integration tests covering azlin lifecycle, session lifecycle, memory round-trip, and end-to-end session-with-migration scenario. All use mock executor.
- **lib.rs**: Wired up modules and public re-exports.

All modules within 400 LOC budget. cargo test (194 total), clippy, and fmt all pass clean.

Closes #96

## Test plan

- [x] `cargo test` — all 194 tests pass (183 unit + 11 integration)
- [x] `cargo clippy --all-targets` — zero warnings
- [x] `cargo fmt -- --check` — clean
- [ ] Review: mock executor faithfully simulates azlin CLI output format
- [ ] Review: memory snapshot only replicates facts + procedures (not ephemeral types)

🤖 Generated with [Claude Code](https://claude.com/claude-code)