### PR TITLE
feat: Phase 8 — meeting mode, goal curation, and dual identity

### DIFF
--- a/src/goal_curation.rs
+++ b/src/goal_curation.rs
@@ -1,0 +1,400 @@
+//! Top-5 goal board with active goals and backlog curation.
+//!
+//! `GoalBoard` maintains a strict maximum of 5 active goals. Promotion from
+//! backlog to active enforces the cap, and progress updates track completion.
+
+use std::fmt::{self, Display, Formatter};
+
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use crate::error::{SimardError, SimardResult};
+use crate::memory_bridge::CognitiveMemoryBridge;
+
+/// Maximum number of concurrently active goals.
+pub const MAX_ACTIVE_GOALS: usize = 5;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// Progress state for an active goal.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum GoalProgress {
+    NotStarted,
+    InProgress { percent: u32 },
+    Blocked(String),
+    Completed,
+}
+
+impl Display for GoalProgress {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotStarted => f.write_str("not-started"),
+            Self::InProgress { percent } => write!(f, "in-progress({percent}%)"),
+            Self::Blocked(reason) => write!(f, "blocked: {reason}"),
+            Self::Completed => f.write_str("completed"),
+        }
+    }
+}
+
+/// An active goal on the board. Active goals are limited to `MAX_ACTIVE_GOALS`.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ActiveGoal {
+    pub id: String,
+    pub description: String,
+    pub priority: u32,
+    pub status: GoalProgress,
+    pub assigned_to: Option<String>,
+}
+
+impl ActiveGoal {
+    /// Short label for display.
+    pub fn concise_label(&self) -> String {
+        format!("p{} [{}] {}", self.priority, self.status, self.description)
+    }
+}
+
+/// A backlog item scored for future promotion.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct BacklogItem {
+    pub id: String,
+    pub description: String,
+    pub source: String,
+    pub score: f64,
+}
+
+/// The goal board: active goals + scored backlog.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct GoalBoard {
+    pub active: Vec<ActiveGoal>,
+    pub backlog: Vec<BacklogItem>,
+}
+
+impl GoalBoard {
+    /// Create an empty goal board.
+    pub fn new() -> Self {
+        Self {
+            active: Vec::new(),
+            backlog: Vec::new(),
+        }
+    }
+
+    /// How many active goal slots remain.
+    pub fn active_slots_remaining(&self) -> usize {
+        MAX_ACTIVE_GOALS.saturating_sub(self.active.len())
+    }
+
+    /// Render a durable summary of the board state.
+    pub fn durable_summary(&self) -> String {
+        let active_labels: Vec<String> = self.active.iter().map(|g| g.concise_label()).collect();
+        let active_text = if active_labels.is_empty() {
+            "none".to_string()
+        } else {
+            active_labels.join("; ")
+        };
+        let backlog_text = if self.backlog.is_empty() {
+            "none".to_string()
+        } else {
+            format!("{} items", self.backlog.len())
+        };
+        format!("active=[{active_text}]; backlog={backlog_text}")
+    }
+}
+
+impl Default for GoalBoard {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn required_field(field: &str, value: &str) -> SimardResult<()> {
+    if value.trim().is_empty() {
+        return Err(SimardError::InvalidGoalRecord {
+            field: field.to_string(),
+            reason: "value cannot be empty".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_priority(field: &str, priority: u32) -> SimardResult<()> {
+    if priority == 0 {
+        return Err(SimardError::InvalidGoalRecord {
+            field: field.to_string(),
+            reason: "priority must be at least 1".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_active_goal(goal: &ActiveGoal) -> SimardResult<()> {
+    required_field("active_goal.id", &goal.id)?;
+    required_field("active_goal.description", &goal.description)?;
+    validate_priority("active_goal.priority", goal.priority)?;
+    if let GoalProgress::InProgress { percent } = &goal.status
+        && *percent > 100
+    {
+        return Err(SimardError::InvalidGoalRecord {
+            field: "active_goal.status".to_string(),
+            reason: "progress percent cannot exceed 100".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_backlog_item(item: &BacklogItem) -> SimardResult<()> {
+    required_field("backlog_item.id", &item.id)?;
+    required_field("backlog_item.description", &item.description)?;
+    required_field("backlog_item.source", &item.source)?;
+    Ok(())
+}
+
+/// Load a goal board from cognitive memory. Searches for the latest board
+/// snapshot stored as a semantic fact and falls back to an empty board.
+pub fn load_goal_board(bridge: &CognitiveMemoryBridge) -> SimardResult<GoalBoard> {
+    let facts = bridge.search_facts("goal-board:snapshot", 1, 0.0)?;
+    if let Some(fact) = facts.first()
+        && let Ok(board) = serde_json::from_str::<GoalBoard>(&fact.content)
+    {
+        return Ok(board);
+    }
+    Ok(GoalBoard::new())
+}
+
+/// Save the current board state as a semantic fact in cognitive memory.
+pub fn save_goal_board(board: &GoalBoard, bridge: &CognitiveMemoryBridge) -> SimardResult<()> {
+    let snapshot = serde_json::to_string(board).map_err(|e| SimardError::InvalidGoalRecord {
+        field: "board".to_string(),
+        reason: format!("failed to serialize goal board: {e}"),
+    })?;
+    bridge.store_fact(
+        "goal-board:snapshot",
+        &snapshot,
+        1.0,
+        &["goal-board".to_string()],
+        "goal-curator",
+    )?;
+    Ok(())
+}
+
+/// Add a new active goal. Fails if the board is already at capacity.
+pub fn add_active_goal(board: &mut GoalBoard, goal: ActiveGoal) -> SimardResult<()> {
+    validate_active_goal(&goal)?;
+    if board.active.len() >= MAX_ACTIVE_GOALS {
+        return Err(SimardError::InvalidGoalRecord {
+            field: "active".to_string(),
+            reason: format!("cannot add active goal — board is at capacity ({MAX_ACTIVE_GOALS})"),
+        });
+    }
+    if board.active.iter().any(|g| g.id == goal.id) {
+        return Err(SimardError::InvalidGoalRecord {
+            field: "active_goal.id".to_string(),
+            reason: format!("goal '{}' is already active", goal.id),
+        });
+    }
+    board.active.push(goal);
+    Ok(())
+}
+
+/// Add a backlog item.
+pub fn add_backlog_item(board: &mut GoalBoard, item: BacklogItem) -> SimardResult<()> {
+    validate_backlog_item(&item)?;
+    if board.backlog.iter().any(|b| b.id == item.id) {
+        return Err(SimardError::InvalidGoalRecord {
+            field: "backlog_item.id".to_string(),
+            reason: format!("backlog item '{}' already exists", item.id),
+        });
+    }
+    board.backlog.push(item);
+    Ok(())
+}
+
+/// Promote a backlog item to an active goal. The item is removed from the
+/// backlog and inserted as a `NotStarted` active goal with the given priority.
+pub fn promote_to_active(
+    board: &mut GoalBoard,
+    backlog_id: &str,
+    priority: u32,
+    assigned_to: Option<String>,
+) -> SimardResult<()> {
+    validate_priority("priority", priority)?;
+    if board.active.len() >= MAX_ACTIVE_GOALS {
+        return Err(SimardError::InvalidGoalRecord {
+            field: "active".to_string(),
+            reason: format!("cannot promote — board is at capacity ({MAX_ACTIVE_GOALS})"),
+        });
+    }
+    let position = board
+        .backlog
+        .iter()
+        .position(|item| item.id == backlog_id)
+        .ok_or_else(|| SimardError::InvalidGoalRecord {
+            field: "backlog_id".to_string(),
+            reason: format!("backlog item '{backlog_id}' not found"),
+        })?;
+    let item = board.backlog.remove(position);
+    board.active.push(ActiveGoal {
+        id: item.id,
+        description: item.description,
+        priority,
+        status: GoalProgress::NotStarted,
+        assigned_to,
+    });
+    Ok(())
+}
+
+/// Update the progress of an active goal.
+pub fn update_goal_progress(
+    board: &mut GoalBoard,
+    goal_id: &str,
+    progress: GoalProgress,
+) -> SimardResult<()> {
+    if let GoalProgress::InProgress { percent } = &progress
+        && *percent > 100
+    {
+        return Err(SimardError::InvalidGoalRecord {
+            field: "progress.percent".to_string(),
+            reason: "progress percent cannot exceed 100".to_string(),
+        });
+    }
+    let goal = board
+        .active
+        .iter_mut()
+        .find(|g| g.id == goal_id)
+        .ok_or_else(|| SimardError::InvalidGoalRecord {
+            field: "goal_id".to_string(),
+            reason: format!("active goal '{goal_id}' not found"),
+        })?;
+    goal.status = progress;
+    Ok(())
+}
+
+/// Remove completed goals from the active list. Returns the removed goals.
+pub fn archive_completed(board: &mut GoalBoard) -> Vec<ActiveGoal> {
+    let mut archived = Vec::new();
+    board.active.retain(|goal| {
+        if matches!(goal.status, GoalProgress::Completed) {
+            archived.push(goal.clone());
+            false
+        } else {
+            true
+        }
+    });
+    archived
+}
+
+/// Persist the board state and record an episode for recall.
+pub fn persist_board(board: &GoalBoard, bridge: &CognitiveMemoryBridge) -> SimardResult<()> {
+    save_goal_board(board, bridge)?;
+    bridge.store_episode(
+        &board.durable_summary(),
+        "goal-curator",
+        Some(&json!({"active_count": board.active.len(), "backlog_count": board.backlog.len()})),
+    )?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bridge_subprocess::InMemoryBridgeTransport;
+    use serde_json::json;
+
+    fn mock_bridge() -> CognitiveMemoryBridge {
+        let transport =
+            InMemoryBridgeTransport::new("test-goals", |method, _params| match method {
+                "memory.search_facts" => Ok(json!({"facts": []})),
+                "memory.store_fact" => Ok(json!({"id": "sem_g1"})),
+                "memory.store_episode" => Ok(json!({"id": "epi_g1"})),
+                _ => Err(crate::bridge::BridgeErrorPayload {
+                    code: -32601,
+                    message: format!("unknown method: {method}"),
+                }),
+            });
+        CognitiveMemoryBridge::new(Box::new(transport))
+    }
+
+    fn sample_goal(id: &str, priority: u32) -> ActiveGoal {
+        ActiveGoal {
+            id: id.to_string(),
+            description: format!("Goal {id}"),
+            priority,
+            status: GoalProgress::NotStarted,
+            assigned_to: None,
+        }
+    }
+
+    #[test]
+    fn enforce_max_active_goals() {
+        let mut board = GoalBoard::new();
+        for i in 1..=MAX_ACTIVE_GOALS {
+            add_active_goal(&mut board, sample_goal(&format!("g{i}"), i as u32)).unwrap();
+        }
+        let err = add_active_goal(&mut board, sample_goal("g-overflow", 1)).unwrap_err();
+        assert!(err.to_string().contains("capacity"));
+    }
+
+    #[test]
+    fn promote_backlog_to_active() {
+        let mut board = GoalBoard::new();
+        add_backlog_item(
+            &mut board,
+            BacklogItem {
+                id: "bl-1".to_string(),
+                description: "Research topic X".to_string(),
+                source: "meeting".to_string(),
+                score: 0.8,
+            },
+        )
+        .unwrap();
+        promote_to_active(&mut board, "bl-1", 2, Some("alice".to_string())).unwrap();
+        assert_eq!(board.active.len(), 1);
+        assert!(board.backlog.is_empty());
+        assert_eq!(board.active[0].assigned_to.as_deref(), Some("alice"));
+    }
+
+    #[test]
+    fn update_progress_and_archive() {
+        let mut board = GoalBoard::new();
+        add_active_goal(&mut board, sample_goal("g1", 1)).unwrap();
+        update_goal_progress(&mut board, "g1", GoalProgress::Completed).unwrap();
+        let archived = archive_completed(&mut board);
+        assert_eq!(archived.len(), 1);
+        assert!(board.active.is_empty());
+    }
+
+    #[test]
+    fn load_empty_board_from_bridge() {
+        let bridge = mock_bridge();
+        let board = load_goal_board(&bridge).unwrap();
+        assert!(board.active.is_empty());
+        assert!(board.backlog.is_empty());
+    }
+
+    #[test]
+    fn rejects_zero_priority() {
+        let mut board = GoalBoard::new();
+        let err = add_active_goal(
+            &mut board,
+            ActiveGoal {
+                id: "bad".to_string(),
+                description: "Zero priority".to_string(),
+                priority: 0,
+                status: GoalProgress::NotStarted,
+                assigned_to: None,
+            },
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("priority"));
+    }
+
+    #[test]
+    fn rejects_progress_over_100() {
+        let mut board = GoalBoard::new();
+        add_active_goal(&mut board, sample_goal("g1", 1)).unwrap();
+        let err = update_goal_progress(&mut board, "g1", GoalProgress::InProgress { percent: 200 })
+            .unwrap_err();
+        assert!(err.to_string().contains("100"));
+    }
+}

--- a/src/identity_auth.rs
+++ b/src/identity_auth.rs
@@ -1,0 +1,279 @@
+//! Dual GitHub identity management for Copilot and commit operations.
+//!
+//! Simard operates under two separate GitHub identities: one for Copilot API
+//! calls (authentication) and one for git commit authorship. This module
+//! provides the configuration and environment variable generation for each.
+
+use std::fmt::{self, Display, Formatter};
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{SimardError, SimardResult};
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// Which identity context is being used.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub enum AuthIdentity {
+    /// Identity used for Copilot SDK / API authentication.
+    CopilotAuth,
+    /// Identity used for git commit authorship.
+    CommitAuth,
+}
+
+impl Display for AuthIdentity {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::CopilotAuth => f.write_str("copilot-auth"),
+            Self::CommitAuth => f.write_str("commit-auth"),
+        }
+    }
+}
+
+/// Configuration for the dual-identity setup.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct DualIdentityConfig {
+    /// GitHub user for Copilot API authentication.
+    pub copilot_user: String,
+    /// GitHub user for commit authorship.
+    pub commit_user: String,
+    /// Email address for commit authorship.
+    pub commit_email: String,
+}
+
+impl DualIdentityConfig {
+    pub fn new(
+        copilot_user: impl Into<String>,
+        commit_user: impl Into<String>,
+        commit_email: impl Into<String>,
+    ) -> SimardResult<Self> {
+        let copilot_user = required_field("copilot_user", copilot_user.into())?;
+        let commit_user = required_field("commit_user", commit_user.into())?;
+        let commit_email = required_field("commit_email", commit_email.into())?;
+        validate_email(&commit_email)?;
+        Ok(Self {
+            copilot_user,
+            commit_user,
+            commit_email,
+        })
+    }
+
+    /// A concise label for logging.
+    pub fn summary(&self) -> String {
+        format!(
+            "copilot={}, commit={} <{}>",
+            self.copilot_user, self.commit_user, self.commit_email
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+fn required_field(field: &str, value: String) -> SimardResult<String> {
+    let trimmed = value.trim().to_string();
+    if trimmed.is_empty() {
+        return Err(SimardError::InvalidConfigValue {
+            key: field.to_string(),
+            value: String::new(),
+            help: format!("{field} cannot be empty"),
+        });
+    }
+    Ok(trimmed)
+}
+
+fn validate_email(email: &str) -> SimardResult<()> {
+    if !email.contains('@') {
+        return Err(SimardError::InvalidConfigValue {
+            key: "commit_email".to_string(),
+            value: email.to_string(),
+            help: "commit_email must contain '@'".to_string(),
+        });
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Operations that require Copilot authentication.
+const COPILOT_OPERATIONS: &[&str] = &[
+    "copilot-chat",
+    "copilot-completions",
+    "copilot-submit",
+    "bridge-call",
+];
+
+/// Operations that require commit authentication.
+const COMMIT_OPERATIONS: &[&str] = &["git-commit", "git-push", "git-tag", "pr-create"];
+
+/// Generate environment variables appropriate for the given identity context.
+///
+/// For `CopilotAuth`, sets `GITHUB_USER` to the Copilot API user.
+/// For `CommitAuth`, sets `GIT_AUTHOR_NAME`, `GIT_AUTHOR_EMAIL`,
+/// `GIT_COMMITTER_NAME`, and `GIT_COMMITTER_EMAIL`.
+pub fn env_for_identity(
+    identity: AuthIdentity,
+    config: &DualIdentityConfig,
+) -> Vec<(String, String)> {
+    match identity {
+        AuthIdentity::CopilotAuth => {
+            vec![("GITHUB_USER".to_string(), config.copilot_user.clone())]
+        }
+        AuthIdentity::CommitAuth => {
+            vec![
+                ("GIT_AUTHOR_NAME".to_string(), config.commit_user.clone()),
+                ("GIT_AUTHOR_EMAIL".to_string(), config.commit_email.clone()),
+                ("GIT_COMMITTER_NAME".to_string(), config.commit_user.clone()),
+                (
+                    "GIT_COMMITTER_EMAIL".to_string(),
+                    config.commit_email.clone(),
+                ),
+            ]
+        }
+    }
+}
+
+/// Validate that an identity is appropriate for a named operation.
+///
+/// Returns `Ok(())` if the identity matches the operation, or an error
+/// explaining the mismatch.
+pub fn validate_identity_for_operation(
+    identity: AuthIdentity,
+    operation: &str,
+) -> SimardResult<()> {
+    let is_copilot_op = COPILOT_OPERATIONS.contains(&operation);
+    let is_commit_op = COMMIT_OPERATIONS.contains(&operation);
+
+    match identity {
+        AuthIdentity::CopilotAuth => {
+            if is_commit_op {
+                return Err(SimardError::InvalidConfigValue {
+                    key: "identity".to_string(),
+                    value: identity.to_string(),
+                    help: format!(
+                        "operation '{operation}' requires commit-auth identity, not copilot-auth"
+                    ),
+                });
+            }
+        }
+        AuthIdentity::CommitAuth => {
+            if is_copilot_op {
+                return Err(SimardError::InvalidConfigValue {
+                    key: "identity".to_string(),
+                    value: identity.to_string(),
+                    help: format!(
+                        "operation '{operation}' requires copilot-auth identity, not commit-auth"
+                    ),
+                });
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Resolve the correct identity for a given operation.
+pub fn identity_for_operation(operation: &str) -> Option<AuthIdentity> {
+    if COPILOT_OPERATIONS.contains(&operation) {
+        Some(AuthIdentity::CopilotAuth)
+    } else if COMMIT_OPERATIONS.contains(&operation) {
+        Some(AuthIdentity::CommitAuth)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config() -> DualIdentityConfig {
+        DualIdentityConfig::new("simard-copilot", "simard-bot", "simard@example.com").unwrap()
+    }
+
+    #[test]
+    fn copilot_env_contains_github_user() {
+        let config = test_config();
+        let env = env_for_identity(AuthIdentity::CopilotAuth, &config);
+        assert_eq!(env.len(), 1);
+        assert_eq!(env[0].0, "GITHUB_USER");
+        assert_eq!(env[0].1, "simard-copilot");
+    }
+
+    #[test]
+    fn commit_env_contains_author_and_committer() {
+        let config = test_config();
+        let env = env_for_identity(AuthIdentity::CommitAuth, &config);
+        assert_eq!(env.len(), 4);
+        let keys: Vec<&str> = env.iter().map(|(k, _)| k.as_str()).collect();
+        assert!(keys.contains(&"GIT_AUTHOR_NAME"));
+        assert!(keys.contains(&"GIT_AUTHOR_EMAIL"));
+        assert!(keys.contains(&"GIT_COMMITTER_NAME"));
+        assert!(keys.contains(&"GIT_COMMITTER_EMAIL"));
+    }
+
+    #[test]
+    fn validate_copilot_for_commit_rejects() {
+        let err =
+            validate_identity_for_operation(AuthIdentity::CopilotAuth, "git-commit").unwrap_err();
+        assert!(err.to_string().contains("commit-auth"));
+    }
+
+    #[test]
+    fn validate_commit_for_copilot_rejects() {
+        let err =
+            validate_identity_for_operation(AuthIdentity::CommitAuth, "copilot-chat").unwrap_err();
+        assert!(err.to_string().contains("copilot-auth"));
+    }
+
+    #[test]
+    fn validate_matching_identities_pass() {
+        validate_identity_for_operation(AuthIdentity::CopilotAuth, "copilot-chat").unwrap();
+        validate_identity_for_operation(AuthIdentity::CommitAuth, "git-commit").unwrap();
+    }
+
+    #[test]
+    fn unknown_operation_passes_both_identities() {
+        validate_identity_for_operation(AuthIdentity::CopilotAuth, "unknown-op").unwrap();
+        validate_identity_for_operation(AuthIdentity::CommitAuth, "unknown-op").unwrap();
+    }
+
+    #[test]
+    fn identity_for_operation_resolves_correctly() {
+        assert_eq!(
+            identity_for_operation("copilot-submit"),
+            Some(AuthIdentity::CopilotAuth)
+        );
+        assert_eq!(
+            identity_for_operation("git-push"),
+            Some(AuthIdentity::CommitAuth)
+        );
+        assert_eq!(identity_for_operation("custom-op"), None);
+    }
+
+    #[test]
+    fn rejects_empty_config_fields() {
+        let err = DualIdentityConfig::new("", "bot", "bot@x.com").unwrap_err();
+        assert!(err.to_string().contains("empty"));
+    }
+
+    #[test]
+    fn rejects_invalid_email() {
+        let err = DualIdentityConfig::new("user", "bot", "not-an-email").unwrap_err();
+        assert!(err.to_string().contains("@"));
+    }
+
+    #[test]
+    fn config_summary() {
+        let config = test_config();
+        assert_eq!(
+            config.summary(),
+            "copilot=simard-copilot, commit=simard-bot <simard@example.com>"
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,16 +15,19 @@ mod copilot_task_submit;
 pub mod engineer_loop;
 pub mod error;
 pub mod evidence;
+pub mod goal_curation;
 pub mod goals;
 pub mod gym;
 pub mod gym_bridge;
 pub mod gym_scoring;
 pub mod handoff;
 pub mod identity;
+pub mod identity_auth;
 pub mod identity_composition;
 pub mod improvements;
 pub mod knowledge_bridge;
 pub mod knowledge_context;
+pub mod meeting_facilitator;
 pub mod meetings;
 pub mod memory;
 pub mod memory_bridge;
@@ -40,6 +43,7 @@ pub mod reflection;
 pub mod remote_azlin;
 pub mod remote_session;
 pub mod remote_transfer;
+pub mod research_tracker;
 pub mod review;
 pub mod runtime;
 mod sanitization;
@@ -92,6 +96,11 @@ pub use error::{SimardError, SimardResult};
 pub use evidence::{
     EvidenceRecord, EvidenceSource, EvidenceStore, FileBackedEvidenceStore, InMemoryEvidenceStore,
 };
+pub use goal_curation::{
+    ActiveGoal, BacklogItem, GoalBoard, GoalProgress, MAX_ACTIVE_GOALS, add_active_goal,
+    add_backlog_item, archive_completed, load_goal_board, persist_board, promote_to_active,
+    update_goal_progress,
+};
 pub use goals::{
     FileBackedGoalStore, GoalRecord, GoalStatus, GoalStore, GoalUpdate, InMemoryGoalStore,
 };
@@ -116,6 +125,10 @@ pub use identity::{
     BuiltinIdentityLoader, IdentityLoadRequest, IdentityLoader, IdentityManifest, ManifestContract,
     MemoryPolicy, OperatingMode,
 };
+pub use identity_auth::{
+    AuthIdentity, DualIdentityConfig, env_for_identity, identity_for_operation,
+    validate_identity_for_operation,
+};
 pub use identity_composition::{
     CompositeIdentity, SubordinateIdentity, compose_identity, max_subordinate_depth,
 };
@@ -127,6 +140,10 @@ pub use knowledge_bridge::{
     KnowledgeBridge, KnowledgePackInfo, KnowledgeQueryResult, KnowledgeSource,
 };
 pub use knowledge_context::{PlanningContext, enrich_planning_context};
+pub use meeting_facilitator::{
+    ActionItem, MeetingDecision, MeetingSession, MeetingSessionStatus, add_note, close_meeting,
+    record_action_item, record_decision, start_meeting,
+};
 pub use meetings::{
     PersistedMeetingGoalUpdate, PersistedMeetingRecord, looks_like_persisted_meeting_record,
 };
@@ -161,6 +178,10 @@ pub use reflection::{ReflectionReport, ReflectionSnapshot, ReflectiveRuntime};
 pub use remote_azlin::{AzlinConfig, AzlinExecutor, AzlinVm, RealAzlinExecutor};
 pub use remote_session::{RemoteConfig, RemoteSession, RemoteStatus};
 pub use remote_transfer::MemorySnapshot;
+pub use research_tracker::{
+    DeveloperWatch, ResearchStatus, ResearchTopic, ResearchTracker, add_research_topic,
+    load_research_topics, track_developer, update_topic_status,
+};
 pub use review::{
     ImprovementProposal, ReviewArtifact, ReviewRequest, ReviewSignal, ReviewTargetKind,
     build_review_artifact, latest_review_artifact, load_review_artifact, persist_review_artifact,

--- a/src/meeting_facilitator.rs
+++ b/src/meeting_facilitator.rs
@@ -1,0 +1,333 @@
+//! Interactive meeting mode — structured session with decisions and action items.
+//!
+//! `MeetingSession` captures a running meeting with its topic, decisions made,
+//! and action items assigned. The facilitator stores a durable summary into
+//! cognitive memory when the meeting closes.
+
+use std::fmt::{self, Display, Formatter};
+
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use crate::error::{SimardError, SimardResult};
+use crate::memory_bridge::CognitiveMemoryBridge;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// A single decision recorded during a meeting.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct MeetingDecision {
+    pub description: String,
+    pub rationale: String,
+    pub participants: Vec<String>,
+}
+
+/// An action item assigned during a meeting.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ActionItem {
+    pub description: String,
+    pub owner: String,
+    pub priority: u32,
+    pub due_description: Option<String>,
+}
+
+/// Status of an in-progress meeting.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub enum MeetingSessionStatus {
+    Open,
+    Closed,
+}
+
+impl Display for MeetingSessionStatus {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Open => f.write_str("open"),
+            Self::Closed => f.write_str("closed"),
+        }
+    }
+}
+
+/// A running or completed meeting session.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct MeetingSession {
+    pub topic: String,
+    pub decisions: Vec<MeetingDecision>,
+    pub action_items: Vec<ActionItem>,
+    pub notes: Vec<String>,
+    pub status: MeetingSessionStatus,
+}
+
+impl MeetingSession {
+    /// Render a concise durable summary suitable for memory storage.
+    pub fn durable_summary(&self) -> String {
+        let decisions = if self.decisions.is_empty() {
+            "none".to_string()
+        } else {
+            self.decisions
+                .iter()
+                .map(|d| d.description.as_str())
+                .collect::<Vec<_>>()
+                .join("; ")
+        };
+        let action_items = if self.action_items.is_empty() {
+            "none".to_string()
+        } else {
+            self.action_items
+                .iter()
+                .map(|a| format!("{} (owner={})", a.description, a.owner))
+                .collect::<Vec<_>>()
+                .join("; ")
+        };
+        format!(
+            "meeting topic={}; decisions=[{}]; action_items=[{}]",
+            self.topic, decisions, action_items,
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Validation helpers
+// ---------------------------------------------------------------------------
+
+fn required_field(field: &str, value: &str) -> SimardResult<()> {
+    if value.trim().is_empty() {
+        return Err(SimardError::InvalidMeetingRecord {
+            field: field.to_string(),
+            reason: "value cannot be empty".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_decision(decision: &MeetingDecision) -> SimardResult<()> {
+    required_field("decision.description", &decision.description)?;
+    required_field("decision.rationale", &decision.rationale)?;
+    Ok(())
+}
+
+fn validate_action_item(item: &ActionItem) -> SimardResult<()> {
+    required_field("action_item.description", &item.description)?;
+    required_field("action_item.owner", &item.owner)?;
+    if item.priority == 0 {
+        return Err(SimardError::InvalidMeetingRecord {
+            field: "action_item.priority".to_string(),
+            reason: "priority must be at least 1".to_string(),
+        });
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Start a new meeting session. Records a sensory observation in cognitive
+/// memory so the meeting start is captured for recall.
+pub fn start_meeting(topic: &str, bridge: &CognitiveMemoryBridge) -> SimardResult<MeetingSession> {
+    required_field("topic", topic)?;
+
+    bridge.record_sensory("meeting-start", &format!("Meeting started: {topic}"), 3600)?;
+
+    Ok(MeetingSession {
+        topic: topic.to_string(),
+        decisions: Vec::new(),
+        action_items: Vec::new(),
+        notes: Vec::new(),
+        status: MeetingSessionStatus::Open,
+    })
+}
+
+/// Record a decision in an open meeting session.
+pub fn record_decision(
+    session: &mut MeetingSession,
+    decision: MeetingDecision,
+) -> SimardResult<()> {
+    if session.status != MeetingSessionStatus::Open {
+        return Err(SimardError::InvalidMeetingRecord {
+            field: "session.status".to_string(),
+            reason: "cannot record a decision in a closed meeting".to_string(),
+        });
+    }
+    validate_decision(&decision)?;
+    session.decisions.push(decision);
+    Ok(())
+}
+
+/// Record an action item in an open meeting session.
+pub fn record_action_item(session: &mut MeetingSession, item: ActionItem) -> SimardResult<()> {
+    if session.status != MeetingSessionStatus::Open {
+        return Err(SimardError::InvalidMeetingRecord {
+            field: "session.status".to_string(),
+            reason: "cannot record an action item in a closed meeting".to_string(),
+        });
+    }
+    validate_action_item(&item)?;
+    session.action_items.push(item);
+    Ok(())
+}
+
+/// Add a free-form note to an open meeting session.
+pub fn add_note(session: &mut MeetingSession, note: &str) -> SimardResult<()> {
+    if session.status != MeetingSessionStatus::Open {
+        return Err(SimardError::InvalidMeetingRecord {
+            field: "session.status".to_string(),
+            reason: "cannot add a note to a closed meeting".to_string(),
+        });
+    }
+    required_field("note", note)?;
+    session.notes.push(note.to_string());
+    Ok(())
+}
+
+/// Close a meeting session and persist a durable summary as both an episode
+/// and a semantic fact in cognitive memory.
+pub fn close_meeting(
+    mut session: MeetingSession,
+    bridge: &CognitiveMemoryBridge,
+) -> SimardResult<MeetingSession> {
+    if session.status != MeetingSessionStatus::Open {
+        return Err(SimardError::InvalidMeetingRecord {
+            field: "session.status".to_string(),
+            reason: "meeting is already closed".to_string(),
+        });
+    }
+
+    session.status = MeetingSessionStatus::Closed;
+    let summary = session.durable_summary();
+
+    // Store as an episodic memory for future recall.
+    bridge.store_episode(
+        &summary,
+        "meeting-facilitator",
+        Some(&json!({"topic": session.topic})),
+    )?;
+
+    // Store a semantic fact capturing the key decisions.
+    if !session.decisions.is_empty() {
+        let decision_text = session
+            .decisions
+            .iter()
+            .map(|d| d.description.as_str())
+            .collect::<Vec<_>>()
+            .join("; ");
+        bridge.store_fact(
+            &format!("meeting:{}", session.topic),
+            &format!("Decisions: {decision_text}"),
+            0.85,
+            &["meeting".to_string(), "decision".to_string()],
+            "meeting-facilitator",
+        )?;
+    }
+
+    // Store action items as a prospective memory so they trigger later.
+    for item in &session.action_items {
+        bridge.store_prospective(
+            &format!("Action: {}", item.description),
+            &format!("owner={} starts work", item.owner),
+            &format!("remind {} about: {}", item.owner, item.description),
+            i64::from(item.priority),
+        )?;
+    }
+
+    Ok(session)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bridge_subprocess::InMemoryBridgeTransport;
+    use serde_json::json;
+
+    fn mock_bridge() -> CognitiveMemoryBridge {
+        let transport =
+            InMemoryBridgeTransport::new("test-meeting", |method, _params| match method {
+                "memory.record_sensory" => Ok(json!({"id": "sen_m1"})),
+                "memory.store_episode" => Ok(json!({"id": "epi_m1"})),
+                "memory.store_fact" => Ok(json!({"id": "sem_m1"})),
+                "memory.store_prospective" => Ok(json!({"id": "pro_m1"})),
+                _ => Err(crate::bridge::BridgeErrorPayload {
+                    code: -32601,
+                    message: format!("unknown method: {method}"),
+                }),
+            });
+        CognitiveMemoryBridge::new(Box::new(transport))
+    }
+
+    #[test]
+    fn start_and_close_meeting_round_trip() {
+        let bridge = mock_bridge();
+        let mut session = start_meeting("Sprint planning", &bridge).unwrap();
+        assert_eq!(session.status, MeetingSessionStatus::Open);
+
+        record_decision(
+            &mut session,
+            MeetingDecision {
+                description: "Ship phase 8".to_string(),
+                rationale: "Unblocks goal curation".to_string(),
+                participants: vec!["alice".to_string()],
+            },
+        )
+        .unwrap();
+
+        record_action_item(
+            &mut session,
+            ActionItem {
+                description: "Write tests".to_string(),
+                owner: "bob".to_string(),
+                priority: 1,
+                due_description: Some("end of sprint".to_string()),
+            },
+        )
+        .unwrap();
+
+        let closed = close_meeting(session, &bridge).unwrap();
+        assert_eq!(closed.status, MeetingSessionStatus::Closed);
+        assert_eq!(closed.decisions.len(), 1);
+        assert_eq!(closed.action_items.len(), 1);
+    }
+
+    #[test]
+    fn cannot_add_to_closed_meeting() {
+        let bridge = mock_bridge();
+        let session = start_meeting("Retro", &bridge).unwrap();
+        let mut closed = close_meeting(session, &bridge).unwrap();
+
+        let err = record_decision(
+            &mut closed,
+            MeetingDecision {
+                description: "late".to_string(),
+                rationale: "oops".to_string(),
+                participants: vec![],
+            },
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("closed meeting"));
+    }
+
+    #[test]
+    fn rejects_empty_topic() {
+        let bridge = mock_bridge();
+        let err = start_meeting("", &bridge).unwrap_err();
+        assert!(err.to_string().contains("empty"));
+    }
+
+    #[test]
+    fn rejects_zero_priority_action_item() {
+        let bridge = mock_bridge();
+        let mut session = start_meeting("Check", &bridge).unwrap();
+        let err = record_action_item(
+            &mut session,
+            ActionItem {
+                description: "task".to_string(),
+                owner: "me".to_string(),
+                priority: 0,
+                due_description: None,
+            },
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("priority"));
+    }
+}

--- a/src/research_tracker.rs
+++ b/src/research_tracker.rs
@@ -1,0 +1,357 @@
+//! Research topic and developer tracking.
+//!
+//! Tracks research topics surfaced during meetings, goal curation, or
+//! engineering work. Also maintains a watch list of developers whose public
+//! activity is relevant to Simard's focus areas.
+
+use std::fmt::{self, Display, Formatter};
+
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use crate::error::{SimardError, SimardResult};
+use crate::memory_bridge::CognitiveMemoryBridge;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// Lifecycle status of a research topic.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub enum ResearchStatus {
+    Proposed,
+    InProgress,
+    Completed,
+    Archived,
+}
+
+impl Display for ResearchStatus {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Proposed => f.write_str("proposed"),
+            Self::InProgress => f.write_str("in-progress"),
+            Self::Completed => f.write_str("completed"),
+            Self::Archived => f.write_str("archived"),
+        }
+    }
+}
+
+/// A research topic tracked for investigation.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ResearchTopic {
+    pub id: String,
+    pub title: String,
+    pub source: String,
+    pub priority: u32,
+    pub status: ResearchStatus,
+}
+
+impl ResearchTopic {
+    /// Short label for display.
+    pub fn concise_label(&self) -> String {
+        format!("p{} [{}] {}", self.priority, self.status, self.title)
+    }
+}
+
+/// A developer whose public activity is tracked.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct DeveloperWatch {
+    pub github_id: String,
+    pub focus_areas: Vec<String>,
+    pub last_checked: Option<u64>,
+}
+
+/// Aggregated research tracker state.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct ResearchTracker {
+    pub topics: Vec<ResearchTopic>,
+    pub watches: Vec<DeveloperWatch>,
+}
+
+impl ResearchTracker {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Durable summary of tracker state.
+    pub fn durable_summary(&self) -> String {
+        let topics_text = if self.topics.is_empty() {
+            "none".to_string()
+        } else {
+            self.topics
+                .iter()
+                .map(|t| t.concise_label())
+                .collect::<Vec<_>>()
+                .join("; ")
+        };
+        let watches_text = if self.watches.is_empty() {
+            "none".to_string()
+        } else {
+            self.watches
+                .iter()
+                .map(|w| w.github_id.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        format!("research topics=[{topics_text}]; watches=[{watches_text}]")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+fn required_field(field: &str, value: &str) -> SimardResult<()> {
+    if value.trim().is_empty() {
+        return Err(SimardError::InvalidGoalRecord {
+            field: field.to_string(),
+            reason: "value cannot be empty".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_topic(topic: &ResearchTopic) -> SimardResult<()> {
+    required_field("research_topic.id", &topic.id)?;
+    required_field("research_topic.title", &topic.title)?;
+    required_field("research_topic.source", &topic.source)?;
+    if topic.priority == 0 {
+        return Err(SimardError::InvalidGoalRecord {
+            field: "research_topic.priority".to_string(),
+            reason: "priority must be at least 1".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_watch(watch: &DeveloperWatch) -> SimardResult<()> {
+    required_field("developer_watch.github_id", &watch.github_id)?;
+    if watch.focus_areas.is_empty() {
+        return Err(SimardError::InvalidGoalRecord {
+            field: "developer_watch.focus_areas".to_string(),
+            reason: "at least one focus area is required".to_string(),
+        });
+    }
+    for area in &watch.focus_areas {
+        required_field("developer_watch.focus_areas[]", area)?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Add a research topic to the tracker and store it as a semantic fact.
+pub fn add_research_topic(
+    topic: ResearchTopic,
+    bridge: &CognitiveMemoryBridge,
+) -> SimardResult<()> {
+    validate_topic(&topic)?;
+
+    bridge.store_fact(
+        &format!("research:{}", topic.id),
+        &format!(
+            "title={}; source={}; priority={}; status={}",
+            topic.title, topic.source, topic.priority, topic.status
+        ),
+        0.8,
+        &["research".to_string(), topic.source.clone()],
+        "research-tracker",
+    )?;
+
+    bridge.store_episode(
+        &format!("Research topic added: {}", topic.concise_label()),
+        "research-tracker",
+        Some(&json!({"topic_id": topic.id})),
+    )?;
+
+    Ok(())
+}
+
+/// Track a developer's public activity and store as a semantic fact.
+pub fn track_developer(watch: DeveloperWatch, bridge: &CognitiveMemoryBridge) -> SimardResult<()> {
+    validate_watch(&watch)?;
+
+    let areas = watch.focus_areas.join(", ");
+    bridge.store_fact(
+        &format!("dev-watch:{}", watch.github_id),
+        &format!("github_id={}; focus_areas={areas}", watch.github_id),
+        0.7,
+        &["developer-watch".to_string()],
+        "research-tracker",
+    )?;
+
+    Ok(())
+}
+
+/// Update the status of a research topic by its id.
+pub fn update_topic_status(
+    topic_id: &str,
+    new_status: ResearchStatus,
+    bridge: &CognitiveMemoryBridge,
+) -> SimardResult<()> {
+    required_field("topic_id", topic_id)?;
+
+    bridge.store_fact(
+        &format!("research:{topic_id}:status"),
+        &format!("status={new_status}"),
+        0.8,
+        &["research".to_string(), "status-update".to_string()],
+        "research-tracker",
+    )?;
+
+    bridge.store_episode(
+        &format!("Research topic '{topic_id}' status changed to {new_status}"),
+        "research-tracker",
+        Some(&json!({"topic_id": topic_id, "new_status": new_status.to_string()})),
+    )?;
+
+    Ok(())
+}
+
+/// Load tracked research topics from cognitive memory.
+pub fn load_research_topics(bridge: &CognitiveMemoryBridge) -> SimardResult<Vec<ResearchTopic>> {
+    let facts = bridge.search_facts("research:", 50, 0.0)?;
+    let mut topics = Vec::new();
+    for fact in facts {
+        // Only parse facts whose concept starts with "research:" and whose
+        // content has the expected structured fields.
+        if fact.concept.starts_with("research:")
+            && !fact.concept.contains(":status")
+            && fact.content.contains("title=")
+            && let Some(topic) = parse_topic_from_fact(&fact.concept, &fact.content)
+        {
+            topics.push(topic);
+        }
+    }
+    Ok(topics)
+}
+
+fn parse_topic_from_fact(concept: &str, content: &str) -> Option<ResearchTopic> {
+    let id = concept.strip_prefix("research:")?;
+    let title = extract_field(content, "title=")?;
+    let source = extract_field(content, "source=")?;
+    let priority_str = extract_field(content, "priority=")?;
+    let priority = priority_str.parse::<u32>().ok()?;
+    let status_str = extract_field(content, "status=")?;
+    let status = match status_str.as_str() {
+        "proposed" => ResearchStatus::Proposed,
+        "in-progress" => ResearchStatus::InProgress,
+        "completed" => ResearchStatus::Completed,
+        "archived" => ResearchStatus::Archived,
+        _ => return None,
+    };
+    Some(ResearchTopic {
+        id: id.to_string(),
+        title,
+        source,
+        priority,
+        status,
+    })
+}
+
+fn extract_field(content: &str, prefix: &str) -> Option<String> {
+    let start = content.find(prefix)?;
+    let value_start = start + prefix.len();
+    let rest = &content[value_start..];
+    let end = rest.find("; ").unwrap_or(rest.len());
+    Some(rest[..end].trim().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bridge_subprocess::InMemoryBridgeTransport;
+    use serde_json::json;
+
+    fn mock_bridge() -> CognitiveMemoryBridge {
+        let transport =
+            InMemoryBridgeTransport::new("test-research", |method, _params| match method {
+                "memory.store_fact" => Ok(json!({"id": "sem_r1"})),
+                "memory.store_episode" => Ok(json!({"id": "epi_r1"})),
+                "memory.search_facts" => Ok(json!({"facts": []})),
+                _ => Err(crate::bridge::BridgeErrorPayload {
+                    code: -32601,
+                    message: format!("unknown method: {method}"),
+                }),
+            });
+        CognitiveMemoryBridge::new(Box::new(transport))
+    }
+
+    #[test]
+    fn add_and_track_research_topic() {
+        let bridge = mock_bridge();
+        add_research_topic(
+            ResearchTopic {
+                id: "rt-1".to_string(),
+                title: "Memory consolidation strategies".to_string(),
+                source: "meeting".to_string(),
+                priority: 2,
+                status: ResearchStatus::Proposed,
+            },
+            &bridge,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn track_developer_watch() {
+        let bridge = mock_bridge();
+        track_developer(
+            DeveloperWatch {
+                github_id: "octocat".to_string(),
+                focus_areas: vec!["agent-frameworks".to_string()],
+                last_checked: None,
+            },
+            &bridge,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn rejects_empty_topic_id() {
+        let bridge = mock_bridge();
+        let err = add_research_topic(
+            ResearchTopic {
+                id: "".to_string(),
+                title: "Something".to_string(),
+                source: "test".to_string(),
+                priority: 1,
+                status: ResearchStatus::Proposed,
+            },
+            &bridge,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("empty"));
+    }
+
+    #[test]
+    fn rejects_watch_without_focus_areas() {
+        let bridge = mock_bridge();
+        let err = track_developer(
+            DeveloperWatch {
+                github_id: "someone".to_string(),
+                focus_areas: vec![],
+                last_checked: None,
+            },
+            &bridge,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("focus area"));
+    }
+
+    #[test]
+    fn parse_topic_from_fact_round_trip() {
+        let topic = parse_topic_from_fact(
+            "research:rt-1",
+            "title=Memory consolidation; source=meeting; priority=2; status=proposed",
+        );
+        assert!(topic.is_some());
+        let topic = topic.unwrap();
+        assert_eq!(topic.id, "rt-1");
+        assert_eq!(topic.title, "Memory consolidation");
+        assert_eq!(topic.priority, 2);
+        assert_eq!(topic.status, ResearchStatus::Proposed);
+    }
+}

--- a/tests/meeting_goals.rs
+++ b/tests/meeting_goals.rs
@@ -1,0 +1,343 @@
+//! Integration tests for Phase 8: meeting facilitator, goal curation,
+//! research tracking, and dual identity.
+
+use serde_json::json;
+
+use simard::bridge::BridgeErrorPayload;
+use simard::bridge_subprocess::InMemoryBridgeTransport;
+use simard::goal_curation::{
+    ActiveGoal, BacklogItem, GoalBoard, GoalProgress, MAX_ACTIVE_GOALS, add_active_goal,
+    add_backlog_item, archive_completed, load_goal_board, persist_board, promote_to_active,
+    update_goal_progress,
+};
+use simard::identity_auth::{
+    AuthIdentity, DualIdentityConfig, env_for_identity, identity_for_operation,
+    validate_identity_for_operation,
+};
+use simard::meeting_facilitator::{
+    ActionItem, MeetingDecision, MeetingSessionStatus, add_note, close_meeting, record_action_item,
+    record_decision, start_meeting,
+};
+use simard::memory_bridge::CognitiveMemoryBridge;
+use simard::research_tracker::{
+    DeveloperWatch, ResearchStatus, ResearchTopic, add_research_topic, track_developer,
+    update_topic_status,
+};
+
+fn mock_bridge() -> CognitiveMemoryBridge {
+    let transport =
+        InMemoryBridgeTransport::new("test-integration", |method, _params| match method {
+            "memory.record_sensory" => Ok(json!({"id": "sen_int"})),
+            "memory.store_episode" => Ok(json!({"id": "epi_int"})),
+            "memory.store_fact" => Ok(json!({"id": "sem_int"})),
+            "memory.store_prospective" => Ok(json!({"id": "pro_int"})),
+            "memory.search_facts" => Ok(json!({"facts": []})),
+            _ => Err(BridgeErrorPayload {
+                code: -32601,
+                message: format!("unknown method: {method}"),
+            }),
+        });
+    CognitiveMemoryBridge::new(Box::new(transport))
+}
+
+fn sample_active(id: &str, priority: u32) -> ActiveGoal {
+    ActiveGoal {
+        id: id.to_string(),
+        description: format!("Goal {id}"),
+        priority,
+        status: GoalProgress::NotStarted,
+        assigned_to: None,
+    }
+}
+
+#[test]
+fn meeting_full_lifecycle() {
+    let bridge = mock_bridge();
+    let mut session = start_meeting("Phase 8 planning", &bridge).expect("meeting should start");
+    assert_eq!(session.status, MeetingSessionStatus::Open);
+
+    record_decision(
+        &mut session,
+        MeetingDecision {
+            description: "Implement goal curation with max 5 active".to_string(),
+            rationale: "Prevents goal sprawl".to_string(),
+            participants: vec!["alice".to_string()],
+        },
+    )
+    .unwrap();
+    record_action_item(
+        &mut session,
+        ActionItem {
+            description: "Write tests".to_string(),
+            owner: "bob".to_string(),
+            priority: 1,
+            due_description: Some("before merge".to_string()),
+        },
+    )
+    .unwrap();
+    add_note(&mut session, "Research tracker also needed").unwrap();
+
+    let closed = close_meeting(session, &bridge).expect("meeting should close");
+    assert_eq!(closed.status, MeetingSessionStatus::Closed);
+    assert_eq!(closed.decisions.len(), 1);
+    assert_eq!(closed.action_items.len(), 1);
+    assert_eq!(closed.notes.len(), 1);
+    assert!(closed.durable_summary().contains("Phase 8 planning"));
+}
+
+#[test]
+fn meeting_rejects_operations_on_closed_session_and_double_close() {
+    let bridge = mock_bridge();
+    let session = start_meeting("Retro", &bridge).unwrap();
+    let mut closed = close_meeting(session, &bridge).unwrap();
+
+    assert!(
+        record_decision(
+            &mut closed,
+            MeetingDecision {
+                description: "late".to_string(),
+                rationale: "nope".to_string(),
+                participants: vec![],
+            }
+        )
+        .is_err()
+    );
+    assert!(
+        record_action_item(
+            &mut closed,
+            ActionItem {
+                description: "late".to_string(),
+                owner: "x".to_string(),
+                priority: 1,
+                due_description: None,
+            }
+        )
+        .is_err()
+    );
+    assert!(add_note(&mut closed, "late").is_err());
+    assert!(close_meeting(closed, &bridge).is_err());
+}
+
+#[test]
+fn goal_board_enforce_capacity_and_promote() {
+    let mut board = GoalBoard::new();
+    for i in 1..=MAX_ACTIVE_GOALS {
+        add_active_goal(&mut board, sample_active(&format!("g{i}"), i as u32)).unwrap();
+    }
+    assert_eq!(board.active_slots_remaining(), 0);
+    assert!(add_active_goal(&mut board, sample_active("overflow", 1)).is_err());
+
+    add_backlog_item(
+        &mut board,
+        BacklogItem {
+            id: "bl-1".to_string(),
+            description: "Backlog item".to_string(),
+            source: "meeting".to_string(),
+            score: 0.9,
+        },
+    )
+    .unwrap();
+    assert!(promote_to_active(&mut board, "bl-1", 1, None).is_err());
+
+    update_goal_progress(&mut board, "g1", GoalProgress::Completed).unwrap();
+    let archived = archive_completed(&mut board);
+    assert_eq!(archived.len(), 1);
+
+    promote_to_active(&mut board, "bl-1", 1, Some("curator".to_string())).unwrap();
+    assert_eq!(board.active.len(), MAX_ACTIVE_GOALS);
+    assert!(board.backlog.is_empty());
+}
+
+#[test]
+fn goal_board_progress_lifecycle() {
+    let mut board = GoalBoard::new();
+    add_active_goal(&mut board, sample_active("g1", 1)).unwrap();
+
+    update_goal_progress(&mut board, "g1", GoalProgress::InProgress { percent: 50 }).unwrap();
+    assert!(matches!(
+        board.active[0].status,
+        GoalProgress::InProgress { percent: 50 }
+    ));
+
+    update_goal_progress(
+        &mut board,
+        "g1",
+        GoalProgress::Blocked("waiting".to_string()),
+    )
+    .unwrap();
+    assert!(matches!(board.active[0].status, GoalProgress::Blocked(_)));
+
+    update_goal_progress(&mut board, "g1", GoalProgress::Completed).unwrap();
+    assert_eq!(archive_completed(&mut board).len(), 1);
+    assert!(board.active.is_empty());
+}
+
+#[test]
+fn goal_board_load_persist_and_duplicates() {
+    let bridge = mock_bridge();
+    let board = load_goal_board(&bridge).unwrap();
+    assert!(board.active.is_empty());
+    persist_board(&board, &bridge).unwrap();
+
+    let mut board2 = GoalBoard::new();
+    add_active_goal(&mut board2, sample_active("g1", 1)).unwrap();
+    assert!(
+        add_active_goal(&mut board2, sample_active("g1", 1))
+            .unwrap_err()
+            .to_string()
+            .contains("already active")
+    );
+}
+
+#[test]
+fn research_topic_and_developer_watch() {
+    let bridge = mock_bridge();
+
+    add_research_topic(
+        ResearchTopic {
+            id: "rt-1".to_string(),
+            title: "Cognitive memory consolidation".to_string(),
+            source: "meeting".to_string(),
+            priority: 1,
+            status: ResearchStatus::Proposed,
+        },
+        &bridge,
+    )
+    .unwrap();
+    update_topic_status("rt-1", ResearchStatus::Completed, &bridge).unwrap();
+
+    track_developer(
+        DeveloperWatch {
+            github_id: "octocat".to_string(),
+            focus_areas: vec!["agent-sdk".to_string()],
+            last_checked: None,
+        },
+        &bridge,
+    )
+    .unwrap();
+
+    // Rejects empty fields.
+    assert!(
+        add_research_topic(
+            ResearchTopic {
+                id: "".to_string(),
+                title: "x".to_string(),
+                source: "y".to_string(),
+                priority: 1,
+                status: ResearchStatus::Proposed,
+            },
+            &bridge,
+        )
+        .is_err()
+    );
+    assert!(
+        track_developer(
+            DeveloperWatch {
+                github_id: "".to_string(),
+                focus_areas: vec!["a".to_string()],
+                last_checked: None,
+            },
+            &bridge,
+        )
+        .is_err()
+    );
+}
+
+#[test]
+fn dual_identity_config_and_env() {
+    let config =
+        DualIdentityConfig::new("copilot-user", "commit-user", "commit@example.com").unwrap();
+    assert_eq!(config.copilot_user, "copilot-user");
+    assert!(DualIdentityConfig::new("", "user", "e@x.com").is_err());
+    assert!(DualIdentityConfig::new("u", "u", "noemail").is_err());
+
+    let copilot_env = env_for_identity(AuthIdentity::CopilotAuth, &config);
+    assert_eq!(copilot_env.len(), 1);
+    assert_eq!(copilot_env[0].0, "GITHUB_USER");
+
+    let commit_env = env_for_identity(AuthIdentity::CommitAuth, &config);
+    assert_eq!(commit_env.len(), 4);
+}
+
+#[test]
+fn identity_operation_validation() {
+    assert!(validate_identity_for_operation(AuthIdentity::CopilotAuth, "git-commit").is_err());
+    assert!(validate_identity_for_operation(AuthIdentity::CommitAuth, "copilot-chat").is_err());
+    assert!(validate_identity_for_operation(AuthIdentity::CopilotAuth, "copilot-chat").is_ok());
+    assert!(validate_identity_for_operation(AuthIdentity::CommitAuth, "git-commit").is_ok());
+    assert!(validate_identity_for_operation(AuthIdentity::CopilotAuth, "custom").is_ok());
+
+    assert_eq!(
+        identity_for_operation("copilot-submit"),
+        Some(AuthIdentity::CopilotAuth)
+    );
+    assert_eq!(
+        identity_for_operation("git-tag"),
+        Some(AuthIdentity::CommitAuth)
+    );
+    assert_eq!(identity_for_operation("unknown"), None);
+}
+
+#[test]
+fn meeting_decisions_feed_goal_board() {
+    let bridge = mock_bridge();
+    let mut session = start_meeting("Goal alignment", &bridge).unwrap();
+    record_decision(
+        &mut session,
+        MeetingDecision {
+            description: "Prioritize cognitive memory consolidation".to_string(),
+            rationale: "Foundation for all features".to_string(),
+            participants: vec!["team".to_string()],
+        },
+    )
+    .unwrap();
+    let closed = close_meeting(session, &bridge).unwrap();
+
+    let mut board = GoalBoard::new();
+    for (i, decision) in closed.decisions.iter().enumerate() {
+        add_active_goal(
+            &mut board,
+            ActiveGoal {
+                id: format!("from-meeting-{i}"),
+                description: decision.description.clone(),
+                priority: (i + 1) as u32,
+                status: GoalProgress::NotStarted,
+                assigned_to: None,
+            },
+        )
+        .unwrap();
+    }
+    assert_eq!(board.active.len(), 1);
+    assert!(board.active[0].description.contains("cognitive memory"));
+}
+
+#[test]
+fn meeting_action_items_become_research_topics() {
+    let bridge = mock_bridge();
+    let mut session = start_meeting("Research planning", &bridge).unwrap();
+    record_action_item(
+        &mut session,
+        ActionItem {
+            description: "Investigate agent memory patterns".to_string(),
+            owner: "researcher".to_string(),
+            priority: 2,
+            due_description: None,
+        },
+    )
+    .unwrap();
+    let closed = close_meeting(session, &bridge).unwrap();
+
+    for (i, item) in closed.action_items.iter().enumerate() {
+        add_research_topic(
+            ResearchTopic {
+                id: format!("from-action-{i}"),
+                title: item.description.clone(),
+                source: "meeting-action-item".to_string(),
+                priority: item.priority,
+                status: ResearchStatus::Proposed,
+            },
+            &bridge,
+        )
+        .unwrap();
+    }
+}


### PR DESCRIPTION
## Summary
- **Meeting facilitator** (`meeting_facilitator.rs`, 333 LOC): structured meeting sessions with decisions, action items, notes, and cognitive memory persistence on close
- **Goal curation** (`goal_curation.rs`, 400 LOC): top-5 active goal board with backlog, promotion, progress tracking, and strict capacity enforcement (max 5 active)
- **Research tracker** (`research_tracker.rs`, 357 LOC): research topic lifecycle (proposed -> in-progress -> completed -> archived) and developer watch list with cognitive memory storage
- **Dual identity auth** (`identity_auth.rs`, 279 LOC): separate Copilot API and git commit identities with environment variable generation and operation validation
- **Integration tests** (`tests/meeting_goals.rs`, 343 LOC): cross-module workflows including meeting decisions feeding the goal board and action items becoming research topics

All modules wired into `lib.rs` with public re-exports. `cargo test` (70 passed), `cargo clippy`, and `cargo fmt` all clean.

Closes #97

## Test plan
- [x] `cargo test` — all 70 tests pass
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] `cargo fmt --check` — formatted
- [x] All modules within LOC limits (<=400 each, tests <=400)
- [x] Meeting session open/close lifecycle with cognitive memory persistence
- [x] Goal board enforces max 5 active goals, promotion from backlog
- [x] Research topic add/status-update cycle
- [x] Dual identity env var generation and operation validation cross-checks
- [x] Cross-module: meeting decisions -> goal board entries
- [x] Cross-module: meeting action items -> research topics

🤖 Generated with [Claude Code](https://claude.com/claude-code)