### PR TITLE
chore: drop unused imports batch 6 (#1405)

### DIFF
--- a/src/engineer_loop/mod.rs
+++ b/src/engineer_loop/mod.rs
@@ -48,7 +48,6 @@ use std::time::Instant;
 
 use crate::error::{SimardError, SimardResult};
 use crate::goals::{FileBackedGoalStore, GoalStore};
-use crate::memory::{FileBackedMemoryStore, MemoryScope, MemoryStore};
 use crate::runtime::RuntimeTopology;
 use crate::terminal_engineer_bridge::{SHARED_EXPLICIT_STATE_ROOT_SOURCE, TerminalBridgeContext};
 

--- a/src/engineer_loop/selection/selectors_extra.rs
+++ b/src/engineer_loop/selection/selectors_extra.rs
@@ -1,7 +1,5 @@
 //! Cargo-action selector + action-achievability checks.
 
-use crate::error::{SimardError, SimardResult};
-
 use super::{extract_existing_issue_number, tokenise_target_argv};
 
 use crate::engineer_loop::types::{

--- a/src/ooda_actions/advance_goal/mod.rs
+++ b/src/ooda_actions/advance_goal/mod.rs
@@ -2,12 +2,10 @@
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use crate::agent_roles::AgentRole;
 use crate::agent_supervisor::{
     HeartbeatStatus, SubordinateConfig, check_heartbeat, spawn_subordinate,
 };
 use crate::goal_curation::{GoalProgress, update_goal_progress};
-use crate::identity_composition::max_subordinate_depth;
 use crate::ooda_loop::{ActionOutcome, OodaBridges, OodaState, PlannedAction};
 
 use super::goal_session::GoalAction;

--- a/src/ooda_actions/goal_session/advance.rs
+++ b/src/ooda_actions/goal_session/advance.rs
@@ -1,6 +1,5 @@
 //! Goal-session "advance" + "assess-only" outcome computation.
 
-use crate::error::SimardResult;
 use crate::goal_curation::{GoalBoard, GoalProgress, update_goal_progress};
 use crate::ooda_loop::{ActionOutcome, OodaState, PlannedAction};
 

--- a/src/ooda_loop/mod.rs
+++ b/src/ooda_loop/mod.rs
@@ -36,16 +36,10 @@ pub use types::{
     OodaBridges, OodaConfig, OodaPhase, OodaState, OodaStateSnapshot, PlannedAction, Priority,
 };
 
-use std::time::Instant;
-
 use crate::error::{SimardError, SimardResult};
-use crate::goal_curation::load_goal_board;
-use crate::gym_bridge::ScoreDimensions;
-use crate::gym_scoring::GymSuiteScore;
 use crate::memory_consolidation;
 use crate::memory_consolidation::preparation_memory_operations;
 use crate::self_improve::{ImprovementCycle, ImprovementPhase};
-use crate::session::SessionId;
 
 /// Act: dispatch actions. Failures are per-action, not cycle-wide (Pillar 11).
 ///


### PR DESCRIPTION
## Summary
Continues clippy #1405 burndown after batch 5 (#1436) merged with only 2 imports.
Removes 13 verified-unused top-level imports across 5 files.

## Files changed
- `src/engineer_loop/mod.rs`: `FileBackedMemoryStore`, `MemoryScope`, `MemoryStore` (3)
- `src/engineer_loop/selection/selectors_extra.rs`: `SimardError`, `SimardResult` (2)
- `src/ooda_actions/advance_goal/mod.rs`: `AgentRole`, `max_subordinate_depth` (2)
- `src/ooda_actions/goal_session/advance.rs`: `SimardResult` (1)
- `src/ooda_loop/mod.rs`: `Instant`, `load_goal_board`, `ScoreDimensions`, `GymSuiteScore`, `SessionId` (5)

**Total: 13 imports / 5 files**

## Verification
- `cargo build --tests --lib` passes (no compile errors)
- Lib-clippy `unused_imports` raw spans: **64 → 51** (-13)
- All pre-push hooks passed locally (fmt, clippy, full `cargo test`)

## False positives discovered & excluded
The following `pub(crate) use`/`pub use` re-exports were initially flagged as unused
but are actually needed by sibling `#[cfg(test)]` modules that consume them via
`use super::*;`. Verified empirically (each removal broke `cargo build --tests`):

- `src/meeting_backend/mod.rs` L28: `SimardResult` (used by `tests_mod.rs`)
- `src/cognitive_memory/mod.rs` L314: `ops::escape_cypher` (used by `tests_mod.rs`)
- `src/cmd_cleanup/mod.rs` L149-150: disk constants + `dir_size` (used by `tests.rs`)
- `src/meeting_backend/persist/mod.rs` L246: extract re-exports (used by `tests_persist.rs`)
- `src/meeting_facilitator/handoff/mod.rs` L237: `find_newest_handoff` (per task scope)
- `src/spawn.rs`: `find_live_engineer_for_goal` (owned by PR #1228)

This is a known limitation of clippy's `unused_imports` lint with the
"pub re-export consumed by glob-import in cfg(test) child module" pattern.

## Notes
- Branch named `batch6` (not `batch5`) because PR #1436 already shipped as batch 5
  while this work was in progress.
- Squash-merge with `--delete-branch` when CI is green.