### PR TITLE
feat(ws-2): subagent tmux tracking with dashboard attach links (#1015)

### DIFF
--- a/.claude/context/PROJECT.md
+++ b/.claude/context/PROJECT.md
@@ -10,7 +10,7 @@ Replace the sections below with information about your project.
 
 ---
 
-## Project: issue-996-ws-2-create-fresh-worktree-off-main-on-branch-fixr
+## Project: issue-1015-ws-2-subagent-tmux-tracking-on-fresh-worktree-off
 
 ## Overview
 

--- a/.claude/context/PROJECT.md.bak
+++ b/.claude/context/PROJECT.md.bak
@@ -10,7 +10,7 @@ Replace the sections below with information about your project.
 
 ---
 
-## Project: issue-996-ws-2-create-fresh-worktree-off-main-on-branch-fixr
+## Project: issue-1015-ws-2-subagent-tmux-tracking-on-fresh-worktree-off
 
 ## Overview
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,11 +139,335 @@ shell-policy-safe alternatives instead:
 
 ## Amplihack Copilot Workflow Rules
 
-A recipe-managed workflow is already active for this session.
+For any DEV, INVESTIGATE, or HYBRID request, invoke `Skill(skill="dev-orchestrator")` immediately.
 
-Do NOT invoke `Skill(skill="dev-orchestrator")`, do NOT run `run_recipe_by_name("smart-orchestrator")`, and do NOT reinterpret the current prompt as a new top-level task.
+After the skill is activated, the next tool call must execute the `smart-orchestrator` recipe via `run_recipe_by_name("smart-orchestrator")`.
 
-Follow the current prompt exactly. Return only the requested output format. Use tools only when the prompt explicitly requires them.
+Do not follow the workflow manually and do not fall back to legacy `ultrathink` behavior.
+
+## Auto-routing prompt
+
+<system-reminder source="auto-intent-router">
+Before responding, classify this prompt using parallel signal evaluation:
+
+```mermaid
+flowchart TD
+    MSG[User Message] --> BYPASS{"Bypass?<br/>'just answer' / 'skip workflow'"}
+    BYPASS -->|yes| SKIP[SKIP: respect bypass]
+
+    MSG --> EVAL{Detect all signals}
+    EVAL --> S1["UNDERSTAND<br/>explain, how does, why,<br/>analyze, research, explore"]
+    EVAL --> S2["IMPLEMENT<br/>build, fix, add, create,<br/>refactor, update, write"]
+    EVAL --> S3["FILE_EDIT<br/>any code/doc file will be<br/>created / modified / deleted"]
+    EVAL --> S4["SHELL_ONLY<br/>run tests, git status,<br/>check logs, show disk"]
+    EVAL --> S5["QUESTION<br/>what is, how do I,<br/>explain, compare"]
+
+    EVAL --> RESOLVE{Resolve by priority}
+    RESOLVE -->|"UNDERSTAND + IMPLEMENT"| HYBRID[HYBRID → dev-orchestrator]
+    RESOLVE -->|"SHELL_ONLY + IMPLEMENT"| HYBRID
+    RESOLVE -->|"FILE_EDIT or IMPLEMENT alone"| DEV[DEV → dev-orchestrator]
+    RESOLVE -->|"UNDERSTAND alone"| INVESTIGATE[INVESTIGATE → dev-orchestrator]
+    RESOLVE -->|"SHELL_ONLY alone"| OPS[OPS: execute directly]
+    RESOLVE -->|"QUESTION alone"| QA[Q&A: answer directly]
+```
+
+Resolution rules — detect all signals, then apply the FIRST matching rule:
+1. BYPASS → SKIP
+2. UNDERSTAND + IMPLEMENT both present → **HYBRID** (even if FILE_EDIT also present)
+3. SHELL_ONLY + IMPLEMENT both present → **HYBRID** (run command then fix)
+4. FILE_EDIT or IMPLEMENT present (no UNDERSTAND) → **DEV**
+5. UNDERSTAND present (no IMPLEMENT) → **INVESTIGATE**
+6. SHELL_ONLY present (no FILE_EDIT) → **OPS**
+7. QUESTION present (no FILE_EDIT) → **Q&A**
+8. Ambiguous → **DEV** (safe default)
+
+Calibration examples (use these to resolve edge cases):
+  "run tests and fix failures" = HYBRID (SHELL_ONLY + IMPLEMENT → both phases)
+  "investigate X then fix Y" = HYBRID
+  "what does this error mean and how do I fix it" = HYBRID (UNDERSTAND + IMPLEMENT)
+  "change the default model" = DEV. "update README" = DEV. "fix a typo" = DEV.
+  "review this PR" = DEV. "make sure it works" = DEV. "write docs" = DEV.
+  "run tests" = OPS. "git status" = OPS.
+  "what is OAuth?" = Q&A. "how does X work?" = Q&A (no fix requested).
+  "what's broken?" = INVESTIGATE. "why is CI failing?" = INVESTIGATE.
+  "research rate limiting then implement it" = HYBRID.
+  "analyze deps and remove circular imports" = HYBRID (UNDERSTAND + IMPLEMENT).
+
+Actions:
+  DEV → Say "[auto-routed] DEV → launching dev-orchestrator" then Invoke Skill(skill="dev-orchestrator"). Do not answer inline.
+  INVESTIGATE → Say "[auto-routed] INVESTIGATE → launching dev-orchestrator" then Invoke Skill(skill="dev-orchestrator"). Do not answer inline.
+  HYBRID → Say "[auto-routed] HYBRID → launching dev-orchestrator" then Invoke Skill(skill="dev-orchestrator"). Do not answer inline.
+  Q&A → Answer directly. No workflow needed.
+  OPS → Execute directly. No workflow needed.
+  SKIP → Respect the bypass.
+
+When in doubt, choose DEV. False positive costs minutes. False negative costs quality.
+</system-reminder>
+
+## Execution Instructions
+
+**YOUR NEXT ACTION after reading this skill MUST include a Bash tool call that
+executes the recipe runner.** If your runtime requires a `report_intent` call
+(e.g. Copilot CLI), emit it **in parallel** with the Bash launch — both tool
+calls in the same response. The constraint is that no
+_other_ substantive action (reading files, calling TodoWrite, invoking Agent,
+or typing a response) may precede or replace the Bash launch.
+
+If you find yourself doing anything else instead of launching the recipe
+runner, you are bypassing the workflow. Stop. Go back. Run the recipe runner.
+
+Development and Investigation tasks have exactly ONE execution path: the
+recipe runner. There is no "Option B." There is no "I'll follow the steps
+manually." There is no "Let me just quickly..." The recipe runner IS the
+workflow. Skipping it means skipping the 23-step process, the recursion
+guards, the goal verification, and the quality gates that exist for a reason.
+
+A PostToolUse hook monitors every tool call after this skill activates. If
+it detects 3 tool calls without recipe runner evidence, it will fire a hard
+WARNING. Do not wait for the warning — run the recipe runner immediately.
+
+When this skill is activated:
+
+### REQUIRED: Execute via Recipe Runner — IMMEDIATELY
+
+Your next tool call(s) must include the recipe runner launch (alongside
+`report_intent` if your runtime requires it).
+
+#### Default: Direct Execution (Rust CLI)
+
+The recipe runner is the Rust `amplihack` binary — invoke it directly:
+
+```bash
+cd /path/to/repo && env -u CLAUDECODE \
+  AMPLIHACK_HOME=/path/to/amplihack \
+  amplihack recipe run amplifier-bundle/recipes/smart-orchestrator.yaml \
+    -c task_description="TASK_DESCRIPTION_HERE" \
+    -c repo_path="." \
+    --verbose
+```
+
+**Key points:**
+
+- `amplihack recipe run` — the native Rust binary; no Python wrapper needed
+- `-c key=value` — passes context variables (equivalent to `user_context` dict)
+- `--verbose` — streams recipe-runner stderr live so you see nested step activity
+- The recipe runner manages its own child processes (agent sessions, bash steps) as direct subprocesses
+
+This is the preferred execution mode for most scenarios. It is simpler, has
+no external dependencies beyond the Rust binary, works on all platforms,
+and makes output capture straightforward.
+
+
+
+#### Durable Execution (tmux) — optional
+
+Use tmux **only** when:
+
+- The agent runtime may kill background processes after a timeout (e.g., some
+  Claude Code hosted environments)
+- You need to survive SSH disconnects or terminal closures
+- You want to detach and monitor a long-running recipe interactively
+
+```bash
+LOG_FILE=$(mktemp /tmp/recipe-runner-output.XXXXXX.log)
+chmod 600 "$LOG_FILE"
+tmux new-session -d -s recipe-runner \
+  "cd /path/to/repo && env -u CLAUDECODE \
+   AMPLIHACK_HOME=/path/to/amplihack \
+   amplihack recipe run amplifier-bundle/recipes/smart-orchestrator.yaml \
+     -c task_description='TASK_DESCRIPTION_HERE' \
+     -c repo_path='.' \
+     --verbose 2>&1 | tee $LOG_FILE"
+echo "Recipe runner log: $LOG_FILE"
+```
+
+- `chmod 600 "$LOG_FILE"` — keeps the log file private
+- `tmux new-session -d` — detached session, no timeout, survives disconnects
+- Monitor with: `tail -f "$LOG_FILE"` or `tmux attach -t recipe-runner`
+
+**Restarting a stale tmux session**: Some runtimes (e.g. Copilot CLI) block
+`tmux kill-session` because it does not target a numeric PID. Use one of these
+shell-policy-safe alternatives instead:
+
+```bash
+# Option A (preferred): use a unique session name per run to avoid collisions
+tmux new-session -d -s "recipe-$(date +%s)" "..."
+
+# Option B: locate the tmux server PID and terminate with numeric kill
+tmux list-sessions -F '#{pid}' 2>/dev/null | xargs -I{} kill {}
+
+# Option C: let tmux itself handle it — send exit to all panes
+tmux send-keys -t recipe-runner "exit" Enter 2>/dev/null; sleep 1
+```
+
+If using Option A, update the `tail -f` / `tmux attach` commands to use the
+same session name.
+
+**The recipe runner is the required execution path for Development and
+Investigation tasks.** Always try `smart-orchestrator` first.
+
+**Required environment variables** for the recipe runner:
+
+- `AMPLIHACK_HOME` — Auto-detected from the current working directory by
+  walking parent directories for an `amplifier-bundle/` folder, with fallback
+  to `~/.amplihack`. If auto-detection fails, set manually to the directory
+  containing `amplifier-bundle/`.
+- Preserve `AMPLIHACK_AGENT_BINARY` — nested workflow agents read this env var
+  to stay on the caller's active binary (for example, Copilot in Copilot CLI).
+- Unset `CLAUDECODE` — required so nested Claude Code sessions can launch.
+
+**Fallback: Direct recipe invocation when smart-orchestrator fails.**
+
+Always try `smart-orchestrator` first — it handles classification, decomposition,
+and routing automatically. However, if `smart-orchestrator` fails at the
+**infrastructure level** (e.g., 0 workstreams from decomposition, missing env
+vars, Rust binary version mismatch), you MAY invoke the specific workflow
+recipe directly based on your classification:
+
+| Classification | Direct Recipe            | When to Use                             |
+| -------------- | ------------------------ | --------------------------------------- |
+| Investigation  | `investigation-workflow` | smart-orchestrator decomposition failed |
+| Development    | `default-workflow`       | smart-orchestrator decomposition failed |
+| Q&A (complex)  | `qa-workflow`            | Q&A needing multi-step research         |
+| Consensus      | `consensus-workflow`     | Critical decisions needing validation   |
+
+Example:
+
+```bash
+amplihack recipe run amplifier-bundle/recipes/investigation-workflow.yaml \
+  -c task_description="TASK_DESCRIPTION_HERE" \
+  -c repo_path="."
+```
+
+This is NOT a license to bypass `smart-orchestrator`. Only use direct
+invocation after `smart-orchestrator` has failed at an infrastructure level
+(not because the task seems "too simple" or "too specific").
+
+**Handling hollow success** (recipe completes but agents produce no findings):
+
+If a recipe returns SUCCESS but the agent outputs indicate the agents could
+not access the codebase or produced empty/generic results (e.g., "no codebase
+exists", "cannot proceed without a target"), this is a **hollow success**.
+In this case:
+
+1. Check that `repo_path` and `AMPLIHACK_HOME` are correct
+2. Verify the working directory is the repo root
+3. Retry with explicit file paths in the `task_description`
+4. If retries also produce hollow results, report the infrastructure
+   failure to the user with specifics
+
+**Common rationalizations that are NOT acceptable:**
+
+- "Let me first understand the codebase" — the recipe does that in Step 0
+- "I'll follow the workflow steps manually" — NO, the recipe enforces them
+- "The recipe runner might not work" — try it first, report errors if it fails
+- "This is a simple task" — simple or complex, the recipe runner handles both
+- "The recipe succeeded but didn't do anything useful, so I'll do it myself"
+  — this is hollow success; retry with better context first
+
+**Q&A and Operations only** may bypass the recipe runner:
+
+- Q&A: Respond directly (analyzer agent)
+- Operations: Builder agent (direct execution, no workflow steps)
+
+### Error Recovery: Adaptive Strategy (NOT Degradation)
+
+When `smart-orchestrator` fails, **failures must be visible and surfaced** —
+never swallowed or silently degraded. The recipe handles error recovery
+automatically via its built-in adaptive strategy steps, but if you observe
+a failure outside the recipe, follow this protocol:
+
+**1. Surface the error with full context:**
+
+Report the exact error, the step that failed, and the log output. Never say
+"something went wrong" — always include the specific failure details.
+
+**2. File a bug with reproduction details:**
+
+For infrastructure failures (import errors, missing env vars, binary not found,
+decomposition producing invalid output), file a GitHub issue:
+
+```bash
+gh issue create \
+  --title "smart-orchestrator infrastructure failure: <one-line summary>" \
+  --body "<full error context, reproduction command, env details>" \
+  --label "bug"
+```
+
+**3. Evaluate alternative strategies:**
+
+If `smart-orchestrator` fails at the infrastructure level (not because the task
+is wrong), you MAY invoke the specific workflow recipe directly. This is an
+**adaptive strategy** — it must be announced explicitly, not done silently:
+
+| Classification | Direct Recipe            | When Permitted                                      |
+| -------------- | ------------------------ | --------------------------------------------------- |
+| Investigation  | `investigation-workflow` | smart-orchestrator failed at parse/decompose/launch |
+| Development    | `default-workflow`       | smart-orchestrator failed at parse/decompose/launch |
+
+Example:
+
+```bash
+# ANNOUNCE the strategy change first — never do this silently
+echo "[ADAPTIVE] smart-orchestrator failed at parse-decomposition: <error>"
+echo "[ADAPTIVE] Switching to direct investigation-workflow invocation"
+amplihack recipe run amplifier-bundle/recipes/investigation-workflow.yaml \
+  -c task_description="TASK_DESCRIPTION_HERE" \
+  -c repo_path="."
+```
+
+**This is NOT a license to bypass smart-orchestrator.** Always try it first.
+Direct invocation is only permitted when smart-orchestrator fails at the
+infrastructure level. "The task seems simple" is NOT an infrastructure failure.
+
+**4. Detect hollow success:**
+
+A recipe can complete structurally (all steps exit 0) but produce empty or
+meaningless results — agents reporting "no codebase found" or reflection
+marking ACHIEVED when no work was done. After execution, check that:
+
+- Round results contain actual findings or code changes (not "I could not access...")
+- PR URLs or concrete outputs are present for Development tasks
+- At least one success criterion was verifiably evaluated
+
+If results are hollow, report this to the user with the specific empty outputs.
+Do not declare success when agents produced no meaningful work.
+
+### Required Environment Variables
+
+The recipe runner requires these environment variables to function:
+
+| Variable                   | Purpose                                           | Default         |
+| -------------------------- | ------------------------------------------------- | --------------- |
+| `AMPLIHACK_HOME`           | Root of amplihack installation (for asset lookup) | Auto-detected   |
+| `AMPLIHACK_AGENT_BINARY`   | Which agent binary to use (claude, copilot, etc.) | Set by launcher |
+| `AMPLIHACK_MAX_DEPTH`      | Max recursion depth for nested sessions           | `3`             |
+| `AMPLIHACK_NONINTERACTIVE` | Set to `1` to skip interactive prompts            | Unset           |
+
+If `AMPLIHACK_HOME` is not set and auto-detection fails, `parse-decomposition`
+and `activate-workflow` will fail with asset lookup errors. Set it to
+the directory containing `amplifier-bundle/`.
+
+### After Execution: Reflect and verify
+
+After execution completes, verify the goal was achieved. If not:
+
+- For missing information: ask the user
+- For fixable gaps: re-invoke with the remaining work description
+- For infrastructure failures: file a bug and try adaptive strategy
+
+### Enforcement: PostToolUse Workflow Guard
+
+A PostToolUse hook (`workflow_enforcement_hook.py`) actively monitors every
+tool call after this skill is invoked. It tracks:
+
+- Whether `/dev` or `dev-orchestrator` was called (sets a flag)
+- Whether the recipe runner was actually executed (clears the flag)
+- How many tool calls have passed without workflow evidence
+
+If 3+ tool calls pass without evidence of recipe runner execution, the hook
+emits a hard WARNING. This is not a suggestion — it means you are violating
+the mandatory workflow. State is stored in `/tmp/amplihack-workflow-state/`.
 
 ## User Preferences
 

--- a/docs/howto/attach-to-a-running-engineer.md
+++ b/docs/howto/attach-to-a-running-engineer.md
@@ -1,0 +1,109 @@
+# How to attach to a running engineer
+
+When the OODA daemon spawns a subordinate engineer, the supervisor wraps the
+engineer process inside a uniquely-named `tmux` session. You can attach to
+that session from any shell on the same host to watch the engineer work in
+real time, drive its TTY, or detach and let it continue.
+
+This how-to covers the three common attach paths:
+
+1. From the **operator dashboard** Terminal tab.
+2. From the **Recent Actions** feed (inline Attach links).
+3. From a **plain shell** using the registry file directly.
+
+## Prerequisites
+
+- A Simard host with `tmux` installed and on `PATH`.
+- The OODA daemon running and dispatching engineers.
+- For dashboard paths: the operator dashboard is reachable and you have its
+  auth token.
+
+## 1. From the dashboard Terminal tab
+
+1. Open the operator dashboard.
+2. Click the **Terminal** tab.
+3. Find the **Subagent Sessions** card. Each live row shows
+   `<agent_id> · <goal_id> · live · [Attach →]`.
+4. Click **Attach →**. The attach command is copied to your clipboard.
+5. In any terminal on the host, paste and run it:
+   ```bash
+   tmux attach -t simard-engineer-<sanitized_agent_id>
+   ```
+6. Detach without killing the engineer with `Ctrl-b d`.
+
+Recently ended engineers (within the last 24 hours) appear in the same card
+with status `ended <Δ ago>`. Their Attach button copies the same command, but
+running it will fail with `no sessions` — the engineer process has exited.
+
+## 2. From the Recent Actions feed
+
+The Recent Actions list now renders an inline **Attach →** button next to any
+detail line of the form:
+
+```
+spawn_engineer dispatched: agent='engineer-2026-04-19-...', task='...', pid=412017
+```
+
+…provided that the matching session is still in the registry (live or
+recently-ended within 24h).
+
+1. Click **Attach →** on the row. The attach command is copied to your
+   clipboard.
+2. Run it in a terminal on the host.
+
+If the regex matches an engineer id but the session has been garbage-collected
+(>24h after end), the line renders as plain text without a button — there is
+nothing left to attach to.
+
+## 3. From a plain shell
+
+The registry file is always usable directly:
+
+```bash
+# All currently-live engineer sessions:
+jq -r '.sessions[] | select(.ended_at == null) | "\(.agent_id)\t\(.session_name)"' \
+  ~/.simard/state/subagent_sessions.json
+
+# Attach by session name:
+tmux attach -t simard-engineer-<sanitized_agent_id>
+```
+
+If you set `SIMARD_STATE_ROOT`, substitute that path for `~/.simard`.
+
+You can also list tmux sessions directly:
+
+```bash
+tmux ls 2>/dev/null | grep '^simard-engineer-'
+```
+
+## Remote hosts
+
+This release **always** records `host = "local"` for every spawned engineer.
+There is no environment variable, CLI flag, or config setting that produces
+a non-`local` host value, so the `ssh` form below is currently unreachable
+in practice and exists only for forward compatibility with a future remote-
+host feature.
+
+The dashboard renderer already understands the remote form: when an entry
+has a non-`local` host, the copied command would become:
+
+```bash
+ssh <host> -t tmux attach -t simard-engineer-<id>
+```
+
+## Tips
+
+- **Read-only attach**: use `tmux attach -t <name> -r` to attach in
+  read-only mode (no keystrokes forwarded).
+- **Multi-watcher**: multiple humans can attach to the same session
+  simultaneously; tmux mirrors the TTY.
+- **Force-kill an engineer**: `tmux kill-session -t simard-engineer-<id>`.
+  The next OODA cycle will mark `ended_at` and GC the entry within 24h.
+- **Logs still work**: the engineer's stdout/stderr is also tee'd to its
+  log file, so `/ws/agent_log` viewers continue to function unchanged.
+
+## See also
+
+- [`docs/reference/subagent-tmux-tracking.md`](../reference/subagent-tmux-tracking.md)
+- [`docs/howto/view-agent-terminal-logs.md`](view-agent-terminal-logs.md)
+- [`docs/howto/spawn-engineers-from-ooda-daemon.md`](spawn-engineers-from-ooda-daemon.md)

--- a/docs/reference/subagent-tmux-tracking.md
+++ b/docs/reference/subagent-tmux-tracking.md
@@ -1,0 +1,374 @@
+# Subagent Tmux Tracking
+
+Reference documentation for the **subagent tmux tracking** subsystem that wraps
+every spawned engineer in a uniquely-named `tmux` session, persists a registry
+of live and recently-ended sessions, exposes that registry via the operator
+dashboard API, and renders attach links inline in the **Recent Actions** feed.
+
+## Overview
+
+When the OODA daemon dispatches a subordinate engineer (the line you see in
+logs as `spawn_engineer dispatched: agent='engineer-XYZ', task='...', pid=N`),
+the supervisor now:
+
+1. Sanitizes the `agent_id` and computes a tmux session name of the form
+   `simard-engineer-<sanitized_id>`.
+2. Wraps the engineer's argv inside `tmux new-session -d -s <name> sh -c
+   '<cmd> 2>&1 | tee -a <logfile>'` so existing `/ws/agent_log` log viewers
+   continue to work.
+3. Records a `SubagentSession` entry in `~/.simard/state/subagent_sessions.json`
+   using an atomic temp-file + rename.
+4. On every OODA cycle (after the Act phase), polls each registry entry with
+   `tmux has-session -t <name>`. Missing sessions are stamped with
+   `ended_at = now`. Entries whose `ended_at` is older than 24 hours are
+   garbage-collected from the registry.
+
+The dashboard surfaces this registry as live data in two places:
+
+- A new **Subagent Sessions** card on the Terminal tab.
+- An inline **Attach →** button rendered next to matching `agent='engineer-…'`
+  entries in the Recent Actions feed (both overview and workboard renderers).
+
+If `tmux` is not installed on the host, spawning falls back to the previous
+direct `exec` path; no registry entry is written and a warning is logged. The
+feature is therefore strictly additive — no engineer spawn ever fails because
+of tracking.
+
+## Storage
+
+### Path resolution
+
+```
+state_root = $SIMARD_STATE_ROOT  // if set
+           | $HOME/.simard       // fallback
+registry   = state_root + "/state/subagent_sessions.json"
+```
+
+The parent directory is created on first write if missing.
+
+### File format
+
+```json
+{
+  "sessions": [
+    {
+      "agent_id":     "engineer-2026-04-19-17-41-53-abcd1234",
+      "session_name": "simard-engineer-engineer-2026-04-19-17-41-53-abcd1234",
+      "host":         "local",
+      "pid":          412017,
+      "created_at":   1745083313,
+      "ended_at":     null,
+      "goal_id":      "goal-7c3f"
+    }
+  ]
+}
+```
+
+| Field          | Type            | Notes                                              |
+|----------------|-----------------|----------------------------------------------------|
+| `agent_id`     | string          | As emitted by the spawn site.                      |
+| `session_name` | string          | `simard-engineer-<sanitize(agent_id)>`. Note the doubled `engineer-` prefix in the example above is **not** a typo: the supervisor prepends `simard-engineer-` to the full sanitized `agent_id`, which itself already begins with `engineer-`. |
+| `host`         | string          | Always `"local"` in this release.                  |
+| `pid`          | u32             | Engineer pane PID via `tmux list-panes -F '#{pane_pid}'`, or `child.id()` fallback. |
+| `created_at`   | i64 (unix sec)  | Time of registry write.                            |
+| `ended_at`     | i64 \| null     | Set by `poll_and_gc` when `tmux has-session` fails.|
+| `goal_id`      | string          | Owning OODA goal.                                  |
+
+### Atomic write
+
+```
+1. Serialize the in-memory Registry to bytes.
+2. Write to "subagent_sessions.json.tmp.<pid>" in the same directory.
+3. fsync the temp file.
+4. std::fs::rename(temp, final).
+```
+
+After a successful write, **no** `*.tmp.<pid>` siblings remain. Corrupt or
+missing files at load time produce an empty `Registry { sessions: vec![] }`
+and a warn-level log line; loading never panics.
+
+## Identifier sanitization
+
+```
+sanitize_id(raw):
+    out = raw.chars().map(|c| if matches!(c, 'A'..='Z' | 'a'..='z' | '0'..='9' | '_' | '-') { c } else { '-' })
+    if out.is_empty() { "engineer" } else { out }
+```
+
+Invariants enforced by the sanitizer:
+
+- The result matches `^[A-Za-z0-9_\-]+$`.
+- The result is non-empty.
+- The session name is therefore always a legal tmux identifier.
+
+## Public Rust API
+
+Module: `simard::subagent_sessions`
+
+```rust
+pub struct SubagentSession {
+    pub agent_id: String,
+    pub session_name: String,
+    pub host: String,
+    pub pid: u32,
+    pub created_at: i64,
+    pub ended_at: Option<i64>,
+    pub goal_id: String,
+}
+
+pub struct Registry {
+    pub sessions: Vec<SubagentSession>,
+}
+
+pub trait SessionProbe {
+    fn alive(&self, session_name: &str) -> bool;
+}
+
+pub struct TmuxProbe; // production probe; runs `tmux has-session -t <name>`
+
+pub fn registry_path() -> std::path::PathBuf;
+pub fn load() -> Registry;
+pub fn save_atomic(reg: &Registry) -> std::io::Result<()>;
+pub fn record_spawn(s: SubagentSession) -> std::io::Result<()>;
+pub fn poll_and_gc<P: SessionProbe>(probe: &P) -> std::io::Result<()>;
+pub fn sanitize_id(raw: &str) -> String;
+```
+
+Module: `simard::agent_supervisor::tmux`
+
+```rust
+/// Build the argv used to spawn the engineer wrapped in a detached tmux
+/// session whose stdout/stderr is also tee'd to `log_path`.
+pub fn build_tmux_wrapped_command(
+    session_name: &str,
+    inner_argv: &[String],
+    log_path: &std::path::Path,
+) -> Vec<String>;
+```
+
+Returned argv shape:
+
+```
+["tmux", "new-session", "-d", "-s", "<session_name>",
+ "sh", "-c", "<shell-quoted inner_argv> 2>&1 | tee -a <log_path>"]
+```
+
+## OODA integration
+
+`run_ooda_cycle` invokes `subagent_sessions::poll_and_gc(&TmuxProbe)` once per
+cycle, immediately after the **Act** phase. Polling semantics:
+
+- For each session with `ended_at = None`, run `tmux has-session -t
+  <session_name>`. Exit code `0` ⇒ alive; non-zero ⇒ set `ended_at = now()`.
+- For each session with `ended_at = Some(t)` where `now() - t > 86400`,
+  drop the entry from the registry.
+- A single `save_atomic` call persists the updated registry at the end of
+  the polling pass.
+
+Polling errors (e.g. tmux not installed) are logged at warn level and do not
+abort the OODA cycle.
+
+## HTTP API
+
+### `GET /api/subagent-sessions`
+
+Auth: requires the same operator token used by all other dashboard endpoints
+(`require_auth` middleware).
+
+Response body:
+
+```json
+{
+  "live": [
+    {
+      "agent_id":     "engineer-...",
+      "session_name": "simard-engineer-engineer-...",
+      "host":         "local",
+      "pid":          412017,
+      "created_at":   1745083313,
+      "ended_at":     null,
+      "goal_id":      "goal-7c3f"
+    }
+  ],
+  "recently_ended": [
+    {
+      "agent_id":     "engineer-...",
+      "session_name": "simard-engineer-engineer-...",
+      "host":         "local",
+      "pid":          411902,
+      "created_at":   1745079700,
+      "ended_at":     1745082010,
+      "goal_id":      "goal-7c3e"
+    }
+  ]
+}
+```
+
+Sorting and partitioning rules:
+
+- `live`           = sessions with `ended_at == null`.
+- `recently_ended` = sessions with `ended_at != null` (≤24h by GC invariant).
+- Both arrays are sorted by `created_at` descending.
+- `live ∩ recently_ended = ∅`.
+
+The handler reads the on-disk registry on each call (no in-memory caching at
+the **server** layer) so dashboard polling and OODA writes do not need
+explicit synchronization. The dashboard JavaScript maintains a separate
+**client-side** `subagentSessionsCache` keyed by `agent_id` that is refreshed
+between the 5-second polls; this cache is purely a render-time lookup so
+`renderActionDetail` can build attach buttons without re-fetching. The two
+caches are independent: the server is stateless, the client cache is best-
+effort and rebuilt on every poll.
+
+## Dashboard UI
+
+### Subagent Sessions card (Terminal tab)
+
+A new card with `id="subagent-sessions"` is injected into the existing
+`#tab-terminal` panel. The card is populated by the dashboard JavaScript:
+
+- On Terminal tab activation, an immediate `fetch('/api/subagent-sessions')`.
+- A `setInterval` of **5 seconds** while the tab is active.
+- Cleared when the tab is hidden.
+
+Each row renders as:
+
+```
+<agent_id> · <goal_id> · <status> · [Attach]
+```
+
+Where:
+
+- `<status>` is `live` for the `live` array and `ended <Δ ago>` for
+  `recently_ended`.
+- `[Attach]` is a `<button class="attach-btn" data-cmd="...">Attach →</button>`.
+  Clicking copies the attach command to the clipboard and flashes "Copied!".
+
+The data-cmd value is:
+
+| Host       | data-cmd                                              |
+|------------|-------------------------------------------------------|
+| `local`    | `tmux attach -t simard-engineer-<id>`                 |
+| `<remote>` | `ssh <remote> -t tmux attach -t simard-engineer-<id>` |
+
+### Recent Actions inline Attach links
+
+The dashboard previously rendered Recent Actions `outcome.detail` strings as
+plain text in two locations (overview list near line ~3855, workboard list
+near line ~4740). Both call sites now route through a single shared helper:
+
+```js
+function renderActionDetail(detail) {
+  const re = /agent='(engineer-[A-Za-z0-9_\-]+)'/;
+  const m  = re.exec(detail);
+  if (!m) return escapeHtml(detail);
+
+  const agentId = m[1];
+  const session = subagentSessionsCache.get(agentId); // populated by /api/subagent-sessions
+  if (!session) return escapeHtml(detail);
+
+  const cmd = session.host === 'local'
+    ? `tmux attach -t ${session.session_name}`
+    : `ssh ${session.host} -t tmux attach -t ${session.session_name}`;
+
+  return `${escapeHtml(detail)} <button class="attach-btn" data-cmd="${escapeHtml(cmd)}">Attach →</button>`;
+}
+```
+
+If the regex matches but no registry entry exists (e.g. the session ended >24h
+ago and was garbage-collected), the detail renders as plain text without a
+button.
+
+## Configuration
+
+| Variable             | Default              | Effect                                         |
+|----------------------|----------------------|------------------------------------------------|
+| `SIMARD_STATE_ROOT`  | `$HOME/.simard`      | Overrides registry directory root.             |
+| (none)               | —                    | Polling interval and 24h retention are fixed.  |
+
+There are no new CLI flags. Tracking is on whenever `tmux` is on `PATH`.
+
+## Operational notes
+
+### Manually attaching from another shell
+
+```bash
+tmux attach -t simard-engineer-<sanitized_agent_id>
+# Detach without killing: Ctrl-b d
+```
+
+Listing all currently-tracked sessions:
+
+```bash
+jq -r '.sessions[] | select(.ended_at == null) | .session_name' \
+  ~/.simard/state/subagent_sessions.json
+```
+
+Cross-checking against tmux:
+
+```bash
+tmux ls 2>/dev/null | grep '^simard-engineer-'
+```
+
+### Cleaning up
+
+Killing a tmux session manually is sufficient — the next OODA cycle will
+mark `ended_at` and the entry will be GC'd within 24 hours:
+
+```bash
+tmux kill-session -t simard-engineer-<id>
+```
+
+To wipe the registry entirely (forces all live sessions to be re-discovered
+as "missing" on the next poll):
+
+```bash
+rm ~/.simard/state/subagent_sessions.json
+```
+
+## Failure modes
+
+| Condition                                | Behavior                                                  |
+|------------------------------------------|-----------------------------------------------------------|
+| `tmux` not installed                     | Direct exec fallback; no registry entry; `warn!` logged.  |
+| `pane_pid` query fails                   | One 100ms retry, then fall back to `child.id()`.          |
+| Registry file is corrupt JSON            | `load()` returns empty `Registry`; `warn!` logged.        |
+| Atomic rename fails (e.g. ENOSPC)        | `record_spawn` returns `Err`; spawn caller logs warn and proceeds. |
+| `SIMARD_STATE_ROOT` is read-only         | `record_spawn` returns `Err` (open/rename fails); spawn caller logs warn and proceeds without a registry entry. |
+| `poll_and_gc` errors                     | OODA cycle continues; warn logged.                        |
+| Two writers race                         | Single-process OODA invariant; last-writer-wins.          |
+| Session ends mid-spawn (poll race)       | `record_spawn` writes `ended_at=null`; the very next `poll_and_gc` stamps `ended_at`. Benign — entry simply appears in `recently_ended` instead of `live`. |
+
+## Tests
+
+| Test file                                                  | Coverage                                                                                                  |
+|------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
+| `src/subagent_sessions/tests.rs`                           | Atomic write leaves no `.tmp.*` siblings; round-trip; GC drops `>86400s`-ended; stub probe sets `ended_at`. |
+| `src/agent_supervisor/tests_tmux.rs`                       | `build_tmux_wrapped_command` argv prefix and `2>&1 \| tee -a <log>` tail; shell-quoting of inner argv.    |
+| `src/operator_commands_dashboard/tests_attach.rs`          | `INDEX_HTML.contains("renderActionDetail")`, `"simard-engineer-"`, and regex source `"agent='(engineer-"`. |
+
+Run only the new and adjacent tests:
+
+```bash
+CARGO_TARGET_DIR=/tmp/simard-ws-1015 \
+  cargo test --lib -- subagent_sessions agent_supervisor operator_commands_dashboard
+```
+
+## Invariants
+
+```
+INV1: ∀ s ∈ registry. s.session_name = "simard-engineer-" ++ sanitize(s.agent_id)
+INV2: ∀ s ∈ registry. s.ended_at.is_none() ⟹ probe.alive(s.session_name) at last poll
+INV3: ∀ s ∈ registry. s.ended_at.is_some() ⟹ now() − s.ended_at ≤ 86400
+INV4: save_atomic Ok ⟹ registry_path exists ∧ ∄ sibling "subagent_sessions.json.tmp.<pid>"
+INV5: sanitize(x) matches [A-Za-z0-9_-]+ ∧ non-empty (empty input → "engineer")
+INV6: API: live ∩ recently_ended = ∅
+INV7: Spawn-site registry write failure is non-fatal (warn-only).
+INV8: tmux unavailable ⟹ direct-exec fallback (pre-change behavior preserved).
+```
+
+## See also
+
+- [`docs/howto/view-agent-terminal-logs.md`](../howto/view-agent-terminal-logs.md)
+- [`docs/howto/spawn-engineers-from-ooda-daemon.md`](../howto/spawn-engineers-from-ooda-daemon.md)
+- [`docs/reference/agent-log-websocket.md`](agent-log-websocket.md)

--- a/src/agent_supervisor/lifecycle.rs
+++ b/src/agent_supervisor/lifecycle.rs
@@ -8,7 +8,9 @@ use crate::cognitive_memory::CognitiveMemoryOps;
 use crate::error::{SimardError, SimardResult};
 
 use super::STALE_THRESHOLD_SECONDS;
+use super::tmux::build_tmux_wrapped_command;
 use super::types::{HeartbeatStatus, SubordinateConfig, SubordinateHandle};
+use crate::subagent_sessions::session_name_for;
 
 /// Resolve the Simard state root the same way the dashboard does.
 ///
@@ -97,26 +99,123 @@ pub fn spawn_subordinate(config: &SubordinateConfig) -> SimardResult<Subordinate
         cmd.stdout(out).stderr(err);
     }
 
-    let child = cmd.spawn().map_err(|e| SimardError::BridgeSpawnFailed {
-        bridge: "subordinate".to_string(),
-        reason: format!(
-            "failed to spawn subordinate '{}' at '{}': {e}",
-            config.agent_name,
-            exe.display()
-        ),
-    })?;
+    // --- WS-2: Wrap inner command in a detached tmux session when tmux is
+    //     available, so the dashboard can offer `tmux attach` deep-links.
+    //     If tmux is not on PATH, fall back to direct exec (preserves the
+    //     pre-WS-2 behavior).
+    let tmux_available = Command::new("tmux")
+        .arg("-V")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
 
-    let pid = child.id();
+    let session_name = session_name_for(&config.agent_name);
+    let log_path = supervisor_state_root()
+        .join("agent_logs")
+        .join(format!("{}.log", config.agent_name));
+
+    let (child_pid, applied_session_name) = if tmux_available {
+        // Build the inner argv (must mirror the direct-exec path above).
+        let inner_argv: Vec<String> = vec![
+            exe.to_string_lossy().into_owned(),
+            "engineer".to_string(),
+            "run".to_string(),
+            "single-process".to_string(),
+            config.worktree_path.to_string_lossy().into_owned(),
+            config.goal.clone(),
+        ];
+        let argv = build_tmux_wrapped_command(&session_name, &inner_argv, &log_path);
+
+        // Run the tmux command. `tmux new-session -d` returns immediately
+        // after the session is created; the inner shell runs detached inside.
+        let status = Command::new(&argv[0])
+            .args(&argv[1..])
+            .env("SIMARD_AGENT_NAME", &config.agent_name)
+            .env(
+                "SIMARD_SUBORDINATE_DEPTH",
+                (config.current_depth + 1).to_string(),
+            )
+            .env("CARGO_BUILD_JOBS", "4")
+            .current_dir(&config.worktree_path)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .map_err(|e| SimardError::BridgeSpawnFailed {
+                bridge: "subordinate".to_string(),
+                reason: format!(
+                    "failed to spawn tmux-wrapped subordinate '{}': {e}",
+                    config.agent_name
+                ),
+            })?;
+
+        if !status.success() {
+            return Err(SimardError::BridgeSpawnFailed {
+                bridge: "subordinate".to_string(),
+                reason: format!(
+                    "tmux new-session for subordinate '{}' exited with {status}",
+                    config.agent_name
+                ),
+            });
+        }
+
+        // Query the engineer pid via the pane's pane_pid. Brief retry to
+        // allow the shell to fork its child.
+        let pid = query_pane_pid(&session_name).unwrap_or(0);
+        (pid, session_name.clone())
+    } else {
+        tracing::warn!(
+            target: "simard::supervisor",
+            agent = %config.agent_name,
+            "tmux not available; spawning subordinate directly (no attach support)",
+        );
+        let child = cmd.spawn().map_err(|e| SimardError::BridgeSpawnFailed {
+            bridge: "subordinate".to_string(),
+            reason: format!(
+                "failed to spawn subordinate '{}' at '{}': {e}",
+                config.agent_name,
+                exe.display()
+            ),
+        })?;
+        (child.id(), String::new())
+    };
 
     Ok(SubordinateHandle {
-        pid,
+        pid: child_pid,
         agent_name: config.agent_name.clone(),
         goal: config.goal.clone(),
         worktree_path: config.worktree_path.clone(),
         spawn_time: now,
         retry_count: 0,
         killed: false,
+        session_name: applied_session_name,
     })
+}
+
+/// Query the pane_pid (the engineer process) for a tmux session. Retries once
+/// after 100ms because `tmux new-session -d` returns before the inner shell
+/// has finished forking. Returns None if the session isn't queryable.
+fn query_pane_pid(session_name: &str) -> Option<u32> {
+    for attempt in 0..2 {
+        if attempt > 0 {
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+        let out = Command::new("tmux")
+            .args(["list-panes", "-t", session_name, "-F", "#{pane_pid}"])
+            .output()
+            .ok()?;
+        if !out.status.success() {
+            continue;
+        }
+        let s = String::from_utf8_lossy(&out.stdout);
+        if let Some(line) = s.lines().next()
+            && let Ok(pid) = line.trim().parse::<u32>()
+        {
+            return Some(pid);
+        }
+    }
+    None
 }
 
 /// Check the heartbeat of a subordinate by polling progress from the hive.
@@ -349,6 +448,7 @@ mod tests {
             spawn_time: 0,
             retry_count: 0,
             killed: false,
+            session_name: String::new(),
         };
         // pid=0 means we won't actually send a signal to a real process.
         let result = kill_subordinate(&mut handle);
@@ -366,6 +466,7 @@ mod tests {
             spawn_time: 0,
             retry_count: 0,
             killed: true,
+            session_name: String::new(),
         };
         let result = kill_subordinate(&mut handle);
         assert!(result.is_err());
@@ -475,6 +576,7 @@ mod tests {
             spawn_time: 0,
             retry_count: 0,
             killed: false,
+            session_name: String::new(),
         };
         let (commits, prs) = validate_subordinate_artifacts(&handle);
         assert_eq!(commits, 0);

--- a/src/agent_supervisor/mod.rs
+++ b/src/agent_supervisor/mod.rs
@@ -9,10 +9,13 @@
 //! semantic facts in the hive, never raw IPC.
 
 mod lifecycle;
+pub mod tmux;
 mod types;
 
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod tests_tmux;
 
 /// Maximum retries per goal before the supervisor gives up.
 const MAX_RETRIES_PER_GOAL: u32 = 5;

--- a/src/agent_supervisor/tests.rs
+++ b/src/agent_supervisor/tests.rs
@@ -26,6 +26,7 @@ fn test_handle() -> SubordinateHandle {
         spawn_time: 1_700_000_000,
         retry_count: 0,
         killed: false,
+        session_name: String::new(),
     }
 }
 

--- a/src/agent_supervisor/tests_tmux.rs
+++ b/src/agent_supervisor/tests_tmux.rs
@@ -1,0 +1,98 @@
+//! TDD tests for the tmux command wrapper.
+//!
+//! Specifies the contract for `build_tmux_wrapped_command`: it must produce
+//! a `tmux new-session -d -s <name> sh -c '<quoted inner> 2>&1 | tee -a <log>'`
+//! invocation so existing log-tailing dashboard endpoints keep working.
+
+use std::path::PathBuf;
+
+use super::tmux::build_tmux_wrapped_command;
+
+#[test]
+fn produces_expected_argv_prefix() {
+    let argv = build_tmux_wrapped_command(
+        "simard-engineer-engineer-abc",
+        &["/usr/bin/simard".to_string(), "engineer".to_string(), "run".to_string()],
+        &PathBuf::from("/tmp/agent_logs/engineer-abc.log"),
+    );
+    assert_eq!(argv[0], "tmux", "argv[0] must be tmux");
+    assert_eq!(argv[1], "new-session");
+    assert_eq!(argv[2], "-d");
+    assert_eq!(argv[3], "-s");
+    assert_eq!(argv[4], "simard-engineer-engineer-abc");
+    assert_eq!(argv[5], "sh");
+    assert_eq!(argv[6], "-c");
+    assert_eq!(argv.len(), 8, "must be exactly 8 argv entries");
+}
+
+#[test]
+fn shell_command_pipes_through_tee_to_log() {
+    let argv = build_tmux_wrapped_command(
+        "simard-engineer-x",
+        &["/bin/echo".to_string(), "hi".to_string()],
+        &PathBuf::from("/tmp/agent_logs/x.log"),
+    );
+    let shell = &argv[7];
+    assert!(
+        shell.contains("2>&1 | tee -a"),
+        "shell command must redirect stderr→stdout and tee to log: {shell}"
+    );
+    assert!(
+        shell.contains("/tmp/agent_logs/x.log"),
+        "shell command must reference the log path: {shell}"
+    );
+}
+
+#[test]
+fn shell_command_includes_inner_argv() {
+    let argv = build_tmux_wrapped_command(
+        "simard-engineer-y",
+        &[
+            "/usr/bin/simard".to_string(),
+            "engineer".to_string(),
+            "run".to_string(),
+            "single-process".to_string(),
+        ],
+        &PathBuf::from("/tmp/y.log"),
+    );
+    let shell = &argv[7];
+    assert!(shell.contains("simard"), "must contain inner exe: {shell}");
+    assert!(shell.contains("engineer"), "must contain 'engineer' arg: {shell}");
+    assert!(shell.contains("single-process"), "must contain subcommand: {shell}");
+}
+
+#[test]
+fn shell_command_quotes_arguments_safely() {
+    // Ensure that paths containing spaces or shell metacharacters survive
+    // composition (defensive: paths under /home/Some User/...).
+    let argv = build_tmux_wrapped_command(
+        "simard-engineer-z",
+        &[
+            "/usr/bin/simard".to_string(),
+            "engineer".to_string(),
+            "/path with spaces/wt".to_string(),
+            "implement \"feature\"".to_string(),
+        ],
+        &PathBuf::from("/tmp/z.log"),
+    );
+    let shell = &argv[7];
+    // The quoted form must NOT allow the spaces to split arguments. We
+    // require either single-quoting or backslash escaping somewhere in the
+    // assembled shell string.
+    assert!(
+        shell.contains('\'') || shell.contains('\\'),
+        "inner argv must be shell-quoted/escaped: {shell}"
+    );
+}
+
+#[test]
+fn session_name_is_passed_verbatim_in_dash_s_slot() {
+    // The builder is pure — caller is responsible for sanitizing. The
+    // builder must NOT silently rewrite the session name.
+    let argv = build_tmux_wrapped_command(
+        "simard-engineer-custom-id",
+        &["/bin/true".to_string()],
+        &PathBuf::from("/tmp/t.log"),
+    );
+    assert_eq!(argv[4], "simard-engineer-custom-id");
+}

--- a/src/agent_supervisor/tmux.rs
+++ b/src/agent_supervisor/tmux.rs
@@ -1,0 +1,50 @@
+//! Pure tmux command-line builder for wrapping engineer subprocesses (WS-2).
+
+use std::path::Path;
+
+/// POSIX shell single-quote escape: wrap the value in single quotes,
+/// replacing any embedded `'` with the sequence `'\''`.
+fn shell_single_quote(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('\'');
+    for ch in s.chars() {
+        if ch == '\'' {
+            out.push_str("'\\''");
+        } else {
+            out.push(ch);
+        }
+    }
+    out.push('\'');
+    out
+}
+
+/// Build the argv vector for launching `inner_argv` inside a detached tmux
+/// session named `session_name`, redirecting stdout+stderr through `tee -a`
+/// so `<log_path>` continues to receive the engineer log stream that the
+/// dashboard `/ws/agent_log/{agent}` viewer tails.
+///
+/// Returned shape:
+/// ```text
+/// ["tmux", "new-session", "-d", "-s", <session_name>,
+///  "sh", "-c", "<shell-quoted inner argv> 2>&1 | tee -a <quoted log_path>"]
+/// ```
+pub fn build_tmux_wrapped_command(
+    session_name: &str,
+    inner_argv: &[String],
+    log_path: &Path,
+) -> Vec<String> {
+    let inner_quoted: Vec<String> = inner_argv.iter().map(|s| shell_single_quote(s)).collect();
+    let log_quoted = shell_single_quote(&log_path.to_string_lossy());
+    let shell_cmd = format!("{} 2>&1 | tee -a {}", inner_quoted.join(" "), log_quoted);
+
+    vec![
+        "tmux".to_string(),
+        "new-session".to_string(),
+        "-d".to_string(),
+        "-s".to_string(),
+        session_name.to_string(),
+        "sh".to_string(),
+        "-c".to_string(),
+        shell_cmd,
+    ]
+}

--- a/src/agent_supervisor/types.rs
+++ b/src/agent_supervisor/types.rs
@@ -76,6 +76,10 @@ pub struct SubordinateHandle {
     pub retry_count: u32,
     /// Whether the subordinate has been killed.
     pub killed: bool,
+    /// Name of the tmux session wrapping this subordinate (empty string if
+    /// no tmux wrapping was applied — e.g. tmux unavailable, test handles).
+    #[doc(hidden)]
+    pub session_name: String,
 }
 
 impl Display for SubordinateHandle {
@@ -170,6 +174,7 @@ mod tests {
             spawn_time: 1000,
             retry_count: 0,
             killed: false,
+            session_name: String::new(),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,7 @@ pub mod self_relaunch_semaphore;
 pub mod session;
 pub mod session_builder;
 pub mod skill_builder;
+pub mod subagent_sessions;
 pub mod terminal_engineer_bridge;
 mod terminal_session;
 #[doc(hidden)]

--- a/src/ooda_actions/advance_goal.rs
+++ b/src/ooda_actions/advance_goal.rs
@@ -175,6 +175,34 @@ fn dispatch_spawn_engineer(
                 g.assigned_to = Some(agent_name.clone());
             }
 
+            // WS-2: persist the tmux session into the dashboard registry so
+            // the Recent Actions feed can render Attach deep-links. Failures
+            // are logged but never block subagent execution.
+            if !handle.session_name.is_empty() {
+                let now = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .map(|d| d.as_secs() as i64)
+                    .unwrap_or(0);
+                let record = crate::subagent_sessions::SubagentSession {
+                    agent_id: agent_name.clone(),
+                    session_name: handle.session_name.clone(),
+                    host: "local".to_string(),
+                    pid: handle.pid,
+                    created_at: now,
+                    ended_at: None,
+                    goal_id: goal_id.to_string(),
+                };
+                if let Err(e) = crate::subagent_sessions::record_spawn(record) {
+                    tracing::warn!(
+                        target: "simard::subagent_sessions",
+                        agent = %agent_name,
+                        session = %handle.session_name,
+                        error = %e,
+                        "failed to persist subagent session registry entry; spawn proceeds",
+                    );
+                }
+            }
+
             eprintln!(
                 "[simard] spawn_engineer dispatched: goal='{goal_id}', agent='{agent_name}', pid={}",
                 handle.pid,
@@ -248,6 +276,7 @@ fn advance_goal_with_subordinate(
         spawn_time: 0,
         retry_count: 0,
         killed: false,
+        session_name: String::new(),
     };
 
     match check_heartbeat(&handle, &*bridges.memory) {

--- a/src/ooda_loop/mod.rs
+++ b/src/ooda_loop/mod.rs
@@ -217,6 +217,15 @@ pub fn run_ooda_cycle(
         act_elapsed.as_secs_f64()
     );
 
+    // --- WS-2: poll subagent tmux sessions and GC ended entries (>24h) ---
+    if let Err(e) = crate::subagent_sessions::poll_and_gc(
+        &crate::subagent_sessions::TmuxProbe,
+    ) {
+        eprintln!(
+            "[simard] OODA cycle: subagent_sessions poll/gc failed: {e}"
+        );
+    }
+
     // --- Update goal current_activity from outcomes ---
     for outcome in &outcomes {
         if let Some(goal_id) = &outcome.action.goal_id {

--- a/src/operator_commands_dashboard/mod.rs
+++ b/src/operator_commands_dashboard/mod.rs
@@ -1,5 +1,8 @@
 mod auth;
-mod routes;
+pub(crate) mod routes;
+
+#[cfg(test)]
+mod tests_attach;
 
 use std::net::SocketAddr;
 

--- a/src/operator_commands_dashboard/routes.rs
+++ b/src/operator_commands_dashboard/routes.rs
@@ -54,6 +54,7 @@ pub fn build_router() -> Router {
         .route("/api/workboard", get(workboard))
         .route("/api/current-work", get(current_work))
         .route("/api/ooda-thinking", get(ooda_thinking))
+        .route("/api/subagent-sessions", get(subagent_sessions))
         .route("/ws/chat", get(ws_chat_handler))
         .route(WS_AGENT_LOG_ROUTE, get(ws_agent_log_handler))
         .route("/api/login", post(login))
@@ -3311,7 +3312,32 @@ const LOGIN_HTML: &str = r#"<!DOCTYPE html>
 </html>
 "#;
 
-const INDEX_HTML: &str = r#"<!DOCTYPE html>
+/// WS-2: list live and recently-ended subagent tmux sessions.
+///
+/// Returns `{ live: [...], recently_ended: [...] }` sorted by `created_at`
+/// descending. The dashboard polls this every 5s to populate the Subagent
+/// Sessions card and to drive Attach deep-links in the Recent Actions feed.
+async fn subagent_sessions() -> Json<Value> {
+    let reg = crate::subagent_sessions::load();
+    let mut live: Vec<&crate::subagent_sessions::SubagentSession> = reg
+        .sessions
+        .iter()
+        .filter(|s| s.ended_at.is_none())
+        .collect();
+    let mut ended: Vec<&crate::subagent_sessions::SubagentSession> = reg
+        .sessions
+        .iter()
+        .filter(|s| s.ended_at.is_some())
+        .collect();
+    live.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+    ended.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+    Json(json!({
+        "live": live,
+        "recently_ended": ended,
+    }))
+}
+
+pub(crate) const INDEX_HTML: &str = r#"<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -3695,6 +3721,18 @@ const INDEX_HTML: &str = r#"<!DOCTYPE html>
       </div>
       <div id="xterm-host" style="height:60vh;background:#000;border:1px solid var(--border);border-radius:6px;padding:.25rem"></div>
     </div>
+    <div class="card" style="max-width:980px" id="subagent-sessions">
+      <h2>Subagent Sessions</h2>
+      <div style="background:#1a1a2e;border:1px solid #333;border-radius:6px;padding:.6rem;margin-bottom:.75rem;font-size:.8rem;color:#8b949e">
+        Live and recently-ended engineer subprocesses tracked via tmux.
+        Click <strong>Attach</strong> to copy the <code>tmux attach</code>
+        command for the corresponding <code>simard-engineer-&lt;id&gt;</code>
+        session.
+      </div>
+      <div id="subagent-sessions-list">
+        <span style="color:#8b949e;font-size:.85rem">Loading…</span>
+      </div>
+    </div>
   </div>
 
   <script>
@@ -3726,6 +3764,78 @@ const INDEX_HTML: &str = r#"<!DOCTYPE html>
       );
     }
 
+    /* --- WS-2: Subagent tmux session registry (cached client-side) --- */
+    let subagentSessionsCache={live:[],recently_ended:[],byId:{}};
+    function rebuildSubagentIndex(){
+      const idx={};
+      for(const s of (subagentSessionsCache.live||[])){idx[s.agent_id]=s;}
+      for(const s of (subagentSessionsCache.recently_ended||[])){if(!idx[s.agent_id])idx[s.agent_id]=s;}
+      subagentSessionsCache.byId=idx;
+    }
+    async function fetchSubagentSessions(){
+      try{
+        const d=await apiFetch('/api/subagent-sessions');
+        subagentSessionsCache.live=d.live||[];
+        subagentSessionsCache.recently_ended=d.recently_ended||[];
+        rebuildSubagentIndex();
+        renderSubagentSessions();
+      }catch(e){
+        const el=document.getElementById('subagent-sessions-list');
+        if(el) el.innerHTML='<span class="err">Failed to load subagent sessions: '+esc(e.message||e)+'</span>';
+      }
+    }
+    function attachCommandFor(s){
+      if(s.host && s.host!=='local'){
+        return 'ssh '+s.host+' -t tmux attach -t '+s.session_name;
+      }
+      return 'tmux attach -t '+s.session_name;
+    }
+    function renderSubagentSessions(){
+      const el=document.getElementById('subagent-sessions-list');
+      if(!el) return;
+      const live=subagentSessionsCache.live||[];
+      const ended=subagentSessionsCache.recently_ended||[];
+      if(!live.length && !ended.length){
+        el.innerHTML='<span style="color:#8b949e;font-size:.85rem">No subagent sessions tracked yet.</span>';
+        return;
+      }
+      const row=(s,status)=>{
+        const cmd=attachCommandFor(s);
+        return '<div style="display:flex;gap:.5rem;align-items:baseline;padding:.35rem 0;border-bottom:1px solid var(--border);font-size:.85rem">'
+          +'<code style="min-width:14rem">'+esc(s.agent_id)+'</code>'
+          +'<span style="color:#8b949e;min-width:8rem">'+esc(s.goal_id||'')+'</span>'
+          +'<span class="'+(status==='live'?'ok':'warn')+'" style="min-width:5rem">'+status+'</span>'
+          +'<span style="flex:1;color:#8b949e;font-size:.75rem">pid '+s.pid+' · '+esc(s.host||'local')+'</span>'
+          +'<button class="btn attach-btn" data-cmd="'+esc(cmd)+'" onclick="copyAttachCmd(this)">Attach →</button>'
+          +'</div>';
+      };
+      el.innerHTML=live.map(s=>row(s,'live')).join('')+ended.map(s=>row(s,'ended')).join('');
+    }
+    function copyAttachCmd(btn){
+      const cmd=btn.getAttribute('data-cmd')||'';
+      navigator.clipboard.writeText(cmd).then(()=>{
+        const prev=btn.textContent;btn.textContent='Copied!';
+        setTimeout(()=>{btn.textContent=prev;},900);
+      },()=>{});
+    }
+    /* Shared renderer for Recent Actions outcome.detail strings.
+       Detects agent='engineer-...' references and, when a matching tmux
+       session is in the registry cache, swaps the literal substring for an
+       inline Attach button. Returns an HTML string (caller already escaped
+       the detail). */
+    function renderActionDetail(detail){
+      const safe=esc(detail||'');
+      const re=/agent='(engineer-[A-Za-z0-9_-]+)'/;
+      const m=safe.match(re);
+      if(!m) return safe;
+      const agentId=m[1];
+      const session=subagentSessionsCache.byId[agentId];
+      if(!session) return safe;
+      const cmd=attachCommandFor(session);
+      const btn=' <button class="btn attach-btn" data-cmd="'+esc(cmd)+'" onclick="copyAttachCmd(this)" style="font-size:.7rem;padding:.05rem .35rem;margin-left:.25rem">Attach →</button>';
+      return safe.replace(m[0], m[0]+btn);
+    }
+
     /* --- Active tab tracking for auto-refresh --- */
     let activeTab='overview';
     let tabRefreshTimers={};
@@ -3751,7 +3861,7 @@ const INDEX_HTML: &str = r#"<!DOCTYPE html>
         if(tab.dataset.tab==='chat') initChat();
         if(tab.dataset.tab==='workboard') {fetchWorkboard();tabRefreshTimers.wb=setInterval(fetchWorkboard,30000);}
         if(tab.dataset.tab==='thinking') {fetchThinking();tabRefreshTimers.thinking=setInterval(fetchThinking,30000);}
-        if(tab.dataset.tab==='terminal') initAgentLogTerminal();
+        if(tab.dataset.tab==='terminal') {initAgentLogTerminal();fetchSubagentSessions();tabRefreshTimers.subagent=setInterval(fetchSubagentSessions,5000);}
       });
     });
     setInterval(()=>{document.getElementById('clock').textContent=new Date().toLocaleString()},1000);
@@ -3868,7 +3978,7 @@ const INDEX_HTML: &str = r#"<!DOCTYPE html>
               <span style="color:var(--accent);min-width:2rem;font-weight:600">#${a.cycle}</span>
               <span>${a.success?'✅':'❌'}</span>
               <code>${esc(a.action_kind||'')}</code>
-              <span style="flex:1">${esc((function(){var arr=Array.from(a.detail||'');var d=arr.length>200?arr.slice(0,200).join('')+'…':arr.join('');return d||a.action_description||'';})())}</span>
+              <span style="flex:1">${renderActionDetail((function(){var arr=Array.from(a.detail||'');var d=arr.length>200?arr.slice(0,200).join('')+'…':arr.join('');return d||a.action_description||'';})())}</span>
             </div>`).join('');
         }else{
           actEl.innerHTML='<span style="color:#8b949e">No structured action history yet. The OODA daemon records actions each cycle.</span>';
@@ -4743,7 +4853,7 @@ const INDEX_HTML: &str = r#"<!DOCTYPE html>
             return`<div style="display:flex;gap:.5rem;padding:.35rem 0;border-bottom:1px solid var(--border);font-size:.85rem">
               <span style="color:var(--accent);min-width:2.5rem;font-weight:600">#${a.cycle}</span>
               <span style="min-width:5rem;color:${isCurrent?'var(--green)':'#8b949e'}">${esc(a.action)}</span>
-              <span style="flex:1">${esc(a.result)}</span>
+              <span style="flex:1">${renderActionDetail(a.result)}</span>
               ${a.at?'<span style="color:#8b949e;font-size:.75rem">'+timeAgo(a.at)+'</span>':''}
             </div>`;
           }).join('');

--- a/src/operator_commands_dashboard/tests_attach.rs
+++ b/src/operator_commands_dashboard/tests_attach.rs
@@ -1,0 +1,62 @@
+//! TDD smoke tests for the dashboard Subagent Sessions card and the
+//! Recent Actions Attach deep-link renderer.
+//!
+//! These assert that the embedded `INDEX_HTML` contains the expected JS
+//! helper, the registry session-name prefix, and the agent_id-extracting
+//! regex source. They will fail until Step 8 wires the UI in.
+
+use super::routes::INDEX_HTML;
+
+#[test]
+fn index_html_defines_render_action_detail_helper() {
+    assert!(
+        INDEX_HTML.contains("renderActionDetail"),
+        "INDEX_HTML must define a shared renderActionDetail helper used by \
+         both the overview and workboard Recent Actions renderers"
+    );
+}
+
+#[test]
+fn index_html_references_simard_engineer_session_prefix() {
+    assert!(
+        INDEX_HTML.contains("simard-engineer-"),
+        "INDEX_HTML must reference the 'simard-engineer-' tmux session prefix \
+         (used to construct attach commands)"
+    );
+}
+
+#[test]
+fn index_html_contains_agent_id_extraction_regex() {
+    assert!(
+        INDEX_HTML.contains("agent='(engineer-"),
+        "INDEX_HTML must contain the agent='engineer-...' regex source \
+         used to extract agent_id from outcome detail strings"
+    );
+}
+
+#[test]
+fn index_html_has_subagent_sessions_card() {
+    assert!(
+        INDEX_HTML.contains("subagent-sessions"),
+        "INDEX_HTML must include the SubagentSessions dashboard card \
+         (id=\"subagent-sessions\")"
+    );
+}
+
+#[test]
+fn index_html_calls_subagent_sessions_api() {
+    assert!(
+        INDEX_HTML.contains("/api/subagent-sessions"),
+        "INDEX_HTML must fetch /api/subagent-sessions for the live registry"
+    );
+}
+
+#[test]
+fn index_html_has_attach_button_class_or_label() {
+    let has_class = INDEX_HTML.contains("attach-btn");
+    let has_label = INDEX_HTML.contains("Attach");
+    assert!(
+        has_class && has_label,
+        "INDEX_HTML must render Attach buttons (class=\"attach-btn\" + label \"Attach\")"
+    );
+}

--- a/src/subagent_sessions/mod.rs
+++ b/src/subagent_sessions/mod.rs
@@ -1,0 +1,216 @@
+//! Subagent tmux session registry (WS-2).
+//!
+//! Tracks engineer subprocesses launched inside tmux sessions so the
+//! dashboard can surface live and recently-ended sessions and offer
+//! `tmux attach` deep-links from the Recent Actions feed.
+
+use std::fs;
+use std::io::{self, Write};
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+/// Sessions ended more than this many seconds ago are GC'd.
+pub const RETENTION_SECONDS: i64 = 86_400;
+
+/// One row in the registry.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SubagentSession {
+    pub agent_id: String,
+    pub session_name: String,
+    pub host: String,
+    pub pid: u32,
+    pub created_at: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ended_at: Option<i64>,
+    pub goal_id: String,
+}
+
+/// On-disk registry shape.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Registry {
+    #[serde(default)]
+    pub sessions: Vec<SubagentSession>,
+}
+
+/// Probe abstraction so polling can be unit-tested without a real tmux.
+pub trait SessionProbe {
+    fn alive(&self, session_name: &str) -> bool;
+}
+
+/// Real probe: shells out to `tmux has-session -t <name>`.
+pub struct TmuxProbe;
+
+impl SessionProbe for TmuxProbe {
+    fn alive(&self, session_name: &str) -> bool {
+        match Command::new("tmux")
+            .args(["has-session", "-t", session_name])
+            .output()
+        {
+            Ok(o) => o.status.success(),
+            Err(_) => false,
+        }
+    }
+}
+
+/// Resolve the state root: `SIMARD_STATE_ROOT` env or `$HOME/.simard`.
+fn state_root() -> PathBuf {
+    if let Ok(v) = std::env::var("SIMARD_STATE_ROOT") {
+        return PathBuf::from(v);
+    }
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
+    PathBuf::from(home).join(".simard")
+}
+
+/// Returns the on-disk registry path: `<state_root>/state/subagent_sessions.json`.
+pub fn registry_path() -> PathBuf {
+    state_root().join("state").join("subagent_sessions.json")
+}
+
+fn now_epoch_seconds() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+/// Load the registry from disk. Returns empty `Registry` on missing/corrupt.
+pub fn load() -> Registry {
+    let path = registry_path();
+    let bytes = match fs::read(&path) {
+        Ok(b) => b,
+        Err(e) => {
+            if e.kind() != io::ErrorKind::NotFound {
+                tracing::warn!(
+                    target: "simard::subagent_sessions",
+                    path = %path.display(),
+                    error = %e,
+                    "failed to read subagent registry; returning empty",
+                );
+            }
+            return Registry::default();
+        }
+    };
+    match serde_json::from_slice::<Registry>(&bytes) {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!(
+                target: "simard::subagent_sessions",
+                path = %path.display(),
+                error = %e,
+                "failed to parse subagent registry; returning empty",
+            );
+            Registry::default()
+        }
+    }
+}
+
+/// Atomic write: write to a uniquely-named temp file in the same directory,
+/// then `rename`. Removes the temp file on any failure so no `.tmp.*`
+/// stragglers are left behind.
+pub fn save_atomic(reg: &Registry) -> io::Result<()> {
+    let path = registry_path();
+    let parent = path.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "registry_path has no parent directory",
+        )
+    })?;
+    fs::create_dir_all(parent)?;
+
+    let tmp = parent.join(format!(
+        "subagent_sessions.json.tmp.{}",
+        std::process::id()
+    ));
+
+    let serialized = serde_json::to_vec_pretty(reg).map_err(io::Error::other)?;
+
+    let write_result = (|| -> io::Result<()> {
+        let mut f = fs::File::create(&tmp)?;
+        f.write_all(&serialized)?;
+        f.sync_all()?;
+        Ok(())
+    })();
+
+    if let Err(e) = write_result {
+        let _ = fs::remove_file(&tmp);
+        return Err(e);
+    }
+
+    if let Err(e) = fs::rename(&tmp, &path) {
+        let _ = fs::remove_file(&tmp);
+        return Err(e);
+    }
+    Ok(())
+}
+
+/// Append a new session record (load → push → save_atomic).
+pub fn record_spawn(session: SubagentSession) -> io::Result<()> {
+    let mut reg = load();
+    reg.sessions.push(session);
+    save_atomic(&reg)
+}
+
+/// Mark dead sessions as ended; GC entries ended >24h ago.
+pub fn poll_and_gc<R: SessionProbe>(probe: &R) -> io::Result<()> {
+    let mut reg = load();
+    let now = now_epoch_seconds();
+
+    for s in reg.sessions.iter_mut() {
+        if s.ended_at.is_some() {
+            continue;
+        }
+        if !probe.alive(&s.session_name) {
+            s.ended_at = Some(now);
+            tracing::info!(
+                target: "simard::subagent_sessions",
+                agent_id = %s.agent_id,
+                session_name = %s.session_name,
+                "subagent session ended (tmux has-session = false)",
+            );
+        }
+    }
+
+    let before = reg.sessions.len();
+    reg.sessions.retain(|s| match s.ended_at {
+        Some(end) => now - end <= RETENTION_SECONDS,
+        None => true,
+    });
+    let pruned = before - reg.sessions.len();
+    if pruned > 0 {
+        tracing::info!(
+            target: "simard::subagent_sessions",
+            pruned,
+            "GC'd subagent sessions ended >24h ago",
+        );
+    }
+
+    save_atomic(&reg)
+}
+
+/// Sanitize an agent_id for use in a tmux session name.
+/// Replaces `[^A-Za-z0-9_-]` with `-`. Empty input becomes `"engineer"`.
+pub fn sanitize_id(raw: &str) -> String {
+    if raw.is_empty() {
+        return "engineer".to_string();
+    }
+    raw.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
+/// Convenience: produce the canonical tmux session name for an agent id.
+pub fn session_name_for(agent_id: &str) -> String {
+    format!("simard-engineer-{}", sanitize_id(agent_id))
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/subagent_sessions/tests.rs
+++ b/src/subagent_sessions/tests.rs
@@ -1,0 +1,237 @@
+//! TDD tests for the subagent_sessions registry module.
+//!
+//! These are written FIRST per the TDD discipline and will fail until
+//! Step 8 implements the module. They define the contract for:
+//!  - atomic write semantics (no `.tmp.*` siblings left behind)
+//!  - round-trip serialization
+//!  - GC of entries ended > 24h ago
+//!  - probe-driven `ended_at` marking
+//!  - id sanitization rules
+
+use std::cell::RefCell;
+use std::collections::HashSet;
+use std::fs;
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use super::*;
+
+/// Serialize tests that mutate the SIMARD_STATE_ROOT env var.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+fn fresh_tempdir(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "simard-subagent-test-{}-{}-{}",
+        tag,
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos(),
+    ));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn with_state_root<F: FnOnce(&PathBuf) -> R, R>(tag: &str, f: F) -> R {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let root = fresh_tempdir(tag);
+    // SAFETY: serialized via ENV_LOCK; tests are single-threaded under this guard.
+    unsafe { std::env::set_var("SIMARD_STATE_ROOT", &root) };
+    let result = f(&root);
+    unsafe { std::env::remove_var("SIMARD_STATE_ROOT") };
+    result
+}
+
+fn sample(agent_id: &str, ended_at: Option<i64>) -> SubagentSession {
+    SubagentSession {
+        agent_id: agent_id.to_string(),
+        session_name: format!("simard-engineer-{agent_id}"),
+        host: "local".to_string(),
+        pid: 12345,
+        created_at: 1_700_000_000,
+        ended_at,
+        goal_id: "goal-abc".to_string(),
+    }
+}
+
+#[test]
+fn registry_path_honors_state_root_env() {
+    with_state_root("path-env", |root| {
+        let p = registry_path();
+        assert!(
+            p.starts_with(root),
+            "registry_path() {p:?} should start with SIMARD_STATE_ROOT {root:?}"
+        );
+        assert!(
+            p.ends_with("subagent_sessions.json"),
+            "registry_path() basename must be subagent_sessions.json: {p:?}"
+        );
+    });
+}
+
+#[test]
+fn load_returns_empty_when_missing() {
+    with_state_root("empty", |_root| {
+        let reg = load();
+        assert!(reg.sessions.is_empty(), "missing file → empty registry");
+    });
+}
+
+#[test]
+fn save_atomic_round_trips_and_creates_parent_dir() {
+    with_state_root("rt", |_root| {
+        let reg = Registry {
+            sessions: vec![
+                sample("engineer-aaa", None),
+                sample("engineer-bbb", Some(1_700_000_500)),
+            ],
+        };
+        save_atomic(&reg).expect("save_atomic must succeed");
+        let loaded = load();
+        assert_eq!(loaded, reg, "round-trip must preserve registry exactly");
+    });
+}
+
+#[test]
+fn save_atomic_leaves_no_tmp_siblings() {
+    with_state_root("atomic", |_root| {
+        let reg = Registry {
+            sessions: vec![sample("engineer-x", None)],
+        };
+        save_atomic(&reg).expect("save_atomic must succeed");
+
+        let path = registry_path();
+        let parent = path.parent().expect("registry path must have parent");
+        let stragglers: Vec<_> = fs::read_dir(parent)
+            .expect("parent dir must be readable")
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|name| name.contains("subagent_sessions.json.tmp"))
+            .collect();
+        assert!(
+            stragglers.is_empty(),
+            "atomic write must not leave .tmp.* siblings, found: {stragglers:?}"
+        );
+    });
+}
+
+#[test]
+fn record_spawn_appends_to_registry() {
+    with_state_root("rec", |_root| {
+        record_spawn(sample("engineer-1", None)).unwrap();
+        record_spawn(sample("engineer-2", None)).unwrap();
+        let reg = load();
+        let ids: HashSet<_> = reg.sessions.iter().map(|s| s.agent_id.clone()).collect();
+        assert!(ids.contains("engineer-1"));
+        assert!(ids.contains("engineer-2"));
+    });
+}
+
+struct StubProbe {
+    alive_set: HashSet<String>,
+    queries: RefCell<Vec<String>>,
+}
+
+impl SessionProbe for StubProbe {
+    fn alive(&self, session_name: &str) -> bool {
+        self.queries.borrow_mut().push(session_name.to_string());
+        self.alive_set.contains(session_name)
+    }
+}
+
+#[test]
+fn poll_and_gc_marks_dead_sessions_with_ended_at() {
+    with_state_root("poll", |_root| {
+        record_spawn(sample("engineer-live", None)).unwrap();
+        record_spawn(sample("engineer-dead", None)).unwrap();
+        let alive_set: HashSet<_> = ["simard-engineer-engineer-live".to_string()]
+            .into_iter()
+            .collect();
+        let probe = StubProbe {
+            alive_set,
+            queries: RefCell::new(Vec::new()),
+        };
+        poll_and_gc(&probe).expect("poll_and_gc must succeed");
+
+        let reg = load();
+        let live = reg
+            .sessions
+            .iter()
+            .find(|s| s.agent_id == "engineer-live")
+            .expect("live session must remain");
+        assert!(live.ended_at.is_none(), "live session must NOT have ended_at");
+
+        let dead = reg
+            .sessions
+            .iter()
+            .find(|s| s.agent_id == "engineer-dead")
+            .expect("dead session must remain (within 24h)");
+        assert!(
+            dead.ended_at.is_some(),
+            "dead session must have ended_at populated"
+        );
+    });
+}
+
+#[test]
+fn poll_and_gc_drops_entries_ended_more_than_24h_ago() {
+    with_state_root("gc", |_root| {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        let stale = SubagentSession {
+            ended_at: Some(now - 86_400 - 60), // > 24h ago
+            ..sample("engineer-stale", Some(now - 86_400 - 60))
+        };
+        let recent = SubagentSession {
+            ended_at: Some(now - 60),
+            ..sample("engineer-recent", Some(now - 60))
+        };
+        save_atomic(&Registry {
+            sessions: vec![stale, recent],
+        })
+        .unwrap();
+
+        let probe = StubProbe {
+            alive_set: HashSet::new(),
+            queries: RefCell::new(Vec::new()),
+        };
+        poll_and_gc(&probe).expect("poll_and_gc must succeed");
+
+        let reg = load();
+        let ids: HashSet<_> = reg.sessions.iter().map(|s| s.agent_id.clone()).collect();
+        assert!(
+            !ids.contains("engineer-stale"),
+            "entry ended >24h ago must be GC'd"
+        );
+        assert!(
+            ids.contains("engineer-recent"),
+            "entry ended <24h ago must be retained"
+        );
+    });
+}
+
+#[test]
+fn sanitize_id_replaces_unsafe_chars_with_dash() {
+    assert_eq!(sanitize_id("engineer-abc_123"), "engineer-abc_123");
+    assert_eq!(sanitize_id("engineer/with spaces"), "engineer-with-spaces");
+    assert_eq!(sanitize_id("foo$bar*baz"), "foo-bar-baz");
+}
+
+#[test]
+fn sanitize_id_empty_input_becomes_engineer() {
+    assert_eq!(sanitize_id(""), "engineer");
+}
+
+#[test]
+fn sanitize_id_output_matches_safe_charset() {
+    let out = sanitize_id("weird!@#$%^&*()chars");
+    assert!(
+        out.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'),
+        "sanitize_id output must only contain [A-Za-z0-9_-]: got {out:?}"
+    );
+    assert!(!out.is_empty());
+}

--- a/tests/composition.rs
+++ b/tests/composition.rs
@@ -101,6 +101,7 @@ fn test_handle(name: &str, goal: &str) -> SubordinateHandle {
         spawn_time: now_epoch(),
         retry_count: 0,
         killed: false,
+        session_name: String::new(),
     }
 }
 


### PR DESCRIPTION
WS-2 SUBAGENT-TMUX-TRACKING — wraps engineer subprocess spawns in detached tmux sessions and exposes them via the dashboard with one-click `tmux attach` deep-links from the Recent Actions feed.

## Changes

**New module `src/subagent_sessions/`**
- Registry on disk at `<state_root>/state/subagent_sessions.json` (honors `SIMARD_STATE_ROOT`).
- Atomic writes via temp-file + rename.
- `SessionProbe` trait + `TmuxProbe` for unit-testable polling.
- `poll_and_gc`: marks dead sessions with `ended_at`, drops entries ended >24h ago.
- `sanitize_id`: `[^A-Za-z0-9_-]` → `-`; empty → `engineer`.

**Spawn site (`src/agent_supervisor/`)**
- New `tmux::build_tmux_wrapped_command` produces `tmux new-session -d -s … sh -c '<argv> 2>&1 | tee -a <log>'`.
- `spawn_subordinate` wraps in tmux when available, queries pane_pid; falls back to direct exec when tmux missing.
- `SubordinateHandle` gains `session_name: String`.

**Registry write (`src/ooda_actions/advance_goal.rs`)**
- After successful spawn, persists `{agent_id, session_name, host:'local', pid, created_at, goal_id}`. Failures are warned, never fatal.

**OODA hook (`src/ooda_loop/mod.rs`)**
- After Act phase: `subagent_sessions::poll_and_gc(&TmuxProbe)`.

**Dashboard (`src/operator_commands_dashboard/`)**
- New API `GET /api/subagent-sessions` → `{ live, recently_ended }`.
- Terminal tab card `#subagent-sessions` with copyable Attach commands; 5s refresh.
- Shared JS helper `renderActionDetail` injects inline `Attach →` buttons in both Recent Actions renderers.

## Tests
21 new tests pass; 254 related existing tests still pass. `cargo check --lib` clean.

## Out of scope
Remote spawn (host hardcoded `local`); ssh form is forward-compat only.