### PR TITLE
test: add unit tests for remaining 23 untested modules (round 10 — final, 100% file coverage)

### DIFF
--- a/src/agent_goal_assignment/types.rs
+++ b/src/agent_goal_assignment/types.rs
@@ -66,3 +66,85 @@ impl SubordinateProgress {
         self
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn subordinate_progress_display() {
+        let p = SubordinateProgress {
+            sub_id: "agent-1".to_string(),
+            phase: "execution".to_string(),
+            steps_completed: 3,
+            steps_total: 10,
+            last_action: "run tests".to_string(),
+            heartbeat_epoch: 1700000000,
+            outcome: None,
+        };
+        let display = format!("{p}");
+        assert!(display.contains("agent-1"));
+        assert!(display.contains("execution"));
+        assert!(display.contains("3/10"));
+        assert!(display.contains("run tests"));
+    }
+
+    #[test]
+    fn subordinate_progress_serde_roundtrip() {
+        let p = SubordinateProgress {
+            sub_id: "agent-2".to_string(),
+            phase: "planning".to_string(),
+            steps_completed: 0,
+            steps_total: 5,
+            last_action: "init".to_string(),
+            heartbeat_epoch: 1700000000,
+            outcome: Some("success".to_string()),
+        };
+        let json = serde_json::to_string(&p).unwrap();
+        let back: SubordinateProgress = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, p);
+    }
+
+    #[test]
+    fn subordinate_progress_with_outcome() {
+        let p = SubordinateProgress {
+            sub_id: "a".to_string(),
+            phase: "complete".to_string(),
+            steps_completed: 5,
+            steps_total: 5,
+            last_action: "done".to_string(),
+            heartbeat_epoch: 100,
+            outcome: None,
+        };
+        let p2 = p.with_outcome("completed successfully");
+        assert_eq!(p2.outcome, Some("completed successfully".to_string()));
+        assert_eq!(p2.sub_id, "a");
+    }
+
+    #[test]
+    fn subordinate_progress_new() {
+        let p =
+            SubordinateProgress::new("sub-1", SessionPhase::Execution, 2, 10, "compiling").unwrap();
+        assert_eq!(p.sub_id, "sub-1");
+        assert_eq!(p.phase, "execution");
+        assert_eq!(p.steps_completed, 2);
+        assert_eq!(p.steps_total, 10);
+        assert!(p.heartbeat_epoch > 0);
+        assert!(p.outcome.is_none());
+    }
+
+    #[test]
+    fn subordinate_progress_outcome_none_by_default() {
+        let p = SubordinateProgress {
+            sub_id: "x".to_string(),
+            phase: "intake".to_string(),
+            steps_completed: 0,
+            steps_total: 0,
+            last_action: "".to_string(),
+            heartbeat_epoch: 0,
+            outcome: None,
+        };
+        let json = serde_json::to_string(&p).unwrap();
+        assert!(json.contains("\"outcome\":null"));
+    }
+}

--- a/src/base_type_claude_agent_sdk.rs
+++ b/src/base_type_claude_agent_sdk.rs
@@ -20,3 +20,26 @@ pub fn claude_agent_sdk_adapter(id: impl Into<String>) -> SimardResult<PendingSd
         "Claude Agent SDK runtime is not yet implemented",
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn claude_agent_sdk_adapter_creates_successfully() {
+        let adapter = claude_agent_sdk_adapter("claude-sdk").unwrap();
+        assert_eq!(adapter.descriptor.id.as_str(), "claude-sdk");
+    }
+
+    #[test]
+    fn claude_agent_sdk_adapter_has_correct_reason() {
+        let adapter = claude_agent_sdk_adapter("claude-sdk").unwrap();
+        assert!(adapter.not_implemented_reason.contains("Claude Agent SDK"));
+    }
+
+    #[test]
+    fn claude_agent_sdk_adapter_type_alias() {
+        let adapter: ClaudeAgentSdkAdapter = claude_agent_sdk_adapter("claude-test").unwrap();
+        assert_eq!(adapter.descriptor.id.as_str(), "claude-test");
+    }
+}

--- a/src/base_type_ms_agent.rs
+++ b/src/base_type_ms_agent.rs
@@ -20,3 +20,31 @@ pub fn ms_agent_framework_adapter(id: impl Into<String>) -> SimardResult<Pending
         "Microsoft Agent Framework runtime is not yet implemented",
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ms_agent_framework_adapter_creates_successfully() {
+        let adapter = ms_agent_framework_adapter("ms-agent").unwrap();
+        assert_eq!(adapter.descriptor.id.as_str(), "ms-agent");
+    }
+
+    #[test]
+    fn ms_agent_framework_adapter_has_correct_reason() {
+        let adapter = ms_agent_framework_adapter("ms-agent").unwrap();
+        assert!(
+            adapter
+                .not_implemented_reason
+                .contains("Microsoft Agent Framework")
+        );
+    }
+
+    #[test]
+    fn ms_agent_framework_adapter_type_alias() {
+        // Verify the type alias compiles
+        let adapter: MsAgentFrameworkAdapter = ms_agent_framework_adapter("ms-test").unwrap();
+        assert_eq!(adapter.descriptor.id.as_str(), "ms-test");
+    }
+}

--- a/src/base_type_pending_sdk/adapter.rs
+++ b/src/base_type_pending_sdk/adapter.rs
@@ -79,3 +79,75 @@ impl BaseTypeFactory for PendingSdkAdapter {
         }))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::identity::OperatingMode;
+    use uuid::Uuid;
+
+    fn test_request(topology: RuntimeTopology) -> BaseTypeSessionRequest {
+        BaseTypeSessionRequest {
+            session_id: crate::session::SessionId::from_uuid(Uuid::nil()),
+            mode: OperatingMode::Engineer,
+            topology,
+            prompt_assets: vec![],
+            runtime_node: crate::runtime::RuntimeNodeId::new("node"),
+            mailbox_address: crate::runtime::RuntimeAddress::new("addr"),
+        }
+    }
+
+    #[test]
+    fn registered_creates_adapter() {
+        let adapter = PendingSdkAdapter::registered(
+            "test-sdk",
+            "test-backend",
+            "registered-base-type:test",
+            "SDK not yet implemented",
+        )
+        .unwrap();
+        assert_eq!(adapter.descriptor.id.as_str(), "test-sdk");
+        assert_eq!(adapter.not_implemented_reason, "SDK not yet implemented");
+    }
+
+    #[test]
+    fn descriptor_returns_correct_id() {
+        let adapter =
+            PendingSdkAdapter::registered("my-sdk", "backend-id", "registered:my-sdk", "not ready")
+                .unwrap();
+        assert_eq!(adapter.descriptor().id.as_str(), "my-sdk");
+    }
+
+    #[test]
+    fn supports_single_process_topology() {
+        let adapter =
+            PendingSdkAdapter::registered("sdk-1", "backend", "registered:sdk-1", "pending")
+                .unwrap();
+        assert!(
+            adapter
+                .descriptor
+                .supported_topologies
+                .contains(&RuntimeTopology::SingleProcess)
+        );
+    }
+
+    #[test]
+    fn open_session_returns_pending_session() {
+        let adapter =
+            PendingSdkAdapter::registered("sdk-2", "backend", "registered:sdk-2", "not yet")
+                .unwrap();
+        let request = test_request(RuntimeTopology::SingleProcess);
+        let session = adapter.open_session(request);
+        assert!(session.is_ok());
+    }
+
+    #[test]
+    fn open_session_unsupported_topology_returns_error() {
+        let adapter =
+            PendingSdkAdapter::registered("sdk-3", "backend", "registered:sdk-3", "not yet")
+                .unwrap();
+        let request = test_request(RuntimeTopology::Distributed);
+        let result = adapter.open_session(request);
+        assert!(result.is_err());
+    }
+}

--- a/src/base_type_pending_sdk/session.rs
+++ b/src/base_type_pending_sdk/session.rs
@@ -63,3 +63,115 @@ impl BaseTypeSession for PendingSdkSession {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base_type_pending_sdk::PendingSdkAdapter;
+    use crate::base_types::BaseTypeFactory;
+    use crate::identity::OperatingMode;
+    use uuid::Uuid;
+
+    fn make_session() -> PendingSdkSession {
+        let adapter = PendingSdkAdapter::registered(
+            "test-sdk",
+            "backend",
+            "registered:test-sdk",
+            "SDK not ready",
+        )
+        .unwrap();
+        let request = BaseTypeSessionRequest {
+            session_id: crate::session::SessionId::from_uuid(Uuid::nil()),
+            mode: OperatingMode::Engineer,
+            topology: crate::runtime::RuntimeTopology::SingleProcess,
+            prompt_assets: vec![],
+            runtime_node: crate::runtime::RuntimeNodeId::new("n"),
+            mailbox_address: crate::runtime::RuntimeAddress::new("a"),
+        };
+        // We know open_session returns PendingSdkSession boxed — downcast
+        let boxed = adapter.open_session(request).unwrap();
+        // Instead of downcasting, create directly
+        drop(boxed);
+        PendingSdkSession {
+            descriptor: adapter.descriptor.clone(),
+            request: BaseTypeSessionRequest {
+                session_id: crate::session::SessionId::from_uuid(Uuid::nil()),
+                mode: OperatingMode::Engineer,
+                topology: crate::runtime::RuntimeTopology::SingleProcess,
+                prompt_assets: vec![],
+                runtime_node: crate::runtime::RuntimeNodeId::new("n"),
+                mailbox_address: crate::runtime::RuntimeAddress::new("a"),
+            },
+            not_implemented_reason: adapter.not_implemented_reason.clone(),
+            is_open: false,
+            is_closed: false,
+        }
+    }
+
+    #[test]
+    fn session_open_succeeds() {
+        let mut session = make_session();
+        assert!(session.open().is_ok());
+        assert!(session.is_open);
+    }
+
+    #[test]
+    fn session_double_open_fails() {
+        let mut session = make_session();
+        session.open().unwrap();
+        assert!(session.open().is_err());
+    }
+
+    #[test]
+    fn session_run_turn_before_open_fails() {
+        let mut session = make_session();
+        let input = BaseTypeTurnInput::objective_only("test");
+        assert!(session.run_turn(input).is_err());
+    }
+
+    #[test]
+    fn session_run_turn_returns_adapter_error() {
+        let mut session = make_session();
+        session.open().unwrap();
+        let input = BaseTypeTurnInput::objective_only("do something");
+        let result = session.run_turn(input);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("SDK not ready"));
+    }
+
+    #[test]
+    fn session_close_after_open_succeeds() {
+        let mut session = make_session();
+        session.open().unwrap();
+        assert!(session.close().is_ok());
+        assert!(session.is_closed);
+    }
+
+    #[test]
+    fn session_close_before_open_fails() {
+        let mut session = make_session();
+        assert!(session.close().is_err());
+    }
+
+    #[test]
+    fn session_double_close_fails() {
+        let mut session = make_session();
+        session.open().unwrap();
+        session.close().unwrap();
+        assert!(session.close().is_err());
+    }
+
+    #[test]
+    fn session_debug_format() {
+        let session = make_session();
+        let debug = format!("{session:?}");
+        assert!(debug.contains("PendingSdkSession"));
+    }
+
+    #[test]
+    fn session_descriptor_matches() {
+        let session = make_session();
+        assert_eq!(session.descriptor().id.as_str(), "test-sdk");
+    }
+}

--- a/src/cmd_self_update/platform.rs
+++ b/src/cmd_self_update/platform.rs
@@ -19,3 +19,27 @@ pub(crate) fn platform_suffix() -> Option<&'static str> {
         None
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn current_version_is_nonempty() {
+        assert!(!CURRENT_VERSION.is_empty());
+    }
+
+    #[test]
+    fn github_repo_format() {
+        assert!(GITHUB_REPO.contains("rysweet"));
+        assert!(GITHUB_REPO.contains("Simard"));
+    }
+
+    #[test]
+    fn platform_suffix_returns_some() {
+        let suffix = platform_suffix();
+        assert!(suffix.is_some());
+        let s = suffix.unwrap();
+        assert!(s.contains("linux") || s.contains("macos") || s.contains("windows"));
+    }
+}

--- a/src/cmd_self_update/release.rs
+++ b/src/cmd_self_update/release.rs
@@ -64,3 +64,20 @@ pub(crate) fn find_latest_release() -> Result<(String, String), Box<dyn std::err
 
     Err(format!("No release asset found for platform '{suffix}'").into())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn github_repo_constant_is_set() {
+        assert!(!GITHUB_REPO.is_empty());
+        assert!(GITHUB_REPO.contains('/'));
+    }
+
+    #[test]
+    fn platform_suffix_returns_some_on_known_platform() {
+        let suffix = platform_suffix();
+        assert!(suffix.is_some(), "expected a platform suffix on this host");
+    }
+}

--- a/src/cmd_self_update/update.rs
+++ b/src/cmd_self_update/update.rs
@@ -91,3 +91,29 @@ pub fn handle_self_update() -> Result<(), Box<dyn std::error::Error>> {
     // handover does not return on success (exec replaces process)
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn current_version_is_set() {
+        // CURRENT_VERSION comes from Cargo.toml via env!("CARGO_PKG_VERSION")
+        assert!(!CURRENT_VERSION.is_empty());
+    }
+
+    #[test]
+    fn run_self_test_on_nonexistent_binary_returns_error() {
+        let result = run_self_test_on_binary(Path::new("/nonexistent/binary"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn run_self_test_on_binary_with_failing_command() {
+        // /usr/bin/false always exits with 1
+        let result = run_self_test_on_binary(Path::new("/usr/bin/false"));
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("Self-test failed"));
+    }
+}

--- a/src/gym/executor_metrics.rs
+++ b/src/gym/executor_metrics.rs
@@ -91,3 +91,103 @@ pub(super) fn derive_benchmark_metrics(facts: &BenchmarkMetricFacts) -> DerivedB
         }),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn benchmark_metric_facts_default_is_empty() {
+        let facts = BenchmarkMetricFacts::default();
+        assert!(facts.attempts.is_empty());
+        assert!(facts.actions.is_empty());
+    }
+
+    #[test]
+    fn record_primary_attempt() {
+        let mut facts = BenchmarkMetricFacts::default();
+        facts.record_primary_attempt();
+        assert_eq!(facts.attempts.len(), 1);
+        assert_eq!(
+            facts.attempts[0].classification,
+            Some(BenchmarkAttemptClassification::Primary)
+        );
+    }
+
+    #[test]
+    fn record_retry_attempt() {
+        let mut facts = BenchmarkMetricFacts::default();
+        facts.record_retry_attempt();
+        assert_eq!(
+            facts.attempts[0].classification,
+            Some(BenchmarkAttemptClassification::Retry)
+        );
+    }
+
+    #[test]
+    fn record_unmeasured_attempt() {
+        let mut facts = BenchmarkMetricFacts::default();
+        facts.record_unmeasured_attempt();
+        assert_eq!(facts.attempts[0].classification, None);
+    }
+
+    #[test]
+    fn record_required_action() {
+        let mut facts = BenchmarkMetricFacts::default();
+        facts.record_required_action();
+        assert_eq!(
+            facts.actions[0].classification,
+            Some(BenchmarkActionClassification::Required)
+        );
+    }
+
+    #[test]
+    fn record_unnecessary_action() {
+        let mut facts = BenchmarkMetricFacts::default();
+        facts.record_unnecessary_action();
+        assert_eq!(
+            facts.actions[0].classification,
+            Some(BenchmarkActionClassification::Unnecessary)
+        );
+    }
+
+    #[test]
+    fn record_unmeasured_action() {
+        let mut facts = BenchmarkMetricFacts::default();
+        facts.record_unmeasured_action();
+        assert_eq!(facts.actions[0].classification, None);
+    }
+
+    #[test]
+    fn derive_metrics_empty_facts() {
+        let facts = BenchmarkMetricFacts::default();
+        let metrics = derive_benchmark_metrics(&facts);
+        assert_eq!(metrics.unnecessary_action_count, Some(0));
+        assert_eq!(metrics.retry_count, Some(0));
+    }
+
+    #[test]
+    fn derive_metrics_counts_correctly() {
+        let mut facts = BenchmarkMetricFacts::default();
+        facts.record_primary_attempt();
+        facts.record_retry_attempt();
+        facts.record_retry_attempt();
+        facts.record_required_action();
+        facts.record_unnecessary_action();
+        let metrics = derive_benchmark_metrics(&facts);
+        assert_eq!(metrics.retry_count, Some(2));
+        assert_eq!(metrics.unnecessary_action_count, Some(1));
+    }
+
+    #[test]
+    fn derive_metrics_unmeasured_yields_none() {
+        let mut facts = BenchmarkMetricFacts::default();
+        facts.record_primary_attempt();
+        facts.record_unmeasured_attempt();
+        facts.record_required_action();
+        facts.record_unmeasured_action();
+        let metrics = derive_benchmark_metrics(&facts);
+        assert_eq!(metrics.retry_count, None);
+        assert_eq!(metrics.unnecessary_action_count, None);
+    }
+}

--- a/src/identity_precedence/conflict.rs
+++ b/src/identity_precedence/conflict.rs
@@ -47,3 +47,62 @@ impl ConflictLog {
         self.entries.len()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn conflict_log_new_is_empty() {
+        let log = ConflictLog::new();
+        assert!(log.is_empty());
+        assert_eq!(log.len(), 0);
+    }
+
+    #[test]
+    fn conflict_log_default_is_empty() {
+        let log = ConflictLog::default();
+        assert!(log.is_empty());
+    }
+
+    #[test]
+    fn conflict_log_record_adds_entry() {
+        let mut log = ConflictLog::new();
+        log.record("prompt_asset", "sys-prompt", "alpha", "beta");
+        assert_eq!(log.len(), 1);
+        assert!(!log.is_empty());
+        let entry = &log.entries[0];
+        assert_eq!(entry.field, "prompt_asset");
+        assert_eq!(entry.key, "sys-prompt");
+        assert_eq!(entry.winner, "alpha");
+        assert_eq!(entry.loser, "beta");
+    }
+
+    #[test]
+    fn conflict_log_multiple_entries() {
+        let mut log = ConflictLog::new();
+        log.record("base_type", "bt-1", "a", "b");
+        log.record("prompt_asset", "pa-1", "c", "d");
+        assert_eq!(log.len(), 2);
+    }
+
+    #[test]
+    fn conflict_entry_equality() {
+        let e1 = ConflictEntry {
+            field: "f".to_string(),
+            key: "k".to_string(),
+            winner: "w".to_string(),
+            loser: "l".to_string(),
+        };
+        let e2 = e1.clone();
+        assert_eq!(e1, e2);
+    }
+
+    #[test]
+    fn conflict_log_equality() {
+        let mut log1 = ConflictLog::new();
+        log1.record("f", "k", "w", "l");
+        let log2 = log1.clone();
+        assert_eq!(log1, log2);
+    }
+}

--- a/src/improvements/types.rs
+++ b/src/improvements/types.rs
@@ -87,3 +87,105 @@ pub(super) fn fallback_value<'a>(value: &'a str, fallback: &'a str) -> &'a str {
         value
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn persisted_approval_concise_label() {
+        let approval = PersistedImprovementApproval {
+            priority: 1,
+            status: GoalStatus::Active,
+            title: "optimize cache".to_string(),
+        };
+        let label = approval.concise_label();
+        assert_eq!(label, "p1 [active] optimize cache");
+    }
+
+    #[test]
+    fn required_improvement_field_valid() {
+        let result = required_improvement_field("title", "hello");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "hello");
+    }
+
+    #[test]
+    fn required_improvement_field_trims_whitespace() {
+        let result = required_improvement_field("title", "  hello  ");
+        assert_eq!(result.unwrap(), "hello");
+    }
+
+    #[test]
+    fn required_improvement_field_empty_returns_error() {
+        let result = required_improvement_field("title", "");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn required_improvement_field_whitespace_only_returns_error() {
+        let result = required_improvement_field("title", "   ");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn sanitize_directive_value_replaces_newlines() {
+        assert_eq!(sanitize_directive_value("a\nb"), "a b");
+    }
+
+    #[test]
+    fn sanitize_directive_value_replaces_pipes() {
+        assert_eq!(sanitize_directive_value("a|b"), "a/b");
+    }
+
+    #[test]
+    fn sanitize_directive_value_replaces_double_semicolons() {
+        assert_eq!(sanitize_directive_value("a;;b"), "a;b");
+    }
+
+    #[test]
+    fn sanitize_directive_value_trims() {
+        assert_eq!(sanitize_directive_value("  hello  "), "hello");
+    }
+
+    #[test]
+    fn fallback_value_uses_value_when_non_empty() {
+        assert_eq!(fallback_value("hello", "default"), "hello");
+    }
+
+    #[test]
+    fn fallback_value_uses_fallback_when_empty() {
+        assert_eq!(fallback_value("", "default"), "default");
+    }
+
+    #[test]
+    fn fallback_value_uses_fallback_when_whitespace() {
+        assert_eq!(fallback_value("   ", "default"), "default");
+    }
+
+    #[test]
+    fn improvement_directive_construction() {
+        let d = ImprovementDirective {
+            title: "t".to_string(),
+            priority: 3,
+            status: GoalStatus::Proposed,
+            rationale: "r".to_string(),
+        };
+        assert_eq!(d.priority, 3);
+        assert_eq!(d.status, GoalStatus::Proposed);
+    }
+
+    #[test]
+    fn improvement_promotion_plan_construction() {
+        let plan = ImprovementPromotionPlan {
+            review_id: "r1".to_string(),
+            review_target: "target".to_string(),
+            proposals: vec![],
+            approvals: vec![],
+            deferrals: vec![],
+        };
+        assert!(plan.proposals.is_empty());
+        assert!(plan.approvals.is_empty());
+        assert!(plan.deferrals.is_empty());
+    }
+}

--- a/src/meeting_repl/persist.rs
+++ b/src/meeting_repl/persist.rs
@@ -90,3 +90,65 @@ pub(super) fn persist_meeting_to_memory<W: Write>(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::meeting_facilitator::{
+        ActionItem, MeetingDecision, MeetingSession, MeetingSessionStatus,
+    };
+
+    fn sample_empty_session() -> MeetingSession {
+        MeetingSession {
+            topic: "test topic".to_string(),
+            decisions: vec![],
+            action_items: vec![],
+            notes: vec![],
+            status: MeetingSessionStatus::Closed,
+            started_at: "2024-01-01T00:00:00Z".to_string(),
+            participants: vec!["alice".to_string()],
+            explicit_questions: vec![],
+        }
+    }
+
+    fn sample_session_with_data() -> MeetingSession {
+        MeetingSession {
+            topic: "architecture review".to_string(),
+            decisions: vec![MeetingDecision {
+                description: "use microservices".to_string(),
+                rationale: "scalability".to_string(),
+                participants: vec!["alice".to_string()],
+            }],
+            action_items: vec![ActionItem {
+                description: "create RFC".to_string(),
+                owner: "bob".to_string(),
+                priority: 1,
+                due_description: None,
+            }],
+            notes: vec!["discussed trade-offs".to_string()],
+            status: MeetingSessionStatus::Closed,
+            started_at: "2024-01-01T00:00:00Z".to_string(),
+            participants: vec!["alice".to_string(), "bob".to_string()],
+            explicit_questions: vec![],
+        }
+    }
+
+    #[test]
+    fn write_meeting_handoff_artifact_empty_session() {
+        let session = sample_empty_session();
+        let mut output = Vec::new();
+        write_meeting_handoff_artifact(&session, &mut output);
+        let text = String::from_utf8(output).unwrap();
+        // Should produce output (success or warn message)
+        assert!(!text.is_empty());
+    }
+
+    #[test]
+    fn write_meeting_handoff_artifact_with_data() {
+        let session = sample_session_with_data();
+        let mut output = Vec::new();
+        write_meeting_handoff_artifact(&session, &mut output);
+        let text = String::from_utf8(output).unwrap();
+        assert!(!text.is_empty());
+    }
+}

--- a/src/memory/store.rs
+++ b/src/memory/store.rs
@@ -43,3 +43,71 @@ pub trait MemoryStore: Send + Sync {
         0
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metadata::Provenance;
+
+    // A minimal MemoryStore implementation for testing default methods.
+    struct StubStore;
+
+    impl MemoryStore for StubStore {
+        fn descriptor(&self) -> BackendDescriptor {
+            BackendDescriptor::new(
+                "stub",
+                Provenance::builtin("test"),
+                crate::metadata::Freshness::now().unwrap(),
+            )
+        }
+
+        fn put(&self, _record: MemoryRecord) -> SimardResult<()> {
+            Ok(())
+        }
+
+        fn list(&self, _scope: MemoryScope) -> SimardResult<Vec<MemoryRecord>> {
+            Ok(vec![])
+        }
+
+        fn list_for_session(&self, _id: &SessionId) -> SimardResult<Vec<MemoryRecord>> {
+            Ok(vec![])
+        }
+
+        fn count_for_session(&self, _id: &SessionId) -> SimardResult<usize> {
+            Ok(0)
+        }
+
+        fn list_all(&self) -> SimardResult<Vec<MemoryRecord>> {
+            Ok(vec![])
+        }
+
+        fn list_by_time_range(
+            &self,
+            _start: DateTime<Utc>,
+            _end: DateTime<Utc>,
+        ) -> SimardResult<Vec<MemoryRecord>> {
+            Ok(vec![])
+        }
+    }
+
+    #[test]
+    fn flush_pending_default_returns_zero() {
+        let store = StubStore;
+        assert_eq!(store.flush_pending(), 0);
+    }
+
+    #[test]
+    fn list_by_scope_across_sessions_delegates_to_list() {
+        let store = StubStore;
+        let result = store
+            .list_by_scope_across_sessions(MemoryScope::Project)
+            .unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn stub_store_descriptor_identity() {
+        let store = StubStore;
+        assert_eq!(store.descriptor().identity, "stub");
+    }
+}

--- a/src/memory/types.rs
+++ b/src/memory/types.rs
@@ -30,3 +30,69 @@ pub struct MemoryRecord {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub created_at: Option<DateTime<Utc>>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uuid::Uuid;
+
+    fn test_session_id() -> SessionId {
+        SessionId::from_uuid(Uuid::nil())
+    }
+
+    #[test]
+    fn memory_scope_serde_roundtrip() {
+        for scope in [
+            MemoryScope::SessionScratch,
+            MemoryScope::SessionSummary,
+            MemoryScope::Decision,
+            MemoryScope::Project,
+            MemoryScope::Benchmark,
+            MemoryScope::Untagged,
+        ] {
+            let json = serde_json::to_string(&scope).unwrap();
+            let back: MemoryScope = serde_json::from_str(&json).unwrap();
+            assert_eq!(back, scope);
+        }
+    }
+
+    #[test]
+    fn memory_scope_kebab_case() {
+        let json = serde_json::to_string(&MemoryScope::SessionScratch).unwrap();
+        assert_eq!(json, "\"session-scratch\"");
+    }
+
+    #[test]
+    fn memory_record_serde_roundtrip() {
+        let record = MemoryRecord {
+            key: "k1".to_string(),
+            scope: MemoryScope::Decision,
+            value: "v1".to_string(),
+            session_id: test_session_id(),
+            recorded_in: SessionPhase::Execution,
+            created_at: None,
+        };
+        let json = serde_json::to_string(&record).unwrap();
+        let back: MemoryRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, record);
+    }
+
+    #[test]
+    fn memory_record_created_at_skipped_when_none() {
+        let record = MemoryRecord {
+            key: "k".to_string(),
+            scope: MemoryScope::Project,
+            value: "v".to_string(),
+            session_id: test_session_id(),
+            recorded_in: SessionPhase::Reflection,
+            created_at: None,
+        };
+        let json = serde_json::to_string(&record).unwrap();
+        assert!(!json.contains("created_at"));
+    }
+
+    #[test]
+    fn memory_store_name_constant() {
+        assert_eq!(MEMORY_STORE_NAME, "memory");
+    }
+}

--- a/src/ooda_scheduler/types.rs
+++ b/src/ooda_scheduler/types.rs
@@ -61,3 +61,91 @@ pub struct ScheduledAction {
     pub goal_id: String,
     pub action: PlannedAction,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ooda_loop::ActionKind;
+
+    fn sample_action() -> PlannedAction {
+        PlannedAction {
+            kind: ActionKind::AdvanceGoal,
+            goal_id: Some("g1".to_string()),
+            description: "advance goal".to_string(),
+        }
+    }
+
+    fn sample_outcome(success: bool) -> ActionOutcome {
+        ActionOutcome {
+            action: sample_action(),
+            success,
+            detail: "detail".to_string(),
+        }
+    }
+
+    #[test]
+    fn slot_status_display_pending() {
+        assert_eq!(format!("{}", SlotStatus::Pending), "pending");
+    }
+
+    #[test]
+    fn slot_status_display_running() {
+        let s = SlotStatus::Running { started_at: 12345 };
+        assert_eq!(format!("{s}"), "running(since=12345)");
+    }
+
+    #[test]
+    fn slot_status_display_completed() {
+        let s = SlotStatus::Completed(sample_outcome(true));
+        let d = format!("{s}");
+        assert!(d.contains("completed(success=true)"));
+    }
+
+    #[test]
+    fn slot_status_display_failed() {
+        let s = SlotStatus::Failed("timeout".to_string());
+        assert_eq!(format!("{s}"), "failed(timeout)");
+    }
+
+    #[test]
+    fn scheduler_slot_construction() {
+        let slot = SchedulerSlot {
+            slot_id: 0,
+            goal_id: "g1".to_string(),
+            action: sample_action(),
+            status: SlotStatus::Pending,
+        };
+        assert_eq!(slot.slot_id, 0);
+        assert_eq!(slot.goal_id, "g1");
+    }
+
+    #[test]
+    fn completed_slot_construction() {
+        let cs = CompletedSlot {
+            slot_id: 1,
+            goal_id: "g2".to_string(),
+            outcome: Ok(sample_outcome(true)),
+        };
+        assert!(cs.outcome.is_ok());
+    }
+
+    #[test]
+    fn completed_slot_with_error() {
+        let cs = CompletedSlot {
+            slot_id: 2,
+            goal_id: "g3".to_string(),
+            outcome: Err("boom".to_string()),
+        };
+        assert!(cs.outcome.is_err());
+    }
+
+    #[test]
+    fn scheduled_action_construction() {
+        let sa = ScheduledAction {
+            slot_id: 3,
+            goal_id: "g4".to_string(),
+            action: sample_action(),
+        };
+        assert_eq!(sa.slot_id, 3);
+    }
+}

--- a/src/operator_cli/dashboard.rs
+++ b/src/operator_cli/dashboard.rs
@@ -23,3 +23,50 @@ pub fn dispatch_dashboard_command(
         other => Err(format!("unsupported command 'dashboard {other}'").into()),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_subcommand_returns_error() {
+        let args = Vec::<String>::new().into_iter();
+        let result = dispatch_dashboard_command(args);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("expected"));
+    }
+
+    #[test]
+    fn unsupported_subcommand_returns_error() {
+        let args = vec!["unknown".to_string()].into_iter();
+        let result = dispatch_dashboard_command(args);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("unsupported command")
+        );
+    }
+
+    #[test]
+    fn serve_invalid_port_returns_error() {
+        let args = vec!["serve".to_string(), "--port=abc".to_string()].into_iter();
+        let result = dispatch_dashboard_command(args);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("invalid --port"));
+    }
+
+    #[test]
+    fn serve_unexpected_arg_returns_error() {
+        let args = vec!["serve".to_string(), "--foo".to_string()].into_iter();
+        let result = dispatch_dashboard_command(args);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("unexpected argument")
+        );
+    }
+}

--- a/src/operator_commands_ooda/persistence.rs
+++ b/src/operator_commands_ooda/persistence.rs
@@ -43,3 +43,85 @@ pub(super) fn persist_cycle_to_memory(
         eprintln!("[simard] OODA persist: failed to store episode: {e}");
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::goal_curation::GoalProgress;
+    use crate::memory_cognitive::CognitiveStatistics;
+    use crate::ooda_loop::{
+        ActionKind, ActionOutcome, CycleReport, EnvironmentSnapshot, GoalSnapshot, Observation,
+        PlannedAction, Priority,
+    };
+
+    fn minimal_report(cycle: u32) -> CycleReport {
+        CycleReport {
+            cycle_number: cycle,
+            observation: Observation {
+                goal_statuses: vec![GoalSnapshot {
+                    id: "g1".to_string(),
+                    description: "test goal".to_string(),
+                    progress: GoalProgress::NotStarted,
+                }],
+                gym_health: None,
+                memory_stats: CognitiveStatistics {
+                    sensory_count: 0,
+                    working_count: 0,
+                    episodic_count: 0,
+                    semantic_count: 0,
+                    procedural_count: 0,
+                    prospective_count: 0,
+                },
+                pending_improvements: vec![],
+                environment: EnvironmentSnapshot::default(),
+            },
+            priorities: vec![Priority {
+                goal_id: "g1".to_string(),
+                urgency: 0.8,
+                reason: "important".to_string(),
+            }],
+            planned_actions: vec![PlannedAction {
+                kind: ActionKind::AdvanceGoal,
+                goal_id: Some("g1".to_string()),
+                description: "advance".to_string(),
+            }],
+            outcomes: vec![ActionOutcome {
+                action: PlannedAction {
+                    kind: ActionKind::AdvanceGoal,
+                    goal_id: Some("g1".to_string()),
+                    description: "advance".to_string(),
+                },
+                success: true,
+                detail: "done".to_string(),
+            }],
+        }
+    }
+
+    #[test]
+    fn persist_cycle_report_creates_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let report = minimal_report(42);
+        persist_cycle_report(dir.path(), &report);
+        let path = dir.path().join("cycle_reports").join("cycle_42.json");
+        assert!(path.exists());
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(!content.is_empty());
+    }
+
+    #[test]
+    fn persist_cycle_report_creates_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let report = minimal_report(1);
+        persist_cycle_report(dir.path(), &report);
+        assert!(dir.path().join("cycle_reports").is_dir());
+    }
+
+    #[test]
+    fn persist_cycle_report_multiple_cycles() {
+        let dir = tempfile::tempdir().unwrap();
+        persist_cycle_report(dir.path(), &minimal_report(1));
+        persist_cycle_report(dir.path(), &minimal_report(2));
+        assert!(dir.path().join("cycle_reports/cycle_1.json").exists());
+        assert!(dir.path().join("cycle_reports/cycle_2.json").exists());
+    }
+}

--- a/src/reflection.rs
+++ b/src/reflection.rs
@@ -46,3 +46,82 @@ pub struct ReflectionReport {
 pub trait ReflectiveRuntime {
     fn snapshot(&self) -> SimardResult<ReflectionSnapshot>;
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metadata::{Freshness, Provenance};
+
+    fn test_backend() -> BackendDescriptor {
+        BackendDescriptor::new(
+            "test-backend",
+            Provenance::builtin("test"),
+            Freshness::now().unwrap(),
+        )
+    }
+
+    fn test_snapshot() -> ReflectionSnapshot {
+        ReflectionSnapshot {
+            identity_name: "test-id".to_string(),
+            identity_components: vec!["c1".to_string()],
+            selected_base_type: BaseTypeId::new("bt"),
+            topology: RuntimeTopology::SingleProcess,
+            runtime_state: RuntimeState::Active,
+            runtime_node: RuntimeNodeId::new("node-1"),
+            mailbox_address: RuntimeAddress::new("addr-1"),
+            session_phase: Some(SessionPhase::Execution),
+            prompt_assets: vec![],
+            manifest_contract: ManifestContract::new(
+                "module::entry",
+                "a -> b",
+                vec!["layer:core".to_string()],
+                Provenance::builtin("test"),
+                Freshness::now().unwrap(),
+            )
+            .unwrap(),
+            evidence_records: 5,
+            memory_records: 10,
+            active_goal_count: 2,
+            active_goals: vec!["g1".to_string()],
+            proposed_goal_count: 1,
+            proposed_goals: vec!["g2".to_string()],
+            agent_program_backend: test_backend(),
+            handoff_backend: test_backend(),
+            adapter_backend: test_backend(),
+            adapter_capabilities: vec!["cap1".to_string()],
+            adapter_supported_topologies: vec!["single".to_string()],
+            topology_backend: test_backend(),
+            transport_backend: test_backend(),
+            supervisor_backend: test_backend(),
+            memory_backend: test_backend(),
+            evidence_backend: test_backend(),
+            goal_backend: test_backend(),
+        }
+    }
+
+    #[test]
+    fn reflection_snapshot_construction() {
+        let snap = test_snapshot();
+        assert_eq!(snap.identity_name, "test-id");
+        assert_eq!(snap.evidence_records, 5);
+        assert_eq!(snap.memory_records, 10);
+        assert_eq!(snap.active_goal_count, 2);
+    }
+
+    #[test]
+    fn reflection_report_construction() {
+        let report = ReflectionReport {
+            summary: "all good".to_string(),
+            snapshot: test_snapshot(),
+        };
+        assert_eq!(report.summary, "all good");
+        assert_eq!(report.snapshot.identity_name, "test-id");
+    }
+
+    #[test]
+    fn reflection_snapshot_equality() {
+        let a = test_snapshot();
+        let b = a.clone();
+        assert_eq!(a, b);
+    }
+}

--- a/src/research_tracker/watches.rs
+++ b/src/research_tracker/watches.rs
@@ -61,3 +61,45 @@ pub fn seed_developer_watches(bridge: &CognitiveMemoryBridge) -> usize {
     }
     seeded
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_developer_watches_count() {
+        let watches = default_developer_watches();
+        assert_eq!(watches.len(), DEFAULT_DEVELOPER_WATCHES.len());
+    }
+
+    #[test]
+    fn default_developer_watches_have_nonempty_fields() {
+        for watch in default_developer_watches() {
+            assert!(!watch.github_id.is_empty());
+            assert!(!watch.focus_areas.is_empty());
+            assert!(watch.last_checked.is_none());
+        }
+    }
+
+    #[test]
+    fn default_developer_watches_contains_known_ids() {
+        let watches = default_developer_watches();
+        let ids: Vec<_> = watches.iter().map(|w| w.github_id.as_str()).collect();
+        assert!(ids.contains(&"ramparte"));
+        assert!(ids.contains(&"simonw"));
+    }
+
+    #[test]
+    fn default_developer_watches_constant_length() {
+        assert_eq!(DEFAULT_DEVELOPER_WATCHES.len(), 5);
+    }
+
+    #[test]
+    fn default_watches_focus_areas_are_nonempty_strings() {
+        for (_, areas) in &DEFAULT_DEVELOPER_WATCHES {
+            for area in *areas {
+                assert!(!area.is_empty());
+            }
+        }
+    }
+}

--- a/src/review/types.rs
+++ b/src/review/types.rs
@@ -88,3 +88,145 @@ impl ReviewArtifact {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_evidence_summary() -> ReviewEvidenceSummary {
+        ReviewEvidenceSummary {
+            memory_records: 10,
+            evidence_records: 5,
+            decision_records: 2,
+            benchmark_records: 3,
+            exported_state: "ready".to_string(),
+            session_phase: Some("execution".to_string()),
+            failed_signals: vec!["signal-a".to_string()],
+        }
+    }
+
+    #[test]
+    fn review_target_kind_as_str() {
+        assert_eq!(ReviewTargetKind::Session.as_str(), "session");
+        assert_eq!(ReviewTargetKind::Benchmark.as_str(), "benchmark");
+    }
+
+    #[test]
+    fn review_target_kind_serde_roundtrip() {
+        let kind = ReviewTargetKind::Benchmark;
+        let json = serde_json::to_string(&kind).unwrap();
+        assert_eq!(json, "\"benchmark\"");
+        let back: ReviewTargetKind = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, kind);
+    }
+
+    #[test]
+    fn review_target_kind_kebab_case_session() {
+        let json = "\"session\"";
+        let kind: ReviewTargetKind = serde_json::from_str(json).unwrap();
+        assert_eq!(kind, ReviewTargetKind::Session);
+    }
+
+    #[test]
+    fn review_signal_serde_roundtrip() {
+        let signal = ReviewSignal {
+            id: "sig-1".to_string(),
+            passed: true,
+            detail: "all good".to_string(),
+        };
+        let json = serde_json::to_string(&signal).unwrap();
+        let back: ReviewSignal = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, signal);
+    }
+
+    #[test]
+    fn improvement_proposal_serde_roundtrip() {
+        let proposal = ImprovementProposal {
+            category: "perf".to_string(),
+            title: "cache lookups".to_string(),
+            rationale: "reduce latency".to_string(),
+            suggested_change: "add LRU cache".to_string(),
+            evidence: vec!["bench-1".to_string()],
+        };
+        let json = serde_json::to_string(&proposal).unwrap();
+        let back: ImprovementProposal = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, proposal);
+    }
+
+    #[test]
+    fn review_evidence_summary_serde_roundtrip() {
+        let summary = sample_evidence_summary();
+        let json = serde_json::to_string(&summary).unwrap();
+        let back: ReviewEvidenceSummary = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, summary);
+    }
+
+    #[test]
+    fn review_artifact_concise_record_no_proposals() {
+        let artifact = ReviewArtifact {
+            review_id: "r1".to_string(),
+            reviewed_at_unix_ms: 1000,
+            target_kind: ReviewTargetKind::Session,
+            target_label: "sess-1".to_string(),
+            identity_name: "id-1".to_string(),
+            session_id: "s-1".to_string(),
+            selected_base_type: "bt".to_string(),
+            topology: "single".to_string(),
+            objective_metadata: "obj".to_string(),
+            execution_summary: "exec".to_string(),
+            reflection_summary: "reflect".to_string(),
+            summary: "sum".to_string(),
+            measurement_notes: vec![],
+            evidence_summary: sample_evidence_summary(),
+            proposals: vec![],
+        };
+        let record = artifact.concise_record();
+        assert!(record.contains("target=sess-1"));
+        assert!(record.contains("evidence_records=5"));
+        assert!(record.contains("failed_signals=1"));
+        assert!(record.contains("proposals=[]"));
+    }
+
+    #[test]
+    fn review_artifact_concise_record_with_proposals() {
+        let artifact = ReviewArtifact {
+            review_id: "r2".to_string(),
+            reviewed_at_unix_ms: 2000,
+            target_kind: ReviewTargetKind::Benchmark,
+            target_label: "bench-1".to_string(),
+            identity_name: "id-2".to_string(),
+            session_id: "s-2".to_string(),
+            selected_base_type: "bt".to_string(),
+            topology: "single".to_string(),
+            objective_metadata: "obj".to_string(),
+            execution_summary: "exec".to_string(),
+            reflection_summary: "reflect".to_string(),
+            summary: "sum".to_string(),
+            measurement_notes: vec![],
+            evidence_summary: sample_evidence_summary(),
+            proposals: vec![ImprovementProposal {
+                category: "perf".to_string(),
+                title: "optimize".to_string(),
+                rationale: "faster".to_string(),
+                suggested_change: "add cache".to_string(),
+                evidence: vec![],
+            }],
+        };
+        let record = artifact.concise_record();
+        assert!(record.contains("optimize: add cache"));
+    }
+
+    #[test]
+    fn review_request_construction() {
+        let req = ReviewRequest {
+            target_kind: ReviewTargetKind::Session,
+            target_label: "sess".to_string(),
+            execution_summary: "exec".to_string(),
+            reflection_summary: "reflect".to_string(),
+            measurement_notes: vec!["note".to_string()],
+            signals: vec![],
+        };
+        assert_eq!(req.target_kind, ReviewTargetKind::Session);
+        assert!(req.signals.is_empty());
+    }
+}

--- a/src/self_improve_executor/types.rs
+++ b/src/self_improve_executor/types.rs
@@ -78,3 +78,118 @@ impl std::fmt::Display for ApplyResult {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_finding(severity: Severity) -> ReviewFinding {
+        ReviewFinding {
+            category: crate::review_pipeline::FindingCategory::Bug,
+            severity,
+            description: "test".to_string(),
+            file_path: "test.rs".to_string(),
+            line_range: None,
+        }
+    }
+
+    #[test]
+    fn apply_result_applied_is_applied() {
+        let r = ApplyResult::Applied { findings: vec![] };
+        assert!(r.is_applied());
+    }
+
+    #[test]
+    fn apply_result_review_blocked_not_applied() {
+        let r = ApplyResult::ReviewBlocked { findings: vec![] };
+        assert!(!r.is_applied());
+    }
+
+    #[test]
+    fn apply_result_plan_failed_not_applied() {
+        let r = ApplyResult::PlanFailed {
+            reason: "err".to_string(),
+        };
+        assert!(!r.is_applied());
+    }
+
+    #[test]
+    fn apply_result_commit_failed_not_applied() {
+        let r = ApplyResult::CommitFailed {
+            reason: "err".to_string(),
+            findings: vec![],
+        };
+        assert!(!r.is_applied());
+    }
+
+    #[test]
+    fn has_critical_true_when_critical_finding() {
+        let r = ApplyResult::Applied {
+            findings: vec![make_finding(Severity::Critical)],
+        };
+        assert!(r.has_critical());
+    }
+
+    #[test]
+    fn has_critical_false_when_no_critical() {
+        let r = ApplyResult::Applied {
+            findings: vec![make_finding(Severity::Low)],
+        };
+        assert!(!r.has_critical());
+    }
+
+    #[test]
+    fn has_critical_false_for_plan_failed() {
+        let r = ApplyResult::PlanFailed {
+            reason: "err".to_string(),
+        };
+        assert!(!r.has_critical());
+    }
+
+    #[test]
+    fn findings_empty_for_plan_failed() {
+        let r = ApplyResult::PlanFailed {
+            reason: "err".to_string(),
+        };
+        assert!(r.findings().is_empty());
+    }
+
+    #[test]
+    fn findings_returns_findings_for_applied() {
+        let r = ApplyResult::Applied {
+            findings: vec![make_finding(Severity::High)],
+        };
+        assert_eq!(r.findings().len(), 1);
+    }
+
+    #[test]
+    fn display_applied() {
+        let r = ApplyResult::Applied {
+            findings: vec![make_finding(Severity::Low), make_finding(Severity::Medium)],
+        };
+        assert_eq!(format!("{r}"), "applied (2 findings)");
+    }
+
+    #[test]
+    fn display_review_blocked() {
+        let r = ApplyResult::ReviewBlocked { findings: vec![] };
+        assert_eq!(format!("{r}"), "review-blocked (0 findings)");
+    }
+
+    #[test]
+    fn display_plan_failed() {
+        let r = ApplyResult::PlanFailed {
+            reason: "oops".to_string(),
+        };
+        assert_eq!(format!("{r}"), "plan-failed: oops");
+    }
+
+    #[test]
+    fn display_commit_failed() {
+        let r = ApplyResult::CommitFailed {
+            reason: "git err".to_string(),
+            findings: vec![make_finding(Severity::Low)],
+        };
+        assert_eq!(format!("{r}"), "commit-failed: git err (1 findings)");
+    }
+}

--- a/src/terminal_engineer_bridge/types.rs
+++ b/src/terminal_engineer_bridge/types.rs
@@ -38,3 +38,53 @@ pub struct TerminalBridgeContext {
     pub wait_count: String,
     pub last_output_line: Option<String>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scoped_handoff_mode_terminal_file_name() {
+        assert_eq!(
+            ScopedHandoffMode::Terminal.scoped_file_name(),
+            TERMINAL_HANDOFF_FILE_NAME
+        );
+    }
+
+    #[test]
+    fn scoped_handoff_mode_engineer_file_name() {
+        assert_eq!(
+            ScopedHandoffMode::Engineer.scoped_file_name(),
+            ENGINEER_HANDOFF_FILE_NAME
+        );
+    }
+
+    #[test]
+    fn constants_are_distinct() {
+        assert_ne!(TERMINAL_HANDOFF_FILE_NAME, ENGINEER_HANDOFF_FILE_NAME);
+        assert_ne!(TERMINAL_MODE_BOUNDARY, ENGINEER_MODE_BOUNDARY);
+    }
+
+    #[test]
+    fn selected_handoff_artifact_construction() {
+        let a = SelectedHandoffArtifact {
+            path: PathBuf::from("/state/handoff.json"),
+            file_name: COMPATIBILITY_HANDOFF_FILE_NAME,
+        };
+        assert_eq!(a.file_name, "latest_handoff.json");
+    }
+
+    #[test]
+    fn terminal_bridge_context_construction() {
+        let ctx = TerminalBridgeContext {
+            continuity_source: "src".to_string(),
+            handoff_file_name: "f.json".to_string(),
+            working_directory: "/home".to_string(),
+            command_count: "5".to_string(),
+            wait_count: "2".to_string(),
+            last_output_line: Some("done".to_string()),
+        };
+        assert_eq!(ctx.command_count, "5");
+        assert_eq!(ctx.last_output_line, Some("done".to_string()));
+    }
+}

--- a/src/terminal_session/types.rs
+++ b/src/terminal_session/types.rs
@@ -32,3 +32,52 @@ pub(crate) struct TerminalSessionCapture {
     pub transcript: String,
     pub exit_status: ExitStatus,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_shell_constant() {
+        assert_eq!(DEFAULT_SHELL, "/usr/bin/bash");
+    }
+
+    #[test]
+    fn pty_launcher_constant() {
+        assert_eq!(PTY_LAUNCHER, "script");
+    }
+
+    #[test]
+    fn wait_step_timeout_is_five_seconds() {
+        assert_eq!(WAIT_STEP_TIMEOUT, Duration::from_secs(5));
+    }
+
+    #[test]
+    fn terminal_step_input_equality() {
+        let a = TerminalStep::Input("ls".to_string());
+        let b = TerminalStep::Input("ls".to_string());
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn terminal_step_wait_for_equality() {
+        let a = TerminalStep::WaitFor("$".to_string());
+        let b = TerminalStep::WaitFor("$".to_string());
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn terminal_turn_spec_construction() {
+        let spec = TerminalTurnSpec {
+            shell: DEFAULT_SHELL.to_string(),
+            working_directory: Some(PathBuf::from("/home")),
+            wait_timeout: WAIT_STEP_TIMEOUT,
+            steps: vec![
+                TerminalStep::Input("echo hello".to_string()),
+                TerminalStep::WaitFor("hello".to_string()),
+            ],
+        };
+        assert_eq!(spec.steps.len(), 2);
+        assert_eq!(spec.wait_timeout, Duration::from_secs(5));
+    }
+}


### PR DESCRIPTION
## Summary
Adds **129 new unit tests** across the final 23 previously untested modules (~1,535 lines). After this merge, **every source module in the codebase has tests** — 100% file coverage.

## Distributed build 🎉
Generated and validated on the **azlin VM** (simard-worker, 128.251.14.62), continuing the distributed Simard multi-VM operation pattern from round 9.

## Modules covered (all 23 remaining)
| Module | Tests | Key coverage |
|--------|-------|-------------|
| `review/types.rs` | 9 | Serde roundtrips, concise_record |
| `self_improve_executor/types.rs` | 13 | ApplyResult variants, Display, has_critical |
| `improvements/types.rs` | 14 | Validation, sanitization, fallback_value |
| `base_type_pending_sdk/session.rs` | 9 | Open/close lifecycle, run_turn error |
| `gym/executor_metrics.rs` | 10 | Record methods, derive metrics |
| `ooda_scheduler/types.rs` | 8 | SlotStatus Display, slot construction |
| `base_type_pending_sdk/adapter.rs` | 5 | Registration, topology, session creation |
| `agent_goal_assignment/types.rs` | 5 | Serde, Display, with_outcome |
| `identity_precedence/conflict.rs` | 6 | ConflictLog CRUD, equality |
| `memory/store.rs` | 3 | Trait defaults |
| `memory/types.rs` | 5 | MemoryScope serde, MemoryRecord roundtrip |
| `reflection.rs` | 3 | Snapshot/report construction |
| `terminal_engineer_bridge/types.rs` | 5 | Constants, handoff mode |
| `terminal_session/types.rs` | 6 | Constants, step equality |
| `research_tracker/watches.rs` | 5 | Default watches, known IDs |
| `operator_commands_ooda/persistence.rs` | 3 | Cycle report persistence |
| `meeting_repl/persist.rs` | 2 | Handoff artifact writing |
| `operator_cli/dashboard.rs` | 4 | Arg parsing errors |
| `cmd_self_update/update.rs` | 3 | Version, binary handling |
| `cmd_self_update/release.rs` | 2 | Constants validation |
| `base_type_ms_agent.rs` | 3 | Adapter creation |
| `base_type_claude_agent_sdk.rs` | 3 | Adapter creation |
| `cmd_self_update/platform.rs` | 3 | Platform suffix detection |

## Coverage journey
| Round | PR | Lines | Tests | Status |
|-------|-----|-------|-------|--------|
| 5 | #294 | ~1,740 | ~100 | ✅ Merged |
| 6 | #321 | ~1,567 | ~100 | ✅ Merged |
| 7 | #338 | ~1,446 | 118 | ✅ Merged |
| 8 | #341 | ~1,180 | 91 | ✅ Merged |
| 9 | #346 | ~1,503 | 123 | 🔄 CI |
| **10** | **this** | **~1,535** | **129** | 🔄 CI |
| **Total** | | **~8,971** | **~661** | |

Closes #347