### PR TITLE
ci(pre-commit): always_run cargo-fmt to catch rebase/merge drift

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,10 @@ repos:
         entry: cargo fmt --all -- --check
         language: system
         pass_filenames: false
-        files: ^(src/|tests/|Cargo\.toml|Cargo\.lock|prompt_assets/)
+        # always_run so rebase/merge drift in unstaged files still fails the
+        # commit. Filtering by changed files lets formatting drift land via
+        # commits that don't touch src/, then CI fails. fmt --check is ~1s.
+        always_run: true
         stages:
           - pre-commit
           - manual


### PR DESCRIPTION
Closes part of #1405 reliability concern.

## Problem

User: "Even on main. you MUST run pre-commit locally and pre-commit needs to match CI."

CI runs `pre-commit run --all-files` which checks every file. The local
hook only ran cargo-fmt when staged files matched `^(src/|tests/|...)`.
Result: a rebase or merge that introduces fmt drift in unstaged files,
followed by a docs-only commit, would land formatting drift onto main and
fail CI.

## Fix

`always_run: true` on the cargo-fmt hook. `cargo fmt --all -- --check`
is ~1s — cheap to run on every commit.

## Verification

```
$ pre-commit run --all-files --hook-stage pre-commit
cargo fmt --all -- --check...............................................Passed
```

## Follow-up

Pre-push (cargo test) caught 3 flaky tests on local push — env/HOME
pollution in modules not annotated by #1409. Filing a P1 follow-up.

Refs #1405