### PR TITLE
feat: add web dashboard skeleton with axum (#252)

### DIFF
--- a/.claude/context/PROJECT.md
+++ b/.claude/context/PROJECT.md
@@ -10,7 +10,7 @@ Replace the sections below with information about your project.
 
 ---
 
-## Project: gym-scenarios
+## Project: dashboard
 
 ## Overview
 

--- a/.claude/context/PROJECT.md.bak
+++ b/.claude/context/PROJECT.md.bak
@@ -10,7 +10,7 @@ Replace the sections below with information about your project.
 
 ---
 
-## Project: gym-scenarios
+## Project: dashboard
 
 ## Overview
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,6 +190,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1200,6 +1252,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1213,6 +1271,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -1741,6 +1800,12 @@ dependencies = [
  "tendril",
  "xml5ever",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
@@ -3013,6 +3078,7 @@ version = "0.15.0"
 dependencies = [
  "amplihack-memory",
  "assert_cmd",
+ "axum",
  "chrono",
  "libc",
  "proptest",
@@ -3023,6 +3089,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "tower-http",
  "tracing",
  "uuid",
 ]
@@ -3422,12 +3489,14 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
+ "base64",
  "bitflags",
  "bytes",
  "futures-util",
  "http",
  "http-body",
  "iri-string",
+ "mime",
  "pin-project-lite",
  "tower",
  "tower-layer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,9 @@ rustyclawd-tools = { git = "https://github.com/rysweet/RustyClawd.git" }
 rusqlite = { version = "0.31", features = ["bundled"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
-tokio = { version = "1", features = ["rt", "process", "io-util", "time"] }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "process", "io-util", "time", "net", "macros"] }
+axum = "0.8"
+tower-http = { version = "0.6", features = ["cors", "auth"] }
 uuid = { version = "1.18.1", features = ["v7"] }
 chrono = "0.4"
 tracing = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@ pub mod ooda_loop;
 pub mod ooda_scheduler;
 pub mod operator_cli;
 pub mod operator_commands;
+mod operator_commands_dashboard;
 mod operator_commands_engineer;
 mod operator_commands_gym;
 mod operator_commands_meeting;

--- a/src/operator_cli/dashboard.rs
+++ b/src/operator_cli/dashboard.rs
@@ -1,0 +1,25 @@
+use crate::operator_commands_dashboard;
+
+use super::args::next_required;
+
+pub fn dispatch_dashboard_command(
+    mut args: impl Iterator<Item = String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let subcommand = next_required(&mut args, "dashboard subcommand (serve)")?;
+    match subcommand.as_str() {
+        "serve" => {
+            let mut port: u16 = 8080;
+            for arg in args {
+                if let Some(p) = arg.strip_prefix("--port=") {
+                    port = p
+                        .parse()
+                        .map_err(|_| format!("invalid --port value: {p}"))?;
+                } else {
+                    return Err(format!("unexpected argument: {arg}").into());
+                }
+            }
+            operator_commands_dashboard::serve(port)
+        }
+        other => Err(format!("unsupported command 'dashboard {other}'").into()),
+    }
+}

--- a/src/operator_cli/mod.rs
+++ b/src/operator_cli/mod.rs
@@ -1,5 +1,6 @@
 mod args;
 mod curation;
+mod dashboard;
 mod decisions;
 mod engineer;
 mod gym;
@@ -45,6 +46,7 @@ Product modes:
   gym compare <scenario-id>
   gym run-suite <suite-id>
   ooda run [--cycles=N] [state-root]
+  dashboard serve [--port=8080]
   spawn <agent-name> <goal> <worktree-path> [--depth=N]
   handover [--canary-dir=PATH] [--manifest-dir=PATH]
   update
@@ -83,6 +85,7 @@ where
         "review" => review::dispatch_review_command(args),
         "gym" => gym::dispatch_gym_command(args),
         "ooda" => ooda::dispatch_ooda_command(args),
+        "dashboard" => dashboard::dispatch_dashboard_command(args),
         "spawn" => dispatch_spawn_command(args),
         "handover" => dispatch_handover_command(args),
         "bootstrap" => dispatch_bootstrap_command(args),

--- a/src/operator_commands_dashboard/auth.rs
+++ b/src/operator_commands_dashboard/auth.rs
@@ -1,0 +1,23 @@
+use axum::{extract::Request, http::StatusCode, middleware::Next, response::Response};
+
+/// Simple bearer-token auth middleware.
+/// Set `SIMARD_DASHBOARD_TOKEN` to enable; if unset, all requests are allowed.
+pub async fn require_auth(request: Request, next: Next) -> Result<Response, StatusCode> {
+    let expected = std::env::var("SIMARD_DASHBOARD_TOKEN").unwrap_or_default();
+    if expected.is_empty() {
+        return Ok(next.run(request).await);
+    }
+
+    let auth_header = request
+        .headers()
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default();
+
+    let token = auth_header.strip_prefix("Bearer ").unwrap_or_default();
+    if token == expected {
+        Ok(next.run(request).await)
+    } else {
+        Err(StatusCode::UNAUTHORIZED)
+    }
+}

--- a/src/operator_commands_dashboard/mod.rs
+++ b/src/operator_commands_dashboard/mod.rs
@@ -1,0 +1,21 @@
+mod auth;
+mod routes;
+
+use std::net::SocketAddr;
+
+pub fn serve(port: u16) -> Result<(), Box<dyn std::error::Error>> {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?;
+
+    rt.block_on(async move {
+        let app = routes::build_router();
+
+        let addr = SocketAddr::from(([0, 0, 0, 0], port));
+        eprintln!("Simard dashboard listening on http://{addr}");
+
+        let listener = tokio::net::TcpListener::bind(addr).await?;
+        axum::serve(listener, app).await?;
+        Ok::<(), Box<dyn std::error::Error>>(())
+    })
+}

--- a/src/operator_commands_dashboard/routes.rs
+++ b/src/operator_commands_dashboard/routes.rs
@@ -1,0 +1,147 @@
+use axum::{Json, Router, middleware, routing::get};
+use serde_json::{Value, json};
+
+use super::auth::require_auth;
+
+pub fn build_router() -> Router {
+    Router::new()
+        .route("/api/status", get(status))
+        .route("/api/issues", get(issues))
+        .route("/", get(index))
+        .layer(middleware::from_fn(require_auth))
+}
+
+async fn status() -> Json<Value> {
+    let version = env!("CARGO_PKG_VERSION");
+
+    let ooda_running = std::process::Command::new("pgrep")
+        .args(["-f", "simard ooda"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+
+    let disk = disk_usage_pct().await;
+
+    Json(json!({
+        "version": version,
+        "ooda_daemon": if ooda_running { "running" } else { "stopped" },
+        "disk_usage_pct": disk,
+        "timestamp": chrono::Utc::now().to_rfc3339(),
+    }))
+}
+
+async fn issues() -> Json<Value> {
+    let output = tokio::process::Command::new("gh")
+        .args([
+            "issue",
+            "list",
+            "--state",
+            "open",
+            "--json",
+            "number,title,labels",
+        ])
+        .output()
+        .await;
+
+    match output {
+        Ok(o) if o.status.success() => {
+            let raw = String::from_utf8_lossy(&o.stdout);
+            match serde_json::from_str::<Value>(&raw) {
+                Ok(v) => Json(v),
+                Err(_) => Json(json!({"error": "failed to parse gh output"})),
+            }
+        }
+        _ => Json(json!({"error": "failed to run gh issue list"})),
+    }
+}
+
+async fn index() -> axum::response::Html<String> {
+    axum::response::Html(INDEX_HTML.to_string())
+}
+
+async fn disk_usage_pct() -> Option<u8> {
+    let output = tokio::process::Command::new("df")
+        .args(["--output=pcent", "/home"])
+        .output()
+        .await
+        .ok()?;
+    let text = String::from_utf8_lossy(&output.stdout);
+    let line = text.lines().nth(1)?;
+    line.trim().trim_end_matches('%').parse().ok()
+}
+
+const INDEX_HTML: &str = r#"<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Simard Dashboard</title>
+  <style>
+    :root { --bg: #0d1117; --fg: #c9d1d9; --accent: #58a6ff; --card: #161b22; --border: #30363d; }
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: var(--bg); color: var(--fg); padding: 2rem; }
+    h1 { color: var(--accent); margin-bottom: 1.5rem; font-size: 1.5rem; }
+    .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 1rem; }
+    .card { background: var(--card); border: 1px solid var(--border); border-radius: 8px; padding: 1.25rem; }
+    .card h2 { color: var(--accent); font-size: 1rem; margin-bottom: 0.75rem; border-bottom: 1px solid var(--border); padding-bottom: 0.5rem; }
+    .stat { display: flex; justify-content: space-between; padding: 0.3rem 0; }
+    .stat .label { color: #8b949e; }
+    .stat .value { font-weight: 600; }
+    .ok { color: #3fb950; }
+    .warn { color: #d29922; }
+    .err { color: #f85149; }
+    #issues-list { list-style: none; }
+    #issues-list li { padding: 0.3rem 0; border-bottom: 1px solid var(--border); }
+    #issues-list li:last-child { border-bottom: none; }
+    .issue-num { color: var(--accent); font-weight: 600; margin-right: 0.5rem; }
+    .loading { color: #8b949e; font-style: italic; }
+  </style>
+</head>
+<body>
+  <h1>🌲 Simard Dashboard</h1>
+  <div class="grid">
+    <div class="card">
+      <h2>System Status</h2>
+      <div id="status"><span class="loading">Loading...</span></div>
+    </div>
+    <div class="card">
+      <h2>Open Issues</h2>
+      <ul id="issues-list"><li class="loading">Loading...</li></ul>
+    </div>
+  </div>
+
+  <script>
+    async function fetchStatus() {
+      try {
+        const r = await fetch('/api/status');
+        const d = await r.json();
+        const diskClass = d.disk_usage_pct > 90 ? 'err' : d.disk_usage_pct > 70 ? 'warn' : 'ok';
+        const daemonClass = d.ooda_daemon === 'running' ? 'ok' : 'err';
+        document.getElementById('status').innerHTML = `
+          <div class="stat"><span class="label">Version</span><span class="value">v${d.version}</span></div>
+          <div class="stat"><span class="label">OODA Daemon</span><span class="value ${daemonClass}">${d.ooda_daemon}</span></div>
+          <div class="stat"><span class="label">Disk Usage</span><span class="value ${diskClass}">${d.disk_usage_pct ?? '?'}%</span></div>
+          <div class="stat"><span class="label">Updated</span><span class="value">${new Date(d.timestamp).toLocaleTimeString()}</span></div>
+        `;
+      } catch (e) { document.getElementById('status').innerHTML = '<span class="err">Failed to load</span>'; }
+    }
+
+    async function fetchIssues() {
+      try {
+        const r = await fetch('/api/issues');
+        const issues = await r.json();
+        if (Array.isArray(issues)) {
+          document.getElementById('issues-list').innerHTML = issues.map(i =>
+            `<li><span class="issue-num">#${i.number}</span>${i.title}</li>`
+          ).join('');
+        }
+      } catch (e) { document.getElementById('issues-list').innerHTML = '<li class="err">Failed to load</li>'; }
+    }
+
+    fetchStatus(); fetchIssues();
+    setInterval(fetchStatus, 30000);
+    setInterval(fetchIssues, 60000);
+  </script>
+</body>
+</html>
+"#;


### PR DESCRIPTION
## Summary

Adds a minimal web dashboard for Simard accessible via `simard dashboard serve [--port=8080]`.

### Endpoints
- **`/api/status`** — JSON: version, OODA daemon state, disk usage %, timestamp
- **`/api/issues`** — Live GitHub issues via `gh` CLI
- **`/`** — Dark-themed HTML dashboard with auto-refreshing status cards and issue list

### Auth
Bearer token middleware via `SIMARD_DASHBOARD_TOKEN` env var (open access if unset).

### Stack
axum 0.8, tower-http 0.6, tokio multi-thread runtime

### Smoke tested
All 3 endpoints return correct data. OODA daemon detection works. Disk usage reports accurately.

### Next steps (Simard to iterate via OODA)
- OODA cycle timeline/log viewer
- Goal register with progress scores  
- WebSocket meeting chat interface
- Memory browser
- Real-time log streaming

Closes #252