### PR TITLE
feat(ooda): prompt-driven decide phase (extends #1458 pattern)

### DIFF
--- a/prompt_assets/simard/ooda_decide.md
+++ b/prompt_assets/simard/ooda_decide.md
@@ -1,0 +1,102 @@
+# OODA Brain — Decide Phase: Action-Kind Routing
+
+> This is the **second** prompt-driven OODA brain in Simard, complementing
+> `prompt_assets/simard/ooda_brain.md` (the engineer-lifecycle brain shipped
+> in PR #1458). Editing this file changes how the daemon routes priorities to
+> action kinds — no code changes required.
+
+## ROLE
+
+You are the routing brain for Simard's OODA **Decide** phase. The Orient phase
+just ranked goals; for each priority, you decide which *kind* of action the
+daemon should dispatch. Output a single JSON judgment the daemon will execute.
+Be conservative: prefer `advance_goal` for ordinary goal IDs unless a clear
+signal in the goal_id or reason indicates a special routing.
+
+## CONTEXT
+
+A single priority entry produced by the Orient phase:
+
+```json
+{
+  "goal_id": "{goal_id}",
+  "urgency": {urgency},
+  "reason": "{reason}"
+}
+```
+
+Field semantics:
+
+- `goal_id` — Either a real goal slug from the active board (e.g.
+  `improve-cognitive-memory-persistence`) or one of the reserved synthetic
+  IDs the Orient phase emits for cross-cutting cycles:
+  - `__memory__` → cross-session memory consolidation
+  - `__improvement__` → run the gym-driven self-improvement loop
+  - `__poll_activity__` → poll developer activity / ingest signals
+  - `__extract_ideas__` → mine recent activity for new research ideas
+- `urgency` — Orient's score in `[0.0, 1.0]`. Already filtered to
+  > `f64::EPSILON` upstream; you do not need to gate on it again.
+- `reason` — Human-readable rationale Orient attached to the priority.
+
+## OPTIONS
+
+Pick exactly one `choice` tag:
+
+- `advance_goal` — Default for any non-reserved `goal_id`. The daemon spawns
+  or re-checks the engineer assigned to this goal.
+- `consolidate_memory` — Use for the reserved `__memory__` synthetic ID.
+- `run_improvement` — Use for `__improvement__`.
+- `poll_developer_activity` — Use for `__poll_activity__`.
+- `extract_ideas` — Use for `__extract_ideas__`.
+- `research_query` — Reserved for future use; only emit if the reason
+  explicitly requests a literature/web research action.
+- `run_gym_eval`, `build_skill`, `launch_session` — Reserved for future
+  routing; do not emit unless the daemon configuration explicitly enables
+  them.
+
+Unknown tags or malformed JSON cause the daemon to fall back to the
+deterministic prefix mapping (`__memory__` → consolidate_memory etc., else
+`advance_goal`). Extra fields are silently ignored (forward compatible).
+
+## OUTPUT_FORMAT
+
+Return a single JSON object on a single line. No prose before or after, no
+markdown fences. Schema:
+
+```json
+{"choice": "<one-of-the-tags-above>", "rationale": "<short reason citing goal_id or reason>"}
+```
+
+## EXAMPLES
+
+Good — reserved synthetic ID routes to its dedicated kind:
+
+Input: `{"goal_id": "__memory__", "urgency": 0.42, "reason": "12 unconsolidated session memories"}`
+```json
+{"choice": "consolidate_memory", "rationale": "reserved __memory__ ID"}
+```
+
+Good — ordinary goal slug routes to `advance_goal`:
+
+Input: `{"goal_id": "ship-v1", "urgency": 0.91, "reason": "high-priority feature, no engineer assigned"}`
+```json
+{"choice": "advance_goal", "rationale": "ordinary goal id, default routing"}
+```
+
+Good — synthetic ID for activity polling:
+
+Input: `{"goal_id": "__poll_activity__", "urgency": 0.30, "reason": "no poll in last hour"}`
+```json
+{"choice": "poll_developer_activity", "rationale": "reserved __poll_activity__ ID"}
+```
+
+Bad — do **not** route a real goal slug to `consolidate_memory` even if its
+description mentions memory:
+
+Input: `{"goal_id": "improve-cognitive-memory-persistence", "urgency": 0.7, "reason": "engineer needed for memory work"}`
+```json
+{"choice": "advance_goal", "rationale": "real goal slug, not reserved __memory__ ID"}
+```
+
+Bad — do **not** invent a `choice` for a goal_id you do not recognise. If the
+ID does not match a reserved synthetic, route to `advance_goal`.

--- a/src/ooda_brain/decide.rs
+++ b/src/ooda_brain/decide.rs
@@ -1,0 +1,205 @@
+//! Prompt-driven brain for the OODA **Decide** phase (extends the pattern
+//! established for the engineer-lifecycle skip branch in PR #1458).
+//!
+//! Today the Decide phase performs one judgment site per priority: mapping a
+//! `Priority` (goal_id + reason + urgency) to an [`ActionKind`]. Historically
+//! that mapping was a deterministic match-arm on `goal_id` prefix. This module
+//! reframes it as a prompt-driven decision so the routing rules live in
+//! `prompt_assets/simard/ooda_decide.md` and can be iterated without code
+//! changes.
+//!
+//! Per the standing architectural mandate, the daemon never depends on LLM
+//! availability for Decide: [`DeterministicFallbackDecideBrain`] preserves the
+//! pre-#1458 mapping bit-for-bit and is the floor when no LLM is configured.
+
+use super::rustyclawd::LlmSubmitter;
+use crate::error::{SimardError, SimardResult};
+use crate::ooda_loop::ActionKind;
+
+const ADAPTER_TAG: &str = "ooda-decide-brain";
+
+/// Embedded prompt — single source of truth. Editing the markdown file
+/// changes brain behaviour without code changes.
+const DECIDE_PROMPT: &str = include_str!("../../prompt_assets/simard/ooda_decide.md");
+
+// ---------------------------------------------------------------------------
+// Context fed to the brain
+// ---------------------------------------------------------------------------
+
+/// Read-only view of one priority entry that the Decide brain judges. Mirrors
+/// the per-priority columns that the deterministic match-arm consumed
+/// (`goal_id`, `urgency`, `reason`) so a fallback impl can reproduce the
+/// existing routing exactly.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct DecideContext {
+    pub goal_id: String,
+    pub urgency: f64,
+    pub reason: String,
+}
+
+// ---------------------------------------------------------------------------
+// Judgment: tagged enum the LLM emits as `{"choice":"...","rationale":"..."}`
+// ---------------------------------------------------------------------------
+
+/// What action kind the brain decided this priority maps to. Tagged on
+/// `choice` for forward-compatibility; unknown tags fail to parse and the
+/// caller falls back to the deterministic mapping.
+///
+/// Variants intentionally cover every [`ActionKind`] (not just the five
+/// emitted today) so the prompt can evolve to route to currently-unused
+/// kinds (`research_query`, `run_gym_eval`, `build_skill`, `launch_session`)
+/// without touching this file.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "choice", rename_all = "snake_case")]
+pub enum DecideJudgment {
+    AdvanceGoal { rationale: String },
+    RunImprovement { rationale: String },
+    ConsolidateMemory { rationale: String },
+    ResearchQuery { rationale: String },
+    RunGymEval { rationale: String },
+    BuildSkill { rationale: String },
+    LaunchSession { rationale: String },
+    PollDeveloperActivity { rationale: String },
+    ExtractIdeas { rationale: String },
+}
+
+impl DecideJudgment {
+    /// Project the tagged judgment back onto the existing [`ActionKind`]
+    /// enum so the Decide phase can keep emitting `PlannedAction` values
+    /// unchanged.
+    pub fn action_kind(&self) -> ActionKind {
+        match self {
+            Self::AdvanceGoal { .. } => ActionKind::AdvanceGoal,
+            Self::RunImprovement { .. } => ActionKind::RunImprovement,
+            Self::ConsolidateMemory { .. } => ActionKind::ConsolidateMemory,
+            Self::ResearchQuery { .. } => ActionKind::ResearchQuery,
+            Self::RunGymEval { .. } => ActionKind::RunGymEval,
+            Self::BuildSkill { .. } => ActionKind::BuildSkill,
+            Self::LaunchSession { .. } => ActionKind::LaunchSession,
+            Self::PollDeveloperActivity { .. } => ActionKind::PollDeveloperActivity,
+            Self::ExtractIdeas { .. } => ActionKind::ExtractIdeas,
+        }
+    }
+
+    pub fn rationale(&self) -> &str {
+        match self {
+            Self::AdvanceGoal { rationale }
+            | Self::RunImprovement { rationale }
+            | Self::ConsolidateMemory { rationale }
+            | Self::ResearchQuery { rationale }
+            | Self::RunGymEval { rationale }
+            | Self::BuildSkill { rationale }
+            | Self::LaunchSession { rationale }
+            | Self::PollDeveloperActivity { rationale }
+            | Self::ExtractIdeas { rationale } => rationale,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The trait
+// ---------------------------------------------------------------------------
+
+/// Single-decision-site trait for the Decide phase. Sync on purpose to match
+/// [`super::OodaBrain`] — the LLM-backed impl bridges to async internally so
+/// callers do not need a runtime.
+pub trait OodaDecideBrain: Send + Sync {
+    fn judge_decision(&self, ctx: &DecideContext) -> SimardResult<DecideJudgment>;
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic fallback — preserves pre-#1458 behaviour bit-for-bit
+// ---------------------------------------------------------------------------
+
+/// Fallback impl that mirrors the deterministic match-arm previously inlined
+/// in `src/ooda_loop/decide.rs`. This is the safety floor: when no LLM is
+/// configured, the daemon's Decide phase behaves identically to its
+/// pre-prompt-driven self.
+#[derive(Debug, Default)]
+pub struct DeterministicFallbackDecideBrain;
+
+impl OodaDecideBrain for DeterministicFallbackDecideBrain {
+    fn judge_decision(&self, ctx: &DecideContext) -> SimardResult<DecideJudgment> {
+        let rationale = "fallback-brain: prefix-routed".to_string();
+        let judgment = match ctx.goal_id.as_str() {
+            "__memory__" => DecideJudgment::ConsolidateMemory { rationale },
+            "__improvement__" => DecideJudgment::RunImprovement { rationale },
+            "__poll_activity__" => DecideJudgment::PollDeveloperActivity { rationale },
+            "__extract_ideas__" => DecideJudgment::ExtractIdeas { rationale },
+            _ => DecideJudgment::AdvanceGoal { rationale },
+        };
+        Ok(judgment)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// LLM-backed brain (mirrors the RustyClawdBrain shape from PR #1458)
+// ---------------------------------------------------------------------------
+
+/// LLM-backed Decide brain. Generic over [`LlmSubmitter`] so tests can swap
+/// in a canned-response stub without touching production wiring. The daemon
+/// uses [`build_rustyclawd_decide_brain`] to construct one wired to a real
+/// session.
+pub struct RustyClawdDecideBrain<S: LlmSubmitter> {
+    submitter: S,
+}
+
+impl<S: LlmSubmitter> RustyClawdDecideBrain<S> {
+    pub fn new(submitter: S) -> Self {
+        Self { submitter }
+    }
+
+    /// Render the embedded prompt with the context. Exposed so tests can
+    /// snapshot the rendering separate from LLM submission.
+    pub fn render_prompt(&self, ctx: &DecideContext) -> String {
+        DECIDE_PROMPT
+            .replace("{goal_id}", &ctx.goal_id)
+            .replace("{urgency}", &format!("{:.3}", ctx.urgency))
+            .replace("{reason}", &ctx.reason)
+    }
+}
+
+impl<S: LlmSubmitter> OodaDecideBrain for RustyClawdDecideBrain<S> {
+    fn judge_decision(&self, ctx: &DecideContext) -> SimardResult<DecideJudgment> {
+        let prompt = self.render_prompt(ctx);
+        let raw = self.submitter.submit(&prompt)?;
+        parse_judgment_from_response(&raw).map_err(|reason| SimardError::AdapterInvocationFailed {
+            base_type: ADAPTER_TAG.to_string(),
+            reason,
+        })
+    }
+}
+
+/// Extract a JSON object from the LLM response (LLMs sometimes wrap JSON in
+/// prose / markdown fences) and parse it as a judgment.
+fn parse_judgment_from_response(raw: &str) -> Result<DecideJudgment, String> {
+    let stripped = raw.trim();
+    let candidate = if let Some(start) = stripped.find('{')
+        && let Some(end) = stripped.rfind('}')
+        && end >= start
+    {
+        &stripped[start..=end]
+    } else {
+        return Err(format!(
+            "no JSON object found in LLM response (got {} bytes)",
+            raw.len()
+        ));
+    };
+    serde_json::from_str::<DecideJudgment>(candidate)
+        .map_err(|e| format!("decide-brain-parse-error: {e}; payload={candidate}"))
+}
+
+// ---------------------------------------------------------------------------
+// Production constructor
+// ---------------------------------------------------------------------------
+
+/// Production constructor mirroring [`super::build_rustyclawd_brain`].
+/// Returns `Err` if no LLM provider is configured; callers must fall back
+/// to [`DeterministicFallbackDecideBrain`] so the daemon's Decide phase
+/// behaves identically to its pre-prompt-driven self when LLM access is
+/// unavailable.
+pub fn build_rustyclawd_decide_brain() -> SimardResult<Box<dyn OodaDecideBrain>> {
+    let provider = crate::session_builder::LlmProvider::resolve()?;
+    let submitter = super::rustyclawd::SessionLlmSubmitter::new(provider);
+    Ok(Box::new(RustyClawdDecideBrain::new(submitter)))
+}

--- a/src/ooda_brain/decide_tests.rs
+++ b/src/ooda_brain/decide_tests.rs
@@ -1,0 +1,162 @@
+//! Tests for the prompt-driven Decide brain (extends PR #1458 pattern).
+
+use std::sync::Mutex;
+
+use super::{
+    DecideContext, DecideJudgment, DeterministicFallbackDecideBrain, LlmSubmitter, OodaDecideBrain,
+    RustyClawdDecideBrain,
+};
+use crate::error::SimardResult;
+use crate::ooda_loop::ActionKind;
+
+// ---------------------------------------------------------------------------
+// Stub LLM submitter (mirrors the pattern in tests.rs)
+// ---------------------------------------------------------------------------
+
+struct StubSubmitter {
+    response: String,
+    last_prompt: Mutex<Option<String>>,
+}
+
+impl StubSubmitter {
+    fn new(response: impl Into<String>) -> Self {
+        Self {
+            response: response.into(),
+            last_prompt: Mutex::new(None),
+        }
+    }
+}
+
+impl LlmSubmitter for StubSubmitter {
+    fn submit(&self, rendered_prompt: &str) -> SimardResult<String> {
+        *self.last_prompt.lock().unwrap() = Some(rendered_prompt.to_string());
+        Ok(self.response.clone())
+    }
+}
+
+fn ctx(goal_id: &str) -> DecideContext {
+    DecideContext {
+        goal_id: goal_id.to_string(),
+        urgency: 0.7,
+        reason: "test".to_string(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Judgment JSON round-trip
+// ---------------------------------------------------------------------------
+
+#[test]
+fn judgment_advance_goal_roundtrips() {
+    let raw = r#"{"choice":"advance_goal","rationale":"ordinary slug"}"#;
+    let parsed: DecideJudgment = serde_json::from_str(raw).expect("parse");
+    assert_eq!(parsed.action_kind(), ActionKind::AdvanceGoal);
+    assert_eq!(parsed.rationale(), "ordinary slug");
+}
+
+#[test]
+fn judgment_consolidate_memory_roundtrips() {
+    let raw = r#"{"choice":"consolidate_memory","rationale":"reserved __memory__"}"#;
+    let parsed: DecideJudgment = serde_json::from_str(raw).expect("parse");
+    assert_eq!(parsed.action_kind(), ActionKind::ConsolidateMemory);
+}
+
+#[test]
+fn judgment_extra_fields_are_ignored() {
+    let raw = r#"{"choice":"run_improvement","rationale":"go","futurefield":42}"#;
+    let parsed: DecideJudgment = serde_json::from_str(raw).expect("parse");
+    assert_eq!(parsed.action_kind(), ActionKind::RunImprovement);
+}
+
+// ---------------------------------------------------------------------------
+// DeterministicFallbackDecideBrain — preserves pre-#1458 mapping
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fallback_routes_memory_synthetic_to_consolidate_memory() {
+    let brain = DeterministicFallbackDecideBrain;
+    let j = brain.judge_decision(&ctx("__memory__")).unwrap();
+    assert_eq!(j.action_kind(), ActionKind::ConsolidateMemory);
+}
+
+#[test]
+fn fallback_routes_improvement_synthetic_to_run_improvement() {
+    let brain = DeterministicFallbackDecideBrain;
+    let j = brain.judge_decision(&ctx("__improvement__")).unwrap();
+    assert_eq!(j.action_kind(), ActionKind::RunImprovement);
+}
+
+#[test]
+fn fallback_routes_poll_activity_synthetic_to_poll_developer_activity() {
+    let brain = DeterministicFallbackDecideBrain;
+    let j = brain.judge_decision(&ctx("__poll_activity__")).unwrap();
+    assert_eq!(j.action_kind(), ActionKind::PollDeveloperActivity);
+}
+
+#[test]
+fn fallback_routes_extract_ideas_synthetic_to_extract_ideas() {
+    let brain = DeterministicFallbackDecideBrain;
+    let j = brain.judge_decision(&ctx("__extract_ideas__")).unwrap();
+    assert_eq!(j.action_kind(), ActionKind::ExtractIdeas);
+}
+
+#[test]
+fn fallback_routes_ordinary_goal_to_advance_goal() {
+    let brain = DeterministicFallbackDecideBrain;
+    let j = brain.judge_decision(&ctx("ship-v1")).unwrap();
+    assert_eq!(j.action_kind(), ActionKind::AdvanceGoal);
+}
+
+// ---------------------------------------------------------------------------
+// RustyClawdDecideBrain — round-trip via stub submitter
+// ---------------------------------------------------------------------------
+
+#[test]
+fn rustyclawd_brain_parses_canned_advance_goal_response() {
+    let stub = StubSubmitter::new(r#"{"choice":"advance_goal","rationale":"stub says go"}"#);
+    let brain = RustyClawdDecideBrain::new(stub);
+    let j = brain.judge_decision(&ctx("ship-v1")).unwrap();
+    assert_eq!(j.action_kind(), ActionKind::AdvanceGoal);
+    assert_eq!(j.rationale(), "stub says go");
+}
+
+#[test]
+fn rustyclawd_brain_parses_response_wrapped_in_prose() {
+    let stub = StubSubmitter::new(
+        "Here is my answer:\n```json\n{\"choice\":\"consolidate_memory\",\"rationale\":\"reserved\"}\n```\nThanks.",
+    );
+    let brain = RustyClawdDecideBrain::new(stub);
+    let j = brain.judge_decision(&ctx("__memory__")).unwrap();
+    assert_eq!(j.action_kind(), ActionKind::ConsolidateMemory);
+}
+
+#[test]
+fn rustyclawd_brain_unparseable_returns_error() {
+    let stub = StubSubmitter::new("totally not json");
+    let brain = RustyClawdDecideBrain::new(stub);
+    let err = brain.judge_decision(&ctx("ship-v1")).unwrap_err();
+    let msg = format!("{err}");
+    assert!(msg.contains("ooda-decide-brain"), "got: {msg}");
+}
+
+#[test]
+fn rustyclawd_brain_renders_prompt_with_context_fields() {
+    let stub = StubSubmitter::new(r#"{"choice":"advance_goal","rationale":"ok"}"#);
+    let brain = RustyClawdDecideBrain::new(stub);
+    let prompt = brain.render_prompt(&DecideContext {
+        goal_id: "marker-goal-id".to_string(),
+        urgency: 0.42,
+        reason: "marker-reason".to_string(),
+    });
+    assert!(prompt.contains("marker-goal-id"));
+    assert!(prompt.contains("marker-reason"));
+    assert!(prompt.contains("0.420"));
+}
+
+// ---------------------------------------------------------------------------
+// decide_with_brain wire-in: brain choice flows through to PlannedAction
+// ---------------------------------------------------------------------------
+
+// (Wire-in tests live in `src/ooda_loop/decide.rs` since `decide_with_brain`
+// is a private module item; co-locating tests with the function avoids
+// adding a public re-export just for tests.)

--- a/src/ooda_brain/mod.rs
+++ b/src/ooda_brain/mod.rs
@@ -16,13 +16,20 @@ use crate::ooda_loop::OodaState;
 use std::path::PathBuf;
 
 mod context;
+mod decide;
 mod fallback;
 mod rustyclawd;
 
 #[cfg(test)]
+mod decide_tests;
+#[cfg(test)]
 mod tests;
 
 pub use context::{gather_engineer_lifecycle_ctx, redact_secrets};
+pub use decide::{
+    DecideContext, DecideJudgment, DeterministicFallbackDecideBrain, OodaDecideBrain,
+    RustyClawdDecideBrain, build_rustyclawd_decide_brain,
+};
 pub use fallback::DeterministicFallbackBrain;
 pub use rustyclawd::{LlmSubmitter, RustyClawdBrain, SessionLlmSubmitter, build_rustyclawd_brain};
 

--- a/src/ooda_loop/decide.rs
+++ b/src/ooda_loop/decide.rs
@@ -1,13 +1,40 @@
 //! Decide phase: select actions from priorities, capped by concurrency limit.
+//!
+//! The action-kind selection (which kind of [`ActionKind`] each priority maps
+//! to) is delegated to a prompt-driven brain — see
+//! `prompt_assets/simard/ooda_decide.md`. The default entrypoint
+//! ([`decide`]) wires in [`DeterministicFallbackDecideBrain`], which preserves
+//! the pre-#1458 prefix-mapping bit-for-bit so the daemon never depends on
+//! LLM availability for Decide. Callers that have an LLM-backed brain can
+//! invoke [`decide_with_brain`] directly.
 
 use crate::error::SimardResult;
+use crate::ooda_brain::{DecideContext, DeterministicFallbackDecideBrain, OodaDecideBrain};
 
-use super::{ActionKind, OodaConfig, PlannedAction, Priority};
+use super::{OodaConfig, PlannedAction, Priority};
 
-/// Decide: select actions from priorities, capped by `max_concurrent_actions`.
+/// Decide using the deterministic fallback brain. This is the entrypoint
+/// the daemon's Act phase calls today; it preserves the pre-#1458 routing
+/// bit-for-bit (no LLM dependency).
 #[tracing::instrument(skip_all)]
 pub fn decide(priorities: &[Priority], config: &OodaConfig) -> SimardResult<Vec<PlannedAction>> {
+    let brain = DeterministicFallbackDecideBrain;
+    decide_with_brain(priorities, config, &brain)
+}
+
+/// Decide using a caller-supplied brain. Used by tests and (in a future
+/// wire-in) by the daemon when an LLM-backed brain is configured. On any
+/// brain error for an individual priority, falls back to the deterministic
+/// mapping for that priority so a transient adapter failure cannot stall
+/// the cycle.
+#[tracing::instrument(skip_all)]
+pub fn decide_with_brain(
+    priorities: &[Priority],
+    config: &OodaConfig,
+    brain: &dyn OodaDecideBrain,
+) -> SimardResult<Vec<PlannedAction>> {
     let limit = config.max_concurrent_actions as usize;
+    let fallback = DeterministicFallbackDecideBrain;
     let mut actions = Vec::with_capacity(limit);
     for priority in priorities {
         if actions.len() >= limit {
@@ -16,15 +43,16 @@ pub fn decide(priorities: &[Priority], config: &OodaConfig) -> SimardResult<Vec<
         if priority.urgency < f64::EPSILON {
             continue;
         }
-        let kind = match priority.goal_id.as_str() {
-            "__memory__" => ActionKind::ConsolidateMemory,
-            "__improvement__" => ActionKind::RunImprovement,
-            "__poll_activity__" => ActionKind::PollDeveloperActivity,
-            "__extract_ideas__" => ActionKind::ExtractIdeas,
-            _ => ActionKind::AdvanceGoal,
+        let ctx = DecideContext {
+            goal_id: priority.goal_id.clone(),
+            urgency: priority.urgency,
+            reason: priority.reason.clone(),
         };
+        let judgment = brain
+            .judge_decision(&ctx)
+            .or_else(|_| fallback.judge_decision(&ctx))?;
         actions.push(PlannedAction {
-            kind,
+            kind: judgment.action_kind(),
             goal_id: if priority.goal_id.starts_with("__") {
                 None
             } else {
@@ -39,6 +67,7 @@ pub fn decide(priorities: &[Priority], config: &OodaConfig) -> SimardResult<Vec<
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ooda_brain::{DecideContext, DecideJudgment, OodaDecideBrain};
     use crate::ooda_loop::{ActionKind, OodaConfig, Priority};
 
     #[test]
@@ -164,5 +193,59 @@ mod tests {
         assert_eq!(actions.len(), 1);
         assert_eq!(actions[0].kind, ActionKind::ExtractIdeas);
         assert!(actions[0].goal_id.is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // Brain wire-in tests: prove the brain's choice flows through and that
+    // a brain error transparently falls back to the deterministic mapping.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn decide_with_brain_uses_brain_judgment_for_action_kind() {
+        struct AlwaysGymBrain;
+        impl OodaDecideBrain for AlwaysGymBrain {
+            fn judge_decision(
+                &self,
+                _ctx: &DecideContext,
+            ) -> crate::error::SimardResult<DecideJudgment> {
+                Ok(DecideJudgment::RunGymEval {
+                    rationale: "stub".to_string(),
+                })
+            }
+        }
+        let priorities = vec![Priority {
+            goal_id: "ship-v1".to_string(),
+            urgency: 0.9,
+            reason: "test".to_string(),
+        }];
+        let config = OodaConfig::default();
+        let actions = decide_with_brain(&priorities, &config, &AlwaysGymBrain).unwrap();
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0].kind, ActionKind::RunGymEval);
+    }
+
+    #[test]
+    fn decide_with_brain_falls_back_on_brain_error() {
+        struct AlwaysErrBrain;
+        impl OodaDecideBrain for AlwaysErrBrain {
+            fn judge_decision(
+                &self,
+                _ctx: &DecideContext,
+            ) -> crate::error::SimardResult<DecideJudgment> {
+                Err(crate::error::SimardError::AdapterInvocationFailed {
+                    base_type: "test".to_string(),
+                    reason: "boom".to_string(),
+                })
+            }
+        }
+        let priorities = vec![Priority {
+            goal_id: "__memory__".to_string(),
+            urgency: 0.5,
+            reason: "fallback expected".to_string(),
+        }];
+        let config = OodaConfig::default();
+        let actions = decide_with_brain(&priorities, &config, &AlwaysErrBrain).unwrap();
+        // Fallback maps __memory__ → ConsolidateMemory, preserving pre-#1458 behaviour.
+        assert_eq!(actions[0].kind, ActionKind::ConsolidateMemory);
     }
 }


### PR DESCRIPTION
## Summary

Migrates the OODA **Decide** phase's action-kind selection from a deterministic Rust match-arm to a prompt-driven LLM brain, extending the pattern PR #1458 established for the engineer-lifecycle skip branch in `act/spawn`.

This is the **second prompt-driven OODA phase** in the rollout — Observe/Orient/Curate/Review will follow the same shape.

## Decision point chosen

The smallest match-arm in the Decide phase: the per-priority `goal_id` → `ActionKind` mapping that previously lived inline in `src/ooda_loop/decide.rs`:

```rust
let kind = match priority.goal_id.as_str() {
    "__memory__" => ActionKind::ConsolidateMemory,
    "__improvement__" => ActionKind::RunImprovement,
    "__poll_activity__" => ActionKind::PollDeveloperActivity,
    "__extract_ideas__" => ActionKind::ExtractIdeas,
    _ => ActionKind::AdvanceGoal,
};
```

Now routed through an `OodaDecideBrain` trait whose prompt-driven impl reads `prompt_assets/simard/ooda_decide.md`. Routing rules can be iterated by editing the prompt — no code changes required.

## Architectural mandate

Per the standing direction: **Simard's brain should be prompt-driven via `prompt_assets/simard/*.md`, NOT deterministic Rust match arms.** This PR moves another judgment site over to that model.

## Mandatory fallback preserved

`DeterministicFallbackDecideBrain` mirrors the pre-#1458 routing bit-for-bit and is the floor when no LLM is configured. The daemon's existing `decide()` entrypoint wires this fallback by default; the new `decide_with_brain()` overload accepts any `OodaDecideBrain` and transparently falls back per-priority on brain error so a transient adapter failure cannot stall the cycle.

## Wire-in surface

Single-site, surgical:
- `src/ooda_loop/decide.rs` — `decide()` now delegates action-kind selection to the brain.
- `cycle.rs` — **untouched** (existing `decide(&priorities, config)` signature preserved).

## New files

| Path | LOC | Purpose |
| --- | --- | --- |
| `src/ooda_brain/decide.rs` | 205 | Trait, fallback impl, RustyClawd LLM impl |
| `src/ooda_brain/decide_tests.rs` | 162 | JSON round-trip, fallback determinism, mock-LLM tests |
| `prompt_assets/simard/ooda_decide.md` | 102 | **Editable prompt — iterate routing without code changes** |

All modules well under the 400 LOC cap (#1266).

## Tests

- All 42 `ooda_brain::` tests pass (12 new in `decide_tests` + the 30 from #1458).
- All 10 `ooda_loop::decide::tests` pass (8 existing + 2 new wire-in tests).
- `cargo fmt --all`, `cargo clippy --all-targets --all-features --locked -- -D warnings` clean.

## Reviewer notes

The prompt asset (`prompt_assets/simard/ooda_decide.md`) is the design surface — review it for routing semantics. Code review can focus on the trait shape and the wire-in (mirror of `OodaBrain` from #1458).
