### PR TITLE
feat(dashboard): add /api/current-work endpoint for real-time OODA state

### DIFF
--- a/src/ooda_loop/types.rs
+++ b/src/ooda_loop/types.rs
@@ -11,13 +11,14 @@ use crate::memory_cognitive::CognitiveStatistics;
 use crate::memory_consolidation::PreparedContext;
 use crate::self_improve::ImprovementCycle;
 
-/// The four phases of a single OODA cycle.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+/// The four phases of a single OODA cycle, plus Sleep between cycles.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Serialize)]
 pub enum OodaPhase {
     Observe,
     Orient,
     Decide,
     Act,
+    Sleep,
 }
 
 impl Display for OodaPhase {
@@ -27,6 +28,7 @@ impl Display for OodaPhase {
             Self::Orient => f.write_str("orient"),
             Self::Decide => f.write_str("decide"),
             Self::Act => f.write_str("act"),
+            Self::Sleep => f.write_str("sleep"),
         }
     }
 }
@@ -43,6 +45,12 @@ pub struct OodaState {
     /// Populated each cycle so the Act phase can use recalled facts, triggered
     /// prospectives, and relevant procedures when advancing goals.
     pub prepared_context: Option<PreparedContext>,
+    /// Unix epoch (seconds) when the current cycle started.
+    pub cycle_start_epoch: u64,
+    /// Human-readable summary from the last completed cycle.
+    pub last_cycle_summary: Option<String>,
+    /// Duration in seconds of the last completed cycle.
+    pub last_cycle_duration_secs: Option<u64>,
 }
 
 impl OodaState {
@@ -54,6 +62,9 @@ impl OodaState {
             last_observation: None,
             review_improvements: Vec::new(),
             prepared_context: None,
+            cycle_start_epoch: 0,
+            last_cycle_summary: None,
+            last_cycle_duration_secs: None,
         }
     }
 }
@@ -217,6 +228,7 @@ mod tests {
         assert_eq!(OodaPhase::Orient.to_string(), "orient");
         assert_eq!(OodaPhase::Decide.to_string(), "decide");
         assert_eq!(OodaPhase::Act.to_string(), "act");
+        assert_eq!(OodaPhase::Sleep.to_string(), "sleep");
     }
 
     #[test]
@@ -243,6 +255,9 @@ mod tests {
         assert!(state.review_improvements.is_empty());
         assert!(state.active_goals.active.is_empty());
         assert!(state.prepared_context.is_none());
+        assert_eq!(state.cycle_start_epoch, 0);
+        assert!(state.last_cycle_summary.is_none());
+        assert!(state.last_cycle_duration_secs.is_none());
     }
 
     #[test]

--- a/src/operator_commands_dashboard/routes.rs
+++ b/src/operator_commands_dashboard/routes.rs
@@ -44,6 +44,7 @@ pub fn build_router() -> Router {
         .route("/api/traces", get(traces))
         .route("/api/activity", get(activity))
         .route("/api/workboard", get(workboard))
+        .route("/api/current-work", get(current_work))
         .route("/ws/chat", get(ws_chat_handler))
         .route("/api/login", post(login))
         .route("/login", get(login_page))
@@ -864,6 +865,167 @@ async fn workboard() -> Json<Value> {
         },
         "timestamp": chrono::Utc::now().to_rfc3339(),
     }))
+}
+
+/// Real-time snapshot of what Simard is doing right now.
+///
+/// Composes data from `daemon_health.json` (cycle/phase), `goal_records.json`
+/// (active goals), and the agent registry (spawned engineers).
+async fn current_work() -> Json<Value> {
+    let health_path = dirs::data_local_dir()
+        .unwrap_or_else(|| std::path::PathBuf::from("/var/tmp"))
+        .join("simard")
+        .join("daemon_health.json");
+
+    let daemon_health: Option<Value> = std::fs::read_to_string(&health_path)
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok());
+
+    let cycle_number = daemon_health
+        .as_ref()
+        .and_then(|h| h.get("cycle_number"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+
+    let cycle_phase = daemon_health
+        .as_ref()
+        .and_then(|h| h.get("cycle_phase"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown")
+        .to_string();
+
+    let cycle_phase_display = {
+        let mut chars = cycle_phase.chars();
+        match chars.next() {
+            Some(c) => format!("{}{}", c.to_uppercase(), chars.as_str()),
+            None => "Unknown".to_string(),
+        }
+    };
+
+    let cycle_start_epoch = daemon_health
+        .as_ref()
+        .and_then(|h| h.get("cycle_start_epoch"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+
+    let now_epoch = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+
+    let uptime_seconds = if cycle_start_epoch > 0 {
+        now_epoch.saturating_sub(cycle_start_epoch)
+    } else {
+        0
+    };
+
+    let interval_secs = daemon_health
+        .as_ref()
+        .and_then(|h| h.get("interval_secs"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(300);
+
+    let last_cycle_summary = daemon_health
+        .as_ref()
+        .and_then(|h| h.get("last_cycle_summary"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    let cycle_duration_secs = daemon_health
+        .as_ref()
+        .and_then(|h| h.get("cycle_duration_secs"))
+        .and_then(|v| v.as_u64());
+
+    let next_cycle_eta_seconds = if cycle_phase == "sleep" {
+        if let Some(dur) = cycle_duration_secs {
+            let next_start = cycle_start_epoch + dur + interval_secs;
+            next_start.saturating_sub(now_epoch)
+        } else {
+            interval_secs
+        }
+    } else {
+        0
+    };
+
+    // Active goals from goal_records.json
+    let state_root = resolve_state_root();
+    let goal_path = state_root.join("goal_records.json");
+    let active_goals: Vec<Value> = std::fs::read_to_string(&goal_path)
+        .ok()
+        .and_then(|content| serde_json::from_str::<GoalBoard>(&content).ok())
+        .map(|board| {
+            board
+                .active
+                .iter()
+                .map(|g| {
+                    let (status_str, blocker) = match &g.status {
+                        crate::goal_curation::GoalProgress::NotStarted => {
+                            ("not_started".to_string(), None)
+                        }
+                        crate::goal_curation::GoalProgress::InProgress { percent } => {
+                            (format!("in_progress({}%)", percent), None)
+                        }
+                        crate::goal_curation::GoalProgress::Blocked(reason) => {
+                            ("blocked".to_string(), Some(reason.clone()))
+                        }
+                        crate::goal_curation::GoalProgress::Completed => {
+                            ("completed".to_string(), None)
+                        }
+                    };
+                    let mut goal_json = json!({
+                        "name": g.id,
+                        "description": g.description,
+                        "status": status_str,
+                        "priority": g.priority,
+                    });
+                    if let Some(b) = blocker {
+                        goal_json["blocker"] = json!(b);
+                    }
+                    if let Some(ref assignee) = g.assigned_to {
+                        goal_json["assigned_to"] = json!(assignee);
+                    }
+                    goal_json
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    // Spawned engineers from agent registry
+    let reg = FileBackedAgentRegistry::new(&state_root);
+    let spawned_engineers: Vec<Value> = reg
+        .list()
+        .unwrap_or_default()
+        .into_iter()
+        .map(|entry| {
+            let alive = is_pid_alive(entry.pid);
+            json!({
+                "id": entry.id,
+                "pid": entry.pid,
+                "role": entry.role,
+                "host": entry.host,
+                "state": format!("{:?}", entry.state),
+                "alive": alive,
+                "start_time": entry.start_time.to_rfc3339(),
+                "last_heartbeat": entry.last_heartbeat.to_rfc3339(),
+            })
+        })
+        .collect();
+
+    Json(json!({
+        "cycle_number": cycle_number,
+        "cycle_phase": cycle_phase_display,
+        "uptime_seconds": uptime_seconds,
+        "active_goals": active_goals,
+        "spawned_engineers": spawned_engineers,
+        "last_cycle_summary": last_cycle_summary,
+        "next_cycle_eta_seconds": next_cycle_eta_seconds,
+        "timestamp": chrono::Utc::now().to_rfc3339(),
+    }))
+}
+
+fn is_pid_alive(pid: u32) -> bool {
+    std::path::Path::new(&format!("/proc/{pid}")).exists()
 }
 
 /// Run a `gh` CLI command and parse JSON output, returning a `Value`.

--- a/src/operator_commands_ooda/daemon.rs
+++ b/src/operator_commands_ooda/daemon.rs
@@ -9,7 +9,7 @@ use crate::goal_curation::load_goal_board;
 use crate::identity::OperatingMode;
 use crate::memory_ipc;
 use crate::ooda_loop::{
-    OodaBridges, OodaConfig, OodaState, run_ooda_cycle, summarize_cycle_report,
+    OodaBridges, OodaConfig, OodaPhase, OodaState, run_ooda_cycle, summarize_cycle_report,
 };
 use crate::session_builder::SessionBuilder;
 
@@ -330,6 +330,11 @@ pub fn run_ooda_daemon(
         // -------------------------------------------------------------------
 
         let cycle_start = Instant::now();
+        let cycle_start_epoch = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        state.cycle_start_epoch = cycle_start_epoch;
 
         // Write heartbeat at cycle START so the dashboard never sees "stale"
         // during a long-running cycle.
@@ -342,6 +347,9 @@ pub fn run_ooda_daemon(
                 "timestamp": chrono::Utc::now().to_rfc3339(),
                 "cycle_number": cycles_run + 1,
                 "status": "running",
+                "cycle_phase": state.current_phase.to_string(),
+                "cycle_start_epoch": cycle_start_epoch,
+                "interval_secs": interval_secs,
                 "actions_taken": format!("Starting cycle #{}", cycles_run + 1),
             });
             let _ = std::fs::write(
@@ -354,6 +362,9 @@ pub fn run_ooda_daemon(
             Ok(report) => {
                 let cycle_elapsed = cycle_start.elapsed();
                 let summary = summarize_cycle_report(&report);
+                state.last_cycle_summary = Some(summary.clone());
+                state.last_cycle_duration_secs = Some(cycle_elapsed.as_secs());
+                state.current_phase = OodaPhase::Sleep;
                 daemon_log(&state_root, &format!("[simard] {summary}"));
                 // Persist the cycle report to filesystem for auditability.
                 persist_cycle_report(&state_root, &report);
@@ -369,7 +380,12 @@ pub fn run_ooda_daemon(
                         "timestamp": chrono::Utc::now().to_rfc3339(),
                         "cycle_number": cycles_run + 1,
                         "status": "healthy",
+                        "cycle_phase": "sleep",
+                        "cycle_start_epoch": cycle_start_epoch,
+                        "cycle_duration_secs": cycle_elapsed.as_secs(),
+                        "interval_secs": interval_secs,
                         "actions_taken": summary.clone(),
+                        "last_cycle_summary": summary,
                     });
                     let health_path = health_dir.join("daemon_health.json");
                     if let Err(e) = std::fs::write(


### PR DESCRIPTION
## Summary

Adds `/api/current-work` — a dashboard endpoint returning a real-time snapshot of what Simard is actively doing.

## Response shape

```json
{
  "cycle_number": 5,
  "cycle_phase": "Act",
  "uptime_seconds": 3200,
  "active_goals": [{"name": "add-gym-scenarios", "status": "in_progress(60%)", "priority": 1}],
  "spawned_engineers": [{"id": "eng-1", "pid": 1876334, "role": "Engineer", "alive": false}],
  "last_cycle_summary": "OODA cycle #5: 2 priorities, 3 actions (3/3 succeeded)...",
  "next_cycle_eta_seconds": 180
}
```

## Changes

- **`src/ooda_loop/types.rs`**: Add `Sleep` variant to `OodaPhase`, `Serialize` derive, new tracking fields on `OodaState`
- **`src/operator_commands_ooda/daemon.rs`**: Enrich `daemon_health.json` with phase/epoch/interval/duration/summary; set `Sleep` phase between cycles
- **`src/operator_commands_dashboard/routes.rs`**: New `/api/current-work` route composing from daemon_health.json + goal_records.json + agent_registry.json

## Verification

- `cargo check` passes
- All `ooda_loop::types::tests` pass (13/13)