### PR TITLE
fix(memory): three cognitive-memory adapter regressions (Bug 1/2/3, #1590)

### DIFF
--- a/docs/concepts/goal-board-persistence.md
+++ b/docs/concepts/goal-board-persistence.md
@@ -1,13 +1,13 @@
 ---
 title: Goal board persistence — cognitive-memory single source of truth
 description: How Simard loads and saves the goal board across OODA cycles, dashboard handlers, meeting flows, and the engineer loop, with cognitive memory as the sole persistence target.
-last_updated: 2026-05-08
+last_updated: 2026-05-09
 owner: simard
 doc_type: concept
-status: design — partially implemented
 related:
   - ../reference/goal-board-api.md
   - ../reference/cognitive-memory-bridge-helpers.md
+  - ../reference/cognitive-memory-goal-store.md
   - ../howto/recover-goal-board.md
   - ../architecture/overview.md
   - ../reference/subagent-tmux-tracking.md
@@ -15,38 +15,34 @@ related:
 
 # Goal board persistence — cognitive-memory single source of truth
 
-> **Status: design specification — partially implemented (issue [#1590](https://github.com/rysweet/Simard/issues/1590)).**
->
-> The persistence APIs (`load_goal_board`, `save_goal_board`,
-> `persist_board`) and the integrity guard already exist in
-> `src/goal_curation/operations.rs`, and the OODA cycle already uses them
-> as its sole goal-board persistence path.
->
-> The migration of **other** consumers (dashboard handlers, meeting REPL
-> flows, engineer loop) onto these APIs — together with the new
-> `active_goals_as_records` adapter and the `launch_writer_bridge`/
-> `open_reader_bridge` helpers — is the in-flight work tracked by issue
-> #1590. The "Consumer matrix" below is split into **Current state** and
-> **Target state (after #1590)** to make it clear which call sites have
-> moved and which still read `goal_records.json` directly.
+This document describes the post-issue-[#1590](https://github.com/rysweet/Simard/issues/1590)
+state in which **cognitive memory is the sole persistence target** for the
+goal board across the OODA cycle, dashboard handlers, meeting REPL flows,
+the engineer loop, and `bootstrap`-assembled local sessions. The
+persistence APIs (`load_goal_board`, `save_goal_board`, `persist_board`)
+and the integrity guard live in `src/goal_curation/operations.rs`. The
+adapter pattern that fronts them as a `GoalStore` for `RuntimePorts` is
+the [`CognitiveMemoryGoalStore`](../reference/cognitive-memory-goal-store.md).
 
 ## The problem this solves
 
-The goal board has historically been persisted to **two** places: the
+The goal board was historically persisted to **two** places: the
 cognitive memory graph (under the `goal-board:snapshot` fact) and a
 `goal_records.json` file in `$SIMARD_STATE_ROOT`. Different consumers read
 from different places:
 
 - The OODA cycle wrote to both, then read disk-first on the next cycle.
-- The operator dashboard reads `goal_records.json` directly from several
+- The operator dashboard read `goal_records.json` directly from several
   handlers (`goals.rs`, `workboard.rs`, `current_work.rs`, `metrics.rs`)
-  and writes to it directly from the dashboard mutation paths.
+  and wrote to it directly from the dashboard mutation paths.
 - The meeting REPL goal-curation and improvement-curation flows read
   through `FileBackedGoalStore`, which targets `goal_records.json`.
-- The engineer loop reads its "next five goals" through the same
+- The engineer loop read its "next five goals" through the same
   `FileBackedGoalStore`.
+- `bootstrap`-assembled local sessions held a
+  `FileBackedGoalStore`-backed `Arc<dyn GoalStore>` in `RuntimePorts`.
 
-This produces a class of subtle bugs:
+This produced a class of subtle bugs:
 
 - **Drift** — a dashboard write that succeeded on disk but was racing a
   daemon cycle could be silently overwritten by the daemon's next save.
@@ -147,29 +143,12 @@ without operator intervention.
 
 ---
 
-## Consumer matrix — current state
-
-| Consumer | File | Pattern today |
-|----------|------|---------------|
-| OODA cycle | `src/ooda_loop/cycle.rs` | ✅ Uses `load_goal_board` + `persist_board` against the daemon's in-process bridge |
-| Dashboard goals API | `src/operator_commands_dashboard/goals.rs` | ❌ `std::fs::read_to_string("…/goal_records.json")` + `serde_json::from_str` for reads; `std::fs::write` for mutations |
-| Dashboard workboard | `src/operator_commands_dashboard/workboard.rs` | ❌ `std::fs::read_to_string("…/goal_records.json")` |
-| Dashboard current work | `src/operator_commands_dashboard/current_work.rs` | ❌ inline file read |
-| Dashboard metrics panel | `src/operator_commands_dashboard/metrics.rs` | ❌ inline file read |
-| Meeting goal curation | `src/operator_commands_meeting/goal_curation.rs:58` | ❌ `FileBackedGoalStore::try_new(state_root.join("goal_records.json"))` |
-| Meeting improvement curation | `src/operator_commands_meeting/improvement_curation.rs:123` | ❌ `FileBackedGoalStore::try_new(state_root.join("goal_records.json"))` |
-| Engineer loop | `src/engineer_loop/mod.rs:276` | ❌ `FileBackedGoalStore::try_new(state_root.join("goal_records.json")).active_top_goals(5)` |
-| Meeting bridge acquisition | `src/operator_commands_meeting/meeting_session.rs:29` | ⚠️ Inline three-tier ladder (`launch_real_meeting_bridge`) — works correctly, but pattern is duplicated everywhere |
-
-✅ already on cognitive-memory-only; ❌ still reads `goal_records.json`;
-⚠️ correct behaviour but not yet extracted as a shared helper.
-
-## Consumer matrix — target state (after #1590)
+## Consumer matrix
 
 | Consumer | File | Bridge helper | Read fn | Write fn | Notes |
 |----------|------|---------------|---------|----------|-------|
 | OODA cycle | `src/ooda_loop/cycle.rs` | (uses daemon's own bridge) | `load_goal_board` | `persist_board` | Records an episode in addition to saving the snapshot |
-| Dashboard goals API | `src/operator_commands_dashboard/goals.rs` | `launch_writer_bridge` (writes), `open_reader_bridge` (reads) | `load_goal_board` | `save_goal_board` (×6 mutation handlers) | Replaces six prior `std::fs::write` sites |
+| Dashboard goals API | `src/operator_commands_dashboard/goals.rs` | `launch_writer_bridge` (writes), `open_reader_bridge` (reads) | `load_goal_board` | `save_goal_board` (×6 mutation handlers) | The in-process Arc shortcut keeps mutation handlers from going through Unix-socket IPC against the same process |
 | Dashboard workboard | `src/operator_commands_dashboard/workboard.rs` | `open_reader_bridge` | `load_goal_board` | — | Read-only |
 | Dashboard current work | `src/operator_commands_dashboard/current_work.rs` | `open_reader_bridge` | `load_goal_board` | — | Read-only |
 | Dashboard metrics panel | `src/operator_commands_dashboard/metrics.rs` | `open_reader_bridge` | `load_goal_board` | — | Reports `{ source: "cognitive-memory:goal-board:snapshot", count: N }` |
@@ -177,11 +156,12 @@ without operator intervention.
 | Meeting goal curation | `src/operator_commands_meeting/goal_curation.rs` | `open_reader_bridge` (read-curation), `launch_writer_bridge` (mutation paths) | `load_goal_board` + `active_goals_as_records` | `save_goal_board` | Replaces `FileBackedGoalStore` |
 | Meeting improvement curation | `src/operator_commands_meeting/improvement_curation.rs` | `launch_writer_bridge` | `load_goal_board` + `active_goals_as_records` | `save_goal_board` | Replaces `FileBackedGoalStore` |
 | Engineer loop | `src/engineer_loop/mod.rs` | `open_reader_bridge` | `load_goal_board` + `active_goals_as_records` | — | Reads top 5 active goals as `GoalRecord`s |
-| Meeting bridge acquisition | `src/operator_commands_meeting/meeting_session.rs` | `launch_writer_bridge` | — | — | `launch_real_meeting_bridge` becomes a thin wrapper around `launch_writer_bridge(&default_state_root())` |
+| Meeting bridge acquisition | `src/operator_commands_meeting/meeting_session.rs` | `launch_writer_bridge` | — | — | `launch_real_meeting_bridge` is a thin wrapper around `launch_writer_bridge(&default_state_root())` |
+| Bootstrap-assembled `RuntimePorts.goal_store` | `src/bootstrap/assembly.rs` | `CognitiveMemoryGoalStore` (which uses both helpers internally) | adapter `list` / `active_top_goals` | adapter `upsert` / `remove` | Replaces `FileBackedGoalStore::try_new(config.goal_store_path())` |
 
-Once all rows above are landed, `FileBackedGoalStore` is no longer
-instantiated in any production goal-board code path. It remains in
-`src/goals/store.rs` as a value type used by `meeting_backend` and tests.
+`FileBackedGoalStore` is no longer instantiated in any production
+goal-board code path. It remains in `src/goals/store.rs` as a value type
+used by `meeting_backend` and tests.
 
 ---
 

--- a/docs/concepts/goal-board-persistence.md
+++ b/docs/concepts/goal-board-persistence.md
@@ -15,14 +15,25 @@ related:
 
 # Goal board persistence — cognitive-memory single source of truth
 
-This document describes the post-issue-[#1590](https://github.com/rysweet/Simard/issues/1590)
-state in which **cognitive memory is the sole persistence target** for the
-goal board across the OODA cycle, dashboard handlers, meeting REPL flows,
-the engineer loop, and `bootstrap`-assembled local sessions. The
-persistence APIs (`load_goal_board`, `save_goal_board`, `persist_board`)
-and the integrity guard live in `src/goal_curation/operations.rs`. The
-adapter pattern that fronts them as a `GoalStore` for `RuntimePorts` is
-the [`CognitiveMemoryGoalStore`](../reference/cognitive-memory-goal-store.md).
+> **Status: partially implemented.** Issue
+> [#1590](https://github.com/rysweet/Simard/issues/1590) and its merged
+> follow-up PRs migrated the OODA cycle, the dashboard handlers, the
+> meeting REPL flows, and the engineer loop onto cognitive memory. The
+> remaining gap — `bootstrap::assembly` still constructs an
+> `Arc<FileBackedGoalStore>` for `RuntimePorts.goal_store` — is
+> tracked under the issue-#1590 follow-up regression-fix work and the
+> ignored `improvement_curation_read_probe_…` test in
+> `tests/improvement_curation.rs`. Sections marked **planned** describe
+> the post-follow-up state.
+
+This document describes the **target state** in which **cognitive memory
+is the sole persistence target** for the goal board across the OODA cycle,
+dashboard handlers, meeting REPL flows, the engineer loop, and
+`bootstrap`-assembled local sessions. The persistence APIs
+(`load_goal_board`, `save_goal_board`, `persist_board`) and the integrity
+guard live in `src/goal_curation/operations.rs`. The adapter pattern that
+fronts them as a `GoalStore` for `RuntimePorts` is the planned
+[`CognitiveMemoryGoalStore`](../reference/cognitive-memory-goal-store.md).
 
 ## The problem this solves
 
@@ -53,10 +64,12 @@ This produced a class of subtle bugs:
 
 Issue #1590 collapses both stores into one: the
 `goal-board:snapshot` fact in cognitive memory becomes the **single source
-of truth**. After the migration, no consumer reads or writes
-`goal_records.json` in production code paths. A one-shot bootstrap
-migration imports any pre-existing disk file on first startup and deletes
-it after a successful re-write into cognitive memory.
+of truth**. After the in-progress migration completes (the
+`bootstrap::assembly` adapter swap is the last piece), no consumer reads
+or writes `goal_records.json` in production code paths that go through
+`RuntimePorts`. A one-shot bootstrap migration imports any pre-existing
+disk file on first startup and deletes it after a successful re-write
+into cognitive memory.
 
 ---
 
@@ -83,15 +96,21 @@ writer lock directly.
 
 ### Bridge ladders
 
-`launch_writer_bridge` resolves two writer-bearing tiers in order:
+`launch_writer_bridge` today resolves two writer-bearing tiers in order,
+followed by a read-only fallback:
 
 1. **Daemon IPC** — connect to `~/.simard/memory.sock` if it exists.
 2. **Local writer** — open the LadybugDB store directly with the writer
    lock, after running the stale-lock reaper.
+3. **Read-only fallback (current)** — wrap a read-only handle as a
+   `WriterBridge`. **The issue-#1590 follow-up removes this tier**; once
+   that lands, callers learn synchronously whether they got a writer
+   instead of receiving a silently-degraded handle.
 
-If both fail, `launch_writer_bridge` returns `Err` immediately. There is
-no silent read-only fallback — callers learn synchronously whether they
-got a writer.
+Planned: an in-process Arc shortcut (tier 0) lets the daemon hand its
+own `Arc<dyn CognitiveMemoryOps>` directly to in-process callers (the
+dashboard, the OODA reflection paths) without going through the Unix
+socket.
 
 `open_reader_bridge` resolves two tiers:
 
@@ -152,16 +171,17 @@ without operator intervention.
 | Dashboard workboard | `src/operator_commands_dashboard/workboard.rs` | `open_reader_bridge` | `load_goal_board` | — | Read-only |
 | Dashboard current work | `src/operator_commands_dashboard/current_work.rs` | `open_reader_bridge` | `load_goal_board` | — | Read-only |
 | Dashboard metrics panel | `src/operator_commands_dashboard/metrics.rs` | `open_reader_bridge` | `load_goal_board` | — | Reports `{ source: "cognitive-memory:goal-board:snapshot", count: N }` |
-| Dashboard memory panel | `src/operator_commands_dashboard/memory.rs` | (n/a) | (n/a) | (n/a) | The `goal_records.json` artefact label is removed; only on-disk artefacts are listed here |
-| Meeting goal curation | `src/operator_commands_meeting/goal_curation.rs` | `open_reader_bridge` (read-curation), `launch_writer_bridge` (mutation paths) | `load_goal_board` + `active_goals_as_records` | `save_goal_board` | Replaces `FileBackedGoalStore` |
+| Meeting goal curation | `src/operator_commands_meeting/goal_curation.rs` | `open_reader_bridge` (reads), `launch_writer_bridge` (mutations) | `load_goal_board` + `active_goals_as_records` | `save_goal_board` | Replaces `FileBackedGoalStore` |
 | Meeting improvement curation | `src/operator_commands_meeting/improvement_curation.rs` | `launch_writer_bridge` | `load_goal_board` + `active_goals_as_records` | `save_goal_board` | Replaces `FileBackedGoalStore` |
-| Engineer loop | `src/engineer_loop/mod.rs` | `open_reader_bridge` | `load_goal_board` + `active_goals_as_records` | — | Reads top 5 active goals as `GoalRecord`s |
-| Meeting bridge acquisition | `src/operator_commands_meeting/meeting_session.rs` | `launch_writer_bridge` | — | — | `launch_real_meeting_bridge` is a thin wrapper around `launch_writer_bridge(&default_state_root())` |
-| Bootstrap-assembled `RuntimePorts.goal_store` | `src/bootstrap/assembly.rs` | `CognitiveMemoryGoalStore` (which uses both helpers internally) | adapter `list` / `active_top_goals` | adapter `upsert` / `remove` | Replaces `FileBackedGoalStore::try_new(config.goal_store_path())` |
+| Engineer loop | `src/engineer_loop/mod.rs` | `launch_writer_bridge` (used because the load step also performs the legacy `goal_records.json` migration write-back) | `load_goal_board` + `active_goals_as_records` | — | Reads top 5 active goals as `GoalRecord`s |
+| Bootstrap-assembled `RuntimePorts.goal_store` | `src/bootstrap/assembly.rs` | **planned** `CognitiveMemoryGoalStore` (uses both helpers internally) | adapter `list` / `active_top_goals` | adapter `upsert` / `remove` | Currently still `FileBackedGoalStore::try_new(config.goal_store_path())` — see [goal-store adapter](../reference/cognitive-memory-goal-store.md) |
 
-`FileBackedGoalStore` is no longer instantiated in any production
-goal-board code path. It remains in `src/goals/store.rs` as a value type
-used by `meeting_backend` and tests.
+After the bootstrap-adapter migration lands, `FileBackedGoalStore` is no
+longer instantiated by `RuntimePorts.goal_store`. It remains in
+`src/goals/store.rs` as a value type — `src/meeting_backend/mod.rs`
+constructs one through its own setup path, and several tests use it
+directly. Both of those uses are out of scope for the issue-#1590
+follow-up.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,9 +28,7 @@ Terminal sessions and repo-grounded engineer runs now bridge through one explici
 - [How to inspect meeting records](./howto/inspect-meeting-records.md) - Read back the latest durable meeting record without mutating stored state.
 - [How to inspect improvement-curation state](./howto/inspect-improvement-curation-state.md) - Read back the latest approved, deferred, and promoted improvement state without mutation.
 - [How to inspect the durable goal register](./howto/inspect-durable-goal-register.md) - Read back the active top-5 goals and backlog without mutation.
-<!-- Held from index until issue #1590 implementation lands:
-- [How to recover a corrupted or missing goal board](./howto/recover-goal-board.md) — design specification for cognitive-memory-only recovery (commands not yet implemented).
--->
+- [How to recover a corrupted or missing goal board](./howto/recover-goal-board.md) — cognitive-memory-only recovery commands.
 
 - [How to run the OODA daemon](./howto/run-ooda-daemon.md) - Start the continuous OODA loop for autonomous goal-driven operation and act on meeting decisions.
 - [Simard CLI reference](./reference/simard-cli.md) - Look up the shipped command tree, `engineer read` audit surface, and compatibility mappings.
@@ -39,6 +37,9 @@ Terminal sessions and repo-grounded engineer runs now bridge through one explici
 - [Meeting backend API reference](./reference/meeting-backend-api.md) - Rust API for the unified MeetingBackend.
 - [LightweightChatSession reference](./reference/lightweight-chat-session.md) - Direct-subprocess session used for Copilot-provider meeting turns (no PTY overhead).
 - [Terminal session idle detection](./reference/terminal-session-idle-detection.md) - How Simard determines when a PTY session is genuinely idle vs. silently computing.
+- [Cognitive memory bridge helpers](./reference/cognitive-memory-bridge-helpers.md) - `launch_writer_bridge` / `open_reader_bridge` resolution ladder, the in-process Arc shortcut, and the strict no-silent-degradation contract.
+- [Cognitive-memory goal store adapter](./reference/cognitive-memory-goal-store.md) - The `GoalStore` implementation that backs `RuntimePorts.goal_store` with cognitive memory.
+- [String truncation helpers](./reference/string-truncation-helpers.md) - `truncate_to_char_boundary` for UTF-8-safe byte-budget truncation.
 - [Concept: truthful runtime metadata](./concepts/truthful-runtime-metadata.md) - Read the design rationale behind the stricter runtime contract.
 
 ## Canonical executable surface
@@ -101,11 +102,8 @@ If you are changing architecture, start with the [architecture overview](./archi
 ## Architecture
 
 - [Architecture overview](./architecture/overview.md) - System diagram, core principles, component descriptions, and module map.
-<!-- Held from index until issue #1590 implementation lands:
-- [Goal board persistence](./concepts/goal-board-persistence.md) — design spec for cognitive-memory single source of truth.
-- [Goal board API reference](./reference/goal-board-api.md) — design spec for `active_goals_as_records` adapter and updated load/save semantics.
-- [Cognitive memory bridge helpers](./reference/cognitive-memory-bridge-helpers.md) — design spec for `launch_writer_bridge` and `open_reader_bridge`.
--->
+- [Goal board persistence](./concepts/goal-board-persistence.md) — cognitive-memory single source of truth.
+- [Goal board API reference](./reference/goal-board-api.md) — `active_goals_as_records` adapter and load/save semantics.
 
 - [Agent composition](./architecture/agent-composition.md) - How Simard composes subordinate agents with goal assignment, supervision, and crash recovery.
 - [Cognitive memory](./architecture/cognitive-memory.md) - Six-type memory model, session lifecycle mapping, and hive mind integration.

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,9 +37,9 @@ Terminal sessions and repo-grounded engineer runs now bridge through one explici
 - [Meeting backend API reference](./reference/meeting-backend-api.md) - Rust API for the unified MeetingBackend.
 - [LightweightChatSession reference](./reference/lightweight-chat-session.md) - Direct-subprocess session used for Copilot-provider meeting turns (no PTY overhead).
 - [Terminal session idle detection](./reference/terminal-session-idle-detection.md) - How Simard determines when a PTY session is genuinely idle vs. silently computing.
-- [Cognitive memory bridge helpers](./reference/cognitive-memory-bridge-helpers.md) - `launch_writer_bridge` / `open_reader_bridge` resolution ladder, the in-process Arc shortcut, and the strict no-silent-degradation contract.
-- [Cognitive-memory goal store adapter](./reference/cognitive-memory-goal-store.md) - The `GoalStore` implementation that backs `RuntimePorts.goal_store` with cognitive memory.
-- [String truncation helpers](./reference/string-truncation-helpers.md) - `truncate_to_char_boundary` for UTF-8-safe byte-budget truncation.
+- [Cognitive memory bridge helpers](./reference/cognitive-memory-bridge-helpers.md) - `launch_writer_bridge` / `open_reader_bridge` resolution ladder; design notes for the planned in-process Arc shortcut and strict no-silent-degradation contract (issue #1590 follow-up).
+- [Cognitive-memory goal store adapter](./reference/cognitive-memory-goal-store.md) - Design for the planned `GoalStore` implementation that will back `RuntimePorts.goal_store` with cognitive memory (issue #1590 follow-up).
+- [String truncation helpers](./reference/string-truncation-helpers.md) - Design for the planned `truncate_to_char_boundary` UTF-8-safe byte-budget helper (issue #1590 follow-up).
 - [Concept: truthful runtime metadata](./concepts/truthful-runtime-metadata.md) - Read the design rationale behind the stricter runtime contract.
 
 ## Canonical executable surface

--- a/docs/reference/cognitive-memory-bridge-helpers.md
+++ b/docs/reference/cognitive-memory-bridge-helpers.md
@@ -1,6 +1,6 @@
 ---
 title: Cognitive memory bridge helpers
-description: Reference for launch_writer_bridge and open_reader_bridge — the canonical entry points for obtaining a CognitiveMemoryOps adapter, including the in-process Arc shortcut and the strict no-silent-degradation contract.
+description: Reference for launch_writer_bridge and open_reader_bridge — the canonical entry points for obtaining a CognitiveMemoryOps adapter, including the planned in-process Arc shortcut and strict no-silent-degradation contract.
 last_updated: 2026-05-09
 owner: simard
 doc_type: reference
@@ -12,21 +12,29 @@ related:
 
 # Cognitive memory bridge helpers
 
+> **Status: partially shipped + design.** The two helpers
+> (`launch_writer_bridge`, `open_reader_bridge`) and their two-tier
+> writer/reader ladders are shipped today and used by every consumer listed
+> in the [migration call-site map](#migration-call-site-map). The
+> **in-process `Arc` shortcut** (tier 0) and the **strict
+> no-silent-degradation contract** (removal of the read-only fallback) are
+> tracked under issue
+> [#1590](https://github.com/rysweet/Simard/issues/1590) and its follow-up
+> regression-fix work; sections below marked "Planned" describe behavior that
+> is **not yet present** on `main`. Sections without that marker describe
+> code that exists today.
+
 `src/memory_ipc/launcher.rs` exposes two helper functions that every
 consumer should use to obtain a typed cognitive-memory bridge:
 
 | Helper | Returns | Use case |
 |--------|---------|----------|
-| `launch_writer_bridge` | `SimardResult<WriterBridge>` | Anything that may write — dashboard mutation handlers (`/api/goals/promote/<id>`, `/api/goals/demote/<id>`, `/api/goals/dismiss/<id>`), meeting REPL flows, restore CLI |
-| `open_reader_bridge` | `SimardResult<ReaderBridge>` | Read-only consumers — dashboard read handlers (`workboard`, `current_work`, `metrics`, `goals` GET), engineer-loop top-5 read, inspection tools |
+| `launch_writer_bridge` | `SimardResult<WriterBridge>` | Anything that may write — dashboard mutation handlers (`promote_goal`, `demote_goal`, `dismiss_goal`, …), meeting REPL flows, restore CLI |
+| `open_reader_bridge` | `SimardResult<ReaderBridge>` | Read-only consumers — dashboard read handlers (`workboard`, `current_work`, `metrics`, GET goals), engineer-loop top-5 read, inspection tools |
 
 These helpers encapsulate the **daemon-or-direct fallback ladder** so that
 callers never instantiate `NativeCognitiveMemory` or `RemoteCognitiveMemory`
-directly. Issue [#1590](https://github.com/rysweet/Simard/issues/1590) and
-its follow-up regression-fix PR refined the resolution ladder to add an
-**in-process Arc shortcut** for callers that share a process with the OODA
-daemon, and to **remove the silent read-only fallback** that previously
-masked writer-acquisition failures as `{"status":"ok"}` responses.
+directly.
 
 ---
 
@@ -74,40 +82,36 @@ reported up-front.
 pub fn launch_writer_bridge(state_root: &Path) -> SimardResult<WriterBridge>
 ```
 
-Returns a bridge that supports both reads and writes. Tries three writer
-sources in order, stopping at the first success:
+Returns a bridge that supports both reads and writes.
+
+### Today's resolution ladder
+
+The shipped implementation tries two writer sources in order, then a
+read-only fallback:
 
 | Tier | Source | Condition |
 |------|--------|-----------|
-| 0 | Daemon-registered in-process `Arc<dyn CognitiveMemoryOps>` | Same-process callers (dashboard handlers, OODA reflection paths) when the daemon has registered its writer via `register_in_process_writer` |
 | 1 | `RemoteCognitiveMemory::connect(default_socket_path())` | A running OODA daemon's IPC socket exists at `~/.simard/memory.sock` and `state_root` matches the daemon's |
 | 2 | `NativeCognitiveMemory::open(state_root)` | No daemon socket; this process can take the writer lock directly (after `reap_stale_open_lock`) |
+| 3 (read-only fallback) | `NativeCognitiveMemory::open_read_only(state_root)` | Both writer attempts failed; the helper currently returns the read-only handle wrapped as a `WriterBridge` |
 
-If all three tiers fail, the helper returns
-`Err(SimardError::RuntimeInitFailed { component: "memory-ipc-launcher", … })`.
+Tier 3 is the **silent-degradation hazard** that issue #1590's follow-up
+work targets — see "Planned changes" below.
 
-**There is no read-only fallback at the writer-acquisition path.** A caller
-that asked for a writer always learns synchronously whether one was
-obtainable. Earlier revisions of this helper ended with a tier-3 fallback
-to `NativeCognitiveMemory::open_read_only` and returned the read-only handle
-wrapped as a `WriterBridge` — that produced silent hollow-success bugs
-(dashboard `demote_goal` returning `{"status":"ok"}` while the underlying
-`store_fact` was a no-op). Tier 3 has been removed; the launcher now
-propagates the read-write open error directly.
+### Planned: tier 0 in-process `Arc` shortcut
 
-The helper additionally:
+For callers that share a process with the OODA daemon (the dashboard, the
+OODA reflection loop), tier 0 is added in front of tiers 1–2:
 
-- Creates `state_root` (and parents) on first call via `fs::create_dir_all`.
-- Runs `reap_stale_open_lock` before tier 2 to clear locks left by crashed
-  writers.
+| Tier | Source | Condition |
+|------|--------|-----------|
+| 0 (planned) | Daemon-registered in-process `Arc<dyn CognitiveMemoryOps>` | Same-process callers when the daemon has registered its writer via `register_in_process_writer` |
 
-### Tier 0: in-process Arc shortcut
-
-The OODA daemon registers its live `Arc<dyn CognitiveMemoryOps>` (the same
-handle backing the IPC server) with the launcher at startup:
+The OODA daemon will register its live `Arc<dyn CognitiveMemoryOps>` (the
+same handle backing the IPC server) with the launcher at startup:
 
 ```rust
-// src/memory_ipc/launcher.rs
+// src/memory_ipc/launcher.rs (planned)
 static IN_PROCESS_WRITER: OnceLock<Arc<dyn CognitiveMemoryOps>> = OnceLock::new();
 
 pub fn register_in_process_writer(writer: Arc<dyn CognitiveMemoryOps>) {
@@ -117,23 +121,38 @@ pub fn register_in_process_writer(writer: Arc<dyn CognitiveMemoryOps>) {
 
 When the dashboard (which runs inside the daemon process) calls
 `launch_writer_bridge`, the launcher checks the `OnceLock` first. On a hit,
-it wraps the `Arc` in a `WriterBridge` and returns immediately — no Unix
-socket round-trip, no lock contention, no risk of falling into a read-only
-fallback. This is the **primary path** for in-process callers.
+it wraps the `Arc` in a `WriterBridge` and returns immediately — no
+Unix-socket round-trip, no lock contention, and (importantly) no risk of
+falling into the read-only fallback that today's tier-3 ladder still has.
 
 Non-daemon callers (the meeting REPL, the engineer loop, CLI tools) skip
-tier 0 because nothing has registered into the `OnceLock` in their
-process. They proceed to tier 1 (IPC) and tier 2 (direct open) as before.
+tier 0 because nothing has registered into the `OnceLock` in their process.
+They proceed to tier 1 (IPC) and tier 2 (direct open) as before.
+
+### Planned: remove the silent read-only fallback
+
+Tier 3 (read-only fallback wrapped as `WriterBridge`) is **removed** in the
+follow-up. After the change, if tiers 0–2 all fail to obtain a writer, the
+helper returns `Err(SimardError::RuntimeInitFailed { component:
+"memory-ipc-launcher", … })`.
+
+This matters because dashboard mutation handlers currently treat
+`launch_writer_bridge` success as "we have a writer". When the helper
+silently returns a read-only handle, `save_goal_board(&board, bridge.ops())`
+silently no-ops at the IPC transport layer (or the underlying
+`store_fact` call returns `BridgeTransportError`), and the handler's HTTP
+response body becomes whatever its post-write code path produces (today,
+`{"status":"ok"}` for the dashboard mutation handlers). This is the
+hollow-success bug class targeted by issue #1590's follow-up.
 
 ### Tier 1 → 2 transition: state-root agreement
 
 Tier 1 (IPC) only fires when the requested `state_root` matches the
-daemon's owned state root, computed via
-`state_root_matches_daemon(state_root)`. Both sides canonicalize their
-paths (resolving symlinks and `..` segments) before comparing. If they
-disagree, the launcher silently skips IPC and proceeds to tier 2 — this
-prevents a daemon owning a different DB from masking the writes the caller
-intended for its own DB.
+daemon's owned state root, computed via `state_root_matches_daemon`. Both
+sides canonicalize their paths (resolving symlinks and `..` segments)
+before comparing. If they disagree, the launcher silently skips IPC and
+proceeds to tier 2 — this prevents a daemon owning a different DB from
+masking the writes the caller intended for its own DB.
 
 If tier 1 is selected and the IPC connection fails (socket exists but
 `RemoteCognitiveMemory::connect` errors), the launcher logs the error to
@@ -141,9 +160,9 @@ stderr and falls through to tier 2 rather than returning early. This keeps
 short-window daemon restarts (where the socket file lingers a few hundred
 milliseconds) from producing spurious failures.
 
-### Defensive guard: `is_read_only()`
+### Planned: defensive `is_read_only()` invariant
 
-`CognitiveMemoryOps` exposes:
+`CognitiveMemoryOps` gains a single defaulted method:
 
 ```rust
 pub trait CognitiveMemoryOps: Send + Sync + 'static {
@@ -156,31 +175,35 @@ pub trait CognitiveMemoryOps: Send + Sync + 'static {
 The IPC client (`RemoteCognitiveMemory`) and the daemon's in-process Arc
 both leave the default `false` because the daemon is the writer.
 
-`WriterBridge::new`/`wrap` debug-asserts `!ops.is_read_only()` before
-returning. In release builds the assertion compiles out, but the launcher
-itself enforces the invariant: tier 0 (Arc), tier 1 (IPC), and tier 2
-(`open`) all return writer-capable handles by construction; the removed
-tier 3 was the only path that could have produced a read-only handle in a
-`WriterBridge`.
+`WriterBridge`'s constructor calls `assert!(!ops.is_read_only(), …)` — an
+always-on assertion (not `debug_assert!`) so the invariant fails loudly
+even in release builds. With tier 3 removed, this assertion exists as a
+belt-and-braces guard against future regressions; tiers 0–2 all return
+writer-capable handles by construction.
 
-**Example — dashboard write handler**
+We chose `assert!` over `debug_assert!` deliberately: a silent degradation
+to read-only is exactly the bug class this work is meant to eliminate, and
+catching it in release builds is worth the negligible runtime cost of one
+virtual call per `WriterBridge` construction.
+
+**Example — dashboard write handler (post-fix)**
 
 ```rust
 use simard::goal_curation::{load_goal_board, save_goal_board};
 use simard::memory_ipc::{launch_writer_bridge, default_state_root};
 
 let state_root = default_state_root();
-let bridge = launch_writer_bridge(&state_root)?;     // Err if no writer available
+let bridge = launch_writer_bridge(&state_root)?;     // Err if no writer
 
 let mut board = load_goal_board(bridge.ops())?;
 mutate(&mut board);
 save_goal_board(&board, bridge.ops())?;
 ```
 
-The `?` on `launch_writer_bridge` is now load-bearing: if it would have
-returned a read-only handle in the prior implementation, it now returns
-`Err`, and the HTTP handler converts that into a 500 with the underlying
-error message rather than `{"status":"ok"}`.
+After the fix, the `?` on `launch_writer_bridge` is load-bearing: where
+today's ladder might silently downgrade and let the handler return
+`{"status":"ok"}`, the post-fix ladder returns `Err`, and the HTTP handler
+converts that into a 500 with the underlying error message.
 
 ---
 
@@ -198,12 +221,12 @@ order:
 | 1 | `RemoteCognitiveMemory::connect(default_socket_path())` | A running daemon's IPC socket exists |
 | 2 | `NativeCognitiveMemory::open_read_only(state_root)` | No daemon; the read-only opener never contends with the writer lock |
 
-Read-only callers should always prefer this helper over `launch_writer_bridge`
-because:
+Read-only callers should always prefer this helper over
+`launch_writer_bridge` because:
 
 - It never attempts to take the writer lock, so it never contends with a
-  running daemon when the IPC socket happens to be missing during a
-  daemon restart.
+  running daemon when the IPC socket happens to be missing during a daemon
+  restart.
 - `open_read_only` is cheap — no WAL recovery, no lock acquisition, no
   reaper.
 
@@ -213,6 +236,9 @@ trait object exposes the full `CognitiveMemoryOps` surface) and will fail
 at runtime with `BridgeTransportError`. Callers should use `WriterBridge`
 when they intend to write — see "Typed bridge wrappers" above for the
 rationale.
+
+`open_reader_bridge` is **not** affected by the issue-#1590 follow-up; its
+ladder is unchanged.
 
 **Example — dashboard read handler**
 
@@ -229,13 +255,14 @@ render_workboard(&board);
 
 ## State root resolution
 
-Both helpers accept a `&Path`. The conventional way to compute that path is:
+Both helpers accept a `&Path`. The conventional way to compute that path
+is:
 
 ```rust
 let state_root = simard::memory_ipc::default_state_root();
 ```
 
-`default_state_root()` already exists today and resolves to:
+`default_state_root()` resolves to:
 
 1. `$SIMARD_STATE_ROOT` if set, else
 2. `$HOME/.simard/state`.
@@ -248,64 +275,41 @@ directory.
 
 ---
 
-## Migration from ad-hoc instantiation
-
-Today (post-issue [#1590](https://github.com/rysweet/Simard/issues/1590) and
-its regression-fix follow-up), every consumer that touches cognitive
-memory uses one of these two helpers. Inline `NativeCognitiveMemory` and
-`RemoteCognitiveMemory` instantiation is reserved for the daemon
-(`SharedMemory` setup) and tests. Direct `goal_records.json` reads via
-`std::fs` and `serde_json` have been removed entirely.
-
-The most-mature inline pattern previously lived in
-`src/operator_commands_meeting/meeting_session.rs::launch_real_meeting_bridge`.
-That function is now a thin wrapper:
-
-```rust
-fn launch_real_meeting_bridge() -> Result<Box<dyn CognitiveMemoryOps>, Box<dyn Error>> {
-    let bridge = launch_writer_bridge(&default_state_root())?;
-    Ok(bridge.into_box())
-}
-```
-
-New consumers should always call the helpers directly rather than copying
-the ladder.
-
----
-
 ## Migration call-site map
 
 The following sites use one of the two helpers in place of inline
-instantiation, `FileBackedGoalStore`, or direct `goal_records.json`
-reads:
+instantiation, `FileBackedGoalStore`, or direct `goal_records.json` reads.
+Rows marked **(planned)** are the consumers covered by the issue-#1590
+follow-up.
 
-| File | Helper |
-|------|--------|
-| `src/operator_commands_meeting/meeting_session.rs` | `launch_writer_bridge` (wrapped as `launch_real_meeting_bridge`) |
-| `src/operator_commands_meeting/goal_curation.rs` | `open_reader_bridge` + `load_goal_board` + `active_goals_as_records` |
-| `src/operator_commands_meeting/improvement_curation.rs` | `launch_writer_bridge` + `load_goal_board` + `active_goals_as_records` |
-| `src/engineer_loop/mod.rs` | `open_reader_bridge` + `load_goal_board` + `active_goals_as_records` |
-| `src/operator_commands_dashboard/goals.rs` (mutation handlers) | `launch_writer_bridge` + `save_goal_board` |
-| `src/operator_commands_dashboard/goals.rs` (GET handlers) | `open_reader_bridge` + `load_goal_board` |
-| `src/operator_commands_dashboard/workboard.rs` | `open_reader_bridge` |
-| `src/operator_commands_dashboard/current_work.rs` | `open_reader_bridge` |
-| `src/operator_commands_dashboard/metrics.rs` | `open_reader_bridge` |
-| `src/bootstrap/assembly.rs` (`goal_store`) | `CognitiveMemoryGoalStore` (which itself uses both helpers) — see [Cognitive-memory goal store adapter](./cognitive-memory-goal-store.md) |
+| Site | Helper | Status |
+|------|--------|--------|
+| `engineer_loop::engineer_loop_run_inner` (top-5 read) | `launch_writer_bridge` | shipped (uses writer for legacy migration write-back; will move to `open_reader_bridge` when migration is removed) |
+| Meeting REPL goal-curation flows | `open_reader_bridge` / `launch_writer_bridge` | shipped |
+| Meeting REPL improvement-curation flows | `launch_writer_bridge` | shipped |
+| Operator dashboard goals API (mutations) | `launch_writer_bridge` | shipped |
+| Operator dashboard goals API (GET) | `open_reader_bridge` | shipped |
+| Operator dashboard workboard / current_work / metrics | `open_reader_bridge` | shipped |
+| `bootstrap::assembly` (`RuntimePorts.goal_store`) | `CognitiveMemoryGoalStore` (planned adapter using both helpers) | **planned** — see [Cognitive-memory goal store adapter](./cognitive-memory-goal-store.md) |
+| Daemon process registers in-process writer | `register_in_process_writer` | **planned** |
 
 `FileBackedGoalStore` itself remains in `src/goals/store.rs` as a value
-type used by `meeting_backend` and tests. It is no longer used as a
-production goal-board persistence target.
+type. Its only remaining production-shaped consumer after the planned
+follow-up is `src/meeting_backend/mod.rs`, which constructs one through a
+file path local to that module's setup. The bootstrap adapter migration is
+what removes `FileBackedGoalStore` from the production goal-board
+persistence path.
 
 ---
 
 ## Related reading
 
-- [Goal board API reference](./goal-board-api.md) — the primary consumers of
-  these helpers.
-- [Cognitive-memory goal store adapter](./cognitive-memory-goal-store.md) —
-  how `RuntimePorts.goal_store` wraps these helpers behind the `GoalStore`
-  trait.
-- [Cognitive memory bridge wire protocol](./bridge-wire-protocol.md) — what
-  the IPC tier negotiates.
-- [Goal board persistence — concept](../concepts/goal-board-persistence.md) —
-  the lifecycle the helpers participate in.
+- [Goal board API reference](./goal-board-api.md) — the primary consumers
+  of these helpers.
+- [Cognitive-memory goal store adapter](./cognitive-memory-goal-store.md)
+  — how the planned `RuntimePorts.goal_store` adapter wraps these helpers
+  behind the `GoalStore` trait.
+- [Cognitive memory bridge wire protocol](./bridge-wire-protocol.md) —
+  what the IPC tier negotiates.
+- [Goal board persistence — concept](../concepts/goal-board-persistence.md)
+  — the lifecycle the helpers participate in.

--- a/docs/reference/cognitive-memory-bridge-helpers.md
+++ b/docs/reference/cognitive-memory-bridge-helpers.md
@@ -1,10 +1,9 @@
 ---
 title: Cognitive memory bridge helpers
-description: Reference for launch_writer_bridge and open_reader_bridge — the canonical entry points for obtaining a CognitiveMemoryOps adapter from non-daemon contexts.
-last_updated: 2026-05-08
+description: Reference for launch_writer_bridge and open_reader_bridge — the canonical entry points for obtaining a CognitiveMemoryOps adapter, including the in-process Arc shortcut and the strict no-silent-degradation contract.
+last_updated: 2026-05-09
 owner: simard
 doc_type: reference
-status: design — not yet implemented
 related:
   - ./goal-board-api.md
   - ../concepts/goal-board-persistence.md
@@ -13,34 +12,21 @@ related:
 
 # Cognitive memory bridge helpers
 
-> **Status: design specification — not yet implemented.**
->
-> Neither `launch_writer_bridge` nor `open_reader_bridge` exists in
-> [`src/memory_ipc/mod.rs`](https://github.com/rysweet/Simard/blob/main/src/memory_ipc/mod.rs)
-> today. That module currently exports `default_socket_path`,
-> `default_state_root`, `reap_stale_open_lock`, `RemoteCognitiveMemory`, and
-> `SharedMemory`. The bridge-acquisition pattern lives inline in
-> [`launch_real_meeting_bridge`](https://github.com/rysweet/Simard/blob/main/src/operator_commands_meeting/meeting_session.rs)
-> at `meeting_session.rs:29`.
->
-> This document is the **target API** that issue
-> [#1590](https://github.com/rysweet/Simard/issues/1590) will land. It
-> exists so that consumer migrations and call-site updates can be reviewed
-> against a stable contract. Once the helpers are implemented, this status
-> banner will be removed and the doc will return to mkdocs nav.
-
-`src/memory_ipc/mod.rs` will expose two helper functions that every non-daemon
+`src/memory_ipc/launcher.rs` exposes two helper functions that every
 consumer should use to obtain a typed cognitive-memory bridge:
 
 | Helper | Returns | Use case |
 |--------|---------|----------|
-| `launch_writer_bridge` | `SimardResult<WriterBridge>` | Anything that may write — dashboard mutation handlers, meeting REPL flows, restore CLI |
+| `launch_writer_bridge` | `SimardResult<WriterBridge>` | Anything that may write — dashboard mutation handlers (`/api/goals/promote/<id>`, `/api/goals/demote/<id>`, `/api/goals/dismiss/<id>`), meeting REPL flows, restore CLI |
 | `open_reader_bridge` | `SimardResult<ReaderBridge>` | Read-only consumers — dashboard read handlers (`workboard`, `current_work`, `metrics`, `goals` GET), engineer-loop top-5 read, inspection tools |
 
-These helpers will encapsulate the **daemon-or-direct fallback ladder** that
-currently lives only inside `launch_real_meeting_bridge`. They replace ad-hoc
-instantiation of `NativeCognitiveMemory` and `RemoteCognitiveMemory` across
-the codebase.
+These helpers encapsulate the **daemon-or-direct fallback ladder** so that
+callers never instantiate `NativeCognitiveMemory` or `RemoteCognitiveMemory`
+directly. Issue [#1590](https://github.com/rysweet/Simard/issues/1590) and
+its follow-up regression-fix PR refined the resolution ladder to add an
+**in-process Arc shortcut** for callers that share a process with the OODA
+daemon, and to **remove the silent read-only fallback** that previously
+masked writer-acquisition failures as `{"status":"ok"}` responses.
 
 ---
 
@@ -88,25 +74,94 @@ reported up-front.
 pub fn launch_writer_bridge(state_root: &Path) -> SimardResult<WriterBridge>
 ```
 
-Returns a bridge that supports both reads and writes. Tries two writer
+Returns a bridge that supports both reads and writes. Tries three writer
 sources in order, stopping at the first success:
 
 | Tier | Source | Condition |
 |------|--------|-----------|
-| 1 | `RemoteCognitiveMemory::connect(default_socket_path())` | A running OODA daemon's IPC socket exists at `~/.simard/memory.sock` |
-| 2 | `NativeCognitiveMemory::open(state_root)` | No daemon socket; this process can take the writer lock directly |
+| 0 | Daemon-registered in-process `Arc<dyn CognitiveMemoryOps>` | Same-process callers (dashboard handlers, OODA reflection paths) when the daemon has registered its writer via `register_in_process_writer` |
+| 1 | `RemoteCognitiveMemory::connect(default_socket_path())` | A running OODA daemon's IPC socket exists at `~/.simard/memory.sock` and `state_root` matches the daemon's |
+| 2 | `NativeCognitiveMemory::open(state_root)` | No daemon socket; this process can take the writer lock directly (after `reap_stale_open_lock`) |
 
-If both tiers fail (the daemon socket is absent **and** another writer holds
-the local LadybugDB lock that the stale-lock reaper could not free), the
-helper returns `Err(SimardError::BridgeTransportError { … })`. There is **no
-silent read-only fallback at the writer-acquisition path** — a caller that
-asked for a writer always learns synchronously whether one was obtainable.
+If all three tiers fail, the helper returns
+`Err(SimardError::RuntimeInitFailed { component: "memory-ipc-launcher", … })`.
+
+**There is no read-only fallback at the writer-acquisition path.** A caller
+that asked for a writer always learns synchronously whether one was
+obtainable. Earlier revisions of this helper ended with a tier-3 fallback
+to `NativeCognitiveMemory::open_read_only` and returned the read-only handle
+wrapped as a `WriterBridge` — that produced silent hollow-success bugs
+(dashboard `demote_goal` returning `{"status":"ok"}` while the underlying
+`store_fact` was a no-op). Tier 3 has been removed; the launcher now
+propagates the read-write open error directly.
 
 The helper additionally:
 
 - Creates `state_root` (and parents) on first call via `fs::create_dir_all`.
 - Runs `reap_stale_open_lock` before tier 2 to clear locks left by crashed
   writers.
+
+### Tier 0: in-process Arc shortcut
+
+The OODA daemon registers its live `Arc<dyn CognitiveMemoryOps>` (the same
+handle backing the IPC server) with the launcher at startup:
+
+```rust
+// src/memory_ipc/launcher.rs
+static IN_PROCESS_WRITER: OnceLock<Arc<dyn CognitiveMemoryOps>> = OnceLock::new();
+
+pub fn register_in_process_writer(writer: Arc<dyn CognitiveMemoryOps>) {
+    let _ = IN_PROCESS_WRITER.set(writer);
+}
+```
+
+When the dashboard (which runs inside the daemon process) calls
+`launch_writer_bridge`, the launcher checks the `OnceLock` first. On a hit,
+it wraps the `Arc` in a `WriterBridge` and returns immediately — no Unix
+socket round-trip, no lock contention, no risk of falling into a read-only
+fallback. This is the **primary path** for in-process callers.
+
+Non-daemon callers (the meeting REPL, the engineer loop, CLI tools) skip
+tier 0 because nothing has registered into the `OnceLock` in their
+process. They proceed to tier 1 (IPC) and tier 2 (direct open) as before.
+
+### Tier 1 → 2 transition: state-root agreement
+
+Tier 1 (IPC) only fires when the requested `state_root` matches the
+daemon's owned state root, computed via
+`state_root_matches_daemon(state_root)`. Both sides canonicalize their
+paths (resolving symlinks and `..` segments) before comparing. If they
+disagree, the launcher silently skips IPC and proceeds to tier 2 — this
+prevents a daemon owning a different DB from masking the writes the caller
+intended for its own DB.
+
+If tier 1 is selected and the IPC connection fails (socket exists but
+`RemoteCognitiveMemory::connect` errors), the launcher logs the error to
+stderr and falls through to tier 2 rather than returning early. This keeps
+short-window daemon restarts (where the socket file lingers a few hundred
+milliseconds) from producing spurious failures.
+
+### Defensive guard: `is_read_only()`
+
+`CognitiveMemoryOps` exposes:
+
+```rust
+pub trait CognitiveMemoryOps: Send + Sync + 'static {
+    // … existing methods …
+    fn is_read_only(&self) -> bool { false }
+}
+```
+
+`NativeCognitiveMemory::open_read_only` overrides this to return `true`.
+The IPC client (`RemoteCognitiveMemory`) and the daemon's in-process Arc
+both leave the default `false` because the daemon is the writer.
+
+`WriterBridge::new`/`wrap` debug-asserts `!ops.is_read_only()` before
+returning. In release builds the assertion compiles out, but the launcher
+itself enforces the invariant: tier 0 (Arc), tier 1 (IPC), and tier 2
+(`open`) all return writer-capable handles by construction; the removed
+tier 3 was the only path that could have produced a read-only handle in a
+`WriterBridge`.
 
 **Example — dashboard write handler**
 
@@ -121,6 +176,11 @@ let mut board = load_goal_board(bridge.ops())?;
 mutate(&mut board);
 save_goal_board(&board, bridge.ops())?;
 ```
+
+The `?` on `launch_writer_bridge` is now load-bearing: if it would have
+returned a read-only handle in the prior implementation, it now returns
+`Err`, and the HTTP handler converts that into a 500 with the underlying
+error message rather than `{"status":"ok"}`.
 
 ---
 
@@ -190,38 +250,23 @@ directory.
 
 ## Migration from ad-hoc instantiation
 
-Today, each consumer either:
+Today (post-issue [#1590](https://github.com/rysweet/Simard/issues/1590) and
+its regression-fix follow-up), every consumer that touches cognitive
+memory uses one of these two helpers. Inline `NativeCognitiveMemory` and
+`RemoteCognitiveMemory` instantiation is reserved for the daemon
+(`SharedMemory` setup) and tests. Direct `goal_records.json` reads via
+`std::fs` and `serde_json` have been removed entirely.
 
-- Instantiates `NativeCognitiveMemory` or `RemoteCognitiveMemory` inline,
-  sometimes with subtle variations in tier order, lock handling, and error
-  reporting; or
-- Reads `goal_records.json` directly via `std::fs` and `serde_json`,
-  bypassing cognitive memory entirely.
+The most-mature inline pattern previously lived in
+`src/operator_commands_meeting/meeting_session.rs::launch_real_meeting_bridge`.
+That function is now a thin wrapper:
 
-The most-mature inline pattern lives in
-[`src/operator_commands_meeting/meeting_session.rs::launch_real_meeting_bridge`](https://github.com/rysweet/Simard/blob/main/src/operator_commands_meeting/meeting_session.rs).
-That function currently:
-
-1. Tries `RemoteCognitiveMemory::connect(default_socket_path())`.
-2. Falls back to `NativeCognitiveMemory::open(state_root)`.
-3. Falls back to `NativeCognitiveMemory::open_read_only(state_root)` with a
-   warning.
-
-Issue #1590 will:
-
-- Extract the writer-bearing tiers (1 + 2) into `launch_writer_bridge`.
-- Extract the read-only tier into `open_reader_bridge` (combined with
-  tier 1 of the writer ladder for daemon-aware reads).
-- Reduce `launch_real_meeting_bridge` to a thin wrapper:
-
-  ```rust
-  fn launch_real_meeting_bridge() -> SimardResult<WriterBridge> {
-      launch_writer_bridge(&default_state_root())
-  }
-  ```
-
-  with the `Box<dyn Error>` shim preserved at its current call site as long
-  as the meeting backend's caller signature still uses it.
+```rust
+fn launch_real_meeting_bridge() -> Result<Box<dyn CognitiveMemoryOps>, Box<dyn Error>> {
+    let bridge = launch_writer_bridge(&default_state_root())?;
+    Ok(bridge.into_box())
+}
+```
 
 New consumers should always call the helpers directly rather than copying
 the ladder.
@@ -230,22 +275,25 @@ the ladder.
 
 ## Migration call-site map
 
-After issue #1590 lands, the following sites will use one of the two
-helpers in place of inline instantiation or `FileBackedGoalStore`:
+The following sites use one of the two helpers in place of inline
+instantiation, `FileBackedGoalStore`, or direct `goal_records.json`
+reads:
 
-| File | Current pattern | Target helper |
-|------|-----------------|---------------|
-| `src/operator_commands_meeting/meeting_session.rs:29` | inline three-tier ladder | `launch_writer_bridge` (wrapped) |
-| `src/operator_commands_meeting/goal_curation.rs:58` | `FileBackedGoalStore::try_new(... goal_records.json)` | `open_reader_bridge` + `load_goal_board` + `active_goals_as_records` |
-| `src/operator_commands_meeting/improvement_curation.rs:123` | `FileBackedGoalStore::try_new(... goal_records.json)` | `launch_writer_bridge` + `load_goal_board` + `active_goals_as_records` |
-| `src/engineer_loop/mod.rs:276` | `FileBackedGoalStore::try_new(... goal_records.json).active_top_goals(5)` | `open_reader_bridge` + `load_goal_board` + `active_goals_as_records` |
-| `src/operator_commands_dashboard/goals.rs:12,48` | `std::fs::read_to_string(... goal_records.json)` + `serde_json::from_str` | `open_reader_bridge` (GET) + `launch_writer_bridge` (mutation handlers) |
-| `src/operator_commands_dashboard/workboard.rs:112` | `std::fs::read_to_string(... goal_records.json)` | `open_reader_bridge` |
-| `src/operator_commands_dashboard/current_work.rs` | inline file read | `open_reader_bridge` |
-| `src/operator_commands_dashboard/metrics.rs` | inline file read | `open_reader_bridge` |
+| File | Helper |
+|------|--------|
+| `src/operator_commands_meeting/meeting_session.rs` | `launch_writer_bridge` (wrapped as `launch_real_meeting_bridge`) |
+| `src/operator_commands_meeting/goal_curation.rs` | `open_reader_bridge` + `load_goal_board` + `active_goals_as_records` |
+| `src/operator_commands_meeting/improvement_curation.rs` | `launch_writer_bridge` + `load_goal_board` + `active_goals_as_records` |
+| `src/engineer_loop/mod.rs` | `open_reader_bridge` + `load_goal_board` + `active_goals_as_records` |
+| `src/operator_commands_dashboard/goals.rs` (mutation handlers) | `launch_writer_bridge` + `save_goal_board` |
+| `src/operator_commands_dashboard/goals.rs` (GET handlers) | `open_reader_bridge` + `load_goal_board` |
+| `src/operator_commands_dashboard/workboard.rs` | `open_reader_bridge` |
+| `src/operator_commands_dashboard/current_work.rs` | `open_reader_bridge` |
+| `src/operator_commands_dashboard/metrics.rs` | `open_reader_bridge` |
+| `src/bootstrap/assembly.rs` (`goal_store`) | `CognitiveMemoryGoalStore` (which itself uses both helpers) — see [Cognitive-memory goal store adapter](./cognitive-memory-goal-store.md) |
 
-`FileBackedGoalStore` itself remains in `src/goals/store.rs` as a value type
-used by `meeting_backend` and tests — issue #1590 only retires its use as a
+`FileBackedGoalStore` itself remains in `src/goals/store.rs` as a value
+type used by `meeting_backend` and tests. It is no longer used as a
 production goal-board persistence target.
 
 ---
@@ -254,6 +302,9 @@ production goal-board persistence target.
 
 - [Goal board API reference](./goal-board-api.md) — the primary consumers of
   these helpers.
+- [Cognitive-memory goal store adapter](./cognitive-memory-goal-store.md) —
+  how `RuntimePorts.goal_store` wraps these helpers behind the `GoalStore`
+  trait.
 - [Cognitive memory bridge wire protocol](./bridge-wire-protocol.md) — what
   the IPC tier negotiates.
 - [Goal board persistence — concept](../concepts/goal-board-persistence.md) —

--- a/docs/reference/cognitive-memory-goal-store.md
+++ b/docs/reference/cognitive-memory-goal-store.md
@@ -1,0 +1,184 @@
+---
+title: Cognitive-memory goal store adapter
+description: Reference for CognitiveMemoryGoalStore — the GoalStore-trait implementation backed by cognitive memory through the bridge helpers, used by RuntimePorts in bootstrap/assembly.
+last_updated: 2026-05-09
+owner: simard
+doc_type: reference
+related:
+  - ./cognitive-memory-bridge-helpers.md
+  - ./goal-board-api.md
+  - ../concepts/goal-board-persistence.md
+---
+
+# Cognitive-memory goal store adapter
+
+`CognitiveMemoryGoalStore` implements the `GoalStore` trait against the
+goal-board snapshot in cognitive memory. It is the production
+`Arc<dyn GoalStore>` constructed in `src/bootstrap/assembly.rs` and wired
+into `RuntimePorts` for local-session execution paths — goal-curation
+runs, improvement-curation runs, meeting probes, and any other consumer
+that reaches `RuntimePorts.goal_store`.
+
+## Why this exists
+
+`FileBackedGoalStore` was the previous production implementation. It
+persisted goals to `goal_records.json` under `$SIMARD_STATE_ROOT`. Issue
+[#1590](https://github.com/rysweet/Simard/issues/1590) and the follow-up
+PRs migrated every other consumer onto cognitive memory but left
+`src/bootstrap/assembly.rs:99` still calling
+`FileBackedGoalStore::try_new(config.goal_store_path())`. That created a
+half-migration: the OODA daemon, the dashboard handlers, the meeting
+flows, and the engineer loop all read from cognitive memory, while
+`bootstrap`-assembled local sessions read from a file that nothing else
+wrote to.
+
+`CognitiveMemoryGoalStore` closes the gap. After it lands,
+`goal_records.json` is no longer read or written by any production code
+path; cognitive memory is the single source of truth.
+
+## Location and shape
+
+```rust
+// src/goals/cognitive_memory_store.rs
+
+pub struct CognitiveMemoryGoalStore {
+    state_root: PathBuf,
+}
+
+impl CognitiveMemoryGoalStore {
+    pub fn new(state_root: PathBuf) -> Self { Self { state_root } }
+}
+
+impl GoalStore for CognitiveMemoryGoalStore {
+    fn list(&self) -> SimardResult<Vec<GoalRecord>> { /* read */ }
+    fn upsert(&self, record: GoalRecord) -> SimardResult<()> { /* write */ }
+    fn remove(&self, id: &str) -> SimardResult<()> { /* write */ }
+    fn active_top_goals(&self, n: usize) -> SimardResult<Vec<GoalRecord>> { /* read */ }
+    // … remaining trait methods …
+}
+```
+
+Each method opens a fresh bridge for the duration of one call and lets it
+drop afterwards. There is no long-lived bridge held inside the adapter
+because:
+
+- The daemon's in-process Arc shortcut (tier 0 of `launch_writer_bridge`)
+  makes per-call acquisition cheap.
+- Holding a `WriterBridge` across awaits would either serialize all
+  callers behind a `Mutex` or risk lock contention with the daemon.
+
+### Read methods
+
+```rust
+fn list(&self) -> SimardResult<Vec<GoalRecord>> {
+    let bridge = open_reader_bridge(&self.state_root)?;
+    let board = load_goal_board(bridge.ops())?;
+    Ok(active_goals_as_records(&board))
+}
+```
+
+Read methods use `open_reader_bridge` because they do not need the writer
+lock and should not contend with the daemon. The `active_goals_as_records`
+adapter (defined in `src/goal_curation/operations.rs`) projects the goal
+board's `active` slot into the same `GoalRecord` shape that
+`FileBackedGoalStore` previously returned, so callers see no behavioural
+change.
+
+### Write methods
+
+```rust
+fn upsert(&self, record: GoalRecord) -> SimardResult<()> {
+    let bridge = launch_writer_bridge(&self.state_root)?;
+    let mut board = load_goal_board(bridge.ops())?;
+    apply_upsert(&mut board, record);
+    save_goal_board(&board, bridge.ops())?;
+    Ok(())
+}
+```
+
+Write methods use `launch_writer_bridge`. With the in-process Arc shortcut
+this is a single `OnceLock::get` + `Box::new(Arc::clone(...))` when the
+daemon is registered — no IPC round-trip and no lock acquisition. Outside
+the daemon process the helper falls back to IPC or direct open as
+documented in [Cognitive memory bridge
+helpers](./cognitive-memory-bridge-helpers.md).
+
+The launcher's strict no-silent-degradation contract means writer-method
+errors (database lock contention, IPC connect failure with no daemon
+available) propagate to the caller as `SimardError` rather than being
+swallowed — preserving the same error-surfacing properties as the
+dashboard mutation handlers.
+
+## Wiring in `bootstrap/assembly.rs`
+
+```rust
+// Before
+let goal_store = Arc::new(FileBackedGoalStore::try_new(
+    config.goal_store_path(),
+)?);
+
+// After
+let goal_store = Arc::new(CognitiveMemoryGoalStore::new(
+    config.state_root().to_path_buf(),
+));
+```
+
+`config.state_root()` is the canonical `$SIMARD_STATE_ROOT`-resolved path
+that `default_state_root` already returns to the bridge helpers, so the
+adapter and the rest of the runtime agree on which DB they are addressing.
+
+`config.goal_store_path()` (which previously returned
+`<state_root>/goal_records.json`) is no longer called from
+`assembly.rs`. The method remains on `BootstrapConfig` for the
+`FileBackedGoalStore` value type still used by `meeting_backend` test
+fixtures, but production no longer calls it.
+
+## Test consequence: improvement_curation read probe
+
+`tests/improvement_curation.rs` previously held a single
+`#[ignore]`d test:
+
+```rust
+#[ignore = "blocked on issue #1590 — RuntimePorts.goal_store still uses FileBackedGoalStore"]
+#[test]
+fn improvement_curation_read_probe_surfaces_persisted_review_decisions_without_mutating_state() {
+    /* … */
+}
+```
+
+The test asserts that an improvement-curation read probe sees the same
+review decisions that an earlier improvement-curation **write** run
+persisted, given that both runs operate against the same `state_root`.
+While `RuntimePorts.goal_store` was `FileBackedGoalStore`-backed and the
+write run wrote to cognitive memory, the read probe loaded an empty list
+from `goal_records.json` and the assertion failed — hence the ignore.
+
+After `CognitiveMemoryGoalStore` lands, both runs share cognitive memory
+through `RuntimePorts`. The `#[ignore]` attribute is removed and the test
+runs in the standard suite; `cargo test --test improvement_curation`
+passes.
+
+## What `FileBackedGoalStore` is still used for
+
+`FileBackedGoalStore` remains in `src/goals/store.rs` for two narrow
+reasons:
+
+1. `src/meeting_backend/mod.rs:149-169` constructs one when a
+   `meeting_backend` operates without a state root and needs an in-memory
+   goal-store-shaped value. This is a test-helper code path; production
+   meeting flows go through cognitive memory.
+2. Existing tests in `src/goals/` and `src/engineer_loop/` that exercise
+   the `GoalStore` trait independently of cognitive memory.
+
+Neither path persists `goal_records.json` to disk in production. The file
+itself remains as a historical artefact that older operators may have
+under `$SIMARD_STATE_ROOT`; nothing reads it.
+
+## Related reading
+
+- [Cognitive memory bridge helpers](./cognitive-memory-bridge-helpers.md) —
+  the lower-level helpers that this adapter wraps.
+- [Goal board API reference](./goal-board-api.md) — `load_goal_board`,
+  `save_goal_board`, and `active_goals_as_records`.
+- [Goal board persistence — concept](../concepts/goal-board-persistence.md) —
+  the full lifecycle this adapter participates in.

--- a/docs/reference/cognitive-memory-goal-store.md
+++ b/docs/reference/cognitive-memory-goal-store.md
@@ -1,6 +1,6 @@
 ---
 title: Cognitive-memory goal store adapter
-description: Reference for CognitiveMemoryGoalStore — the GoalStore-trait implementation backed by cognitive memory through the bridge helpers, used by RuntimePorts in bootstrap/assembly.
+description: Design reference for CognitiveMemoryGoalStore — the planned GoalStore-trait implementation backed by cognitive memory through the bridge helpers, used by RuntimePorts in bootstrap/assembly.
 last_updated: 2026-05-09
 owner: simard
 doc_type: reference
@@ -12,34 +12,48 @@ related:
 
 # Cognitive-memory goal store adapter
 
-`CognitiveMemoryGoalStore` implements the `GoalStore` trait against the
-goal-board snapshot in cognitive memory. It is the production
-`Arc<dyn GoalStore>` constructed in `src/bootstrap/assembly.rs` and wired
-into `RuntimePorts` for local-session execution paths — goal-curation
-runs, improvement-curation runs, meeting probes, and any other consumer
-that reaches `RuntimePorts.goal_store`.
+> **Status: design — not yet implemented.** This document describes the
+> `CognitiveMemoryGoalStore` adapter and the
+> `bootstrap::assembly`-level wiring that the issue
+> [#1590](https://github.com/rysweet/Simard/issues/1590) follow-up
+> regression-fix work will introduce. On `main` today,
+> `bootstrap::assembly` constructs an
+> `Arc<FileBackedGoalStore>` for `RuntimePorts.goal_store`, and the
+> ignored `improvement_curation_read_probe_…` test in
+> `tests/improvement_curation.rs` documents this gap. Update this document
+> to drop the "design" banner and the "planned" qualifiers when the
+> adapter lands.
+
+`CognitiveMemoryGoalStore` will implement the `GoalStore` trait against
+the goal-board snapshot in cognitive memory. It is the production
+`Arc<dyn GoalStore>` constructed in `bootstrap::assembly` and wired into
+`RuntimePorts` for local-session execution paths — goal-curation runs,
+improvement-curation runs, meeting probes, and any other consumer that
+reaches `RuntimePorts.goal_store`.
 
 ## Why this exists
 
-`FileBackedGoalStore` was the previous production implementation. It
-persisted goals to `goal_records.json` under `$SIMARD_STATE_ROOT`. Issue
-[#1590](https://github.com/rysweet/Simard/issues/1590) and the follow-up
-PRs migrated every other consumer onto cognitive memory but left
-`src/bootstrap/assembly.rs:99` still calling
+`FileBackedGoalStore` is the current production implementation. It
+persists goals to `goal_records.json` under `$SIMARD_STATE_ROOT`. Issue
+[#1590](https://github.com/rysweet/Simard/issues/1590) and the merged
+follow-up PRs migrated every other consumer onto cognitive memory but
+left `bootstrap::assembly` still calling
 `FileBackedGoalStore::try_new(config.goal_store_path())`. That created a
 half-migration: the OODA daemon, the dashboard handlers, the meeting
-flows, and the engineer loop all read from cognitive memory, while
-`bootstrap`-assembled local sessions read from a file that nothing else
-wrote to.
+flows, and the engineer loop all read and write through cognitive memory,
+while `bootstrap`-assembled local sessions read from a file that nothing
+else writes to (and write to a file that nothing else reads from).
 
-`CognitiveMemoryGoalStore` closes the gap. After it lands,
+`CognitiveMemoryGoalStore` closes the gap. After it lands and replaces
+the `FileBackedGoalStore` instantiation in `bootstrap::assembly`,
 `goal_records.json` is no longer read or written by any production code
-path; cognitive memory is the single source of truth.
+path that goes through `RuntimePorts`; cognitive memory is the single
+source of truth for the goal board.
 
 ## Location and shape
 
 ```rust
-// src/goals/cognitive_memory_store.rs
+// src/goals/cognitive_memory_store.rs (planned)
 
 pub struct CognitiveMemoryGoalStore {
     state_root: PathBuf,
@@ -58,12 +72,12 @@ impl GoalStore for CognitiveMemoryGoalStore {
 }
 ```
 
-Each method opens a fresh bridge for the duration of one call and lets it
-drop afterwards. There is no long-lived bridge held inside the adapter
-because:
+Each method opens a fresh bridge for the duration of one call and lets
+it drop afterwards. There is no long-lived bridge held inside the
+adapter because:
 
-- The daemon's in-process Arc shortcut (tier 0 of `launch_writer_bridge`)
-  makes per-call acquisition cheap.
+- The planned in-process Arc shortcut (tier 0 of `launch_writer_bridge`)
+  makes per-call acquisition cheap inside the daemon process.
 - Holding a `WriterBridge` across awaits would either serialize all
   callers behind a `Mutex` or risk lock contention with the daemon.
 
@@ -77,12 +91,12 @@ fn list(&self) -> SimardResult<Vec<GoalRecord>> {
 }
 ```
 
-Read methods use `open_reader_bridge` because they do not need the writer
-lock and should not contend with the daemon. The `active_goals_as_records`
-adapter (defined in `src/goal_curation/operations.rs`) projects the goal
-board's `active` slot into the same `GoalRecord` shape that
-`FileBackedGoalStore` previously returned, so callers see no behavioural
-change.
+Read methods use `open_reader_bridge` because they do not need the
+writer lock and should not contend with the daemon. The
+`active_goals_as_records` adapter (defined in
+`goal_curation::operations`) projects the goal board's `active` slot into
+the same `GoalRecord` shape that `FileBackedGoalStore` previously
+returned, so callers see no behavioural change.
 
 ### Write methods
 
@@ -96,50 +110,51 @@ fn upsert(&self, record: GoalRecord) -> SimardResult<()> {
 }
 ```
 
-Write methods use `launch_writer_bridge`. With the in-process Arc shortcut
-this is a single `OnceLock::get` + `Box::new(Arc::clone(...))` when the
-daemon is registered — no IPC round-trip and no lock acquisition. Outside
-the daemon process the helper falls back to IPC or direct open as
-documented in [Cognitive memory bridge
+Write methods use `launch_writer_bridge`. With the planned in-process Arc
+shortcut this is a single `OnceLock::get` plus an `Arc::clone` when the
+daemon is registered — no IPC round-trip and no lock acquisition.
+Outside the daemon process the helper falls back to IPC or direct open
+as documented in [Cognitive memory bridge
 helpers](./cognitive-memory-bridge-helpers.md).
 
-The launcher's strict no-silent-degradation contract means writer-method
-errors (database lock contention, IPC connect failure with no daemon
-available) propagate to the caller as `SimardError` rather than being
-swallowed — preserving the same error-surfacing properties as the
-dashboard mutation handlers.
+The launcher's planned strict no-silent-degradation contract means
+writer-method errors (database lock contention, IPC connect failure with
+no daemon available) propagate to the caller as `SimardError` rather
+than being swallowed — preserving the same error-surfacing properties as
+the dashboard mutation handlers.
 
-## Wiring in `bootstrap/assembly.rs`
+## Wiring in `bootstrap::assembly`
 
 ```rust
-// Before
+// Before (current main)
 let goal_store = Arc::new(FileBackedGoalStore::try_new(
     config.goal_store_path(),
 )?);
 
-// After
+// After (post-follow-up)
 let goal_store = Arc::new(CognitiveMemoryGoalStore::new(
-    config.state_root().to_path_buf(),
+    config.state_root_path().to_path_buf(),
 ));
 ```
 
-`config.state_root()` is the canonical `$SIMARD_STATE_ROOT`-resolved path
-that `default_state_root` already returns to the bridge helpers, so the
-adapter and the rest of the runtime agree on which DB they are addressing.
+`config.state_root_path()` is the canonical
+`$SIMARD_STATE_ROOT`-resolved path that `default_state_root` already
+returns to the bridge helpers, so the adapter and the rest of the
+runtime agree on which DB they are addressing.
 
-`config.goal_store_path()` (which previously returned
+`config.goal_store_path()` (which returns
 `<state_root>/goal_records.json`) is no longer called from
-`assembly.rs`. The method remains on `BootstrapConfig` for the
-`FileBackedGoalStore` value type still used by `meeting_backend` test
-fixtures, but production no longer calls it.
+`bootstrap::assembly` after the migration. The accessor remains on
+`BootstrapConfig` for the `FileBackedGoalStore` value type still
+constructed by the `meeting_backend` setup path.
 
 ## Test consequence: improvement_curation read probe
 
-`tests/improvement_curation.rs` previously held a single
-`#[ignore]`d test:
+`tests/improvement_curation.rs` currently holds an ignored test:
 
 ```rust
-#[ignore = "blocked on issue #1590 — RuntimePorts.goal_store still uses FileBackedGoalStore"]
+#[ignore = "Probe round-trip needs bootstrap/assembly.rs migration to write \
+            goals through cognitive memory (follow-up to #1590)"]
 #[test]
 fn improvement_curation_read_probe_surfaces_persisted_review_decisions_without_mutating_state() {
     /* … */
@@ -149,36 +164,40 @@ fn improvement_curation_read_probe_surfaces_persisted_review_decisions_without_m
 The test asserts that an improvement-curation read probe sees the same
 review decisions that an earlier improvement-curation **write** run
 persisted, given that both runs operate against the same `state_root`.
-While `RuntimePorts.goal_store` was `FileBackedGoalStore`-backed and the
-write run wrote to cognitive memory, the read probe loaded an empty list
-from `goal_records.json` and the assertion failed — hence the ignore.
+While `RuntimePorts.goal_store` is `FileBackedGoalStore`-backed and the
+write run writes to cognitive memory, the read probe loads an empty list
+from `goal_records.json` and the assertion fails — hence the ignore.
 
-After `CognitiveMemoryGoalStore` lands, both runs share cognitive memory
-through `RuntimePorts`. The `#[ignore]` attribute is removed and the test
-runs in the standard suite; `cargo test --test improvement_curation`
-passes.
+After `CognitiveMemoryGoalStore` lands and replaces
+`FileBackedGoalStore` in `bootstrap::assembly`, both runs share
+cognitive memory through `RuntimePorts`. The `#[ignore]` attribute is
+removed and the test runs in the standard suite; `cargo test --test
+improvement_curation` passes the probe round-trip.
 
 ## What `FileBackedGoalStore` is still used for
 
-`FileBackedGoalStore` remains in `src/goals/store.rs` for two narrow
-reasons:
+After the bootstrap migration, `FileBackedGoalStore` remains in
+`src/goals/store.rs` for one verified production-shaped consumer plus
+test fixtures:
 
-1. `src/meeting_backend/mod.rs:149-169` constructs one when a
-   `meeting_backend` operates without a state root and needs an in-memory
-   goal-store-shaped value. This is a test-helper code path; production
-   meeting flows go through cognitive memory.
-2. Existing tests in `src/goals/` and `src/engineer_loop/` that exercise
-   the `GoalStore` trait independently of cognitive memory.
+1. `src/meeting_backend/mod.rs` constructs a `FileBackedGoalStore` when
+   the meeting backend wires up its own goal store from a local file
+   path. This path is independent of `RuntimePorts.goal_store` and is
+   not affected by the bootstrap migration. Whether this should also
+   migrate is **out of scope** for the issue-#1590 follow-up.
+2. Tests in `src/goals/` and elsewhere that exercise the `GoalStore`
+   trait independently of cognitive memory.
 
-Neither path persists `goal_records.json` to disk in production. The file
-itself remains as a historical artefact that older operators may have
-under `$SIMARD_STATE_ROOT`; nothing reads it.
+The `goal_records.json` file itself remains as a historical artefact
+that older operators may have under `$SIMARD_STATE_ROOT`; after the
+follow-up migration, no production code path inside
+`RuntimePorts.goal_store` reads or writes it.
 
 ## Related reading
 
-- [Cognitive memory bridge helpers](./cognitive-memory-bridge-helpers.md) —
-  the lower-level helpers that this adapter wraps.
+- [Cognitive memory bridge helpers](./cognitive-memory-bridge-helpers.md)
+  — the lower-level helpers that this adapter wraps.
 - [Goal board API reference](./goal-board-api.md) — `load_goal_board`,
   `save_goal_board`, and `active_goals_as_records`.
-- [Goal board persistence — concept](../concepts/goal-board-persistence.md) —
-  the full lifecycle this adapter participates in.
+- [Goal board persistence — concept](../concepts/goal-board-persistence.md)
+  — the full lifecycle this adapter participates in.

--- a/docs/reference/string-truncation-helpers.md
+++ b/docs/reference/string-truncation-helpers.md
@@ -1,0 +1,116 @@
+---
+title: String truncation helpers
+description: Reference for truncate_to_char_boundary — the char-boundary-safe helper that replaces String::truncate(N) at every site where N is a byte budget rather than a code-point count.
+last_updated: 2026-05-09
+owner: simard
+doc_type: reference
+related:
+  - ./meeting-backend-api.md
+  - ./terminal-session-idle-detection.md
+---
+
+# String truncation helpers
+
+`src/util/string_truncate.rs` exports a single helper used wherever a
+`String` must fit inside a byte budget (evidence buffers, transcript
+previews, log lines):
+
+```rust
+pub fn truncate_to_char_boundary(s: &mut String, max_bytes: usize)
+```
+
+## Why this exists
+
+`String::truncate(new_len)` panics if `new_len` is not a UTF-8 character
+boundary:
+
+```text
+thread 'tokio-rt-worker' panicked at src/terminal_session/evidence.rs:10:
+assertion failed: self.is_char_boundary(new_len)
+```
+
+This regression surfaced from the live daemon when a chat-tab message
+contained an em-dash (`—`, three UTF-8 bytes) at byte offset 512. Before
+this helper landed, three call sites called `normalized.truncate(512)`
+directly:
+
+- `src/terminal_session/evidence.rs:10` — `transcript_preview`
+- `src/terminal_session/evidence.rs:109` — `compact_terminal_evidence_value`
+- `src/copilot_task_submit/transcript.rs:350` — visible-fragment join
+
+Any of them could panic the runtime worker on multi-byte input crossing
+the budget. `truncate_to_char_boundary` provides a stable-Rust replacement
+that is safe for any UTF-8 string at any byte budget.
+
+## Contract
+
+`truncate_to_char_boundary(s, max_bytes)`:
+
+1. If `s.len() <= max_bytes`, returns without modifying `s`.
+2. Otherwise finds the largest `i ≤ max_bytes` such that
+   `s.is_char_boundary(i)` and calls `s.truncate(i)`.
+
+Because byte 0 is always a valid char boundary, the loop always
+terminates — even if `max_bytes` falls inside a multi-byte sequence the
+helper backs up to the start of that sequence rather than panicking.
+
+The helper is a thin wrapper over `String::truncate`:
+
+```rust
+pub fn truncate_to_char_boundary(s: &mut String, max_bytes: usize) {
+    if s.len() <= max_bytes {
+        return;
+    }
+    let mut boundary = max_bytes;
+    while boundary > 0 && !s.is_char_boundary(boundary) {
+        boundary -= 1;
+    }
+    s.truncate(boundary);
+}
+```
+
+## Stability and toolchain
+
+The implementation uses only stable-Rust APIs — `String::len`,
+`str::is_char_boundary`, and `String::truncate`. It does **not** use the
+nightly-only `floor_char_boundary`, so the helper compiles on the same
+toolchain as the rest of the codebase.
+
+## Use this everywhere a byte budget is enforced
+
+Every place that previously chained
+`if normalized.len() > N { normalized.truncate(N); normalized.push_str("...");
+}` now calls:
+
+```rust
+use crate::util::string_truncate::truncate_to_char_boundary;
+
+if normalized.len() > N {
+    truncate_to_char_boundary(&mut normalized, N);
+    normalized.push_str("...");
+}
+```
+
+The ellipsis push remains the caller's responsibility because some sites
+want a different sentinel (`"…"`, `"[truncated]"`, `""`).
+
+## Tests
+
+`src/util/string_truncate.rs` ships unit tests covering:
+
+- ASCII shorter than budget — no-op.
+- ASCII at exactly the budget — no-op.
+- ASCII longer than budget — truncate at the boundary, no panic.
+- Em-dash (`—`, 3 bytes) straddling the budget — backs up to the previous
+  char boundary and produces valid UTF-8.
+- CJK characters (3 bytes each) at the budget — same.
+- 4-byte emoji (`🎉`) at the budget — same.
+- Empty string — no-op.
+- `max_bytes = 0` — truncates to empty without panic.
+
+## Related reading
+
+- [Terminal session idle detection](./terminal-session-idle-detection.md) —
+  one of the consumers via `compact_terminal_evidence_value`.
+- [Meeting backend API](./meeting-backend-api.md) — the chat WebSocket path
+  that surfaced the original UTF-8 panic.

--- a/docs/reference/string-truncation-helpers.md
+++ b/docs/reference/string-truncation-helpers.md
@@ -1,6 +1,6 @@
 ---
 title: String truncation helpers
-description: Reference for truncate_to_char_boundary — the char-boundary-safe helper that replaces String::truncate(N) at every site where N is a byte budget rather than a code-point count.
+description: Design reference for truncate_to_char_boundary — a planned char-boundary-safe helper that will replace String::truncate(N) at every site where N is a byte budget rather than a code-point count.
 last_updated: 2026-05-09
 owner: simard
 doc_type: reference
@@ -11,9 +11,17 @@ related:
 
 # String truncation helpers
 
-`src/util/string_truncate.rs` exports a single helper used wherever a
-`String` must fit inside a byte budget (evidence buffers, transcript
-previews, log lines):
+> **Status: design — not yet implemented.** This document describes a
+> helper module that the issue
+> [#1590](https://github.com/rysweet/Simard/issues/1590) follow-up
+> regression-fix work will introduce at `src/util/string_truncate.rs`. The
+> three call sites listed in [Why this exists](#why-this-exists) currently
+> still call `String::truncate` directly. Update this document to drop the
+> "design" banner and the "planned" qualifiers when the helper lands.
+
+The planned `src/util/string_truncate.rs` module will export a single
+helper used wherever a `String` must fit inside a byte budget (evidence
+buffers, transcript previews, log lines):
 
 ```rust
 pub fn truncate_to_char_boundary(s: &mut String, max_bytes: usize)
@@ -22,25 +30,21 @@ pub fn truncate_to_char_boundary(s: &mut String, max_bytes: usize)
 ## Why this exists
 
 `String::truncate(new_len)` panics if `new_len` is not a UTF-8 character
-boundary:
+boundary — the standard library asserts `self.is_char_boundary(new_len)`
+before truncating. Three call sites in Simard currently call
+`normalized.truncate(N)` with `N` as a byte budget rather than a
+code-point count, so any input where a multi-byte sequence (em-dash, CJK,
+emoji) crosses byte `N` will panic the runtime worker:
 
-```text
-thread 'tokio-rt-worker' panicked at src/terminal_session/evidence.rs:10:
-assertion failed: self.is_char_boundary(new_len)
-```
+- `terminal_session::evidence::transcript_preview` — uses `512`.
+- `terminal_session::evidence::compact_terminal_evidence_value` — uses a
+  caller-supplied `limit`.
+- `copilot_task_submit::transcript` (visible-fragment join) — uses `512`.
 
-This regression surfaced from the live daemon when a chat-tab message
-contained an em-dash (`—`, three UTF-8 bytes) at byte offset 512. Before
-this helper landed, three call sites called `normalized.truncate(512)`
-directly:
-
-- `src/terminal_session/evidence.rs:10` — `transcript_preview`
-- `src/terminal_session/evidence.rs:109` — `compact_terminal_evidence_value`
-- `src/copilot_task_submit/transcript.rs:350` — visible-fragment join
-
-Any of them could panic the runtime worker on multi-byte input crossing
-the budget. `truncate_to_char_boundary` provides a stable-Rust replacement
-that is safe for any UTF-8 string at any byte budget.
+These sites are the regression target. `truncate_to_char_boundary`
+provides a stable-Rust replacement that is safe for any UTF-8 string at
+any byte budget; the three sites above will move to it as part of the
+same follow-up commit that adds the helper.
 
 ## Contract
 
@@ -76,11 +80,11 @@ The implementation uses only stable-Rust APIs — `String::len`,
 nightly-only `floor_char_boundary`, so the helper compiles on the same
 toolchain as the rest of the codebase.
 
-## Use this everywhere a byte budget is enforced
+## Usage convention
 
-Every place that previously chained
+Every place that currently chains
 `if normalized.len() > N { normalized.truncate(N); normalized.push_str("...");
-}` now calls:
+}` will be rewritten to:
 
 ```rust
 use crate::util::string_truncate::truncate_to_char_boundary;
@@ -96,21 +100,25 @@ want a different sentinel (`"…"`, `"[truncated]"`, `""`).
 
 ## Tests
 
-`src/util/string_truncate.rs` ships unit tests covering:
+The helper module ships with unit tests covering at minimum:
 
 - ASCII shorter than budget — no-op.
 - ASCII at exactly the budget — no-op.
 - ASCII longer than budget — truncate at the boundary, no panic.
-- Em-dash (`—`, 3 bytes) straddling the budget — backs up to the previous
-  char boundary and produces valid UTF-8.
-- CJK characters (3 bytes each) at the budget — same.
-- 4-byte emoji (`🎉`) at the budget — same.
+- Em-dash (`—`, 3 bytes) straddling the budget — backs up to the
+  previous char boundary and produces valid UTF-8.
+- CJK characters (3 bytes each) straddling the budget — same.
+- 4-byte emoji (`🎉`) straddling the budget — same.
 - Empty string — no-op.
 - `max_bytes = 0` — truncates to empty without panic.
 
+These cases exercise every branch of the helper plus the three byte-width
+classes (2-byte Latin-1 supplement, 3-byte BMP, 4-byte SMP) that real
+input contains.
+
 ## Related reading
 
-- [Terminal session idle detection](./terminal-session-idle-detection.md) —
-  one of the consumers via `compact_terminal_evidence_value`.
-- [Meeting backend API](./meeting-backend-api.md) — the chat WebSocket path
-  that surfaced the original UTF-8 panic.
+- [Terminal session idle detection](./terminal-session-idle-detection.md)
+  — one of the consumers via `compact_terminal_evidence_value`.
+- [Meeting backend API](./meeting-backend-api.md) — the chat WebSocket
+  path that surfaces evidence text into the chat preview pipeline.

--- a/src/bootstrap/assembly.rs
+++ b/src/bootstrap/assembly.rs
@@ -13,7 +13,7 @@ use crate::base_types::BaseTypeId;
 use crate::cognitive_memory::{CognitiveMemoryOps, NativeCognitiveMemory};
 use crate::error::{SimardError, SimardResult};
 use crate::evidence::{EvidenceStore, FileBackedEvidenceStore};
-use crate::goals::{FileBackedGoalStore, GoalStore};
+use crate::goals::{CognitiveMemoryGoalStore, FileBackedGoalStore, GoalStore};
 use crate::handoff::{FileBackedHandoffStore, RuntimeHandoffSnapshot, RuntimeHandoffStore};
 use crate::identity::{
     BuiltinIdentityLoader, IdentityLoadRequest, IdentityLoader, IdentityManifest, ManifestContract,
@@ -96,7 +96,38 @@ fn assemble_parts(config: &BootstrapConfig) -> SimardResult<AssembledParts> {
     let evidence_store = Arc::new(FileBackedEvidenceStore::try_new(
         config.evidence_store_path(),
     )?);
-    let goal_store = Arc::new(FileBackedGoalStore::try_new(config.goal_store_path())?);
+    // Issue #1590 (Bug 3): the goal store is now backed by cognitive
+    // memory. The legacy `FileBackedGoalStore` only persisted half of
+    // the surface area — every other consumer (the operator probes,
+    // engineer-loop, dashboard, meeting backend) reads/writes through
+    // cognitive memory, so a `FileBackedGoalStore` here meant
+    // `goal_store.put(record)` was invisible to those readers across
+    // subprocess boundaries.
+    //
+    // In `BuiltinDefaults` mode we still fall back to the file-backed
+    // store when cognitive memory cannot be opened (no LadybugDB on
+    // disk, e.g. in dev / unit tests that skip the bridge). Production
+    // mode never reaches this fallback because `build_memory_store`
+    // already returned `Err` above.
+    let goal_store: Arc<dyn GoalStore> =
+        match CognitiveMemoryGoalStore::new(config.state_root.value.clone()) {
+            Ok(store) => Arc::new(store),
+            Err(e) if config.mode == crate::bootstrap::BootstrapMode::BuiltinDefaults => {
+                eprintln!(
+                    "[simard] cognitive-memory goal store unavailable ({e}) — \
+                     falling back to file-backed goal store for testing"
+                );
+                Arc::new(FileBackedGoalStore::try_new(config.goal_store_path())?)
+            }
+            Err(e) => {
+                return Err(SimardError::RuntimeInitFailed {
+                    component: "goal-store".into(),
+                    reason: format!(
+                        "cognitive-memory goal store is required in production mode: {e}"
+                    ),
+                });
+            }
+        };
     let handoff_store = Arc::new(FileBackedHandoffStore::try_new(
         config.handoff_store_path(),
     )?);

--- a/src/cognitive_memory/mod.rs
+++ b/src/cognitive_memory/mod.rs
@@ -91,6 +91,21 @@ pub trait CognitiveMemoryOps: Send + Sync {
     fn check_triggers(&self, content: &str) -> SimardResult<Vec<CognitiveProspective>>;
 
     fn get_statistics(&self) -> SimardResult<CognitiveStatistics>;
+
+    /// Reports whether this backend was opened in read-only mode.
+    ///
+    /// Defaulted to `false` because the overwhelming majority of
+    /// implementations are writers (the IPC client, the daemon's
+    /// in-process Arc, the live `NativeCognitiveMemory::open`).
+    /// `NativeCognitiveMemory::open_read_only` overrides this to `true`.
+    ///
+    /// `WriterBridge` constructors assert that this is `false` so a
+    /// read-only handle cannot be silently wrapped as a writer — the
+    /// "hollow success" failure mode that issue #1590's follow-up
+    /// targets.
+    fn is_read_only(&self) -> bool {
+        false
+    }
 }
 
 // ============================================================================

--- a/src/cognitive_memory/mod.rs
+++ b/src/cognitive_memory/mod.rs
@@ -122,6 +122,7 @@ pub struct NativeCognitiveMemory {
     path: PathBuf,
     #[allow(dead_code)]
     _temp_dir: Option<Arc<tempfile::TempDir>>,
+    read_only: bool,
 }
 
 // SAFETY: lbug::Database is thread-safe by design (internal locking).
@@ -164,6 +165,7 @@ impl NativeCognitiveMemory {
             db: Arc::new(db),
             path: db_path,
             _temp_dir: None,
+            read_only: false,
         };
         mem.ensure_schema()?;
         eprintln!(
@@ -195,6 +197,7 @@ impl NativeCognitiveMemory {
             db: Arc::new(db),
             path: db_path,
             _temp_dir: Some(Arc::new(tmp)),
+            read_only: false,
         };
         mem.ensure_schema()?;
         Ok(mem)
@@ -232,6 +235,7 @@ impl NativeCognitiveMemory {
             db: Arc::new(db),
             path: db_path,
             _temp_dir: None,
+            read_only: true,
         };
         eprintln!(
             "[simard] cognitive memory opened read-only — LadybugDB at {}",

--- a/src/cognitive_memory/ops.rs
+++ b/src/cognitive_memory/ops.rs
@@ -324,4 +324,8 @@ impl CognitiveMemoryOps for NativeCognitiveMemory {
             prospective_count: count_query("Prospective")?,
         })
     }
+
+    fn is_read_only(&self) -> bool {
+        self.read_only
+    }
 }

--- a/src/copilot_task_submit/transcript.rs
+++ b/src/copilot_task_submit/transcript.rs
@@ -4,6 +4,7 @@ use super::types::{
 };
 use crate::sanitization::sanitize_terminal_text;
 use crate::terminal_session::compact_terminal_evidence_value;
+use crate::util::string_truncate::truncate_to_char_boundary;
 
 pub(super) fn classify_startup(scan: &TranscriptCheckpointScan, exited: bool) -> StartupStatus {
     if scan.has_wrapper_error {
@@ -347,7 +348,7 @@ pub(super) fn copilot_transcript_preview(
         .join(" | ");
 
     if normalized.len() > 512 {
-        normalized.truncate(512);
+        truncate_to_char_boundary(&mut normalized, 512);
         normalized.push_str("...");
     }
 

--- a/src/copilot_task_submit/transcript.rs
+++ b/src/copilot_task_submit/transcript.rs
@@ -353,3 +353,78 @@ pub(super) fn copilot_transcript_preview(
 
     normalized
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn flow_for_payload(payload: &str) -> CopilotSubmitFlowAsset {
+        CopilotSubmitFlowAsset {
+            launch_command: String::new(),
+            working_directory: PathBuf::new(),
+            wait_timeout_seconds: 0,
+            startup_banner: String::new(),
+            guidance_checkpoint: String::new(),
+            submit_hint: String::new(),
+            post_submit_checkpoint: None,
+            trust_prompt: None,
+            wrapper_error_signal: None,
+            workflow_noise_signals: Vec::new(),
+            payload_id: String::new(),
+            payload: payload.to_string(),
+        }
+    }
+
+    /// Issue #1590 follow-up — UTF-8 truncation panic regression test.
+    ///
+    /// `copilot_transcript_preview` calls `normalized.truncate(512)` after
+    /// joining the visible fragments. A multi-byte char (em-dash, CJK,
+    /// emoji) straddling byte 512 panics the runtime worker with
+    /// `assertion failed: self.is_char_boundary(new_len)`. After the
+    /// fix this site uses `truncate_to_char_boundary` and remains valid
+    /// UTF-8.
+    #[test]
+    fn copilot_transcript_preview_does_not_panic_on_em_dash_at_byte_512_boundary() {
+        // Build a single fragment whose byte length pushes the joined
+        // preview past byte 512 with an em-dash straddling 512.
+        let mut fragment = String::with_capacity(600);
+        fragment.push_str(&"a".repeat(511));
+        fragment.push('—'); // 3-byte UTF-8 sequence starts at byte 511
+        fragment.push_str(&"b".repeat(100));
+        let fragments = vec![fragment.clone()];
+        let flow = flow_for_payload("ignored-payload");
+
+        // Sanity: the joined preview is ≥ 512 bytes and the em-dash
+        // straddles byte 512.
+        assert!(fragment.len() > 512);
+        assert!(!fragment.is_char_boundary(512));
+
+        let preview = copilot_transcript_preview(&fragments, &flow);
+
+        assert!(
+            std::str::from_utf8(preview.as_bytes()).is_ok(),
+            "preview must remain valid UTF-8"
+        );
+        assert!(
+            preview.ends_with("..."),
+            "preview should still indicate truncation; got {preview:?}"
+        );
+    }
+
+    #[test]
+    fn copilot_transcript_preview_does_not_panic_on_emoji_at_byte_512_boundary() {
+        // 4-byte emoji 🎉 straddles byte 512 in the joined string.
+        let mut fragment = String::with_capacity(600);
+        fragment.push_str(&"a".repeat(510));
+        fragment.push('🎉'); // 4-byte UTF-8 sequence starts at byte 510
+        fragment.push_str(&"b".repeat(100));
+        let fragments = vec![fragment];
+        let flow = flow_for_payload("ignored-payload");
+
+        let preview = copilot_transcript_preview(&fragments, &flow);
+
+        assert!(std::str::from_utf8(preview.as_bytes()).is_ok());
+        assert!(preview.ends_with("..."));
+    }
+}

--- a/src/goals/cognitive_memory_store.rs
+++ b/src/goals/cognitive_memory_store.rs
@@ -2,31 +2,43 @@
 //!
 //! See `docs/reference/cognitive-memory-goal-store.md` for the design.
 //!
-//! `bootstrap::assembly` is the production caller: today it constructs an
-//! `Arc<FileBackedGoalStore>` for `RuntimePorts.goal_store`, which leaves
+//! `bootstrap::assembly` is the production caller: previously it constructed
+//! an `Arc<FileBackedGoalStore>` for `RuntimePorts.goal_store`, which left
 //! a half-migration gap (every other consumer reads/writes through
 //! cognitive memory; only the bootstrap-assembled local sessions still
-//! touch `goal_records.json`). Step 8 of the issue #1590 follow-up
-//! replaces that instantiation with `Arc::new(CognitiveMemoryGoalStore::new(...))`.
-//!
-//! **TDD stub** — every `GoalStore` method body is `unimplemented!()` so
-//! the failing tests in this module pin the contract before the
-//! implementation lands.
+//! touched `goal_records.json`). Issue #1590 closes that gap.
 
 use std::path::PathBuf;
 
+use crate::cognitive_memory::CognitiveMemoryOps;
 use crate::error::SimardResult;
+use crate::goal_curation::{GoalProgress, load_goal_board, save_goal_board};
+use crate::memory_ipc::launch_writer_bridge;
 use crate::metadata::{BackendDescriptor, Freshness};
 
 use super::{GoalRecord, GoalStatus, GoalStore};
+
+/// Concept prefix used to namespace serialized `GoalRecord` facts in
+/// cognitive memory. The full concept is
+/// `goal-record:{slug}` so a `search_facts("goal-record:", …)` returns
+/// every record across all slugs.
+const GOAL_RECORD_PREFIX: &str = "goal-record:";
+
+/// Owner-identity to attribute board snapshots to when projecting from
+/// `GoalRecord`s. Boards persisted by the goal-curation pipeline use
+/// `"goal-curator"`; we intentionally use a different label here so the
+/// origin of each snapshot is auditable.
+const GOAL_STORE_SOURCE: &str = "cognitive-memory-goal-store";
 
 /// `GoalStore` implementation backed by cognitive memory through the
 /// bridge helpers (`launch_writer_bridge` / `open_reader_bridge`).
 ///
 /// Each method opens a fresh bridge for the duration of one call and
-/// drops it afterwards. With the planned tier-0 in-process Arc shortcut
-/// (issue #1590 follow-up), per-call acquisition inside the daemon
-/// process is a single `OnceLock::get` plus `Arc::clone`.
+/// drops it afterwards. Inside the OODA daemon the tier-0 in-process Arc
+/// shortcut means this is a single `RwLock::read` plus `Arc::clone`; in
+/// out-of-process callers (operator probes spawned from cargo tests, the
+/// `simard-operator-probe` binary, etc.) it walks the IPC / direct-open
+/// ladder.
 #[derive(Debug)]
 pub struct CognitiveMemoryGoalStore {
     state_root: PathBuf,
@@ -53,6 +65,38 @@ impl CognitiveMemoryGoalStore {
     pub fn state_root(&self) -> &PathBuf {
         &self.state_root
     }
+
+    /// Read every persisted `GoalRecord` through `bridge`. Records are
+    /// deduplicated by `slug` — the lexicographically-largest `node_id`
+    /// wins (uuid-v7 ⇒ time-ordered, so largest = most-recent put).
+    fn list_via_bridge(&self, bridge: &dyn CognitiveMemoryOps) -> SimardResult<Vec<GoalRecord>> {
+        let facts = bridge.search_facts(GOAL_RECORD_PREFIX, 1024, 0.0)?;
+        let mut latest_by_slug: std::collections::BTreeMap<String, (String, GoalRecord)> =
+            std::collections::BTreeMap::new();
+        for fact in facts {
+            if !fact.concept.starts_with(GOAL_RECORD_PREFIX) {
+                continue;
+            }
+            let record: GoalRecord = match serde_json::from_str(&fact.content) {
+                Ok(r) => r,
+                Err(e) => {
+                    eprintln!(
+                        "[simard] CognitiveMemoryGoalStore::list_via_bridge: skipping \
+                         malformed goal-record fact (node_id={}): {e}",
+                        fact.node_id
+                    );
+                    continue;
+                }
+            };
+            match latest_by_slug.get(&record.slug) {
+                Some((existing_id, _)) if existing_id >= &fact.node_id => continue,
+                _ => {
+                    latest_by_slug.insert(record.slug.clone(), (fact.node_id.clone(), record));
+                }
+            }
+        }
+        Ok(latest_by_slug.into_values().map(|(_, r)| r).collect())
+    }
 }
 
 impl GoalStore for CognitiveMemoryGoalStore {
@@ -61,18 +105,51 @@ impl GoalStore for CognitiveMemoryGoalStore {
     }
 
     fn put(&self, record: GoalRecord) -> SimardResult<()> {
-        let _ = record;
-        unimplemented!(
-            "CognitiveMemoryGoalStore::put: TDD stub — implementation lands in \
-             step 8 of issue #1590 follow-up"
-        );
+        let bridge = launch_writer_bridge(&self.state_root)?;
+        let ops = bridge.ops();
+
+        // (1) Persist the full record as a fact for fidelity. The
+        // concept is `goal-record:{slug}` so list/queries can prefix-scan.
+        let serialized = serde_json::to_string(&record).map_err(|e| {
+            crate::error::SimardError::InvalidGoalRecord {
+                field: "record".to_string(),
+                reason: format!("failed to serialize GoalRecord: {e}"),
+            }
+        })?;
+        let concept = format!("{GOAL_RECORD_PREFIX}{}", record.slug);
+        ops.store_fact(
+            &concept,
+            &serialized,
+            1.0,
+            &[
+                "goal-record".to_string(),
+                record.status.to_string(),
+                record.owner_identity.clone(),
+            ],
+            GOAL_STORE_SOURCE,
+        )?;
+
+        // (2) Project the active set into `GoalBoard.active` and persist
+        // a fresh snapshot. This is what `engineer-loop-run` reads via
+        // `load_goal_board` + `active_goals_as_records`. Without this
+        // projection, a `goal_store.put(active record)` would be invisible
+        // to the engineer-loop probe and the regression tests in
+        // `tests/improvement_curation.rs` would fail their cross-subprocess
+        // assertion (`Active goals count: 1`).
+        let all = self.list_via_bridge(ops)?;
+        let mut board = load_goal_board(ops)?;
+        board.active = all
+            .iter()
+            .filter(|r| r.status == GoalStatus::Active)
+            .map(record_to_active_goal)
+            .collect();
+        save_goal_board(&board, ops)?;
+        Ok(())
     }
 
     fn list(&self) -> SimardResult<Vec<GoalRecord>> {
-        unimplemented!(
-            "CognitiveMemoryGoalStore::list: TDD stub — implementation lands in \
-             step 8 of issue #1590 follow-up"
-        );
+        let bridge = launch_writer_bridge(&self.state_root)?;
+        self.list_via_bridge(bridge.ops())
     }
 
     fn top_goals_by_status(
@@ -80,27 +157,69 @@ impl GoalStore for CognitiveMemoryGoalStore {
         status: GoalStatus,
         limit: usize,
     ) -> SimardResult<Vec<GoalRecord>> {
-        let _ = (status, limit);
-        unimplemented!(
-            "CognitiveMemoryGoalStore::top_goals_by_status: TDD stub — implementation \
-             lands in step 8 of issue #1590 follow-up"
-        );
+        let mut records: Vec<GoalRecord> = self
+            .list()?
+            .into_iter()
+            .filter(|r| r.status == status)
+            .collect();
+        sort_goal_records(&mut records);
+        records.truncate(limit);
+        Ok(records)
     }
 
     fn active_top_goals(&self, limit: usize) -> SimardResult<Vec<GoalRecord>> {
-        let _ = limit;
-        unimplemented!(
-            "CognitiveMemoryGoalStore::active_top_goals: TDD stub — implementation \
-             lands in step 8 of issue #1590 follow-up"
-        );
+        self.top_goals_by_status(GoalStatus::Active, limit)
     }
 }
+
+fn sort_goal_records(records: &mut [GoalRecord]) {
+    records.sort_by(|a, b| {
+        a.status
+            .rank()
+            .cmp(&b.status.rank())
+            .then(a.priority.cmp(&b.priority))
+            .then(a.title.cmp(&b.title))
+            .then(a.slug.cmp(&b.slug))
+    });
+}
+
+/// Project a `GoalRecord` into the `ActiveGoal` shape consumed by
+/// `goal_curation::save_goal_board` / `load_goal_board`.
+///
+/// This is the inverse of `goal_curation::active_goals_as_records`, but
+/// the two mappings are deliberately not symmetric: `ActiveGoal.id` is
+/// the goal slug here so a subsequent `active_goals_as_records` round
+/// trip preserves the slug.
+fn record_to_active_goal(record: &GoalRecord) -> crate::goal_curation::ActiveGoal {
+    crate::goal_curation::ActiveGoal {
+        id: record.slug.clone(),
+        description: record.title.clone(),
+        priority: u32::from(record.priority),
+        status: if record.status == GoalStatus::Completed {
+            GoalProgress::Completed
+        } else {
+            GoalProgress::NotStarted
+        },
+        assigned_to: Some(record.owner_identity.clone()),
+        current_activity: if record.rationale.is_empty() {
+            None
+        } else {
+            Some(record.rationale.clone())
+        },
+        wip_refs: Vec::new(),
+    }
+}
+
+// `GoalStatus::rank` is `pub(super)` in `super::types`; we are inside
+// the `goals` module so the visibility is satisfied.
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::goals::{GoalRecord, GoalStatus, GoalUpdate};
+    use crate::memory_ipc::unregister_in_process_writer_for_test;
     use crate::session::{SessionId, SessionPhase};
+    use serial_test::serial;
     use std::path::PathBuf;
 
     fn fresh_state_root(tag: &str) -> PathBuf {
@@ -128,7 +247,9 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn cognitive_memory_goal_store_round_trips_active_goal() {
+        unregister_in_process_writer_for_test();
         let root = fresh_state_root("round-trip");
         let store = CognitiveMemoryGoalStore::new(root.clone()).expect("store should build");
 
@@ -162,7 +283,9 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn cognitive_memory_goal_store_active_top_goals_returns_active_only() {
+        unregister_in_process_writer_for_test();
         let root = fresh_state_root("active-top");
         let store = CognitiveMemoryGoalStore::new(root).expect("store should build");
         store
@@ -189,7 +312,9 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn cognitive_memory_goal_store_top_goals_by_status_filters_correctly() {
+        unregister_in_process_writer_for_test();
         let root = fresh_state_root("top-by-status");
         let store = CognitiveMemoryGoalStore::new(root).expect("store should build");
         store

--- a/src/goals/cognitive_memory_store.rs
+++ b/src/goals/cognitive_memory_store.rs
@@ -1,0 +1,211 @@
+//! Cognitive-memory backed [`GoalStore`] adapter.
+//!
+//! See `docs/reference/cognitive-memory-goal-store.md` for the design.
+//!
+//! `bootstrap::assembly` is the production caller: today it constructs an
+//! `Arc<FileBackedGoalStore>` for `RuntimePorts.goal_store`, which leaves
+//! a half-migration gap (every other consumer reads/writes through
+//! cognitive memory; only the bootstrap-assembled local sessions still
+//! touch `goal_records.json`). Step 8 of the issue #1590 follow-up
+//! replaces that instantiation with `Arc::new(CognitiveMemoryGoalStore::new(...))`.
+//!
+//! **TDD stub** — every `GoalStore` method body is `unimplemented!()` so
+//! the failing tests in this module pin the contract before the
+//! implementation lands.
+
+use std::path::PathBuf;
+
+use crate::error::SimardResult;
+use crate::metadata::{BackendDescriptor, Freshness};
+
+use super::{GoalRecord, GoalStatus, GoalStore};
+
+/// `GoalStore` implementation backed by cognitive memory through the
+/// bridge helpers (`launch_writer_bridge` / `open_reader_bridge`).
+///
+/// Each method opens a fresh bridge for the duration of one call and
+/// drops it afterwards. With the planned tier-0 in-process Arc shortcut
+/// (issue #1590 follow-up), per-call acquisition inside the daemon
+/// process is a single `OnceLock::get` plus `Arc::clone`.
+#[derive(Debug)]
+pub struct CognitiveMemoryGoalStore {
+    state_root: PathBuf,
+    descriptor: BackendDescriptor,
+}
+
+impl CognitiveMemoryGoalStore {
+    /// Construct a store rooted at `state_root`.
+    ///
+    /// The path must be the same `SIMARD_STATE_ROOT`-resolved directory
+    /// the rest of the runtime addresses (i.e. `default_state_root()`).
+    pub fn new(state_root: PathBuf) -> SimardResult<Self> {
+        Ok(Self {
+            descriptor: BackendDescriptor::for_runtime_type::<Self>(
+                "goals::cognitive-memory-store",
+                "runtime-port:goal-store:cognitive-memory",
+                Freshness::now()?,
+            ),
+            state_root,
+        })
+    }
+
+    /// State root this store is bound to (used by tests and diagnostics).
+    pub fn state_root(&self) -> &PathBuf {
+        &self.state_root
+    }
+}
+
+impl GoalStore for CognitiveMemoryGoalStore {
+    fn descriptor(&self) -> BackendDescriptor {
+        self.descriptor.clone()
+    }
+
+    fn put(&self, record: GoalRecord) -> SimardResult<()> {
+        let _ = record;
+        unimplemented!(
+            "CognitiveMemoryGoalStore::put: TDD stub — implementation lands in \
+             step 8 of issue #1590 follow-up"
+        );
+    }
+
+    fn list(&self) -> SimardResult<Vec<GoalRecord>> {
+        unimplemented!(
+            "CognitiveMemoryGoalStore::list: TDD stub — implementation lands in \
+             step 8 of issue #1590 follow-up"
+        );
+    }
+
+    fn top_goals_by_status(
+        &self,
+        status: GoalStatus,
+        limit: usize,
+    ) -> SimardResult<Vec<GoalRecord>> {
+        let _ = (status, limit);
+        unimplemented!(
+            "CognitiveMemoryGoalStore::top_goals_by_status: TDD stub — implementation \
+             lands in step 8 of issue #1590 follow-up"
+        );
+    }
+
+    fn active_top_goals(&self, limit: usize) -> SimardResult<Vec<GoalRecord>> {
+        let _ = limit;
+        unimplemented!(
+            "CognitiveMemoryGoalStore::active_top_goals: TDD stub — implementation \
+             lands in step 8 of issue #1590 follow-up"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::goals::{GoalRecord, GoalStatus, GoalUpdate};
+    use crate::session::{SessionId, SessionPhase};
+    use std::path::PathBuf;
+
+    fn fresh_state_root(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "simard-cognitive-goal-store-{tag}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        std::fs::create_dir_all(&dir).expect("temp dir should be created");
+        dir
+    }
+
+    fn record(title: &str, status: GoalStatus, priority: u8) -> GoalRecord {
+        GoalRecord::from_update(
+            GoalUpdate::new(title, "tdd rationale", status, priority).expect("valid update"),
+            "tdd-1590-cognitive-store",
+            SessionId::parse("session-018f1f7e-4c5d-7b2a-8f10-b5c0d4f7b123")
+                .expect("valid session id"),
+            SessionPhase::Persistence,
+        )
+        .expect("valid record")
+    }
+
+    #[test]
+    fn cognitive_memory_goal_store_round_trips_active_goal() {
+        let root = fresh_state_root("round-trip");
+        let store = CognitiveMemoryGoalStore::new(root.clone()).expect("store should build");
+
+        store
+            .put(record(
+                "Cognitive store round-trip goal",
+                GoalStatus::Active,
+                1,
+            ))
+            .expect("put must persist through cognitive memory");
+
+        let listed = store
+            .list()
+            .expect("list must read through cognitive memory");
+        assert!(
+            listed
+                .iter()
+                .any(|r| r.title == "Cognitive store round-trip goal"),
+            "round-tripped goal must appear in list(); got {} records",
+            listed.len()
+        );
+
+        // Every write must flow through cognitive memory — never the
+        // legacy file. This is the half-migration we're closing.
+        let legacy = root.join("goal_records.json");
+        assert!(
+            !legacy.exists(),
+            "CognitiveMemoryGoalStore must NOT create {}",
+            legacy.display()
+        );
+    }
+
+    #[test]
+    fn cognitive_memory_goal_store_active_top_goals_returns_active_only() {
+        let root = fresh_state_root("active-top");
+        let store = CognitiveMemoryGoalStore::new(root).expect("store should build");
+        store
+            .put(record("Active alpha", GoalStatus::Active, 2))
+            .unwrap();
+        store
+            .put(record("Active beta", GoalStatus::Active, 1))
+            .unwrap();
+        store
+            .put(record("Proposed gamma", GoalStatus::Proposed, 1))
+            .unwrap();
+
+        let top = store.active_top_goals(5).expect("active_top_goals");
+        assert_eq!(
+            top.len(),
+            2,
+            "active_top_goals must filter to active records only"
+        );
+        assert!(top.iter().all(|r| r.status == GoalStatus::Active));
+        // Sort key is (status_rank, priority, title, slug); priority 1
+        // wins over priority 2.
+        assert_eq!(top[0].title, "Active beta");
+        assert_eq!(top[1].title, "Active alpha");
+    }
+
+    #[test]
+    fn cognitive_memory_goal_store_top_goals_by_status_filters_correctly() {
+        let root = fresh_state_root("top-by-status");
+        let store = CognitiveMemoryGoalStore::new(root).expect("store should build");
+        store
+            .put(record("Active alpha", GoalStatus::Active, 1))
+            .unwrap();
+        store
+            .put(record("Proposed beta", GoalStatus::Proposed, 1))
+            .unwrap();
+        store
+            .put(record("Proposed gamma", GoalStatus::Proposed, 2))
+            .unwrap();
+
+        let proposed = store
+            .top_goals_by_status(GoalStatus::Proposed, 5)
+            .expect("top_goals_by_status");
+        assert_eq!(proposed.len(), 2);
+        assert!(proposed.iter().all(|r| r.status == GoalStatus::Proposed));
+    }
+}

--- a/src/goals/mod.rs
+++ b/src/goals/mod.rs
@@ -1,8 +1,10 @@
+mod cognitive_memory_store;
 mod seed;
 mod store;
 mod types;
 
 // Re-export all public items so `crate::goals::X` still works.
+pub use cognitive_memory_store::CognitiveMemoryGoalStore;
 pub use seed::seed_default_goals;
 pub use store::{FileBackedGoalStore, GoalStore, InMemoryGoalStore};
 pub use types::{GoalRecord, GoalStatus, GoalUpdate, goal_slug};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,7 @@ mod tests_base_type_copilot;
 #[cfg(test)]
 mod tests_memory_ipc;
 pub mod trace_collector;
+pub mod util;
 
 pub use agent_goal_assignment::{
     SubordinateProgress, assign_goal, poll_progress, read_assigned_goal, report_progress,

--- a/src/memory_ipc/launcher.rs
+++ b/src/memory_ipc/launcher.rs
@@ -21,12 +21,38 @@
 //! underlying DB has never been opened.
 
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use crate::cognitive_memory::{CognitiveMemoryOps, NativeCognitiveMemory};
 use crate::error::{SimardError, SimardResult};
 
-use super::{RemoteCognitiveMemory, default_socket_path, default_state_root, reap_stale_open_lock};
+use super::{
+    RemoteCognitiveMemory, SharedMemory, default_socket_path, default_state_root,
+    reap_stale_open_lock,
+};
+
+/// Process-wide registration slot for the in-process cognitive-memory
+/// writer. The OODA daemon registers its `Arc<dyn CognitiveMemoryOps>`
+/// here at startup; subsequent same-process callers (dashboard,
+/// reflection loop, goal store) skip IPC and direct-open entirely and
+/// share the daemon's writer through `Arc::clone`.
+///
+/// Production: only the first registration wins; subsequent calls are
+/// silently ignored. Tests can use [`unregister_in_process_writer_for_test`]
+/// to reset between cases — combine with `#[serial]` from `serial_test` to
+/// avoid cross-test pollution.
+fn in_process_writer_slot() -> &'static RwLock<Option<Arc<dyn CognitiveMemoryOps>>> {
+    static SLOT: std::sync::OnceLock<RwLock<Option<Arc<dyn CognitiveMemoryOps>>>> =
+        std::sync::OnceLock::new();
+    SLOT.get_or_init(|| RwLock::new(None))
+}
+
+fn current_in_process_writer() -> Option<Arc<dyn CognitiveMemoryOps>> {
+    in_process_writer_slot()
+        .read()
+        .ok()
+        .and_then(|guard| guard.as_ref().map(Arc::clone))
+}
 
 /// Writer bridge to cognitive memory. Holds a `Box<dyn CognitiveMemoryOps>`
 /// underneath; callers should use [`WriterBridge::ops`] to access it.
@@ -48,21 +74,24 @@ impl WriterBridge {
         self.inner
     }
 
-    /// Test-only constructor.
-    ///
-    /// Wraps a caller-provided `Box<dyn CognitiveMemoryOps>` as a
-    /// `WriterBridge` so tests can pin the defensive
-    /// "writer must not be read-only" invariant directly.
-    ///
-    /// Production code MUST go through [`launch_writer_bridge`] so the
-    /// resolution ladder runs. Step 8 of issue #1590 follow-up will add
-    /// the `assert!(!inner.is_read_only())` invariant to this
-    /// constructor and route all production [`WriterBridge`] construction
-    /// through it — pinned by
-    /// `writer_bridge_construction_panics_when_inner_is_read_only`.
+    /// Defensive constructor: panics if the wrapped handle reports
+    /// `is_read_only() == true`. A `WriterBridge` wrapping a read-only
+    /// handle is exactly the silent-degradation hazard issue #1590
+    /// targets — write attempts would silently no-op or surface
+    /// `BridgeTransportError` only after the `Ok(())` path has been
+    /// threaded through dashboards / probes.
+    fn checked_new(inner: Box<dyn CognitiveMemoryOps>) -> Self {
+        assert!(
+            !inner.is_read_only(),
+            "WriterBridge cannot wrap a read-only handle — would silently swallow writes"
+        );
+        Self { inner }
+    }
+
+    /// Test-only constructor that mirrors [`Self::checked_new`].
     #[cfg(test)]
     pub fn from_ops_for_test(inner: Box<dyn CognitiveMemoryOps>) -> Self {
-        Self { inner }
+        Self::checked_new(inner)
     }
 }
 
@@ -90,13 +119,25 @@ impl ReaderBridge {
 ///
 /// Only the first call wins; subsequent calls are silently ignored. This
 /// is sufficient because there is exactly one daemon writer per process.
-///
-/// **TDD stub** — the implementation lands in step 8 of the issue #1590
-/// follow-up. Today this is a no-op so [`launch_writer_bridge`] still
-/// proceeds through tiers 1–3 unchanged.
 pub fn register_in_process_writer(writer: Arc<dyn CognitiveMemoryOps>) {
-    let _ = writer;
-    // TDD stub — see `IN_PROCESS_WRITER` in step 8.
+    if let Ok(mut guard) = in_process_writer_slot().write()
+        && guard.is_none()
+    {
+        *guard = Some(writer);
+    }
+}
+
+/// Test-only: clear any registered in-process writer so subsequent calls
+/// to [`launch_writer_bridge`] / [`open_reader_bridge`] fall through to
+/// the IPC and direct-open tiers.
+///
+/// Combine with `#[serial_test::serial]` to avoid pollution from tests
+/// that need fresh registration semantics.
+#[cfg(test)]
+pub(crate) fn unregister_in_process_writer_for_test() {
+    if let Ok(mut guard) = in_process_writer_slot().write() {
+        *guard = None;
+    }
 }
 
 /// Decide whether `state_root` matches the daemon's owned state root.
@@ -113,15 +154,28 @@ fn state_root_matches_daemon(state_root: &Path) -> bool {
 
 /// Launch a cognitive-memory writer bridge against `state_root`.
 ///
-/// Resolution ladder:
-///   1. Try `RemoteCognitiveMemory::connect(default_socket_path())` — if the
-///      OODA daemon is running, share its writer.
+/// Resolution ladder (no silent read-only fallback after issue #1590):
+///   0. If an in-process writer is registered (the OODA daemon does this
+///      at startup), return it immediately. Same-process callers skip
+///      IPC entirely and share the daemon's writer through `Arc::clone`.
+///   1. Try `RemoteCognitiveMemory::connect(default_socket_path())` — if
+///      the OODA daemon is running on a different process and owns the
+///      same `state_root`, share its writer.
 ///   2. Otherwise reap any stale open-lock and `NativeCognitiveMemory::open`
 ///      the DB directly (we own it because no daemon is running).
-///   3. Last-resort: `NativeCognitiveMemory::open_read_only` — recoverable
-///      degradation; later write calls will surface their own errors.
+///
+/// Failures at every tier propagate as `SimardError`. The previous
+/// "tier 3 = silent open_read_only fallback" path is removed: surfacing
+/// the failure loudly is the explicit contract of the launcher (issue
+/// #1590, dashboard hollow-success bug).
 pub fn launch_writer_bridge(state_root: &Path) -> SimardResult<WriterBridge> {
     let _ = std::fs::create_dir_all(state_root);
+
+    // (0) In-process Arc shortcut — the daemon registers itself at
+    // startup via `register_in_process_writer`.
+    if let Some(writer) = current_in_process_writer() {
+        return Ok(WriterBridge::checked_new(Box::new(SharedMemory(writer))));
+    }
 
     // (1) Prefer the running daemon's IPC writer — but only when our
     // requested state_root actually matches the daemon's. Otherwise we'd
@@ -130,9 +184,7 @@ pub fn launch_writer_bridge(state_root: &Path) -> SimardResult<WriterBridge> {
     if sock.exists() && state_root_matches_daemon(state_root) {
         match RemoteCognitiveMemory::connect(&sock) {
             Ok(client) => {
-                return Ok(WriterBridge {
-                    inner: Box::new(client),
-                });
+                return Ok(WriterBridge::checked_new(Box::new(client)));
             }
             Err(e) => {
                 eprintln!(
@@ -148,39 +200,36 @@ pub fn launch_writer_bridge(state_root: &Path) -> SimardResult<WriterBridge> {
         eprintln!("[simard] launch_writer_bridge: stale-lock reap failed: {e}");
     }
 
-    match NativeCognitiveMemory::open(state_root) {
-        Ok(mem) => Ok(WriterBridge {
-            inner: Box::new(mem),
-        }),
-        Err(rw_err) => {
-            // (3) Last-resort read-only fallback.
-            eprintln!(
-                "[simard] launch_writer_bridge: read-write open failed ({rw_err}); falling back \
-                 to read-only — write attempts will surface errors at call time"
-            );
-            let mem = NativeCognitiveMemory::open_read_only(state_root).map_err(|e| {
-                SimardError::RuntimeInitFailed {
-                    component: "memory-ipc-launcher".into(),
-                    reason: format!(
-                        "cognitive memory failed to open even read-only at {}: {e}",
-                        state_root.display()
-                    ),
-                }
-            })?;
-            Ok(WriterBridge {
-                inner: Box::new(mem),
-            })
-        }
-    }
+    let mem =
+        NativeCognitiveMemory::open(state_root).map_err(|e| SimardError::RuntimeInitFailed {
+            component: "memory-ipc-launcher".into(),
+            reason: format!(
+                "cognitive memory writer failed to open at {}: {e} \
+                 (no in-process writer registered, no daemon socket usable; \
+                  refusing silent read-only fallback per issue #1590)",
+                state_root.display()
+            ),
+        })?;
+    Ok(WriterBridge::checked_new(Box::new(mem)))
 }
 
 /// Open a cognitive-memory reader bridge against `state_root`.
 ///
 /// Resolution ladder:
+///   0. If an in-process writer is registered (the OODA daemon does this
+///      at startup), share it as a reader so we observe live state
+///      without contending on disk.
 ///   1. Try `RemoteCognitiveMemory::connect(default_socket_path())`.
 ///   2. Otherwise `NativeCognitiveMemory::open_read_only` — fails when the
 ///      DB has never been opened by a writer.
 pub fn open_reader_bridge(state_root: &Path) -> SimardResult<ReaderBridge> {
+    // (0) In-process Arc shortcut — sees live writes from the daemon.
+    if let Some(writer) = current_in_process_writer() {
+        return Ok(ReaderBridge {
+            inner: Box::new(SharedMemory(writer)),
+        });
+    }
+
     // (1) Prefer the daemon socket when present — but only when the
     // requested state_root matches the daemon's. Otherwise a daemon owning
     // a different DB would mask the read we actually want.

--- a/src/memory_ipc/launcher.rs
+++ b/src/memory_ipc/launcher.rs
@@ -21,6 +21,7 @@
 //! underlying DB has never been opened.
 
 use std::path::Path;
+use std::sync::Arc;
 
 use crate::cognitive_memory::{CognitiveMemoryOps, NativeCognitiveMemory};
 use crate::error::{SimardError, SimardResult};
@@ -46,6 +47,23 @@ impl WriterBridge {
     pub fn into_box(self) -> Box<dyn CognitiveMemoryOps> {
         self.inner
     }
+
+    /// Test-only constructor.
+    ///
+    /// Wraps a caller-provided `Box<dyn CognitiveMemoryOps>` as a
+    /// `WriterBridge` so tests can pin the defensive
+    /// "writer must not be read-only" invariant directly.
+    ///
+    /// Production code MUST go through [`launch_writer_bridge`] so the
+    /// resolution ladder runs. Step 8 of issue #1590 follow-up will add
+    /// the `assert!(!inner.is_read_only())` invariant to this
+    /// constructor and route all production [`WriterBridge`] construction
+    /// through it — pinned by
+    /// `writer_bridge_construction_panics_when_inner_is_read_only`.
+    #[cfg(test)]
+    pub fn from_ops_for_test(inner: Box<dyn CognitiveMemoryOps>) -> Self {
+        Self { inner }
+    }
 }
 
 /// Reader bridge to cognitive memory. Read-only by construction (either the
@@ -59,6 +77,26 @@ impl ReaderBridge {
     pub fn ops(&self) -> &dyn CognitiveMemoryOps {
         &*self.inner
     }
+}
+
+/// Register an in-process writer that [`launch_writer_bridge`] should
+/// return immediately when called from the same process.
+///
+/// The OODA daemon calls this at startup with its live
+/// `Arc<dyn CognitiveMemoryOps>` (the same handle that backs the IPC
+/// server). After registration, in-process callers (the dashboard,
+/// reflection loop, …) skip the IPC round-trip and the direct-open
+/// ladder entirely — they share the daemon's writer through `Arc::clone`.
+///
+/// Only the first call wins; subsequent calls are silently ignored. This
+/// is sufficient because there is exactly one daemon writer per process.
+///
+/// **TDD stub** — the implementation lands in step 8 of the issue #1590
+/// follow-up. Today this is a no-op so [`launch_writer_bridge`] still
+/// proceeds through tiers 1–3 unchanged.
+pub fn register_in_process_writer(writer: Arc<dyn CognitiveMemoryOps>) {
+    let _ = writer;
+    // TDD stub — see `IN_PROCESS_WRITER` in step 8.
 }
 
 /// Decide whether `state_root` matches the daemon's owned state root.

--- a/src/memory_ipc/mod.rs
+++ b/src/memory_ipc/mod.rs
@@ -172,6 +172,8 @@ mod client;
 mod launcher;
 mod server;
 pub use client::RemoteCognitiveMemory;
+#[cfg(test)]
+pub(crate) use launcher::unregister_in_process_writer_for_test;
 pub use launcher::{
     ReaderBridge, WriterBridge, launch_writer_bridge, open_reader_bridge,
     register_in_process_writer,
@@ -266,6 +268,9 @@ impl CognitiveMemoryOps for SharedMemory {
     }
     fn get_statistics(&self) -> SimardResult<CognitiveStatistics> {
         self.0.get_statistics()
+    }
+    fn is_read_only(&self) -> bool {
+        self.0.is_read_only()
     }
 }
 

--- a/src/memory_ipc/mod.rs
+++ b/src/memory_ipc/mod.rs
@@ -172,7 +172,10 @@ mod client;
 mod launcher;
 mod server;
 pub use client::RemoteCognitiveMemory;
-pub use launcher::{ReaderBridge, WriterBridge, launch_writer_bridge, open_reader_bridge};
+pub use launcher::{
+    ReaderBridge, WriterBridge, launch_writer_bridge, open_reader_bridge,
+    register_in_process_writer,
+};
 pub use server::{ServerHandle, spawn_server};
 
 // ============================================================================

--- a/src/memory_ipc/tests_launcher.rs
+++ b/src/memory_ipc/tests_launcher.rs
@@ -23,9 +23,13 @@
 //! Reader semantics: prefer the daemon socket; otherwise `open_read_only`
 //! (which requires the underlying DB file to already exist).
 
-use super::{launch_writer_bridge, open_reader_bridge, register_in_process_writer};
+use super::{
+    launch_writer_bridge, open_reader_bridge, register_in_process_writer,
+    unregister_in_process_writer_for_test,
+};
 use crate::cognitive_memory::{CognitiveMemoryOps, NativeCognitiveMemory};
 use crate::goal_curation::{GoalBoard, load_goal_board, save_goal_board};
+use serial_test::serial;
 use std::sync::Arc;
 
 fn fresh_state_root(tag: &str) -> std::path::PathBuf {
@@ -42,7 +46,9 @@ fn fresh_state_root(tag: &str) -> std::path::PathBuf {
 }
 
 #[test]
+#[serial]
 fn launch_writer_bridge_succeeds_on_fresh_state_root_without_daemon() {
+    unregister_in_process_writer_for_test();
     // No daemon socket → must fall through to NativeCognitiveMemory::open.
     let root = fresh_state_root("writer-fresh");
     let writer = launch_writer_bridge(&root)
@@ -55,7 +61,9 @@ fn launch_writer_bridge_succeeds_on_fresh_state_root_without_daemon() {
 }
 
 #[test]
+#[serial]
 fn writer_bridge_supports_store_fact_round_trip() {
+    unregister_in_process_writer_for_test();
     let root = fresh_state_root("writer-roundtrip");
     let writer = launch_writer_bridge(&root).expect("writer bridge");
 
@@ -82,7 +90,9 @@ fn writer_bridge_supports_store_fact_round_trip() {
 }
 
 #[test]
+#[serial]
 fn open_reader_bridge_requires_existing_db() {
+    unregister_in_process_writer_for_test();
     // No DB has ever been opened → open_read_only would fail. The reader
     // helper is allowed to surface that as `Err`, but it must NOT panic
     // and must NOT silently succeed against a DB that was never created.
@@ -95,7 +105,9 @@ fn open_reader_bridge_requires_existing_db() {
 }
 
 #[test]
+#[serial]
 fn open_reader_bridge_succeeds_after_writer_initialises_db() {
+    unregister_in_process_writer_for_test();
     let root = fresh_state_root("reader-after-writer");
     {
         // Drop the writer to release the open-lock before the reader opens.
@@ -125,7 +137,9 @@ fn open_reader_bridge_succeeds_after_writer_initialises_db() {
 }
 
 #[test]
+#[serial]
 fn writer_bridge_is_compatible_with_save_and_load_goal_board() {
+    unregister_in_process_writer_for_test();
     // The whole point of these helpers is to let dashboard / meeting /
     // engineer call sites flow through `save_goal_board(&board, writer.ops())`
     // and `load_goal_board(reader.ops())` without any ceremony.
@@ -151,7 +165,9 @@ fn writer_bridge_is_compatible_with_save_and_load_goal_board() {
 }
 
 #[test]
+#[serial]
 fn writer_bridge_does_not_create_legacy_goal_records_json_on_save() {
+    unregister_in_process_writer_for_test();
     // Acceptance criterion #6: every save must flow through cognitive memory.
     // No writer call site is allowed to create the legacy JSON file.
     let root = fresh_state_root("writer-no-disk-file");
@@ -203,7 +219,9 @@ fn writer_bridge_does_not_create_legacy_goal_records_json_on_save() {
 // ---------------------------------------------------------------------------
 
 #[test]
+#[serial]
 fn register_in_process_writer_returns_registered_arc_via_launch_writer_bridge() {
+    unregister_in_process_writer_for_test();
     // Use an in-memory NativeCognitiveMemory so we don't depend on disk
     // state. The state_root passed to launch_writer_bridge is irrelevant
     // when the in-process writer is registered: the launcher must short-
@@ -256,10 +274,15 @@ fn register_in_process_writer_returns_registered_arc_via_launch_writer_bridge() 
         "tier-0 shortcut must NOT create an on-disk DB at {}",
         db_path.display()
     );
+
+    // Cleanup so subsequent tests in this module run with a fresh slot.
+    unregister_in_process_writer_for_test();
 }
 
 #[test]
+#[serial]
 fn writer_bridge_construction_panics_when_inner_is_read_only() {
+    unregister_in_process_writer_for_test();
     // Defensive invariant: WriterBridge must refuse to wrap a read-only
     // handle. We construct a NativeCognitiveMemory via open() to create
     // the DB, drop it, then re-open read-only and assert that the
@@ -298,7 +321,9 @@ fn writer_bridge_construction_panics_when_inner_is_read_only() {
 }
 
 #[test]
+#[serial]
 fn launch_writer_bridge_returns_err_when_state_root_is_unwritable_file() {
+    unregister_in_process_writer_for_test();
     // Force tiers 1 and 2 to fail by passing a path that is a regular
     // file rather than a directory. Today the launcher falls through
     // to tier 3 (open_read_only) which itself fails because the file
@@ -322,7 +347,9 @@ fn launch_writer_bridge_returns_err_when_state_root_is_unwritable_file() {
 }
 
 #[test]
+#[serial]
 fn native_cognitive_memory_open_read_only_reports_is_read_only_true() {
+    unregister_in_process_writer_for_test();
     // Trait-default contract: writers report false, the read-only
     // opener reports true. Pin both so any future regression that
     // forgets to override `is_read_only` for a read-only backend is

--- a/src/memory_ipc/tests_launcher.rs
+++ b/src/memory_ipc/tests_launcher.rs
@@ -23,9 +23,10 @@
 //! Reader semantics: prefer the daemon socket; otherwise `open_read_only`
 //! (which requires the underlying DB file to already exist).
 
-use super::{launch_writer_bridge, open_reader_bridge};
-use crate::cognitive_memory::CognitiveMemoryOps;
+use super::{launch_writer_bridge, open_reader_bridge, register_in_process_writer};
+use crate::cognitive_memory::{CognitiveMemoryOps, NativeCognitiveMemory};
 use crate::goal_curation::{GoalBoard, load_goal_board, save_goal_board};
+use std::sync::Arc;
 
 fn fresh_state_root(tag: &str) -> std::path::PathBuf {
     let dir = std::env::temp_dir().join(format!(
@@ -173,5 +174,170 @@ fn writer_bridge_does_not_create_legacy_goal_records_json_on_save() {
         !legacy.exists(),
         "save_goal_board through WriterBridge must NOT create {}",
         legacy.display()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Issue #1590 follow-up — TDD tests for the dashboard hollow-success bug.
+//
+// The dashboard runs in the same process as the OODA daemon. When it calls
+// `launch_writer_bridge`, the launcher today walks tiers 1 → 2 → 3:
+//
+//   1. IPC to ~/.simard/memory.sock — fails when the daemon's own writer
+//      thread is already serving the request from the same process and
+//      the connection self-deadlocks (or when state_root_matches_daemon
+//      returns false for non-canonicalised paths).
+//   2. NativeCognitiveMemory::open — fails because the daemon owns the
+//      writer flock.
+//   3. open_read_only — succeeds, returns a read-only handle wrapped as
+//      a `WriterBridge`. Subsequent writes silently no-op at the IPC
+//      transport (or surface BridgeTransportError that the dashboard
+//      handler converts into Json({"error": …}) but only after the
+//      Ok(()) path has been threaded through `dashboard_save_goal_board`).
+//
+// The fix:
+//   - Tier 0: in-process Arc shortcut, registered by the daemon at
+//     startup. Same-process callers skip IPC entirely.
+//   - Remove tier 3 (silent read-only fallback).
+//   - Defensive `is_read_only()` invariant on `WriterBridge`.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn register_in_process_writer_returns_registered_arc_via_launch_writer_bridge() {
+    // Use an in-memory NativeCognitiveMemory so we don't depend on disk
+    // state. The state_root passed to launch_writer_bridge is irrelevant
+    // when the in-process writer is registered: the launcher must short-
+    // circuit and return the registered Arc.
+    let inner: Arc<dyn CognitiveMemoryOps> = Arc::new(
+        NativeCognitiveMemory::in_memory()
+            .expect("in-memory NativeCognitiveMemory must construct for tests"),
+    );
+
+    register_in_process_writer(Arc::clone(&inner));
+
+    // Call launch_writer_bridge with a state_root that has nothing on
+    // disk — without the in-process shortcut, tier 2 would create a
+    // fresh DB at this path. With the shortcut, the launcher returns
+    // the registered Arc and never touches disk.
+    let root = fresh_state_root("in-process-writer-shortcut");
+    let writer = launch_writer_bridge(&root)
+        .expect("launch_writer_bridge must succeed via the registered in-process writer");
+
+    // Write through the bridge.
+    writer
+        .ops()
+        .store_fact(
+            "tdd-1590:in-process-writer",
+            "written via launch_writer_bridge after register",
+            1.0,
+            &["tdd-1590".to_string()],
+            "tdd-test",
+        )
+        .expect("store_fact through in-process writer must succeed");
+
+    // The fact must be visible on the registered Arc directly,
+    // proving the bridge and the registered handle are the SAME backend.
+    let facts = inner
+        .search_facts("tdd-1590:in-process-writer", 5, 0.0)
+        .expect("search_facts on the registered Arc must succeed");
+    assert!(
+        facts
+            .iter()
+            .any(|f| f.content == "written via launch_writer_bridge after register"),
+        "the in-process shortcut must route writes to the registered Arc; got {} facts",
+        facts.len()
+    );
+
+    // The registered shortcut must also avoid creating a DB file on disk
+    // at the (irrelevant) state_root passed to launch_writer_bridge.
+    let db_path = root.join("cognitive_memory.ladybug");
+    assert!(
+        !db_path.exists(),
+        "tier-0 shortcut must NOT create an on-disk DB at {}",
+        db_path.display()
+    );
+}
+
+#[test]
+fn writer_bridge_construction_panics_when_inner_is_read_only() {
+    // Defensive invariant: WriterBridge must refuse to wrap a read-only
+    // handle. We construct a NativeCognitiveMemory via open() to create
+    // the DB, drop it, then re-open read-only and assert that the
+    // launcher (or whatever path constructs a WriterBridge from the
+    // read-only handle) panics with a clear message.
+    use crate::memory_ipc::WriterBridge;
+
+    let root = fresh_state_root("writer-bridge-readonly-guard");
+    {
+        let _writer = launch_writer_bridge(&root).expect("seed the DB");
+    }
+    let ro = NativeCognitiveMemory::open_read_only(&root).expect("open read-only");
+    assert!(
+        ro.is_read_only(),
+        "open_read_only must report is_read_only() == true"
+    );
+
+    // Construct a WriterBridge directly from the read-only handle. The
+    // assertion in WriterBridge's constructor must fire — a writer
+    // bridge wrapping a read-only handle is exactly the silent-
+    // degradation hazard the fix eliminates.
+    //
+    // `NativeCognitiveMemory` is not `RefUnwindSafe` (its inner
+    // `lbug::Database` wraps an `UnsafeCell`), so wrap the call in
+    // `AssertUnwindSafe` — we are the sole owner of `ro` here, and the
+    // panic we want to assert against happens before any state can be
+    // observed.
+    let ro_box: Box<dyn CognitiveMemoryOps> = Box::new(ro);
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+        WriterBridge::from_ops_for_test(ro_box)
+    }));
+    assert!(
+        result.is_err(),
+        "WriterBridge construction must panic when wrapping a read-only handle"
+    );
+}
+
+#[test]
+fn launch_writer_bridge_returns_err_when_state_root_is_unwritable_file() {
+    // Force tiers 1 and 2 to fail by passing a path that is a regular
+    // file rather than a directory. Today the launcher falls through
+    // to tier 3 (open_read_only) which itself fails because the file
+    // is not a LadybugDB — the user-visible result is `Err`. After the
+    // fix tier 3 is removed entirely; the failure surfaces from tier 2
+    // with a clearer message but still as `Err`.
+    //
+    // Either way, the contract this test pins is: the launcher must
+    // never silently return a `WriterBridge` whose underlying handle
+    // cannot perform writes against the requested state_root.
+    let parent = fresh_state_root("writer-unwritable-parent");
+    let unwritable = parent.join("not-a-dir.txt");
+    std::fs::write(&unwritable, b"this is a regular file, not a directory").expect("seed file");
+
+    let result = launch_writer_bridge(&unwritable);
+    assert!(
+        result.is_err(),
+        "launch_writer_bridge must return Err for an unusable state_root, \
+         got Ok writer (regression: silent read-only fallback or hollow success)"
+    );
+}
+
+#[test]
+fn native_cognitive_memory_open_read_only_reports_is_read_only_true() {
+    // Trait-default contract: writers report false, the read-only
+    // opener reports true. Pin both so any future regression that
+    // forgets to override `is_read_only` for a read-only backend is
+    // caught immediately.
+    let root = fresh_state_root("is-read-only-trait");
+    {
+        let writer = launch_writer_bridge(&root).expect("seed DB");
+        assert!(
+            !writer.ops().is_read_only(),
+            "writer bridge must report is_read_only() == false"
+        );
+    }
+    let ro = NativeCognitiveMemory::open_read_only(&root).expect("open read-only");
+    assert!(
+        ro.is_read_only(),
+        "NativeCognitiveMemory::open_read_only must report is_read_only() == true"
     );
 }

--- a/src/terminal_session/evidence.rs
+++ b/src/terminal_session/evidence.rs
@@ -177,4 +177,101 @@ mod tests {
         let raw = "line1\nline2\tline3";
         assert_eq!(compact_terminal_evidence_value(raw, 12), "line1\\nline2...");
     }
+
+    // ---------------------------------------------------------------------
+    // Issue #1590 follow-up — UTF-8 truncation panic regression tests.
+    //
+    // `String::truncate(N)` panics if `N` is not a UTF-8 char boundary.
+    // The transcript_preview / compact_terminal_evidence_value sites call
+    // `normalized.truncate(N)` with `N` as a byte budget, so any input
+    // where a multi-byte sequence (em-dash, CJK, emoji) crosses byte `N`
+    // panics the runtime worker. Confirmed in production journal:
+    //
+    //   thread 'tokio-rt-worker' panicked at src/terminal_session/evidence.rs:10:20
+    //
+    // These tests assert the helpers do not panic on multi-byte input at
+    // the budget boundary. Until the implementation switches to
+    // `crate::util::string_truncate::truncate_to_char_boundary`, they fail
+    // by panicking.
+    // ---------------------------------------------------------------------
+
+    /// Build a string whose total byte length exceeds `budget` and where a
+    /// multi-byte char straddles `budget`. Returns a string built from
+    /// `prefix_ascii_bytes` ASCII bytes, then the multi-byte char `mb`,
+    /// then enough trailing ASCII to push past `budget`. The caller picks
+    /// `prefix_ascii_bytes` so that the multi-byte char crosses the
+    /// boundary they want to test.
+    fn straddle(prefix_ascii_bytes: usize, mb: char, trailing: usize) -> String {
+        let mut s = String::with_capacity(prefix_ascii_bytes + 4 + trailing);
+        s.push_str(&"a".repeat(prefix_ascii_bytes));
+        s.push(mb);
+        s.push_str(&"b".repeat(trailing));
+        s
+    }
+
+    #[test]
+    fn transcript_preview_does_not_panic_on_em_dash_at_byte_512_boundary() {
+        // `transcript_preview` uses the literal budget `512`. We need the
+        // joined preview line to be longer than 512 bytes with an em-dash
+        // straddling byte 512. The join inserts " | " between non-script
+        // lines; a single content line with an em-dash at byte 511 is
+        // simplest.
+        let body = straddle(511, '—', 100);
+        let transcript = format!("Script started on 2026-04-01\n{body}\nScript done on 2026-04-01");
+
+        // Sanity: the body's em-dash straddles byte 512.
+        assert!(
+            !body.is_char_boundary(512),
+            "test fixture invariant: em-dash should straddle byte 512"
+        );
+
+        // Today: panics with `assertion failed: self.is_char_boundary(new_len)`.
+        // After fix: returns a sanitized, valid-UTF-8 preview.
+        let preview = transcript_preview(&transcript);
+
+        assert!(
+            std::str::from_utf8(preview.as_bytes()).is_ok(),
+            "preview must remain valid UTF-8"
+        );
+        assert!(
+            preview.ends_with("..."),
+            "preview must still indicate truncation; got {preview:?}"
+        );
+    }
+
+    #[test]
+    fn compact_terminal_evidence_value_does_not_panic_on_em_dash_at_boundary() {
+        // limit = 100; em-dash straddles byte 100.
+        let raw = straddle(99, '—', 50);
+        let compacted = compact_terminal_evidence_value(&raw, 100);
+        assert!(
+            std::str::from_utf8(compacted.as_bytes()).is_ok(),
+            "compacted value must remain valid UTF-8"
+        );
+        assert!(compacted.ends_with("..."));
+    }
+
+    #[test]
+    fn compact_terminal_evidence_value_does_not_panic_on_emoji_at_boundary() {
+        // 4-byte emoji 🎉 straddles byte 50; limit = 50.
+        let raw = straddle(48, '🎉', 30);
+        let compacted = compact_terminal_evidence_value(&raw, 50);
+        assert!(
+            std::str::from_utf8(compacted.as_bytes()).is_ok(),
+            "compacted value must remain valid UTF-8"
+        );
+        assert!(compacted.ends_with("..."));
+    }
+
+    #[test]
+    fn compact_terminal_evidence_value_does_not_panic_on_cjk_at_boundary() {
+        // 3-byte CJK '日' straddles byte 64; limit = 64.
+        let raw = straddle(63, '日', 30);
+        let compacted = compact_terminal_evidence_value(&raw, 64);
+        assert!(
+            std::str::from_utf8(compacted.as_bytes()).is_ok(),
+            "compacted value must remain valid UTF-8"
+        );
+        assert!(compacted.ends_with("..."));
+    }
 }

--- a/src/terminal_session/evidence.rs
+++ b/src/terminal_session/evidence.rs
@@ -1,4 +1,5 @@
 use crate::sanitization::sanitize_terminal_text;
+use crate::util::string_truncate::truncate_to_char_boundary;
 
 use super::types::TerminalStep;
 
@@ -7,7 +8,7 @@ pub(crate) fn transcript_preview(transcript: &str) -> String {
     let mut normalized = transcript_content_lines(&sanitized).join(" | ");
 
     if normalized.len() > 512 {
-        normalized.truncate(512);
+        truncate_to_char_boundary(&mut normalized, 512);
         normalized.push_str("...");
     }
 
@@ -106,7 +107,7 @@ pub(crate) fn compact_terminal_evidence_value(raw: &str, limit: usize) -> String
         .replace('\n', "\\n")
         .replace('\t', "\\t");
     if normalized.len() > limit {
-        normalized.truncate(limit);
+        truncate_to_char_boundary(&mut normalized, limit);
         normalized.push_str("...");
     }
     normalized

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,0 +1,10 @@
+//! Cross-cutting utility modules.
+//!
+//! Currently exports:
+//!
+//! - [`string_truncate`] — a stable-Rust char-boundary-safe replacement for
+//!   `String::truncate(N)` at every site where `N` is a byte budget rather
+//!   than a code-point count. See
+//!   `docs/reference/string-truncation-helpers.md`.
+
+pub mod string_truncate;

--- a/src/util/string_truncate.rs
+++ b/src/util/string_truncate.rs
@@ -25,11 +25,17 @@
 /// Stable Rust only — does not depend on the nightly
 /// `floor_char_boundary` API.
 pub fn truncate_to_char_boundary(s: &mut String, max_bytes: usize) {
-    let _ = (s, max_bytes);
-    unimplemented!(
-        "truncate_to_char_boundary: TDD stub — implementation lands in \
-         step 8 of issue #1590 follow-up"
-    );
+    if s.len() <= max_bytes {
+        return;
+    }
+    // Walk backward from max_bytes toward byte 0 until we land on a
+    // valid char boundary. Byte 0 is always a valid boundary so this
+    // loop terminates.
+    let mut cut = max_bytes;
+    while !s.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    s.truncate(cut);
 }
 
 #[cfg(test)]

--- a/src/util/string_truncate.rs
+++ b/src/util/string_truncate.rs
@@ -1,0 +1,168 @@
+//! Char-boundary-safe `String` truncation.
+//!
+//! `String::truncate(new_len)` panics when `new_len` is not a UTF-8 char
+//! boundary — the standard library asserts `self.is_char_boundary(new_len)`
+//! before truncating. Several Simard sites (transcript previews, evidence
+//! buffers, log lines) call `s.truncate(N)` with `N` as a byte budget
+//! rather than a code-point count, so any input where a multi-byte sequence
+//! (em-dash, CJK character, emoji) crosses byte `N` panics the runtime
+//! worker.
+//!
+//! See `docs/reference/string-truncation-helpers.md` for the design.
+
+/// Truncate `s` so its byte length does not exceed `max_bytes`, backing up
+/// to the previous UTF-8 char boundary if `max_bytes` falls inside a
+/// multi-byte sequence.
+///
+/// Properties:
+///
+/// - If `s.len() <= max_bytes` the string is left unchanged.
+/// - Otherwise the result satisfies `s.len() <= max_bytes` and remains
+///   valid UTF-8.
+/// - Never panics. Byte 0 is always a valid char boundary, so the
+///   boundary search always terminates.
+///
+/// Stable Rust only — does not depend on the nightly
+/// `floor_char_boundary` API.
+pub fn truncate_to_char_boundary(s: &mut String, max_bytes: usize) {
+    let _ = (s, max_bytes);
+    unimplemented!(
+        "truncate_to_char_boundary: TDD stub — implementation lands in \
+         step 8 of issue #1590 follow-up"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_op_when_within_budget() {
+        let mut s = "short ascii".to_string();
+        truncate_to_char_boundary(&mut s, 1024);
+        assert_eq!(s, "short ascii");
+    }
+
+    #[test]
+    fn no_op_when_exactly_at_budget() {
+        let mut s = "exactly".to_string();
+        let n = s.len();
+        truncate_to_char_boundary(&mut s, n);
+        assert_eq!(s, "exactly");
+    }
+
+    #[test]
+    fn ascii_longer_than_budget_truncates_at_byte_boundary() {
+        let mut s = "a".repeat(20);
+        truncate_to_char_boundary(&mut s, 5);
+        assert_eq!(s.len(), 5);
+        assert_eq!(s, "aaaaa");
+    }
+
+    #[test]
+    fn em_dash_at_boundary_does_not_panic() {
+        // Em-dash '—' is 3 bytes (0xE2 0x80 0x94).
+        // Build a string where an em-dash straddles byte 512.
+        let mut s = String::new();
+        s.push_str(&"a".repeat(511));
+        s.push('—'); // 3 bytes start at index 511, end at index 514
+        s.push_str(&"b".repeat(20));
+
+        // Sanity: byte 512 is mid-em-dash.
+        assert!(!s.is_char_boundary(512), "test fixture invariant");
+
+        truncate_to_char_boundary(&mut s, 512);
+
+        assert!(
+            s.len() <= 512,
+            "result must respect byte budget; got {}",
+            s.len()
+        );
+        // The em-dash must be fully present or fully removed — never
+        // partial. After truncating at byte 511 (the last valid boundary
+        // ≤ 512), the em-dash is dropped.
+        assert!(
+            std::str::from_utf8(s.as_bytes()).is_ok(),
+            "result must remain valid UTF-8"
+        );
+        assert_eq!(s.len(), 511);
+        assert!(!s.contains('—'));
+    }
+
+    #[test]
+    fn cjk_at_boundary_does_not_panic() {
+        // CJK characters are 3 bytes each in UTF-8.
+        let mut s = String::new();
+        s.push_str(&"a".repeat(99));
+        s.push('日'); // 3 bytes start at 99, end at 102
+        s.push('本');
+        s.push('語');
+
+        truncate_to_char_boundary(&mut s, 100);
+
+        assert!(s.len() <= 100);
+        assert!(std::str::from_utf8(s.as_bytes()).is_ok());
+        assert_eq!(s.len(), 99); // backed up before the CJK char
+    }
+
+    #[test]
+    fn emoji_at_boundary_does_not_panic() {
+        // 4-byte emoji 🎉 (U+1F389)
+        let mut s = String::new();
+        s.push_str(&"a".repeat(50));
+        s.push('🎉'); // 4 bytes start at 50, end at 54
+        s.push_str("trailing");
+
+        truncate_to_char_boundary(&mut s, 51);
+
+        assert!(s.len() <= 51);
+        assert!(std::str::from_utf8(s.as_bytes()).is_ok());
+        assert_eq!(s.len(), 50);
+        assert!(!s.contains('🎉'));
+    }
+
+    #[test]
+    fn emoji_at_boundary_keeps_emoji_when_budget_includes_it() {
+        let mut s = String::new();
+        s.push_str(&"a".repeat(50));
+        s.push('🎉');
+        s.push_str(&"b".repeat(50));
+
+        truncate_to_char_boundary(&mut s, 54);
+        // 50 ASCII + 4-byte emoji = 54 bytes — exactly at boundary.
+        assert_eq!(s.len(), 54);
+        assert!(s.contains('🎉'));
+    }
+
+    #[test]
+    fn empty_string_no_op() {
+        let mut s = String::new();
+        truncate_to_char_boundary(&mut s, 100);
+        assert_eq!(s, "");
+        truncate_to_char_boundary(&mut s, 0);
+        assert_eq!(s, "");
+    }
+
+    #[test]
+    fn zero_max_bytes_truncates_to_empty() {
+        let mut s = "anything".to_string();
+        truncate_to_char_boundary(&mut s, 0);
+        assert_eq!(s, "");
+    }
+
+    #[test]
+    fn zero_max_bytes_with_multibyte_lead_does_not_panic() {
+        let mut s = "—🎉日".to_string();
+        truncate_to_char_boundary(&mut s, 0);
+        assert_eq!(s, "");
+    }
+
+    #[test]
+    fn budget_one_truncates_to_empty_when_first_char_is_multibyte() {
+        // Em-dash starts at byte 0; max_bytes=1 falls mid-em-dash.
+        let mut s = "—trailing".to_string();
+        truncate_to_char_boundary(&mut s, 1);
+        // Backs up to byte 0 (the only char boundary ≤ 1 in this prefix).
+        assert_eq!(s, "");
+    }
+}

--- a/tests/improvement_curation.rs
+++ b/tests/improvement_curation.rs
@@ -147,7 +147,6 @@ approve: Promote this pattern into a repeatable benchmark | priority=2 | status=
 }
 
 #[test]
-#[ignore = "Probe round-trip needs bootstrap/assembly.rs migration to write goals through cognitive memory (follow-up to #1590)"]
 fn improvement_curation_read_probe_surfaces_persisted_review_decisions_without_mutating_state() {
     let state_root = TempDirGuard::new("simard-improvement-curation-read-probe");
 
@@ -186,10 +185,25 @@ defer: Promote this pattern into a repeatable benchmark | rationale=wait for the
         "improvement curation probe should persist the decisions that readback inspects:\n{improvement_rendered}"
     );
 
+    // Issue #1590 follow-up: with bootstrap migrated to
+    // `CognitiveMemoryGoalStore`, the goal register is durable inside
+    // cognitive memory, NOT in `goal_records.json`. We pin the
+    // read-only contract of the read probe by snapshotting the bridge-
+    // backed `memory_records.json` (which hosts non-goal review
+    // artefacts that the read probe must leave alone) before and after
+    // the read.
     let memory_before =
         fs::read(state_root.path().join("memory_records.json")).expect("memory store should exist");
-    let goals_before =
-        fs::read(state_root.path().join("goal_records.json")).expect("goal store should exist");
+    // After the migration `goal_records.json` is no longer written by
+    // the bootstrap goal store. If it exists at all (legacy operator
+    // state), it must remain unchanged across the read; if it does not
+    // exist the absence is itself the post-migration invariant.
+    let goals_path = state_root.path().join("goal_records.json");
+    let goals_before = if goals_path.exists() {
+        Some(fs::read(&goals_path).expect("legacy goal store should be readable"))
+    } else {
+        None
+    };
 
     let read_output = Command::new(env!("CARGO_BIN_EXE_simard_operator_probe"))
         .env("SIMARD_BOOTSTRAP_MODE", "builtin-defaults")
@@ -228,15 +242,19 @@ defer: Promote this pattern into a repeatable benchmark | rationale=wait for the
 
     let memory_after =
         fs::read(state_root.path().join("memory_records.json")).expect("memory store should exist");
-    let goals_after =
-        fs::read(state_root.path().join("goal_records.json")).expect("goal store should exist");
     assert_eq!(
         memory_before, memory_after,
         "improvement curation read must stay read-only with respect to persisted decision state"
     );
+    let goals_after = if goals_path.exists() {
+        Some(fs::read(&goals_path).expect("legacy goal store should be readable"))
+    } else {
+        None
+    };
     assert_eq!(
         goals_before, goals_after,
-        "improvement curation read must not rewrite the durable goal register"
+        "improvement curation read must not create or rewrite the legacy goal register \
+         (post-migration: file should remain absent; pre-migration legacy state must stay byte-identical)"
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes three regression bugs in Simard's adapter and wiring layer (all in Simard, none in amplihack-memory-lib or lbug). Refs #1590.

| Bug | Symptom | Fix |
|-----|---------|-----|
| 1 | Dashboard `POST /api/goals/demote/<id>` returns 200 but goal stays active (hollow success) | `src/memory_ipc/launcher.rs` rewrite: removed silent read-only fallback, added `WriterBridge::checked_new` panic guard, added in-process Arc tier-0 shortcut |
| 2 | `String::truncate(512)` panics on multi-byte UTF-8 in transcript truncation | New `src/util/string_truncate.rs::truncate_to_char_boundary`; wired into `terminal_session/evidence.rs` and `copilot_task_submit/transcript.rs` |
| 3 | Cross-subprocess goal state lost: improvement-curation subprocess writes via FileBackedGoalStore, engineer-loop subprocess reads via cognitive memory | New `CognitiveMemoryGoalStore` in `src/goals/cognitive_memory_store.rs`; bootstrap wired in `src/bootstrap/assembly.rs` |

## Commits

- `2bed5ea` test(#1590): TDD scaffolding for three regression fixes
- `8cff59f` fix(terminal_session,copilot_task_submit): UTF-8-safe transcript truncation (Bug 2)
- `4faea10` fix(memory_ipc): remove silent read-only fallback, add tier-0 in-process writer (Bug 1)
- `b53847c` fix(bootstrap,goals): migrate goal store to cognitive memory (Bug 3)

(Plus two earlier docs commits `aa65c1e` and `9f079ce` retconning the design notes.)

## Bug 1 detail — silent read-only fallback removed

The previous launcher had a tier-3 fallback that wrapped a `NativeCognitiveMemory::open_read_only` handle as a `WriterBridge` whenever tier-2 (writer open) failed. Subsequent `store_fact` calls on that handle were silently no-ops at the lbug layer, surfacing only as `Ok(())` at the `WriterBridge` layer. This is the root cause of the dashboard "hollow success" symptom in #1590.

Four coordinated changes make this fail loudly per the issue's "loud failure over silent degradation" design intent:

1. Default trait method `CognitiveMemoryOps::is_read_only()` returns `false`. `NativeCognitiveMemory` tracks a `read_only` field set by `open_read_only` and overrides the trait method. `SharedMemory` forwards.
2. `WriterBridge::checked_new` asserts `!inner.is_read_only()`. Every constructor (production and test) goes through this guard.
3. `launch_writer_bridge`: tier ladder is now `0=in-process Arc shortcut → 1=RemoteCognitiveMemory IPC → 2=NativeCognitiveMemory::open`. When tier-2 fails, the failure surfaces as `SimardError::RuntimeInitFailed` with an explicit "refusing silent read-only fallback per issue #1590" message.
4. `register_in_process_writer` is no longer a no-op. Test isolation uses `RwLock<Option<Arc>>` plus `serial_test`. Note: the daemon-startup wiring of `register_in_process_writer` itself is left as a follow-up; the launcher contract is now in place and tested, but tier-0 is dormant in production until that wiring lands.

## Bug 2 detail — UTF-8-safe truncation

Three call sites in `terminal_session/evidence.rs:10`, `terminal_session/evidence.rs:109`, and `copilot_task_submit/transcript.rs:350` used `String::truncate(N)` directly, which panics when `N` falls in the middle of a multi-byte UTF-8 sequence. The new `truncate_to_char_boundary` walks back from `max_bytes` to the nearest char boundary. 11 unit tests cover ASCII, em-dash, CJK, emoji, empty, zero-budget, and exact-budget cases.

## Bug 3 detail — CognitiveMemoryGoalStore

The half-migration was in `RuntimePorts.goal_store`: it remained wired to `FileBackedGoalStore` even after PR #1593 / #1600 migrated operator probes, engineer-loop, dashboard, and meeting backend to cognitive memory. Cross-subprocess reads went stale because `goal_store.put` wrote to `goal_records.json` while engineer-loop's `load_goal_board` read from a `goal-board:snapshot` cognitive memory fact.

`CognitiveMemoryGoalStore` implements `put` / `list` / `top_goals_by_status` / `active_top_goals`:

- `put` stores the full `GoalRecord` as a `goal-record:{slug}` fact AND projects the active set into `GoalBoard.active` via `save_goal_board`. The board projection is essential — engineer-loop subprocesses observe goals via `load_goal_board`, so without it the durability fix would be invisible across the subprocess boundary.
- `list` scans `search_facts(GOAL_RECORD_PREFIX, ...)` and dedupes by slug taking max `node_id` (uuid-v7 ⇒ time-ordered ⇒ most recent put wins).
- Active filtering and sorting `(status_rank, priority, title, slug)` matches the existing `FileBackedGoalStore` semantics.

Bootstrap fallback: `BootstrapMode::BuiltinDefaults` keeps a defensive `FileBackedGoalStore` fallback for environments where the bridge cannot open. In practice `CognitiveMemoryGoalStore::new` is essentially infallible.

## Tests

- `src/util/string_truncate.rs` — 11 new unit tests pin the UTF-8 contract.
- `src/memory_ipc/tests_launcher.rs` — 10 launcher tests (all `#[serial]`) pin: in-process Arc shortcut, panic on read-only writer wrap, no-silent-degradation on unwritable state_root, read-only flag visible through SharedMemory.
- `src/goals/cognitive_memory_store.rs` — 3 unit tests for round-trip, active filtering, sort.
- `tests/improvement_curation.rs` — `improvement_curation_read_probe_surfaces_persisted_review_decisions_without_mutating_state` now passes (was the original Bug 3 acceptance test).

### Validation chain

- `cargo build --release` ✅ (35 MB binary at `target/release/simard`)
- `cargo test --release --lib` ✅ **3789 passed; 0 failed; 1 ignored**
- `cargo test --test improvement_curation` ✅ 3/4 pass — including the original gating failure at line 142 (`Active goals count: 1`)
- `cargo clippy --all-targets --locked -- -D warnings` ✅ clean
- `cargo fmt --check` ✅ clean

### Pre-existing out-of-scope failure

`tests/improvement_curation.rs::review_artifacts_can_be_promoted_into_durable_improvement_goals` still fails at line 146 on `assertion failed: engineer_rendered.contains("Verification status: verified")`. This is NOT a #1590 regression:

- The task description named only line 142 (`Active goals count: 1`) as the gating failure; that assertion now passes.
- The literal `"verified"` is never assigned anywhere in `src/`. `verification.status` is hardcoded to `"agent-completed"` at `src/engineer_loop/mod.rs:187` and never upgraded. `src/engineer_loop/*` is byte-identical to `origin/main`.
- The test reaches line 146 only because Bug 3 unblocked the previously-failing line 142.

This pre-existing failure should be tracked as its own issue (engineer loop never marks verification status as `verified`). It is out of scope for #1590.

### Disk pressure note

`cargo test --release` (full suite, including `--all-targets`) attempted to compile every test binary and ran the host out of disk. The `--lib` subset which is the meaningful coverage for #1590 surface code passed cleanly. Targeted release tests across the #1590 surface (`goals::cognitive_memory_store` + `memory_ipc::tests_launcher` + `util::string_truncate` + `terminal_session` + `copilot_task_submit::transcript`) — 82/82 pass.

## Out of scope / follow-ups

- Wire `register_in_process_writer` at OODA daemon startup so tier-0 is live in production (currently dormant; same-process callers go through tier-1 IPC instead, which is correct but suboptimal).
- Engineer-loop verification status upgrade path (line-146 pre-existing failure above).

Refs #1590

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
