### PR TITLE
feat(engineer-loop): prose fallback for goal actions + configurable agent kind

### DIFF
--- a/docs/reference/spawn-agent-for-goal.md
+++ b/docs/reference/spawn-agent-for-goal.md
@@ -121,6 +121,23 @@ The amplihack binary path is resolved from `PATH` by default; override
 via the `SIMARD_AMPLIHACK_BIN` environment variable for tests or
 non-standard installs.
 
+### Choosing the agent kind
+
+The subprocess defaults to `amplihack RustyClawd --auto`, but the agent
+kind is configurable via the `SIMARD_ENGINEER_AGENT` environment
+variable. Recognised values (case-insensitive):
+
+| Value         | Subcommand invoked            | Argv shape (after the binary)                                                     |
+|---------------|-------------------------------|-----------------------------------------------------------------------------------|
+| `rustyclawd`  | `amplihack RustyClawd`        | `RustyClawd --auto --subprocess-safe --no-reflection --max-turns 30 -- -p <prompt>` |
+| `copilot`     | `amplihack copilot`           | `copilot --allow-all-paths -p <prompt>`                                           |
+
+Unknown values fall back to `rustyclawd` with a stderr warning so a typo
+does not silently change the engineer behaviour. Adding more agent kinds
+is a matter of extending `AgentKind` in
+`src/engineer_loop/agent_spawn.rs` and providing the per-kind argv in
+`engineer_argv()`.
+
 ---
 
 ## Example usage

--- a/prompt_assets/simard/goal_session_objective.md
+++ b/prompt_assets/simard/goal_session_objective.md
@@ -9,9 +9,17 @@ literally into your response. A response whose `task`, `reason`, or
 `assessment` field equals `<one-paragraph concrete task>` (or any
 similar `<placeholder>`) is a bug and will be rejected.
 
-You MUST respond with a single JSON object and nothing else (no prose, no
-code fences, no markdown). The object must match exactly one of the seven
-schemas below.
+You SHOULD respond with a single JSON object matching one of the seven
+schemas below. JSON lets Simard run direct GitHub operations (create
+issue, comment, close) without spinning a subordinate engineer subprocess.
+
+If you cannot produce structured JSON for any reason — for example you
+need to describe a complex task that does not fit the spawn_engineer
+schema, or you are uncertain which action applies — write a single
+paragraph of plain English describing what the engineer should do next.
+Simard will treat the entire response as a `spawn_engineer` task and
+hand it directly to the autonomous coding subprocess. Prose responses
+ARE valid; the engineer is itself an LLM and reads natural language.
 
 # Issue-first workflow
 

--- a/src/engineer_loop/agent_spawn.rs
+++ b/src/engineer_loop/agent_spawn.rs
@@ -45,6 +45,53 @@ pub(crate) fn amplihack_binary() -> String {
     std::env::var("SIMARD_AMPLIHACK_BIN").unwrap_or_else(|_| "amplihack".to_string())
 }
 
+/// Which amplihack agent subcommand to use for engineering work.
+///
+/// The pivot in PR #1652 hardcoded `RustyClawd` as the engineer subprocess.
+/// In practice multiple amplihack autonomous agents are valid choices
+/// (e.g. `amplihack copilot -p <prompt>`), and operators need to be able
+/// to swap kinds without recompiling Simard.
+///
+/// Configure via the `SIMARD_ENGINEER_AGENT` env var. Recognised values
+/// (case-insensitive): `rustyclawd` (default), `copilot`. Unknown values
+/// fall back to the default with a stderr warning so operator typos do
+/// not silently change behaviour.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AgentKind {
+    RustyClawd,
+    Copilot,
+}
+
+impl AgentKind {
+    /// Subcommand name as accepted by `amplihack <subcommand>`.
+    pub(crate) fn subcommand(self) -> &'static str {
+        match self {
+            AgentKind::RustyClawd => "RustyClawd",
+            AgentKind::Copilot => "copilot",
+        }
+    }
+
+    /// Resolve the configured agent kind from the `SIMARD_ENGINEER_AGENT`
+    /// environment variable. Unknown values warn to stderr and fall back
+    /// to the default (`RustyClawd`).
+    pub(crate) fn from_env() -> AgentKind {
+        match std::env::var("SIMARD_ENGINEER_AGENT") {
+            Err(_) => AgentKind::RustyClawd,
+            Ok(raw) => match raw.trim().to_ascii_lowercase().as_str() {
+                "" | "rustyclawd" | "rusty-clawd" | "rusty_clawd" => AgentKind::RustyClawd,
+                "copilot" => AgentKind::Copilot,
+                other => {
+                    eprintln!(
+                        "[simard] SIMARD_ENGINEER_AGENT={other:?} not recognised; \
+                         falling back to RustyClawd. Valid: rustyclawd, copilot."
+                    );
+                    AgentKind::RustyClawd
+                }
+            },
+        }
+    }
+}
+
 pub(crate) fn build_agent_prompt(objective: &str, inspection: &RepoInspection) -> String {
     let files = if inspection.changed_files.is_empty() {
         "none".to_string()
@@ -90,19 +137,40 @@ pub(crate) fn build_agent_prompt(objective: &str, inspection: &RepoInspection) -
     prompt
 }
 
-/// Build the argv passed to `amplihack RustyClawd --auto`. Exposed for tests.
+/// Build the argv passed to `amplihack <subcommand>` for the chosen
+/// [`AgentKind`]. Each kind has its own prompt-passing convention.
+///
+/// * `RustyClawd` uses `--auto -- -p <prompt>` (the `--` separator is
+///   required so the inner `-p` reaches the autonomous loop).
+/// * `copilot` accepts `-p <prompt>` directly with `--allow-all-paths`
+///   so it can read/write across the workspace.
+pub(crate) fn engineer_argv(kind: AgentKind, prompt: &str, max_turns: u32) -> Vec<String> {
+    match kind {
+        AgentKind::RustyClawd => vec![
+            kind.subcommand().to_string(),
+            "--auto".to_string(),
+            "--subprocess-safe".to_string(),
+            "--no-reflection".to_string(),
+            "--max-turns".to_string(),
+            max_turns.to_string(),
+            "--".to_string(),
+            "-p".to_string(),
+            prompt.to_string(),
+        ],
+        AgentKind::Copilot => vec![
+            kind.subcommand().to_string(),
+            "--allow-all-paths".to_string(),
+            "-p".to_string(),
+            prompt.to_string(),
+        ],
+    }
+}
+
+/// Backwards-compatible wrapper kept so existing callers (and tests pinned
+/// to the RustyClawd argv shape) keep working unchanged.
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn rustyclawd_argv(prompt: &str, max_turns: u32) -> Vec<String> {
-    vec![
-        "RustyClawd".to_string(),
-        "--auto".to_string(),
-        "--subprocess-safe".to_string(),
-        "--no-reflection".to_string(),
-        "--max-turns".to_string(),
-        max_turns.to_string(),
-        "--".to_string(),
-        "-p".to_string(),
-        prompt.to_string(),
-    ]
+    engineer_argv(AgentKind::RustyClawd, prompt, max_turns)
 }
 
 fn keep_summary_tail(buf: &[u8]) -> String {
@@ -119,11 +187,16 @@ fn keep_summary_tail(buf: &[u8]) -> String {
     s
 }
 
-/// Run the `amplihack RustyClawd` subprocess and return its trailing output.
-pub(crate) fn run_rustyclawd_subprocess(prompt: &str, workspace: &Path) -> SimardResult<String> {
+/// Run the `amplihack <agent>` subprocess and return its trailing output.
+/// `kind` selects which agent subcommand to invoke; see [`AgentKind`].
+pub(crate) fn run_engineer_subprocess(
+    prompt: &str,
+    workspace: &Path,
+    kind: AgentKind,
+) -> SimardResult<String> {
     let bin = amplihack_binary();
-    let argv = rustyclawd_argv(prompt, DEFAULT_MAX_TURNS);
-    let action_label = format!("{bin} RustyClawd --auto");
+    let argv = engineer_argv(kind, prompt, DEFAULT_MAX_TURNS);
+    let action_label = format!("{bin} {}", kind.subcommand());
 
     let mut child = Command::new(&bin)
         .args(&argv)
@@ -175,7 +248,8 @@ pub(crate) fn run_rustyclawd_subprocess(prompt: &str, workspace: &Path) -> Simar
         return Err(SimardError::ActionExecutionFailed {
             action: action_label,
             reason: format!(
-                "RustyClawd exited with status {}; stderr_tail=\n{}",
+                "{} exited with status {}; stderr_tail=\n{}",
+                kind.subcommand(),
                 output.status,
                 stderr_tail.trim()
             ),
@@ -190,16 +264,27 @@ pub(crate) fn run_rustyclawd_subprocess(prompt: &str, workspace: &Path) -> Simar
     Ok(summary)
 }
 
+/// Backwards-compatible wrapper that always uses [`AgentKind::RustyClawd`].
+///
+/// Older test code and any callers that pre-date the configurable agent
+/// kind keep using this entrypoint unchanged. Production code paths read
+/// the kind from the environment via [`AgentKind::from_env`].
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) fn run_rustyclawd_subprocess(prompt: &str, workspace: &Path) -> SimardResult<String> {
+    run_engineer_subprocess(prompt, workspace, AgentKind::RustyClawd)
+}
+
 /// Start an agent session in a background thread and return the channel
-/// receiver. The thread spawns `amplihack RustyClawd --auto` as a subprocess
-/// and reports its summary back to the caller.
+/// receiver. The thread spawns the configured `amplihack <agent>` subprocess
+/// (via [`AgentKind::from_env`]) and reports its summary back to the caller.
 pub(crate) fn start_agent_session(
     prompt: String,
     workspace: PathBuf,
 ) -> mpsc::Receiver<SimardResult<String>> {
     let (tx, rx) = mpsc::channel();
+    let kind = AgentKind::from_env();
     thread::spawn(move || {
-        let result = run_rustyclawd_subprocess(&prompt, &workspace);
+        let result = run_engineer_subprocess(&prompt, &workspace, kind);
         let _ = tx.send(result);
     });
     rx
@@ -363,5 +448,84 @@ mod tests {
             err.contains("failed to spawn") || err.contains("RustyClawd"),
             "unexpected error message: {err}"
         );
+    }
+
+    #[test]
+    fn agent_kind_subcommand_strings_are_stable() {
+        assert_eq!(AgentKind::RustyClawd.subcommand(), "RustyClawd");
+        assert_eq!(AgentKind::Copilot.subcommand(), "copilot");
+    }
+
+    #[test]
+    fn agent_kind_from_env_defaults_to_rustyclawd() {
+        let original = std::env::var("SIMARD_ENGINEER_AGENT").ok();
+        unsafe {
+            std::env::remove_var("SIMARD_ENGINEER_AGENT");
+        }
+        assert_eq!(AgentKind::from_env(), AgentKind::RustyClawd);
+        unsafe {
+            if let Some(v) = original {
+                std::env::set_var("SIMARD_ENGINEER_AGENT", v);
+            }
+        }
+    }
+
+    #[test]
+    fn agent_kind_from_env_recognises_copilot_case_insensitive() {
+        let original = std::env::var("SIMARD_ENGINEER_AGENT").ok();
+        for raw in ["copilot", "Copilot", "COPILOT", "  copilot  "] {
+            unsafe {
+                std::env::set_var("SIMARD_ENGINEER_AGENT", raw);
+            }
+            assert_eq!(AgentKind::from_env(), AgentKind::Copilot, "raw={raw:?}");
+        }
+        unsafe {
+            match original {
+                Some(v) => std::env::set_var("SIMARD_ENGINEER_AGENT", v),
+                None => std::env::remove_var("SIMARD_ENGINEER_AGENT"),
+            }
+        }
+    }
+
+    #[test]
+    fn agent_kind_from_env_unknown_falls_back_to_default() {
+        let original = std::env::var("SIMARD_ENGINEER_AGENT").ok();
+        unsafe {
+            std::env::set_var("SIMARD_ENGINEER_AGENT", "totally-not-a-real-agent");
+        }
+        // Falls back rather than panicking; warning is emitted to stderr.
+        assert_eq!(AgentKind::from_env(), AgentKind::RustyClawd);
+        unsafe {
+            match original {
+                Some(v) => std::env::set_var("SIMARD_ENGINEER_AGENT", v),
+                None => std::env::remove_var("SIMARD_ENGINEER_AGENT"),
+            }
+        }
+    }
+
+    #[test]
+    fn engineer_argv_copilot_uses_p_without_dash_separator() {
+        let argv = engineer_argv(AgentKind::Copilot, "hello world", 7);
+        assert_eq!(argv[0], "copilot");
+        assert!(argv.iter().any(|a| a == "--allow-all-paths"));
+        assert!(argv.iter().any(|a| a == "-p"));
+        assert!(argv.iter().any(|a| a == "hello world"));
+        // copilot does not use the `--` separator that RustyClawd needs.
+        assert!(
+            !argv.iter().any(|a| a == "--"),
+            "copilot argv should not include `--` separator: {argv:?}"
+        );
+        // copilot is not driven by --auto / --max-turns; ensure those
+        // RustyClawd-specific flags are absent so behaviour matches the
+        // amplihack copilot subcommand surface.
+        assert!(!argv.iter().any(|a| a == "--auto"));
+        assert!(!argv.iter().any(|a| a == "--max-turns"));
+    }
+
+    #[test]
+    fn engineer_argv_rustyclawd_matches_legacy_wrapper() {
+        let new = engineer_argv(AgentKind::RustyClawd, "x", 30);
+        let legacy = rustyclawd_argv("x", 30);
+        assert_eq!(new, legacy);
     }
 }

--- a/src/ooda_actions/goal_session/advance.rs
+++ b/src/ooda_actions/goal_session/advance.rs
@@ -311,23 +311,53 @@ pub(crate) fn advance_goal_with_session(
                     }
                 }
                 None => {
-                    // FAIL LOUD per PHILOSOPHY.md: when the LLM returns prose
-                    // instead of the required JSON object, this is a planning
-                    // failure. We do NOT fall back to PROGRESS-line scraping —
-                    // that masked broken planning for months. Surface the
-                    // failure so the cooldown machinery can demote this goal.
-                    let raw = truncate_for_outcome(&outcome.execution_summary);
-                    eprintln!(
-                        "[simard] OODA goal-action PARSE FAILED for '{}': LLM returned non-JSON response: {}",
-                        goal.id, raw,
-                    );
-                    let detail = format!(
-                        "goal-action parse failed for goal '{}': LLM did not emit a recognised JSON action (one of spawn_engineer / noop / assess_only / gh_issue_create / gh_issue_comment / gh_issue_close / gh_pr_comment). Raw response head: {}",
-                        goal.id, raw,
-                    );
-                    GoalSessionResult {
-                        outcome: make_outcome(action, false, detail),
-                        action: None,
+                    // The LLM did not emit a recognised JSON action — but it
+                    // may still have emitted prose describing what to do.
+                    // The engineer is itself an LLM that reads natural
+                    // language, so we fall back to spawning an engineer
+                    // with the response as its task description rather than
+                    // discarding the cycle's planning work.
+                    //
+                    // Structured JSON actions (noop / assess_only / spawn /
+                    // gh_*) remain the preferred contract — they let Simard
+                    // perform GH ops directly without spinning a subprocess.
+                    // But "no JSON parsed" no longer kills the cycle.
+                    match prose_fallback_action(&outcome.execution_summary) {
+                        Some(prose_action) => {
+                            let task = match &prose_action {
+                                GoalAction::SpawnEngineer { task, .. } => task.as_str(),
+                                _ => "",
+                            };
+                            let truncated = truncate_for_outcome(task);
+                            eprintln!(
+                                "[simard] OODA goal-action prose fallback for '{}': spawning engineer with raw response as task: {}",
+                                goal.id, truncated,
+                            );
+                            let detail = format!(
+                                "prose-fallback spawn_engineer for goal '{}': {}",
+                                goal.id, truncated,
+                            );
+                            GoalSessionResult {
+                                outcome: make_outcome(action, true, detail),
+                                action: Some(prose_action),
+                            }
+                        }
+                        None => {
+                            // Truly empty response — nothing for the engineer
+                            // to act on, so this is a real failure.
+                            eprintln!(
+                                "[simard] OODA goal-action EMPTY response for '{}': LLM returned no content",
+                                goal.id,
+                            );
+                            let detail = format!(
+                                "goal-action empty response for goal '{}': LLM returned no content",
+                                goal.id,
+                            );
+                            GoalSessionResult {
+                                outcome: make_outcome(action, false, detail),
+                                action: None,
+                            }
+                        }
                     }
                 }
             }
@@ -340,5 +370,78 @@ pub(crate) fn advance_goal_with_session(
             ),
             action: None,
         },
+    }
+}
+
+/// Build the prose-fallback `GoalAction` from a raw LLM response.
+///
+/// When the orchestrator LLM emits free-form prose instead of a JSON
+/// action, treat the trimmed response as the task description for a
+/// subordinate engineer subprocess. This is the user-facing answer to
+/// "why does it have to be JSON?" — it doesn't, the engineer reads
+/// natural language too.
+///
+/// Returns `None` only when the response trims to the empty string;
+/// every non-empty response yields a `SpawnEngineer` action.
+pub(super) fn prose_fallback_action(response: &str) -> Option<GoalAction> {
+    let trimmed = response.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(GoalAction::SpawnEngineer {
+        task: trimmed.to_string(),
+        files: Vec::new(),
+        issue: None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prose_fallback_action_returns_spawn_engineer_for_pure_prose() {
+        let response = "Run `cargo test --lib prioritization` and report which tests fail.";
+        let action = prose_fallback_action(response).expect("non-empty prose yields action");
+        match action {
+            GoalAction::SpawnEngineer { task, files, issue } => {
+                assert_eq!(task, response);
+                assert!(files.is_empty(), "files defaults to empty");
+                assert!(issue.is_none(), "issue defaults to None");
+            }
+            other => panic!("expected SpawnEngineer, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn prose_fallback_action_trims_surrounding_whitespace() {
+        let action =
+            prose_fallback_action("\n\n   fix the meeting REPL  \n\n").expect("yields action");
+        match action {
+            GoalAction::SpawnEngineer { task, .. } => {
+                assert_eq!(task, "fix the meeting REPL");
+            }
+            other => panic!("expected SpawnEngineer, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn prose_fallback_action_returns_none_for_empty_or_whitespace() {
+        assert!(prose_fallback_action("").is_none());
+        assert!(prose_fallback_action("   ").is_none());
+        assert!(prose_fallback_action("\n\t  \r\n").is_none());
+    }
+
+    #[test]
+    fn prose_fallback_action_preserves_multiline_task_descriptions() {
+        let response = "First, check the current state with `git status`.\n\nThen, if dirty, stash and proceed to fix issue #1234.";
+        let action = prose_fallback_action(response).expect("yields action");
+        match action {
+            GoalAction::SpawnEngineer { task, .. } => {
+                assert!(task.contains("git status"));
+                assert!(task.contains("issue #1234"));
+            }
+            other => panic!("expected SpawnEngineer, got {other:?}"),
+        }
     }
 }

--- a/src/ooda_actions/tests_goal_session.rs
+++ b/src/ooda_actions/tests_goal_session.rs
@@ -104,9 +104,12 @@ fn session_progress_comes_from_agent_response_not_auto_bump() {
 }
 
 #[test]
-fn session_no_progress_marker_preserves_current() {
-    // Agent returns prose instead of valid JSON — action MUST fail loudly,
-    // progress MUST be preserved, no silent fallback.
+fn session_no_progress_marker_routes_prose_to_engineer_fallback() {
+    // When the LLM returns prose instead of structured JSON, the dispatcher
+    // now treats the response as the engineer's task description (the
+    // engineer is itself an LLM that reads prose). Goal progress MUST still
+    // be preserved — only the engineer subprocess can advance progress, and
+    // in unit tests the spawn is blocked by the recursion depth guard.
     let (session, _captured) = MockSession::new_ok(
         "Checked the repo. Everything looks fine.",
         vec!["no markers here".to_string()],
@@ -121,21 +124,20 @@ fn session_no_progress_marker_preserves_current() {
     };
     let outcomes = dispatch_actions(&[action], &mut bridges, &mut state).unwrap();
 
-    // Non-JSON response = parse failure = failed outcome.
+    // The outcome detail must reflect the spawn attempt (not the legacy
+    // "parse failed" path).
+    let detail = outcomes[0].detail.to_lowercase();
     assert!(
-        !outcomes[0].success,
-        "non-JSON LLM response must produce a failed outcome (no silent fallback)"
-    );
-    assert!(
-        outcomes[0].detail.contains("parse failed"),
-        "outcome detail should explain the parse failure, got: {}",
+        detail.contains("spawn_engineer") || detail.contains("subordinate"),
+        "outcome should reference spawn_engineer fallback, got: {}",
         outcomes[0].detail,
     );
-    // Progress MUST stay at 40% (no silent mutation).
+    // Progress MUST stay at 40% — only a successful engineer run could
+    // advance it, and the test harness blocks that.
     assert_eq!(
         state.active_goals.active[0].status,
         GoalProgress::InProgress { percent: 40 },
-        "progress must be preserved when LLM emits invalid action"
+        "progress must be preserved when only prose-fallback fired in tests"
     );
 }
 

--- a/src/ooda_actions/tests_goal_session_extra.rs
+++ b/src/ooda_actions/tests_goal_session_extra.rs
@@ -90,10 +90,13 @@ fn dispatch_assess_only_updates_progress_from_json() {
 }
 
 #[test]
-fn dispatch_records_parse_failure_outcome_detail() {
+fn dispatch_records_prose_fallback_outcome_detail() {
     // LLM returns prose with no JSON — parser returns None and the
-    // dispatcher MUST fail loudly (no silent fallback). The outcome detail
-    // must explain the parse failure so operators can diagnose.
+    // dispatcher routes the response into the engineer subprocess as a
+    // task description ("the engineer reads natural language too"). The
+    // test harness blocks the actual spawn via the depth limit, so the
+    // visible outcome describes the spawn attempt rather than the legacy
+    // "parse failed" message.
     let (session, _) = MockSession::new_ok("I have no idea what to do. PROGRESS: 30", vec![]);
     let mut bridges = bridges_with_session(session);
     let board = board_with_goal("g1", GoalProgress::InProgress { percent: 25 }, None);
@@ -105,21 +108,17 @@ fn dispatch_records_parse_failure_outcome_detail() {
     };
     let outcomes = dispatch_actions(&[action], &mut bridges, &mut state).unwrap();
 
-    assert!(
-        !outcomes[0].success,
-        "non-JSON LLM response must produce a failed outcome, got success"
-    );
     let detail = outcomes[0].detail.to_lowercase();
     assert!(
-        detail.contains("parse failed"),
-        "outcome detail must explain the parse failure, got: {}",
+        detail.contains("spawn_engineer") || detail.contains("subordinate"),
+        "outcome detail must reference the spawn_engineer fallback, got: {}",
         outcomes[0].detail
     );
-    // Progress MUST stay at 25% (no silent mutation).
+    // Progress MUST stay at 25% (no silent mutation, no auto-bump).
     assert_eq!(
         state.active_goals.active[0].status,
         GoalProgress::InProgress { percent: 25 },
-        "progress must be preserved when LLM emits invalid action"
+        "progress must be preserved when only prose-fallback fired in tests"
     );
 }
 


### PR DESCRIPTION
## Summary

Three user-driven changes that remove unnecessary friction in the OODA goal-action path and let operators pick which `amplihack` subcommand the engineer subprocess uses.

### 1. Drop the FAIL LOUD on non-JSON LLM responses

The prior dispatcher in `src/ooda_actions/goal_session/advance.rs` marked any non-JSON LLM reply as `PARSE FAILED` and stalled the goal. The engineer is itself an LLM that reads natural language, so any non-empty prose response is now routed to a `SpawnEngineer { task: prose, files: [], issue: None }` action.

Structured JSON actions remain *preferred* (they let Simard run direct GH ops without spawning a subprocess) — but prose works because the engineer reads it.

- Extracted `prose_fallback_action` helper (`pub(super)`) for direct unit-test coverage.
- Empty / whitespace-only responses still return `None` so the existing retry path engages.
- Updated `prompt_assets/simard/goal_session_objective.md` to describe the prose-as-task fallback (was: "MUST respond JSON").

### 2. Configurable engineer agent kind

New `SIMARD_ENGINEER_AGENT` env var controls which `amplihack` subcommand the engineer subprocess invokes. Defaults to `rustyclawd` (current behavior); accepts `copilot`.

| Kind | argv shape |
|---|---|
| `rustyclawd` (default) | `--auto --subprocess-safe --no-reflection --max-turns N -- -p <prompt>` |
| `copilot` | `--allow-all-paths -p <prompt>` (no `--auto`, no `--`, no `--max-turns`) |

- Added `pub(crate) AgentKind { RustyClawd, Copilot }` with `subcommand()` and case-insensitive `from_env()`. Unknown values warn-and-default rather than panicking on operator typos.
- Renamed `run_rustyclawd_subprocess` → `run_engineer_subprocess(kind)`. `start_agent_session` now resolves the kind from env via `AgentKind::from_env()`.
- Kept `rustyclawd_argv` / `run_rustyclawd_subprocess` as thin backwards-compat wrappers tagged `#[cfg_attr(not(test), allow(dead_code))]` so the existing pinned contract tests keep working.

### 3. Documentation

`docs/reference/spawn-agent-for-goal.md`: added "Choosing the agent kind" section listing both AgentKind values, env var, and per-kind argv shapes.

## Local verification

- `cargo fmt --all -- --check` — clean
- `cargo build --release --bin simard` — clean
- `cargo clippy --all-targets --all-features --locked -- -D warnings` — clean
- `cargo test --release --lib agent_spawn` — 29 ok / 0 fail
- `cargo test --release --lib advance::tests` — 4 ok (new prose tests)
- Pre-push hook — Passed

## Test updates

| Was | Now |
|---|---|
| `session_no_progress_marker_preserves_current` | `session_no_progress_marker_routes_prose_to_engineer_fallback` |
| `dispatch_records_parse_failure_outcome_detail` | `dispatch_records_prose_fallback_outcome_detail` |

Both now assert `spawn_engineer` routing instead of `parse failed`. Progress preservation semantics unchanged.

## Behavioral impact

After deploy, the daemon will stop logging `OODA goal-action PARSE FAILED: LLM returned non-JSON response` and instead log a prose-fallback dispatch line followed by an `amplihack` subprocess launch. Goals that were stalling will start producing real engineer subprocesses.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>