### PR TITLE
fix(dashboard): log when goal_records.json fails to parse

### DIFF
--- a/src/operator_commands_dashboard/routes.rs
+++ b/src/operator_commands_dashboard/routes.rs
@@ -1123,7 +1123,24 @@ async fn workboard() -> Json<Value> {
     // --- 2. Goals with enriched status ---
     let goal_path = state_root.join("goal_records.json");
     let goal_content = std::fs::read_to_string(&goal_path).unwrap_or_default();
-    let goal_board = serde_json::from_str::<GoalBoard>(&goal_content).ok();
+    let goal_board = if goal_content.trim().is_empty() {
+        None
+    } else {
+        match serde_json::from_str::<GoalBoard>(&goal_content) {
+            Ok(b) => Some(b),
+            Err(e) => {
+                // Surface parse failures so the dashboard doesn't silently
+                // render "no goals" when the file is malformed. Fail-open
+                // returns None (same as before) but logs why.
+                tracing::warn!(
+                    path = %goal_path.display(),
+                    error = %e,
+                    "goal_records.json failed to parse; dashboard rendering 0 goals"
+                );
+                None
+            }
+        }
+    };
 
     let goals_json: Vec<Value> = goal_board
         .as_ref()


### PR DESCRIPTION
Follow-up to #1254 (P5 fail-open audit).

Dashboard's goal-card section silently rendered 'no goals' when `goal_records.json` was malformed. Operators couldn't tell 'no goals yet' from 'storage corrupt.'


Round 8 of COE fix loop.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>