### PR TITLE
feat: git guardrails, structured tracing, dashboard logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1864,6 +1864,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1968,6 +1977,15 @@ dependencies = [
  "bytecount",
  "memchr",
  "nom",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3181,6 +3199,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3235,6 +3262,7 @@ dependencies = [
  "tokio",
  "tower-http",
  "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 
@@ -3504,6 +3532,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3702,6 +3739,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -3871,6 +3951,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ chrono = "0.4"
 dirs = "6"
 crc32fast = "1"
 tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
 ctrlc = "3.4"
 
 [target.'cfg(unix)'.dependencies]

--- a/src/cost_tracking.rs
+++ b/src/cost_tracking.rs
@@ -74,6 +74,15 @@ pub fn record_cost(
     let completion_tokens_est = estimate_tokens(completion_chars);
     let cost_usd_est = estimate_cost(prompt_tokens_est, completion_tokens_est);
 
+    tracing::debug!(
+        session_id,
+        model,
+        prompt_tokens_est,
+        completion_tokens_est,
+        cost_usd_est,
+        "recording LLM cost"
+    );
+
     let entry = CostEntry {
         timestamp: Utc::now(),
         session_id: session_id.to_string(),

--- a/src/git_guardrails.rs
+++ b/src/git_guardrails.rs
@@ -1,0 +1,145 @@
+//! Git guardrails — prevent destructive operations on protected repositories.
+//!
+//! The OODA daemon runs autonomously and can execute git operations. This module
+//! ensures it never performs destructive operations (force push, reset --hard,
+//! branch -D on main/release) on protected repository paths.
+
+use std::path::Path;
+
+/// Destructive git operations that are always blocked.
+const BLOCKED_PATTERNS: &[&str] = &[
+    "push --force",
+    "push -f",
+    "reset --hard",
+    "branch -D main",
+    "branch -D release",
+    "branch -D master",
+    "clean -fdx",
+    "reflog expire",
+    "gc --prune=now --aggressive",
+];
+
+/// Check whether `SIMARD_GIT_GUARDRAILS` is enabled (default: enabled).
+fn guardrails_enabled() -> bool {
+    std::env::var("SIMARD_GIT_GUARDRAILS")
+        .map(|v| !matches!(v.as_str(), "0" | "false" | "disabled"))
+        .unwrap_or(true)
+}
+
+/// Protected repo root paths (from `SIMARD_GIT_PROTECTED_REPOS`, colon-separated).
+fn protected_roots() -> Vec<String> {
+    std::env::var("SIMARD_GIT_PROTECTED_REPOS")
+        .unwrap_or_default()
+        .split(':')
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+/// Returns `Err` with a descriptive message if the proposed git command would
+/// violate guardrails. Returns `Ok(())` if the command is safe to execute.
+pub fn check_git_safety(workspace: &Path, args: &[&str]) -> Result<(), String> {
+    if !guardrails_enabled() {
+        return Ok(());
+    }
+
+    let cmd_str = args.join(" ");
+
+    // Block globally-destructive patterns regardless of repo path.
+    for pattern in BLOCKED_PATTERNS {
+        if cmd_str.contains(pattern) {
+            return Err(format!(
+                "GUARDRAIL BLOCKED: 'git {cmd_str}' matches destructive pattern '{pattern}'. \
+                 Destructive git operations are not permitted in autonomous mode."
+            ));
+        }
+    }
+
+    // If workspace is under a protected root, block all write operations
+    // except: add, commit, checkout (non-force), branch (create), push (non-force), pull, fetch, stash.
+    let ws = workspace.to_string_lossy();
+    let roots = protected_roots();
+    let is_protected = roots.iter().any(|root| ws.starts_with(root));
+
+    if is_protected {
+        let first_arg = args.first().copied().unwrap_or("");
+        let safe_commands = [
+            "add", "commit", "checkout", "branch", "push", "pull", "fetch",
+            "stash", "status", "log", "diff", "show", "tag", "remote",
+            "config", "rev-parse",
+        ];
+        if !safe_commands.contains(&first_arg) {
+            return Err(format!(
+                "GUARDRAIL BLOCKED: 'git {first_arg}' is not in the safe command list \
+                 for protected repo at {ws}. Safe commands: {safe_commands:?}"
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn blocks_force_push() {
+        let result = check_git_safety(
+            &PathBuf::from("/home/user/src/repo"),
+            &["push", "--force", "origin", "main"],
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("GUARDRAIL BLOCKED"));
+    }
+
+    #[test]
+    fn blocks_reset_hard() {
+        let result = check_git_safety(
+            &PathBuf::from("/tmp/repo"),
+            &["reset", "--hard", "HEAD~1"],
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn allows_normal_push() {
+        unsafe { std::env::set_var("SIMARD_GIT_GUARDRAILS", "enabled") };
+        unsafe { std::env::remove_var("SIMARD_GIT_PROTECTED_REPOS") };
+        let result = check_git_safety(
+            &PathBuf::from("/tmp/repo"),
+            &["push", "origin", "feature-branch"],
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn allows_commit() {
+        let result = check_git_safety(
+            &PathBuf::from("/tmp/repo"),
+            &["commit", "-m", "fix: stuff"],
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn disabled_allows_everything() {
+        unsafe { std::env::set_var("SIMARD_GIT_GUARDRAILS", "disabled") };
+        let result = check_git_safety(
+            &PathBuf::from("/tmp/repo"),
+            &["push", "--force", "origin", "main"],
+        );
+        assert!(result.is_ok());
+        unsafe { std::env::set_var("SIMARD_GIT_GUARDRAILS", "enabled") };
+    }
+
+    #[test]
+    fn blocks_delete_main_branch() {
+        let result = check_git_safety(
+            &PathBuf::from("/tmp/repo"),
+            &["branch", "-D", "main"],
+        );
+        assert!(result.is_err());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ pub mod engineer_loop;
 pub mod engineer_plan;
 pub mod error;
 pub mod evidence;
+pub mod git_guardrails;
 pub mod goal_curation;
 pub mod goals;
 pub mod greeting_banner;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,32 @@
 use simard::dispatch_operator_cli;
 
 fn main() -> std::process::ExitCode {
+    // Initialize structured tracing. RUST_LOG controls verbosity
+    // (default: info). Set SIMARD_LOG_JSON=1 for JSON output.
+    let use_json = std::env::var("SIMARD_LOG_JSON")
+        .map(|v| matches!(v.as_str(), "1" | "true"))
+        .unwrap_or(false);
+
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
+
+    if use_json {
+        tracing_subscriber::fmt()
+            .json()
+            .with_env_filter(filter)
+            .with_target(true)
+            .init();
+    } else {
+        tracing_subscriber::fmt()
+            .with_env_filter(filter)
+            .with_target(true)
+            .init();
+    }
+
     match dispatch_operator_cli(std::env::args().skip(1)) {
         Ok(()) => std::process::ExitCode::SUCCESS,
         Err(error) => {
+            tracing::error!(%error, "command failed");
             eprintln!("Error: {error}");
             std::process::ExitCode::FAILURE
         }

--- a/src/ooda_loop/mod.rs
+++ b/src/ooda_loop/mod.rs
@@ -60,6 +60,7 @@ pub fn act(
 ///
 /// Takes `&mut OodaBridges` so that the optional session can be used for
 /// `run_turn` calls during `AdvanceGoal` dispatch.
+#[tracing::instrument(skip_all, fields(cycle = state.cycle_count))]
 pub fn run_ooda_cycle(
     state: &mut OodaState,
     bridges: &mut OodaBridges,

--- a/src/operator_commands_dashboard/routes.rs
+++ b/src/operator_commands_dashboard/routes.rs
@@ -727,9 +727,16 @@ async fn logs() -> Json<Value> {
         }
     }
 
+    let cost_log = {
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/home/azureuser".to_string());
+        let ledger = std::path::PathBuf::from(home).join(".simard/costs/ledger.jsonl");
+        read_tail(&ledger.to_string_lossy(), 50).unwrap_or_default()
+    };
+
     Json(json!({
         "daemon_log_lines": daemon_log,
         "ooda_transcripts": transcripts,
+        "cost_log_lines": cost_log,
         "timestamp": chrono::Utc::now().to_rfc3339(),
     }))
 }

--- a/src/self_improve_executor/git_ops.rs
+++ b/src/self_improve_executor/git_ops.rs
@@ -4,8 +4,11 @@ use std::path::Path;
 use std::process::Command;
 
 use crate::error::{SimardError, SimardResult};
+use crate::git_guardrails;
 
 pub(crate) fn git_diff(workspace: &Path) -> SimardResult<String> {
+    git_guardrails::check_git_safety(workspace, &["diff", "HEAD"])
+        .map_err(|e| SimardError::GitCommandFailed { command: "git diff HEAD".into(), reason: e })?;
     let output = Command::new("git")
         .args(["diff", "HEAD"])
         .current_dir(workspace)
@@ -26,6 +29,10 @@ pub(crate) fn git_diff(workspace: &Path) -> SimardResult<String> {
 }
 
 pub(crate) fn git_commit(workspace: &Path, message: &str) -> SimardResult<()> {
+    git_guardrails::check_git_safety(workspace, &["add", "-A"])
+        .map_err(|e| SimardError::GitCommandFailed { command: "git add -A".into(), reason: e })?;
+    git_guardrails::check_git_safety(workspace, &["commit", "-m", message])
+        .map_err(|e| SimardError::GitCommandFailed { command: "git commit".into(), reason: e })?;
     let add_output = Command::new("git")
         .args(["add", "-A"])
         .current_dir(workspace)
@@ -62,6 +69,10 @@ pub(crate) fn git_commit(workspace: &Path, message: &str) -> SimardResult<()> {
 }
 
 pub(crate) fn rollback(workspace: &Path) -> SimardResult<()> {
+    git_guardrails::check_git_safety(workspace, &["checkout", "--", "."])
+        .map_err(|e| SimardError::GitCommandFailed { command: "git checkout -- .".into(), reason: e })?;
+    git_guardrails::check_git_safety(workspace, &["clean", "-fd"])
+        .map_err(|e| SimardError::GitCommandFailed { command: "git clean -fd".into(), reason: e })?;
     // Restore modified tracked files.
     let checkout = Command::new("git")
         .args(["checkout", "--", "."])

--- a/src/session_builder.rs
+++ b/src/session_builder.rs
@@ -140,6 +140,7 @@ impl SessionBuilder {
     ///
     /// Returns `Ok(session)` on success, `Err` with a diagnostic message
     /// describing exactly which step failed.
+    #[tracing::instrument(skip(self), fields(provider = ?self.provider, tag = %self.adapter_tag))]
     pub fn open(self) -> Result<Box<dyn BaseTypeSession>, String> {
         let request = self.build_request();
         match self.provider {


### PR DESCRIPTION
## Git Guardrails
- New `git_guardrails` module blocks destructive git operations in autonomous mode
- Blocks: force push, reset --hard, branch -D main/master/release, clean -fdx
- Protected repo paths via `SIMARD_GIT_PROTECTED_REPOS` (colon-separated)
- Wired into `self_improve_executor/git_ops.rs` — checks run before every git operation
- Full test suite for guardrail logic

## Structured Tracing
- `tracing-subscriber` with JSON and env-filter support
- `RUST_LOG` controls verbosity (default: info)
- `SIMARD_LOG_JSON=1` for JSON structured output (for log aggregation)
- Instrumented key paths: OODA cycle, SessionBuilder::open, cost recording

## Dashboard Logs
- Logs endpoint now includes cost ledger tail (last 50 entries)

## Testing
- cargo build --release: ✅
- git_guardrails module has 6 unit tests