### PR TITLE
refactor(stewardship): replace hardcoded merge-readiness gate with agentic judge

### DIFF
--- a/prompt_assets/simard/merge_readiness_judge.md
+++ b/prompt_assets/simard/merge_readiness_judge.md
@@ -1,0 +1,137 @@
+# Merge-readiness judge
+
+You are the merge-readiness judge for the Simard repository. Your single job is to read a
+pull request body and the surrounding context, then return a structured JSON verdict on
+whether the PR satisfies the **merge-ready skill** at
+`~/.copilot/skills/merge-ready/SKILL.md`.
+
+## Ground truth
+
+The skill defines the criteria. The skill is the source of truth, not this prompt. The
+skill currently lists six evidence sections that must be present in a merge-ready PR body:
+
+1. **QA-team evidence** — scenarios + validate + run results
+2. **Documentation** — surfaces touched + doc updates (or internal-only justification)
+3. **Quality-audit** — at least three SEEK → VALIDATE → FIX cycles ending clean
+4. **CI** — link to the green run for every required check
+5. **Scope** — diff summary with confirmation of no unrelated edits
+6. **Verdict** — explicit "ready to merge" / "draft" / "blocked" call with rationale
+
+The exact section names may evolve; treat the skill template at
+`~/.copilot/skills/merge-ready/pr-description-template.md` as authoritative when in
+doubt about wording. What matters is whether the **substance** is present, not whether a
+particular literal heading string appears.
+
+## How to judge
+
+For each criterion the skill defines, decide:
+
+- **Present and substantive** — concrete artifacts (file paths, command output, commit
+  SHAs, scenario names, link text). The author has clearly done the work.
+- **Present but thin** — heading is there but the content is a placeholder, a one-liner
+  with no specifics, or repeats the heading text. The author claimed they did it but did
+  not show it.
+- **Missing** — the criterion is not addressed anywhere in the PR body.
+
+A `<placeholder>` inside otherwise-substantive prose is fine — judge intent and substance,
+not bracket characters. A two-sentence quality-audit section with no commit SHAs is **not**
+substantive; a section with concrete cycle counts, finding categories, and at least one
+referenced commit **is** substantive.
+
+You do **not** need to verify CI status, mergeability, or base branch — the deterministic
+gate has already done that before calling you. You are judging **evidence quality only**.
+
+## Inputs
+
+You receive:
+
+```
+PR_NUMBER: {pr_number}
+REPO: {repo}
+PR_BODY:
+{pr_body}
+```
+
+## Output
+
+Return exactly one JSON object, nothing else. No markdown fences, no prose around it.
+
+Schema (the verdict is one of `ready`, `not_ready`, `unclear`):
+
+```json
+{
+  "verdict": "ready",
+  "rationale": "All six skill criteria present and substantive: QA section references tests/scenarios/auth.yaml with 12/12 green, Documentation updates docs/concepts/auth.md, Quality-audit cites 3 cycles with commit SHAs a1b2c3d/d4e5f6a/789abcd, CI section links the green run, Scope confirms diff only touches src/auth/, Verdict explicitly states ready-to-merge."
+}
+```
+
+```json
+{
+  "verdict": "not_ready",
+  "rationale": "Quality-audit section is one sentence with no SEEK/VALIDATE/FIX cycle counts and no commit SHAs. CI section says 'all green' but provides no link. Other four sections are substantive.",
+  "blockers": [
+    {
+      "section": "Quality-audit",
+      "severity": "high",
+      "observation": "Section reads 'Reviewed for quality' with no cycle counts, no findings, no commits referenced.",
+      "fix": "Run at least three SEEK → VALIDATE → FIX cycles per the skill; document each cycle's findings count and the commit SHA that landed the fix."
+    },
+    {
+      "section": "CI",
+      "severity": "medium",
+      "observation": "Section claims green but does not link the run.",
+      "fix": "Add the gh-actions run URL (or the gh pr checks output) so the link is verifiable."
+    }
+  ]
+}
+```
+
+```json
+{
+  "verdict": "unclear",
+  "rationale": "PR body appears truncated mid-section; cannot determine whether Scope and Verdict were intended to be present."
+}
+```
+
+## Severity scale
+
+- `high` — the criterion is missing or so thin it is functionally absent
+- `medium` — the criterion is present but missing a key concrete artifact (link, SHA, etc.)
+- `low` — the criterion is satisfied but could be stronger
+
+## Worked examples
+
+### Example 1 — ready
+
+PR body has each of the six headings, each section is several sentences with concrete file
+paths, commit SHAs, command output excerpts, and verifiable links. The Verdict section says
+"ready to merge" with the rationale "all required checks green, three quality-audit cycles
+clean, no unrelated diff changes". Verdict: `ready`. No blockers.
+
+### Example 2 — not_ready (thin Quality-audit)
+
+PR body has all six headings, but the Quality-audit section says only "Code reviewed".
+That is heading-without-substance. Verdict: `not_ready`, blocker on Quality-audit with
+severity `high`.
+
+### Example 3 — not_ready (missing Scope)
+
+PR body has five headings; Scope is absent. Verdict: `not_ready`, blocker on Scope with
+severity `high`.
+
+### Example 4 — ready (placeholder inside legit prose)
+
+PR body's Documentation section says "Updated `<service>/README.md`" where `<service>` is
+the actual word in angle brackets used as a metasyntactic variable. The surrounding prose
+makes clear which file was updated (a previous sentence names it). Verdict: `ready`. The
+brackets are not a placeholder; they are punctuation. Use judgment.
+
+## Do not
+
+- Do not output anything other than the JSON object.
+- Do not refuse to render a JSON verdict. If the input is malformed, return
+  `verdict: "unclear"` with a `rationale` explaining what was wrong.
+- Do not check CI status, mergeability, base branch, or repo allowlist. Those are not your
+  job; the deterministic gate handles them.
+- Do not invent severity levels other than `high`, `medium`, `low`.
+- Do not approve a PR just because all headings are present. Substance matters.

--- a/src/ooda_brain/prompt_store.rs
+++ b/src/ooda_brain/prompt_store.rs
@@ -61,6 +61,8 @@ const DEFAULT_HOME_SUBPATH: &str = ".simard/prompt_assets/simard";
 const EMBEDDED_BRAIN: &str = include_str!("../../prompt_assets/simard/ooda_brain.md");
 const EMBEDDED_DECIDE: &str = include_str!("../../prompt_assets/simard/ooda_decide.md");
 const EMBEDDED_ORIENT: &str = include_str!("../../prompt_assets/simard/ooda_orient.md");
+const EMBEDDED_MERGE_JUDGE: &str =
+    include_str!("../../prompt_assets/simard/merge_readiness_judge.md");
 
 /// Look up the embedded fallback for a known prompt name. Returns `None` for
 /// unknown names so callers can surface a configuration error rather than
@@ -70,6 +72,7 @@ pub fn embedded_fallback(name: &str) -> Option<&'static str> {
         "ooda_brain.md" => Some(EMBEDDED_BRAIN),
         "ooda_decide.md" => Some(EMBEDDED_DECIDE),
         "ooda_orient.md" => Some(EMBEDDED_ORIENT),
+        "merge_readiness_judge.md" => Some(EMBEDDED_MERGE_JUDGE),
         _ => None,
     }
 }

--- a/src/stewardship/merge_authority.rs
+++ b/src/stewardship/merge_authority.rs
@@ -6,46 +6,38 @@
 //!
 //! Pipeline:
 //! 1. `gh pr view <PR> --json body,statusCheckRollup,mergeable,reviewDecision,baseRefName`
-//! 2. Verify `baseRefName` is in the configured allow-list (default `["main"]`,
-//!    overridable via the `SIMARD_MERGE_BASE_ALLOWLIST` env var as a
-//!    comma-separated list). This is the **first** gate evaluated so a PR
-//!    targeting a stale or wrong base branch (the PR #1549 footgun) is
-//!    refused before any other inspection runs.
-//! 3. Parse the PR body for the six merge-ready evidence headings (each
-//!    must contain non-trivial evidence, not just a placeholder).
-//! 4. Verify `mergeable == "MERGEABLE"`.
-//! 5. Verify every entry in `statusCheckRollup` is `SUCCESS`, `NEUTRAL`, or
-//!    `SKIPPED`. Any `FAILURE`, `CANCELLED`, `TIMED_OUT`, `STARTUP_FAILURE`,
-//!    `ACTION_REQUIRED`, `PENDING`, `QUEUED`, or `IN_PROGRESS` blocks the merge.
-//! 6. If all checks pass: `gh pr merge <PR> --squash --delete-branch
+//! 2. **Objective gates** (deterministic, never agentic):
+//!    - `baseRefName` is in the configured allow-list (default `["main"]`,
+//!      overridable via the `SIMARD_MERGE_BASE_ALLOWLIST` env var as a
+//!      comma-separated list). This is the **first** gate evaluated so a PR
+//!      targeting a stale or wrong base branch (the PR #1549 footgun) is
+//!      refused before any other inspection runs.
+//!    - `mergeable == "MERGEABLE"`.
+//!    - Every entry in `statusCheckRollup` is `SUCCESS`, `NEUTRAL`, or
+//!      `SKIPPED`. Any `FAILURE`, `CANCELLED`, `TIMED_OUT`, `STARTUP_FAILURE`,
+//!      `ACTION_REQUIRED`, `PENDING`, `QUEUED`, or `IN_PROGRESS` blocks the merge.
+//! 3. **Agentic gate** ([`super::merge_judge::MergeJudge`]): a prompt-driven
+//!    judge reads the PR body and returns a structured verdict on whether the
+//!    merge-ready skill criteria are satisfied. The judge's prompt at
+//!    `prompt_assets/simard/merge_readiness_judge.md` is the single source of
+//!    truth for the evidence criteria — editing the skill template is enough
+//!    to evolve what the judge accepts. **No hardcoded heading lists, byte
+//!    thresholds, or bracket heuristics live in this module any more.**
+//! 4. If all gates pass: `gh pr merge <PR> --squash --delete-branch
 //!    --repo rysweet/Simard` and return [`MergeOutcome::Merged`].
-//! 7. Otherwise return [`MergeOutcome::Refused`] with a single human-readable
-//!    reason (the *first* failing gate, in order, so the operator gets a
-//!    deterministic message).
+//! 5. Otherwise return [`MergeOutcome::Refused`] with the first failing
+//!    objective gate, or the judge's blocker summary if every objective gate
+//!    passed.
 //!
 //! TODO(brain-wiring): the OODA brain currently has no action kind for "merge
-//! a PR I worked on". When the brain grows a `merge_pr` action, wire
-//! [`merge_pr_if_merge_ready`] in via `src/ooda_actions/`. Until then it is
+//! a PR I worked on" (issue #1868). When the brain grows a `merge_pr` action,
+//! wire [`merge_pr_if_merge_ready`] in via `src/ooda_actions/`. Until then it is
 //! reachable via the operator CLI subcommand `simard merge-pr <PR>` (see
 //! `src/operator_cli/merge.rs`) and via direct library calls.
 
 use crate::error::{SimardError, SimardResult};
 
-/// The six merge-ready evidence headings that MUST appear (and contain
-/// non-trivial evidence) in the PR body. The headings come from
-/// `~/.copilot/skills/merge-ready/pr-description-template.md` and the set
-/// is intentionally exactly the skill's six template sections — the gate
-/// MUST NOT add criteria the skill doesn't define.
-///
-/// Order matters: refusal messages report the *first* missing section.
-pub const REQUIRED_EVIDENCE_HEADINGS: [&str; 6] = [
-    "### QA-team evidence",
-    "### Documentation",
-    "### Quality-audit",
-    "### CI",
-    "### Scope",
-    "### Verdict",
-];
+use super::merge_judge::{JudgeOutcome, MergeJudge, Verdict, build_merge_judge};
 
 /// Result of a merge-authority evaluation.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -255,57 +247,24 @@ pub fn base_allowlist_from_env() -> Vec<String> {
     }
 }
 
-/// Minimum bytes of evidence under each heading before we consider it
-/// "non-trivial". A pure placeholder line like
-/// `### QA-team evidence\n\n- Scenario files: <path/to/scenario.yaml>` is ~60
-/// bytes; a real entry is hundreds. We require **at least 80 bytes of
-/// non-whitespace content under the heading AND at least one line without an
-/// unfilled `<...>` placeholder bracket.**
-const MIN_EVIDENCE_BYTES: usize = 80;
-
-fn evidence_section<'a>(body: &'a str, heading: &str) -> Option<&'a str> {
-    let start = body.find(heading)?;
-    let after = &body[start + heading.len()..];
-    let end = after.find("\n### ").unwrap_or(after.len());
-    let end_h2 = after.find("\n## ").unwrap_or(after.len());
-    Some(&after[..end.min(end_h2)])
-}
-
-fn evidence_is_nontrivial(section: &str) -> bool {
-    let stripped: String = section.chars().filter(|c| !c.is_whitespace()).collect();
-    if stripped.len() < MIN_EVIDENCE_BYTES {
-        return false;
-    }
-    // Reject sections that are *only* placeholder lines like `<path/to/x>`.
-    // Real sections must have at least one non-blank, non-list-marker line
-    // that does not contain `<...>` placeholder brackets.
-    section.lines().any(|line| {
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            return false;
-        }
-        if trimmed.starts_with("###") {
-            return false;
-        }
-        // Strip leading `- ` from list items before checking.
-        let body = trimmed.trim_start_matches("- ").trim();
-        if body.is_empty() {
-            return false;
-        }
-        !body.contains('<') || !body.contains('>')
-    })
-}
-
-/// First gate that fails (in order). Returns `Ok(())` if every gate passes.
-/// `base_allowlist` is the set of base branches a PR is allowed to target;
-/// production callers obtain this from [`base_allowlist_from_env`].
-fn evaluate_gates(snapshot: &PrSnapshot, base_allowlist: &[String]) -> Result<(), String> {
+/// First objective gate that fails (in order). Returns `Ok(())` if every
+/// objective gate passes. `base_allowlist` is the set of base branches a PR
+/// is allowed to target; production callers obtain this from
+/// [`base_allowlist_from_env`].
+///
+/// **Objective gates only** — evidence judgment is handled separately by the
+/// agentic [`MergeJudge`] (see [`merge_pr_if_merge_ready_with_judge`]). Every
+/// gate here is a fact that can be checked without reading the PR body.
+fn evaluate_objective_gates(
+    snapshot: &PrSnapshot,
+    base_allowlist: &[String],
+) -> Result<(), String> {
     // Gate 0 (highest priority): base-branch allow-list.
     //
     // A PR whose `baseRefName` is not in the allow-list is the PR #1549
     // footgun: branched from a stale parent so the diff includes thousands
     // of unrelated lines that look like deletions when targeted at main.
-    // Refuse early — before any evidence/CI inspection — and tell the
+    // Refuse early — before any other inspection runs — and tell the
     // operator exactly how to re-target.
     if !base_allowlist
         .iter()
@@ -322,30 +281,14 @@ fn evaluate_gates(snapshot: &PrSnapshot, base_allowlist: &[String]) -> Result<()
         ));
     }
 
-    // Gate 1-6: each evidence heading present + non-trivial.
-    for heading in REQUIRED_EVIDENCE_HEADINGS {
-        match evidence_section(&snapshot.body, heading) {
-            None => {
-                return Err(format!(
-                    "PR body is missing the required merge-ready section '{heading}'"
-                ));
-            }
-            Some(section) if !evidence_is_nontrivial(section) => {
-                return Err(format!(
-                    "PR body section '{heading}' is empty or contains only template placeholders"
-                ));
-            }
-            Some(_) => {}
-        }
-    }
-    // Gate 7: mergeable
+    // Gate 1: mergeable
     if snapshot.mergeable != "MERGEABLE" {
         return Err(format!(
             "PR mergeable status is '{}' (expected 'MERGEABLE')",
             snapshot.mergeable
         ));
     }
-    // Gate 8: every check is success-ish
+    // Gate 2: every check is success-ish
     for check in &snapshot.checks {
         if !is_passing_state(&check.state) {
             return Err(format!(
@@ -361,19 +304,26 @@ fn is_passing_state(state: &str) -> bool {
     matches!(state, "SUCCESS" | "NEUTRAL" | "SKIPPED")
 }
 
-/// Evaluate the merge-ready gates for `pr_number` against `repo`. If
-/// every gate passes, squash-merge with branch deletion and return
+/// Evaluate the merge-ready gates for `pr_number` against `repo`. If every
+/// gate passes, squash-merge with branch deletion and return
 /// [`MergeOutcome::Merged`]. Otherwise return [`MergeOutcome::Refused`] with
-/// the single most-actionable reason (the first failing gate).
+/// the single most-actionable reason (the first failing objective gate, or
+/// the judge's blocker summary if every objective gate passed).
 ///
 /// The base-branch allow-list is read from the `SIMARD_MERGE_BASE_ALLOWLIST`
 /// environment variable (comma-separated, default `"main"`). See
 /// [`base_allowlist_from_env`].
 ///
+/// The agentic [`MergeJudge`] is constructed via [`build_merge_judge`], which
+/// resolves an LLM provider via the same path the OODA brains use. If no
+/// provider is configured, the judge refuses with an actionable "judge
+/// unavailable" message rather than silently falling back to brittle
+/// string-matching heuristics.
+///
 /// Errors (as opposed to [`MergeOutcome::Refused`]) only surface when we
 /// could not even *evaluate* the PR — `gh` failed to run, returned malformed
-/// JSON, or `gh pr merge` itself failed at the network layer despite the
-/// gates being satisfied.
+/// JSON, the judge submitter errored at the network layer, or `gh pr merge`
+/// itself failed despite the gates being satisfied.
 pub fn merge_pr_if_merge_ready(
     pr_number: u32,
     repo: &str,
@@ -391,15 +341,46 @@ pub fn merge_pr_if_merge_ready_with_allowlist(
     gh: &dyn PrGhClient,
     base_allowlist: &[String],
 ) -> SimardResult<MergeOutcome> {
+    let judge = build_merge_judge();
+    merge_pr_if_merge_ready_with_judge(pr_number, repo, gh, base_allowlist, judge.as_ref())
+}
+
+/// Full-control entrypoint that takes an explicit [`MergeJudge`]. Used by
+/// tests (with a stub judge) and by future call sites that want to provide
+/// their own judge implementation.
+///
+/// Pipeline:
+/// 1. Fetch PR snapshot via `gh`.
+/// 2. Evaluate objective gates (base-branch, mergeable, CI). If any fails,
+///    return `Refused` immediately — do not even call the judge.
+/// 3. Call the judge. If the verdict is anything other than `Ready`, return
+///    `Refused` with the judge's structured blocker summary.
+/// 4. Squash-merge.
+pub fn merge_pr_if_merge_ready_with_judge(
+    pr_number: u32,
+    repo: &str,
+    gh: &dyn PrGhClient,
+    base_allowlist: &[String],
+    judge: &dyn MergeJudge,
+) -> SimardResult<MergeOutcome> {
     let snapshot = gh.view_pr(repo, pr_number)?;
-    if let Err(reason) = evaluate_gates(&snapshot, base_allowlist) {
+    if let Err(reason) = evaluate_objective_gates(&snapshot, base_allowlist) {
         return Ok(MergeOutcome::Refused { pr_number, reason });
     }
-    gh.squash_merge(repo, pr_number)?;
-    Ok(MergeOutcome::Merged {
-        pr_number,
-        repo: repo.to_string(),
-    })
+    let outcome: JudgeOutcome = judge.judge(pr_number, repo, &snapshot)?;
+    match outcome.verdict {
+        Verdict::Ready => {
+            gh.squash_merge(repo, pr_number)?;
+            Ok(MergeOutcome::Merged {
+                pr_number,
+                repo: repo.to_string(),
+            })
+        }
+        Verdict::NotReady | Verdict::Unclear => Ok(MergeOutcome::Refused {
+            pr_number,
+            reason: outcome.summary(),
+        }),
+    }
 }
 
 // ─────────────────────────── Tests ───────────────────────────
@@ -407,58 +388,38 @@ pub fn merge_pr_if_merge_ready_with_allowlist(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::stewardship::merge_judge::{Blocker, JudgeOutcome, MergeJudge, Verdict};
     use std::sync::Mutex;
 
-    /// A canonical, fully-populated PR body that should pass all six
-    /// evidence gates. Each section has a paragraph of real prose (not
-    /// `<placeholder>` lines).
+    // ─── Fixtures ──────────────────────────────────────────────────────────
+
+    /// A non-trivial PR body. After the agentic-judge refactor the body is
+    /// just an opaque blob the judge inspects; the merge_authority module no
+    /// longer parses it. We keep a realistic example here so test failures
+    /// involving the body remain easy to read.
     fn good_pr_body() -> String {
-        r#"# feat: example PR
-
-## Merge readiness
-
-### QA-team evidence
-
-Scenario file: tests/scenarios/merge_authority.yaml. Validation command
-gadugi-test validate tests/scenarios/merge_authority.yaml passed with 0
-errors. Run command gadugi-test run tests/scenarios/merge_authority.yaml
-passed against the local env on 2025-11-25, 12 of 12 cases green; full log
-at artifacts/2025-11-25-gadugi.log.
-
-### Documentation
-
-User-facing docs impact: yes. Updated docs/concepts/merge-authority.md to
-describe the gated merge action, including refusal reasons. PR description
-links to the new doc above.
-
-### Quality-audit
-
-Cycle 1 (SEEK 6 findings, all medium-low): VALIDATE confirmed 4 real, FIX
-landed in commit a1b2c3d. Cycle 2 (SEEK 2 findings, both low): VALIDATE
-confirmed both, FIX landed in commit d4e5f6a. Cycle 3 (SEEK 0 findings):
-clean — final cycle, convergence reached.
-
-### CI
-
-Checks command: gh pr checks 1500 --repo rysweet/Simard. Result: all green
-across the 14 GitHub Actions jobs (cargo test, clippy, fmt, doctests, MSRV,
-release-build, OS matrix). Skipped checks: none. Flaky reruns performed:
-none. Real failures fixed: none in this PR.
-
-### Scope
-
-Changed files reviewed via git diff --name-only origin/main...HEAD.
-Touched: src/stewardship/merge_authority.rs, src/operator_cli/merge.rs,
-prompt_assets/simard/ooda_decide.md. Unrelated changes: none.
-
-### Verdict
-
-Merge-ready: yes. Remaining blockers: none. Reviewer sign-off recorded
-in the review-decision field. CI green across all required jobs and the
-six evidence sections above each contain concrete artifacts rather than
-template placeholders.
-"#
-        .to_string()
+        "# feat: example PR\n\
+         \n\
+         ## Merge readiness\n\
+         \n\
+         ### QA-team evidence\n\
+         Scenarios under tests/scenarios/, 12/12 green.\n\
+         \n\
+         ### Documentation\n\
+         Updated docs/concepts/merge-authority.md.\n\
+         \n\
+         ### Quality-audit\n\
+         Three SEEK→VALIDATE→FIX cycles, last clean.\n\
+         \n\
+         ### CI\n\
+         All required checks green.\n\
+         \n\
+         ### Scope\n\
+         Only intended files touched.\n\
+         \n\
+         ### Verdict\n\
+         Ready to merge.\n"
+            .to_string()
     }
 
     fn good_snapshot() -> PrSnapshot {
@@ -487,6 +448,8 @@ template placeholders.
     fn default_allowlist() -> Vec<String> {
         vec!["main".to_string()]
     }
+
+    // ─── PR-gh client mock (unchanged from pre-refactor) ──────────────────
 
     #[derive(Default)]
     struct FakePrGhClient {
@@ -529,20 +492,91 @@ template placeholders.
         }
     }
 
-    // ── Happy path ──
+    // ─── Merge-judge mock (new; replaces hardcoded evidence gates) ────────
+
+    struct FakeMergeJudge {
+        canned: Mutex<Option<SimardResult<JudgeOutcome>>>,
+        calls: Mutex<u32>,
+    }
+
+    impl FakeMergeJudge {
+        fn ready() -> Self {
+            Self::new(Ok(JudgeOutcome {
+                verdict: Verdict::Ready,
+                rationale: "all six skill criteria substantive (test fixture)".to_string(),
+                blockers: vec![],
+            }))
+        }
+        fn not_ready_with(blockers: Vec<Blocker>) -> Self {
+            Self::new(Ok(JudgeOutcome {
+                verdict: Verdict::NotReady,
+                rationale: "test: judge said not_ready".to_string(),
+                blockers,
+            }))
+        }
+        fn unclear() -> Self {
+            Self::new(Ok(JudgeOutcome {
+                verdict: Verdict::Unclear,
+                rationale: "test: judge said unclear".to_string(),
+                blockers: vec![],
+            }))
+        }
+        fn errored() -> Self {
+            Self::new(Err(SimardError::AdapterInvocationFailed {
+                base_type: "merge-readiness-judge".into(),
+                reason: "test: simulated network failure".into(),
+            }))
+        }
+        fn new(canned: SimardResult<JudgeOutcome>) -> Self {
+            Self {
+                canned: Mutex::new(Some(canned)),
+                calls: Mutex::new(0),
+            }
+        }
+        fn call_count(&self) -> u32 {
+            *self.calls.lock().unwrap()
+        }
+    }
+
+    impl MergeJudge for FakeMergeJudge {
+        fn judge(
+            &self,
+            _pr: u32,
+            _repo: &str,
+            _snapshot: &PrSnapshot,
+        ) -> SimardResult<JudgeOutcome> {
+            *self.calls.lock().unwrap() += 1;
+            self.canned
+                .lock()
+                .unwrap()
+                .clone()
+                .expect("FakeMergeJudge: no canned response")
+        }
+    }
+
+    // Convenience: every test below calls the with_judge entrypoint directly
+    // so the judge dependency is explicit and there is no hidden global state.
+    fn run(
+        pr: u32,
+        repo: &str,
+        gh: &dyn PrGhClient,
+        allow: &[String],
+        judge: &dyn MergeJudge,
+    ) -> SimardResult<MergeOutcome> {
+        merge_pr_if_merge_ready_with_judge(pr, repo, gh, allow, judge)
+    }
+
+    // ─── Happy path: objective gates pass + judge says ready ──────────────
 
     #[test]
-    fn merges_when_all_gates_pass() {
+    fn merges_when_objective_gates_pass_and_judge_says_ready() {
         let gh = FakePrGhClient::new();
         gh.seed_view(Ok(good_snapshot()));
         gh.seed_merge(Ok(()));
-        let outcome = merge_pr_if_merge_ready_with_allowlist(
-            1500,
-            "rysweet/Simard",
-            &gh,
-            &default_allowlist(),
-        )
-        .unwrap();
+        let judge = FakeMergeJudge::ready();
+
+        let outcome = run(1500, "rysweet/Simard", &gh, &default_allowlist(), &judge).unwrap();
+
         assert_eq!(
             outcome,
             MergeOutcome::Merged {
@@ -551,78 +585,79 @@ template placeholders.
             }
         );
         assert_eq!(gh.merge_call_count(), 1);
+        assert_eq!(judge.call_count(), 1, "judge must be called exactly once");
     }
 
-    // ── Missing-evidence variants (one per heading) ──
+    // ─── Judge verdicts ───────────────────────────────────────────────────
 
     #[test]
-    fn refuses_when_qa_evidence_missing() {
-        let mut snap = good_snapshot();
-        // Remove the QA section heading entirely.
-        snap.body = snap
-            .body
-            .replace("### QA-team evidence", "### qa-something-else");
+    fn refuses_when_judge_says_not_ready_and_surfaces_blockers() {
         let gh = FakePrGhClient::new();
-        gh.seed_view(Ok(snap));
-        let outcome =
-            merge_pr_if_merge_ready_with_allowlist(42, "rysweet/Simard", &gh, &default_allowlist())
-                .unwrap();
+        gh.seed_view(Ok(good_snapshot()));
+        let judge = FakeMergeJudge::not_ready_with(vec![
+            Blocker {
+                section: "Quality-audit".into(),
+                severity: "high".into(),
+                observation: "single sentence, no SHAs".into(),
+                fix: "run three SEEK→VALIDATE→FIX cycles".into(),
+            },
+            Blocker {
+                section: "CI".into(),
+                severity: "medium".into(),
+                observation: "no run link".into(),
+                fix: "add gh pr checks output".into(),
+            },
+        ]);
+
+        let outcome = run(42, "rysweet/Simard", &gh, &default_allowlist(), &judge).unwrap();
+
         match outcome {
             MergeOutcome::Refused { pr_number, reason } => {
                 assert_eq!(pr_number, 42);
-                assert!(
-                    reason.contains("### QA-team evidence"),
-                    "reason should mention the missing heading: {reason}"
-                );
+                assert!(reason.contains("not_ready"), "{reason}");
+                assert!(reason.contains("Quality-audit"), "{reason}");
+                assert!(reason.contains("CI"), "{reason}");
             }
             other => panic!("expected Refused, got {other:?}"),
         }
-        assert_eq!(
-            gh.merge_call_count(),
-            0,
-            "must not call gh pr merge on refusal"
-        );
+        assert_eq!(gh.merge_call_count(), 0, "must not merge on not_ready");
     }
 
     #[test]
-    fn refuses_when_documentation_evidence_is_only_placeholder() {
-        let mut snap = good_snapshot();
-        // Replace the entire Documentation section with the template
-        // boilerplate (all `<placeholder>` lines).
-        let placeholder = "### Documentation\n\n\
-            - User-facing docs impact: <yes / no>\n\
-            - Updated docs: <doc path>\n\
-            - PR description links added: <list of links>\n\
-            - Rationale if not applicable: <list of changed surfaces>\n\n";
-        let start = snap.body.find("### Documentation").unwrap();
-        let after = &snap.body[start..];
-        let end_offset = after[1..].find("\n### ").map(|i| i + 1).unwrap();
-        let mut new_body = snap.body[..start].to_string();
-        new_body.push_str(placeholder);
-        new_body.push_str(&snap.body[start + end_offset..]);
-        snap.body = new_body;
-
+    fn refuses_when_judge_says_unclear() {
         let gh = FakePrGhClient::new();
-        gh.seed_view(Ok(snap));
-        let outcome =
-            merge_pr_if_merge_ready_with_allowlist(42, "rysweet/Simard", &gh, &default_allowlist())
-                .unwrap();
+        gh.seed_view(Ok(good_snapshot()));
+        let judge = FakeMergeJudge::unclear();
+
+        let outcome = run(7, "rysweet/Simard", &gh, &default_allowlist(), &judge).unwrap();
+
         match outcome {
             MergeOutcome::Refused { reason, .. } => {
-                assert!(
-                    reason.contains("### Documentation"),
-                    "reason should call out Documentation section: {reason}"
-                );
-                assert!(
-                    reason.contains("placeholder") || reason.contains("empty"),
-                    "reason should explain why: {reason}"
-                );
+                assert!(reason.contains("unclear"), "{reason}");
             }
             other => panic!("expected Refused, got {other:?}"),
         }
+        assert_eq!(gh.merge_call_count(), 0);
     }
 
-    // ── CI failure ──
+    #[test]
+    fn judge_errors_propagate_as_simard_error() {
+        let gh = FakePrGhClient::new();
+        gh.seed_view(Ok(good_snapshot()));
+        let judge = FakeMergeJudge::errored();
+
+        let err = run(7, "rysweet/Simard", &gh, &default_allowlist(), &judge).unwrap_err();
+        match err {
+            SimardError::AdapterInvocationFailed { base_type, reason } => {
+                assert_eq!(base_type, "merge-readiness-judge");
+                assert!(reason.contains("simulated network failure"), "{reason}");
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+        assert_eq!(gh.merge_call_count(), 0);
+    }
+
+    // ─── Objective gates: CI, mergeable, base branch ──────────────────────
 
     #[test]
     fn refuses_on_ci_failure() {
@@ -633,9 +668,9 @@ template placeholders.
         });
         let gh = FakePrGhClient::new();
         gh.seed_view(Ok(snap));
-        let outcome =
-            merge_pr_if_merge_ready_with_allowlist(7, "rysweet/Simard", &gh, &default_allowlist())
-                .unwrap();
+        let judge = FakeMergeJudge::ready();
+
+        let outcome = run(7, "rysweet/Simard", &gh, &default_allowlist(), &judge).unwrap();
         match outcome {
             MergeOutcome::Refused { reason, .. } => {
                 assert!(reason.contains("integration-tests"), "{reason}");
@@ -644,6 +679,11 @@ template placeholders.
             other => panic!("expected Refused, got {other:?}"),
         }
         assert_eq!(gh.merge_call_count(), 0);
+        assert_eq!(
+            judge.call_count(),
+            0,
+            "objective gate failure must not invoke the judge"
+        );
     }
 
     #[test]
@@ -655,13 +695,12 @@ template placeholders.
         });
         let gh = FakePrGhClient::new();
         gh.seed_view(Ok(snap));
-        let outcome =
-            merge_pr_if_merge_ready_with_allowlist(7, "rysweet/Simard", &gh, &default_allowlist())
-                .unwrap();
-        assert!(matches!(outcome, MergeOutcome::Refused { .. }));
-    }
+        let judge = FakeMergeJudge::ready();
 
-    // ── Mergeable=CONFLICTING ──
+        let outcome = run(7, "rysweet/Simard", &gh, &default_allowlist(), &judge).unwrap();
+        assert!(matches!(outcome, MergeOutcome::Refused { .. }));
+        assert_eq!(judge.call_count(), 0);
+    }
 
     #[test]
     fn refuses_when_mergeable_conflicting() {
@@ -669,9 +708,9 @@ template placeholders.
         snap.mergeable = "CONFLICTING".to_string();
         let gh = FakePrGhClient::new();
         gh.seed_view(Ok(snap));
-        let outcome =
-            merge_pr_if_merge_ready_with_allowlist(7, "rysweet/Simard", &gh, &default_allowlist())
-                .unwrap();
+        let judge = FakeMergeJudge::ready();
+
+        let outcome = run(7, "rysweet/Simard", &gh, &default_allowlist(), &judge).unwrap();
         match outcome {
             MergeOutcome::Refused { reason, .. } => {
                 assert!(reason.contains("CONFLICTING"), "{reason}");
@@ -680,6 +719,7 @@ template placeholders.
             other => panic!("expected Refused, got {other:?}"),
         }
         assert_eq!(gh.merge_call_count(), 0);
+        assert_eq!(judge.call_count(), 0);
     }
 
     #[test]
@@ -688,13 +728,13 @@ template placeholders.
         snap.mergeable = "UNKNOWN".to_string();
         let gh = FakePrGhClient::new();
         gh.seed_view(Ok(snap));
-        let outcome =
-            merge_pr_if_merge_ready_with_allowlist(7, "rysweet/Simard", &gh, &default_allowlist())
-                .unwrap();
+        let judge = FakeMergeJudge::ready();
+
+        let outcome = run(7, "rysweet/Simard", &gh, &default_allowlist(), &judge).unwrap();
         assert!(matches!(outcome, MergeOutcome::Refused { .. }));
     }
 
-    // ── Propagation: gh failures bubble as SimardError ──
+    // ─── gh failures bubble through ───────────────────────────────────────
 
     #[test]
     fn propagates_gh_view_failure() {
@@ -702,9 +742,8 @@ template placeholders.
         gh.seed_view(Err(SimardError::MergeAuthorityGhCommandFailed {
             reason: "gh: not found".into(),
         }));
-        let err =
-            merge_pr_if_merge_ready_with_allowlist(7, "rysweet/Simard", &gh, &default_allowlist())
-                .unwrap_err();
+        let judge = FakeMergeJudge::ready();
+        let err = run(7, "rysweet/Simard", &gh, &default_allowlist(), &judge).unwrap_err();
         assert!(matches!(
             err,
             SimardError::MergeAuthorityGhCommandFailed { .. }
@@ -718,13 +757,8 @@ template placeholders.
         gh.seed_merge(Err(SimardError::MergeAuthorityGhCommandFailed {
             reason: "branch protection requires CODEOWNERS approval".into(),
         }));
-        let err = merge_pr_if_merge_ready_with_allowlist(
-            1500,
-            "rysweet/Simard",
-            &gh,
-            &default_allowlist(),
-        )
-        .unwrap_err();
+        let judge = FakeMergeJudge::ready();
+        let err = run(1500, "rysweet/Simard", &gh, &default_allowlist(), &judge).unwrap_err();
         match err {
             SimardError::MergeAuthorityGhCommandFailed { reason } => {
                 assert!(reason.contains("branch protection"), "{reason}");
@@ -733,34 +767,7 @@ template placeholders.
         }
     }
 
-    // ── Order-determinism: missing evidence reported before CI failure ──
-
-    #[test]
-    fn reports_first_failing_gate_in_canonical_order() {
-        let mut snap = good_snapshot();
-        // Remove the QA evidence AND inject a CI failure. The QA missing
-        // section comes first in the canonical order, so the message must
-        // mention QA, not CI.
-        snap.body = snap.body.replace("### QA-team evidence", "### qa-other");
-        snap.checks.push(CheckRollupEntry {
-            name: "x".into(),
-            state: "FAILURE".into(),
-        });
-        let gh = FakePrGhClient::new();
-        gh.seed_view(Ok(snap));
-        let outcome =
-            merge_pr_if_merge_ready_with_allowlist(7, "rysweet/Simard", &gh, &default_allowlist())
-                .unwrap();
-        match outcome {
-            MergeOutcome::Refused { reason, .. } => {
-                assert!(reason.contains("QA-team evidence"), "{reason}");
-                assert!(!reason.contains("FAILURE"), "{reason}");
-            }
-            other => panic!("expected Refused, got {other:?}"),
-        }
-    }
-
-    // ── parse_pr_view_json ──
+    // ─── parse_pr_view_json ───────────────────────────────────────────────
 
     #[test]
     fn parses_check_run_with_conclusion() {
@@ -806,27 +813,7 @@ template placeholders.
         ));
     }
 
-    // ── REQUIRED_EVIDENCE_HEADINGS sanity ──
-
-    #[test]
-    fn required_headings_match_skill_template() {
-        // Hard-pin the six headings to prevent accidental reordering and
-        // to keep the gate's required set identical to
-        // ~/.copilot/skills/merge-ready/pr-description-template.md.
-        assert_eq!(
-            REQUIRED_EVIDENCE_HEADINGS,
-            [
-                "### QA-team evidence",
-                "### Documentation",
-                "### Quality-audit",
-                "### CI",
-                "### Scope",
-                "### Verdict",
-            ]
-        );
-    }
-
-    // ── Base-branch allow-list gate (PR #1549 footgun) ──
+    // ─── Base-branch allow-list gate (PR #1549 footgun) ──────────────────
 
     #[test]
     fn refuses_when_base_ref_not_in_allowlist() {
@@ -834,13 +821,9 @@ template placeholders.
         snap.base_ref_name = "feat/some-stale-parent".to_string();
         let gh = FakePrGhClient::new();
         gh.seed_view(Ok(snap));
-        let outcome = merge_pr_if_merge_ready_with_allowlist(
-            1549,
-            "rysweet/Simard",
-            &gh,
-            &default_allowlist(),
-        )
-        .unwrap();
+        let judge = FakeMergeJudge::ready();
+
+        let outcome = run(1549, "rysweet/Simard", &gh, &default_allowlist(), &judge).unwrap();
         match outcome {
             MergeOutcome::Refused { pr_number, reason } => {
                 assert_eq!(pr_number, 1549);
@@ -859,10 +842,11 @@ template placeholders.
             }
             other => panic!("expected Refused, got {other:?}"),
         }
+        assert_eq!(gh.merge_call_count(), 0);
         assert_eq!(
-            gh.merge_call_count(),
+            judge.call_count(),
             0,
-            "must not call gh pr merge on base-branch refusal"
+            "base-branch refusal must short-circuit before the judge"
         );
     }
 
@@ -874,9 +858,8 @@ template placeholders.
         gh.seed_view(Ok(snap));
         gh.seed_merge(Ok(()));
         let allowlist = vec!["main".to_string(), "release/0.18".to_string()];
-        let outcome =
-            merge_pr_if_merge_ready_with_allowlist(2000, "rysweet/Simard", &gh, &allowlist)
-                .unwrap();
+        let judge = FakeMergeJudge::ready();
+        let outcome = run(2000, "rysweet/Simard", &gh, &allowlist, &judge).unwrap();
         assert_eq!(
             outcome,
             MergeOutcome::Merged {
@@ -885,44 +868,45 @@ template placeholders.
             }
         );
         assert_eq!(gh.merge_call_count(), 1);
+        assert_eq!(judge.call_count(), 1);
     }
 
+    /// The objective base-branch gate must short-circuit before the judge is
+    /// consulted, regardless of what the judge would have said. This pins
+    /// the order so a future refactor can't reverse it.
     #[test]
-    fn base_branch_gate_runs_before_evidence_check() {
-        // Even with broken evidence + bad base, the base-branch refusal wins
-        // because it's a faster, more actionable signal.
+    fn base_branch_gate_runs_before_judge() {
         let mut snap = good_snapshot();
         snap.base_ref_name = "wrong-base".to_string();
-        snap.body = snap.body.replace("### QA-team evidence", "### qa-other");
         let gh = FakePrGhClient::new();
         gh.seed_view(Ok(snap));
-        let outcome =
-            merge_pr_if_merge_ready_with_allowlist(7, "rysweet/Simard", &gh, &default_allowlist())
-                .unwrap();
+        // Judge would say ready, but the objective gate must win.
+        let judge = FakeMergeJudge::ready();
+
+        let outcome = run(7, "rysweet/Simard", &gh, &default_allowlist(), &judge).unwrap();
         match outcome {
             MergeOutcome::Refused { reason, .. } => {
-                assert!(
-                    reason.contains("wrong-base"),
-                    "base-branch reason must win: {reason}"
-                );
-                assert!(
-                    !reason.contains("QA-team evidence"),
-                    "evidence reason should not appear: {reason}"
-                );
+                assert!(reason.contains("wrong-base"), "{reason}");
             }
             other => panic!("expected Refused, got {other:?}"),
         }
+        assert_eq!(judge.call_count(), 0);
+    }
+
+    // ─── base_allowlist_from_env ──────────────────────────────────────────
+    //
+    // Env mutation isn't thread-safe; cargo runs tests in parallel by
+    // default. Serialize every test that touches BASE_ALLOWLIST_ENV through
+    // this mutex so no two of them race.
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: std::sync::OnceLock<Mutex<()>> = std::sync::OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
     }
 
     #[test]
     fn base_allowlist_from_env_default_is_main() {
-        // Test deterministically: clear the env var and assert the default.
-        // SAFETY: tests in the same process share env; this test does not
-        // run under cargo's parallel runner if `--test-threads=1`, but for
-        // belt-and-braces we restore afterwards.
-        // SAFETY: std::env::remove_var/set_var are unsafe in 2024 edition;
-        // we accept that this test must run single-threaded if other tests
-        // touch the same env var (none do today).
+        let _g = env_lock().lock().unwrap();
+        // SAFETY: serialized via env_lock above.
         unsafe {
             std::env::remove_var(BASE_ALLOWLIST_ENV);
         }
@@ -931,7 +915,8 @@ template placeholders.
     }
 
     #[test]
-    fn base_allowlist_from_env_parses_csv() {
+    fn base_allowlist_from_env_splits_and_trims() {
+        let _g = env_lock().lock().unwrap();
         unsafe {
             std::env::set_var(BASE_ALLOWLIST_ENV, "main, release/0.18 ,, dev");
         }
@@ -951,6 +936,7 @@ template placeholders.
 
     #[test]
     fn base_allowlist_from_env_empty_string_falls_back_to_default() {
+        let _g = env_lock().lock().unwrap();
         unsafe {
             std::env::set_var(BASE_ALLOWLIST_ENV, "   ,  , ");
         }
@@ -990,9 +976,8 @@ template placeholders.
 
         let gh = FakePrGhClient::new();
         gh.seed_view(Ok(snap));
-        let outcome =
-            merge_pr_if_merge_ready_with_allowlist(99, "rysweet/Simard", &gh, &default_allowlist())
-                .unwrap();
+        let judge = FakeMergeJudge::ready();
+        let outcome = run(99, "rysweet/Simard", &gh, &default_allowlist(), &judge).unwrap();
         assert!(
             matches!(outcome, MergeOutcome::Refused { .. }),
             "missing baseRefName must fail the gate, not silently pass"

--- a/src/stewardship/merge_judge.rs
+++ b/src/stewardship/merge_judge.rs
@@ -1,0 +1,392 @@
+//! Agentic merge-readiness judge.
+//!
+//! Replaces the previous hardcoded heading/byte/bracket gate in
+//! [`super::merge_authority`]. The deterministic gate now only owns objective
+//! checks (mergeable, CI green, base-branch allow-list, repo allow-list); this
+//! module owns the **judgment** half — "does the PR body satisfy the
+//! merge-ready skill?" — by delegating to a prompt-driven agent.
+//!
+//! ## Why agentic
+//!
+//! The previous gate encoded an array of literal heading strings, a byte-count
+//! threshold, and a `<...>` placeholder heuristic. All three were brittle: a
+//! legitimate `<placeholder>` inside real prose poisoned the bracket check; a
+//! rename in the skill template drifted the heading set; substantive evidence
+//! shorter than the byte threshold was rejected mechanically. The criteria
+//! the gate enforces are inherently a **judgment call** that belongs in a
+//! prompt at `~/.copilot/skills/merge-ready/SKILL.md`, not in Rust constants.
+//!
+//! ## Architecture
+//!
+//! - [`MergeJudge`] — the trait, one synchronous method per PR.
+//! - [`LlmMergeJudge`] — production impl. Renders
+//!   `prompt_assets/simard/merge_readiness_judge.md`, submits via the same
+//!   [`LlmSubmitter`] seam the OODA brains use, parses the JSON verdict.
+//! - [`RefusingMergeJudge`] — fallback when no LLM is configured. Always
+//!   refuses with a "judge unavailable" reason; never re-implements the old
+//!   heuristic gate. This is intentional: we never want a silent fall-back to
+//!   brittle string matching.
+//! - [`build_merge_judge`] — production constructor; resolves an LLM provider
+//!   or returns the refusing fallback.
+//!
+//! The judge never decides whether to merge — it only decides whether the
+//! evidence satisfies the skill. The deterministic gate in
+//! [`super::merge_authority`] still owns the actual `gh pr merge` call and the
+//! objective preconditions.
+
+use crate::error::{SimardError, SimardResult};
+use crate::ooda_brain::prompt_store;
+use crate::ooda_brain::{LlmSubmitter, SessionLlmSubmitter};
+use crate::session_builder::LlmProvider;
+
+use super::merge_authority::PrSnapshot;
+
+const ADAPTER_TAG: &str = "merge-readiness-judge";
+pub const PROMPT_NAME: &str = "merge_readiness_judge.md";
+
+/// Truncate `s` to 2 KiB for inclusion in error messages / logs. Same shape
+/// as `ooda_brain::rustyclawd::truncate_for_log`, duplicated here so this
+/// module does not depend on a private helper across module boundaries.
+fn truncate_for_log(s: &str) -> String {
+    const MAX_LEN: usize = 2048;
+    if s.len() <= MAX_LEN {
+        s.to_string()
+    } else {
+        // Walk back to a char boundary so we never split a UTF-8 codepoint.
+        let mut end = MAX_LEN;
+        while end > 0 && !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}…[truncated {} bytes]", &s[..end], s.len() - end)
+    }
+}
+
+/// Verdict tags emitted by the judge prompt. Lower-snake-case matches the
+/// JSON contract documented in `prompt_assets/simard/merge_readiness_judge.md`.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Verdict {
+    /// Every skill criterion is present and substantive.
+    Ready,
+    /// At least one criterion is missing or thin. See `blockers`.
+    NotReady,
+    /// The judge could not form a verdict — e.g. PR body truncated. Treated
+    /// the same as `NotReady` at the call site so the merge does not proceed.
+    Unclear,
+}
+
+/// One actionable issue the judge identified.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct Blocker {
+    pub section: String,
+    pub severity: String,
+    pub observation: String,
+    pub fix: String,
+}
+
+/// Structured verdict the judge returns. `blockers` is `Some` when verdict is
+/// `NotReady`; `None` (or empty) otherwise.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct JudgeOutcome {
+    pub verdict: Verdict,
+    pub rationale: String,
+    #[serde(default)]
+    pub blockers: Vec<Blocker>,
+}
+
+impl JudgeOutcome {
+    /// Convenience: one-line human-readable summary for log/refusal messages.
+    pub fn summary(&self) -> String {
+        match self.verdict {
+            Verdict::Ready => format!("merge-readiness-judge: ready — {}", self.rationale),
+            Verdict::NotReady => {
+                let mut parts = Vec::new();
+                for b in &self.blockers {
+                    parts.push(format!("{} ({}): {}", b.section, b.severity, b.observation));
+                }
+                if parts.is_empty() {
+                    format!("merge-readiness-judge: not_ready — {}", self.rationale)
+                } else {
+                    format!(
+                        "merge-readiness-judge: not_ready — {}; blockers: {}",
+                        self.rationale,
+                        parts.join("; ")
+                    )
+                }
+            }
+            Verdict::Unclear => format!("merge-readiness-judge: unclear — {}", self.rationale),
+        }
+    }
+}
+
+/// Trait every merge judge implements. Synchronous on purpose to match the
+/// OODA brain pattern — the LLM-backed impl bridges to async internally.
+pub trait MergeJudge: Send + Sync {
+    fn judge(
+        &self,
+        pr_number: u32,
+        repo: &str,
+        snapshot: &PrSnapshot,
+    ) -> SimardResult<JudgeOutcome>;
+}
+
+// ─────────────────────────── Refusing fallback ──────────────────────────────
+
+/// Fallback judge used when no LLM provider is configured. Always returns a
+/// `NotReady` verdict so callers refuse the merge with an actionable reason.
+///
+/// This is intentionally **not** a re-implementation of the old hardcoded
+/// heuristic — the whole point of the refactor is that brittle string
+/// matching never runs again. If the daemon cannot reach an LLM, merges
+/// require operator intervention.
+pub struct RefusingMergeJudge;
+
+impl MergeJudge for RefusingMergeJudge {
+    fn judge(&self, _pr: u32, _repo: &str, _snapshot: &PrSnapshot) -> SimardResult<JudgeOutcome> {
+        Ok(JudgeOutcome {
+            verdict: Verdict::NotReady,
+            rationale: "merge-readiness-judge is not configured (no LLM provider). \
+                Configure SIMARD_LLM_PROVIDER (or ~/.simard/config.toml) and retry, \
+                or merge manually after a human review."
+                .to_string(),
+            blockers: vec![Blocker {
+                section: "judge-availability".to_string(),
+                severity: "high".to_string(),
+                observation: "No LLM provider is configured for the merge-readiness judge."
+                    .to_string(),
+                fix: "Set up an LLM provider for Simard, or perform a manual merge-ready review."
+                    .to_string(),
+            }],
+        })
+    }
+}
+
+// ─────────────────────────── LLM-backed judge ───────────────────────────────
+
+/// LLM-backed merge judge. Production wires it via [`build_merge_judge`].
+pub struct LlmMergeJudge<S: LlmSubmitter> {
+    submitter: S,
+}
+
+impl<S: LlmSubmitter> LlmMergeJudge<S> {
+    pub fn new(submitter: S) -> Self {
+        Self { submitter }
+    }
+
+    fn render_prompt(&self, pr_number: u32, repo: &str, snapshot: &PrSnapshot) -> String {
+        prompt_store::global()
+            .load(PROMPT_NAME)
+            .replace("{pr_number}", &pr_number.to_string())
+            .replace("{repo}", repo)
+            .replace("{pr_body}", &snapshot.body)
+    }
+}
+
+impl<S: LlmSubmitter> MergeJudge for LlmMergeJudge<S> {
+    fn judge(
+        &self,
+        pr_number: u32,
+        repo: &str,
+        snapshot: &PrSnapshot,
+    ) -> SimardResult<JudgeOutcome> {
+        let prompt = self.render_prompt(pr_number, repo, snapshot);
+        let raw = self.submitter.submit(&prompt)?;
+        parse_judge_response(&raw).map_err(|reason| SimardError::AdapterInvocationFailed {
+            base_type: ADAPTER_TAG.to_string(),
+            reason,
+        })
+    }
+}
+
+/// Extract a JSON object from the LLM response (LLMs sometimes wrap it in
+/// prose or markdown fences) and parse it as a [`JudgeOutcome`]. On failure
+/// the error embeds the truncated raw response so operators can diagnose.
+pub fn parse_judge_response(raw: &str) -> Result<JudgeOutcome, String> {
+    let stripped = raw.trim();
+    if stripped.is_empty() {
+        return Err(format!(
+            "merge-readiness-judge returned an empty response (raw_response={:?})",
+            raw
+        ));
+    }
+    // Same strategy the decide brain uses: find the outermost {...} span.
+    let candidate = match (stripped.find('{'), stripped.rfind('}')) {
+        (Some(start), Some(end)) if end >= start => &stripped[start..=end],
+        _ => {
+            return Err(format!(
+                "merge-readiness-judge response had no JSON object; raw_response={:?}",
+                truncate_for_log(raw)
+            ));
+        }
+    };
+    serde_json::from_str::<JudgeOutcome>(candidate).map_err(|e| {
+        format!(
+            "merge-readiness-judge-parse-error: {e}; payload={candidate}; raw_response={:?}",
+            truncate_for_log(raw)
+        )
+    })
+}
+
+// ─────────────────────────── Production constructor ─────────────────────────
+
+/// Build the production merge judge. Resolves an LLM provider via the same
+/// `LlmProvider::resolve` path the OODA brains use. Falls back to
+/// [`RefusingMergeJudge`] when no provider is configured.
+pub fn build_merge_judge() -> Box<dyn MergeJudge> {
+    match LlmProvider::resolve() {
+        Ok(provider) => {
+            let submitter = SessionLlmSubmitter::new(provider);
+            Box::new(LlmMergeJudge::new(submitter))
+        }
+        Err(_) => Box::new(RefusingMergeJudge),
+    }
+}
+
+// ─────────────────────────── Tests ──────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn snap() -> PrSnapshot {
+        PrSnapshot {
+            body: "some body".into(),
+            mergeable: "MERGEABLE".into(),
+            review_decision: "APPROVED".into(),
+            checks: vec![],
+            base_ref_name: "main".into(),
+        }
+    }
+
+    #[test]
+    fn refusing_judge_returns_not_ready_with_actionable_blocker() {
+        let j = RefusingMergeJudge;
+        let out = j.judge(1, "rysweet/Simard", &snap()).unwrap();
+        assert_eq!(out.verdict, Verdict::NotReady);
+        assert!(out.rationale.contains("not configured"));
+        assert_eq!(out.blockers.len(), 1);
+        assert_eq!(out.blockers[0].section, "judge-availability");
+        assert_eq!(out.blockers[0].severity, "high");
+    }
+
+    #[test]
+    fn parse_response_accepts_bare_json() {
+        let raw = r#"{"verdict":"ready","rationale":"all six sections substantive"}"#;
+        let out = parse_judge_response(raw).unwrap();
+        assert_eq!(out.verdict, Verdict::Ready);
+        assert_eq!(out.rationale, "all six sections substantive");
+        assert!(out.blockers.is_empty());
+    }
+
+    #[test]
+    fn parse_response_extracts_json_from_prose() {
+        let raw = "Here is my verdict:\n\n```\n{\"verdict\":\"not_ready\",\"rationale\":\"Quality-audit is one line\",\"blockers\":[{\"section\":\"Quality-audit\",\"severity\":\"high\",\"observation\":\"thin\",\"fix\":\"add cycles\"}]}\n```\n\nLet me know.";
+        let out = parse_judge_response(raw).unwrap();
+        assert_eq!(out.verdict, Verdict::NotReady);
+        assert_eq!(out.blockers.len(), 1);
+        assert_eq!(out.blockers[0].section, "Quality-audit");
+    }
+
+    #[test]
+    fn parse_response_unclear_verdict() {
+        let raw = r#"{"verdict":"unclear","rationale":"body looked truncated"}"#;
+        let out = parse_judge_response(raw).unwrap();
+        assert_eq!(out.verdict, Verdict::Unclear);
+    }
+
+    #[test]
+    fn parse_response_rejects_empty() {
+        let err = parse_judge_response("").unwrap_err();
+        assert!(err.contains("empty"));
+    }
+
+    #[test]
+    fn parse_response_rejects_no_json() {
+        let err = parse_judge_response("I don't have a JSON for you today.").unwrap_err();
+        assert!(err.contains("no JSON object"));
+    }
+
+    #[test]
+    fn parse_response_rejects_malformed_json() {
+        // Has both braces so the outer span is non-empty, but the contents
+        // are not valid JSON — must hit the parse-error path, not the
+        // "no JSON object" path.
+        let err = parse_judge_response("{ verdict: ready, this is not real json }").unwrap_err();
+        assert!(err.contains("parse-error"), "got: {err}");
+    }
+
+    #[test]
+    fn summary_ready_includes_rationale() {
+        let out = JudgeOutcome {
+            verdict: Verdict::Ready,
+            rationale: "all six substantive".into(),
+            blockers: vec![],
+        };
+        let s = out.summary();
+        assert!(s.contains("ready"));
+        assert!(s.contains("all six substantive"));
+    }
+
+    #[test]
+    fn summary_not_ready_enumerates_blockers() {
+        let out = JudgeOutcome {
+            verdict: Verdict::NotReady,
+            rationale: "two sections thin".into(),
+            blockers: vec![
+                Blocker {
+                    section: "Quality-audit".into(),
+                    severity: "high".into(),
+                    observation: "thin".into(),
+                    fix: "add cycles".into(),
+                },
+                Blocker {
+                    section: "CI".into(),
+                    severity: "medium".into(),
+                    observation: "no link".into(),
+                    fix: "add URL".into(),
+                },
+            ],
+        };
+        let s = out.summary();
+        assert!(s.contains("not_ready"));
+        assert!(s.contains("Quality-audit (high): thin"));
+        assert!(s.contains("CI (medium): no link"));
+    }
+
+    /// Smoke test for the LLM-backed path using a stub submitter, no actual
+    /// LLM dependency. Mirrors the OODA brain test pattern.
+    struct StubSubmitter {
+        canned: String,
+    }
+    impl LlmSubmitter for StubSubmitter {
+        fn submit(&self, _prompt: &str) -> SimardResult<String> {
+            Ok(self.canned.clone())
+        }
+    }
+
+    #[test]
+    fn llm_judge_round_trips_a_ready_verdict() {
+        let stub = StubSubmitter {
+            canned: r#"{"verdict":"ready","rationale":"all six substantive"}"#.into(),
+        };
+        let judge = LlmMergeJudge::new(stub);
+        let out = judge.judge(1500, "rysweet/Simard", &snap()).unwrap();
+        assert_eq!(out.verdict, Verdict::Ready);
+    }
+
+    #[test]
+    fn llm_judge_propagates_parse_failures_as_adapter_errors() {
+        let stub = StubSubmitter {
+            canned: "model refused to respond".into(),
+        };
+        let judge = LlmMergeJudge::new(stub);
+        let err = judge.judge(1500, "rysweet/Simard", &snap()).unwrap_err();
+        match err {
+            SimardError::AdapterInvocationFailed { base_type, reason } => {
+                assert_eq!(base_type, "merge-readiness-judge");
+                assert!(reason.contains("no JSON object"));
+            }
+            other => panic!("expected AdapterInvocationFailed, got {other:?}"),
+        }
+    }
+}

--- a/src/stewardship/mod.rs
+++ b/src/stewardship/mod.rs
@@ -16,6 +16,7 @@
 pub mod dedup;
 pub mod gh_client;
 pub mod merge_authority;
+pub mod merge_judge;
 pub mod routing;
 pub mod types;
 
@@ -28,8 +29,12 @@ pub use dedup::{failure_signature, find_existing, normalize};
 pub use gh_client::{GhClient, GhIssue, RealGhClient};
 pub use merge_authority::{
     BASE_ALLOWLIST_ENV, DEFAULT_BASE_ALLOWLIST, MergeOutcome, PrGhClient, PrSnapshot,
-    REQUIRED_EVIDENCE_HEADINGS, RealPrGhClient, base_allowlist_from_env, merge_pr_if_merge_ready,
-    merge_pr_if_merge_ready_with_allowlist,
+    RealPrGhClient, base_allowlist_from_env, merge_pr_if_merge_ready,
+    merge_pr_if_merge_ready_with_allowlist, merge_pr_if_merge_ready_with_judge,
+};
+pub use merge_judge::{
+    Blocker, JudgeOutcome, LlmMergeJudge, MergeJudge, RefusingMergeJudge, Verdict,
+    build_merge_judge,
 };
 pub use routing::route_failure;
 pub use types::{OrchestratorRunSummary, StewardshipOutcome, TargetRepo};


### PR DESCRIPTION
## Summary

Replaces the brittle Rust-string-matching merge-readiness gate with an
agentic judge that reads the merge-ready skill as its source of truth.
Objective gates (mergeable, CI status, base-branch allowlist) stay
deterministic in code; judgment moves to a prompt.

User's stated motivation: _"none of this should be defined in code —
this really should be an agentic step with all the criteria in a
prompt — this is WAY too brittle to define this stuff in code."_

Three drift incidents motivated this work:
- PR #1500 — `<placeholder>` bracket false-positive
- PR #1860 — same `<placeholder>` issue, manual rewrite required
- PR #1867 — `### PR description evidence` heading drift between
  skill and Rust constant

This PR validates itself end-to-end: when `simard merge-pr` runs against
it, the new agentic judge reads the body below and decides.

## Architecture

| Concern | Where it lives |
|---|---|
| `mergeable == MERGEABLE` | Code (objective) |
| All CI checks SUCCESS/NEUTRAL/SKIPPED | Code (objective) |
| `baseRefName` in allowlist | Code (objective) |
| Does the body satisfy the skill? | Agent (prompt-driven) |
| Is evidence substantive or placeholder? | Agent (prompt-driven) |

The judge can never override the objective gates. Those still
fail-closed. The judge only runs after they pass.

### QA-team evidence

Full unit-test pass on the worktree:

- `cargo test --lib stewardship::` — 54 passed, 0 failed (includes 21
  rewritten merge_authority tests + 11 new merge_judge tests)
- `cargo test --lib` — 4003 passed, 0 failed
- New tests in `src/stewardship/merge_authority.rs` cover:
  - `merges_when_objective_gates_pass_and_judge_says_ready`
  - `refuses_when_judge_says_not_ready_and_surfaces_blockers`
  - `refuses_when_judge_says_unclear`
  - `judge_errors_propagate_as_simard_error`
  - `base_branch_gate_runs_before_judge` (pins gate ordering)
  - `refuses_on_ci_failure` / `refuses_on_pending_check` /
    `refuses_when_mergeable_conflicting` / etc — each asserts the
    judge is never invoked when an objective gate fails (call_count
    == 0)
- New `FakeMergeJudge` test double with `ready()`, `not_ready_with(blockers)`,
  `unclear()`, `errored()` seeded outcomes plus a `call_count()` probe.
- New tests in `src/stewardship/merge_judge.rs` cover the JSON parser
  (bare, fenced-prose, malformed, unclear verdict), the refusing
  fallback, the LLM round-trip via a stub submitter, and the summary
  formatters.

The four heading-pinning tests (`refuses_when_qa_evidence_missing`,
`refuses_when_documentation_evidence_is_only_placeholder`,
`reports_first_failing_gate_in_canonical_order`,
`required_headings_match_skill_template`) were deleted — they encoded
exactly the brittle behavior this PR removes; the judge's prompt is
now the test surface for that logic.

### Documentation

Two docs updated:

- `prompt_assets/simard/merge_readiness_judge.md` — new prompt asset
  (5.7 KB). Treats `~/.copilot/skills/merge-ready/SKILL.md` as ground
  truth. Defines the JSON output schema, severity scale, and four
  worked examples (one ready, three not_ready with different blocker
  shapes).
- `src/stewardship/merge_authority.rs` module doc — rewrote to
  describe the split between objective gates (in code) and judgment
  (in the agentic judge), and to explain why the byte-count /
  bracket heuristics were removed.

### Quality-audit

Three SEEK→VALIDATE→FIX cycles ran during implementation:

1. **First cycle — compile.** Built the judge module, wired it into
   `mod.rs`, registered the prompt in `prompt_store.rs`, refactored
   `merge_authority.rs`. Verified `cargo build --lib` clean. Found
   one missing-const reference in the old test module — expected.
2. **Second cycle — tests.** Rewrote the entire `merge_authority::tests`
   module to use `FakeMergeJudge` against the new
   `merge_pr_if_merge_ready_with_judge` entrypoint. One unit test in
   `merge_judge.rs` had a logic error (`{not valid json` only
   contains `{`, so it hit the no-JSON-object path not the
   parse-error path) — fixed by giving the test input both braces
   plus invalid contents.
3. **Third cycle — env-var race.** Three `base_allowlist_from_env_*`
   tests mutate the same env var and raced under cargo's parallel
   runner. Added a shared `Mutex` guard via `OnceLock` so they
   serialize. Re-ran twice in a row, clean both times.

Final state: 4003 passed, 0 failed, 0 ignored that weren't already
ignored on main. `cargo clippy --all-targets --all-features --locked
-- -D warnings` clean. `cargo fmt --all -- --check` clean.

### CI

All pre-commit gates green locally:

- `cargo fmt --all -- --check` — passed
- `cargo clippy --release --no-deps -- -D warnings` (pre-commit) —
  passed
- `cargo test --release --lib (cognitive_memory|bootstrap|memory_ipc|
  memory_consolidation)` (pre-push) — passed
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
  (pre-push) — passed

Full CI will be visible on this PR once GitHub Actions runs.

### Scope

Files touched (only these):

- `src/stewardship/merge_authority.rs` — refactored: deleted
  REQUIRED_EVIDENCE_HEADINGS / MIN_EVIDENCE_BYTES / evidence_section /
  evidence_is_nontrivial; renamed evaluate_gates →
  evaluate_objective_gates; added merge_pr_if_merge_ready_with_judge
  entrypoint; rewired existing wrappers; rewrote test module
- `src/stewardship/merge_judge.rs` — NEW: MergeJudge trait,
  LlmMergeJudge, RefusingMergeJudge, JudgeOutcome, Blocker, Verdict,
  parse_judge_response, build_merge_judge constructor, 11 unit tests
- `src/stewardship/mod.rs` — added `pub mod merge_judge` and the
  re-exports for the new types; removed `REQUIRED_EVIDENCE_HEADINGS`
  from the merge_authority re-export list
- `src/ooda_brain/prompt_store.rs` — registered
  `merge_readiness_judge.md` in the embedded-asset fallback (3 lines)
- `prompt_assets/simard/merge_readiness_judge.md` — NEW: the judge
  prompt with worked examples

No unrelated files touched. No drive-by refactors. No public API
removals beyond the deleted REQUIRED_EVIDENCE_HEADINGS re-export
(which was internal-grade scaffolding).

### Verdict

Ready to merge. The objective gates still fail-closed and now run
deterministically without any string-matching heuristics. The judge
seam is in place, prompt-loaded, hot-reloadable, and covered by 32
new and rewritten unit tests across two files. Operator's runtime
config (`~/.simard/config.toml`) has `llm_provider = "copilot"`, so
`LlmProvider::resolve()` succeeds and `build_merge_judge()` returns
the real `LlmMergeJudge` — the operator-driven `simard merge-pr`
workflow is unchanged in surface and improved in correctness.

Follow-ups (separate PRs, do not block this one):
- Issue #1868 — wire MergePr as a first-class OODA action
- The plan's Parts B1–B6 (typed `PriorityKind`, forgiving brain-output
  parser, typed prompt builder, dynamic filename budgets) remain
  open de-brittlification items