### PR TITLE
fix: add #[serial] to env-var-mutating tests to prevent flaky failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2927,6 +2927,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2940,6 +2949,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "sec1"
@@ -3077,6 +3092,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3135,6 +3176,7 @@ dependencies = [
  "rustyclawd-tools",
  "serde",
  "serde_json",
+ "serial_test",
  "tempfile",
  "tokio",
  "tower-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ libc = "0.2"
 assert_cmd = "2"
 tempfile = "3"
 proptest = "1"
+serial_test = "3.4.0"
 
 [profile.release]
 lto = "thin"

--- a/src/meeting_repl/repl.rs
+++ b/src/meeting_repl/repl.rs
@@ -548,6 +548,7 @@ mod tests {
     use super::super::test_support::{MockAgentSession, mock_bridge};
     use super::*;
     use crate::meeting_facilitator::MeetingSessionStatus;
+    use serial_test::serial;
 
     #[test]
     fn repl_records_decision_and_closes() {
@@ -916,6 +917,7 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
+    #[serial]
     fn repl_saves_wip_on_command_and_cleans_up_on_close() {
         let dir = tempfile::tempdir().unwrap();
         // SAFETY: test-only, run with --test-threads=1 to avoid races.
@@ -945,6 +947,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn repl_resumes_from_wip_on_y() {
         let dir = tempfile::tempdir().unwrap();
         // SAFETY: test-only, run with --test-threads=1 to avoid races.
@@ -999,6 +1002,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn repl_declines_resume_starts_fresh() {
         let dir = tempfile::tempdir().unwrap();
         // SAFETY: test-only, run with --test-threads=1 to avoid races.

--- a/src/ooda_loop/tests_observe.rs
+++ b/src/ooda_loop/tests_observe.rs
@@ -7,6 +7,7 @@ use crate::meeting_facilitator::{MeetingDecision, MeetingHandoff, write_meeting_
 use crate::memory_cognitive::CognitiveStatistics;
 use crate::ooda_loop::OodaState;
 use crate::self_improve::{ImprovementCycle, ImprovementPhase};
+use serial_test::serial;
 use tempfile::TempDir;
 
 fn make_gym_score(overall: f64, factual_accuracy: f64) -> GymSuiteScore {
@@ -28,6 +29,7 @@ fn make_gym_score(overall: f64, factual_accuracy: f64) -> GymSuiteScore {
 }
 
 #[test]
+#[serial]
 fn collect_pending_improvements_empty_when_no_signals() {
     let dir = TempDir::new().unwrap();
     // Isolate from any leftover handoff files in the default directory.
@@ -44,6 +46,7 @@ fn collect_pending_improvements_empty_when_no_signals() {
 }
 
 #[test]
+#[serial]
 fn collect_pending_improvements_detects_gym_regression() {
     let dir = TempDir::new().unwrap();
     unsafe { std::env::set_var("SIMARD_HANDOFF_DIR", dir.path()) };
@@ -78,6 +81,7 @@ fn collect_pending_improvements_detects_gym_regression() {
 }
 
 #[test]
+#[serial]
 fn collect_pending_improvements_no_regression_when_scores_stable() {
     let dir = TempDir::new().unwrap();
     unsafe { std::env::set_var("SIMARD_HANDOFF_DIR", dir.path()) };
@@ -107,6 +111,7 @@ fn collect_pending_improvements_no_regression_when_scores_stable() {
 }
 
 #[test]
+#[serial]
 fn collect_pending_improvements_no_crash_when_no_gym_health() {
     let dir = TempDir::new().unwrap();
     unsafe { std::env::set_var("SIMARD_HANDOFF_DIR", dir.path()) };
@@ -125,6 +130,7 @@ fn collect_pending_improvements_no_crash_when_no_gym_health() {
 }
 
 #[test]
+#[serial]
 fn collect_pending_improvements_no_crash_when_no_last_observation() {
     let dir = TempDir::new().unwrap();
     unsafe { std::env::set_var("SIMARD_HANDOFF_DIR", dir.path()) };
@@ -204,6 +210,7 @@ fn scan_unprocessed_handoffs_returns_false_when_no_file() {
 }
 
 #[test]
+#[serial]
 fn collect_pending_improvements_drains_review_improvements() {
     let dir = TempDir::new().unwrap();
     unsafe { std::env::set_var("SIMARD_HANDOFF_DIR", dir.path()) };


### PR DESCRIPTION
Tests that mutate SIMARD_HANDOFF_DIR via set_var race when run in parallel. Mark them #[serial] so they execute sequentially.

Changes:
- Add serial_test = 3.4.0 dev-dependency
- Add #[serial] to 3 tests in meeting_repl/repl.rs
- Add #[serial] to 6 tests in ooda_loop/tests_observe.rs

Fixes #313