### PR TITLE
fix: copilot meeting PTY — remove timeout, use natural process exit

### DIFF
--- a/src/base_type_copilot.rs
+++ b/src/base_type_copilot.rs
@@ -276,13 +276,19 @@ fn build_copilot_terminal_objective(
 /// Extract the actual copilot LLM response from the terminal transcript
 /// embedded in the evidence vector.
 ///
-/// The transcript (available as `terminal-transcript-preview`) contains the
-/// command input, the copilot's response, and shell bookkeeping.  We strip
-/// the command echo and shell noise to isolate the copilot output.
+/// Prefers the full transcript (`terminal-transcript-full`) over the
+/// truncated preview.  The full transcript is newline-delimited; the
+/// preview is pipe-delimited.
 fn extract_copilot_response_from_evidence(evidence: &[String]) -> String {
+    // Prefer full transcript; fall back to the preview.
     let transcript = evidence
         .iter()
-        .find_map(|e| e.strip_prefix("terminal-transcript-preview="))
+        .find_map(|e| e.strip_prefix("terminal-transcript-full="))
+        .or_else(|| {
+            evidence
+                .iter()
+                .find_map(|e| e.strip_prefix("terminal-transcript-preview="))
+        })
         .unwrap_or("");
 
     extract_response_from_transcript(transcript)
@@ -290,34 +296,81 @@ fn extract_copilot_response_from_evidence(evidence: &[String]) -> String {
 
 /// Parse the raw transcript text to isolate the copilot's response.
 ///
-/// The transcript (pipe-delimited from `transcript_preview`) typically looks
-/// like:
-///   <shell prompt> <command>
-///   <copilot output lines...>
-///   <shell prompt> exit
+/// The transcript from `script` contains (in order):
+///   Script started on ...
+///   <bash prompt> <command echo>
+///   <copilot bootstrap lines — hooks, XPIA defender, etc.>
+///   <actual LLM response>
+///   Total usage est: ...
+///   API time spent: ...
+///   bash-5.2$ exit
+///   Script done on ...
 ///
-/// We find the command line, skip it, and take everything up to the `exit`
-/// line, stripping shell prompts and empty lines.
+/// We find the end of bootstrap noise and the start of usage stats to
+/// isolate the actual LLM response in between.
 fn extract_response_from_transcript(transcript: &str) -> String {
-    let lines: Vec<&str> = transcript.split(" | ").collect();
+    let lines: Vec<&str> = transcript.lines().collect();
+    // Also try pipe-delimited (preview format) if no newlines found.
+    let lines = if lines.len() <= 1 && transcript.contains(" | ") {
+        transcript.split(" | ").collect::<Vec<_>>()
+    } else {
+        lines
+    };
 
-    // Find the command line (contains "amplihack copilot" or SIMARD_PROMPT_FILE)
-    let command_pos = lines
+    let mut response_start = 0;
+    let mut response_end = lines.len();
+
+    for (i, line) in lines.iter().enumerate() {
+        let trimmed = line.trim();
+        // Bootstrap output: hook staging, XPIA defender, prompt file creation
+        if trimmed.contains("Staged") && trimmed.contains("hook")
+            || trimmed.contains("XPIA")
+            || trimmed.contains("SIMARD_PROMPT_FILE")
+            || trimmed.contains("amplihack copilot")
+            || trimmed.starts_with("Script started on")
+            || trimmed.starts_with("bash-") && trimmed.contains("$") && trimmed.contains("cat ")
+        {
+            response_start = i + 1;
+        }
+        // Usage stats / session footer
+        if (trimmed.starts_with("Total usage est:")
+            || trimmed.starts_with("API time spent:")
+            || trimmed.starts_with("Total session time:"))
+            && response_end == lines.len()
+        {
+            response_end = i;
+        }
+        // Shell exit / script done
+        if (trimmed == "exit"
+            || trimmed.ends_with("$ exit")
+            || trimmed.starts_with("Script done on"))
+            && response_end == lines.len()
+        {
+            response_end = i;
+        }
+    }
+
+    if response_start >= response_end {
+        // Fallback: strip known noise lines
+        return lines
+            .iter()
+            .filter(|l| {
+                let t = l.trim();
+                !(t.is_empty()
+                    || t.starts_with("Script ")
+                    || t.contains("amplihack copilot")
+                    || t.contains("SIMARD_PROMPT_FILE")
+                    || t == "exit"
+                    || t.ends_with("$ exit"))
+            })
+            .copied()
+            .collect::<Vec<_>>()
+            .join("\n");
+    }
+
+    lines[response_start..response_end]
         .iter()
-        .position(|line| line.contains("amplihack copilot") || line.contains("SIMARD_PROMPT_FILE"));
-
-    let start = command_pos.map_or(0, |p| p + 1);
-
-    lines[start..]
-        .iter()
-        .filter(|l| {
-            let trimmed = l.trim();
-            !(trimmed.is_empty()
-                || trimmed == "exit"
-                || trimmed.ends_with("$ exit")
-                || trimmed.ends_with("# exit")
-                || trimmed.starts_with("bash-") && trimmed.ends_with('$'))
-        })
+        .filter(|l| !l.trim().is_empty())
         .copied()
         .collect::<Vec<_>>()
         .join("\n")
@@ -486,7 +539,14 @@ mod tests {
 
     #[test]
     fn extract_response_from_transcript_isolates_copilot_output() {
-        let transcript = "bash-5.2$ SIMARD_PROMPT_FILE=$(mktemp) && printf '%s' 'Hello' > \"$SIMARD_PROMPT_FILE\" && amplihack copilot -p \"$(cat \"$SIMARD_PROMPT_FILE\")\" ; rm -f \"$SIMARD_PROMPT_FILE\" | I'm Simard, your engineering agent. How can I help? | bash-5.2$ exit";
+        // Full transcript format: newline-delimited lines from `script`
+        let transcript = "\
+Script started on 2025-04-07 02:55:00+00:00
+bash-5.2$ SIMARD_PROMPT_FILE=$(mktemp) && printf '%s' 'Hello' > \"$SIMARD_PROMPT_FILE\" && amplihack copilot -p \"$(cat \"$SIMARD_PROMPT_FILE\")\" ; rm -f \"$SIMARD_PROMPT_FILE\" ; exit
+I'm Simard, your engineering agent. How can I help?
+Total usage est: 0.012
+bash-5.2$ exit
+Script done on 2025-04-07 02:56:00+00:00";
         let response = extract_response_from_transcript(transcript);
         assert!(
             response.contains("I'm Simard"),
@@ -496,11 +556,26 @@ mod tests {
             !response.contains("exit"),
             "exit command should be stripped"
         );
+        assert!(
+            !response.contains("Total usage"),
+            "usage stats should be stripped"
+        );
+    }
+
+    #[test]
+    fn extract_response_from_transcript_pipe_delimited_fallback() {
+        // Preview format: pipe-delimited
+        let transcript = "SIMARD_PROMPT_FILE=x && amplihack copilot -p test | Hello from Simard | bash-5.2$ exit";
+        let response = extract_response_from_transcript(transcript);
+        assert!(
+            response.contains("Hello from Simard"),
+            "should handle pipe-delimited: got '{response}'"
+        );
     }
 
     #[test]
     fn extract_response_from_transcript_handles_no_command_marker() {
-        let transcript = "some output | actual response text | more text";
+        let transcript = "some output\nactual response text\nmore text";
         let response = extract_response_from_transcript(transcript);
         assert!(!response.is_empty(), "should return all content lines");
     }
@@ -512,7 +587,25 @@ mod tests {
     }
 
     #[test]
-    fn extract_copilot_response_from_evidence_finds_transcript() {
+    fn extract_copilot_response_from_evidence_prefers_full_transcript() {
+        let evidence = vec![
+            "selected-base-type=copilot-test".to_string(),
+            "terminal-transcript-preview=SIMARD_PROMPT_FILE=x && amplihack copilot -p test | Preview only | bash-5.2$ exit".to_string(),
+            "terminal-transcript-full=Script started on 2025-04-07\nbash-5.2$ amplihack copilot -p test\nFull response from Simard\nTotal usage est: 0.01\nbash-5.2$ exit\nScript done on 2025-04-07".to_string(),
+        ];
+        let response = extract_copilot_response_from_evidence(&evidence);
+        assert!(
+            response.contains("Full response from Simard"),
+            "should prefer full transcript: got '{response}'"
+        );
+        assert!(
+            !response.contains("Preview only"),
+            "should not use preview when full is available"
+        );
+    }
+
+    #[test]
+    fn extract_copilot_response_from_evidence_falls_back_to_preview() {
         let evidence = vec![
             "selected-base-type=copilot-test".to_string(),
             "terminal-transcript-preview=SIMARD_PROMPT_FILE=x && amplihack copilot -p test | Hello from Simard | bash-5.2$ exit".to_string(),
@@ -520,7 +613,7 @@ mod tests {
         let response = extract_copilot_response_from_evidence(&evidence);
         assert!(
             response.contains("Hello from Simard"),
-            "should extract response: got '{response}'"
+            "should fall back to preview: got '{response}'"
         );
     }
 

--- a/src/base_type_copilot.rs
+++ b/src/base_type_copilot.rs
@@ -193,12 +193,9 @@ impl BaseTypeSession for CopilotSdkSession {
 
         self.turn_count += 1;
 
-        // Build enriched objective and dispatch via terminal infrastructure.
         let enriched_objective = self.build_enriched_objective(&input);
         let enriched_input = BaseTypeTurnInput::objective_only(enriched_objective);
 
-        // Delegate to the terminal session infrastructure. If the terminal
-        // turn fails, wrap the error with copilot-specific context.
         let terminal_outcome =
             execute_terminal_turn(&self.descriptor, &self.request, &enriched_input).map_err(
                 |err| SimardError::AdapterInvocationFailed {
@@ -207,7 +204,12 @@ impl BaseTypeSession for CopilotSdkSession {
                 },
             )?;
 
-        // Augment evidence with copilot-specific metadata.
+        // Extract the actual LLM response from the transcript.  The transcript
+        // contains the command we sent, the copilot's response text, and then
+        // our sentinel marker.  We extract everything between the command echo
+        // and the sentinel as the meaningful response.
+        let response_text = extract_copilot_response_from_evidence(&terminal_outcome.evidence);
+
         let objective_summary = objective_metadata(&input.objective);
         let mut evidence = terminal_outcome.evidence;
         evidence.push(format!("copilot-adapter-command={}", self.config.command));
@@ -222,7 +224,7 @@ impl BaseTypeSession for CopilotSdkSession {
                 "Copilot SDK adapter dispatched {} via '{}' on '{}' (turn {}).",
                 objective_summary, self.config.command, self.request.topology, self.turn_count,
             ),
-            execution_summary: terminal_outcome.execution_summary,
+            execution_summary: response_text,
             evidence,
         })
     }
@@ -237,6 +239,12 @@ impl BaseTypeSession for CopilotSdkSession {
 
 /// Build a terminal-session-compatible objective string that launches the
 /// copilot command with the enriched prompt.
+///
+/// Strategy: write the prompt to a temp file, run `<copilot-cmd> -p @file`,
+/// then `exit` the shell.  The terminal infrastructure calls `finish()` which
+/// waits for the process to exit naturally — no artificial timeouts.  The
+/// copilot runs to completion however long it takes, and we read the full
+/// transcript afterward.
 fn build_copilot_terminal_objective(
     config: &CopilotAdapterConfig,
     formatted_prompt: &str,
@@ -247,18 +255,72 @@ fn build_copilot_terminal_objective(
         objective.push_str(&format!("working-directory: {cwd}\n"));
     }
 
-    // The command sends the formatted prompt to the copilot via stdin echo.
-    // We use printf to avoid issues with special characters in the prompt.
+    // Write the prompt to a temp file to avoid shell quoting issues with
+    // large multi-line prompts containing arbitrary characters.
+    // Chain the copilot command with `exit` so the shell exits naturally
+    // after the copilot finishes — no separate input step needed.
     let escaped = formatted_prompt
         .replace('\\', "\\\\")
         .replace('\'', "'\\''");
     objective.push_str(&format!(
-        "command: printf '%s' '{}' | {}\n",
-        escaped, config.command
+        "command: SIMARD_PROMPT_FILE=$(mktemp /tmp/simard-copilot-prompt.XXXXXX) && \
+         printf '%s' '{}' > \"$SIMARD_PROMPT_FILE\" && \
+         {} -p \"$(cat \"$SIMARD_PROMPT_FILE\")\" ; \
+         rm -f \"$SIMARD_PROMPT_FILE\" ; exit\n",
+        escaped, config.command,
     ));
-    objective.push_str("wait-for: $\n");
 
     objective
+}
+
+/// Extract the actual copilot LLM response from the terminal transcript
+/// embedded in the evidence vector.
+///
+/// The transcript (available as `terminal-transcript-preview`) contains the
+/// command input, the copilot's response, and shell bookkeeping.  We strip
+/// the command echo and shell noise to isolate the copilot output.
+fn extract_copilot_response_from_evidence(evidence: &[String]) -> String {
+    let transcript = evidence
+        .iter()
+        .find_map(|e| e.strip_prefix("terminal-transcript-preview="))
+        .unwrap_or("");
+
+    extract_response_from_transcript(transcript)
+}
+
+/// Parse the raw transcript text to isolate the copilot's response.
+///
+/// The transcript (pipe-delimited from `transcript_preview`) typically looks
+/// like:
+///   <shell prompt> <command>
+///   <copilot output lines...>
+///   <shell prompt> exit
+///
+/// We find the command line, skip it, and take everything up to the `exit`
+/// line, stripping shell prompts and empty lines.
+fn extract_response_from_transcript(transcript: &str) -> String {
+    let lines: Vec<&str> = transcript.split(" | ").collect();
+
+    // Find the command line (contains "amplihack copilot" or SIMARD_PROMPT_FILE)
+    let command_pos = lines
+        .iter()
+        .position(|line| line.contains("amplihack copilot") || line.contains("SIMARD_PROMPT_FILE"));
+
+    let start = command_pos.map_or(0, |p| p + 1);
+
+    lines[start..]
+        .iter()
+        .filter(|l| {
+            let trimmed = l.trim();
+            !(trimmed.is_empty()
+                || trimmed == "exit"
+                || trimmed.ends_with("$ exit")
+                || trimmed.ends_with("# exit")
+                || trimmed.starts_with("bash-") && trimmed.ends_with('$'))
+        })
+        .copied()
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 /// Parse copilot response text and extract a turn context summary for
@@ -380,7 +442,7 @@ mod tests {
     }
 
     #[test]
-    fn build_copilot_objective_includes_command() {
+    fn build_copilot_objective_includes_command_and_exit() {
         let config = CopilotAdapterConfig {
             command: "my-copilot run".to_string(),
             working_directory: Some("/tmp/work".to_string()),
@@ -390,5 +452,82 @@ mod tests {
         assert!(objective.contains("my-copilot run"));
         assert!(objective.contains("working-directory: /tmp/work"));
         assert!(objective.contains("Do the thing."));
+        assert!(
+            objective.contains("; exit"),
+            "objective must chain exit to end the shell naturally"
+        );
+        assert!(
+            !objective.contains("wait-for:"),
+            "no wait-for — process exits naturally"
+        );
+        assert!(
+            !objective.contains("wait-timeout"),
+            "no timeout — process runs to completion"
+        );
+    }
+
+    #[test]
+    fn build_copilot_objective_without_working_directory() {
+        let config = CopilotAdapterConfig::default();
+        let prompt = "Hello world";
+        let objective = build_copilot_terminal_objective(&config, prompt);
+        assert!(!objective.contains("working-directory:"));
+        assert!(objective.contains("; exit"));
+        assert!(objective.contains("amplihack copilot"));
+    }
+
+    #[test]
+    fn build_copilot_objective_escapes_single_quotes() {
+        let config = CopilotAdapterConfig::default();
+        let prompt = "it's a test with 'quotes'";
+        let objective = build_copilot_terminal_objective(&config, prompt);
+        assert!(!objective.contains("it's"), "single quotes must be escaped");
+    }
+
+    #[test]
+    fn extract_response_from_transcript_isolates_copilot_output() {
+        let transcript = "bash-5.2$ SIMARD_PROMPT_FILE=$(mktemp) && printf '%s' 'Hello' > \"$SIMARD_PROMPT_FILE\" && amplihack copilot -p \"$(cat \"$SIMARD_PROMPT_FILE\")\" ; rm -f \"$SIMARD_PROMPT_FILE\" | I'm Simard, your engineering agent. How can I help? | bash-5.2$ exit";
+        let response = extract_response_from_transcript(transcript);
+        assert!(
+            response.contains("I'm Simard"),
+            "should extract copilot response: got '{response}'"
+        );
+        assert!(
+            !response.contains("exit"),
+            "exit command should be stripped"
+        );
+    }
+
+    #[test]
+    fn extract_response_from_transcript_handles_no_command_marker() {
+        let transcript = "some output | actual response text | more text";
+        let response = extract_response_from_transcript(transcript);
+        assert!(!response.is_empty(), "should return all content lines");
+    }
+
+    #[test]
+    fn extract_response_from_transcript_handles_empty() {
+        let response = extract_response_from_transcript("");
+        assert!(response.is_empty() || response.trim().is_empty());
+    }
+
+    #[test]
+    fn extract_copilot_response_from_evidence_finds_transcript() {
+        let evidence = vec![
+            "selected-base-type=copilot-test".to_string(),
+            "terminal-transcript-preview=SIMARD_PROMPT_FILE=x && amplihack copilot -p test | Hello from Simard | bash-5.2$ exit".to_string(),
+        ];
+        let response = extract_copilot_response_from_evidence(&evidence);
+        assert!(
+            response.contains("Hello from Simard"),
+            "should extract response: got '{response}'"
+        );
+    }
+
+    #[test]
+    fn extract_copilot_response_from_evidence_handles_missing_preview() {
+        let evidence = vec!["selected-base-type=copilot-test".to_string()];
+        let response = extract_copilot_response_from_evidence(&evidence);
+        assert!(response.is_empty());
     }
 }

--- a/src/terminal_session/execution.rs
+++ b/src/terminal_session/execution.rs
@@ -51,6 +51,9 @@ pub fn execute_terminal_turn(
     if let Some(last_output_line) = last_output_line {
         evidence.push(format!("terminal-last-output-line={last_output_line}"));
     }
+    // Include the full transcript so adapters (e.g. copilot) can extract
+    // the actual LLM response instead of relying on the truncated preview.
+    evidence.push(format!("terminal-transcript-full={transcript}"));
 
     Ok(BaseTypeOutcome {
         plan: format!(

--- a/src/terminal_session/session.rs
+++ b/src/terminal_session/session.rs
@@ -137,7 +137,7 @@ impl PtyTerminalSession {
     }
 
     pub(crate) fn read_transcript(&self) -> SimardResult<String> {
-        fs::read_to_string(&self.transcript_path).map_err(|error| {
+        let bytes = fs::read(&self.transcript_path).map_err(|error| {
             SimardError::AdapterInvocationFailed {
                 base_type: self.base_type.clone(),
                 reason: format!(
@@ -145,7 +145,11 @@ impl PtyTerminalSession {
                     self.transcript_path.display()
                 ),
             }
-        })
+        })?;
+        // Terminal transcripts may contain raw ANSI escapes or other non-UTF-8
+        // bytes from the copilot process.  Use lossy conversion so we never
+        // fail just because the output includes terminal control sequences.
+        Ok(String::from_utf8_lossy(&bytes).into_owned())
     }
 
     pub(crate) fn terminate(&mut self) -> SimardResult<()> {


### PR DESCRIPTION
## Summary

Fixes #207 — Meeting REPL Copilot SDK terminal turn fails with 5s timeout.

## Root Cause

`build_copilot_terminal_objective()` generated a `wait-for: $` step that expected a shell prompt within 5 seconds. The `amplihack copilot` command takes 10-40s for LLM inference and doesn't emit a `$` prompt — it's not a shell.

## Fix

**No timeouts, no sentinels.** The copilot command runs to natural completion:

1. Write prompt to temp file (avoids shell quoting issues)
2. Invoke `amplihack copilot -p "$(cat file)"` chained with `; exit`
3. Process exits naturally; `finish()` collects the transcript (up to 600s)
4. Extract the actual LLM response from the full transcript

### Changes

- **`src/base_type_copilot.rs`**: Rewrote `build_copilot_terminal_objective()` — no `wait-for`, no timeout. Added `extract_copilot_response_from_evidence()` and `extract_response_from_transcript()` that parse real `script` output to isolate the LLM response between bootstrap noise and usage stats. 16 tests.
- **`src/terminal_session/execution.rs`**: Added `terminal-transcript-full` evidence field containing the complete transcript (newline-delimited) instead of the 512-char truncated preview.
- **`src/terminal_session/session.rs`**: `read_transcript()` uses `String::from_utf8_lossy` to handle non-UTF-8 ANSI sequences from copilot output.

### Dogfood Result

Meeting REPL works end-to-end:
```
simard:meeting> Hello Simard
Hey Ryan, I can hear you — ready to dig into whatever's on your mind today.
```