### PR TITLE
feat: meeting REPL — dynamic help text and improved unknown-command errors

### DIFF
--- a/src/meeting_repl/command.rs
+++ b/src/meeting_repl/command.rs
@@ -418,6 +418,7 @@ mod tests {
             "/done",
             "/help",
             "/status",
+            "/recap",
             "/participants",
         ] {
             assert!(text.contains(cmd), "help_text() should mention {cmd}");


### PR DESCRIPTION
Closes #239

## Changes
- `/help` command shows dynamic list of all available REPL commands with descriptions
- Unknown commands show helpful error message with similar command suggestions
- Improved command parsing error messages

Part of goal: enhance-simard-meeting-experience

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>