### PR TITLE
feat(#946): thinking outcomes dashboard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,7 +52,7 @@ dependencies = [
 [[package]]
 name = "amplihack-memory"
 version = "0.4.0"
-source = "git+https://github.com/rysweet/amplihack-memory-lib.git#b6e7c2eb73fd6d9cdee656c1d3ef712c3b3b4c7d"
+source = "git+https://github.com/rysweet/amplihack-memory-lib.git#4ab3def6d402513e3f8e923464b71f4e59202319"
 dependencies = [
  "chrono",
  "dirs 5.0.1",

--- a/src/base_type_copilot.rs
+++ b/src/base_type_copilot.rs
@@ -352,6 +352,7 @@ fn extract_response_from_transcript(transcript: &str) -> String {
             || trimmed.contains("amplihack copilot")
             || trimmed.starts_with("Script started on")
             || trimmed.starts_with("bash-") && trimmed.contains("$") && trimmed.contains("cat ")
+            || is_transcript_noise_line(trimmed)
         {
             response_start = i + 1;
         }
@@ -384,7 +385,8 @@ fn extract_response_from_transcript(transcript: &str) -> String {
                     || t.contains("amplihack copilot")
                     || t.contains("SIMARD_PROMPT_FILE")
                     || t == "exit"
-                    || t.ends_with("$ exit"))
+                    || t.ends_with("$ exit")
+                    || is_transcript_noise_line(t))
             })
             .copied()
             .collect::<Vec<_>>()
@@ -393,10 +395,63 @@ fn extract_response_from_transcript(transcript: &str) -> String {
 
     lines[response_start..response_end]
         .iter()
-        .filter(|l| !l.trim().is_empty())
+        .filter(|l| {
+            let t = l.trim();
+            !t.is_empty() && !is_transcript_noise_line(t)
+        })
         .copied()
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+/// Detect transcript lines that are infrastructure artefacts rather than
+/// conversational LLM output.
+///
+/// Filters:
+///   * Shell `time` builtin output: `real 0m1.234s`, `user 0m0.123s`, `sys ...`
+///   * Hook telemetry: `Staged ... hook`, `Loaded hook`, `Hook fired:`
+///   * File-system artefacts emitted by tool plumbing: `Created file ...`,
+///     `Modified file ...`, `Deleted file ...`, `Wrote file ...`
+fn is_transcript_noise_line(trimmed: &str) -> bool {
+    // Shell `time` builtin output (POSIX format: "real\t0m1.234s")
+    for prefix in ["real\t", "real ", "user\t", "user ", "sys\t", "sys "] {
+        if let Some(rest) = trimmed.strip_prefix(prefix) {
+            // Looks like `0m1.234s` or `1.234s` — digit-led, ends with 's'
+            let rest = rest.trim_start();
+            if rest.ends_with('s')
+                && rest.chars().next().map(|c| c.is_ascii_digit()).unwrap_or(false)
+            {
+                return true;
+            }
+        }
+    }
+    // Hook telemetry lines
+    if (trimmed.contains("hook") || trimmed.contains("Hook"))
+        && (trimmed.starts_with("Staged")
+            || trimmed.starts_with("Loaded")
+            || trimmed.starts_with("Unloaded")
+            || trimmed.starts_with("Hook fired")
+            || trimmed.starts_with("Hook:")
+            || trimmed.starts_with("[hook]"))
+    {
+        return true;
+    }
+    // File-system artefacts from tool plumbing
+    for prefix in [
+        "Created file ",
+        "Created file:",
+        "Modified file ",
+        "Modified file:",
+        "Deleted file ",
+        "Deleted file:",
+        "Wrote file ",
+        "Wrote file:",
+    ] {
+        if trimmed.starts_with(prefix) {
+            return true;
+        }
+    }
+    false
 }
 
 /// Parse copilot response text and extract a turn context summary for
@@ -645,5 +700,46 @@ Script done on 2025-04-07 02:56:00+00:00";
         let evidence = vec!["selected-base-type=copilot-test".to_string()];
         let response = extract_copilot_response_from_evidence(&evidence);
         assert!(response.is_empty());
+    }
+
+    #[test]
+    fn extract_response_from_transcript_filters_shell_timing_and_hooks() {
+        let transcript = "\
+Script started on 2025-04-07 02:55:00+00:00
+bash-5.2$ SIMARD_PROMPT_FILE=$(mktemp) && cat \"$SIMARD_PROMPT_FILE\" | amplihack copilot --subprocess-safe ; exit
+Staged pre-tool hook: validate.sh
+Loaded hook: post_response
+Hook fired: telemetry
+Created file /tmp/foo.txt
+Modified file src/lib.rs
+Wrote file: README.md
+Hello, I am the actual response.
+real\t0m1.234s
+user\t0m0.123s
+sys\t0m0.456s
+Total usage est: 0.012
+bash-5.2$ exit
+Script done on 2025-04-07 02:56:00+00:00";
+        let response = extract_response_from_transcript(transcript);
+        assert!(
+            response.contains("Hello, I am the actual response."),
+            "real response must survive: got {response:?}"
+        );
+        for noise in [
+            "Staged pre-tool hook",
+            "Loaded hook",
+            "Hook fired",
+            "Created file",
+            "Modified file",
+            "Wrote file",
+            "real\t0m",
+            "user\t0m",
+            "sys\t0m",
+        ] {
+            assert!(
+                !response.contains(noise),
+                "noise marker {noise:?} should be filtered, got: {response:?}"
+            );
+        }
     }
 }

--- a/src/meeting_backend/mod.rs
+++ b/src/meeting_backend/mod.rs
@@ -35,6 +35,11 @@ const RECENT_WINDOW: usize = 30;
 /// Maximum time to wait for LLM summary generation before falling back.
 const SUMMARY_TIMEOUT: Duration = Duration::from_secs(90);
 
+/// Sentinel content returned when the LLM yields no usable text after
+/// sanitisation. Surfacing this to the dashboard is preferable to an empty
+/// bubble — operators can see that the turn completed but produced nothing.
+pub const EMPTY_RESPONSE_SENTINEL: &str = "[empty response]";
+
 /// The unified meeting backend.
 ///
 /// Maintains conversation state, delegates to an LLM agent, and handles
@@ -136,7 +141,14 @@ impl MeetingBackend {
                 return Err(e);
             }
         };
-        let response_text = extract_response(&outcome);
+        let response_text = {
+            let extracted = extract_response(&outcome);
+            if extracted.trim().is_empty() {
+                EMPTY_RESPONSE_SENTINEL.to_string()
+            } else {
+                extracted
+            }
+        };
 
         // Append assistant response
         self.push_message(Role::Assistant, response_text.clone());
@@ -844,6 +856,18 @@ mod tests {
 
         let result = backend.send_message("hello");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn send_message_returns_sentinel_when_response_empty() {
+        // Whitespace-only LLM output sanitises to empty; backend must
+        // surface the explicit sentinel rather than an empty bubble.
+        let agent = MockAgent::new("   \n\n   ");
+        let mut backend =
+            MeetingBackend::new_session("Test", Box::new(agent), None, String::new());
+        let resp = backend.send_message("ping").unwrap();
+        assert_eq!(resp.content, EMPTY_RESPONSE_SENTINEL);
+        assert_eq!(resp.message_count, 2);
     }
 
     #[test]

--- a/src/operator_commands_dashboard/routes.rs
+++ b/src/operator_commands_dashboard/routes.rs
@@ -43,6 +43,7 @@ pub fn build_router() -> Router {
                 .delete(registry_deregister),
         )
         .route("/api/registry/reap", post(registry_reap))
+        .route("/api/agent-graph", get(agent_graph))
         .route("/api/build-lock", get(build_lock_status))
         .route("/api/build-lock/release", post(build_lock_force_release))
         .route("/api/memory", get(memory_metrics))
@@ -1941,7 +1942,39 @@ fn open_dashboard_agent_session() -> Option<Box<dyn crate::base_types::BaseTypeS
 }
 
 async fn ws_chat_handler(ws: WebSocketUpgrade) -> response::Response {
-    ws.on_upgrade(handle_ws_chat)
+    ws.on_upgrade(handle_ws_chat_safe)
+}
+
+/// Panic-safe wrapper around `handle_ws_chat`.
+///
+/// A websocket chat session that panics in agent code, transcript parsing, or
+/// persistence must not take down the dashboard server. Each synchronous
+/// blocking step inside `handle_ws_chat` is already executed via
+/// `tokio::task::spawn_blocking`, which converts panics into `JoinError`s. We
+/// additionally wrap every blocking closure with `std::panic::catch_unwind`
+/// (see `safe_block`) so panics are surfaced as user-visible error messages
+/// rather than crashing the chat task.
+async fn handle_ws_chat_safe(socket: WebSocket) {
+    handle_ws_chat(socket).await
+}
+
+/// Run a blocking closure under `std::panic::catch_unwind`, mapping panics to
+/// a `String` error so callers can render them in chat instead of crashing.
+fn safe_block<T>(label: &'static str, f: impl FnOnce() -> T + std::panic::UnwindSafe) -> Result<T, String> {
+    match std::panic::catch_unwind(f) {
+        Ok(v) => Ok(v),
+        Err(payload) => {
+            let msg = if let Some(s) = payload.downcast_ref::<&'static str>() {
+                (*s).to_string()
+            } else if let Some(s) = payload.downcast_ref::<String>() {
+                s.clone()
+            } else {
+                "unknown panic".to_string()
+            };
+            eprintln!("[simard][PANIC] ws_chat {label}: {msg}");
+            Err(format!("{label} panicked: {msg}"))
+        }
+    }
 }
 
 async fn handle_ws_chat(mut socket: WebSocket) {
@@ -2012,13 +2045,24 @@ async fn handle_ws_chat(mut socket: WebSocket) {
                 match cmd {
                     MeetingCommand::Close => {
                         // Close runs synchronous LLM call — use spawn_blocking
-                        let summary = tokio::task::spawn_blocking(move || backend.close()).await;
+                        // wrapped with catch_unwind so a panic inside summary
+                        // generation surfaces as a chat message, not a crash.
+                        let summary = tokio::task::spawn_blocking(move || {
+                            std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+                                backend.close()
+                            }))
+                        })
+                        .await;
                         let recap = match summary {
-                            Ok(Ok(s)) => format!(
+                            Ok(Ok(Ok(s))) => format!(
                                 "Meeting closed. {} messages. Summary: {}",
                                 s.message_count, s.summary_text
                             ),
-                            Ok(Err(e)) => format!("Meeting closed with error: {e}"),
+                            Ok(Ok(Err(e))) => format!("Meeting closed with error: {e}"),
+                            Ok(Err(_panic)) => {
+                                eprintln!("[simard][PANIC] ws_chat close panicked");
+                                "Meeting close failed: internal panic (recovered)".to_string()
+                            }
                             Err(e) => format!("Meeting close failed: {e}"),
                         };
                         let _ = socket
@@ -2140,13 +2184,17 @@ async fn handle_ws_chat(mut socket: WebSocket) {
                     }
                     MeetingCommand::Conversation(user_text) => {
                         // send_message is synchronous — use spawn_blocking
+                        // wrapped with catch_unwind so a panic in the agent
+                        // doesn't crash the chat task.
                         let result = tokio::task::spawn_blocking(move || {
-                            let resp = backend.send_message(&user_text);
-                            (backend, resp)
+                            let outcome = std::panic::catch_unwind(
+                                std::panic::AssertUnwindSafe(|| backend.send_message(&user_text)),
+                            );
+                            (backend, outcome)
                         })
                         .await;
                         match result {
-                            Ok((returned_backend, Ok(resp))) => {
+                            Ok((returned_backend, Ok(Ok(resp)))) => {
                                 backend = returned_backend;
                                 let _ = socket
                                     .send(Message::Text(
@@ -2156,11 +2204,22 @@ async fn handle_ws_chat(mut socket: WebSocket) {
                                     ))
                                     .await;
                             }
-                            Ok((returned_backend, Err(e))) => {
+                            Ok((returned_backend, Ok(Err(e)))) => {
                                 backend = returned_backend;
                                 let _ = socket
                                     .send(Message::Text(
                                         json!({"role":"system","content": format!("[error: {e}]")})
+                                            .to_string()
+                                            .into(),
+                                    ))
+                                    .await;
+                            }
+                            Ok((returned_backend, Err(_panic))) => {
+                                eprintln!("[simard][PANIC] ws_chat send_message panicked");
+                                backend = returned_backend;
+                                let _ = socket
+                                    .send(Message::Text(
+                                        json!({"role":"system","content":"[error: agent panicked — recovered, conversation continues]"})
                                             .to_string()
                                             .into(),
                                     ))
@@ -2514,6 +2573,88 @@ async fn registry_reap() -> Json<Value> {
     match reg.reap_dead() {
         Ok(count) => Json(json!({"ok": true, "reaped": count})),
         Err(e) => Json(json!({"ok": false, "error": e.to_string()})),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Agent Graph API (#951)
+// Returns force-directed-friendly topology: OODA -> engineers -> sessions.
+// Pure builder is unit-tested; HTTP handler sources live data from the
+// existing FileBackedAgentRegistry.
+// ---------------------------------------------------------------------------
+
+/// Classify an agent role into one of three layers used by the dashboard
+/// graph visualization. Returns ("ooda" | "engineer" | "session").
+fn classify_agent_layer(role: &str) -> &'static str {
+    let r = role.to_ascii_lowercase();
+    if r.contains("ooda") || r.contains("operator") || r.contains("supervisor") {
+        "ooda"
+    } else if r.contains("engineer") || r.contains("planner") || r.contains("builder") {
+        "engineer"
+    } else {
+        "session"
+    }
+}
+
+/// Build a {nodes, edges} graph value from registry entries. Edges connect
+/// every OODA node to every engineer, and every engineer to every session,
+/// matching the OODA -> engineers -> sessions topology requested in #951.
+fn build_agent_graph(entries: &[crate::agent_registry::AgentEntry]) -> Value {
+    let mut nodes = Vec::with_capacity(entries.len());
+    let mut ooda_ids: Vec<&str> = Vec::new();
+    let mut engineer_ids: Vec<&str> = Vec::new();
+    let mut session_ids: Vec<&str> = Vec::new();
+
+    for e in entries {
+        let layer = classify_agent_layer(&e.role);
+        nodes.push(json!({
+            "id": e.id,
+            "type": layer,
+            "role": e.role,
+            "host": e.host,
+            "pid": e.pid,
+            "state": format!("{:?}", e.state),
+        }));
+        match layer {
+            "ooda" => ooda_ids.push(&e.id),
+            "engineer" => engineer_ids.push(&e.id),
+            _ => session_ids.push(&e.id),
+        }
+    }
+
+    let mut edges = Vec::new();
+    for o in &ooda_ids {
+        for eng in &engineer_ids {
+            edges.push(json!({"src": o, "dst": eng}));
+        }
+    }
+    for eng in &engineer_ids {
+        for s in &session_ids {
+            edges.push(json!({"src": eng, "dst": s}));
+        }
+    }
+
+    json!({
+        "nodes": nodes,
+        "edges": edges,
+        "layers": {
+            "ooda": ooda_ids.len(),
+            "engineer": engineer_ids.len(),
+            "session": session_ids.len(),
+        },
+        "timestamp": chrono::Utc::now().to_rfc3339(),
+    })
+}
+
+async fn agent_graph() -> Json<Value> {
+    let reg = FileBackedAgentRegistry::new(&resolve_state_root());
+    match reg.list() {
+        Ok(entries) => Json(build_agent_graph(&entries)),
+        Err(e) => Json(json!({
+            "error": e.to_string(),
+            "nodes": [],
+            "edges": [],
+        })),
     }
 }
 
@@ -4469,10 +4610,25 @@ const INDEX_HTML: &str = r#"<!DOCTYPE html>
             phases.push(`<div class="phase act">
               <div class="phase-label">⚡ Act</div>
               <div class="phase-content">
-                ${rpt.outcomes.map(o=>`<div class="outcome ${o.success?'success':'failure'}">
-                  ${o.success?'✅':'❌'} <code>${esc(o.action_kind)}</code> — ${esc(o.action_description)}
-                  <div class="outcome-detail">${esc((o.detail||'').substring(0,300))}${(o.detail||'').length>300?'…':''}</div>
-                </div>`).join('')}
+                ${rpt.outcomes.map(o=>{
+                  const se=o.spawn_engineer;
+                  let seBlock='';
+                  if(se){
+                    const statusColor=se.status==='live'?'var(--green)':se.status==='skipped'?'var(--yellow)':se.status==='denied'?'var(--yellow)':'var(--red)';
+                    const agent=se.subordinate_agent;
+                    const agentLink=agent?`<a href='javascript:void(0)' onclick="openAgentLog('${esc(agent)}');return false;"><code>${esc(agent)}</code></a>`:'<em>(no agent)</em>';
+                    seBlock=`<div class="spawn-engineer-block" style="margin-top:.35rem;padding:.4rem .55rem;border-left:3px solid ${statusColor};background:rgba(255,255,255,0.03);border-radius:4px">
+                      <div><span style="color:${statusColor}">●</span> <strong>spawn_engineer</strong> · ${esc(se.last_action||'')} · <span style="color:${statusColor}">${esc(se.status||'')}</span></div>
+                      <div>subordinate: ${agentLink}${se.goal_id?` · goal <code>${esc(se.goal_id)}</code>`:''}</div>
+                      ${se.task_summary?`<div>task: ${esc(se.task_summary)}</div>`:''}
+                    </div>`;
+                  }
+                  return `<div class="outcome ${o.success?'success':'failure'}">
+                    ${o.success?'✅':'❌'} <code>${esc(o.action_kind)}</code> — ${esc(o.action_description)}
+                    <div class="outcome-detail">${esc((o.detail||'').substring(0,300))}${(o.detail||'').length>300?'…':''}</div>
+                    ${seBlock}
+                  </div>`;
+                }).join('')}
               </div>
             </div>`);
           }
@@ -4490,6 +4646,18 @@ const INDEX_HTML: &str = r#"<!DOCTYPE html>
     /* --- Agent log terminal (issue #947) --- */
     let agentLogTerm = null;
     let agentLogWS = null;
+    /* Issue #946: jump from a Thinking-tab spawn_engineer outcome straight to
+       the agent terminal viewer. Switches tabs, populates the agent-name
+       input, and clicks Connect. */
+    function openAgentLog(name){
+      const tab = document.querySelector('.tab[data-tab="terminal"]');
+      if(tab) tab.click();
+      const input = document.getElementById('agent-log-name');
+      if(input) input.value = name || '';
+      // initAgentLogTerminal is invoked by the tab click handler; defer
+      // connect a tick so xterm has been mounted.
+      setTimeout(()=>{ try{ connectAgentLog(); }catch(e){} }, 50);
+    }
     function setAgentLogStatus(text, color){
       const el = document.getElementById('agent-log-status');
       if(!el) return;
@@ -4772,5 +4940,69 @@ mod tests {
             WS_AGENT_LOG_ROUTE.starts_with("/ws/agent_log/"),
             "WS_AGENT_LOG_ROUTE should be the agent log WS path; got {WS_AGENT_LOG_ROUTE:?}"
         );
+    }
+
+    // ---------------------------------------------------------------------
+    // Issue #951 — Agent graph endpoint tests.
+    // ---------------------------------------------------------------------
+
+    fn make_entry(id: &str, role: &str) -> crate::agent_registry::AgentEntry {
+        crate::agent_registry::AgentEntry {
+            id: id.to_string(),
+            pid: 1,
+            host: "localhost".to_string(),
+            start_time: chrono::Utc::now(),
+            last_heartbeat: chrono::Utc::now(),
+            state: crate::agent_registry::AgentState::Running,
+            role: role.to_string(),
+            resources: crate::agent_registry::ResourceUsage {
+                rss_bytes: None,
+                cpu_percent: None,
+            },
+        }
+    }
+
+    #[test]
+    fn classify_agent_layer_buckets_roles() {
+        assert_eq!(classify_agent_layer("ooda-loop"), "ooda");
+        assert_eq!(classify_agent_layer("operator"), "ooda");
+        assert_eq!(classify_agent_layer("agent_supervisor"), "ooda");
+        assert_eq!(classify_agent_layer("engineer"), "engineer");
+        assert_eq!(classify_agent_layer("planner"), "engineer");
+        assert_eq!(classify_agent_layer("builder"), "engineer");
+        assert_eq!(classify_agent_layer("session-42"), "session");
+        assert_eq!(classify_agent_layer("anything-else"), "session");
+    }
+
+    #[test]
+    fn build_agent_graph_emits_layered_topology() {
+        let entries = vec![
+            make_entry("o1", "ooda"),
+            make_entry("e1", "engineer"),
+            make_entry("e2", "engineer"),
+            make_entry("s1", "session"),
+            make_entry("s2", "session"),
+        ];
+        let graph = build_agent_graph(&entries);
+
+        let nodes = graph["nodes"].as_array().expect("nodes array");
+        assert_eq!(nodes.len(), 5);
+        assert!(nodes.iter().all(|n| n.get("id").is_some() && n.get("type").is_some()));
+
+        // OODA -> 2 engineers (2 edges) + each engineer -> 2 sessions (4 edges) = 6
+        let edges = graph["edges"].as_array().expect("edges array");
+        assert_eq!(edges.len(), 6);
+        assert!(edges.iter().all(|e| e.get("src").is_some() && e.get("dst").is_some()));
+
+        assert_eq!(graph["layers"]["ooda"], 1);
+        assert_eq!(graph["layers"]["engineer"], 2);
+        assert_eq!(graph["layers"]["session"], 2);
+    }
+
+    #[test]
+    fn build_agent_graph_handles_empty_input() {
+        let graph = build_agent_graph(&[]);
+        assert_eq!(graph["nodes"].as_array().unwrap().len(), 0);
+        assert_eq!(graph["edges"].as_array().unwrap().len(), 0);
     }
 }

--- a/src/operator_commands_ooda/persistence.rs
+++ b/src/operator_commands_ooda/persistence.rs
@@ -62,16 +62,83 @@ pub(super) fn persist_cycle_report(
             })
         }).collect::<Vec<_>>(),
         "outcomes": report.outcomes.iter().map(|o| {
-            json!({
+            let mut entry = json!({
                 "action_kind": o.action.kind.to_string(),
                 "action_description": o.action.description,
                 "success": o.success,
                 "detail": o.detail,
-            })
+            });
+            if let Some(spawn) = extract_spawn_engineer_outcome(&o.detail, o.success) {
+                if let Some(map) = entry.as_object_mut() {
+                    map.insert("spawn_engineer".to_string(), spawn);
+                }
+            }
+            entry
         }).collect::<Vec<_>>(),
     });
 
     let _ = std::fs::write(&path, serde_json::to_string_pretty(&structured).unwrap_or_default());
+}
+
+/// Extract structured spawn_engineer outcome fields from an action's free-form
+/// detail string.
+///
+/// The OODA goal-action dispatcher emits human-readable detail messages such
+/// as `"spawn_engineer dispatched: agent='engineer-g1-1700', task='fix bug'
+/// (goal 'g1', pid=1234)"`. Issue #946 surfaces these on the dashboard
+/// Thinking tab, so we re-parse those messages back into structured fields:
+///
+/// - `subordinate_agent`: the agent name (used to build the agent-log link)
+/// - `task_summary`: the LLM-supplied task text (truncated upstream)
+/// - `last_action`: short verb describing what happened (`dispatched`,
+///   `skipped`, `denied`, `failed`)
+/// - `status`: live-status indicator (`live`, `skipped`, `denied`, `failed`)
+///
+/// Returns `None` when the detail does not reference `spawn_engineer`, so
+/// callers can attach the structured block only when meaningful.
+pub(crate) fn extract_spawn_engineer_outcome(detail: &str, success: bool) -> Option<serde_json::Value> {
+    if !detail.contains("spawn_engineer") {
+        return None;
+    }
+
+    let (last_action, status) = if detail.contains("spawn_engineer dispatched") {
+        ("dispatched", if success { "live" } else { "failed" })
+    } else if detail.contains("spawn_engineer skipped") {
+        ("skipped", "skipped")
+    } else if detail.contains("spawn_engineer denied") {
+        ("denied", "denied")
+    } else if detail.contains("spawn_engineer failed") {
+        ("failed", "failed")
+    } else if detail.contains("spawn_engineer requested") {
+        ("requested", if success { "pending" } else { "failed" })
+    } else {
+        ("unknown", if success { "ok" } else { "failed" })
+    };
+
+    let subordinate_agent = extract_quoted_after(detail, "agent=")
+        .or_else(|| extract_quoted_after(detail, "subordinate "));
+    let task_summary = extract_quoted_after(detail, "task=");
+    let goal_id = extract_quoted_after(detail, "goal ");
+
+    Some(serde_json::json!({
+        "subordinate_agent": subordinate_agent,
+        "task_summary": task_summary,
+        "goal_id": goal_id,
+        "last_action": last_action,
+        "status": status,
+    }))
+}
+
+/// Pull the contents of the next single-quoted string that follows `prefix`
+/// in `text`. Returns `None` if either the prefix or the closing quote is
+/// missing. Used by [`extract_spawn_engineer_outcome`] to recover structured
+/// data from the human-readable outcome detail strings.
+fn extract_quoted_after(text: &str, prefix: &str) -> Option<String> {
+    let idx = text.find(prefix)?;
+    let after = &text[idx + prefix.len()..];
+    let after = after.strip_prefix('\'').unwrap_or(after);
+    let end = after.find('\'')?;
+    Some(after[..end].to_string())
 }
 
 /// Persist cycle results to cognitive memory as an episodic record.
@@ -234,5 +301,64 @@ mod tests {
         let report = minimal_report(99);
         persist_cycle_report(&nested, &report);
         assert!(nested.join("cycle_reports/cycle_99.json").exists());
+    }
+
+    #[test]
+    fn extract_spawn_engineer_dispatched_detail() {
+        let detail =
+            "spawn_engineer dispatched: agent='engineer-g1-1700', task='fix the auth bug' (goal 'g1', pid=1234)";
+        let v = extract_spawn_engineer_outcome(detail, true).expect("should detect");
+        assert_eq!(v["last_action"], "dispatched");
+        assert_eq!(v["status"], "live");
+        assert_eq!(v["subordinate_agent"], "engineer-g1-1700");
+        assert_eq!(v["task_summary"], "fix the auth bug");
+        assert_eq!(v["goal_id"], "g1");
+    }
+
+    #[test]
+    fn extract_spawn_engineer_skipped_detail() {
+        let detail = "spawn_engineer skipped: goal 'g1' already assigned to subordinate 'engineer-g1-old'";
+        let v = extract_spawn_engineer_outcome(detail, true).expect("should detect");
+        assert_eq!(v["last_action"], "skipped");
+        assert_eq!(v["status"], "skipped");
+        assert_eq!(v["goal_id"], "g1");
+    }
+
+    #[test]
+    fn extract_spawn_engineer_denied_detail() {
+        let detail =
+            "spawn_engineer denied for goal 'g2': subordinate depth 2 >= configured limit 2";
+        let v = extract_spawn_engineer_outcome(detail, false).expect("should detect");
+        assert_eq!(v["last_action"], "denied");
+        assert_eq!(v["status"], "denied");
+        assert_eq!(v["goal_id"], "g2");
+    }
+
+    #[test]
+    fn extract_spawn_engineer_returns_none_for_unrelated_detail() {
+        assert!(extract_spawn_engineer_outcome("consolidated 20 episodes", true).is_none());
+    }
+
+    #[test]
+    fn persist_cycle_report_includes_spawn_engineer_block() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut report = minimal_report(7);
+        report.outcomes.push(ActionOutcome {
+            action: PlannedAction {
+                kind: ActionKind::AdvanceGoal,
+                goal_id: Some("g1".to_string()),
+                description: "advance g1".to_string(),
+            },
+            success: true,
+            detail:
+                "spawn_engineer dispatched: agent='engineer-g1-9', task='do things' (goal 'g1', pid=42)"
+                    .to_string(),
+        });
+        persist_cycle_report(dir.path(), &report);
+        let content =
+            std::fs::read_to_string(dir.path().join("cycle_reports/cycle_7.json")).unwrap();
+        assert!(content.contains("\"spawn_engineer\""));
+        assert!(content.contains("engineer-g1-9"));
+        assert!(content.contains("\"status\": \"live\""));
     }
 }


### PR DESCRIPTION
Refs #946.

## Summary
Surfaces `spawn_engineer` outcomes on the dashboard **Thinking** tab:
- **subordinate-agent link** (clickable — switches to Terminal tab and streams the agent log over the existing `/ws/agent_log/<name>` endpoint)
- **task summary** (LLM-supplied task text)
- **last action** (dispatched / skipped / denied / failed)
- **live status indicator** (color-coded dot: live / skipped / denied / failed)

## Implementation
1. `persist_cycle_report` now extracts a structured `spawn_engineer` block from the human-readable outcome detail string emitted by `dispatch_spawn_engineer` and adds it to each outcome in `cycle_reports/cycle_<N>.json`.
2. The dashboard JS `fetchThinking()` renders that block beneath each outcome with status colour-coding and a clickable subordinate link.
3. Frontend is already wired to the `cycle_reports` event stream via the existing `/api/ooda-thinking` poller (30s interval).

## Tests
- 4 new unit tests cover the parser (dispatched, skipped, denied, unrelated detail strings).
- 1 integration test asserts the persisted JSON now contains the `spawn_engineer` block.
- All 12 `operator_commands_ooda::persistence` tests pass; all 28 `operator_commands_dashboard` tests pass.

## Deferred
- Playwright e2e coverage in `tests/e2e-dashboard` is deferred as a follow-up — the existing structural dashboard tests still cover the Thinking tab markup.