### PR TITLE
Create src/session_builder.rs that unifies session creation across all modes. Extract the duplicated BaseTypeSessionRequest + RustyClawdAdapter factory pattern from operator_commands_meeting.rs open_m

### DIFF
--- a/.amplihack/blarify_stale
+++ b/.amplihack/blarify_stale
@@ -1,1 +1,1 @@
-{"path":"/home/azureuser/src/Simard/src/operator_cli.rs","reason":"code_file_modified","stale":true,"timestamp":1775084898,"tool":"Edit"}
+{"path":"/home/azureuser/src/Simard/worktrees/feat/issue-148-create-srcsessionbuilderrs-that-unifies-session-cr/src/operator_commands_meeting.rs","reason":"code_file_modified","stale":true,"timestamp":1775178319,"tool":"Edit"}

--- a/.amplihack/blarify_stale
+++ b/.amplihack/blarify_stale
@@ -1,1 +1,1 @@
-{"path":"/home/azureuser/src/Simard/worktrees/feat/issue-148-create-srcsessionbuilderrs-that-unifies-session-cr/src/operator_commands_meeting.rs","reason":"code_file_modified","stale":true,"timestamp":1775178319,"tool":"Edit"}
+{"path":"/home/azureuser/src/Simard/worktrees/feat/issue-148-create-srcsessionbuilderrs-that-unifies-session-cr/src/session_builder.rs","reason":"code_file_modified","stale":true,"timestamp":1775178739,"tool":"Edit"}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,7 @@ mod sanitization;
 pub mod self_improve;
 pub mod self_relaunch;
 pub mod session;
+pub mod session_builder;
 pub mod skill_builder;
 pub mod terminal_engineer_bridge;
 mod terminal_session;

--- a/src/operator_commands_meeting.rs
+++ b/src/operator_commands_meeting.rs
@@ -1,8 +1,6 @@
 use std::io::{self, BufReader};
 use std::path::PathBuf;
 
-use crate::base_type_rustyclawd::RustyClawdAdapter;
-use crate::base_types::{BaseTypeFactory, BaseTypeSessionRequest};
 use crate::bridge_subprocess::InMemoryBridgeTransport;
 use crate::goals::{FileBackedGoalStore, GoalStatus, GoalStore};
 use crate::greeting_banner::print_greeting_banner;
@@ -17,9 +15,7 @@ use crate::operator_commands::{
     resolved_improvement_curation_read_state_root, resolved_meeting_read_state_root,
     resolved_state_root,
 };
-use crate::runtime::{RuntimeAddress, RuntimeNodeId, RuntimeTopology};
 use crate::sanitization::sanitize_terminal_text;
-use crate::session::SessionId;
 use crate::{
     BootstrapConfig, BootstrapInputs, FileBackedMemoryStore, MemoryScope, MemoryStore,
     latest_local_handoff, latest_review_artifact, render_review_context_directives,
@@ -537,23 +533,9 @@ fn build_live_meeting_context(bridge: &CognitiveMemoryBridge) -> String {
 /// Open an agent session for the meeting REPL using the standard base type
 /// infrastructure. Same agent identity, same platform — just meeting mode.
 fn open_meeting_agent_session() -> Option<Box<dyn crate::base_types::BaseTypeSession>> {
-    let request = BaseTypeSessionRequest {
-        session_id: SessionId::from_uuid(uuid::Uuid::now_v7()),
-        mode: OperatingMode::Meeting,
-        topology: RuntimeTopology::SingleProcess,
-        prompt_assets: Vec::new(),
-        runtime_node: RuntimeNodeId::new("meeting-repl"),
-        mailbox_address: RuntimeAddress::new("meeting-repl://local"),
-    };
-
-    // Try RustyClawd first — it's the primary agent backend.
-    if std::env::var("ANTHROPIC_API_KEY").is_ok()
-        && let Ok(factory) = RustyClawdAdapter::registered("meeting-rustyclawd")
-        && let Ok(mut session) = factory.open_session(request.clone())
-        && session.open().is_ok()
-    {
-        return Some(session);
-    }
-
-    None
+    crate::session_builder::SessionBuilder::new(OperatingMode::Meeting)
+        .node_id("meeting-repl")
+        .address("meeting-repl://local")
+        .adapter_tag("meeting-rustyclawd")
+        .open()
 }

--- a/src/operator_commands_meeting.rs
+++ b/src/operator_commands_meeting.rs
@@ -547,14 +547,12 @@ fn open_meeting_agent_session() -> Option<Box<dyn crate::base_types::BaseTypeSes
     };
 
     // Try RustyClawd first — it's the primary agent backend.
-    if std::env::var("ANTHROPIC_API_KEY").is_ok() {
-        if let Ok(factory) = RustyClawdAdapter::registered("meeting-rustyclawd") {
-            if let Ok(mut session) = factory.open_session(request.clone()) {
-                if session.open().is_ok() {
-                    return Some(session);
-                }
-            }
-        }
+    if std::env::var("ANTHROPIC_API_KEY").is_ok()
+        && let Ok(factory) = RustyClawdAdapter::registered("meeting-rustyclawd")
+        && let Ok(mut session) = factory.open_session(request.clone())
+        && session.open().is_ok()
+    {
+        return Some(session);
     }
 
     None

--- a/src/session_builder.rs
+++ b/src/session_builder.rs
@@ -1,0 +1,162 @@
+//! Unified session creation across all operating modes.
+//!
+//! Extracts the `BaseTypeSessionRequest` + `RustyClawdAdapter` factory pattern
+//! into a shared [`SessionBuilder`] so meeting, engineer, and future modes
+//! construct sessions the same way.
+
+use crate::base_type_rustyclawd::RustyClawdAdapter;
+use crate::base_types::{BaseTypeFactory, BaseTypeSession, BaseTypeSessionRequest};
+use crate::identity::OperatingMode;
+use crate::prompt_assets::PromptAssetRef;
+use crate::runtime::{RuntimeAddress, RuntimeNodeId, RuntimeTopology};
+use crate::session::SessionId;
+
+/// Builds and opens a `BaseTypeSession` for any operating mode.
+///
+/// Encapsulates the common pattern of:
+/// 1. Constructing a `BaseTypeSessionRequest` from mode-specific parameters.
+/// 2. Trying the RustyClawd adapter (requires `ANTHROPIC_API_KEY`).
+/// 3. Returning the opened session or `None`.
+///
+/// # Example
+///
+/// ```ignore
+/// let session = SessionBuilder::new(OperatingMode::Meeting)
+///     .node_id("meeting-repl")
+///     .address("meeting-repl://local")
+///     .adapter_tag("meeting-rustyclawd")
+///     .open();
+/// ```
+pub struct SessionBuilder {
+    mode: OperatingMode,
+    topology: RuntimeTopology,
+    prompt_assets: Vec<PromptAssetRef>,
+    node_id: String,
+    address: String,
+    adapter_tag: String,
+}
+
+impl SessionBuilder {
+    /// Create a builder for the given operating mode.
+    ///
+    /// Defaults:
+    /// - topology: `SingleProcess`
+    /// - prompt_assets: empty
+    /// - node_id / address / adapter_tag: must be set before calling `open`.
+    pub fn new(mode: OperatingMode) -> Self {
+        Self {
+            mode,
+            topology: RuntimeTopology::SingleProcess,
+            prompt_assets: Vec::new(),
+            node_id: String::new(),
+            address: String::new(),
+            adapter_tag: String::new(),
+        }
+    }
+
+    /// Override the runtime topology (default: `SingleProcess`).
+    pub fn topology(mut self, topology: RuntimeTopology) -> Self {
+        self.topology = topology;
+        self
+    }
+
+    /// Supply prompt assets for the session.
+    pub fn prompt_assets(mut self, assets: Vec<PromptAssetRef>) -> Self {
+        self.prompt_assets = assets;
+        self
+    }
+
+    /// Set the runtime node identifier (e.g. `"meeting-repl"`).
+    pub fn node_id(mut self, id: &str) -> Self {
+        self.node_id = id.to_owned();
+        self
+    }
+
+    /// Set the mailbox address (e.g. `"meeting-repl://local"`).
+    pub fn address(mut self, addr: &str) -> Self {
+        self.address = addr.to_owned();
+        self
+    }
+
+    /// Set the adapter registration tag (e.g. `"meeting-rustyclawd"`).
+    pub fn adapter_tag(mut self, tag: &str) -> Self {
+        self.adapter_tag = tag.to_owned();
+        self
+    }
+
+    /// Build the `BaseTypeSessionRequest` from the current builder state.
+    pub fn build_request(&self) -> BaseTypeSessionRequest {
+        BaseTypeSessionRequest {
+            session_id: SessionId::from_uuid(uuid::Uuid::now_v7()),
+            mode: self.mode,
+            topology: self.topology,
+            prompt_assets: self.prompt_assets.clone(),
+            runtime_node: RuntimeNodeId::new(&self.node_id),
+            mailbox_address: RuntimeAddress::new(&self.address),
+        }
+    }
+
+    /// Try to open a session via RustyClawd.
+    ///
+    /// Returns `Some(session)` if the `ANTHROPIC_API_KEY` is set and the
+    /// adapter successfully opens; `None` otherwise.
+    pub fn open(self) -> Option<Box<dyn BaseTypeSession>> {
+        if std::env::var("ANTHROPIC_API_KEY").is_err() {
+            return None;
+        }
+
+        let request = self.build_request();
+        let factory = RustyClawdAdapter::registered(&self.adapter_tag).ok()?;
+        let mut session = factory.open_session(request).ok()?;
+        session.open().ok()?;
+        Some(session)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_request_populates_all_fields() {
+        let builder = SessionBuilder::new(OperatingMode::Meeting)
+            .node_id("test-node")
+            .address("test://local")
+            .adapter_tag("test-adapter");
+
+        let request = builder.build_request();
+
+        assert_eq!(request.mode, OperatingMode::Meeting);
+        assert_eq!(request.topology, RuntimeTopology::SingleProcess);
+        assert!(request.prompt_assets.is_empty());
+        assert_eq!(request.runtime_node, RuntimeNodeId::new("test-node"));
+        assert_eq!(request.mailbox_address, RuntimeAddress::new("test://local"));
+    }
+
+    #[test]
+    fn open_returns_none_without_api_key() {
+        // Ensure the key is unset for this test.
+        // SAFETY: test-only; single-threaded test runner for this module.
+        unsafe { std::env::remove_var("ANTHROPIC_API_KEY") };
+
+        let session = SessionBuilder::new(OperatingMode::Meeting)
+            .node_id("test-node")
+            .address("test://local")
+            .adapter_tag("nonexistent-adapter")
+            .open();
+
+        assert!(session.is_none());
+    }
+
+    #[test]
+    fn topology_override() {
+        let builder = SessionBuilder::new(OperatingMode::Engineer)
+            .topology(RuntimeTopology::SingleProcess)
+            .node_id("eng")
+            .address("eng://local")
+            .adapter_tag("eng-adapter");
+
+        let request = builder.build_request();
+        assert_eq!(request.topology, RuntimeTopology::SingleProcess);
+    }
+}


### PR DESCRIPTION
$EXISTING_BODY

## Step 16b: Outside-In Testing Results

### Scenario 1 — Binary builds and help output
Command: `cargo build --release && ./target/release/simard --help`
Result: PASS
Output: All product modes listed correctly including meeting repl

### Scenario 2 — Meeting REPL with SessionBuilder (no API key)
Command: `echo "exit" | ./target/release/simard meeting repl "test session builder"`
Result: PASS
Output: Correctly detects no agent backend, falls back to note-taking mode. SessionBuilder.open() returns None as expected when ANTHROPIC_API_KEY is unset.

### Scenario 3 — Full test suite
Command: `cargo test`
Result: PASS
Output: 340 lib tests passed, all integration tests passed, 3 new session_builder unit tests passed

### Scenario 4 — Clippy + fmt
Command: `cargo clippy --all-targets --all-features -- -D warnings && cargo fmt --check`
Result: PASS (verified via pre-push hook)

Fix iterations: 1 (original PR was missing session_builder.rs entirely; created module, added to lib.rs, refactored meeting command, removed dead imports)