### PR TITLE
feat(e2e): add Playwright tests for dashboard (#565)

### DIFF
--- a/tests/e2e-dashboard/pages/overview.page.ts
+++ b/tests/e2e-dashboard/pages/overview.page.ts
@@ -1,0 +1,38 @@
+import { type Page, type Locator } from '@playwright/test';
+
+export class OverviewPage {
+  readonly page: Page;
+  readonly heading: Locator;
+  readonly statusCard: Locator;
+  readonly statusDiv: Locator;
+  readonly issuesCard: Locator;
+  readonly issuesList: Locator;
+  readonly tabs: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.heading = page.locator('text=Simard Dashboard');
+    this.statusCard = page.locator('#tab-overview .card:has(#status)');
+    this.statusDiv = page.locator('#status');
+    this.issuesCard = page.locator('#tab-overview .card:has(#issues-list)');
+    this.issuesList = page.locator('#issues-list');
+    this.tabs = page.locator('.tab');
+  }
+
+  async getTabNames(): Promise<string[]> {
+    const count = await this.tabs.count();
+    const names: string[] = [];
+    for (let i = 0; i < count; i++) {
+      names.push((await this.tabs.nth(i).textContent()) ?? '');
+    }
+    return names;
+  }
+
+  async clickTab(name: string): Promise<void> {
+    await this.page.locator(`.tab[data-tab="${name}"]`).click();
+  }
+
+  async isTabContentVisible(name: string): Promise<boolean> {
+    return this.page.locator(`#tab-${name}`).isVisible();
+  }
+}

--- a/tests/e2e-dashboard/playwright.config.ts
+++ b/tests/e2e-dashboard/playwright.config.ts
@@ -34,8 +34,8 @@ export default defineConfig({
   ],
   webServer: {
     command: process.env.SIMARD_BIN
-      ? `${process.env.SIMARD_BIN} dashboard --port ${PORT}`
-      : `cargo run --release -- dashboard --port ${PORT}`,
+      ? `${process.env.SIMARD_BIN} dashboard serve --port=${PORT}`
+      : `cargo run --release -- dashboard serve --port=${PORT}`,
     url: `http://localhost:${PORT}/login`,
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,

--- a/tests/e2e-dashboard/specs/overview.spec.ts
+++ b/tests/e2e-dashboard/specs/overview.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect } from '../fixtures/simard-dashboard';
+import { OverviewPage } from '../pages/overview.page';
+
+test.describe('Dashboard Overview @structural', () => {
+  let overview: OverviewPage;
+
+  test.beforeEach(async ({ authenticatedPage }) => {
+    // Mock API endpoints so page renders without a live backend
+    await authenticatedPage.route('**/api/status', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          version: '0.7.1.test',
+          git_hash: 'abc1234',
+          ooda_status: 'idle',
+          uptime_secs: 3600,
+        }),
+      }),
+    );
+    await authenticatedPage.route('**/api/issues', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          { number: 1, title: 'Test issue', state: 'open', html_url: '#' },
+        ]),
+      }),
+    );
+
+    await authenticatedPage.goto('/');
+    overview = new OverviewPage(authenticatedPage);
+  });
+
+  test('overview page displays dashboard heading', async () => {
+    await expect(overview.heading).toBeVisible();
+  });
+
+  test('overview tab is active by default', async ({ authenticatedPage }) => {
+    const overviewTab = authenticatedPage.locator('.tab[data-tab="overview"]');
+    await expect(overviewTab).toHaveClass(/active/);
+    await expect(authenticatedPage.locator('#tab-overview')).toBeVisible();
+  });
+
+  test('System Status card renders', async () => {
+    await expect(overview.statusCard).toBeVisible();
+    await expect(overview.statusCard.locator('h2')).toContainText('System Status');
+  });
+
+  test('Open Issues card renders', async () => {
+    await expect(overview.issuesCard).toBeVisible();
+    await expect(overview.issuesCard.locator('h2')).toContainText('Open Issues');
+  });
+
+  test('status div populates from API', async ({ authenticatedPage }) => {
+    // Wait for fetchStatus to complete and render
+    await authenticatedPage.waitForFunction(
+      () => {
+        const el = document.getElementById('status');
+        return el && !el.querySelector('.loading');
+      },
+      { timeout: 10_000 },
+    );
+    const text = await overview.statusDiv.textContent();
+    expect(text).toContain('0.7.1');
+  });
+
+  test('issues list populates from API', async ({ authenticatedPage }) => {
+    await authenticatedPage.waitForFunction(
+      () => {
+        const el = document.getElementById('issues-list');
+        return el && !el.querySelector('.loading');
+      },
+      { timeout: 10_000 },
+    );
+    const text = await overview.issuesList.textContent();
+    expect(text).toContain('Test issue');
+  });
+
+  test('all 9 tabs are present', async () => {
+    const names = await overview.getTabNames();
+    expect(names).toEqual([
+      'Overview',
+      'Distributed',
+      'Goals',
+      'Traces',
+      'Logs',
+      'Processes',
+      'Memory',
+      'Costs',
+      'Chat',
+    ]);
+  });
+});

--- a/tests/e2e-dashboard/specs/system-status.spec.ts
+++ b/tests/e2e-dashboard/specs/system-status.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '../fixtures/simard-dashboard';
+
+test.describe('System Status API @structural', () => {
+  test('/api/status returns JSON with version', async ({
+    authenticatedPage,
+    baseURL,
+  }) => {
+    const resp = await authenticatedPage.request.get(`${baseURL}/api/status`);
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    expect(body).toHaveProperty('version');
+    expect(body).toHaveProperty('git_hash');
+  });
+
+  test('status card updates after fetch', async ({ authenticatedPage }) => {
+    await authenticatedPage.route('**/api/status', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          version: '0.7.1.42',
+          git_hash: 'deadbeef',
+          ooda_status: 'running',
+          uptime_secs: 7200,
+        }),
+      }),
+    );
+    // Mock other endpoints the page fetches on load
+    await authenticatedPage.route('**/api/issues', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
+    );
+
+    await authenticatedPage.goto('/');
+
+    await authenticatedPage.waitForFunction(
+      () => {
+        const el = document.getElementById('status');
+        return el && !el.querySelector('.loading');
+      },
+      { timeout: 10_000 },
+    );
+
+    const statusText = await authenticatedPage.locator('#status').textContent();
+    expect(statusText).toContain('0.7.1.42');
+    // Dashboard truncates git hash to 7 chars
+    expect(statusText).toContain('deadbee');
+  });
+});

--- a/tests/e2e-dashboard/specs/tabs.spec.ts
+++ b/tests/e2e-dashboard/specs/tabs.spec.ts
@@ -1,0 +1,142 @@
+import { test, expect } from '../fixtures/simard-dashboard';
+
+const ALL_TABS = [
+  'overview',
+  'distributed',
+  'goals',
+  'traces',
+  'logs',
+  'processes',
+  'memory',
+  'costs',
+  'chat',
+] as const;
+
+// Mock all API endpoints so tabs render without a live backend
+async function mockAllApis(page: import('@playwright/test').Page) {
+  const emptyJson = { status: 200, contentType: 'application/json', body: '[]' };
+  const emptyObj = { status: 200, contentType: 'application/json', body: '{}' };
+
+  await page.route('**/api/status', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        version: '0.7.1.0',
+        git_hash: 'test',
+        ooda_status: 'idle',
+        uptime_secs: 0,
+      }),
+    }),
+  );
+  await page.route('**/api/issues', (route) => route.fulfill(emptyJson));
+  await page.route('**/api/distributed', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ topology: [], vms: [] }),
+    }),
+  );
+  await page.route('**/api/hosts', (route) => route.fulfill(emptyJson));
+  await page.route('**/api/goals', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ active: [], backlog: [] }),
+    }),
+  );
+  await page.route('**/api/traces', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ otel_status: 'disabled', traces: [] }),
+    }),
+  );
+  await page.route('**/api/logs', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ daemon: '', cost_ledger: '', transcripts: [] }),
+    }),
+  );
+  await page.route('**/api/processes', (route) => route.fulfill(emptyJson));
+  await page.route('**/api/memory', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ overview: {}, files: [] }),
+    }),
+  );
+  await page.route('**/api/costs', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ daily: [], weekly: [] }),
+    }),
+  );
+  await page.route('**/api/budget', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ daily: 10, weekly: 50 }),
+    }),
+  );
+  await page.route('**/api/registry', (route) => route.fulfill(emptyJson));
+  await page.route('**/api/build-lock', (route) => route.fulfill(emptyObj));
+  await page.route('**/api/metrics', (route) => route.fulfill(emptyObj));
+}
+
+test.describe('Tab Navigation @structural', () => {
+  test.beforeEach(async ({ authenticatedPage }) => {
+    await mockAllApis(authenticatedPage);
+    await authenticatedPage.goto('/');
+  });
+
+  for (const tabName of ALL_TABS) {
+    test(`clicking "${tabName}" tab shows its content without JS errors`, async ({
+      authenticatedPage,
+    }) => {
+      const errors: string[] = [];
+      authenticatedPage.on('pageerror', (err) => errors.push(err.message));
+
+      const tab = authenticatedPage.locator(`.tab[data-tab="${tabName}"]`);
+      await tab.click();
+
+      // Tab should become active
+      await expect(tab).toHaveClass(/active/);
+
+      // Tab content panel should be visible
+      const panel = authenticatedPage.locator(`#tab-${tabName}`);
+      await expect(panel).toBeVisible();
+
+      // Other panels should be hidden
+      for (const other of ALL_TABS) {
+        if (other !== tabName) {
+          await expect(
+            authenticatedPage.locator(`#tab-${other}`),
+          ).not.toBeVisible();
+        }
+      }
+
+      // No JS errors should have fired
+      expect(errors).toEqual([]);
+    });
+  }
+
+  test('tab switching preserves content on return', async ({
+    authenticatedPage,
+  }) => {
+    // Go to Goals tab
+    await authenticatedPage.locator('.tab[data-tab="goals"]').click();
+    await expect(authenticatedPage.locator('#tab-goals')).toBeVisible();
+
+    // Go to Logs tab
+    await authenticatedPage.locator('.tab[data-tab="logs"]').click();
+    await expect(authenticatedPage.locator('#tab-logs')).toBeVisible();
+    await expect(authenticatedPage.locator('#tab-goals')).not.toBeVisible();
+
+    // Return to Overview
+    await authenticatedPage.locator('.tab[data-tab="overview"]').click();
+    await expect(authenticatedPage.locator('#tab-overview')).toBeVisible();
+  });
+});


### PR DESCRIPTION
Fixes #565. Adds Playwright E2E tests covering: overview page, system status, and all dashboard tabs. Includes 3 spec files with comprehensive assertions.