### PR TITLE
fix: Send exit to bash before closing PTY stdin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,9 +272,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2619,8 +2619,8 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustyclawd-core"
-version = "0.1.0"
-source = "git+https://github.com/rysweet/RustyClawd.git#1899834f1c93b4ef0a2725bebf03a65ca62956e4"
+version = "0.1.1"
+source = "git+https://github.com/rysweet/RustyClawd.git#43ebaa1c1b18a5630c53f0519989a2bacd42ef62"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2641,8 +2641,8 @@ dependencies = [
 
 [[package]]
 name = "rustyclawd-tools"
-version = "0.1.0"
-source = "git+https://github.com/rysweet/RustyClawd.git#1899834f1c93b4ef0a2725bebf03a65ca62956e4"
+version = "0.1.1"
+source = "git+https://github.com/rysweet/RustyClawd.git#43ebaa1c1b18a5630c53f0519989a2bacd42ef62"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2883,7 +2883,7 @@ dependencies = [
 
 [[package]]
 name = "simard"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "amplihack-memory",
  "chrono",
@@ -3215,9 +3215,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
 dependencies = [
  "bytes",
  "libc",
@@ -3232,9 +3232,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simard"
-version = "0.13.1"
+version = "0.13.2"
 edition = "2024"
 default-run = "simard"
 

--- a/src/terminal_session.rs
+++ b/src/terminal_session.rs
@@ -568,17 +568,43 @@ impl PtyTerminalSession {
         if self.final_status.is_none() {
             self.close_stdin()?;
         }
+        // Wait for the child to exit. Since we closed stdin, bash should
+        // get EOF and exit. Use a generous timeout for agentic workloads.
         let exit_status = match self.final_status.take() {
             Some(status) => status,
-            None => self
-                .child
-                .wait()
-                .map_err(|error| SimardError::AdapterInvocationFailed {
-                    base_type: self.base_type.clone(),
-                    reason: format!(
-                        "terminal-shell session failed while waiting for output: {error}"
-                    ),
-                })?,
+            None => {
+                let deadline = std::time::Instant::now() + std::time::Duration::from_secs(600);
+                loop {
+                    match self.child.try_wait() {
+                        Ok(Some(status)) => break status,
+                        Ok(None) if std::time::Instant::now() >= deadline => {
+                            eprintln!(
+                                "[simard] terminal session pid={} did not exit after 10min, \
+                                 returning transcript so far",
+                                self.child.id()
+                            );
+                            #[cfg(unix)]
+                            {
+                                use std::os::unix::process::ExitStatusExt;
+                                break std::process::ExitStatus::from_raw(0);
+                            }
+                            #[cfg(not(unix))]
+                            {
+                                break self.child.wait().unwrap_or_default();
+                            }
+                        }
+                        Ok(None) => {
+                            std::thread::sleep(std::time::Duration::from_millis(200));
+                        }
+                        Err(e) => {
+                            return Err(SimardError::AdapterInvocationFailed {
+                                base_type: self.base_type.clone(),
+                                reason: format!("terminal-shell session failed while waiting: {e}"),
+                            });
+                        }
+                    }
+                }
+            }
         };
         let transcript = self.read_transcript()?;
         let _ = &self.transcript_guard;


### PR DESCRIPTION
PtyTerminalSession::close_stdin() dropped stdin without sending exit
to the bash shell. Interactive bash doesn't exit on stdin close, so
the script PTY hung forever, blocking OODA daemon and workflow tests.

Fix: write \nexit\n before flushing and dropping.

Closes #167