### PR TITLE
fix: ooda_daemon_seeds_five_goals uses fresh tempdir

### DIFF
--- a/tests/e2e_engineer_external_repo.rs
+++ b/tests/e2e_engineer_external_repo.rs
@@ -95,6 +95,7 @@ fn meeting_repl_shows_greeting() {
 /// Skipped in CI when amplihack-memory-lib is unavailable.
 #[test]
 fn ooda_daemon_seeds_five_goals() {
+    let state_root = tempfile::tempdir().expect("temp dir for ooda test");
     let output = Command::new("timeout")
         .args([
             "15",
@@ -103,7 +104,7 @@ fn ooda_daemon_seeds_five_goals() {
             "run",
             "--cycles=1",
         ])
-        .env("SIMARD_STATE_ROOT", "/tmp/simard-e2e-ooda")
+        .env("SIMARD_STATE_ROOT", state_root.path())
         .output()
         .expect("failed to run ooda daemon");
 


### PR DESCRIPTION
The e2e test was using a hardcoded `/tmp/simard-e2e-ooda` state root. On subsequent runs, goals already exist so the 'seeded 5 default goal' message never appears, causing the assertion to fail.

Fix: Use `tempfile::tempdir()` so each run starts fresh.

Also validated on the Simard VM — OODA cycle with fresh state root seeds 5 goals correctly.