### PR TITLE
feat(docs): position Simard as Rust successor to Python amplihack (#896)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,13 @@ Named after [Suzanne Simard](https://en.wikipedia.org/wiki/Suzanne_Simard), the 
 
 Simard is a terminal-native engineering agent built in Rust. She operates like a disciplined software engineer: she understands codebases, works through tasks in explicit sessions, preserves useful memory, evaluates herself against benchmarks, and improves through structured review loops.
 
-Simard is part of the [amplihack](https://github.com/rysweet/amplihack) ecosystem of agentic coding tools.
+### Relationship to Python amplihack
+
+Simard is the **Rust successor to [Python amplihack](https://github.com/rysweet/amplihack)**. The intent is for Simard to become a drop-in replacement: the same agentic-coding capabilities, delivered as a single static Rust binary, with no Python runtime or `pip install` step required.
+
+That goal is **not yet fully met**. Today Simard implements the core engineer/meeting/goal-curation/improvement-curation/gym/OODA loops natively in Rust, but does not yet cover the full amplihack command surface (37 slash commands) or skill catalog (117 skills). Parity work is tracked in the [parity matrix](docs/reference/parity-matrix.md) and in issues [#896](https://github.com/rysweet/Simard/issues/896), [#897](https://github.com/rysweet/Simard/issues/897), and [#898](https://github.com/rysweet/Simard/issues/898).
+
+If you are a current Python amplihack user: see [Migrating from Python amplihack](#migrating-from-python-amplihack) below for the command map.
 
 ## Install
 
@@ -47,6 +53,22 @@ cargo build --release
 ```bash
 cargo install --git https://github.com/rysweet/Simard.git
 ```
+
+## Migrating from Python amplihack
+
+Simard's CLI is grouped by product mode rather than slash commands. Common amplihack workflows map as follows. Items marked **TBD** are not yet implemented natively in Simard — see the [parity audit (#898)](https://github.com/rysweet/Simard/issues/898) for status and to request prioritization.
+
+| Python amplihack                  | Simard equivalent                                     | Status            |
+| --------------------------------- | ----------------------------------------------------- | ----------------- |
+| `/dev <task>`                     | `simard engineer terminal <topology> <objective>`     | parity            |
+| `/improve <area>`                 | `simard improvement-curation run <base> <topo> <obj>` | parity            |
+| `/analyze <target>`               | `simard engineer read <topology>` + meeting review    | partial           |
+| `/investigation <topic>`          | `simard meeting repl <topic>`                         | partial           |
+| `/customize`                      | direct edits to `prompt_assets/` + recompile          | partial           |
+| skills auto-routing (117 skills)  | curated set of native Rust subcommands                | partial — see #898 |
+| `amplihack install`               | `simard install` or `npx github:rysweet/Simard install` | parity          |
+
+If your workflow is not covered above, please open an issue referencing #898 so it lands in the parity matrix.
 
 ## Quick Start
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,8 @@ owner: simard
 
 # Simard documentation
 
+Simard is the **Rust successor to [Python amplihack](https://github.com/rysweet/amplihack)**. The intent is for Simard to become a drop-in replacement: the same agentic-coding capabilities, delivered as a single static Rust binary. Today Simard implements the core engineer/meeting/goal-curation/improvement-curation/gym/OODA loops natively, but does not yet cover the full amplihack command and skill surface — see the parity issues [#896](https://github.com/rysweet/Simard/issues/896), [#897](https://github.com/rysweet/Simard/issues/897), and [#898](https://github.com/rysweet/Simard/issues/898).
+
 `simard` is the canonical operator-facing CLI.
 
 The shipped command tree covers `engineer`, `meeting`, `goal-curation`, `improvement-curation`, `gym`, `review`, and `bootstrap` from one binary, including the read-only `engineer read` audit companion and the bounded `engineer terminal*` session surfaces. The legacy `simard_operator_probe` and `simard-gym` binaries remain available as compatibility surfaces while operators migrate, but the primary product surface is now `simard ...`.


### PR DESCRIPTION
Resolves #896.

## Why

Operator decision: Simard (amplihack-rs) is the intended **Rust successor / drop-in replacement** for Python amplihack. The README previously said only 'part of the amplihack ecosystem,' which understates the relationship and leaves users coming from amplihack without guidance.

## What

- **README.md**: Replace the 'ecosystem' framing with an explicit successor framing under `### Relationship to Python amplihack`. State honestly that drop-in replacement is the goal but parity is not yet complete, and link the parity tracking issues.
- **README.md**: Add a new `## Migrating from Python amplihack` section with a CLI command-mapping table (parity / partial / TBD) covering `/dev`, `/improve`, `/analyze`, `/investigation`, `/customize`, the skill catalog, and `amplihack install`. TBD entries are honest — they point at #898.
- **docs/index.md**: Mirror the same opening framing so the GH Pages landing page leads with positioning instead of jumping straight into CLI details.

## What this PR is **not**

- Not a parity audit. That's #898.
- Not the GH Pages site rework. That's #897.
- Not a code change. README + docs/index.md only.

## Process note

Smart-orchestrator was invoked first per workflow mandate but failed at `default-workflow:step-07-write-tests` with a parser bug (`Condition error: Parse error: unexpected token: LBracket`). The 17 prior steps completed but never edited README.md (they only built planning docs in `.claude/`). Workflow bug filed at rysweet/amplihack#4398. Made the docs change directly per the adaptive-strategy fallback in the dev-orchestrator skill.

## Refs

- #896 (this issue)
- #897 (mkdocs site parity)
- #898 (parity audit)
- rysweet/amplihack#4398 (workflow parser bug)