### PR TITLE
chore: remove phantom gym-wave6-tmp gitlink and correct README framing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ logs/
 worktrees/
 node_modules/
 test-results/
+gym-wave*-tmp/

--- a/README.md
+++ b/README.md
@@ -8,13 +8,19 @@ Named after [Suzanne Simard](https://en.wikipedia.org/wiki/Suzanne_Simard), the 
 
 Simard is a terminal-native engineering agent built in Rust. She operates like a disciplined software engineer: she understands codebases, works through tasks in explicit sessions, preserves useful memory, evaluates herself against benchmarks, and improves through structured review loops.
 
-### Relationship to Python amplihack
+### What Simard is (and isn't)
 
-Simard is the **Rust successor to [Python amplihack](https://github.com/rysweet/amplihack)**. The intent is for Simard to become a drop-in replacement: the same agentic-coding capabilities, delivered as a single static Rust binary, with no Python runtime or `pip install` step required.
+Simard is **her own project** with her own mission: an autonomous, self-improving
+engineering agent that runs continuous OODA loops to drive long-running goals
+under human stewardship. She is built natively in Rust as a single static binary,
+with explicit sessions, durable memory, gym benchmarks, and structured
+improvement-curation loops.
 
-That goal is **not yet fully met**. Today Simard implements the core engineer/meeting/goal-curation/improvement-curation/gym/OODA loops natively in Rust, but does not yet cover the full amplihack command surface (37 slash commands) or skill catalog (117 skills). Parity work is tracked in the [parity matrix](docs/reference/parity-matrix.md) and in issues [#896](https://github.com/rysweet/Simard/issues/896), [#897](https://github.com/rysweet/Simard/issues/897), and [#898](https://github.com/rysweet/Simard/issues/898).
-
-If you are a current Python amplihack user: see [Migrating from Python amplihack](#migrating-from-python-amplihack) below for the command map.
+Simard is **not** a successor, port, or replacement for any other agentic system.
+She borrows ideas from the broader agentic-coding ecosystem (including
+[amplihack](https://github.com/rysweet/amplihack), which she can invoke as one of
+several agent base types), but her scope, command surface, and design goals are
+distinct. There is no parity goal with any external project.
 
 ## Install
 
@@ -53,22 +59,6 @@ cargo build --release
 ```bash
 cargo install --git https://github.com/rysweet/Simard.git
 ```
-
-## Migrating from Python amplihack
-
-Simard's CLI is grouped by product mode rather than slash commands. Common amplihack workflows map as follows. Items marked **TBD** are not yet implemented natively in Simard — see the [parity audit (#898)](https://github.com/rysweet/Simard/issues/898) for status and to request prioritization.
-
-| Python amplihack                  | Simard equivalent                                     | Status            |
-| --------------------------------- | ----------------------------------------------------- | ----------------- |
-| `/dev <task>`                     | `simard engineer terminal <topology> <objective>`     | parity            |
-| `/improve <area>`                 | `simard improvement-curation run <base> <topo> <obj>` | parity            |
-| `/analyze <target>`               | `simard engineer read <topology>` + meeting review    | partial           |
-| `/investigation <topic>`          | `simard meeting repl <topic>`                         | partial           |
-| `/customize`                      | direct edits to `prompt_assets/` + recompile          | partial           |
-| skills auto-routing (117 skills)  | curated set of native Rust subcommands                | partial — see #898 |
-| `amplihack install`               | `simard install` or `npx github:rysweet/Simard install` | parity          |
-
-If your workflow is not covered above, please open an issue referencing #898 so it lands in the parity matrix.
 
 ## Quick Start
 
@@ -137,7 +127,7 @@ Simard delegates work to agent runtimes through base types:
 | Base Type | Description | Status |
 |-----------|-------------|--------|
 | `rusty-clawd` | RustyClawd SDK — LLM + tool calling pipeline | Real (needs `ANTHROPIC_API_KEY`) |
-| `copilot-sdk` | amplihack copilot via PTY terminal | Real (needs `amplihack copilot`) |
+| `copilot-sdk` | GitHub Copilot CLI via PTY terminal | Real (needs `copilot` CLI) |
 | `claude-agent-sdk` | Claude Code CLI as subprocess agent | Real (needs `claude` binary) |
 | `ms-agent-framework` | Microsoft Agent Framework | Real (needs `ms-agent-framework` or `python -m microsoft_agent_framework`) |
 | `local-harness` | Test adapter for development | Always available |


### PR DESCRIPTION
## Summary
- Removes `gym-wave6-tmp` — it was an accidental gitlink (submodule entry pointing at a Simard main commit) with no `.gitmodules` registration. Working dir was empty.
- Adds `gym-wave*-tmp/` to `.gitignore`.
- README: corrects misleading framing. Simard is **not** the 'Rust successor to Python amplihack' — she is her own project with her own mission. Removes parity matrix language, migration-from-amplihack table, and the `amplihack copilot` reference (replaced with the actual GitHub Copilot CLI binary name).

## Test plan
Documentation + tracking-only changes. Pre-commit will validate.