### PR TITLE
fix: make CI swap space allocation idempotent

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -17,12 +17,15 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Add swap space (4 GB)
+        continue-on-error: true
         run: |
-          sudo fallocate -l 4G /swapfile
-          sudo chmod 600 /swapfile
-          sudo mkswap /swapfile
-          sudo swapon /swapfile
-          echo "Swap enabled: $(swapon --show)"
+          if [ ! -f /swapfile ]; then
+            sudo fallocate -l 4G /swapfile || sudo dd if=/dev/zero of=/swapfile bs=1M count=4096
+            sudo chmod 600 /swapfile
+            sudo mkswap /swapfile
+          fi
+          sudo swapon /swapfile 2>/dev/null || true
+          echo "Swap: $(swapon --show)"
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
@@ -58,12 +61,15 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Add swap space (4 GB)
+        continue-on-error: true
         run: |
-          sudo fallocate -l 4G /swapfile
-          sudo chmod 600 /swapfile
-          sudo mkswap /swapfile
-          sudo swapon /swapfile
-          echo "Swap enabled: $(swapon --show)"
+          if [ ! -f /swapfile ]; then
+            sudo fallocate -l 4G /swapfile || sudo dd if=/dev/zero of=/swapfile bs=1M count=4096
+            sudo chmod 600 /swapfile
+            sudo mkswap /swapfile
+          fi
+          sudo swapon /swapfile 2>/dev/null || true
+          echo "Swap: $(swapon --show)"
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Problem
The CI `verify` workflow fails on all branches with:
```
fallocate: fallocate failed: Text file busy
```

## Fix
- Check if `/swapfile` exists before creating it
- Fall back to `dd` if `fallocate` fails
- Add `continue-on-error: true` since swap is nice-to-have
- Suppress `swapon` errors for already-active swap

Applied to both `pre-commit` and `install-smoke` jobs.