### PR TITLE
fix(engineer-worktree): record (pid, starttime) in claim sentinel

### DIFF
--- a/src/engineer_worktree/mod.rs
+++ b/src/engineer_worktree/mod.rs
@@ -150,9 +150,7 @@ fn read_engineer_claim_full(worktree_dir: &Path) -> Option<EngineerClaim> {
     let raw = fs::read_to_string(&path).ok()?;
     let mut lines = raw.lines();
     let pid: i32 = lines.next()?.trim().parse().ok()?;
-    let starttime = lines
-        .next()
-        .and_then(|s| s.trim().parse::<u64>().ok());
+    let starttime = lines.next().and_then(|s| s.trim().parse::<u64>().ok());
     Some(EngineerClaim { pid, starttime })
 }
 

--- a/src/engineer_worktree/mod.rs
+++ b/src/engineer_worktree/mod.rs
@@ -39,10 +39,68 @@ mod tests;
 pub const WORKTREES_SUBDIR: &str = "engineer-worktrees";
 
 /// Filename of the per-worktree liveness sentinel (issue #1213). Contains the
-/// PID of the process that allocated the worktree. Used by
-/// [`sweep_orphaned_worktrees`] to skip live worktrees whose git registration
-/// transiently disappeared (e.g. after a `git worktree prune` race).
+/// PID of the process that allocated the worktree, plus its starttime read
+/// from `/proc/<pid>/stat` field 22 (issue #1238). The starttime guards
+/// against the daemon-restart-with-recycled-PID race: after a daemon restart,
+/// the new daemon's PID is unrelated to the old one, but Linux can recycle
+/// PIDs over time. Recording (PID, starttime) lets us distinguish "the
+/// original claimant is still running" from "a different process happens
+/// to occupy that PID slot now."
+///
+/// File format (line-separated, trailing newline tolerated):
+///   line 1: `<pid>` (decimal i32, required)
+///   line 2: `<starttime>` (u64 jiffies from /proc/<pid>/stat field 22,
+///           optional — absent in pre-#1238 sentinels)
 pub const ENGINEER_CLAIM_FILE: &str = ".simard-engineer-claim";
+
+/// Read field 22 (starttime in jiffies since boot) from `/proc/<pid>/stat`.
+/// Returns `None` if the file can't be read or is malformed.
+///
+/// `/proc/<pid>/stat` format: `pid (comm) state ppid ...` where `comm` may
+/// itself contain spaces and parentheses. We must therefore find the LAST
+/// `)` and split the remainder by whitespace; field 22 (starttime) is the
+/// 20th token AFTER `comm` (state=1, ppid=2, ..., starttime=20).
+#[cfg(unix)]
+fn read_pid_starttime(pid: i32) -> Option<u64> {
+    if pid <= 0 {
+        return None;
+    }
+    let raw = fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    let close_paren = raw.rfind(')')?;
+    let after = raw.get(close_paren + 1..)?.trim_start();
+    // After `comm`: state(1) ppid(2) pgrp(3) session(4) tty_nr(5) tpgid(6)
+    // flags(7) minflt(8) cminflt(9) majflt(10) cmajflt(11) utime(12) stime(13)
+    // cutime(14) cstime(15) priority(16) nice(17) num_threads(18)
+    // itrealvalue(19) starttime(20)
+    let mut tokens = after.split_ascii_whitespace();
+    let starttime = tokens.nth(19)?;
+    starttime.parse().ok()
+}
+
+#[cfg(not(unix))]
+fn read_pid_starttime(_pid: i32) -> Option<u64> {
+    None
+}
+
+/// Format the contents written into the engineer-claim sentinel file.
+fn format_engineer_claim(pid: u32) -> String {
+    match read_pid_starttime(pid as i32) {
+        Some(st) => format!("{pid}\n{st}\n"),
+        // /proc unavailable (test sandboxes, non-Linux): fall back to PID-only.
+        // Read path treats absent starttime as "unverifiable", but kill(pid,0)
+        // alone is still better than no claim.
+        None => format!("{pid}\n"),
+    }
+}
+
+/// Parsed engineer-claim sentinel contents.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct EngineerClaim {
+    pid: i32,
+    /// Starttime in /proc jiffies, if recorded (None for pre-#1238 sentinels
+    /// or platforms without /proc).
+    starttime: Option<u64>,
+}
 
 /// Probe whether `pid` refers to a running process via `kill(pid, 0)`. Returns
 /// `true` if the process exists (regardless of permission to signal it).
@@ -77,13 +135,58 @@ pub fn is_pid_alive_public(pid: i32) -> bool {
     is_pid_alive(pid)
 }
 
-/// Read the engineer-claim PID out of `worktree_dir/.simard-engineer-claim`.
+/// Public wrapper over `/proc/<pid>/stat` starttime lookup. Used by
+/// `ooda_actions::advance_goal` so it can do the same starttime-validated
+/// claim check as the sweep path.
+pub fn read_pid_starttime_public(pid: i32) -> Option<u64> {
+    read_pid_starttime(pid)
+}
+
+/// Read the engineer-claim sentinel out of `worktree_dir/.simard-engineer-claim`.
 /// Returns `None` if the file is missing, empty, malformed, or unreadable.
 /// Tolerant of all I/O errors — the caller treats `None` as "no claim".
-fn read_engineer_claim(worktree_dir: &Path) -> Option<i32> {
+fn read_engineer_claim_full(worktree_dir: &Path) -> Option<EngineerClaim> {
     let path = worktree_dir.join(ENGINEER_CLAIM_FILE);
     let raw = fs::read_to_string(&path).ok()?;
-    raw.trim().parse::<i32>().ok()
+    let mut lines = raw.lines();
+    let pid: i32 = lines.next()?.trim().parse().ok()?;
+    let starttime = lines
+        .next()
+        .and_then(|s| s.trim().parse::<u64>().ok());
+    Some(EngineerClaim { pid, starttime })
+}
+
+/// Back-compat thin wrapper for callers that only care about the PID.
+#[allow(dead_code)]
+fn read_engineer_claim(worktree_dir: &Path) -> Option<i32> {
+    read_engineer_claim_full(worktree_dir).map(|c| c.pid)
+}
+
+/// Decide whether a parsed claim still names the original allocating process.
+///
+/// Returns `true` only if BOTH:
+///   1. `kill(pid, 0)` reports the PID is alive
+///   2. The recorded starttime matches the live process's current starttime
+///      (or the claim has no starttime, in which case we fall back to PID-only)
+///
+/// The starttime check defends against the daemon-restart-with-recycled-PID
+/// false positive: after a daemon restart the old PID may eventually be
+/// reused by an unrelated process, but its starttime will differ.
+fn claim_is_live(claim: &EngineerClaim) -> bool {
+    if !is_pid_alive(claim.pid) {
+        return false;
+    }
+    match claim.starttime {
+        Some(recorded) => match read_pid_starttime(claim.pid) {
+            Some(current) => current == recorded,
+            // Process exists but we can't read its stat — be conservative
+            // and treat as NOT live (better to occasionally re-allocate a
+            // worktree than to nuke a live engineer's cwd).
+            None => false,
+        },
+        // Pre-#1238 sentinel: no starttime recorded. Fall back to PID-only.
+        None => true,
+    }
 }
 
 /// Maximum length of a `goal_id` accepted by [`EngineerWorktree::allocate`].
@@ -256,13 +359,15 @@ impl EngineerWorktree {
             });
         }
 
-        // 5. Write the per-worktree liveness sentinel (issue #1213). If the
-        //    sweep ever runs against this worktree while git's registration
-        //    is transiently missing, the live PID guard prevents the
-        //    cwd-deletion-under-the-engineer's-feet bug.
+        // 5. Write the per-worktree liveness sentinel (issue #1213, refined
+        //    in #1238). If the sweep ever runs against this worktree while
+        //    git's registration is transiently missing, the live PID +
+        //    starttime guard prevents the cwd-deletion-under-the-engineer's-
+        //    feet bug. Recording starttime alongside the PID closes the
+        //    daemon-restart-with-recycled-PID race.
         let claim_path = dir.join(ENGINEER_CLAIM_FILE);
         let claim_pid = std::process::id();
-        if let Err(e) = fs::write(&claim_path, format!("{claim_pid}\n")) {
+        if let Err(e) = fs::write(&claim_path, format_engineer_claim(claim_pid)) {
             // Sentinel write failure is non-fatal: the AtomicBool guard plus
             // the existing canonical-prefix safety still protect us. Log loud
             // so the regression is visible.
@@ -508,18 +613,22 @@ pub fn sweep_orphaned_worktrees(
         if registered.contains(&canonical) {
             continue;
         }
-        // Issue #1213: skip dirs whose engineer-claim sentinel names a live
-        // PID. Git's `worktree prune` can transiently drop a registration
-        // (observed during concurrent worktree mutations) and we must not
-        // delete a worktree out from under a running engineer subprocess.
-        if let Some(pid) = read_engineer_claim(&canonical)
-            && is_pid_alive(pid)
+        // Issue #1213 / #1238: skip dirs whose engineer-claim sentinel
+        // names a live PID whose starttime still matches. Git's
+        // `worktree prune` can transiently drop a registration (observed
+        // during concurrent worktree mutations) and we must not delete
+        // a worktree out from under a running engineer subprocess.
+        // Starttime validation prevents the recycled-PID false positive
+        // after a daemon restart.
+        if let Some(claim) = read_engineer_claim_full(&canonical)
+            && claim_is_live(&claim)
         {
             tracing::debug!(
                 target: "simard::engineer_worktree",
                 worktree = %canonical.display(),
-                pid,
-                "skipping unregistered worktree with live engineer-claim PID",
+                pid = claim.pid,
+                starttime = ?claim.starttime,
+                "skipping unregistered worktree with live engineer-claim",
             );
             report.skipped_live_dirs.push(canonical);
             continue;

--- a/src/engineer_worktree/tests.rs
+++ b/src/engineer_worktree/tests.rs
@@ -528,7 +528,16 @@ fn allocate_writes_engineer_claim_sentinel_with_current_pid() {
 
     let claim = wt.path().join(super::ENGINEER_CLAIM_FILE);
     let raw = fs::read_to_string(&claim).expect("claim file present");
-    let pid: i32 = raw.trim().parse().expect("claim file contains an i32 pid");
+    // First line is the PID; remaining lines (if any) carry starttime metadata
+    // added in #1238. Both the legacy single-line PID-only format and the
+    // new (PID, starttime) format are accepted by the readers.
+    let pid: i32 = raw
+        .lines()
+        .next()
+        .expect("claim file has at least one line")
+        .trim()
+        .parse()
+        .expect("first line is an i32 pid");
     assert_eq!(
         pid,
         std::process::id() as i32,
@@ -536,6 +545,120 @@ fn allocate_writes_engineer_claim_sentinel_with_current_pid() {
     );
 
     wt.cleanup().expect("cleanup");
+}
+
+#[test]
+fn allocate_writes_starttime_alongside_pid_on_linux() {
+    // On Linux (where /proc/<pid>/stat is available), the sentinel must
+    // include the allocating process's starttime as a second line so the
+    // sweep can defend against PID-recycling false positives after a
+    // daemon restart (issue #1238).
+    if !std::path::Path::new("/proc/self/stat").exists() {
+        // /proc unavailable — skip on non-Linux test runners.
+        return;
+    }
+    let parent_dir = tempdir().unwrap();
+    let state_dir = tempdir().unwrap();
+    let parent_repo = init_parent_repo(parent_dir.path());
+
+    let wt = EngineerWorktree::allocate(&parent_repo, state_dir.path(), "claim-starttime")
+        .expect("allocate");
+
+    let claim = wt.path().join(super::ENGINEER_CLAIM_FILE);
+    let raw = fs::read_to_string(&claim).expect("claim file present");
+    let mut lines = raw.lines();
+    let pid: i32 = lines.next().unwrap().trim().parse().unwrap();
+    let recorded_starttime: u64 = lines
+        .next()
+        .expect("starttime line must be present on Linux")
+        .trim()
+        .parse()
+        .expect("starttime parses as u64");
+    let live_starttime = super::read_pid_starttime_public(pid)
+        .expect("can read starttime for own pid");
+    assert_eq!(
+        recorded_starttime, live_starttime,
+        "recorded starttime must match the live process's current starttime"
+    );
+
+    wt.cleanup().expect("cleanup");
+}
+
+#[test]
+fn sweep_removes_dir_with_recycled_pid_claim() {
+    // Regression test for issue #1238: a sentinel that names a live PID
+    // whose starttime DOES NOT match the recorded one (i.e. the original
+    // process is gone and the PID has been reassigned) must NOT cause the
+    // sweep to skip the worktree. Otherwise the daemon-restart-with-recycled-
+    // PID race leaks orphan worktrees forever.
+    if !std::path::Path::new("/proc/self/stat").exists() {
+        return; // /proc not available
+    }
+    let parent_dir = tempdir().unwrap();
+    let state_dir = tempdir().unwrap();
+    let parent_repo = init_parent_repo(parent_dir.path());
+
+    let worktrees_root = state_dir.path().join(super::WORKTREES_SUBDIR);
+    fs::create_dir_all(&worktrees_root).unwrap();
+    let recycled = worktrees_root.join("recycled-claim");
+    fs::create_dir_all(&recycled).unwrap();
+    // Write a claim naming the test process's PID but with a starttime
+    // that cannot match the live process (use 0 — the test process started
+    // some non-zero number of jiffies after boot).
+    fs::write(
+        recycled.join(super::ENGINEER_CLAIM_FILE),
+        format!("{}\n0\n", std::process::id()),
+    )
+    .unwrap();
+
+    let report = sweep_orphaned_worktrees(&parent_repo, state_dir.path()).expect("sweep");
+
+    assert!(
+        !recycled.exists(),
+        "sweep must remove dir whose claim PID is alive but starttime doesn't match"
+    );
+    assert!(
+        report.removed_orphan_dirs.iter().any(|p| p == &recycled),
+        "sweep must record the recycled-PID removal; got {:?}",
+        report.removed_orphan_dirs
+    );
+}
+
+#[test]
+fn sweep_keeps_legacy_pid_only_claim_with_live_pid() {
+    // Pre-#1238 sentinels are PID-only (no starttime line). They must
+    // still be honored as live when the PID is alive — otherwise a daemon
+    // upgrade would nuke every existing engineer worktree on the first
+    // sweep after the upgrade.
+    let parent_dir = tempdir().unwrap();
+    let state_dir = tempdir().unwrap();
+    let parent_repo = init_parent_repo(parent_dir.path());
+
+    let worktrees_root = state_dir.path().join(super::WORKTREES_SUBDIR);
+    fs::create_dir_all(&worktrees_root).unwrap();
+    let legacy = worktrees_root.join("legacy-pid-only-claim");
+    fs::create_dir_all(&legacy).unwrap();
+    // Single-line PID-only sentinel naming this test process.
+    fs::write(
+        legacy.join(super::ENGINEER_CLAIM_FILE),
+        format!("{}\n", std::process::id()),
+    )
+    .unwrap();
+
+    let report = sweep_orphaned_worktrees(&parent_repo, state_dir.path()).expect("sweep");
+
+    assert!(
+        legacy.exists(),
+        "sweep must not delete legacy PID-only claim with live PID"
+    );
+    assert!(
+        report
+            .skipped_live_dirs
+            .iter()
+            .any(|p| p.canonicalize().ok() == legacy.canonicalize().ok()),
+        "sweep must record legacy PID-only claim as skipped-live; got {:?}",
+        report.skipped_live_dirs
+    );
 }
 
 #[test]

--- a/src/engineer_worktree/tests.rs
+++ b/src/engineer_worktree/tests.rs
@@ -574,8 +574,8 @@ fn allocate_writes_starttime_alongside_pid_on_linux() {
         .trim()
         .parse()
         .expect("starttime parses as u64");
-    let live_starttime = super::read_pid_starttime_public(pid)
-        .expect("can read starttime for own pid");
+    let live_starttime =
+        super::read_pid_starttime_public(pid).expect("can read starttime for own pid");
     assert_eq!(
         recorded_starttime, live_starttime,
         "recorded starttime must match the live process's current starttime"

--- a/src/ooda_actions/advance_goal.rs
+++ b/src/ooda_actions/advance_goal.rs
@@ -341,8 +341,7 @@ pub(crate) fn find_live_engineer_for_goal(
             Some(p) => p,
             None => continue,
         };
-        let recorded_starttime: Option<u64> =
-            lines.next().and_then(|s| s.trim().parse().ok());
+        let recorded_starttime: Option<u64> = lines.next().and_then(|s| s.trim().parse().ok());
         if !crate::engineer_worktree::is_pid_alive_public(pid) {
             continue;
         }

--- a/src/ooda_actions/advance_goal.rs
+++ b/src/ooda_actions/advance_goal.rs
@@ -334,13 +334,28 @@ pub(crate) fn find_live_engineer_for_goal(
             Ok(s) => s,
             Err(_) => continue,
         };
-        let pid: i32 = match raw.trim().parse() {
-            Ok(p) => p,
-            Err(_) => continue,
+        // Sentinel format (issue #1238): `<pid>\n<starttime>\n` (starttime
+        // optional for backwards compat with pre-#1238 sentinels).
+        let mut lines = raw.lines();
+        let pid: i32 = match lines.next().and_then(|s| s.trim().parse().ok()) {
+            Some(p) => p,
+            None => continue,
         };
-        if crate::engineer_worktree::is_pid_alive_public(pid) {
-            return Some(path);
+        let recorded_starttime: Option<u64> =
+            lines.next().and_then(|s| s.trim().parse().ok());
+        if !crate::engineer_worktree::is_pid_alive_public(pid) {
+            continue;
         }
+        // Starttime guard: if the sentinel records a starttime, it must
+        // still match the live process. Mismatch → recycled PID, treat as
+        // dead. Pre-#1238 sentinels have no starttime → fall back to PID-only.
+        if let Some(recorded) = recorded_starttime {
+            match crate::engineer_worktree::read_pid_starttime_public(pid) {
+                Some(current) if current == recorded => {}
+                _ => continue,
+            }
+        }
+        return Some(path);
     }
     None
 }


### PR DESCRIPTION
Closes #1238.

## Symptom (reproduced today on production daemon)

```
DEAD:  add-more-gym-benchmark-scenarios-1777080579 → PID 622243 (process gone)
DEAD:  improve-cognitive-memory-persistence-1777080559 → PID 622243 (process gone)
DEAD:  add-more-gym-benchmark-scenarios-1777089468 → PID 812356 (process gone)
DEAD:  improve-cognitive-memory-persistence-1777089448 → PID 812356 (process gone)
DEAD:  add-more-gym-benchmark-scenarios-1777089960 → PID 835454 (process gone)
DEAD:  improve-cognitive-memory-persistence-1777089939 → PID 835454 (process gone)
ALIVE: add-more-gym-benchmark-scenarios-1777091161 → PID 859180 (simard)
ALIVE: improve-cognitive-memory-persistence-1777091141 → PID 859180 (simard)
```

Every claim names the **daemon** PID (`std::process::id()`), not the engineer. Each daemon restart leaves stale claims pointing at dead-or-recycled PIDs.

## Bug

The sentinel was supposed to defend against the cwd-deletion-under-the-engineer's-feet race (#1213). It does not, because:

1. **False negative**: After daemon restart, the old daemon PID is dead → sweep happily reclaims worktrees whose engineer subprocesses are still alive in tmux.
2. **False positive**: Linux recycles PIDs. If the old daemon PID is reassigned to an unrelated process, sweep skips the orphan forever.

## Fix

Sentinel format becomes:
```
<pid>
<starttime_jiffies>
```

`starttime` comes from `/proc/<pid>/stat` field 22 (boot-relative jiffies). On read, verify both PID alive AND starttime matches. PIDs cannot collide on (pid, starttime) without the original process resuming.

## Backwards compatibility

Legacy single-line PID-only sentinels are still honored as live when the PID is alive. This is required so a daemon upgrade does not sweep every existing engineer worktree on the first cycle after deployment.

## Tests

- `allocate_writes_starttime_alongside_pid_on_linux` — new format is written
- `sweep_removes_dir_with_recycled_pid_claim` — regression for #1238
- `sweep_keeps_legacy_pid_only_claim_with_live_pid` — back-compat
- `allocate_writes_engineer_claim_sentinel_with_current_pid` — updated to parse first line of multi-line format

All 17 `engineer_worktree` tests pass. `cargo clippy --lib --tests` clean.

Same guard applied symmetrically in `ooda_actions/advance_goal.rs::find_live_engineer_for_goal`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>