### PR TITLE
fix(memory): propagate snapshot save errors and use tracing for prune (#1604, gaps G10/G11)

### DIFF
--- a/src/memory_consolidation/mod.rs
+++ b/src/memory_consolidation/mod.rs
@@ -189,10 +189,30 @@ pub fn reflection_memory_operations(
 /// This is the final phase of a session. Working memory for this session is
 /// cleared, expired sensory items are pruned, and episode consolidation is
 /// attempted to keep episodic memory compact.
+///
+/// A JSON snapshot is also saved to the default snapshot directory
+/// (`~/.simard/snapshots/`) so cross-session recall survives process exit.
+/// Snapshot save failures are **propagated** (issue #1604, gap G10) so that
+/// disk-full / permission errors fail loudly rather than silently degrading
+/// durability.
 #[tracing::instrument(skip_all)]
 pub fn persistence_memory_operations(
     session_id: &SessionId,
     bridge: &dyn CognitiveMemoryOps,
+) -> SimardResult<()> {
+    persistence_memory_operations_with_snapshot_dir(session_id, bridge, None)
+}
+
+/// Same as [`persistence_memory_operations`] but allows callers (typically
+/// tests) to override the snapshot directory.  When `snapshot_dir_override`
+/// is `None`, the default location (`~/.simard/snapshots/`) is used.
+///
+/// Snapshot save errors are propagated via `?` (issue #1604, gap G10).
+#[tracing::instrument(skip_all)]
+pub fn persistence_memory_operations_with_snapshot_dir(
+    session_id: &SessionId,
+    bridge: &dyn CognitiveMemoryOps,
+    snapshot_dir_override: Option<&std::path::Path>,
 ) -> SimardResult<()> {
     // Consolidate episodes (batch of 10) BEFORE clearing working memory, so a
     // consolidation failure aborts teardown rather than silently dropping the
@@ -213,19 +233,31 @@ pub fn persistence_memory_operations(
     )?;
 
     // Save a JSON snapshot for durable cross-session recall.  Errors are
-    // non-fatal: log and continue so a snapshot failure never aborts the
-    // session lifecycle.
-    if let Some(dir) = crate::memory_snapshot::snapshot_dir(None) {
-        match crate::memory_snapshot::save_session_snapshot(bridge, session_id.as_str(), &dir) {
-            Ok(path) => {
-                eprintln!("[simard] memory_snapshot: saved {}", path.display());
-                // Prune: keep only the 10 most recent snapshots.
-                prune_snapshots(&dir, 10);
-            }
-            Err(e) => {
-                eprintln!("[simard] memory_snapshot: save failed (non-fatal): {e}");
-            }
+    // PROPAGATED so the operator can fix the underlying disk/permission
+    // issue (issue #1604, gap G10).  Previously these errors were swallowed
+    // via `eprintln!`, which is exactly the silent-degradation bug class
+    // that #1427 was filed against.
+    if let Some(dir) = crate::memory_snapshot::snapshot_dir(snapshot_dir_override) {
+        let path =
+            crate::memory_snapshot::save_session_snapshot(bridge, session_id.as_str(), &dir)?;
+        tracing::info!(path = %path.display(), "memory_snapshot: saved");
+        // Prune: keep only the 10 most recent snapshots.
+        prune_snapshots(&dir, 10);
+    } else {
+        // `snapshot_dir` returned `None`.  When the caller supplied an
+        // explicit override and we still got `None`, that is a hard error
+        // (the override was unusable).  Otherwise it just means the home
+        // directory could not be resolved — log and continue so headless
+        // environments without `$HOME` are not broken.
+        if let Some(override_path) = snapshot_dir_override {
+            return Err(crate::error::SimardError::PersistentStoreIo {
+                store: "memory_snapshot".to_string(),
+                action: "snapshot_dir".to_string(),
+                path: override_path.to_path_buf(),
+                reason: "snapshot_dir() returned None for the supplied override".to_string(),
+            });
         }
+        tracing::info!("memory_snapshot: home directory not resolved — skipping save");
     }
 
     Ok(())
@@ -234,7 +266,11 @@ pub fn persistence_memory_operations(
 /// Delete all but the `keep` most-recent snapshot files in `dir`.
 ///
 /// Filenames are `<agent>-<epoch>.json`; lexicographic sort == chronological.
-/// Errors during deletion are logged but not propagated.
+/// Errors during deletion are logged via `tracing::warn!` (issue #1604,
+/// gap G11) so a stuck pruner is detectable through the existing
+/// `tracing-subscriber` / `tracing-opentelemetry` pipeline.  Errors are
+/// intentionally not propagated: leaving stale snapshots is preferable to
+/// failing the session teardown.
 fn prune_snapshots(dir: &std::path::Path, keep: usize) {
     let mut entries: Vec<std::path::PathBuf> = match std::fs::read_dir(dir) {
         Ok(rd) => rd
@@ -249,7 +285,11 @@ fn prune_snapshots(dir: &std::path::Path, keep: usize) {
             })
             .collect(),
         Err(e) => {
-            eprintln!("[simard] memory_snapshot: prune read_dir failed (non-fatal): {e}");
+            tracing::warn!(
+                dir = %dir.display(),
+                error = %e,
+                "memory_snapshot: prune read_dir failed (non-fatal)",
+            );
             return;
         }
     };
@@ -260,9 +300,10 @@ fn prune_snapshots(dir: &std::path::Path, keep: usize) {
     let to_delete = entries.len() - keep;
     for path in entries.iter().take(to_delete) {
         if let Err(e) = std::fs::remove_file(path) {
-            eprintln!(
-                "[simard] memory_snapshot: prune delete {} failed (non-fatal): {e}",
-                path.display()
+            tracing::warn!(
+                path = %path.display(),
+                error = %e,
+                "memory_snapshot: prune delete failed (non-fatal)",
             );
         }
     }

--- a/src/memory_consolidation/tests.rs
+++ b/src/memory_consolidation/tests.rs
@@ -168,6 +168,127 @@ fn consolidation_persistence_flushes_and_consolidates() {
     assert_eq!(count.load(Ordering::SeqCst), 3);
 }
 
+// ───────────────────────────────────────────────────────────────────────────
+// G10 (issue #1604): persistence_memory_operations must propagate snapshot
+// save failures rather than silently swallowing them via `eprintln!`.
+// ───────────────────────────────────────────────────────────────────────────
+
+/// Build a counting bridge that satisfies every call needed by the
+/// persistence phase *and* the snapshot save (search_facts + recall_procedure).
+fn persistence_capable_bridge() -> CognitiveMemoryBridge {
+    let transport = InMemoryBridgeTransport::new("snapshot-fail", |method, _params| match method {
+        "memory.consolidate_episodes" => Ok(json!({"id": null})),
+        "memory.clear_working" => Ok(json!({"count": 0})),
+        "memory.prune_expired_sensory" => Ok(json!({"count": 0})),
+        "memory.store_episode" => Ok(json!({"id": "epi_1"})),
+        "memory.search_facts" => Ok(json!({"facts": []})),
+        "memory.recall_procedure" => Ok(json!({"procedures": []})),
+        _ => Err(crate::bridge::BridgeErrorPayload {
+            code: -32601,
+            message: format!("unknown: {method}"),
+        }),
+    });
+    CognitiveMemoryBridge::new(Box::new(transport))
+}
+
+#[test]
+fn persistence_propagates_snapshot_save_error_when_dir_is_a_file() {
+    // The snapshot-save path resolves to `<dir>/<agent>-<epoch>.json`.
+    // If `dir` is actually a regular file, `std::fs::write` returns
+    // `ENOTDIR`.  The fix for G10 (issue #1604) propagates that error
+    // instead of swallowing it via `eprintln!`.
+    let bridge = persistence_capable_bridge();
+    let tmp_file = tempfile::NamedTempFile::new().expect("create tmp file");
+    let dir_that_is_a_file = tmp_file.path().to_path_buf();
+
+    let err = persistence_memory_operations_with_snapshot_dir(
+        &test_session_id(),
+        &bridge,
+        Some(&dir_that_is_a_file),
+    )
+    .expect_err("snapshot save into a non-directory must propagate as Err");
+
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("memory-snapshot")
+            || msg.contains("memory_snapshot")
+            || msg.to_lowercase().contains("not a directory")
+            || msg.to_lowercase().contains("notadirectory"),
+        "expected error to mention snapshot/IO failure, got: {msg}",
+    );
+}
+
+#[test]
+fn persistence_with_valid_override_dir_writes_snapshot_and_returns_ok() {
+    // Sanity check: the override mechanism still writes a snapshot when
+    // pointed at a real directory, so the G10 propagation path does not
+    // regress the happy case.
+    let bridge = persistence_capable_bridge();
+    let tmp_dir = tempfile::tempdir().expect("create tmp dir");
+
+    persistence_memory_operations_with_snapshot_dir(
+        &test_session_id(),
+        &bridge,
+        Some(tmp_dir.path()),
+    )
+    .expect("happy-path snapshot save must succeed");
+
+    let entries: Vec<_> = std::fs::read_dir(tmp_dir.path())
+        .expect("read snapshot dir")
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("json"))
+        .collect();
+    assert_eq!(
+        entries.len(),
+        1,
+        "expected exactly one snapshot file, found {}",
+        entries.len()
+    );
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// G11 (issue #1604): prune_snapshots must remain non-fatal AND switch its
+// telemetry from `eprintln!` to `tracing::warn!`.  We cannot intercept the
+// `tracing` event in a unit test without pulling in a subscriber, so the
+// behavioural assertion focuses on the contract: pruning still removes the
+// oldest entries, leaves the newest `keep` files intact, and never panics
+// when individual deletions fail (e.g. read-only files).
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn prune_snapshots_keeps_newest_and_deletes_oldest() {
+    let tmp_dir = tempfile::tempdir().expect("create tmp dir");
+    // Create five snapshot-like files with embedded epochs so lexicographic
+    // sort matches chronological order.
+    for epoch in 1_000_000..1_000_005u64 {
+        let p = tmp_dir.path().join(format!("agent-{epoch}.json"));
+        std::fs::write(&p, b"{}").expect("write tmp snapshot");
+    }
+    super::prune_snapshots(tmp_dir.path(), 2);
+    let mut remaining: Vec<String> = std::fs::read_dir(tmp_dir.path())
+        .expect("read tmp dir")
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .collect();
+    remaining.sort();
+    assert_eq!(
+        remaining,
+        vec![
+            "agent-1000003.json".to_string(),
+            "agent-1000004.json".to_string()
+        ],
+        "prune_snapshots must keep the two newest entries and delete the rest",
+    );
+}
+
+#[test]
+fn prune_snapshots_does_not_panic_when_dir_missing() {
+    // read_dir failure path — the function must log via tracing::warn!
+    // (no eprintln, no panic, no propagated error).
+    let missing = std::path::Path::new("/nonexistent/simard/prune-target");
+    super::prune_snapshots(missing, 1); // must not panic
+}
+
 /// Round-trip verification: intake → execution → persistence → recall.
 ///
 /// Uses `NativeCognitiveMemory` (in-memory LadybugDB) so that stored


### PR DESCRIPTION
## Summary

Fixes two follow-up gaps from issue #1604 / #1427 in `src/memory_consolidation/mod.rs`:

- **G10**: `persistence_memory_operations` now propagates snapshot save errors instead of silently swallowing them. This is the same silent-degradation bug class #1427 was filed against — a feature whose stated purpose is *durable* cross-session recall must not silently skip persistence on disk-full or permission errors.
- **G11**: `prune_snapshots` migrated from `eprintln!` to `tracing::warn!/debug!` so operators can route prune-failure visibility through the normal log subscriber chain.

These are the smallest-first follow-up tickets called out in the issue's *Suggested follow-up tickets* list.

## API change (additive only)

A new `pub fn persistence_memory_operations_with_snapshot_dir(session_id, bridge, snapshot_dir_override: Option<&Path>)` exposes the snapshot-dir override so callers (and tests) can inject a deliberately-broken or temporary directory.

The original `persistence_memory_operations(session_id, bridge)` signature is **unchanged** and delegates to the new helper with `None`. The runtime call site at `src/runtime/session.rs:68` requires no change.

## Tests

Added 4 tests under `src/memory_consolidation/tests.rs`:

| Test | Validates |
|---|---|
| `persistence_propagates_snapshot_save_error_when_dir_is_a_file` | **Fails without the fix.** Passes a regular file (via `tempfile::NamedTempFile`) as the snapshot dir; `std::fs::write` returns ENOTDIR; the error must surface as `Err`. The pre-fix `match` block would have swallowed it and returned `Ok(())`. |
| `persistence_with_valid_override_dir_writes_snapshot_and_returns_ok` | Happy-path regression guard: real `tempdir` produces exactly one `.json` snapshot. |
| `prune_snapshots_keeps_newest_and_deletes_oldest` | Contract verification — pruning still keeps the newest `keep` files after the tracing migration. |
| `prune_snapshots_does_not_panic_when_dir_missing` | `read_dir` failure path is non-fatal (no panic, no eprintln). |

## Out of scope

The remaining 18 gaps (G1–G9, G12–G20) are tracked in #1604's *Suggested follow-up tickets* list and will land as separate PRs, smallest first.

---

## Merge readiness

### QA-team evidence

- Scenario files: n/a — Simard has no `gadugi-test` scenario harness; this fix is exercised by 4 new unit tests in `src/memory_consolidation/tests.rs` (1 negative-path snapshot save error + 1 happy path + 2 for `prune_snapshots` contract)
- Validation command: `cargo test --release --lib -- memory_consolidation`
- Validation result: **passed** (17/17 tests pass; the new ENOTDIR test asserts the error propagates instead of silent `Ok(())`)
- Run command: pre-push hook on rebased branch (`cargo fmt --check`, `cargo test --release --lib (cognitive_memory|bootstrap|memory_ipc|memory_consolidation)`, `cargo clippy --all-targets --all-features --locked -- -D warnings`)
- Run target: local pre-push fence + CI `verify/pre-commit (push)` + `verify/pre-commit (pull_request)`
- Run result: **passed** (all 7 CI checks green on commit `5f553f5e` after rebase)
- Evidence location: pre-push hook output captured at push step:
  ```
  cargo fmt --all -- --check                                                                            ✓ Passed
  cargo test --release --lib (cognitive_memory|bootstrap|memory_ipc|memory_consolidation)               ✓ Passed
  cargo clippy --all-targets --all-features --locked -- -D warnings (pre-push)                          ✓ Passed
  ```
  Plus 7 fresh CI checks all SUCCESS on commit `5f553f5e` after rebase on `main@0f5f078d`.

### Documentation

- User-facing docs impact: **no** — change is internal to `memory_consolidation`; the public function signature `persistence_memory_operations(session_id, bridge)` is preserved (the new `_with_snapshot_dir` variant is additive)
- Updated docs: none required (the operator visibility improvement is migrating prune logging from `eprintln!` to `tracing::warn!`/`debug!`, which uses the existing log routing — the operator already has `tracing` configured in the standard subscriber)
- PR description links added: n/a
- Rationale if not applicable: changed surfaces are `src/memory_consolidation/mod.rs` (function bodies + new additive helper) and `src/memory_consolidation/tests.rs` (4 new tests) — internal correctness fix with no API/CLI/config break

### Quality-audit

- Cycle 1 summary: initial implementation — fixed silent-error swallow in `persistence_memory_operations`, migrated prune logging to tracing, added 4 unit tests including the negative-path snapshot save error test that fails without the fix. Validation: `cargo build --lib` ✓; `cargo test --lib -- memory_consolidation` ✓ (17/17)
- Cycle 2 summary: rebased onto `origin/main@0f5f078d` (which now includes the pre-commit hook installer from PR #1695 and the `agent_kind_from_env` serial-test flake fix). No conflicts. Pre-push hook ran cargo fmt + targeted tests + cargo clippy --all-targets --all-features --locked — all green
- Cycle 3 summary: CI verification — all 7 checks SUCCESS after force-push on `5f553f5e` (verify/pre-commit, verify/install-real, verify/e2e-dashboard on both push + pull_request events; GitGuardian)
- Additional cycles: none required
- Final clean cycle: **Cycle 3** (zero clippy warnings, zero fmt deltas, zero test failures, all CI green)
- Fixes followed default-workflow: yes — implement → test → rebase → push → re-validate
- Convergence summary: 2-file diff, +179/-17 lines, all unit tests pass, all CI green; backward-compat preserved (additive API only)

### CI

- Checks command: `gh pr checks 1607 --repo rysweet/Simard`
- Result: **all green** — 7 checks SUCCESS, 0 failing, 0 pending, 0 skipped
- Skipped checks: none
- Flaky reruns performed: none needed — fresh CI on rebased commit `5f553f5e` passed cleanly first time
- Real failures fixed: none on this branch (the rebase pulled in the upstream `agent_kind_from_env` serial-test flake fix)

### PR description evidence

- This PR description follows the merge-ready template at `~/.copilot/skills/merge-ready/pr-description-template.md`
- All six required evidence headings present (QA-team evidence, Documentation, Quality-audit, CI, PR description evidence, Scope)
- Verdict section below

### Scope

- Changed files reviewed: 2 files, +179/-17 lines total
  - `src/memory_consolidation/mod.rs` — fix the silent-`match` swallow in `persistence_memory_operations`; add `persistence_memory_operations_with_snapshot_dir` helper; migrate `prune_snapshots` logging to `tracing`
  - `src/memory_consolidation/tests.rs` — 4 new unit tests covering the snapshot-error propagation, happy path, and prune contract
- Unrelated changes: none

### Verdict

- Merge-ready: **yes**
- Remaining blockers: none

Refs #1604, #1427

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
