### PR TITLE
chore: drop ~30 verified-unused lib imports (#1405)

### DIFF
--- a/src/cognitive_memory/mod.rs
+++ b/src/cognitive_memory/mod.rs
@@ -10,9 +10,6 @@
 
 pub(crate) mod schema;
 
-#[cfg(unix)]
-use std::os::unix::io::AsRawFd;
-use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 

--- a/src/cognitive_memory/ops.rs
+++ b/src/cognitive_memory/ops.rs
@@ -1,6 +1,6 @@
 //! CognitiveMemoryOps trait impl for NativeCognitiveMemory + Cypher escaping.
 
-use crate::error::{SimardError, SimardResult};
+use crate::error::SimardResult;
 use crate::memory_cognitive::{
     CognitiveFact, CognitiveProcedure, CognitiveProspective, CognitiveStatistics,
     CognitiveWorkingSlot,

--- a/src/engineer_loop/execution/dispatch.rs
+++ b/src/engineer_loop/execution/dispatch.rs
@@ -10,10 +10,7 @@ use crate::engineer_loop::types::{
     EngineerActionKind, ExecutedEngineerAction, SelectedEngineerAction, validate_repo_relative_path,
 };
 
-use super::{
-    run_command, sanitize_issue_create_args, timeout_for_command, trimmed_stdout,
-    trimmed_stdout_allow_empty,
-};
+use super::{run_command, sanitize_issue_create_args};
 
 pub fn execute_engineer_action(
     repo_root: &Path,

--- a/src/engineer_loop/execution/mod.rs
+++ b/src/engineer_loop/execution/mod.rs
@@ -1,4 +1,3 @@
-use std::fs;
 use std::path::Path;
 use std::process::Command;
 use std::time::{Duration, Instant};

--- a/src/engineer_worktree/mod.rs
+++ b/src/engineer_worktree/mod.rs
@@ -8,18 +8,12 @@
 //!
 //! See `docs/reference/engineer-worktree-isolation.md` for the full contract.
 
-use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use std::sync::Mutex;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use std::sync::OnceLock;
-
-#[cfg(unix)]
-use std::os::unix::fs::DirBuilderExt;
 
 /// Process-wide lock serializing mutating `git worktree` commands against
 /// the parent repository. Git's `.git/worktrees/` registry is not safe to
@@ -58,10 +52,7 @@ pub const WORKTREES_SUBDIR: &str = "engineer-worktrees";
 pub const ENGINEER_CLAIM_FILE: &str = ".simard-engineer-claim";
 
 mod claim;
-use claim::{
-    EngineerClaim, claim_is_live, format_engineer_claim, is_pid_alive, read_engineer_claim,
-    read_engineer_claim_full, read_pid_starttime,
-};
+use claim::{EngineerClaim, claim_is_live, format_engineer_claim, read_engineer_claim_full};
 pub use claim::{is_pid_alive_public, read_pid_starttime_public};
 
 /// Maximum length of a `goal_id` accepted by [`EngineerWorktree::allocate`].

--- a/src/gym/scenarios/mod.rs
+++ b/src/gym/scenarios/mod.rs
@@ -1,8 +1,6 @@
 use crate::error::{SimardError, SimardResult};
-use crate::handoff::RuntimeHandoffSnapshot;
-use crate::runtime::RuntimeTopology;
 
-use super::types::{BenchmarkCheckResult, BenchmarkClass, BenchmarkScenario};
+use super::types::BenchmarkScenario;
 
 // NEEDLE-XYZ-GYM-MARKER: long-context-needle-in-haystack benchmark searches for this exact comment.
 

--- a/src/meeting_backend/messaging.rs
+++ b/src/meeting_backend/messaging.rs
@@ -2,12 +2,12 @@
 
 use tracing::{debug, info, warn};
 
-use crate::base_types::{BaseTypeOutcome, BaseTypeTurnInput};
+use crate::base_types::BaseTypeTurnInput;
 use crate::error::{SimardError, SimardResult};
 
 use super::sanitize::extract_response;
 use super::types::{MeetingResponse, Role};
-use super::{EMPTY_RESPONSE_SENTINEL, MAX_HISTORY, MeetingBackend};
+use super::{EMPTY_RESPONSE_SENTINEL, MeetingBackend};
 
 impl MeetingBackend {
     /// Send a user message and get Simard's response.

--- a/src/meeting_backend/mod.rs
+++ b/src/meeting_backend/mod.rs
@@ -23,9 +23,9 @@ use std::time::Duration;
 use chrono::Utc;
 use tracing::{debug, info, warn};
 
-use crate::base_types::{BaseTypeOutcome, BaseTypeSession, BaseTypeTurnInput};
+use crate::base_types::{BaseTypeSession, BaseTypeTurnInput};
 use crate::cognitive_memory::CognitiveMemoryOps;
-use crate::error::{SimardError, SimardResult};
+use crate::error::SimardResult;
 
 pub use command::{MeetingCommand, parse_command};
 pub use types::{

--- a/src/meeting_backend/persist/extract.rs
+++ b/src/meeting_backend/persist/extract.rs
@@ -1,7 +1,6 @@
 //! Action-item / decision / theme extraction from meeting messages.
 
-use crate::error::SimardResult;
-use crate::meeting_facilitator::{ActionItem, MeetingDecision, MeetingHandoff, OpenQuestion};
+use crate::meeting_facilitator::OpenQuestion;
 
 use crate::meeting_backend::types::{ConversationMessage, HandoffActionItem};
 

--- a/src/meeting_backend/persist/markdown.rs
+++ b/src/meeting_backend/persist/markdown.rs
@@ -7,7 +7,7 @@ use tracing::{info, warn};
 use crate::error::{SimardError, SimardResult};
 use crate::meeting_facilitator::MeetingDecision;
 
-use super::extract::{extract_decisions, extract_open_questions, extract_themes};
+use super::extract::{extract_open_questions, extract_themes};
 use super::{meetings_dir, sanitize_filename};
 use crate::meeting_backend::types::{ConversationMessage, HandoffActionItem};
 

--- a/src/meeting_backend/persist/mod.rs
+++ b/src/meeting_backend/persist/mod.rs
@@ -4,11 +4,9 @@ use std::path::PathBuf;
 
 use tracing::{debug, info, warn};
 
-use crate::cognitive_memory::CognitiveMemoryOps;
 use crate::error::{SimardError, SimardResult};
 use crate::meeting_facilitator::{
-    ActionItem, MeetingDecision, MeetingHandoff, OpenQuestion, default_handoff_dir,
-    write_meeting_handoff,
+    ActionItem, MeetingDecision, MeetingHandoff, default_handoff_dir, write_meeting_handoff,
 };
 
 use super::types::{ConversationMessage, HandoffActionItem, MeetingTranscript};

--- a/src/meeting_facilitator/handoff/mod.rs
+++ b/src/meeting_facilitator/handoff/mod.rs
@@ -1,13 +1,10 @@
 //! Meeting handoff artifacts — written when a meeting closes, consumed by
 //! the engineer loop and the `act-on-decisions` CLI subcommand.
 
-use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
-
-use crate::error::{SimardError, SimardResult};
 
 use super::types::{ActionItem, MeetingDecision, MeetingSession, OpenQuestion};
 

--- a/src/memory_ipc/mod.rs
+++ b/src/memory_ipc/mod.rs
@@ -16,11 +16,8 @@
 //! caller should open the DB directly.
 
 use std::io::{Read, Write};
-use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
-use std::thread;
-use std::time::Duration;
+use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 

--- a/src/memory_ipc/server.rs
+++ b/src/memory_ipc/server.rs
@@ -1,6 +1,5 @@
 //! Server: spawn_server + ServerHandle + serve_connection + dispatch.
 
-use std::io::{Read, Write};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::PathBuf;
 use std::sync::Arc;

--- a/src/operator_commands_ooda/daemon/helpers.rs
+++ b/src/operator_commands_ooda/daemon/helpers.rs
@@ -1,5 +1,5 @@
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::{Duration, Instant, SystemTime};
+use std::time::{Duration, SystemTime};
 
 /// Append a timestamped log line to `{state_root}/ooda.log` **and** stderr.
 ///


### PR DESCRIPTION
## Summary

Continues the #1405 clippy unused-imports burndown. Manual selective pass across hot-spot mod.rs files in recently-promoted dirs.

## Warnings: 80 → 49 (-31)

## Files touched
```
src/cognitive_memory/mod.rs
src/cognitive_memory/ops.rs
src/engineer_loop/execution/dispatch.rs
src/engineer_loop/execution/mod.rs
src/engineer_worktree/mod.rs
src/gym/scenarios/mod.rs
src/meeting_backend/messaging.rs
src/meeting_backend/mod.rs
src/meeting_backend/persist/extract.rs
src/meeting_backend/persist/markdown.rs
src/meeting_backend/persist/mod.rs
src/meeting_facilitator/handoff/mod.rs
src/memory_ipc/mod.rs
src/memory_ipc/server.rs
src/operator_commands_ooda/daemon/helpers.rs
```

## Approach
- For each warning: `grep` symbol across file; remove only when zero remaining usage.
- Skipped `pub(crate) use` re-exports needed by tests (`cargo fix --lib` is unsafe — strips them).

## Verification
- `cargo check --tests --locked` ✅
- `cargo test --lib --locked -- --skip cargo_install_from_repo_succeeds --test-threads=4` → **3905 passed, 0 failed**
- Pre-commit + pre-push green (clippy + cargo-fmt + tests). No `--no-verify` used.

Refs #1405

Routed via amplihack `/dev` recipe runner. Verification phase timed out (filed as amplihack-rs#449); manual completion of test+push+PR.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>