### PR TITLE
fix: resolve 6 pre-existing test failures on main (meeting_repl + self_metrics)

### DIFF
--- a/src/meeting_repl/repl.rs
+++ b/src/meeting_repl/repl.rs
@@ -551,6 +551,7 @@ mod tests {
     use serial_test::serial;
 
     #[test]
+    #[serial]
     fn repl_records_decision_and_closes() {
         let bridge = mock_bridge();
         let input = b"/decision Ship it | Ready for production\n/close\n";
@@ -573,6 +574,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn repl_records_action_item_and_closes() {
         let bridge = mock_bridge();
         let input = b"/action Write tests | bob | 2\n/close\n";
@@ -588,6 +590,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn repl_shows_help() {
         let bridge = mock_bridge();
         let input = b"/help\n/close\n";
@@ -602,6 +605,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn repl_natural_language_without_agent_falls_back_to_note() {
         let bridge = mock_bridge();
         let input = b"Hello tell me about projects\n/close\n";
@@ -617,6 +621,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn repl_sends_natural_language_to_agent() {
         let bridge = mock_bridge();
         let mut agent = MockAgentSession::new("Hello! I'm Simard, ready to discuss your project.");
@@ -655,6 +660,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn repl_slash_commands_bypass_agent() {
         let bridge = mock_bridge();
         let mut agent = MockAgentSession::new("Agent response");
@@ -679,6 +685,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn repl_list_shows_items_grouped() {
         let bridge = mock_bridge();
         let input =
@@ -698,6 +705,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn repl_list_empty() {
         let bridge = mock_bridge();
         let input = b"/list\n/close\n";
@@ -711,6 +719,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn repl_edit_decision() {
         let bridge = mock_bridge();
         let input = b"/decision Old text | reason\n/edit decision 1 New text\n/close\n";
@@ -726,6 +735,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn repl_delete_action() {
         let bridge = mock_bridge();
         let input = b"/action Task one | alice\n/action Task two | bob\n/delete action 1\n/close\n";
@@ -742,6 +752,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn repl_edit_out_of_bounds_shows_error() {
         let bridge = mock_bridge();
         let input = b"/edit decision 1 text\n/close\n";
@@ -756,6 +767,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn repl_delete_out_of_bounds_shows_error() {
         let bridge = mock_bridge();
         let input = b"/delete note 5\n/close\n";
@@ -770,6 +782,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn repl_help_includes_new_commands() {
         let bridge = mock_bridge();
         let input = b"/help\n/close\n";
@@ -786,6 +799,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn repl_question_command_adds_explicit_question() {
         let bridge = mock_bridge();
         let input = b"/question What is the release timeline?\n/close\n";
@@ -805,6 +819,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn repl_question_appears_in_list() {
         let bridge = mock_bridge();
         let input = b"/question Who owns rollback?\n/list\n/close\n";
@@ -819,6 +834,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn repl_preview_shows_handoff_without_closing() {
         let bridge = mock_bridge();
         let input = b"/decision Ship it | Ready\n/action Write tests | bob | 2\n/question ETA?\n/preview\n/close\n";
@@ -844,6 +860,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn repl_preview_empty_session() {
         let bridge = mock_bridge();
         let input = b"/preview\n/close\n";
@@ -859,6 +876,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn repl_action_with_due_date() {
         let bridge = mock_bridge();
         let input = b"/action Write tests | bob | 2 due:2026-04-15\n/close\n";
@@ -881,6 +899,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn repl_action_due_date_shows_in_list() {
         let bridge = mock_bridge();
         let input = b"/action Write tests | bob due:next Friday\n/list\n/close\n";
@@ -897,6 +916,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn repl_action_due_date_shows_in_preview() {
         let bridge = mock_bridge();
         let input = b"/action Deploy | alice | 1 due:2026-05-01\n/preview\n/close\n";

--- a/src/self_metrics.rs
+++ b/src/self_metrics.rs
@@ -269,6 +269,7 @@ pub fn recent_metrics(limit: usize) -> Result<Vec<MetricEntry>, Box<dyn std::err
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use std::env;
 
     /// Helper: set HOME to a temp dir so tests don't pollute the real home.
@@ -308,6 +309,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn record_and_query_metric() {
         with_temp_home(|| {
             record_metric("bugs_fixed", 3.0, "test context").unwrap();
@@ -324,9 +326,11 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn query_metrics_with_since_filter() {
         with_temp_home(|| {
             record_metric("test_count", 10.0, "old").unwrap();
+            std::thread::sleep(std::time::Duration::from_millis(10));
             let cutoff = Utc::now();
             record_metric("test_count", 20.0, "new").unwrap();
 
@@ -340,6 +344,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn query_metrics_empty_file() {
         with_temp_home(|| {
             let result = query_metrics("nonexistent", None).unwrap();
@@ -348,6 +353,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn daily_report_empty() {
         with_temp_home(|| {
             let report = daily_report().unwrap();
@@ -357,6 +363,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn daily_report_with_data() {
         with_temp_home(|| {
             record_metric("bugs_fixed", 2.0, "ctx").unwrap();
@@ -375,6 +382,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn recent_metrics_limit() {
         with_temp_home(|| {
             for i in 0..10 {
@@ -388,6 +396,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn collect_and_record_all_records_four_metrics() {
         with_temp_home(|| {
             // collect_and_record_all may fail on gh commands, but it should
@@ -402,6 +411,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn malformed_lines_skipped() {
         with_temp_home(|| {
             let dir = metrics_dir();


### PR DESCRIPTION
Closes #340

Fixes 6 test failures on main caused by test parallelism:

**meeting_repl (4 failures):** Tests sharing target/meeting_handoffs WIP file raced — added #[serial] to all 20 REPL tests.

**self_metrics (2 failures):** Tests sharing target/test-metrics-home and mutating HOME via env::set_var — added #[serial] to all 8 metrics tests + 10ms sleep before cutoff capture.

Result: 2816 tests pass, 0 failures.