### PR TITLE
chore: cargo fmt drift cleanup (#1031)

### DIFF
--- a/src/cognitive_memory/backup.rs
+++ b/src/cognitive_memory/backup.rs
@@ -1,16 +1,15 @@
 //! NativeCognitiveMemory backup, restore, and DB-recovery helpers.
 
 use std::fs;
-use std::path::{Path, PathBuf};
 use std::os::unix::io::AsRawFd;
 use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::path::{Path, PathBuf};
 
 use crate::error::{SimardError, SimardResult};
 
 use super::NativeCognitiveMemory;
 
 impl NativeCognitiveMemory {
-
     /// Return the WAL file paths that LadybugDB may use for a given DB path.
     fn wal_paths(db_path: &Path) -> [PathBuf; 2] {
         let wal1 = db_path.with_extension("ladybug.wal");
@@ -341,7 +340,10 @@ impl NativeCognitiveMemory {
     }
 
     #[cfg(unix)]
-    pub(super) fn with_open_lock<T>(db_path: &Path, f: impl FnOnce() -> SimardResult<T>) -> SimardResult<T> {
+    pub(super) fn with_open_lock<T>(
+        db_path: &Path,
+        f: impl FnOnce() -> SimardResult<T>,
+    ) -> SimardResult<T> {
         let lock_path = db_path.with_extension("open.lock");
         if let Some(parent) = lock_path.parent() {
             std::fs::create_dir_all(parent).map_err(|e| SimardError::PersistentStoreIo {

--- a/src/cognitive_memory/mod.rs
+++ b/src/cognitive_memory/mod.rs
@@ -234,7 +234,6 @@ mod backup;
 mod ops;
 
 impl NativeCognitiveMemory {
-
     fn conn(&self) -> SimardResult<lbug::Connection<'_>> {
         lbug::Connection::new(&self.db).map_err(|e| SimardError::RuntimeInitFailed {
             component: "cognitive-memory".into(),

--- a/src/cognitive_memory/ops.rs
+++ b/src/cognitive_memory/ops.rs
@@ -325,4 +325,3 @@ impl CognitiveMemoryOps for NativeCognitiveMemory {
         })
     }
 }
-

--- a/src/engineer_loop/meeting_decisions.rs
+++ b/src/engineer_loop/meeting_decisions.rs
@@ -10,7 +10,6 @@ use crate::memory::{FileBackedMemoryStore, MemoryScope, MemoryStore};
 
 use super::MAX_CARRIED_MEETING_DECISIONS;
 
-
 pub(crate) fn load_carried_meeting_decisions(state_root: &Path) -> SimardResult<Vec<String>> {
     let memory_store = FileBackedMemoryStore::try_new(state_root.join("memory_records.json"))?;
     let mut carried = memory_store

--- a/src/engineer_loop/mod.rs
+++ b/src/engineer_loop/mod.rs
@@ -308,4 +308,6 @@ pub fn inspect_workspace(workspace_root: &Path, state_root: &Path) -> SimardResu
 }
 
 mod meeting_decisions;
-pub(crate) use meeting_decisions::{architecture_gap_summary, is_meeting_decision_record, load_carried_meeting_decisions};
+pub(crate) use meeting_decisions::{
+    architecture_gap_summary, is_meeting_decision_record, load_carried_meeting_decisions,
+};

--- a/src/engineer_worktree/claim.rs
+++ b/src/engineer_worktree/claim.rs
@@ -1,8 +1,8 @@
 //! Per-engineer worktree claim helpers — PID + starttime sentinel.
 
+use super::ENGINEER_CLAIM_FILE;
 use std::fs;
 use std::path::Path;
-use super::ENGINEER_CLAIM_FILE;
 
 /// Read field 22 (starttime in jiffies since boot) from `/proc/<pid>/stat`.
 /// Returns `None` if the file can't be read or is malformed.

--- a/src/engineer_worktree/cleanup.rs
+++ b/src/engineer_worktree/cleanup.rs
@@ -1,17 +1,16 @@
 //! Cleanup primitive + path helpers used by allocate/drop.
 
 use std::fs;
-use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
-use std::sync::atomic::{AtomicU64, Ordering};
 #[cfg(unix)]
 use std::os::unix::fs::DirBuilderExt;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::error::SimardError;
 
-use super::{ENGINEER_CLAIM_FILE, worktree_mutation_lock};
 use super::sweep::git_capture;
-
+use super::{ENGINEER_CLAIM_FILE, worktree_mutation_lock};
 
 /// Cleanup primitive shared by `cleanup()` and `Drop`.
 ///
@@ -70,7 +69,6 @@ pub fn cleanup_inner(
     }
     Ok(())
 }
-
 
 /// Canonicalize `dir` and verify it lives under `root_canonical`.
 /// Returns the canonicalized path so the caller can `fs::remove_dir_all`

--- a/src/engineer_worktree/mod.rs
+++ b/src/engineer_worktree/mod.rs
@@ -58,8 +58,11 @@ pub const WORKTREES_SUBDIR: &str = "engineer-worktrees";
 pub const ENGINEER_CLAIM_FILE: &str = ".simard-engineer-claim";
 
 mod claim;
+use claim::{
+    EngineerClaim, claim_is_live, format_engineer_claim, is_pid_alive, read_engineer_claim,
+    read_engineer_claim_full, read_pid_starttime,
+};
 pub use claim::{is_pid_alive_public, read_pid_starttime_public};
-use claim::{EngineerClaim, claim_is_live, format_engineer_claim, is_pid_alive, read_engineer_claim, read_engineer_claim_full, read_pid_starttime};
 
 /// Maximum length of a `goal_id` accepted by [`EngineerWorktree::allocate`].
 pub const MAX_GOAL_ID_LEN: usize = 64;
@@ -73,7 +76,6 @@ pub const MAX_GOAL_ID_LEN: usize = 64;
 /// Cleanup is idempotent and runs either via [`EngineerWorktree::cleanup`]
 /// (the explicit, observable path) or via [`Drop`] (the safety-net path).
 #[derive(Debug)]
-
 
 pub struct EngineerWorktree {
     path: PathBuf,

--- a/src/engineer_worktree/sweep.rs
+++ b/src/engineer_worktree/sweep.rs
@@ -1,19 +1,18 @@
 //! Sweeping orphaned engineer worktrees + helpers used by allocate.
 
-use std::path::Path;
-use std::process::Command;
 use std::collections::HashSet;
 use std::fs;
+use std::path::Path;
 use std::path::PathBuf;
+use std::process::Command;
 
-use crate::error::SimardError;
 use super::{MAX_GOAL_ID_LEN, WORKTREES_SUBDIR};
+use crate::error::SimardError;
 
 use super::{
-    EngineerClaim, ENGINEER_CLAIM_FILE, SweepReport, claim_is_live, is_pid_alive_public,
+    ENGINEER_CLAIM_FILE, EngineerClaim, SweepReport, claim_is_live, is_pid_alive_public,
     read_engineer_claim_full, read_pid_starttime_public, worktree_mutation_lock,
 };
-
 
 /// Sweep `<state_root>/engineer-worktrees/` for orphans on daemon boot.
 ///

--- a/src/gym/scenarios/checks.rs
+++ b/src/gym/scenarios/checks.rs
@@ -1,7 +1,7 @@
 //! Class-specific check builders for `BenchmarkScenario`s.
 
-use crate::handoff::RuntimeHandoffSnapshot;
 use super::super::types::{BenchmarkCheckResult, BenchmarkClass, BenchmarkScenario};
+use crate::handoff::RuntimeHandoffSnapshot;
 
 pub(crate) fn class_specific_checks(
     scenario: &BenchmarkScenario,
@@ -20,33 +20,61 @@ pub(crate) fn class_specific_checks(
         BenchmarkClass::Documentation => super::checks_3::checks_for_documentation(&combined),
         BenchmarkClass::SafeCodeChange => super::checks_3::checks_for_safe_code_change(&combined),
         BenchmarkClass::TestWriting => super::checks_6::checks_for_test_writing(&combined),
-        BenchmarkClass::SessionQuality => super::checks_5::checks_for_session_quality(&combined, outcome, exported),
+        BenchmarkClass::SessionQuality => {
+            super::checks_5::checks_for_session_quality(&combined, outcome, exported)
+        }
         BenchmarkClass::BugFix => super::checks_1::checks_for_bug_fix(&combined),
         BenchmarkClass::Refactoring => super::checks_4::checks_for_refactoring(&combined),
-        BenchmarkClass::DependencyAnalysis => super::checks_1::checks_for_dependency_analysis(&combined),
+        BenchmarkClass::DependencyAnalysis => {
+            super::checks_1::checks_for_dependency_analysis(&combined)
+        }
         BenchmarkClass::ErrorHandling => super::checks_4::checks_for_error_handling(&combined),
-        BenchmarkClass::PerformanceAnalysis => super::checks_3::checks_for_performance_analysis(&combined),
+        BenchmarkClass::PerformanceAnalysis => {
+            super::checks_3::checks_for_performance_analysis(&combined)
+        }
         BenchmarkClass::SecurityAudit => super::checks_3::checks_for_security_audit(&combined),
         BenchmarkClass::ApiDesign => super::checks_4::checks_for_api_design(&combined),
         BenchmarkClass::CodeReview => super::checks_2::checks_for_code_review(&combined),
         BenchmarkClass::Debugging => super::checks_6::checks_for_debugging(&combined),
-        BenchmarkClass::ConfigManagement => super::checks_6::checks_for_config_management(&combined),
-        BenchmarkClass::ConcurrencyAnalysis => super::checks_2::checks_for_concurrency_analysis(&combined),
-        BenchmarkClass::MigrationPlanning => super::checks_2::checks_for_migration_planning(&combined),
-        BenchmarkClass::ObservabilityInstrumentation => super::checks_5::checks_for_observability_instrumentation(&combined),
+        BenchmarkClass::ConfigManagement => {
+            super::checks_6::checks_for_config_management(&combined)
+        }
+        BenchmarkClass::ConcurrencyAnalysis => {
+            super::checks_2::checks_for_concurrency_analysis(&combined)
+        }
+        BenchmarkClass::MigrationPlanning => {
+            super::checks_2::checks_for_migration_planning(&combined)
+        }
+        BenchmarkClass::ObservabilityInstrumentation => {
+            super::checks_5::checks_for_observability_instrumentation(&combined)
+        }
         BenchmarkClass::DataModeling => super::checks_5::checks_for_data_modeling(&combined),
         BenchmarkClass::DataMigration => super::checks_1::checks_for_data_migration(&combined),
         BenchmarkClass::CicdPipeline => super::checks_2::checks_for_cicd_pipeline(&combined),
-        BenchmarkClass::DependencyUpgrade => super::checks_1::checks_for_dependency_upgrade(&combined),
-        BenchmarkClass::ReleaseManagement => super::checks_3::checks_for_release_management(&combined),
-        BenchmarkClass::AccessibilityReview => super::checks_2::checks_for_accessibility_review(&combined),
-        BenchmarkClass::InternationalizationReview => super::checks_1::checks_for_internationalization_review(&combined),
-        BenchmarkClass::IncidentResponse => super::checks_3::checks_for_incident_response(&combined),
-        BenchmarkClass::DatabaseSchemaChange => super::checks_4::checks_for_database_schema_change(&combined),
+        BenchmarkClass::DependencyUpgrade => {
+            super::checks_1::checks_for_dependency_upgrade(&combined)
+        }
+        BenchmarkClass::ReleaseManagement => {
+            super::checks_3::checks_for_release_management(&combined)
+        }
+        BenchmarkClass::AccessibilityReview => {
+            super::checks_2::checks_for_accessibility_review(&combined)
+        }
+        BenchmarkClass::InternationalizationReview => {
+            super::checks_1::checks_for_internationalization_review(&combined)
+        }
+        BenchmarkClass::IncidentResponse => {
+            super::checks_3::checks_for_incident_response(&combined)
+        }
+        BenchmarkClass::DatabaseSchemaChange => {
+            super::checks_4::checks_for_database_schema_change(&combined)
+        }
         BenchmarkClass::CachingStrategy => super::checks_5::checks_for_caching_strategy(&combined),
         BenchmarkClass::FeatureFlagging => super::checks_6::checks_for_feature_flagging(&combined),
         BenchmarkClass::RateLimiting => super::checks_4::checks_for_rate_limiting(&combined),
         BenchmarkClass::EventSourcing => super::checks_6::checks_for_event_sourcing(&combined),
-        BenchmarkClass::ChaosEngineering => super::checks_5::checks_for_chaos_engineering(&combined),
+        BenchmarkClass::ChaosEngineering => {
+            super::checks_5::checks_for_chaos_engineering(&combined)
+        }
     }
 }

--- a/src/gym/scenarios/checks_1.rs
+++ b/src/gym/scenarios/checks_1.rs
@@ -71,7 +71,6 @@ pub(super) fn checks_for_internationalization_review(combined: &str) -> Vec<Benc
     ]
 }
 
-
 pub(super) fn checks_for_dependency_upgrade(combined: &str) -> Vec<BenchmarkCheckResult> {
     let upgrade_target_named = combined.contains("cargo.toml")
         || combined.contains("dependenc")
@@ -131,7 +130,6 @@ pub(super) fn checks_for_dependency_upgrade(combined: &str) -> Vec<BenchmarkChec
     ]
 }
 
-
 pub(super) fn checks_for_data_migration(combined: &str) -> Vec<BenchmarkCheckResult> {
     let schema_delta_described = combined.contains("schema")
         || combined.contains("field")
@@ -190,7 +188,6 @@ pub(super) fn checks_for_data_migration(combined: &str) -> Vec<BenchmarkCheckRes
     ]
 }
 
-
 pub(super) fn checks_for_dependency_analysis(combined: &str) -> Vec<BenchmarkCheckResult> {
     let deps_analyzed = combined.contains("cargo.toml")
         || combined.contains("dependenc")
@@ -240,7 +237,6 @@ pub(super) fn checks_for_dependency_analysis(combined: &str) -> Vec<BenchmarkChe
         },
     ]
 }
-
 
 pub(super) fn checks_for_bug_fix(combined: &str) -> Vec<BenchmarkCheckResult> {
     let defect_identified = combined.contains("bug")

--- a/src/gym/scenarios/checks_2.rs
+++ b/src/gym/scenarios/checks_2.rs
@@ -70,7 +70,6 @@ pub(super) fn checks_for_accessibility_review(combined: &str) -> Vec<BenchmarkCh
     ]
 }
 
-
 pub(super) fn checks_for_cicd_pipeline(combined: &str) -> Vec<BenchmarkCheckResult> {
     let workflow_structure_described = combined.contains("workflow")
         || combined.contains("github actions")
@@ -132,7 +131,6 @@ pub(super) fn checks_for_cicd_pipeline(combined: &str) -> Vec<BenchmarkCheckResu
     ]
 }
 
-
 pub(super) fn checks_for_concurrency_analysis(combined: &str) -> Vec<BenchmarkCheckResult> {
     let race_condition_analyzed = combined.contains("race")
         || combined.contains("concurrent")
@@ -189,7 +187,6 @@ pub(super) fn checks_for_concurrency_analysis(combined: &str) -> Vec<BenchmarkCh
     ]
 }
 
-
 pub(super) fn checks_for_migration_planning(combined: &str) -> Vec<BenchmarkCheckResult> {
     let migration_scope_defined = combined.contains("migrat")
         || combined.contains("schema")
@@ -241,7 +238,6 @@ pub(super) fn checks_for_migration_planning(combined: &str) -> Vec<BenchmarkChec
         },
     ]
 }
-
 
 pub(super) fn checks_for_code_review(combined: &str) -> Vec<BenchmarkCheckResult> {
     let review_findings = combined.contains("finding")

--- a/src/gym/scenarios/checks_3.rs
+++ b/src/gym/scenarios/checks_3.rs
@@ -70,7 +70,6 @@ pub(super) fn checks_for_incident_response(combined: &str) -> Vec<BenchmarkCheck
     ]
 }
 
-
 pub(super) fn checks_for_release_management(combined: &str) -> Vec<BenchmarkCheckResult> {
     let version_bump_planned = combined.contains("version")
         || combined.contains("semver")
@@ -131,7 +130,6 @@ pub(super) fn checks_for_release_management(combined: &str) -> Vec<BenchmarkChec
     ]
 }
 
-
 pub(super) fn checks_for_performance_analysis(combined: &str) -> Vec<BenchmarkCheckResult> {
     let complexity_mentioned = combined.contains("o(n")
         || combined.contains("complexity")
@@ -188,7 +186,6 @@ pub(super) fn checks_for_performance_analysis(combined: &str) -> Vec<BenchmarkCh
     ]
 }
 
-
 pub(super) fn checks_for_security_audit(combined: &str) -> Vec<BenchmarkCheckResult> {
     let vulnerability_found = combined.contains("unsafe")
         || combined.contains("vulnerab")
@@ -243,7 +240,6 @@ pub(super) fn checks_for_security_audit(combined: &str) -> Vec<BenchmarkCheckRes
     ]
 }
 
-
 pub(super) fn checks_for_safe_code_change(combined: &str) -> Vec<BenchmarkCheckResult> {
     let compilation_evidence = combined.contains("compil")
         || combined.contains("cargo build")
@@ -281,7 +277,6 @@ pub(super) fn checks_for_safe_code_change(combined: &str) -> Vec<BenchmarkCheckR
         },
     ]
 }
-
 
 pub(super) fn checks_for_documentation(combined: &str) -> Vec<BenchmarkCheckResult> {
     let has_doc_syntax = combined.contains("///")

--- a/src/gym/scenarios/checks_4.rs
+++ b/src/gym/scenarios/checks_4.rs
@@ -68,7 +68,6 @@ pub(super) fn checks_for_database_schema_change(combined: &str) -> Vec<Benchmark
     ]
 }
 
-
 pub(super) fn checks_for_rate_limiting(combined: &str) -> Vec<BenchmarkCheckResult> {
     let algorithm_named = combined.contains("token bucket")
         || combined.contains("token-bucket")
@@ -131,7 +130,6 @@ pub(super) fn checks_for_rate_limiting(combined: &str) -> Vec<BenchmarkCheckResu
     ]
 }
 
-
 pub(super) fn checks_for_api_design(combined: &str) -> Vec<BenchmarkCheckResult> {
     let api_surface_analyzed = combined.contains("pub fn")
         || combined.contains("pub struct")
@@ -188,7 +186,6 @@ pub(super) fn checks_for_api_design(combined: &str) -> Vec<BenchmarkCheckResult>
     ]
 }
 
-
 pub(super) fn checks_for_refactoring(combined: &str) -> Vec<BenchmarkCheckResult> {
     let change_identified = combined.contains("extract")
         || combined.contains("simplif")
@@ -240,7 +237,6 @@ pub(super) fn checks_for_refactoring(combined: &str) -> Vec<BenchmarkCheckResult
         },
     ]
 }
-
 
 pub(super) fn checks_for_error_handling(combined: &str) -> Vec<BenchmarkCheckResult> {
     let error_analysis = combined.contains("unwrap")

--- a/src/gym/scenarios/checks_5.rs
+++ b/src/gym/scenarios/checks_5.rs
@@ -67,7 +67,6 @@ pub(super) fn checks_for_caching_strategy(combined: &str) -> Vec<BenchmarkCheckR
     ]
 }
 
-
 pub(super) fn checks_for_chaos_engineering(combined: &str) -> Vec<BenchmarkCheckResult> {
     let experiment_or_fault_described = combined.contains("chaos")
         || combined.contains("fault injection")
@@ -132,8 +131,9 @@ pub(super) fn checks_for_chaos_engineering(combined: &str) -> Vec<BenchmarkCheck
     ]
 }
 
-
-pub(super) fn checks_for_observability_instrumentation(combined: &str) -> Vec<BenchmarkCheckResult> {
+pub(super) fn checks_for_observability_instrumentation(
+    combined: &str,
+) -> Vec<BenchmarkCheckResult> {
     let instrumentation_analyzed = combined.contains("log")
         || combined.contains("trac")
         || combined.contains("metric")
@@ -189,7 +189,6 @@ pub(super) fn checks_for_observability_instrumentation(combined: &str) -> Vec<Be
     ]
 }
 
-
 pub(super) fn checks_for_data_modeling(combined: &str) -> Vec<BenchmarkCheckResult> {
     let model_analyzed = combined.contains("type")
         || combined.contains("struct")
@@ -242,7 +241,6 @@ pub(super) fn checks_for_data_modeling(combined: &str) -> Vec<BenchmarkCheckResu
     ]
 }
 
-
 pub(super) fn checks_for_repo_exploration(combined: &str) -> Vec<BenchmarkCheckResult> {
     let structure_mentioned = combined.contains("src/")
         || combined.contains("directory")
@@ -286,7 +284,6 @@ pub(super) fn checks_for_repo_exploration(combined: &str) -> Vec<BenchmarkCheckR
         },
     ]
 }
-
 
 pub(super) fn checks_for_session_quality(
     combined: &str,

--- a/src/gym/scenarios/checks_6.rs
+++ b/src/gym/scenarios/checks_6.rs
@@ -66,7 +66,6 @@ pub(super) fn checks_for_feature_flagging(combined: &str) -> Vec<BenchmarkCheckR
     ]
 }
 
-
 pub(super) fn checks_for_event_sourcing(combined: &str) -> Vec<BenchmarkCheckResult> {
     let event_store_described = combined.contains("event store")
         || combined.contains("event-store")
@@ -131,7 +130,6 @@ pub(super) fn checks_for_event_sourcing(combined: &str) -> Vec<BenchmarkCheckRes
     ]
 }
 
-
 pub(super) fn checks_for_debugging(combined: &str) -> Vec<BenchmarkCheckResult> {
     let root_cause_traced = combined.contains("trace")
         || combined.contains("origin")
@@ -188,7 +186,6 @@ pub(super) fn checks_for_debugging(combined: &str) -> Vec<BenchmarkCheckResult> 
     ]
 }
 
-
 pub(super) fn checks_for_config_management(combined: &str) -> Vec<BenchmarkCheckResult> {
     let config_inventoried = combined.contains("config")
         || combined.contains("feature")
@@ -240,7 +237,6 @@ pub(super) fn checks_for_config_management(combined: &str) -> Vec<BenchmarkCheck
         },
     ]
 }
-
 
 pub(super) fn checks_for_test_writing(combined: &str) -> Vec<BenchmarkCheckResult> {
     let has_test_annotation = combined.contains("#[test]")

--- a/src/gym/scenarios/data_1.rs
+++ b/src/gym/scenarios/data_1.rs
@@ -1,7 +1,7 @@
 //! Auto-split BENCHMARK_SCENARIOS data — chunk 1 of 5.
 
-use crate::runtime::RuntimeTopology;
 use super::super::types::{BenchmarkClass, BenchmarkScenario};
+use crate::runtime::RuntimeTopology;
 
 pub(super) static SCENARIOS: [BenchmarkScenario; 31] = [
     BenchmarkScenario {

--- a/src/gym/scenarios/data_2.rs
+++ b/src/gym/scenarios/data_2.rs
@@ -1,7 +1,7 @@
 //! Auto-split BENCHMARK_SCENARIOS data — chunk 2 of 5.
 
-use crate::runtime::RuntimeTopology;
 use super::super::types::{BenchmarkClass, BenchmarkScenario};
+use crate::runtime::RuntimeTopology;
 
 pub(super) static SCENARIOS: [BenchmarkScenario; 31] = [
     BenchmarkScenario {

--- a/src/gym/scenarios/data_3.rs
+++ b/src/gym/scenarios/data_3.rs
@@ -1,7 +1,7 @@
 //! Auto-split BENCHMARK_SCENARIOS data — chunk 3 of 5.
 
-use crate::runtime::RuntimeTopology;
 use super::super::types::{BenchmarkClass, BenchmarkScenario};
+use crate::runtime::RuntimeTopology;
 
 pub(super) static SCENARIOS: [BenchmarkScenario; 31] = [
     BenchmarkScenario {

--- a/src/gym/scenarios/data_4.rs
+++ b/src/gym/scenarios/data_4.rs
@@ -1,7 +1,7 @@
 //! Auto-split BENCHMARK_SCENARIOS data — chunk 4 of 5.
 
-use crate::runtime::RuntimeTopology;
 use super::super::types::{BenchmarkClass, BenchmarkScenario};
+use crate::runtime::RuntimeTopology;
 
 pub(super) static SCENARIOS: [BenchmarkScenario; 31] = [
     BenchmarkScenario {

--- a/src/gym/scenarios/data_5.rs
+++ b/src/gym/scenarios/data_5.rs
@@ -1,7 +1,7 @@
 //! Auto-split BENCHMARK_SCENARIOS data — chunk 5 of 5.
 
-use crate::runtime::RuntimeTopology;
 use super::super::types::{BenchmarkClass, BenchmarkScenario};
+use crate::runtime::RuntimeTopology;
 
 pub(super) static SCENARIOS: [BenchmarkScenario; 29] = [
     BenchmarkScenario {

--- a/src/gym/scenarios/mod.rs
+++ b/src/gym/scenarios/mod.rs
@@ -44,7 +44,6 @@ pub(super) fn resolve_benchmark_scenario(scenario_id: &str) -> SimardResult<Benc
         })
 }
 
-
 mod checks;
 mod checks_1;
 mod checks_2;

--- a/src/meeting_backend/closing.rs
+++ b/src/meeting_backend/closing.rs
@@ -6,14 +6,14 @@ use tracing::{info, warn};
 use crate::cognitive_memory::CognitiveMemoryOps;
 use crate::error::{SimardError, SimardResult};
 
-use super::MeetingBackend;
-use super::persist;
-use super::types::MeetingTranscript;
 use super::EMPTY_RESPONSE_SENTINEL;
+use super::MeetingBackend;
 use super::SUMMARY_TIMEOUT;
+use super::persist;
 use super::types::HandoffActionItem;
-use super::types::Role;
 use super::types::MeetingSummary;
+use super::types::MeetingTranscript;
+use super::types::Role;
 
 impl MeetingBackend {
     /// Close the meeting session: summarize, extract action items, link goals,

--- a/src/meeting_backend/messaging.rs
+++ b/src/meeting_backend/messaging.rs
@@ -6,9 +6,9 @@ use tracing::{debug, info, warn};
 use crate::base_types::{BaseTypeOutcome, BaseTypeTurnInput};
 use crate::error::{SimardError, SimardResult};
 
-use super::{EMPTY_RESPONSE_SENTINEL, MAX_HISTORY, MeetingBackend};
-use super::types::{MeetingResponse, Role};
 use super::sanitize::extract_response;
+use super::types::{MeetingResponse, Role};
+use super::{EMPTY_RESPONSE_SENTINEL, MAX_HISTORY, MeetingBackend};
 
 impl MeetingBackend {
     /// Send a user message and get Simard's response.

--- a/src/meeting_backend/persist/cognitive.rs
+++ b/src/meeting_backend/persist/cognitive.rs
@@ -8,7 +8,6 @@ use crate::meeting_facilitator::{ActionItem, MeetingDecision, MeetingHandoff, Op
 
 use super::super::types::{ConversationMessage, HandoffActionItem, MeetingTranscript};
 
-
 /// Store the meeting as an episodic memory via the cognitive bridge.
 pub fn store_cognitive_memory(
     bridge: &dyn CognitiveMemoryOps,
@@ -74,7 +73,6 @@ pub fn store_cognitive_memory(
 ///
 /// The file includes YAML frontmatter (topic, date, participants) and the
 /// conversation transcript formatted as markdown.
-
 
 /// Store enriched meeting data (with action items) into episodic memory.
 pub fn store_enriched_cognitive_memory(

--- a/src/meeting_backend/persist/extract.rs
+++ b/src/meeting_backend/persist/extract.rs
@@ -5,7 +5,6 @@ use crate::meeting_facilitator::{ActionItem, MeetingDecision, MeetingHandoff, Op
 
 use crate::meeting_backend::types::{ConversationMessage, HandoffActionItem};
 
-
 const ACTION_SIGNALS: &[&str] = &[
     "action item:",
     "todo:",
@@ -46,9 +45,6 @@ const DEADLINE_SIGNALS: &[&str] = &[
     "today",
     "tonight",
 ];
-
-
-
 
 /// Extract structured action items from a conversation transcript.
 ///

--- a/src/meeting_backend/persist/markdown.rs
+++ b/src/meeting_backend/persist/markdown.rs
@@ -9,12 +9,12 @@ use tracing::{info, warn};
 use crate::error::{SimardError, SimardResult};
 use crate::meeting_facilitator::{ActionItem, MeetingDecision, MeetingHandoff, OpenQuestion};
 
-use crate::meeting_backend::types::{ConversationMessage, HandoffActionItem, MeetingTranscript};
 use super::extract::{
     extract_action_items, extract_decision_participants_pub, extract_decision_rationale_pub,
     extract_decisions, extract_open_questions, extract_themes,
 };
 use super::{meetings_dir, sanitize_filename};
+use crate::meeting_backend::types::{ConversationMessage, HandoffActionItem, MeetingTranscript};
 
 pub fn write_markdown_export(
     topic: &str,
@@ -252,4 +252,3 @@ pub fn write_handoff_markdown_report(
     info!(path = %path.display(), "Meeting handoff report written");
     Ok(path)
 }
-

--- a/src/meeting_backend/persist/mod.rs
+++ b/src/meeting_backend/persist/mod.rs
@@ -244,6 +244,11 @@ mod extract;
 mod templates;
 
 pub use cognitive::{store_cognitive_memory, store_enriched_cognitive_memory};
-pub(crate) use extract::{clean_action_description, extract_assignee, extract_deadline, split_sentences};
-pub use extract::{ extract_action_items, extract_decisions, extract_open_questions, extract_themes, extract_decision_rationale_pub, extract_decision_participants_pub, link_action_items_to_goals};
+pub(crate) use extract::{
+    clean_action_description, extract_assignee, extract_deadline, split_sentences,
+};
+pub use extract::{
+    extract_action_items, extract_decision_participants_pub, extract_decision_rationale_pub,
+    extract_decisions, extract_open_questions, extract_themes, link_action_items_to_goals,
+};
 pub use templates::{MeetingTemplate, TEMPLATES, find_template};

--- a/src/meeting_backend/persist/templates.rs
+++ b/src/meeting_backend/persist/templates.rs
@@ -1,6 +1,5 @@
 //! Built-in meeting templates and lookup.
 
-
 /// Meeting template content (agenda and prompts) for common meeting types.
 pub struct MeetingTemplate {
     pub name: &'static str,

--- a/src/memory_ipc/mod.rs
+++ b/src/memory_ipc/mod.rs
@@ -168,11 +168,10 @@ pub(crate) fn read_frame<R: Read>(r: &mut R) -> SimardResult<Vec<u8>> {
     Ok(buf)
 }
 
-mod server;
 mod client;
+mod server;
 pub use client::RemoteCognitiveMemory;
 pub use server::{ServerHandle, spawn_server};
-
 
 // ============================================================================
 // Shared-memory adapter: Arc → Box<dyn CognitiveMemoryOps>

--- a/src/memory_ipc/server.rs
+++ b/src/memory_ipc/server.rs
@@ -11,7 +11,6 @@ use crate::error::{SimardError, SimardResult};
 
 use super::{MemoryRequest, MemoryResponse, ipc_err, read_frame, write_frame};
 
-
 // ============================================================================
 // Server
 // ============================================================================

--- a/src/ooda_actions/goal_session/advance.rs
+++ b/src/ooda_actions/goal_session/advance.rs
@@ -9,7 +9,9 @@ use super::gh::{
     dispatch_gh_issue_close, dispatch_gh_issue_comment, dispatch_gh_issue_create,
     dispatch_gh_pr_comment, find_duplicate_open_issue,
 };
-use super::{GoalAction, GoalSessionResult, OUTCOME_TEXT_MAX, parse_goal_action, truncate_for_outcome};
+use super::{
+    GoalAction, GoalSessionResult, OUTCOME_TEXT_MAX, parse_goal_action, truncate_for_outcome,
+};
 
 pub(crate) fn assess_only_outcome(
     action: &PlannedAction,

--- a/src/ooda_actions/goal_session/gh.rs
+++ b/src/ooda_actions/goal_session/gh.rs
@@ -122,14 +122,22 @@ pub(crate) fn is_plausible_label(label: &str) -> bool {
     label.chars().any(|c| c.is_alphanumeric())
 }
 
-pub(super) fn dispatch_gh_issue_comment(repo: &str, issue: u64, body: &str) -> Result<String, String> {
+pub(super) fn dispatch_gh_issue_comment(
+    repo: &str,
+    issue: u64,
+    body: &str,
+) -> Result<String, String> {
     let issue_str = issue.to_string();
     run_gh(&[
         "issue", "comment", &issue_str, "--repo", repo, "--body", body,
     ])
 }
 
-pub(super) fn dispatch_gh_issue_close(repo: &str, issue: u64, comment: Option<&str>) -> Result<(), String> {
+pub(super) fn dispatch_gh_issue_close(
+    repo: &str,
+    issue: u64,
+    comment: Option<&str>,
+) -> Result<(), String> {
     let issue_str = issue.to_string();
     if let Some(body) = comment
         && !body.trim().is_empty()
@@ -146,4 +154,3 @@ pub(super) fn dispatch_gh_pr_comment(repo: &str, pr: u64, body: &str) -> Result<
     let pr_str = pr.to_string();
     run_gh(&["pr", "comment", &pr_str, "--repo", repo, "--body", body])
 }
-

--- a/src/ooda_actions/goal_session/mod.rs
+++ b/src/ooda_actions/goal_session/mod.rs
@@ -372,7 +372,6 @@ pub(super) fn truncate_for_outcome(s: &str) -> String {
 ///
 /// Fixes #1258: the previous `let _ = update_goal_progress(...)` swallowed
 /// the error and the next log line lied about success.
-
 mod advance;
 mod gh;
 

--- a/src/ooda_actions/tests_goal_session_inline.rs
+++ b/src/ooda_actions/tests_goal_session_inline.rs
@@ -315,5 +315,4 @@ Hope that helps!"#;
             other => panic!("expected SpawnEngineer, got {other:?}"),
         }
     }
-
 }

--- a/src/ooda_actions/tests_goal_session_validators.rs
+++ b/src/ooda_actions/tests_goal_session_validators.rs
@@ -28,7 +28,6 @@ mod label_sanitizer_tests {
     }
 }
 
-
 mod placeholder_echo_tests {
     use crate::ooda_actions::goal_session::{GoalAction, action_is_valid, is_placeholder_echo};
 
@@ -120,7 +119,6 @@ mod placeholder_echo_tests {
         assert!(!action_is_valid(&action));
     }
 }
-
 
 mod makework_title_tests {
     use crate::ooda_actions::goal_session::{GoalAction, action_is_valid, is_makework_title};

--- a/src/operator_commands_dashboard/activity.rs
+++ b/src/operator_commands_dashboard/activity.rs
@@ -1,9 +1,9 @@
 use axum::Json;
 use serde_json::{Value, json};
 
+use super::current_work::read_recent_cycle_reports;
 use super::logs::read_tail;
 use super::routes::{resolve_state_root, run_gh_json};
-use super::current_work::read_recent_cycle_reports;
 
 pub(crate) async fn traces() -> Json<Value> {
     // Read recent spans from the trace log file

--- a/src/operator_commands_dashboard/auth.rs
+++ b/src/operator_commands_dashboard/auth.rs
@@ -256,7 +256,6 @@ mod tests {
     }
 }
 
-
 // === Login HTTP handlers ===
 
 use axum::{Json, response};

--- a/src/operator_commands_dashboard/distributed.rs
+++ b/src/operator_commands_dashboard/distributed.rs
@@ -1,8 +1,8 @@
 use axum::Json;
 use serde_json::{Value, json};
 
-use super::routes::run_gh_json;
 use super::hosts::{host_entry_name, load_hosts, save_hosts};
+use super::routes::run_gh_json;
 
 /// Map the configured hosts list (the canonical source used by the Cluster
 /// Topology panel via `load_hosts()`) into the entries rendered by the

--- a/src/operator_commands_dashboard/goals.rs
+++ b/src/operator_commands_dashboard/goals.rs
@@ -259,7 +259,10 @@ pub(crate) async fn remove_goal(Path(id): Path<String>) -> Json<Value> {
     }
 }
 
-pub(crate) async fn update_goal_status(Path(id): Path<String>, Json(body): Json<Value>) -> Json<Value> {
+pub(crate) async fn update_goal_status(
+    Path(id): Path<String>,
+    Json(body): Json<Value>,
+) -> Json<Value> {
     let state_root = resolve_state_root();
     let goal_path = state_root.join("goal_records.json");
     let content = std::fs::read_to_string(&goal_path).unwrap_or_default();
@@ -372,4 +375,3 @@ pub(crate) async fn demote_goal(Path(id): Path<String>) -> Json<Value> {
         Err(e) => Json(json!({"error": format!("{e}")})),
     }
 }
-

--- a/src/operator_commands_dashboard/hosts.rs
+++ b/src/operator_commands_dashboard/hosts.rs
@@ -26,7 +26,6 @@ pub(crate) fn save_hosts(hosts: &[Value]) -> std::io::Result<()> {
     )
 }
 
-
 /// Compare two hostnames as short, case-insensitive names.
 ///
 /// Strips the first dot onward (FQDN suffix) on both sides and lowercases
@@ -67,7 +66,11 @@ pub(crate) fn host_entry_name(entry: &Value) -> &str {
 ///
 /// **Security: This is a UI hint only — MUST NOT be used for authorization
 /// decisions.** Hostnames are user-controlled and easily spoofed.
-pub(crate) fn tag_local_membership(hosts: &mut [Value], cluster_members: &[String], local_hostname: &str) {
+pub(crate) fn tag_local_membership(
+    hosts: &mut [Value],
+    cluster_members: &[String],
+    local_hostname: &str,
+) {
     let in_cluster =
         |name: &str| -> bool { cluster_members.iter().any(|m| is_local_host(m, name)) };
     for entry in hosts.iter_mut() {

--- a/src/operator_commands_dashboard/logs.rs
+++ b/src/operator_commands_dashboard/logs.rs
@@ -3,8 +3,8 @@ use std::path::PathBuf;
 use axum::Json;
 use serde_json::{Value, json};
 
-use crate::error::SimardResult;
 use super::routes::resolve_state_root;
+use crate::error::SimardResult;
 
 // ---------------------------------------------------------------------------
 // Logs endpoint — returns tail of daemon log + OODA transcripts

--- a/src/operator_commands_dashboard/metrics.rs
+++ b/src/operator_commands_dashboard/metrics.rs
@@ -1,9 +1,9 @@
 use axum::Json;
 use serde_json::{Value, json};
 
-use crate::cognitive_memory::{CognitiveMemoryOps, NativeCognitiveMemory, as_f64, as_i64, as_str};
 use super::routes::resolve_state_root;
 use super::subagent::{count_json_records, file_metrics};
+use crate::cognitive_memory::{CognitiveMemoryOps, NativeCognitiveMemory, as_f64, as_i64, as_str};
 
 // ---------------------------------------------------------------------------
 // Memory metrics panel

--- a/src/operator_commands_dashboard/mod.rs
+++ b/src/operator_commands_dashboard/mod.rs
@@ -1,21 +1,21 @@
-mod auth;
-mod monitoring;
-mod goals;
-mod memory;
 mod activity;
-mod workboard;
+mod agent_log;
+mod auth;
+mod chat;
 mod current_work;
 mod distributed;
-mod tmux;
+mod goals;
 mod hosts;
-mod chat;
-mod logs;
-mod registry;
-mod metrics;
-mod agent_log;
-mod subagent;
 mod index_html;
+mod logs;
+mod memory;
+mod metrics;
+mod monitoring;
+mod registry;
 pub(crate) mod routes;
+mod subagent;
+mod tmux;
+mod workboard;
 
 #[cfg(test)]
 mod tests_attach;

--- a/src/operator_commands_dashboard/registry.rs
+++ b/src/operator_commands_dashboard/registry.rs
@@ -1,10 +1,10 @@
 use axum::Json;
 use serde_json::{Value, json};
 
-use crate::agent_registry::{AgentRegistry, FileBackedAgentRegistry};
-use crate::build_lock::BuildLock;
 use super::memory::build_agent_graph;
 use super::routes::resolve_state_root;
+use crate::agent_registry::{AgentRegistry, FileBackedAgentRegistry};
+use crate::build_lock::BuildLock;
 
 // ---------------------------------------------------------------------------
 // Agent Registry API (#296)
@@ -69,8 +69,6 @@ pub(crate) async fn registry_reap() -> Json<Value> {
 // Pure builder is unit-tested; HTTP handler sources live data from the
 // existing FileBackedAgentRegistry.
 // ---------------------------------------------------------------------------
-
-
 
 pub(crate) async fn agent_graph() -> Json<Value> {
     let reg = FileBackedAgentRegistry::new(&resolve_state_root());

--- a/src/operator_commands_dashboard/routes.rs
+++ b/src/operator_commands_dashboard/routes.rs
@@ -7,23 +7,31 @@ use axum::{
 };
 use serde_json::{Value, json};
 
-use super::auth::{login, login_page, require_auth};
-use super::monitoring::{costs, get_budget, metrics, set_budget};
 use super::activity::{activity, traces};
-use super::workboard::workboard;
+use super::agent_log::{WS_AGENT_LOG_ROUTE, ws_agent_log_handler};
+use super::auth::{login, login_page, require_auth};
+use super::chat::ws_chat_handler;
 use super::current_work::current_work;
 use super::distributed::{distributed, strip_ansi_codes, vacate_vm};
-use super::tmux::{azlin_tmux_sessions, ws_tmux_attach_handler};
-use super::chat::ws_chat_handler;
+use super::goals::{
+    add_goal, demote_goal, goals, promote_backlog_item, remove_goal, seed_goals, update_goal_status,
+};
+use super::hosts::{
+    add_host, get_hosts, host_entry_name, is_local_host, load_hosts, remove_host, save_hosts,
+    tag_local_membership,
+};
 use super::logs::read_tail;
-use super::subagent::{disk_usage_pct, file_metrics, count_json_records, subagent_sessions};
-use super::agent_log::{WS_AGENT_LOG_ROUTE, ws_agent_log_handler};
-use super::metrics::{memory_metrics, ooda_thinking};
-use super::registry::{agent_graph, build_lock_force_release, build_lock_status, registry_deregister, registry_list, registry_register, registry_reap};
 use super::logs::{logs, processes, read_journal_logs};
-use super::hosts::{add_host, get_hosts, host_entry_name, is_local_host, load_hosts, remove_host, save_hosts, tag_local_membership};
 use super::memory::{build_agent_graph, classify_agent_layer, memory_graph, memory_search};
-use super::goals::{add_goal, demote_goal, goals, promote_backlog_item, remove_goal, seed_goals, update_goal_status};
+use super::metrics::{memory_metrics, ooda_thinking};
+use super::monitoring::{costs, get_budget, metrics, set_budget};
+use super::registry::{
+    agent_graph, build_lock_force_release, build_lock_status, registry_deregister, registry_list,
+    registry_reap, registry_register,
+};
+use super::subagent::{count_json_records, disk_usage_pct, file_metrics, subagent_sessions};
+use super::tmux::{azlin_tmux_sessions, ws_tmux_attach_handler};
+use super::workboard::workboard;
 use crate::agent_registry::{AgentRegistry, FileBackedAgentRegistry};
 use crate::build_lock::BuildLock;
 use crate::cognitive_memory::{CognitiveMemoryOps, NativeCognitiveMemory, as_f64, as_i64, as_str};
@@ -83,7 +91,6 @@ pub fn build_router() -> Router {
         .route("/", get(index))
         .layer(middleware::from_fn(require_auth))
 }
-
 
 async fn status() -> Json<Value> {
     let version = format!(
@@ -176,13 +183,6 @@ async fn issues() -> Json<Value> {
     }
 }
 
-
-
-
-
-
-
-
 pub(crate) fn is_pid_alive(pid: u32) -> bool {
     std::path::Path::new(&format!("/proc/{pid}")).exists()
 }
@@ -211,10 +211,6 @@ pub(crate) fn truncate_with_ellipsis(s: &str, max: usize) -> String {
     }
 }
 
-
-
-
-
 /// Vacate a remote VM: stop Simard processes and export memory snapshot.
 ///
 /// Steps:
@@ -226,14 +222,9 @@ pub(crate) fn truncate_with_ellipsis(s: &str, max: usize) -> String {
 /// Strip ANSI escape sequences (CSI, OSC, and single-char escapes) so that
 /// output from azlin/SSH can be reliably parsed for KEY=value markers.
 
-
 async fn index() -> axum::response::Html<String> {
     axum::response::Html(super::index_html::index_html_string())
 }
-
-
-
-
 
 pub(crate) fn resolve_state_root() -> std::path::PathBuf {
     std::env::var("SIMARD_STATE_ROOT")
@@ -243,4 +234,3 @@ pub(crate) fn resolve_state_root() -> std::path::PathBuf {
             std::path::PathBuf::from(home).join(".simard")
         })
 }
-

--- a/src/operator_commands_dashboard/subagent.rs
+++ b/src/operator_commands_dashboard/subagent.rs
@@ -1,8 +1,6 @@
 use axum::Json;
 use serde_json::{Value, json};
 
-
-
 pub(crate) fn file_metrics(path: &std::path::Path) -> (u64, Option<String>) {
     match std::fs::metadata(path) {
         Ok(m) => {
@@ -38,7 +36,6 @@ pub(crate) async fn disk_usage_pct() -> Option<u8> {
     let line = text.lines().nth(1)?;
     line.trim().trim_end_matches('%').parse().ok()
 }
-
 
 /// WS-2: list live and recently-ended subagent tmux sessions.
 ///

--- a/src/operator_commands_dashboard/tests_routes_a.rs
+++ b/src/operator_commands_dashboard/tests_routes_a.rs
@@ -1,12 +1,18 @@
 #[cfg(test)]
 mod tests {
-    use crate::operator_commands_dashboard::routes::*;
-    use crate::operator_commands_dashboard::index_html::INDEX_HTML;
-    use crate::operator_commands_dashboard::agent_log::{sanitize_agent_name, agent_log_path, WS_AGENT_LOG_ROUTE};
-    use crate::operator_commands_dashboard::tmux::TmuxSession;
+    use crate::operator_commands_dashboard::agent_log::{
+        WS_AGENT_LOG_ROUTE, agent_log_path, sanitize_agent_name,
+    };
+    use crate::operator_commands_dashboard::current_work::{
+        format_recent_actions_for_cycle, read_recent_cycle_reports,
+    };
     use crate::operator_commands_dashboard::distributed::remote_vms_from_hosts;
-    use crate::operator_commands_dashboard::hosts::{host_entry_name, is_local_host, load_hosts, tag_local_membership};
-    use crate::operator_commands_dashboard::current_work::{format_recent_actions_for_cycle, read_recent_cycle_reports};
+    use crate::operator_commands_dashboard::hosts::{
+        host_entry_name, is_local_host, load_hosts, tag_local_membership,
+    };
+    use crate::operator_commands_dashboard::index_html::INDEX_HTML;
+    use crate::operator_commands_dashboard::routes::*;
+    use crate::operator_commands_dashboard::tmux::TmuxSession;
     use serde_json::json;
 
     #[test]
@@ -393,5 +399,4 @@ mod tests {
         let max_len: String = std::iter::repeat_n('x', 64).collect();
         assert_eq!(sanitize_agent_name(&max_len), Some(max_len.clone()));
     }
-
 }

--- a/src/operator_commands_dashboard/tests_routes_b.rs
+++ b/src/operator_commands_dashboard/tests_routes_b.rs
@@ -1,12 +1,14 @@
 #[cfg(test)]
 mod tests_b {
-    use crate::operator_commands_dashboard::routes::*;
-    use crate::operator_commands_dashboard::index_html::INDEX_HTML;
-    use crate::operator_commands_dashboard::agent_log::{sanitize_agent_name, agent_log_path, WS_AGENT_LOG_ROUTE};
-    use crate::operator_commands_dashboard::tmux::parse_tmux_sessions;
+    use crate::operator_commands_dashboard::agent_log::{
+        WS_AGENT_LOG_ROUTE, agent_log_path, sanitize_agent_name,
+    };
     use crate::operator_commands_dashboard::hosts::{host_entry_name, load_hosts};
+    use crate::operator_commands_dashboard::index_html::INDEX_HTML;
     use crate::operator_commands_dashboard::memory::{build_agent_graph, classify_agent_layer};
+    use crate::operator_commands_dashboard::routes::*;
     use crate::operator_commands_dashboard::tmux::TmuxSession;
+    use crate::operator_commands_dashboard::tmux::parse_tmux_sessions;
     use serde_json::json;
     #[test]
     fn sanitize_agent_name_rejects_invalid_names() {

--- a/src/operator_commands_dashboard/tmux.rs
+++ b/src/operator_commands_dashboard/tmux.rs
@@ -5,8 +5,8 @@ use axum::{
 };
 use serde_json::{Value, json};
 
-use super::hosts::{host_entry_name, load_hosts};
 use super::distributed::strip_ansi_codes;
+use super::hosts::{host_entry_name, load_hosts};
 use axum::extract::Path;
 
 // WS-1 AZLIN-TMUX-SESSIONS-LIST: per-host tmux session listing via azlin connect.

--- a/src/operator_commands_dashboard/workboard.rs
+++ b/src/operator_commands_dashboard/workboard.rs
@@ -1,12 +1,12 @@
 use axum::Json;
 use serde_json::{Value, json};
 
-use super::routes::{is_pid_alive, resolve_state_root};
-use super::current_work::read_recent_cycle_reports;
-use crate::agent_registry::{AgentRegistry, FileBackedAgentRegistry};
-use crate::goal_curation::GoalBoard;
-use crate::cognitive_memory::{CognitiveMemoryOps, NativeCognitiveMemory};
 use super::current_work::format_recent_actions_for_cycle;
+use super::current_work::read_recent_cycle_reports;
+use super::routes::{is_pid_alive, resolve_state_root};
+use crate::agent_registry::{AgentRegistry, FileBackedAgentRegistry};
+use crate::cognitive_memory::{CognitiveMemoryOps, NativeCognitiveMemory};
+use crate::goal_curation::GoalBoard;
 
 // ---------------------------------------------------------------------------
 // Workboard API — aggregated view of Simard's current mental state


### PR DESCRIPTION
Pure cargo-fmt cleanup over 51 files. Addresses the fmt-drift symptom of #1031.

`cargo build --tests` clean post-fmt. Clippy follow-up is separate.