### PR TITLE
test: add unit tests for 10 untested modules (round 6)

### DIFF
--- a/src/copilot_task_submit/types.rs
+++ b/src/copilot_task_submit/types.rs
@@ -276,3 +276,173 @@ impl TranscriptCheckpointScan {
 fn prompt_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("prompt_assets")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- CopilotSubmitOutcome --
+
+    #[test]
+    fn outcome_as_str() {
+        assert_eq!(CopilotSubmitOutcome::Success.as_str(), "success");
+        assert_eq!(CopilotSubmitOutcome::Unsupported.as_str(), "unsupported");
+    }
+
+    #[test]
+    fn outcome_serializes_to_kebab_case() {
+        let json = serde_json::to_string(&CopilotSubmitOutcome::Success).unwrap();
+        assert_eq!(json, r#""success""#);
+        let json = serde_json::to_string(&CopilotSubmitOutcome::Unsupported).unwrap();
+        assert_eq!(json, r#""unsupported""#);
+    }
+
+    // -- TranscriptCheckpointScan --
+
+    #[test]
+    fn empty_scan_has_no_checkpoints() {
+        let scan = TranscriptCheckpointScan::default();
+        assert!(!scan.has_banner());
+        assert!(!scan.has_guidance());
+        assert!(!scan.has_submit_hint());
+        assert!(!scan.has_post_submit_checkpoint());
+        assert!(!scan.has_visible_startup_evidence());
+    }
+
+    #[test]
+    fn record_and_query_checkpoints() {
+        let mut scan = TranscriptCheckpointScan::default();
+        scan.record_checkpoint(PositiveCheckpointKind::StartupBanner, "banner line", 0);
+        scan.record_checkpoint(PositiveCheckpointKind::Guidance, "guidance line", 1);
+
+        assert!(scan.has_banner());
+        assert!(scan.has_guidance());
+        assert!(!scan.has_submit_hint());
+        assert_eq!(
+            scan.checkpoint_index(PositiveCheckpointKind::StartupBanner),
+            Some(0)
+        );
+        assert_eq!(
+            scan.checkpoint_index(PositiveCheckpointKind::Guidance),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn has_ordered_startup_sequence() {
+        let mut scan = TranscriptCheckpointScan::default();
+        scan.record_checkpoint(PositiveCheckpointKind::StartupBanner, "banner", 0);
+        scan.record_checkpoint(PositiveCheckpointKind::Guidance, "guidance", 5);
+        assert!(scan.has_ordered_startup_sequence());
+    }
+
+    #[test]
+    fn no_ordered_startup_when_guidance_before_banner() {
+        let mut scan = TranscriptCheckpointScan::default();
+        scan.record_checkpoint(PositiveCheckpointKind::Guidance, "guidance", 0);
+        scan.record_checkpoint(PositiveCheckpointKind::StartupBanner, "banner", 5);
+        assert!(!scan.has_ordered_startup_sequence());
+    }
+
+    #[test]
+    fn observed_banner_before_guidance_when_banner_only() {
+        let mut scan = TranscriptCheckpointScan::default();
+        scan.record_checkpoint(PositiveCheckpointKind::StartupBanner, "banner", 0);
+        // No guidance recorded — should still return true
+        assert!(scan.observed_banner_before_guidance());
+    }
+
+    #[test]
+    fn observed_checkpoints_collects_lines() {
+        let mut scan = TranscriptCheckpointScan::default();
+        scan.record_checkpoint(PositiveCheckpointKind::StartupBanner, "line-a", 0);
+        scan.record_checkpoint(PositiveCheckpointKind::SubmitHint, "line-b", 1);
+        let lines = scan.observed_checkpoints();
+        assert_eq!(lines, vec!["line-a".to_string(), "line-b".to_string()]);
+    }
+
+    #[test]
+    fn has_visible_startup_evidence_with_trust_prompt() {
+        let scan = TranscriptCheckpointScan {
+            has_trust_prompt: true,
+            ..Default::default()
+        };
+        assert!(scan.has_visible_startup_evidence());
+    }
+
+    // -- StartupStatus / SubmitStatus equality --
+
+    #[test]
+    fn startup_status_equality() {
+        assert_eq!(StartupStatus::Ready, StartupStatus::Ready);
+        assert_eq!(StartupStatus::Wait, StartupStatus::Wait);
+        assert_ne!(StartupStatus::Ready, StartupStatus::Wait);
+        assert_eq!(
+            StartupStatus::Unsupported("reason"),
+            StartupStatus::Unsupported("reason")
+        );
+    }
+
+    #[test]
+    fn submit_status_equality() {
+        assert_eq!(SubmitStatus::Success, SubmitStatus::Success);
+        assert_eq!(SubmitStatus::Wait, SubmitStatus::Wait);
+        assert_ne!(SubmitStatus::Success, SubmitStatus::Wait);
+    }
+
+    // -- CopilotSubmitFlowAsset helpers --
+
+    #[test]
+    fn flow_asset_wait_timeout() {
+        let flow = CopilotSubmitFlowAsset {
+            launch_command: "copilot".to_string(),
+            working_directory: PathBuf::from("."),
+            wait_timeout_seconds: 30,
+            startup_banner: "Welcome".to_string(),
+            guidance_checkpoint: "Ready".to_string(),
+            submit_hint: "Submit".to_string(),
+            post_submit_checkpoint: None,
+            trust_prompt: None,
+            wrapper_error_signal: None,
+            workflow_noise_signals: vec![],
+            payload_id: "test-payload".to_string(),
+            payload: "task data".to_string(),
+        };
+        assert_eq!(flow.wait_timeout(), Duration::from_secs(30));
+        assert_eq!(flow.launch_step(), "launch: copilot");
+        assert!(flow.post_submit_step().is_none());
+    }
+
+    #[test]
+    fn flow_asset_post_submit_step_some() {
+        let flow = CopilotSubmitFlowAsset {
+            launch_command: "copilot".to_string(),
+            working_directory: PathBuf::from("."),
+            wait_timeout_seconds: 10,
+            startup_banner: "Welcome".to_string(),
+            guidance_checkpoint: "Ready".to_string(),
+            submit_hint: "Submit".to_string(),
+            post_submit_checkpoint: Some("Done!".to_string()),
+            trust_prompt: None,
+            wrapper_error_signal: None,
+            workflow_noise_signals: vec![],
+            payload_id: "test".to_string(),
+            payload: "data".to_string(),
+        };
+        assert!(flow.post_submit_step().is_some());
+    }
+
+    // -- StartupCheckpointState --
+
+    #[test]
+    fn startup_checkpoint_state_variants() {
+        let states = [
+            StartupCheckpointState::ExpectBanner,
+            StartupCheckpointState::ExpectGuidance,
+            StartupCheckpointState::Complete,
+        ];
+        // Ensure all variants exist and are distinct
+        assert_ne!(states[0], states[1]);
+        assert_ne!(states[1], states[2]);
+    }
+}

--- a/src/engineer_loop/review_persist.rs
+++ b/src/engineer_loop/review_persist.rs
@@ -260,3 +260,102 @@ pub(crate) fn persist_engineer_loop_artifacts(
     persist_handoff_artifacts(state_root, ScopedHandoffMode::Engineer, &handoff)?;
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    use crate::engineer_loop::types::{
+        EngineerActionKind, ExecutedEngineerAction, SelectedEngineerAction,
+    };
+
+    fn make_inspection() -> RepoInspection {
+        RepoInspection {
+            workspace_root: PathBuf::from("/fake/workspace"),
+            repo_root: PathBuf::from("/fake/repo"),
+            branch: "main".to_string(),
+            head: "abc123".to_string(),
+            worktree_dirty: false,
+            changed_files: Vec::new(),
+            active_goals: Vec::new(),
+            carried_meeting_decisions: Vec::new(),
+            architecture_gap_summary: String::new(),
+        }
+    }
+
+    fn make_executed(kind: EngineerActionKind) -> ExecutedEngineerAction {
+        ExecutedEngineerAction {
+            selected: SelectedEngineerAction {
+                label: "test-action".into(),
+                rationale: "test".into(),
+                argv: vec!["test".into()],
+                plan_summary: "test plan".into(),
+                verification_steps: Vec::new(),
+                expected_changed_files: Vec::new(),
+                kind,
+            },
+            exit_code: 0,
+            stdout: String::new(),
+            stderr: String::new(),
+            changed_files: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn philosophy_review_contains_required_keywords() {
+        assert!(PHILOSOPHY_REVIEW.contains("simplicity"));
+        assert!(PHILOSOPHY_REVIEW.contains("Clippy"));
+        assert!(PHILOSOPHY_REVIEW.contains("400 lines"));
+        assert!(!PHILOSOPHY_REVIEW.is_empty());
+    }
+
+    #[test]
+    fn compute_diff_for_review_returns_empty_on_nonexistent_repo() {
+        let result = compute_diff_for_review(
+            Path::new("/nonexistent/path"),
+            &EngineerActionKind::ReadOnlyScan,
+        );
+        assert!(
+            result.is_empty(),
+            "expected empty diff for nonexistent repo"
+        );
+    }
+
+    #[test]
+    fn compute_diff_uses_head_diff_for_git_commit() {
+        // GitCommit variant should trigger `git diff HEAD~1 HEAD`
+        // On a nonexistent path this still returns empty, but exercises the branch
+        let result = compute_diff_for_review(
+            Path::new("/nonexistent/path"),
+            &EngineerActionKind::GitCommit(crate::engineer_loop::types::GitCommitRequest {
+                message: "test commit".to_string(),
+            }),
+        );
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn run_optional_review_skips_read_only_scan() {
+        let inspection = make_inspection();
+        let action = make_executed(EngineerActionKind::ReadOnlyScan);
+        let result = run_optional_review(&inspection, &action);
+        assert!(result.is_ok(), "read-only actions should be skipped");
+    }
+
+    #[test]
+    fn run_optional_review_skips_cargo_test() {
+        let inspection = make_inspection();
+        let action = make_executed(EngineerActionKind::CargoTest);
+        let result = run_optional_review(&inspection, &action);
+        assert!(result.is_ok(), "cargo test actions should be skipped");
+    }
+
+    #[test]
+    fn run_optional_review_skips_cargo_check() {
+        let inspection = make_inspection();
+        let action = make_executed(EngineerActionKind::CargoCheck);
+        let result = run_optional_review(&inspection, &action);
+        assert!(result.is_ok(), "cargo check actions should be skipped");
+    }
+}

--- a/src/engineer_loop/verification_actions.rs
+++ b/src/engineer_loop/verification_actions.rs
@@ -282,3 +282,272 @@ pub(crate) fn verify_cargo_metadata(
     checks.push(format!("metadata-packages={}", packages.len()));
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::types::SelectedEngineerAction;
+    use super::*;
+
+    fn make_action(
+        kind: EngineerActionKind,
+        exit_code: i32,
+        stdout: &str,
+        stderr: &str,
+    ) -> ExecutedEngineerAction {
+        ExecutedEngineerAction {
+            selected: SelectedEngineerAction {
+                label: "test-action".to_string(),
+                rationale: "test".to_string(),
+                argv: vec![],
+                plan_summary: "test plan".to_string(),
+                verification_steps: vec![],
+                expected_changed_files: vec![],
+                kind,
+            },
+            exit_code,
+            stdout: stdout.to_string(),
+            stderr: stderr.to_string(),
+            changed_files: vec![],
+        }
+    }
+
+    // -- verify_cargo_test --
+
+    #[test]
+    fn verify_cargo_test_passing() {
+        let action = make_action(
+            EngineerActionKind::CargoTest,
+            0,
+            "test result: ok. 5 passed; 0 failed",
+            "",
+        );
+        let mut checks = vec![];
+        verify_cargo_test(&action, &mut checks).unwrap();
+        assert!(checks.iter().any(|c| c == "cargo-test-result-present=true"));
+        assert!(checks.iter().any(|c| c == "cargo-test-passed=true"));
+    }
+
+    #[test]
+    fn verify_cargo_test_failing() {
+        let action = make_action(
+            EngineerActionKind::CargoTest,
+            101,
+            "",
+            "test result: FAILED. 1 passed; 2 failed",
+        );
+        let mut checks = vec![];
+        verify_cargo_test(&action, &mut checks).unwrap();
+        assert!(checks.iter().any(|c| c == "cargo-test-passed=false"));
+    }
+
+    #[test]
+    fn verify_cargo_test_no_output_nonzero_exit() {
+        let action = make_action(EngineerActionKind::CargoTest, 1, "", "");
+        let mut checks = vec![];
+        let result = verify_cargo_test(&action, &mut checks);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn verify_cargo_test_no_output_zero_exit() {
+        let action = make_action(EngineerActionKind::CargoTest, 0, "", "");
+        let mut checks = vec![];
+        verify_cargo_test(&action, &mut checks).unwrap();
+        assert!(checks.iter().any(|c| c.contains("exit 0")));
+    }
+
+    // -- verify_cargo_check --
+
+    #[test]
+    fn verify_cargo_check_success() {
+        let action = make_action(EngineerActionKind::CargoCheck, 0, "", "");
+        let mut checks = vec![];
+        verify_cargo_check(&action, &mut checks);
+        assert!(checks.iter().any(|c| c == "cargo-check-passed=true"));
+    }
+
+    #[test]
+    fn verify_cargo_check_failure_with_errors() {
+        let action = make_action(
+            EngineerActionKind::CargoCheck,
+            1,
+            "",
+            "error[E0308]: mismatched types\nerror: aborting",
+        );
+        let mut checks = vec![];
+        verify_cargo_check(&action, &mut checks);
+        assert!(
+            checks
+                .iter()
+                .any(|c| c.contains("cargo-check-passed=false") && c.contains("errors=2"))
+        );
+    }
+
+    // -- verify_create_file --
+
+    #[test]
+    fn verify_create_file_success() {
+        let dir = std::env::temp_dir().join("simard_test_create_file");
+        let _ = fs::create_dir_all(&dir);
+        let file_path = dir.join("hello.txt");
+        fs::write(&file_path, "hello world").unwrap();
+
+        let inspection = RepoInspection {
+            workspace_root: dir.clone(),
+            repo_root: dir.clone(),
+            branch: "main".to_string(),
+            head: "abc123".to_string(),
+            worktree_dirty: false,
+            changed_files: vec![],
+            active_goals: vec![],
+            carried_meeting_decisions: vec![],
+            architecture_gap_summary: String::new(),
+        };
+        let req = CreateFileRequest {
+            relative_path: "hello.txt".to_string(),
+            content: "hello world".to_string(),
+        };
+        let mut checks = vec![];
+        verify_create_file(&inspection, &req, &mut checks).unwrap();
+        assert!(checks.iter().any(|c| c.contains("file-exists")));
+        assert!(checks.iter().any(|c| c == "file-content-matches=true"));
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn verify_create_file_missing() {
+        let dir = std::env::temp_dir().join("simard_test_create_file_missing");
+        let _ = fs::create_dir_all(&dir);
+
+        let inspection = RepoInspection {
+            workspace_root: dir.clone(),
+            repo_root: dir.clone(),
+            branch: "main".to_string(),
+            head: "abc123".to_string(),
+            worktree_dirty: false,
+            changed_files: vec![],
+            active_goals: vec![],
+            carried_meeting_decisions: vec![],
+            architecture_gap_summary: String::new(),
+        };
+        let req = CreateFileRequest {
+            relative_path: "nonexistent.txt".to_string(),
+            content: "content".to_string(),
+        };
+        let mut checks = vec![];
+        let result = verify_create_file(&inspection, &req, &mut checks);
+        assert!(result.is_err());
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    // -- verify_append_to_file --
+
+    #[test]
+    fn verify_append_to_file_success() {
+        let dir = std::env::temp_dir().join("simard_test_append");
+        let _ = fs::create_dir_all(&dir);
+        fs::write(dir.join("log.txt"), "line1\nAPPENDED DATA\nline3").unwrap();
+
+        let inspection = RepoInspection {
+            workspace_root: dir.clone(),
+            repo_root: dir.clone(),
+            branch: "main".to_string(),
+            head: "abc123".to_string(),
+            worktree_dirty: false,
+            changed_files: vec![],
+            active_goals: vec![],
+            carried_meeting_decisions: vec![],
+            architecture_gap_summary: String::new(),
+        };
+        let req = AppendToFileRequest {
+            relative_path: "log.txt".to_string(),
+            content: "APPENDED DATA".to_string(),
+        };
+        let mut checks = vec![];
+        verify_append_to_file(&inspection, &req, &mut checks).unwrap();
+        assert!(checks.iter().any(|c| c.contains("file-contains-appended")));
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    // -- verify_open_issue --
+
+    #[test]
+    fn verify_open_issue_with_url() {
+        let action = make_action(
+            EngineerActionKind::ReadOnlyScan,
+            0,
+            "Created issue https://github.com/org/repo/issues/42",
+            "",
+        );
+        let mut checks = vec![];
+        verify_open_issue(&action, &mut checks).unwrap();
+        assert!(checks.iter().any(|c| c == "issue-url-present=true"));
+    }
+
+    #[test]
+    fn verify_open_issue_without_url() {
+        let action = make_action(EngineerActionKind::ReadOnlyScan, 0, "no url here", "");
+        let mut checks = vec![];
+        let result = verify_open_issue(&action, &mut checks);
+        assert!(result.is_err());
+    }
+
+    // -- build_verification_summary --
+
+    #[test]
+    fn build_verification_summary_cargo_test() {
+        let action = make_action(EngineerActionKind::CargoTest, 0, "", "");
+        let summary = build_verification_summary(&action);
+        assert!(summary.contains("cargo test"));
+        assert!(summary.contains("passed"));
+    }
+
+    #[test]
+    fn build_verification_summary_cargo_check() {
+        let action = make_action(EngineerActionKind::CargoCheck, 1, "", "");
+        let summary = build_verification_summary(&action);
+        assert!(summary.contains("cargo check"));
+        assert!(summary.contains("failed"));
+    }
+
+    #[test]
+    fn build_verification_summary_read_only() {
+        let action = make_action(EngineerActionKind::ReadOnlyScan, 0, "", "");
+        let summary = build_verification_summary(&action);
+        assert!(summary.contains("local-only engineer action"));
+    }
+
+    // -- verify_cargo_metadata --
+
+    #[test]
+    fn verify_cargo_metadata_invalid_json() {
+        let mut checks = vec![];
+        let result = verify_cargo_metadata(Path::new("/fake"), "not json", &mut checks);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn verify_cargo_metadata_missing_workspace_root() {
+        let json = r#"{"packages": [{"name": "foo"}]}"#;
+        let mut checks = vec![];
+        let result = verify_cargo_metadata(Path::new("/fake"), json, &mut checks);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn verify_cargo_metadata_empty_packages() {
+        let cwd = std::env::current_dir().unwrap();
+        let canonical = fs::canonicalize(&cwd).unwrap();
+        let json = serde_json::json!({
+            "workspace_root": canonical.to_str().unwrap(),
+            "packages": []
+        })
+        .to_string();
+        let mut checks = vec![];
+        let result = verify_cargo_metadata(&canonical, &json, &mut checks);
+        assert!(result.is_err());
+    }
+}

--- a/src/goal_curation/operations.rs
+++ b/src/goal_curation/operations.rs
@@ -266,3 +266,210 @@ pub fn seed_default_board(board: &mut GoalBoard) -> usize {
 
     DEFAULT_SEED_GOALS.len()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_goal(id: &str, priority: u32) -> ActiveGoal {
+        ActiveGoal {
+            id: id.to_string(),
+            description: "A test goal".to_string(),
+            priority,
+            status: GoalProgress::NotStarted,
+            assigned_to: None,
+        }
+    }
+
+    fn make_backlog(id: &str) -> BacklogItem {
+        BacklogItem {
+            id: id.to_string(),
+            description: "A backlog item".to_string(),
+            source: "test".to_string(),
+            score: 0.5,
+        }
+    }
+
+    // -- Validation helpers --
+
+    #[test]
+    fn required_field_rejects_empty() {
+        assert!(required_field("name", "").is_err());
+        assert!(required_field("name", "   ").is_err());
+        assert!(required_field("name", "ok").is_ok());
+    }
+
+    #[test]
+    fn validate_priority_rejects_zero() {
+        assert!(validate_priority("p", 0).is_err());
+        assert!(validate_priority("p", 1).is_ok());
+        assert!(validate_priority("p", 100).is_ok());
+    }
+
+    #[test]
+    fn validate_active_goal_rejects_invalid() {
+        let mut goal = make_goal("g1", 1);
+        assert!(validate_active_goal(&goal).is_ok());
+
+        goal.id = String::new();
+        assert!(validate_active_goal(&goal).is_err());
+
+        let mut goal2 = make_goal("g2", 0);
+        assert!(validate_active_goal(&goal2).is_err());
+
+        goal2.priority = 1;
+        goal2.status = GoalProgress::InProgress { percent: 150 };
+        assert!(validate_active_goal(&goal2).is_err());
+    }
+
+    #[test]
+    fn validate_backlog_item_rejects_empty_fields() {
+        let item = make_backlog("b1");
+        assert!(validate_backlog_item(&item).is_ok());
+
+        let bad = BacklogItem {
+            id: "".to_string(),
+            ..item.clone()
+        };
+        assert!(validate_backlog_item(&bad).is_err());
+
+        let bad2 = BacklogItem {
+            source: "".to_string(),
+            ..make_backlog("b2")
+        };
+        assert!(validate_backlog_item(&bad2).is_err());
+    }
+
+    // -- Board mutations --
+
+    #[test]
+    fn add_active_goal_success() {
+        let mut board = GoalBoard::new();
+        add_active_goal(&mut board, make_goal("g1", 1)).unwrap();
+        assert_eq!(board.active.len(), 1);
+        assert_eq!(board.active[0].id, "g1");
+    }
+
+    #[test]
+    fn add_active_goal_rejects_duplicate() {
+        let mut board = GoalBoard::new();
+        add_active_goal(&mut board, make_goal("g1", 1)).unwrap();
+        let result = add_active_goal(&mut board, make_goal("g1", 2));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn add_active_goal_rejects_over_capacity() {
+        let mut board = GoalBoard::new();
+        for i in 0..MAX_ACTIVE_GOALS {
+            add_active_goal(&mut board, make_goal(&format!("g{i}"), 1)).unwrap();
+        }
+        let result = add_active_goal(&mut board, make_goal("overflow", 1));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn add_backlog_item_success() {
+        let mut board = GoalBoard::new();
+        add_backlog_item(&mut board, make_backlog("b1")).unwrap();
+        assert_eq!(board.backlog.len(), 1);
+    }
+
+    #[test]
+    fn add_backlog_item_rejects_duplicate() {
+        let mut board = GoalBoard::new();
+        add_backlog_item(&mut board, make_backlog("b1")).unwrap();
+        assert!(add_backlog_item(&mut board, make_backlog("b1")).is_err());
+    }
+
+    // -- promote_to_active --
+
+    #[test]
+    fn promote_to_active_moves_item() {
+        let mut board = GoalBoard::new();
+        add_backlog_item(&mut board, make_backlog("b1")).unwrap();
+        promote_to_active(&mut board, "b1", 1, Some("owner".into())).unwrap();
+        assert!(board.backlog.is_empty());
+        assert_eq!(board.active.len(), 1);
+        assert_eq!(board.active[0].assigned_to.as_deref(), Some("owner"));
+    }
+
+    #[test]
+    fn promote_to_active_fails_for_missing_item() {
+        let mut board = GoalBoard::new();
+        assert!(promote_to_active(&mut board, "ghost", 1, None).is_err());
+    }
+
+    #[test]
+    fn promote_to_active_fails_at_capacity() {
+        let mut board = GoalBoard::new();
+        for i in 0..MAX_ACTIVE_GOALS {
+            add_active_goal(&mut board, make_goal(&format!("g{i}"), 1)).unwrap();
+        }
+        add_backlog_item(&mut board, make_backlog("b1")).unwrap();
+        assert!(promote_to_active(&mut board, "b1", 1, None).is_err());
+    }
+
+    // -- update_goal_progress --
+
+    #[test]
+    fn update_goal_progress_success() {
+        let mut board = GoalBoard::new();
+        add_active_goal(&mut board, make_goal("g1", 1)).unwrap();
+        update_goal_progress(&mut board, "g1", GoalProgress::InProgress { percent: 50 }).unwrap();
+        assert_eq!(
+            board.active[0].status,
+            GoalProgress::InProgress { percent: 50 }
+        );
+    }
+
+    #[test]
+    fn update_goal_progress_rejects_over_100() {
+        let mut board = GoalBoard::new();
+        add_active_goal(&mut board, make_goal("g1", 1)).unwrap();
+        let result =
+            update_goal_progress(&mut board, "g1", GoalProgress::InProgress { percent: 200 });
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn update_goal_progress_fails_for_missing_goal() {
+        let mut board = GoalBoard::new();
+        assert!(update_goal_progress(&mut board, "ghost", GoalProgress::Completed).is_err());
+    }
+
+    // -- archive_completed --
+
+    #[test]
+    fn archive_completed_removes_completed_goals() {
+        let mut board = GoalBoard::new();
+        add_active_goal(&mut board, make_goal("g1", 1)).unwrap();
+        add_active_goal(&mut board, make_goal("g2", 2)).unwrap();
+        update_goal_progress(&mut board, "g1", GoalProgress::Completed).unwrap();
+
+        let archived = archive_completed(&mut board);
+        assert_eq!(archived.len(), 1);
+        assert_eq!(archived[0].id, "g1");
+        assert_eq!(board.active.len(), 1);
+        assert_eq!(board.active[0].id, "g2");
+    }
+
+    // -- seed_default_board --
+
+    #[test]
+    fn seed_default_board_populates_empty_board() {
+        let mut board = GoalBoard::new();
+        let count = seed_default_board(&mut board);
+        assert_eq!(count, DEFAULT_SEED_GOALS.len());
+        assert_eq!(board.active.len(), DEFAULT_SEED_GOALS.len());
+    }
+
+    #[test]
+    fn seed_default_board_noop_when_goals_exist() {
+        let mut board = GoalBoard::new();
+        add_active_goal(&mut board, make_goal("existing", 1)).unwrap();
+        let count = seed_default_board(&mut board);
+        assert_eq!(count, 0);
+        assert_eq!(board.active.len(), 1);
+    }
+}

--- a/src/improvements/parsing.rs
+++ b/src/improvements/parsing.rs
@@ -255,3 +255,176 @@ pub(super) fn looks_like_field_start(raw: &str, cursor: usize) -> bool {
     }
     false
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── parse_bracketed_list ──────────────────────────────────────
+
+    #[test]
+    fn bracketed_list_nested_brackets_preserved() {
+        let result = parse_bracketed_list("f", "[outer [inner] value]").unwrap();
+        assert_eq!(result, vec!["outer [inner] value"]);
+    }
+
+    #[test]
+    fn bracketed_list_pipe_inside_nested_brackets_not_split() {
+        let result = parse_bracketed_list("f", "[a [x|y] | b]").unwrap();
+        assert_eq!(result, vec!["a [x|y]", "b"]);
+    }
+
+    #[test]
+    fn bracketed_list_rejects_missing_brackets() {
+        let result = parse_bracketed_list("test-field", "no brackets here");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        match err {
+            SimardError::InvalidImprovementRecord { field, reason } => {
+                assert_eq!(field, "test-field");
+                assert!(reason.contains("bracketed list syntax"));
+            }
+            other => panic!("expected InvalidImprovementRecord, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn bracketed_list_rejects_empty_item() {
+        let result = parse_bracketed_list("f", "[a||b]");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn bracketed_list_rejects_unbalanced_open_bracket() {
+        let result = parse_bracketed_list("f", "[a [b]");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn bracketed_list_rejects_extra_close_bracket() {
+        let result = parse_bracketed_list("f", "[a ] b]");
+        assert!(result.is_err());
+    }
+
+    // ── parse_non_negative_count ──────────────────────────────────
+
+    #[test]
+    fn non_negative_count_valid() {
+        assert_eq!(parse_non_negative_count("f", "42").unwrap(), 42);
+    }
+
+    #[test]
+    fn non_negative_count_zero() {
+        assert_eq!(parse_non_negative_count("f", "0").unwrap(), 0);
+    }
+
+    #[test]
+    fn non_negative_count_trims_whitespace() {
+        assert_eq!(parse_non_negative_count("f", "  7  ").unwrap(), 7);
+    }
+
+    #[test]
+    fn non_negative_count_rejects_negative() {
+        assert!(parse_non_negative_count("f", "-1").is_err());
+    }
+
+    #[test]
+    fn non_negative_count_rejects_non_numeric() {
+        assert!(parse_non_negative_count("f", "abc").is_err());
+    }
+
+    // ── parse_persisted_record_pairs ──────────────────────────────
+
+    #[test]
+    fn record_pairs_simple() {
+        let pairs = parse_persisted_record_pairs("key=value").unwrap();
+        assert_eq!(pairs, vec![("key", "value")]);
+    }
+
+    #[test]
+    fn record_pairs_multiple_pipe_separated() {
+        let pairs = parse_persisted_record_pairs("a=1 | b=2 | c=3").unwrap();
+        assert_eq!(pairs.len(), 3);
+        assert_eq!(pairs[0], ("a", "1"));
+        assert_eq!(pairs[1], ("b", "2"));
+        assert_eq!(pairs[2], ("c", "3"));
+    }
+
+    #[test]
+    fn record_pairs_strips_improvement_curation_prefix() {
+        let pairs =
+            parse_persisted_record_pairs("improvement-curation-record | key=value").unwrap();
+        assert_eq!(pairs, vec![("key", "value")]);
+    }
+
+    #[test]
+    fn record_pairs_bracketed_value() {
+        let pairs = parse_persisted_record_pairs("items=[a|b|c]").unwrap();
+        assert_eq!(pairs.len(), 1);
+        assert_eq!(pairs[0].0, "items");
+        assert_eq!(pairs[0].1, "[a|b|c]");
+    }
+
+    #[test]
+    fn record_pairs_rejects_empty_input() {
+        assert!(parse_persisted_record_pairs("").is_err());
+    }
+
+    #[test]
+    fn record_pairs_rejects_whitespace_only() {
+        assert!(parse_persisted_record_pairs("   ").is_err());
+    }
+
+    // ── read_bracketed_value ──────────────────────────────────────
+
+    #[test]
+    fn read_bracketed_value_simple() {
+        let (value, next) = read_bracketed_value("[abc]", 0).unwrap();
+        assert_eq!(value, "[abc]");
+        assert_eq!(next, 5);
+    }
+
+    #[test]
+    fn read_bracketed_value_nested() {
+        let (value, next) = read_bracketed_value("[a [b] c]", 0).unwrap();
+        assert_eq!(value, "[a [b] c]");
+        assert_eq!(next, 9);
+    }
+
+    #[test]
+    fn read_bracketed_value_unterminated() {
+        assert!(read_bracketed_value("[abc", 0).is_err());
+    }
+
+    // ── skip helpers ──────────────────────────────────────────────
+
+    #[test]
+    fn skip_record_separators_skips_pipes_and_spaces() {
+        assert_eq!(skip_record_separators(" | | abc", 0), 5);
+    }
+
+    #[test]
+    fn skip_record_separators_noop_on_non_separator() {
+        assert_eq!(skip_record_separators("abc", 0), 0);
+    }
+
+    #[test]
+    fn skip_spaces_basic() {
+        assert_eq!(skip_spaces("   abc", 0), 3);
+    }
+
+    #[test]
+    fn looks_like_field_start_true_for_key_equals() {
+        assert!(looks_like_field_start("key=value", 0));
+    }
+
+    #[test]
+    fn looks_like_field_start_false_for_plain_text() {
+        assert!(!looks_like_field_start("plain text", 0));
+    }
+
+    #[test]
+    fn looks_like_field_start_false_at_pipe() {
+        assert!(!looks_like_field_start("| key=value", 0));
+    }
+}

--- a/src/memory_bridge_adapter/store.rs
+++ b/src/memory_bridge_adapter/store.rs
@@ -389,3 +389,230 @@ impl MemoryStore for CognitiveBridgeMemoryStore {
         self.sync_pending()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bridge::{BridgeRequest, BridgeResponse};
+    use crate::memory::{MemoryRecord, MemoryScope, MemoryStore};
+    use crate::metadata::{BackendDescriptor, Freshness};
+    use crate::session::{SessionId, SessionPhase};
+
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// A mock bridge transport that returns configurable responses.
+    struct MockTransport {
+        /// Counts how many calls were made.
+        call_count: AtomicUsize,
+        /// If true, store_fact calls succeed; if false, they fail.
+        store_succeeds: bool,
+        /// If true, search_facts returns empty results; if false, returns an error.
+        search_returns_empty: bool,
+    }
+
+    impl MockTransport {
+        fn new_succeeding() -> Self {
+            Self {
+                call_count: AtomicUsize::new(0),
+                store_succeeds: true,
+                search_returns_empty: true,
+            }
+        }
+
+        fn new_failing() -> Self {
+            Self {
+                call_count: AtomicUsize::new(0),
+                store_succeeds: false,
+                search_returns_empty: false,
+            }
+        }
+    }
+
+    impl crate::bridge::BridgeTransport for MockTransport {
+        fn call(&self, request: BridgeRequest) -> SimardResult<BridgeResponse> {
+            self.call_count.fetch_add(1, Ordering::Relaxed);
+            if request.method.contains("store") {
+                if self.store_succeeds {
+                    Ok(BridgeResponse {
+                        id: request.id,
+                        result: Some(serde_json::json!({"id": "mock-node-id"})),
+                        error: None,
+                    })
+                } else {
+                    Err(SimardError::BridgeCallFailed {
+                        bridge: "mock".to_string(),
+                        method: request.method,
+                        reason: "mock failure".to_string(),
+                    })
+                }
+            } else if request.method.contains("search") {
+                if self.search_returns_empty {
+                    Ok(BridgeResponse {
+                        id: request.id,
+                        result: Some(serde_json::json!([])),
+                        error: None,
+                    })
+                } else {
+                    Err(SimardError::BridgeCallFailed {
+                        bridge: "mock".to_string(),
+                        method: request.method,
+                        reason: "mock search failure".to_string(),
+                    })
+                }
+            } else {
+                Ok(BridgeResponse {
+                    id: request.id,
+                    result: Some(serde_json::json!(null)),
+                    error: None,
+                })
+            }
+        }
+
+        fn descriptor(&self) -> BackendDescriptor {
+            BackendDescriptor::for_runtime_type::<Self>(
+                "mock-bridge",
+                "test",
+                Freshness::now().unwrap(),
+            )
+        }
+    }
+
+    fn make_store(transport: MockTransport) -> CognitiveBridgeMemoryStore {
+        let dir = std::env::temp_dir().join(format!(
+            "simard_test_cbs_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let _ = std::fs::create_dir_all(&dir);
+        let bridge = CognitiveMemoryBridge::new(Box::new(transport));
+        CognitiveBridgeMemoryStore::new(bridge, dir.join("fallback.json")).unwrap()
+    }
+
+    fn make_record(key: &str, scope: MemoryScope) -> MemoryRecord {
+        MemoryRecord {
+            key: key.to_string(),
+            scope,
+            value: format!("value-for-{key}"),
+            session_id: SessionId::from_uuid(uuid::Uuid::nil()),
+            recorded_in: SessionPhase::Execution,
+            created_at: None,
+        }
+    }
+
+    #[test]
+    fn put_and_list_records() {
+        let store = make_store(MockTransport::new_succeeding());
+        store.put(make_record("k1", MemoryScope::Decision)).unwrap();
+        store.put(make_record("k2", MemoryScope::Decision)).unwrap();
+        store.put(make_record("k3", MemoryScope::Project)).unwrap();
+
+        let decisions = store.list(MemoryScope::Decision).unwrap();
+        assert_eq!(decisions.len(), 2);
+
+        let projects = store.list(MemoryScope::Project).unwrap();
+        assert_eq!(projects.len(), 1);
+    }
+
+    #[test]
+    fn put_stamps_created_at() {
+        let store = make_store(MockTransport::new_succeeding());
+        let record = make_record("k1", MemoryScope::Decision);
+        assert!(record.created_at.is_none());
+        store.put(record.clone()).unwrap();
+
+        let all = store.list_all().unwrap();
+        assert_eq!(all.len(), 1);
+        assert!(all[0].created_at.is_some());
+    }
+
+    #[test]
+    fn list_all_returns_all_scopes() {
+        let store = make_store(MockTransport::new_succeeding());
+        store.put(make_record("a", MemoryScope::Decision)).unwrap();
+        store.put(make_record("b", MemoryScope::Project)).unwrap();
+        store.put(make_record("c", MemoryScope::Benchmark)).unwrap();
+
+        let all = store.list_all().unwrap();
+        assert_eq!(all.len(), 3);
+    }
+
+    #[test]
+    fn list_for_session_filters_by_session() {
+        let store = make_store(MockTransport::new_succeeding());
+        store.put(make_record("k1", MemoryScope::Decision)).unwrap();
+
+        let nil_session = SessionId::from_uuid(uuid::Uuid::nil());
+        let other_session = SessionId::from_uuid(uuid::Uuid::from_u128(1));
+
+        let results = store.list_for_session(&nil_session).unwrap();
+        assert_eq!(results.len(), 1);
+
+        let results = store.list_for_session(&other_session).unwrap();
+        assert_eq!(results.len(), 0);
+    }
+
+    #[test]
+    fn count_for_session() {
+        let store = make_store(MockTransport::new_succeeding());
+        store.put(make_record("k1", MemoryScope::Decision)).unwrap();
+        store.put(make_record("k2", MemoryScope::Project)).unwrap();
+
+        let nil_session = SessionId::from_uuid(uuid::Uuid::nil());
+        assert_eq!(store.count_for_session(&nil_session).unwrap(), 2);
+    }
+
+    #[test]
+    fn list_by_time_range() {
+        let store = make_store(MockTransport::new_succeeding());
+        store.put(make_record("k1", MemoryScope::Decision)).unwrap();
+
+        let start = Utc::now() - chrono::Duration::seconds(10);
+        let end = Utc::now() + chrono::Duration::seconds(10);
+        let results = store.list_by_time_range(start, end).unwrap();
+        assert_eq!(results.len(), 1);
+
+        // Range in the past should return nothing
+        let old_start = Utc::now() - chrono::Duration::hours(2);
+        let old_end = Utc::now() - chrono::Duration::hours(1);
+        let results = store.list_by_time_range(old_start, old_end).unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn put_overwrites_same_key() {
+        let store = make_store(MockTransport::new_succeeding());
+        store.put(make_record("k1", MemoryScope::Decision)).unwrap();
+        let mut updated = make_record("k1", MemoryScope::Decision);
+        updated.value = "updated-value".to_string();
+        store.put(updated).unwrap();
+
+        let all = store.list_all().unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].value, "updated-value");
+    }
+
+    #[test]
+    fn put_with_bridge_failure_still_persists_locally() {
+        let store = make_store(MockTransport::new_failing());
+        // Bridge store will fail, but the put should still succeed (fallback)
+        store.put(make_record("k1", MemoryScope::Decision)).unwrap();
+
+        let all = store.list_all().unwrap();
+        assert_eq!(all.len(), 1);
+    }
+
+    #[test]
+    fn sync_pending_returns_zero_when_empty() {
+        let store = make_store(MockTransport::new_succeeding());
+        assert_eq!(store.sync_pending(), 0);
+    }
+
+    #[test]
+    fn descriptor_returns_bridge_backend() {
+        let store = make_store(MockTransport::new_succeeding());
+        let desc = store.descriptor();
+        assert!(desc.identity.contains("cognitive-bridge"));
+    }
+}

--- a/src/operator_commands/probe.rs
+++ b/src/operator_commands/probe.rs
@@ -219,3 +219,86 @@ fn print_copilot_submit_report(
     print_text("Terminal transcript preview", &report.transcript_preview);
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::copilot_task_submit::{CopilotSubmitOutcome, CopilotSubmitReport};
+
+    fn make_report() -> CopilotSubmitReport {
+        CopilotSubmitReport {
+            selected_base_type: "terminal-shell".to_string(),
+            flow_asset: "test-flow-asset".to_string(),
+            outcome: CopilotSubmitOutcome::Success,
+            reason_code: None,
+            payload_id: "payload-001".to_string(),
+            ordered_steps: vec!["step-one".to_string(), "step-two".to_string()],
+            observed_checkpoints: vec!["checkpoint-alpha".to_string()],
+            last_meaningful_output_line: Some("last line".to_string()),
+            transcript_preview: "$ echo hello".to_string(),
+        }
+    }
+
+    #[test]
+    fn print_copilot_submit_report_json_succeeds() {
+        let report = make_report();
+        let result =
+            print_copilot_submit_report(Path::new("/test/state"), "single-process", &report, true);
+        assert!(result.is_ok(), "JSON output should succeed");
+    }
+
+    #[test]
+    fn print_copilot_submit_report_text_succeeds() {
+        let report = make_report();
+        let result =
+            print_copilot_submit_report(Path::new("/test/state"), "single-process", &report, false);
+        assert!(result.is_ok(), "text output should succeed");
+    }
+
+    #[test]
+    fn print_copilot_submit_report_with_reason_code() {
+        let mut report = make_report();
+        report.outcome = CopilotSubmitOutcome::Unsupported;
+        report.reason_code = Some("no-terminal-session".to_string());
+        let result =
+            print_copilot_submit_report(Path::new("/test/state"), "multi-process", &report, false);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn print_copilot_submit_report_empty_steps_and_checkpoints() {
+        let mut report = make_report();
+        report.ordered_steps.clear();
+        report.observed_checkpoints.clear();
+        report.last_meaningful_output_line = None;
+        let result =
+            print_copilot_submit_report(Path::new("/test/state"), "single-process", &report, false);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    #[ignore = "requires bootstrap runtime environment"]
+    fn bootstrap_probe_requires_valid_environment() {
+        let result = run_bootstrap_probe(
+            "simard-engineer",
+            "terminal-shell",
+            "single-process",
+            "test objective",
+            None,
+        );
+        // This would fail without a real environment; just verify it returns an error
+        assert!(result.is_err());
+    }
+
+    #[test]
+    #[ignore = "requires bootstrap runtime environment"]
+    fn handoff_probe_requires_valid_environment() {
+        let result = run_handoff_probe(
+            "simard-engineer",
+            "terminal-shell",
+            "single-process",
+            "test objective",
+        );
+        assert!(result.is_err());
+    }
+}

--- a/src/operator_commands_dashboard/routes.rs
+++ b/src/operator_commands_dashboard/routes.rs
@@ -798,7 +798,7 @@ mod tests {
 
     #[test]
     fn index_html_has_refresh_intervals() {
-        assert!(INDEX_HTML.contains("setInterval(fetchStatus, 30000)"));
-        assert!(INDEX_HTML.contains("setInterval(fetchIssues, 60000)"));
+        assert!(INDEX_HTML.contains("setInterval(fetchStatus,30000)"));
+        assert!(INDEX_HTML.contains("setInterval(fetchIssues,60000)"));
     }
 }

--- a/src/operator_commands_dashboard/routes.rs
+++ b/src/operator_commands_dashboard/routes.rs
@@ -762,3 +762,43 @@ const INDEX_HTML: &str = r##"<!DOCTYPE html>
 </body>
 </html>
 "##;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_router_has_expected_routes() {
+        let router = build_router();
+        let _ = router;
+    }
+
+    #[test]
+    fn login_html_contains_form_elements() {
+        assert!(LOGIN_HTML.contains("<form id=\"login-form\">"));
+        assert!(LOGIN_HTML.contains("input id=\"code\""));
+        assert!(LOGIN_HTML.contains("Log in"));
+        assert!(LOGIN_HTML.contains("Simard"));
+    }
+
+    #[test]
+    fn index_html_contains_dashboard_sections() {
+        assert!(INDEX_HTML.contains("Simard Dashboard"));
+        assert!(INDEX_HTML.contains("System Status"));
+        assert!(INDEX_HTML.contains("Open Issues"));
+        assert!(INDEX_HTML.contains("fetchStatus"));
+        assert!(INDEX_HTML.contains("fetchIssues"));
+    }
+
+    #[test]
+    fn login_html_has_security_attributes() {
+        assert!(LOGIN_HTML.contains("maxlength=\"8\""));
+        assert!(LOGIN_HTML.contains("autocomplete=\"off\""));
+    }
+
+    #[test]
+    fn index_html_has_refresh_intervals() {
+        assert!(INDEX_HTML.contains("setInterval(fetchStatus, 30000)"));
+        assert!(INDEX_HTML.contains("setInterval(fetchIssues, 60000)"));
+    }
+}

--- a/src/operator_commands_engineer/read_view.rs
+++ b/src/operator_commands_engineer/read_view.rs
@@ -219,3 +219,142 @@ impl EngineerReadView {
         println!("Evidence records: {}", self.evidence_record_count);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::evidence::EvidenceSource;
+    use crate::session::{SessionId, SessionPhase};
+    use crate::{
+        BaseTypeId, EvidenceRecord, OperatingMode, RuntimeAddress, RuntimeHandoffSnapshot,
+        RuntimeNodeId, RuntimeState, RuntimeTopology,
+    };
+
+    fn make_evidence(detail: &str) -> EvidenceRecord {
+        EvidenceRecord {
+            id: "ev-test".to_string(),
+            session_id: SessionId::parse("00000000-0000-0000-0000-000000000001").unwrap(),
+            phase: SessionPhase::Execution,
+            detail: detail.to_string(),
+            source: EvidenceSource::Runtime,
+        }
+    }
+
+    #[allow(dead_code)]
+    fn make_session() -> crate::session::SessionRecord {
+        crate::session::SessionRecord {
+            id: SessionId::parse("00000000-0000-0000-0000-000000000001").unwrap(),
+            mode: OperatingMode::Engineer,
+            objective: "objective-metadata(chars=42, words=8, lines=2)".to_string(),
+            phase: SessionPhase::Complete,
+            selected_base_type: BaseTypeId::from("terminal-shell"),
+            evidence_ids: vec![],
+            memory_keys: vec![],
+        }
+    }
+
+    fn engineer_evidence() -> Vec<EvidenceRecord> {
+        vec![
+            make_evidence("repo-root=/home/user/project"),
+            make_evidence("repo-branch=main"),
+            make_evidence("repo-head=abc123"),
+            make_evidence("worktree-dirty=false"),
+            make_evidence("changed-files=<none>"),
+            make_evidence("active-goals=<none>"),
+            make_evidence("carried-meeting-decisions=<none>"),
+            make_evidence("selected-action=cargo-check"),
+            make_evidence("action-plan=run cargo check"),
+            make_evidence("action-verification-steps=verify clean build"),
+            make_evidence("action-status=success"),
+            make_evidence("changed-files-after-action=<none>"),
+            make_evidence("verification-status=passed"),
+            make_evidence("verification-summary=all checks passed"),
+        ]
+    }
+
+    #[allow(dead_code)]
+    fn make_handoff(
+        session: Option<crate::session::SessionRecord>,
+        evidence: Vec<EvidenceRecord>,
+    ) -> RuntimeHandoffSnapshot {
+        RuntimeHandoffSnapshot {
+            exported_state: RuntimeState::Ready,
+            identity_name: "simard-engineer".to_string(),
+            selected_base_type: BaseTypeId::from("terminal-shell"),
+            topology: RuntimeTopology::SingleProcess,
+            source_runtime_node: RuntimeNodeId::new("test-node"),
+            source_mailbox_address: RuntimeAddress::new("test-addr"),
+            session,
+            memory_records: vec![],
+            evidence_records: evidence,
+            copilot_submit_audit: None,
+        }
+    }
+
+    #[test]
+    fn engineer_read_view_struct_captures_all_fields() {
+        let view = EngineerReadView {
+            state_root: PathBuf::from("/test/state"),
+            handoff_source: "test-source.json".to_string(),
+            identity: "simard-engineer".to_string(),
+            selected_base_type: "terminal-shell".to_string(),
+            topology: "single-process".to_string(),
+            session_phase: "Complete".to_string(),
+            objective_metadata: "objective-metadata(chars=42, words=8, lines=2)".to_string(),
+            repo_root: PathBuf::from("/home/user/project"),
+            repo_branch: "main".to_string(),
+            repo_head: "abc123".to_string(),
+            worktree_dirty: "false".to_string(),
+            changed_files: "<none>".to_string(),
+            active_goals: vec![],
+            carried_meeting_decisions: vec![],
+            selected_action: "cargo-check".to_string(),
+            action_plan: "run cargo check".to_string(),
+            verification_steps: "verify clean build".to_string(),
+            action_status: "success".to_string(),
+            changed_files_after_action: "<none>".to_string(),
+            verification_status: "passed".to_string(),
+            verification_summary: "all checks passed".to_string(),
+            terminal_bridge_context: None,
+            memory_record_count: 0,
+            evidence_record_count: 0,
+        };
+        assert_eq!(view.identity, "simard-engineer");
+        assert_eq!(view.repo_branch, "main");
+        assert_eq!(view.verification_status, "passed");
+    }
+
+    #[test]
+    fn parse_engineer_summary_list_empty_for_none() {
+        let result = parse_engineer_summary_list("<none>", ", ");
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn parse_engineer_summary_list_splits_items() {
+        let result = parse_engineer_summary_list("goal-a, goal-b", ", ");
+        assert_eq!(result, vec!["goal-a", "goal-b"]);
+    }
+
+    #[test]
+    fn parse_carried_meeting_decisions_returns_empty_for_none() {
+        let result = parse_carried_meeting_decisions("<none>").unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn required_evidence_value_finds_matching_prefix() {
+        let records = engineer_evidence();
+        let result =
+            required_engineer_evidence_value(&records, "repo-branch=", "test-source").unwrap();
+        assert_eq!(result, "main");
+    }
+
+    #[test]
+    fn required_evidence_value_errors_on_missing() {
+        let records = engineer_evidence();
+        let result =
+            required_engineer_evidence_value(&records, "nonexistent-field=", "test-source");
+        assert!(result.is_err());
+    }
+}

--- a/src/operator_commands_terminal/read_view.rs
+++ b/src/operator_commands_terminal/read_view.rs
@@ -220,3 +220,163 @@ impl TerminalReadView {
         println!("Evidence records: {}", self.evidence_record_count);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::evidence::EvidenceSource;
+    use crate::session::{SessionId, SessionPhase};
+    use crate::{
+        BaseTypeId, EvidenceRecord, OperatingMode, RuntimeAddress, RuntimeHandoffSnapshot,
+        RuntimeNodeId, RuntimeState, RuntimeTopology,
+    };
+
+    fn make_evidence(detail: &str) -> EvidenceRecord {
+        EvidenceRecord {
+            id: "ev-test".to_string(),
+            session_id: SessionId::parse("00000000-0000-0000-0000-000000000001").unwrap(),
+            phase: SessionPhase::Execution,
+            detail: detail.to_string(),
+            source: EvidenceSource::Runtime,
+        }
+    }
+
+    fn make_session() -> crate::session::SessionRecord {
+        crate::session::SessionRecord {
+            id: SessionId::parse("00000000-0000-0000-0000-000000000001").unwrap(),
+            mode: OperatingMode::Engineer,
+            objective: "objective-metadata(chars=42, words=8, lines=2)".to_string(),
+            phase: SessionPhase::Complete,
+            selected_base_type: BaseTypeId::from("terminal-shell"),
+            evidence_ids: vec![],
+            memory_keys: vec![],
+        }
+    }
+
+    fn required_evidence() -> Vec<EvidenceRecord> {
+        vec![
+            make_evidence("backend-implementation=test-adapter"),
+            make_evidence("shell=/bin/bash"),
+            make_evidence("terminal-working-directory=/home/user/project"),
+            make_evidence("terminal-command-count=5"),
+            make_evidence("terminal-transcript-preview=$ echo hello"),
+        ]
+    }
+
+    fn make_handoff(
+        session: Option<crate::session::SessionRecord>,
+        evidence: Vec<EvidenceRecord>,
+    ) -> RuntimeHandoffSnapshot {
+        RuntimeHandoffSnapshot {
+            exported_state: RuntimeState::Ready,
+            identity_name: "simard-engineer".to_string(),
+            selected_base_type: BaseTypeId::from("terminal-shell"),
+            topology: RuntimeTopology::SingleProcess,
+            source_runtime_node: RuntimeNodeId::new("test-node"),
+            source_mailbox_address: RuntimeAddress::new("test-addr"),
+            session,
+            memory_records: vec![],
+            evidence_records: evidence,
+            copilot_submit_audit: None,
+        }
+    }
+
+    #[test]
+    fn from_handoff_succeeds_with_required_fields() {
+        let handoff = make_handoff(Some(make_session()), required_evidence());
+        let view = TerminalReadView::from_handoff(
+            PathBuf::from("/test/state"),
+            handoff,
+            "test-handoff.json".to_string(),
+            None,
+        );
+        assert!(view.is_ok(), "expected success, got: {:?}", view.err());
+    }
+
+    #[test]
+    fn from_handoff_extracts_identity_and_topology() {
+        let handoff = make_handoff(Some(make_session()), required_evidence());
+        let view = TerminalReadView::from_handoff(
+            PathBuf::from("/test/state"),
+            handoff,
+            "test-handoff.json".to_string(),
+            None,
+        )
+        .unwrap();
+        assert_eq!(view.identity, "simard-engineer");
+        assert_eq!(view.selected_base_type, "terminal-shell");
+        assert_eq!(view.topology, "single-process");
+    }
+
+    #[test]
+    fn from_handoff_fails_without_session() {
+        let handoff = make_handoff(None, required_evidence());
+        let result = TerminalReadView::from_handoff(
+            PathBuf::from("/test/state"),
+            handoff,
+            "test-handoff.json".to_string(),
+            None,
+        );
+        assert!(result.is_err(), "should fail without session");
+    }
+
+    #[test]
+    fn from_handoff_uses_default_wait_values() {
+        let handoff = make_handoff(Some(make_session()), required_evidence());
+        let view = TerminalReadView::from_handoff(
+            PathBuf::from("/test/state"),
+            handoff,
+            "test-handoff.json".to_string(),
+            None,
+        )
+        .unwrap();
+        assert_eq!(view.wait_count, "0");
+        assert_eq!(view.wait_timeout_seconds, "5");
+    }
+
+    #[test]
+    fn from_handoff_captures_step_and_checkpoint_counts() {
+        let mut evidence = required_evidence();
+        evidence.push(make_evidence("terminal-step-1=run cargo check"));
+        evidence.push(make_evidence("terminal-step-2=run cargo test"));
+        evidence.push(make_evidence("terminal-checkpoint-1=tests pass"));
+        let handoff = make_handoff(Some(make_session()), evidence);
+        let view = TerminalReadView::from_handoff(
+            PathBuf::from("/test/state"),
+            handoff,
+            "test-handoff.json".to_string(),
+            None,
+        )
+        .unwrap();
+        assert_eq!(view.step_count, 2);
+        assert_eq!(view.steps.len(), 2);
+        assert_eq!(view.checkpoints.len(), 1);
+    }
+
+    #[test]
+    fn from_handoff_captures_copilot_submit_audit() {
+        let mut handoff = make_handoff(Some(make_session()), required_evidence());
+        handoff.copilot_submit_audit = Some(CopilotSubmitAudit {
+            flow_asset: "test-flow".to_string(),
+            payload_id: "payload-1".to_string(),
+            outcome: "success".to_string(),
+            reason_code: Some("ok".to_string()),
+            ordered_steps: vec!["step1".to_string()],
+            observed_checkpoints: vec![],
+            last_meaningful_output_line: None,
+            transcript_preview: "preview".to_string(),
+        });
+        let view = TerminalReadView::from_handoff(
+            PathBuf::from("/test/state"),
+            handoff,
+            "test-handoff.json".to_string(),
+            None,
+        )
+        .unwrap();
+        assert!(view.copilot_submit_audit.is_some());
+        assert_eq!(
+            view.copilot_submit_audit.as_ref().unwrap().flow_asset,
+            "test-flow"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds **1,559 lines** of unit tests across **10 modules** with **114 new test functions**.

## Modules Covered

| Module | Tests | Coverage |
|--------|-------|----------|
| `operator_commands_dashboard/routes.rs` | 5 | Router construction, HTML content, security, refresh intervals |
| `memory_bridge_adapter/store.rs` | 10 | put/list/count/filter, overwrite, bridge fallback, sync_pending |
| `engineer_loop/verification_actions.rs` | 17 | Cargo test/check, file ops, issue creation, metadata parsing |
| `copilot_task_submit/types.rs` | 14 | Outcome serialization, transcript scanning, startup ordering |
| `goal_curation/operations.rs` | 18 | Validation, add/promote/update/archive, capacity, dedup, seeding |
| `engineer_loop/review_persist.rs` | 6 | Philosophy, diff computation, review skip logic |
| `improvements/parsing.rs` | 26 | Bracketed lists, count helpers, record pairs, skip helpers |
| `operator_commands_terminal/read_view.rs` | 6 | View construction, field extraction, defaults, counting |
| `operator_commands_engineer/read_view.rs` | 6 | Struct construction, summary parsing, evidence lookup |
| `operator_commands/probe.rs` | 6 | Report printing (JSON/text), reason codes, empty collections |

## Verification

- `cargo check` ✅
- `cargo clippy -D warnings` ✅
- `cargo test --lib` — **2539 passed, 0 failed, 3 ignored**
- No production code modified

## Closes
Closes #309, #318. Refs #281.