### PR TITLE
refactor(bootstrap/assembly): extract tests to sibling tests_assembly.rs (#1266)

### DIFF
--- a/src/bootstrap/assembly.rs
+++ b/src/bootstrap/assembly.rs
@@ -258,7 +258,7 @@ fn agent_program_for_manifest(manifest: &IdentityManifest) -> SimardResult<Arc<d
     }
 }
 
-fn register_builtin_base_type(
+pub(super) fn register_builtin_base_type(
     base_types: &mut BaseTypeRegistry,
     base_type: &BaseTypeId,
 ) -> SimardResult<()> {
@@ -295,113 +295,5 @@ fn register_builtin_base_type(
             Ok(())
         }
         _ => Ok(()),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{
-        LOCAL_BASE_TYPE, builtin_base_type_registry_for_manifest, register_builtin_base_type,
-    };
-    use crate::base_type_rustyclawd::RustyClawdAdapter;
-    use crate::base_types::{BaseTypeFactory, BaseTypeId};
-    use crate::identity::{
-        BuiltinIdentityLoader, IdentityLoadRequest, IdentityLoader, ManifestContract,
-    };
-    use crate::metadata::{Freshness, Provenance};
-    use crate::runtime::BaseTypeRegistry;
-
-    #[test]
-    fn builtin_adapter_catalog_covers_manifest_advertised_base_types() {
-        let manifest = BuiltinIdentityLoader
-            .load(&IdentityLoadRequest::new(
-                "simard-engineer",
-                env!("CARGO_PKG_VERSION"),
-                ManifestContract::new(
-                    crate::bootstrap_entrypoint(),
-                    "bootstrap-config -> identity-loader -> runtime-ports -> local-runtime",
-                    vec!["tests:bootstrap-catalog".to_string()],
-                    Provenance::new("test", "bootstrap::catalog"),
-                    Freshness::now().expect("freshness should be observable"),
-                )
-                .expect("contract should be valid"),
-            ))
-            .expect("builtin identity should load");
-
-        let registry =
-            builtin_base_type_registry_for_manifest(&manifest).expect("registry should build");
-        let local = registry
-            .get(&BaseTypeId::new("local-harness"))
-            .expect("local harness should be registered");
-        let rusty = registry
-            .get(&BaseTypeId::new("rusty-clawd"))
-            .expect("rusty-clawd should be registered");
-        let copilot = registry
-            .get(&BaseTypeId::new("copilot-sdk"))
-            .expect("copilot-sdk should be registered");
-        let claude_sdk = registry
-            .get(&BaseTypeId::new("claude-agent-sdk"))
-            .expect("claude-agent-sdk should be registered");
-        let ms_agent = registry
-            .get(&BaseTypeId::new("ms-agent-framework"))
-            .expect("ms-agent-framework should be registered");
-
-        assert_eq!(local.descriptor().backend.identity, LOCAL_BASE_TYPE);
-        assert_eq!(
-            copilot.descriptor().backend.identity,
-            "copilot-sdk::pty-session"
-        );
-        assert_eq!(
-            rusty.descriptor().backend.identity,
-            RustyClawdAdapter::registered("rusty-clawd")
-                .expect("rusty-clawd adapter should initialize")
-                .descriptor()
-                .backend
-                .identity
-        );
-        assert_eq!(
-            claude_sdk.descriptor().backend.identity,
-            "claude-agent-sdk::session-backend"
-        );
-        assert_eq!(
-            ms_agent.descriptor().backend.identity,
-            "ms-agent-framework::session-backend"
-        );
-    }
-
-    // ── register_builtin_base_type ──
-
-    #[test]
-    fn register_unknown_base_type_does_not_error() {
-        let mut registry = BaseTypeRegistry::default();
-        let result = register_builtin_base_type(&mut registry, &BaseTypeId::new("nonexistent"));
-        assert!(
-            result.is_ok(),
-            "unknown base type should be silently ignored"
-        );
-    }
-
-    #[test]
-    fn register_local_harness_base_type_succeeds() {
-        let mut registry = BaseTypeRegistry::default();
-        let result = register_builtin_base_type(&mut registry, &BaseTypeId::new("local-harness"));
-        assert!(result.is_ok());
-        assert!(registry.get(&BaseTypeId::new("local-harness")).is_some());
-    }
-
-    #[test]
-    fn register_rusty_clawd_base_type_succeeds() {
-        let mut registry = BaseTypeRegistry::default();
-        let result = register_builtin_base_type(&mut registry, &BaseTypeId::new("rusty-clawd"));
-        assert!(result.is_ok());
-        assert!(registry.get(&BaseTypeId::new("rusty-clawd")).is_some());
-    }
-
-    #[test]
-    fn register_terminal_shell_base_type_succeeds() {
-        let mut registry = BaseTypeRegistry::default();
-        let result = register_builtin_base_type(&mut registry, &BaseTypeId::new("terminal-shell"));
-        assert!(result.is_ok());
-        assert!(registry.get(&BaseTypeId::new("terminal-shell")).is_some());
     }
 }

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -6,6 +6,8 @@ mod validation;
 #[cfg(test)]
 mod test_support;
 #[cfg(test)]
+mod tests_assembly;
+#[cfg(test)]
 mod tests_config;
 
 // Shared constants accessible to child modules.

--- a/src/bootstrap/tests_assembly.rs
+++ b/src/bootstrap/tests_assembly.rs
@@ -1,0 +1,103 @@
+use super::LOCAL_BASE_TYPE;
+use super::assembly::{builtin_base_type_registry_for_manifest, register_builtin_base_type};
+use crate::base_type_rustyclawd::RustyClawdAdapter;
+use crate::base_types::{BaseTypeFactory, BaseTypeId};
+use crate::identity::{
+    BuiltinIdentityLoader, IdentityLoadRequest, IdentityLoader, ManifestContract,
+};
+use crate::metadata::{Freshness, Provenance};
+use crate::runtime::BaseTypeRegistry;
+
+#[test]
+fn builtin_adapter_catalog_covers_manifest_advertised_base_types() {
+    let manifest = BuiltinIdentityLoader
+        .load(&IdentityLoadRequest::new(
+            "simard-engineer",
+            env!("CARGO_PKG_VERSION"),
+            ManifestContract::new(
+                crate::bootstrap_entrypoint(),
+                "bootstrap-config -> identity-loader -> runtime-ports -> local-runtime",
+                vec!["tests:bootstrap-catalog".to_string()],
+                Provenance::new("test", "bootstrap::catalog"),
+                Freshness::now().expect("freshness should be observable"),
+            )
+            .expect("contract should be valid"),
+        ))
+        .expect("builtin identity should load");
+
+    let registry =
+        builtin_base_type_registry_for_manifest(&manifest).expect("registry should build");
+    let local = registry
+        .get(&BaseTypeId::new("local-harness"))
+        .expect("local harness should be registered");
+    let rusty = registry
+        .get(&BaseTypeId::new("rusty-clawd"))
+        .expect("rusty-clawd should be registered");
+    let copilot = registry
+        .get(&BaseTypeId::new("copilot-sdk"))
+        .expect("copilot-sdk should be registered");
+    let claude_sdk = registry
+        .get(&BaseTypeId::new("claude-agent-sdk"))
+        .expect("claude-agent-sdk should be registered");
+    let ms_agent = registry
+        .get(&BaseTypeId::new("ms-agent-framework"))
+        .expect("ms-agent-framework should be registered");
+
+    assert_eq!(local.descriptor().backend.identity, LOCAL_BASE_TYPE);
+    assert_eq!(
+        copilot.descriptor().backend.identity,
+        "copilot-sdk::pty-session"
+    );
+    assert_eq!(
+        rusty.descriptor().backend.identity,
+        RustyClawdAdapter::registered("rusty-clawd")
+            .expect("rusty-clawd adapter should initialize")
+            .descriptor()
+            .backend
+            .identity
+    );
+    assert_eq!(
+        claude_sdk.descriptor().backend.identity,
+        "claude-agent-sdk::session-backend"
+    );
+    assert_eq!(
+        ms_agent.descriptor().backend.identity,
+        "ms-agent-framework::session-backend"
+    );
+}
+
+// ── register_builtin_base_type ──
+
+#[test]
+fn register_unknown_base_type_does_not_error() {
+    let mut registry = BaseTypeRegistry::default();
+    let result = register_builtin_base_type(&mut registry, &BaseTypeId::new("nonexistent"));
+    assert!(
+        result.is_ok(),
+        "unknown base type should be silently ignored"
+    );
+}
+
+#[test]
+fn register_local_harness_base_type_succeeds() {
+    let mut registry = BaseTypeRegistry::default();
+    let result = register_builtin_base_type(&mut registry, &BaseTypeId::new("local-harness"));
+    assert!(result.is_ok());
+    assert!(registry.get(&BaseTypeId::new("local-harness")).is_some());
+}
+
+#[test]
+fn register_rusty_clawd_base_type_succeeds() {
+    let mut registry = BaseTypeRegistry::default();
+    let result = register_builtin_base_type(&mut registry, &BaseTypeId::new("rusty-clawd"));
+    assert!(result.is_ok());
+    assert!(registry.get(&BaseTypeId::new("rusty-clawd")).is_some());
+}
+
+#[test]
+fn register_terminal_shell_base_type_succeeds() {
+    let mut registry = BaseTypeRegistry::default();
+    let result = register_builtin_base_type(&mut registry, &BaseTypeId::new("terminal-shell"));
+    assert!(result.is_ok());
+    assert!(registry.get(&BaseTypeId::new("terminal-shell")).is_some());
+}


### PR DESCRIPTION
Inline test module in `assembly.rs` is moved into a sibling `tests_assembly.rs` using the existing bootstrap convention (alongside `tests_config.rs`).

- `src/bootstrap/assembly.rs`: **407 → 300 LOC** (under 400-line rule)
- `src/bootstrap/tests_assembly.rs`: new (~105 LOC)
- `src/bootstrap/mod.rs`: registers `mod tests_assembly`
- `register_builtin_base_type`: `fn` → `pub(super) fn` so the sibling test module can reach it (was reachable via `super::*` from the inline tests)

Pure refactor: zero logic changes, all 52 `bootstrap::*` tests pass.

Closes 1/70 of #1266 (after #1285, #1286, #1287).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>