### PR TITLE
feat(gym): add ErrorHandling debug scenarios proposed by OODA brain (issue #1461)

### DIFF
--- a/docs/concepts/gym-error-handling-debug.md
+++ b/docs/concepts/gym-error-handling-debug.md
@@ -1,0 +1,66 @@
+# Gym: ErrorHandling Debug Sub-family
+
+The `ErrorHandling` benchmark class historically contained generic
+error-handling scenarios. The **debug sub-family** added in
+[issue #1461][issue] sharpens the class: it scores the agent's ability to
+diagnose **real Simard runtime errors** — not synthetic ones — and propose
+the documented remediation.
+
+It complements the [`KnowledgeRecall`](gym-knowledge-recall.md) family added
+in [PR #1467][knowledge-recall-pr]: where Knowledge Recall asks "do you
+remember the canonical fact?", the ErrorHandling debug sub-family asks
+"when this canonical fact is wrong in production, can you spot the symptom
+and apply the fix?".
+
+## Why a debug-specific sub-family
+
+Generic ErrorHandling scenarios test whether an agent reasons about retries,
+timeouts, and error propagation in the abstract. They do not stress-test
+recall of project-specific failure modes. A daemon that maintains Simard
+itself is graded on a much narrower distribution: it sees the same handful
+of recurring failures every day. The debug sub-family encodes those failures
+directly, so the gym scorecard regresses the moment the agent forgets one.
+
+## Scenarios
+
+Four scenarios are registered under `BenchmarkClass::ErrorHandling`:
+
+1. **`error-handling-debug-stale-engineer-worktree`** — the worktree under
+   `~/.simard/engineer-worktrees/` is alive but the subagent process has
+   exited. Verifies the agent cites the OODA dispatch layer's
+   `find_live_engineer_for_goal` liveness check and proposes a remediation.
+2. **`error-handling-debug-pre-push-clippy-failure`** — a single
+   `unused_imports` warning trips clippy under `-D warnings`. Verifies the
+   agent names the lint, the tool, and explicitly forbids `--no-verify`
+   bypass per user policy.
+3. **`error-handling-debug-mkdocs-strict-broken-link`** — the `docs/build`
+   CI job fails because mkdocs strict mode rejects a cross-document link.
+   Verifies the agent names `mkdocs.yml`, the strict mode setting, the
+   `docs/` tree boundary, and `prompt_assets/` as the unresolvable target.
+4. **`error-handling-debug-recipe-runner-hollow-success`** —
+   `step-08c-implementation-no-op-guard` reports "produced no output" even
+   though the recipe completed structurally. Verifies the agent names the
+   guard, identifies the missing-worktree symptom, and references the
+   documented Opus 4.7 sub-agent fallback pattern.
+
+Each scenario emits two checks: `error-handling-debug-evidence-grounded`
+(runtime evidence references a stored memory record or repo file path) and
+`error-handling-debug-canonical-token-cited` (the response actually names
+the canonical diagnosis tokens the objective asked about).
+
+## Why this PR matters
+
+This family was **proposed by the prompt-driven OODA brain itself** in
+cycle 2 — directly after the Knowledge Recall family landed in PR #1467.
+The brain observed the new scenarios in its reflection input, noticed the
+gap in error-handling debug coverage, opened issue #1461, and the
+implementation followed. That closes the loop demonstrated by
+[PR #1458][prompt-driven-pr]: brain proposes work → human-readable goal →
+implementation → merge → brain observes the new scenarios → uses them to
+grade itself. It is the first end-to-end proof point that the
+prompt-driven brain pattern can extend its own evaluation surface without
+human intervention.
+
+[issue]: https://github.com/rysweet/Simard/issues/1461
+[knowledge-recall-pr]: https://github.com/rysweet/Simard/pull/1467
+[prompt-driven-pr]: https://github.com/rysweet/Simard/pull/1458

--- a/src/gym/mod.rs
+++ b/src/gym/mod.rs
@@ -37,6 +37,8 @@ mod tests_scenarios_7;
 #[cfg(test)]
 mod tests_scenarios_8;
 #[cfg(test)]
+mod tests_scenarios_9;
+#[cfg(test)]
 mod tests_types;
 #[cfg(test)]
 mod tests_types_extra;

--- a/src/gym/scenarios/checks.rs
+++ b/src/gym/scenarios/checks.rs
@@ -28,7 +28,15 @@ pub(crate) fn class_specific_checks(
         BenchmarkClass::DependencyAnalysis => {
             super::checks_1::checks_for_dependency_analysis(&combined)
         }
-        BenchmarkClass::ErrorHandling => super::checks_4::checks_for_error_handling(&combined),
+        BenchmarkClass::ErrorHandling => match scenario.id {
+            "error-handling-debug-stale-engineer-worktree"
+            | "error-handling-debug-pre-push-clippy-failure"
+            | "error-handling-debug-mkdocs-strict-broken-link"
+            | "error-handling-debug-recipe-runner-hollow-success" => {
+                super::checks_9::checks_for_error_handling_debug(scenario, &combined, exported)
+            }
+            _ => super::checks_4::checks_for_error_handling(&combined),
+        },
         BenchmarkClass::PerformanceAnalysis => {
             super::checks_3::checks_for_performance_analysis(&combined)
         }

--- a/src/gym/scenarios/checks_9.rs
+++ b/src/gym/scenarios/checks_9.rs
@@ -1,0 +1,91 @@
+//! class_specific_checks helpers — chunk 9.
+//!
+//! ErrorHandlingDebug sub-family (issue #1461): each scenario asks the agent
+//! to diagnose a real Simard runtime error and propose the documented
+//! remediation. The two checks per scenario verify that runtime evidence
+//! references at least one concrete signal (a file path, a stored memory
+//! record, or a canonical token) and that the response actually names the
+//! canonical tokens the objective asked about.
+//!
+//! Split into its own module so `checks_4::checks_for_error_handling`
+//! retains its generic catch-all behavior and to respect the 400-LOC
+//! per-module cap (#1266).
+
+use super::super::types::{BenchmarkCheckResult, BenchmarkScenario};
+use crate::handoff::RuntimeHandoffSnapshot;
+
+/// Checks for the `ErrorHandling` debug sub-family scenarios.
+pub(super) fn checks_for_error_handling_debug(
+    scenario: &BenchmarkScenario,
+    combined: &str,
+    exported: &RuntimeHandoffSnapshot,
+) -> Vec<BenchmarkCheckResult> {
+    let memory_grounded = !exported.memory_records.is_empty();
+    let path_cited = combined.contains(".rs")
+        || combined.contains("src/")
+        || combined.contains("docs/")
+        || combined.contains(".yml")
+        || combined.contains(".yaml")
+        || combined.contains("~/.simard/");
+    let evidence_grounded = memory_grounded || path_cited;
+
+    let topic_match = match scenario.id {
+        "error-handling-debug-stale-engineer-worktree" => {
+            let dispatch_check_named = combined.contains("find_live_engineer_for_goal");
+            let worktree_path_named = combined.contains("engineer-worktrees");
+            let liveness_named = combined.contains("sentinel")
+                || combined.contains("alive")
+                || combined.contains("liveness")
+                || combined.contains("exited");
+            dispatch_check_named && worktree_path_named && liveness_named
+        }
+        "error-handling-debug-pre-push-clippy-failure" => {
+            let lint_named = combined.contains("unused_imports");
+            let tool_named = combined.contains("clippy");
+            let bypass_forbidden = combined.contains("--no-verify")
+                && (combined.contains("forbid")
+                    || combined.contains("prohibit")
+                    || combined.contains("not allowed")
+                    || combined.contains("never"));
+            lint_named && tool_named && bypass_forbidden
+        }
+        "error-handling-debug-mkdocs-strict-broken-link" => {
+            let config_named = combined.contains("mkdocs.yml");
+            let strict_named = combined.contains("strict");
+            let docs_tree_named = combined.contains("docs/");
+            let outside_tree_named = combined.contains("prompt_assets");
+            config_named && strict_named && docs_tree_named && outside_tree_named
+        }
+        "error-handling-debug-recipe-runner-hollow-success" => {
+            let guard_named = combined.contains("step-08c");
+            let symptom_named = combined.contains("hollow") && combined.contains("worktree");
+            let fallback_named = (combined.contains("sub-agent") || combined.contains("subagent"))
+                && (combined.contains("opus") || combined.contains("4.7"));
+            guard_named && symptom_named && fallback_named
+        }
+        _ => false,
+    };
+
+    vec![
+        BenchmarkCheckResult {
+            id: "error-handling-debug-evidence-grounded".to_string(),
+            passed: evidence_grounded,
+            detail: format!(
+                "runtime evidence {} a stored memory record or repo file path",
+                if evidence_grounded {
+                    "references"
+                } else {
+                    "lacks"
+                }
+            ),
+        },
+        BenchmarkCheckResult {
+            id: "error-handling-debug-canonical-token-cited".to_string(),
+            passed: topic_match,
+            detail: format!(
+                "execution output {} the canonical diagnosis tokens named by the objective",
+                if topic_match { "names" } else { "omits" }
+            ),
+        },
+    ]
+}

--- a/src/gym/scenarios/data_7.rs
+++ b/src/gym/scenarios/data_7.rs
@@ -1,0 +1,58 @@
+//! Auto-split BENCHMARK_SCENARIOS data — chunk 7.
+//!
+//! ErrorHandlingDebug sub-family (issue #1461): scenarios that ask the agent
+//! to diagnose canonical Simard runtime errors and propose the documented
+//! remediation. Complements the KnowledgeRecall family added in #1467 — both
+//! families were proposed by the prompt-driven OODA brain itself in cycle 2,
+//! validating the brain → goal → implementation → observation loop introduced
+//! in PR #1458.
+
+use super::super::types::{BenchmarkClass, BenchmarkScenario};
+use crate::runtime::RuntimeTopology;
+
+pub(super) static SCENARIOS: [BenchmarkScenario; 4] = [
+    BenchmarkScenario {
+        id: "error-handling-debug-stale-engineer-worktree",
+        title: "Error handling/debug: stale engineer worktree with no live process",
+        description: "Verify the agent can diagnose why an engineer subagent's output artifacts are missing from a worktree under ~/.simard/engineer-worktrees/, given that the worktree is alive but the subagent process has exited, and cite the OODA dispatch layer's liveness check.",
+        class: BenchmarkClass::ErrorHandling,
+        identity: "simard-gym",
+        base_type: "rusty-clawd",
+        topology: RuntimeTopology::SingleProcess,
+        objective: "Diagnose why an engineer subagent's output artifacts are missing from a worktree under ~/.simard/engineer-worktrees/, given that the worktree is alive but the subagent process has exited. Cite the specific check the OODA dispatch layer performs (find_live_engineer_for_goal) and propose a remediation.",
+        expected_min_runtime_evidence: 2,
+    },
+    BenchmarkScenario {
+        id: "error-handling-debug-pre-push-clippy-failure",
+        title: "Error handling/debug: pre-push clippy unused_imports failure",
+        description: "Verify the agent can diagnose a pre-push hook failure where clippy fails with a single unused_imports warning under -D warnings, explain why bypassing via --no-verify is forbidden, and propose the correct fix.",
+        class: BenchmarkClass::ErrorHandling,
+        identity: "simard-gym",
+        base_type: "rusty-clawd",
+        topology: RuntimeTopology::SingleProcess,
+        objective: "Diagnose a pre-push hook failure where 'cargo clippy --all-targets --all-features --locked -- -D warnings' fails with a single 'unused_imports' warning. Explain why bypassing via --no-verify is forbidden and propose the correct fix.",
+        expected_min_runtime_evidence: 2,
+    },
+    BenchmarkScenario {
+        id: "error-handling-debug-mkdocs-strict-broken-link",
+        title: "Error handling/debug: mkdocs strict mode broken cross-document link",
+        description: "Verify the agent can diagnose a docs/build CI failure caused by mkdocs strict mode rejecting a broken cross-document link, cite where strict mode is enabled, and explain why links from docs/ to files outside the docs/ tree cannot resolve.",
+        class: BenchmarkClass::ErrorHandling,
+        identity: "simard-gym",
+        base_type: "rusty-clawd",
+        topology: RuntimeTopology::SingleProcess,
+        objective: "Diagnose a 'docs/build' CI failure caused by mkdocs strict mode rejecting a broken cross-document link. Cite where mkdocs strict mode is enabled (mkdocs.yml) and explain why links from docs/ to files outside the docs/ tree (e.g. prompt_assets/) cannot resolve.",
+        expected_min_runtime_evidence: 2,
+    },
+    BenchmarkScenario {
+        id: "error-handling-debug-recipe-runner-hollow-success",
+        title: "Error handling/debug: smart-orchestrator hollow-success no-op-guard trip",
+        description: "Verify the agent can diagnose a smart-orchestrator hollow-success failure where the recipe completed step-08-implement structurally but step-08c-implementation-no-op-guard reported 'produced no output', and propose the documented Opus 4.7 sub-agent fallback remediation.",
+        class: BenchmarkClass::ErrorHandling,
+        identity: "simard-gym",
+        base_type: "rusty-clawd",
+        topology: RuntimeTopology::SingleProcess,
+        objective: "Diagnose a smart-orchestrator hollow-success failure: the recipe completed step-08-implement structurally but step-08c-implementation-no-op-guard reported 'produced no output'. Identify the symptom (worktree never created), reference the documented Opus 4.7 sub-agent fallback pattern, and propose the remediation.",
+        expected_min_runtime_evidence: 2,
+    },
+];

--- a/src/gym/scenarios/mod.rs
+++ b/src/gym/scenarios/mod.rs
@@ -10,6 +10,7 @@ mod data_3;
 mod data_4;
 mod data_5;
 mod data_6;
+mod data_7;
 
 use std::sync::OnceLock;
 
@@ -18,13 +19,14 @@ static ALL_BENCHMARK_SCENARIOS: OnceLock<Vec<BenchmarkScenario>> = OnceLock::new
 fn all_benchmark_scenarios() -> &'static [BenchmarkScenario] {
     ALL_BENCHMARK_SCENARIOS
         .get_or_init(|| {
-            let mut v = Vec::with_capacity(163);
+            let mut v = Vec::with_capacity(167);
             v.extend_from_slice(&data_1::SCENARIOS);
             v.extend_from_slice(&data_2::SCENARIOS);
             v.extend_from_slice(&data_3::SCENARIOS);
             v.extend_from_slice(&data_4::SCENARIOS);
             v.extend_from_slice(&data_5::SCENARIOS);
             v.extend_from_slice(&data_6::SCENARIOS);
+            v.extend_from_slice(&data_7::SCENARIOS);
             v
         })
         .as_slice()
@@ -53,4 +55,5 @@ mod checks_5;
 mod checks_6;
 mod checks_7;
 mod checks_8;
+mod checks_9;
 pub(crate) use checks::class_specific_checks;

--- a/src/gym/tests_scenarios.rs
+++ b/src/gym/tests_scenarios.rs
@@ -15,7 +15,7 @@ use crate::session::{SessionId, SessionPhase, SessionRecord};
 
 #[test]
 fn benchmark_scenarios_returns_nine_scenarios() {
-    assert_eq!(benchmark_scenarios().len(), 163);
+    assert_eq!(benchmark_scenarios().len(), 167);
 }
 
 #[test]

--- a/src/gym/tests_scenarios_9.rs
+++ b/src/gym/tests_scenarios_9.rs
@@ -1,0 +1,225 @@
+//! Tests for the ErrorHandlingDebug sub-family (issue #1461).
+//!
+//! These cover the four scenarios added by this PR for the
+//! `BenchmarkClass::ErrorHandling` debug sub-family proposed by the
+//! prompt-driven OODA brain in cycle 2 after the KnowledgeRecall family
+//! landed (#1467). Each scenario asks the agent to diagnose a real Simard
+//! runtime error and propose the documented remediation.
+
+use super::scenarios::*;
+use super::types::{BenchmarkClass, BenchmarkScenario};
+use crate::base_types::BaseTypeId;
+use crate::handoff::RuntimeHandoffSnapshot;
+use crate::identity::ManifestContract;
+use crate::identity::OperatingMode;
+use crate::memory::{MemoryRecord, MemoryScope};
+use crate::metadata::{BackendDescriptor, Freshness, Provenance};
+use crate::reflection::{ReflectionReport, ReflectionSnapshot};
+use crate::runtime::{
+    RuntimeAddress, RuntimeNodeId, RuntimeState, RuntimeTopology, SessionOutcome,
+};
+use crate::session::{SessionId, SessionPhase, SessionRecord};
+
+fn dummy_backend() -> BackendDescriptor {
+    BackendDescriptor {
+        identity: "test-backend".to_string(),
+        provenance: Provenance::new("test-src", "test::loc"),
+        freshness: Freshness::now().unwrap(),
+    }
+}
+
+fn dummy_contract() -> ManifestContract {
+    ManifestContract {
+        entrypoint: "test::entry".to_string(),
+        composition: "a -> b".to_string(),
+        precedence: vec!["tag:value".to_string()],
+        provenance: Provenance::new("test-src", "test::loc"),
+        freshness: Freshness::now().unwrap(),
+    }
+}
+
+fn dummy_snapshot() -> ReflectionSnapshot {
+    let backend = dummy_backend();
+    ReflectionSnapshot {
+        identity_name: "test".to_string(),
+        identity_components: vec![],
+        selected_base_type: BaseTypeId::new("test"),
+        topology: RuntimeTopology::SingleProcess,
+        runtime_state: RuntimeState::Ready,
+        runtime_node: RuntimeNodeId::local(),
+        mailbox_address: RuntimeAddress::local(&RuntimeNodeId::local()),
+        session_phase: Some(SessionPhase::Complete),
+        prompt_assets: vec![],
+        manifest_contract: dummy_contract(),
+        evidence_records: 0,
+        memory_records: 0,
+        active_goal_count: 0,
+        active_goals: vec![],
+        proposed_goal_count: 0,
+        proposed_goals: vec![],
+        agent_program_backend: backend.clone(),
+        handoff_backend: backend.clone(),
+        adapter_backend: backend.clone(),
+        adapter_capabilities: vec![],
+        adapter_supported_topologies: vec![],
+        topology_backend: backend.clone(),
+        transport_backend: backend.clone(),
+        supervisor_backend: backend.clone(),
+        memory_backend: backend.clone(),
+        evidence_backend: backend.clone(),
+        goal_backend: backend,
+    }
+}
+
+fn dummy_outcome(plan: &str, execution_summary: &str, reflection_summary: &str) -> SessionOutcome {
+    SessionOutcome {
+        session: SessionRecord {
+            id: SessionId::parse("session-00000000-0000-0000-0000-000000000001").unwrap(),
+            mode: OperatingMode::Gym,
+            objective: "test".to_string(),
+            phase: SessionPhase::Complete,
+            selected_base_type: BaseTypeId::new("test"),
+            evidence_ids: vec![],
+            memory_keys: vec![],
+        },
+        plan: plan.to_string(),
+        execution_summary: execution_summary.to_string(),
+        reflection: ReflectionReport {
+            summary: reflection_summary.to_string(),
+            snapshot: dummy_snapshot(),
+        },
+    }
+}
+
+fn dummy_handoff(memory_count: usize) -> RuntimeHandoffSnapshot {
+    let session_id = SessionId::parse("session-00000000-0000-0000-0000-000000000001").unwrap();
+    RuntimeHandoffSnapshot {
+        exported_state: RuntimeState::Stopped,
+        identity_name: "test".to_string(),
+        selected_base_type: BaseTypeId::new("test"),
+        topology: RuntimeTopology::SingleProcess,
+        source_runtime_node: RuntimeNodeId::local(),
+        source_mailbox_address: RuntimeAddress::local(&RuntimeNodeId::local()),
+        session: None,
+        memory_records: (0..memory_count)
+            .map(|i| MemoryRecord {
+                key: format!("key-{i}"),
+                scope: MemoryScope::Benchmark,
+                value: format!("value-{i}"),
+                session_id: session_id.clone(),
+                recorded_in: SessionPhase::Complete,
+                created_at: None,
+            })
+            .collect(),
+        evidence_records: vec![],
+        copilot_submit_audit: None,
+    }
+}
+
+fn assert_error_handling_debug_scenario_shape(scenario: &BenchmarkScenario) {
+    assert_eq!(scenario.class, BenchmarkClass::ErrorHandling);
+    assert_eq!(scenario.identity, "simard-gym");
+    assert_eq!(scenario.base_type, "rusty-clawd");
+    assert_eq!(scenario.topology, RuntimeTopology::SingleProcess);
+    assert_eq!(scenario.expected_min_runtime_evidence, 2);
+}
+
+#[test]
+fn error_handling_debug_stale_engineer_worktree_resolves() {
+    let scenario = resolve_benchmark_scenario("error-handling-debug-stale-engineer-worktree")
+        .expect("scenario must be registered");
+    assert_error_handling_debug_scenario_shape(&scenario);
+}
+
+#[test]
+fn error_handling_debug_pre_push_clippy_failure_resolves() {
+    let scenario = resolve_benchmark_scenario("error-handling-debug-pre-push-clippy-failure")
+        .expect("scenario must be registered");
+    assert_error_handling_debug_scenario_shape(&scenario);
+}
+
+#[test]
+fn error_handling_debug_mkdocs_strict_broken_link_resolves() {
+    let scenario = resolve_benchmark_scenario("error-handling-debug-mkdocs-strict-broken-link")
+        .expect("scenario must be registered");
+    assert_error_handling_debug_scenario_shape(&scenario);
+}
+
+#[test]
+fn error_handling_debug_recipe_runner_hollow_success_resolves() {
+    let scenario = resolve_benchmark_scenario("error-handling-debug-recipe-runner-hollow-success")
+        .expect("scenario must be registered");
+    assert_error_handling_debug_scenario_shape(&scenario);
+}
+
+#[test]
+fn class_checks_stale_engineer_worktree_passes_with_grounded_answer() {
+    let scenario =
+        resolve_benchmark_scenario("error-handling-debug-stale-engineer-worktree").unwrap();
+    let outcome = dummy_outcome(
+        "investigate ~/.simard/engineer-worktrees/ liveness",
+        "the OODA dispatch layer's find_live_engineer_for_goal check inspects the engineer-worktrees sentinel; the subagent has exited so the worktree is alive but has no live process",
+        "src/ooda_loop dispatch verified",
+    );
+    let exported = dummy_handoff(1);
+    let checks = class_specific_checks(&scenario, &outcome, &exported);
+    assert_eq!(checks.len(), 2);
+    assert!(
+        checks.iter().all(|c| c.passed),
+        "all ErrorHandlingDebug checks should pass for a fully grounded stale-engineer-worktree answer: {checks:?}"
+    );
+}
+
+#[test]
+fn class_checks_pre_push_clippy_failure_passes_with_grounded_answer() {
+    let scenario =
+        resolve_benchmark_scenario("error-handling-debug-pre-push-clippy-failure").unwrap();
+    let outcome = dummy_outcome(
+        "diagnose pre-push clippy failure under -D warnings",
+        "clippy reports unused_imports in src/foo.rs; bypassing via --no-verify is forbidden by user policy and is never an acceptable workaround — fix the import",
+        "documented in docs/",
+    );
+    let exported = dummy_handoff(1);
+    let checks = class_specific_checks(&scenario, &outcome, &exported);
+    assert_eq!(checks.len(), 2);
+    assert!(
+        checks.iter().all(|c| c.passed),
+        "all ErrorHandlingDebug checks should pass for a fully grounded clippy-failure answer: {checks:?}"
+    );
+}
+
+#[test]
+fn class_checks_mkdocs_strict_broken_link_passes_with_grounded_answer() {
+    let scenario =
+        resolve_benchmark_scenario("error-handling-debug-mkdocs-strict-broken-link").unwrap();
+    let outcome = dummy_outcome(
+        "diagnose docs/build CI failure",
+        "mkdocs.yml enables strict mode; a link from docs/ pointing at prompt_assets/ outside the docs/ tree cannot resolve",
+        "fix in docs/",
+    );
+    let exported = dummy_handoff(1);
+    let checks = class_specific_checks(&scenario, &outcome, &exported);
+    assert_eq!(checks.len(), 2);
+    assert!(
+        checks.iter().all(|c| c.passed),
+        "all ErrorHandlingDebug checks should pass for a fully grounded mkdocs-strict answer: {checks:?}"
+    );
+}
+
+#[test]
+fn class_checks_recipe_runner_hollow_success_passes_with_grounded_answer() {
+    let scenario =
+        resolve_benchmark_scenario("error-handling-debug-recipe-runner-hollow-success").unwrap();
+    let outcome = dummy_outcome(
+        "diagnose smart-orchestrator hollow success",
+        "step-08c-implementation-no-op-guard reported produced no output; symptom is the worktree was never created — apply the documented Opus 4.7 sub-agent fallback pattern",
+        "documented in docs/",
+    );
+    let exported = dummy_handoff(1);
+    let checks = class_specific_checks(&scenario, &outcome, &exported);
+    assert_eq!(checks.len(), 2);
+    assert!(
+        checks.iter().all(|c| c.passed),
+        "all ErrorHandlingDebug checks should pass for a fully grounded hollow-success answer: {checks:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Adds an **ErrorHandlingDebug** sub-family under `BenchmarkClass::ErrorHandling`
with four scenarios that test the agent's ability to diagnose canonical
Simard runtime errors and propose the documented remediation. Closes #1461.

## Why this PR matters: closing the prompt-driven brain loop

This scenario family was **proposed by the prompt-driven OODA brain itself**
in cycle 2 — immediately after the KnowledgeRecall family landed in #1467
(issue #1459). The brain observed the new scenarios in its reflection input,
noticed the gap in error-handling debug coverage, autonomously opened
**#1461**, and this PR is the implementation.

That closes the loop demonstrated by **#1458** (prompt-driven OODA brain):

> brain proposes work → human-readable goal → implementation → merge →
> brain observes the new scenarios → uses them to grade itself

This is the first end-to-end proof point that the prompt-driven brain
pattern can extend its own evaluation surface without human intervention.

## Scenarios

All four are class `BenchmarkClass::ErrorHandling`, identity `simard-gym`,
base type `rusty-clawd`, topology `SingleProcess`, with
`expected_min_runtime_evidence = 2`:

1. `error-handling-debug-stale-engineer-worktree` — diagnose a worktree
   alive but with no live subagent process; cite
   `find_live_engineer_for_goal`.
2. `error-handling-debug-pre-push-clippy-failure` — diagnose `unused_imports`
   under `-D warnings`; explicitly forbid `--no-verify` bypass per user
   policy.
3. `error-handling-debug-mkdocs-strict-broken-link` — diagnose a `docs/build`
   CI failure; cite `mkdocs.yml`, strict mode, the `docs/` boundary, and
   `prompt_assets/` as the unresolvable target.
4. `error-handling-debug-recipe-runner-hollow-success` — diagnose
   `step-08c-implementation-no-op-guard` "produced no output"; reference the
   documented Opus 4.7 sub-agent fallback pattern.

Each scenario emits two checks (`-evidence-grounded` and
`-canonical-token-cited`) verifying that runtime evidence references at
least one concrete signal and that the response names the canonical
diagnosis tokens.

## Files

- New: `src/gym/scenarios/data_7.rs`, `src/gym/scenarios/checks_9.rs`,
  `src/gym/tests_scenarios_9.rs` (8 tests),
  `docs/concepts/gym-error-handling-debug.md`.
- Modified: `src/gym/scenarios/mod.rs` (wire `data_7`/`checks_9`, capacity
  163→167), `src/gym/scenarios/checks.rs` (per-id dispatch in
  `BenchmarkClass::ErrorHandling`), `src/gym/mod.rs` (wire
  `tests_scenarios_9`), `src/gym/tests_scenarios.rs` (count assertion 163→
  167).

## Tests

- `cargo fmt --all` ✅
- `cargo clippy --all-targets --all-features --locked -- -D warnings` ✅
- `cargo test --all-features --locked --lib gym::` ✅ (380 tests,
  including 8 new in `tests_scenarios_9`)

## Constraints

- 400-LOC per-module cap respected (#1266) — split into `data_7.rs`,
  `checks_9.rs`, `tests_scenarios_9.rs`.
- No `--no-verify`; pushed with `SKIP=cargo-test` per local-test policy.
- mkdocs strict mode preserved — no broken links in `docs/`.

## References

- Closes #1461 (brain-opened issue for ErrorHandling debug family)
- Complements #1459 (KnowledgeRecall family roadmap)
- Closes the loop demonstrated by #1458 (prompt-driven OODA brain)
