### PR TITLE
feat(ooda): persist brain judgments to cycle reports (#1458, #1469, #1471)

### DIFF
--- a/src/ooda_actions/advance_goal/spawn.rs
+++ b/src/ooda_actions/advance_goal/spawn.rs
@@ -6,7 +6,8 @@ use crate::agent_roles::AgentRole;
 use crate::agent_supervisor::{SubordinateConfig, spawn_subordinate};
 use crate::identity_composition::max_subordinate_depth;
 use crate::ooda_brain::{
-    EngineerLifecycleDecision, OodaBrain, apply_decision_to_state, gather_engineer_lifecycle_ctx,
+    BrainJudgmentRecord, EngineerLifecycleDecision, OodaBrain, apply_decision_to_state,
+    gather_engineer_lifecycle_ctx, push_brain_judgment,
 };
 use crate::ooda_loop::{ActionOutcome, OodaState, PlannedAction};
 
@@ -54,8 +55,8 @@ pub fn dispatch_spawn_engineer(
     let state_root_inflight = engineer_worktree_state_root();
     if let Some(live) = find_live_engineer_for_goal(&state_root_inflight, goal_id) {
         let ctx = gather_engineer_lifecycle_ctx(state, &state_root_inflight, goal_id, &live);
-        let decision = match brain.decide_engineer_lifecycle(&ctx) {
-            Ok(d) => d,
+        let (decision, fallback_used) = match brain.decide_engineer_lifecycle(&ctx) {
+            Ok(d) => (d, false),
             Err(e) => {
                 tracing::warn!(
                     target: "simard::ooda_brain",
@@ -63,11 +64,19 @@ pub fn dispatch_spawn_engineer(
                     error = %e,
                     "brain.decide_engineer_lifecycle failed; falling back to continue_skipping",
                 );
-                EngineerLifecycleDecision::ContinueSkipping {
-                    rationale: format!("brain-error fallback: {e}"),
-                }
+                (
+                    EngineerLifecycleDecision::ContinueSkipping {
+                        rationale: format!("brain-error fallback: {e}"),
+                    },
+                    true,
+                )
             }
         };
+        push_brain_judgment(BrainJudgmentRecord::from_engineer_lifecycle(
+            goal_id,
+            &decision,
+            fallback_used,
+        ));
         return apply_lifecycle_decision(action, state, goal_id, &live, decision);
     }
 

--- a/src/ooda_brain/judgment_record.rs
+++ b/src/ooda_brain/judgment_record.rs
@@ -1,0 +1,338 @@
+//! Per-cycle accumulator of prompt-driven brain judgments.
+//!
+//! Surfaces what each prompt-driven OODA phase decided for the user to
+//! inspect via `~/.simard/cycle_reports/cycle_*.json`. The Act, Decide and
+//! Orient phases each call `brain.judge_*()` (or fall back to the
+//! deterministic floor). After every such call site, the wire-in pushes a
+//! [`BrainJudgmentRecord`] onto the per-cycle accumulator. The cycle-report
+//! writer drains the accumulator and persists the records under the new
+//! `brain_judgments` field.
+//!
+//! Threading: the accumulator is a `thread_local!` `RefCell<Vec<...>>`. The
+//! OODA cycle runs single-threaded per daemon (`run_ooda_cycle`), so a
+//! thread-local is the least invasive plumbing — it avoids threading a
+//! per-cycle context through every brain call site (each lives at a
+//! different layer of the stack: `ooda_loop::orient`, `ooda_loop::decide`,
+//! `ooda_actions::advance_goal::spawn`).
+//!
+//! Lifecycle is deterministic:
+//! 1. `clear()` at the start of each `run_ooda_cycle`.
+//! 2. `push()` after each `brain.judge_*()` call (or fallback).
+//! 3. `take_all()` when assembling the final `CycleReport`.
+
+use std::cell::RefCell;
+
+use super::{DecideJudgment, EngineerLifecycleDecision, OrientJudgment};
+
+/// Which OODA phase produced the judgment. Serialised as lowercase strings
+/// so the cycle-report JSON consumers (dashboard, ad-hoc inspection) read
+/// `"act"`, `"decide"`, `"orient"`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum BrainPhase {
+    Act,
+    Decide,
+    Orient,
+}
+
+/// One record of a single `brain.judge_*()` call (or its fallback). Fields
+/// are intentionally simple strings/floats so the cycle-report consumer can
+/// render them verbatim without re-deserialising the per-phase judgment
+/// types.
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct BrainJudgmentRecord {
+    pub phase: BrainPhase,
+    /// Short summary of the inputs to the brain (truncated to ~200 chars).
+    pub context_summary: String,
+    /// Short label describing the variant chosen (e.g.
+    /// `"reclaim_and_redispatch"`, `"advance_goal"`, `"demote"`).
+    pub decision: String,
+    pub rationale: String,
+    /// In `[0.0, 1.0]`. Phases without a native confidence field report 1.0
+    /// for deterministic outputs and a fixed lower value for fallback paths.
+    pub confidence: f32,
+    /// `true` when the deterministic fallback fired because the LLM brain
+    /// errored or returned an invalid judgment.
+    pub fallback: bool,
+}
+
+const CONTEXT_SUMMARY_MAX: usize = 200;
+
+fn truncate(s: &str) -> String {
+    let trimmed = s.trim();
+    if trimmed.len() <= CONTEXT_SUMMARY_MAX {
+        trimmed.to_string()
+    } else {
+        format!("{}…", &trimmed[..CONTEXT_SUMMARY_MAX])
+    }
+}
+
+impl BrainJudgmentRecord {
+    /// Build an Act-phase record from the engineer-lifecycle decision. The
+    /// `EngineerLifecycleDecision` enum carries the rationale per variant.
+    pub fn from_engineer_lifecycle(
+        goal_id: &str,
+        decision: &EngineerLifecycleDecision,
+        fallback: bool,
+    ) -> Self {
+        let (label, rationale) = match decision {
+            EngineerLifecycleDecision::ContinueSkipping { rationale } => {
+                ("continue_skipping", rationale.as_str())
+            }
+            EngineerLifecycleDecision::ReclaimAndRedispatch { rationale, .. } => {
+                ("reclaim_and_redispatch", rationale.as_str())
+            }
+            EngineerLifecycleDecision::Deprioritize { rationale } => {
+                ("deprioritize", rationale.as_str())
+            }
+            EngineerLifecycleDecision::OpenTrackingIssue { rationale, .. } => {
+                ("open_tracking_issue", rationale.as_str())
+            }
+            EngineerLifecycleDecision::MarkGoalBlocked { rationale, .. } => {
+                ("mark_goal_blocked", rationale.as_str())
+            }
+        };
+        Self {
+            phase: BrainPhase::Act,
+            context_summary: truncate(&format!("engineer-lifecycle goal_id={goal_id}")),
+            decision: label.to_string(),
+            rationale: rationale.to_string(),
+            confidence: if fallback { 0.5 } else { 1.0 },
+            fallback,
+        }
+    }
+
+    /// Build a Decide-phase record from the action-kind judgment + the
+    /// priority that drove it.
+    pub fn from_decide(
+        goal_id: &str,
+        urgency: f64,
+        judgment: &DecideJudgment,
+        fallback: bool,
+    ) -> Self {
+        let label = match judgment {
+            DecideJudgment::AdvanceGoal { .. } => "advance_goal",
+            DecideJudgment::RunImprovement { .. } => "run_improvement",
+            DecideJudgment::ConsolidateMemory { .. } => "consolidate_memory",
+            DecideJudgment::ResearchQuery { .. } => "research_query",
+            DecideJudgment::RunGymEval { .. } => "run_gym_eval",
+            DecideJudgment::BuildSkill { .. } => "build_skill",
+            DecideJudgment::LaunchSession { .. } => "launch_session",
+            DecideJudgment::PollDeveloperActivity { .. } => "poll_developer_activity",
+            DecideJudgment::ExtractIdeas { .. } => "extract_ideas",
+        };
+        Self {
+            phase: BrainPhase::Decide,
+            context_summary: truncate(&format!("goal_id={goal_id} urgency={urgency:.3}")),
+            decision: label.to_string(),
+            rationale: judgment.rationale().to_string(),
+            confidence: if fallback { 0.5 } else { 1.0 },
+            fallback,
+        }
+    }
+
+    /// Build an Orient-phase record from the demotion judgment + originating
+    /// goal context.
+    pub fn from_orient(
+        goal_id: &str,
+        base_urgency: f64,
+        failure_count: u32,
+        judgment: &OrientJudgment,
+        fallback: bool,
+    ) -> Self {
+        let label = if judgment.demotion_applied > 0.0 {
+            "demote"
+        } else {
+            "no_demotion"
+        };
+        Self {
+            phase: BrainPhase::Orient,
+            context_summary: truncate(&format!(
+                "goal_id={goal_id} base_urgency={base_urgency:.3} failures={failure_count}"
+            )),
+            decision: label.to_string(),
+            rationale: judgment.rationale.clone(),
+            confidence: judgment.confidence as f32,
+            fallback,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Per-cycle thread-local accumulator
+// ---------------------------------------------------------------------------
+
+thread_local! {
+    static BRAIN_JUDGMENTS: RefCell<Vec<BrainJudgmentRecord>> = const { RefCell::new(Vec::new()) };
+}
+
+/// Append one judgment to the current cycle's accumulator.
+pub fn push(record: BrainJudgmentRecord) {
+    BRAIN_JUDGMENTS.with(|cell| cell.borrow_mut().push(record));
+}
+
+/// Drain and return all records accumulated so far. Called at the end of
+/// `run_ooda_cycle` to attach the records to the [`CycleReport`].
+pub fn take_all() -> Vec<BrainJudgmentRecord> {
+    BRAIN_JUDGMENTS.with(|cell| std::mem::take(&mut *cell.borrow_mut()))
+}
+
+/// Reset the accumulator (drops any leftover records). Called at the start
+/// of `run_ooda_cycle` so a previous cycle (or test) cannot leak entries
+/// into the next one.
+pub fn clear() {
+    BRAIN_JUDGMENTS.with(|cell| cell.borrow_mut().clear());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ooda_brain::{DecideJudgment, EngineerLifecycleDecision, OrientJudgment};
+
+    fn sample_orient_judgment() -> OrientJudgment {
+        OrientJudgment {
+            adjusted_urgency: 0.4,
+            rationale: "demoted".to_string(),
+            confidence: 0.9,
+            demotion_applied: 0.2,
+        }
+    }
+
+    #[test]
+    fn record_round_trips_through_json() {
+        let rec = BrainJudgmentRecord {
+            phase: BrainPhase::Decide,
+            context_summary: "ctx".to_string(),
+            decision: "advance_goal".to_string(),
+            rationale: "because".to_string(),
+            confidence: 0.75,
+            fallback: false,
+        };
+        let json = serde_json::to_string(&rec).unwrap();
+        assert!(json.contains("\"phase\":\"decide\""));
+        let back: BrainJudgmentRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(rec, back);
+    }
+
+    #[test]
+    fn from_engineer_lifecycle_picks_variant_label() {
+        let dec = EngineerLifecycleDecision::ReclaimAndRedispatch {
+            rationale: "stuck".to_string(),
+            redispatch_context: "ctx".to_string(),
+        };
+        let rec = BrainJudgmentRecord::from_engineer_lifecycle("g1", &dec, false);
+        assert_eq!(rec.phase, BrainPhase::Act);
+        assert_eq!(rec.decision, "reclaim_and_redispatch");
+        assert_eq!(rec.rationale, "stuck");
+        assert!(!rec.fallback);
+    }
+
+    #[test]
+    fn from_decide_uses_judgment_rationale() {
+        let j = DecideJudgment::RunGymEval {
+            rationale: "gym slipped".to_string(),
+        };
+        let rec = BrainJudgmentRecord::from_decide("__improvement__", 0.7, &j, true);
+        assert_eq!(rec.phase, BrainPhase::Decide);
+        assert_eq!(rec.decision, "run_gym_eval");
+        assert!(rec.fallback);
+        assert!((rec.confidence - 0.5).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn from_orient_labels_demotion_vs_no_op() {
+        let demoted = sample_orient_judgment();
+        let rec = BrainJudgmentRecord::from_orient("g1", 0.6, 1, &demoted, false);
+        assert_eq!(rec.decision, "demote");
+
+        let untouched = OrientJudgment {
+            adjusted_urgency: 0.6,
+            rationale: "no change".to_string(),
+            confidence: 1.0,
+            demotion_applied: 0.0,
+        };
+        let rec = BrainJudgmentRecord::from_orient("g1", 0.6, 0, &untouched, false);
+        assert_eq!(rec.decision, "no_demotion");
+    }
+
+    #[test]
+    fn truncate_long_context_summary() {
+        let long = "x".repeat(500);
+        let dec = EngineerLifecycleDecision::ContinueSkipping {
+            rationale: long.clone(),
+        };
+        let rec = BrainJudgmentRecord::from_engineer_lifecycle(&long, &dec, false);
+        assert!(rec.context_summary.len() <= CONTEXT_SUMMARY_MAX + 4);
+    }
+
+    #[test]
+    fn accumulator_push_take_clear_isolation() {
+        // Use a fresh thread so the thread-local starts empty regardless of
+        // any leftovers from other tests in the same module.
+        let handle = std::thread::spawn(|| {
+            clear();
+            assert!(take_all().is_empty());
+
+            push(BrainJudgmentRecord {
+                phase: BrainPhase::Act,
+                context_summary: "a".to_string(),
+                decision: "x".to_string(),
+                rationale: "r".to_string(),
+                confidence: 1.0,
+                fallback: false,
+            });
+            push(BrainJudgmentRecord {
+                phase: BrainPhase::Decide,
+                context_summary: "b".to_string(),
+                decision: "y".to_string(),
+                rationale: "r".to_string(),
+                confidence: 1.0,
+                fallback: false,
+            });
+
+            let drained = take_all();
+            assert_eq!(drained.len(), 2);
+            // Second drain is empty — take_all() consumes.
+            assert!(take_all().is_empty());
+
+            // clear() also wipes after pushes.
+            push(BrainJudgmentRecord {
+                phase: BrainPhase::Orient,
+                context_summary: "c".to_string(),
+                decision: "z".to_string(),
+                rationale: "r".to_string(),
+                confidence: 1.0,
+                fallback: false,
+            });
+            clear();
+            assert!(take_all().is_empty());
+        });
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn accumulator_isolates_across_threads() {
+        // Each thread has its own thread-local — pushes in one thread must
+        // not appear in another.
+        let t1 = std::thread::spawn(|| {
+            clear();
+            push(BrainJudgmentRecord {
+                phase: BrainPhase::Act,
+                context_summary: "t1".to_string(),
+                decision: "x".to_string(),
+                rationale: "r".to_string(),
+                confidence: 1.0,
+                fallback: false,
+            });
+            take_all()
+        });
+        let t2 = std::thread::spawn(|| {
+            clear();
+            take_all()
+        });
+        let v1 = t1.join().unwrap();
+        let v2 = t2.join().unwrap();
+        assert_eq!(v1.len(), 1);
+        assert!(v2.is_empty());
+    }
+}

--- a/src/ooda_brain/mod.rs
+++ b/src/ooda_brain/mod.rs
@@ -18,6 +18,7 @@ use std::path::PathBuf;
 mod context;
 mod decide;
 mod fallback;
+mod judgment_record;
 mod orient;
 mod rustyclawd;
 
@@ -34,6 +35,10 @@ pub use decide::{
     RustyClawdDecideBrain, build_rustyclawd_decide_brain,
 };
 pub use fallback::DeterministicFallbackBrain;
+pub use judgment_record::{
+    BrainJudgmentRecord, BrainPhase, clear as clear_brain_judgments, push as push_brain_judgment,
+    take_all as take_brain_judgments,
+};
 pub use orient::{
     DeterministicFallbackOrientBrain, FAILURE_PENALTY_PER_CONSECUTIVE, OodaOrientBrain,
     OrientContext, OrientJudgment, RustyClawdOrientBrain, build_rustyclawd_orient_brain,

--- a/src/ooda_loop/cycle.rs
+++ b/src/ooda_loop/cycle.rs
@@ -30,6 +30,10 @@ pub fn run_ooda_cycle(
     bridges: &mut OodaBridges,
     config: &OodaConfig,
 ) -> SimardResult<CycleReport> {
+    // Reset per-cycle brain-judgment accumulator so a previous cycle (or a
+    // panicking test) cannot leak entries into this one.
+    crate::ooda_brain::clear_brain_judgments();
+
     // Budget enforcement: refuse to run if daily or weekly spend is exceeded.
     if let Ok(daily) = crate::cost_tracking::daily_summary()
         && daily.total_cost_usd >= config.daily_budget_usd
@@ -377,12 +381,14 @@ pub fn run_ooda_cycle(
     }
 
     state.cycle_count += 1;
+    let brain_judgments = crate::ooda_brain::take_brain_judgments();
     Ok(CycleReport {
         cycle_number: state.cycle_count,
         observation,
         priorities,
         planned_actions,
         outcomes,
+        brain_judgments,
     })
 }
 

--- a/src/ooda_loop/decide.rs
+++ b/src/ooda_loop/decide.rs
@@ -9,7 +9,10 @@
 //! invoke [`decide_with_brain`] directly.
 
 use crate::error::SimardResult;
-use crate::ooda_brain::{DecideContext, DeterministicFallbackDecideBrain, OodaDecideBrain};
+use crate::ooda_brain::{
+    BrainJudgmentRecord, DecideContext, DeterministicFallbackDecideBrain, OodaDecideBrain,
+    push_brain_judgment,
+};
 
 use super::{OodaConfig, PlannedAction, Priority};
 
@@ -48,9 +51,27 @@ pub fn decide_with_brain(
             urgency: priority.urgency,
             reason: priority.reason.clone(),
         };
-        let judgment = brain
-            .judge_decision(&ctx)
-            .or_else(|_| fallback.judge_decision(&ctx))?;
+        let judgment = match brain.judge_decision(&ctx) {
+            Ok(j) => {
+                push_brain_judgment(BrainJudgmentRecord::from_decide(
+                    &priority.goal_id,
+                    priority.urgency,
+                    &j,
+                    false,
+                ));
+                j
+            }
+            Err(_) => {
+                let j = fallback.judge_decision(&ctx)?;
+                push_brain_judgment(BrainJudgmentRecord::from_decide(
+                    &priority.goal_id,
+                    priority.urgency,
+                    &j,
+                    true,
+                ));
+                j
+            }
+        };
         actions.push(PlannedAction {
             kind: judgment.action_kind(),
             goal_id: if priority.goal_id.starts_with("__") {

--- a/src/ooda_loop/orient.rs
+++ b/src/ooda_loop/orient.rs
@@ -4,7 +4,10 @@ use std::collections::HashMap;
 
 use crate::error::SimardResult;
 use crate::goal_curation::{GoalBoard, GoalProgress};
-use crate::ooda_brain::{DeterministicFallbackOrientBrain, OodaOrientBrain, OrientContext};
+use crate::ooda_brain::{
+    BrainJudgmentRecord, DeterministicFallbackOrientBrain, OodaOrientBrain, OrientContext,
+    push_brain_judgment,
+};
 
 use super::{Observation, Priority};
 
@@ -92,11 +95,17 @@ pub fn orient_with_brain(
                     base_reason: reason.clone(),
                     failure_count: count,
                 };
-                let judgment = brain
-                    .judge_orientation(&ctx)
-                    .ok()
-                    .filter(|j| j.validate(ctx.base_urgency).is_ok())
-                    .unwrap_or_else(|| DeterministicFallbackOrientBrain::compute(&ctx));
+                let (judgment, fallback_used) = match brain.judge_orientation(&ctx) {
+                    Ok(j) if j.validate(ctx.base_urgency).is_ok() => (j, false),
+                    _ => (DeterministicFallbackOrientBrain::compute(&ctx), true),
+                };
+                push_brain_judgment(BrainJudgmentRecord::from_orient(
+                    &g.id,
+                    ctx.base_urgency,
+                    count,
+                    &judgment,
+                    fallback_used,
+                ));
                 reason = format!("{reason}; {}", judgment.rationale);
                 urgency = judgment.adjusted_urgency;
             }

--- a/src/ooda_loop/summary.rs
+++ b/src/ooda_loop/summary.rs
@@ -70,6 +70,7 @@ mod tests {
                 success: true,
                 detail: "done".to_string(),
             }],
+            brain_judgments: Vec::new(),
         };
         let summary = summarize_cycle_report(&report);
         assert!(summary.contains("cycle #1"));
@@ -98,6 +99,7 @@ mod tests {
             priorities: Vec::new(),
             planned_actions: Vec::new(),
             outcomes: Vec::new(),
+            brain_judgments: Vec::new(),
         };
         let summary = summarize_cycle_report(&report);
         assert!(summary.contains("tree=dirty"));
@@ -138,6 +140,7 @@ mod tests {
                     detail: "fail".to_string(),
                 },
             ],
+            brain_judgments: Vec::new(),
         };
         let summary = summarize_cycle_report(&report);
         assert!(summary.contains("1/2 succeeded"));

--- a/src/ooda_loop/types.rs
+++ b/src/ooda_loop/types.rs
@@ -195,6 +195,11 @@ pub struct CycleReport {
     pub priorities: Vec<Priority>,
     pub planned_actions: Vec<PlannedAction>,
     pub outcomes: Vec<ActionOutcome>,
+    /// Per-cycle forensic trace of prompt-driven OODA brain judgments
+    /// (act / decide / orient). Empty when no brain calls fired this cycle
+    /// or when reading older reports written before this field existed.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub brain_judgments: Vec<crate::ooda_brain::BrainJudgmentRecord>,
 }
 
 /// Configuration for the OODA loop.

--- a/src/operator_commands_ooda/persistence.rs
+++ b/src/operator_commands_ooda/persistence.rs
@@ -74,6 +74,16 @@ pub(super) fn persist_cycle_report(
                 }
             entry
         }).collect::<Vec<_>>(),
+        "brain_judgments": report.brain_judgments.iter().map(|j| {
+            json!({
+                "phase": j.phase,
+                "context_summary": j.context_summary,
+                "decision": j.decision,
+                "rationale": j.rationale,
+                "confidence": j.confidence,
+                "fallback": j.fallback,
+            })
+        }).collect::<Vec<_>>(),
     });
 
     let _ = std::fs::write(
@@ -228,6 +238,7 @@ mod tests {
                 success: true,
                 detail: "done".to_string(),
             }],
+            brain_judgments: Vec::new(),
         }
     }
 
@@ -366,5 +377,55 @@ mod tests {
         assert!(content.contains("\"spawn_engineer\""));
         assert!(content.contains("engineer-g1-9"));
         assert!(content.contains("\"status\": \"live\""));
+    }
+
+    #[test]
+    fn persist_cycle_report_serialises_brain_judgments_when_present() {
+        use crate::ooda_brain::{BrainJudgmentRecord, BrainPhase};
+
+        let dir = tempfile::tempdir().unwrap();
+        let mut report = minimal_report(11);
+        report.brain_judgments.push(BrainJudgmentRecord {
+            phase: BrainPhase::Decide,
+            context_summary: "goal_id=ship-v1 urgency=0.900".to_string(),
+            decision: "advance_goal".to_string(),
+            rationale: "high priority".to_string(),
+            confidence: 1.0,
+            fallback: false,
+        });
+        report.brain_judgments.push(BrainJudgmentRecord {
+            phase: BrainPhase::Orient,
+            context_summary: "goal_id=g1 base_urgency=0.600 failures=2".to_string(),
+            decision: "demote".to_string(),
+            rationale: "two failures".to_string(),
+            confidence: 0.8,
+            fallback: true,
+        });
+        persist_cycle_report(dir.path(), &report);
+        let content =
+            std::fs::read_to_string(dir.path().join("cycle_reports/cycle_11.json")).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+        let arr = parsed["brain_judgments"].as_array().expect("array");
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0]["phase"], "decide");
+        assert_eq!(arr[0]["decision"], "advance_goal");
+        assert_eq!(arr[0]["fallback"], false);
+        assert_eq!(arr[1]["phase"], "orient");
+        assert_eq!(arr[1]["fallback"], true);
+    }
+
+    #[test]
+    fn persist_cycle_report_emits_empty_brain_judgments_array_when_none() {
+        let dir = tempfile::tempdir().unwrap();
+        // minimal_report(...) has brain_judgments = vec![] by default.
+        let report = minimal_report(12);
+        persist_cycle_report(dir.path(), &report);
+        let content =
+            std::fs::read_to_string(dir.path().join("cycle_reports/cycle_12.json")).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+        // Persistence writer always emits the field as [] for forensic
+        // consistency on the dashboard side, even though the Rust struct's
+        // `Vec` skips serialisation when empty.
+        assert_eq!(parsed["brain_judgments"], serde_json::json!([]));
     }
 }

--- a/src/operator_commands_ooda/tests/mod.rs
+++ b/src/operator_commands_ooda/tests/mod.rs
@@ -29,6 +29,7 @@ pub(crate) fn make_test_report(cycle_number: u32) -> CycleReport {
         priorities: vec![],
         planned_actions: vec![],
         outcomes: vec![],
+        brain_judgments: vec![],
     }
 }
 
@@ -88,5 +89,6 @@ pub(crate) fn make_report_with_goals_and_outcomes() -> CycleReport {
                 detail: "Failed".to_string(),
             },
         ],
+        brain_judgments: vec![],
     }
 }


### PR DESCRIPTION
## Summary

Surfaces the prompt-driven OODA brain judgments (Act / Decide / Orient) in `~/.simard/cycle_reports/cycle_*.json` so the user can observe **what** each prompt-driven phase actually decided each cycle. Previously the brain trait calls (`act`/`decide`/`orient`) executed and influenced behaviour, but their `decision`, `rationale`, `confidence` outputs were not persisted anywhere — pure black-box from the operator's view.

## Three brain-driven phases now traced

| Phase  | PR    | Call site                                                | Trait                |
| ------ | ----- | -------------------------------------------------------- | -------------------- |
| Act    | #1458 | `src/ooda_actions/advance_goal/spawn.rs`                 | `OodaBrain`          |
| Decide | #1469 | `src/ooda_loop/decide.rs`                                | `OodaDecideBrain`    |
| Orient | #1471 | `src/ooda_loop/orient.rs`                                | `OodaOrientBrain`    |

Each call site now records a `BrainJudgmentRecord` immediately after the brain returns (or after the deterministic fallback fires).

## New schema field on `CycleReport`

```json
"brain_judgments": [
  {
    "phase": "act|decide|orient",
    "context_summary": "...",
    "decision": "...",
    "rationale": "...",
    "confidence": 0.0-1.0,
    "fallback": false
  }
]
```

`decision` is a stable variant label (e.g. `"advance_goal"`, `"demote"`, `"reclaim_and_redispatch"`). `fallback: true` means the deterministic fallback fired because the LLM brain errored or returned invalid output.

## Threading approach

Per-cycle thread-local accumulator (`src/ooda_brain/judgment_record.rs`):

- `push(record)` after each `brain.judge_*()` call
- `clear()` at the top of `run_ooda_cycle`
- `take_all()` when assembling the final `CycleReport`

Chosen because the three brain call sites live at three different layers of the stack and the OODA cycle runs single-threaded per daemon. A thread-local sidesteps threading a per-cycle context through every layer (would touch ~all of `ooda_actions`); per-cycle isolation is enforced by `clear()` at start + `take_all()` at end.

Tests verify both intra-thread isolation (`take_all` consumes; `clear` wipes) and cross-thread isolation (each thread sees its own accumulator).

## Backward compatibility

- `brain_judgments` is `#[serde(default, skip_serializing_if = "Vec::is_empty")]` on the Rust struct → older reports without the field still deserialise.
- The persistence writer always emits the field as `[]` for forensic consistency on the dashboard side, even on cycles with no brain calls.
- Pre-existing dashboard / persistence consumers continue to work unchanged.

## User-facing benefit

Operators can now `cat ~/.simard/cycle_reports/cycle_42.json | jq '.brain_judgments'` and see exactly which prompt-driven decisions the daemon made this cycle, with rationale and confidence — including which calls were forced through the deterministic fallback (LLM unavailable / errored / produced invalid output). Closes the observability gap on the prompt-driven OODA round.

## Tests

- `BrainJudgmentRecord` JSON round-trips
- Per-variant label mapping (`from_engineer_lifecycle`, `from_decide`, `from_orient`)
- Long context-summary truncation
- Accumulator push/take/clear isolation (within and across threads)
- `persist_cycle_report_serialises_brain_judgments_when_present`
- `persist_cycle_report_emits_empty_brain_judgments_array_when_none`

All existing `ooda_brain::*`, `ooda_loop::*`, and `operator_commands_ooda::persistence` tests continue to pass (163 tests).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
