### PR TITLE
feat(gym): add KnowledgeRecall tools sub-family (issue #1459)

### DIFF
--- a/docs/concepts/gym-knowledge-recall.md
+++ b/docs/concepts/gym-knowledge-recall.md
@@ -55,4 +55,36 @@ Subsequent PRs add the repo-knowledge and tools-knowledge sub-families and
 extend the scoring to read directly from the ladybug-backed cognitive memory
 store under `~/.simard/cognitive_memory/`.
 
+## Tools sub-family (this PR)
+
+The second PR in the series adds the **tools-knowledge** sub-family (sub-family
+#4 in the enumeration above). It ships before the repo-knowledge sub-family
+(#3) because tool-recall scenarios require no repo-history fixtures and land
+as a pure data + checks change.
+
+Three new scenarios are registered, each grounded in canonical lowercase
+tokens that the topic-cited check searches for in the agent's combined plan,
+execution summary, and reflection summary text:
+
+- `knowledge-recall-tool-amplihack-recipe` — recall how the amplihack recipe
+  runner is invoked for development and investigation work, including the
+  sub-command, the recipe name, and at least one required environment
+  variable. Topic-cited verifies the response names `amplihack`, either
+  `recipe` or `smart-orchestrator`, and the `AMPLIHACK_HOME` env var.
+- `knowledge-recall-tool-pre-push-skip` — recall the approved environment
+  variable used to skip the cargo-test stage of the local pre-push hook for
+  known-flaky tests, and explain why `--no-verify` is forbidden. Topic-cited
+  verifies the response contains both the `SKIP=cargo-test` token and the
+  `--no-verify` token. The check verifies *presence* of these tokens only;
+  the framing — that `--no-verify` is prohibited and `SKIP=cargo-test` is the
+  approved alternative — is enforced by the scenario's objective prompt, not
+  by the check arm itself.
+- `knowledge-recall-tool-redeploy-script` — recall the script and target-
+  directory environment variable used to rebuild and reinstall the running
+  simard daemon binary after a main-branch merge. Topic-cited verifies the
+  response names `redeploy-local.sh` and `CARGO_TARGET_DIR`.
+
+Each scenario reuses the same two BenchmarkCheckResults established by the
+first PR (`knowledge-recall-evidence-grounded` + `knowledge-recall-topic-cited`).
+
 [issue]: https://github.com/rysweet/Simard/issues/1459

--- a/src/gym/mod.rs
+++ b/src/gym/mod.rs
@@ -33,6 +33,8 @@ mod tests_scenarios_5;
 #[cfg(test)]
 mod tests_scenarios_6;
 #[cfg(test)]
+mod tests_scenarios_7;
+#[cfg(test)]
 mod tests_types;
 #[cfg(test)]
 mod tests_types_extra;

--- a/src/gym/scenarios/checks_6.rs
+++ b/src/gym/scenarios/checks_6.rs
@@ -318,6 +318,17 @@ pub(super) fn checks_for_knowledge_recall(
                     || combined.contains("skip cargo-test")
                     || combined.contains("cargo-test"))
         }
+        "knowledge-recall-tool-amplihack-recipe" => {
+            combined.contains("amplihack")
+                && (combined.contains("recipe") || combined.contains("smart-orchestrator"))
+                && combined.contains("amplihack_home")
+        }
+        "knowledge-recall-tool-pre-push-skip" => {
+            combined.contains("skip=cargo-test") && combined.contains("--no-verify")
+        }
+        "knowledge-recall-tool-redeploy-script" => {
+            combined.contains("redeploy-local.sh") && combined.contains("cargo_target_dir")
+        }
         _ => false,
     };
 

--- a/src/gym/scenarios/data_6.rs
+++ b/src/gym/scenarios/data_6.rs
@@ -9,7 +9,7 @@
 use super::super::types::{BenchmarkClass, BenchmarkScenario};
 use crate::runtime::RuntimeTopology;
 
-pub(super) static SCENARIOS: [BenchmarkScenario; 2] = [
+pub(super) static SCENARIOS: [BenchmarkScenario; 5] = [
     BenchmarkScenario {
         id: "knowledge-recall-self-code",
         title: "Knowledge recall: locate the OodaBrain trait and its wire-in site",
@@ -30,6 +30,39 @@ pub(super) static SCENARIOS: [BenchmarkScenario; 2] = [
         base_type: "rusty-clawd",
         topology: RuntimeTopology::SingleProcess,
         objective: "Recall the user-mandated stance on bypassing pre-push verification (--no-verify) and explain the approved alternative for known-flaky local tests.",
+        expected_min_runtime_evidence: 2,
+    },
+    BenchmarkScenario {
+        id: "knowledge-recall-tool-amplihack-recipe",
+        title: "Knowledge recall: amplihack recipe runner invocation",
+        description: "Verify the agent can recall how the amplihack recipe runner is invoked for development and investigation work, including the sub-command, the recipe name, and at least one required environment variable.",
+        class: BenchmarkClass::KnowledgeRecall,
+        identity: "simard-gym",
+        base_type: "rusty-clawd",
+        topology: RuntimeTopology::SingleProcess,
+        objective: "Recall how the amplihack recipe runner is invoked for development and investigation work, including the sub-command, the recipe name, and at least one required environment variable.",
+        expected_min_runtime_evidence: 2,
+    },
+    BenchmarkScenario {
+        id: "knowledge-recall-tool-pre-push-skip",
+        title: "Knowledge recall: pre-push hook SKIP=cargo-test policy",
+        description: "Verify the agent can recall the approved environment variable used to skip the cargo-test stage of the local pre-push hook for known-flaky tests, and explain why --no-verify is forbidden.",
+        class: BenchmarkClass::KnowledgeRecall,
+        identity: "simard-gym",
+        base_type: "rusty-clawd",
+        topology: RuntimeTopology::SingleProcess,
+        objective: "Recall the approved environment variable used to skip the cargo-test stage of the local pre-push hook for known-flaky tests, and explain why --no-verify is forbidden.",
+        expected_min_runtime_evidence: 2,
+    },
+    BenchmarkScenario {
+        id: "knowledge-recall-tool-redeploy-script",
+        title: "Knowledge recall: redeploy-local.sh + CARGO_TARGET_DIR",
+        description: "Verify the agent can recall the script and target-directory environment variable used to rebuild and reinstall the running simard daemon binary after a main-branch merge.",
+        class: BenchmarkClass::KnowledgeRecall,
+        identity: "simard-gym",
+        base_type: "rusty-clawd",
+        topology: RuntimeTopology::SingleProcess,
+        objective: "Recall the script and target-directory environment variable used to rebuild and reinstall the running simard daemon binary after a main-branch merge.",
         expected_min_runtime_evidence: 2,
     },
 ];

--- a/src/gym/scenarios/mod.rs
+++ b/src/gym/scenarios/mod.rs
@@ -18,7 +18,7 @@ static ALL_BENCHMARK_SCENARIOS: OnceLock<Vec<BenchmarkScenario>> = OnceLock::new
 fn all_benchmark_scenarios() -> &'static [BenchmarkScenario] {
     ALL_BENCHMARK_SCENARIOS
         .get_or_init(|| {
-            let mut v = Vec::with_capacity(155);
+            let mut v = Vec::with_capacity(158);
             v.extend_from_slice(&data_1::SCENARIOS);
             v.extend_from_slice(&data_2::SCENARIOS);
             v.extend_from_slice(&data_3::SCENARIOS);

--- a/src/gym/tests_scenarios.rs
+++ b/src/gym/tests_scenarios.rs
@@ -15,7 +15,7 @@ use crate::session::{SessionId, SessionPhase, SessionRecord};
 
 #[test]
 fn benchmark_scenarios_returns_nine_scenarios() {
-    assert_eq!(benchmark_scenarios().len(), 155);
+    assert_eq!(benchmark_scenarios().len(), 158);
 }
 
 #[test]

--- a/src/gym/tests_scenarios_7.rs
+++ b/src/gym/tests_scenarios_7.rs
@@ -1,0 +1,306 @@
+//! Tests for the KnowledgeRecall tools sub-family (issue #1459, second PR).
+//!
+//! Covers the three new scenarios:
+//!   - knowledge-recall-tool-amplihack-recipe
+//!   - knowledge-recall-tool-pre-push-skip
+//!   - knowledge-recall-tool-redeploy-script
+//!
+//! For each scenario this file verifies:
+//!   (a) the scenario resolves via `resolve_benchmark_scenario` with the
+//!       expected class/identity/base_type/expected_min_runtime_evidence; and
+//!   (b) `class_specific_checks` dispatches to `checks_for_knowledge_recall`
+//!       and produces both `knowledge-recall-evidence-grounded` and
+//!       `knowledge-recall-topic-cited` results, passing for grounded answers
+//!       and failing for ungrounded ones.
+
+use super::scenarios::*;
+use super::types::BenchmarkClass;
+use crate::base_types::BaseTypeId;
+use crate::handoff::RuntimeHandoffSnapshot;
+use crate::identity::ManifestContract;
+use crate::identity::OperatingMode;
+use crate::memory::{MemoryRecord, MemoryScope};
+use crate::metadata::{BackendDescriptor, Freshness, Provenance};
+use crate::reflection::{ReflectionReport, ReflectionSnapshot};
+use crate::runtime::{
+    RuntimeAddress, RuntimeNodeId, RuntimeState, RuntimeTopology, SessionOutcome,
+};
+use crate::session::{SessionId, SessionPhase, SessionRecord};
+
+fn dummy_backend() -> BackendDescriptor {
+    BackendDescriptor {
+        identity: "test-backend".to_string(),
+        provenance: Provenance::new("test-src", "test::loc"),
+        freshness: Freshness::now().unwrap(),
+    }
+}
+
+fn dummy_contract() -> ManifestContract {
+    ManifestContract {
+        entrypoint: "test::entry".to_string(),
+        composition: "a -> b".to_string(),
+        precedence: vec!["tag:value".to_string()],
+        provenance: Provenance::new("test-src", "test::loc"),
+        freshness: Freshness::now().unwrap(),
+    }
+}
+
+fn dummy_snapshot() -> ReflectionSnapshot {
+    let backend = dummy_backend();
+    ReflectionSnapshot {
+        identity_name: "test".to_string(),
+        identity_components: vec![],
+        selected_base_type: BaseTypeId::new("test"),
+        topology: RuntimeTopology::SingleProcess,
+        runtime_state: RuntimeState::Ready,
+        runtime_node: RuntimeNodeId::local(),
+        mailbox_address: RuntimeAddress::local(&RuntimeNodeId::local()),
+        session_phase: Some(SessionPhase::Complete),
+        prompt_assets: vec![],
+        manifest_contract: dummy_contract(),
+        evidence_records: 0,
+        memory_records: 0,
+        active_goal_count: 0,
+        active_goals: vec![],
+        proposed_goal_count: 0,
+        proposed_goals: vec![],
+        agent_program_backend: backend.clone(),
+        handoff_backend: backend.clone(),
+        adapter_backend: backend.clone(),
+        adapter_capabilities: vec![],
+        adapter_supported_topologies: vec![],
+        topology_backend: backend.clone(),
+        transport_backend: backend.clone(),
+        supervisor_backend: backend.clone(),
+        memory_backend: backend.clone(),
+        evidence_backend: backend.clone(),
+        goal_backend: backend,
+    }
+}
+
+fn dummy_outcome(plan: &str, execution_summary: &str, reflection_summary: &str) -> SessionOutcome {
+    SessionOutcome {
+        session: SessionRecord {
+            id: SessionId::parse("session-00000000-0000-0000-0000-000000000001").unwrap(),
+            mode: OperatingMode::Gym,
+            objective: "test".to_string(),
+            phase: SessionPhase::Complete,
+            selected_base_type: BaseTypeId::new("test"),
+            evidence_ids: vec![],
+            memory_keys: vec![],
+        },
+        plan: plan.to_string(),
+        execution_summary: execution_summary.to_string(),
+        reflection: ReflectionReport {
+            summary: reflection_summary.to_string(),
+            snapshot: dummy_snapshot(),
+        },
+    }
+}
+
+fn dummy_handoff(memory_count: usize) -> RuntimeHandoffSnapshot {
+    let session_id = SessionId::parse("session-00000000-0000-0000-0000-000000000001").unwrap();
+    RuntimeHandoffSnapshot {
+        exported_state: RuntimeState::Stopped,
+        identity_name: "test".to_string(),
+        selected_base_type: BaseTypeId::new("test"),
+        topology: RuntimeTopology::SingleProcess,
+        source_runtime_node: RuntimeNodeId::local(),
+        source_mailbox_address: RuntimeAddress::local(&RuntimeNodeId::local()),
+        session: None,
+        memory_records: (0..memory_count)
+            .map(|i| MemoryRecord {
+                key: format!("key-{i}"),
+                scope: MemoryScope::Benchmark,
+                value: format!("value-{i}"),
+                session_id: session_id.clone(),
+                recorded_in: SessionPhase::Complete,
+                created_at: None,
+            })
+            .collect(),
+        evidence_records: vec![],
+        copilot_submit_audit: None,
+    }
+}
+
+// -- (a) Resolve coverage: each new scenario is registered with the right shape. --
+
+#[test]
+fn knowledge_recall_tool_amplihack_recipe_scenario_resolves() {
+    let scenario = resolve_benchmark_scenario("knowledge-recall-tool-amplihack-recipe")
+        .expect("knowledge-recall-tool-amplihack-recipe scenario must be registered");
+    assert_eq!(scenario.class, BenchmarkClass::KnowledgeRecall);
+    assert_eq!(scenario.identity, "simard-gym");
+    assert_eq!(scenario.base_type, "rusty-clawd");
+    assert_eq!(scenario.topology, RuntimeTopology::SingleProcess);
+    assert_eq!(scenario.expected_min_runtime_evidence, 2);
+}
+
+#[test]
+fn knowledge_recall_tool_pre_push_skip_scenario_resolves() {
+    let scenario = resolve_benchmark_scenario("knowledge-recall-tool-pre-push-skip")
+        .expect("knowledge-recall-tool-pre-push-skip scenario must be registered");
+    assert_eq!(scenario.class, BenchmarkClass::KnowledgeRecall);
+    assert_eq!(scenario.identity, "simard-gym");
+    assert_eq!(scenario.base_type, "rusty-clawd");
+    assert_eq!(scenario.topology, RuntimeTopology::SingleProcess);
+    assert_eq!(scenario.expected_min_runtime_evidence, 2);
+}
+
+#[test]
+fn knowledge_recall_tool_redeploy_script_scenario_resolves() {
+    let scenario = resolve_benchmark_scenario("knowledge-recall-tool-redeploy-script")
+        .expect("knowledge-recall-tool-redeploy-script scenario must be registered");
+    assert_eq!(scenario.class, BenchmarkClass::KnowledgeRecall);
+    assert_eq!(scenario.identity, "simard-gym");
+    assert_eq!(scenario.base_type, "rusty-clawd");
+    assert_eq!(scenario.topology, RuntimeTopology::SingleProcess);
+    assert_eq!(scenario.expected_min_runtime_evidence, 2);
+}
+
+// -- (b) Dispatch coverage: class_specific_checks routes to KnowledgeRecall and
+//        the topic_match arm fires for each new scenario id. --
+
+#[test]
+fn class_checks_knowledge_recall_tool_amplihack_recipe_passes_with_grounded_answer() {
+    let scenario = resolve_benchmark_scenario("knowledge-recall-tool-amplihack-recipe").unwrap();
+    let outcome = dummy_outcome(
+        "consult docs/ for amplihack recipe runner invocation patterns",
+        "amplihack recipe run smart-orchestrator -c task_description=... requires AMPLIHACK_HOME env var",
+        "cited recipe + AMPLIHACK_HOME env var",
+    );
+    let exported = dummy_handoff(1);
+    let checks = class_specific_checks(&scenario, &outcome, &exported);
+    assert_eq!(checks.len(), 2);
+    assert!(
+        checks
+            .iter()
+            .any(|c| c.id == "knowledge-recall-evidence-grounded" && c.passed),
+        "evidence-grounded must pass when memory records exist or a path is cited"
+    );
+    assert!(
+        checks
+            .iter()
+            .any(|c| c.id == "knowledge-recall-topic-cited" && c.passed),
+        "topic-cited must pass when amplihack + recipe + AMPLIHACK_HOME are named"
+    );
+}
+
+#[test]
+fn class_checks_knowledge_recall_tool_amplihack_recipe_fails_when_topic_missing() {
+    let scenario = resolve_benchmark_scenario("knowledge-recall-tool-amplihack-recipe").unwrap();
+    // grounded by a path but missing the canonical tokens
+    let outcome = dummy_outcome(
+        "look at src/main.rs",
+        "I think you run some command somewhere",
+        "no specifics recalled",
+    );
+    let exported = dummy_handoff(0);
+    let checks = class_specific_checks(&scenario, &outcome, &exported);
+    assert_eq!(checks.len(), 2);
+    assert!(
+        checks
+            .iter()
+            .any(|c| c.id == "knowledge-recall-topic-cited" && !c.passed),
+        "topic-cited must fail when amplihack/recipe/AMPLIHACK_HOME tokens are absent"
+    );
+}
+
+#[test]
+fn class_checks_knowledge_recall_tool_pre_push_skip_passes_with_grounded_answer() {
+    let scenario = resolve_benchmark_scenario("knowledge-recall-tool-pre-push-skip").unwrap();
+    let outcome = dummy_outcome(
+        "recall pre-push hook policy from stored user-preference memory",
+        "use SKIP=cargo-test for known-flaky local cargo tests; --no-verify is forbidden by user policy",
+        "documented preference",
+    );
+    let exported = dummy_handoff(1);
+    let checks = class_specific_checks(&scenario, &outcome, &exported);
+    assert_eq!(checks.len(), 2);
+    assert!(
+        checks.iter().all(|c| c.passed),
+        "all KnowledgeRecall checks should pass for a fully grounded pre-push-skip answer"
+    );
+}
+
+#[test]
+fn class_checks_knowledge_recall_tool_pre_push_skip_fails_when_topic_missing() {
+    let scenario = resolve_benchmark_scenario("knowledge-recall-tool-pre-push-skip").unwrap();
+    let outcome = dummy_outcome(
+        "look at scripts/ folder",
+        "there is some way to skip tests",
+        "vague",
+    );
+    let exported = dummy_handoff(0);
+    let checks = class_specific_checks(&scenario, &outcome, &exported);
+    assert_eq!(checks.len(), 2);
+    assert!(
+        checks
+            .iter()
+            .any(|c| c.id == "knowledge-recall-topic-cited" && !c.passed),
+        "topic-cited must fail when SKIP=cargo-test and --no-verify tokens are absent"
+    );
+}
+
+#[test]
+fn class_checks_knowledge_recall_tool_redeploy_script_passes_with_grounded_answer() {
+    let scenario = resolve_benchmark_scenario("knowledge-recall-tool-redeploy-script").unwrap();
+    let outcome = dummy_outcome(
+        "recall scripts/redeploy-local.sh from prior maintenance sessions",
+        "scripts/redeploy-local.sh rebuilds and reinstalls the daemon; CARGO_TARGET_DIR points it at the build cache",
+        "cited script + CARGO_TARGET_DIR env var",
+    );
+    let exported = dummy_handoff(1);
+    let checks = class_specific_checks(&scenario, &outcome, &exported);
+    assert_eq!(checks.len(), 2);
+    assert!(
+        checks
+            .iter()
+            .any(|c| c.id == "knowledge-recall-evidence-grounded" && c.passed)
+    );
+    assert!(
+        checks
+            .iter()
+            .any(|c| c.id == "knowledge-recall-topic-cited" && c.passed),
+        "topic-cited must pass when redeploy-local.sh + CARGO_TARGET_DIR are named"
+    );
+}
+
+#[test]
+fn class_checks_knowledge_recall_tool_redeploy_script_fails_when_topic_missing() {
+    let scenario = resolve_benchmark_scenario("knowledge-recall-tool-redeploy-script").unwrap();
+    let outcome = dummy_outcome(
+        "look at scripts/",
+        "there is a build-and-install flow somewhere",
+        "vague",
+    );
+    let exported = dummy_handoff(0);
+    let checks = class_specific_checks(&scenario, &outcome, &exported);
+    assert_eq!(checks.len(), 2);
+    assert!(
+        checks
+            .iter()
+            .any(|c| c.id == "knowledge-recall-topic-cited" && !c.passed),
+        "topic-cited must fail when redeploy-local.sh and CARGO_TARGET_DIR tokens are absent"
+    );
+}
+
+// -- All-three-resolve smoke test: handy single assertion for the sub-family. --
+
+#[test]
+fn knowledge_recall_tools_subfamily_has_three_scenarios() {
+    let ids = [
+        "knowledge-recall-tool-amplihack-recipe",
+        "knowledge-recall-tool-pre-push-skip",
+        "knowledge-recall-tool-redeploy-script",
+    ];
+    for id in ids {
+        let scenario =
+            resolve_benchmark_scenario(id).unwrap_or_else(|_| panic!("scenario {id} must resolve"));
+        assert_eq!(
+            scenario.class,
+            BenchmarkClass::KnowledgeRecall,
+            "scenario {id} must be KnowledgeRecall"
+        );
+    }
+}


### PR DESCRIPTION
Second PR in the KnowledgeRecall family for #1459. Self-code and user-preference scenarios already landed in #1460. Repo-knowledge sub-family to follow.

## What

Adds the **tools-knowledge** sub-family — three new `KnowledgeRecall` benchmark scenarios that measure whether Simard recalls how her own tools are invoked, rather than re-discovering them on each task.

### New scenarios

| ID | Topic-cited tokens (lowercase string-contains) |
| --- | --- |
| `knowledge-recall-tool-amplihack-recipe` | `amplihack` AND (`recipe` OR `smart-orchestrator`) AND `amplihack_home` |
| `knowledge-recall-tool-pre-push-skip` | `skip=cargo-test` AND `--no-verify` |
| `knowledge-recall-tool-redeploy-script` | `redeploy-local.sh` AND `cargo_target_dir` |

Each scenario reuses the two BenchmarkCheckResults established by #1460:
`knowledge-recall-evidence-grounded` (memory record or repo path cited) and `knowledge-recall-topic-cited` (canonical tokens present).

### Files

- `src/gym/scenarios/data_6.rs`: array `[BenchmarkScenario; 2]` → `[BenchmarkScenario; 5]`; +3 entries.
- `src/gym/scenarios/mod.rs`: `Vec::with_capacity(155)` → `158`.
- `src/gym/scenarios/checks_6.rs`: +3 `topic_match` arms (357 LOC, under the 400 cap).
- `src/gym/tests_scenarios.rs`: scenario-count assertion 155 → 158.
- `src/gym/tests_scenarios_7.rs` (new, 306 LOC): 10 tests — resolve + class_specific_checks dispatch coverage for each new scenario, with positive and negative topic-match cases. Created as a new file because `tests_scenarios_6.rs` already exists with general tests and adding more would breach the #1266 400-LOC cap.
- `src/gym/mod.rs`: wires `#[cfg(test)] mod tests_scenarios_7;`.
- `docs/concepts/gym-knowledge-recall.md`: appended *Tools sub-family (this PR)* section.

## Why pre-push-skip pairs SKIP=cargo-test with --no-verify

The check verifies token *presence* only. The framing (that `--no-verify` is prohibited and `SKIP=cargo-test` is the approved alternative) is enforced by the scenario's objective prompt — not the check arm. This rewards the agent for citing both sides of the policy in the same answer.

## Quality gates

- `cargo fmt --all` — clean
- `cargo clippy --all-targets --all-features --locked -- -D warnings` — clean
- `cargo test --all-features --locked --lib gym::` — **363 passed, 0 failed**
- All 10 new tests in `gym::tests_scenarios_7::` pass

## Standing rules honoured

- Never `--no-verify`. Pre-push cargo-test surfaced 17 pre-existing failures in `self_improve_executor` and friends (unrelated to this PR); pushed with the approved `SKIP=cargo-test` per repo policy.
- 400-LOC module cap (#1266) respected: `checks_6.rs` 357 LOC, `data_6.rs` 68 LOC, `tests_scenarios_7.rs` 306 LOC.
- Single commit with the mandated `Co-authored-by: Copilot` trailer.

Closes part of #1459 (one more PR for repo-knowledge to follow).