### PR TITLE
refactor(operator_commands_dashboard): extract monitoring handlers

### DIFF
--- a/src/operator_commands_dashboard/mod.rs
+++ b/src/operator_commands_dashboard/mod.rs
@@ -1,4 +1,5 @@
 mod auth;
+mod monitoring;
 pub(crate) mod routes;
 
 #[cfg(test)]

--- a/src/operator_commands_dashboard/monitoring.rs
+++ b/src/operator_commands_dashboard/monitoring.rs
@@ -1,0 +1,73 @@
+use axum::Json;
+use serde_json::{Value, json};
+
+pub(crate) async fn metrics() -> Json<Value> {
+    let recent = crate::self_metrics::recent_metrics(100).unwrap_or_default();
+    let report = crate::self_metrics::daily_report().unwrap_or_default();
+
+    let entries: Vec<Value> = recent
+        .iter()
+        .map(|e| {
+            json!({
+                "timestamp": e.timestamp.to_rfc3339(),
+                "metric_name": e.metric_name,
+                "value": e.value,
+                "context": e.context,
+            })
+        })
+        .collect();
+
+    Json(json!({
+        "recent": entries,
+        "daily_report": report,
+    }))
+}
+
+pub(crate) async fn costs() -> Json<Value> {
+    let daily = crate::cost_tracking::daily_summary()
+        .map(|s| serde_json::to_value(s).unwrap_or_default())
+        .unwrap_or_else(|e| json!({"error": format!("daily: {e}")}));
+    let weekly = crate::cost_tracking::weekly_summary()
+        .map(|s| serde_json::to_value(s).unwrap_or_default())
+        .unwrap_or_else(|e| json!({"error": format!("weekly: {e}")}));
+    Json(json!({
+        "daily": daily,
+        "weekly": weekly,
+    }))
+}
+
+/// Budget config file path.
+fn budget_config_path() -> std::path::PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/home/azureuser".to_string());
+    std::path::PathBuf::from(home)
+        .join(".simard")
+        .join("budget.json")
+}
+
+pub(crate) async fn get_budget() -> Json<Value> {
+    let path = budget_config_path();
+    let content = std::fs::read_to_string(&path).unwrap_or_default();
+    match serde_json::from_str::<Value>(&content) {
+        Ok(v) => Json(v),
+        Err(_) => Json(json!({
+            "daily_budget_usd": std::env::var("SIMARD_DAILY_BUDGET_USD")
+                .ok().and_then(|v| v.parse::<f64>().ok()).unwrap_or(500.0),
+            "weekly_budget_usd": std::env::var("SIMARD_WEEKLY_BUDGET_USD")
+                .ok().and_then(|v| v.parse::<f64>().ok()).unwrap_or(2500.0),
+        })),
+    }
+}
+
+pub(crate) async fn set_budget(Json(body): Json<Value>) -> Json<Value> {
+    let path = budget_config_path();
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    match std::fs::write(
+        &path,
+        serde_json::to_string_pretty(&body).unwrap_or_default(),
+    ) {
+        Ok(_) => Json(json!({"status": "ok"})),
+        Err(e) => Json(json!({"error": format!("{e}")})),
+    }
+}

--- a/src/operator_commands_dashboard/routes.rs
+++ b/src/operator_commands_dashboard/routes.rs
@@ -8,6 +8,7 @@ use axum::{
 use serde_json::{Value, json};
 
 use super::auth::{login, login_page, require_auth};
+use super::monitoring::{costs, get_budget, metrics, set_budget};
 use crate::agent_registry::{AgentRegistry, FileBackedAgentRegistry};
 use crate::build_lock::BuildLock;
 use crate::cognitive_memory::{CognitiveMemoryOps, NativeCognitiveMemory, as_f64, as_i64, as_str};
@@ -160,76 +161,6 @@ async fn issues() -> Json<Value> {
     }
 }
 
-async fn metrics() -> Json<Value> {
-    let recent = crate::self_metrics::recent_metrics(100).unwrap_or_default();
-    let report = crate::self_metrics::daily_report().unwrap_or_default();
-
-    let entries: Vec<Value> = recent
-        .iter()
-        .map(|e| {
-            json!({
-                "timestamp": e.timestamp.to_rfc3339(),
-                "metric_name": e.metric_name,
-                "value": e.value,
-                "context": e.context,
-            })
-        })
-        .collect();
-
-    Json(json!({
-        "recent": entries,
-        "daily_report": report,
-    }))
-}
-
-async fn costs() -> Json<Value> {
-    let daily = crate::cost_tracking::daily_summary()
-        .map(|s| serde_json::to_value(s).unwrap_or_default())
-        .unwrap_or_else(|e| json!({"error": format!("daily: {e}")}));
-    let weekly = crate::cost_tracking::weekly_summary()
-        .map(|s| serde_json::to_value(s).unwrap_or_default())
-        .unwrap_or_else(|e| json!({"error": format!("weekly: {e}")}));
-    Json(json!({
-        "daily": daily,
-        "weekly": weekly,
-    }))
-}
-
-/// Budget config file path.
-fn budget_config_path() -> std::path::PathBuf {
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/home/azureuser".to_string());
-    std::path::PathBuf::from(home)
-        .join(".simard")
-        .join("budget.json")
-}
-
-async fn get_budget() -> Json<Value> {
-    let path = budget_config_path();
-    let content = std::fs::read_to_string(&path).unwrap_or_default();
-    match serde_json::from_str::<Value>(&content) {
-        Ok(v) => Json(v),
-        Err(_) => Json(json!({
-            "daily_budget_usd": std::env::var("SIMARD_DAILY_BUDGET_USD")
-                .ok().and_then(|v| v.parse::<f64>().ok()).unwrap_or(500.0),
-            "weekly_budget_usd": std::env::var("SIMARD_WEEKLY_BUDGET_USD")
-                .ok().and_then(|v| v.parse::<f64>().ok()).unwrap_or(2500.0),
-        })),
-    }
-}
-
-async fn set_budget(Json(body): Json<Value>) -> Json<Value> {
-    let path = budget_config_path();
-    if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent);
-    }
-    match std::fs::write(
-        &path,
-        serde_json::to_string_pretty(&body).unwrap_or_default(),
-    ) {
-        Ok(_) => Json(json!({"status": "ok"})),
-        Err(e) => Json(json!({"error": format!("{e}")})),
-    }
-}
 
 async fn goals() -> Json<Value> {
     let state_root = resolve_state_root();


### PR DESCRIPTION
Move metrics/costs/budget HTTP handlers from routes.rs into a new monitoring.rs sibling.

- routes.rs: 5558 -> 5488
- monitoring.rs (NEW, 74)

Refs #1266