### PR TITLE
fix(memory): cross-session fact dedup, sync_pending at teardown

### DIFF
--- a/src/memory_consolidation.rs
+++ b/src/memory_consolidation.rs
@@ -159,10 +159,17 @@ pub fn reflection_memory_operations(
     )?;
 
     // Store each extracted fact in semantic memory, deduplicating by concept
-    // so that repeated facts within the same session don't produce redundant entries.
+    // both within this session and across prior sessions.
     let mut seen_concepts = std::collections::HashSet::<String>::new();
     for fact in facts {
         if !seen_concepts.insert(fact.concept.clone()) {
+            continue;
+        }
+        // Cross-session dedup: skip if an existing fact has >= confidence.
+        let existing = bridge
+            .search_facts(&fact.concept, 5, fact.confidence)
+            .unwrap_or_default();
+        if existing.iter().any(|f| f.confidence >= fact.confidence) {
             continue;
         }
         bridge.store_fact(
@@ -385,8 +392,8 @@ mod tests {
             },
         ];
         reflection_memory_operations("transcript...", &facts, &test_session_id(), &bridge).unwrap();
-        // 1 store_episode + 2 store_fact = 3
-        assert_eq!(count.load(Ordering::SeqCst), 3);
+        // 1 store_episode + 2*(search_facts + store_fact) = 5
+        assert_eq!(count.load(Ordering::SeqCst), 5);
     }
 
     #[test]
@@ -405,8 +412,8 @@ mod tests {
             },
         ];
         reflection_memory_operations("transcript...", &facts, &test_session_id(), &bridge).unwrap();
-        // 1 store_episode + 1 store_fact (second duplicate skipped) = 2
-        assert_eq!(count.load(Ordering::SeqCst), 2);
+        // 1 store_episode + 1*(search_facts + store_fact) (second duplicate skipped) = 3
+        assert_eq!(count.load(Ordering::SeqCst), 3);
     }
 
     #[test]

--- a/src/runtime/session.rs
+++ b/src/runtime/session.rs
@@ -54,6 +54,14 @@ impl RuntimeKernel {
         self.persist_session_summary(&mut session, &outcome, &context)?;
 
         // --- Memory consolidation: persistence at session end ---
+
+        // Flush any pending bridge writes before final persistence so that
+        // records that fell back to the local file store get one last retry.
+        let synced = self.ports.memory_store.flush_pending();
+        if synced > 0 {
+            eprintln!("[simard] session teardown: flushed {synced} pending memory records");
+        }
+
         if let Some(bridge) = &self.cognitive_bridge {
             // Flush working memory to episodes before final persistence.
             if let Err(e) =


### PR DESCRIPTION
## Summary

Closes #848, closes #688.

Three surgical fixes to the cognitive memory subsystem:

### 1. Cross-session fact deduplication (Gap 3)
`reflection_memory_operations()` now calls `bridge.search_facts()` before storing each fact. If an existing fact with >= confidence is found, the new fact is skipped. This prevents redundant cross-session entries.

### 2. sync_pending at teardown (Gap 2)  
Session teardown now calls `flush_pending()` on the memory store before `consolidation_persistence()`, giving any locally-cached bridge writes one last retry before the session ends.

### 3. consolidation_intake objective query (Gap 1)
Already fixed in prior work — `consolidation_intake` already takes `objective: &str` and uses it in `search_facts`.

### Files changed
- `src/memory_consolidation.rs` — cross-session dedup logic + test count updates
- `src/runtime/session.rs` — flush_pending call at teardown

### Validation
- `cargo check` ✅
- `cargo clippy --lib -- -D warnings` ✅
- `cargo fmt -- --check` ✅