### PR TITLE
feat(worktree-gc): prune merged/stale engineer worktrees via simard subcommand

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,6 +109,7 @@ mod tests_base_type_copilot;
 mod tests_memory_ipc;
 pub mod trace_collector;
 pub mod util;
+pub mod worktree_gc;
 
 pub use agent_goal_assignment::{
     SubordinateProgress, assign_goal, poll_progress, read_assigned_goal, report_progress,

--- a/src/operator_cli/mod.rs
+++ b/src/operator_cli/mod.rs
@@ -9,6 +9,7 @@ mod merge;
 mod ooda;
 mod review;
 mod safe_update;
+mod worktree_gc;
 
 use std::path::PathBuf;
 
@@ -53,6 +54,8 @@ Product modes:
   dashboard serve [--port=8080]
   spawn <agent-name> <goal> <worktree-path> [--depth=N]
   merge-pr <pr-number>   — squash-merge PR in rysweet/Simard if it is merge-ready
+  worktree-gc [--apply] [--idle-days=N] [--root=PATH ...] [--parent-repo=PATH]
+                         — prune merged/stale engineer worktrees (dry-run by default)
   handover [--canary-dir=PATH] [--manifest-dir=PATH]
   update
   self-test
@@ -107,6 +110,7 @@ where
         "dashboard" => dashboard::dispatch_dashboard_command(args),
         "spawn" => dispatch_spawn_command(args),
         "merge-pr" => merge::dispatch_merge_pr_command(args),
+        "worktree-gc" => worktree_gc::dispatch_worktree_gc_command(args),
         "handover" => dispatch_handover_command(args),
         "bootstrap" => dispatch_bootstrap_command(args),
         "act-on-decisions" => {
@@ -147,7 +151,7 @@ where
 }
 
 pub fn operator_cli_usage() -> &'static str {
-    "usage: simard <engineer|meeting|goal-curation|improvement-curation|gym|ooda|spawn|merge-pr|handover|update|safe-update|rollback|rollback-watchdog|install|review|bootstrap> ..."
+    "usage: simard <engineer|meeting|goal-curation|improvement-curation|gym|ooda|spawn|merge-pr|worktree-gc|handover|update|safe-update|rollback|rollback-watchdog|install|review|bootstrap> ..."
 }
 
 pub fn operator_cli_help() -> &'static str {

--- a/src/operator_cli/worktree_gc.rs
+++ b/src/operator_cli/worktree_gc.rs
@@ -1,0 +1,167 @@
+//! Operator subcommand `simard worktree-gc [--apply]`.
+//!
+//! Defaults to dry-run. Operators must pass `--apply` to perform any
+//! filesystem mutation.
+
+use crate::worktree_gc::{GcConfig, GhClientShell, default_roots, run_gc, runner::render_reason};
+
+use super::args::reject_extra_args;
+
+/// Repo for upstream PR queries. Hard-coded to the home repo for now;
+/// matches `merge-pr`'s hard-coded `rysweet/Simard`.
+const HOME_REPO: &str = "rysweet/Simard";
+
+pub(crate) fn dispatch_worktree_gc_command(
+    mut args: impl Iterator<Item = String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut apply = false;
+    let mut idle_days: u64 = crate::worktree_gc::DEFAULT_IDLE_DAYS;
+    let mut explicit_roots: Vec<std::path::PathBuf> = Vec::new();
+    let mut parent_repo: Option<std::path::PathBuf> = None;
+
+    let remaining: Vec<String> = (&mut args).collect();
+    for arg in remaining {
+        if arg == "--apply" {
+            apply = true;
+        } else if arg == "--dry-run" {
+            apply = false;
+        } else if let Some(n) = arg.strip_prefix("--idle-days=") {
+            idle_days = n
+                .parse()
+                .map_err(|_| format!("invalid --idle-days value: {n}"))?;
+        } else if let Some(p) = arg.strip_prefix("--root=") {
+            explicit_roots.push(std::path::PathBuf::from(p));
+        } else if let Some(p) = arg.strip_prefix("--parent-repo=") {
+            parent_repo = Some(std::path::PathBuf::from(p));
+        } else if arg == "--help" || arg == "-h" {
+            print!("{WORKTREE_GC_HELP}");
+            return Ok(());
+        } else {
+            return Err(format!("unexpected argument: {arg}").into());
+        }
+    }
+    reject_extra_args(std::iter::empty::<String>())?;
+
+    let parent_repo = parent_repo
+        .or_else(|| std::env::current_dir().ok())
+        .ok_or("cannot resolve parent repo (pass --parent-repo=PATH)")?;
+
+    let roots = if explicit_roots.is_empty() {
+        default_roots()
+    } else {
+        explicit_roots
+    };
+
+    let cfg = GcConfig {
+        roots,
+        parent_repo: parent_repo.clone(),
+        apply,
+        idle_days,
+        now: std::time::SystemTime::now(),
+    };
+
+    if apply {
+        eprintln!("[worktree-gc] APPLY mode — pruning candidates");
+    } else {
+        eprintln!("[worktree-gc] DRY-RUN — pass --apply to actually prune");
+    }
+    eprintln!("[worktree-gc] parent_repo = {}", parent_repo.display());
+    eprintln!("[worktree-gc] idle_days   = {idle_days}");
+    eprintln!("[worktree-gc] roots:");
+    for r in &cfg.roots {
+        eprintln!("[worktree-gc]   - {}", r.display());
+    }
+
+    let gh = GhClientShell::new(HOME_REPO, parent_repo);
+    let report = run_gc(&cfg, &gh).map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+
+    eprintln!(
+        "[worktree-gc] examined={} candidates={}",
+        report.worktrees_examined,
+        report.candidates.len(),
+    );
+    for cand in &report.candidates {
+        let primary = cand
+            .primary_reason()
+            .map(render_reason)
+            .unwrap_or_else(|| "(no reason)".to_string());
+        let extras: Vec<String> = cand
+            .reasons
+            .iter()
+            .filter(|r| Some(*r) != cand.primary_reason())
+            .map(render_reason)
+            .collect();
+        let extras_str = if extras.is_empty() {
+            String::new()
+        } else {
+            format!(" (+ {})", extras.join(", "))
+        };
+        eprintln!(
+            "[worktree-gc] candidate: {} branch={} reason={}{}",
+            cand.path.display(),
+            cand.branch.as_deref().unwrap_or("<detached>"),
+            primary,
+            extras_str,
+        );
+    }
+
+    if apply {
+        for p in &report.pruned {
+            eprintln!("[worktree-gc] pruned: {}", p.display());
+        }
+        for (p, e) in &report.failures {
+            eprintln!("[worktree-gc] FAILED: {} — {e}", p.display());
+        }
+        eprintln!(
+            "[worktree-gc] DONE pruned={} failures={}",
+            report.pruned.len(),
+            report.failures.len()
+        );
+        if !report.failures.is_empty() {
+            return Err(format!("{} prune failures", report.failures.len()).into());
+        }
+    }
+
+    Ok(())
+}
+
+const WORKTREE_GC_HELP: &str = "\
+Usage: simard worktree-gc [--apply] [--dry-run] [--idle-days=N] \
+[--root=PATH ...] [--parent-repo=PATH]
+
+Prune engineer worktrees whose:
+  - branch was merged upstream (gh pr list --state merged), OR
+  - branch was deleted from origin, OR
+  - have been idle longer than --idle-days (default 7).
+
+Defaults to dry-run. Pass --apply to actually prune.
+
+Roots default to:
+  $HOME/.simard/engineer-worktrees
+  $HOME/src/Simard/worktrees
+or to SIMARD_WORKTREE_GC_ROOTS (colon-separated) if set.
+
+--root may be passed multiple times.
+--parent-repo defaults to the current working directory.
+";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unknown_flag_is_rejected() {
+        let err = dispatch_worktree_gc_command(["--whoops".to_string()].into_iter())
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("--whoops"), "{err}");
+    }
+
+    #[test]
+    fn invalid_idle_days_is_rejected() {
+        let err = dispatch_worktree_gc_command(["--idle-days=abc".to_string()].into_iter())
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("--idle-days"), "{err}");
+    }
+}

--- a/src/worktree_gc/mod.rs
+++ b/src/worktree_gc/mod.rs
@@ -1,0 +1,133 @@
+//! Worktree garbage collector (issue #1697 follow-up).
+//!
+//! Enumerates engineer worktrees under a configurable list of roots and
+//! prunes those whose:
+//!   - branch was merged into main upstream (gh PR list returns nonempty), OR
+//!   - have been idle > 7 days (no `.simard-engineer-claim` heartbeat
+//!     update, or worktree mtime > 7 days), OR
+//!   - branch was deleted from origin.
+//!
+//! The first-cause precedence is `BranchMerged > BranchDeletedFromOrigin >
+//! IdleTooLong` so the operator-facing log line names the most semantic
+//! reason first.
+//!
+//! # Why this exists
+//!
+//! Engineer worktrees are allocated under
+//! `<state_root>/engineer-worktrees/` per OODA cycle. Without GC, merged
+//! engineer branches accumulate as ghost worktrees on disk — combined
+//! with the per-worktree cargo target dir (issue #1697), each leaked
+//! worktree costs 7-12 GB. The disk-fill incident was triggered by 81 GB
+//! of orphaned worktrees that no path was ever responsible for cleaning.
+//!
+//! `cleanup` (in `engineer_worktree::cleanup`) handles the per-allocation
+//! tear-down for live OODA cycles. This module handles the cross-cycle
+//! and cross-process leakage that `cleanup` cannot see (because the OODA
+//! daemon that allocated those worktrees has long since exited).
+//!
+//! # Safety
+//!
+//! - `--dry-run` is the default. The CLI demands an explicit `--apply`
+//!   to perform any filesystem mutation.
+//! - Pruning gates on `git worktree remove --force` first; the `rm -rf`
+//!   fallback only triggers if git's removal failed and the dir is
+//!   still present (e.g. on filesystems where git left a stub).
+//! - All filesystem deletions are guarded by a canonical-prefix check
+//!   against the configured roots: a candidate dir whose canonical path
+//!   does not live under one of the roots is refused, never deleted.
+
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+pub mod parse;
+pub mod policy;
+pub mod runner;
+
+#[cfg(test)]
+mod tests;
+
+pub use parse::{WorktreeEntry, parse_worktree_list};
+pub use policy::{GcCandidate, PruneReason, evaluate_candidate};
+pub use runner::{GcReport, GhClient, GhClientShell, run_gc};
+
+/// Default idle threshold for the IdleTooLong rule.
+pub const DEFAULT_IDLE_DAYS: u64 = 7;
+
+/// Default upstream remote name used when checking
+/// `branch deleted from origin`.
+pub const DEFAULT_REMOTE: &str = "origin";
+
+/// GC configuration assembled from CLI flags + env defaults.
+#[derive(Debug, Clone)]
+pub struct GcConfig {
+    /// Filesystem roots to scan for engineer worktrees. Worktrees whose
+    /// canonical path does not start with any of these roots are skipped.
+    pub roots: Vec<PathBuf>,
+    /// Parent repository to drive `git worktree list` and
+    /// `git worktree remove`. Must already be a valid git working tree
+    /// or bare repo.
+    pub parent_repo: PathBuf,
+    /// `false` → only print what would be pruned. `true` → actually prune.
+    pub apply: bool,
+    /// Idle threshold (days). Worktrees whose claim/sentinel mtime
+    /// exceeds this many days qualify as IdleTooLong.
+    pub idle_days: u64,
+    /// "Now" reference used by the policy. Tests inject a fixed value;
+    /// production passes `SystemTime::now()`.
+    pub now: SystemTime,
+}
+
+impl GcConfig {
+    /// Build a default config: dry-run, 7-day idle threshold, two roots
+    /// (the production engineer-worktrees root and the rebase-worktrees
+    /// root inside the home checkout). Both can be overridden by the
+    /// caller before passing into [`run_gc`].
+    pub fn defaults(parent_repo: PathBuf) -> Self {
+        Self {
+            roots: default_roots(),
+            parent_repo,
+            apply: false,
+            idle_days: DEFAULT_IDLE_DAYS,
+            now: SystemTime::now(),
+        }
+    }
+}
+
+/// Resolve the default scan roots. Reads `SIMARD_WORKTREE_GC_ROOTS`
+/// (colon-separated) when set; otherwise returns a conservative pair:
+/// `<HOME>/.simard/engineer-worktrees` and `<HOME>/src/Simard/worktrees`.
+pub fn default_roots() -> Vec<PathBuf> {
+    if let Ok(raw) = std::env::var("SIMARD_WORKTREE_GC_ROOTS") {
+        let parsed: Vec<PathBuf> = raw
+            .split(':')
+            .filter(|s| !s.is_empty())
+            .map(PathBuf::from)
+            .collect();
+        if !parsed.is_empty() {
+            return parsed;
+        }
+    }
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/home/azureuser".to_string());
+    vec![
+        PathBuf::from(format!("{home}/.simard/engineer-worktrees")),
+        PathBuf::from(format!("{home}/src/Simard/worktrees")),
+    ]
+}
+
+/// Returns true iff `dir` lives, after canonicalization, inside any of
+/// the configured `roots`. Roots that do not exist are skipped; this
+/// allows a host to be missing one of the default roots without failing
+/// the safety check on the other.
+pub fn under_any_root(dir: &Path, roots: &[PathBuf]) -> bool {
+    let Ok(canon_dir) = dir.canonicalize() else {
+        return false;
+    };
+    for root in roots {
+        if let Ok(canon_root) = root.canonicalize()
+            && canon_dir.starts_with(&canon_root)
+        {
+            return true;
+        }
+    }
+    false
+}

--- a/src/worktree_gc/parse.rs
+++ b/src/worktree_gc/parse.rs
@@ -1,0 +1,177 @@
+//! Pure parser for `git worktree list --porcelain` output.
+//!
+//! The porcelain format is line-oriented and stable across git versions
+//! we care about (git ≥ 2.36). Each entry is a block of `KEY VALUE` lines
+//! terminated by a blank line. The keys we use are:
+//!
+//! - `worktree <path>` — absolute path to the worktree
+//! - `HEAD <sha>` — checked-out commit
+//! - `branch <ref>` — checked-out branch (omitted for detached HEAD)
+//! - `bare` — flag for the bare parent
+//! - `detached` — flag for a worktree with no branch
+//!
+//! Unknown keys are ignored — git is allowed to add new lines without
+//! breaking us.
+
+use std::path::PathBuf;
+
+/// Parsed entry from `git worktree list --porcelain`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorktreeEntry {
+    /// Absolute filesystem path. Always present (parser drops entries
+    /// that lack a `worktree` line — never observed in practice).
+    pub path: PathBuf,
+    /// Checked-out commit SHA, if reported. Absent for the bare parent.
+    pub head: Option<String>,
+    /// Branch ref name without the leading `refs/heads/`.
+    /// `None` for detached HEAD or for the bare parent.
+    pub branch: Option<String>,
+    /// `true` for the bare parent entry. The worktrees themselves are
+    /// never bare.
+    pub is_bare: bool,
+    /// `true` if the worktree is on a detached HEAD (no branch).
+    pub is_detached: bool,
+}
+
+/// Parse the raw stdout of `git worktree list --porcelain` into a vec
+/// of [`WorktreeEntry`]. Pure — no IO.
+pub fn parse_worktree_list(input: &str) -> Vec<WorktreeEntry> {
+    let mut entries = Vec::new();
+    let mut cur: Option<WorktreeEntry> = None;
+
+    let flush = |cur: &mut Option<WorktreeEntry>, entries: &mut Vec<WorktreeEntry>| {
+        if let Some(entry) = cur.take()
+            && !entry.path.as_os_str().is_empty()
+        {
+            entries.push(entry);
+        }
+    };
+
+    for line in input.lines() {
+        if line.is_empty() {
+            flush(&mut cur, &mut entries);
+            continue;
+        }
+        let entry = cur.get_or_insert_with(|| WorktreeEntry {
+            path: PathBuf::new(),
+            head: None,
+            branch: None,
+            is_bare: false,
+            is_detached: false,
+        });
+
+        if let Some(rest) = line.strip_prefix("worktree ") {
+            entry.path = PathBuf::from(rest);
+        } else if let Some(rest) = line.strip_prefix("HEAD ") {
+            entry.head = Some(rest.to_string());
+        } else if let Some(rest) = line.strip_prefix("branch ") {
+            // git emits `refs/heads/<name>` here; strip the prefix.
+            let name = rest.strip_prefix("refs/heads/").unwrap_or(rest);
+            entry.branch = Some(name.to_string());
+        } else if line == "bare" {
+            entry.is_bare = true;
+        } else if line == "detached" {
+            entry.is_detached = true;
+        }
+        // Unknown keys are silently ignored.
+    }
+    flush(&mut cur, &mut entries);
+    entries
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_empty_input() {
+        assert!(parse_worktree_list("").is_empty());
+    }
+
+    #[test]
+    fn parses_single_branch_entry() {
+        let raw = "\
+worktree /tmp/wt1
+HEAD abcdef0123456789
+branch refs/heads/feat/x
+";
+        let parsed = parse_worktree_list(raw);
+        assert_eq!(parsed.len(), 1);
+        let e = &parsed[0];
+        assert_eq!(e.path, PathBuf::from("/tmp/wt1"));
+        assert_eq!(e.head.as_deref(), Some("abcdef0123456789"));
+        assert_eq!(e.branch.as_deref(), Some("feat/x"));
+        assert!(!e.is_bare);
+        assert!(!e.is_detached);
+    }
+
+    #[test]
+    fn parses_bare_parent_then_branch_worktree() {
+        let raw = "\
+worktree /home/u/repo
+bare
+
+worktree /home/u/repo/wt
+HEAD 1234
+branch refs/heads/feat/y
+";
+        let parsed = parse_worktree_list(raw);
+        assert_eq!(parsed.len(), 2);
+        assert!(parsed[0].is_bare);
+        assert_eq!(parsed[0].path, PathBuf::from("/home/u/repo"));
+        assert_eq!(parsed[1].branch.as_deref(), Some("feat/y"));
+    }
+
+    #[test]
+    fn parses_detached_worktree() {
+        let raw = "\
+worktree /tmp/d
+HEAD aaaa
+detached
+";
+        let parsed = parse_worktree_list(raw);
+        assert_eq!(parsed.len(), 1);
+        assert!(parsed[0].is_detached);
+        assert!(parsed[0].branch.is_none());
+    }
+
+    #[test]
+    fn ignores_unknown_keys() {
+        let raw = "\
+worktree /tmp/u
+HEAD ffff
+locked some-reason
+prunable-since 1234567890
+branch refs/heads/x
+";
+        let parsed = parse_worktree_list(raw);
+        assert_eq!(parsed.len(), 1);
+        // We don't expose locked/prunable-since today; just confirm
+        // the known fields parse cleanly past them.
+        assert_eq!(parsed[0].branch.as_deref(), Some("x"));
+    }
+
+    #[test]
+    fn drops_entries_without_worktree_line() {
+        // git never emits this in practice, but the parser must not
+        // synthesize a phantom entry from a stray HEAD block.
+        let raw = "\
+HEAD ffff
+branch refs/heads/x
+";
+        let parsed = parse_worktree_list(raw);
+        assert!(parsed.is_empty(), "got {parsed:?}");
+    }
+
+    #[test]
+    fn accepts_branch_without_refs_heads_prefix() {
+        // Defensive: future git versions or `--porcelain=v2` may emit a
+        // bare branch name. Parser should accept either form.
+        let raw = "\
+worktree /tmp/x
+branch feat/already-stripped
+";
+        let parsed = parse_worktree_list(raw);
+        assert_eq!(parsed[0].branch.as_deref(), Some("feat/already-stripped"));
+    }
+}

--- a/src/worktree_gc/policy.rs
+++ b/src/worktree_gc/policy.rs
@@ -1,0 +1,335 @@
+//! Pure decision logic for the worktree GC.
+//!
+//! Tests inject the upstream-status answers (`branch_merged`,
+//! `branch_exists_on_origin`) and the on-disk mtime so the policy can be
+//! driven without spawning gh / git.
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use super::parse::WorktreeEntry;
+
+/// Why a worktree qualifies for pruning. Multiple reasons may be true at
+/// once; the runner records all of them and reports the most-semantic
+/// reason first (see `mod.rs` precedence rules).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PruneReason {
+    /// The branch has at least one merged PR upstream.
+    BranchMerged { pr_numbers: Vec<u32> },
+    /// `git ls-remote --heads <remote> <branch>` returned nothing.
+    BranchDeletedFromOrigin,
+    /// Sentinel/worktree mtime exceeded the configured idle threshold.
+    IdleTooLong { age_days: u64 },
+}
+
+/// A worktree that the policy says we should prune. Carries enough
+/// context for the runner's log line and for the `--dry-run` report.
+#[derive(Debug, Clone)]
+pub struct GcCandidate {
+    pub path: PathBuf,
+    pub branch: Option<String>,
+    pub reasons: Vec<PruneReason>,
+}
+
+impl GcCandidate {
+    /// Headline reason for log/report output.
+    pub fn primary_reason(&self) -> Option<&PruneReason> {
+        self.reasons
+            .iter()
+            .find(|r| matches!(r, PruneReason::BranchMerged { .. }))
+            .or_else(|| {
+                self.reasons
+                    .iter()
+                    .find(|r| matches!(r, PruneReason::BranchDeletedFromOrigin))
+            })
+            .or_else(|| {
+                self.reasons
+                    .iter()
+                    .find(|r| matches!(r, PruneReason::IdleTooLong { .. }))
+            })
+    }
+}
+
+/// Inputs the policy needs about each worktree, gathered by the runner
+/// (filesystem) and the GhClient (gh CLI). Tests construct these
+/// directly so the policy can be exercised hermetically.
+#[derive(Debug, Clone)]
+pub struct CandidateInputs {
+    /// Merged PRs upstream targeting `entry.branch`. Empty vec means
+    /// "checked, none merged"; see runner for `gh` shellout.
+    pub merged_prs: Vec<u32>,
+    /// `Some(true)` → branch present on origin; `Some(false)` → branch
+    /// absent from origin (deleted); `None` → check skipped (no
+    /// `branch` to check, or remote unreachable).
+    pub branch_on_origin: Option<bool>,
+    /// Most recent mtime of the worktree's claim sentinel, falling back
+    /// to the worktree directory mtime when the sentinel is absent.
+    pub last_activity: Option<SystemTime>,
+}
+
+/// Apply the policy to one worktree entry. Returns `Some(GcCandidate)`
+/// if at least one prune reason is true, `None` otherwise.
+///
+/// Pure — no IO. The runner gathers `inputs` first and then calls this.
+pub fn evaluate_candidate(
+    entry: &WorktreeEntry,
+    inputs: &CandidateInputs,
+    now: SystemTime,
+    idle_days: u64,
+) -> Option<GcCandidate> {
+    // Never propose pruning the bare parent.
+    if entry.is_bare {
+        return None;
+    }
+
+    let mut reasons = Vec::new();
+
+    if !inputs.merged_prs.is_empty() {
+        reasons.push(PruneReason::BranchMerged {
+            pr_numbers: inputs.merged_prs.clone(),
+        });
+    }
+
+    // Branch-deleted-from-origin only applies when we have a branch to
+    // check AND the remote check actually answered. A `None` answer is
+    // treated as inconclusive — never prune on a network error.
+    if entry.branch.is_some() && inputs.branch_on_origin == Some(false) {
+        reasons.push(PruneReason::BranchDeletedFromOrigin);
+    }
+
+    if let Some(activity) = inputs.last_activity
+        && let Ok(age) = now.duration_since(activity)
+    {
+        let threshold = Duration::from_secs(idle_days * 24 * 60 * 60);
+        if age >= threshold {
+            // Saturating arithmetic keeps the result well-defined even
+            // for absurd durations from a clock-skewed sentinel.
+            let age_days = age.as_secs() / (24 * 60 * 60);
+            reasons.push(PruneReason::IdleTooLong { age_days });
+        }
+    }
+
+    if reasons.is_empty() {
+        None
+    } else {
+        Some(GcCandidate {
+            path: entry.path.clone(),
+            branch: entry.branch.clone(),
+            reasons,
+        })
+    }
+}
+
+/// Helper: read the most recent mtime among `<dir>/.simard-engineer-claim`
+/// and `<dir>` itself, returning the newer of the two. Returns `None` if
+/// neither path exists or both stat() calls fail.
+///
+/// Uses an explicit fallback chain so a worktree whose sentinel was
+/// removed by hand still gets the dir's own mtime as the activity proxy,
+/// and a worktree whose dir never had a sentinel still works.
+pub fn worktree_last_activity(dir: &Path) -> Option<SystemTime> {
+    let claim = dir.join(crate::engineer_worktree::ENGINEER_CLAIM_FILE);
+    let mut best: Option<SystemTime> = None;
+
+    for path in [claim.as_path(), dir] {
+        if let Ok(meta) = std::fs::metadata(path)
+            && let Ok(mtime) = meta.modified()
+        {
+            best = Some(match best {
+                Some(prev) if prev > mtime => prev,
+                _ => mtime,
+            });
+        }
+    }
+    best
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn entry(path: &str, branch: Option<&str>) -> WorktreeEntry {
+        WorktreeEntry {
+            path: PathBuf::from(path),
+            head: Some("abc".to_string()),
+            branch: branch.map(String::from),
+            is_bare: false,
+            is_detached: branch.is_none(),
+        }
+    }
+
+    #[test]
+    fn fresh_worktree_with_open_branch_is_not_a_candidate() {
+        let e = entry("/tmp/wt", Some("feat/x"));
+        let inputs = CandidateInputs {
+            merged_prs: vec![],
+            branch_on_origin: Some(true),
+            last_activity: Some(SystemTime::now()),
+        };
+        let now = SystemTime::now();
+        assert!(evaluate_candidate(&e, &inputs, now, 7).is_none());
+    }
+
+    #[test]
+    fn merged_branch_is_candidate_with_branchmerged_reason() {
+        let e = entry("/tmp/wt", Some("feat/x"));
+        let inputs = CandidateInputs {
+            merged_prs: vec![42],
+            branch_on_origin: Some(true),
+            last_activity: Some(SystemTime::now()),
+        };
+        let cand = evaluate_candidate(&e, &inputs, SystemTime::now(), 7).expect("merged → cand");
+        assert_eq!(cand.reasons.len(), 1);
+        match &cand.reasons[0] {
+            PruneReason::BranchMerged { pr_numbers } => assert_eq!(pr_numbers, &vec![42]),
+            other => panic!("wrong reason: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn branch_deleted_from_origin_is_candidate() {
+        let e = entry("/tmp/wt", Some("feat/gone"));
+        let inputs = CandidateInputs {
+            merged_prs: vec![],
+            branch_on_origin: Some(false),
+            last_activity: Some(SystemTime::now()),
+        };
+        let cand =
+            evaluate_candidate(&e, &inputs, SystemTime::now(), 7).expect("deleted → candidate");
+        assert!(matches!(
+            cand.reasons[0],
+            PruneReason::BranchDeletedFromOrigin
+        ));
+    }
+
+    #[test]
+    fn idle_above_threshold_is_candidate() {
+        let e = entry("/tmp/wt", Some("feat/old"));
+        let now = SystemTime::now();
+        let activity = now - Duration::from_secs(8 * 24 * 3600);
+        let inputs = CandidateInputs {
+            merged_prs: vec![],
+            branch_on_origin: Some(true),
+            last_activity: Some(activity),
+        };
+        let cand = evaluate_candidate(&e, &inputs, now, 7).expect("idle → candidate");
+        match &cand.reasons[0] {
+            PruneReason::IdleTooLong { age_days } => assert!(*age_days >= 8, "got {age_days}"),
+            other => panic!("wrong reason: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn idle_below_threshold_is_not_a_candidate() {
+        let e = entry("/tmp/wt", Some("feat/x"));
+        let now = SystemTime::now();
+        let activity = now - Duration::from_secs(2 * 24 * 3600);
+        let inputs = CandidateInputs {
+            merged_prs: vec![],
+            branch_on_origin: Some(true),
+            last_activity: Some(activity),
+        };
+        assert!(evaluate_candidate(&e, &inputs, now, 7).is_none());
+    }
+
+    #[test]
+    fn bare_parent_is_never_a_candidate() {
+        let mut e = entry("/tmp/repo", None);
+        e.is_bare = true;
+        let inputs = CandidateInputs {
+            merged_prs: vec![1, 2, 3],
+            branch_on_origin: Some(false),
+            last_activity: Some(SystemTime::UNIX_EPOCH),
+        };
+        assert!(
+            evaluate_candidate(&e, &inputs, SystemTime::now(), 7).is_none(),
+            "bare parent must never qualify, even if every signal is hot"
+        );
+    }
+
+    #[test]
+    fn detached_worktree_skips_branch_deleted_check_but_still_idle_eligible() {
+        // No branch → branch-deleted-from-origin must NOT fire even if
+        // branch_on_origin is Some(false) (the runner shouldn't even
+        // call the branch check, but we defend in the policy too).
+        let e = entry("/tmp/det", None);
+        let now = SystemTime::now();
+        let activity = now - Duration::from_secs(30 * 24 * 3600);
+        let inputs = CandidateInputs {
+            merged_prs: vec![],
+            branch_on_origin: Some(false),
+            last_activity: Some(activity),
+        };
+        let cand = evaluate_candidate(&e, &inputs, now, 7).expect("idle still applies on detached");
+        assert!(
+            !cand
+                .reasons
+                .iter()
+                .any(|r| matches!(r, PruneReason::BranchDeletedFromOrigin)),
+            "detached worktree must not get BranchDeletedFromOrigin: {cand:?}"
+        );
+        assert!(matches!(cand.reasons[0], PruneReason::IdleTooLong { .. }));
+    }
+
+    #[test]
+    fn inconclusive_origin_check_does_not_force_prune() {
+        // Network error scenario: `branch_on_origin: None`. Must not
+        // produce a candidate by itself, even if the branch is set.
+        let e = entry("/tmp/wt", Some("feat/q"));
+        let inputs = CandidateInputs {
+            merged_prs: vec![],
+            branch_on_origin: None,
+            last_activity: Some(SystemTime::now()),
+        };
+        assert!(evaluate_candidate(&e, &inputs, SystemTime::now(), 7).is_none());
+    }
+
+    #[test]
+    fn primary_reason_prefers_branchmerged() {
+        let e = entry("/tmp/wt", Some("feat/q"));
+        let now = SystemTime::now();
+        let activity = now - Duration::from_secs(40 * 24 * 3600);
+        let inputs = CandidateInputs {
+            merged_prs: vec![99],
+            branch_on_origin: Some(false),
+            last_activity: Some(activity),
+        };
+        let cand = evaluate_candidate(&e, &inputs, now, 7).expect("hot in 3 ways");
+        assert!(matches!(
+            cand.primary_reason(),
+            Some(PruneReason::BranchMerged { .. })
+        ));
+    }
+
+    #[test]
+    fn primary_reason_prefers_branchdeleted_over_idle() {
+        let e = entry("/tmp/wt", Some("feat/q"));
+        let now = SystemTime::now();
+        let activity = now - Duration::from_secs(40 * 24 * 3600);
+        let inputs = CandidateInputs {
+            merged_prs: vec![],
+            branch_on_origin: Some(false),
+            last_activity: Some(activity),
+        };
+        let cand = evaluate_candidate(&e, &inputs, now, 7).expect("hot in 2 ways");
+        assert!(matches!(
+            cand.primary_reason(),
+            Some(PruneReason::BranchDeletedFromOrigin)
+        ));
+    }
+
+    #[test]
+    fn worktree_last_activity_uses_dir_mtime_when_no_sentinel() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let activity = worktree_last_activity(tmp.path()).expect("dir has mtime");
+        // Dir mtime was set at creation; should be ≤ now.
+        assert!(activity <= SystemTime::now());
+    }
+
+    #[test]
+    fn worktree_last_activity_returns_none_for_missing_dir() {
+        let path = PathBuf::from("/nonexistent/definitely/not/here-99999");
+        assert!(worktree_last_activity(&path).is_none());
+    }
+}

--- a/src/worktree_gc/runner.rs
+++ b/src/worktree_gc/runner.rs
@@ -1,0 +1,313 @@
+//! Runner: glue between the policy + parsers and the actual git/gh shell.
+//!
+//! The runner owns the side-effecting code paths (`git worktree list`,
+//! `git worktree remove`, `gh pr list`, `git ls-remote`, `fs::remove_dir_all`).
+//! Everything decision-related is delegated to [`super::policy`] so the
+//! tests can stay hermetic.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::SystemTime;
+
+use super::parse::{WorktreeEntry, parse_worktree_list};
+use super::policy::{CandidateInputs, GcCandidate, PruneReason, evaluate_candidate};
+use super::{DEFAULT_REMOTE, GcConfig, under_any_root};
+
+/// Indirection for the upstream-branch / merged-PR queries so tests can
+/// substitute deterministic answers.
+pub trait GhClient {
+    /// Return PR numbers (any state) merged for `branch`. Empty vec
+    /// means "checked, none merged".
+    fn merged_prs_for_branch(&self, branch: &str) -> Result<Vec<u32>, String>;
+    /// Return whether the named branch still exists on the remote.
+    /// `Ok(None)` means "could not check" — runner treats as inconclusive.
+    fn branch_exists_on_remote(&self, remote: &str, branch: &str) -> Result<Option<bool>, String>;
+}
+
+/// Production implementation: shells out to `gh` and `git ls-remote`.
+pub struct GhClientShell {
+    pub repo: String,
+    pub parent_repo: PathBuf,
+}
+
+impl GhClientShell {
+    pub fn new(repo: impl Into<String>, parent_repo: PathBuf) -> Self {
+        Self {
+            repo: repo.into(),
+            parent_repo,
+        }
+    }
+}
+
+impl GhClient for GhClientShell {
+    fn merged_prs_for_branch(&self, branch: &str) -> Result<Vec<u32>, String> {
+        // gh pr list --repo <repo> --state merged --search "head:<branch>" --json number
+        let out = Command::new("gh")
+            .args([
+                "pr",
+                "list",
+                "--repo",
+                &self.repo,
+                "--state",
+                "merged",
+                "--search",
+                &format!("head:{branch}"),
+                "--json",
+                "number",
+            ])
+            .output()
+            .map_err(|e| format!("gh spawn failed: {e}"))?;
+        if !out.status.success() {
+            return Err(format!(
+                "gh pr list failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            ));
+        }
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        // Tiny ad-hoc parse: stdout is JSON like `[{"number":42},{"number":43}]`.
+        // Avoid pulling serde_json into this leaf by scanning for `"number":N`.
+        let mut prs = Vec::new();
+        let mut rest = stdout.as_ref();
+        while let Some(pos) = rest.find("\"number\":") {
+            rest = &rest[pos + "\"number\":".len()..];
+            let trimmed = rest.trim_start();
+            let end = trimmed
+                .find(|c: char| !c.is_ascii_digit())
+                .unwrap_or(trimmed.len());
+            if end > 0
+                && let Ok(n) = trimmed[..end].parse::<u32>()
+            {
+                prs.push(n);
+            }
+            rest = &trimmed[end..];
+        }
+        Ok(prs)
+    }
+
+    fn branch_exists_on_remote(&self, remote: &str, branch: &str) -> Result<Option<bool>, String> {
+        // `git -C <parent> ls-remote --heads <remote> <branch>` — empty
+        // stdout (status 0) means the branch is not on the remote.
+        let out = Command::new("git")
+            .args([
+                "-C",
+                &self.parent_repo.to_string_lossy(),
+                "ls-remote",
+                "--heads",
+                remote,
+                branch,
+            ])
+            .output()
+            .map_err(|e| format!("git ls-remote spawn failed: {e}"))?;
+        if !out.status.success() {
+            // Network/auth failure: inconclusive.
+            return Ok(None);
+        }
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        Ok(Some(!stdout.trim().is_empty()))
+    }
+}
+
+/// Outcome of one GC pass.
+#[derive(Debug, Default)]
+pub struct GcReport {
+    pub roots_scanned: Vec<PathBuf>,
+    pub worktrees_examined: usize,
+    pub candidates: Vec<GcCandidate>,
+    /// Paths that were physically pruned in `--apply` mode.
+    pub pruned: Vec<PathBuf>,
+    /// Per-candidate failures during the prune step.
+    pub failures: Vec<(PathBuf, String)>,
+}
+
+/// Format a [`PruneReason`] as a single-line operator-readable string.
+pub fn render_reason(r: &PruneReason) -> String {
+    match r {
+        PruneReason::BranchMerged { pr_numbers } => {
+            let nums: Vec<String> = pr_numbers.iter().map(|n| format!("#{n}")).collect();
+            format!("branch merged ({})", nums.join(", "))
+        }
+        PruneReason::BranchDeletedFromOrigin => "branch deleted from origin".to_string(),
+        PruneReason::IdleTooLong { age_days } => format!("idle {age_days}d"),
+    }
+}
+
+/// Drive one GC pass against `cfg`. Returns the structured report; the
+/// caller is responsible for printing whatever it wants on top of it.
+pub fn run_gc(cfg: &GcConfig, gh: &dyn GhClient) -> Result<GcReport, String> {
+    let mut report = GcReport {
+        roots_scanned: cfg.roots.clone(),
+        ..Default::default()
+    };
+
+    // 1. Enumerate worktrees registered under the parent repo.
+    let raw = git_capture(&cfg.parent_repo, &["worktree", "list", "--porcelain"])
+        .map_err(|e| format!("git worktree list failed: {e}"))?;
+    let entries = parse_worktree_list(&raw);
+
+    // 2. For each entry whose path lives under one of the configured
+    //    roots, gather inputs and run the policy.
+    for entry in &entries {
+        if entry.is_bare {
+            continue;
+        }
+        if !under_any_root(&entry.path, &cfg.roots) {
+            continue;
+        }
+        report.worktrees_examined += 1;
+
+        let inputs = gather_inputs(entry, gh, cfg.now);
+        if let Some(cand) = evaluate_candidate(entry, &inputs, cfg.now, cfg.idle_days) {
+            report.candidates.push(cand);
+        }
+    }
+
+    // 3. In --apply mode, attempt to prune each candidate. Continue on
+    //    individual failures so one bad worktree does not block GC of
+    //    the others.
+    if cfg.apply {
+        for cand in &report.candidates {
+            match prune_candidate(&cfg.parent_repo, cand, &cfg.roots) {
+                Ok(()) => report.pruned.push(cand.path.clone()),
+                Err(e) => report.failures.push((cand.path.clone(), e)),
+            }
+        }
+    }
+
+    Ok(report)
+}
+
+fn gather_inputs(entry: &WorktreeEntry, gh: &dyn GhClient, _now: SystemTime) -> CandidateInputs {
+    let merged_prs = if let Some(ref branch) = entry.branch {
+        gh.merged_prs_for_branch(branch).unwrap_or_else(|e| {
+            tracing::warn!(
+                target: "simard::worktree_gc",
+                error = %e,
+                branch = %branch,
+                "merged_prs_for_branch failed; treating as none merged",
+            );
+            Vec::new()
+        })
+    } else {
+        Vec::new()
+    };
+
+    let branch_on_origin = if let Some(ref branch) = entry.branch {
+        gh.branch_exists_on_remote(DEFAULT_REMOTE, branch)
+            .unwrap_or_else(|e| {
+                tracing::warn!(
+                    target: "simard::worktree_gc",
+                    error = %e,
+                    branch = %branch,
+                    "branch_exists_on_remote failed; treating as inconclusive",
+                );
+                None
+            })
+    } else {
+        None
+    };
+
+    let last_activity = super::policy::worktree_last_activity(&entry.path);
+
+    CandidateInputs {
+        merged_prs,
+        branch_on_origin,
+        last_activity,
+    }
+}
+
+/// Prune one candidate: `git worktree remove --force` first; on failure,
+/// fall back to `fs::remove_dir_all` (gated on the canonical-prefix
+/// check). Then best-effort `git worktree prune` to reconcile registry.
+fn prune_candidate(
+    parent_repo: &Path,
+    cand: &GcCandidate,
+    roots: &[PathBuf],
+) -> Result<(), String> {
+    let dir = &cand.path;
+    let dir_str = dir.to_string_lossy();
+
+    // Defensive: re-check canonical prefix at prune time. Cheap, and
+    // protects against a scan/prune TOCTOU race that lets the path drift.
+    if !under_any_root(dir, roots) {
+        return Err(format!(
+            "refusing to prune {} — not under configured roots",
+            dir.display()
+        ));
+    }
+
+    let remove_status = git_capture(parent_repo, &["worktree", "remove", "--force", &dir_str]);
+    if let Err(e) = &remove_status {
+        tracing::debug!(
+            target: "simard::worktree_gc",
+            worktree = %dir.display(),
+            error = %e,
+            "git worktree remove --force failed; will fall back to manual rmdir",
+        );
+    }
+
+    if dir.exists() {
+        // Fallback rmdir, guarded by canonical prefix.
+        let canon = dir
+            .canonicalize()
+            .map_err(|e| format!("cannot canonicalize {} for prune: {e}", dir.display()))?;
+        let mut ok = false;
+        for root in roots {
+            if let Ok(canon_root) = root.canonicalize()
+                && canon.starts_with(&canon_root)
+            {
+                ok = true;
+                break;
+            }
+        }
+        if !ok {
+            return Err(format!(
+                "refusing to rmdir {} (canonical {}): not contained in any GC root",
+                dir.display(),
+                canon.display()
+            ));
+        }
+        std::fs::remove_dir_all(&canon)
+            .map_err(|e| format!("rm -rf {} failed: {e}", canon.display()))?;
+    }
+
+    if let Err(e) = git_capture(parent_repo, &["worktree", "prune"]) {
+        tracing::debug!(
+            target: "simard::worktree_gc",
+            error = %e,
+            "best-effort `git worktree prune` failed during GC",
+        );
+    }
+    if let Some(ref branch) = cand.branch
+        && let Err(e) = git_capture(parent_repo, &["branch", "-D", branch])
+    {
+        tracing::debug!(
+            target: "simard::worktree_gc",
+            error = %e,
+            branch = %branch,
+            "best-effort `git branch -D` failed during GC (branch may already be gone)",
+        );
+    }
+    Ok(())
+}
+
+/// Minimal git wrapper: env-cleared, captures stdout, returns Err on
+/// non-zero status with stderr in the message.
+fn git_capture(repo: &Path, args: &[&str]) -> Result<String, String> {
+    let mut cmd = Command::new("git");
+    cmd.args(args).current_dir(repo).env_clear();
+    if let Ok(p) = std::env::var("PATH") {
+        cmd.env("PATH", p);
+    }
+    if let Ok(h) = std::env::var("HOME") {
+        cmd.env("HOME", h);
+    }
+    let out = cmd.output().map_err(|e| format!("spawn git: {e}"))?;
+    if !out.status.success() {
+        return Err(format!(
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&out.stderr).trim()
+        ));
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+}

--- a/src/worktree_gc/tests.rs
+++ b/src/worktree_gc/tests.rs
@@ -1,0 +1,308 @@
+//! Integration tests for the worktree GC.
+//!
+//! Exercises [`run_gc`] with a real `git worktree list` against a tempdir
+//! repo and a fake [`GhClient`] so the policy + parser + runner glue can
+//! be tested without touching the real GitHub API.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Mutex;
+use std::time::SystemTime;
+
+use tempfile::tempdir;
+
+use super::policy::{CandidateInputs, PruneReason, evaluate_candidate};
+use super::runner::{GhClient, render_reason, run_gc};
+use super::{GcConfig, parse_worktree_list, under_any_root};
+
+// ------------------------------------------------------------------
+// Fake GhClient
+// ------------------------------------------------------------------
+
+#[derive(Default)]
+struct FakeGh {
+    /// branch → merged PR numbers
+    merged: Mutex<HashMap<String, Vec<u32>>>,
+    /// branch → presence on origin (None means "inconclusive")
+    on_origin: Mutex<HashMap<String, Option<bool>>>,
+}
+
+impl GhClient for FakeGh {
+    fn merged_prs_for_branch(&self, branch: &str) -> Result<Vec<u32>, String> {
+        Ok(self
+            .merged
+            .lock()
+            .unwrap()
+            .get(branch)
+            .cloned()
+            .unwrap_or_default())
+    }
+    fn branch_exists_on_remote(&self, _remote: &str, branch: &str) -> Result<Option<bool>, String> {
+        Ok(self
+            .on_origin
+            .lock()
+            .unwrap()
+            .get(branch)
+            .copied()
+            .unwrap_or(Some(true)))
+    }
+}
+
+// ------------------------------------------------------------------
+// Repo fixtures
+// ------------------------------------------------------------------
+
+fn run_git(repo: &Path, args: &[&str]) {
+    let out = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .expect("git spawn");
+    assert!(
+        out.status.success(),
+        "git {args:?} failed in {}: {}",
+        repo.display(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn init_repo(dir: &Path) {
+    std::fs::create_dir_all(dir).unwrap();
+    run_git(dir, &["init", "--initial-branch=main", "--quiet"]);
+    run_git(dir, &["config", "user.email", "t@e.com"]);
+    run_git(dir, &["config", "user.name", "t"]);
+    run_git(dir, &["config", "commit.gpgsign", "false"]);
+    std::fs::write(dir.join("seed"), "x").unwrap();
+    run_git(dir, &["add", "seed"]);
+    run_git(dir, &["commit", "-m", "seed", "--quiet"]);
+}
+
+fn add_worktree(parent: &Path, branch: &str, dir: &Path) {
+    run_git(
+        parent,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            branch,
+            &dir.to_string_lossy(),
+            "main",
+        ],
+    );
+}
+
+// ------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------
+
+#[test]
+fn dry_run_lists_merged_branch_but_does_not_remove() {
+    let parent_tmp = tempdir().unwrap();
+    let parent = parent_tmp.path();
+    init_repo(parent);
+
+    let roots_tmp = tempdir().unwrap();
+    let wt_dir = roots_tmp.path().join("eng-1");
+    add_worktree(parent, "engineer/eng-1", &wt_dir);
+
+    let gh = FakeGh::default();
+    gh.merged
+        .lock()
+        .unwrap()
+        .insert("engineer/eng-1".to_string(), vec![42]);
+
+    let cfg = GcConfig {
+        roots: vec![roots_tmp.path().to_path_buf()],
+        parent_repo: parent.to_path_buf(),
+        apply: false,
+        idle_days: 7,
+        now: SystemTime::now(),
+    };
+    let report = run_gc(&cfg, &gh).expect("gc");
+
+    assert_eq!(report.candidates.len(), 1, "{report:?}");
+    assert!(matches!(
+        report.candidates[0].reasons[0],
+        PruneReason::BranchMerged { .. }
+    ));
+    assert!(report.pruned.is_empty(), "dry-run must not prune");
+    assert!(wt_dir.exists(), "dry-run must leave worktree on disk");
+}
+
+#[test]
+fn apply_prunes_merged_worktree_and_removes_dir() {
+    let parent_tmp = tempdir().unwrap();
+    let parent = parent_tmp.path();
+    init_repo(parent);
+
+    let roots_tmp = tempdir().unwrap();
+    let wt_dir = roots_tmp.path().join("eng-merged");
+    add_worktree(parent, "engineer/eng-merged", &wt_dir);
+
+    let gh = FakeGh::default();
+    gh.merged
+        .lock()
+        .unwrap()
+        .insert("engineer/eng-merged".to_string(), vec![777]);
+
+    let cfg = GcConfig {
+        roots: vec![roots_tmp.path().to_path_buf()],
+        parent_repo: parent.to_path_buf(),
+        apply: true,
+        idle_days: 7,
+        now: SystemTime::now(),
+    };
+    let report = run_gc(&cfg, &gh).expect("gc apply");
+
+    assert_eq!(report.pruned.len(), 1);
+    assert!(report.failures.is_empty(), "{report:?}");
+    assert!(!wt_dir.exists(), "worktree dir must be removed");
+}
+
+#[test]
+fn worktree_outside_configured_roots_is_skipped() {
+    let parent_tmp = tempdir().unwrap();
+    let parent = parent_tmp.path();
+    init_repo(parent);
+
+    // Worktree placed elsewhere; configured root is the empty subdir.
+    let elsewhere = tempdir().unwrap();
+    let wt_dir = elsewhere.path().join("eng-outside");
+    add_worktree(parent, "engineer/eng-outside", &wt_dir);
+
+    let configured_root = tempdir().unwrap();
+
+    let gh = FakeGh::default();
+    gh.merged
+        .lock()
+        .unwrap()
+        .insert("engineer/eng-outside".to_string(), vec![1]);
+
+    let cfg = GcConfig {
+        roots: vec![configured_root.path().to_path_buf()],
+        parent_repo: parent.to_path_buf(),
+        apply: true,
+        idle_days: 7,
+        now: SystemTime::now(),
+    };
+    let report = run_gc(&cfg, &gh).expect("gc apply");
+
+    assert_eq!(report.worktrees_examined, 0);
+    assert!(report.pruned.is_empty());
+    assert!(wt_dir.exists(), "outside-root worktree must not be touched");
+}
+
+#[test]
+fn fresh_unmerged_worktree_is_not_pruned() {
+    let parent_tmp = tempdir().unwrap();
+    let parent = parent_tmp.path();
+    init_repo(parent);
+
+    let roots_tmp = tempdir().unwrap();
+    let wt_dir = roots_tmp.path().join("eng-fresh");
+    add_worktree(parent, "engineer/eng-fresh", &wt_dir);
+
+    let gh = FakeGh::default(); // empty: no merged PRs, branch on origin
+
+    let cfg = GcConfig {
+        roots: vec![roots_tmp.path().to_path_buf()],
+        parent_repo: parent.to_path_buf(),
+        apply: true,
+        idle_days: 7,
+        now: SystemTime::now(),
+    };
+    let report = run_gc(&cfg, &gh).expect("gc apply");
+
+    assert_eq!(report.worktrees_examined, 1);
+    assert_eq!(report.candidates.len(), 0, "{report:?}");
+    assert!(report.pruned.is_empty());
+    assert!(wt_dir.exists());
+}
+
+#[test]
+fn deleted_origin_branch_is_pruned() {
+    let parent_tmp = tempdir().unwrap();
+    let parent = parent_tmp.path();
+    init_repo(parent);
+
+    let roots_tmp = tempdir().unwrap();
+    let wt_dir = roots_tmp.path().join("eng-gone");
+    add_worktree(parent, "engineer/eng-gone", &wt_dir);
+
+    let gh = FakeGh::default();
+    gh.on_origin
+        .lock()
+        .unwrap()
+        .insert("engineer/eng-gone".to_string(), Some(false));
+
+    let cfg = GcConfig {
+        roots: vec![roots_tmp.path().to_path_buf()],
+        parent_repo: parent.to_path_buf(),
+        apply: false,
+        idle_days: 7,
+        now: SystemTime::now(),
+    };
+    let report = run_gc(&cfg, &gh).expect("gc dry");
+
+    assert_eq!(report.candidates.len(), 1);
+    assert!(matches!(
+        report.candidates[0].reasons[0],
+        PruneReason::BranchDeletedFromOrigin
+    ));
+}
+
+#[test]
+fn parser_then_policy_round_trip() {
+    // Synthesize a porcelain block by hand and feed it through both
+    // pieces — the runner does this same composition on real `git
+    // worktree list` output.
+    let raw = "\
+worktree /repo
+bare
+
+worktree /tmp/wt
+HEAD abc
+branch refs/heads/feat/x
+";
+    let entries = parse_worktree_list(raw);
+    assert_eq!(entries.len(), 2);
+
+    let inputs = CandidateInputs {
+        merged_prs: vec![1],
+        branch_on_origin: Some(true),
+        last_activity: Some(SystemTime::now()),
+    };
+    assert!(evaluate_candidate(&entries[0], &inputs, SystemTime::now(), 7).is_none());
+    assert!(evaluate_candidate(&entries[1], &inputs, SystemTime::now(), 7).is_some());
+}
+
+#[test]
+fn render_reason_strings_are_human_readable() {
+    let s = render_reason(&PruneReason::BranchMerged {
+        pr_numbers: vec![42, 43],
+    });
+    assert_eq!(s, "branch merged (#42, #43)");
+    assert_eq!(
+        render_reason(&PruneReason::BranchDeletedFromOrigin),
+        "branch deleted from origin"
+    );
+    assert_eq!(
+        render_reason(&PruneReason::IdleTooLong { age_days: 14 }),
+        "idle 14d"
+    );
+}
+
+#[test]
+fn under_any_root_handles_missing_root_gracefully() {
+    let real = tempdir().unwrap();
+    let inside = real.path().join("child");
+    std::fs::create_dir_all(&inside).unwrap();
+
+    let roots = vec![
+        PathBuf::from("/nonexistent/root/does/not/exist"),
+        real.path().to_path_buf(),
+    ];
+    assert!(under_any_root(&inside, &roots));
+    assert!(!under_any_root(Path::new("/etc"), &roots));
+}


### PR DESCRIPTION
## Summary

New `simard worktree-gc [--apply]` subcommand and `worktree_gc` module that enumerate engineer worktrees registered with the parent repo and prune those whose:

- branch was merged upstream (`gh pr list --state merged` returns >0 PRs), OR
- branch was deleted from origin (`git ls-remote --heads origin <b>` empty), OR
- have been idle longer than `--idle-days` (default 7d, claim sentinel / worktree dir mtime).

## Why

The disk-fill incident (issue #1697) was triggered by ~81 GB of orphaned engineer worktrees that no path was ever responsible for cleaning. The existing `engineer_worktree::cleanup` handles per-allocation tear-down for live OODA cycles only; cross-cycle and cross-process leakage (daemon restarts, crashed engineers, manually-killed sweeps) accumulates indefinitely. This GC closes that gap.

## What changed

- `src/worktree_gc/{mod,parse,policy,runner,tests}.rs` — new module, layered as parser → pure policy → side-effecting runner with `GhClient` trait for tests.
- `src/operator_cli/worktree_gc.rs` — CLI dispatch. Defaults to dry-run; `--apply` required to mutate. Supports `--idle-days=N`, `--root=PATH` (repeatable), `--parent-repo=PATH`.
- `src/operator_cli/mod.rs` — wire the subcommand into dispatch + help.
- `src/lib.rs` — `pub mod worktree_gc;`.

## Safety

- Dry-run is the default. `--apply` must be explicit.
- Both scan and prune phases gate on canonical-prefix containment in the configured roots — a candidate that drifts outside is refused, never deleted.
- `gh` / `git ls-remote` failures → inconclusive (logged at WARN); policy never prunes on a network error alone.
- Bare parent worktree is never a candidate.

## Configurability

- `SIMARD_WORKTREE_GC_ROOTS` (colon-separated) overrides default roots.
- Defaults: `$HOME/.simard/engineer-worktrees`, `$HOME/src/Simard/worktrees`.

OODA-cycle integration (one-tick-per-hour) is intentionally out of scope; the CLI is the foundation and periodic invocation becomes a one-line follow-up once operators have hand-tested it.

## Merge readiness

### QA-team evidence

- Scenario files: `src/worktree_gc/parse.rs` (7 tests), `src/worktree_gc/policy.rs` (12 tests), `src/worktree_gc/tests.rs` (8 integration tests using real `git worktree add` + FakeGh), `src/operator_cli/worktree_gc.rs` (2 CLI dispatch tests). Total: 29 new tests.
- Validation command: `cargo test --release --lib worktree_gc operator_cli::worktree_gc`
- Validation result: passed (29/29)
- Run command: `cargo test --release --lib -- --test-threads=$(nproc)`
- Run target: local
- Run result: passed (3876 passed, 0 failed, 4 ignored)
- Evidence location: PR description above; commit message body has full per-area test counts.

### Documentation

- User-facing docs impact: yes (new operator subcommand)
- Updated docs: `src/operator_cli/mod.rs` `OPERATOR_CLI_HELP` + usage one-liner now lists `worktree-gc`; `src/operator_cli/worktree_gc.rs` carries inline `--help` text printable via `simard worktree-gc --help`.
- PR description links added: n/a
- Rationale if not applicable: README/docs site updates intentionally deferred — operators discover this via `simard --help` and the CLI's own `--help` flag, matching the pattern used by `merge-pr`, `safe-update`, and `rollback-watchdog`.

### Quality-audit

- Cycle 1 summary: identified `dead_code` warning on a leftover test helper (`empty_inputs`) — removed, re-ran tests, clean.
- Cycle 2 summary: cargo fmt rewrites for consolidated `use` and one-liner trait methods — auto-applied, no behavior change.
- Cycle 3 summary: re-checked safety properties: bare-parent never qualifies, dry-run leaves disk untouched, network-error treated as inconclusive, canonical-prefix check at scan AND prune. All explicitly tested.
- Additional cycles: none
- Final clean cycle: 3 (zero critical/high, zero medium correctness/security findings)
- Fixes followed default-workflow: yes
- Convergence summary: module is self-contained (no other crate code touched besides `lib.rs` mod declaration and `operator_cli/mod.rs` dispatch wiring); both touched files have unit-test coverage of the dispatch path.

### CI

- Checks command: `gh pr checks <pr>`
- Result: pending (will be filled after CI completes)
- Skipped checks: none expected
- Flaky reruns performed: none
- Real failures fixed: none

### PR description evidence

This PR description follows `~/.copilot/skills/merge-ready/pr-description-template.md`. All six required sections present with concrete evidence (commands, counts, rationale).

### Scope

- Changed files reviewed: `git diff origin/main --stat` → 8 files, 1439 insertions, 1 deletion. New `worktree_gc/` module + new `operator_cli/worktree_gc.rs` + 2 small wiring edits to `lib.rs` and `operator_cli/mod.rs`.
- Unrelated changes: none. Reverted an auto-modified `.github/hooks/amplihack-hooks.json` before commit.

### Verdict

- Merge-ready: yes (pending CI green)
- Remaining blockers: none

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
