### PR TITLE
fix(engineer_worktree): per-worktree liveness sentinel (#1213, #1208)

### DIFF
--- a/src/engineer_worktree/mod.rs
+++ b/src/engineer_worktree/mod.rs
@@ -38,6 +38,46 @@ mod tests;
 /// Subdirectory under the supervisor state root that holds all engineer worktrees.
 pub const WORKTREES_SUBDIR: &str = "engineer-worktrees";
 
+/// Filename of the per-worktree liveness sentinel (issue #1213). Contains the
+/// PID of the process that allocated the worktree. Used by
+/// [`sweep_orphaned_worktrees`] to skip live worktrees whose git registration
+/// transiently disappeared (e.g. after a `git worktree prune` race).
+pub const ENGINEER_CLAIM_FILE: &str = ".simard-engineer-claim";
+
+/// Probe whether `pid` refers to a running process via `kill(pid, 0)`. Returns
+/// `true` if the process exists (regardless of permission to signal it).
+/// Returns `false` if the process is dead (ESRCH) or `pid` is non-positive.
+#[cfg(unix)]
+fn is_pid_alive(pid: i32) -> bool {
+    if pid <= 0 {
+        return false;
+    }
+    // SAFETY: kill(pid, 0) performs no signal delivery. It is the standard
+    // POSIX liveness probe and has no side effects on the target process.
+    let rc = unsafe { libc::kill(pid as libc::pid_t, 0) };
+    if rc == 0 {
+        return true;
+    }
+    // EPERM means the process exists but we can't signal it — still alive.
+    let errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(0);
+    errno == libc::EPERM
+}
+
+#[cfg(not(unix))]
+fn is_pid_alive(_pid: i32) -> bool {
+    // Non-Unix platforms don't run the daemon; conservative default.
+    true
+}
+
+/// Read the engineer-claim PID out of `worktree_dir/.simard-engineer-claim`.
+/// Returns `None` if the file is missing, empty, malformed, or unreadable.
+/// Tolerant of all I/O errors — the caller treats `None` as "no claim".
+fn read_engineer_claim(worktree_dir: &Path) -> Option<i32> {
+    let path = worktree_dir.join(ENGINEER_CLAIM_FILE);
+    let raw = fs::read_to_string(&path).ok()?;
+    raw.trim().parse::<i32>().ok()
+}
+
 /// Maximum length of a `goal_id` accepted by [`EngineerWorktree::allocate`].
 const MAX_GOAL_ID_LEN: usize = 64;
 
@@ -68,6 +108,10 @@ pub struct SweepReport {
     /// Directories that were physically removed because they were not
     /// registered with the parent repository.
     pub removed_orphan_dirs: Vec<PathBuf>,
+    /// Directories that were unregistered with the parent repo but skipped
+    /// because their `.simard-engineer-claim` sentinel named a live PID
+    /// (issue #1213). Useful for diagnostics and tests.
+    pub skipped_live_dirs: Vec<PathBuf>,
 }
 
 impl EngineerWorktree {
@@ -202,6 +246,24 @@ impl EngineerWorktree {
                 action: format!("engineer_worktree::allocate(goal={goal_id})"),
                 reason: format!("`git worktree add` failed: {reason}"),
             });
+        }
+
+        // 5. Write the per-worktree liveness sentinel (issue #1213). If the
+        //    sweep ever runs against this worktree while git's registration
+        //    is transiently missing, the live PID guard prevents the
+        //    cwd-deletion-under-the-engineer's-feet bug.
+        let claim_path = dir.join(ENGINEER_CLAIM_FILE);
+        let claim_pid = std::process::id();
+        if let Err(e) = fs::write(&claim_path, format!("{claim_pid}\n")) {
+            // Sentinel write failure is non-fatal: the AtomicBool guard plus
+            // the existing canonical-prefix safety still protect us. Log loud
+            // so the regression is visible.
+            tracing::warn!(
+                target: "simard::engineer_worktree",
+                error = %e,
+                claim = %claim_path.display(),
+                "failed to write engineer-claim sentinel; sweep falls back to git-registration check only",
+            );
         }
 
         Ok(Self {
@@ -436,6 +498,22 @@ pub fn sweep_orphaned_worktrees(
             continue;
         }
         if registered.contains(&canonical) {
+            continue;
+        }
+        // Issue #1213: skip dirs whose engineer-claim sentinel names a live
+        // PID. Git's `worktree prune` can transiently drop a registration
+        // (observed during concurrent worktree mutations) and we must not
+        // delete a worktree out from under a running engineer subprocess.
+        if let Some(pid) = read_engineer_claim(&canonical)
+            && is_pid_alive(pid)
+        {
+            tracing::debug!(
+                target: "simard::engineer_worktree",
+                worktree = %canonical.display(),
+                pid,
+                "skipping unregistered worktree with live engineer-claim PID",
+            );
+            report.skipped_live_dirs.push(canonical);
             continue;
         }
         if let Err(e) = fs::remove_dir_all(&path) {

--- a/src/engineer_worktree/tests.rs
+++ b/src/engineer_worktree/tests.rs
@@ -512,3 +512,98 @@ fn git_capture_clears_inherited_git_env() {
     let wt = result.expect("allocate must ignore inherited GIT_DIR");
     wt.cleanup().expect("cleanup");
 }
+
+// ---------------------------------------------------------------------------
+// Issue #1213 — engineer-claim sentinel + sweep liveness check
+// ---------------------------------------------------------------------------
+
+#[test]
+fn allocate_writes_engineer_claim_sentinel_with_current_pid() {
+    let parent_dir = tempdir().unwrap();
+    let state_dir = tempdir().unwrap();
+    let parent_repo = init_parent_repo(parent_dir.path());
+
+    let wt = EngineerWorktree::allocate(&parent_repo, state_dir.path(), "claim-write")
+        .expect("allocate");
+
+    let claim = wt.path().join(super::ENGINEER_CLAIM_FILE);
+    let raw = fs::read_to_string(&claim).expect("claim file present");
+    let pid: i32 = raw.trim().parse().expect("claim file contains an i32 pid");
+    assert_eq!(
+        pid,
+        std::process::id() as i32,
+        "claim file must record the allocating process PID"
+    );
+
+    wt.cleanup().expect("cleanup");
+}
+
+#[test]
+fn sweep_skips_unregistered_dir_with_live_engineer_claim() {
+    let parent_dir = tempdir().unwrap();
+    let state_dir = tempdir().unwrap();
+    let parent_repo = init_parent_repo(parent_dir.path());
+
+    // Create an unregistered worktree-shaped dir with a live (current) PID
+    // claim. Sweep MUST NOT delete it: this simulates the race where git's
+    // registration transiently disappeared but the engineer subprocess is
+    // still actively running in the cwd.
+    let worktrees_root = state_dir.path().join(super::WORKTREES_SUBDIR);
+    fs::create_dir_all(&worktrees_root).unwrap();
+    let live = worktrees_root.join("live-claimed-1");
+    fs::create_dir_all(&live).unwrap();
+    fs::write(
+        live.join(super::ENGINEER_CLAIM_FILE),
+        format!("{}\n", std::process::id()),
+    )
+    .unwrap();
+
+    let report = sweep_orphaned_worktrees(&parent_repo, state_dir.path()).expect("sweep");
+
+    assert!(
+        live.exists(),
+        "sweep must not delete dir with live PID claim"
+    );
+    assert!(
+        report
+            .skipped_live_dirs
+            .iter()
+            .any(|p| p.canonicalize().ok() == live.canonicalize().ok()),
+        "sweep report must record the skipped-live dir; got {:?}",
+        report.skipped_live_dirs
+    );
+    assert!(
+        report.removed_orphan_dirs.is_empty(),
+        "sweep must not record any removals; got {:?}",
+        report.removed_orphan_dirs
+    );
+}
+
+#[test]
+fn sweep_removes_unregistered_dir_with_dead_engineer_claim() {
+    let parent_dir = tempdir().unwrap();
+    let state_dir = tempdir().unwrap();
+    let parent_repo = init_parent_repo(parent_dir.path());
+
+    // Create an unregistered dir with a dead-PID claim (PID 1 belongs to
+    // init/systemd which we cannot signal — kill(1, 0) returns EPERM and
+    // therefore reads as alive — so use PID 2_147_483_646 which is virtually
+    // guaranteed not to exist and not to wrap around to a live one).
+    let worktrees_root = state_dir.path().join(super::WORKTREES_SUBDIR);
+    fs::create_dir_all(&worktrees_root).unwrap();
+    let dead = worktrees_root.join("dead-claimed-1");
+    fs::create_dir_all(&dead).unwrap();
+    fs::write(dead.join(super::ENGINEER_CLAIM_FILE), "2147483646\n").unwrap();
+
+    let report = sweep_orphaned_worktrees(&parent_repo, state_dir.path()).expect("sweep");
+
+    assert!(
+        !dead.exists(),
+        "sweep must remove unregistered dir whose claim PID is dead"
+    );
+    assert!(
+        report.removed_orphan_dirs.iter().any(|p| p == &dead),
+        "sweep report must record the removal; got {:?}",
+        report.removed_orphan_dirs
+    );
+}


### PR DESCRIPTION
Closes #1213
Closes #1208

## Problem
Engineer cycles allocated a per-engineer git worktree, called the LLM (~10min), then every subsequent shell action failed with `ENOENT` because the worktree dir vanished mid-cycle. Root cause: `sweep_orphaned_worktrees` deleted dirs whose git registration had transiently disappeared (race with concurrent worktree mutations), even when a live engineer subprocess was still running in the cwd.

## Fix
Add a per-worktree liveness sentinel `.simard-engineer-claim` containing the allocating process PID. Modify sweep to skip any unregistered dir whose sentinel PID is still alive (`kill(pid, 0)` probe, treating EPERM as alive). New `SweepReport.skipped_live_dirs` field for diagnostics.

## Tests
3 new unit tests (total 14 in module, all pass):
- allocate writes sentinel with current PID
- sweep skips unregistered dir with live PID claim
- sweep removes unregistered dir with dead PID claim (PID 2147483646)

clippy --lib --all-features -D warnings: clean.