### PR TITLE
chore: clear final clippy --all-targets warnings (#1405)

### DIFF
--- a/src/engineer_worktree/tests_extra.rs
+++ b/src/engineer_worktree/tests_extra.rs
@@ -29,18 +29,6 @@ fn init_parent_repo(dir: &Path) -> PathBuf {
     dir.to_path_buf()
 }
 
-fn init_parent_repo_no_main(dir: &Path) -> PathBuf {
-    fs::create_dir_all(dir).expect("create dir");
-    run_git(dir, &["init", "--initial-branch=trunk", "--quiet"]);
-    run_git(dir, &["config", "user.email", "t@e.com"]);
-    run_git(dir, &["config", "user.name", "t"]);
-    run_git(dir, &["config", "commit.gpgsign", "false"]);
-    fs::write(dir.join("a"), "x").unwrap();
-    run_git(dir, &["add", "a"]);
-    run_git(dir, &["commit", "-m", "x", "--quiet"]);
-    dir.to_path_buf()
-}
-
 fn run_git(repo: &Path, args: &[&str]) {
     let out = git_cmd(repo, args).output().expect("spawn git");
     assert!(
@@ -61,19 +49,6 @@ fn git_output(repo: &Path, args: &[&str]) -> String {
         String::from_utf8_lossy(&out.stderr)
     );
     String::from_utf8_lossy(&out.stdout).into_owned()
-}
-
-fn worktree_registered(parent_repo: &Path, path: &Path) -> bool {
-    let listing = git_output(parent_repo, &["worktree", "list", "--porcelain"]);
-    let needle = format!("worktree {}", path.display());
-    listing.lines().any(|l| l == needle)
-}
-
-fn branch_exists(parent_repo: &Path, branch: &str) -> bool {
-    git_cmd(parent_repo, &["rev-parse", "--verify", "--quiet", branch])
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
 }
 
 /// Build a `git` command that mirrors production isolation: clear env, then

--- a/src/engineer_worktree/tests_more.rs
+++ b/src/engineer_worktree/tests_more.rs
@@ -30,18 +30,6 @@ fn init_parent_repo(dir: &Path) -> PathBuf {
     dir.to_path_buf()
 }
 
-fn init_parent_repo_no_main(dir: &Path) -> PathBuf {
-    fs::create_dir_all(dir).expect("create dir");
-    run_git(dir, &["init", "--initial-branch=trunk", "--quiet"]);
-    run_git(dir, &["config", "user.email", "t@e.com"]);
-    run_git(dir, &["config", "user.name", "t"]);
-    run_git(dir, &["config", "commit.gpgsign", "false"]);
-    fs::write(dir.join("a"), "x").unwrap();
-    run_git(dir, &["add", "a"]);
-    run_git(dir, &["commit", "-m", "x", "--quiet"]);
-    dir.to_path_buf()
-}
-
 fn run_git(repo: &Path, args: &[&str]) {
     let out = git_cmd(repo, args).output().expect("spawn git");
     assert!(
@@ -68,13 +56,6 @@ fn worktree_registered(parent_repo: &Path, path: &Path) -> bool {
     let listing = git_output(parent_repo, &["worktree", "list", "--porcelain"]);
     let needle = format!("worktree {}", path.display());
     listing.lines().any(|l| l == needle)
-}
-
-fn branch_exists(parent_repo: &Path, branch: &str) -> bool {
-    git_cmd(parent_repo, &["rev-parse", "--verify", "--quiet", branch])
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
 }
 
 /// Build a `git` command that mirrors production isolation: clear env, then

--- a/src/ooda_loop/tests_orient.rs
+++ b/src/ooda_loop/tests_orient.rs
@@ -1,27 +1,7 @@
 use super::orient::*;
 use crate::goal_curation::{ActiveGoal, GoalBoard, GoalProgress};
-use crate::gym_bridge::ScoreDimensions;
-use crate::gym_scoring::GymSuiteScore;
 use crate::memory_cognitive::CognitiveStatistics;
 use crate::ooda_loop::{EnvironmentSnapshot, Observation};
-
-fn make_gym_score(overall: f64, factual_accuracy: f64) -> GymSuiteScore {
-    GymSuiteScore {
-        suite_id: "progressive".to_string(),
-        overall,
-        dimensions: ScoreDimensions {
-            factual_accuracy,
-            specificity: 0.8,
-            temporal_awareness: 0.7,
-            source_attribution: 0.6,
-            confidence_calibration: 0.5,
-        },
-        scenario_count: 5,
-        scenarios_passed: 4,
-        pass_rate: 0.8,
-        recorded_at_unix_ms: None,
-    }
-}
 
 fn make_board_with_goals(goals: Vec<ActiveGoal>) -> GoalBoard {
     let mut board = GoalBoard::new();

--- a/src/self_improve_executor/git_ops.rs
+++ b/src/self_improve_executor/git_ops.rs
@@ -133,7 +133,6 @@ pub(crate) fn rollback(workspace: &Path) -> SimardResult<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serial_test::serial;
     use tempfile::tempdir;
 
     /// Run a `git` subcommand with isolated config (immune to other tests

--- a/src/self_improve_executor/tests_extra.rs
+++ b/src/self_improve_executor/tests_extra.rs
@@ -15,10 +15,6 @@ fn make_patch(steps: Vec<PlanStep>) -> ImprovementPatch {
     }
 }
 
-fn passing_step() -> PlanStep {
-    step("src/lib.rs", "true")
-}
-
 fn failing_step() -> PlanStep {
     step("src/fail.rs", "false")
 }

--- a/src/stewardship/tests.rs
+++ b/src/stewardship/tests.rs
@@ -113,17 +113,6 @@ fn sample_run() -> OrchestratorRunSummary {
     }
 }
 
-fn amplihack_run() -> OrchestratorRunSummary {
-    OrchestratorRunSummary {
-        run_id: "run-xyz789".to_string(),
-        recipe_name: "smart-orchestrator".to_string(),
-        failed_step: "decompose".to_string(),
-        source_module: "amplihack::recipe-runner".to_string(),
-        failure_kind: "NonZeroExit".to_string(),
-        error_text: "exit 1: decomposition produced 0 workstreams".to_string(),
-    }
-}
-
 // ─────────────────────────── Routing tests ───────────────────────────
 
 #[test]


### PR DESCRIPTION
Resolves the last 9 `cargo clippy --all-targets --all-features --locked -- -D warnings` violations remaining after PR #1442 cleared `--lib`. All flagged symbols verified by grep to have duplicate live definitions in sibling test files; pure dead-code cleanup, no behavior change.

## Changes

| File | Action |
|------|--------|
| `src/self_improve_executor/git_ops.rs` | Drop unused \`use serial_test::serial;\` (file uses fully-qualified \`#[serial_test::serial]\`) |
| `src/self_improve_executor/tests_extra.rs` | Drop unused \`passing_step\` (live copy in \`tests.rs\`) |
| \`src/engineer_worktree/tests_extra.rs\` | Drop unused \`init_parent_repo_no_main\`, \`worktree_registered\`, \`branch_exists\` (live copies in \`tests.rs\`) |
| \`src/engineer_worktree/tests_more.rs\` | Drop unused \`init_parent_repo_no_main\`, \`branch_exists\` (\`worktree_registered\` retained — still called) |
| \`src/ooda_loop/tests_orient.rs\` | Drop unused \`make_gym_score\` plus the \`ScoreDimensions\`/\`GymSuiteScore\` imports it solely required |
| \`src/stewardship/tests.rs\` | Drop unused \`amplihack_run\` helper (live copy in \`tests_extra.rs\`) |

## Verification

\`\`\`
cargo clippy --all-targets --all-features --locked -- -D warnings  # exits 0
cargo test --all-features --locked --lib -- --test-threads=4       # 3905 passed
\`\`\`

## Follow-up

A second PR will restore strict pre-commit clippy enforcement (remove \`-A unused_imports -A dead_code\` allowances from \`.pre-commit-config.yaml\`) once this lands.

Closes part of #1405.