### PR TITLE
feat: dashboard health check, commit SHA link, download link, build.rs auto-version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ version = "0.4.0"
 source = "git+https://github.com/rysweet/amplihack-memory-lib.git#b6e7c2eb73fd6d9cdee656c1d3ef712c3b3b4c7d"
 dependencies = [
  "chrono",
- "dirs",
+ "dirs 5.0.1",
  "regex",
  "rusqlite",
  "serde",
@@ -712,7 +712,16 @@ version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys 0.5.0",
 ]
 
 [[package]]
@@ -723,8 +732,20 @@ checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.4.6",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.5.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2612,6 +2633,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3189,6 +3221,7 @@ dependencies = [
  "axum",
  "chrono",
  "ctrlc",
+ "dirs 6.0.0",
  "libc",
  "proptest",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ axum = { version = "0.8", features = ["ws"] }
 tower-http = { version = "0.6", features = ["cors", "auth"] }
 uuid = { version = "1.18.1", features = ["v7"] }
 chrono = "0.4"
+dirs = "6"
 tracing = "0.1"
 ctrlc = "3.4"
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,28 @@
+fn main() {
+    // Git commit hash
+    let git_hash = std::process::Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+    println!("cargo:rustc-env=SIMARD_GIT_HASH={git_hash}");
+
+    // Build number: count of git commits on HEAD, or env var override
+    let build_number = std::env::var("SIMARD_BUILD_NUMBER").unwrap_or_else(|_| {
+        std::process::Command::new("git")
+            .args(["rev-list", "--count", "HEAD"])
+            .output()
+            .ok()
+            .and_then(|o| String::from_utf8(o.stdout).ok())
+            .map(|s| s.trim().to_string())
+            .unwrap_or_else(|| "0".to_string())
+    });
+    println!("cargo:rustc-env=SIMARD_BUILD_NUMBER={build_number}");
+
+    // Rebuild when HEAD changes
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-changed=.git/refs/heads/");
+    println!("cargo:rerun-if-env-changed=SIMARD_BUILD_NUMBER");
+}

--- a/src/operator_commands_dashboard/routes.rs
+++ b/src/operator_commands_dashboard/routes.rs
@@ -56,14 +56,42 @@ async fn login_page() -> response::Html<String> {
 }
 
 async fn status() -> Json<Value> {
-    let build_number = std::env::var("SIMARD_BUILD_NUMBER").unwrap_or_else(|_| "dev".to_string());
-    let version = format!("{}.{}", env!("CARGO_PKG_VERSION"), build_number);
+    let version = format!(
+        "{}.{}",
+        env!("CARGO_PKG_VERSION"),
+        env!("SIMARD_BUILD_NUMBER")
+    );
+    let git_hash = env!("SIMARD_GIT_HASH");
 
-    let ooda_running = std::process::Command::new("pgrep")
-        .args(["-f", "simard.*ooda run"])
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false);
+    // Real health check: read daemon_health.json
+    let health_path = dirs::data_local_dir()
+        .unwrap_or_else(|| std::path::PathBuf::from("/var/tmp"))
+        .join("simard")
+        .join("daemon_health.json");
+
+    let daemon_health: Option<serde_json::Value> = std::fs::read_to_string(&health_path)
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok());
+
+    let ooda_status = match &daemon_health {
+        Some(h) => {
+            if let Some(ts) = h.get("timestamp").and_then(|t| t.as_str()) {
+                if let Ok(health_time) = chrono::DateTime::parse_from_rfc3339(ts) {
+                    let age = chrono::Utc::now().signed_duration_since(health_time);
+                    if age.num_seconds() < 600 {
+                        "running"
+                    } else {
+                        "stale"
+                    }
+                } else {
+                    "unknown"
+                }
+            } else {
+                "unknown"
+            }
+        }
+        None => "stopped",
+    };
 
     let disk = disk_usage_pct().await;
 
@@ -75,13 +103,20 @@ async fn status() -> Json<Value> {
         .and_then(|s| s.trim().parse::<u32>().ok())
         .unwrap_or(0);
 
-    Json(json!({
+    let mut status_json = json!({
         "version": version,
-        "ooda_daemon": if ooda_running { "running" } else { "stopped" },
+        "git_hash": git_hash,
+        "ooda_daemon": ooda_status,
         "active_processes": child_count,
         "disk_usage_pct": disk,
         "timestamp": chrono::Utc::now().to_rfc3339(),
-    }))
+    });
+
+    if let Some(h) = daemon_health {
+        status_json["daemon_health"] = h;
+    }
+
+    Json(status_json)
 }
 
 async fn issues() -> Json<Value> {
@@ -525,7 +560,10 @@ const INDEX_HTML: &str = r##"<!DOCTYPE html>
 <body>
   <header>
     <h1>🌲 Simard Dashboard <span style="font-size:.75rem;color:#8b949e">v2</span></h1>
-    <span id="clock" style="color:#8b949e;font-size:.85rem"></span>
+    <div style="display:flex;align-items:center;gap:1rem">
+      <a href="https://github.com/rysweet/Simard/releases/latest" target="_blank" style="color:#3fb950;text-decoration:none;font-size:.85rem;border:1px solid #3fb950;padding:.2rem .6rem;border-radius:4px">📦 Download Latest</a>
+      <span id="clock" style="color:#8b949e;font-size:.85rem"></span>
+    </div>
   </header>
   <div class="tabs">
     <div class="tab active" data-tab="overview">Overview</div>
@@ -599,10 +637,19 @@ const INDEX_HTML: &str = r##"<!DOCTYPE html>
       try{
         const r=await fetch('/api/status'); const d=await r.json();
         const dc=d.disk_usage_pct>90?'err':d.disk_usage_pct>70?'warn':'ok';
-        const oc=d.ooda_daemon==='running'?'ok':'err';
+        const oc=d.ooda_daemon==='running'?'ok':(d.ooda_daemon==='stale'?'warn':'err');
+        const shortHash=d.git_hash?d.git_hash.substring(0,7):'';
+        const versionLink=d.git_hash?`<a href="https://github.com/rysweet/Simard/commit/${d.git_hash}" target="_blank" style="color:#3fb950;text-decoration:none">v${d.version}</a> (<code>${shortHash}</code>)`:`v${d.version}`;
+        let healthDetail='';
+        if(d.daemon_health){
+          const dh=d.daemon_health;
+          healthDetail=` (cycle #${dh.cycle_number??'?'}`;
+          if(dh.timestamp) healthDetail+=`, last: ${new Date(dh.timestamp).toLocaleTimeString()}`;
+          healthDetail+=')';
+        }
         document.getElementById('status').innerHTML=`
-          <div class="stat"><span class="label">Version</span><span class="value">v${d.version}</span></div>
-          <div class="stat"><span class="label">OODA Daemon</span><span class="value ${oc}">${d.ooda_daemon}</span></div>
+          <div class="stat"><span class="label">Version</span><span class="value">${versionLink}</span></div>
+          <div class="stat"><span class="label">OODA Daemon</span><span class="value ${oc}">${d.ooda_daemon}${healthDetail}</span></div>
           <div class="stat"><span class="label">Active Processes</span><span class="value">${d.active_processes??0}</span></div>
           <div class="stat"><span class="label">Disk Usage</span><span class="value ${dc}">${d.disk_usage_pct??'?'}%</span></div>
           <div class="stat"><span class="label">Updated</span><span class="value">${new Date(d.timestamp).toLocaleTimeString()}</span></div>`;

--- a/src/operator_commands_ooda/daemon.rs
+++ b/src/operator_commands_ooda/daemon.rs
@@ -188,6 +188,26 @@ pub fn run_ooda_daemon(
                 persist_cycle_report(&state_root, &report);
                 // Persist the cycle summary to cognitive memory as an episode.
                 persist_cycle_to_memory(&bridges, &report);
+                // Write daemon health file for dashboard
+                {
+                    let health_dir = dirs::data_local_dir()
+                        .unwrap_or_else(|| std::path::PathBuf::from("/var/tmp"))
+                        .join("simard");
+                    let _ = std::fs::create_dir_all(&health_dir);
+                    let health = serde_json::json!({
+                        "timestamp": chrono::Utc::now().to_rfc3339(),
+                        "cycle_number": cycles_run + 1,
+                        "status": "healthy",
+                        "actions_taken": summary.clone(),
+                    });
+                    let health_path = health_dir.join("daemon_health.json");
+                    if let Err(e) = std::fs::write(
+                        &health_path,
+                        serde_json::to_string_pretty(&health).unwrap_or_default(),
+                    ) {
+                        eprintln!("[simard] OODA health: failed to write health file: {e}");
+                    }
+                }
                 // Collect self-improvement metrics at end of each cycle.
                 if let Err(e) = crate::self_metrics::collect_and_record_all(cycle_elapsed) {
                     eprintln!("[simard] OODA metrics: failed to record: {e}");


### PR DESCRIPTION
## Changes

### build.rs (new)
- Embeds `SIMARD_GIT_HASH` (git rev-parse HEAD) at compile time
- Embeds `SIMARD_BUILD_NUMBER` (git commit count or env var override)
- Auto-rebuilds when HEAD changes

### Dashboard improvements
- Version display links to the specific commit on GitHub
- Short commit SHA displayed next to version
- Download link in header to latest GitHub release
- OODA daemon health now based on `daemon_health.json` (not pgrep)
- Daemon health shows cycle number and last action details
- Stale health (>10 min since last cycle) shown as warning

### Daemon health file
- OODA daemon writes `~/.local/share/simard/daemon_health.json` after each cycle
- Contains: timestamp, cycle number, status, actions summary
- Enables distributed health monitoring (any node can read the file)

### Auto-versioning
- Version format: `{major}.{minor}.{patch}.{build_number}`
- Build number = git commit count (auto-increments on each commit)
- Can be overridden via `SIMARD_BUILD_NUMBER` env var

Closes partial items from #312 (closed as dirty worktree).