### PR TITLE
feat(dashboard): add interactive memory graph visualization

### DIFF
--- a/src/cognitive_memory/mod.rs
+++ b/src/cognitive_memory/mod.rs
@@ -618,7 +618,7 @@ impl NativeCognitiveMemory {
         })
     }
 
-    fn query(&self, cypher: &str) -> SimardResult<Vec<Vec<lbug::Value>>> {
+    pub(crate) fn query(&self, cypher: &str) -> SimardResult<Vec<Vec<lbug::Value>>> {
         let conn = self.conn()?;
         let result = conn
             .query(cypher)
@@ -667,21 +667,21 @@ impl NativeCognitiveMemory {
     }
 }
 
-fn as_str(val: &lbug::Value) -> Option<&str> {
+pub(crate) fn as_str(val: &lbug::Value) -> Option<&str> {
     match val {
         lbug::Value::String(s) => Some(s.as_str()),
         _ => None,
     }
 }
 
-fn as_i64(val: &lbug::Value) -> Option<i64> {
+pub(crate) fn as_i64(val: &lbug::Value) -> Option<i64> {
     match val {
         lbug::Value::Int64(n) => Some(*n),
         _ => None,
     }
 }
 
-fn as_f64(val: &lbug::Value) -> Option<f64> {
+pub(crate) fn as_f64(val: &lbug::Value) -> Option<f64> {
     match val {
         lbug::Value::Double(d) => Some(*d),
         lbug::Value::Int64(n) => Some(*n as f64),

--- a/src/operator_commands_dashboard/routes.rs
+++ b/src/operator_commands_dashboard/routes.rs
@@ -9,7 +9,7 @@ use serde_json::{Value, json};
 use super::auth::{require_auth, try_login};
 use crate::agent_registry::{AgentRegistry, FileBackedAgentRegistry};
 use crate::build_lock::BuildLock;
-use crate::cognitive_memory::{CognitiveMemoryOps, NativeCognitiveMemory};
+use crate::cognitive_memory::{as_f64, as_i64, as_str, CognitiveMemoryOps, NativeCognitiveMemory};
 use crate::error::{SimardError, SimardResult};
 use crate::goal_curation::GoalBoard;
 use crate::goals::GoalRecord;
@@ -41,6 +41,7 @@ pub fn build_router() -> Router {
         .route("/api/build-lock/release", post(build_lock_force_release))
         .route("/api/memory", get(memory_metrics))
         .route("/api/memory/search", post(memory_search))
+        .route("/api/memory/graph", get(memory_graph))
         .route("/api/traces", get(traces))
         .route("/api/activity", get(activity))
         .route("/api/workboard", get(workboard))
@@ -460,6 +461,162 @@ async fn memory_search(Json(body): Json<Value>) -> Json<Value> {
         "result_count": results.len(),
         "results": results,
         "timestamp": chrono::Utc::now().to_rfc3339(),
+    }))
+}
+
+async fn memory_graph() -> Json<Value> {
+    let state_root = resolve_state_root();
+    let mem = match NativeCognitiveMemory::open_read_only(&state_root) {
+        Ok(m) => m,
+        Err(e) => {
+            return Json(json!({
+                "nodes": [],
+                "edges": [],
+                "stats": {},
+                "error": format!("Cannot open cognitive memory: {e}"),
+            }));
+        }
+    };
+
+    let stats = mem.get_statistics().unwrap_or_default();
+    let mut nodes: Vec<Value> = Vec::new();
+    let mut edges: Vec<Value> = Vec::new();
+
+    let query_rows = |cypher: &str| -> Vec<Vec<lbug::Value>> {
+        mem.query(cypher).unwrap_or_default()
+    };
+
+    for row in query_rows(
+        "MATCH (w:WorkingMemory) RETURN w.id, w.slot_type, w.content, w.task_id, w.relevance LIMIT 100",
+    ) {
+        if let Some(id) = row.first().and_then(as_str) {
+            let content = row.get(2).and_then(as_str).unwrap_or("");
+            let label = if content.len() > 60 { format!("{}…", &content[..60]) } else { content.to_string() };
+            nodes.push(json!({
+                "id": id, "type": "WorkingMemory", "label": label,
+                "content": content,
+                "task_id": row.get(3).and_then(as_str).unwrap_or(""),
+                "relevance": row.get(4).and_then(as_f64).unwrap_or(0.0),
+            }));
+        }
+    }
+
+    for row in query_rows(
+        "MATCH (f:Fact) RETURN f.id, f.concept, f.content, f.confidence, f.source_id, f.tags LIMIT 100",
+    ) {
+        if let Some(id) = row.first().and_then(as_str) {
+            let concept = row.get(1).and_then(as_str).unwrap_or("");
+            let content = row.get(2).and_then(as_str).unwrap_or("");
+            let label = if concept.is_empty() {
+                if content.len() > 60 { format!("{}…", &content[..60]) } else { content.to_string() }
+            } else { concept.to_string() };
+            nodes.push(json!({
+                "id": id, "type": "SemanticFact", "label": label,
+                "content": content, "confidence": row.get(3).and_then(as_f64).unwrap_or(0.0),
+                "source_id": row.get(4).and_then(as_str).unwrap_or(""),
+            }));
+        }
+    }
+
+    for row in query_rows(
+        "MATCH (e:Episode) RETURN e.id, e.content, e.source_label, e.temporal_index LIMIT 100",
+    ) {
+        if let Some(id) = row.first().and_then(as_str) {
+            let content = row.get(1).and_then(as_str).unwrap_or("");
+            let label = if content.len() > 60 { format!("{}…", &content[..60]) } else { content.to_string() };
+            nodes.push(json!({
+                "id": id, "type": "EpisodicMemory", "label": label,
+                "content": content,
+                "temporal_index": row.get(3).and_then(as_i64).unwrap_or(0),
+            }));
+        }
+    }
+
+    for row in query_rows(
+        "MATCH (p:Procedure) RETURN p.id, p.name, p.steps, p.prerequisites, p.usage_count LIMIT 100",
+    ) {
+        if let Some(id) = row.first().and_then(as_str) {
+            nodes.push(json!({
+                "id": id, "type": "ProceduralMemory",
+                "label": row.get(1).and_then(as_str).unwrap_or(""),
+                "content": row.get(2).and_then(as_str).unwrap_or(""),
+                "usage_count": row.get(4).and_then(as_i64).unwrap_or(0),
+            }));
+        }
+    }
+
+    for row in query_rows(
+        "MATCH (p:Prospective) RETURN p.id, p.description, p.trigger_condition, p.action_on_trigger, p.status, p.priority LIMIT 100",
+    ) {
+        if let Some(id) = row.first().and_then(as_str) {
+            nodes.push(json!({
+                "id": id, "type": "ProspectiveMemory",
+                "label": row.get(1).and_then(as_str).unwrap_or(""),
+                "content": row.get(2).and_then(as_str).unwrap_or(""),
+                "status": row.get(4).and_then(as_str).unwrap_or("pending"),
+            }));
+        }
+    }
+
+    for row in query_rows("MATCH (s:Sensory) RETURN s.id, s.modality, s.raw_data LIMIT 100") {
+        if let Some(id) = row.first().and_then(as_str) {
+            let modality = row.get(1).and_then(as_str).unwrap_or("");
+            let raw = row.get(2).and_then(as_str).unwrap_or("");
+            let label = if raw.len() > 40 {
+                format!("[{modality}] {}…", &raw[..40])
+            } else {
+                format!("[{modality}] {raw}")
+            };
+            nodes.push(json!({
+                "id": id, "type": "SensoryBuffer", "label": label,
+                "content": raw, "modality": modality,
+            }));
+        }
+    }
+
+    // Infer edges: link WorkingMemory to nodes sharing the same task_id via source_id
+    let working_nodes: Vec<(String, String)> = nodes.iter()
+        .filter(|n| n["type"] == "WorkingMemory")
+        .filter_map(|n| {
+            let id = n["id"].as_str()?.to_string();
+            let tid = n["task_id"].as_str()?.to_string();
+            if tid.is_empty() { None } else { Some((id, tid)) }
+        })
+        .collect();
+    for wn in &working_nodes {
+        for other in &nodes {
+            if other["type"] == "WorkingMemory" { continue; }
+            if let Some(oid) = other["id"].as_str() {
+                if let Some(src) = other["source_id"].as_str() {
+                    if !src.is_empty() && src == wn.1 {
+                        edges.push(json!({"source": wn.0, "target": oid, "type": "REFERENCES"}));
+                    }
+                }
+            }
+        }
+    }
+
+    // Link episodes with sequential temporal indices
+    let mut episode_ids: Vec<(String, i64)> = nodes.iter()
+        .filter(|n| n["type"] == "EpisodicMemory")
+        .filter_map(|n| Some((n["id"].as_str()?.to_string(), n["temporal_index"].as_i64().unwrap_or(0))))
+        .collect();
+    episode_ids.sort_by_key(|e| e.1);
+    for pair in episode_ids.windows(2) {
+        edges.push(json!({"source": pair[0].0, "target": pair[1].0, "type": "FOLLOWS"}));
+    }
+
+    Json(json!({
+        "nodes": nodes,
+        "edges": edges,
+        "stats": {
+            "working": stats.working_count,
+            "semantic": stats.semantic_count,
+            "episodic": stats.episodic_count,
+            "procedural": stats.procedural_count,
+            "prospective": stats.prospective_count,
+            "sensory": stats.sensory_count,
+        },
     }))
 }
 
@@ -2282,17 +2439,49 @@ const INDEX_HTML: &str = r#"<!DOCTYPE html>
   </div>
 
   <div class="tab-content" id="tab-memory">
-    <div class="grid">
-      <div class="card"><h2>Memory Overview</h2><div id="mem-overview"><span class="loading">Loading…</span></div></div>
-      <div class="card"><h2>Memory Files</h2><div id="mem-files"><span class="loading">Loading…</span></div></div>
+    <div style="display:flex;align-items:center;gap:1rem;margin-bottom:1rem">
+      <button id="mem-view-graph" class="btn" style="opacity:1" onclick="setMemView('graph')">Graph View</button>
+      <button id="mem-view-search" class="btn" style="opacity:.5" onclick="setMemView('search')">Search View</button>
+      <span id="mem-graph-stats" style="color:#8b949e;font-size:.8rem;margin-left:auto"></span>
     </div>
-    <div class="card" style="margin-top:1rem">
-      <h2>Memory Search</h2>
-      <div style="display:flex;gap:.5rem;align-items:center;margin-bottom:1rem">
-        <input id="mem-search-input" placeholder="Search memories…" style="flex:1;padding:6px;background:#1a1a2e;border:1px solid #333;color:#e0e0e0;border-radius:4px">
-        <button class="btn" onclick="searchMemory()">Search</button>
+
+    <div id="mem-graph-panel">
+      <div class="card" style="margin-bottom:1rem;padding:.75rem">
+        <div style="display:flex;gap:1rem;flex-wrap:wrap;align-items:center;font-size:.8rem">
+          <label style="color:#f0883e"><input type="checkbox" class="mem-filter" data-type="WorkingMemory" checked> Working</label>
+          <label style="color:#58a6ff"><input type="checkbox" class="mem-filter" data-type="SemanticFact" checked> Semantic</label>
+          <label style="color:#3fb950"><input type="checkbox" class="mem-filter" data-type="EpisodicMemory" checked> Episodic</label>
+          <label style="color:#a371f7"><input type="checkbox" class="mem-filter" data-type="ProceduralMemory" checked> Procedural</label>
+          <label style="color:#d29922"><input type="checkbox" class="mem-filter" data-type="ProspectiveMemory" checked> Prospective</label>
+          <label style="color:#8b949e"><input type="checkbox" class="mem-filter" data-type="SensoryBuffer" checked> Sensory</label>
+          <button class="btn" onclick="fetchMemoryGraph()" style="margin-left:auto">Refresh</button>
+        </div>
       </div>
-      <div id="mem-search-results"></div>
+      <div style="display:flex;gap:1rem">
+        <div class="card" style="flex:1;padding:0;position:relative;min-height:500px">
+          <canvas id="mem-graph-canvas" style="width:100%;height:500px;display:block;cursor:grab"></canvas>
+          <div id="mem-graph-tooltip" style="display:none;position:absolute;background:#161b22;border:1px solid #30363d;border-radius:6px;padding:.5rem .75rem;font-size:.8rem;max-width:320px;pointer-events:none;z-index:10;word-break:break-word"></div>
+        </div>
+        <div id="mem-graph-detail" class="card" style="width:280px;display:none">
+          <h2 id="mg-detail-title">Node Details</h2>
+          <div id="mg-detail-body"></div>
+        </div>
+      </div>
+    </div>
+
+    <div id="mem-search-panel" style="display:none">
+      <div class="grid">
+        <div class="card"><h2>Memory Overview</h2><div id="mem-overview"><span class="loading">Loading…</span></div></div>
+        <div class="card"><h2>Memory Files</h2><div id="mem-files"><span class="loading">Loading…</span></div></div>
+      </div>
+      <div class="card" style="margin-top:1rem">
+        <h2>Memory Search</h2>
+        <div style="display:flex;gap:.5rem;align-items:center;margin-bottom:1rem">
+          <input id="mem-search-input" placeholder="Search memories…" style="flex:1;padding:6px;background:#1a1a2e;border:1px solid #333;color:#e0e0e0;border-radius:4px">
+          <button class="btn" onclick="searchMemory()">Search</button>
+        </div>
+        <div id="mem-search-results"></div>
+      </div>
     </div>
   </div>
 
@@ -2418,7 +2607,7 @@ const INDEX_HTML: &str = r#"<!DOCTYPE html>
         clearTabTimers();
         if(tab.dataset.tab==='logs') {fetchLogs();tabRefreshTimers.logs=setInterval(fetchLogs,15000);}
         if(tab.dataset.tab==='processes') {fetchProcessTree();tabRefreshTimers.proc=setInterval(fetchProcessTree,15000);}
-        if(tab.dataset.tab==='memory') fetchMemory();
+        if(tab.dataset.tab==='memory') {fetchMemoryGraph();}
 
         if(tab.dataset.tab==='goals') fetchGoals();
         if(tab.dataset.tab==='costs') fetchCosts();
@@ -2775,6 +2964,183 @@ const INDEX_HTML: &str = r#"<!DOCTYPE html>
     }
     document.getElementById('mem-search-input')?.addEventListener('keypress',e=>{if(e.key==='Enter')searchMemory();});
 
+    /* --- Memory Graph Visualization --- */
+    let mgNodes=[],mgEdges=[],mgFiltered=[],mgFilteredEdges=[];
+    let mgDrag=null,mgPinned=null;
+    let mgOffX=0,mgOffY=0,mgScale=1,mgPanX=0,mgPanY=0;
+    const mgColors={WorkingMemory:'#f0883e',SemanticFact:'#58a6ff',EpisodicMemory:'#3fb950',ProceduralMemory:'#a371f7',ProspectiveMemory:'#d29922',SensoryBuffer:'#8b949e'};
+
+    function setMemView(v){
+      document.getElementById('mem-graph-panel').style.display=v==='graph'?'block':'none';
+      document.getElementById('mem-search-panel').style.display=v==='search'?'block':'none';
+      document.getElementById('mem-view-graph').style.opacity=v==='graph'?'1':'.5';
+      document.getElementById('mem-view-search').style.opacity=v==='search'?'1':'.5';
+      if(v==='graph') fetchMemoryGraph();
+      if(v==='search') fetchMemory();
+    }
+
+    function mgApplyFilters(){
+      const checks={};
+      document.querySelectorAll('.mem-filter').forEach(cb=>{checks[cb.dataset.type]=cb.checked;});
+      mgFiltered=mgNodes.filter(n=>checks[n.type]!==false);
+      const ids=new Set(mgFiltered.map(n=>n.id));
+      mgFilteredEdges=mgEdges.filter(e=>ids.has(e.source)&&ids.has(e.target));
+      mgRender();
+    }
+    document.querySelectorAll('.mem-filter').forEach(cb=>cb.addEventListener('change',mgApplyFilters));
+
+    async function fetchMemoryGraph(){
+      try{
+        const r=await fetch('/api/memory/graph');const d=await r.json();
+        if(d.error){document.getElementById('mem-graph-stats').textContent='Error: '+d.error;return;}
+        const s=d.stats||{};
+        document.getElementById('mem-graph-stats').textContent=
+          'W:'+(s.working||0)+' S:'+(s.semantic||0)+' E:'+(s.episodic||0)+' P:'+(s.procedural||0)+' Pr:'+(s.prospective||0)+' Se:'+(s.sensory||0);
+        mgNodes=(d.nodes||[]);mgEdges=(d.edges||[]);
+        mgInitLayout();mgApplyFilters();mgSimulate();
+      }catch(e){document.getElementById('mem-graph-stats').textContent='Load failed';}
+    }
+
+    function mgInitLayout(){
+      const canvas=document.getElementById('mem-graph-canvas');
+      const w=canvas.clientWidth||800,h=canvas.clientHeight||500;
+      mgPanX=0;mgPanY=0;mgScale=1;
+      const n=mgNodes.length||1;
+      mgNodes.forEach((nd,i)=>{
+        const angle=(2*Math.PI*i)/n;
+        const radius=Math.min(w,h)*0.3;
+        nd.x=w/2+radius*Math.cos(angle);
+        nd.y=h/2+radius*Math.sin(angle);
+        nd.vx=0;nd.vy=0;nd.pinned=false;
+      });
+    }
+
+    function mgSimulate(){
+      const canvas=document.getElementById('mem-graph-canvas');
+      const dt=0.3,repulsion=800,springLen=100,springK=0.02,gravity=0.01,damping=0.85;
+      const cx=(canvas.clientWidth||800)/2,cy=(canvas.clientHeight||500)/2;
+      for(let iter=0;iter<120;iter++){
+        for(let i=0;i<mgFiltered.length;i++){
+          if(mgFiltered[i].pinned)continue;
+          let fx=0,fy=0;
+          for(let j=0;j<mgFiltered.length;j++){
+            if(i===j)continue;
+            let dx=mgFiltered[i].x-mgFiltered[j].x,dy=mgFiltered[i].y-mgFiltered[j].y;
+            let dist=Math.sqrt(dx*dx+dy*dy)||1;
+            let f=repulsion/(dist*dist);
+            fx+=f*dx/dist;fy+=f*dy/dist;
+          }
+          fx+=(cx-mgFiltered[i].x)*gravity;
+          fy+=(cy-mgFiltered[i].y)*gravity;
+          mgFiltered[i].vx=(mgFiltered[i].vx+fx*dt)*damping;
+          mgFiltered[i].vy=(mgFiltered[i].vy+fy*dt)*damping;
+          mgFiltered[i].x+=mgFiltered[i].vx*dt;
+          mgFiltered[i].y+=mgFiltered[i].vy*dt;
+        }
+        const nodeMap={};mgFiltered.forEach(n=>{nodeMap[n.id]=n;});
+        mgFilteredEdges.forEach(e=>{
+          const a=nodeMap[e.source],b=nodeMap[e.target];
+          if(!a||!b)return;
+          let dx=b.x-a.x,dy=b.y-a.y;
+          let dist=Math.sqrt(dx*dx+dy*dy)||1;
+          let f=(dist-springLen)*springK;
+          let fx2=f*dx/dist,fy2=f*dy/dist;
+          if(!a.pinned){a.vx+=fx2*dt;a.vy+=fy2*dt;}
+          if(!b.pinned){b.vx-=fx2*dt;b.vy-=fy2*dt;}
+        });
+      }
+      mgRender();
+    }
+
+    function mgRender(){
+      const canvas=document.getElementById('mem-graph-canvas');
+      if(!canvas)return;
+      canvas.width=canvas.clientWidth*(window.devicePixelRatio||1);
+      canvas.height=canvas.clientHeight*(window.devicePixelRatio||1);
+      const ctx=canvas.getContext('2d');
+      const dpr=window.devicePixelRatio||1;
+      ctx.scale(dpr,dpr);
+      ctx.clearRect(0,0,canvas.clientWidth,canvas.clientHeight);
+      ctx.save();ctx.translate(mgPanX,mgPanY);ctx.scale(mgScale,mgScale);
+      const nodeMap={};mgFiltered.forEach(n=>{nodeMap[n.id]=n;});
+      mgFilteredEdges.forEach(e=>{
+        const a=nodeMap[e.source],b=nodeMap[e.target];
+        if(!a||!b)return;
+        ctx.beginPath();ctx.moveTo(a.x,a.y);ctx.lineTo(b.x,b.y);
+        ctx.strokeStyle='#30363d';ctx.lineWidth=1;ctx.stroke();
+      });
+      const r=8;
+      mgFiltered.forEach(n=>{
+        ctx.beginPath();ctx.arc(n.x,n.y,n===mgPinned?r+3:r,0,Math.PI*2);
+        ctx.fillStyle=mgColors[n.type]||'#8b949e';
+        if(n===mgPinned){ctx.lineWidth=2;ctx.strokeStyle='#fff';ctx.stroke();}
+        ctx.fill();
+        const lbl=n.label||'';
+        if(lbl.length>0&&mgScale>0.5){
+          ctx.fillStyle='#c9d1d9';ctx.font='10px sans-serif';ctx.textAlign='center';
+          ctx.fillText(lbl.substring(0,30),n.x,n.y-r-4);
+        }
+      });
+      ctx.restore();
+    }
+
+    (function(){
+      const mgCanvas=document.getElementById('mem-graph-canvas');
+      if(!mgCanvas)return;
+      function mgHitTest(mx,my){
+        const x=(mx-mgPanX)/mgScale,y=(my-mgPanY)/mgScale;
+        for(const n of mgFiltered){if((n.x-x)**2+(n.y-y)**2<144)return n;}
+        return null;
+      }
+      mgCanvas.addEventListener('mousemove',function(e){
+        const rect=mgCanvas.getBoundingClientRect();
+        const mx=e.clientX-rect.left,my=e.clientY-rect.top;
+        if(mgDrag){mgDrag.x=(mx-mgOffX-mgPanX)/mgScale;mgDrag.y=(my-mgOffY-mgPanY)/mgScale;mgRender();return;}
+        const node=mgHitTest(mx,my);
+        const tip=document.getElementById('mem-graph-tooltip');
+        if(node){
+          mgCanvas.style.cursor='pointer';tip.style.display='block';
+          tip.style.left=Math.min(mx+12,mgCanvas.clientWidth-330)+'px';tip.style.top=(my+12)+'px';
+          tip.innerHTML='<strong style="color:'+(mgColors[node.type]||'#ccc')+'">'+esc(node.type)+'</strong><br>'+esc((node.content||'').substring(0,200));
+        }else{mgCanvas.style.cursor='grab';tip.style.display='none';}
+      });
+      mgCanvas.addEventListener('mousedown',function(e){
+        const rect=mgCanvas.getBoundingClientRect();const mx=e.clientX-rect.left,my=e.clientY-rect.top;
+        const node=mgHitTest(mx,my);
+        if(node){mgDrag=node;mgCanvas.style.cursor='grabbing';mgOffX=mx-node.x*mgScale-mgPanX;mgOffY=my-node.y*mgScale-mgPanY;}
+        else{
+          const startPX=mgPanX,startPY=mgPanY,sx=e.clientX,sy=e.clientY;
+          function onMove(ev){mgPanX=startPX+(ev.clientX-sx);mgPanY=startPY+(ev.clientY-sy);mgRender();}
+          function onUp(){window.removeEventListener('mousemove',onMove);window.removeEventListener('mouseup',onUp);}
+          window.addEventListener('mousemove',onMove);window.addEventListener('mouseup',onUp);
+        }
+      });
+      mgCanvas.addEventListener('mouseup',function(){mgDrag=null;mgCanvas.style.cursor='grab';});
+      mgCanvas.addEventListener('click',function(e){
+        const rect=mgCanvas.getBoundingClientRect();const node=mgHitTest(e.clientX-rect.left,e.clientY-rect.top);
+        if(node){
+          mgPinned=node;node.pinned=true;
+          document.getElementById('mem-graph-detail').style.display='block';
+          document.getElementById('mg-detail-title').textContent=node.type;
+          document.getElementById('mg-detail-body').innerHTML=
+            '<div class="stat"><span class="label">ID</span><span class="value" style="font-size:.75rem;word-break:break-all">'+esc(node.id)+'</span></div>'+
+            '<div class="stat"><span class="label">Label</span><span class="value">'+esc(node.label)+'</span></div>'+
+            '<div style="margin-top:.5rem;font-size:.8rem;color:#c9d1d9;white-space:pre-wrap;max-height:300px;overflow-y:auto">'+esc(node.content||'')+'</div>';
+          mgRender();
+        }else{
+          if(mgPinned){mgPinned.pinned=false;mgPinned=null;}
+          document.getElementById('mem-graph-detail').style.display='none';mgRender();
+        }
+      });
+      mgCanvas.addEventListener('wheel',function(e){
+        e.preventDefault();const rect=mgCanvas.getBoundingClientRect();
+        const mx=e.clientX-rect.left,my=e.clientY-rect.top;
+        const factor=e.deltaY<0?1.1:0.9;
+        mgPanX=mx-(mx-mgPanX)*factor;mgPanY=my-(my-mgPanY)*factor;
+        mgScale*=factor;mgRender();
+      },{passive:false});
+    })();
+
     /* --- Costs --- */
     function fmtLabel(k){
       const map={
@@ -2999,6 +3365,8 @@ mod tests {
         assert!(INDEX_HTML.contains("Whiteboard"));
         assert!(INDEX_HTML.contains("/api/issues"));
         assert!(INDEX_HTML.contains("fetchStatus"));
+        assert!(INDEX_HTML.contains("mem-graph-canvas"));
+        assert!(INDEX_HTML.contains("fetchMemoryGraph"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds an interactive force-directed graph visualization to the dashboard Memory tab, letting operators visually explore cognitive memory nodes and their relationships.

### Backend
- New `/api/memory/graph` endpoint queries all 6 node types (WorkingMemory, SemanticFact, EpisodicMemory, ProceduralMemory, ProspectiveMemory, SensoryBuffer) from LadybugDB
- Infers edges: WorkingMemory→Fact via task_id/source_id matching, episodic links by temporal sequence, cross-node links by shared source_id
- Returns JSON with typed nodes, edges, and per-type count stats

### Frontend
- Canvas-based force simulation (repulsion + spring + gravity) — no external dependencies
- Color-coded nodes by memory type with filter checkboxes to toggle visibility
- Interactions: drag to reposition, click to pin & inspect details, hover tooltip, scroll zoom, click-drag pan
- Dual-view toggle: Graph View (new, default) and Search View (existing)

### Changes
- `src/cognitive_memory/mod.rs`: make `query()`, `as_str()`, `as_i64()`, `as_f64()` `pub(crate)`
- `src/operator_commands_dashboard/routes.rs`: add endpoint, route, HTML, JS, and test assertions

### Testing
- `cargo check` passes
- All 40 tests pass (19 dashboard + 21 cognitive_memory)
- New assertions verify `mem-graph-canvas` and `fetchMemoryGraph` are present in INDEX_HTML