### PR TITLE
chore: dead imports in meeting_backend (#1031)

### DIFF
--- a/src/meeting_backend/closing.rs
+++ b/src/meeting_backend/closing.rs
@@ -3,14 +3,10 @@
 use chrono::Utc;
 use tracing::{info, warn};
 
-use crate::cognitive_memory::CognitiveMemoryOps;
 use crate::error::{SimardError, SimardResult};
 
-use super::EMPTY_RESPONSE_SENTINEL;
 use super::MeetingBackend;
-use super::SUMMARY_TIMEOUT;
 use super::persist;
-use super::types::HandoffActionItem;
 use super::types::MeetingSummary;
 use super::types::MeetingTranscript;
 use super::types::Role;

--- a/src/meeting_backend/persist/cognitive.rs
+++ b/src/meeting_backend/persist/cognitive.rs
@@ -1,12 +1,10 @@
 //! Cognitive memory writers for meeting summaries and handoffs.
 
-use tracing::{debug, info, warn};
+use tracing::{debug, warn};
 
 use crate::cognitive_memory::CognitiveMemoryOps;
-use crate::error::SimardResult;
-use crate::meeting_facilitator::{ActionItem, MeetingDecision, MeetingHandoff, OpenQuestion};
 
-use super::super::types::{ConversationMessage, HandoffActionItem, MeetingTranscript};
+use super::super::types::{ConversationMessage, HandoffActionItem};
 
 /// Store the meeting as an episodic memory via the cognitive bridge.
 pub fn store_cognitive_memory(

--- a/src/meeting_backend/persist/markdown.rs
+++ b/src/meeting_backend/persist/markdown.rs
@@ -1,20 +1,15 @@
 //! Markdown export writers for meeting transcripts and handoffs.
 
-use std::fs;
-use std::io::Write;
 use std::path::PathBuf;
 
 use tracing::{info, warn};
 
 use crate::error::{SimardError, SimardResult};
-use crate::meeting_facilitator::{ActionItem, MeetingDecision, MeetingHandoff, OpenQuestion};
+use crate::meeting_facilitator::MeetingDecision;
 
-use super::extract::{
-    extract_action_items, extract_decision_participants_pub, extract_decision_rationale_pub,
-    extract_decisions, extract_open_questions, extract_themes,
-};
+use super::extract::{extract_decisions, extract_open_questions, extract_themes};
 use super::{meetings_dir, sanitize_filename};
-use crate::meeting_backend::types::{ConversationMessage, HandoffActionItem, MeetingTranscript};
+use crate::meeting_backend::types::{ConversationMessage, HandoffActionItem};
 
 pub fn write_markdown_export(
     topic: &str,


### PR DESCRIPTION
Trims unused imports left in meeting_backend persist/closing modules. 143→131 warnings.

Refs #1031