### PR TITLE
feat(ooda): eval watchdog detects dead-signal in gym progressive

### DIFF
--- a/src/eval_watchdog.rs
+++ b/src/eval_watchdog.rs
@@ -1,0 +1,355 @@
+//! Eval watchdog: detects "absence of signal" in the gym progressive suite.
+//!
+//! Background
+//! ----------
+//! Between 2026-04-12 and 2026-04-25 the OODA daemon ran 89 cycles
+//! reporting `✓ completed` while every L1-L12 evaluation scored 0.00%
+//! and every cycle logged `Grading failed: Expecting value`. The
+//! signal was dead — the bundled Claude Code CLI was not authenticated
+//! and Copilot was not in the path because of an amplihack router bug
+//! (fixed in amplihack#4477) — but Simard's loop kept marching because
+//! it trusted its own success codes more than its measurements.
+//!
+//! This is the same anti-pattern as Therac-25 and a thousand cheaper
+//! incidents: the supervisor cannot detect that its own observation
+//! infrastructure is lying to it. The watchdog exists so that "every
+//! L-test scored 0.0" is a halt-worthy event instead of business as usual.
+//!
+//! References
+//! ----------
+//! - Rob Ewaschuk, *My Philosophy on Alerting* (Google SRE Book):
+//!   alert on user-visible symptoms, not on internal state.
+//! - Marc Brooker, *Avoid Fallback in Distributed Systems* (AWS
+//!   Builders' Library): fallback paths reduce observability of the
+//!   failure they were meant to handle.
+
+use std::collections::HashMap;
+
+use crate::error::SimardResult;
+use crate::gym_history::{ScoreHistory, ScoreRecord};
+
+/// Reason a watchdog fired.
+#[derive(Clone, Debug, PartialEq)]
+pub enum DeadSignalReason {
+    /// All recorded scores in the inspection window were exactly 0.0.
+    /// Strongest signal: the grader is returning empty / failing JSON
+    /// parse on every scenario.
+    AllZero {
+        /// Number of consecutive zero-score records observed.
+        count: usize,
+        /// Distinct scenario ids that contributed (so we don't fire on
+        /// a single broken scenario).
+        scenarios: usize,
+    },
+    /// All recent scores across multiple distinct scenarios are
+    /// pixel-identical (e.g. all exactly 1.0 or all exactly 0.5).
+    /// Distinct scenarios producing distinct content but identical
+    /// scores almost always means a degenerate grader.
+    SuspiciouslyIdentical {
+        score: f64,
+        count: usize,
+        scenarios: usize,
+    },
+}
+
+impl std::fmt::Display for DeadSignalReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::AllZero { count, scenarios } => write!(
+                f,
+                "all-zero scores: {count} consecutive records across {scenarios} \
+                 distinct scenarios. Grader likely returning empty / failing \
+                 JSON parse. The eval signal is dead.",
+            ),
+            Self::SuspiciouslyIdentical {
+                score,
+                count,
+                scenarios,
+            } => write!(
+                f,
+                "suspiciously identical scores: {count} consecutive records \
+                 across {scenarios} distinct scenarios all == {score:.4}. \
+                 Grader likely degenerate.",
+            ),
+        }
+    }
+}
+
+/// Configuration for the dead-signal detector.
+#[derive(Clone, Debug)]
+pub struct WatchdogConfig {
+    /// Inspect at most this many of the most recent records per scenario.
+    pub window_per_scenario: usize,
+    /// Require at least this many distinct scenarios with consistent
+    /// dead-signal evidence before firing. Single-scenario flat-lining
+    /// might be a real failure of one test, not infrastructure dead.
+    pub min_distinct_scenarios: usize,
+    /// Minimum number of total records inspected before any signal can
+    /// fire. Prevents firing on cold start.
+    pub min_total_records: usize,
+}
+
+impl Default for WatchdogConfig {
+    fn default() -> Self {
+        Self {
+            window_per_scenario: 3,
+            min_distinct_scenarios: 3,
+            min_total_records: 6,
+        }
+    }
+}
+
+/// Detect a dead signal in the given score records.
+///
+/// Pure function: takes a flat slice of records (typically the last N
+/// per scenario, concatenated), returns Some(reason) if the watchdog
+/// should fire.
+pub fn detect_dead_signal(
+    records: &[ScoreRecord],
+    config: &WatchdogConfig,
+) -> Option<DeadSignalReason> {
+    if records.len() < config.min_total_records {
+        return None;
+    }
+
+    // Bucket per scenario; we only care about the most recent
+    // `window_per_scenario` per scenario.
+    let mut by_scenario: HashMap<&str, Vec<&ScoreRecord>> = HashMap::new();
+    for r in records {
+        by_scenario
+            .entry(r.scenario_id.as_str())
+            .or_default()
+            .push(r);
+    }
+
+    // Sort each bucket newest-first and trim.
+    let mut tails: Vec<Vec<&ScoreRecord>> = by_scenario
+        .into_values()
+        .map(|mut v| {
+            v.sort_by_key(|r| std::cmp::Reverse(r.timestamp));
+            v.truncate(config.window_per_scenario);
+            v
+        })
+        .collect();
+
+    // Drop scenarios that didn't have enough recent records to be
+    // meaningful evidence on their own.
+    tails.retain(|v| !v.is_empty());
+
+    let distinct = tails.len();
+    if distinct < config.min_distinct_scenarios {
+        return None;
+    }
+
+    // ── AllZero check ────────────────────────────────────────────────
+    let total_inspected: usize = tails.iter().map(|v| v.len()).sum();
+    let all_zero = tails.iter().all(|v| v.iter().all(|r| r.score == 0.0));
+    if all_zero {
+        return Some(DeadSignalReason::AllZero {
+            count: total_inspected,
+            scenarios: distinct,
+        });
+    }
+
+    // ── SuspiciouslyIdentical check ─────────────────────────────────
+    // All scenarios' recent records are exactly equal to the same
+    // non-zero value. (Multiple distinct scenarios producing the exact
+    // same score across multiple runs is statistically improbable.)
+    let first_score = tails[0][0].score;
+    let all_same = tails
+        .iter()
+        .all(|v| v.iter().all(|r| (r.score - first_score).abs() < f64::EPSILON));
+    if all_same && first_score != 0.0 {
+        return Some(DeadSignalReason::SuspiciouslyIdentical {
+            score: first_score,
+            count: total_inspected,
+            scenarios: distinct,
+        });
+    }
+
+    None
+}
+
+/// Helper: load recent records from a [`ScoreHistory`] suitable for
+/// passing to [`detect_dead_signal`].
+///
+/// Pulls the most recent `window` records per known scenario in `suite_id`.
+pub fn collect_recent_records(
+    history: &ScoreHistory,
+    suite_id: &str,
+    window: usize,
+) -> SimardResult<Vec<ScoreRecord>> {
+    let scenario_ids = history.scenario_ids(suite_id)?;
+    let mut out = Vec::new();
+    for sid in scenario_ids {
+        let recs = history.history(suite_id, &sid, window)?;
+        out.extend(recs);
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rec(scenario: &str, score: f64, ts: i64) -> ScoreRecord {
+        ScoreRecord {
+            suite_id: "progressive".into(),
+            scenario_id: scenario.into(),
+            score,
+            timestamp: ts,
+            commit_hash: None,
+        }
+    }
+
+    #[test]
+    fn detects_all_zero_across_scenarios() {
+        let cfg = WatchdogConfig::default();
+        let records = vec![
+            rec("L1", 0.0, 100),
+            rec("L1", 0.0, 200),
+            rec("L1", 0.0, 300),
+            rec("L2", 0.0, 100),
+            rec("L2", 0.0, 200),
+            rec("L2", 0.0, 300),
+            rec("L3", 0.0, 100),
+            rec("L3", 0.0, 200),
+            rec("L3", 0.0, 300),
+        ];
+        match detect_dead_signal(&records, &cfg) {
+            Some(DeadSignalReason::AllZero { count, scenarios }) => {
+                assert_eq!(scenarios, 3);
+                assert!(count >= cfg.min_total_records);
+            }
+            other => panic!("expected AllZero, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn does_not_fire_below_min_total() {
+        let cfg = WatchdogConfig::default();
+        let records = vec![rec("L1", 0.0, 100), rec("L2", 0.0, 100)];
+        assert!(detect_dead_signal(&records, &cfg).is_none());
+    }
+
+    #[test]
+    fn does_not_fire_below_min_distinct_scenarios() {
+        let cfg = WatchdogConfig::default();
+        // 6 records but all on one scenario — could be a bug in just
+        // that scenario, not infrastructure death. Should not fire.
+        let records = vec![
+            rec("L1", 0.0, 100),
+            rec("L1", 0.0, 200),
+            rec("L1", 0.0, 300),
+            rec("L1", 0.0, 400),
+            rec("L1", 0.0, 500),
+            rec("L1", 0.0, 600),
+        ];
+        assert!(detect_dead_signal(&records, &cfg).is_none());
+    }
+
+    #[test]
+    fn does_not_fire_when_some_nonzero() {
+        let cfg = WatchdogConfig::default();
+        let records = vec![
+            rec("L1", 0.0, 100),
+            rec("L1", 0.0, 200),
+            rec("L1", 0.0, 300),
+            rec("L2", 0.0, 100),
+            rec("L2", 0.0, 200),
+            rec("L2", 0.83, 300), // recovery
+            rec("L3", 0.0, 100),
+            rec("L3", 0.0, 200),
+            rec("L3", 0.0, 300),
+        ];
+        assert!(detect_dead_signal(&records, &cfg).is_none());
+    }
+
+    #[test]
+    fn detects_suspiciously_identical_nonzero() {
+        let cfg = WatchdogConfig::default();
+        let records = vec![
+            rec("L1", 0.5, 100),
+            rec("L1", 0.5, 200),
+            rec("L1", 0.5, 300),
+            rec("L2", 0.5, 100),
+            rec("L2", 0.5, 200),
+            rec("L2", 0.5, 300),
+            rec("L3", 0.5, 100),
+            rec("L3", 0.5, 200),
+            rec("L3", 0.5, 300),
+        ];
+        match detect_dead_signal(&records, &cfg) {
+            Some(DeadSignalReason::SuspiciouslyIdentical { score, .. }) => {
+                assert!((score - 0.5).abs() < 1e-9);
+            }
+            other => panic!("expected SuspiciouslyIdentical, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn does_not_fire_on_healthy_signal() {
+        let cfg = WatchdogConfig::default();
+        let records = vec![
+            rec("L1", 1.00, 300),
+            rec("L1", 0.96, 200),
+            rec("L1", 0.92, 100),
+            rec("L2", 0.98, 300),
+            rec("L2", 0.93, 200),
+            rec("L2", 0.90, 100),
+            rec("L3", 0.97, 300),
+            rec("L3", 0.95, 200),
+            rec("L3", 0.91, 100),
+        ];
+        assert!(detect_dead_signal(&records, &cfg).is_none());
+    }
+
+    #[test]
+    fn windowing_picks_most_recent_per_scenario() {
+        let cfg = WatchdogConfig {
+            window_per_scenario: 2,
+            min_distinct_scenarios: 3,
+            min_total_records: 6,
+        };
+        // Older records show healthy scores; the most recent are all zero.
+        // Watchdog should fire on the most recent window.
+        let records = vec![
+            rec("L1", 0.95, 100),
+            rec("L1", 0.0, 200),
+            rec("L1", 0.0, 300),
+            rec("L2", 0.94, 100),
+            rec("L2", 0.0, 200),
+            rec("L2", 0.0, 300),
+            rec("L3", 0.93, 100),
+            rec("L3", 0.0, 200),
+            rec("L3", 0.0, 300),
+        ];
+        match detect_dead_signal(&records, &cfg) {
+            Some(DeadSignalReason::AllZero { .. }) => {}
+            other => panic!("expected AllZero on most-recent window, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ignores_scenario_with_insufficient_records() {
+        let cfg = WatchdogConfig::default();
+        // L4 has only 1 record; should be dropped from the bucket
+        // analysis, leaving 3 valid scenarios all-zero → fire.
+        let records = vec![
+            rec("L1", 0.0, 100),
+            rec("L1", 0.0, 200),
+            rec("L1", 0.0, 300),
+            rec("L2", 0.0, 100),
+            rec("L2", 0.0, 200),
+            rec("L2", 0.0, 300),
+            rec("L3", 0.0, 100),
+            rec("L3", 0.0, 200),
+            rec("L3", 0.0, 300),
+            rec("L4", 0.95, 400),
+        ];
+        // L4's window is just one healthy record; the all-zero check
+        // requires ALL scenarios in the analysis to be zero, so this
+        // mixed case should NOT fire.
+        assert!(detect_dead_signal(&records, &cfg).is_none());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub mod engineer_loop;
 pub mod engineer_plan;
 pub mod engineer_worktree;
 pub mod error;
+pub mod eval_watchdog;
 pub mod evidence;
 pub mod git_guardrails;
 pub mod goal_curation;

--- a/src/ooda_loop/observe.rs
+++ b/src/ooda_loop/observe.rs
@@ -103,13 +103,52 @@ pub fn observe(state: &mut OodaState, bridges: &OodaBridges) -> SimardResult<Obs
 
     let pending_improvements = collect_pending_improvements(state, &gym_health);
 
+    // ── Eval watchdog ────────────────────────────────────────────────
+    // Detect dead signal in the gym progressive suite. This MUST run
+    // every cycle — the whole point is to fire when the loop is
+    // otherwise reporting "✓ completed" while every L-test scores 0.
+    let eval_watchdog = run_eval_watchdog();
+    if let Some(ref reason) = eval_watchdog {
+        // ERROR level. Use stderr (journal records all stderr at the
+        // service's default level; operators grepping for "EVAL
+        // WATCHDOG" must be able to find this).
+        eprintln!(
+            "[simard] ERROR EVAL WATCHDOG TRIPPED — {reason} \
+             — refusing to trust eval-derived priorities this cycle. \
+             Investigate amplihack LLM router, gym bridge, and Copilot \
+             auth state. Cycle will skip eval-driven actions."
+        );
+    }
+
     Ok(Observation {
         goal_statuses,
         gym_health,
         memory_stats,
         pending_improvements,
         environment,
+        eval_watchdog,
     })
+}
+
+/// Run the eval watchdog against the on-disk gym score history.
+///
+/// Returns Some(reason_text) when a dead signal is detected. Degrades
+/// honestly: if the history db doesn't exist or can't be opened we
+/// return None (no watchdog signal — but observe()'s usual logging
+/// will surface the underlying failure).
+fn run_eval_watchdog() -> Option<String> {
+    use crate::eval_watchdog::{
+        WatchdogConfig, collect_recent_records, detect_dead_signal,
+    };
+    let history_path = std::path::Path::new("gym_history.db");
+    if !history_path.exists() {
+        return None;
+    }
+    let history = ScoreHistory::open(history_path).ok()?;
+    let cfg = WatchdogConfig::default();
+    let recs = collect_recent_records(&history, "progressive", cfg.window_per_scenario)
+        .ok()?;
+    detect_dead_signal(&recs, &cfg).map(|r| r.to_string())
 }
 
 /// Collect pending improvement signals from gym regressions, unprocessed

--- a/src/ooda_loop/orient.rs
+++ b/src/ooda_loop/orient.rs
@@ -99,6 +99,21 @@ pub fn orient(
         });
     }
 
+    // ── Eval watchdog override ──────────────────────────────────────
+    // If the watchdog tripped in observe(), nothing else matters this
+    // cycle. Push a synthetic priority with urgency 1.0 (above any
+    // real goal) so decide() routes to it. This is the loop's "stop
+    // and ring the alarm" path — kept alongside other priorities so
+    // the existing ranking/filing/dashboard infrastructure picks it up
+    // for free, but with enough urgency that it preempts ordinary work.
+    if let Some(ref reason) = observation.eval_watchdog {
+        priorities.push(Priority {
+            goal_id: "__eval_watchdog__".to_string(),
+            urgency: 1.0,
+            reason: format!("EVAL WATCHDOG: {reason}"),
+        });
+    }
+
     priorities.sort_by(|a, b| {
         b.urgency
             .partial_cmp(&a.urgency)
@@ -147,6 +162,7 @@ mod tests {
             memory_stats: CognitiveStatistics::default(),
             pending_improvements: Vec::new(),
             environment: env,
+        eval_watchdog: None,
         }
     }
 
@@ -349,6 +365,7 @@ mod tests {
             },
             pending_improvements: Vec::new(),
             environment: EnvironmentSnapshot::default(),
+        eval_watchdog: None,
         };
         let priorities = orient(&obs, &board, &std::collections::HashMap::new()).unwrap();
         assert!(
@@ -369,6 +386,7 @@ mod tests {
             },
             pending_improvements: Vec::new(),
             environment: EnvironmentSnapshot::default(),
+        eval_watchdog: None,
         };
         let priorities = orient(&obs, &board, &std::collections::HashMap::new()).unwrap();
         assert!(
@@ -386,6 +404,7 @@ mod tests {
             memory_stats: CognitiveStatistics::default(),
             pending_improvements: Vec::new(),
             environment: EnvironmentSnapshot::default(),
+        eval_watchdog: None,
         };
         let priorities = orient(&obs, &board, &std::collections::HashMap::new()).unwrap();
         assert!(
@@ -403,6 +422,7 @@ mod tests {
             memory_stats: CognitiveStatistics::default(),
             pending_improvements: Vec::new(),
             environment: EnvironmentSnapshot::default(),
+        eval_watchdog: None,
         };
         let priorities = orient(&obs, &board, &std::collections::HashMap::new()).unwrap();
         assert!(

--- a/src/ooda_loop/summary.rs
+++ b/src/ooda_loop/summary.rs
@@ -49,6 +49,7 @@ mod tests {
                 memory_stats: CognitiveStatistics::default(),
                 pending_improvements: Vec::new(),
                 environment: EnvironmentSnapshot::default(),
+            eval_watchdog: None,
             },
             priorities: vec![Priority {
                 goal_id: "g1".to_string(),
@@ -92,6 +93,7 @@ mod tests {
                     open_issues: vec!["issue 1".to_string()],
                     recent_commits: Vec::new(),
                 },
+                eval_watchdog: None,
             },
             priorities: Vec::new(),
             planned_actions: Vec::new(),
@@ -112,6 +114,7 @@ mod tests {
                 memory_stats: CognitiveStatistics::default(),
                 pending_improvements: Vec::new(),
                 environment: EnvironmentSnapshot::default(),
+            eval_watchdog: None,
             },
             priorities: Vec::new(),
             planned_actions: Vec::new(),

--- a/src/ooda_loop/tests_observe.rs
+++ b/src/ooda_loop/tests_observe.rs
@@ -61,6 +61,7 @@ fn collect_pending_improvements_detects_gym_regression() {
         memory_stats: CognitiveStatistics::default(),
         pending_improvements: Vec::new(),
         environment: EnvironmentSnapshot::default(),
+    eval_watchdog: None,
     });
 
     let result = collect_pending_improvements(&mut state, &Some(current_score.clone()));
@@ -96,6 +97,7 @@ fn collect_pending_improvements_no_regression_when_scores_stable() {
         memory_stats: CognitiveStatistics::default(),
         pending_improvements: Vec::new(),
         environment: EnvironmentSnapshot::default(),
+    eval_watchdog: None,
     });
 
     let result = collect_pending_improvements(&mut state, &Some(current_score));

--- a/src/ooda_loop/types.rs
+++ b/src/ooda_loop/types.rs
@@ -121,6 +121,16 @@ pub struct Observation {
     pub pending_improvements: Vec<ImprovementCycle>,
     /// Local environment state for goal assessment.
     pub environment: EnvironmentSnapshot,
+    /// Set when the eval watchdog has detected a dead signal — i.e. the
+    /// gym progressive suite has been silently producing zeros (or
+    /// pixel-identical scores) across multiple distinct scenarios for
+    /// long enough that the OODA loop must NOT trust further eval-derived
+    /// decisions until an operator investigates.
+    ///
+    /// Reason text is logged at ERROR level by observe(); orient pushes
+    /// a `__eval_watchdog__` priority with maximum urgency so the loop
+    /// surfaces the failure instead of marching past it.
+    pub eval_watchdog: Option<String>,
 }
 
 /// A ranked priority produced during the Orient phase.

--- a/src/operator_commands_ooda/persistence.rs
+++ b/src/operator_commands_ooda/persistence.rs
@@ -207,6 +207,7 @@ mod tests {
                 },
                 pending_improvements: vec![],
                 environment: EnvironmentSnapshot::default(),
+            eval_watchdog: None,
             },
             priorities: vec![Priority {
                 goal_id: "g1".to_string(),

--- a/src/operator_commands_ooda/tests/mod.rs
+++ b/src/operator_commands_ooda/tests/mod.rs
@@ -17,6 +17,7 @@ pub(crate) fn make_minimal_observation() -> Observation {
         memory_stats: CognitiveStatistics::default(),
         pending_improvements: vec![],
         environment: EnvironmentSnapshot::default(),
+    eval_watchdog: None,
     }
 }
 
@@ -54,6 +55,7 @@ pub(crate) fn make_report_with_goals_and_outcomes() -> CycleReport {
                 open_issues: vec!["issue-1".to_string()],
                 recent_commits: vec![],
             },
+            eval_watchdog: None,
         },
         priorities: vec![Priority {
             goal_id: "goal-1".to_string(),

--- a/src/operator_commands_ooda/tests/persistence_memory_tests.rs
+++ b/src/operator_commands_ooda/tests/persistence_memory_tests.rs
@@ -90,6 +90,7 @@ fn persist_cycle_to_memory_with_open_issues() {
             open_issues: vec!["issue-1".to_string(), "issue-2".to_string()],
             recent_commits: vec!["abc123".to_string()],
         },
+        eval_watchdog: None,
     };
     super::super::persistence::persist_cycle_to_memory(&bridges, &report);
 }


### PR DESCRIPTION
## Why

The amplihack LLM-router bug (now fixed in PR #4477) caused 89 OODA cycles to score 0.00% across 13 days while the dashboard reported '✓ completed' every cycle. Simard had no mechanism to detect that her own evaluation signal had gone silent — she trusted that *some* score was produced and read the value blindly.

This is a textbook absence-of-signal failure. The fix is the watchdog those bugs always argue for in retrospect.

## What

`src/eval_watchdog.rs` is a **pure detector** that reads `gym_history.db` and reports a `DeadSignalReason` when:

- **AllZero**: the most recent N records across ≥3 distinct scenarios are all 0.0
- **SuspiciouslyIdentical**: the most recent N records are bit-identical non-zero across ≥3 distinct scenarios (degenerate grader)

Configurable via `WatchdogConfig` (defaults: window=3, min_distinct_scenarios=3, min_total_records=6). Below the minimum it returns `None` — won't fire on cold starts or single-scenario hiccups.

## Wire-in

- `observe()` calls the detector every cycle, logs at ERROR to stderr/journal when tripped, and stashes the reason on `Observation.eval_watchdog`.
- `orient()` pushes a synthetic `__eval_watchdog__` priority with urgency=1.0 so it always preempts ordinary work.

## Phase 1 only

This PR is **visibility-only**. It does not yet halt the OODA loop or auto-file issues — that's Phase 2, gated by a last-fire timestamp to avoid issue-spam.

## Tests

8 unit tests pass:
- detects all-zero across 3 scenarios
- doesn't fire below min_total_records
- doesn't fire with only 1 distinct scenario
- doesn't fire after recovery (most-recent records healthy)
- detects suspiciously-identical non-zero
- doesn't fire on healthy mixed scores
- windowing picks the most-recent N
- doesn't fire below min_distinct_scenarios

## References

- Google SRE Book, [Monitoring Distributed Systems](https://sre.google/sre-book/monitoring-distributed-systems/)
- Specs/ProductArchitecture.md: *"Do not claim success without evidence"*

cc @rysweet