### PR TITLE
feat(meeting): color-code REPL prompt and assistant role label (#1584)

### DIFF
--- a/src/meeting_repl/repl.rs
+++ b/src/meeting_repl/repl.rs
@@ -14,7 +14,22 @@ use crate::meeting_facilitator::MeetingSession;
 use super::color::{cyan, green, yellow};
 use super::spinner::Spinner;
 
-const PROMPT: &str = "simard:meeting> ";
+const PROMPT_TEXT: &str = "simard:meeting> ";
+
+/// Build the live REPL prompt, optionally color-coded.
+///
+/// The literal text is always `simard:meeting> ` so non-TTY callers and tests
+/// can match on it without dealing with ANSI codes; color is applied via the
+/// `color::cyan` helper which already honors `NO_COLOR`.
+fn prompt_string() -> String {
+    cyan(PROMPT_TEXT)
+}
+
+/// Role label shown before each assistant response in the live conversation
+/// view. Color-coded green to mirror `simard:meeting>` (cyan) for the user.
+fn assistant_label() -> String {
+    green("Simard:")
+}
 
 /// Run the interactive meeting REPL.
 ///
@@ -52,9 +67,10 @@ pub fn run_meeting_repl<R: BufRead, W: Write>(
     )
     .ok();
 
+    let prompt = prompt_string();
     let mut line = String::new();
     loop {
-        write!(output, "{PROMPT}").ok();
+        write!(output, "{prompt}").ok();
         output.flush().ok();
 
         line.clear();
@@ -146,7 +162,7 @@ pub fn run_meeting_repl<R: BufRead, W: Write>(
                         Ok(resp) => {
                             spinner.stop();
                             if !resp.content.is_empty() {
-                                writeln!(output, "{}\n", resp.content).ok();
+                                writeln!(output, "{} {}\n", assistant_label(), resp.content).ok();
                             }
                         }
                         Err(e) => {
@@ -196,7 +212,7 @@ pub fn run_meeting_repl<R: BufRead, W: Write>(
                     Ok(resp) => {
                         spinner.stop();
                         if !resp.content.is_empty() {
-                            writeln!(output, "\n{}\n", resp.content).ok();
+                            writeln!(output, "\n{} {}\n", assistant_label(), resp.content).ok();
                         }
                     }
                     Err(e) => {

--- a/src/meeting_repl/tests_repl.rs
+++ b/src/meeting_repl/tests_repl.rs
@@ -208,6 +208,86 @@ fn repl_preview_shows_handoff_preview() {
 
 #[test]
 #[serial]
+fn repl_live_output_uses_colored_prompt_and_assistant_label() {
+    // Ensure NO_COLOR is unset so ANSI escapes are emitted.
+    // SAFETY: serial_test guards against parallel access to env vars.
+    unsafe { std::env::remove_var("NO_COLOR") };
+
+    let bridge = mock_bridge();
+    let agent = MockAgentSession::new("Acknowledged.");
+    let input = b"Quick check\n/close\n";
+    let mut reader = &input[..];
+    let mut output = Vec::new();
+
+    run_meeting_repl(
+        "Live label test",
+        &bridge,
+        Some(Box::new(agent)),
+        "",
+        &mut reader,
+        &mut output,
+    )
+    .unwrap();
+
+    let output_str = String::from_utf8(output).unwrap();
+    // Prompt text is preserved literally so existing tests/scripts still match.
+    assert!(
+        output_str.contains("simard:meeting>"),
+        "prompt text should be present: {output_str}"
+    );
+    // Cyan ANSI escape (\x1b[36m) should wrap the prompt when NO_COLOR is unset.
+    assert!(
+        output_str.contains("\x1b[36msimard:meeting> \x1b[0m"),
+        "prompt should be color-coded cyan: {output_str:?}"
+    );
+    // Assistant responses get a green-coded "Simard:" role label.
+    assert!(
+        output_str.contains("\x1b[32mSimard:\x1b[0m Acknowledged."),
+        "assistant response should be prefixed with colored role label: {output_str:?}"
+    );
+}
+
+#[test]
+#[serial]
+fn repl_no_color_env_strips_prompt_and_label_escapes() {
+    // SAFETY: serial_test guards against parallel access to env vars.
+    unsafe { std::env::set_var("NO_COLOR", "1") };
+
+    let bridge = mock_bridge();
+    let agent = MockAgentSession::new("Plain reply.");
+    let input = b"Plain please\n/close\n";
+    let mut reader = &input[..];
+    let mut output = Vec::new();
+
+    run_meeting_repl(
+        "NO_COLOR test",
+        &bridge,
+        Some(Box::new(agent)),
+        "",
+        &mut reader,
+        &mut output,
+    )
+    .unwrap();
+
+    unsafe { std::env::remove_var("NO_COLOR") };
+
+    let output_str = String::from_utf8(output).unwrap();
+    assert!(
+        !output_str.contains("\x1b["),
+        "no ANSI escapes should appear when NO_COLOR is set: {output_str:?}"
+    );
+    assert!(
+        output_str.contains("simard:meeting>"),
+        "plain prompt still present: {output_str}"
+    );
+    assert!(
+        output_str.contains("Simard: Plain reply."),
+        "plain assistant label still present: {output_str}"
+    );
+}
+
+#[test]
+#[serial]
 fn repl_help_includes_theme_recap_preview() {
     let bridge = mock_bridge();
     let agent = MockAgentSession::new("ok");


### PR DESCRIPTION
## Summary

Implements the **second** UX item from the proposed-improvements list in #1584. (The first — show a spinner during LLM turns — is already in place via `Spinner::after_default_delay` on every `backend.send_message` call site.)

The interactive meeting REPL now:
- Wraps the live `simard:meeting>` prompt in **cyan** so the user's input boundary stands out from rendered conversation text.
- Prefixes each assistant response (both `/template` apply and free conversation) with a **green** `Simard:` role label, so transcripts make role boundaries obvious at a glance.

Both behaviors honor `NO_COLOR` via the existing `color::cyan` / `color::green` helpers (which already implement the `NO_COLOR` contract). The literal prompt text `simard:meeting>` is preserved verbatim so existing scripts and tests that match on it keep working.

## Files changed

- `src/meeting_repl/repl.rs`
  - Replace the `PROMPT` const with two helpers: `prompt_string()` (cyan-wrapped prompt) and `assistant_label()` (green `Simard:` label).
  - Use the colored label when emitting both template-apply responses and conversational responses.
- `src/meeting_repl/tests_repl.rs`
  - New test `repl_live_output_uses_colored_prompt_and_assistant_label` — asserts the cyan prompt wrap (`\x1b[36msimard:meeting> \x1b[0m`) and the green assistant label (`\x1b[32mSimard:\x1b[0m Acknowledged.`) appear when `NO_COLOR` is unset.
  - New test `repl_no_color_env_strips_prompt_and_label_escapes` — asserts no ANSI escapes appear and the plain `Simard: …` label is still present when `NO_COLOR=1`. Both tests are `#[serial]` because they touch the `NO_COLOR` env var.

---

## Merge readiness

### QA-team evidence

- Scenario files: n/a — Simard has no `gadugi-test` scenario harness; this UX change is exercised by 2 new unit tests in `src/meeting_repl/tests_repl.rs` (one with `NO_COLOR` unset, one with `NO_COLOR=1`)
- Validation command: `cargo test --release --lib -- meeting`
- Validation result: **passed** (341 tests pass including 2 new tests; the new tests use `#[serial]` because they touch the `NO_COLOR` env var)
- Run command: pre-push hook on rebased branch (`cargo fmt --check`, `cargo test --release --lib (cognitive_memory|bootstrap|memory_ipc|memory_consolidation)`, `cargo clippy --all-targets --all-features --locked -- -D warnings`)
- Run target: local pre-push fence + CI `verify/pre-commit (push)` + `verify/pre-commit (pull_request)`
- Run result: **passed** (all 7 CI checks green on commit `a5fb8ec4` after rebase)
- Evidence location: pre-push hook output captured at push step:
  ```
  cargo fmt --all -- --check                                                                            ✓ Passed
  cargo test --release --lib (cognitive_memory|bootstrap|memory_ipc|memory_consolidation)               ✓ Passed
  cargo clippy --all-targets --all-features --locked -- -D warnings (pre-push)                          ✓ Passed
  ```
  Plus 7 fresh CI checks all SUCCESS on commit `a5fb8ec4` after rebase on `main@0f5f078d`.

### Documentation

- User-facing docs impact: **no** — change is internal styling of the REPL output; the literal prompt text `simard:meeting>` is preserved verbatim and `NO_COLOR` honored via existing helpers, so no operator-facing surface needs updating
- Updated docs: none required (the REPL prompt is its own self-documentation; the `NO_COLOR` contract is industry-standard and the helpers already implement it)
- PR description links added: n/a
- Rationale if not applicable: changed surfaces are `src/meeting_repl/repl.rs` (prompt + assistant-label helpers) and `src/meeting_repl/tests_repl.rs` (two new tests) — internal terminal styling with no API/CLI flag/config impact

### Quality-audit

- Cycle 1 summary: initial implementation — wrapped prompt in cyan, prefixed assistant responses with green `Simard:` label, added 2 unit tests covering color-on and `NO_COLOR=1` paths. Validation: `cargo build --lib` ✓; `cargo test --lib -- meeting` ✓ (341/341)
- Cycle 2 summary: rebased onto `origin/main@0f5f078d` (which now includes the pre-commit hook installer from PR #1695 and the `agent_kind_from_env` serial-test flake fix). No conflicts. Pre-push hook ran cargo fmt + targeted tests + cargo clippy --all-targets --all-features --locked — all green
- Cycle 3 summary: CI verification — all 7 checks SUCCESS after force-push on `a5fb8ec4` (verify/pre-commit, verify/install-real, verify/e2e-dashboard on both push + pull_request events; GitGuardian)
- Additional cycles: none required
- Final clean cycle: **Cycle 3** (zero clippy warnings, zero fmt deltas, zero test failures, all CI green)
- Fixes followed default-workflow: yes — implement → test → rebase → push → re-validate
- Convergence summary: 2-file diff, +100/-4 lines, all unit tests pass, all CI green; backward-compat preserved (literal prompt text unchanged)

### CI

- Checks command: `gh pr checks 1608 --repo rysweet/Simard`
- Result: **all green** — 7 checks SUCCESS, 0 failing, 0 pending, 0 skipped
- Skipped checks: none
- Flaky reruns performed: none needed — fresh CI on rebased commit `a5fb8ec4` passed cleanly first time
- Real failures fixed: none on this branch (the rebase pulled in the upstream `agent_kind_from_env` serial-test flake fix)

### PR description evidence

- This PR description follows the merge-ready template at `~/.copilot/skills/merge-ready/pr-description-template.md`
- All six required evidence headings present (QA-team evidence, Documentation, Quality-audit, CI, PR description evidence, Scope)
- Verdict section below

### Scope

- Changed files reviewed: 2 files, +100/-4 lines total
  - `src/meeting_repl/repl.rs` — replace `PROMPT` const with `prompt_string()` and `assistant_label()` helpers; use them in template-apply and conversational response paths
  - `src/meeting_repl/tests_repl.rs` — 2 new `#[serial]` unit tests for color-on and `NO_COLOR=1` paths
- Unrelated changes: none

### Verdict

- Merge-ready: **yes**
- Remaining blockers: none

Refs #1584

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
