### PR TITLE
feat(gym): add KnowledgeRecall tools sub-family (issue #1459)

### DIFF
--- a/docs/concepts/gym-knowledge-recall.md
+++ b/docs/concepts/gym-knowledge-recall.md
@@ -56,3 +56,32 @@ extend the scoring to read directly from the ladybug-backed cognitive memory
 store under `~/.simard/cognitive_memory/`.
 
 [issue]: https://github.com/rysweet/Simard/issues/1459
+
+## Tools sub-family (PR #1461)
+
+The second scenario-level PR after [#1460][pr-1460] adds three
+`tools-knowledge` scenarios. Each one verifies that Simard recalls a
+concrete operating-tool fact rather than confabulating an interface:
+
+- `knowledge-recall-tool-amplihack-recipe` — recalls how the amplihack
+  recipe runner is invoked for development and investigation work: the
+  `amplihack recipe run` sub-command, the `smart-orchestrator` recipe
+  name, and at least one required environment variable
+  (`AMPLIHACK_HOME` or `AMPLIHACK_AGENT_BINARY`).
+- `knowledge-recall-tool-pre-push-skip` — recalls that
+  `SKIP=cargo-test` is the approved override for the cargo-test stage
+  of the local pre-push hook on known-flaky tests, and explains why
+  `--no-verify` is forbidden as a bypass.
+- `knowledge-recall-tool-redeploy-script` — recalls that
+  `scripts/redeploy-local.sh` rebuilds the simard daemon using the
+  `SIMARD_SHARED_TARGET` target directory and reinstalls to
+  `~/.simard/bin/simard` after a main-branch merge.
+
+All three scenarios reuse the same two-check template seeded by the
+first PR (`knowledge-recall-evidence-grounded` and
+`knowledge-recall-topic-cited`), with topic matchers extended in
+`src/gym/scenarios/checks_6.rs` to look for the canonical tokens above.
+
+The next planned PR adds the `repo-knowledge` sub-family.
+
+[pr-1460]: https://github.com/rysweet/Simard/pull/1460

--- a/src/gym/mod.rs
+++ b/src/gym/mod.rs
@@ -33,6 +33,8 @@ mod tests_scenarios_5;
 #[cfg(test)]
 mod tests_scenarios_6;
 #[cfg(test)]
+mod tests_scenarios_7;
+#[cfg(test)]
 mod tests_types;
 #[cfg(test)]
 mod tests_types_extra;

--- a/src/gym/scenarios/checks_6.rs
+++ b/src/gym/scenarios/checks_6.rs
@@ -318,6 +318,27 @@ pub(super) fn checks_for_knowledge_recall(
                     || combined.contains("skip cargo-test")
                     || combined.contains("cargo-test"))
         }
+        "knowledge-recall-tool-amplihack-recipe" => {
+            combined.contains("amplihack")
+                && (combined.contains("recipe run") || combined.contains("smart-orchestrator"))
+                && (combined.contains("amplihack_home")
+                    || combined.contains("amplihack_agent_binary"))
+        }
+        "knowledge-recall-tool-pre-push-skip" => {
+            (combined.contains("skip=cargo-test") || combined.contains("skip cargo-test"))
+                && combined.contains("--no-verify")
+                && (combined.contains("forbid")
+                    || combined.contains("prohibit")
+                    || combined.contains("never")
+                    || combined.contains("not allowed")
+                    || combined.contains("disallow"))
+        }
+        "knowledge-recall-tool-redeploy-script" => {
+            combined.contains("redeploy-local.sh")
+                && (combined.contains("simard_shared_target")
+                    || combined.contains("~/.simard/bin/simard")
+                    || combined.contains(".simard/bin/simard"))
+        }
         _ => false,
     };
 

--- a/src/gym/scenarios/data_6.rs
+++ b/src/gym/scenarios/data_6.rs
@@ -9,7 +9,7 @@
 use super::super::types::{BenchmarkClass, BenchmarkScenario};
 use crate::runtime::RuntimeTopology;
 
-pub(super) static SCENARIOS: [BenchmarkScenario; 2] = [
+pub(super) static SCENARIOS: [BenchmarkScenario; 5] = [
     BenchmarkScenario {
         id: "knowledge-recall-self-code",
         title: "Knowledge recall: locate the OodaBrain trait and its wire-in site",
@@ -30,6 +30,39 @@ pub(super) static SCENARIOS: [BenchmarkScenario; 2] = [
         base_type: "rusty-clawd",
         topology: RuntimeTopology::SingleProcess,
         objective: "Recall the user-mandated stance on bypassing pre-push verification (--no-verify) and explain the approved alternative for known-flaky local tests.",
+        expected_min_runtime_evidence: 2,
+    },
+    BenchmarkScenario {
+        id: "knowledge-recall-tool-amplihack-recipe",
+        title: "Knowledge recall: amplihack recipe runner invocation",
+        description: "Verify the agent can recall how the amplihack recipe runner is invoked for development and investigation work — the sub-command, the recipe name, and at least one required environment variable — rather than confabulating an interface.",
+        class: BenchmarkClass::KnowledgeRecall,
+        identity: "simard-gym",
+        base_type: "rusty-clawd",
+        topology: RuntimeTopology::SingleProcess,
+        objective: "Recall how the amplihack recipe runner is invoked for development and investigation work, including the sub-command, the recipe name, and at least one required environment variable.",
+        expected_min_runtime_evidence: 2,
+    },
+    BenchmarkScenario {
+        id: "knowledge-recall-tool-pre-push-skip",
+        title: "Knowledge recall: SKIP=cargo-test pre-push override",
+        description: "Verify the agent can recall the approved environment variable used to skip the cargo-test stage of the local pre-push hook when known-flaky tests are tripping it, and explain why --no-verify is forbidden as a bypass.",
+        class: BenchmarkClass::KnowledgeRecall,
+        identity: "simard-gym",
+        base_type: "rusty-clawd",
+        topology: RuntimeTopology::SingleProcess,
+        objective: "Recall the approved environment variable used to skip the cargo-test stage of the local pre-push hook for known-flaky tests, and explain why --no-verify is forbidden.",
+        expected_min_runtime_evidence: 2,
+    },
+    BenchmarkScenario {
+        id: "knowledge-recall-tool-redeploy-script",
+        title: "Knowledge recall: redeploy-local.sh and SIMARD_SHARED_TARGET",
+        description: "Verify the agent can recall the script and target-directory environment variable used to rebuild and reinstall the running simard daemon binary after a main-branch merge, instead of guessing at a cargo install command.",
+        class: BenchmarkClass::KnowledgeRecall,
+        identity: "simard-gym",
+        base_type: "rusty-clawd",
+        topology: RuntimeTopology::SingleProcess,
+        objective: "Recall the script and target-directory environment variable used to rebuild and reinstall the running simard daemon binary after a main-branch merge.",
         expected_min_runtime_evidence: 2,
     },
 ];

--- a/src/gym/scenarios/mod.rs
+++ b/src/gym/scenarios/mod.rs
@@ -18,7 +18,7 @@ static ALL_BENCHMARK_SCENARIOS: OnceLock<Vec<BenchmarkScenario>> = OnceLock::new
 fn all_benchmark_scenarios() -> &'static [BenchmarkScenario] {
     ALL_BENCHMARK_SCENARIOS
         .get_or_init(|| {
-            let mut v = Vec::with_capacity(155);
+            let mut v = Vec::with_capacity(158);
             v.extend_from_slice(&data_1::SCENARIOS);
             v.extend_from_slice(&data_2::SCENARIOS);
             v.extend_from_slice(&data_3::SCENARIOS);

--- a/src/gym/tests_scenarios.rs
+++ b/src/gym/tests_scenarios.rs
@@ -15,7 +15,7 @@ use crate::session::{SessionId, SessionPhase, SessionRecord};
 
 #[test]
 fn benchmark_scenarios_returns_nine_scenarios() {
-    assert_eq!(benchmark_scenarios().len(), 155);
+    assert_eq!(benchmark_scenarios().len(), 158);
 }
 
 #[test]

--- a/src/gym/tests_scenarios_7.rs
+++ b/src/gym/tests_scenarios_7.rs
@@ -1,0 +1,217 @@
+//! Tests for the KnowledgeRecall **tools-knowledge** sub-family (issue #1459).
+//!
+//! These cover the three scenarios added by the second scenario-level PR
+//! after #1460: amplihack recipe runner recall, the SKIP=cargo-test pre-push
+//! override recall, and the redeploy-local.sh / SIMARD_SHARED_TARGET recall.
+
+use super::scenarios::*;
+use super::types::{BenchmarkClass, BenchmarkScenario};
+use crate::base_types::BaseTypeId;
+use crate::handoff::RuntimeHandoffSnapshot;
+use crate::identity::ManifestContract;
+use crate::identity::OperatingMode;
+use crate::memory::{MemoryRecord, MemoryScope};
+use crate::metadata::{BackendDescriptor, Freshness, Provenance};
+use crate::reflection::{ReflectionReport, ReflectionSnapshot};
+use crate::runtime::{
+    RuntimeAddress, RuntimeNodeId, RuntimeState, RuntimeTopology, SessionOutcome,
+};
+use crate::session::{SessionId, SessionPhase, SessionRecord};
+
+fn dummy_backend() -> BackendDescriptor {
+    BackendDescriptor {
+        identity: "test-backend".to_string(),
+        provenance: Provenance::new("test-src", "test::loc"),
+        freshness: Freshness::now().unwrap(),
+    }
+}
+
+fn dummy_contract() -> ManifestContract {
+    ManifestContract {
+        entrypoint: "test::entry".to_string(),
+        composition: "a -> b".to_string(),
+        precedence: vec!["tag:value".to_string()],
+        provenance: Provenance::new("test-src", "test::loc"),
+        freshness: Freshness::now().unwrap(),
+    }
+}
+
+fn dummy_snapshot() -> ReflectionSnapshot {
+    let backend = dummy_backend();
+    ReflectionSnapshot {
+        identity_name: "test".to_string(),
+        identity_components: vec![],
+        selected_base_type: BaseTypeId::new("test"),
+        topology: RuntimeTopology::SingleProcess,
+        runtime_state: RuntimeState::Ready,
+        runtime_node: RuntimeNodeId::local(),
+        mailbox_address: RuntimeAddress::local(&RuntimeNodeId::local()),
+        session_phase: Some(SessionPhase::Complete),
+        prompt_assets: vec![],
+        manifest_contract: dummy_contract(),
+        evidence_records: 0,
+        memory_records: 0,
+        active_goal_count: 0,
+        active_goals: vec![],
+        proposed_goal_count: 0,
+        proposed_goals: vec![],
+        agent_program_backend: backend.clone(),
+        handoff_backend: backend.clone(),
+        adapter_backend: backend.clone(),
+        adapter_capabilities: vec![],
+        adapter_supported_topologies: vec![],
+        topology_backend: backend.clone(),
+        transport_backend: backend.clone(),
+        supervisor_backend: backend.clone(),
+        memory_backend: backend.clone(),
+        evidence_backend: backend.clone(),
+        goal_backend: backend,
+    }
+}
+
+fn dummy_outcome(plan: &str, execution_summary: &str, reflection_summary: &str) -> SessionOutcome {
+    SessionOutcome {
+        session: SessionRecord {
+            id: SessionId::parse("session-00000000-0000-0000-0000-000000000001").unwrap(),
+            mode: OperatingMode::Gym,
+            objective: "test".to_string(),
+            phase: SessionPhase::Complete,
+            selected_base_type: BaseTypeId::new("test"),
+            evidence_ids: vec![],
+            memory_keys: vec![],
+        },
+        plan: plan.to_string(),
+        execution_summary: execution_summary.to_string(),
+        reflection: ReflectionReport {
+            summary: reflection_summary.to_string(),
+            snapshot: dummy_snapshot(),
+        },
+    }
+}
+
+fn dummy_handoff(memory_count: usize) -> RuntimeHandoffSnapshot {
+    let session_id = SessionId::parse("session-00000000-0000-0000-0000-000000000001").unwrap();
+    RuntimeHandoffSnapshot {
+        exported_state: RuntimeState::Stopped,
+        identity_name: "test".to_string(),
+        selected_base_type: BaseTypeId::new("test"),
+        topology: RuntimeTopology::SingleProcess,
+        source_runtime_node: RuntimeNodeId::local(),
+        source_mailbox_address: RuntimeAddress::local(&RuntimeNodeId::local()),
+        session: None,
+        memory_records: (0..memory_count)
+            .map(|i| MemoryRecord {
+                key: format!("key-{i}"),
+                scope: MemoryScope::Benchmark,
+                value: format!("value-{i}"),
+                session_id: session_id.clone(),
+                recorded_in: SessionPhase::Complete,
+                created_at: None,
+            })
+            .collect(),
+        evidence_records: vec![],
+        copilot_submit_audit: None,
+    }
+}
+
+fn assert_tools_scenario_shape(scenario: &BenchmarkScenario) {
+    assert_eq!(scenario.class, BenchmarkClass::KnowledgeRecall);
+    assert_eq!(scenario.identity, "simard-gym");
+    assert_eq!(scenario.base_type, "rusty-clawd");
+    assert_eq!(scenario.topology, RuntimeTopology::SingleProcess);
+    assert_eq!(scenario.expected_min_runtime_evidence, 2);
+}
+
+#[test]
+fn knowledge_recall_tool_amplihack_recipe_scenario_resolves() {
+    let scenario = resolve_benchmark_scenario("knowledge-recall-tool-amplihack-recipe")
+        .expect("knowledge-recall-tool-amplihack-recipe scenario must be registered");
+    assert_tools_scenario_shape(&scenario);
+}
+
+#[test]
+fn knowledge_recall_tool_pre_push_skip_scenario_resolves() {
+    let scenario = resolve_benchmark_scenario("knowledge-recall-tool-pre-push-skip")
+        .expect("knowledge-recall-tool-pre-push-skip scenario must be registered");
+    assert_tools_scenario_shape(&scenario);
+}
+
+#[test]
+fn knowledge_recall_tool_redeploy_script_scenario_resolves() {
+    let scenario = resolve_benchmark_scenario("knowledge-recall-tool-redeploy-script")
+        .expect("knowledge-recall-tool-redeploy-script scenario must be registered");
+    assert_tools_scenario_shape(&scenario);
+}
+
+#[test]
+fn class_checks_knowledge_recall_tool_amplihack_recipe_passes_with_grounded_answer() {
+    let scenario = resolve_benchmark_scenario("knowledge-recall-tool-amplihack-recipe").unwrap();
+    let outcome = dummy_outcome(
+        "consult stored memory on the amplihack recipe runner invocation pattern",
+        "amplihack recipe run smart-orchestrator -c repo_path=. — requires AMPLIHACK_HOME and preserves AMPLIHACK_AGENT_BINARY",
+        "documented invocation in src/gym/scenarios/data_6.rs",
+    );
+    let exported = dummy_handoff(1);
+    let checks = class_specific_checks(&scenario, &outcome, &exported);
+    assert_eq!(checks.len(), 2);
+    assert!(
+        checks.iter().all(|c| c.passed),
+        "all KnowledgeRecall checks should pass for a fully grounded amplihack-recipe answer: {checks:?}"
+    );
+}
+
+#[test]
+fn class_checks_knowledge_recall_tool_pre_push_skip_passes_with_grounded_answer() {
+    let scenario = resolve_benchmark_scenario("knowledge-recall-tool-pre-push-skip").unwrap();
+    let outcome = dummy_outcome(
+        "recall the approved pre-push override for known-flaky tests",
+        "use SKIP=cargo-test git push to skip the cargo-test stage of the local pre-push hook",
+        "--no-verify is forbidden because it bypasses every hook stage; SKIP=cargo-test is the only sanctioned override (cited in docs/)",
+    );
+    let exported = dummy_handoff(1);
+    let checks = class_specific_checks(&scenario, &outcome, &exported);
+    assert_eq!(checks.len(), 2);
+    assert!(
+        checks.iter().all(|c| c.passed),
+        "all KnowledgeRecall checks should pass for a fully grounded pre-push-skip answer: {checks:?}"
+    );
+}
+
+#[test]
+fn class_checks_knowledge_recall_tool_redeploy_script_passes_with_grounded_answer() {
+    let scenario = resolve_benchmark_scenario("knowledge-recall-tool-redeploy-script").unwrap();
+    let outcome = dummy_outcome(
+        "recall the post-merge redeploy script for the simard daemon",
+        "scripts/redeploy-local.sh rebuilds the simard binary using SIMARD_SHARED_TARGET as the target dir and reinstalls to ~/.simard/bin/simard",
+        "documented in src/ workflow notes",
+    );
+    let exported = dummy_handoff(1);
+    let checks = class_specific_checks(&scenario, &outcome, &exported);
+    assert_eq!(checks.len(), 2);
+    assert!(
+        checks.iter().all(|c| c.passed),
+        "all KnowledgeRecall checks should pass for a fully grounded redeploy-script answer: {checks:?}"
+    );
+}
+
+#[test]
+fn class_checks_knowledge_recall_tools_fail_when_ungrounded() {
+    for id in [
+        "knowledge-recall-tool-amplihack-recipe",
+        "knowledge-recall-tool-pre-push-skip",
+        "knowledge-recall-tool-redeploy-script",
+    ] {
+        let scenario = resolve_benchmark_scenario(id).unwrap();
+        let outcome = dummy_outcome("nothing", "bland text", "empty");
+        let exported = dummy_handoff(0);
+        let checks = class_specific_checks(&scenario, &outcome, &exported);
+        assert_eq!(checks.len(), 2);
+        for check in &checks {
+            assert!(
+                !check.passed,
+                "scenario {id}: check '{}' should have failed",
+                check.id
+            );
+        }
+    }
+}


### PR DESCRIPTION
Implements the **tools-knowledge** sub-family of the `KnowledgeRecall` benchmark class introduced in #1459. This is the second scenario-level PR, following #1460 which seeded the family with the self-code and user-preference scenarios.

## What's new

Three new scenarios in `src/gym/scenarios/data_6.rs`, all in the `KnowledgeRecall` class with identity `simard-gym`, base type `rusty-clawd`, and `expected_min_runtime_evidence: 2`:

- **`knowledge-recall-tool-amplihack-recipe`** — verifies recall of the amplihack recipe runner invocation: the `amplihack recipe run` sub-command, the `smart-orchestrator` recipe name, and at least one required env var (`AMPLIHACK_HOME` / `AMPLIHACK_AGENT_BINARY`).
- **`knowledge-recall-tool-pre-push-skip`** — verifies recall that `SKIP=cargo-test` is the only sanctioned override for the cargo-test stage of the local pre-push hook on known-flaky tests, and that `--no-verify` is forbidden.
- **`knowledge-recall-tool-redeploy-script`** — verifies recall that `scripts/redeploy-local.sh` rebuilds the simard daemon using `SIMARD_SHARED_TARGET` and reinstalls to `~/.simard/bin/simard` after a main-branch merge.

Each scenario reuses the two-check template introduced in #1460 (`knowledge-recall-evidence-grounded` + `knowledge-recall-topic-cited`); topic matchers were extended in `src/gym/scenarios/checks_6.rs` to look for the canonical tokens above.

## Wiring

- `Vec::with_capacity(155)` → `158` in `src/gym/scenarios/mod.rs`.
- Total scenario count assertion bumped `155` → `158` in `tests_scenarios.rs`.
- New tests in `src/gym/tests_scenarios_7.rs` (created to stay under the 400-LOC per-module cap, #1266); module declared from `src/gym/mod.rs`.
- Docs section appended to `docs/concepts/gym-knowledge-recall.md`.

## Verification

- `cargo fmt --all` ✓
- `cargo clippy --all-targets --all-features --locked -- -D warnings` ✓
- `cargo test --all-features --locked --lib gym::` — 360 passed, 0 failed.

## Next

The `repo-knowledge` sub-family is the next planned PR for #1459.

Refs #1459. Follow-up to #1460.
