### PR TITLE
docs: workflow smoke test marker (#1158)

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,3 +287,4 @@ cargo run -- gym run repo-exploration-local
 ## License
 
 Private repository. See [rysweet/Simard](https://github.com/rysweet/Simard).
+<!-- workflow smoke test - safe to merge -->


### PR DESCRIPTION
Closes #1158

Appends a single trailing comment line to README.md as a workflow smoke test. Safe to merge.