### PR TITLE
fix: remove amplihack auto-install (#839)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -28,7 +28,7 @@
 | Dashboard v2 | WebSocket chat, logs, processes, memory, auth, issues | `src/operator_commands_dashboard/` |
 | Remote Session | azlin-based remote VM orchestration with lifecycle | `src/remote_session.rs`, `src/remote_azlin.rs` |
 | Self-Metrics | Metric recording, daily reports, cost tracking | `src/self_metrics/`, `src/cost_tracking/` |
-| Ensure-Deps | Auto-install runtime dependencies (git, python3, gh, etc.) | `src/cmd_ensure_deps.rs` |
+| Ensure-Deps | Check runtime dependencies (git, python3, gh) with warnings | `src/cmd_ensure_deps.rs` |
 | Cleanup Command | Resource reclamation (canary dirs, stale targets, orphans) | `src/cmd_cleanup.rs` |
 | Test Coverage | 3,177 tests across 238 source files (100% file coverage) | `tests/` |
 

--- a/src/cmd_ensure_deps.rs
+++ b/src/cmd_ensure_deps.rs
@@ -1,10 +1,10 @@
-//! Dependency auto-installer: ensures all Simard runtime dependencies are present.
+//! Dependency checker: verifies that Simard runtime dependencies are present.
 //!
-//! Checks for required tools (python3, gh, amplihack, git), Python packages
-//! (kuzu, amplihack-memory), and the amplihack-memory-lib source tree. Installs
-//! or clones anything missing so Simard can operate without pre-existing setup.
+//! Checks for required tools (python3, gh, git) and Python packages (kuzu).
+//! Reports missing dependencies with actionable guidance rather than
+//! auto-installing them — Simard's native Rust modules now cover capabilities
+//! that previously required the Python amplihack installation.
 
-use std::path::PathBuf;
 use std::process::Command;
 
 /// Summary of a single dependency check.
@@ -16,11 +16,10 @@ struct DepCheck {
 enum DepStatus {
     Ok(String),
     Missing(String),
-    Installed(String),
-    Failed(String),
+    Warning(String),
 }
 
-/// Run all dependency checks and install anything missing.
+/// Run all dependency checks and report results.
 pub fn handle_ensure_deps() -> Result<(), Box<dyn std::error::Error>> {
     println!("simard ensure-deps: checking runtime dependencies\n");
 
@@ -28,22 +27,20 @@ pub fn handle_ensure_deps() -> Result<(), Box<dyn std::error::Error>> {
         check_binary("git", &["--version"]),
         check_binary("python3", &["--version"]),
         check_binary("gh", &["--version"]),
-        check_amplihack(),
-        ensure_python_package("kuzu"),
-        ensure_memory_lib(),
+        check_python_package("kuzu"),
     ];
 
     println!();
     let mut failed = 0;
+    let mut warnings = 0;
     for dep in &results {
         let (icon, detail) = match &dep.status {
             DepStatus::Ok(msg) => ("✓", msg.as_str()),
-            DepStatus::Installed(msg) => ("⟳", msg.as_str()),
-            DepStatus::Missing(msg) => {
-                failed += 1;
-                ("✗", msg.as_str())
+            DepStatus::Warning(msg) => {
+                warnings += 1;
+                ("⚠", msg.as_str())
             }
-            DepStatus::Failed(msg) => {
+            DepStatus::Missing(msg) => {
                 failed += 1;
                 ("✗", msg.as_str())
             }
@@ -55,7 +52,11 @@ pub fn handle_ensure_deps() -> Result<(), Box<dyn std::error::Error>> {
     if failed > 0 {
         Err(format!("{failed} dependency check(s) failed").into())
     } else {
-        println!("All dependencies satisfied.");
+        if warnings > 0 {
+            println!("All required dependencies satisfied ({warnings} optional warning(s)).");
+        } else {
+            println!("All dependencies satisfied.");
+        }
         Ok(())
     }
 }
@@ -85,36 +86,7 @@ fn check_binary(name: &'static str, version_args: &[&str]) -> DepCheck {
     }
 }
 
-fn check_amplihack() -> DepCheck {
-    if let Ok(output) = Command::new("amplihack").arg("--version").output()
-        && output.status.success()
-    {
-        let ver = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        return DepCheck {
-            name: "amplihack",
-            status: DepStatus::Ok(ver),
-        };
-    }
-
-    // Try installing via cargo
-    println!("  installing amplihack via cargo...");
-    match Command::new("cargo")
-        .args(["install", "amplihack"])
-        .output()
-    {
-        Ok(output) if output.status.success() => DepCheck {
-            name: "amplihack",
-            status: DepStatus::Installed("installed via cargo".into()),
-        },
-        _ => DepCheck {
-            name: "amplihack",
-            status: DepStatus::Missing("not found; cargo install amplihack failed".into()),
-        },
-    }
-}
-
-fn ensure_python_package(package: &'static str) -> DepCheck {
-    // Check if importable
+fn check_python_package(package: &'static str) -> DepCheck {
     let check = Command::new("python3")
         .args(["-c", &format!("import {package}")])
         .output();
@@ -128,117 +100,11 @@ fn ensure_python_package(package: &'static str) -> DepCheck {
         };
     }
 
-    // Try pip install
-    println!("  installing {package} via pip...");
-    let install = Command::new("python3")
-        .args([
-            "-m",
-            "pip",
-            "install",
-            "--break-system-packages",
-            "--quiet",
-            package,
-        ])
-        .output();
-
-    match install {
-        Ok(output) if output.status.success() => DepCheck {
-            name: package,
-            status: DepStatus::Installed(format!("installed {package}")),
-        },
-        Ok(output) => {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            DepCheck {
-                name: package,
-                status: DepStatus::Failed(format!("pip install failed: {}", stderr.trim())),
-            }
-        }
-        Err(e) => DepCheck {
-            name: package,
-            status: DepStatus::Failed(format!("pip not available: {e}")),
-        },
-    }
-}
-
-fn memory_lib_candidates() -> Vec<PathBuf> {
-    let home = dirs_or_home();
-    vec![
-        home.join("src/amplirusty/amplihack-memory-lib/src"),
-        home.join("amplirusty/amplihack-memory-lib/src"),
-    ]
-}
-
-fn dirs_or_home() -> PathBuf {
-    std::env::var_os("HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("/usr/local"))
-}
-
-fn ensure_memory_lib() -> DepCheck {
-    let name = "amplihack-memory-lib";
-
-    // Check if already importable
-    if let Ok(output) = Command::new("python3")
-        .args(["-c", "import amplihack_memory"])
-        .output()
-        && output.status.success()
-    {
-        return DepCheck {
-            name,
-            status: DepStatus::Ok("importable".into()),
-        };
-    }
-
-    // Check candidate paths
-    for candidate in memory_lib_candidates() {
-        if candidate.join("amplihack_memory/__init__.py").exists() {
-            return DepCheck {
-                name,
-                status: DepStatus::Ok(format!("found at {}", candidate.display())),
-            };
-        }
-    }
-
-    // Clone amplihack repo to get the memory lib
-    let target = dirs_or_home().join("src/amplirusty");
-    if !target.exists() {
-        println!("  cloning amplihack repo for memory lib...");
-        let result = Command::new("git")
-            .args([
-                "clone",
-                "--depth=1",
-                "https://github.com/rysweet/amplihack.git",
-                &target.to_string_lossy(),
-            ])
-            .output();
-
-        match result {
-            Ok(output) if output.status.success() => {
-                // Verify the memory lib exists in the clone
-                let lib_path = target.join("amplihack-memory-lib/src");
-                if lib_path.join("amplihack_memory/__init__.py").exists() {
-                    return DepCheck {
-                        name,
-                        status: DepStatus::Installed(format!("cloned to {}", lib_path.display())),
-                    };
-                }
-            }
-            _ => {}
-        }
-    }
-
-    // Check if it exists in the clone even if we didn't just clone
-    let lib_path = target.join("amplihack-memory-lib/src");
-    if lib_path.join("amplihack_memory/__init__.py").exists() {
-        return DepCheck {
-            name,
-            status: DepStatus::Ok(format!("found at {}", lib_path.display())),
-        };
-    }
-
     DepCheck {
-        name,
-        status: DepStatus::Failed("could not locate or install amplihack-memory-lib".into()),
+        name: package,
+        status: DepStatus::Warning(format!(
+            "not importable; install with: pip install {package}"
+        )),
     }
 }
 
@@ -259,19 +125,9 @@ mod tests {
     }
 
     #[test]
-    fn memory_lib_candidates_are_absolute() {
-        for path in memory_lib_candidates() {
-            assert!(
-                path.is_absolute(),
-                "candidate should be absolute: {}",
-                path.display()
-            );
-        }
-    }
-
-    #[test]
-    fn dirs_or_home_returns_absolute() {
-        let home = dirs_or_home();
-        assert!(home.is_absolute());
+    fn check_python_package_reports_status() {
+        // A package that definitely doesn't exist should warn
+        let result = check_python_package("nonexistent_pkg_xyz_12345");
+        assert!(matches!(result.status, DepStatus::Warning(_)));
     }
 }


### PR DESCRIPTION
Closes #839

## Summary

Removes the auto-installation of Python amplihack from `cmd_ensure_deps.rs`. Simard's native Rust modules (`memory_cognitive`, `gym/`, `copilot_sdk`) now cover the capabilities that previously required the Python amplihack package.

## Changes

- **Removed** `check_amplihack()` — no longer auto-runs `cargo install amplihack`
- **Removed** `ensure_memory_lib()` — no longer clones the amplihack repo for `amplihack-memory-lib`
- **Removed** `ensure_python_package()` auto-install via pip — replaced with `check_python_package()` that warns instead
- **Simplified** `DepStatus` enum: `Ok`, `Missing`, `Warning` (removed `Installed`/`Failed`)
- **Kept** checks for git, python3, gh, and kuzu (still needed)
- **Updated** `docs/ROADMAP.md` to reflect check-only behavior
- **Updated** tests to match new API

## Validation

- `cargo check` ✓
- `cargo clippy -- -D warnings` ✓
- `cargo fmt --check` ✓