### PR TITLE
feat(gym): add KnowledgeRecall benchmark family (issue #1459)

### DIFF
--- a/docs/concepts/gym-knowledge-recall.md
+++ b/docs/concepts/gym-knowledge-recall.md
@@ -1,0 +1,58 @@
+# Gym: Knowledge Recall Family
+
+The `KnowledgeRecall` benchmark class measures **longitudinal learning** —
+whether Simard remembers what she should already know by now. Every other
+benchmark class scores a single-shot task. Knowledge Recall scores
+*accumulation*.
+
+It was introduced in [issue #1459][issue] as the first scenario-level addition
+on top of the prompt-driven OODA brain (PR #1458): now that the brain reads
+stored memories as context, memory accumulation is the gating capability for
+nearly every other quality the gym tries to measure. Without recall scoring
+we cannot detect when memory consolidation regresses.
+
+## Motivation
+
+Simard's job is to maintain a fleet of repositories over time. The valuable
+agent is not the one that solves any given task in isolation — it is the one
+who knows the codebase, the tools, and the operator's preferences well
+enough to skip the rediscovery step. Knowledge Recall scenarios formalise
+that expectation: each one poses a question whose answer should already be
+in the cognitive memory store or directly observable in the repository.
+
+A regression on any Knowledge Recall scorecard is a signal that recall is
+silently degrading even when one-shot tasks still pass.
+
+## Sub-families
+
+The family covers four sub-families, rolled out incrementally:
+
+1. **Self-code recall** — facts about Simard's own implementation. Example:
+   *"Identify the file containing the `OodaBrain` trait definition and cite
+   its single wire-in site in the OODA action layer."*
+2. **User-preference recall** — preferences and prohibitions the user has
+   stated. Example: *"Recall the user-mandated stance on `--no-verify` and
+   explain the approved alternative for known-flaky local tests."*
+3. **Repo-knowledge recall** — facts about the repositories Simard
+   maintains: most-touched modules over a window, ownership of an invariant,
+   resolution of a closed issue.
+4. **Tools-knowledge recall** — facts about the tools available to Simard:
+   environment variables that gate hooks, what a given recipe runner does
+   that a direct invocation does not.
+
+## First PR
+
+The first PR seeds two scenarios — one self-code, one user-preference — and
+wires them into the existing `class_specific_checks` dispatch path. Each
+scenario produces two checks:
+
+- `knowledge-recall-evidence-grounded` — the runtime evidence references at
+  least one stored memory record or a real repository file path.
+- `knowledge-recall-topic-cited` — the response actually names the topic the
+  objective asked about, rather than a plausible-sounding confabulation.
+
+Subsequent PRs add the repo-knowledge and tools-knowledge sub-families and
+extend the scoring to read directly from the ladybug-backed cognitive memory
+store under `~/.simard/cognitive_memory/`.
+
+[issue]: https://github.com/rysweet/Simard/issues/1459

--- a/src/gym/scenarios/checks.rs
+++ b/src/gym/scenarios/checks.rs
@@ -76,5 +76,8 @@ pub(crate) fn class_specific_checks(
         BenchmarkClass::ChaosEngineering => {
             super::checks_5::checks_for_chaos_engineering(&combined)
         }
+        BenchmarkClass::KnowledgeRecall => {
+            super::checks_6::checks_for_knowledge_recall(scenario, &combined, exported)
+        }
     }
 }

--- a/src/gym/scenarios/checks_6.rs
+++ b/src/gym/scenarios/checks_6.rs
@@ -1,6 +1,7 @@
 //! class_specific_checks helpers — chunk 6 of 6.
 
-use super::super::types::BenchmarkCheckResult;
+use super::super::types::{BenchmarkCheckResult, BenchmarkScenario};
+use crate::handoff::RuntimeHandoffSnapshot;
 
 pub(super) fn checks_for_feature_flagging(combined: &str) -> Vec<BenchmarkCheckResult> {
     let flag_mechanism_described = combined.contains("feature flag")
@@ -281,6 +282,64 @@ pub(super) fn checks_for_test_writing(combined: &str) -> Vec<BenchmarkCheckResul
                 } else {
                     "lacks"
                 }
+            ),
+        },
+    ]
+}
+
+/// Checks for the `KnowledgeRecall` benchmark family (issue #1459).
+///
+/// Each scenario in this family asks the agent to recall something she should
+/// already know (her own code, her tools, the repos she maintains, or the
+/// user's stated preferences). The checks verify that runtime evidence is
+/// grounded — either by referencing at least one stored memory record or by
+/// citing a real repository file path — and that the response actually names
+/// the topic the objective asked about.
+pub(super) fn checks_for_knowledge_recall(
+    scenario: &BenchmarkScenario,
+    combined: &str,
+    exported: &RuntimeHandoffSnapshot,
+) -> Vec<BenchmarkCheckResult> {
+    let memory_grounded = !exported.memory_records.is_empty();
+    let path_cited =
+        combined.contains(".rs") || combined.contains("src/") || combined.contains("docs/");
+    let evidence_grounded = memory_grounded || path_cited;
+
+    let topic_match = match scenario.id {
+        "knowledge-recall-self-code" => {
+            (combined.contains("oodabrain")
+                || combined.contains("ooda_brain")
+                || combined.contains("ooda brain"))
+                && (combined.contains("trait") || combined.contains("wire"))
+        }
+        "knowledge-recall-user-preference" => {
+            combined.contains("--no-verify")
+                && (combined.contains("skip=cargo-test")
+                    || combined.contains("skip cargo-test")
+                    || combined.contains("cargo-test"))
+        }
+        _ => false,
+    };
+
+    vec![
+        BenchmarkCheckResult {
+            id: "knowledge-recall-evidence-grounded".to_string(),
+            passed: evidence_grounded,
+            detail: format!(
+                "runtime evidence {} a stored memory record or repo file path",
+                if evidence_grounded {
+                    "references"
+                } else {
+                    "lacks"
+                }
+            ),
+        },
+        BenchmarkCheckResult {
+            id: "knowledge-recall-topic-cited".to_string(),
+            passed: topic_match,
+            detail: format!(
+                "execution output {} the recall topic named by the objective",
+                if topic_match { "names" } else { "omits" }
             ),
         },
     ]

--- a/src/gym/scenarios/data_6.rs
+++ b/src/gym/scenarios/data_6.rs
@@ -1,0 +1,35 @@
+//! Auto-split BENCHMARK_SCENARIOS data — chunk 6 of 6.
+//!
+//! KnowledgeRecall family (issue #1459): scenarios that measure longitudinal
+//! learning. Each scenario asks the agent to recall something she should
+//! already know — about her own code, her tools, the repos she maintains, or
+//! the user's stated preferences — and grounds the answer in stored memories
+//! or real repository file paths rather than confabulation.
+
+use super::super::types::{BenchmarkClass, BenchmarkScenario};
+use crate::runtime::RuntimeTopology;
+
+pub(super) static SCENARIOS: [BenchmarkScenario; 2] = [
+    BenchmarkScenario {
+        id: "knowledge-recall-self-code",
+        title: "Knowledge recall: locate the OodaBrain trait and its wire-in site",
+        description: "Verify the agent can recall structural facts about her own codebase: which file defines the OodaBrain trait and where in the OODA action layer it is wired in.",
+        class: BenchmarkClass::KnowledgeRecall,
+        identity: "simard-gym",
+        base_type: "rusty-clawd",
+        topology: RuntimeTopology::SingleProcess,
+        objective: "Identify the file containing the OodaBrain trait definition and cite its single wire-in site in the OODA action layer.",
+        expected_min_runtime_evidence: 2,
+    },
+    BenchmarkScenario {
+        id: "knowledge-recall-user-preference",
+        title: "Knowledge recall: user stance on --no-verify",
+        description: "Verify the agent can recall a user-stated preference — the prohibition on bypassing pre-push verification with --no-verify — and cite the approved alternative for known-flaky local tests.",
+        class: BenchmarkClass::KnowledgeRecall,
+        identity: "simard-gym",
+        base_type: "rusty-clawd",
+        topology: RuntimeTopology::SingleProcess,
+        objective: "Recall the user-mandated stance on bypassing pre-push verification (--no-verify) and explain the approved alternative for known-flaky local tests.",
+        expected_min_runtime_evidence: 2,
+    },
+];

--- a/src/gym/scenarios/mod.rs
+++ b/src/gym/scenarios/mod.rs
@@ -9,6 +9,7 @@ mod data_2;
 mod data_3;
 mod data_4;
 mod data_5;
+mod data_6;
 
 use std::sync::OnceLock;
 
@@ -17,12 +18,13 @@ static ALL_BENCHMARK_SCENARIOS: OnceLock<Vec<BenchmarkScenario>> = OnceLock::new
 fn all_benchmark_scenarios() -> &'static [BenchmarkScenario] {
     ALL_BENCHMARK_SCENARIOS
         .get_or_init(|| {
-            let mut v = Vec::with_capacity(153);
+            let mut v = Vec::with_capacity(155);
             v.extend_from_slice(&data_1::SCENARIOS);
             v.extend_from_slice(&data_2::SCENARIOS);
             v.extend_from_slice(&data_3::SCENARIOS);
             v.extend_from_slice(&data_4::SCENARIOS);
             v.extend_from_slice(&data_5::SCENARIOS);
+            v.extend_from_slice(&data_6::SCENARIOS);
             v
         })
         .as_slice()

--- a/src/gym/tests_scenarios.rs
+++ b/src/gym/tests_scenarios.rs
@@ -15,7 +15,7 @@ use crate::session::{SessionId, SessionPhase, SessionRecord};
 
 #[test]
 fn benchmark_scenarios_returns_nine_scenarios() {
-    assert_eq!(benchmark_scenarios().len(), 153);
+    assert_eq!(benchmark_scenarios().len(), 155);
 }
 
 #[test]

--- a/src/gym/tests_scenarios_5.rs
+++ b/src/gym/tests_scenarios_5.rs
@@ -271,3 +271,79 @@ fn class_checks_incident_response_fails_without_keywords() {
         assert!(!check.passed, "check '{}' should have failed", check.id);
     }
 }
+
+// -- Wave 9: KnowledgeRecall (issue #1459) --
+
+#[test]
+fn knowledge_recall_self_code_scenario_resolves() {
+    let scenario = resolve_benchmark_scenario("knowledge-recall-self-code")
+        .expect("knowledge-recall-self-code scenario must be registered");
+    assert_eq!(scenario.class, BenchmarkClass::KnowledgeRecall);
+    assert_eq!(scenario.identity, "simard-gym");
+    assert_eq!(scenario.base_type, "rusty-clawd");
+    assert_eq!(scenario.expected_min_runtime_evidence, 2);
+}
+
+#[test]
+fn knowledge_recall_user_preference_scenario_resolves() {
+    let scenario = resolve_benchmark_scenario("knowledge-recall-user-preference")
+        .expect("knowledge-recall-user-preference scenario must be registered");
+    assert_eq!(scenario.class, BenchmarkClass::KnowledgeRecall);
+    assert_eq!(scenario.identity, "simard-gym");
+    assert_eq!(scenario.base_type, "rusty-clawd");
+    assert_eq!(scenario.expected_min_runtime_evidence, 2);
+}
+
+#[test]
+fn class_checks_knowledge_recall_self_code_passes_with_grounded_answer() {
+    let scenario = resolve_benchmark_scenario("knowledge-recall-self-code").unwrap();
+    let outcome = dummy_outcome(
+        "review src/ooda_brain/mod.rs to locate the OodaBrain trait definition",
+        "OodaBrain trait lives in src/ooda_brain/mod.rs and is wired in by the OODA action layer",
+        "cited single wire-in site; trait is the brain entrypoint",
+    );
+    let exported = dummy_handoff(1);
+    let checks = class_specific_checks(&scenario, &outcome, &exported);
+    assert_eq!(checks.len(), 2);
+    assert!(
+        checks
+            .iter()
+            .any(|c| c.id == "knowledge-recall-evidence-grounded" && c.passed),
+        "evidence-grounded check should pass when memory records exist or a path is cited"
+    );
+    assert!(
+        checks
+            .iter()
+            .any(|c| c.id == "knowledge-recall-topic-cited" && c.passed),
+        "topic-cited check should pass when OodaBrain trait is named"
+    );
+}
+
+#[test]
+fn class_checks_knowledge_recall_user_preference_passes_with_grounded_answer() {
+    let scenario = resolve_benchmark_scenario("knowledge-recall-user-preference").unwrap();
+    let outcome = dummy_outcome(
+        "consult stored memory on user stance regarding --no-verify",
+        "user mandates never using --no-verify; SKIP=cargo-test is the approved alternative for known-flaky local tests",
+        "documented preference in cognitive memory",
+    );
+    let exported = dummy_handoff(1);
+    let checks = class_specific_checks(&scenario, &outcome, &exported);
+    assert_eq!(checks.len(), 2);
+    assert!(
+        checks.iter().all(|c| c.passed),
+        "all KnowledgeRecall checks should pass for a fully grounded answer"
+    );
+}
+
+#[test]
+fn class_checks_knowledge_recall_fails_when_ungrounded() {
+    let scenario = resolve_benchmark_scenario("knowledge-recall-self-code").unwrap();
+    let outcome = dummy_outcome("nothing", "bland text", "empty");
+    let exported = dummy_handoff(0);
+    let checks = class_specific_checks(&scenario, &outcome, &exported);
+    assert_eq!(checks.len(), 2);
+    for check in &checks {
+        assert!(!check.passed, "check '{}' should have failed", check.id);
+    }
+}

--- a/src/gym/types.rs
+++ b/src/gym/types.rs
@@ -39,6 +39,7 @@ pub enum BenchmarkClass {
     RateLimiting,
     EventSourcing,
     ChaosEngineering,
+    KnowledgeRecall,
 }
 
 impl Display for BenchmarkClass {
@@ -76,6 +77,7 @@ impl Display for BenchmarkClass {
             Self::RateLimiting => "rate-limiting",
             Self::EventSourcing => "event-sourcing",
             Self::ChaosEngineering => "chaos-engineering",
+            Self::KnowledgeRecall => "knowledge-recall",
         };
         f.write_str(label)
     }


### PR DESCRIPTION
## Summary

This is the **first scenario-level PR** in the [#1459][issue] initiative to add a `KnowledgeRecall` gym benchmark family that scores **longitudinal learning** instead of single-shot task execution.

PR #1458 just landed the prompt-driven OODA brain — the brain reads stored memories as context. That makes memory accumulation the gating capability for nearly every other quality the gym tries to measure, so we need a way to detect when recall regresses. This PR plants the seed; subsequent PRs fill in the four sub-families.

## Changes

- **`BenchmarkClass::KnowledgeRecall`** added to `src/gym/types.rs`.
- **`src/gym/scenarios/data_6.rs`** — two seed scenarios:
  - `knowledge-recall-self-code` — *"Identify the file containing the OodaBrain trait definition and cite its single wire-in site in the OODA action layer."*
  - `knowledge-recall-user-preference` — *"Recall the user-mandated stance on bypassing pre-push verification (`--no-verify`) and explain the approved alternative for known-flaky local tests."*
- **`checks_for_knowledge_recall`** in `src/gym/scenarios/checks_6.rs`, dispatched through the existing `class_specific_checks` path. Each scenario produces two checks:
  - `knowledge-recall-evidence-grounded` — runtime evidence references at least one stored memory record or a real repository file path.
  - `knowledge-recall-topic-cited` — the response actually names the topic the objective asked about.
- **Tests** in `src/gym/tests_scenarios_5.rs` covering scenario resolution and the new dispatch path (passing + ungrounded failure cases).
- **Docs** in `docs/concepts/gym-knowledge-recall.md` explaining the family, motivation, and four sub-families.
- Bumped the scenario count from 153 → 155.

## Roadmap (4 sub-families)

1. **Self-code recall** — facts about Simard's own implementation. *(seeded here)*
2. **User-preference recall** — preferences and prohibitions the user has stated. *(seeded here)*
3. **Repo-knowledge recall** — most-touched modules, ownership of invariants, resolution of closed issues. *(future PR)*
4. **Tools-knowledge recall** — env vars that gate hooks, what recipes do beyond direct invocation. *(future PR)*

A follow-up will wire scoring directly into the ladybug-backed cognitive memory store under `~/.simard/cognitive_memory/`.

## Verification

- `cargo fmt --all` ✅
- `cargo clippy --all-targets --all-features --locked -- -D warnings` ✅
- `cargo test --all-features --locked --lib gym::` ✅ (353 passed)

Pushed with `SKIP=cargo-test` (only the known-flaky local test stage of the pre-push hook is skipped; clippy and fmt run as usual).

[issue]: https://github.com/rysweet/Simard/issues/1459
