### PR TITLE
feat: agent registry and build lock (#296, #337)

### DIFF
--- a/src/agent_registry/mod.rs
+++ b/src/agent_registry/mod.rs
@@ -1,0 +1,8 @@
+mod registry;
+#[cfg(test)]
+mod tests;
+
+pub use registry::{
+    AgentEntry, AgentRegistry, AgentState, FileBackedAgentRegistry, ResourceUsage, hostname,
+    self_entry, self_resource_usage,
+};

--- a/src/agent_registry/registry.rs
+++ b/src/agent_registry/registry.rs
@@ -1,0 +1,224 @@
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::error::SimardError;
+
+/// State of a registered Simard agent process.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentState {
+    Starting,
+    Running,
+    Idle,
+    ShuttingDown,
+    Dead,
+}
+
+/// Snapshot of resource usage at last heartbeat.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ResourceUsage {
+    pub rss_bytes: Option<u64>,
+    pub cpu_percent: Option<f32>,
+}
+
+/// A single registered agent process.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AgentEntry {
+    pub id: String,
+    pub pid: u32,
+    pub host: String,
+    pub start_time: DateTime<Utc>,
+    pub last_heartbeat: DateTime<Utc>,
+    pub state: AgentState,
+    pub role: String,
+    pub resources: ResourceUsage,
+}
+
+/// Trait for registry backends.
+pub trait AgentRegistry {
+    fn register(&self, entry: AgentEntry) -> Result<(), SimardError>;
+    fn heartbeat(
+        &self,
+        id: &str,
+        state: AgentState,
+        resources: ResourceUsage,
+    ) -> Result<(), SimardError>;
+    fn deregister(&self, id: &str) -> Result<(), SimardError>;
+    fn list(&self) -> Result<Vec<AgentEntry>, SimardError>;
+    fn get(&self, id: &str) -> Result<Option<AgentEntry>, SimardError>;
+    /// Reap entries whose process is no longer alive (local only).
+    fn reap_dead(&self) -> Result<usize, SimardError>;
+}
+
+/// File-backed registry stored as JSON in `~/.simard/agent_registry.json`.
+pub struct FileBackedAgentRegistry {
+    path: PathBuf,
+}
+
+impl FileBackedAgentRegistry {
+    pub fn new(state_root: &Path) -> Self {
+        Self {
+            path: state_root.join("agent_registry.json"),
+        }
+    }
+
+    pub fn default_path() -> PathBuf {
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/home/azureuser".to_string());
+        PathBuf::from(home).join(".simard")
+    }
+
+    fn load(&self) -> Result<Vec<AgentEntry>, SimardError> {
+        if !self.path.exists() {
+            return Ok(Vec::new());
+        }
+        let content =
+            std::fs::read_to_string(&self.path).map_err(|e| SimardError::PersistentStoreIo {
+                store: "agent_registry".into(),
+                action: "read".into(),
+                path: self.path.clone(),
+                reason: e.to_string(),
+            })?;
+        if content.trim().is_empty() {
+            return Ok(Vec::new());
+        }
+        serde_json::from_str(&content).map_err(|e| SimardError::PersistentStoreIo {
+            store: "agent_registry".into(),
+            action: "parse".into(),
+            path: self.path.clone(),
+            reason: e.to_string(),
+        })
+    }
+
+    fn save(&self, entries: &[AgentEntry]) -> Result<(), SimardError> {
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| SimardError::PersistentStoreIo {
+                store: "agent_registry".into(),
+                action: "mkdir".into(),
+                path: parent.to_path_buf(),
+                reason: e.to_string(),
+            })?;
+        }
+        let json =
+            serde_json::to_string_pretty(&entries).map_err(|e| SimardError::PersistentStoreIo {
+                store: "agent_registry".into(),
+                action: "serialize".into(),
+                path: self.path.clone(),
+                reason: e.to_string(),
+            })?;
+        std::fs::write(&self.path, json).map_err(|e| SimardError::PersistentStoreIo {
+            store: "agent_registry".into(),
+            action: "write".into(),
+            path: self.path.clone(),
+            reason: e.to_string(),
+        })
+    }
+}
+
+impl AgentRegistry for FileBackedAgentRegistry {
+    fn register(&self, entry: AgentEntry) -> Result<(), SimardError> {
+        let mut entries = self.load()?;
+        entries.retain(|e| e.id != entry.id);
+        entries.push(entry);
+        self.save(&entries)
+    }
+
+    fn heartbeat(
+        &self,
+        id: &str,
+        state: AgentState,
+        resources: ResourceUsage,
+    ) -> Result<(), SimardError> {
+        let mut entries = self.load()?;
+        if let Some(entry) = entries.iter_mut().find(|e| e.id == id) {
+            entry.last_heartbeat = Utc::now();
+            entry.state = state;
+            entry.resources = resources;
+            self.save(&entries)
+        } else {
+            Err(SimardError::PersistentStoreIo {
+                store: "agent_registry".into(),
+                action: "heartbeat".into(),
+                path: self.path.clone(),
+                reason: format!("agent {id} not found in registry"),
+            })
+        }
+    }
+
+    fn deregister(&self, id: &str) -> Result<(), SimardError> {
+        let mut entries = self.load()?;
+        entries.retain(|e| e.id != id);
+        self.save(&entries)
+    }
+
+    fn list(&self) -> Result<Vec<AgentEntry>, SimardError> {
+        self.load()
+    }
+
+    fn get(&self, id: &str) -> Result<Option<AgentEntry>, SimardError> {
+        let entries = self.load()?;
+        Ok(entries.into_iter().find(|e| e.id == id))
+    }
+
+    fn reap_dead(&self) -> Result<usize, SimardError> {
+        let mut entries = self.load()?;
+        let before = entries.len();
+
+        let local_hostname = hostname();
+        entries.retain(|entry| {
+            if entry.host != local_hostname {
+                return true; // can't verify remote processes
+            }
+            is_pid_alive(entry.pid)
+        });
+
+        let reaped = before - entries.len();
+        if reaped > 0 {
+            self.save(&entries)?;
+        }
+        Ok(reaped)
+    }
+}
+
+/// Read the local hostname.
+pub fn hostname() -> String {
+    std::fs::read_to_string("/etc/hostname")
+        .unwrap_or_else(|_| "unknown".into())
+        .trim()
+        .to_string()
+}
+
+/// Check whether a PID is still alive on this host.
+fn is_pid_alive(pid: u32) -> bool {
+    Path::new(&format!("/proc/{pid}")).exists()
+}
+
+/// Gather resource usage for the current process via /proc/self.
+pub fn self_resource_usage() -> ResourceUsage {
+    let rss_bytes = std::fs::read_to_string("/proc/self/statm")
+        .ok()
+        .and_then(|s| {
+            let pages: u64 = s.split_whitespace().nth(1)?.parse().ok()?;
+            Some(pages * 4096) // page size
+        });
+
+    ResourceUsage {
+        rss_bytes,
+        cpu_percent: None,
+    }
+}
+
+/// Create an `AgentEntry` for the current process.
+pub fn self_entry(role: &str) -> AgentEntry {
+    AgentEntry {
+        id: format!("{}-{}", role, std::process::id()),
+        pid: std::process::id(),
+        host: hostname(),
+        start_time: Utc::now(),
+        last_heartbeat: Utc::now(),
+        state: AgentState::Running,
+        role: role.to_string(),
+        resources: self_resource_usage(),
+    }
+}

--- a/src/agent_registry/tests.rs
+++ b/src/agent_registry/tests.rs
@@ -1,0 +1,141 @@
+use super::*;
+use chrono::Utc;
+use tempfile::TempDir;
+
+fn test_registry() -> (TempDir, FileBackedAgentRegistry) {
+    let dir = TempDir::new().unwrap();
+    let reg = FileBackedAgentRegistry::new(dir.path());
+    (dir, reg)
+}
+
+fn sample_entry(id: &str) -> AgentEntry {
+    AgentEntry {
+        id: id.to_string(),
+        pid: std::process::id(),
+        host: "test-host".into(),
+        start_time: Utc::now(),
+        last_heartbeat: Utc::now(),
+        state: AgentState::Running,
+        role: "operator".into(),
+        resources: ResourceUsage {
+            rss_bytes: Some(1024),
+            cpu_percent: None,
+        },
+    }
+}
+
+#[test]
+fn register_and_list() {
+    let (_dir, reg) = test_registry();
+    reg.register(sample_entry("a1")).unwrap();
+    reg.register(sample_entry("a2")).unwrap();
+
+    let entries = reg.list().unwrap();
+    assert_eq!(entries.len(), 2);
+}
+
+#[test]
+fn deregister_removes_entry() {
+    let (_dir, reg) = test_registry();
+    reg.register(sample_entry("a1")).unwrap();
+    reg.deregister("a1").unwrap();
+
+    let entries = reg.list().unwrap();
+    assert!(entries.is_empty());
+}
+
+#[test]
+fn heartbeat_updates_state() {
+    let (_dir, reg) = test_registry();
+    reg.register(sample_entry("a1")).unwrap();
+    reg.heartbeat(
+        "a1",
+        AgentState::Idle,
+        ResourceUsage {
+            rss_bytes: Some(2048),
+            cpu_percent: Some(1.5),
+        },
+    )
+    .unwrap();
+
+    let entry = reg.get("a1").unwrap().unwrap();
+    assert_eq!(entry.state, AgentState::Idle);
+    assert_eq!(entry.resources.rss_bytes, Some(2048));
+}
+
+#[test]
+fn heartbeat_missing_entry_returns_error() {
+    let (_dir, reg) = test_registry();
+    let result = reg.heartbeat(
+        "nonexistent",
+        AgentState::Running,
+        ResourceUsage {
+            rss_bytes: None,
+            cpu_percent: None,
+        },
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn reap_dead_removes_defunct_pids() {
+    let (_dir, reg) = test_registry();
+    let mut entry = sample_entry("dead-proc");
+    entry.pid = 999_999_999; // very unlikely to be alive
+    entry.host = super::registry::hostname();
+    reg.register(entry).unwrap();
+
+    let reaped = reg.reap_dead().unwrap();
+    assert_eq!(reaped, 1);
+    assert!(reg.list().unwrap().is_empty());
+}
+
+#[test]
+fn empty_registry_loads_clean() {
+    let (_dir, reg) = test_registry();
+    let entries = reg.list().unwrap();
+    assert!(entries.is_empty());
+}
+
+#[test]
+fn get_returns_none_for_missing() {
+    let (_dir, reg) = test_registry();
+    assert!(reg.get("nope").unwrap().is_none());
+}
+
+#[test]
+fn duplicate_register_replaces() {
+    let (_dir, reg) = test_registry();
+    let e1 = sample_entry("dup");
+    reg.register(e1).unwrap();
+    let mut e2 = sample_entry("dup");
+    e2.role = "engineer".into();
+    reg.register(e2).unwrap();
+
+    let entries = reg.list().unwrap();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].role, "engineer");
+}
+
+#[test]
+fn default_path_is_sensible() {
+    let p = FileBackedAgentRegistry::default_path();
+    assert!(p.to_string_lossy().contains(".simard"));
+}
+
+#[test]
+fn self_entry_creates_valid_entry() {
+    let entry = super::registry::self_entry("operator");
+    assert_eq!(entry.pid, std::process::id());
+    assert_eq!(entry.role, "operator");
+    assert_eq!(entry.state, AgentState::Running);
+}
+
+#[test]
+fn self_resource_usage_returns_some_rss() {
+    let usage = super::registry::self_resource_usage();
+    // On Linux /proc/self/statm should be readable
+    if cfg!(target_os = "linux") {
+        assert!(usage.rss_bytes.is_some());
+    }
+}

--- a/src/build_lock/lock.rs
+++ b/src/build_lock/lock.rs
@@ -1,0 +1,179 @@
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use crate::error::SimardError;
+
+const LOCK_FILENAME: &str = "cargo_build.lock";
+const STALE_THRESHOLD_SECS: u64 = 600; // 10 minutes — assume dead build
+
+/// Manages exclusive access to cargo builds via a lock file.
+///
+/// Only one cargo build can run at a time on a host. Others block
+/// with FIFO-like semantics (poll + sleep) until the lock is released.
+pub struct BuildLock {
+    lock_path: PathBuf,
+}
+
+/// RAII guard — releases the lock file on drop.
+pub struct BuildLockGuard {
+    lock_path: PathBuf,
+}
+
+impl Drop for BuildLockGuard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.lock_path);
+    }
+}
+
+impl BuildLock {
+    pub fn new(state_root: &Path) -> Self {
+        Self {
+            lock_path: state_root.join(LOCK_FILENAME),
+        }
+    }
+
+    /// Default state root (`~/.simard`).
+    pub fn default_state_root() -> PathBuf {
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/home/azureuser".to_string());
+        PathBuf::from(home).join(".simard")
+    }
+
+    /// Attempt to acquire the build lock immediately. Returns `None` if held.
+    pub fn try_acquire(&self) -> Result<Option<BuildLockGuard>, SimardError> {
+        self.reap_stale()?;
+
+        if self.lock_path.exists() {
+            return Ok(None);
+        }
+
+        self.write_lock_file()?;
+        Ok(Some(BuildLockGuard {
+            lock_path: self.lock_path.clone(),
+        }))
+    }
+
+    /// Block until the build lock is acquired (with timeout).
+    pub fn acquire(&self, timeout: Duration) -> Result<BuildLockGuard, SimardError> {
+        let start = Instant::now();
+        let poll_interval = Duration::from_millis(500);
+
+        loop {
+            if let Some(guard) = self.try_acquire()? {
+                return Ok(guard);
+            }
+
+            if start.elapsed() >= timeout {
+                let holder = self.current_holder();
+                return Err(SimardError::CommandTimeout {
+                    action: format!(
+                        "acquire cargo build lock (held by {})",
+                        holder.unwrap_or_else(|| "unknown".into())
+                    ),
+                    timeout_secs: timeout.as_secs(),
+                });
+            }
+
+            std::thread::sleep(poll_interval);
+        }
+    }
+
+    /// Return information about the current lock holder.
+    pub fn current_holder(&self) -> Option<String> {
+        std::fs::read_to_string(&self.lock_path).ok()
+    }
+
+    /// Is the lock currently held?
+    pub fn is_locked(&self) -> bool {
+        self.lock_path.exists()
+    }
+
+    /// Force-release a stale lock (e.g., from a crashed process).
+    pub fn force_release(&self) -> Result<bool, SimardError> {
+        if self.lock_path.exists() {
+            std::fs::remove_file(&self.lock_path).map_err(|e| SimardError::PersistentStoreIo {
+                store: "build_lock".into(),
+                action: "force_release".into(),
+                path: self.lock_path.clone(),
+                reason: e.to_string(),
+            })?;
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn write_lock_file(&self) -> Result<(), SimardError> {
+        if let Some(parent) = self.lock_path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| SimardError::PersistentStoreIo {
+                store: "build_lock".into(),
+                action: "mkdir".into(),
+                path: parent.to_path_buf(),
+                reason: e.to_string(),
+            })?;
+        }
+
+        let info = format!(
+            "pid={}\nhost={}\nstarted={}\n",
+            std::process::id(),
+            crate::agent_registry::hostname(),
+            chrono::Utc::now().to_rfc3339(),
+        );
+        std::fs::write(&self.lock_path, info).map_err(|e| SimardError::PersistentStoreIo {
+            store: "build_lock".into(),
+            action: "write".into(),
+            path: self.lock_path.clone(),
+            reason: e.to_string(),
+        })
+    }
+
+    fn reap_stale(&self) -> Result<(), SimardError> {
+        if !self.lock_path.exists() {
+            return Ok(());
+        }
+        let metadata =
+            std::fs::metadata(&self.lock_path).map_err(|e| SimardError::PersistentStoreIo {
+                store: "build_lock".into(),
+                action: "stat".into(),
+                path: self.lock_path.clone(),
+                reason: e.to_string(),
+            })?;
+
+        let age = metadata
+            .modified()
+            .ok()
+            .and_then(|t| t.elapsed().ok())
+            .unwrap_or(Duration::ZERO);
+
+        if age > Duration::from_secs(STALE_THRESHOLD_SECS) {
+            tracing::warn!("Reaping stale cargo build lock (age: {}s)", age.as_secs());
+            std::fs::remove_file(&self.lock_path).map_err(|e| SimardError::PersistentStoreIo {
+                store: "build_lock".into(),
+                action: "reap_stale".into(),
+                path: self.lock_path.clone(),
+                reason: e.to_string(),
+            })?;
+        } else {
+            // Check if holding PID is still alive (local only)
+            if let Ok(content) = std::fs::read_to_string(&self.lock_path)
+                && let Some(pid_str) = content
+                    .lines()
+                    .find(|l| l.starts_with("pid="))
+                    .and_then(|l| l.strip_prefix("pid="))
+                && let Ok(pid) = pid_str.parse::<u32>()
+                && !Path::new(&format!("/proc/{pid}")).exists()
+            {
+                tracing::warn!("Reaping build lock held by dead PID {pid}");
+                std::fs::remove_file(&self.lock_path).map_err(|e| {
+                    SimardError::PersistentStoreIo {
+                        store: "build_lock".into(),
+                        action: "reap_dead_holder".into(),
+                        path: self.lock_path.clone(),
+                        reason: e.to_string(),
+                    }
+                })?;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/build_lock/mod.rs
+++ b/src/build_lock/mod.rs
@@ -1,0 +1,5 @@
+mod lock;
+#[cfg(test)]
+mod tests;
+
+pub use lock::{BuildLock, BuildLockGuard};

--- a/src/build_lock/tests.rs
+++ b/src/build_lock/tests.rs
@@ -1,0 +1,92 @@
+use super::*;
+use std::time::Duration;
+
+fn test_lock() -> (tempfile::TempDir, BuildLock) {
+    let dir = tempfile::TempDir::new().unwrap();
+    let bl = BuildLock::new(dir.path());
+    (dir, bl)
+}
+
+#[test]
+fn try_acquire_succeeds_when_unlocked() {
+    let (_dir, bl) = test_lock();
+    let guard = bl.try_acquire().unwrap();
+    assert!(guard.is_some());
+    assert!(bl.is_locked());
+}
+
+#[test]
+fn try_acquire_returns_none_when_locked() {
+    let (_dir, bl) = test_lock();
+    let _guard = bl.try_acquire().unwrap().unwrap();
+    let second = bl.try_acquire().unwrap();
+    assert!(second.is_none());
+}
+
+#[test]
+fn drop_guard_releases_lock() {
+    let (_dir, bl) = test_lock();
+    {
+        let _guard = bl.try_acquire().unwrap().unwrap();
+        assert!(bl.is_locked());
+    }
+    assert!(!bl.is_locked());
+}
+
+#[test]
+fn acquire_with_timeout_succeeds_when_free() {
+    let (_dir, bl) = test_lock();
+    let _guard = bl.acquire(Duration::from_secs(1)).unwrap();
+    assert!(bl.is_locked());
+}
+
+#[test]
+fn acquire_with_timeout_fails_when_locked() {
+    let (_dir, bl) = test_lock();
+    let _guard = bl.try_acquire().unwrap().unwrap();
+    let result = bl.acquire(Duration::from_millis(100));
+    assert!(result.is_err());
+}
+
+#[test]
+fn force_release_clears_lock() {
+    let (_dir, bl) = test_lock();
+    let _guard = bl.try_acquire().unwrap().unwrap();
+    // manually leak the guard so we can test force_release
+    std::mem::forget(_guard);
+
+    assert!(bl.is_locked());
+    assert!(bl.force_release().unwrap());
+    assert!(!bl.is_locked());
+}
+
+#[test]
+fn force_release_when_not_locked() {
+    let (_dir, bl) = test_lock();
+    assert!(!bl.force_release().unwrap());
+}
+
+#[test]
+fn current_holder_returns_info() {
+    let (_dir, bl) = test_lock();
+    assert!(bl.current_holder().is_none());
+    let _guard = bl.try_acquire().unwrap().unwrap();
+    let info = bl.current_holder().unwrap();
+    assert!(info.contains("pid="));
+}
+
+#[test]
+fn stale_lock_from_dead_pid_is_reaped() {
+    let (dir, _bl) = test_lock();
+    // Manually write a lock with a dead PID
+    let lock_path = dir.path().join("cargo_build.lock");
+    std::fs::write(
+        &lock_path,
+        "pid=999999999\nhost=test\nstarted=2024-01-01T00:00:00Z\n",
+    )
+    .unwrap();
+
+    let bl = BuildLock::new(dir.path());
+    let guard = bl.try_acquire().unwrap();
+    assert!(guard.is_some(), "Should reap dead PID lock and acquire");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod agent_goal_assignment;
 pub mod agent_program;
+pub mod agent_registry;
 pub mod agent_roles;
 pub mod agent_supervisor;
 pub mod base_type_claude_agent_sdk;
@@ -15,6 +16,7 @@ pub mod bridge;
 pub mod bridge_circuit;
 pub mod bridge_launcher;
 pub mod bridge_subprocess;
+pub mod build_lock;
 pub mod cmd_cleanup;
 pub mod cmd_ensure_deps;
 pub mod cmd_install;
@@ -100,6 +102,10 @@ pub use agent_program::{
     AgentProgram, AgentProgramContext, AgentProgramMemoryRecord, ImprovementCuratorProgram,
     MeetingFacilitatorProgram, ObjectiveRelayProgram,
 };
+pub use agent_registry::{
+    AgentEntry, AgentRegistry, AgentState, FileBackedAgentRegistry, ResourceUsage, hostname,
+    self_entry, self_resource_usage,
+};
 pub use agent_roles::{AgentRole, identity_for_role, role_for_objective};
 pub use agent_supervisor::{
     HeartbeatStatus, SubordinateConfig, SubordinateHandle, check_heartbeat, kill_subordinate,
@@ -133,6 +139,7 @@ pub use bridge::{
 };
 pub use bridge_circuit::{CircuitBreakerConfig, CircuitBreakerTransport, CircuitState};
 pub use bridge_subprocess::{InMemoryBridgeTransport, SubprocessBridgeTransport};
+pub use build_lock::{BuildLock, BuildLockGuard};
 pub use cognitive_memory::{CognitiveMemoryOps, NativeCognitiveMemory};
 pub use cost_tracking::{
     CostEntry, CostSummary, daily_summary, estimate_tokens, record_cost, weekly_summary,

--- a/src/operator_commands_dashboard/routes.rs
+++ b/src/operator_commands_dashboard/routes.rs
@@ -2,13 +2,14 @@ use axum::{
     Json, Router,
     extract::ws::{Message, WebSocket, WebSocketUpgrade},
     middleware, response,
-    routing::get,
-    routing::post,
+    routing::{get, post},
 };
 use serde_json::{Value, json};
 
 use super::auth::{require_auth, try_login};
 use crate::cognitive_memory::{CognitiveMemoryOps, NativeCognitiveMemory};
+use crate::agent_registry::{AgentRegistry, FileBackedAgentRegistry};
+use crate::build_lock::BuildLock;
 use crate::error::{SimardError, SimardResult};
 
 pub fn build_router() -> Router {
@@ -27,6 +28,15 @@ pub fn build_router() -> Router {
         )
         .route("/api/logs", get(logs))
         .route("/api/processes", get(processes))
+        .route(
+            "/api/registry",
+            get(registry_list)
+                .post(registry_register)
+                .delete(registry_deregister),
+        )
+        .route("/api/registry/reap", post(registry_reap))
+        .route("/api/build-lock", get(build_lock_status))
+        .route("/api/build-lock/release", post(build_lock_force_release))
         .route("/api/memory", get(memory_metrics))
         .route("/api/memory/search", post(memory_search))
         .route("/api/traces", get(traces))
@@ -989,6 +999,84 @@ async fn processes() -> Json<Value> {
         "count": procs.len(),
         "timestamp": chrono::Utc::now().to_rfc3339(),
     }))
+}
+
+// ---------------------------------------------------------------------------
+// Agent Registry API (#296)
+// ---------------------------------------------------------------------------
+
+async fn registry_list() -> Json<Value> {
+    let reg = FileBackedAgentRegistry::new(&resolve_state_root());
+    match reg.list() {
+        Ok(entries) => {
+            let serialized: Vec<Value> = entries
+                .iter()
+                .filter_map(|e| serde_json::to_value(e).ok())
+                .collect();
+            Json(json!({
+                "agents": serialized,
+                "count": serialized.len(),
+                "timestamp": chrono::Utc::now().to_rfc3339(),
+            }))
+        }
+        Err(e) => Json(json!({
+            "error": e.to_string(),
+            "agents": [],
+            "count": 0,
+        })),
+    }
+}
+
+async fn registry_register(Json(body): Json<Value>) -> Json<Value> {
+    let reg = FileBackedAgentRegistry::new(&resolve_state_root());
+    let entry: crate::agent_registry::AgentEntry = match serde_json::from_value(body) {
+        Ok(e) => e,
+        Err(e) => {
+            return Json(json!({"ok": false, "error": format!("invalid entry: {e}")}));
+        }
+    };
+    match reg.register(entry) {
+        Ok(()) => Json(json!({"ok": true})),
+        Err(e) => Json(json!({"ok": false, "error": e.to_string()})),
+    }
+}
+
+async fn registry_deregister(Json(body): Json<Value>) -> Json<Value> {
+    let id = body.get("id").and_then(|v| v.as_str()).unwrap_or_default();
+    let reg = FileBackedAgentRegistry::new(&resolve_state_root());
+    match reg.deregister(id) {
+        Ok(()) => Json(json!({"ok": true})),
+        Err(e) => Json(json!({"ok": false, "error": e.to_string()})),
+    }
+}
+
+async fn registry_reap() -> Json<Value> {
+    let reg = FileBackedAgentRegistry::new(&resolve_state_root());
+    match reg.reap_dead() {
+        Ok(count) => Json(json!({"ok": true, "reaped": count})),
+        Err(e) => Json(json!({"ok": false, "error": e.to_string()})),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Build Lock API (#337)
+// ---------------------------------------------------------------------------
+
+async fn build_lock_status() -> Json<Value> {
+    let bl = BuildLock::new(&resolve_state_root());
+    Json(json!({
+        "locked": bl.is_locked(),
+        "holder": bl.current_holder(),
+        "timestamp": chrono::Utc::now().to_rfc3339(),
+    }))
+}
+
+async fn build_lock_force_release() -> Json<Value> {
+    let bl = BuildLock::new(&resolve_state_root());
+    match bl.force_release() {
+        Ok(was_locked) => Json(json!({"ok": true, "was_locked": was_locked})),
+        Err(e) => Json(json!({"ok": false, "error": e.to_string()})),
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #296 (Agent Registry) and #337 (Cargo Process Accumulation).

### Agent Registry (#296)
- New `agent_registry` module with `FileBackedAgentRegistry` — file-based at `~/.simard/agent_registry.json`
- Tracks PID, host, start time, state, resource usage (RSS) per agent
- Heartbeat updates, dead-process reaping via `/proc` checks
- Dashboard API: `GET/POST/DELETE /api/registry`, `POST /api/registry/reap`
- Helper functions `self_entry()` and `self_resource_usage()` for agents to self-register

### Build Lock (#337)
- New `build_lock` module with RAII `BuildLockGuard` — prevents concurrent cargo builds
- Lock file at `~/.simard/cargo_build.lock` with PID/host/timestamp
- Stale lock detection: reaps dead PIDs and 10-minute-old locks
- Blocking `acquire(timeout)` for FIFO-like queuing
- Dashboard API: `GET /api/build-lock`, `POST /api/build-lock/release`

### Validation
- `cargo check` ✅
- `cargo clippy -- -D warnings` ✅  
- `cargo fmt` ✅
- Tests included for both modules (11 agent_registry tests, 9 build_lock tests)

Note: `cargo test` cannot run in CI due to pre-existing infrastructure issues (lbug C++ build failures, corrupted target dirs). The modules compile and pass clippy cleanly.