### PR TITLE
feat(ooda/daemon): loud visibility for fallback brain construction (#1748 Step 1)

### DIFF
--- a/src/operator_commands_ooda/daemon/brains.rs
+++ b/src/operator_commands_ooda/daemon/brains.rs
@@ -5,17 +5,71 @@
 //!   * [`crate::ooda_brain::OodaDecideBrain`] — decide phase (PR #1469).
 //!   * [`crate::ooda_brain::OodaOrientBrain`] — orient phase (PR #1471).
 //!
-//! Each builder degrades gracefully: on `Err` (no LLM provider configured,
-//! adapter init failure, etc.) the daemon proceeds with the deterministic
-//! fallback so the cycle never depends on LLM availability.
+//! Each builder falls back to a deterministic brain when no LLM provider is
+//! configured. Per operator hard constraint (issues #1711, #1748), that
+//! degradation **must be LOUD**: every fallback construction logs at ERROR
+//! severity, writes a dashboard-visible line to `ooda.log`, and increments
+//! a process-wide counter (see [`fallback_brain_count`]) so operators
+//! cannot miss that the daemon is running in degraded mode.
+//!
+//! This is the first installment of the #1748 ladder. Step 2 will convert
+//! the fallback brains' `judge_*` methods to return `Err` instead of
+//! `Ok(safe_default)`. Step 3 will delete the fallback brains entirely
+//! and replace the engineer-lifecycle brain with an agentic subprocess
+//! per #1711's spec.
 
 use std::path::Path;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use super::helpers::daemon_log;
 
+/// Counts how many times any `Deterministic*FallbackBrain` has been
+/// constructed in this process. Bumped from [`record_fallback`].
+///
+/// Exposed via [`fallback_brain_count`] for tests + a future
+/// `/api/health` endpoint that should refuse "healthy" when this is
+/// nonzero. The metric is process-wide (not per-phase) on purpose: the
+/// loudest possible signal is "you're degraded somewhere" — the log
+/// line carries the per-phase detail.
+static FALLBACK_BRAIN_COUNT: AtomicU64 = AtomicU64::new(0);
+
+/// Read the process-wide count of fallback-brain constructions.
+pub fn fallback_brain_count() -> u64 {
+    FALLBACK_BRAIN_COUNT.load(Ordering::Relaxed)
+}
+
+#[cfg(test)]
+pub(crate) fn reset_fallback_brain_count_for_test() {
+    FALLBACK_BRAIN_COUNT.store(0, Ordering::Relaxed);
+}
+
+/// Loudly record that a fallback brain was constructed: ERROR-level
+/// tracing, dashboard-visible `ooda.log` line, and a process-wide
+/// counter bump.
+///
+/// `phase` is the OODA phase whose brain fell back (`"act"`,
+/// `"decide"`, or `"orient"`). `reason` is the `LlmProvider::resolve()`
+/// error rendered to string.
+fn record_fallback(state_root: &Path, phase: &str, reason: &str) {
+    FALLBACK_BRAIN_COUNT.fetch_add(1, Ordering::Relaxed);
+    tracing::error!(
+        target: "simard::ooda::fallback",
+        phase = phase,
+        reason = reason,
+        "OODA daemon running in DEGRADED mode: {phase}_brain fell back to deterministic (no LLM available) — see issues #1711, #1748",
+    );
+    daemon_log(
+        state_root,
+        &format!(
+            "[simard] OODA daemon: DEGRADED — {phase}_brain = Deterministic*FallbackBrain (no LLM: {reason}); see issues #1711, #1748"
+        ),
+    );
+}
+
 /// Construct the engineer-lifecycle brain. Always returns an Arc — falls
-/// back to [`crate::ooda_brain::DeterministicFallbackBrain`] on Err.
+/// back to [`crate::ooda_brain::DeterministicFallbackBrain`] on Err,
+/// loudly per [`record_fallback`].
 pub(super) fn build_act_brain(state_root: &Path) -> Arc<dyn crate::ooda_brain::OodaBrain> {
     match crate::ooda_brain::build_rustyclawd_brain() {
         Ok(b) => {
@@ -26,12 +80,7 @@ pub(super) fn build_act_brain(state_root: &Path) -> Arc<dyn crate::ooda_brain::O
             b.into()
         }
         Err(e) => {
-            daemon_log(
-                state_root,
-                &format!(
-                    "[simard] OODA daemon: brain = DeterministicFallbackBrain (rustyclawd unavailable: {e})"
-                ),
-            );
+            record_fallback(state_root, "act", &e.to_string());
             Arc::new(crate::ooda_brain::DeterministicFallbackBrain)
         }
     }
@@ -51,12 +100,7 @@ pub(super) fn build_decide_brain(
             Some(Arc::from(b))
         }
         Err(e) => {
-            daemon_log(
-                state_root,
-                &format!(
-                    "[simard] OODA daemon: decide_brain = DeterministicFallbackDecideBrain (no LLM: {e})"
-                ),
-            );
+            record_fallback(state_root, "decide", &e.to_string());
             None
         }
     }
@@ -76,13 +120,90 @@ pub(super) fn build_orient_brain(
             Some(Arc::from(b))
         }
         Err(e) => {
-            daemon_log(
-                state_root,
-                &format!(
-                    "[simard] OODA daemon: orient_brain = DeterministicFallbackOrientBrain (no LLM: {e})"
-                ),
-            );
+            record_fallback(state_root, "orient", &e.to_string());
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+    use tempfile::TempDir;
+
+    // Serializes tests that mutate process-global state (env vars + the
+    // atomic counter). cargo's parallel runner would otherwise interleave
+    // record_fallback() calls and corrupt counter expectations.
+    fn lock() -> std::sync::MutexGuard<'static, ()> {
+        static M: Mutex<()> = Mutex::new(());
+        M.lock().unwrap_or_else(|p| p.into_inner())
+    }
+
+    /// Direct unit test: record_fallback bumps the counter and writes a
+    /// dashboard-visible line containing the issue references. Does NOT
+    /// depend on LlmProvider::resolve() at all — exercises the loud-
+    /// failure recording code path in isolation.
+    #[test]
+    fn record_fallback_bumps_counter_and_writes_dashboard_log() {
+        let _g = lock();
+        reset_fallback_brain_count_for_test();
+        let tmp = TempDir::new().expect("tempdir");
+
+        assert_eq!(fallback_brain_count(), 0, "precondition");
+        record_fallback(tmp.path(), "act", "no llm provider configured");
+        assert_eq!(
+            fallback_brain_count(),
+            1,
+            "counter must increment on every fallback construction"
+        );
+
+        let log =
+            std::fs::read_to_string(tmp.path().join("ooda.log")).expect("ooda.log must be created");
+        assert!(
+            log.contains("DEGRADED"),
+            "log must contain DEGRADED marker; got: {log}"
+        );
+        assert!(
+            log.contains("act_brain"),
+            "log must name the phase; got: {log}"
+        );
+        assert!(
+            log.contains("#1711") && log.contains("#1748"),
+            "log must cite tracking issues so operators can find context; got: {log}"
+        );
+    }
+
+    /// Counter is monotonic across multiple fallback constructions
+    /// regardless of phase.
+    #[test]
+    fn record_fallback_counter_accumulates_across_phases() {
+        let _g = lock();
+        reset_fallback_brain_count_for_test();
+        let tmp = TempDir::new().expect("tempdir");
+
+        record_fallback(tmp.path(), "act", "x");
+        record_fallback(tmp.path(), "decide", "y");
+        record_fallback(tmp.path(), "orient", "z");
+        assert_eq!(fallback_brain_count(), 3);
+    }
+
+    /// The reason string from LlmProvider::resolve() must be preserved
+    /// verbatim in the dashboard log so operators can diagnose without
+    /// hunting through tracing output.
+    #[test]
+    fn record_fallback_preserves_resolve_error_in_dashboard_log() {
+        let _g = lock();
+        reset_fallback_brain_count_for_test();
+        let tmp = TempDir::new().expect("tempdir");
+        let unique_reason = "config.toml missing llm_provider key (unit-test sentinel)";
+
+        record_fallback(tmp.path(), "decide", unique_reason);
+
+        let log = std::fs::read_to_string(tmp.path().join("ooda.log")).expect("log");
+        assert!(
+            log.contains(unique_reason),
+            "the LlmProvider::resolve() error must be in the dashboard log verbatim; got: {log}"
+        );
     }
 }

--- a/src/operator_commands_ooda/daemon/mod.rs
+++ b/src/operator_commands_ooda/daemon/mod.rs
@@ -154,6 +154,25 @@ pub fn run_ooda_daemon(
     let decide_brain = brains::build_decide_brain(&state_root);
     let orient_brain = brains::build_orient_brain(&state_root);
 
+    // After all three brains are constructed, surface the cumulative
+    // fallback count in the dashboard. Nonzero == daemon is running in
+    // degraded mode (see issues #1711, #1748). Future health endpoints
+    // should refuse "healthy" when this is nonzero.
+    let degraded = brains::fallback_brain_count();
+    if degraded > 0 {
+        daemon_log(
+            &state_root,
+            &format!(
+                "[simard] OODA daemon: DEGRADED MODE — {degraded}/3 brains fell back to deterministic (see issues #1711, #1748)"
+            ),
+        );
+    } else {
+        daemon_log(
+            &state_root,
+            "[simard] OODA daemon: all 3 brains LLM-backed (no fallback in use)",
+        );
+    }
+
     // Surface where the daemon will look for hot-reloadable prompt assets so
     // operators know where to edit (see `docs/concepts/prompt-driven-brain-iteration.md`).
     {


### PR DESCRIPTION
## Summary

When `LlmProvider::resolve()` fails, the OODA daemon previously logged a
single `eprintln` + `ooda.log` line and silently constructed a
`Deterministic*FallbackBrain`. Operators routinely missed that the daemon
was running in degraded mode — exactly the silent-fallback pattern that
issues #1711 and #1748 explicitly ban.

This is **Step 1 of the #1748 ladder** (audit recorded in
https://github.com/rysweet/Simard/issues/1748#issuecomment-4465841296):

- **Step 1 (this PR):** Loud visibility. Behavior unchanged; pure operator
  signal upgrade.
- **Step 2 (next PR):** Convert `Deterministic*FallbackBrain::judge_*` to
  return `Err` instead of `Ok(safe_default)`.
- **Step 3:** Agentic engineer-lifecycle brain per #1711's spec; delete
  `EngineerLifecycleDecision` enum + parser entirely.

This is the second installment of the de-brittlification campaign
(PR #1870 = merge_authority agentic judge; PR #1874 = typed
`SyntheticPriorityKind` enum). Strategy correction: the prior plan's B4
("forgiving JSON parser") was killed because lenient parsing is still
parsing — the user's hard constraint in #1711 forbids it.

### What changed

Every fallback-brain construction now produces three signals:

1. **`tracing::error!`** at ERROR severity (was: `eprintln` at no level)
   with structured fields for the phase and the `LlmProvider::resolve()`
   reason. Routes to the global tracing subscriber so structured logging
   sinks (JSON, OpenTelemetry, file rotation) pick it up.
2. **`AtomicU64` counter** — `fallback_brain_count()`. Bumped on every
   fallback construction. Nonzero == daemon is degraded somewhere.
   Designed for a future `/api/health` endpoint that should refuse
   "healthy" when nonzero.
3. **Dashboard-visible `ooda.log` line** that cites both tracking issues
   so operators can find context without grepping the source.

After all three brains construct, the daemon also logs a summary line:
either `DEGRADED MODE — N/3 brains fell back...` if the counter is
nonzero, or `all 3 brains LLM-backed (no fallback in use)` if it is
zero. This is the line that appears in the dashboard's Logs tab.

### Out of scope (deferred to Steps 2 and 3)

- The fallback brains still construct and still return their safe
  defaults. Step 2 will convert them to return `Err` so the cycle is
  marked failed (which then engages the existing
  `FAILURE_PENALTY_PER_CONSECUTIVE = 0.2` machinery naturally).
- `EngineerLifecycleDecision` enum and its hand-rolled JSON parser
  still exist. Step 3 deletes both per #1711's spec and replaces the
  engineer-lifecycle brain with an agentic subprocess that acts via
  its own tools.

This deliberate staging keeps each PR small enough to review carefully
and avoids one mega-PR that touches three brains, the daemon, and 50+
tests in one shot.

### QA-team evidence

3 new unit tests in `operator_commands_ooda::daemon::brains::tests`:

- `record_fallback_bumps_counter_and_writes_dashboard_log` — verifies
  the counter increments and the log line contains the `DEGRADED`
  marker, the phase name, and references to both #1711 and #1748.
- `record_fallback_counter_accumulates_across_phases` — verifies the
  counter is monotonic across act/decide/orient phases.
- `record_fallback_preserves_resolve_error_in_dashboard_log` —
  verifies the LlmProvider::resolve() error string is preserved
  verbatim so operators can diagnose without hunting through tracing.

All 4006 lib tests pass (`cargo test --lib`). Tests use a
`Mutex<()>` to serialize against cargo's parallel runner since they
mutate the process-global atomic counter.

### Documentation

The module doc-comment on `brains.rs` now explicitly cites #1711 and
#1748 and explains the three-step ladder. The `record_fallback`
function has a doc comment describing what each signal is for. The
`FALLBACK_BRAIN_COUNT` static documents the operator-visibility
contract.

### Quality-audit

- `cargo fmt --all -- --check` — passes (pre-commit hook).
- `cargo clippy --release --no-deps -- -D warnings` — passes (pre-commit).
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
  — passes (pre-push).
- `cargo test --release --lib (cognitive_memory|bootstrap|memory_ipc|memory_consolidation)`
  — passes (pre-push smoke-test gate).
- `cargo test --lib` — 4006 passed, 0 failed, 4 ignored.

### CI

Pre-commit and pre-push hooks all green on push. Full CI runs on PR
open; will monitor and address any failures before requesting merge.

### Scope

Pure observability — no behavior change. The fallback brains still
construct, still return their safe defaults; the daemon still runs.
The only visible change is that operators now see ERROR-level tracing,
a counter they can query, and a clear DEGRADED-MODE line in the
dashboard Logs tab whenever any brain falls back. No goal, no cycle,
no action, no judgment changes.

### Verdict

Ready to merge once CI is green. Small, focused, no-regret change:
zero behavior change, three new operator signals, three unit tests,
clear staging toward Steps 2 and 3 documented in the comment on #1748.
