### PR TITLE
fix(memory): propagate consolidate_episodes errors and reorder before clear_working (Simard's draft for #1182)

### DIFF
--- a/src/memory_consolidation.rs
+++ b/src/memory_consolidation.rs
@@ -194,17 +194,16 @@ pub fn persistence_memory_operations(
     session_id: &SessionId,
     bridge: &dyn CognitiveMemoryOps,
 ) -> SimardResult<()> {
+    // Consolidate episodes (batch of 10) BEFORE clearing working memory, so a
+    // consolidation failure aborts teardown rather than silently dropping the
+    // session's working-memory contents. Errors are propagated.
+    bridge.consolidate_episodes(10)?;
+
     // Clear working memory for this session.
     bridge.clear_working(session_id.as_str())?;
 
     // Prune expired sensory items.
     bridge.prune_expired_sensory()?;
-
-    // Attempt episode consolidation (batch of 10) — best-effort; don't abort
-    // session teardown if the consolidation flush fails.
-    if let Err(e) = bridge.consolidate_episodes(10) {
-        eprintln!("[memory] consolidate_episodes error in persistence_memory_operations: {e}");
-    }
 
     // Store a final episodic memory marking session end.
     bridge.store_episode(
@@ -311,11 +310,10 @@ pub fn consolidation_persistence(
         None,
     )?;
 
-    // Consolidate any remaining episodes into long-term storage — best-effort;
-    // a flush error should not abort the persistence phase.
-    if let Err(e) = bridge.consolidate_episodes(20) {
-        eprintln!("[memory] consolidate_episodes error in consolidation_persistence: {e}");
-    }
+    // Consolidate any remaining episodes into long-term storage. Errors are
+    // propagated so a failed consolidation aborts the persistence phase
+    // rather than silently dropping data.
+    bridge.consolidate_episodes(20)?;
 
     Ok(())
 }


### PR DESCRIPTION
Closes #1182.

## What is this?

This is **Simard's first shipped code change.** Her engineer subprocess ran the OODA loop, selected issue #1182, planned the fix, and produced this exact diff against \`src/memory_consolidation.rs\`. The verification gate killed her run before commit could happen (see #1197 for the architectural bug), so a human is shepherding her draft into a PR on her behalf.

## Behaviour change

\`persistence_memory_operations\`:
- \`consolidate_episodes(10)\` now runs **before** \`clear_working()\`.
- Errors propagate with \`?\` instead of being swallowed with \`eprintln!\`.
- A failed consolidation now aborts session teardown rather than silently dropping working-memory contents.

\`consolidation_persistence\`:
- \`consolidate_episodes(20)\` errors propagate with \`?\` instead of \`eprintln!\`.
- A failed consolidation aborts the persistence phase rather than silently dropping data.

This matches the locked requirements in #1182 verbatim.

## Verification

- \`cargo check --lib\` passes.
- \`cargo test --lib memory_consolidation::\`: 11 passed, 0 failed.

## Note

Authored by Simard's engineer subprocess (powered by GitHub Copilot via PR #1194). Issue #1197 tracks the verification-gate race that prevented her from shipping it herself.