### PR TITLE
ci: add cargo caching to verify workflow

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     steps:
       - name: Check out repository
@@ -16,6 +17,9 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
+
+      - name: Cache cargo registry and build artifacts
+        uses: Swatinem/rust-cache@v2
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -33,6 +37,7 @@ jobs:
 
   install-smoke:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     steps:
       - name: Check out repository
@@ -40,6 +45,9 @@ jobs:
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry and build artifacts
+        uses: Swatinem/rust-cache@v2
 
       - name: Run install smoke test
         run: cargo test --test install_smoke -- --nocapture


### PR DESCRIPTION
## Problem

The `lbug` (LadybugDB) crate builds a C++ graph database engine from source via cmake. Without caching, every CI run compiles from scratch (~30+ min) and frequently times out. This broke CI for PRs #509 and #515.

## Fix

- Add `Swatinem/rust-cache@v2` to both `pre-commit` and `install-smoke` jobs (same pattern as [skwaq CI](https://github.com/rysweet/skwaq/blob/main/.github/workflows/ci.yml))
- Add `timeout-minutes: 45` to prevent runaway builds
- First run will still be slow (cold cache), subsequent runs use cached `~/.cargo` and `target/`

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>