### PR TITLE
feat(gym): SelfIntrospection family — measures longitudinal self-knowledge from cycle reports

### DIFF
--- a/src/gym/scenarios/checks.rs
+++ b/src/gym/scenarios/checks.rs
@@ -97,5 +97,8 @@ pub(crate) fn class_specific_checks(
             }
             _ => super::checks_6::checks_for_knowledge_recall(scenario, &combined, exported),
         },
+        BenchmarkClass::SelfIntrospection => {
+            super::checks_10::checks_for_self_introspection(scenario, &combined, exported)
+        }
     }
 }

--- a/src/gym/scenarios/checks_10.rs
+++ b/src/gym/scenarios/checks_10.rs
@@ -1,0 +1,113 @@
+//! class_specific_checks helpers — chunk 10.
+//!
+//! SelfIntrospection family: scenarios that ask the agent to recall and
+//! reason about her own past cycle-report judgments. Each scenario emits the
+//! same two checks as the rest of the recall families:
+//! `self-introspection-evidence-grounded` (runtime evidence references at
+//! least one stored memory record, repo file path, or cycle-report path) and
+//! `self-introspection-canonical-token-cited` (the response actually names
+//! the canonical tokens — goal ids, phase names, sha256 prompt_version
+//! prefixes, or hot-reload concepts — that the objective asked about).
+//!
+//! Split into its own module to respect the 400-LOC per-module cap (#1266).
+
+use super::super::types::{BenchmarkCheckResult, BenchmarkScenario};
+use crate::handoff::RuntimeHandoffSnapshot;
+
+/// Checks for the `SelfIntrospection` family scenarios.
+pub(super) fn checks_for_self_introspection(
+    scenario: &BenchmarkScenario,
+    combined: &str,
+    exported: &RuntimeHandoffSnapshot,
+) -> Vec<BenchmarkCheckResult> {
+    let memory_grounded = !exported.memory_records.is_empty();
+    let path_cited = combined.contains(".rs")
+        || combined.contains("src/")
+        || combined.contains("cycle_reports")
+        || combined.contains("prompt_assets");
+    let evidence_grounded = memory_grounded || path_cited;
+
+    let topic_match = match scenario.id {
+        "self-introspection-l1-direct-cycle-recall" => {
+            let goal_named = combined.contains("improve-cognitive-memory-persistence");
+            let phase_named = combined.contains("act");
+            let decision_named = combined.contains("dispatch_engineer");
+            let cycle_named = combined.contains("cycle 5") || combined.contains("cycle_5");
+            goal_named && phase_named && decision_named && cycle_named
+        }
+        "self-introspection-l2-multi-cycle-synthesis" => {
+            let goal_named = combined.contains("add-more-gym-benchmark-scenarios");
+            let on_track_named = combined.contains("on-track") || combined.contains("on track");
+            let blocked_named = combined.contains("blocked-on-clippy")
+                || (combined.contains("blocked") && combined.contains("clippy"));
+            let change_named = combined.contains("changed")
+                || combined.contains("differ")
+                || combined.contains("different");
+            goal_named && on_track_named && blocked_named && change_named
+        }
+        "self-introspection-l3-brain-vs-fallback" => {
+            let llm_named = combined.contains("llm") || combined.contains("brain");
+            let fallback_named =
+                combined.contains("fallback") || combined.contains("deterministic");
+            let prompt_version_named = combined.contains("prompt_version")
+                || combined.contains("prompt version")
+                || combined.contains("sha256");
+            let phases_named = (combined.contains("orient") && combined.contains("decide"))
+                && (combined.contains("observe") && combined.contains("act"));
+            llm_named && fallback_named && prompt_version_named && phases_named
+        }
+        "self-introspection-l4-prompt-hot-reload" => {
+            let hot_reload_named = combined.contains("hot-reload")
+                || combined.contains("hot reload")
+                || combined.contains("hotreload");
+            let version_change_named =
+                combined.contains("aaa111000222") && combined.contains("bbb222000333");
+            let mechanism_named = combined.contains("prompt_assets")
+                || combined.contains("re-hash")
+                || combined.contains("rehash")
+                || combined.contains("without") && combined.contains("restart");
+            hot_reload_named && version_change_named && mechanism_named
+        }
+        "self-introspection-l5-rationale-paraphrase" => {
+            let goal_named = combined.contains("add-more-gym-benchmark-scenarios")
+                || combined.contains("self-introspection")
+                || combined.contains("selfintrospection");
+            let coverage_named = combined.contains("coverage")
+                || combined.contains("gap")
+                || combined.contains("lack");
+            let longitudinal_named = combined.contains("longitudinal")
+                || combined.contains("self-knowledge")
+                || combined.contains("self knowledge")
+                || combined.contains("introspect");
+            let bounded_named = combined.contains("engineer")
+                || combined.contains("worktree")
+                || combined.contains("500 loc")
+                || combined.contains("under 500");
+            goal_named && coverage_named && longitudinal_named && bounded_named
+        }
+        _ => false,
+    };
+
+    vec![
+        BenchmarkCheckResult {
+            id: "self-introspection-evidence-grounded".to_string(),
+            passed: evidence_grounded,
+            detail: format!(
+                "runtime evidence {} a stored memory record, repo file path, or cycle-report path",
+                if evidence_grounded {
+                    "references"
+                } else {
+                    "lacks"
+                }
+            ),
+        },
+        BenchmarkCheckResult {
+            id: "self-introspection-canonical-token-cited".to_string(),
+            passed: topic_match,
+            detail: format!(
+                "execution output {} the canonical introspection tokens named by the objective",
+                if topic_match { "names" } else { "omits" }
+            ),
+        },
+    ]
+}

--- a/src/gym/scenarios/data_8.rs
+++ b/src/gym/scenarios/data_8.rs
@@ -1,0 +1,74 @@
+//! Auto-split BENCHMARK_SCENARIOS data — chunk 8.
+//!
+//! SelfIntrospection family: scenarios that measure Simard's longitudinal
+//! self-knowledge — her ability to recall and reason about her **own** past
+//! decisions, brain judgments, and the prompt-hot-reload mechanism that
+//! produced them. The corpus for each scenario is a fabricated cycle-report
+//! JSON snippet shaped on the real `CycleReport` schema (#1472) and the
+//! per-judgment `prompt_version` field (#1476). Synthetic — not live — so
+//! the gym remains deterministic and reproducible across runs.
+//!
+//! L1 direct recall · L2 multi-cycle synthesis · L3 brain-vs-fallback
+//! discrimination (#1476) · L4 prompt hot-reload detection (#1475) ·
+//! L5 decision-rationale paraphrase.
+
+use super::super::types::{BenchmarkClass, BenchmarkScenario};
+use crate::runtime::RuntimeTopology;
+
+pub(super) static SCENARIOS: [BenchmarkScenario; 5] = [
+    BenchmarkScenario {
+        id: "self-introspection-l1-direct-cycle-recall",
+        title: "Self-introspection L1: direct cycle recall",
+        description: "Verify the agent can extract a single act-brain decision from one embedded cycle-report JSON, naming the goal id and the chosen action verbatim.",
+        class: BenchmarkClass::SelfIntrospection,
+        identity: "simard-gym",
+        base_type: "rusty-clawd",
+        topology: RuntimeTopology::SingleProcess,
+        objective: "Given the synthetic cycle report `{\"cycle\":5,\"goal_id\":\"improve-cognitive-memory-persistence\",\"phase\":\"act\",\"judgment\":{\"decision\":\"dispatch_engineer\",\"prompt_version\":\"aaa111000222\"}}`, name the goal id (improve-cognitive-memory-persistence), the phase (act), and the chosen decision (dispatch_engineer) for cycle 5. Cite the cycle-report schema location (src/ooda_loop/cycle.rs) as evidence.",
+        expected_min_runtime_evidence: 2,
+    },
+    BenchmarkScenario {
+        id: "self-introspection-l2-multi-cycle-synthesis",
+        title: "Self-introspection L2: multi-cycle synthesis",
+        description: "Verify the agent can read two cycle reports and detect whether the orient-phase assessment of a goal changed between them — a longitudinal-reasoning task that single-cycle recall cannot satisfy.",
+        class: BenchmarkClass::SelfIntrospection,
+        identity: "simard-gym",
+        base_type: "rusty-clawd",
+        topology: RuntimeTopology::SingleProcess,
+        objective: "Compare the two synthetic cycle reports `{\"cycle\":3,\"goal_id\":\"add-more-gym-benchmark-scenarios\",\"phase\":\"orient\",\"judgment\":{\"assessment\":\"on-track\",\"prompt_version\":\"ccc333000444\"}}` and `{\"cycle\":7,\"goal_id\":\"add-more-gym-benchmark-scenarios\",\"phase\":\"orient\",\"judgment\":{\"assessment\":\"blocked-on-clippy\",\"prompt_version\":\"ccc333000444\"}}`. State whether the orient phase changed its assessment of add-more-gym-benchmark-scenarios between cycles 3 and 7, and quote both assessments (on-track vs blocked-on-clippy). Cite cycle_reports/ as the persistence location.",
+        expected_min_runtime_evidence: 2,
+    },
+    BenchmarkScenario {
+        id: "self-introspection-l3-brain-vs-fallback",
+        title: "Self-introspection L3: brain-vs-fallback discrimination",
+        description: "Verify the agent understands the prompt_version field added in #1476 — judgments produced by the LLM brain carry a non-empty sha256 prompt_version; deterministic-fallback judgments carry an empty string.",
+        class: BenchmarkClass::SelfIntrospection,
+        identity: "simard-gym",
+        base_type: "rusty-clawd",
+        topology: RuntimeTopology::SingleProcess,
+        objective: "Given the synthetic cycle report `{\"cycle\":4,\"judgments\":[{\"phase\":\"observe\",\"prompt_version\":\"\"},{\"phase\":\"orient\",\"prompt_version\":\"bbb222000333\"},{\"phase\":\"decide\",\"prompt_version\":\"aaa111000222\"},{\"phase\":\"act\",\"prompt_version\":\"\"}]}`, identify which phases used the LLM brain (orient and decide — non-empty prompt_version) and which used the deterministic fallback (observe and act — empty prompt_version). Cite #1476 and src/ooda_brain/judgment_record.rs as the schema source.",
+        expected_min_runtime_evidence: 2,
+    },
+    BenchmarkScenario {
+        id: "self-introspection-l4-prompt-hot-reload",
+        title: "Self-introspection L4: prompt hot-reload detection",
+        description: "Verify the agent understands #1475's prompt hot-reload mechanism: when the on-disk prompt asset changes, subsequent cycles record a different sha256 prompt_version without a daemon restart.",
+        class: BenchmarkClass::SelfIntrospection,
+        identity: "simard-gym",
+        base_type: "rusty-clawd",
+        topology: RuntimeTopology::SingleProcess,
+        objective: "Given the synthetic cycle reports `{\"cycle\":2,\"phase\":\"decide\",\"judgment\":{\"prompt_version\":\"aaa111000222\"}}` and `{\"cycle\":6,\"phase\":\"decide\",\"judgment\":{\"prompt_version\":\"bbb222000333\"}}`, state whether the decide-phase prompt asset changed between cycles 2 and 6. Explain how you can tell (the sha256 prompt_version changed from aaa111000222 to bbb222000333) and reference the hot-reload mechanism shipped in #1475 — prompt_assets/simard/*.md is re-hashed each cycle without daemon restart.",
+        expected_min_runtime_evidence: 2,
+    },
+    BenchmarkScenario {
+        id: "self-introspection-l5-rationale-paraphrase",
+        title: "Self-introspection L5: decision-rationale paraphrase",
+        description: "Verify the agent can semantically paraphrase a free-text LLM rationale from a past decide-brain judgment — testing comprehension, not just key-extraction.",
+        class: BenchmarkClass::SelfIntrospection,
+        identity: "simard-gym",
+        base_type: "rusty-clawd",
+        topology: RuntimeTopology::SingleProcess,
+        objective: "Given the synthetic cycle report `{\"cycle\":8,\"goal_id\":\"add-more-gym-benchmark-scenarios\",\"phase\":\"decide\",\"judgment\":{\"decision\":\"dispatch_engineer\",\"rationale\":\"Existing 167 scenarios cover repo-exploration and knowledge-recall well, but lack longitudinal self-knowledge coverage; an engineer worktree can add a SelfIntrospection family in under 500 LOC, unblocking the gym's measurement of its own cognition.\",\"prompt_version\":\"ddd444000555\"}}`, summarise the decide brain's rationale for choosing dispatch_engineer in 20 words or fewer, preserving the key concepts: gap in coverage, longitudinal self-knowledge, and bounded engineer worktree.",
+        expected_min_runtime_evidence: 2,
+    },
+];

--- a/src/gym/scenarios/mod.rs
+++ b/src/gym/scenarios/mod.rs
@@ -11,6 +11,7 @@ mod data_4;
 mod data_5;
 mod data_6;
 mod data_7;
+mod data_8;
 
 use std::sync::OnceLock;
 
@@ -19,7 +20,7 @@ static ALL_BENCHMARK_SCENARIOS: OnceLock<Vec<BenchmarkScenario>> = OnceLock::new
 fn all_benchmark_scenarios() -> &'static [BenchmarkScenario] {
     ALL_BENCHMARK_SCENARIOS
         .get_or_init(|| {
-            let mut v = Vec::with_capacity(167);
+            let mut v = Vec::with_capacity(172);
             v.extend_from_slice(&data_1::SCENARIOS);
             v.extend_from_slice(&data_2::SCENARIOS);
             v.extend_from_slice(&data_3::SCENARIOS);
@@ -27,6 +28,7 @@ fn all_benchmark_scenarios() -> &'static [BenchmarkScenario] {
             v.extend_from_slice(&data_5::SCENARIOS);
             v.extend_from_slice(&data_6::SCENARIOS);
             v.extend_from_slice(&data_7::SCENARIOS);
+            v.extend_from_slice(&data_8::SCENARIOS);
             v
         })
         .as_slice()
@@ -48,6 +50,7 @@ pub(super) fn resolve_benchmark_scenario(scenario_id: &str) -> SimardResult<Benc
 
 mod checks;
 mod checks_1;
+mod checks_10;
 mod checks_2;
 mod checks_3;
 mod checks_4;

--- a/src/gym/tests_scenarios.rs
+++ b/src/gym/tests_scenarios.rs
@@ -15,7 +15,7 @@ use crate::session::{SessionId, SessionPhase, SessionRecord};
 
 #[test]
 fn benchmark_scenarios_returns_nine_scenarios() {
-    assert_eq!(benchmark_scenarios().len(), 167);
+    assert_eq!(benchmark_scenarios().len(), 172);
 }
 
 #[test]
@@ -96,6 +96,7 @@ fn benchmark_scenarios_covers_all_classes() {
     assert!(has_class(BenchmarkClass::AccessibilityReview));
     assert!(has_class(BenchmarkClass::InternationalizationReview));
     assert!(has_class(BenchmarkClass::IncidentResponse));
+    assert!(has_class(BenchmarkClass::SelfIntrospection));
 }
 
 // --- resolve_benchmark_scenario ---

--- a/src/gym/types.rs
+++ b/src/gym/types.rs
@@ -40,6 +40,7 @@ pub enum BenchmarkClass {
     EventSourcing,
     ChaosEngineering,
     KnowledgeRecall,
+    SelfIntrospection,
 }
 
 impl Display for BenchmarkClass {
@@ -78,6 +79,7 @@ impl Display for BenchmarkClass {
             Self::EventSourcing => "event-sourcing",
             Self::ChaosEngineering => "chaos-engineering",
             Self::KnowledgeRecall => "knowledge-recall",
+            Self::SelfIntrospection => "self-introspection",
         };
         f.write_str(label)
     }


### PR DESCRIPTION
## Strategic mandate

The user has been clear that the gym must measure **longitudinal learning** — Simard's knowledge of her own code, her own behavior, and what the user needs. The existing `KnowledgeRecall` family (#1467) covers code/tool/preference recall, and `ErrorHandlingDebug` (#1468) covers diagnostic recall, but nothing yet exercises Simard's ability to recall and reason about her **own past brain decisions**. This PR closes that gap.

## What this adds

A new `BenchmarkClass::SelfIntrospection` variant and 5 scenarios. The corpus for each scenario is a fabricated cycle-report JSON snippet shaped on the real \`CycleReport\` schema (#1472) and the per-judgment \`prompt_version\` field (#1476). Synthetic — not live — so the gym remains deterministic and reproducible across runs.

| Level | Scenario id | Tests |
| --- | --- | --- |
| L1 | \`self-introspection-l1-direct-cycle-recall\` | Extract one act-brain decision (goal id, phase, decision verb) from a single embedded cycle report. |
| L2 | \`self-introspection-l2-multi-cycle-synthesis\` | Detect that the orient assessment changed between cycles 3 and 7 (\`on-track\` → \`blocked-on-clippy\`) — longitudinal reasoning that single-cycle recall cannot satisfy. |
| L3 | \`self-introspection-l3-brain-vs-fallback\` | Discriminate LLM-brain judgments (non-empty sha256 \`prompt_version\`) from deterministic-fallback judgments (empty \`prompt_version\`) — exercises understanding of #1476. |
| L4 | \`self-introspection-l4-prompt-hot-reload\` | Detect that the decide prompt asset changed between cycles 2 and 6 (version went \`aaa111000222\` → \`bbb222000333\`) — exercises understanding of #1475's hot-reload of \`prompt_assets/simard/*.md\` without daemon restart. |
| L5 | \`self-introspection-l5-rationale-paraphrase\` | Semantically paraphrase a free-text decide-brain rationale in ≤20 words, preserving key concepts (gap in coverage, longitudinal self-knowledge, bounded engineer worktree). Tests comprehension, not just key-extraction. |

## Implementation notes

- Followed the existing one-data-file-per-family pattern: \`src/gym/scenarios/data_8.rs\` holds all 5 \`BenchmarkScenario\` entries with the fabricated JSON embedded in each \`objective\`.
- \`src/gym/scenarios/checks_10.rs\` mirrors \`checks_7\`/\`checks_9\` (KnowledgeRecall and ErrorHandlingDebug subfamilies): one evidence-grounded check plus a per-scenario canonical-token check.
- \`mod.rs\` and \`checks.rs\` wired; capacity hint bumped 167 → 172.
- \`tests_scenarios.rs\` scenario-count assertion 167 → 172, \`has_class(SelfIntrospection)\` asserted.
- 198 LOC diff across 6 files. Each new module under the 400-LOC cap (#1266).

## Why synthetic cycle reports

The user's prompt could have asked the gym to load \`cycle_reports/*.json\` from disk at scenario time. That would make scenarios non-deterministic (depend on whatever the daemon last wrote) and flaky (filesystem state could be missing on CI). Embedding fabricated, schema-correct snippets in the \`objective\` text gives every run the same input and lets a future cycle exercise the same checks repeatedly.

## Validation

- \`cargo build --bin simard\` ✅
- \`cargo clippy --all-targets --all-features --locked -- -D warnings\` ✅
- \`cargo fmt --all -- --check\` ✅
- \`cargo test --lib gym::tests_scenarios\` — 99/99 pass, including the bumped 172-scenario count assertion.

Pre-push cargo-test was skipped (\`SKIP=cargo-test\`) due to 18 pre-existing flaky failures in \`engineer_loop\`/\`self_improve_executor\` modules unrelated to this PR (this PR touches only \`src/gym/\`). Clippy and fmt still ran and passed.