### PR TITLE
fix(security): close dashboard auth bypass when unconfigured

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3572,6 +3572,7 @@ dependencies = [
  "serial_test",
  "tempfile",
  "tokio",
+ "tower",
  "tower-http",
  "tracing",
  "tracing-opentelemetry",

--- a/src/operator_commands_dashboard/auth.rs
+++ b/src/operator_commands_dashboard/auth.rs
@@ -81,12 +81,10 @@ pub async fn require_auth(request: Request, next: Next) -> Result<Response, Stat
         return Ok(next.run(request).await);
     }
 
-    // If no login code was configured (SIMARD_DASHBOARD_TOKEN unset + no init), allow all
+    // If no login code was configured, deny all — never silently allow traffic
     if LOGIN_CODE.get().is_none() {
-        let expected = std::env::var("SIMARD_DASHBOARD_TOKEN").unwrap_or_default();
-        if expected.is_empty() {
-            return Ok(next.run(request).await);
-        }
+        tracing::warn!("dashboard auth: no login code configured — denying request to {path}");
+        return Err(StatusCode::UNAUTHORIZED);
     }
 
     // Check session cookie
@@ -239,4 +237,9 @@ mod tests {
         // Just verify we can acquire the lock
         drop(guard);
     }
+}
+
+/// Check whether the login code has been initialized.
+pub fn is_auth_initialized() -> bool {
+    LOGIN_CODE.get().is_some()
 }

--- a/src/operator_commands_dashboard/mod.rs
+++ b/src/operator_commands_dashboard/mod.rs
@@ -5,6 +5,12 @@ use std::net::SocketAddr;
 
 pub fn serve(port: u16) -> Result<(), Box<dyn std::error::Error>> {
     let (code, loaded) = auth::init_login_code();
+
+    // Double-check: auth must be initialized before serving traffic
+    assert!(
+        auth::is_auth_initialized(),
+        "BUG: dashboard auth not initialized after init_login_code()"
+    );
     eprintln!("\n  🌲 Simard Dashboard");
     if loaded {
         eprintln!("  Login code: {code} (loaded from ~/.simard/.dashkey)");


### PR DESCRIPTION
## Problem
Dashboard could be accessed without authentication when no login code or `SIMARD_DASHBOARD_TOKEN` was configured, creating a security bypass.

## Fix
Deny all dashboard requests unless authentication is properly initialized — either via login code or environment token.

## Files Changed
- `src/operator_commands_dashboard/auth.rs`
- `src/operator_commands_dashboard/mod.rs`

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>