### PR TITLE
feat(engineer-worktree): per-worktree CARGO_TARGET_DIR default to prevent disk fill

### DIFF
--- a/src/agent_supervisor/tests_tmux.rs
+++ b/src/agent_supervisor/tests_tmux.rs
@@ -213,13 +213,114 @@ fn compute_tmux_env_seeds_required_simard_vars_from_config() {
 }
 
 #[test]
-fn compute_tmux_env_uses_default_cargo_target_when_parent_unset() {
+fn compute_tmux_env_uses_per_worktree_default_when_parent_unset() {
+    // No HOME, no SIMARD_CARGO_TARGETS_ROOT, no CARGO_TARGET_DIR — must
+    // fall back to /tmp/simard-cargo-targets/<basename>. The basename is
+    // taken from config.worktree_path so concurrent engineers never share
+    // one cargo target dir.
     let config = make_test_config("e1", 0);
     let env = compute_tmux_env(&config, std::iter::empty::<(String, String)>());
     assert_eq!(
         env_value(&env, "CARGO_TARGET_DIR"),
-        Some("/tmp/simard-engineer-target"),
-        "CARGO_TARGET_DIR default must be /tmp/simard-engineer-target (issue #1197)"
+        Some("/tmp/simard-cargo-targets/worktree"),
+        "fallback default must be /tmp/simard-cargo-targets/<basename>"
+    );
+}
+
+#[test]
+fn compute_tmux_env_default_uses_home_when_present() {
+    // Production case: the OODA daemon inherits HOME from the operator
+    // shell. Default must be <HOME>/.cargo-targets/<basename>.
+    let config = make_test_config("e1", 0);
+    let parent = vec![("HOME".to_string(), "/home/azureuser".to_string())];
+    let env = compute_tmux_env(&config, parent);
+    assert_eq!(
+        env_value(&env, "CARGO_TARGET_DIR"),
+        Some("/home/azureuser/.cargo-targets/worktree"),
+        "default must be <HOME>/.cargo-targets/<basename>"
+    );
+}
+
+#[test]
+fn compute_tmux_env_default_honors_simard_cargo_targets_root_override() {
+    // Operators can pin a custom root via SIMARD_CARGO_TARGETS_ROOT —
+    // useful for routing cargo target dirs onto a separate, larger
+    // filesystem (e.g. ephemeral SSD).
+    let config = make_test_config("e1", 0);
+    let parent = vec![
+        ("HOME".to_string(), "/home/azureuser".to_string()),
+        (
+            "SIMARD_CARGO_TARGETS_ROOT".to_string(),
+            "/srv/cargo-targets".to_string(),
+        ),
+    ];
+    let env = compute_tmux_env(&config, parent);
+    assert_eq!(
+        env_value(&env, "CARGO_TARGET_DIR"),
+        Some("/srv/cargo-targets/worktree"),
+        "SIMARD_CARGO_TARGETS_ROOT must override the HOME-derived default"
+    );
+}
+
+#[test]
+fn compute_tmux_env_default_is_per_worktree_basename() {
+    // Two configs with different worktree paths must produce two distinct
+    // CARGO_TARGET_DIR values. This is the property that prevents the
+    // disk-fill incident's "concurrent cargo builds collide on shared
+    // target dir" failure mode.
+    let mut a = make_test_config("e1", 0);
+    a.worktree_path = PathBuf::from("/tmp/wt-a-12345");
+    let mut b = make_test_config("e2", 0);
+    b.worktree_path = PathBuf::from("/tmp/wt-b-67890");
+
+    let parent = || vec![("HOME".to_string(), "/h".to_string())];
+    let env_a = compute_tmux_env(&a, parent());
+    let env_b = compute_tmux_env(&b, parent());
+
+    let target_a = env_value(&env_a, "CARGO_TARGET_DIR").expect("a has target");
+    let target_b = env_value(&env_b, "CARGO_TARGET_DIR").expect("b has target");
+    assert_ne!(
+        target_a, target_b,
+        "different worktree basenames must yield different CARGO_TARGET_DIR (got {target_a} vs {target_b})"
+    );
+    assert!(
+        target_a.ends_with("/wt-a-12345"),
+        "target_a must end with worktree basename: {target_a}"
+    );
+    assert!(
+        target_b.ends_with("/wt-b-67890"),
+        "target_b must end with worktree basename: {target_b}"
+    );
+}
+
+#[test]
+fn compute_tmux_env_default_falls_back_when_home_empty() {
+    // Defensive: an explicitly-empty HOME must not produce
+    // `<empty>/.cargo-targets/<basename>` (which would be a relative path
+    // and thus depend on CWD). Treat empty HOME as missing.
+    let config = make_test_config("e1", 0);
+    let parent = vec![("HOME".to_string(), String::new())];
+    let env = compute_tmux_env(&config, parent);
+    assert_eq!(
+        env_value(&env, "CARGO_TARGET_DIR"),
+        Some("/tmp/simard-cargo-targets/worktree"),
+        "empty HOME must be treated as missing and fall back to /tmp"
+    );
+}
+
+#[test]
+fn compute_tmux_env_uses_default_cargo_target_when_parent_unset() {
+    // Backwards-compatible alias for the original test name. Some external
+    // grep-based tooling looks for this exact identifier; keep it pointing
+    // at the new contract so that tooling does not silently miss the
+    // regression target.
+    let config = make_test_config("e1", 0);
+    let env = compute_tmux_env(&config, std::iter::empty::<(String, String)>());
+    assert!(
+        env_value(&env, "CARGO_TARGET_DIR")
+            .map(|v| v.starts_with("/tmp/simard-cargo-targets/"))
+            .unwrap_or(false),
+        "fallback default must live under /tmp/simard-cargo-targets/ (issue #1697)"
     );
 }
 

--- a/src/agent_supervisor/tmux.rs
+++ b/src/agent_supervisor/tmux.rs
@@ -70,6 +70,59 @@ pub fn build_tmux_wrapped_command(
     argv
 }
 
+/// Default fallback root for per-worktree cargo target dirs when neither
+/// `CARGO_TARGET_DIR` nor `SIMARD_CARGO_TARGETS_ROOT` is set in the parent
+/// env, AND `HOME` is also absent. Kept under `/tmp` so a missing-HOME
+/// edge case can never escalate into writing target artifacts somewhere
+/// the operator did not anticipate.
+pub const DEFAULT_CARGO_TARGETS_ROOT_FALLBACK: &str = "/tmp/simard-cargo-targets";
+
+/// Default subdirectory of `$HOME` used as the per-worktree cargo targets
+/// root when `SIMARD_CARGO_TARGETS_ROOT` is unset.
+pub const DEFAULT_CARGO_TARGETS_HOME_SUBDIR: &str = ".cargo-targets";
+
+/// Compute the default `CARGO_TARGET_DIR` for an engineer worktree at
+/// `worktree_path`. Pure — pulls `HOME` and `SIMARD_CARGO_TARGETS_ROOT`
+/// from `parent_pairs` only (never `std::env`).
+///
+/// Resolution order:
+/// 1. `<SIMARD_CARGO_TARGETS_ROOT>/<worktree_basename>` if the env var is set.
+/// 2. `<HOME>/.cargo-targets/<worktree_basename>` if `HOME` is set in
+///    parent_pairs (the production case — the OODA daemon always inherits
+///    `HOME` from the operator shell).
+/// 3. `/tmp/simard-cargo-targets/<worktree_basename>` as a last-resort fallback.
+///
+/// The basename is taken from `worktree_path.file_name()`. If the path has
+/// no terminal component (extremely unlikely — would require `/`), the
+/// literal string `"engineer-worktree"` is substituted so the resulting
+/// path is still well-formed and per-engineer (the worktree path's full
+/// hash gets folded in by callers via the directory layout, but for this
+/// purely defensive branch we accept a shared fallback dir).
+fn default_cargo_target_for_worktree(
+    worktree_path: &Path,
+    parent_pairs: &[(String, String)],
+) -> String {
+    let basename = worktree_path
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "engineer-worktree".to_string());
+
+    let lookup = |key: &str| -> Option<String> {
+        parent_pairs
+            .iter()
+            .find(|(k, _)| k == key)
+            .map(|(_, v)| v.clone())
+            .filter(|v| !v.is_empty())
+    };
+
+    let root = lookup("SIMARD_CARGO_TARGETS_ROOT")
+        .or_else(|| lookup("HOME").map(|h| format!("{h}/{DEFAULT_CARGO_TARGETS_HOME_SUBDIR}")))
+        .unwrap_or_else(|| DEFAULT_CARGO_TARGETS_ROOT_FALLBACK.to_string());
+
+    format!("{root}/{basename}")
+}
+
 /// Build the `(KEY, VALUE)` pairs that must be passed to
 /// `tmux new-session -e KEY=VAL` so the engineer subprocess inherits them.
 ///
@@ -80,8 +133,21 @@ pub fn build_tmux_wrapped_command(
 ///    - `SIMARD_SUBORDINATE_DEPTH` = `config.current_depth + 1`
 ///    - `CARGO_BUILD_JOBS`         = `"4"` (issue #373 OOM guard)
 /// 2. `CARGO_TARGET_DIR` honors a `parent_env` override; otherwise defaults
-///    to `/tmp/simard-engineer-target` (issue #1197 — share one target dir
-///    across all engineer worktrees).
+///    to a **per-worktree** path so concurrent engineers never share one
+///    cargo target dir (which would deadlock cargo's file lock or corrupt
+///    incremental output). The default is
+///    `<root>/<basename(config.worktree_path)>`, where `<root>` resolves
+///    in this order:
+///     1. `SIMARD_CARGO_TARGETS_ROOT` env (operator override),
+///     2. `<HOME>/.cargo-targets` (production default),
+///     3. `/tmp/simard-cargo-targets` (last-resort fallback when HOME
+///        is absent — should never happen under the OODA daemon).
+///
+///    This intentionally REPLACES the previous shared
+///    `/tmp/simard-engineer-target` default: that path caused 7-12 GB
+///    target dirs to be created in every engineer worktree once
+///    concurrent engineers deadlocked on the cargo build lock and fell
+///    back to per-worktree builds (the disk-fill incident, issue #1697).
 /// 3. Every `SIMARD_*` entry from `parent_env` that isn't already in (1) is
 ///    appended, sorted by key for stable test/debug ordering.
 ///
@@ -108,7 +174,8 @@ where
         .iter()
         .find(|(k, _)| k == "CARGO_TARGET_DIR")
         .map(|(_, v)| v.clone())
-        .unwrap_or_else(|| "/tmp/simard-engineer-target".to_string());
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| default_cargo_target_for_worktree(&config.worktree_path, &parent_pairs));
     tmux_env.push(("CARGO_TARGET_DIR".to_string(), cargo_target));
 
     // Forward every SIMARD_* var from parent_env that isn't already set.

--- a/src/engineer_worktree/mod.rs
+++ b/src/engineer_worktree/mod.rs
@@ -7,6 +7,20 @@
 //! verification race that was preventing the OODA daemon from shipping PRs.
 //!
 //! See `docs/reference/engineer-worktree-isolation.md` for the full contract.
+//!
+//! # Cargo target dir isolation (issue #1697)
+//!
+//! Each engineer subprocess inherits a per-worktree `CARGO_TARGET_DIR`
+//! computed by [`crate::agent_supervisor::tmux::compute_tmux_env`]. The
+//! default is `<HOME>/.cargo-targets/<worktree-basename>`, configurable
+//! via the `SIMARD_CARGO_TARGETS_ROOT` env var. The basename is unique
+//! per engineer (it embeds the goal id and a per-allocation suffix), so
+//! two concurrent engineers never collide on cargo's build lock and never
+//! corrupt each other's incremental output.
+//!
+//! Routing target dirs to a single shared root prevents the disk-fill
+//! incident where each of N engineer worktrees grew its own ~7 GB `target/`
+//! inside the worktree itself (8 worktrees ⇒ ~60 GB lost).
 
 use std::fs;
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
## Summary

Engineer subprocesses now receive a per-worktree `CARGO_TARGET_DIR` instead of sharing one global path. Default resolves to `<root>/<basename(worktree_path)>` where `<root>` is, in priority order:

1. `SIMARD_CARGO_TARGETS_ROOT` (operator override),
2. `<HOME>/.cargo-targets` (production default),
3. `/tmp/simard-cargo-targets` (fallback when `HOME` absent).

## Why

The disk-fill incident filled `/home/azureuser` to 100% and ENOSPC-killed cognitive-memory WAL writes plus mid-cycle OODA consolidation. ~7-12 GB cargo `target/` dirs accumulated inside each engineer worktree because the previous shared default (`/tmp/simard-engineer-target`) caused concurrent cargo builds to deadlock on a single target dir's build lock and fall back to per-worktree builds inside the worktree.

Per-worktree paths under one configurable root give us:
- no concurrent build collisions (each worktree has its own target dir),
- no in-worktree pollution (target dir lives outside the worktree),
- operator control via `SIMARD_CARGO_TARGETS_ROOT` for routing onto a larger filesystem.

## What changed

- `src/agent_supervisor/tmux.rs`: new pure helper `default_cargo_target_for_worktree`, two consts, and `compute_tmux_env` now produces per-worktree default. Override path unchanged.
- `src/agent_supervisor/tests_tmux.rs`: 5 new unit tests + one contract-anchor existing test retained.
- `src/engineer_worktree/mod.rs`: module-doc section documenting the contract.

No worktree allocator behavior changed — pre-commit install, engineer-claim sentinel, sweep, cleanup, Drop paths are untouched.

## Merge readiness

### QA-team evidence

- Scenario files: `src/agent_supervisor/tests_tmux.rs` (19 unit tests covering compute_tmux_env contract, including 5 new tests for per-worktree CARGO_TARGET_DIR)
- Validation command: `cargo test --release --lib agent_supervisor::tests_tmux`
- Validation result: passed (19/19)
- Run command: `cargo test --release --lib -- --test-threads=$(nproc)`
- Run target: local
- Run result: passed (3852 passed, 0 failed, 4 ignored)
- Evidence location: PR description (test counts + commands above; full output in commit message body)

### Documentation

- User-facing docs impact: no
- Updated docs: `src/engineer_worktree/mod.rs` module docs (in-tree rustdoc); no operator-facing doc changes
- PR description links added: n/a
- Rationale if not applicable: env var contract is internal to the engineer subprocess spawn path; surfaces (worktree allocator API, OODA cycle, dashboard) all unchanged. Operators discover `SIMARD_CARGO_TARGETS_ROOT` via the rustdoc on `compute_tmux_env`.

### Quality-audit

- Cycle 1 summary: identified `clippy::doc_lazy_continuation` warning on the new module-doc list block; reformatted with explicit blank line and 1-space sub-indentation. Re-ran clippy → clean.
- Cycle 2 summary: verified no other tests reference `/tmp/simard-engineer-target` (the old default) via `git grep`; confirmed no behavior change for the override path (`compute_tmux_env_honors_parent_cargo_target_override` still passes).
- Cycle 3 summary: verified all 17 existing `engineer_worktree` tests still pass and the 4 existing `compute_tmux_env_*` tests retain their original semantics (CARGO_TARGET_DIR override / SIMARD_* forwarding / no-double-add / sorted ordering).
- Additional cycles: none
- Final clean cycle: 3 (zero critical/high, zero medium correctness/security findings)
- Fixes followed default-workflow: yes
- Convergence summary: change is local to one helper + its tests; full lib suite green; no integration-test regressions because no callers of `compute_tmux_env` changed signature.

### CI

- Checks command: `gh pr checks <pr>`
- Result: pending (will be filled after CI completes)
- Skipped checks: none expected
- Flaky reruns performed: none
- Real failures fixed: none

### PR description evidence

This PR description follows `~/.copilot/skills/merge-ready/pr-description-template.md`. All six required sections present with concrete evidence (commands, counts, rationale).

### Scope

- Changed files reviewed: `git diff origin/main --stat` → 3 files, 188 insertions, 6 deletions, all under `src/agent_supervisor/` and `src/engineer_worktree/mod.rs`.
- Unrelated changes: none. Reverted an auto-modified `.github/hooks/amplihack-hooks.json` before commit.

### Verdict

- Merge-ready: yes (pending CI green)
- Remaining blockers: none

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
