### PR TITLE
feat: Phase 6 — Self-improvement loop & canary self-relaunch

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,8 @@ pub mod reflection;
 pub mod review;
 pub mod runtime;
 mod sanitization;
+pub mod self_improve;
+pub mod self_relaunch;
 pub mod session;
 pub mod terminal_engineer_bridge;
 mod terminal_session;
@@ -164,6 +166,14 @@ pub use runtime::{
     RuntimeAddress, RuntimeKernel, RuntimeMailboxTransport, RuntimeNodeId, RuntimePorts,
     RuntimeRequest, RuntimeState, RuntimeSupervisor, RuntimeTopology, RuntimeTopologyDriver,
     SessionOutcome,
+};
+pub use self_improve::{
+    ImprovementConfig, ImprovementCycle, ImprovementDecision, ImprovementPhase, ProposedChange,
+    run_improvement_cycle, summarize_cycle,
+};
+pub use self_relaunch::{
+    GateResult, RelaunchConfig, RelaunchGate, all_gates_passed, build_canary, default_gates,
+    handover, verify_canary,
 };
 pub use session::{
     SessionId, SessionIdGenerator, SessionPhase, SessionRecord, UuidSessionIdGenerator,

--- a/src/self_improve.rs
+++ b/src/self_improve.rs
@@ -1,0 +1,392 @@
+//! Self-improvement loop that evaluates, analyzes, and decides on changes.
+//!
+//! The improvement cycle follows a disciplined sequence:
+//! `Eval -> Analyze -> Research -> Improve -> ReEval -> Decide`.
+//!
+//! Each cycle produces a typed [`ImprovementCycle`] record with full
+//! provenance so decisions are reviewable (Pillar 6). Changes are only
+//! committed when the net improvement meets the threshold and no single
+//! dimension regresses beyond the allowed maximum (Pillar 11).
+
+use crate::error::SimardResult;
+use crate::gym_bridge::GymBridge;
+use crate::gym_scoring::{
+    GymSuiteScore, Regression, RegressionSeverity, detect_regression, suite_score_from_result,
+};
+
+/// Phases of a single self-improvement cycle.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ImprovementPhase {
+    /// Run the gym suite to establish a baseline score.
+    Eval,
+    /// Analyze the baseline results for weak dimensions.
+    Analyze,
+    /// Research possible changes that could address weaknesses.
+    Research,
+    /// Apply the proposed changes (in a sandbox / canary environment).
+    Improve,
+    /// Re-run the gym suite against the changed version.
+    ReEval,
+    /// Compare baseline and post-change scores and decide.
+    Decide,
+}
+
+impl std::fmt::Display for ImprovementPhase {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let label = match self {
+            Self::Eval => "eval",
+            Self::Analyze => "analyze",
+            Self::Research => "research",
+            Self::Improve => "improve",
+            Self::ReEval => "re-eval",
+            Self::Decide => "decide",
+        };
+        f.write_str(label)
+    }
+}
+
+/// A single proposed change to prompts, policies, or orchestration.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProposedChange {
+    /// Path to the file that would be changed.
+    pub file_path: String,
+    /// Human-readable description of the change.
+    pub description: String,
+    /// Why this change is expected to help.
+    pub expected_impact: String,
+}
+
+/// The outcome of the decision phase.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ImprovementDecision {
+    /// The changes should be committed.
+    Commit {
+        /// Net overall improvement as a fraction (e.g. 0.05 = 5%).
+        net_improvement: f64,
+    },
+    /// The changes should be reverted.
+    Revert {
+        /// Why the changes were rejected.
+        reason: String,
+    },
+}
+
+/// Configuration for an improvement cycle.
+#[derive(Clone, Debug)]
+pub struct ImprovementConfig {
+    /// The gym suite to evaluate against.
+    pub suite_id: String,
+    /// Minimum net improvement required to commit (fraction, e.g. 0.02 = 2%).
+    pub min_net_improvement: f64,
+    /// Maximum allowed regression on any single dimension (fraction, e.g. 0.05 = 5%).
+    pub max_single_regression: f64,
+    /// Proposed changes to evaluate.
+    pub proposed_changes: Vec<ProposedChange>,
+}
+
+impl Default for ImprovementConfig {
+    fn default() -> Self {
+        Self {
+            suite_id: "progressive".to_string(),
+            min_net_improvement: 0.02,
+            max_single_regression: 0.05,
+            proposed_changes: Vec::new(),
+        }
+    }
+}
+
+/// A complete improvement cycle record with full provenance.
+#[derive(Clone, Debug)]
+pub struct ImprovementCycle {
+    /// The baseline score established in the Eval phase.
+    pub baseline: GymSuiteScore,
+    /// Changes that were proposed during the Research/Improve phases.
+    pub proposed_changes: Vec<ProposedChange>,
+    /// The post-change score from the ReEval phase (None if ReEval was skipped).
+    pub post_score: Option<GymSuiteScore>,
+    /// Regressions detected during the Decide phase.
+    pub regressions: Vec<Regression>,
+    /// The final decision (None if the cycle was aborted before Decide).
+    pub decision: Option<ImprovementDecision>,
+    /// The phase the cycle reached before completing or aborting.
+    pub final_phase: ImprovementPhase,
+}
+
+/// Run a full improvement cycle: Eval -> Analyze -> Research -> Improve -> ReEval -> Decide.
+///
+/// The cycle requires at least one proposed change in `config.proposed_changes`.
+/// If no changes are proposed, the cycle stops after Analyze and returns a
+/// Revert decision.
+///
+/// The gym bridge is called twice: once for baseline and once for re-evaluation.
+/// If either call fails, the error propagates immediately (Pillar 11).
+pub fn run_improvement_cycle(
+    gym: &GymBridge,
+    config: &ImprovementConfig,
+) -> SimardResult<ImprovementCycle> {
+    // Phase 1: Eval — establish baseline
+    let baseline_result = gym.run_suite(&config.suite_id)?;
+    let baseline = suite_score_from_result(&baseline_result);
+
+    // Phase 2: Analyze — identify weak dimensions
+    let weak_dimensions = find_weak_dimensions(&baseline);
+
+    // Phase 3: Research — check if we have proposed changes
+    if config.proposed_changes.is_empty() {
+        return Ok(ImprovementCycle {
+            baseline,
+            proposed_changes: Vec::new(),
+            post_score: None,
+            regressions: Vec::new(),
+            decision: Some(ImprovementDecision::Revert {
+                reason: format!(
+                    "no changes proposed; weak dimensions: {}",
+                    if weak_dimensions.is_empty() {
+                        "none".to_string()
+                    } else {
+                        weak_dimensions.join(", ")
+                    }
+                ),
+            }),
+            final_phase: ImprovementPhase::Analyze,
+        });
+    }
+
+    // Phase 4: Improve — changes are assumed to be applied externally
+    // (the caller applies the changes before calling this function in a
+    // canary environment; see self_relaunch.rs for the canary flow).
+
+    // Phase 5: ReEval — re-run the suite
+    let post_result = gym.run_suite(&config.suite_id)?;
+    let post_score = suite_score_from_result(&post_result);
+
+    // Phase 6: Decide — compare and decide
+    let regressions = detect_regression(&post_score, &baseline);
+    let decision = decide(config, &baseline, &post_score, &regressions);
+
+    Ok(ImprovementCycle {
+        baseline,
+        proposed_changes: config.proposed_changes.clone(),
+        post_score: Some(post_score),
+        regressions,
+        decision: Some(decision),
+        final_phase: ImprovementPhase::Decide,
+    })
+}
+
+/// Apply the decision rule: commit if net improvement >= threshold
+/// and no single dimension regresses beyond the allowed maximum.
+fn decide(
+    config: &ImprovementConfig,
+    baseline: &GymSuiteScore,
+    post: &GymSuiteScore,
+    regressions: &[Regression],
+) -> ImprovementDecision {
+    let net = post.overall - baseline.overall;
+
+    // Check for severe regressions first
+    let worst_regression = regressions
+        .iter()
+        .map(|r| r.delta.abs())
+        .fold(0.0_f64, f64::max);
+
+    if worst_regression > config.max_single_regression {
+        let severe: Vec<&Regression> = regressions
+            .iter()
+            .filter(|r| r.delta.abs() > config.max_single_regression)
+            .collect();
+        let detail: Vec<String> = severe
+            .iter()
+            .map(|r| format!("{}: {:.1}% regression", r.dimension, r.delta.abs() * 100.0))
+            .collect();
+        return ImprovementDecision::Revert {
+            reason: format!(
+                "regression exceeds max allowed ({:.1}%): {}",
+                config.max_single_regression * 100.0,
+                detail.join("; ")
+            ),
+        };
+    }
+
+    if net < config.min_net_improvement {
+        return ImprovementDecision::Revert {
+            reason: format!(
+                "net improvement {:.1}% is below minimum threshold {:.1}%",
+                net * 100.0,
+                config.min_net_improvement * 100.0,
+            ),
+        };
+    }
+
+    ImprovementDecision::Commit {
+        net_improvement: net,
+    }
+}
+
+/// Identify dimensions scoring below 0.6 (the "weak" threshold).
+fn find_weak_dimensions(score: &GymSuiteScore) -> Vec<String> {
+    const WEAK_THRESHOLD: f64 = 0.6;
+    let dims = &score.dimensions;
+    let mut weak = Vec::new();
+    let checks: [(&str, f64); 5] = [
+        ("factual_accuracy", dims.factual_accuracy),
+        ("specificity", dims.specificity),
+        ("temporal_awareness", dims.temporal_awareness),
+        ("source_attribution", dims.source_attribution),
+        ("confidence_calibration", dims.confidence_calibration),
+    ];
+    for (name, value) in checks {
+        if value < WEAK_THRESHOLD {
+            weak.push(name.to_string());
+        }
+    }
+    weak
+}
+
+/// Summary of an improvement cycle suitable for persistence or display.
+pub fn summarize_cycle(cycle: &ImprovementCycle) -> String {
+    let mut lines = Vec::new();
+    lines.push(format!(
+        "Baseline: {:.1}% overall ({} scenarios)",
+        cycle.baseline.overall * 100.0,
+        cycle.baseline.scenario_count,
+    ));
+
+    if let Some(ref post) = cycle.post_score {
+        let net = post.overall - cycle.baseline.overall;
+        lines.push(format!(
+            "Post-change: {:.1}% overall (net {}{:.1}%)",
+            post.overall * 100.0,
+            if net >= 0.0 { "+" } else { "" },
+            net * 100.0,
+        ));
+    }
+
+    if !cycle.regressions.is_empty() {
+        let severe_count = cycle
+            .regressions
+            .iter()
+            .filter(|r| r.severity == RegressionSeverity::Severe)
+            .count();
+        lines.push(format!(
+            "Regressions: {} total ({} severe)",
+            cycle.regressions.len(),
+            severe_count,
+        ));
+    }
+
+    match &cycle.decision {
+        Some(ImprovementDecision::Commit { net_improvement }) => {
+            lines.push(format!(
+                "Decision: COMMIT (net +{:.1}%)",
+                net_improvement * 100.0
+            ));
+        }
+        Some(ImprovementDecision::Revert { reason }) => {
+            lines.push(format!("Decision: REVERT ({reason})"));
+        }
+        None => {
+            lines.push(format!(
+                "Decision: INCOMPLETE (stopped at {})",
+                cycle.final_phase
+            ));
+        }
+    }
+
+    lines.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn improvement_phase_display() {
+        assert_eq!(ImprovementPhase::Eval.to_string(), "eval");
+        assert_eq!(ImprovementPhase::ReEval.to_string(), "re-eval");
+        assert_eq!(ImprovementPhase::Decide.to_string(), "decide");
+    }
+
+    #[test]
+    fn default_config_thresholds() {
+        let cfg = ImprovementConfig::default();
+        assert!((cfg.min_net_improvement - 0.02).abs() < 1e-9);
+        assert!((cfg.max_single_regression - 0.05).abs() < 1e-9);
+    }
+
+    #[test]
+    fn decide_commits_when_improvement_sufficient() {
+        let cfg = ImprovementConfig::default();
+        let baseline = make_score(0.70);
+        let post = make_score(0.75);
+        let regressions = vec![];
+        let d = decide(&cfg, &baseline, &post, &regressions);
+        match d {
+            ImprovementDecision::Commit { net_improvement } => {
+                assert!((net_improvement - 0.05).abs() < 1e-9);
+            }
+            ImprovementDecision::Revert { .. } => panic!("expected commit"),
+        }
+    }
+
+    #[test]
+    fn decide_reverts_when_below_threshold() {
+        let cfg = ImprovementConfig::default();
+        let baseline = make_score(0.70);
+        let post = make_score(0.71);
+        let regressions = vec![];
+        let d = decide(&cfg, &baseline, &post, &regressions);
+        assert!(matches!(d, ImprovementDecision::Revert { .. }));
+    }
+
+    #[test]
+    fn decide_reverts_on_severe_regression() {
+        let cfg = ImprovementConfig::default();
+        let baseline = make_score(0.70);
+        let post = make_score(0.80);
+        let regressions = vec![Regression {
+            dimension: "specificity".to_string(),
+            baseline_score: 0.7,
+            current_score: 0.6,
+            delta: -0.10,
+            severity: RegressionSeverity::Moderate,
+        }];
+        let d = decide(&cfg, &baseline, &post, &regressions);
+        assert!(matches!(d, ImprovementDecision::Revert { .. }));
+    }
+
+    #[test]
+    fn find_weak_dimensions_identifies_low_scores() {
+        let score = make_score(0.50);
+        let weak = find_weak_dimensions(&score);
+        // At 0.50 overall, all dimension values (0.50, 0.45, 0.40, 0.35, 0.425)
+        // are below 0.6
+        assert!(!weak.is_empty());
+    }
+
+    #[test]
+    fn find_weak_dimensions_empty_when_strong() {
+        let score = make_score(0.90);
+        let weak = find_weak_dimensions(&score);
+        assert!(weak.is_empty());
+    }
+
+    fn make_score(v: f64) -> GymSuiteScore {
+        use crate::gym_bridge::ScoreDimensions;
+        GymSuiteScore {
+            suite_id: "test".to_string(),
+            overall: v,
+            dimensions: ScoreDimensions {
+                factual_accuracy: v,
+                specificity: v * 0.9,
+                temporal_awareness: v * 0.8,
+                source_attribution: v * 0.7,
+                confidence_calibration: v * 0.85,
+            },
+            scenario_count: 6,
+            scenarios_passed: 6,
+            pass_rate: 1.0,
+            recorded_at_unix_ms: None,
+        }
+    }
+}

--- a/src/self_relaunch.rs
+++ b/src/self_relaunch.rs
@@ -1,0 +1,334 @@
+//! Canary deployment and handover for self-relaunch.
+//!
+//! Gate sequence: Smoke -> UnitTest -> GymBaseline -> BridgeHealth.
+//! All gates must pass before handover. Failures reject the canary (Pillar 11).
+
+use std::fmt::{self, Display, Formatter};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Duration;
+
+use crate::error::{SimardError, SimardResult};
+
+#[derive(Clone, Debug)]
+pub struct RelaunchConfig {
+    pub canary_target_dir: PathBuf,
+    pub health_timeout: Duration,
+    pub manifest_dir: PathBuf,
+}
+
+impl Default for RelaunchConfig {
+    fn default() -> Self {
+        Self {
+            canary_target_dir: PathBuf::from("/tmp/simard-canary"),
+            health_timeout: Duration::from_secs(30),
+            manifest_dir: PathBuf::from("."),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RelaunchGate {
+    Smoke,
+    UnitTest,
+    GymBaseline,
+    BridgeHealth,
+}
+
+impl Display for RelaunchGate {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let label = match self {
+            Self::Smoke => "smoke",
+            Self::UnitTest => "unit-test",
+            Self::GymBaseline => "gym-baseline",
+            Self::BridgeHealth => "bridge-health",
+        };
+        f.write_str(label)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct GateResult {
+    pub gate: RelaunchGate,
+    pub passed: bool,
+    pub detail: String,
+}
+
+impl Display for GateResult {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let status = if self.passed { "PASS" } else { "FAIL" };
+        write!(f, "[{}] {}: {}", status, self.gate, self.detail)
+    }
+}
+
+pub fn default_gates() -> Vec<RelaunchGate> {
+    vec![
+        RelaunchGate::Smoke,
+        RelaunchGate::UnitTest,
+        RelaunchGate::GymBaseline,
+        RelaunchGate::BridgeHealth,
+    ]
+}
+
+/// Build a canary binary via `cargo build --release` in a separate target directory.
+pub fn build_canary(config: &RelaunchConfig) -> SimardResult<PathBuf> {
+    let target_dir = &config.canary_target_dir;
+
+    std::fs::create_dir_all(target_dir).map_err(|e| SimardError::PersistentStoreIo {
+        store: "canary-build".to_string(),
+        action: "create target directory".to_string(),
+        path: target_dir.clone(),
+        reason: e.to_string(),
+    })?;
+
+    let output = Command::new("cargo")
+        .arg("build")
+        .arg("--release")
+        .arg("--target-dir")
+        .arg(target_dir)
+        .arg("--manifest-path")
+        .arg(config.manifest_dir.join("Cargo.toml"))
+        .output()
+        .map_err(|e| SimardError::BridgeSpawnFailed {
+            bridge: "canary-build".to_string(),
+            reason: format!("cargo build failed to start: {e}"),
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(SimardError::BridgeCallFailed {
+            bridge: "canary-build".to_string(),
+            method: "cargo build --release".to_string(),
+            reason: format!("build failed (exit {}): {}", output.status, stderr),
+        });
+    }
+
+    let binary_path = target_dir.join("release").join("simard");
+    if !binary_path.exists() {
+        return Err(SimardError::ArtifactIo {
+            path: binary_path,
+            reason: "canary binary not found after successful build".to_string(),
+        });
+    }
+
+    Ok(binary_path)
+}
+
+/// Verify a canary binary against a sequence of gates (does not short-circuit).
+pub fn verify_canary(
+    binary: &Path,
+    gates: &[RelaunchGate],
+    config: &RelaunchConfig,
+) -> SimardResult<Vec<GateResult>> {
+    let mut results = Vec::with_capacity(gates.len());
+
+    for &gate in gates {
+        let result = run_gate(binary, gate, config);
+        results.push(result);
+    }
+
+    Ok(results)
+}
+
+pub fn all_gates_passed(results: &[GateResult]) -> bool {
+    results.iter().all(|r| r.passed)
+}
+
+/// Validate preconditions and approve handover from current process to canary.
+/// Returns error if pid is 0 or binary does not exist.
+pub fn handover(current_pid: u32, canary_binary: &Path) -> SimardResult<()> {
+    if current_pid == 0 {
+        return Err(SimardError::BridgeCallFailed {
+            bridge: "self-relaunch".to_string(),
+            method: "handover".to_string(),
+            reason: "current_pid cannot be 0".to_string(),
+        });
+    }
+
+    if !canary_binary.exists() {
+        return Err(SimardError::ArtifactIo {
+            path: canary_binary.to_path_buf(),
+            reason: "canary binary does not exist at handover time".to_string(),
+        });
+    }
+
+    let metadata = std::fs::metadata(canary_binary).map_err(|e| SimardError::ArtifactIo {
+        path: canary_binary.to_path_buf(),
+        reason: format!("cannot read canary binary metadata: {e}"),
+    })?;
+
+    if !metadata.is_file() {
+        return Err(SimardError::ArtifactIo {
+            path: canary_binary.to_path_buf(),
+            reason: "canary path is not a regular file".to_string(),
+        });
+    }
+
+    // Phase 6: preconditions validated. Actual exec deferred to CLI integration.
+    Ok(())
+}
+
+fn run_gate(binary: &Path, gate: RelaunchGate, config: &RelaunchConfig) -> GateResult {
+    match gate {
+        RelaunchGate::Smoke => run_smoke_gate(binary),
+        RelaunchGate::UnitTest => run_unit_test_gate(config),
+        RelaunchGate::GymBaseline => run_gym_baseline_gate(binary),
+        RelaunchGate::BridgeHealth => run_bridge_health_gate(binary, config),
+    }
+}
+
+fn run_smoke_gate(binary: &Path) -> GateResult {
+    match Command::new(binary).arg("--version").output() {
+        Ok(output) if output.status.success() => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            GateResult {
+                gate: RelaunchGate::Smoke,
+                passed: true,
+                detail: format!("version: {}", stdout.trim()),
+            }
+        }
+        Ok(output) => GateResult {
+            gate: RelaunchGate::Smoke,
+            passed: false,
+            detail: format!(
+                "binary exited with {}: {}",
+                output.status,
+                String::from_utf8_lossy(&output.stderr).trim()
+            ),
+        },
+        Err(e) => GateResult {
+            gate: RelaunchGate::Smoke,
+            passed: false,
+            detail: format!("failed to execute binary: {e}"),
+        },
+    }
+}
+
+fn run_unit_test_gate(config: &RelaunchConfig) -> GateResult {
+    match Command::new("cargo")
+        .arg("test")
+        .arg("--manifest-path")
+        .arg(config.manifest_dir.join("Cargo.toml"))
+        .arg("--target-dir")
+        .arg(&config.canary_target_dir)
+        .env("CARGO_BUILD_JOBS", "2")
+        .output()
+    {
+        Ok(output) if output.status.success() => GateResult {
+            gate: RelaunchGate::UnitTest,
+            passed: true,
+            detail: "all tests passed".to_string(),
+        },
+        Ok(output) => {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let truncated = truncate_output(&stderr, 200);
+            GateResult {
+                gate: RelaunchGate::UnitTest,
+                passed: false,
+                detail: format!("tests failed (exit {}): {}", output.status, truncated),
+            }
+        }
+        Err(e) => GateResult {
+            gate: RelaunchGate::UnitTest,
+            passed: false,
+            detail: format!("cargo test failed to run: {e}"),
+        },
+    }
+}
+
+fn run_gym_baseline_gate(binary: &Path) -> GateResult {
+    match Command::new(binary).args(["gym", "list"]).output() {
+        Ok(output) if output.status.success() => GateResult {
+            gate: RelaunchGate::GymBaseline,
+            passed: true,
+            detail: "gym list succeeded".to_string(),
+        },
+        Ok(output) => GateResult {
+            gate: RelaunchGate::GymBaseline,
+            passed: false,
+            detail: format!(
+                "gym probe failed (exit {}): {}",
+                output.status,
+                String::from_utf8_lossy(&output.stderr).trim()
+            ),
+        },
+        Err(e) => GateResult {
+            gate: RelaunchGate::GymBaseline,
+            passed: false,
+            detail: format!("gym probe failed to run: {e}"),
+        },
+    }
+}
+
+fn run_bridge_health_gate(binary: &Path, config: &RelaunchConfig) -> GateResult {
+    let timeout_secs = config.health_timeout.as_secs().to_string();
+    match Command::new(binary)
+        .args(["probe", "bridge", "--timeout", &timeout_secs])
+        .output()
+    {
+        Ok(output) if output.status.success() => GateResult {
+            gate: RelaunchGate::BridgeHealth,
+            passed: true,
+            detail: "bridge health check passed".to_string(),
+        },
+        Ok(output) => GateResult {
+            gate: RelaunchGate::BridgeHealth,
+            passed: false,
+            detail: format!(
+                "bridge health failed (exit {}): {}",
+                output.status,
+                String::from_utf8_lossy(&output.stderr).trim()
+            ),
+        },
+        Err(e) => GateResult {
+            gate: RelaunchGate::BridgeHealth,
+            passed: false,
+            detail: format!("bridge health probe failed to run: {e}"),
+        },
+    }
+}
+
+fn truncate_output(s: &str, max_len: usize) -> String {
+    if s.len() <= max_len {
+        s.trim().to_string()
+    } else {
+        format!("{}...", &s[..max_len].trim())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn relaunch_gate_display() {
+        assert_eq!(RelaunchGate::Smoke.to_string(), "smoke");
+        assert_eq!(RelaunchGate::BridgeHealth.to_string(), "bridge-health");
+    }
+
+    #[test]
+    fn default_gates_has_all_four() {
+        let gates = default_gates();
+        assert_eq!(gates.len(), 4);
+        assert_eq!(gates[0], RelaunchGate::Smoke);
+        assert_eq!(gates[3], RelaunchGate::BridgeHealth);
+    }
+
+    #[test]
+    fn handover_rejects_zero_pid() {
+        let err = handover(0, Path::new("/usr/bin/true")).unwrap_err();
+        assert!(err.to_string().contains("current_pid"));
+    }
+
+    #[test]
+    fn handover_rejects_missing_binary() {
+        let err = handover(12345, Path::new("/tmp/no-such-canary-82719")).unwrap_err();
+        assert!(err.to_string().contains("does not exist"));
+    }
+
+    #[test]
+    fn smoke_gate_handles_missing_binary() {
+        let result = run_smoke_gate(Path::new("/tmp/no-such-binary-48291"));
+        assert!(!result.passed);
+    }
+}

--- a/tests/self_improve.rs
+++ b/tests/self_improve.rs
@@ -1,0 +1,329 @@
+//! Integration tests for self-improvement loop and self-relaunch canary.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use simard::bridge_subprocess::InMemoryBridgeTransport;
+use simard::gym_bridge::GymBridge;
+use simard::self_improve::{
+    ImprovementConfig, ImprovementDecision, ImprovementPhase, ProposedChange,
+    run_improvement_cycle, summarize_cycle,
+};
+use simard::self_relaunch::{GateResult, RelaunchGate, all_gates_passed, default_gates, handover};
+
+fn suite_json(suite_id: &str, overall: f64) -> serde_json::Value {
+    let d = |v: f64| {
+        serde_json::json!({
+            "factual_accuracy": v, "specificity": v * 0.9,
+            "temporal_awareness": v * 0.8, "source_attribution": v * 0.7,
+            "confidence_calibration": v * 0.85
+        })
+    };
+    serde_json::json!({
+        "suite_id": suite_id, "success": true, "overall_score": overall,
+        "dimensions": d(overall),
+        "scenario_results": [{
+            "scenario_id": "L1", "success": true, "score": overall,
+            "dimensions": d(overall), "question_count": 5,
+            "questions_answered": 5, "degraded_sources": []
+        }],
+        "scenarios_passed": 1, "scenarios_total": 1, "degraded_sources": []
+    })
+}
+
+fn fixed_score_bridge(score: f64) -> GymBridge {
+    let t = InMemoryBridgeTransport::new("gym", move |method, _| match method {
+        "gym.run_suite" => Ok(suite_json("progressive", score)),
+        _ => Ok(serde_json::json!([])),
+    });
+    GymBridge::new(Box::new(t))
+}
+
+fn improving_bridge(base: f64, post: f64) -> GymBridge {
+    let n = AtomicUsize::new(0);
+    let t = InMemoryBridgeTransport::new("gym", move |method, _| match method {
+        "gym.run_suite" => {
+            let s = if n.fetch_add(1, Ordering::SeqCst) == 0 {
+                base
+            } else {
+                post
+            };
+            Ok(suite_json("progressive", s))
+        }
+        _ => Ok(serde_json::json!([])),
+    });
+    GymBridge::new(Box::new(t))
+}
+
+fn regressing_bridge(base: f64, post_overall: f64, post_spec: f64) -> GymBridge {
+    let n = AtomicUsize::new(0);
+    let t = InMemoryBridgeTransport::new("gym", move |method, _| match method {
+        "gym.run_suite" => {
+            if n.fetch_add(1, Ordering::SeqCst) == 0 {
+                Ok(suite_json("progressive", base))
+            } else {
+                Ok(serde_json::json!({
+                    "suite_id": "progressive", "success": true,
+                    "overall_score": post_overall,
+                    "dimensions": {
+                        "factual_accuracy": post_overall, "specificity": post_spec,
+                        "temporal_awareness": post_overall * 0.8,
+                        "source_attribution": post_overall * 0.7,
+                        "confidence_calibration": post_overall * 0.85
+                    },
+                    "scenario_results": [], "scenarios_passed": 1,
+                    "scenarios_total": 1, "degraded_sources": []
+                }))
+            }
+        }
+        _ => Ok(serde_json::json!([])),
+    });
+    GymBridge::new(Box::new(t))
+}
+
+fn sample_changes() -> Vec<ProposedChange> {
+    vec![ProposedChange {
+        file_path: "prompt_assets/engineer_system.md".to_string(),
+        description: "Add evidence-citing instruction".to_string(),
+        expected_impact: "Improve source_attribution".to_string(),
+    }]
+}
+
+fn cfg(changes: Vec<ProposedChange>) -> ImprovementConfig {
+    ImprovementConfig {
+        suite_id: "progressive".to_string(),
+        min_net_improvement: 0.02,
+        max_single_regression: 0.05,
+        proposed_changes: changes,
+    }
+}
+
+#[test]
+fn cycle_with_no_changes_stops_at_analyze() {
+    let gym = fixed_score_bridge(0.70);
+    let config = cfg(vec![]);
+
+    let cycle = run_improvement_cycle(&gym, &config).expect("cycle should succeed");
+    assert_eq!(cycle.final_phase, ImprovementPhase::Analyze);
+    assert!(cycle.post_score.is_none(), "no re-eval without changes");
+    assert!(
+        matches!(&cycle.decision, Some(ImprovementDecision::Revert { reason }) if reason.contains("no changes proposed")),
+        "should revert when no changes: {:?}",
+        cycle.decision,
+    );
+}
+
+#[test]
+fn cycle_commits_on_sufficient_improvement() {
+    let gym = improving_bridge(0.70, 0.75);
+    let config = cfg(sample_changes());
+
+    let cycle = run_improvement_cycle(&gym, &config).expect("cycle should succeed");
+    assert_eq!(cycle.final_phase, ImprovementPhase::Decide);
+    assert!(cycle.post_score.is_some());
+
+    match &cycle.decision {
+        Some(ImprovementDecision::Commit { net_improvement }) => {
+            assert!(
+                (*net_improvement - 0.05).abs() < 1e-9,
+                "expected ~5% improvement, got {net_improvement}"
+            );
+        }
+        other => panic!("expected commit, got {other:?}"),
+    }
+}
+
+#[test]
+fn cycle_reverts_when_improvement_too_small() {
+    let gym = improving_bridge(0.70, 0.71);
+    let config = cfg(sample_changes());
+
+    let cycle = run_improvement_cycle(&gym, &config).expect("cycle should succeed");
+    assert_eq!(cycle.final_phase, ImprovementPhase::Decide);
+    assert!(
+        matches!(&cycle.decision, Some(ImprovementDecision::Revert { reason }) if reason.contains("below minimum")),
+        "should revert: {:?}",
+        cycle.decision,
+    );
+}
+
+#[test]
+fn cycle_reverts_on_dimension_regression() {
+    // Overall improves from 0.70 to 0.80, but specificity drops from 0.63 to 0.40
+    let gym = regressing_bridge(0.70, 0.80, 0.40);
+    let config = cfg(sample_changes());
+
+    let cycle = run_improvement_cycle(&gym, &config).expect("cycle should succeed");
+    assert_eq!(cycle.final_phase, ImprovementPhase::Decide);
+    assert!(!cycle.regressions.is_empty(), "should detect regressions");
+    assert!(
+        matches!(&cycle.decision, Some(ImprovementDecision::Revert { reason }) if reason.contains("regression")),
+        "should revert on regression: {:?}",
+        cycle.decision,
+    );
+}
+
+#[test]
+fn cycle_records_baseline_accurately() {
+    let gym = fixed_score_bridge(0.82);
+    let config = ImprovementConfig {
+        suite_id: "progressive".to_string(),
+        min_net_improvement: 0.02,
+        max_single_regression: 0.05,
+        proposed_changes: vec![],
+    };
+
+    let cycle = run_improvement_cycle(&gym, &config).expect("cycle should succeed");
+    assert!(
+        (cycle.baseline.overall - 0.82).abs() < 1e-9,
+        "baseline should be 0.82"
+    );
+    assert_eq!(cycle.baseline.suite_id, "progressive");
+}
+
+#[test]
+fn summarize_cycle_includes_key_info() {
+    let gym = improving_bridge(0.70, 0.75);
+    let config = cfg(sample_changes());
+
+    let cycle = run_improvement_cycle(&gym, &config).expect("cycle should succeed");
+    let summary = summarize_cycle(&cycle);
+    assert!(
+        summary.contains("Baseline"),
+        "summary should contain baseline"
+    );
+    assert!(
+        summary.contains("Post-change"),
+        "summary should contain post-change"
+    );
+    assert!(
+        summary.contains("Decision"),
+        "summary should contain decision"
+    );
+    assert!(
+        summary.contains("COMMIT"),
+        "summary should show commit decision"
+    );
+}
+
+#[test]
+fn bridge_error_propagates_from_cycle() {
+    let transport = InMemoryBridgeTransport::new("gym-fail", |_method, _params| {
+        Err(simard::bridge::BridgeErrorPayload {
+            code: -32603,
+            message: "gym server crashed".to_string(),
+        })
+    });
+    let gym = GymBridge::new(Box::new(transport));
+    let config = cfg(sample_changes());
+
+    let err = run_improvement_cycle(&gym, &config).expect_err("should propagate bridge error");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("gym server crashed"),
+        "error should contain root cause: {msg}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Self-relaunch tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn default_gates_is_ordered() {
+    let gates = default_gates();
+    assert_eq!(gates[0], RelaunchGate::Smoke);
+    assert_eq!(gates[1], RelaunchGate::UnitTest);
+    assert_eq!(gates[2], RelaunchGate::GymBaseline);
+    assert_eq!(gates[3], RelaunchGate::BridgeHealth);
+}
+
+#[test]
+fn all_gates_passed_with_mixed_results() {
+    let results = vec![
+        GateResult {
+            gate: RelaunchGate::Smoke,
+            passed: true,
+            detail: "ok".to_string(),
+        },
+        GateResult {
+            gate: RelaunchGate::UnitTest,
+            passed: true,
+            detail: "ok".to_string(),
+        },
+        GateResult {
+            gate: RelaunchGate::GymBaseline,
+            passed: false,
+            detail: "gym failed".to_string(),
+        },
+    ];
+    assert!(!all_gates_passed(&results));
+}
+
+#[test]
+fn handover_rejects_pid_zero() {
+    let binary = PathBuf::from("/usr/bin/true");
+    let err = handover(0, &binary).unwrap_err();
+    assert!(err.to_string().contains("current_pid"));
+}
+
+#[test]
+fn handover_rejects_nonexistent_binary() {
+    let missing = PathBuf::from("/tmp/simard-nonexistent-canary-test-82719");
+    let err = handover(9999, &missing).unwrap_err();
+    assert!(err.to_string().contains("does not exist"));
+}
+
+#[test]
+fn handover_accepts_valid_file() {
+    let binary = PathBuf::from("/usr/bin/true");
+    if binary.exists() {
+        handover(9999, &binary).expect("handover with valid binary should succeed");
+    }
+}
+
+#[test]
+fn cycle_with_exact_threshold_improvement_commits() {
+    // Net improvement of exactly 0.02 (the default threshold) should commit
+    let gym = improving_bridge(0.70, 0.72);
+    let config = cfg(sample_changes());
+
+    let cycle = run_improvement_cycle(&gym, &config).expect("cycle should succeed");
+    match &cycle.decision {
+        Some(ImprovementDecision::Commit { net_improvement }) => {
+            assert!(
+                (*net_improvement - 0.02).abs() < 1e-9,
+                "expected exactly 2% improvement"
+            );
+        }
+        other => panic!("expected commit at exact threshold, got {other:?}"),
+    }
+}
+
+#[test]
+fn cycle_with_zero_net_change_reverts() {
+    let gym = improving_bridge(0.70, 0.70);
+    let config = cfg(sample_changes());
+
+    let cycle = run_improvement_cycle(&gym, &config).expect("cycle should succeed");
+    assert!(matches!(
+        &cycle.decision,
+        Some(ImprovementDecision::Revert { .. })
+    ));
+}
+
+#[test]
+fn cycle_with_negative_improvement_reverts() {
+    let gym = improving_bridge(0.70, 0.65);
+    let config = cfg(sample_changes());
+
+    let cycle = run_improvement_cycle(&gym, &config).expect("cycle should succeed");
+    assert!(matches!(
+        &cycle.decision,
+        Some(ImprovementDecision::Revert { .. })
+    ));
+    assert!(
+        !cycle.regressions.is_empty(),
+        "negative improvement should show regressions"
+    );
+}


### PR DESCRIPTION
## Summary

- **`src/self_improve.rs`** (392 LOC): Self-improvement loop with `ImprovementPhase` enum (Eval/Analyze/Research/Improve/ReEval/Decide), `ImprovementCycle` record with full provenance, and `run_improvement_cycle()` that uses the gym bridge for baseline + re-eval. Decision rule: commit if net improvement >= 2% and max single-dimension regression < 5%.
- **`src/self_relaunch.rs`** (334 LOC): Canary deployment with `RelaunchConfig`, four `RelaunchGate` checks (Smoke/UnitTest/GymBaseline/BridgeHealth), `build_canary()`, `verify_canary()`, and `handover()` with precondition validation. Actual exec deferred to future CLI integration.
- **`tests/self_improve.rs`** (329 LOC): Integration tests using mock gym bridge — covers commit/revert decisions, regression detection, bridge error propagation, threshold edge cases, and relaunch gate/handover validation.
- Wired into `lib.rs` with full public exports.

All modules under LOC limits. `cargo test` (425 tests), `cargo clippy -D warnings`, and `cargo fmt --check` pass.

Closes #95

## Test plan

- [x] `cargo test` passes (425 tests, 0 failures)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Improvement cycle commits when net >= 2% with no severe regressions
- [x] Improvement cycle reverts when below threshold or regression exceeds 5%
- [x] Handover rejects invalid PID and missing binary
- [x] Bridge errors propagate honestly (Pillar 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)