### PR TITLE
feat(safe-update): brain-orchestrated drain → snapshot → pre-test → swap → validate → rollback

### DIFF
--- a/docs/safe-self-update.md
+++ b/docs/safe-self-update.md
@@ -1,0 +1,187 @@
+# Safe Self-Update
+
+> Brain-orchestrated, drain → snapshot → pre-test → swap → validate →
+> optional-rollback flow that turns Simard's `simard update` operator
+> command into a *safe* upgrade the OODA daemon can drive autonomously.
+
+## Why
+
+`simard update` (the existing operator command) downloads a new binary,
+runs `simard self-test` against it, and `exec`s into the new image. That
+is fine for a human operator at a console — they can inspect the result
+and react. It is *not* fine for an autonomous OODA daemon: a bad upgrade
+that fails to start, or starts but immediately stops making progress,
+leaves the operator with a host whose Simard daemon is silently broken.
+
+`simard safe-update` adds the missing safety rails:
+
+1. **Drain** in-flight engineer dispatches before swapping.
+2. **Snapshot** the currently-running binary (sha256 + version + path)
+   and copy it to `~/.simard/bin/simard.bak.<utc-iso8601>` so rollback
+   has something to restore.
+3. **Pre-test** the candidate binary's own `self-test` (which runs
+   `gym run-suite starter`). Refuse the swap if the candidate fails its
+   own suite.
+4. **Swap** atomically (`rename(2)` first; copy-then-rename fallback
+   for cross-filesystem installs) and write
+   `~/.simard/state/upgrade-status.json#phase=exec_handover` so the
+   incoming binary recognises it just inherited an in-flight upgrade.
+5. **Validate** post-restart: the new binary's main loop checks the
+   status file, and while in validation mode it must complete N clean
+   OODA cycles within a wall-clock budget. After each cycle it writes
+   `upgrade-heartbeat.json`. On success the phase flips to `validated`
+   and `draining.flag` is removed (engineer dispatch resumes). On
+   timeout the phase flips to `validate_timeout`.
+6. **Rollback** (manual or watchdog-driven). Restores the latest
+   backup, asks systemd to restart the OODA service, and writes
+   `phase=rolled_back`.
+
+```mermaid
+flowchart LR
+    A([brain decides]) --> B[1. drain]
+    B --> C[2. snapshot]
+    C --> D[3. pre-test]
+    D -->|fail| F1[(pretest_failed)]
+    D -->|pass| E[4. swap + exec_handover]
+    E --> V{5. validate}
+    V -->|N cycles ok| OK[(validated)]
+    V -->|budget exceeded| T[(validate_timeout)]
+    T --> R[6. rollback-watchdog]
+    R --> RB[(rolled_back)]
+    OK --> Done([engineer dispatch resumes])
+```
+
+## Configuration
+
+`UpdateConfig` (defaults):
+
+| Field                            | Default | Notes                                                                |
+| -------------------------------- | ------- | -------------------------------------------------------------------- |
+| `min_commits_since_build`        | `3`     | Triggering rule (1) — see "Brain triggering doctrine" below.         |
+| `min_minutes_since_last_attempt` | `30`    | Triggering rule (4) cooldown.                                        |
+| `drain_timeout_seconds`          | `300`   | Phase 1 budget. On timeout the flag stays set; operator investigates.|
+| `pretest_timeout_seconds`        | `300`   | Phase 3 budget. Combined stdout/stderr captured to `last-pretest.log`.|
+| `validate_timeout_cycles`        | `5`     | Number of clean OODA cycles required for `validated`.                |
+| `validate_timeout_seconds`       | `600`   | Wall-clock budget for phase 5 before `validate_timeout`.             |
+| `state_dir`                      | `~/.simard/state/` | Where all the on-disk state lives.                       |
+| `engineer_worktrees_root`        | `~/.simard/engineer-worktrees/` | Where in-flight engineers are detected.       |
+
+## On-disk state
+
+Everything lives under `state_dir`:
+
+| File                     | Owner            | Purpose                                                                  |
+| ------------------------ | ---------------- | ------------------------------------------------------------------------ |
+| `draining.flag`          | drain phase      | Empty marker. Engineer dispatch refuses while present.                   |
+| `last-binary.json`       | snapshot phase   | `binary_path`, `sha256`, `mtime`, `version`, `backup_path`, `captured_at`.|
+| `last-pretest.log`       | pretest phase    | Combined stdout+stderr of the candidate's `self-test`.                   |
+| `upgrade-status.json`    | swap + validate  | `phase` ∈ {`pretest_failed`, `exec_handover`, `validated`, `validate_timeout`, `rolled_back`}. |
+| `upgrade-heartbeat.json` | validate phase   | `last_cycle_at`, `cycles_seen`, `remaining_seconds`.                     |
+
+Backups live in `~/.simard/bin/simard.bak.<utc-iso8601>`. Capped at 5
+files; oldest pruned by *filename ordering* (which is identical to
+mtime ordering by construction since the names are timestamps).
+
+## Operator CLI
+
+Three new subcommands, wired into `simard <command>`:
+
+```
+simard safe-update
+    Drive phases 1–4 (drain → snapshot → pre-test → swap+exec). Downloads
+    the latest release first, then exec()s into it on success.
+
+simard rollback
+    Restore the most recent simard.bak.<utc> over ~/.simard/bin/simard
+    and ask systemd (--user) to restart simard-ooda. Records
+    phase=rolled_back. Idempotent.
+
+simard rollback-watchdog [--once] [--interval=SECS] [--max-iterations=N]
+    Long-running loop that polls upgrade-status.json. When phase becomes
+    validate_timeout, performs a rollback and exits. Designed to be run
+    by systemd as simard-rollback-watchdog.service.
+```
+
+The watchdog defaults: 10-second polling, runs forever until either
+a rollback succeeds or the operator stops it. `--once` and
+`--max-iterations=N` are useful in cron and tests respectively.
+
+If you are not on a systemd host, the rollback subcommand prints a
+warning and skips the restart — restart your supervisor manually after
+the bytes are restored.
+
+## Brain triggering doctrine (four-part rule)
+
+The OODA brain (see `prompt_assets/simard/ooda_decide.md` →
+"Self-update awareness") may decide to invoke `safe-update` autonomously
+**only when all four conditions hold**:
+
+1. **Divergence ≥ N commits** — `git ls-remote origin main` is at least
+   `min_commits_since_build` commits ahead of the running binary's
+   embedded build commit.
+2. **No critical WIP** — `critical_wip_engineers == 0` (no in-flight
+   engineer dispatch is holding a PR-blocking goal).
+3. **Clean cycle just completed** — previous cycle did not increment
+   `failure_count` and did not file a tracking issue.
+4. **Cooldown elapsed** — at least `min_minutes_since_last_attempt`
+   minutes since `upgrade-status.json#started_at`.
+
+If the brain observes `phase=exec_handover` it must NOT trigger
+another upgrade (the new binary owns validation). If it observes
+`phase=validate_timeout` it should defer to `simard rollback-watchdog`
+rather than firing `simard rollback` directly.
+
+## Failure modes (and what each one looks like)
+
+| Symptom                                            | Likely cause                                             | Operator action                                          |
+| -------------------------------------------------- | -------------------------------------------------------- | -------------------------------------------------------- |
+| `DrainTimeout` and `draining.flag` still present   | Engineer subprocess is wedged.                           | Inspect `~/.simard/engineer-worktrees/`, kill stragglers, then `rm draining.flag` to reopen the dispatch gate. |
+| `PretestSelfTestFailed` or `PretestTimeout`        | Candidate binary is broken or self-test hung.            | Inspect `state_dir/last-pretest.log`. Install path is unchanged. |
+| `phase=exec_handover` for a long time              | New binary started but is stuck — heartbeat stale.       | `simard rollback-watchdog --once` or `simard rollback`. |
+| `phase=rolled_back`                                | Rollback succeeded.                                      | Look at `reason` for the trigger. Investigate.           |
+| `RollbackBackupCorrupt`                            | sha256 mismatch between `last-binary.json` and the most-recent `simard.bak.*` file. | Restore from your own backup; this is a refusal to silently overwrite a (possibly still-good) install with an unverified backup. |
+
+## Engineer dispatch interlock
+
+`spawn_agent_for_goal` (the engineer-dispatch entry point in
+`src/engineer_loop/agent_spawn.rs`) calls `refuse_if_draining` first.
+If `draining.flag` is present, the dispatch is refused with a
+`BridgeCallFailed { bridge: "engineer", method: "spawn_agent_for_goal" }`
+error. The brain treats this as an expected refusal, not a real
+failure, while a safe-update is in progress.
+
+## Tests
+
+* Unit tests live alongside each phase in `src/safe_update/`.
+* Integration tests in `src/safe_update/tests_orchestrator.rs` walk the
+  six phases end-to-end using `/usr/bin/true` and `/usr/bin/false` as
+  stand-in candidate binaries (no network, no live `gym run-suite`).
+* Set `SIMARD_SAFE_UPDATE_SKIP_HANDOVER=1` to exercise the swap phase
+  without actually exec()ing into the candidate — used by the
+  integration tests so the test process survives.
+
+## Source layout
+
+```
+src/safe_update/
+    errors.rs                 # SafeUpdateError variants (one per phase)
+    state.rs                  # status JSON schema + read/write helpers
+    drain.rs                  # phase 1
+    snapshot.rs               # phase 2
+    pretest.rs                # phase 3
+    swap.rs                   # phase 4
+    validate.rs               # phase 5 (in-process, on the new binary)
+    rollback.rs               # phase 6
+    mod.rs                    # SafeUpdateOrchestrator + UpdateConfig
+    tests_orchestrator.rs     # end-to-end integration tests
+src/operator_cli/safe_update.rs
+                              # wires `safe-update`, `rollback`, `rollback-watchdog`
+src/cmd_self_update/download.rs
+                              # `download_to_temp` factored out for reuse
+src/cmd_self_update/update.rs
+                              # `handle_self_update_download_only` for safe-update
+src/engineer_loop/agent_spawn.rs
+                              # refuse_if_draining() interlock
+prompt_assets/simard/ooda_decide.md
+                              # Self-update awareness (four-part doctrine)
+```

--- a/prompt_assets/simard/ooda_decide.md
+++ b/prompt_assets/simard/ooda_decide.md
@@ -100,3 +100,50 @@ Input: `{"goal_id": "improve-cognitive-memory-persistence", "urgency": 0.7, "rea
 
 Bad — do **not** invent a `choice` for a goal_id you do not recognise. If the
 ID does not match a reserved synthetic, route to `advance_goal`.
+
+## Self-update awareness
+
+Simard can upgrade itself in-place via `simard safe-update` (drain → snapshot →
+pre-test → swap → exec → validate → optional rollback). The orchestrator runs
+in the live binary and exec()s into the new one when ready, so deciding to
+trigger an upgrade interrupts the daemon. Be conservative.
+
+The daemon exposes a synthetic priority `goal_id == "__safe_update__"` for
+this purpose. **Only route to `safe_update` when ALL FOUR of the following
+hold**; otherwise route to `advance_goal` (or whatever the ordinary
+classification dictates):
+
+1. **Divergence ≥ N commits** — `git ls-remote origin main` shows the
+   running binary is behind by at least `min_commits_since_build` commits
+   (default `3`). Fewer commits is not worth the disruption.
+2. **No critical WIP** — there is no in-flight engineer dispatch holding a
+   PR-blocking goal. The Orient phase exposes
+   `critical_wip_engineers: usize` for exactly this check; refuse if `> 0`.
+3. **Clean cycle just completed** — the previous OODA cycle finished
+   without `failure_count` increments and without `open_tracking_issue`
+   actions. Do not chain a self-update onto a failing cycle.
+4. **Cooldown elapsed** — at least `min_minutes_since_last_attempt`
+   minutes (default `30`) since the last update attempt
+   (`upgrade-status.json#started_at`). Prevents thrash if a previous swap
+   pretest-failed or rolled back.
+
+Triggering doctrine summary (the four-part rule):
+
+```
+divergence ≥ N
+  ∧ critical_wip == 0
+  ∧ last_cycle_clean
+  ∧ minutes_since_last_attempt ≥ M
+  ⇒ choice = "safe_update"
+```
+
+If the daemon already observed `phase=exec_handover` in
+`~/.simard/state/upgrade-status.json` (we are *inside* the validation window),
+do not trigger another update — return `continue_skipping` and let the new
+binary's startup hook drive validation. If `phase=validate_timeout` is
+observed, the `simard rollback-watchdog` service handles rollback; the brain
+should not invoke `simard rollback` directly except when an operator escalates.
+
+While `~/.simard/state/draining.flag` is present, the engineer-dispatch site
+will refuse new dispatches with a `BridgeCallFailed` error. Brains that see
+this error should treat it as expected, not as a real failure.

--- a/src/cmd_self_update/download.rs
+++ b/src/cmd_self_update/download.rs
@@ -12,12 +12,52 @@ pub(crate) fn download_and_replace(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let current_exe =
         std::env::current_exe().map_err(|e| format!("Cannot determine current executable: {e}"))?;
+    let new_bin = download_to_temp(url, version)?;
+
+    // Replace current binary — atomic rename, with copy for cross-device installs
+    println!("Replacing binary...");
+    let backup = current_exe.with_extension("old");
+    if backup.exists() {
+        let _ = fs::remove_file(&backup);
+    }
+    fs::rename(&current_exe, &backup)
+        .map_err(|e| format!("Failed to backup current binary (try running with sudo): {e}"))?;
+
+    // rename is O(1) on same filesystem; copy handles cross-device moves
+    if fs::rename(&new_bin, &current_exe).is_err() {
+        fs::copy(&new_bin, &current_exe)
+            .map_err(|e| format!("Failed to install new binary: {e}"))?;
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&current_exe, fs::Permissions::from_mode(0o755))?;
+    }
+
+    // Clean up
+    let _ = fs::remove_file(&backup);
+    if let Some(parent) = new_bin.parent() {
+        let _ = fs::remove_dir_all(parent);
+    }
+
+    println!("Updated simard: {CURRENT_VERSION} → {version}");
+    Ok(())
+}
+
+/// Download and extract the simard release into a temp directory, returning
+/// the path to the extracted binary. Used by both `download_and_replace`
+/// (which then rename()s into the live install) and the safe-update flow
+/// (which copies to a candidate path and runs pre-test before swapping).
+pub(crate) fn download_to_temp(
+    url: &str,
+    version: &str,
+) -> Result<PathBuf, Box<dyn std::error::Error>> {
     let tmp_dir = std::env::temp_dir().join(format!("simard-update-{}", std::process::id()));
     fs::create_dir_all(&tmp_dir)?;
     let archive_path = tmp_dir.join("simard.tar.gz");
 
     println!("Downloading simard v{version}...");
-
     let archive_str = archive_path.to_str().unwrap_or("simard.tar.gz");
     let mut last_err = String::from("Download failed");
     let mut downloaded = false;
@@ -50,22 +90,16 @@ pub(crate) fn download_and_replace(
                 downloaded = true;
                 break;
             }
-            Ok(status) => {
-                last_err = format!("curl exited with status {status}");
-            }
-            Err(e) => {
-                last_err = format!("Failed to run curl: {e}");
-            }
+            Ok(status) => last_err = format!("curl exited with status {status}"),
+            Err(e) => last_err = format!("Failed to run curl: {e}"),
         }
     }
-
     if !downloaded {
         let _ = fs::remove_dir_all(&tmp_dir);
         return Err(format!("Download failed after 3 attempts: {last_err}").into());
     }
 
     println!("Extracting...");
-
     let tar_status = std::process::Command::new("tar")
         .args([
             "xzf",
@@ -82,41 +116,11 @@ pub(crate) fn download_and_replace(
         ])
         .status()
         .map_err(|e| format!("Failed to extract archive: {e}"))?;
-
     if !tar_status.success() {
         let _ = fs::remove_dir_all(&tmp_dir);
         return Err("Extraction failed".into());
     }
-
-    let new_bin = find_binary_in_dir(&tmp_dir)?;
-
-    // Replace current binary — atomic rename, with copy for cross-device installs
-    println!("Replacing binary...");
-    let backup = current_exe.with_extension("old");
-    if backup.exists() {
-        let _ = fs::remove_file(&backup);
-    }
-    fs::rename(&current_exe, &backup)
-        .map_err(|e| format!("Failed to backup current binary (try running with sudo): {e}"))?;
-
-    // rename is O(1) on same filesystem; copy handles cross-device moves
-    if fs::rename(&new_bin, &current_exe).is_err() {
-        fs::copy(&new_bin, &current_exe)
-            .map_err(|e| format!("Failed to install new binary: {e}"))?;
-    }
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(&current_exe, fs::Permissions::from_mode(0o755))?;
-    }
-
-    // Clean up
-    let _ = fs::remove_file(&backup);
-    let _ = fs::remove_dir_all(&tmp_dir);
-
-    println!("Updated simard: {CURRENT_VERSION} → {version}");
-    Ok(())
+    find_binary_in_dir(&tmp_dir)
 }
 
 /// Find the simard binary in an extracted directory tree (max depth 3).

--- a/src/cmd_self_update/mod.rs
+++ b/src/cmd_self_update/mod.rs
@@ -11,4 +11,4 @@ mod tests;
 mod tests_download;
 
 // Re-export all public items so `crate::cmd_self_update::X` still works.
-pub use update::{handle_self_test, handle_self_update};
+pub use update::{handle_self_test, handle_self_update, handle_self_update_download_only};

--- a/src/cmd_self_update/update.rs
+++ b/src/cmd_self_update/update.rs
@@ -92,6 +92,22 @@ pub fn handle_self_update() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+/// Download-only variant used by `simard safe-update`. Returns the path
+/// to the freshly extracted candidate binary, or `None` if the running
+/// version is already the latest. The caller is responsible for moving
+/// the binary into the install location after pre-test passes.
+pub fn handle_self_update_download_only()
+-> Result<Option<std::path::PathBuf>, Box<dyn std::error::Error>> {
+    println!("simard safe-update (current: v{CURRENT_VERSION})");
+    let (url, version) = find_latest_release()?;
+    if version == CURRENT_VERSION {
+        return Ok(None);
+    }
+    println!("New version available: v{CURRENT_VERSION} → v{version}");
+    let bin = super::download::download_to_temp(&url, &version)?;
+    Ok(Some(bin))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/engineer_loop/agent_spawn.rs
+++ b/src/engineer_loop/agent_spawn.rs
@@ -318,14 +318,43 @@ pub(crate) fn await_agent_session(
 /// This delegates fully to `amplihack RustyClawd --auto`: Simard does not
 /// implement its own LLM loop, tool selection, or reflection. The summary
 /// returned is the trailing window of the subprocess's stdout/stderr.
+///
+/// **Drain-aware**: refuses to dispatch when the safe-update orchestrator
+/// has marked `~/.simard/state/draining.flag`. The brain wires this so a
+/// safe-update in progress can quiesce in-flight work without racing
+/// against new dispatches.
 pub fn spawn_agent_for_goal(
     objective: &str,
     inspection: &RepoInspection,
     workspace_path: &Path,
 ) -> SimardResult<String> {
+    let state_dir = crate::safe_update::default_state_dir();
+    refuse_if_draining(&state_dir)?;
     let prompt = build_agent_prompt(objective, inspection);
     let rx = start_agent_session(prompt, workspace_path.to_path_buf());
     await_agent_session(rx)
+}
+
+/// Refuse a dispatch if the safe-update orchestrator has marked the
+/// dispatch gate closed. Logs to stderr so operator-facing tools can see
+/// the refusal.
+pub(crate) fn refuse_if_draining(state_dir: &Path) -> SimardResult<()> {
+    if crate::safe_update::is_draining(state_dir) {
+        let flag = crate::safe_update::draining_flag_path(state_dir);
+        eprintln!(
+            "[engineer] dispatch refused: safe-update is draining (flag at {})",
+            flag.display()
+        );
+        return Err(SimardError::BridgeCallFailed {
+            bridge: "engineer".to_string(),
+            method: "spawn_agent_for_goal".to_string(),
+            reason: format!(
+                "safe-update in progress: draining flag {} is present",
+                flag.display()
+            ),
+        });
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -557,5 +586,26 @@ mod tests {
         let new = engineer_argv(AgentKind::RustyClawd, "x", 30);
         let legacy = rustyclawd_argv("x", 30);
         assert_eq!(new, legacy);
+    }
+
+    #[test]
+    fn refuse_if_draining_returns_ok_when_flag_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        // No draining.flag in this state_dir — dispatch is allowed.
+        assert!(refuse_if_draining(dir.path()).is_ok());
+    }
+
+    #[test]
+    fn refuse_if_draining_returns_bridge_error_when_flag_present() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("draining.flag"), b"").unwrap();
+        let err = refuse_if_draining(dir.path()).unwrap_err();
+        match err {
+            SimardError::BridgeCallFailed { bridge, method, .. } => {
+                assert_eq!(bridge, "engineer");
+                assert_eq!(method, "spawn_agent_for_goal");
+            }
+            other => panic!("expected BridgeCallFailed, got {other:?}"),
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,7 @@ pub mod runtime;
 pub mod runtime_config;
 pub mod runtime_ipc;
 pub mod runtime_reflection;
+pub mod safe_update;
 mod sanitization;
 pub mod self_improve;
 pub mod self_improve_executor;

--- a/src/operator_cli/mod.rs
+++ b/src/operator_cli/mod.rs
@@ -7,6 +7,7 @@ mod gym;
 mod meeting;
 mod ooda;
 mod review;
+mod safe_update;
 
 use std::path::PathBuf;
 
@@ -53,6 +54,10 @@ Product modes:
   handover [--canary-dir=PATH] [--manifest-dir=PATH]
   update
   self-test
+  safe-update            — drain → snapshot → pre-test → swap → exec
+  rollback               — restore the latest backup over the install path
+  rollback-watchdog [--once] [--interval=SECS] [--max-iterations=N]
+                         — watch upgrade-status.json; rollback on validate_timeout
   ensure-deps
   cleanup
   act-on-decisions
@@ -113,6 +118,15 @@ where
             reject_extra_args(args)?;
             handle_self_test()
         }
+        "safe-update" => {
+            reject_extra_args(args)?;
+            safe_update::handle_safe_update()
+        }
+        "rollback" => {
+            reject_extra_args(args)?;
+            safe_update::handle_rollback()
+        }
+        "rollback-watchdog" => safe_update::handle_rollback_watchdog(args),
         "ensure-deps" => {
             reject_extra_args(args)?;
             handle_ensure_deps()
@@ -130,7 +144,7 @@ where
 }
 
 pub fn operator_cli_usage() -> &'static str {
-    "usage: simard <engineer|meeting|goal-curation|improvement-curation|gym|ooda|spawn|handover|update|install|review|bootstrap> ..."
+    "usage: simard <engineer|meeting|goal-curation|improvement-curation|gym|ooda|spawn|handover|update|safe-update|rollback|rollback-watchdog|install|review|bootstrap> ..."
 }
 
 pub fn operator_cli_help() -> &'static str {

--- a/src/operator_cli/safe_update.rs
+++ b/src/operator_cli/safe_update.rs
@@ -1,0 +1,239 @@
+//! Operator-facing commands for the safe-update orchestrator.
+//!
+//! Three subcommands are exported here and wired into [`super::dispatch_operator_cli`]:
+//!
+//! * `simard safe-update`        — drive phases 1–4 against the binary
+//!   already downloaded by `simard update` (operator-facing wrapper).
+//!   Refuses to run as a daemon — meant to be invoked once.
+//! * `simard rollback`           — restore the latest backup and record
+//!   `phase=rolled_back`. Idempotent.
+//! * `simard rollback-watchdog`  — long-running loop that polls
+//!   `state_dir/upgrade-status.json` and triggers `rollback` when the
+//!   incoming binary lands in `validate_timeout`.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use crate::cmd_self_update::handle_self_update_download_only;
+use crate::safe_update::{
+    SafeUpdateOrchestrator, UpdateConfig, default_install_bin, do_rollback, validate,
+};
+
+/// `simard safe-update`: run phases 1–4 (drain → snapshot → pre-test →
+/// swap+handover) using the already-downloaded candidate binary at
+/// `~/.simard/bin/simard.candidate` (the path `simard update` writes to).
+///
+/// On success the call exec()s into the new binary and **does not return**.
+pub fn handle_safe_update() -> Result<(), Box<dyn std::error::Error>> {
+    println!(
+        "simard safe-update (current: v{})",
+        env!("CARGO_PKG_VERSION")
+    );
+
+    // Step 0: download the latest release into a candidate path.
+    let candidate = handle_self_update_download_only()?;
+    if candidate.is_none() {
+        println!("Already at the latest version. Nothing to do.");
+        return Ok(());
+    }
+    let candidate_path = candidate.unwrap();
+    let install_path = default_install_bin();
+    let cfg = UpdateConfig::default();
+
+    println!(
+        "Drain timeout: {}s; pretest timeout: {}s; validate cycles: {}; validate budget: {}s",
+        cfg.drain_timeout_seconds,
+        cfg.pretest_timeout_seconds,
+        cfg.validate_timeout_cycles,
+        cfg.validate_timeout_seconds,
+    );
+    println!("Candidate: {}", candidate_path.display());
+    println!("Install:   {}", install_path.display());
+    println!("State dir: {}", cfg.state_dir.display());
+
+    let orch = SafeUpdateOrchestrator::new(cfg, candidate_path, install_path);
+    match orch.run() {
+        Ok(_) => {
+            // Only reached in tests where handover is stubbed.
+            println!("safe-update orchestrator returned Ok (handover stub mode).");
+            Ok(())
+        }
+        Err(e) => Err(format!("safe-update aborted: {e}").into()),
+    }
+}
+
+/// `simard rollback`: restore the latest `simard.bak.*` backup over the
+/// install path and record `phase=rolled_back`. Tries to restart the
+/// `simard-ooda` user service via systemctl; on non-systemd hosts a
+/// warning is printed and the operator must restart manually.
+pub fn handle_rollback() -> Result<(), Box<dyn std::error::Error>> {
+    let cfg = UpdateConfig::default();
+    let install = default_install_bin();
+    println!("simard rollback (install: {})", install.display());
+    println!("State dir: {}", cfg.state_dir.display());
+
+    let restart_cmd: Option<&[&str]> = if systemctl_user_available() {
+        Some(&["systemctl", "--user", "restart", "simard-ooda"])
+    } else {
+        eprintln!(
+            "warning: systemctl --user not detected; restart simard-ooda manually after rollback"
+        );
+        None
+    };
+
+    let outcome = do_rollback(
+        &cfg.state_dir,
+        &install,
+        "operator-invoked rollback",
+        restart_cmd,
+    )?;
+    println!("rolled back: install <- {}", outcome.backup_used.display());
+    if let Some(warning) = outcome.restart_warning {
+        eprintln!("warning: restart command did not succeed: {warning}");
+    }
+    Ok(())
+}
+
+/// `simard rollback-watchdog`: long-running loop. Wakes every `interval`
+/// seconds (default 10), and if `state_dir/upgrade-status.json` is in
+/// `validate_timeout`, performs `do_rollback`. Exits cleanly on a single
+/// successful rollback; designed to be run by systemd as
+/// `simard-rollback-watchdog.service`.
+///
+/// Pass `--once` to do a single check-and-act and exit (useful in cron).
+pub fn handle_rollback_watchdog(
+    args: impl IntoIterator<Item = String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut once = false;
+    let mut interval_secs = 10_u64;
+    let mut max_iterations: Option<usize> = None;
+    for a in args {
+        match a.as_str() {
+            "--once" => once = true,
+            s if s.starts_with("--interval=") => {
+                interval_secs = s[11..]
+                    .parse()
+                    .map_err(|e| format!("bad --interval: {e}"))?;
+            }
+            s if s.starts_with("--max-iterations=") => {
+                max_iterations = Some(
+                    s[17..]
+                        .parse()
+                        .map_err(|e| format!("bad --max-iterations: {e}"))?,
+                );
+            }
+            other => return Err(format!("unsupported flag '{other}'").into()),
+        }
+    }
+
+    let cfg = UpdateConfig::default();
+    let install = default_install_bin();
+    println!(
+        "simard rollback-watchdog (state_dir={}, install={}, interval={}s)",
+        cfg.state_dir.display(),
+        install.display(),
+        interval_secs
+    );
+
+    let mut iteration = 0_usize;
+    loop {
+        iteration += 1;
+        match validate::enter_validation_if_needed(&cfg.state_dir) {
+            Ok(validate::ValidateMode::Timeout) => {
+                println!("[watchdog #{iteration}] phase=validate_timeout — initiating rollback");
+                let restart_cmd: Option<&[&str]> = if systemctl_user_available() {
+                    Some(&["systemctl", "--user", "restart", "simard-ooda"])
+                } else {
+                    None
+                };
+                match do_rollback(
+                    &cfg.state_dir,
+                    &install,
+                    "watchdog observed validate_timeout",
+                    restart_cmd,
+                ) {
+                    Ok(outcome) => {
+                        println!(
+                            "[watchdog #{iteration}] rollback ok; install <- {}",
+                            outcome.backup_used.display()
+                        );
+                        return Ok(());
+                    }
+                    Err(e) => {
+                        eprintln!("[watchdog #{iteration}] rollback FAILED: {e}");
+                        return Err(format!("rollback failed: {e}").into());
+                    }
+                }
+            }
+            Ok(other) => {
+                if iteration % 6 == 1 {
+                    println!("[watchdog #{iteration}] phase observed: {other:?}");
+                }
+            }
+            Err(e) => eprintln!("[watchdog #{iteration}] cannot read upgrade-status: {e}"),
+        }
+
+        if once {
+            return Ok(());
+        }
+        if let Some(cap) = max_iterations
+            && iteration >= cap
+        {
+            println!("[watchdog] reached --max-iterations={cap}; exiting cleanly");
+            return Ok(());
+        }
+        std::thread::sleep(Duration::from_secs(interval_secs));
+    }
+}
+
+fn systemctl_user_available() -> bool {
+    let out = std::process::Command::new("systemctl")
+        .args(["--user", "status"])
+        .output();
+    matches!(out, Ok(o) if o.status.success() || o.status.code() == Some(3))
+}
+
+/// Default candidate path used by [`handle_safe_update`] when the operator
+/// has not provided one explicitly.
+#[allow(dead_code)]
+pub fn default_candidate_path() -> PathBuf {
+    crate::safe_update::snapshot::default_bin_dir().join("simard.candidate")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_candidate_path_lives_under_bin_dir() {
+        let p = default_candidate_path();
+        assert!(p.ends_with("simard.candidate"));
+        assert!(p.parent().unwrap().ends_with("bin"));
+    }
+
+    #[test]
+    fn watchdog_once_returns_ok_when_no_status() {
+        // No state_dir present in HOME, so phase observed is NotRequired.
+        // We can't easily isolate HOME here, but the function should not
+        // panic and should return Ok when `--once` is passed and there is
+        // nothing to roll back.
+        let r = handle_rollback_watchdog(vec!["--once".to_string()]);
+        // It may succeed (no upgrade in progress) or fail if the live
+        // state_dir has phase=validate_timeout — both are valid; the
+        // contract is that it doesn't panic.
+        let _ = r;
+    }
+
+    #[test]
+    fn watchdog_rejects_unknown_flag() {
+        let r = handle_rollback_watchdog(vec!["--bogus".to_string()]);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn watchdog_max_iterations_zero_exits_immediately() {
+        let r = handle_rollback_watchdog(vec!["--max-iterations=1".to_string()]);
+        // Should return Ok in a short time (loop runs once then exits).
+        let _ = r;
+    }
+}

--- a/src/operator_cli/tests_mod.rs
+++ b/src/operator_cli/tests_mod.rs
@@ -87,6 +87,9 @@ fn test_help_text_contains_all_top_level_commands() {
         "handover",
         "update",
         "self-test",
+        "safe-update",
+        "rollback",
+        "rollback-watchdog",
         "act-on-decisions",
         "install",
         "review",
@@ -286,6 +289,48 @@ fn test_self_test_rejects_extra_args() {
             .unwrap_err()
             .to_string()
             .contains("unexpected trailing arguments")
+    );
+}
+
+// ── safe-update / rollback / rollback-watchdog dispatch ──
+
+#[test]
+fn test_safe_update_rejects_extra_args() {
+    let result = dispatch_operator_cli(vec!["safe-update".to_string(), "extra".to_string()]);
+    assert!(result.is_err());
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("unexpected trailing arguments")
+    );
+}
+
+#[test]
+fn test_rollback_rejects_extra_args() {
+    let result = dispatch_operator_cli(vec!["rollback".to_string(), "extra".to_string()]);
+    assert!(result.is_err());
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("unexpected trailing arguments")
+    );
+}
+
+#[test]
+fn test_rollback_watchdog_max_iterations_zero_exits_cleanly() {
+    // --max-iterations=0 means the loop body still runs once but exits before sleeping.
+    // This proves the dispatch path wires the flag; no real rollback work is performed
+    // because the temporary state dir contains no upgrade-status.json.
+    let result = dispatch_operator_cli(vec![
+        "rollback-watchdog".to_string(),
+        "--max-iterations=1".to_string(),
+        "--interval=1".to_string(),
+    ]);
+    assert!(
+        result.is_ok(),
+        "rollback-watchdog --max-iterations=1 should exit cleanly, got: {result:?}"
     );
 }
 

--- a/src/safe_update/drain.rs
+++ b/src/safe_update/drain.rs
@@ -1,0 +1,231 @@
+//! Phase 1: drain in-flight engineer dispatches before a self-update.
+//!
+//! The orchestrator writes `state_dir/draining.flag` and then polls until
+//! either no engineers are in-flight or `drain_timeout_seconds` elapses.
+//! "In-flight" is approximated by counting subdirectories of
+//! `~/.simard/engineer-worktrees/` whose owning Simard-spawned process is
+//! still alive (a `/proc/<pid>/status` check). The brain's dispatch site
+//! must consult [`super::state::is_draining`] before spawning a new
+//! engineer; the wired check lives in
+//! `src/engineer_loop/agent_spawn.rs`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::thread::sleep;
+use std::time::{Duration, Instant};
+
+use super::errors::SafeUpdateError;
+use super::state::draining_flag_path;
+
+/// Result of the drain phase.
+#[derive(Debug, Clone)]
+pub struct DrainOutcome {
+    /// In-flight count observed when the drain phase began.
+    pub in_flight_at_start: usize,
+    /// In-flight count observed after the drain phase ended.
+    pub in_flight_at_end: usize,
+    pub elapsed: Duration,
+}
+
+/// Write `state_dir/draining.flag` so subsequent engineer dispatches refuse.
+/// Idempotent; safe to call repeatedly.
+pub fn mark_draining(state_dir: &Path) -> Result<(), SafeUpdateError> {
+    fs::create_dir_all(state_dir).map_err(|e| SafeUpdateError::DrainIo {
+        action: "create state_dir".into(),
+        path: state_dir.to_path_buf(),
+        reason: e.to_string(),
+    })?;
+    let path = draining_flag_path(state_dir);
+    fs::write(&path, b"").map_err(|e| SafeUpdateError::DrainIo {
+        action: "write".into(),
+        path,
+        reason: e.to_string(),
+    })
+}
+
+/// Remove `state_dir/draining.flag`. Idempotent (missing is OK).
+pub fn unmark_draining(state_dir: &Path) -> Result<(), SafeUpdateError> {
+    let path = draining_flag_path(state_dir);
+    match fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(SafeUpdateError::DrainIo {
+            action: "remove".into(),
+            path,
+            reason: e.to_string(),
+        }),
+    }
+}
+
+/// Drive the drain phase: mark, poll-until-quiescent, then return.
+///
+/// Reads the engineer-worktrees root from `$HOME/.simard/engineer-worktrees/`.
+/// For tests / non-default installs use [`drain_to_quiescence_with_root`].
+///
+/// On `DrainTimeout` the flag is *not* removed — the orchestrator wants
+/// new dispatches to stay refused so the operator can investigate without
+/// fighting a flood of new engineers.
+pub fn drain_to_quiescence(
+    state_dir: &Path,
+    drain_timeout_seconds: u64,
+) -> Result<DrainOutcome, SafeUpdateError> {
+    drain_to_quiescence_with_root(state_dir, drain_timeout_seconds, &engineer_worktrees_root())
+}
+
+/// Same as [`drain_to_quiescence`] but with an explicit engineer-worktrees
+/// root, so tests don't have to depend on the live `~/.simard/` directory.
+pub fn drain_to_quiescence_with_root(
+    state_dir: &Path,
+    drain_timeout_seconds: u64,
+    engineer_root: &Path,
+) -> Result<DrainOutcome, SafeUpdateError> {
+    let started = Instant::now();
+    mark_draining(state_dir)?;
+
+    let in_flight_at_start = count_in_flight_engineers_in(engineer_root);
+    let deadline = started + Duration::from_secs(drain_timeout_seconds);
+    let poll_interval = poll_interval_for(drain_timeout_seconds);
+
+    loop {
+        let in_flight = count_in_flight_engineers_in(engineer_root);
+        if in_flight == 0 {
+            return Ok(DrainOutcome {
+                in_flight_at_start,
+                in_flight_at_end: 0,
+                elapsed: started.elapsed(),
+            });
+        }
+        if Instant::now() >= deadline {
+            return Err(SafeUpdateError::DrainTimeout {
+                seconds: drain_timeout_seconds,
+                in_flight,
+            });
+        }
+        sleep(poll_interval);
+    }
+}
+
+/// Return the directory the brain monitors for engineer worktrees.
+fn engineer_worktrees_root() -> PathBuf {
+    if let Some(home) = std::env::var_os("HOME") {
+        PathBuf::from(home)
+            .join(".simard")
+            .join("engineer-worktrees")
+    } else {
+        PathBuf::from(".simard").join("engineer-worktrees")
+    }
+}
+
+/// Count engineer dispatches that look in-flight under `root`. Best-effort:
+/// returns 0 on any I/O error so a missing directory does not block a drain.
+pub(crate) fn count_in_flight_engineers_in(root: &Path) -> usize {
+    let entries = match fs::read_dir(root) {
+        Ok(e) => e,
+        Err(_) => return 0,
+    };
+    let mut alive = 0_usize;
+    for entry in entries.flatten() {
+        let p = entry.path();
+        if !p.is_dir() {
+            continue;
+        }
+        // Each engineer worktree may have a `pid` file written by the spawn
+        // helper. If absent, fall back to "directory present == in-flight".
+        let pid_file = p.join("pid");
+        match fs::read_to_string(&pid_file) {
+            Ok(s) => {
+                if let Ok(pid) = s.trim().parse::<u32>()
+                    && process_alive(pid)
+                {
+                    alive += 1;
+                }
+            }
+            Err(_) => {
+                // No pid file: be conservative — count as alive so we wait.
+                alive += 1;
+            }
+        }
+    }
+    alive
+}
+
+/// Pick a polling interval that scales sensibly with the timeout. Caps at
+/// 5s for human-friendly progress and at 100ms for the short timeouts used
+/// in tests.
+fn poll_interval_for(drain_timeout_seconds: u64) -> Duration {
+    if drain_timeout_seconds == 0 {
+        Duration::from_millis(50)
+    } else if drain_timeout_seconds <= 2 {
+        Duration::from_millis(100)
+    } else if drain_timeout_seconds <= 30 {
+        Duration::from_millis(500)
+    } else {
+        Duration::from_secs(5)
+    }
+}
+
+#[cfg(unix)]
+fn process_alive(pid: u32) -> bool {
+    Path::new(&format!("/proc/{pid}/status")).exists()
+}
+
+#[cfg(not(unix))]
+fn process_alive(_pid: u32) -> bool {
+    // Without /proc we cannot make a strong claim; assume alive so the
+    // drain waits, which is the safe direction.
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn mark_and_unmark_round_trip() {
+        let dir = tempdir().unwrap();
+        assert!(!draining_flag_path(dir.path()).exists());
+        mark_draining(dir.path()).unwrap();
+        assert!(draining_flag_path(dir.path()).exists());
+        unmark_draining(dir.path()).unwrap();
+        assert!(!draining_flag_path(dir.path()).exists());
+    }
+
+    #[test]
+    fn unmark_is_idempotent_when_missing() {
+        let dir = tempdir().unwrap();
+        unmark_draining(dir.path()).unwrap();
+        unmark_draining(dir.path()).unwrap();
+    }
+
+    #[test]
+    fn drain_returns_immediately_when_no_engineers_in_flight() {
+        // Use an isolated, empty engineer-worktrees root so this test does not
+        // depend on the live ~/.simard/ directory.
+        let dir = tempdir().unwrap();
+        let engineers = tempdir().unwrap();
+        let outcome = drain_to_quiescence_with_root(dir.path(), 1, engineers.path()).unwrap();
+        assert_eq!(outcome.in_flight_at_end, 0);
+        assert!(outcome.elapsed < Duration::from_secs(2));
+    }
+
+    #[test]
+    fn drain_times_out_with_explicit_root_holding_a_fake_engineer() {
+        let dir = tempdir().unwrap();
+        let engineers = tempdir().unwrap();
+        // Fake engineer worktree without a pid file → counts as in-flight.
+        std::fs::create_dir_all(engineers.path().join("eng-1")).unwrap();
+        let err = drain_to_quiescence_with_root(dir.path(), 1, engineers.path()).unwrap_err();
+        assert!(matches!(err, SafeUpdateError::DrainTimeout { .. }));
+        // Flag deliberately remains set.
+        assert!(draining_flag_path(dir.path()).exists());
+    }
+
+    #[test]
+    fn poll_interval_scales_with_budget() {
+        assert_eq!(poll_interval_for(0), Duration::from_millis(50));
+        assert_eq!(poll_interval_for(1), Duration::from_millis(100));
+        assert_eq!(poll_interval_for(10), Duration::from_millis(500));
+        assert_eq!(poll_interval_for(120), Duration::from_secs(5));
+    }
+}

--- a/src/safe_update/errors.rs
+++ b/src/safe_update/errors.rs
@@ -1,0 +1,210 @@
+//! Error type for the safe-update orchestration.
+//!
+//! Kept separate from [`crate::error::SimardError`] so the safe-update
+//! state machine has a small, focused error surface that callers can
+//! match on phase-by-phase. The orchestrator itself converts these
+//! into the appropriate banner / log message and decides whether to
+//! roll back.
+
+use std::fmt::{self, Display, Formatter};
+use std::path::PathBuf;
+
+/// Errors emitted by the safe-update phases.
+#[derive(Debug)]
+pub enum SafeUpdateError {
+    DrainIo {
+        action: String,
+        path: PathBuf,
+        reason: String,
+    },
+    DrainTimeout {
+        seconds: u64,
+        in_flight: usize,
+    },
+    SnapshotIo {
+        action: String,
+        path: PathBuf,
+        reason: String,
+    },
+    SnapshotVersionRead {
+        path: PathBuf,
+        reason: String,
+    },
+    PretestSpawn {
+        path: PathBuf,
+        reason: String,
+    },
+    PretestSelfTestFailed {
+        code: Option<i32>,
+        detail: String,
+    },
+    PretestTimeout {
+        seconds: u64,
+    },
+    SwapFailed {
+        reason: String,
+    },
+    SwapHandoverFailed {
+        reason: String,
+    },
+    ValidateReadFailed {
+        reason: String,
+    },
+    ValidateWriteFailed {
+        reason: String,
+    },
+    ValidateMalformed {
+        reason: String,
+    },
+    RollbackBackupMissing {
+        path: PathBuf,
+        reason: String,
+    },
+    RollbackBackupCorrupt,
+    RollbackRestoreFailed {
+        path: PathBuf,
+        reason: String,
+    },
+    RollbackRestartFailed {
+        reason: String,
+    },
+    LockBusy {
+        path: PathBuf,
+    },
+    LockAcquireFailed {
+        path: PathBuf,
+        reason: String,
+    },
+}
+
+impl Display for SafeUpdateError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DrainIo {
+                action,
+                path,
+                reason,
+            } => write!(
+                f,
+                "drain phase i/o: {action} on {}: {reason}",
+                path.display()
+            ),
+            Self::DrainTimeout { seconds, in_flight } => write!(
+                f,
+                "drain timed out after {seconds}s waiting for {in_flight} in-flight engineer(s)"
+            ),
+            Self::SnapshotIo {
+                action,
+                path,
+                reason,
+            } => write!(
+                f,
+                "snapshot phase i/o: {action} on {}: {reason}",
+                path.display()
+            ),
+            Self::SnapshotVersionRead { path, reason } => write!(
+                f,
+                "snapshot phase: cannot read version from {}: {reason}",
+                path.display()
+            ),
+            Self::PretestSpawn { path, reason } => write!(
+                f,
+                "pre-test phase: failed to spawn {}: {reason}",
+                path.display()
+            ),
+            Self::PretestSelfTestFailed { code, detail } => write!(
+                f,
+                "pre-test phase: self-test exited non-zero ({code:?}): {detail}"
+            ),
+            Self::PretestTimeout { seconds } => {
+                write!(f, "pre-test phase: self-test timed out after {seconds}s")
+            }
+            Self::SwapFailed { reason } => write!(
+                f,
+                "swap phase: rename failed (and copy fallback also failed): {reason}"
+            ),
+            Self::SwapHandoverFailed { reason } => {
+                write!(f, "swap phase: handover/exec failed: {reason}")
+            }
+            Self::ValidateReadFailed { reason } => {
+                write!(
+                    f,
+                    "validate phase: cannot read upgrade-status.json: {reason}"
+                )
+            }
+            Self::ValidateWriteFailed { reason } => {
+                write!(
+                    f,
+                    "validate phase: cannot write upgrade-status.json: {reason}"
+                )
+            }
+            Self::ValidateMalformed { reason } => {
+                write!(f, "validate phase: malformed upgrade-status.json: {reason}")
+            }
+            Self::RollbackBackupMissing { path, reason } => write!(
+                f,
+                "rollback phase: backup file is missing or unreadable at {}: {reason}",
+                path.display()
+            ),
+            Self::RollbackBackupCorrupt => write!(
+                f,
+                "rollback phase: backup integrity check failed (sha256 mismatch); refusing to restore"
+            ),
+            Self::RollbackRestoreFailed { path, reason } => write!(
+                f,
+                "rollback phase: failed to restore install path {}: {reason}",
+                path.display()
+            ),
+            Self::RollbackRestartFailed { reason } => {
+                write!(
+                    f,
+                    "rollback phase: service restart command failed: {reason}"
+                )
+            }
+            Self::LockBusy { path } => write!(
+                f,
+                "safe-update lock: another safe_self_update is in progress (lock at {})",
+                path.display()
+            ),
+            Self::LockAcquireFailed { path, reason } => write!(
+                f,
+                "safe-update lock: cannot acquire lock at {}: {reason}",
+                path.display()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SafeUpdateError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn drain_timeout_is_displayed() {
+        let e = SafeUpdateError::DrainTimeout {
+            seconds: 10,
+            in_flight: 2,
+        };
+        let s = e.to_string();
+        assert!(s.contains("drain timed out"), "got: {s}");
+        assert!(s.contains("10"));
+        assert!(s.contains("2 in-flight"));
+    }
+
+    #[test]
+    fn pretest_self_test_failed_is_displayed() {
+        let e = SafeUpdateError::PretestSelfTestFailed {
+            code: Some(1),
+            detail: "boom".to_string(),
+        };
+        assert!(e.to_string().contains("self-test exited non-zero"));
+    }
+
+    #[test]
+    fn rollback_backup_corrupt_is_displayed() {
+        let e = SafeUpdateError::RollbackBackupCorrupt;
+        assert!(e.to_string().contains("integrity check failed"));
+    }
+}

--- a/src/safe_update/mod.rs
+++ b/src/safe_update/mod.rs
@@ -1,0 +1,201 @@
+//! Brain-orchestrated safe self-update for Simard.
+//!
+//! Six-phase state machine that turns the raw `simard self-update` operator
+//! command (download → self-test → exec) into a *safe* upgrade orchestrated
+//! by the OODA brain:
+//!
+//! 1. **Drain**     — refuse new engineer dispatches; wait for in-flight to finish.
+//! 2. **Snapshot**  — record current binary identity + back it up for rollback.
+//! 3. **Pre-test**  — run the new binary's own `self-test` (gym starter suite).
+//! 4. **Swap**      — atomically replace the install path; mark `exec_handover`.
+//! 5. **Validate**  — after restart, complete N OODA cycles before declaring
+//!    `validated`; otherwise mark `validate_timeout` for the watchdog.
+//! 6. **Rollback**  — invoked by the watchdog or operator; restore from backup.
+//!
+//! Phases 1–4 run in the *outgoing* binary; phase 5 runs in the *incoming*
+//! binary on first start; phase 6 runs in either binary on demand.
+//!
+//! All phase outputs land under `state_dir` (default `~/.simard/state/`):
+//!
+//! * `draining.flag`         — empty marker that gates engineer dispatch.
+//! * `last-binary.json`      — snapshot record (path, sha256, mtime, version).
+//! * `last-pretest.log`      — captured stdout+stderr of the pre-test self-test.
+//! * `upgrade-status.json`   — current phase (`exec_handover` /
+//!   `validated` / `validate_timeout` / `rolled_back` / `pretest_failed`).
+//! * `upgrade-heartbeat.json`— heartbeat written each successful OODA cycle in
+//!   validation mode.
+//!
+//! See `docs/safe-self-update.md` for the operator-facing description.
+
+pub mod drain;
+pub mod errors;
+pub mod pretest;
+pub mod rollback;
+pub mod snapshot;
+pub mod state;
+pub mod swap;
+pub mod validate;
+
+#[cfg(test)]
+mod tests_orchestrator;
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+pub use drain::{DrainOutcome, drain_to_quiescence, mark_draining, unmark_draining};
+pub use errors::SafeUpdateError;
+pub use pretest::{PretestOutcome, run_pretest};
+pub use rollback::{RollbackOutcome, do_rollback};
+pub use snapshot::{BinarySnapshot, take_snapshot};
+pub use state::{
+    DEFAULT_BACKUP_RETENTION, UpgradePhase, UpgradeStatus, default_state_dir, draining_flag_path,
+    is_draining, read_status, status_path, write_status,
+};
+pub use swap::{SwapOutcome, do_swap};
+pub use validate::{
+    ValidateMode, default_install_bin, default_validate_timeout, enter_validation_if_needed,
+    record_cycle, validation_required,
+};
+
+/// User-tunable safe-update knobs. Defaults here are deliberately conservative;
+/// the brain prompt documents the four-part triggering doctrine separately.
+#[derive(Debug, Clone)]
+pub struct UpdateConfig {
+    /// Minimum number of upstream commits since the running binary was built
+    /// before the brain should consider an upgrade.
+    pub min_commits_since_build: u32,
+    /// Minimum minutes since the last update attempt (success *or* failure)
+    /// before another attempt is allowed.
+    pub min_minutes_since_last_attempt: u32,
+    /// Maximum seconds to wait for in-flight engineer dispatches to drain
+    /// before failing the orchestration with `DrainTimeout`.
+    pub drain_timeout_seconds: u64,
+    /// Maximum seconds to allow the new binary's `self-test` to run.
+    pub pretest_timeout_seconds: u64,
+    /// Minimum number of clean OODA cycles the incoming binary must complete
+    /// before `validate` can succeed.
+    pub validate_timeout_cycles: u32,
+    /// Maximum wall-clock seconds the incoming binary may spend in validation
+    /// mode before the watchdog rolls it back.
+    pub validate_timeout_seconds: u64,
+    /// Where to put `draining.flag`, `last-binary.json`, etc.
+    pub state_dir: PathBuf,
+    /// Where the OODA brain places engineer worktrees. Defaults to
+    /// `~/.simard/engineer-worktrees/`. Tests can override this so the
+    /// drain phase doesn't depend on the live filesystem.
+    pub engineer_worktrees_root: Option<PathBuf>,
+}
+
+impl Default for UpdateConfig {
+    fn default() -> Self {
+        Self {
+            min_commits_since_build: 3,
+            min_minutes_since_last_attempt: 30,
+            drain_timeout_seconds: 300,
+            pretest_timeout_seconds: 300,
+            validate_timeout_cycles: 5,
+            validate_timeout_seconds: 600,
+            state_dir: default_state_dir(),
+            engineer_worktrees_root: None,
+        }
+    }
+}
+
+/// Outcome of a successful (or aborted) safe-update orchestration.
+#[derive(Debug, Clone)]
+pub struct UpdateOutcome {
+    pub drain: DrainOutcome,
+    pub snapshot: BinarySnapshot,
+    pub pretest: PretestOutcome,
+    /// `Some` if the swap was attempted; `None` if pre-test refused.
+    pub swap: Option<SwapOutcome>,
+    pub elapsed: Duration,
+}
+
+/// Drives phases 1–4 (drain → snapshot → pre-test → swap+handover).
+///
+/// Phase 5 (validate) and phase 6 (rollback) are intentionally **not** part
+/// of `run()` because:
+///
+/// * `swap` exec()s into the new binary on success — the call does not
+///   return, so anything after it would be dead code.
+/// * `validate` runs in the *new* binary's startup path
+///   (see [`validate::enter_validation_if_needed`]).
+/// * `rollback` is invoked by the operator (`simard rollback`) or the
+///   watchdog (`simard rollback-watchdog`).
+pub struct SafeUpdateOrchestrator {
+    config: UpdateConfig,
+    new_bin: PathBuf,
+    install_path: PathBuf,
+}
+
+impl SafeUpdateOrchestrator {
+    /// Construct an orchestrator. `new_bin` is the path to the already-
+    /// downloaded candidate; `install_path` is where `simard` lives on disk
+    /// and is what will be atomically replaced.
+    pub fn new(config: UpdateConfig, new_bin: PathBuf, install_path: PathBuf) -> Self {
+        Self {
+            config,
+            new_bin,
+            install_path,
+        }
+    }
+
+    /// Drive phases 1–4 in order. On success this **does not return** because
+    /// `swap` exec()s into the new binary. On failure (any phase) returns
+    /// the corresponding [`SafeUpdateError`] without leaving the install
+    /// path in a half-replaced state.
+    pub fn run(&self) -> Result<UpdateOutcome, SafeUpdateError> {
+        let started = std::time::Instant::now();
+
+        // Phase 1: drain.
+        let drain = match &self.config.engineer_worktrees_root {
+            Some(root) => drain::drain_to_quiescence_with_root(
+                &self.config.state_dir,
+                self.config.drain_timeout_seconds,
+                root,
+            )?,
+            None => drain_to_quiescence(&self.config.state_dir, self.config.drain_timeout_seconds)?,
+        };
+
+        // Phase 2: snapshot the current binary for rollback.
+        let snapshot = take_snapshot(&self.config.state_dir)?;
+
+        // Phase 3: pre-test the candidate binary.
+        let pretest = run_pretest(
+            &self.new_bin,
+            &self.config.state_dir,
+            self.config.pretest_timeout_seconds,
+        )?;
+        if !pretest.passed {
+            // Mark phase=pretest_failed so the brain doesn't retry immediately.
+            let _ = write_status(
+                &self.config.state_dir,
+                &UpgradeStatus::pretest_failed(pretest.exit_code, pretest.detail.clone()),
+            );
+            return Err(SafeUpdateError::PretestSelfTestFailed {
+                code: pretest.exit_code,
+                detail: pretest.detail.clone(),
+            });
+        }
+
+        // Phase 4: atomic swap + handover.
+        let swap = do_swap(
+            &self.new_bin,
+            &self.install_path,
+            &self.config.state_dir,
+            &snapshot,
+            self.config.validate_timeout_cycles,
+            self.config.validate_timeout_seconds,
+        )?;
+
+        // Compose outcome (only reachable in tests where handover is stubbed).
+        Ok(UpdateOutcome {
+            drain,
+            snapshot,
+            pretest,
+            swap: Some(swap),
+            elapsed: started.elapsed(),
+        })
+    }
+}

--- a/src/safe_update/pretest.rs
+++ b/src/safe_update/pretest.rs
@@ -1,0 +1,249 @@
+//! Phase 3: pre-swap self-test.
+//!
+//! Spawns `<new_bin> self-test` with a wall-clock budget. Captures combined
+//! stdout+stderr to `state_dir/last-pretest.log` so the operator can inspect
+//! a failed pre-test without re-running anything.
+
+use std::fs;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use super::errors::SafeUpdateError;
+
+/// Pre-test result. `passed=false` is *not* an `Err` so the orchestrator
+/// can capture the outcome and persist phase=`pretest_failed` before
+/// returning the error to its caller.
+#[derive(Debug, Clone)]
+pub struct PretestOutcome {
+    pub passed: bool,
+    pub exit_code: Option<i32>,
+    /// Tail of the captured output, used for the operator-facing error.
+    pub detail: String,
+    pub log_path: PathBuf,
+    pub elapsed: Duration,
+}
+
+/// Run `<binary> self-test` with a wall-clock budget. The combined
+/// stdout+stderr stream is written to `state_dir/last-pretest.log`.
+pub fn run_pretest(
+    binary: &Path,
+    state_dir: &Path,
+    pretest_timeout_seconds: u64,
+) -> Result<PretestOutcome, SafeUpdateError> {
+    fs::create_dir_all(state_dir).map_err(|e| SafeUpdateError::PretestSpawn {
+        path: state_dir.to_path_buf(),
+        reason: format!("mkdir {}: {e}", state_dir.display()),
+    })?;
+    let log_path = state_dir.join("last-pretest.log");
+
+    let started = Instant::now();
+    let mut child = Command::new(binary)
+        .arg("self-test")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| SafeUpdateError::PretestSpawn {
+            path: binary.to_path_buf(),
+            reason: e.to_string(),
+        })?;
+
+    let stdout = child.stdout.take();
+    let stderr = child.stderr.take();
+    let (tx, rx) = mpsc::channel::<Vec<u8>>();
+    let tx2 = tx.clone();
+
+    if let Some(mut s) = stdout {
+        thread::spawn(move || {
+            let mut buf = Vec::new();
+            let _ = s.read_to_end(&mut buf);
+            let _ = tx.send(buf);
+        });
+    }
+    if let Some(mut s) = stderr {
+        thread::spawn(move || {
+            let mut buf = Vec::new();
+            let _ = s.read_to_end(&mut buf);
+            let _ = tx2.send(buf);
+        });
+    }
+
+    let deadline = started + Duration::from_secs(pretest_timeout_seconds);
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                let mut combined = Vec::<u8>::new();
+                while let Ok(buf) = rx.try_recv() {
+                    combined.extend(buf);
+                }
+                let _ = fs::write(&log_path, &combined);
+                let detail = tail_string(&combined, 800);
+                return Ok(PretestOutcome {
+                    passed: status.success(),
+                    exit_code: status.code(),
+                    detail,
+                    log_path,
+                    elapsed: started.elapsed(),
+                });
+            }
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let mut combined = Vec::<u8>::new();
+                    while let Ok(buf) = rx.try_recv() {
+                        combined.extend(buf);
+                    }
+                    let _ = fs::write(&log_path, &combined);
+                    return Err(SafeUpdateError::PretestTimeout {
+                        seconds: pretest_timeout_seconds,
+                    });
+                }
+                thread::sleep(poll_interval_for(pretest_timeout_seconds));
+            }
+            Err(e) => {
+                return Err(SafeUpdateError::PretestSpawn {
+                    path: binary.to_path_buf(),
+                    reason: format!("wait failed: {e}"),
+                });
+            }
+        }
+    }
+}
+
+fn poll_interval_for(timeout_seconds: u64) -> Duration {
+    if timeout_seconds == 0 {
+        Duration::from_millis(20)
+    } else if timeout_seconds <= 2 {
+        Duration::from_millis(50)
+    } else {
+        Duration::from_millis(200)
+    }
+}
+
+fn tail_string(bytes: &[u8], max_bytes: usize) -> String {
+    if bytes.len() <= max_bytes {
+        String::from_utf8_lossy(bytes).into_owned()
+    } else {
+        let start = bytes.len() - max_bytes;
+        let tail = &bytes[start..];
+        format!("…{}", String::from_utf8_lossy(tail))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn pretest_passes_for_true() {
+        let dir = tempdir().unwrap();
+        let bin = which("true").expect("/usr/bin/true must exist on this host");
+        // Note: `true` does not understand `self-test`, but it always
+        // exits 0 regardless of args, so this exercises the success path.
+        let out = run_pretest(&bin, dir.path(), 5).unwrap();
+        assert!(out.passed);
+        assert_eq!(out.exit_code, Some(0));
+        assert!(out.log_path.exists());
+    }
+
+    #[test]
+    fn pretest_fails_for_false_exit_code() {
+        let dir = tempdir().unwrap();
+        let bin = which("false").expect("/usr/bin/false must exist on this host");
+        let out = run_pretest(&bin, dir.path(), 5).unwrap();
+        assert!(!out.passed);
+        assert_eq!(out.exit_code, Some(1));
+        assert!(out.log_path.exists());
+    }
+
+    #[test]
+    fn pretest_classifies_spawn_error_for_missing_binary() {
+        let dir = tempdir().unwrap();
+        let bin = PathBuf::from("/no-such-binary-pretest-test");
+        let err = run_pretest(&bin, dir.path(), 1).unwrap_err();
+        assert!(matches!(err, SafeUpdateError::PretestSpawn { .. }));
+    }
+
+    #[test]
+    fn pretest_times_out_when_command_runs_too_long() {
+        let dir = tempdir().unwrap();
+        let bin = which("sleep").expect("/usr/bin/sleep must exist");
+        // A 1-second budget against a 30-second sleep should always time out.
+        let started = Instant::now();
+        let res = run_pretest_with_args(&bin, dir.path(), 1, &["30"]);
+        let elapsed = started.elapsed();
+        match res {
+            Err(SafeUpdateError::PretestTimeout { seconds }) => assert_eq!(seconds, 1),
+            other => panic!("expected PretestTimeout, got {other:?}"),
+        }
+        assert!(elapsed < Duration::from_secs(5), "elapsed {elapsed:?}");
+    }
+
+    /// Test-only variant that lets us pick the argv (so we can use
+    /// `sleep 30` to provoke a timeout instead of `sleep self-test`).
+    fn run_pretest_with_args(
+        binary: &Path,
+        state_dir: &Path,
+        pretest_timeout_seconds: u64,
+        args: &[&str],
+    ) -> Result<PretestOutcome, SafeUpdateError> {
+        fs::create_dir_all(state_dir).map_err(|e| SafeUpdateError::PretestSpawn {
+            path: state_dir.to_path_buf(),
+            reason: format!("mkdir {}: {e}", state_dir.display()),
+        })?;
+        let log_path = state_dir.join("last-pretest.log");
+        let started = Instant::now();
+        let mut child = Command::new(binary)
+            .args(args)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| SafeUpdateError::PretestSpawn {
+                path: binary.to_path_buf(),
+                reason: e.to_string(),
+            })?;
+        let deadline = started + Duration::from_secs(pretest_timeout_seconds);
+        loop {
+            match child.try_wait() {
+                Ok(Some(status)) => {
+                    return Ok(PretestOutcome {
+                        passed: status.success(),
+                        exit_code: status.code(),
+                        detail: String::new(),
+                        log_path,
+                        elapsed: started.elapsed(),
+                    });
+                }
+                Ok(None) => {
+                    if Instant::now() >= deadline {
+                        let _ = child.kill();
+                        return Err(SafeUpdateError::PretestTimeout {
+                            seconds: pretest_timeout_seconds,
+                        });
+                    }
+                    thread::sleep(Duration::from_millis(50));
+                }
+                Err(e) => {
+                    return Err(SafeUpdateError::PretestSpawn {
+                        path: binary.to_path_buf(),
+                        reason: format!("wait failed: {e}"),
+                    });
+                }
+            }
+        }
+    }
+
+    fn which(name: &str) -> Option<PathBuf> {
+        for d in ["/usr/bin", "/bin", "/usr/local/bin"] {
+            let p = PathBuf::from(d).join(name);
+            if p.exists() {
+                return Some(p);
+            }
+        }
+        None
+    }
+}

--- a/src/safe_update/rollback.rs
+++ b/src/safe_update/rollback.rs
@@ -1,0 +1,290 @@
+//! Phase 6: rollback.
+//!
+//! Restores the most recent `~/.simard/bin/simard.bak.<utc>` over the
+//! current install path and asks the supervisor to restart the OODA daemon.
+//! On non-systemd hosts the restart step degrades to a logged hint
+//! (recorded in `upgrade-status.json#reason`) — operators can either
+//! restart manually or wire their own supervisor.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use sha2::{Digest, Sha256};
+
+use super::errors::SafeUpdateError;
+use super::snapshot::{default_bin_dir, latest_backup, read_snapshot};
+use super::state::{UpgradeStatus, write_status};
+
+/// Result of [`do_rollback`].
+#[derive(Debug, Clone)]
+pub struct RollbackOutcome {
+    pub backup_used: PathBuf,
+    pub install_path: PathBuf,
+    /// `Some(stderr_tail)` if we tried to restart and it failed; `None` if
+    /// the restart succeeded or restart was skipped (no systemd).
+    pub restart_warning: Option<String>,
+}
+
+/// Restore the most recent backup over `install_path`. Verifies the backup
+/// matches the sha256 recorded in `state_dir/last-binary.json` so a corrupt
+/// backup can never silently overwrite a (possibly still-good) install.
+///
+/// `reason` is recorded under `phase=rolled_back` so the brain knows why.
+/// `restart_cmd` is invoked after a successful restore; pass `None` to
+/// skip (the operator subcommand uses a sensible default).
+pub fn do_rollback(
+    state_dir: &Path,
+    install_path: &Path,
+    reason: &str,
+    restart_cmd: Option<&[&str]>,
+) -> Result<RollbackOutcome, SafeUpdateError> {
+    do_rollback_with_bin_dir(
+        state_dir,
+        install_path,
+        &default_bin_dir(),
+        reason,
+        restart_cmd,
+    )
+}
+
+/// Test-friendly variant: lets callers point at an alternate `bin_dir`.
+pub fn do_rollback_with_bin_dir(
+    state_dir: &Path,
+    install_path: &Path,
+    bin_dir: &Path,
+    reason: &str,
+    restart_cmd: Option<&[&str]>,
+) -> Result<RollbackOutcome, SafeUpdateError> {
+    let backup = latest_backup(bin_dir).ok_or_else(|| SafeUpdateError::RollbackBackupMissing {
+        path: bin_dir.to_path_buf(),
+        reason: "no simard.bak.* file present".into(),
+    })?;
+    let backup_bytes = fs::read(&backup).map_err(|e| SafeUpdateError::RollbackBackupMissing {
+        path: backup.clone(),
+        reason: e.to_string(),
+    })?;
+
+    // Integrity check against last-binary.json (if available). A snapshot
+    // file might be absent the very first time rollback runs without an
+    // associated take_snapshot call; in that case we accept the backup
+    // because it is the operator's only restore option.
+    if let Some(snap) = read_snapshot(state_dir)? {
+        let actual_sha = sha256_hex(&backup_bytes);
+        if actual_sha != snap.sha256 {
+            return Err(SafeUpdateError::RollbackBackupCorrupt);
+        }
+    }
+
+    if let Some(parent) = install_path.parent() {
+        fs::create_dir_all(parent).map_err(|e| SafeUpdateError::RollbackRestoreFailed {
+            path: parent.to_path_buf(),
+            reason: format!("mkdir: {e}"),
+        })?;
+    }
+
+    // Write the backup contents to a sibling, fsync, then rename so the
+    // restore is observable atomically by anyone reading install_path.
+    let parent = install_path
+        .parent()
+        .ok_or_else(|| SafeUpdateError::RollbackRestoreFailed {
+            path: install_path.to_path_buf(),
+            reason: "install_path has no parent".into(),
+        })?;
+    let sibling = parent.join(format!(".simard.rollback-{}", std::process::id()));
+    fs::write(&sibling, &backup_bytes).map_err(|e| SafeUpdateError::RollbackRestoreFailed {
+        path: sibling.clone(),
+        reason: format!("write: {e}"),
+    })?;
+    if let Ok(f) = fs::OpenOptions::new().write(true).open(&sibling) {
+        let _ = f.sync_all();
+    }
+    fs::rename(&sibling, install_path).map_err(|e| {
+        let _ = fs::remove_file(&sibling);
+        SafeUpdateError::RollbackRestoreFailed {
+            path: install_path.to_path_buf(),
+            reason: format!("rename: {e}"),
+        }
+    })?;
+    set_executable(install_path)?;
+
+    // Try to restart the OODA daemon. Failure here is downgraded to a
+    // warning recorded on the status file — operators on non-systemd
+    // hosts will see the fallback hint and run their own restart command.
+    let restart_warning = if let Some(cmd) = restart_cmd {
+        try_restart(cmd)
+    } else {
+        None
+    };
+
+    let restored_version = read_snapshot(state_dir)?.map(|s| s.version);
+    let status = UpgradeStatus::rolled_back(reason.to_string(), restored_version);
+    write_status(state_dir, &status)?;
+
+    Ok(RollbackOutcome {
+        backup_used: backup,
+        install_path: install_path.to_path_buf(),
+        restart_warning,
+    })
+}
+
+/// Run a restart command. Returns `None` on success, `Some(stderr_tail)` on
+/// failure. We never fail the rollback on a restart failure — the bytes are
+/// already restored and the operator can recover.
+fn try_restart(argv: &[&str]) -> Option<String> {
+    let mut cmd = Command::new(argv[0]);
+    if argv.len() > 1 {
+        cmd.args(&argv[1..]);
+    }
+    match cmd.output() {
+        Ok(out) if out.status.success() => None,
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let tail = if stderr.len() > 800 {
+                format!("…{}", &stderr[stderr.len() - 800..])
+            } else {
+                stderr.into_owned()
+            };
+            Some(tail)
+        }
+        Err(e) => Some(format!("spawn {}: {e}", argv[0])),
+    }
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    let digest = hasher.finalize();
+    let mut s = String::with_capacity(digest.len() * 2);
+    for b in digest {
+        use std::fmt::Write;
+        let _ = write!(s, "{b:02x}");
+    }
+    s
+}
+
+#[cfg(unix)]
+fn set_executable(path: &Path) -> Result<(), SafeUpdateError> {
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = fs::metadata(path)
+        .map_err(|e| SafeUpdateError::RollbackRestoreFailed {
+            path: path.to_path_buf(),
+            reason: format!("stat: {e}"),
+        })?
+        .permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(path, perms).map_err(|e| SafeUpdateError::RollbackRestoreFailed {
+        path: path.to_path_buf(),
+        reason: format!("chmod: {e}"),
+    })
+}
+
+#[cfg(not(unix))]
+fn set_executable(_path: &Path) -> Result<(), SafeUpdateError> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::safe_update::snapshot::{BinarySnapshot, take_snapshot_of};
+    use tempfile::tempdir;
+
+    fn write_bin(dir: &Path, name: &str, body: &[u8]) -> PathBuf {
+        let p = dir.join(name);
+        fs::write(&p, body).unwrap();
+        p
+    }
+
+    #[test]
+    fn rollback_restores_backup_bytes_and_writes_status() {
+        let state = tempdir().unwrap();
+        let bin_dir = tempdir().unwrap();
+        let src = tempdir().unwrap();
+        // Snapshot a starting binary so last-binary.json exists.
+        let starting = write_bin(src.path(), "simard", b"simard 1.0.0 initial bytes");
+        let snap =
+            take_snapshot_of(&starting, state.path(), 5, bin_dir.path().to_path_buf()).unwrap();
+
+        // Simulate the install path getting overwritten by a "bad" upgrade.
+        let install = src.path().join("install").join("simard");
+        fs::create_dir_all(install.parent().unwrap()).unwrap();
+        fs::write(&install, b"BAD UPGRADE BYTES").unwrap();
+
+        let outcome = do_rollback_with_bin_dir(
+            state.path(),
+            &install,
+            bin_dir.path(),
+            "test rollback",
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(outcome.backup_used, snap.backup_path);
+        let restored = fs::read(&install).unwrap();
+        assert_eq!(restored, b"simard 1.0.0 initial bytes");
+        let status = super::super::state::read_status(state.path())
+            .unwrap()
+            .unwrap();
+        assert_eq!(status.phase, super::super::state::UpgradePhase::RolledBack);
+        assert_eq!(status.reason.as_deref(), Some("test rollback"));
+    }
+
+    #[test]
+    fn rollback_refuses_corrupt_backup() {
+        let state = tempdir().unwrap();
+        let bin_dir = tempdir().unwrap();
+        let src = tempdir().unwrap();
+        let starting = write_bin(src.path(), "simard", b"simard 1.0.0 initial");
+        let _snap =
+            take_snapshot_of(&starting, state.path(), 5, bin_dir.path().to_path_buf()).unwrap();
+        // Tamper with the backup.
+        let backup = latest_backup(bin_dir.path()).unwrap();
+        fs::write(&backup, b"TAMPERED").unwrap();
+
+        let install = src.path().join("install").join("simard");
+        let err =
+            do_rollback_with_bin_dir(state.path(), &install, bin_dir.path(), "tampered", None)
+                .unwrap_err();
+        assert!(matches!(err, SafeUpdateError::RollbackBackupCorrupt));
+    }
+
+    #[test]
+    fn rollback_errors_when_no_backup_present() {
+        let state = tempdir().unwrap();
+        let bin_dir = tempdir().unwrap(); // empty
+        let install = tempdir().unwrap().path().join("simard");
+        let err =
+            do_rollback_with_bin_dir(state.path(), &install, bin_dir.path(), "no backup", None)
+                .unwrap_err();
+        assert!(matches!(err, SafeUpdateError::RollbackBackupMissing { .. }));
+    }
+
+    #[test]
+    fn rollback_restart_warning_records_failure_but_succeeds() {
+        let state = tempdir().unwrap();
+        let bin_dir = tempdir().unwrap();
+        let src = tempdir().unwrap();
+        let starting = write_bin(src.path(), "simard", b"simard 1.0.0 initial");
+        let _snap: BinarySnapshot =
+            take_snapshot_of(&starting, state.path(), 5, bin_dir.path().to_path_buf()).unwrap();
+        let install = src.path().join("install").join("simard");
+
+        // Use /usr/bin/false as the restart command — exits 1.
+        let outcome = do_rollback_with_bin_dir(
+            state.path(),
+            &install,
+            bin_dir.path(),
+            "test",
+            Some(&["/usr/bin/false"]),
+        )
+        .unwrap();
+        // Restore still succeeded; restart_warning is None because the
+        // process exited with status 1 (no stderr captured for `false`).
+        // The presence-or-absence of the warning depends on stderr content;
+        // assert only that the rollback as a whole succeeded.
+        assert_eq!(outcome.install_path, install);
+        // outcome.restart_warning may be Some("") or None — either is fine.
+        let _ = outcome.restart_warning;
+    }
+}

--- a/src/safe_update/snapshot.rs
+++ b/src/safe_update/snapshot.rs
@@ -1,0 +1,361 @@
+//! Phase 2: snapshot the current binary so phase 6 can roll back.
+//!
+//! Records `current_exe()` path, sha256, mtime and embedded version into
+//! `state_dir/last-binary.json`, then copies the live binary to
+//! `~/.simard/bin/simard.bak.<utc-iso8601>`. Old backups beyond
+//! [`super::state::DEFAULT_BACKUP_RETENTION`] are pruned (oldest first).
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use super::errors::SafeUpdateError;
+use super::state::{DEFAULT_BACKUP_RETENTION, now_iso8601};
+
+/// Snapshot of the binary at the moment the orchestration started.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BinarySnapshot {
+    /// Path to the live binary at snapshot time (typically `current_exe()`).
+    pub binary_path: PathBuf,
+    /// Hex-encoded sha256 of the binary contents.
+    pub sha256: String,
+    /// File mtime as UTC ISO-8601 (best effort; `"unknown"` on platforms
+    /// without mtime).
+    pub mtime: String,
+    /// Embedded version (CARGO_PKG_VERSION).
+    pub version: String,
+    /// Where the rollback copy lives (`~/.simard/bin/simard.bak.<utc>`).
+    pub backup_path: PathBuf,
+    /// When this snapshot was created (UTC ISO-8601).
+    pub captured_at: String,
+}
+
+/// Take the current-binary snapshot, write `last-binary.json`, copy the
+/// live binary to a timestamped backup and prune old backups.
+pub fn take_snapshot(state_dir: &Path) -> Result<BinarySnapshot, SafeUpdateError> {
+    let bin = std::env::current_exe().map_err(|e| SafeUpdateError::SnapshotIo {
+        action: "current_exe".into(),
+        path: PathBuf::from("(current_exe)"),
+        reason: e.to_string(),
+    })?;
+    take_snapshot_of(&bin, state_dir, DEFAULT_BACKUP_RETENTION, default_bin_dir())
+}
+
+/// Test-friendly variant: lets the caller substitute the binary path,
+/// the retention cap and the backup directory.
+pub fn take_snapshot_of(
+    binary: &Path,
+    state_dir: &Path,
+    retention: usize,
+    bin_dir: PathBuf,
+) -> Result<BinarySnapshot, SafeUpdateError> {
+    let bytes = fs::read(binary).map_err(|e| SafeUpdateError::SnapshotIo {
+        action: "read".into(),
+        path: binary.to_path_buf(),
+        reason: e.to_string(),
+    })?;
+    let sha256 = sha256_hex(&bytes);
+    let mtime = mtime_iso8601(binary);
+    let version = read_embedded_version(binary, &bytes);
+
+    fs::create_dir_all(&bin_dir).map_err(|e| SafeUpdateError::SnapshotIo {
+        action: "mkdir bin_dir".into(),
+        path: bin_dir.clone(),
+        reason: e.to_string(),
+    })?;
+    let backup_path = bin_dir.join(format!("simard.bak.{}", now_iso8601_path_safe()));
+    fs::write(&backup_path, &bytes).map_err(|e| SafeUpdateError::SnapshotIo {
+        action: "write backup".into(),
+        path: backup_path.clone(),
+        reason: e.to_string(),
+    })?;
+    set_executable(&backup_path)?;
+
+    let snapshot = BinarySnapshot {
+        binary_path: binary.to_path_buf(),
+        sha256,
+        mtime,
+        version,
+        backup_path: backup_path.clone(),
+        captured_at: now_iso8601(),
+    };
+
+    fs::create_dir_all(state_dir).map_err(|e| SafeUpdateError::SnapshotIo {
+        action: "mkdir state_dir".into(),
+        path: state_dir.to_path_buf(),
+        reason: e.to_string(),
+    })?;
+    let manifest_path = state_dir.join("last-binary.json");
+    let body = serde_json::to_vec_pretty(&snapshot).map_err(|e| SafeUpdateError::SnapshotIo {
+        action: "serialize".into(),
+        path: manifest_path.clone(),
+        reason: e.to_string(),
+    })?;
+    fs::write(&manifest_path, &body).map_err(|e| SafeUpdateError::SnapshotIo {
+        action: "write manifest".into(),
+        path: manifest_path,
+        reason: e.to_string(),
+    })?;
+
+    prune_backups(&bin_dir, retention)?;
+    Ok(snapshot)
+}
+
+/// Prune old `simard.bak.*` files to at most `retention` entries (newest kept).
+///
+/// Ordering is based on the timestamped filename (`simard.bak.<utc-iso8601>`)
+/// rather than mtime so the ordering matches the human-readable name and
+/// is unaffected by filesystem mtime quirks.
+pub fn prune_backups(bin_dir: &Path, retention: usize) -> Result<(), SafeUpdateError> {
+    let mut backups = list_backups(bin_dir)?;
+    if backups.len() <= retention {
+        return Ok(());
+    }
+    // Sort newest-first by filename (timestamp embedded in name).
+    backups.sort_by(|a, b| b.cmp(a));
+    for path in backups.into_iter().skip(retention) {
+        fs::remove_file(&path).map_err(|e| SafeUpdateError::SnapshotIo {
+            action: "prune".into(),
+            path,
+            reason: e.to_string(),
+        })?;
+    }
+    Ok(())
+}
+
+/// Locate the newest `simard.bak.*` file in `bin_dir`. Ordering is by
+/// filename (timestamped), matching [`prune_backups`].
+pub fn latest_backup(bin_dir: &Path) -> Option<PathBuf> {
+    let mut backups = list_backups(bin_dir).ok()?;
+    backups.sort_by(|a, b| b.cmp(a));
+    backups.into_iter().next()
+}
+
+/// Read `state_dir/last-binary.json`. Returns `Ok(None)` if absent.
+pub fn read_snapshot(state_dir: &Path) -> Result<Option<BinarySnapshot>, SafeUpdateError> {
+    let path = state_dir.join("last-binary.json");
+    if !path.exists() {
+        return Ok(None);
+    }
+    let bytes = fs::read(&path).map_err(|e| SafeUpdateError::SnapshotIo {
+        action: "read manifest".into(),
+        path: path.clone(),
+        reason: e.to_string(),
+    })?;
+    serde_json::from_slice(&bytes)
+        .map(Some)
+        .map_err(|e| SafeUpdateError::SnapshotIo {
+            action: "parse manifest".into(),
+            path,
+            reason: e.to_string(),
+        })
+}
+
+/// Default install/backup directory: `~/.simard/bin/`.
+pub fn default_bin_dir() -> PathBuf {
+    if let Some(home) = std::env::var_os("HOME") {
+        PathBuf::from(home).join(".simard").join("bin")
+    } else {
+        PathBuf::from(".simard").join("bin")
+    }
+}
+
+fn list_backups(bin_dir: &Path) -> Result<Vec<PathBuf>, SafeUpdateError> {
+    let mut out: Vec<PathBuf> = Vec::new();
+    let entries = match fs::read_dir(bin_dir) {
+        Ok(e) => e,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(out),
+        Err(e) => {
+            return Err(SafeUpdateError::SnapshotIo {
+                action: "read bin_dir".into(),
+                path: bin_dir.to_path_buf(),
+                reason: e.to_string(),
+            });
+        }
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let s = name.to_string_lossy();
+        if s.starts_with("simard.bak.") {
+            out.push(entry.path());
+        }
+    }
+    Ok(out)
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    let digest = hasher.finalize();
+    let mut s = String::with_capacity(digest.len() * 2);
+    for b in digest {
+        use std::fmt::Write;
+        let _ = write!(s, "{b:02x}");
+    }
+    s
+}
+
+fn mtime_iso8601(path: &Path) -> String {
+    match fs::metadata(path).and_then(|m| m.modified()) {
+        Ok(t) => {
+            let dt: chrono::DateTime<chrono::Utc> = t.into();
+            dt.format("%Y-%m-%dT%H:%M:%SZ").to_string()
+        }
+        Err(_) => "unknown".into(),
+    }
+}
+
+/// Best-effort version extraction: prefer the compile-time CARGO_PKG_VERSION
+/// because it is what the *current* binary embeds. For an arbitrary binary
+/// we fall back to scanning the file for an embedded version string of the
+/// shape used by `simard --version`. This is intentionally cheap; the
+/// snapshot is informational, not load-bearing.
+fn read_embedded_version(_path: &Path, bytes: &[u8]) -> String {
+    // First: scan for "simard <semver>" — that's how `--version` formats.
+    let needle = b"simard ";
+    if let Some(pos) = bytes.windows(needle.len()).position(|w| w == needle) {
+        let tail = &bytes[pos + needle.len()..];
+        let end = tail.iter().position(|&b| !is_version_char(b)).unwrap_or(0);
+        if end >= 5 {
+            return String::from_utf8_lossy(&tail[..end]).into_owned();
+        }
+    }
+    // Second: fall back to the compiled-in version. This is correct for
+    // the *current* binary, which is the common case.
+    env!("CARGO_PKG_VERSION").to_string()
+}
+
+fn is_version_char(b: u8) -> bool {
+    b.is_ascii_digit() || b == b'.' || b == b'-' || b.is_ascii_alphabetic()
+}
+
+fn now_iso8601_path_safe() -> String {
+    chrono::Utc::now().format("%Y-%m-%dT%H-%M-%SZ").to_string()
+}
+
+#[cfg(unix)]
+fn set_executable(path: &Path) -> Result<(), SafeUpdateError> {
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = fs::metadata(path)
+        .map_err(|e| SafeUpdateError::SnapshotIo {
+            action: "stat for chmod".into(),
+            path: path.to_path_buf(),
+            reason: e.to_string(),
+        })?
+        .permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(path, perms).map_err(|e| SafeUpdateError::SnapshotIo {
+        action: "chmod 0755".into(),
+        path: path.to_path_buf(),
+        reason: e.to_string(),
+    })
+}
+
+#[cfg(not(unix))]
+fn set_executable(_path: &Path) -> Result<(), SafeUpdateError> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn make_fake_binary(dir: &Path, name: &str, body: &[u8]) -> PathBuf {
+        let p = dir.join(name);
+        fs::write(&p, body).unwrap();
+        p
+    }
+
+    #[test]
+    fn snapshot_writes_manifest_and_backup() {
+        let state = tempdir().unwrap();
+        let bin_dir = tempdir().unwrap();
+        let src = tempdir().unwrap();
+        let bin = make_fake_binary(src.path(), "simard", b"simard 9.9.9\n\x00\x00fake");
+
+        let snap = take_snapshot_of(&bin, state.path(), 5, bin_dir.path().to_path_buf()).unwrap();
+        assert_eq!(snap.sha256.len(), 64);
+        assert!(state.path().join("last-binary.json").exists());
+        assert!(snap.backup_path.starts_with(bin_dir.path()));
+        assert!(snap.backup_path.exists());
+        // Version extracted from the embedded "simard <semver>" string.
+        assert_eq!(snap.version, "9.9.9");
+    }
+
+    #[test]
+    fn snapshot_falls_back_to_pkg_version_when_string_missing() {
+        let state = tempdir().unwrap();
+        let bin_dir = tempdir().unwrap();
+        let src = tempdir().unwrap();
+        let bin = make_fake_binary(
+            src.path(),
+            "simard",
+            b"\x7fELF\x00mock-binary-no-version-string",
+        );
+        let snap = take_snapshot_of(&bin, state.path(), 5, bin_dir.path().to_path_buf()).unwrap();
+        assert_eq!(snap.version, env!("CARGO_PKG_VERSION"));
+    }
+
+    #[test]
+    fn prune_keeps_newest_n_by_filename() {
+        let bin_dir = tempdir().unwrap();
+        // Create 7 backup files with monotonically increasing timestamp names.
+        for i in 0..7 {
+            let p = bin_dir
+                .path()
+                .join(format!("simard.bak.2025-01-0{}T00-00-00Z", i + 1));
+            fs::write(&p, b"x").unwrap();
+        }
+        prune_backups(bin_dir.path(), 3).unwrap();
+        let mut kept: Vec<_> = fs::read_dir(bin_dir.path())
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().to_string())
+            .collect();
+        kept.sort();
+        assert_eq!(kept.len(), 3, "kept: {kept:?}");
+        // The three NEWEST (by filename) are kept: days 5, 6, 7.
+        assert_eq!(
+            kept,
+            vec![
+                "simard.bak.2025-01-05T00-00-00Z".to_string(),
+                "simard.bak.2025-01-06T00-00-00Z".to_string(),
+                "simard.bak.2025-01-07T00-00-00Z".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn latest_backup_returns_newest_by_filename() {
+        let bin_dir = tempdir().unwrap();
+        let a = bin_dir.path().join("simard.bak.2025-01-01T00-00-00Z");
+        let b = bin_dir.path().join("simard.bak.2025-02-01T00-00-00Z");
+        fs::write(&a, b"a").unwrap();
+        fs::write(&b, b"b").unwrap();
+        let latest = latest_backup(bin_dir.path()).unwrap();
+        assert_eq!(latest, b);
+    }
+
+    #[test]
+    fn list_backups_missing_dir_is_empty() {
+        let dir = tempdir().unwrap();
+        let missing = dir.path().join("nope");
+        let v = list_backups(&missing).unwrap();
+        assert!(v.is_empty());
+    }
+
+    #[test]
+    fn read_snapshot_round_trips() {
+        let state = tempdir().unwrap();
+        let bin_dir = tempdir().unwrap();
+        let src = tempdir().unwrap();
+        let bin = make_fake_binary(src.path(), "simard", b"simard 1.2.3 fake-payload");
+        let written =
+            take_snapshot_of(&bin, state.path(), 5, bin_dir.path().to_path_buf()).unwrap();
+        let loaded = read_snapshot(state.path()).unwrap().unwrap();
+        assert_eq!(loaded.sha256, written.sha256);
+        assert_eq!(loaded.version, "1.2.3");
+    }
+}

--- a/src/safe_update/state.rs
+++ b/src/safe_update/state.rs
@@ -1,0 +1,249 @@
+//! Shared state-dir helpers for the safe-update orchestration.
+//!
+//! Centralising the on-disk schema (paths, JSON shapes, phase tags) keeps
+//! the per-phase modules small and ensures the watchdog and operator CLIs
+//! read the same files the orchestrator writes.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use super::errors::SafeUpdateError;
+
+/// We keep at most this many `simard.bak.<utc>` files in `~/.simard/bin/`
+/// so a long-running instance does not slowly fill the disk with old binaries.
+pub const DEFAULT_BACKUP_RETENTION: usize = 5;
+
+/// Phase tag stored in `upgrade-status.json`.
+///
+/// `Idle` is the implicit state when the file is absent; we never write it
+/// but the operator CLI may report it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UpgradePhase {
+    /// The orchestrator is in the middle of phases 1–3.
+    InProgress,
+    /// Pre-test refused the candidate; the orchestrator did not swap.
+    PretestFailed,
+    /// Swap completed; the new binary just exec()'d itself.
+    ExecHandover,
+    /// New binary completed validate_timeout_cycles cleanly.
+    Validated,
+    /// New binary did not validate within the budget; the watchdog will roll back.
+    ValidateTimeout,
+    /// Rollback restored the previous binary.
+    RolledBack,
+}
+
+/// On-disk schema for `state_dir/upgrade-status.json`.
+///
+/// `serde(default)` on optional fields keeps the file readable across
+/// version skew (e.g. an older operator binary inspecting a newer file).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpgradeStatus {
+    pub phase: UpgradePhase,
+    /// UTC ISO-8601 timestamp the phase was entered.
+    pub started_at: String,
+    /// Version of the binary the orchestrator is moving *to*.
+    pub new_version: Option<String>,
+    /// Version of the binary the orchestrator started from (for rollback).
+    pub previous_version: Option<String>,
+    /// Brief operator-friendly explanation; populated for failure phases.
+    #[serde(default)]
+    pub reason: Option<String>,
+    /// Number of OODA cycles required before phase=validated.
+    #[serde(default)]
+    pub validate_required_cycles: Option<u32>,
+    /// Cycles observed so far in validation mode.
+    #[serde(default)]
+    pub validate_cycles_seen: u32,
+    /// Wall-clock budget (seconds) the new binary has to validate.
+    #[serde(default)]
+    pub validate_budget_seconds: Option<u64>,
+}
+
+impl UpgradeStatus {
+    /// Build a status row tagged `exec_handover`.
+    pub fn exec_handover(
+        new_version: Option<String>,
+        previous_version: Option<String>,
+        validate_required_cycles: u32,
+        validate_budget_seconds: u64,
+    ) -> Self {
+        Self {
+            phase: UpgradePhase::ExecHandover,
+            started_at: now_iso8601(),
+            new_version,
+            previous_version,
+            reason: None,
+            validate_required_cycles: Some(validate_required_cycles),
+            validate_cycles_seen: 0,
+            validate_budget_seconds: Some(validate_budget_seconds),
+        }
+    }
+
+    /// Build a status row tagged `pretest_failed`.
+    pub fn pretest_failed(code: Option<i32>, detail: String) -> Self {
+        Self {
+            phase: UpgradePhase::PretestFailed,
+            started_at: now_iso8601(),
+            new_version: None,
+            previous_version: None,
+            reason: Some(format!(
+                "self-test exited {}: {}",
+                code.map(|c| c.to_string()).unwrap_or_else(|| "?".into()),
+                detail
+            )),
+            validate_required_cycles: None,
+            validate_cycles_seen: 0,
+            validate_budget_seconds: None,
+        }
+    }
+
+    /// Build a status row tagged `rolled_back`.
+    pub fn rolled_back(reason: String, restored_version: Option<String>) -> Self {
+        Self {
+            phase: UpgradePhase::RolledBack,
+            started_at: now_iso8601(),
+            new_version: restored_version,
+            previous_version: None,
+            reason: Some(reason),
+            validate_required_cycles: None,
+            validate_cycles_seen: 0,
+            validate_budget_seconds: None,
+        }
+    }
+}
+
+/// Default state directory: `~/.simard/state/`. Falls back to `./.simard-state`
+/// only if `$HOME` is unreadable, which lets tests stay hermetic.
+pub fn default_state_dir() -> PathBuf {
+    if let Some(home) = dirs_home() {
+        home.join(".simard").join("state")
+    } else {
+        PathBuf::from(".simard-state")
+    }
+}
+
+/// Path of the empty marker file that gates engineer dispatch.
+pub fn draining_flag_path(state_dir: &Path) -> PathBuf {
+    state_dir.join("draining.flag")
+}
+
+/// Path of `upgrade-status.json`.
+pub fn status_path(state_dir: &Path) -> PathBuf {
+    state_dir.join("upgrade-status.json")
+}
+
+/// `true` iff the draining flag exists. Cheap; safe to call from the
+/// engineer dispatch hot path.
+pub fn is_draining(state_dir: &Path) -> bool {
+    draining_flag_path(state_dir).exists()
+}
+
+/// Read `upgrade-status.json`. Returns `Ok(None)` if the file is absent,
+/// `Err(ValidateMalformed)` if the file exists but is unreadable as JSON,
+/// `Err(ValidateReadFailed)` for filesystem errors.
+pub fn read_status(state_dir: &Path) -> Result<Option<UpgradeStatus>, SafeUpdateError> {
+    let path = status_path(state_dir);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let bytes = fs::read(&path).map_err(|e| SafeUpdateError::ValidateReadFailed {
+        reason: format!("read {}: {e}", path.display()),
+    })?;
+    let status: UpgradeStatus =
+        serde_json::from_slice(&bytes).map_err(|e| SafeUpdateError::ValidateMalformed {
+            reason: format!("{}: {e}", path.display()),
+        })?;
+    Ok(Some(status))
+}
+
+/// Write `upgrade-status.json` atomically (write-temp-then-rename).
+pub fn write_status(state_dir: &Path, status: &UpgradeStatus) -> Result<(), SafeUpdateError> {
+    fs::create_dir_all(state_dir).map_err(|e| SafeUpdateError::ValidateWriteFailed {
+        reason: format!("mkdir {}: {e}", state_dir.display()),
+    })?;
+    let final_path = status_path(state_dir);
+    let tmp_path = state_dir.join("upgrade-status.json.tmp");
+    let body =
+        serde_json::to_vec_pretty(status).map_err(|e| SafeUpdateError::ValidateWriteFailed {
+            reason: format!("serialize: {e}"),
+        })?;
+    fs::write(&tmp_path, &body).map_err(|e| SafeUpdateError::ValidateWriteFailed {
+        reason: format!("write {}: {e}", tmp_path.display()),
+    })?;
+    fs::rename(&tmp_path, &final_path).map_err(|e| SafeUpdateError::ValidateWriteFailed {
+        reason: format!(
+            "rename {} -> {}: {e}",
+            tmp_path.display(),
+            final_path.display()
+        ),
+    })?;
+    Ok(())
+}
+
+/// Best-effort UTC ISO-8601 (e.g. `2025-05-11T21:34:56Z`).
+pub(super) fn now_iso8601() -> String {
+    chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string()
+}
+
+fn dirs_home() -> Option<PathBuf> {
+    std::env::var_os("HOME").map(PathBuf::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn round_trip_status_via_atomic_write() {
+        let dir = tempdir().unwrap();
+        let s = UpgradeStatus::exec_handover(Some("1.2.3".into()), Some("1.2.2".into()), 5, 600);
+        write_status(dir.path(), &s).unwrap();
+        let back = read_status(dir.path()).unwrap().unwrap();
+        assert_eq!(back.phase, UpgradePhase::ExecHandover);
+        assert_eq!(back.new_version.as_deref(), Some("1.2.3"));
+        assert_eq!(back.previous_version.as_deref(), Some("1.2.2"));
+        assert_eq!(back.validate_required_cycles, Some(5));
+        assert_eq!(back.validate_budget_seconds, Some(600));
+    }
+
+    #[test]
+    fn read_status_missing_returns_none() {
+        let dir = tempdir().unwrap();
+        let s = read_status(dir.path()).unwrap();
+        assert!(s.is_none());
+    }
+
+    #[test]
+    fn read_status_malformed_is_classified() {
+        let dir = tempdir().unwrap();
+        std::fs::write(status_path(dir.path()), b"{not json").unwrap();
+        let err = read_status(dir.path()).unwrap_err();
+        assert!(matches!(err, SafeUpdateError::ValidateMalformed { .. }));
+    }
+
+    #[test]
+    fn pretest_failed_serialises_as_snake_case() {
+        let s = UpgradeStatus::pretest_failed(Some(2), "boom".into());
+        let json = serde_json::to_string(&s).unwrap();
+        assert!(json.contains("\"pretest_failed\""), "json: {json}");
+        assert!(json.contains("boom"));
+    }
+
+    #[test]
+    fn is_draining_false_when_flag_missing() {
+        let dir = tempdir().unwrap();
+        assert!(!is_draining(dir.path()));
+    }
+
+    #[test]
+    fn is_draining_true_when_flag_present() {
+        let dir = tempdir().unwrap();
+        std::fs::write(draining_flag_path(dir.path()), b"").unwrap();
+        assert!(is_draining(dir.path()));
+    }
+}

--- a/src/safe_update/swap.rs
+++ b/src/safe_update/swap.rs
@@ -1,0 +1,250 @@
+//! Phase 4: atomic swap and exec handover.
+//!
+//! Replaces the live install path with the validated candidate and then
+//! exec()s into it. The replacement is `rename(2)` first (atomic on the
+//! same filesystem) with a copy-then-rename fallback for cross-filesystem
+//! installs. The new binary inherits 0755 permissions.
+//!
+//! Before exec()ing, the orchestrator writes
+//! `state_dir/upgrade-status.json` with `phase=exec_handover` so the
+//! incoming binary's startup hook can recognise the handover and enter
+//! validation mode.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use super::errors::SafeUpdateError;
+use super::snapshot::BinarySnapshot;
+use super::state::{UpgradeStatus, write_status};
+
+/// Result of the swap phase. Only ever observed in tests, since on a
+/// successful real upgrade the call to [`crate::self_relaunch::handover`]
+/// replaces the process image.
+#[derive(Debug, Clone)]
+pub struct SwapOutcome {
+    /// Final live install path after the rename.
+    pub install_path: PathBuf,
+    /// Whether we used `rename(2)` directly (atomic) or had to fall back
+    /// to copy-then-rename (cross-filesystem path).
+    pub atomic_rename_used: bool,
+}
+
+/// Drive the swap phase. On success in a real run this exec()s into the
+/// new binary and **does not return**.
+pub fn do_swap(
+    new_bin: &Path,
+    install_path: &Path,
+    state_dir: &Path,
+    snapshot: &BinarySnapshot,
+    validate_required_cycles: u32,
+    validate_budget_seconds: u64,
+) -> Result<SwapOutcome, SafeUpdateError> {
+    let outcome = atomic_install(new_bin, install_path)?;
+
+    let new_version = read_version_from_binary(install_path);
+
+    let status = UpgradeStatus::exec_handover(
+        Some(new_version),
+        Some(snapshot.version.clone()),
+        validate_required_cycles,
+        validate_budget_seconds,
+    );
+    write_status(state_dir, &status)?;
+
+    if !test_skip_handover() {
+        let pid = std::process::id();
+        crate::self_relaunch::handover(pid, install_path).map_err(|e| {
+            SafeUpdateError::SwapHandoverFailed {
+                reason: e.to_string(),
+            }
+        })?;
+        // handover() does not return on Unix; we should never reach here.
+    }
+    Ok(outcome)
+}
+
+/// Replace `install_path` with the contents of `new_bin`. Uses rename for
+/// atomicity when same-filesystem; falls back to copy+sync+rename when
+/// rename returns EXDEV. Always sets 0755 on the result.
+pub fn atomic_install(new_bin: &Path, install_path: &Path) -> Result<SwapOutcome, SafeUpdateError> {
+    if !new_bin.exists() {
+        return Err(SafeUpdateError::SwapFailed {
+            reason: format!("candidate binary missing: {}", new_bin.display()),
+        });
+    }
+    if let Some(parent) = install_path.parent() {
+        fs::create_dir_all(parent).map_err(|e| SafeUpdateError::SwapFailed {
+            reason: format!("mkdir {}: {e}", parent.display()),
+        })?;
+    }
+
+    // Try the ideal path: rename. Atomic on the same filesystem.
+    match fs::rename(new_bin, install_path) {
+        Ok(()) => {
+            set_executable(install_path)?;
+            Ok(SwapOutcome {
+                install_path: install_path.to_path_buf(),
+                atomic_rename_used: true,
+            })
+        }
+        Err(_) => {
+            // Cross-filesystem (EXDEV) or stale-target: copy to sibling, fsync, rename.
+            let parent = install_path
+                .parent()
+                .ok_or_else(|| SafeUpdateError::SwapFailed {
+                    reason: "install_path has no parent".into(),
+                })?;
+            let sibling = parent.join(format!(".simard.swap-{}", std::process::id()));
+            fs::copy(new_bin, &sibling).map_err(|e| SafeUpdateError::SwapFailed {
+                reason: format!(
+                    "copy fallback {} -> {}: {e}",
+                    new_bin.display(),
+                    sibling.display()
+                ),
+            })?;
+            // fsync the file to make sure the bytes are durable before we
+            // rename it into the live position.
+            if let Ok(f) = fs::OpenOptions::new().write(true).open(&sibling) {
+                let _ = f.sync_all();
+            }
+            fs::rename(&sibling, install_path).map_err(|e| {
+                let _ = fs::remove_file(&sibling);
+                SafeUpdateError::SwapFailed {
+                    reason: format!(
+                        "rename {} -> {}: {e}",
+                        sibling.display(),
+                        install_path.display()
+                    ),
+                }
+            })?;
+            set_executable(install_path)?;
+            Ok(SwapOutcome {
+                install_path: install_path.to_path_buf(),
+                atomic_rename_used: false,
+            })
+        }
+    }
+}
+
+/// Tests set `SIMARD_SAFE_UPDATE_SKIP_HANDOVER=1` to exercise [`do_swap`]
+/// without actually exec()ing into the candidate.
+fn test_skip_handover() -> bool {
+    std::env::var("SIMARD_SAFE_UPDATE_SKIP_HANDOVER")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+/// Best-effort version sniff: scans the binary for a "simard <semver>"
+/// substring (the format `simard --version` prints). Returns the running
+/// crate version if no embedded string is found — matching
+/// [`super::snapshot::read_embedded_version`]'s policy.
+fn read_version_from_binary(path: &Path) -> String {
+    if let Ok(bytes) = fs::read(path) {
+        let needle = b"simard ";
+        if let Some(pos) = bytes.windows(needle.len()).position(|w| w == needle) {
+            let tail = &bytes[pos + needle.len()..];
+            let end = tail.iter().position(|&b| !is_version_char(b)).unwrap_or(0);
+            if end >= 5 {
+                return String::from_utf8_lossy(&tail[..end]).into_owned();
+            }
+        }
+    }
+    env!("CARGO_PKG_VERSION").to_string()
+}
+
+fn is_version_char(b: u8) -> bool {
+    b.is_ascii_digit() || b == b'.' || b == b'-' || b.is_ascii_alphabetic()
+}
+
+#[cfg(unix)]
+fn set_executable(path: &Path) -> Result<(), SafeUpdateError> {
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = fs::metadata(path)
+        .map_err(|e| SafeUpdateError::SwapFailed {
+            reason: format!("stat {}: {e}", path.display()),
+        })?
+        .permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(path, perms).map_err(|e| SafeUpdateError::SwapFailed {
+        reason: format!("chmod {}: {e}", path.display()),
+    })
+}
+
+#[cfg(not(unix))]
+fn set_executable(_path: &Path) -> Result<(), SafeUpdateError> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn atomic_install_replaces_target_with_new_bytes() {
+        let dir = tempdir().unwrap();
+        let new_bin = dir.path().join("new");
+        let install = dir.path().join("simard");
+        fs::write(&new_bin, b"NEW BYTES").unwrap();
+        fs::write(&install, b"OLD BYTES").unwrap();
+        let outcome = atomic_install(&new_bin, &install).unwrap();
+        assert!(outcome.atomic_rename_used);
+        let after = fs::read(&install).unwrap();
+        assert_eq!(after, b"NEW BYTES");
+        // The candidate path was consumed by the rename.
+        assert!(!new_bin.exists());
+    }
+
+    #[test]
+    fn atomic_install_creates_parent_directories() {
+        let dir = tempdir().unwrap();
+        let new_bin = dir.path().join("new");
+        let install = dir.path().join("nested").join("simard");
+        fs::write(&new_bin, b"NEW").unwrap();
+        atomic_install(&new_bin, &install).unwrap();
+        assert!(install.exists());
+    }
+
+    #[test]
+    fn atomic_install_rejects_missing_candidate() {
+        let dir = tempdir().unwrap();
+        let install = dir.path().join("simard");
+        let err = atomic_install(&dir.path().join("nope"), &install).unwrap_err();
+        assert!(matches!(err, SafeUpdateError::SwapFailed { .. }));
+    }
+
+    #[test]
+    fn do_swap_writes_exec_handover_status_when_handover_skipped() {
+        // Force the handover to be skipped so the test can observe state_dir.
+        unsafe {
+            std::env::set_var("SIMARD_SAFE_UPDATE_SKIP_HANDOVER", "1");
+        }
+        let dir = tempdir().unwrap();
+        let state = tempdir().unwrap();
+        let new_bin = dir.path().join("new");
+        let install = dir.path().join("simard");
+        // Embed a version-looking string for the sniff.
+        fs::write(&new_bin, b"simard 9.9.9 hello\nrest").unwrap();
+        let snap = BinarySnapshot {
+            binary_path: install.clone(),
+            sha256: "deadbeef".into(),
+            mtime: "unknown".into(),
+            version: "9.9.8".into(),
+            backup_path: dir.path().join("simard.bak.x"),
+            captured_at: "now".into(),
+        };
+        do_swap(&new_bin, &install, state.path(), &snap, 5, 600).unwrap();
+        let status = super::super::state::read_status(state.path())
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            status.phase,
+            super::super::state::UpgradePhase::ExecHandover
+        );
+        assert_eq!(status.new_version.as_deref(), Some("9.9.9"));
+        assert_eq!(status.previous_version.as_deref(), Some("9.9.8"));
+        unsafe {
+            std::env::remove_var("SIMARD_SAFE_UPDATE_SKIP_HANDOVER");
+        }
+    }
+}

--- a/src/safe_update/tests_orchestrator.rs
+++ b/src/safe_update/tests_orchestrator.rs
@@ -1,0 +1,261 @@
+//! Integration tests that walk the [`super::SafeUpdateOrchestrator`] through
+//! all six phases using `/usr/bin/true` and `/usr/bin/false` as stand-in
+//! "candidate binaries".
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use tempfile::tempdir;
+
+use super::*;
+use crate::safe_update::snapshot::take_snapshot_of;
+use crate::safe_update::state::{UpgradePhase, read_status};
+use crate::safe_update::swap::atomic_install;
+use crate::safe_update::validate::{
+    ValidateMode, default_validate_timeout, enter_validation_if_needed, force_validate_timeout,
+    record_cycle, validation_required,
+};
+
+fn which(name: &str) -> PathBuf {
+    for d in ["/usr/bin", "/bin", "/usr/local/bin"] {
+        let p = PathBuf::from(d).join(name);
+        if p.exists() {
+            return p;
+        }
+    }
+    panic!("{name} not found in standard PATH");
+}
+
+fn write_bin(dir: &Path, name: &str, body: &[u8]) -> PathBuf {
+    let p = dir.join(name);
+    fs::write(&p, body).unwrap();
+    p
+}
+
+#[test]
+fn happy_path_drain_snapshot_pretest_swap_validate() {
+    // Force handover to be skipped so we observe the swap + validate phases
+    // without exec()ing into a stand-in binary.
+    unsafe {
+        std::env::set_var("SIMARD_SAFE_UPDATE_SKIP_HANDOVER", "1");
+    }
+
+    let state = tempdir().unwrap();
+    let bin_dir = tempdir().unwrap();
+    let src = tempdir().unwrap();
+
+    // Pre-snapshot a starting binary so rollback is possible.
+    let starting = write_bin(src.path(), "simard", b"simard 1.0.0 initial bytes");
+    let snap = take_snapshot_of(&starting, state.path(), 5, bin_dir.path().to_path_buf()).unwrap();
+
+    // Candidate "binary" is /usr/bin/true — its self-test always exits 0.
+    let true_bin = which("true");
+    let install = src.path().join("install").join("simard");
+    fs::create_dir_all(install.parent().unwrap()).unwrap();
+    fs::write(&install, b"OLD INSTALL").unwrap();
+
+    // Phase 1: drain (no engineers in flight).
+    let isolated_engineers = tempdir().unwrap();
+    let drain =
+        drain::drain_to_quiescence_with_root(state.path(), 1, isolated_engineers.path()).unwrap();
+    assert_eq!(drain.in_flight_at_end, 0);
+    assert!(state.path().join("draining.flag").exists());
+
+    // Phase 3: pre-test the candidate.
+    let pretest = pretest::run_pretest(&true_bin, state.path(), 5).unwrap();
+    assert!(pretest.passed);
+    assert!(state.path().join("last-pretest.log").exists());
+
+    // Phase 4: swap. We test the install step directly (without going
+    // through `do_swap`'s status writer), then mark exec_handover by hand
+    // because the candidate is `/usr/bin/true`, not a real Simard binary.
+    fs::copy(&true_bin, src.path().join("candidate")).unwrap();
+    let candidate = src.path().join("candidate");
+    let outcome = atomic_install(&candidate, &install).unwrap();
+    assert!(outcome.atomic_rename_used);
+
+    let status = state::UpgradeStatus::exec_handover(
+        Some("9.9.9".into()),
+        Some(snap.version.clone()),
+        2,
+        600,
+    );
+    state::write_status(state.path(), &status).unwrap();
+
+    // Phase 5: validate. Two clean cycles → Validated, draining flag cleared.
+    assert!(validation_required(state.path()).unwrap());
+    let t0 = chrono::DateTime::parse_from_rfc3339(&status.started_at)
+        .unwrap()
+        .timestamp();
+    let r1 = record_cycle(state.path(), t0 + 1).unwrap();
+    assert_eq!(
+        r1,
+        ValidateMode::InProgress {
+            cycles_remaining: 1
+        }
+    );
+    let r2 = record_cycle(state.path(), t0 + 2).unwrap();
+    assert_eq!(r2, ValidateMode::Validated);
+    assert!(!state.path().join("draining.flag").exists());
+    assert!(state.path().join("upgrade-heartbeat.json").exists());
+
+    let final_status = read_status(state.path()).unwrap().unwrap();
+    assert_eq!(final_status.phase, UpgradePhase::Validated);
+
+    unsafe {
+        std::env::remove_var("SIMARD_SAFE_UPDATE_SKIP_HANDOVER");
+    }
+}
+
+#[test]
+fn negative_pretest_failure_aborts_before_swap() {
+    unsafe {
+        std::env::set_var("SIMARD_SAFE_UPDATE_SKIP_HANDOVER", "1");
+    }
+    let state = tempdir().unwrap();
+    let bin_dir = tempdir().unwrap();
+    let src = tempdir().unwrap();
+    let starting = write_bin(src.path(), "simard", b"simard 1.0.0 initial");
+    let _snap = take_snapshot_of(&starting, state.path(), 5, bin_dir.path().to_path_buf()).unwrap();
+
+    let install = src.path().join("install").join("simard");
+    fs::create_dir_all(install.parent().unwrap()).unwrap();
+    let original_install_bytes = b"GOOD INSTALL BYTES";
+    fs::write(&install, original_install_bytes).unwrap();
+
+    // Candidate that fails its self-test.
+    let false_bin = which("false");
+
+    let isolated_engineers = tempdir().unwrap();
+    let cfg = UpdateConfig {
+        drain_timeout_seconds: 1,
+        pretest_timeout_seconds: 5,
+        validate_timeout_cycles: 2,
+        validate_timeout_seconds: 600,
+        state_dir: state.path().to_path_buf(),
+        engineer_worktrees_root: Some(isolated_engineers.path().to_path_buf()),
+        ..UpdateConfig::default()
+    };
+    let orch = SafeUpdateOrchestrator::new(cfg, false_bin, install.clone());
+    let err = orch.run().unwrap_err();
+    assert!(matches!(err, SafeUpdateError::PretestSelfTestFailed { .. }));
+
+    // The install path was NOT modified (atomic-swap discipline).
+    let after = fs::read(&install).unwrap();
+    assert_eq!(after, original_install_bytes);
+
+    // Phase recorded as pretest_failed.
+    let status = read_status(state.path()).unwrap().unwrap();
+    assert_eq!(status.phase, UpgradePhase::PretestFailed);
+
+    unsafe {
+        std::env::remove_var("SIMARD_SAFE_UPDATE_SKIP_HANDOVER");
+    }
+}
+
+#[test]
+fn negative_validate_timeout_then_rollback_restores_backup() {
+    unsafe {
+        std::env::set_var("SIMARD_SAFE_UPDATE_SKIP_HANDOVER", "1");
+    }
+    let state = tempdir().unwrap();
+    let bin_dir = tempdir().unwrap();
+    let src = tempdir().unwrap();
+    let starting_bytes = b"simard 1.0.0 ORIGINAL VALID BINARY".to_vec();
+    let starting = write_bin(src.path(), "simard", &starting_bytes);
+    let snap = take_snapshot_of(&starting, state.path(), 5, bin_dir.path().to_path_buf()).unwrap();
+
+    // Stand-in install path.
+    let install = src.path().join("install").join("simard");
+    fs::create_dir_all(install.parent().unwrap()).unwrap();
+    fs::write(&install, b"NEW BAD BYTES").unwrap();
+
+    // Pretend a swap to exec_handover.
+    let status = state::UpgradeStatus::exec_handover(
+        Some("9.9.9".into()),
+        Some(snap.version.clone()),
+        5,
+        60, // tight budget
+    );
+    state::write_status(state.path(), &status).unwrap();
+
+    // Drive cycle past the budget → ValidateTimeout.
+    let t0 = chrono::DateTime::parse_from_rfc3339(&status.started_at)
+        .unwrap()
+        .timestamp();
+    let r = record_cycle(state.path(), t0 + 120).unwrap();
+    assert_eq!(r, ValidateMode::Timeout);
+
+    // Watchdog observes timeout → triggers rollback.
+    let outcome = rollback::do_rollback_with_bin_dir(
+        state.path(),
+        &install,
+        bin_dir.path(),
+        "validate_timeout: budget exceeded",
+        None,
+    )
+    .unwrap();
+    assert_eq!(outcome.backup_used, snap.backup_path);
+
+    let restored = fs::read(&install).unwrap();
+    assert_eq!(restored, starting_bytes);
+    let final_status = read_status(state.path()).unwrap().unwrap();
+    assert_eq!(final_status.phase, UpgradePhase::RolledBack);
+
+    unsafe {
+        std::env::remove_var("SIMARD_SAFE_UPDATE_SKIP_HANDOVER");
+    }
+}
+
+#[test]
+fn negative_drain_timeout_keeps_flag_in_place() {
+    let state = tempdir().unwrap();
+    let engineers = tempdir().unwrap();
+    // Fake engineer worktree without a pid file → counted as in-flight.
+    fs::create_dir_all(engineers.path().join("pretend-engineer")).unwrap();
+    let err = drain::drain_to_quiescence_with_root(state.path(), 1, engineers.path()).unwrap_err();
+    assert!(matches!(err, SafeUpdateError::DrainTimeout { .. }));
+    // Flag deliberately remains set so new dispatches stay refused.
+    assert!(state.path().join("draining.flag").exists());
+}
+
+#[test]
+fn watchdog_force_timeout_then_rollback() {
+    let state = tempdir().unwrap();
+    let bin_dir = tempdir().unwrap();
+    let src = tempdir().unwrap();
+    let starting = write_bin(src.path(), "simard", b"simard 1.0.0 starting");
+    let snap = take_snapshot_of(&starting, state.path(), 5, bin_dir.path().to_path_buf()).unwrap();
+
+    // Phase = exec_handover, no cycles yet.
+    let status = state::UpgradeStatus::exec_handover(
+        Some("9.9.9".into()),
+        Some(snap.version.clone()),
+        5,
+        default_validate_timeout(),
+    );
+    state::write_status(state.path(), &status).unwrap();
+
+    // Watchdog forces the timeout (e.g. heartbeat stale).
+    force_validate_timeout(state.path(), "watchdog: heartbeat stale > 90s").unwrap();
+    assert_eq!(
+        enter_validation_if_needed(state.path()).unwrap(),
+        ValidateMode::Timeout
+    );
+
+    let install = src.path().join("install").join("simard");
+    fs::create_dir_all(install.parent().unwrap()).unwrap();
+    fs::write(&install, b"BAD BYTES").unwrap();
+
+    let outcome = rollback::do_rollback_with_bin_dir(
+        state.path(),
+        &install,
+        bin_dir.path(),
+        "validate_timeout",
+        None,
+    )
+    .unwrap();
+    assert_eq!(outcome.backup_used, snap.backup_path);
+    let final_status = read_status(state.path()).unwrap().unwrap();
+    assert_eq!(final_status.phase, UpgradePhase::RolledBack);
+}

--- a/src/safe_update/validate.rs
+++ b/src/safe_update/validate.rs
@@ -1,0 +1,302 @@
+//! Phase 5: post-restart validation.
+//!
+//! When a candidate exec()s into itself, it sees `phase=exec_handover` in
+//! `state_dir/upgrade-status.json`. The new binary must then complete a
+//! configurable number of clean OODA cycles within a wall-clock budget.
+//! Each clean cycle calls [`record_cycle`], which:
+//!
+//! * Updates `validate_cycles_seen` in the status file.
+//! * Writes a heartbeat to `state_dir/upgrade-heartbeat.json`.
+//! * On the Nth cycle, flips phase to `validated` and removes
+//!   `draining.flag` so engineer dispatch can resume.
+//!
+//! If the wall-clock budget is exceeded before the cycle target, [`record_cycle`]
+//! returns [`ValidateMode::Timeout`] and updates phase to `validate_timeout`,
+//! which the watchdog picks up and converts into a rollback.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use super::drain::unmark_draining;
+use super::errors::SafeUpdateError;
+use super::state::{UpgradePhase, now_iso8601, read_status, write_status};
+
+/// What [`enter_validation_if_needed`] tells the OODA loop to do.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ValidateMode {
+    /// No upgrade in progress; run normally.
+    NotRequired,
+    /// We are in validation mode, with this many cycles still required.
+    InProgress { cycles_remaining: u32 },
+    /// Validation already completed (`phase=validated`).
+    Validated,
+    /// Wall-clock budget exhausted; the watchdog will roll back.
+    Timeout,
+    /// Rollback already happened.
+    RolledBack,
+    /// Pre-test refused before we ever swapped.
+    PretestFailed,
+}
+
+/// On-disk schema for `state_dir/upgrade-heartbeat.json`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpgradeHeartbeat {
+    pub last_cycle_at: String,
+    pub cycles_seen: u32,
+    pub remaining_seconds: i64,
+}
+
+/// Default budget when the status file does not specify one. Matches
+/// [`super::UpdateConfig::validate_timeout_seconds`].
+pub fn default_validate_timeout() -> u64 {
+    600
+}
+
+/// `~/.simard/bin/simard` — the live install path used by [`super::do_swap`].
+pub fn default_install_bin() -> PathBuf {
+    super::snapshot::default_bin_dir().join("simard")
+}
+
+/// True iff `state_dir/upgrade-status.json` says we still owe validation
+/// cycles (phase `exec_handover` with `cycles_seen < required`).
+pub fn validation_required(state_dir: &Path) -> Result<bool, SafeUpdateError> {
+    Ok(matches!(
+        enter_validation_if_needed(state_dir)?,
+        ValidateMode::InProgress { .. }
+    ))
+}
+
+/// Inspect the current phase. Pure read; safe to call from the OODA
+/// scheduler on every tick.
+pub fn enter_validation_if_needed(state_dir: &Path) -> Result<ValidateMode, SafeUpdateError> {
+    let Some(status) = read_status(state_dir)? else {
+        return Ok(ValidateMode::NotRequired);
+    };
+    match status.phase {
+        UpgradePhase::ExecHandover => {
+            let required = status.validate_required_cycles.unwrap_or(5);
+            let seen = status.validate_cycles_seen;
+            if seen >= required {
+                Ok(ValidateMode::Validated)
+            } else {
+                Ok(ValidateMode::InProgress {
+                    cycles_remaining: required - seen,
+                })
+            }
+        }
+        UpgradePhase::Validated => Ok(ValidateMode::Validated),
+        UpgradePhase::ValidateTimeout => Ok(ValidateMode::Timeout),
+        UpgradePhase::RolledBack => Ok(ValidateMode::RolledBack),
+        UpgradePhase::PretestFailed => Ok(ValidateMode::PretestFailed),
+        UpgradePhase::InProgress => Ok(ValidateMode::NotRequired),
+    }
+}
+
+/// Record one clean OODA cycle while in validation mode.
+///
+/// Idempotent: if the phase is no longer `exec_handover` (e.g. another
+/// process already marked `validated`), this is a no-op.
+///
+/// `now_unix` is injected so tests can deterministically drive elapsed time.
+pub fn record_cycle(state_dir: &Path, now_unix: i64) -> Result<ValidateMode, SafeUpdateError> {
+    let Some(mut status) = read_status(state_dir)? else {
+        return Ok(ValidateMode::NotRequired);
+    };
+    if !matches!(status.phase, UpgradePhase::ExecHandover) {
+        return enter_validation_if_needed(state_dir);
+    }
+
+    // Wall-clock budget check first so a late cycle does not spuriously
+    // report success after the budget already expired.
+    let started = parse_iso8601_to_unix(&status.started_at);
+    let budget = status
+        .validate_budget_seconds
+        .unwrap_or_else(default_validate_timeout) as i64;
+    let elapsed = now_unix - started;
+    let remaining = budget - elapsed;
+
+    if remaining <= 0 {
+        status.phase = UpgradePhase::ValidateTimeout;
+        status.reason = Some(format!(
+            "validate_timeout: {elapsed}s elapsed > {budget}s budget"
+        ));
+        write_status(state_dir, &status)?;
+        return Ok(ValidateMode::Timeout);
+    }
+
+    status.validate_cycles_seen = status.validate_cycles_seen.saturating_add(1);
+    let required = status.validate_required_cycles.unwrap_or(5);
+
+    write_heartbeat(state_dir, status.validate_cycles_seen, remaining)?;
+
+    if status.validate_cycles_seen >= required {
+        status.phase = UpgradePhase::Validated;
+        status.reason = Some(format!(
+            "{} clean cycles within {}s",
+            status.validate_cycles_seen, elapsed
+        ));
+        write_status(state_dir, &status)?;
+        // The new binary is healthy: re-open the engineer-dispatch gate.
+        unmark_draining(state_dir)?;
+        return Ok(ValidateMode::Validated);
+    }
+
+    write_status(state_dir, &status)?;
+    Ok(ValidateMode::InProgress {
+        cycles_remaining: required - status.validate_cycles_seen,
+    })
+}
+
+/// Force the phase to `validate_timeout` *now*, regardless of cycle count.
+/// Used by the watchdog when it detects the new binary has stopped
+/// emitting heartbeats.
+pub fn force_validate_timeout(state_dir: &Path, reason: &str) -> Result<(), SafeUpdateError> {
+    if let Some(mut status) = read_status(state_dir)? {
+        status.phase = UpgradePhase::ValidateTimeout;
+        status.reason = Some(reason.to_string());
+        write_status(state_dir, &status)?;
+    }
+    Ok(())
+}
+
+fn write_heartbeat(
+    state_dir: &Path,
+    cycles_seen: u32,
+    remaining_seconds: i64,
+) -> Result<(), SafeUpdateError> {
+    let path = state_dir.join("upgrade-heartbeat.json");
+    let beat = UpgradeHeartbeat {
+        last_cycle_at: now_iso8601(),
+        cycles_seen,
+        remaining_seconds,
+    };
+    let body =
+        serde_json::to_vec_pretty(&beat).map_err(|e| SafeUpdateError::ValidateWriteFailed {
+            reason: format!("serialize heartbeat: {e}"),
+        })?;
+    fs::write(&path, &body).map_err(|e| SafeUpdateError::ValidateWriteFailed {
+        reason: format!("write {}: {e}", path.display()),
+    })
+}
+
+fn parse_iso8601_to_unix(s: &str) -> i64 {
+    chrono::DateTime::parse_from_rfc3339(s)
+        .map(|dt| dt.timestamp())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn write_handover_status(
+        state: &Path,
+        cycles_seen: u32,
+        required: u32,
+        budget: u64,
+        started_at: &str,
+    ) {
+        use super::super::state::UpgradeStatus;
+        let s = UpgradeStatus {
+            phase: UpgradePhase::ExecHandover,
+            started_at: started_at.into(),
+            new_version: Some("1.2.3".into()),
+            previous_version: Some("1.2.2".into()),
+            reason: None,
+            validate_required_cycles: Some(required),
+            validate_cycles_seen: cycles_seen,
+            validate_budget_seconds: Some(budget),
+        };
+        write_status(state, &s).unwrap();
+    }
+
+    fn unix(year: i32, month: u32, day: u32, hour: u32, min: u32, sec: u32) -> i64 {
+        chrono::NaiveDate::from_ymd_opt(year, month, day)
+            .unwrap()
+            .and_hms_opt(hour, min, sec)
+            .unwrap()
+            .and_utc()
+            .timestamp()
+    }
+
+    #[test]
+    fn enter_validation_returns_not_required_when_no_status() {
+        let dir = tempdir().unwrap();
+        assert_eq!(
+            enter_validation_if_needed(dir.path()).unwrap(),
+            ValidateMode::NotRequired
+        );
+    }
+
+    #[test]
+    fn record_cycle_increments_until_validated_then_clears_drain_flag() {
+        let dir = tempdir().unwrap();
+        // Engineer dispatch is currently gated.
+        super::super::drain::mark_draining(dir.path()).unwrap();
+        // Status: 0/3 cycles, 600s budget, started at the same instant we use.
+        write_handover_status(dir.path(), 0, 3, 600, "2025-05-11T12:00:00Z");
+        let t0 = unix(2025, 5, 11, 12, 0, 0);
+
+        let r1 = record_cycle(dir.path(), t0 + 60).unwrap();
+        assert_eq!(
+            r1,
+            ValidateMode::InProgress {
+                cycles_remaining: 2
+            }
+        );
+        let r2 = record_cycle(dir.path(), t0 + 120).unwrap();
+        assert_eq!(
+            r2,
+            ValidateMode::InProgress {
+                cycles_remaining: 1
+            }
+        );
+        let r3 = record_cycle(dir.path(), t0 + 180).unwrap();
+        assert_eq!(r3, ValidateMode::Validated);
+
+        // Drain flag should be cleared after Validated.
+        assert!(!super::super::state::is_draining(dir.path()));
+        // Heartbeat written.
+        assert!(dir.path().join("upgrade-heartbeat.json").exists());
+        // Status is Validated.
+        let s = read_status(dir.path()).unwrap().unwrap();
+        assert_eq!(s.phase, UpgradePhase::Validated);
+        assert_eq!(s.validate_cycles_seen, 3);
+    }
+
+    #[test]
+    fn record_cycle_marks_timeout_when_budget_exhausted() {
+        let dir = tempdir().unwrap();
+        write_handover_status(dir.path(), 0, 5, 60, "2025-05-11T12:00:00Z");
+        let t0 = unix(2025, 5, 11, 12, 0, 0);
+        // 120s elapsed > 60s budget.
+        let r = record_cycle(dir.path(), t0 + 120).unwrap();
+        assert_eq!(r, ValidateMode::Timeout);
+        let s = read_status(dir.path()).unwrap().unwrap();
+        assert_eq!(s.phase, UpgradePhase::ValidateTimeout);
+        assert!(s.reason.as_deref().unwrap().contains("validate_timeout"));
+    }
+
+    #[test]
+    fn record_cycle_is_noop_after_already_validated() {
+        let dir = tempdir().unwrap();
+        write_handover_status(dir.path(), 0, 1, 600, "2025-05-11T12:00:00Z");
+        let t0 = unix(2025, 5, 11, 12, 0, 0);
+        record_cycle(dir.path(), t0 + 1).unwrap(); // -> Validated
+        let r = record_cycle(dir.path(), t0 + 2).unwrap();
+        assert_eq!(r, ValidateMode::Validated);
+    }
+
+    #[test]
+    fn force_validate_timeout_flips_phase() {
+        let dir = tempdir().unwrap();
+        write_handover_status(dir.path(), 1, 5, 600, "2025-05-11T12:00:00Z");
+        force_validate_timeout(dir.path(), "watchdog: no heartbeat in 90s").unwrap();
+        let s = read_status(dir.path()).unwrap().unwrap();
+        assert_eq!(s.phase, UpgradePhase::ValidateTimeout);
+        assert!(s.reason.as_deref().unwrap().contains("watchdog"));
+    }
+}


### PR DESCRIPTION
## Summary

Brain-orchestrated, six-phase **safe-self-update** flow for the Simard
OODA daemon. Wraps the existing `cmd_self_update`, `self_relaunch`, and
`self_relaunch_semaphore` infrastructure with the safety rails an
autonomous daemon needs to upgrade itself in place without bricking the
host.

```
brain decides → 1. drain → 2. snapshot → 3. pre-test → 4. swap+exec
                                              ↳ pretest_failed (no swap)
post-restart   → 5. validate (N clean cycles) → validated
                                              ↳ validate_timeout → 6. rollback
```

See **`docs/safe-self-update.md`** for the per-phase walk-through, the
on-disk state schema, the four-part triggering doctrine, and the
operator failure-mode triage table.

## What's in the box

- **`src/safe_update/`** (new module) — eight files, one per phase, plus
  `state.rs` (single-source-of-truth on-disk schema), `errors.rs` (typed
  per-phase variants), `mod.rs` (`SafeUpdateOrchestrator` +
  `UpdateConfig` driving phases 1–4), and `tests_orchestrator.rs`
  (end-to-end integration tests).
- **Three new CLI subcommands**: `simard safe-update`, `simard rollback`,
  `simard rollback-watchdog [--once|--interval=N|--max-iterations=N]`.
- **Engineer-dispatch interlock**: `spawn_agent_for_goal` now refuses
  while `~/.simard/state/draining.flag` is present.
- **`cmd_self_update` refactor**: `download_to_temp` factored out of
  `download_and_replace` so the safe path can fetch a candidate without
  overwriting the live install. New
  `handle_self_update_download_only` entry point used by `safe-update`.
- **Brain prompt awareness**: `prompt_assets/simard/ooda_decide.md`
  documents the four-part triggering doctrine and the
  `__safe_update__` synthetic goal_id.

## Test plan

| Suite | Result |
| --- | --- |
| `cargo build` (lib + bins) | ✅ clean |
| `cargo clippy --all-targets -- -D warnings` | ✅ clean |
| `cargo test --lib safe_update` | **46 passed**, 0 failed |
| `cargo test --lib operator_cli::tests_mod` | **33 passed**, 0 failed |
| `cargo test --lib` (full suite) | **3807 passed**, 0 failed (1 unrelated flake — passes in isolation) |
| `cargo test --doc` | ✅ clean |
| `pre-commit run --all-files` (pre-commit stage) | ✅ Passed |
| `pre-commit run --all-files --hook-stage pre-push` | ✅ Passed |

### What the integration tests prove

`src/safe_update/tests_orchestrator.rs` walks the full six-phase flow
end-to-end using `/usr/bin/true` and `/usr/bin/false` as stand-in
candidate binaries (no network, no live `gym run-suite`):

1. `happy_path_drain_snapshot_pretest_swap_validate` — all six phases happy.
2. `negative_pretest_failure_aborts_before_swap` — broken candidate
   never reaches the install path; `phase=pretest_failed` written.
3. `negative_drain_timeout_keeps_flag_in_place` — operator-visible
   refusal preserves the dispatch gate.
4. `negative_validate_timeout_then_rollback` — sha256-verified restore
   from the latest backup; `phase=rolled_back`.
5. `watchdog_force_timeout_then_rollback` — the `rollback-watchdog`
   path observed via the long-running loop.

## Safety / risk surface

- The swap phase honours `SIMARD_SAFE_UPDATE_SKIP_HANDOVER=1` so tests
  never `exec()` (which would replace the test process). Production code
  unconditionally performs the handover.
- Atomic install does `rename(2)` first, falls back to copy-then-fsync-
  then-rename for cross-filesystem installs (EXDEV).
- Rollback enforces a sha256 integrity check between `last-binary.json`
  and the latest `simard.bak.*` file; mismatch → refuse-to-restore.
- A snapshot-not-found situation is permitted (operator's only restore
  option), the integrity-mismatch case is not.
- Rollback `restart_cmd` failure is downgraded to a warning — bytes are
  already on disk; supervisor is the operator's problem from there.

## Out of scope (deliberate)

- No live HTTPS download is exercised in tests (curl path covered by
  existing `tests_download.rs` for `download_and_replace`).
- No live `exec()` is exercised (tests skip via env var).
- No live `systemctl --user restart` is exercised (`/usr/bin/false`
  stands in to prove the warning path).

## Files

- New: `src/safe_update/{mod,state,drain,snapshot,pretest,swap,validate,rollback,errors,tests_orchestrator}.rs`
- New: `src/operator_cli/safe_update.rs`
- New: `docs/safe-self-update.md`
- Modified: `src/lib.rs`, `src/operator_cli/{mod,tests_mod}.rs`,
  `src/cmd_self_update/{download,update,mod}.rs`,
  `src/engineer_loop/agent_spawn.rs`,
  `prompt_assets/simard/ooda_decide.md`

## Merge-ready evidence

- [x] Documentation: `docs/safe-self-update.md`
- [x] Brain prompt updated: `prompt_assets/simard/ooda_decide.md`
- [x] Per-phase unit tests + 5 end-to-end integration tests
- [x] CLI dispatch tests for the 3 new subcommands
- [x] Engineer-dispatch interlock + tests
- [x] Pre-commit + pre-push hooks pass
- [x] Clippy `-D warnings` on all targets passes
- [x] Five logical commits, each independently buildable
