### PR TITLE
fix(engineer_worktree): gate tests_extra with cfg(test) (#1031)

### DIFF
--- a/src/engineer_worktree/mod.rs
+++ b/src/engineer_worktree/mod.rs
@@ -34,8 +34,8 @@ use crate::error::SimardError;
 
 #[cfg(test)]
 mod tests;
-mod tests_extra;
 #[cfg(test)]
+mod tests_extra;
 #[cfg(test)]
 mod tests_more;
 


### PR DESCRIPTION
tests_extra.rs was missing #[cfg(test)], leaking fixture helpers into the production lib build (13 spurious unused warnings). Also removes a duplicate cfg(test) attribute on tests_more.

Refs #1031