### PR TITLE
fix(cmd_cleanup): spare amplihack orchestrators from janitor

### DIFF
--- a/src/cmd_cleanup.rs
+++ b/src/cmd_cleanup.rs
@@ -179,7 +179,15 @@ fn kill_orphaned_cargo_processes(report: &mut CleanupReport) {
         };
         let cmd = parts[2..].join(" ");
 
-        if elapsed > threshold_seconds && cmd.contains("cargo") && cmd.contains("test") {
+        // Be precise: the process executable basename must be exactly "cargo",
+        // not just any path containing "cargo" (which matches /home/.../.cargo/
+        // and amplihack/recipe-runner-rs orchestrators that legitimately run
+        // for hours).
+        let exe_basename = parts[2].rsplit('/').next().unwrap_or("");
+        let is_cargo_invocation = exe_basename == "cargo"
+            && parts.get(3).map(|s| *s == "test" || *s == "build").unwrap_or(false);
+
+        if elapsed > threshold_seconds && is_cargo_invocation {
             eprintln!("  Killing orphaned cargo process pid={pid} (running {elapsed}s): {cmd}");
             let _ = Command::new("kill").arg(pid.to_string()).output();
             report.processes_killed += 1;


### PR DESCRIPTION
## Summary

Simard's OODA daemon janitor (`src/cmd_cleanup.rs::kill_orphaned_cargo_processes`)
was terminating its own orchestration system after 30 minutes.

## Root cause

The heuristic was:
```rust
if elapsed > 1800 && cmd.contains("cargo") && cmd.contains("test") { ... }
```

amplihack's `recipe-runner-rs` lives at `~/.cargo/bin/recipe-runner-rs` (matches
"cargo") and the smart-orchestrator task descriptions routinely include the
phrase "cargo test" (matches "test"). Result: every long-running orchestrator
got terminated at the 30 minute mark.

Confirmed evidence: Phase 3 orchestrator PID 2635960 was logged at 03:43:08 with
"Killing orphaned cargo process pid=2635960 (running 2014s)" — followed by all
9 child workstream orchestrators dying together.

## Fix

Require the process **executable basename** to be exactly `cargo` AND the next
arg to be `test` or `build`:

```rust
let exe_basename = parts[2].rsplit('/').next().unwrap_or("");
let is_cargo_invocation = exe_basename == "cargo"
    && parts.get(3).map(|s| *s == "test" || *s == "build").unwrap_or(false);

if elapsed > threshold_seconds && is_cargo_invocation { ... }
```

Still catches runaway `cargo test` / `cargo build` from issue #337, but spares:
- `~/.cargo/bin/*` tools (recipe-runner-rs, cargo-binstall, etc.)
- Any process whose task description happens to mention "cargo" or "test"
- Long-lived orchestrators that legitimately run for hours

## Verification

Hotfix binary built and deployed as `~/.simard/bin/simard`. Daemon restarted at
04:01 UTC. Will monitor next several cycles to confirm no false positives.

## Related issues

This unblocks #943-#952 (Phase 3 workstreams) which were repeatedly aborted by
this self-bug.
