### PR TITLE
test: add unit tests for 10 untested modules (round 9 — first distributed build)

### DIFF
--- a/src/agent_goal_assignment/operations.rs
+++ b/src/agent_goal_assignment/operations.rs
@@ -97,3 +97,121 @@ pub fn poll_progress(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bridge::BridgeErrorPayload;
+    use crate::bridge_subprocess::InMemoryBridgeTransport;
+
+    fn mock_bridge_store_ok() -> CognitiveMemoryBridge {
+        let transport = InMemoryBridgeTransport::new("test-ops", |method, _params| match method {
+            "memory.store_fact" => Ok(serde_json::json!({"id": "fact_1"})),
+            "memory.search_facts" => Ok(serde_json::json!({"facts": []})),
+            _ => Err(BridgeErrorPayload {
+                code: -32601,
+                message: format!("unknown: {method}"),
+            }),
+        });
+        CognitiveMemoryBridge::new(Box::new(transport))
+    }
+
+    fn mock_bridge_store_fail() -> CognitiveMemoryBridge {
+        let transport = InMemoryBridgeTransport::new("test-fail", |_method, _params| {
+            Err(BridgeErrorPayload {
+                code: -1,
+                message: "store failed".to_string(),
+            })
+        });
+        CognitiveMemoryBridge::new(Box::new(transport))
+    }
+
+    // ── assign_goal ─────────────────────────────────────────────────
+
+    #[test]
+    fn assign_goal_empty_goal_string() {
+        let bridge = mock_bridge_store_ok();
+        let result = assign_goal("agent-x", "", &bridge);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn assign_goal_empty_sub_id() {
+        let bridge = mock_bridge_store_ok();
+        let result = assign_goal("", "some goal", &bridge);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn assign_goal_bridge_failure_propagates() {
+        let bridge = mock_bridge_store_fail();
+        let result = assign_goal("agent-1", "goal", &bridge);
+        assert!(result.is_err());
+    }
+
+    // ── read_assigned_goal ──────────────────────────────────────────
+
+    #[test]
+    fn read_assigned_goal_empty_id() {
+        let bridge = mock_bridge_store_ok();
+        let result = read_assigned_goal("", &bridge).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn read_assigned_goal_bridge_failure_propagates() {
+        let bridge = mock_bridge_store_fail();
+        let result = read_assigned_goal("agent-1", &bridge);
+        assert!(result.is_err());
+    }
+
+    // ── report_progress ─────────────────────────────────────────────
+
+    #[test]
+    fn report_progress_serializes_correctly() {
+        let bridge = mock_bridge_store_ok();
+        let progress = SubordinateProgress {
+            sub_id: "a".to_string(),
+            phase: "planning".to_string(),
+            steps_completed: 0,
+            steps_total: 0,
+            last_action: "init".to_string(),
+            heartbeat_epoch: 1,
+            outcome: None,
+        };
+        let result = report_progress("a", &progress, &bridge);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn report_progress_bridge_failure_propagates() {
+        let bridge = mock_bridge_store_fail();
+        let progress = SubordinateProgress {
+            sub_id: "a".to_string(),
+            phase: "p".to_string(),
+            steps_completed: 0,
+            steps_total: 0,
+            last_action: "x".to_string(),
+            heartbeat_epoch: 0,
+            outcome: None,
+        };
+        let result = report_progress("a", &progress, &bridge);
+        assert!(result.is_err());
+    }
+
+    // ── poll_progress ───────────────────────────────────────────────
+
+    #[test]
+    fn poll_progress_empty_id() {
+        let bridge = mock_bridge_store_ok();
+        let result = poll_progress("", &bridge).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn poll_progress_bridge_failure_propagates() {
+        let bridge = mock_bridge_store_fail();
+        let result = poll_progress("agent-1", &bridge);
+        assert!(result.is_err());
+    }
+}

--- a/src/goal_curation/types.rs
+++ b/src/goal_curation/types.rs
@@ -96,3 +96,248 @@ impl Default for GoalBoard {
         Self::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── GoalProgress Display ────────────────────────────────────────
+
+    #[test]
+    fn goal_progress_display_not_started() {
+        assert_eq!(GoalProgress::NotStarted.to_string(), "not-started");
+    }
+
+    #[test]
+    fn goal_progress_display_in_progress() {
+        let p = GoalProgress::InProgress { percent: 42 };
+        assert_eq!(p.to_string(), "in-progress(42%)");
+    }
+
+    #[test]
+    fn goal_progress_display_in_progress_zero() {
+        let p = GoalProgress::InProgress { percent: 0 };
+        assert_eq!(p.to_string(), "in-progress(0%)");
+    }
+
+    #[test]
+    fn goal_progress_display_in_progress_hundred() {
+        let p = GoalProgress::InProgress { percent: 100 };
+        assert_eq!(p.to_string(), "in-progress(100%)");
+    }
+
+    #[test]
+    fn goal_progress_display_blocked() {
+        let p = GoalProgress::Blocked("waiting on review".to_string());
+        assert_eq!(p.to_string(), "blocked: waiting on review");
+    }
+
+    #[test]
+    fn goal_progress_display_completed() {
+        assert_eq!(GoalProgress::Completed.to_string(), "completed");
+    }
+
+    // ── GoalProgress Serde ──────────────────────────────────────────
+
+    #[test]
+    fn goal_progress_serde_all_variants() {
+        let variants = vec![
+            GoalProgress::NotStarted,
+            GoalProgress::InProgress { percent: 50 },
+            GoalProgress::Blocked("reason".to_string()),
+            GoalProgress::Completed,
+        ];
+        for v in variants {
+            let json = serde_json::to_string(&v).unwrap();
+            let v2: GoalProgress = serde_json::from_str(&json).unwrap();
+            assert_eq!(v, v2);
+        }
+    }
+
+    // ── ActiveGoal ──────────────────────────────────────────────────
+
+    fn sample_goal() -> ActiveGoal {
+        ActiveGoal {
+            id: "g-1".to_string(),
+            description: "Ship MVP".to_string(),
+            priority: 1,
+            status: GoalProgress::InProgress { percent: 75 },
+            assigned_to: Some("team-a".to_string()),
+        }
+    }
+
+    #[test]
+    fn active_goal_serde_round_trip() {
+        let g = sample_goal();
+        let json = serde_json::to_string(&g).unwrap();
+        let g2: ActiveGoal = serde_json::from_str(&json).unwrap();
+        assert_eq!(g, g2);
+    }
+
+    #[test]
+    fn active_goal_concise_label() {
+        let g = sample_goal();
+        let label = g.concise_label();
+        assert!(label.contains("p1"));
+        assert!(label.contains("in-progress(75%)"));
+        assert!(label.contains("Ship MVP"));
+    }
+
+    #[test]
+    fn active_goal_assigned_to_none() {
+        let g = ActiveGoal {
+            id: "g-2".to_string(),
+            description: "Unassigned".to_string(),
+            priority: 3,
+            status: GoalProgress::NotStarted,
+            assigned_to: None,
+        };
+        let json = serde_json::to_string(&g).unwrap();
+        let g2: ActiveGoal = serde_json::from_str(&json).unwrap();
+        assert_eq!(g2.assigned_to, None);
+    }
+
+    // ── BacklogItem ─────────────────────────────────────────────────
+
+    #[test]
+    fn backlog_item_serde_round_trip() {
+        let b = BacklogItem {
+            id: "b-1".to_string(),
+            description: "Refactor auth".to_string(),
+            source: "review".to_string(),
+            score: 0.85,
+        };
+        let json = serde_json::to_string(&b).unwrap();
+        let b2: BacklogItem = serde_json::from_str(&json).unwrap();
+        assert_eq!(b, b2);
+    }
+
+    #[test]
+    fn backlog_item_zero_score() {
+        let b = BacklogItem {
+            id: "b-0".to_string(),
+            description: "Low priority".to_string(),
+            source: "auto".to_string(),
+            score: 0.0,
+        };
+        assert_eq!(b.score, 0.0);
+    }
+
+    // ── GoalBoard ───────────────────────────────────────────────────
+
+    #[test]
+    fn goal_board_new_is_empty() {
+        let board = GoalBoard::new();
+        assert!(board.active.is_empty());
+        assert!(board.backlog.is_empty());
+    }
+
+    #[test]
+    fn goal_board_default_equals_new() {
+        assert_eq!(GoalBoard::default(), GoalBoard::new());
+    }
+
+    #[test]
+    fn goal_board_active_slots_remaining_empty() {
+        let board = GoalBoard::new();
+        assert_eq!(board.active_slots_remaining(), MAX_ACTIVE_GOALS);
+    }
+
+    #[test]
+    fn goal_board_active_slots_remaining_partial() {
+        let board = GoalBoard {
+            active: vec![sample_goal(), sample_goal()],
+            backlog: vec![],
+        };
+        assert_eq!(board.active_slots_remaining(), MAX_ACTIVE_GOALS - 2);
+    }
+
+    #[test]
+    fn goal_board_active_slots_remaining_full() {
+        let goals: Vec<ActiveGoal> = (0..MAX_ACTIVE_GOALS)
+            .map(|i| ActiveGoal {
+                id: format!("g-{i}"),
+                description: format!("Goal {i}"),
+                priority: 1,
+                status: GoalProgress::NotStarted,
+                assigned_to: None,
+            })
+            .collect();
+        let board = GoalBoard {
+            active: goals,
+            backlog: vec![],
+        };
+        assert_eq!(board.active_slots_remaining(), 0);
+    }
+
+    #[test]
+    fn goal_board_active_slots_remaining_overflow_saturates() {
+        let goals: Vec<ActiveGoal> = (0..MAX_ACTIVE_GOALS + 2)
+            .map(|i| ActiveGoal {
+                id: format!("g-{i}"),
+                description: format!("Goal {i}"),
+                priority: 1,
+                status: GoalProgress::NotStarted,
+                assigned_to: None,
+            })
+            .collect();
+        let board = GoalBoard {
+            active: goals,
+            backlog: vec![],
+        };
+        assert_eq!(board.active_slots_remaining(), 0);
+    }
+
+    #[test]
+    fn goal_board_serde_round_trip() {
+        let board = GoalBoard {
+            active: vec![sample_goal()],
+            backlog: vec![BacklogItem {
+                id: "b-1".to_string(),
+                description: "Later".to_string(),
+                source: "auto".to_string(),
+                score: 0.5,
+            }],
+        };
+        let json = serde_json::to_string(&board).unwrap();
+        let b2: GoalBoard = serde_json::from_str(&json).unwrap();
+        assert_eq!(board, b2);
+    }
+
+    #[test]
+    fn durable_summary_empty_board() {
+        let board = GoalBoard::new();
+        let s = board.durable_summary();
+        assert!(s.contains("active=[none]"));
+        assert!(s.contains("backlog=none"));
+    }
+
+    #[test]
+    fn durable_summary_with_goals_and_backlog() {
+        let board = GoalBoard {
+            active: vec![sample_goal()],
+            backlog: vec![
+                BacklogItem {
+                    id: "b-1".to_string(),
+                    description: "X".to_string(),
+                    source: "s".to_string(),
+                    score: 0.1,
+                },
+                BacklogItem {
+                    id: "b-2".to_string(),
+                    description: "Y".to_string(),
+                    source: "s".to_string(),
+                    score: 0.2,
+                },
+            ],
+        };
+        let s = board.durable_summary();
+        assert!(s.contains("Ship MVP"));
+        assert!(s.contains("2 items"));
+    }
+
+    #[test]
+    fn max_active_goals_constant() {
+        assert_eq!(MAX_ACTIVE_GOALS, 5);
+    }
+}

--- a/src/meeting_facilitator/types.rs
+++ b/src/meeting_facilitator/types.rs
@@ -103,3 +103,231 @@ impl MeetingSession {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── MeetingDecision ─────────────────────────────────────────────
+
+    #[test]
+    fn meeting_decision_round_trip_serde() {
+        let d = MeetingDecision {
+            description: "Use Rust".to_string(),
+            rationale: "Memory safety".to_string(),
+            participants: vec!["alice".to_string(), "bob".to_string()],
+        };
+        let json = serde_json::to_string(&d).unwrap();
+        let d2: MeetingDecision = serde_json::from_str(&json).unwrap();
+        assert_eq!(d, d2);
+    }
+
+    #[test]
+    fn meeting_decision_empty_participants() {
+        let d = MeetingDecision {
+            description: "No attendees".to_string(),
+            rationale: "Testing".to_string(),
+            participants: vec![],
+        };
+        let json = serde_json::to_string(&d).unwrap();
+        let d2: MeetingDecision = serde_json::from_str(&json).unwrap();
+        assert!(d2.participants.is_empty());
+    }
+
+    // ── ActionItem ──────────────────────────────────────────────────
+
+    #[test]
+    fn action_item_round_trip_serde() {
+        let a = ActionItem {
+            description: "Write tests".to_string(),
+            owner: "dev".to_string(),
+            priority: 1,
+            due_description: Some("next sprint".to_string()),
+        };
+        let json = serde_json::to_string(&a).unwrap();
+        let a2: ActionItem = serde_json::from_str(&json).unwrap();
+        assert_eq!(a, a2);
+    }
+
+    #[test]
+    fn action_item_due_description_none() {
+        let a = ActionItem {
+            description: "Fix bug".to_string(),
+            owner: "ops".to_string(),
+            priority: 3,
+            due_description: None,
+        };
+        let json = serde_json::to_string(&a).unwrap();
+        let a2: ActionItem = serde_json::from_str(&json).unwrap();
+        assert_eq!(a2.due_description, None);
+    }
+
+    #[test]
+    fn action_item_zero_priority() {
+        let a = ActionItem {
+            description: "Low".to_string(),
+            owner: "x".to_string(),
+            priority: 0,
+            due_description: None,
+        };
+        assert_eq!(a.priority, 0);
+    }
+
+    // ── OpenQuestion ────────────────────────────────────────────────
+
+    #[test]
+    fn open_question_explicit_flag() {
+        let q = OpenQuestion {
+            text: "Why?".to_string(),
+            explicit: true,
+        };
+        let json = serde_json::to_string(&q).unwrap();
+        let q2: OpenQuestion = serde_json::from_str(&json).unwrap();
+        assert!(q2.explicit);
+    }
+
+    #[test]
+    fn open_question_inferred_flag() {
+        let q = OpenQuestion {
+            text: "What about X?".to_string(),
+            explicit: false,
+        };
+        let json = serde_json::to_string(&q).unwrap();
+        let q2: OpenQuestion = serde_json::from_str(&json).unwrap();
+        assert!(!q2.explicit);
+    }
+
+    // ── MeetingSessionStatus ────────────────────────────────────────
+
+    #[test]
+    fn status_display_open() {
+        assert_eq!(MeetingSessionStatus::Open.to_string(), "open");
+    }
+
+    #[test]
+    fn status_display_closed() {
+        assert_eq!(MeetingSessionStatus::Closed.to_string(), "closed");
+    }
+
+    #[test]
+    fn status_serde_round_trip() {
+        for status in [MeetingSessionStatus::Open, MeetingSessionStatus::Closed] {
+            let json = serde_json::to_string(&status).unwrap();
+            let s2: MeetingSessionStatus = serde_json::from_str(&json).unwrap();
+            assert_eq!(status, s2);
+        }
+    }
+
+    // ── MeetingSession ──────────────────────────────────────────────
+
+    fn sample_session() -> MeetingSession {
+        MeetingSession {
+            topic: "Sprint planning".to_string(),
+            decisions: vec![MeetingDecision {
+                description: "Adopt TDD".to_string(),
+                rationale: "Better quality".to_string(),
+                participants: vec!["alice".to_string()],
+            }],
+            action_items: vec![ActionItem {
+                description: "Set up CI".to_string(),
+                owner: "bob".to_string(),
+                priority: 1,
+                due_description: Some("Friday".to_string()),
+            }],
+            notes: vec!["Good discussion".to_string()],
+            status: MeetingSessionStatus::Open,
+            started_at: "2025-01-01T00:00:00Z".to_string(),
+            participants: vec!["alice".to_string(), "bob".to_string()],
+            explicit_questions: vec!["What about testing?".to_string()],
+        }
+    }
+
+    #[test]
+    fn session_round_trip_serde() {
+        let s = sample_session();
+        let json = serde_json::to_string(&s).unwrap();
+        let s2: MeetingSession = serde_json::from_str(&json).unwrap();
+        assert_eq!(s, s2);
+    }
+
+    #[test]
+    fn session_explicit_questions_default() {
+        // explicit_questions has #[serde(default)], so missing field should default to empty vec
+        let json = r#"{
+            "topic": "test",
+            "decisions": [],
+            "action_items": [],
+            "notes": [],
+            "status": "Open",
+            "started_at": "",
+            "participants": []
+        }"#;
+        let s: MeetingSession = serde_json::from_str(json).unwrap();
+        assert!(s.explicit_questions.is_empty());
+    }
+
+    #[test]
+    fn durable_summary_contains_topic() {
+        let s = sample_session();
+        let summary = s.durable_summary();
+        assert!(summary.contains("Sprint planning"));
+    }
+
+    #[test]
+    fn durable_summary_contains_decisions() {
+        let s = sample_session();
+        let summary = s.durable_summary();
+        assert!(summary.contains("Adopt TDD"));
+    }
+
+    #[test]
+    fn durable_summary_contains_action_items_with_owner() {
+        let s = sample_session();
+        let summary = s.durable_summary();
+        assert!(summary.contains("Set up CI"));
+        assert!(summary.contains("owner=bob"));
+    }
+
+    #[test]
+    fn durable_summary_contains_participants() {
+        let s = sample_session();
+        let summary = s.durable_summary();
+        assert!(summary.contains("alice"));
+        assert!(summary.contains("bob"));
+    }
+
+    #[test]
+    fn durable_summary_empty_session() {
+        let s = MeetingSession {
+            topic: "empty".to_string(),
+            decisions: vec![],
+            action_items: vec![],
+            notes: vec![],
+            status: MeetingSessionStatus::Open,
+            started_at: "".to_string(),
+            participants: vec![],
+            explicit_questions: vec![],
+        };
+        let summary = s.durable_summary();
+        assert!(summary.contains("decisions=[none]"));
+        assert!(summary.contains("action_items=[none]"));
+        assert!(summary.contains("participants=[none]"));
+        assert!(summary.contains("duration=unknown"));
+    }
+
+    #[test]
+    fn durable_summary_invalid_started_at_shows_unknown_duration() {
+        let s = MeetingSession {
+            topic: "bad-ts".to_string(),
+            decisions: vec![],
+            action_items: vec![],
+            notes: vec![],
+            status: MeetingSessionStatus::Open,
+            started_at: "not-a-date".to_string(),
+            participants: vec![],
+            explicit_questions: vec![],
+        };
+        let summary = s.durable_summary();
+        assert!(summary.contains("duration=unknown"));
+    }
+}

--- a/src/operator_cli/decisions.rs
+++ b/src/operator_cli/decisions.rs
@@ -95,3 +95,125 @@ pub(super) fn dispatch_act_on_decisions() -> Result<(), Box<dyn std::error::Erro
     println!("\nDone. Created {created} issue(s). Handoff marked as processed.");
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::meeting_facilitator::{ActionItem, MeetingDecision, OpenQuestion};
+    use crate::meeting_facilitator::{
+        MeetingHandoff, load_meeting_handoff, mark_meeting_handoff_processed, write_meeting_handoff,
+    };
+    use tempfile::tempdir;
+
+    fn sample_handoff(processed: bool) -> MeetingHandoff {
+        MeetingHandoff {
+            topic: "Sprint Review".to_string(),
+            started_at: "2025-01-01T00:00:00Z".to_string(),
+            closed_at: "2025-01-01T01:00:00Z".to_string(),
+            decisions: vec![MeetingDecision {
+                description: "Adopt Rust".to_string(),
+                rationale: "Safety".to_string(),
+                participants: vec!["alice".to_string()],
+            }],
+            action_items: vec![ActionItem {
+                description: "Write tests".to_string(),
+                owner: "bob".to_string(),
+                priority: 1,
+                due_description: Some("next week".to_string()),
+            }],
+            open_questions: vec![OpenQuestion {
+                text: "What about Python?".to_string(),
+                explicit: true,
+            }],
+            processed,
+            duration_secs: Some(3600),
+            transcript: vec![],
+            participants: vec!["alice".to_string(), "bob".to_string()],
+        }
+    }
+
+    #[test]
+    fn gh_create_issue_handles_missing_binary() {
+        let result = gh_create_issue("test-only", "body", "label");
+        let _ = result;
+    }
+
+    #[test]
+    fn dispatch_fn_exists() {
+        let _fn_ref: fn() -> Result<(), Box<dyn std::error::Error>> = dispatch_act_on_decisions;
+    }
+
+    #[test]
+    fn handoff_serde_round_trip() {
+        let h = sample_handoff(false);
+        let json = serde_json::to_string(&h).unwrap();
+        let h2: MeetingHandoff = serde_json::from_str(&json).unwrap();
+        assert_eq!(h.topic, h2.topic);
+        assert_eq!(h.decisions.len(), h2.decisions.len());
+        assert_eq!(h.action_items.len(), h2.action_items.len());
+        assert_eq!(h.processed, h2.processed);
+    }
+
+    #[test]
+    fn handoff_processed_flag_default() {
+        let json = r#"{"topic":"t","started_at":"","closed_at":"","decisions":[],"action_items":[],"open_questions":[]}"#;
+        let h: MeetingHandoff = serde_json::from_str(json).unwrap();
+        assert!(!h.processed);
+    }
+
+    #[test]
+    fn handoff_processed_true() {
+        let h = sample_handoff(true);
+        assert!(h.processed);
+    }
+
+    #[test]
+    fn handoff_open_questions_preserved() {
+        let h = sample_handoff(false);
+        assert_eq!(h.open_questions.len(), 1);
+        assert!(h.open_questions[0].explicit);
+        assert!(h.open_questions[0].text.contains("Python"));
+    }
+
+    #[test]
+    fn handoff_empty_decisions_and_actions() {
+        let h = MeetingHandoff {
+            topic: "empty".to_string(),
+            started_at: String::new(),
+            closed_at: String::new(),
+            decisions: vec![],
+            action_items: vec![],
+            open_questions: vec![],
+            processed: false,
+            duration_secs: None,
+            transcript: vec![],
+            participants: vec![],
+        };
+        let json = serde_json::to_string(&h).unwrap();
+        let h2: MeetingHandoff = serde_json::from_str(&json).unwrap();
+        assert!(h2.decisions.is_empty());
+        assert!(h2.action_items.is_empty());
+    }
+
+    #[test]
+    fn write_and_load_handoff_round_trip() {
+        let tmp = tempdir().unwrap();
+        let h = sample_handoff(false);
+        write_meeting_handoff(tmp.path(), &h).unwrap();
+        let loaded = load_meeting_handoff(tmp.path()).unwrap();
+        assert!(loaded.is_some());
+        let loaded = loaded.unwrap();
+        assert_eq!(loaded.topic, "Sprint Review");
+        assert!(!loaded.processed);
+    }
+
+    #[test]
+    fn mark_handoff_processed_updates_flag() {
+        let tmp = tempdir().unwrap();
+        let h = sample_handoff(false);
+        write_meeting_handoff(tmp.path(), &h).unwrap();
+        mark_meeting_handoff_processed(tmp.path()).unwrap();
+        let loaded = load_meeting_handoff(tmp.path()).unwrap().unwrap();
+        assert!(loaded.processed);
+    }
+}

--- a/src/operator_commands_dashboard/auth.rs
+++ b/src/operator_commands_dashboard/auth.rs
@@ -109,3 +109,103 @@ pub async fn require_auth(request: Request, next: Next) -> Result<Response, Stat
             .unwrap())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── init_login_code ─────────────────────────────────────────────
+
+    #[test]
+    fn init_login_code_returns_8_char_string() {
+        let code = init_login_code();
+        assert_eq!(
+            code.len(),
+            8,
+            "Login code should be 8 characters, got: {code}"
+        );
+    }
+
+    #[test]
+    fn init_login_code_is_nonempty() {
+        let code = init_login_code();
+        assert!(!code.is_empty());
+    }
+
+    // ── try_login ───────────────────────────────────────────────────
+
+    #[test]
+    fn try_login_wrong_code_returns_none() {
+        // Ensure some login code is set
+        init_login_code();
+        let result = try_login("definitely-wrong-code");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn try_login_correct_code_returns_token() {
+        let code = init_login_code();
+        // LOGIN_CODE is a OnceLock, so it may already be set from a prior test;
+        // we test with whatever code was stored
+        if let Some(stored) = LOGIN_CODE.get() {
+            let result = try_login(stored);
+            assert!(
+                result.is_some(),
+                "Correct code should yield a session token"
+            );
+            let token = result.unwrap();
+            assert!(!token.is_empty());
+        } else {
+            // If init_login_code set it, use code
+            let result = try_login(&code);
+            assert!(result.is_some());
+        }
+    }
+
+    #[test]
+    fn try_login_trims_whitespace() {
+        if let Some(stored) = LOGIN_CODE.get() {
+            let padded = format!("  {}  ", stored);
+            let result = try_login(&padded);
+            assert!(result.is_some(), "try_login should trim whitespace");
+        }
+    }
+
+    #[test]
+    fn try_login_empty_string_returns_none() {
+        init_login_code();
+        let result = try_login("");
+        assert!(result.is_none());
+    }
+
+    // ── is_valid_session ────────────────────────────────────────────
+
+    #[test]
+    fn is_valid_session_unknown_token() {
+        assert!(!is_valid_session("nonexistent-token"));
+    }
+
+    #[test]
+    fn is_valid_session_after_login() {
+        init_login_code();
+        if let Some(stored) = LOGIN_CODE.get() {
+            if let Some(token) = try_login(stored) {
+                assert!(is_valid_session(&token));
+            }
+        }
+    }
+
+    #[test]
+    fn is_valid_session_empty_token() {
+        assert!(!is_valid_session(""));
+    }
+
+    // ── sessions() helper ───────────────────────────────────────────
+
+    #[test]
+    fn sessions_mutex_is_accessible() {
+        let guard = sessions().lock().unwrap();
+        // Just verify we can acquire the lock
+        drop(guard);
+    }
+}

--- a/src/operator_commands_dashboard/auth.rs
+++ b/src/operator_commands_dashboard/auth.rs
@@ -188,10 +188,10 @@ mod tests {
     #[test]
     fn is_valid_session_after_login() {
         init_login_code();
-        if let Some(stored) = LOGIN_CODE.get() {
-            if let Some(token) = try_login(stored) {
-                assert!(is_valid_session(&token));
-            }
+        if let Some(stored) = LOGIN_CODE.get()
+            && let Some(token) = try_login(stored)
+        {
+            assert!(is_valid_session(&token));
         }
     }
 

--- a/src/operator_commands_gym/commands.rs
+++ b/src/operator_commands_gym/commands.rs
@@ -130,3 +130,77 @@ pub fn run_gym_suite(suite_id: &str) -> Result<(), Box<dyn std::error::Error>> {
     println!("Suite artifact report: {}", report.artifact_path);
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── benchmark_scenarios ─────────────────────────────────────────
+
+    #[test]
+    fn benchmark_scenarios_is_not_empty() {
+        let scenarios = benchmark_scenarios();
+        assert!(
+            !scenarios.is_empty(),
+            "benchmark_scenarios should return at least one scenario"
+        );
+    }
+
+    #[test]
+    fn benchmark_scenarios_have_non_empty_ids() {
+        for scenario in benchmark_scenarios() {
+            assert!(!scenario.id.is_empty(), "Scenario id should not be empty");
+        }
+    }
+
+    #[test]
+    fn benchmark_scenarios_have_non_empty_titles() {
+        for scenario in benchmark_scenarios() {
+            assert!(
+                !scenario.title.is_empty(),
+                "Scenario {} should have a title",
+                scenario.id
+            );
+        }
+    }
+
+    #[test]
+    fn benchmark_scenarios_ids_are_unique() {
+        let scenarios = benchmark_scenarios();
+        let mut ids: Vec<&str> = scenarios.iter().map(|s| s.id).collect();
+        let len_before = ids.len();
+        ids.sort();
+        ids.dedup();
+        assert_eq!(ids.len(), len_before, "Scenario IDs should be unique");
+    }
+
+    #[test]
+    fn benchmark_scenarios_have_required_fields() {
+        for scenario in benchmark_scenarios() {
+            assert!(
+                !scenario.identity.is_empty(),
+                "identity empty for {}",
+                scenario.id
+            );
+            assert!(
+                !scenario.base_type.is_empty(),
+                "base_type empty for {}",
+                scenario.id
+            );
+            assert!(
+                !scenario.objective.is_empty(),
+                "objective empty for {}",
+                scenario.id
+            );
+        }
+    }
+
+    // ── run_gym_list ────────────────────────────────────────────────
+
+    #[test]
+    fn run_gym_list_succeeds() {
+        // This function just prints to stdout, so we verify it does not error
+        let result = run_gym_list();
+        assert!(result.is_ok());
+    }
+}

--- a/src/operator_commands_meeting/live_context.rs
+++ b/src/operator_commands_meeting/live_context.rs
@@ -118,3 +118,113 @@ pub(super) fn build_live_meeting_context(bridge: &CognitiveMemoryBridge) -> Stri
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bridge::BridgeErrorPayload;
+    use crate::bridge_subprocess::InMemoryBridgeTransport;
+
+    // ── resolve_operator_name ───────────────────────────────────────
+
+    #[test]
+    fn resolve_operator_name_default_fallback() {
+        unsafe { std::env::remove_var("SIMARD_OPERATOR_NAME") };
+        let name = resolve_operator_name();
+        assert_eq!(name, "operator");
+    }
+
+    #[test]
+    fn resolve_operator_name_from_env() {
+        unsafe { std::env::set_var("SIMARD_OPERATOR_NAME", "alice") };
+        let name = resolve_operator_name();
+        assert_eq!(name, "alice");
+        unsafe { std::env::remove_var("SIMARD_OPERATOR_NAME") };
+    }
+
+    #[test]
+    fn resolve_operator_name_empty_env_falls_back() {
+        unsafe { std::env::set_var("SIMARD_OPERATOR_NAME", "") };
+        let name = resolve_operator_name();
+        assert_eq!(name, "operator");
+        unsafe { std::env::remove_var("SIMARD_OPERATOR_NAME") };
+    }
+
+    // ── search_or_warn ──────────────────────────────────────────────
+
+    fn empty_bridge() -> CognitiveMemoryBridge {
+        let transport = InMemoryBridgeTransport::new("test-ctx", |method, _params| match method {
+            "memory.search_facts" => Ok(serde_json::json!({"facts": []})),
+            _ => Err(BridgeErrorPayload {
+                code: -32601,
+                message: format!("unknown: {method}"),
+            }),
+        });
+        CognitiveMemoryBridge::new(Box::new(transport))
+    }
+
+    fn failing_bridge() -> CognitiveMemoryBridge {
+        let transport = InMemoryBridgeTransport::new("test-fail", |_method, _params| {
+            Err(BridgeErrorPayload {
+                code: -1,
+                message: "forced error".to_string(),
+            })
+        });
+        CognitiveMemoryBridge::new(Box::new(transport))
+    }
+
+    #[test]
+    fn search_or_warn_empty_result() {
+        let bridge = empty_bridge();
+        let facts = search_or_warn(&bridge, "anything", 5);
+        assert!(facts.is_empty());
+    }
+
+    #[test]
+    fn search_or_warn_bridge_failure_returns_empty() {
+        let bridge = failing_bridge();
+        let facts = search_or_warn(&bridge, "query", 5);
+        assert!(facts.is_empty());
+    }
+
+    // ── build_live_meeting_context ──────────────────────────────────
+
+    #[test]
+    fn build_context_empty_memory() {
+        let bridge = empty_bridge();
+        unsafe { std::env::remove_var("SIMARD_OPERATOR_NAME") };
+        let ctx = build_live_meeting_context(&bridge);
+        assert!(ctx.contains("Operator Context"));
+        assert!(ctx.contains("operator"));
+    }
+
+    #[test]
+    fn build_context_failing_bridge_shows_operator_fallback() {
+        let bridge = failing_bridge();
+        unsafe { std::env::remove_var("SIMARD_OPERATOR_NAME") };
+        let ctx = build_live_meeting_context(&bridge);
+        assert!(ctx.contains("Operator Context"));
+    }
+
+    #[test]
+    fn build_context_always_has_operator_section() {
+        let bridge = empty_bridge();
+        let ctx = build_live_meeting_context(&bridge);
+        assert!(ctx.contains("Operator Context"));
+    }
+
+    #[test]
+    fn build_context_result_is_not_empty() {
+        let bridge = empty_bridge();
+        let ctx = build_live_meeting_context(&bridge);
+        assert!(!ctx.is_empty());
+    }
+
+    #[test]
+    fn build_context_contains_live_state_header() {
+        let bridge = empty_bridge();
+        let ctx = build_live_meeting_context(&bridge);
+        // Either shows "Live State" or "Live State (from cognitive memory)"
+        assert!(ctx.contains("Live State"));
+    }
+}

--- a/src/research_tracker/types.rs
+++ b/src/research_tracker/types.rs
@@ -96,3 +96,195 @@ impl ResearchTracker {
         format!("research topics=[{topics_text}]; watches=[{watches_text}]")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── ResearchStatus ──────────────────────────────────────────────
+
+    #[test]
+    fn research_status_display_all_variants() {
+        assert_eq!(ResearchStatus::Proposed.to_string(), "proposed");
+        assert_eq!(ResearchStatus::InProgress.to_string(), "in-progress");
+        assert_eq!(ResearchStatus::Completed.to_string(), "completed");
+        assert_eq!(ResearchStatus::Archived.to_string(), "archived");
+    }
+
+    #[test]
+    fn research_status_serde_round_trip() {
+        for status in [
+            ResearchStatus::Proposed,
+            ResearchStatus::InProgress,
+            ResearchStatus::Completed,
+            ResearchStatus::Archived,
+        ] {
+            let json = serde_json::to_string(&status).unwrap();
+            let s2: ResearchStatus = serde_json::from_str(&json).unwrap();
+            assert_eq!(status, s2);
+        }
+    }
+
+    // ── ResearchTopic ───────────────────────────────────────────────
+
+    fn sample_topic() -> ResearchTopic {
+        ResearchTopic {
+            id: "rt-1".to_string(),
+            title: "LLM Agents".to_string(),
+            source: "paper".to_string(),
+            priority: 2,
+            status: ResearchStatus::InProgress,
+        }
+    }
+
+    #[test]
+    fn research_topic_serde_round_trip() {
+        let t = sample_topic();
+        let json = serde_json::to_string(&t).unwrap();
+        let t2: ResearchTopic = serde_json::from_str(&json).unwrap();
+        assert_eq!(t, t2);
+    }
+
+    #[test]
+    fn concise_label_contains_priority_status_title() {
+        let t = sample_topic();
+        let label = t.concise_label();
+        assert!(label.contains("p2"));
+        assert!(label.contains("in-progress"));
+        assert!(label.contains("LLM Agents"));
+    }
+
+    #[test]
+    fn concise_label_zero_priority() {
+        let t = ResearchTopic {
+            id: "rt-0".to_string(),
+            title: "Low".to_string(),
+            source: "internal".to_string(),
+            priority: 0,
+            status: ResearchStatus::Proposed,
+        };
+        assert!(t.concise_label().starts_with("p0"));
+    }
+
+    // ── DeveloperWatch ──────────────────────────────────────────────
+
+    #[test]
+    fn developer_watch_serde_round_trip() {
+        let w = DeveloperWatch {
+            github_id: "octocat".to_string(),
+            focus_areas: vec!["rust".to_string(), "wasm".to_string()],
+            last_checked: Some(1234567890),
+        };
+        let json = serde_json::to_string(&w).unwrap();
+        let w2: DeveloperWatch = serde_json::from_str(&json).unwrap();
+        assert_eq!(w, w2);
+    }
+
+    #[test]
+    fn developer_watch_last_checked_none() {
+        let w = DeveloperWatch {
+            github_id: "dev".to_string(),
+            focus_areas: vec![],
+            last_checked: None,
+        };
+        let json = serde_json::to_string(&w).unwrap();
+        let w2: DeveloperWatch = serde_json::from_str(&json).unwrap();
+        assert_eq!(w2.last_checked, None);
+    }
+
+    #[test]
+    fn developer_watch_empty_focus_areas() {
+        let w = DeveloperWatch {
+            github_id: "solo".to_string(),
+            focus_areas: vec![],
+            last_checked: None,
+        };
+        assert!(w.focus_areas.is_empty());
+    }
+
+    // ── ResearchTracker ─────────────────────────────────────────────
+
+    #[test]
+    fn tracker_default_is_empty() {
+        let t = ResearchTracker::default();
+        assert!(t.topics.is_empty());
+        assert!(t.watches.is_empty());
+    }
+
+    #[test]
+    fn tracker_new_equals_default() {
+        assert_eq!(ResearchTracker::new(), ResearchTracker::default());
+    }
+
+    #[test]
+    fn tracker_with_default_watches_has_watches() {
+        let t = ResearchTracker::with_default_watches();
+        assert!(t.topics.is_empty());
+        assert!(!t.watches.is_empty());
+    }
+
+    #[test]
+    fn tracker_serde_round_trip() {
+        let t = ResearchTracker {
+            topics: vec![sample_topic()],
+            watches: vec![DeveloperWatch {
+                github_id: "dev".to_string(),
+                focus_areas: vec!["ai".to_string()],
+                last_checked: Some(100),
+            }],
+        };
+        let json = serde_json::to_string(&t).unwrap();
+        let t2: ResearchTracker = serde_json::from_str(&json).unwrap();
+        assert_eq!(t, t2);
+    }
+
+    #[test]
+    fn durable_summary_empty_tracker() {
+        let t = ResearchTracker::new();
+        let s = t.durable_summary();
+        assert!(s.contains("topics=[none]"));
+        assert!(s.contains("watches=[none]"));
+    }
+
+    #[test]
+    fn durable_summary_with_topics_and_watches() {
+        let t = ResearchTracker {
+            topics: vec![sample_topic()],
+            watches: vec![DeveloperWatch {
+                github_id: "octocat".to_string(),
+                focus_areas: vec![],
+                last_checked: None,
+            }],
+        };
+        let s = t.durable_summary();
+        assert!(s.contains("LLM Agents"));
+        assert!(s.contains("octocat"));
+    }
+
+    #[test]
+    fn durable_summary_multiple_topics_semicolon_separated() {
+        let t = ResearchTracker {
+            topics: vec![
+                ResearchTopic {
+                    id: "1".to_string(),
+                    title: "Alpha".to_string(),
+                    source: "s".to_string(),
+                    priority: 1,
+                    status: ResearchStatus::Proposed,
+                },
+                ResearchTopic {
+                    id: "2".to_string(),
+                    title: "Beta".to_string(),
+                    source: "s".to_string(),
+                    priority: 2,
+                    status: ResearchStatus::Completed,
+                },
+            ],
+            watches: vec![],
+        };
+        let s = t.durable_summary();
+        assert!(s.contains("Alpha"));
+        assert!(s.contains("Beta"));
+        assert!(s.contains("; "));
+    }
+}

--- a/src/review/persistence.rs
+++ b/src/review/persistence.rs
@@ -111,3 +111,186 @@ pub fn render_review_text(artifact: &ReviewArtifact) -> String {
     }
     lines.join("\n")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::review::types::{
+        ImprovementProposal, ReviewArtifact, ReviewEvidenceSummary, ReviewTargetKind,
+    };
+    use tempfile::tempdir;
+
+    fn sample_artifact(review_id: &str, unix_ms: u128) -> ReviewArtifact {
+        ReviewArtifact {
+            review_id: review_id.to_string(),
+            reviewed_at_unix_ms: unix_ms,
+            target_kind: ReviewTargetKind::Session,
+            target_label: "session-42".to_string(),
+            identity_name: "simard".to_string(),
+            session_id: "sess-001".to_string(),
+            selected_base_type: "base".to_string(),
+            topology: "single".to_string(),
+            objective_metadata: "meta".to_string(),
+            execution_summary: "ran well".to_string(),
+            reflection_summary: "good".to_string(),
+            summary: "All good".to_string(),
+            measurement_notes: vec!["note1".to_string()],
+            evidence_summary: ReviewEvidenceSummary {
+                memory_records: 10,
+                evidence_records: 5,
+                decision_records: 2,
+                benchmark_records: 1,
+                exported_state: "ok".to_string(),
+                session_phase: Some("execution".to_string()),
+                failed_signals: vec![],
+            },
+            proposals: vec![ImprovementProposal {
+                category: "perf".to_string(),
+                title: "Cache more".to_string(),
+                rationale: "Faster".to_string(),
+                suggested_change: "Add LRU cache".to_string(),
+                evidence: vec!["slow queries".to_string()],
+            }],
+        }
+    }
+
+    // ── review_artifacts_dir ────────────────────────────────────────
+
+    #[test]
+    fn review_artifacts_dir_appends_correct_subdir() {
+        let root = std::path::Path::new("/state");
+        let dir = review_artifacts_dir(root);
+        assert_eq!(dir, std::path::PathBuf::from("/state/review-artifacts"));
+    }
+
+    // ── persist and load round-trip ─────────────────────────────────
+
+    #[test]
+    fn persist_and_load_round_trip() {
+        let tmp = tempdir().unwrap();
+        let state_root = tmp.path();
+
+        let artifact = sample_artifact("rev-001", 1000);
+        let path = persist_review_artifact(state_root, &artifact).unwrap();
+
+        assert!(path.exists());
+        assert!(path.to_string_lossy().contains("rev-001.json"));
+
+        let loaded = load_review_artifact(&path).unwrap();
+        assert_eq!(loaded, artifact);
+    }
+
+    #[test]
+    fn load_review_artifact_nonexistent_file() {
+        let result = load_review_artifact(Path::new("/nonexistent/artifact.json"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn load_review_artifact_invalid_json() {
+        let tmp = tempdir().unwrap();
+        let bad_file = tmp.path().join("bad.json");
+        fs::write(&bad_file, "not valid json").unwrap();
+        let result = load_review_artifact(&bad_file);
+        assert!(result.is_err());
+    }
+
+    // ── latest_review_artifact ──────────────────────────────────────
+
+    #[test]
+    fn latest_review_artifact_no_dir() {
+        let tmp = tempdir().unwrap();
+        let result = latest_review_artifact(tmp.path()).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn latest_review_artifact_empty_dir() {
+        let tmp = tempdir().unwrap();
+        fs::create_dir_all(review_artifacts_dir(tmp.path())).unwrap();
+        let result = latest_review_artifact(tmp.path()).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn latest_review_artifact_picks_newest() {
+        let tmp = tempdir().unwrap();
+        let state_root = tmp.path();
+
+        let old = sample_artifact("rev-old", 1000);
+        let new = sample_artifact("rev-new", 2000);
+        persist_review_artifact(state_root, &old).unwrap();
+        persist_review_artifact(state_root, &new).unwrap();
+
+        let (path, artifact) = latest_review_artifact(state_root).unwrap().unwrap();
+        assert_eq!(artifact.review_id, "rev-new");
+        assert!(path.to_string_lossy().contains("rev-new"));
+    }
+
+    #[test]
+    fn latest_review_artifact_ignores_non_json() {
+        let tmp = tempdir().unwrap();
+        let state_root = tmp.path();
+        let dir = review_artifacts_dir(state_root);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("readme.txt"), "not json").unwrap();
+
+        let result = latest_review_artifact(state_root).unwrap();
+        assert!(result.is_none());
+    }
+
+    // ── render_review_text ──────────────────────────────────────────
+
+    #[test]
+    fn render_review_text_contains_key_fields() {
+        let artifact = sample_artifact("rev-render", 5000);
+        let text = render_review_text(&artifact);
+        assert!(text.contains("Review: rev-render"));
+        assert!(text.contains("Target: session-42"));
+        assert!(text.contains("Target kind: session"));
+        assert!(text.contains("Identity: simard"));
+        assert!(text.contains("Session: sess-001"));
+        assert!(text.contains("Summary: All good"));
+    }
+
+    #[test]
+    fn render_review_text_contains_evidence_summary() {
+        let artifact = sample_artifact("rev-ev", 5000);
+        let text = render_review_text(&artifact);
+        assert!(text.contains("memory_records=10"));
+        assert!(text.contains("evidence_records=5"));
+        assert!(text.contains("decision_records=2"));
+        assert!(text.contains("benchmark_records=1"));
+    }
+
+    #[test]
+    fn render_review_text_contains_proposals() {
+        let artifact = sample_artifact("rev-prop", 5000);
+        let text = render_review_text(&artifact);
+        assert!(text.contains("[perf] Cache more -> Add LRU cache"));
+    }
+
+    #[test]
+    fn render_review_text_contains_measurement_notes() {
+        let artifact = sample_artifact("rev-notes", 5000);
+        let text = render_review_text(&artifact);
+        assert!(text.contains("Measurement notes:"));
+        assert!(text.contains("- note1"));
+    }
+
+    #[test]
+    fn render_review_text_empty_measurement_notes_omitted() {
+        let mut artifact = sample_artifact("rev-empty", 5000);
+        artifact.measurement_notes.clear();
+        let text = render_review_text(&artifact);
+        assert!(!text.contains("Measurement notes:"));
+    }
+
+    #[test]
+    fn render_review_text_empty_proposals() {
+        let mut artifact = sample_artifact("rev-noprop", 5000);
+        artifact.proposals.clear();
+        let text = render_review_text(&artifact);
+        assert!(text.contains("Proposals:"));
+    }
+}

--- a/src/self_improve_executor/git_ops.rs
+++ b/src/self_improve_executor/git_ops.rs
@@ -98,3 +98,134 @@ pub(crate) fn rollback(workspace: &Path) -> SimardResult<()> {
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    /// Set up a temporary git repository with an initial commit.
+    fn init_temp_repo() -> tempfile::TempDir {
+        let tmp = tempdir().unwrap();
+        let ws = tmp.path();
+        Command::new("git")
+            .args(["init"])
+            .current_dir(ws)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["config", "user.email", "test@test.com"])
+            .current_dir(ws)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["config", "user.name", "Test"])
+            .current_dir(ws)
+            .output()
+            .unwrap();
+        std::fs::write(ws.join("init.txt"), "hello").unwrap();
+        Command::new("git")
+            .args(["add", "-A"])
+            .current_dir(ws)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["commit", "-m", "initial"])
+            .current_dir(ws)
+            .output()
+            .unwrap();
+        tmp
+    }
+
+    // ── git_diff ────────────────────────────────────────────────────
+
+    #[test]
+    fn git_diff_clean_repo_empty_diff() {
+        let tmp = init_temp_repo();
+        let diff = git_diff(tmp.path()).unwrap();
+        assert!(diff.is_empty(), "Clean repo should have empty diff");
+    }
+
+    #[test]
+    fn git_diff_with_changes() {
+        let tmp = init_temp_repo();
+        std::fs::write(tmp.path().join("init.txt"), "changed").unwrap();
+        let diff = git_diff(tmp.path()).unwrap();
+        assert!(diff.contains("changed"), "Diff should show the change");
+    }
+
+    #[test]
+    fn git_diff_nonexistent_dir() {
+        let result = git_diff(Path::new("/nonexistent/repo"));
+        assert!(result.is_err());
+    }
+
+    // ── git_commit ──────────────────────────────────────────────────
+
+    #[test]
+    fn git_commit_with_staged_changes() {
+        let tmp = init_temp_repo();
+        std::fs::write(tmp.path().join("new.txt"), "content").unwrap();
+        let result = git_commit(tmp.path(), "add new file");
+        assert!(result.is_ok());
+        // Verify commit was made
+        let log = Command::new("git")
+            .args(["log", "--oneline", "-1"])
+            .current_dir(tmp.path())
+            .output()
+            .unwrap();
+        let log_text = String::from_utf8_lossy(&log.stdout);
+        assert!(log_text.contains("add new file"));
+    }
+
+    #[test]
+    fn git_commit_nothing_to_commit_fails() {
+        let tmp = init_temp_repo();
+        // Nothing changed, so git commit should fail
+        let result = git_commit(tmp.path(), "empty commit");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn git_commit_nonexistent_dir() {
+        let result = git_commit(Path::new("/nonexistent/repo"), "msg");
+        assert!(result.is_err());
+    }
+
+    // ── rollback ────────────────────────────────────────────────────
+
+    #[test]
+    fn rollback_restores_modified_files() {
+        let tmp = init_temp_repo();
+        let file = tmp.path().join("init.txt");
+        std::fs::write(&file, "modified").unwrap();
+        assert_eq!(std::fs::read_to_string(&file).unwrap(), "modified");
+
+        rollback(tmp.path()).unwrap();
+        assert_eq!(std::fs::read_to_string(&file).unwrap(), "hello");
+    }
+
+    #[test]
+    fn rollback_removes_untracked_files() {
+        let tmp = init_temp_repo();
+        let untracked = tmp.path().join("untracked.txt");
+        std::fs::write(&untracked, "junk").unwrap();
+        assert!(untracked.exists());
+
+        rollback(tmp.path()).unwrap();
+        assert!(!untracked.exists());
+    }
+
+    #[test]
+    fn rollback_clean_repo_is_noop() {
+        let tmp = init_temp_repo();
+        let result = rollback(tmp.path());
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn rollback_nonexistent_dir() {
+        let result = rollback(Path::new("/nonexistent/repo"));
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
## Summary
Adds **123 new unit tests** across 10 previously untested modules (~1,498 lines).

## First distributed build 🎉
This is the first test round generated and validated on the **azlin VM** (simard-worker, 128.251.14.62), demonstrating distributed Simard multi-VM operation.

## Modules covered
| Module | Tests | Lines | Key coverage |
|--------|-------|-------|-------------|
| `goal_curation/types.rs` | 22 | 245 | GoalProgress variants, slots remaining, board |
| `meeting_facilitator/types.rs` | 18 | 228 | Serde, Display, durable_summary, defaults |
| `research_tracker/types.rs` | 15 | 192 | Status display, tracker defaults, watches |
| `review/persistence.rs` | 14 | 183 | File I/O round-trip, latest artifact, render |
| `operator_cli/decisions.rs` | 9 | 126 | Handoff serde, write/load, processed flag |
| `self_improve_executor/git_ops.rs` | 10 | 123 | diff/commit/rollback with temp git repos |
| `agent_goal_assignment/operations.rs` | 9 | 120 | Bridge error propagation, edge cases |
| `operator_commands_meeting/live_context.rs` | 10 | 110 | Operator name resolution, bridge mocks |
| `operator_commands_dashboard/auth.rs` | 10 | 93 | Login code, session validation, try_login |
| `operator_commands_gym/commands.rs` | 6 | 78 | Scenario data integrity, uniqueness |

## Validation
- All 2,939 tests pass on azlin VM (16 CPUs, 125GB RAM)
- Clean rebase on main (includes rounds 5-8 + pre-existing failure fixes)

Closes #343