### PR TITLE
test: rebase wave 6 test coverage onto main (closes #851, closes #819)

### DIFF
--- a/src/knowledge_context.rs
+++ b/src/knowledge_context.rs
@@ -60,7 +60,7 @@ pub fn enrich_planning_context(
         .collect();
 
     // Sort descending by score.
-    scored.sort_by(|a, b| b.0.cmp(&a.0));
+    scored.sort_by_key(|a| std::cmp::Reverse(a.0));
     scored.truncate(MAX_PACKS_PER_OBJECTIVE);
 
     let mut relevant_knowledge = Vec::new();

--- a/src/meeting_backend/persist.rs
+++ b/src/meeting_backend/persist.rs
@@ -698,7 +698,7 @@ pub fn extract_themes(messages: &[ConversationMessage]) -> Vec<String> {
         .into_iter()
         .filter(|(_, count)| *count >= min_freq)
         .collect();
-    themes.sort_by(|a, b| b.1.cmp(&a.1));
+    themes.sort_by_key(|a| std::cmp::Reverse(a.1));
     themes.truncate(10);
     themes.into_iter().map(|(word, _)| word).collect()
 }

--- a/src/meeting_facilitator/handoff.rs
+++ b/src/meeting_facilitator/handoff.rs
@@ -217,7 +217,7 @@ impl MeetingHandoff {
             .into_iter()
             .filter(|(_, count)| *count >= min_freq)
             .collect();
-        themes.sort_by(|a, b| b.1.cmp(&a.1));
+        themes.sort_by_key(|a| std::cmp::Reverse(a.1));
         themes.truncate(10);
         themes.into_iter().map(|(word, _)| word).collect()
     }

--- a/src/ooda_loop/observe.rs
+++ b/src/ooda_loop/observe.rs
@@ -395,4 +395,27 @@ mod tests {
             0
         );
     }
+
+    #[test]
+    fn scan_unprocessed_handoffs_in_empty_dir_returns_false() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let result = scan_unprocessed_handoffs_in(dir.path());
+        // Empty directory has no handoff files.
+        assert!(!result.unwrap_or(false));
+    }
+
+    #[test]
+    fn gather_environment_fields_are_strings() {
+        let snap = gather_environment();
+        // All fields must be valid UTF-8 strings — no panics and no binary data.
+        assert!(
+            snap.git_status.is_ascii() || !snap.git_status.is_empty() || snap.git_status.is_empty()
+        );
+        for commit in &snap.recent_commits {
+            assert!(!commit.contains('\0'), "commit line must not contain NUL");
+        }
+        for issue in &snap.open_issues {
+            assert!(!issue.contains('\0'), "issue title must not contain NUL");
+        }
+    }
 }

--- a/src/operator_commands_engineer/read_view.rs
+++ b/src/operator_commands_engineer/read_view.rs
@@ -358,4 +358,17 @@ mod tests {
             required_engineer_evidence_value(&records, "nonexistent-field=", "test-source");
         assert!(result.is_err());
     }
+
+    #[test]
+    fn parse_engineer_summary_list_with_single_item() {
+        let result = parse_engineer_summary_list("only-one-goal", ", ");
+        assert_eq!(result, vec!["only-one-goal"]);
+    }
+
+    #[test]
+    fn parse_carried_meeting_decisions_with_content() {
+        let record = "agenda=Sprint review; updates=[Updated A]; decisions=[Use strategy X | Defer Y]; risks=[Risk 1]; next_steps=[Step 1]; open_questions=[Question 1]; goals=[p1:active:Goal title:Goal rationale]";
+        let result = parse_carried_meeting_decisions(record).unwrap();
+        assert_eq!(result, vec!["Use strategy X", "Defer Y"]);
+    }
 }

--- a/src/self_improve/prioritization.rs
+++ b/src/self_improve/prioritization.rs
@@ -197,3 +197,106 @@ pub fn dimension_value(score: &GymSuiteScore, name: &str) -> f64 {
         _ => 0.0,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gym_bridge::ScoreDimensions;
+
+    fn make_score(v: f64) -> GymSuiteScore {
+        GymSuiteScore {
+            suite_id: "test".into(),
+            overall: v,
+            dimensions: ScoreDimensions {
+                factual_accuracy: v,
+                specificity: v,
+                temporal_awareness: v,
+                source_attribution: v,
+                confidence_calibration: v,
+            },
+            scenario_count: 4,
+            scenarios_passed: 4,
+            pass_rate: 1.0,
+            recorded_at_unix_ms: None,
+        }
+    }
+
+    #[test]
+    fn priority_weights_default_sum_to_one() {
+        let w = PriorityWeights::default();
+        let sum = w.deficit + w.chronic + w.trend;
+        assert!(
+            (sum - 1.0).abs() < 1e-10,
+            "weights must sum to 1.0, got {sum}"
+        );
+    }
+
+    #[test]
+    fn find_weak_dimensions_detailed_empty_when_all_above_threshold() {
+        let score = make_score(0.9);
+        let result = find_weak_dimensions_detailed(&score, 0.5, None);
+        assert!(
+            result.is_empty(),
+            "no dimensions should be weak when all scores exceed threshold"
+        );
+    }
+
+    #[test]
+    fn find_weak_dimensions_detailed_detects_below_threshold() {
+        let score = make_score(0.3);
+        let result = find_weak_dimensions_detailed(&score, 0.5, None);
+        assert_eq!(
+            result.len(),
+            5,
+            "all 5 dimensions should be weak when score is 0.3"
+        );
+        for dim in &result {
+            assert!(
+                (dim.deficit - 0.2).abs() < 1e-10,
+                "deficit should be 0.5 - 0.3 = 0.2"
+            );
+        }
+    }
+
+    #[test]
+    fn find_weak_dimensions_detailed_sorted_by_deficit_descending() {
+        let mut score = make_score(0.9);
+        score.dimensions.specificity = 0.2; // large deficit
+        score.dimensions.factual_accuracy = 0.4; // smaller deficit
+        let result = find_weak_dimensions_detailed(&score, 0.5, None);
+        assert_eq!(
+            result[0].name, "specificity",
+            "largest deficit should sort first"
+        );
+    }
+
+    #[test]
+    fn find_weak_dimensions_detailed_target_filter_restricts_to_one() {
+        let score = make_score(0.3);
+        let result = find_weak_dimensions_detailed(&score, 0.5, Some("specificity"));
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "specificity");
+    }
+
+    #[test]
+    fn prioritize_dimensions_returns_all_five() {
+        let score = make_score(0.7);
+        let result = prioritize_dimensions(&score, 0.5, &[], &PriorityWeights::default());
+        assert_eq!(result.len(), 5, "must return one entry per dimension");
+    }
+
+    #[test]
+    fn dimension_value_unknown_name_returns_zero() {
+        let score = make_score(0.8);
+        assert_eq!(dimension_value(&score, "unknown_dimension"), 0.0);
+    }
+
+    #[test]
+    fn prioritize_dimensions_default_matches_explicit_default_weights() {
+        let score = make_score(0.4);
+        let past = vec![make_score(0.5), make_score(0.3)];
+        let via_default = prioritize_dimensions_default(&score, 0.6, &past);
+        let via_explicit = prioritize_dimensions(&score, 0.6, &past, &PriorityWeights::default());
+        assert_eq!(via_default, via_explicit);
+    }
+}

--- a/src/skill_builder.rs
+++ b/src/skill_builder.rs
@@ -56,7 +56,7 @@ pub fn extract_skill_candidates(
         .collect();
 
     // Sort by usage count descending (implicit from the procedure data).
-    candidates.sort_by(|a, b| b.steps.len().cmp(&a.steps.len()));
+    candidates.sort_by_key(|a| std::cmp::Reverse(a.steps.len()));
 
     Ok(candidates)
 }


### PR DESCRIPTION
## Summary

Cherry-picks test coverage commits from PR #823 (`feat/test-coverage-wave6-819`) onto current main, resolving merge conflicts and fixing clippy warnings.

## Changes
- Add inline unit tests for `ooda_loop/observe.rs` and `operator_commands_engineer/read_view.rs`
- Add inline `#[cfg(test)]` module to `self_improve/prioritization.rs`
- Fix `sort_by` → `sort_by_key+Reverse` for clippy `unnecessary_sort_by`
- Fix `bool_assert_comparison` clippy warning in `observe.rs`

## Verification
- `cargo build` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo fmt --all -- --check` ✅

Closes #851
Closes #819
Supersedes #823