### PR TITLE
fix(cognitive-memory): no silent fallback in recall_procedure JSON decode (#1604 gap G17)

### DIFF
--- a/src/cognitive_memory/ops.rs
+++ b/src/cognitive_memory/ops.rs
@@ -1,6 +1,6 @@
 //! CognitiveMemoryOps trait impl for NativeCognitiveMemory + Cypher escaping.
 
-use crate::error::SimardResult;
+use crate::error::{SimardError, SimardResult};
 use crate::memory_cognitive::{
     CognitiveFact, CognitiveProcedure, CognitiveProspective, CognitiveStatistics,
     CognitiveWorkingSlot,
@@ -247,8 +247,29 @@ impl CognitiveMemoryOps for NativeCognitiveMemory {
         prerequisites: &[String],
     ) -> SimardResult<String> {
         let id = Self::new_id("proc");
-        let steps_json = serde_json::to_string(steps).unwrap_or_default();
-        let prereqs_json = serde_json::to_string(prerequisites).unwrap_or_default();
+        // Errors propagated (no silent `unwrap_or_default()`) so a
+        // serialize failure cannot land a row whose `steps` column is the
+        // empty string — that would round-trip as `[]` and look like a
+        // legitimate zero-step procedure on recall.  See issue #1604 gap
+        // G17 / the #1711/#1748/#1754 "no silent fallback" pattern.
+        let steps_json =
+            serde_json::to_string(steps).map_err(|e| SimardError::BridgeCallFailed {
+                bridge: "cognitive-memory-native".into(),
+                method: "store_procedure".into(),
+                reason: format!(
+                    "failed to serialize {} step(s) for procedure '{name}': {e}",
+                    steps.len()
+                ),
+            })?;
+        let prereqs_json =
+            serde_json::to_string(prerequisites).map_err(|e| SimardError::BridgeCallFailed {
+                bridge: "cognitive-memory-native".into(),
+                method: "store_procedure".into(),
+                reason: format!(
+                    "failed to serialize {} prerequisite(s) for procedure '{name}': {e}",
+                    prerequisites.len()
+                ),
+            })?;
         self.execute(&format!(
             "CREATE (p:Procedure {{id: '{}', name: '{}', steps: '{}', prerequisites: '{}', usage_count: 0}})",
             escape_cypher(&id),
@@ -264,20 +285,107 @@ impl CognitiveMemoryOps for NativeCognitiveMemory {
         let rows = self.query(&format!(
             "MATCH (p:Procedure) WHERE p.name CONTAINS '{q}' OR p.steps CONTAINS '{q}' RETURN p.id, p.name, p.steps, p.prerequisites, p.usage_count LIMIT {limit}"
         ))?;
-        Ok(rows
-            .iter()
-            .map(|row| {
-                let steps_str = as_str(&row[2]).unwrap_or("[]");
-                let prereqs_str = as_str(&row[3]).unwrap_or("[]");
-                CognitiveProcedure {
-                    node_id: as_str(&row[0]).unwrap_or("").to_string(),
-                    name: as_str(&row[1]).unwrap_or("").to_string(),
-                    steps: serde_json::from_str(steps_str).unwrap_or_default(),
-                    prerequisites: serde_json::from_str(prereqs_str).unwrap_or_default(),
-                    usage_count: as_i64(&row[4]).unwrap_or(0),
+        // Each row is decoded with **loud** failure on schema drift or
+        // corrupt JSON in `steps` / `prerequisites`.  The previous
+        // implementation called `unwrap_or_default()` on the JSON parse
+        // and `unwrap_or("")` on every column, which turned a corrupt
+        // procedure into a "valid procedure with zero steps" — the exact
+        // silent-empty-recall failure mode called out in issue #1604
+        // (gap G17) and the recent #1711/#1748/#1754 work to remove
+        // silent fallbacks from the cognitive substrate.
+        rows.into_iter()
+            .map(|row| -> SimardResult<CognitiveProcedure> {
+                if row.len() < 5 {
+                    return Err(SimardError::BridgeCallFailed {
+                        bridge: "cognitive-memory-native".into(),
+                        method: "recall_procedure".into(),
+                        reason: format!(
+                            "expected 5 columns from MATCH (p:Procedure), got {}",
+                            row.len()
+                        ),
+                    });
                 }
+                let node_id = as_str(&row[0])
+                    .ok_or_else(|| SimardError::BridgeCallFailed {
+                        bridge: "cognitive-memory-native".into(),
+                        method: "recall_procedure".into(),
+                        reason: format!(
+                            "procedure row column 0 (id) was not a string: {:?}",
+                            row[0]
+                        ),
+                    })?
+                    .to_string();
+                let name = as_str(&row[1])
+                    .ok_or_else(|| SimardError::BridgeCallFailed {
+                        bridge: "cognitive-memory-native".into(),
+                        method: "recall_procedure".into(),
+                        reason: format!(
+                            "procedure '{node_id}' column 1 (name) was not a string: {:?}",
+                            row[1]
+                        ),
+                    })?
+                    .to_string();
+                let steps_str =
+                    as_str(&row[2]).ok_or_else(|| SimardError::BridgeCallFailed {
+                        bridge: "cognitive-memory-native".into(),
+                        method: "recall_procedure".into(),
+                        reason: format!(
+                            "procedure '{node_id}' column 2 (steps) was not a string: {:?}",
+                            row[2]
+                        ),
+                    })?;
+                let prereqs_str =
+                    as_str(&row[3]).ok_or_else(|| SimardError::BridgeCallFailed {
+                        bridge: "cognitive-memory-native".into(),
+                        method: "recall_procedure".into(),
+                        reason: format!(
+                            "procedure '{node_id}' column 3 (prerequisites) was not a string: {:?}",
+                            row[3]
+                        ),
+                    })?;
+                let steps: Vec<String> = serde_json::from_str(steps_str).map_err(|e| {
+                    tracing::warn!(
+                        node_id = %node_id,
+                        column = "steps",
+                        payload = %steps_str,
+                        error = %e,
+                        "cognitive_memory::recall_procedure: corrupt steps JSON",
+                    );
+                    SimardError::BridgeCallFailed {
+                        bridge: "cognitive-memory-native".into(),
+                        method: "recall_procedure".into(),
+                        reason: format!(
+                            "procedure '{node_id}' has corrupt steps JSON ({e}); payload={steps_str:?}"
+                        ),
+                    }
+                })?;
+                let prerequisites: Vec<String> =
+                    serde_json::from_str(prereqs_str).map_err(|e| {
+                        tracing::warn!(
+                            node_id = %node_id,
+                            column = "prerequisites",
+                            payload = %prereqs_str,
+                            error = %e,
+                            "cognitive_memory::recall_procedure: corrupt prerequisites JSON",
+                        );
+                        SimardError::BridgeCallFailed {
+                            bridge: "cognitive-memory-native".into(),
+                            method: "recall_procedure".into(),
+                            reason: format!(
+                                "procedure '{node_id}' has corrupt prerequisites JSON ({e}); payload={prereqs_str:?}"
+                            ),
+                        }
+                    })?;
+                let usage_count = as_i64(&row[4]).unwrap_or(0);
+                Ok(CognitiveProcedure {
+                    node_id,
+                    name,
+                    steps,
+                    prerequisites,
+                    usage_count,
+                })
             })
-            .collect())
+            .collect()
     }
 
     fn store_prospective(

--- a/src/cognitive_memory/tests_mod.rs
+++ b/src/cognitive_memory/tests_mod.rs
@@ -93,6 +93,109 @@ fn store_and_recall_procedure() {
     assert_eq!(procs[0].steps, steps);
 }
 
+// G17 (issue #1604): `recall_procedure` previously called
+// `serde_json::from_str(...).unwrap_or_default()` on the `steps` and
+// `prerequisites` columns.  A row whose JSON was corrupted (schema drift,
+// truncation, partial flush before fsync) was silently surfaced as a
+// "valid procedure with zero steps" — the exact silent-empty-recall
+// failure mode that the #1711/#1748/#1754 "no silent fallback" pattern
+// targets across the cognitive substrate.
+//
+// This test plants a Procedure node whose `steps` column is **not** valid
+// JSON and asserts that recall returns a loud `BridgeCallFailed` error
+// that names the offending node id, the column, and the corrupt payload —
+// instead of cheerfully returning an empty-steps procedure.
+#[test]
+fn recall_procedure_loudly_errors_on_corrupt_steps_json() {
+    let mem = test_mem();
+
+    // Plant a Procedure row with deliberately corrupt steps JSON.
+    // `escape_cypher` is used so the corrupt payload survives Cypher
+    // string parsing — what we want to corrupt is the *JSON* payload
+    // after escape, not the Cypher literal itself.
+    let corrupt_steps = "not-valid-json{[";
+    mem.execute(&format!(
+        "CREATE (p:Procedure {{id: 'proc_corrupt_steps', name: 'corrupt', steps: '{}', prerequisites: '[]', usage_count: 0}})",
+        escape_cypher(corrupt_steps),
+    ))
+    .expect("planted corrupt row should insert");
+
+    let err = mem
+        .recall_procedure("corrupt", 5)
+        .expect_err("recall must fail loudly on corrupt steps JSON, not return empty steps");
+
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("proc_corrupt_steps"),
+        "error must name offending procedure id, got: {msg}"
+    );
+    assert!(
+        msg.contains("steps"),
+        "error must name the corrupt column, got: {msg}"
+    );
+    assert!(
+        msg.contains("corrupt steps JSON")
+            || msg.contains("corrupt_steps")
+            || msg.contains("not-valid-json"),
+        "error must surface the corruption, got: {msg}"
+    );
+}
+
+// Companion test for the prerequisites column — same gap, different field.
+#[test]
+fn recall_procedure_loudly_errors_on_corrupt_prerequisites_json() {
+    let mem = test_mem();
+
+    let corrupt_prereqs = "{not valid";
+    mem.execute(&format!(
+        "CREATE (p:Procedure {{id: 'proc_corrupt_prereqs', name: 'corrupt2', steps: '[]', prerequisites: '{}', usage_count: 0}})",
+        escape_cypher(corrupt_prereqs),
+    ))
+    .expect("planted corrupt row should insert");
+
+    let err = mem
+        .recall_procedure("corrupt2", 5)
+        .expect_err("recall must fail loudly on corrupt prerequisites JSON");
+
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("proc_corrupt_prereqs"),
+        "error must name offending procedure id, got: {msg}"
+    );
+    assert!(
+        msg.contains("prerequisites"),
+        "error must name the corrupt column, got: {msg}"
+    );
+}
+
+// Negative control: a healthy row sitting alongside a corrupt one still
+// causes the whole recall to fail loudly, rather than partial-success
+// where the healthy row hides the corrupt one.  This protects against a
+// "skip corrupt rows" regression that would re-introduce silent recall.
+#[test]
+fn recall_procedure_corrupt_row_taints_whole_batch() {
+    let mem = test_mem();
+
+    mem.store_procedure("healthy", &["step-a".to_string()], &[])
+        .expect("healthy row should insert");
+    mem.execute(&format!(
+        "CREATE (p:Procedure {{id: 'proc_mixed_corrupt', name: 'healthy_mixed', steps: '{}', prerequisites: '[]', usage_count: 0}})",
+        escape_cypher("garbage{"),
+    ))
+    .expect("planted corrupt row should insert");
+
+    // Query that matches both rows.
+    let result = mem.recall_procedure("healthy", 10);
+    let err = result.expect_err(
+        "recall must surface corruption from any matched row — silent skip would let bad data hide",
+    );
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("proc_mixed_corrupt"),
+        "error must name the corrupt row even when a healthy row matched first, got: {msg}"
+    );
+}
+
 #[test]
 fn store_prospective_and_check_triggers() {
     let mem = test_mem();


### PR DESCRIPTION
## Summary

Closes one of the gaps enumerated in issue #1604 ("Cognitive memory persistence: gap analysis follow-up to #1427"), specifically **gap G17 — `recall_procedure` silently degrades corrupt JSON to empty vectors via `unwrap_or_default()`**.

This is the same anti-pattern that #1711 / #1748 / #1754 removed from the OODA brain: a read path that swallows decode errors and returns a default value, so the operator cannot distinguish *"I have no procedure for X"* from *"I have a procedure for X but the bytes are scrambled."* For a feature named "cognitive memory persistence with durable cross-session recall", this is the exact failure mode worth closing.

## Audit context

Before fixing I surveyed the cognitive memory subsystem:

| Surface | Status |
|---|---|
| `src/cognitive_memory/` (LadybugDB native backend) | persistence, schema, ops, backup, in-memory + on-disk tests |
| `src/memory_consolidation/` (session-phase hooks) | gaps G10/G11 already fixed in #1607; G1/G2 propagation visible in tests |
| `src/memory_snapshot.rs` + `src/remote_transfer/` | JSON snapshot save/load — separate gaps (non-atomic write, load_latest swallowing) remain, see below |
| `src/persistence/mod.rs::persist_json` | already does atomic temp + `sync_all` + rename |
| `tests/memory_durable.rs` | bridge-contract tests with in-memory transport; **not** a process-restart durability test |

Baseline test runs (HEAD f87503a3, before this PR):

```
cargo test --lib cognitive_memory::           → 24 passed
cargo test --lib memory_consolidation::       → 15 passed
cargo test --test memory_durable              → 18 passed
cargo test --lib                              → 4016 passed, 0 failed, 4 ignored
```

Green baseline. No ignored/flaky cases on the memory path.

## The gap (G17)

`src/cognitive_memory/ops.rs::recall_procedure` was decoding columns like this:

```rust
let steps_str = as_str(&row[2]).unwrap_or("[]");
let prereqs_str = as_str(&row[3]).unwrap_or("[]");
CognitiveProcedure {
    node_id: as_str(&row[0]).unwrap_or("").to_string(),
    name: as_str(&row[1]).unwrap_or("").to_string(),
    steps: serde_json::from_str(steps_str).unwrap_or_default(),
    prerequisites: serde_json::from_str(prereqs_str).unwrap_or_default(),
    usage_count: as_i64(&row[4]).unwrap_or(0),
}
```

Failure modes silently masked:
- Corrupt or truncated `steps` JSON → procedure surfaces with zero steps (looks legitimate)
- Schema drift in `prerequisites` → procedure surfaces with empty prereqs
- Non-string column type in id/name → empty string id, indistinguishable from valid data

Symmetric footgun in `store_procedure`: `serde_json::to_string(...).unwrap_or_default()` would land a row whose `steps` column is `""` and round-trip as `[]` on recall.

## Fix

- `store_procedure`: replaces `unwrap_or_default()` on the serialize side with `?` (consistency — Vec<String> serialization can't fail today, but the lint surface should stay clean).
- Diff is focused; only `src/cognitive_memory/ops.rs` and `src/cognitive_memory/tests_mod.rs` changed.

## Evidence — new tests (added as part of this PR)

Three new tests in `src/cognitive_memory/tests_mod.rs` plant Procedure rows with deliberately corrupt JSON via raw cypher `CREATE` and assert recall fails loudly:

| Test | What it proves |
|---|---|
| `recall_procedure_loudly_errors_on_corrupt_steps_json` | Corrupt `steps` column → `BridgeCallFailed` naming the node id, the column, and the payload — **not** an empty-steps procedure |
| `recall_procedure_loudly_errors_on_corrupt_prerequisites_json` | Same shape, `prerequisites` column |
| `recall_procedure_corrupt_row_taints_whole_batch` | Negative control: a healthy row matched alongside a corrupt one still surfaces the corruption — prevents a future "silently skip corrupt rows" regression |

After this PR:

```
cargo test --lib cognitive_memory::           → 27 passed (was 24; +3 new)
cargo test --lib                              → 4019 passed, 0 failed, 4 ignored
cargo test --test memory_durable              → 18 passed
cargo test --test memory_consolidation_lifecycle → green
cargo test --test memory_bridge_adapter       → green
cargo fmt --check                             → clean
cargo clippy --all-targets --all-features --locked -- -D warnings → clean
```

Pre-push hook (fmt + race-subset `cargo test --release --lib (cognitive_memory|bootstrap|memory_ipc|memory_consolidation) --test-threads=$(nproc)` + full clippy) ran clean on the local push.

## Out of scope (deliberate)

To keep the PR focused per the merge-ready criteria, the following gaps from #1604 are **not** touched here and should be filed/picked up separately:

- **G1/G2** intake & cross-session-hydration error propagation in `runtime/session.rs`
- **G3** persist `pending_bridge_keys` to disk
- **G5/G7** RAII `SessionGuard` + `catch_unwind` around `execute_session`
- **G13** explicit LadybugDB checkpoint after persistence phase
- **G14** `preemptive_wal_cleanup` removing WAL on transient `metadata` errors
- **G15/G16** session-end verified backup + restore-from-rename-aside on open failure
- **G19** mirror evidence/goal/summary writes into cognitive memory
- **G20** cross-process kernel-level durability integration test
- `remote_transfer::export_memory_snapshot` uses `std::fs::write` (non-atomic, no fsync) — separate snapshot-durability follow-up

## Refs

- Closes one item from #1604 (gap G17)
- Pattern alignment: #1711, #1748, #1754 ("no silent fallback" in OODA brain)
- Companion to #1607 (G10/G11 snapshot save error propagation)
