### PR TITLE
fix: dashboard goals tab shows data from both GoalBoard and GoalRecord formats (#415)

### DIFF
--- a/src/operator_commands_dashboard/routes.rs
+++ b/src/operator_commands_dashboard/routes.rs
@@ -11,6 +11,8 @@ use crate::agent_registry::{AgentRegistry, FileBackedAgentRegistry};
 use crate::build_lock::BuildLock;
 use crate::cognitive_memory::{CognitiveMemoryOps, NativeCognitiveMemory};
 use crate::error::{SimardError, SimardResult};
+use crate::goal_curation::GoalBoard;
+use crate::goals::GoalRecord;
 
 pub fn build_router() -> Router {
     Router::new()
@@ -244,17 +246,55 @@ async fn goals() -> Json<Value> {
     let goal_path = state_root.join("goal_records.json");
     let content = std::fs::read_to_string(&goal_path).unwrap_or_default();
 
-    let (active, mut backlog) = match serde_json::from_str::<Value>(&content) {
-        Ok(val) if val.is_object() => {
-            let a = val.get("active").cloned().unwrap_or(json!([]));
-            let b = val.get("backlog").cloned().unwrap_or(json!([]));
-            (
-                a.as_array().cloned().unwrap_or_default(),
-                b.as_array().cloned().unwrap_or_default(),
-            )
+    let (active, mut backlog) = match serde_json::from_str::<GoalBoard>(&content) {
+        // GoalBoard from OODA loop — already has the right schema.
+        Ok(board) => {
+            let a: Vec<Value> = board
+                .active
+                .into_iter()
+                .map(|g| {
+                    json!({
+                        "id": g.id,
+                        "description": g.description,
+                        "priority": g.priority,
+                        "status": g.status.to_string(),
+                        "assigned_to": g.assigned_to,
+                    })
+                })
+                .collect();
+            let b: Vec<Value> = board
+                .backlog
+                .into_iter()
+                .map(|g| {
+                    json!({
+                        "id": g.id,
+                        "description": g.description,
+                        "source": g.source,
+                        "score": g.score,
+                    })
+                })
+                .collect();
+            (a, b)
         }
-        Ok(val) if val.is_array() => (val.as_array().cloned().unwrap_or_default(), vec![]),
-        _ => (vec![], vec![]),
+        Err(_) => match serde_json::from_str::<Vec<GoalRecord>>(&content) {
+            // Flat array of GoalRecord from FileBackedGoalStore — map fields.
+            Ok(records) => {
+                let mapped: Vec<Value> = records
+                    .into_iter()
+                    .map(|r| {
+                        json!({
+                            "id": r.slug,
+                            "description": r.title,
+                            "priority": r.priority,
+                            "status": r.status.to_string(),
+                            "assigned_to": r.owner_identity,
+                        })
+                    })
+                    .collect();
+                (mapped, vec![])
+            }
+            Err(_) => (vec![], vec![]),
+        },
     };
 
     // Pull meeting-captured actions and decisions from cognitive memory (#415)


### PR DESCRIPTION
## Problem

The `/api/goals` endpoint returned empty data despite meeting-captured actions existing. The dashboard goals tab was empty because:

1. **Schema mismatch**: `FileBackedGoalStore` (used by meeting goal curation) writes a flat `Vec<GoalRecord>` to `goal_records.json` with fields `slug`, `title`, `rationale`, `owner_identity`. The handler read these as raw JSON arrays but the frontend expected `id`, `description`, `assigned_to` — resulting in undefined values rendered as empty rows.

2. **Format confusion**: The OODA loop writes a `GoalBoard` (object with `active`/`backlog` keys using `ActiveGoal`/`BacklogItem` types that match the frontend schema). The old handler used untyped JSON matching that couldn't properly map both formats.

## Fix

Replace raw `serde_json::Value` parsing with typed deserialization:

1. Try `GoalBoard` first (OODA format) — maps `ActiveGoal`/`BacklogItem` fields to frontend schema
2. Fall back to `Vec<GoalRecord>` (FileBackedGoalStore format) — maps `slug→id`, `title→description`, `owner_identity→assigned_to`
3. Empty fallback if neither parses

Cognitive memory augmentation for meeting-captured actions/decisions is unchanged.

## Testing

- `cargo check` passes
- All 21 `operator_commands_dashboard` tests pass

Closes #415