### PR TITLE
fix(#685): remove duplicate methods in self_improve/history

### DIFF
--- a/src/self_improve/history.rs
+++ b/src/self_improve/history.rs
@@ -1,0 +1,193 @@
+//! Persistent history of improvement cycles (JSON-lines format).
+//!
+//! Each completed cycle is appended as a single JSON line to a history file.
+//! This enables cross-cycle analysis: deduplicating previously-failed proposals,
+//! tracking score trends, and surfacing chronically-weak dimensions.
+
+use std::fs::{self, OpenOptions};
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+
+use crate::error::{SimardError, SimardResult};
+
+use super::types::{ImprovementCycle, ImprovementDecision, ProposedChange};
+
+const HISTORY_FILENAME: &str = "improvement_history.jsonl";
+
+/// Handle to the on-disk improvement history.
+#[derive(Debug, Clone)]
+pub struct ImprovementHistory {
+    path: PathBuf,
+}
+
+fn io_err(path: &Path, action: &str, reason: impl std::fmt::Display) -> SimardError {
+    SimardError::PersistentStoreIo {
+        store: "improvement_history".into(),
+        action: action.into(),
+        path: path.to_path_buf(),
+        reason: reason.to_string(),
+    }
+}
+
+impl ImprovementHistory {
+    /// Open (or create) a history file in the given directory.
+    pub fn open(dir: &Path) -> SimardResult<Self> {
+        fs::create_dir_all(dir).map_err(|e| io_err(dir, "create_dir", e))?;
+        Ok(Self {
+            path: dir.join(HISTORY_FILENAME),
+        })
+    }
+
+    /// Open a history file at an exact path (useful for tests).
+    pub fn open_file(path: PathBuf) -> Self {
+        Self { path }
+    }
+
+    /// Append a completed cycle to the history file.
+    pub fn append(&self, cycle: &ImprovementCycle) -> SimardResult<()> {
+        let json = serde_json::to_string(cycle).map_err(|e| io_err(&self.path, "serialize", e))?;
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)
+            .map_err(|e| io_err(&self.path, "open_append", e))?;
+        writeln!(file, "{json}").map_err(|e| io_err(&self.path, "write", e))?;
+        Ok(())
+    }
+
+    /// Load all cycles from the history file.
+    ///
+    /// Corrupt lines are silently skipped — partial writes from crashes
+    /// should not block future cycles.
+    pub fn load(&self) -> SimardResult<Vec<ImprovementCycle>> {
+        if !self.path.exists() {
+            return Ok(Vec::new());
+        }
+        let file = fs::File::open(&self.path).map_err(|e| io_err(&self.path, "open_read", e))?;
+        let reader = BufReader::new(file);
+        let mut cycles = Vec::new();
+        for line_result in reader.lines() {
+            let line: String = match line_result {
+                Ok(l) => l,
+                Err(_) => continue,
+            };
+            if line.trim().is_empty() {
+                continue;
+            }
+            if let Ok(cycle) = serde_json::from_str::<ImprovementCycle>(&line) {
+                cycles.push(cycle);
+            }
+            // silently skip corrupt lines
+        }
+        Ok(cycles)
+    }
+
+    /// Check whether a proposal (identified by file_path + description) was
+    /// previously attempted and reverted.
+    pub fn was_previously_reverted(&self, proposal: &ProposedChange) -> SimardResult<bool> {
+        let cycles = self.load()?;
+        Ok(cycles.iter().any(|c| {
+            matches!(&c.decision, Some(ImprovementDecision::Revert { .. }))
+                && c.proposed_changes.iter().any(|p| {
+                    p.file_path == proposal.file_path && p.description == proposal.description
+                })
+        }))
+    }
+
+    /// Filter out proposals that were previously reverted.
+    pub fn dedup_proposals(
+        &self,
+        proposals: &[ProposedChange],
+    ) -> SimardResult<Vec<ProposedChange>> {
+        let cycles = self.load()?;
+        let reverted_keys: Vec<(&str, &str)> = cycles
+            .iter()
+            .filter(|c| matches!(&c.decision, Some(ImprovementDecision::Revert { .. })))
+            .flat_map(|c| {
+                c.proposed_changes
+                    .iter()
+                    .map(|p| (p.file_path.as_str(), p.description.as_str()))
+            })
+            .collect();
+
+        Ok(proposals
+            .iter()
+            .filter(|p| {
+                !reverted_keys
+                    .iter()
+                    .any(|(fp, desc)| *fp == p.file_path && *desc == p.description)
+            })
+            .cloned()
+            .collect())
+    }
+
+    /// Return the number of cycles in the history.
+    ///
+    /// Counts non-blank lines without deserializing, which is cheaper than
+    /// `load().len()` for large history files.
+    pub fn cycle_count(&self) -> SimardResult<usize> {
+        if !self.path.exists() {
+            return Ok(0);
+        }
+        let file = fs::File::open(&self.path).map_err(|e| io_err(&self.path, "open_read", e))?;
+        let reader = BufReader::new(file);
+        let count = reader
+            .lines()
+            .map_while(Result::ok)
+            .filter(|l| !l.trim().is_empty())
+            .count();
+        Ok(count)
+    }
+
+    /// Truncate the history to the most recent `max_cycles` entries.
+    ///
+    /// If the history already has fewer entries, this is a no-op.
+    /// Corrupt lines are dropped during the rewrite.
+    pub fn prune(&self, max_cycles: usize) -> SimardResult<()> {
+        let cycles = self.load()?;
+        if cycles.len() <= max_cycles {
+            return Ok(());
+        }
+        let keep = &cycles[cycles.len() - max_cycles..];
+        let mut file =
+            fs::File::create(&self.path).map_err(|e| io_err(&self.path, "prune_rewrite", e))?;
+        for cycle in keep {
+            let json =
+                serde_json::to_string(cycle).map_err(|e| io_err(&self.path, "serialize", e))?;
+            writeln!(file, "{json}").map_err(|e| io_err(&self.path, "write", e))?;
+        }
+        Ok(())
+    }
+
+    /// Count how many times a proposal was previously reverted.
+    ///
+    /// This enables callers to implement exponential backoff on proposals
+    /// that keep failing.
+    pub fn reverted_count(&self, proposal: &ProposedChange) -> SimardResult<usize> {
+        let cycles = self.load()?;
+        let count = cycles
+            .iter()
+            .filter(|c| {
+                matches!(&c.decision, Some(ImprovementDecision::Revert { .. }))
+                    && c.proposed_changes.iter().any(|p| {
+                        p.file_path == proposal.file_path && p.description == proposal.description
+                    })
+            })
+            .count();
+        Ok(count)
+    }
+
+    /// Return the most recent `n` cycles from the history.
+    ///
+    /// If fewer than `n` cycles exist, returns all of them.
+    pub fn last_n_cycles(&self, n: usize) -> SimardResult<Vec<ImprovementCycle>> {
+        let cycles = self.load()?;
+        let start = cycles.len().saturating_sub(n);
+        Ok(cycles[start..].to_vec())
+    }
+
+    /// Return the path to the history file.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}

--- a/src/self_improve/mod.rs
+++ b/src/self_improve/mod.rs
@@ -9,21 +9,31 @@
 //! dimension regresses beyond the allowed maximum (Pillar 11).
 
 pub(crate) mod cycle;
+pub mod history;
 pub mod prioritization;
+pub mod trend;
 mod types;
 
 #[cfg(test)]
 mod tests_cycle;
 
 #[cfg(test)]
+mod tests_history;
+
+#[cfg(test)]
 mod tests_prioritization;
+
+#[cfg(test)]
+mod tests_trend;
 
 // Re-export all public items so `crate::self_improve::X` still works.
 pub use cycle::{apply_improvements, run_improvement_cycle, summarize_cycle};
+pub use history::ImprovementHistory;
 pub use prioritization::{
     PrioritizedDimension, PriorityWeights, find_weak_dimensions_detailed, prioritize_dimensions,
     prioritize_dimensions_default,
 };
+pub use trend::{CycleTrend, DimensionTrend, analyze_trends, rank_dimensions_by_priority};
 pub use types::{
     ImprovementConfig, ImprovementCycle, ImprovementDecision, ImprovementPhase, ProposedChange,
     WeakDimension,

--- a/src/self_improve/tests_history.rs
+++ b/src/self_improve/tests_history.rs
@@ -1,0 +1,387 @@
+use super::history::ImprovementHistory;
+use super::types::*;
+use crate::gym_bridge::ScoreDimensions;
+use crate::gym_scoring::GymSuiteScore;
+
+fn make_score(v: f64) -> GymSuiteScore {
+    GymSuiteScore {
+        suite_id: "test".into(),
+        overall: v,
+        dimensions: ScoreDimensions {
+            factual_accuracy: v,
+            specificity: v * 0.9,
+            temporal_awareness: v * 0.8,
+            source_attribution: v * 0.7,
+            confidence_calibration: v * 0.85,
+        },
+        scenario_count: 4,
+        scenarios_passed: 4,
+        pass_rate: 1.0,
+        recorded_at_unix_ms: None,
+    }
+}
+
+fn make_cycle(
+    overall: f64,
+    decision: ImprovementDecision,
+    changes: Vec<ProposedChange>,
+) -> ImprovementCycle {
+    ImprovementCycle {
+        baseline: make_score(overall),
+        proposed_changes: changes,
+        post_score: None,
+        regressions: Vec::new(),
+        decision: Some(decision),
+        final_phase: ImprovementPhase::Decide,
+        weak_dimensions: Vec::new(),
+        weak_dimension_details: Vec::new(),
+        target_dimension: None,
+    }
+}
+
+fn temp_history() -> (tempfile::TempDir, ImprovementHistory) {
+    let dir = tempfile::TempDir::new().unwrap();
+    let hist = ImprovementHistory::open(dir.path()).unwrap();
+    (dir, hist)
+}
+
+#[test]
+fn empty_history_loads_empty() {
+    let (_dir, hist) = temp_history();
+    let cycles = hist.load().unwrap();
+    assert!(cycles.is_empty());
+    assert_eq!(hist.cycle_count().unwrap(), 0);
+}
+
+#[test]
+fn append_and_load_single_cycle() {
+    let (_dir, hist) = temp_history();
+    let cycle = make_cycle(
+        0.7,
+        ImprovementDecision::Commit {
+            net_improvement: 0.05,
+        },
+        vec![],
+    );
+    hist.append(&cycle).unwrap();
+    let loaded = hist.load().unwrap();
+    assert_eq!(loaded.len(), 1);
+    assert!((loaded[0].baseline.overall - 0.7).abs() < 1e-9);
+}
+
+#[test]
+fn append_multiple_cycles() {
+    let (_dir, hist) = temp_history();
+    for i in 0..5 {
+        let cycle = make_cycle(
+            0.5 + (i as f64) * 0.05,
+            ImprovementDecision::Commit {
+                net_improvement: 0.05,
+            },
+            vec![],
+        );
+        hist.append(&cycle).unwrap();
+    }
+    assert_eq!(hist.cycle_count().unwrap(), 5);
+}
+
+#[test]
+fn corrupt_lines_skipped() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let path = dir.path().join("improvement_history.jsonl");
+    // Write a valid line, a corrupt line, then another valid line
+    let cycle = make_cycle(
+        0.7,
+        ImprovementDecision::Commit {
+            net_improvement: 0.05,
+        },
+        vec![],
+    );
+    let json = serde_json::to_string(&cycle).unwrap();
+    std::fs::write(&path, format!("{json}\nNOT_VALID_JSON\n{json}\n")).unwrap();
+
+    let hist = ImprovementHistory::open_file(path);
+    let loaded = hist.load().unwrap();
+    assert_eq!(loaded.len(), 2);
+}
+
+#[test]
+fn blank_lines_skipped() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let path = dir.path().join("improvement_history.jsonl");
+    let cycle = make_cycle(
+        0.7,
+        ImprovementDecision::Commit {
+            net_improvement: 0.05,
+        },
+        vec![],
+    );
+    let json = serde_json::to_string(&cycle).unwrap();
+    std::fs::write(&path, format!("{json}\n\n\n{json}\n")).unwrap();
+
+    let hist = ImprovementHistory::open_file(path);
+    let loaded = hist.load().unwrap();
+    assert_eq!(loaded.len(), 2);
+}
+
+#[test]
+fn was_previously_reverted_true() {
+    let (_dir, hist) = temp_history();
+    let change = ProposedChange {
+        file_path: "src/lib.rs".into(),
+        description: "refactor error handling".into(),
+        expected_impact: "fewer panics".into(),
+    };
+    let cycle = make_cycle(
+        0.5,
+        ImprovementDecision::Revert {
+            reason: "too risky".into(),
+        },
+        vec![change.clone()],
+    );
+    hist.append(&cycle).unwrap();
+    assert!(hist.was_previously_reverted(&change).unwrap());
+}
+
+#[test]
+fn was_previously_reverted_false_when_committed() {
+    let (_dir, hist) = temp_history();
+    let change = ProposedChange {
+        file_path: "src/lib.rs".into(),
+        description: "refactor error handling".into(),
+        expected_impact: "fewer panics".into(),
+    };
+    let cycle = make_cycle(
+        0.5,
+        ImprovementDecision::Commit {
+            net_improvement: 0.1,
+        },
+        vec![change.clone()],
+    );
+    hist.append(&cycle).unwrap();
+    assert!(!hist.was_previously_reverted(&change).unwrap());
+}
+
+#[test]
+fn was_previously_reverted_false_when_empty() {
+    let (_dir, hist) = temp_history();
+    let change = ProposedChange {
+        file_path: "src/lib.rs".into(),
+        description: "anything".into(),
+        expected_impact: "anything".into(),
+    };
+    assert!(!hist.was_previously_reverted(&change).unwrap());
+}
+
+#[test]
+fn dedup_proposals_filters_reverted() {
+    let (_dir, hist) = temp_history();
+    let reverted_change = ProposedChange {
+        file_path: "a.rs".into(),
+        description: "bad change".into(),
+        expected_impact: "none".into(),
+    };
+    let good_change = ProposedChange {
+        file_path: "b.rs".into(),
+        description: "good change".into(),
+        expected_impact: "improvement".into(),
+    };
+    let cycle = make_cycle(
+        0.5,
+        ImprovementDecision::Revert {
+            reason: "regression".into(),
+        },
+        vec![reverted_change.clone()],
+    );
+    hist.append(&cycle).unwrap();
+
+    let filtered = hist
+        .dedup_proposals(&[reverted_change, good_change.clone()])
+        .unwrap();
+    assert_eq!(filtered.len(), 1);
+    assert_eq!(filtered[0].file_path, "b.rs");
+}
+
+#[test]
+fn dedup_proposals_keeps_all_when_no_reverts() {
+    let (_dir, hist) = temp_history();
+    let proposals = vec![
+        ProposedChange {
+            file_path: "a.rs".into(),
+            description: "x".into(),
+            expected_impact: "y".into(),
+        },
+        ProposedChange {
+            file_path: "b.rs".into(),
+            description: "x".into(),
+            expected_impact: "y".into(),
+        },
+    ];
+    let filtered = hist.dedup_proposals(&proposals).unwrap();
+    assert_eq!(filtered.len(), 2);
+}
+
+#[test]
+fn history_path_reflects_dir() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let hist = ImprovementHistory::open(dir.path()).unwrap();
+    assert!(hist.path().ends_with("improvement_history.jsonl"));
+    assert!(hist.path().starts_with(dir.path()));
+}
+
+#[test]
+fn open_file_direct() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let path = dir.path().join("custom.jsonl");
+    let hist = ImprovementHistory::open_file(path.clone());
+    assert_eq!(hist.path(), path);
+}
+
+#[test]
+fn prune_keeps_most_recent() {
+    let (_dir, hist) = temp_history();
+    for i in 0..5 {
+        let cycle = make_cycle(
+            0.5 + (i as f64) * 0.05,
+            ImprovementDecision::Commit {
+                net_improvement: 0.05,
+            },
+            vec![],
+        );
+        hist.append(&cycle).unwrap();
+    }
+    assert_eq!(hist.cycle_count().unwrap(), 5);
+    hist.prune(3).unwrap();
+    let cycles = hist.load().unwrap();
+    assert_eq!(cycles.len(), 3);
+    assert!((cycles[0].baseline.overall - 0.60).abs() < 1e-9);
+    assert!((cycles[2].baseline.overall - 0.70).abs() < 1e-9);
+}
+
+#[test]
+fn prune_noop_when_under_limit() {
+    let (_dir, hist) = temp_history();
+    let cycle = make_cycle(
+        0.7,
+        ImprovementDecision::Commit {
+            net_improvement: 0.05,
+        },
+        vec![],
+    );
+    hist.append(&cycle).unwrap();
+    hist.prune(10).unwrap();
+    assert_eq!(hist.cycle_count().unwrap(), 1);
+}
+
+#[test]
+fn prune_empty_history_noop() {
+    let (_dir, hist) = temp_history();
+    hist.prune(5).unwrap();
+    assert_eq!(hist.cycle_count().unwrap(), 0);
+}
+
+#[test]
+fn reverted_count_zero_when_empty() {
+    let (_dir, hist) = temp_history();
+    let change = ProposedChange {
+        file_path: "src/lib.rs".into(),
+        description: "anything".into(),
+        expected_impact: "anything".into(),
+    };
+    assert_eq!(hist.reverted_count(&change).unwrap(), 0);
+}
+
+#[test]
+fn reverted_count_tracks_multiple_reverts() {
+    let (_dir, hist) = temp_history();
+    let change = ProposedChange {
+        file_path: "src/lib.rs".into(),
+        description: "risky change".into(),
+        expected_impact: "might break".into(),
+    };
+    for _ in 0..3 {
+        let cycle = make_cycle(
+            0.5,
+            ImprovementDecision::Revert {
+                reason: "regression".into(),
+            },
+            vec![change.clone()],
+        );
+        hist.append(&cycle).unwrap();
+    }
+    let committed = make_cycle(
+        0.6,
+        ImprovementDecision::Commit {
+            net_improvement: 0.1,
+        },
+        vec![change.clone()],
+    );
+    hist.append(&committed).unwrap();
+    assert_eq!(hist.reverted_count(&change).unwrap(), 3);
+}
+
+#[test]
+fn reverted_count_ignores_different_proposals() {
+    let (_dir, hist) = temp_history();
+    let change_a = ProposedChange {
+        file_path: "a.rs".into(),
+        description: "change a".into(),
+        expected_impact: "a".into(),
+    };
+    let change_b = ProposedChange {
+        file_path: "b.rs".into(),
+        description: "change b".into(),
+        expected_impact: "b".into(),
+    };
+    let cycle = make_cycle(
+        0.5,
+        ImprovementDecision::Revert {
+            reason: "regression".into(),
+        },
+        vec![change_a],
+    );
+    hist.append(&cycle).unwrap();
+    assert_eq!(hist.reverted_count(&change_b).unwrap(), 0);
+}
+
+#[test]
+fn last_n_cycles_returns_recent() {
+    let (_dir, hist) = temp_history();
+    for i in 0..5 {
+        let cycle = make_cycle(
+            0.5 + (i as f64) * 0.05,
+            ImprovementDecision::Commit {
+                net_improvement: 0.05,
+            },
+            vec![],
+        );
+        hist.append(&cycle).unwrap();
+    }
+    let last2 = hist.last_n_cycles(2).unwrap();
+    assert_eq!(last2.len(), 2);
+    // Should be the last two: overall 0.65 and 0.70
+    assert!((last2[0].baseline.overall - 0.65).abs() < 1e-9);
+    assert!((last2[1].baseline.overall - 0.70).abs() < 1e-9);
+}
+
+#[test]
+fn last_n_cycles_returns_all_when_fewer() {
+    let (_dir, hist) = temp_history();
+    let cycle = make_cycle(
+        0.7,
+        ImprovementDecision::Commit {
+            net_improvement: 0.05,
+        },
+        vec![],
+    );
+    hist.append(&cycle).unwrap();
+    let result = hist.last_n_cycles(10).unwrap();
+    assert_eq!(result.len(), 1);
+}
+
+#[test]
+fn last_n_cycles_empty_history() {
+    let (_dir, hist) = temp_history();
+    let result = hist.last_n_cycles(5).unwrap();
+    assert!(result.is_empty());
+}

--- a/src/self_improve/tests_trend.rs
+++ b/src/self_improve/tests_trend.rs
@@ -1,0 +1,196 @@
+use super::trend::{analyze_trends, rank_dimensions_by_priority};
+use super::types::*;
+use crate::gym_bridge::ScoreDimensions;
+use crate::gym_scoring::GymSuiteScore;
+
+fn make_score(v: f64) -> GymSuiteScore {
+    GymSuiteScore {
+        suite_id: "test".into(),
+        overall: v,
+        dimensions: ScoreDimensions {
+            factual_accuracy: v,
+            specificity: v * 0.9,
+            temporal_awareness: v * 0.8,
+            source_attribution: v * 0.7,
+            confidence_calibration: v * 0.85,
+        },
+        scenario_count: 4,
+        scenarios_passed: 4,
+        pass_rate: 1.0,
+        recorded_at_unix_ms: None,
+    }
+}
+
+fn make_cycle(overall: f64) -> ImprovementCycle {
+    ImprovementCycle {
+        baseline: make_score(overall),
+        proposed_changes: Vec::new(),
+        post_score: None,
+        regressions: Vec::new(),
+        decision: None,
+        final_phase: ImprovementPhase::Eval,
+        weak_dimensions: Vec::new(),
+        weak_dimension_details: Vec::new(),
+        target_dimension: None,
+    }
+}
+
+#[test]
+fn empty_cycles_produces_empty_trend() {
+    let trend = analyze_trends(&[], 10, 0.6);
+    assert_eq!(trend.cycle_count, 0);
+    assert!(trend.overall_scores.is_empty());
+    assert!(trend.dimensions.is_empty());
+    assert!((trend.overall_delta - 0.0).abs() < 1e-9);
+}
+
+#[test]
+fn single_cycle_zero_delta() {
+    let cycles = vec![make_cycle(0.7)];
+    let trend = analyze_trends(&cycles, 10, 0.6);
+    assert_eq!(trend.cycle_count, 1);
+    assert_eq!(trend.overall_scores.len(), 1);
+    assert!((trend.overall_delta - 0.0).abs() < 1e-9);
+}
+
+#[test]
+fn improving_trend_positive_delta() {
+    let cycles = vec![make_cycle(0.5), make_cycle(0.6), make_cycle(0.7)];
+    let trend = analyze_trends(&cycles, 10, 0.6);
+    assert_eq!(trend.cycle_count, 3);
+    assert!((trend.overall_delta - 0.2).abs() < 1e-9);
+}
+
+#[test]
+fn declining_trend_negative_delta() {
+    let cycles = vec![make_cycle(0.8), make_cycle(0.7), make_cycle(0.6)];
+    let trend = analyze_trends(&cycles, 10, 0.6);
+    assert!((trend.overall_delta - (-0.2)).abs() < 1e-9);
+}
+
+#[test]
+fn max_cycles_window_applied() {
+    let cycles = vec![
+        make_cycle(0.3),
+        make_cycle(0.5),
+        make_cycle(0.6),
+        make_cycle(0.7),
+    ];
+    let trend = analyze_trends(&cycles, 2, 0.6);
+    assert_eq!(trend.cycle_count, 2);
+    // Window is last 2: [0.6, 0.7]
+    assert!((trend.overall_delta - 0.1).abs() < 1e-9);
+}
+
+#[test]
+fn chronically_weak_dimension_detected() {
+    // source_attribution = overall * 0.7
+    // With overall at 0.5, source_attribution = 0.35 — well below 0.6
+    let cycles = vec![make_cycle(0.5), make_cycle(0.5), make_cycle(0.5)];
+    let trend = analyze_trends(&cycles, 10, 0.6);
+    let sa = trend
+        .dimensions
+        .iter()
+        .find(|d| d.dimension == "source_attribution")
+        .unwrap();
+    assert!(sa.chronically_weak);
+}
+
+#[test]
+fn strong_dimension_not_chronically_weak() {
+    // factual_accuracy = overall, at 0.8 that's above 0.6
+    let cycles = vec![make_cycle(0.8), make_cycle(0.8), make_cycle(0.8)];
+    let trend = analyze_trends(&cycles, 10, 0.6);
+    let fa = trend
+        .dimensions
+        .iter()
+        .find(|d| d.dimension == "factual_accuracy")
+        .unwrap();
+    assert!(!fa.chronically_weak);
+}
+
+#[test]
+fn dimension_scores_tracked_correctly() {
+    let cycles = vec![make_cycle(0.5), make_cycle(0.6), make_cycle(0.7)];
+    let trend = analyze_trends(&cycles, 10, 0.6);
+    let fa = trend
+        .dimensions
+        .iter()
+        .find(|d| d.dimension == "factual_accuracy")
+        .unwrap();
+    assert_eq!(fa.scores.len(), 3);
+    assert!((fa.scores[0] - 0.5).abs() < 1e-9);
+    assert!((fa.scores[2] - 0.7).abs() < 1e-9);
+    assert!((fa.net_delta - 0.2).abs() < 1e-9);
+}
+
+#[test]
+fn rank_dimensions_chronically_weak_first() {
+    // At 0.5 overall: source_attribution=0.35, temporal_awareness=0.40 are weak
+    // factual_accuracy=0.50 is also weak, but less chronically
+    let cycles = vec![make_cycle(0.5), make_cycle(0.5), make_cycle(0.5)];
+    let trend = analyze_trends(&cycles, 10, 0.6);
+    let ranked = rank_dimensions_by_priority(&trend);
+    // All are chronically weak at these scores, but source_attribution has lowest average
+    assert_eq!(ranked[0], "source_attribution");
+}
+
+#[test]
+fn rank_dimensions_with_mixed_weakness() {
+    // Two cycles at 0.5, one at 0.9 — some dimensions will be weak in >50% of cycles
+    let cycles = vec![make_cycle(0.5), make_cycle(0.5), make_cycle(0.9)];
+    let trend = analyze_trends(&cycles, 10, 0.6);
+    let ranked = rank_dimensions_by_priority(&trend);
+    // Should have 5 dimensions
+    assert_eq!(ranked.len(), 5);
+    // source_attribution at [0.35, 0.35, 0.63] — weak in 2/3 = chronically weak
+    let sa_idx = ranked
+        .iter()
+        .position(|d| d == "source_attribution")
+        .unwrap();
+    // factual_accuracy at [0.5, 0.5, 0.9] — weak in 2/3 = chronically weak
+    let fa_idx = ranked.iter().position(|d| d == "factual_accuracy").unwrap();
+    // sa should be before fa because its average is lower
+    assert!(sa_idx < fa_idx);
+}
+
+#[test]
+fn five_dimensions_always_present() {
+    let cycles = vec![make_cycle(0.7)];
+    let trend = analyze_trends(&cycles, 10, 0.6);
+    assert_eq!(trend.dimensions.len(), 5);
+    let names: Vec<&str> = trend
+        .dimensions
+        .iter()
+        .map(|d| d.dimension.as_str())
+        .collect();
+    assert!(names.contains(&"factual_accuracy"));
+    assert!(names.contains(&"specificity"));
+    assert!(names.contains(&"temporal_awareness"));
+    assert!(names.contains(&"source_attribution"));
+    assert!(names.contains(&"confidence_calibration"));
+}
+
+#[test]
+fn cycle_trend_serde_round_trip() {
+    let cycles = vec![make_cycle(0.5), make_cycle(0.6), make_cycle(0.7)];
+    let trend = analyze_trends(&cycles, 10, 0.6);
+    let json = serde_json::to_string(&trend).expect("serialize CycleTrend");
+    let deser: super::trend::CycleTrend =
+        serde_json::from_str(&json).expect("deserialize CycleTrend");
+    assert_eq!(deser.cycle_count, trend.cycle_count);
+    assert_eq!(deser.dimensions.len(), trend.dimensions.len());
+    assert!((deser.overall_delta - trend.overall_delta).abs() < 1e-9);
+}
+
+#[test]
+fn dimension_trend_serde_round_trip() {
+    let cycles = vec![make_cycle(0.5)];
+    let trend = analyze_trends(&cycles, 10, 0.6);
+    let dim = &trend.dimensions[0];
+    let json = serde_json::to_string(dim).expect("serialize DimensionTrend");
+    let deser: super::trend::DimensionTrend =
+        serde_json::from_str(&json).expect("deserialize DimensionTrend");
+    assert_eq!(deser.dimension, dim.dimension);
+    assert_eq!(deser.chronically_weak, dim.chronically_weak);
+}

--- a/src/self_improve/trend.rs
+++ b/src/self_improve/trend.rs
@@ -1,0 +1,135 @@
+//! Trend analysis across improvement cycles.
+//!
+//! Computes per-dimension score deltas over the last N cycles to surface
+//! persistent weaknesses vs transient dips. This helps the improvement
+//! cycle prioritize chronically-weak dimensions.
+
+use serde::{Deserialize, Serialize};
+
+use super::types::ImprovementCycle;
+
+/// Per-dimension trend summary.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct DimensionTrend {
+    pub dimension: String,
+    /// Score values across cycles (oldest first).
+    pub scores: Vec<f64>,
+    /// Net change from first to last cycle.
+    pub net_delta: f64,
+    /// Whether this dimension is chronically weak (below threshold in >50% of cycles).
+    pub chronically_weak: bool,
+}
+
+/// Aggregate trend across all dimensions.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CycleTrend {
+    /// Overall score values across cycles (oldest first).
+    pub overall_scores: Vec<f64>,
+    /// Net change in overall score from first to last cycle.
+    pub overall_delta: f64,
+    /// Per-dimension breakdowns.
+    pub dimensions: Vec<DimensionTrend>,
+    /// Number of cycles analyzed.
+    pub cycle_count: usize,
+}
+
+/// Analyze trends across the last `max_cycles` improvement cycles.
+///
+/// `weak_threshold` is used to determine if a dimension is chronically weak
+/// (below threshold in more than half of the analyzed cycles).
+pub fn analyze_trends(
+    cycles: &[ImprovementCycle],
+    max_cycles: usize,
+    weak_threshold: f64,
+) -> CycleTrend {
+    let window: &[ImprovementCycle] = if cycles.len() > max_cycles {
+        &cycles[cycles.len() - max_cycles..]
+    } else {
+        cycles
+    };
+
+    if window.is_empty() {
+        return CycleTrend {
+            overall_scores: Vec::new(),
+            overall_delta: 0.0,
+            dimensions: Vec::new(),
+            cycle_count: 0,
+        };
+    }
+
+    let overall_scores: Vec<f64> = window.iter().map(|c| c.baseline.overall).collect();
+    let overall_delta =
+        overall_scores.last().unwrap_or(&0.0) - overall_scores.first().unwrap_or(&0.0);
+
+    let dim_names = [
+        "factual_accuracy",
+        "specificity",
+        "temporal_awareness",
+        "source_attribution",
+        "confidence_calibration",
+    ];
+
+    let dimensions = dim_names
+        .iter()
+        .map(|&name| {
+            let scores: Vec<f64> = window
+                .iter()
+                .map(|c| dimension_value(&c.baseline, name))
+                .collect();
+            let net_delta = scores.last().unwrap_or(&0.0) - scores.first().unwrap_or(&0.0);
+            let weak_count = scores.iter().filter(|&&v| v < weak_threshold).count();
+            let chronically_weak = weak_count > window.len() / 2;
+            DimensionTrend {
+                dimension: name.to_string(),
+                scores,
+                net_delta,
+                chronically_weak,
+            }
+        })
+        .collect();
+
+    CycleTrend {
+        overall_scores,
+        overall_delta,
+        dimensions,
+        cycle_count: window.len(),
+    }
+}
+
+/// Rank dimensions by priority for improvement.
+///
+/// Chronically weak dimensions come first, then by lowest average score.
+pub fn rank_dimensions_by_priority(trend: &CycleTrend) -> Vec<String> {
+    let mut dims: Vec<&DimensionTrend> = trend.dimensions.iter().collect();
+    dims.sort_by(|a, b| {
+        // Chronically weak first
+        b.chronically_weak.cmp(&a.chronically_weak).then_with(|| {
+            // Then by average score (lower = higher priority)
+            let avg_a = if a.scores.is_empty() {
+                0.0
+            } else {
+                a.scores.iter().sum::<f64>() / a.scores.len() as f64
+            };
+            let avg_b = if b.scores.is_empty() {
+                0.0
+            } else {
+                b.scores.iter().sum::<f64>() / b.scores.len() as f64
+            };
+            avg_a
+                .partial_cmp(&avg_b)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })
+    });
+    dims.iter().map(|d| d.dimension.clone()).collect()
+}
+
+fn dimension_value(score: &crate::gym_scoring::GymSuiteScore, name: &str) -> f64 {
+    match name {
+        "factual_accuracy" => score.dimensions.factual_accuracy,
+        "specificity" => score.dimensions.specificity,
+        "temporal_awareness" => score.dimensions.temporal_awareness,
+        "source_attribution" => score.dimensions.source_attribution,
+        "confidence_calibration" => score.dimensions.confidence_calibration,
+        _ => 0.0,
+    }
+}

--- a/src/self_improve/types.rs
+++ b/src/self_improve/types.rs
@@ -1,7 +1,8 @@
 //! Types for the self-improvement loop.
 
-use crate::gym_scoring::{GymSuiteScore, Regression};
 use serde::{Deserialize, Serialize};
+
+use crate::gym_scoring::{GymSuiteScore, Regression};
 
 /// Phases of a single self-improvement cycle.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -73,7 +74,7 @@ pub enum ImprovementDecision {
 }
 
 /// Configuration for an improvement cycle.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ImprovementConfig {
     /// The gym suite to evaluate against.
     pub suite_id: String,


### PR DESCRIPTION
Fixes #685.

## Changes
- Add history.rs and trend.rs modules (cherry-picked from feat/harden-error-handling)
- Remove duplicate `use serde` import in types.rs
- Remove duplicate `cycle_trend_serde_round_trip` and `dimension_trend_serde_round_trip` test functions in tests_trend.rs
- Add missing `last_n_cycles` method to `ImprovementHistory`
- Add missing `weak_dimension_details` field in test constructors
- Fix clippy `lines_filter_map_ok` lint
- Update mod.rs to register new modules

## Verification
- `cargo check` passes clean
- `cargo clippy -- -D warnings` passes clean
- `cargo test --lib -- self_improve` — 178 tests pass