### PR TITLE
chore: remove stale new.txt artifact

### DIFF
--- a/new.txt
+++ b/new.txt
@@ -1,1 +1,0 @@
-content


### PR DESCRIPTION
Stale 7-byte file from #1052 flake debugging on Apr 19, no codebase references. Repo pollution cleanup.

```
$ cat new.txt
content
```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>