### PR TITLE
fix: remaining review findings — path traversal, dead field, env caching

### DIFF
--- a/python/simard_gym_bridge.py
+++ b/python/simard_gym_bridge.py
@@ -176,6 +176,8 @@ class GymBridgeServer(BridgeServer):
 
     def _handle_run_scenario(self, params: dict[str, Any]) -> dict[str, Any]:
         sid = params.get("scenario_id", "")
+        if any(bad in sid for bad in ("/", "\\", "..")):
+            return _fail_result(sid, f"scenario_id contains illegal path characters: '{sid}'")
         if sid == "long-horizon-memory":
             return self._run_long_horizon()
         if self._progressive is None:

--- a/src/identity_composition.rs
+++ b/src/identity_composition.rs
@@ -6,6 +6,7 @@
 //! assigned role and recursion depth limit.
 
 use std::fmt::{self, Display, Formatter};
+use std::sync::OnceLock;
 
 use crate::agent_roles::AgentRole;
 use crate::error::{SimardError, SimardResult};
@@ -14,6 +15,8 @@ use crate::identity::IdentityManifest;
 /// Maximum subordinate nesting depth from the environment, defaulting to 3.
 const ENV_MAX_DEPTH: &str = "SIMARD_MAX_SUBORDINATE_DEPTH";
 const DEFAULT_MAX_DEPTH: u32 = 3;
+/// Absolute upper bound for subordinate depth regardless of env config.
+const ABSOLUTE_MAX_DEPTH: u32 = 10;
 
 /// A subordinate's identity within a composition.
 ///
@@ -74,13 +77,19 @@ impl Display for CompositeIdentity {
 
 /// Read the maximum subordinate depth from the environment.
 ///
+/// The value is read once and cached for the lifetime of the process.
 /// Returns `SIMARD_MAX_SUBORDINATE_DEPTH` if set and valid, otherwise
-/// returns `DEFAULT_MAX_DEPTH` (3).
+/// returns `DEFAULT_MAX_DEPTH` (3). The result is always clamped to
+/// at most `ABSOLUTE_MAX_DEPTH` (10).
 pub fn max_subordinate_depth() -> u32 {
-    std::env::var(ENV_MAX_DEPTH)
-        .ok()
-        .and_then(|v| v.parse::<u32>().ok())
-        .unwrap_or(DEFAULT_MAX_DEPTH)
+    static CACHED: OnceLock<u32> = OnceLock::new();
+    *CACHED.get_or_init(|| {
+        std::env::var(ENV_MAX_DEPTH)
+            .ok()
+            .and_then(|v| v.parse::<u32>().ok())
+            .unwrap_or(DEFAULT_MAX_DEPTH)
+            .min(ABSOLUTE_MAX_DEPTH)
+    })
 }
 
 /// Compose a primary identity with a set of subordinate identities.

--- a/src/remote_azlin.rs
+++ b/src/remote_azlin.rs
@@ -19,8 +19,6 @@ pub struct AzlinConfig {
     pub region: Option<String>,
     /// VM size (e.g. "Standard_D4s_v3"). None uses azlin's default.
     pub size: Option<String>,
-    /// Optional SSH public key path. None uses azlin's default (~/.ssh/id_rsa.pub).
-    pub ssh_key_path: Option<String>,
 }
 
 /// Represents a VM managed by azlin.
@@ -275,7 +273,6 @@ mod tests {
         let config = AzlinConfig {
             region: Some("westus2".to_string()),
             size: Some("Standard_D4s_v3".to_string()),
-            ssh_key_path: None,
         };
         let vm = azlin_create("test-vm", &config, &executor).unwrap();
         assert_eq!(vm.status, "running");


### PR DESCRIPTION
Fix the last 3 review findings from #110 and #114:

1. **python/simard_gym_bridge.py**: Sanitize scenario_id against path traversal (reject /, \\, ..)
2. **src/remote_azlin.rs**: Remove unused ssh_key_path field
3. **src/identity_composition.rs**: Cache max_subordinate_depth with OnceLock, clamp to max 10

Resolves #110, resolves #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)