### PR TITLE
feat(meeting): /state slash command + JSON sibling for handoff artifact (#1646)

### DIFF
--- a/src/meeting_backend/command.rs
+++ b/src/meeting_backend/command.rs
@@ -19,6 +19,9 @@ pub enum MeetingCommand {
     Recap,
     /// Preview what the handoff artifact will look like when the meeting closes.
     Preview,
+    /// Re-display the running list of decisions, open questions, and action items
+    /// extracted from the live meeting transcript. Read-only — does not close.
+    State,
     /// Natural language — forwarded to the LLM.
     Conversation(String),
 }
@@ -41,6 +44,7 @@ pub fn parse_command(input: &str) -> MeetingCommand {
         "/export" => MeetingCommand::Export,
         "/recap" => MeetingCommand::Recap,
         "/preview" => MeetingCommand::Preview,
+        "/state" => MeetingCommand::State,
         "/template" => MeetingCommand::Template(String::new()),
         _ if lower.starts_with("/template ") => {
             let arg = trimmed["/template ".len()..].trim().to_string();
@@ -169,6 +173,36 @@ mod tests {
         assert_eq!(
             parse_command("   "),
             MeetingCommand::Conversation(String::new()),
+        );
+    }
+
+    // ── /state command (issue #1646 — TDD red phase) ─────────────────
+
+    #[test]
+    fn parse_state_exact_token() {
+        // "/state" with no surplus tokens parses to State variant.
+        assert_eq!(parse_command("/state"), MeetingCommand::State);
+    }
+
+    #[test]
+    fn parse_state_case_and_whitespace_insensitive() {
+        // Mirrors /help, /close, /status conventions.
+        assert_eq!(parse_command("  /STATE  "), MeetingCommand::State);
+        assert_eq!(parse_command("/State"), MeetingCommand::State);
+    }
+
+    #[test]
+    fn parse_state_with_surplus_tokens_is_conversation() {
+        // Security M4 / S5: /state takes no arguments. Surplus tokens must
+        // NOT be silently coerced into a State command — they fall through
+        // to Conversation so the operator's intent isn't misread.
+        assert_eq!(
+            parse_command("/state foo"),
+            MeetingCommand::Conversation("/state foo".to_string()),
+        );
+        assert_eq!(
+            parse_command("/state extra args"),
+            MeetingCommand::Conversation("/state extra args".to_string()),
         );
     }
 }

--- a/src/meeting_backend/persist/json_sibling.rs
+++ b/src/meeting_backend/persist/json_sibling.rs
@@ -1,0 +1,192 @@
+//! Structured JSON sibling artifact emitted alongside the markdown handoff
+//! report (issue #1646).
+//!
+//! For every markdown handoff report written to `meetings_dir()/{stem}.md`,
+//! we also emit `meetings_dir()/{stem}.json` containing the same content in
+//! a stable, machine-readable shape so downstream tooling (dashboards, OODA
+//! loops, third-party consumers) can ingest meeting outcomes without
+//! re-parsing the markdown.
+//!
+//! Markdown remains the canonical artifact: a JSON write failure must NOT
+//! abort the markdown write — it is logged at `warn!` level and skipped,
+//! mirroring the resilience pattern in [`super::write_handoff`].
+//!
+//! Schema: [`JsonHandoffSibling`] — versioned via [`JsonHandoffSibling::schema_version`]
+//! ("v1") so consumers can branch on future schema changes.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use tracing::warn;
+
+use crate::error::SimardResult;
+use crate::meeting_backend::types::HandoffActionItem;
+
+use super::extract::extract_open_questions;
+use crate::meeting_backend::types::ConversationMessage;
+use crate::meeting_facilitator::MeetingDecision;
+
+/// Current sibling JSON schema version. Bump when adding non-additive changes.
+const SCHEMA_VERSION: &str = "v1";
+
+/// Structured JSON sibling artifact written next to the markdown handoff
+/// report. Same directory, same basename, `.json` extension.
+///
+/// `Option<String>` fields serialize as explicit JSON `null` (NOT omitted)
+/// so consumers see a uniform shape across every emitted file.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct JsonHandoffSibling {
+    /// Schema version string ("v1"). Always present.
+    pub schema_version: String,
+    /// Unique participant labels derived from message roles + action item
+    /// assignees. Order: insertion order from extraction (deterministic).
+    pub participants: Vec<String>,
+    /// Decision descriptions extracted from the meeting.
+    pub decisions: Vec<String>,
+    /// Action items in the canonical sibling shape (title/owner/acceptance_criteria).
+    pub action_items: Vec<JsonHandoffActionItem>,
+    /// Open questions extracted from the transcript via [`extract_open_questions`].
+    pub open_questions: Vec<String>,
+    /// Reference to the canonical markdown report — the markdown file's
+    /// basename (NOT a full local path, to avoid leaking host paths into a
+    /// portable artifact).
+    pub transcript_ref: String,
+}
+
+/// Action item shape used inside the JSON sibling.
+///
+/// Field mapping from [`HandoffActionItem`] (resolved per design A3):
+/// - `title`               := `description`
+/// - `owner`               := `assignee` (`None` for unassigned, NOT empty/"unassigned")
+/// - `acceptance_criteria` := always `None` until the extractor learns to populate it (A2)
+///
+/// `Option<String>` fields serialize as explicit JSON `null` so every
+/// `action_items[i]` entry has the same shape — consumers can rely on
+/// `obj.owner === null` rather than branching on missing keys.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct JsonHandoffActionItem {
+    pub title: String,
+    pub owner: Option<String>,
+    pub acceptance_criteria: Option<String>,
+}
+
+impl From<&HandoffActionItem> for JsonHandoffActionItem {
+    fn from(src: &HandoffActionItem) -> Self {
+        Self {
+            title: src.description.clone(),
+            owner: src.assignee.clone(),
+            // `acceptance_criteria` is a reserved slot for future extractor
+            // work (design A2): the current heuristic extractor produces no
+            // such field, so we always emit `null` here. Schema-stable.
+            acceptance_criteria: None,
+        }
+    }
+}
+
+/// Build the [`JsonHandoffSibling`] DTO from the same inputs as the markdown
+/// writer. Pure function — performs no I/O.
+///
+/// Reuses [`extract_open_questions`] for the `open_questions` field so there
+/// is no duplicate parsing logic (per task spec).
+pub(super) fn build_sibling(
+    md_path: &Path,
+    messages: &[ConversationMessage],
+    action_items: &[HandoffActionItem],
+    decisions: &[MeetingDecision],
+) -> JsonHandoffSibling {
+    // Participants: same derivation as the markdown writer — message roles
+    // plus action-item assignees, deduped, insertion-order preserved.
+    let mut participants: Vec<String> = Vec::new();
+    for msg in messages {
+        let role_name = match msg.role {
+            crate::meeting_backend::types::Role::User => "operator",
+            crate::meeting_backend::types::Role::Assistant => "simard",
+            crate::meeting_backend::types::Role::System => "system",
+        };
+        let s = role_name.to_string();
+        if !participants.contains(&s) {
+            participants.push(s);
+        }
+    }
+    for a in action_items {
+        if let Some(ref assignee) = a.assignee
+            && !participants.contains(assignee)
+        {
+            participants.push(assignee.clone());
+        }
+    }
+
+    // Decisions: flatten to descriptions for the JSON schema (rationale and
+    // participants live in the markdown view, not the structured sibling).
+    let decision_strings: Vec<String> = decisions.iter().map(|d| d.description.clone()).collect();
+
+    // Open questions: reuse the existing extractor — no duplicate parsing.
+    let open_questions: Vec<String> = extract_open_questions(messages)
+        .into_iter()
+        .map(|q| q.text)
+        .collect();
+
+    // Action items: convert via the documented field mapping.
+    let action_items: Vec<JsonHandoffActionItem> = action_items
+        .iter()
+        .map(JsonHandoffActionItem::from)
+        .collect();
+
+    // transcript_ref is the markdown file's basename (privacy: never the
+    // full local path — see design A4).
+    let transcript_ref = md_path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("")
+        .to_string();
+
+    JsonHandoffSibling {
+        schema_version: SCHEMA_VERSION.to_string(),
+        participants,
+        decisions: decision_strings,
+        action_items,
+        open_questions,
+        transcript_ref,
+    }
+}
+
+/// Write the JSON sibling artifact next to `md_path`.
+///
+/// Sibling path is `md_path.with_extension("json")`. On Unix the file mode
+/// is set to `0o600` to mirror the markdown report's privacy guarantee
+/// (security S2). Errors are propagated so the caller can decide whether to
+/// log-and-continue (resilience) or fail.
+pub(super) fn write_json_sibling_for_markdown(
+    md_path: &Path,
+    messages: &[ConversationMessage],
+    action_items: &[HandoffActionItem],
+    decisions: &[MeetingDecision],
+) -> SimardResult<PathBuf> {
+    let sibling = build_sibling(md_path, messages, action_items, decisions);
+    let json_path = md_path.with_extension("json");
+
+    let json = serde_json::to_string_pretty(&sibling).map_err(|e| {
+        crate::error::SimardError::ActionExecutionFailed {
+            action: "serialize-json-sibling".to_string(),
+            reason: e.to_string(),
+        }
+    })?;
+
+    std::fs::write(&json_path, &json).map_err(|e| {
+        crate::error::SimardError::ActionExecutionFailed {
+            action: "write-json-sibling".to_string(),
+            reason: e.to_string(),
+        }
+    })?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = std::fs::Permissions::from_mode(0o600);
+        if let Err(e) = std::fs::set_permissions(&json_path, perms) {
+            warn!("Failed to set JSON sibling permissions: {e}");
+        }
+    }
+
+    Ok(json_path)
+}

--- a/src/meeting_backend/persist/markdown.rs
+++ b/src/meeting_backend/persist/markdown.rs
@@ -262,5 +262,23 @@ pub fn write_handoff_markdown_report(
     }
 
     info!(path = %path.display(), "Meeting handoff report written");
+
+    // Emit the structured JSON sibling artifact alongside the markdown
+    // report (issue #1646). Markdown remains the canonical artifact —
+    // a JSON write failure is logged and skipped, never propagated.
+    match super::json_sibling::write_json_sibling_for_markdown(
+        &path,
+        messages,
+        action_items,
+        decisions,
+    ) {
+        Ok(json_path) => {
+            info!(path = %json_path.display(), "Meeting handoff JSON sibling written");
+        }
+        Err(e) => {
+            warn!(error = %e, "Failed to write JSON sibling for handoff report — markdown remains canonical");
+        }
+    }
+
     Ok(path)
 }

--- a/src/meeting_backend/persist/mod.rs
+++ b/src/meeting_backend/persist/mod.rs
@@ -43,8 +43,16 @@ pub fn sanitize_filename(input: &str) -> String {
     }
 }
 
-/// Directory for meeting transcripts: `~/.simard/meetings/`.
+/// Directory for meeting transcripts: `$SIMARD_MEETINGS_DIR` if set, else
+/// `~/.simard/meetings/`.
+///
+/// The env var override mirrors the `SIMARD_HANDOFF_DIR` idiom in
+/// [`meeting_facilitator::default_handoff_dir`] so tests (and operators) can
+/// redirect meeting artifacts to a tempdir without touching `$HOME`.
 pub(super) fn meetings_dir() -> PathBuf {
+    if let Some(override_path) = std::env::var_os("SIMARD_MEETINGS_DIR") {
+        return PathBuf::from(override_path);
+    }
     dirs::home_dir()
         .unwrap_or_else(|| PathBuf::from("."))
         .join(".simard/meetings")
@@ -239,6 +247,7 @@ mod markdown;
 pub use markdown::{write_handoff_markdown_report, write_markdown_export};
 mod cognitive;
 mod extract;
+mod json_sibling;
 mod templates;
 
 pub use cognitive::{store_cognitive_memory, store_enriched_cognitive_memory};
@@ -251,4 +260,5 @@ pub use extract::{
     extract_action_items, extract_decision_participants_pub, extract_decision_rationale_pub,
     extract_decisions, extract_open_questions, extract_themes, link_action_items_to_goals,
 };
+pub use json_sibling::{JsonHandoffActionItem, JsonHandoffSibling};
 pub use templates::{MeetingTemplate, TEMPLATES, find_template};

--- a/src/meeting_backend/tests_persist_extra.rs
+++ b/src/meeting_backend/tests_persist_extra.rs
@@ -187,3 +187,389 @@ fn write_handoff_empty_data_uses_defaults() {
         std::env::remove_var("SIMARD_HANDOFF_DIR");
     }
 }
+
+// ── JSON sibling artifact (issue #1646 — TDD red phase) ──────────────────
+//
+// The markdown handoff writer emits a structured JSON sibling artifact next
+// to the markdown report (same dir, same basename, `.json` extension). The
+// JSON shape is documented in `docs/operations/meeting-handoffs.md` and
+// includes: schema_version, participants, decisions, action_items
+// (each with title/owner/acceptance_criteria), open_questions, transcript_ref.
+//
+// Tests below set SIMARD_MEETINGS_DIR to a tempdir to redirect output.
+// The env override mirrors the SIMARD_HANDOFF_DIR idiom in
+// meeting_facilitator::default_handoff_dir().
+
+use crate::meeting_backend::persist::{
+    JsonHandoffActionItem, JsonHandoffSibling, write_handoff_markdown_report,
+};
+use crate::meeting_facilitator::MeetingDecision;
+
+fn populated_messages() -> Vec<ConversationMessage> {
+    vec![
+        make_msg(Role::User, "We need to ship the migration."),
+        make_msg(
+            Role::Assistant,
+            "Decision: We will adopt TDD. OPEN: Who owns the rollback plan for the migration?",
+        ),
+    ]
+}
+
+fn populated_action_items() -> Vec<HandoffActionItem> {
+    vec![
+        HandoffActionItem {
+            description: "Set up CI pipeline".to_string(),
+            assignee: Some("alice".to_string()),
+            deadline: Some("Friday".to_string()),
+            linked_goal: None,
+            priority: Some(1),
+        },
+        HandoffActionItem {
+            description: "Document migration steps".to_string(),
+            assignee: None,
+            deadline: None,
+            linked_goal: None,
+            priority: None,
+        },
+    ]
+}
+
+fn populated_decisions() -> Vec<MeetingDecision> {
+    vec![MeetingDecision {
+        description: "We will adopt TDD".to_string(),
+        rationale: "Better quality bar.".to_string(),
+        participants: vec!["operator".to_string(), "simard".to_string()],
+    }]
+}
+
+/// The markdown handoff writer must emit a JSON sibling file with the same
+/// basename and a `.json` extension, in the same directory as the markdown
+/// report. Markdown remains the canonical artifact; JSON is a side-effect.
+#[test]
+#[serial]
+fn markdown_handoff_writes_json_sibling_with_same_basename() {
+    let dir = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("SIMARD_MEETINGS_DIR", dir.path().as_os_str());
+    }
+
+    let md_path = write_handoff_markdown_report(
+        "Sprint planning",
+        "2025-01-01T00:00:00Z",
+        "Good meeting summary.",
+        &populated_messages(),
+        &populated_action_items(),
+        &populated_decisions(),
+        &[],
+    )
+    .expect("markdown handoff write should succeed under SIMARD_MEETINGS_DIR override");
+
+    // Sibling lives at the same path with `.json` extension.
+    let json_path = md_path.with_extension("json");
+    assert!(
+        json_path.exists(),
+        "expected JSON sibling at {} alongside markdown {}",
+        json_path.display(),
+        md_path.display(),
+    );
+
+    // Same parent directory as the markdown report.
+    assert_eq!(
+        json_path.parent(),
+        md_path.parent(),
+        "JSON sibling must live in the same directory as the markdown report",
+    );
+
+    // Same basename (stem) — only the extension differs.
+    assert_eq!(
+        json_path.file_stem(),
+        md_path.file_stem(),
+        "JSON sibling must share the markdown report's basename",
+    );
+
+    unsafe {
+        std::env::remove_var("SIMARD_MEETINGS_DIR");
+    }
+}
+
+/// JSON sibling deserializes into the `JsonHandoffSibling` DTO with all
+/// expected fields populated. This is the contract consumers depend on:
+/// - schema_version (string, "v1")
+/// - participants (Vec<String>)
+/// - decisions (Vec<String>)
+/// - action_items: Vec<JsonHandoffActionItem { title, owner, acceptance_criteria }>
+/// - open_questions (Vec<String>)
+/// - transcript_ref (String)
+#[test]
+#[serial]
+fn json_sibling_round_trips_all_fields_via_serde_json() {
+    let dir = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("SIMARD_MEETINGS_DIR", dir.path().as_os_str());
+    }
+
+    let md_path = write_handoff_markdown_report(
+        "Sprint planning",
+        "2025-01-01T00:00:00Z",
+        "Good summary.",
+        &populated_messages(),
+        &populated_action_items(),
+        &populated_decisions(),
+        &[],
+    )
+    .unwrap();
+
+    let json_path = md_path.with_extension("json");
+    let json_text = std::fs::read_to_string(&json_path).unwrap_or_else(|e| {
+        panic!(
+            "failed to read JSON sibling at {}: {e}",
+            json_path.display()
+        )
+    });
+
+    // Must deserialize into the canonical DTO.
+    let sibling: JsonHandoffSibling = serde_json::from_str(&json_text)
+        .unwrap_or_else(|e| panic!("JSON sibling failed to deserialize into JsonHandoffSibling: {e}\n--- json ---\n{json_text}"));
+
+    // schema_version is "v1" so consumers can branch on future schema changes.
+    assert_eq!(
+        sibling.schema_version, "v1",
+        "schema_version must be 'v1' for the initial schema",
+    );
+
+    // Participants must include the operator role at minimum (derived from
+    // the user message in populated_messages()).
+    assert!(
+        sibling.participants.iter().any(|p| p == "operator"),
+        "participants should include 'operator' from messages: {:?}",
+        sibling.participants,
+    );
+
+    // Decisions vector contains the structured decision descriptions.
+    assert!(
+        sibling
+            .decisions
+            .iter()
+            .any(|d| d.contains("adopt TDD") || d.contains("TDD")),
+        "decisions should include the TDD decision: {:?}",
+        sibling.decisions,
+    );
+
+    // Action items map title := description, owner := assignee.
+    assert_eq!(
+        sibling.action_items.len(),
+        2,
+        "expected 2 action items in sibling: {:?}",
+        sibling.action_items,
+    );
+    let ci = sibling
+        .action_items
+        .iter()
+        .find(|a| a.title == "Set up CI pipeline")
+        .unwrap_or_else(|| {
+            panic!(
+                "missing 'Set up CI pipeline' action item: {:?}",
+                sibling.action_items
+            )
+        });
+    assert_eq!(ci.owner.as_deref(), Some("alice"));
+
+    // Open questions are extracted from the transcript via existing
+    // extract_open_questions helper (no duplicate parsing).
+    assert!(
+        !sibling.open_questions.is_empty(),
+        "open_questions should be populated from message extraction: {:?}",
+        sibling.open_questions,
+    );
+
+    // transcript_ref locates the markdown file. Per the design, it is the
+    // markdown report's basename (privacy: no full local paths leak into the
+    // handoff artifact).
+    let md_basename = md_path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap()
+        .to_string();
+    assert_eq!(
+        sibling.transcript_ref, md_basename,
+        "transcript_ref should be the markdown report's basename, not a full path",
+    );
+
+    // Round-trip through serde_json::to_string preserves equality.
+    let reserialized = serde_json::to_string(&sibling).unwrap();
+    let sibling2: JsonHandoffSibling = serde_json::from_str(&reserialized).unwrap();
+    assert_eq!(sibling, sibling2);
+
+    unsafe {
+        std::env::remove_var("SIMARD_MEETINGS_DIR");
+    }
+}
+
+/// Empty extraction must serialize as JSON empty arrays (`[]`), NOT as
+/// `null`. Consumers (dashboards, downstream tools) iterate over these
+/// arrays and would crash on `null`.
+#[test]
+#[serial]
+fn json_sibling_with_empty_extraction_serializes_empty_arrays_not_null() {
+    let dir = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("SIMARD_MEETINGS_DIR", dir.path().as_os_str());
+    }
+
+    let md_path = write_handoff_markdown_report(
+        "Empty meeting",
+        "2025-01-01T00:00:00Z",
+        "Nothing was discussed.",
+        &[],
+        &[],
+        &[],
+        &[],
+    )
+    .unwrap();
+
+    let json_path = md_path.with_extension("json");
+    let json_text = std::fs::read_to_string(&json_path).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&json_text).unwrap();
+
+    for field in &[
+        "participants",
+        "decisions",
+        "action_items",
+        "open_questions",
+    ] {
+        let val = &v[field];
+        assert!(
+            val.is_array(),
+            "field `{field}` must serialize as a JSON array (not null/missing): {json_text}"
+        );
+        assert!(
+            val.as_array().unwrap().is_empty(),
+            "field `{field}` should be an empty array on empty extraction: {json_text}"
+        );
+    }
+
+    // schema_version still present even on empty meeting.
+    assert_eq!(
+        v["schema_version"],
+        serde_json::Value::String("v1".to_string())
+    );
+
+    // transcript_ref is always a non-empty string (the markdown basename).
+    assert!(
+        v["transcript_ref"].is_string(),
+        "transcript_ref must be a string: {json_text}"
+    );
+    assert!(
+        !v["transcript_ref"].as_str().unwrap().is_empty(),
+        "transcript_ref must not be empty: {json_text}"
+    );
+
+    unsafe {
+        std::env::remove_var("SIMARD_MEETINGS_DIR");
+    }
+}
+
+/// Security S2: JSON sibling must be world-unreadable (mode 0o600) on Unix
+/// to mirror the markdown report and transcript privacy guarantees. This
+/// prevents meeting content leaking via shared `~` directories or backups
+/// readable by other users on the same host.
+#[cfg(unix)]
+#[test]
+#[serial]
+fn json_sibling_has_owner_only_permissions_on_unix() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("SIMARD_MEETINGS_DIR", dir.path().as_os_str());
+    }
+
+    let md_path = write_handoff_markdown_report(
+        "Permission test",
+        "2025-01-01T00:00:00Z",
+        "Some summary.",
+        &populated_messages(),
+        &populated_action_items(),
+        &populated_decisions(),
+        &[],
+    )
+    .unwrap();
+
+    let json_path = md_path.with_extension("json");
+    let meta = std::fs::metadata(&json_path).unwrap();
+    let mode = meta.permissions().mode() & 0o777;
+    assert_eq!(
+        mode,
+        0o600,
+        "JSON sibling at {} must be 0o600, got {:o}",
+        json_path.display(),
+        mode,
+    );
+
+    unsafe {
+        std::env::remove_var("SIMARD_MEETINGS_DIR");
+    }
+}
+
+/// `JsonHandoffActionItem::from(&HandoffActionItem)` maps fields exactly as
+/// specified: `title := description`, `owner := assignee`,
+/// `acceptance_criteria := None` (reserved slot for future extractor work).
+#[test]
+fn json_handoff_action_item_from_handoff_action_item_maps_fields() {
+    let src = HandoffActionItem {
+        description: "Ship v1.0".to_string(),
+        assignee: Some("bob".to_string()),
+        deadline: Some("EOD".to_string()),
+        linked_goal: Some("release-train".to_string()),
+        priority: Some(1),
+    };
+    let dst: JsonHandoffActionItem = (&src).into();
+    assert_eq!(dst.title, "Ship v1.0");
+    assert_eq!(dst.owner.as_deref(), Some("bob"));
+    assert_eq!(
+        dst.acceptance_criteria, None,
+        "acceptance_criteria is a reserved slot; current extractor never populates it",
+    );
+
+    // Unassigned action item maps to owner=None (NOT empty string, NOT 'unassigned').
+    let unassigned = HandoffActionItem {
+        description: "Triage backlog".to_string(),
+        assignee: None,
+        deadline: None,
+        linked_goal: None,
+        priority: None,
+    };
+    let dst2: JsonHandoffActionItem = (&unassigned).into();
+    assert_eq!(dst2.title, "Triage backlog");
+    assert_eq!(dst2.owner, None);
+}
+
+/// Per design A2 (resolve to explicit `null`), `Option<String>` fields on
+/// `JsonHandoffActionItem` must serialize as JSON `null` when None — NOT
+/// be omitted via `skip_serializing_if`. This is a contract consumers can
+/// rely on (every action_item entry has the same shape).
+#[test]
+fn json_handoff_action_item_none_fields_serialize_as_explicit_null() {
+    let item = JsonHandoffActionItem {
+        title: "Triage backlog".to_string(),
+        owner: None,
+        acceptance_criteria: None,
+    };
+    let json = serde_json::to_string(&item).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(
+        v["owner"],
+        serde_json::Value::Null,
+        "owner=None must serialize as explicit JSON null: {json}"
+    );
+    assert_eq!(
+        v["acceptance_criteria"],
+        serde_json::Value::Null,
+        "acceptance_criteria=None must serialize as explicit JSON null: {json}"
+    );
+    // The `title` field is always present.
+    assert_eq!(
+        v["title"],
+        serde_json::Value::String("Triage backlog".to_string())
+    );
+}

--- a/src/meeting_repl/repl.rs
+++ b/src/meeting_repl/repl.rs
@@ -8,7 +8,10 @@ use std::io::{BufRead, Write};
 use crate::base_types::BaseTypeSession;
 use crate::cognitive_memory::CognitiveMemoryOps;
 use crate::error::{SimardError, SimardResult};
-use crate::meeting_backend::{MeetingBackend, MeetingCommand, parse_command};
+use crate::meeting_backend::persist::{
+    extract_action_items, extract_decisions, extract_open_questions,
+};
+use crate::meeting_backend::{MeetingBackend, MeetingCommand, parse_command, strip_ansi_escapes};
 use crate::meeting_facilitator::MeetingSession;
 
 use super::color::{cyan, green, yellow};
@@ -92,7 +95,7 @@ pub fn run_meeting_repl<R: BufRead, W: Write>(
             MeetingCommand::Help => {
                 writeln!(
                     output,
-                    "Commands:\n  /status    — show session info\n  /template  — list meeting templates\n  /template <name> — apply a template (standup, 1on1, retro, planning)\n  /theme <text>    — record a theme for this meeting\n  /recap     — show color-coded session recap\n  /preview   — preview the handoff artifact\n  /export    — export meeting as markdown\n  /close     — end meeting and persist\n  /help      — this message\n\nEverything else is natural conversation with Simard."
+                    "Commands:\n  /status    — show session info\n  /state     — show current decisions, open questions, action items\n  /template  — list meeting templates\n  /template <name> — apply a template (standup, 1on1, retro, planning)\n  /theme <text>    — record a theme for this meeting\n  /recap     — show color-coded session recap\n  /preview   — preview the handoff artifact\n  /export    — export meeting as markdown\n  /close     — end meeting and persist\n  /help      — this message\n\nEverything else is natural conversation with Simard."
                 )
                 .ok();
             }
@@ -101,6 +104,62 @@ pub fn run_meeting_repl<R: BufRead, W: Write>(
                 writeln!(output, "Meeting: {}", status.topic).ok();
                 writeln!(output, "  Messages: {}", status.message_count).ok();
                 writeln!(output, "  Started:  {}", status.started_at).ok();
+            }
+            MeetingCommand::State => {
+                // Re-display the running list of decisions, open questions, and
+                // action items extracted from the live transcript. Read-only —
+                // does not close or summarize the meeting. Reuses the existing
+                // extractors in `meeting_backend::persist::extract` (issue #1646).
+                let messages = backend.history();
+                let decisions = extract_decisions(messages);
+                let open_questions = extract_open_questions(messages);
+                let action_items = extract_action_items(messages);
+
+                // Canonical order per task spec: Decisions → Open Questions →
+                // Action Items. (Different from the post-/close summary order.)
+                writeln!(output, "\n{}", cyan("── Decisions ──")).ok();
+                if decisions.is_empty() {
+                    writeln!(output, "  _(none)_").ok();
+                } else {
+                    for (i, d) in decisions.iter().enumerate() {
+                        // Sanitize LLM-sourced content (S1): strip ANSI escapes
+                        // before rendering to the terminal so a malicious model
+                        // can't reposition the cursor or clear the screen.
+                        let safe = strip_ansi_escapes(d);
+                        writeln!(output, "  {}. {safe}", i + 1).ok();
+                    }
+                }
+
+                writeln!(output, "\n{}", yellow("── Open Questions ──")).ok();
+                if open_questions.is_empty() {
+                    writeln!(output, "  _(none)_").ok();
+                } else {
+                    for q in &open_questions {
+                        let safe = strip_ansi_escapes(&q.text);
+                        let tag = if q.explicit { " *(explicit)*" } else { "" };
+                        writeln!(output, "  - {safe}{tag}").ok();
+                    }
+                }
+
+                writeln!(output, "\n{}", green("── Action Items ──")).ok();
+                if action_items.is_empty() {
+                    writeln!(output, "  _(none)_").ok();
+                } else {
+                    for (i, item) in action_items.iter().enumerate() {
+                        let safe_desc = strip_ansi_escapes(&item.description);
+                        let mut line = format!("  {}. {safe_desc}", i + 1);
+                        if let Some(ref who) = item.assignee {
+                            let safe_who = strip_ansi_escapes(who);
+                            line.push_str(&format!(" [→ {safe_who}]"));
+                        }
+                        if let Some(ref when) = item.deadline {
+                            let safe_when = strip_ansi_escapes(when);
+                            line.push_str(&format!(" ({safe_when})"));
+                        }
+                        writeln!(output, "{line}").ok();
+                    }
+                }
+                writeln!(output).ok();
             }
             MeetingCommand::Theme(text) => {
                 backend.push_theme(text.clone());

--- a/src/meeting_repl/tests_repl.rs
+++ b/src/meeting_repl/tests_repl.rs
@@ -363,3 +363,267 @@ fn repl_close_prints_one_line_headline_summary() {
         "headline summary must precede the detailed Meeting Summary section: {output_str}"
     );
 }
+
+// ── /state slash command (issue #1646 — TDD red phase) ──────────────────
+//
+// The /state command re-displays the running list of decisions, open
+// questions, and action items extracted from the live meeting transcript
+// without closing the meeting. Sections are rendered in a canonical order
+// (Decisions → Open Questions → Action Items), each with a colored heading
+// and `_(none)_` placeholders when empty. Reuses the existing extractors in
+// `meeting_backend::persist::extract` — no new parsing logic.
+
+/// /state on an empty transcript renders all three section headings with
+/// `_(none)_` placeholders so the operator gets a predictable, complete UI
+/// instead of a blank screen. Headings are always present.
+#[test]
+#[serial]
+fn repl_state_empty_renders_all_section_headings_with_none_placeholders() {
+    let bridge = mock_bridge();
+    // Use a benign canned response so any history entries don't accidentally
+    // trip the heuristic extractors.
+    let agent = MockAgentSession::new("ok");
+    let input = b"/state\n/close\n";
+    let mut reader = &input[..];
+    let mut output = Vec::new();
+
+    run_meeting_repl(
+        "Empty state test",
+        &bridge,
+        Some(Box::new(agent)),
+        "",
+        &mut reader,
+        &mut output,
+    )
+    .unwrap();
+
+    let output_str = String::from_utf8(output).unwrap();
+
+    // All three section headings appear when /state is invoked on an empty
+    // transcript. Match on the section labels (color-stripped) so the test
+    // is robust to ANSI changes.
+    assert!(
+        output_str.contains("Decisions"),
+        "state output should include 'Decisions' heading: {output_str}"
+    );
+    assert!(
+        output_str.contains("Open Questions"),
+        "state output should include 'Open Questions' heading: {output_str}"
+    );
+    assert!(
+        output_str.contains("Action Items"),
+        "state output should include 'Action Items' heading: {output_str}"
+    );
+
+    // The empty-state placeholder convention is `_(none)_`. We expect at
+    // least three occurrences (one per section) for a fully empty state.
+    let none_count = output_str.matches("_(none)_").count();
+    assert!(
+        none_count >= 3,
+        "expected at least 3 '_(none)_' placeholders (one per section) on empty state, got {none_count}: {output_str}"
+    );
+}
+
+/// /state on a populated transcript renders the extracted decisions, open
+/// questions, and action items derived from the in-memory history via the
+/// existing `meeting_backend::persist::extract` helpers.
+#[test]
+#[serial]
+fn repl_state_populated_renders_extracted_decisions_action_items_open_questions() {
+    let bridge = mock_bridge();
+    // Agent response embeds explicit signals the extractors recognize:
+    //   - "Decision:" → extract_decisions
+    //   - "TODO:"     → extract_action_items
+    //   - "OPEN:"     → extract_open_questions (explicit marker)
+    let agent = MockAgentSession::new(
+        "Decision: We will adopt TDD. TODO: Set up CI pipeline. OPEN: Who will own the rollout plan for the new pipeline?",
+    );
+    // First send a user message so the agent reply (with all the signals)
+    // is appended to backend.history(); then invoke /state.
+    let input = b"Let's plan the sprint\n/state\n/close\n";
+    let mut reader = &input[..];
+    let mut output = Vec::new();
+
+    run_meeting_repl(
+        "Populated state test",
+        &bridge,
+        Some(Box::new(agent)),
+        "",
+        &mut reader,
+        &mut output,
+    )
+    .unwrap();
+
+    let output_str = String::from_utf8(output).unwrap();
+
+    // Find the /state output region by locating the first "Decisions"
+    // heading after the opening prompt — this is the /state-rendered block,
+    // not the post-/close summary block (which appears later).
+    let state_region_start = output_str
+        .find("Decisions")
+        .unwrap_or_else(|| panic!("expected /state to render a 'Decisions' heading: {output_str}"));
+    // Bound the region by the next prompt or by the end-of-meeting summary.
+    let state_region_end = output_str[state_region_start..]
+        .find("simard:meeting>")
+        .map(|i| state_region_start + i)
+        .unwrap_or(output_str.len());
+    let state_region = &output_str[state_region_start..state_region_end];
+
+    // Each extracted item should appear in the /state output region.
+    assert!(
+        state_region.contains("TDD"),
+        "state output should include the extracted decision (TDD): {state_region}"
+    );
+    assert!(
+        state_region.contains("CI pipeline"),
+        "state output should include the extracted action item (CI pipeline): {state_region}"
+    );
+    assert!(
+        state_region.contains("rollout plan"),
+        "state output should include the extracted open question (rollout plan): {state_region}"
+    );
+}
+
+/// /state must render sections in the canonical order specified by the
+/// task: Decisions → Open Questions → Action Items. This is intentionally
+/// different from the /close summary order; verify the ordering directly.
+#[test]
+#[serial]
+fn repl_state_renders_sections_in_canonical_order_decisions_then_questions_then_actions() {
+    let bridge = mock_bridge();
+    let agent = MockAgentSession::new(
+        "Decision: Use Rust. TODO: Write the migration script. OPEN: What is the rollback strategy here?",
+    );
+    let input = b"Plan the migration\n/state\n/close\n";
+    let mut reader = &input[..];
+    let mut output = Vec::new();
+
+    run_meeting_repl(
+        "Order test",
+        &bridge,
+        Some(Box::new(agent)),
+        "",
+        &mut reader,
+        &mut output,
+    )
+    .unwrap();
+
+    let output_str = String::from_utf8(output).unwrap();
+
+    // Bound the region to the /state-rendered block (between the input echo
+    // and the next prompt) so we don't accidentally match the post-/close
+    // "── Decisions ──" / "── Action Items ──" summary headings (which use a
+    // different ordering and would hide a real bug).
+    let first_state_idx = output_str
+        .find("Decisions")
+        .unwrap_or_else(|| panic!("expected /state output to contain 'Decisions': {output_str}"));
+    let region_end = output_str[first_state_idx..]
+        .find("simard:meeting>")
+        .map(|i| first_state_idx + i)
+        .unwrap_or(output_str.len());
+    let region = &output_str[first_state_idx..region_end];
+
+    let dec_pos = region
+        .find("Decisions")
+        .unwrap_or_else(|| panic!("missing 'Decisions' in /state region: {region}"));
+    let oq_pos = region
+        .find("Open Questions")
+        .unwrap_or_else(|| panic!("missing 'Open Questions' in /state region: {region}"));
+    let ai_pos = region
+        .find("Action Items")
+        .unwrap_or_else(|| panic!("missing 'Action Items' in /state region: {region}"));
+
+    assert!(
+        dec_pos < oq_pos,
+        "Decisions must appear before Open Questions in /state output. \
+         dec_pos={dec_pos} oq_pos={oq_pos} region={region}"
+    );
+    assert!(
+        oq_pos < ai_pos,
+        "Open Questions must appear before Action Items in /state output. \
+         oq_pos={oq_pos} ai_pos={ai_pos} region={region}"
+    );
+}
+
+/// Security S1: any ANSI escape sequence (e.g. `\x1b[2J` clear-screen)
+/// embedded in an LLM-sourced message must be stripped before /state
+/// renders the bullet content to the terminal — otherwise an attacker
+/// controlling the LLM could reposition the cursor, clear the screen,
+/// or hijack the operator's terminal session.
+#[test]
+#[serial]
+fn repl_state_strips_ansi_escapes_from_llm_sourced_content_before_rendering() {
+    // Force NO_COLOR off so the REPL itself emits ANSI for headings — but
+    // any ANSI in the LLM content must still be stripped.
+    unsafe { std::env::remove_var("NO_COLOR") };
+
+    let bridge = mock_bridge();
+    // Embed a clear-screen escape inside the canned agent reply. After
+    // sanitization the literal ESC byte must NOT appear inside any extracted
+    // bullet shown by /state.
+    let agent =
+        MockAgentSession::new("Decision: Use \x1b[2JRust for the rewrite project unconditionally.");
+    let input = b"Make a call\n/state\n/close\n";
+    let mut reader = &input[..];
+    let mut output = Vec::new();
+
+    run_meeting_repl(
+        "Sanitize test",
+        &bridge,
+        Some(Box::new(agent)),
+        "",
+        &mut reader,
+        &mut output,
+    )
+    .unwrap();
+
+    let output_str = String::from_utf8(output).unwrap();
+
+    // Locate the /state region (between first Decisions heading and next prompt).
+    let region_start = output_str
+        .find("Decisions")
+        .unwrap_or_else(|| panic!("expected /state to render Decisions heading: {output_str}"));
+    let region_end = output_str[region_start..]
+        .find("simard:meeting>")
+        .map(|i| region_start + i)
+        .unwrap_or(output_str.len());
+    let region = &output_str[region_start..region_end];
+
+    // The decision text body should still be present (so we know the bullet
+    // was rendered) but the malicious clear-screen escape must be stripped.
+    assert!(
+        region.contains("Rust for the rewrite"),
+        "decision body should still be rendered after sanitization: {region}"
+    );
+    assert!(
+        !region.contains("\x1b[2J"),
+        "clear-screen escape from LLM content must be stripped from /state output: {region:?}"
+    );
+}
+
+/// /help text must mention the new /state command so operators discover it.
+#[test]
+#[serial]
+fn repl_help_mentions_state_command() {
+    let bridge = mock_bridge();
+    let agent = MockAgentSession::new("ok");
+    let input = b"/help\n/close\n";
+    let mut reader = &input[..];
+    let mut output = Vec::new();
+
+    run_meeting_repl(
+        "Help mentions /state",
+        &bridge,
+        Some(Box::new(agent)),
+        "",
+        &mut reader,
+        &mut output,
+    )
+    .unwrap();
+
+    let output_str = String::from_utf8(output).unwrap();
+    assert!(
+        output_str.contains("/state"),
+        "help text should advertise the new /state command: {output_str}"
+    );
+}

--- a/src/operator_commands_dashboard/chat.rs
+++ b/src/operator_commands_dashboard/chat.rs
@@ -279,6 +279,58 @@ pub(crate) async fn handle_ws_chat(mut socket: WebSocket) {
                             ))
                             .await;
                     }
+                    MeetingCommand::State => {
+                        // Re-display the running list of decisions, open
+                        // questions, and action items (issue #1646). Reuses
+                        // the existing extractors — no duplicate parsing.
+                        use crate::meeting_backend::persist::{
+                            extract_action_items, extract_decisions, extract_open_questions,
+                        };
+                        let messages = backend.history();
+                        let decisions = extract_decisions(messages);
+                        let open_questions = extract_open_questions(messages);
+                        let action_items = extract_action_items(messages);
+
+                        let mut body = String::new();
+                        body.push_str("── Decisions ──\n");
+                        if decisions.is_empty() {
+                            body.push_str("  _(none)_\n");
+                        } else {
+                            for (i, d) in decisions.iter().enumerate() {
+                                body.push_str(&format!("  {}. {d}\n", i + 1));
+                            }
+                        }
+                        body.push_str("\n── Open Questions ──\n");
+                        if open_questions.is_empty() {
+                            body.push_str("  _(none)_\n");
+                        } else {
+                            for q in &open_questions {
+                                let tag = if q.explicit { " *(explicit)*" } else { "" };
+                                body.push_str(&format!("  - {}{tag}\n", q.text));
+                            }
+                        }
+                        body.push_str("\n── Action Items ──\n");
+                        if action_items.is_empty() {
+                            body.push_str("  _(none)_\n");
+                        } else {
+                            for (i, item) in action_items.iter().enumerate() {
+                                let mut line = format!("  {}. {}", i + 1, item.description);
+                                if let Some(ref who) = item.assignee {
+                                    line.push_str(&format!(" [→ {who}]"));
+                                }
+                                if let Some(ref when) = item.deadline {
+                                    line.push_str(&format!(" ({when})"));
+                                }
+                                body.push_str(&line);
+                                body.push('\n');
+                            }
+                        }
+                        let _ = socket
+                            .send(Message::Text(
+                                json!({"role":"system","content": body}).to_string().into(),
+                            ))
+                            .await;
+                    }
                     MeetingCommand::Conversation(user_text) => {
                         // send_message is synchronous — use spawn_blocking
                         // wrapped with catch_unwind so a panic in the agent


### PR DESCRIPTION
## Summary

Lands two checklist items from issue #1646 ("Enhance Simard meeting REPL: better UX and richer handoffs"):

1. **`/state` slash command** — re-displays the running list of decisions, open
   questions, and action items extracted from the live transcript without
   closing the meeting. Read-only and reuses the existing
   `meeting_backend::persist::extract::*` helpers — no duplicate parsing.

2. **Structured JSON sibling artifact** — emitted alongside every markdown
   handoff report (same directory, same basename, `.json` extension) for
   downstream consumers (dashboards, OODA loops, third-party tools).

## Cumulative arc on the enhance-simard-meeting-experience goal

This PR continues the partial progress already shipped under #1646:

- **#1598** — initial `/close` + handoff scaffolding
- **#1608** — meeting templates and theme support
- **#1641** — handoff report agenda + structured action items
- **#1646** — *this PR*: `/state` read-only view + JSON sibling for downstream consumers

Reviewers can see the full arc by reading those PRs in order.

## What changed

### `/state` slash command

- New `MeetingCommand::State` variant in `src/meeting_backend/command.rs` with
  parser tests covering exact match, case insensitivity, and surplus-token
  rejection (surplus tokens fall through to `Conversation`, never silently
  swallowed).
- Dispatcher arm added to `src/meeting_repl/repl.rs` (CLI REPL) and
  `src/operator_commands_dashboard/chat.rs` (dashboard websocket) so both
  surfaces stay in sync.
- Sections render in **canonical order**: Decisions → Open Questions → Action
  Items, each with a colored heading and `_(none)_` placeholder when empty
  (mirrors the `_None recorded._` convention in the markdown report).
- ANSI escape sequences in LLM-sourced content (decisions, action item
  descriptions, assignees, deadlines, open questions) are stripped via
  `strip_ansi_escapes` before rendering — defends against terminal-hijack
  attacks where a malicious model emits `\x1b[2J` to clear the operator's
  screen.
- `/help` text updated to advertise `/state`.

### JSON sibling for handoff artifact

New module `src/meeting_backend/persist/json_sibling.rs`:

```text
{
  "schema_version": "v1",
  "participants":   [...],
  "decisions":      [...],
  "action_items":   [{"title", "owner", "acceptance_criteria"}, ...],
  "open_questions": [...],
  "transcript_ref": "<markdown basename>"
}
```

- Field mapping (`HandoffActionItem` → `JsonHandoffActionItem`):
  `title := description`, `owner := assignee`,
  `acceptance_criteria := None` (reserved slot for future extractor work).
- `Option<String>` fields serialize as **explicit JSON `null`** (NOT omitted)
  so consumers can rely on a uniform per-entry shape.
- Empty extractions serialize as `[]` (never `null`/missing) — dashboards
  iterate over these arrays and would crash on `null`.
- File mode `0o600` on Unix to mirror the markdown report's privacy
  guarantee.
- JSON write failure is logged at `warn!` and skipped — markdown remains the
  canonical artifact (resilience pattern matches the existing
  `write_handoff()` flow).
- `meetings_dir()` now honors `SIMARD_MEETINGS_DIR` env var (mirrors the
  `SIMARD_HANDOFF_DIR` idiom in `meeting_facilitator::default_handoff_dir`)
  so tests and operators can redirect output without touching `$HOME`.
- `transcript_ref` is the markdown basename (not a full local path) — keeps
  the JSON portable and avoids leaking host paths.

### Ambiguity resolutions worth noting for reviewers

- **Sibling location**: Spec text said `target/meeting_handoffs/<basename>.json`
  but `write_handoff_markdown_report` writes to `~/.simard/meetings/`. The
  operative invariant is "sibling of the markdown, same basename, `.json`".
  Cohabiting with the markdown is the only way "sibling" + "same basename"
  is meaningful, so the JSON is written next to the markdown report.
- **`/state` order**: Render order is **Decisions → Open Questions → Action
  Items** per the explicit task wording, intentionally different from the
  post-`/close` summary order.
- **Empty state**: All three section headings always render with
  `_(none)_` placeholders when empty (predictable UI, mirrors markdown
  `_None recorded._`).

## Tests

11 new tests (all `#[serial]` where they touch env vars):

REPL tests in `src/meeting_repl/tests_repl.rs`:
- `repl_state_empty_renders_all_section_headings_with_none_placeholders`
- `repl_state_populated_renders_extracted_decisions_action_items_open_questions`
- `repl_state_renders_sections_in_canonical_order_decisions_then_questions_then_actions`
- `repl_state_strips_ansi_escapes_from_llm_sourced_content_before_rendering`
- `repl_help_mentions_state_command`

Persist tests in `src/meeting_backend/tests_persist_extra.rs`:
- `markdown_handoff_writes_json_sibling_with_same_basename`
- `json_sibling_round_trips_all_fields_via_serde_json`
- `json_sibling_with_empty_extraction_serializes_empty_arrays_not_null`
- `json_sibling_has_owner_only_permissions_on_unix` (Unix-only)
- `json_handoff_action_item_from_handoff_action_item_maps_fields`
- `json_handoff_action_item_none_fields_serialize_as_explicit_null`

Parser tests in `src/meeting_backend/command.rs`:
- `parse_state_exact_token`
- `parse_state_case_and_whitespace_insensitive`
- `parse_state_with_surplus_tokens_is_conversation`

## Verification gates

- `cargo test --lib -- meeting_repl meeting_backend` → **142 passed, 0 failed**
- `cargo check --workspace --tests --quiet` → **green**

## Closes / refs

Drives a slice of #1646 forward. Two more checklist items shipped; remaining
checklist items continue under #1646.
