### PR TITLE
feat(ooda): hot-reload prompt assets so prompt edits take effect without daemon restart

### DIFF
--- a/docs/concepts/prompt-driven-brain-iteration.md
+++ b/docs/concepts/prompt-driven-brain-iteration.md
@@ -1,0 +1,59 @@
+# Prompt-driven brain iteration (hot-reload)
+
+The three prompt-driven OODA brains — **act** (`RustyClawdBrain`, PR #1458),
+**decide** (`RustyClawdDecideBrain`, PR #1469), and **orient**
+(`RustyClawdOrientBrain`, PR #1471), all wired in [#1474] — load their
+prompt text from disk on every OODA cycle. Editing a prompt takes effect on
+the **next cycle**; no rebuild, no daemon restart.
+
+This realises the standing project goal: *iterate on prompts, not code*.
+
+## Where prompts live
+
+The daemon resolves the prompt-asset directory in this order:
+
+1. `$SIMARD_PROMPT_ASSETS_DIR` (override; useful for development worktrees).
+2. `$HOME/.simard/prompt_assets/simard/` — the default. `scripts/redeploy-local.sh`
+   syncs the repository's `prompt_assets/` tree here on every redeploy.
+3. Compile-time embedded fallback baked into the binary via `include_str!`.
+   This safety net guarantees the daemon never fails to start because a
+   prompt file was deleted.
+
+The resolved path is logged at daemon startup, e.g.
+
+```text
+[simard] OODA daemon: prompt_assets dir = /home/USER/.simard/prompt_assets/simard (3 prompts hot-reloadable)
+```
+
+## The three hot-reloadable prompts
+
+| File              | Brain                        | Decision site                                                      |
+| ----------------- | ---------------------------- | ------------------------------------------------------------------ |
+| `ooda_brain.md`   | `RustyClawdBrain` (act)      | Engineer-lifecycle skip branch — keep skipping, reclaim, deprioritise, open issue, or block. |
+| `ooda_decide.md`  | `RustyClawdDecideBrain`      | Map a prioritised goal to an `ActionKind` (advance, improve, consolidate, ...). |
+| `ooda_orient.md`  | `RustyClawdOrientBrain`      | Demote per-goal urgency in proportion to consecutive failures.     |
+
+## How hot-reload works
+
+Each brain reads its prompt fresh per call via a shared `PromptStore`
+singleton. The store stats the file once per call (cheap) and only re-reads
+when the mtime has changed. So the steady-state cost is one `metadata()`
+syscall per brain per cycle.
+
+Touching a prompt file (`touch`, any editor save) bumps mtime and the next
+brain invocation picks up the new contents.
+
+## Iteration workflow
+
+1. Edit the prompt at `~/.simard/prompt_assets/simard/<name>.md`.
+2. Save.
+3. Watch `~/.simard/daemon.log` — the new behaviour appears on the next
+   OODA cycle.
+
+For a full rebuild + redeploy (binary changes), run
+`scripts/redeploy-local.sh`. The redeploy step also re-syncs prompt assets
+from the repository, so any local edits to `~/.simard/prompt_assets/` are
+overwritten by the repository copy on redeploy. Commit prompt changes back
+to the repository to make them durable.
+
+[#1474]: https://github.com/rysweet/Simard/pull/1474

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,7 @@ nav:
     - Implementation Plan: architecture/implementation-plan.md
   - Concepts:
     - Truthful Runtime Metadata: concepts/truthful-runtime-metadata.md
+    - Prompt-driven Brain Iteration: concepts/prompt-driven-brain-iteration.md
   - Tutorials:
     - First Local Session: tutorials/run-your-first-local-session.md
     - First Benchmark Suite: tutorials/run-your-first-benchmark-gym.md

--- a/scripts/redeploy-local.sh
+++ b/scripts/redeploy-local.sh
@@ -60,6 +60,29 @@ cp -f "$NEW_BIN" "${INSTALL_BIN}.new"
 mv -f "${INSTALL_BIN}.new" "$INSTALL_BIN"
 echo "[redeploy] installed → ${INSTALL_BIN}"
 
+# ---------------------------------------------------------------------------
+# Sync prompt assets so the running daemon can hot-reload prompt edits on the
+# next OODA cycle (see docs/concepts/prompt-driven-brain-iteration.md). The
+# daemon resolves prompts from $SIMARD_PROMPT_ASSETS_DIR (override) or, by
+# default, from $HOME/.simard/prompt_assets/simard/ — which is exactly where
+# we copy them here. The embedded compile-time fallback always remains as a
+# safety net.
+# ---------------------------------------------------------------------------
+PROMPT_SRC="${SIMARD_REPO}/prompt_assets"
+PROMPT_DST="${HOME}/.simard/prompt_assets"
+if [[ -d "$PROMPT_SRC" ]]; then
+  mkdir -p "$PROMPT_DST"
+  cp -rf "$PROMPT_SRC/." "$PROMPT_DST/"
+  echo "[redeploy] synced prompt assets → ${PROMPT_DST}"
+  if [[ -d "$PROMPT_DST/simard" ]]; then
+    while IFS= read -r f; do
+      echo "[redeploy]   prompt: $(basename "$f")"
+    done < <(find "$PROMPT_DST/simard" -maxdepth 1 -type f -name '*.md' | sort)
+  fi
+else
+  echo "[redeploy] WARN: ${PROMPT_SRC} missing; daemon will use embedded prompts only"
+fi
+
 if [[ "$RESTART" -eq 0 ]]; then
   echo "[redeploy] --no-restart given; daemon NOT restarted"
   exit 0

--- a/src/ooda_brain/decide.rs
+++ b/src/ooda_brain/decide.rs
@@ -12,15 +12,18 @@
 //! availability for Decide: [`DeterministicFallbackDecideBrain`] preserves the
 //! pre-#1458 mapping bit-for-bit and is the floor when no LLM is configured.
 
+use super::prompt_store;
 use super::rustyclawd::LlmSubmitter;
 use crate::error::{SimardError, SimardResult};
 use crate::ooda_loop::ActionKind;
 
 const ADAPTER_TAG: &str = "ooda-decide-brain";
 
-/// Embedded prompt — single source of truth. Editing the markdown file
-/// changes brain behaviour without code changes.
-const DECIDE_PROMPT: &str = include_str!("../../prompt_assets/simard/ooda_decide.md");
+/// Prompt asset name. The on-disk file is read fresh per call via
+/// [`prompt_store::global`]; the compile-time embedded baseline is
+/// preserved in [`prompt_store::embedded_fallback`] so the daemon never
+/// fails because a prompt file is missing.
+const PROMPT_NAME: &str = "ooda_decide.md";
 
 // ---------------------------------------------------------------------------
 // Context fed to the brain
@@ -149,10 +152,11 @@ impl<S: LlmSubmitter> RustyClawdDecideBrain<S> {
         Self { submitter }
     }
 
-    /// Render the embedded prompt with the context. Exposed so tests can
-    /// snapshot the rendering separate from LLM submission.
+    /// Render the prompt with the context. Loaded fresh per call so prompt
+    /// edits take effect on the next OODA cycle (see [`prompt_store`]).
     pub fn render_prompt(&self, ctx: &DecideContext) -> String {
-        DECIDE_PROMPT
+        prompt_store::global()
+            .load(PROMPT_NAME)
             .replace("{goal_id}", &ctx.goal_id)
             .replace("{urgency}", &format!("{:.3}", ctx.urgency))
             .replace("{reason}", &ctx.reason)

--- a/src/ooda_brain/mod.rs
+++ b/src/ooda_brain/mod.rs
@@ -20,12 +20,15 @@ mod decide;
 mod fallback;
 mod judgment_record;
 mod orient;
+pub mod prompt_store;
 mod rustyclawd;
 
 #[cfg(test)]
 mod decide_tests;
 #[cfg(test)]
 mod orient_tests;
+#[cfg(test)]
+mod prompt_store_tests;
 #[cfg(test)]
 mod tests;
 

--- a/src/ooda_brain/orient.rs
+++ b/src/ooda_brain/orient.rs
@@ -18,6 +18,7 @@
 //! configured *or* when the LLM-backed brain returns an invalid judgment
 //! (e.g. attempts to escalate above `base_urgency`).
 
+use super::prompt_store;
 use super::rustyclawd::LlmSubmitter;
 use crate::error::{SimardError, SimardResult};
 
@@ -28,9 +29,9 @@ const ADAPTER_TAG: &str = "ooda-orient-brain";
 /// `src/ooda_loop/orient.rs`. Five failures drive any goal's urgency to 0.
 pub const FAILURE_PENALTY_PER_CONSECUTIVE: f64 = 0.2;
 
-/// Embedded prompt — single source of truth. Editing the markdown file
-/// changes brain behaviour without code changes.
-const ORIENT_PROMPT: &str = include_str!("../../prompt_assets/simard/ooda_orient.md");
+/// Prompt asset name. Loaded fresh per call from disk (with embedded
+/// fallback) so prompt edits take effect on the next OODA cycle.
+const PROMPT_NAME: &str = "ooda_orient.md";
 
 // ---------------------------------------------------------------------------
 // Context fed to the brain
@@ -177,10 +178,11 @@ impl<S: LlmSubmitter> RustyClawdOrientBrain<S> {
         Self { submitter }
     }
 
-    /// Render the embedded prompt with the context. Exposed so tests can
-    /// snapshot the rendering separate from LLM submission.
+    /// Render the prompt with the context. Loaded fresh per call so prompt
+    /// edits take effect on the next OODA cycle (see [`prompt_store`]).
     pub fn render_prompt(&self, ctx: &OrientContext) -> String {
-        ORIENT_PROMPT
+        prompt_store::global()
+            .load(PROMPT_NAME)
             .replace("{goal_id}", &ctx.goal_id)
             .replace("{base_urgency}", &format!("{:.3}", ctx.base_urgency))
             .replace("{base_reason}", &ctx.base_reason)

--- a/src/ooda_brain/prompt_store.rs
+++ b/src/ooda_brain/prompt_store.rs
@@ -1,0 +1,183 @@
+//! Hot-reloading prompt asset store for the prompt-driven OODA brains
+//! (`ooda_brain.md`, `ooda_decide.md`, `ooda_orient.md`).
+//!
+//! ## Why
+//!
+//! The three prompt-driven brains (`RustyClawdBrain`, `RustyClawdDecideBrain`,
+//! `RustyClawdOrientBrain` — PRs #1458, #1469, #1471, wired in #1474) embed
+//! their prompts via `include_str!`, so editing a prompt requires a full
+//! rebuild + daemon restart (`scripts/redeploy-local.sh`, ~2 minutes). The
+//! standing project goal is **"iterate on prompts not code"**, which only
+//! holds if a prompt edit can take effect on the next OODA cycle.
+//!
+//! ## What
+//!
+//! [`PromptStore`] resolves a prompt by name (e.g. `"ooda_brain.md"`) in this
+//! priority order:
+//!
+//! 1. Disk file at `<resolved-dir>/<name>` — if present, this wins so prompt
+//!    edits take effect immediately.
+//! 2. Embedded fallback baked in via `include_str!` at build time — used when
+//!    the file is missing so the daemon NEVER fails to start because a prompt
+//!    file was deleted.
+//!
+//! `<resolved-dir>` is taken from:
+//!
+//! 1. `$SIMARD_PROMPT_ASSETS_DIR` (if set and non-empty), else
+//! 2. `$HOME/.simard/prompt_assets/simard/` (the path
+//!    `scripts/redeploy-local.sh` syncs to), else
+//! 3. `None` — pure embedded mode (HOME unset / no env var → behaves
+//!    identically to the pre-#1266 baked-in prompts).
+//!
+//! ## Cache
+//!
+//! Prompts are cached keyed by file path + mtime. Each `load()` call stats
+//! the file (cheap — single syscall) and only re-reads when the mtime has
+//! changed, so the steady-state cost is one `metadata()` call per OODA cycle
+//! per prompt. Touching a prompt file (`touch ooda_brain.md` or any editor
+//! save) bumps mtime and invalidates the cache on the next call.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+use std::time::SystemTime;
+
+/// Environment variable that overrides the prompt-asset directory.
+pub const ENV_VAR: &str = "SIMARD_PROMPT_ASSETS_DIR";
+
+/// Default subpath under `$HOME` that `scripts/redeploy-local.sh` syncs the
+/// prompt assets to.
+const DEFAULT_HOME_SUBPATH: &str = ".simard/prompt_assets/simard";
+
+// --- Embedded fallbacks ----------------------------------------------------
+//
+// These constants are the single source of truth for the daemon's
+// out-of-the-box behaviour. They are baked at compile time so the daemon
+// always has a working prompt even when no on-disk asset directory exists.
+
+const EMBEDDED_BRAIN: &str = include_str!("../../prompt_assets/simard/ooda_brain.md");
+const EMBEDDED_DECIDE: &str = include_str!("../../prompt_assets/simard/ooda_decide.md");
+const EMBEDDED_ORIENT: &str = include_str!("../../prompt_assets/simard/ooda_orient.md");
+
+/// Look up the embedded fallback for a known prompt name. Returns `None` for
+/// unknown names so callers can surface a configuration error rather than
+/// silently serving an empty prompt.
+pub fn embedded_fallback(name: &str) -> Option<&'static str> {
+    match name {
+        "ooda_brain.md" => Some(EMBEDDED_BRAIN),
+        "ooda_decide.md" => Some(EMBEDDED_DECIDE),
+        "ooda_orient.md" => Some(EMBEDDED_ORIENT),
+        _ => None,
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CachedPrompt {
+    mtime: SystemTime,
+    contents: String,
+}
+
+/// Thread-safe, mtime-aware loader for prompt-asset markdown files.
+#[derive(Debug)]
+pub struct PromptStore {
+    dir: Option<PathBuf>,
+    cache: Mutex<HashMap<String, CachedPrompt>>,
+}
+
+impl PromptStore {
+    /// Construct a store rooted at the given directory. `None` disables
+    /// disk lookup so every `load()` returns the embedded fallback.
+    pub fn new(dir: Option<PathBuf>) -> Self {
+        Self {
+            dir,
+            cache: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Construct a store with the directory resolved from environment
+    /// variables — see module docs for the resolution order.
+    pub fn from_env() -> Self {
+        Self::new(resolve_dir_from_env())
+    }
+
+    /// Resolved on-disk directory (if any). `None` means the store is
+    /// running in pure embedded mode.
+    pub fn resolved_dir(&self) -> Option<&Path> {
+        self.dir.as_deref()
+    }
+
+    /// Load a prompt by file name (e.g. `"ooda_brain.md"`).
+    ///
+    /// Behaviour:
+    /// - If the resolved directory contains the file, return its contents
+    ///   (cached by mtime).
+    /// - Otherwise, return the compiled-in embedded fallback.
+    /// - If neither is available (unknown prompt name with no disk file),
+    ///   return an empty string. Callers treat this as a configuration
+    ///   error surfaced via the LLM response parser.
+    pub fn load(&self, name: &str) -> String {
+        let fallback = embedded_fallback(name).unwrap_or("");
+
+        let Some(dir) = self.dir.as_ref() else {
+            return fallback.to_string();
+        };
+        let path = dir.join(name);
+
+        let Ok(meta) = std::fs::metadata(&path) else {
+            return fallback.to_string();
+        };
+        let mtime = meta.modified().unwrap_or(SystemTime::UNIX_EPOCH);
+
+        // Fast path: cache hit at the same mtime.
+        {
+            let cache = self.cache.lock().expect("prompt cache poisoned");
+            if let Some(c) = cache.get(name)
+                && c.mtime == mtime
+            {
+                return c.contents.clone();
+            }
+        }
+
+        // Slow path: re-read and refresh the cache entry.
+        match std::fs::read_to_string(&path) {
+            Ok(s) => {
+                let mut cache = self.cache.lock().expect("prompt cache poisoned");
+                cache.insert(
+                    name.to_string(),
+                    CachedPrompt {
+                        mtime,
+                        contents: s.clone(),
+                    },
+                );
+                s
+            }
+            Err(_) => fallback.to_string(),
+        }
+    }
+}
+
+/// Resolve the prompt directory from `$SIMARD_PROMPT_ASSETS_DIR` then
+/// `$HOME/.simard/prompt_assets/simard/`. Returns `None` if neither yields
+/// a path (forces pure embedded mode).
+pub fn resolve_dir_from_env() -> Option<PathBuf> {
+    if let Some(v) = std::env::var_os(ENV_VAR)
+        && !v.is_empty()
+    {
+        return Some(PathBuf::from(v));
+    }
+    let home = std::env::var_os("HOME")?;
+    if home.is_empty() {
+        return None;
+    }
+    Some(PathBuf::from(home).join(DEFAULT_HOME_SUBPATH))
+}
+
+// --- Singleton -------------------------------------------------------------
+
+static GLOBAL: OnceLock<PromptStore> = OnceLock::new();
+
+/// Process-wide singleton. Initialized lazily on first call from environment.
+/// Subsequent calls are guaranteed to return the same instance.
+pub fn global() -> &'static PromptStore {
+    GLOBAL.get_or_init(PromptStore::from_env)
+}

--- a/src/ooda_brain/prompt_store_tests.rs
+++ b/src/ooda_brain/prompt_store_tests.rs
@@ -1,0 +1,177 @@
+//! Tests for [`super::PromptStore`].
+//!
+//! These tests deliberately avoid touching process environment in parallel —
+//! env-var resolution is exercised through the pure helper
+//! [`super::resolve_dir_from_env`] guarded by a serializing mutex.
+
+use super::prompt_store::*;
+use std::path::PathBuf;
+use std::sync::Mutex;
+use std::time::Duration;
+
+/// Serialize tests that mutate process environment.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+fn tmpdir(label: &str) -> PathBuf {
+    let base = std::env::var_os("CARGO_TARGET_TMPDIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("target/test-tmp"));
+    let dir = base.join(format!(
+        "prompt-store-{label}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    ));
+    std::fs::create_dir_all(&dir).expect("create tmpdir");
+    dir
+}
+
+#[test]
+fn missing_file_falls_back_to_embedded() {
+    let dir = tmpdir("missing");
+    let store = PromptStore::new(Some(dir));
+    let prompt = store.load("ooda_brain.md");
+    assert!(
+        prompt.contains("ROLE"),
+        "embedded fallback must be served when file is missing"
+    );
+    assert_eq!(prompt, embedded_fallback("ooda_brain.md").unwrap());
+}
+
+#[test]
+fn disk_file_overrides_embedded_fallback() {
+    let dir = tmpdir("override");
+    let path = dir.join("ooda_brain.md");
+    std::fs::write(&path, "# CUSTOM BRAIN PROMPT\n").unwrap();
+    let store = PromptStore::new(Some(dir));
+    assert_eq!(store.load("ooda_brain.md"), "# CUSTOM BRAIN PROMPT\n");
+}
+
+#[test]
+fn mtime_change_invalidates_cache() {
+    let dir = tmpdir("mtime");
+    let path = dir.join("ooda_decide.md");
+    std::fs::write(&path, "v1").unwrap();
+    let store = PromptStore::new(Some(dir.clone()));
+    assert_eq!(store.load("ooda_decide.md"), "v1");
+
+    // Sleep past filesystem mtime resolution (commonly 1s on ext4 without
+    // O_NOATIME tricks; 1.1s is safe across CI filesystems).
+    std::thread::sleep(Duration::from_millis(1100));
+    std::fs::write(&path, "v2").unwrap();
+    assert_eq!(
+        store.load("ooda_decide.md"),
+        "v2",
+        "cache must invalidate when mtime advances"
+    );
+}
+
+#[test]
+fn unchanged_file_serves_from_cache() {
+    let dir = tmpdir("cache");
+    let path = dir.join("ooda_orient.md");
+    std::fs::write(&path, "stable").unwrap();
+    let store = PromptStore::new(Some(dir.clone()));
+    assert_eq!(store.load("ooda_orient.md"), "stable");
+
+    // Replace contents WITHOUT bumping mtime by restoring the original
+    // mtime after the write. This proves the cache key is `(path, mtime)`
+    // and not `(path, contents)`.
+    let original = std::fs::metadata(&path).unwrap().modified().unwrap();
+    std::fs::write(&path, "altered").unwrap();
+    let f = std::fs::File::options().write(true).open(&path).unwrap();
+    f.set_modified(original).unwrap();
+
+    assert_eq!(
+        store.load("ooda_orient.md"),
+        "stable",
+        "unchanged mtime must serve cached value"
+    );
+}
+
+#[test]
+fn no_dir_means_pure_embedded() {
+    let store = PromptStore::new(None);
+    assert_eq!(
+        store.load("ooda_brain.md"),
+        embedded_fallback("ooda_brain.md").unwrap()
+    );
+    assert_eq!(
+        store.load("ooda_decide.md"),
+        embedded_fallback("ooda_decide.md").unwrap()
+    );
+    assert_eq!(
+        store.load("ooda_orient.md"),
+        embedded_fallback("ooda_orient.md").unwrap()
+    );
+}
+
+#[test]
+fn unknown_prompt_name_returns_empty_when_no_disk_file() {
+    let store = PromptStore::new(None);
+    assert_eq!(store.load("never_existed.md"), "");
+}
+
+#[test]
+fn env_var_takes_precedence_over_home() {
+    let _g = ENV_LOCK.lock().unwrap();
+    let saved_env = std::env::var_os(ENV_VAR);
+    let saved_home = std::env::var_os("HOME");
+
+    let env_dir = tmpdir("envwin");
+    // SAFETY: serialized via ENV_LOCK above.
+    unsafe {
+        std::env::set_var(ENV_VAR, &env_dir);
+        std::env::set_var("HOME", "/nonexistent-home-for-test");
+    }
+    let resolved = resolve_dir_from_env();
+    unsafe {
+        match saved_env {
+            Some(v) => std::env::set_var(ENV_VAR, v),
+            None => std::env::remove_var(ENV_VAR),
+        }
+        match saved_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+    assert_eq!(resolved.as_deref(), Some(env_dir.as_path()));
+}
+
+#[test]
+fn home_used_when_env_var_unset() {
+    let _g = ENV_LOCK.lock().unwrap();
+    let saved_env = std::env::var_os(ENV_VAR);
+    let saved_home = std::env::var_os("HOME");
+
+    unsafe {
+        std::env::remove_var(ENV_VAR);
+        std::env::set_var("HOME", "/tmp/fake-home-for-test");
+    }
+    let resolved = resolve_dir_from_env();
+    unsafe {
+        match saved_env {
+            Some(v) => std::env::set_var(ENV_VAR, v),
+            None => std::env::remove_var(ENV_VAR),
+        }
+        match saved_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+    assert_eq!(
+        resolved,
+        Some(PathBuf::from(
+            "/tmp/fake-home-for-test/.simard/prompt_assets/simard"
+        ))
+    );
+}
+
+#[test]
+fn singleton_is_idempotent() {
+    let a = global() as *const PromptStore;
+    let b = global() as *const PromptStore;
+    assert_eq!(a, b, "global() must return the same instance");
+}

--- a/src/ooda_brain/rustyclawd.rs
+++ b/src/ooda_brain/rustyclawd.rs
@@ -2,15 +2,19 @@
 //! abstraction. Production wires the real RustyClawd session; tests wire a
 //! canned-response stub.
 
+use super::prompt_store;
 use super::{EngineerLifecycleCtx, EngineerLifecycleDecision, OodaBrain};
 use crate::base_types::BaseTypeTurnInput;
 use crate::error::{SimardError, SimardResult};
 use crate::identity::OperatingMode;
 use crate::session_builder::{LlmProvider, SessionBuilder};
 
-/// Embedded prompt — single source of truth. Editing this file changes the
-/// brain's behaviour without code changes (the central design claim of #1266).
-const BRAIN_PROMPT: &str = include_str!("../../prompt_assets/simard/ooda_brain.md");
+/// Embedded prompt — compile-time fallback. The runtime brain reads from
+/// disk via [`prompt_store::global`] so prompt edits take effect on the
+/// next OODA cycle without restarting the daemon (PR #1474 follow-up).
+/// This constant is retained as documentation of the embedded baseline; the
+/// authoritative copy lives in [`prompt_store::embedded_fallback`].
+const PROMPT_NAME: &str = "ooda_brain.md";
 
 const ADAPTER_TAG: &str = "ooda-brain";
 
@@ -33,14 +37,17 @@ impl<S: LlmSubmitter> RustyClawdBrain<S> {
         Self { submitter }
     }
 
-    /// Render the embedded prompt with the context. Exposed so tests can
-    /// snapshot the rendering separate from LLM submission.
+    /// Render the prompt with the context. Loads the prompt fresh per call
+    /// via [`prompt_store::global`] so on-disk edits take effect on the
+    /// next OODA cycle. Falls back to the embedded baseline when no file
+    /// exists at the resolved path.
     pub fn render_prompt(&self, ctx: &EngineerLifecycleCtx) -> String {
         let sentinel = ctx
             .sentinel_pid
             .map(|p| p.to_string())
             .unwrap_or_else(|| "<none>".to_string());
-        BRAIN_PROMPT
+        prompt_store::global()
+            .load(PROMPT_NAME)
             .replace("{goal_id}", &ctx.goal_id)
             .replace("{goal_description}", &ctx.goal_description)
             .replace("{cycle_number}", &ctx.cycle_number.to_string())

--- a/src/operator_commands_ooda/daemon/mod.rs
+++ b/src/operator_commands_ooda/daemon/mod.rs
@@ -140,6 +140,22 @@ pub fn run_ooda_daemon(
     let decide_brain = brains::build_decide_brain(&state_root);
     let orient_brain = brains::build_orient_brain(&state_root);
 
+    // Surface where the daemon will look for hot-reloadable prompt assets so
+    // operators know where to edit (see `docs/concepts/prompt-driven-brain-iteration.md`).
+    {
+        let store = crate::ooda_brain::prompt_store::global();
+        let dir_str = store
+            .resolved_dir()
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|| "<embedded only>".to_string());
+        daemon_log(
+            &state_root,
+            &format!(
+                "[simard] OODA daemon: prompt_assets dir = {dir_str} (3 prompts hot-reloadable)"
+            ),
+        );
+    }
+
     let mut bridges = OodaBridges {
         memory,
         knowledge,


### PR DESCRIPTION
## Motivation — *iterate on prompts, not code*

The three prompt-driven OODA brains
([#1458](https://github.com/rysweet/Simard/pull/1458) act,
[#1469](https://github.com/rysweet/Simard/pull/1469) decide,
[#1471](https://github.com/rysweet/Simard/pull/1471) orient, all wired in
[#1474](https://github.com/rysweet/Simard/pull/1474)) embed their prompts
via `include_str!`. So even though the prompt *content* lives in a
markdown file, every prompt edit requires the full
`scripts/redeploy-local.sh` cycle:

1. `cargo build --release` (~90s)
2. binary swap + `systemctl --user restart simard-ooda`
3. wait for the next cycle to start

Total: ~2 minutes per iteration. That friction defeats the design
intent — *the whole point* of factoring brain logic out into markdown
prompts is to enable fast iteration on judgement.

## Change

After this PR: **edit → save → next OODA cycle picks it up**. No build,
no restart.

Each brain's `render_prompt` now calls
`prompt_store::global().load("ooda_<phase>.md")` per invocation instead
of using a `const … = include_str!(…)`. The store reads from disk on
each call, cached by file mtime, so the steady-state cost is one
`metadata()` syscall per brain per cycle.

## Resolution order

The store resolves `<dir>/<name>.md` in this priority:

1. **`$SIMARD_PROMPT_ASSETS_DIR`** — new env var; intended for
   development worktrees that want to point the daemon at a checked-out
   `prompt_assets/` directly.
2. **`$HOME/.simard/prompt_assets/simard/`** — default path. This is
   exactly where `scripts/redeploy-local.sh` now syncs the repo's
   `prompt_assets/` tree on every redeploy.
3. **Compiled-in `include_str!` fallback** — preserved as a hard safety
   net so the daemon NEVER fails to start because a prompt file was
   deleted or the directory is missing.

## Daemon visibility

A new startup log line surfaces the resolved path so operators know
exactly where to edit:

```text
[simard] OODA daemon: prompt_assets dir = /home/USER/.simard/prompt_assets/simard (3 prompts hot-reloadable)
```

## redeploy-local.sh

After installing the binary, the script now copies
`prompt_assets/` → `~/.simard/prompt_assets/` and prints which prompt
files were synced. Existing redeploy behaviour is unchanged otherwise.

## Tests

Nine new tests in `src/ooda_brain/prompt_store_tests.rs`:

* env var > HOME default > embedded fallback resolution order
* disk file overrides embedded fallback
* mtime change invalidates cache; unchanged mtime serves from cache
* missing file silently falls back to embedded
* unknown prompt name returns empty when no disk file exists
* `global()` singleton is idempotent

All 78 `ooda_brain::` tests pass. `cargo clippy --all-targets
--all-features -- -D warnings` clean. `cargo fmt --all --check` clean.

## Docs

`docs/concepts/prompt-driven-brain-iteration.md` (linked from the
mkdocs nav under *Concepts*) documents the iteration workflow, the
three prompts, and the cache invariants.

## Files

* New module: `src/ooda_brain/prompt_store.rs` (183 LOC, well under the
  400-LOC cap from #1266)
* New tests: `src/ooda_brain/prompt_store_tests.rs` (177 LOC)
* Wire-in: `decide.rs`, `orient.rs`, `rustyclawd.rs`,
  `operator_commands_ooda/daemon/mod.rs`
* Tooling: `scripts/redeploy-local.sh`
* Docs: `docs/concepts/prompt-driven-brain-iteration.md`, `mkdocs.yml`
