### PR TITLE
feat: progress spinner during LLM calls in meeting REPL (#552)

### DIFF
--- a/src/meeting_repl/mod.rs
+++ b/src/meeting_repl/mod.rs
@@ -4,6 +4,7 @@
 //! the CLI-specific REPL loop and backward-compatible re-exports.
 
 mod repl;
+mod spinner;
 #[cfg(test)]
 mod test_support;
 

--- a/src/meeting_repl/repl.rs
+++ b/src/meeting_repl/repl.rs
@@ -11,6 +11,8 @@ use crate::error::{SimardError, SimardResult};
 use crate::meeting_backend::{MeetingBackend, MeetingCommand, parse_command};
 use crate::meeting_facilitator::MeetingSession;
 
+use super::spinner::Spinner;
+
 const PROMPT: &str = "simard:meeting> ";
 
 /// Run the interactive meeting REPL.
@@ -99,16 +101,16 @@ pub fn run_meeting_repl<R: BufRead, W: Write>(
                          Please follow this agenda:\n{}",
                         tmpl.name, tmpl.agenda
                     );
-                    eprint!("  ⏳ Applying template...");
+                    let spinner = Spinner::after_default_delay("Applying template...");
                     match backend.send_message(&ctx) {
                         Ok(resp) => {
-                            eprint!("\r\x1b[K");
+                            spinner.stop();
                             if !resp.content.is_empty() {
                                 writeln!(output, "{}\n", resp.content).ok();
                             }
                         }
                         Err(e) => {
-                            eprint!("\r\x1b[K");
+                            spinner.stop();
                             writeln!(output, "[agent error: {e}]").ok();
                         }
                     }
@@ -119,41 +121,41 @@ pub fn run_meeting_repl<R: BufRead, W: Write>(
             }
             MeetingCommand::Export => {
                 use crate::meeting_backend::persist::write_markdown_export;
-                eprint!("  ⏳ Exporting...");
+                let spinner = Spinner::after_default_delay("Exporting...");
                 match write_markdown_export(
                     backend.topic(),
                     backend.started_at(),
                     backend.history(),
                 ) {
                     Ok(path) => {
-                        eprint!("\r\x1b[K");
+                        spinner.stop();
                         writeln!(output, "Meeting exported to: {}", path.display()).ok();
                     }
                     Err(e) => {
-                        eprint!("\r\x1b[K");
+                        spinner.stop();
                         writeln!(output, "[export error: {e}]").ok();
                     }
                 }
             }
             MeetingCommand::Close => {
                 writeln!(output, "Closing meeting...").ok();
-                eprint!("  Generating summary (timeout: 90s)...");
+                // Spinner for the close/summary will be handled below.
                 break;
             }
             MeetingCommand::Conversation(text) => {
                 if text.is_empty() {
                     continue;
                 }
-                eprint!("  ⏳ Thinking...");
+                let spinner = Spinner::after_default_delay("Thinking...");
                 match backend.send_message(&text) {
                     Ok(resp) => {
-                        eprint!("\r\x1b[K"); // clear thinking indicator
+                        spinner.stop();
                         if !resp.content.is_empty() {
                             writeln!(output, "\n{}\n", resp.content).ok();
                         }
                     }
                     Err(e) => {
-                        eprint!("\r\x1b[K");
+                        spinner.stop();
                         writeln!(output, "[agent error: {e}]").ok();
                     }
                 }
@@ -162,9 +164,10 @@ pub fn run_meeting_repl<R: BufRead, W: Write>(
     }
 
     // Close the backend (summarize, persist, memory)
+    let spinner = Spinner::after_default_delay("Generating summary...");
     match backend.close() {
         Ok(summary) => {
-            eprint!("\r\x1b[K");
+            spinner.stop();
             writeln!(output, "\n── Meeting Summary ──").ok();
             writeln!(output, "{}", summary.summary_text).ok();
             writeln!(
@@ -178,7 +181,7 @@ pub fn run_meeting_repl<R: BufRead, W: Write>(
             }
         }
         Err(e) => {
-            eprint!("\r\x1b[K");
+            // spinner dropped here, which also cleans up
             writeln!(output, "[warn] Failed to close meeting cleanly: {e}").ok();
         }
     }

--- a/src/meeting_repl/spinner.rs
+++ b/src/meeting_repl/spinner.rs
@@ -1,0 +1,160 @@
+//! Lightweight progress spinner for LLM calls in the meeting REPL.
+//!
+//! Shows an animated spinner on stderr after a configurable delay (default
+//! 500 ms). Automatically suppressed when stderr is not a terminal.
+
+use std::io::{IsTerminal, Write};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+use std::time::Duration;
+
+const FRAMES: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+const FRAME_INTERVAL: Duration = Duration::from_millis(80);
+
+/// Default delay before the spinner becomes visible.
+pub const DEFAULT_DELAY: Duration = Duration::from_millis(500);
+
+/// A progress spinner that animates on stderr in a background thread.
+///
+/// Create with [`Spinner::new`], which returns immediately. The spinner
+/// thread starts animating after `delay` elapses. Call [`Spinner::stop`]
+/// (or drop) to clear the line and join the thread.
+///
+/// In non-TTY mode the spinner is a no-op: no thread is spawned and
+/// `stop` returns instantly.
+pub struct Spinner {
+    stop_flag: Arc<AtomicBool>,
+    handle: Option<thread::JoinHandle<()>>,
+}
+
+impl Spinner {
+    /// Start a spinner that will display `message` on stderr after `delay`.
+    ///
+    /// If stderr is not a terminal, returns a no-op spinner.
+    pub fn new(message: &str, delay: Duration) -> Self {
+        if !std::io::stderr().is_terminal() {
+            return Self::noop();
+        }
+        Self::spawn(message.to_string(), delay)
+    }
+
+    /// Start a spinner with the default 500 ms delay.
+    pub fn after_default_delay(message: &str) -> Self {
+        Self::new(message, DEFAULT_DELAY)
+    }
+
+    /// Create a no-op spinner (no thread, no output).
+    fn noop() -> Self {
+        Self {
+            stop_flag: Arc::new(AtomicBool::new(true)),
+            handle: None,
+        }
+    }
+
+    fn spawn(message: String, delay: Duration) -> Self {
+        let stop_flag = Arc::new(AtomicBool::new(false));
+        let flag = stop_flag.clone();
+
+        let handle = thread::spawn(move || {
+            // Wait for the delay period, checking for early cancellation.
+            let deadline = std::time::Instant::now() + delay;
+            while std::time::Instant::now() < deadline {
+                if flag.load(Ordering::Relaxed) {
+                    return;
+                }
+                thread::sleep(Duration::from_millis(20));
+            }
+
+            // Animate until stopped.
+            let mut idx = 0;
+            let mut stderr = std::io::stderr().lock();
+            while !flag.load(Ordering::Relaxed) {
+                let frame = FRAMES[idx % FRAMES.len()];
+                let _ = write!(stderr, "\r  {frame} {message}");
+                let _ = stderr.flush();
+                idx += 1;
+                // Sleep in small increments so we can check the flag.
+                for _ in 0..(FRAME_INTERVAL.as_millis() / 20) {
+                    if flag.load(Ordering::Relaxed) {
+                        break;
+                    }
+                    thread::sleep(Duration::from_millis(20));
+                }
+            }
+            // Clear the spinner line.
+            let _ = write!(stderr, "\r\x1b[K");
+            let _ = stderr.flush();
+        });
+
+        Self {
+            stop_flag,
+            handle: Some(handle),
+        }
+    }
+
+    /// Stop the spinner and clear the line. Idempotent.
+    pub fn stop(mut self) {
+        self.cancel();
+    }
+
+    fn cancel(&mut self) {
+        self.stop_flag.store(true, Ordering::Relaxed);
+        if let Some(h) = self.handle.take() {
+            let _ = h.join();
+        }
+    }
+}
+
+impl Drop for Spinner {
+    fn drop(&mut self) {
+        self.cancel();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn noop_spinner_stop_is_harmless() {
+        let spinner = Spinner::noop();
+        spinner.stop(); // should not panic
+    }
+
+    #[test]
+    fn spinner_cancelled_before_delay_produces_no_output() {
+        // Use a very long delay so we can cancel before any frames render.
+        let spinner = Spinner::spawn("Testing...".to_string(), Duration::from_secs(60));
+        // Cancel immediately — the thread should exit without writing frames.
+        spinner.stop();
+    }
+
+    #[test]
+    fn spinner_drop_cleans_up() {
+        let spinner = Spinner::spawn("Drop test".to_string(), Duration::from_millis(10));
+        // Let a few frames render.
+        thread::sleep(Duration::from_millis(100));
+        drop(spinner); // should join cleanly
+    }
+
+    #[test]
+    fn noop_when_not_tty() {
+        // In a test environment stderr is typically not a TTY, so `new`
+        // should return a no-op spinner. We verify the handle is None.
+        let spinner = Spinner::new("should be noop", DEFAULT_DELAY);
+        assert!(
+            spinner.handle.is_none(),
+            "Spinner::new should be no-op when stderr is not a TTY"
+        );
+        spinner.stop();
+    }
+
+    #[test]
+    fn default_delay_is_500ms() {
+        assert_eq!(DEFAULT_DELAY, Duration::from_millis(500));
+    }
+}


### PR DESCRIPTION
## Summary
Adds a lightweight animated spinner to the meeting REPL that appears on stderr after 500ms when waiting for LLM responses. Automatically suppressed in non-TTY/piped mode.

## Changes
- **src/meeting_repl/spinner.rs** — new module: Spinner struct with background thread, configurable delay, atomic stop flag
- **src/meeting_repl/repl.rs** — wraps LLM adapter calls with Spinner::after_default_delay
- **src/meeting_repl/mod.rs** — exports spinner module

## Tests
4 new unit tests: default delay, no-op in non-TTY, early cancel, drop cleanup. All 10 meeting_repl tests pass.

Closes #552