### PR TITLE
ci(pre-commit): restore strict clippy now that #1405 burndown is complete

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,8 +20,8 @@ repos:
           - manual
 
       - id: cargo-clippy
-        name: cargo clippy --all-targets --all-features --locked -- -D warnings -A unused_imports -A dead_code
-        entry: cargo clippy --all-targets --all-features --locked -- -D warnings -A unused_imports -A dead_code
+        name: cargo clippy --all-targets --all-features --locked -- -D warnings
+        entry: cargo clippy --all-targets --all-features --locked -- -D warnings
         language: system
         pass_filenames: false
         always_run: true


### PR DESCRIPTION
Removes the temporary `-A unused_imports -A dead_code` allowances from the `cargo-clippy` pre-commit hook now that the #1405 burndown is complete (final cleanup landed in #1455).

## Change

`.pre-commit-config.yaml` — both the `name:` and `entry:` keys of the `cargo-clippy` hook lose the trailing ` -A unused_imports -A dead_code` suffix. The hook now matches CI's canonical strict invocation byte-for-byte:

```
cargo clippy --all-targets --all-features --locked -- -D warnings
```

## Verification

```
cargo clippy --all-targets --all-features --locked -- -D warnings   # exits 0
```

## Rollback Note

If this hook causes unexpected blockages on developer machines post-merge, re-add the allowances via a fresh hotfix PR rather than reverting #1455 (which is pure dead-code cleanup with no behavior risk).

Closes #1405.