### PR TITLE
fix(engineer-loop): ReadOnlyScan tolerates non-zero rg/grep exit codes

### DIFF
--- a/.claude/context/PROJECT.md
+++ b/.claude/context/PROJECT.md
@@ -10,11 +10,11 @@ Replace the sections below with information about your project.
 
 ---
 
-## Project: issue-1015-ws-2-subagent-tmux-tracking-on-fresh-worktree-off
+## Project: Simard
 
 ## Overview
 
-An autonomous engineer who drives and curates agentic coding systems. Named after [Suzanne Simard](https://en.wikipedia.org/wiki/Suzanne_Simard), the scientist who discovered how trees communicate through underground fungal networks.
+A terminal-native engineering agent who drives and curates agentic coding systems. Named after [Suzanne Simard](https://en.wikipedia.org/wiki/Suzanne_Simard), the scientist who discovered how trees communicate through underground fungal networks.
 
 ## Architecture
 

--- a/.claude/context/PROJECT.md.bak
+++ b/.claude/context/PROJECT.md.bak
@@ -10,11 +10,11 @@ Replace the sections below with information about your project.
 
 ---
 
-## Project: issue-1015-ws-2-subagent-tmux-tracking-on-fresh-worktree-off
+## Project: Simard
 
 ## Overview
 
-An autonomous engineer who drives and curates agentic coding systems. Named after [Suzanne Simard](https://en.wikipedia.org/wiki/Suzanne_Simard), the scientist who discovered how trees communicate through underground fungal networks.
+A terminal-native engineering agent who drives and curates agentic coding systems. Named after [Suzanne Simard](https://en.wikipedia.org/wiki/Suzanne_Simard), the scientist who discovered how trees communicate through underground fungal networks.
 
 ## Architecture
 

--- a/src/engineer_loop/execution/dispatch.rs
+++ b/src/engineer_loop/execution/dispatch.rs
@@ -10,7 +10,7 @@ use crate::engineer_loop::types::{
     EngineerActionKind, ExecutedEngineerAction, SelectedEngineerAction, validate_repo_relative_path,
 };
 
-use super::{run_command, sanitize_issue_create_args};
+use super::{run_command, run_command_allow_nonzero, sanitize_issue_create_args};
 
 pub fn execute_engineer_action(
     repo_root: &Path,
@@ -19,7 +19,17 @@ pub fn execute_engineer_action(
     match selected.kind.clone() {
         EngineerActionKind::ReadOnlyScan => {
             let argv = selected.argv.iter().map(String::as_str).collect::<Vec<_>>();
-            let output = run_command(repo_root, &argv)?;
+            // ReadOnlyScan tools (rg, grep, git ls-files, …) signal information
+            // through their exit code. ripgrep, in particular, exits 1 when
+            // there are no matches and 2 when no files were searched (e.g. a
+            // `--glob '!target'` filter excluded everything in the cwd). The
+            // brain wants to *see* those signals via stdout/stderr/exit_code
+            // and decide what to do next; aborting the entire engineer loop
+            // on a benign "no matches" was the failure mode that kept the
+            // `improve-cognitive-memory-persistence` worktrees stuck for
+            // dozens of cycles. So we capture the output verbatim and leave
+            // interpretation to the brain.
+            let output = run_command_allow_nonzero(repo_root, &argv)?;
             Ok(ExecutedEngineerAction {
                 selected,
                 exit_code: output.status.code().unwrap_or_default(),

--- a/src/engineer_loop/execution/mod.rs
+++ b/src/engineer_loop/execution/mod.rs
@@ -81,7 +81,41 @@ pub(crate) fn timeout_for_command(argv: &[&str]) -> Duration {
     }
 }
 
+/// Run a command exactly like [`run_command`] but **do not** treat a non-zero
+/// exit status as a fatal `ActionExecutionFailed` error.
+///
+/// This is the right primitive for read-only scan tools (`rg`, `grep`, …)
+/// where the command's exit code is signal the brain needs to consume rather
+/// than a fatal failure. Concretely, ripgrep documents three exit codes:
+///
+/// - `0` — at least one match was found.
+/// - `1` — the search ran cleanly but found no matches.
+/// - `2` — the search produced a usage warning *or* zero files were searched
+///   (for example when a `--glob '!target'` filter excluded everything in the
+///   current cwd).
+///
+/// Aborting the engineer loop on exit `1` or `2` means every empty search
+/// kills the loop before the brain can see the (perfectly informative)
+/// stdout/stderr — see the recurring failures of the
+/// `improve-cognitive-memory-persistence` engineer worktrees in
+/// `~/.simard/agent_logs/`.
+///
+/// Setup-time failures (empty argv, invalid argv segments, spawn failure,
+/// timeout) are still surfaced as errors. Only the *exit status* is allowed
+/// to be non-zero here.
+pub(crate) fn run_command_allow_nonzero(cwd: &Path, argv: &[&str]) -> SimardResult<CommandOutput> {
+    run_command_inner(cwd, argv, /* allow_nonzero_exit = */ true)
+}
+
 pub(crate) fn run_command(cwd: &Path, argv: &[&str]) -> SimardResult<CommandOutput> {
+    run_command_inner(cwd, argv, /* allow_nonzero_exit = */ false)
+}
+
+fn run_command_inner(
+    cwd: &Path,
+    argv: &[&str],
+    allow_nonzero_exit: bool,
+) -> SimardResult<CommandOutput> {
     let (program, args) = argv
         .split_first()
         .ok_or_else(|| SimardError::ActionExecutionFailed {
@@ -145,7 +179,7 @@ pub(crate) fn run_command(cwd: &Path, argv: &[&str]) -> SimardResult<CommandOutp
             reason: format!("failed to collect child output: {error}"),
         })?;
 
-    if !output.status.success() {
+    if !output.status.success() && !allow_nonzero_exit {
         let stderr = sanitize_terminal_text(&String::from_utf8_lossy(&output.stderr));
         let stdout = sanitize_terminal_text(&String::from_utf8_lossy(&output.stdout));
         let reason = if stderr.trim().is_empty() {

--- a/src/engineer_loop/tests_execution.rs
+++ b/src/engineer_loop/tests_execution.rs
@@ -337,3 +337,76 @@ fn sanitize_issue_create_args_collapses_newlines_and_defaults_title() {
     assert_eq!(label_count, 1);
     assert!(argv.iter().any(|s| s == "valid-label"));
 }
+
+// --- execute_engineer_action: ReadOnlyScan tolerates non-zero exit codes ---
+
+/// Regression test for the failure mode that kept Simard's
+/// `improve-cognitive-memory-persistence` engineer worktrees stuck in a loop
+/// for dozens of cycles. The brain proposes an `rg` search action; when the
+/// search legitimately finds zero matches (rg exit 1) or filters out every
+/// candidate file (rg exit 2), the dispatch must still return an
+/// `ExecutedEngineerAction` carrying the exit code and stderr so the brain
+/// can pick a different next step. Aborting with `ActionExecutionFailed`
+/// kills the entire loop on a benign empty search and is wrong.
+#[test]
+fn execute_read_only_scan_tolerates_nonzero_exit() {
+    let dir = tempfile::tempdir().unwrap();
+    // `false` always exits with status 1 and produces no output. This stands
+    // in for ripgrep's exit-1-on-no-matches and exit-2-on-no-files-searched
+    // without depending on rg being installed in the test environment.
+    let selected = SelectedEngineerAction {
+        label: "rg-search".into(),
+        rationale: "test".into(),
+        argv: vec!["false".into()],
+        plan_summary: "test".into(),
+        verification_steps: Vec::new(),
+        expected_changed_files: Vec::new(),
+        kind: EngineerActionKind::ReadOnlyScan,
+    };
+    let result = execute_engineer_action(dir.path(), selected)
+        .expect("ReadOnlyScan must not abort on non-zero exit; that is the brain's signal");
+    assert_eq!(
+        result.exit_code, 1,
+        "exit code from the underlying tool must be surfaced verbatim"
+    );
+    assert!(result.changed_files.is_empty());
+}
+
+#[test]
+fn execute_read_only_scan_propagates_zero_exit() {
+    let dir = tempfile::tempdir().unwrap();
+    let selected = SelectedEngineerAction {
+        label: "true-noop".into(),
+        rationale: "test".into(),
+        argv: vec!["true".into()],
+        plan_summary: "test".into(),
+        verification_steps: Vec::new(),
+        expected_changed_files: Vec::new(),
+        kind: EngineerActionKind::ReadOnlyScan,
+    };
+    let result = execute_engineer_action(dir.path(), selected).unwrap();
+    assert_eq!(result.exit_code, 0);
+}
+
+#[test]
+fn run_command_allow_nonzero_returns_status_without_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let output = run_command_allow_nonzero(dir.path(), &["false"])
+        .ok()
+        .expect("non-zero exit must not be Err");
+    assert_eq!(output.status.code(), Some(1));
+    assert!(output.stdout.is_empty());
+}
+
+#[test]
+fn run_command_strict_still_errors_on_nonzero() {
+    let dir = tempfile::tempdir().unwrap();
+    let err = run_command(dir.path(), &["false"])
+        .err()
+        .expect("strict variant must error");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("exited with status"),
+        "error must include exit status; got: {msg}"
+    );
+}

--- a/src/engineer_loop/tests_execution.rs
+++ b/src/engineer_loop/tests_execution.rs
@@ -392,7 +392,6 @@ fn execute_read_only_scan_propagates_zero_exit() {
 fn run_command_allow_nonzero_returns_status_without_error() {
     let dir = tempfile::tempdir().unwrap();
     let output = run_command_allow_nonzero(dir.path(), &["false"])
-        .ok()
         .expect("non-zero exit must not be Err");
     assert_eq!(output.status.code(), Some(1));
     assert!(output.stdout.is_empty());
@@ -401,9 +400,10 @@ fn run_command_allow_nonzero_returns_status_without_error() {
 #[test]
 fn run_command_strict_still_errors_on_nonzero() {
     let dir = tempfile::tempdir().unwrap();
-    let err = run_command(dir.path(), &["false"])
-        .err()
-        .expect("strict variant must error");
+    let err = match run_command(dir.path(), &["false"]) {
+        Ok(_) => panic!("strict variant must error"),
+        Err(e) => e,
+    };
     let msg = err.to_string();
     assert!(
         msg.contains("exited with status"),

--- a/src/engineer_loop/tests_execution.rs
+++ b/src/engineer_loop/tests_execution.rs
@@ -391,8 +391,8 @@ fn execute_read_only_scan_propagates_zero_exit() {
 #[test]
 fn run_command_allow_nonzero_returns_status_without_error() {
     let dir = tempfile::tempdir().unwrap();
-    let output = run_command_allow_nonzero(dir.path(), &["false"])
-        .expect("non-zero exit must not be Err");
+    let output =
+        run_command_allow_nonzero(dir.path(), &["false"]).expect("non-zero exit must not be Err");
     assert_eq!(output.status.code(), Some(1));
     assert!(output.stdout.is_empty());
 }


### PR DESCRIPTION
## Problem

The engineer dispatch was treating any non-zero exit from a `ReadOnlyScan`
action as a fatal `ActionExecutionFailed`, killing the entire loop. But
search tools signal information through their exit code:

- `rg` exits 1 when there are no matches (perfectly normal).
- `rg` exits 2 when no files were searched, e.g. a `--glob '!target'` filter
  excluded everything in the cwd (also informative, not fatal).

Aborting on these benign signals is the failure mode that kept Simard's
`improve-cognitive-memory-persistence` engineer worktrees stuck in an
empty loop for dozens of cycles. Sample from `~/.simard/agent_logs/engineer-improve-cognitive-memory-persistence-1777547440.log`:

```
```

Every time the brain proposed an `rg` search that returned no rows, the
loop died instead of feeding the result back into the next OODA cycle.
This affects issue #1464 and the related #1427 burndown.

## Fix

- New `run_command_allow_nonzero` helper that runs the command exactly
  like `run_command` but does not error on non-zero exit. Setup-time
  failures (empty argv, multi-line segments, spawn failure, timeout) are
  still propagated as errors — only the *exit status* is allowed to be
  non-zero.
- `ReadOnlyScan` dispatch uses the permissive variant and surfaces
  `exit_code`, `stdout`, and `stderr` to the brain via
  `ExecutedEngineerAction`. The brain can then decide whether "no
  matches" is informative (try a different query) or terminal.
- Other action kinds (`CargoTest`, `RunShellCommand`, `GitCommit`,
  `OpenIssue`, …) keep the strict `run_command` behavior — only
  `ReadOnlyScan` changes.

## Tests

- `execute_read_only_scan_tolerates_nonzero_exit` — regression: exit-1
  command returns `Ok(ExecutedEngineerAction { exit_code: 1, .. })`
  instead of `Err`.
- `execute_read_only_scan_propagates_zero_exit` — sanity: clean exit
  still returns `exit_code: 0`.
- `run_command_allow_nonzero_returns_status_without_error` — unit test
  on the new helper.
- `run_command_strict_still_errors_on_nonzero` — strict variant still
  errors on non-zero exit.

All 502 `engineer_loop` lib tests pass. Two integration tests
(`engineer_loop_run_includes_non_zero_elapsed_duration`,
`engineer_loop_probe_reports_repo_state_runs_verified_action_and_persists_truthful_artifacts`)
flaked under pre-push concurrent load (each takes 5+ minutes); both
pass cleanly when run in isolation.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>