### PR TITLE
fix(dashboard): surface save_hosts error in vacate handler (#1263)

### DIFF
--- a/src/operator_commands_dashboard/routes.rs
+++ b/src/operator_commands_dashboard/routes.rs
@@ -1893,7 +1893,17 @@ async fn vacate_vm(Json(body): Json<Value>) -> Json<Value> {
             // Remove from configured hosts
             let mut hosts = load_hosts();
             hosts.retain(|h| h.get("name").and_then(|v| v.as_str()) != Some(vm_name));
-            let _ = save_hosts(&hosts);
+            if let Err(e) = save_hosts(&hosts) {
+                return Json(json!({
+                    "status": "partial",
+                    "message": format!(
+                        "Vacate succeeded on {vm_name} ({remaining} process(es) remaining) \
+                         but failed to update hosts file: {e}. Manual cleanup of \
+                         ~/.simard/hosts.json may be needed."
+                    ),
+                    "remaining_processes": remaining,
+                }));
+            }
 
             let msg = if remaining == 0 {
                 format!("All processes stopped on {vm_name}.")


### PR DESCRIPTION
## Summary

Fixes #1263 — vacate handler did `let _ = save_hosts(&hosts)` and lied about success when the hosts.json write failed. Same anti-pattern as #1258 / #1264.

## Change

If `save_hosts` returns `Err`, the handler now returns a JSON payload with `status: "partial"` and a message identifying the error and the manual-cleanup path (`~/.simard/hosts.json`). The remaining-process count is preserved so the operator still has the relevant context.

## Verification

```
$ grep -rn 'let _ = save_' src/ --include='*.rs' | grep -v test
(no output)
$ cargo clippy --lib --tests -- -D warnings  # clean
```

Closes #1263