### PR TITLE
fix(#1915): merge-on-write semantics for save_goal_board

### DIFF
--- a/docs/concepts/goal-board-persistence.md
+++ b/docs/concepts/goal-board-persistence.md
@@ -1,7 +1,7 @@
 ---
 title: Goal board persistence — cognitive-memory single source of truth
 description: How Simard loads and saves the goal board across OODA cycles, dashboard handlers, meeting flows, and the engineer loop, with cognitive memory as the sole persistence target.
-last_updated: 2026-05-09
+last_updated: 2026-05-19
 owner: simard
 doc_type: concept
 related:
@@ -57,6 +57,20 @@ This produced a class of subtle bugs:
 
 - **Drift** — a dashboard write that succeeded on disk but was racing a
   daemon cycle could be silently overwritten by the daemon's next save.
+  A related intra-store race in `save_goal_board` itself — two
+  `CognitiveMemoryOps` clients each writing a stale snapshot fact —
+  caused issue
+  [#1915](https://github.com/rysweet/Simard/issues/1915), where production
+  goals were silently deleted from cognitive memory between OODA cycles 5
+  and 6 during concurrent worktree/cargo build activity. The fix layers
+  **merge-on-write** semantics on top of `save_goal_board`: read the latest
+  persisted snapshot, union by `id` with the in-flight board (in-flight
+  wins on collision), truncate the active set to `MAX_ACTIVE_GOALS` using
+  a deterministic sort key, then `store_fact`. See the
+  [`save_goal_board` API reference](../reference/goal-board-api.md#save_goal_board)
+  for the merge rule, the read-failure fallback, and the best-effort
+  concurrency guarantee (no goal disappears in the common race; field-level
+  last-writer still applies on same-id concurrent edits).
 - **Stale reads** — a consumer that read the disk file just after another
   consumer had updated only the cognitive memory snapshot saw outdated data.
 - **Recovery confusion** — an operator restoring from a backup of one store
@@ -208,15 +222,19 @@ run_ooda_cycle_inner
 ├─ check .reseed_goals marker  ← if present: reset board to empty + skip load
 ├─ load_goal_board(bridge)
 │   ├─ migrate_legacy_disk_file_if_present(bridge)  ← one-shot bootstrap
-│   └─ search_facts("goal-board:snapshot", 1, 0.0)  ← primary read
-│       (failure → log + Ok(GoalBoard::new()))
+│   └─ read_latest_snapshot(bridge)                 ← shared with save_goal_board
+│       (search_facts("goal-board:snapshot", 64, 0.0) → filter → max_by(node_id))
+│       (None on error → log + Ok(GoalBoard::new()))
 │   └─ only applied if board.active is non-empty
 ├─ sweep_stale_assignments()   ← clear dead tmux sessions (no-op outside tmux)
 ├─ seed_default_board()        ← only if board still empty
 ├─ check_meeting_handoffs()
 └─ [Observe → Orient → Decide → Act → Curate]
     └─ persist_board(bridge)   ← writes goal-board:snapshot fact + episode
-        (rejects suspect boards via integrity guard before any write)
+        ├─ guard(in-flight)                       ← rejects suspect boards before any read/write
+        ├─ read_latest_snapshot(bridge)           ← re-reads latest persisted fact (None on error → skip merge)
+        ├─ merge_boards(persisted, in-flight)     ← union by id, in-flight wins, truncate to MAX_ACTIVE_GOALS
+        └─ store_fact(merged)                     ← writes goal-board:snapshot fact + episode
 ```
 
 Three important notes on the load step:
@@ -247,8 +265,19 @@ Three important notes on the load step:
 - Writes from the dashboard, the meeting REPL, and the daemon never race
   against each other when the daemon is running, because they all flow
   through the same daemon IPC socket.
+- **No goal *added* in a disjoint subset disappears in the common
+  multi-client race** (issue #1915): `save_goal_board` re-reads the latest
+  persisted snapshot and merges by-`id` union with the in-flight board
+  before storing, so two `CognitiveMemoryOps` clients writing disjoint
+  goal subsets each preserve the other's goals. See the
+  [`save_goal_board` API reference](../reference/goal-board-api.md#save_goal_board)
+  for the merge rule, deterministic truncation order, and the
+  read-failure fallback. Explicit *removals* (`archive_completed`, local
+  `retain`/`drain` followed by save) are **eventually consistent**, not
+  atomic across clients — see
+  [Deletion semantics (RR-5)](../reference/goal-board-api.md#deletion-semantics-rr-5).
 - `save_goal_board` rejects boards containing placeholder descriptions or
-  suspiciously short IDs **before** any write, preventing LLM
+  suspiciously short IDs **before** any merge or write, preventing LLM
   hallucinations during the Decide phase from silently overwriting the
   authoritative snapshot.
 - `load_goal_board` never panics or raises an error from a corrupt
@@ -257,6 +286,23 @@ Three important notes on the load step:
   boards).
 
 **Not guaranteed:**
+- **Strict linearizability of `save_goal_board`**: the merge-on-write fix
+  for issue #1915 prevents goal *disappearance* in the common race (two
+  writers on disjoint goal subsets), but a tight read-read-write-write
+  interleaving across separate `CognitiveMemoryOps` clients can still
+  produce a snapshot that omits the earlier writer's most recent fact
+  (the fact remains in the append-only log but is no longer
+  `max_by(node_id)`). Same-id concurrent edits resolve field-level
+  last-writer-wins. Callers that need strict serializability must route
+  through the daemon IPC socket.
+- **Unbounded backlog growth**: `merge_boards` does not cap
+  `board.backlog.len()`. Callers that accumulate stewardship items
+  without periodic pruning will grow the persisted snapshot fact
+  monotonically. The active set is bounded by `MAX_ACTIVE_GOALS = 5` and
+  is truncated deterministically on merge — see
+  [Active capacity truncation](../reference/goal-board-api.md#save_goal_board)
+  in the API reference for the bounded/unbounded contrast and the
+  deterministic sort key.
 - **Concurrent daemons**: if two Simard daemons share the same
   `SIMARD_STATE_ROOT`, the second one will fail to take the writer lock
   and exit. This is enforced by LadybugDB.

--- a/docs/reference/goal-board-api.md
+++ b/docs/reference/goal-board-api.md
@@ -1,7 +1,7 @@
 ---
 title: Goal board API reference
 description: Rust API reference for goal board persistence, mutation, and adapter functions in src/goal_curation/operations.rs.
-last_updated: 2026-05-08
+last_updated: 2026-05-19
 owner: simard
 doc_type: reference
 status: design — partially implemented
@@ -69,8 +69,15 @@ fresh snapshot.
    and the file is deleted. Failures here are logged and non-fatal — the
    file is left in place for the next startup to retry. Once migrated, this
    step costs only a single `metadata` syscall.
-2. **Read snapshot.** Calls `bridge.search_facts("goal-board:snapshot", 1, 0.0)`
-   and parses the most-recent matching fact's payload as `GoalBoard`.
+2. **Read snapshot.** Delegates to the private `read_latest_snapshot` helper
+   (see [below](#read_latest_snapshot-private-helper)). That helper calls
+   `bridge.search_facts("goal-board:snapshot", 64, 0.0)`, filters by
+   `concept == "goal-board:snapshot"`, picks `max_by(node_id)`, and parses
+   the payload as `GoalBoard`. The 64-fact window protects against ordering
+   surprises in `search_facts` and matches the read path now shared with
+   `save_goal_board`'s merge step. The previous `limit=1` call relied on
+   implicit recency ordering inside `search_facts`; the new path is robust
+   to that ordering changing.
 
 **Parameters**
 
@@ -121,29 +128,214 @@ pub fn save_goal_board(
 ) -> SimardResult<()>
 ```
 
-Persists the board to cognitive memory. Internally calls:
+Persists the board to cognitive memory **using merge-on-write semantics**.
+The function runs three steps in order: (1) integrity guard on the in-flight
+board, (2) read-latest-snapshot + merge against the freshly persisted state,
+(3) `store_fact` of the merged board. The merged payload is encoded as:
 
 ```rust
 bridge.store_fact(
     "goal-board:snapshot",   // concept
-    &serde_json::to_string(board)?,  // content
+    &serde_json::to_string(&merged)?,  // content (merged, not in-flight)
     1.0,                     // confidence
     &["goal-board".to_string()],  // tags
     "goal-curator",          // source_id
 )?;
 ```
 
+The `store_fact` call always emits **constant fact-level metadata**
+(`confidence = 1.0`, the single tag `"goal-board"`, and `source_id =
+"goal-curator"`). Fact metadata is **not** merged from the persisted
+snapshot or derived from the in-flight board — only the `GoalBoard`
+payload itself is merged. Implementers should not attempt three-way
+merging of fact attributes.
+
 There is no disk write — cognitive memory is the sole authoritative store.
 `persist_board` should be preferred for end-of-cycle saves: it calls
 `save_goal_board` and additionally records a durable episode for
 cross-session recall.
 
-**Integrity guard (runs before any write)**
+#### Merge-on-write semantics (issue [#1915](https://github.com/rysweet/Simard/issues/1915))
+
+Two `CognitiveMemoryOps` clients (the daemon's own bridge, the dashboard's
+writer bridge, a meeting REPL flow, …) can race on `save_goal_board`. Before
+issue #1915, each call wrote a fresh `goal-board:snapshot` fact derived from
+the caller's stale local copy, so the second writer's snapshot silently
+overwrote the first writer's goals — a production cycle observed goals
+disappearing between OODA cycles 5 and 6 during concurrent worktree/cargo
+build activity.
+
+`save_goal_board` now defends against that race by re-reading the latest
+persisted snapshot immediately before writing and merging the in-flight
+board into it:
+
+1. **Read latest persisted snapshot.** Delegates to the same private
+   `read_latest_snapshot` helper used by `load_goal_board`:
+   `bridge.search_facts("goal-board:snapshot", 64, 0.0)`, filtered by
+   `concept == "goal-board:snapshot"`, `max_by(node_id)`,
+   `serde_json::from_str` into a `GoalBoard`. Returns `Option<GoalBoard>`.
+2. **Merge** in-flight ⨁ persisted via the pure `merge_boards` helper
+   (see below).
+3. **Store** the merged board with the same `store_fact` parameters as
+   before.
+
+**Conflict-resolution rule.** Union `active` and `backlog` by `id`:
+
+| Case | Result |
+|------|--------|
+| `id` present only in persisted | Persisted goal/item kept verbatim |
+| `id` present only in in-flight | In-flight goal/item kept verbatim |
+| `id` present in both (collision) | **In-flight wins for all fields** (`status`, `priority`, `assigned_to`, `description`, `current_activity`, …) |
+
+The in-flight precedence rule reflects that the caller has the most recent
+intent for the goals it owns. It does *not* attempt field-level three-way
+merging — for callers operating on disjoint goal subsets (the common case
+in production), this preserves every goal; for the rare same-id concurrent
+edit, the second writer's view of that one goal wins (see "Best-effort
+guarantee" below).
+
+**Active capacity truncation.** If the merged active set exceeds
+`MAX_ACTIVE_GOALS` (= 5), it is truncated using a **deterministic sort key**
+applied before the cut:
+
+1. `priority` ascending (lower numeric value = higher importance, kept first).
+2. In-flight-origin preferred over persisted-origin on tie.
+3. `id` lexicographic on tie.
+
+The truncation is computed with a `BTreeMap` so iteration order does not
+depend on `HashMap` seeding. Backlog has no capacity bound and is never
+truncated.
+
+**Integrity guard order.** The guard runs on the **in-flight board only**,
+before the merge read. It does *not* run on the persisted snapshot or on
+the merged result. The persisted snapshot is inductively guard-clean (every
+prior write went through the same guard), and re-guarding the merged board
+would risk erroneously rejecting valid persisted goals that an LLM later
+contaminated locally.
+
+**Read-failure fallback.** If `bridge.search_facts` returns an error, or
+if the latest fact's payload fails to deserialize, the merge step is
+skipped and the in-flight board is persisted unchanged. A `warn!` line is
+emitted with the concept name, the bridge operation that failed, and the
+error kind — never the payload, never goal descriptions. This preserves
+write availability when the cognitive memory read path is temporarily
+unhealthy.
+
+**Successful-merge logging.** A `debug!` line records the merge with a
+fixed key=value field format suitable for `grep`/structured log ingestion:
+
+```text
+merge=goal-board persisted_active=N in_flight_active=M merged_active=K truncated=T
+```
+
+where `N`, `M`, `K` are non-negative counts and `T` is the number of goals
+dropped by the active-capacity truncation (`0` when the merged active set
+fits within `MAX_ACTIVE_GOALS`). No goal payloads, ids, or descriptions
+are ever logged.
+
+**Best-effort guarantee (RR-1, RR-4).** The merge guarantees that no goal
+*added* on a disjoint subset *disappears* in the common race (two writers
+each operating on its own snapshot, mutating disjoint goal ids). It does
+**not** provide linearizability: in a tight read-read-write-write
+interleaving where writer B's merge read completes before writer A's
+`store_fact`, A's goal can still be missing from B's merged snapshot when
+B writes — A's fact remains in the append-only log but is no longer
+`max_by(node_id)`. Field-level last-writer-wins also applies on same-id
+concurrent edits. Callers that need strict serializability must serialize
+through the daemon IPC socket (see
+[Cognitive memory bridge helpers](./cognitive-memory-bridge-helpers.md)).
+
+#### Deletion semantics (RR-5)
+
+Because the merge is a **union by `id`**
+with in-flight precedence on collisions, *explicit removal* of a goal from
+`board.active` or `board.backlog` followed by `save_goal_board` does **not**
+propagate the deletion to the persisted snapshot in a single save: the
+removed `id` is absent from the in-flight board, so the persisted copy
+survives the union and re-appears in the merged result. This is the
+expected (and necessary) trade-off for the additive correctness guarantee
+above — there is no way for a single writer to distinguish "I never knew
+about this id" from "I deliberately removed this id" without a tombstone
+protocol, which is out of scope for issue #1915.
+
+Practical consequences:
+
+- **Mutate-then-save deletion is eventually consistent, not atomic across
+  clients.** The deletion is applied on the next save by a client that
+  *also* sees the removed id as absent from its persisted snapshot — in
+  practice, after the daemon's authoritative `archive_completed` step
+  re-applies the removal on a snapshot it owns end-to-end.
+- **`archive_completed` interacts the same way.** A concurrent writer
+  holding a stale snapshot will *resurrect* an archived goal on its next
+  `save_goal_board`. The OODA daemon is the only writer that consistently
+  archives, and its archive only becomes durable once the next writer to
+  observe the post-archive snapshot performs a merge against it.
+- **Callers that need immediate, cross-client deletion must serialize
+  through the daemon IPC socket** so all writes are funnelled through a
+  single in-process bridge with no concurrent observers.
+
+This caveat applies symmetrically to `active` and `backlog`. It does
+**not** affect mutation of fields on an existing goal (status, priority,
+description, assignment) — those are governed by the field-level
+last-writer-wins rule above.
+
+#### `merge_boards` (private helper, testable in isolation)
+
+```rust
+fn merge_boards(persisted: GoalBoard, in_flight: GoalBoard) -> GoalBoard
+```
+
+Pure function. Total: never panics, never `unwrap`s, never `expect`s. Total
+cost `O(n + m)` where `n = persisted.active.len() + persisted.backlog.len()`
+and likewise for `m`. Uses `BTreeMap` internally for deterministic iteration.
+Tolerates `persisted.active.len() > MAX_ACTIVE_GOALS` on input (does not
+assert) and enforces the bound only on output.
+
+**Cross-set id collision.** When the same `id` appears in `persisted.active`
+and `in_flight.backlog` (the legitimate "demoted from active" case), or
+symmetrically `persisted.backlog` and `in_flight.active`, the **in-flight
+classification wins**: the goal/item appears exactly once in the merged
+board, in whichever set (`active` or `backlog`) the in-flight board placed
+it. The persisted classification is not retained alongside. This is a
+direct consequence of "in-flight wins on collision" applied across sets.
+
+Identity properties exercised by unit tests:
+
+- `merge_boards(empty, b) == b` (left identity)
+- `merge_boards(b, empty) == b` (right identity)
+- `merge_boards(b, b) == b` (self-merge identity)
+- Output is deterministic across repeated runs with identical inputs.
+
+The 9 enumerated unit tests for `merge_boards` cover:
+
+(a) left identity, (b) right identity, (c) self-merge identity,
+(d) disjoint active sets union without loss, (e) disjoint backlog sets
+union without loss, (f) same-id collision in `active` — in-flight wins on
+all fields, (g) same-id collision in `backlog` — in-flight wins, (h)
+truncation to `MAX_ACTIVE_GOALS` applies the deterministic sort key
+(priority asc, in-flight-preferred, id lex), and (i) cross-set id collision
+(id in `persisted.active` ∩ `in_flight.backlog` and vice-versa) — in-flight
+classification wins, goal appears exactly once in the in-flight set.
+
+#### `read_latest_snapshot` (private helper)
+
+```rust
+fn read_latest_snapshot(bridge: &dyn CognitiveMemoryOps) -> Option<GoalBoard>
+```
+
+Extracted from `load_goal_board`'s body and now shared with
+`save_goal_board`. Returns `None` on `search_facts` error, on zero results,
+or on `serde_json::from_str` failure (all logged at `warn!` level with no
+payload). `load_goal_board`'s behaviour is unchanged — it still falls
+through to `Ok(GoalBoard::new())` on `None`.
+
+**Integrity guard (runs before merge and store)**
 
 `save_goal_board` calls `board_integrity_suspect(board)` first. If that
 returns `Some(reason)`, the function returns
 `Err(SimardError::InvalidGoalRecord)` **without** invoking
-`bridge.store_fact`. This blocks two classes of corruption:
+`read_latest_snapshot` or `bridge.store_fact`. This blocks two classes of
+corruption:
 
 - Active goals whose `id` is shorter than 5 characters (catches `g1`,
   `g12`, …).
@@ -158,24 +350,61 @@ snapshot remains the authoritative state.
 
 | Outcome | Behaviour |
 |---------|-----------|
-| `board_integrity_suspect` returns `Some(_)` | `Err(SimardError::InvalidGoalRecord { field: "board", reason: format!("refusing to persist suspect board: {reason}") })` — `store_fact` is not called |
-| `serde_json::to_string(board)` fails | `Err(SimardError::InvalidGoalRecord { field: "board", reason: format!("failed to serialize goal board: {e}") })` |
+| `board_integrity_suspect` returns `Some(_)` | `Err(SimardError::InvalidGoalRecord { field: "board", reason: format!("refusing to persist suspect board: {reason}") })` — merge read and `store_fact` are not called |
+| `read_latest_snapshot` returns `None` (read error / parse error / no prior fact) | Merge skipped; **in-flight board is persisted as-written**. `warn!` logged. **Not** an `Err` to the caller |
+| `serde_json::to_string(&merged)` fails | `Err(SimardError::InvalidGoalRecord { field: "board", reason: format!("failed to serialize goal board: {e}") })` |
 | `bridge.store_fact` fails | The underlying `SimardError` is propagated via `?` |
 
 The error is fatal for the caller: the in-memory mutation is not retained
 anywhere else.
 
-**Example — dashboard write handler**
+**Example — dashboard write handler** (no caller change required)
 
 ```rust
-use simard::goal_curation::{load_goal_board, save_goal_board};
+use simard::goal_curation::{load_goal_board, save_goal_board, update_goal_progress};
+use simard::goals::GoalProgress;
 use simard::memory_ipc::launch_writer_bridge;
 
 let bridge = launch_writer_bridge(&state_root)?;     // WriterBridge or Err
 let mut board = load_goal_board(bridge.ops())?;
-board.active.retain(|g| g.id != deleted_id);
+update_goal_progress(&mut board, &goal_id, GoalProgress::InProgress { percent: 75 })?;
+// save_goal_board now re-reads the latest snapshot and merges before storing,
+// so a concurrent daemon write that added a new goal will not be clobbered.
+// Same-id mutations (this 75% update) win against the persisted snapshot.
 save_goal_board(&board, bridge.ops())?;
 ```
+
+> ⚠ **Deletion via mutate-then-save is not propagated in a single call.**
+> Removing a goal locally with `board.active.retain(|g| g.id != id)` and
+> then calling `save_goal_board` will **not** delete the goal from the
+> persisted snapshot — the union-by-id merge re-introduces the persisted
+> copy. See [Deletion semantics (RR-5)](#deletion-semantics-rr-5) above.
+> Use `archive_completed` from the daemon's authoritative cycle for
+> archival, or route the delete through the daemon IPC socket if cross-
+> client immediacy is required.
+
+**Example — concurrent OODA cycle and dashboard (post-fix)**
+
+```text
+T0  daemon: load_goal_board → {g-abc (in-progress 40%)}
+T1  dashboard: load_goal_board → {g-abc (in-progress 40%)}
+T2  daemon: mutates → {g-abc (in-progress 60%), g-def (not-started)}
+T3  dashboard: adds backlog → {g-abc (in-progress 40%), backlog: [bk-xyz]}
+T4  daemon: save_goal_board
+       merge read: (no prior writer since load)
+       store: {g-abc (60%), g-def}
+T5  dashboard: save_goal_board
+       merge read: {g-abc (60%), g-def}
+       merge:      active   = union by id, in-flight wins
+                            = {g-abc (40%, in-flight wins), g-def (persisted kept)}
+                   backlog  = {bk-xyz (in-flight)}
+       store: {g-abc (40%), g-def, backlog: [bk-xyz]}
+```
+
+Pre-fix, T5 would have silently dropped `g-def`. Post-fix, no goal
+disappears. The same-id collision on `g-abc` resolves to the dashboard's
+40% (in-flight wins); this is the documented best-effort field-level
+behaviour (RR-4).
 
 ---
 

--- a/src/goal_curation/operations.rs
+++ b/src/goal_curation/operations.rs
@@ -1,11 +1,29 @@
 //! Board mutation, validation, persistence, and seeding operations.
 
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::{LazyLock, Mutex};
+
 use serde_json::json;
+use tracing::{debug, warn};
 
 use crate::cognitive_memory::CognitiveMemoryOps;
 use crate::error::{SimardError, SimardResult};
 
 use super::types::{ActiveGoal, BacklogItem, GoalBoard, GoalProgress, MAX_ACTIVE_GOALS};
+
+/// Process-local critical section for the merge-on-write pipeline in
+/// [`save_goal_board`]. Serializes the read-merge-write window inside a
+/// single Simard process so two concurrent in-process bridge clients
+/// (daemon + dashboard, two engineer worktrees in one cargo build, …)
+/// cannot both observe the same persisted snapshot and then each store a
+/// stale-derived snapshot that drops the other writer's goals (issue
+/// [#1915](https://github.com/rysweet/Simard/issues/1915)).
+///
+/// Cross-process races still fall back to the best-effort field-level
+/// guarantees documented on `save_goal_board` (the LadybugDB flock at the
+/// storage layer prevents simultaneous writes, but does not provide
+/// snapshot isolation across separate read-then-write sequences).
+static SAVE_GOAL_BOARD_MUTEX: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
 // ---------------------------------------------------------------------------
 // Validation helpers
@@ -183,61 +201,241 @@ fn migrate_legacy_disk_file_if_present(bridge: &dyn CognitiveMemoryOps) {
 /// `Err` from migration.
 ///
 /// Resolution order after migration:
-/// 1. `bridge.search_facts("goal-board:snapshot", 1, 0.0)` → parsed board
-/// 2. `GoalBoard::new()` — empty board when no snapshot exists or parsing fails
+/// 1. [`read_latest_snapshot`] — `bridge.search_facts("goal-board:snapshot", 64, 0.0)`
+///    filtered by `concept == "goal-board:snapshot"`, `max_by(node_id)`, parsed.
+/// 2. `GoalBoard::new()` — empty board when no snapshot exists or parsing fails.
 pub fn load_goal_board(bridge: &dyn CognitiveMemoryOps) -> SimardResult<GoalBoard> {
     migrate_legacy_disk_file_if_present(bridge);
 
-    // Primary read path: cognitive memory snapshot. Bridge errors are
-    // non-fatal — log and fall through to the empty board.
-    //
-    // NOTE: store_fact is append-only at the trait level (no UPSERT or
-    // DELETE), so multiple `save_goal_board` calls accumulate facts. We
-    // ask for several and pick the lexicographically-largest id — fact
-    // ids are uuid-v7 (`new_id()` in cognitive_memory/mod.rs:276) which
-    // are time-ordered, so the largest id is the most recent snapshot.
+    // Primary read path: cognitive memory snapshot via the shared helper.
+    // The helper returns `None` on bridge error, on zero results, or on a
+    // payload parse failure — load_goal_board folds all three into the
+    // legacy "empty board" fallback so callers see a stable contract.
+    Ok(read_latest_snapshot(bridge).unwrap_or_default())
+}
+
+/// Read the most recent `goal-board:snapshot` fact from cognitive memory,
+/// or `None` if no snapshot is available.
+///
+/// Shared by [`load_goal_board`] (initial read) and [`save_goal_board`]
+/// (merge-on-write read). All failure modes (bridge error, empty result,
+/// payload deserialization failure) return `None` with a `warn!` log line
+/// that records the bridge operation and error kind only — never the
+/// payload, never goal descriptions.
+///
+/// `search_facts` is called with `limit=64, min_confidence=0.0` so that
+/// the merge read can see recent snapshots even when the fact log has
+/// accumulated. Fact ids are uuid-v7 (see `new_id()` in
+/// `cognitive_memory/mod.rs`), so the lexicographically-largest id is the
+/// most recent snapshot.
+pub(super) fn read_latest_snapshot(bridge: &dyn CognitiveMemoryOps) -> Option<GoalBoard> {
     let facts = match bridge.search_facts("goal-board:snapshot", 64, 0.0) {
         Ok(f) => f,
         Err(e) => {
-            eprintln!(
-                "[simard] load_goal_board: cognitive memory search_facts failed ({e}) — returning empty board"
+            warn!(
+                concept = "goal-board:snapshot",
+                op = "search_facts",
+                error_kind = %e,
+                "read_latest_snapshot: cognitive memory read failed; returning None"
             );
-            vec![]
+            return None;
         }
     };
     let latest = facts
         .iter()
         .filter(|f| f.concept == "goal-board:snapshot")
-        .max_by(|a, b| a.node_id.cmp(&b.node_id));
-    if let Some(fact) = latest {
-        match serde_json::from_str::<GoalBoard>(&fact.content) {
-            Ok(board) => return Ok(board),
-            Err(e) => {
-                eprintln!(
-                    "[simard] load_goal_board: cognitive memory snapshot parse error ({e}) — returning empty board"
-                );
-            }
+        .max_by(|a, b| a.node_id.cmp(&b.node_id))?;
+    match serde_json::from_str::<GoalBoard>(&latest.content) {
+        Ok(board) => Some(board),
+        Err(e) => {
+            warn!(
+                concept = "goal-board:snapshot",
+                op = "deserialize",
+                error_kind = %e,
+                "read_latest_snapshot: snapshot payload parse failed; returning None"
+            );
+            None
         }
     }
+}
 
-    Ok(GoalBoard::new())
+/// Merge a persisted snapshot with an in-flight board to produce a new
+/// merged board suitable for `store_fact`.
+///
+/// **Union by `id`.** Both `active` and `backlog` are unioned by `id`.
+/// On id collision the in-flight side wins for all fields (description,
+/// priority, status, assigned_to, current_activity, wip_refs). This
+/// reflects that the caller has the most recent intent for the goals it
+/// owns. Cross-set collisions (same id in `persisted.active` and
+/// `in_flight.backlog`, or vice versa) resolve to the in-flight
+/// classification — the goal/item appears exactly once in the merged
+/// board, in whichever set the in-flight board placed it.
+///
+/// **Active capacity.** If the merged active set exceeds
+/// [`MAX_ACTIVE_GOALS`] (= 5), it is truncated using a deterministic sort
+/// key:
+///
+/// 1. `priority` ascending (lower numeric value = higher importance, kept first)
+/// 2. In-flight-origin preferred over persisted-origin on tie
+/// 3. `id` lexicographic ascending on tie
+///
+/// **Backlog capacity.** Backlog has no bound and is never truncated.
+///
+/// Pure function: never panics, never `unwrap`s, never `expect`s.
+/// Iteration order is deterministic via `BTreeMap`/`BTreeSet`, so repeated
+/// merges of identical inputs produce identical outputs.
+///
+/// See issue [#1915](https://github.com/rysweet/Simard/issues/1915) for
+/// the race this prevents.
+pub(super) fn merge_boards(persisted: GoalBoard, in_flight: GoalBoard) -> GoalBoard {
+    // Collect all in-flight ids (both active and backlog) so that
+    // cross-set collisions resolve to the in-flight classification.
+    let in_flight_ids: BTreeSet<String> = in_flight
+        .active
+        .iter()
+        .map(|g| g.id.clone())
+        .chain(in_flight.backlog.iter().map(|b| b.id.clone()))
+        .collect();
+
+    // Active union. `BTreeMap` keyed on id gives deterministic iteration.
+    // For each entry we also track whether the goal originated from the
+    // in-flight board (true) or the persisted board (false) — used by the
+    // capacity-truncation tiebreak.
+    let mut active_map: BTreeMap<String, (ActiveGoal, bool)> = BTreeMap::new();
+    for goal in persisted.active {
+        // Skip persisted entries shadowed by an in-flight entry in *either*
+        // set; in-flight classification wins on cross-set collisions.
+        if in_flight_ids.contains(&goal.id) {
+            continue;
+        }
+        active_map.insert(goal.id.clone(), (goal, false));
+    }
+    for goal in in_flight.active {
+        active_map.insert(goal.id.clone(), (goal, true));
+    }
+
+    // Backlog union with the same rules.
+    let mut backlog_map: BTreeMap<String, BacklogItem> = BTreeMap::new();
+    for item in persisted.backlog {
+        if in_flight_ids.contains(&item.id) {
+            continue;
+        }
+        backlog_map.insert(item.id.clone(), item);
+    }
+    for item in in_flight.backlog {
+        backlog_map.insert(item.id.clone(), item);
+    }
+
+    let mut active_with_origin: Vec<(ActiveGoal, bool)> = active_map.into_values().collect();
+    let mut truncated_count = 0usize;
+    if active_with_origin.len() > MAX_ACTIVE_GOALS {
+        // Deterministic sort key: priority asc, in-flight (true) before
+        // persisted (false), id lex asc. We invert the bool comparison
+        // because `true > false` in Rust's default Ord — we want `true`
+        // (in-flight) to come first in ascending order, hence reverse.
+        active_with_origin.sort_by(|a, b| {
+            a.0.priority
+                .cmp(&b.0.priority)
+                .then_with(|| b.1.cmp(&a.1))
+                .then_with(|| a.0.id.cmp(&b.0.id))
+        });
+        truncated_count = active_with_origin.len() - MAX_ACTIVE_GOALS;
+        active_with_origin.truncate(MAX_ACTIVE_GOALS);
+    }
+
+    let active: Vec<ActiveGoal> = active_with_origin.into_iter().map(|(g, _)| g).collect();
+    let backlog: Vec<BacklogItem> = backlog_map.into_values().collect();
+
+    debug!(
+        merge = "goal-board",
+        merged_active = active.len(),
+        merged_backlog = backlog.len(),
+        truncated = truncated_count,
+        "merge_boards: completed"
+    );
+
+    GoalBoard { active, backlog }
 }
 
 /// Save the current board state to cognitive memory as the single source of
-/// truth.
+/// truth, using **merge-on-write** semantics to prevent concurrent
+/// `CognitiveMemoryOps` clients from silently clobbering each other's
+/// goals (issue [#1915](https://github.com/rysweet/Simard/issues/1915)).
 ///
-/// Rejects suspect boards (placeholder descriptions, suspiciously short
-/// ids) with `SimardError::InvalidGoalRecord` before any persistence
-/// attempt — `bridge.store_fact` is not called when the integrity guard
-/// fires.
+/// Pipeline:
+/// 1. Run [`board_integrity_suspect`] on the in-flight board. Returning
+///    `Some(_)` short-circuits with `SimardError::InvalidGoalRecord`
+///    before any read or write — the persisted snapshot is inductively
+///    guard-clean (every prior write went through this same guard).
+/// 2. Call [`read_latest_snapshot`] to re-read the latest persisted
+///    `goal-board:snapshot` fact. On error / empty / parse failure
+///    (already logged inside the helper), the merge step is skipped and
+///    the in-flight board is persisted unchanged — preserving write
+///    availability when the read path is temporarily unhealthy.
+/// 3. Call [`merge_boards`] to union by `id` (in-flight wins on collision)
+///    and truncate the active set to [`MAX_ACTIVE_GOALS`] using the
+///    deterministic sort key documented on `merge_boards`.
+/// 4. `bridge.store_fact("goal-board:snapshot", &serde_json::to_string(&merged)?, 1.0, &["goal-board"], "goal-curator")`.
+///    Fact metadata is constant — only the `GoalBoard` payload is merged.
+///
+/// **Best-effort guarantee.** No goal *added* on a disjoint subset
+/// *disappears* in the common multi-client race. A tight
+/// read-read-write-write interleaving across separate
+/// `CognitiveMemoryOps` clients can still produce a snapshot that omits
+/// the earlier writer's most recent fact; same-id concurrent edits
+/// resolve field-level last-writer-wins. Callers needing strict
+/// serializability must route through the daemon IPC socket.
 pub fn save_goal_board(board: &GoalBoard, bridge: &dyn CognitiveMemoryOps) -> SimardResult<()> {
+    // Step 1: guard the in-flight board. Persisted snapshot is inductively
+    // guard-clean (every prior write went through this same check), so the
+    // merged board does not need re-guarding — re-guarding would risk
+    // erroneously rejecting valid persisted goals that an LLM later
+    // contaminated locally on the in-flight side.
     if let Some(reason) = board_integrity_suspect(board) {
         return Err(SimardError::InvalidGoalRecord {
             field: "board".to_string(),
             reason: format!("refusing to persist suspect board: {reason}"),
         });
     }
-    let snapshot = serde_json::to_string(board).map_err(|e| SimardError::InvalidGoalRecord {
+
+    // Acquire the process-local merge-on-write critical section so two
+    // in-process callers serialize their read-merge-write windows. Without
+    // this, two threads can both read an empty (or stale) snapshot, each
+    // merge it with their own in-flight board, and each store a snapshot
+    // that lacks the other writer's goals — the original #1915 failure.
+    // Mutex poisoning is treated as recoverable: we take the inner guard
+    // and proceed, because a poisoned mutex still serialises us correctly.
+    let _critical = SAVE_GOAL_BOARD_MUTEX
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    // Step 2: read latest persisted snapshot (None on any failure).
+    let persisted = read_latest_snapshot(bridge);
+
+    // Step 3: merge in-flight on top of persisted. On read failure /
+    // empty store, persist the in-flight board unchanged.
+    let (merged, persisted_active, persisted_backlog) = match persisted {
+        Some(p) => {
+            let pa = p.active.len();
+            let pb = p.backlog.len();
+            (merge_boards(p, board.clone()), pa, pb)
+        }
+        None => (board.clone(), 0, 0),
+    };
+
+    debug!(
+        merge = "goal-board",
+        persisted_active = persisted_active,
+        persisted_backlog = persisted_backlog,
+        in_flight_active = board.active.len(),
+        in_flight_backlog = board.backlog.len(),
+        merged_active = merged.active.len(),
+        merged_backlog = merged.backlog.len(),
+        "save_goal_board: persisting merged snapshot"
+    );
+
+    // Step 4: serialize and store.
+    let snapshot = serde_json::to_string(&merged).map_err(|e| SimardError::InvalidGoalRecord {
         field: "board".to_string(),
         reason: format!("failed to serialize goal board: {e}"),
     })?;

--- a/src/goal_curation/tests_operations.rs
+++ b/src/goal_curation/tests_operations.rs
@@ -657,3 +657,865 @@ fn clear_goal_assignment_returns_err_for_missing_goal() {
     let err = super::clear_goal_assignment(&mut board, "nonexistent").unwrap_err();
     assert!(err.to_string().contains("not found"), "{err}");
 }
+
+// ═════════════════════════════════════════════════════════════════════════
+// Issue #1915 — merge-on-write semantics for save_goal_board
+// ═════════════════════════════════════════════════════════════════════════
+//
+// These tests specify the merge-on-write contract introduced to prevent
+// concurrent CognitiveMemoryOps clients from silently clobbering each
+// other's goals (root cause of #1915). They reference three new symbols:
+//
+//   - `merge_boards(persisted, in_flight) -> GoalBoard`     (pure helper)
+//   - `read_latest_snapshot(bridge) -> Option<GoalBoard>`   (read helper)
+//   - revised `save_goal_board(...)` that performs
+//        guard(in_flight) -> read_latest_snapshot -> merge -> store_fact
+//
+// All tests in this section MUST fail against the pre-fix code and pass
+// after the fix is applied.
+
+use super::operations::{merge_boards, read_latest_snapshot};
+
+// ── shared test helpers ─────────────────────────────────────────────────
+
+/// Build an `ActiveGoal` with id/priority/status/description set.
+/// All other fields default to `None` / `vec![]`.
+fn goal_with(id: &str, priority: u32, status: GoalProgress, desc: &str) -> ActiveGoal {
+    ActiveGoal {
+        id: id.to_string(),
+        description: desc.to_string(),
+        priority,
+        status,
+        assigned_to: None,
+        current_activity: None,
+        wip_refs: vec![],
+    }
+}
+
+/// Build a `BacklogItem` with id/description/source/score set.
+fn backlog_with(id: &str, description: &str, source: &str, score: f64) -> BacklogItem {
+    BacklogItem {
+        id: id.to_string(),
+        description: description.to_string(),
+        source: source.to_string(),
+        score,
+    }
+}
+
+/// Stateful in-memory bridge that simulates the LadybugDB append-only fact
+/// store. Every `store_fact` appends to a shared `Vec<CognitiveFact>` with a
+/// monotonically-increasing `node_id` (so `max_by(node_id)` always picks
+/// the most recent snapshot — matching production uuid-v7 semantics).
+/// Every `search_facts` returns the current shared vec.
+///
+/// Returns the bridge and a handle to the shared facts vec so tests can
+/// assert on stored counts/content.
+#[allow(clippy::type_complexity)]
+fn stateful_bridge() -> (
+    crate::memory_bridge::CognitiveMemoryBridge,
+    std::sync::Arc<std::sync::Mutex<Vec<crate::memory_cognitive::CognitiveFact>>>,
+) {
+    use crate::bridge_subprocess::InMemoryBridgeTransport;
+    use crate::memory_bridge::CognitiveMemoryBridge;
+    use crate::memory_cognitive::CognitiveFact;
+    use serde_json::json;
+
+    let facts: std::sync::Arc<std::sync::Mutex<Vec<CognitiveFact>>> =
+        std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let counter = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let facts_for_handler = facts.clone();
+    let counter_for_handler = counter.clone();
+
+    let transport = InMemoryBridgeTransport::new("test-stateful", move |method, params| {
+        match method {
+            "memory.search_facts" => {
+                let snapshot = facts_for_handler.lock().unwrap().clone();
+                let serialized = serde_json::to_value(&snapshot).unwrap();
+                Ok(json!({ "facts": serialized }))
+            }
+            "memory.store_fact" => {
+                let concept = params
+                    .get("concept")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default()
+                    .to_string();
+                let content = params
+                    .get("content")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default()
+                    .to_string();
+                let confidence = params
+                    .get("confidence")
+                    .and_then(|v| v.as_f64())
+                    .unwrap_or(1.0);
+                let source_id = params
+                    .get("source_id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default()
+                    .to_string();
+                let tags: Vec<String> = params
+                    .get("tags")
+                    .and_then(|v| v.as_array())
+                    .map(|a| {
+                        a.iter()
+                            .filter_map(|x| x.as_str().map(|s| s.to_string()))
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                let n = counter_for_handler.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                // Zero-padded so lexicographic max == numeric max.
+                let node_id = format!("fact-{n:020}");
+                facts_for_handler.lock().unwrap().push(CognitiveFact {
+                    node_id: node_id.clone(),
+                    concept,
+                    content,
+                    confidence,
+                    source_id,
+                    tags,
+                });
+                Ok(json!({ "id": node_id }))
+            }
+            "memory.store_episode" => Ok(json!({ "id": "epi_x" })),
+            _ => Err(crate::bridge::BridgeErrorPayload {
+                code: -32601,
+                message: format!("unknown method: {method}"),
+            }),
+        }
+    });
+    (CognitiveMemoryBridge::new(Box::new(transport)), facts)
+}
+
+/// Bridge whose `memory.search_facts` always errors but whose
+/// `memory.store_fact` succeeds and is recorded. Used to verify the
+/// read-failure fallback path in `save_goal_board`.
+fn bridge_search_fails_store_works(
+    recording: std::sync::Arc<BridgeRecording>,
+) -> crate::memory_bridge::CognitiveMemoryBridge {
+    use crate::bridge_subprocess::InMemoryBridgeTransport;
+    use crate::memory_bridge::CognitiveMemoryBridge;
+    use serde_json::json;
+    let recording_for_handler = recording;
+    let transport =
+        InMemoryBridgeTransport::new("test-search-fails-store-works", move |method, params| {
+            match method {
+                "memory.search_facts" => Err(crate::bridge::BridgeErrorPayload {
+                    code: -32000,
+                    message: "simulated search_facts failure".to_string(),
+                }),
+                "memory.store_fact" => {
+                    let concept = params
+                        .get("concept")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or_default()
+                        .to_string();
+                    let content = params
+                        .get("content")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or_default()
+                        .to_string();
+                    recording_for_handler
+                        .stored_facts
+                        .lock()
+                        .unwrap()
+                        .push(StoredFactCall { concept, content });
+                    Ok(json!({ "id": "sem_x" }))
+                }
+                "memory.store_episode" => Ok(json!({ "id": "epi_x" })),
+                _ => Err(crate::bridge::BridgeErrorPayload {
+                    code: -32601,
+                    message: format!("unknown method: {method}"),
+                }),
+            }
+        });
+    CognitiveMemoryBridge::new(Box::new(transport))
+}
+
+// ── merge_boards: pure helper unit tests (9 cases per design spec) ──────
+
+/// (a) Disjoint active ids → union of both.
+#[test]
+fn merge_boards_disjoint_active_ids_unions_both() {
+    let persisted = GoalBoard {
+        active: vec![goal_with(
+            "alpha-goal-aaaa",
+            1,
+            GoalProgress::NotStarted,
+            "Alpha",
+        )],
+        backlog: vec![],
+    };
+    let in_flight = GoalBoard {
+        active: vec![goal_with(
+            "beta-goal-bbbb",
+            2,
+            GoalProgress::NotStarted,
+            "Beta",
+        )],
+        backlog: vec![],
+    };
+    let merged = merge_boards(persisted, in_flight);
+    assert_eq!(merged.active.len(), 2);
+    let ids: Vec<&str> = merged.active.iter().map(|g| g.id.as_str()).collect();
+    assert!(ids.contains(&"alpha-goal-aaaa"));
+    assert!(ids.contains(&"beta-goal-bbbb"));
+}
+
+/// (b) Active collision on id → in-flight wins for ALL fields
+/// (description, priority, status, assigned_to, current_activity).
+#[test]
+fn merge_boards_active_collision_in_flight_wins_all_fields() {
+    let persisted = GoalBoard {
+        active: vec![goal_with(
+            "shared-id-xxxx",
+            5,
+            GoalProgress::NotStarted,
+            "Persisted desc",
+        )],
+        backlog: vec![],
+    };
+    let mut in_flight_goal = goal_with(
+        "shared-id-xxxx",
+        1,
+        GoalProgress::InProgress { percent: 75 },
+        "In-flight desc",
+    );
+    in_flight_goal.assigned_to = Some("engineer-1".to_string());
+    in_flight_goal.current_activity = Some("compiling".to_string());
+    let in_flight = GoalBoard {
+        active: vec![in_flight_goal],
+        backlog: vec![],
+    };
+    let merged = merge_boards(persisted, in_flight);
+    assert_eq!(merged.active.len(), 1);
+    let g = &merged.active[0];
+    assert_eq!(
+        g.description, "In-flight desc",
+        "description must come from in-flight"
+    );
+    assert_eq!(g.priority, 1, "priority must come from in-flight");
+    assert!(
+        matches!(g.status, GoalProgress::InProgress { percent: 75 }),
+        "status must come from in-flight, got {:?}",
+        g.status
+    );
+    assert_eq!(g.assigned_to.as_deref(), Some("engineer-1"));
+    assert_eq!(g.current_activity.as_deref(), Some("compiling"));
+}
+
+/// (c) Backlog union by id with in-flight precedence on collision.
+#[test]
+fn merge_boards_backlog_unions_by_id_with_in_flight_precedence() {
+    let persisted = GoalBoard {
+        active: vec![],
+        backlog: vec![
+            backlog_with("b-only-persisted", "Only persisted", "p", 0.1),
+            backlog_with("b-shared", "Old persisted desc", "p", 0.2),
+        ],
+    };
+    let in_flight = GoalBoard {
+        active: vec![],
+        backlog: vec![
+            backlog_with("b-only-flight", "Only flight", "f", 0.5),
+            backlog_with("b-shared", "Newer flight desc", "f", 0.9),
+        ],
+    };
+    let merged = merge_boards(persisted, in_flight);
+    assert_eq!(
+        merged.backlog.len(),
+        3,
+        "union: only-persisted + only-flight + shared = 3"
+    );
+    let shared = merged
+        .backlog
+        .iter()
+        .find(|b| b.id == "b-shared")
+        .expect("shared backlog id must be present");
+    assert_eq!(shared.description, "Newer flight desc");
+    assert_eq!(shared.source, "f");
+    assert!((shared.score - 0.9).abs() < f64::EPSILON);
+}
+
+/// (d) Active overflow (>MAX_ACTIVE_GOALS) → truncate by priority ASC
+/// (lowest priority number = highest importance kept).
+#[test]
+fn merge_boards_active_overflow_truncates_to_max_keeping_lowest_priority() {
+    // Persisted has 3 goals with priorities 4, 5, 6.
+    // In-flight has 3 goals with priorities 1, 2, 3.
+    // Union = 6 distinct ids; MAX_ACTIVE_GOALS=5 → drop priority 6.
+    let persisted = GoalBoard {
+        active: vec![
+            goal_with("p-aaaaa", 4, GoalProgress::NotStarted, "p-a"),
+            goal_with("p-bbbbb", 5, GoalProgress::NotStarted, "p-b"),
+            goal_with("p-ccccc", 6, GoalProgress::NotStarted, "p-c"),
+        ],
+        backlog: vec![],
+    };
+    let in_flight = GoalBoard {
+        active: vec![
+            goal_with("f-aaaaa", 1, GoalProgress::NotStarted, "f-a"),
+            goal_with("f-bbbbb", 2, GoalProgress::NotStarted, "f-b"),
+            goal_with("f-ccccc", 3, GoalProgress::NotStarted, "f-c"),
+        ],
+        backlog: vec![],
+    };
+    let merged = merge_boards(persisted, in_flight);
+    assert_eq!(merged.active.len(), MAX_ACTIVE_GOALS);
+    let priorities: Vec<u32> = merged.active.iter().map(|g| g.priority).collect();
+    assert!(
+        !priorities.contains(&6),
+        "priority 6 goal must be truncated, got {priorities:?}"
+    );
+    for p in [1u32, 2, 3, 4, 5] {
+        assert!(
+            priorities.contains(&p),
+            "priority {p} must be kept, got {priorities:?}"
+        );
+    }
+}
+
+/// (e) Active overflow tiebreak on equal priority → in-flight is preferred,
+/// so a persisted goal must be the one dropped, never the in-flight one.
+#[test]
+fn merge_boards_overflow_tiebreak_prefers_in_flight() {
+    let persisted = GoalBoard {
+        active: (0..5)
+            .map(|i| {
+                goal_with(
+                    &format!("persisted-{i:02}-id"),
+                    3,
+                    GoalProgress::NotStarted,
+                    "p",
+                )
+            })
+            .collect(),
+        backlog: vec![],
+    };
+    let in_flight = GoalBoard {
+        active: vec![goal_with(
+            "flight-only-id",
+            3,
+            GoalProgress::NotStarted,
+            "f",
+        )],
+        backlog: vec![],
+    };
+    let merged = merge_boards(persisted, in_flight);
+    assert_eq!(merged.active.len(), MAX_ACTIVE_GOALS);
+    let ids: Vec<String> = merged.active.iter().map(|g| g.id.clone()).collect();
+    assert!(
+        ids.iter().any(|id| id == "flight-only-id"),
+        "in-flight goal must survive on tiebreak, got {ids:?}"
+    );
+}
+
+/// (f) Self-merge is identity at the field-set level (idempotent).
+#[test]
+fn merge_boards_self_merge_is_identity() {
+    let board = GoalBoard {
+        active: vec![
+            goal_with(
+                "self-aaaaa",
+                1,
+                GoalProgress::InProgress { percent: 10 },
+                "a",
+            ),
+            goal_with("self-bbbbb", 2, GoalProgress::NotStarted, "b"),
+        ],
+        backlog: vec![backlog_with("self-bk", "x", "s", 0.5)],
+    };
+    let merged = merge_boards(board.clone(), board.clone());
+    assert_eq!(merged.active.len(), board.active.len());
+    assert_eq!(merged.backlog.len(), board.backlog.len());
+    for g in &board.active {
+        assert!(
+            merged.active.iter().any(|m| m == g),
+            "active goal {} must be preserved",
+            g.id
+        );
+    }
+    for b in &board.backlog {
+        assert!(
+            merged.backlog.iter().any(|m| m == b),
+            "backlog item {} must be preserved",
+            b.id
+        );
+    }
+}
+
+/// (g) Empty persisted → returns in-flight content unchanged.
+#[test]
+fn merge_boards_empty_persisted_returns_in_flight_unchanged() {
+    let in_flight = GoalBoard {
+        active: vec![goal_with("only-flight", 1, GoalProgress::NotStarted, "f")],
+        backlog: vec![backlog_with("bk-flight", "x", "s", 0.1)],
+    };
+    let merged = merge_boards(GoalBoard::new(), in_flight.clone());
+    assert_eq!(merged.active.len(), 1);
+    assert_eq!(merged.active[0].id, "only-flight");
+    assert_eq!(merged.backlog.len(), 1);
+    assert_eq!(merged.backlog[0].id, "bk-flight");
+}
+
+/// (h) Empty in-flight → returns persisted content unchanged.
+#[test]
+fn merge_boards_empty_in_flight_returns_persisted_unchanged() {
+    let persisted = GoalBoard {
+        active: vec![goal_with(
+            "only-persisted",
+            1,
+            GoalProgress::NotStarted,
+            "p",
+        )],
+        backlog: vec![backlog_with("bk-persisted", "x", "s", 0.1)],
+    };
+    let merged = merge_boards(persisted.clone(), GoalBoard::new());
+    assert_eq!(merged.active.len(), 1);
+    assert_eq!(merged.active[0].id, "only-persisted");
+    assert_eq!(merged.backlog.len(), 1);
+    assert_eq!(merged.backlog[0].id, "bk-persisted");
+}
+
+/// (i) Cross-set collision (RR-5): id appears in persisted.active and
+/// in_flight.backlog → in-flight classification wins, so it ends up in
+/// backlog only.
+#[test]
+fn merge_boards_cross_set_collision_uses_in_flight_classification() {
+    let persisted = GoalBoard {
+        active: vec![goal_with(
+            "shared-cross-id",
+            1,
+            GoalProgress::InProgress { percent: 50 },
+            "from persisted active",
+        )],
+        backlog: vec![],
+    };
+    let in_flight = GoalBoard {
+        active: vec![],
+        backlog: vec![backlog_with(
+            "shared-cross-id",
+            "from in-flight backlog",
+            "f",
+            0.7,
+        )],
+    };
+    let merged = merge_boards(persisted, in_flight);
+    assert!(
+        merged.active.iter().all(|g| g.id != "shared-cross-id"),
+        "shared id must NOT appear in active after cross-set collision (got {:?})",
+        merged
+            .active
+            .iter()
+            .map(|g| g.id.as_str())
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        merged.backlog.iter().any(|b| b.id == "shared-cross-id"),
+        "shared id must appear in backlog (in-flight classification wins)"
+    );
+}
+
+/// Determinism: repeated merges of the same inputs produce equal outputs.
+#[test]
+fn merge_boards_is_deterministic_across_runs() {
+    let persisted = GoalBoard {
+        active: vec![
+            goal_with("zzz-goal-id", 2, GoalProgress::NotStarted, "z"),
+            goal_with("aaa-goal-id", 2, GoalProgress::NotStarted, "a"),
+        ],
+        backlog: vec![],
+    };
+    let in_flight = GoalBoard {
+        active: vec![goal_with("mmm-goal-id", 2, GoalProgress::NotStarted, "m")],
+        backlog: vec![],
+    };
+    let merged_1 = merge_boards(persisted.clone(), in_flight.clone());
+    let merged_2 = merge_boards(persisted.clone(), in_flight.clone());
+    let merged_3 = merge_boards(persisted, in_flight);
+    assert_eq!(merged_1, merged_2);
+    assert_eq!(merged_2, merged_3);
+}
+
+// ── read_latest_snapshot: extracted helper ──────────────────────────────
+
+/// `read_latest_snapshot` returns `None` when the bridge has no snapshot.
+#[test]
+fn read_latest_snapshot_returns_none_when_empty() {
+    let (bridge, _facts) = stateful_bridge();
+    let result = read_latest_snapshot(&bridge);
+    assert!(
+        result.is_none(),
+        "expected None for empty store, got {result:?}"
+    );
+}
+
+/// With multiple snapshot facts, `read_latest_snapshot` picks the one with
+/// the largest `node_id` (most recent uuid-v7 / monotonic id).
+#[test]
+fn read_latest_snapshot_picks_max_node_id_when_multiple_present() {
+    let (bridge, _facts) = stateful_bridge();
+    let root = tmp_state_root("read-latest-multi");
+
+    let first = GoalBoard {
+        active: vec![goal_with(
+            "first-saved-goal",
+            1,
+            GoalProgress::NotStarted,
+            "first",
+        )],
+        backlog: vec![],
+    };
+    let second = GoalBoard {
+        active: vec![
+            goal_with("first-saved-goal", 1, GoalProgress::NotStarted, "first"),
+            goal_with("second-saved-goal", 2, GoalProgress::NotStarted, "second"),
+        ],
+        backlog: vec![],
+    };
+    // Pre-fix save_goal_board appends two facts; post-fix it appends two
+    // (merge of empty + first, then merge of first + second). Either way
+    // there are ≥2 facts and the latest one must be returned.
+    with_state_root(&root, || {
+        super::save_goal_board(&first, &bridge).unwrap();
+        super::save_goal_board(&second, &bridge).unwrap();
+    });
+
+    let latest =
+        read_latest_snapshot(&bridge).expect("must return Some when at least one snapshot exists");
+    let ids: Vec<&str> = latest.active.iter().map(|g| g.id.as_str()).collect();
+    assert!(
+        ids.contains(&"second-saved-goal"),
+        "latest snapshot must contain the most recently saved goal, got {ids:?}"
+    );
+}
+
+/// `read_latest_snapshot` returns `None` (not Err / panic) when the bridge
+/// errors on search_facts. The caller (save_goal_board) uses this to fall
+/// back to writing the in-flight board unchanged.
+#[test]
+fn read_latest_snapshot_returns_none_on_bridge_search_error() {
+    let bridge = bridge_search_fails();
+    let result = read_latest_snapshot(&bridge);
+    assert!(
+        result.is_none(),
+        "search_facts error must surface as None, got {result:?}"
+    );
+}
+
+// ── save_goal_board: merge-on-write integration tests ───────────────────
+
+/// I1 — Sequential two writers with disjoint goal ids. After both saves,
+/// `load_goal_board` returns BOTH goals. This is the canonical #1915
+/// regression: pre-fix, the second save clobbered the first.
+#[test]
+fn save_goal_board_sequential_two_disjoint_writers_preserves_both() {
+    let (bridge, _facts) = stateful_bridge();
+    let root = tmp_state_root("save-seq-merge");
+
+    let writer_a_board = GoalBoard {
+        active: vec![goal_with(
+            "alpha-writer-aaaa",
+            1,
+            GoalProgress::NotStarted,
+            "Alpha goal",
+        )],
+        backlog: vec![],
+    };
+    let writer_b_board = GoalBoard {
+        active: vec![goal_with(
+            "beta-writer-bbbb",
+            2,
+            GoalProgress::NotStarted,
+            "Beta goal",
+        )],
+        backlog: vec![],
+    };
+
+    with_state_root(&root, || {
+        super::save_goal_board(&writer_a_board, &bridge).unwrap();
+        super::save_goal_board(&writer_b_board, &bridge).unwrap();
+        let loaded = super::load_goal_board(&bridge).unwrap();
+        let ids: Vec<&str> = loaded.active.iter().map(|g| g.id.as_str()).collect();
+        assert!(
+            ids.contains(&"alpha-writer-aaaa"),
+            "writer A's goal must survive writer B's save (issue #1915), got {ids:?}"
+        );
+        assert!(
+            ids.contains(&"beta-writer-bbbb"),
+            "writer B's goal must be present, got {ids:?}"
+        );
+        assert_eq!(loaded.active.len(), 2);
+    });
+}
+
+/// I2 — Sequential writes with same goal id → second write's fields win
+/// (in-flight precedence on collision, applied at save time).
+#[test]
+fn save_goal_board_collision_persists_in_flight_fields() {
+    let (bridge, _facts) = stateful_bridge();
+    let root = tmp_state_root("save-collision");
+
+    let first = GoalBoard {
+        active: vec![goal_with(
+            "collision-goal-idid",
+            5,
+            GoalProgress::NotStarted,
+            "First desc",
+        )],
+        backlog: vec![],
+    };
+    let mut updated_goal = goal_with(
+        "collision-goal-idid",
+        1,
+        GoalProgress::InProgress { percent: 80 },
+        "Updated desc",
+    );
+    updated_goal.assigned_to = Some("engineer-9".to_string());
+    let second = GoalBoard {
+        active: vec![updated_goal],
+        backlog: vec![],
+    };
+
+    with_state_root(&root, || {
+        super::save_goal_board(&first, &bridge).unwrap();
+        super::save_goal_board(&second, &bridge).unwrap();
+        let loaded = super::load_goal_board(&bridge).unwrap();
+        assert_eq!(loaded.active.len(), 1);
+        let g = &loaded.active[0];
+        assert_eq!(g.description, "Updated desc");
+        assert_eq!(g.priority, 1);
+        assert!(
+            matches!(g.status, GoalProgress::InProgress { percent: 80 }),
+            "expected InProgress(80%), got {:?}",
+            g.status
+        );
+        assert_eq!(g.assigned_to.as_deref(), Some("engineer-9"));
+    });
+}
+
+/// I7 — Read-failure fallback: when `search_facts` errors, save_goal_board
+/// must NOT panic and must NOT propagate the read error — it persists the
+/// in-flight board unchanged (best-effort fail-open on read, per SR-6.1).
+#[test]
+fn save_goal_board_read_failure_falls_back_to_persisting_in_flight() {
+    let recording = BridgeRecording::shared();
+    let bridge = bridge_search_fails_store_works(recording.clone());
+    let root = tmp_state_root("save-readfail");
+
+    let board = GoalBoard {
+        active: vec![goal_with(
+            "readfail-goal-idid",
+            1,
+            GoalProgress::NotStarted,
+            "Fallback goal",
+        )],
+        backlog: vec![],
+    };
+
+    with_state_root(&root, || {
+        super::save_goal_board(&board, &bridge)
+            .expect("read-failure must not propagate from save_goal_board");
+    });
+
+    let calls = recording.calls();
+    assert_eq!(
+        calls.len(),
+        1,
+        "in-flight board must still be persisted on read failure"
+    );
+    assert_eq!(calls[0].concept, "goal-board:snapshot");
+    let persisted: GoalBoard = serde_json::from_str(&calls[0].content).unwrap();
+    assert_eq!(persisted.active.len(), 1);
+    assert_eq!(persisted.active[0].id, "readfail-goal-idid");
+}
+
+/// I4 — Capacity bound holds across many merge-on-write saves. Saving 7
+/// disjoint single-goal boards must result in a merged board of exactly
+/// MAX_ACTIVE_GOALS=5 goals (the ones with the lowest priority numbers).
+#[test]
+fn save_goal_board_capacity_bound_holds_after_multiple_merges() {
+    let (bridge, _facts) = stateful_bridge();
+    let root = tmp_state_root("save-capacity");
+
+    with_state_root(&root, || {
+        for i in 0u32..7 {
+            let board = GoalBoard {
+                active: vec![goal_with(
+                    &format!("capgoal-{i:04}-aaaa"),
+                    i + 1,
+                    GoalProgress::NotStarted,
+                    "x",
+                )],
+                backlog: vec![],
+            };
+            super::save_goal_board(&board, &bridge).unwrap();
+        }
+        let loaded = super::load_goal_board(&bridge).unwrap();
+        assert_eq!(
+            loaded.active.len(),
+            MAX_ACTIVE_GOALS,
+            "merged board must be capped at MAX_ACTIVE_GOALS, got {} goals: {:?}",
+            loaded.active.len(),
+            loaded
+                .active
+                .iter()
+                .map(|g| (g.id.as_str(), g.priority))
+                .collect::<Vec<_>>()
+        );
+        let priorities: Vec<u32> = loaded.active.iter().map(|g| g.priority).collect();
+        for p in [1u32, 2, 3, 4, 5] {
+            assert!(
+                priorities.contains(&p),
+                "priority {p} must be kept, got {priorities:?}"
+            );
+        }
+        assert!(
+            !priorities.contains(&6),
+            "priority 6 must be truncated, got {priorities:?}"
+        );
+        assert!(
+            !priorities.contains(&7),
+            "priority 7 must be truncated, got {priorities:?}"
+        );
+    });
+}
+
+// ── concurrent save_goal_board: regression test for #1915 ───────────────
+
+/// Issue #1915 concurrency regression: two threads simultaneously
+/// `save_goal_board` with disjoint single-goal boards against a shared
+/// stateful bridge. After both joins, `load_goal_board` MUST return a
+/// board containing both goals. Repeated for 50 iterations with a Barrier
+/// to maximise contention on the read-modify-write window.
+#[test]
+fn save_goal_board_concurrent_two_writers_preserves_both_goals() {
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+
+    let root = tmp_state_root("save-concurrent");
+
+    for iter in 0..50u32 {
+        let (bridge, _facts) = stateful_bridge();
+        let bridge: Arc<crate::memory_bridge::CognitiveMemoryBridge> = Arc::new(bridge);
+        let barrier = Arc::new(Barrier::new(2));
+
+        let alpha_id = format!("alpha-concur-{iter:04}");
+        let beta_id = format!("beta-concur-{iter:04}");
+
+        let bridge_a = bridge.clone();
+        let barrier_a = barrier.clone();
+        let alpha_id_thread = alpha_id.clone();
+        let h_a = thread::spawn(move || {
+            barrier_a.wait();
+            let board = GoalBoard {
+                active: vec![goal_with(
+                    &alpha_id_thread,
+                    1,
+                    GoalProgress::NotStarted,
+                    "Alpha",
+                )],
+                backlog: vec![],
+            };
+            super::save_goal_board(&board, bridge_a.as_ref()).unwrap();
+        });
+
+        let bridge_b = bridge.clone();
+        let barrier_b = barrier.clone();
+        let beta_id_thread = beta_id.clone();
+        let h_b = thread::spawn(move || {
+            barrier_b.wait();
+            let board = GoalBoard {
+                active: vec![goal_with(
+                    &beta_id_thread,
+                    2,
+                    GoalProgress::NotStarted,
+                    "Beta",
+                )],
+                backlog: vec![],
+            };
+            super::save_goal_board(&board, bridge_b.as_ref()).unwrap();
+        });
+
+        h_a.join().expect("alpha thread must not panic");
+        h_b.join().expect("beta thread must not panic");
+
+        let loaded = with_state_root(&root, || super::load_goal_board(bridge.as_ref()).unwrap());
+        let ids: Vec<String> = loaded.active.iter().map(|g| g.id.clone()).collect();
+        assert!(
+            ids.iter().any(|id| id == &alpha_id),
+            "iter {iter}: alpha goal {alpha_id} disappeared — issue #1915 regression. ids={ids:?}"
+        );
+        assert!(
+            ids.iter().any(|id| id == &beta_id),
+            "iter {iter}: beta goal {beta_id} disappeared — issue #1915 regression. ids={ids:?}"
+        );
+    }
+}
+
+/// Companion concurrency test: backlog-only writes from two threads must
+/// also preserve both items (backlog has the same drift risk as active
+/// per requirement #2).
+#[test]
+fn save_goal_board_concurrent_backlog_writers_preserve_both_items() {
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+
+    let root = tmp_state_root("save-concurrent-backlog");
+
+    for iter in 0..25u32 {
+        let (bridge, _facts) = stateful_bridge();
+        let bridge: Arc<crate::memory_bridge::CognitiveMemoryBridge> = Arc::new(bridge);
+        let barrier = Arc::new(Barrier::new(2));
+
+        // Seed a guard-clean active goal so board_integrity_suspect passes
+        // for both writers' boards (short ids would be rejected).
+        let seed_goal = goal_with(
+            &format!("seedgoal-{iter:04}-aa"),
+            1,
+            GoalProgress::NotStarted,
+            "Seed",
+        );
+
+        let alpha_bk_id = format!("alpha-bk-{iter:04}");
+        let beta_bk_id = format!("beta-bk-{iter:04}");
+
+        let bridge_a = bridge.clone();
+        let barrier_a = barrier.clone();
+        let alpha_bk_id_t = alpha_bk_id.clone();
+        let seed_a = seed_goal.clone();
+        let h_a = thread::spawn(move || {
+            barrier_a.wait();
+            let board = GoalBoard {
+                active: vec![seed_a],
+                backlog: vec![backlog_with(&alpha_bk_id_t, "alpha-bk", "a", 0.3)],
+            };
+            super::save_goal_board(&board, bridge_a.as_ref()).unwrap();
+        });
+
+        let bridge_b = bridge.clone();
+        let barrier_b = barrier.clone();
+        let beta_bk_id_t = beta_bk_id.clone();
+        let seed_b = seed_goal.clone();
+        let h_b = thread::spawn(move || {
+            barrier_b.wait();
+            let board = GoalBoard {
+                active: vec![seed_b],
+                backlog: vec![backlog_with(&beta_bk_id_t, "beta-bk", "b", 0.4)],
+            };
+            super::save_goal_board(&board, bridge_b.as_ref()).unwrap();
+        });
+
+        h_a.join().unwrap();
+        h_b.join().unwrap();
+
+        let loaded = with_state_root(&root, || super::load_goal_board(bridge.as_ref()).unwrap());
+        let bk_ids: Vec<String> = loaded.backlog.iter().map(|b| b.id.clone()).collect();
+        assert!(
+            bk_ids.iter().any(|id| id == &alpha_bk_id),
+            "iter {iter}: alpha backlog item {alpha_bk_id} disappeared, got {bk_ids:?}"
+        );
+        assert!(
+            bk_ids.iter().any(|id| id == &beta_bk_id),
+            "iter {iter}: beta backlog item {beta_bk_id} disappeared, got {bk_ids:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fix Simard issue [#1915](https://github.com/rysweet/Simard/issues/1915): production goals were silently deleted from `cognitive_memory` between OODA cycles 5 and 6 during concurrent worktree/cargo build activity.

**Root cause.** `save_goal_board` in `src/goal_curation/operations.rs` replaced the entire `goal-board:snapshot` fact in LadybugDB from each writer's local copy without protecting against stale-snapshot writes from concurrent `CognitiveMemoryOps` clients. Two writers each reading an empty (or older) snapshot would each store a fresh snapshot derived from their stale view, and the later writer's snapshot silently overwrote the earlier writer's goals on `max_by(node_id)` reads.

**Fix.** Layer **merge-on-write** semantics onto `save_goal_board`:

```
guard(in_flight)
  -> acquire process-local merge-on-write mutex
  -> read_latest_snapshot(bridge)        // shared with load_goal_board
  -> merge_boards(persisted, in_flight)  // union by id, in-flight wins
  -> store_fact(merged)                  // constant fact metadata
```

The merge unions both `active` and `backlog` by `id` with in-flight precedence on collision, then deterministically truncates the active set to `MAX_ACTIVE_GOALS = 5` (priority asc, in-flight-preferred, id lex). Public API is unchanged.

A process-local `LazyLock<Mutex<()>>` serialises the read-merge-write window inside a single Simard process so two in-process bridge clients cannot both observe the same persisted snapshot and then each store a stale-derived snapshot. Cross-process races fall back to the LadybugDB flock at the storage layer plus the documented best-effort field-level guarantees.

## Files changed (focused diff — criterion 6)

```
 docs/concepts/goal-board-persistence.md |  56 ++++-     (+50 / -6)
 docs/reference/goal-board-api.md        | 252 +++++++-   (+247 / -5)
 src/goal_curation/operations.rs         | 256 ++++++-   (+239 / -17)
 src/goal_curation/tests_operations.rs   | 869 +++++++++  (+869 / -0)
 4 files changed, 1381 insertions(+), 46 deletions(-)
```

No source files outside `src/goal_curation/` are touched. No public-API signatures change. No new dependencies. No CI / pre-commit / Cargo.toml changes.

## Evidence

### Criterion 1 — qa-team gadugi-test scenarios (concurrency regression)

Two concurrency regression tests in `src/goal_curation/tests_operations.rs` reproduce the #1915 race against a shared `Arc<Mutex<Vec<CognitiveFact>>>`-backed bridge using `std::thread::spawn` + `std::sync::Barrier` for maximum contention on the read-merge-write window:

- `save_goal_board_concurrent_two_writers_preserves_both_goals` — 50 iterations, two threads each storing a disjoint single-goal board; asserts both ids survive in `load_goal_board`'s output.
- `save_goal_board_concurrent_backlog_writers_preserve_both_items` — 25 iterations, same shape with backlog items (plus a shared guard-clean seed goal so the integrity guard passes).

Both fail against the pre-fix `save_goal_board` and pass after the fix:

```
test save_goal_board_concurrent_two_writers_preserves_both_goals ... ok
test save_goal_board_concurrent_backlog_writers_preserve_both_items ... ok
```

Additional scenarios (sequential disjoint writers, collision-wins-in-flight, read-failure fallback, capacity bound after 7 saves) all pass:

```
test save_goal_board_sequential_two_disjoint_writers_preserves_both ... ok
test save_goal_board_collision_persists_in_flight_fields ... ok
test save_goal_board_read_failure_falls_back_to_persisting_in_flight ... ok
test save_goal_board_capacity_bound_holds_after_multiple_merges ... ok
```

Total: **48 goal_curation tests pass, 0 failed**.

### Criterion 2 — docs updates

- [`docs/reference/goal-board-api.md`](docs/reference/goal-board-api.md): merge-on-write section, conflict-resolution table, active-capacity truncation rule, integrity-guard order, read-failure fallback contract, successful-merge logging spec, best-effort guarantee (RR-1/RR-4), `Deletion semantics (RR-5)` subsection, `merge_boards` and `read_latest_snapshot` helper docs, post-fix concurrent-cycle example.
- [`docs/concepts/goal-board-persistence.md`](docs/concepts/goal-board-persistence.md): drift section references #1915, OODA flowchart shows the new `guard -> read -> merge -> store` step, "What is guaranteed" gets the no-disappearance guarantee, "Not guaranteed" gets strict-linearizability + unbounded-backlog caveats.
- `mkdocs build --strict` passes with all new anchors resolving.

### Criterion 3 — quality-audit cycles (SEEK -> VALIDATE -> FIX)

| Cycle | SEEK | VALIDATE | FIX |
|------|------|----------|-----|
| 1 | Implement merge-on-write + integrity guard + read helper | `cargo build --lib` ok | None needed |
| 2 | Run goal_curation tests | 46/48 pass — 2 concurrency tests fail because read-modify-write is not atomic | Added process-local `LazyLock<Mutex<()>>` SAVE_GOAL_BOARD_MUTEX serialising the critical section |
| 3 | Re-run full suite + clippy + fmt + mkdocs | `cargo test --lib`: 4137 pass / 0 fail / 4 ignored. `cargo clippy --all-targets --all-features -- -D warnings`: clean. `cargo fmt --all -- --check`: clean. `mkdocs build --strict`: clean (after promoting "Deletion semantics (RR-5)" inline-bold to a real heading) | None needed — final cycle clean |

### Criterion 4 — CI green

Local pre-push gate (mirrors CI surface) passed:

```
cargo fmt --all -- --check ........................................... Passed
cargo test --release --lib (cognitive_memory|bootstrap|memory_ipc|
                            memory_consolidation) --test-threads=$(nproc)  Passed
cargo clippy --all-targets --all-features --locked -- -D warnings .... Passed
pre-commit run --all-files ........................................... Passed
```

GitHub Actions checks on this PR will provide the authoritative green badge — see the **Checks** tab.

### Criterion 5 — *intentionally omitted per task prompt*

### Criterion 6 — focused diff

See "Files changed" above. Four files, all in scope per the design specification (operations + tests + two doc files). No incidental edits, no unrelated refactors, no new helper modules.

## How the fix resolves the issue

1. **Daemon (cycle N) and concurrent dashboard writer (worktree build helper) both call `save_goal_board`.**
2. Both acquire `SAVE_GOAL_BOARD_MUTEX` in turn (process-local serialisation).
3. The second writer's `read_latest_snapshot` observes the first writer's just-persisted fact via `max_by(node_id)`.
4. `merge_boards` unions both goal sets by id (in-flight wins on collision), producing a snapshot that contains every goal from both writers.
5. `store_fact` writes the merged board. The next OODA cycle (and any subsequent reader) sees both writers' goals.

Pre-fix, step 3 saw the writer's own stale snapshot or an empty store, step 4 produced a board missing the other writer's goals, and step 5 silently overwrote the authoritative state — the observed #1915 production failure.

Closes #1915.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
