### PR TITLE
fix(meeting): intercept --help before REPL starts (#1746)

### DIFF
--- a/src/operator_cli/meeting.rs
+++ b/src/operator_cli/meeting.rs
@@ -5,11 +5,39 @@ use crate::operator_commands_meeting::run_meeting_repl_command;
 
 use super::args::{next_optional_path, next_required, reject_extra_args};
 
+pub(super) const MEETING_HELP: &str = "\
+Simard meeting subcommand
+
+Usage: simard meeting <command> [args]
+
+Commands:
+  run <base-type> <topology> <objective> [state-root]
+                            Run an automated meeting probe and exit.
+  read <base-type> <topology> [state-root]
+                            Read the latest meeting transcript and exit.
+  repl [topic]              Start an interactive meeting REPL on stdin.
+  begin [topic]             Alias for `repl`.
+  start [topic]             Alias for `repl`.
+  help, -h, --help          Show this help message and exit.
+
+If no command is given, an interactive REPL is started with a timestamp topic.
+
+Examples:
+  simard meeting --help
+  simard meeting repl \"weekly sync\"
+  simard meeting run gpt-5 ring \"design review\"
+  simard meeting read gpt-5 ring
+";
+
 pub(super) fn dispatch_meeting_command(
     mut args: impl Iterator<Item = String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let subcommand = args.next().unwrap_or_else(|| "repl".to_string());
     match subcommand.as_str() {
+        "--help" | "-h" | "help" => {
+            print!("{MEETING_HELP}");
+            Ok(())
+        }
         "run" => {
             let base_type = next_required(&mut args, "base type")?;
             let topology = next_required(&mut args, "topology")?;
@@ -32,6 +60,13 @@ pub(super) fn dispatch_meeting_command(
             reject_extra_args(args)?;
             run_meeting_repl_command(&topic)
         }
+        // Reject unknown flag-shaped tokens visibly instead of silently
+        // treating them as a meeting topic and blocking the REPL on stdin.
+        // See issue #1746 (Pillar 11: honest degradation beats hidden silence).
+        flag if flag.starts_with('-') => Err(format!(
+            "unknown flag '{flag}' for `simard meeting` (try `simard meeting --help`)"
+        )
+        .into()),
         // Any other word is treated as a topic for a meeting repl
         topic => {
             let rest: Vec<String> = args.collect();
@@ -119,6 +154,74 @@ mod tests {
                 .unwrap_err()
                 .to_string()
                 .contains("expected topology")
+        );
+    }
+
+    // ── issue #1746: --help must short-circuit before the REPL ──
+
+    #[test]
+    fn test_meeting_double_dash_help_exits_ok() {
+        // Regression for issue #1746: `simard meeting --help` previously
+        // treated `--help` as a topic name and entered an interactive REPL
+        // that blocked on stdin forever. It MUST now exit Ok without doing
+        // any I/O on stdin.
+        let result = dispatch_operator_cli(vec!["meeting".to_string(), "--help".to_string()]);
+        assert!(
+            result.is_ok(),
+            "meeting --help must exit Ok, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_meeting_short_dash_help_exits_ok() {
+        // Regression for issue #1746: `simard meeting -h` must short-circuit
+        // the same way `--help` does.
+        let result = dispatch_operator_cli(vec!["meeting".to_string(), "-h".to_string()]);
+        assert!(result.is_ok(), "meeting -h must exit Ok, got: {result:?}");
+    }
+
+    #[test]
+    fn test_meeting_help_word_exits_ok() {
+        // `simard meeting help` must also be honoured as a help request,
+        // not as a meeting topic literally named "help".
+        let result = dispatch_operator_cli(vec!["meeting".to_string(), "help".to_string()]);
+        assert!(result.is_ok(), "meeting help must exit Ok, got: {result:?}");
+    }
+
+    #[test]
+    fn test_meeting_help_text_lists_subcommands() {
+        // The help text constant must enumerate the supported subcommands
+        // so users can discover the meeting surface.
+        for keyword in &["run", "read", "repl", "begin", "start"] {
+            assert!(
+                super::MEETING_HELP.contains(keyword),
+                "MEETING_HELP must mention '{keyword}'"
+            );
+        }
+    }
+
+    #[test]
+    fn test_meeting_unknown_long_flag_errors() {
+        // Unknown long flags must fail visibly to stderr (Pillar 11) instead
+        // of being silently accepted as a meeting topic name.
+        let result = dispatch_operator_cli(vec!["meeting".to_string(), "--bogus".to_string()]);
+        assert!(result.is_err(), "unknown --flag must error");
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("unknown flag") && msg.contains("--bogus"),
+            "error must name the offending flag, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_meeting_unknown_short_flag_errors() {
+        // Unknown short flags must also error rather than start a REPL.
+        let result = dispatch_operator_cli(vec!["meeting".to_string(), "-x".to_string()]);
+        assert!(result.is_err(), "unknown -x flag must error");
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("unknown flag") && msg.contains("-x"),
+            "error must name the offending flag, got: {msg}"
         );
     }
 }

--- a/tests/cli_golden.rs
+++ b/tests/cli_golden.rs
@@ -128,3 +128,59 @@ fn help_documents_compatibility_binaries() {
         "help text should mention compatibility binaries:\n{stdout}"
     );
 }
+
+// ── issue #1746: `simard meeting --help` regression suite ────────────────
+//
+// Before the fix, `simard meeting --help` (and `-h`) was silently treated as
+// the meeting topic name `--help` and entered an interactive REPL that
+// blocked on stdin forever — making the binary appear hung. These tests
+// invoke the real `simard` binary with closed stdin and a hard timeout so
+// any regression that re-introduces the hang fails fast and visibly.
+
+fn meeting_help_should_not_hang(flag: &str) {
+    let assert = simard()
+        .arg("meeting")
+        .arg(flag)
+        .timeout(std::time::Duration::from_secs(15))
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+
+    for keyword in &["meeting", "run", "read", "repl", "Usage"] {
+        assert!(
+            stdout.contains(keyword),
+            "`simard meeting {flag}` stdout should mention '{keyword}':\n{stdout}"
+        );
+    }
+}
+
+#[test]
+fn meeting_double_dash_help_succeeds_quickly() {
+    meeting_help_should_not_hang("--help");
+}
+
+#[test]
+fn meeting_short_dash_help_succeeds_quickly() {
+    meeting_help_should_not_hang("-h");
+}
+
+#[test]
+fn meeting_help_word_succeeds_quickly() {
+    meeting_help_should_not_hang("help");
+}
+
+#[test]
+fn meeting_unknown_flag_errors_quickly() {
+    let assert = simard()
+        .arg("meeting")
+        .arg("--definitely-not-a-real-flag")
+        .timeout(std::time::Duration::from_secs(15))
+        .assert()
+        .failure();
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+
+    assert!(
+        stderr.contains("unknown flag") && stderr.contains("--definitely-not-a-real-flag"),
+        "unknown meeting flag must produce a visible stderr error, got: {stderr}"
+    );
+}


### PR DESCRIPTION
Closes #1746

## Root cause

`src/operator_cli/meeting.rs:8-46` `dispatch_meeting_command` matched on `run` / `read` / `repl` / `begin` / `start`, then had a final catch-all that treated **every** other word as a meeting topic and called `run_meeting_repl_command(&full_topic)`. There was no `--help` / `-h` / `help` branch and no rejection of flag-shaped tokens, so:

```
$ simard meeting --help     # silently entered REPL with topic "--help"
                            # blocked on stdin forever
                            # transcript persisted as ~/.simard/meetings/*_--help.json
```

From the operator's perspective, the binary was indistinguishable from a freeze. This is a P0 Pillar 11 ("honest degradation beats hidden silence") violation directly called out in the goal description ("meeting REPL").

## Fix

`src/operator_cli/meeting.rs`:

1. **Help branch added at the top of the match.** `--help`, `-h`, and bare `help` now print a meeting-specific usage summary to stdout and return `Ok(())` *before* any REPL is constructed. No stdin I/O occurs.
2. **`MEETING_HELP` constant** enumerates every supported subcommand (`run`, `read`, `repl`, `begin`, `start`, plus the help variants) with arg-count summaries and examples — same format as the top-level `OPERATOR_CLI_HELP`.
3. **Unknown flag-shaped tokens are rejected visibly.** Any first arg starting with `-` (and not matched by `--help` / `-h`) returns an error to stderr with non-zero exit, naming the offending flag and pointing the user at `simard meeting --help`. Previously these were silently swallowed as a topic name.

Diff:

```
src/operator_cli/meeting.rs | 103 +++++++++++++++++++++++++++++++++++
tests/cli_golden.rs         |  56 ++++++++++++++++++
2 files changed, 159 insertions(+)
```

## Acceptance criteria (from #1746)

| # | Criterion | Verification |
|---|-----------|--------------|
| 1 | `simard meeting --help` and `-h` print usage and exit 0 | New unit + cli_golden tests + manual smoke |
| 2 | Unknown flags error visibly to stderr, non-zero exit | New unit + cli_golden tests |
| 3 | Bonus: same pattern on every operator subcommand | **Out of scope** — tracked under parent #1742; this PR keeps the diff narrow so it can merge fast |

## Tests

**Regression unit tests** (`src/operator_cli/meeting.rs`, 6 new):

- `test_meeting_double_dash_help_exits_ok` — `--help` returns `Ok(())`
- `test_meeting_short_dash_help_exits_ok` — `-h` returns `Ok(())`
- `test_meeting_help_word_exits_ok` — bare `help` returns `Ok(())`
- `test_meeting_help_text_lists_subcommands` — `MEETING_HELP` mentions every subcommand
- `test_meeting_unknown_long_flag_errors` — `--bogus` returns error naming the flag
- `test_meeting_unknown_short_flag_errors` — `-x` returns error naming the flag

**End-to-end binary tests** (`tests/cli_golden.rs`, 4 new) — invoke the real `simard` binary via `assert_cmd` with a 15s hard timeout so any regression that re-introduces the stdin-blocking REPL fails the build immediately:

- `meeting_double_dash_help_succeeds_quickly`
- `meeting_short_dash_help_succeeds_quickly`
- `meeting_help_word_succeeds_quickly`
- `meeting_unknown_flag_errors_quickly`

**Suite results:**

```
cargo test -p simard --lib                                    # 3946 passed, 0 failed
cargo test -p simard --lib operator_cli::meeting              #   11 passed, 0 failed (5 pre-existing + 6 new)
cargo test -p simard --test cli_golden                        #   12 passed, 0 failed (8 pre-existing + 4 new)
cargo test -p simard --test meeting_goals --test meeting_handoff
                                                              #   30 passed, 0 failed
```

**Pre-push hooks** (all passed locally before push):

- `cargo fmt --all -- --check`
- `cargo clippy --release --no-deps -- -D warnings`
- `cargo test --release --lib (cognitive_memory|bootstrap|memory_ipc|memory_consolidation)`
- `cargo clippy --all-targets --all-features --locked -- -D warnings` (full CI mirror)

**Manual smoke test:**

```
$ simard meeting --help    # exits 0, prints usage to stdout
$ simard meeting -h        # exits 0, prints usage to stdout
$ simard meeting --bogus   # exits 1, prints "unknown flag '--bogus' for `simard meeting`" to stderr
```

## Scope

Deliberately scoped to the meeting subcommand only. Sibling P0 issues #1743, #1744, #1745 will be tracked in their own PRs so we can knock these down one at a time. The "no `--help` dispatch on any operator subcommand" generalisation is parent #1742.

## Diff focus

Only `src/operator_cli/meeting.rs` (production fix + unit tests) and `tests/cli_golden.rs` (regression integration tests). No unrelated edits.
