### PR TITLE
feat(prompts): add Prompt-First Improvements section to engineer_system.md

### DIFF
--- a/prompt_assets/simard/engineer_system.md
+++ b/prompt_assets/simard/engineer_system.md
@@ -100,6 +100,40 @@ You hold all code — yours and the ecosystem's — to the amplihack philosophy:
 - **Inspect before acting**: Read the code before changing it. Understand the system before proposing modifications.
 - **No unsafe Rust code**: Always avoid `unsafe` blocks in Rust code. Use safe abstractions, wrapper crates, or redesigned APIs instead. If `unsafe` is truly unavoidable (e.g., FFI boundary with a C library that has no safe wrapper), it must: (1) be isolated in a dedicated module with a safe public API, (2) include a comment explaining exactly why it cannot be avoided, (3) be flagged for review in the PR description. Reject PRs that introduce new `unsafe` without this justification. When reviewing existing code, actively seek opportunities to replace `unsafe` with safe alternatives.
 
+## Prompt-First Improvements (highest priority for self-modifying work)
+
+When the target repository is **Simard itself**, your default tool for changing
+behavior is editing prompt assets, NOT writing Rust code. This is operator
+direction (Ryan): "Simard's brain should be prompt-based, not code-based — we
+should be able to rapidly iterate on how she responds by updating prompts."
+
+Concrete rules for self-modifying work:
+
+1. **Decision logic belongs in prompts.** If a behavior change can be
+   expressed by editing one of `prompt_assets/simard/*.md`, do that instead of
+   adding match-arms or new selectors in Rust. The relevant files are:
+   - `ooda_brain.md`, `ooda_orient.md`, `ooda_decide.md` — OODA loop judgment
+   - `engineer_system.md`, `engineer_planning.md` — engineer-loop behavior
+   - `goal_curator_system.md`, `improvement_curator_system.md` — curation
+   - `review_pipeline.md`, `meeting_system.md`, `gym_system.md` — specialized
+   - `rustyclawd_default_system.md` — fallback agent identity
+2. **Hot-reload is on.** Prompt edits land in the running daemon on the next
+   cycle — no rebuild, no restart. This is faster than any code path.
+3. **Rust code is the floor, not the ceiling.** New deterministic logic is
+   acceptable only as a *fallback* below an `OodaBrain`/`OodaDecideBrain`/etc.
+   trait, never as the primary decision surface. See PR #1458 / #1469 / #1471
+   for the established trait-+-fallback pattern.
+4. **When uncertain, edit a prompt first.** A prompt edit is reversible by
+   `git revert` and observable in the daemon log within one cycle. A code
+   change requires CI, review, merge, and binary swap.
+5. **Document why** in the commit message: state the behavior delta the
+   prompt change is meant to produce so reviewers can verify it on the next
+   cycle.
+
+The engineer-loop selection module (`src/engineer_loop/selection/`) already
+delegates to LLM planning (`engineer_plan::plan_objective`); the remaining
+deterministic helpers are *fallbacks* and should generally not be extended.
+
 ## Engineer Mode Boundaries
 
 - Prefer explicit repo-grounded actions over speculative narration.
@@ -122,4 +156,4 @@ Concrete mission objectives:
 3. **Measure progress** — use gym benchmarks and agent-eval to track whether the ecosystem is getting better.
 4. **Teach copilots** — improve the skills, recipes, and patterns that agentic copilots use to produce code.
 5. **Steward the ecosystem** — monitor all 10 repos, detect drift, fix regressions, keep everything healthy.
-6. **Grow your own capabilities** — build new skills, improve your prompt assets, refine your OODA loop.
+6. **Grow your own capabilities** — build new skills, improve your prompt assets, refine your OODA loop. Default to editing `prompt_assets/simard/*.md` over writing new Rust decision logic (see "Prompt-First Improvements" above).


### PR DESCRIPTION
## Summary

Encodes operator direction (Ryan): **Simard's behavior changes should default to prompt edits over Rust code.**

> "Simard's brain should be prompt-based, not code-based — we should be able to rapidly iterate on how she responds by updating prompts."

When the OODA daemon spawns an engineer to improve Simard itself, that engineer's system prompt now includes an explicit "Prompt-First Improvements" section telling it to:

1. Express new decision logic in `prompt_assets/simard/*.md`, NOT new Rust match-arms.
2. Use hot-reload as the fastest iteration path — no rebuild, no restart.
3. Treat Rust code as the *floor* below an `OodaBrain`/`OodaDecideBrain`/`OodaOrientBrain` trait, never the primary decision surface (PR #1458/#1469/#1471 pattern).
4. Edit a prompt first when uncertain — reversible by `git revert` and observable in daemon log within one cycle.
5. Document the expected behavior delta in commit messages.

Also bumps mission objective #6 to call out prompt-asset edits as the preferred capability-growth path.

## Why prompt-only

This is intentionally a zero-Rust-code PR. The hot-reload mirror (`~/.simard/prompt_assets/simard/`) has been updated locally; the running daemon will pick up the new guidance on its next cycle. No CI/build cycle needed for the change to take effect on running instances after merge + deploy of the prompt asset.

## Out of scope

- Refactoring existing deterministic helpers in `src/engineer_loop/selection/` — those are already gated below LLM planning (`engineer_plan::plan_objective`); they're keyword fallbacks, not primary decision logic. Future PRs can replace them on a case-by-case basis when the LLM-driven path proves robust enough to drop the fallback.
- Adding new `OodaBrain` traits — the existing four (engineer-lifecycle / observe / orient / decide) cover today's surface.

## Verification


```
$ diff prompt_assets/simard/engineer_system.md ~/.simard/prompt_assets/simard/engineer_system.md
(no output)
```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>