### PR TITLE
fix(engineer): forward SIMARD_* env to engineer subprocess and default to Copilot

### DIFF
--- a/python/simard_gym_bridge.py
+++ b/python/simard_gym_bridge.py
@@ -203,6 +203,21 @@ class GymBridgeServer(BridgeServer):
 
     def _handle_run_suite(self, params: dict[str, Any]) -> dict[str, Any]:
         suite_id = params.get("suite_id", "progressive")
+        # Workaround for upstream amplihack metacognition_grader rejecting
+        # reasoning_effort=medium and hanging the Observe phase for 25+ min
+        # per cycle (tracked separately; see follow-up issue linked from
+        # fix/forward-engineer-env-and-copilot-default PR). When the daemon
+        # exports SIMARD_SKIP_GYM=1, return a synthetic success immediately
+        # so OODA cycles can complete. Remove once the upstream fix lands.
+        if os.environ.get("SIMARD_SKIP_GYM") == "1":
+            logger.info("SIMARD_SKIP_GYM=1; returning synthetic success for suite %s", suite_id)
+            return {
+                "suite_id": suite_id, "success": True, "overall_score": 0.0,
+                "dimensions": _zero_dims(), "scenario_results": [],
+                "scenarios_passed": 0, "scenarios_total": 0,
+                "error_message": None,
+                "degraded_sources": ["SIMARD_SKIP_GYM=1 workaround"],
+            }
         if self._progressive is None:
             return {
                 "suite_id": suite_id, "success": False, "overall_score": 0.0,

--- a/src/agent_supervisor/lifecycle/spawn.rs
+++ b/src/agent_supervisor/lifecycle/spawn.rs
@@ -111,6 +111,27 @@ pub fn spawn_subordinate(config: &SubordinateConfig) -> SimardResult<Subordinate
                 "/tmp/simard-engineer-target".to_string(),
             ));
         }
+        // Forward every SIMARD_* env var from the daemon's environment to the
+        // engineer subprocess (issue #4537 / fix/forward-engineer-env-and-copilot-default).
+        // Without this loop, `SIMARD_ENGINEER_AGENT=copilot` set on the systemd
+        // unit reaches the daemon but is silently dropped at the tmux boundary
+        // because the long-running tmux server forks new sessions from its own
+        // environment, not from the tmux client's. The result: engineers
+        // ignored the operator's agent override and fell back to the broken
+        // upstream RustyClawd default. Convention: any SIMARD_* var present in
+        // the daemon environment is propagated; vars already explicitly added
+        // above (SIMARD_AGENT_NAME, SIMARD_SUBORDINATE_DEPTH) are skipped to
+        // avoid double-add.
+        let already_set: std::collections::HashSet<&str> = tmux_env
+            .iter()
+            .map(|(k, _)| k.as_str())
+            .collect::<std::collections::HashSet<_>>();
+        let mut simard_extras: Vec<(String, String)> = std::env::vars()
+            .filter(|(k, _)| k.starts_with("SIMARD_") && !already_set.contains(k.as_str()))
+            .collect();
+        // Stable ordering helps test/debug reproducibility.
+        simard_extras.sort_by(|a, b| a.0.cmp(&b.0));
+        tmux_env.extend(simard_extras);
         let argv = build_tmux_wrapped_command(&session_name, &inner_argv, &log_path, &tmux_env);
 
         // Run the tmux command. `tmux new-session -d` returns immediately

--- a/src/engineer_loop/agent_spawn.rs
+++ b/src/engineer_loop/agent_spawn.rs
@@ -73,19 +73,26 @@ impl AgentKind {
 
     /// Resolve the configured agent kind from the `SIMARD_ENGINEER_AGENT`
     /// environment variable. Unknown values warn to stderr and fall back
-    /// to the default (`RustyClawd`).
+    /// to the default (`Copilot`).
+    ///
+    /// Default flipped from `RustyClawd` to `Copilot` on
+    /// fix/forward-engineer-env-and-copilot-default: upstream RustyClawd
+    /// crashes with `aclose(): asynchronous generator is already running`
+    /// (rysweet/amplihack#4537), so every engineer dispatch fails closed
+    /// with the previous default. Operators who still want RustyClawd
+    /// can opt in by setting `SIMARD_ENGINEER_AGENT=rustyclawd`.
     pub(crate) fn from_env() -> AgentKind {
         match std::env::var("SIMARD_ENGINEER_AGENT") {
-            Err(_) => AgentKind::RustyClawd,
+            Err(_) => AgentKind::Copilot,
             Ok(raw) => match raw.trim().to_ascii_lowercase().as_str() {
-                "" | "rustyclawd" | "rusty-clawd" | "rusty_clawd" => AgentKind::RustyClawd,
-                "copilot" => AgentKind::Copilot,
+                "" | "copilot" => AgentKind::Copilot,
+                "rustyclawd" | "rusty-clawd" | "rusty_clawd" => AgentKind::RustyClawd,
                 other => {
                     eprintln!(
                         "[simard] SIMARD_ENGINEER_AGENT={other:?} not recognised; \
-                         falling back to RustyClawd. Valid: rustyclawd, copilot."
+                         falling back to Copilot. Valid: copilot, rustyclawd."
                     );
-                    AgentKind::RustyClawd
+                    AgentKind::Copilot
                 }
             },
         }
@@ -457,15 +464,38 @@ mod tests {
     }
 
     #[test]
-    fn agent_kind_from_env_defaults_to_rustyclawd() {
+    fn agent_kind_from_env_defaults_to_copilot() {
         let original = std::env::var("SIMARD_ENGINEER_AGENT").ok();
         unsafe {
             std::env::remove_var("SIMARD_ENGINEER_AGENT");
         }
-        assert_eq!(AgentKind::from_env(), AgentKind::RustyClawd);
+        assert_eq!(AgentKind::from_env(), AgentKind::Copilot);
         unsafe {
             if let Some(v) = original {
                 std::env::set_var("SIMARD_ENGINEER_AGENT", v);
+            }
+        }
+    }
+
+    #[test]
+    fn agent_kind_from_env_recognises_rustyclawd_explicitly() {
+        let original = std::env::var("SIMARD_ENGINEER_AGENT").ok();
+        for raw in [
+            "rustyclawd",
+            "RustyClawd",
+            "RUSTYCLAWD",
+            "rusty-clawd",
+            "  rusty_clawd  ",
+        ] {
+            unsafe {
+                std::env::set_var("SIMARD_ENGINEER_AGENT", raw);
+            }
+            assert_eq!(AgentKind::from_env(), AgentKind::RustyClawd, "raw={raw:?}");
+        }
+        unsafe {
+            match original {
+                Some(v) => std::env::set_var("SIMARD_ENGINEER_AGENT", v),
+                None => std::env::remove_var("SIMARD_ENGINEER_AGENT"),
             }
         }
     }
@@ -494,7 +524,7 @@ mod tests {
             std::env::set_var("SIMARD_ENGINEER_AGENT", "totally-not-a-real-agent");
         }
         // Falls back rather than panicking; warning is emitted to stderr.
-        assert_eq!(AgentKind::from_env(), AgentKind::RustyClawd);
+        assert_eq!(AgentKind::from_env(), AgentKind::Copilot);
         unsafe {
             match original {
                 Some(v) => std::env::set_var("SIMARD_ENGINEER_AGENT", v),


### PR DESCRIPTION
## Summary

Three surgical fixes that together unblock the live engineer pipeline. Over the past 24h on the deployed daemon, every engineer dispatch fell back to the broken upstream RustyClawd default and produced 0 commits / 0 PRs / 0 issues. This PR fixes the propagation gap, flips the default to a working agent, and lets the OODA cycle complete by short-circuiting the gym path that's hung upstream.

## Changes (3 files)

| File | Change |
|---|---|
| `src/agent_supervisor/lifecycle/spawn.rs` | Forward all `SIMARD_*` env vars from the daemon to the engineer subprocess via explicit `tmux new-session -e KEY=VAL` flags. Vars already explicitly added (`SIMARD_AGENT_NAME`, `SIMARD_SUBORDINATE_DEPTH`) are skipped to avoid double-add. |
| `src/engineer_loop/agent_spawn.rs` | `AgentKind::from_env()` default flipped from `RustyClawd` to `Copilot`. Tests updated (`agent_kind_from_env_defaults_to_copilot`, `agent_kind_from_env_recognises_rustyclawd_explicitly`). RustyClawd remains opt-in via `SIMARD_ENGINEER_AGENT=rustyclawd`. |
| `python/simard_gym_bridge.py` | `_handle_run_suite` returns synthetic success when `SIMARD_SKIP_GYM=1`. Workaround for the upstream amplihack metacognition_grader rejecting `reasoning_effort=medium` and hanging Observe for 25+ min per cycle. |

## Root cause

Live daemon agent log `~/.simard/agent_logs/engineer-fix-broken-features-1778473616.log` shows:

```
engineer action amplihack RustyClawd failed: RustyClawd exited with status exit status: 1; aclose(): asynchronous generator is already running
```

Filed upstream as **rysweet/amplihack#4537**. The systemd unit had `SIMARD_ENGINEER_AGENT=copilot`, but the deployed binary did not propagate it through tmux to the engineer subprocess (long-running tmux server forks new sessions from its own env, not the tmux client's), so engineers fell back to the broken default.

## Mitigations called out in the crusty-old-engineer review

1. **The default flip is a deliberate behaviour change**, not a no-op refactor. Operators who pinned RustyClawd implicitly via the previous default need to set `SIMARD_ENGINEER_AGENT=rustyclawd` explicitly. Tracked at upstream rysweet/amplihack#4537.
2. **`SIMARD_SKIP_GYM=1` is a workaround**, not a fix. It is blocked on the upstream amplihack `reasoning_effort=medium` bug. Removal is tracked as a follow-up — see issue #1660 and upstream rysweet/amplihack#4538.
3. **Permissive `SIMARD_*` whitelist forwarding is a deliberate convention.** Any future env var with the `SIMARD_` prefix is now silently propagated to engineer subprocesses. This is intentional — the alternative (per-var allow-listing) is what bit us in the first place — but contributors should be aware.
4. **Integration-test gap is acknowledged.** No test in this PR actually crosses the tmux boundary to assert the engineer subprocess sees the env. Filed as follow-up #1658.
5. **Deploy step copies `python/simard_gym_bridge.py` too**, not just the Rust binary, because the gym workaround is in Python.

## Follow-up issues (filed)

- #1658 — Add engineer-supervisor integration test asserting `tmux` env propagation reaches engineer subprocess.
- #1659 — Capture amplihack stderr separately so warnings cannot pollute prose passed to the engineer.
- #1660 — Re-enable gym suite once amplihack `metacognition_grader reasoning_effort=medium` rejection is fixed upstream (depends on rysweet/amplihack#4538).
- rysweet/amplihack#4538 — `metacognition_grader` rejects `reasoning_effort=medium` causing 25+ minute hangs (upstream).

## Testing

- `cargo fmt --all -- --check` — pass (pre-commit + pre-push)
- `cargo clippy --release --no-deps -- -D warnings` — pass (pre-commit)
- `cargo clippy --all-targets --all-features --locked -- -D warnings` — pass (pre-push)
- `cargo test --release --lib (cognitive_memory|bootstrap|memory_ipc|memory_consolidation)` — pass (pre-push)
- `cargo test --lib -- engineer_loop::agent_spawn` — 16 passed, 0 failed
- `cargo test --lib -- agent_supervisor:: engineer_loop::` — 215 passed, 1 unrelated SIGCHLD flake (`run_local_engineer_loop_emits_agent_prompt_build_phase`) that passes in isolation.

## Out of scope (deferred to follow-ups, not this PR)

- Cognitive memory persistence of engineer episodes (Phase 3 of session plan).
- Dashboard endpoint `/api/engineer-activity` and Engineers UI tab (Phase 3).
- Switching `TranscriptGuard` from delete to archive (Phase 2).
- Stale-clear loud failure outcome (Phase 2).

## Verification plan post-merge

1. Build release binary on the merged commit.
2. Copy to `~/.simard/bin/simard` (with backup of the old one).
3. Copy `python/simard_gym_bridge.py` to `/home/azureuser/src/Simard/worktrees/main/python/`.
4. Restart `simard-ooda.service` via `systemctl --user restart`.
5. Within 10 minutes, journal must show at least one engineer dispatch where the worktree under `~/.simard/engineer-worktrees/<latest>/` contains a non-trivial file change (more than just `.simard-engineer-claim`).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
