### PR TITLE
feat: Strengthen cognitive memory read persistence with bridge fallback + retry

### DIFF
--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -393,6 +393,9 @@ fn build_memory_store(config: &BootstrapConfig) -> SimardResult<Arc<dyn MemorySt
     if let Some(bridge) = bridge {
         eprintln!("[simard] cognitive memory bridge active — using Kuzu backend");
         let store = CognitiveBridgeMemoryStore::new(bridge, config.memory_store_path())?;
+        // Pull cross-session records from the cognitive bridge to supplement
+        // local fallback hydration — recovers data written by other processes.
+        store.hydrate_from_bridge();
         Ok(Arc::new(store))
     } else {
         eprintln!("[simard] cognitive memory bridge unavailable — using JSON file backend");

--- a/src/memory_bridge_adapter.rs
+++ b/src/memory_bridge_adapter.rs
@@ -15,10 +15,17 @@ use std::sync::Mutex;
 use crate::error::{SimardError, SimardResult};
 use crate::memory::{FileBackedMemoryStore, MemoryRecord, MemoryScope, MemoryStore};
 use crate::memory_bridge::CognitiveMemoryBridge;
+use crate::memory_cognitive::CognitiveFact;
 use crate::metadata::{BackendDescriptor, Freshness};
-use crate::session::SessionId;
+use crate::session::{SessionId, SessionPhase};
 
 const STORE_NAME: &str = "cognitive-bridge-memory";
+
+/// Maximum retries for bridge read operations.
+const BRIDGE_READ_MAX_RETRIES: usize = 1;
+
+/// Backoff between bridge retries in milliseconds.
+const BRIDGE_RETRY_BACKOFF_MS: u64 = 200;
 
 /// Tag prefix used to encode scope in cognitive memory tags.
 fn scope_tag(scope: MemoryScope) -> String {
@@ -28,6 +35,46 @@ fn scope_tag(scope: MemoryScope) -> String {
 /// Tag prefix used to encode session ID in cognitive memory tags.
 fn session_tag(session_id: &SessionId) -> String {
     format!("session:{}", session_id.as_str())
+}
+
+/// Parse a scope from a tag string like "scope:Decision".
+fn parse_scope_tag(tag: &str) -> Option<MemoryScope> {
+    let suffix = tag.strip_prefix("scope:")?;
+    match suffix {
+        "SessionScratch" => Some(MemoryScope::SessionScratch),
+        "SessionSummary" => Some(MemoryScope::SessionSummary),
+        "Decision" => Some(MemoryScope::Decision),
+        "Project" => Some(MemoryScope::Project),
+        "Benchmark" => Some(MemoryScope::Benchmark),
+        _ => None,
+    }
+}
+
+/// Parse a session ID from a tag string like "session:<uuid>".
+fn parse_session_tag(tag: &str) -> Option<SessionId> {
+    let suffix = tag.strip_prefix("session:")?;
+    uuid::Uuid::parse_str(suffix).ok().map(SessionId::from_uuid)
+}
+
+/// Convert a `CognitiveFact` back to a `MemoryRecord` by parsing encoded tags.
+fn fact_to_record(fact: &CognitiveFact) -> MemoryRecord {
+    let scope = fact
+        .tags
+        .iter()
+        .find_map(|t| parse_scope_tag(t))
+        .unwrap_or(MemoryScope::Project);
+    let session_id = fact
+        .tags
+        .iter()
+        .find_map(|t| parse_session_tag(t))
+        .unwrap_or_else(|| SessionId::from_uuid(uuid::Uuid::nil()));
+    MemoryRecord {
+        key: fact.concept.clone(),
+        scope,
+        value: fact.content.clone(),
+        session_id,
+        recorded_in: SessionPhase::Execution,
+    }
 }
 
 /// `MemoryStore` implementation backed by cognitive memory via Python bridge.
@@ -111,6 +158,101 @@ impl CognitiveBridgeMemoryStore {
         }
     }
 
+    /// Pull facts from the cognitive bridge (Python subprocess) and merge into
+    /// the local in-memory index. This supplements fallback hydration by
+    /// recovering records that were persisted to the graph but not yet in the
+    /// local JSON file (e.g., written by another Simard process).
+    ///
+    /// Uses retry logic: if the bridge returns an error, retry once with
+    /// backoff before giving up (Pillar 11: honest degradation).
+    pub fn hydrate_from_bridge(&self) {
+        let facts = self.search_facts_with_retry("memory-store-adapter", 500, 0.0);
+        let facts = match facts {
+            Ok(f) => f,
+            Err(e) => {
+                eprintln!("[simard] cognitive-bridge: bridge hydration failed: {e}");
+                return;
+            }
+        };
+        if facts.is_empty() {
+            return;
+        }
+        let mut hydrated = 0usize;
+        if let Ok(mut map) = self.records.lock() {
+            for fact in &facts {
+                let record = fact_to_record(fact);
+                // Only insert if not already present — local data is fresher.
+                if !map.contains_key(&record.key) {
+                    map.insert(record.key.clone(), record);
+                    hydrated += 1;
+                }
+            }
+        }
+        if hydrated > 0 {
+            eprintln!("[simard] cognitive-bridge: hydrated {hydrated} records from bridge");
+        }
+    }
+
+    /// Search facts via the cognitive bridge with retry logic.
+    fn search_facts_with_retry(
+        &self,
+        query: &str,
+        limit: u32,
+        min_confidence: f64,
+    ) -> SimardResult<Vec<CognitiveFact>> {
+        let mut last_err = None;
+        for attempt in 0..=BRIDGE_READ_MAX_RETRIES {
+            match self.bridge.search_facts(query, limit, min_confidence) {
+                Ok(facts) => return Ok(facts),
+                Err(e) => {
+                    if attempt < BRIDGE_READ_MAX_RETRIES {
+                        eprintln!(
+                            "[simard] cognitive-bridge: search_facts retry {}/{} after error: {e}",
+                            attempt + 1,
+                            BRIDGE_READ_MAX_RETRIES
+                        );
+                        std::thread::sleep(std::time::Duration::from_millis(
+                            BRIDGE_RETRY_BACKOFF_MS,
+                        ));
+                    }
+                    last_err = Some(e);
+                }
+            }
+        }
+        Err(last_err.unwrap())
+    }
+
+    /// Query the bridge for records matching a scope, converting facts back to
+    /// `MemoryRecord`s. Used as fallback when the local index has no results.
+    fn bridge_fallback_list(&self, scope: MemoryScope) -> Vec<MemoryRecord> {
+        let query = format!("scope:{scope:?}");
+        match self.search_facts_with_retry(&query, 200, 0.0) {
+            Ok(facts) => {
+                let records: Vec<MemoryRecord> = facts
+                    .iter()
+                    .map(fact_to_record)
+                    .filter(|r| r.scope == scope)
+                    .collect();
+                // Merge into local index for future reads.
+                if !records.is_empty()
+                    && let Ok(mut map) = self.records.lock()
+                {
+                    for record in &records {
+                        map.entry(record.key.clone())
+                            .or_insert_with(|| record.clone());
+                    }
+                }
+                records
+            }
+            Err(e) => {
+                eprintln!(
+                    "[simard] cognitive-bridge: bridge fallback for scope {scope:?} failed: {e}"
+                );
+                Vec::new()
+            }
+        }
+    }
+
     /// Store a record in cognitive memory as a semantic fact.
     fn store_as_fact(&self, record: &MemoryRecord) -> SimardResult<String> {
         let tags = vec![
@@ -159,11 +301,18 @@ impl MemoryStore for CognitiveBridgeMemoryStore {
             .map_err(|_| SimardError::StoragePoisoned {
                 store: STORE_NAME.to_string(),
             })?;
-        Ok(records
+        let local: Vec<MemoryRecord> = records
             .values()
             .filter(|r| r.scope == scope)
             .cloned()
-            .collect())
+            .collect();
+        if !local.is_empty() {
+            return Ok(local);
+        }
+        // Local miss — try bridge fallback to recover cross-session data.
+        drop(records); // release lock before bridge call
+        let bridged = self.bridge_fallback_list(scope);
+        Ok(bridged)
     }
 
     fn list_for_session(&self, session_id: &SessionId) -> SimardResult<Vec<MemoryRecord>> {
@@ -450,5 +599,251 @@ mod tests {
         );
 
         let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn local_read_hits_without_bridge() {
+        // When local index has records, list() returns them without calling bridge.
+        let store = test_store();
+        store
+            .put(make_record("local-hit", MemoryScope::Decision))
+            .unwrap();
+
+        let results = store.list(MemoryScope::Decision).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].key, "local-hit");
+    }
+
+    #[test]
+    fn local_miss_triggers_bridge_fallback() {
+        // When local index is empty for a scope, list() queries the bridge.
+        let sid = Uuid::nil();
+        let transport =
+            InMemoryBridgeTransport::new("test-fallback", move |method, _params| match method {
+                "memory.store_fact" => Ok(json!({"id": "sem_fallback"})),
+                "memory.search_facts" => Ok(json!({
+                    "facts": [{
+                        "node_id": "n1",
+                        "concept": "bridge-fact",
+                        "content": "from-bridge",
+                        "confidence": 1.0,
+                        "source_id": "test",
+                        "tags": [
+                            format!("scope:Decision"),
+                            format!("session:{sid}")
+                        ]
+                    }]
+                })),
+                _ => Err(crate::bridge::BridgeErrorPayload {
+                    code: -32601,
+                    message: format!("unknown method: {method}"),
+                }),
+            });
+        let bridge = CognitiveMemoryBridge::new(Box::new(transport));
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("fallback-test-{unique}.json"));
+        let store = CognitiveBridgeMemoryStore::new(bridge, path.clone()).unwrap();
+
+        // No local records in Decision scope — should fall back to bridge.
+        let results = store.list(MemoryScope::Decision).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].key, "bridge-fact");
+        assert_eq!(results[0].value, "from-bridge");
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn bridge_timeout_triggers_retry() {
+        // Bridge fails on first call, succeeds on second.
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let cc = call_count.clone();
+        let transport = InMemoryBridgeTransport::new("test-retry", move |method, _params| {
+            match method {
+                "memory.store_fact" => Ok(json!({"id": "sem_retry"})),
+                "memory.search_facts" => {
+                    let count = cc.fetch_add(1, Ordering::SeqCst);
+                    if count == 0 {
+                        // First call fails.
+                        Err(crate::bridge::BridgeErrorPayload {
+                            code: -32000,
+                            message: "timeout".to_string(),
+                        })
+                    } else {
+                        // Retry succeeds.
+                        Ok(json!({"facts": [{
+                            "node_id": "n2",
+                            "concept": "retried-fact",
+                            "content": "after-retry",
+                            "confidence": 1.0,
+                            "source_id": "test",
+                            "tags": ["scope:Project", "session:00000000-0000-0000-0000-000000000000"]
+                        }]}))
+                    }
+                }
+                _ => Err(crate::bridge::BridgeErrorPayload {
+                    code: -32601,
+                    message: format!("unknown method: {method}"),
+                }),
+            }
+        });
+        let bridge = CognitiveMemoryBridge::new(Box::new(transport));
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("retry-test-{unique}.json"));
+        let store = CognitiveBridgeMemoryStore::new(bridge, path.clone()).unwrap();
+
+        // list() for empty scope should trigger bridge fallback with retry.
+        let results = store.list(MemoryScope::Project).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].key, "retried-fact");
+        // Two calls should have been made (initial + 1 retry).
+        assert_eq!(call_count.load(Ordering::SeqCst), 2);
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn write_through_updates_local_cache() {
+        // After put(), the record should be immediately visible via list()
+        // without needing a bridge call.
+        let store = test_store();
+
+        assert!(store.list(MemoryScope::Benchmark).unwrap().is_empty());
+        store
+            .put(make_record("cached", MemoryScope::Benchmark))
+            .unwrap();
+        let results = store.list(MemoryScope::Benchmark).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].key, "cached");
+    }
+
+    #[test]
+    fn hydrate_from_bridge_merges_new_records() {
+        let transport =
+            InMemoryBridgeTransport::new("test-bridge-hydrate", |method, _params| match method {
+                "memory.store_fact" => Ok(json!({"id": "sem_bh"})),
+                "memory.search_facts" => Ok(json!({
+                    "facts": [{
+                        "node_id": "n3",
+                        "concept": "bridge-only",
+                        "content": "from-bridge-hydrate",
+                        "confidence": 1.0,
+                        "source_id": "memory-store-adapter",
+                        "tags": ["scope:Project", "session:00000000-0000-0000-0000-000000000000"]
+                    }]
+                })),
+                _ => Err(crate::bridge::BridgeErrorPayload {
+                    code: -32601,
+                    message: format!("unknown method: {method}"),
+                }),
+            });
+        let bridge = CognitiveMemoryBridge::new(Box::new(transport));
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("bridge-hydrate-{unique}.json"));
+        let store = CognitiveBridgeMemoryStore::new(bridge, path.clone()).unwrap();
+
+        // Before hydration — local index should be empty.
+        assert!(store.records.lock().unwrap().is_empty());
+
+        // Hydrate from bridge.
+        store.hydrate_from_bridge();
+
+        // Bridge record should now be in local index.
+        let records = store.records.lock().unwrap();
+        assert_eq!(records.len(), 1);
+        assert!(records.contains_key("bridge-only"));
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn hydrate_from_bridge_does_not_overwrite_local() {
+        let transport =
+            InMemoryBridgeTransport::new("test-no-overwrite", |method, _params| match method {
+                "memory.store_fact" => Ok(json!({"id": "sem_no"})),
+                "memory.search_facts" => Ok(json!({
+                    "facts": [{
+                        "node_id": "n4",
+                        "concept": "shared-key",
+                        "content": "bridge-version",
+                        "confidence": 1.0,
+                        "source_id": "memory-store-adapter",
+                        "tags": ["scope:Decision", "session:00000000-0000-0000-0000-000000000000"]
+                    }]
+                })),
+                _ => Err(crate::bridge::BridgeErrorPayload {
+                    code: -32601,
+                    message: format!("unknown method: {method}"),
+                }),
+            });
+        let bridge = CognitiveMemoryBridge::new(Box::new(transport));
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("no-overwrite-{unique}.json"));
+        let store = CognitiveBridgeMemoryStore::new(bridge, path.clone()).unwrap();
+
+        // Put a local record with the same key.
+        store
+            .put(make_record("shared-key", MemoryScope::Decision))
+            .unwrap();
+
+        // Hydrate — should NOT overwrite the local version.
+        store.hydrate_from_bridge();
+
+        let records = store.records.lock().unwrap();
+        let rec = records.get("shared-key").unwrap();
+        assert_eq!(
+            rec.value, "value-for-shared-key",
+            "local version should be preserved over bridge version"
+        );
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn fact_to_record_parses_tags_correctly() {
+        let fact = CognitiveFact {
+            node_id: "n1".to_string(),
+            concept: "test-concept".to_string(),
+            content: "test-content".to_string(),
+            confidence: 0.9,
+            source_id: "test".to_string(),
+            tags: vec![
+                "scope:Benchmark".to_string(),
+                "session:00000000-0000-0000-0000-000000000001".to_string(),
+            ],
+        };
+        let record = fact_to_record(&fact);
+        assert_eq!(record.key, "test-concept");
+        assert_eq!(record.value, "test-content");
+        assert_eq!(record.scope, MemoryScope::Benchmark);
+    }
+
+    #[test]
+    fn fact_to_record_defaults_on_missing_tags() {
+        let fact = CognitiveFact {
+            node_id: "n2".to_string(),
+            concept: "no-tags".to_string(),
+            content: "content".to_string(),
+            confidence: 0.5,
+            source_id: "test".to_string(),
+            tags: vec![],
+        };
+        let record = fact_to_record(&fact);
+        assert_eq!(record.scope, MemoryScope::Project); // default
     }
 }


### PR DESCRIPTION
## Summary

Strengthens the cognitive memory bridge adapter so cross-session reads work reliably. Adds bridge fallback, retry logic, and bootstrap hydration.

## Changes (src/memory_bridge_adapter.rs, +401 lines)

### Bridge Hydration
- `hydrate_from_bridge()`: Queries cognitive bridge via `search_facts` for records written by other Simard processes, merges into local index without overwriting fresher local data.
- Called during bootstrap (`src/bootstrap.rs`) right after `CognitiveBridgeMemoryStore` construction.

### Bridge Fallback on Read
- `list(scope)` now: local hit → return immediately. Local miss → query bridge via `bridge_fallback_list()`, merge results into local index, return.
- Ensures cross-session data persisted to the graph (but not yet in local JSON) is discoverable.

### Retry Logic
- `search_facts_with_retry()`: 1 retry with 200ms backoff on bridge errors (timeout, subprocess crash). Logged.

### Tag Round-Trip
- `fact_to_record()`: Converts `CognitiveFact` back to `MemoryRecord` by parsing scope/session tags.
- `parse_scope_tag()` / `parse_session_tag()`: Extract structured data from tag strings.
- Graceful defaults when tags are missing (scope → Project, session → nil UUID).

## Tests (8 new)

| Test | What it verifies |
|------|-----------------|
| `local_read_hits_without_bridge` | Local hit skips bridge |
| `local_miss_triggers_bridge_fallback` | Empty local triggers bridge query |
| `bridge_timeout_triggers_retry` | First fail → retry → success |
| `write_through_updates_local_cache` | `put()` makes record immediately readable |
| `hydrate_from_bridge_merges_new_records` | Bridge records appear in local index |
| `hydrate_from_bridge_does_not_overwrite_local` | Local data takes priority |
| `fact_to_record_parses_tags_correctly` | Tag → scope/session round-trip |
| `fact_to_record_defaults_on_missing_tags` | Graceful defaults |

## Verification

- 425 lib tests pass (up from 417), 0 failures
- Clippy clean with `-D warnings`
- Build clean, cargo fmt clean