### PR TITLE
fix(operator-cli): align meeting --help example with registered base-type/topology (#1907)

### DIFF
--- a/src/operator_cli/meeting.rs
+++ b/src/operator_cli/meeting.rs
@@ -25,8 +25,8 @@ If no command is given, an interactive REPL is started with a timestamp topic.
 Examples:
   simard meeting --help
   simard meeting repl \"weekly sync\"
-  simard meeting run gpt-5 ring \"design review\"
-  simard meeting read gpt-5 ring
+  simard meeting run local-harness single-process \"design review\"
+  simard meeting read local-harness single-process
 ";
 
 pub(super) fn dispatch_meeting_command(
@@ -198,6 +198,46 @@ mod tests {
                 "MEETING_HELP must mention '{keyword}'"
             );
         }
+    }
+
+    #[test]
+    fn test_meeting_help_uses_registered_base_type_and_topology() {
+        // Regression for issue #1907: `simard meeting --help` previously advertised
+        // example commands using `gpt-5` as the base type and `ring` as the topology.
+        // Neither value is registered with the runtime base-type/topology registry
+        // (see Specs/ProductArchitecture.md §"Agent Base Type"), so copy-pasting the
+        // example into adjacent subcommands such as `simard goal-curation read`
+        // produced "no adapter is registered for base type 'gpt-5'" and
+        // "invalid value for configuration 'SIMARD_RUNTIME_TOPOLOGY'" errors.
+        //
+        // The help text MUST advertise only registry-valid identifiers so the
+        // examples remain runnable across every operator subcommand. We assert on
+        // `local-harness` / `single-process` because they are the canonical
+        // registered builtin pair already used throughout docs/reference/simard-cli.md.
+        //
+        // The forbidden-substring checks use space-padded " ring " specifically to
+        // avoid false positives on legitimate substrings like "string" or "differing".
+        let help = super::MEETING_HELP;
+        assert!(
+            !help.contains("gpt-5"),
+            "MEETING_HELP must not advertise unregistered base type 'gpt-5' (issue #1907); \
+             use a registry-valid identifier such as 'local-harness'"
+        );
+        assert!(
+            !help.contains(" ring "),
+            "MEETING_HELP must not advertise unregistered topology 'ring' (issue #1907); \
+             use a registry-valid topology such as 'single-process'"
+        );
+        assert!(
+            help.contains("local-harness"),
+            "MEETING_HELP must advertise the registered builtin base type 'local-harness' \
+             so the example is runnable across operator subcommands (issue #1907)"
+        );
+        assert!(
+            help.contains("single-process"),
+            "MEETING_HELP must advertise the registered topology 'single-process' \
+             so the example is runnable across operator subcommands (issue #1907)"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #1907

## Problem

`simard meeting --help` advertised example commands using a base type and topology
that the runtime base-type/topology registry does not recognize:

```
simard meeting run gpt-5 ring "design review"
simard meeting read gpt-5 ring
```

Per `Specs/ProductArchitecture.md` §"Agent Base Type" (lines 335-386), the
registered builtin base types are `local-harness`, `terminal-shell`,
`rusty-clawd`, `copilot-sdk`, and the valid topologies are `single-process`,
`multi-process`, `distributed`. Copy-pasting the bad example into any adjacent
operator subcommand failed visibly:

```console
$ simard goal-curation read gpt-5 single-process
ERROR: no adapter is registered for base type 'gpt-5'
$ simard goal-curation read local-harness ring
ERROR: invalid value for configuration 'SIMARD_RUNTIME_TOPOLOGY'
```

## Fix

Replace the two stale example lines in `MEETING_HELP` with the canonical
registered pair `local-harness single-process` already used throughout
`docs/reference/simard-cli.md`.

## Before / After — `simard meeting --help` (Examples block)

**Before:**
```
Examples:
  simard meeting --help
  simard meeting repl "weekly sync"
  simard meeting run gpt-5 ring "design review"
  simard meeting read gpt-5 ring
```

**After:**
```
Examples:
  simard meeting --help
  simard meeting repl "weekly sync"
  simard meeting run local-harness single-process "design review"
  simard meeting read local-harness single-process
```

## Cross-subcommand demonstration

The new example copy-pastes cleanly into `simard goal-curation read` (the same
sibling subcommand that the bug report cited as broken):

```console
$ STATE_ROOT=$(mktemp -d)
$ simard goal-curation read local-harness single-process "$STATE_ROOT"
Goal register: durable
Selected base type: local-harness
Topology: single-process
State root: /tmp/tmp.rmg2D6iWUI
Active goals count: 4
Active goal 1: p1 [active] Goal alpha
Active goal 2: p1 [active] Goal operator-blocked
Active goal 3: p1 [active] Goal pending
Active goal 4: p1 [active] Goal running
Proposed goals count: 0
...
```

No `no adapter is registered for base type 'gpt-5'` error.
No `invalid value for configuration 'SIMARD_RUNTIME_TOPOLOGY'` error.
Registry validation passes; the example is now genuinely runnable across
adjacent operator subcommands.

## Regression test

Added `test_meeting_help_uses_registered_base_type_and_topology` in the
existing `src/operator_cli/meeting.rs` tests module. It locks down the help
text against future drift of #1907 with four assertions:

| # | Assertion | Rationale |
|---|---|---|
| 1 | `!help.contains("gpt-5")` | Forbid the stale unregistered base type |
| 2 | `!help.contains(" ring ")` | Forbid the stale topology; space-padded to avoid false positives on `string`/`differing` |
| 3 | `help.contains("local-harness")` | Require the registered builtin base type |
| 4 | `help.contains("single-process")` | Require the registered topology |

Verified TDD red phase before edit, green after edit:

```console
$ cargo test --lib test_meeting_help_uses_registered_base_type_and_topology
test operator_cli::meeting::tests::test_meeting_help_uses_registered_base_type_and_topology ... ok
test result: ok. 1 passed; 0 failed; ...
```

## Local quality gates (all green)

- `cargo build` — passed
- `cargo test --lib` — **4156 passed; 0 failed; 4 ignored**
- `cargo fmt --check` — clean
- `cargo clippy --all-targets --all-features --locked -- -D warnings` — clean (pre-push hook)
- `cargo clippy --release --no-deps -- -D warnings` — clean (pre-commit hook)
- Smoke: `simard meeting --help` shows new example; `gpt-5`/`ring` absent
- Cross-subcommand: `simard goal-curation read local-harness single-process` succeeds

## Scope (intentionally narrow)

**In scope (per the issue and design spec):**
- Two stale tokens in `MEETING_HELP` (lines 28-29 of `src/operator_cli/meeting.rs`)
- One regression test referencing #1907

**Audited and intentionally out of scope:**
- Other operator CLI help texts (`src/operator_cli/mod.rs`, `engineer.rs`,
  `curation.rs`, `review.rs`, `ooda.rs`, `goal.rs`) use generic
  `<base-type> <topology>` placeholders — no drift, no change required.
- `docs/reference/simard-cli.md` — already uses `local-harness single-process`
  consistently throughout (verified at lines 511, 533, 572).
- A `simard base-types list` discovery command — deferred to follow-up issue #1930
  to keep this diff focused. The registry surface
  (`BaseTypeRegistry::registered_ids()` at `src/runtime/types.rs:142-144`)
  requires manifest construction to enumerate, so adding a clean discovery
  command needs its own design + tests and would violate "diff focused".
- Spec-vs-registry drift (spec lists 4 builtins, registry registers 6 by
  adding `claude-agent-sdk` and `ms-agent-framework`) — separate
  documentation/registry alignment task; not blocking on this help-text fix.
- Sibling worktrees (`pr1-worktree/`, `pr2-worktree/`) carrying the bad text —
  isolated branch checkouts; they will resync naturally when those branches
  rebase on `main` post-merge.

## Diff

```
 src/operator_cli/meeting.rs | 44 ++++++++++++++++++++++++++++++++++++++++++--
 1 file changed, 42 insertions(+), 2 deletions(-)
```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
