### PR TITLE
fix: dashboard tabs — costs formatting, logs wiring, goals from memory, native memory stats (#413, #414, #415, #419)

### DIFF
--- a/src/meeting_backend/mod.rs
+++ b/src/meeting_backend/mod.rs
@@ -9,6 +9,8 @@ pub mod persist;
 pub mod types;
 
 use std::fmt::Write as _;
+use std::sync::mpsc;
+use std::time::Duration;
 
 use chrono::Utc;
 use tracing::{debug, info, warn};
@@ -27,6 +29,9 @@ const MAX_HISTORY: usize = 500;
 
 /// Number of recent messages included verbatim in the LLM prompt.
 const RECENT_WINDOW: usize = 30;
+
+/// Maximum time to wait for LLM summary generation before falling back.
+const SUMMARY_TIMEOUT: Duration = Duration::from_secs(90);
 
 /// The unified meeting backend.
 ///
@@ -126,6 +131,9 @@ impl MeetingBackend {
 
         // Append assistant response
         self.push_message(Role::Assistant, response_text.clone());
+
+        // Auto-save transcript after every turn so killed meetings don't lose data
+        self.auto_save_transcript();
 
         debug!(messages = self.history.len(), "Meeting turn completed");
 
@@ -272,7 +280,7 @@ impl MeetingBackend {
         preamble
     }
 
-    /// Ask the LLM for a summary of the conversation.
+    /// Ask the LLM for a summary with a timeout to prevent `/close` from hanging.
     fn generate_summary(&mut self) -> String {
         if self.history.is_empty() {
             return "Empty meeting — no messages exchanged.".to_string();
@@ -292,8 +300,32 @@ impl MeetingBackend {
             prompt_preamble: preamble,
         };
 
-        match self.agent.run_turn(turn_input) {
-            Ok(outcome) => {
+        info!(
+            timeout_secs = SUMMARY_TIMEOUT.as_secs(),
+            "Starting summary generation"
+        );
+        let start = std::time::Instant::now();
+
+        // Run the LLM call in a scoped thread with a timeout so /close never hangs.
+        let result = {
+            let (tx, rx) = mpsc::channel();
+            let agent = &mut *self.agent;
+
+            std::thread::scope(|s| {
+                s.spawn(move || {
+                    let r = agent.run_turn(turn_input);
+                    let _ = tx.send(r);
+                });
+                rx.recv_timeout(SUMMARY_TIMEOUT)
+            })
+        };
+
+        match result {
+            Ok(Ok(outcome)) => {
+                info!(
+                    elapsed_ms = start.elapsed().as_millis() as u64,
+                    "Summary generated"
+                );
                 let text = extract_response(&outcome);
                 if text.is_empty() {
                     warn!("LLM returned empty summary — using metadata summary");
@@ -302,8 +334,16 @@ impl MeetingBackend {
                     text
                 }
             }
-            Err(e) => {
-                warn!("LLM summarization failed: {e} — using metadata summary");
+            Ok(Err(e)) => {
+                warn!(elapsed_ms = start.elapsed().as_millis() as u64, error = %e, "LLM summarization failed");
+                self.metadata_summary()
+            }
+            Err(_) => {
+                warn!(
+                    timeout_secs = SUMMARY_TIMEOUT.as_secs(),
+                    elapsed_ms = start.elapsed().as_millis() as u64,
+                    "Summary generation timed out — saving transcript without LLM summary"
+                );
                 self.metadata_summary()
             }
         }
@@ -329,14 +369,114 @@ impl MeetingBackend {
             .map(|start| Utc::now().signed_duration_since(start).num_seconds().max(0) as u64)
             .unwrap_or(0)
     }
+
+    /// Save an in-progress transcript after every turn so killed meetings
+    /// don't lose data. Errors are logged but not propagated.
+    fn auto_save_transcript(&self) {
+        let transcript = MeetingTranscript {
+            topic: self.topic.clone(),
+            started_at: self.started_at.clone(),
+            closed_at: String::new(),
+            duration_secs: self.elapsed_secs(),
+            summary: "[in-progress — meeting still open]".to_string(),
+            messages: self.history.clone(),
+        };
+        match persist::write_auto_save(&transcript) {
+            Ok(p) => debug!(path = %p.display(), "Auto-saved transcript"),
+            Err(e) => warn!("Auto-save failed (meeting continues): {e}"),
+        }
+    }
 }
 
-/// Extract the conversational response text from a `BaseTypeOutcome`.
-///
-/// The `execution_summary` field is used by all adapters to return the LLM's
-/// natural-language response.
+/// Extract the conversational response text from a `BaseTypeOutcome`,
+/// stripping agentic tool-call log noise that garbles terminal display.
 fn extract_response(outcome: &BaseTypeOutcome) -> String {
-    outcome.execution_summary.trim().to_string()
+    sanitize_agent_output(outcome.execution_summary.trim())
+}
+
+/// Remove agentic tool-call log lines and XML-style tool blocks from LLM
+/// output so the terminal displays only the conversational content.
+fn sanitize_agent_output(raw: &str) -> String {
+    let mut result = String::with_capacity(raw.len());
+    let mut in_tool_block = false;
+    let mut consecutive_blank = 0u8;
+
+    for line in raw.lines() {
+        let trimmed = line.trim();
+
+        if is_tool_block_open(trimmed) {
+            in_tool_block = true;
+            continue;
+        }
+
+        if in_tool_block {
+            if is_tool_block_close(trimmed) {
+                in_tool_block = false;
+            }
+            continue;
+        }
+
+        if is_tool_call_line(trimmed) {
+            continue;
+        }
+
+        if trimmed.is_empty() {
+            consecutive_blank += 1;
+            if consecutive_blank <= 2 {
+                result.push('\n');
+            }
+            continue;
+        }
+        consecutive_blank = 0;
+
+        result.push_str(line);
+        result.push('\n');
+    }
+
+    result.trim().to_string()
+}
+
+fn is_tool_block_open(trimmed: &str) -> bool {
+    for tag in &[
+        "<tool_call",
+        "<tool_result",
+        "<function_call",
+        "<invoke",
+        "<function",
+    ] {
+        if trimmed.starts_with(tag) {
+            return true;
+        }
+    }
+    false
+}
+
+fn is_tool_block_close(trimmed: &str) -> bool {
+    for tag in &[
+        "</tool_call",
+        "</tool_result",
+        "</function_call",
+        "</invoke",
+        "</function",
+    ] {
+        if trimmed.contains(tag) {
+            return true;
+        }
+    }
+    false
+}
+
+fn is_tool_call_line(trimmed: &str) -> bool {
+    if trimmed.starts_with("[tool_call:") || trimmed.starts_with("[tool_result:") {
+        return true;
+    }
+    if trimmed.starts_with("[Tool ") && trimmed.contains("executed") {
+        return true;
+    }
+    if trimmed.starts_with("Running tool:") || trimmed.starts_with("Tool output:") {
+        return true;
+    }
+    false
 }
 
 #[cfg(test)]
@@ -502,5 +642,57 @@ mod tests {
             evidence: Vec::new(),
         };
         assert_eq!(extract_response(&outcome), "hello world");
+    }
+
+    #[test]
+    fn sanitize_strips_tool_call_lines() {
+        let input = "Here is the answer.\n[tool_call: search_files]\n[tool_result: found 3 files]\nThe files are ready.";
+        let result = sanitize_agent_output(input);
+        assert!(result.contains("Here is the answer."), "result: {result}");
+        assert!(result.contains("The files are ready."), "result: {result}");
+        assert!(!result.contains("[tool_call:"), "result: {result}");
+        assert!(!result.contains("[tool_result:"), "result: {result}");
+    }
+
+    #[test]
+    fn sanitize_strips_xml_tool_blocks() {
+        let input = "Before block.\n<tool_call>\ninternal stuff\n</tool_call>\nAfter block.";
+        let result = sanitize_agent_output(input);
+        assert!(result.contains("Before block."), "result: {result}");
+        assert!(result.contains("After block."), "result: {result}");
+        assert!(!result.contains("internal stuff"), "result: {result}");
+    }
+
+    #[test]
+    fn sanitize_passes_clean_text() {
+        let input = "Normal response.\nWith multiple lines.\n\nAnd paragraphs.";
+        let result = sanitize_agent_output(input);
+        assert!(result.contains("Normal response."), "result: {result}");
+        assert!(result.contains("With multiple lines."), "result: {result}");
+        assert!(result.contains("And paragraphs."), "result: {result}");
+    }
+
+    #[test]
+    fn sanitize_collapses_excessive_blanks() {
+        let input = "Line 1\n\n\n\n\n\nLine 2";
+        let result = sanitize_agent_output(input);
+        assert!(!result.contains("\n\n\n\n"), "too many blanks: {result}");
+        assert!(result.contains("Line 1"), "result: {result}");
+        assert!(result.contains("Line 2"), "result: {result}");
+    }
+
+    #[test]
+    fn sanitize_handles_empty_input() {
+        assert_eq!(sanitize_agent_output(""), "");
+        assert_eq!(sanitize_agent_output("   "), "");
+    }
+
+    #[test]
+    fn auto_save_does_not_panic() {
+        let agent = MockAgent::new("noted");
+        let mut backend =
+            MeetingBackend::new_session("AutoSave Test", Box::new(agent), None, String::new());
+        backend.send_message("Test message").unwrap();
+        assert_eq!(backend.status().message_count, 2);
     }
 }

--- a/src/meeting_backend/persist.rs
+++ b/src/meeting_backend/persist.rs
@@ -91,6 +91,46 @@ pub fn write_transcript(transcript: &MeetingTranscript) -> SimardResult<PathBuf>
     Ok(path)
 }
 
+/// Write an auto-save transcript to `~/.simard/meetings/_autosave_{topic}.json`.
+///
+/// Overwrites the same file each turn. The final `write_transcript()` on
+/// `/close` writes the canonical timestamped file.
+pub fn write_auto_save(transcript: &MeetingTranscript) -> SimardResult<PathBuf> {
+    let dir = meetings_dir();
+    std::fs::create_dir_all(&dir).map_err(|e| SimardError::ActionExecutionFailed {
+        action: "create-meetings-dir".to_string(),
+        reason: e.to_string(),
+    })?;
+
+    let safe_topic = sanitize_filename(&transcript.topic);
+    let filename = format!("_autosave_{safe_topic}.json");
+    let path = dir.join(&filename);
+
+    let json = serde_json::to_string_pretty(transcript).map_err(|e| {
+        SimardError::ActionExecutionFailed {
+            action: "serialize-autosave".to_string(),
+            reason: e.to_string(),
+        }
+    })?;
+
+    std::fs::write(&path, &json).map_err(|e| SimardError::ActionExecutionFailed {
+        action: "write-autosave".to_string(),
+        reason: e.to_string(),
+    })?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = std::fs::Permissions::from_mode(0o600);
+        if let Err(e) = std::fs::set_permissions(&path, perms) {
+            warn!("Failed to set autosave permissions: {e}");
+        }
+    }
+
+    debug!(path = %path.display(), "Auto-save transcript written");
+    Ok(path)
+}
+
 /// Write a `MeetingHandoff` artifact for OODA integration.
 ///
 /// The handoff uses empty decisions/action_items vectors (per the arch spec —

--- a/src/meeting_repl/repl.rs
+++ b/src/meeting_repl/repl.rs
@@ -84,7 +84,8 @@ pub fn run_meeting_repl<R: BufRead, W: Write>(
                 writeln!(output, "  Started:  {}", status.started_at).ok();
             }
             MeetingCommand::Close => {
-                writeln!(output, "Closing meeting.").ok();
+                writeln!(output, "Closing meeting...").ok();
+                eprint!("  Generating summary (timeout: 90s)...");
                 break;
             }
             MeetingCommand::Conversation(text) => {
@@ -94,13 +95,13 @@ pub fn run_meeting_repl<R: BufRead, W: Write>(
                 eprint!("  ⏳ Thinking...");
                 match backend.send_message(&text) {
                     Ok(resp) => {
-                        eprintln!("\r                "); // clear the thinking indicator
+                        eprint!("\r\x1b[K"); // clear thinking indicator
                         if !resp.content.is_empty() {
                             writeln!(output, "\n{}\n", resp.content).ok();
                         }
                     }
                     Err(e) => {
-                        eprintln!("\r                "); // clear the thinking indicator
+                        eprint!("\r\x1b[K");
                         writeln!(output, "[agent error: {e}]").ok();
                     }
                 }
@@ -111,6 +112,7 @@ pub fn run_meeting_repl<R: BufRead, W: Write>(
     // Close the backend (summarize, persist, memory)
     match backend.close() {
         Ok(summary) => {
+            eprint!("\r\x1b[K");
             writeln!(output, "\n── Meeting Summary ──").ok();
             writeln!(output, "{}", summary.summary_text).ok();
             writeln!(
@@ -124,6 +126,7 @@ pub fn run_meeting_repl<R: BufRead, W: Write>(
             }
         }
         Err(e) => {
+            eprint!("\r\x1b[K");
             writeln!(output, "[warn] Failed to close meeting cleanly: {e}").ok();
         }
     }

--- a/src/operator_commands_dashboard/routes.rs
+++ b/src/operator_commands_dashboard/routes.rs
@@ -8,6 +8,7 @@ use axum::{
 use serde_json::{Value, json};
 
 use super::auth::{require_auth, try_login};
+use crate::cognitive_memory::{CognitiveMemoryOps, NativeCognitiveMemory};
 use crate::error::{SimardError, SimardResult};
 
 pub fn build_router() -> Router {
@@ -230,31 +231,48 @@ async fn goals() -> Json<Value> {
     let state_root = resolve_state_root();
     let goal_path = state_root.join("goal_records.json");
     let content = std::fs::read_to_string(&goal_path).unwrap_or_default();
-    match serde_json::from_str::<Value>(&content) {
-        Ok(val) => {
-            // goal_records.json may be a GoalBoard or an array of goals
-            if val.is_object() {
-                let active = val.get("active").cloned().unwrap_or(json!([]));
-                let backlog = val.get("backlog").cloned().unwrap_or(json!([]));
-                Json(json!({
-                    "active": active,
-                    "backlog": backlog,
-                    "active_count": active.as_array().map(|a| a.len()).unwrap_or(0),
-                    "backlog_count": backlog.as_array().map(|a| a.len()).unwrap_or(0),
-                }))
-            } else if val.is_array() {
-                Json(json!({
-                    "active": val,
-                    "backlog": [],
-                    "active_count": val.as_array().map(|a| a.len()).unwrap_or(0),
-                    "backlog_count": 0,
-                }))
-            } else {
-                Json(json!({"active": [], "backlog": [], "active_count": 0, "backlog_count": 0}))
+
+    let (active, mut backlog) = match serde_json::from_str::<Value>(&content) {
+        Ok(val) if val.is_object() => {
+            let a = val.get("active").cloned().unwrap_or(json!([]));
+            let b = val.get("backlog").cloned().unwrap_or(json!([]));
+            (
+                a.as_array().cloned().unwrap_or_default(),
+                b.as_array().cloned().unwrap_or_default(),
+            )
+        }
+        Ok(val) if val.is_array() => (val.as_array().cloned().unwrap_or_default(), vec![]),
+        _ => (vec![], vec![]),
+    };
+
+    // Pull meeting-captured actions and decisions from cognitive memory (#415)
+    if let Ok(mem) = NativeCognitiveMemory::open(&state_root) {
+        for tag in &["goal", "action", "decision"] {
+            if let Ok(facts) = mem.search_facts(tag, 20, 0.0) {
+                for fact in facts {
+                    let already_listed = active
+                        .iter()
+                        .chain(backlog.iter())
+                        .any(|g| g.get("id").and_then(|v| v.as_str()) == Some(&fact.node_id));
+                    if !already_listed {
+                        backlog.push(json!({
+                            "id": fact.node_id,
+                            "description": fact.content,
+                            "source": format!("cognitive-memory/{}", fact.concept),
+                            "score": fact.confidence,
+                        }));
+                    }
+                }
             }
         }
-        Err(_) => Json(json!({"active": [], "backlog": [], "active_count": 0, "backlog_count": 0})),
     }
+
+    Json(json!({
+        "active": active,
+        "backlog": backlog,
+        "active_count": active.len(),
+        "backlog_count": backlog.len(),
+    }))
 }
 
 async fn seed_goals() -> Json<Value> {
@@ -814,12 +832,28 @@ async fn handle_ws_chat(mut socket: WebSocket) {
 async fn logs() -> Json<Value> {
     let state_root = resolve_state_root();
 
+    // Try multiple log sources for daemon output (#414)
     let daemon_log = read_tail("/var/log/simard-daemon.log", 200)
         .or_else(|| {
             let alt_path = state_root.join("simard-daemon.log");
             read_tail(&alt_path.to_string_lossy(), 200)
         })
+        .or_else(|| {
+            let alt_path = state_root.join("ooda.log");
+            read_tail(&alt_path.to_string_lossy(), 200)
+        })
+        .or_else(|| {
+            let alt_path = state_root.join("simard.log");
+            read_tail(&alt_path.to_string_lossy(), 200)
+        })
         .unwrap_or_default();
+
+    // Fall back to journalctl if no file-based logs found
+    let combined_log = if daemon_log.is_empty() {
+        read_journal_logs().await
+    } else {
+        daemon_log
+    };
 
     let ooda_dir = state_root.join("ooda_transcripts");
 
@@ -851,7 +885,7 @@ async fn logs() -> Json<Value> {
     };
 
     Json(json!({
-        "daemon_log_lines": daemon_log,
+        "daemon_log_lines": combined_log,
         "ooda_transcripts": transcripts,
         "cost_log_lines": cost_log,
         "timestamp": chrono::Utc::now().to_rfc3339(),
@@ -863,6 +897,59 @@ fn read_tail(path: &str, max_lines: usize) -> Option<Vec<String>> {
     let lines: Vec<String> = content.lines().map(String::from).collect();
     let start = lines.len().saturating_sub(max_lines);
     Some(lines[start..].to_vec())
+}
+
+/// Read recent log entries from systemd journal for simard-related units (#414).
+async fn read_journal_logs() -> Vec<String> {
+    // Try user-level journal first
+    let output = tokio::process::Command::new("journalctl")
+        .args([
+            "--user",
+            "--unit=simard*",
+            "--no-pager",
+            "-n",
+            "200",
+            "--output=short-iso",
+        ])
+        .output()
+        .await;
+
+    if let Ok(o) = output {
+        if o.status.success() {
+            let text = String::from_utf8_lossy(&o.stdout);
+            let lines: Vec<String> = text
+                .lines()
+                .filter(|l| !l.contains("No entries"))
+                .map(String::from)
+                .collect();
+            if !lines.is_empty() {
+                return lines;
+            }
+        }
+    }
+
+    // Fall back to system-level journal
+    let output = tokio::process::Command::new("journalctl")
+        .args([
+            "--unit=simard*",
+            "--no-pager",
+            "-n",
+            "200",
+            "--output=short-iso",
+        ])
+        .output()
+        .await;
+
+    match output {
+        Ok(o) if o.status.success() => {
+            let text = String::from_utf8_lossy(&o.stdout);
+            text.lines()
+                .filter(|l| !l.contains("No entries"))
+                .map(String::from)
+                .collect()
+        }
+        _ => vec![],
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -925,6 +1012,11 @@ async fn memory_metrics() -> Json<Value> {
     let evidence_count = count_json_records(&evidence_path);
     let goal_count = count_json_records(&goal_path);
 
+    // Query NativeCognitiveMemory (LadybugDB) for live statistics (#419)
+    let native_stats = NativeCognitiveMemory::open(&state_root)
+        .and_then(|mem| mem.get_statistics())
+        .ok();
+
     let last_consolidation = [&memory_path, &evidence_path, &goal_path]
         .iter()
         .filter_map(|p| std::fs::metadata(p).ok())
@@ -934,6 +1026,12 @@ async fn memory_metrics() -> Json<Value> {
             let dt: chrono::DateTime<chrono::Utc> = t.into();
             dt.to_rfc3339()
         });
+
+    // Prefer LadybugDB counts when available, fall back to JSON file counts
+    let total = native_stats
+        .as_ref()
+        .map(|s| s.total())
+        .unwrap_or(fact_count + evidence_count + goal_count);
 
     Json(json!({
         "state_root": state_root.to_string_lossy(),
@@ -960,7 +1058,16 @@ async fn memory_metrics() -> Json<Value> {
             "size_bytes": handoff_info.0,
             "modified": handoff_info.1,
         },
-        "total_facts": fact_count + evidence_count + goal_count,
+        "native_memory": native_stats.as_ref().map(|s| json!({
+            "sensory": s.sensory_count,
+            "working": s.working_count,
+            "episodic": s.episodic_count,
+            "semantic": s.semantic_count,
+            "procedural": s.procedural_count,
+            "prospective": s.prospective_count,
+            "total": s.total(),
+        })),
+        "total_facts": total,
         "last_consolidation": last_consolidation,
         "timestamp": chrono::Utc::now().to_rfc3339(),
     }))
@@ -1406,10 +1513,23 @@ const INDEX_HTML: &str = r##"<!DOCTYPE html>
     async function fetchMemory(){
       try{
         const r=await fetch('/api/memory'); const d=await r.json();
-        document.getElementById('mem-overview').innerHTML=`
+        let overviewHtml=`
           <div class="stat"><span class="label">Total Facts</span><span class="value">${d.total_facts}</span></div>
           <div class="stat"><span class="label">Last Consolidation</span><span class="value">${d.last_consolidation?timeAgo(d.last_consolidation)+' ('+new Date(d.last_consolidation).toLocaleString()+')':'Never'}</span></div>
           <div class="stat"><span class="label">State Root</span><span class="value" style="font-size:.8rem;word-break:break-all">${esc(d.state_root)}</span></div>`;
+        if(d.native_memory){
+          const nm=d.native_memory;
+          overviewHtml+=`
+          <h3 style="color:var(--accent);font-size:.9rem;margin-top:.75rem;border-top:1px solid var(--border);padding-top:.5rem">LadybugDB (Native Memory)</h3>
+          <div class="stat"><span class="label">Sensory</span><span class="value">${nm.sensory}</span></div>
+          <div class="stat"><span class="label">Working</span><span class="value">${nm.working}</span></div>
+          <div class="stat"><span class="label">Episodic</span><span class="value">${nm.episodic}</span></div>
+          <div class="stat"><span class="label">Semantic (Facts)</span><span class="value">${nm.semantic}</span></div>
+          <div class="stat"><span class="label">Procedural</span><span class="value">${nm.procedural}</span></div>
+          <div class="stat"><span class="label">Prospective</span><span class="value">${nm.prospective}</span></div>
+          <div class="stat"><span class="label"><strong>Total Native</strong></span><span class="value"><strong>${nm.total}</strong></span></div>`;
+        }
+        document.getElementById('mem-overview').innerHTML=overviewHtml;
         const files=[
           {key:'memory_records',label:'Memory Records'},
           {key:'evidence_records',label:'Evidence Records'},
@@ -1582,6 +1702,13 @@ const INDEX_HTML: &str = r##"<!DOCTYPE html>
     document.getElementById('mem-search-input')?.addEventListener('keypress',e=>{if(e.key==='Enter')searchMemory();});
 
     /* --- Costs --- */
+    function fmtLabel(k){
+      const map={
+        'period':'Period','entry_count':'API Calls',
+        'total_prompt_tokens':'Prompt Tokens','total_completion_tokens':'Completion Tokens',
+        'total_cost_usd':'Estimated Cost'};
+      return map[k]||k.replace(/_/g,' ').replace(/\b\w/g,c=>c.toUpperCase());
+    }
     async function fetchCosts(){
       try{
         const r=await fetch('/api/costs'); const d=await r.json();
@@ -1589,10 +1716,16 @@ const INDEX_HTML: &str = r##"<!DOCTYPE html>
           if(!s||s.error) return `<span class="err">${esc(s?.error||'No cost data — is cost tracking configured?')}</span>`;
           return Object.entries(s).map(([k,v])=>{
             if(v==null)return'';
-            if(typeof v==='object')return`<div class="stat"><span class="label">${esc(k)}</span><span class="value" style="font-size:.8rem">${esc(JSON.stringify(v))}</span></div>`;
-            const isCost=k.toLowerCase().includes('cost')||k.toLowerCase().includes('usd');
-            const fmt=typeof v==='number'?(isCost?'$'+v.toFixed(4):v.toLocaleString()):String(v);
-            return `<div class="stat"><span class="label">${esc(k)}</span><span class="value">${fmt}</span></div>`;
+            if(typeof v==='object')return`<div class="stat"><span class="label">${esc(fmtLabel(k))}</span><span class="value" style="font-size:.8rem">${esc(JSON.stringify(v))}</span></div>`;
+            const isCost=k.toLowerCase().includes('cost_usd');
+            const isTokens=k.toLowerCase().includes('token');
+            let fmt;
+            if(typeof v==='number'){
+              if(isCost) fmt='$'+v.toFixed(4);
+              else if(isTokens) fmt=v.toLocaleString()+' tokens';
+              else fmt=v.toLocaleString();
+            }else{fmt=String(v);}
+            return `<div class="stat"><span class="label">${esc(fmtLabel(k))}</span><span class="value">${fmt}</span></div>`;
           }).join('');
         }
         document.getElementById('costs-daily').innerHTML=renderSummary(d.daily);


### PR DESCRIPTION
## Summary

Fixes four dashboard tab issues in a single branch:

- **#413 — Costs tab**: Fixed dollar-sign formatting on raw token counts. Token fields now show `1,234 tokens` instead of `$1234`. Only `*_cost_usd` fields get dollar formatting.
- **#414 — Logs tab**: Wired up multiple log data sources — falls back through `simard-daemon.log`, `ooda.log`, `simard.log`, and journalctl.
- **#415 — Goals tab**: Pulls meeting-captured actions/decisions from cognitive memory via `NativeCognitiveMemory::search_facts()` and merges into goal board.
- **#419 — Memory tab**: Queries `NativeCognitiveMemory` via `CognitiveMemoryOps` trait, shows LadybugDB per-type counts (sensory, working, episodic, semantic, procedural, prospective).

## Changes
- `src/operator_commands_dashboard/routes.rs` — New API logic for all 4 tabs
- `src/meeting_backend/mod.rs` — Auto-save + summary timeout (shared with #287)
- `src/meeting_backend/persist.rs` — Persistence improvements
- `src/meeting_repl/repl.rs` — Terminal output fixes

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>