### PR TITLE
fix(ooda-brain): no silent ContinueSkipping fallback when brain Errs (#1711, #1748)

### DIFF
--- a/src/ooda_actions/advance_goal/spawn.rs
+++ b/src/ooda_actions/advance_goal/spawn.rs
@@ -55,32 +55,121 @@ pub fn dispatch_spawn_engineer(
     let state_root_inflight = engineer_worktree_state_root();
     if let Some(live) = find_live_engineer_for_goal(&state_root_inflight, goal_id) {
         let ctx = gather_engineer_lifecycle_ctx(state, &state_root_inflight, goal_id, &live);
-        let (decision, fallback_used) = match brain.decide_engineer_lifecycle(&ctx) {
-            Ok(d) => (d, false),
+        // NO FALLBACK: brain.decide_engineer_lifecycle Err must surface as a
+        // visible cycle failure (operator constraint, issue #1711, #1748).
+        // Silent ContinueSkipping on brain Err was the bug: it cleared the
+        // failure counter and made the system look healthy while the brain
+        // was completely broken. We now propagate the error loudly:
+        //   - log at ERROR severity with full context
+        //   - return success=false outcome (cycle.rs auto-bumps
+        //     state.goal_failure_counts[goal_id])
+        //   - if the failure count crosses the deterministic safeguard
+        //     threshold (3 consecutive cycles), file a tracking issue and
+        //     mark the goal Blocked. NOTE: this is a deterministic safeguard
+        //     enforced by simard, NOT a brain decision — the brain is broken
+        //     and cannot be trusted to make decisions about itself.
+        let decision = match brain.decide_engineer_lifecycle(&ctx) {
+            Ok(d) => d,
             Err(e) => {
-                tracing::warn!(
+                let prior_failures = state.goal_failure_counts.get(goal_id).copied().unwrap_or(0);
+                tracing::error!(
                     target: "simard::ooda_brain",
                     goal = %goal_id,
                     error = %e,
-                    "brain.decide_engineer_lifecycle failed; falling back to continue_skipping",
+                    prior_consecutive_failures = prior_failures,
+                    "brain.decide_engineer_lifecycle FAILED — surfacing as cycle failure (NO silent continue_skipping fallback per issue #1711)",
                 );
-                (
-                    EngineerLifecycleDecision::ContinueSkipping {
-                        rationale: format!("brain-error fallback: {e}"),
-                    },
-                    true,
-                )
+                eprintln!(
+                    "[simard] BRAIN FAILURE goal={} error={} prior_consecutive_failures={}",
+                    goal_id, e, prior_failures
+                );
+
+                // Deterministic safeguard: with this failure the count
+                // becomes prior_failures + 1. Trigger at >= 3.
+                if prior_failures >= 2 {
+                    let new_count = prior_failures + 1;
+                    let title = format!(
+                        "OODA brain failing on goal '{}' ({} consecutive cycles)",
+                        goal_id, new_count
+                    );
+                    let body = format!(
+                        "The OODA brain has failed to produce an engineer-lifecycle decision \
+                         for goal `{}` for {} consecutive cycles.\n\n\
+                         Latest error:\n```\n{}\n```\n\n\
+                         Simard has marked this goal Blocked pending human review. \
+                         Inspect the brain logs and the relevant prompt asset \
+                         (`prompt_assets/simard/ooda_brain.md`) before reactivating.\n\n\
+                         Triggered by deterministic safeguard in \
+                         `src/ooda_actions/advance_goal/spawn.rs` (issue #1711).",
+                        goal_id, new_count, e
+                    );
+                    // Mark goal Blocked deterministically.
+                    if let Some(g) = state
+                        .active_goals
+                        .active
+                        .iter_mut()
+                        .find(|g| g.id == goal_id)
+                    {
+                        g.status = crate::goal_curation::GoalProgress::Blocked(format!(
+                            "OODA brain failing for {} consecutive cycles; needs human review",
+                            new_count
+                        ));
+                    }
+                    // File tracking issue. Failure to file is logged but
+                    // does NOT swallow the original brain failure.
+                    match std::process::Command::new("gh")
+                        .args([
+                            "issue",
+                            "create",
+                            "--title",
+                            &title,
+                            "--body",
+                            &body,
+                            "--label",
+                            "ooda-stuck",
+                        ])
+                        .output()
+                    {
+                        Ok(out) if out.status.success() => {
+                            eprintln!(
+                                "[simard] DETERMINISTIC SAFEGUARD: goal '{}' marked Blocked + tracking issue filed",
+                                goal_id
+                            );
+                        }
+                        Ok(out) => {
+                            tracing::error!(
+                                target: "simard::ooda_brain",
+                                goal = %goal_id,
+                                stderr = %String::from_utf8_lossy(&out.stderr),
+                                "deterministic safeguard: gh issue create FAILED (goal still marked Blocked)",
+                            );
+                        }
+                        Err(io_err) => {
+                            tracing::error!(
+                                target: "simard::ooda_brain",
+                                goal = %goal_id,
+                                error = %io_err,
+                                "deterministic safeguard: gh process spawn FAILED (goal still marked Blocked)",
+                            );
+                        }
+                    }
+                }
+
+                return make_outcome(
+                    action,
+                    false,
+                    format!(
+                        "brain failure: {} (prior consecutive failures: {})",
+                        e, prior_failures
+                    ),
+                );
             }
         };
         push_brain_judgment(BrainJudgmentRecord::from_engineer_lifecycle(
             goal_id,
             &decision,
-            fallback_used,
-            if fallback_used {
-                String::new()
-            } else {
-                crate::ooda_brain::prompt_store::current_version(crate::ooda_brain::ACT_PROMPT_NAME)
-            },
+            false,
+            crate::ooda_brain::prompt_store::current_version(crate::ooda_brain::ACT_PROMPT_NAME),
         ));
         return apply_lifecycle_decision(action, state, goal_id, &live, decision);
     }

--- a/src/operator_cli/decisions.rs
+++ b/src/operator_cli/decisions.rs
@@ -4,7 +4,16 @@ use crate::meeting_facilitator::{
 
 /// Run `gh issue create` and print the result. Returns `true` on success.
 fn gh_create_issue(title: &str, body: &str, label: &str) -> bool {
-    match std::process::Command::new("gh")
+    gh_create_issue_with_bin("gh", title, body, label)
+}
+
+/// Inner implementation parameterized on the gh binary path. Tests use this
+/// with a non-existent path to verify graceful failure handling without
+/// invoking the real `gh` (which would create real issues — see issue #1711
+/// and the 10 polluted issues #1719/#1721/#1724/#1725/#1727/#1731/#1733/
+/// #1734/#1736/#1737 caused by the prior test design).
+fn gh_create_issue_with_bin(bin: &str, title: &str, body: &str, label: &str) -> bool {
+    match std::process::Command::new(bin)
         .args(["issue", "create", "--title", title, "--body", body])
         .output()
     {
@@ -138,8 +147,20 @@ mod tests {
 
     #[test]
     fn gh_create_issue_handles_missing_binary() {
-        let result = gh_create_issue("test-only", "body", "label");
-        let _ = result;
+        // Use a non-existent binary path so we exercise the IO-error branch
+        // WITHOUT invoking the real `gh` (which would actually create issues
+        // in the tracker — see #1719/#1721/#1724/#1725/#1727/#1731/#1733/
+        // #1734/#1736/#1737 polluted by the prior test design).
+        let result = gh_create_issue_with_bin(
+            "/nonexistent/gh-binary-for-test",
+            "test-only",
+            "body",
+            "label",
+        );
+        assert!(
+            !result,
+            "missing binary must produce a graceful false return, not panic or pollute"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Removes the silent `ContinueSkipping` fallback in `dispatch_spawn_engineer` when the brain returns an Err. Adds a deterministic safeguard that marks goals Blocked and files a tracking issue after 3 consecutive brain failures. Also fixes the long-standing stub-issues bug where a test was creating real GitHub issues every CI run.

Refs: #1711 (engineer-lifecycle agentic redesign), #1748 (eliminate all silent-fallback patterns).

## Operator constraint

> **NO FALLBACKS. EVER. Fallback == silent failure.**

The previous behavior — when the brain failed, return a fake-success ContinueSkipping outcome and clear the per-goal failure counter — exactly matched what the operator has repeatedly told us not to do. The system would loop forever invoking a broken brain while reporting healthy cycles.

## Changes

### `src/ooda_actions/advance_goal/spawn.rs`

- Removed the `match brain.decide_engineer_lifecycle(&ctx) { Err => silent ContinueSkipping fallback }` block.
- Brain Err now:
  1. Logs at ERROR severity with full context (`goal`, `error`, `prior_consecutive_failures`).
  2. Returns `make_outcome(action, false, ...)`, so `cycle.rs` auto-bumps `state.goal_failure_counts[goal_id]`.
  3. If `prior_failures >= 2` (this failure makes it 3+), simard *deterministically* (NOT the brain):
     - Marks the goal `GoalProgress::Blocked(...)`.
     - Files a `gh issue create --label ooda-stuck` tracking issue with the latest error.
     - The `gh` failure path is logged but does NOT swallow the original brain failure.

### `src/operator_cli/decisions.rs`

- Refactored `gh_create_issue` → delegates to `gh_create_issue_with_bin(bin, ...)`.
- The flaky-by-design test `gh_create_issue_handles_missing_binary` now passes `"/nonexistent/gh-binary-for-test"` so it exercises the IO-error branch **without** invoking the real `gh`.
- This stops the test from creating real issues every CI run (it created 10 polluted issues: #1719/#1721/#1724/#1725/#1727/#1731/#1733/#1734/#1736/#1737, all of which will be closed in this PR).

## Verification

- [x] `cargo check --lib` — clean
- [x] `cargo test --lib ooda_brain` — 85 / 85 passed
- [x] `cargo test --lib operator_cli::decisions::tests::gh_create_issue_handles_missing_binary` — ok
- [x] `cargo test --lib` (full) — 3963 / 3963 passed (1 pre-existing flake `engineer_loop::tests_agent_spawn::run_local_engineer_loop_emits_agent_prompt_build_phase` under parallel-process contention with the running simard daemon; passes in isolation; unrelated to these changes)
- [x] `cargo fmt --all -- --check` — passed (pre-commit)
- [x] `cargo clippy --release --no-deps -- -D warnings` — passed (pre-commit)
- [x] `cargo clippy --all-targets --all-features --locked -- -D warnings` — passed (pre-push)
- [x] `cargo test --release --lib (cognitive_memory|bootstrap|memory_ipc|memory_consolidation)` — passed (pre-push)

## Out of scope (tracked in #1711 / #1748)

This PR is **step 1** of the broader redesign. The full agentic rework still to come:

1. Replace `RustyClawdBrain::decide_engineer_lifecycle`'s JSON-parser-based dispatch with subprocess-based agentic invocation (`amplihack copilot --allow-all-tools --allow-all-paths -p <prompt>`).
2. Delete `DeterministicFallbackBrain` (engineer-lifecycle), `DeterministicFallbackDecideBrain`, `DeterministicFallbackOrientBrain`.
3. Delete `EngineerLifecycleDecision` enum, `apply_decision_to_state`, `apply_lifecycle_decision`.
4. Make `build_act_brain` / `build_decide_brain` / `build_orient_brain` return `Result<...>` and refuse to construct without LLM.
5. Migrate `decide` and `orient` brains to the same agentic pattern.

These are significant schema changes (`BrainJudgmentRecord` is consumed by the dashboard) that need design review beyond an unsupervised session. Tracked in #1711 (act-brain) and #1748 (cross-brain).

## DoD

- [x] Operator constraint satisfied for the most-frequently-hit fallback site (engineer-lifecycle dispatch).
- [x] Brain failure produces visible operator signal (ERROR log + cycle marked failed + escalation to gh issue on persistence).
- [x] Daemon does NOT silently degrade behavior when the brain breaks.
- [x] Test no longer pollutes the issue tracker.
- [x] All existing tests still pass.
- [x] Diff focused; no unrelated edits.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>