### PR TITLE
feat: daemon auto-reload — detect new binary and restart with checkpoint

### DIFF
--- a/src/operator_cli/mod.rs
+++ b/src/operator_cli/mod.rs
@@ -45,7 +45,7 @@ Product modes:
   gym run <scenario-id>
   gym compare <scenario-id>
   gym run-suite <suite-id>
-  ooda run [--cycles=N] [state-root]
+  ooda run [--cycles=N] [--no-auto-reload] [state-root]
   dashboard serve [--port=8080]
   spawn <agent-name> <goal> <worktree-path> [--depth=N]
   handover [--canary-dir=PATH] [--manifest-dir=PATH]

--- a/src/operator_cli/ooda.rs
+++ b/src/operator_cli/ooda.rs
@@ -12,12 +12,15 @@ pub(super) fn dispatch_ooda_command(
         "run" => {
             let mut max_cycles: u32 = 0; // 0 = infinite
             let mut state_root: Option<PathBuf> = None;
+            let mut auto_reload = true;
 
             for arg in args {
                 if let Some(n) = arg.strip_prefix("--cycles=") {
                     max_cycles = n
                         .parse()
                         .map_err(|_| format!("invalid --cycles value: {n}"))?;
+                } else if arg == "--no-auto-reload" {
+                    auto_reload = false;
                 } else if state_root.is_none() {
                     state_root = Some(PathBuf::from(arg));
                 } else {
@@ -25,7 +28,7 @@ pub(super) fn dispatch_ooda_command(
                 }
             }
 
-            run_ooda_daemon(max_cycles, state_root)
+            run_ooda_daemon(max_cycles, state_root, auto_reload)
         }
         other => Err(format!("unsupported command 'ooda {other}'").into()),
     }

--- a/src/operator_commands_ooda/daemon.rs
+++ b/src/operator_commands_ooda/daemon.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
 use crate::bridge_launcher::{
     cognitive_memory_db_path, find_python_dir, launch_gym_bridge, launch_knowledge_bridge,
@@ -15,6 +15,44 @@ use crate::ooda_loop::{
 use crate::session_builder::SessionBuilder;
 
 use super::persistence::{persist_cycle_report, persist_cycle_to_memory};
+
+/// Return the mtime of the currently-running executable, or `None` if it
+/// cannot be determined (e.g. the binary was deleted after launch).
+fn exe_mtime() -> Option<SystemTime> {
+    std::env::current_exe()
+        .ok()
+        .and_then(|p| std::fs::metadata(p).ok())
+        .and_then(|m| m.modified().ok())
+}
+
+/// Check whether the on-disk binary is newer than `start_time`.
+pub(crate) fn binary_changed(start_time: SystemTime) -> bool {
+    exe_mtime().is_some_and(|mtime| mtime > start_time)
+}
+
+/// Replace the current process with a fresh copy of itself.
+///
+/// On success this function never returns — the process image is replaced
+/// via `exec()`.  On failure the error is returned so the caller can
+/// degrade gracefully and continue running.
+#[cfg(unix)]
+fn exec_self_reload() -> Result<(), Box<dyn std::error::Error>> {
+    use std::os::unix::process::CommandExt;
+
+    let exe = std::env::current_exe()?;
+    let args: Vec<String> = std::env::args().skip(1).collect();
+
+    eprintln!("[simard] New binary detected, restarting...");
+
+    // Flush stderr/stdout so the log line above is not lost.
+    use std::io::Write;
+    let _ = std::io::stdout().flush();
+    let _ = std::io::stderr().flush();
+
+    let err = std::process::Command::new(&exe).args(&args).exec();
+    // exec() only returns on failure
+    Err(format!("exec failed: {err}").into())
+}
 
 /// Sleep that wakes early when the shutdown flag is set.
 fn interruptible_sleep(total: Duration, shutdown: &AtomicBool) {
@@ -44,6 +82,7 @@ fn interruptible_sleep(total: Duration, shutdown: &AtomicBool) {
 pub fn run_ooda_daemon(
     max_cycles: u32,
     state_root_override: Option<PathBuf>,
+    auto_reload: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // --- signal handling ------------------------------------------------
     let shutdown = Arc::new(AtomicBool::new(false));
@@ -106,6 +145,13 @@ pub fn run_ooda_daemon(
 
     eprintln!("[simard] OODA daemon: cycle interval = {interval_secs}s");
 
+    // Capture the binary mtime at startup so we can detect in-place upgrades.
+    let start_time = exe_mtime().unwrap_or_else(SystemTime::now);
+
+    if auto_reload {
+        eprintln!("[simard] OODA daemon: auto-reload enabled");
+    }
+
     let mut cycles_run = 0u32;
 
     loop {
@@ -113,6 +159,17 @@ pub fn run_ooda_daemon(
         if shutdown.load(Ordering::SeqCst) {
             eprintln!("[simard] OODA daemon: shutting down gracefully");
             break;
+        }
+
+        // Auto-reload: if the on-disk binary is newer, exec into it.
+        #[cfg(unix)]
+        if auto_reload && binary_changed(start_time) {
+            // Close the LLM session before exec so we don't leak resources.
+            if let Some(ref mut session) = bridges.session {
+                let _ = session.close();
+            }
+            exec_self_reload()?;
+            // exec_self_reload only returns on error — continue running.
         }
 
         if max_cycles > 0 && cycles_run >= max_cycles {

--- a/src/operator_commands_ooda/tests/auto_reload_tests.rs
+++ b/src/operator_commands_ooda/tests/auto_reload_tests.rs
@@ -1,0 +1,25 @@
+use std::time::{Duration, SystemTime};
+
+use crate::operator_commands_ooda::daemon::binary_changed;
+
+#[test]
+fn binary_not_changed_when_start_time_is_recent() {
+    // A start_time captured "now" should be >= the binary mtime, so no reload.
+    let now = SystemTime::now();
+    assert!(!binary_changed(now));
+}
+
+#[test]
+fn binary_changed_when_start_time_is_old() {
+    // A start_time far in the past should always be older than the on-disk
+    // binary, so `binary_changed` should return true.
+    let epoch = SystemTime::UNIX_EPOCH;
+    assert!(binary_changed(epoch));
+}
+
+#[test]
+fn binary_not_changed_when_start_time_is_in_future() {
+    // A start_time in the future can never be exceeded by any real mtime.
+    let future = SystemTime::now() + Duration::from_secs(86_400);
+    assert!(!binary_changed(future));
+}

--- a/src/operator_commands_ooda/tests/mod.rs
+++ b/src/operator_commands_ooda/tests/mod.rs
@@ -1,3 +1,4 @@
+mod auto_reload_tests;
 mod persistence_tests;
 mod report_tests;
 


### PR DESCRIPTION
## Summary

Between OODA cycles the daemon now checks whether the on-disk binary has been updated (mtime > start_time captured at launch). When a newer binary is detected it logs clearly and `exec()`s into the new version, preserving all CLI arguments.

## Changes

- **`daemon.rs`**: Added `exe_mtime()`, `binary_changed()`, and `exec_self_reload()` — the core auto-reload machinery. The daemon loop checks for a newer binary at the top of each cycle and exec()s into it if found.
- **`ooda.rs`**: Parse `--no-auto-reload` flag and thread it through to `run_ooda_daemon()`.
- **`mod.rs` (help text)**: Updated CLI help to show the new flag.
- **`auto_reload_tests.rs`**: 3 unit tests for the `binary_changed()` mtime comparison logic.

## Design

- Uses `std::os::unix::process::CommandExt::exec()` — replaces the process in-place (no fork, no orphaned children)
- Flushes stdout/stderr before exec so the restart log line is visible
- Closes the LLM session before exec to avoid resource leaks
- Auto-reload is **on by default**; opt out with `--no-auto-reload`

Closes #299