### PR TITLE
test: add 102 tests to 5 zero-coverage modules (Phase 1)

### DIFF
--- a/docs/meetings/2026-04-04-self-reflection.md
+++ b/docs/meetings/2026-04-04-self-reflection.md
@@ -1,0 +1,83 @@
+# Simard Self-Reflection Meeting — 2026-04-04
+
+## Attendees
+- Simard (autonomous engineering agent, v0.13.2)
+- Operator (rysweet)
+
+## Meeting Purpose
+First self-evaluation meeting. Simard reflects on her own capabilities, identifies improvement areas, and creates an autonomous work plan.
+
+## Current State Assessment
+
+### Strengths (what's working)
+- **8 new architectural modules** merged this session (PRs #185-#195)
+- **553 lib tests**, all passing, clippy clean
+- **Well-integrated new modules**: engineer_plan → engineer_loop, review_pipeline → engineer_loop, gym_history → ooda_loop, runtime_reflection → runtime, runtime_ipc → runtime, identity_precedence → identity
+- **Strong coverage on new modules**: identity_precedence (100%), runtime_reflection (100%), gym_history (98.5%), gym_scoring (97.3%), identity_composition (97.5%), memory_consolidation (100%), knowledge_bridge (100%)
+
+### Critical Issues Found
+
+#### 1. Test Coverage: 39% (target: >70%)
+- **11 modules at 0% coverage** (1,841 coverable lines untested)
+- **Worst offenders**: operator_commands.rs (534 lines, 0%), operator_commands_meeting.rs (274, 0%), review.rs (175, 0%), terminal_engineer_bridge.rs (135, 0%), ooda_scheduler.rs (107, 0%)
+- **Large modules with low coverage**: engineer_loop.rs (11.4%), gym.rs (2.7%), bootstrap.rs (23.8%)
+
+#### 2. Module Size: 15 modules exceed 400-line limit
+- **engineer_loop.rs**: 1,967 impl lines (nearly 5x limit!)
+- **gym.rs**: 1,459 impl lines
+- **operator_commands.rs**: 1,180 impl lines
+- **runtime.rs**: 1,077 impl lines
+- **copilot_task_submit.rs**: 1,022 impl lines
+- **improvements.rs**: 934 impl lines
+- **ooda_loop.rs**: 870 impl lines
+- **terminal_session.rs**: 842 impl lines
+
+#### 3. Code Quality
+- **97 functions exceed 50-line limit** — worst: select_engineer_action (321 lines!), verify_engineer_action (311), execute_scenario (271)
+- **5 unwrap() calls in non-test code** (cmd_self_update.rs, gym_history.rs, memory_bridge_adapter.rs)
+- **self_relaunch_semaphore.rs not wired into self_relaunch.rs** — the new module is exported but not integrated
+
+#### 4. Architectural Gaps
+- No tests for operator_commands* family (CLI interface completely untested)
+- review.rs has 0% coverage — the original review module predates review_pipeline.rs
+- ooda_scheduler.rs has 0% coverage — scheduling logic untested
+- terminal_engineer_bridge.rs has 0% coverage — critical integration point
+
+## Simard's Self-Assessment
+"I have strong foundations in my newest modules — the pm-architect backlog work was high quality with excellent test coverage. But my older core modules are bloated and undertested. My engineer_loop.rs is nearly 2,000 lines of implementation — that's unacceptable by my own PHILOSOPHY.md standards. I have 11 modules with zero test coverage, and my overall coverage is barely half of the 70% target.
+
+My most urgent need is not new features — it's refactoring my largest modules and adding tests to my untested ones. I need to practice what I preach about code quality."
+
+## Prioritized Improvement Plan
+
+### Phase 1: Coverage for Zero-Test Modules (highest impact)
+1. Add tests to `operator_commands.rs` (534 untested lines)
+2. Add tests to `review.rs` (175 untested lines)
+3. Add tests to `ooda_scheduler.rs` (107 untested lines)
+4. Add tests to `terminal_engineer_bridge.rs` (135 untested lines)
+5. Add tests to `operator_commands_meeting.rs` (274 untested lines)
+
+### Phase 2: Split Oversized Modules (architectural health)
+6. Split `engineer_loop.rs` (1,967 → ~5 modules of ≤400 lines)
+7. Split `gym.rs` (1,459 → ~4 modules)
+8. Split `operator_commands.rs` (1,180 → already partially split, finish it)
+9. Split `runtime.rs` (1,077 → ~3 modules)
+10. Split `copilot_task_submit.rs` (1,022 → ~3 modules)
+
+### Phase 3: Fix Code Quality Issues
+11. Refactor functions >50 lines (97 total, start with worst 10)
+12. Replace unwrap() calls with proper error handling (5 instances)
+13. Wire self_relaunch_semaphore.rs into self_relaunch.rs
+
+### Phase 4: Coverage Push to 70%
+14. Target remaining <70% modules with test additions
+15. Re-measure and iterate until >70% overall
+
+## Decisions
+- All PRs must pass merge-ready skill criteria before merging
+- Regular quality-audit skill runs between PRs
+- Module size limit: 400 lines impl (enforced)
+- Test coverage target: >70% overall, >50% per module minimum
+
+## Next Meeting
+After Phase 1 completion — review coverage progress.

--- a/src/ooda_scheduler.rs
+++ b/src/ooda_scheduler.rs
@@ -289,3 +289,232 @@ pub fn scheduler_summary(scheduler: &Scheduler) -> String {
         scheduler.max_concurrent
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ooda_loop::ActionKind;
+
+    fn make_action(goal_id: Option<&str>) -> PlannedAction {
+        PlannedAction {
+            kind: ActionKind::AdvanceGoal,
+            goal_id: goal_id.map(String::from),
+            description: "test action".to_string(),
+        }
+    }
+
+    fn make_outcome(success: bool) -> ActionOutcome {
+        ActionOutcome {
+            action: make_action(None),
+            success,
+            detail: "done".to_string(),
+        }
+    }
+
+    // 1. Scheduler::new sets max_concurrent, starts empty
+    #[test]
+    fn new_scheduler_is_empty() {
+        let s = Scheduler::new(4);
+        assert_eq!(s.max_concurrent, 4);
+        assert!(s.slots.is_empty());
+        assert_eq!(s.active_count(), 0);
+        assert!(s.has_capacity());
+    }
+
+    // 2. schedule_actions respects max_concurrent capacity
+    #[test]
+    fn schedule_actions_respects_capacity() {
+        let mut s = Scheduler::new(2);
+        let actions = vec![
+            make_action(Some("g1")),
+            make_action(Some("g2")),
+            make_action(Some("g3")),
+        ];
+        let scheduled = schedule_actions(&mut s, actions).unwrap();
+        assert_eq!(scheduled.len(), 2);
+        assert_eq!(s.slots.len(), 2);
+        assert_eq!(s.active_count(), 2);
+        assert!(!s.has_capacity());
+    }
+
+    // 3. schedule_actions assigns sequential slot IDs
+    #[test]
+    fn schedule_actions_assigns_sequential_ids() {
+        let mut s = Scheduler::new(10);
+        let batch1 = vec![make_action(None), make_action(None)];
+        let scheduled1 = schedule_actions(&mut s, batch1).unwrap();
+        assert_eq!(scheduled1[0].slot_id, 0);
+        assert_eq!(scheduled1[1].slot_id, 1);
+
+        let batch2 = vec![make_action(None)];
+        let scheduled2 = schedule_actions(&mut s, batch2).unwrap();
+        assert_eq!(scheduled2[0].slot_id, 2);
+    }
+
+    // 4a. start_slot transitions Pending → Running
+    #[test]
+    fn start_slot_pending_to_running() {
+        let mut s = Scheduler::new(2);
+        schedule_actions(&mut s, vec![make_action(Some("g1"))]).unwrap();
+        start_slot(&mut s, 0).unwrap();
+        assert!(matches!(s.slots[0].status, SlotStatus::Running { .. }));
+    }
+
+    // 4b. start_slot errors on missing slot
+    #[test]
+    fn start_slot_missing_slot_errors() {
+        let mut s = Scheduler::new(2);
+        let result = start_slot(&mut s, 99);
+        assert!(result.is_err());
+    }
+
+    // 4c. start_slot errors on non-pending (already running) slot
+    #[test]
+    fn start_slot_non_pending_errors() {
+        let mut s = Scheduler::new(2);
+        schedule_actions(&mut s, vec![make_action(None)]).unwrap();
+        start_slot(&mut s, 0).unwrap();
+        let result = start_slot(&mut s, 0);
+        assert!(result.is_err());
+    }
+
+    // 5a. complete_slot only works on Running slots
+    #[test]
+    fn complete_slot_on_running_succeeds() {
+        let mut s = Scheduler::new(2);
+        schedule_actions(&mut s, vec![make_action(None)]).unwrap();
+        start_slot(&mut s, 0).unwrap();
+        complete_slot(&mut s, 0, make_outcome(true)).unwrap();
+        assert!(matches!(s.slots[0].status, SlotStatus::Completed(_)));
+    }
+
+    #[test]
+    fn complete_slot_on_pending_errors() {
+        let mut s = Scheduler::new(2);
+        schedule_actions(&mut s, vec![make_action(None)]).unwrap();
+        assert!(complete_slot(&mut s, 0, make_outcome(true)).is_err());
+    }
+
+    #[test]
+    fn complete_slot_missing_slot_errors() {
+        let mut s = Scheduler::new(2);
+        assert!(complete_slot(&mut s, 42, make_outcome(true)).is_err());
+    }
+
+    // 5b. fail_slot only works on Running slots
+    #[test]
+    fn fail_slot_on_running_succeeds() {
+        let mut s = Scheduler::new(2);
+        schedule_actions(&mut s, vec![make_action(None)]).unwrap();
+        start_slot(&mut s, 0).unwrap();
+        fail_slot(&mut s, 0, "boom".to_string()).unwrap();
+        assert!(matches!(s.slots[0].status, SlotStatus::Failed(_)));
+    }
+
+    #[test]
+    fn fail_slot_on_pending_errors() {
+        let mut s = Scheduler::new(2);
+        schedule_actions(&mut s, vec![make_action(None)]).unwrap();
+        assert!(fail_slot(&mut s, 0, "nope".to_string()).is_err());
+    }
+
+    #[test]
+    fn fail_slot_missing_slot_errors() {
+        let mut s = Scheduler::new(2);
+        assert!(fail_slot(&mut s, 42, "nope".to_string()).is_err());
+    }
+
+    // 6. poll_slots returns completed/failed without removing
+    #[test]
+    fn poll_slots_returns_finished_without_removing() {
+        let mut s = Scheduler::new(4);
+        schedule_actions(
+            &mut s,
+            vec![
+                make_action(Some("a")),
+                make_action(Some("b")),
+                make_action(Some("c")),
+            ],
+        )
+        .unwrap();
+
+        start_slot(&mut s, 0).unwrap();
+        start_slot(&mut s, 1).unwrap();
+        complete_slot(&mut s, 0, make_outcome(true)).unwrap();
+        fail_slot(&mut s, 1, "err".to_string()).unwrap();
+
+        let polled = poll_slots(&mut s);
+        assert_eq!(polled.len(), 2);
+        assert!(polled[0].outcome.is_ok());
+        assert!(polled[1].outcome.is_err());
+        // Slots are still present
+        assert_eq!(s.slots.len(), 3);
+    }
+
+    // 7. drain_finished removes completed/failed slots
+    #[test]
+    fn drain_finished_removes_completed_and_failed() {
+        let mut s = Scheduler::new(4);
+        schedule_actions(
+            &mut s,
+            vec![
+                make_action(Some("a")),
+                make_action(Some("b")),
+                make_action(Some("c")),
+            ],
+        )
+        .unwrap();
+
+        start_slot(&mut s, 0).unwrap();
+        start_slot(&mut s, 1).unwrap();
+        complete_slot(&mut s, 0, make_outcome(true)).unwrap();
+        fail_slot(&mut s, 1, "err".to_string()).unwrap();
+
+        let drained = drain_finished(&mut s);
+        assert_eq!(drained.len(), 2);
+        // Only the pending slot remains
+        assert_eq!(s.slots.len(), 1);
+        assert!(matches!(s.slots[0].status, SlotStatus::Pending));
+    }
+
+    // 8. scheduler_summary contains slot counts
+    #[test]
+    fn scheduler_summary_contains_counts() {
+        let mut s = Scheduler::new(4);
+        schedule_actions(&mut s, vec![make_action(None), make_action(None)]).unwrap();
+        start_slot(&mut s, 0).unwrap();
+
+        let summary = scheduler_summary(&s);
+        assert!(summary.contains("1 pending"));
+        assert!(summary.contains("1 running"));
+        assert!(summary.contains("0 completed"));
+        assert!(summary.contains("0 failed"));
+        assert!(summary.contains("max=4"));
+    }
+
+    // 9. has_capacity returns false when at limit
+    #[test]
+    fn has_capacity_false_at_limit() {
+        let mut s = Scheduler::new(1);
+        assert!(s.has_capacity());
+        schedule_actions(&mut s, vec![make_action(None)]).unwrap();
+        assert!(!s.has_capacity());
+    }
+
+    // Extra: goal_id defaults to empty string when None
+    #[test]
+    fn goal_id_defaults_to_empty_when_none() {
+        let mut s = Scheduler::new(2);
+        let scheduled = schedule_actions(&mut s, vec![make_action(None)]).unwrap();
+        assert_eq!(scheduled[0].goal_id, "");
+        assert_eq!(s.slots[0].goal_id, "");
+    }
+
+    // Extra: drain on empty scheduler returns nothing
+    #[test]
+    fn drain_empty_scheduler() {
+        let mut s = Scheduler::new(2);
+        let drained = drain_finished(&mut s);
+        assert!(drained.is_empty());
+    }
+}

--- a/src/operator_commands.rs
+++ b/src/operator_commands.rs
@@ -1178,3 +1178,369 @@ pub(crate) fn print_terminal_recipe(recipe_name: &str, recipe: &PromptAsset) {
         println!("{line}");
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::goals::{GoalRecord, GoalStatus};
+    use crate::session::{SessionId, SessionPhase};
+
+    fn s(value: &str) -> String {
+        value.to_string()
+    }
+
+    fn args(values: &[&str]) -> Vec<String> {
+        values.iter().map(|v| s(v)).collect()
+    }
+
+    fn make_evidence(detail: &str) -> crate::EvidenceRecord {
+        crate::EvidenceRecord {
+            id: s("ev-1"),
+            session_id: SessionId::parse("00000000-0000-0000-0000-000000000001").unwrap(),
+            phase: SessionPhase::Execution,
+            detail: s(detail),
+            source: crate::evidence::EvidenceSource::Runtime,
+        }
+    }
+
+    fn make_goal(title: &str, status: GoalStatus, priority: u8) -> GoalRecord {
+        GoalRecord {
+            slug: title.to_lowercase().replace(' ', "-"),
+            title: s(title),
+            rationale: s("test rationale"),
+            status,
+            priority,
+            owner_identity: s("test-identity"),
+            source_session_id: SessionId::parse("00000000-0000-0000-0000-000000000001").unwrap(),
+            updated_in: SessionPhase::Execution,
+        }
+    }
+
+    // --- gym_usage ---
+
+    #[test]
+    fn gym_usage_contains_expected_subcommands() {
+        let usage = gym_usage();
+        assert!(usage.contains("list"), "should mention 'list'");
+        assert!(usage.contains("run"), "should mention 'run'");
+        assert!(usage.contains("compare"), "should mention 'compare'");
+        assert!(usage.contains("run-suite"), "should mention 'run-suite'");
+        assert!(usage.contains("simard-gym"), "should mention binary name");
+    }
+
+    // --- parse_runtime_topology ---
+
+    #[test]
+    fn parse_runtime_topology_single_process() {
+        assert_eq!(
+            parse_runtime_topology("single-process").unwrap(),
+            RuntimeTopology::SingleProcess
+        );
+    }
+
+    #[test]
+    fn parse_runtime_topology_multi_process() {
+        assert_eq!(
+            parse_runtime_topology("multi-process").unwrap(),
+            RuntimeTopology::MultiProcess
+        );
+    }
+
+    #[test]
+    fn parse_runtime_topology_distributed() {
+        assert_eq!(
+            parse_runtime_topology("distributed").unwrap(),
+            RuntimeTopology::Distributed
+        );
+    }
+
+    #[test]
+    fn parse_runtime_topology_invalid_value() {
+        let err = parse_runtime_topology("bogus").unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("SIMARD_RUNTIME_TOPOLOGY"),
+            "error should reference the config key"
+        );
+        assert!(
+            msg.contains("single-process"),
+            "error should list valid values"
+        );
+    }
+
+    // --- next_required / next_optional_path / reject_extra_args ---
+
+    #[test]
+    fn next_required_returns_value_when_present() {
+        let mut iter = args(&["hello"]).into_iter();
+        assert_eq!(next_required(&mut iter, "greeting").unwrap(), "hello");
+    }
+
+    #[test]
+    fn next_required_errors_when_empty() {
+        let mut iter = std::iter::empty::<String>();
+        let err = next_required(&mut iter, "widget").unwrap_err();
+        assert!(err.to_string().contains("expected widget"));
+    }
+
+    #[test]
+    fn next_optional_path_returns_some() {
+        let mut iter = args(&["/a/b"]).into_iter();
+        assert_eq!(next_optional_path(&mut iter), Some(PathBuf::from("/a/b")));
+    }
+
+    #[test]
+    fn next_optional_path_returns_none_when_empty() {
+        let mut iter = std::iter::empty::<String>();
+        assert_eq!(next_optional_path(&mut iter), None);
+    }
+
+    #[test]
+    fn reject_extra_args_ok_when_empty() {
+        reject_extra_args(std::iter::empty::<String>()).unwrap();
+    }
+
+    #[test]
+    fn reject_extra_args_errors_on_trailing() {
+        let err = reject_extra_args(args(&["extra1", "extra2"]).into_iter()).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("extra1"));
+        assert!(msg.contains("extra2"));
+    }
+
+    // --- artifact_name ---
+
+    #[test]
+    fn artifact_name_extracts_file_name() {
+        assert_eq!(artifact_name(Path::new("/foo/bar/baz.json")), "baz.json");
+    }
+
+    #[test]
+    fn artifact_name_returns_fallback_for_root() {
+        assert_eq!(artifact_name(Path::new("/")), "file");
+    }
+
+    // --- terminal_recipe_reference ---
+
+    #[test]
+    fn terminal_recipe_reference_valid_name() {
+        let reference = terminal_recipe_reference("my-recipe-1").unwrap();
+        assert_eq!(
+            reference.id,
+            crate::prompt_assets::PromptAssetId::new("terminal-recipe:my-recipe-1")
+        );
+        assert_eq!(
+            reference.relative_path,
+            PathBuf::from("simard/terminal_recipes/my-recipe-1.simard-terminal")
+        );
+    }
+
+    #[test]
+    fn terminal_recipe_reference_rejects_empty() {
+        assert!(terminal_recipe_reference("").is_err());
+    }
+
+    #[test]
+    fn terminal_recipe_reference_rejects_uppercase() {
+        assert!(terminal_recipe_reference("MyRecipe").is_err());
+    }
+
+    #[test]
+    fn terminal_recipe_reference_rejects_spaces() {
+        assert!(terminal_recipe_reference("my recipe").is_err());
+    }
+
+    // --- dispatch_operator_probe: argument validation ---
+
+    #[test]
+    fn dispatch_operator_probe_no_command() {
+        let err = dispatch_operator_probe(std::iter::empty::<String>()).unwrap_err();
+        assert!(err.to_string().contains("expected a probe command"));
+    }
+
+    #[test]
+    fn dispatch_operator_probe_unknown_command() {
+        let err = dispatch_operator_probe(args(&["nonexistent"])).unwrap_err();
+        assert!(err.to_string().contains("unsupported probe command"));
+        assert!(err.to_string().contains("nonexistent"));
+    }
+
+    #[test]
+    fn dispatch_operator_probe_missing_required_args() {
+        // bootstrap-run needs identity, base type, topology, objective
+        let err = dispatch_operator_probe(args(&["bootstrap-run"])).unwrap_err();
+        assert!(err.to_string().contains("expected identity"));
+    }
+
+    // --- dispatch_legacy_gym_cli: argument validation ---
+
+    #[test]
+    fn dispatch_legacy_gym_cli_no_command() {
+        let err = dispatch_legacy_gym_cli(std::iter::empty::<String>()).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("simard-gym"), "should show usage on no args");
+    }
+
+    #[test]
+    fn dispatch_legacy_gym_cli_unknown_command() {
+        let err = dispatch_legacy_gym_cli(args(&["bogus"])).unwrap_err();
+        assert!(err.to_string().contains("simard-gym"));
+    }
+
+    #[test]
+    fn dispatch_legacy_gym_cli_run_missing_scenario_id() {
+        let err = dispatch_legacy_gym_cli(args(&["run"])).unwrap_err();
+        assert!(err.to_string().contains("expected scenario id"));
+    }
+
+    // --- terminal evidence helpers ---
+
+    #[test]
+    fn required_terminal_evidence_value_found() {
+        let records = vec![
+            make_evidence("terminal-cwd=/home/user"),
+            make_evidence("terminal-exit-code=0"),
+        ];
+        let val = required_terminal_evidence_value(&records, "terminal-exit-code=", "test-handoff")
+            .unwrap();
+        assert_eq!(val, "0");
+    }
+
+    #[test]
+    fn required_terminal_evidence_value_not_found() {
+        let records = vec![make_evidence("terminal-cwd=/home/user")];
+        let err = required_terminal_evidence_value(&records, "terminal-exit-code=", "test-handoff")
+            .unwrap_err();
+        assert!(err.to_string().contains("terminal-exit-code"));
+    }
+
+    #[test]
+    fn required_terminal_evidence_value_returns_last_match() {
+        let records = vec![
+            make_evidence("terminal-exit-code=1"),
+            make_evidence("terminal-exit-code=0"),
+        ];
+        let val = required_terminal_evidence_value(&records, "terminal-exit-code=", "test-handoff")
+            .unwrap();
+        assert_eq!(val, "0", "should return last (most recent) match");
+    }
+
+    #[test]
+    fn optional_terminal_evidence_value_found() {
+        let records = vec![make_evidence("terminal-cwd=/workspace")];
+        assert_eq!(
+            optional_terminal_evidence_value(&records, "terminal-cwd="),
+            Some("/workspace")
+        );
+    }
+
+    #[test]
+    fn optional_terminal_evidence_value_missing() {
+        let records = vec![make_evidence("other-key=value")];
+        assert_eq!(
+            optional_terminal_evidence_value(&records, "terminal-cwd="),
+            None
+        );
+    }
+
+    #[test]
+    fn terminal_evidence_values_collects_indexed_entries() {
+        let records = vec![
+            make_evidence("checkpoint1=first"),
+            make_evidence("checkpoint2=second"),
+            make_evidence("unrelated=skip"),
+        ];
+        let values = terminal_evidence_values(&records, "checkpoint");
+        assert_eq!(values, vec!["first", "second"]);
+    }
+
+    #[test]
+    fn terminal_evidence_values_empty_when_no_match() {
+        let records = vec![make_evidence("other=value")];
+        let values = terminal_evidence_values(&records, "checkpoint");
+        assert!(values.is_empty());
+    }
+
+    // --- GoalRegisterView::from_records ---
+
+    #[test]
+    fn goal_register_view_partitions_by_status() {
+        let records = vec![
+            make_goal("Alpha", GoalStatus::Active, 1),
+            make_goal("Beta", GoalStatus::Proposed, 2),
+            make_goal("Gamma", GoalStatus::Paused, 3),
+            make_goal("Delta", GoalStatus::Completed, 1),
+            make_goal("Epsilon", GoalStatus::Active, 2),
+        ];
+        let view = GoalRegisterView::from_records(records);
+
+        assert_eq!(view.sections[0].goals.len(), 2, "Active");
+        assert_eq!(view.sections[1].goals.len(), 1, "Proposed");
+        assert_eq!(view.sections[2].goals.len(), 1, "Paused");
+        assert_eq!(view.sections[3].goals.len(), 1, "Completed");
+
+        // Active section should be sorted by priority
+        assert_eq!(view.sections[0].goals[0].title, "Alpha");
+        assert_eq!(view.sections[0].goals[1].title, "Epsilon");
+    }
+
+    #[test]
+    fn goal_register_view_empty_input() {
+        let view = GoalRegisterView::from_records(vec![]);
+        for section in &view.sections {
+            assert!(section.goals.is_empty());
+        }
+    }
+
+    // --- prompt_root ---
+
+    #[test]
+    fn prompt_root_ends_with_prompt_assets() {
+        let root = prompt_root();
+        assert!(
+            root.ends_with("prompt_assets"),
+            "prompt_root should end with 'prompt_assets', got: {}",
+            root.display()
+        );
+    }
+
+    // --- state_root path construction ---
+
+    #[test]
+    fn state_root_builds_expected_path() {
+        let base_type = BaseTypeId::new("my-type");
+        let path = state_root(
+            "my-id",
+            &base_type,
+            RuntimeTopology::SingleProcess,
+            "probe-x",
+        );
+        let path_str = path.to_string_lossy();
+        assert!(path_str.contains("target/operator-probe-state"));
+        assert!(path_str.contains("probe-x"));
+        assert!(path_str.contains("my-id"));
+        assert!(path_str.contains("my-type"));
+        assert!(path_str.contains("single-process"));
+    }
+
+    // --- render_redacted_objective_metadata ---
+
+    #[test]
+    fn render_redacted_objective_metadata_valid() {
+        let result =
+            render_redacted_objective_metadata("objective-metadata(chars=10, words=2, lines=1)");
+        assert!(result.is_ok());
+        let rendered = result.unwrap();
+        assert!(rendered.contains("chars=10"));
+        assert!(rendered.contains("words=2"));
+        assert!(rendered.contains("lines=1"));
+    }
+
+    #[test]
+    fn render_redacted_objective_metadata_invalid() {
+        let result = render_redacted_objective_metadata("not a valid metadata string");
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("objective"));
+    }
+}

--- a/src/operator_commands_meeting.rs
+++ b/src/operator_commands_meeting.rs
@@ -565,3 +565,188 @@ fn open_meeting_agent_session() -> Option<Box<dyn crate::base_types::BaseTypeSes
         .adapter_tag("meeting-rustyclawd")
         .open()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// Create a `CognitiveMemoryBridge` backed by an in-memory stub that
+    /// returns empty results for all `search_facts` queries.
+    fn empty_bridge() -> CognitiveMemoryBridge {
+        let transport =
+            InMemoryBridgeTransport::new("test-empty", |method, _params| match method {
+                "memory.search_facts" => Ok(serde_json::json!({"facts": []})),
+                "memory.get_statistics" => Ok(serde_json::json!({
+                    "sensory_count": 0, "working_count": 0, "episodic_count": 0,
+                    "semantic_count": 0, "procedural_count": 0, "prospective_count": 0
+                })),
+                _ => Err(crate::bridge::BridgeErrorPayload {
+                    code: -32601,
+                    message: format!("unknown method: {method}"),
+                }),
+            });
+        CognitiveMemoryBridge::new(Box::new(transport))
+    }
+
+    /// Create a bridge that returns a single meeting fact for `"meeting:"`
+    /// queries and empty results for everything else.
+    fn bridge_with_meeting_facts() -> CognitiveMemoryBridge {
+        let transport = InMemoryBridgeTransport::new("test-facts", |method, params| match method {
+            "memory.search_facts" => {
+                let query = params["query"].as_str().unwrap_or("");
+                if query.starts_with("meeting:") {
+                    Ok(serde_json::json!({
+                        "facts": [{
+                            "node_id": "f1",
+                            "concept": "weekly-sync",
+                            "content": "Discussed deployment timeline",
+                            "confidence": 0.9,
+                            "source_id": "s1",
+                            "tags": []
+                        }]
+                    }))
+                } else {
+                    Ok(serde_json::json!({"facts": []}))
+                }
+            }
+            _ => Err(crate::bridge::BridgeErrorPayload {
+                code: -32601,
+                message: format!("unknown method: {method}"),
+            }),
+        });
+        CognitiveMemoryBridge::new(Box::new(transport))
+    }
+
+    // ── build_live_meeting_context ──────────────────────────────────────
+
+    #[test]
+    fn build_live_meeting_context_defaults_with_empty_bridge() {
+        let bridge = empty_bridge();
+        let ctx = build_live_meeting_context(&bridge);
+
+        assert!(
+            ctx.starts_with("## Live State (from cognitive memory)"),
+            "expected live-state header, got: {ctx}"
+        );
+        assert!(
+            ctx.contains("## Operator Context"),
+            "expected default operator section"
+        );
+        assert!(ctx.contains("Ryan Sweet"), "expected default operator name");
+        assert!(
+            ctx.contains("## Known Projects"),
+            "expected default projects section"
+        );
+        assert!(
+            ctx.contains("Simard"),
+            "expected Simard in default projects"
+        );
+    }
+
+    #[test]
+    fn build_live_meeting_context_includes_bridge_meeting_facts() {
+        let bridge = bridge_with_meeting_facts();
+        let ctx = build_live_meeting_context(&bridge);
+
+        assert!(
+            ctx.contains("Previous Meeting Summaries"),
+            "expected meeting summaries section"
+        );
+        assert!(
+            ctx.contains("Discussed deployment timeline"),
+            "expected meeting content from bridge"
+        );
+    }
+
+    // ── load_meeting_system_prompt ──────────────────────────────────────
+
+    #[test]
+    fn load_meeting_system_prompt_does_not_panic() {
+        // Uses unwrap_or_default internally so must never panic even when
+        // the prompt asset file is absent (e.g. in CI).
+        let _prompt = load_meeting_system_prompt();
+    }
+
+    // ── run_meeting_read_probe error paths ─────────────────────────────
+
+    #[test]
+    fn meeting_read_probe_rejects_nonexistent_state_root() {
+        let dir = TempDir::new().unwrap();
+        let missing = dir.path().join("does-not-exist");
+        let result = run_meeting_read_probe("local-harness", "single-process", Some(missing));
+        assert!(result.is_err(), "expected error for nonexistent state root");
+    }
+
+    #[test]
+    fn meeting_read_probe_rejects_missing_memory_file() {
+        let dir = TempDir::new().unwrap();
+        let result = run_meeting_read_probe(
+            "local-harness",
+            "single-process",
+            Some(dir.path().to_path_buf()),
+        );
+        assert!(
+            result.is_err(),
+            "expected error when memory_records.json is absent"
+        );
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("memory_records.json"),
+            "error should mention the missing file: {msg}"
+        );
+    }
+
+    #[test]
+    fn meeting_read_probe_rejects_empty_meeting_store() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("memory_records.json"), "[]").unwrap();
+        let result = run_meeting_read_probe(
+            "local-harness",
+            "single-process",
+            Some(dir.path().to_path_buf()),
+        );
+        assert!(
+            result.is_err(),
+            "expected error when no meeting records exist"
+        );
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("expected persisted meeting decision record"),
+            "error should explain the missing record: {msg}"
+        );
+    }
+
+    // ── run_goal_curation_read_probe ───────────────────────────────────
+
+    #[test]
+    fn goal_curation_read_probe_succeeds_with_empty_state() {
+        let dir = TempDir::new().unwrap();
+        let result = run_goal_curation_read_probe(
+            "local-harness",
+            "single-process",
+            Some(dir.path().to_path_buf()),
+        );
+        assert!(
+            result.is_ok(),
+            "expected success with empty state: {:?}",
+            result.err()
+        );
+    }
+
+    // ── run_improvement_curation_read_probe ─────────────────────────────
+
+    #[test]
+    fn improvement_curation_read_probe_rejects_incomplete_state() {
+        let dir = TempDir::new().unwrap();
+        let result = run_improvement_curation_read_probe(
+            "local-harness",
+            "single-process",
+            Some(dir.path().to_path_buf()),
+        );
+        assert!(
+            result.is_err(),
+            "expected error when review artifacts are missing"
+        );
+    }
+}

--- a/src/review.rs
+++ b/src/review.rs
@@ -399,3 +399,315 @@ fn now_unix_ms() -> SimardResult<u128> {
         })?
         .as_millis())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base_types::BaseTypeId;
+    use crate::evidence::{EvidenceRecord, EvidenceSource};
+    use crate::identity::OperatingMode;
+    use crate::memory::{MemoryRecord, MemoryScope};
+    use crate::runtime::{RuntimeAddress, RuntimeNodeId, RuntimeState, RuntimeTopology};
+    use crate::session::{SessionId, SessionPhase, SessionRecord};
+    use tempfile::TempDir;
+
+    fn make_session_id() -> SessionId {
+        SessionId::parse("session-00000000-0000-0000-0000-000000000001").unwrap()
+    }
+
+    fn make_session_record() -> SessionRecord {
+        SessionRecord {
+            id: make_session_id(),
+            mode: OperatingMode::Engineer,
+            objective: "test objective".to_string(),
+            phase: SessionPhase::Complete,
+            selected_base_type: BaseTypeId::new("test-base"),
+            evidence_ids: vec![],
+            memory_keys: vec![],
+        }
+    }
+
+    fn make_handoff() -> RuntimeHandoffSnapshot {
+        let node = RuntimeNodeId::new("test-node");
+        RuntimeHandoffSnapshot {
+            exported_state: RuntimeState::Active,
+            identity_name: "test-identity".to_string(),
+            selected_base_type: BaseTypeId::new("test-base"),
+            topology: RuntimeTopology::SingleProcess,
+            source_runtime_node: node.clone(),
+            source_mailbox_address: RuntimeAddress::local(&node),
+            session: Some(make_session_record()),
+            memory_records: vec![],
+            evidence_records: vec![],
+            copilot_submit_audit: None,
+        }
+    }
+
+    fn make_handoff_with_records() -> RuntimeHandoffSnapshot {
+        let sid = make_session_id();
+        let mut handoff = make_handoff();
+        handoff.memory_records = vec![
+            MemoryRecord {
+                key: "decision-1".to_string(),
+                scope: MemoryScope::Decision,
+                value: "decided something".to_string(),
+                session_id: sid.clone(),
+                recorded_in: SessionPhase::Execution,
+            },
+            MemoryRecord {
+                key: "bench-1".to_string(),
+                scope: MemoryScope::Benchmark,
+                value: "benchmark data".to_string(),
+                session_id: sid.clone(),
+                recorded_in: SessionPhase::Execution,
+            },
+            MemoryRecord {
+                key: "scratch-1".to_string(),
+                scope: MemoryScope::SessionScratch,
+                value: "scratch".to_string(),
+                session_id: sid.clone(),
+                recorded_in: SessionPhase::Execution,
+            },
+        ];
+        handoff.evidence_records = vec![
+            EvidenceRecord {
+                id: "ev-1".to_string(),
+                session_id: sid.clone(),
+                phase: SessionPhase::Execution,
+                detail: "first evidence".to_string(),
+                source: EvidenceSource::Runtime,
+            },
+            EvidenceRecord {
+                id: "ev-2".to_string(),
+                session_id: sid.clone(),
+                phase: SessionPhase::Execution,
+                detail: "second evidence".to_string(),
+                source: EvidenceSource::Runtime,
+            },
+        ];
+        handoff
+    }
+
+    fn make_request() -> ReviewRequest {
+        ReviewRequest {
+            target_kind: ReviewTargetKind::Session,
+            target_label: "test-session".to_string(),
+            execution_summary: "Executed successfully".to_string(),
+            reflection_summary: "Reflection on the session with enough detail to pass \
+                the length check for the improvement proposal threshold"
+                .to_string(),
+            measurement_notes: vec!["latency=100ms".to_string()],
+            signals: vec![
+                ReviewSignal {
+                    id: "signal-pass".to_string(),
+                    passed: true,
+                    detail: "all good".to_string(),
+                },
+                ReviewSignal {
+                    id: "signal-fail".to_string(),
+                    passed: false,
+                    detail: "something went wrong".to_string(),
+                },
+            ],
+        }
+    }
+
+    fn make_artifact_direct(review_id: &str, timestamp: u128) -> ReviewArtifact {
+        ReviewArtifact {
+            review_id: review_id.to_string(),
+            reviewed_at_unix_ms: timestamp,
+            target_kind: ReviewTargetKind::Session,
+            target_label: "label".to_string(),
+            identity_name: "id".to_string(),
+            session_id: "s1".to_string(),
+            selected_base_type: "base".to_string(),
+            topology: "single".to_string(),
+            objective_metadata: "obj".to_string(),
+            execution_summary: "exec".to_string(),
+            reflection_summary: "refl".to_string(),
+            summary: "summary".to_string(),
+            measurement_notes: vec![],
+            evidence_summary: ReviewEvidenceSummary {
+                memory_records: 0,
+                evidence_records: 0,
+                decision_records: 0,
+                benchmark_records: 0,
+                exported_state: "active".to_string(),
+                session_phase: None,
+                failed_signals: vec![],
+            },
+            proposals: vec![],
+        }
+    }
+
+    // 1. review_artifacts_dir returns correct path
+    #[test]
+    fn review_artifacts_dir_appends_subdir() {
+        let root = PathBuf::from("/state/root");
+        assert_eq!(review_artifacts_dir(&root), root.join("review-artifacts"));
+    }
+
+    // 2. build_review_artifact with mixed signals extracts failed ones correctly
+    #[test]
+    fn build_artifact_extracts_failed_signals() {
+        let artifact = build_review_artifact(make_request(), &make_handoff()).unwrap();
+        let failed = &artifact.evidence_summary.failed_signals;
+        assert_eq!(failed.len(), 1);
+        assert!(failed[0].contains("signal-fail"));
+        assert!(failed[0].contains("something went wrong"));
+    }
+
+    #[test]
+    fn build_artifact_counts_memory_scopes() {
+        let handoff = make_handoff_with_records();
+        let artifact = build_review_artifact(make_request(), &handoff).unwrap();
+        assert_eq!(artifact.evidence_summary.memory_records, 3);
+        assert_eq!(artifact.evidence_summary.evidence_records, 2);
+        assert_eq!(artifact.evidence_summary.decision_records, 1);
+        assert_eq!(artifact.evidence_summary.benchmark_records, 1);
+    }
+
+    // 3. build_review_artifact generates a review_id and sets reviewed_at_unix_ms
+    #[test]
+    fn build_artifact_sets_id_and_timestamp() {
+        let before = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis();
+        let artifact = build_review_artifact(make_request(), &make_handoff()).unwrap();
+        let after = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis();
+
+        assert!(!artifact.review_id.is_empty());
+        assert!(artifact.review_id.contains("review"));
+        assert!(artifact.reviewed_at_unix_ms >= before);
+        assert!(artifact.reviewed_at_unix_ms <= after);
+    }
+
+    #[test]
+    fn build_artifact_fails_without_session() {
+        let mut handoff = make_handoff();
+        handoff.session = None;
+        let result = build_review_artifact(make_request(), &handoff);
+        assert!(result.is_err());
+    }
+
+    // 4. concise_record contains target label and signal counts
+    #[test]
+    fn concise_record_includes_target_and_counts() {
+        let artifact = build_review_artifact(make_request(), &make_handoff()).unwrap();
+        let record = artifact.concise_record();
+        assert!(record.contains("test-session"), "missing target label");
+        assert!(
+            record.contains("failed_signals=1"),
+            "missing failed signal count"
+        );
+        assert!(
+            record.contains("evidence_records=0"),
+            "missing evidence count"
+        );
+    }
+
+    #[test]
+    fn concise_record_includes_proposal_text() {
+        let artifact = build_review_artifact(make_request(), &make_handoff()).unwrap();
+        let record = artifact.concise_record();
+        assert!(record.contains("proposals=["), "missing proposals bracket");
+        // The artifact should have at least one proposal
+        assert!(!artifact.proposals.is_empty());
+        assert!(
+            record.contains(&artifact.proposals[0].title),
+            "missing first proposal title"
+        );
+    }
+
+    // 5. render_review_text contains header, proposals section, measurement notes
+    #[test]
+    fn render_review_text_has_sections() {
+        let artifact = build_review_artifact(make_request(), &make_handoff()).unwrap();
+        let text = render_review_text(&artifact);
+        assert!(text.contains("Review:"), "missing Review header");
+        assert!(text.contains("Target: test-session"), "missing target");
+        assert!(text.contains("Identity: test-identity"), "missing identity");
+        assert!(text.contains("Proposals:"), "missing Proposals section");
+        assert!(
+            text.contains("Measurement notes:"),
+            "missing Measurement notes section"
+        );
+        assert!(text.contains("latency=100ms"), "missing measurement note");
+    }
+
+    #[test]
+    fn render_review_text_shows_target_kind() {
+        let artifact = build_review_artifact(make_request(), &make_handoff()).unwrap();
+        let text = render_review_text(&artifact);
+        assert!(text.contains("Target kind: session"), "missing target kind");
+    }
+
+    // 6. persist + load roundtrip
+    #[test]
+    fn persist_and_load_roundtrip() {
+        let dir = TempDir::new().unwrap();
+        let artifact = build_review_artifact(make_request(), &make_handoff()).unwrap();
+
+        let path = persist_review_artifact(dir.path(), &artifact).unwrap();
+        assert!(path.exists());
+        assert!(path.extension().unwrap() == "json");
+
+        let loaded = load_review_artifact(&path).unwrap();
+        assert_eq!(artifact, loaded);
+    }
+
+    // 7. latest_review_artifact returns None on empty dir, newest when multiple exist
+    #[test]
+    fn latest_review_artifact_none_when_no_dir() {
+        let dir = TempDir::new().unwrap();
+        let result = latest_review_artifact(dir.path()).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn latest_review_artifact_none_when_dir_empty() {
+        let dir = TempDir::new().unwrap();
+        fs::create_dir_all(review_artifacts_dir(dir.path())).unwrap();
+        let result = latest_review_artifact(dir.path()).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn latest_review_artifact_returns_newest() {
+        let dir = TempDir::new().unwrap();
+        let older = make_artifact_direct("older-review", 1000);
+        let newer = make_artifact_direct("newer-review", 2000);
+
+        persist_review_artifact(dir.path(), &older).unwrap();
+        persist_review_artifact(dir.path(), &newer).unwrap();
+
+        let (path, latest) = latest_review_artifact(dir.path()).unwrap().unwrap();
+        assert_eq!(latest.review_id, "newer-review");
+        assert_eq!(latest.reviewed_at_unix_ms, 2000);
+        assert!(path.to_string_lossy().contains("newer-review"));
+    }
+
+    // 8. ReviewTargetKind as_str shows "session" / "benchmark"
+    #[test]
+    fn target_kind_as_str_values() {
+        assert_eq!(ReviewTargetKind::Session.as_str(), "session");
+        assert_eq!(ReviewTargetKind::Benchmark.as_str(), "benchmark");
+    }
+
+    #[test]
+    fn target_kind_serde_roundtrip() {
+        let session_json = serde_json::to_string(&ReviewTargetKind::Session).unwrap();
+        assert_eq!(session_json, "\"session\"");
+        let benchmark_json = serde_json::to_string(&ReviewTargetKind::Benchmark).unwrap();
+        assert_eq!(benchmark_json, "\"benchmark\"");
+
+        let parsed: ReviewTargetKind = serde_json::from_str("\"session\"").unwrap();
+        assert_eq!(parsed, ReviewTargetKind::Session);
+        let parsed: ReviewTargetKind = serde_json::from_str("\"benchmark\"").unwrap();
+        assert_eq!(parsed, ReviewTargetKind::Benchmark);
+    }
+}

--- a/src/terminal_engineer_bridge.rs
+++ b/src/terminal_engineer_bridge.rs
@@ -382,3 +382,370 @@ fn optional_evidence_value<'a>(
         .rev()
         .find_map(|record| record.detail.strip_prefix(prefix))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base_types::BaseTypeId;
+    use crate::evidence::EvidenceSource;
+    use crate::runtime::{RuntimeAddress, RuntimeNodeId, RuntimeState, RuntimeTopology};
+    use crate::session::{SessionId, SessionPhase};
+    use std::collections::HashSet;
+    use tempfile::TempDir;
+
+    fn test_session_id() -> SessionId {
+        SessionId::from_uuid(uuid::Uuid::nil())
+    }
+
+    fn make_evidence(detail: &str) -> EvidenceRecord {
+        EvidenceRecord {
+            id: "ev-1".to_string(),
+            session_id: test_session_id(),
+            phase: SessionPhase::Execution,
+            detail: detail.to_string(),
+            source: EvidenceSource::Runtime,
+        }
+    }
+
+    fn minimal_snapshot(evidence: Vec<EvidenceRecord>) -> RuntimeHandoffSnapshot {
+        let node = RuntimeNodeId::local();
+        RuntimeHandoffSnapshot {
+            exported_state: RuntimeState::Ready,
+            identity_name: "test-identity".to_string(),
+            selected_base_type: BaseTypeId::new("test-base"),
+            topology: RuntimeTopology::SingleProcess,
+            source_runtime_node: node.clone(),
+            source_mailbox_address: RuntimeAddress::local(&node),
+            session: None,
+            memory_records: vec![],
+            evidence_records: evidence,
+            copilot_submit_audit: None,
+        }
+    }
+
+    // ── 1. Constants have expected values ──
+
+    #[test]
+    fn constants_are_non_empty() {
+        let constants: &[&str] = &[
+            COMPATIBILITY_HANDOFF_FILE_NAME,
+            TERMINAL_HANDOFF_FILE_NAME,
+            ENGINEER_HANDOFF_FILE_NAME,
+            TERMINAL_MODE_BOUNDARY,
+            ENGINEER_MODE_BOUNDARY,
+            SHARED_EXPLICIT_STATE_ROOT_SOURCE,
+            SHARED_DEFAULT_STATE_ROOT_SOURCE,
+        ];
+        for c in constants {
+            assert!(!c.is_empty(), "constant must not be empty");
+        }
+    }
+
+    #[test]
+    fn handoff_file_name_constants_are_distinct() {
+        let names: HashSet<&str> = [
+            COMPATIBILITY_HANDOFF_FILE_NAME,
+            TERMINAL_HANDOFF_FILE_NAME,
+            ENGINEER_HANDOFF_FILE_NAME,
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(
+            names.len(),
+            3,
+            "all three handoff file names must be distinct"
+        );
+    }
+
+    #[test]
+    fn mode_boundary_constants_are_distinct() {
+        assert_ne!(TERMINAL_MODE_BOUNDARY, ENGINEER_MODE_BOUNDARY);
+    }
+
+    #[test]
+    fn state_root_source_constants_are_distinct() {
+        assert_ne!(
+            SHARED_EXPLICIT_STATE_ROOT_SOURCE,
+            SHARED_DEFAULT_STATE_ROOT_SOURCE
+        );
+    }
+
+    // ── 2. ScopedHandoffMode::scoped_file_name ──
+
+    #[test]
+    fn scoped_file_name_terminal() {
+        assert_eq!(
+            ScopedHandoffMode::Terminal.scoped_file_name(),
+            TERMINAL_HANDOFF_FILE_NAME
+        );
+    }
+
+    #[test]
+    fn scoped_file_name_engineer() {
+        assert_eq!(
+            ScopedHandoffMode::Engineer.scoped_file_name(),
+            ENGINEER_HANDOFF_FILE_NAME
+        );
+    }
+
+    // ── 3. Path construction helpers ──
+
+    #[test]
+    fn compatibility_handoff_path_constructs_correctly() {
+        let root = Path::new("/state");
+        assert_eq!(
+            compatibility_handoff_path(root),
+            PathBuf::from("/state/latest_handoff.json")
+        );
+    }
+
+    #[test]
+    fn scoped_handoff_path_terminal() {
+        let root = Path::new("/state");
+        assert_eq!(
+            scoped_handoff_path(root, ScopedHandoffMode::Terminal),
+            PathBuf::from("/state/latest_terminal_handoff.json")
+        );
+    }
+
+    #[test]
+    fn scoped_handoff_path_engineer() {
+        let root = Path::new("/state");
+        assert_eq!(
+            scoped_handoff_path(root, ScopedHandoffMode::Engineer),
+            PathBuf::from("/state/latest_engineer_handoff.json")
+        );
+    }
+
+    // ── 4. from_engineer_evidence with empty evidence ──
+
+    #[test]
+    fn from_engineer_evidence_returns_none_for_empty_evidence() {
+        let result = TerminalBridgeContext::from_engineer_evidence(&[]).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn from_engineer_evidence_returns_none_without_source_prefix() {
+        let records = vec![make_evidence("unrelated-detail=hello")];
+        let result = TerminalBridgeContext::from_engineer_evidence(&records).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn from_engineer_evidence_rejects_unknown_source() {
+        let records = vec![
+            make_evidence("terminal-continuity-source=unknown-source"),
+            make_evidence("terminal-continuity-handoff=latest_terminal_handoff.json"),
+            make_evidence("terminal-continuity-working-directory=/home"),
+            make_evidence("terminal-continuity-command-count=5"),
+        ];
+        let result = TerminalBridgeContext::from_engineer_evidence(&records);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn from_engineer_evidence_rejects_unknown_handoff_file() {
+        let records = vec![
+            make_evidence(&format!(
+                "terminal-continuity-source={SHARED_EXPLICIT_STATE_ROOT_SOURCE}"
+            )),
+            make_evidence("terminal-continuity-handoff=bad_file.json"),
+        ];
+        let result = TerminalBridgeContext::from_engineer_evidence(&records);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn from_engineer_evidence_succeeds_with_valid_records() {
+        let records = vec![
+            make_evidence(&format!(
+                "terminal-continuity-source={SHARED_EXPLICIT_STATE_ROOT_SOURCE}"
+            )),
+            make_evidence(&format!(
+                "terminal-continuity-handoff={TERMINAL_HANDOFF_FILE_NAME}"
+            )),
+            make_evidence("terminal-continuity-working-directory=/home/user/project"),
+            make_evidence("terminal-continuity-command-count=42"),
+            make_evidence("terminal-continuity-wait-count=3"),
+            make_evidence("terminal-continuity-last-output-line=build succeeded"),
+        ];
+        let ctx = TerminalBridgeContext::from_engineer_evidence(&records)
+            .unwrap()
+            .expect("should return Some");
+        assert_eq!(ctx.continuity_source, SHARED_EXPLICIT_STATE_ROOT_SOURCE);
+        assert_eq!(ctx.handoff_file_name, TERMINAL_HANDOFF_FILE_NAME);
+        assert_eq!(ctx.working_directory, "/home/user/project");
+        assert_eq!(ctx.command_count, "42");
+        assert_eq!(ctx.wait_count, "3");
+        assert_eq!(ctx.last_output_line.as_deref(), Some("build succeeded"));
+    }
+
+    #[test]
+    fn from_engineer_evidence_defaults_wait_count_to_zero() {
+        let records = vec![
+            make_evidence(&format!(
+                "terminal-continuity-source={SHARED_DEFAULT_STATE_ROOT_SOURCE}"
+            )),
+            make_evidence(&format!(
+                "terminal-continuity-handoff={COMPATIBILITY_HANDOFF_FILE_NAME}"
+            )),
+            make_evidence("terminal-continuity-working-directory=/w"),
+            make_evidence("terminal-continuity-command-count=1"),
+        ];
+        let ctx = TerminalBridgeContext::from_engineer_evidence(&records)
+            .unwrap()
+            .expect("should return Some");
+        assert_eq!(ctx.wait_count, "0");
+        assert!(ctx.last_output_line.is_none());
+    }
+
+    // ── 5. engineer_evidence_details ──
+
+    #[test]
+    fn engineer_evidence_details_without_last_output_line() {
+        let ctx = TerminalBridgeContext {
+            continuity_source: "src".to_string(),
+            handoff_file_name: "file.json".to_string(),
+            working_directory: "/wd".to_string(),
+            command_count: "10".to_string(),
+            wait_count: "2".to_string(),
+            last_output_line: None,
+        };
+        let details = ctx.engineer_evidence_details();
+        assert_eq!(details.len(), 5);
+        assert_eq!(details[0], "terminal-continuity-source=src");
+        assert_eq!(details[1], "terminal-continuity-handoff=file.json");
+        assert_eq!(details[2], "terminal-continuity-working-directory=/wd");
+        assert_eq!(details[3], "terminal-continuity-command-count=10");
+        assert_eq!(details[4], "terminal-continuity-wait-count=2");
+    }
+
+    #[test]
+    fn engineer_evidence_details_with_last_output_line() {
+        let ctx = TerminalBridgeContext {
+            continuity_source: "src".to_string(),
+            handoff_file_name: "file.json".to_string(),
+            working_directory: "/wd".to_string(),
+            command_count: "10".to_string(),
+            wait_count: "2".to_string(),
+            last_output_line: Some("done".to_string()),
+        };
+        let details = ctx.engineer_evidence_details();
+        assert_eq!(details.len(), 6);
+        assert_eq!(details[5], "terminal-continuity-last-output-line=done");
+    }
+
+    // ── 6. select_optional_handoff_artifact returns None when no files exist ──
+
+    #[test]
+    fn select_optional_handoff_artifact_returns_none_for_empty_dir() {
+        let dir = TempDir::new().unwrap();
+        let result =
+            select_optional_handoff_artifact(dir.path(), ScopedHandoffMode::Terminal, "test")
+                .unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn select_optional_handoff_artifact_returns_none_for_engineer_mode() {
+        let dir = TempDir::new().unwrap();
+        let result =
+            select_optional_handoff_artifact(dir.path(), ScopedHandoffMode::Engineer, "test")
+                .unwrap();
+        assert!(result.is_none());
+    }
+
+    // ── 7. persist + select + load roundtrip ──
+
+    #[test]
+    fn persist_and_select_roundtrip_terminal() {
+        let dir = TempDir::new().unwrap();
+        let snapshot = minimal_snapshot(vec![]);
+
+        persist_handoff_artifacts(dir.path(), ScopedHandoffMode::Terminal, &snapshot).unwrap();
+
+        assert!(scoped_handoff_path(dir.path(), ScopedHandoffMode::Terminal).exists());
+        assert!(compatibility_handoff_path(dir.path()).exists());
+
+        let artifact =
+            select_handoff_artifact_for_read(dir.path(), ScopedHandoffMode::Terminal, "test")
+                .unwrap();
+        assert_eq!(artifact.file_name, TERMINAL_HANDOFF_FILE_NAME);
+        assert_eq!(
+            artifact.path,
+            scoped_handoff_path(dir.path(), ScopedHandoffMode::Terminal)
+        );
+
+        let loaded = load_runtime_handoff_snapshot(&artifact, "test").unwrap();
+        assert_eq!(loaded, snapshot);
+    }
+
+    #[test]
+    fn persist_and_select_roundtrip_engineer() {
+        let dir = TempDir::new().unwrap();
+        let snapshot = minimal_snapshot(vec![make_evidence("some-detail")]);
+
+        persist_handoff_artifacts(dir.path(), ScopedHandoffMode::Engineer, &snapshot).unwrap();
+
+        assert!(scoped_handoff_path(dir.path(), ScopedHandoffMode::Engineer).exists());
+        assert!(compatibility_handoff_path(dir.path()).exists());
+
+        let artifact =
+            select_handoff_artifact_for_read(dir.path(), ScopedHandoffMode::Engineer, "test")
+                .unwrap();
+        assert_eq!(artifact.file_name, ENGINEER_HANDOFF_FILE_NAME);
+
+        let loaded = load_runtime_handoff_snapshot(&artifact, "test").unwrap();
+        assert_eq!(loaded.evidence_records.len(), 1);
+        assert_eq!(loaded.evidence_records[0].detail, "some-detail");
+    }
+
+    #[test]
+    fn select_optional_finds_compatibility_fallback() {
+        let dir = TempDir::new().unwrap();
+        let snapshot = minimal_snapshot(vec![]);
+
+        persist_handoff_artifacts(dir.path(), ScopedHandoffMode::Terminal, &snapshot).unwrap();
+
+        let artifact =
+            select_optional_handoff_artifact(dir.path(), ScopedHandoffMode::Engineer, "test")
+                .unwrap()
+                .expect("should fall back to compatibility file");
+        assert_eq!(artifact.file_name, COMPATIBILITY_HANDOFF_FILE_NAME);
+
+        let loaded = load_runtime_handoff_snapshot(&artifact, "test").unwrap();
+        assert_eq!(loaded, snapshot);
+    }
+
+    #[test]
+    fn select_for_read_falls_back_to_compatibility() {
+        let dir = TempDir::new().unwrap();
+        let snapshot = minimal_snapshot(vec![]);
+
+        persist_handoff_artifacts(dir.path(), ScopedHandoffMode::Terminal, &snapshot).unwrap();
+
+        fs::remove_file(scoped_handoff_path(dir.path(), ScopedHandoffMode::Terminal)).unwrap();
+
+        let artifact =
+            select_handoff_artifact_for_read(dir.path(), ScopedHandoffMode::Terminal, "test")
+                .unwrap();
+        assert_eq!(artifact.file_name, COMPATIBILITY_HANDOFF_FILE_NAME);
+    }
+
+    #[test]
+    fn select_for_read_errors_when_no_files_exist() {
+        let dir = TempDir::new().unwrap();
+        let result =
+            select_handoff_artifact_for_read(dir.path(), ScopedHandoffMode::Terminal, "test");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn load_from_state_root_returns_none_when_no_files() {
+        let dir = TempDir::new().unwrap();
+        let result =
+            TerminalBridgeContext::load_from_state_root(dir.path(), "test-source").unwrap();
+        assert!(result.is_none());
+    }
+}


### PR DESCRIPTION
## Summary
Phase 1 of Simard's self-improvement plan: add tests to the 5 highest-impact zero-coverage modules.

### Changes (test-only, no impl modifications)
| Module | Tests Added | Coverage Areas |
|--------|------------|----------------|
| `ooda_scheduler.rs` | 18 | Scheduler lifecycle, capacity limits, slot state transitions, poll/drain, summary |
| `operator_commands.rs` | 36 | Arg parsing, topology parsing, evidence helpers, path construction, CLI dispatch errors |
| `terminal_engineer_bridge.rs` | 25 | Path builders, evidence parsing, handoff persist/load roundtrip, error paths |
| `review.rs` | 15 | Artifact build, signal extraction, persist/load roundtrip, render, latest artifact |
| `operator_commands_meeting.rs` | 8 | Meeting context builder, read probe error paths, empty state handling |

### Testing
- **553 → 655 lib tests** (+102 new tests)
- All passing, clippy clean
- No implementation changes — test-only additions

### Context
First item in Simard's self-reflection improvement plan (docs/meetings/2026-04-04-self-reflection.md). These 5 modules had 0% coverage totaling 1,841 untested coverable lines.