### PR TITLE
fix: resolve 8 bug-level findings from quality review

### DIFF
--- a/python/simard_gym_bridge.py
+++ b/python/simard_gym_bridge.py
@@ -93,6 +93,13 @@ def _extract_dimensions(grades: list[dict]) -> dict[str, float]:
     dims = _zero_dims()
     dims["factual_accuracy"] = avg
     dims["specificity"] = avg
+    # temporal_awareness: derive from grades that include a temporal score,
+    # fall back to None when the data source does not provide it.
+    temporal = [g["temporal_awareness"] for g in grades if "temporal_awareness" in g]
+    dims["temporal_awareness"] = sum(temporal) / len(temporal) if temporal else None
+    # source_attribution: derive from grades that include an attribution score.
+    attribution = [g["source_attribution"] for g in grades if "source_attribution" in g]
+    dims["source_attribution"] = sum(attribution) / len(attribution) if attribution else None
     metacog = [
         g["metacognition"]["overall"]
         for g in grades

--- a/src/agent_goal_assignment.rs
+++ b/src/agent_goal_assignment.rs
@@ -14,7 +14,7 @@ use std::fmt::{self, Display, Formatter};
 
 use serde::{Deserialize, Serialize};
 
-use crate::error::SimardResult;
+use crate::error::{SimardError, SimardResult};
 use crate::memory_bridge::CognitiveMemoryBridge;
 use crate::session::SessionPhase;
 
@@ -175,12 +175,23 @@ pub fn poll_progress(
 ) -> SimardResult<Option<SubordinateProgress>> {
     let facts = bridge.search_facts(&sub_tag(sub_id), 10, 0.0)?;
 
-    let progress = facts
+    let fact = facts
         .into_iter()
-        .rfind(|f| f.concept == PROGRESS_CONCEPT && f.tags.contains(&sub_tag(sub_id)))
-        .and_then(|f| serde_json::from_str::<SubordinateProgress>(&f.content).ok());
+        .rfind(|f| f.concept == PROGRESS_CONCEPT && f.tags.contains(&sub_tag(sub_id)));
 
-    Ok(progress)
+    match fact {
+        None => Ok(None),
+        Some(f) => {
+            let progress =
+                serde_json::from_str::<SubordinateProgress>(&f.content).map_err(|e| {
+                    SimardError::InvalidGoalRecord {
+                        field: format!("progress:{sub_id}"),
+                        reason: format!("failed to deserialize subordinate progress: {e}"),
+                    }
+                })?;
+            Ok(Some(progress))
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,6 +35,10 @@ pub enum SimardError {
         field: String,
         reason: String,
     },
+    InvalidResearchRecord {
+        field: String,
+        reason: String,
+    },
     InvalidMeetingRecord {
         field: String,
         reason: String,
@@ -211,6 +215,9 @@ impl Display for SimardError {
             }
             Self::InvalidGoalRecord { field, reason } => {
                 write!(f, "invalid goal record field '{field}': {reason}")
+            }
+            Self::InvalidResearchRecord { field, reason } => {
+                write!(f, "invalid research record field '{field}': {reason}")
             }
             Self::InvalidMeetingRecord { field, reason } => {
                 write!(f, "invalid meeting record field '{field}': {reason}")

--- a/src/goal_curation.rs
+++ b/src/goal_curation.rs
@@ -154,9 +154,13 @@ fn validate_backlog_item(item: &BacklogItem) -> SimardResult<()> {
 /// snapshot stored as a semantic fact and falls back to an empty board.
 pub fn load_goal_board(bridge: &CognitiveMemoryBridge) -> SimardResult<GoalBoard> {
     let facts = bridge.search_facts("goal-board:snapshot", 1, 0.0)?;
-    if let Some(fact) = facts.first()
-        && let Ok(board) = serde_json::from_str::<GoalBoard>(&fact.content)
-    {
+    if let Some(fact) = facts.first() {
+        let board = serde_json::from_str::<GoalBoard>(&fact.content).map_err(|e| {
+            SimardError::InvalidGoalRecord {
+                field: "board".to_string(),
+                reason: format!("failed to deserialize goal board: {e}"),
+            }
+        })?;
         return Ok(board);
     }
     Ok(GoalBoard::new())

--- a/src/identity_auth.rs
+++ b/src/identity_auth.rs
@@ -86,11 +86,13 @@ fn required_field(field: &str, value: String) -> SimardResult<String> {
 }
 
 fn validate_email(email: &str) -> SimardResult<()> {
-    if !email.contains('@') {
+    let parts: Vec<&str> = email.splitn(2, '@').collect();
+    if parts.len() != 2 || parts[0].is_empty() || parts[1].is_empty() || !parts[1].contains('.') {
         return Err(SimardError::InvalidConfigValue {
             key: "commit_email".to_string(),
             value: email.to_string(),
-            help: "commit_email must contain '@'".to_string(),
+            help: "commit_email must have a non-empty local part, '@', and a domain with a '.'"
+                .to_string(),
         });
     }
     Ok(())

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -33,10 +33,15 @@ impl TempFileGuard {
         &self.path
     }
 
-    fn file_mut(&mut self) -> &mut File {
+    fn file_mut(&mut self) -> SimardResult<&mut File> {
         self.file
             .as_mut()
-            .expect("temporary persistence file should stay open until rename")
+            .ok_or_else(|| SimardError::PersistentStoreIo {
+                store: String::new(),
+                action: "write".to_string(),
+                path: self.path.clone(),
+                reason: "temporary persistence file was already closed".to_string(),
+            })
     }
 
     fn close(&mut self) {
@@ -112,7 +117,7 @@ where
         })?;
     let mut temp_file = TempFileGuard::new(store, path)?;
     temp_file
-        .file_mut()
+        .file_mut()?
         .write_all(&payload)
         .map_err(|error| SimardError::PersistentStoreIo {
             store: store.to_string(),
@@ -121,7 +126,7 @@ where
             reason: error.to_string(),
         })?;
     temp_file
-        .file_mut()
+        .file_mut()?
         .sync_all()
         .map_err(|error| SimardError::PersistentStoreIo {
             store: store.to_string(),
@@ -278,6 +283,7 @@ mod tests {
                 TempFileGuard::new("memory", &store_path).expect("temp file guard should open");
             temp_file
                 .file_mut()
+                .expect("temp file should still be open")
                 .write_all(br#"["pending"]"#)
                 .expect("temporary payload should be writable");
             let temp_path = temp_file.path().to_path_buf();

--- a/src/remote_azlin.rs
+++ b/src/remote_azlin.rs
@@ -118,11 +118,33 @@ pub fn azlin_create(
     let mut args = vec!["create", name];
     let region_flag;
     if let Some(ref region) = config.region {
+        if !region
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        {
+            return Err(SimardError::InvalidConfigValue {
+                key: "region".to_string(),
+                value: region.to_string(),
+                help: "region must contain only alphanumeric characters, hyphens, and underscores"
+                    .to_string(),
+            });
+        }
         region_flag = format!("--region={region}");
         args.push(&region_flag);
     }
     let size_flag;
     if let Some(ref size) = config.size {
+        if !size
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        {
+            return Err(SimardError::InvalidConfigValue {
+                key: "size".to_string(),
+                value: size.to_string(),
+                help: "size must contain only alphanumeric characters, hyphens, and underscores"
+                    .to_string(),
+            });
+        }
         size_flag = format!("--size={size}");
         args.push(&size_flag);
     }

--- a/src/research_tracker.rs
+++ b/src/research_tracker.rs
@@ -103,7 +103,7 @@ impl ResearchTracker {
 
 fn required_field(field: &str, value: &str) -> SimardResult<()> {
     if value.trim().is_empty() {
-        return Err(SimardError::InvalidGoalRecord {
+        return Err(SimardError::InvalidResearchRecord {
             field: field.to_string(),
             reason: "value cannot be empty".to_string(),
         });
@@ -116,7 +116,7 @@ fn validate_topic(topic: &ResearchTopic) -> SimardResult<()> {
     required_field("research_topic.title", &topic.title)?;
     required_field("research_topic.source", &topic.source)?;
     if topic.priority == 0 {
-        return Err(SimardError::InvalidGoalRecord {
+        return Err(SimardError::InvalidResearchRecord {
             field: "research_topic.priority".to_string(),
             reason: "priority must be at least 1".to_string(),
         });
@@ -127,7 +127,7 @@ fn validate_topic(topic: &ResearchTopic) -> SimardResult<()> {
 fn validate_watch(watch: &DeveloperWatch) -> SimardResult<()> {
     required_field("developer_watch.github_id", &watch.github_id)?;
     if watch.focus_areas.is_empty() {
-        return Err(SimardError::InvalidGoalRecord {
+        return Err(SimardError::InvalidResearchRecord {
             field: "developer_watch.focus_areas".to_string(),
             reason: "at least one focus area is required".to_string(),
         });

--- a/src/self_relaunch.rs
+++ b/src/self_relaunch.rs
@@ -292,7 +292,14 @@ fn truncate_output(s: &str, max_len: usize) -> String {
     if s.len() <= max_len {
         s.trim().to_string()
     } else {
-        format!("{}...", &s[..max_len].trim())
+        // Use char-boundary-safe truncation to avoid panic on multi-byte UTF-8.
+        let boundary = s
+            .char_indices()
+            .take_while(|(i, _)| *i < max_len)
+            .last()
+            .map(|(i, c)| i + c.len_utf8())
+            .unwrap_or(0);
+        format!("{}...", s[..boundary].trim())
     }
 }
 


### PR DESCRIPTION
## Summary
- **self_relaunch.rs**: Fix `truncate_output` to use char-boundary-safe UTF-8 truncation (char_indices pattern) instead of `&s[..max_len]` which panics on multi-byte chars
- **goal_curation.rs**: `load_goal_board` now returns `SimardError` when a stored fact cannot be deserialized, instead of silently falling back to an empty board
- **remote_azlin.rs**: Validate `config.region` and `config.size` with the same alphanumeric+hyphen+underscore character-class check used for `vm_name`, preventing shell injection
- **agent_goal_assignment.rs**: `poll_progress` returns a deserialization error instead of silently swallowing corrupt progress data via `.ok()`
- **error.rs / research_tracker.rs**: Add `InvalidResearchRecord` error variant so research validation no longer misuses `InvalidGoalRecord`
- **identity_auth.rs**: Strengthen email validation to require non-empty local part, `@`, and a domain containing `.`
- **persistence.rs**: Replace production `expect()` in `file_mut()` with proper `SimardResult` error return
- **simard_gym_bridge.py**: `_extract_dimensions` now populates all 5 dimensions, marking unavailable ones as `None`

## Test plan
- [x] `cargo fmt` passes
- [x] `cargo clippy -- -D warnings` passes (zero warnings)
- [x] `cargo test --quiet` passes (all 139 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)