### PR TITLE
feat: move Distributed tab contents into System Status on Overview page (#564)

### DIFF
--- a/src/operator_commands_dashboard/routes.rs
+++ b/src/operator_commands_dashboard/routes.rs
@@ -1441,7 +1441,6 @@ const INDEX_HTML: &str = r##"<!DOCTYPE html>
   </header>
   <div class="tabs">
     <div class="tab active" data-tab="overview">Overview</div>
-    <div class="tab" data-tab="distributed">Distributed</div>
     <div class="tab" data-tab="goals">Goals</div>
     <div class="tab" data-tab="traces">Traces</div>
     <div class="tab" data-tab="logs">Logs</div>
@@ -1455,11 +1454,6 @@ const INDEX_HTML: &str = r##"<!DOCTYPE html>
     <div class="grid">
       <div class="card"><h2>System Status</h2><div id="status"><span class="loading">Loading…</span></div></div>
       <div class="card"><h2>Open Issues</h2><ul id="issues-list"><li class="loading">Loading…</li></ul></div>
-    </div>
-  </div>
-
-  <div class="tab-content" id="tab-distributed">
-    <div class="grid">
       <div class="card">
         <h2>Cluster Topology <button class="btn" onclick="fetchDistributed()">Refresh</button></h2>
         <div id="cluster-topology"><span class="loading">Loading…</span></div>
@@ -1626,7 +1620,7 @@ const INDEX_HTML: &str = r##"<!DOCTYPE html>
         if(tab.dataset.tab==='logs') {fetchLogs();tabRefreshTimers.logs=setInterval(fetchLogs,15000);}
         if(tab.dataset.tab==='processes') {fetchProcesses();tabRefreshTimers.proc=setInterval(fetchProcesses,10000);}
         if(tab.dataset.tab==='memory') fetchMemory();
-        if(tab.dataset.tab==='distributed') fetchDistributed();
+
         if(tab.dataset.tab==='goals') fetchGoals();
         if(tab.dataset.tab==='costs') fetchCosts();
         if(tab.dataset.tab==='traces') fetchTraces();
@@ -2017,7 +2011,7 @@ const INDEX_HTML: &str = r##"<!DOCTYPE html>
     });
 
     /* --- Init --- */
-    fetchStatus(); fetchIssues();
+    fetchStatus(); fetchIssues(); fetchDistributed();
     setInterval(fetchStatus,30000);
     setInterval(fetchIssues,120000);
   </script>
@@ -2085,9 +2079,8 @@ mod tests {
     }
 
     #[test]
-    fn index_html_contains_distributed_tab() {
-        assert!(INDEX_HTML.contains("data-tab=\"distributed\""));
-        assert!(INDEX_HTML.contains("Distributed"));
+    fn index_html_contains_cluster_topology_in_overview() {
+        assert!(!INDEX_HTML.contains("data-tab=\"distributed\""));
         assert!(INDEX_HTML.contains("fetchDistributed"));
         assert!(INDEX_HTML.contains("Cluster Topology"));
         assert!(INDEX_HTML.contains("Remote VMs"));


### PR DESCRIPTION
Fixes #564. Removes the standalone Distributed tab and moves Cluster Topology and Remote VMs content into the System Status section on the Overview page. Fetches distributed data on page load.