### PR TITLE
fix: meeting REPL reliability — chunked prompt writes and send_input timeout (#287)

### DIFF
--- a/src/base_type_copilot.rs
+++ b/src/base_type_copilot.rs
@@ -313,9 +313,7 @@ fn build_copilot_terminal_objective(
         let chars: Vec<char> = formatted_prompt.chars().collect();
         for (i, chunk) in chars.chunks(PROMPT_CHUNK_SIZE).enumerate() {
             let chunk_str: String = chunk.iter().collect();
-            let escaped_chunk = chunk_str
-                .replace('\\', "\\\\")
-                .replace('\'', "'\\''");
+            let escaped_chunk = chunk_str.replace('\\', "\\\\").replace('\'', "'\\''");
             let redirect = if i == 0 { ">" } else { ">>" };
             objective.push_str(&format!(
                 "input: printf '%s' '{escaped_chunk}' {redirect} \"$SIMARD_PROMPT_FILE\"\n",

--- a/src/base_type_copilot.rs
+++ b/src/base_type_copilot.rs
@@ -253,6 +253,15 @@ impl BaseTypeSession for CopilotSdkSession {
     }
 }
 
+/// Maximum prompt length (in chars) to embed inline in a single shell
+/// command.  Prompts exceeding this threshold are written to a temp file in
+/// smaller chunks to avoid PTY buffer overflow and shell command-line limits.
+const PROMPT_INLINE_THRESHOLD: usize = 400;
+
+/// Maximum number of *original* (pre-escape) characters per chunk when
+/// writing long prompts to a temp file via multiple shell commands.
+const PROMPT_CHUNK_SIZE: usize = 300;
+
 /// Build a terminal-session-compatible objective string that launches the
 /// copilot command with the enriched prompt.
 ///
@@ -261,6 +270,10 @@ impl BaseTypeSession for CopilotSdkSession {
 /// waits for the process to exit naturally — no artificial timeouts.  The
 /// copilot runs to completion however long it takes, and we read the full
 /// transcript afterward.
+///
+/// For prompts longer than [`PROMPT_INLINE_THRESHOLD`] characters the prompt
+/// content is written in multiple small `input:` steps so that no single
+/// shell command line exceeds a safe length for the PTY buffer.
 fn build_copilot_terminal_objective(
     config: &CopilotAdapterConfig,
     formatted_prompt: &str,
@@ -271,20 +284,50 @@ fn build_copilot_terminal_objective(
         objective.push_str(&format!("working-directory: {cwd}\n"));
     }
 
-    // Write the prompt to a temp file to avoid shell quoting issues with
-    // large multi-line prompts containing arbitrary characters.
-    // Chain the copilot command with `exit` so the shell exits naturally
-    // after the copilot finishes — no separate input step needed.
-    let escaped = formatted_prompt
-        .replace('\\', "\\\\")
-        .replace('\'', "'\\''");
-    objective.push_str(&format!(
-        "command: SIMARD_PROMPT_FILE=$(mktemp /tmp/simard-copilot-prompt.XXXXXX) && \
-         printf '%s' '{}' > \"$SIMARD_PROMPT_FILE\" && \
-         {} -p \"$(cat \"$SIMARD_PROMPT_FILE\")\" ; \
-         rm -f \"$SIMARD_PROMPT_FILE\" ; exit\n",
-        escaped, config.command,
-    ));
+    if formatted_prompt.len() <= PROMPT_INLINE_THRESHOLD {
+        // Short prompt: inline in a single command (original fast path).
+        let escaped = formatted_prompt
+            .replace('\\', "\\\\")
+            .replace('\'', "'\\''");
+        objective.push_str(&format!(
+            "command: SIMARD_PROMPT_FILE=$(mktemp /tmp/simard-copilot-prompt.XXXXXX) && \
+             printf '%s' '{}' > \"$SIMARD_PROMPT_FILE\" && \
+             {} -p \"$(cat \"$SIMARD_PROMPT_FILE\")\" ; \
+             rm -f \"$SIMARD_PROMPT_FILE\" ; exit\n",
+            escaped, config.command,
+        ));
+    } else {
+        // Long prompt: write in chunks to avoid shell command-line overflow.
+        eprintln!(
+            "[simard] prompt length ({} chars) exceeds inline threshold ({}), \
+             using chunked file write",
+            formatted_prompt.len(),
+            PROMPT_INLINE_THRESHOLD,
+        );
+
+        objective
+            .push_str("input: SIMARD_PROMPT_FILE=$(mktemp /tmp/simard-copilot-prompt.XXXXXX)\n");
+
+        // Chunk by chars (not bytes) so we never split a multi-byte UTF-8
+        // codepoint or an escape sequence across chunks.
+        let chars: Vec<char> = formatted_prompt.chars().collect();
+        for (i, chunk) in chars.chunks(PROMPT_CHUNK_SIZE).enumerate() {
+            let chunk_str: String = chunk.iter().collect();
+            let escaped_chunk = chunk_str
+                .replace('\\', "\\\\")
+                .replace('\'', "'\\''");
+            let redirect = if i == 0 { ">" } else { ">>" };
+            objective.push_str(&format!(
+                "input: printf '%s' '{escaped_chunk}' {redirect} \"$SIMARD_PROMPT_FILE\"\n",
+            ));
+        }
+
+        objective.push_str(&format!(
+            "command: {} -p \"$(cat \"$SIMARD_PROMPT_FILE\")\" ; \
+             rm -f \"$SIMARD_PROMPT_FILE\" ; exit\n",
+            config.command,
+        ));
+    }
 
     objective
 }
@@ -638,5 +681,108 @@ Script done on 2025-04-07 02:56:00+00:00";
         let evidence = vec!["selected-base-type=copilot-test".to_string()];
         let response = extract_copilot_response_from_evidence(&evidence);
         assert!(response.is_empty());
+    }
+
+    // --- Long-prompt / chunked-write tests ---
+
+    #[test]
+    fn build_copilot_objective_uses_chunked_write_for_long_prompts() {
+        let config = CopilotAdapterConfig::default();
+        let prompt = "x".repeat(600);
+        let objective = build_copilot_terminal_objective(&config, &prompt);
+
+        let input_count = objective
+            .lines()
+            .filter(|l| l.starts_with("input:"))
+            .count();
+        assert!(
+            input_count >= 2,
+            "long prompts should produce multiple input steps, got {input_count}"
+        );
+        assert!(
+            objective.contains("amplihack copilot"),
+            "copilot command must still appear"
+        );
+        assert!(
+            objective.contains("; exit"),
+            "objective must chain exit to end the shell"
+        );
+        assert!(
+            objective.contains("mktemp"),
+            "should create a temp file for the prompt"
+        );
+    }
+
+    #[test]
+    fn build_copilot_objective_short_prompts_stay_inline() {
+        let config = CopilotAdapterConfig::default();
+        let prompt = "Hello world";
+        let objective = build_copilot_terminal_objective(&config, prompt);
+
+        let command_count = objective
+            .lines()
+            .filter(|l| l.starts_with("command:"))
+            .count();
+        assert_eq!(command_count, 1, "short prompts should use single command");
+        let input_count = objective
+            .lines()
+            .filter(|l| l.starts_with("input:"))
+            .count();
+        assert_eq!(
+            input_count, 0,
+            "short prompts should not produce separate input lines"
+        );
+    }
+
+    #[test]
+    fn build_copilot_objective_chunked_preserves_full_prompt_content() {
+        let config = CopilotAdapterConfig::default();
+        let prompt = "a".repeat(800);
+        let objective = build_copilot_terminal_objective(&config, &prompt);
+
+        // Every original 'a' must appear somewhere in the printf chunks.
+        let a_count: usize = objective
+            .lines()
+            .filter(|l| l.starts_with("input:") && l.contains("printf"))
+            .map(|l| l.chars().filter(|&c| c == 'a').count())
+            .sum();
+        assert!(
+            a_count >= 800,
+            "all prompt characters should appear in chunks, found {a_count}"
+        );
+    }
+
+    #[test]
+    fn build_copilot_objective_very_long_prompt_produces_many_chunks() {
+        let config = CopilotAdapterConfig::default();
+        let prompt = "test phrase ".repeat(200); // ~2 400 chars
+        let objective = build_copilot_terminal_objective(&config, &prompt);
+
+        let input_count = objective
+            .lines()
+            .filter(|l| l.starts_with("input:"))
+            .count();
+        assert!(
+            input_count > 5,
+            "very long prompts need many chunks, got {input_count}"
+        );
+        assert!(objective.contains("command:"));
+        assert!(objective.contains("; exit"));
+    }
+
+    #[test]
+    fn build_copilot_objective_chunked_escapes_quotes_per_chunk() {
+        let config = CopilotAdapterConfig::default();
+        // Build a prompt that exceeds the threshold and contains quotes.
+        let prompt = format!("it's a {}long prompt with 'quotes'", "x".repeat(500));
+        let objective = build_copilot_terminal_objective(&config, &prompt);
+
+        // No unescaped single-quotes should appear inside printf arguments.
+        for line in objective.lines().filter(|l| l.contains("printf")) {
+            assert!(
+                !line.contains("it's"),
+                "single quotes must be escaped even in chunked mode: {line}"
+            );
+        }
     }
 }

--- a/src/terminal_session/session.rs
+++ b/src/terminal_session/session.rs
@@ -2,6 +2,7 @@ use std::fs::{self, File, OpenOptions};
 use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, Command, ExitStatus, Stdio};
+use std::sync::mpsc;
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -89,24 +90,54 @@ impl PtyTerminalSession {
         })
     }
 
+    /// Timeout for PTY stdin write operations.  If a write does not complete
+    /// within this duration we assume the PTY buffer is blocked and return an
+    /// error instead of hanging the session indefinitely.
+    const SEND_INPUT_TIMEOUT: Duration = Duration::from_secs(30);
+
     pub(crate) fn send_input(&mut self, command: &str) -> SimardResult<()> {
         let stdin = self
             .stdin
-            .as_mut()
+            .take()
             .ok_or_else(|| SimardError::AdapterInvocationFailed {
                 base_type: self.base_type.clone(),
                 reason: "terminal-shell session stdin is already closed".to_string(),
             })?;
-        writeln!(stdin, "{command}").map_err(|error| SimardError::AdapterInvocationFailed {
-            base_type: self.base_type.clone(),
-            reason: format!("failed to write terminal command input: {error}"),
-        })?;
-        stdin
-            .flush()
-            .map_err(|error| SimardError::AdapterInvocationFailed {
-                base_type: self.base_type.clone(),
-                reason: format!("failed to flush terminal command input: {error}"),
-            })
+
+        let base_type = self.base_type.clone();
+        let owned_command = command.to_string();
+        let (tx, rx) = mpsc::channel();
+
+        thread::spawn(move || {
+            let mut writer = stdin;
+            let result = writeln!(writer, "{owned_command}").and_then(|_| writer.flush());
+            // Send back the writer and result; ignore error if the receiver
+            // has already dropped (timeout path).
+            let _ = tx.send((writer, result));
+        });
+
+        match rx.recv_timeout(Self::SEND_INPUT_TIMEOUT) {
+            Ok((stdin_back, write_result)) => {
+                self.stdin = Some(stdin_back);
+                write_result.map_err(|error| SimardError::AdapterInvocationFailed {
+                    base_type,
+                    reason: format!("failed to write terminal command input: {error}"),
+                })
+            }
+            Err(_) => {
+                // Write timed out — stdin is lost (the spawned thread still
+                // holds it), but we can still read the transcript and
+                // terminate the session.
+                Err(SimardError::AdapterInvocationFailed {
+                    base_type,
+                    reason: format!(
+                        "terminal command input write timed out after {}s \
+                         (prompt may be too large for PTY buffer)",
+                        Self::SEND_INPUT_TIMEOUT.as_secs(),
+                    ),
+                })
+            }
+        }
     }
 
     pub(crate) fn wait_for_output(


### PR DESCRIPTION
## Summary
Fixes #287 — Meeting REPL hangs on long prompts (>500 chars) and unreliable multi-turn sessions.

## Root Causes & Fixes

### 1. Shell command line overflow for long prompts
**File:** `src/base_type_copilot.rs`

The entire user prompt was embedded inline in a `printf '%s' ...` shell command. Prompts >400 chars overflowed the PTY command buffer, causing deadlock.

**Fix:** Prompts >400 chars are now split into 300-char chunks, each written via a separate `input:` step to a temp file, then read back with `cat`. Short prompts (<= 400 chars) use the existing inline approach — zero behavior change for typical use.

### 2. No timeout on PTY write operations  
**File:** `src/terminal_session/session.rs`


**Fix:** Write+flush now runs in a background thread with a 30-second timeout via `mpsc::channel`. On timeout, returns `SimardError` instead of hanging.

## Tests
- 5 new unit tests for chunked/inline prompt paths, content preservation, and escaping
- All 57 existing terminal_session + base_type_copilot tests pass
- `cargo check` and `cargo clippy` clean

## Changes
- `src/base_type_copilot.rs` — chunked prompt write for long prompts
- `src/terminal_session/session.rs` — 30s timeout on `send_input()`