### PR TITLE
feat: add /question REPL command for explicit open questions (#240)

### DIFF
--- a/src/meeting_facilitator/handoff.rs
+++ b/src/meeting_facilitator/handoff.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::{SimardError, SimardResult};
 
-use super::types::{ActionItem, MeetingDecision, MeetingSession};
+use super::types::{ActionItem, MeetingDecision, MeetingSession, OpenQuestion};
 
 /// Well-known filename for meeting handoff artifacts.
 pub const MEETING_HANDOFF_FILENAME: &str = "meeting_handoff.json";
@@ -35,7 +35,7 @@ pub struct MeetingHandoff {
     pub closed_at: String,
     pub decisions: Vec<MeetingDecision>,
     pub action_items: Vec<ActionItem>,
-    pub open_questions: Vec<String>,
+    pub open_questions: Vec<OpenQuestion>,
     #[serde(default)]
     pub processed: bool,
     #[serde(default)]
@@ -100,18 +100,33 @@ fn is_open_question(note: &str) -> bool {
 impl MeetingHandoff {
     /// Create a handoff from a closed meeting session.
     ///
-    /// Open questions are extracted from notes using a simple heuristic:
-    /// * Notes containing `?` are included unless they look rhetorical (very
-    ///   short or matching common filler patterns).
-    /// * Notes starting with explicit markers (`OPEN:`, `TODO:`, `QUESTION:`,
-    ///   `TBD:`, `UNRESOLVED:`) are always included regardless of `?`.
+    /// Open questions are extracted from two sources:
+    /// 1. **Explicit** — questions added via `/question` during the meeting.
+    /// 2. **Inferred** — notes containing `?` (unless rhetorical) or notes
+    ///    starting with explicit markers (`OPEN:`, `TODO:`, `QUESTION:`,
+    ///    `TBD:`, `UNRESOLVED:`).
     pub fn from_session(session: &MeetingSession) -> Self {
-        let open_questions: Vec<String> = session
+        // Explicit questions from /question command.
+        let mut open_questions: Vec<OpenQuestion> = session
+            .explicit_questions
+            .iter()
+            .map(|q| OpenQuestion {
+                text: q.clone(),
+                explicit: true,
+            })
+            .collect();
+
+        // Inferred questions from notes heuristics.
+        let inferred: Vec<OpenQuestion> = session
             .notes
             .iter()
             .filter(|n| is_open_question(n))
-            .cloned()
+            .map(|n| OpenQuestion {
+                text: n.clone(),
+                explicit: false,
+            })
             .collect();
+        open_questions.extend(inferred);
 
         let duration_secs = chrono::DateTime::parse_from_rfc3339(&session.started_at)
             .ok()
@@ -290,6 +305,7 @@ mod tests {
             status: MeetingSessionStatus::Closed,
             started_at: chrono::Utc::now().to_rfc3339(),
             participants: participants.into_iter().map(String::from).collect(),
+            explicit_questions: Vec::new(),
         }
     }
 
@@ -378,7 +394,10 @@ mod tests {
         assert_eq!(handoff.action_items.len(), 1);
         assert_eq!(
             handoff.open_questions,
-            vec!["What is the timeline for phase 9?"]
+            vec![OpenQuestion {
+                text: "What is the timeline for phase 9?".to_string(),
+                explicit: false,
+            }]
         );
         assert!(!handoff.processed);
         assert!(handoff.duration_secs.is_some());
@@ -472,8 +491,10 @@ mod tests {
         );
         let handoff = MeetingHandoff::from_session(&session);
         assert_eq!(handoff.open_questions.len(), 2);
-        assert!(handoff.open_questions[0].starts_with("OPEN:"));
-        assert!(handoff.open_questions[1].starts_with("TODO:"));
+        assert!(handoff.open_questions[0].text.starts_with("OPEN:"));
+        assert!(!handoff.open_questions[0].explicit);
+        assert!(handoff.open_questions[1].text.starts_with("TODO:"));
+        assert!(!handoff.open_questions[1].explicit);
     }
 
     // -----------------------------------------------------------------------
@@ -584,5 +605,49 @@ mod tests {
         // returns a non-empty path.
         let dir = default_handoff_dir();
         assert!(!dir.as_os_str().is_empty());
+    }
+
+    #[test]
+    fn from_session_explicit_questions_tagged() {
+        let mut session = make_session(
+            "Tagged",
+            vec!["What is the deadline for the release?"],
+            vec![],
+            vec![],
+            vec![],
+        );
+        session
+            .explicit_questions
+            .push("Who owns the rollback plan?".to_string());
+
+        let handoff = MeetingHandoff::from_session(&session);
+        assert_eq!(handoff.open_questions.len(), 2);
+
+        // Explicit question comes first.
+        assert_eq!(
+            handoff.open_questions[0].text,
+            "Who owns the rollback plan?"
+        );
+        assert!(handoff.open_questions[0].explicit);
+
+        // Inferred question from notes comes second.
+        assert_eq!(
+            handoff.open_questions[1].text,
+            "What is the deadline for the release?"
+        );
+        assert!(!handoff.open_questions[1].explicit);
+    }
+
+    #[test]
+    fn from_session_only_explicit_questions() {
+        let mut session = make_session("Explicit only", vec!["plain note"], vec![], vec![], vec![]);
+        session
+            .explicit_questions
+            .push("When do we ship?".to_string());
+
+        let handoff = MeetingHandoff::from_session(&session);
+        assert_eq!(handoff.open_questions.len(), 1);
+        assert_eq!(handoff.open_questions[0].text, "When do we ship?");
+        assert!(handoff.open_questions[0].explicit);
     }
 }

--- a/src/meeting_facilitator/mod.rs
+++ b/src/meeting_facilitator/mod.rs
@@ -14,7 +14,7 @@ pub use handoff::{
     mark_handoff_processed_in_place, mark_meeting_handoff_processed, write_meeting_handoff,
 };
 pub use session::{
-    add_note, close_meeting, edit_item, record_action_item, record_decision, remove_item,
-    start_meeting,
+    add_note, add_question, close_meeting, edit_item, record_action_item, record_decision,
+    remove_item, start_meeting,
 };
-pub use types::{ActionItem, MeetingDecision, MeetingSession, MeetingSessionStatus};
+pub use types::{ActionItem, MeetingDecision, MeetingSession, MeetingSessionStatus, OpenQuestion};

--- a/src/meeting_facilitator/session.rs
+++ b/src/meeting_facilitator/session.rs
@@ -58,6 +58,7 @@ pub fn start_meeting(topic: &str, bridge: &CognitiveMemoryBridge) -> SimardResul
         status: MeetingSessionStatus::Open,
         started_at: chrono::Utc::now().to_rfc3339(),
         participants: Vec::new(),
+        explicit_questions: Vec::new(),
     })
 }
 
@@ -100,6 +101,19 @@ pub fn add_note(session: &mut MeetingSession, note: &str) -> SimardResult<()> {
     }
     required_field("note", note)?;
     session.notes.push(note.to_string());
+    Ok(())
+}
+
+/// Add an explicit open question to an open meeting session.
+pub fn add_question(session: &mut MeetingSession, question: &str) -> SimardResult<()> {
+    if session.status != MeetingSessionStatus::Open {
+        return Err(SimardError::InvalidMeetingRecord {
+            field: "session.status".to_string(),
+            reason: "cannot add a question to a closed meeting".to_string(),
+        });
+    }
+    required_field("question", question)?;
+    session.explicit_questions.push(question.to_string());
     Ok(())
 }
 
@@ -159,10 +173,25 @@ pub fn edit_item(
             }
             session.notes[index] = new_text.to_string();
         }
+        "question" => {
+            if index >= session.explicit_questions.len() {
+                return Err(SimardError::InvalidMeetingRecord {
+                    field: "index".to_string(),
+                    reason: format!(
+                        "question index {idx} out of range (have {n})",
+                        idx = index + 1,
+                        n = session.explicit_questions.len()
+                    ),
+                });
+            }
+            session.explicit_questions[index] = new_text.to_string();
+        }
         _ => {
             return Err(SimardError::InvalidMeetingRecord {
                 field: "item_type".to_string(),
-                reason: format!("unknown item type '{item_type}'; use decision, action, or note"),
+                reason: format!(
+                    "unknown item type '{item_type}'; use decision, action, note, or question"
+                ),
             });
         }
     }
@@ -222,10 +251,25 @@ pub fn remove_item(
             }
             session.notes.remove(index);
         }
+        "question" => {
+            if index >= session.explicit_questions.len() {
+                return Err(SimardError::InvalidMeetingRecord {
+                    field: "index".to_string(),
+                    reason: format!(
+                        "question index {idx} out of range (have {n})",
+                        idx = index + 1,
+                        n = session.explicit_questions.len()
+                    ),
+                });
+            }
+            session.explicit_questions.remove(index);
+        }
         _ => {
             return Err(SimardError::InvalidMeetingRecord {
                 field: "item_type".to_string(),
-                reason: format!("unknown item type '{item_type}'; use decision, action, or note"),
+                reason: format!(
+                    "unknown item type '{item_type}'; use decision, action, note, or question"
+                ),
             });
         }
     }
@@ -512,5 +556,53 @@ mod tests {
         let mut session = start_meeting("Delete test", &bridge).unwrap();
         let err = remove_item(&mut session, "bogus", 0).unwrap_err();
         assert!(err.to_string().contains("unknown item type"));
+    }
+
+    #[test]
+    fn add_question_to_session() {
+        let bridge = mock_bridge();
+        let mut session = start_meeting("Question test", &bridge).unwrap();
+        add_question(&mut session, "What is the release timeline?").unwrap();
+        assert_eq!(session.explicit_questions.len(), 1);
+        assert_eq!(
+            session.explicit_questions[0],
+            "What is the release timeline?"
+        );
+    }
+
+    #[test]
+    fn add_question_rejects_empty() {
+        let bridge = mock_bridge();
+        let mut session = start_meeting("Question test", &bridge).unwrap();
+        let err = add_question(&mut session, "").unwrap_err();
+        assert!(err.to_string().contains("empty"));
+    }
+
+    #[test]
+    fn add_question_rejects_closed_meeting() {
+        let bridge = mock_bridge();
+        let session = start_meeting("Q", &bridge).unwrap();
+        let mut closed = close_meeting(session, &bridge).unwrap();
+        let err = add_question(&mut closed, "Late question").unwrap_err();
+        assert!(err.to_string().contains("closed meeting"));
+    }
+
+    #[test]
+    fn edit_question() {
+        let bridge = mock_bridge();
+        let mut session = start_meeting("Edit Q", &bridge).unwrap();
+        add_question(&mut session, "Original question").unwrap();
+        edit_item(&mut session, "question", 0, "Updated question").unwrap();
+        assert_eq!(session.explicit_questions[0], "Updated question");
+    }
+
+    #[test]
+    fn remove_question() {
+        let bridge = mock_bridge();
+        let mut session = start_meeting("Delete Q", &bridge).unwrap();
+        add_question(&mut session, "Q1").unwrap();
+        add_question(&mut session, "Q2").unwrap();
+        remove_item(&mut session, "question", 0).unwrap();
+        assert_eq!(session.explicit_questions, vec!["Q2"]);
     }
 }

--- a/src/meeting_facilitator/types.rs
+++ b/src/meeting_facilitator/types.rs
@@ -21,6 +21,15 @@ pub struct ActionItem {
     pub due_description: Option<String>,
 }
 
+/// An open question recorded during or inferred from a meeting.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct OpenQuestion {
+    pub text: String,
+    /// `true` when the user explicitly typed `/question`, `false` when inferred
+    /// from notes heuristics (contains `?`, starts with `OPEN:`, etc.).
+    pub explicit: bool,
+}
+
 /// Status of an in-progress meeting.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum MeetingSessionStatus {
@@ -47,6 +56,9 @@ pub struct MeetingSession {
     pub status: MeetingSessionStatus,
     pub started_at: String,
     pub participants: Vec<String>,
+    /// Questions explicitly added via `/question`.
+    #[serde(default)]
+    pub explicit_questions: Vec<String>,
 }
 
 impl MeetingSession {

--- a/src/meeting_repl/command.rs
+++ b/src/meeting_repl/command.rs
@@ -16,6 +16,8 @@ pub enum MeetingCommand {
     },
     /// `/note <text>` — explicit note (not sent to agent)
     Note(String),
+    /// `/question <text>` — explicit open question
+    Question(String),
     /// Natural language — sent to the agent for a conversational response
     Conversation(String),
     /// `/status` — show meeting status summary
@@ -93,6 +95,14 @@ pub fn parse_meeting_command(line: &str) -> MeetingCommand {
         let text = rest.trim().to_string();
         if !text.is_empty() {
             return MeetingCommand::Note(text);
+        }
+        return MeetingCommand::Unknown(trimmed.to_string());
+    }
+
+    if let Some(rest) = trimmed.strip_prefix("/question ") {
+        let text = rest.trim().to_string();
+        if !text.is_empty() {
+            return MeetingCommand::Question(text);
         }
         return MeetingCommand::Unknown(trimmed.to_string());
     }
@@ -185,6 +195,7 @@ Commands (optional):
   /decision <description> | <rationale>        Record a formal decision
   /action <description> | <owner> [| <priority>]  Record an action item
   /note <text>                                  Add an explicit note
+  /question <text>                              Add an explicit open question
   /list                                         Show numbered list of all items
   /edit <type> <number> <new text>              Edit an item (type: decision, action, note)
   /delete <type> <number>                       Delete an item (type: decision, action, note)
@@ -233,6 +244,22 @@ mod tests {
             parse_meeting_command("/note Check CI before merge"),
             MeetingCommand::Note("Check CI before merge".to_string())
         );
+    }
+
+    #[test]
+    fn parse_question_command() {
+        assert_eq!(
+            parse_meeting_command("/question What is the release timeline?"),
+            MeetingCommand::Question("What is the release timeline?".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_question_empty_is_unknown() {
+        assert!(matches!(
+            parse_meeting_command("/question "),
+            MeetingCommand::Unknown(_)
+        ));
     }
 
     #[test]
@@ -411,6 +438,7 @@ mod tests {
             "/decision",
             "/action",
             "/note",
+            "/question",
             "/list",
             "/edit",
             "/delete",

--- a/src/meeting_repl/repl.rs
+++ b/src/meeting_repl/repl.rs
@@ -5,7 +5,7 @@ use std::io::{BufRead, Write};
 use crate::base_types::{BaseTypeSession, BaseTypeTurnInput};
 use crate::error::{SimardError, SimardResult};
 use crate::meeting_facilitator::{
-    ActionItem, MeetingDecision, MeetingSession, add_note, close_meeting, edit_item,
+    ActionItem, MeetingDecision, MeetingSession, add_note, add_question, close_meeting, edit_item,
     record_action_item, record_decision, remove_item, start_meeting,
 };
 use crate::memory_bridge::CognitiveMemoryBridge;
@@ -224,6 +224,14 @@ fn dispatch_command<W: Write>(
                 writeln!(output, "Error: {e}").ok();
             }
         },
+        MeetingCommand::Question(text) => match add_question(session, &text) {
+            Ok(()) => {
+                writeln!(output, "Question added: {text}").ok();
+            }
+            Err(e) => {
+                writeln!(output, "Error: {e}").ok();
+            }
+        },
         MeetingCommand::Conversation(text) => {
             if let Some(agent_session) = agent {
                 let turn_input = BaseTypeTurnInput {
@@ -256,7 +264,8 @@ fn dispatch_command<W: Write>(
         MeetingCommand::List => {
             let has_items = !session.decisions.is_empty()
                 || !session.action_items.is_empty()
-                || !session.notes.is_empty();
+                || !session.notes.is_empty()
+                || !session.explicit_questions.is_empty();
             if !has_items {
                 writeln!(output, "No items recorded yet.").ok();
             } else {
@@ -276,6 +285,12 @@ fn dispatch_command<W: Write>(
                     writeln!(output, "Notes:").ok();
                     for (i, n) in session.notes.iter().enumerate() {
                         writeln!(output, "  {}. {}", i + 1, n).ok();
+                    }
+                }
+                if !session.explicit_questions.is_empty() {
+                    writeln!(output, "Questions:").ok();
+                    for (i, q) in session.explicit_questions.iter().enumerate() {
+                        writeln!(output, "  {}. {}", i + 1, q).ok();
                     }
                 }
             }
@@ -309,6 +324,12 @@ fn dispatch_command<W: Write>(
             writeln!(output, "  Decisions:   {}", session.decisions.len()).ok();
             writeln!(output, "  Actions:     {}", session.action_items.len()).ok();
             writeln!(output, "  Notes:       {}", session.notes.len()).ok();
+            writeln!(
+                output,
+                "  Questions:   {}",
+                session.explicit_questions.len()
+            )
+            .ok();
             writeln!(output, "  Participants: {}", session.participants.len()).ok();
         }
         MeetingCommand::Recap => {
@@ -335,7 +356,7 @@ fn dispatch_command<W: Write>(
             writeln!(output, "Unknown command: {input}").ok();
             writeln!(
                 output,
-                "Available commands: /decision, /action, /note, /close, /done, /help"
+                "Available commands: /decision, /action, /note, /question, /close, /done, /help"
             )
             .ok();
             writeln!(
@@ -585,5 +606,39 @@ mod tests {
         assert!(output_str.contains("/list"));
         assert!(output_str.contains("/edit"));
         assert!(output_str.contains("/delete"));
+        assert!(output_str.contains("/question"));
+    }
+
+    #[test]
+    fn repl_question_command_adds_explicit_question() {
+        let bridge = mock_bridge();
+        let input = b"/question What is the release timeline?\n/close\n";
+        let mut reader = &input[..];
+        let mut output = Vec::new();
+
+        let session =
+            run_meeting_repl("Q test", &bridge, None, "", &mut reader, &mut output).unwrap();
+
+        let output_str = String::from_utf8(output).unwrap();
+        assert!(output_str.contains("Question added"));
+        assert_eq!(session.explicit_questions.len(), 1);
+        assert_eq!(
+            session.explicit_questions[0],
+            "What is the release timeline?"
+        );
+    }
+
+    #[test]
+    fn repl_question_appears_in_list() {
+        let bridge = mock_bridge();
+        let input = b"/question Who owns rollback?\n/list\n/close\n";
+        let mut reader = &input[..];
+        let mut output = Vec::new();
+
+        run_meeting_repl("Q list", &bridge, None, "", &mut reader, &mut output).unwrap();
+
+        let output_str = String::from_utf8(output).unwrap();
+        assert!(output_str.contains("Questions:"));
+        assert!(output_str.contains("1. Who owns rollback?"));
     }
 }

--- a/src/operator_cli/decisions.rs
+++ b/src/operator_cli/decisions.rs
@@ -86,7 +86,8 @@ pub(super) fn dispatch_act_on_decisions() -> Result<(), Box<dyn std::error::Erro
     if !handoff.open_questions.is_empty() {
         println!("\nOpen questions (not filed as issues):");
         for q in &handoff.open_questions {
-            println!("  - {q}");
+            let tag = if q.explicit { "explicit" } else { "inferred" };
+            println!("  - [{tag}] {}", q.text);
         }
     }
 

--- a/tests/act_on_decisions.rs
+++ b/tests/act_on_decisions.rs
@@ -64,6 +64,7 @@ fn sample_handoff() -> MeetingHandoff {
         status: MeetingSessionStatus::Closed,
         started_at: chrono::Utc::now().to_rfc3339(),
         participants: Vec::new(),
+        explicit_questions: Vec::new(),
     };
     MeetingHandoff::from_session(&session)
 }
@@ -256,6 +257,7 @@ fn act_on_decisions_with_empty_handoff_creates_no_issues() {
         status: MeetingSessionStatus::Closed,
         started_at: chrono::Utc::now().to_rfc3339(),
         participants: Vec::new(),
+        explicit_questions: Vec::new(),
     };
     let handoff = MeetingHandoff::from_session(&session);
     write_meeting_handoff(&dir, &handoff).unwrap();
@@ -285,7 +287,7 @@ fn open_questions_are_not_included_in_issue_count() {
 
     // Open questions are reported separately, not as issues
     assert_eq!(handoff.open_questions.len(), 1);
-    assert!(handoff.open_questions[0].contains("metrics?"));
+    assert!(handoff.open_questions[0].text.contains("metrics?"));
 }
 
 // ===========================================================================

--- a/tests/meeting_handoff.rs
+++ b/tests/meeting_handoff.rs
@@ -67,6 +67,7 @@ fn sample_session_with_questions() -> MeetingSession {
         status: MeetingSessionStatus::Closed,
         started_at: chrono::Utc::now().to_rfc3339(),
         participants: Vec::new(),
+        explicit_questions: Vec::new(),
     }
 }
 
@@ -79,6 +80,7 @@ fn sample_empty_session() -> MeetingSession {
         status: MeetingSessionStatus::Closed,
         started_at: chrono::Utc::now().to_rfc3339(),
         participants: Vec::new(),
+        explicit_questions: Vec::new(),
     }
 }
 
@@ -109,8 +111,8 @@ fn handoff_extracts_questions_from_notes() {
 
     // Notes containing '?' are extracted as open questions
     assert_eq!(handoff.open_questions.len(), 2);
-    assert!(handoff.open_questions[0].contains("error handling?"));
-    assert!(handoff.open_questions[1].contains("metrics?"));
+    assert!(handoff.open_questions[0].text.contains("error handling?"));
+    assert!(handoff.open_questions[1].text.contains("metrics?"));
 }
 
 #[test]
@@ -447,6 +449,7 @@ fn handoff_with_only_action_items_no_decisions() {
         status: MeetingSessionStatus::Closed,
         started_at: chrono::Utc::now().to_rfc3339(),
         participants: Vec::new(),
+        explicit_questions: Vec::new(),
     };
     let handoff = MeetingHandoff::from_session(&session);
     assert!(handoff.decisions.is_empty());
@@ -472,6 +475,7 @@ fn handoff_with_only_decisions_no_actions() {
         status: MeetingSessionStatus::Closed,
         started_at: chrono::Utc::now().to_rfc3339(),
         participants: Vec::new(),
+        explicit_questions: Vec::new(),
     };
     let handoff = MeetingHandoff::from_session(&session);
     assert_eq!(handoff.decisions.len(), 1);

--- a/tests/parser_proptest.rs
+++ b/tests/parser_proptest.rs
@@ -30,7 +30,8 @@ proptest! {
             | MeetingCommand::ListParticipants
             | MeetingCommand::List
             | MeetingCommand::Edit { .. }
-            | MeetingCommand::Delete { .. } => {}
+            | MeetingCommand::Delete { .. }
+            | MeetingCommand::Question(_) => {}
         }
     }
 


### PR DESCRIPTION
Implements #240

## Changes
- Add `/question` command to meeting REPL
- Distinguish explicit vs inferred open questions in session and handoff
- Unit tests for parsing, execution, and handoff tagging

Part of goal: enhance-simard-meeting-experience

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>