### PR TITLE
feat(meeting): one-line headline summary after /close (#1584)

### DIFF
--- a/src/meeting_repl/repl.rs
+++ b/src/meeting_repl/repl.rs
@@ -213,6 +213,20 @@ pub fn run_meeting_repl<R: BufRead, W: Write>(
     match backend.close() {
         Ok(summary) => {
             spinner.stop();
+            // One-line headline summary, shown before the detailed sections
+            // and before any handoff/transcript paths. Helps the operator
+            // see the bottom-line outcome at a glance.
+            let action_count = summary.action_items.len();
+            let plural = if action_count == 1 { "" } else { "s" };
+            writeln!(
+                output,
+                "\n{}",
+                cyan(&format!(
+                    "✓ Meeting closed: \"{}\" — {} action item{}",
+                    summary.topic, action_count, plural
+                ))
+            )
+            .ok();
             writeln!(output, "\n── Meeting Summary ──").ok();
             writeln!(output, "{}", summary.summary_text).ok();
 

--- a/src/meeting_repl/tests_repl.rs
+++ b/src/meeting_repl/tests_repl.rs
@@ -239,3 +239,47 @@ fn repl_help_includes_theme_recap_preview() {
         "help should mention /preview: {output_str}"
     );
 }
+
+#[test]
+#[serial]
+fn repl_close_prints_one_line_headline_summary() {
+    // Suppress ANSI color codes so substring assertions are robust.
+    // SAFETY: serial_test guards against parallel env mutations.
+    unsafe { std::env::set_var("NO_COLOR", "1") };
+
+    let bridge = mock_bridge();
+    let agent = MockAgentSession::new("noted");
+    // Two conversational turns, then close. MockAgent emits no action items
+    // so the count should render as "0 action items".
+    let input = b"Discuss release plan\nAny blockers?\n/close\n";
+    let mut reader = &input[..];
+    let mut output = Vec::new();
+
+    run_meeting_repl(
+        "Release planning",
+        &bridge,
+        Some(Box::new(agent)),
+        "",
+        &mut reader,
+        &mut output,
+    )
+    .unwrap();
+
+    unsafe { std::env::remove_var("NO_COLOR") };
+
+    let output_str = String::from_utf8(output).unwrap();
+    // One-line headline must include the topic, the bottom-line action item
+    // count, and must appear before the detailed "Meeting Summary" section.
+    let headline_pos = output_str
+        .find("✓ Meeting closed: \"Release planning\" — 0 action items")
+        .unwrap_or_else(|| {
+            panic!("missing one-line headline summary in output: {output_str}");
+        });
+    let detailed_pos = output_str
+        .find("── Meeting Summary ──")
+        .unwrap_or_else(|| panic!("missing detailed summary section: {output_str}"));
+    assert!(
+        headline_pos < detailed_pos,
+        "headline summary must precede the detailed Meeting Summary section: {output_str}"
+    );
+}


### PR DESCRIPTION
## Summary

Implements the smallest-scoped UX improvement from #1584: after the operator types `/close`, the meeting REPL now prints a one-line headline summary — `✓ Meeting closed: "<topic>" — N action item(s)` — immediately after the close spinner stops, before the detailed `── Meeting Summary ──` section and any handoff/transcript paths.

This gives the operator the bottom-line outcome at a glance instead of having to scan the full structured summary.

## Changes

- `src/meeting_repl/repl.rs` — Add cyan-colored one-line headline in the `backend.close()` Ok branch, before the existing detailed sections. Pluralizes `item` correctly.
- `src/meeting_repl/tests_repl.rs` — Add `repl_close_prints_one_line_headline_summary` unit test that:
  - Sets `NO_COLOR=1` (under `#[serial]`) for robust substring matching
  - Drives the REPL with two conversational turns plus `/close`
  - Asserts the headline appears verbatim with `0 action items`
  - Asserts the headline position precedes `── Meeting Summary ──`

## What remains for #1584

Other items from the issue, for follow-up PRs:

- [ ] `/preview` should render action items as a numbered list grouped by owner
- [ ] `/export` markdown should include `## Decisions` and `## Action Items` sections with checkboxes
- [ ] ISO-8601 timestamp + attendee list in handoff frontmatter
- [ ] New `/attendees <names>` command, reflected in `/status` and handoff
- [x] Spinner integration during LLM turns — already wired in `repl.rs`
- [x] Color-code `simard:meeting>` prompt and `Simard:` role labels — landed via PR #1608
- [x] One-line summary after `/close` — **this PR**

---

## Merge readiness

### QA-team evidence

- Scenario files: n/a — Simard has no `gadugi-test` scenario harness; this UX change is exercised by 1 new `#[serial]` unit test in `src/meeting_repl/tests_repl.rs` (drives REPL with two turns + `/close` and asserts the headline + position vs. detailed summary)
- Validation command: `cargo test --release --lib -- meeting`
- Validation result: **passed** (337 tests pass including the new `repl_close_prints_one_line_headline_summary`)
- Run command: pre-push hook on rebased branch (`cargo fmt --check`, `cargo test --release --lib (cognitive_memory|bootstrap|memory_ipc|memory_consolidation)`, `cargo clippy --all-targets --all-features --locked -- -D warnings`)
- Run target: local pre-push fence + CI `verify/pre-commit (push)` + `verify/pre-commit (pull_request)`
- Run result: **passed** (all 7 CI checks green on commit `d52d7698` after rebase)
- Evidence location: pre-push hook output captured at push step:
  ```
  cargo fmt --all -- --check                                                                            ✓ Passed
  cargo test --release --lib (cognitive_memory|bootstrap|memory_ipc|memory_consolidation)               ✓ Passed
  cargo clippy --all-targets --all-features --locked -- -D warnings (pre-push)                          ✓ Passed
  ```
  Plus 7 fresh CI checks all SUCCESS on commit `d52d7698` after rebase on `main@0f5f078d`.

### Documentation

- User-facing docs impact: **no** — change adds a one-line print to the existing REPL `/close` output; no new commands, no new flags, no operator-config impact
- Updated docs: none required (the headline is its own self-documentation; the `NO_COLOR` contract is honored via the existing `color::cyan` helper which has been documented in PR #1608)
- PR description links added: n/a
- Rationale if not applicable: changed surfaces are `src/meeting_repl/repl.rs` (one-line print before the existing `── Meeting Summary ──` block) and `src/meeting_repl/tests_repl.rs` (1 new test) — internal terminal output enhancement with no API/CLI flag/config impact

### Quality-audit

- Cycle 1 summary: initial implementation — added cyan headline print + `#[serial]` test asserting headline + position. Validation: `cargo build --lib` ✓; `cargo test --lib -- meeting` ✓ (337/337)
- Cycle 2 summary: rebased onto `origin/main@0f5f078d` (which now includes the pre-commit hook installer from PR #1695, the `agent_kind_from_env` serial-test flake fix, and the related meeting-REPL color work from PR #1608). No conflicts. Pre-push hook ran cargo fmt + targeted tests + cargo clippy --all-targets --all-features --locked — all green
- Cycle 3 summary: marked PR ready for review (was draft); CI verification — all 7 checks SUCCESS on commit `d52d7698` (verify/pre-commit, verify/install-real, verify/e2e-dashboard on both push + pull_request events; GitGuardian)
- Additional cycles: none required
- Final clean cycle: **Cycle 3** (zero clippy warnings, zero fmt deltas, zero test failures, all CI green)
- Fixes followed default-workflow: yes — implement → test → rebase → ready-for-review → re-validate
- Convergence summary: 2-file diff, +58/-0 lines, all unit tests pass, all CI green; no behavior change to non-meeting-REPL code

### CI

- Checks command: `gh pr checks 1598 --repo rysweet/Simard`
- Result: **all green** — 7 checks SUCCESS, 0 failing, 0 pending, 0 skipped
- Skipped checks: none
- Flaky reruns performed: none needed — fresh CI on rebased commit `d52d7698` passed cleanly first time
- Real failures fixed: none on this branch (the rebase pulled in the upstream `agent_kind_from_env` serial-test flake fix)

### PR description evidence

- This PR description follows the merge-ready template at `~/.copilot/skills/merge-ready/pr-description-template.md`
- All six required evidence headings present (QA-team evidence, Documentation, Quality-audit, CI, PR description evidence, Scope)
- Verdict section below

### Scope

- Changed files reviewed: 2 files, +58/-0 lines total
  - `src/meeting_repl/repl.rs` (+14 lines) — cyan one-line headline in `backend.close()` Ok branch, before the existing `── Meeting Summary ──` block; correct pluralization
  - `src/meeting_repl/tests_repl.rs` (+44 lines) — 1 new `#[serial]` test asserting headline + position vs. detailed summary, with `NO_COLOR=1` for robust substring matching
- Unrelated changes: none

### Verdict

- Merge-ready: **yes** (was DRAFT; marked ready for review during this audit)
- Remaining blockers: none

Refs #1584

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
