### PR TITLE
fix(meeting): drop empty-response sentinel and FIFO handoff dispatch (#1649, #1671)

### DIFF
--- a/src/meeting_backend/messaging.rs
+++ b/src/meeting_backend/messaging.rs
@@ -1,13 +1,13 @@
 //! Send-message turn handling: prompt construction + LLM dispatch.
 
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::base_types::BaseTypeTurnInput;
 use crate::error::{SimardError, SimardResult};
 
+use super::MeetingBackend;
 use super::sanitize::extract_response;
 use super::types::{MeetingResponse, Role};
-use super::{EMPTY_RESPONSE_SENTINEL, MeetingBackend};
 
 impl MeetingBackend {
     /// Send a user message and get Simard's response.
@@ -65,18 +65,27 @@ impl MeetingBackend {
                 return Err(e);
             }
         };
-        let response_text = {
-            let extracted = extract_response(&outcome);
-            if extracted.trim().is_empty() {
-                tracing::warn!(
-                    raw_len = outcome.execution_summary.len(),
-                    "MeetingBackend: extract_response produced empty result"
-                );
-                EMPTY_RESPONSE_SENTINEL.to_string()
-            } else {
-                extracted
-            }
-        };
+        let extracted = extract_response(&outcome);
+        if extracted.trim().is_empty() {
+            // Fail loud on empty adapter output rather than substituting a
+            // sentinel string that downstream code (transcript writers,
+            // /act-on-decisions, dashboard chat) treats as legitimate
+            // assistant content. See #1671.
+            error!(
+                raw_len = outcome.execution_summary.len(),
+                topic = self.topic,
+                "MeetingBackend: adapter returned empty response — failing the turn"
+            );
+            return Err(SimardError::ActionExecutionFailed {
+                action: "send-message".to_string(),
+                reason: format!(
+                    "empty_adapter_response: extract_response produced empty result \
+                     (raw_summary_len={})",
+                    outcome.execution_summary.len()
+                ),
+            });
+        }
+        let response_text = extracted;
 
         // Append assistant response
         self.push_message(Role::Assistant, response_text.clone());

--- a/src/meeting_backend/mod.rs
+++ b/src/meeting_backend/mod.rs
@@ -44,11 +44,6 @@ const RECENT_WINDOW: usize = 30;
 /// Maximum time to wait for LLM summary generation before falling back.
 const SUMMARY_TIMEOUT: Duration = Duration::from_secs(90);
 
-/// Sentinel content returned when the LLM yields no usable text after
-/// sanitisation. Surfacing this to the dashboard is preferable to an empty
-/// bubble — operators can see that the turn completed but produced nothing.
-pub const EMPTY_RESPONSE_SENTINEL: &str = "[empty response]";
-
 /// The unified meeting backend.
 ///
 /// Maintains conversation state, delegates to an LLM agent, and handles

--- a/src/meeting_backend/tests_mod.rs
+++ b/src/meeting_backend/tests_mod.rs
@@ -119,14 +119,42 @@ fn send_message_after_close_fails() {
 }
 
 #[test]
-fn send_message_returns_sentinel_when_response_empty() {
+fn send_message_returns_err_on_empty_adapter_response() {
     // Whitespace-only LLM output sanitises to empty; backend must
-    // surface the explicit sentinel rather than an empty bubble.
+    // surface a structured error (handoff `failed` with reason
+    // `empty_adapter_response`) rather than substituting a sentinel
+    // string that downstream code treats as successful content. See #1671.
     let agent = MockAgent::new("   \n\n   ");
     let mut backend = MeetingBackend::new_session("Test", Box::new(agent), None, String::new());
-    let resp = backend.send_message("ping").unwrap();
-    assert_eq!(resp.content, EMPTY_RESPONSE_SENTINEL);
-    assert_eq!(resp.message_count, 2);
+    let result = backend.send_message("ping");
+    let err = result.expect_err("empty adapter response must produce Err");
+    match err {
+        crate::error::SimardError::ActionExecutionFailed { action, reason } => {
+            assert_eq!(action, "send-message");
+            assert!(
+                reason.starts_with("empty_adapter_response"),
+                "reason should be structured 'empty_adapter_response: ...', got: {reason}"
+            );
+        }
+        other => panic!("expected ActionExecutionFailed, got: {other:?}"),
+    }
+
+    // Transcript history must NOT contain a sentinel-bearing assistant
+    // message for the failed turn — only the user's prompt remains.
+    let history = backend.history();
+    assert_eq!(
+        history.len(),
+        1,
+        "only the user message should be persisted on a failed turn, got {history:?}"
+    );
+    assert!(matches!(history[0].role, Role::User));
+    let any_sentinel = history
+        .iter()
+        .any(|m| m.content.contains("[empty response]"));
+    assert!(
+        !any_sentinel,
+        "no sentinel string should leak into the transcript"
+    );
 }
 
 #[test]

--- a/src/meeting_facilitator/handoff/mod.rs
+++ b/src/meeting_facilitator/handoff/mod.rs
@@ -237,6 +237,7 @@ mod persistence;
 // clippy flags it as unused in non-test compilation. Keep the re-export stable.
 #[allow(unused_imports)]
 pub use persistence::{
-    find_newest_handoff, load_meeting_handoff, load_session_wip, mark_handoff_processed_in_place,
-    mark_meeting_handoff_processed, remove_session_wip, save_session_wip, write_meeting_handoff,
+    find_newest_handoff, find_oldest_unprocessed_handoff, load_meeting_handoff, load_session_wip,
+    mark_handoff_processed_in_place, mark_meeting_handoff_processed, remove_session_wip,
+    save_session_wip, write_meeting_handoff,
 };

--- a/src/meeting_facilitator/handoff/persistence.rs
+++ b/src/meeting_facilitator/handoff/persistence.rs
@@ -27,6 +27,11 @@ pub fn write_meeting_handoff(dir: &Path, handoff: &MeetingHandoff) -> SimardResu
 
 /// Find the newest handoff file in a directory (timestamped `handoff-*.json`
 /// or legacy `meeting_handoff.json`). Returns `None` if no file exists.
+///
+/// **Note**: this is the historical "newest by filename" selector kept for
+/// callers that want a single representative handoff regardless of state
+/// (e.g. CLI display, observe scan). The OODA dispatch queue must use
+/// [`find_oldest_unprocessed_handoff`] instead — see #1649.
 pub fn find_newest_handoff(dir: &Path) -> Option<PathBuf> {
     let mut candidates: Vec<PathBuf> = Vec::new();
 
@@ -50,6 +55,75 @@ pub fn find_newest_handoff(dir: &Path) -> Option<PathBuf> {
     // Newest by filename (timestamps sort lexicographically).
     candidates.sort();
     candidates.pop()
+}
+
+/// List all handoff files in a directory sorted by filename ascending
+/// (oldest first, since timestamps sort lexicographically). Includes both
+/// timestamped `handoff-*.json` files and the legacy `meeting_handoff.json`.
+fn list_handoff_files(dir: &Path) -> Vec<PathBuf> {
+    let mut candidates: Vec<PathBuf> = Vec::new();
+
+    let legacy = dir.join(MEETING_HANDOFF_FILENAME);
+    if legacy.is_file() {
+        candidates.push(legacy);
+    }
+
+    if let Ok(entries) = fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let name_str = name.to_string_lossy();
+            if name_str.starts_with("handoff-") && name_str.ends_with(".json") {
+                candidates.push(entry.path());
+            }
+        }
+    }
+
+    candidates.sort(); // oldest first
+    candidates
+}
+
+/// Find the **oldest unprocessed** handoff file in a directory — i.e. the
+/// FIFO-next pending handoff for OODA ingestion.
+///
+/// This replaces the previous "newest by filename" behaviour for the
+/// dispatch queue (#1649): a fresh empty handoff (e.g. emitted by a
+/// dashboard chat that closes with zero items) was permanently shadowing
+/// older content-rich handoffs because `find_newest_handoff` ignored the
+/// `processed` flag and the older file would never be selected after a
+/// newer one had been marked processed.
+///
+/// Each candidate file is read and parsed to inspect its `processed`
+/// field; malformed JSON is skipped (an old half-written file should not
+/// block dispatch). Returns `Ok(None)` when no unprocessed handoff exists.
+pub fn find_oldest_unprocessed_handoff(dir: &Path) -> SimardResult<Option<PathBuf>> {
+    for path in list_handoff_files(dir) {
+        let raw = match fs::read_to_string(&path) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(
+                    path = %path.display(),
+                    error = %e,
+                    "skipping unreadable handoff while scanning for oldest unprocessed"
+                );
+                continue;
+            }
+        };
+        let handoff: MeetingHandoff = match serde_json::from_str(&raw) {
+            Ok(h) => h,
+            Err(e) => {
+                tracing::warn!(
+                    path = %path.display(),
+                    error = %e,
+                    "skipping malformed handoff JSON while scanning for oldest unprocessed"
+                );
+                continue;
+            }
+        };
+        if !handoff.processed {
+            return Ok(Some(path));
+        }
+    }
+    Ok(None)
 }
 
 /// Load a meeting handoff artifact from a directory. Returns `None` if no

--- a/src/meeting_facilitator/mod.rs
+++ b/src/meeting_facilitator/mod.rs
@@ -17,8 +17,9 @@ mod types;
 // Re-export all public items so `crate::meeting_facilitator::X` still works.
 pub use handoff::{
     MEETING_HANDOFF_FILENAME, MEETING_SESSION_WIP_FILENAME, MeetingHandoff, default_handoff_dir,
-    load_meeting_handoff, load_session_wip, mark_handoff_processed_in_place,
-    mark_meeting_handoff_processed, remove_session_wip, save_session_wip, write_meeting_handoff,
+    find_newest_handoff, find_oldest_unprocessed_handoff, load_meeting_handoff, load_session_wip,
+    mark_handoff_processed_in_place, mark_meeting_handoff_processed, remove_session_wip,
+    save_session_wip, write_meeting_handoff,
 };
 pub use session::{
     add_note, add_question, close_meeting, edit_item, record_action_item, record_decision,

--- a/src/ooda_loop/curate.rs
+++ b/src/ooda_loop/curate.rs
@@ -33,16 +33,50 @@ pub fn promote_from_backlog(board: &mut GoalBoard) {
 /// their decisions into active goals (or backlog items when at capacity) and
 /// action items into backlog items on the board. Marks the handoff processed.
 /// Returns the number of goals + backlog items created.
+///
+/// **FIFO ordering** (#1649): selects the **oldest** unprocessed handoff
+/// among all candidates (lexicographic filename sort = chronological order
+/// for `handoff-<rfc3339>.json`). The previous "newest by filename"
+/// behaviour caused starvation: a fresh empty handoff (e.g. from a
+/// dashboard chat closing with zero items) would permanently shadow an
+/// older content-rich handoff because the older file was never selected
+/// after a newer one had been marked processed.
 pub fn check_meeting_handoffs(
     board: &mut GoalBoard,
     handoff_dir: &std::path::Path,
 ) -> SimardResult<u32> {
-    use crate::meeting_facilitator::{load_meeting_handoff, mark_handoff_processed_in_place};
+    use crate::meeting_facilitator::find_oldest_unprocessed_handoff;
 
-    let mut handoff = match load_meeting_handoff(handoff_dir)? {
-        Some(h) if !h.processed => h,
-        _ => return Ok(0),
+    let path = match find_oldest_unprocessed_handoff(handoff_dir)? {
+        Some(p) => p,
+        None => return Ok(0),
     };
+
+    // Diagnostic: surface starvation that would have occurred under the old
+    // "newest by filename" selection — log when the oldest unprocessed file
+    // is older than the newest file in the directory (meaning at least one
+    // newer file exists and is already processed, or is itself unprocessed
+    // but properly deferred).
+    if let Some(newest) = crate::meeting_facilitator::find_newest_handoff(handoff_dir)
+        && newest != path
+    {
+        tracing::info!(
+            selected = %path.display(),
+            newest = %newest.display(),
+            "OODA curate: selecting older unprocessed handoff over newer file (FIFO)"
+        );
+    }
+
+    let raw =
+        std::fs::read_to_string(&path).map_err(|e| crate::error::SimardError::ArtifactIo {
+            path: path.clone(),
+            reason: format!("reading handoff: {e}"),
+        })?;
+    let mut handoff: crate::meeting_facilitator::MeetingHandoff = serde_json::from_str(&raw)
+        .map_err(|e| crate::error::SimardError::ArtifactIo {
+            path: path.clone(),
+            reason: format!("failed to parse handoff JSON: {e}"),
+        })?;
 
     let mut created = 0u32;
 
@@ -105,7 +139,22 @@ pub fn check_meeting_handoffs(
         created += 1;
     }
 
-    mark_handoff_processed_in_place(handoff_dir, &mut handoff)?;
+    // Mark this specific file processed and write back to the same path —
+    // never let the path-lookup pick a sibling file (which is the core of
+    // the #1649 starvation: under the old in_place helper the writeback
+    // could land on the wrong file when multiple handoffs co-exist).
+    handoff.processed = true;
+    let json = serde_json::to_string_pretty(&handoff).map_err(|e| {
+        crate::error::SimardError::ArtifactIo {
+            path: path.clone(),
+            reason: format!("serializing handoff: {e}"),
+        }
+    })?;
+    std::fs::write(&path, &json).map_err(|e| crate::error::SimardError::ArtifactIo {
+        path: path.clone(),
+        reason: format!("writing handoff: {e}"),
+    })?;
+
     Ok(created)
 }
 
@@ -376,5 +425,92 @@ mod tests {
         let mut board = GoalBoard::new();
         promote_from_backlog(&mut board);
         assert!(board.active.is_empty());
+    }
+
+    // -----------------------------------------------------------------
+    // FIFO regression test for #1649 (handoff starvation).
+    //
+    // Scenario: a content-rich handoff A is written first, then a fresh
+    // empty handoff B is written. Under the old "newest by filename"
+    // selection, B would be processed first (and A would be permanently
+    // shadowed once B was marked processed). With FIFO-by-`created_at`
+    // ascending among `pending` handoffs, A must be processed first.
+    // -----------------------------------------------------------------
+    #[test]
+    fn check_meeting_handoffs_picks_oldest_unprocessed_first_fifo() {
+        use std::fs;
+
+        let dir = TempDir::new().expect("create temp dir");
+
+        // Handoff A — older, content-rich.
+        let mut handoff_a = sample_handoff(vec![sample_decision("Older meeting decision A")]);
+        handoff_a.topic = "Older meeting".to_string();
+        handoff_a.closed_at = "2026-04-03T00:00:00Z".to_string();
+        let path_a = dir.path().join("handoff-2026-04-03T00-00-00_00-00.json");
+        fs::write(&path_a, serde_json::to_string_pretty(&handoff_a).unwrap()).unwrap();
+
+        // Handoff B — newer, empty (zero decisions, zero action items).
+        let handoff_b = MeetingHandoff {
+            topic: "Empty dashboard chat".to_string(),
+            started_at: "2026-04-03T00:05:00Z".to_string(),
+            closed_at: "2026-04-03T00:05:01Z".to_string(),
+            decisions: Vec::new(),
+            action_items: Vec::new(),
+            open_questions: Vec::new(),
+            processed: false,
+            duration_secs: None,
+            transcript: Vec::new(),
+            participants: Vec::new(),
+            themes: Vec::new(),
+        };
+        let path_b = dir.path().join("handoff-2026-04-03T00-05-01_00-00.json");
+        fs::write(&path_b, serde_json::to_string_pretty(&handoff_b).unwrap()).unwrap();
+
+        let mut board = GoalBoard::new();
+
+        // First cycle: must process A (older, content-rich) — NOT B.
+        let count = check_meeting_handoffs(&mut board, dir.path())
+            .expect("check_meeting_handoffs cycle 1 should succeed");
+        assert_eq!(count, 1, "first cycle should ingest A's single decision");
+        assert_eq!(board.active.len(), 1);
+        assert_eq!(
+            board.active[0].description, "[meeting] Older meeting decision A",
+            "older handoff A must be processed first under FIFO ordering"
+        );
+
+        // A's file must be marked processed; B's must remain unprocessed.
+        let reloaded_a: MeetingHandoff =
+            serde_json::from_str(&fs::read_to_string(&path_a).unwrap()).unwrap();
+        let reloaded_b: MeetingHandoff =
+            serde_json::from_str(&fs::read_to_string(&path_b).unwrap()).unwrap();
+        assert!(
+            reloaded_a.processed,
+            "handoff A must be marked processed after first cycle"
+        );
+        assert!(
+            !reloaded_b.processed,
+            "handoff B must remain unprocessed after first cycle"
+        );
+
+        // Second cycle: B is now the oldest unprocessed → gets processed
+        // (with zero items, since it's empty). Demonstrates B is no longer
+        // permanently shadowing A.
+        let count2 = check_meeting_handoffs(&mut board, dir.path())
+            .expect("check_meeting_handoffs cycle 2 should succeed");
+        assert_eq!(
+            count2, 0,
+            "second cycle ingests empty handoff B → zero items"
+        );
+        let reloaded_b2: MeetingHandoff =
+            serde_json::from_str(&fs::read_to_string(&path_b).unwrap()).unwrap();
+        assert!(
+            reloaded_b2.processed,
+            "handoff B must be marked processed after second cycle"
+        );
+
+        // Third cycle: nothing left to process.
+        let count3 = check_meeting_handoffs(&mut board, dir.path())
+            .expect("check_meeting_handoffs cycle 3 should succeed");
+        assert_eq!(count3, 0, "no unprocessed handoffs remain");
     }
 }


### PR DESCRIPTION
## Summary

Two tightly-coupled meeting-facilitator UX bugs fixed as a single coherent change. They share a root cause: empty handoffs being treated as first-class content.

Closes #1671 (sentinel propagation).
Closes #1649 (handoff starvation).

## Fix 1 — #1671: drop `EMPTY_RESPONSE_SENTINEL`

`MeetingBackend::send_message` previously substituted the literal string `"[empty response]"` into history when the adapter returned empty/whitespace output and returned `Ok(MeetingResponse)` — claiming success without evidence and leaking the sentinel into transcripts and downstream handoff consumers (dashboard chat, REPL, `/act-on-decisions`).

Now: an empty `extract_response` result fails the turn with

```rust
SimardError::ActionExecutionFailed {
    action: "send-message".to_string(),
    reason: format!("empty_adapter_response: extract_response produced empty result (raw_summary_len={N})"),
}
```

- The `EMPTY_RESPONSE_SENTINEL` constant is removed from `meeting_backend/mod.rs`.
- No sentinel is appended to history; no `auto_save_transcript()` runs for a failed turn (matches the existing failure path when the LLM call itself errors).
- The two callers (REPL `meeting_repl::repl` and dashboard chat `operator_commands_dashboard::chat`) already handle `Err`, so operators see a structured error message instead of a fake assistant message.

## Fix 2 — #1649: FIFO handoff dispatch

`check_meeting_handoffs` (in `src/ooda_loop/curate.rs`) loaded the **newest** handoff via `find_newest_handoff` and ignored the `processed` flag. A fresh empty handoff (e.g. from a dashboard chat closing with zero items) permanently shadowed older content-rich handoffs — once the empty newer file was marked processed, the older real handoff would never be selected.

Now: `check_meeting_handoffs` uses a new `find_oldest_unprocessed_handoff` helper — FIFO by filename ascending (chronological for `handoff-<rfc3339>.json`), filtered by `processed: false`. The same path used for selection is the path used for the in-place writeback, eliminating a path-mismatch hazard in the previous `mark_handoff_processed_in_place` fallback (which would have written to the newest file regardless of which file was just loaded). An `INFO` log fires when an older unprocessed file is selected over a newer already-processed one, closing the silent-skip diagnostic gap called out in the issue.

- New helper `find_oldest_unprocessed_handoff` in `meeting_facilitator/handoff/persistence.rs`, re-exported from `meeting_facilitator`.
- `find_newest_handoff` retained for callers that want a representative handoff regardless of state (CLI display, observe scan).

## Tests

```
cargo test --lib -- meeting_backend handoff   # 238 passed, 0 failed
```

New regression tests added:

- `meeting_backend::tests_mod::send_message_returns_err_on_empty_adapter_response` — replaces the old `send_message_returns_sentinel_when_response_empty`. Asserts that an empty adapter response produces `SimardError::ActionExecutionFailed { action: "send-message", reason: "empty_adapter_response: ..." }` AND that no sentinel string leaks into the transcript history.
- `ooda_loop::curate::tests::check_meeting_handoffs_picks_oldest_unprocessed_first_fifo` — enqueues handoff A (older, with content) then handoff B (newer, empty) and asserts A is processed first; second cycle then processes B; third cycle returns 0.

## Verification

- `cargo check --workspace --quiet`: exit 0
- `cargo check --workspace --tests --quiet`: exit 0
- `cargo fmt --all -- --check`: clean
- `cargo clippy --release --no-deps -- -D warnings` (pre-commit): clean
- `cargo clippy --all-targets --all-features --locked -- -D warnings` (pre-push): clean
- `cargo test --release --lib cognitive_memory bootstrap memory_ipc memory_consolidation` (race subset, pre-push): clean
- `cargo test --lib -- meeting_backend handoff`: 238 passed, 0 failed
- `grep -rn EMPTY_RESPONSE_SENTINEL src/`: no matches

## Out of scope

- #1662 (dashboard usability audit / jargon / panels) — separate goal lane.
- #1668 (FileBackedGoalStore in meeting_backend) — larger refactor that depends on the cognitive-memory migration in #1590/#1600/#1621 stabilizing first; deferred to a later cycle.

---

## Merge readiness

### QA-team evidence

- Scenario files: regression unit tests added in-repo (no separate gadugi YAML — these are correctness-of-meeting-backend invariants verified via `cargo test`)
  - `src/meeting_backend/tests_mod.rs::send_message_returns_err_on_empty_adapter_response`
  - `src/ooda_loop/curate.rs::tests::check_meeting_handoffs_picks_oldest_unprocessed_first_fifo`
- Validation command: `cargo test --lib -- meeting_backend handoff`
- Validation result: **passed** (238 passed, 0 failed)
- Run command: `cargo test --release --lib cognitive_memory bootstrap memory_ipc memory_consolidation` (pre-push race subset) plus full workspace tests in CI `verify/install-real`
- Run target: local pre-push hook + CI `verify/install-real` (push and pull_request)
- Run result: **passed** (see CI status — both `verify/install-real` jobs green at 24m49s / 24m50s)
- Evidence location: CI run https://github.com/rysweet/Simard/actions/runs/25657694... (verify/install-real, verify/pre-commit, verify/e2e-dashboard) — all green; pre-push hook output recorded under `## Verification` above.

### Documentation

- User-facing docs impact: **no**
- Updated docs: none
- PR description links added: closes #1671, closes #1649
- Rationale if not applicable: changed surfaces are entirely internal — `meeting_backend/{messaging,mod,tests_mod}.rs`, `meeting_facilitator/handoff/{mod,persistence}.rs`, `meeting_facilitator/mod.rs`, `ooda_loop/curate.rs`. No CLI flags, no public API, no configuration keys, no operator-visible behavior change other than swapping a fake-success transcript line for a structured error already surfaced through existing `Err` paths.

### Quality-audit

- Cycle 1 summary: identified the sentinel leakage in `MeetingBackend::send_message` and the FIFO/processed-flag bypass in `check_meeting_handoffs`; produced the new helper `find_oldest_unprocessed_handoff` and the structured `ActionExecutionFailed` error; added the two regression tests.
- Cycle 2 summary: closed the path-mismatch hazard in `mark_handoff_processed_in_place` by ensuring the same path used for selection is used for in-place writeback; added the INFO log when an older unprocessed file is selected over a newer processed one.
- Cycle 3 summary: ran `grep -rn EMPTY_RESPONSE_SENTINEL src/` to confirm no straggling references; ran the full pre-push gate (fmt, clippy `-D warnings`, race subset tests) — all clean. Zero critical/high findings, zero medium correctness/security findings.
- Additional cycles: none required
- Final clean cycle: **Cycle 3** (zero critical/high findings)
- Fixes followed default-workflow: yes
- Convergence summary: both root causes addressed with focused tests; no behavioral changes to callers (already handle `Err`); CI confirms no regressions across pre-commit, install-real, and e2e-dashboard.

### CI

- Checks command: `gh pr checks 1675 --repo rysweet/Simard`
- Result: **all green** (0 cancelled, 0 failing, 7 successful, 0 skipped, 0 pending — GitGuardian, verify/e2e-dashboard ×2, verify/install-real ×2, verify/pre-commit ×2)
- Skipped checks: none
- Flaky reruns performed: none
- Real failures fixed: none — all checks passed first time

### PR description evidence

- This PR description follows the merge-ready template at `~/.copilot/skills/merge-ready/pr-description-template.md`
- All six required evidence headings present
- Verdict section below

### Scope

- Changed files reviewed: 7 files — `src/meeting_backend/{messaging.rs,mod.rs,tests_mod.rs}`, `src/meeting_facilitator/{mod.rs,handoff/mod.rs,handoff/persistence.rs}`, `src/ooda_loop/curate.rs`
- `git diff --stat`: +277 −33, 7 changed files (per `gh pr view 1675 --json additions,deletions,changedFiles`)
- Unrelated changes: **none** — every changed file relates directly to the empty-response sentinel removal (#1671) or the FIFO handoff dispatch fix (#1649)

### Verdict

- Merge-ready: **yes**
- Remaining blockers: none

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
