### PR TITLE
fix(#1915): add `simard goal delete` + regression-test auto-recovery against placeholder leakage

### DIFF
--- a/docs/reference/simard-cli.md
+++ b/docs/reference/simard-cli.md
@@ -122,6 +122,28 @@ subordinate-blocked) are intentionally untouched so the command is safe
 to rerun. Idempotent: empty board → no-op, exit zero. The count of
 cleared and skipped goals is logged to stderr.
 
+### `simard goal delete <goal-id>`
+
+Operator escape hatch — removes a goal record from the active board
+regardless of its current status. Intended for the narrow case where a
+goal entry on the active board is **demonstrably fabricated** (e.g.
+test-fixture leakage tracked under issue #1915, where ids like
+`stuck-a`/`stuck-b` with descriptions of the shape `Goal <id>` appeared
+on the production board between cycles 6 and 7). Backlog items are not
+touched — only `active`.
+
+Exits non-zero if `<goal-id>` is not on the active board (no silent
+no-op), so operators notice typos. The removal is logged to stderr.
+
+> Safety: this is a destructive operation. Prefer
+> `simard goal unblock` for transient lockouts; only reach for
+> `delete` when the goal record itself has no legitimate body, no
+> meaningful description, and no recoverable operator intent. The
+> regression test
+> `auto_recovery_ladder_never_emits_placeholder_goal_titles_or_stuck_ids`
+> in `src/ooda_actions/tests_advance_goal.rs` enforces that the
+> brain-failure auto-recovery ladder never re-synthesises such records.
+
 ## Self-management commands
 
 ### `simard update`

--- a/src/ooda_actions/tests_advance_goal.rs
+++ b/src/ooda_actions/tests_advance_goal.rs
@@ -168,6 +168,157 @@ fn failures_then_success_clears_marker_and_counter() {
     );
 }
 
+/// **Regression test required by the `stuck-b` engineer brief
+/// (synthetic-placeholder remediation cycle).**
+///
+/// The auto-recovery ladder in `dispatch_advance_goal` must NEVER
+/// synthesise a goal record on the active board — its single
+/// responsibility is to (a) drop the brain-failure marker, (b) clear
+/// the per-goal failure counter, and (c) restore the existing goal's
+/// status to `NotStarted`. It must NOT mint new active-board entries,
+/// and in particular must never produce ids of the form `stuck-<x>` or
+/// descriptions of the form `Goal <id>` (the test-fixture shape that
+/// leaked into the production board between cycles 6 and 7 — see
+/// session forensics under
+/// `~/.copilot/session-state/.../plan.md`).
+///
+/// This test exercises both the marker-recovery path (T1) and the
+/// non-marker path (T5) and asserts on the entire post-call active
+/// board, not just the dispatched goal.
+#[test]
+fn auto_recovery_ladder_never_emits_placeholder_goal_titles_or_stuck_ids() {
+    use crate::ooda_actions::advance_goal::spawn::{
+        BRAIN_FAILURE_BLOCKED_PREFIX, BRAIN_FAILURE_BLOCKED_SUFFIX,
+    };
+
+    let marker = format!("{BRAIN_FAILURE_BLOCKED_PREFIX}9{BRAIN_FAILURE_BLOCKED_SUFFIX}");
+
+    // Two scenarios — marker (auto-recovery fires) and non-marker
+    // (auto-recovery is gated off). Both must leave the board
+    // free of synthesised placeholder rows.
+    for (label, status) in [
+        (
+            "brain-failure-marker",
+            GoalProgress::Blocked(marker.clone()),
+        ),
+        (
+            "operator-blocked-non-marker",
+            GoalProgress::Blocked("waiting for human review".into()),
+        ),
+        ("not-started-baseline", GoalProgress::NotStarted),
+    ] {
+        let goal_id = "real-goal-with-meaningful-id";
+        let board = board_with_goal(goal_id, status.clone(), None);
+        let pre_active_count = board.active.len();
+        let pre_ids: Vec<String> = board.active.iter().map(|g| g.id.clone()).collect();
+
+        let mut bridges = test_bridges();
+        let mut state = OodaState::new(board);
+        state.goal_failure_counts.insert(goal_id.to_string(), 9);
+
+        let action = PlannedAction {
+            kind: ActionKind::AdvanceGoal,
+            goal_id: Some(goal_id.into()),
+            description: "advance".into(),
+        };
+        let _outcomes = dispatch_actions(&[action], &mut bridges, &mut state).unwrap();
+
+        // (a) No NEW goals were minted by the auto-recovery ladder.
+        assert_eq!(
+            state.active_goals.active.len(),
+            pre_active_count,
+            "scenario {label}: auto-recovery must not add active-board rows; \
+             before={pre_ids:?}, after={:?}",
+            state
+                .active_goals
+                .active
+                .iter()
+                .map(|g| g.id.clone())
+                .collect::<Vec<_>>()
+        );
+
+        // (b) No `stuck-<x>` id appears (test-fixture shape from
+        //     src/operator_cli/tests_goal.rs that was observed in
+        //     production cycle_7.json).
+        for g in &state.active_goals.active {
+            assert!(
+                !is_stuck_fixture_id(&g.id),
+                "scenario {label}: auto-recovery must NEVER emit a `stuck-<letter>` placeholder id; \
+                 got id {:?}",
+                g.id,
+            );
+        }
+
+        // (c) No `Goal <id>` description appears unless it was already
+        //     present on the pre-call board (which test_helpers.rs
+        //     populates by default — the post-call board must be a
+        //     subset of the pre-call descriptions in this dimension).
+        let pre_descriptions: std::collections::HashSet<String> =
+            pre_ids.iter().map(|id| format!("Goal {id}")).collect();
+        for g in &state.active_goals.active {
+            if is_goal_id_placeholder_description(&g.description) {
+                assert!(
+                    pre_descriptions.contains(&g.description),
+                    "scenario {label}: auto-recovery must NEVER synthesise a new \
+                     `Goal <id>` placeholder description; got new description {:?}",
+                    g.description,
+                );
+            }
+        }
+    }
+}
+
+/// Helper: `stuck-<single-lowercase-letter>` is the test-fixture id
+/// pattern from `src/operator_cli/tests_goal.rs`. Catches the exact
+/// shape observed in the cycle_7.json corruption (`stuck-a`, `stuck-b`).
+fn is_stuck_fixture_id(id: &str) -> bool {
+    let Some(rest) = id.strip_prefix("stuck-") else {
+        return false;
+    };
+    rest.len() == 1 && rest.chars().all(|c| c.is_ascii_lowercase())
+}
+
+/// Helper: matches descriptions of the form `Goal <id>` (the
+/// `active_goal()` test helper's `format!("Goal {id}")` shape).
+fn is_goal_id_placeholder_description(desc: &str) -> bool {
+    let trimmed = desc.trim();
+    let Some(rest) = trimmed
+        .strip_prefix("Goal ")
+        .or_else(|| trimmed.strip_prefix("goal "))
+    else {
+        return false;
+    };
+    !rest.is_empty()
+        && rest
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
+
+#[test]
+fn helper_is_stuck_fixture_id_catches_the_observed_corruption_pattern() {
+    assert!(is_stuck_fixture_id("stuck-a"));
+    assert!(is_stuck_fixture_id("stuck-b"));
+    assert!(is_stuck_fixture_id("stuck-z"));
+    // Negative cases: real goal slugs.
+    assert!(!is_stuck_fixture_id("enhance-simard-meeting-experience"));
+    assert!(!is_stuck_fixture_id("stuck-goal")); // pre-existing synthetic id, different shape
+    assert!(!is_stuck_fixture_id("stuck-"));
+    assert!(!is_stuck_fixture_id(""));
+    assert!(!is_stuck_fixture_id("STUCK-A")); // uppercase doesn't match
+}
+
+#[test]
+fn helper_is_goal_id_placeholder_description_catches_test_fixture_shape() {
+    assert!(is_goal_id_placeholder_description("Goal stuck-b"));
+    assert!(is_goal_id_placeholder_description("Goal alpha"));
+    assert!(is_goal_id_placeholder_description("goal working"));
+    // Negative cases: real descriptions.
+    assert!(!is_goal_id_placeholder_description("Ship the v1 release"));
+    assert!(!is_goal_id_placeholder_description("Goal "));
+    assert!(!is_goal_id_placeholder_description(""));
+    assert!(!is_goal_id_placeholder_description("Goal with spaces"));
+}
+
 /// T5 — `auto_recovery_skipped_when_blocked_reason_is_not_marker`.
 ///
 /// A goal whose `Blocked` reason does NOT match the brain-failure marker

--- a/src/operator_cli/goal.rs
+++ b/src/operator_cli/goal.rs
@@ -1,6 +1,7 @@
 //! `simard goal` operator subcommands: `list`, `unblock <id>`,
-//! `unblock-all`. Operator escape hatch for the issue-#1911 OODA goal
-//! lockout (and a general-purpose board-inspection tool).
+//! `unblock-all`, `delete <id>`. Operator escape hatch for the
+//! issue-#1911 OODA goal lockout (and a general-purpose board
+//! inspection / remediation tool).
 //!
 //! Subcommand semantics (asymmetric by design — see spec A4):
 //!   - `goal list`         — print active + backlog snapshot to stdout.
@@ -11,6 +12,12 @@
 //!     safeguard marker (`is_brain_failure_marker`). Operator-set,
 //!     scope-blocked, dependency-blocked, and subordinate-blocked
 //!     goals are untouched.
+//!   - `goal delete <id>`  — operator escape hatch for removing a
+//!     corrupt or fabricated placeholder goal record from the active
+//!     board (e.g. test-fixture-shaped goals that leaked into
+//!     production state via the cycle-5→6 corruption pathway tracked
+//!     in issue #1915). Removes the goal regardless of status; backlog
+//!     items are untouched.
 //!
 //! Persistence is cognitive memory via `launch_writer_bridge` against
 //! `simard_state_root()` (honours `SIMARD_STATE_ROOT`). Audit traces are
@@ -45,6 +52,11 @@ pub(super) fn dispatch_goal_command(
         "unblock-all" => {
             reject_extra_args(args)?;
             handle_unblock_all()
+        }
+        "delete" => {
+            let goal_id = next_required(&mut args, "goal id")?;
+            reject_extra_args(args)?;
+            handle_delete(&goal_id)
         }
         other => Err(format!("unsupported command 'goal {other}'").into()),
     }
@@ -115,6 +127,32 @@ fn handle_unblock(goal_id: &str) -> Result<(), Box<dyn Error>> {
     goal.status = GoalProgress::NotStarted;
     save_board(&board)?;
     eprintln!("[simard] goal unblock: '{goal_id}' restored to NotStarted (was: {prior})");
+    Ok(())
+}
+
+/// Remove a goal record from the active board by id.
+///
+/// Operator escape hatch for clearing fabricated placeholder goals (e.g.
+/// test-fixture-shaped records that leaked into the production board via
+/// the cycle-5→6 corruption pathway in issue #1915). Removes the goal
+/// regardless of its current status — operators are expected to verify
+/// the goal is legitimately disposable before invoking this. Backlog
+/// items are intentionally untouched; only the `active` board is
+/// mutated.
+///
+/// Errors when `goal_id` is not present on the active board so operators
+/// notice typos instead of silently no-opping.
+fn handle_delete(goal_id: &str) -> Result<(), Box<dyn Error>> {
+    let mut board = load_board()?;
+    let before = board.active.len();
+    board.active.retain(|g| g.id != goal_id);
+    if board.active.len() == before {
+        return Err(
+            format!("goal '{goal_id}' not found on active board (nothing to delete)").into(),
+        );
+    }
+    save_board(&board)?;
+    eprintln!("[simard] goal delete: '{goal_id}' removed from active board");
     Ok(())
 }
 

--- a/src/operator_cli/mod.rs
+++ b/src/operator_cli/mod.rs
@@ -51,6 +51,10 @@ Product modes:
                              deterministic brain-failure safeguard
                              marker; operator-, scope-, dependency-, and
                              subordinate-blocked goals are untouched
+  goal delete <goal-id>    — operator escape hatch: remove a fabricated
+                             or corrupt goal record from the active
+                             board (e.g. test-fixture leakage tracked in
+                             issue #1915); errors if id is unknown
   goal-curation run <base-type> <topology> <objective> [state-root]
   goal-curation read <base-type> <topology> [state-root]
                          — read goals from $SIMARD_STATE_ROOT (or

--- a/src/operator_cli/tests_goal.rs
+++ b/src/operator_cli/tests_goal.rs
@@ -319,3 +319,123 @@ fn simard_goal_unblock_all_does_not_touch_completed_or_in_progress_goals() {
     );
     assert_eq!(by_id("pending").status, GoalProgress::NotStarted);
 }
+
+// ─── `simard goal delete <id>` — operator escape hatch for fabricated/corrupt goals ──
+//
+// Motivating incident: synthetic placeholder goals (e.g. `stuck-b` with
+// description "Goal stuck-b") leaked into the production OODA board via
+// the cycle-5→6 corruption pathway tracked in issue #1915. Operators
+// need a CLI to remove these without raw `cognitive_memory.ladybug`
+// mutation. Tests below cover the three required behaviours:
+//   1. delete-success removes the named goal and preserves the rest
+//   2. unknown-id is a hard error (no silent no-op)
+//   3. backlog items are not touched
+
+#[test]
+#[serial_test::serial(cognitive_memory)]
+fn simard_goal_delete_removes_named_goal_and_preserves_siblings() {
+    let (_tmp, root) = isolated_state_root();
+    seed_board(
+        &root,
+        vec![
+            active_goal("alpha-1", GoalProgress::NotStarted),
+            active_goal("beta-2", GoalProgress::InProgress { percent: 25 }),
+            active_goal("gamma-3", GoalProgress::Completed),
+        ],
+    );
+
+    let result = dispatch_operator_cli(vec![
+        "goal".to_string(),
+        "delete".to_string(),
+        "beta-2".to_string(),
+    ]);
+    assert!(
+        result.is_ok(),
+        "`simard goal delete beta-2` must exit 0; got: {:?}",
+        result.err().map(|e| e.to_string())
+    );
+
+    let board = load_board(&root);
+    assert!(
+        board.active.iter().all(|g| g.id != "beta-2"),
+        "deleted goal must be absent from the board; got ids: {:?}",
+        board.active.iter().map(|g| &g.id).collect::<Vec<_>>()
+    );
+    // Siblings must survive untouched.
+    let surviving_ids: Vec<&str> = board.active.iter().map(|g| g.id.as_str()).collect();
+    assert!(
+        surviving_ids.contains(&"alpha-1") && surviving_ids.contains(&"gamma-3"),
+        "sibling goals must survive delete; got: {surviving_ids:?}"
+    );
+    assert_eq!(
+        board.active.len(),
+        2,
+        "exactly one goal must be removed; got {} active goal(s)",
+        board.active.len()
+    );
+}
+
+#[test]
+#[serial_test::serial(cognitive_memory)]
+fn simard_goal_delete_unknown_id_returns_error_without_mutating_board() {
+    let (_tmp, root) = isolated_state_root();
+    seed_board(
+        &root,
+        vec![active_goal("alpha-1", GoalProgress::NotStarted)],
+    );
+
+    let result = dispatch_operator_cli(vec![
+        "goal".to_string(),
+        "delete".to_string(),
+        "no-such-goal".to_string(),
+    ]);
+    assert!(
+        result.is_err(),
+        "delete of unknown goal id must return a non-zero exit"
+    );
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("no-such-goal"),
+        "error must name the unknown goal id; got: {msg}"
+    );
+
+    // Board must be untouched.
+    let board = load_board(&root);
+    assert_eq!(board.active.len(), 1, "board must be unchanged on error");
+    assert_eq!(board.active[0].id, "alpha-1");
+}
+
+#[test]
+#[serial_test::serial(cognitive_memory)]
+fn simard_goal_delete_clears_brain_failure_marker_goals_via_id() {
+    // Regression scenario from the `stuck-b` engineer brief: a goal stuck
+    // on the brain-failure safeguard marker (or any other Blocked reason)
+    // can be deleted by id when the operator confirms it is fabricated.
+    use crate::ooda_actions::advance_goal::spawn::{
+        BRAIN_FAILURE_BLOCKED_PREFIX, BRAIN_FAILURE_BLOCKED_SUFFIX,
+    };
+    let marker = format!("{BRAIN_FAILURE_BLOCKED_PREFIX}5{BRAIN_FAILURE_BLOCKED_SUFFIX}");
+    let (_tmp, root) = isolated_state_root();
+    seed_board(
+        &root,
+        vec![
+            active_goal("legit-goal", GoalProgress::NotStarted),
+            active_goal("fabricated", GoalProgress::Blocked(marker)),
+        ],
+    );
+
+    let result = dispatch_operator_cli(vec![
+        "goal".to_string(),
+        "delete".to_string(),
+        "fabricated".to_string(),
+    ]);
+    assert!(
+        result.is_ok(),
+        "delete must remove a Blocked goal regardless of reason: {:?}",
+        result.err().map(|e| e.to_string())
+    );
+
+    let board = load_board(&root);
+    assert_eq!(board.active.len(), 1);
+    assert_eq!(board.active[0].id, "legit-goal");
+}

--- a/src/operator_cli/tests_mod.rs
+++ b/src/operator_cli/tests_mod.rs
@@ -434,10 +434,29 @@ fn test_goal_unblock_missing_id_returns_error() {
 #[test]
 fn test_help_text_mentions_goal_subcommands() {
     let help = operator_cli_help();
-    for needle in &["goal list", "goal unblock", "goal unblock-all"] {
+    for needle in &[
+        "goal list",
+        "goal unblock",
+        "goal unblock-all",
+        "goal delete",
+    ] {
         assert!(
             help.contains(needle),
             "help must document '{needle}' subcommand for issue #1911"
         );
     }
+}
+
+#[test]
+fn test_goal_delete_missing_id_returns_error() {
+    let result = dispatch_operator_cli(vec!["goal".to_string(), "delete".to_string()]);
+    assert!(
+        result.is_err(),
+        "`simard goal delete` without a goal-id must error"
+    );
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("expected goal id") || msg.contains("expected goal-id"),
+        "error should explain the missing goal id; got: {msg}"
+    );
 }


### PR DESCRIPTION
## Summary

Engineer-cycle remediation for the synthetic placeholder goal `stuck-b`
that was observed on the production OODA active board at spawn time
(May 19 2026 01:38 UTC). Adds the operator-side escape hatch +
regression test required by the brief.

Closes the per-cycle remediation for `stuck-b` (and siblings
`stuck-a`, `operator-blocked`, `working`, and later `alpha`).
Underlying corruption mechanism is filed as a separate
follow-up: #1925.
Refs #1915, PR #1914.

## Forensic finding

The active board observed at spawn time contained exactly the
4-goal vector from `src/operator_cli/tests_goal.rs::
simard_goal_unblock_all_clears_only_marker_blocked_goals`:

```
stuck-a          p1  in-progress(5%)  engineer-stuck-a-1779154672  Goal stuck-a
stuck-b          p1  in-progress(5%)  engineer-stuck-b-1779154698  Goal stuck-b
operator-blocked p1  blocked: waiting on human review  -            Goal operator-blocked
working          p1  in-progress(50%) -                             Goal working
```

- ids, descriptions, and status fingerprints match the test helper
  `active_goal()` + `seed_board` argument vector verbatim
- production code paths emit no `Goal <id>` descriptions outside
  `#[cfg(test)]` modules (`rg "format!\(\"Goal \{" src/`)
- cycle_report timeline: cycles 1–2 had 5 real goals, cycles 3–6
  had only `stuck-goal` (the #1915 corruption pathway), cycle 7 had
  the 4 test fixtures above
- by the time the new binary was built (15-min cargo release), the
  daemon had cycled and replaced them with `alpha` (another test
  fixture from `tests_goal.rs:99`)

**Verdict (per the brief):** fabricated stub of test-fixture origin
— delete, add regression test, open PR. Root-cause mechanism filed
separately as #1925.

## Changes

| File | Change |
| --- | --- |
| `src/operator_cli/goal.rs` | new `handle_delete(goal_id)` + `delete` subcommand routing |
| `src/operator_cli/mod.rs` | `OPERATOR_CLI_HELP` documents `goal delete <goal-id>` |
| `src/operator_cli/tests_goal.rs` | 3 hermetic tests for `goal delete` under `#[serial_test::serial(cognitive_memory)]` |
| `src/operator_cli/tests_mod.rs` | dispatcher-wiring test + help-text expansion |
| `src/ooda_actions/tests_advance_goal.rs` | regression test required by the brief: `auto_recovery_ladder_never_emits_placeholder_goal_titles_or_stuck_ids` + 2 helper-coverage tests |
| `docs/reference/simard-cli.md` | documents `simard goal delete <goal-id>` and its safety contract |

## Production-state remediation

Ran the new binary against `~/.simard/`:

```
$ simard goal list   # before
active goals: 1 / 5
ID  PRIORITY  STATUS       ASSIGNED                    DESCRIPTION
alpha  p1     not-started  engineer-alpha-1779156686   Goal alpha

$ simard goal delete alpha
[simard] goal delete: 'alpha' removed from active board

$ simard goal list   # after
active goals: 0 / 5
  (none)
```

The 4 originally-observed fixtures (`stuck-a`, `stuck-b`,
`operator-blocked`, `working`) were no longer present by the time
the binary was ready — daemon cycles had already replaced them with
`alpha`. The single live fixture is now deleted.

## Merge-ready evidence

### Criterion 1 — qa-team scenarios

Not applicable for this PR: no new user-facing surface beyond the
new CLI subcommand, which is covered by 4 hermetic Rust integration
tests under `#[serial_test::serial(cognitive_memory)]`. The
behavioural scenarios are already encoded as Rust tests and run on
every `cargo test --lib`:

- `simard_goal_delete_removes_named_goal_and_preserves_siblings`
- `simard_goal_delete_unknown_id_returns_error_without_mutating_board`
- `simard_goal_delete_clears_brain_failure_marker_goals_via_id`
- `test_goal_delete_missing_id_returns_error`

The qa-team scenario surface is gated on web/UI flows; the
operator CLI is exercised via Rust integration tests by project
convention (matches the `goal list`/`goal unblock` test surface
shipped in PR #1914).

### Criterion 2 — docs updated

`docs/reference/simard-cli.md` now documents `simard goal delete
<goal-id>`, including the safety contract and a back-reference to
the regression test.

### Criterion 3 — quality-audit

Manual SEEK→VALIDATE→FIX cycles performed inline during
development:

1. **SEEK**: cargo test failed —
   `simard_goal_delete_removes_named_goal_and_preserves_siblings`
   panicked because test fixture used 4-char id `beta` rejected by
   the existing `board_integrity_suspect` heuristic.
   **VALIDATE**: confirmed the error matched the heuristic.
   **FIX**: switched fixture ids to `alpha-1`/`beta-2`/`gamma-3`,
   re-ran tests → all 3 pass.
2. **SEEK**: lost the `T5` doc-comment header during the
   `auto_recovery_skipped_when_blocked_reason_is_not_marker`
   edit. **VALIDATE**: `grep -n "T5 —"` returned nothing.
   **FIX**: restored the header. Re-ran `cargo test --lib
   ooda_actions::tests_advance_goal` → all 19 tests pass.
3. **SEEK**: `cargo fmt -- --check` flagged two long lines in the
   new code. **VALIDATE**: ran `cargo fmt --check` to confirm.
   **FIX**: ran `cargo fmt`; re-ran with `--check` → exit 0.

Final cycle (after the 3 above) was clean:
- `cargo test --lib`: 4125 passed, 0 failed, 4 ignored
- `cargo clippy --all-targets --all-features --locked -- -D warnings`:
  passed (enforced by the pre-push hook in this repo)
- `cargo fmt --all -- --check`: passed
- Pre-commit + pre-push hooks (cognitive_memory / bootstrap /
  memory_ipc / memory_consolidation slices) all passed

### Criterion 4 — CI green

Pre-push hook ran the project's `cargo fmt`, focused `cargo test
--release --lib`, and `cargo clippy --all-targets --all-features
--locked` — all passed. GH Actions CI will run on push of this
branch.

### Criterion 5 — PR description has evidence

This section.

### Criterion 6 — diff focused

```
 docs/reference/simard-cli.md           |  22 +++
 src/ooda_actions/tests_advance_goal.rs | 151 ++++++++++++++++++++
 src/operator_cli/goal.rs               |  42 +++++-
 src/operator_cli/mod.rs                |   4 +
 src/operator_cli/tests_goal.rs         | 120 +++++++++++++++
 src/operator_cli/tests_mod.rs          |  21 ++-
 6 files changed, 357 insertions(+), 3 deletions(-)
```

Only files touched are those required for the new subcommand, its
tests, dispatcher wiring, docs, and the regression test. No
unrelated edits.

## Out of scope (filed separately)

How the test fixtures from `tests_goal.rs` leaked from a
`tempfile::TempDir` into `~/.simard/cognitive_memory.ladybug`
across cycles is **not** addressed here — that's a distinct
mechanism investigation filed as #1925. This PR only ships the
operator-side workaround + the per-cycle remediation required by
the engineer brief.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
