### PR TITLE
refactor(ooda): use serde_json::to_value for cycle report persistence

### DIFF
--- a/src/operator_commands_ooda/persistence.rs
+++ b/src/operator_commands_ooda/persistence.rs
@@ -74,29 +74,25 @@ pub(super) fn persist_cycle_report(
                 }
             entry
         }).collect::<Vec<_>>(),
+        // BrainJudgmentRecord is a flat data carrier whose external JSON
+        // shape is governed entirely by its `Serialize` derive (including
+        // `#[serde(skip_serializing_if = "String::is_empty")]` on
+        // `prompt_version`). Defer to `serde_json::to_value` so the auto-
+        // derive is the single source of truth — adding a new field to
+        // the struct then forgetting to mirror it here is exactly the
+        // divergence-class bug PR #1480 had to repair.
+        //
+        // The other sub-structs (observation, outcomes, …) are NOT pure
+        // 1:1 mappings — they intentionally project / summarise (counts
+        // vs full lists, derived `summary`, `kind.to_string()`-style
+        // labels, the `spawn_engineer` enrichment block) and so stay
+        // hand-rolled by design.
+        //
+        // `BrainJudgmentRecord` only carries primitives + a small enum
+        // and so cannot fail to serialise; the `unwrap_or` keeps the
+        // best-effort write contract of this function.
         "brain_judgments": report.brain_judgments.iter().map(|j| {
-            let mut entry = json!({
-                "phase": j.phase,
-                "context_summary": j.context_summary,
-                "decision": j.decision,
-                "rationale": j.rationale,
-                "confidence": j.confidence,
-                "fallback": j.fallback,
-            });
-            // PR #1476 added `prompt_version` to BrainJudgmentRecord but the
-            // manual json! mapping here was missed, silently dropping the
-            // field on every persisted cycle report. Restore it (and skip
-            // when empty so deterministic-fallback judgments — and pre-#1476
-            // call sites — stay clean).
-            if !j.prompt_version.is_empty()
-                && let Some(map) = entry.as_object_mut()
-            {
-                map.insert(
-                    "prompt_version".to_string(),
-                    serde_json::Value::String(j.prompt_version.clone()),
-                );
-            }
-            entry
+            serde_json::to_value(j).unwrap_or(serde_json::Value::Null)
         }).collect::<Vec<_>>(),
     });
 

--- a/src/operator_commands_ooda/tests/persistence_tests.rs
+++ b/src/operator_commands_ooda/tests/persistence_tests.rs
@@ -131,3 +131,75 @@ fn persist_cycle_report_multiple_cycles_coexist() {
     }
     let _ = std::fs::remove_dir_all(&scratch);
 }
+
+#[test]
+fn persist_cycle_report_uses_serde_derive_for_all_fields() {
+    // Regression for the divergence-class bug fixed in PR #1480: the
+    // hand-rolled brain_judgments mapping in `persist_cycle_report`
+    // silently dropped any field added to `BrainJudgmentRecord` (e.g.
+    // PR #1476's `prompt_version`). Persisting via
+    // `serde_json::to_value(&record)` makes the struct's `Serialize`
+    // derive the single source of truth — assert that here so any future
+    // field addition is caught by `cargo test` instead of going missing
+    // from cycle reports for days.
+    use crate::ooda_brain::{BrainJudgmentRecord, BrainPhase};
+
+    let record = BrainJudgmentRecord {
+        phase: BrainPhase::Decide,
+        context_summary: "goal_id=ship-v1 urgency=0.900".to_string(),
+        decision: "advance_goal".to_string(),
+        rationale: "high priority".to_string(),
+        confidence: 0.95,
+        fallback: false,
+        prompt_version: "abc123def456".to_string(),
+    };
+
+    let scratch = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("target")
+        .join("test-scratch")
+        .join(format!("ooda-serde-derive-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&scratch);
+
+    let mut report = make_test_report(77);
+    report.brain_judgments.push(record.clone());
+    persist_cycle_report(&scratch, &report);
+
+    let content =
+        std::fs::read_to_string(scratch.join("cycle_reports").join("cycle_77.json")).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+    let persisted = parsed["brain_judgments"]
+        .as_array()
+        .and_then(|a| a.first())
+        .and_then(|v| v.as_object())
+        .expect("brain_judgments[0] must be a JSON object");
+
+    // (a) Round-trip: every populated field of the input record appears in
+    //     the persisted JSON with its original value.
+    assert_eq!(persisted["phase"], "decide");
+    assert_eq!(persisted["context_summary"], record.context_summary);
+    assert_eq!(persisted["decision"], record.decision);
+    assert_eq!(persisted["rationale"], record.rationale);
+    assert_eq!(persisted["confidence"], record.confidence);
+    assert_eq!(persisted["fallback"], record.fallback);
+    assert_eq!(persisted["prompt_version"], record.prompt_version);
+
+    // (b) Key-set equality with the struct's own Serialize derive: if
+    //     anyone adds a new field to BrainJudgmentRecord, this assertion
+    //     fires immediately instead of letting the field be silently
+    //     dropped from cycle reports (cf. PR #1480).
+    let expected: std::collections::BTreeSet<String> = serde_json::to_value(&record)
+        .unwrap()
+        .as_object()
+        .unwrap()
+        .keys()
+        .cloned()
+        .collect();
+    let actual: std::collections::BTreeSet<String> = persisted.keys().cloned().collect();
+    assert_eq!(
+        actual, expected,
+        "persisted brain_judgments[0] keys must match the struct's Serialize derive output \
+         (divergence-class bug fixed in PR #1480 — keep auto-derive as source of truth)"
+    );
+
+    let _ = std::fs::remove_dir_all(&scratch);
+}


### PR DESCRIPTION
## Why


This is a **divergence-class footgun**: any field added to a struct that is also re-mapped by hand will be silently dropped from cycle reports until somebody audits the JSON. Fix the *class*, not the instance.

## What

- The other sub-structs (`observation`, `outcomes`, …) are **not** pure 1:1 mappings — they intentionally project / summarise (counts vs full lists, derived `summary`, `kind.to_string()`-style labels, the `spawn_engineer` enrichment block). They stay hand-rolled by design and a comment now documents that intent next to the change so future readers know which sub-mappings are deliberate vs accidental.
- Add regression test `persist_cycle_report_uses_serde_derive_for_all_fields` (in `tests/persistence_tests.rs`):
  - Constructs a populated `BrainJudgmentRecord` with `prompt_version: "abc123def456"`.
  - Round-trips it through `persist_cycle_report` → file → parse-back and asserts every input field appears in the persisted JSON with its original value.
  - Asserts `persisted.keys() == serde_json::to_value(&record).unwrap().as_object().unwrap().keys()` — so any future field added to `BrainJudgmentRecord` will trip a **red test** instead of silently going missing from cycle reports for days.

## Verification

- `cargo build --lib` ✅
- `cargo test --lib operator_commands_ooda::persistence` → 14/14 pass
- `cargo test --lib operator_commands_ooda::tests::persistence_tests` → 8/8 pass (incl. new test)
- `cargo clippy --all-targets --all-features --locked -- -D warnings` ✅
- `cargo fmt` clean
- Pre-push: clippy + fmt ran via pre-push hooks; `SKIP=cargo-test` per project convention (17 pre-existing flakes unrelated to this work).

## Scope

- Files changed: 2
  - `src/operator_commands_ooda/persistence.rs` (461 → 457 LOC)
  - `src/operator_commands_ooda/tests/persistence_tests.rs` (133 → 205 LOC)
- Diff: `+90 / -22` (well under 150 LOC budget)

## Motivating reference

Cites PR #1480 (sha b98d042) as the exact instance this refactor turns into a class-level fix.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>