### PR TITLE
fix(rustyclawd): honor llm_provider=copilot via gh-auth (#1193)

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,12 +264,29 @@ simard bootstrap run <identity> <base-type> <topology> <objective>
 
 | Environment Variable | Purpose |
 |---------------------|---------|
-| `ANTHROPIC_API_KEY` | API key for the `rusty-clawd` base type |
+| `ANTHROPIC_API_KEY` | API key for the `rusty-clawd` base type when configured for the Anthropic provider |
 | `SIMARD_LLM_PROVIDER` | Override the LLM provider selected from `~/.simard/config.toml` |
 | `SIMARD_COPILOT_GH_ACCOUNT` | GitHub account for Copilot auth (e.g., `rysweet_microsoft`) |
 | `SIMARD_COMMIT_GH_ACCOUNT` | GitHub account for git commits (e.g., `rysweet`) |
 
 Runtime configuration lives at `~/.simard/config.toml`. The runtime fails loudly when required configuration is missing — there are no silent defaults.
+
+### Provider Selection
+
+RustyClawd is multi-provider. Pick a provider by either:
+
+- Setting the env var `SIMARD_LLM_PROVIDER=copilot` (or `rustyclawd`), **or**
+- Adding `llm_provider = "copilot"` (or `"rustyclawd"`) to `~/.simard/config.toml`.
+
+When `copilot` is selected, the only credential step is `gh auth login`. RustyClawd resolves the token via `gh auth token` automatically — no API-key env var is needed. If the GitHub token lacks the Copilot scope, run:
+
+```bash
+gh auth refresh --hostname github.com --scopes copilot
+```
+
+When `rustyclawd` is selected, set `ANTHROPIC_API_KEY` (or place the key in `~/.rustyclawd/config`).
+
+There is no silent default — leaving both the env var and the config-file key unset is an error and will be reported as such.
 
 ## Repository Layout
 

--- a/src/base_type_rustyclawd/session.rs
+++ b/src/base_type_rustyclawd/session.rs
@@ -10,9 +10,30 @@ use crate::base_types::{
     ensure_session_open, joined_prompt_ids,
 };
 use crate::error::{SimardError, SimardResult};
+use crate::runtime_config::RuntimeConfig;
 use crate::sanitization::objective_metadata;
+use crate::session_builder::LlmProvider;
 
 use super::execution::execute_rustyclawd_client;
+
+/// Build the `rustyclawd_core` `Config` for the configured provider.
+///
+/// Splits the provider branch out so it is independently testable without
+/// going through the full session lifecycle.
+///
+/// * `Copilot` — uses `RcConfig::new_copilot()` (sync, infallible). Token
+///   is resolved at HTTP-call time via `gh auth token`.
+/// * `RustyClawd` — uses `RcConfig::from_default_location().await` which
+///   reads `ANTHROPIC_API_KEY` env / `.env` / legacy on-disk key file.
+pub(super) fn build_rc_config(
+    provider: LlmProvider,
+    rt: &tokio::runtime::Runtime,
+) -> std::result::Result<RcConfig, ClientError> {
+    match provider {
+        LlmProvider::Copilot => Ok(RcConfig::new_copilot()),
+        LlmProvider::RustyClawd => rt.block_on(RcConfig::from_default_location()),
+    }
+}
 
 pub(super) struct RustyClawdSession {
     pub(super) descriptor: BaseTypeDescriptor,
@@ -56,27 +77,66 @@ impl BaseTypeSession for RustyClawdSession {
                 reason: format!("failed to create tokio runtime: {e}"),
             })?;
 
-        tracing::info!("RustyClawd: attempting client initialization from default config…");
-        let client_result = rt.block_on(async {
-            let config = RcConfig::from_default_location().await?;
-            RcClient::new(config)
-        });
+        // Resolve the configured provider before opening — RustyClawd is
+        // multi-provider, and we honor the operator's `SIMARD_LLM_PROVIDER`
+        // env var / `~/.simard/config.toml` choice. There is no silent
+        // default: a missing config is surfaced verbatim so the operator
+        // sees what to fix.
+        let provider = RuntimeConfig::load()
+            .map(|cfg| cfg.llm_provider)
+            .map_err(|e| match e {
+            SimardError::MissingRequiredConfig { .. } => SimardError::AdapterInvocationFailed {
+                base_type: self.descriptor.id.to_string(),
+                reason:
+                    "Simard llm_provider not configured. Set SIMARD_LLM_PROVIDER=copilot|rustyclawd \
+                     or add `llm_provider = \"...\"` to ~/.simard/config.toml."
+                        .to_string(),
+            },
+            other => SimardError::AdapterInvocationFailed {
+                base_type: self.descriptor.id.to_string(),
+                reason: format!("failed to load runtime config: {other}"),
+            },
+        })?;
+
+        tracing::info!(
+            provider = ?provider,
+            "RustyClawd: attempting client initialization for resolved provider…"
+        );
+        let client_result = build_rc_config(provider, &rt).and_then(RcClient::new);
 
         match client_result {
             Ok(client) => {
-                tracing::info!("RustyClawd: API client initialized successfully");
+                tracing::info!(
+                    provider = ?provider,
+                    "RustyClawd: API client initialized successfully"
+                );
                 self.client = Some(client);
             }
             Err(ClientError::ApiKeyNotFound) => {
+                let reason = match provider {
+                    LlmProvider::Copilot => {
+                        "RustyClawd configured for Copilot provider but token resolution failed. \
+                         Run `gh auth login` (and `gh auth refresh --hostname github.com \
+                         --scopes copilot` if the Copilot scope is rejected)."
+                            .to_string()
+                    }
+                    LlmProvider::RustyClawd => {
+                        "RustyClawd configured for Anthropic provider but no API key found. \
+                         Set ANTHROPIC_API_KEY env var or place key in ~/.rustyclawd/config."
+                            .to_string()
+                    }
+                };
                 return Err(SimardError::AdapterInvocationFailed {
                     base_type: self.descriptor.id.to_string(),
-                    reason: "No API key found. Set ANTHROPIC_API_KEY or configure gh auth for Copilot SDK.".to_string(),
+                    reason,
                 });
             }
             Err(e) => {
                 return Err(SimardError::AdapterInvocationFailed {
                     base_type: self.descriptor.id.to_string(),
-                    reason: format!("failed to initialize RustyClawd client: {e}"),
+                    reason: format!(
+                        "failed to initialize RustyClawd client (provider={provider:?}): {e}"
+                    ),
                 });
             }
         }
@@ -232,5 +292,19 @@ mod tests {
     fn max_history_messages_is_at_least_10() {
         let m = MAX_HISTORY_MESSAGES;
         assert!(m >= 10, "too low: {m}");
+    }
+
+    // ── Provider-aware config selection (issue #1193) ──
+
+    #[test]
+    fn build_rc_config_returns_copilot_endpoint_for_copilot_provider() {
+        // RcConfig::new_copilot() is sync + infallible — no network needed.
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let cfg =
+            build_rc_config(LlmProvider::Copilot, &rt).expect("Copilot path must be infallible");
+        assert_eq!(cfg.api_url, "https://api.githubcopilot.com");
     }
 }


### PR DESCRIPTION
Closes #1193.

## Problem

`RustyClawdSession::open()` only ever called `Config::from_default_location()`, which reads `ANTHROPIC_API_KEY`. Engineer subprocesses with `llm_provider = "copilot"` in `~/.simard/config.toml` would still fail with `"No API key found. Set ANTHROPIC_API_KEY"` even though RustyClawd itself is multi-provider.

## Fix

`RustyClawdSession::open()` now resolves the provider via `RuntimeConfig::load()` and branches:

- `Copilot` → `RcConfig::new_copilot()` (sync, infallible — token resolves via `gh auth token` at HTTP-call time, no env var required).
- `RustyClawd` → `RcConfig::from_default_location().await` (existing Anthropic path, preserved verbatim).

Provider-aware error messages (Copilot / Anthropic / missing-config) each name the right remediation:

- Copilot: `"Run 'gh auth login' (and 'gh auth refresh --hostname github.com --scopes copilot' if the Copilot scope is rejected)."`
- Anthropic: `"Set ANTHROPIC_API_KEY env var or place key in ~/.rustyclawd/config."`
- Missing: `"Set SIMARD_LLM_PROVIDER=copilot|rustyclawd or add llm_provider=... to ~/.simard/config.toml."`

**Anthropic and RustyClawd remain fully supported.** This is purely configuration plumbing per the user mandate: *"rustyclawd is the agent. period. it supports multiple llm providers. you just need to configure it with my gh auth."*

## Test Plan

- [x] `cargo check --lib` passes
- [x] `cargo clippy --lib` passes
- [x] New hermetic unit test `build_rc_config_returns_copilot_endpoint_for_copilot_provider` asserts the Copilot endpoint is selected for `LlmProvider::Copilot`
- [x] All existing `base_type_rustyclawd::*` tests pass (50 passed)
- [x] All existing `runtime_config::*` tests pass (9 passed)
- [x] README gains a "Provider Selection" subsection documenting both selection mechanisms and the `gh auth login` flow

## Post-merge

`systemctl --user restart simard-ooda` and verify an engineer subprocess log contains `RustyClawd: API client initialized successfully` and exceeds 1167 bytes (the keyword-fallback signature).