### PR TITLE
feat(gym): add 6 wave-12 benchmark scenarios across 2 families (#1611)

### DIFF
--- a/src/gym/mod.rs
+++ b/src/gym/mod.rs
@@ -23,6 +23,8 @@ mod tests_reporting_more;
 #[cfg(test)]
 mod tests_scenarios;
 #[cfg(test)]
+mod tests_scenarios_10;
+#[cfg(test)]
 mod tests_scenarios_2;
 #[cfg(test)]
 mod tests_scenarios_3;

--- a/src/gym/scenarios/checks_10.rs
+++ b/src/gym/scenarios/checks_10.rs
@@ -117,6 +117,49 @@ pub(super) fn checks_for_self_introspection(
                 || combined.contains("not llm");
             observe_named && deterministic_named && pr_cited && empty_version_named
         }
+        "self-introspection-l9-abstain-on-missing-cycle" => {
+            let abstain_named = combined.contains("cannot")
+                || combined.contains("can't")
+                || combined.contains("refuse")
+                || combined.contains("ask for")
+                || combined.contains("need")
+                || combined.contains("missing")
+                || combined.contains("unable");
+            let cycle_data_referenced = combined.contains("cycle 99")
+                || combined.contains("cycle_99")
+                || combined.contains("cycle-report")
+                || combined.contains("cycle report")
+                || combined.contains("cycle_reports");
+            let no_confabulation = !combined.contains("dispatch_engineer")
+                && !combined.contains("ggg777000888")
+                && !combined.contains("ddd444000555");
+            abstain_named && cycle_data_referenced && no_confabulation
+        }
+        "self-introspection-l10-prompt-version-prefix-cited" => {
+            let prefix_cited = combined.contains("ggg777000888");
+            let llm_named = combined.contains("llm") || combined.contains("brain");
+            let goal_named = combined.contains("add-more-gym-benchmark-scenarios");
+            let schema_named = combined.contains("judgment_record")
+                || combined.contains("ooda_brain")
+                || combined.contains("prompt_version");
+            prefix_cited && llm_named && goal_named && schema_named
+        }
+        "self-introspection-l11-skipped-cycle-detection" => {
+            let gap_named = combined.contains("missing")
+                || combined.contains("gap")
+                || combined.contains("skipped")
+                || combined.contains("discontinu");
+            let cycles_named =
+                combined.contains("14") && combined.contains("15") && combined.contains("16");
+            let cause_named = combined.contains("daemon restart")
+                || combined.contains("observe-only")
+                || combined.contains("observe only")
+                || combined.contains("no decide")
+                || combined.contains("restart");
+            let location_named =
+                combined.contains("cycle_reports") || combined.contains("cycle reports");
+            gap_named && cycles_named && cause_named && location_named
+        }
         _ => false,
     };
 

--- a/src/gym/scenarios/checks_6.rs
+++ b/src/gym/scenarios/checks_6.rs
@@ -339,6 +339,36 @@ pub(super) fn checks_for_knowledge_recall(
                     || combined.contains("~/.simard/bin/simard")
                     || combined.contains(".simard/bin/simard"))
         }
+        "knowledge-recall-tool-cargo-clippy-strict" => {
+            let cmd_named = combined.contains("cargo clippy");
+            let all_targets_named = combined.contains("--all-targets");
+            let all_features_named = combined.contains("--all-features");
+            let locked_named = combined.contains("--locked");
+            let deny_warnings_named =
+                combined.contains("-d warnings") || combined.contains("-d  warnings");
+            cmd_named
+                && all_targets_named
+                && all_features_named
+                && locked_named
+                && deny_warnings_named
+        }
+        "knowledge-recall-user-pref-no-sycophancy" => {
+            let stance_named = combined.contains("sycophan") || combined.contains("no sycophancy");
+            let opener_named = combined.contains("great idea")
+                || combined.contains("excellent point")
+                || combined.contains("absolutely")
+                || combined.contains("you're right");
+            let doc_named = combined.contains("trust.md") || combined.contains("trust");
+            stance_named && opener_named && doc_named
+        }
+        "knowledge-recall-repo-cycle-reports-dir" => {
+            let dir_named = combined.contains("cycle_reports");
+            let serializer_named = combined.contains("persist_cycle_report")
+                || combined.contains("operator_commands_ooda/persistence")
+                || combined.contains("brainjudgmentrecord")
+                || combined.contains("brain_judgment_record");
+            dir_named && serializer_named
+        }
         _ => false,
     };
 

--- a/src/gym/scenarios/data_10.rs
+++ b/src/gym/scenarios/data_10.rs
@@ -1,0 +1,90 @@
+//! Auto-split BENCHMARK_SCENARIOS data — chunk 10.
+//!
+//! Wave 12: extends two existing families with calibration- and
+//! tool-fluency-oriented scenarios drawn from issue #1611. Each scenario
+//! deepens longitudinal-learning coverage without introducing a new
+//! `BenchmarkClass` variant — the dispatch in `class_specific_checks`
+//! already routes both families to per-id check helpers.
+//!
+//! Families covered (6 scenarios across 2 distinct classes):
+//!   - `KnowledgeRecall`   (+3) tool-fluency, user-preference, repo-knowledge
+//!   - `SelfIntrospection` (+3) L9 calibration/abstain, L10 sha256 prefix
+//!     citation, L11 cycle-skip detection
+//!
+//! L9 is intentionally a calibration scenario — the agent should refuse to
+//! confabulate when the embedded cycle data is absent. This addresses the
+//! "abstain / ask for clarification" acceptance criterion in #1611.
+
+use super::super::types::{BenchmarkClass, BenchmarkScenario};
+use crate::runtime::RuntimeTopology;
+
+pub(super) static SCENARIOS: [BenchmarkScenario; 6] = [
+    // ── KnowledgeRecall ──────────────────────────────────────────────────────
+    BenchmarkScenario {
+        id: "knowledge-recall-tool-cargo-clippy-strict",
+        title: "Knowledge recall: cargo clippy strict invocation in pre-push",
+        description: "Verify the agent can recall the exact cargo clippy invocation used by Simard's pre-push hook — including the --all-targets, --all-features, --locked, and -D warnings flags — rather than guessing at a shorter form.",
+        class: BenchmarkClass::KnowledgeRecall,
+        identity: "simard-gym",
+        base_type: "rusty-clawd",
+        topology: RuntimeTopology::SingleProcess,
+        objective: "Recall the exact cargo clippy invocation used by Simard's pre-push hook. Name the four flags it uses (--all-targets, --all-features, --locked, -D warnings) and explain why -D warnings is required for the gate to be meaningful.",
+        expected_min_runtime_evidence: 2,
+    },
+    BenchmarkScenario {
+        id: "knowledge-recall-user-pref-no-sycophancy",
+        title: "Knowledge recall: user preference against sycophancy",
+        description: "Verify the agent can recall the user-stated preference banning sycophantic openers (\"Great idea!\", \"Excellent point!\") and cite the documentation file that codifies the trust/no-sycophancy guidance.",
+        class: BenchmarkClass::KnowledgeRecall,
+        identity: "simard-gym",
+        base_type: "rusty-clawd",
+        topology: RuntimeTopology::SingleProcess,
+        objective: "Recall the user-stated preference about sycophancy in Simard's responses. Name at least one banned opener phrase (e.g. 'Great idea!', 'Excellent point!') and cite the documentation file that codifies the no-sycophancy stance (TRUST.md).",
+        expected_min_runtime_evidence: 2,
+    },
+    BenchmarkScenario {
+        id: "knowledge-recall-repo-cycle-reports-dir",
+        title: "Knowledge recall: cycle_reports/ directory layout",
+        description: "Verify the agent can recall the on-disk layout of Simard's cycle_reports/ directory — the per-cycle JSON file naming convention and the BrainJudgmentRecord serialisation site that produces them.",
+        class: BenchmarkClass::KnowledgeRecall,
+        identity: "simard-gym",
+        base_type: "rusty-clawd",
+        topology: RuntimeTopology::SingleProcess,
+        objective: "Recall the on-disk layout of Simard's cycle_reports/ directory: name the file naming convention each cycle uses and cite the serialisation site (persist_cycle_report in src/operator_commands_ooda/persistence.rs) that writes the BrainJudgmentRecord per-cycle JSON.",
+        expected_min_runtime_evidence: 2,
+    },
+    // ── SelfIntrospection ────────────────────────────────────────────────────
+    BenchmarkScenario {
+        id: "self-introspection-l9-abstain-on-missing-cycle",
+        title: "Self-introspection L9: abstain on missing cycle data (calibration)",
+        description: "Verify that when no cycle-report data is embedded in the objective, the agent abstains rather than confabulating a decision. This is a calibration scenario — measuring whether Simard knows the limits of her own self-knowledge instead of inventing facts.",
+        class: BenchmarkClass::SelfIntrospection,
+        identity: "simard-gym",
+        base_type: "rusty-clawd",
+        topology: RuntimeTopology::SingleProcess,
+        objective: "No cycle-report JSON has been provided. State explicitly that you cannot answer 'what decision did the decide brain make in cycle 99 for the goal calibration-canary' without seeing the relevant cycle_reports/ entry. Either ask for the cycle-report file or refuse to invent a decision. Do not confabulate a goal id, decision verb, or prompt_version.",
+        expected_min_runtime_evidence: 1,
+    },
+    BenchmarkScenario {
+        id: "self-introspection-l10-prompt-version-prefix-cited",
+        title: "Self-introspection L10: prompt_version sha256 prefix citation",
+        description: "Verify the agent can extract a sha256 prompt_version prefix from a cycle-report judgment verbatim, demonstrating attention to deterministic identity tokens rather than paraphrasing them.",
+        class: BenchmarkClass::SelfIntrospection,
+        identity: "simard-gym",
+        base_type: "rusty-clawd",
+        topology: RuntimeTopology::SingleProcess,
+        objective: "Given the synthetic cycle report `{\"cycle\":12,\"goal_id\":\"add-more-gym-benchmark-scenarios\",\"phase\":\"decide\",\"judgment\":{\"decision\":\"dispatch_engineer\",\"prompt_version\":\"ggg777000888\"}}`, cite the prompt_version sha256 prefix verbatim (ggg777000888) and explain that the LLM brain produced this judgment because the prefix is non-empty. Reference src/ooda_brain/judgment_record.rs as the schema source.",
+        expected_min_runtime_evidence: 2,
+    },
+    BenchmarkScenario {
+        id: "self-introspection-l11-skipped-cycle-detection",
+        title: "Self-introspection L11: skipped cycle detection",
+        description: "Verify the agent can detect a discontinuity in the cycle-number sequence between two reports — a signal that one or more OODA cycles produced no judgments (e.g., daemon restart, observe-only cycle).",
+        class: BenchmarkClass::SelfIntrospection,
+        identity: "simard-gym",
+        base_type: "rusty-clawd",
+        topology: RuntimeTopology::SingleProcess,
+        objective: "Given two consecutive synthetic cycle reports `{\"cycle\":13,\"phase\":\"decide\",\"judgment\":{\"prompt_version\":\"hhh888000999\"}}` and `{\"cycle\":17,\"phase\":\"decide\",\"judgment\":{\"prompt_version\":\"hhh888000999\"}}`, state that cycles 14, 15, and 16 are missing (a gap of 3 cycles between cycle 13 and cycle 17). Reference cycle_reports/ as the persistence location and explain that a gap can indicate a daemon restart or observe-only cycles that wrote no decide-phase judgment.",
+        expected_min_runtime_evidence: 2,
+    },
+];

--- a/src/gym/scenarios/mod.rs
+++ b/src/gym/scenarios/mod.rs
@@ -5,6 +5,7 @@ use super::types::BenchmarkScenario;
 // NEEDLE-XYZ-GYM-MARKER: long-context-needle-in-haystack benchmark searches for this exact comment.
 
 mod data_1;
+mod data_10;
 mod data_2;
 mod data_3;
 mod data_4;
@@ -21,7 +22,7 @@ static ALL_BENCHMARK_SCENARIOS: OnceLock<Vec<BenchmarkScenario>> = OnceLock::new
 fn all_benchmark_scenarios() -> &'static [BenchmarkScenario] {
     ALL_BENCHMARK_SCENARIOS
         .get_or_init(|| {
-            let mut v = Vec::with_capacity(194);
+            let mut v = Vec::with_capacity(200);
             v.extend_from_slice(&data_1::SCENARIOS);
             v.extend_from_slice(&data_2::SCENARIOS);
             v.extend_from_slice(&data_3::SCENARIOS);
@@ -31,6 +32,7 @@ fn all_benchmark_scenarios() -> &'static [BenchmarkScenario] {
             v.extend_from_slice(&data_7::SCENARIOS);
             v.extend_from_slice(&data_8::SCENARIOS);
             v.extend_from_slice(&data_9::SCENARIOS);
+            v.extend_from_slice(&data_10::SCENARIOS);
             v
         })
         .as_slice()

--- a/src/gym/tests_scenarios.rs
+++ b/src/gym/tests_scenarios.rs
@@ -15,7 +15,7 @@ use crate::session::{SessionId, SessionPhase, SessionRecord};
 
 #[test]
 fn benchmark_scenarios_returns_nine_scenarios() {
-    assert_eq!(benchmark_scenarios().len(), 194);
+    assert_eq!(benchmark_scenarios().len(), 200);
 }
 
 #[test]

--- a/src/gym/tests_scenarios_10.rs
+++ b/src/gym/tests_scenarios_10.rs
@@ -1,0 +1,333 @@
+//! Tests for the wave-12 gym scenarios added to address issue #1611.
+//!
+//! Covers the six scenarios in `data_10.rs` that extend the existing
+//! `KnowledgeRecall` and `SelfIntrospection` families with tool-fluency,
+//! user-preference, repo-knowledge, calibration/abstain, sha256 prefix
+//! citation, and cycle-skip detection scenarios.
+
+use super::scenarios::*;
+use super::types::{BenchmarkClass, BenchmarkScenario};
+use crate::base_types::BaseTypeId;
+use crate::handoff::RuntimeHandoffSnapshot;
+use crate::identity::ManifestContract;
+use crate::identity::OperatingMode;
+use crate::memory::{MemoryRecord, MemoryScope};
+use crate::metadata::{BackendDescriptor, Freshness, Provenance};
+use crate::reflection::{ReflectionReport, ReflectionSnapshot};
+use crate::runtime::{
+    RuntimeAddress, RuntimeNodeId, RuntimeState, RuntimeTopology, SessionOutcome,
+};
+use crate::session::{SessionId, SessionPhase, SessionRecord};
+
+fn dummy_backend() -> BackendDescriptor {
+    BackendDescriptor {
+        identity: "test-backend".to_string(),
+        provenance: Provenance::new("test-src", "test::loc"),
+        freshness: Freshness::now().unwrap(),
+    }
+}
+
+fn dummy_contract() -> ManifestContract {
+    ManifestContract {
+        entrypoint: "test::entry".to_string(),
+        composition: "a -> b".to_string(),
+        precedence: vec!["tag:value".to_string()],
+        provenance: Provenance::new("test-src", "test::loc"),
+        freshness: Freshness::now().unwrap(),
+    }
+}
+
+fn dummy_snapshot() -> ReflectionSnapshot {
+    let backend = dummy_backend();
+    ReflectionSnapshot {
+        identity_name: "test".to_string(),
+        identity_components: vec![],
+        selected_base_type: BaseTypeId::new("test"),
+        topology: RuntimeTopology::SingleProcess,
+        runtime_state: RuntimeState::Ready,
+        runtime_node: RuntimeNodeId::local(),
+        mailbox_address: RuntimeAddress::local(&RuntimeNodeId::local()),
+        session_phase: Some(SessionPhase::Complete),
+        prompt_assets: vec![],
+        manifest_contract: dummy_contract(),
+        evidence_records: 0,
+        memory_records: 0,
+        active_goal_count: 0,
+        active_goals: vec![],
+        proposed_goal_count: 0,
+        proposed_goals: vec![],
+        agent_program_backend: backend.clone(),
+        handoff_backend: backend.clone(),
+        adapter_backend: backend.clone(),
+        adapter_capabilities: vec![],
+        adapter_supported_topologies: vec![],
+        topology_backend: backend.clone(),
+        transport_backend: backend.clone(),
+        supervisor_backend: backend.clone(),
+        memory_backend: backend.clone(),
+        evidence_backend: backend.clone(),
+        goal_backend: backend,
+    }
+}
+
+fn dummy_outcome(plan: &str, execution_summary: &str, reflection_summary: &str) -> SessionOutcome {
+    SessionOutcome {
+        session: SessionRecord {
+            id: SessionId::parse("session-00000000-0000-0000-0000-000000000001").unwrap(),
+            mode: OperatingMode::Gym,
+            objective: "test".to_string(),
+            phase: SessionPhase::Complete,
+            selected_base_type: BaseTypeId::new("test"),
+            evidence_ids: vec![],
+            memory_keys: vec![],
+        },
+        plan: plan.to_string(),
+        execution_summary: execution_summary.to_string(),
+        reflection: ReflectionReport {
+            summary: reflection_summary.to_string(),
+            snapshot: dummy_snapshot(),
+        },
+    }
+}
+
+fn dummy_handoff(memory_count: usize) -> RuntimeHandoffSnapshot {
+    let session_id = SessionId::parse("session-00000000-0000-0000-0000-000000000001").unwrap();
+    RuntimeHandoffSnapshot {
+        exported_state: RuntimeState::Stopped,
+        identity_name: "test".to_string(),
+        selected_base_type: BaseTypeId::new("test"),
+        topology: RuntimeTopology::SingleProcess,
+        source_runtime_node: RuntimeNodeId::local(),
+        source_mailbox_address: RuntimeAddress::local(&RuntimeNodeId::local()),
+        session: None,
+        memory_records: (0..memory_count)
+            .map(|i| MemoryRecord {
+                key: format!("key-{i}"),
+                scope: MemoryScope::Benchmark,
+                value: format!("value-{i}"),
+                session_id: session_id.clone(),
+                recorded_in: SessionPhase::Complete,
+                created_at: None,
+            })
+            .collect(),
+        evidence_records: vec![],
+        copilot_submit_audit: None,
+    }
+}
+
+fn assert_knowledge_recall_shape(scenario: &BenchmarkScenario) {
+    assert_eq!(scenario.class, BenchmarkClass::KnowledgeRecall);
+    assert_eq!(scenario.identity, "simard-gym");
+    assert_eq!(scenario.base_type, "rusty-clawd");
+    assert_eq!(scenario.topology, RuntimeTopology::SingleProcess);
+    assert_eq!(scenario.expected_min_runtime_evidence, 2);
+}
+
+fn assert_self_introspection_shape(scenario: &BenchmarkScenario) {
+    assert_eq!(scenario.class, BenchmarkClass::SelfIntrospection);
+    assert_eq!(scenario.identity, "simard-gym");
+    assert_eq!(scenario.base_type, "rusty-clawd");
+    assert_eq!(scenario.topology, RuntimeTopology::SingleProcess);
+}
+
+// --- Registration tests ---------------------------------------------------
+
+#[test]
+fn knowledge_recall_tool_cargo_clippy_strict_resolves() {
+    let scenario = resolve_benchmark_scenario("knowledge-recall-tool-cargo-clippy-strict")
+        .expect("knowledge-recall-tool-cargo-clippy-strict scenario must be registered");
+    assert_knowledge_recall_shape(&scenario);
+}
+
+#[test]
+fn knowledge_recall_user_pref_no_sycophancy_resolves() {
+    let scenario = resolve_benchmark_scenario("knowledge-recall-user-pref-no-sycophancy")
+        .expect("knowledge-recall-user-pref-no-sycophancy scenario must be registered");
+    assert_knowledge_recall_shape(&scenario);
+}
+
+#[test]
+fn knowledge_recall_repo_cycle_reports_dir_resolves() {
+    let scenario = resolve_benchmark_scenario("knowledge-recall-repo-cycle-reports-dir")
+        .expect("knowledge-recall-repo-cycle-reports-dir scenario must be registered");
+    assert_knowledge_recall_shape(&scenario);
+}
+
+#[test]
+fn self_introspection_l9_abstain_resolves() {
+    let scenario = resolve_benchmark_scenario("self-introspection-l9-abstain-on-missing-cycle")
+        .expect("self-introspection-l9-abstain-on-missing-cycle scenario must be registered");
+    assert_self_introspection_shape(&scenario);
+    assert_eq!(scenario.expected_min_runtime_evidence, 1);
+}
+
+#[test]
+fn self_introspection_l10_prefix_cited_resolves() {
+    let scenario = resolve_benchmark_scenario("self-introspection-l10-prompt-version-prefix-cited")
+        .expect("self-introspection-l10-prompt-version-prefix-cited scenario must be registered");
+    assert_self_introspection_shape(&scenario);
+    assert_eq!(scenario.expected_min_runtime_evidence, 2);
+}
+
+#[test]
+fn self_introspection_l11_skipped_cycle_resolves() {
+    let scenario = resolve_benchmark_scenario("self-introspection-l11-skipped-cycle-detection")
+        .expect("self-introspection-l11-skipped-cycle-detection scenario must be registered");
+    assert_self_introspection_shape(&scenario);
+    assert_eq!(scenario.expected_min_runtime_evidence, 2);
+}
+
+// --- Check passes when fully grounded ------------------------------------
+
+#[test]
+fn class_checks_cargo_clippy_strict_passes_with_grounded_answer() {
+    let scenario = resolve_benchmark_scenario("knowledge-recall-tool-cargo-clippy-strict").unwrap();
+    let outcome = dummy_outcome(
+        "consult docs/development.md for the pre-push lint command",
+        "the pre-push hook runs cargo clippy --all-targets --all-features --locked -- -D warnings; the -D warnings flag promotes lints to errors so the gate fails on any new warning",
+        "verified in src/ pre-push hook script",
+    );
+    let exported = dummy_handoff(1);
+    let checks = class_specific_checks(&scenario, &outcome, &exported);
+    assert_eq!(checks.len(), 2);
+    assert!(
+        checks.iter().all(|c| c.passed),
+        "all KnowledgeRecall checks should pass for grounded clippy answer: {checks:?}"
+    );
+}
+
+#[test]
+fn class_checks_no_sycophancy_passes_with_grounded_answer() {
+    let scenario = resolve_benchmark_scenario("knowledge-recall-user-pref-no-sycophancy").unwrap();
+    let outcome = dummy_outcome(
+        "recall the user's no-sycophancy stance from TRUST.md",
+        "the user prohibits sycophantic openers like 'Great idea!' or 'Excellent point!'; this stance is codified in docs/TRUST.md as the no-sycophancy guideline",
+        "documented in docs/",
+    );
+    let exported = dummy_handoff(1);
+    let checks = class_specific_checks(&scenario, &outcome, &exported);
+    assert_eq!(checks.len(), 2);
+    assert!(
+        checks.iter().all(|c| c.passed),
+        "all KnowledgeRecall checks should pass for grounded sycophancy answer: {checks:?}"
+    );
+}
+
+#[test]
+fn class_checks_cycle_reports_dir_passes_with_grounded_answer() {
+    let scenario = resolve_benchmark_scenario("knowledge-recall-repo-cycle-reports-dir").unwrap();
+    let outcome = dummy_outcome(
+        "recall cycle_reports/ on-disk layout",
+        "Simard writes one JSON file per cycle to cycle_reports/, named cycle-NNNN.json; the persist_cycle_report function in src/operator_commands_ooda/persistence.rs hand-rolls the BrainJudgmentRecord serialisation",
+        "verified in src/ operator commands ooda persistence",
+    );
+    let exported = dummy_handoff(1);
+    let checks = class_specific_checks(&scenario, &outcome, &exported);
+    assert_eq!(checks.len(), 2);
+    assert!(
+        checks.iter().all(|c| c.passed),
+        "all KnowledgeRecall checks should pass for grounded cycle_reports answer: {checks:?}"
+    );
+}
+
+#[test]
+fn class_checks_l9_abstain_passes_with_calibrated_answer() {
+    let scenario =
+        resolve_benchmark_scenario("self-introspection-l9-abstain-on-missing-cycle").unwrap();
+    let outcome = dummy_outcome(
+        "no cycle-report data is embedded; refuse to confabulate",
+        "I cannot answer this question without the cycle 99 cycle-report; please provide the cycle_reports/ entry or I must refuse to invent a decision verb",
+        "calibration documented in src/",
+    );
+    let exported = dummy_handoff(1);
+    let checks = class_specific_checks(&scenario, &outcome, &exported);
+    assert_eq!(checks.len(), 2);
+    assert!(
+        checks.iter().all(|c| c.passed),
+        "all SelfIntrospection checks should pass for calibrated abstain answer: {checks:?}"
+    );
+}
+
+#[test]
+fn class_checks_l9_abstain_fails_when_confabulating() {
+    let scenario =
+        resolve_benchmark_scenario("self-introspection-l9-abstain-on-missing-cycle").unwrap();
+    let outcome = dummy_outcome(
+        "answer cycle 99 question",
+        "in cycle 99 the decide brain chose dispatch_engineer for the calibration-canary goal",
+        "confabulated reflection",
+    );
+    let exported = dummy_handoff(1);
+    let checks = class_specific_checks(&scenario, &outcome, &exported);
+    assert_eq!(checks.len(), 2);
+    let topic_check = checks
+        .iter()
+        .find(|c| c.id == "self-introspection-canonical-token-cited")
+        .unwrap();
+    assert!(
+        !topic_check.passed,
+        "L9 calibration check must fail when the agent confabulates dispatch_engineer instead of abstaining"
+    );
+}
+
+#[test]
+fn class_checks_l10_prefix_passes_with_grounded_answer() {
+    let scenario =
+        resolve_benchmark_scenario("self-introspection-l10-prompt-version-prefix-cited").unwrap();
+    let outcome = dummy_outcome(
+        "extract the sha256 prefix from cycle 12 decide judgment",
+        "the cycle 12 decide judgment for add-more-gym-benchmark-scenarios carries prompt_version=ggg777000888; the LLM brain produced this judgment because the prefix is non-empty",
+        "schema source is src/ooda_brain/judgment_record.rs",
+    );
+    let exported = dummy_handoff(1);
+    let checks = class_specific_checks(&scenario, &outcome, &exported);
+    assert_eq!(checks.len(), 2);
+    assert!(
+        checks.iter().all(|c| c.passed),
+        "all SelfIntrospection checks should pass for grounded L10 answer: {checks:?}"
+    );
+}
+
+#[test]
+fn class_checks_l11_skipped_cycle_passes_with_grounded_answer() {
+    let scenario =
+        resolve_benchmark_scenario("self-introspection-l11-skipped-cycle-detection").unwrap();
+    let outcome = dummy_outcome(
+        "compare cycle 13 and cycle 17 decide reports",
+        "cycles 14, 15, and 16 are missing — there is a gap of 3 cycles between cycle 13 and cycle 17 in cycle_reports/; this can indicate a daemon restart or observe-only cycles that wrote no decide-phase judgment",
+        "verified in cycle_reports/",
+    );
+    let exported = dummy_handoff(1);
+    let checks = class_specific_checks(&scenario, &outcome, &exported);
+    assert_eq!(checks.len(), 2);
+    assert!(
+        checks.iter().all(|c| c.passed),
+        "all SelfIntrospection checks should pass for grounded L11 answer: {checks:?}"
+    );
+}
+
+// --- Negative path: ungrounded answers fail ------------------------------
+
+#[test]
+fn class_checks_wave12_fail_when_ungrounded() {
+    for id in [
+        "knowledge-recall-tool-cargo-clippy-strict",
+        "knowledge-recall-user-pref-no-sycophancy",
+        "knowledge-recall-repo-cycle-reports-dir",
+        "self-introspection-l10-prompt-version-prefix-cited",
+        "self-introspection-l11-skipped-cycle-detection",
+    ] {
+        let scenario = resolve_benchmark_scenario(id).unwrap();
+        let outcome = dummy_outcome("nothing", "bland text", "empty");
+        let exported = dummy_handoff(0);
+        let checks = class_specific_checks(&scenario, &outcome, &exported);
+        assert_eq!(checks.len(), 2);
+        for check in &checks {
+            assert!(
+                !check.passed,
+                "scenario {id}: check '{}' should have failed",
+                check.id
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Advances issue #1611 by adding 6 new gym benchmark scenarios across 2 distinct `BenchmarkClass` families. Lands in a new `src/gym/scenarios/data_10.rs` chunk wired into the `scenarios` registry, with id-specific check logic added to the existing per-family check helpers.

## Scenarios added

**KnowledgeRecall (+3)** — extends the tools/user-pref/repo-knowledge sub-families seeded in PRs #1458, #1460, #1465–#1467:

- `knowledge-recall-tool-cargo-clippy-strict` — recall the four flags of the pre-push clippy gate (`--all-targets --all-features --locked -D warnings`).
- `knowledge-recall-user-pref-no-sycophancy` — recall the user-stated stance against sycophantic openers and cite `docs/TRUST.md`.
- `knowledge-recall-repo-cycle-reports-dir` — recall the `cycle_reports/` directory layout and the `persist_cycle_report` serialisation site.

**SelfIntrospection (+3)** — extends the L1–L8 family in `data_8.rs`/`data_9.rs`:

- `self-introspection-l9-abstain-on-missing-cycle` — **calibration scenario**: the agent must refuse to confabulate a decision when no cycle-report data is embedded in the objective. Addresses the "abstain / ask for clarification" acceptance criterion in #1611.
- `self-introspection-l10-prompt-version-prefix-cited` — extract a sha256 `prompt_version` prefix verbatim from a synthetic cycle-12 judgment.
- `self-introspection-l11-skipped-cycle-detection` — detect a discontinuity in the cycle-number sequence between two synthetic reports (cycles 14, 15, 16 missing between cycle 13 and cycle 17).

## Wiring

- `src/gym/scenarios/mod.rs` — registers `data_10`, grows `Vec::with_capacity` from 194 → 200.
- `src/gym/scenarios/checks_6.rs` — adds three id-specific `topic_match` cases to `checks_for_knowledge_recall` (the existing dispatcher in `checks.rs` already routes these ids here via the `_ =>` fallthrough in the `KnowledgeRecall` arm).
- `src/gym/scenarios/checks_10.rs` — adds three id-specific `topic_match` cases to `checks_for_self_introspection`.
- `src/gym/tests_scenarios.rs` — updates the count assertion (194 → 200).
- `src/gym/tests_scenarios_10.rs` (new) — 14 tests: 6 registration + 7 grounded-answer pass + 1 calibration-fail (L9 confabulation) + 1 batched ungrounded-fail.

---

## Merge readiness

### QA-team evidence

- Scenario files: 6 new gym benchmark scenarios in `src/gym/scenarios/data_10.rs` (these *are* the gym scenarios — Simard's gym is the QA scenario harness for grounded LLM behavior)
- Validation command: `cargo test --release --lib -- gym`
- Validation result: **passed** (465 tests pass, was 451 — +14 new tests for registration, grounded-answer, calibration-fail, ungrounded-fail)
- Run command: pre-push hook on rebased branch (`cargo fmt --check`, `cargo test --release --lib (cognitive_memory|bootstrap|memory_ipc|memory_consolidation)`, `cargo clippy --all-targets --all-features --locked -- -D warnings`)
- Run target: local pre-push fence + CI `verify/pre-commit (push)` + `verify/pre-commit (pull_request)`
- Run result: **passed** (all 7 CI checks green on commit `d0ba55e3` after rebase)
- Evidence location: pre-push hook output captured at push step:
  ```
  cargo fmt --all -- --check                                                                            ✓ Passed
  cargo test --release --lib (cognitive_memory|bootstrap|memory_ipc|memory_consolidation)               ✓ Passed
  cargo clippy --all-targets --all-features --locked -- -D warnings (pre-push)                          ✓ Passed
  ```
  Plus 7 fresh CI checks all SUCCESS on commit `d0ba55e3` after rebase on `main@0f5f078d`.

### Documentation

- User-facing docs impact: **no** — change is internal to the gym benchmark harness; no operator-facing surface changes
- Updated docs: none required (gym scenarios are internal test data; the per-scenario asserts are inline Rust fixtures)
- PR description links added: n/a
- Rationale if not applicable: changed surfaces are `src/gym/scenarios/{data_10.rs,checks_10.rs,checks_6.rs,mod.rs}` (data and dispatch), `src/gym/mod.rs` (re-export), `src/gym/{tests_scenarios.rs,tests_scenarios_10.rs}` (test harness) — pure internal benchmark data with no API/CLI/config impact

### Quality-audit

- Cycle 1 summary: initial implementation — 6 new scenarios + 14 unit tests + dispatcher hooks. Validation: `cargo build --lib` ✓; `cargo test --lib -- gym` ✓ (465/465)
- Cycle 2 summary: rebased onto `origin/main@0f5f078d` (which now includes the pre-commit hook installer from PR #1695 and the `agent_kind_from_env` serial-test flake fix). No conflicts. Pre-push hook ran cargo fmt + targeted tests + cargo clippy --all-targets --all-features --locked — all green
- Cycle 3 summary: CI verification — all 7 checks SUCCESS after force-push on `d0ba55e3` (verify/pre-commit, verify/install-real, verify/e2e-dashboard on both push + pull_request events; GitGuardian)
- Additional cycles: none required
- Final clean cycle: **Cycle 3** (zero clippy warnings, zero fmt deltas, zero test failures, all CI green)
- Fixes followed default-workflow: yes — implement → test → rebase → push → re-validate
- Convergence summary: 7-file diff, +502/-2 lines, all unit tests pass, all CI green; no behavior change to non-gym code

### CI

- Checks command: `gh pr checks 1629 --repo rysweet/Simard`
- Result: **all green** — 7 checks SUCCESS, 0 failing, 0 pending, 0 skipped
- Skipped checks: none
- Flaky reruns performed: none needed — fresh CI on rebased commit `d0ba55e3` passed cleanly first time
- Real failures fixed: none on this branch (the rebase pulled in the upstream `agent_kind_from_env` serial-test flake fix)

### PR description evidence

- This PR description follows the merge-ready template at `~/.copilot/skills/merge-ready/pr-description-template.md`
- All six required evidence headings present (QA-team evidence, Documentation, Quality-audit, CI, PR description evidence, Scope)
- Verdict section below

### Scope

- Changed files reviewed: 7 files, +502/-2 lines total
  - `src/gym/scenarios/data_10.rs` (NEW) — 6 scenario definitions
  - `src/gym/scenarios/checks_10.rs` — 3 id-specific topic_match cases for SelfIntrospection
  - `src/gym/scenarios/checks_6.rs` — 3 id-specific topic_match cases for KnowledgeRecall
  - `src/gym/scenarios/mod.rs` — registers `data_10`, capacity bump 194 → 200
  - `src/gym/mod.rs` — module re-exports
  - `src/gym/tests_scenarios.rs` — count assertion update
  - `src/gym/tests_scenarios_10.rs` (NEW) — 14 unit tests
- Unrelated changes: none

### Verdict

- Merge-ready: **yes**
- Remaining blockers: none

Refs #1611

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
