### PR TITLE
fix: graceful OODA daemon shutdown with signal handling (#264)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,6 +299,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,6 +575,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -696,6 +716,18 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
 ]
 
 [[package]]
@@ -1971,6 +2003,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
 name = "octocrab"
 version = "0.49.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3080,6 +3127,7 @@ dependencies = [
  "assert_cmd",
  "axum",
  "chrono",
+ "ctrlc",
  "libc",
  "proptest",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ tower-http = { version = "0.6", features = ["cors", "auth"] }
 uuid = { version = "1.18.1", features = ["v7"] }
 chrono = "0.4"
 tracing = "0.1"
+ctrlc = "3.4"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/src/operator_commands_ooda/daemon.rs
+++ b/src/operator_commands_ooda/daemon.rs
@@ -1,4 +1,7 @@
 use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
 
 use crate::bridge_launcher::{
     cognitive_memory_db_path, find_python_dir, launch_gym_bridge, launch_knowledge_bridge,
@@ -13,11 +16,28 @@ use crate::session_builder::SessionBuilder;
 
 use super::persistence::{persist_cycle_report, persist_cycle_to_memory};
 
+/// Sleep that wakes early when the shutdown flag is set.
+fn interruptible_sleep(total: Duration, shutdown: &AtomicBool) {
+    let tick = Duration::from_millis(250);
+    let mut remaining = total;
+    while remaining > Duration::ZERO {
+        if shutdown.load(Ordering::Relaxed) {
+            return;
+        }
+        let chunk = remaining.min(tick);
+        std::thread::sleep(chunk);
+        remaining = remaining.saturating_sub(chunk);
+    }
+}
+
 /// Run one or more OODA cycles as a daemon-style loop.
 ///
 /// Launches all bridges, opens a RustyClawd session via [`SessionBuilder`]
 /// for real autonomous work, loads the goal board from cognitive memory,
 /// and runs OODA cycles until `max_cycles` is reached (0 = infinite).
+///
+/// On SIGTERM/SIGINT the current cycle finishes, the session is closed
+/// cleanly, and the daemon exits without orphaning PTY subprocesses.
 ///
 /// If no `ANTHROPIC_API_KEY` is set, the session will be `None` and the
 /// daemon degrades honestly to bridge-only dispatch (Pillar 11).
@@ -25,6 +45,17 @@ pub fn run_ooda_daemon(
     max_cycles: u32,
     state_root_override: Option<PathBuf>,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    // --- signal handling ------------------------------------------------
+    let shutdown = Arc::new(AtomicBool::new(false));
+    {
+        let flag = Arc::clone(&shutdown);
+        ctrlc::set_handler(move || {
+            flag.store(true, Ordering::SeqCst);
+        })
+        .expect("failed to install SIGTERM/SIGINT handler");
+    }
+    // --------------------------------------------------------------------
+
     let state_root = state_root_override.unwrap_or_else(|| {
         PathBuf::from(
             std::env::var("SIMARD_STATE_ROOT").unwrap_or_else(|_| "/tmp/simard-ooda".to_string()),
@@ -78,6 +109,12 @@ pub fn run_ooda_daemon(
     let mut cycles_run = 0u32;
 
     loop {
+        // Check for shutdown signal at the top of each iteration.
+        if shutdown.load(Ordering::SeqCst) {
+            eprintln!("[simard] OODA daemon: shutting down gracefully");
+            break;
+        }
+
         if max_cycles > 0 && cycles_run >= max_cycles {
             eprintln!("[simard] OODA daemon: completed {cycles_run} cycle(s), exiting");
             break;
@@ -104,9 +141,9 @@ pub fn run_ooda_daemon(
             continue;
         }
 
-        // Sleep between cycles to avoid busy-looping. Configurable via
-        // SIMARD_OODA_INTERVAL_SECS; default is 300 seconds.
-        std::thread::sleep(std::time::Duration::from_secs(interval_secs));
+        // Interruptible sleep — wakes early on SIGTERM/SIGINT instead of
+        // blocking for the full interval.
+        interruptible_sleep(Duration::from_secs(interval_secs), &shutdown);
     }
 
     // Close the session cleanly if it was opened.


### PR DESCRIPTION
## Summary

Installs a SIGTERM/SIGINT handler so the OODA daemon shuts down cleanly instead of dying mid-cycle and potentially orphaning PTY subprocesses.

## Changes

- **Cargo.toml**: Add `ctrlc = "3.4"` for portable signal handling
- **daemon.rs**:
  - `Arc<AtomicBool>` shutdown flag set by `ctrlc::set_handler`
  - Flag checked at the top of each OODA cycle loop iteration
  - `interruptible_sleep()` replaces `thread::sleep()` — wakes within 250ms of signal instead of blocking for the full 300s interval
  - Existing `session.close()` cleanup runs on graceful exit

## Behavior

| Before | After |
|--------|-------|
| SIGTERM kills process immediately | Current cycle completes, then clean exit |
| PTY subprocesses may be orphaned | `session.close()` cleans up child processes |
| 300s sleep blocks signal response | Interruptible sleep wakes within 250ms |

Closes #264, closes #265, closes #266