### PR TITLE
fix(tests): eliminate git-test parallel-isolation flakes (#1405)

### DIFF
--- a/src/cmd_cleanup/tests.rs
+++ b/src/cmd_cleanup/tests.rs
@@ -151,6 +151,7 @@ fn corrupt_db_retention_at_least_a_day() {
 // ── rotate_simard_binary_backups ──
 
 #[test]
+#[serial_test::serial]
 fn rotate_keeps_newest_n_backups() {
     let tmp = tempfile::tempdir().unwrap();
     let bin_dir = tmp.path().join(".simard").join("bin");
@@ -200,6 +201,7 @@ fn rotate_keeps_newest_n_backups() {
 }
 
 #[test]
+#[serial_test::serial]
 fn rotate_noop_when_under_threshold() {
     let tmp = tempfile::tempdir().unwrap();
     let bin_dir = tmp.path().join(".simard").join("bin");
@@ -223,6 +225,7 @@ fn rotate_noop_when_under_threshold() {
 // ── trim_simard_snapshots ──
 
 #[test]
+#[serial_test::serial]
 fn trim_snapshots_keeps_newest_n() {
     let tmp = tempfile::tempdir().unwrap();
     let snap_dir = tmp.path().join(".simard").join("snapshots");
@@ -261,6 +264,7 @@ fn trim_snapshots_keeps_newest_n() {
 // ── remove_old_corrupt_dbs ──
 
 #[test]
+#[serial_test::serial]
 fn corrupt_db_removed_when_older_than_threshold() {
     let tmp = tempfile::tempdir().unwrap();
     let simard = tmp.path().join(".simard");

--- a/src/engineer_worktree/tests.rs
+++ b/src/engineer_worktree/tests.rs
@@ -99,6 +99,7 @@ fn git_cmd(repo: &Path, args: &[&str]) -> Command {
 // ---------------------------------------------------------------------------
 
 #[test]
+#[serial_test::serial]
 fn allocate_creates_unique_worktree_under_state_root() {
     let parent_dir = tempdir().expect("tempdir");
     let state_dir = tempdir().expect("tempdir");
@@ -137,6 +138,7 @@ fn allocate_creates_unique_worktree_under_state_root() {
 // ---------------------------------------------------------------------------
 
 #[test]
+#[serial_test::serial]
 fn cleanup_removes_dir_branch_and_registration_idempotently() {
     let parent_dir = tempdir().unwrap();
     let state_dir = tempdir().unwrap();
@@ -168,6 +170,7 @@ fn cleanup_removes_dir_branch_and_registration_idempotently() {
 // ---------------------------------------------------------------------------
 
 #[test]
+#[serial_test::serial]
 fn drop_runs_cleanup_when_explicit_cleanup_skipped() {
     let parent_dir = tempdir().unwrap();
     let state_dir = tempdir().unwrap();
@@ -198,6 +201,7 @@ fn drop_runs_cleanup_when_explicit_cleanup_skipped() {
 // ---------------------------------------------------------------------------
 
 #[test]
+#[serial_test::serial]
 fn parallel_allocations_produce_distinct_paths_and_branches() {
     let parent_dir = tempdir().unwrap();
     let state_dir = tempdir().unwrap();
@@ -242,6 +246,7 @@ fn parallel_allocations_produce_distinct_paths_and_branches() {
 // ---------------------------------------------------------------------------
 
 #[test]
+#[serial_test::serial]
 fn allocate_without_main_branch_returns_hard_error_and_leaves_no_dir() {
     let parent_dir = tempdir().unwrap();
     let state_dir = tempdir().unwrap();

--- a/src/engineer_worktree/tests_extra.rs
+++ b/src/engineer_worktree/tests_extra.rs
@@ -99,6 +99,7 @@ fn git_cmd(repo: &Path, args: &[&str]) -> Command {
 // ---------------------------------------------------------------------------
 
 #[test]
+#[serial_test::serial]
 fn allocate_records_full_40hex_main_sha_on_branch() {
     let parent_dir = tempdir().unwrap();
     let state_dir = tempdir().unwrap();
@@ -129,6 +130,7 @@ fn allocate_records_full_40hex_main_sha_on_branch() {
 // ---------------------------------------------------------------------------
 
 #[test]
+#[serial_test::serial]
 fn git_capture_clears_inherited_git_env() {
     use std::sync::Mutex;
     static ENV_LOCK: Mutex<()> = Mutex::new(());
@@ -159,6 +161,7 @@ fn git_capture_clears_inherited_git_env() {
 // ---------------------------------------------------------------------------
 
 #[test]
+#[serial_test::serial]
 fn allocate_writes_engineer_claim_sentinel_with_current_pid() {
     let parent_dir = tempdir().unwrap();
     let state_dir = tempdir().unwrap();
@@ -189,6 +192,7 @@ fn allocate_writes_engineer_claim_sentinel_with_current_pid() {
 }
 
 #[test]
+#[serial_test::serial]
 fn allocate_writes_starttime_alongside_pid_on_linux() {
     // On Linux (where /proc/<pid>/stat is available), the sentinel must
     // include the allocating process's starttime as a second line so the
@@ -226,6 +230,7 @@ fn allocate_writes_starttime_alongside_pid_on_linux() {
 }
 
 #[test]
+#[serial_test::serial]
 fn sweep_removes_dir_with_recycled_pid_claim() {
     // Regression test for issue #1238: a sentinel that names a live PID
     // whose starttime DOES NOT match the recorded one (i.e. the original
@@ -266,6 +271,7 @@ fn sweep_removes_dir_with_recycled_pid_claim() {
 }
 
 #[test]
+#[serial_test::serial]
 fn sweep_keeps_legacy_pid_only_claim_with_live_pid() {
     // Pre-#1238 sentinels are PID-only (no starttime line). They must
     // still be honored as live when the PID is alive — otherwise a daemon
@@ -303,6 +309,7 @@ fn sweep_keeps_legacy_pid_only_claim_with_live_pid() {
 }
 
 #[test]
+#[serial_test::serial]
 fn sweep_skips_unregistered_dir_with_live_engineer_claim() {
     let parent_dir = tempdir().unwrap();
     let state_dir = tempdir().unwrap();
@@ -344,6 +351,7 @@ fn sweep_skips_unregistered_dir_with_live_engineer_claim() {
 }
 
 #[test]
+#[serial_test::serial]
 fn sweep_removes_unregistered_dir_with_dead_engineer_claim() {
     let parent_dir = tempdir().unwrap();
     let state_dir = tempdir().unwrap();

--- a/src/engineer_worktree/tests_more.rs
+++ b/src/engineer_worktree/tests_more.rs
@@ -99,6 +99,7 @@ fn git_cmd(repo: &Path, args: &[&str]) -> Command {
 // ---------------------------------------------------------------------------
 
 #[test]
+#[serial_test::serial]
 fn sweep_removes_orphan_dirs_and_preserves_live_worktrees() {
     let parent_dir = tempdir().unwrap();
     let state_dir = tempdir().unwrap();
@@ -142,6 +143,7 @@ fn sweep_removes_orphan_dirs_and_preserves_live_worktrees() {
 // ---------------------------------------------------------------------------
 
 #[test]
+#[serial_test::serial]
 fn verification_scope_isolates_worktree_from_parent_repo_mutations() {
     let parent_dir = tempdir().unwrap();
     let state_dir = tempdir().unwrap();
@@ -179,6 +181,7 @@ fn verification_scope_isolates_worktree_from_parent_repo_mutations() {
 // ---------------------------------------------------------------------------
 
 #[test]
+#[serial_test::serial]
 fn rejects_invalid_goal_id() {
     let parent_dir = tempdir().unwrap();
     let state_dir = tempdir().unwrap();
@@ -239,6 +242,7 @@ fn rejects_invalid_goal_id() {
 
 #[cfg(unix)]
 #[test]
+#[serial_test::serial]
 fn sweep_skips_symlinks_and_preserves_targets() {
     use std::os::unix::fs::symlink;
 

--- a/src/self_improve_executor/git_ops.rs
+++ b/src/self_improve_executor/git_ops.rs
@@ -133,44 +133,51 @@ pub(crate) fn rollback(workspace: &Path) -> SimardResult<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use tempfile::tempdir;
+
+    /// Run a `git` subcommand with isolated config (immune to other tests
+    /// mutating HOME/XDG_CONFIG_HOME via env::set_var). Required because
+    /// some tests in this binary (e.g. cmd_cleanup) reassign HOME globally,
+    /// which would otherwise cause our `git` invocations to fail when
+    /// scheduled concurrently. Tests are also marked `#[serial_test::serial]` to prevent
+    /// concurrent HOME-mutating tests from breaking the production
+    /// `git_diff`/`git_commit`/`rollback` calls (which can't take env
+    /// overrides without changing the API).
+    fn isolated_git(workspace: &Path, args: &[&str]) -> std::process::Output {
+        Command::new("git")
+            .args(args)
+            .current_dir(workspace)
+            .env("GIT_CONFIG_NOSYSTEM", "1")
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .env("HOME", workspace)
+            .env("XDG_CONFIG_HOME", workspace)
+            .env("GIT_AUTHOR_NAME", "Test")
+            .env("GIT_AUTHOR_EMAIL", "test@test.com")
+            .env("GIT_COMMITTER_NAME", "Test")
+            .env("GIT_COMMITTER_EMAIL", "test@test.com")
+            .output()
+            .unwrap()
+    }
 
     /// Set up a temporary git repository with an initial commit.
     fn init_temp_repo() -> tempfile::TempDir {
         let tmp = tempdir().unwrap();
         let ws = tmp.path();
-        Command::new("git")
-            .args(["init"])
-            .current_dir(ws)
-            .output()
-            .unwrap();
-        Command::new("git")
-            .args(["config", "user.email", "test@test.com"])
-            .current_dir(ws)
-            .output()
-            .unwrap();
-        Command::new("git")
-            .args(["config", "user.name", "Test"])
-            .current_dir(ws)
-            .output()
-            .unwrap();
+        isolated_git(ws, &["init", "-b", "main"]);
+        isolated_git(ws, &["config", "user.email", "test@test.com"]);
+        isolated_git(ws, &["config", "user.name", "Test"]);
+        isolated_git(ws, &["config", "commit.gpgsign", "false"]);
         std::fs::write(ws.join("init.txt"), "hello").unwrap();
-        Command::new("git")
-            .args(["add", "-A"])
-            .current_dir(ws)
-            .output()
-            .unwrap();
-        Command::new("git")
-            .args(["commit", "-m", "initial"])
-            .current_dir(ws)
-            .output()
-            .unwrap();
+        isolated_git(ws, &["add", "-A"]);
+        isolated_git(ws, &["commit", "-m", "initial"]);
         tmp
     }
 
     // ── git_diff ────────────────────────────────────────────────────
 
     #[test]
+    #[serial_test::serial]
     fn git_diff_clean_repo_empty_diff() {
         let tmp = init_temp_repo();
         let diff = git_diff(tmp.path()).unwrap();
@@ -178,6 +185,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn git_diff_with_changes() {
         let tmp = init_temp_repo();
         std::fs::write(tmp.path().join("init.txt"), "changed").unwrap();
@@ -186,6 +194,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn git_diff_nonexistent_dir() {
         let result = git_diff(Path::new("/nonexistent/repo"));
         assert!(result.is_err());
@@ -194,22 +203,20 @@ mod tests {
     // ── git_commit ──────────────────────────────────────────────────
 
     #[test]
+    #[serial_test::serial]
     fn git_commit_with_staged_changes() {
         let tmp = init_temp_repo();
         std::fs::write(tmp.path().join("new.txt"), "content").unwrap();
         let result = git_commit(tmp.path(), "add new file");
         assert!(result.is_ok());
         // Verify commit was made
-        let log = Command::new("git")
-            .args(["log", "--oneline", "-1"])
-            .current_dir(tmp.path())
-            .output()
-            .unwrap();
+        let log = isolated_git(tmp.path(), &["log", "--oneline", "-1"]);
         let log_text = String::from_utf8_lossy(&log.stdout);
         assert!(log_text.contains("add new file"));
     }
 
     #[test]
+    #[serial_test::serial]
     fn git_commit_nothing_to_commit_fails() {
         let tmp = init_temp_repo();
         // Nothing changed, so git commit should fail
@@ -218,6 +225,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn git_commit_nonexistent_dir() {
         let result = git_commit(Path::new("/nonexistent/repo"), "msg");
         assert!(result.is_err());
@@ -226,6 +234,7 @@ mod tests {
     // ── rollback ────────────────────────────────────────────────────
 
     #[test]
+    #[serial_test::serial]
     fn rollback_restores_modified_files() {
         let tmp = init_temp_repo();
         let file = tmp.path().join("init.txt");
@@ -237,6 +246,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn rollback_removes_untracked_files() {
         let tmp = init_temp_repo();
         let untracked = tmp.path().join("untracked.txt");
@@ -248,6 +258,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn rollback_clean_repo_is_noop() {
         let tmp = init_temp_repo();
         let result = rollback(tmp.path());
@@ -255,6 +266,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn rollback_nonexistent_dir() {
         let result = rollback(Path::new("/nonexistent/repo"));
         assert!(result.is_err());

--- a/src/self_improve_executor/tests.rs
+++ b/src/self_improve_executor/tests.rs
@@ -165,6 +165,7 @@ fn apply_and_review_plan_failed_on_bad_step() {
 }
 
 #[test]
+#[serial_test::serial]
 fn apply_and_review_empty_diff_is_applied() {
     // A plan with only no-op steps produces no diff.
     // Use a real temp git repo so `git diff HEAD` works.

--- a/src/self_improve_executor/tests_extra.rs
+++ b/src/self_improve_executor/tests_extra.rs
@@ -44,6 +44,7 @@ fn finding(category: FindingCategory, severity: Severity) -> crate::review_pipel
 }
 
 #[test]
+#[serial_test::serial]
 fn rollback_cleans_untracked_files() {
     let tmp = tempfile::tempdir().expect("create tempdir");
     let ws = tmp.path();
@@ -130,6 +131,7 @@ fn apply_result_display_commit_failed() {
 }
 
 #[test]
+#[serial_test::serial]
 fn apply_and_review_git_diff_failure_includes_rollback_error() {
     // If git diff fails and rollback also fails, both errors must surface.
     // We simulate this by running against a path that is NOT a git repo, so
@@ -184,6 +186,7 @@ fn apply_and_review_plan_failed_rollback_also_failed() {
 }
 
 #[test]
+#[serial_test::serial]
 fn apply_and_review_noop_plan_in_real_repo_succeeds() {
     // A plan with a no-op step in a real git repo should produce Applied
     // with no findings (empty diff → auto-pass).


### PR DESCRIPTION
Closes the dominant cause of pre-push cargo-test failures and red main verify CI.

## Root cause
`cmd_cleanup/tests.rs` and `self_metrics/tests.rs` mutate `HOME` process-globally via `env::set_var`. When git-using tests in `self_improve_executor` and `engineer_worktree` run concurrently with those mutators, git can't find user config → 10–13 intermittent failures per run.

## Fix
1. `isolated_git()` helper in `self_improve_executor/git_ops.rs` wraps git in tests with `GIT_CONFIG_NOSYSTEM=1`, `GIT_CONFIG_GLOBAL=/dev/null`, explicit `HOME`/`XDG_CONFIG_HOME`/`GIT_AUTHOR_*`/`GIT_COMMITTER_*`.
2. `#[serial_test::serial]` annotations (default group) on:
   - 10 `self_improve_executor::git_ops::tests`
   - 3 `self_improve_executor::tests*` that touch real git repos
   - 4 `cmd_cleanup::tests` HOME-mutators
   - 17 `engineer_worktree::tests*` (read HOME via `git_cmd`)

## Verification
`cargo test --lib --locked` → **3902 passed; 0 failed** (was 10–13 intermittent failures).

Refs #1405.