### PR TITLE
fix(#945): cleanup unused safe_block helper from ws chat handler

### DIFF
--- a/src/operator_commands_dashboard/routes.rs
+++ b/src/operator_commands_dashboard/routes.rs
@@ -1942,39 +1942,7 @@ fn open_dashboard_agent_session() -> Option<Box<dyn crate::base_types::BaseTypeS
 }
 
 async fn ws_chat_handler(ws: WebSocketUpgrade) -> response::Response {
-    ws.on_upgrade(handle_ws_chat_safe)
-}
-
-/// Panic-safe wrapper around `handle_ws_chat`.
-///
-/// A websocket chat session that panics in agent code, transcript parsing, or
-/// persistence must not take down the dashboard server. Each synchronous
-/// blocking step inside `handle_ws_chat` is already executed via
-/// `tokio::task::spawn_blocking`, which converts panics into `JoinError`s. We
-/// additionally wrap every blocking closure with `std::panic::catch_unwind`
-/// (see `safe_block`) so panics are surfaced as user-visible error messages
-/// rather than crashing the chat task.
-async fn handle_ws_chat_safe(socket: WebSocket) {
-    handle_ws_chat(socket).await
-}
-
-/// Run a blocking closure under `std::panic::catch_unwind`, mapping panics to
-/// a `String` error so callers can render them in chat instead of crashing.
-fn safe_block<T>(label: &'static str, f: impl FnOnce() -> T + std::panic::UnwindSafe) -> Result<T, String> {
-    match std::panic::catch_unwind(f) {
-        Ok(v) => Ok(v),
-        Err(payload) => {
-            let msg = if let Some(s) = payload.downcast_ref::<&'static str>() {
-                (*s).to_string()
-            } else if let Some(s) = payload.downcast_ref::<String>() {
-                s.clone()
-            } else {
-                "unknown panic".to_string()
-            };
-            eprintln!("[simard][PANIC] ws_chat {label}: {msg}");
-            Err(format!("{label} panicked: {msg}"))
-        }
-    }
+    ws.on_upgrade(handle_ws_chat)
 }
 
 async fn handle_ws_chat(mut socket: WebSocket) {


### PR DESCRIPTION
Refs #945.

Follow-up cleanup to commit 43016dd4 which already landed the bulk of issue #945 (ws3-chat-reliability):

- `extract_response_from_transcript` filters shell-timing lines (`real/user/sys 0m1.234s`), hook telemetry (`Staged/Loaded/Hook fired`), and file-system artefacts (`Created/Modified/Wrote file ...`) via the new `is_transcript_noise_line` helper
- `MeetingBackend::send_message` returns the `[empty response]` sentinel when sanitisation yields empty content
- WS chat handler wraps both blocking closures (`backend.send_message`, `backend.close`) in `std::panic::catch_unwind(AssertUnwindSafe(...))` so a panicking agent surfaces a recoverable error message instead of crashing the chat task
- New unit tests cover transcript noise filtering and the empty-response sentinel

That commit left behind an unused `safe_block` helper and a thin `handle_ws_chat_safe` shim that just forwarded to `handle_ws_chat` — both never wired into the dispatch path. This PR removes the dead code (eliminates `dead_code` warning).

**Deferred** (noted as TODO): persistent copilot subprocess session reuse keyed by session id (significant refactor, out of fast-ship scope), and Playwright chat e2e spec.

Build: `cargo build --lib` clean, no warnings.