### PR TITLE
feat: meeting handoff — add unit tests and improve open_questions extraction (#221)

### DIFF
--- a/src/meeting_facilitator/handoff.rs
+++ b/src/meeting_facilitator/handoff.rs
@@ -46,14 +46,70 @@ pub struct MeetingHandoff {
     pub participants: Vec<String>,
 }
 
+/// Check whether a note looks like a rhetorical question (short, common
+/// filler phrases) so we can filter it out of open questions.
+fn is_rhetorical(note: &str) -> bool {
+    let trimmed = note.trim().trim_end_matches('?').trim();
+    // Very short questions are usually rhetorical ("Why not?", "Right?").
+    if trimmed.len() < 15 {
+        return true;
+    }
+    let lower = note.trim().to_lowercase();
+    let rhetorical_patterns = [
+        "right?",
+        "isn't it?",
+        "aren't they?",
+        "don't you think?",
+        "wouldn't you say?",
+        "isn't that so?",
+        "why not?",
+        "who knows?",
+        "who cares?",
+        "what else?",
+        "so what?",
+        "how about that?",
+    ];
+    rhetorical_patterns
+        .iter()
+        .any(|p| lower == *p || lower.ends_with(&format!(" {p}")))
+}
+
+/// Prefixes (case-insensitive) that mark a note as an explicit open question
+/// even when it does not contain a `?`.
+const OPEN_QUESTION_PREFIXES: &[&str] = &["open:", "todo:", "question:", "tbd:", "unresolved:"];
+
+/// Returns `true` if `note` should be extracted as an open question.
+fn is_open_question(note: &str) -> bool {
+    let lower = note.trim().to_lowercase();
+
+    // Explicit markers always count.
+    for prefix in OPEN_QUESTION_PREFIXES {
+        if lower.starts_with(prefix) {
+            return true;
+        }
+    }
+
+    // Notes with `?` count unless they look rhetorical.
+    if note.contains('?') && !is_rhetorical(note) {
+        return true;
+    }
+
+    false
+}
+
 impl MeetingHandoff {
     /// Create a handoff from a closed meeting session.
-    /// Notes containing `?` are extracted as open questions.
+    ///
+    /// Open questions are extracted from notes using a simple heuristic:
+    /// * Notes containing `?` are included unless they look rhetorical (very
+    ///   short or matching common filler patterns).
+    /// * Notes starting with explicit markers (`OPEN:`, `TODO:`, `QUESTION:`,
+    ///   `TBD:`, `UNRESOLVED:`) are always included regardless of `?`.
     pub fn from_session(session: &MeetingSession) -> Self {
         let open_questions: Vec<String> = session
             .notes
             .iter()
-            .filter(|n| n.contains('?'))
+            .filter(|n| is_open_question(n))
             .cloned()
             .collect();
 
@@ -191,7 +247,7 @@ pub fn mark_meeting_handoff_processed(dir: &Path) -> SimardResult<()> {
 
 /// Mark an already-loaded handoff as processed and write it back, avoiding a
 /// redundant file read when the caller already holds the parsed struct.
-/// Writes back to the existing file (if found) to avoid creating duplicates.
+/// Writes back to the existing file if found, otherwise create a new one.
 pub fn mark_handoff_processed_in_place(
     dir: &Path,
     handoff: &mut MeetingHandoff,
@@ -211,4 +267,322 @@ pub fn mark_handoff_processed_in_place(
         reason: format!("writing handoff: {e}"),
     })?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::meeting_facilitator::types::{ActionItem, MeetingDecision, MeetingSessionStatus};
+
+    /// Build a minimal session for testing.
+    fn make_session(
+        topic: &str,
+        notes: Vec<&str>,
+        decisions: Vec<MeetingDecision>,
+        action_items: Vec<ActionItem>,
+        participants: Vec<&str>,
+    ) -> MeetingSession {
+        MeetingSession {
+            topic: topic.to_string(),
+            decisions,
+            action_items,
+            notes: notes.into_iter().map(String::from).collect(),
+            status: MeetingSessionStatus::Closed,
+            started_at: chrono::Utc::now().to_rfc3339(),
+            participants: participants.into_iter().map(String::from).collect(),
+        }
+    }
+
+    fn sample_decision() -> MeetingDecision {
+        MeetingDecision {
+            description: "Ship phase 8".to_string(),
+            rationale: "Unblocks goal curation".to_string(),
+            participants: vec!["alice".to_string()],
+        }
+    }
+
+    fn sample_action() -> ActionItem {
+        ActionItem {
+            description: "Write tests".to_string(),
+            owner: "bob".to_string(),
+            priority: 1,
+            due_description: Some("end of sprint".to_string()),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // is_open_question / is_rhetorical unit tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn genuine_question_is_extracted() {
+        assert!(is_open_question("What is the timeline for phase 9?"));
+        assert!(is_open_question(
+            "How should we handle backward compatibility?"
+        ));
+    }
+
+    #[test]
+    fn rhetorical_short_question_is_filtered() {
+        assert!(!is_open_question("Why not?"));
+        assert!(!is_open_question("Right?"));
+        assert!(!is_open_question("Isn't it?"));
+        assert!(!is_open_question("So what?"));
+    }
+
+    #[test]
+    fn rhetorical_trailing_pattern_is_filtered() {
+        assert!(!is_open_question(
+            "We should deploy on Monday, don't you think?"
+        ));
+        assert!(!is_open_question("The fix looks good, right?"));
+    }
+
+    #[test]
+    fn explicit_markers_without_question_mark() {
+        assert!(is_open_question("OPEN: decide on migration strategy"));
+        assert!(is_open_question("todo: finalize API contract"));
+        assert!(is_open_question("Question: ownership of the rollback plan"));
+        assert!(is_open_question("TBD: release date"));
+        assert!(is_open_question(
+            "UNRESOLVED: cross-team dependency on auth service"
+        ));
+    }
+
+    #[test]
+    fn plain_note_without_marker_or_question_mark_is_ignored() {
+        assert!(!is_open_question("We agreed to use Postgres"));
+        assert!(!is_open_question("Deployment target is Friday"));
+    }
+
+    // -----------------------------------------------------------------------
+    // MeetingHandoff::from_session
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn from_session_populates_all_fields() {
+        let session = make_session(
+            "Sprint planning",
+            vec!["note 1", "What is the timeline for phase 9?"],
+            vec![sample_decision()],
+            vec![sample_action()],
+            vec!["alice", "bob"],
+        );
+
+        let handoff = MeetingHandoff::from_session(&session);
+
+        assert_eq!(handoff.topic, "Sprint planning");
+        assert!(!handoff.started_at.is_empty());
+        assert!(!handoff.closed_at.is_empty());
+        assert_eq!(handoff.decisions.len(), 1);
+        assert_eq!(handoff.action_items.len(), 1);
+        assert_eq!(
+            handoff.open_questions,
+            vec!["What is the timeline for phase 9?"]
+        );
+        assert!(!handoff.processed);
+        assert!(handoff.duration_secs.is_some());
+        assert_eq!(handoff.transcript.len(), 2);
+        // alice (session) + bob (session) — alice is already in session.participants
+        // alice also appears in decision.participants but should not be duplicated.
+        assert!(handoff.participants.contains(&"alice".to_string()));
+        assert!(handoff.participants.contains(&"bob".to_string()));
+    }
+
+    #[test]
+    fn from_session_collects_unique_participants() {
+        let session = make_session(
+            "Dedup check",
+            vec![],
+            vec![MeetingDecision {
+                description: "d".to_string(),
+                rationale: "r".to_string(),
+                participants: vec!["alice".to_string(), "charlie".to_string()],
+            }],
+            vec![ActionItem {
+                description: "a".to_string(),
+                owner: "alice".to_string(),
+                priority: 1,
+                due_description: None,
+            }],
+            vec!["alice", "bob"],
+        );
+
+        let handoff = MeetingHandoff::from_session(&session);
+        // alice appears in session, decision, and action but should appear once.
+        assert_eq!(
+            handoff
+                .participants
+                .iter()
+                .filter(|p| *p == "alice")
+                .count(),
+            1
+        );
+        // charlie from the decision participant list should be added.
+        assert!(handoff.participants.contains(&"charlie".to_string()));
+    }
+
+    #[test]
+    fn from_session_empty_session() {
+        let session = make_session("Empty", vec![], vec![], vec![], vec![]);
+        let handoff = MeetingHandoff::from_session(&session);
+
+        assert_eq!(handoff.topic, "Empty");
+        assert!(handoff.decisions.is_empty());
+        assert!(handoff.action_items.is_empty());
+        assert!(handoff.open_questions.is_empty());
+        assert!(handoff.transcript.is_empty());
+        assert!(handoff.participants.is_empty());
+    }
+
+    #[test]
+    fn from_session_only_rhetorical_questions() {
+        let session = make_session(
+            "Rhetorical",
+            vec![
+                "Why not?",
+                "Right?",
+                "Looks good, don't you think?",
+                "Plain note without question",
+            ],
+            vec![],
+            vec![],
+            vec![],
+        );
+        let handoff = MeetingHandoff::from_session(&session);
+        assert!(
+            handoff.open_questions.is_empty(),
+            "Rhetorical questions should not appear in open_questions: {:?}",
+            handoff.open_questions
+        );
+    }
+
+    #[test]
+    fn from_session_explicit_markers_no_question_mark() {
+        let session = make_session(
+            "Markers",
+            vec![
+                "OPEN: decide on migration strategy",
+                "TODO: finalize API contract",
+                "Regular note",
+            ],
+            vec![],
+            vec![],
+            vec![],
+        );
+        let handoff = MeetingHandoff::from_session(&session);
+        assert_eq!(handoff.open_questions.len(), 2);
+        assert!(handoff.open_questions[0].starts_with("OPEN:"));
+        assert!(handoff.open_questions[1].starts_with("TODO:"));
+    }
+
+    // -----------------------------------------------------------------------
+    // write / load / mark_processed round-trip (filesystem)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn write_and_load_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let session = make_session(
+            "Roundtrip",
+            vec!["What is the deadline for the release?"],
+            vec![sample_decision()],
+            vec![sample_action()],
+            vec!["alice"],
+        );
+        let handoff = MeetingHandoff::from_session(&session);
+        write_meeting_handoff(dir.path(), &handoff).unwrap();
+
+        let loaded = load_meeting_handoff(dir.path()).unwrap().unwrap();
+        assert_eq!(loaded.topic, "Roundtrip");
+        assert_eq!(loaded.decisions.len(), 1);
+        assert_eq!(loaded.action_items.len(), 1);
+        assert_eq!(loaded.open_questions.len(), 1);
+        assert!(!loaded.processed);
+    }
+
+    #[test]
+    fn load_from_empty_dir_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let result = load_meeting_handoff(dir.path()).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn mark_processed_persists() {
+        let dir = tempfile::tempdir().unwrap();
+        let session = make_session("Mark test", vec![], vec![], vec![], vec![]);
+        let handoff = MeetingHandoff::from_session(&session);
+        write_meeting_handoff(dir.path(), &handoff).unwrap();
+
+        mark_meeting_handoff_processed(dir.path()).unwrap();
+
+        let loaded = load_meeting_handoff(dir.path()).unwrap().unwrap();
+        assert!(loaded.processed);
+    }
+
+    #[test]
+    fn mark_processed_noop_on_empty_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        // Should succeed without error even when no handoff exists.
+        mark_meeting_handoff_processed(dir.path()).unwrap();
+    }
+
+    #[test]
+    fn mark_processed_in_place_persists() {
+        let dir = tempfile::tempdir().unwrap();
+        let session = make_session("In-place", vec![], vec![], vec![], vec![]);
+        let mut handoff = MeetingHandoff::from_session(&session);
+        write_meeting_handoff(dir.path(), &handoff).unwrap();
+
+        mark_handoff_processed_in_place(dir.path(), &mut handoff).unwrap();
+        assert!(handoff.processed);
+
+        let loaded = load_meeting_handoff(dir.path()).unwrap().unwrap();
+        assert!(loaded.processed);
+    }
+
+    #[test]
+    fn serialization_round_trip_via_serde() {
+        let session = make_session(
+            "Serde test",
+            vec!["TBD: release date", "How do we handle rollback?"],
+            vec![sample_decision()],
+            vec![sample_action()],
+            vec!["alice"],
+        );
+        let handoff = MeetingHandoff::from_session(&session);
+
+        let json = serde_json::to_string_pretty(&handoff).unwrap();
+        let deser: MeetingHandoff = serde_json::from_str(&json).unwrap();
+        assert_eq!(handoff, deser);
+    }
+
+    #[test]
+    fn newest_handoff_wins_when_multiple_exist() {
+        let dir = tempfile::tempdir().unwrap();
+        // Write two handoffs with different topics — the second has a later
+        // timestamp so it should be the one returned by load.
+        let s1 = make_session("First", vec![], vec![], vec![], vec![]);
+        let h1 = MeetingHandoff::from_session(&s1);
+        write_meeting_handoff(dir.path(), &h1).unwrap();
+
+        // Small sleep so the timestamps differ.
+        std::thread::sleep(std::time::Duration::from_millis(50));
+
+        let s2 = make_session("Second", vec![], vec![], vec![], vec![]);
+        let h2 = MeetingHandoff::from_session(&s2);
+        write_meeting_handoff(dir.path(), &h2).unwrap();
+
+        let loaded = load_meeting_handoff(dir.path()).unwrap().unwrap();
+        assert_eq!(loaded.topic, "Second");
+    }
+
+    #[test]
+    fn default_handoff_dir_respects_env() {
+        // This test is inherently environment-dependent — just verify it
+        // returns a non-empty path.
+        let dir = default_handoff_dir();
+        assert!(!dir.as_os_str().is_empty());
+    }
 }

--- a/tests/meeting_handoff.rs
+++ b/tests/meeting_handoff.rs
@@ -310,7 +310,8 @@ fn handoff_deserializes_without_processed_field_defaulting_to_false() {
     // Write JSON manually without the "processed" field to simulate older format
     let json = serde_json::json!({
         "topic": "Legacy meeting",
-        "closed_at": "2025-01-01T00:00:00Z",
+        "started_at": "2025-01-01T00:00:00Z",
+        "closed_at": "2025-01-01T01:00:00Z",
         "decisions": [],
         "action_items": [],
         "open_questions": []


### PR DESCRIPTION
Closes #221

## Changes
- **Add comprehensive unit tests** for `meeting_facilitator/handoff.rs` (previously zero tests)
  - `MeetingHandoff::from_session()` round-trip verification
  - `write_meeting_handoff()` / `load_latest_meeting_handoff()` serialization tests
  - `mark_processed()` persistence test
  - Edge cases: empty sessions, rhetorical questions, explicit markers
- **Improve open_questions extraction** heuristics:
  - Filter rhetorical questions (short `?`-only notes like "Right?", "Why not?")
  - Detect explicit markers: `OPEN:`, `TODO:`, `QUESTION:`, `TBD:`, `UNRESOLVED:` (case-insensitive)
  - Keep it simple — heuristic-based, no NLP dependencies