### PR TITLE
feat(ooda): wire OODA daemon to spawn engineer agents (#929)

### DIFF
--- a/.claude/context/PROJECT.md
+++ b/.claude/context/PROJECT.md
@@ -10,7 +10,7 @@ Replace the sections below with information about your project.
 
 ---
 
-## Project: main
+## Project: issue-929-wire-simard-ooda-daemon-to-spawn-engineer-agents-i
 
 ## Overview
 

--- a/.claude/context/PROJECT.md.bak
+++ b/.claude/context/PROJECT.md.bak
@@ -10,7 +10,7 @@ Replace the sections below with information about your project.
 
 ---
 
-## Project: main
+## Project: issue-929-wire-simard-ooda-daemon-to-spawn-engineer-agents-i
 
 ## Overview
 

--- a/docs/howto/spawn-engineers-from-ooda-daemon.md
+++ b/docs/howto/spawn-engineers-from-ooda-daemon.md
@@ -1,0 +1,236 @@
+---
+title: How OODA spawns engineer agents
+description: Describes how the OODA daemon's advance-goal action parses the LLM's structured response and dispatches subordinate engineer agents.
+last_updated: 2026-04-18
+review_schedule: as-needed
+owner: simard
+doc_type: howto
+related:
+  - ./run-ooda-daemon.md
+  - ../reference/simard-cli.md
+  - ../../prompt_assets/simard/goal_session_objective.md
+---
+
+# How OODA spawns engineer agents
+
+When the OODA daemon advances a goal, it consults an LLM "goal session" that
+returns a **structured JSON action**. The dispatcher parses that action and
+either (a) spawns a subordinate engineer agent to execute the work,
+(b) records a no-op with a reason, or (c) records an assessment-only update
+of the goal's progress.
+
+This replaces the previous behaviour where `dispatch_advance_goal` ran the
+session purely for free-form assessment text and never actually spawned any
+worker.
+
+## The action contract
+
+The LLM is instructed (via `prompt_assets/simard/goal_session_objective.md`)
+to emit **exactly one JSON object** as its entire response, matching one of
+the following three shapes:
+
+```json
+{"action": "spawn_engineer", "task": "<concrete task>", "files": ["path/to/file", "..."]}
+```
+
+```json
+{"action": "noop", "reason": "<why no action is needed right now>"}
+```
+
+```json
+{"action": "assess_only", "assessment": "<short status>", "progress_pct": 42}
+```
+
+Field rules:
+
+| Field          | Variant         | Required | Notes                                      |
+| -------------- | --------------- | -------- | ------------------------------------------ |
+| `action`       | all             | yes      | Discriminator. Must be one of three values. |
+| `task`         | spawn_engineer  | yes      | Non-empty, ≤ 8 KiB.                        |
+| `files`        | spawn_engineer  | no       | Defaults to `[]`. Accepted but ignored; reserved for a future PR. Path validation will be added when wired — do not rely on any sandboxing today. |
+| `reason`       | noop            | yes      | ≤ 4 KiB.                                   |
+| `assessment`   | assess_only     | yes      | ≤ 4 KiB.                                   |
+| `progress_pct` | assess_only     | yes      | Integer in `0..=100`. Parsed as `u8`; negative values, decimals, and out-of-range integers are rejected (action falls back to parse-failure path). |
+
+The prompt instructs the LLM to emit JSON only (no prose, no Markdown
+fences). When uncertain it should prefer `assess_only`.
+
+## How the dispatcher consumes the action
+
+`src/operator_commands_ooda/goal_session.rs` exposes a private
+`parse_goal_action(response: &str) -> Option<GoalAction>` that:
+
+1. Trims whitespace and tries `serde_json::from_str` directly on the response.
+2. On failure, scans for the first balanced `{ ... }` block (string- and
+   escape-aware, depth capped at 256, input capped at 64 KiB) and re-parses
+   that substring.
+3. Returns `None` (with a `warn!` log) if neither attempt yields a valid
+   `GoalAction`.
+
+`advance_goal_with_session` returns a `GoalSessionResult` carrying the parsed
+action (if any), the raw response, and a descriptive outcome detail string.
+
+`dispatch_advance_goal` in `src/operator_commands_ooda/advance_goal.rs` then
+branches:
+
+- **`SpawnEngineer { task, files }`**
+  1. Re-checks `goal.assigned_to.is_none()` under the state lock to prevent
+     double-spawn races.
+  2. Reads `SIMARD_SUBORDINATE_DEPTH` (default `0`) and refuses to spawn if
+     it is already at or above `SIMARD_MAX_SUBORDINATE_DEPTH` (default
+     `u32::MAX`, i.e. unlimited unless an operator opts in). **The dispatcher
+     is the sole hard gate** — see the recursion-and-safety section below.
+  3. Builds a `SubordinateConfig` (`AgentRole` from
+     `crate::identity_composition::AgentRole`):
+     ```rust
+     use crate::identity_composition::AgentRole;
+     // Goal IDs may be re-dispatched after release/crash, so suffix the
+     // agent_name with an epoch nonce to keep CompositeIdentity and
+     // CognitiveMemory keys unique.
+     let nonce = std::time::SystemTime::now()
+         .duration_since(std::time::UNIX_EPOCH)
+         .map(|d| d.as_secs())
+         .unwrap_or(0);
+     SubordinateConfig {
+         agent_name: format!("engineer-{}-{}", goal.id, nonce),
+         goal: task.clone(),
+         role: AgentRole::Engineer,
+         // NOTE: dispatch_advance_goal runs inside the daemon process whose
+         // CWD is the supervisor's worktree, not a per-goal worktree. This
+         // PR ships single-worktree spawn; per-goal worktrees are tracked
+         // separately.
+         worktree_path: std::env::current_dir()?,
+         current_depth: env_depth(),
+     }
+     ```
+  4. Calls `agent_supervisor::lifecycle::spawn_subordinate(&config)`.
+  5. On success, releases the session borrow and mutates
+     `state.active_goals.active.iter_mut().find(|g| g.id == goal_id)` to set
+     `assigned_to = Some(agent_name)`.
+  6. Records an outcome:
+     `"spawn_engineer dispatched: agent='engineer-<id>-<nonce>', task='<truncated to 256>'"`.
+  7. On `Err`, logs at `error!` and records:
+     `"spawn_engineer failed: <error>"`.
+
+- **`Noop { reason }`** — records `"noop: <reason truncated to 256>"` and
+  leaves the goal unchanged.
+
+- **`AssessOnly { assessment, progress_pct }`** — records
+  `"assess_only: <assessment truncated to 256> (progress=<N>%)"` and applies
+  the assessment via the existing progress-update path.
+
+- **Parse failed (`None`)** — records
+  `"goal-action parse failed; fell back to assessment"` and falls through to
+  the legacy `assess_progress_from_outcome` + `verify_claimed_actions` path
+  for backward compatibility with free-form responses.
+
+The cycle report's `outcomes` vec now always contains at least one
+descriptive entry per advance-goal dispatch (it was previously left empty).
+
+## Recursion and safety
+
+- **Depth guard.** The parent supervisor sets `SIMARD_SUBORDINATE_DEPTH`
+  before forking each child. The dispatcher reads it and refuses to spawn
+  when it is already at or above `SIMARD_MAX_SUBORDINATE_DEPTH` (default
+  unlimited, see `src/identity_composition.rs`). **The dispatcher is the
+  sole hard gate**: `SubordinateConfig::validate` (in
+  `src/agent_supervisor/types.rs`) only emits an `eprintln!("warning: …")`
+  when the configured limit is exceeded and then spawns anyway, mirroring
+  the supervisor's "external tools (Copilot, Claude, etc.) have their own
+  guardrails" stance. If the dispatcher does not enforce the gate, nothing
+  else will.
+- **Argv-only spawn.** The task string is passed as opaque data through the
+  child's argv — never interpolated into a shell.
+- **Input bounds.** The parser caps the response at 64 KiB and the
+  brace-balanced extractor at depth 256. Malformed or oversized responses
+  fall back instead of panicking.
+- **Race protection.** `assigned_to.is_none()` is rechecked under the state
+  lock immediately before dispatching, so two cycles racing on the same goal
+  can never spawn two engineers.
+
+## Worked example
+
+Suppose the goal board contains:
+
+```text
+goal_42: "Add JSON serialization tests for GoalAction"
+```
+
+A cycle invokes the LLM goal-session prompt and the model returns:
+
+```json
+{
+  "action": "spawn_engineer",
+  "task": "Add unit tests in src/operator_commands_ooda/goal_session.rs that exercise GoalAction serde for all three variants, including JSON-in-prose extraction.",
+  "files": ["src/operator_commands_ooda/goal_session.rs"]
+}
+```
+
+The dispatcher:
+
+1. Parses the JSON into `GoalAction::SpawnEngineer { task, files }`.
+2. Confirms `goal_42.assigned_to` is `None`.
+3. Spawns `engineer-goal_42-1776552500` (epoch-suffixed) with the task as
+   its goal.
+4. Sets `goal_42.assigned_to = Some("engineer-goal_42-1776552500")`.
+5. Appends to the cycle report:
+   `outcomes: ["spawn_engineer dispatched: agent='engineer-goal_42-1776552500', task='Add unit tests in src/operator_commands_ooda/goal_session.rs ...'"]`.
+
+Subsequent cycles see `assigned_to.is_some()` and will skip respawning until
+the engineer terminates and the goal is released.
+
+## Backward compatibility
+
+If a model still returns free-form prose (or any non-JSON), the dispatcher:
+
+1. Logs a single `warn!` line ("goal session response did not parse as JSON
+   action; falling back").
+2. Runs the legacy assessment path unchanged.
+3. Records the parse-failure outcome string.
+
+No existing OODA loop behaviour is removed — `noop` and `assess_only` map
+1-to-1 onto previous semantics, and parse failures preserve the old code
+path completely.
+
+Operators with a stale `prompt_assets/simard/goal_session_objective.md`
+(one that does not instruct the model to emit JSON) will continue to hit
+the legacy assessment branch on every cycle — nothing breaks, but no
+engineers will ever spawn until the prompt asset is updated. Refresh the
+prompt asset to opt in.
+
+## Configuration
+
+| Variable                       | Default     | Purpose                                                                                                     |
+| ------------------------------ | ----------- | ----------------------------------------------------------------------------------------------------------- |
+| `SIMARD_SUBORDINATE_DEPTH`     | `0`         | Current recursion depth. The parent supervisor sets this before forking each child.                         |
+| `SIMARD_MAX_SUBORDINATE_DEPTH` | `u32::MAX`  | Maximum allowed recursion. Default is **unlimited**; operators commonly set this to `3` or `4` in practice. The dispatcher refuses to spawn when `SIMARD_SUBORDINATE_DEPTH >= SIMARD_MAX_SUBORDINATE_DEPTH`. The supervisor's `SubordinateConfig::validate` only logs a warning at this threshold — it does not block. |
+
+There is no new CLI flag and no systemd config change. Operators who
+already run `simard ooda run` get engineer-spawning behaviour automatically
+once their goal-session prompt asset emits the JSON contract above.
+
+## Observability
+
+Each cycle report includes:
+
+- `outcomes[]` — one descriptive string per advance-goal action (see branch
+  table above). Strings are truncated to 256 characters to prevent log
+  flooding. **Format stability:** the exact outcome strings
+  (e.g. `spawn_engineer dispatched: agent='…', task='…'`) are **unstable**
+  in this PR and may change without notice. Do not parse them from external
+  tools or tests; query the structured cycle-report fields instead. A
+  versioned schema will be introduced if/when downstream consumers need it.
+- `warn!` log on JSON parse failure (with raw response truncated to 256 chars).
+- `error!` log on `spawn_subordinate` failure (with the underlying error).
+- `info!` log on successful spawn, including agent name and goal id.
+
+## Related
+
+- [How to run the OODA daemon](./run-ooda-daemon.md)
+- [Simard CLI reference](../reference/simard-cli.md)
+- [Goal session objective prompt](../../prompt_assets/simard/goal_session_objective.md)
+- Source: `src/agent_supervisor/lifecycle.rs` (`spawn_subordinate`)
+- Source: `src/agent_supervisor/types.rs` (`SubordinateConfig::validate`)
+- Source: `src/identity_composition.rs` (`max_subordinate_depth`,
+  `SIMARD_MAX_SUBORDINATE_DEPTH`)
+- Issue: [#929 — Wire Simard OODA daemon to spawn engineer agents](https://github.com/rysweet/Simard/issues/929)

--- a/prompt_assets/simard/goal_session_objective.md
+++ b/prompt_assets/simard/goal_session_objective.md
@@ -1,16 +1,49 @@
-Assess this goal's current status by:
-1. Check the repository state, open issues, and recent commits to understand where things stand.
-2. Decide whether this goal needs a coding session to make progress.
-3. If work is needed: create a GitHub issue describing the specific task, then run `simard spawn engineer "<task description>" <worktree-path>` to delegate coding work to a subordinate agent.
-4. If the goal is already progressing or blocked, report the status without launching new work.
+Assess this goal and decide how to advance it. You MUST respond with a
+single JSON object and nothing else (no prose, no code fences, no
+markdown). The object must match exactly one of the three schemas below.
 
-End your response with a PROGRESS line indicating your assessed completion percentage (0-100), e.g.: PROGRESS: 45
+1. Spawn a subordinate engineer to do concrete coding work. Internally the
+   supervisor invokes `simard spawn engineer` (or the equivalent
+   `amplihack copilot` agent) with the task you provide:
 
-Concrete commands you can use:
-- Create a GitHub issue: `gh issue create --repo rysweet/Simard --title "<title>" --body "<body>"`
+```
+{"action": "spawn_engineer", "task": "<one-paragraph concrete task>", "files": ["path/to/file", "..."]}
+```
+
+The `files` field is optional (defaults to []). The `task` must be a
+non-empty, concrete description an engineer can act on without further
+context (cite files, commands, or issue numbers when known).
+
+2. No work is needed this cycle (e.g. another agent is already on it,
+   or the goal is blocked on external input):
+
+```
+{"action": "noop", "reason": "<short explanation of why no action is needed>"}
+```
+
+3. Update the assessed completion percentage without spawning anything.
+   The integer in `progress_pct` replaces the legacy `PROGRESS:` line:
+
+```
+{"action": "assess_only", "assessment": "<short status>", "progress_pct": <integer 0..=100>}
+```
+
+Decision guidance:
+- Check the repository state, open issues, and recent commits in the
+  Environment context section before deciding.
+- Prefer `spawn_engineer` when there is a concrete coding task that no
+  subordinate is already pursuing. Reference an existing GitHub issue
+  (`gh issue create --repo rysweet/Simard --title "<title>" --body "<body>"`)
+  in the task body when one exists.
+- Prefer `assess_only` when you are uncertain or only updating progress.
+- Use `noop` only when no action is justified at all.
+
+Concrete commands an engineer subordinate may use (do not run these
+yourself; cite them in the `task` field if helpful):
 - Create a branch: `git checkout -b feat/<description>`
-- Spawn a coding agent: `simard spawn engineer "<task description>" <worktree-path>`
 - Run tests: `cargo test 2>&1 | tail -20`
 - Check build: `cargo check 2>&1`
 - Open a PR: `gh pr create --title "<title>" --body "<body>"`
 - Check CI status: `gh run list --limit 5`
+
+Output requirement: emit ONLY the JSON object. No surrounding text.

--- a/src/goal_curation/types.rs
+++ b/src/goal_curation/types.rs
@@ -183,6 +183,8 @@ mod tests {
             priority: 1,
             status: GoalProgress::InProgress { percent: 75 },
             assigned_to: Some("team-a".to_string()),
+            current_activity: None,
+            wip_refs: vec![],
         }
     }
 

--- a/src/ooda_actions/advance_goal.rs
+++ b/src/ooda_actions/advance_goal.rs
@@ -1,9 +1,14 @@
 //! AdvanceGoal dispatch — routing, subordinate heartbeat, and session-based advancement.
 
-use crate::agent_supervisor::{HeartbeatStatus, check_heartbeat};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::agent_roles::AgentRole;
+use crate::agent_supervisor::{HeartbeatStatus, SubordinateConfig, check_heartbeat, spawn_subordinate};
 use crate::goal_curation::{GoalProgress, update_goal_progress};
+use crate::identity_composition::max_subordinate_depth;
 use crate::ooda_loop::{ActionOutcome, OodaBridges, OodaState, PlannedAction};
 
+use super::goal_session::GoalAction;
 use super::make_outcome;
 
 /// AdvanceGoal: progress the target goal on the board.
@@ -63,12 +68,20 @@ pub(super) fn dispatch_advance_goal(
 
     // If a base-type session is available, use run_turn for real agent work.
     if let Some(ref mut session) = bridges.session {
-        return super::goal_session::advance_goal_with_session(
+        let result = super::goal_session::advance_goal_with_session(
             action,
             session.as_mut(),
             state,
             &goal,
         );
+
+        // For spawn_engineer the dispatcher must perform the actual fork
+        // (it owns the state mutation needed to set goal.assigned_to).
+        if let Some(GoalAction::SpawnEngineer { task, files: _ }) = result.action {
+            return dispatch_spawn_engineer(action, state, &goal_id, &task);
+        }
+
+        return result.outcome;
     }
 
     // No session = cannot advance. Fail visibly per PHILOSOPHY.md.
@@ -79,6 +92,142 @@ pub(super) fn dispatch_advance_goal(
             "goal '{goal_id}' cannot advance: no LLM session available. Check SIMARD_LLM_PROVIDER and auth config."
         ),
     )
+}
+
+/// Spawn a subordinate engineer for a goal that the LLM picked
+/// `spawn_engineer` for, then mutate the active board to record the
+/// assignment.
+///
+/// Honours `SIMARD_SUBORDINATE_DEPTH` vs. `SIMARD_MAX_SUBORDINATE_DEPTH`
+/// so a recursing supervisor does not spawn forever.
+fn dispatch_spawn_engineer(
+    action: &PlannedAction,
+    state: &mut OodaState,
+    goal_id: &str,
+    task: &str,
+) -> ActionOutcome {
+    // Re-check assignment under exclusive state borrow to prevent a
+    // double-spawn race (two cycles parsing spawn_engineer back-to-back).
+    if let Some(g) = state.active_goals.active.iter().find(|g| g.id == goal_id)
+        && g.assigned_to.is_some()
+    {
+        return make_outcome(
+            action,
+            true,
+            format!(
+                "spawn_engineer skipped: goal '{goal_id}' already assigned to subordinate '{}'",
+                g.assigned_to.as_deref().unwrap_or("?"),
+            ),
+        );
+    }
+
+    // Recursion guard. Default current depth = 0 (top-level supervisor).
+    let current_depth: u32 = std::env::var("SIMARD_SUBORDINATE_DEPTH")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+    let depth_limit = max_subordinate_depth();
+    if depth_limit < u32::MAX && current_depth >= depth_limit {
+        eprintln!(
+            "[simard] spawn_engineer DENIED for goal '{goal_id}': depth {current_depth} >= limit {depth_limit}"
+        );
+        return make_outcome(
+            action,
+            false,
+            format!(
+                "spawn_engineer denied for goal '{goal_id}': subordinate depth {current_depth} >= configured limit {depth_limit}"
+            ),
+        );
+    }
+
+    let agent_name = build_engineer_name(goal_id);
+    let worktree_path = match std::env::current_dir() {
+        Ok(p) => p,
+        Err(e) => {
+            return make_outcome(
+                action,
+                false,
+                format!(
+                    "spawn_engineer failed for goal '{goal_id}': cannot resolve current_dir: {e}"
+                ),
+            );
+        }
+    };
+
+    let config = SubordinateConfig {
+        agent_name: agent_name.clone(),
+        goal: task.to_string(),
+        role: AgentRole::Engineer,
+        worktree_path,
+        current_depth,
+    };
+
+    match spawn_subordinate(&config) {
+        Ok(handle) => {
+            // Record the assignment so subsequent cycles take the
+            // heartbeat-checking path instead of re-spawning.
+            if let Some(g) = state
+                .active_goals
+                .active
+                .iter_mut()
+                .find(|g| g.id == goal_id)
+            {
+                g.assigned_to = Some(agent_name.clone());
+            }
+
+            eprintln!(
+                "[simard] spawn_engineer dispatched: goal='{goal_id}', agent='{agent_name}', pid={}",
+                handle.pid,
+            );
+            make_outcome(
+                action,
+                true,
+                format!(
+                    "spawn_engineer dispatched: agent='{agent_name}', task='{}' (goal '{goal_id}', pid={})",
+                    truncate_for_log(task),
+                    handle.pid,
+                ),
+            )
+        }
+        Err(e) => {
+            eprintln!(
+                "[simard] spawn_engineer FAILED for goal '{goal_id}': {e}"
+            );
+            make_outcome(
+                action,
+                false,
+                format!(
+                    "spawn_engineer failed for goal '{goal_id}': {e}"
+                ),
+            )
+        }
+    }
+}
+
+/// Build a unique subordinate agent name for a goal.
+///
+/// The epoch suffix prevents collisions when a goal's previous engineer
+/// died and a fresh one needs to be spawned in the same process.
+fn build_engineer_name(goal_id: &str) -> String {
+    let epoch = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    format!("engineer-{goal_id}-{epoch}")
+}
+
+/// Truncate a user-derived string for safe inclusion in outcome detail / logs.
+fn truncate_for_log(s: &str) -> String {
+    const MAX: usize = 256;
+    if s.len() <= MAX {
+        s.to_string()
+    } else {
+        let mut end = MAX;
+        while end > 0 && !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}…", &s[..end])
+    }
 }
 
 /// Advance a goal that has a subordinate assigned by checking heartbeat

--- a/src/ooda_actions/goal_session.rs
+++ b/src/ooda_actions/goal_session.rs
@@ -1,10 +1,206 @@
 //! Session-based goal advancement — delegates work to a base-type agent.
 
+use serde::Deserialize;
+
 use crate::goal_curation::{GoalProgress, update_goal_progress};
 use crate::ooda_loop::{ActionOutcome, OodaState, PlannedAction};
 
 use super::make_outcome;
 use super::verification::{assess_progress_from_outcome, verify_claimed_actions};
+
+/// Maximum LLM response size accepted by [`parse_goal_action`] (64 KiB).
+///
+/// Larger inputs are rejected without parsing to bound CPU and memory cost.
+const MAX_RESPONSE_BYTES: usize = 64 * 1024;
+
+/// Maximum brace-nesting depth permitted while extracting a JSON object
+/// from prose. Anything deeper is rejected as a parser-DoS attempt.
+const MAX_BRACE_DEPTH: usize = 256;
+
+/// Maximum length of user-derived text (task, reason, assessment) included
+/// in outcome detail strings before truncation.
+const OUTCOME_TEXT_MAX: usize = 256;
+
+/// A structured action returned by the goal-advance LLM session.
+///
+/// Used internally to dispatch to spawn / noop / assess_only branches.
+/// The variants are tagged by the `action` field per the prompt asset
+/// `prompt_assets/simard/goal_session_objective.md`.
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[serde(tag = "action", rename_all = "snake_case", deny_unknown_fields)]
+pub(super) enum GoalAction {
+    /// Spawn a subordinate engineer to do the concrete `task`.
+    SpawnEngineer {
+        task: String,
+        #[serde(default)]
+        files: Vec<String>,
+    },
+    /// Skip this cycle for the supplied human-readable `reason`.
+    Noop { reason: String },
+    /// Update the assessed completion percentage without spawning.
+    AssessOnly {
+        assessment: String,
+        progress_pct: u8,
+    },
+}
+
+/// The outcome of a single LLM-driven goal-advance turn.
+///
+/// Carries both the user-visible [`ActionOutcome`] and the parsed
+/// [`GoalAction`] (when the LLM emitted a recognisable JSON object), so
+/// the dispatcher can take side-effecting follow-up steps such as
+/// spawning a subordinate.
+pub(super) struct GoalSessionResult {
+    pub(super) outcome: ActionOutcome,
+    pub(super) action: Option<GoalAction>,
+}
+
+/// Parse a structured [`GoalAction`] from an LLM response.
+///
+/// The function accepts either a clean JSON object or a JSON object
+/// embedded in surrounding prose / code fences. Returns `None` when:
+///   * the input exceeds [`MAX_RESPONSE_BYTES`],
+///   * brace-nesting exceeds [`MAX_BRACE_DEPTH`],
+///   * no candidate JSON object parses cleanly,
+///   * the parsed object fails the per-variant invariants
+///     (empty/whitespace `task`, `progress_pct > 100`, etc.).
+///
+/// The function never panics.
+pub(super) fn parse_goal_action(response: &str) -> Option<GoalAction> {
+    if response.len() > MAX_RESPONSE_BYTES {
+        return None;
+    }
+
+    let trimmed = response.trim();
+
+    // Fast path: the LLM followed instructions and emitted only a JSON object.
+    if trimmed.starts_with('{')
+        && trimmed.ends_with('}')
+        && let Some(action) = try_parse_action(trimmed)
+    {
+        return Some(action);
+    }
+
+    // Slow path: scan for embedded JSON objects in prose / code fences and
+    // return the first one that parses cleanly into a GoalAction.
+    let bytes = response.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'{' {
+            match scan_json_block(&response[i..]) {
+                Ok(Some(end)) => {
+                    let candidate = &response[i..i + end];
+                    if let Some(action) = try_parse_action(candidate) {
+                        return Some(action);
+                    }
+                    // Move past this opening brace and keep scanning.
+                    i += 1;
+                }
+                Ok(None) => {
+                    // Unterminated JSON candidate — no further '{' can form
+                    // a valid object inside this region without first
+                    // closing this one, but the rest of the input may still
+                    // contain a valid block, so we just advance.
+                    i += 1;
+                }
+                Err(_) => {
+                    // Hit the depth cap or other structural error — bail.
+                    return None;
+                }
+            }
+        } else {
+            i += 1;
+        }
+    }
+
+    None
+}
+
+/// Attempt to deserialize `s` as a [`GoalAction`] and validate it.
+fn try_parse_action(s: &str) -> Option<GoalAction> {
+    let action: GoalAction = serde_json::from_str(s).ok()?;
+    if action_is_valid(&action) {
+        Some(action)
+    } else {
+        None
+    }
+}
+
+/// Per-variant invariants beyond what serde enforces.
+fn action_is_valid(action: &GoalAction) -> bool {
+    match action {
+        GoalAction::SpawnEngineer { task, .. } => !task.trim().is_empty(),
+        GoalAction::Noop { .. } => true,
+        GoalAction::AssessOnly { progress_pct, .. } => *progress_pct <= 100,
+    }
+}
+
+/// Scan a string starting at an opening `{` and return the byte offset
+/// (exclusive) of the matching closing `}`, respecting JSON string
+/// literals and escape sequences.
+///
+/// Returns:
+///   * `Ok(Some(end))` — a balanced object was found ending at byte `end`.
+///   * `Ok(None)` — input ended before the object closed.
+///   * `Err(())` — brace-nesting exceeded [`MAX_BRACE_DEPTH`].
+fn scan_json_block(s: &str) -> Result<Option<usize>, ()> {
+    let bytes = s.as_bytes();
+    debug_assert_eq!(bytes.first(), Some(&b'{'));
+
+    let mut depth: usize = 0;
+    let mut in_string = false;
+    let mut escape = false;
+    let mut i = 0;
+
+    while i < bytes.len() {
+        let c = bytes[i];
+
+        if in_string {
+            if escape {
+                escape = false;
+            } else if c == b'\\' {
+                escape = true;
+            } else if c == b'"' {
+                in_string = false;
+            }
+        } else {
+            match c {
+                b'"' => in_string = true,
+                b'{' => {
+                    depth += 1;
+                    if depth > MAX_BRACE_DEPTH {
+                        return Err(());
+                    }
+                }
+                b'}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return Ok(Some(i + 1));
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        i += 1;
+    }
+
+    Ok(None)
+}
+
+/// Truncate a user-derived string for safe inclusion in outcome details / logs.
+fn truncate_for_outcome(s: &str) -> String {
+    if s.len() <= OUTCOME_TEXT_MAX {
+        s.to_string()
+    } else {
+        // Truncate at a UTF-8 char boundary <= OUTCOME_TEXT_MAX.
+        let mut end = OUTCOME_TEXT_MAX;
+        while end > 0 && !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}…", &s[..end])
+    }
+}
 
 /// Advance a goal using a base-type session's `run_turn`.
 ///
@@ -16,7 +212,7 @@ pub(super) fn advance_goal_with_session(
     session: &mut dyn crate::base_types::BaseTypeSession,
     state: &mut OodaState,
     goal: &crate::goal_curation::ActiveGoal,
-) -> ActionOutcome {
+) -> GoalSessionResult {
     use crate::base_types::BaseTypeTurnInput;
     use std::fmt::Write;
 
@@ -108,53 +304,147 @@ pub(super) fn advance_goal_with_session(
 
     match session.run_turn(input) {
         Ok(outcome) => {
-            let new_progress = assess_progress_from_outcome(&outcome, &goal.status);
+            // Try to parse a structured GoalAction from the LLM response.
+            // The response text is `outcome.execution_summary` per BaseTypeSession contract.
+            let parsed = parse_goal_action(&outcome.execution_summary);
 
-            // Verify claimed actions against reality.
-            let verification = verify_claimed_actions(&outcome.execution_summary);
-            let verified_count = verification.iter().filter(|v| v.verified).count();
-            let claimed_count = verification.len();
-
-            let _ = update_goal_progress(&mut state.active_goals, &goal.id, new_progress.clone());
-
-            if !verification.is_empty() {
-                eprintln!(
-                    "[simard] OODA action verification for '{}': {}/{} claims verified",
-                    goal.id, verified_count, claimed_count,
-                );
-                for v in &verification {
+            match parsed {
+                Some(GoalAction::Noop { ref reason }) => {
                     eprintln!(
-                        "[simard]   {} {}: {}",
-                        if v.verified { "✓" } else { "✗" },
-                        v.claim_type,
-                        v.detail,
+                        "[simard] OODA goal-action noop for '{}': {}",
+                        goal.id,
+                        truncate_for_outcome(reason),
                     );
+                    let detail = format!(
+                        "noop: {} (goal '{}')",
+                        truncate_for_outcome(reason),
+                        goal.id,
+                    );
+                    GoalSessionResult {
+                        outcome: make_outcome(action, true, detail),
+                        action: parsed,
+                    }
+                }
+                Some(GoalAction::AssessOnly {
+                    ref assessment,
+                    progress_pct,
+                }) => {
+                    let new_progress = if progress_pct >= 100 {
+                        GoalProgress::Completed
+                    } else if progress_pct == 0 {
+                        GoalProgress::NotStarted
+                    } else {
+                        GoalProgress::InProgress {
+                            percent: progress_pct as u32,
+                        }
+                    };
+                    let _ = update_goal_progress(
+                        &mut state.active_goals,
+                        &goal.id,
+                        new_progress.clone(),
+                    );
+                    eprintln!(
+                        "[simard] OODA goal-action assess_only for '{}': {} (progress={}%)",
+                        goal.id,
+                        truncate_for_outcome(assessment),
+                        progress_pct,
+                    );
+                    let detail = format!(
+                        "assess_only: {} (progress={}%, goal '{}')",
+                        truncate_for_outcome(assessment),
+                        progress_pct,
+                        goal.id,
+                    );
+                    GoalSessionResult {
+                        outcome: make_outcome(action, true, detail),
+                        action: parsed,
+                    }
+                }
+                Some(GoalAction::SpawnEngineer { ref task, .. }) => {
+                    // Actual spawning is handled by the dispatcher (it owns
+                    // the state mutation needed to set goal.assigned_to).
+                    // Here we just record that the action was parsed, with
+                    // a placeholder detail the dispatcher will overwrite.
+                    eprintln!(
+                        "[simard] OODA goal-action spawn_engineer requested for '{}': {}",
+                        goal.id,
+                        truncate_for_outcome(task),
+                    );
+                    let detail = format!(
+                        "spawn_engineer requested for goal '{}': {}",
+                        goal.id,
+                        truncate_for_outcome(task),
+                    );
+                    GoalSessionResult {
+                        outcome: make_outcome(action, true, detail),
+                        action: parsed,
+                    }
+                }
+                None => {
+                    // Legacy fallback: no structured JSON action found in
+                    // the LLM response. Fall back to PROGRESS-line scraping
+                    // and claim verification, but mark the outcome detail
+                    // so operators can see the parser failed.
+                    eprintln!(
+                        "[simard] WARN: goal-action parse failed for '{}'; falling back to legacy assessment path",
+                        goal.id,
+                    );
+
+                    let new_progress =
+                        assess_progress_from_outcome(&outcome, &goal.status);
+                    let verification = verify_claimed_actions(&outcome.execution_summary);
+                    let verified_count = verification.iter().filter(|v| v.verified).count();
+                    let claimed_count = verification.len();
+
+                    let _ = update_goal_progress(
+                        &mut state.active_goals,
+                        &goal.id,
+                        new_progress.clone(),
+                    );
+
+                    if !verification.is_empty() {
+                        eprintln!(
+                            "[simard] OODA action verification for '{}': {}/{} claims verified",
+                            goal.id, verified_count, claimed_count,
+                        );
+                        for v in &verification {
+                            eprintln!(
+                                "[simard]   {} {}: {}",
+                                if v.verified { "✓" } else { "✗" },
+                                v.claim_type,
+                                v.detail,
+                            );
+                        }
+                    }
+
+                    eprintln!(
+                        "[simard] OODA session result: advance-goal '{}': {}",
+                        goal.id, outcome.execution_summary
+                    );
+
+                    let detail = format!(
+                        "goal-action parse failed; fell back to legacy assessment for goal '{}' at {} (evidence={}, verified={}/{})",
+                        goal.id,
+                        new_progress,
+                        outcome.evidence.len(),
+                        verified_count,
+                        claimed_count,
+                    );
+                    GoalSessionResult {
+                        outcome: make_outcome(action, true, detail),
+                        action: None,
+                    }
                 }
             }
-
-            eprintln!(
-                "[simard] OODA session result: advance-goal '{}': {}",
-                goal.id, outcome.execution_summary
-            );
-
-            make_outcome(
-                action,
-                true,
-                format!(
-                    "goal '{}' assessed at {} via session (evidence={}, verified={}/{})",
-                    goal.id,
-                    new_progress,
-                    outcome.evidence.len(),
-                    verified_count,
-                    claimed_count,
-                ),
-            )
         }
-        Err(e) => make_outcome(
-            action,
-            false,
-            format!("session run_turn failed for goal '{}': {e}", goal.id),
-        ),
+        Err(e) => GoalSessionResult {
+            outcome: make_outcome(
+                action,
+                false,
+                format!("session run_turn failed for goal '{}': {e}", goal.id),
+            ),
+            action: None,
+        },
     }
 }
 
@@ -263,5 +553,263 @@ mod tests {
         }
         assert!(objective.contains("commit-4"));
         assert!(!objective.contains("commit-5"));
+    }
+
+    // ===== Issue #929: parse_goal_action tests =====
+    //
+    // These tests specify the contract for the new GoalAction enum and
+    // parse_goal_action() function. They MUST fail until the parser is
+    // implemented in this module.
+
+    use super::{GoalAction, parse_goal_action};
+
+    #[test]
+    fn parse_clean_spawn_engineer_json() {
+        let response = r#"{"action": "spawn_engineer", "task": "fix the auth bug", "files": ["src/auth.rs", "src/lib.rs"]}"#;
+        let parsed = parse_goal_action(response).expect("clean spawn_engineer JSON must parse");
+        match parsed {
+            GoalAction::SpawnEngineer { task, files } => {
+                assert_eq!(task, "fix the auth bug");
+                assert_eq!(files, vec!["src/auth.rs".to_string(), "src/lib.rs".to_string()]);
+            }
+            other => panic!("expected SpawnEngineer, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_spawn_engineer_default_files_when_missing() {
+        let response = r#"{"action": "spawn_engineer", "task": "do the thing"}"#;
+        let parsed = parse_goal_action(response).expect("missing files should default to empty");
+        match parsed {
+            GoalAction::SpawnEngineer { task, files } => {
+                assert_eq!(task, "do the thing");
+                assert!(files.is_empty(), "files should default to empty Vec");
+            }
+            other => panic!("expected SpawnEngineer, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_clean_noop_json() {
+        let response = r#"{"action": "noop", "reason": "all goals are already in progress"}"#;
+        let parsed = parse_goal_action(response).expect("clean noop JSON must parse");
+        match parsed {
+            GoalAction::Noop { reason } => {
+                assert_eq!(reason, "all goals are already in progress");
+            }
+            other => panic!("expected Noop, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_clean_assess_only_json() {
+        let response = r#"{"action": "assess_only", "assessment": "good progress, no spawn needed", "progress_pct": 65}"#;
+        let parsed = parse_goal_action(response).expect("clean assess_only JSON must parse");
+        match parsed {
+            GoalAction::AssessOnly { assessment, progress_pct } => {
+                assert_eq!(assessment, "good progress, no spawn needed");
+                assert_eq!(progress_pct, 65);
+            }
+            other => panic!("expected AssessOnly, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_assess_only_at_zero_percent() {
+        let response = r#"{"action": "assess_only", "assessment": "not started", "progress_pct": 0}"#;
+        let parsed = parse_goal_action(response).expect("0% should be valid");
+        assert!(matches!(parsed, GoalAction::AssessOnly { progress_pct: 0, .. }));
+    }
+
+    #[test]
+    fn parse_assess_only_at_100_percent() {
+        let response = r#"{"action": "assess_only", "assessment": "done", "progress_pct": 100}"#;
+        let parsed = parse_goal_action(response).expect("100% should be valid");
+        assert!(matches!(parsed, GoalAction::AssessOnly { progress_pct: 100, .. }));
+    }
+
+    #[test]
+    fn parse_json_embedded_in_prose() {
+        let response = r#"After thinking carefully, here is my decision:
+
+{"action": "noop", "reason": "everything is fine"}
+
+Hope that helps!"#;
+        let parsed = parse_goal_action(response).expect("JSON embedded in prose must be extracted");
+        match parsed {
+            GoalAction::Noop { reason } => assert_eq!(reason, "everything is fine"),
+            other => panic!("expected Noop, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_json_embedded_in_code_fence() {
+        let response = "```json\n{\"action\": \"spawn_engineer\", \"task\": \"refactor\"}\n```";
+        let parsed = parse_goal_action(response).expect("JSON in code fence must parse");
+        assert!(matches!(parsed, GoalAction::SpawnEngineer { .. }));
+    }
+
+    #[test]
+    fn parse_json_with_nested_braces_in_strings() {
+        // The brace-balanced extractor must respect string boundaries and
+        // not be confused by literal { or } inside JSON string values.
+        let response = r#"prefix {"action": "spawn_engineer", "task": "implement fn foo() { return {}; }"} suffix"#;
+        let parsed = parse_goal_action(response).expect("nested braces inside strings must not break extraction");
+        match parsed {
+            GoalAction::SpawnEngineer { task, .. } => {
+                assert_eq!(task, "implement fn foo() { return {}; }");
+            }
+            other => panic!("expected SpawnEngineer, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_json_with_escaped_quotes_in_strings() {
+        let response = r#"{"action": "noop", "reason": "user said \"go away\""}"#;
+        let parsed = parse_goal_action(response).expect("escaped quotes must not break extraction");
+        match parsed {
+            GoalAction::Noop { reason } => assert_eq!(reason, r#"user said "go away""#),
+            other => panic!("expected Noop, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_returns_none_for_malformed_json() {
+        let response = r#"{"action": "spawn_engineer", "task": "broken"#; // unclosed
+        assert!(
+            parse_goal_action(response).is_none(),
+            "malformed JSON must return None, never panic"
+        );
+    }
+
+    #[test]
+    fn parse_returns_none_for_unknown_action_tag() {
+        let response = r#"{"action": "explode_universe", "task": "whatever"}"#;
+        assert!(
+            parse_goal_action(response).is_none(),
+            "unknown action tag must return None"
+        );
+    }
+
+    #[test]
+    fn parse_returns_none_for_missing_required_field() {
+        // spawn_engineer requires "task"
+        let response = r#"{"action": "spawn_engineer", "files": []}"#;
+        assert!(
+            parse_goal_action(response).is_none(),
+            "missing required field must return None"
+        );
+    }
+
+    #[test]
+    fn parse_returns_none_for_noop_missing_reason() {
+        let response = r#"{"action": "noop"}"#;
+        assert!(
+            parse_goal_action(response).is_none(),
+            "noop missing reason must return None"
+        );
+    }
+
+    #[test]
+    fn parse_returns_none_for_assess_only_missing_progress() {
+        let response = r#"{"action": "assess_only", "assessment": "x"}"#;
+        assert!(
+            parse_goal_action(response).is_none(),
+            "assess_only missing progress_pct must return None"
+        );
+    }
+
+    #[test]
+    fn parse_returns_none_for_progress_pct_above_100() {
+        let response = r#"{"action": "assess_only", "assessment": "x", "progress_pct": 150}"#;
+        assert!(
+            parse_goal_action(response).is_none(),
+            "progress_pct > 100 must be rejected"
+        );
+    }
+
+    #[test]
+    fn parse_returns_none_for_negative_progress_pct() {
+        // u8 deserialization will reject negatives.
+        let response = r#"{"action": "assess_only", "assessment": "x", "progress_pct": -1}"#;
+        assert!(
+            parse_goal_action(response).is_none(),
+            "negative progress_pct must be rejected"
+        );
+    }
+
+    #[test]
+    fn parse_returns_none_for_empty_string() {
+        assert!(parse_goal_action("").is_none());
+    }
+
+    #[test]
+    fn parse_returns_none_for_pure_prose() {
+        let response = "I think we should spawn an engineer to fix this.";
+        assert!(
+            parse_goal_action(response).is_none(),
+            "prose without JSON must return None"
+        );
+    }
+
+    #[test]
+    fn parse_returns_none_for_empty_task() {
+        let response = r#"{"action": "spawn_engineer", "task": ""}"#;
+        assert!(
+            parse_goal_action(response).is_none(),
+            "empty task must be rejected (per design spec)"
+        );
+    }
+
+    #[test]
+    fn parse_returns_none_for_whitespace_only_task() {
+        let response = r#"{"action": "spawn_engineer", "task": "   \t\n  "}"#;
+        assert!(
+            parse_goal_action(response).is_none(),
+            "whitespace-only task must be rejected"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_oversized_input() {
+        // Per design: 64 KiB cap on input.
+        let huge = "x".repeat(70 * 1024);
+        let response = format!(r#"{{"action": "noop", "reason": "{huge}"}}"#);
+        assert!(
+            parse_goal_action(&response).is_none(),
+            "input exceeding 64 KiB must be rejected"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_excessive_brace_depth() {
+        // Per design: 256 brace-depth cap to prevent parser DoS.
+        let deep = "{".repeat(300) + &"}".repeat(300);
+        assert!(
+            parse_goal_action(&deep).is_none(),
+            "brace depth > 256 must be rejected"
+        );
+    }
+
+    #[test]
+    fn parse_picks_first_complete_json_object() {
+        // If multiple candidate JSON blocks appear, the first valid one wins.
+        let response = r#"garbage {not json} more {"action": "noop", "reason": "first"} and {"action": "noop", "reason": "second"}"#;
+        let parsed = parse_goal_action(response).expect("should extract first valid JSON");
+        match parsed {
+            GoalAction::Noop { reason } => assert_eq!(reason, "first"),
+            other => panic!("expected Noop, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn goal_action_variants_are_distinct() {
+        // Sanity: the three variants compare unequal.
+        let a = GoalAction::Noop { reason: "x".into() };
+        let b = GoalAction::AssessOnly { assessment: "x".into(), progress_pct: 0 };
+        let c = GoalAction::SpawnEngineer { task: "x".into(), files: vec![] };
+        assert_ne!(a, b);
+        assert_ne!(b, c);
+        assert_ne!(a, c);
     }
 }

--- a/src/ooda_actions/tests_goal_session.rs
+++ b/src/ooda_actions/tests_goal_session.rs
@@ -269,3 +269,229 @@ fn objective_includes_concrete_commands() {
         "objective should include cargo test command"
     );
 }
+
+// ===== Issue #929: dispatch outcome wiring tests =====
+//
+// These tests verify that dispatch_advance_goal records descriptive outcome
+// detail strings for each LLM-action branch — no longer leaving outcomes
+// empty. They MUST fail until advance_goal_with_session is refactored to
+// parse JSON actions and emit branch-specific outcome strings.
+
+#[test]
+fn dispatch_records_noop_outcome_detail() {
+    // LLM returns a clean noop JSON action.
+    let (session, _) = MockSession::new_ok(
+        r#"{"action": "noop", "reason": "no work to do this cycle"}"#,
+        vec![],
+    );
+    let mut bridges = bridges_with_session(session);
+    let board = board_with_goal("g1", GoalProgress::InProgress { percent: 30 }, None);
+    let mut state = OodaState::new(board);
+    let action = PlannedAction {
+        kind: ActionKind::AdvanceGoal,
+        goal_id: Some("g1".into()),
+        description: "advance".into(),
+    };
+    let outcomes = dispatch_actions(&[action], &mut bridges, &mut state).unwrap();
+
+    assert!(outcomes[0].success, "noop should be a successful outcome");
+    let detail = outcomes[0].detail.to_lowercase();
+    assert!(
+        detail.contains("noop"),
+        "outcome detail must mention 'noop' branch, got: {}",
+        outcomes[0].detail
+    );
+    assert!(
+        detail.contains("no work to do this cycle") || detail.contains("reason"),
+        "outcome detail must include the LLM-supplied reason, got: {}",
+        outcomes[0].detail
+    );
+}
+
+#[test]
+fn dispatch_records_assess_only_outcome_detail() {
+    let (session, _) = MockSession::new_ok(
+        r#"{"action": "assess_only", "assessment": "halfway through", "progress_pct": 50}"#,
+        vec![],
+    );
+    let mut bridges = bridges_with_session(session);
+    let board = board_with_goal("g1", GoalProgress::InProgress { percent: 20 }, None);
+    let mut state = OodaState::new(board);
+    let action = PlannedAction {
+        kind: ActionKind::AdvanceGoal,
+        goal_id: Some("g1".into()),
+        description: "advance".into(),
+    };
+    let outcomes = dispatch_actions(&[action], &mut bridges, &mut state).unwrap();
+
+    assert!(outcomes[0].success);
+    let detail = outcomes[0].detail.to_lowercase();
+    assert!(
+        detail.contains("assess_only") || detail.contains("assess only"),
+        "outcome detail must mention assess_only branch, got: {}",
+        outcomes[0].detail
+    );
+    assert!(
+        outcomes[0].detail.contains("halfway through") || outcomes[0].detail.contains("50"),
+        "outcome detail must include the assessment text or progress, got: {}",
+        outcomes[0].detail
+    );
+}
+
+#[test]
+fn dispatch_assess_only_updates_progress_from_json() {
+    // A clean assess_only JSON with progress_pct should update goal progress
+    // — this is the structured replacement for the legacy "PROGRESS:" line.
+    let (session, _) = MockSession::new_ok(
+        r#"{"action": "assess_only", "assessment": "good", "progress_pct": 75}"#,
+        vec![],
+    );
+    let mut bridges = bridges_with_session(session);
+    let board = board_with_goal("g1", GoalProgress::InProgress { percent: 20 }, None);
+    let mut state = OodaState::new(board);
+    let action = PlannedAction {
+        kind: ActionKind::AdvanceGoal,
+        goal_id: Some("g1".into()),
+        description: "advance".into(),
+    };
+    let outcomes = dispatch_actions(&[action], &mut bridges, &mut state).unwrap();
+    assert!(outcomes[0].success);
+    assert_eq!(
+        state.active_goals.active[0].status,
+        GoalProgress::InProgress { percent: 75 },
+        "assess_only progress_pct must propagate to goal status"
+    );
+}
+
+#[test]
+fn dispatch_records_parse_failure_fallback_outcome_detail() {
+    // LLM returns prose with no JSON — parser returns None and the
+    // dispatcher should fall back to legacy assessment, but the outcome
+    // detail must indicate the fallback path was taken.
+    let (session, _) = MockSession::new_ok(
+        "I have no idea what to do. PROGRESS: 30",
+        vec![],
+    );
+    let mut bridges = bridges_with_session(session);
+    let board = board_with_goal("g1", GoalProgress::InProgress { percent: 25 }, None);
+    let mut state = OodaState::new(board);
+    let action = PlannedAction {
+        kind: ActionKind::AdvanceGoal,
+        goal_id: Some("g1".into()),
+        description: "advance".into(),
+    };
+    let outcomes = dispatch_actions(&[action], &mut bridges, &mut state).unwrap();
+
+    let detail = outcomes[0].detail.to_lowercase();
+    assert!(
+        detail.contains("parse fail")
+            || detail.contains("fell back")
+            || detail.contains("fallback")
+            || detail.contains("legacy"),
+        "outcome detail must indicate parse fallback was used, got: {}",
+        outcomes[0].detail
+    );
+}
+
+#[test]
+fn dispatch_outcomes_are_never_empty() {
+    // Verify every branch produces a non-empty outcome detail string.
+    for response in [
+        r#"{"action": "noop", "reason": "nothing"}"#,
+        r#"{"action": "assess_only", "assessment": "x", "progress_pct": 10}"#,
+        "totally unparseable prose",
+    ] {
+        let (session, _) = MockSession::new_ok(response, vec![]);
+        let mut bridges = bridges_with_session(session);
+        let board = board_with_goal("g1", GoalProgress::InProgress { percent: 5 }, None);
+        let mut state = OodaState::new(board);
+        let action = PlannedAction {
+            kind: ActionKind::AdvanceGoal,
+            goal_id: Some("g1".into()),
+            description: "advance".into(),
+        };
+        let outcomes = dispatch_actions(&[action], &mut bridges, &mut state).unwrap();
+        assert!(
+            !outcomes[0].detail.trim().is_empty(),
+            "outcome detail must never be empty for response: {response:?}"
+        );
+    }
+}
+
+#[test]
+fn dispatch_spawn_engineer_outcome_mentions_branch() {
+    // For spawn_engineer we cannot exercise real spawn_subordinate in unit
+    // tests (it would actually fork the current_exe). But we can still
+    // assert the outcome detail mentions the spawn_engineer branch — even
+    // if the spawn itself fails, the detail should reflect the attempt.
+    //
+    // This test uses a deeply-nested depth env var so any future depth gate
+    // can short-circuit, but per the design spec the dispatcher attempts
+    // spawn_subordinate and reports the result either way.
+    //
+    // SAFETY: env mutation is process-global; isolated in this test only.
+    // SAFETY: env mutation is process-global; isolated in this test only.
+    // SAFETY: env mutation is process-global; isolated in this test only.
+    unsafe {
+        std::env::set_var("SIMARD_SUBORDINATE_DEPTH", "9999");
+        std::env::set_var("SIMARD_MAX_SUBORDINATE_DEPTH", "1");
+    }
+
+    let (session, _) = MockSession::new_ok(
+        r#"{"action": "spawn_engineer", "task": "fix issue 929"}"#,
+        vec![],
+    );
+    let mut bridges = bridges_with_session(session);
+    let board = board_with_goal("g1", GoalProgress::InProgress { percent: 10 }, None);
+    let mut state = OodaState::new(board);
+    let action = PlannedAction {
+        kind: ActionKind::AdvanceGoal,
+        goal_id: Some("g1".into()),
+        description: "advance".into(),
+    };
+    let outcomes = dispatch_actions(&[action], &mut bridges, &mut state).unwrap();
+
+    let detail = outcomes[0].detail.to_lowercase();
+    assert!(
+        detail.contains("spawn_engineer") || detail.contains("spawn engineer") || detail.contains("subordinate"),
+        "spawn_engineer outcome detail must mention the branch, got: {}",
+        outcomes[0].detail
+    );
+
+    // SAFETY: cleanup of process-global env after test.
+    unsafe {
+        std::env::remove_var("SIMARD_SUBORDINATE_DEPTH");
+        std::env::remove_var("SIMARD_MAX_SUBORDINATE_DEPTH");
+    }
+}
+
+// ===== Issue #929: prompt asset contract tests =====
+
+#[test]
+fn prompt_asset_instructs_json_output() {
+    const ASSET: &str =
+        include_str!("../../prompt_assets/simard/goal_session_objective.md");
+    let lower = ASSET.to_lowercase();
+    assert!(
+        lower.contains("json"),
+        "goal_session_objective.md must instruct JSON output (issue #929)"
+    );
+}
+
+#[test]
+fn prompt_asset_documents_three_action_variants() {
+    const ASSET: &str =
+        include_str!("../../prompt_assets/simard/goal_session_objective.md");
+    assert!(
+        ASSET.contains("spawn_engineer"),
+        "prompt asset must document spawn_engineer action"
+    );
+    assert!(
+        ASSET.contains("noop"),
+        "prompt asset must document noop action"
+    );
+    assert!(
+        ASSET.contains("assess_only"),
+        "prompt asset must document assess_only action"
+    );
+}

--- a/src/ooda_loop/types.rs
+++ b/src/ooda_loop/types.rs
@@ -269,6 +269,8 @@ mod tests {
             priority: 1,
             status: GoalProgress::NotStarted,
             assigned_to: None,
+            current_activity: None,
+            wip_refs: vec![],
         });
         let state = OodaState::new(board);
         assert_eq!(state.active_goals.active.len(), 1);
@@ -284,6 +286,8 @@ mod tests {
             priority: 2,
             status: GoalProgress::InProgress { percent: 50 },
             assigned_to: Some("engineer".to_string()),
+            current_activity: None,
+            wip_refs: vec![],
         };
         let snapshot = GoalSnapshot::from(&goal);
         assert_eq!(snapshot.id, "g-1");
@@ -302,6 +306,8 @@ mod tests {
             priority: 1,
             status: GoalProgress::Blocked("dependency missing".to_string()),
             assigned_to: None,
+            current_activity: None,
+            wip_refs: vec![],
         };
         let snapshot = GoalSnapshot::from(&goal);
         assert!(matches!(snapshot.progress, GoalProgress::Blocked(_)));


### PR DESCRIPTION
Wires the Simard OODA daemon to spawn engineer agents.

Refs #929
Closes #929

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>