### PR TITLE
chore(dashboard): remove unused imports (#1031)

### DIFF
--- a/src/operator_commands_dashboard/current_work.rs
+++ b/src/operator_commands_dashboard/current_work.rs
@@ -4,7 +4,6 @@ use serde_json::{Value, json};
 use super::routes::{is_pid_alive, resolve_state_root, truncate_with_ellipsis};
 use crate::agent_registry::{AgentRegistry, FileBackedAgentRegistry};
 use crate::goal_curation::GoalBoard;
-use crate::goals::GoalRecord;
 
 /// Real-time snapshot of what Simard is doing right now.
 ///

--- a/src/operator_commands_dashboard/distributed.rs
+++ b/src/operator_commands_dashboard/distributed.rs
@@ -2,7 +2,6 @@ use axum::Json;
 use serde_json::{Value, json};
 
 use super::hosts::{host_entry_name, load_hosts, save_hosts};
-use super::routes::run_gh_json;
 
 /// Map the configured hosts list (the canonical source used by the Cluster
 /// Topology panel via `load_hosts()`) into the entries rendered by the

--- a/src/operator_commands_dashboard/goals.rs
+++ b/src/operator_commands_dashboard/goals.rs
@@ -3,7 +3,7 @@ use axum::extract::Path;
 use serde_json::{Value, json};
 
 use super::routes::resolve_state_root;
-use crate::cognitive_memory::{CognitiveMemoryOps, NativeCognitiveMemory, as_f64, as_i64, as_str};
+use crate::cognitive_memory::{CognitiveMemoryOps, NativeCognitiveMemory};
 use crate::goal_curation::{ActiveGoal, BacklogItem, GoalBoard, GoalProgress, MAX_ACTIVE_GOALS};
 use crate::goals::{GoalRecord, goal_slug};
 

--- a/src/operator_commands_dashboard/logs.rs
+++ b/src/operator_commands_dashboard/logs.rs
@@ -1,10 +1,8 @@
-use std::path::PathBuf;
 
 use axum::Json;
 use serde_json::{Value, json};
 
 use super::routes::resolve_state_root;
-use crate::error::SimardResult;
 
 // ---------------------------------------------------------------------------
 // Logs endpoint — returns tail of daemon log + OODA transcripts

--- a/src/operator_commands_dashboard/metrics.rs
+++ b/src/operator_commands_dashboard/metrics.rs
@@ -3,7 +3,7 @@ use serde_json::{Value, json};
 
 use super::routes::resolve_state_root;
 use super::subagent::{count_json_records, file_metrics};
-use crate::cognitive_memory::{CognitiveMemoryOps, NativeCognitiveMemory, as_f64, as_i64, as_str};
+use crate::cognitive_memory::{CognitiveMemoryOps, NativeCognitiveMemory};
 
 // ---------------------------------------------------------------------------
 // Memory metrics panel

--- a/src/operator_commands_dashboard/routes.rs
+++ b/src/operator_commands_dashboard/routes.rs
@@ -1,8 +1,6 @@
 use axum::{
     Json, Router,
-    extract::Path,
-    extract::ws::{Message, WebSocket, WebSocketUpgrade},
-    middleware, response,
+    middleware,
     routing::{delete, get, post, put},
 };
 use serde_json::{Value, json};
@@ -12,32 +10,22 @@ use super::agent_log::{WS_AGENT_LOG_ROUTE, ws_agent_log_handler};
 use super::auth::{login, login_page, require_auth};
 use super::chat::ws_chat_handler;
 use super::current_work::current_work;
-use super::distributed::{distributed, strip_ansi_codes, vacate_vm};
+use super::distributed::{distributed, vacate_vm};
 use super::goals::{
     add_goal, demote_goal, goals, promote_backlog_item, remove_goal, seed_goals, update_goal_status,
 };
-use super::hosts::{
-    add_host, get_hosts, host_entry_name, is_local_host, load_hosts, remove_host, save_hosts,
-    tag_local_membership,
-};
-use super::logs::read_tail;
-use super::logs::{logs, processes, read_journal_logs};
-use super::memory::{build_agent_graph, classify_agent_layer, memory_graph, memory_search};
+use super::hosts::{add_host, get_hosts, remove_host};
+use super::logs::{logs, processes};
+use super::memory::{memory_graph, memory_search};
 use super::metrics::{memory_metrics, ooda_thinking};
 use super::monitoring::{costs, get_budget, metrics, set_budget};
 use super::registry::{
     agent_graph, build_lock_force_release, build_lock_status, registry_deregister, registry_list,
     registry_reap, registry_register,
 };
-use super::subagent::{count_json_records, disk_usage_pct, file_metrics, subagent_sessions};
+use super::subagent::{disk_usage_pct, subagent_sessions};
 use super::tmux::{azlin_tmux_sessions, ws_tmux_attach_handler};
 use super::workboard::workboard;
-use crate::agent_registry::{AgentRegistry, FileBackedAgentRegistry};
-use crate::build_lock::BuildLock;
-use crate::cognitive_memory::{CognitiveMemoryOps, NativeCognitiveMemory, as_f64, as_i64, as_str};
-use crate::error::{SimardError, SimardResult};
-use crate::goal_curation::{ActiveGoal, BacklogItem, GoalBoard, GoalProgress, MAX_ACTIVE_GOALS};
-use crate::goals::{GoalRecord, goal_slug};
 
 pub fn build_router() -> Router {
     Router::new()

--- a/src/operator_commands_dashboard/tests_routes_a.rs
+++ b/src/operator_commands_dashboard/tests_routes_a.rs
@@ -1,18 +1,15 @@
 #[cfg(test)]
 mod tests {
-    use crate::operator_commands_dashboard::agent_log::{
-        WS_AGENT_LOG_ROUTE, agent_log_path, sanitize_agent_name,
-    };
+    use crate::operator_commands_dashboard::agent_log::sanitize_agent_name;
     use crate::operator_commands_dashboard::current_work::{
         format_recent_actions_for_cycle, read_recent_cycle_reports,
     };
     use crate::operator_commands_dashboard::distributed::remote_vms_from_hosts;
     use crate::operator_commands_dashboard::hosts::{
-        host_entry_name, is_local_host, load_hosts, tag_local_membership,
+        host_entry_name, is_local_host, tag_local_membership,
     };
     use crate::operator_commands_dashboard::index_html::INDEX_HTML;
     use crate::operator_commands_dashboard::routes::*;
-    use crate::operator_commands_dashboard::tmux::TmuxSession;
     use serde_json::json;
 
     #[test]

--- a/src/operator_commands_dashboard/tests_routes_b.rs
+++ b/src/operator_commands_dashboard/tests_routes_b.rs
@@ -7,9 +7,7 @@ mod tests_b {
     use crate::operator_commands_dashboard::index_html::INDEX_HTML;
     use crate::operator_commands_dashboard::memory::{build_agent_graph, classify_agent_layer};
     use crate::operator_commands_dashboard::routes::*;
-    use crate::operator_commands_dashboard::tmux::TmuxSession;
     use crate::operator_commands_dashboard::tmux::parse_tmux_sessions;
-    use serde_json::json;
     #[test]
     fn sanitize_agent_name_rejects_invalid_names() {
         assert_eq!(sanitize_agent_name(""), None);

--- a/src/operator_commands_dashboard/workboard.rs
+++ b/src/operator_commands_dashboard/workboard.rs
@@ -3,7 +3,7 @@ use serde_json::{Value, json};
 
 use super::current_work::format_recent_actions_for_cycle;
 use super::current_work::read_recent_cycle_reports;
-use super::routes::{is_pid_alive, resolve_state_root};
+use super::routes::{resolve_state_root};
 use crate::agent_registry::{AgentRegistry, FileBackedAgentRegistry};
 use crate::cognitive_memory::{CognitiveMemoryOps, NativeCognitiveMemory};
 use crate::goal_curation::GoalBoard;


### PR DESCRIPTION
Cleanup of unused imports left after the routes.rs decomposition cascade (#1389-#1395). Dashboard module now compiles with zero unused-import warnings.

Refs #1031