### PR TITLE
fix(dashboard): show cycle reports in Traces tab, scan cycle_reports in logs

### DIFF
--- a/src/operator_commands_dashboard/routes.rs
+++ b/src/operator_commands_dashboard/routes.rs
@@ -2365,7 +2365,7 @@ const INDEX_HTML: &str = r#"<!DOCTYPE html>
         activeTab=tab.dataset.tab;
         clearTabTimers();
         if(tab.dataset.tab==='logs') {fetchLogs();tabRefreshTimers.logs=setInterval(fetchLogs,15000);}
-        if(tab.dataset.tab==='processes') {fetchProcesses();tabRefreshTimers.proc=setInterval(fetchProcesses,10000);}
+        if(tab.dataset.tab==='processes') {fetchProcessTree();tabRefreshTimers.proc=setInterval(fetchProcessTree,15000);}
         if(tab.dataset.tab==='memory') fetchMemory();
 
         if(tab.dataset.tab==='goals') fetchGoals();
@@ -2432,7 +2432,19 @@ const INDEX_HTML: &str = r#"<!DOCTYPE html>
               <h3>${esc(t.name)} <span class="badge">${fmtB(t.size_bytes)}</span></h3>
               <div class="log-box" style="max-height:200px">${esc((t.preview_lines||[]).join('\n'))||'(empty)'}</div>
             </div>`).join('');
-        }else{tEl.innerHTML='<span style="color:#8b949e">No OODA transcripts found in state root. Run the OODA daemon to generate transcripts.</span>';}
+        }else{tEl.innerHTML='<span style="color:#8b949e">No OODA transcripts found in state root.</span>';}
+        // Render cycle reports
+        const crEl=document.getElementById('cycle-reports');
+        if(d.cycle_reports?.length){
+          crEl.innerHTML=d.cycle_reports.map(c=>{
+            const num=c.cycle_number;
+            const text=c.summary||JSON.stringify(c.report||{});
+            return`<div class="transcript-item">
+              <h3>Cycle #${num}</h3>
+              <div class="log-box" style="max-height:100px">${esc(text)}</div>
+            </div>`;
+          }).join('');
+        }else{crEl.innerHTML='<span style="color:#8b949e">No cycle reports found. Run the OODA daemon to generate cycle data.</span>';}
         const ttEl=document.getElementById('terminal-transcripts');
         if(d.terminal_transcripts?.length){
           ttEl.innerHTML=d.terminal_transcripts.map(t=>`


### PR DESCRIPTION
## Summary

Fixes two dashboard display bugs in the operator dashboard.

### Bug 1: Traces tab shows setup instructions instead of useful content

**Before:** When OTEL isn't configured, the Traces tab prominently displayed "OTEL not configured — set OTEL_EXPORTER_OTLP_ENDPOINT..." making the tab appear broken.

**After:**
- Small info banner noting OTEL tracing is optional
- Main content: last 20 OODA cycle reports displayed as a timeline (from `~/.simard/state/cycle_reports/`)
- Collected spans shown below the timeline
- OTEL setup instructions moved to a collapsible "Advanced: External OTEL" section at the bottom

### Bug 2: "No OODA transcripts found" when data exists in wrong path

**Before:** The `/api/logs` endpoint only scanned `ooda_transcripts/` which may not exist, showing "No OODA transcripts found".

**After:**
- Logs endpoint also scans `cycle_reports/` via `read_recent_cycle_reports()` (returns last 20)
- Returns structured `cycle_reports` array in the API response
- Frontend renders these as "OODA Cycle Reports" section in the Logs tab
- Original OODA Transcripts section preserved for backward compatibility

### Validation
- `cargo check` passes clean