### PR TITLE
fix(ooda): sanitize LLM-emitted gh issue labels to drop ellipsis placeholders

### DIFF
--- a/src/ooda_actions/goal_session.rs
+++ b/src/ooda_actions/goal_session.rs
@@ -649,12 +649,32 @@ fn dispatch_gh_issue_create(
         "issue", "create", "--repo", repo, "--title", title, "--body", body,
     ];
     let label_csv;
-    if !labels.is_empty() {
-        label_csv = labels.join(",");
+    let sanitized_labels: Vec<String> = labels
+        .iter()
+        .map(|l| l.trim().to_string())
+        .filter(|l| is_plausible_label(l))
+        .collect();
+    if !sanitized_labels.is_empty() {
+        label_csv = sanitized_labels.join(",");
         args.push("--label");
         args.push(&label_csv);
     }
     run_gh(&args)
+}
+
+/// Filter labels that are obviously bogus (placeholders, ellipses, control chars, empty).
+/// Real labels here are short kebab-case-or-spaced strings; LLM occasionally emits
+/// `"..."` or `".…"` (literal ellipsis) from truncated examples in the prompt.
+fn is_plausible_label(label: &str) -> bool {
+    if label.is_empty() || label.len() > 50 {
+        return false;
+    }
+    // Reject pure-punctuation placeholders the LLM tends to emit (`...`, `.…`, `…`).
+    if label.chars().all(|c| matches!(c, '.' | '…' | '-' | '_' | ' ')) {
+        return false;
+    }
+    // Require at least one alphanumeric character.
+    label.chars().any(|c| c.is_alphanumeric())
 }
 
 fn dispatch_gh_issue_comment(repo: &str, issue: u64, body: &str) -> Result<String, String> {
@@ -1108,5 +1128,35 @@ Hope that helps!"#;
         assert_ne!(a, b);
         assert_ne!(b, c);
         assert_ne!(a, c);
+    }
+}
+
+#[cfg(test)]
+mod label_sanitizer_tests {
+    use super::is_plausible_label;
+
+    #[test]
+    fn rejects_ellipsis_placeholders() {
+        assert!(!is_plausible_label("..."));
+        assert!(!is_plausible_label(".…"));
+        assert!(!is_plausible_label("…"));
+        assert!(!is_plausible_label("---"));
+        assert!(!is_plausible_label(""));
+        assert!(!is_plausible_label("   "));
+    }
+
+    #[test]
+    fn accepts_real_labels() {
+        assert!(is_plausible_label("bug"));
+        assert!(is_plausible_label("enhancement"));
+        assert!(is_plausible_label("good first issue"));
+        assert!(is_plausible_label("workflow:default"));
+        assert!(is_plausible_label("parity"));
+    }
+
+    #[test]
+    fn rejects_too_long_labels() {
+        let long = "x".repeat(60);
+        assert!(!is_plausible_label(&long));
     }
 }

--- a/src/ooda_actions/goal_session.rs
+++ b/src/ooda_actions/goal_session.rs
@@ -670,7 +670,10 @@ fn is_plausible_label(label: &str) -> bool {
         return false;
     }
     // Reject pure-punctuation placeholders the LLM tends to emit (`...`, `.…`, `…`).
-    if label.chars().all(|c| matches!(c, '.' | '…' | '-' | '_' | ' ')) {
+    if label
+        .chars()
+        .all(|c| matches!(c, '.' | '…' | '-' | '_' | ' '))
+    {
         return false;
     }
     // Require at least one alphanumeric character.


### PR DESCRIPTION
## Diagnosis

Two of Simard's active goals (`improve-cognitive-memory-persistence`, `add-more-gym-benchmark-scenarios`) were stuck in a loop, repeatedly failing at the `gh_issue_create` action step. From the live goal register:

```
advance-goal (failed): gh exited with status 1: could not add label: '.…
advance-goal (failed): gh exited with status 1: could not add label: '...'
```

The LLM occasionally emits literal ellipsis strings (`...`, `.…`, `…`) when truncating a list of example labels. Previously these passed straight to `gh issue create --label`, which rejects unknown labels and aborts the call. The daemon then logs the failure and retries the same broken action next cycle — an unbounded retry loop.

## Fix

`is_plausible_label` filter drops empty / pure-punctuation / no-alphanumeric / overlong strings. If nothing survives, the issue is created without `--label` rather than failing.

## Tests

3 unit tests in `label_sanitizer_tests`; all pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>