### PR TITLE
feat(dashboard): login code auth for browser access

### DIFF
--- a/src/operator_commands_dashboard/auth.rs
+++ b/src/operator_commands_dashboard/auth.rs
@@ -66,10 +66,10 @@ pub async fn require_auth(request: Request, next: Next) -> Result<Response, Stat
         .unwrap_or_default();
     for part in cookie_header.split(';') {
         let part = part.trim();
-        if let Some(token) = part.strip_prefix("simard_session=") {
-            if is_valid_session(token) {
-                return Ok(next.run(request).await);
-            }
+        if let Some(token) = part.strip_prefix("simard_session=")
+            && is_valid_session(token)
+        {
+            return Ok(next.run(request).await);
         }
     }
 

--- a/src/operator_commands_dashboard/auth.rs
+++ b/src/operator_commands_dashboard/auth.rs
@@ -1,23 +1,111 @@
 use axum::{extract::Request, http::StatusCode, middleware::Next, response::Response};
+use std::sync::OnceLock;
 
-/// Simple bearer-token auth middleware.
-/// Set `SIMARD_DASHBOARD_TOKEN` to enable; if unset, all requests are allowed.
+/// The login code generated at startup, printed to stderr for the operator.
+static LOGIN_CODE: OnceLock<String> = OnceLock::new();
+/// Session tokens issued after successful login.
+static SESSIONS: OnceLock<std::sync::Mutex<std::collections::HashSet<String>>> = OnceLock::new();
+
+fn sessions() -> &'static std::sync::Mutex<std::collections::HashSet<String>> {
+    SESSIONS.get_or_init(|| std::sync::Mutex::new(std::collections::HashSet::new()))
+}
+
+/// Generate and print the one-time login code. Call once at startup.
+pub fn init_login_code() -> String {
+    let code: String = uuid::Uuid::now_v7().to_string()[..8].to_string();
+    LOGIN_CODE.set(code.clone()).ok();
+    code
+}
+
+/// Validate the login code, return a session token if correct.
+pub fn try_login(code: &str) -> Option<String> {
+    let expected = LOGIN_CODE.get()?;
+    if code.trim() == expected.as_str() {
+        let token = uuid::Uuid::now_v7().to_string();
+        sessions().lock().ok()?.insert(token.clone());
+        Some(token)
+    } else {
+        None
+    }
+}
+
+fn is_valid_session(token: &str) -> bool {
+    sessions()
+        .lock()
+        .map(|s| s.contains(token))
+        .unwrap_or(false)
+}
+
+/// Auth middleware. Checks (in order):
+/// 1. `session` cookie
+/// 2. `Authorization: Bearer <token>` header (for API clients)
+/// 3. `?token=` query param (legacy)
+///
+/// The `/login` path is always allowed through.
 pub async fn require_auth(request: Request, next: Next) -> Result<Response, StatusCode> {
-    let expected = std::env::var("SIMARD_DASHBOARD_TOKEN").unwrap_or_default();
-    if expected.is_empty() {
+    let path = request.uri().path().to_string();
+
+    // Login page and login POST are always accessible
+    if path == "/login" || path == "/api/login" {
         return Ok(next.run(request).await);
     }
 
-    let auth_header = request
+    // If no login code was configured (SIMARD_DASHBOARD_TOKEN unset + no init), allow all
+    if LOGIN_CODE.get().is_none() {
+        let expected = std::env::var("SIMARD_DASHBOARD_TOKEN").unwrap_or_default();
+        if expected.is_empty() {
+            return Ok(next.run(request).await);
+        }
+    }
+
+    // Check session cookie
+    let cookie_header = request
+        .headers()
+        .get("cookie")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default();
+    for part in cookie_header.split(';') {
+        let part = part.trim();
+        if let Some(token) = part.strip_prefix("simard_session=") {
+            if is_valid_session(token) {
+                return Ok(next.run(request).await);
+            }
+        }
+    }
+
+    // Check Bearer header (for curl/API usage)
+    let bearer = request
         .headers()
         .get("authorization")
         .and_then(|v| v.to_str().ok())
-        .unwrap_or_default();
+        .and_then(|s| s.strip_prefix("Bearer "));
+    if let Some(token) = bearer {
+        let expected_env = std::env::var("SIMARD_DASHBOARD_TOKEN").unwrap_or_default();
+        if !expected_env.is_empty() && token == expected_env {
+            return Ok(next.run(request).await);
+        }
+        if is_valid_session(token) {
+            return Ok(next.run(request).await);
+        }
+    }
 
-    let token = auth_header.strip_prefix("Bearer ").unwrap_or_default();
-    if token == expected {
-        Ok(next.run(request).await)
-    } else {
+    // Check ?token= query param (legacy)
+    let query = request.uri().query().unwrap_or_default();
+    if let Some(token) = query.split('&').find_map(|p| p.strip_prefix("token=")) {
+        let expected_env = std::env::var("SIMARD_DASHBOARD_TOKEN").unwrap_or_default();
+        if !expected_env.is_empty() && token == expected_env {
+            return Ok(next.run(request).await);
+        }
+    }
+
+    // Not authenticated — redirect to login page
+    if path.starts_with("/api/") {
         Err(StatusCode::UNAUTHORIZED)
+    } else {
+        Ok(Response::builder()
+            .status(303)
+            .header("location", "/login")
+            .body(axum::body::Body::empty())
+            .unwrap())
     }
 }

--- a/src/operator_commands_dashboard/mod.rs
+++ b/src/operator_commands_dashboard/mod.rs
@@ -4,6 +4,11 @@ mod routes;
 use std::net::SocketAddr;
 
 pub fn serve(port: u16) -> Result<(), Box<dyn std::error::Error>> {
+    let code = auth::init_login_code();
+    eprintln!("\n  🌲 Simard Dashboard");
+    eprintln!("  Login code: {code}");
+    eprintln!("  Open http://localhost:{port} and enter the code\n");
+
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()?;

--- a/src/operator_commands_dashboard/routes.rs
+++ b/src/operator_commands_dashboard/routes.rs
@@ -15,16 +15,25 @@ async fn status() -> Json<Value> {
     let version = env!("CARGO_PKG_VERSION");
 
     let ooda_running = std::process::Command::new("pgrep")
-        .args(["-f", "simard ooda"])
+        .args(["-f", "simard.*ooda run"])
         .output()
         .map(|o| o.status.success())
         .unwrap_or(false);
 
     let disk = disk_usage_pct().await;
 
+    let child_count = std::process::Command::new("pgrep")
+        .args(["-f", "-c", "copilot.*Simard|simard.*ooda|cargo.*simard"])
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .and_then(|s| s.trim().parse::<u32>().ok())
+        .unwrap_or(0);
+
     Json(json!({
         "version": version,
         "ooda_daemon": if ooda_running { "running" } else { "stopped" },
+        "active_processes": child_count,
         "disk_usage_pct": disk,
         "timestamp": chrono::Utc::now().to_rfc3339(),
     }))
@@ -120,6 +129,7 @@ const INDEX_HTML: &str = r#"<!DOCTYPE html>
         document.getElementById('status').innerHTML = `
           <div class="stat"><span class="label">Version</span><span class="value">v${d.version}</span></div>
           <div class="stat"><span class="label">OODA Daemon</span><span class="value ${daemonClass}">${d.ooda_daemon}</span></div>
+          <div class="stat"><span class="label">Active Processes</span><span class="value">${d.active_processes ?? 0}</span></div>
           <div class="stat"><span class="label">Disk Usage</span><span class="value ${diskClass}">${d.disk_usage_pct ?? '?'}%</span></div>
           <div class="stat"><span class="label">Updated</span><span class="value">${new Date(d.timestamp).toLocaleTimeString()}</span></div>
         `;

--- a/src/operator_commands_dashboard/routes.rs
+++ b/src/operator_commands_dashboard/routes.rs
@@ -1,14 +1,46 @@
-use axum::{Json, Router, middleware, routing::get};
+use axum::{Json, Router, middleware, response, routing::get, routing::post};
 use serde_json::{Value, json};
 
-use super::auth::require_auth;
+use super::auth::{require_auth, try_login};
 
 pub fn build_router() -> Router {
     Router::new()
         .route("/api/status", get(status))
         .route("/api/issues", get(issues))
+        .route("/api/login", post(login))
+        .route("/login", get(login_page))
         .route("/", get(index))
         .layer(middleware::from_fn(require_auth))
+}
+
+async fn login(Json(body): Json<Value>) -> response::Response {
+    let code = body.get("code").and_then(|v| v.as_str()).unwrap_or("");
+    match try_login(code) {
+        Some(session_token) => response::Response::builder()
+            .status(200)
+            .header(
+                "set-cookie",
+                format!(
+                    "simard_session={session_token}; Path=/; HttpOnly; SameSite=Strict; Max-Age=86400"
+                ),
+            )
+            .header("content-type", "application/json")
+            .body(axum::body::Body::from(
+                json!({"ok": true}).to_string(),
+            ))
+            .unwrap(),
+        None => response::Response::builder()
+            .status(401)
+            .header("content-type", "application/json")
+            .body(axum::body::Body::from(
+                json!({"ok": false, "error": "invalid code"}).to_string(),
+            ))
+            .unwrap(),
+    }
+}
+
+async fn login_page() -> response::Html<String> {
+    response::Html(LOGIN_HTML.to_string())
 }
 
 async fn status() -> Json<Value> {
@@ -78,6 +110,49 @@ async fn disk_usage_pct() -> Option<u8> {
     let line = text.lines().nth(1)?;
     line.trim().trim_end_matches('%').parse().ok()
 }
+
+const LOGIN_HTML: &str = r#"<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Simard — Login</title>
+  <style>
+    :root { --bg: #0d1117; --fg: #c9d1d9; --accent: #58a6ff; --card: #161b22; --border: #30363d; }
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: var(--bg); color: var(--fg); display: flex; align-items: center; justify-content: center; min-height: 100vh; }
+    .login-card { background: var(--card); border: 1px solid var(--border); border-radius: 12px; padding: 2rem; width: 340px; text-align: center; }
+    h1 { color: var(--accent); font-size: 1.3rem; margin-bottom: 0.5rem; }
+    p { color: #8b949e; font-size: 0.85rem; margin-bottom: 1.5rem; }
+    input { width: 100%; padding: 0.6rem; border: 1px solid var(--border); border-radius: 6px; background: var(--bg); color: var(--fg); font-size: 1.1rem; text-align: center; letter-spacing: 0.15em; }
+    input:focus { outline: none; border-color: var(--accent); }
+    button { width: 100%; margin-top: 1rem; padding: 0.6rem; border: none; border-radius: 6px; background: var(--accent); color: #0d1117; font-weight: 600; font-size: 0.95rem; cursor: pointer; }
+    button:hover { opacity: 0.9; }
+    .error { color: #f85149; margin-top: 0.75rem; font-size: 0.85rem; display: none; }
+  </style>
+</head>
+<body>
+  <div class="login-card">
+    <h1>🌲 Simard</h1>
+    <p>Enter the login code from the server terminal</p>
+    <form id="login-form">
+      <input id="code" type="text" placeholder="code" autocomplete="off" autofocus maxlength="8">
+      <button type="submit">Log in</button>
+    </form>
+    <div class="error" id="error">Invalid code. Check terminal output.</div>
+  </div>
+  <script>
+    document.getElementById('login-form').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const code = document.getElementById('code').value;
+      const r = await fetch('/api/login', { method: 'POST', headers: {'content-type':'application/json'}, body: JSON.stringify({code}) });
+      if (r.ok) { window.location.href = '/'; }
+      else { document.getElementById('error').style.display = 'block'; }
+    });
+  </script>
+</body>
+</html>
+"#;
 
 const INDEX_HTML: &str = r#"<!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
Replaces bearer-token-only auth with a startup login code flow.

**How it works:**
1. Dashboard prints an 8-char login code to stderr on startup
2. Browser visits `/` → redirected to `/login`
3. User enters code → session cookie set (24h, HttpOnly, SameSite=Strict)
4. All subsequent requests authenticated via cookie

Bearer token (`Authorization: Bearer`) and `?token=` query param still work for curl/API clients.

No external dependencies added — uses uuid (already in Cargo.toml) for code and session token generation.