### PR TITLE
chore(tests): drop 51 unused imports from test modules + serialize subagent_sessions (#1405)

### DIFF
--- a/src/agent_registry/tests.rs
+++ b/src/agent_registry/tests.rs
@@ -146,8 +146,6 @@ mod registry_inline {
     use super::*;
     use std::path::{Path, PathBuf};
 
-    use super::*;
-
     fn temp_registry_dir(label: &str) -> PathBuf {
         let dir = std::env::temp_dir().join(format!(
             "simard-registry-test-{}-{}",

--- a/src/cognitive_memory/tests_mod.rs
+++ b/src/cognitive_memory/tests_mod.rs
@@ -1,5 +1,4 @@
 use super::*;
-use super::*;
 
 fn test_mem() -> NativeCognitiveMemory {
     NativeCognitiveMemory::in_memory().expect("in-memory DB should create")

--- a/src/copilot_task_submit/tests_orchestration.rs
+++ b/src/copilot_task_submit/tests_orchestration.rs
@@ -5,7 +5,6 @@ use super::types::{
 };
 
 use crate::base_types::BaseTypeId;
-use crate::evidence::EvidenceSource;
 use crate::handoff::CopilotSubmitAudit;
 use crate::identity::OperatingMode;
 use crate::runtime::{RuntimeAddress, RuntimeNodeId, RuntimeTopology};

--- a/src/copilot_task_submit/tests_orchestration_extra.rs
+++ b/src/copilot_task_submit/tests_orchestration_extra.rs
@@ -1,7 +1,7 @@
 use super::orchestration::*;
 use super::types::{
     COPILOT_SUBMIT_BASE_TYPE, COPILOT_SUBMIT_FLOW_ASSET_PATH, COPILOT_SUBMIT_RUNTIME_NODE,
-    CopilotSubmitFlowAsset, CopilotSubmitOutcome, StartupStatus, SubmitStatus,
+    CopilotSubmitFlowAsset, CopilotSubmitOutcome,
 };
 
 use crate::base_types::BaseTypeId;
@@ -9,7 +9,7 @@ use crate::evidence::EvidenceSource;
 use crate::handoff::CopilotSubmitAudit;
 use crate::identity::OperatingMode;
 use crate::runtime::{RuntimeAddress, RuntimeNodeId, RuntimeTopology};
-use crate::session::{SessionPhase, SessionRecord, UuidSessionIdGenerator};
+use crate::session::{SessionRecord, UuidSessionIdGenerator};
 
 use std::path::PathBuf;
 

--- a/src/copilot_task_submit/tests_orchestration_inline.rs
+++ b/src/copilot_task_submit/tests_orchestration_inline.rs
@@ -1,7 +1,7 @@
 use super::orchestration::*;
 use super::types::{
     COPILOT_SUBMIT_BASE_TYPE, COPILOT_SUBMIT_FLOW_ASSET_PATH, COPILOT_SUBMIT_RUNTIME_NODE,
-    CopilotSubmitFlowAsset, CopilotSubmitOutcome, StartupStatus, SubmitStatus,
+    CopilotSubmitFlowAsset, StartupStatus, SubmitStatus,
 };
 
 use crate::base_types::BaseTypeId;

--- a/src/engineer_loop/tests_execution_extra.rs
+++ b/src/engineer_loop/tests_execution_extra.rs
@@ -1,7 +1,5 @@
 use super::execution::*;
-use super::types::{EngineerActionKind, SelectedEngineerAction};
 use super::{CARGO_COMMAND_TIMEOUT_SECS, GIT_COMMAND_TIMEOUT_SECS};
-use crate::error::SimardError;
 use std::path::Path;
 use std::time::Duration;
 

--- a/src/engineer_loop/tests_mod.rs
+++ b/src/engineer_loop/tests_mod.rs
@@ -5,7 +5,6 @@ use super::types::{
     SelectedEngineerAction, ShellCommandRequest, analyze_objective, parse_structured_edit_request,
     validate_repo_relative_path,
 };
-use crate::PhaseOutcome;
 
 #[test]
 fn git_status_paths_strip_status_prefixes() {

--- a/src/engineer_loop/tests_mod_more.rs
+++ b/src/engineer_loop/tests_mod_more.rs
@@ -1,11 +1,5 @@
-use super::execution::execute_engineer_action;
 use super::execution::parse_status_paths;
-use super::types::{
-    AnalyzedAction, AppendToFileRequest, CreateFileRequest, EngineerActionKind,
-    SelectedEngineerAction, ShellCommandRequest, analyze_objective, parse_structured_edit_request,
-    validate_repo_relative_path,
-};
-use crate::PhaseOutcome;
+use super::types::{parse_structured_edit_request, validate_repo_relative_path};
 
 #[test]
 fn is_meeting_decision_record_positive() {

--- a/src/engineer_loop/tests_mod_most.rs
+++ b/src/engineer_loop/tests_mod_most.rs
@@ -2,8 +2,7 @@ use super::execution::execute_engineer_action;
 use super::execution::parse_status_paths;
 use super::types::{
     AnalyzedAction, AppendToFileRequest, CreateFileRequest, EngineerActionKind,
-    SelectedEngineerAction, ShellCommandRequest, analyze_objective, parse_structured_edit_request,
-    validate_repo_relative_path,
+    SelectedEngineerAction, ShellCommandRequest, analyze_objective, validate_repo_relative_path,
 };
 use crate::PhaseOutcome;
 

--- a/src/engineer_loop/tests_verification.rs
+++ b/src/engineer_loop/tests_verification.rs
@@ -1,5 +1,5 @@
 use super::verification::*;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use super::types::{
     AppendToFileRequest, CreateFileRequest, EngineerActionKind, ExecutedEngineerAction,

--- a/src/engineer_loop/tests_verification_extra.rs
+++ b/src/engineer_loop/tests_verification_extra.rs
@@ -2,9 +2,8 @@ use super::verification::*;
 use std::path::{Path, PathBuf};
 
 use super::types::{
-    AppendToFileRequest, CreateFileRequest, EngineerActionKind, ExecutedEngineerAction,
-    GitCommitRequest, OpenIssueRequest, RepoInspection, SelectedEngineerAction,
-    ShellCommandRequest, StructuredEditRequest,
+    CreateFileRequest, EngineerActionKind, ExecutedEngineerAction, GitCommitRequest,
+    RepoInspection, SelectedEngineerAction, ShellCommandRequest,
 };
 
 fn make_inspection() -> RepoInspection {

--- a/src/engineer_loop/tests_verification_more.rs
+++ b/src/engineer_loop/tests_verification_more.rs
@@ -1,7 +1,6 @@
 use super::types::{
     AppendToFileRequest, CreateFileRequest, EngineerActionKind, ExecutedEngineerAction,
-    GitCommitRequest, OpenIssueRequest, RepoInspection, SelectedEngineerAction,
-    ShellCommandRequest, StructuredEditRequest,
+    GitCommitRequest, RepoInspection, SelectedEngineerAction, ShellCommandRequest,
 };
 use super::verification::*;
 use std::path::{Path, PathBuf};

--- a/src/engineer_worktree/tests.rs
+++ b/src/engineer_worktree/tests.rs
@@ -13,7 +13,7 @@ use std::thread;
 
 use tempfile::tempdir;
 
-use super::{EngineerWorktree, sweep_orphaned_worktrees};
+use super::EngineerWorktree;
 use crate::error::SimardError;
 
 // ---------------------------------------------------------------------------

--- a/src/engineer_worktree/tests_extra.rs
+++ b/src/engineer_worktree/tests_extra.rs
@@ -12,7 +12,6 @@ use std::process::Command;
 use tempfile::tempdir;
 
 use super::{EngineerWorktree, sweep_orphaned_worktrees};
-use crate::error::SimardError;
 
 // ---------------------------------------------------------------------------
 // Fixtures

--- a/src/gym/tests_reporting.rs
+++ b/src/gym/tests_reporting.rs
@@ -2,12 +2,8 @@ use std::path::PathBuf;
 
 use super::reporting::*;
 use crate::gym::types::{
-    BenchmarkArtifactPaths, BenchmarkCheckResult, BenchmarkClass, BenchmarkComparisonArtifactPaths,
-    BenchmarkComparisonDelta, BenchmarkComparisonReport, BenchmarkComparisonRunSummary,
-    BenchmarkComparisonStatus, BenchmarkHandoffReport, BenchmarkRunReport, BenchmarkRuntimeReport,
-    BenchmarkScenario, BenchmarkScorecard,
+    BenchmarkComparisonDelta, BenchmarkComparisonRunSummary, BenchmarkComparisonStatus,
 };
-use crate::runtime::RuntimeTopology;
 // --- render_benchmark_count ---
 
 #[test]

--- a/src/gym/tests_reporting_extra.rs
+++ b/src/gym/tests_reporting_extra.rs
@@ -2,12 +2,8 @@ use std::path::PathBuf;
 
 use super::reporting::*;
 use crate::gym::types::{
-    BenchmarkArtifactPaths, BenchmarkCheckResult, BenchmarkClass, BenchmarkComparisonArtifactPaths,
-    BenchmarkComparisonDelta, BenchmarkComparisonReport, BenchmarkComparisonRunSummary,
-    BenchmarkComparisonStatus, BenchmarkHandoffReport, BenchmarkRunReport, BenchmarkRuntimeReport,
-    BenchmarkScenario, BenchmarkScorecard,
+    BenchmarkComparisonDelta, BenchmarkComparisonRunSummary, BenchmarkComparisonStatus,
 };
-use crate::runtime::RuntimeTopology;
 
 #[test]
 fn render_benchmark_count_some() {

--- a/src/gym/tests_scenarios_6.rs
+++ b/src/gym/tests_scenarios_6.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests {
     use crate::gym::scenarios::*;
-    use crate::gym::types::{BenchmarkClass, BenchmarkScenario};
+    use crate::gym::types::BenchmarkClass;
 
     #[test]
     fn benchmark_scenarios_not_empty() {

--- a/src/meeting_backend/tests_mod.rs
+++ b/src/meeting_backend/tests_mod.rs
@@ -1,5 +1,4 @@
 use super::*;
-use super::*;
 use crate::base_types::{
     BaseTypeDescriptor, BaseTypeId, BaseTypeOutcome, BaseTypeSession, BaseTypeTurnInput,
     ensure_session_not_already_open, ensure_session_not_closed, ensure_session_open,

--- a/src/meeting_backend/tests_persist.rs
+++ b/src/meeting_backend/tests_persist.rs
@@ -1,8 +1,6 @@
 use super::persist::*;
 use super::types::{ConversationMessage, Role};
 use super::*;
-use crate::meeting_facilitator::MeetingHandoff;
-use serial_test::serial;
 
 #[test]
 fn sanitize_basic() {

--- a/src/meeting_facilitator/tests_handoff_extra.rs
+++ b/src/meeting_facilitator/tests_handoff_extra.rs
@@ -2,7 +2,7 @@ use super::handoff::*;
 use super::*;
 use crate::meeting_facilitator::types::{ActionItem, MeetingDecision, MeetingSessionStatus};
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 /// Build a minimal session for testing.
 fn make_session(

--- a/src/memory_bridge_adapter/tests_store.rs
+++ b/src/memory_bridge_adapter/tests_store.rs
@@ -1,4 +1,3 @@
-use super::store::*;
 use super::test_helpers::{make_record, test_store};
 use crate::memory::{MemoryScope, MemoryStore};
 

--- a/src/operator_commands/tests_dispatch_extra.rs
+++ b/src/operator_commands/tests_dispatch_extra.rs
@@ -1,7 +1,5 @@
 use super::dispatch::*;
 
-use std::path::PathBuf;
-
 fn s(value: &str) -> String {
     value.to_string()
 }

--- a/src/review/tests_build.rs
+++ b/src/review/tests_build.rs
@@ -1,7 +1,6 @@
 use super::build::*;
 use super::types::*;
 use crate::handoff::RuntimeHandoffSnapshot;
-use crate::memory::MemoryScope;
 
 // ---- failed_signal ----
 

--- a/src/self_improve/tests_cycle.rs
+++ b/src/self_improve/tests_cycle.rs
@@ -1,7 +1,5 @@
 use super::cycle::*;
-use super::types::{
-    ImprovementConfig, ImprovementCycle, ImprovementDecision, ImprovementPhase, ProposedChange,
-};
+use super::types::{ImprovementConfig, ImprovementCycle, ImprovementDecision, ImprovementPhase};
 use crate::gym_bridge::ScoreDimensions;
 use crate::gym_scoring::{GymSuiteScore, Regression, RegressionSeverity};
 

--- a/src/self_improve/tests_cycle_more.rs
+++ b/src/self_improve/tests_cycle_more.rs
@@ -1,7 +1,5 @@
 use super::cycle::*;
-use super::types::{
-    ImprovementConfig, ImprovementCycle, ImprovementDecision, ImprovementPhase, ProposedChange,
-};
+use super::types::{ImprovementConfig, ImprovementCycle, ImprovementDecision, ImprovementPhase};
 use crate::gym_bridge::ScoreDimensions;
 use crate::gym_scoring::{GymSuiteScore, Regression, RegressionSeverity};
 

--- a/src/self_improve/tests_cycle_most.rs
+++ b/src/self_improve/tests_cycle_most.rs
@@ -1,9 +1,7 @@
 use super::cycle::*;
-use super::types::{
-    ImprovementConfig, ImprovementCycle, ImprovementDecision, ImprovementPhase, ProposedChange,
-};
+use super::types::{ImprovementCycle, ImprovementDecision, ImprovementPhase, ProposedChange};
 use crate::gym_bridge::ScoreDimensions;
-use crate::gym_scoring::{GymSuiteScore, Regression, RegressionSeverity};
+use crate::gym_scoring::GymSuiteScore;
 
 fn make_score(v: f64) -> GymSuiteScore {
     GymSuiteScore {

--- a/src/self_improve_executor/tests.rs
+++ b/src/self_improve_executor/tests.rs
@@ -1,6 +1,5 @@
 use std::path::Path;
 
-use super::git_ops::rollback;
 use super::*;
 use crate::engineer_loop::AnalyzedAction;
 use crate::engineer_plan::{Plan, PlanStep};

--- a/src/self_improve_executor/tests_extra.rs
+++ b/src/self_improve_executor/tests_extra.rs
@@ -4,7 +4,6 @@ use super::git_ops::rollback;
 use super::*;
 use crate::engineer_loop::AnalyzedAction;
 use crate::engineer_plan::{Plan, PlanStep};
-use crate::error::SimardError;
 use crate::review_pipeline::{FindingCategory, Severity};
 
 fn make_patch(steps: Vec<PlanStep>) -> ImprovementPatch {

--- a/src/self_relaunch_semaphore/tests.rs
+++ b/src/self_relaunch_semaphore/tests.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
-use semaphore::{epoch_now, extract_u64, is_pid_alive};
+use semaphore::{epoch_now, extract_u64};
 
 use handoff::wait_for_ready;
 

--- a/src/self_relaunch_semaphore/tests_extra.rs
+++ b/src/self_relaunch_semaphore/tests_extra.rs
@@ -4,9 +4,7 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
-use semaphore::{epoch_now, extract_u64, is_pid_alive};
-
-use handoff::wait_for_ready;
+use semaphore::{epoch_now, is_pid_alive};
 
 static TEST_COUNTER: AtomicU64 = AtomicU64::new(0);
 

--- a/src/stewardship/tests.rs
+++ b/src/stewardship/tests.rs
@@ -13,7 +13,6 @@
 //! - Input validation: empty required fields → InvalidRunSummary
 //! - No-fallback: ambiguous routing never calls gh
 
-use std::cell::RefCell;
 use std::sync::Mutex;
 
 use crate::error::SimardError;

--- a/src/stewardship/tests_extra.rs
+++ b/src/stewardship/tests_extra.rs
@@ -18,11 +18,9 @@ use std::sync::Mutex;
 
 use crate::error::SimardError;
 use crate::goal_curation::GoalBoard;
-use crate::stewardship::dedup::{failure_signature, find_existing, normalize};
-use crate::stewardship::routing::route_failure;
+use crate::stewardship::dedup::failure_signature;
 use crate::stewardship::{
-    GhClient, GhIssue, OrchestratorRunSummary, StewardshipOutcome, TargetRepo,
-    process_orchestrator_run,
+    GhClient, GhIssue, OrchestratorRunSummary, StewardshipOutcome, process_orchestrator_run,
 };
 
 // ─────────────────────────── FakeGhClient ───────────────────────────

--- a/src/subagent_sessions/tests.rs
+++ b/src/subagent_sessions/tests.rs
@@ -57,6 +57,7 @@ fn sample(agent_id: &str, ended_at: Option<i64>) -> SubagentSession {
 }
 
 #[test]
+#[serial_test::serial]
 fn registry_path_honors_state_root_env() {
     with_state_root("path-env", |root| {
         let p = registry_path();
@@ -72,6 +73,7 @@ fn registry_path_honors_state_root_env() {
 }
 
 #[test]
+#[serial_test::serial]
 fn load_returns_empty_when_missing() {
     with_state_root("empty", |_root| {
         let reg = load();
@@ -80,6 +82,7 @@ fn load_returns_empty_when_missing() {
 }
 
 #[test]
+#[serial_test::serial]
 fn save_atomic_round_trips_and_creates_parent_dir() {
     with_state_root("rt", |_root| {
         let reg = Registry {
@@ -95,6 +98,7 @@ fn save_atomic_round_trips_and_creates_parent_dir() {
 }
 
 #[test]
+#[serial_test::serial]
 fn save_atomic_leaves_no_tmp_siblings() {
     with_state_root("atomic", |_root| {
         let reg = Registry {
@@ -118,6 +122,7 @@ fn save_atomic_leaves_no_tmp_siblings() {
 }
 
 #[test]
+#[serial_test::serial]
 fn record_spawn_appends_to_registry() {
     with_state_root("rec", |_root| {
         record_spawn(sample("engineer-1", None)).unwrap();
@@ -142,6 +147,7 @@ impl SessionProbe for StubProbe {
 }
 
 #[test]
+#[serial_test::serial]
 fn poll_and_gc_marks_dead_sessions_with_ended_at() {
     with_state_root("poll", |_root| {
         record_spawn(sample("engineer-live", None)).unwrap();
@@ -179,6 +185,7 @@ fn poll_and_gc_marks_dead_sessions_with_ended_at() {
 }
 
 #[test]
+#[serial_test::serial]
 fn poll_and_gc_drops_entries_ended_more_than_24h_ago() {
     with_state_root("gc", |_root| {
         let now = std::time::SystemTime::now()
@@ -218,6 +225,7 @@ fn poll_and_gc_drops_entries_ended_more_than_24h_ago() {
 }
 
 #[test]
+#[serial_test::serial]
 fn sanitize_id_replaces_unsafe_chars_with_dash() {
     assert_eq!(sanitize_id("engineer-abc_123"), "engineer-abc_123");
     assert_eq!(sanitize_id("engineer/with spaces"), "engineer-with-spaces");
@@ -225,11 +233,13 @@ fn sanitize_id_replaces_unsafe_chars_with_dash() {
 }
 
 #[test]
+#[serial_test::serial]
 fn sanitize_id_empty_input_becomes_engineer() {
     assert_eq!(sanitize_id(""), "engineer");
 }
 
 #[test]
+#[serial_test::serial]
 fn sanitize_id_output_matches_safe_charset() {
     let out = sanitize_id("weird!@#$%^&*()chars");
     assert!(


### PR DESCRIPTION
Part of #1405 burndown. Two related changes:

## 1. Test-only unused imports (commit 1)

Generated by `cargo fix --tests` with non-test files reverted to preserve
`pub(crate) use` re-exports needed via `use super::*`.

- 32 test files cleaned
- Lib-test warnings: 131 → 80 (51 fewer)
- No production code touched

## 2. Serialize subagent_sessions tests (commit 2)

Tripped local pre-push:
`subagent_sessions::tests::poll_and_gc_marks_dead_sessions_with_ended_at`

Same env-race pattern as #1414. The local `ENV_LOCK` only protected
intra-module concurrency; cross-module readers of `SIMARD_STATE_ROOT`
still raced. `#[serial_test::serial]` provides cross-module guarantee.

## Verified locally without --no-verify

```
cargo fmt --all -- --check..............Passed
cargo clippy --all-targets --all-features.Passed
cargo test --all-features --locked.......Passed (with --test-threads=4)
```

This is the first push in this session that ran the full local pre-push
clean and matched what CI is going to do — proof that #1413 + #1418
closed the local-vs-CI gap.

Refs #1405