### PR TITLE
fix: exclude install_smoke from pre-push cargo test to prevent CI disk exhaustion

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,8 +27,8 @@ repos:
           - manual
 
       - id: cargo-test
-        name: cargo test --all-features --locked
-        entry: cargo test --all-features --locked
+        name: cargo test --all-features --locked (skip install_smoke)
+        entry: cargo test --all-features --locked -- --skip cargo_install_from_repo_succeeds
         language: system
         pass_filenames: false
         always_run: true


### PR DESCRIPTION
## Fixes #328

**Problem:** The `pre-commit` CI job runs `cargo test --all-features --locked` (pre-push stage), which includes `tests/install_smoke.rs`. This test does `cargo install --path .` in release mode, compiling the full binary a second time. Combined debug+release builds exceed runner disk space, failing with `No space left on device` on `ring` crate C compilation.

**This blocks ALL open PRs:** #325, #294, #321

**Fix:** Skip `cargo_install_from_repo_succeeds` in the pre-push hook's cargo test. The dedicated `install-smoke` CI job already covers this test independently and passes.

**Change:** `.pre-commit-config.yaml` — add `-- --skip cargo_install_from_repo_succeeds` to the cargo-test entry.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>