### PR TITLE
fix(ooda): consume LLM step.target in selector + per-goal failure cooldown

### DIFF
--- a/prompt_assets/simard/engineer_planning.md
+++ b/prompt_assets/simard/engineer_planning.md
@@ -1,4 +1,27 @@
 You are an engineer planning assistant. Produce a JSON array of plan steps.
-Each step: {"action": "<snake_case>", "target": "<path_or_cmd>", "expected_outcome": "<text>", "verification_command": "<shell_cmd>"}
-Valid actions: create_file, append_to_file, run_shell_command, git_commit, open_issue, structured_text_replace, cargo_test, read_only_scan
-Return ONLY the JSON array.
+
+Each step MUST be an object with these fields:
+  - "action": one of [create_file, append_to_file, run_shell_command, git_commit, open_issue, structured_text_replace, cargo_test, read_only_scan]
+  - "target": the CONCRETE artefact the action operates on:
+      * For run_shell_command: the exact argv to execute (e.g. "gh issue view 915").
+        The first token MUST be one of: cargo, gh, git, ls, cat, grep, rg, find, wc, head, tail, jq.
+        DO NOT put prose in `target`. DO NOT put multi-line plans in `target`.
+      * For create_file / append_to_file: the file path (e.g. "src/foo.rs").
+      * For git_commit: the commit message (single line, no shell metachars).
+      * For open_issue: the issue title (single line).
+      * For structured_text_replace: the relative file path being edited.
+      * For cargo_test / read_only_scan: may be empty.
+  - "expected_outcome": one short sentence describing success.
+  - "verification_command": a shell command (allowlisted prefix) whose exit-zero proves the step worked.
+
+Decompose multi-paragraph or multi-task objectives into ATOMIC steps. Do NOT collapse a multi-step plan into a single run_shell_command whose target is the entire plan as prose — that will be rejected. Each step is one tool invocation.
+
+If the objective cannot be decomposed into supported actions, return an empty array `[]` and the planner will report PlanningUnavailable.
+
+Return ONLY the JSON array — no markdown fences, no prose preamble, no trailing commentary.
+
+Example for objective "verify issue 915 exists and read its body":
+[
+  {"action":"run_shell_command","target":"gh issue view 915","expected_outcome":"issue 915 metadata printed","verification_command":"gh issue view 915"}
+]
+

--- a/src/engineer_loop/mod.rs
+++ b/src/engineer_loop/mod.rs
@@ -52,7 +52,12 @@ pub(crate) const EXECUTION_SCOPE: &str = "local-only";
 pub(crate) const MAX_CARRIED_MEETING_DECISIONS: usize = 3;
 pub(crate) const GIT_COMMAND_TIMEOUT_SECS: u64 = 60;
 pub(crate) const CARGO_COMMAND_TIMEOUT_SECS: u64 = 120;
-pub(crate) const SHELL_COMMAND_ALLOWLIST: &[&str] = &["cargo", "git", "gh", "rustfmt", "clippy"];
+pub(crate) const SHELL_COMMAND_ALLOWLIST: &[&str] = &[
+    // Mutating / build / VCS — produce real work
+    "cargo", "git", "gh", "rustfmt", "clippy",
+    // Read-only inspection — safe for engineers to use during planning
+    "ls", "cat", "grep", "rg", "find", "wc", "head", "tail", "jq",
+];
 
 pub(crate) const CLEARED_GIT_ENV_VARS: &[&str] = &[
     "GIT_DIR",

--- a/src/engineer_loop/selection.rs
+++ b/src/engineer_loop/selection.rs
@@ -139,6 +139,22 @@ pub(crate) fn select_append_to_file(
 
 pub(crate) fn select_shell_command(objective: &str, note: &str) -> Option<SelectedEngineerAction> {
     let argv = extract_command_from_objective(objective)?;
+    select_shell_command_from_argv(argv, note, "Objective")
+}
+
+/// Build a shell-command action from an explicit argv vector.
+///
+/// Used when the LLM-produced `PlanStep.target` already contains the
+/// concrete command, so we do not need to re-extract it from a prose
+/// objective. The allowlist is enforced identically.
+pub(crate) fn select_shell_command_from_argv(
+    argv: Vec<String>,
+    note: &str,
+    source_label: &str,
+) -> Option<SelectedEngineerAction> {
+    if argv.is_empty() {
+        return None;
+    }
     let first = argv.first().cloned().unwrap_or_default();
     if !SHELL_COMMAND_ALLOWLIST.contains(&first.as_str()) {
         return None;
@@ -146,7 +162,7 @@ pub(crate) fn select_shell_command(objective: &str, note: &str) -> Option<Select
     Some(SelectedEngineerAction {
         label: "run-shell-command".to_string(),
         rationale: format!(
-            "Objective requests running '{}', which is in the shell allowlist.{note}",
+            "{source_label} requests running '{}', which is in the shell allowlist.{note}",
             argv.join(" ")
         ),
         argv: argv.clone(),
@@ -155,6 +171,26 @@ pub(crate) fn select_shell_command(objective: &str, note: &str) -> Option<Select
         expected_changed_files: Vec::new(),
         kind: EngineerActionKind::RunShellCommand(ShellCommandRequest { argv }),
     })
+}
+
+/// Tokenise an LLM-supplied target string into argv.
+///
+/// LLMs emit shell-command targets in two common forms:
+///   * Plain space-separated argv (`"gh issue view 915"`).
+///   * Backtick- or quote-wrapped (`"`gh issue view 915`"`).
+///
+/// We strip surrounding backticks/quotes and split on whitespace. This
+/// is intentionally simple — the allowlist gate in
+/// `select_shell_command_from_argv` rejects anything that does not begin
+/// with a vetted binary, so adversarial parsing is not required here.
+pub(crate) fn tokenise_target_argv(target: &str) -> Vec<String> {
+    let trimmed = target.trim();
+    let unwrapped = trimmed
+        .trim_matches('`')
+        .trim_matches('\'')
+        .trim_matches('"')
+        .trim();
+    unwrapped.split_whitespace().map(String::from).collect()
 }
 
 pub(crate) fn select_git_commit(objective: &str, note: &str) -> SelectedEngineerAction {
@@ -543,7 +579,20 @@ pub(crate) fn select_cargo_action(objective: &str, note: &str) -> SelectedEngine
 /// Check whether a keyword-analyzed action is achievable given the current
 /// objective and context. Returns `true` when the action is safe to proceed
 /// with, `false` when it should be demoted to a safe default.
+#[allow(dead_code)] // retained for tests + back-compat callers
 pub(crate) fn is_keyword_action_achievable(action: &AnalyzedAction, objective: &str) -> bool {
+    is_action_achievable(action, objective, None)
+}
+
+/// Like [`is_keyword_action_achievable`] but also considers the LLM's
+/// explicit `PlanStep.target` field. RunShellCommand is achievable when
+/// the target tokenises to an allowlisted command, even if the objective
+/// itself is prose.
+pub(crate) fn is_action_achievable(
+    action: &AnalyzedAction,
+    objective: &str,
+    llm_target: Option<&str>,
+) -> bool {
     match action {
         // These are always safe — they don't mutate the repo.
         AnalyzedAction::ReadOnlyScan | AnalyzedAction::CargoTest => true,
@@ -576,8 +625,14 @@ pub(crate) fn is_keyword_action_achievable(action: &AnalyzedAction, objective: &
             }
             true
         }
-        // CreateFile / AppendToFile: need a discernible file path in the objective.
+        // CreateFile / AppendToFile: need a discernible file path in the objective
+        // OR in the LLM's target field.
         AnalyzedAction::CreateFile | AnalyzedAction::AppendToFile => {
+            if let Some(target) = llm_target
+                && !target.trim().is_empty()
+            {
+                return true;
+            }
             extract_file_path_from_objective(objective).is_some()
         }
         // StructuredTextReplace: needs edit-like directives.
@@ -585,8 +640,20 @@ pub(crate) fn is_keyword_action_achievable(action: &AnalyzedAction, objective: &
             let lower = objective.to_lowercase();
             lower.contains("replace") || lower.contains("edit-file") || lower.contains("update")
         }
-        // RunShellCommand: needs an extractable command that is not a prose fragment.
-        AnalyzedAction::RunShellCommand => extract_command_from_objective(objective).is_some(),
+        // RunShellCommand: achievable when either the LLM provided a target
+        // whose first token is allowlisted, or the objective contains an
+        // extractable allowlisted command.
+        AnalyzedAction::RunShellCommand => {
+            if let Some(target) = llm_target {
+                let argv = tokenise_target_argv(target);
+                if let Some(first) = argv.first()
+                    && SHELL_COMMAND_ALLOWLIST.contains(&first.as_str())
+                {
+                    return true;
+                }
+            }
+            extract_command_from_objective(objective).is_some()
+        }
     }
 }
 
@@ -607,22 +674,20 @@ pub(crate) fn select_engineer_action(
     // failure here propagates as PlanningUnavailable so the cycle reports a
     // real failure instead of fabricating progress.
     let plan = crate::engineer_plan::plan_objective(objective, inspection)?;
-    let analyzed = if let Some(step) = plan.steps().first() {
-        let action = &step.action;
-        if !is_keyword_action_achievable(action, objective) {
-            return Err(SimardError::PlanningUnavailable {
-                reason: format!(
-                    "LLM plan selected action {:?} which is not achievable for objective: {}",
-                    action, objective
-                ),
-            });
-        }
-        action.clone()
-    } else {
-        return Err(SimardError::PlanningUnavailable {
+    let first_step = plan.steps().first().cloned().ok_or_else(|| {
+        SimardError::PlanningUnavailable {
             reason: format!("LLM plan returned zero steps for objective: {objective}"),
+        }
+    })?;
+    let analyzed = first_step.action.clone();
+    if !is_action_achievable(&analyzed, objective, Some(&first_step.target)) {
+        return Err(SimardError::PlanningUnavailable {
+            reason: format!(
+                "LLM plan selected action {:?} with target {:?} which is not achievable for objective: {}",
+                analyzed, first_step.target, objective
+            ),
         });
-    };
+    }
 
     match analyzed {
         AnalyzedAction::CreateFile => {
@@ -636,9 +701,24 @@ pub(crate) fn select_engineer_action(
             }
         }
         AnalyzedAction::RunShellCommand => {
+            // Prefer the LLM's explicit target field — it already contains
+            // the concrete argv. Fall back to objective extraction only if
+            // the target is empty (older planner outputs).
+            let argv = tokenise_target_argv(&first_step.target);
+            if !argv.is_empty()
+                && let Some(action) = select_shell_command_from_argv(argv, &note, "LLM plan step")
+            {
+                return Ok(action);
+            }
             if let Some(action) = select_shell_command(objective, &note) {
                 return Ok(action);
             }
+            return Err(SimardError::PlanningUnavailable {
+                reason: format!(
+                    "LLM plan step selected RunShellCommand but target {:?} is empty or not in the shell allowlist (objective: {})",
+                    first_step.target, objective
+                ),
+            });
         }
         AnalyzedAction::GitCommit => return Ok(select_git_commit(objective, &note)),
         AnalyzedAction::OpenIssue => return select_open_issue(objective, &note),
@@ -1144,5 +1224,123 @@ mod tests {
             &AnalyzedAction::OpenIssue,
             "backtrack the change"
         ));
+    }
+
+    // ──────────────────────────────────────────────────────────
+    // Regression coverage for fix/planner-shape-and-backoff:
+    // selector now consumes PlanStep.target instead of re-extracting
+    // argv from prose. These tests pin the new behavior.
+    // ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn tokenise_target_argv_strips_backticks() {
+        let argv = tokenise_target_argv("`gh issue view 915`");
+        assert_eq!(argv, vec!["gh", "issue", "view", "915"]);
+    }
+
+    #[test]
+    fn tokenise_target_argv_strips_double_quotes() {
+        let argv = tokenise_target_argv("\"cargo check --lib\"");
+        assert_eq!(argv, vec!["cargo", "check", "--lib"]);
+    }
+
+    #[test]
+    fn tokenise_target_argv_strips_single_quotes() {
+        let argv = tokenise_target_argv("'git status'");
+        assert_eq!(argv, vec!["git", "status"]);
+    }
+
+    #[test]
+    fn tokenise_target_argv_handles_extra_whitespace() {
+        let argv = tokenise_target_argv("  gh   issue  view   915  ");
+        assert_eq!(argv, vec!["gh", "issue", "view", "915"]);
+    }
+
+    #[test]
+    fn tokenise_target_argv_empty_returns_empty() {
+        assert!(tokenise_target_argv("").is_empty());
+        assert!(tokenise_target_argv("   ").is_empty());
+        assert!(tokenise_target_argv("``").is_empty());
+    }
+
+    #[test]
+    fn select_shell_command_from_argv_accepts_gh() {
+        let action =
+            select_shell_command_from_argv(vec!["gh".into(), "issue".into(), "view".into(), "915".into()], "note", "test")
+                .expect("gh is allowlisted");
+        assert_eq!(action.argv[0], "gh");
+        assert_eq!(action.argv.len(), 4);
+    }
+
+    #[test]
+    fn select_shell_command_from_argv_rejects_non_allowlisted() {
+        let action = select_shell_command_from_argv(
+            vec!["curl".into(), "https://example.com".into()],
+            "note",
+            "test",
+        );
+        assert!(action.is_none(), "curl must not be allowlisted");
+    }
+
+    #[test]
+    fn select_shell_command_from_argv_rejects_empty_argv() {
+        assert!(select_shell_command_from_argv(vec![], "note", "test").is_none());
+    }
+
+    #[test]
+    fn is_action_achievable_runshell_with_llm_target_passes() {
+        // Objective is multi-paragraph prose that the keyword extractor
+        // would fail on, but the LLM provided a concrete allowlisted target.
+        let prose = "Investigate issue 915 thoroughly. Read its body. Comment on findings.\n\
+                     Several paragraphs of context. No literal command in this prose.";
+        assert!(is_action_achievable(
+            &AnalyzedAction::RunShellCommand,
+            prose,
+            Some("gh issue view 915"),
+        ));
+    }
+
+    #[test]
+    fn is_action_achievable_runshell_rejects_non_allowlisted_target() {
+        assert!(!is_action_achievable(
+            &AnalyzedAction::RunShellCommand,
+            "anything",
+            Some("curl https://evil.example.com"),
+        ));
+    }
+
+    #[test]
+    fn is_action_achievable_runshell_empty_target_falls_back_to_keyword_gate() {
+        // Empty target ⇒ behaves like the legacy gate over objective text.
+        let achievable_via_objective = is_action_achievable(
+            &AnalyzedAction::RunShellCommand,
+            "run cargo check",
+            Some(""),
+        );
+        let legacy = is_keyword_action_achievable(&AnalyzedAction::RunShellCommand, "run cargo check");
+        assert_eq!(achievable_via_objective, legacy);
+    }
+
+    #[test]
+    fn is_action_achievable_create_file_with_target() {
+        assert!(is_action_achievable(
+            &AnalyzedAction::CreateFile,
+            "objective without filename",
+            Some("src/foo.rs"),
+        ));
+    }
+
+    #[test]
+    fn is_action_achievable_create_file_empty_target() {
+        // Empty target ⇒ delegate to legacy gate on objective.
+        let result = is_action_achievable(
+            &AnalyzedAction::CreateFile,
+            "objective without filename",
+            Some(""),
+        );
+        assert_eq!(
+            result,
+            is_keyword_action_achievable(&AnalyzedAction::CreateFile, "objective without filename")
+        );
     }
 }

--- a/src/engineer_loop/selection.rs
+++ b/src/engineer_loop/selection.rs
@@ -674,11 +674,13 @@ pub(crate) fn select_engineer_action(
     // failure here propagates as PlanningUnavailable so the cycle reports a
     // real failure instead of fabricating progress.
     let plan = crate::engineer_plan::plan_objective(objective, inspection)?;
-    let first_step = plan.steps().first().cloned().ok_or_else(|| {
-        SimardError::PlanningUnavailable {
-            reason: format!("LLM plan returned zero steps for objective: {objective}"),
-        }
-    })?;
+    let first_step =
+        plan.steps()
+            .first()
+            .cloned()
+            .ok_or_else(|| SimardError::PlanningUnavailable {
+                reason: format!("LLM plan returned zero steps for objective: {objective}"),
+            })?;
     let analyzed = first_step.action.clone();
     if !is_action_achievable(&analyzed, objective, Some(&first_step.target)) {
         return Err(SimardError::PlanningUnavailable {
@@ -1265,9 +1267,12 @@ mod tests {
 
     #[test]
     fn select_shell_command_from_argv_accepts_gh() {
-        let action =
-            select_shell_command_from_argv(vec!["gh".into(), "issue".into(), "view".into(), "915".into()], "note", "test")
-                .expect("gh is allowlisted");
+        let action = select_shell_command_from_argv(
+            vec!["gh".into(), "issue".into(), "view".into(), "915".into()],
+            "note",
+            "test",
+        )
+        .expect("gh is allowlisted");
         assert_eq!(action.argv[0], "gh");
         assert_eq!(action.argv.len(), 4);
     }
@@ -1317,7 +1322,8 @@ mod tests {
             "run cargo check",
             Some(""),
         );
-        let legacy = is_keyword_action_achievable(&AnalyzedAction::RunShellCommand, "run cargo check");
+        let legacy =
+            is_keyword_action_achievable(&AnalyzedAction::RunShellCommand, "run cargo check");
         assert_eq!(achievable_via_objective, legacy);
     }
 

--- a/src/ooda_loop/mod.rs
+++ b/src/ooda_loop/mod.rs
@@ -181,7 +181,7 @@ pub fn run_ooda_cycle(
     // --- Orient ---
     state.current_phase = OodaPhase::Orient;
     eprintln!("[simard] OODA cycle: entering Orient phase");
-    let priorities = orient(&observation, &state.active_goals)?;
+    let priorities = orient(&observation, &state.active_goals, &state.goal_failure_counts)?;
     eprintln!(
         "[simard] OODA cycle: Orient complete ({} priorities)",
         priorities.len()
@@ -224,27 +224,43 @@ pub fn run_ooda_cycle(
 
     // --- Update goal current_activity from outcomes ---
     for outcome in &outcomes {
-        if let Some(goal_id) = &outcome.action.goal_id
-            && let Some(goal) = state
+        if let Some(goal_id) = &outcome.action.goal_id {
+            // Update per-goal failure cooldown counter.
+            if outcome.success {
+                state.goal_failure_counts.remove(goal_id);
+            } else {
+                let entry = state
+                    .goal_failure_counts
+                    .entry(goal_id.clone())
+                    .or_insert(0);
+                *entry = entry.saturating_add(1);
+                eprintln!(
+                    "[simard] OODA cycle: goal '{goal_id}' consecutive failures = {} (cooldown will demote urgency)",
+                    *entry
+                );
+            }
+
+            if let Some(goal) = state
                 .active_goals
                 .active
                 .iter_mut()
                 .find(|g| g.id == *goal_id)
-        {
-            let activity = if outcome.success {
-                format!(
-                    "{}: {}",
-                    outcome.action.kind,
-                    truncate_detail(&outcome.detail, 120)
-                )
-            } else {
-                format!(
-                    "{} (failed): {}",
-                    outcome.action.kind,
-                    truncate_detail(&outcome.detail, 120)
-                )
-            };
-            goal.current_activity = Some(activity);
+            {
+                let activity = if outcome.success {
+                    format!(
+                        "{}: {}",
+                        outcome.action.kind,
+                        truncate_detail(&outcome.detail, 120)
+                    )
+                } else {
+                    format!(
+                        "{} (failed): {}",
+                        outcome.action.kind,
+                        truncate_detail(&outcome.detail, 120)
+                    )
+                };
+                goal.current_activity = Some(activity);
+            }
         }
     }
 

--- a/src/ooda_loop/mod.rs
+++ b/src/ooda_loop/mod.rs
@@ -181,7 +181,11 @@ pub fn run_ooda_cycle(
     // --- Orient ---
     state.current_phase = OodaPhase::Orient;
     eprintln!("[simard] OODA cycle: entering Orient phase");
-    let priorities = orient(&observation, &state.active_goals, &state.goal_failure_counts)?;
+    let priorities = orient(
+        &observation,
+        &state.active_goals,
+        &state.goal_failure_counts,
+    )?;
     eprintln!(
         "[simard] OODA cycle: Orient complete ({} priorities)",
         priorities.len()

--- a/src/ooda_loop/orient.rs
+++ b/src/ooda_loop/orient.rs
@@ -278,8 +278,18 @@ mod tests {
         };
         let env_without = EnvironmentSnapshot::default();
 
-        let prio_with = orient(&make_observation(env_with_issue), &board, &std::collections::HashMap::new()).unwrap();
-        let prio_without = orient(&make_observation(env_without), &board, &std::collections::HashMap::new()).unwrap();
+        let prio_with = orient(
+            &make_observation(env_with_issue),
+            &board,
+            &std::collections::HashMap::new(),
+        )
+        .unwrap();
+        let prio_without = orient(
+            &make_observation(env_without),
+            &board,
+            &std::collections::HashMap::new(),
+        )
+        .unwrap();
         assert!(prio_with[0].urgency > prio_without[0].urgency);
         assert!(prio_with[0].reason.contains("open issue"));
     }
@@ -302,8 +312,18 @@ mod tests {
             recent_commits: Vec::new(),
         };
         let env_clean = EnvironmentSnapshot::default();
-        let prio_dirty = orient(&make_observation(env_dirty), &board, &std::collections::HashMap::new()).unwrap();
-        let prio_clean = orient(&make_observation(env_clean), &board, &std::collections::HashMap::new()).unwrap();
+        let prio_dirty = orient(
+            &make_observation(env_dirty),
+            &board,
+            &std::collections::HashMap::new(),
+        )
+        .unwrap();
+        let prio_clean = orient(
+            &make_observation(env_clean),
+            &board,
+            &std::collections::HashMap::new(),
+        )
+        .unwrap();
         assert!(prio_dirty[0].urgency > prio_clean[0].urgency);
         assert!(prio_dirty[0].reason.contains("dirty"));
     }

--- a/src/ooda_loop/orient.rs
+++ b/src/ooda_loop/orient.rs
@@ -1,16 +1,29 @@
 //! Orient phase: rank goals by urgency, informed by environment context.
 
+use std::collections::HashMap;
+
 use crate::error::SimardResult;
 use crate::goal_curation::{GoalBoard, GoalProgress};
 
 use super::{Observation, Priority};
+
+/// Urgency penalty per consecutive failure on a goal. Five failures in a
+/// row drives any goal's urgency to 0 (deprioritised below everything else).
+const FAILURE_PENALTY_PER_CONSECUTIVE: f64 = 0.2;
 
 /// Orient: rank goals by urgency, informed by environment context.
 ///
 /// Base urgency: Blocked > not-started > in-progress > completed.
 /// Environment signals (dirty working tree, open issues mentioning a goal)
 /// can boost a goal's urgency so the OODA loop prioritises actionable work.
-pub fn orient(observation: &Observation, goals: &GoalBoard) -> SimardResult<Vec<Priority>> {
+/// Goals with consecutive failures are demoted by
+/// `FAILURE_PENALTY_PER_CONSECUTIVE * count` (clamped to ≥0) so the daemon
+/// stops burning budget retrying the same broken target.
+pub fn orient(
+    observation: &Observation,
+    goals: &GoalBoard,
+    failure_counts: &HashMap<String, u32>,
+) -> SimardResult<Vec<Priority>> {
     let env = &observation.environment;
     let has_dirty_tree = !env.git_status.is_empty();
 
@@ -43,6 +56,18 @@ pub fn orient(observation: &Observation, goals: &GoalBoard) -> SimardResult<Vec<
             if has_dirty_tree && matches!(g.status, GoalProgress::InProgress { .. }) {
                 urgency = (urgency + 0.05).min(1.0);
                 reason = format!("{reason}; dirty working tree");
+            }
+
+            // Demote chronically failing goals.
+            if let Some(&count) = failure_counts.get(&g.id)
+                && count > 0
+            {
+                let penalty = FAILURE_PENALTY_PER_CONSECUTIVE * count as f64;
+                let demoted = (urgency - penalty).max(0.0);
+                reason = format!(
+                    "{reason}; {count} consecutive failure(s) → urgency {urgency:.2} − {penalty:.2}"
+                );
+                urgency = demoted;
             }
 
             Priority {
@@ -149,7 +174,7 @@ mod tests {
         ];
         let board = make_board_with_goals(goals);
         let obs = make_observation(EnvironmentSnapshot::default());
-        let priorities = orient(&obs, &board).unwrap();
+        let priorities = orient(&obs, &board, &std::collections::HashMap::new()).unwrap();
         assert_eq!(priorities[0].goal_id, "blocked");
         assert!(priorities[0].urgency > priorities[1].urgency);
     }
@@ -167,7 +192,7 @@ mod tests {
         }];
         let board = make_board_with_goals(goals);
         let obs = make_observation(EnvironmentSnapshot::default());
-        let priorities = orient(&obs, &board).unwrap();
+        let priorities = orient(&obs, &board, &std::collections::HashMap::new()).unwrap();
         assert!(
             priorities[0].urgency < f64::EPSILON,
             "completed goals should have zero urgency"
@@ -198,7 +223,7 @@ mod tests {
         ];
         let board = make_board_with_goals(goals);
         let obs = make_observation(EnvironmentSnapshot::default());
-        let priorities = orient(&obs, &board).unwrap();
+        let priorities = orient(&obs, &board, &std::collections::HashMap::new()).unwrap();
         let new_prio = priorities.iter().find(|p| p.goal_id == "new").unwrap();
         let wip_prio = priorities.iter().find(|p| p.goal_id == "wip").unwrap();
         assert!(new_prio.urgency > wip_prio.urgency);
@@ -228,7 +253,7 @@ mod tests {
         ];
         let board = make_board_with_goals(goals);
         let obs = make_observation(EnvironmentSnapshot::default());
-        let priorities = orient(&obs, &board).unwrap();
+        let priorities = orient(&obs, &board, &std::collections::HashMap::new()).unwrap();
         let early = priorities.iter().find(|p| p.goal_id == "early").unwrap();
         let late = priorities.iter().find(|p| p.goal_id == "late").unwrap();
         assert!(early.urgency > late.urgency);
@@ -253,8 +278,8 @@ mod tests {
         };
         let env_without = EnvironmentSnapshot::default();
 
-        let prio_with = orient(&make_observation(env_with_issue), &board).unwrap();
-        let prio_without = orient(&make_observation(env_without), &board).unwrap();
+        let prio_with = orient(&make_observation(env_with_issue), &board, &std::collections::HashMap::new()).unwrap();
+        let prio_without = orient(&make_observation(env_without), &board, &std::collections::HashMap::new()).unwrap();
         assert!(prio_with[0].urgency > prio_without[0].urgency);
         assert!(prio_with[0].reason.contains("open issue"));
     }
@@ -277,8 +302,8 @@ mod tests {
             recent_commits: Vec::new(),
         };
         let env_clean = EnvironmentSnapshot::default();
-        let prio_dirty = orient(&make_observation(env_dirty), &board).unwrap();
-        let prio_clean = orient(&make_observation(env_clean), &board).unwrap();
+        let prio_dirty = orient(&make_observation(env_dirty), &board, &std::collections::HashMap::new()).unwrap();
+        let prio_clean = orient(&make_observation(env_clean), &board, &std::collections::HashMap::new()).unwrap();
         assert!(prio_dirty[0].urgency > prio_clean[0].urgency);
         assert!(prio_dirty[0].reason.contains("dirty"));
     }
@@ -305,7 +330,7 @@ mod tests {
             pending_improvements: Vec::new(),
             environment: EnvironmentSnapshot::default(),
         };
-        let priorities = orient(&obs, &board).unwrap();
+        let priorities = orient(&obs, &board, &std::collections::HashMap::new()).unwrap();
         assert!(
             priorities.iter().any(|p| p.goal_id == "__memory__"),
             "should add memory consolidation priority"
@@ -325,7 +350,7 @@ mod tests {
             pending_improvements: Vec::new(),
             environment: EnvironmentSnapshot::default(),
         };
-        let priorities = orient(&obs, &board).unwrap();
+        let priorities = orient(&obs, &board, &std::collections::HashMap::new()).unwrap();
         assert!(
             !priorities.iter().any(|p| p.goal_id == "__memory__"),
             "should not add memory priority at exactly 100"
@@ -342,7 +367,7 @@ mod tests {
             pending_improvements: Vec::new(),
             environment: EnvironmentSnapshot::default(),
         };
-        let priorities = orient(&obs, &board).unwrap();
+        let priorities = orient(&obs, &board, &std::collections::HashMap::new()).unwrap();
         assert!(
             priorities.iter().any(|p| p.goal_id == "__improvement__"),
             "should add improvement priority when gym < 70%"
@@ -359,7 +384,7 @@ mod tests {
             pending_improvements: Vec::new(),
             environment: EnvironmentSnapshot::default(),
         };
-        let priorities = orient(&obs, &board).unwrap();
+        let priorities = orient(&obs, &board, &std::collections::HashMap::new()).unwrap();
         assert!(
             !priorities.iter().any(|p| p.goal_id == "__improvement__"),
             "should not add improvement priority when gym >= 70%"
@@ -399,9 +424,77 @@ mod tests {
         ];
         let board = make_board_with_goals(goals);
         let obs = make_observation(EnvironmentSnapshot::default());
-        let priorities = orient(&obs, &board).unwrap();
+        let priorities = orient(&obs, &board, &std::collections::HashMap::new()).unwrap();
         for i in 0..priorities.len() - 1 {
             assert!(priorities[i].urgency >= priorities[i + 1].urgency);
         }
+    }
+
+    #[test]
+    fn orient_failure_cooldown_demotes_urgency() {
+        let goals = vec![ActiveGoal {
+            id: "broken-goal".to_string(),
+            description: "always fails".to_string(),
+            priority: 1,
+            status: GoalProgress::NotStarted, // base urgency 0.8
+            assigned_to: None,
+            current_activity: None,
+            wip_refs: vec![],
+        }];
+        let board = make_board_with_goals(goals);
+        let obs = make_observation(EnvironmentSnapshot::default());
+
+        let mut counts = std::collections::HashMap::new();
+        counts.insert("broken-goal".to_string(), 3); // 3 × 0.2 = 0.6 penalty
+
+        let priorities = orient(&obs, &board, &counts).unwrap();
+        assert_eq!(priorities.len(), 1);
+        // 0.8 base − 0.6 penalty = 0.2
+        assert!(
+            (priorities[0].urgency - 0.2).abs() < 1e-9,
+            "expected urgency ≈ 0.2 after 3 failures, got {}",
+            priorities[0].urgency
+        );
+        assert!(priorities[0].reason.contains("3 consecutive failure"));
+    }
+
+    #[test]
+    fn orient_failure_cooldown_clamps_to_zero() {
+        let goals = vec![ActiveGoal {
+            id: "really-broken".to_string(),
+            description: "many failures".to_string(),
+            priority: 1,
+            status: GoalProgress::Blocked("flaky".to_string()), // base urgency 1.0
+            assigned_to: None,
+            current_activity: None,
+            wip_refs: vec![],
+        }];
+        let board = make_board_with_goals(goals);
+        let obs = make_observation(EnvironmentSnapshot::default());
+
+        let mut counts = std::collections::HashMap::new();
+        counts.insert("really-broken".to_string(), 20); // huge penalty
+
+        let priorities = orient(&obs, &board, &counts).unwrap();
+        assert_eq!(priorities[0].urgency, 0.0);
+    }
+
+    #[test]
+    fn orient_no_demotion_when_failure_count_zero() {
+        let goals = vec![ActiveGoal {
+            id: "healthy-goal".to_string(),
+            description: "OK".to_string(),
+            priority: 1,
+            status: GoalProgress::NotStarted,
+            assigned_to: None,
+            current_activity: None,
+            wip_refs: vec![],
+        }];
+        let board = make_board_with_goals(goals);
+        let obs = make_observation(EnvironmentSnapshot::default());
+        let counts = std::collections::HashMap::new();
+        let priorities = orient(&obs, &board, &counts).unwrap();
+        assert!((priorities[0].urgency - 0.8).abs() < 1e-9);
+        assert!(!priorities[0].reason.contains("consecutive failure"));
     }
 }

--- a/src/ooda_loop/types.rs
+++ b/src/ooda_loop/types.rs
@@ -1,5 +1,6 @@
 //! Shared types for the OODA loop.
 
+use std::collections::HashMap;
 use std::fmt::{self, Display, Formatter};
 
 use crate::cognitive_memory::CognitiveMemoryOps;
@@ -51,6 +52,11 @@ pub struct OodaState {
     pub last_cycle_summary: Option<String>,
     /// Duration in seconds of the last completed cycle.
     pub last_cycle_duration_secs: Option<u64>,
+    /// Per-goal consecutive-failure count. Incremented after each Act phase
+    /// when an outcome with `goal_id == Some(g)` has `success == false`,
+    /// reset to 0 on success. Used by Orient to demote chronically failing
+    /// goals so the daemon stops burning budget on the same broken target.
+    pub goal_failure_counts: HashMap<String, u32>,
 }
 
 impl OodaState {
@@ -65,6 +71,7 @@ impl OodaState {
             cycle_start_epoch: 0,
             last_cycle_summary: None,
             last_cycle_duration_secs: None,
+            goal_failure_counts: HashMap::new(),
         }
     }
 }

--- a/tests/ooda.rs
+++ b/tests/ooda.rs
@@ -128,7 +128,7 @@ fn orient_produces_ranked_priorities() {
     let board = board_with_goals();
     let mut state = OodaState::new(board.clone());
     let obs = observe(&mut state, &bridges).unwrap();
-    let priorities = orient(&obs, &board).unwrap();
+    let priorities = orient(&obs, &board, &std::collections::HashMap::new()).unwrap();
     assert!(!priorities.is_empty());
     assert_eq!(priorities[0].goal_id, "g3"); // blocked = highest urgency
     assert!(priorities[0].urgency > priorities.last().unwrap().urgency);
@@ -140,7 +140,7 @@ fn decide_selects_actions_within_concurrent_limit() {
     let board = board_with_goals();
     let mut state = OodaState::new(board.clone());
     let obs = observe(&mut state, &bridges).unwrap();
-    let priorities = orient(&obs, &board).unwrap();
+    let priorities = orient(&obs, &board, &std::collections::HashMap::new()).unwrap();
     let config = OodaConfig {
         max_concurrent_actions: 2,
         ..Default::default()
@@ -156,7 +156,7 @@ fn act_dispatches_and_returns_outcomes() {
     let board = board_with_goals();
     let mut state = OodaState::new(board.clone());
     let obs = observe(&mut state, &bridges).unwrap();
-    let priorities = orient(&obs, &board).unwrap();
+    let priorities = orient(&obs, &board, &std::collections::HashMap::new()).unwrap();
     let actions = decide(&priorities, &OodaConfig::default()).unwrap();
     let outcomes = act(&actions, &mut bridges, &mut state).unwrap();
     assert_eq!(outcomes.len(), actions.len());
@@ -217,7 +217,7 @@ fn feral_all_goals_blocked() {
     .unwrap();
     let mut state = OodaState::new(board.clone());
     let obs = observe(&mut state, &bridges).unwrap();
-    let priorities = orient(&obs, &board).unwrap();
+    let priorities = orient(&obs, &board, &std::collections::HashMap::new()).unwrap();
     for p in priorities.iter().filter(|p| !p.goal_id.starts_with("__")) {
         assert!((p.urgency - 1.0).abs() < f64::EPSILON);
     }


### PR DESCRIPTION
Stacked on #1141.

## Why

Daemon spawned 224 engineer subprocesses in 24h with 0 commits. Every plan came back `PlanningUnavailable: LLM plan selected action RunShellCommand which is not achievable`. Three coupled bugs:

1. **Selector ignored `step.target`** — the LLM correctly produces `PlanStep { action: RunShellCommand, target: "gh issue view 915" }`, but `select_engineer_action` only used `step.action` (the enum tag) and threw away `step.target`, then re-extracted argv from the multi-paragraph prose objective via keyword extraction, which always failed.
2. **No failure backoff in Orient** — a `Blocked` goal stayed at urgency 1.0 forever, so Decide picked the same broken goal every cycle.
3. **Planner prompt was vague** — five lines, no explicit guidance that `target` must be allowlisted concrete argv.

## What

1. **Selector consumes `step.target`**: new `tokenise_target_argv()`, `select_shell_command_from_argv()`, `is_action_achievable(action, objective, llm_target)`. `select_engineer_action` prefers tokenising the LLM target; defers to keyword extraction only when target is empty; returns `PlanningUnavailable` if neither yields an allowlisted argv.
2. **Per-goal failure cooldown**: `OodaState.goal_failure_counts: HashMap<String,u32>` tracks consecutive failures per goal. Orient subtracts `0.2 × count` from urgency (clamped to ≥0). After 5 failures any goal drops to urgency 0 and Decide stops picking it.
3. **Planner prompt**: explicit allowlist (`cargo, gh, git, ls, cat, grep, rg, find, wc, head, tail, jq`), explicit "target is concrete argv, not prose", per-action contract for each of the 8 supported action kinds, worked example.

## Tests

- 13 new tests in `engineer_loop::selection` covering `tokenise_target_argv`, `select_shell_command_from_argv`, `is_action_achievable` with LLM target.
- 3 new tests in `ooda_loop::orient` for cooldown demotion, clamp-to-zero, no-demotion-when-zero.
- All **3789 lib tests pass**.

## Deployed

Built release, deployed binary md5 `f6f4ab415759fd4dc194408ba4f72503` to `~/.simard/bin/simard`, restarted `simard-ooda.service` (active).

## Stack

- #1141: stop the silent fake-success loop — base
- this PR: selector + cooldown + prompt

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
