### PR TITLE
feat: expand gym benchmark scenarios from 9 to 15 with 2 new classes

### DIFF
--- a/src/gym/scenarios.rs
+++ b/src/gym/scenarios.rs
@@ -4,7 +4,7 @@ use crate::runtime::RuntimeTopology;
 
 use super::types::{BenchmarkCheckResult, BenchmarkClass, BenchmarkScenario};
 
-const BENCHMARK_SCENARIOS: [BenchmarkScenario; 9] = [
+const BENCHMARK_SCENARIOS: [BenchmarkScenario; 15] = [
     BenchmarkScenario {
         id: "repo-exploration-local",
         title: "Repo exploration on local harness",
@@ -104,6 +104,73 @@ const BENCHMARK_SCENARIOS: [BenchmarkScenario; 9] = [
         topology: RuntimeTopology::SingleProcess,
         objective: "Write a unit test for the function `pub fn goal_slug(title: &str) -> String` defined in src/goals.rs. The test should: (1) call goal_slug with a representative input string containing uppercase letters, spaces, and special characters, (2) assert the output matches expected slug format (lowercase, hyphen-separated, no leading/trailing hyphens), (3) be a valid #[test] function that compiles and runs.",
         expected_min_runtime_evidence: 3,
+    },
+    // --- Additional scenarios for broader coverage ---
+    BenchmarkScenario {
+        id: "test-writing-edge-cases",
+        title: "Write edge-case tests for boundary conditions",
+        description: "Exercise writing tests that cover boundary conditions and edge cases for a function with numeric or string inputs. Scored on whether tests cover empty input, maximum values, and off-by-one conditions.",
+        class: BenchmarkClass::TestWriting,
+        identity: "simard-gym",
+        base_type: "local-harness",
+        topology: RuntimeTopology::SingleProcess,
+        objective: "Write edge-case unit tests for the function `pub fn render_benchmark_count(count: usize, label: &str) -> String` in src/gym/reporting.rs. Tests should cover: (1) count of zero, (2) count of 1 (singular vs plural handling), (3) a large count value, (4) an empty label string. Each test should be a valid #[test] function with clear assertions.",
+        expected_min_runtime_evidence: 3,
+    },
+    BenchmarkScenario {
+        id: "bug-fix-error-propagation",
+        title: "Identify and describe an error propagation fix",
+        description: "Exercise identifying code that uses .expect() or .unwrap() where Result propagation with ? would be safer. Scored on whether the defect is correctly identified, the fix is described precisely, and safety implications are noted.",
+        class: BenchmarkClass::BugFix,
+        identity: "simard-gym",
+        base_type: "local-harness",
+        topology: RuntimeTopology::SingleProcess,
+        objective: "Scan the Simard codebase for a production (non-test) function that uses .expect() or .unwrap() on a Result or Option where the calling function already returns Result. Identify: (1) the exact file and line, (2) why the panic is unsafe in that context, (3) the precise replacement using ? or .ok_or_else(), (4) any signature changes needed. Produce a structured fix description.",
+        expected_min_runtime_evidence: 3,
+    },
+    BenchmarkScenario {
+        id: "bug-fix-off-by-one",
+        title: "Identify potential off-by-one or boundary bug",
+        description: "Exercise identifying code with potential off-by-one errors, incorrect boundary checks, or fence-post problems. Scored on whether the analysis is specific, the risk is correctly assessed, and a concrete fix is proposed.",
+        class: BenchmarkClass::BugFix,
+        identity: "simard-gym",
+        base_type: "copilot-sdk",
+        topology: RuntimeTopology::SingleProcess,
+        objective: "Analyze the Simard codebase for a function that performs index arithmetic, slice operations, or loop bounds checking. Identify: (1) a specific location where boundary handling could be incorrect, (2) the exact inputs that would trigger the issue, (3) a concrete fix with before/after code. If no real bug exists, describe the defensive check that would guard against one.",
+        expected_min_runtime_evidence: 3,
+    },
+    BenchmarkScenario {
+        id: "refactor-extract-function",
+        title: "Identify and plan a function extraction refactor",
+        description: "Exercise identifying a code block that should be extracted into a named function for clarity and reuse. Scored on whether the extracted function has a clear responsibility, appropriate parameters, and preserves existing behavior.",
+        class: BenchmarkClass::Refactoring,
+        identity: "simard-gym",
+        base_type: "local-harness",
+        topology: RuntimeTopology::SingleProcess,
+        objective: "Find a function in the Simard codebase longer than 30 lines that contains a logically distinct block of code suitable for extraction. Describe: (1) the source file and function name, (2) the lines to extract, (3) the new function signature (name, parameters, return type), (4) how the original function would call the extracted function. Verify the refactor preserves behavior.",
+        expected_min_runtime_evidence: 3,
+    },
+    BenchmarkScenario {
+        id: "refactor-simplify-match",
+        title: "Simplify a complex match expression",
+        description: "Exercise simplifying a match expression by combining arms, using wildcard patterns, or converting to if-let chains. Scored on whether the simplification is correct, reduces line count, and preserves all behavior.",
+        class: BenchmarkClass::Refactoring,
+        identity: "simard-engineer",
+        base_type: "local-harness",
+        topology: RuntimeTopology::SingleProcess,
+        objective: "Find a match expression in the Simard codebase with 4 or more arms where some arms share identical or nearly identical bodies. Describe: (1) the exact location, (2) which arms can be combined, (3) the simplified match expression, (4) any edge cases that must be preserved. Show both the original and simplified code.",
+        expected_min_runtime_evidence: 3,
+    },
+    BenchmarkScenario {
+        id: "repo-exploration-multi-process",
+        title: "Repository exploration under multi-process topology",
+        description: "Exercise the same repo-exploration task as the local variant but under the multi-process topology, validating that the loopback mesh transport and coordinated supervisor correctly propagate exploration results.",
+        class: BenchmarkClass::RepoExploration,
+        identity: "simard-gym",
+        base_type: "rusty-clawd",
+        topology: RuntimeTopology::MultiProcess,
+        objective: "Analyze the repository at /home/azureuser/src/Simard under multi-process topology. Identify: (1) the top-level project structure and key directories, (2) all Cargo.toml dependencies and their purposes, (3) the main entry point(s), (4) at least five public modules and their responsibilities. Produce a structured summary covering all four areas.",
+        expected_min_runtime_evidence: 4,
     },
 ];
 
@@ -316,36 +383,107 @@ pub(super) fn class_specific_checks(
             }]
         }
         BenchmarkClass::BugFix => {
-            let fix_mentioned = combined.contains("fix")
-                || combined.contains("bug")
-                || combined.contains("patch")
-                || combined.contains("resolve");
-            vec![BenchmarkCheckResult {
-                id: "bug-fix-attempted".to_string(),
-                passed: fix_mentioned,
-                detail: format!(
-                    "execution output {} bug-fix references",
-                    if fix_mentioned { "contains" } else { "lacks" }
-                ),
-            }]
+            let defect_identified = combined.contains("bug")
+                || combined.contains("defect")
+                || combined.contains("issue")
+                || combined.contains("unwrap")
+                || combined.contains("expect")
+                || combined.contains("panic");
+            let fix_described = combined.contains("fix")
+                || combined.contains("replac")
+                || combined.contains("propagat")
+                || combined.contains("convert")
+                || combined.contains("refactor");
+            let safety_analysis = combined.contains("safe")
+                || combined.contains("error handling")
+                || combined.contains("result")
+                || combined.contains("graceful")
+                || combined.contains("recover");
+            vec![
+                BenchmarkCheckResult {
+                    id: "bug-defect-identified".to_string(),
+                    passed: defect_identified,
+                    detail: format!(
+                        "execution output {} defect identification",
+                        if defect_identified {
+                            "includes"
+                        } else {
+                            "lacks"
+                        }
+                    ),
+                },
+                BenchmarkCheckResult {
+                    id: "bug-fix-described".to_string(),
+                    passed: fix_described,
+                    detail: format!(
+                        "execution output {} fix description",
+                        if fix_described { "includes" } else { "lacks" }
+                    ),
+                },
+                BenchmarkCheckResult {
+                    id: "bug-safety-analyzed".to_string(),
+                    passed: safety_analysis,
+                    detail: format!(
+                        "execution output {} safety analysis",
+                        if safety_analysis {
+                            "includes"
+                        } else {
+                            "lacks"
+                        }
+                    ),
+                },
+            ]
         }
         BenchmarkClass::Refactoring => {
-            let refactor_mentioned = combined.contains("refactor")
-                || combined.contains("restructur")
-                || combined.contains("clean")
-                || combined.contains("simplif");
-            vec![BenchmarkCheckResult {
-                id: "refactoring-attempted".to_string(),
-                passed: refactor_mentioned,
-                detail: format!(
-                    "execution output {} refactoring references",
-                    if refactor_mentioned {
-                        "contains"
-                    } else {
-                        "lacks"
-                    }
-                ),
-            }]
+            let change_identified = combined.contains("extract")
+                || combined.contains("simplif")
+                || combined.contains("refactor")
+                || combined.contains("renam")
+                || combined.contains("restructur");
+            let behavior_preserved = combined.contains("preserv")
+                || combined.contains("behavior")
+                || combined.contains("equivalent")
+                || combined.contains("same result")
+                || combined.contains("no change in");
+            let code_shown = combined.contains("fn ")
+                || combined.contains("before")
+                || combined.contains("after")
+                || combined.contains("original")
+                || combined.contains("simplified");
+            vec![
+                BenchmarkCheckResult {
+                    id: "refactor-change-identified".to_string(),
+                    passed: change_identified,
+                    detail: format!(
+                        "execution output {} refactoring identification",
+                        if change_identified {
+                            "includes"
+                        } else {
+                            "lacks"
+                        }
+                    ),
+                },
+                BenchmarkCheckResult {
+                    id: "refactor-behavior-preserved".to_string(),
+                    passed: behavior_preserved,
+                    detail: format!(
+                        "execution output {} behavior preservation evidence",
+                        if behavior_preserved {
+                            "includes"
+                        } else {
+                            "lacks"
+                        }
+                    ),
+                },
+                BenchmarkCheckResult {
+                    id: "refactor-code-shown".to_string(),
+                    passed: code_shown,
+                    detail: format!(
+                        "execution output {} code examples",
+                        if code_shown { "includes" } else { "lacks" }
+                    ),
+                },
+            ]
         }
     }
 }

--- a/src/gym/scenarios.rs
+++ b/src/gym/scenarios.rs
@@ -425,11 +425,7 @@ pub(super) fn class_specific_checks(
                     passed: safety_analysis,
                     detail: format!(
                         "execution output {} safety analysis",
-                        if safety_analysis {
-                            "includes"
-                        } else {
-                            "lacks"
-                        }
+                        if safety_analysis { "includes" } else { "lacks" }
                     ),
                 },
             ]

--- a/src/gym/tests_scenarios.rs
+++ b/src/gym/tests_scenarios.rs
@@ -15,7 +15,7 @@ use crate::session::{SessionId, SessionPhase, SessionRecord};
 
 #[test]
 fn benchmark_scenarios_returns_nine_scenarios() {
-    assert_eq!(benchmark_scenarios().len(), 9);
+    assert_eq!(benchmark_scenarios().len(), 15);
 }
 
 #[test]
@@ -60,6 +60,8 @@ fn benchmark_scenarios_covers_all_classes() {
     assert!(has_class(BenchmarkClass::SafeCodeChange));
     assert!(has_class(BenchmarkClass::SessionQuality));
     assert!(has_class(BenchmarkClass::TestWriting));
+    assert!(has_class(BenchmarkClass::BugFix));
+    assert!(has_class(BenchmarkClass::Refactoring));
 }
 
 // --- resolve_benchmark_scenario ---
@@ -507,4 +509,203 @@ fn class_checks_test_writing_detects_expect_for_assertions() {
         .find(|c| c.id == "test-has-assertions")
         .unwrap();
     assert!(check.passed);
+}
+
+// -- BugFix checks --
+
+#[test]
+fn class_checks_bug_fix_passes_with_keywords() {
+    let scenario = BenchmarkScenario {
+        class: BenchmarkClass::BugFix,
+        ..repo_exploration_scenario()
+    };
+    let outcome = dummy_outcome(
+        "found unwrap bug in error handling path",
+        "fix: replace expect with Result propagation for safety",
+        "the panic was unsafe, now uses graceful error recovery",
+    );
+    let exported = dummy_handoff(0);
+    let checks = class_specific_checks(&scenario, &outcome, &exported);
+    assert_eq!(checks.len(), 3);
+    assert!(
+        checks
+            .iter()
+            .any(|c| c.id == "bug-defect-identified" && c.passed)
+    );
+    assert!(
+        checks
+            .iter()
+            .any(|c| c.id == "bug-fix-described" && c.passed)
+    );
+    assert!(
+        checks
+            .iter()
+            .any(|c| c.id == "bug-safety-analyzed" && c.passed)
+    );
+}
+
+#[test]
+fn class_checks_bug_fix_fails_without_keywords() {
+    let scenario = BenchmarkScenario {
+        class: BenchmarkClass::BugFix,
+        ..repo_exploration_scenario()
+    };
+    let outcome = dummy_outcome("nothing", "bland text", "empty");
+    let exported = dummy_handoff(0);
+    let checks = class_specific_checks(&scenario, &outcome, &exported);
+    assert_eq!(checks.len(), 3);
+    for check in &checks {
+        assert!(!check.passed, "check '{}' should have failed", check.id);
+    }
+}
+
+#[test]
+fn class_checks_bug_fix_detects_panic_keyword() {
+    let scenario = BenchmarkScenario {
+        class: BenchmarkClass::BugFix,
+        ..repo_exploration_scenario()
+    };
+    let outcome = dummy_outcome("found a panic in production code", "bland", "bland");
+    let exported = dummy_handoff(0);
+    let checks = class_specific_checks(&scenario, &outcome, &exported);
+    let check = checks
+        .iter()
+        .find(|c| c.id == "bug-defect-identified")
+        .unwrap();
+    assert!(check.passed);
+}
+
+#[test]
+fn class_checks_bug_fix_detects_convert_for_fix() {
+    let scenario = BenchmarkScenario {
+        class: BenchmarkClass::BugFix,
+        ..repo_exploration_scenario()
+    };
+    let outcome = dummy_outcome("bland", "convert the call to use ? operator", "bland");
+    let exported = dummy_handoff(0);
+    let checks = class_specific_checks(&scenario, &outcome, &exported);
+    let check = checks
+        .iter()
+        .find(|c| c.id == "bug-fix-described")
+        .unwrap();
+    assert!(check.passed);
+}
+
+// -- Refactoring checks --
+
+#[test]
+fn class_checks_refactoring_passes_with_keywords() {
+    let scenario = BenchmarkScenario {
+        class: BenchmarkClass::Refactoring,
+        ..repo_exploration_scenario()
+    };
+    let outcome = dummy_outcome(
+        "extract helper fn from long function",
+        "refactored code preserves original behavior",
+        "before and after code shown, equivalent output",
+    );
+    let exported = dummy_handoff(0);
+    let checks = class_specific_checks(&scenario, &outcome, &exported);
+    assert_eq!(checks.len(), 3);
+    assert!(
+        checks
+            .iter()
+            .any(|c| c.id == "refactor-change-identified" && c.passed)
+    );
+    assert!(
+        checks
+            .iter()
+            .any(|c| c.id == "refactor-behavior-preserved" && c.passed)
+    );
+    assert!(
+        checks
+            .iter()
+            .any(|c| c.id == "refactor-code-shown" && c.passed)
+    );
+}
+
+#[test]
+fn class_checks_refactoring_fails_without_keywords() {
+    let scenario = BenchmarkScenario {
+        class: BenchmarkClass::Refactoring,
+        ..repo_exploration_scenario()
+    };
+    let outcome = dummy_outcome("nothing", "bland text", "empty");
+    let exported = dummy_handoff(0);
+    let checks = class_specific_checks(&scenario, &outcome, &exported);
+    assert_eq!(checks.len(), 3);
+    for check in &checks {
+        assert!(!check.passed, "check '{}' should have failed", check.id);
+    }
+}
+
+#[test]
+fn class_checks_refactoring_detects_simplify_keyword() {
+    let scenario = BenchmarkScenario {
+        class: BenchmarkClass::Refactoring,
+        ..repo_exploration_scenario()
+    };
+    let outcome = dummy_outcome("simplified the match expression", "bland", "bland");
+    let exported = dummy_handoff(0);
+    let checks = class_specific_checks(&scenario, &outcome, &exported);
+    let check = checks
+        .iter()
+        .find(|c| c.id == "refactor-change-identified")
+        .unwrap();
+    assert!(check.passed);
+}
+
+#[test]
+fn class_checks_refactoring_detects_preserve_keyword() {
+    let scenario = BenchmarkScenario {
+        class: BenchmarkClass::Refactoring,
+        ..repo_exploration_scenario()
+    };
+    let outcome = dummy_outcome("bland", "bland", "behavior is preserved after change");
+    let exported = dummy_handoff(0);
+    let checks = class_specific_checks(&scenario, &outcome, &exported);
+    let check = checks
+        .iter()
+        .find(|c| c.id == "refactor-behavior-preserved")
+        .unwrap();
+    assert!(check.passed);
+}
+
+// -- Coverage distribution checks --
+
+#[test]
+fn benchmark_scenarios_each_class_has_at_least_two() {
+    let scenarios = benchmark_scenarios();
+    let count = |class: BenchmarkClass| scenarios.iter().filter(|s| s.class == class).count();
+    assert!(count(BenchmarkClass::RepoExploration) >= 2);
+    assert!(count(BenchmarkClass::Documentation) >= 2);
+    assert!(count(BenchmarkClass::SafeCodeChange) >= 2);
+    assert!(count(BenchmarkClass::SessionQuality) >= 2);
+    assert!(count(BenchmarkClass::TestWriting) >= 2);
+    assert!(count(BenchmarkClass::BugFix) >= 2);
+    assert!(count(BenchmarkClass::Refactoring) >= 2);
+}
+
+#[test]
+fn benchmark_scenarios_multi_process_coverage() {
+    let multi = benchmark_scenarios()
+        .iter()
+        .filter(|s| s.topology == RuntimeTopology::MultiProcess)
+        .count();
+    assert!(
+        multi >= 2,
+        "need at least 2 MultiProcess scenarios, got {multi}"
+    );
+}
+
+#[test]
+fn benchmark_scenarios_copilot_sdk_coverage() {
+    let copilot = benchmark_scenarios()
+        .iter()
+        .filter(|s| s.base_type == "copilot-sdk")
+        .count();
+    assert!(
+        copilot >= 2,
+        "need at least 2 copilot-sdk scenarios, got {copilot}"
+    );
 }

--- a/src/gym/tests_scenarios.rs
+++ b/src/gym/tests_scenarios.rs
@@ -584,10 +584,7 @@ fn class_checks_bug_fix_detects_convert_for_fix() {
     let outcome = dummy_outcome("bland", "convert the call to use ? operator", "bland");
     let exported = dummy_handoff(0);
     let checks = class_specific_checks(&scenario, &outcome, &exported);
-    let check = checks
-        .iter()
-        .find(|c| c.id == "bug-fix-described")
-        .unwrap();
+    let check = checks.iter().find(|c| c.id == "bug-fix-described").unwrap();
     assert!(check.passed);
 }
 

--- a/src/gym/tests_types.rs
+++ b/src/gym/tests_types.rs
@@ -16,6 +16,8 @@ fn benchmark_class_display_all_variants() {
         "session-quality"
     );
     assert_eq!(BenchmarkClass::TestWriting.to_string(), "test-writing");
+    assert_eq!(BenchmarkClass::BugFix.to_string(), "bug-fix");
+    assert_eq!(BenchmarkClass::Refactoring.to_string(), "refactoring");
 }
 
 #[test]
@@ -39,6 +41,10 @@ fn benchmark_class_serializes_to_kebab_case() {
     assert!(json.contains("safe-code-change"));
     let json = serde_json::to_string(&BenchmarkClass::TestWriting).unwrap();
     assert!(json.contains("test-writing"));
+    let json = serde_json::to_string(&BenchmarkClass::BugFix).unwrap();
+    assert!(json.contains("bug-fix"));
+    let json = serde_json::to_string(&BenchmarkClass::Refactoring).unwrap();
+    assert!(json.contains("refactoring"));
 }
 
 #[test]


### PR DESCRIPTION
Closes #224

## Changes

Expands the gym evaluation suite from 9 scenarios / 5 classes to **15 scenarios / 7 classes**.

### New `BenchmarkClass` variants
- **`BugFix`** — defect identification, fix description, safety analysis
- **`Refactoring`** — structural change identification, behavior preservation, code examples

### New scenarios (6)
| ID | Class | Base Type | Topology |
|----|-------|-----------|----------|
| `test-writing-edge-cases` | TestWriting | local-harness | SingleProcess |
| `bug-fix-error-propagation` | BugFix | local-harness | SingleProcess |
| `bug-fix-off-by-one` | BugFix | copilot-sdk | SingleProcess |
| `refactor-extract-function` | Refactoring | local-harness | SingleProcess |
| `refactor-simplify-match` | Refactoring | local-harness | SingleProcess |
| `repo-exploration-multi-process` | RepoExploration | rusty-clawd | MultiProcess |

### Coverage improvements
- Every BenchmarkClass has ≥ 2 scenarios (TestWriting was 1)
- MultiProcess topology: 2 scenarios (was 1)
- copilot-sdk base type: 2 scenarios (was 1)
- simard-engineer identity: 2 scenarios (was 1)

### Tests
- All 233 gym tests pass
- New tests for BugFix and Refactoring class_specific_checks (pass/fail/keyword)
- Coverage distribution assertions (class minimum, topology, base type)