### PR TITLE
chore: remove unused imports in 3 test modules (#1031)

### DIFF
--- a/src/copilot_task_submit/tests_orchestration_inline.rs
+++ b/src/copilot_task_submit/tests_orchestration_inline.rs
@@ -5,13 +5,12 @@ use super::types::{
 };
 
 use crate::base_types::BaseTypeId;
-use crate::evidence::EvidenceSource;
 use crate::handoff::CopilotSubmitAudit;
 use crate::identity::OperatingMode;
-use crate::runtime::{RuntimeAddress, RuntimeNodeId, RuntimeTopology};
+use crate::runtime::{RuntimeAddress, RuntimeNodeId};
 use crate::session::{SessionPhase, SessionRecord, UuidSessionIdGenerator};
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 fn test_flow() -> CopilotSubmitFlowAsset {
     CopilotSubmitFlowAsset {

--- a/src/hive_event_bus/tests_extra.rs
+++ b/src/hive_event_bus/tests_extra.rs
@@ -1,8 +1,4 @@
 use super::*;
-use std::sync::Arc;
-use std::time::Duration;
-use tokio::sync::Barrier;
-use tokio::time::timeout;
 
 fn sample_kind() -> HiveEventKind {
     HiveEventKind::FactPromoted {

--- a/src/improvements/tests_promotion.rs
+++ b/src/improvements/tests_promotion.rs
@@ -84,13 +84,7 @@ fn renders_review_context_directives_for_operator_curator_sessions() {
 mod promotion_inline {
     use super::super::promotion::*;
     use super::super::types::ImprovementPromotionPlan;
-    use crate::error::SimardError;
-    use crate::goals::GoalStatus;
-    use crate::review::{
-        ImprovementProposal, ReviewArtifact, ReviewEvidenceSummary, ReviewTargetKind,
-    };
-
-    use super::*;
+    use crate::review::ReviewArtifact;
 
     fn valid_plan_text() -> String {
         [


### PR DESCRIPTION
Drops dead imports in test modules across improvements, hive_event_bus, copilot_task_submit. ~11 warnings fewer (163→152).

Refs #1031