### PR TITLE
feat(gym): add KnowledgeRecall repo-knowledge sub-family (issue #1459)

### DIFF
--- a/docs/concepts/gym-knowledge-recall.md
+++ b/docs/concepts/gym-knowledge-recall.md
@@ -85,3 +85,32 @@ first PR (`knowledge-recall-evidence-grounded` and
 The next planned PR adds the `repo-knowledge` sub-family.
 
 [pr-1460]: https://github.com/rysweet/Simard/pull/1460
+
+## Repo-knowledge sub-family (this PR)
+
+The third (and final scaffolding) scenario-level PR for [#1459][issue]
+adds three `repo-knowledge` scenarios. Each one verifies that Simard
+recalls a structural fact about her own repository layout rather than
+re-deriving it from a fresh `grep`:
+
+- `knowledge-recall-repo-ooda-loop-layout` — recalls the layout of
+  Simard's OODA loop module: the four canonical phase modules under
+  `src/ooda_loop/` (`observe`, `orient`, `decide`, `act`) and the file
+  that holds the cycle entry point (`cycle.rs` / `mod.rs`).
+- `knowledge-recall-repo-cognitive-memory-store` — recalls the storage
+  backend used by the cognitive memory subsystem (`ladybug`) and the
+  on-disk filename of the primary persistent store under
+  `~/.simard/` (`cognitive_memory.ladybug`).
+- `knowledge-recall-repo-engineer-worktree-pattern` — recalls how the
+  OODA daemon spawns engineer subagents into isolated worktrees: the
+  `~/.simard/engineer-worktrees/` directory and the
+  `engineer-<goal-id>-<timestamp>` naming convention.
+
+All three scenarios reuse the same two-check template seeded by the
+first PR (`knowledge-recall-evidence-grounded` and
+`knowledge-recall-topic-cited`). Topic matchers for the new scenarios
+live in `src/gym/scenarios/checks_7.rs`, split out of `checks_6.rs` to
+respect the 400-LOC per-module cap (#1266).
+
+This PR completes the four-sub-family scaffolding from [#1459][issue]:
+self-code, user-preference, tools-knowledge, and repo-knowledge.

--- a/src/gym/scenarios/checks.rs
+++ b/src/gym/scenarios/checks.rs
@@ -76,8 +76,13 @@ pub(crate) fn class_specific_checks(
         BenchmarkClass::ChaosEngineering => {
             super::checks_5::checks_for_chaos_engineering(&combined)
         }
-        BenchmarkClass::KnowledgeRecall => {
-            super::checks_6::checks_for_knowledge_recall(scenario, &combined, exported)
-        }
+        BenchmarkClass::KnowledgeRecall => match scenario.id {
+            "knowledge-recall-repo-ooda-loop-layout"
+            | "knowledge-recall-repo-cognitive-memory-store"
+            | "knowledge-recall-repo-engineer-worktree-pattern" => {
+                super::checks_7::checks_for_knowledge_recall_repo(scenario, &combined, exported)
+            }
+            _ => super::checks_6::checks_for_knowledge_recall(scenario, &combined, exported),
+        },
     }
 }

--- a/src/gym/scenarios/checks_7.rs
+++ b/src/gym/scenarios/checks_7.rs
@@ -1,0 +1,82 @@
+//! class_specific_checks helpers — chunk 7.
+//!
+//! KnowledgeRecall **repo-knowledge** sub-family (issue #1459): scenarios
+//! that ask the agent to recall structural facts about Simard's own
+//! repository layout — OODA loop module structure, the cognitive memory
+//! storage backend, and the engineer-subagent worktree pattern. Split out
+//! of `checks_6.rs` to keep that module under the 400-LOC cap (#1266).
+
+use super::super::types::{BenchmarkCheckResult, BenchmarkScenario};
+use crate::handoff::RuntimeHandoffSnapshot;
+
+/// Checks for the `KnowledgeRecall` repo-knowledge scenarios.
+///
+/// Each scenario produces the same two checks as the rest of the family:
+/// `knowledge-recall-evidence-grounded` (runtime evidence references at
+/// least one stored memory record or repo file path) and
+/// `knowledge-recall-topic-cited` (the response actually names the canonical
+/// tokens the objective asked about).
+pub(super) fn checks_for_knowledge_recall_repo(
+    scenario: &BenchmarkScenario,
+    combined: &str,
+    exported: &RuntimeHandoffSnapshot,
+) -> Vec<BenchmarkCheckResult> {
+    let memory_grounded = !exported.memory_records.is_empty();
+    let path_cited =
+        combined.contains(".rs") || combined.contains("src/") || combined.contains("docs/");
+    let evidence_grounded = memory_grounded || path_cited;
+
+    let topic_match = match scenario.id {
+        "knowledge-recall-repo-ooda-loop-layout" => {
+            let phase_named = combined.contains("observe")
+                || combined.contains("orient")
+                || combined.contains("decide")
+                || combined.contains("act");
+            let layout_named = combined.contains("src/ooda_loop/")
+                || combined.contains("cycle.rs")
+                || combined.contains("mod.rs");
+            phase_named && layout_named
+        }
+        "knowledge-recall-repo-cognitive-memory-store" => {
+            let backend_named =
+                combined.contains("ladybug") || combined.contains("cognitive_memory.ladybug");
+            let path_named = combined.contains("~/.simard/")
+                || combined.contains(".simard/cognitive_memory")
+                || combined.contains("cognitive_memory.ladybug");
+            backend_named && path_named
+        }
+        "knowledge-recall-repo-engineer-worktree-pattern" => {
+            let dir_named = combined.contains("engineer-worktrees")
+                || combined.contains("~/.simard/engineer-worktrees/");
+            let convention_named = combined.contains("engineer-<goal-id>-<timestamp>")
+                || combined.contains("engineer-<goal-id>")
+                || combined.contains("goal-id")
+                || combined.contains("goal id");
+            dir_named && convention_named
+        }
+        _ => false,
+    };
+
+    vec![
+        BenchmarkCheckResult {
+            id: "knowledge-recall-evidence-grounded".to_string(),
+            passed: evidence_grounded,
+            detail: format!(
+                "runtime evidence {} a stored memory record or repo file path",
+                if evidence_grounded {
+                    "references"
+                } else {
+                    "lacks"
+                }
+            ),
+        },
+        BenchmarkCheckResult {
+            id: "knowledge-recall-topic-cited".to_string(),
+            passed: topic_match,
+            detail: format!(
+                "execution output {} the recall topic named by the objective",
+                if topic_match { "names" } else { "omits" }
+            ),
+        },
+    ]
+}

--- a/src/gym/scenarios/data_6.rs
+++ b/src/gym/scenarios/data_6.rs
@@ -9,7 +9,7 @@
 use super::super::types::{BenchmarkClass, BenchmarkScenario};
 use crate::runtime::RuntimeTopology;
 
-pub(super) static SCENARIOS: [BenchmarkScenario; 5] = [
+pub(super) static SCENARIOS: [BenchmarkScenario; 8] = [
     BenchmarkScenario {
         id: "knowledge-recall-self-code",
         title: "Knowledge recall: locate the OodaBrain trait and its wire-in site",
@@ -63,6 +63,39 @@ pub(super) static SCENARIOS: [BenchmarkScenario; 5] = [
         base_type: "rusty-clawd",
         topology: RuntimeTopology::SingleProcess,
         objective: "Recall the script and target-directory environment variable used to rebuild and reinstall the running simard daemon binary after a main-branch merge.",
+        expected_min_runtime_evidence: 2,
+    },
+    BenchmarkScenario {
+        id: "knowledge-recall-repo-ooda-loop-layout",
+        title: "Knowledge recall: Simard OODA loop module layout",
+        description: "Verify the agent can recall the on-disk layout of Simard's OODA loop module — the four canonical phase modules under src/ooda_loop/ and the file that holds the cycle entry point — rather than guessing at module names.",
+        class: BenchmarkClass::KnowledgeRecall,
+        identity: "simard-gym",
+        base_type: "rusty-clawd",
+        topology: RuntimeTopology::SingleProcess,
+        objective: "Recall the layout of Simard's OODA loop module: name the four canonical phase modules under src/ooda_loop/ and the file that holds the cycle entry point.",
+        expected_min_runtime_evidence: 2,
+    },
+    BenchmarkScenario {
+        id: "knowledge-recall-repo-cognitive-memory-store",
+        title: "Knowledge recall: cognitive memory storage backend",
+        description: "Verify the agent can recall the storage backend used by Simard's cognitive memory subsystem and the on-disk filename of the primary persistent store under ~/.simard/, rather than confabulating a path or backend name.",
+        class: BenchmarkClass::KnowledgeRecall,
+        identity: "simard-gym",
+        base_type: "rusty-clawd",
+        topology: RuntimeTopology::SingleProcess,
+        objective: "Recall the storage backend used by Simard's cognitive memory subsystem and the on-disk filename of the primary persistent store under ~/.simard/.",
+        expected_min_runtime_evidence: 2,
+    },
+    BenchmarkScenario {
+        id: "knowledge-recall-repo-engineer-worktree-pattern",
+        title: "Knowledge recall: engineer subagent worktree pattern",
+        description: "Verify the agent can recall how Simard's OODA daemon spawns engineer subagents into isolated worktrees: the directory under ~/.simard/ where engineer worktrees live and the goal-id-prefixed naming convention used for each worktree.",
+        class: BenchmarkClass::KnowledgeRecall,
+        identity: "simard-gym",
+        base_type: "rusty-clawd",
+        topology: RuntimeTopology::SingleProcess,
+        objective: "Recall how Simard's OODA daemon spawns engineer subagents into isolated worktrees: name the directory under ~/.simard/ where engineer worktrees live, and the goal-id-prefixed naming convention.",
         expected_min_runtime_evidence: 2,
     },
 ];

--- a/src/gym/scenarios/mod.rs
+++ b/src/gym/scenarios/mod.rs
@@ -18,7 +18,7 @@ static ALL_BENCHMARK_SCENARIOS: OnceLock<Vec<BenchmarkScenario>> = OnceLock::new
 fn all_benchmark_scenarios() -> &'static [BenchmarkScenario] {
     ALL_BENCHMARK_SCENARIOS
         .get_or_init(|| {
-            let mut v = Vec::with_capacity(158);
+            let mut v = Vec::with_capacity(161);
             v.extend_from_slice(&data_1::SCENARIOS);
             v.extend_from_slice(&data_2::SCENARIOS);
             v.extend_from_slice(&data_3::SCENARIOS);
@@ -51,4 +51,5 @@ mod checks_3;
 mod checks_4;
 mod checks_5;
 mod checks_6;
+mod checks_7;
 pub(crate) use checks::class_specific_checks;

--- a/src/gym/tests_scenarios.rs
+++ b/src/gym/tests_scenarios.rs
@@ -15,7 +15,7 @@ use crate::session::{SessionId, SessionPhase, SessionRecord};
 
 #[test]
 fn benchmark_scenarios_returns_nine_scenarios() {
-    assert_eq!(benchmark_scenarios().len(), 158);
+    assert_eq!(benchmark_scenarios().len(), 161);
 }
 
 #[test]

--- a/src/gym/tests_scenarios_7.rs
+++ b/src/gym/tests_scenarios_7.rs
@@ -215,3 +215,101 @@ fn class_checks_knowledge_recall_tools_fail_when_ungrounded() {
         }
     }
 }
+
+// ---- repo-knowledge sub-family (issue #1459) ----
+
+#[test]
+fn knowledge_recall_repo_ooda_loop_layout_scenario_resolves() {
+    let scenario = resolve_benchmark_scenario("knowledge-recall-repo-ooda-loop-layout")
+        .expect("knowledge-recall-repo-ooda-loop-layout scenario must be registered");
+    assert_tools_scenario_shape(&scenario);
+}
+
+#[test]
+fn knowledge_recall_repo_cognitive_memory_store_scenario_resolves() {
+    let scenario = resolve_benchmark_scenario("knowledge-recall-repo-cognitive-memory-store")
+        .expect("knowledge-recall-repo-cognitive-memory-store scenario must be registered");
+    assert_tools_scenario_shape(&scenario);
+}
+
+#[test]
+fn knowledge_recall_repo_engineer_worktree_pattern_scenario_resolves() {
+    let scenario = resolve_benchmark_scenario("knowledge-recall-repo-engineer-worktree-pattern")
+        .expect("knowledge-recall-repo-engineer-worktree-pattern scenario must be registered");
+    assert_tools_scenario_shape(&scenario);
+}
+
+#[test]
+fn class_checks_knowledge_recall_repo_ooda_loop_layout_passes_with_grounded_answer() {
+    let scenario = resolve_benchmark_scenario("knowledge-recall-repo-ooda-loop-layout").unwrap();
+    let outcome = dummy_outcome(
+        "consult stored memory on Simard's OODA loop module layout",
+        "the OODA loop lives under src/ooda_loop/ with phase modules observe, orient, decide, act and the cycle entry point in cycle.rs",
+        "documented module map confirmed via mod.rs",
+    );
+    let exported = dummy_handoff(1);
+    let checks = class_specific_checks(&scenario, &outcome, &exported);
+    assert_eq!(checks.len(), 2);
+    assert!(
+        checks.iter().all(|c| c.passed),
+        "all KnowledgeRecall checks should pass for a fully grounded ooda-loop-layout answer: {checks:?}"
+    );
+}
+
+#[test]
+fn class_checks_knowledge_recall_repo_cognitive_memory_store_passes_with_grounded_answer() {
+    let scenario =
+        resolve_benchmark_scenario("knowledge-recall-repo-cognitive-memory-store").unwrap();
+    let outcome = dummy_outcome(
+        "recall the cognitive memory storage backend",
+        "Simard's cognitive memory subsystem uses the ladybug embedded store and persists to ~/.simard/cognitive_memory.ladybug",
+        "verified via src/ inspection",
+    );
+    let exported = dummy_handoff(1);
+    let checks = class_specific_checks(&scenario, &outcome, &exported);
+    assert_eq!(checks.len(), 2);
+    assert!(
+        checks.iter().all(|c| c.passed),
+        "all KnowledgeRecall checks should pass for a fully grounded cognitive-memory-store answer: {checks:?}"
+    );
+}
+
+#[test]
+fn class_checks_knowledge_recall_repo_engineer_worktree_pattern_passes_with_grounded_answer() {
+    let scenario =
+        resolve_benchmark_scenario("knowledge-recall-repo-engineer-worktree-pattern").unwrap();
+    let outcome = dummy_outcome(
+        "recall how the OODA daemon spawns engineer subagents into worktrees",
+        "engineer worktrees live under ~/.simard/engineer-worktrees/ named engineer-<goal-id>-<timestamp>",
+        "documented in src/ daemon notes",
+    );
+    let exported = dummy_handoff(1);
+    let checks = class_specific_checks(&scenario, &outcome, &exported);
+    assert_eq!(checks.len(), 2);
+    assert!(
+        checks.iter().all(|c| c.passed),
+        "all KnowledgeRecall checks should pass for a fully grounded engineer-worktree-pattern answer: {checks:?}"
+    );
+}
+
+#[test]
+fn class_checks_knowledge_recall_repo_fail_when_ungrounded() {
+    for id in [
+        "knowledge-recall-repo-ooda-loop-layout",
+        "knowledge-recall-repo-cognitive-memory-store",
+        "knowledge-recall-repo-engineer-worktree-pattern",
+    ] {
+        let scenario = resolve_benchmark_scenario(id).unwrap();
+        let outcome = dummy_outcome("nothing", "bland text", "empty");
+        let exported = dummy_handoff(0);
+        let checks = class_specific_checks(&scenario, &outcome, &exported);
+        assert_eq!(checks.len(), 2);
+        for check in &checks {
+            assert!(
+                !check.passed,
+                "scenario {id}: check '{}' should have failed",
+                check.id
+            );
+        }
+    }
+}


### PR DESCRIPTION
Implements the **repo-knowledge** sub-family of the `KnowledgeRecall` benchmark class introduced in #1459. This is the third (and final scaffolding) scenario-level PR, completing the four-sub-family roadmap: self-code + user-prefs (#1460), tools-knowledge (#1465), and now repo-knowledge.

## What's new

Three new scenarios in `src/gym/scenarios/data_6.rs`, all in the `KnowledgeRecall` class with identity `simard-gym`, base type `rusty-clawd`, and `expected_min_runtime_evidence: 2`:

- **`knowledge-recall-repo-ooda-loop-layout`** — recalls the four canonical phase modules under `src/ooda_loop/` (`observe`, `orient`, `decide`, `act`) and the file holding the cycle entry point (`cycle.rs` / `mod.rs`).
- **`knowledge-recall-repo-cognitive-memory-store`** — recalls the `ladybug` storage backend used by Simard's cognitive memory subsystem and the on-disk filename of the primary persistent store under `~/.simard/` (`cognitive_memory.ladybug`).
- **`knowledge-recall-repo-engineer-worktree-pattern`** — recalls the `~/.simard/engineer-worktrees/` directory and the `engineer-<goal-id>-<timestamp>` naming convention used when the OODA daemon spawns engineer subagents into isolated worktrees.

Each scenario reuses the two-check template seeded by #1460 (`knowledge-recall-evidence-grounded` + `knowledge-recall-topic-cited`).

## Module split (#1266 cap)

Topic matchers for the new scenarios live in a new `src/gym/scenarios/checks_7.rs` module, split out of `checks_6.rs` (368 LOC after #1465) to respect the 400-LOC per-module cap (#1266). `src/gym/scenarios/checks.rs` dispatches the three new ids to `checks_7` and falls back to `checks_6` for the existing five `KnowledgeRecall` scenarios.

## Wiring

- `Vec::with_capacity(158)` → `161` in `src/gym/scenarios/mod.rs`.
- Total scenario count assertion bumped `158` → `161` in `src/gym/tests_scenarios.rs`.
- Six new tests appended to `src/gym/tests_scenarios_7.rs` (still well under the 400-LOC cap).
- Docs section appended to `docs/concepts/gym-knowledge-recall.md` (strict-mode-safe links only).

## Verification

- `cargo fmt --all` ✓
- `cargo clippy --all-targets --all-features --locked -- -D warnings` ✓
- `cargo test --all-features --locked --lib gym::` — 367 passed, 0 failed.

Refs #1459. Follow-up to #1460 and #1465. Completes the four-sub-family scaffolding from the issue.
