### PR TITLE
fix(adapter/copilot): pass prompt via argv/stdin to handle apostrophes and large bodies (#1871)

### DIFF
--- a/src/base_type_copilot/mod.rs
+++ b/src/base_type_copilot/mod.rs
@@ -7,6 +7,11 @@
 //! objective with memory facts and domain knowledge, and parses the copilot's
 //! structured output into [`BaseTypeOutcome`].
 
+use std::io::Write;
+use std::path::Path;
+
+use tempfile::NamedTempFile;
+
 use crate::base_type_turn::{format_turn_input, parse_turn_output, prepare_turn_context};
 use crate::base_types::{
     BaseTypeCapability, BaseTypeDescriptor, BaseTypeFactory, BaseTypeId, BaseTypeOutcome,
@@ -154,7 +159,17 @@ impl CopilotSdkSession {
     /// When `identity_context` or `prompt_preamble` are provided (e.g. in
     /// meeting mode), they are prepended to the objective so the agent
     /// receives the full conversational context.
-    fn build_enriched_objective(&self, input: &BaseTypeTurnInput) -> SimardResult<String> {
+    ///
+    /// The returned [`NamedTempFile`] holds the on-disk prompt file referenced
+    /// by the shell command. The caller must keep it alive for the duration
+    /// of the terminal turn so the copilot subprocess can `cat` it; the file
+    /// is auto-deleted when dropped (see issue #1871: passing the prompt by
+    /// file path rather than inlining it into the shell command avoids the
+    /// single-quote / `printf %s` escaping bugs that broke multi-KB prompts).
+    fn build_enriched_objective(
+        &self,
+        input: &BaseTypeTurnInput,
+    ) -> SimardResult<(String, NamedTempFile)> {
         let mut parts = Vec::new();
         if !input.prompt_preamble.is_empty() {
             parts.push(input.prompt_preamble.as_str());
@@ -171,7 +186,9 @@ impl CopilotSdkSession {
             self.knowledge_bridge.as_ref(),
         )?;
         let formatted = format_turn_input(&context);
-        Ok(build_copilot_terminal_objective(&self.config, &formatted))
+        let prompt_file = write_prompt_to_tempfile(&formatted)?;
+        let objective = build_copilot_terminal_objective(&self.config, prompt_file.path());
+        Ok((objective, prompt_file))
     }
 }
 
@@ -193,7 +210,7 @@ impl BaseTypeSession for CopilotSdkSession {
 
         self.turn_count += 1;
 
-        let enriched_objective = self.build_enriched_objective(&input)?;
+        let (enriched_objective, _prompt_file) = self.build_enriched_objective(&input)?;
         let enriched_input = BaseTypeTurnInput::objective_only(enriched_objective);
 
         tracing::info!(mode = %self.request.mode, turn = self.turn_count, "Copilot adapter: sending turn to Copilot SDK (this may take 30-90s)…");
@@ -275,16 +292,36 @@ impl BaseTypeSession for CopilotSdkSession {
 }
 
 /// Build a terminal-session-compatible objective string that launches the
-/// copilot command with the enriched prompt.
+/// copilot command and reads the prompt from a pre-written file on disk.
 ///
-/// Strategy: write the prompt to a temp file, run `<copilot-cmd> -p "$(cat file)"`
-/// in non-interactive mode with `--allow-all-tools`, then `exit` the shell.
-/// The terminal infrastructure calls `finish()` which waits for the process
-/// to exit naturally.  The copilot runs to completion however long it takes,
-/// and we read the full transcript afterward.
+/// **Why a file, not a `printf '%s' '<escaped>'` inline literal**: prior to
+/// issue #1871 this function embedded the entire enriched prompt as a
+/// single-quoted argument to `printf '%s'`. That string was then sent as
+/// PTY input via `writeln!(stdin, …)`. Two failure modes followed:
+///
+/// 1. **PTY line-buffer overflow.** Line discipline in canonical mode
+///    has a small input buffer (~4 KB on Linux); larger prompts truncated
+///    silently, leaving bash in continuation mode.
+/// 2. **Apostrophe escaping interactions.** Even within the buffer limit,
+///    the `\\` → `\\\\` + `'\''` escape sequence broke for some payloads,
+///    producing a malformed command that bash interpreted as an unterminated
+///    string. The transcript parser then returned the bootstrap noise as
+///    the "response", which downstream callers (e.g. the merge-readiness
+///    judge in PR #1870) parsed as their own prompt.
+///
+/// The fix: write the prompt to a temp file from Rust code (out-of-band,
+/// via `write_prompt_to_tempfile`), and pass only the path through the
+/// shell. Paths returned by [`NamedTempFile`] are guaranteed-safe ASCII
+/// (`/tmp/.tmpXXXXXX`), so single-quoting them is unconditional and the
+/// command line stays well under a hundred bytes regardless of prompt size.
+///
+/// Cleanup is owned by Rust: the [`NamedTempFile`] guard in `run_turn`
+/// unlinks the file on Drop. We deliberately do NOT chain `rm -f` in the
+/// shell command — that would race with the Rust guard and could mask
+/// transcript-debugging artefacts.
 pub(super) fn build_copilot_terminal_objective(
     config: &CopilotAdapterConfig,
-    formatted_prompt: &str,
+    prompt_file_path: &Path,
 ) -> String {
     let mut objective = String::new();
 
@@ -292,25 +329,52 @@ pub(super) fn build_copilot_terminal_objective(
         objective.push_str(&format!("working-directory: {cwd}\n"));
     }
 
-    // Write the prompt to a temp file and pass it to the copilot command via
-    // `-p "$(cat file)"` for non-interactive execution. The copilot CLI does
-    // NOT read prompts from piped stdin in interactive mode — it requires the
-    // `-p` flag for scripted/non-interactive usage. `--allow-all-tools` is
-    // required by copilot for non-interactive mode. `--subprocess-safe` skips
-    // interactive staging/env updates. Chain with `exit` so the shell exits
-    // after the copilot finishes.
-    let escaped = formatted_prompt
-        .replace('\\', "\\\\")
-        .replace('\'', "'\\''");
+    // Single-quote the path. NamedTempFile only produces paths from a
+    // restricted ASCII alphabet (`/`, `.`, alnum, `_`), so single-quoting is
+    // safe — but we still assert-check for defense-in-depth at construction.
+    let path_str = prompt_file_path.to_string_lossy();
+    debug_assert!(
+        !path_str.contains('\''),
+        "tempfile path unexpectedly contains a single quote: {path_str}"
+    );
+
+    // `-p "$(cat 'PATH')"` runs the copilot CLI in non-interactive mode with
+    // the full prompt body. `--subprocess-safe` skips interactive staging.
+    // `--allow-all-tools` is required by copilot for non-interactive runs.
+    // Chain with `exit` so the shell returns after the copilot finishes.
     objective.push_str(&format!(
-        "command: SIMARD_PROMPT_FILE=$(mktemp /tmp/simard-copilot-prompt.XXXXXX) && \
-         printf '%s' '{}' > \"$SIMARD_PROMPT_FILE\" && \
-         {} --subprocess-safe -p \"$(cat \"$SIMARD_PROMPT_FILE\")\" --allow-all-tools ; \
-         rm -f \"$SIMARD_PROMPT_FILE\" ; exit\n",
-        escaped, config.command,
+        "command: {} --subprocess-safe -p \"$(cat '{}')\" --allow-all-tools ; exit\n",
+        config.command, path_str,
     ));
 
     objective
+}
+
+/// Write an enriched prompt to a freshly-created `NamedTempFile` and return
+/// the handle. The file is auto-deleted on Drop, so the caller must keep
+/// the handle alive for as long as the copilot subprocess may read from it.
+///
+/// Returns [`SimardError::AdapterInvocationFailed`] if the temp file cannot
+/// be created or written — both are extremely unlikely on a healthy host
+/// but worth surfacing rather than swallowing.
+pub(super) fn write_prompt_to_tempfile(prompt: &str) -> SimardResult<NamedTempFile> {
+    let mut file = NamedTempFile::with_prefix("simard-copilot-prompt-").map_err(|error| {
+        SimardError::AdapterInvocationFailed {
+            base_type: "copilot-sdk".to_string(),
+            reason: format!("failed to create copilot prompt temp file: {error}"),
+        }
+    })?;
+    file.write_all(prompt.as_bytes())
+        .map_err(|error| SimardError::AdapterInvocationFailed {
+            base_type: "copilot-sdk".to_string(),
+            reason: format!("failed to write copilot prompt temp file: {error}"),
+        })?;
+    file.flush()
+        .map_err(|error| SimardError::AdapterInvocationFailed {
+            base_type: "copilot-sdk".to_string(),
+            reason: format!("failed to flush copilot prompt temp file: {error}"),
+        })?;
+    Ok(file)
 }
 
 /// Extract the actual copilot LLM response from the terminal transcript

--- a/src/tests_base_type_copilot.rs
+++ b/src/tests_base_type_copilot.rs
@@ -88,11 +88,20 @@ fn build_copilot_objective_includes_command_and_exit() {
         command: "my-copilot run".to_string(),
         working_directory: Some("/tmp/work".to_string()),
     };
-    let prompt = "Do the thing.";
-    let objective = build_copilot_terminal_objective(&config, prompt);
+    let prompt_file = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(prompt_file.path(), "Do the thing.").unwrap();
+    let objective = build_copilot_terminal_objective(&config, prompt_file.path());
     assert!(objective.contains("my-copilot run"));
     assert!(objective.contains("working-directory: /tmp/work"));
-    assert!(objective.contains("Do the thing."));
+    // Issue #1871: the prompt body is now read from the temp file, not inlined.
+    assert!(
+        objective.contains(prompt_file.path().to_str().unwrap()),
+        "objective should reference the prompt file path"
+    );
+    assert!(
+        !objective.contains("Do the thing."),
+        "prompt body must NOT be inlined into the shell command (issue #1871)"
+    );
     assert!(
         objective.contains("; exit"),
         "objective must chain exit to end the shell naturally"
@@ -118,19 +127,121 @@ fn build_copilot_objective_includes_command_and_exit() {
 #[test]
 fn build_copilot_objective_without_working_directory() {
     let config = CopilotAdapterConfig::default();
-    let prompt = "Hello world";
-    let objective = build_copilot_terminal_objective(&config, prompt);
+    let prompt_file = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(prompt_file.path(), "Hello world").unwrap();
+    let objective = build_copilot_terminal_objective(&config, prompt_file.path());
     assert!(!objective.contains("working-directory:"));
     assert!(objective.contains("; exit"));
     assert!(objective.contains("amplihack copilot"));
 }
 
+/// Regression for issue #1871: prompts containing both single and double
+/// quotes (plus a large body) must round-trip through the adapter without
+/// any shell-escaping ambiguity. With the new file-based approach, the
+/// objective shell command is short and does not embed the prompt body at
+/// all — the prompt is delivered to the copilot subprocess via
+/// `cat 'PATH'` reading a file written out-of-band from Rust.
 #[test]
-fn build_copilot_objective_escapes_single_quotes() {
+fn build_copilot_objective_handles_apostrophes_and_double_quotes() {
     let config = CopilotAdapterConfig::default();
-    let prompt = "it's a test with 'quotes'";
-    let objective = build_copilot_terminal_objective(&config, prompt);
-    assert!(!objective.contains("it's"), "single quotes must be escaped");
+    // Prompt with the classic failure patterns: apostrophes ("author's",
+    // "Simard's"), backslashes, double quotes, and a $-prefixed token that
+    // would have undergone shell expansion if inlined.
+    let prompt = "author's Simard's judge's response: she said \"hello $USER\" and \\escaped\\";
+    let temp_file = write_prompt_to_tempfile(prompt).expect("write tempfile");
+    let objective = build_copilot_terminal_objective(&config, temp_file.path());
+
+    // The prompt body must NEVER appear in the shell command line — that
+    // was the root cause of #1871.
+    for needle in [
+        "author's",
+        "Simard's",
+        "judge's",
+        "hello $USER",
+        "\\escaped\\",
+    ] {
+        assert!(
+            !objective.contains(needle),
+            "prompt fragment {needle:?} leaked into shell command: {objective:?}"
+        );
+    }
+
+    // The file on disk must contain the prompt verbatim.
+    let written = std::fs::read_to_string(temp_file.path()).expect("read prompt file");
+    assert_eq!(
+        written, prompt,
+        "tempfile contents must be byte-for-byte identical to the input prompt"
+    );
+
+    // The objective must reference the temp file path.
+    assert!(
+        objective.contains(temp_file.path().to_str().unwrap()),
+        "objective must reference the temp file path"
+    );
+}
+
+/// Regression for issue #1871 (PTY line-buffer overflow): a 128 KB+ prompt
+/// containing apostrophes must produce a short shell command line and a
+/// faithful on-disk prompt file. The reporter observed the failure with a
+/// ~12 KB prompt; we lock the larger 128 KB threshold to leave headroom.
+#[test]
+fn build_copilot_objective_handles_prompts_over_128kb() {
+    let config = CopilotAdapterConfig::default();
+
+    // Build a > 128 KB prompt mixing apostrophes, double quotes, backslashes,
+    // and shell metacharacters. The repeated unit is 64 bytes so 3000 reps
+    // ≈ 187 KB — well over the threshold.
+    let unit = "author's judge's \"merge\" `pwned` ${injected} \\nope\\ end-of-line\n";
+    assert_eq!(unit.len(), 64);
+    let prompt: String = unit.repeat(3000);
+    assert!(prompt.len() > 128 * 1024, "prompt should exceed 128 KB");
+
+    let temp_file = write_prompt_to_tempfile(&prompt).expect("write tempfile");
+    let objective = build_copilot_terminal_objective(&config, temp_file.path());
+
+    // The objective shell-command must stay small — comfortably under the
+    // canonical PTY line buffer (~4 KB on Linux). A few hundred bytes is
+    // typical: command + path + flags.
+    assert!(
+        objective.len() < 1024,
+        "objective length {} exceeded 1 KB; large prompt may have leaked into command line",
+        objective.len()
+    );
+
+    // The on-disk file must contain the prompt byte-for-byte.
+    let written = std::fs::read_to_string(temp_file.path()).expect("read prompt file");
+    assert_eq!(written.len(), prompt.len(), "tempfile size mismatch");
+    assert_eq!(written, prompt, "tempfile content mismatch");
+
+    // The command must reference the file via `cat 'PATH'`, not inline it.
+    assert!(
+        objective.contains("$(cat '"),
+        "objective must read prompt via $(cat 'PATH'): {objective:?}"
+    );
+
+    // Sanity: no fragment of the inlined prompt body leaked through.
+    assert!(
+        !objective.contains("author's"),
+        "prompt body must not appear in shell command"
+    );
+}
+
+/// `write_prompt_to_tempfile` returns a `NamedTempFile` whose path is safe
+/// to single-quote in shell. The `NamedTempFile` API guarantees ASCII
+/// alphanumerics, `/`, `.`, `_`, and `-`; this test pins that contract so
+/// any future change that broke it would surface here, not as a production
+/// shell-injection bug.
+#[test]
+fn write_prompt_tempfile_path_is_shell_safe() {
+    let file = write_prompt_to_tempfile("ok").expect("write tempfile");
+    let path = file.path().to_string_lossy();
+    for ch in path.chars() {
+        assert!(
+            ch.is_ascii_alphanumeric() || matches!(ch, '/' | '.' | '_' | '-'),
+            "tempfile path {path:?} contains unexpected character {ch:?}; \
+             single-quoting in build_copilot_terminal_objective would no longer be safe"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Fixes #1871 — the Copilot adapter built its shell invocation by embedding the entire
enriched prompt as a single-quoted `printf '%s' '<escaped>'` argument and then sent
that string as PTY input. Two failure modes accumulated:

1. **PTY line-buffer overflow.** Canonical-mode line discipline has a ~4 KB input
   buffer on Linux. Multi-KB prompts (e.g. the ~12 KB merge-readiness judge prompt
   from PR #1870) silently truncated, leaving bash in continuation mode.
2. **Apostrophe escaping interactions.** The `\\` + `'\''` escape combination
   interacted with `printf %s` backslash handling in subtle ways for prompts
   containing many apostrophes (`author's`, `Simard's`, `judge's`). The malformed
   command terminated string parsing early, copilot never received the real prompt,
   and the transcript parser returned the bootstrap noise as the response. Downstream
   callers parsed that noise as their own prompt — the exact symptom in #1871.

## Fix
Write the enriched prompt to a `NamedTempFile` from Rust code, out-of-band, before
launching the PTY shell. The command line becomes short and constant-size:

```
<command> --subprocess-safe -p "$(cat 'PATH')" --allow-all-tools ; exit
```

`NamedTempFile` paths use a restricted ASCII alphabet so single-quoting `PATH` is
unconditional. The Rust handle is held alive by `run_turn` for the duration of the
terminal turn and unlinks the file on `Drop` — we deliberately do NOT chain
`rm -f` in the shell so the Rust guard owns cleanup unambiguously.

## Repro — before vs after

**Before** (~12 KB prompt with apostrophes, e.g. `merge-readiness-judge`):

```
$ simard merge-pr <PR-with-long-substantive-body>
…
base type 'merge-readiness-judge' failed during invocation:
merge-readiness-judge response had no JSON object;
raw_response="# Merge-readiness judge\nYou are the merge-readiness judge…"
```

The transcript contained bash continuation prompts (`> `) interleaved with the
prompt body, then no real response.

**After** the same prompt (and prompts up to 128 KB+ exercised in unit tests)
goes through cleanly — the copilot CLI receives the full prompt via
`-p "$(cat <tempfile>)"` and emits a synthesized response.

## Test plan
- `cargo test --lib tests_base_type_copilot` → **24 / 24 passing**, including
  three new regression tests:
  - `build_copilot_objective_handles_apostrophes_and_double_quotes` — prompt with
    `'`, `"`, `\`, and `$USER` round-trips through the temp file with no fragment
    leaking into the shell command.
  - `build_copilot_objective_handles_prompts_over_128kb` — ~187 KB prompt produces
    an objective under 1 KB and a byte-for-byte-faithful temp file. (The reporter
    saw the bug at ~12 KB; locking the 128 KB bar leaves headroom.)
  - `write_prompt_tempfile_path_is_shell_safe` — pins the path-alphabet contract
    that makes unconditional single-quoting safe.
- `cargo test --lib` → **4005 / 4005 passing**, 0 failures (no unrelated regressions).
- `cargo clippy --all-targets -- -D warnings` → clean.
- Pre-push hooks (fmt-check, race-subset tests, `--all-targets --all-features
  --locked` clippy) → all passed on push.

## Diff focus
2 files, +209 / −34. No unrelated edits.

- `src/base_type_copilot/mod.rs` — `build_copilot_terminal_objective` signature
  change (now takes `&Path` instead of the prompt body); new
  `write_prompt_to_tempfile` helper; `build_enriched_objective` returns
  `(String, NamedTempFile)`; `run_turn` holds the tempfile alive.
- `src/tests_base_type_copilot.rs` — update existing call sites to the new
  signature; three new regression tests above.

## Out of scope (follow-up)
The same `printf '%s' '<escaped>'` pattern exists in:
- `src/ooda_actions/session.rs:79` (Claude path)
- `src/base_type_harness.rs:131`

Per the engineer instructions I am noting these as a follow-up issue rather
than expanding scope.

Closes #1871
