### PR TITLE
fix(meeting): use -p flag for non-interactive copilot execution (#1488)

### DIFF
--- a/src/base_type_copilot/mod.rs
+++ b/src/base_type_copilot/mod.rs
@@ -277,11 +277,11 @@ impl BaseTypeSession for CopilotSdkSession {
 /// Build a terminal-session-compatible objective string that launches the
 /// copilot command with the enriched prompt.
 ///
-/// Strategy: write the prompt to a temp file, run `<copilot-cmd> -p @file`,
-/// then `exit` the shell.  The terminal infrastructure calls `finish()` which
-/// waits for the process to exit naturally — no artificial timeouts.  The
-/// copilot runs to completion however long it takes, and we read the full
-/// transcript afterward.
+/// Strategy: write the prompt to a temp file, run `<copilot-cmd> -p "$(cat file)"`
+/// in non-interactive mode with `--allow-all-tools`, then `exit` the shell.
+/// The terminal infrastructure calls `finish()` which waits for the process
+/// to exit naturally.  The copilot runs to completion however long it takes,
+/// and we read the full transcript afterward.
 pub(super) fn build_copilot_terminal_objective(
     config: &CopilotAdapterConfig,
     formatted_prompt: &str,
@@ -292,9 +292,11 @@ pub(super) fn build_copilot_terminal_objective(
         objective.push_str(&format!("working-directory: {cwd}\n"));
     }
 
-    // Write the prompt to a temp file and pipe it via stdin to the copilot
-    // command. Using stdin avoids `-p` flag incompatibility between the Python
-    // and Rust versions of amplihack. The `--subprocess-safe` flag skips
+    // Write the prompt to a temp file and pass it to the copilot command via
+    // `-p "$(cat file)"` for non-interactive execution. The copilot CLI does
+    // NOT read prompts from piped stdin in interactive mode — it requires the
+    // `-p` flag for scripted/non-interactive usage. `--allow-all-tools` is
+    // required by copilot for non-interactive mode. `--subprocess-safe` skips
     // interactive staging/env updates. Chain with `exit` so the shell exits
     // after the copilot finishes.
     let escaped = formatted_prompt
@@ -303,7 +305,7 @@ pub(super) fn build_copilot_terminal_objective(
     objective.push_str(&format!(
         "command: SIMARD_PROMPT_FILE=$(mktemp /tmp/simard-copilot-prompt.XXXXXX) && \
          printf '%s' '{}' > \"$SIMARD_PROMPT_FILE\" && \
-         cat \"$SIMARD_PROMPT_FILE\" | {} --subprocess-safe ; \
+         {} --subprocess-safe -p \"$(cat \"$SIMARD_PROMPT_FILE\")\" --allow-all-tools ; \
          rm -f \"$SIMARD_PROMPT_FILE\" ; exit\n",
         escaped, config.command,
     ));

--- a/src/tests_base_type_copilot.rs
+++ b/src/tests_base_type_copilot.rs
@@ -98,6 +98,14 @@ fn build_copilot_objective_includes_command_and_exit() {
         "objective must chain exit to end the shell naturally"
     );
     assert!(
+        objective.contains("-p"),
+        "must use -p flag for non-interactive copilot execution"
+    );
+    assert!(
+        objective.contains("--allow-all-tools"),
+        "must include --allow-all-tools for non-interactive mode"
+    );
+    assert!(
         !objective.contains("wait-for:"),
         "no wait-for — process exits naturally"
     );


### PR DESCRIPTION
## Problem

The meeting REPL hangs indefinitely when sending messages (issue #1488).

## Root Cause

`build_copilot_terminal_objective()` was using `cat file | amplihack copilot --subprocess-safe` to pipe the prompt via stdin. However, the Copilot CLI **does not read prompts from piped stdin in interactive mode** — it starts its own REPL and waits for terminal input, causing an indefinite hang until the 600s PTY timeout.

## Fix

Use `-p "$(cat file)"` with `--allow-all-tools` to run copilot in **non-interactive mode**:

```
amplihack copilot --subprocess-safe -p "$(cat \"$SIMARD_PROMPT_FILE\")" --allow-all-tools
```

The copilot processes the prompt, produces output, and exits — allowing the PTY session to complete naturally.

## Testing

- All 22 `tests_base_type_copilot` tests pass (2 new assertions added for `-p` and `--allow-all-tools`)
- `cargo check` clean
- Verified `amplihack copilot --subprocess-safe -p "prompt" --allow-all-tools` works correctly in non-interactive mode

Closes #1488