### PR TITLE
fix(#1906): meeting REPL honors SIMARD_STATE_ROOT

### DIFF
--- a/src/meeting_backend/persist/mod.rs
+++ b/src/meeting_backend/persist/mod.rs
@@ -43,15 +43,33 @@ pub fn sanitize_filename(input: &str) -> String {
     }
 }
 
-/// Directory for meeting transcripts: `$SIMARD_MEETINGS_DIR` if set, else
-/// `~/.simard/meetings/`.
+/// Directory for meeting transcripts.
 ///
-/// The env var override mirrors the `SIMARD_HANDOFF_DIR` idiom in
-/// [`meeting_facilitator::default_handoff_dir`] so tests (and operators) can
-/// redirect meeting artifacts to a tempdir without touching `$HOME`.
+/// Resolution order (mirrors `goal-curation read` per audit issue #1906 and
+/// `Specs/ProductArchitecture.md` §"Memory Architecture → Session Summary":
+/// handoff records must live under the operator-chosen state-root):
+///   1. `SIMARD_MEETINGS_DIR` — narrow override used by existing tests and
+///      operators who want to redirect only the meeting artifact path
+///      without affecting the cognitive-memory DB root.
+///   2. `SIMARD_STATE_ROOT` — canonical operator-chosen state-root. When set,
+///      meeting transcripts and autosaves land under
+///      `$SIMARD_STATE_ROOT/meetings/`. This matches `memory_ipc::default_state_root()`
+///      / `goal_curation::operations::resolve_state_root` precedent so an
+///      operator who exports `SIMARD_STATE_ROOT=/tmp/foo` gets ALL durable
+///      simard state under `/tmp/foo`, including meeting persistence.
+///   3. `$HOME/.simard/meetings/` — historical default; preserves
+///      backward-compatible layout when neither env var is set.
+///
+/// Previously this only honored `SIMARD_MEETINGS_DIR`, so operators who set
+/// `SIMARD_STATE_ROOT` (e.g. for hermetic probe runs) silently had their
+/// meeting autosave and transcript files dumped into `~/.simard/meetings/`
+/// regardless. See audit issue #1906 for the full reproduction.
 pub(super) fn meetings_dir() -> PathBuf {
     if let Some(override_path) = std::env::var_os("SIMARD_MEETINGS_DIR") {
         return PathBuf::from(override_path);
+    }
+    if let Some(state_root) = std::env::var_os("SIMARD_STATE_ROOT") {
+        return PathBuf::from(state_root).join("meetings");
     }
     dirs::home_dir()
         .unwrap_or_else(|| PathBuf::from("."))

--- a/src/meeting_backend/tests_persist_extra.rs
+++ b/src/meeting_backend/tests_persist_extra.rs
@@ -573,3 +573,124 @@ fn json_handoff_action_item_none_fields_serialize_as_explicit_null() {
         serde_json::Value::String("Triage backlog".to_string())
     );
 }
+
+// ────────────────────────────────────────────────────────────────────────────
+// #1906: meeting REPL must honor SIMARD_STATE_ROOT
+//
+// `meetings_dir()` is the resolver used by `write_transcript` and
+// `write_auto_save`. The audit (issue #1906) found that operators who set
+// SIMARD_STATE_ROOT saw their autosaves silently written to
+// `~/.simard/meetings/_autosave_<topic>.json` regardless. The resolver now
+// mirrors `goal-curation read`:
+//   1. SIMARD_MEETINGS_DIR (narrow override; wins)
+//   2. SIMARD_STATE_ROOT    -> $SIMARD_STATE_ROOT/meetings
+//   3. $HOME/.simard/meetings (default)
+// ────────────────────────────────────────────────────────────────────────────
+
+/// End-to-end: with only SIMARD_STATE_ROOT set, `write_auto_save` must
+/// land the autosave file under `$SIMARD_STATE_ROOT/meetings/` and must
+/// NOT touch `$HOME/.simard/meetings/`. This is the outside-in assertion
+/// the #1906 audit reproduction specifies.
+#[test]
+#[serial]
+fn write_auto_save_lands_under_simard_state_root() {
+    use std::path::PathBuf;
+
+    // Belt-and-braces: clear both narrow overrides before setting STATE_ROOT.
+    // SAFETY: serialized via `#[serial]` (default lock group) across this
+    // test binary; matches the existing tests in this file that mutate
+    // SIMARD_MEETINGS_DIR.
+    unsafe {
+        std::env::remove_var("SIMARD_MEETINGS_DIR");
+        std::env::remove_var("SIMARD_STATE_ROOT");
+    }
+
+    let state_root = tempfile::tempdir().expect("create state-root tempdir");
+    unsafe {
+        std::env::set_var("SIMARD_STATE_ROOT", state_root.path().as_os_str());
+    }
+
+    let transcript = MeetingTranscript {
+        topic: "audit_state_root_probe".to_string(),
+        started_at: "2026-05-19T00:00:00Z".to_string(),
+        closed_at: String::new(),
+        duration_secs: 0,
+        summary: "[in-progress — meeting still open]".to_string(),
+        messages: vec![
+            make_msg(Role::User, "hello"),
+            make_msg(Role::User, "/close"),
+        ],
+    };
+
+    let written = write_auto_save(&transcript).expect("autosave should succeed");
+
+    let expected_parent = state_root.path().join("meetings");
+    assert_eq!(
+        written.parent(),
+        Some(expected_parent.as_path()),
+        "autosave parent must be $SIMARD_STATE_ROOT/meetings (got {})",
+        written.display(),
+    );
+    assert_eq!(
+        written.file_name().and_then(|s| s.to_str()),
+        Some("_autosave_audit_state_root_probe.json"),
+        "autosave filename contract preserved (got {})",
+        written.display(),
+    );
+    assert!(written.is_file(), "autosave file must exist on disk");
+
+    // Critical #1906 assertion (on the returned write path, not on stale disk
+    // state): the resolver must route writes to $SIMARD_STATE_ROOT/meetings,
+    // not silently fall through to $HOME/.simard/meetings. Developer machines
+    // already have stale artifacts under $HOME/.simard/meetings/ from prior
+    // operator probes (which is exactly how #1906 was discovered), so we can
+    // only test fix-correctness via the returned path.
+    let home_meetings =
+        PathBuf::from(std::env::var("HOME").unwrap_or_default()).join(".simard/meetings");
+    assert!(
+        !written.starts_with(&home_meetings),
+        "audit #1906: write_auto_save must NOT write under $HOME/.simard/meetings \
+         when SIMARD_STATE_ROOT is set. Got: {}",
+        written.display(),
+    );
+
+    unsafe {
+        std::env::remove_var("SIMARD_STATE_ROOT");
+    }
+}
+
+/// SIMARD_MEETINGS_DIR is the narrow override and must win over
+/// SIMARD_STATE_ROOT when both are set. Preserves the existing operator/test
+/// contract that lets callers redirect only the meeting artifact dir.
+#[test]
+#[serial]
+fn meetings_dir_narrow_override_wins_over_state_root() {
+    let narrow = tempfile::tempdir().expect("narrow tempdir");
+    let state = tempfile::tempdir().expect("state tempdir");
+    unsafe {
+        std::env::set_var("SIMARD_MEETINGS_DIR", narrow.path().as_os_str());
+        std::env::set_var("SIMARD_STATE_ROOT", state.path().as_os_str());
+    }
+
+    let transcript = MeetingTranscript {
+        topic: "narrow_wins".to_string(),
+        started_at: "2026-05-19T00:00:00Z".to_string(),
+        closed_at: String::new(),
+        duration_secs: 0,
+        summary: String::new(),
+        messages: vec![make_msg(Role::User, "hi")],
+    };
+
+    let written = write_auto_save(&transcript).expect("autosave should succeed");
+
+    assert_eq!(
+        written.parent(),
+        Some(narrow.path()),
+        "SIMARD_MEETINGS_DIR must win over SIMARD_STATE_ROOT (preserves narrow-override contract)"
+    );
+
+    unsafe {
+        std::env::remove_var("SIMARD_MEETINGS_DIR");
+        std::env::remove_var("SIMARD_STATE_ROOT");
+    }
+}

--- a/src/meeting_facilitator/handoff/persistence.rs
+++ b/src/meeting_facilitator/handoff/persistence.rs
@@ -279,11 +279,27 @@ pub const BUNDLE_TRANSCRIPT_JSON: &str = "transcript.json";
 
 /// Root directory for per-meeting handoff bundles.
 ///
-/// Honours `SIMARD_MEETINGS_ROOT` when set (used by tests for isolation),
-/// otherwise falls back to `~/.simard/meetings/`.
+/// Resolution order (mirrors `goal-curation read` per audit issue #1906 —
+/// the canonical operator-chosen state-root contract):
+///   1. `SIMARD_MEETINGS_ROOT` — narrow override used by existing bundle
+///      writer tests for isolation; preserved for backward compatibility.
+///   2. `SIMARD_STATE_ROOT` — canonical operator-chosen state-root. When set,
+///      meeting bundles land under `$SIMARD_STATE_ROOT/meetings/`. This
+///      matches `memory_ipc::default_state_root()` semantics so the entire
+///      simard durable state lives beneath a single operator-chosen root.
+///   3. `$HOME/.simard/meetings/` — historical default; preserves
+///      backward-compatible layout when neither env var is set.
+///
+/// Previously this only honored `SIMARD_MEETINGS_ROOT`, so operators who set
+/// `SIMARD_STATE_ROOT` (e.g. for hermetic probe runs) silently had per-meeting
+/// bundles dumped into `~/.simard/meetings/<meeting_id>/` regardless. See
+/// audit issue #1906 for the full reproduction.
 pub fn default_bundle_root() -> PathBuf {
     if let Some(p) = std::env::var_os("SIMARD_MEETINGS_ROOT") {
         return PathBuf::from(p);
+    }
+    if let Some(state_root) = std::env::var_os("SIMARD_STATE_ROOT") {
+        return PathBuf::from(state_root).join("meetings");
     }
     dirs::home_dir()
         .unwrap_or_else(|| PathBuf::from("."))
@@ -718,5 +734,162 @@ mod bundle_tests {
         // Should not panic; should produce a 16-char timestamp prefix even
         // when started_at is bad.
         assert!(id.len() >= 16);
+    }
+
+    // ── #1906: default_bundle_root must honor SIMARD_STATE_ROOT ────────────
+    //
+    // Resolution-order contract (mirrors `goal-curation read`):
+    //   1. SIMARD_MEETINGS_ROOT (narrow override; wins when set)
+    //   2. SIMARD_STATE_ROOT    -> $SIMARD_STATE_ROOT/meetings
+    //   3. $HOME/.simard/meetings (default)
+
+    /// When SIMARD_STATE_ROOT is set and the narrow override
+    /// SIMARD_MEETINGS_ROOT is not, bundles must land under
+    /// `$SIMARD_STATE_ROOT/meetings/` — NOT `~/.simard/meetings/`.
+    /// This is the headline #1906 fix.
+    #[test]
+    #[serial(simard_meetings_root_env, simard_state_root_env)]
+    fn default_bundle_root_honors_simard_state_root_when_narrow_override_unset() {
+        let state_root = temp_root("state-root-fallback");
+        // SAFETY: serialized via the serial_test locks above.
+        unsafe {
+            std::env::remove_var("SIMARD_MEETINGS_ROOT");
+            std::env::set_var("SIMARD_STATE_ROOT", &state_root);
+        }
+
+        let resolved = default_bundle_root();
+
+        let expected = state_root.join("meetings");
+        assert_eq!(
+            resolved,
+            expected,
+            "with SIMARD_STATE_ROOT={} and no SIMARD_MEETINGS_ROOT, bundle root \
+             must resolve to $SIMARD_STATE_ROOT/meetings (got {})",
+            state_root.display(),
+            resolved.display(),
+        );
+
+        let home_default = dirs::home_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join(".simard/meetings");
+        assert_ne!(
+            resolved, home_default,
+            "bundle root must NOT silently fall through to ~/.simard/meetings when \
+             SIMARD_STATE_ROOT is set (the audit-issue-#1906 regression)",
+        );
+
+        unsafe {
+            std::env::remove_var("SIMARD_STATE_ROOT");
+        }
+        std::fs::remove_dir_all(&state_root).ok();
+    }
+
+    /// SIMARD_MEETINGS_ROOT is the narrow override and must win over
+    /// SIMARD_STATE_ROOT when both are set. This preserves the existing
+    /// contract used by `bundle_tests::write_meeting_bundle_*` tests.
+    #[test]
+    #[serial(simard_meetings_root_env, simard_state_root_env)]
+    fn default_bundle_root_narrow_override_wins_over_state_root() {
+        let narrow_root = temp_root("narrow-wins-narrow");
+        let state_root = temp_root("narrow-wins-state");
+        unsafe {
+            std::env::set_var("SIMARD_MEETINGS_ROOT", &narrow_root);
+            std::env::set_var("SIMARD_STATE_ROOT", &state_root);
+        }
+
+        let resolved = default_bundle_root();
+
+        assert_eq!(
+            resolved, narrow_root,
+            "SIMARD_MEETINGS_ROOT must win over SIMARD_STATE_ROOT \
+             (preserves narrow-override contract for existing tests/operators)"
+        );
+
+        unsafe {
+            std::env::remove_var("SIMARD_MEETINGS_ROOT");
+            std::env::remove_var("SIMARD_STATE_ROOT");
+        }
+        std::fs::remove_dir_all(&narrow_root).ok();
+        std::fs::remove_dir_all(&state_root).ok();
+    }
+
+    /// With neither env var set, the historical default
+    /// (`$HOME/.simard/meetings`) is preserved. This guards against the
+    /// resolver accidentally changing the default-mode layout.
+    #[test]
+    #[serial(simard_meetings_root_env, simard_state_root_env)]
+    fn default_bundle_root_falls_back_to_home_when_no_env_set() {
+        unsafe {
+            std::env::remove_var("SIMARD_MEETINGS_ROOT");
+            std::env::remove_var("SIMARD_STATE_ROOT");
+        }
+
+        let resolved = default_bundle_root();
+        let expected = dirs::home_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join(".simard/meetings");
+
+        assert_eq!(
+            resolved,
+            expected,
+            "with neither SIMARD_MEETINGS_ROOT nor SIMARD_STATE_ROOT set, \
+             bundle root must resolve to $HOME/.simard/meetings (got {})",
+            resolved.display(),
+        );
+    }
+
+    /// End-to-end: writing a full bundle with only SIMARD_STATE_ROOT set
+    /// must materialize all three canonical bundle files under
+    /// `$SIMARD_STATE_ROOT/meetings/<meeting_id>/` and the returned bundle
+    /// path must not be under `$HOME/.simard/meetings/`. This is the
+    /// outside-in assertion the audit in #1906 specifies.
+    ///
+    /// Note: we cannot assert the home-default directory is absent on disk —
+    /// developer machines accumulate stale artifacts from earlier operator
+    /// probes (which is exactly how #1906 was discovered). The fix-correctness
+    /// check is the *returned path*: post-fix the resolver must route to
+    /// `$SIMARD_STATE_ROOT/meetings`, not to `$HOME/.simard/meetings`.
+    #[test]
+    #[serial(simard_meetings_root_env, simard_state_root_env)]
+    fn write_meeting_bundle_lands_under_simard_state_root() {
+        let state_root = temp_root("bundle-under-state-root");
+        unsafe {
+            std::env::remove_var("SIMARD_MEETINGS_ROOT");
+            std::env::set_var("SIMARD_STATE_ROOT", &state_root);
+        }
+
+        let mut handoff = sample_handoff();
+        let lines = sample_lines();
+        let dir = write_meeting_bundle(&mut handoff, &lines).expect("write bundle");
+
+        let expected_parent = state_root.join("meetings");
+        assert_eq!(
+            dir.parent(),
+            Some(expected_parent.as_path()),
+            "bundle dir parent must be $SIMARD_STATE_ROOT/meetings (got {})",
+            dir.display(),
+        );
+        assert!(dir.join("meeting_handoff.json").is_file());
+        assert!(dir.join("meeting_handoff.md").is_file());
+        assert!(dir.join("transcript.json").is_file());
+
+        // Critical #1906 assertion (on the returned path, not on stale disk state):
+        // the resolver must route the write to $SIMARD_STATE_ROOT/meetings, not
+        // silently fall through to $HOME/.simard/meetings.
+        let home_meetings = dirs::home_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join(".simard/meetings");
+        assert!(
+            !dir.starts_with(&home_meetings),
+            "audit #1906: write_meeting_bundle must NOT write under \
+             $HOME/.simard/meetings when SIMARD_STATE_ROOT is set. \
+             Got bundle dir: {}",
+            dir.display(),
+        );
+
+        unsafe {
+            std::env::remove_var("SIMARD_STATE_ROOT");
+        }
+        std::fs::remove_dir_all(&state_root).ok();
     }
 }


### PR DESCRIPTION
## Summary

The meeting REPL silently ignored `SIMARD_STATE_ROOT`, writing autosaves and per-meeting handoff bundles to `$HOME/.simard/meetings/` regardless of the operator-chosen state-root. This violated the durable-handoff contract in `Specs/ProductArchitecture.md` §"Memory Architecture → Session Summary" and Pillar 11 (Honest Degradation): `goal-curation read` honored `SIMARD_STATE_ROOT`, but `meeting` did not — same operator, same env var, two different answers, zero warnings.

## Root cause

`memory_ipc::default_state_root()` already honored `SIMARD_STATE_ROOT` correctly. But two **meeting-persist resolvers** ignored it entirely:

| Resolver | File | Bug |
|---|---|---|
| `meetings_dir()` | `src/meeting_backend/persist/mod.rs` | Honored only `SIMARD_MEETINGS_DIR`; fell straight to `$HOME/.simard/meetings`. |
| `default_bundle_root()` | `src/meeting_facilitator/handoff/persistence.rs` | Honored only `SIMARD_MEETINGS_ROOT`; fell straight to `$HOME/.simard/meetings`. |

So an operator who exported `SIMARD_STATE_ROOT=/tmp/foo` got their cognitive-memory DB under `/tmp/foo/state/` (correct) but their meeting autosave/handoff under `$HOME/.simard/meetings/` (silently wrong) — corrupting the hermetic-probe contract on which the audit/probe workflows depend.

## Fix

Both resolvers now follow the canonical `goal-curation` resolution order:

1. **Narrow override** (`SIMARD_MEETINGS_DIR` / `SIMARD_MEETINGS_ROOT`) wins — preserves existing test and operator workflows.
2. **`SIMARD_STATE_ROOT`** → `\$SIMARD_STATE_ROOT/meetings/` — the canonical operator-chosen state-root contract, mirrored from `memory_ipc::default_state_root()` and `goal_curation::operations::resolve_state_root`.
3. **`\$HOME/.simard/meetings/`** — historical default, preserved when neither env var is set.

## What this PR does NOT address

Per the audit's explicit "do not bundle" guidance (#1910 §Recommended dispatch order), each remaining audit finding lands as its own follow-up PR so they can be reviewed and reverted independently:

- **#1908** — meeting \`/close\` hangs past 90s timeout, durable handoff never written
- **#1909** — \`meeting\`/\`improvement-curation\`/\`review read\` brittle when probe state-root absent
- **#1907** — base-type registry inconsistent (\`gpt-5\` works in \`meeting\` examples but not \`goal-curation\`/\`improvement-curation\`)
- **#1905** — spurious \`session is already open\` WARN on every meeting boot

These are tracked in the coordinating comment on [#1910](https://github.com/rysweet/Simard/issues/1910#issuecomment-4483326026).

## Evidence

### Tests (criterion 1)

6 new tests added; 0 regressions across the full meeting-persist surface (53 unit tests + 22 meeting integration tests + full simard lib suite 4124 pass / 0 fail).

| Test | What it asserts |
|---|---|
| \`meeting_backend::tests_persist_extra::write_auto_save_lands_under_simard_state_root\` | Outside-in: sets \`SIMARD_STATE_ROOT=<tmpdir>\`, calls \`write_auto_save\`, asserts returned path is under \`<tmpdir>/meetings/\` and NOT under \`\$HOME/.simard/meetings/\`. Mirrors the audit reproduction in #1906. |
| \`meeting_backend::tests_persist_extra::meetings_dir_narrow_override_wins_over_state_root\` | Regression guard: \`SIMARD_MEETINGS_DIR\` still wins. |
| \`meeting_facilitator::handoff::persistence::bundle_tests::write_meeting_bundle_lands_under_simard_state_root\` | Outside-in: writes a full meeting bundle and asserts all three canonical files (\`meeting_handoff.json\`, \`meeting_handoff.md\`, \`transcript.json\`) land under \`\$SIMARD_STATE_ROOT/meetings/<meeting_id>/\`. |
| \`bundle_tests::default_bundle_root_honors_simard_state_root_when_narrow_override_unset\` | Unit-level resolver assertion. |
| \`bundle_tests::default_bundle_root_narrow_override_wins_over_state_root\` | Regression guard: \`SIMARD_MEETINGS_ROOT\` still wins. |
| \`bundle_tests::default_bundle_root_falls_back_to_home_when_no_env_set\` | Default-mode layout preserved. |

\`\`\`
\$ cargo test -p simard --lib -- meeting_backend::tests_persist meeting_facilitator::handoff::persistence
...
test result: ok. 53 passed; 0 failed; 0 ignored; 0 measured; 4075 filtered out

\$ cargo test -p simard --test meeting_goals --test meeting_handoff --test meeting_handoff_bundle --test handoff_redaction
...
test result: ok. 22 passed; 0 failed; 0 ignored; 0 measured

\$ cargo test -p simard --lib
...
test result: ok. 4124 passed; 0 failed; 4 ignored; 0 measured
\`\`\`

### Docs (criterion 2)

User-facing surface is the resolver behavior. Both resolver docstrings now explicitly document the three-layer resolution order, the precedent (\`goal-curation read\`), and link the audit issue (#1906) so future maintainers see the pinned contract. No external README/spec change needed — \`Specs/ProductArchitecture.md\` §"Memory Architecture → Session Summary" already mandated this behavior; this PR brings the implementation into alignment with the existing spec.

### Quality audit (criterion 3)

SEEK→VALIDATE→FIX cycles run:
1. **Cycle 1 (seek)**: \`rg -n "SIMARD_STATE_ROOT" src/\` + \`rg -n "default_state_root" src/\` + \`rg -n "\\.simard/meetings" src/\` — identified the two narrow-override resolvers vs. the canonical \`memory_ipc::default_state_root\` resolver as the inconsistency surface. (Validated: confirmed the audit hypothesis at \`meeting_session.rs:25\` was a red herring — that line already uses the canonical resolver for the cognitive-memory bridge; the actual leak was in the persist functions.)
2. **Cycle 2 (validate)**: Wrote the outside-in tests **first**; ran them — got the expected failure shape (writes landing under \`\$HOME/.simard/meetings/\`). Applied the resolver fix; tests went green. Discovered that the strict \`!leaked.exists()\` assertion was flaky on developer machines with stale operator-probe artifacts; tightened to \`!written.starts_with(\$HOME/.simard/meetings)\` which is the actual fix-correctness contract.
3. **Cycle 3 (validate, clean)**: Ran the full lib test suite (4124 pass / 0 fail), all meeting integration suites (22 pass / 0 fail), \`cargo fmt --check\` (clean), \`cargo clippy -p simard --lib --no-deps -- -D warnings\` (clean), then pre-commit + pre-push hooks (release-mode \`cargo fmt\`, \`cargo clippy --release --no-deps -- -D warnings\`, and the targeted release-mode unit suite \`cognitive_memory|bootstrap|memory_ipc|memory_consolidation\`) — all passed. Zero critical/high or medium correctness/security findings.

### CI (criterion 4)

Pre-commit + pre-push hooks (which are the locally-enforced subset of CI) all pass:
- \`cargo fmt --all -- --check\` ✅
- \`cargo clippy --release --no-deps -- -D warnings\` ✅ (pre-commit)
- \`cargo clippy --all-targets --all-features --locked -- -D warnings\` ✅ (pre-push)
- \`cargo test --release --lib (cognitive_memory|bootstrap|memory_ipc|memory_consolidation)\` ✅ (pre-push)

Full CI will run on the PR; this section will be updated if anything regresses there.

### Focused diff (criterion 6)

3 files changed, 319 insertions, 7 deletions. All edits are inside the two resolver functions and their associated test files — no unrelated cleanups, no drive-by refactors. The two resolver doc comments were rewritten to document the new contract, which is the only meaningful prose change.

\`\`\`
src/meeting_backend/persist/mod.rs             |  28 +++++++++--
src/meeting_backend/tests_persist_extra.rs     | 121 ++++++++++++++++++++++++++++++++++++++++++++
src/meeting_facilitator/handoff/persistence.rs | 177 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-
3 files changed, 319 insertions(+), 7 deletions(-)
\`\`\`

Fixes #1906