### PR TITLE
fix: remove hardcoded identity and project fallbacks from meeting live_context

### DIFF
--- a/src/operator_commands_meeting/live_context.rs
+++ b/src/operator_commands_meeting/live_context.rs
@@ -1,12 +1,42 @@
 use crate::memory_bridge::CognitiveMemoryBridge;
 
+/// Search the bridge for facts matching `query`, logging a warning on failure.
+///
+/// Returns the matching facts, or an empty `Vec` when the bridge call fails
+/// (after logging the error so operators can diagnose memory issues).
+fn search_or_warn(
+    bridge: &CognitiveMemoryBridge,
+    query: &str,
+    limit: u32,
+) -> Vec<crate::memory_cognitive::CognitiveFact> {
+    match bridge.search_facts(query, limit, 0.0) {
+        Ok(facts) => facts,
+        Err(e) => {
+            eprintln!("[simard] live_context: memory search failed for \"{query}\": {e}");
+            Vec::new()
+        }
+    }
+}
+
+/// Resolve the operator display name.
+///
+/// Precedence:
+/// 1. `SIMARD_OPERATOR_NAME` environment variable (if set and non-empty)
+/// 2. Falls back to `"operator"`
+fn resolve_operator_name() -> String {
+    std::env::var("SIMARD_OPERATOR_NAME")
+        .ok()
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| "operator".to_string())
+}
+
 /// Build live context from cognitive memory, goals, and project state to
 /// enrich the meeting system prompt so Simard knows her own state.
 pub(super) fn build_live_meeting_context(bridge: &CognitiveMemoryBridge) -> String {
     let mut sections = Vec::new();
 
     // Recent meeting summaries (decisions from past meetings)
-    let past_meetings = bridge.search_facts("meeting:", 10, 0.0).unwrap_or_default();
+    let past_meetings = search_or_warn(bridge, "meeting:", 10);
     if !past_meetings.is_empty() {
         let mut meeting_text = String::from("## Previous Meeting Summaries\n");
         for (i, m) in past_meetings.iter().enumerate().take(5) {
@@ -16,9 +46,7 @@ pub(super) fn build_live_meeting_context(bridge: &CognitiveMemoryBridge) -> Stri
     }
 
     // Recent decisions from meetings (individually stored by REPL)
-    let past_decisions = bridge
-        .search_facts("decision:", 10, 0.0)
-        .unwrap_or_default();
+    let past_decisions = search_or_warn(bridge, "decision:", 10);
     if !past_decisions.is_empty() {
         let mut dec_text = String::from("## Past Decisions\n");
         for (i, d) in past_decisions.iter().enumerate().take(10) {
@@ -28,7 +56,7 @@ pub(super) fn build_live_meeting_context(bridge: &CognitiveMemoryBridge) -> Stri
     }
 
     // Active goals
-    let goals = bridge.search_facts("goal:", 10, 0.0).unwrap_or_default();
+    let goals = search_or_warn(bridge, "goal:", 10);
     if !goals.is_empty() {
         let mut goal_text = String::from("## Active Goals\n");
         for (i, g) in goals.iter().enumerate().take(5) {
@@ -37,8 +65,8 @@ pub(super) fn build_live_meeting_context(bridge: &CognitiveMemoryBridge) -> Stri
         sections.push(goal_text);
     }
 
-    // Operator identity
-    let operator = bridge.search_facts("operator:", 3, 0.0).unwrap_or_default();
+    // Operator identity — from memory, env var, or generic fallback (never hardcoded name)
+    let operator = search_or_warn(bridge, "operator:", 3);
     if !operator.is_empty() {
         let mut op_text = String::from("## Operator Context\n");
         for fact in &operator {
@@ -46,36 +74,23 @@ pub(super) fn build_live_meeting_context(bridge: &CognitiveMemoryBridge) -> Stri
         }
         sections.push(op_text);
     } else {
-        sections.push(
-            "## Operator Context\nYour operator is Ryan Sweet (GitHub: rysweet). \
-             He is your creator and principal architect. He manages the Simard, \
-             RustyClawd, amplihack, and azlin repositories.\n"
-                .to_string(),
-        );
+        let name = resolve_operator_name();
+        sections.push(format!("## Operator Context\nYour operator is {name}.\n"));
     }
 
-    // Known projects
-    let projects = bridge.search_facts("project:", 10, 0.0).unwrap_or_default();
+    // Known projects — only shown when memory has project facts
+    let projects = search_or_warn(bridge, "project:", 10);
     if !projects.is_empty() {
         let mut proj_text = String::from("## Known Projects\n");
         for p in &projects {
             proj_text.push_str(&format!("- {}\n", p.content));
         }
         sections.push(proj_text);
-    } else {
-        sections.push(
-            "## Known Projects\n\
-             - Simard (this project) — autonomous engineering agent in Rust\n\
-             - RustyClawd — LLM + tool calling SDK\n\
-             - amplihack — agentic coding framework\n\
-             - azlin — Azure VM orchestration CLI\n\
-             - amplihack-memory-lib — 6-type cognitive memory system\n"
-                .to_string(),
-        );
     }
+    // No hardcoded fallback — if memory has no projects, the section is omitted.
 
     // Research tracker / watched developers
-    let research = bridge.search_facts("research:", 5, 0.0).unwrap_or_default();
+    let research = search_or_warn(bridge, "research:", 5);
     if !research.is_empty() {
         let mut res_text = String::from("## Research Topics\n");
         for r in &research {
@@ -85,9 +100,7 @@ pub(super) fn build_live_meeting_context(bridge: &CognitiveMemoryBridge) -> Stri
     }
 
     // Recent improvements
-    let improvements = bridge
-        .search_facts("improvement:", 5, 0.0)
-        .unwrap_or_default();
+    let improvements = search_or_warn(bridge, "improvement:", 5);
     if !improvements.is_empty() {
         let mut imp_text = String::from("## Improvement Backlog\n");
         for imp in &improvements {

--- a/src/operator_commands_meeting/tests_live_context.rs
+++ b/src/operator_commands_meeting/tests_live_context.rs
@@ -1,10 +1,18 @@
 use super::live_context::*;
 use super::test_support::*;
 
+/// Mutex to serialize tests that mutate environment variables. `set_var` /
+/// `remove_var` are process-global so concurrent tests would race.
+static ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 // ── build_live_meeting_context ──────────────────────────────────────
 
 #[test]
 fn defaults_with_empty_bridge() {
+    let _lock = ENV_MUTEX.lock().unwrap();
+    // Ensure the env var is unset so we test the true default path.
+    unsafe { std::env::remove_var("SIMARD_OPERATOR_NAME") };
+
     let bridge = empty_bridge();
     let ctx = build_live_meeting_context(&bridge);
 
@@ -16,14 +24,53 @@ fn defaults_with_empty_bridge() {
         ctx.contains("## Operator Context"),
         "expected default operator section"
     );
-    assert!(ctx.contains("Ryan Sweet"), "expected default operator name");
+    // No hardcoded personal names — falls back to env var or "operator"
     assert!(
-        ctx.contains("## Known Projects"),
-        "expected default projects section"
+        !ctx.contains("Ryan Sweet"),
+        "must not contain hardcoded personal name"
     );
     assert!(
-        ctx.contains("Simard"),
-        "expected Simard in default projects"
+        ctx.contains("operator"),
+        "expected generic operator fallback"
+    );
+    // No hardcoded project list when memory is empty
+    assert!(
+        !ctx.contains("## Known Projects"),
+        "projects section should be omitted when memory has no project facts"
+    );
+}
+
+#[test]
+fn empty_bridge_uses_env_var_operator_name() {
+    let _lock = ENV_MUTEX.lock().unwrap();
+    // SAFETY: Serialized by ENV_MUTEX; restored immediately after use.
+    unsafe { std::env::set_var("SIMARD_OPERATOR_NAME", "Test User") };
+    let bridge = empty_bridge();
+    let ctx = build_live_meeting_context(&bridge);
+    unsafe { std::env::remove_var("SIMARD_OPERATOR_NAME") };
+
+    assert!(
+        ctx.contains("Test User"),
+        "expected operator name from SIMARD_OPERATOR_NAME env var"
+    );
+    assert!(
+        !ctx.contains("Ryan Sweet"),
+        "must not contain hardcoded name"
+    );
+}
+
+#[test]
+fn empty_env_var_falls_back_to_generic() {
+    let _lock = ENV_MUTEX.lock().unwrap();
+    // SAFETY: Serialized by ENV_MUTEX; restored immediately after use.
+    unsafe { std::env::set_var("SIMARD_OPERATOR_NAME", "") };
+    let bridge = empty_bridge();
+    let ctx = build_live_meeting_context(&bridge);
+    unsafe { std::env::remove_var("SIMARD_OPERATOR_NAME") };
+
+    assert!(
+        ctx.contains("Your operator is operator"),
+        "empty env var should fall back to generic 'operator'"
     );
 }
 
@@ -82,7 +129,7 @@ fn includes_operator_facts() {
         ctx.contains("Custom operator identity"),
         "expected operator content from bridge"
     );
-    // Should NOT contain the default operator text when bridge provides facts
+    // Should NOT contain any fallback operator text when bridge provides facts
     assert!(
         !ctx.contains("Ryan Sweet"),
         "should not contain default operator when bridge provides custom operator"
@@ -151,7 +198,7 @@ fn with_all_fact_types() {
 fn has_live_state_header() {
     let bridge = empty_bridge();
     let ctx = build_live_meeting_context(&bridge);
-    // Even with only defaults, the sections are present so it uses the live header
+    // Even with only the operator fallback, the section is present so it uses the live header
     assert!(ctx.starts_with("## Live State"));
 }
 
@@ -208,26 +255,32 @@ fn empty_bridge_returns_empty_search_results() {
 // ── structural checks ──────────────────────────────────────────────
 
 #[test]
-fn empty_bridge_has_at_least_two_sections() {
+fn empty_bridge_has_operator_section_only() {
     let bridge = empty_bridge();
     let ctx = build_live_meeting_context(&bridge);
-    // Even with empty bridge, default operator and projects sections appear
+    // With empty bridge, only the operator fallback section appears (no hardcoded projects)
+    assert!(ctx.contains("## Operator Context"));
+    assert!(!ctx.contains("## Known Projects"));
     let section_count = ctx.matches("## ").count();
+    // Live State header + Operator Context = at least 2
     assert!(
         section_count >= 2,
-        "expected at least 2 sections, got {section_count}"
+        "expected at least 2 sections (header + operator), got {section_count}"
     );
 }
 
 #[test]
-fn empty_bridge_includes_known_projects() {
+fn empty_bridge_omits_hardcoded_projects() {
     let bridge = empty_bridge();
     let ctx = build_live_meeting_context(&bridge);
     assert!(
-        ctx.contains("RustyClawd"),
-        "expected RustyClawd in defaults"
+        !ctx.contains("RustyClawd"),
+        "must not contain hardcoded project names"
     );
-    assert!(ctx.contains("amplihack"), "expected amplihack in defaults");
+    assert!(
+        !ctx.contains("amplihack-memory-lib"),
+        "must not contain hardcoded project names"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Fixes #222

### Changes
- **Removed hardcoded operator identity**: `SIMARD_OPERATOR_NAME` env var → fallback to generic `"operator"`
- **Removed hardcoded project list**: omitted when memory has no project facts
- **Added `search_or_warn()` helper**: replaces 7 silent `.unwrap_or_default()` calls with logged warnings
- **Updated tests**: 5 new/updated tests covering empty memory, env var behavior, and no-projects paths

All 31 module tests pass.