### PR TITLE
fix(ooda-actions): reject placeholder-echo titles/bodies in gh_issue_create

### DIFF
--- a/src/ooda_actions/goal_session.rs
+++ b/src/ooda_actions/goal_session.rs
@@ -171,11 +171,19 @@ fn action_is_valid(action: &GoalAction) -> bool {
         GoalAction::Noop { .. } => true,
         GoalAction::AssessOnly { progress_pct, .. } => *progress_pct <= 100,
         GoalAction::GhIssueCreate { title, body, .. } => {
-            !title.trim().is_empty() && !title.contains('\n') && !body.trim().is_empty()
+            !title.trim().is_empty()
+                && !title.contains('\n')
+                && !body.trim().is_empty()
+                && !is_placeholder_echo(title.trim())
+                && !is_placeholder_echo(body.trim())
         }
-        GoalAction::GhIssueComment { issue, body, .. } => *issue > 0 && !body.trim().is_empty(),
+        GoalAction::GhIssueComment { issue, body, .. } => {
+            *issue > 0 && !body.trim().is_empty() && !is_placeholder_echo(body.trim())
+        }
         GoalAction::GhIssueClose { issue, .. } => *issue > 0,
-        GoalAction::GhPrComment { pr, body, .. } => *pr > 0 && !body.trim().is_empty(),
+        GoalAction::GhPrComment { pr, body, .. } => {
+            *pr > 0 && !body.trim().is_empty() && !is_placeholder_echo(body.trim())
+        }
     }
 }
 
@@ -207,6 +215,10 @@ fn is_placeholder_echo(task: &str) -> bool {
         "<title>",
         "<body>",
         "<description>",
+        "<short title, single line>",
+        "<markdown body, can be multi-line>",
+        "<comment body, can be multi-line>",
+        "<reason for closing>",
     ];
     if KNOWN_PLACEHOLDERS.contains(&stripped) {
         return true;
@@ -1161,5 +1173,98 @@ mod label_sanitizer_tests {
     fn rejects_too_long_labels() {
         let long = "x".repeat(60);
         assert!(!is_plausible_label(&long));
+    }
+}
+
+#[cfg(test)]
+mod placeholder_echo_tests {
+    use super::{GoalAction, action_is_valid, is_placeholder_echo};
+
+    #[test]
+    fn rejects_short_title_single_line_placeholder() {
+        // Exact bug observed 2026-04-25 — daemon filed issues #1247-1249 with
+        // these literal template tokens as the title and body.
+        assert!(is_placeholder_echo("<short title, single line>"));
+        assert!(is_placeholder_echo("<markdown body, can be multi-line>"));
+        assert!(is_placeholder_echo("<comment body, can be multi-line>"));
+        assert!(is_placeholder_echo("<reason for closing>"));
+    }
+
+    #[test]
+    fn rejects_existing_placeholders_still() {
+        assert!(is_placeholder_echo("<one-paragraph concrete task>"));
+        assert!(is_placeholder_echo("<title>"));
+        assert!(is_placeholder_echo("<body>"));
+    }
+
+    #[test]
+    fn accepts_real_titles_and_bodies() {
+        assert!(!is_placeholder_echo(
+            "P3: issue creator dedup by title-hash"
+        ));
+        assert!(!is_placeholder_echo("Fix race in cleanup hook"));
+        // Bodies that legitimately use angle-bracketed jargon must pass.
+        assert!(!is_placeholder_echo(
+            "The handler returns `Result<T, E>` instead of panicking."
+        ));
+    }
+
+    #[test]
+    fn gh_issue_create_with_placeholder_title_is_invalid() {
+        let action = GoalAction::GhIssueCreate {
+            title: "<short title, single line>".into(),
+            body: "real body content".into(),
+            repo: None,
+            labels: vec![],
+        };
+        assert!(
+            !action_is_valid(&action),
+            "placeholder title must be rejected"
+        );
+    }
+
+    #[test]
+    fn gh_issue_create_with_placeholder_body_is_invalid() {
+        let action = GoalAction::GhIssueCreate {
+            title: "real title".into(),
+            body: "<markdown body, can be multi-line>".into(),
+            repo: None,
+            labels: vec![],
+        };
+        assert!(
+            !action_is_valid(&action),
+            "placeholder body must be rejected"
+        );
+    }
+
+    #[test]
+    fn gh_issue_create_with_real_content_is_valid() {
+        let action = GoalAction::GhIssueCreate {
+            title: "Fix the issue creator template echo bug".into(),
+            body: "When the LLM returns the schema scaffold verbatim, we file garbage.".into(),
+            repo: None,
+            labels: vec!["bug".into()],
+        };
+        assert!(action_is_valid(&action));
+    }
+
+    #[test]
+    fn gh_issue_comment_rejects_placeholder_body() {
+        let action = GoalAction::GhIssueComment {
+            issue: 1247,
+            body: "<comment body, can be multi-line>".into(),
+            repo: None,
+        };
+        assert!(!action_is_valid(&action));
+    }
+
+    #[test]
+    fn gh_pr_comment_rejects_placeholder_body() {
+        let action = GoalAction::GhPrComment {
+            pr: 1240,
+            body: "<comment body, can be multi-line>".into(),
+            repo: None,
+        };
+        assert!(!action_is_valid(&action));
     }
 }


### PR DESCRIPTION
## Symptom

Daemon filed three garbage issues today:
- #1247, #1248, #1249 — title `<short title, single line>`, body `<markdown body, can be multi-line>`

The LLM returned the schema scaffold from `prompt_assets/simard/goal_session_objective.md` verbatim instead of filling it in.

## Root cause

`is_placeholder_echo()` in `src/ooda_actions/goal_session.rs` already existed (added 2026-04-23 for the same failure mode in `spawn_engineer`) but had two gaps:

1. **Token coverage** — the title/body scaffolds use `<short title, single line>` and `<markdown body, can be multi-line>`, which weren't in `KNOWN_PLACEHOLDERS`.
2. **Wire-in** — even if the tokens had matched, `action_is_valid()` only called `is_placeholder_echo` on `SpawnEngineer`. The `GhIssueCreate`/`GhIssueComment`/`GhPrComment` arms only checked for empty/newline-in-title.

## Fix

- Add the new tokens to `KNOWN_PLACEHOLDERS` (3 new + 1 reason-for-closing variant)
- Wire `is_placeholder_echo` into `action_is_valid` for all three issue/comment variants

When a placeholder slips through, `try_parse_action` returns `None`, the loop logs a 'goal-action parse failed' message at line 585, and the cycle moves on. No more garbage issues filed.

## Tests

8 new tests in `placeholder_echo_tests` mod:
- Each new placeholder token is rejected
- Existing tokens still rejected
- Real titles/bodies pass validation
- `GhIssueCreate` with placeholder title is invalid
- `GhIssueCreate` with placeholder body is invalid
- `GhIssueCreate` with real content is valid
- `GhIssueComment` with placeholder body is invalid
- `GhPrComment` with placeholder body is invalid

Existing 98 `ooda_actions` tests continue to pass.

## Relation to P3

This is strictly narrower than #1243 (issue dedup + reject make-work). The dedup work still needed; this PR just stops the daemon from filing the *most obviously* garbage issues.

cc @rysweet