### PR TITLE
fix(docs): use absolute URL for prompt_assets link in spawn-engineers howto

### DIFF
--- a/docs/howto/spawn-engineers-from-ooda-daemon.md
+++ b/docs/howto/spawn-engineers-from-ooda-daemon.md
@@ -8,7 +8,7 @@ doc_type: howto
 related:
   - ./run-ooda-daemon.md
   - ../reference/simard-cli.md
-  - ../../prompt_assets/simard/goal_session_objective.md
+  - https://github.com/rysweet/Simard/blob/main/prompt_assets/simard/goal_session_objective.md
 ---
 
 # How OODA spawns engineer agents
@@ -228,7 +228,7 @@ Each cycle report includes:
 
 - [How to run the OODA daemon](./run-ooda-daemon.md)
 - [Simard CLI reference](../reference/simard-cli.md)
-- [Goal session objective prompt](../../prompt_assets/simard/goal_session_objective.md)
+- [Goal session objective prompt](https://github.com/rysweet/Simard/blob/main/prompt_assets/simard/goal_session_objective.md)
 - Source: `src/agent_supervisor/lifecycle.rs` (`spawn_subordinate`)
 - Source: `src/agent_supervisor/types.rs` (`SubordinateConfig::validate`)
 - Source: `src/identity_composition.rs` (`max_subordinate_depth`,


### PR DESCRIPTION
Fixes mkdocs strict-mode failure that has been blocking PR #979 (terminal widget) and other docs builds.

The link in the YAML frontmatter and bottom-of-page list pointed to a file
outside the docs/ tree using a relative path. mkdocs cannot resolve
non-docs files via relative paths in strict mode, so use a GitHub
absolute URL.

Unblocks: #979

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>