### PR TITLE
feat: implement GitHub activity polling for tracked developer watches

### DIFF
--- a/src/goal_curation/mod.rs
+++ b/src/goal_curation/mod.rs
@@ -9,7 +9,8 @@ mod types;
 // Re-export all public items so `crate::goal_curation::X` still works.
 pub use operations::{
     DEFAULT_SEED_GOALS, add_active_goal, add_backlog_item, archive_completed, load_goal_board,
-    persist_board, promote_to_active, save_goal_board, seed_default_board, update_goal_progress,
+    persist_board, promote_to_active, save_goal_board, seed_default_board,
+    surface_developer_discoveries, update_goal_progress,
 };
 pub use types::{ActiveGoal, BacklogItem, GoalBoard, GoalProgress, MAX_ACTIVE_GOALS};
 

--- a/src/goal_curation/operations.rs
+++ b/src/goal_curation/operations.rs
@@ -4,6 +4,7 @@ use serde_json::json;
 
 use crate::cognitive_memory::CognitiveMemoryOps;
 use crate::error::{SimardError, SimardResult};
+use crate::research_tracker::{EventFetcher, ResearchTracker};
 
 use super::types::{ActiveGoal, BacklogItem, GoalBoard, GoalProgress, MAX_ACTIVE_GOALS};
 
@@ -208,6 +209,63 @@ pub fn archive_completed(board: &mut GoalBoard) -> Vec<ActiveGoal> {
         }
     });
     archived
+}
+
+// ---------------------------------------------------------------------------
+// Developer activity integration
+// ---------------------------------------------------------------------------
+
+/// Poll tracked developers for GitHub activity and surface new discoveries as
+/// backlog items on the goal board. Skips topics that already exist in the
+/// backlog. Returns the number of new backlog items added.
+pub fn surface_developer_discoveries(
+    board: &mut GoalBoard,
+    tracker: &mut ResearchTracker,
+    fetcher: &dyn EventFetcher,
+    bridge: &dyn CognitiveMemoryOps,
+) -> SimardResult<usize> {
+    let new_topics = crate::research_tracker::check_developer_activity(tracker, fetcher)?;
+
+    let mut added = 0;
+    for topic in &new_topics {
+        // Skip if already in backlog
+        if board.backlog.iter().any(|b| b.id == topic.id) {
+            continue;
+        }
+
+        let item = BacklogItem {
+            id: topic.id.clone(),
+            description: topic.title.clone(),
+            source: topic.source.clone(),
+            score: 0.5,
+        };
+
+        if add_backlog_item(board, item).is_ok() {
+            added += 1;
+        }
+    }
+
+    // Persist discovered topics to cognitive memory
+    for topic in new_topics {
+        let _ = crate::research_tracker::add_research_topic(topic, bridge);
+    }
+
+    // Also add new topics to the tracker's in-memory list for dedup in future polls
+    tracker.topics.extend(
+        board
+            .backlog
+            .iter()
+            .filter(|b| b.source.starts_with("github:"))
+            .map(|b| crate::research_tracker::ResearchTopic {
+                id: b.id.clone(),
+                title: b.description.clone(),
+                source: b.source.clone(),
+                priority: 3,
+                status: crate::research_tracker::ResearchStatus::Proposed,
+            }),
+    );
+
+    Ok(added)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/goal_curation/tests.rs
+++ b/src/goal_curation/tests.rs
@@ -235,3 +235,93 @@ fn promote_at_capacity_fails() {
     let err = promote_to_active(&mut board, "bl-cap", 1, None).unwrap_err();
     assert!(err.to_string().contains("capacity"), "{}", err);
 }
+
+// ---------------------------------------------------------------------------
+// surface_developer_discoveries integration tests
+// ---------------------------------------------------------------------------
+
+use crate::research_tracker::activity::GitHubEvent;
+use crate::research_tracker::activity::GitHubRepo;
+use crate::research_tracker::{EventFetcher, ResearchTracker};
+
+struct MockEventFetcher {
+    events: Vec<GitHubEvent>,
+}
+
+impl EventFetcher for MockEventFetcher {
+    fn fetch_events(&self, _github_id: &str) -> crate::error::SimardResult<Vec<GitHubEvent>> {
+        Ok(self.events.clone())
+    }
+}
+
+#[test]
+fn surface_discoveries_adds_backlog_items() {
+    let bridge = mock_bridge();
+    let fetcher = MockEventFetcher {
+        events: vec![GitHubEvent {
+            event_type: "PushEvent".to_string(),
+            repo: GitHubRepo {
+                name: "user/agent-frameworks".to_string(),
+            },
+            created_at: "2026-04-16T00:00:00Z".to_string(),
+        }],
+    };
+    let mut board = GoalBoard::default();
+    let mut tracker = ResearchTracker {
+        topics: vec![],
+        watches: vec![crate::research_tracker::DeveloperWatch {
+            github_id: "octocat".to_string(),
+            focus_areas: vec!["agent-frameworks".to_string()],
+            last_checked: None,
+        }],
+    };
+
+    let added = surface_developer_discoveries(&mut board, &mut tracker, &fetcher, &bridge).unwrap();
+    assert_eq!(added, 1);
+    assert_eq!(board.backlog.len(), 1);
+    assert!(board.backlog[0].source.starts_with("github:"));
+}
+
+#[test]
+fn surface_discoveries_skips_existing_backlog() {
+    let bridge = mock_bridge();
+    let fetcher = MockEventFetcher {
+        events: vec![GitHubEvent {
+            event_type: "PushEvent".to_string(),
+            repo: GitHubRepo {
+                name: "user/agent-frameworks".to_string(),
+            },
+            created_at: "2026-04-16T00:00:00Z".to_string(),
+        }],
+    };
+    let mut board = GoalBoard::default();
+    let mut tracker = ResearchTracker {
+        topics: vec![],
+        watches: vec![crate::research_tracker::DeveloperWatch {
+            github_id: "octocat".to_string(),
+            focus_areas: vec!["agent-frameworks".to_string()],
+            last_checked: None,
+        }],
+    };
+
+    // First call adds the item
+    surface_developer_discoveries(&mut board, &mut tracker, &fetcher, &bridge).unwrap();
+    assert_eq!(board.backlog.len(), 1);
+
+    // Second call with same data: tracker already has topic, so 0 new
+    let added = surface_developer_discoveries(&mut board, &mut tracker, &fetcher, &bridge).unwrap();
+    assert_eq!(added, 0);
+    assert_eq!(board.backlog.len(), 1);
+}
+
+#[test]
+fn surface_discoveries_no_events_no_items() {
+    let bridge = mock_bridge();
+    let fetcher = MockEventFetcher { events: vec![] };
+    let mut board = GoalBoard::default();
+    let mut tracker = ResearchTracker::with_default_watches();
+
+    let added = surface_developer_discoveries(&mut board, &mut tracker, &fetcher, &bridge).unwrap();
+    assert_eq!(added, 0);
+    assert!(board.backlog.is_empty());
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,7 @@ pub use evidence::{
 pub use goal_curation::{
     ActiveGoal, BacklogItem, DEFAULT_SEED_GOALS, GoalBoard, GoalProgress, MAX_ACTIVE_GOALS,
     add_active_goal, add_backlog_item, archive_completed, load_goal_board, persist_board,
-    promote_to_active, seed_default_board, update_goal_progress,
+    promote_to_active, seed_default_board, surface_developer_discoveries, update_goal_progress,
 };
 pub use goals::{
     FileBackedGoalStore, GoalRecord, GoalStatus, GoalStore, GoalUpdate, InMemoryGoalStore,
@@ -267,8 +267,9 @@ pub use remote_azlin::{AzlinConfig, AzlinExecutor, AzlinVm, RealAzlinExecutor};
 pub use remote_session::{RemoteConfig, RemoteSession, RemoteStatus};
 pub use remote_transfer::MemorySnapshot;
 pub use research_tracker::{
-    DeveloperWatch, ResearchStatus, ResearchTopic, ResearchTracker, add_research_topic,
-    load_research_topics, track_developer, update_topic_status,
+    DeveloperWatch, EventFetcher, GhCliFetcher, ResearchStatus, ResearchTopic, ResearchTracker,
+    add_research_topic, check_developer_activity, load_research_topics, track_developer,
+    update_topic_status,
 };
 pub use review::{
     ImprovementProposal, ReviewArtifact, ReviewRequest, ReviewSignal, ReviewTargetKind,

--- a/src/research_tracker/activity.rs
+++ b/src/research_tracker/activity.rs
@@ -1,0 +1,403 @@
+//! Poll GitHub for tracked developer activity and surface research topics.
+
+use std::collections::HashSet;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::Deserialize;
+
+use crate::error::{SimardError, SimardResult};
+
+use super::types::{ResearchStatus, ResearchTopic, ResearchTracker};
+
+// ---------------------------------------------------------------------------
+// GitHub event types
+// ---------------------------------------------------------------------------
+
+/// Minimal representation of a GitHub public event.
+#[derive(Clone, Debug, Deserialize)]
+pub struct GitHubEvent {
+    #[serde(rename = "type")]
+    pub event_type: String,
+    pub repo: GitHubRepo,
+    pub created_at: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct GitHubRepo {
+    pub name: String,
+}
+
+// ---------------------------------------------------------------------------
+// Event fetcher trait (for testability)
+// ---------------------------------------------------------------------------
+
+/// Abstraction over GitHub event fetching so tests can inject a mock.
+pub trait EventFetcher: Send + Sync {
+    fn fetch_events(&self, github_id: &str) -> SimardResult<Vec<GitHubEvent>>;
+}
+
+/// Default fetcher that shells out to `gh api`.
+pub struct GhCliFetcher;
+
+impl EventFetcher for GhCliFetcher {
+    fn fetch_events(&self, github_id: &str) -> SimardResult<Vec<GitHubEvent>> {
+        let output = std::process::Command::new("gh")
+            .args([
+                "api",
+                &format!("/users/{github_id}/events/public"),
+                "--jq",
+                "[.[] | {type, repo: {name: .repo.name}, created_at}]",
+            ])
+            .output()
+            .map_err(|e| SimardError::InvalidResearchRecord {
+                field: "event_fetch".to_string(),
+                reason: format!("failed to run gh cli: {e}"),
+            })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(SimardError::InvalidResearchRecord {
+                field: "event_fetch".to_string(),
+                reason: format!("gh api failed for {github_id}: {stderr}"),
+            });
+        }
+
+        let events: Vec<GitHubEvent> = serde_json::from_slice(&output.stdout).map_err(|e| {
+            SimardError::InvalidResearchRecord {
+                field: "event_parse".to_string(),
+                reason: format!("failed to parse events for {github_id}: {e}"),
+            }
+        })?;
+
+        Ok(events)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Core logic
+// ---------------------------------------------------------------------------
+
+fn now_epoch_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before UNIX epoch")
+        .as_secs()
+}
+
+/// Derive a stable topic ID from a developer event.
+fn topic_id_for_event(github_id: &str, repo_name: &str) -> String {
+    format!("dev-activity:{github_id}:{repo_name}")
+}
+
+/// Convert a developer's events into candidate research topics, filtering by
+/// focus areas. Returns only unique topics (deduplicated by topic id).
+pub(super) fn events_to_research_topics(
+    github_id: &str,
+    events: &[GitHubEvent],
+    focus_areas: &[String],
+) -> Vec<ResearchTopic> {
+    let mut seen = HashSet::new();
+    let mut topics = Vec::new();
+
+    for event in events {
+        let repo_lower = event.repo.name.to_lowercase();
+        let is_relevant = focus_areas.iter().any(|area| {
+            let area_lower = area.to_lowercase();
+            repo_lower.contains(&area_lower) || area_lower.contains(&repo_lower)
+        });
+        if !is_relevant {
+            continue;
+        }
+
+        let id = topic_id_for_event(github_id, &event.repo.name);
+        if seen.contains(&id) {
+            continue;
+        }
+        seen.insert(id.clone());
+
+        topics.push(ResearchTopic {
+            id,
+            title: format!(
+                "{} activity in {} ({})",
+                github_id, event.repo.name, event.event_type
+            ),
+            source: format!("github:{github_id}"),
+            priority: 3,
+            status: ResearchStatus::Proposed,
+        });
+    }
+
+    topics
+}
+
+/// Poll GitHub for each tracked developer, return new [`ResearchTopic`]s that
+/// are not already present in the tracker. Updates `last_checked` on each
+/// watch entry.
+pub fn check_developer_activity(
+    tracker: &mut ResearchTracker,
+    fetcher: &dyn EventFetcher,
+) -> SimardResult<Vec<ResearchTopic>> {
+    let existing_ids: HashSet<String> = tracker.topics.iter().map(|t| t.id.clone()).collect();
+
+    let mut new_topics: Vec<ResearchTopic> = Vec::new();
+    let mut seen_ids: HashSet<String> = HashSet::new();
+    let now = now_epoch_secs();
+
+    for watch in &mut tracker.watches {
+        let events = fetcher.fetch_events(&watch.github_id)?;
+        let candidates = events_to_research_topics(&watch.github_id, &events, &watch.focus_areas);
+
+        for topic in candidates {
+            if !existing_ids.contains(&topic.id) && !seen_ids.contains(&topic.id) {
+                seen_ids.insert(topic.id.clone());
+                new_topics.push(topic);
+            }
+        }
+
+        watch.last_checked = Some(now);
+    }
+
+    Ok(new_topics)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::research_tracker::DeveloperWatch;
+
+    /// Mock fetcher that returns canned events.
+    struct MockFetcher {
+        events: Vec<GitHubEvent>,
+    }
+
+    impl MockFetcher {
+        fn new(events: Vec<GitHubEvent>) -> Self {
+            Self { events }
+        }
+
+        fn empty() -> Self {
+            Self { events: vec![] }
+        }
+    }
+
+    impl EventFetcher for MockFetcher {
+        fn fetch_events(&self, _github_id: &str) -> SimardResult<Vec<GitHubEvent>> {
+            Ok(self.events.clone())
+        }
+    }
+
+    /// Mock fetcher that always fails.
+    struct FailingFetcher;
+
+    impl EventFetcher for FailingFetcher {
+        fn fetch_events(&self, github_id: &str) -> SimardResult<Vec<GitHubEvent>> {
+            Err(SimardError::InvalidResearchRecord {
+                field: "event_fetch".to_string(),
+                reason: format!("mock failure for {github_id}"),
+            })
+        }
+    }
+
+    fn make_event(event_type: &str, repo_name: &str) -> GitHubEvent {
+        GitHubEvent {
+            event_type: event_type.to_string(),
+            repo: GitHubRepo {
+                name: repo_name.to_string(),
+            },
+            created_at: "2026-04-16T00:00:00Z".to_string(),
+        }
+    }
+
+    fn make_watch(github_id: &str, areas: Vec<&str>) -> DeveloperWatch {
+        DeveloperWatch {
+            github_id: github_id.to_string(),
+            focus_areas: areas.into_iter().map(String::from).collect(),
+            last_checked: None,
+        }
+    }
+
+    // -- events_to_research_topics --
+
+    #[test]
+    fn events_to_topics_filters_by_focus_area() {
+        let events = vec![
+            make_event("PushEvent", "user/agent-frameworks"),
+            make_event("PushEvent", "user/unrelated-repo"),
+        ];
+        let areas = vec!["agent-frameworks".to_string()];
+        let topics = events_to_research_topics("octocat", &events, &areas);
+        assert_eq!(topics.len(), 1);
+        assert!(topics[0].id.contains("agent-frameworks"));
+        assert_eq!(topics[0].source, "github:octocat");
+    }
+
+    #[test]
+    fn events_to_topics_deduplicates_same_repo() {
+        let events = vec![
+            make_event("PushEvent", "user/llm-tooling"),
+            make_event("CreateEvent", "user/llm-tooling"),
+        ];
+        let areas = vec!["llm-tooling".to_string()];
+        let topics = events_to_research_topics("dev", &events, &areas);
+        assert_eq!(topics.len(), 1);
+    }
+
+    #[test]
+    fn events_to_topics_empty_events() {
+        let topics = events_to_research_topics("dev", &[], &["anything".to_string()]);
+        assert!(topics.is_empty());
+    }
+
+    #[test]
+    fn events_to_topics_no_matching_areas() {
+        let events = vec![make_event("PushEvent", "user/cooking-recipes")];
+        let areas = vec!["rust".to_string(), "llm".to_string()];
+        let topics = events_to_research_topics("dev", &events, &areas);
+        assert!(topics.is_empty());
+    }
+
+    #[test]
+    fn events_to_topics_case_insensitive_matching() {
+        let events = vec![make_event("PushEvent", "user/LLM-Tooling")];
+        let areas = vec!["llm-tooling".to_string()];
+        let topics = events_to_research_topics("dev", &events, &areas);
+        assert_eq!(topics.len(), 1);
+    }
+
+    #[test]
+    fn events_to_topics_sets_proposed_status() {
+        let events = vec![make_event("PushEvent", "user/rust-tooling")];
+        let areas = vec!["rust-tooling".to_string()];
+        let topics = events_to_research_topics("dev", &events, &areas);
+        assert_eq!(topics[0].status, ResearchStatus::Proposed);
+        assert_eq!(topics[0].priority, 3);
+    }
+
+    // -- check_developer_activity --
+
+    #[test]
+    fn check_activity_returns_new_topics() {
+        let fetcher = MockFetcher::new(vec![make_event("PushEvent", "user/agent-frameworks")]);
+        let mut tracker = ResearchTracker {
+            topics: vec![],
+            watches: vec![make_watch("octocat", vec!["agent-frameworks"])],
+        };
+
+        let new = check_developer_activity(&mut tracker, &fetcher).unwrap();
+        assert_eq!(new.len(), 1);
+        assert!(new[0].id.contains("octocat"));
+    }
+
+    #[test]
+    fn check_activity_updates_last_checked() {
+        let fetcher = MockFetcher::empty();
+        let mut tracker = ResearchTracker {
+            topics: vec![],
+            watches: vec![make_watch("dev1", vec!["rust"])],
+        };
+
+        assert!(tracker.watches[0].last_checked.is_none());
+        check_developer_activity(&mut tracker, &fetcher).unwrap();
+        assert!(tracker.watches[0].last_checked.is_some());
+    }
+
+    #[test]
+    fn check_activity_skips_existing_topics() {
+        let fetcher = MockFetcher::new(vec![make_event("PushEvent", "user/llm-tooling")]);
+        let existing_id = topic_id_for_event("simonw", "user/llm-tooling");
+        let mut tracker = ResearchTracker {
+            topics: vec![ResearchTopic {
+                id: existing_id,
+                title: "Already tracked".to_string(),
+                source: "github:simonw".to_string(),
+                priority: 2,
+                status: ResearchStatus::InProgress,
+            }],
+            watches: vec![make_watch("simonw", vec!["llm-tooling"])],
+        };
+
+        let new = check_developer_activity(&mut tracker, &fetcher).unwrap();
+        assert!(new.is_empty());
+    }
+
+    #[test]
+    fn check_activity_empty_watches_returns_empty() {
+        let fetcher = MockFetcher::empty();
+        let mut tracker = ResearchTracker::new();
+
+        let new = check_developer_activity(&mut tracker, &fetcher).unwrap();
+        assert!(new.is_empty());
+    }
+
+    #[test]
+    fn check_activity_deduplicates_across_watches() {
+        let fetcher = MockFetcher::new(vec![make_event("PushEvent", "user/shared-repo")]);
+        let mut tracker = ResearchTracker {
+            topics: vec![],
+            watches: vec![
+                make_watch("dev1", vec!["shared-repo"]),
+                make_watch("dev2", vec!["shared-repo"]),
+            ],
+        };
+
+        let new = check_developer_activity(&mut tracker, &fetcher).unwrap();
+        // Each dev produces a different topic id (includes github_id)
+        assert_eq!(new.len(), 2);
+        assert_ne!(new[0].id, new[1].id);
+    }
+
+    #[test]
+    fn check_activity_propagates_fetch_errors() {
+        let fetcher = FailingFetcher;
+        let mut tracker = ResearchTracker {
+            topics: vec![],
+            watches: vec![make_watch("fail-dev", vec!["anything"])],
+        };
+
+        let err = check_developer_activity(&mut tracker, &fetcher).unwrap_err();
+        assert!(err.to_string().contains("mock failure"));
+    }
+
+    #[test]
+    fn check_activity_updates_all_watches_last_checked() {
+        let fetcher = MockFetcher::empty();
+        let mut tracker = ResearchTracker {
+            topics: vec![],
+            watches: vec![
+                make_watch("a", vec!["x"]),
+                make_watch("b", vec!["y"]),
+                make_watch("c", vec!["z"]),
+            ],
+        };
+
+        check_developer_activity(&mut tracker, &fetcher).unwrap();
+        for watch in &tracker.watches {
+            assert!(
+                watch.last_checked.is_some(),
+                "{} should have last_checked set",
+                watch.github_id
+            );
+        }
+    }
+
+    // -- topic_id_for_event --
+
+    #[test]
+    fn topic_id_is_stable_and_deterministic() {
+        let id1 = topic_id_for_event("user", "repo/name");
+        let id2 = topic_id_for_event("user", "repo/name");
+        assert_eq!(id1, id2);
+        assert!(id1.starts_with("dev-activity:"));
+    }
+
+    #[test]
+    fn topic_id_differs_for_different_users() {
+        let id1 = topic_id_for_event("alice", "repo");
+        let id2 = topic_id_for_event("bob", "repo");
+        assert_ne!(id1, id2);
+    }
+}

--- a/src/research_tracker/mod.rs
+++ b/src/research_tracker/mod.rs
@@ -4,11 +4,13 @@
 //! engineering work. Also maintains a watch list of developers whose public
 //! activity is relevant to Simard's focus areas.
 
+pub mod activity;
 mod operations;
 mod types;
 mod watches;
 
 // Re-export all public items so `crate::research_tracker::X` still works.
+pub use activity::{EventFetcher, GhCliFetcher, check_developer_activity};
 pub use operations::{
     add_research_topic, load_research_topics, track_developer, update_topic_status,
 };


### PR DESCRIPTION
## Summary

Implements issue #772: GitHub activity polling for tracked developer watches.

### Changes

- **`src/research_tracker/activity.rs`** (new): Core polling logic
  - `EventFetcher` trait with `GhCliFetcher` implementation (shells out to `gh api`)
  - `check_developer_activity()`: polls GitHub for each tracked developer, filters by focus areas, deduplicates, updates `last_checked`
  - `events_to_research_topics()`: converts GitHub events to `ResearchTopic` candidates with case-insensitive matching
  - 15 unit tests with mock fetcher

- **`src/goal_curation/operations.rs`**: Integration point
  - `surface_developer_discoveries()`: bridges activity polling into goal board backlog items, persists to cognitive memory
  - 3 integration tests

- **`src/research_tracker/mod.rs`**: Re-exports activity module
- **`src/goal_curation/mod.rs`**: Re-exports new function  
- **`src/lib.rs`**: Public API exports

### Acceptance Criteria
- [x] `check_developer_activity` implemented with GitHub API calls
- [x] `last_checked` updated after each poll
- [x] New topics stored via `add_research_topic` with `source=github:<id>`
- [x] Integration point wired (goal curation `surface_developer_discoveries`)
- [x] Tests with mocked GitHub responses (18 tests)
- [x] `cargo test --lib` passes

Closes #772