### PR TITLE
test: add unit tests for engineer_loop, gym, ooda_actions, operator_commands_ooda (#648)

### DIFF
--- a/src/engineer_loop/mod.rs
+++ b/src/engineer_loop/mod.rs
@@ -14,6 +14,8 @@ mod tests_review_persist;
 #[cfg(test)]
 mod tests_selection;
 #[cfg(test)]
+mod tests_selection_extra;
+#[cfg(test)]
 mod tests_types;
 #[cfg(test)]
 mod tests_types_inline;

--- a/src/engineer_loop/selection.rs
+++ b/src/engineer_loop/selection.rs
@@ -224,7 +224,7 @@ pub(crate) fn select_open_issue(
 /// Sanitize an objective string for use as a GitHub issue title.
 ///
 /// Strips newlines, collapses whitespace, and truncates to a reasonable length.
-fn sanitize_issue_title(raw: &str) -> String {
+pub(crate) fn sanitize_issue_title(raw: &str) -> String {
     let single_line: String = raw
         .chars()
         .map(|c| if c == '\n' || c == '\r' { ' ' } else { c })

--- a/src/engineer_loop/tests_selection_extra.rs
+++ b/src/engineer_loop/tests_selection_extra.rs
@@ -1,0 +1,165 @@
+//! Additional unit tests for engineer_loop::selection — edge cases for
+//! `sanitize_issue_title`, `select_engineer_action`, and related helpers.
+
+use std::path::PathBuf;
+
+use super::selection::*;
+use super::types::*;
+
+fn make_clean_inspection() -> RepoInspection {
+    RepoInspection {
+        workspace_root: PathBuf::from("/tmp/test-repo"),
+        repo_root: PathBuf::from("/tmp/test-repo"),
+        branch: "main".into(),
+        head: "abc1234".into(),
+        worktree_dirty: false,
+        changed_files: vec![],
+        active_goals: vec![],
+        carried_meeting_decisions: vec![],
+        architecture_gap_summary: String::new(),
+    }
+}
+
+// ── sanitize_issue_title ────────────────────────────────────────
+
+#[test]
+fn sanitize_issue_title_short_title_unchanged() {
+    let title = sanitize_issue_title("Fix broken CI pipeline");
+    assert_eq!(title, "Fix broken CI pipeline");
+}
+
+#[test]
+fn sanitize_issue_title_empty_input() {
+    let title = sanitize_issue_title("");
+    assert_eq!(title, "");
+}
+
+#[test]
+fn sanitize_issue_title_whitespace_only_collapses() {
+    let title = sanitize_issue_title("   \t   \n   ");
+    assert_eq!(title, "");
+}
+
+#[test]
+fn sanitize_issue_title_multiple_newlines_become_spaces() {
+    let title = sanitize_issue_title("first\n\nsecond\r\nthird");
+    assert_eq!(title, "first second third");
+}
+
+#[test]
+fn sanitize_issue_title_exactly_at_limit_not_truncated() {
+    let title_256 = "a".repeat(256);
+    let result = sanitize_issue_title(&title_256);
+    assert_eq!(result.len(), 256);
+    assert!(!result.contains('…'));
+}
+
+#[test]
+fn sanitize_issue_title_one_over_limit_truncated() {
+    // Build a string of 257 chars with word boundaries
+    let words = "word ".repeat(60); // 300 chars
+    let result = sanitize_issue_title(&words);
+    assert!(result.len() <= 260); // 256 + ellipsis char
+    assert!(result.ends_with('…'));
+}
+
+#[test]
+fn sanitize_issue_title_long_single_word_truncated_at_limit() {
+    // No word boundary to split at — truncates at exactly MAX_ISSUE_TITLE_LEN
+    let long_word = "x".repeat(300);
+    let result = sanitize_issue_title(&long_word);
+    assert!(result.ends_with('…'));
+    // Should be 256 x's + ellipsis
+    assert!(result.len() <= 260);
+}
+
+#[test]
+fn sanitize_issue_title_extra_spaces_collapsed() {
+    let title = sanitize_issue_title("  too   many    spaces  ");
+    assert_eq!(title, "too many spaces");
+}
+
+// ── select_cargo_action variants ────────────────────────────────
+
+#[test]
+fn select_cargo_action_cargo_build_detected() {
+    let action = select_cargo_action("cargo build the project", "");
+    assert_eq!(action.label, "cargo-check");
+}
+
+#[test]
+fn select_cargo_action_compilation_check_detected() {
+    let action = select_cargo_action("run a compilation check", "");
+    assert_eq!(action.label, "cargo-check");
+}
+
+#[test]
+fn select_cargo_action_note_appears_in_rationale() {
+    let action = select_cargo_action("cargo test", " (note: decided in meeting)");
+    assert!(action.rationale.contains("decided in meeting"));
+}
+
+// ── select_shell_command edge cases ─────────────────────────────
+
+#[test]
+fn select_shell_command_gh_allowed() {
+    let action = select_shell_command("run gh issue list", "");
+    assert!(action.is_some());
+    let action = action.unwrap();
+    assert!(action.argv.contains(&"gh".to_string()));
+}
+
+#[test]
+fn select_shell_command_rustfmt_allowed() {
+    let action = select_shell_command("run rustfmt src/main.rs", "");
+    assert!(action.is_some());
+}
+
+#[test]
+fn select_shell_command_npm_blocked() {
+    let action = select_shell_command("run npm install", "");
+    assert!(action.is_none());
+}
+
+// ── carry_forward_note ──────────────────────────────────────────
+
+#[test]
+fn carry_forward_note_three_decisions() {
+    let inspection = RepoInspection {
+        carried_meeting_decisions: vec!["d1".into(), "d2".into(), "d3".into()],
+        ..make_clean_inspection()
+    };
+    let note = carry_forward_note(&inspection);
+    assert!(note.contains("3 meeting decision records"));
+}
+
+// ── extract_content_body ────────────────────────────────────────
+
+#[test]
+fn extract_content_body_preserves_multiline_content() {
+    let objective = "create file\ncontent: begin\nline1\nline2\nline3";
+    let body = extract_content_body(objective);
+    assert_eq!(body, "line1\nline2\nline3");
+}
+
+#[test]
+fn extract_content_body_empty_after_content_directive() {
+    let objective = "some preamble\ncontent:";
+    let body = extract_content_body(objective);
+    assert!(body.is_empty());
+}
+
+// ── select_git_commit ───────────────────────────────────────────
+
+#[test]
+fn select_git_commit_verification_steps_nonempty() {
+    let action = select_git_commit("commit initial scaffold", "");
+    assert!(!action.verification_steps.is_empty());
+}
+
+#[test]
+fn select_git_commit_argv_starts_with_git() {
+    let action = select_git_commit("commit refactor types", "");
+    assert_eq!(action.argv[0], "git");
+    assert_eq!(action.argv[1], "commit");
+}

--- a/src/gym/mod.rs
+++ b/src/gym/mod.rs
@@ -7,6 +7,8 @@ mod types;
 #[cfg(test)]
 mod tests_executor;
 #[cfg(test)]
+mod tests_gym_extra;
+#[cfg(test)]
 mod tests_mod;
 #[cfg(test)]
 mod tests_reporting;

--- a/src/gym/tests_gym_extra.rs
+++ b/src/gym/tests_gym_extra.rs
@@ -1,0 +1,157 @@
+//! Additional unit tests for gym module — covering scenario resolution
+//! edge cases, metric derivation boundaries, and reporting helpers.
+
+use super::scenarios::{benchmark_scenarios, resolve_benchmark_scenario};
+use super::types::*;
+use super::{STARTER_SUITE_ID, default_output_root};
+
+// ── default_output_root ─────────────────────────────────────────
+
+#[test]
+fn default_output_root_contains_simard_gym() {
+    let root = default_output_root();
+    let as_str = root.to_string_lossy();
+    assert!(as_str.contains("simard-gym"), "got: {as_str}");
+}
+
+#[test]
+fn default_output_root_is_not_absolute() {
+    assert!(!default_output_root().is_absolute());
+}
+
+// ── benchmark_scenarios invariants ──────────────────────────────
+
+#[test]
+fn all_scenario_titles_are_nonempty() {
+    for s in benchmark_scenarios() {
+        assert!(
+            !s.title.trim().is_empty(),
+            "scenario {} has empty title",
+            s.id
+        );
+    }
+}
+
+#[test]
+fn all_scenario_objectives_are_nonempty() {
+    for s in benchmark_scenarios() {
+        assert!(
+            !s.objective.trim().is_empty(),
+            "scenario {} has empty objective",
+            s.id
+        );
+    }
+}
+
+#[test]
+fn all_scenario_ids_are_ascii() {
+    for s in benchmark_scenarios() {
+        assert!(
+            s.id.is_ascii(),
+            "scenario id '{}' contains non-ASCII chars",
+            s.id
+        );
+    }
+}
+
+#[test]
+fn no_duplicate_scenario_titles() {
+    let titles: Vec<&str> = benchmark_scenarios().iter().map(|s| s.title).collect();
+    let mut seen = std::collections::HashSet::new();
+    for title in &titles {
+        assert!(seen.insert(title), "duplicate scenario title: {title}");
+    }
+}
+
+#[test]
+fn resolve_benchmark_scenario_returns_matching_id() {
+    let scenarios = benchmark_scenarios();
+    let first = scenarios[0];
+    let resolved = resolve_benchmark_scenario(first.id).unwrap();
+    assert_eq!(resolved.id, first.id);
+    assert_eq!(resolved.title, first.title);
+}
+
+#[test]
+fn resolve_benchmark_scenario_not_found_error_contains_id() {
+    let err = resolve_benchmark_scenario("nonexistent-scenario-xyz").unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("nonexistent-scenario-xyz"),
+        "error should contain the scenario id: {msg}"
+    );
+}
+
+// ── starter suite constant ──────────────────────────────────────
+
+#[test]
+fn starter_suite_id_is_lowercase() {
+    assert_eq!(STARTER_SUITE_ID, STARTER_SUITE_ID.to_lowercase());
+}
+
+// ── BenchmarkClass display coverage ─────────────────────────────
+
+#[test]
+fn benchmark_class_display_covers_all_variants() {
+    let classes = [
+        BenchmarkClass::RepoExploration,
+        BenchmarkClass::Documentation,
+        BenchmarkClass::SafeCodeChange,
+        BenchmarkClass::TestWriting,
+        BenchmarkClass::SessionQuality,
+        BenchmarkClass::BugFix,
+        BenchmarkClass::Refactoring,
+        BenchmarkClass::DependencyAnalysis,
+        BenchmarkClass::ErrorHandling,
+    ];
+    for class in &classes {
+        let display = format!("{class}");
+        assert!(!display.is_empty(), "{class:?} has empty display");
+    }
+}
+
+// ── BenchmarkComparisonStatus ───────────────────────────────────
+
+#[test]
+fn comparison_status_debug_and_clone() {
+    let status = BenchmarkComparisonStatus::Improved;
+    let cloned = status;
+    assert_eq!(format!("{status:?}"), format!("{cloned:?}"));
+}
+
+#[test]
+fn comparison_status_all_variants_display() {
+    let variants = [
+        BenchmarkComparisonStatus::Improved,
+        BenchmarkComparisonStatus::Regressed,
+        BenchmarkComparisonStatus::Unchanged,
+    ];
+    for v in &variants {
+        let display = format!("{v}");
+        assert!(!display.is_empty());
+    }
+}
+
+// ── BenchmarkCheckResult construction ───────────────────────────
+
+#[test]
+fn check_result_passed_has_no_detail_requirement() {
+    let check = BenchmarkCheckResult {
+        id: "syntax-valid".to_string(),
+        passed: true,
+        detail: String::new(),
+    };
+    assert!(check.passed);
+    assert!(check.detail.is_empty());
+}
+
+#[test]
+fn check_result_failed_preserves_detail() {
+    let check = BenchmarkCheckResult {
+        id: "output-check".to_string(),
+        passed: false,
+        detail: "expected foo, got bar".to_string(),
+    };
+    assert!(!check.passed);
+    assert!(check.detail.contains("foo"));
+}

--- a/src/ooda_actions/mod.rs
+++ b/src/ooda_actions/mod.rs
@@ -11,7 +11,9 @@ mod simple_actions;
 mod verification;
 
 #[cfg(test)]
-mod test_helpers;
+pub(crate) mod test_helpers;
+#[cfg(test)]
+mod tests_dispatch;
 #[cfg(test)]
 mod tests_goal_session;
 

--- a/src/ooda_actions/tests_dispatch.rs
+++ b/src/ooda_actions/tests_dispatch.rs
@@ -1,0 +1,127 @@
+//! Unit tests for the top-level `dispatch_actions` orchestrator and
+//! the `make_outcome` helper in ooda_actions.
+
+use crate::ooda_actions::dispatch_actions;
+use crate::ooda_loop::{ActionKind, OodaState, PlannedAction};
+
+use super::make_outcome;
+use super::test_helpers::{board_with_goal, test_bridges};
+use crate::goal_curation::GoalProgress;
+
+// ── make_outcome ────────────────────────────────────────────────
+
+#[test]
+fn make_outcome_success_preserves_fields() {
+    let action = PlannedAction {
+        kind: ActionKind::ConsolidateMemory,
+        goal_id: None,
+        description: "consolidate all memory".to_string(),
+    };
+    let outcome = make_outcome(&action, true, "done".to_string());
+    assert!(outcome.success);
+    assert_eq!(outcome.detail, "done");
+    assert_eq!(outcome.action.kind, ActionKind::ConsolidateMemory);
+    assert_eq!(outcome.action.description, "consolidate all memory");
+}
+
+#[test]
+fn make_outcome_failure_preserves_fields() {
+    let action = PlannedAction {
+        kind: ActionKind::RunGymEval,
+        goal_id: None,
+        description: "run gym".to_string(),
+    };
+    let outcome = make_outcome(&action, false, "timeout".to_string());
+    assert!(!outcome.success);
+    assert_eq!(outcome.detail, "timeout");
+}
+
+#[test]
+fn make_outcome_clones_action_independently() {
+    let action = PlannedAction {
+        kind: ActionKind::ResearchQuery,
+        goal_id: Some("g1".to_string()),
+        description: "research".to_string(),
+    };
+    let outcome = make_outcome(&action, true, "ok".to_string());
+    assert_eq!(outcome.action.goal_id, Some("g1".to_string()));
+}
+
+// ── dispatch_actions ────────────────────────────────────────────
+
+#[test]
+fn dispatch_empty_actions_returns_empty_vec() {
+    let mut bridges = test_bridges();
+    let board = board_with_goal("g1", GoalProgress::NotStarted, None);
+    let mut state = OodaState::new(board);
+    let outcomes = dispatch_actions(&[], &mut bridges, &mut state).unwrap();
+    assert!(outcomes.is_empty());
+}
+
+#[test]
+fn dispatch_consolidate_memory_returns_one_outcome() {
+    let mut bridges = test_bridges();
+    let board = board_with_goal("g1", GoalProgress::NotStarted, None);
+    let mut state = OodaState::new(board);
+    let actions = vec![PlannedAction {
+        kind: ActionKind::ConsolidateMemory,
+        goal_id: None,
+        description: "consolidate".to_string(),
+    }];
+    let outcomes = dispatch_actions(&actions, &mut bridges, &mut state).unwrap();
+    assert_eq!(outcomes.len(), 1);
+    assert!(outcomes[0].success);
+}
+
+#[test]
+fn dispatch_research_query_returns_one_outcome() {
+    let mut bridges = test_bridges();
+    let board = board_with_goal("g1", GoalProgress::NotStarted, None);
+    let mut state = OodaState::new(board);
+    let actions = vec![PlannedAction {
+        kind: ActionKind::ResearchQuery,
+        goal_id: None,
+        description: "look up patterns".to_string(),
+    }];
+    let outcomes = dispatch_actions(&actions, &mut bridges, &mut state).unwrap();
+    assert_eq!(outcomes.len(), 1);
+    assert!(outcomes[0].success);
+}
+
+#[test]
+fn dispatch_multiple_independent_actions_preserves_order() {
+    let mut bridges = test_bridges();
+    let board = board_with_goal("g1", GoalProgress::NotStarted, None);
+    let mut state = OodaState::new(board);
+    let actions = vec![
+        PlannedAction {
+            kind: ActionKind::ConsolidateMemory,
+            goal_id: None,
+            description: "consolidate".to_string(),
+        },
+        PlannedAction {
+            kind: ActionKind::RunGymEval,
+            goal_id: None,
+            description: "gym eval".to_string(),
+        },
+    ];
+    let outcomes = dispatch_actions(&actions, &mut bridges, &mut state).unwrap();
+    assert_eq!(outcomes.len(), 2);
+    assert_eq!(outcomes[0].action.description, "consolidate");
+    assert_eq!(outcomes[1].action.description, "gym eval");
+}
+
+#[test]
+fn dispatch_advance_goal_without_session_fails_gracefully() {
+    let mut bridges = test_bridges(); // no session
+    let board = board_with_goal("g1", GoalProgress::InProgress { percent: 30 }, None);
+    let mut state = OodaState::new(board);
+    let actions = vec![PlannedAction {
+        kind: ActionKind::AdvanceGoal,
+        goal_id: Some("g1".to_string()),
+        description: "advance goal".to_string(),
+    }];
+    let outcomes = dispatch_actions(&actions, &mut bridges, &mut state).unwrap();
+    assert_eq!(outcomes.len(), 1);
+    assert!(!outcomes[0].success);
+}

--- a/src/operator_commands_ooda/tests/mod.rs
+++ b/src/operator_commands_ooda/tests/mod.rs
@@ -1,4 +1,5 @@
 mod auto_reload_tests;
+mod persistence_memory_tests;
 mod persistence_tests;
 mod report_tests;
 

--- a/src/operator_commands_ooda/tests/persistence_memory_tests.rs
+++ b/src/operator_commands_ooda/tests/persistence_memory_tests.rs
@@ -1,0 +1,95 @@
+//! Unit tests for `persist_cycle_to_memory` — the cognitive memory
+//! persistence path that was previously uncovered.
+
+use super::*;
+use crate::ooda_loop::ActionKind;
+
+#[test]
+fn persist_cycle_to_memory_succeeds_for_minimal_report() {
+    let bridges = crate::ooda_actions::test_helpers::test_bridges();
+    let report = make_test_report(1);
+    // Should not panic — best-effort persistence
+    super::super::persistence::persist_cycle_to_memory(&bridges, &report);
+}
+
+#[test]
+fn persist_cycle_to_memory_with_goals_and_outcomes() {
+    let bridges = crate::ooda_actions::test_helpers::test_bridges();
+    let report = make_report_with_goals_and_outcomes();
+    super::super::persistence::persist_cycle_to_memory(&bridges, &report);
+}
+
+#[test]
+fn persist_cycle_to_memory_with_zero_outcomes() {
+    let bridges = crate::ooda_actions::test_helpers::test_bridges();
+    let mut report = make_test_report(5);
+    report.outcomes.clear();
+    super::super::persistence::persist_cycle_to_memory(&bridges, &report);
+}
+
+#[test]
+fn persist_cycle_to_memory_with_all_failed_outcomes() {
+    use crate::ooda_loop::{ActionOutcome, PlannedAction};
+
+    let bridges = crate::ooda_actions::test_helpers::test_bridges();
+    let mut report = make_test_report(10);
+    report.outcomes = vec![
+        ActionOutcome {
+            action: PlannedAction {
+                kind: ActionKind::AdvanceGoal,
+                goal_id: Some("g1".to_string()),
+                description: "try advance".to_string(),
+            },
+            success: false,
+            detail: "blocked".to_string(),
+        },
+        ActionOutcome {
+            action: PlannedAction {
+                kind: ActionKind::RunGymEval,
+                goal_id: None,
+                description: "eval".to_string(),
+            },
+            success: false,
+            detail: "timeout".to_string(),
+        },
+    ];
+    super::super::persistence::persist_cycle_to_memory(&bridges, &report);
+}
+
+#[test]
+fn persist_cycle_report_and_memory_together() {
+    let bridges = crate::ooda_actions::test_helpers::test_bridges();
+    let dir = tempfile::tempdir().unwrap();
+    let report = make_report_with_goals_and_outcomes();
+
+    persist_cycle_report(dir.path(), &report);
+    super::super::persistence::persist_cycle_to_memory(&bridges, &report);
+
+    // File should exist from persist_cycle_report
+    let path = dir.path().join("cycle_reports").join("cycle_7.json");
+    assert!(path.exists());
+}
+
+#[test]
+fn persist_cycle_to_memory_with_open_issues() {
+    use crate::ooda_loop::{EnvironmentSnapshot, GoalSnapshot, Observation};
+
+    let bridges = crate::ooda_actions::test_helpers::test_bridges();
+    let mut report = make_test_report(3);
+    report.observation = Observation {
+        goal_statuses: vec![GoalSnapshot {
+            id: "g1".to_string(),
+            description: "fix bug".to_string(),
+            progress: GoalProgress::InProgress { percent: 50 },
+        }],
+        gym_health: None,
+        memory_stats: CognitiveStatistics::default(),
+        pending_improvements: vec![],
+        environment: EnvironmentSnapshot {
+            git_status: String::new(),
+            open_issues: vec!["issue-1".to_string(), "issue-2".to_string()],
+            recent_commits: vec!["abc123".to_string()],
+        },
+    };
+    super::super::persistence::persist_cycle_to_memory(&bridges, &report);
+}


### PR DESCRIPTION
Closes #648

## Summary

Adds **47 new unit tests** across four under-tested production modules:

| Module | New Tests | Key Coverage |
|--------|-----------|--------------|
| `engineer_loop` | 19 | `sanitize_issue_title` edge cases, `select_cargo_action`, `select_shell_command`, `carry_forward_note`, `extract_content_body`, `select_git_commit` |
| `gym` | 14 | Scenario invariants, benchmark type construction, comparison status display, `default_output_root` |
| `ooda_actions` | 8 | `make_outcome` helper, `dispatch_actions` orchestration (empty, single, multiple, missing session) |
| `operator_commands_ooda` | 6 | `persist_cycle_to_memory` (previously untested), covering minimal/rich reports, empty/failed outcomes |

## Changes

- 4 new test files added
- `sanitize_issue_title` visibility widened to `pub(crate)` for direct testing
- `ooda_actions::test_helpers` visibility widened to `pub(crate)` for cross-module test reuse
- All tests pass; no pre-existing tests affected
- `cargo clippy -- -D warnings` clean; `cargo fmt --check` clean