### PR TITLE
fix: wire consolidation_intake/persistence into session lifecycle

### DIFF
--- a/src/memory_consolidation.rs
+++ b/src/memory_consolidation.rs
@@ -211,7 +211,7 @@ pub fn consolidation_intake(
     session_id: &SessionId,
     bridge: &dyn CognitiveMemoryOps,
 ) -> SimardResult<usize> {
-    let prior_facts = bridge.search_facts("memory-store-adapter", 50, 0.0)?;
+    let prior_facts = bridge.search_facts("prior-session", 50, 0.0)?;
     let count = prior_facts.len();
     if count > 0 {
         let summary = format!("Hydrated {count} prior-session facts for cross-session recall");

--- a/src/ooda_loop/mod.rs
+++ b/src/ooda_loop/mod.rs
@@ -128,6 +128,16 @@ pub fn run_ooda_cycle(
     ) {
         eprintln!("[simard] OODA consolidation: intake failed: {e}");
     }
+    // Hydrate prior-session facts into working memory for cross-cycle recall.
+    match memory_consolidation::consolidation_intake(&cycle_session_id, &*bridges.memory) {
+        Ok(n) if n > 0 => {
+            eprintln!("[simard] OODA consolidation: hydrated {n} prior-session facts");
+        }
+        Err(e) => {
+            eprintln!("[simard] OODA consolidation: cross-session hydration failed: {e}");
+        }
+        _ => {}
+    }
 
     // --- Observe ---
     state.current_phase = OodaPhase::Observe;
@@ -314,6 +324,12 @@ pub fn run_ooda_cycle(
     }
 
     // --- Memory consolidation: persistence at cycle end ---
+    // Flush working memory to episodes before final persistence.
+    if let Err(e) =
+        memory_consolidation::consolidation_persistence(&cycle_session_id, &*bridges.memory)
+    {
+        eprintln!("[simard] OODA consolidation: flush failed: {e}");
+    }
     if let Err(e) =
         memory_consolidation::persistence_memory_operations(&cycle_session_id, &*bridges.memory)
     {

--- a/src/runtime/session.rs
+++ b/src/runtime/session.rs
@@ -19,14 +19,26 @@ impl RuntimeKernel {
         let mut session = self.new_session(objective);
 
         // --- Memory consolidation: intake at session start ---
-        if let Some(bridge) = &self.cognitive_bridge
-            && let Err(e) = crate::memory_consolidation::intake_memory_operations(
+        if let Some(bridge) = &self.cognitive_bridge {
+            if let Err(e) = crate::memory_consolidation::intake_memory_operations(
                 &session.objective,
                 &session.id,
                 &**bridge,
-            )
-        {
-            eprintln!("[simard] session consolidation: intake failed: {e}");
+            ) {
+                eprintln!("[simard] session consolidation: intake failed: {e}");
+            }
+            // Hydrate prior-session facts into working memory for cross-session recall.
+            match crate::memory_consolidation::consolidation_intake(&session.id, &**bridge) {
+                Ok(n) if n > 0 => {
+                    eprintln!("[simard] session consolidation: hydrated {n} prior-session facts");
+                }
+                Err(e) => {
+                    eprintln!(
+                        "[simard] session consolidation: cross-session hydration failed: {e}"
+                    );
+                }
+                _ => {}
+            }
         }
 
         self.persist_session_scratch(&mut session)?;
@@ -38,11 +50,18 @@ impl RuntimeKernel {
         self.persist_session_summary(&mut session, &outcome, &context)?;
 
         // --- Memory consolidation: persistence at session end ---
-        if let Some(bridge) = &self.cognitive_bridge
-            && let Err(e) =
+        if let Some(bridge) = &self.cognitive_bridge {
+            // Flush working memory to episodes before final persistence.
+            if let Err(e) =
+                crate::memory_consolidation::consolidation_persistence(&session.id, &**bridge)
+            {
+                eprintln!("[simard] session consolidation: flush failed: {e}");
+            }
+            if let Err(e) =
                 crate::memory_consolidation::persistence_memory_operations(&session.id, &**bridge)
-        {
-            eprintln!("[simard] session consolidation: persistence failed: {e}");
+            {
+                eprintln!("[simard] session consolidation: persistence failed: {e}");
+            }
         }
 
         self.complete_session(session, outcome, reflection)


### PR DESCRIPTION
## Summary

Wires the cross-session memory hydration (`consolidation_intake`) and working-memory flush (`consolidation_persistence`) functions into the session lifecycle. These functions were **defined and exported but never called**, meaning:

1. Prior-session facts were never loaded into working memory at startup
2. Working memory items weren't flushed to episodes before session shutdown

## Changes

### `src/runtime/session.rs`
- Call `consolidation_intake()` after `intake_memory_operations` at session start
- Call `consolidation_persistence()` before `persistence_memory_operations` at session end

### `src/ooda_loop/mod.rs`
- Same wiring for the OODA cycle lifecycle (intake at cycle start, flush at cycle end)

### `src/memory_consolidation.rs`
- Fix hardcoded search query in `consolidation_intake` from `'memory-store-adapter'` (placeholder) to `'prior-session'`

## Testing
- `cargo check` passes clean
- Existing unit tests for `consolidation_intake` and `consolidation_persistence` in `memory_consolidation.rs` cover the function logic
- CI will validate full test suite

Closes #524