### PR TITLE
fix(#835): handle LLM plan parse failures without creating malformed issues

### DIFF
--- a/src/engineer_loop/selection.rs
+++ b/src/engineer_loop/selection.rs
@@ -185,9 +185,22 @@ pub(crate) fn select_git_commit(objective: &str, note: &str) -> SelectedEngineer
     }
 }
 
-pub(crate) fn select_open_issue(objective: &str, note: &str) -> SelectedEngineerAction {
-    let title = objective.to_string();
-    SelectedEngineerAction {
+/// Maximum length for a GitHub issue title created by the engineer loop.
+const MAX_ISSUE_TITLE_LEN: usize = 256;
+
+pub(crate) fn select_open_issue(
+    objective: &str,
+    note: &str,
+) -> SimardResult<SelectedEngineerAction> {
+    let title = sanitize_issue_title(objective);
+
+    if title.is_empty() {
+        return Err(SimardError::UnsupportedEngineerAction {
+            reason: "refusing to create a GitHub issue with an empty title".to_string(),
+        });
+    }
+
+    Ok(SelectedEngineerAction {
         label: "open-issue".to_string(),
         rationale: format!("Objective requests opening a GitHub issue.{note}"),
         argv: vec![
@@ -205,6 +218,30 @@ pub(crate) fn select_open_issue(objective: &str, note: &str) -> SelectedEngineer
             body: String::new(),
             labels: Vec::new(),
         }),
+    })
+}
+
+/// Sanitize an objective string for use as a GitHub issue title.
+///
+/// Strips newlines, collapses whitespace, and truncates to a reasonable length.
+fn sanitize_issue_title(raw: &str) -> String {
+    let single_line: String = raw
+        .chars()
+        .map(|c| if c == '\n' || c == '\r' { ' ' } else { c })
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    if single_line.len() <= MAX_ISSUE_TITLE_LEN {
+        single_line
+    } else {
+        let truncated = &single_line[..MAX_ISSUE_TITLE_LEN];
+        // Cut at the last word boundary to avoid mid-word truncation.
+        match truncated.rfind(' ') {
+            Some(pos) if pos > MAX_ISSUE_TITLE_LEN / 2 => format!("{}…", &truncated[..pos]),
+            _ => format!("{truncated}…"),
+        }
     }
 }
 
@@ -294,6 +331,7 @@ pub(crate) fn select_engineer_action(
     // LLM-based planning. If unavailable, use keyword analysis as the
     // base strategy — keyword analysis is the foundational
     // implementation, LLM planning is an enhancement).
+    let mut plan_parse_failed = false;
     let analyzed = match crate::engineer_plan::plan_objective(objective, inspection) {
         Ok(plan) if !plan.steps().is_empty() => plan.steps()[0].action.clone(),
         Ok(_) => {
@@ -302,9 +340,23 @@ pub(crate) fn select_engineer_action(
         }
         Err(e) => {
             tracing::warn!("LLM planning failed: {e} — using keyword analysis");
+            plan_parse_failed = true;
             super::types::analyze_objective(objective)
         }
     };
+
+    // When LLM plan parsing failed and keyword analysis matched "issue"
+    // in the objective text (e.g. "fix issue #835"), do NOT create a
+    // GitHub issue — the user did not intend to open one.  Demote to a
+    // read-only scan so the loop stays safe.
+    if plan_parse_failed && matches!(analyzed, AnalyzedAction::OpenIssue) {
+        tracing::warn!(
+            "suppressed OpenIssue action after plan parse failure — \
+             keyword matched 'issue' in objective but intent is ambiguous"
+        );
+        return Ok(select_cargo_action(objective, &note));
+    }
+
     match analyzed {
         AnalyzedAction::CreateFile => {
             if let Some(result) = select_create_file(objective, &note) {
@@ -322,7 +374,7 @@ pub(crate) fn select_engineer_action(
             }
         }
         AnalyzedAction::GitCommit => return Ok(select_git_commit(objective, &note)),
-        AnalyzedAction::OpenIssue => return Ok(select_open_issue(objective, &note)),
+        AnalyzedAction::OpenIssue => return select_open_issue(objective, &note),
         _ => {}
     }
 
@@ -441,9 +493,32 @@ mod tests {
 
     #[test]
     fn select_open_issue_creates_action() {
-        let action = select_open_issue("Report a bug", "");
+        let action = select_open_issue("Report a bug", "").unwrap();
         assert_eq!(action.label, "open-issue");
         assert!(action.argv.contains(&"--title".to_string()));
+    }
+
+    #[test]
+    fn select_open_issue_truncates_long_title() {
+        let long_title = "x ".repeat(200);
+        let action = select_open_issue(&long_title, "").unwrap();
+        let title_arg_idx = action.argv.iter().position(|a| a == "--title").unwrap() + 1;
+        // Title should be truncated near MAX_ISSUE_TITLE_LEN (plus '…' suffix)
+        assert!(action.argv[title_arg_idx].len() <= MAX_ISSUE_TITLE_LEN + "…".len());
+    }
+
+    #[test]
+    fn select_open_issue_rejects_empty_title() {
+        assert!(select_open_issue("", "").is_err());
+    }
+
+    #[test]
+    fn sanitize_issue_title_collapses_whitespace_and_newlines() {
+        let raw = "line one\nline two\r\nline three";
+        let title = sanitize_issue_title(raw);
+        assert_eq!(title, "line one line two line three");
+        assert!(!title.contains('\n'));
+        assert!(!title.contains('\r'));
     }
 
     #[test]

--- a/src/engineer_loop/tests_selection.rs
+++ b/src/engineer_loop/tests_selection.rs
@@ -145,7 +145,7 @@ fn select_git_commit_argv_contains_git_commit_m() {
 
 #[test]
 fn select_open_issue_builds_action_with_title() {
-    let action = select_open_issue("fix the login page", "");
+    let action = select_open_issue("fix the login page", "").unwrap();
     assert_eq!(action.label, "open-issue");
     assert!(action.argv.contains(&"gh".to_string()));
     match &action.kind {
@@ -160,7 +160,7 @@ fn select_open_issue_builds_action_with_title() {
 
 #[test]
 fn select_open_issue_note_appears_in_rationale() {
-    let action = select_open_issue("test", " [extra]");
+    let action = select_open_issue("test", " [extra]").unwrap();
     assert!(action.rationale.contains("[extra]"));
 }
 


### PR DESCRIPTION
## Problem

When the engineer loop fails to parse the LLM's plan response, keyword analysis on objectives containing the word 'issue' (e.g. 'fix issue #835') incorrectly triggers `OpenIssue`, creating a malformed GitHub issue with the raw objective text as the title.

## Changes

- **Suppress spurious issue creation after plan parse failure**: Track when `plan_objective` fails and, if keyword analysis returns `OpenIssue`, demote to a safe cargo action instead.
- **Validate and sanitize issue titles**: `select_open_issue` now strips newlines, collapses whitespace, truncates to 256 chars, and rejects empty titles.
- **New tests**: Title truncation, empty title rejection, and whitespace sanitization.

## Files changed

- `src/engineer_loop/selection.rs` — Core fix + title sanitization
- `src/engineer_loop/tests_selection.rs` — Updated tests for new return type

## Verification

- `cargo check` ✅
- `cargo clippy -- -D warnings` ✅
- `cargo fmt` ✅
- `cargo test --lib -- selection` — 53 passed ✅

Closes #835