### PR TITLE
feat: OTEL tracing pipeline + dashboard traces/memory/goals + systemd activation

### DIFF
--- a/.claude/context/PROJECT.md
+++ b/.claude/context/PROJECT.md
@@ -10,7 +10,7 @@ Replace the sections below with information about your project.
 
 ---
 
-## Project: test-round-8
+## Project: main
 
 ## Overview
 
@@ -29,7 +29,6 @@ An autonomous engineer who drives and curates agentic coding systems. Named afte
 - **Language**: Python
 - **Language**: JavaScript/TypeScript
 - **Language**: Rust
-- **Language**: Go
 - **Framework**: [Main framework if applicable]
 - **Database**: [Database system if applicable]
 

--- a/.claude/context/PROJECT.md.bak
+++ b/.claude/context/PROJECT.md.bak
@@ -10,7 +10,7 @@ Replace the sections below with information about your project.
 
 ---
 
-## Project: test-round-8
+## Project: main
 
 ## Overview
 
@@ -29,7 +29,6 @@ An autonomous engineer who drives and curates agentic coding systems. Named afte
 - **Language**: Python
 - **Language**: JavaScript/TypeScript
 - **Language**: Rust
-- **Language**: Go
 - **Framework**: [Main framework if applicable]
 - **Database**: [Database system if applicable]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,11 +191,38 @@ dependencies = [
 
 [[package]]
 name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.5",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit 0.7.3",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
- "axum-core",
+ "axum-core 0.5.6",
  "base64",
  "bytes",
  "form_urlencoded",
@@ -206,7 +233,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit",
+ "matchit 0.8.4",
  "memchr",
  "mime",
  "percent-encoding",
@@ -219,10 +246,30 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -1182,12 +1229,18 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.13.1",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1389,7 +1442,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -1538,6 +1591,16 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
@@ -1572,6 +1635,15 @@ checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -1810,7 +1882,7 @@ dependencies = [
  "encoding_rs",
  "flate2",
  "getrandom 0.3.4",
- "indexmap",
+ "indexmap 2.13.1",
  "itoa",
  "log",
  "md-5",
@@ -1871,6 +1943,12 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "matchit"
@@ -2100,7 +2178,7 @@ dependencies = [
  "serde_urlencoded",
  "snafu",
  "tokio",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tracing",
  "url",
@@ -2135,6 +2213,72 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "opentelemetry"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab70038c28ed37b97d8ed414b6429d343a8bbf44c9f79ec854f3a643029ba6d7"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91cf61a1868dacc576bf2b2a1c3e9ab150af7272909e80085c3173384fe11f76"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "http",
+ "opentelemetry",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "thiserror 1.0.69",
+ "tokio",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e05acbfada5ec79023c85368af14abd0b307c015e9064d249b2a950ef459a6"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231e9d6ceef9b0b2546ddf52335785ce41252bc7474ee8ba05bfad277be13ab8"
+dependencies = [
+ "async-trait",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.8.5",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "tracing",
 ]
 
 [[package]]
@@ -2474,6 +2618,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2492,7 +2659,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2530,7 +2697,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -2723,7 +2890,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -3143,7 +3310,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.1",
  "itoa",
  "ryu",
  "serde",
@@ -3245,12 +3412,15 @@ version = "0.16.0"
 dependencies = [
  "amplihack-memory",
  "assert_cmd",
- "axum",
+ "axum 0.8.8",
  "chrono",
  "crc32fast",
  "ctrlc",
  "dirs 6.0.0",
  "libc",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "proptest",
  "rusqlite",
  "rustyclawd-core",
@@ -3262,6 +3432,7 @@ dependencies = [
  "tokio",
  "tower-http",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "uuid",
 ]
@@ -3321,6 +3492,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3608,7 +3789,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -3635,6 +3816,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3657,6 +3849,56 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum 0.7.9",
+ "base64",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3691,7 +3933,7 @@ dependencies = [
  "iri-string",
  "mime",
  "pin-project-lite",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3751,6 +3993,24 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a971f6058498b5c0f1affa23e7ea202057a7301dbff68e968b2d578bcbd053"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]
@@ -4094,7 +4354,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.13.1",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -4120,7 +4380,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.13.1",
  "semver",
 ]
 
@@ -4555,7 +4815,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.13.1",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -4586,7 +4846,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap",
+ "indexmap 2.13.1",
  "log",
  "serde",
  "serde_derive",
@@ -4605,7 +4865,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.13.1",
  "log",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,10 @@ crc32fast = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
 ctrlc = "3.4"
+opentelemetry = "0.27"
+opentelemetry-otlp = "0.27"
+tracing-opentelemetry = "0.28"
+opentelemetry_sdk = { version = "0.27", features = ["rt-tokio"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/scripts/simard-ooda.service
+++ b/scripts/simard-ooda.service
@@ -16,6 +16,11 @@ Environment=SIMARD_WEEKLY_BUDGET_USD=2500
 Environment=SIMARD_AUTONOMY_LEVEL=unlimited
 Environment=SIMARD_LLM_PROVIDER=copilot
 Environment=HOME=/home/azureuser
+Environment=SIMARD_STATE_ROOT=/home/azureuser/.simard
+
+# Structured tracing — set OTEL_EXPORTER_OTLP_ENDPOINT to enable OTLP export
+# Environment=OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+Environment=RUST_LOG=info
 
 # Prevent destructive git actions
 Environment=SIMARD_GIT_GUARDRAILS=enabled

--- a/src/error/display.rs
+++ b/src/error/display.rs
@@ -230,8 +230,15 @@ impl Display for SimardError {
             Self::BridgeError(msg) => {
                 write!(f, "bridge error: {msg}")
             }
-            Self::BudgetExceeded { period, spent, limit } => {
-                write!(f, "{period} budget exceeded: {spent} spent of {limit} limit")
+            Self::BudgetExceeded {
+                period,
+                spent,
+                limit,
+            } => {
+                write!(
+                    f,
+                    "{period} budget exceeded: {spent} spent of {limit} limit"
+                )
             }
             Self::PlanningUnavailable { reason } => {
                 write!(f, "LLM-based planning is unavailable: {reason}")

--- a/src/git_guardrails.rs
+++ b/src/git_guardrails.rs
@@ -64,9 +64,22 @@ pub fn check_git_safety(workspace: &Path, args: &[&str]) -> Result<(), String> {
     if is_protected {
         let first_arg = args.first().copied().unwrap_or("");
         let safe_commands = [
-            "add", "commit", "checkout", "branch", "push", "pull", "fetch",
-            "stash", "status", "log", "diff", "show", "tag", "remote",
-            "config", "rev-parse",
+            "add",
+            "commit",
+            "checkout",
+            "branch",
+            "push",
+            "pull",
+            "fetch",
+            "stash",
+            "status",
+            "log",
+            "diff",
+            "show",
+            "tag",
+            "remote",
+            "config",
+            "rev-parse",
         ];
         if !safe_commands.contains(&first_arg) {
             return Err(format!(
@@ -96,10 +109,7 @@ mod tests {
 
     #[test]
     fn blocks_reset_hard() {
-        let result = check_git_safety(
-            &PathBuf::from("/tmp/repo"),
-            &["reset", "--hard", "HEAD~1"],
-        );
+        let result = check_git_safety(&PathBuf::from("/tmp/repo"), &["reset", "--hard", "HEAD~1"]);
         assert!(result.is_err());
     }
 
@@ -116,10 +126,7 @@ mod tests {
 
     #[test]
     fn allows_commit() {
-        let result = check_git_safety(
-            &PathBuf::from("/tmp/repo"),
-            &["commit", "-m", "fix: stuff"],
-        );
+        let result = check_git_safety(&PathBuf::from("/tmp/repo"), &["commit", "-m", "fix: stuff"]);
         assert!(result.is_ok());
     }
 
@@ -136,10 +143,7 @@ mod tests {
 
     #[test]
     fn blocks_delete_main_branch() {
-        let result = check_git_safety(
-            &PathBuf::from("/tmp/repo"),
-            &["branch", "-D", "main"],
-        );
+        let result = check_git_safety(&PathBuf::from("/tmp/repo"), &["branch", "-D", "main"]);
         assert!(result.is_err());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,28 @@
 use simard::dispatch_operator_cli;
+use tracing_subscriber::prelude::*;
 
 fn main() -> std::process::ExitCode {
-    // Initialize structured tracing. RUST_LOG controls verbosity
-    // (default: info). Set SIMARD_LOG_JSON=1 for JSON output.
+    init_tracing();
+
+    let result = match dispatch_operator_cli(std::env::args().skip(1)) {
+        Ok(()) => std::process::ExitCode::SUCCESS,
+        Err(error) => {
+            tracing::error!(%error, "command failed");
+            eprintln!("Error: {error}");
+            std::process::ExitCode::FAILURE
+        }
+    };
+
+    opentelemetry::global::shutdown_tracer_provider();
+    result
+}
+
+/// Initialize structured tracing with optional OTEL export.
+///
+/// - `RUST_LOG` controls verbosity (default: info)
+/// - `SIMARD_LOG_JSON=1` enables JSON log output
+/// - `OTEL_EXPORTER_OTLP_ENDPOINT` enables OTLP span export (e.g. http://localhost:4317)
+fn init_tracing() {
     let use_json = std::env::var("SIMARD_LOG_JSON")
         .map(|v| matches!(v.as_str(), "1" | "true"))
         .unwrap_or(false);
@@ -10,25 +30,63 @@ fn main() -> std::process::ExitCode {
     let filter = tracing_subscriber::EnvFilter::try_from_default_env()
         .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
 
-    if use_json {
-        tracing_subscriber::fmt()
-            .json()
-            .with_env_filter(filter)
-            .with_target(true)
-            .init();
-    } else {
-        tracing_subscriber::fmt()
-            .with_env_filter(filter)
-            .with_target(true)
-            .init();
+    let endpoint = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT").ok();
+
+    if let Some(ref ep) = endpoint {
+        eprintln!("[simard] OTEL tracing enabled → {ep}");
     }
 
-    match dispatch_operator_cli(std::env::args().skip(1)) {
-        Ok(()) => std::process::ExitCode::SUCCESS,
-        Err(error) => {
-            tracing::error!(%error, "command failed");
-            eprintln!("Error: {error}");
-            std::process::ExitCode::FAILURE
-        }
+    // Each branch creates the otel layer inline so Rust infers the subscriber
+    // type parameter correctly for the layered stack.
+    if use_json {
+        let otel = endpoint
+            .as_deref()
+            .and_then(|ep| make_otel_tracer(ep).ok())
+            .map(|t| tracing_opentelemetry::layer().with_tracer(t));
+        tracing_subscriber::registry()
+            .with(filter)
+            .with(tracing_subscriber::fmt::layer().json().with_target(true))
+            .with(otel)
+            .init();
+    } else {
+        let otel = endpoint
+            .as_deref()
+            .and_then(|ep| make_otel_tracer(ep).ok())
+            .map(|t| tracing_opentelemetry::layer().with_tracer(t));
+        tracing_subscriber::registry()
+            .with(filter)
+            .with(tracing_subscriber::fmt::layer().with_target(true))
+            .with(otel)
+            .init();
     }
+}
+
+fn make_otel_tracer(
+    endpoint: &str,
+) -> Result<opentelemetry_sdk::trace::Tracer, Box<dyn std::error::Error + Send + Sync>> {
+    use opentelemetry::KeyValue;
+    use opentelemetry::trace::TracerProvider as _;
+    use opentelemetry_otlp::{SpanExporter, WithExportConfig};
+    use opentelemetry_sdk::Resource;
+    use opentelemetry_sdk::trace::TracerProvider;
+
+    let exporter = SpanExporter::builder()
+        .with_tonic()
+        .with_endpoint(endpoint)
+        .build()?;
+
+    let resource = Resource::new(vec![
+        KeyValue::new("service.name", "simard"),
+        KeyValue::new("service.version", env!("CARGO_PKG_VERSION")),
+    ]);
+
+    let provider = TracerProvider::builder()
+        .with_batch_exporter(exporter, opentelemetry_sdk::runtime::Tokio)
+        .with_resource(resource)
+        .build();
+
+    let tracer = provider.tracer("simard");
+    opentelemetry::global::set_tracer_provider(provider);
+
+    Ok(tracer)
 }

--- a/src/ooda_loop/mod.rs
+++ b/src/ooda_loop/mod.rs
@@ -297,6 +297,28 @@ pub fn run_ooda_cycle(
         eprintln!("[simard] OODA curate: failed to persist goal board: {e}");
     }
 
+    // Also write the board to disk so the dashboard can read it.
+    {
+        let state_root = std::env::var("SIMARD_STATE_ROOT")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|_| {
+                let home = std::env::var("HOME").unwrap_or_else(|_| "/home/azureuser".into());
+                std::path::PathBuf::from(home).join(".simard")
+            });
+        let goal_path = state_root.join("goal_records.json");
+        if let Err(e) = std::fs::create_dir_all(&state_root) {
+            eprintln!("[simard] OODA curate: failed to create state dir: {e}");
+        }
+        match serde_json::to_string_pretty(&state.active_goals) {
+            Ok(json) => {
+                if let Err(e) = std::fs::write(&goal_path, json) {
+                    eprintln!("[simard] OODA curate: failed to write goal_records.json: {e}");
+                }
+            }
+            Err(e) => eprintln!("[simard] OODA curate: failed to serialize goal board: {e}"),
+        }
+    }
+
     // --- Memory consolidation: persistence at cycle end ---
     if let Err(e) =
         memory_consolidation::persistence_memory_operations(&cycle_session_id, &bridges.memory)

--- a/src/operator_commands_dashboard/routes.rs
+++ b/src/operator_commands_dashboard/routes.rs
@@ -17,11 +17,17 @@ pub fn build_router() -> Router {
         .route("/api/costs", get(costs))
         .route("/api/budget", get(get_budget).post(set_budget))
         .route("/api/goals", get(goals))
+        .route("/api/goals/seed", post(seed_goals))
         .route("/api/distributed", get(distributed))
-        .route("/api/hosts", get(get_hosts).post(add_host).delete(remove_host))
+        .route(
+            "/api/hosts",
+            get(get_hosts).post(add_host).delete(remove_host),
+        )
         .route("/api/logs", get(logs))
         .route("/api/processes", get(processes))
         .route("/api/memory", get(memory_metrics))
+        .route("/api/memory/search", post(memory_search))
+        .route("/api/traces", get(traces))
         .route("/ws/chat", get(ws_chat_handler))
         .route("/api/login", post(login))
         .route("/login", get(login_page))
@@ -186,7 +192,9 @@ async fn costs() -> Json<Value> {
 /// Budget config file path.
 fn budget_config_path() -> std::path::PathBuf {
     let home = std::env::var("HOME").unwrap_or_else(|_| "/home/azureuser".to_string());
-    std::path::PathBuf::from(home).join(".simard").join("budget.json")
+    std::path::PathBuf::from(home)
+        .join(".simard")
+        .join("budget.json")
 }
 
 async fn get_budget() -> Json<Value> {
@@ -208,7 +216,10 @@ async fn set_budget(Json(body): Json<Value>) -> Json<Value> {
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
-    match std::fs::write(&path, serde_json::to_string_pretty(&body).unwrap_or_default()) {
+    match std::fs::write(
+        &path,
+        serde_json::to_string_pretty(&body).unwrap_or_default(),
+    ) {
         Ok(_) => Json(json!({"status": "ok"})),
         Err(e) => Json(json!({"error": format!("{e}")})),
     }
@@ -243,6 +254,202 @@ async fn goals() -> Json<Value> {
         }
         Err(_) => Json(json!({"active": [], "backlog": [], "active_count": 0, "backlog_count": 0})),
     }
+}
+
+async fn seed_goals() -> Json<Value> {
+    let state_root = resolve_state_root();
+    let goal_path = state_root.join("goal_records.json");
+
+    // Only seed if no goals exist yet
+    if goal_path.exists() {
+        if let Ok(content) = std::fs::read_to_string(&goal_path) {
+            if let Ok(val) = serde_json::from_str::<Value>(&content) {
+                let has_goals = val
+                    .get("active")
+                    .and_then(|a| a.as_array())
+                    .map(|a| !a.is_empty())
+                    .unwrap_or(false);
+                if has_goals {
+                    return Json(
+                        json!({"status": "already_seeded", "message": "Goals already exist"}),
+                    );
+                }
+            }
+        }
+    }
+
+    let seed_board = json!({
+        "active": [
+            {
+                "id": "self-improvement",
+                "description": "Continuously improve own capabilities through gym scenarios and self-evaluation",
+                "priority": 1,
+                "status": "in_progress",
+                "assigned_to": "simard",
+                "progress": [{"timestamp": chrono::Utc::now().to_rfc3339(), "note": "Goal seeded via dashboard"}]
+            },
+            {
+                "id": "knowledge-growth",
+                "description": "Expand knowledge base through meetings, research, and cognitive memory consolidation",
+                "priority": 2,
+                "status": "in_progress",
+                "assigned_to": "simard",
+                "progress": [{"timestamp": chrono::Utc::now().to_rfc3339(), "note": "Goal seeded via dashboard"}]
+            },
+            {
+                "id": "operational-health",
+                "description": "Maintain system health: budget compliance, resource usage, and error rates within thresholds",
+                "priority": 3,
+                "status": "in_progress",
+                "assigned_to": "simard",
+                "progress": [{"timestamp": chrono::Utc::now().to_rfc3339(), "note": "Goal seeded via dashboard"}]
+            }
+        ],
+        "backlog": [
+            {
+                "id": "distributed-sync",
+                "description": "Establish hive mind sync with remote Simard instances for cross-agent knowledge sharing",
+                "source": "dashboard-seed",
+                "score": 0.7
+            },
+            {
+                "id": "meeting-quality",
+                "description": "Improve meeting facilitation quality and actionable outcome generation",
+                "source": "dashboard-seed",
+                "score": 0.6
+            }
+        ]
+    });
+
+    if let Err(e) = std::fs::create_dir_all(&state_root) {
+        return Json(
+            json!({"status": "error", "error": format!("failed to create state dir: {e}")}),
+        );
+    }
+    match std::fs::write(
+        &goal_path,
+        serde_json::to_string_pretty(&seed_board).unwrap(),
+    ) {
+        Ok(()) => {
+            Json(json!({"status": "ok", "message": "Seeded 3 active goals and 2 backlog items"}))
+        }
+        Err(e) => Json(json!({"status": "error", "error": format!("write failed: {e}")})),
+    }
+}
+
+async fn memory_search(Json(body): Json<Value>) -> Json<Value> {
+    let query = body.get("query").and_then(|v| v.as_str()).unwrap_or("");
+    if query.is_empty() {
+        return Json(json!({"status": "error", "error": "query is required"}));
+    }
+
+    // Search through memory_records.json, evidence_records.json for matching content
+    let state_root = resolve_state_root();
+    let mut results: Vec<Value> = Vec::new();
+
+    for (file, label) in [
+        ("memory_records.json", "memory"),
+        ("evidence_records.json", "evidence"),
+        ("goal_records.json", "goal"),
+    ] {
+        let path = state_root.join(file);
+        if let Ok(content) = std::fs::read_to_string(&path) {
+            if let Ok(val) = serde_json::from_str::<Value>(&content) {
+                let search_in = |v: &Value| -> bool {
+                    let s = serde_json::to_string(v).unwrap_or_default().to_lowercase();
+                    s.contains(&query.to_lowercase())
+                };
+
+                match val {
+                    Value::Array(arr) => {
+                        for item in arr.iter().filter(|i| search_in(i)).take(10) {
+                            results.push(json!({"source": label, "data": item}));
+                        }
+                    }
+                    Value::Object(ref map) => {
+                        // For goal board format: search in active and backlog
+                        if let Some(Value::Array(active)) = map.get("active") {
+                            for item in active.iter().filter(|i| search_in(i)).take(5) {
+                                results.push(json!({"source": "active_goal", "data": item}));
+                            }
+                        }
+                        if let Some(Value::Array(backlog)) = map.get("backlog") {
+                            for item in backlog.iter().filter(|i| search_in(i)).take(5) {
+                                results.push(json!({"source": "backlog_goal", "data": item}));
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    Json(json!({
+        "query": query,
+        "result_count": results.len(),
+        "results": results,
+        "timestamp": chrono::Utc::now().to_rfc3339(),
+    }))
+}
+
+async fn traces() -> Json<Value> {
+    // Read recent spans from the trace log file
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/home/azureuser".to_string());
+    let trace_sources = vec![(
+        std::path::PathBuf::from(&home).join(".simard/costs/ledger.jsonl"),
+        "cost",
+    )];
+
+    let mut spans: Vec<Value> = Vec::new();
+
+    for (path, source) in &trace_sources {
+        if let Some(lines) = read_tail(&path.to_string_lossy(), 100) {
+            for line in lines.iter().rev().take(50) {
+                if let Ok(val) = serde_json::from_str::<Value>(line) {
+                    spans.push(json!({
+                        "source": source,
+                        "data": val,
+                    }));
+                }
+            }
+        }
+    }
+
+    // Also read from journalctl if available (last 100 simard-ooda entries)
+    if let Ok(output) = tokio::process::Command::new("journalctl")
+        .args([
+            "--user",
+            "-u",
+            "simard-ooda",
+            "--no-pager",
+            "-n",
+            "50",
+            "-o",
+            "json",
+        ])
+        .output()
+        .await
+    {
+        if output.status.success() {
+            let text = String::from_utf8_lossy(&output.stdout);
+            for line in text.lines().take(50) {
+                if let Ok(val) = serde_json::from_str::<Value>(line) {
+                    spans.push(json!({"source": "journald", "data": val}));
+                }
+            }
+        }
+    }
+
+    let otel_endpoint = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT").ok();
+
+    Json(json!({
+        "span_count": spans.len(),
+        "spans": spans,
+        "otel_enabled": otel_endpoint.is_some(),
+        "otel_endpoint": otel_endpoint,
+        "timestamp": chrono::Utc::now().to_rfc3339(),
+    }))
 }
 
 async fn distributed() -> Json<Value> {
@@ -330,7 +537,9 @@ async fn distributed() -> Json<Value> {
 /// Hosts config file path.
 fn hosts_config_path() -> std::path::PathBuf {
     let home = std::env::var("HOME").unwrap_or_else(|_| "/home/azureuser".to_string());
-    std::path::PathBuf::from(home).join(".simard").join("hosts.json")
+    std::path::PathBuf::from(home)
+        .join(".simard")
+        .join("hosts.json")
 }
 
 fn load_hosts() -> Vec<Value> {
@@ -344,7 +553,10 @@ fn save_hosts(hosts: &[Value]) -> std::io::Result<()> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    std::fs::write(&path, serde_json::to_string_pretty(hosts).unwrap_or_default())
+    std::fs::write(
+        &path,
+        serde_json::to_string_pretty(hosts).unwrap_or_default(),
+    )
 }
 
 async fn get_hosts() -> Json<Value> {
@@ -353,12 +565,18 @@ async fn get_hosts() -> Json<Value> {
 
 async fn add_host(Json(body): Json<Value>) -> Json<Value> {
     let name = body.get("name").and_then(|v| v.as_str()).unwrap_or("");
-    let rg = body.get("resource_group").and_then(|v| v.as_str()).unwrap_or("rysweet-linux-vm-pool");
+    let rg = body
+        .get("resource_group")
+        .and_then(|v| v.as_str())
+        .unwrap_or("rysweet-linux-vm-pool");
     if name.is_empty() {
         return Json(json!({"error": "name is required"}));
     }
     let mut hosts = load_hosts();
-    if hosts.iter().any(|h| h.get("name").and_then(|v| v.as_str()) == Some(name)) {
+    if hosts
+        .iter()
+        .any(|h| h.get("name").and_then(|v| v.as_str()) == Some(name))
+    {
         return Json(json!({"error": format!("host '{name}' already exists")}));
     }
     hosts.push(json!({
@@ -1058,6 +1276,7 @@ const INDEX_HTML: &str = r##"<!DOCTYPE html>
     <div class="tab active" data-tab="overview">Overview</div>
     <div class="tab" data-tab="distributed">Distributed</div>
     <div class="tab" data-tab="goals">Goals</div>
+    <div class="tab" data-tab="traces">Traces</div>
     <div class="tab" data-tab="logs">Logs</div>
     <div class="tab" data-tab="processes">Processes</div>
     <div class="tab" data-tab="memory">Memory</div>
@@ -1097,12 +1316,28 @@ const INDEX_HTML: &str = r##"<!DOCTYPE html>
 
   <div class="tab-content" id="tab-goals">
     <div class="card" style="margin-bottom:1rem">
-      <h2>Active Goals <button class="btn" onclick="fetchGoals()">Refresh</button></h2>
+      <h2>Active Goals
+        <button class="btn" onclick="fetchGoals()">Refresh</button>
+        <button class="btn" onclick="seedGoals()" style="margin-left:.5rem">Seed Default Goals</button>
+      </h2>
       <div id="goals-active"><span class="loading">Loading…</span></div>
     </div>
     <div class="card">
       <h2>Backlog</h2>
       <div id="goals-backlog"><span class="loading">Loading…</span></div>
+    </div>
+  </div>
+
+  <div class="tab-content" id="tab-traces">
+    <div class="card" style="margin-bottom:1rem">
+      <h2>OTEL Traces <button class="btn" onclick="fetchTraces()">Refresh</button></h2>
+      <div id="otel-status" style="margin-bottom:.75rem"><span class="loading">Loading…</span></div>
+      <div id="trace-list" class="log-box" style="max-height:600px;overflow-y:auto"><span class="loading">Loading…</span></div>
+    </div>
+    <div class="card">
+      <h2>Setup</h2>
+      <p style="color:#8b949e;font-size:.85rem">To enable full OTEL tracing, set <code>OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317</code> and run an OTEL collector (e.g. Jaeger, Grafana Tempo).</p>
+      <p style="color:#8b949e;font-size:.85rem;margin-top:.5rem">For systemd: <code>systemctl --user edit simard-ooda</code> and add the env var in an [Service] override.</p>
     </div>
   </div>
 
@@ -1128,6 +1363,14 @@ const INDEX_HTML: &str = r##"<!DOCTYPE html>
       <div class="card"><h2>Memory Overview</h2><div id="mem-overview"><span class="loading">Loading…</span></div></div>
       <div class="card"><h2>Memory Files</h2><div id="mem-files"><span class="loading">Loading…</span></div></div>
     </div>
+    <div class="card" style="margin-top:1rem">
+      <h2>Memory Search</h2>
+      <div style="display:flex;gap:.5rem;align-items:center;margin-bottom:1rem">
+        <input id="mem-search-input" placeholder="Search memories…" style="flex:1;padding:6px;background:#1a1a2e;border:1px solid #333;color:#e0e0e0;border-radius:4px">
+        <button class="btn" onclick="searchMemory()">Search</button>
+      </div>
+      <div id="mem-search-results"></div>
+    </div>
   </div>
 
   <div class="tab-content" id="tab-costs">
@@ -1148,6 +1391,12 @@ const INDEX_HTML: &str = r##"<!DOCTYPE html>
   <div class="tab-content" id="tab-chat">
     <div class="card" style="max-width:720px">
       <h2>Meeting Chat</h2>
+      <div style="background:#1a1a2e;border:1px solid #333;border-radius:6px;padding:.75rem;margin-bottom:1rem;font-size:.85rem;color:#8b949e">
+        <strong style="color:var(--accent)">💡 Meeting Help:</strong>
+        Use this chat or run <code>simard meeting &lt;topic&gt;</code> from the terminal.
+        Commands: <code>/close</code> end session, <code>/goals</code> review goals, <code>/status</code> system status.
+        Meetings generate handoff documents that the OODA daemon ingests as new goals.
+      </div>
       <div class="ws-status disconnected" id="ws-status">● Disconnected</div>
       <div id="chat-messages"></div>
       <div id="chat-input-row">
@@ -1171,6 +1420,7 @@ const INDEX_HTML: &str = r##"<!DOCTYPE html>
         if(tab.dataset.tab==='distributed') fetchDistributed();
         if(tab.dataset.tab==='goals') fetchGoals();
         if(tab.dataset.tab==='costs') fetchCosts();
+        if(tab.dataset.tab==='traces') fetchTraces();
         if(tab.dataset.tab==='chat') initChat();
       });
     });
@@ -1350,6 +1600,64 @@ const INDEX_HTML: &str = r##"<!DOCTYPE html>
         }else{document.getElementById('goals-backlog').innerHTML='<span class="loading">No backlog items</span>';}
       }catch(e){document.getElementById('goals-active').innerHTML='<span class="err">Failed to load</span>';}
     }
+
+    async function seedGoals(){
+      try{
+        const r=await fetch('/api/goals/seed',{method:'POST'});
+        const d=await r.json();
+        if(d.status==='ok'||d.status==='already_seeded'){
+          fetchGoals();
+        }else{
+          alert('Seed failed: '+(d.error||'unknown'));
+        }
+      }catch(e){alert('Seed failed: '+e);}
+    }
+
+    /* --- Traces --- */
+    async function fetchTraces(){
+      try{
+        const r=await fetch('/api/traces'); const d=await r.json();
+        const status=d.otel_enabled
+          ?`<span class="ok">OTEL enabled</span> → <code>${esc(d.otel_endpoint||'')}</code>`
+          :'<span class="warn">OTEL not configured</span> — set OTEL_EXPORTER_OTLP_ENDPOINT to enable';
+        document.getElementById('otel-status').innerHTML=`
+          <div class="stat"><span class="label">OTEL Status</span><span class="value">${status}</span></div>
+          <div class="stat"><span class="label">Collected Entries</span><span class="value">${d.span_count}</span></div>`;
+        if(d.spans?.length){
+          document.getElementById('trace-list').innerHTML=d.spans.map(s=>{
+            const data=s.data;
+            const ts=data.timestamp||data.__REALTIME_TIMESTAMP||data._SOURCE_REALTIME_TIMESTAMP||'';
+            const msg=data.MESSAGE||data.message||data.description||data.model||JSON.stringify(data).substring(0,200);
+            return`<div style="border-bottom:1px solid #222;padding:4px 0;font-size:.82rem">
+              <span style="color:#8b949e">[${esc(s.source)}]</span>
+              ${ts?'<span style="color:#58a6ff;margin:0 .5rem">'+esc(String(ts).substring(0,19))+'</span>':''}
+              <span>${esc(String(msg))}</span>
+            </div>`;
+          }).join('');
+        }else{document.getElementById('trace-list').innerHTML='<span class="loading">No trace data yet. Run the OODA daemon or make API calls to generate traces.</span>';}
+      }catch(e){document.getElementById('trace-list').innerHTML='<span class="err">Failed to load</span>';}
+    }
+
+    /* --- Memory Search --- */
+    async function searchMemory(){
+      const q=document.getElementById('mem-search-input').value.trim();
+      if(!q){document.getElementById('mem-search-results').innerHTML='<span class="warn">Enter a search term</span>';return;}
+      try{
+        const r=await fetch('/api/memory/search',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({query:q})});
+        const d=await r.json();
+        if(d.results?.length){
+          document.getElementById('mem-search-results').innerHTML=`
+            <p style="color:#8b949e;font-size:.85rem">${d.result_count} result(s) for "${esc(d.query)}"</p>
+            ${d.results.map(r=>`<div style="border:1px solid #30363d;border-radius:6px;padding:.75rem;margin-bottom:.5rem">
+              <span class="badge">${esc(r.source)}</span>
+              <pre style="margin:.5rem 0 0;white-space:pre-wrap;font-size:.8rem;color:#c9d1d9">${esc(JSON.stringify(r.data,null,2).substring(0,500))}</pre>
+            </div>`).join('')}`;
+        }else{
+          document.getElementById('mem-search-results').innerHTML='<span class="loading">No results found</span>';
+        }
+      }catch(e){document.getElementById('mem-search-results').innerHTML='<span class="err">Search failed</span>';}
+    }
+    document.getElementById('mem-search-input')?.addEventListener('keypress',e=>{if(e.key==='Enter')searchMemory();});
 
     /* --- Costs --- */
     async function fetchCosts(){

--- a/src/self_improve_executor/git_ops.rs
+++ b/src/self_improve_executor/git_ops.rs
@@ -7,8 +7,12 @@ use crate::error::{SimardError, SimardResult};
 use crate::git_guardrails;
 
 pub(crate) fn git_diff(workspace: &Path) -> SimardResult<String> {
-    git_guardrails::check_git_safety(workspace, &["diff", "HEAD"])
-        .map_err(|e| SimardError::GitCommandFailed { command: "git diff HEAD".into(), reason: e })?;
+    git_guardrails::check_git_safety(workspace, &["diff", "HEAD"]).map_err(|e| {
+        SimardError::GitCommandFailed {
+            command: "git diff HEAD".into(),
+            reason: e,
+        }
+    })?;
     let output = Command::new("git")
         .args(["diff", "HEAD"])
         .current_dir(workspace)
@@ -29,10 +33,18 @@ pub(crate) fn git_diff(workspace: &Path) -> SimardResult<String> {
 }
 
 pub(crate) fn git_commit(workspace: &Path, message: &str) -> SimardResult<()> {
-    git_guardrails::check_git_safety(workspace, &["add", "-A"])
-        .map_err(|e| SimardError::GitCommandFailed { command: "git add -A".into(), reason: e })?;
-    git_guardrails::check_git_safety(workspace, &["commit", "-m", message])
-        .map_err(|e| SimardError::GitCommandFailed { command: "git commit".into(), reason: e })?;
+    git_guardrails::check_git_safety(workspace, &["add", "-A"]).map_err(|e| {
+        SimardError::GitCommandFailed {
+            command: "git add -A".into(),
+            reason: e,
+        }
+    })?;
+    git_guardrails::check_git_safety(workspace, &["commit", "-m", message]).map_err(|e| {
+        SimardError::GitCommandFailed {
+            command: "git commit".into(),
+            reason: e,
+        }
+    })?;
     let add_output = Command::new("git")
         .args(["add", "-A"])
         .current_dir(workspace)
@@ -69,10 +81,18 @@ pub(crate) fn git_commit(workspace: &Path, message: &str) -> SimardResult<()> {
 }
 
 pub(crate) fn rollback(workspace: &Path) -> SimardResult<()> {
-    git_guardrails::check_git_safety(workspace, &["checkout", "--", "."])
-        .map_err(|e| SimardError::GitCommandFailed { command: "git checkout -- .".into(), reason: e })?;
-    git_guardrails::check_git_safety(workspace, &["clean", "-fd"])
-        .map_err(|e| SimardError::GitCommandFailed { command: "git clean -fd".into(), reason: e })?;
+    git_guardrails::check_git_safety(workspace, &["checkout", "--", "."]).map_err(|e| {
+        SimardError::GitCommandFailed {
+            command: "git checkout -- .".into(),
+            reason: e,
+        }
+    })?;
+    git_guardrails::check_git_safety(workspace, &["clean", "-fd"]).map_err(|e| {
+        SimardError::GitCommandFailed {
+            command: "git clean -fd".into(),
+            reason: e,
+        }
+    })?;
     // Restore modified tracked files.
     let checkout = Command::new("git")
         .args(["checkout", "--", "."])


### PR DESCRIPTION
## Summary
Adds full OpenTelemetry tracing pipeline, fixes dashboard data tabs, and activates the OODA systemd service.

### OTEL Tracing Pipeline
- Added `opentelemetry`, `opentelemetry-otlp`, `opentelemetry_sdk`, `tracing-opentelemetry` crates
- OTEL export layer in `main.rs` — activated by `OTEL_EXPORTER_OTLP_ENDPOINT` env var
- Spans export to any OTLP-compatible collector (Jaeger, Grafana Tempo, etc.)
- Graceful shutdown via `opentelemetry::global::shutdown_tracer_provider()`

### Dashboard Fixes
- **Traces tab**: New tab showing OTEL status, journald entries, and cost ledger spans
- **Goals tab**: Seed button for first-run (3 active + 2 backlog goals); goals now written to disk by OODA loop
- **Memory tab**: Added search input querying memory/evidence/goal records
- **Chat tab**: Added meeting help text with commands reference
- **New endpoints**: `/api/traces`, `/api/goals/seed` (POST), `/api/memory/search` (POST)

### OODA Goal Persistence
- OODA loop now writes `goal_records.json` to disk after each cycle (was only persisting to cognitive memory)
- Dashboard goals tab will now show data even without the full memory server

### Systemd
- Updated `simard-ooda.service` with `SIMARD_STATE_ROOT`, `RUST_LOG`, commented OTEL endpoint
- Service linked and enabled via `systemctl --user`

### Build
- `cargo build --release` ✅
- `cargo fmt` ✅