### PR TITLE
fix: wire cognitive bridge into bootstrap + sync_pending lifecycle hook

### DIFF
--- a/src/bootstrap/assembly.rs
+++ b/src/bootstrap/assembly.rs
@@ -20,6 +20,7 @@ use crate::identity::{
     OperatingMode,
 };
 use crate::memory::{FileBackedMemoryStore, MemoryStore};
+use crate::memory_bridge::CognitiveMemoryBridge;
 use crate::memory_bridge_adapter::CognitiveBridgeMemoryStore;
 use crate::metadata::{Freshness, Provenance};
 use crate::prompt_assets::{FilePromptAssetStore, PromptAssetStore};
@@ -44,29 +45,50 @@ pub struct LocalSessionExecution {
     pub stopped_snapshot: ReflectionSnapshot,
 }
 
-/// Build the memory store — cognitive bridge is mandatory in production.
+/// Build the memory store and an optional second cognitive bridge for
+/// session lifecycle consolidation hooks.
 ///
 /// In `BuiltinDefaults` mode (tests/dev), falls back to file-backed store
 /// when the Python bridge is unavailable. In `ExplicitConfig` mode (production),
 /// the cognitive bridge MUST succeed or startup fails.
-fn build_memory_store(config: &BootstrapConfig) -> SimardResult<Arc<dyn MemoryStore>> {
-    let bridge = find_python_dir().ok().and_then(|python_dir| {
-        let db_path = cognitive_memory_db_path(&config.state_root.value);
-        launch_memory_bridge(&config.identity, &db_path, &python_dir).ok()
-    });
+///
+/// When the bridge is available, a second bridge instance is launched for
+/// `RuntimeKernel::set_cognitive_bridge()` so that consolidation hooks
+/// (`intake_memory_operations`, `persistence_memory_operations`) are active.
+fn build_memory_store(
+    config: &BootstrapConfig,
+) -> SimardResult<(Arc<dyn MemoryStore>, Option<CognitiveMemoryBridge>)> {
+    let python_dir = find_python_dir().ok();
+    let db_path = cognitive_memory_db_path(&config.state_root.value);
+
+    let bridge = python_dir
+        .as_ref()
+        .and_then(|pd| launch_memory_bridge(&config.identity, &db_path, pd).ok());
 
     if let Some(bridge) = bridge {
         eprintln!("[simard] cognitive memory bridge active — using LadybugDB backend");
         let store = CognitiveBridgeMemoryStore::new(bridge, config.memory_store_path())?;
         store.hydrate_from_bridge();
-        Ok(Arc::new(store))
+
+        // Launch a second bridge for RuntimeKernel consolidation hooks.
+        let consolidation_bridge = python_dir
+            .as_ref()
+            .and_then(|pd| launch_memory_bridge(&config.identity, &db_path, pd).ok());
+        if consolidation_bridge.is_some() {
+            eprintln!("[simard] consolidation bridge active — session lifecycle hooks enabled");
+        } else {
+            eprintln!("[simard] consolidation bridge unavailable — lifecycle hooks will no-op");
+        }
+
+        Ok((Arc::new(store), consolidation_bridge))
     } else if config.mode == crate::bootstrap::BootstrapMode::BuiltinDefaults {
         eprintln!(
             "[simard] cognitive memory bridge unavailable (builtin-defaults mode) — using file backend for testing"
         );
-        Ok(Arc::new(FileBackedMemoryStore::try_new(
-            config.memory_store_path(),
-        )?))
+        Ok((
+            Arc::new(FileBackedMemoryStore::try_new(config.memory_store_path())?),
+            None,
+        ))
     } else {
         Err(SimardError::BridgeSpawnFailed {
             bridge: "cognitive-memory".into(),
@@ -82,12 +104,14 @@ fn build_memory_store(config: &BootstrapConfig) -> SimardResult<Arc<dyn MemorySt
 struct AssembledParts {
     ports: RuntimePorts,
     request: RuntimeRequest,
+    /// Second bridge instance for `RuntimeKernel::set_cognitive_bridge()`.
+    consolidation_bridge: Option<CognitiveMemoryBridge>,
 }
 
 /// Build all runtime components from a bootstrap config.
 fn assemble_parts(config: &BootstrapConfig) -> SimardResult<AssembledParts> {
     let prompt_store = Arc::new(FilePromptAssetStore::new(config.prompt_root.value.clone()));
-    let memory_store = build_memory_store(config)?;
+    let (memory_store, consolidation_bridge) = build_memory_store(config)?;
     let evidence_store = Arc::new(FileBackedEvidenceStore::try_new(
         config.evidence_store_path(),
     )?);
@@ -131,12 +155,20 @@ fn assemble_parts(config: &BootstrapConfig) -> SimardResult<AssembledParts> {
         agent_program,
     )?;
 
-    Ok(AssembledParts { ports, request })
+    Ok(AssembledParts {
+        ports,
+        request,
+        consolidation_bridge,
+    })
 }
 
 pub fn assemble_local_runtime(config: &BootstrapConfig) -> SimardResult<LocalRuntime> {
     let parts = assemble_parts(config)?;
-    LocalRuntime::compose(parts.ports, parts.request)
+    let mut runtime = LocalRuntime::compose(parts.ports, parts.request)?;
+    if let Some(bridge) = parts.consolidation_bridge {
+        runtime.set_cognitive_bridge(bridge);
+    }
+    Ok(runtime)
 }
 
 pub fn assemble_local_runtime_from_handoff(
@@ -144,7 +176,11 @@ pub fn assemble_local_runtime_from_handoff(
     snapshot: RuntimeHandoffSnapshot,
 ) -> SimardResult<LocalRuntime> {
     let parts = assemble_parts(config)?;
-    LocalRuntime::compose_from_handoff(parts.ports, parts.request, snapshot)
+    let mut runtime = LocalRuntime::compose_from_handoff(parts.ports, parts.request, snapshot)?;
+    if let Some(bridge) = parts.consolidation_bridge {
+        runtime.set_cognitive_bridge(bridge);
+    }
+    Ok(runtime)
 }
 
 pub fn run_local_session(config: &BootstrapConfig) -> SimardResult<LocalSessionExecution> {
@@ -153,6 +189,10 @@ pub fn run_local_session(config: &BootstrapConfig) -> SimardResult<LocalSessionE
 
     let outcome = runtime.run(config.objective.value.clone())?;
     let _ = runtime.export_handoff()?;
+
+    // Flush any pending bridge writes before shutdown.
+    runtime.flush_pending_memory();
+
     let snapshot = runtime.snapshot()?;
     runtime.stop()?;
     let stopped_snapshot = runtime.snapshot()?;

--- a/src/memory/store.rs
+++ b/src/memory/store.rs
@@ -35,4 +35,11 @@ pub trait MemoryStore: Send + Sync {
     fn list_by_scope_across_sessions(&self, scope: MemoryScope) -> SimardResult<Vec<MemoryRecord>> {
         self.list(scope)
     }
+
+    /// Retry any pending bridge writes that failed during normal operation.
+    /// Returns the number of records successfully synced.
+    /// Default: no-op (only `CognitiveBridgeMemoryStore` has pending writes).
+    fn flush_pending(&self) -> usize {
+        0
+    }
 }

--- a/src/memory_bridge_adapter/store.rs
+++ b/src/memory_bridge_adapter/store.rs
@@ -384,4 +384,8 @@ impl MemoryStore for CognitiveBridgeMemoryStore {
             .cloned()
             .collect())
     }
+
+    fn flush_pending(&self) -> usize {
+        self.sync_pending()
+    }
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -253,6 +253,14 @@ impl RuntimeKernel {
         self.cognitive_bridge = Some(bridge);
     }
 
+    /// Flush any pending memory bridge writes (retries failed writes).
+    pub fn flush_pending_memory(&self) {
+        let synced = self.ports.memory_store.flush_pending();
+        if synced > 0 {
+            eprintln!("[simard] runtime: flushed {synced} pending memory writes");
+        }
+    }
+
     pub fn export_handoff(&self) -> SimardResult<RuntimeHandoffSnapshot> {
         let memory_records = match self.last_session.as_ref() {
             Some(session) => self.ports.memory_store.list_for_session(&session.id)?,


### PR DESCRIPTION
## Problem

`set_cognitive_bridge()` was never called in bootstrap, so `RuntimePorts.cognitive_bridge` was always `None`. This made all session-level memory consolidation hooks (`intake_memory_operations`, `persistence_memory_operations`) silently no-op in production.

Additionally, `CognitiveBridgeMemoryStore::sync_pending()` was never called from any lifecycle path — failed bridge writes silently accumulated.

## Changes

- **`build_memory_store()`** now launches a second `CognitiveMemoryBridge` instance alongside the store bridge, returned as an `Option`
- **`assemble_local_runtime()`** and **`assemble_local_runtime_from_handoff()`** call `set_cognitive_bridge()` when the consolidation bridge is available
- **`MemoryStore` trait** gains `flush_pending()` (default no-op) — `CognitiveBridgeMemoryStore` overrides to delegate to `sync_pending()`
- **`run_local_session()`** calls `flush_pending_memory()` before shutdown
- **`RuntimeKernel`** gains `flush_pending_memory()` convenience method

## Testing

- All 120 memory tests pass
- All 49 bootstrap tests pass
- All 83 runtime tests pass
- `cargo check` clean, `cargo fmt` clean

Closes #269