### PR TITLE
fix(tests): serialize SIMARD_MEETINGS_ROOT and process-reaper races (#1779)

### DIFF
--- a/src/agent_supervisor/tests_lifecycle.rs
+++ b/src/agent_supervisor/tests_lifecycle.rs
@@ -198,29 +198,23 @@ fn validate_artifacts_returns_zero_for_nonexistent_path() {
 #[cfg(all(test, unix))]
 mod reaper_tests {
     use super::reap_zombies;
+    use serial_test::serial;
     use std::process::Command;
-    use std::sync::{Mutex, MutexGuard};
     use std::thread;
     use std::time::{Duration, Instant};
 
     // `reap_zombies()` is process-wide: it reaps ANY <defunct> child of this
     // process, regardless of which test spawned it. Without serialization,
-    // peer tests in this module race with each other — e.g. one test's
-    // `drain()` can steal another test's zombie before the assertion runs,
-    // producing flaky "got 0" failures in CI. Serialize all reaper tests
-    // through this module-local mutex so each test owns the process state
-    // for its duration.
-    static REAPER_TEST_LOCK: Mutex<()> = Mutex::new(());
-
-    fn lock_reaper() -> MutexGuard<'static, ()> {
-        // If a previous test panicked while holding the lock the mutex is
-        // poisoned — that's still safe to use here because the protected
-        // state is process-global and we always re-drain at the start of
-        // each test.
-        REAPER_TEST_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-    }
+    // peer tests in this module race with each other AND with subprocess-
+    // spawning tests elsewhere in the lib (e.g. the engineer_loop tests that
+    // run `git branch --show-current` via `try_wait()`). A concurrent
+    // `reap_zombies()` can steal those tests' SIGCHLDs, leaving `try_wait()`
+    // to fail with ECHILD ("No child processes"). See issue #1779.
+    //
+    // Serialize all reaper tests through the `simard_process_reaper` named
+    // lock from `serial_test`; subprocess-spawning tests that race against
+    // this reaper (e.g. `run_local_engineer_loop_emits_agent_prompt_build_phase`)
+    // must join the same group.
 
     /// Drain any pre-existing zombies left behind by other tests in the same
     /// process so each test starts from a clean baseline.
@@ -247,8 +241,8 @@ mod reaper_tests {
     }
 
     #[test]
+    #[serial(simard_process_reaper)]
     fn reaps_dropped_child_within_one_cycle() {
-        let _guard = lock_reaper();
         drain();
         spawn_short_lived_unwaited();
 
@@ -271,8 +265,8 @@ mod reaper_tests {
     }
 
     #[test]
+    #[serial(simard_process_reaper)]
     fn idempotent_when_no_zombies() {
-        let _guard = lock_reaper();
         drain();
         // With no unwaited children, two consecutive calls must both return 0.
         let first = reap_zombies();
@@ -288,8 +282,8 @@ mod reaper_tests {
     }
 
     #[test]
+    #[serial(simard_process_reaper)]
     fn never_blocks_when_live_child_exists() {
-        let _guard = lock_reaper();
         drain();
         // Spawn a child that lives longer than the call to reap_zombies.
         // WNOHANG must guarantee non-blocking behaviour even when a child

--- a/src/engineer_loop/tests_agent_spawn.rs
+++ b/src/engineer_loop/tests_agent_spawn.rs
@@ -11,6 +11,8 @@
 
 use std::path::PathBuf;
 
+use serial_test::serial;
+
 use super::agent_spawn::{
     AGENT_SESSION_TIMEOUT_SECS, DEFAULT_MAX_TURNS, build_agent_prompt, rustyclawd_argv,
 };
@@ -229,6 +231,7 @@ fn compute_diff_for_review_agent_session_uses_git_diff() {
 /// It requires no LLM: the loop is expected to fail at the agent-spawn phase
 /// (no session configured), but the prompt-build trace must already exist.
 #[test]
+#[serial(simard_engineer_agent_env, simard_process_reaper)]
 fn run_local_engineer_loop_emits_agent_prompt_build_phase() {
     use crate::engineer_loop::run_local_engineer_loop;
     use crate::runtime::RuntimeTopology;

--- a/src/meeting_facilitator/handoff/persistence.rs
+++ b/src/meeting_facilitator/handoff/persistence.rs
@@ -527,6 +527,7 @@ fn render_bundle_markdown(
 mod bundle_tests {
     use super::*;
     use crate::meeting_facilitator::{ActionItem, MeetingDecision, OpenQuestion};
+    use serial_test::serial;
 
     fn temp_root(label: &str) -> PathBuf {
         let unique = std::time::SystemTime::now()
@@ -585,6 +586,7 @@ mod bundle_tests {
     }
 
     #[test]
+    #[serial(simard_meetings_root_env)]
     fn write_meeting_bundle_creates_canonical_files() {
         let root = temp_root("bundle-canonical");
         // SAFETY: tests in this binary that touch SIMARD_MEETINGS_ROOT serialize
@@ -616,6 +618,7 @@ mod bundle_tests {
     }
 
     #[test]
+    #[serial(simard_meetings_root_env)]
     fn write_meeting_bundle_round_trips_handoff_json() {
         let root = temp_root("bundle-roundtrip");
         unsafe {
@@ -655,6 +658,7 @@ mod bundle_tests {
     }
 
     #[test]
+    #[serial(simard_meetings_root_env)]
     fn write_meeting_bundle_markdown_contains_sections() {
         let root = temp_root("bundle-md");
         unsafe {

--- a/tests/meeting_handoff_bundle.rs
+++ b/tests/meeting_handoff_bundle.rs
@@ -11,6 +11,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use serial_test::serial;
 use simard::meeting_facilitator::{
     ActionItem, BundleTranscriptLine, MeetingDecision, MeetingHandoff, MeetingSession,
     MeetingSessionStatus, derive_meeting_id, write_meeting_bundle,
@@ -52,6 +53,7 @@ impl Drop for ScopedMeetingsRoot {
 }
 
 #[test]
+#[serial(simard_meetings_root_env)]
 fn scripted_meeting_emits_structured_handoff_bundle() {
     let root = ScopedMeetingsRoot::new("scripted");
 
@@ -194,6 +196,7 @@ fn scripted_meeting_emits_structured_handoff_bundle() {
 }
 
 #[test]
+#[serial(simard_meetings_root_env)]
 fn empty_transcript_still_produces_well_formed_bundle() {
     let _root = ScopedMeetingsRoot::new("empty-transcript");
 


### PR DESCRIPTION
Closes #1779.

## Three flaky failures, two distinct race classes

### 1. `meeting_facilitator::handoff::persistence::bundle_tests::*` (3 tests, lib)
The three `write_meeting_bundle_*` tests mutate `SIMARD_MEETINGS_ROOT` (read by `default_bundle_root()`). When two ran concurrently, one test's `set_var` raced another's `remove_var`/assertion, surfacing as transient bundle-path mismatches.

**Fix:** `#[serial(simard_meetings_root_env)]` on each.

### 2. `engineer_loop::tests_agent_spawn::run_local_engineer_loop_emits_agent_prompt_build_phase` (lib)
First phase (`inspect_workspace`) shells out to `git branch --show-current` and `try_wait()`s for it. Concurrently, `agent_supervisor::tests_lifecycle::reaper_tests::*` call the process-wide `reap_zombies()` which `waitpid()`s every defunct child of this process — **including the git child** — so `try_wait()` then fails with `ECHILD` (`No child processes (os error 10)`), which the test assertion (line 294) does not recognize as a known failure mode.

The reaper tests had a module-local `Mutex` for reaper-vs-reaper synchronization, but it was invisible to other modules.

**Fix:**
- Migrate three reaper tests from local `Mutex` → `#[serial(simard_process_reaper)]`
- Engineer-loop test joins **both** groups: `#[serial(simard_engineer_agent_env, simard_process_reaper)]` (it reads `SIMARD_ENGINEER_AGENT` via `AgentKind::from_env` AND races against the reaper)

### 3. `tests/meeting_handoff_bundle.rs::{scripted_meeting_emits_structured_handoff_bundle, empty_transcript_still_produces_well_formed_bundle}` (integration)
**Surfaced by CI on this PR** — same root-cause class as #1: the two `#[test]` fns in this integration binary both mutate `SIMARD_MEETINGS_ROOT` via `ScopedMeetingsRoot::{new, drop}` and run in parallel. When one test's `Drop::remove_var` interleaved with the other's `write_meeting_bundle()` call, `default_bundle_root()` fell back to `~/.simard/meetings/`, producing:

```
bundle dir /home/runner/.simard/meetings/...phase-9-kickoff
should be inside test root /tmp/meeting-bundle-scripted-...
```

**Fix:** `#[serial(simard_meetings_root_env)]` on both. (Named serial groups in `serial_test` are per-binary, which is exactly the contention scope here — only the two tests in this file touch the env var.)

## Verification (on top of `origin/main @ 04929588`)

| Gate | Result |
|------|--------|
| `cargo fmt --check` | ✅ |
| `cargo clippy --release --no-deps -- -D warnings` (pre-commit) | ✅ |
| `cargo clippy --all-targets --all-features --locked -- -D warnings` (pre-push / CI mirror) | ✅ |
| 5× `cargo test --lib` (default threads) | ✅ 3987 passed / 0 failed each pass |
| 5× `cargo test --lib -- --test-threads=8` | ✅ 3987 passed / 0 failed each pass |
| 3× `cargo test --test meeting_handoff_bundle` | ✅ 2 passed / 0 failed each pass |

**Pre-fix observation:** with `#[serial(simard_meetings_root_env)]` only on the lib tests, the engineer-loop test still failed in 4 of 5 default runs with the exact ECHILD signature above. After adding the reaper-group serialization, 10/10 lib runs are green. The integration-test fix was added in commit 2 after the first CI run surfaced the third flake.

## Files changed
```
src/agent_supervisor/tests_lifecycle.rs        | 34 +++++++++--------------
src/engineer_loop/tests_agent_spawn.rs         |  3 +++
src/meeting_facilitator/handoff/persistence.rs |  4 ++++
tests/meeting_handoff_bundle.rs                |  3 +++
```
Net: +24 / -20 lines. No production code touched. No public API changes.

## Out of scope (per design spec)
- `~/.simard/prompt_assets/` and `SIMARD_PROMPT_ASSETS_DIR`
- `write_meeting_bundle` API
- Tokio process driver / SIGCHLD handling production code
- Branch name kept as-is
- Other unrelated flakes observed in local 5-run sweep (`engineer_worktree::tests::allocate_*`, `stewardship::merge_authority::tests::base_allowlist_from_env_parses_csv`) — distinct root causes, belong in follow-up backlog issues

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
