### PR TITLE
FIX: Kuzu DB path inconsistency causes RuntimeError. Three files reference the cognitive memory database path differently. src/bridge_launcher.rs line 168 has cognitive_memory (no extension). src/oper

### DIFF
--- a/.amplihack/blarify_stale
+++ b/.amplihack/blarify_stale
@@ -1,1 +1,1 @@
-{"path":"/home/azureuser/src/Simard/worktrees/feat/issue-161-the-ooda-daemon-must-run-without-any-timeout-check/tests/meeting_handoff.rs","reason":"code_file_modified","stale":true,"timestamp":1775207453,"tool":"Edit"}
+{"path":"/home/azureuser/src/Simard/worktrees/feat/issue-165-fix-kuzu-db-path-inconsistency-causes-runtimeerror/src/bootstrap.rs","reason":"code_file_modified","stale":true,"timestamp":1775214945,"tool":"Edit"}

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -12,7 +12,7 @@ use crate::base_type_claude_agent_sdk::claude_agent_sdk_adapter;
 use crate::base_type_ms_agent::ms_agent_framework_adapter;
 use crate::base_type_rustyclawd::RustyClawdAdapter;
 use crate::base_types::BaseTypeId;
-use crate::bridge_launcher::{find_python_dir, launch_memory_bridge};
+use crate::bridge_launcher::{cognitive_memory_db_path, find_python_dir, launch_memory_bridge};
 use crate::error::{SimardError, SimardResult};
 use crate::evidence::{EvidenceStore, FileBackedEvidenceStore};
 use crate::goals::{FileBackedGoalStore, GoalStore};
@@ -386,7 +386,7 @@ impl BootstrapConfig {
 /// on-demand by subsystems that need them, avoiding unnecessary subprocess spawns.
 fn build_memory_store(config: &BootstrapConfig) -> SimardResult<Arc<dyn MemoryStore>> {
     let bridge = find_python_dir().ok().and_then(|python_dir| {
-        let db_path = config.state_root.value.join("cognitive_memory");
+        let db_path = cognitive_memory_db_path(&config.state_root.value);
         launch_memory_bridge(&config.identity, &db_path, &python_dir).ok()
     });
 

--- a/src/bridge_launcher.rs
+++ b/src/bridge_launcher.rs
@@ -18,6 +18,14 @@ use crate::memory_bridge::CognitiveMemoryBridge;
 
 const DEFAULT_BRIDGE_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Canonical filename for the Kuzu cognitive-memory database.
+const COGNITIVE_MEMORY_DB: &str = "cognitive_memory.kuzu";
+
+/// Return the canonical path to the Kuzu cognitive-memory database.
+pub fn cognitive_memory_db_path(state_root: &Path) -> PathBuf {
+    state_root.join(COGNITIVE_MEMORY_DB)
+}
+
 fn default_circuit_breaker() -> CircuitBreakerConfig {
     CircuitBreakerConfig {
         failure_threshold: 3,
@@ -165,7 +173,7 @@ pub fn launch_all_bridges(
         }
     };
 
-    let db_path = state_root.join("cognitive_memory");
+    let db_path = cognitive_memory_db_path(state_root);
     let memory = launch_memory_bridge(agent_name, &db_path, &python_dir).ok();
     let knowledge = launch_knowledge_bridge(&python_dir).ok();
     let gym = launch_gym_bridge(&python_dir).ok();

--- a/src/operator_commands_meeting.rs
+++ b/src/operator_commands_meeting.rs
@@ -1,7 +1,7 @@
 use std::io::{self, BufReader};
 use std::path::PathBuf;
 
-use crate::bridge_launcher::{find_python_dir, launch_memory_bridge};
+use crate::bridge_launcher::{cognitive_memory_db_path, find_python_dir, launch_memory_bridge};
 use crate::bridge_subprocess::InMemoryBridgeTransport;
 use crate::goals::{FileBackedGoalStore, GoalStatus, GoalStore};
 use crate::greeting_banner::print_greeting_banner;
@@ -360,7 +360,7 @@ fn launch_real_meeting_bridge() -> Option<CognitiveMemoryBridge> {
     let python_dir = find_python_dir().ok()?;
     let state_root = PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/target/simard-state"));
     let _ = std::fs::create_dir_all(&state_root);
-    let db_path = state_root.join("cognitive_memory.kuzu");
+    let db_path = cognitive_memory_db_path(&state_root);
     launch_memory_bridge("simard-meeting", &db_path, &python_dir).ok()
 }
 

--- a/src/operator_commands_ooda.rs
+++ b/src/operator_commands_ooda.rs
@@ -1,7 +1,8 @@
 use std::path::PathBuf;
 
 use crate::bridge_launcher::{
-    find_python_dir, launch_gym_bridge, launch_knowledge_bridge, launch_memory_bridge,
+    cognitive_memory_db_path, find_python_dir, launch_gym_bridge, launch_knowledge_bridge,
+    launch_memory_bridge,
 };
 use crate::goal_curation::load_goal_board;
 use crate::identity::OperatingMode;
@@ -34,7 +35,7 @@ pub fn run_ooda_daemon(
         std::env::var("SIMARD_AGENT_NAME").unwrap_or_else(|_| "simard-ooda".to_string());
 
     let python_dir = find_python_dir()?;
-    let db_path = state_root.join("cognitive_memory");
+    let db_path = cognitive_memory_db_path(&state_root);
 
     let memory = launch_memory_bridge(&agent_name, &db_path, &python_dir)?;
     let knowledge = launch_knowledge_bridge(&python_dir)?;


### PR DESCRIPTION


## Step 16b: Outside-In Testing Results

### Scenario 1 — Compilation check (cargo check)
Command: `cargo check` on PR branch
Result: PASS
Output: `Finished dev profile [unoptimized + debuginfo] target(s) in 0.21s`

### Scenario 2 — Full test suite (cargo test)
Command: `cargo test` on PR branch
Result: PASS
Output: `test result: ok. 0 passed; 0 failed; 70 ignored; 0 measured; 0 filtered out`
All 70 integration tests ignored (require external services); 0 failures. Doc-tests also pass.

### Scenario 3 — Grep audit for stale path references
Command: `rg "cognitive_memory[^_]" src/`
Result: PASS
Output: Only reference is the canonical constant `COGNITIVE_MEMORY_DB = "cognitive_memory.kuzu"` in `bridge_launcher.rs`. All three call sites use the centralized `cognitive_memory_db_path()` function.

Fix iterations: 0