### PR TITLE
fix: dashboard logs tab reads OODA daemon log file (#414)

### DIFF
--- a/src/operator_commands_dashboard/routes.rs
+++ b/src/operator_commands_dashboard/routes.rs
@@ -1025,9 +1025,39 @@ async fn logs() -> Json<Value> {
         read_tail(&ledger.to_string_lossy(), 50).unwrap_or_default()
     };
 
+    // Collect recent terminal session transcripts from /tmp (#414)
+    let mut terminal_transcripts: Vec<Value> = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(std::env::temp_dir()) {
+        let mut files: Vec<_> = entries
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                e.file_name()
+                    .to_string_lossy()
+                    .starts_with("simard-terminal-shell-")
+            })
+            .collect();
+        files.sort_by_key(|e| std::cmp::Reverse(e.path()));
+        for entry in files.into_iter().take(10) {
+            let path = entry.path();
+            let name = path
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .to_string();
+            let size = std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+            let preview = read_tail(&path.to_string_lossy(), 20).unwrap_or_default();
+            terminal_transcripts.push(json!({
+                "name": name,
+                "size_bytes": size,
+                "preview_lines": preview,
+            }));
+        }
+    }
+
     Json(json!({
         "daemon_log_lines": combined_log,
         "ooda_transcripts": transcripts,
+        "terminal_transcripts": terminal_transcripts,
         "cost_log_lines": cost_log,
         "timestamp": chrono::Utc::now().to_rfc3339(),
     }))
@@ -1529,6 +1559,8 @@ const INDEX_HTML: &str = r##"<!DOCTYPE html>
     </div>
     <h2 style="color:var(--accent);font-size:1rem;margin-bottom:.5rem">OODA Transcripts</h2>
     <div id="ooda-transcripts"><span class="loading">Loading…</span></div>
+    <h2 style="color:var(--accent);font-size:1rem;margin:.75rem 0 .5rem">Terminal Session Transcripts</h2>
+    <div id="terminal-transcripts"><span class="loading">Loading…</span></div>
   </div>
 
   <div class="tab-content" id="tab-processes">
@@ -1691,6 +1723,14 @@ const INDEX_HTML: &str = r##"<!DOCTYPE html>
               <div class="log-box" style="max-height:200px">${esc((t.preview_lines||[]).join('\n'))||'(empty)'}</div>
             </div>`).join('');
         }else{tEl.innerHTML='<span style="color:#8b949e">No OODA transcripts found in state root. Run the OODA daemon to generate transcripts.</span>';}
+        const ttEl=document.getElementById('terminal-transcripts');
+        if(d.terminal_transcripts?.length){
+          ttEl.innerHTML=d.terminal_transcripts.map(t=>`
+            <div class="transcript-item">
+              <h3>${esc(t.name)} <span class="badge">${fmtB(t.size_bytes)}</span></h3>
+              <div class="log-box" style="max-height:200px">${esc((t.preview_lines||[]).join('\n'))||'(empty)'}</div>
+            </div>`).join('');
+        }else{ttEl.innerHTML='<span style="color:#8b949e">No terminal session transcripts found.</span>';}
         const costEl=document.getElementById('cost-log-box');
         if(d.cost_log_lines?.length){
           costEl.textContent=d.cost_log_lines.join('\n');

--- a/src/operator_commands_ooda/daemon.rs
+++ b/src/operator_commands_ooda/daemon.rs
@@ -14,6 +14,25 @@ use crate::session_builder::SessionBuilder;
 
 use super::persistence::{persist_cycle_report, persist_cycle_to_memory};
 
+/// Append a timestamped log line to `{state_root}/ooda.log` **and** stderr.
+///
+/// The dashboard `/api/logs` endpoint already looks for `ooda.log` inside the
+/// state root, so writing here makes daemon output visible in the Logs tab
+/// without requiring systemd or manual redirection.  Failures to write are
+/// silently ignored — stderr is the primary output channel.
+fn daemon_log(state_root: &std::path::Path, msg: &str) {
+    let line = format!("{} {msg}", chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ"),);
+    eprintln!("{msg}");
+    use std::io::Write;
+    if let Ok(mut f) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(state_root.join("ooda.log"))
+    {
+        let _ = writeln!(f, "{line}");
+    }
+}
+
 /// Return the mtime of the currently-running executable, or `None` if it
 /// cannot be determined (e.g. the binary was deleted after launch).
 fn exe_mtime() -> Option<SystemTime> {
@@ -146,7 +165,10 @@ pub fn run_ooda_daemon(
         .adapter_tag("ooda")
         .open()
         .map_err(|e| format!("OODA daemon requires LLM session but open() failed: {e}"))?;
-    eprintln!("[simard] OODA daemon: LLM session opened for autonomous work");
+    daemon_log(
+        &state_root,
+        "[simard] OODA daemon: LLM session opened for autonomous work",
+    );
 
     let mut bridges = OodaBridges {
         memory,
@@ -164,7 +186,10 @@ pub fn run_ooda_daemon(
         .and_then(|v| v.parse().ok())
         .unwrap_or(300);
 
-    eprintln!("[simard] OODA daemon: cycle interval = {interval_secs}s");
+    daemon_log(
+        &state_root,
+        &format!("[simard] OODA daemon: cycle interval = {interval_secs}s"),
+    );
 
     // --- embedded dashboard ------------------------------------------------
     // Spawn the dashboard as a background tokio task so both OODA loop and
@@ -195,7 +220,10 @@ pub fn run_ooda_daemon(
     } else {
         _dashboard_rt = None;
         _dashboard_handle = None;
-        eprintln!("[simard] OODA daemon: dashboard disabled (use --no-dashboard to suppress)");
+        daemon_log(
+            &state_root,
+            "[simard] OODA daemon: dashboard disabled (use --no-dashboard to suppress)",
+        );
     }
     // -----------------------------------------------------------------------
 
@@ -203,7 +231,7 @@ pub fn run_ooda_daemon(
     let start_time = exe_mtime().unwrap_or_else(SystemTime::now);
 
     if auto_reload {
-        eprintln!("[simard] OODA daemon: auto-reload enabled");
+        daemon_log(&state_root, "[simard] OODA daemon: auto-reload enabled");
     }
 
     let mut cycles_run = 0u32;
@@ -211,7 +239,10 @@ pub fn run_ooda_daemon(
     loop {
         // Check for shutdown signal at the top of each iteration.
         if shutdown.load(Ordering::SeqCst) {
-            eprintln!("[simard] OODA daemon: shutting down gracefully");
+            daemon_log(
+                &state_root,
+                "[simard] OODA daemon: shutting down gracefully",
+            );
             break;
         }
 
@@ -227,7 +258,10 @@ pub fn run_ooda_daemon(
         }
 
         if max_cycles > 0 && cycles_run >= max_cycles {
-            eprintln!("[simard] OODA daemon: completed {cycles_run} cycle(s), exiting");
+            daemon_log(
+                &state_root,
+                &format!("[simard] OODA daemon: completed {cycles_run} cycle(s), exiting"),
+            );
             break;
         }
 
@@ -256,7 +290,7 @@ pub fn run_ooda_daemon(
             Ok(report) => {
                 let cycle_elapsed = cycle_start.elapsed();
                 let summary = summarize_cycle_report(&report);
-                eprintln!("[simard] {summary}");
+                daemon_log(&state_root, &format!("[simard] {summary}"));
                 // Persist the cycle report to filesystem for auditability.
                 persist_cycle_report(&state_root, &report);
                 // Persist the cycle summary to cognitive memory as an episode.
@@ -287,7 +321,7 @@ pub fn run_ooda_daemon(
                 }
             }
             Err(e) => {
-                eprintln!("[simard] OODA cycle error: {e}");
+                daemon_log(&state_root, &format!("[simard] OODA cycle error: {e}"));
             }
         }
 


### PR DESCRIPTION
## Problem
The dashboard Logs tab was empty because `/api/logs` returned no data.


## Fix
- **`daemon_log()` helper** in `daemon.rs` — tees messages to both stderr and `{state_root}/ooda.log`. The dashboard already checks for this file.
- **Terminal transcript discovery** — `/api/logs` now scans `/tmp` for `simard-terminal-shell-*.log` files and returns the 10 most recent as `terminal_transcripts`.
- **UI update** — Logs tab now shows a Terminal Session Transcripts section.

## Testing
- `cargo check` ✅
- `cargo test --lib -- operator_commands_ooda` — 45 tests passed ✅

Closes #414