### PR TITLE
chore(orchestrator): drop "fallback" framing for prose-to-engineer path

### DIFF
--- a/prompt_assets/simard/goal_session_objective.md
+++ b/prompt_assets/simard/goal_session_objective.md
@@ -10,16 +10,17 @@ literally into your response. A response whose `task`, `reason`, or
 similar `<placeholder>`) is a bug and will be rejected.
 
 You SHOULD respond with a single JSON object matching one of the seven
-schemas below. JSON lets Simard run direct GitHub operations (create
-issue, comment, close) without spinning a subordinate engineer subprocess.
+schemas below. JSON is preferred because it lets Simard run direct GitHub
+operations (create issue, comment, close) without spinning a subordinate
+engineer subprocess.
 
-If you cannot produce structured JSON for any reason — for example you
-need to describe a complex task that does not fit the spawn_engineer
-schema, or you are uncertain which action applies — write a single
-paragraph of plain English describing what the engineer should do next.
-Simard will treat the entire response as a `spawn_engineer` task and
-hand it directly to the autonomous coding subprocess. Prose responses
-ARE valid; the engineer is itself an LLM and reads natural language.
+If a JSON action does not fit (for example, you need to describe a complex
+task that does not fit the `spawn_engineer` schema, or you are uncertain
+which action applies), write a single paragraph of plain English describing
+what the engineer should do next. Simard will spawn a `spawn_engineer`
+subprocess with the entire prose response as the task description. Prose
+is a first-class response shape — the engineer is itself an LLM and reads
+natural language directly.
 
 # Issue-first workflow
 
@@ -145,8 +146,13 @@ Update the assessed completion percentage with no other side effects.
 
 # Failure mode
 
-If you emit anything other than one of the seven JSON objects above, the
-cycle FAILS LOUDLY. There is no fallback that scrapes prose. Pick an action.
+The only response that fails the cycle is an empty/whitespace-only
+response. Both shapes succeed:
 
-Output requirement: emit ONLY the JSON object. No surrounding text, no code
-fences, no markdown.
+- A valid JSON object → Simard executes it directly.
+- Any non-empty prose       → Simard spawns an engineer subprocess with the
+                              prose as its task description.
+
+Output requirement: emit either a single JSON object **or** a single
+paragraph of prose. Do not mix both. No code fences, no markdown around
+the JSON.

--- a/src/ooda_actions/goal_session/advance.rs
+++ b/src/ooda_actions/goal_session/advance.rs
@@ -311,18 +311,16 @@ pub(crate) fn advance_goal_with_session(
                     }
                 }
                 None => {
-                    // The LLM did not emit a recognised JSON action — but it
-                    // may still have emitted prose describing what to do.
-                    // The engineer is itself an LLM that reads natural
-                    // language, so we fall back to spawning an engineer
-                    // with the response as its task description rather than
-                    // discarding the cycle's planning work.
-                    //
-                    // Structured JSON actions (noop / assess_only / spawn /
-                    // gh_*) remain the preferred contract — they let Simard
-                    // perform GH ops directly without spinning a subprocess.
-                    // But "no JSON parsed" no longer kills the cycle.
-                    match prose_fallback_action(&outcome.execution_summary) {
+                    // The LLM did not emit a recognised JSON action. JSON is
+                    // the preferred contract because it lets Simard run
+                    // direct GH ops (noop / assess_only / spawn / gh_*)
+                    // without spawning a subprocess. But prose is also a
+                    // valid response shape: the engineer subprocess is
+                    // itself an LLM that reads natural language, so any
+                    // non-empty prose response IS a usable engineer task
+                    // description. Only a literally empty response is a
+                    // failure here.
+                    match engineer_task_from_prose(&outcome.execution_summary) {
                         Some(prose_action) => {
                             let task = match &prose_action {
                                 GoalAction::SpawnEngineer { task, .. } => task.as_str(),
@@ -330,11 +328,11 @@ pub(crate) fn advance_goal_with_session(
                             };
                             let truncated = truncate_for_outcome(task);
                             eprintln!(
-                                "[simard] OODA goal-action prose fallback for '{}': spawning engineer with raw response as task: {}",
+                                "[simard] OODA goal-action: LLM emitted prose for '{}'; spawning engineer with prose as task: {}",
                                 goal.id, truncated,
                             );
                             let detail = format!(
-                                "prose-fallback spawn_engineer for goal '{}': {}",
+                                "spawn_engineer (from prose) for goal '{}': {}",
                                 goal.id, truncated,
                             );
                             GoalSessionResult {
@@ -373,17 +371,20 @@ pub(crate) fn advance_goal_with_session(
     }
 }
 
-/// Build the prose-fallback `GoalAction` from a raw LLM response.
+/// Build a `SpawnEngineer` `GoalAction` from a free-form LLM prose response.
 ///
-/// When the orchestrator LLM emits free-form prose instead of a JSON
-/// action, treat the trimmed response as the task description for a
-/// subordinate engineer subprocess. This is the user-facing answer to
-/// "why does it have to be JSON?" — it doesn't, the engineer reads
-/// natural language too.
+/// The orchestrator LLM may answer in two equally-valid shapes:
+///   1. A structured JSON action (preferred — Simard executes it directly).
+///   2. Free-form prose describing what should be done.
+///
+/// Prose is **not** a fallback or error-recovery path; it is a first-class
+/// input format. The engineer subprocess is itself an LLM that reads
+/// natural language, so a prose response IS a usable engineer task
+/// description with no transformation beyond trimming.
 ///
 /// Returns `None` only when the response trims to the empty string;
 /// every non-empty response yields a `SpawnEngineer` action.
-pub(super) fn prose_fallback_action(response: &str) -> Option<GoalAction> {
+pub(super) fn engineer_task_from_prose(response: &str) -> Option<GoalAction> {
     let trimmed = response.trim();
     if trimmed.is_empty() {
         return None;
@@ -400,9 +401,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn prose_fallback_action_returns_spawn_engineer_for_pure_prose() {
+    fn engineer_task_from_prose_returns_spawn_engineer_for_pure_prose() {
         let response = "Run `cargo test --lib prioritization` and report which tests fail.";
-        let action = prose_fallback_action(response).expect("non-empty prose yields action");
+        let action = engineer_task_from_prose(response).expect("non-empty prose yields action");
         match action {
             GoalAction::SpawnEngineer { task, files, issue } => {
                 assert_eq!(task, response);
@@ -414,9 +415,9 @@ mod tests {
     }
 
     #[test]
-    fn prose_fallback_action_trims_surrounding_whitespace() {
+    fn engineer_task_from_prose_trims_surrounding_whitespace() {
         let action =
-            prose_fallback_action("\n\n   fix the meeting REPL  \n\n").expect("yields action");
+            engineer_task_from_prose("\n\n   fix the meeting REPL  \n\n").expect("yields action");
         match action {
             GoalAction::SpawnEngineer { task, .. } => {
                 assert_eq!(task, "fix the meeting REPL");
@@ -426,16 +427,16 @@ mod tests {
     }
 
     #[test]
-    fn prose_fallback_action_returns_none_for_empty_or_whitespace() {
-        assert!(prose_fallback_action("").is_none());
-        assert!(prose_fallback_action("   ").is_none());
-        assert!(prose_fallback_action("\n\t  \r\n").is_none());
+    fn engineer_task_from_prose_returns_none_for_empty_or_whitespace() {
+        assert!(engineer_task_from_prose("").is_none());
+        assert!(engineer_task_from_prose("   ").is_none());
+        assert!(engineer_task_from_prose("\n\t  \r\n").is_none());
     }
 
     #[test]
-    fn prose_fallback_action_preserves_multiline_task_descriptions() {
+    fn engineer_task_from_prose_preserves_multiline_task_descriptions() {
         let response = "First, check the current state with `git status`.\n\nThen, if dirty, stash and proceed to fix issue #1234.";
-        let action = prose_fallback_action(response).expect("yields action");
+        let action = engineer_task_from_prose(response).expect("yields action");
         match action {
             GoalAction::SpawnEngineer { task, .. } => {
                 assert!(task.contains("git status"));

--- a/src/ooda_actions/tests_goal_session.rs
+++ b/src/ooda_actions/tests_goal_session.rs
@@ -104,12 +104,13 @@ fn session_progress_comes_from_agent_response_not_auto_bump() {
 }
 
 #[test]
-fn session_no_progress_marker_routes_prose_to_engineer_fallback() {
+fn session_no_progress_marker_routes_prose_to_engineer_task() {
     // When the LLM returns prose instead of structured JSON, the dispatcher
-    // now treats the response as the engineer's task description (the
-    // engineer is itself an LLM that reads prose). Goal progress MUST still
-    // be preserved — only the engineer subprocess can advance progress, and
-    // in unit tests the spawn is blocked by the recursion depth guard.
+    // treats the prose as the engineer subprocess's task description (the
+    // engineer is itself an LLM that reads natural language). Goal progress
+    // MUST still be preserved — only the engineer subprocess can advance
+    // progress, and in unit tests the spawn is blocked by the recursion
+    // depth guard.
     let (session, _captured) = MockSession::new_ok(
         "Checked the repo. Everything looks fine.",
         vec!["no markers here".to_string()],
@@ -129,7 +130,7 @@ fn session_no_progress_marker_routes_prose_to_engineer_fallback() {
     let detail = outcomes[0].detail.to_lowercase();
     assert!(
         detail.contains("spawn_engineer") || detail.contains("subordinate"),
-        "outcome should reference spawn_engineer fallback, got: {}",
+        "outcome should reference spawn_engineer, got: {}",
         outcomes[0].detail,
     );
     // Progress MUST stay at 40% — only a successful engineer run could
@@ -137,7 +138,7 @@ fn session_no_progress_marker_routes_prose_to_engineer_fallback() {
     assert_eq!(
         state.active_goals.active[0].status,
         GoalProgress::InProgress { percent: 40 },
-        "progress must be preserved when only prose-fallback fired in tests"
+        "progress must be preserved when only the prose-to-engineer path fired in tests"
     );
 }
 

--- a/src/ooda_actions/tests_goal_session_extra.rs
+++ b/src/ooda_actions/tests_goal_session_extra.rs
@@ -90,9 +90,9 @@ fn dispatch_assess_only_updates_progress_from_json() {
 }
 
 #[test]
-fn dispatch_records_prose_fallback_outcome_detail() {
-    // LLM returns prose with no JSON — parser returns None and the
-    // dispatcher routes the response into the engineer subprocess as a
+fn dispatch_records_prose_to_engineer_outcome_detail() {
+    // LLM returns prose with no JSON. Prose is a valid response shape — the
+    // dispatcher routes the response into the engineer subprocess as the
     // task description ("the engineer reads natural language too"). The
     // test harness blocks the actual spawn via the depth limit, so the
     // visible outcome describes the spawn attempt rather than the legacy
@@ -111,14 +111,14 @@ fn dispatch_records_prose_fallback_outcome_detail() {
     let detail = outcomes[0].detail.to_lowercase();
     assert!(
         detail.contains("spawn_engineer") || detail.contains("subordinate"),
-        "outcome detail must reference the spawn_engineer fallback, got: {}",
+        "outcome detail must reference spawn_engineer, got: {}",
         outcomes[0].detail
     );
     // Progress MUST stay at 25% (no silent mutation, no auto-bump).
     assert_eq!(
         state.active_goals.active[0].status,
         GoalProgress::InProgress { percent: 25 },
-        "progress must be preserved when only prose-fallback fired in tests"
+        "progress must be preserved when only the prose-to-engineer path fired in tests"
     );
 }
 


### PR DESCRIPTION
## Summary

User feedback: calling the prose-to-engineer dispatch a "fallback" was wrong. Prose and JSON are both first-class valid response shapes from the orchestrator LLM. "Fallback" implies prose is recovery from a failure, which silently mislabels working code as broken.

## What changed (naming + docs only — zero behavior change)

| Was | Now |
|---|---|
| `prose_fallback_action` (function) | `engineer_task_from_prose` |
| `OODA goal-action prose fallback for '<goal>': spawning engineer with raw response as task: ...` | `OODA goal-action: LLM emitted prose for '<goal>'; spawning engineer with prose as task: ...` |
| `prose-fallback spawn_engineer for goal '<goal>': ...` (outcome detail) | `spawn_engineer (from prose) for goal '<goal>': ...` |
| `session_no_progress_marker_routes_prose_to_engineer_fallback` (test) | `session_no_progress_marker_routes_prose_to_engineer_task` |
| `dispatch_records_prose_fallback_outcome_detail` (test) | `dispatch_records_prose_to_engineer_outcome_detail` |

## Prompt asset cleanup

`prompt_assets/simard/goal_session_objective.md` had a contradiction the prior PR introduced — the "Format" section said prose was valid, the "Failure mode" section said `FAILS LOUDLY. There is no fallback that scrapes prose.` Both can't be true. Rewrote the Failure mode section to state plainly:

> The only response that fails the cycle is an empty/whitespace-only response. Both shapes succeed.

## Local verification

- `cargo fmt --all -- --check`: clean
- `cargo build --release --bin simard`: clean
- `cargo clippy --all-targets --all-features --locked -- -D warnings`: clean
- `cargo test --release --lib advance::tests`: 4 ok
- Renamed dispatcher tests + `dispatch_outcomes_are_never_empty`: 3 ok
- Pre-push hook: Passed

## Open question (not in this PR)

The deeper question raised by the user is "why does this orchestrator path need JSON parsing at all?" — the JSON contract was an early-design optimization to skip the engineer subprocess for `noop` / `assess_only` / `gh_*` ops. It costs a 7-schema parser, ~120 lines of prompt, and bugs like the one this PR cleans up. A follow-up could rip out the JSON contract entirely; this PR does not.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>