### PR TITLE
fix: macOS portability — build, PTY launcher, and bash path

### DIFF
--- a/src/memory_ipc/mod.rs
+++ b/src/memory_ipc/mod.rs
@@ -319,9 +319,13 @@ pub fn reap_stale_open_lock(state_root: &Path) -> SimardResult<bool> {
 
 fn is_pid_alive(pid: u32) -> bool {
     // kill(pid, 0) returns 0 if the process exists and we can signal it,
-    // ESRCH if it doesn't exist.
+    // ESRCH if it doesn't exist. Use std::io::Error::last_os_error() to read
+    // errno portably (macOS exposes __error(), Linux exposes __errno_location()).
     let pid_i = pid as i32;
-    unsafe { libc::kill(pid_i, 0) == 0 || *libc::__errno_location() != libc::ESRCH }
+    if unsafe { libc::kill(pid_i, 0) } == 0 {
+        return true;
+    }
+    std::io::Error::last_os_error().raw_os_error() != Some(libc::ESRCH)
 }
 
 fn flock_held(path: &Path) -> bool {

--- a/src/ooda_actions/session.rs
+++ b/src/ooda_actions/session.rs
@@ -56,7 +56,11 @@ fn dispatch_launch_session_copilot(action: &PlannedAction) -> ActionOutcome {
     let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
 
     // Launch bash in a PTY — we'll send the copilot command ourselves.
-    let mut session = match PtyTerminalSession::launch("terminal-shell", "/usr/bin/bash", &cwd) {
+    #[cfg(target_os = "macos")]
+    const SHELL_PATH: &str = "/bin/bash";
+    #[cfg(not(target_os = "macos"))]
+    const SHELL_PATH: &str = "/usr/bin/bash";
+    let mut session = match PtyTerminalSession::launch("terminal-shell", SHELL_PATH, &cwd) {
         Ok(s) => s,
         Err(e) => {
             return make_outcome(

--- a/src/terminal_session/session.rs
+++ b/src/terminal_session/session.rs
@@ -68,10 +68,27 @@ impl PtyTerminalSession {
         let _transcript_file = open_exclusive_temp_file(&transcript_path, base_type)?;
         let workflow_restore_guards =
             capture_workflow_restore_guards(base_type, launch_command, working_directory)?;
-        let mut child = Command::new(PTY_LAUNCHER)
-            .arg("-qefc")
-            .arg(launch_command)
-            .arg(&transcript_path)
+        let mut command = Command::new(PTY_LAUNCHER);
+        // GNU `script` (Linux util-linux) uses `-qefc <command> <file>`.
+        // BSD `script` (macOS) uses positional `script [-qFe] <file> <command...>`
+        // and has no `-c` flag — the command and its args are passed positionally.
+        #[cfg(target_os = "macos")]
+        {
+            command
+                .arg("-qFe")
+                .arg(&transcript_path)
+                .arg("/bin/sh")
+                .arg("-c")
+                .arg(launch_command);
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            command
+                .arg("-qefc")
+                .arg(launch_command)
+                .arg(&transcript_path);
+        }
+        let mut child = command
             .current_dir(working_directory)
             .env("TERM", "dumb")
             .stdin(Stdio::piped())

--- a/src/terminal_session/types.rs
+++ b/src/terminal_session/types.rs
@@ -2,6 +2,9 @@ use std::path::PathBuf;
 use std::process::ExitStatus;
 use std::time::Duration;
 
+#[cfg(target_os = "macos")]
+pub(crate) const DEFAULT_SHELL: &str = "/bin/bash";
+#[cfg(not(target_os = "macos"))]
 pub(crate) const DEFAULT_SHELL: &str = "/usr/bin/bash";
 pub(crate) const PTY_LAUNCHER: &str = "script";
 pub(crate) const WAIT_STEP_TIMEOUT: Duration = Duration::from_secs(5);
@@ -39,6 +42,9 @@ mod tests {
 
     #[test]
     fn default_shell_constant() {
+        #[cfg(target_os = "macos")]
+        assert_eq!(DEFAULT_SHELL, "/bin/bash");
+        #[cfg(not(target_os = "macos"))]
         assert_eq!(DEFAULT_SHELL, "/usr/bin/bash");
     }
 


### PR DESCRIPTION
## Summary

Three small, surgical fixes that allow `simard` to build and run on macOS (Darwin arm64). Each fix is gated by `cfg(target_os = "macos")` or uses a portable Rust API, so Linux behavior is unchanged.

## Bugs fixed

### 1. Build failure: `libc::__errno_location` is Linux-only
`src/memory_ipc/mod.rs:309` failed with E0425 on macOS:
```
error[E0425]: cannot find function `__errno_location` in crate `libc`
```
Fix: replace the unsafe direct deref with the portable
`std::io::Error::last_os_error().raw_os_error()` helper, which works on
Linux, macOS, and other Unix targets without changing semantics.

### 2. Runtime failure: `script -qefc` is GNU `util-linux` syntax, not BSD
On macOS, `/usr/bin/script` is BSD `script`, which has no `-c` flag and
takes `file` and `command...` positionally as `script [-aeFkpqr] [file [command ...]]`.
The GNU invocation exits immediately with status 1, surfacing as
`terminal-shell session exited with status exit status: 1`.

Fix (`src/terminal_session/session.rs`): branch on `cfg(target_os = "macos")`. macOS uses
`script -qFe <file> /bin/sh -c "<launch_command>"`, the BSD equivalent of the GNU form
(`-F` flushes after each write, `-e` propagates the child's exit status).

### 3. Runtime failure: `/usr/bin/bash` does not exist on macOS
The system bash on macOS lives at `/bin/bash`, not `/usr/bin/bash`.
After the BSD-script fix, the wrapped shell still failed with status 127
("command not found") because the hardcoded bash path is invalid.

Fix:
- `src/terminal_session/types.rs`: `DEFAULT_SHELL` is now cfg-gated to
  `/bin/bash` on macOS, `/usr/bin/bash` elsewhere. The corresponding
  unit test is similarly cfg-gated.
- `src/ooda_actions/session.rs`: the hardcoded `/usr/bin/bash` in the
  copilot launch-session handler is replaced by a local `SHELL_PATH`
  const that follows the same cfg-based selection.

## Linux impact

None — all changes are either portable Rust APIs (`std::io::Error::last_os_error`)
or guarded by `cfg(target_os = "macos")`. The `#[cfg(not(target_os = "macos"))]`
branches preserve the existing Linux code paths verbatim.

---

## Merge readiness

### QA-team evidence

- Scenario files: n/a — Simard has no `gadugi-test` scenario harness; portability fix is exercised by:
  - the existing cfg-gated unit test `default_shell_path_exists` (now branches on macOS vs Linux)
  - manual end-to-end on macOS 26.4 (Darwin arm64): `cargo install --path . --locked` builds + installs cleanly; `simard self-test` drives a Copilot turn through the `copilot-sdk` adapter with `Copilot adapter: received response response_len=177`
- Validation command: Linux CI `cargo build --release --locked --all-targets` + `cargo test --release --lib`
- Validation result: **passed** on Linux (CI verify/pre-commit + verify/install-real + verify/e2e-dashboard all green on commit `cb64409f`)
- Run command: pre-push hook on rebased branch (`cargo fmt --check`, `cargo test --release --lib (cognitive_memory|bootstrap|memory_ipc|memory_consolidation)`, `cargo clippy --all-targets --all-features --locked -- -D warnings`)
- Run target: local pre-push fence on Linux + manual install/run on macOS + CI on Linux (CI runners are Ubuntu, so the macOS branches are exercised by code review + manual verification rather than CI)
- Run result: **passed** — all 4 CI checks SUCCESS on Linux; manual macOS verification confirms the build + first self-test sub-test succeed
- Evidence location: pre-push hook output captured at push step:
  ```
  cargo fmt --all -- --check                                                                            ✓ Passed
  cargo test --release --lib (cognitive_memory|bootstrap|memory_ipc|memory_consolidation)               ✓ Passed
  cargo clippy --all-targets --all-features --locked -- -D warnings (pre-push)                          ✓ Passed
  ```
  Plus 4 fresh CI checks all SUCCESS on commit `cb64409f` after rebase on `main@0f5f078d` (verify/pre-commit, verify/install-real, verify/e2e-dashboard, GitGuardian — fork-PR triggers `pull_request` event only, so each verify job runs once instead of twice).

### Documentation

- User-facing docs impact: **no** — change is internal portability fix; the `simard` CLI surface, environment variables, config files, and operator workflow are unchanged on either platform
- Updated docs: none required (the macOS branches are pure cfg-guarded equivalents of existing Linux code; operator-visible behavior is identical)
- PR description links added: n/a
- Rationale if not applicable: changed surfaces are `src/memory_ipc/mod.rs` (portable errno API), `src/terminal_session/{session,types}.rs` (cfg-guarded BSD-script + `/bin/bash` path), `src/ooda_actions/session.rs` (cfg-guarded `SHELL_PATH` const) — internal Unix portability only; no API/CLI/config break

### Quality-audit

- Cycle 1 summary: initial implementation — replaced `libc::__errno_location` with portable `std::io::Error::last_os_error().raw_os_error()`; added cfg-gated BSD-script invocation; switched hardcoded `/usr/bin/bash` to cfg-gated `/bin/bash` on macOS. Validation: `cargo install --path . --locked` ✓ on macOS 26.4 Darwin arm64; `simard self-test` Copilot adapter sub-test ✓
- Cycle 2 summary: rebased onto `origin/main@0f5f078d` (which now includes the pre-commit hook installer from PR #1695 and the `agent_kind_from_env` serial-test flake fix). No conflicts. Pre-push hook ran cargo fmt + targeted tests + cargo clippy --all-targets --all-features --locked — all green on Linux
- Cycle 3 summary: CI verification on Linux — 4/4 verify checks SUCCESS on commit `cb64409f` after fork-PR re-approval (fork PRs from new contributors require maintainer approval to run workflows; this was a one-time approval). The Linux CI exercises the `#[cfg(not(target_os = "macos"))]` branches, which are byte-identical to pre-PR behavior. The macOS branches were exercised by the manual install + self-test on Darwin arm64 reported in Cycle 1
- Additional cycles: none required
- Final clean cycle: **Cycle 3** (zero clippy warnings, zero fmt deltas, zero test failures on Linux CI; manual macOS install + first Copilot turn confirmed)
- Fixes followed default-workflow: yes — implement → test on each platform → rebase → re-validate
- Convergence summary: 4-file diff, +38/-7 lines, all guarded by `cfg(target_os = "macos")` or using portable APIs; Linux CI green, macOS install + first Copilot turn confirmed

### CI

- Checks command: `gh pr checks 1591 --repo rysweet/Simard`
- Result: **all green** — 4 checks SUCCESS, 0 failing, 0 pending, 0 skipped (fork-PR runs each verify job once on the `pull_request` event, not the matched `push` + `pull_request` pair you see on same-repo PRs)
- Skipped checks: none
- Flaky reruns performed: none — the only "rerun" was the maintainer approval needed to run any verify job at all on a fork PR (handled at the start of this cycle)
- Real failures fixed: none on Linux this cycle; the 3 macOS bugs fixed in this PR do not surface on the Linux CI runners

### PR description evidence

- This PR description follows the merge-ready template at `~/.copilot/skills/merge-ready/pr-description-template.md`
- All six required evidence headings present (QA-team evidence, Documentation, Quality-audit, CI, PR description evidence, Scope)
- Verdict section below

### Scope

- Changed files reviewed: 4 files, +38/-7 lines total
  - `src/memory_ipc/mod.rs` — replace `libc::__errno_location` with portable `std::io::Error::last_os_error().raw_os_error()`
  - `src/terminal_session/session.rs` — cfg-gated BSD `script -qFe <file> /bin/sh -c "<cmd>"` for macOS; existing GNU form preserved for Linux
  - `src/terminal_session/types.rs` — cfg-gated `DEFAULT_SHELL` (`/bin/bash` on macOS, `/usr/bin/bash` elsewhere); test similarly cfg-gated
  - `src/ooda_actions/session.rs` — local `SHELL_PATH` const replacing hardcoded `/usr/bin/bash` in the copilot launch-session handler
- Unrelated changes: none

### Verdict

- Merge-ready: **yes**
- Remaining blockers: none

(The second self-test sub-test failure on macOS — `rusty-clawd` Copilot backend requiring `Client::new_copilot()` — is a separate, unrelated bug and out of scope for this PR.)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
