### PR TITLE
feat(meeting): include applied template agendas in handoff report (#1615)

### DIFF
--- a/src/meeting_backend/closing.rs
+++ b/src/meeting_backend/closing.rs
@@ -129,6 +129,7 @@ impl MeetingBackend {
             &self.history,
             &action_items,
             &structured_decisions,
+            &self.applied_templates,
         ) {
             Ok(p) => Some(p.to_string_lossy().to_string()),
             Err(e) => {
@@ -175,6 +176,7 @@ impl MeetingBackend {
             open_questions,
             themes,
             participants,
+            applied_templates: self.applied_templates.clone(),
         })
     }
 }

--- a/src/meeting_backend/mod.rs
+++ b/src/meeting_backend/mod.rs
@@ -31,8 +31,8 @@ use crate::error::SimardResult;
 
 pub use command::{MeetingCommand, parse_command};
 pub use types::{
-    ConversationMessage, HandoffActionItem, MeetingResponse, MeetingSummary, MeetingTranscript,
-    Role, SessionStatus,
+    AppliedTemplate, ConversationMessage, HandoffActionItem, MeetingResponse, MeetingSummary,
+    MeetingTranscript, Role, SessionStatus,
 };
 
 /// Maximum messages kept in conversation history.
@@ -58,6 +58,9 @@ pub struct MeetingBackend {
     is_open: bool,
     /// Explicit themes recorded via the `/theme` command.
     themes: Vec<String>,
+    /// Templates applied via the `/template <name>` command. Surfaced in the
+    /// handoff markdown report as the `## Agenda` section.
+    applied_templates: Vec<AppliedTemplate>,
 }
 
 impl MeetingBackend {
@@ -87,6 +90,7 @@ impl MeetingBackend {
             started_at,
             is_open: true,
             themes: Vec::new(),
+            applied_templates: Vec::new(),
         }
     }
 
@@ -132,6 +136,31 @@ impl MeetingBackend {
     /// Read the explicit themes recorded so far.
     pub fn explicit_themes(&self) -> &[String] {
         &self.themes
+    }
+
+    /// Record that the operator applied a meeting template (e.g. `/template
+    /// standup`). Dedupes by template name (case-insensitive) so re-applying
+    /// the same template is a no-op. The first application wins so the
+    /// `applied_at` timestamp reflects when the agenda was first introduced.
+    pub fn apply_template(&mut self, name: &str, agenda: &str) {
+        let lower = name.to_lowercase();
+        if self
+            .applied_templates
+            .iter()
+            .any(|t| t.name.to_lowercase() == lower)
+        {
+            return;
+        }
+        self.applied_templates.push(AppliedTemplate {
+            name: name.to_string(),
+            agenda: agenda.to_string(),
+            applied_at: Utc::now().to_rfc3339(),
+        });
+    }
+
+    /// Read the templates applied during this meeting.
+    pub fn applied_templates(&self) -> &[AppliedTemplate] {
+        &self.applied_templates
     }
 
     // --- Private helpers ---

--- a/src/meeting_backend/persist/markdown.rs
+++ b/src/meeting_backend/persist/markdown.rs
@@ -9,7 +9,7 @@ use crate::meeting_facilitator::MeetingDecision;
 
 use super::extract::{extract_open_questions, extract_themes};
 use super::{meetings_dir, sanitize_filename};
-use crate::meeting_backend::types::{ConversationMessage, HandoffActionItem};
+use crate::meeting_backend::types::{AppliedTemplate, ConversationMessage, HandoffActionItem};
 
 pub fn write_markdown_export(
     topic: &str,
@@ -94,6 +94,7 @@ pub fn write_handoff_markdown_report(
     messages: &[ConversationMessage],
     action_items: &[HandoffActionItem],
     decisions: &[MeetingDecision],
+    applied_templates: &[AppliedTemplate],
 ) -> SimardResult<PathBuf> {
     let dir = meetings_dir();
     std::fs::create_dir_all(&dir).map_err(|e| SimardError::ActionExecutionFailed {
@@ -149,6 +150,22 @@ pub fn write_handoff_markdown_report(
     md.push_str("## Summary\n\n");
     md.push_str(summary);
     md.push_str("\n\n");
+
+    // Agenda from any templates applied during the meeting. Renders the
+    // template name plus its full agenda body so reviewers can see the
+    // intended structure of the discussion. Skipped entirely if no
+    // template was applied (avoid an empty section).
+    if !applied_templates.is_empty() {
+        md.push_str("## Agenda\n\n");
+        for tmpl in applied_templates {
+            md.push_str(&format!(
+                "### Template: `{}` (applied {})\n\n",
+                tmpl.name, tmpl.applied_at
+            ));
+            md.push_str(tmpl.agenda.trim_end());
+            md.push_str("\n\n");
+        }
+    }
 
     md.push_str("## Decisions\n\n");
     if decisions.is_empty() {

--- a/src/meeting_backend/tests_mod.rs
+++ b/src/meeting_backend/tests_mod.rs
@@ -311,3 +311,73 @@ fn auto_save_does_not_panic() {
     backend.send_message("Test message").unwrap();
     assert_eq!(backend.status().message_count, 2);
 }
+
+#[test]
+fn apply_template_records_agenda() {
+    let agent = MockAgent::new("noted");
+    let mut backend = MeetingBackend::new_session("Test", Box::new(agent), None, String::new());
+
+    assert!(backend.applied_templates().is_empty());
+    backend.apply_template("retro", "## Retro\n1. Wins\n2. Losses\n");
+
+    let templates = backend.applied_templates();
+    assert_eq!(templates.len(), 1);
+    assert_eq!(templates[0].name, "retro");
+    assert!(templates[0].agenda.contains("Wins"));
+    assert!(
+        !templates[0].applied_at.is_empty(),
+        "applied_at should be set"
+    );
+}
+
+#[test]
+fn apply_template_dedupes_by_name_case_insensitive() {
+    let agent = MockAgent::new("noted");
+    let mut backend = MeetingBackend::new_session("Test", Box::new(agent), None, String::new());
+
+    backend.apply_template("standup", "## Standup A");
+    backend.apply_template("STANDUP", "## Standup B");
+    backend.apply_template("Standup", "## Standup C");
+
+    let templates = backend.applied_templates();
+    assert_eq!(templates.len(), 1, "duplicate template names should dedupe");
+    assert_eq!(templates[0].name, "standup", "first applied wins");
+    assert!(
+        templates[0].agenda.contains("Standup A"),
+        "first agenda preserved"
+    );
+}
+
+#[test]
+fn apply_template_records_distinct_templates() {
+    let agent = MockAgent::new("noted");
+    let mut backend = MeetingBackend::new_session("Test", Box::new(agent), None, String::new());
+
+    backend.apply_template("standup", "agenda 1");
+    backend.apply_template("retro", "agenda 2");
+
+    let templates = backend.applied_templates();
+    assert_eq!(templates.len(), 2);
+    assert_eq!(templates[0].name, "standup");
+    assert_eq!(templates[1].name, "retro");
+}
+
+#[test]
+fn close_summary_includes_applied_templates() {
+    let agent = MockAgent::new("Summary text.");
+    let mut backend = MeetingBackend::new_session("Sprint", Box::new(agent), None, String::new());
+    backend.apply_template(
+        "standup",
+        "## Standup\n1. Yesterday\n2. Today\n3. Blockers\n",
+    );
+    backend.send_message("hello").unwrap();
+
+    let summary = backend.close().unwrap();
+    assert_eq!(
+        summary.applied_templates.len(),
+        1,
+        "summary should carry applied templates"
+    );
+    assert_eq!(summary.applied_templates[0].name, "standup");
+    assert!(summary.applied_templates[0].agenda.contains("Blockers"));
+}

--- a/src/meeting_backend/tests_persist.rs
+++ b/src/meeting_backend/tests_persist.rs
@@ -239,4 +239,95 @@ fn extract_decisions_none_found() {
     assert!(decisions.is_empty());
 }
 
+// ── Handoff markdown report — agenda section (issue #1615) ──────
+
+#[test]
+fn handoff_report_omits_agenda_section_when_no_template_applied() {
+    use std::fs;
+
+    let topic = format!(
+        "test_no_agenda_{}",
+        chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0)
+    );
+    let path = write_handoff_markdown_report(
+        &topic,
+        "2025-01-01T00:00:00Z",
+        "Summary",
+        &[],
+        &[],
+        &[],
+        &[],
+    )
+    .expect("write report");
+    let body = fs::read_to_string(&path).expect("read report");
+    let _ = fs::remove_file(&path);
+    assert!(
+        !body.contains("## Agenda"),
+        "agenda section should be omitted when no template applied: {body}"
+    );
+}
+
+#[test]
+fn handoff_report_includes_agenda_section_when_template_applied() {
+    use std::fs;
+
+    let topic = format!(
+        "test_with_agenda_{}",
+        chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0)
+    );
+    let templates = vec![
+        AppliedTemplate {
+            name: "standup".to_string(),
+            agenda: "## Daily Standup\n\n1. **What did you accomplish?**\n2. **Blockers?**"
+                .to_string(),
+            applied_at: "2025-01-01T00:05:00Z".to_string(),
+        },
+        AppliedTemplate {
+            name: "retro".to_string(),
+            agenda: "## Retro\n\n1. Wins\n2. Losses".to_string(),
+            applied_at: "2025-01-01T00:30:00Z".to_string(),
+        },
+    ];
+    let path = write_handoff_markdown_report(
+        &topic,
+        "2025-01-01T00:00:00Z",
+        "Summary",
+        &[],
+        &[],
+        &[],
+        &templates,
+    )
+    .expect("write report");
+    let body = fs::read_to_string(&path).expect("read report");
+    let _ = fs::remove_file(&path);
+
+    assert!(body.contains("## Agenda"), "missing Agenda section: {body}");
+    assert!(
+        body.contains("Template: `standup`"),
+        "missing standup template header: {body}"
+    );
+    assert!(
+        body.contains("Template: `retro`"),
+        "missing retro template header: {body}"
+    );
+    assert!(
+        body.contains("Daily Standup"),
+        "missing standup agenda body: {body}"
+    );
+    assert!(body.contains("Wins"), "missing retro agenda body: {body}");
+    assert!(
+        body.contains("2025-01-01T00:05:00Z"),
+        "missing applied_at timestamp: {body}"
+    );
+
+    // Agenda must precede Decisions/Action Items so reviewers see the
+    // intended structure before the outcomes.
+    let agenda_pos = body.find("## Agenda").unwrap();
+    let decisions_pos = body.find("## Decisions").unwrap();
+    assert!(
+        agenda_pos < decisions_pos,
+        "agenda should appear before decisions: agenda@{agenda_pos} decisions@{decisions_pos}"
+    );
+}
+
 // ── Open question extraction tests ──────────────────────────────

--- a/src/meeting_backend/types.rs
+++ b/src/meeting_backend/types.rs
@@ -26,6 +26,22 @@ pub struct MeetingResponse {
     pub message_count: usize,
 }
 
+/// A meeting template the operator applied during the session.
+///
+/// Recorded so the handoff report can render the agenda items the meeting
+/// was structured around. Tracked even if the operator skipped sections —
+/// the agenda is the *intended* discussion shape, not a guarantee of
+/// coverage.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct AppliedTemplate {
+    /// Template name (e.g. "standup", "retro").
+    pub name: String,
+    /// Full agenda markdown as shown to the operator.
+    pub agenda: String,
+    /// RFC3339 timestamp of when the template was applied.
+    pub applied_at: String,
+}
+
 /// A structured action item extracted from meeting transcript on close.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct HandoffActionItem {
@@ -67,6 +83,10 @@ pub struct MeetingSummary {
     /// Participants identified from the conversation.
     #[serde(default)]
     pub participants: Vec<String>,
+    /// Templates the operator applied via `/template <name>`. Drives the
+    /// `## Agenda` section in the handoff markdown report.
+    #[serde(default)]
+    pub applied_templates: Vec<AppliedTemplate>,
 }
 
 /// Current status of a meeting session.
@@ -145,6 +165,11 @@ mod tests {
             open_questions: vec!["Who will lead the effort?".to_string()],
             themes: vec!["testing".to_string(), "quality".to_string()],
             participants: vec!["operator".to_string(), "simard".to_string()],
+            applied_templates: vec![AppliedTemplate {
+                name: "retro".to_string(),
+                agenda: "## Retrospective\n1. ...".to_string(),
+                applied_at: "2025-01-01T00:10:00Z".to_string(),
+            }],
         };
         let json = serde_json::to_string(&summary).unwrap();
         let s2: MeetingSummary = serde_json::from_str(&json).unwrap();
@@ -168,6 +193,7 @@ mod tests {
         assert!(s.open_questions.is_empty());
         assert!(s.themes.is_empty());
         assert!(s.participants.is_empty());
+        assert!(s.applied_templates.is_empty());
     }
 
     #[test]

--- a/src/meeting_repl/repl.rs
+++ b/src/meeting_repl/repl.rs
@@ -135,6 +135,9 @@ pub fn run_meeting_repl<R: BufRead, W: Write>(
                     writeln!(output, "\nUsage: /template <name>").ok();
                 } else if let Some(tmpl) = find_template(&name) {
                     writeln!(output, "\n{}\n", tmpl.agenda).ok();
+                    // Record the agenda on the session so /close can include
+                    // an `## Agenda` section in the handoff markdown report.
+                    backend.apply_template(tmpl.name, tmpl.agenda);
                     // Inject template as context via a message to the backend
                     let ctx = format!(
                         "The operator has selected the '{}' meeting template. \


### PR DESCRIPTION
## Summary

Implements one bounded UX/handoff improvement from #1615: the auto-generated end-of-meeting markdown handoff report now includes a structured **`## Agenda`** section listing every meeting template the operator applied during the session.

## Gap analysis (top 3 UX gaps in the current meeting facilitator)

1. **Agenda items vanish after `/template`.** The REPL shows the template's agenda and feeds it to the LLM, but never records the agenda on the session — so reviewers reading the closed-meeting markdown report had no anchor for what was *meant* to be discussed (`src/meeting_repl/repl.rs` template branch, `src/meeting_backend/persist/markdown.rs`).
2. **No `## Agenda` section in the markdown handoff report.** The auto-exported `*_report.md` had Decisions, Action Items, Open Questions, Themes, Transcript — but no agenda, despite the spec listing 'meeting artifacts that future engineer sessions can use' (`Specs/ProductArchitecture.md:631`).
3. **Action items table lacks an owner-grouped rollup.** Owners only appear inline per row (deferred — separate PR).

## Bounded change in this PR

- New `AppliedTemplate { name, agenda, applied_at }` type (`meeting_backend/types.rs`).
- `MeetingBackend::apply_template(name, agenda)` records applied templates; dedupes by name (case-insensitive); first application wins.
- `MeetingBackend::applied_templates()` getter.
- REPL `/template <name>` now calls `apply_template` so the agenda persists on the session (`src/meeting_repl/repl.rs`).
- `MeetingSummary` carries `applied_templates` (`#[serde(default)]` for backward-compat).
- `write_handoff_markdown_report` renders an `## Agenda` section listing each template's name, applied_at timestamp, and full agenda body. Section is **omitted entirely** when no template was applied. Positioned **before** `## Decisions` so reviewers see the intended structure first.

## Out of scope (future PRs against #1615)

- Owner-grouped action items in the table.
- Auto-fanning open questions into GitHub issues.
- `/agenda` command for free-form operator-typed agenda items (vs. template-driven).

---

## Merge readiness

### QA-team evidence

- Scenario files: n/a — Simard has no `gadugi-test` scenario harness; this change is exercised by 6 new unit tests in `src/meeting_backend/tests_mod.rs` and `src/meeting_backend/tests_persist.rs`
- Validation command: `cargo test --release --lib -- meeting`
- Validation result: **passed** (345 tests pass, 0 failures, 5 new tests for agenda tracking + 1 reuse via `close_summary_includes_applied_templates`)
- Run command: pre-push hook on rebased branch (`cargo fmt --check`, `cargo test --release --lib (cognitive_memory|bootstrap|memory_ipc|memory_consolidation)`, `cargo clippy --all-targets --all-features --locked -- -D warnings`)
- Run target: local pre-push fence + CI `verify/pre-commit (push)` + `verify/pre-commit (pull_request)`
- Run result: **passed** (all 7 CI checks green on commit `5a7d2ebc`)
- Evidence location: pre-push hook output captured at push step:
  ```
  cargo fmt --all -- --check                                                                            ✓ Passed
  cargo test --release --lib (cognitive_memory|bootstrap|memory_ipc|memory_consolidation)               ✓ Passed
  cargo clippy --all-targets --all-features --locked -- -D warnings (pre-push)                          ✓ Passed
  ```
  Plus 7 fresh CI checks all SUCCESS on commit `5a7d2ebc` after rebase on `main@0f5f078d`.

### Documentation

- User-facing docs impact: **no** — change is internal to the meeting backend and REPL; the new `## Agenda` section is rendered into the auto-generated markdown handoff report which is itself an operator artifact, not API/CLI/config
- Updated docs: none required (handoff report is the documentation-as-output for meeting flows; `Specs/ProductArchitecture.md:631` already lists 'meeting artifacts' as a goal — this PR fulfills that goal without changing the spec)
- PR description links added: n/a
- Rationale if not applicable: changed surfaces are `meeting_backend/{closing,mod,persist/markdown,tests_mod,tests_persist,types}.rs` and `meeting_repl/repl.rs` — internal module wiring + tests + a new fields on existing types; backward-compat preserved via `#[serde(default)]` on `applied_templates`

### Quality-audit

- Cycle 1 summary: initial implementation — added `AppliedTemplate` type, `apply_template` method, REPL hook, markdown rendering, 6 unit tests. Validation: `cargo build --lib` ✓; `cargo test --lib -- meeting` ✓ (345/345)
- Cycle 2 summary: rebased onto `origin/main@0f5f078d` (which now includes the pre-commit hook installer from PR #1695 and the `agent_kind_from_env` serial-test flake fix). No conflicts. Pre-push hook ran cargo fmt + targeted tests + cargo clippy --all-targets --all-features --locked — all green
- Cycle 3 summary: CI verification — all 7 checks SUCCESS after force-push on `5a7d2ebc` (verify/pre-commit, verify/install-real, verify/e2e-dashboard on both push + pull_request events; GitGuardian)
- Additional cycles: none required
- Final clean cycle: **Cycle 3** (zero clippy warnings, zero fmt deltas, zero test failures, all CI green)
- Fixes followed default-workflow: yes — implement → test → rebase → push → re-validate
- Convergence summary: 7-file diff, +241/-3 lines, all unit tests pass, all CI green; backward-compat preserved on serialized types

### CI

- Checks command: `gh pr checks 1641 --repo rysweet/Simard`
- Result: **all green** — 7 checks SUCCESS, 0 failing, 0 pending, 0 skipped
- Skipped checks: none
- Flaky reruns performed: none needed — fresh CI on rebased commit `5a7d2ebc` passed cleanly first time
- Real failures fixed: none on this branch (the rebase pulled in the upstream `agent_kind_from_env` serial-test flake fix, which would otherwise have been a CI flake risk)

### PR description evidence

- This PR description follows the merge-ready template at `~/.copilot/skills/merge-ready/pr-description-template.md`
- All six required evidence headings present (QA-team evidence, Documentation, Quality-audit, CI, PR description evidence, Scope)
- Verdict section below

### Scope

- Changed files reviewed: 7 files, +241/-3 lines total
  - `src/meeting_backend/types.rs` — new `AppliedTemplate` struct + `MeetingSummary.applied_templates` field with `#[serde(default)]`
  - `src/meeting_backend/mod.rs` — `apply_template()` + `applied_templates()` methods
  - `src/meeting_backend/closing.rs` — propagate `applied_templates` into `MeetingSummary`
  - `src/meeting_backend/persist/markdown.rs` — `## Agenda` section renderer (omitted when empty, positioned before `## Decisions`)
  - `src/meeting_backend/tests_mod.rs` — 3 new unit tests on `apply_template` + `close_summary_includes_applied_templates`
  - `src/meeting_backend/tests_persist.rs` — 2 new markdown rendering tests
  - `src/meeting_repl/repl.rs` — wire `/template <name>` to call `apply_template`
- Unrelated changes: none

### Verdict

- Merge-ready: **yes**
- Remaining blockers: none

Refs #1615

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
