### PR TITLE
feat: wire memory consolidation phases into session lifecycle (#234)

### DIFF
--- a/.claude/context/PROJECT.md
+++ b/.claude/context/PROJECT.md
@@ -10,7 +10,7 @@ Replace the sections below with information about your project.
 
 ---
 
-## Project: Simard
+## Project: memory-lifecycle
 
 ## Overview
 

--- a/.claude/context/PROJECT.md.bak
+++ b/.claude/context/PROJECT.md.bak
@@ -10,7 +10,7 @@ Replace the sections below with information about your project.
 
 ---
 
-## Project: Simard
+## Project: memory-lifecycle
 
 ## Overview
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3023,6 +3023,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "tracing",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ serde_json = "1.0.145"
 tokio = { version = "1", features = ["rt", "process", "io-util", "time"] }
 uuid = { version = "1.18.1", features = ["v7"] }
 chrono = "0.4"
+tracing = "0.1"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/src/memory_bridge_adapter/convert.rs
+++ b/src/memory_bridge_adapter/convert.rs
@@ -44,9 +44,9 @@ pub(super) fn fact_to_record(fact: &CognitiveFact) -> MemoryRecord {
         .iter()
         .find_map(|t| parse_scope_tag(t))
         .unwrap_or_else(|| {
-            eprintln!(
-                "[simard] cognitive-bridge: fact {:?} missing scope tag, defaulting to Untagged",
-                fact.concept
+            tracing::warn!(
+                concept = %fact.concept,
+                "fact missing scope tag, defaulting to Untagged"
             );
             MemoryScope::Untagged
         });
@@ -55,9 +55,9 @@ pub(super) fn fact_to_record(fact: &CognitiveFact) -> MemoryRecord {
         .iter()
         .find_map(|t| parse_session_tag(t))
         .unwrap_or_else(|| {
-            eprintln!(
-                "[simard] cognitive-bridge: fact {:?} missing session tag, using nil UUID",
-                fact.concept
+            tracing::warn!(
+                concept = %fact.concept,
+                "fact missing session tag, using nil UUID"
             );
             SessionId::from_uuid(uuid::Uuid::nil())
         });

--- a/src/ooda_loop/mod.rs
+++ b/src/ooda_loop/mod.rs
@@ -33,6 +33,7 @@ use crate::error::SimardResult;
 use crate::goal_curation::load_goal_board;
 use crate::gym_bridge::ScoreDimensions;
 use crate::gym_scoring::GymSuiteScore;
+use crate::memory_consolidation;
 use crate::self_improve::{ImprovementCycle, ImprovementPhase};
 
 /// Act: dispatch actions. Failures are per-action, not cycle-wide (Pillar 11).
@@ -89,6 +90,22 @@ pub fn run_ooda_cycle(
         _ => {}
     }
 
+    // --- Memory consolidation: intake at cycle start ---
+    let cycle_session_id = crate::session::SessionId::from_uuid(uuid::Uuid::now_v7());
+    let cycle_objective = state
+        .active_goals
+        .active
+        .first()
+        .map(|g| g.description.clone())
+        .unwrap_or_else(|| "ooda-cycle".to_string());
+    if let Err(e) = memory_consolidation::intake_memory_operations(
+        &cycle_objective,
+        &cycle_session_id,
+        &bridges.memory,
+    ) {
+        eprintln!("[simard] OODA consolidation: intake failed: {e}");
+    }
+
     // --- Observe ---
     state.current_phase = OodaPhase::Observe;
     eprintln!("[simard] OODA cycle: entering Observe phase");
@@ -103,6 +120,15 @@ pub fn run_ooda_cycle(
         "[simard] OODA cycle: Orient complete ({} priorities)",
         priorities.len()
     );
+
+    // --- Memory consolidation: preparation (cross-session recall) ---
+    if let Err(e) = memory_consolidation::preparation_memory_operations(
+        &cycle_objective,
+        &cycle_session_id,
+        &bridges.memory,
+    ) {
+        eprintln!("[simard] OODA consolidation: preparation failed: {e}");
+    }
 
     // --- Decide ---
     state.current_phase = OodaPhase::Decide;
@@ -127,6 +153,23 @@ pub fn run_ooda_cycle(
 
     // --- Review: analyze outcomes and propose improvements ---
     let review_proposals = review::review_outcomes(&outcomes, act_elapsed);
+
+    // --- Memory consolidation: reflection ---
+    {
+        let transcript = outcomes
+            .iter()
+            .map(|o| format!("{}: {}", o.action.description, o.detail))
+            .collect::<Vec<_>>()
+            .join("\n");
+        if let Err(e) = memory_consolidation::reflection_memory_operations(
+            &transcript,
+            &[],
+            &cycle_session_id,
+            &bridges.memory,
+        ) {
+            eprintln!("[simard] OODA consolidation: reflection failed: {e}");
+        }
+    }
 
     // --- Consolidate: best-effort memory maintenance after each cycle ---
     if let Err(e) = bridges.memory.consolidate_episodes(10) {
@@ -203,6 +246,13 @@ pub fn run_ooda_cycle(
     // Persist the updated board to cognitive memory (best-effort).
     if let Err(e) = crate::goal_curation::persist_board(&state.active_goals, &bridges.memory) {
         eprintln!("[simard] OODA curate: failed to persist goal board: {e}");
+    }
+
+    // --- Memory consolidation: persistence at cycle end ---
+    if let Err(e) =
+        memory_consolidation::persistence_memory_operations(&cycle_session_id, &bridges.memory)
+    {
+        eprintln!("[simard] OODA consolidation: persistence failed: {e}");
     }
 
     state.cycle_count += 1;

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -16,6 +16,7 @@ use std::time::Instant;
 use crate::base_types::BaseTypeFactory;
 use crate::error::{SimardError, SimardResult};
 use crate::handoff::RuntimeHandoffSnapshot;
+use crate::memory_bridge::CognitiveMemoryBridge;
 use crate::prompt_assets::PromptAssetRef;
 use crate::session::SessionRecord;
 
@@ -30,6 +31,8 @@ pub struct RuntimeKernel {
     mailbox_address: RuntimeAddress,
     start_time: Instant,
     subordinates: Vec<crate::runtime_ipc::IpcSubprocessHandle>,
+    /// Optional cognitive memory bridge for consolidation lifecycle hooks.
+    cognitive_bridge: Option<CognitiveMemoryBridge>,
 }
 
 pub type LocalRuntime = RuntimeKernel;
@@ -93,6 +96,7 @@ impl RuntimeKernel {
             mailbox_address,
             start_time: Instant::now(),
             subordinates: Vec::new(),
+            cognitive_bridge: None,
         })
     }
 
@@ -242,6 +246,11 @@ impl RuntimeKernel {
         }
 
         result
+    }
+
+    /// Attach a cognitive memory bridge for session lifecycle consolidation.
+    pub fn set_cognitive_bridge(&mut self, bridge: CognitiveMemoryBridge) {
+        self.cognitive_bridge = Some(bridge);
     }
 
     pub fn export_handoff(&self) -> SimardResult<RuntimeHandoffSnapshot> {

--- a/src/runtime/session.rs
+++ b/src/runtime/session.rs
@@ -17,6 +17,18 @@ impl RuntimeKernel {
         self.transition(RuntimeState::Active)?;
 
         let mut session = self.new_session(objective);
+
+        // --- Memory consolidation: intake at session start ---
+        if let Some(bridge) = &self.cognitive_bridge
+            && let Err(e) = crate::memory_consolidation::intake_memory_operations(
+                &session.objective,
+                &session.id,
+                bridge,
+            )
+        {
+            eprintln!("[simard] session consolidation: intake failed: {e}");
+        }
+
         self.persist_session_scratch(&mut session)?;
         let outcome = self.run_selected_base_type_session(&mut session)?;
         self.record_execution_evidence(&mut session, &outcome)?;
@@ -24,6 +36,15 @@ impl RuntimeKernel {
         let context = self.agent_program_context(&session);
         let reflection = self.build_reflection(&mut session, &outcome, &context)?;
         self.persist_session_summary(&mut session, &outcome, &context)?;
+
+        // --- Memory consolidation: persistence at session end ---
+        if let Some(bridge) = &self.cognitive_bridge
+            && let Err(e) =
+                crate::memory_consolidation::persistence_memory_operations(&session.id, bridge)
+        {
+            eprintln!("[simard] session consolidation: persistence failed: {e}");
+        }
+
         self.complete_session(session, outcome, reflection)
     }
 

--- a/tests/memory_consolidation_lifecycle.rs
+++ b/tests/memory_consolidation_lifecycle.rs
@@ -1,0 +1,343 @@
+//! Integration tests verifying end-to-end session lifecycle triggers
+//! memory consolidation phases.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use serde_json::json;
+use simard::bridge::BridgeErrorPayload;
+use simard::bridge_subprocess::InMemoryBridgeTransport;
+use simard::goal_curation::{ActiveGoal, GoalBoard, GoalProgress};
+use simard::gym_bridge::GymBridge;
+use simard::knowledge_bridge::KnowledgeBridge;
+use simard::memory_bridge::CognitiveMemoryBridge;
+use simard::memory_consolidation::{
+    FactExtraction, consolidation_intake, consolidation_persistence, intake_memory_operations,
+    persistence_memory_operations, preparation_memory_operations, reflection_memory_operations,
+};
+use simard::ooda_loop::{OodaBridges, OodaConfig, OodaState, run_ooda_cycle};
+use simard::session::SessionId;
+
+/// Build a bridge whose transport counts calls per method category.
+fn counting_bridge() -> (CognitiveMemoryBridge, Arc<AtomicU32>) {
+    let call_count = Arc::new(AtomicU32::new(0));
+    let counter = call_count.clone();
+    let transport = InMemoryBridgeTransport::new("lifecycle-test", move |method, _params| {
+        counter.fetch_add(1, Ordering::SeqCst);
+        match method {
+            "memory.record_sensory" => Ok(json!({"id": "sen_1"})),
+            "memory.push_working" => Ok(json!({"id": "wrk_1"})),
+            "memory.store_episode" => Ok(json!({"id": "epi_1"})),
+            "memory.search_facts" => Ok(json!({"facts": []})),
+            "memory.check_triggers" => Ok(json!({"prospectives": []})),
+            "memory.recall_procedure" => Ok(json!({"procedures": []})),
+            "memory.store_fact" => Ok(json!({"id": "sem_1"})),
+            "memory.clear_working" => Ok(json!({"count": 2})),
+            "memory.prune_expired_sensory" => Ok(json!({"count": 0})),
+            "memory.consolidate_episodes" => Ok(json!({"id": null})),
+            _ => Err(BridgeErrorPayload {
+                code: -32601,
+                message: format!("unknown: {method}"),
+            }),
+        }
+    });
+    (CognitiveMemoryBridge::new(Box::new(transport)), call_count)
+}
+
+fn test_session_id() -> SessionId {
+    SessionId::parse("session-01234567-89ab-cdef-0123-456789abcdef").unwrap()
+}
+
+// ============================================================================
+// Test 1: Full session lifecycle triggers all consolidation phases
+// ============================================================================
+
+#[test]
+fn full_session_lifecycle_triggers_all_consolidation_phases() {
+    let (bridge, call_count) = counting_bridge();
+    let sid = test_session_id();
+    let objective = "implement feature X";
+
+    // Phase 1: Intake
+    intake_memory_operations(objective, &sid, &bridge).unwrap();
+    let after_intake = call_count.load(Ordering::SeqCst);
+    assert!(
+        after_intake >= 3,
+        "intake should make at least 3 bridge calls"
+    );
+
+    // Phase 1b: Cross-session recall
+    consolidation_intake(&sid, &bridge).unwrap();
+    let after_consolidation_intake = call_count.load(Ordering::SeqCst);
+    assert!(
+        after_consolidation_intake > after_intake,
+        "consolidation_intake should make at least 1 bridge call"
+    );
+
+    // Phase 2: Preparation
+    let ctx = preparation_memory_operations(objective, &sid, &bridge).unwrap();
+    let after_prep = call_count.load(Ordering::SeqCst);
+    assert!(
+        after_prep > after_consolidation_intake,
+        "preparation should make bridge calls"
+    );
+    // With empty memory, all results should be empty.
+    assert!(ctx.relevant_facts.is_empty());
+    assert!(ctx.triggered_prospectives.is_empty());
+    assert!(ctx.recalled_procedures.is_empty());
+
+    // Phase 3: Reflection
+    let facts = vec![FactExtraction {
+        concept: "rust-ownership".to_string(),
+        content: "Rust uses ownership for memory safety".to_string(),
+        confidence: 0.95,
+    }];
+    reflection_memory_operations("session transcript here", &facts, &sid, &bridge).unwrap();
+    let after_reflection = call_count.load(Ordering::SeqCst);
+    assert!(
+        after_reflection > after_prep,
+        "reflection should make bridge calls"
+    );
+
+    // Phase 4: Persistence
+    consolidation_persistence(&sid, &bridge).unwrap();
+    persistence_memory_operations(&sid, &bridge).unwrap();
+    let after_persistence = call_count.load(Ordering::SeqCst);
+    assert!(
+        after_persistence > after_reflection,
+        "persistence should make bridge calls"
+    );
+}
+
+// ============================================================================
+// Test 2: OODA cycle triggers consolidation phases end-to-end
+// ============================================================================
+
+fn full_mock_memory_transport() -> InMemoryBridgeTransport {
+    InMemoryBridgeTransport::new("ooda-lifecycle-test", |method, _params| match method {
+        "memory.search_facts" => Ok(json!({"facts": []})),
+        "memory.store_fact" => Ok(json!({"id": "sem_1"})),
+        "memory.store_episode" => Ok(json!({"id": "epi_1"})),
+        "memory.get_statistics" => Ok(json!({
+            "sensory_count": 5, "working_count": 3, "episodic_count": 12,
+            "semantic_count": 8, "procedural_count": 2, "prospective_count": 1
+        })),
+        "memory.consolidate_episodes" => Ok(json!({"id": null})),
+        "memory.recall_procedure" => Ok(json!({
+            "procedures": []
+        })),
+        "memory.record_sensory" => Ok(json!({"id": "sen_1"})),
+        "memory.push_working" => Ok(json!({"id": "wrk_1"})),
+        "memory.check_triggers" => Ok(json!({"prospectives": []})),
+        "memory.clear_working" => Ok(json!({"count": 0})),
+        "memory.prune_expired_sensory" => Ok(json!({"count": 0})),
+        _ => Err(BridgeErrorPayload {
+            code: -32601,
+            message: format!("unknown: {method}"),
+        }),
+    })
+}
+
+#[test]
+fn ooda_cycle_runs_with_consolidation_wired_in() {
+    let bridges = OodaBridges {
+        memory: CognitiveMemoryBridge::new(Box::new(full_mock_memory_transport())),
+        knowledge: KnowledgeBridge::new(Box::new(InMemoryBridgeTransport::new(
+            "test-knowledge",
+            |method, _params| match method {
+                "knowledge.list_packs" => Ok(json!({"packs": []})),
+                _ => Err(BridgeErrorPayload {
+                    code: -32601,
+                    message: format!("unknown: {method}"),
+                }),
+            },
+        ))),
+        gym: GymBridge::new(Box::new(InMemoryBridgeTransport::new(
+            "test-gym",
+            |_method, _params| {
+                Ok(json!({
+                    "suite_id": "progressive", "success": true, "overall_score": 0.75,
+                    "dimensions": {"factual_accuracy": 0.8, "specificity": 0.7,
+                        "temporal_awareness": 0.75, "source_attribution": 0.7,
+                        "confidence_calibration": 0.8},
+                    "scenario_results": [], "scenarios_passed": 6, "scenarios_total": 6,
+                    "degraded_sources": []
+                }))
+            },
+        ))),
+        session: None,
+    };
+
+    let mut board = GoalBoard::new();
+    board.active.push(ActiveGoal {
+        id: "test-goal".to_string(),
+        description: "Test goal for lifecycle".to_string(),
+        priority: 1,
+        status: GoalProgress::NotStarted,
+        assigned_to: None,
+    });
+
+    let mut state = OodaState::new(board);
+    let mut bridges = bridges;
+    let config = OodaConfig::default();
+
+    // The cycle should complete without errors, proving consolidation
+    // phases are wired in and the mock handles all required methods.
+    let report = run_ooda_cycle(&mut state, &mut bridges, &config).unwrap();
+    assert!(report.cycle_number > 0);
+}
+
+// ============================================================================
+// Test 3: Cross-session recall via intake hydration
+// ============================================================================
+
+#[test]
+fn cross_session_recall_hydrates_prior_facts() {
+    let call_count = Arc::new(AtomicU32::new(0));
+    let counter = call_count.clone();
+    let transport = InMemoryBridgeTransport::new("recall-test", move |method, _params| {
+        counter.fetch_add(1, Ordering::SeqCst);
+        match method {
+            "memory.search_facts" => Ok(json!({
+                "facts": [
+                    {
+                        "node_id": "n1",
+                        "concept": "prior-session-fact",
+                        "content": "learned from session A",
+                        "confidence": 0.9,
+                        "source_id": "memory-store-adapter",
+                        "tags": []
+                    },
+                    {
+                        "node_id": "n2",
+                        "concept": "another-prior-fact",
+                        "content": "also from session A",
+                        "confidence": 0.85,
+                        "source_id": "memory-store-adapter",
+                        "tags": []
+                    }
+                ]
+            })),
+            "memory.push_working" => Ok(json!({"id": "wrk_1"})),
+            "memory.store_episode" => Ok(json!({"id": "epi_1"})),
+            "memory.record_sensory" => Ok(json!({"id": "sen_1"})),
+            _ => Err(BridgeErrorPayload {
+                code: -32601,
+                message: format!("unknown: {method}"),
+            }),
+        }
+    });
+    let bridge = CognitiveMemoryBridge::new(Box::new(transport));
+
+    // Start a new session: intake records the objective.
+    let sid = SessionId::parse("session-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee").unwrap();
+    intake_memory_operations("continue prior work", &sid, &bridge).unwrap();
+
+    // Cross-session recall should find 2 prior facts and push summary to
+    // working memory.
+    let hydrated = consolidation_intake(&sid, &bridge).unwrap();
+    assert_eq!(hydrated, 2, "should hydrate 2 prior-session facts");
+
+    // Verify bridge calls: intake (3) + consolidation_intake with facts (3)
+    let total = call_count.load(Ordering::SeqCst);
+    assert!(
+        total >= 6,
+        "intake + consolidation_intake should make >= 6 calls, got {total}"
+    );
+}
+
+// ============================================================================
+// Test 4: Multiple OODA cycles accumulate consolidation
+// ============================================================================
+
+#[test]
+fn multiple_ooda_cycles_accumulate_consolidation() {
+    let call_count = Arc::new(AtomicU32::new(0));
+    let counter = call_count.clone();
+    let transport = InMemoryBridgeTransport::new("multi-cycle-test", move |method, _params| {
+        counter.fetch_add(1, Ordering::SeqCst);
+        match method {
+            "memory.search_facts" => Ok(json!({"facts": []})),
+            "memory.store_fact" => Ok(json!({"id": "sem_1"})),
+            "memory.store_episode" => Ok(json!({"id": "epi_1"})),
+            "memory.get_statistics" => Ok(json!({
+                "sensory_count": 0, "working_count": 0, "episodic_count": 0,
+                "semantic_count": 0, "procedural_count": 0, "prospective_count": 0
+            })),
+            "memory.consolidate_episodes" => Ok(json!({"id": null})),
+            "memory.recall_procedure" => Ok(json!({"procedures": []})),
+            "memory.record_sensory" => Ok(json!({"id": "sen_1"})),
+            "memory.push_working" => Ok(json!({"id": "wrk_1"})),
+            "memory.check_triggers" => Ok(json!({"prospectives": []})),
+            "memory.clear_working" => Ok(json!({"count": 0})),
+            "memory.prune_expired_sensory" => Ok(json!({"count": 0})),
+            _ => Err(BridgeErrorPayload {
+                code: -32601,
+                message: format!("unknown: {method}"),
+            }),
+        }
+    });
+
+    let mut bridges = OodaBridges {
+        memory: CognitiveMemoryBridge::new(Box::new(transport)),
+        knowledge: KnowledgeBridge::new(Box::new(InMemoryBridgeTransport::new(
+            "k",
+            |method, _params| match method {
+                "knowledge.list_packs" => Ok(json!({"packs": []})),
+                _ => Err(BridgeErrorPayload {
+                    code: -32601,
+                    message: format!("unknown: {method}"),
+                }),
+            },
+        ))),
+        gym: GymBridge::new(Box::new(InMemoryBridgeTransport::new(
+            "g",
+            |_method, _params| {
+                Ok(json!({
+                    "suite_id": "progressive", "success": true, "overall_score": 0.9,
+                    "dimensions": {"factual_accuracy": 0.9, "specificity": 0.9,
+                        "temporal_awareness": 0.9, "source_attribution": 0.9,
+                        "confidence_calibration": 0.9},
+                    "scenario_results": [], "scenarios_passed": 1, "scenarios_total": 1,
+                    "degraded_sources": []
+                }))
+            },
+        ))),
+        session: None,
+    };
+
+    let mut board = GoalBoard::new();
+    board.active.push(ActiveGoal {
+        id: "g1".to_string(),
+        description: "Accumulation test".to_string(),
+        priority: 1,
+        status: GoalProgress::InProgress { percent: 50 },
+        assigned_to: None,
+    });
+
+    let mut state = OodaState::new(board);
+    let config = OodaConfig::default();
+
+    // Run two cycles — both should succeed.
+    let r1 = run_ooda_cycle(&mut state, &mut bridges, &config).unwrap();
+    let calls_after_first = call_count.load(Ordering::SeqCst);
+
+    let r2 = run_ooda_cycle(&mut state, &mut bridges, &config).unwrap();
+    let calls_after_second = call_count.load(Ordering::SeqCst);
+
+    assert_eq!(r1.cycle_number, 1);
+    assert_eq!(r2.cycle_number, 2);
+
+    // Second cycle should make roughly the same number of bridge calls,
+    // proving consolidation runs each cycle.
+    let first_cycle_calls = calls_after_first;
+    let second_cycle_calls = calls_after_second - calls_after_first;
+    assert!(
+        second_cycle_calls > 0,
+        "second cycle should make bridge calls for consolidation"
+    );
+    assert!(
+        (second_cycle_calls as f64) >= (first_cycle_calls as f64 * 0.5),
+        "second cycle should make a similar number of calls as first: {second_cycle_calls} vs {first_cycle_calls}"
+    );
+}

--- a/tests/ooda.rs
+++ b/tests/ooda.rs
@@ -33,6 +33,11 @@ fn mock_memory_transport() -> InMemoryBridgeTransport {
             "procedures": [{"node_id": "proc_1", "name": "cargo build",
                 "steps": ["compile", "test"], "prerequisites": ["rust"], "usage_count": 5}]
         })),
+        "memory.record_sensory" => Ok(json!({"id": "sen_1"})),
+        "memory.push_working" => Ok(json!({"id": "wrk_1"})),
+        "memory.check_triggers" => Ok(json!({"prospectives": []})),
+        "memory.clear_working" => Ok(json!({"count": 0})),
+        "memory.prune_expired_sensory" => Ok(json!({"count": 0})),
         _ => Err(BridgeErrorPayload {
             code: -32601,
             message: format!("unknown: {method}"),

--- a/tests/ooda_daemon.rs
+++ b/tests/ooda_daemon.rs
@@ -44,6 +44,11 @@ fn mock_memory() -> CognitiveMemoryBridge {
                     "steps": ["compile", "test"], "prerequisites": ["rust"],
                     "usage_count": 5}]
             })),
+            "memory.record_sensory" => Ok(json!({"id": "sen_1"})),
+            "memory.push_working" => Ok(json!({"id": "wrk_1"})),
+            "memory.check_triggers" => Ok(json!({"prospectives": []})),
+            "memory.clear_working" => Ok(json!({"count": 0})),
+            "memory.prune_expired_sensory" => Ok(json!({"count": 0})),
             _ => Err(BridgeErrorPayload {
                 code: -32601,
                 message: format!("unknown: {method}"),


### PR DESCRIPTION
## Summary

Closes #234. Wires the memory consolidation phase functions (from PR #227) into the actual session lifecycle so they execute at runtime, completing the cognitive memory persistence goal.

## Changes

### OODA loop integration (`src/ooda_loop/mod.rs`)
- Calls `intake_memory_operations()` during observe phase (session start)
- Calls `preparation_memory_operations()` during orient phase
- Calls `reflection_memory_operations()` during review phase
- Calls `persistence_memory_operations()` during session teardown

### Runtime session lifecycle (`src/runtime/session.rs`, `src/runtime/mod.rs`)
- Hooks consolidation intake at session creation
- Hooks consolidation persistence at session drop/end

### Lossy tag defaults (`src/memory_bridge_adapter/convert.rs`)

### Test coverage
- 4 integration tests in `tests/memory_consolidation_lifecycle.rs` verifying end-to-end lifecycle wiring
- Additional test hooks in `tests/ooda.rs` and `tests/ooda_daemon.rs`

## Verification
- `cargo check --all-targets` ✅
- `cargo clippy` ✅
- `cargo test --lib` ✅