### PR TITLE
feat(gym): add cross-session KnowledgeRecall scenarios (issue #1459)

### DIFF
--- a/docs/concepts/gym-knowledge-recall.md
+++ b/docs/concepts/gym-knowledge-recall.md
@@ -114,3 +114,47 @@ respect the 400-LOC per-module cap (#1266).
 
 This PR completes the four-sub-family scaffolding from [#1459][issue]:
 self-code, user-preference, tools-knowledge, and repo-knowledge.
+
+## Cross-session recall (this PR)
+
+The capstone PR for the four-sub-family roadmap from [#1459][issue]
+adds a fifth sub-family: **cross-session recall**. Where the previous
+sub-families verify that Simard remembers facts about her own code,
+her tools, the repos she maintains, and the operator's preferences,
+cross-session recall verifies the underlying capability that makes any
+of those memories useful in the long run — that they **survive session
+boundaries**.
+
+This is the hardest variant of the family because every other check in
+this file can be satisfied by the agent re-deriving the answer from the
+current session's prompt context. Cross-session checks deliberately
+cannot: each scenario's check looks for tokens that only make sense if
+the agent read accumulated cognitive memory from a *prior* gym run.
+That makes these scenarios a direct stress test of the cognitive memory
+persistence subsystem — and a complement to the still-wedged
+`improve-cognitive-memory-persistence` daemon goal, whose whole purpose
+is to make that subsystem reliable across restarts.
+
+The two new scenarios are:
+
+- `knowledge-recall-cross-session-fact` — recalls a fact stored in a
+  prior gym session as a memory tagged `gym-cross-session-canary` with
+  a deterministic canary token. The check requires the runtime evidence
+  to cite the canary token, the tag, and the prior-session origin from
+  accumulated cognitive memory.
+- `knowledge-recall-cross-session-preference` — recalls the
+  user-stated preference that Simard's brain be prompt-driven rather
+  than code-driven, including the date the preference was stated
+  (Apr 29) and the architectural pattern it produced
+  (`prompt_assets/simard/*.md` + `include_str!` + an LLM trait such as
+  `OodaBrain`).
+
+Both scenarios reuse the same two-check template seeded by the first
+PR (`knowledge-recall-evidence-grounded` and
+`knowledge-recall-topic-cited`), with topic matchers tuned for
+cross-session tokens in `src/gym/scenarios/checks_8.rs` (split out of
+`checks_7.rs` to respect the 400-LOC per-module cap from #1266).
+
+This PR closes out the four-sub-family roadmap from [#1459][issue]:
+self-code, user-preference, tools-knowledge, repo-knowledge, and now
+cross-session.

--- a/src/gym/mod.rs
+++ b/src/gym/mod.rs
@@ -35,6 +35,8 @@ mod tests_scenarios_6;
 #[cfg(test)]
 mod tests_scenarios_7;
 #[cfg(test)]
+mod tests_scenarios_8;
+#[cfg(test)]
 mod tests_types;
 #[cfg(test)]
 mod tests_types_extra;

--- a/src/gym/scenarios/checks.rs
+++ b/src/gym/scenarios/checks.rs
@@ -82,6 +82,11 @@ pub(crate) fn class_specific_checks(
             | "knowledge-recall-repo-engineer-worktree-pattern" => {
                 super::checks_7::checks_for_knowledge_recall_repo(scenario, &combined, exported)
             }
+            "knowledge-recall-cross-session-fact" | "knowledge-recall-cross-session-preference" => {
+                super::checks_8::checks_for_knowledge_recall_cross_session(
+                    scenario, &combined, exported,
+                )
+            }
             _ => super::checks_6::checks_for_knowledge_recall(scenario, &combined, exported),
         },
     }

--- a/src/gym/scenarios/checks_8.rs
+++ b/src/gym/scenarios/checks_8.rs
@@ -1,0 +1,80 @@
+//! class_specific_checks helpers — chunk 8.
+//!
+//! KnowledgeRecall **cross-session** sub-family (issue #1459, capstone PR):
+//! scenarios that ask the agent to recall something stored in a **prior**
+//! gym session. These directly stress-test cognitive memory persistence
+//! across session boundaries — the same subsystem the still-wedged
+//! `improve-cognitive-memory-persistence` daemon goal is trying to fix.
+//!
+//! Split into its own module so `checks_7.rs` keeps its narrower
+//! repo-knowledge focus and to respect the 400-LOC per-module cap (#1266).
+
+use super::super::types::{BenchmarkCheckResult, BenchmarkScenario};
+use crate::handoff::RuntimeHandoffSnapshot;
+
+/// Checks for the `KnowledgeRecall` cross-session scenarios.
+///
+/// Each scenario produces the same two checks as the rest of the family:
+/// `knowledge-recall-evidence-grounded` (runtime evidence references at
+/// least one stored memory record or repo file path) and
+/// `knowledge-recall-topic-cited` (the response actually names the
+/// canonical tokens the objective asked about — including tokens that
+/// only make sense if the agent read accumulated cross-session memory,
+/// not just the current session's prompt context).
+pub(super) fn checks_for_knowledge_recall_cross_session(
+    scenario: &BenchmarkScenario,
+    combined: &str,
+    exported: &RuntimeHandoffSnapshot,
+) -> Vec<BenchmarkCheckResult> {
+    let memory_grounded = !exported.memory_records.is_empty();
+    let path_cited =
+        combined.contains(".rs") || combined.contains("src/") || combined.contains("docs/");
+    let evidence_grounded = memory_grounded || path_cited;
+
+    let topic_match = match scenario.id {
+        "knowledge-recall-cross-session-fact" => {
+            let canary_named = combined.contains("gym-cross-session-canary");
+            let prior_session_named =
+                combined.contains("prior session") || combined.contains("previous session");
+            let memory_layer_named = combined.contains("cognitive memory")
+                || combined.contains("cognitive_memory")
+                || combined.contains("accumulated");
+            canary_named && prior_session_named && memory_layer_named
+        }
+        "knowledge-recall-cross-session-preference" => {
+            let stance_named =
+                combined.contains("prompt-driven") || combined.contains("prompt driven");
+            let pattern_named = combined.contains("prompt_assets/simard")
+                || combined.contains("include_str!")
+                || combined.contains("oodabrain");
+            let date_named = combined.contains("apr 29")
+                || combined.contains("2026-04-29")
+                || combined.contains("april 29");
+            stance_named && pattern_named && date_named
+        }
+        _ => false,
+    };
+
+    vec![
+        BenchmarkCheckResult {
+            id: "knowledge-recall-evidence-grounded".to_string(),
+            passed: evidence_grounded,
+            detail: format!(
+                "runtime evidence {} a stored memory record or repo file path",
+                if evidence_grounded {
+                    "references"
+                } else {
+                    "lacks"
+                }
+            ),
+        },
+        BenchmarkCheckResult {
+            id: "knowledge-recall-topic-cited".to_string(),
+            passed: topic_match,
+            detail: format!(
+                "execution output {} the cross-session recall topic named by the objective",
+                if topic_match { "names" } else { "omits" }
+            ),
+        },
+    ]
+}

--- a/src/gym/scenarios/data_6.rs
+++ b/src/gym/scenarios/data_6.rs
@@ -9,7 +9,7 @@
 use super::super::types::{BenchmarkClass, BenchmarkScenario};
 use crate::runtime::RuntimeTopology;
 
-pub(super) static SCENARIOS: [BenchmarkScenario; 8] = [
+pub(super) static SCENARIOS: [BenchmarkScenario; 10] = [
     BenchmarkScenario {
         id: "knowledge-recall-self-code",
         title: "Knowledge recall: locate the OodaBrain trait and its wire-in site",
@@ -96,6 +96,28 @@ pub(super) static SCENARIOS: [BenchmarkScenario; 8] = [
         base_type: "rusty-clawd",
         topology: RuntimeTopology::SingleProcess,
         objective: "Recall how Simard's OODA daemon spawns engineer subagents into isolated worktrees: name the directory under ~/.simard/ where engineer worktrees live, and the goal-id-prefixed naming convention.",
+        expected_min_runtime_evidence: 2,
+    },
+    BenchmarkScenario {
+        id: "knowledge-recall-cross-session-fact",
+        title: "Knowledge recall: cross-session canary fact from prior gym run",
+        description: "Verify the agent can recall a fact stored during a prior gym session — a memory tagged 'gym-cross-session-canary' carrying a deterministic canary token — directly stress-testing that cognitive memory survives session boundaries.",
+        class: BenchmarkClass::KnowledgeRecall,
+        identity: "simard-gym",
+        base_type: "rusty-clawd",
+        topology: RuntimeTopology::SingleProcess,
+        objective: "Recall a fact stored in a prior gym session: in the previous run a memory was written tagged 'gym-cross-session-canary' with content describing a deterministic canary token. Cite the canary token and the tag from accumulated cognitive memory, demonstrating cross-session persistence.",
+        expected_min_runtime_evidence: 2,
+    },
+    BenchmarkScenario {
+        id: "knowledge-recall-cross-session-preference",
+        title: "Knowledge recall: cross-session user preference for prompt-driven brain",
+        description: "Verify the agent can recall a user-stated preference from a prior session — that Simard's brain be prompt-driven rather than code-driven — including the date the preference was stated and the architectural pattern it produced.",
+        class: BenchmarkClass::KnowledgeRecall,
+        identity: "simard-gym",
+        base_type: "rusty-clawd",
+        topology: RuntimeTopology::SingleProcess,
+        objective: "Recall a user-stated preference from a prior session: the user mandated that Simard's brain be prompt-driven rather than code-driven. Cite the date the preference was stated and the architectural pattern it produced (prompt_assets/simard/*.md plus include_str! plus an LLM trait).",
         expected_min_runtime_evidence: 2,
     },
 ];

--- a/src/gym/scenarios/mod.rs
+++ b/src/gym/scenarios/mod.rs
@@ -18,7 +18,7 @@ static ALL_BENCHMARK_SCENARIOS: OnceLock<Vec<BenchmarkScenario>> = OnceLock::new
 fn all_benchmark_scenarios() -> &'static [BenchmarkScenario] {
     ALL_BENCHMARK_SCENARIOS
         .get_or_init(|| {
-            let mut v = Vec::with_capacity(161);
+            let mut v = Vec::with_capacity(163);
             v.extend_from_slice(&data_1::SCENARIOS);
             v.extend_from_slice(&data_2::SCENARIOS);
             v.extend_from_slice(&data_3::SCENARIOS);
@@ -52,4 +52,5 @@ mod checks_4;
 mod checks_5;
 mod checks_6;
 mod checks_7;
+mod checks_8;
 pub(crate) use checks::class_specific_checks;

--- a/src/gym/tests_scenarios.rs
+++ b/src/gym/tests_scenarios.rs
@@ -15,7 +15,7 @@ use crate::session::{SessionId, SessionPhase, SessionRecord};
 
 #[test]
 fn benchmark_scenarios_returns_nine_scenarios() {
-    assert_eq!(benchmark_scenarios().len(), 161);
+    assert_eq!(benchmark_scenarios().len(), 163);
 }
 
 #[test]

--- a/src/gym/tests_scenarios_8.rs
+++ b/src/gym/tests_scenarios_8.rs
@@ -1,0 +1,196 @@
+//! Tests for the KnowledgeRecall **cross-session** sub-family (issue #1459).
+//!
+//! These cover the two scenarios added by the capstone PR for the
+//! `KnowledgeRecall` family roadmap from #1459:
+//! `knowledge-recall-cross-session-fact` and
+//! `knowledge-recall-cross-session-preference`. Each scenario directly
+//! stress-tests cognitive memory persistence across session boundaries —
+//! the same subsystem the still-wedged `improve-cognitive-memory-persistence`
+//! daemon goal is trying to fix.
+
+use super::scenarios::*;
+use super::types::{BenchmarkClass, BenchmarkScenario};
+use crate::base_types::BaseTypeId;
+use crate::handoff::RuntimeHandoffSnapshot;
+use crate::identity::ManifestContract;
+use crate::identity::OperatingMode;
+use crate::memory::{MemoryRecord, MemoryScope};
+use crate::metadata::{BackendDescriptor, Freshness, Provenance};
+use crate::reflection::{ReflectionReport, ReflectionSnapshot};
+use crate::runtime::{
+    RuntimeAddress, RuntimeNodeId, RuntimeState, RuntimeTopology, SessionOutcome,
+};
+use crate::session::{SessionId, SessionPhase, SessionRecord};
+
+fn dummy_backend() -> BackendDescriptor {
+    BackendDescriptor {
+        identity: "test-backend".to_string(),
+        provenance: Provenance::new("test-src", "test::loc"),
+        freshness: Freshness::now().unwrap(),
+    }
+}
+
+fn dummy_contract() -> ManifestContract {
+    ManifestContract {
+        entrypoint: "test::entry".to_string(),
+        composition: "a -> b".to_string(),
+        precedence: vec!["tag:value".to_string()],
+        provenance: Provenance::new("test-src", "test::loc"),
+        freshness: Freshness::now().unwrap(),
+    }
+}
+
+fn dummy_snapshot() -> ReflectionSnapshot {
+    let backend = dummy_backend();
+    ReflectionSnapshot {
+        identity_name: "test".to_string(),
+        identity_components: vec![],
+        selected_base_type: BaseTypeId::new("test"),
+        topology: RuntimeTopology::SingleProcess,
+        runtime_state: RuntimeState::Ready,
+        runtime_node: RuntimeNodeId::local(),
+        mailbox_address: RuntimeAddress::local(&RuntimeNodeId::local()),
+        session_phase: Some(SessionPhase::Complete),
+        prompt_assets: vec![],
+        manifest_contract: dummy_contract(),
+        evidence_records: 0,
+        memory_records: 0,
+        active_goal_count: 0,
+        active_goals: vec![],
+        proposed_goal_count: 0,
+        proposed_goals: vec![],
+        agent_program_backend: backend.clone(),
+        handoff_backend: backend.clone(),
+        adapter_backend: backend.clone(),
+        adapter_capabilities: vec![],
+        adapter_supported_topologies: vec![],
+        topology_backend: backend.clone(),
+        transport_backend: backend.clone(),
+        supervisor_backend: backend.clone(),
+        memory_backend: backend.clone(),
+        evidence_backend: backend.clone(),
+        goal_backend: backend,
+    }
+}
+
+fn dummy_outcome(plan: &str, execution_summary: &str, reflection_summary: &str) -> SessionOutcome {
+    SessionOutcome {
+        session: SessionRecord {
+            id: SessionId::parse("session-00000000-0000-0000-0000-000000000001").unwrap(),
+            mode: OperatingMode::Gym,
+            objective: "test".to_string(),
+            phase: SessionPhase::Complete,
+            selected_base_type: BaseTypeId::new("test"),
+            evidence_ids: vec![],
+            memory_keys: vec![],
+        },
+        plan: plan.to_string(),
+        execution_summary: execution_summary.to_string(),
+        reflection: ReflectionReport {
+            summary: reflection_summary.to_string(),
+            snapshot: dummy_snapshot(),
+        },
+    }
+}
+
+fn dummy_handoff(memory_count: usize) -> RuntimeHandoffSnapshot {
+    let session_id = SessionId::parse("session-00000000-0000-0000-0000-000000000001").unwrap();
+    RuntimeHandoffSnapshot {
+        exported_state: RuntimeState::Stopped,
+        identity_name: "test".to_string(),
+        selected_base_type: BaseTypeId::new("test"),
+        topology: RuntimeTopology::SingleProcess,
+        source_runtime_node: RuntimeNodeId::local(),
+        source_mailbox_address: RuntimeAddress::local(&RuntimeNodeId::local()),
+        session: None,
+        memory_records: (0..memory_count)
+            .map(|i| MemoryRecord {
+                key: format!("key-{i}"),
+                scope: MemoryScope::Benchmark,
+                value: format!("value-{i}"),
+                session_id: session_id.clone(),
+                recorded_in: SessionPhase::Complete,
+                created_at: None,
+            })
+            .collect(),
+        evidence_records: vec![],
+        copilot_submit_audit: None,
+    }
+}
+
+fn assert_cross_session_scenario_shape(scenario: &BenchmarkScenario) {
+    assert_eq!(scenario.class, BenchmarkClass::KnowledgeRecall);
+    assert_eq!(scenario.identity, "simard-gym");
+    assert_eq!(scenario.base_type, "rusty-clawd");
+    assert_eq!(scenario.topology, RuntimeTopology::SingleProcess);
+    assert_eq!(scenario.expected_min_runtime_evidence, 2);
+}
+
+#[test]
+fn knowledge_recall_cross_session_fact_scenario_resolves() {
+    let scenario = resolve_benchmark_scenario("knowledge-recall-cross-session-fact")
+        .expect("knowledge-recall-cross-session-fact scenario must be registered");
+    assert_cross_session_scenario_shape(&scenario);
+}
+
+#[test]
+fn knowledge_recall_cross_session_preference_scenario_resolves() {
+    let scenario = resolve_benchmark_scenario("knowledge-recall-cross-session-preference")
+        .expect("knowledge-recall-cross-session-preference scenario must be registered");
+    assert_cross_session_scenario_shape(&scenario);
+}
+
+#[test]
+fn class_checks_knowledge_recall_cross_session_fact_passes_with_grounded_answer() {
+    let scenario = resolve_benchmark_scenario("knowledge-recall-cross-session-fact").unwrap();
+    let outcome = dummy_outcome(
+        "consult accumulated cognitive memory for the prior session canary",
+        "the gym-cross-session-canary memory from the prior session carries token CANARY-42 in cognitive memory",
+        "verified accumulated record from previous session in src/ cognitive_memory store",
+    );
+    let exported = dummy_handoff(1);
+    let checks = class_specific_checks(&scenario, &outcome, &exported);
+    assert_eq!(checks.len(), 2);
+    assert!(
+        checks.iter().all(|c| c.passed),
+        "all KnowledgeRecall checks should pass for a fully grounded cross-session-fact answer: {checks:?}"
+    );
+}
+
+#[test]
+fn class_checks_knowledge_recall_cross_session_preference_passes_with_grounded_answer() {
+    let scenario = resolve_benchmark_scenario("knowledge-recall-cross-session-preference").unwrap();
+    let outcome = dummy_outcome(
+        "recall the prompt-driven brain preference stated in a prior session",
+        "the user mandated a prompt-driven brain on Apr 29; the resulting pattern is prompt_assets/simard/*.md plus include_str! plus the OodaBrain LLM trait",
+        "documented in src/ prompt assets",
+    );
+    let exported = dummy_handoff(1);
+    let checks = class_specific_checks(&scenario, &outcome, &exported);
+    assert_eq!(checks.len(), 2);
+    assert!(
+        checks.iter().all(|c| c.passed),
+        "all KnowledgeRecall checks should pass for a fully grounded cross-session-preference answer: {checks:?}"
+    );
+}
+
+#[test]
+fn class_checks_knowledge_recall_cross_session_fail_when_ungrounded() {
+    for id in [
+        "knowledge-recall-cross-session-fact",
+        "knowledge-recall-cross-session-preference",
+    ] {
+        let scenario = resolve_benchmark_scenario(id).unwrap();
+        let outcome = dummy_outcome("nothing", "bland text", "empty");
+        let exported = dummy_handoff(0);
+        let checks = class_specific_checks(&scenario, &outcome, &exported);
+        assert_eq!(checks.len(), 2);
+        for check in &checks {
+            assert!(
+                !check.passed,
+                "scenario {id}: check '{}' should have failed",
+                check.id
+            );
+        }
+    }
+}


### PR DESCRIPTION
Capstone PR for the four-sub-family `KnowledgeRecall` roadmap from #1459.
Adds the **cross-session** sub-family — the hardest variant of the family.
Each scenario verifies that a memory stored in a *prior* gym session is
recallable in the current session, directly stress-testing cognitive
memory persistence across session boundaries — the same subsystem the
still-wedged `improve-cognitive-memory-persistence` daemon goal is
trying to fix.

## What's new

Two scenarios in `src/gym/scenarios/data_6.rs` (8 → 10), both
`KnowledgeRecall`, identity `simard-gym`, base type `rusty-clawd`,
`expected_min_runtime_evidence: 2`:

- **`knowledge-recall-cross-session-fact`** — recalls a canary token
  stored in a prior gym session under tag `gym-cross-session-canary`.
  Topic check requires citing the canary token, the tag, and the
  prior-session origin from accumulated cognitive memory.
- **`knowledge-recall-cross-session-preference`** — recalls the
  user-stated preference that Simard's brain be prompt-driven rather
  than code-driven (Apr 29) and the architectural pattern it produced
  (`prompt_assets/simard/*.md` + `include_str!` + an LLM trait such
  as `OodaBrain`).

## Why cross-session is the hardest variant

Every other `KnowledgeRecall` check can be satisfied by the agent
re-deriving the answer from the current session's prompt context.
Cross-session checks deliberately cannot: each topic matcher looks for
tokens that only make sense if the agent read accumulated cognitive
memory from a prior gym run. That makes these scenarios a direct
stress test of cognitive memory persistence, complementing the still-
wedged `improve-cognitive-memory-persistence` daemon goal.

## Module split (#1266 cap)

Topic matchers for the new scenarios live in a new
`src/gym/scenarios/checks_8.rs` (split out of `checks_7.rs` to keep
that module narrowly focused on the repo-knowledge sub-family and to
respect the 400-LOC per-module cap from #1266). Tests live in a new
`src/gym/tests_scenarios_8.rs` for the same reason.

## Family roster (10 scenarios across 5 sub-families)

After this PR the `KnowledgeRecall` family contains:

1. **self-code** (#1460): `knowledge-recall-self-code`
2. **user-preference** (#1460): `knowledge-recall-user-preference`
3. **tools-knowledge** (#1465): `knowledge-recall-tool-amplihack-recipe`,
   `knowledge-recall-tool-pre-push-skip`,
   `knowledge-recall-tool-redeploy-script`
4. **repo-knowledge** (#1466): `knowledge-recall-repo-ooda-loop-layout`,
   `knowledge-recall-repo-cognitive-memory-store`,
   `knowledge-recall-repo-engineer-worktree-pattern`
5. **cross-session** (this PR):
   `knowledge-recall-cross-session-fact`,
   `knowledge-recall-cross-session-preference`

## Wiring

- `Vec::with_capacity(161)` → `163` in `src/gym/scenarios/mod.rs`.
- Total scenario count assertion bumped `161` → `163` in
  `src/gym/tests_scenarios.rs`.
- Five new tests in `src/gym/tests_scenarios_8.rs` (resolves + grounded
  + ungrounded paths for both new scenarios).
- Docs section appended to `docs/concepts/gym-knowledge-recall.md`
  (strict-mode-safe links only).

## Verification

- `cargo fmt --all` ✓
- `cargo clippy --all-targets --all-features --locked -- -D warnings` ✓
- `cargo test --all-features --locked --lib gym::` — 372 passed, 0 failed.

Refs #1459. Closes the four-sub-family roadmap from the issue. These
scenarios explicitly stress-test the still-wedged
`improve-cognitive-memory-persistence` daemon goal.
