### PR TITLE
feat(ooda_loop): introduce typed SyntheticPriorityKind enum (Part B1+B6 of de-brittlification)

### DIFF
--- a/src/ooda_brain/decide.rs
+++ b/src/ooda_brain/decide.rs
@@ -16,6 +16,7 @@ use super::prompt_store;
 use super::rustyclawd::LlmSubmitter;
 use crate::error::{SimardError, SimardResult};
 use crate::ooda_loop::ActionKind;
+use crate::ooda_loop::SyntheticPriorityKind;
 
 const ADAPTER_TAG: &str = "ooda-decide-brain";
 
@@ -124,12 +125,23 @@ pub struct DeterministicFallbackDecideBrain;
 impl OodaDecideBrain for DeterministicFallbackDecideBrain {
     fn judge_decision(&self, ctx: &DecideContext) -> SimardResult<DecideJudgment> {
         let rationale = "fallback-brain: prefix-routed".to_string();
-        let judgment = match ctx.goal_id.as_str() {
-            "__memory__" => DecideJudgment::ConsolidateMemory { rationale },
-            "__improvement__" => DecideJudgment::RunImprovement { rationale },
-            "__poll_activity__" => DecideJudgment::PollDeveloperActivity { rationale },
-            "__extract_ideas__" => DecideJudgment::ExtractIdeas { rationale },
-            _ => DecideJudgment::AdvanceGoal { rationale },
+        // Route synthetic priorities via the typed enum (single source of
+        // truth in `ooda_loop::priority_kind`). Real goal_ids — and any
+        // unrecognized synthetic — fall through to AdvanceGoal.
+        let judgment = match SyntheticPriorityKind::from_synthetic_id(ctx.goal_id.as_str()) {
+            Some(SyntheticPriorityKind::ConsolidateMemory) => {
+                DecideJudgment::ConsolidateMemory { rationale }
+            }
+            Some(SyntheticPriorityKind::RunImprovement) => {
+                DecideJudgment::RunImprovement { rationale }
+            }
+            Some(SyntheticPriorityKind::PollDeveloperActivity) => {
+                DecideJudgment::PollDeveloperActivity { rationale }
+            }
+            Some(SyntheticPriorityKind::ExtractIdeas) => DecideJudgment::ExtractIdeas { rationale },
+            Some(SyntheticPriorityKind::EvalWatchdog) | None => {
+                DecideJudgment::AdvanceGoal { rationale }
+            }
         };
         Ok(judgment)
     }

--- a/src/ooda_loop/decide.rs
+++ b/src/ooda_loop/decide.rs
@@ -14,7 +14,7 @@ use crate::ooda_brain::{
     push_brain_judgment,
 };
 
-use super::{OodaConfig, PlannedAction, Priority};
+use super::{OodaConfig, PlannedAction, Priority, is_synthetic_id};
 
 /// Decide using the deterministic fallback brain. This is the entrypoint
 /// the daemon's Act phase calls today; it preserves the pre-#1458 routing
@@ -78,7 +78,7 @@ pub fn decide_with_brain(
         };
         actions.push(PlannedAction {
             kind: judgment.action_kind(),
-            goal_id: if priority.goal_id.starts_with("__") {
+            goal_id: if is_synthetic_id(&priority.goal_id) {
                 None
             } else {
                 Some(priority.goal_id.clone())

--- a/src/ooda_loop/mod.rs
+++ b/src/ooda_loop/mod.rs
@@ -10,6 +10,7 @@ mod curate;
 mod decide;
 mod observe;
 mod orient;
+mod priority_kind;
 mod review;
 mod summary;
 mod types;
@@ -29,6 +30,7 @@ pub use curate::{check_meeting_handoffs, promote_from_backlog};
 pub use decide::{decide, decide_with_brain};
 pub use observe::{gather_environment, observe};
 pub use orient::{orient, orient_with_brain};
+pub use priority_kind::{SyntheticPriorityKind, is_synthetic_id};
 pub use review::review_outcomes;
 pub use summary::summarize_cycle_report;
 pub use types::{

--- a/src/ooda_loop/orient.rs
+++ b/src/ooda_loop/orient.rs
@@ -9,7 +9,7 @@ use crate::ooda_brain::{
     push_brain_judgment,
 };
 
-use super::{Observation, Priority};
+use super::{Observation, Priority, SyntheticPriorityKind, is_synthetic_id};
 
 /// Orient: rank goals by urgency, informed by environment context.
 ///
@@ -129,7 +129,9 @@ pub fn orient_with_brain(
 
     if observation.memory_stats.episodic_count > 100 {
         priorities.push(Priority {
-            goal_id: "__memory__".to_string(),
+            goal_id: SyntheticPriorityKind::ConsolidateMemory
+                .synthetic_id()
+                .to_string(),
             urgency: 0.5,
             reason: format!(
                 "episodic memory has {} entries, consolidation needed",
@@ -143,7 +145,9 @@ pub fn orient_with_brain(
         && score.overall < 0.7
     {
         priorities.push(Priority {
-            goal_id: "__improvement__".to_string(),
+            goal_id: SyntheticPriorityKind::RunImprovement
+                .synthetic_id()
+                .to_string(),
             urgency: 0.7,
             reason: format!(
                 "gym overall {:.1}% below 70% target ({} scenarios)",
@@ -162,7 +166,9 @@ pub fn orient_with_brain(
     // for free, but with enough urgency that it preempts ordinary work.
     if let Some(ref reason) = observation.eval_watchdog {
         priorities.push(Priority {
-            goal_id: "__eval_watchdog__".to_string(),
+            goal_id: SyntheticPriorityKind::EvalWatchdog
+                .synthetic_id()
+                .to_string(),
             urgency: 1.0,
             reason: format!("EVAL WATCHDOG: {reason}"),
         });
@@ -176,17 +182,21 @@ pub fn orient_with_brain(
     Ok(priorities)
 }
 
-/// Drop any priorities whose `goal_id` is neither in `active_goals` nor a
-/// synthetic (`__`-prefix). Called after building the priorities vec from
-/// `goals.active` and before appending synthetic priorities, so synthetics
-/// are never filtered.
+/// Drop any priorities whose `goal_id` is neither a real active-board id
+/// nor a recognized synthetic kind (see [`SyntheticPriorityKind`]).
+/// Called after building the priorities vec from `goals.active` and before
+/// appending synthetic priorities, so synthetics are never filtered.
+///
+/// Previously this used `goal_id.starts_with("__")` to detect synthetics,
+/// which would have accepted any unknown `__foo__` (typos, removed kinds)
+/// as legitimate. The enum-backed check refuses unknowns explicitly.
 pub(crate) fn filter_hallucinated_priorities(
     priorities: &mut Vec<Priority>,
     active_goals: &[ActiveGoal],
 ) {
     let active_ids: HashSet<&str> = active_goals.iter().map(|g| g.id.as_str()).collect();
     priorities.retain(|p| {
-        if p.goal_id.starts_with("__") || active_ids.contains(p.goal_id.as_str()) {
+        if is_synthetic_id(&p.goal_id) || active_ids.contains(p.goal_id.as_str()) {
             true
         } else {
             eprintln!(
@@ -368,12 +378,18 @@ mod hallucination_filter_tests {
     }
 
     #[test]
-    fn double_underscore_prefix_arbitrary_suffix_is_synthetic() {
-        // Any __ prefix must be retained regardless of the suffix.
+    fn unknown_double_underscore_string_is_dropped_not_treated_as_synthetic() {
+        // Pre-PR-#1872 behavior: any `__foo__` string was retained on the
+        // assumption that it was a future synthetic kind. That was the
+        // brittleness — typos and removed kinds passed through silently.
+        // Post-refactor: only the enum-recognized synthetic kinds survive.
         let goals: Vec<ActiveGoal> = vec![];
         let mut priorities = vec![priority("__new_future_system__")];
         filter_hallucinated_priorities(&mut priorities, &goals);
-        assert_eq!(priorities.len(), 1);
+        assert!(
+            priorities.is_empty(),
+            "unknown synthetic-shaped string must be rejected, not silently kept"
+        );
     }
 
     #[test]

--- a/src/ooda_loop/priority_kind.rs
+++ b/src/ooda_loop/priority_kind.rs
@@ -1,0 +1,213 @@
+//! Typed registry of synthetic OODA priority kinds.
+//!
+//! ## Motivation
+//!
+//! Before this module landed, the OODA loop encoded its synthetic (non-goal)
+//! priorities as magic `goal_id` strings — `__memory__`, `__improvement__`,
+//! `__poll_activity__`, `__extract_ideas__`, `__eval_watchdog__` — sprinkled
+//! across ~30 sites in 6 files. The strings were the implicit "type" of a
+//! priority: `priority.goal_id.starts_with("__")` was the test for
+//! "is this a synthetic kind?" and a 4-arm string `match` in the
+//! [`DeterministicFallbackDecideBrain`] was the routing table.
+//!
+//! Adding a new synthetic priority (e.g. issue #1868's `MergePr`) meant
+//! touching every site, hoping nobody mistyped the underscore count, and
+//! praying no real goal id ever started with `__`. The fix:
+//!
+//! - One enum, one source of truth.
+//! - Every magic string in the code base is constructed from the enum
+//!   via [`SyntheticPriorityKind::synthetic_id`].
+//! - Every place that asked "is this synthetic?" or "what kind?" now goes
+//!   through [`SyntheticPriorityKind::from_synthetic_id`].
+//!
+//! ## Why "synthetic"
+//!
+//! Most priorities map 1:1 to a real goal in the goal board — those carry
+//! the goal's slug as their `goal_id`. **Synthetic** priorities are the
+//! cross-cutting ones the Orient phase synthesizes from observation state
+//! (memory pressure, gym health, watchdog tripped, etc.) that do not
+//! correspond to any persisted goal. This enum enumerates exactly those.
+//!
+//! The serialization format is unchanged: priorities still serialize with
+//! `goal_id: "__memory__"` etc. so the dashboard, cycle reports, and
+//! persisted history keep working bit-for-bit. The enum is the **in-code**
+//! type; the string is the **on-wire** projection.
+
+use std::fmt;
+
+/// One of the synthetic (non-goal) priority kinds the OODA loop knows about.
+///
+/// A real goal-based priority is *not* represented here — that's just a
+/// `Priority { goal_id: "<slug>", … }` whose slug is a real goal id. Use
+/// [`SyntheticPriorityKind::from_synthetic_id`] to detect synthetic kinds
+/// in a typed way.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum SyntheticPriorityKind {
+    /// Cross-session episodic memory consolidation. Synthesized when the
+    /// episodic store has grown past the consolidation threshold.
+    ConsolidateMemory,
+    /// Gym-driven self-improvement cycle. Synthesized when gym overall
+    /// score is below the target threshold with at least one scenario.
+    RunImprovement,
+    /// Poll developer activity / ingest signals. Periodic synthetic cycle.
+    PollDeveloperActivity,
+    /// Mine recent activity for new research ideas. Periodic synthetic cycle.
+    ExtractIdeas,
+    /// The eval watchdog tripped in the Observe phase. Highest-urgency
+    /// synthetic — preempts ordinary work until an operator investigates.
+    EvalWatchdog,
+}
+
+impl SyntheticPriorityKind {
+    /// The on-wire goal_id string used to serialize this synthetic kind.
+    ///
+    /// **Do not** spell these literals out anywhere else in the code base —
+    /// always go through this method. That is the whole point of this enum.
+    pub const fn synthetic_id(self) -> &'static str {
+        match self {
+            Self::ConsolidateMemory => "__memory__",
+            Self::RunImprovement => "__improvement__",
+            Self::PollDeveloperActivity => "__poll_activity__",
+            Self::ExtractIdeas => "__extract_ideas__",
+            Self::EvalWatchdog => "__eval_watchdog__",
+        }
+    }
+
+    /// Inverse of [`synthetic_id`]. Returns `None` for any string that is
+    /// not a known synthetic id — including real goal slugs and unknown
+    /// `__foo__` strings (an unknown synthetic must be a typo, never a
+    /// silent fallback).
+    pub fn from_synthetic_id(id: &str) -> Option<Self> {
+        Some(match id {
+            "__memory__" => Self::ConsolidateMemory,
+            "__improvement__" => Self::RunImprovement,
+            "__poll_activity__" => Self::PollDeveloperActivity,
+            "__extract_ideas__" => Self::ExtractIdeas,
+            "__eval_watchdog__" => Self::EvalWatchdog,
+            _ => return None,
+        })
+    }
+
+    /// Iterate over every known synthetic kind. Used by tests and audits to
+    /// guarantee that adding a variant here will surface in coverage that
+    /// enumerates all kinds.
+    pub fn all() -> &'static [Self] {
+        &[
+            Self::ConsolidateMemory,
+            Self::RunImprovement,
+            Self::PollDeveloperActivity,
+            Self::ExtractIdeas,
+            Self::EvalWatchdog,
+        ]
+    }
+}
+
+impl fmt::Display for SyntheticPriorityKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.synthetic_id())
+    }
+}
+
+/// Convenience: is this `goal_id` string a recognized synthetic priority?
+///
+/// Replaces the previous `goal_id.starts_with("__")` heuristic, which had
+/// two problems: (a) it accepted any unknown `__foo__` as synthetic, and
+/// (b) it made the test for "synthetic" implicit in lexical shape rather
+/// than in enumeration membership.
+pub fn is_synthetic_id(goal_id: &str) -> bool {
+    SyntheticPriorityKind::from_synthetic_id(goal_id).is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Round-trip every variant. Catches the next person who adds a variant
+    /// to `all()` but forgets to map it in `synthetic_id` /
+    /// `from_synthetic_id`.
+    #[test]
+    fn synthetic_id_roundtrips_for_every_variant() {
+        for kind in SyntheticPriorityKind::all() {
+            let id = kind.synthetic_id();
+            assert_eq!(
+                SyntheticPriorityKind::from_synthetic_id(id),
+                Some(*kind),
+                "round-trip failed for {kind:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn synthetic_ids_are_unique() {
+        let mut seen = std::collections::HashSet::new();
+        for kind in SyntheticPriorityKind::all() {
+            assert!(
+                seen.insert(kind.synthetic_id()),
+                "duplicate synthetic id for {kind:?}: {}",
+                kind.synthetic_id()
+            );
+        }
+    }
+
+    #[test]
+    fn is_synthetic_id_rejects_real_goal_slugs() {
+        assert!(!is_synthetic_id("ship-v1"));
+        assert!(!is_synthetic_id("improve-memory-persistence"));
+        assert!(!is_synthetic_id(""));
+    }
+
+    #[test]
+    fn is_synthetic_id_rejects_unknown_double_underscore_strings() {
+        // The old `starts_with("__")` heuristic would accept this. We
+        // explicitly do not — an unknown `__foo__` is a typo, not a kind.
+        assert!(!is_synthetic_id("__unknown__"));
+        assert!(!is_synthetic_id("__memory"));
+        assert!(!is_synthetic_id("memory__"));
+        assert!(!is_synthetic_id("__"));
+    }
+
+    #[test]
+    fn is_synthetic_id_accepts_every_known_kind() {
+        for kind in SyntheticPriorityKind::all() {
+            assert!(
+                is_synthetic_id(kind.synthetic_id()),
+                "is_synthetic_id failed for {kind:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn display_matches_synthetic_id() {
+        for kind in SyntheticPriorityKind::all() {
+            assert_eq!(format!("{kind}"), kind.synthetic_id());
+        }
+    }
+
+    /// Pin the on-wire string format so a future "rename for clarity" PR
+    /// can't silently break the dashboard / persisted cycle reports. If
+    /// you really want to rename one of these, do it intentionally and
+    /// add a migration; do not let the test catch you by surprise.
+    #[test]
+    fn synthetic_ids_pinned_for_serialization_compat() {
+        assert_eq!(
+            SyntheticPriorityKind::ConsolidateMemory.synthetic_id(),
+            "__memory__"
+        );
+        assert_eq!(
+            SyntheticPriorityKind::RunImprovement.synthetic_id(),
+            "__improvement__"
+        );
+        assert_eq!(
+            SyntheticPriorityKind::PollDeveloperActivity.synthetic_id(),
+            "__poll_activity__"
+        );
+        assert_eq!(
+            SyntheticPriorityKind::ExtractIdeas.synthetic_id(),
+            "__extract_ideas__"
+        );
+        assert_eq!(
+            SyntheticPriorityKind::EvalWatchdog.synthetic_id(),
+            "__eval_watchdog__"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Replaces the magic-string encoding of synthetic priorities in the OODA loop
with a typed `SyntheticPriorityKind` enum that owns the single source of
truth for each synthetic id (`__memory__`, `__improvement__`,
`__poll_activity__`, `__extract_ideas__`, `__eval_watchdog__`). Five
variants, one module, one string constant per kind, instead of 29 scattered
literals across 6 files.

This is the second installment of the de-brittlification campaign
(PR #1870 was Part A — the merge_authority agentic judge). User's core
principle: when judgment is expressed as substring matching, it drifts;
when objective facts have multiple sources of truth, they desync. The
synthetic-priority strings had both problems.

The on-wire format (the `Priority.goal_id` String) is unchanged. The
dashboard, cycle reports, brain prompts, and persisted history all keep
working bit-for-bit. Only construction and dispatch sites change.

### What changed

- NEW `src/ooda_loop/priority_kind.rs` (~210 LOC): `SyntheticPriorityKind`
  enum with `synthetic_id() -> &'static str`, `from_synthetic_id(&str) ->
  Option<Self>`, free function `is_synthetic_id(&str) -> bool`, `all()`,
  `Display`. 7 unit tests covering round-trip, uniqueness, known-only,
  serialization-pinning.
- `src/ooda_loop/orient.rs`: three synthesis sites now build via
  `SyntheticPriorityKind::*.synthetic_id().to_string()`.
- `src/ooda_loop/orient.rs:filter_hallucinated_priorities`: replaced
  `goal_id.starts_with("__")` with `is_synthetic_id(&p.goal_id)`. The old
  heuristic silently accepted any `__foo__` (typos, removed kinds); the
  enum-backed check refuses unknowns explicitly.
- `src/ooda_loop/decide.rs:81`: same swap.
- `src/ooda_brain/decide.rs`: `DeterministicFallbackDecideBrain` now
  matches on `SyntheticPriorityKind::from_synthetic_id(...)` instead of a
  4-arm string match.

### Out of scope (deferred)

Changing `Priority { goal_id: String }` to `Priority { kind:
SyntheticPriorityKind }` would touch `DecideContext`, dashboard
serialization, `judgment_record`, all tests, and the brain prompts.
That's a separate follow-up PR. This PR ships only the enum + the
construction/dispatch refactor, so the change set stays small enough to
review carefully.

Issue #1868's `MergePr { pr_number, repo }` variant cannot fit cleanly
into the current Copy/value-only enum and will fold into the follow-up
typed-Priority PR.

### QA-team evidence

`cargo test --lib` from worktree root: 4010 passed, 0 failed, 4 ignored.
This includes the 7 new `priority_kind` tests:

- `synthetic_id_roundtrips_for_every_variant`
- `synthetic_ids_are_unique`
- `synthetic_ids_pinned_for_serialization_compat`
- `display_matches_synthetic_id`
- `is_synthetic_id_accepts_every_known_kind`
- `is_synthetic_id_rejects_real_goal_slugs`
- `is_synthetic_id_rejects_unknown_double_underscore_strings`

One pre-existing test
(`hallucination_filter_tests::double_underscore_prefix_arbitrary_suffix_is_synthetic`)
asserted the old lenient behavior — that any `__foo__` string passed the
synthetic filter. That lenience was the brittleness being fixed; rewrote
the test as `unknown_double_underscore_string_is_dropped_not_treated_as_synthetic`
to pin the new explicit behavior.

### Documentation

The new module's doc comment explains the architectural principle:
on-wire format is unchanged, the enum is purely an internal
single-source-of-truth so the wire format and the dispatch code cannot
drift apart. Each variant has a doc string describing what observation
synthesizes it and which `DecideJudgment` it routes to in the
deterministic fallback brain.

### Quality-audit

- 4010/4010 lib tests pass locally (`cargo test --lib`).
- `cargo fmt --all -- --check` passes (pre-commit hook verified).
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
  passes (pre-commit + pre-push hooks verified).
- `cargo clippy --release --no-deps -- -D warnings` (pre-commit gate)
  passes.
- `cargo test --release --lib` for the memory/bootstrap test gate
  (pre-push) passes.

### CI

All hooks (cargo fmt, cargo clippy debug, cargo clippy release, cargo
test memory/bootstrap) passed on push. Full CI suite runs on PR open;
will monitor and address any failures before requesting merge.

### Scope

Refactor-only — no behavior change for any real goal, no change to the
on-wire `goal_id` string format, no change to the dashboard or persisted
records. The only behavior change is the one called out under
QA-team evidence: unknown `__foo__` strings are now rejected by the
hallucination filter instead of silently accepted. That is a deliberate
tightening, not a regression — the old behavior was the bug.

### Verdict

Ready to merge once CI is green. This is a clean refactor: small
surface area, comprehensive tests, no on-wire format changes, no
behavior change for legitimate priorities, one intentional tightening
that fixes a long-standing silent-acceptance bug.
