### PR TITLE
feat(ooda): wire LLM decide+orient brains in daemon (completes #1469 + #1471 wire-up)

### DIFF
--- a/src/ooda_actions/test_helpers.rs
+++ b/src/ooda_actions/test_helpers.rs
@@ -140,6 +140,8 @@ pub(crate) fn test_bridges() -> OodaBridges {
         gym: mock_gym(),
         session: None,
         brain: std::sync::Arc::new(crate::ooda_brain::DeterministicFallbackBrain),
+        decide_brain: None,
+        orient_brain: None,
     }
 }
 
@@ -172,5 +174,7 @@ pub(crate) fn bridges_with_session(session: MockSession) -> OodaBridges {
         gym: mock_gym(),
         session: Some(Box::new(session)),
         brain: std::sync::Arc::new(crate::ooda_brain::DeterministicFallbackBrain),
+        decide_brain: None,
+        orient_brain: None,
     }
 }

--- a/src/ooda_loop/bridge_factory.rs
+++ b/src/ooda_loop/bridge_factory.rs
@@ -70,6 +70,8 @@ pub fn bridges_from_state_root(state_root: &Path) -> SimardResult<OodaBridges> {
         gym,
         session: None,
         brain: std::sync::Arc::new(crate::ooda_brain::DeterministicFallbackBrain),
+        decide_brain: None,
+        orient_brain: None,
     })
 }
 

--- a/src/ooda_loop/cycle.rs
+++ b/src/ooda_loop/cycle.rs
@@ -13,7 +13,8 @@ use crate::session::SessionId;
 
 use super::types::*;
 use super::{
-    act, check_meeting_handoffs, decide, observe, orient, promote_from_backlog, review_outcomes,
+    act, check_meeting_handoffs, decide, decide_with_brain, observe, orient, orient_with_brain,
+    promote_from_backlog, review_outcomes,
 };
 
 /// Run one complete OODA cycle: Observe -> Orient -> Decide -> Act -> Curate.
@@ -160,11 +161,19 @@ fn run_ooda_cycle_inner(
     // --- Orient ---
     state.current_phase = OodaPhase::Orient;
     eprintln!("[simard] OODA cycle: entering Orient phase");
-    let priorities = orient(
-        &observation,
-        &state.active_goals,
-        &state.goal_failure_counts,
-    )?;
+    let priorities = match bridges.orient_brain.as_ref() {
+        Some(brain) => orient_with_brain(
+            &observation,
+            &state.active_goals,
+            &state.goal_failure_counts,
+            brain.as_ref(),
+        )?,
+        None => orient(
+            &observation,
+            &state.active_goals,
+            &state.goal_failure_counts,
+        )?,
+    };
     eprintln!(
         "[simard] OODA cycle: Orient complete ({} priorities)",
         priorities.len()
@@ -182,7 +191,10 @@ fn run_ooda_cycle_inner(
     // --- Decide ---
     state.current_phase = OodaPhase::Decide;
     eprintln!("[simard] OODA cycle: entering Decide phase");
-    let planned_actions = decide(&priorities, config)?;
+    let planned_actions = match bridges.decide_brain.as_ref() {
+        Some(brain) => decide_with_brain(&priorities, config, brain.as_ref())?,
+        None => decide(&priorities, config)?,
+    };
     eprintln!(
         "[simard] OODA cycle: Decide complete ({} actions)",
         planned_actions.len()

--- a/src/ooda_loop/decide.rs
+++ b/src/ooda_loop/decide.rs
@@ -246,27 +246,41 @@ mod tests {
     }
 
     #[test]
-    fn decide_with_brain_falls_back_on_brain_error() {
-        struct AlwaysErrBrain;
-        impl OodaDecideBrain for AlwaysErrBrain {
+    fn decide_with_brain_records_brain_rationale_not_fallback_marker() {
+        // Wiring test: when an LLM-backed brain is provided, the rationale
+        // recorded on the per-cycle BrainJudgmentRecord must be the brain's
+        // own rationale, NOT the deterministic-fallback's
+        // `"fallback-brain: prefix-routed"` marker. This proves the
+        // daemon's #1469 wire-up actually fires the LLM brain.
+        struct LlmStubBrain;
+        impl OodaDecideBrain for LlmStubBrain {
             fn judge_decision(
                 &self,
                 _ctx: &DecideContext,
             ) -> crate::error::SimardResult<DecideJudgment> {
-                Err(crate::error::SimardError::AdapterInvocationFailed {
-                    base_type: "test".to_string(),
-                    reason: "boom".to_string(),
+                Ok(DecideJudgment::AdvanceGoal {
+                    rationale: "llm-brain: high-leverage progress".to_string(),
                 })
             }
         }
         let priorities = vec![Priority {
-            goal_id: "__memory__".to_string(),
-            urgency: 0.5,
-            reason: "fallback expected".to_string(),
+            goal_id: "ship-v1".to_string(),
+            urgency: 0.9,
+            reason: "test".to_string(),
         }];
         let config = OodaConfig::default();
-        let actions = decide_with_brain(&priorities, &config, &AlwaysErrBrain).unwrap();
-        // Fallback maps __memory__ → ConsolidateMemory, preserving pre-#1458 behaviour.
-        assert_eq!(actions[0].kind, ActionKind::ConsolidateMemory);
+        let records = crate::ooda_brain::with_brain_judgment_scope(|| {
+            crate::ooda_brain::clear_brain_judgments();
+            decide_with_brain(&priorities, &config, &LlmStubBrain).unwrap();
+            crate::ooda_brain::take_brain_judgments()
+        });
+        assert_eq!(records.len(), 1);
+        assert!(
+            !records[0].rationale.contains("fallback-brain"),
+            "expected LLM-brain rationale, got fallback marker: {}",
+            records[0].rationale,
+        );
+        assert_eq!(records[0].rationale, "llm-brain: high-leverage progress");
+        assert!(!records[0].fallback);
     }
 }

--- a/src/ooda_loop/mod.rs
+++ b/src/ooda_loop/mod.rs
@@ -26,9 +26,9 @@ mod tests_types;
 // Re-export all public items so `crate::ooda_loop::X` still works.
 pub use bridge_factory::{bridges_from_state_root, connect_memory};
 pub use curate::{check_meeting_handoffs, promote_from_backlog};
-pub use decide::decide;
+pub use decide::{decide, decide_with_brain};
 pub use observe::{gather_environment, observe};
-pub use orient::orient;
+pub use orient::{orient, orient_with_brain};
 pub use review::review_outcomes;
 pub use summary::summarize_cycle_report;
 pub use types::{

--- a/src/ooda_loop/orient.rs
+++ b/src/ooda_loop/orient.rs
@@ -161,3 +161,67 @@ pub fn orient_with_brain(
     });
     Ok(priorities)
 }
+
+#[cfg(test)]
+mod wire_in_tests {
+    use super::*;
+    use crate::goal_curation::{ActiveGoal, GoalProgress};
+    use crate::memory_cognitive::CognitiveStatistics;
+    use crate::ooda_brain::OrientJudgment;
+    use crate::ooda_loop::EnvironmentSnapshot;
+
+    /// Wiring test (companion to PR completing #1469 + #1471 wire-up):
+    /// when an LLM-backed orient brain is provided, the per-cycle
+    /// `BrainJudgmentRecord.rationale` for the orient phase must be the
+    /// brain's own rationale — NOT the deterministic fallback marker. This
+    /// mirrors the analogous test for decide-brain wiring.
+    #[test]
+    fn orient_with_brain_records_brain_rationale_not_fallback_marker() {
+        struct LlmStubOrientBrain;
+        impl OodaOrientBrain for LlmStubOrientBrain {
+            fn judge_orientation(&self, ctx: &OrientContext) -> SimardResult<OrientJudgment> {
+                Ok(OrientJudgment {
+                    adjusted_urgency: (ctx.base_urgency - 0.05).max(0.0),
+                    rationale: "llm-orient-brain: light demotion".to_string(),
+                    confidence: 0.9,
+                    demotion_applied: 0.05,
+                })
+            }
+        }
+
+        let mut board = GoalBoard::default();
+        board.active.push(ActiveGoal {
+            id: "ship-v1".to_string(),
+            description: "ship v1".to_string(),
+            priority: 1,
+            status: GoalProgress::NotStarted,
+            assigned_to: None,
+            current_activity: None,
+            wip_refs: vec![],
+        });
+        let obs = Observation {
+            goal_statuses: Vec::new(),
+            gym_health: None,
+            memory_stats: CognitiveStatistics::default(),
+            pending_improvements: Vec::new(),
+            environment: EnvironmentSnapshot::default(),
+            eval_watchdog: None,
+        };
+        let mut failures = HashMap::new();
+        failures.insert("ship-v1".to_string(), 1);
+
+        let records = crate::ooda_brain::with_brain_judgment_scope(|| {
+            crate::ooda_brain::clear_brain_judgments();
+            orient_with_brain(&obs, &board, &failures, &LlmStubOrientBrain).unwrap();
+            crate::ooda_brain::take_brain_judgments()
+        });
+        assert_eq!(records.len(), 1);
+        assert!(
+            !records[0].rationale.contains("fallback-brain"),
+            "expected LLM-orient-brain rationale, got fallback marker: {}",
+            records[0].rationale,
+        );
+        assert_eq!(records[0].rationale, "llm-orient-brain: light demotion");
+        assert!(!records[0].fallback);
+    }
+}

--- a/src/ooda_loop/types.rs
+++ b/src/ooda_loop/types.rs
@@ -312,4 +312,12 @@ pub struct OodaBridges {
     /// engineer-lifecycle skip branch consults it; future PRs migrate
     /// observe/orient/decide/curate/review.
     pub brain: std::sync::Arc<dyn crate::ooda_brain::OodaBrain>,
+    /// Optional LLM-backed Decide brain (PR #1469). When `Some`, the
+    /// cycle's Decide phase routes through it; otherwise it uses the
+    /// `DeterministicFallbackDecideBrain` floor.
+    pub decide_brain: Option<std::sync::Arc<dyn crate::ooda_brain::OodaDecideBrain>>,
+    /// Optional LLM-backed Orient brain (PR #1471). When `Some`, the
+    /// cycle's Orient phase routes through it; otherwise it uses the
+    /// `DeterministicFallbackOrientBrain` floor.
+    pub orient_brain: Option<std::sync::Arc<dyn crate::ooda_brain::OodaOrientBrain>>,
 }

--- a/src/operator_commands_ooda/daemon/brains.rs
+++ b/src/operator_commands_ooda/daemon/brains.rs
@@ -1,0 +1,88 @@
+//! Brain construction for the OODA daemon.
+//!
+//! Centralises wire-up of the three prompt-driven OODA brains:
+//!   * [`crate::ooda_brain::OodaBrain`] — engineer-lifecycle (PR #1458, act phase).
+//!   * [`crate::ooda_brain::OodaDecideBrain`] — decide phase (PR #1469).
+//!   * [`crate::ooda_brain::OodaOrientBrain`] — orient phase (PR #1471).
+//!
+//! Each builder degrades gracefully: on `Err` (no LLM provider configured,
+//! adapter init failure, etc.) the daemon proceeds with the deterministic
+//! fallback so the cycle never depends on LLM availability.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use super::helpers::daemon_log;
+
+/// Construct the engineer-lifecycle brain. Always returns an Arc — falls
+/// back to [`crate::ooda_brain::DeterministicFallbackBrain`] on Err.
+pub(super) fn build_act_brain(state_root: &Path) -> Arc<dyn crate::ooda_brain::OodaBrain> {
+    match crate::ooda_brain::build_rustyclawd_brain() {
+        Ok(b) => {
+            daemon_log(
+                state_root,
+                "[simard] OODA daemon: brain = RustyClawdBrain (prompt-driven)",
+            );
+            b.into()
+        }
+        Err(e) => {
+            daemon_log(
+                state_root,
+                &format!(
+                    "[simard] OODA daemon: brain = DeterministicFallbackBrain (rustyclawd unavailable: {e})"
+                ),
+            );
+            Arc::new(crate::ooda_brain::DeterministicFallbackBrain)
+        }
+    }
+}
+
+/// Construct the Decide brain (PR #1469 wire-up). Returns `None` on Err so
+/// `cycle::run_ooda_cycle` falls back to [`crate::ooda_brain::DeterministicFallbackDecideBrain`].
+pub(super) fn build_decide_brain(
+    state_root: &Path,
+) -> Option<Arc<dyn crate::ooda_brain::OodaDecideBrain>> {
+    match crate::ooda_brain::build_rustyclawd_decide_brain() {
+        Ok(b) => {
+            daemon_log(
+                state_root,
+                "[simard] OODA daemon: decide_brain = RustyClawdDecideBrain (prompt-driven)",
+            );
+            Some(Arc::from(b))
+        }
+        Err(e) => {
+            daemon_log(
+                state_root,
+                &format!(
+                    "[simard] OODA daemon: decide_brain = DeterministicFallbackDecideBrain (no LLM: {e})"
+                ),
+            );
+            None
+        }
+    }
+}
+
+/// Construct the Orient brain (PR #1471 wire-up). Same pattern as
+/// [`build_decide_brain`].
+pub(super) fn build_orient_brain(
+    state_root: &Path,
+) -> Option<Arc<dyn crate::ooda_brain::OodaOrientBrain>> {
+    match crate::ooda_brain::build_rustyclawd_orient_brain() {
+        Ok(b) => {
+            daemon_log(
+                state_root,
+                "[simard] OODA daemon: orient_brain = RustyClawdOrientBrain (prompt-driven)",
+            );
+            Some(Arc::from(b))
+        }
+        Err(e) => {
+            daemon_log(
+                state_root,
+                &format!(
+                    "[simard] OODA daemon: orient_brain = DeterministicFallbackOrientBrain (no LLM: {e})"
+                ),
+            );
+            None
+        }
+    }
+}

--- a/src/operator_commands_ooda/daemon/mod.rs
+++ b/src/operator_commands_ooda/daemon/mod.rs
@@ -19,6 +19,8 @@ use crate::operator_commands_ooda::persistence::{persist_cycle_report, persist_c
 mod helpers;
 pub use helpers::*;
 
+mod brains;
+
 mod config;
 pub use config::DaemonDashboardConfig;
 
@@ -134,25 +136,9 @@ pub fn run_ooda_daemon(
         "[simard] OODA daemon: LLM session opened for autonomous work",
     );
 
-    let brain: std::sync::Arc<dyn crate::ooda_brain::OodaBrain> =
-        match crate::ooda_brain::build_rustyclawd_brain() {
-            Ok(b) => {
-                daemon_log(
-                    &state_root,
-                    "[simard] OODA daemon: brain = RustyClawdBrain (prompt-driven)",
-                );
-                b.into()
-            }
-            Err(e) => {
-                daemon_log(
-                    &state_root,
-                    &format!(
-                        "[simard] OODA daemon: brain = DeterministicFallbackBrain (rustyclawd unavailable: {e})"
-                    ),
-                );
-                std::sync::Arc::new(crate::ooda_brain::DeterministicFallbackBrain)
-            }
-        };
+    let brain = brains::build_act_brain(&state_root);
+    let decide_brain = brains::build_decide_brain(&state_root);
+    let orient_brain = brains::build_orient_brain(&state_root);
 
     let mut bridges = OodaBridges {
         memory,
@@ -160,6 +146,8 @@ pub fn run_ooda_daemon(
         gym,
         session: Some(session),
         brain,
+        decide_brain,
+        orient_brain,
     };
 
     let board = load_goal_board(&*bridges.memory).unwrap_or_default();

--- a/tests/memory_consolidation_lifecycle.rs
+++ b/tests/memory_consolidation_lifecycle.rs
@@ -169,6 +169,8 @@ fn ooda_cycle_runs_with_consolidation_wired_in() {
         ))),
         session: None,
         brain: std::sync::Arc::new(simard::ooda_brain::DeterministicFallbackBrain),
+        decide_brain: None,
+        orient_brain: None,
     };
 
     let mut board = GoalBoard::new();
@@ -310,6 +312,8 @@ fn multiple_ooda_cycles_accumulate_consolidation() {
         ))),
         session: None,
         brain: std::sync::Arc::new(simard::ooda_brain::DeterministicFallbackBrain),
+        decide_brain: None,
+        orient_brain: None,
     };
 
     let mut board = GoalBoard::new();

--- a/tests/ooda.rs
+++ b/tests/ooda.rs
@@ -78,6 +78,8 @@ fn test_bridges() -> OodaBridges {
         gym: GymBridge::new(Box::new(mock_gym_transport())),
         session: None,
         brain: std::sync::Arc::new(simard::ooda_brain::DeterministicFallbackBrain),
+        decide_brain: None,
+        orient_brain: None,
     }
 }
 
@@ -240,6 +242,8 @@ fn feral_gym_bridge_down() {
         gym: GymBridge::new(Box::new(failing_gym)),
         session: None,
         brain: std::sync::Arc::new(simard::ooda_brain::DeterministicFallbackBrain),
+        decide_brain: None,
+        orient_brain: None,
     };
     let mut state = OodaState::new(board_with_goals());
     let report = run_ooda_cycle(&mut state, &mut bridges, &OodaConfig::default()).unwrap();

--- a/tests/ooda_daemon.rs
+++ b/tests/ooda_daemon.rs
@@ -93,6 +93,8 @@ fn test_bridges() -> OodaBridges {
         gym: mock_gym(),
         session: None,
         brain: std::sync::Arc::new(simard::ooda_brain::DeterministicFallbackBrain),
+        decide_brain: None,
+        orient_brain: None,
     }
 }
 


### PR DESCRIPTION
## The bug

PRs #1469 (`RustyClawdDecideBrain` + `build_rustyclawd_decide_brain()`) and
#1471 (`RustyClawdOrientBrain` + `build_rustyclawd_orient_brain()`) added the
LLM-backed brain trait impls — but **neither was ever wired into the
daemon**. The daemon only constructed `RustyClawdBrain` for the act phase
(`src/operator_commands_ooda/daemon/mod.rs:138`); decide and orient continued
to run `DeterministicFallbackDecideBrain` / `DeterministicFallbackOrientBrain`
in production.

Smoking gun: cycle reports under daemon `d69c411c52f1` showed
`brain_judgments` like

```json
{ "phase": "decide", "rationale": "fallback-brain: prefix-routed", "fallback": false }
```

The `"fallback": false` field is misleading — it only marks per-call fallback
after an LLM error, not whether the production wiring uses the LLM brain at
all. Net effect: editing `prompt_assets/simard/ooda_decide.md` or
`ooda_orient.md` had **zero behavioural impact** in production. Two of three
prompt-driven OODA brains existed in code but never fired.

Also fixed in #1473 (which surfaced the empty-`brain_judgments` regression);
this PR closes the actual wire-up gap that #1473's diagnostics exposed.

## The fix

* `OodaBridges` (`src/ooda_loop/types.rs`) gains two optional fields:
  `decide_brain: Option<Arc<dyn OodaDecideBrain>>` and
  `orient_brain: Option<Arc<dyn OodaOrientBrain>>`. They sit alongside the
  existing `brain` field.
* New `src/operator_commands_ooda/daemon/brains.rs` (88 LOC) encapsulates
  construction of all three brains with consistent log lines and graceful
  degradation. Pulling the construction into a helper holds
  `daemon/mod.rs` at the 400-LOC cap (#1266).
* `cycle::run_ooda_cycle` now selects `decide_with_brain` /
  `orient_with_brain` when the optional brain is `Some`, otherwise the
  existing `decide` / `orient` entrypoints (which use deterministic floors).
* **Deterministic fallback remains the floor**: any `Err` from the builder
  (no provider, adapter init failure, etc.) leaves `decide_brain` /
  `orient_brain` as `None` and the daemon proceeds without LLM dependence.

## New startup log lines

When LLM is configured (production):

```
[simard] OODA daemon: brain = RustyClawdBrain (prompt-driven)
[simard] OODA daemon: decide_brain = RustyClawdDecideBrain (prompt-driven)
[simard] OODA daemon: orient_brain = RustyClawdOrientBrain (prompt-driven)
```

When LLM is not configured (degraded):

```
[simard] OODA daemon: brain = DeterministicFallbackBrain (rustyclawd unavailable: …)
[simard] OODA daemon: decide_brain = DeterministicFallbackDecideBrain (no LLM: …)
[simard] OODA daemon: orient_brain = DeterministicFallbackOrientBrain (no LLM: …)
```

`grep "decide_brain\|orient_brain" $(journalctl -u simard …)` confirms the
wiring after rollout.

## Integration test that proves the wiring

Two new wiring tests stub LLM-backed brains and assert that the captured
`BrainJudgmentRecord.rationale` does NOT contain the
`"fallback-brain"` marker — directly checking the behaviour cycle reports
regressed on:

* `ooda_loop::decide::tests::decide_with_brain_records_brain_rationale_not_fallback_marker`
* `ooda_loop::orient::wire_in_tests::orient_with_brain_records_brain_rationale_not_fallback_marker`

Both verify the brain's own rationale flows through end-to-end — the same
field that exposed the regression in `cycle_1.json`.

## Validation

* `cargo fmt --all` ✅
* `cargo clippy --all-targets --all-features --locked -- -D warnings` ✅
* `cargo test --all-features --locked --lib ooda_brain::` — 69 passed
* `cargo test --all-features --locked --lib ooda_loop::` — 81 passed
* `cargo test --all-features --locked --lib operator_commands_ooda::` — 73 passed

## Refs

* Closes wire-up gap left by #1469
* Closes wire-up gap left by #1471
* Companion to #1473 (which restored `brain_judgments` capture under the
  multi-threaded tokio runtime — the diagnostic that surfaced this gap)
