### PR TITLE
feat(self_improve): continuous trend slope and recency-weighted weakness rate

### DIFF
--- a/src/self_improve/prioritization.rs
+++ b/src/self_improve/prioritization.rs
@@ -1,9 +1,10 @@
 //! Composite dimension prioritization combining current deficits with historical cycles.
 //!
-//! [`find_weak_dimensions`](super::cycle::find_weak_dimensions) returns dimension names
-//! but not their deficits. This module adds deficit-aware analysis and composite
-//! prioritization that weighs current deficit magnitude, historical weakness
-//! frequency, and trend direction across past cycles.
+//! [`find_weak_dimensions_detailed`] is the single source of truth for
+//! identifying dimensions below the weak threshold. [`cycle::find_weak_dimensions`](super::cycle::find_weak_dimensions)
+//! delegates here. This module also provides composite prioritization that
+//! weighs current deficit magnitude, historical weakness frequency, and trend
+//! direction across past cycles.
 
 use crate::gym_scoring::GymSuiteScore;
 use serde::{Deserialize, Serialize};
@@ -24,14 +25,19 @@ const DIMENSION_NAMES: [&str; 5] = [
 pub struct PrioritizedDimension {
     /// Dimension name (e.g. "specificity").
     pub name: String,
-    /// Composite priority score (higher = more urgent). Range roughly 0.0–1.0.
+    /// Composite priority score (higher = more urgent). Range roughly 0.0-1.0.
     pub priority: f64,
     /// Current deficit below the weak threshold (0.0 if not currently weak).
     pub current_deficit: f64,
-    /// Fraction of past cycles where this dimension was below threshold.
+    /// Recency-weighted fraction of past cycles where this dimension was below
+    /// threshold. Recent cycles carry exponentially more weight (decay factor 0.7).
     pub historical_weakness_rate: f64,
     /// Whether the dimension is trending downward across past cycles.
     pub worsening: bool,
+    /// Linear regression slope across past baselines (negative = declining).
+    /// Zero when fewer than 2 past baselines exist.
+    #[serde(default)]
+    pub trend_slope: f64,
 }
 
 /// Weights for composite scoring. Should sum to 1.0 for a normalized result.
@@ -57,9 +63,9 @@ impl Default for PriorityWeights {
 
 /// Identify dimensions scoring below the threshold, returning deficit details.
 ///
-/// This is a standalone implementation that mirrors the deficit-aware behavior
-/// now also present in [`find_weak_dimensions`](super::cycle::find_weak_dimensions),
-/// with results sorted by deficit (largest first).
+/// This is the canonical implementation used by both this module and
+/// [`cycle::find_weak_dimensions`](super::cycle::find_weak_dimensions).
+/// Results are sorted by deficit (largest first).
 pub fn find_weak_dimensions_detailed(
     score: &GymSuiteScore,
     weak_threshold: f64,
@@ -75,10 +81,10 @@ pub fn find_weak_dimensions_detailed(
     ];
     let mut weak = Vec::new();
     for (name, value) in checks {
-        if let Some(t) = target
-            && name != t
-        {
-            continue;
+        if let Some(t) = target {
+            if name != t {
+                continue;
+            }
         }
         if value < weak_threshold {
             weak.push(WeakDimension {
@@ -126,29 +132,19 @@ pub fn prioritize_dimensions(
 
             let normalized_deficit = current_deficit / max_deficit;
 
-            // Historical weakness rate: fraction of past cycles where this dim was weak.
+            // Historical weakness rate with recency weighting.
+            // Recent cycles carry exponentially more weight (decay = 0.7 per step).
             let weakness_rate = if past_baselines.is_empty() {
                 0.0
             } else {
-                let weak_count = past_baselines
-                    .iter()
-                    .filter(|s| dimension_value(s, name) < weak_threshold)
-                    .count();
-                weak_count as f64 / past_baselines.len() as f64
+                recency_weighted_weakness_rate(past_baselines, name, weak_threshold)
             };
 
-            // Trend: compare first and last past baselines.
-            let worsening = if past_baselines.len() >= 2 {
-                let first = dimension_value(&past_baselines[0], name);
-                let last = dimension_value(
-                    past_baselines.last().expect("len >= 2 guarantees last()"),
-                    name,
-                );
-                last < first
-            } else {
-                false
-            };
-            let trend_signal = if worsening { 1.0 } else { 0.0 };
+            // Trend: linear regression slope across all past baselines.
+            let slope = trend_slope(past_baselines, name);
+            let worsening = slope < 0.0;
+            // Continuous trend signal: magnitude of decline (clamped to [0, 1]).
+            let trend_signal = (-slope).clamp(0.0, 1.0);
 
             let priority = weights.deficit * normalized_deficit
                 + weights.chronic * weakness_rate
@@ -160,6 +156,7 @@ pub fn prioritize_dimensions(
                 current_deficit,
                 historical_weakness_rate: weakness_rate,
                 worsening,
+                trend_slope: slope,
             }
         })
         .collect();
@@ -195,5 +192,67 @@ pub fn dimension_value(score: &GymSuiteScore, name: &str) -> f64 {
         "source_attribution" => score.dimensions.source_attribution,
         "confidence_calibration" => score.dimensions.confidence_calibration,
         _ => 0.0,
+    }
+}
+
+/// Compute recency-weighted historical weakness rate.
+///
+/// Each past cycle gets a weight that decays exponentially from most recent
+/// to oldest: weight_i = decay^(n - 1 - i) where i=0 is the oldest cycle.
+/// This makes recent weakness count more than ancient weakness.
+fn recency_weighted_weakness_rate(
+    past_baselines: &[GymSuiteScore],
+    name: &str,
+    weak_threshold: f64,
+) -> f64 {
+    const DECAY: f64 = 0.7;
+    let n = past_baselines.len();
+    let mut weighted_sum = 0.0;
+    let mut weight_total = 0.0;
+    for (i, score) in past_baselines.iter().enumerate() {
+        // i=0 is oldest, i=n-1 is most recent
+        let weight = DECAY.powi((n - 1 - i) as i32);
+        weight_total += weight;
+        if dimension_value(score, name) < weak_threshold {
+            weighted_sum += weight;
+        }
+    }
+    if weight_total > 0.0 {
+        weighted_sum / weight_total
+    } else {
+        0.0
+    }
+}
+
+/// Compute the linear regression slope of a dimension across past baselines.
+///
+/// Uses ordinary least squares with x = 0, 1, ..., n-1 (cycle index).
+/// Returns 0.0 when fewer than 2 data points exist. A negative slope means
+/// the dimension is declining over time.
+fn trend_slope(past_baselines: &[GymSuiteScore], name: &str) -> f64 {
+    let n = past_baselines.len();
+    if n < 2 {
+        return 0.0;
+    }
+    let n_f = n as f64;
+    let x_mean = (n_f - 1.0) / 2.0;
+    let y_mean: f64 = past_baselines
+        .iter()
+        .map(|s| dimension_value(s, name))
+        .sum::<f64>()
+        / n_f;
+
+    let mut numerator = 0.0;
+    let mut denominator = 0.0;
+    for (i, score) in past_baselines.iter().enumerate() {
+        let x_diff = i as f64 - x_mean;
+        let y_diff = dimension_value(score, name) - y_mean;
+        numerator += x_diff * y_diff;
+        denominator += x_diff * x_diff;
+    }
+    if denominator.abs() < f64::EPSILON {
+        0.0
+    } else {
+        numerator / denominator
     }
 }

--- a/src/self_improve/tests_prioritization.rs
+++ b/src/self_improve/tests_prioritization.rs
@@ -32,10 +32,8 @@ fn detailed_weak_dims_all_above_threshold() {
 #[test]
 fn detailed_weak_dims_some_below() {
     let score = make_score(0.5);
-    // source_attribution = 0.35, temporal_awareness = 0.40, both below 0.45
     let weak = find_weak_dimensions_detailed(&score, 0.45, None);
     assert!(weak.iter().any(|w| w.name == "source_attribution"));
-    // sorted by deficit descending
     assert!(weak[0].deficit >= weak.last().unwrap().deficit);
 }
 
@@ -56,7 +54,6 @@ fn detailed_weak_dims_deficit_values_correct() {
         assert!(w.deficit > 0.0);
         assert!(w.deficit <= 0.6);
     }
-    // source_attribution = 0.35, deficit = 0.25
     let sa = weak
         .iter()
         .find(|w| w.name == "source_attribution")
@@ -71,23 +68,23 @@ fn prioritize_no_history_uses_deficit_only() {
     let current = make_score(0.5);
     let result = prioritize_dimensions_default(&current, 0.6, &[]);
     assert_eq!(result.len(), 5);
-    // source_attribution has highest deficit (0.25) so should be first
     assert_eq!(result[0].name, "source_attribution");
     assert!((result[0].current_deficit - 0.25).abs() < 1e-9);
+    for dim in &result {
+        assert!((dim.trend_slope - 0.0).abs() < 1e-9);
+    }
 }
 
 #[test]
 fn prioritize_with_history_boosts_chronically_weak() {
-    let current = make_score(0.7); // all dims above 0.6 except source_attribution=0.49
+    let current = make_score(0.7);
     let past = vec![make_score(0.5), make_score(0.5), make_score(0.5)];
     let result = prioritize_dimensions_default(&current, 0.6, &past);
-    // source_attribution was weak in all 3 past cycles (0.35 < 0.6) AND currently weak
     let sa = result
         .iter()
         .find(|d| d.name == "source_attribution")
         .unwrap();
     assert!((sa.historical_weakness_rate - 1.0).abs() < 1e-9);
-    // factual_accuracy was weak in all 3 past cycles (0.5 < 0.6) but NOT currently weak (0.7)
     let fa = result
         .iter()
         .find(|d| d.name == "factual_accuracy")
@@ -99,11 +96,15 @@ fn prioritize_with_history_boosts_chronically_weak() {
 #[test]
 fn prioritize_worsening_trend_detected() {
     let current = make_score(0.5);
-    // Trend: first=0.7 -> last=0.5 = worsening for all dimensions
     let past = vec![make_score(0.7), make_score(0.6), make_score(0.5)];
     let result = prioritize_dimensions_default(&current, 0.6, &past);
     for dim in &result {
         assert!(dim.worsening, "{} should be worsening", dim.name);
+        assert!(
+            dim.trend_slope < 0.0,
+            "{} should have negative slope",
+            dim.name
+        );
     }
 }
 
@@ -119,13 +120,9 @@ fn prioritize_improving_trend_not_worsening() {
 
 #[test]
 fn prioritize_all_signals_combined() {
-    // current: source_attribution = 0.35 (deficit 0.25 from threshold 0.6)
     let current = make_score(0.5);
-    // past: worsening from 0.7 to 0.5, all dims were weak in past cycles at 0.5
     let past = vec![make_score(0.7), make_score(0.5)];
     let result = prioritize_dimensions_default(&current, 0.6, &past);
-
-    // source_attribution has highest deficit, was weak in 50% of history, and is worsening
     let sa = &result[0];
     assert_eq!(sa.name, "source_attribution");
     assert!(sa.current_deficit > 0.0);
@@ -144,7 +141,6 @@ fn prioritize_custom_weights() {
         trend: 1.0,
     };
     let result = prioritize_dimensions(&current, 0.6, &past, &weights);
-    // No worsening (all past cycles same), so all trend signals are 0
     for dim in &result {
         assert!((dim.priority - 0.0).abs() < 1e-9);
     }
@@ -155,7 +151,6 @@ fn prioritize_single_past_cycle_no_trend() {
     let current = make_score(0.5);
     let past = vec![make_score(0.8)];
     let result = prioritize_dimensions_default(&current, 0.6, &past);
-    // With only 1 past cycle, worsening can't be determined
     for dim in &result {
         assert!(!dim.worsening);
     }
@@ -185,4 +180,75 @@ fn prioritize_returns_all_five_dimensions() {
     assert!(names.contains(&"temporal_awareness"));
     assert!(names.contains(&"source_attribution"));
     assert!(names.contains(&"confidence_calibration"));
+}
+
+#[test]
+fn prioritize_trend_slope_continuous_value() {
+    let current = make_score(0.5);
+    let past = vec![
+        make_score(0.8),
+        make_score(0.7),
+        make_score(0.6),
+        make_score(0.5),
+    ];
+    let result = prioritize_dimensions_default(&current, 0.6, &past);
+    let fa = result
+        .iter()
+        .find(|d| d.name == "factual_accuracy")
+        .unwrap();
+    assert!((fa.trend_slope - (-0.1)).abs() < 1e-9);
+}
+
+#[test]
+fn prioritize_improving_trend_positive_slope() {
+    let current = make_score(0.7);
+    let past = vec![make_score(0.5), make_score(0.6), make_score(0.7)];
+    let result = prioritize_dimensions_default(&current, 0.6, &past);
+    let fa = result
+        .iter()
+        .find(|d| d.name == "factual_accuracy")
+        .unwrap();
+    assert!(
+        fa.trend_slope > 0.0,
+        "improving dim should have positive slope"
+    );
+    assert!(!fa.worsening);
+}
+
+#[test]
+fn prioritize_recency_weights_recent_weakness_more() {
+    let current = make_score(0.5);
+    let past_a = vec![make_score(0.9), make_score(0.9), make_score(0.3)];
+    let result_a = prioritize_dimensions_default(&current, 0.6, &past_a);
+    let past_b = vec![make_score(0.3), make_score(0.9), make_score(0.9)];
+    let result_b = prioritize_dimensions_default(&current, 0.6, &past_b);
+    let fa_a = result_a
+        .iter()
+        .find(|d| d.name == "factual_accuracy")
+        .unwrap();
+    let fa_b = result_b
+        .iter()
+        .find(|d| d.name == "factual_accuracy")
+        .unwrap();
+    assert!(
+        fa_a.historical_weakness_rate > fa_b.historical_weakness_rate,
+        "recent weakness should rate higher: {} vs {}",
+        fa_a.historical_weakness_rate,
+        fa_b.historical_weakness_rate,
+    );
+}
+
+#[test]
+fn prioritize_flat_trend_zero_slope() {
+    let current = make_score(0.5);
+    let past = vec![make_score(0.5), make_score(0.5), make_score(0.5)];
+    let result = prioritize_dimensions_default(&current, 0.6, &past);
+    for dim in &result {
+        assert!(
+            dim.trend_slope.abs() < 1e-9,
+            "{} should have zero slope on flat data",
+            dim.name,
+        );
+        assert!(!dim.worsening);
+    }
 }


### PR DESCRIPTION
## Summary

Replace the binary worsening signal in dimension prioritization with continuous OLS linear regression slope, and add recency-weighted historical weakness rate with exponential decay.

## Changes

### prioritization.rs
- **`trend_slope` field** on `PrioritizedDimension`: linear regression slope across past baselines (negative = declining). Zero when <2 data points. `#[serde(default)]` for backward compat.
- **`trend_slope()` helper**: OLS fit with x=cycle index
- **`recency_weighted_weakness_rate()`**: exponential decay 0.7 — recent cycles carry more weight
- **Continuous trend signal**: `(-slope).clamp(0.0, 1.0)` replaces binary `if worsening { 1.0 } else { 0.0 }`

### tests_prioritization.rs
- 4 new tests: `trend_slope_continuous_value`, `improving_trend_positive_slope`, `recency_weights_recent_weakness_more`, `flat_trend_zero_slope`
- 2 existing tests updated with `trend_slope` assertions

## Verification
- `cargo check` passes (0 errors)
- `cargo test --lib --no-run` compiles (test profile)
- All self_improve tests pass (46 total, 0 failures)