### PR TITLE
fix: OODA daemon respects SIMARD_LLM_PROVIDER, fix session launch pattern

### DIFF
--- a/src/ooda_actions/session.rs
+++ b/src/ooda_actions/session.rs
@@ -6,57 +6,49 @@ use super::make_outcome;
 
 /// Launch a bounded terminal session to work on a specific task.
 ///
-/// Uses `PtyTerminalSession` to start `amplihack copilot`, send the task
-/// description, wait for completion signals, and capture the transcript.
+/// Uses `PtyTerminalSession` to start `amplihack copilot -p <prompt>`,
+/// wait for natural process exit, and capture the transcript.
+/// This mirrors the copilot adapter pattern from `base_type_copilot.rs`:
+/// write the prompt to a temp file, invoke copilot with `-p`, chain `; exit`.
 pub(super) fn dispatch_launch_session(action: &PlannedAction) -> ActionOutcome {
     use crate::terminal_session::PtyTerminalSession;
-    use std::time::Duration;
 
     let task = &action.description;
     let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
 
-    // Launch amplihack copilot in a PTY.
-    let mut session =
-        match PtyTerminalSession::launch_command("terminal-shell", "amplihack copilot", &cwd) {
-            Ok(s) => s,
-            Err(e) => {
-                return make_outcome(
-                    action,
-                    false,
-                    format!("failed to launch amplihack copilot: {e}"),
-                );
-            }
-        };
-
-    // Wait for the copilot prompt to appear.
-    let prompt_timeout = Duration::from_secs(30);
-    match session.wait_for_output("$", prompt_timeout) {
-        Ok(_) => {}
+    // Launch bash in a PTY — we'll send the copilot command ourselves.
+    let mut session = match PtyTerminalSession::launch("terminal-shell", "/usr/bin/bash", &cwd) {
+        Ok(s) => s,
         Err(e) => {
-            eprintln!("[simard] OODA launch-session: copilot prompt not detected: {e}");
-            // Continue anyway — the session may still be responsive.
+            return make_outcome(
+                action,
+                false,
+                format!("failed to launch terminal session: {e}"),
+            );
         }
-    }
+    };
 
-    // Send the task description.
-    if let Err(e) = session.send_input(task) {
+    // Build a single command that writes the prompt to a temp file, invokes
+    // copilot with -p, cleans up, and exits. No sentinels, no timeouts.
+    let escaped = task.replace('\\', "\\\\").replace('\'', "'\\''");
+    let command = format!(
+        "SIMARD_PROMPT_FILE=$(mktemp /tmp/simard-ooda-prompt.XXXXXX) && \
+         printf '%s' '{escaped}' > \"$SIMARD_PROMPT_FILE\" && \
+         amplihack copilot -p \"$(cat \"$SIMARD_PROMPT_FILE\")\" ; \
+         rm -f \"$SIMARD_PROMPT_FILE\" ; exit\n"
+    );
+
+    if let Err(e) = session.send_input(&command) {
         let _ = session.finish();
         return make_outcome(
             action,
             false,
-            format!("failed to send task to copilot: {e}"),
+            format!("failed to send command to terminal: {e}"),
         );
     }
 
-    // Wait for the task to complete (up to 5 minutes).
-    let work_timeout = Duration::from_secs(300);
-    let _ = session.wait_for_output("$", work_timeout);
-
-    // Send /exit to cleanly close the copilot session.
-    let _ = session.send_input("/exit");
-    let _ = session.wait_for_output("Bye", Duration::from_secs(10));
-
-    // Capture transcript.
+    // Wait for natural process exit — copilot runs to completion, then
+    // bash exits via the chained `; exit`. finish() polls up to 600s.
     match session.finish() {
         Ok(capture) => {
             let preview = crate::terminal_session::transcript_preview(&capture.transcript);

--- a/src/operator_commands_ooda/daemon.rs
+++ b/src/operator_commands_ooda/daemon.rs
@@ -43,17 +43,18 @@ pub fn run_ooda_daemon(
     let knowledge = launch_knowledge_bridge(&python_dir)?;
     let gym = launch_gym_bridge(&python_dir)?;
 
-    // Try to open a RustyClawd session for real autonomous work.
+    // Try to open an LLM session for real autonomous work.
+    // The provider is selected by SIMARD_LLM_PROVIDER (default: Copilot).
     let session = SessionBuilder::new(OperatingMode::Orchestrator)
         .node_id("ooda-daemon")
         .address("ooda-daemon://local")
-        .adapter_tag("ooda-rustyclawd")
+        .adapter_tag("ooda")
         .open();
 
     if session.is_some() {
-        eprintln!("[simard] OODA daemon: RustyClawd session opened for autonomous work");
+        eprintln!("[simard] OODA daemon: LLM session opened for autonomous work");
     } else {
-        eprintln!("[simard] OODA daemon: no API key — running in bridge-only mode");
+        eprintln!("[simard] OODA daemon: no LLM session available — running in bridge-only mode");
     }
 
     let mut bridges = OodaBridges {


### PR DESCRIPTION
## Summary

Two fixes to enable the OODA daemon to run through the Copilot backend:

### 1. daemon.rs — Provider-agnostic session
Changed `adapter_tag("ooda-rustyclawd")` to `adapter_tag("ooda")`, letting `SessionBuilder` route via `SIMARD_LLM_PROVIDER` (default: Copilot). Previously the daemon was hardcoded to RustyClawd and would degrade to bridge-only mode without `ANTHROPIC_API_KEY`.

### 2. session.rs — Fix launch pattern (same as #214)
Rewrote `dispatch_launch_session()` to use the temp-file + `-p` + `; exit` pattern from PR #214. The old code used `wait_for_output("$")` with hardcoded timeouts — the exact same bug that #207 documented.

143 OODA tests pass, clippy clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>