### PR TITLE
fix: spawn topology bug + add ensure-deps auto-installer

### DIFF
--- a/src/agent_supervisor/lifecycle.rs
+++ b/src/agent_supervisor/lifecycle.rs
@@ -31,7 +31,7 @@ pub fn spawn_subordinate(config: &SubordinateConfig) -> SimardResult<Subordinate
     let child = Command::new(&exe)
         .arg("engineer")
         .arg("run")
-        .arg("local")
+        .arg("single-process")
         .arg(&config.worktree_path)
         .arg(&config.goal)
         .env("SIMARD_AGENT_NAME", &config.agent_name)

--- a/src/cmd_ensure_deps.rs
+++ b/src/cmd_ensure_deps.rs
@@ -1,0 +1,277 @@
+//! Dependency auto-installer: ensures all Simard runtime dependencies are present.
+//!
+//! Checks for required tools (python3, gh, amplihack, git), Python packages
+//! (kuzu, amplihack-memory), and the amplihack-memory-lib source tree. Installs
+//! or clones anything missing so Simard can operate without pre-existing setup.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Summary of a single dependency check.
+struct DepCheck {
+    name: &'static str,
+    status: DepStatus,
+}
+
+enum DepStatus {
+    Ok(String),
+    Missing(String),
+    Installed(String),
+    Failed(String),
+}
+
+/// Run all dependency checks and install anything missing.
+pub fn handle_ensure_deps() -> Result<(), Box<dyn std::error::Error>> {
+    println!("simard ensure-deps: checking runtime dependencies\n");
+
+    let results = vec![
+        check_binary("git", &["--version"]),
+        check_binary("python3", &["--version"]),
+        check_binary("gh", &["--version"]),
+        check_amplihack(),
+        ensure_python_package("kuzu"),
+        ensure_memory_lib(),
+    ];
+
+    println!();
+    let mut failed = 0;
+    for dep in &results {
+        let (icon, detail) = match &dep.status {
+            DepStatus::Ok(msg) => ("✓", msg.as_str()),
+            DepStatus::Installed(msg) => ("⟳", msg.as_str()),
+            DepStatus::Missing(msg) => {
+                failed += 1;
+                ("✗", msg.as_str())
+            }
+            DepStatus::Failed(msg) => {
+                failed += 1;
+                ("✗", msg.as_str())
+            }
+        };
+        println!("  {icon} {}: {detail}", dep.name);
+    }
+
+    println!();
+    if failed > 0 {
+        Err(format!("{failed} dependency check(s) failed").into())
+    } else {
+        println!("All dependencies satisfied.");
+        Ok(())
+    }
+}
+
+fn check_binary(name: &'static str, version_args: &[&str]) -> DepCheck {
+    match Command::new(name).args(version_args).output() {
+        Ok(output) if output.status.success() => {
+            let ver = String::from_utf8_lossy(&output.stdout)
+                .trim()
+                .lines()
+                .next()
+                .unwrap_or("ok")
+                .to_string();
+            DepCheck {
+                name,
+                status: DepStatus::Ok(ver),
+            }
+        }
+        Ok(_) => DepCheck {
+            name,
+            status: DepStatus::Missing(format!("{name} found but returned error")),
+        },
+        Err(_) => DepCheck {
+            name,
+            status: DepStatus::Missing(format!("{name} not found in PATH")),
+        },
+    }
+}
+
+fn check_amplihack() -> DepCheck {
+    if let Ok(output) = Command::new("amplihack").arg("--version").output()
+        && output.status.success()
+    {
+        let ver = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        return DepCheck {
+            name: "amplihack",
+            status: DepStatus::Ok(ver),
+        };
+    }
+
+    // Try installing via cargo
+    println!("  installing amplihack via cargo...");
+    match Command::new("cargo")
+        .args(["install", "amplihack"])
+        .output()
+    {
+        Ok(output) if output.status.success() => DepCheck {
+            name: "amplihack",
+            status: DepStatus::Installed("installed via cargo".into()),
+        },
+        _ => DepCheck {
+            name: "amplihack",
+            status: DepStatus::Missing("not found; cargo install amplihack failed".into()),
+        },
+    }
+}
+
+fn ensure_python_package(package: &'static str) -> DepCheck {
+    // Check if importable
+    let check = Command::new("python3")
+        .args(["-c", &format!("import {package}")])
+        .output();
+
+    if let Ok(output) = &check
+        && output.status.success()
+    {
+        return DepCheck {
+            name: package,
+            status: DepStatus::Ok("importable".into()),
+        };
+    }
+
+    // Try pip install
+    println!("  installing {package} via pip...");
+    let install = Command::new("python3")
+        .args([
+            "-m",
+            "pip",
+            "install",
+            "--break-system-packages",
+            "--quiet",
+            package,
+        ])
+        .output();
+
+    match install {
+        Ok(output) if output.status.success() => DepCheck {
+            name: package,
+            status: DepStatus::Installed(format!("installed {package}")),
+        },
+        Ok(output) => {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            DepCheck {
+                name: package,
+                status: DepStatus::Failed(format!("pip install failed: {}", stderr.trim())),
+            }
+        }
+        Err(e) => DepCheck {
+            name: package,
+            status: DepStatus::Failed(format!("pip not available: {e}")),
+        },
+    }
+}
+
+fn memory_lib_candidates() -> Vec<PathBuf> {
+    let home = dirs_or_home();
+    vec![
+        home.join("src/amplirusty/amplihack-memory-lib/src"),
+        home.join("amplirusty/amplihack-memory-lib/src"),
+    ]
+}
+
+fn dirs_or_home() -> PathBuf {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("/usr/local"))
+}
+
+fn ensure_memory_lib() -> DepCheck {
+    let name = "amplihack-memory-lib";
+
+    // Check if already importable
+    if let Ok(output) = Command::new("python3")
+        .args(["-c", "import amplihack_memory"])
+        .output()
+        && output.status.success()
+    {
+        return DepCheck {
+            name,
+            status: DepStatus::Ok("importable".into()),
+        };
+    }
+
+    // Check candidate paths
+    for candidate in memory_lib_candidates() {
+        if candidate.join("amplihack_memory/__init__.py").exists() {
+            return DepCheck {
+                name,
+                status: DepStatus::Ok(format!("found at {}", candidate.display())),
+            };
+        }
+    }
+
+    // Clone amplihack repo to get the memory lib
+    let target = dirs_or_home().join("src/amplirusty");
+    if !target.exists() {
+        println!("  cloning amplihack repo for memory lib...");
+        let result = Command::new("git")
+            .args([
+                "clone",
+                "--depth=1",
+                "https://github.com/rysweet/amplihack.git",
+                &target.to_string_lossy(),
+            ])
+            .output();
+
+        match result {
+            Ok(output) if output.status.success() => {
+                // Verify the memory lib exists in the clone
+                let lib_path = target.join("amplihack-memory-lib/src");
+                if lib_path.join("amplihack_memory/__init__.py").exists() {
+                    return DepCheck {
+                        name,
+                        status: DepStatus::Installed(format!("cloned to {}", lib_path.display())),
+                    };
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // Check if it exists in the clone even if we didn't just clone
+    let lib_path = target.join("amplihack-memory-lib/src");
+    if lib_path.join("amplihack_memory/__init__.py").exists() {
+        return DepCheck {
+            name,
+            status: DepStatus::Ok(format!("found at {}", lib_path.display())),
+        };
+    }
+
+    DepCheck {
+        name,
+        status: DepStatus::Failed("could not locate or install amplihack-memory-lib".into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn check_binary_finds_git() {
+        let result = check_binary("git", &["--version"]);
+        assert!(matches!(result.status, DepStatus::Ok(_)));
+    }
+
+    #[test]
+    fn check_binary_missing_returns_missing() {
+        let result = check_binary("nonexistent-binary-xyz", &["--version"]);
+        assert!(matches!(result.status, DepStatus::Missing(_)));
+    }
+
+    #[test]
+    fn memory_lib_candidates_are_absolute() {
+        for path in memory_lib_candidates() {
+            assert!(
+                path.is_absolute(),
+                "candidate should be absolute: {}",
+                path.display()
+            );
+        }
+    }
+
+    #[test]
+    fn dirs_or_home_returns_absolute() {
+        let home = dirs_or_home();
+        assert!(home.is_absolute());
+    }
+}

--- a/src/cmd_install.rs
+++ b/src/cmd_install.rs
@@ -47,6 +47,12 @@ pub fn handle_install() -> Result<(), Box<dyn std::error::Error>> {
     println!("Add to your PATH if not already present:");
     println!("  export PATH=\"$HOME/.simard/bin:$PATH\"");
 
+    // Auto-ensure runtime dependencies after install
+    println!();
+    if let Err(e) = crate::cmd_ensure_deps::handle_ensure_deps() {
+        eprintln!("Warning: some dependencies could not be verified: {e}");
+    }
+
     Ok(())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod bridge;
 pub mod bridge_circuit;
 pub mod bridge_launcher;
 pub mod bridge_subprocess;
+pub mod cmd_ensure_deps;
 pub mod cmd_install;
 pub mod cmd_self_update;
 mod copilot_status_probe;

--- a/src/operator_cli/mod.rs
+++ b/src/operator_cli/mod.rs
@@ -12,6 +12,7 @@ use std::path::PathBuf;
 
 use crate::agent_roles::AgentRole;
 use crate::agent_supervisor::{SubordinateConfig, spawn_subordinate};
+use crate::cmd_ensure_deps::handle_ensure_deps;
 use crate::cmd_install::handle_install;
 use crate::cmd_self_update::{handle_self_test, handle_self_update};
 use crate::operator_commands::run_bootstrap_probe;
@@ -51,6 +52,7 @@ Product modes:
   handover [--canary-dir=PATH] [--manifest-dir=PATH]
   update
   self-test
+  ensure-deps
   act-on-decisions
   install
 
@@ -100,6 +102,10 @@ where
         "self-test" => {
             reject_extra_args(args)?;
             handle_self_test()
+        }
+        "ensure-deps" => {
+            reject_extra_args(args)?;
+            handle_ensure_deps()
         }
         "install" => {
             reject_extra_args(args)?;

--- a/src/operator_commands_ooda/daemon.rs
+++ b/src/operator_commands_ooda/daemon.rs
@@ -95,6 +95,11 @@ pub fn run_ooda_daemon(
     }
     // --------------------------------------------------------------------
 
+    // Auto-ensure runtime dependencies before launching bridges
+    if let Err(e) = crate::cmd_ensure_deps::handle_ensure_deps() {
+        eprintln!("Warning: some dependencies could not be verified: {e}");
+    }
+
     let state_root = state_root_override.unwrap_or_else(|| {
         PathBuf::from(
             std::env::var("SIMARD_STATE_ROOT").unwrap_or_else(|_| "/tmp/simard-ooda".to_string()),


### PR DESCRIPTION
## Changes

### 1. Fix spawn topology bug
`spawn_subordinate()` in `lifecycle.rs` was passing `"local"` as the topology argument, but `parse_runtime_topology()` only accepts `single-process`, `multi-process`, or `distributed`. Changed to `"single-process"`.

### 2. Add `simard ensure-deps` command
New module `cmd_ensure_deps.rs` (277 lines) that checks and auto-installs runtime dependencies:
- **Binaries**: git, python3, gh, amplihack CLI
- **Python packages**: kuzu
- **Source trees**: amplihack-memory-lib (clones from GitHub if missing)

### 3. Auto-ensure deps at key entry points
- `simard install` now calls `ensure-deps` after binary installation
- OODA daemon calls `ensure-deps` at startup before launching bridges

This ensures Simard is self-sufficient — she installs her own dependencies rather than relying on pre-existing setup.

### Tests
- 4 unit tests for `cmd_ensure_deps` (all passing)
- `cargo clippy -- -D warnings` clean
- `cargo fmt` clean

Closes #357 (partial — distributed validation)