### PR TITLE
scripts: add redeploy-local.sh for local OODA daemon updates

### DIFF
--- a/scripts/redeploy-local.sh
+++ b/scripts/redeploy-local.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# redeploy-local.sh — rebuild the simard binary, swap it into ~/.simard/bin/,
+# restart the user systemd daemon, and tail the log until the next cycle starts.
+#
+# Use this after merging changes to main (or after explicitly opting into a
+# branch build) to bring the running OODA daemon up to date.
+#
+# Flags:
+#   -b, --branch <name>   Build from a specific git branch (default: main)
+#   -n, --no-restart      Build + swap binary only; do not restart daemon
+#   -h, --help            Show this help
+
+set -euo pipefail
+
+BRANCH="main"
+RESTART=1
+SIMARD_REPO="${SIMARD_REPO:-/home/azureuser/src/Simard}"
+SHARED_TARGET="${SIMARD_SHARED_TARGET:-/home/azureuser/src/Simard/worktrees/meeting-ux-762/target}"
+INSTALL_BIN="${HOME}/.simard/bin/simard"
+LOG_TAIL_SECS=15
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -b|--branch) BRANCH="$2"; shift 2 ;;
+    -n|--no-restart) RESTART=0; shift ;;
+    -h|--help)
+      sed -n '2,16p' "$0"; exit 0 ;;
+    *) echo "unknown flag: $1" >&2; exit 1 ;;
+  esac
+done
+
+echo "[redeploy] repo=${SIMARD_REPO} branch=${BRANCH} target=${SHARED_TARGET}"
+cd "$SIMARD_REPO"
+
+ORIG_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$BRANCH" != "$ORIG_BRANCH" ]]; then
+  echo "[redeploy] checking out ${BRANCH} (was ${ORIG_BRANCH})"
+  git checkout "$BRANCH"
+fi
+
+echo "[redeploy] building simard (release) ..."
+CARGO_TARGET_DIR="$SHARED_TARGET" cargo build --release --bin simard
+
+NEW_BIN="${SHARED_TARGET}/release/simard"
+if [[ ! -x "$NEW_BIN" ]]; then
+  echo "[redeploy] FATAL: built binary missing: $NEW_BIN" >&2
+  exit 1
+fi
+
+NEW_SHA=$(sha256sum "$NEW_BIN" | awk '{print $1}')
+OLD_SHA=$(sha256sum "$INSTALL_BIN" 2>/dev/null | awk '{print $1}' || echo "<absent>")
+if [[ "$NEW_SHA" == "$OLD_SHA" ]]; then
+  echo "[redeploy] binary unchanged (sha=${NEW_SHA:0:12}); nothing to do"
+  exit 0
+fi
+echo "[redeploy] new sha=${NEW_SHA:0:12} (was ${OLD_SHA:0:12})"
+
+mkdir -p "$(dirname "$INSTALL_BIN")"
+cp -f "$NEW_BIN" "${INSTALL_BIN}.new"
+mv -f "${INSTALL_BIN}.new" "$INSTALL_BIN"
+echo "[redeploy] installed → ${INSTALL_BIN}"
+
+if [[ "$RESTART" -eq 0 ]]; then
+  echo "[redeploy] --no-restart given; daemon NOT restarted"
+  exit 0
+fi
+
+echo "[redeploy] restarting simard-ooda.service (user) ..."
+systemctl --user restart simard-ooda
+
+sleep 2
+if systemctl --user is-active simard-ooda >/dev/null; then
+  echo "[redeploy] daemon active; tailing daemon.log for ${LOG_TAIL_SECS}s ..."
+  timeout "$LOG_TAIL_SECS" tail -f -n 5 "$HOME/.simard/daemon.log" || true
+  echo "[redeploy] done"
+else
+  echo "[redeploy] FATAL: daemon failed to start" >&2
+  systemctl --user status simard-ooda --no-pager | head -20 >&2
+  exit 1
+fi


### PR DESCRIPTION
## scripts/redeploy-local.sh — local OODA daemon redeployment

Closes the deployment automation gap discovered in the post-migration
audit on host `ia2`. Prior to this PR, refreshing the running daemon
required a manual `cargo build && cp && systemctl restart` dance with
no liveness check.

### What it does

Single shell script (`scripts/redeploy-local.sh`):
1. Builds the release binary in the shared CARGO_TARGET_DIR (reuses
   pre-built lbug C++ artifacts from the meeting-ux-762 worktree → no
   40-min rebuild on every invocation).
2. Compares sha256 with the installed binary; short-circuits on match.
3. Atomically swaps the new binary into `~/.simard/bin/simard`.
4. Restarts `simard-ooda.service` (user systemd).
5. Tails `~/.simard/daemon.log` for 15s to confirm startup.

### Flags
- `-b <branch>` — build from named branch (default: `main`)
- `-n` — build + swap binary; skip restart
- `-h` — show usage

### Merge-Ready Evidence

- **qa-team:** the script's external surface is its CLI flags (`-b`,
  `-n`, `-h`) and its idempotency contract (same sha256 → no-op).
  Smoke tests run on the dev host:
  - `bash -n scripts/redeploy-local.sh` → syntax OK
  - `scripts/redeploy-local.sh -h` → prints usage banner
  Full live test (rebuild + restart) deferred until a no-op merge to
  main lands, to avoid restarting the running daemon mid-cycle. Once
  available, the script self-validates by tailing daemon.log post-restart.
- **docs:** the script's leading comments ARE its docs (operator-facing
  CLI help via `-h`). No external docs site needs updating; this is a
  self-documented operations script following the same pattern as
  `scripts/cargo-low-space` and `scripts/reclaim-build-space`.
- **quality-audit:** script reviewed for safety:
  - `set -euo pipefail` — fail on any error or unset var
  - sha256 short-circuit — no needless restarts
  - atomic swap (`mv -f`) — no partially-written binary
  - liveness check via `systemctl is-active` — fails loudly if daemon
    won't start
  No destructive operations on existing daemon state or logs.
- **CI:** monitored via `gh pr checks 1272`. Bash-only PR — relevant
  checks are minimal.
- **PR description:** this section.
- **diff scope:** clean. Single new file at `scripts/redeploy-local.sh`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
