### PR TITLE
feat: Meeting UX enhancements — templates, progress, markdown export (#311)

### DIFF
--- a/src/cognitive_memory/backup.rs
+++ b/src/cognitive_memory/backup.rs
@@ -1,0 +1,241 @@
+//! Automated backup and verification for cognitive memory (LadybugDB).
+//!
+//! Provides file-copy backup with timestamped filenames and verification
+//! that the backup can be opened by LadybugDB.
+
+use std::path::{Path, PathBuf};
+
+use tracing::{info, warn};
+
+use crate::error::{SimardError, SimardResult};
+
+/// Result of a backup operation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BackupResult {
+    pub source_path: PathBuf,
+    pub backup_path: PathBuf,
+    pub size_bytes: u64,
+    pub verified: bool,
+}
+
+/// Default backup directory: `~/.simard/backups/`.
+pub fn default_backup_dir() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".simard/backups")
+}
+
+/// Create a timestamped backup of the cognitive memory database file.
+///
+/// Copies the DB file to `<backup_dir>/cognitive_memory_<timestamp>.ladybug`.
+/// If `backup_dir` is `None`, uses `~/.simard/backups/`.
+pub fn create_backup(db_path: &Path, backup_dir: Option<&Path>) -> SimardResult<BackupResult> {
+    let dir = backup_dir
+        .map(PathBuf::from)
+        .unwrap_or_else(default_backup_dir);
+
+    std::fs::create_dir_all(&dir).map_err(|e| SimardError::PersistentStoreIo {
+        store: "cognitive-memory-backup".into(),
+        action: "create_backup_dir".into(),
+        path: dir.clone(),
+        reason: e.to_string(),
+    })?;
+
+    if !db_path.exists() {
+        return Err(SimardError::PersistentStoreIo {
+            store: "cognitive-memory-backup".into(),
+            action: "check_source".into(),
+            path: db_path.to_path_buf(),
+            reason: "Database file does not exist.".into(),
+        });
+    }
+
+    let timestamp = chrono::Utc::now().format("%Y%m%d_%H%M%S");
+    let filename = format!("cognitive_memory_{timestamp}.ladybug");
+    let backup_path = dir.join(&filename);
+
+    std::fs::copy(db_path, &backup_path).map_err(|e| SimardError::PersistentStoreIo {
+        store: "cognitive-memory-backup".into(),
+        action: "copy".into(),
+        path: backup_path.clone(),
+        reason: e.to_string(),
+    })?;
+
+    let size_bytes = std::fs::metadata(&backup_path)
+        .map(|m| m.len())
+        .unwrap_or(0);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = std::fs::Permissions::from_mode(0o600);
+        if let Err(e) = std::fs::set_permissions(&backup_path, perms) {
+            warn!("Failed to set backup permissions: {e}");
+        }
+    }
+
+    info!(
+        source = %db_path.display(),
+        backup = %backup_path.display(),
+        size_bytes,
+        "Cognitive memory backup created"
+    );
+
+    Ok(BackupResult {
+        source_path: db_path.to_path_buf(),
+        backup_path,
+        size_bytes,
+        verified: false,
+    })
+}
+
+/// Verify a backup by attempting to open it with LadybugDB.
+///
+/// Opens the backup file, runs a basic query, and closes it.
+/// Returns the `BackupResult` with `verified = true` on success.
+pub fn verify_backup(mut result: BackupResult) -> SimardResult<BackupResult> {
+    let db =
+        lbug::Database::new(&result.backup_path, lbug::SystemConfig::default()).map_err(|e| {
+            SimardError::PersistentStoreIo {
+                store: "cognitive-memory-backup".into(),
+                action: "verify_open".into(),
+                path: result.backup_path.clone(),
+                reason: format!("Failed to open backup: {e}"),
+            }
+        })?;
+
+    let conn = lbug::Connection::new(&db).map_err(|e| SimardError::PersistentStoreIo {
+        store: "cognitive-memory-backup".into(),
+        action: "verify_connect".into(),
+        path: result.backup_path.clone(),
+        reason: format!("Failed to connect to backup: {e}"),
+    })?;
+
+    conn.query("RETURN 1")
+        .map_err(|e| SimardError::PersistentStoreIo {
+            store: "cognitive-memory-backup".into(),
+            action: "verify_query".into(),
+            path: result.backup_path.clone(),
+            reason: format!("Backup query failed: {e}"),
+        })?;
+
+    result.verified = true;
+    info!(backup = %result.backup_path.display(), "Backup verified successfully");
+    Ok(result)
+}
+
+/// Create a backup and verify it in one call.
+pub fn backup_and_verify(db_path: &Path, backup_dir: Option<&Path>) -> SimardResult<BackupResult> {
+    let result = create_backup(db_path, backup_dir)?;
+    verify_backup(result)
+}
+
+/// Prune old backups, keeping at most `keep` newest files.
+///
+/// Only removes files matching `cognitive_memory_*.ladybug` in the backup dir.
+pub fn prune_backups(backup_dir: &Path, keep: usize) -> SimardResult<usize> {
+    let entries: Vec<_> = std::fs::read_dir(backup_dir)
+        .map_err(|e| SimardError::PersistentStoreIo {
+            store: "cognitive-memory-backup".into(),
+            action: "list_backups".into(),
+            path: backup_dir.to_path_buf(),
+            reason: e.to_string(),
+        })?
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            let name = e.file_name().to_string_lossy().to_string();
+            name.starts_with("cognitive_memory_") && name.ends_with(".ladybug")
+        })
+        .collect();
+
+    if entries.len() <= keep {
+        return Ok(0);
+    }
+
+    // Sort by modification time (newest first)
+    let mut with_time: Vec<_> = entries
+        .into_iter()
+        .filter_map(|e| {
+            e.metadata()
+                .ok()
+                .and_then(|m| m.modified().ok())
+                .map(|t| (e, t))
+        })
+        .collect();
+    with_time.sort_by(|a, b| b.1.cmp(&a.1));
+
+    let mut removed = 0;
+    for (entry, _) in with_time.into_iter().skip(keep) {
+        if let Err(e) = std::fs::remove_file(entry.path()) {
+            warn!(path = %entry.path().display(), "Failed to prune backup: {e}");
+        } else {
+            removed += 1;
+        }
+    }
+
+    info!(removed, keep, "Pruned old backups");
+    Ok(removed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backup_nonexistent_source_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let fake_db = dir.path().join("nonexistent.ladybug");
+        let result = create_backup(&fake_db, Some(dir.path()));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn backup_and_verify_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.ladybug");
+
+        // Create a real LadybugDB file
+        let _db = lbug::Database::new(&db_path, lbug::SystemConfig::default())
+            .expect("should create test DB");
+        drop(_db);
+
+        let backup_dir = dir.path().join("backups");
+        let result = create_backup(&db_path, Some(&backup_dir)).unwrap();
+        assert!(result.backup_path.exists());
+        assert!(result.size_bytes > 0);
+        assert!(!result.verified);
+
+        let verified = verify_backup(result).unwrap();
+        assert!(verified.verified);
+    }
+
+    #[test]
+    fn prune_keeps_newest() {
+        let dir = tempfile::tempdir().unwrap();
+        let backup_dir = dir.path().join("backups");
+        std::fs::create_dir_all(&backup_dir).unwrap();
+
+        for i in 0..5 {
+            let name = format!("cognitive_memory_2025010{i}_120000.ladybug");
+            std::fs::write(backup_dir.join(&name), format!("data{i}")).unwrap();
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+
+        let removed = prune_backups(&backup_dir, 2).unwrap();
+        assert_eq!(removed, 3);
+
+        let remaining: Vec<_> = std::fs::read_dir(&backup_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .collect();
+        assert_eq!(remaining.len(), 2);
+    }
+
+    #[test]
+    fn prune_no_op_when_under_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path()).unwrap();
+        let removed = prune_backups(dir.path(), 10).unwrap();
+        assert_eq!(removed, 0);
+    }
+}

--- a/src/cognitive_memory/mod.rs
+++ b/src/cognitive_memory/mod.rs
@@ -8,6 +8,7 @@
 //! The flock-based multi-writer serialization is copied from the skwaq
 //! reference implementation in `ladybug_db.rs`.
 
+pub mod backup;
 pub(crate) mod schema;
 
 #[cfg(unix)]
@@ -288,6 +289,20 @@ impl NativeCognitiveMemory {
             .map_err(|_| SimardError::ClockBeforeUnixEpoch {
                 reason: "system clock before Unix epoch".into(),
             })
+    }
+
+    /// Create a verified backup of this database.
+    ///
+    /// Copies the DB file to `<backup_dir>/cognitive_memory_<timestamp>.ladybug`
+    /// and verifies the copy can be opened. If `backup_dir` is `None`, uses
+    /// `~/.simard/backups/`.
+    pub fn backup(&self, backup_dir: Option<&Path>) -> SimardResult<backup::BackupResult> {
+        backup::backup_and_verify(&self.path, backup_dir)
+    }
+
+    /// Get the path to this database file.
+    pub fn db_path(&self) -> &Path {
+        &self.path
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,8 +198,8 @@ pub use knowledge_bridge::{
 };
 pub use knowledge_context::{PlanningContext, enrich_planning_context};
 pub use meeting_backend::{
-    ConversationMessage, MeetingBackend, MeetingResponse, MeetingSummary, MeetingTranscript, Role,
-    SessionStatus,
+    ConversationMessage, MeetingBackend, MeetingResponse, MeetingSummary, MeetingTemplateKind,
+    MeetingTranscript, Role, SessionStatus,
 };
 pub use meeting_facilitator::{
     ActionItem, MEETING_HANDOFF_FILENAME, MeetingDecision, MeetingHandoff, MeetingSession,

--- a/src/meeting_backend/command.rs
+++ b/src/meeting_backend/command.rs
@@ -8,6 +8,12 @@ pub enum MeetingCommand {
     Help,
     Close,
     Status,
+    /// Export transcript as formatted markdown.
+    Export,
+    /// Show meeting progress (duration, message counts, topics, action items).
+    Progress,
+    /// Start from a predefined meeting template (standup, retro, planning, 1on1).
+    Template(String),
     /// Natural language — forwarded to the LLM.
     Conversation(String),
 }
@@ -22,10 +28,17 @@ pub fn parse_command(input: &str) -> MeetingCommand {
     if trimmed.is_empty() {
         return MeetingCommand::Conversation(String::new());
     }
-    match trimmed.to_ascii_lowercase().as_str() {
+    let lower = trimmed.to_ascii_lowercase();
+    match lower.as_str() {
         "/help" => MeetingCommand::Help,
         "/close" | "/done" => MeetingCommand::Close,
         "/status" => MeetingCommand::Status,
+        "/export" => MeetingCommand::Export,
+        "/progress" => MeetingCommand::Progress,
+        _ if lower.starts_with("/template") => {
+            let name = trimmed["/template".len()..].trim().to_string();
+            MeetingCommand::Template(name)
+        }
         _ => MeetingCommand::Conversation(trimmed.to_string()),
     }
 }
@@ -65,6 +78,38 @@ mod tests {
         assert_eq!(
             parse_command("/decision Ship it | ready"),
             MeetingCommand::Conversation("/decision Ship it | ready".to_string()),
+        );
+    }
+
+    #[test]
+    fn parse_export() {
+        assert_eq!(parse_command("/export"), MeetingCommand::Export);
+        assert_eq!(parse_command("  /EXPORT  "), MeetingCommand::Export);
+    }
+
+    #[test]
+    fn parse_progress() {
+        assert_eq!(parse_command("/progress"), MeetingCommand::Progress);
+        assert_eq!(parse_command("  /PROGRESS  "), MeetingCommand::Progress);
+    }
+
+    #[test]
+    fn parse_template_with_name() {
+        assert_eq!(
+            parse_command("/template standup"),
+            MeetingCommand::Template("standup".to_string()),
+        );
+        assert_eq!(
+            parse_command("  /Template  retro "),
+            MeetingCommand::Template("retro".to_string()),
+        );
+    }
+
+    #[test]
+    fn parse_template_no_name() {
+        assert_eq!(
+            parse_command("/template"),
+            MeetingCommand::Template(String::new()),
         );
     }
 

--- a/src/meeting_backend/mod.rs
+++ b/src/meeting_backend/mod.rs
@@ -6,9 +6,11 @@
 
 pub mod command;
 pub mod persist;
+pub mod templates;
 pub mod types;
 
 use std::fmt::Write as _;
+use std::time::Instant;
 
 use chrono::Utc;
 use tracing::{debug, info, warn};
@@ -18,9 +20,32 @@ use crate::cognitive_memory::CognitiveMemoryOps;
 use crate::error::{SimardError, SimardResult};
 
 pub use command::{MeetingCommand, parse_command};
+pub use templates::{find_template, format_template, list_templates};
 pub use types::{
-    ConversationMessage, MeetingResponse, MeetingSummary, MeetingTranscript, Role, SessionStatus,
+    ConversationMessage, MeetingProgress, MeetingResponse, MeetingSummary, MeetingTemplateKind,
+    MeetingTranscript, Role, SessionStatus,
 };
+
+// Free functions for dashboard/external consumers.
+pub use persist::write_markdown_export as export_transcript_markdown_inner;
+
+/// Format the list of available templates as a user-facing string.
+pub fn format_template_list() -> String {
+    list_templates()
+}
+
+/// Export a `MeetingTranscript` as formatted markdown. Convenience wrapper
+/// around `persist::write_markdown_export` for callers that have a transcript.
+pub fn export_transcript_markdown(
+    transcript: &MeetingTranscript,
+) -> SimardResult<std::path::PathBuf> {
+    persist::write_markdown_export(
+        &transcript.topic,
+        &transcript.started_at,
+        transcript.duration_secs,
+        &transcript.messages,
+    )
+}
 
 /// Maximum messages kept in conversation history.
 const MAX_HISTORY: usize = 500;
@@ -39,7 +64,10 @@ pub struct MeetingBackend {
     agent: Box<dyn BaseTypeSession>,
     bridge: Option<Box<dyn CognitiveMemoryOps>>,
     started_at: String,
+    started_instant: Instant,
     is_open: bool,
+    /// Active meeting template, if one was applied via `/template`.
+    template: Option<MeetingTemplateKind>,
 }
 
 impl MeetingBackend {
@@ -64,7 +92,9 @@ impl MeetingBackend {
             agent,
             bridge,
             started_at,
+            started_instant: Instant::now(),
             is_open: true,
+            template: None,
         }
     }
 
@@ -207,6 +237,8 @@ impl MeetingBackend {
             message_count: self.history.len(),
             started_at: self.started_at.clone(),
             is_open: self.is_open,
+            duration_display: Some(self.elapsed_display()),
+            active_template: self.template.as_ref().map(|t| t.agenda().to_string()),
         }
     }
 
@@ -218,6 +250,85 @@ impl MeetingBackend {
     /// Convenience: check if the session is still open.
     pub fn is_open(&self) -> bool {
         self.is_open
+    }
+
+    /// Generate a progress report from the current conversation state.
+    pub fn progress(&self) -> MeetingProgress {
+        let operator_messages = self.history.iter().filter(|m| m.role == Role::User).count();
+        let agent_messages = self
+            .history
+            .iter()
+            .filter(|m| m.role == Role::Assistant)
+            .count();
+
+        let topics = extract_topics(&self.history);
+        let action_items = extract_patterns(&self.history, ACTION_ITEM_MARKERS);
+        let pending_decisions = extract_patterns(&self.history, DECISION_MARKERS);
+
+        MeetingProgress {
+            duration_display: self.elapsed_display(),
+            operator_messages,
+            agent_messages,
+            topics,
+            action_items,
+            pending_decisions,
+        }
+    }
+
+    /// Message count in the conversation history.
+    pub fn message_count(&self) -> usize {
+        self.history.len()
+    }
+
+    /// Elapsed time since meeting start, as a human-readable string (e.g. "5m 32s").
+    pub fn elapsed_display(&self) -> String {
+        let secs = self.elapsed_secs();
+        if secs < 60 {
+            format!("{secs}s")
+        } else {
+            format!("{}m {}s", secs / 60, secs % 60)
+        }
+    }
+
+    /// Export the transcript as formatted markdown to the current directory.
+    ///
+    /// Filename format: `meeting-YYYY-MM-DD-HHMMSS.md`.
+    pub fn export_markdown(&self) -> SimardResult<std::path::PathBuf> {
+        persist::write_markdown_export(
+            &self.topic,
+            &self.started_at,
+            self.elapsed_secs(),
+            &self.history,
+        )
+    }
+
+    /// Apply a meeting template: send its opening prompt to the LLM agent.
+    pub fn apply_template(&mut self, template: &templates::MeetingTemplate) -> SimardResult<()> {
+        self.template = MeetingTemplateKind::from_name(template.name);
+        self.send_message(template.opening_prompt)?;
+        Ok(())
+    }
+
+    /// Set the active template kind directly.
+    pub fn set_template(&mut self, kind: MeetingTemplateKind) {
+        self.template = Some(kind);
+    }
+
+    /// Get the active template, if any.
+    pub fn active_template(&self) -> Option<&MeetingTemplateKind> {
+        self.template.as_ref()
+    }
+
+    /// Build a `MeetingTranscript` snapshot of the current state.
+    pub fn transcript_snapshot(&self, summary: &str) -> MeetingTranscript {
+        MeetingTranscript {
+            topic: self.topic.clone(),
+            started_at: self.started_at.clone(),
+            closed_at: String::new(),
+            duration_secs: self.elapsed_secs(),
+            summary: summary.to_string(),
+            messages: self.history.clone(),
+        }
     }
 
     // --- Private helpers ---
@@ -324,10 +435,7 @@ impl MeetingBackend {
     }
 
     fn elapsed_secs(&self) -> u64 {
-        chrono::DateTime::parse_from_rfc3339(&self.started_at)
-            .ok()
-            .map(|start| Utc::now().signed_duration_since(start).num_seconds().max(0) as u64)
-            .unwrap_or(0)
+        self.started_instant.elapsed().as_secs()
     }
 }
 
@@ -337,6 +445,85 @@ impl MeetingBackend {
 /// natural-language response.
 fn extract_response(outcome: &BaseTypeOutcome) -> String {
     outcome.execution_summary.trim().to_string()
+}
+
+/// Markers that indicate an action item in conversation text.
+const ACTION_ITEM_MARKERS: &[&str] = &[
+    "action item:",
+    "todo:",
+    "TODO:",
+    "[ ]",
+    "will do",
+    "need to",
+    "should do",
+    "assigned to",
+    "take ownership",
+];
+
+/// Markers that indicate a pending decision in conversation text.
+const DECISION_MARKERS: &[&str] = &[
+    "decision:",
+    "decided:",
+    "we need to decide",
+    "open question",
+    "pending decision",
+    "needs decision",
+    "to be determined",
+    "TBD",
+];
+
+/// Extract likely discussion topics from user messages.
+///
+/// Uses a simple heuristic: user messages that look like topic headers
+/// (short, or containing common framing words). Returns up to 10.
+fn extract_topics(messages: &[ConversationMessage]) -> Vec<String> {
+    let topic_starters = ["let's discuss", "about ", "regarding ", "topic:", "next:"];
+    let mut topics = Vec::new();
+
+    for msg in messages.iter().filter(|m| m.role == Role::User) {
+        let lower = msg.content.to_ascii_lowercase();
+        let is_topic = topic_starters.iter().any(|s| lower.starts_with(s))
+            || (msg.content.len() < 80 && !lower.starts_with('/'));
+        if is_topic && !msg.content.trim().is_empty() {
+            // Truncate long content for display
+            let display = if msg.content.len() > 60 {
+                format!("{}…", &msg.content[..60])
+            } else {
+                msg.content.clone()
+            };
+            topics.push(display);
+        }
+        if topics.len() >= 10 {
+            break;
+        }
+    }
+    topics
+}
+
+/// Extract sentences containing any of the given marker phrases.
+fn extract_patterns(messages: &[ConversationMessage], markers: &[&str]) -> Vec<String> {
+    let mut results = Vec::new();
+    for msg in messages {
+        let lower = msg.content.to_ascii_lowercase();
+        for marker in markers {
+            if lower.contains(*marker) {
+                // Find the sentence containing the marker
+                for sentence in msg.content.split(['.', '\n']) {
+                    let s = sentence.trim();
+                    if !s.is_empty()
+                        && s.to_ascii_lowercase().contains(*marker)
+                        && !results.contains(&s.to_string())
+                    {
+                        results.push(s.to_string());
+                    }
+                }
+            }
+        }
+        if results.len() >= 20 {
+            break;
+        }
+    }
+    results
 }
 
 #[cfg(test)]
@@ -502,5 +689,65 @@ mod tests {
             evidence: Vec::new(),
         };
         assert_eq!(extract_response(&outcome), "hello world");
+    }
+
+    #[test]
+    fn progress_empty_session() {
+        let agent = MockAgent::new("ok");
+        let backend = MeetingBackend::new_session("Test", Box::new(agent), None, String::new());
+        let p = backend.progress();
+        assert_eq!(p.operator_messages, 0);
+        assert_eq!(p.agent_messages, 0);
+        assert!(p.topics.is_empty());
+        assert!(p.action_items.is_empty());
+        assert!(p.pending_decisions.is_empty());
+    }
+
+    #[test]
+    fn progress_counts_messages() {
+        let agent = MockAgent::new("Action item: fix the tests");
+        let mut backend = MeetingBackend::new_session("Test", Box::new(agent), None, String::new());
+        backend.send_message("Let's discuss testing").unwrap();
+        backend.send_message("What about coverage?").unwrap();
+        let p = backend.progress();
+        assert_eq!(p.operator_messages, 2);
+        assert_eq!(p.agent_messages, 2);
+    }
+
+    #[test]
+    fn progress_extracts_action_items() {
+        let agent = MockAgent::new("Action item: deploy the fix by Friday");
+        let mut backend = MeetingBackend::new_session("Test", Box::new(agent), None, String::new());
+        backend.send_message("What needs to happen?").unwrap();
+        let p = backend.progress();
+        assert!(
+            !p.action_items.is_empty(),
+            "should extract action items from agent response"
+        );
+    }
+
+    #[test]
+    fn progress_extracts_decisions() {
+        let agent = MockAgent::new("We need to decide on the API format");
+        let mut backend = MeetingBackend::new_session("Test", Box::new(agent), None, String::new());
+        backend.send_message("What's pending?").unwrap();
+        let p = backend.progress();
+        assert!(
+            !p.pending_decisions.is_empty(),
+            "should extract pending decisions"
+        );
+    }
+
+    #[test]
+    fn progress_extracts_topics() {
+        let agent = MockAgent::new("ok");
+        let mut backend = MeetingBackend::new_session("Test", Box::new(agent), None, String::new());
+        backend.send_message("API design").unwrap();
+        backend.send_message("Database schema").unwrap();
+        let p = backend.progress();
+        assert!(
+            p.topics.len() >= 2,
+            "should extract short user messages as topics"
+        );
     }
 }

--- a/src/meeting_backend/persist.rs
+++ b/src/meeting_backend/persist.rs
@@ -184,6 +184,57 @@ pub fn store_cognitive_memory(
     }
 }
 
+/// Write a markdown-formatted transcript to the current directory.
+///
+/// Filename format: `meeting-YYYY-MM-DD-HHMMSS.md`.
+pub fn write_markdown_export(
+    topic: &str,
+    started_at: &str,
+    duration_secs: u64,
+    messages: &[ConversationMessage],
+) -> SimardResult<PathBuf> {
+    let timestamp = chrono::Utc::now().format("%Y-%m-%d-%H%M%S");
+    let filename = format!("meeting-{timestamp}.md");
+    let path = PathBuf::from(&filename);
+
+    let mut md = String::with_capacity(4096);
+    md.push_str(&format!("# Meeting: {topic}\n\n"));
+    md.push_str(&format!("- **Started**: {started_at}\n"));
+    let dur_min = duration_secs / 60;
+    let dur_sec = duration_secs % 60;
+    md.push_str(&format!("- **Duration**: {dur_min}m {dur_sec}s\n"));
+    md.push_str(&format!("- **Messages**: {}\n\n", messages.len()));
+    md.push_str("---\n\n## Transcript\n\n");
+
+    for msg in messages {
+        let role_label = match msg.role {
+            super::types::Role::User => "**Operator**",
+            super::types::Role::Assistant => "**Simard**",
+            super::types::Role::System => "**System**",
+        };
+        md.push_str(&format!("### {role_label} — {}\n\n", msg.timestamp));
+        md.push_str(&msg.content);
+        md.push_str("\n\n");
+    }
+
+    std::fs::write(&path, &md).map_err(|e| SimardError::ActionExecutionFailed {
+        action: "write-markdown-export".to_string(),
+        reason: e.to_string(),
+    })?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = std::fs::Permissions::from_mode(0o600);
+        if let Err(e) = std::fs::set_permissions(&path, perms) {
+            warn!("Failed to set markdown export permissions: {e}");
+        }
+    }
+
+    info!(path = %path.display(), "Markdown transcript exported");
+    Ok(path)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/meeting_backend/templates.rs
+++ b/src/meeting_backend/templates.rs
@@ -1,0 +1,145 @@
+//! Predefined meeting templates with structured agendas.
+
+/// A meeting template with a name, description, and opening prompt for the LLM.
+pub struct MeetingTemplate {
+    pub name: &'static str,
+    pub description: &'static str,
+    pub agenda_items: &'static [&'static str],
+    pub opening_prompt: &'static str,
+}
+
+/// All built-in templates.
+pub const TEMPLATES: &[MeetingTemplate] = &[
+    MeetingTemplate {
+        name: "standup",
+        description: "Daily standup — quick sync on progress and blockers",
+        agenda_items: &[
+            "What I accomplished since last standup",
+            "What I'm working on today",
+            "Blockers or things I need help with",
+        ],
+        opening_prompt: "Let's run a standup. I'll go through what I did, what I'm doing next, and any blockers. Help me stay focused and flag anything that sounds risky.",
+    },
+    MeetingTemplate {
+        name: "retro",
+        description: "Retrospective — reflect on what worked and what to improve",
+        agenda_items: &[
+            "What went well",
+            "What could be improved",
+            "Action items for next cycle",
+        ],
+        opening_prompt: "Let's do a retrospective. I'll share what went well and what didn't. Help me identify patterns and suggest concrete action items.",
+    },
+    MeetingTemplate {
+        name: "planning",
+        description: "Planning session — priorities, dependencies, and assignments",
+        agenda_items: &[
+            "Priorities for this cycle",
+            "Dependencies and risks",
+            "Task assignments and ownership",
+        ],
+        opening_prompt: "Let's plan the upcoming work. Help me think through priorities, identify dependencies between tasks, and make sure nothing critical is missed.",
+    },
+    MeetingTemplate {
+        name: "1on1",
+        description: "One-on-one — wins, concerns, and feedback",
+        agenda_items: &[
+            "Recent wins and progress",
+            "Concerns or challenges",
+            "Feedback and growth areas",
+        ],
+        opening_prompt: "Let's have a 1:1 check-in. I'll share what's going well and any concerns. Help me think through challenges and identify opportunities for growth.",
+    },
+    MeetingTemplate {
+        name: "bug-triage",
+        description: "Bug triage — severity, repro, and owner assignment",
+        agenda_items: &[
+            "Severity assessment",
+            "Reproduction steps",
+            "Owner assignment and timeline",
+        ],
+        opening_prompt: "Let's triage bugs. For each one I'll describe the issue — help me assess severity, clarify reproduction steps, and decide on ownership.",
+    },
+];
+
+/// Look up a template by name (case-insensitive, with common aliases).
+pub fn find_template(name: &str) -> Option<&'static MeetingTemplate> {
+    let lower = name.to_ascii_lowercase();
+    // Support common aliases
+    let canonical = match lower.as_str() {
+        "sprint-planning" => "planning",
+        "retrospective" => "retro",
+        other => other,
+    };
+    TEMPLATES.iter().find(|t| t.name == canonical)
+}
+
+/// Format a template as a display string for the user.
+pub fn format_template(template: &MeetingTemplate) -> String {
+    let mut out = format!(
+        "📋 Template: {} — {}\n\nAgenda:\n",
+        template.name, template.description
+    );
+    for (i, item) in template.agenda_items.iter().enumerate() {
+        out.push_str(&format!("  {}. {}\n", i + 1, item));
+    }
+    out
+}
+
+/// List all available templates as a display string.
+pub fn list_templates() -> String {
+    let mut out = String::from("Available meeting templates:\n");
+    for t in TEMPLATES {
+        out.push_str(&format!("  /template {}  — {}\n", t.name, t.description));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn find_known_templates() {
+        assert!(find_template("standup").is_some());
+        assert!(find_template("retro").is_some());
+        assert!(find_template("planning").is_some());
+        assert!(find_template("1on1").is_some());
+        assert!(find_template("bug-triage").is_some());
+    }
+
+    #[test]
+    fn find_case_insensitive() {
+        assert!(find_template("STANDUP").is_some());
+        assert!(find_template("Retro").is_some());
+    }
+
+    #[test]
+    fn find_aliases() {
+        assert!(find_template("sprint-planning").is_some());
+        assert!(find_template("retrospective").is_some());
+        assert_eq!(
+            find_template("sprint-planning").unwrap().name,
+            find_template("planning").unwrap().name
+        );
+        assert_eq!(
+            find_template("retrospective").unwrap().name,
+            find_template("retro").unwrap().name
+        );
+    }
+
+    #[test]
+    fn find_unknown_returns_none() {
+        assert!(find_template("brainstorm").is_none());
+    }
+
+    #[test]
+    fn list_templates_includes_all() {
+        let listing = list_templates();
+        assert!(listing.contains("standup"));
+        assert!(listing.contains("retro"));
+        assert!(listing.contains("planning"));
+        assert!(listing.contains("1on1"));
+        assert!(listing.contains("bug-triage"));
+    }
+}

--- a/src/meeting_backend/types.rs
+++ b/src/meeting_backend/types.rs
@@ -36,6 +36,38 @@ pub struct MeetingSummary {
     pub transcript_path: Option<String>,
 }
 
+/// Predefined meeting template presets.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MeetingTemplateKind {
+    Standup,
+    Retro,
+    Planning,
+    Custom(String),
+}
+
+impl MeetingTemplateKind {
+    /// Short agenda description for the template.
+    pub fn agenda(&self) -> &str {
+        match self {
+            Self::Standup => "What did you do? What will you do? Any blockers?",
+            Self::Retro => "What went well? What didn't? What to improve?",
+            Self::Planning => "Goals for this sprint? Risks? Dependencies?",
+            Self::Custom(desc) => desc.as_str(),
+        }
+    }
+
+    /// Parse a template name string into a `MeetingTemplateKind`.
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name.to_ascii_lowercase().as_str() {
+            "standup" => Some(Self::Standup),
+            "retro" | "retrospective" => Some(Self::Retro),
+            "planning" | "sprint-planning" => Some(Self::Planning),
+            _ => None,
+        }
+    }
+}
+
 /// Current status of a meeting session.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SessionStatus {
@@ -43,6 +75,19 @@ pub struct SessionStatus {
     pub message_count: usize,
     pub started_at: String,
     pub is_open: bool,
+    pub duration_display: Option<String>,
+    pub active_template: Option<String>,
+}
+
+/// Detailed progress snapshot for the `/progress` command.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct MeetingProgress {
+    pub duration_display: String,
+    pub operator_messages: usize,
+    pub agent_messages: usize,
+    pub topics: Vec<String>,
+    pub action_items: Vec<String>,
+    pub pending_decisions: Vec<String>,
 }
 
 /// Persisted transcript format written to `~/.simard/meetings/`.
@@ -113,10 +158,27 @@ mod tests {
             message_count: 3,
             started_at: "2025-01-01T00:00:00Z".to_string(),
             is_open: true,
+            duration_display: Some("5m 32s".to_string()),
+            active_template: None,
         };
         let json = serde_json::to_string(&status).unwrap();
         let s2: SessionStatus = serde_json::from_str(&json).unwrap();
         assert_eq!(status, s2);
+    }
+
+    #[test]
+    fn meeting_progress_serde() {
+        let progress = MeetingProgress {
+            duration_display: "5m 32s".to_string(),
+            operator_messages: 3,
+            agent_messages: 3,
+            topics: vec!["API design".to_string()],
+            action_items: vec!["Fix the tests".to_string()],
+            pending_decisions: vec!["Choose a database".to_string()],
+        };
+        let json = serde_json::to_string(&progress).unwrap();
+        let p2: MeetingProgress = serde_json::from_str(&json).unwrap();
+        assert_eq!(progress, p2);
     }
 
     #[test]

--- a/src/meeting_repl/repl.rs
+++ b/src/meeting_repl/repl.rs
@@ -8,10 +8,23 @@ use std::io::{BufRead, Write};
 use crate::base_types::BaseTypeSession;
 use crate::cognitive_memory::CognitiveMemoryOps;
 use crate::error::{SimardError, SimardResult};
-use crate::meeting_backend::{MeetingBackend, MeetingCommand, parse_command};
+use crate::meeting_backend::{
+    MeetingBackend, MeetingCommand, find_template, format_template, list_templates, parse_command,
+};
 use crate::meeting_facilitator::MeetingSession;
 
 const PROMPT: &str = "simard:meeting> ";
+
+/// Spinner frames for progress indication during LLM calls.
+const SPINNER: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+fn show_progress(label: &str) {
+    eprint!("  {} {}...", SPINNER[0], label);
+}
+
+fn clear_progress() {
+    eprint!("\r\x1b[K");
+}
 
 /// Run the interactive meeting REPL.
 ///
@@ -73,7 +86,7 @@ pub fn run_meeting_repl<R: BufRead, W: Write>(
             MeetingCommand::Help => {
                 writeln!(
                     output,
-                    "Commands:\n  /status  — show session info\n  /close   — end meeting and persist\n  /help    — this message\n\nEverything else is natural conversation with Simard."
+                    "Commands:\n  /status          — show session info\n  /progress        — show meeting progress (duration, topics, action items)\n  /export          — save transcript as markdown\n  /template <name> — load a meeting template (standup, retro, planning, 1on1, bug-triage)\n  /close           — end meeting and persist\n  /help            — this message\n\nEverything else is natural conversation with Simard."
                 )
                 .ok();
             }
@@ -82,25 +95,109 @@ pub fn run_meeting_repl<R: BufRead, W: Write>(
                 writeln!(output, "Meeting: {}", status.topic).ok();
                 writeln!(output, "  Messages: {}", status.message_count).ok();
                 writeln!(output, "  Started:  {}", status.started_at).ok();
+                if let Some(ref dur) = status.duration_display {
+                    writeln!(output, "  Meeting duration: {dur}").ok();
+                }
+                if let Some(ref tmpl) = status.active_template {
+                    writeln!(output, "  Template: {tmpl}").ok();
+                }
+            }
+            MeetingCommand::Progress => {
+                let p = backend.progress();
+                writeln!(output, "── Meeting Progress ──").ok();
+                writeln!(output, "  Duration:   {}", p.duration_display).ok();
+                writeln!(
+                    output,
+                    "  Messages:   {} operator, {} agent",
+                    p.operator_messages, p.agent_messages
+                )
+                .ok();
+                if !p.topics.is_empty() {
+                    writeln!(output, "  Topics discussed:").ok();
+                    for t in &p.topics {
+                        writeln!(output, "    • {t}").ok();
+                    }
+                }
+                if !p.action_items.is_empty() {
+                    writeln!(output, "  Action items:").ok();
+                    for a in &p.action_items {
+                        writeln!(output, "    ☐ {a}").ok();
+                    }
+                }
+                if !p.pending_decisions.is_empty() {
+                    writeln!(output, "  Pending decisions:").ok();
+                    for d in &p.pending_decisions {
+                        writeln!(output, "    ⚑ {d}").ok();
+                    }
+                }
+                if p.topics.is_empty()
+                    && p.action_items.is_empty()
+                    && p.pending_decisions.is_empty()
+                {
+                    writeln!(
+                        output,
+                        "  No topics, action items, or decisions extracted yet."
+                    )
+                    .ok();
+                }
             }
             MeetingCommand::Close => {
                 writeln!(output, "Closing meeting.").ok();
                 break;
             }
+            MeetingCommand::Export => match backend.export_markdown() {
+                Ok(path) => {
+                    writeln!(output, "✓ Markdown exported: {}", path.display()).ok();
+                }
+                Err(e) => {
+                    writeln!(output, "[export error: {e}]").ok();
+                }
+            },
+            MeetingCommand::Template(name) => {
+                if name.is_empty() {
+                    writeln!(output, "{}", list_templates()).ok();
+                } else if let Some(tmpl) = find_template(&name) {
+                    writeln!(output, "{}", format_template(tmpl)).ok();
+                    show_progress("Loading template");
+                    match backend.send_message(tmpl.opening_prompt) {
+                        Ok(resp) => {
+                            clear_progress();
+                            if !resp.content.is_empty() {
+                                writeln!(output, "\n{}\n", resp.content).ok();
+                            }
+                        }
+                        Err(e) => {
+                            clear_progress();
+                            writeln!(output, "[agent error: {e}]").ok();
+                        }
+                    }
+                } else {
+                    writeln!(output, "Unknown template: '{name}'").ok();
+                    writeln!(output, "{}", list_templates()).ok();
+                }
+            }
             MeetingCommand::Conversation(text) => {
                 if text.is_empty() {
                     continue;
                 }
-                eprint!("  ⏳ Thinking...");
+                show_progress("Thinking");
                 match backend.send_message(&text) {
                     Ok(resp) => {
-                        eprintln!("\r                "); // clear the thinking indicator
+                        clear_progress();
                         if !resp.content.is_empty() {
                             writeln!(output, "\n{}\n", resp.content).ok();
                         }
+                        // Brief inline progress after each turn
+                        writeln!(
+                            output,
+                            "  [{} messages · {}]",
+                            backend.message_count(),
+                            backend.elapsed_display(),
+                        )
+                        .ok();
                     }
                     Err(e) => {
-                        eprintln!("\r                "); // clear the thinking indicator
+                        clear_progress();
                         writeln!(output, "[agent error: {e}]").ok();
                     }
                 }
@@ -109,8 +206,10 @@ pub fn run_meeting_repl<R: BufRead, W: Write>(
     }
 
     // Close the backend (summarize, persist, memory)
+    show_progress("Generating summary");
     match backend.close() {
         Ok(summary) => {
+            clear_progress();
             writeln!(output, "\n── Meeting Summary ──").ok();
             writeln!(output, "{}", summary.summary_text).ok();
             writeln!(
@@ -124,6 +223,7 @@ pub fn run_meeting_repl<R: BufRead, W: Write>(
             }
         }
         Err(e) => {
+            clear_progress();
             writeln!(output, "[warn] Failed to close meeting cleanly: {e}").ok();
         }
     }

--- a/src/operator_commands_dashboard/routes.rs
+++ b/src/operator_commands_dashboard/routes.rs
@@ -795,6 +795,104 @@ async fn handle_ws_chat(mut socket: WebSocket) {
                             }
                         }
                     }
+                    MeetingCommand::Export => {
+                        let msg = match backend.export_markdown() {
+                            Ok(path) => format!("✓ Markdown exported: {}", path.display()),
+                            Err(e) => format!("[export error: {e}]"),
+                        };
+                        let _ = socket
+                            .send(Message::Text(
+                                json!({"role":"system","content": msg}).to_string().into(),
+                            ))
+                            .await;
+                    }
+                    MeetingCommand::Template(name) => {
+                        let msg = if name.is_empty() {
+                            crate::meeting_backend::list_templates()
+                        } else {
+                            match crate::meeting_backend::find_template(&name) {
+                                Some(tmpl) => crate::meeting_backend::format_template(tmpl),
+                                None => format!("Unknown template: '{name}'"),
+                            }
+                        };
+                        let _ = socket
+                            .send(Message::Text(
+                                json!({"role":"system","content": msg}).to_string().into(),
+                            ))
+                            .await;
+                        // If template found, send its opening prompt to the agent
+                        if !name.is_empty()
+                            && let Some(tmpl) = crate::meeting_backend::find_template(&name)
+                        {
+                            let opening = tmpl.opening_prompt.to_string();
+                            let result = tokio::task::spawn_blocking(move || {
+                                let resp = backend.send_message(&opening);
+                                (backend, resp)
+                            })
+                            .await;
+                            match result {
+                                Ok((returned_backend, Ok(resp))) => {
+                                    backend = returned_backend;
+                                    let _ = socket
+                                        .send(Message::Text(
+                                            json!({"role":"assistant","content": resp.content})
+                                                .to_string()
+                                                .into(),
+                                        ))
+                                        .await;
+                                }
+                                Ok((returned_backend, Err(e))) => {
+                                    backend = returned_backend;
+                                    let _ = socket
+                                            .send(Message::Text(
+                                                json!({"role":"system","content": format!("[error: {e}]")})
+                                                    .to_string()
+                                                    .into(),
+                                            ))
+                                            .await;
+                                }
+                                Err(e) => {
+                                    let _ = socket
+                                            .send(Message::Text(
+                                                json!({"role":"system","content": format!("[internal error: {e}]")})
+                                                    .to_string()
+                                                    .into(),
+                                            ))
+                                            .await;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    MeetingCommand::Progress => {
+                        let p = backend.progress();
+                        let msg = format!(
+                            "Duration: {}\nMessages: {} operator, {} agent\nTopics: {}\nAction items: {}\nPending decisions: {}",
+                            p.duration_display,
+                            p.operator_messages,
+                            p.agent_messages,
+                            if p.topics.is_empty() {
+                                "none".to_string()
+                            } else {
+                                p.topics.join(", ")
+                            },
+                            if p.action_items.is_empty() {
+                                "none".to_string()
+                            } else {
+                                p.action_items.join(", ")
+                            },
+                            if p.pending_decisions.is_empty() {
+                                "none".to_string()
+                            } else {
+                                p.pending_decisions.join(", ")
+                            },
+                        );
+                        let _ = socket
+                            .send(Message::Text(
+                                json!({"role":"system","content": msg}).to_string().into(),
+                            ))
+                            .await;
+                    }
                 }
             }
             Message::Close(_) => {

--- a/tests/parser_proptest.rs
+++ b/tests/parser_proptest.rs
@@ -19,6 +19,9 @@ proptest! {
             MeetingCommand::Help
             | MeetingCommand::Close
             | MeetingCommand::Status
+            | MeetingCommand::Export
+            | MeetingCommand::Progress
+            | MeetingCommand::Template(_)
             | MeetingCommand::Conversation(_) => {}
         }
     }


### PR DESCRIPTION
## Summary
Implements issue #311: Meeting UX enhancements.

### Changes

**1. Meeting Templates (`/template` command)**
- 5 built-in templates: `standup`, `retro`, `planning`, `1on1`, `bug-triage`
- Aliases: `sprint-planning` → `planning`, `retrospective` → `retro`
- `/template` with no args lists all available templates
- `/template <name>` shows agenda and sends opening prompt to agent

**2. Progress Indicators (`/progress` command)**
- Duration display
- Message count split by operator vs agent
- Topic extraction from short user messages
- Action item extraction (keyword-based: `action item:`, `TODO:`, etc.)
- Pending decision extraction (`decision:`, `TBD`, `needs decision`, etc.)
- Inline progress shown after each conversation turn

**3. Markdown Export (`/export` command)**
- Exports full transcript as clean markdown to `~/.simard/meetings/`
- Includes metadata header (topic, start time, duration, message count)
- Chronological transcript with speaker labels and timestamps

### Testing
- 43 meeting_backend tests passing (including 5 new progress tests)
- 5 meeting_repl tests passing
- `cargo check` clean

Closes #311