### PR TITLE
test(supervisor): close #1658 — assert tmux env propagation

### DIFF
--- a/src/agent_supervisor/lifecycle/spawn.rs
+++ b/src/agent_supervisor/lifecycle/spawn.rs
@@ -6,7 +6,7 @@ use crate::error::{SimardError, SimardResult};
 use crate::subagent_sessions::session_name_for;
 
 use super::{open_agent_log, query_pane_pid, supervisor_state_root};
-use crate::agent_supervisor::tmux::build_tmux_wrapped_command;
+use crate::agent_supervisor::tmux::{build_tmux_wrapped_command, compute_tmux_env};
 use crate::agent_supervisor::types::{SubordinateConfig, SubordinateHandle};
 
 /// Spawn a subordinate agent as a real child process.
@@ -91,47 +91,10 @@ pub fn spawn_subordinate(config: &SubordinateConfig) -> SimardResult<Subordinate
         // them on `tmux_cmd` only reaches the tmux client; the long-running
         // tmux server forks new sessions from its own env. Without explicit
         // `-e`, vars like CARGO_TARGET_DIR silently fail to propagate and
-        // each engineer worktree builds its own ~12 GB cargo target dir.
-        let mut tmux_env: Vec<(String, String)> = vec![
-            ("SIMARD_AGENT_NAME".to_string(), config.agent_name.clone()),
-            (
-                "SIMARD_SUBORDINATE_DEPTH".to_string(),
-                (config.current_depth + 1).to_string(),
-            ),
-            ("CARGO_BUILD_JOBS".to_string(), "4".to_string()),
-        ];
-        if let Some(existing) = std::env::var_os("CARGO_TARGET_DIR") {
-            tmux_env.push((
-                "CARGO_TARGET_DIR".to_string(),
-                existing.to_string_lossy().into_owned(),
-            ));
-        } else {
-            tmux_env.push((
-                "CARGO_TARGET_DIR".to_string(),
-                "/tmp/simard-engineer-target".to_string(),
-            ));
-        }
-        // Forward every SIMARD_* env var from the daemon's environment to the
-        // engineer subprocess (issue #4537 / fix/forward-engineer-env-and-copilot-default).
-        // Without this loop, `SIMARD_ENGINEER_AGENT=copilot` set on the systemd
-        // unit reaches the daemon but is silently dropped at the tmux boundary
-        // because the long-running tmux server forks new sessions from its own
-        // environment, not from the tmux client's. The result: engineers
-        // ignored the operator's agent override and fell back to the broken
-        // upstream RustyClawd default. Convention: any SIMARD_* var present in
-        // the daemon environment is propagated; vars already explicitly added
-        // above (SIMARD_AGENT_NAME, SIMARD_SUBORDINATE_DEPTH) are skipped to
-        // avoid double-add.
-        let already_set: std::collections::HashSet<&str> = tmux_env
-            .iter()
-            .map(|(k, _)| k.as_str())
-            .collect::<std::collections::HashSet<_>>();
-        let mut simard_extras: Vec<(String, String)> = std::env::vars()
-            .filter(|(k, _)| k.starts_with("SIMARD_") && !already_set.contains(k.as_str()))
-            .collect();
-        // Stable ordering helps test/debug reproducibility.
-        simard_extras.sort_by(|a, b| a.0.cmp(&b.0));
-        tmux_env.extend(simard_extras);
+        // each engineer worktree builds its own ~12 GB cargo target dir
+        // (issue #1197), and operator-set `SIMARD_ENGINEER_AGENT=copilot`
+        // never reaches the engineer (issue #1658 / PR #1661).
+        let tmux_env = compute_tmux_env(config, std::env::vars());
         let argv = build_tmux_wrapped_command(&session_name, &inner_argv, &log_path, &tmux_env);
 
         // Run the tmux command. `tmux new-session -d` returns immediately

--- a/src/agent_supervisor/tests_tmux.rs
+++ b/src/agent_supervisor/tests_tmux.rs
@@ -161,3 +161,236 @@ fn empty_extra_env_emits_no_dash_e_flags() {
         "empty extra_env must not emit any -e flags: {argv:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// compute_tmux_env unit tests (issue #1658).
+//
+// These pin the contract that PR #1661 / commit aca976ea established: every
+// SIMARD_* var present in the daemon's environment must be forwarded to the
+// engineer subprocess via `tmux new-session -e KEY=VAL`. A future refactor
+// that drops the SIMARD_* propagation loop would otherwise silently regress
+// the operator-set `SIMARD_ENGINEER_AGENT=copilot` override.
+// ---------------------------------------------------------------------------
+
+use super::tmux::compute_tmux_env;
+use crate::agent_roles::AgentRole;
+use crate::agent_supervisor::types::SubordinateConfig;
+
+fn make_test_config(name: &str, depth: u32) -> SubordinateConfig {
+    SubordinateConfig {
+        agent_name: name.to_string(),
+        goal: "test goal".to_string(),
+        role: AgentRole::Engineer,
+        worktree_path: PathBuf::from("/fake/worktree"),
+        current_depth: depth,
+    }
+}
+
+fn env_value<'a>(env: &'a [(String, String)], key: &str) -> Option<&'a str> {
+    env.iter().find(|(k, _)| k == key).map(|(_, v)| v.as_str())
+}
+
+#[test]
+fn compute_tmux_env_seeds_required_simard_vars_from_config() {
+    let config = make_test_config("engineer-abc", 2);
+    let env = compute_tmux_env(&config, std::iter::empty::<(String, String)>());
+
+    assert_eq!(
+        env_value(&env, "SIMARD_AGENT_NAME"),
+        Some("engineer-abc"),
+        "SIMARD_AGENT_NAME must come from config.agent_name"
+    );
+    assert_eq!(
+        env_value(&env, "SIMARD_SUBORDINATE_DEPTH"),
+        Some("3"),
+        "SIMARD_SUBORDINATE_DEPTH must be config.current_depth + 1"
+    );
+    assert_eq!(
+        env_value(&env, "CARGO_BUILD_JOBS"),
+        Some("4"),
+        "CARGO_BUILD_JOBS must be capped at 4 (issue #373 OOM guard)"
+    );
+}
+
+#[test]
+fn compute_tmux_env_uses_default_cargo_target_when_parent_unset() {
+    let config = make_test_config("e1", 0);
+    let env = compute_tmux_env(&config, std::iter::empty::<(String, String)>());
+    assert_eq!(
+        env_value(&env, "CARGO_TARGET_DIR"),
+        Some("/tmp/simard-engineer-target"),
+        "CARGO_TARGET_DIR default must be /tmp/simard-engineer-target (issue #1197)"
+    );
+}
+
+#[test]
+fn compute_tmux_env_honors_parent_cargo_target_override() {
+    let config = make_test_config("e1", 0);
+    let parent = vec![(
+        "CARGO_TARGET_DIR".to_string(),
+        "/srv/shared-target".to_string(),
+    )];
+    let env = compute_tmux_env(&config, parent);
+    assert_eq!(
+        env_value(&env, "CARGO_TARGET_DIR"),
+        Some("/srv/shared-target"),
+        "CARGO_TARGET_DIR from parent_env must override the default"
+    );
+}
+
+#[test]
+fn compute_tmux_env_forwards_simard_vars_from_parent_env() {
+    // Regression target: PR #1661 added a loop that forwards every SIMARD_*
+    // parent env var. If a future refactor drops this loop, the operator's
+    // SIMARD_ENGINEER_AGENT=copilot override silently fails to reach the
+    // engineer and engineers fall back to the broken default agent.
+    let config = make_test_config("e1", 0);
+    let parent = vec![
+        ("SIMARD_ENGINEER_AGENT".to_string(), "copilot".to_string()),
+        ("SIMARD_KEEP_TRANSCRIPTS".to_string(), "1".to_string()),
+        ("SIMARD_LLM_PROVIDER".to_string(), "openai".to_string()),
+        // Non-SIMARD vars must NOT be forwarded.
+        ("HOME".to_string(), "/home/azureuser".to_string()),
+        ("PATH".to_string(), "/usr/bin".to_string()),
+    ];
+    let env = compute_tmux_env(&config, parent);
+
+    assert_eq!(env_value(&env, "SIMARD_ENGINEER_AGENT"), Some("copilot"));
+    assert_eq!(env_value(&env, "SIMARD_KEEP_TRANSCRIPTS"), Some("1"));
+    assert_eq!(env_value(&env, "SIMARD_LLM_PROVIDER"), Some("openai"));
+    assert!(
+        env_value(&env, "HOME").is_none(),
+        "non-SIMARD_ vars must not leak into tmux_env: {env:?}"
+    );
+    assert!(
+        env_value(&env, "PATH").is_none(),
+        "non-SIMARD_ vars must not leak into tmux_env: {env:?}"
+    );
+}
+
+#[test]
+fn compute_tmux_env_does_not_double_add_seeded_vars() {
+    // SIMARD_AGENT_NAME and SIMARD_SUBORDINATE_DEPTH are seeded from config.
+    // Even if they appear in parent_env, the seeded values must win and the
+    // key must appear exactly once.
+    let config = make_test_config("from-config", 5);
+    let parent = vec![
+        (
+            "SIMARD_AGENT_NAME".to_string(),
+            "from-parent-env".to_string(),
+        ),
+        ("SIMARD_SUBORDINATE_DEPTH".to_string(), "999".to_string()),
+        ("SIMARD_OTHER".to_string(), "ok".to_string()),
+    ];
+    let env = compute_tmux_env(&config, parent);
+
+    let agent_name_count = env.iter().filter(|(k, _)| k == "SIMARD_AGENT_NAME").count();
+    let depth_count = env
+        .iter()
+        .filter(|(k, _)| k == "SIMARD_SUBORDINATE_DEPTH")
+        .count();
+    assert_eq!(
+        agent_name_count, 1,
+        "SIMARD_AGENT_NAME must be unique: {env:?}"
+    );
+    assert_eq!(
+        depth_count, 1,
+        "SIMARD_SUBORDINATE_DEPTH must be unique: {env:?}"
+    );
+    assert_eq!(
+        env_value(&env, "SIMARD_AGENT_NAME"),
+        Some("from-config"),
+        "config-seeded SIMARD_AGENT_NAME must win over parent_env"
+    );
+    assert_eq!(
+        env_value(&env, "SIMARD_SUBORDINATE_DEPTH"),
+        Some("6"),
+        "config-derived SIMARD_SUBORDINATE_DEPTH (depth+1) must win over parent_env"
+    );
+    assert_eq!(env_value(&env, "SIMARD_OTHER"), Some("ok"));
+}
+
+#[test]
+fn compute_tmux_env_sorts_simard_extras_for_stable_ordering() {
+    let config = make_test_config("e1", 0);
+    let parent = vec![
+        ("SIMARD_ZULU".to_string(), "z".to_string()),
+        ("SIMARD_ALPHA".to_string(), "a".to_string()),
+        ("SIMARD_MIKE".to_string(), "m".to_string()),
+    ];
+    let env = compute_tmux_env(&config, parent);
+
+    // Find the positions of the SIMARD_ extras (they come after the seeded vars).
+    let positions: Vec<(String, usize)> = env
+        .iter()
+        .enumerate()
+        .filter_map(|(i, (k, _))| {
+            if matches!(k.as_str(), "SIMARD_ALPHA" | "SIMARD_MIKE" | "SIMARD_ZULU") {
+                Some((k.clone(), i))
+            } else {
+                None
+            }
+        })
+        .collect();
+    assert_eq!(positions.len(), 3, "all three extras must appear: {env:?}");
+    let alpha_idx = positions
+        .iter()
+        .find(|(k, _)| k == "SIMARD_ALPHA")
+        .unwrap()
+        .1;
+    let mike_idx = positions
+        .iter()
+        .find(|(k, _)| k == "SIMARD_MIKE")
+        .unwrap()
+        .1;
+    let zulu_idx = positions
+        .iter()
+        .find(|(k, _)| k == "SIMARD_ZULU")
+        .unwrap()
+        .1;
+    assert!(
+        alpha_idx < mike_idx && mike_idx < zulu_idx,
+        "SIMARD_ extras must be sorted alphabetically: alpha={alpha_idx} mike={mike_idx} zulu={zulu_idx}"
+    );
+}
+
+#[test]
+fn compute_tmux_env_output_threads_through_build_tmux_wrapped_command() {
+    // Round-trip: compute_tmux_env's output must be accepted by
+    // build_tmux_wrapped_command and produce the corresponding `-e KEY=VAL`
+    // flags on the resulting tmux argv.
+    let config = make_test_config("engineer-x", 0);
+    let parent = vec![("SIMARD_ENGINEER_AGENT".to_string(), "copilot".to_string())];
+    let tmux_env = compute_tmux_env(&config, parent);
+    let argv = build_tmux_wrapped_command(
+        "simard-engineer-x",
+        &["/bin/printenv".to_string()],
+        &PathBuf::from("/tmp/x.log"),
+        &tmux_env,
+    );
+
+    let env_flags: Vec<&String> = argv
+        .iter()
+        .enumerate()
+        .filter_map(|(i, a)| {
+            if a == "-e" && i + 1 < argv.len() {
+                Some(&argv[i + 1])
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    assert!(
+        env_flags
+            .iter()
+            .any(|s| s.as_str() == "SIMARD_ENGINEER_AGENT=copilot"),
+        "tmux argv must carry SIMARD_ENGINEER_AGENT=copilot via -e: {env_flags:?}"
+    );
+    assert!(
+        env_flags
+            .iter()
+            .any(|s| s.as_str() == "SIMARD_AGENT_NAME=engineer-x"),
+        "tmux argv must carry seeded SIMARD_AGENT_NAME via -e: {env_flags:?}"
+    );
+}

--- a/src/agent_supervisor/tmux.rs
+++ b/src/agent_supervisor/tmux.rs
@@ -1,6 +1,9 @@
 //! Pure tmux command-line builder for wrapping engineer subprocesses (WS-2).
 
+use std::collections::HashSet;
 use std::path::Path;
+
+use crate::agent_supervisor::types::SubordinateConfig;
 
 /// POSIX shell single-quote escape: wrap the value in single quotes,
 /// replacing any embedded `'` with the sequence `'\''`.
@@ -65,4 +68,60 @@ pub fn build_tmux_wrapped_command(
         shell_cmd,
     ]);
     argv
+}
+
+/// Build the `(KEY, VALUE)` pairs that must be passed to
+/// `tmux new-session -e KEY=VAL` so the engineer subprocess inherits them.
+///
+/// Composition rules (kept stable so issue #1658 can regression-test this):
+///
+/// 1. Always-set vars seeded from `config`:
+///    - `SIMARD_AGENT_NAME`        = `config.agent_name`
+///    - `SIMARD_SUBORDINATE_DEPTH` = `config.current_depth + 1`
+///    - `CARGO_BUILD_JOBS`         = `"4"` (issue #373 OOM guard)
+/// 2. `CARGO_TARGET_DIR` honors a `parent_env` override; otherwise defaults
+///    to `/tmp/simard-engineer-target` (issue #1197 — share one target dir
+///    across all engineer worktrees).
+/// 3. Every `SIMARD_*` entry from `parent_env` that isn't already in (1) is
+///    appended, sorted by key for stable test/debug ordering.
+///
+/// The function is pure (it does not touch `std::env` itself), so unit tests
+/// can drive it with synthetic parent environments and the integration test
+/// `tests/engineer_supervisor_tmux_env.rs` can pin the propagation contract
+/// across the real tmux boundary without mutating process-wide state.
+pub fn compute_tmux_env<I>(config: &SubordinateConfig, parent_env: I) -> Vec<(String, String)>
+where
+    I: IntoIterator<Item = (String, String)>,
+{
+    let mut tmux_env: Vec<(String, String)> = vec![
+        ("SIMARD_AGENT_NAME".to_string(), config.agent_name.clone()),
+        (
+            "SIMARD_SUBORDINATE_DEPTH".to_string(),
+            (config.current_depth + 1).to_string(),
+        ),
+        ("CARGO_BUILD_JOBS".to_string(), "4".to_string()),
+    ];
+
+    let parent_pairs: Vec<(String, String)> = parent_env.into_iter().collect();
+
+    let cargo_target = parent_pairs
+        .iter()
+        .find(|(k, _)| k == "CARGO_TARGET_DIR")
+        .map(|(_, v)| v.clone())
+        .unwrap_or_else(|| "/tmp/simard-engineer-target".to_string());
+    tmux_env.push(("CARGO_TARGET_DIR".to_string(), cargo_target));
+
+    // Forward every SIMARD_* var from parent_env that isn't already set.
+    // Convention landed in PR #1661 / commit aca976ea: any SIMARD_* var
+    // present in the daemon environment is propagated; vars seeded above
+    // are skipped to avoid double-add.
+    let already_set: HashSet<&str> = tmux_env.iter().map(|(k, _)| k.as_str()).collect();
+    let mut simard_extras: Vec<(String, String)> = parent_pairs
+        .into_iter()
+        .filter(|(k, _)| k.starts_with("SIMARD_") && !already_set.contains(k.as_str()))
+        .collect();
+    simard_extras.sort_by(|a, b| a.0.cmp(&b.0));
+    tmux_env.extend(simard_extras);
+
+    tmux_env
 }

--- a/tests/engineer_supervisor_tmux_env.rs
+++ b/tests/engineer_supervisor_tmux_env.rs
@@ -1,0 +1,239 @@
+//! Integration test: assert that env vars set on the engineer supervisor's
+//! parent environment actually propagate across the tmux boundary into the
+//! engineer subprocess.
+//!
+//! Closes issue #1658. Pinned regression coverage for the fix landed in
+//! PR #1661 / commit aca976ea ("fix(engineer): forward SIMARD_* env to
+//! engineer subprocess and default to Copilot"):
+//!
+//! > ... env vars set on the spawning Command don't propagate to tmux
+//! > sessions when a tmux server already exists. The fix is `-e KEY=VAL`
+//! > arguments to `tmux new-session`. Without this loop,
+//! > `SIMARD_ENGINEER_AGENT=copilot` set on the systemd unit reaches the
+//! > daemon but is silently dropped at the tmux boundary because the
+//! > long-running tmux server forks new sessions from its own environment,
+//! > not from the tmux client's.
+//!
+//! Strategy: drive `compute_tmux_env` + `build_tmux_wrapped_command` end to
+//! end with a real `tmux` server. Use `printenv` as the inner "engineer"
+//! command and read back the wrapper's tee'd log file. If `printenv` shows
+//! the sentinel value, the env reached the inner subprocess across the tmux
+//! boundary; if it doesn't, the propagation regressed.
+//!
+//! Skipped when `tmux` is not on PATH so CI environments without tmux do
+//! not break.
+
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use simard::agent_roles::AgentRole;
+use simard::agent_supervisor::SubordinateConfig;
+use simard::agent_supervisor::tmux::{build_tmux_wrapped_command, compute_tmux_env};
+
+fn tmux_available() -> bool {
+    Command::new("tmux")
+        .arg("-V")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn unique_suffix() -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let pid = std::process::id();
+    format!("{pid}-{nanos}")
+}
+
+fn make_engineer_config(name: &str) -> SubordinateConfig {
+    SubordinateConfig {
+        agent_name: name.to_string(),
+        goal: "tmux-env-propagation-integration-test".to_string(),
+        role: AgentRole::Engineer,
+        worktree_path: PathBuf::from(env!("CARGO_MANIFEST_DIR")),
+        current_depth: 0,
+    }
+}
+
+/// Wait up to `deadline` for `path` to exist and contain non-empty content.
+fn wait_for_log_content(path: &std::path::Path, deadline: Duration) -> Option<String> {
+    let start = Instant::now();
+    while start.elapsed() < deadline {
+        if let Ok(s) = std::fs::read_to_string(path)
+            && !s.is_empty()
+        {
+            return Some(s);
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    std::fs::read_to_string(path).ok()
+}
+
+/// Best-effort cleanup: kill the tmux session and remove the log file.
+fn cleanup(session_name: &str, log_path: &std::path::Path) {
+    let _ = Command::new("tmux")
+        .args(["kill-session", "-t", session_name])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+    let _ = std::fs::remove_file(log_path);
+}
+
+/// End-to-end propagation contract for issue #1658.
+///
+/// Builds the tmux env vec from a synthetic parent environment containing a
+/// sentinel `SIMARD_*` value, then spawns a real detached tmux session whose
+/// inner command is `printenv SIMARD_TEST_TMUX_PROPAGATE`. The wrapper pipes
+/// inner stdout through `tee -a <log>`, so the log file ends up containing
+/// whatever value `printenv` saw in its own environment.
+///
+/// If the `-e KEY=VAL` propagation regresses (e.g. a future refactor drops
+/// `compute_tmux_env`'s SIMARD_* loop), `printenv` will print an empty line
+/// and this test fails.
+#[test]
+fn simard_env_var_propagates_through_tmux_to_engineer_subprocess() {
+    if !tmux_available() {
+        eprintln!(
+            "[skip] tmux is not on PATH; cannot exercise the engineer-supervisor \
+             tmux env propagation path. Install tmux or run this test in a \
+             tmux-capable environment to enable issue #1658 regression coverage."
+        );
+        return;
+    }
+
+    let suffix = unique_suffix();
+    let sentinel = format!("propagated-{suffix}");
+    let session_name = format!("simard-itest-tmuxenv-{suffix}");
+    let log_path = std::env::temp_dir().join(format!("simard-itest-tmuxenv-{suffix}.log"));
+    // Pre-clean any stale log/session from a previous interrupted run.
+    let _ = std::fs::remove_file(&log_path);
+
+    let config = make_engineer_config("engineer-itest-tmuxenv");
+
+    // Synthetic parent environment carrying the sentinel — note we do NOT
+    // touch std::env so the test is safe under cargo test's parallel runner.
+    let synthetic_parent_env = vec![
+        ("SIMARD_TEST_TMUX_PROPAGATE".to_string(), sentinel.clone()),
+        // Confirm a non-SIMARD var is NOT propagated (whitelist guarantee).
+        (
+            "ITEST_NON_SIMARD_VAR".to_string(),
+            "should-not-propagate".to_string(),
+        ),
+    ];
+
+    let tmux_env = compute_tmux_env(&config, synthetic_parent_env);
+    assert!(
+        tmux_env
+            .iter()
+            .any(|(k, v)| k == "SIMARD_TEST_TMUX_PROPAGATE" && v == &sentinel),
+        "Pre-condition: compute_tmux_env must include the sentinel SIMARD_* var. \
+         Got: {tmux_env:?}"
+    );
+    assert!(
+        !tmux_env.iter().any(|(k, _)| k == "ITEST_NON_SIMARD_VAR"),
+        "Pre-condition: compute_tmux_env must NOT propagate non-SIMARD_ vars. \
+         Got: {tmux_env:?}"
+    );
+
+    // Inner argv = `printenv SIMARD_TEST_TMUX_PROPAGATE`. The wrapper's
+    // `tee -a` will dump printenv's stdout into log_path so we can read it.
+    let inner_argv = vec![
+        "printenv".to_string(),
+        "SIMARD_TEST_TMUX_PROPAGATE".to_string(),
+    ];
+
+    let argv = build_tmux_wrapped_command(&session_name, &inner_argv, &log_path, &tmux_env);
+
+    // Run the tmux command. Critically: do NOT set the sentinel on tmux_cmd
+    // itself — the whole point of issue #1658 is that vars on the tmux
+    // client are silently dropped. The only mechanism under test is the
+    // `-e KEY=VAL` propagation that compute_tmux_env wires up.
+    let status = Command::new(&argv[0])
+        .args(&argv[1..])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .expect("tmux new-session should launch");
+    assert!(
+        status.success(),
+        "tmux new-session exited with {status}; argv was {argv:?}"
+    );
+
+    // Give the inner shell up to 10s to run `printenv` and tee its output.
+    let log_contents = wait_for_log_content(&log_path, Duration::from_secs(10)).unwrap_or_default();
+
+    cleanup(&session_name, &log_path);
+
+    assert!(
+        log_contents.contains(&sentinel),
+        "engineer subprocess did not see SIMARD_TEST_TMUX_PROPAGATE={sentinel} \
+         after tmux propagation. This is the issue #1658 regression — env \
+         vars set on the tmux client without `-e KEY=VAL` are silently \
+         dropped by the long-running tmux server. log_contents={log_contents:?}"
+    );
+}
+
+/// Negative control: when the SIMARD_* var is NOT included in the parent
+/// env passed to `compute_tmux_env`, it must NOT appear in the inner
+/// engineer subprocess. This pins the contract that propagation is opt-in
+/// via `compute_tmux_env`, not implicit through tmux server inheritance —
+/// which is the very behaviour issue #1658 needs to guard against.
+#[test]
+fn missing_simard_env_var_does_not_propagate_implicitly_through_tmux() {
+    if !tmux_available() {
+        eprintln!(
+            "[skip] tmux is not on PATH; cannot exercise negative-control case \
+             for issue #1658 propagation."
+        );
+        return;
+    }
+
+    let suffix = unique_suffix();
+    let session_name = format!("simard-itest-tmuxenv-neg-{suffix}");
+    let log_path = std::env::temp_dir().join(format!("simard-itest-tmuxenv-neg-{suffix}.log"));
+    let _ = std::fs::remove_file(&log_path);
+
+    let config = make_engineer_config("engineer-itest-tmuxenv-neg");
+    // Empty parent env — no SIMARD_TEST_TMUX_PROPAGATE present.
+    let tmux_env = compute_tmux_env(&config, std::iter::empty::<(String, String)>());
+    assert!(
+        !tmux_env
+            .iter()
+            .any(|(k, _)| k == "SIMARD_TEST_TMUX_PROPAGATE"),
+        "Pre-condition: compute_tmux_env with empty parent must not include \
+         SIMARD_TEST_TMUX_PROPAGATE. Got: {tmux_env:?}"
+    );
+
+    // Inner: print SIMARD_TEST_TMUX_PROPAGATE if present, else a sentinel.
+    let inner_argv = vec![
+        "sh".to_string(),
+        "-c".to_string(),
+        "printenv SIMARD_TEST_TMUX_PROPAGATE || echo NOT_SET".to_string(),
+    ];
+
+    let argv = build_tmux_wrapped_command(&session_name, &inner_argv, &log_path, &tmux_env);
+
+    let status = Command::new(&argv[0])
+        .args(&argv[1..])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .expect("tmux new-session should launch");
+    assert!(status.success(), "tmux new-session exited with {status}");
+
+    let log_contents = wait_for_log_content(&log_path, Duration::from_secs(10)).unwrap_or_default();
+
+    cleanup(&session_name, &log_path);
+
+    assert!(
+        log_contents.contains("NOT_SET"),
+        "negative control: with no -e flag the inner subprocess should not \
+         see the var (printenv exits non-zero, then `|| echo NOT_SET` runs). \
+         log_contents={log_contents:?}"
+    );
+}


### PR DESCRIPTION
Closes #1658.

## Why

PR #1661 / commit `aca976ea` ("fix(engineer): forward SIMARD_* env to engineer subprocess and default to Copilot") fixed a regression where the daemon set `SIMARD_ENGINEER_AGENT=copilot` on the systemd unit but the value never reached the engineer subprocess. Quoting that PR's root-cause analysis:

> Live daemon agent log `~/.simard/agent_logs/engineer-fix-broken-features-1778473616.log` shows:
>
> ```
> engineer action amplihack RustyClawd failed: RustyClawd exited with status exit status: 1; aclose(): asynchronous generator is already running
> ```
>
> Filed upstream as **rysweet/amplihack#4537**. The systemd unit had `SIMARD_ENGINEER_AGENT=copilot`, but the deployed binary did not propagate it through tmux to the engineer subprocess (long-running tmux server forks new sessions from its own env, not the tmux client's), so engineers fell back to the broken default.

Issue #1658 ("Add engineer-supervisor integration test asserting tmux env propagation reaches engineer subprocess") flagged that the fix was not covered by an integration test that actually crosses the tmux boundary, so a future refactor that drops the `-e KEY=VAL` propagation loop would silently regress the whole feature.

This PR closes that gap.

## What

1. **Refactor (`src/agent_supervisor/tmux.rs`)** — extract the tmux-env composition into a pure `compute_tmux_env(config, parent_env) -> Vec<(String, String)>` function. Same composition rules as the inline version landed in PR #1661:
    - seeded `SIMARD_AGENT_NAME` / `SIMARD_SUBORDINATE_DEPTH` / `CARGO_BUILD_JOBS` from `config`
    - `CARGO_TARGET_DIR` honors a `parent_env` override (issue #1197), defaults to `/tmp/simard-engineer-target`
    - every `SIMARD_*` parent-env entry forwarded, sorted, deduped against seeded keys
2. **`src/agent_supervisor/lifecycle/spawn.rs`** — replace the 47-line inline block with a single `compute_tmux_env(config, std::env::vars())` call. Behavior preserved.
3. **Unit tests (`src/agent_supervisor/tests_tmux.rs`)** — 6 new tests pinning the composition contract: seeded vars, CARGO_TARGET_DIR default + override, SIMARD_* whitelist forwarding, no-double-add, sorted ordering, and a round-trip through `build_tmux_wrapped_command` that asserts `SIMARD_ENGINEER_AGENT=copilot` ends up as a `-e` flag.
4. **Integration test (`tests/engineer_supervisor_tmux_env.rs`, NEW)** — two end-to-end tests that spawn a real tmux session whose inner command is `printenv`, then read back the wrapper's tee'd log file:
    - **Positive:** asserts the sentinel `SIMARD_TEST_TMUX_PROPAGATE=propagated-<unique>` actually reaches the inner subprocess across the tmux boundary. Critically, the test does NOT set the var via `Command::env(...)` on the tmux command — the only mechanism under test is the `-e KEY=VAL` propagation that `compute_tmux_env` wires up. If the `SIMARD_*` loop regresses, `printenv` prints empty and the test fails.
    - **Negative control:** asserts a `SIMARD_TEST_TMUX_PROPAGATE` not in `compute_tmux_env`'s output does NOT leak to the inner subprocess implicitly, and that non-`SIMARD_` parent vars are filtered out (whitelist contract).
    - Both gracefully skip with a clear stderr message when `tmux` is not on PATH so CI environments without tmux do not break.

## Verification (warm cache)

```
$ cargo test --lib agent_supervisor::tests_tmux::
test result: ok. 14 passed; 0 failed; 0 ignored

$ cargo test --test engineer_supervisor_tmux_env -- --nocapture
test result: ok. 2 passed; 0 failed; 0 ignored

$ cargo check --workspace --tests --quiet
(0 warnings, exit 0)

$ cargo clippy --tests --no-deps -- -D warnings
(0 warnings, exit 0)
```

## Notes

- The integration test bypasses `std::env::set_var` and instead builds a synthetic `parent_env` for `compute_tmux_env`, so it is safe under `cargo test`'s parallel runner with no need for `#[serial]` or `--test-threads=1`.
- Per the "amplihack hook drift" memory: no hook config files were modified.

---

## Merge readiness

### QA-team evidence

- Scenario files: `tests/engineer_supervisor_tmux_env.rs` (Rust integration tests are the project's outside-in coverage equivalent for supervisor behaviour; `gadugi-test` targets Electron apps and is not applicable to the Rust supervisor crate).
- Validation command: `cargo check --workspace --tests --quiet`
- Validation result: passed (0 warnings, exit 0)
- Run command: `cargo test --test engineer_supervisor_tmux_env -- --nocapture` and `cargo test --lib agent_supervisor::tests_tmux::`
- Run target: local + GitHub Actions (`verify/install-real`, both push and pull_request triggers)
- Run result: passed (2/2 integration + 14/14 unit, also green on CI)
- Evidence location: this PR's "Verification (warm cache)" section above + GitHub Actions run logs linked under "Checks".

### Documentation

- User-facing docs impact: no
- Updated docs: none
- PR description links added: n/a
- Rationale: changed surfaces are all internal supervisor plumbing — `src/agent_supervisor/tmux.rs` (new pure helper, no public crate API), `src/agent_supervisor/lifecycle/spawn.rs` (internal call site), `src/agent_supervisor/tests_tmux.rs` (test-only), `tests/engineer_supervisor_tmux_env.rs` (test-only). No CLI flag, config key, daemon API, or operator-visible behaviour changes.

### Quality-audit

- Cycle 1 summary: SEEK across `src/agent_supervisor/` (broader than the PR's diff) found 10 candidate findings; 3-agent VALIDATE (analyzer + reviewer + architect) confirmed 7 (2 high, 5 medium) and downgraded 2 to low. **All 7 confirmed findings live in code that is NOT modified by this PR** — they pre-exist in `lifecycle/mod.rs`, `types.rs`, `mod.rs`, and at lines of `spawn.rs` outside this PR's hunks. Per the merge-ready scope criterion, fixes were not applied here.
- Cycle 2 summary: not run — see "Convergence summary" below.
- Cycle 3 summary: not run — see "Convergence summary" below.
- Additional cycles: none.
- Final clean cycle: cycle 1 cleared the in-scope (PR #1674 diff) findings (zero critical/high/medium in the actually-changed files). Pre-existing findings in adjacent files were extracted to issue **#1676** and routed to the `fix-broken-features` OODA goal.
- Fixes followed default-workflow: n/a (no in-scope findings to fix).
- Convergence summary: the audit's `target_path=src/agent_supervisor` was deliberately wider than the PR diff to surface any latent issues in adjacent code. Once it became clear that all confirmed findings were pre-existing (none in the 4 files this PR touches: `tmux.rs`, `lifecycle/spawn.rs` lines 90-138, `tests_tmux.rs`, `tests/engineer_supervisor_tmux_env.rs`), running cycles 2/3 against unchanged code would have applied fixes outside this PR's scope (violating the scope criterion). The findings were instead filed as #1676 for the `fix-broken-features` goal to pick up. The PR's own changes — a 47-line→1-call refactor that strictly preserves behaviour, plus 6 unit + 2 integration tests pinning the contract — were independently re-reviewed: zero critical/high, zero medium correctness/security findings.

### CI

- Checks command: `gh pr checks 1674`
- Result: all 7 green (`pre-commit`, `install-real`, `e2e-dashboard` x2 each for push + pull_request, plus `GitGuardian Security Checks`).
- Skipped checks: none.
- Flaky reruns performed: none.
- Real failures fixed: none (all checks passed first try after the branch was rebased on `aca976ea`).

### Scope

- Changed files reviewed: `gh pr diff 1674 --name-only` returned exactly 4 files, all under `src/agent_supervisor/` and `tests/engineer_supervisor_tmux_env.rs`. `gh pr diff 1674` confirms the only behavioural change to `spawn.rs` is the 47-line block at lines 90-138 being collapsed to one `compute_tmux_env(config, std::env::vars())` call; everything else is additive (new pure function + tests).
- Unrelated changes: none.

### Verdict

- Merge-ready: **yes**
- Remaining blockers: none. Pre-existing audit findings tracked in #1676 are out of scope for this PR.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
