### PR TITLE
test(python): add 68 unit tests for bridge_server, gym_bridge, and knowledge_bridge

### DIFF
--- a/tests/test_bridge_server.py
+++ b/tests/test_bridge_server.py
@@ -1,0 +1,266 @@
+"""Tests for python/bridge_server.py — the JSON-RPC base bridge protocol.
+
+Run with:
+    uv run --with pytest python3 -m pytest tests/test_bridge_server.py -v
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Add python/ directory to sys.path so the bridge modules are importable
+_PYTHON_DIR = Path(__file__).parent.parent / "python"
+if str(_PYTHON_DIR) not in sys.path:
+    sys.path.insert(0, str(_PYTHON_DIR))
+
+import bridge_server as bs
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_request(method: str, params: dict = None, req_id: str = "test-1") -> str:
+    return json.dumps({"id": req_id, "method": method, "params": params or {}})
+
+
+def _parse_response(line: str) -> dict:
+    return json.loads(line)
+
+
+# ---------------------------------------------------------------------------
+# _error helper
+# ---------------------------------------------------------------------------
+
+
+class TestErrorHelper:
+    def test_error_returns_dict_with_code_and_message(self):
+        result = bs._error(-32601, "not found")
+        assert result == {"code": -32601, "message": "not found"}
+
+    def test_error_preserves_negative_codes(self):
+        err = bs._error(-32603, "internal")
+        assert err["code"] == -32603
+
+    def test_error_message_is_string(self):
+        err = bs._error(bs.ERROR_INTERNAL, "boom")
+        assert isinstance(err["message"], str)
+
+
+# ---------------------------------------------------------------------------
+# BridgeServer — registration and dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestBridgeServerRegistration:
+    def test_health_handler_registered_at_construction(self):
+        server = bs.BridgeServer("test-server")
+        assert "bridge.health" in server._handlers
+
+    def test_register_adds_handler(self):
+        server = bs.BridgeServer("test-server")
+        handler = MagicMock(return_value={"ok": True})
+        server.register("my.method", handler)
+        assert "my.method" in server._handlers
+
+    def test_register_overwrites_existing_handler(self):
+        server = bs.BridgeServer("test-server")
+        h1 = MagicMock(return_value=1)
+        h2 = MagicMock(return_value=2)
+        server.register("my.method", h1)
+        server.register("my.method", h2)
+        assert server._handlers["my.method"] is h2
+
+    def test_server_name_stored(self):
+        server = bs.BridgeServer("my-bridge")
+        assert server.server_name == "my-bridge"
+
+
+class TestBridgeServerDispatch:
+    def test_dispatch_calls_registered_handler(self):
+        server = bs.BridgeServer("test-server")
+        handler = MagicMock(return_value={"result": 42})
+        server.register("my.method", handler)
+        result = server.dispatch("my.method", {"key": "val"})
+        handler.assert_called_once_with({"key": "val"})
+        assert result == {"result": 42}
+
+    def test_dispatch_unknown_method_raises_method_not_found_error(self):
+        server = bs.BridgeServer("test-server")
+        with pytest.raises(bs.MethodNotFoundError) as exc_info:
+            server.dispatch("no.such.method", {})
+        assert "no.such.method" in str(exc_info.value)
+
+    def test_dispatch_health_check_returns_correct_structure(self):
+        server = bs.BridgeServer("healthy-bridge")
+        result = server.dispatch("bridge.health", {})
+        assert result == {"server_name": "healthy-bridge", "healthy": True}
+
+    def test_dispatch_handler_exception_propagates(self):
+        server = bs.BridgeServer("test-server")
+        server.register("boom", lambda p: (_ for _ in ()).throw(RuntimeError("kaboom")))
+        with pytest.raises(RuntimeError, match="kaboom"):
+            server.dispatch("boom", {})
+
+
+# ---------------------------------------------------------------------------
+# MethodNotFoundError
+# ---------------------------------------------------------------------------
+
+
+class TestMethodNotFoundError:
+    def test_is_exception_subclass(self):
+        err = bs.MethodNotFoundError("foo.bar")
+        assert isinstance(err, Exception)
+
+    def test_stores_method_name(self):
+        err = bs.MethodNotFoundError("my.missing.method")
+        assert err.method == "my.missing.method"
+
+    def test_str_includes_method_name(self):
+        err = bs.MethodNotFoundError("foo.bar")
+        assert "foo.bar" in str(err)
+
+
+# ---------------------------------------------------------------------------
+# BridgeServer.run() — stdin/stdout processing
+# ---------------------------------------------------------------------------
+
+
+class TestBridgeServerRun:
+    """Test the JSON-RPC loop via monkey-patched stdin/stdout."""
+
+    def _run_with_input(self, server: bs.BridgeServer, lines: list[str]) -> list[dict]:
+        """Feed lines into server.run() and collect parsed responses."""
+        stdin_data = "\n".join(lines) + "\n"
+        responses: list[dict] = []
+
+        captured_lines: list[str] = []
+
+        def fake_write_response(response: dict) -> None:
+            captured_lines.append(json.dumps(response))
+
+        with (
+            patch("sys.stdin", io.StringIO(stdin_data)),
+            patch("bridge_server._write_response", side_effect=fake_write_response),
+        ):
+            server.run()
+
+        return [json.loads(line) for line in captured_lines]
+
+    def test_health_request_returns_success(self):
+        server = bs.BridgeServer("test-srv")
+        req = _make_request("bridge.health", {}, "req-1")
+        responses = self._run_with_input(server, [req])
+        assert len(responses) == 1
+        assert responses[0]["id"] == "req-1"
+        assert responses[0]["result"]["healthy"] is True
+
+    def test_unknown_method_returns_error(self):
+        server = bs.BridgeServer("test-srv")
+        req = _make_request("no.such.method", {}, "req-2")
+        responses = self._run_with_input(server, [req])
+        assert len(responses) == 1
+        resp = responses[0]
+        assert resp["id"] == "req-2"
+        assert "error" in resp
+        assert resp["error"]["code"] == bs.ERROR_METHOD_NOT_FOUND
+
+    def test_handler_exception_returns_internal_error(self):
+        server = bs.BridgeServer("test-srv")
+        server.register("bad.method", lambda p: (_ for _ in ()).throw(RuntimeError("oops")))
+        req = _make_request("bad.method", {}, "req-3")
+        responses = self._run_with_input(server, [req])
+        assert len(responses) == 1
+        assert responses[0]["error"]["code"] == bs.ERROR_INTERNAL
+
+    def test_malformed_json_returns_internal_error(self):
+        server = bs.BridgeServer("test-srv")
+        responses = self._run_with_input(server, ["not-json{"])
+        assert len(responses) == 1
+        assert responses[0]["error"]["code"] == bs.ERROR_INTERNAL
+
+    def test_empty_lines_are_skipped(self):
+        server = bs.BridgeServer("test-srv")
+        req = _make_request("bridge.health", {}, "req-5")
+        responses = self._run_with_input(server, ["", "   ", req])
+        assert len(responses) == 1  # only one response for the valid request
+
+    def test_multiple_requests_all_processed(self):
+        server = bs.BridgeServer("test-srv")
+        server.register("echo", lambda p: p)
+        reqs = [
+            _make_request("echo", {"n": i}, f"req-{i}")
+            for i in range(5)
+        ]
+        responses = self._run_with_input(server, reqs)
+        assert len(responses) == 5
+        ids = {r["id"] for r in responses}
+        assert ids == {f"req-{i}" for i in range(5)}
+
+    def test_missing_id_defaults_to_unknown(self):
+        server = bs.BridgeServer("test-srv")
+        req = json.dumps({"method": "bridge.health", "params": {}})
+        responses = self._run_with_input(server, [req])
+        assert len(responses) == 1
+        assert responses[0]["id"] == "unknown"
+
+    def test_missing_params_defaults_to_empty_dict(self):
+        server = bs.BridgeServer("test-srv")
+        server.register("echo", lambda p: {"got": p})
+        req = json.dumps({"id": "x", "method": "echo"})
+        responses = self._run_with_input(server, [req])
+        assert responses[0]["result"]["got"] == {}
+
+
+# ---------------------------------------------------------------------------
+# EchoBridgeServer
+# ---------------------------------------------------------------------------
+
+
+class TestEchoBridgeServer:
+    def test_echo_method_registered(self):
+        server = bs.EchoBridgeServer()
+        assert "echo" in server._handlers
+
+    def test_echo_returns_params(self):
+        server = bs.EchoBridgeServer()
+        params = {"foo": "bar", "num": 42}
+        result = server.dispatch("echo", params)
+        assert result == params
+
+    def test_server_name_is_echo(self):
+        server = bs.EchoBridgeServer()
+        assert server.server_name == "echo"
+
+    def test_health_check_also_available(self):
+        server = bs.EchoBridgeServer()
+        result = server.dispatch("bridge.health", {})
+        assert result["healthy"] is True
+        assert result["server_name"] == "echo"
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+class TestConstants:
+    def test_error_codes_are_negative(self):
+        assert bs.ERROR_METHOD_NOT_FOUND < 0
+        assert bs.ERROR_INTERNAL < 0
+        assert bs.ERROR_TIMEOUT < 0
+        assert bs.ERROR_TRANSPORT < 0
+
+    def test_method_not_found_is_jsonrpc_standard(self):
+        assert bs.ERROR_METHOD_NOT_FOUND == -32601
+
+    def test_internal_error_is_jsonrpc_standard(self):
+        assert bs.ERROR_INTERNAL == -32603

--- a/tests/test_bridges.py
+++ b/tests/test_bridges.py
@@ -1,0 +1,333 @@
+"""Tests for python/simard_gym_bridge.py and python/simard_knowledge_bridge.py.
+
+Tests the bridge servers in degraded mode (missing amplihack.eval / wikigr deps)
+and unit-tests pure helper functions that have no external dependencies.
+
+Run with:
+    uv run --with pytest python3 -m pytest tests/test_bridges.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Ensure python/ directory is importable
+_PYTHON_DIR = Path(__file__).parent.parent / "python"
+if str(_PYTHON_DIR) not in sys.path:
+    sys.path.insert(0, str(_PYTHON_DIR))
+
+
+# ---------------------------------------------------------------------------
+# simard_gym_bridge — helper functions (no external deps)
+# ---------------------------------------------------------------------------
+
+
+import simard_gym_bridge as gym_bridge
+
+
+class TestGymHelpers:
+    def test_zero_dims_returns_all_five_dimensions(self):
+        dims = gym_bridge._zero_dims()
+        expected = {
+            "factual_accuracy", "specificity", "temporal_awareness",
+            "source_attribution", "confidence_calibration",
+        }
+        assert set(dims.keys()) == expected
+
+    def test_zero_dims_all_values_are_zero(self):
+        dims = gym_bridge._zero_dims()
+        for val in dims.values():
+            assert val == 0.0
+
+    def test_fail_result_returns_failure_shape(self):
+        result = gym_bridge._fail_result("my-scenario", "something broke", "source-a")
+        assert result["scenario_id"] == "my-scenario"
+        assert result["success"] is False
+        assert result["score"] == 0.0
+        assert result["error_message"] == "something broke"
+        assert result["degraded_sources"] == ["source-a"]
+        assert result["question_count"] == 0
+        assert result["questions_answered"] == 0
+
+    def test_fail_result_without_source(self):
+        result = gym_bridge._fail_result("sid", "err")
+        assert result["degraded_sources"] == []
+
+    def test_fail_result_dimensions_are_all_zero(self):
+        result = gym_bridge._fail_result("sid", "err")
+        for val in result["dimensions"].values():
+            assert val == 0.0
+
+
+# ---------------------------------------------------------------------------
+# GymBridgeServer — degraded mode (no amplihack.eval import)
+# ---------------------------------------------------------------------------
+
+
+class TestGymBridgeServerDegradedMode:
+    """Test GymBridgeServer when progressive and long_horizon are unavailable."""
+
+    def _make_server(self) -> gym_bridge.GymBridgeServer:
+        """Create a GymBridgeServer with both imports patched to None."""
+        with (
+            patch.object(gym_bridge, "_try_import_progressive", return_value=(None, "not installed")),
+            patch.object(gym_bridge, "_try_import_long_horizon", return_value=(None, "not installed")),
+        ):
+            return gym_bridge.GymBridgeServer()
+
+    def test_server_initializes_in_degraded_mode(self):
+        server = self._make_server()
+        assert server._progressive is None
+        assert server._long_horizon is None
+
+    def test_list_scenarios_returns_empty_list_in_degraded_mode(self):
+        server = self._make_server()
+        result = server.dispatch("gym.list_scenarios", {})
+        assert result == []
+
+    def test_run_scenario_returns_failure_when_no_progressive(self):
+        server = self._make_server()
+        result = server.dispatch("gym.run_scenario", {"scenario_id": "level-1"})
+        assert result["success"] is False
+        assert "progressive" in result["error_message"].lower() or "unavailable" in result["error_message"].lower()
+
+    def test_run_suite_returns_failure_when_no_progressive(self):
+        server = self._make_server()
+        result = server.dispatch("gym.run_suite", {"suite_id": "progressive"})
+        assert result["success"] is False
+        assert result["scenarios_total"] == 0
+        assert result["overall_score"] == 0.0
+
+    def test_run_suite_reports_degraded_source(self):
+        server = self._make_server()
+        result = server.dispatch("gym.run_suite", {})
+        assert "progressive_test_suite" in result["degraded_sources"]
+
+    def test_run_long_horizon_returns_failure_when_unavailable(self):
+        server = self._make_server()
+        result = server._run_long_horizon()
+        assert result["success"] is False
+        assert "unavailable" in result["error_message"].lower()
+
+    def test_path_traversal_rejected(self):
+        server = self._make_server()
+        for bad_id in ["../etc/passwd", "foo/bar", "..\\etc"]:
+            result = server.dispatch("gym.run_scenario", {"scenario_id": bad_id})
+            assert result["success"] is False
+            assert "illegal path" in result["error_message"]
+
+    def test_health_check_available(self):
+        server = self._make_server()
+        result = server.dispatch("bridge.health", {})
+        assert result["healthy"] is True
+
+    def test_gym_methods_are_registered(self):
+        server = self._make_server()
+        for method in ("gym.list_scenarios", "gym.run_scenario", "gym.run_suite"):
+            assert method in server._handlers
+
+
+# ---------------------------------------------------------------------------
+# GymBridgeServer — list_scenarios with long_horizon available
+# ---------------------------------------------------------------------------
+
+
+class TestGymBridgeServerWithLongHorizon:
+    def _make_server_with_lh(self) -> gym_bridge.GymBridgeServer:
+        mock_lh = {"LongHorizonMemoryEval": MagicMock()}
+        with (
+            patch.object(gym_bridge, "_try_import_progressive", return_value=(None, "not installed")),
+            patch.object(gym_bridge, "_try_import_long_horizon", return_value=(mock_lh, None)),
+        ):
+            return gym_bridge.GymBridgeServer()
+
+    def test_list_scenarios_includes_long_horizon(self):
+        server = self._make_server_with_lh()
+        result = server.dispatch("gym.list_scenarios", {})
+        ids = [s["id"] for s in result]
+        assert "long-horizon-memory" in ids
+
+    def test_long_horizon_scenario_shape(self):
+        server = self._make_server_with_lh()
+        result = server.dispatch("gym.list_scenarios", {})
+        lh = next(s for s in result if s["id"] == "long-horizon-memory")
+        assert "name" in lh
+        assert "description" in lh
+        assert "level" in lh
+
+
+# ---------------------------------------------------------------------------
+# simard_knowledge_bridge — helper functions
+# ---------------------------------------------------------------------------
+
+
+import simard_knowledge_bridge as kb
+
+
+class TestKnowledgeBridgeHelpers:
+    def test_extract_sources_string_list(self):
+        result = kb._extract_sources({"sources": ["Title A", "Title B"]})
+        assert len(result) == 2
+        assert result[0] == {"title": "Title A", "section": ""}
+        assert result[1] == {"title": "Title B", "section": ""}
+
+    def test_extract_sources_dict_list(self):
+        raw = [{"title": "Art", "section": "Intro", "url": "http://x.com"}]
+        result = kb._extract_sources({"sources": raw})
+        assert result[0]["title"] == "Art"
+        assert result[0]["section"] == "Intro"
+        assert result[0]["url"] == "http://x.com"
+
+    def test_extract_sources_empty_list(self):
+        assert kb._extract_sources({}) == []
+
+    def test_extract_sources_mixed_dict_with_name(self):
+        raw = [{"name": "By Name", "section": ""}]
+        result = kb._extract_sources({"sources": raw})
+        assert result[0]["title"] == "By Name"
+
+    def test_estimate_confidence_training_only(self):
+        result = kb._estimate_confidence({
+            "query_type": "training_only_response",
+            "answer": "some answer",
+            "sources": ["A", "B"],
+        })
+        assert result == 0.2
+
+    def test_estimate_confidence_no_sources(self):
+        conf = kb._estimate_confidence({"answer": "x", "sources": []})
+        assert conf == 0.3
+
+    def test_estimate_confidence_no_answer(self):
+        conf = kb._estimate_confidence({"answer": "", "sources": ["A"]})
+        assert conf == 0.1
+
+    def test_estimate_confidence_with_sources_and_answer(self):
+        conf = kb._estimate_confidence({
+            "answer": "A" * 200,
+            "sources": ["A", "B", "C", "D", "E"],
+        })
+        assert 0.0 < conf <= 1.0
+        assert conf > 0.3  # should be higher than no-sources baseline
+
+    def test_estimate_confidence_returns_rounded_float(self):
+        conf = kb._estimate_confidence({"answer": "hi", "sources": ["A"]})
+        # Round to 2 decimal places
+        assert conf == round(conf, 2)
+
+    def test_section_count_uses_entities(self):
+        stats = MagicMock()
+        stats.entities = 42
+        assert kb._section_count(stats) == 42
+
+
+# ---------------------------------------------------------------------------
+# KnowledgeBridgeServer — initialization
+# ---------------------------------------------------------------------------
+
+
+class TestKnowledgeBridgeServerInit:
+    def test_server_name_is_simard_knowledge(self):
+        server = kb.KnowledgeBridgeServer()
+        assert server.server_name == "simard-knowledge"
+
+    def test_knowledge_methods_registered(self):
+        server = kb.KnowledgeBridgeServer()
+        for method in ("knowledge.query", "knowledge.list_packs", "knowledge.pack_info"):
+            assert method in server._handlers
+
+    def test_default_packs_dir(self):
+        server = kb.KnowledgeBridgeServer()
+        assert server._packs_dir == Path.home() / ".wikigr/packs"
+
+    def test_custom_packs_dir(self):
+        custom = Path("/tmp/my-packs")
+        server = kb.KnowledgeBridgeServer(packs_dir=custom)
+        assert server._packs_dir == custom
+
+    def test_registry_starts_none(self):
+        server = kb.KnowledgeBridgeServer()
+        assert server._registry is None
+
+
+# ---------------------------------------------------------------------------
+# KnowledgeBridgeServer — handler validation (no wikigr installed)
+# ---------------------------------------------------------------------------
+
+
+class TestKnowledgeBridgeServerHandlers:
+    def _make_server(self) -> kb.KnowledgeBridgeServer:
+        return kb.KnowledgeBridgeServer(packs_dir=Path("/nonexistent"))
+
+    def test_query_missing_pack_name_raises_value_error(self):
+        server = self._make_server()
+        with pytest.raises(ValueError, match="pack_name"):
+            server.dispatch("knowledge.query", {"question": "hello"})
+
+    def test_query_empty_question_returns_placeholder(self):
+        server = self._make_server()
+        # patch _get_agent so we don't hit wikigr
+        server._get_agent = MagicMock()
+        result = server.dispatch("knowledge.query", {"pack_name": "my-pack", "question": ""})
+        assert "answer" in result
+        assert result["confidence"] == 0.0
+        assert result["sources"] == []
+
+    def test_list_packs_raises_runtime_when_no_wikigr(self):
+        server = self._make_server()
+        with pytest.raises(RuntimeError, match="agent-kgpacks"):
+            server.dispatch("knowledge.list_packs", {})
+
+    def test_pack_info_missing_pack_name_raises_value_error(self):
+        server = self._make_server()
+        with pytest.raises(ValueError, match="pack_name"):
+            server.dispatch("knowledge.pack_info", {})
+
+    def test_pack_info_missing_pack_raises_runtime_when_no_wikigr(self):
+        server = self._make_server()
+        with pytest.raises(RuntimeError, match="agent-kgpacks"):
+            server.dispatch("knowledge.pack_info", {"pack_name": "my-pack"})
+
+    def test_health_check_available(self):
+        server = self._make_server()
+        result = server.dispatch("bridge.health", {})
+        assert result["healthy"] is True
+
+    def test_query_with_mock_agent(self):
+        server = self._make_server()
+        mock_agent = MagicMock()
+        mock_agent.query.return_value = {
+            "answer": "Paris is the capital of France.",
+            "sources": ["France article"],
+            "query_type": "factual",
+        }
+        server._get_agent = MagicMock(return_value=mock_agent)
+        result = server.dispatch("knowledge.query", {
+            "pack_name": "world-facts",
+            "question": "What is the capital of France?",
+            "limit": 3,
+        })
+        assert result["answer"] == "Paris is the capital of France."
+        assert isinstance(result["confidence"], float)
+        assert len(result["sources"]) <= 3
+
+    def test_query_limits_sources_to_limit_param(self):
+        server = self._make_server()
+        mock_agent = MagicMock()
+        mock_agent.query.return_value = {
+            "answer": "answer",
+            "sources": [f"src-{i}" for i in range(10)],
+        }
+        server._get_agent = MagicMock(return_value=mock_agent)
+        result = server.dispatch("knowledge.query", {
+            "pack_name": "pack",
+            "question": "q",
+            "limit": 3,
+        })
+        assert len(result["sources"]) <= 3

--- a/tests/test_knowledge_bridge.py
+++ b/tests/test_knowledge_bridge.py
@@ -1,0 +1,449 @@
+"""Unit tests for python/simard_knowledge_bridge.py.
+
+Uses mocks for the wikigr package (not installed in CI) to test all handler
+paths, helper functions, and error conditions without real knowledge packs.
+
+Run with:
+    pipx run pytest tests/test_knowledge_bridge.py -v
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Make python/ importable
+# ---------------------------------------------------------------------------
+
+_PYTHON_DIR = Path(__file__).resolve().parent.parent / "python"
+if str(_PYTHON_DIR) not in sys.path:
+    sys.path.insert(0, str(_PYTHON_DIR))
+
+# ---------------------------------------------------------------------------
+# Stub out wikigr so the module can import without the real package
+# ---------------------------------------------------------------------------
+
+_wikigr_packs = ModuleType("wikigr.packs")
+_wikigr_packs_registry = ModuleType("wikigr.packs.registry")
+_wikigr_agent = ModuleType("wikigr.agent")
+_wikigr_agent_kg = ModuleType("wikigr.agent.kg_agent")
+_wikigr = ModuleType("wikigr")
+
+_wikigr_stubs = {
+    "wikigr": _wikigr,
+    "wikigr.packs": _wikigr_packs,
+    "wikigr.packs.registry": _wikigr_packs_registry,
+    "wikigr.agent": _wikigr_agent,
+    "wikigr.agent.kg_agent": _wikigr_agent_kg,
+}
+
+for _name, _mod in _wikigr_stubs.items():
+    sys.modules.setdefault(_name, _mod)
+
+from simard_knowledge_bridge import (  # noqa: E402
+    KnowledgeBridgeServer,
+    _estimate_confidence,
+    _extract_sources,
+    _pack_info_dict,
+    _section_count,
+)
+
+
+# ===========================================================================
+# Fixtures
+# ===========================================================================
+
+
+def _make_stats(articles: int = 10, entities: int = 30) -> SimpleNamespace:
+    return SimpleNamespace(articles=articles, entities=entities)
+
+
+def _make_manifest(
+    name: str = "test-pack",
+    description: str = "A test pack",
+    articles: int = 10,
+    entities: int = 30,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        name=name,
+        description=description,
+        graph_stats=_make_stats(articles=articles, entities=entities),
+    )
+
+
+def _make_pack(
+    name: str = "test-pack",
+    description: str = "A test pack",
+    articles: int = 10,
+    entities: int = 30,
+    db_exists: bool = True,
+    pack_path: Path | None = None,
+) -> SimpleNamespace:
+    path = pack_path or Path("/fake/packs") / name
+    db_path = path / "pack.db"
+    pack = SimpleNamespace(
+        manifest=_make_manifest(name=name, description=description,
+                                articles=articles, entities=entities),
+        path=path,
+    )
+    return pack
+
+
+def _make_registry(packs: list = None) -> MagicMock:
+    registry = MagicMock()
+    packs = packs or []
+    registry.list_packs.return_value = packs
+    registry.get_pack.side_effect = lambda name: next(
+        (p for p in packs if p.manifest.name == name), None
+    )
+    return registry
+
+
+def _make_server(packs: list = None, packs_dir: Path = None) -> KnowledgeBridgeServer:
+    """Build a KnowledgeBridgeServer with a mocked registry."""
+    srv = KnowledgeBridgeServer(packs_dir=packs_dir or Path("/fake/packs"))
+    registry = _make_registry(packs or [])
+    srv._registry = registry
+    return srv
+
+
+# ===========================================================================
+# KnowledgeBridgeServer — construction
+# ===========================================================================
+
+
+class TestKnowledgeBridgeServerConstruction:
+    def test_default_packs_dir_is_home_wikigr(self):
+        srv = KnowledgeBridgeServer()
+        assert srv._packs_dir == Path.home() / ".wikigr/packs"
+
+    def test_custom_packs_dir_stored(self, tmp_path):
+        srv = KnowledgeBridgeServer(packs_dir=tmp_path)
+        assert srv._packs_dir == tmp_path
+
+    def test_server_name_is_simard_knowledge(self):
+        srv = KnowledgeBridgeServer()
+        assert srv.server_name == "simard-knowledge"
+
+    def test_required_methods_registered(self):
+        srv = KnowledgeBridgeServer()
+        assert "knowledge.query" in srv._handlers
+        assert "knowledge.list_packs" in srv._handlers
+        assert "knowledge.pack_info" in srv._handlers
+
+    def test_health_method_still_registered(self):
+        srv = KnowledgeBridgeServer()
+        result = srv.dispatch("bridge.health", {})
+        assert result["healthy"] is True
+
+    def test_registry_starts_as_none(self):
+        srv = KnowledgeBridgeServer()
+        assert srv._registry is None
+
+    def test_agents_cache_starts_empty(self):
+        srv = KnowledgeBridgeServer()
+        assert srv._agents == {}
+
+
+# ===========================================================================
+# _ensure_registry — lazy init
+# ===========================================================================
+
+
+class TestEnsureRegistry:
+    def test_skips_if_registry_already_set(self):
+        srv = KnowledgeBridgeServer(packs_dir=Path("/p"))
+        mock_reg = MagicMock()
+        srv._registry = mock_reg
+        srv._ensure_registry()
+        assert srv._registry is mock_reg  # not replaced
+
+    def test_raises_if_wikigr_not_importable(self):
+        srv = KnowledgeBridgeServer(packs_dir=Path("/p"))
+        with patch.dict(sys.modules, {"wikigr.packs.registry": None}):
+            with pytest.raises((RuntimeError, ImportError)):
+                srv._ensure_registry()
+
+    def test_creates_registry_with_pack_registry(self):
+        srv = KnowledgeBridgeServer(packs_dir=Path("/p"))
+        mock_cls = MagicMock(return_value=MagicMock())
+        with patch("wikigr.packs.registry.PackRegistry", mock_cls, create=True):
+            import wikigr.packs.registry as reg_mod
+            reg_mod.PackRegistry = mock_cls
+            srv._ensure_registry()
+        assert srv._registry is not None
+
+
+# ===========================================================================
+# knowledge.list_packs
+# ===========================================================================
+
+
+class TestHandleListPacks:
+    def test_returns_empty_list_when_no_packs(self):
+        srv = _make_server(packs=[])
+        result = srv.dispatch("knowledge.list_packs", {})
+        assert result == {"packs": []}
+
+    def test_returns_one_pack(self):
+        pack = _make_pack("wiki", "Wikipedia mirror", articles=100, entities=500)
+        srv = _make_server(packs=[pack])
+        result = srv.dispatch("knowledge.list_packs", {})
+        assert len(result["packs"]) == 1
+        info = result["packs"][0]
+        assert info["name"] == "wiki"
+        assert info["description"] == "Wikipedia mirror"
+        assert info["article_count"] == 100
+        assert info["section_count"] == 500
+
+    def test_returns_multiple_packs(self):
+        packs = [
+            _make_pack("a", "Pack A", articles=5, entities=10),
+            _make_pack("b", "Pack B", articles=7, entities=14),
+        ]
+        srv = _make_server(packs=packs)
+        result = srv.dispatch("knowledge.list_packs", {})
+        names = {p["name"] for p in result["packs"]}
+        assert names == {"a", "b"}
+
+    def test_calls_refresh_before_listing(self):
+        srv = _make_server(packs=[])
+        srv.dispatch("knowledge.list_packs", {})
+        srv._registry.refresh.assert_called_once()
+
+
+# ===========================================================================
+# knowledge.pack_info
+# ===========================================================================
+
+
+class TestHandlePackInfo:
+    def test_returns_pack_info(self):
+        pack = _make_pack("mypkg", "Desc", articles=3, entities=9)
+        srv = _make_server(packs=[pack])
+        result = srv.dispatch("knowledge.pack_info", {"pack_name": "mypkg"})
+        assert result["name"] == "mypkg"
+        assert result["description"] == "Desc"
+        assert result["article_count"] == 3
+        assert result["section_count"] == 9
+
+    def test_raises_if_pack_name_missing(self):
+        srv = _make_server(packs=[])
+        with pytest.raises(ValueError, match="pack_name is required"):
+            srv.dispatch("knowledge.pack_info", {})
+
+    def test_raises_if_pack_name_empty(self):
+        srv = _make_server(packs=[])
+        with pytest.raises(ValueError, match="pack_name is required"):
+            srv.dispatch("knowledge.pack_info", {"pack_name": ""})
+
+    def test_raises_if_pack_not_found(self):
+        srv = _make_server(packs=[])
+        with pytest.raises(ValueError, match="'nope' not found"):
+            srv.dispatch("knowledge.pack_info", {"pack_name": "nope"})
+
+
+# ===========================================================================
+# knowledge.query
+# ===========================================================================
+
+
+class TestHandleQuery:
+    def _make_agent(self, answer: str = "42", sources=None, query_type: str = "") -> MagicMock:
+        agent = MagicMock()
+        agent.query.return_value = {
+            "answer": answer,
+            "sources": sources if sources is not None else ["ArticleA"],
+            "query_type": query_type,
+        }
+        return agent
+
+    def test_raises_if_pack_name_missing(self):
+        srv = _make_server(packs=[])
+        with pytest.raises(ValueError, match="pack_name is required"):
+            srv.dispatch("knowledge.query", {"question": "hello"})
+
+    def test_returns_please_provide_question_when_empty(self):
+        pack = _make_pack("wiki")
+        srv = _make_server(packs=[pack])
+        srv._agents["wiki"] = self._make_agent()
+        result = srv.dispatch("knowledge.query", {"pack_name": "wiki", "question": ""})
+        assert result["answer"] == "Please provide a question."
+        assert result["sources"] == []
+        assert result["confidence"] == 0.0
+
+    def test_basic_query_returns_answer(self):
+        pack = _make_pack("wiki")
+        srv = _make_server(packs=[pack])
+        agent = self._make_agent(answer="Paris", sources=["France article"])
+        srv._agents["wiki"] = agent
+        result = srv.dispatch(
+            "knowledge.query", {"pack_name": "wiki", "question": "Capital of France?"}
+        )
+        assert result["answer"] == "Paris"
+        assert len(result["sources"]) == 1
+        assert result["confidence"] > 0.0
+
+    def test_limit_applied_to_sources(self):
+        pack = _make_pack("wiki")
+        srv = _make_server(packs=[pack])
+        many_sources = [f"Article{i}" for i in range(20)]
+        agent = self._make_agent(sources=many_sources)
+        srv._agents["wiki"] = agent
+        result = srv.dispatch(
+            "knowledge.query",
+            {"pack_name": "wiki", "question": "X", "limit": 3},
+        )
+        assert len(result["sources"]) == 3
+
+    def test_default_limit_is_five(self):
+        pack = _make_pack("wiki")
+        srv = _make_server(packs=[pack])
+        many_sources = [f"A{i}" for i in range(10)]
+        agent = self._make_agent(sources=many_sources)
+        srv._agents["wiki"] = agent
+        result = srv.dispatch(
+            "knowledge.query", {"pack_name": "wiki", "question": "X"}
+        )
+        assert len(result["sources"]) == 5
+
+    def test_agent_called_with_question(self):
+        pack = _make_pack("wiki")
+        srv = _make_server(packs=[pack])
+        agent = self._make_agent()
+        srv._agents["wiki"] = agent
+        srv.dispatch("knowledge.query", {"pack_name": "wiki", "question": "Foo?"})
+        agent.query.assert_called_once()
+        call_kwargs = agent.query.call_args
+        assert call_kwargs[0][0] == "Foo?"
+
+    def test_agent_cached_for_same_pack(self):
+        pack = _make_pack("wiki")
+        srv = _make_server(packs=[pack])
+        agent = self._make_agent()
+        srv._agents["wiki"] = agent
+        srv.dispatch("knowledge.query", {"pack_name": "wiki", "question": "Q1"})
+        srv.dispatch("knowledge.query", {"pack_name": "wiki", "question": "Q2"})
+        assert agent.query.call_count == 2  # same agent reused
+
+
+# ===========================================================================
+# _pack_info_dict helper
+# ===========================================================================
+
+
+class TestPackInfoDict:
+    def test_basic_structure(self):
+        pack = _make_pack("p", "desc", articles=4, entities=8)
+        result = _pack_info_dict(pack)
+        assert result == {
+            "name": "p",
+            "description": "desc",
+            "article_count": 4,
+            "section_count": 8,
+        }
+
+    def test_section_count_uses_entities(self):
+        pack = _make_pack(entities=17)
+        result = _pack_info_dict(pack)
+        assert result["section_count"] == 17
+
+
+# ===========================================================================
+# _section_count helper
+# ===========================================================================
+
+
+class TestSectionCount:
+    def test_returns_entities(self):
+        stats = _make_stats(articles=5, entities=42)
+        assert _section_count(stats) == 42
+
+    def test_zero_entities(self):
+        stats = _make_stats(articles=0, entities=0)
+        assert _section_count(stats) == 0
+
+
+# ===========================================================================
+# _extract_sources helper
+# ===========================================================================
+
+
+class TestExtractSources:
+    def test_empty_result(self):
+        assert _extract_sources({}) == []
+
+    def test_string_sources_converted(self):
+        result = {"sources": ["Article A", "Article B"]}
+        sources = _extract_sources(result)
+        assert sources == [
+            {"title": "Article A", "section": ""},
+            {"title": "Article B", "section": ""},
+        ]
+
+    def test_dict_sources_with_title(self):
+        result = {"sources": [{"title": "Foo", "section": "Intro", "url": "http://x"}]}
+        sources = _extract_sources(result)
+        assert sources[0] == {"title": "Foo", "section": "Intro", "url": "http://x"}
+
+    def test_dict_sources_fallback_to_name(self):
+        result = {"sources": [{"name": "Bar", "section": ""}]}
+        sources = _extract_sources(result)
+        assert sources[0]["title"] == "Bar"
+
+    def test_mixed_string_and_dict(self):
+        result = {"sources": ["Str", {"title": "Dict", "section": "S"}]}
+        sources = _extract_sources(result)
+        assert sources[0] == {"title": "Str", "section": ""}
+        assert sources[1] == {"title": "Dict", "section": "S", "url": None}
+
+    def test_dict_source_missing_url_is_none(self):
+        result = {"sources": [{"title": "X", "section": ""}]}
+        sources = _extract_sources(result)
+        assert sources[0].get("url") is None
+
+
+# ===========================================================================
+# _estimate_confidence helper
+# ===========================================================================
+
+
+class TestEstimateConfidence:
+    def test_training_only_response_returns_0_2(self):
+        result = {"query_type": "training_only_response", "sources": [], "answer": ""}
+        assert _estimate_confidence(result) == 0.2
+
+    def test_no_sources_returns_0_3(self):
+        result = {"answer": "Yes", "sources": []}
+        assert _estimate_confidence(result) == 0.3
+
+    def test_no_answer_returns_0_1(self):
+        result = {"answer": "", "sources": ["A"]}
+        assert _estimate_confidence(result) == 0.1
+
+    def test_confidence_increases_with_more_sources(self):
+        few = _estimate_confidence({"answer": "X" * 50, "sources": ["A"]})
+        many = _estimate_confidence({"answer": "X" * 50, "sources": ["A"] * 5})
+        assert many > few
+
+    def test_confidence_increases_with_longer_answer(self):
+        short = _estimate_confidence({"answer": "X", "sources": ["A"]})
+        long_ = _estimate_confidence({"answer": "X" * 300, "sources": ["A"]})
+        assert long_ > short
+
+    def test_max_source_score_capped_at_1(self):
+        # 10 sources should give same score as 5 (cap at 5)
+        five = _estimate_confidence({"answer": "X" * 200, "sources": ["A"] * 5})
+        ten = _estimate_confidence({"answer": "X" * 200, "sources": ["A"] * 10})
+        assert five == ten
+
+    def test_result_is_rounded_to_two_decimals(self):
+        result = {"answer": "abc", "sources": ["A", "B"]}
+        conf = _estimate_confidence(result)
+        assert conf == round(conf, 2)


### PR DESCRIPTION
## Summary

Adds unit-test coverage for three previously-uncovered Python bridge modules:

- **`tests/test_bridge_server.py`** — covers `bridge_server` JSONL protocol handling (request parsing, response serialization, error paths)
- **`tests/test_bridges.py`** — covers `gym_bridge` (gym-side IPC adapter)
- **`tests/test_knowledge_bridge.py`** — 42 unit tests covering the `knowledge_bridge` module (knowledge-graph IPC + memory routing)

Total: 110 new unit tests (68 bridge_server/gym_bridge + 42 knowledge_bridge), +1048/-0 lines, no production-code changes.

### Why

Three Python bridge modules sat at ~0% unit-test coverage despite being on critical IPC paths between Rust core, gym runners, and the knowledge graph. This PR closes that gap with focused unit tests that exercise the public API surface of each bridge.

### Risk

Test-only — zero production code changes.

---

## Merge readiness

### QA-team evidence

- Scenario files: n/a — Simard has no `gadugi-test` scenario harness for Python bridge tests; the new tests in this PR *are* the validation harness for the changed scope
- Validation command: `python -m pytest tests/test_bridge_server.py tests/test_bridges.py tests/test_knowledge_bridge.py -v`
- Validation result: **passed** (110/110 tests pass locally)
- Run command: pre-push hook fence on rebased branch (`cargo fmt --check`, `cargo test --release --lib (cognitive_memory|bootstrap|memory_ipc|memory_consolidation)`, `cargo clippy --all-targets --all-features --locked -- -D warnings`) + GitHub Actions CI on rebased commits `3b2403d4` and `d33f2257`
- Run target: local pre-push + CI `verify/pre-commit (push)` + `verify/pre-commit (pull_request)` + `verify/install-real (push)` + `verify/install-real (pull_request)` + `verify/e2e-dashboard (push)` + `verify/e2e-dashboard (pull_request)` + GitGuardian
- Run result: **passed** (all 7 CI checks green on rebased branch tip)
- Evidence location: pre-push hook output captured at push step:
  ```
  cargo fmt --all -- --check                                                                            ✓ Passed
  cargo test --release --lib (cognitive_memory|bootstrap|memory_ipc|memory_consolidation)               ✓ Passed
  cargo clippy --all-targets --all-features --locked -- -D warnings (pre-push)                          ✓ Passed
  ```
  Plus 7 fresh CI checks all SUCCESS on the rebased branch tip after `git reset --hard 3b2403d4` (dropping debris commit `594df5e8`) followed by appending `d33f2257`.

### Documentation

- User-facing docs impact: **no** — change is test-only; adds three new files under `tests/` and does not touch any production code, CLI flag, config, or REST surface
- Updated docs: none required
- PR description links added: n/a
- Rationale if not applicable: test-only PR with no behavior change; the tests themselves document the bridge modules' contracts

### Quality-audit

- Cycle 1 summary: initial implementation — added `tests/test_bridge_server.py` and `tests/test_bridges.py` (68 unit tests covering bridge_server JSONL protocol and gym_bridge IPC adapter). Validation: `pytest tests/test_bridge_server.py tests/test_bridges.py -v` ✓ (68/68)
- Cycle 2 summary: rebased onto `origin/main@0f5f078d`. Encountered debris commit `594df5e8` left behind in the branch — its only content was a `.simard-engineer-claim` agent-coordination artifact with no test/source value. **Resolution: `git reset --hard 3b2403d4` to drop the debris commit entirely**; then appended a follow-up commit `d33f2257 test(python): add coverage for bridge_server, gym_bridge, knowledge_bridge` adding 42 additional `knowledge_bridge` unit tests on top. Pre-push hook ran cargo fmt + targeted tests + cargo clippy --all-targets --all-features --locked — all green
- Cycle 3 summary: CI verification — all 7 checks SUCCESS on rebased branch tip (`d33f2257`)
- Additional cycles: none required
- Final clean cycle: **Cycle 3** (zero clippy warnings, zero fmt deltas, zero test failures, all CI green; debris `.simard-engineer-claim` artifact dropped from history)
- Fixes followed default-workflow: yes — implement tests → rebase → drop debris commit → add more tests → push → re-validate
- Convergence summary: 3-file diff (post-resolution), +1048/-0 lines, all 110 new tests pass, all CI green; PR is now narrowly scoped to its title (Python bridge unit tests only)

### CI

- Checks command: `gh pr checks 1558 --repo rysweet/Simard`
- Result: **all green** — 7 checks SUCCESS, 0 failing, 0 pending, 0 skipped
- Skipped checks: none
- Flaky reruns performed: none needed — fresh CI on rebased branch tip passed cleanly
- Real failures fixed: dropped debris commit `594df5e8` (containing only `.simard-engineer-claim` agent-coordination artifact) during rebase to keep the diff narrowly scoped to test additions

### PR description evidence

- This PR description follows the merge-ready template at `~/.copilot/skills/merge-ready/pr-description-template.md`
- All six required evidence headings present (QA-team evidence, Documentation, Quality-audit, CI, PR description evidence, Scope)
- Verdict section below

### Scope

- Changed files reviewed: 3 files, +1048/-0 lines total (post-resolution; the original PR also carried a `.simard-engineer-claim` debris commit which was dropped during rebase per Cycle 2)
  - `tests/test_bridge_server.py` — new file; unit tests for bridge_server JSONL protocol
  - `tests/test_bridges.py` — new file; unit tests for gym_bridge IPC adapter
  - `tests/test_knowledge_bridge.py` — new file; 42 unit tests for knowledge_bridge module
- Unrelated changes: none (the debris `.simard-engineer-claim` commit was dropped — see Cycle 2)

### Verdict

- Merge-ready: **yes**
- Remaining blockers: none

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
