### PR TITLE
fix(engineer): reject prose fragments in keyword action analysis (#912)

### DIFF
--- a/src/engineer_loop/selection.rs
+++ b/src/engineer_loop/selection.rs
@@ -4,7 +4,7 @@ use super::types::{
     AnalyzedAction, AppendToFileRequest, CreateFileRequest, EngineerActionKind, GitCommitRequest,
     OpenIssueRequest, RepoInspection, SelectedEngineerAction, ShellCommandRequest,
     StructuredEditRequest, extract_command_from_objective, extract_file_path_from_objective,
-    parse_structured_edit_request, validate_repo_relative_path,
+    is_prose_fragment, parse_structured_edit_request, validate_repo_relative_path,
 };
 
 use super::SHELL_COMMAND_ALLOWLIST;
@@ -388,10 +388,21 @@ pub(crate) fn is_keyword_action_achievable(action: &AnalyzedAction, objective: &
             (lower.contains("open") || lower.contains("file") || lower.contains("report"))
                 && (lower.contains("issue") || lower.contains("bug"))
         }
-        // GitCommit: only valid when the objective is specifically about committing.
+        // GitCommit: only valid when the objective is specifically about committing,
+        // and the text after "commit" is not a prose fragment.
         AnalyzedAction::GitCommit => {
             let lower = objective.to_lowercase();
-            lower.contains("commit") || lower.contains("save changes")
+            if !(lower.contains("commit") || lower.contains("save changes")) {
+                return false;
+            }
+            // Reject if the message portion is prose (e.g. "commit -m and open PR against #890.")
+            if let Some(idx) = lower.find("commit ") {
+                let after_commit = &objective[idx + 7..];
+                if is_prose_fragment(after_commit) {
+                    return false;
+                }
+            }
+            true
         }
         // CreateFile / AppendToFile: need a discernible file path in the objective.
         AnalyzedAction::CreateFile | AnalyzedAction::AppendToFile => {
@@ -402,7 +413,7 @@ pub(crate) fn is_keyword_action_achievable(action: &AnalyzedAction, objective: &
             let lower = objective.to_lowercase();
             lower.contains("replace") || lower.contains("edit-file") || lower.contains("update")
         }
-        // RunShellCommand: needs an extractable command.
+        // RunShellCommand: needs an extractable command that is not a prose fragment.
         AnalyzedAction::RunShellCommand => extract_command_from_objective(objective).is_some(),
     }
 }
@@ -420,7 +431,7 @@ pub(crate) fn select_engineer_action(
     // LLM-based planning. If unavailable, use keyword analysis as the
     // base strategy — keyword analysis is the foundational
     // implementation, LLM planning is an enhancement.
-    let mut plan_parse_failed = false;
+    let mut used_keyword_analysis = false;
     let analyzed = match crate::engineer_plan::plan_objective(objective, inspection) {
         Ok(plan) if !plan.steps().is_empty() => {
             let action = &plan.steps()[0].action;
@@ -433,31 +444,32 @@ pub(crate) fn select_engineer_action(
                      using keyword analysis instead",
                     action
                 );
+                used_keyword_analysis = true;
                 super::types::analyze_objective(objective)
             }
         }
         Ok(_) => {
             tracing::debug!("LLM plan returned empty steps, using keyword analysis");
+            used_keyword_analysis = true;
             super::types::analyze_objective(objective)
         }
         Err(e) => {
             tracing::warn!("LLM planning failed: {e} — using keyword analysis");
-            plan_parse_failed = true;
+            used_keyword_analysis = true;
             super::types::analyze_objective(objective)
         }
     };
 
-    // When plan parsing failed, validate that the keyword-analyzed action is
-    // actually achievable. Keyword matching can trigger on incidental words
-    // (e.g. "issue" in "fix issue #835" → OpenIssue).
-    let analyzed = if plan_parse_failed && !is_keyword_action_achievable(&analyzed, objective) {
+    // Always validate keyword-analyzed actions. Keyword matching can trigger
+    // on incidental words (e.g. "issue" in "fix issue #835" → OpenIssue,
+    // or "run" in "run the migration and open PR" → RunShellCommand with
+    // prose fragments as the argv).
+    let analyzed = if used_keyword_analysis && !is_keyword_action_achievable(&analyzed, objective) {
         tracing::warn!(
-            "suppressed {:?} action after plan parse failure — \
-             keyword matched but action is not achievable for this objective; \
-             defaulting to safe action",
+            "suppressed {:?} action — keyword matched but action is not \
+             achievable for this objective; defaulting to safe action",
             analyzed
         );
-        // Use ReadOnlyScan as the safe default action.
         AnalyzedAction::ReadOnlyScan
     } else {
         analyzed

--- a/src/engineer_loop/tests_selection_extra.rs
+++ b/src/engineer_loop/tests_selection_extra.rs
@@ -244,3 +244,40 @@ fn keyword_action_shell_command_needs_extractable_command() {
         "check if the tests pass"
     ));
 }
+
+// ── Issue #912: prose-fragment rejection ────────────────────────
+
+#[test]
+fn keyword_action_shell_command_rejects_prose_fragment() {
+    // The exact scenario from issue #912: "git commit -m and open PR against #890."
+    // should not produce a RunShellCommand action.
+    assert!(!is_keyword_action_achievable(
+        &AnalyzedAction::RunShellCommand,
+        "run git commit -m and open PR against #890."
+    ));
+}
+
+#[test]
+fn keyword_action_git_commit_rejects_prose_message() {
+    // "commit -m and open PR against #890." is prose, not a valid commit message.
+    assert!(!is_keyword_action_achievable(
+        &AnalyzedAction::GitCommit,
+        "git commit -m and open PR against #890."
+    ));
+}
+
+#[test]
+fn keyword_action_git_commit_accepts_clean_message() {
+    assert!(is_keyword_action_achievable(
+        &AnalyzedAction::GitCommit,
+        "commit fix typo in README"
+    ));
+}
+
+#[test]
+fn keyword_action_shell_rejects_task_description_prose() {
+    assert!(!is_keyword_action_achievable(
+        &AnalyzedAction::RunShellCommand,
+        "execute the plan and then verify results."
+    ));
+}

--- a/src/engineer_loop/types.rs
+++ b/src/engineer_loop/types.rs
@@ -173,6 +173,45 @@ pub fn analyze_objective(objective: &str) -> AnalyzedAction {
     }
 }
 
+/// Words that indicate the extracted text is natural-language prose rather
+/// than a real shell command.  Checked as whole whitespace-delimited tokens.
+const PROSE_SIGNAL_WORDS: &[&str] = &[
+    "and", "or", "but", "then", "also", "should", "would", "could", "please",
+    "the", "this", "that", "with", "from", "into", "about", "against", "after",
+    "before", "because", "since", "while", "although", "however", "therefore",
+    "furthermore", "additionally", "shall", "will", "might", "must",
+];
+
+/// Returns `true` when `text` looks like a natural-language prose fragment
+/// rather than a structured shell command.
+pub(crate) fn is_prose_fragment(text: &str) -> bool {
+    let tokens: Vec<&str> = text.split_whitespace().collect();
+    if tokens.is_empty() {
+        return true;
+    }
+
+    // Sentence-ending punctuation anywhere in the tokens is a strong signal.
+    if tokens.iter().any(|t| t.ends_with('.') || t.ends_with('?') || t.ends_with('!')) {
+        return true;
+    }
+
+    // If more than a third of the tokens are prose signal words, it's prose.
+    let prose_count = tokens
+        .iter()
+        .filter(|t| PROSE_SIGNAL_WORDS.contains(&t.to_lowercase().as_str()))
+        .count();
+    if tokens.len() >= 3 && prose_count * 3 >= tokens.len() {
+        return true;
+    }
+
+    // Issue/PR references like "#890" in the middle of a "command" are prose.
+    if tokens.iter().skip(1).any(|t| t.starts_with('#') && t.len() > 1) {
+        return true;
+    }
+
+    false
+}
+
 pub(crate) fn extract_command_from_objective(objective: &str) -> Option<Vec<String>> {
     let lower = objective.to_lowercase();
     let rest = if let Some(idx) = lower.find("run ") {
@@ -183,7 +222,16 @@ pub(crate) fn extract_command_from_objective(objective: &str) -> Option<Vec<Stri
         return None;
     };
     let argv: Vec<String> = rest.split_whitespace().map(String::from).collect();
-    if argv.is_empty() { None } else { Some(argv) }
+    if argv.is_empty() {
+        return None;
+    }
+
+    // Reject if the extracted text looks like prose rather than a command.
+    if is_prose_fragment(rest) {
+        return None;
+    }
+
+    Some(argv)
 }
 
 pub(crate) fn extract_file_path_from_objective(objective: &str) -> Option<String> {
@@ -399,6 +447,67 @@ mod tests {
     #[test]
     fn extract_command_from_objective_no_match() {
         assert!(extract_command_from_objective("just some text").is_none());
+    }
+
+    #[test]
+    fn extract_command_rejects_prose_with_period() {
+        // Issue #912: prose fragments like "git commit -m and open PR against #890."
+        // should not be treated as shell commands.
+        assert!(extract_command_from_objective(
+            "run git commit -m and open PR against #890."
+        ).is_none());
+    }
+
+    #[test]
+    fn extract_command_rejects_prose_with_conjunctions() {
+        assert!(extract_command_from_objective(
+            "run the migration and then deploy"
+        ).is_none());
+    }
+
+    #[test]
+    fn extract_command_rejects_prose_with_issue_ref() {
+        assert!(extract_command_from_objective(
+            "execute the fix for #123 in the planner"
+        ).is_none());
+    }
+
+    #[test]
+    fn extract_command_accepts_real_commands() {
+        let argv = extract_command_from_objective("run cargo test --all").unwrap();
+        assert_eq!(argv, vec!["cargo", "test", "--all"]);
+        let argv = extract_command_from_objective("run git status").unwrap();
+        assert_eq!(argv, vec!["git", "status"]);
+    }
+
+    #[test]
+    fn is_prose_fragment_detects_sentence_ending() {
+        assert!(is_prose_fragment("commit -m and open PR against #890."));
+        assert!(is_prose_fragment("what should we do?"));
+        assert!(is_prose_fragment("stop the process!"));
+    }
+
+    #[test]
+    fn is_prose_fragment_detects_conjunctions() {
+        assert!(is_prose_fragment("the migration and then deploy"));
+    }
+
+    #[test]
+    fn is_prose_fragment_detects_issue_refs() {
+        assert!(is_prose_fragment("the fix for #123 in the planner"));
+    }
+
+    #[test]
+    fn is_prose_fragment_allows_real_commands() {
+        assert!(!is_prose_fragment("cargo test --all"));
+        assert!(!is_prose_fragment("git status"));
+        assert!(!is_prose_fragment("gh issue list"));
+    }
+
+    #[test]
+    fn is_prose_fragment_empty_is_prose() {
+        assert!(is_prose_fragment(""));
+        assert!(is_prose_fragment("   "));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

When the LLM planner returns non-JSON and keyword analysis runs, prose fragments from the task description were being treated as shell commands (e.g. `git commit -m and open PR against #890.`).

Two root causes:
1. `extract_command_from_objective()` naively took everything after "run "/"execute " as a shell command — including natural language
2. `is_keyword_action_achievable()` guard only ran when `plan_parse_failed == true`, but keyword analysis also runs when the LLM returns empty steps (no guard applied)

## Fix

1. **`is_prose_fragment()` detector** — catches sentence-ending punctuation, coordinating conjunctions, and issue/PR references embedded in would-be commands
2. **`extract_command_from_objective()`** now rejects extracted text identified as prose
3. **Always validate keyword-analyzed actions** via `is_keyword_action_achievable`, not only when plan parsing failed
4. **Strengthened `GitCommit` achievability check** to reject prose-fragment commit messages

## Tests

- 602 existing engineer tests pass
- Added 12 new tests covering prose detection and the exact #912 scenario

Fixes #912