### PR TITLE
feat: meeting session persistence — auto-save and crash resume (#273)

### DIFF
--- a/src/meeting_facilitator/handoff.rs
+++ b/src/meeting_facilitator/handoff.rs
@@ -14,6 +14,9 @@ use super::types::{ActionItem, MeetingDecision, MeetingSession, OpenQuestion};
 /// Well-known filename for meeting handoff artifacts.
 pub const MEETING_HANDOFF_FILENAME: &str = "meeting_handoff.json";
 
+/// Well-known filename for the work-in-progress session snapshot.
+pub const MEETING_SESSION_WIP_FILENAME: &str = "meeting_session_wip.json";
+
 /// Default directory for meeting handoff artifacts.
 ///
 /// Respects `SIMARD_HANDOFF_DIR` when set, otherwise falls back to
@@ -281,6 +284,67 @@ pub fn mark_handoff_processed_in_place(
         path: path.clone(),
         reason: format!("writing handoff: {e}"),
     })?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Work-in-progress session persistence (auto-save / crash resume)
+// ---------------------------------------------------------------------------
+
+/// Save the current meeting session to a WIP file in the handoff directory.
+///
+/// This is called periodically (every 60 s) and after every slash command so
+/// that a crash loses at most the last few seconds of work.
+pub fn save_session_wip(dir: &Path, session: &MeetingSession) -> SimardResult<()> {
+    fs::create_dir_all(dir).map_err(|e| SimardError::ArtifactIo {
+        path: dir.to_path_buf(),
+        reason: format!("creating handoff dir: {e}"),
+    })?;
+    let path = dir.join(MEETING_SESSION_WIP_FILENAME);
+    let json = serde_json::to_string_pretty(session).map_err(|e| SimardError::ArtifactIo {
+        path: path.clone(),
+        reason: format!("serializing WIP session: {e}"),
+    })?;
+    fs::write(&path, &json).map_err(|e| SimardError::ArtifactIo {
+        path: path.clone(),
+        reason: format!("writing WIP session: {e}"),
+    })?;
+    Ok(())
+}
+
+/// Load a previously saved WIP session from the handoff directory.
+///
+/// Returns `None` if no WIP file exists. The caller should prompt the user
+/// for resume vs. fresh start.
+pub fn load_session_wip(dir: &Path) -> SimardResult<Option<MeetingSession>> {
+    let path = dir.join(MEETING_SESSION_WIP_FILENAME);
+    if !path.is_file() {
+        return Ok(None);
+    }
+    let raw = fs::read_to_string(&path).map_err(|e| SimardError::ArtifactIo {
+        path: path.clone(),
+        reason: format!("reading WIP session: {e}"),
+    })?;
+    let session: MeetingSession =
+        serde_json::from_str(&raw).map_err(|e| SimardError::ArtifactIo {
+            path: path.clone(),
+            reason: format!("parsing WIP session JSON: {e}"),
+        })?;
+    Ok(Some(session))
+}
+
+/// Remove the WIP file from the handoff directory.
+///
+/// Called on clean `/close` (after writing the final handoff artifact) and
+/// when the user declines to resume a stale WIP session.
+pub fn remove_session_wip(dir: &Path) -> SimardResult<()> {
+    let path = dir.join(MEETING_SESSION_WIP_FILENAME);
+    if path.is_file() {
+        fs::remove_file(&path).map_err(|e| SimardError::ArtifactIo {
+            path: path.clone(),
+            reason: format!("removing WIP session: {e}"),
+        })?;
+    }
     Ok(())
 }
 
@@ -705,5 +769,74 @@ mod tests {
             name == MEETING_HANDOFF_FILENAME || name.contains("2099"),
             "expected either legacy or timestamped file, got {name}"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // WIP session persistence tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn save_and_load_wip_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let session = make_session(
+            "WIP test",
+            vec!["note one"],
+            vec![sample_decision()],
+            vec![sample_action()],
+            vec!["alice"],
+        );
+        save_session_wip(dir.path(), &session).unwrap();
+
+        let loaded = load_session_wip(dir.path()).unwrap().unwrap();
+        assert_eq!(loaded.topic, "WIP test");
+        assert_eq!(loaded.decisions.len(), 1);
+        assert_eq!(loaded.action_items.len(), 1);
+        assert_eq!(loaded.notes, vec!["note one"]);
+        assert_eq!(loaded.participants, vec!["alice"]);
+    }
+
+    #[test]
+    fn load_wip_returns_none_when_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let result = load_session_wip(dir.path()).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn remove_wip_deletes_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let session = make_session("Remove me", vec![], vec![], vec![], vec![]);
+        save_session_wip(dir.path(), &session).unwrap();
+
+        // File should exist.
+        assert!(dir.path().join(MEETING_SESSION_WIP_FILENAME).is_file());
+
+        remove_session_wip(dir.path()).unwrap();
+
+        // File should be gone.
+        assert!(!dir.path().join(MEETING_SESSION_WIP_FILENAME).is_file());
+        // Loading should return None.
+        assert!(load_session_wip(dir.path()).unwrap().is_none());
+    }
+
+    #[test]
+    fn remove_wip_noop_when_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        // Should not error when there's nothing to remove.
+        remove_session_wip(dir.path()).unwrap();
+    }
+
+    #[test]
+    fn save_wip_overwrites_previous() {
+        let dir = tempfile::tempdir().unwrap();
+        let s1 = make_session("First", vec![], vec![], vec![], vec![]);
+        save_session_wip(dir.path(), &s1).unwrap();
+
+        let s2 = make_session("Second", vec!["updated"], vec![], vec![], vec![]);
+        save_session_wip(dir.path(), &s2).unwrap();
+
+        let loaded = load_session_wip(dir.path()).unwrap().unwrap();
+        assert_eq!(loaded.topic, "Second");
+        assert_eq!(loaded.notes, vec!["updated"]);
     }
 }

--- a/src/meeting_facilitator/mod.rs
+++ b/src/meeting_facilitator/mod.rs
@@ -10,8 +10,9 @@ mod types;
 
 // Re-export all public items so `crate::meeting_facilitator::X` still works.
 pub use handoff::{
-    MEETING_HANDOFF_FILENAME, MeetingHandoff, default_handoff_dir, load_meeting_handoff,
-    mark_handoff_processed_in_place, mark_meeting_handoff_processed, write_meeting_handoff,
+    MEETING_HANDOFF_FILENAME, MEETING_SESSION_WIP_FILENAME, MeetingHandoff, default_handoff_dir,
+    load_meeting_handoff, load_session_wip, mark_handoff_processed_in_place,
+    mark_meeting_handoff_processed, remove_session_wip, save_session_wip, write_meeting_handoff,
 };
 pub use session::{
     add_note, add_question, close_meeting, edit_item, record_action_item, record_decision,

--- a/src/meeting_repl/repl.rs
+++ b/src/meeting_repl/repl.rs
@@ -6,7 +6,8 @@ use crate::base_types::{BaseTypeSession, BaseTypeTurnInput};
 use crate::error::{SimardError, SimardResult};
 use crate::meeting_facilitator::{
     ActionItem, MeetingDecision, MeetingHandoff, MeetingSession, add_note, add_question,
-    close_meeting, edit_item, record_action_item, record_decision, remove_item, start_meeting,
+    close_meeting, default_handoff_dir, edit_item, load_session_wip, record_action_item,
+    record_decision, remove_item, remove_session_wip, save_session_wip, start_meeting,
 };
 use crate::memory_bridge::CognitiveMemoryBridge;
 
@@ -15,6 +16,16 @@ use super::command::{MeetingCommand, help_text, parse_meeting_command};
 use super::persist::{persist_meeting_to_memory, write_meeting_handoff_artifact};
 
 const PROMPT: &str = "simard:meeting> ";
+
+/// Auto-save interval for periodic WIP snapshots.
+const AUTO_SAVE_INTERVAL_SECS: u64 = 60;
+
+/// Save session WIP, logging warnings on failure without aborting.
+fn try_save_wip<W: Write>(session: &MeetingSession, handoff_dir: &std::path::Path, output: &mut W) {
+    if let Err(e) = save_session_wip(handoff_dir, session) {
+        writeln!(output, "[warn] Auto-save failed: {e}").ok();
+    }
+}
 
 /// Run the interactive meeting REPL.
 ///
@@ -30,11 +41,46 @@ pub fn run_meeting_repl<R: BufRead, W: Write>(
     input: &mut R,
     output: &mut W,
 ) -> SimardResult<MeetingSession> {
-    let mut session = start_meeting(topic, bridge)?;
+    let handoff_dir = default_handoff_dir();
+
+    // --- Resume logic: check for a WIP session on disk ---
+    let mut session = match load_session_wip(&handoff_dir) {
+        Ok(Some(wip)) => {
+            writeln!(
+                output,
+                "Found a previous session (topic: \"{}\"). Resume previous session? (y/n)",
+                wip.topic
+            )
+            .ok();
+            write!(output, "> ").ok();
+            output.flush().ok();
+
+            let mut answer = String::new();
+            let resumed = match input.read_line(&mut answer) {
+                Ok(n) if n > 0 => answer.trim().eq_ignore_ascii_case("y"),
+                _ => false,
+            };
+
+            if resumed {
+                writeln!(output, "Resuming session: \"{}\"", wip.topic).ok();
+                wip
+            } else {
+                writeln!(output, "Starting fresh session.").ok();
+                remove_session_wip(&handoff_dir).ok();
+                start_meeting(topic, bridge)?
+            }
+        }
+        _ => start_meeting(topic, bridge)?,
+    };
+
     let mut agent = agent;
 
-    print_banner(topic, agent.is_some(), output);
+    print_banner(&session.topic, agent.is_some(), output);
 
+    // Initial WIP save so even a very early crash is recoverable.
+    try_save_wip(&session, &handoff_dir, output);
+
+    let mut last_save = std::time::Instant::now();
     let mut line = String::new();
     loop {
         write!(output, "{PROMPT}").ok();
@@ -67,14 +113,39 @@ pub fn run_meeting_repl<R: BufRead, W: Write>(
             writeln!(output, "Closing meeting.").ok();
             break;
         }
+
+        let is_state_changing = !matches!(
+            cmd,
+            MeetingCommand::Empty
+                | MeetingCommand::Help
+                | MeetingCommand::Status
+                | MeetingCommand::Recap
+                | MeetingCommand::List
+                | MeetingCommand::ListParticipants
+                | MeetingCommand::Preview
+        );
+
+        let current_topic = session.topic.clone();
         dispatch_command(
             cmd,
             &mut session,
             &mut agent,
-            topic,
+            &current_topic,
             meeting_system_prompt,
             output,
         );
+
+        // Save WIP after state-changing commands.
+        if is_state_changing {
+            try_save_wip(&session, &handoff_dir, output);
+            last_save = std::time::Instant::now();
+        }
+
+        // Periodic auto-save (60 s).
+        if last_save.elapsed().as_secs() >= AUTO_SAVE_INTERVAL_SECS {
+            try_save_wip(&session, &handoff_dir, output);
+            last_save = std::time::Instant::now();
+        }
     }
 
     let closed = close_meeting(session, bridge)?;
@@ -83,6 +154,9 @@ pub fn run_meeting_repl<R: BufRead, W: Write>(
 
     write_meeting_handoff_artifact(&closed, output);
     persist_meeting_to_memory(&closed, bridge, output);
+
+    // Clean up WIP file after successful close.
+    remove_session_wip(&handoff_dir).ok();
 
     Ok(closed)
 }
@@ -835,5 +909,135 @@ mod tests {
             output_str.contains("[due: 2026-05-01]"),
             "preview should show due date: {output_str}"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // WIP persistence integration tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn repl_saves_wip_on_command_and_cleans_up_on_close() {
+        let dir = tempfile::tempdir().unwrap();
+        // SAFETY: test-only, run with --test-threads=1 to avoid races.
+        unsafe { std::env::set_var("SIMARD_HANDOFF_DIR", dir.path()) };
+
+        let bridge = mock_bridge();
+        let input = b"/decision Ship it | Ready\n/close\n";
+        let mut reader = &input[..];
+        let mut output = Vec::new();
+
+        let session =
+            run_meeting_repl("WIP test", &bridge, None, "", &mut reader, &mut output).unwrap();
+
+        assert_eq!(session.status, MeetingSessionStatus::Closed);
+        assert_eq!(session.decisions.len(), 1);
+
+        // WIP file should be cleaned up after /close.
+        let wip_path = dir
+            .path()
+            .join(crate::meeting_facilitator::MEETING_SESSION_WIP_FILENAME);
+        assert!(
+            !wip_path.exists(),
+            "WIP file should be removed after /close"
+        );
+
+        unsafe { std::env::remove_var("SIMARD_HANDOFF_DIR") };
+    }
+
+    #[test]
+    fn repl_resumes_from_wip_on_y() {
+        let dir = tempfile::tempdir().unwrap();
+        // SAFETY: test-only, run with --test-threads=1 to avoid races.
+        unsafe { std::env::set_var("SIMARD_HANDOFF_DIR", dir.path()) };
+
+        // Pre-populate a WIP session.
+        use crate::meeting_facilitator::{
+            MeetingSession as MS, MeetingSessionStatus as MSS, save_session_wip,
+        };
+        let wip = MS {
+            topic: "Resumed topic".to_string(),
+            decisions: vec![MeetingDecision {
+                description: "Old decision".to_string(),
+                rationale: "From before crash".to_string(),
+                participants: vec![],
+            }],
+            action_items: vec![],
+            notes: vec!["old note".to_string()],
+            status: MSS::Open,
+            started_at: chrono::Utc::now().to_rfc3339(),
+            participants: vec!["alice".to_string()],
+            explicit_questions: vec![],
+        };
+        save_session_wip(dir.path(), &wip).unwrap();
+
+        let bridge = mock_bridge();
+        // Answer "y" to resume, then close immediately.
+        let input = b"y\n/close\n";
+        let mut reader = &input[..];
+        let mut output = Vec::new();
+
+        let session =
+            run_meeting_repl("Ignored topic", &bridge, None, "", &mut reader, &mut output).unwrap();
+
+        let output_str = String::from_utf8(output).unwrap();
+        assert!(
+            output_str.contains("Resume previous session?"),
+            "should prompt for resume: {output_str}"
+        );
+        assert!(
+            output_str.contains("Resuming session"),
+            "should confirm resume: {output_str}"
+        );
+        // Session should carry over the old decision and topic.
+        assert_eq!(session.topic, "Resumed topic");
+        assert_eq!(session.decisions.len(), 1);
+        assert_eq!(session.decisions[0].description, "Old decision");
+        assert!(session.notes.contains(&"old note".to_string()));
+        assert!(session.participants.contains(&"alice".to_string()));
+
+        unsafe { std::env::remove_var("SIMARD_HANDOFF_DIR") };
+    }
+
+    #[test]
+    fn repl_declines_resume_starts_fresh() {
+        let dir = tempfile::tempdir().unwrap();
+        // SAFETY: test-only, run with --test-threads=1 to avoid races.
+        unsafe { std::env::set_var("SIMARD_HANDOFF_DIR", dir.path()) };
+
+        // Pre-populate a stale WIP session.
+        use crate::meeting_facilitator::{
+            MeetingSession as MS, MeetingSessionStatus as MSS, save_session_wip,
+        };
+        let wip = MS {
+            topic: "Stale topic".to_string(),
+            decisions: vec![],
+            action_items: vec![],
+            notes: vec!["stale note".to_string()],
+            status: MSS::Open,
+            started_at: chrono::Utc::now().to_rfc3339(),
+            participants: vec![],
+            explicit_questions: vec![],
+        };
+        save_session_wip(dir.path(), &wip).unwrap();
+
+        let bridge = mock_bridge();
+        // Answer "n" to decline resume, then close.
+        let input = b"n\n/close\n";
+        let mut reader = &input[..];
+        let mut output = Vec::new();
+
+        let session =
+            run_meeting_repl("Fresh topic", &bridge, None, "", &mut reader, &mut output).unwrap();
+
+        let output_str = String::from_utf8(output).unwrap();
+        assert!(
+            output_str.contains("Starting fresh session"),
+            "should start fresh: {output_str}"
+        );
+        // Should use the new topic, not the stale one.
+        assert_eq!(session.topic, "Fresh topic");
+        assert!(session.notes.is_empty());
+
+        unsafe { std::env::remove_var("SIMARD_HANDOFF_DIR") };
     }
 }


### PR DESCRIPTION
## Summary
Implements periodic auto-save and crash resume for meeting sessions (closes #273).

## Changes
- **`handoff.rs`** — `save_session_wip()`, `load_session_wip()`, `remove_session_wip()` + 5 unit tests
- **`mod.rs`** — Re-export new persistence functions
- **`repl.rs`** — REPL integration: resume prompt on startup, save after each slash command, 60s periodic auto-save, WIP cleanup on `/close`

## Behavior
- WIP state saved to `meeting_session_wip.json` in handoff directory
- On startup, detects existing WIP file and prompts `Resume previous session? (y/n)`
- On `/close`, WIP file deleted after final handoff written

## Testing
- 28 handoff tests pass (5 new: round-trip, missing file, removal, overwrite)
- `cargo clippy` clean
- `cargo check` clean