### PR TITLE
chore: dead imports in execution + lifecycle (#1031)

### DIFF
--- a/src/agent_supervisor/lifecycle/mod.rs
+++ b/src/agent_supervisor/lifecycle/mod.rs
@@ -8,9 +8,7 @@ use crate::cognitive_memory::CognitiveMemoryOps;
 use crate::error::{SimardError, SimardResult};
 
 use super::STALE_THRESHOLD_SECONDS;
-use super::tmux::build_tmux_wrapped_command;
-use super::types::{HeartbeatStatus, SubordinateConfig, SubordinateHandle};
-use crate::subagent_sessions::session_name_for;
+use super::types::{HeartbeatStatus, SubordinateHandle};
 
 /// Resolve the Simard state root the same way the dashboard does.
 ///

--- a/src/engineer_loop/execution/dispatch.rs
+++ b/src/engineer_loop/execution/dispatch.rs
@@ -1,8 +1,6 @@
 use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::Path;
-use std::process::Command;
-use std::time::{Duration, Instant};
 
 use crate::error::{SimardError, SimardResult};
 use crate::sanitization::sanitize_terminal_text;
@@ -10,14 +8,11 @@ use crate::sanitization::sanitize_terminal_text;
 use crate::engineer_loop::types::{
     EngineerActionKind, ExecutedEngineerAction, SelectedEngineerAction, validate_repo_relative_path,
 };
-use crate::engineer_loop::{
-    CARGO_COMMAND_TIMEOUT_SECS, CLEARED_GIT_ENV_VARS, GIT_COMMAND_TIMEOUT_SECS,
-    SHELL_COMMAND_ALLOWLIST,
-};
+use crate::engineer_loop::SHELL_COMMAND_ALLOWLIST;
 
 use super::{
-    CommandOutput, parse_status_paths, run_command, sanitize_issue_create_args,
-    timeout_for_command, trimmed_stdout, trimmed_stdout_allow_empty,
+    run_command, sanitize_issue_create_args, timeout_for_command, trimmed_stdout,
+    trimmed_stdout_allow_empty,
 };
 
 pub fn execute_engineer_action(

--- a/src/engineer_loop/execution/mod.rs
+++ b/src/engineer_loop/execution/mod.rs
@@ -1,5 +1,4 @@
-use std::fs::{self, OpenOptions};
-use std::io::Write;
+use std::fs;
 use std::path::Path;
 use std::process::Command;
 use std::time::{Duration, Instant};
@@ -7,13 +6,7 @@ use std::time::{Duration, Instant};
 use crate::error::{SimardError, SimardResult};
 use crate::sanitization::sanitize_terminal_text;
 
-use super::types::{
-    EngineerActionKind, ExecutedEngineerAction, SelectedEngineerAction, validate_repo_relative_path,
-};
-use super::{
-    CARGO_COMMAND_TIMEOUT_SECS, CLEARED_GIT_ENV_VARS, GIT_COMMAND_TIMEOUT_SECS,
-    SHELL_COMMAND_ALLOWLIST,
-};
+use super::{CARGO_COMMAND_TIMEOUT_SECS, CLEARED_GIT_ENV_VARS, GIT_COMMAND_TIMEOUT_SECS};
 
 pub(crate) struct CommandOutput {
     pub(crate) status: std::process::ExitStatus,


### PR DESCRIPTION
Trimming unused imports left over from the engineer_loop/execution dir promotion (#1355) and agent_supervisor/lifecycle dir promotion (#1325). 143 warnings remaining.

Refs #1031