### PR TITLE
fix(bridges): redirect handler stdout to stderr to protect JSON-RPC channel (closes #1230)

### DIFF
--- a/python/bridge_server.py
+++ b/python/bridge_server.py
@@ -34,6 +34,13 @@ import sys
 import traceback
 from typing import Any, Callable
 
+# Capture the real stdout at import time so handlers can't accidentally
+# clobber the JSON-RPC channel with print() banners. After run() starts,
+# sys.stdout is rebound to sys.stderr; only _write_response writes to the
+# real stdout. This protects every BridgeServer subclass from any
+# downstream library that prints to stdout.
+_REAL_STDOUT = sys.stdout
+
 ERROR_METHOD_NOT_FOUND = -32601
 ERROR_INTERNAL = -32603
 ERROR_TIMEOUT = -32000
@@ -66,6 +73,10 @@ class BridgeServer:
 
     def run(self) -> None:
         """Read requests from stdin, dispatch, write responses to stdout."""
+        # Reroute any stray print() from handlers (or libraries they call)
+        # to stderr. The JSON-RPC channel must remain pristine; otherwise
+        # the Rust transport reports "malformed response line".
+        sys.stdout = sys.stderr
         for line in sys.stdin:
             line = line.strip()
             if not line:
@@ -119,8 +130,8 @@ def _error(code: int, message: str) -> dict[str, Any]:
 
 def _write_response(response: dict[str, Any]) -> None:
     line = json.dumps(response, separators=(",", ":"))
-    sys.stdout.write(line + "\n")
-    sys.stdout.flush()
+    _REAL_STDOUT.write(line + "\n")
+    _REAL_STDOUT.flush()
 
 
 # --- Standalone echo server for integration testing ---


### PR DESCRIPTION
Closes #1230.

## Bug
Gym bridge had been failing **every** OODA cycle for hours:
```
bridge 'gym-eval' protocol error: malformed response line: expected value at line 1 column 1
```
Root cause: progressive-test-suite prints `====== Running L1: ... ======` banners to stdout, but bridges write JSON-RPC responses to stdout. The first banner corrupts the channel.

Result: Simard's autonomous loop ran with **zero benchmark feedback** — couldn't measure any improvement, all gym-driven dimensions stuck at 0.

## Fix
`bridge_server.py`:
- Capture real stdout at import time → `_REAL_STDOUT`
- `BridgeServer.run()` rebinds `sys.stdout = sys.stderr` before the dispatch loop
- `_write_response` writes to `_REAL_STDOUT` only

13 lines changed, defends every BridgeServer subclass.

## Test
```
$ echo '{"id":1,"method":"bridge.health","params":{}}' | python3 python/simard_gym_bridge.py
{"id":1,"result":{"server_name":"simard-gym-eval","healthy":true}}
```
Pure JSON — banners now go to stderr where they belong.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>