### PR TITLE
fix(runtime_config): serialize env-touching tests behind mutex

### DIFF
--- a/src/runtime_config.rs
+++ b/src/runtime_config.rs
@@ -216,11 +216,24 @@ mod tests {
     use tempfile::TempDir;
 
     fn with_clean_env<F: FnOnce()>(f: F) {
-        // SAFETY: tests are serialized via cargo's default single-threaded
-        // env access — no other thread reads/writes SIMARD_LLM_PROVIDER
-        // during the test body.
+        // The tests in this module all read/write `SIMARD_LLM_PROVIDER`.
+        // cargo runs tests multi-threaded by default, so they MUST be
+        // serialized to avoid env-var races where one test's `set_var`
+        // is observed by another test's `read_env_provider()`.
+        //
+        // CI flake observed at runtime_config.rs:286 in run 24947780630:
+        // `bootstrap_from_env_writes_when_missing` saw `wrote == false`
+        // because a concurrent test had cleared the env var between
+        // set_var and bootstrap_from_env.
+        static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        // SAFETY: lock above guarantees no other test in this module
+        // reads/writes SIMARD_LLM_PROVIDER while the closure runs.
         unsafe { std::env::remove_var(ENV_LLM_PROVIDER) };
         f();
+        // Always clear on exit so the next test starts clean even if the
+        // closure panicked before its own remove_var ran.
+        unsafe { std::env::remove_var(ENV_LLM_PROVIDER) };
     }
 
     #[test]


### PR DESCRIPTION
## Summary

CI flake on `runtime_config::tests::bootstrap_from_env_writes_when_missing` (observed in PR #1278's verify run #24947780630).

## Root cause

`with_clean_env()` claimed *'tests are serialized via cargo's default single-threaded env access'* — **wrong**. Cargo runs tests multi-threaded by default. Multiple tests in this module mutate the same global env var (`SIMARD_LLM_PROVIDER`):

1. Test A: `set_var(SIMARD_LLM_PROVIDER, "copilot")`
2. Test B (concurrent): `remove_var(SIMARD_LLM_PROVIDER)`
3. Test A: `bootstrap_from_env` → `read_env_provider` sees `None` → returns `Ok(false)`

## Fix

Wrap the env mutation in a process-wide static `Mutex<()>` so all tests in this module are serialized. Always clear the env var on closure exit so a panicking test doesn't leak state.

## Verification

```
for i in 1 2 3; do cargo test --lib runtime_config:: -- --test-threads=8; done
test result: ok. 9 passed; 0 failed
test result: ok. 9 passed; 0 failed
test result: ok. 9 passed; 0 failed
```

(Pre-fix: ran intermittently when scheduled with other env-touching tests under load.)

## Scope

Surgical: `src/runtime_config.rs` only, only the `#[cfg(test)] with_clean_env` helper.

Refs #1052 (this fixes the runtime_config-specific class; the broader self_improve_executor flake from #1052 is a separate environmental issue tracked there).