### PR TITLE
fix(ooda-brain): close silent JSON-parse fallback in decide/orient (#1890)

### DIFF
--- a/docs/howto/diagnose-decide-orient-parse-failures.md
+++ b/docs/howto/diagnose-decide-orient-parse-failures.md
@@ -1,0 +1,235 @@
+---
+title: Diagnose OODA decide/orient brain parse failures
+description: Operator runbook for the silent-fallback fix in #1890. Find, classify, and remediate JSON-parse failures from the decide and orient phases.
+last_updated: 2026-05-19
+review_schedule: as-needed
+owner: simard
+---
+
+# How-to: Diagnose OODA decide/orient brain parse failures
+
+> **Audience:** operators on call when an OODA goal is making no progress
+> across many cycles despite the dashboard reporting `success: true`
+> decisions.
+>
+> **Prerequisites:** read access to `~/.simard/logs/`,
+> `~/.simard/cycle_reports/`, and `~/.simard/metrics/` on the daemon
+> host; familiarity with the `simard` CLI and `jq`.
+
+Before [#1890](https://github.com/rysweet/Simard/issues/1890) shipped, the `decide_with_brain` and `orient_with_brain` call sites in `simard::ooda_loop` would respond to an LLM brain JSON-parse failure by emitting a single `WARN` line — `no JSON object found in LLM response (got N bytes)` — and then silently substituting `DeterministicFallbackDecideBrain` / `DeterministicFallbackOrientBrain`. The cycle continued, `cycle_N.json` recorded a perfectly normal-looking deterministic decision, and the goal stalled invisibly.
+
+That silent-fallback path is now closed. Parse failures fire four visibility channels in lock-step. This guide tells you how to find them, read them, and decide what to do.
+
+For the full schema and contract, see [Reference: OODA Brain Parse-Failure Record](../reference/ooda-brain-parse-failure-record.md). The engineer-lifecycle equivalent (#1711) is covered by [Diagnose OODA brain decision parse failures](./diagnose-brain-decision-parse-failures.md) — this page is its sibling for the decide / orient phases.
+
+## Step 1: Find the failing cycle
+
+Symptoms that justify reading parse-failure evidence:
+
+* A goal's `consecutive_skip` or "no progress" counter climbs every cycle even though the dashboard says recent decisions succeeded.
+* `~/.simard/cycle_reports/cycle_*.json` shows `brain_judgments[].fallback == true` for `decide` or `orient` on consecutive cycles and the new `parse_failure` block on the same record is non-null. (Pre-#1890 cycles produced the same `fallback == true` shape but no `parse_failure` key — that's the discriminator. The deterministic-bootstrap path, which is legitimate, also omits `parse_failure`.)
+* The metric jsonl shows non-zero `brain_parse_failure` counters.
+* A GitHub issue titled `OODA decide brain parse failure: goal=<id> (N consecutive)` was auto-filed against the `ESCALATION_REPO_SLUG` repo.
+
+### Tail the structured log
+
+The daemon writes to `~/.simard/logs/` on the host. Look for the constant `brain.decide parse failed` / `brain.orient parse failed` message strings — both are at `ERROR` level:
+
+```bash
+tail -F ~/.simard/logs/rustyclawd.log \
+  | grep -E 'brain\.(decide|orient) parse failed'
+```
+
+A matching line looks like:
+
+```
+ERROR simard::ooda_brain: brain.decide parse failed
+    phase="decide"
+    goal_id="improve-amplihack-test-coverage"
+    error="base type \"ooda-brain\" failed during invocation: no JSON object found in LLM response (got 3 bytes)"
+    raw_response_truncated="OK"
+    prompt_name="ooda_decide.md"
+    prompt_version="a1b2c3d4e5f6"
+    consecutive_count=2
+    retry_attempted=false
+```
+
+`raw_response_truncated` is the **complete** model response, truncated only at 8 KiB on a UTF-8 boundary (with a `…(truncated, total N bytes)` suffix if it overflowed). `prompt_name` and `prompt_version` together identify the exact prompt bytes the model saw — `cat $SIMARD_PROMPT_ASSETS_DIR/$prompt_name` recovers them. If you still see the legacy `WARN simard::ooda_brain: … no JSON object found in LLM response (got N bytes)` line **without** the `ERROR` companion, the daemon is running a pre-#1890 build; finish reading this guide and then run `simard safe-update` to pick up the fix.
+
+### Check the metric stream
+
+The `brain_parse_failure` counter lands in `~/.simard/metrics/metrics.jsonl` (single append-only file; not date-partitioned):
+
+```bash
+jq -c 'select(.metric_name == "brain_parse_failure")
+       | .context |= fromjson' \
+   ~/.simard/metrics/metrics.jsonl \
+  | tail -20
+```
+
+Each event carries `metric_name`, `value`, `timestamp`, and a `context` field that is itself a JSON string encoding `{ phase, goal_id, retry_attempted, consecutive_count }`. The `|= fromjson` step in the jq filter unwraps the inner object so the dimensions are queryable. Use this stream for "rate of failures over the last hour" questions; use the log for "what exactly did the model say" questions.
+
+### Read the cycle report
+
+Every parse-failed cycle now carries a populated `parse_failure` block on the corresponding `BrainJudgmentRecord`:
+
+```bash
+jq '.brain_judgments[]
+     | select(.parse_failure != null)
+     | { phase: .parse_failure.phase,
+         goal_id: .parse_failure.goal_id,
+         consecutive: .parse_failure.consecutive_count,
+         raw: .parse_failure.raw_response_truncated,
+         prompt: (.parse_failure.prompt_name + "@" + .parse_failure.prompt_version),
+         error: .parse_failure.error_message }' \
+   ~/.simard/cycle_reports/cycle_42.json
+```
+
+Healthy cycles have `parse_failure == null` (the field is omitted via `skip_serializing_if`, so older `cycle_*.json` files are unaffected). To list every failed cycle in the report directory:
+
+```bash
+for f in ~/.simard/cycle_reports/cycle_*.json; do
+  if jq -e '[.brain_judgments[] | select(.parse_failure != null)] | length > 0' "$f" >/dev/null; then
+    echo "$f"
+  fi
+done
+```
+
+## Step 2: Classify the response
+
+Open the `raw_response_truncated` value (from the log, the metric, or the cycle report — all three carry the same string) and match against this triage table.
+
+| `raw_response_truncated` looks like…                       | Likely cause                                                               | Action                                                                                                                       |
+|------------------------------------------------------------|----------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------|
+| `"OK"`, `"continue"`, `"yes"`                              | Model ignored the structured-output instruction; emitted a chat ack         | [Step 3 — replay the prompt](#step-3-replay-the-prompt-locally); then strengthen the prompt's role section.                  |
+| `""` (empty string)                                        | Adapter returned `Err` with no body (5xx, timeout, missing adapter)        | Check the adapter logs in `~/.simard/logs/rustyclawd.log` for a 5xx / rate-limit / timeout / "adapter unavailable" line immediately preceding the parse-failure event. `error_message` will name the underlying `SimardError` variant. |
+| Long prose without any `{` character                       | Model is in chat mode instead of structured-output mode                    | Check that the brain's adapter forces JSON mode for the configured provider.                                                 |
+| JSON that *looks* valid but parses with the same error     | Field rename or `choice` casing drift in the prompt                        | Diff `prompt_assets/simard/$prompt_name` (the value of the `prompt_name` field) against the brain's expected fields; the prompt is the contract. |
+| Markdown fence-wrapped JSON                                | The decide / orient parser is stricter than the engineer-lifecycle one     | Open a bug — the decide/orient parser is intended to tolerate fenced JSON the same way `parse_decision_from_response` does.   |
+| Partial JSON ending mid-object                             | Adapter truncated mid-stream                                               | Look for an `EOF` / `truncated stream` line in the adapter log; investigate the adapter, not the brain.                      |
+
+If `consecutive_count` is 1 or 2 and the next cycle's record shows `parse_failure == null`, the model recovered on its own and no action is required — the visibility channels exist so transient failures are *visible*, not *suppressed*.
+
+If `consecutive_count` reaches 3, the daemon has already auto-filed a GitHub issue (see Step 4); treat the failure as persistent.
+
+## Step 3: Replay the prompt locally
+
+There is no dedicated dry-run subcommand. To confirm a hypothesis without waiting for the next cycle, use the two crate-level helpers this PR exposes for exactly this purpose:
+
+```rust
+pub fn try_parse_decide_response(raw: &str)
+    -> Result<DecideJudgment, SimardError>;
+pub fn try_parse_orient_response(raw: &str)
+    -> Result<OrientJudgment, SimardError>;
+```
+
+Both helpers wrap the same parse path that `RustyClawdDecideBrain::run` / `RustyClawdOrientBrain::run` use internally. They are `pub(crate)` in the always-shipped build and re-exported `pub` under `#[cfg(any(test, feature = "ooda-brain-replay"))]`, so they're available to integration tests and ad-hoc replay binaries without widening the always-shipped public API.
+
+1. Copy `raw_response_truncated` from the cycle report (it round-trips through JSON, so newlines and quotes are already escaped — use `jq -r '.brain_judgments[].parse_failure.raw_response_truncated // empty'` to unescape).
+2. Add a one-off test to `src/ooda_brain/decide_tests.rs` (or `orient_tests.rs`):
+
+   ```rust
+   #[test]
+   fn repro_1890_OK_payload() {
+       let raw = "OK"; // <-- paste unescaped payload here
+       let result = crate::ooda_brain::try_parse_decide_response(raw);
+       eprintln!("{result:?}");
+   }
+   ```
+
+3. Run with `cargo test repro_1890_OK_payload -- --nocapture`.
+
+Discard the test before committing. The parsers have no I/O dependencies, so the replay is faithful — they read the same bytes you captured in the cycle report and return the same `SimardError` variant the call site saw in production.
+
+If you need to reproduce an *adapter*-class failure (where `raw_response_truncated == ""` because no body was returned), the replay helpers won't help — there is no body to parse. Investigate the adapter log directly; the `error_message` field of the `parse_failure` block names the underlying `SimardError` variant for cross-reference.
+
+## Step 4: Read the auto-filed issue (if any)
+
+When `consecutive_count` reaches `ISSUE_ESCALATION_THRESHOLD` (currently 3), the daemon files a GitHub issue via:
+
+```
+gh issue create
+    --repo rysweet/Simard            # compile-time ESCALATION_REPO_SLUG
+    --title "OODA decide brain parse failure: goal=<id> (3 consecutive)"
+    --body-file <NamedTempFile>      # 0600 on Unix
+    --label ooda-brain-parse-failure
+    --label auto-filed
+```
+
+The body is a markdown document containing:
+
+* The full `ParseFailureRecord` as a fenced JSON block.
+* A pointer to the relevant `cycle_N.json` filenames.
+* A short hand-off paragraph noting the threshold and how to silence further escalations (resolve the upstream cause; the counter resets on the next successful parse).
+
+Find the issue:
+
+```bash
+gh issue list --repo rysweet/Simard \
+  --label ooda-brain-parse-failure --label auto-filed \
+  --state open
+```
+
+(Forks of this codebase that rebuilt with a different `ESCALATION_REPO_SLUG` constant in `parse_failure.rs` should substitute that slug above. The slug is **not** runtime-configurable — see the reference's [Configuration section](../reference/ooda-brain-parse-failure-record.md#configuration) for why.)
+
+The escalation is **throttled per `(phase, goal_id)`**: one issue per crossing of the threshold, not one per failure. If the same goal continues to fail past the threshold, the counter keeps climbing but no second issue is filed until a successful parse resets it and a fresh streak of three occurs.
+
+## Step 5: Pick a remediation
+
+| Cause from Step 2                          | Remediation                                                                                                                |
+|--------------------------------------------|----------------------------------------------------------------------------------------------------------------------------|
+| Chat acknowledgment / wrong mode           | Edit `prompt_assets/simard/ooda_decide.md` (or `ooda_orient.md`) to strengthen the "respond ONLY with a JSON object" instruction. The `prompt_name` field of the failed `parse_failure` block names the exact file. See [edit-the-ooda-brain-prompt](edit-the-ooda-brain-prompt.md). |
+| Adapter 5xx / rate limit / timeout         | Investigate the adapter; the brain itself is healthy. The four channels exist precisely so you can attribute the failure.   |
+| Fence-wrapped JSON the parser rejected     | File a bug — the parser should match `parse_decision_from_response`'s leniency.                                              |
+| Drift in prompt vs. expected fields        | Diff the prompt against the `DecideJudgment` / `OrientJudgment` struct; the struct is the contract.                          |
+| Persistent unparseable noise from one model| Switch the provider in the brain config; the parser cannot fix a fundamentally non-cooperative model.                       |
+
+After editing a prompt, **do not** restart the daemon by hand. The prompt-asset directory under `$HOME/.simard/prompt_assets/simard/` is mtime-watched (see [Reference: prompt-driven OODA brain](../concepts/prompt-driven-ooda-brain.md)) so a file edit takes effect on the next cycle — but if the cause was code rather than prompt, you must rebuild and hot-swap:
+
+```bash
+simard safe-update
+```
+
+`safe-update` rebuilds, drains in-flight cycles, hot-swaps the binary, and verifies the new daemon is responsive — see [safe-self-update](../safe-self-update.md).
+
+## Step 6: Verify the fix
+
+After `safe-update` completes:
+
+```bash
+tail -F ~/.simard/logs/rustyclawd.log \
+  | grep -E 'goal_id="<goal-id>"'
+```
+
+You should see:
+
+* The next decide or orient cycle for the affected goal produce a non-`fallback` decision with a substantive rationale (not the legitimate `"deterministic fallback"` sentinel that fires on the no-LLM bootstrap path).
+* The `brain_parse_failure` metric stop incrementing for `(phase, goal_id)`.
+* The next `cycle_N.json` for the goal omit the `parse_failure` key entirely (`skip_serializing_if` drops it when there is no failure).
+* The counter reset — confirm by waiting for the next failure (if any) and checking that `consecutive_count` starts at 1, not at the prior value.
+
+To close the auto-filed GitHub issue:
+
+```bash
+gh issue close <issue-number> --comment \
+  "Resolved by prompt fix in <commit>. Counter reset confirmed in cycle_<N>.json."
+```
+
+## Anti-patterns
+
+The following patterns indicate the operator is **fighting** the visibility contract rather than diagnosing it. Stop and re-read the [Parse-Failure Record reference](../reference/ooda-brain-parse-failure-record.md) before proceeding:
+
+* **Restarting the daemon directly** (`kill <pid>`, `systemctl --user restart simard-ooda`) to "clear" parse failures. The counters are process-local but the cycle reports and metric jsonl are not; a bare restart loses the in-memory streak (potentially un-throttling the next `gh issue create`) but does **not** delete on-disk evidence. Always go through `simard safe-update` for any remediation that requires new code; for evidence-only investigation, do not restart at all.
+* **Suppressing the `ERROR` log line** with a `tracing` filter to "calm down" the dashboard. The line is the primary visibility channel; suppressing it returns to the pre-#1890 silent-fallback behavior with extra steps.
+* **Closing the auto-filed GitHub issue without fixing the cause.** The issue is throttled per streak; closing it does not reset the counter. If you close without fixing, the next failure beyond the threshold will not file a fresh issue until a successful parse intervenes — losing the very escalation the throttle was designed to provide.
+* **Adding a `match` arm to silently rerout a specific raw response** in `decide_with_brain` / `orient_with_brain`. The single fail-loud path is intentional; any per-raw-response branch is the silent fallback pattern returning under a new name.
+* **Removing `DeterministicFallbackDecideBrain` / `DeterministicFallbackOrientBrain` because "they look like silent fallback now."** They are the no-LLM bootstrap path; their use as silent error-swallow was what #1890 closed. Broader removal is the scope of [#1748](https://github.com/rysweet/Simard/issues/1748).
+
+## See also
+
+* [Reference: OODA Brain Parse-Failure Record](../reference/ooda-brain-parse-failure-record.md) — schema, channels, and contracts.
+* [Reference: OODA Brain Decision Protocol](../reference/ooda-brain-decision-protocol.md) — engineer-lifecycle wire format (#1711).
+* [How-to: diagnose OODA brain decision parse failures](./diagnose-brain-decision-parse-failures.md) — engineer-lifecycle equivalent of this runbook.
+* [How-to: edit the OODA brain prompt](./edit-the-ooda-brain-prompt.md) — the canonical change surface for prompt fixes.
+* [Fail-Open Audit (P5 / #1245)](../fail-open-audit.md) — broader audit context.
+* [safe-self-update](../safe-self-update.md) — the only supported way to roll a daemon to new code.

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,8 @@ Terminal sessions and repo-grounded engineer runs now bridge through one explici
 - [How to recover a corrupted or missing goal board](./howto/recover-goal-board.md) — cognitive-memory-only recovery commands.
 
 - [How to run the OODA daemon](./howto/run-ooda-daemon.md) - Start the continuous OODA loop for autonomous goal-driven operation and act on meeting decisions.
+- [How to diagnose OODA decide/orient brain parse failures](./howto/diagnose-decide-orient-parse-failures.md) - Runbook for the silent-fallback fix (#1890): find the ERROR log, read the `parse_failure` cycle-report block, and remediate.
+- [OODA brain parse-failure record reference](./reference/ooda-brain-parse-failure-record.md) - Schema and visibility contract for decide/orient brain JSON-parse failures (#1890, sibling of #1711 / #1748).
 - [Simard CLI reference](./reference/simard-cli.md) - Look up the shipped command tree, `engineer read` audit surface, and compatibility mappings.
 - [Runtime contracts reference](./reference/runtime-contracts.md) - Look up executable contracts, state-root guarantees, and the shipped engineer audit readback semantics.
 - [Base type adapters reference](./reference/base-type-adapters.md) - Look up the pluggable agent execution substrates, their capabilities, and topology support.

--- a/docs/reference/ooda-brain-parse-failure-record.md
+++ b/docs/reference/ooda-brain-parse-failure-record.md
@@ -1,0 +1,360 @@
+---
+title: OODA Brain Parse-Failure Record
+description: Normative schema and visibility contract for decide/orient brain JSON-parse failures (#1890). Companion to the engineer-lifecycle protocol (#1711) and the broader fail-open audit (#1245).
+last_updated: 2026-05-19
+review_schedule: as-needed
+owner: simard
+---
+
+# Reference: OODA Brain Parse-Failure Record
+
+Crate: `simard` · Module: `simard::ooda_brain::parse_failure`
+Closes the visibility gap that Issue [#1890](https://github.com/rysweet/Simard/issues/1890) opened. Sibling of [#1711](https://github.com/rysweet/Simard/issues/1711) (engineer-lifecycle decision protocol) and [#1748](https://github.com/rysweet/Simard/issues/1748) (silent deterministic fallback audit).
+
+This page is the normative definition of how `decide_with_brain` and `orient_with_brain` in `simard::ooda_loop` surface a brain-invocation failure (the dominant case is a JSON-parse failure; other adapter `Err` variants are covered identically — see [Scope of the record](#scope-of-the-record)). Before this contract, a brain failure produced a single `WARN` line of the form `no JSON object found in LLM response (got N bytes)` and was then silently substituted by `DeterministicFallbackDecideBrain` / `DeterministicFallbackOrientBrain`. The cycle still ran, the cycle report still claimed a decision, and the operator had no way to tell a healthy cycle from a degraded one.
+
+> **TL;DR** — Decide and orient brain failures fire four visibility channels in a fixed sequence: (1) a single `ERROR`-level structured `tracing` event, (2) a `brain_parse_failure` metric increment, (3) a new `parse_failure` block on the corresponding `BrainJudgmentRecord` (which lands in `cycle_reports/cycle_*.json`), and (4) a throttled `gh issue create` escalation at ≥3 consecutive failures per `(phase, goal_id)`. The cycle does **not** abort — it continues with a deterministic substitution whose record now carries a `parse_failure` block, so the cycle report makes the degraded state machine-readable.
+
+## Scope of the record
+
+The `_with_brain` call site for decide currently has the shape:
+
+```rust
+match brain.judge_decision(&ctx) {
+    Ok(j)  => …,
+    Err(_) => fallback.judge_decision(&ctx)?,
+}
+```
+
+and orient has:
+
+```rust
+match brain.judge_orientation(&ctx) {
+    Ok(j) if j.validate(ctx.base_urgency).is_ok() => (j, false),
+    _ => (DeterministicFallbackOrientBrain::compute(&ctx), true),
+}
+```
+
+This PR fires the four-channel record for **every `Err(_)` return from the LLM brain** at those call sites. That includes:
+
+* JSON-parse failures from `RustyClawd*Brain::run` (the dominant cause).
+* Adapter-level errors (5xx, rate-limit, timeout, missing adapter) — they reach the same `Err` arm.
+
+This PR deliberately does **not** fire the record for orient's `Ok(j) if j.validate(...).is_err()` case — that is a *structurally parsed* judgment that violated post-parse invariants. It is a different failure mode (the model cooperated; the daemon rejected the content) and is tracked separately in a follow-up issue noted in [Known limits](#known-limits). When that case is addressed, it should use the same `ParseFailureRecord` shape but a distinct `error_message` prefix (`"orient validation failed: …"`) so operators reading `cycle_*.json` can distinguish the two failure modes by string-matching on `error_message` alone.
+
+The `consecutive_count` therefore tracks consecutive *brain-invocation failures*, not strictly parse failures. The metric name (`brain_parse_failure`) is retained for back-compat with planned dashboards; a future PR may rename it once the validation-failure case is folded in.
+
+## Why a new record
+
+Before this PR, the only on-disk evidence of a parse-failed cycle was an indistinguishable `cycle_N.json` whose `brain_judgments[].fallback` was `true` and whose `rationale` was the literal `"deterministic fallback"`. That sentinel is also legitimately produced by the no-LLM bootstrap path — there was no way to tell "operator chose deterministic" from "LLM responded with `OK`". Goals would stall for hundreds of cycles before anyone noticed; the parent issue documents one case that ran 89 cycles at 0.00% completion across 13 days before the fail-open audit (#1245) caught it.
+
+The new record makes the difference **machine-detectable** and **operator-visible** in one read of one cycle file: the deterministic-fallback shape is unchanged (preserving back-compat for every existing dashboard query that filters on `fallback == true`), and the discriminator is the presence of the new `parse_failure` object. Healthy cycles and bootstrap cycles continue to serialize without the key.
+
+## The `ParseFailureRecord` schema
+
+`ParseFailureRecord` is a serde-serializable struct exported from `simard::ooda_brain::parse_failure`. It is embedded on `BrainJudgmentRecord` via a new optional field (see below).
+
+```rust
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct ParseFailureRecord {
+    /// `"decide"` or `"orient"`. Other phases (act, engineer-lifecycle)
+    /// have their own records; this struct is only emitted by the two
+    /// `_with_brain` call sites in `simard::ooda_loop`.
+    pub phase: String,
+    /// The goal under which the brain was invoked. Internal id; never a
+    /// user-controlled string.
+    pub goal_id: String,
+    /// `err.to_string()` of the `SimardError` the brain returned (the
+    /// dominant variant is `AdapterInvocationFailed`; other adapter
+    /// errors that reach the `Err(_)` arm of the `_with_brain` call site
+    /// are recorded identically — see [Scope of the record]). Uses
+    /// `Display`, never `Debug`, to avoid leaking unrelated fields from
+    /// future error variants.
+    pub error_message: String,
+    /// The complete model response (or, for non-parse `Err` variants, an
+    /// empty string when no body was returned), truncated via
+    /// `simard::util::string_truncate::truncate_to_char_boundary` at 8 KiB
+    /// on a UTF-8 boundary. Longer responses get a trailing
+    /// `…(truncated, total N bytes)` marker (see the helper's contract in
+    /// [Reference: string truncation helpers](./string-truncation-helpers.md))
+    /// so the operator can correlate against the adapter log if the full
+    /// body was captured upstream.
+    pub raw_response_truncated: String,
+    /// The name of the prompt asset the brain loaded (e.g.
+    /// `"ooda_decide.md"`, `"ooda_orient.md"`). Sourced from the
+    /// `DECIDE_PROMPT_NAME` / `ORIENT_PROMPT_NAME` `&'static str`
+    /// constants the call site already passes to
+    /// `prompt_store::current_version`. No new prompt-store API is
+    /// introduced for this field.
+    pub prompt_name: String,
+    /// 12-char sha256 prefix of the prompt-asset content that was loaded
+    /// for this brain invocation, sourced from the existing
+    /// `prompt_store::current_version(name)` helper. Empty string when
+    /// the prompt-asset directory is unreachable (`prompt_store` returns
+    /// embedded fallback content; an empty version distinguishes that
+    /// case). Together with `prompt_name`, this identifies the exact
+    /// prompt bytes the model saw without re-loading the asset.
+    pub prompt_version: String,
+    /// How many *consecutive* failures (per `(phase, goal_id)`) have
+    /// occurred up to and including this one. Resets to 0 on the next
+    /// successful parse for the same key. The `gh issue create`
+    /// escalation fires when this reaches `ISSUE_ESCALATION_THRESHOLD`
+    /// (currently 3).
+    pub consecutive_count: u32,
+    /// Reserved for future retry-with-feedback. Always `false` in this
+    /// release; the call site has at most one parse attempt per cycle.
+    /// Kept on the schema so the JSON shape is stable when retry lands.
+    pub retry_attempted: bool,
+    /// RFC 3339 UTC timestamp of the failure. Set by the
+    /// `record_parse_failure` helper, not by the call site, so all four
+    /// visibility channels agree on the moment.
+    pub timestamp: String,
+}
+```
+
+### Field-level guarantees
+
+| Field | Source | Stability |
+|---|---|---|
+| `phase` | `BrainPhase::Decide` / `Orient` lowercased | Enum-equivalent; treated as opaque bytes when used in `gh` `Command::args`. |
+| `goal_id` | Internal goal id from `OodaState` | Originates from meeting decisions and `goal-curation` commands (so is user-influenced at origin); treated as opaque bytes — only used as a `HashMap` key and as an argument to `Command::args` (never shell-interpolated, never path-joined). |
+| `error_message` | `SimardError::Display` (`err.to_string()`) | Stable across the existing `AdapterInvocationFailed { base_type, reason }` shape. `Display`, never `Debug`, so future variants that grow private fields cannot leak. |
+| `raw_response_truncated` | `let mut s = raw.to_string(); truncate_to_char_boundary(&mut s, RAW_RESPONSE_TRUNCATE_BYTES);` | UTF-8-boundary safe; in-place mutation on a `String` (the existing helper signature). |
+| `prompt_name` | `&'static str` constant the call site already passes to `prompt_store::current_version` (e.g. `DECIDE_PROMPT_NAME`) | No new prompt-store API needed. |
+| `prompt_version` | `prompt_store::current_version(prompt_name)` (12-char sha256 prefix) | Same helper the `BrainJudgmentRecord.prompt_version` field already uses; empty string means embedded fallback was served. |
+| `consecutive_count` | `Mutex<HashMap<(BrainPhase, String), u32>>` in `parse_failure` module (a `OnceLock` global) | Process-local; resets on success per `(phase, goal_id)`; cross-restart loss is acceptable and documented. |
+| `retry_attempted` | Always `false` in this release | Reserved; schema-stable for future retry-with-feedback. |
+| `timestamp` | `chrono::Utc::now().to_rfc3339()` at moment of failure | One source of truth across all four channels. |
+
+`ParseFailureRecord` deliberately holds **no `Option` fields** — every field is always populated. If `prompt_version` is unknown (embedded-fallback path), it is the empty string, not a missing key.
+
+### Why these fields and not others
+
+* **No `cycle_id`** — `cycle_N.json` already carries it on the enclosing record; embedding here would duplicate state.
+* **No `model_name` / `adapter` / `provider`** — the brain log line for the same cycle already names them; this record describes the *failure*, not the brain.
+* **No `secrets_scrubbed: bool`** — truncation is the only sanitization (see [Known limits](#known-limits)). A boolean would imply guarantees the implementation does not make.
+* **No `prompt_summary`** — earlier drafts proposed a one-line prose summary, but the existing `prompt_name` + `prompt_version` pair (both already sourced from `prompt_store`) is already sufficient to identify the exact prompt bytes, and avoids introducing a new prompt-store API (`prompt_summary(name) -> String`) just for this record. Operators who need the full prompt can `cat $SIMARD_PROMPT_ASSETS_DIR/$prompt_name` (or read the embedded fallback in `src/ooda_brain/prompt_store.rs`).
+* **No back-references to `BrainJudgmentRecord.rationale`** — the rationale field continues to hold the existing fallback rationale (`"deterministic fallback"`) so `BrainJudgmentRecord` remains self-describing for callers that don't load `parse_failure`. The `parse_failure.error_message` carries the human-readable failure detail.
+
+## `BrainJudgmentRecord` extension
+
+The existing record gains exactly one additive field:
+
+```rust
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct BrainJudgmentRecord {
+    pub phase: BrainPhase,
+    pub context_summary: String,
+    pub decision: String,
+    pub rationale: String,
+    pub confidence: f32,
+    pub fallback: bool,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub prompt_version: String,
+
+    /// Present only when this record corresponds to a brain JSON-parse
+    /// failure (decide / orient call sites). `None` on every healthy
+    /// cycle and on every deterministic-bootstrap cycle, so consumers
+    /// that don't care about parse failures see no schema change at
+    /// all. See [`ParseFailureRecord`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parse_failure: Option<ParseFailureRecord>,
+}
+```
+
+### Back-compat properties
+
+* `#[serde(default, skip_serializing_if = "Option::is_none")]` — older `cycle_*.json` files (before this PR) round-trip identically; newer files without a parse failure emit no extra key.
+* `decision` and `rationale` keep their pre-existing semantics — the deterministic substitution still populates them — so dashboards that index on `decision` continue to work.
+* `fallback` remains `true` on a parse-failure cycle for the same reason. Readers that previously branched on `fallback` get the same behavior; readers that need to distinguish operator-chosen deterministic from forced-by-failure deterministic now check `parse_failure.is_some()`.
+
+### One-line discriminator
+
+A `cycle_N.json` reader (dashboard, ad-hoc `jq`) can classify a fallback cycle in one expression:
+
+```bash
+jq '.brain_judgments[]
+    | select(.fallback == true)
+    | { phase, forced_by_parse_failure: (.parse_failure != null) }' \
+   ~/.simard/cycle_reports/cycle_42.json
+```
+
+## The four visibility channels
+
+Every call to `record_parse_failure(phase, goal_id, &err, &raw, prompt_name)` fires the four channels in a **fixed sequence**: tracing → metric → counter-increment → in-memory record returned for embedding into `BrainJudgmentRecord` → conditional `gh issue create`. The sequence is not atomic (channel 4 spawns a subprocess; channel 3 only lands on disk when `persist_cycle_report` runs at end-of-cycle), but an observer that sees channel N is guaranteed to have a record of channels `1..N−1` as well: the helper runs synchronously and only returns once channels 1, 2, and 4 (the externally observable ones) have been invoked.
+
+**Sequencing relative to the fallback brain.** The four channels fire *before* the deterministic fallback brain is invoked, so even if the fallback itself errors (the `?` propagation on `fallback.judge_decision(&ctx)?` in `decide.rs`) the parse failure has already been recorded on channels 1, 2, and 4. Only channel 3 (the on-disk `BrainJudgmentRecord`) is lost in that pathological case — the cycle never gets to call `push_brain_judgment` — but the tracing event, the metric increment, and the auto-filed issue all survive. This sequencing is asserted by a regression test that injects a failing fallback brain and verifies channels 1, 2, and 4 still fire.
+
+### 1. Structured `tracing::error!`
+
+Target: `simard::ooda_brain`. Level: `ERROR`. Shape:
+
+```
+ERROR simard::ooda_brain: brain.{phase} parse failed
+    phase="decide"
+    goal_id="improve-amplihack-test-coverage"
+    error="base type \"ooda-brain\" failed during invocation: …"
+    raw_response_truncated="OK"
+    prompt_name="ooda_decide.md"
+    prompt_version="a1b2c3d4e5f6"
+    consecutive_count=1
+    retry_attempted=false
+```
+
+The fields are emitted via `tracing`'s structured-field syntax, not interpolated into the message, so log subscribers (jsonl writer, dashboard tail) get a real key/value map. The message string itself is constant (`brain.decide parse failed` / `brain.orient parse failed`) so subscribers can `MATCH` on it without regex. Per the `target=simard::ooda_brain` namespace, operators who need to tame a pathological per-cycle failure loop on the console (without losing on-disk evidence) can subscriber-side filter on a different `MAX_LEVEL` for that target rather than touching the helper.
+
+### 2. `brain_parse_failure` metric
+
+```rust
+let ctx_json = serde_json::to_string(&serde_json::json!({
+    "phase": "decide",
+    "goal_id": &goal_id,
+    "retry_attempted": false,
+    "consecutive_count": 1u32,
+}))
+.unwrap_or_default();
+let _ = record_metric("brain_parse_failure", 1.0, &ctx_json);
+```
+
+The existing `record_metric(name: &str, value: f64, context: &str)` API (in `simard::self_metrics`) takes `context` as an opaque string; the helper above renders the structured dimensions as a JSON object inside that string, matching the convention the dashboard already uses to parse `context` back out. The return value is ignored — a metric-write failure must not abort a cycle, and channels 1 and 3 still record the event. The metric lands in `~/.simard/metrics/metrics.jsonl` (single append-only file; see `metrics_file_path()`). One counter name with dimensions (per A7 in the spec); aggregation by phase is `select(.metric_name == "brain_parse_failure") | (.context | fromjson).phase`.
+
+### 3. `BrainJudgmentRecord.parse_failure` on disk
+
+The record produced by `record_parse_failure` is wrapped into the existing `push_brain_judgment(BrainJudgmentRecord { …, parse_failure: Some(record), … })` call. `persist_cycle_report` in `operator_commands_ooda::persistence` serializes it via `serde_json::to_value` with no manual schema work — the field is on the struct, so it lands in the JSON.
+
+### 4. Throttled `gh issue create`
+
+When `consecutive_count >= ISSUE_ESCALATION_THRESHOLD` (currently `3`), the helper spawns:
+
+```rust
+std::process::Command::new("gh")
+    .args([
+        "issue", "create",
+        "--repo", ESCALATION_REPO_SLUG,     // compile-time &'static str
+        "--title", &title,                  // pre-formatted, no shell
+        "--body-file", body_path,           // NamedTempFile, never --body
+        "--label", "ooda-brain-parse-failure",
+        "--label", "auto-filed",
+    ])
+    .status()
+```
+
+The title pattern is `OODA decide brain parse failure: goal=<id> (N consecutive)`; the body is a `tempfile::NamedTempFile`-backed markdown file containing the full `ParseFailureRecord` serialized as a fenced JSON block plus a short hand-off paragraph. **No shell interpolation, ever** — see [Security](#security).
+
+`ESCALATION_REPO_SLUG` is a compile-time `&'static str` constant (`"rysweet/Simard"` in this repo) defined alongside `ISSUE_ESCALATION_THRESHOLD`. This matches the existing `--repo` pattern used by `stewardship/merge_authority.rs` and `worktree_gc/runner.rs` — the slug is passed positionally to `Command::args`, never interpolated into a shell string. Forks rebuilding this binary must edit the constant; this is intentional, so escalations cannot be silently redirected by an env var or runtime flag.
+
+## Operator-visible decision tree
+
+```
+                    LLM brain returns…
+                          │
+            ┌─────────────┴──────────────┐
+        Ok(judgment)              Err(AdapterInvocationFailed{…})
+            │                             │
+            ▼                             ▼
+   continue cycle             record_parse_failure(…)
+   parse_failure = None              │
+                                     ├─► tracing::error!  (ch.1)
+                                     ├─► record_metric   (ch.2)
+                                     ├─► BrainJudgmentRecord.parse_failure = Some(_)  (ch.3)
+                                     ├─► counter[ (phase, goal_id) ] += 1
+                                     │       │
+                                     │       └─► if ≥3:  gh issue create  (ch.4)
+                                     │
+                                     ▼
+                          DeterministicFallback*Brain
+                          (cycle continues; BrainJudgmentRecord keeps its
+                           existing fallback shape — fallback: true,
+                           rationale: "deterministic fallback",
+                           prompt_version: "" — but the new
+                           parse_failure: Some(_) field is the
+                           machine-readable discriminator.)
+```
+
+On the **next** successful parse for the same `(phase, goal_id)`, the counter is reset to `0`. The threshold therefore means *three in a row*, not *three in this cycle's lifetime*.
+
+## Configuration
+
+None. No new env var, CLI flag, or `~/.simard/config` key is introduced. The visibility channels are non-opt-out by design — silencing them was the bug that #1890 closes. Three compile-time constants live in `parse_failure.rs` for reviewers:
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `RAW_RESPONSE_TRUNCATE_BYTES` | `8192` | Cap fed to `truncate_to_char_boundary`. Matches the existing helper's default for `~/.simard/logs` protection. |
+| `ISSUE_ESCALATION_THRESHOLD` | `3` | Mirror of `spawn_engineer`/`#1711` throttle (see A6). |
+| `ESCALATION_REPO_SLUG` | `"rysweet/Simard"` | `--repo` target for `gh issue create`. Forks must edit at compile time. |
+
+Operators who want to disable the `gh issue create` channel (e.g., on an air-gapped daemon) should ensure the `gh` binary is not on `PATH`; the spawn fails fast, the failure is itself logged at `WARN`, and the other three channels continue unaffected. There is intentionally no "silence the issue filer" boolean — see [#1245](https://github.com/rysweet/Simard/issues/1245).
+
+## Cycle-report shape
+
+A `cycle_N.json` produced by a cycle that hit a decide-brain parse failure now contains a `brain_judgments` entry shaped as:
+
+```json
+{
+  "phase": "decide",
+  "context_summary": "goal=improve-amplihack-test-coverage; urgency=…; reason=…",
+  "decision": "advance_goal",
+  "rationale": "deterministic fallback",
+  "confidence": 0.5,
+  "fallback": true,
+  "prompt_version": "",
+  "parse_failure": {
+    "phase": "decide",
+    "goal_id": "improve-amplihack-test-coverage",
+    "error_message": "base type \"ooda-brain\" failed during invocation: no JSON object found in LLM response (got 3 bytes)",
+    "raw_response_truncated": "OK",
+    "prompt_name": "ooda_decide.md",
+    "prompt_version": "a1b2c3d4e5f6",
+    "consecutive_count": 1,
+    "retry_attempted": false,
+    "timestamp": "2026-05-19T04:44:26.848Z"
+  }
+}
+```
+
+The `decision`, `rationale`, `confidence`, `fallback`, and `prompt_version` fields keep the values that `BrainJudgmentRecord::from_decide(..., fallback=true, prompt_version="")` (the existing fallback path) already produces — this PR does **not** introduce a synthetic `"deterministic-fallback (forced)"` label or rewrite the rationale. The `parse_failure.is_some()` discriminator is the single signal operators and dashboards use to distinguish "operator deliberately ran without an LLM brain" (no `parse_failure` key) from "LLM brain failed and the deterministic floor caught it" (`parse_failure` present). Note that `prompt_version` on the outer record is empty here because the fallback brain doesn't read a prompt asset; the `parse_failure.prompt_version` field carries the version of the LLM brain's prompt that produced the unparseable response.
+
+Healthy cycles serialize **byte-for-byte identically** to the pre-PR shape: the `parse_failure` key is omitted via `skip_serializing_if`. The TR4 regression test fixture pins this property.
+
+## Security
+
+* **`gh` invocation discipline.** All `gh issue create` calls use `Command::args([...])` with positional arguments. Bodies are passed via `--body-file <NamedTempFile>` (RAII-cleaned), not `--body` with `format!()`. The codebase contains an explicit grep-based test (`gh_issue_invocation_uses_arg_array_not_shell`) that fails CI if any caller composes a `gh` invocation from an interpolated string.
+* **Tempfile mode.** `tempfile::NamedTempFile::new()` creates the body file with mode `0600` on Unix (the crate's documented default; the open uses `O_CREAT | O_EXCL` and chmod-on-create). A regression test (`gh_body_tempfile_is_0600`) opens the file via `metadata().permissions().mode()` and asserts the low 9 bits are `0o600`, so a future tempfile-crate change or platform port can't silently relax this.
+* **Display, not Debug.** `error_message` is `err.to_string()`. Future `SimardError` variants that grow sensitive fields cannot leak into the record via `{:?}`.
+* **Truncation as sanitization.** `raw_response_truncated` is `truncate_to_char_boundary(&mut s, 8192)`. No regex secret-scrubbing — see [Known limits](#known-limits).
+* **No new auth surface.** The `gh` channel reuses the operator's pre-existing `GH_TOKEN` / `gh auth` configuration. No new credential file, no new env var.
+* **Process-local counter.** The `(phase, goal_id) → u32` map lives behind `Mutex<HashMap<…>>` (in a `OnceLock`) to prevent a race when decide and orient fail for the same goal in the same cycle (SR7). Cross-restart counter loss is documented and accepted — the worst case is one extra `gh issue` per daemon restart loop, also documented in the PR body.
+* **JSON-injection resistance.** `ParseFailureRecord` is built as a typed struct and serialized via `serde_json` — no manual string concatenation into JSON. The `parse_failure_record_serializes_safely_with_quotes_and_braces` regression test feeds a `raw_response_truncated` containing `"}` and asserts the resulting JSON round-trips.
+
+## Known limits
+
+* **No secret scrubbing of LLM output.** Per A9 in the requirements, `raw_response_truncated` contains whatever the model returned, truncated only. The model is reading our prompt; secret exposure in its *response* is low-probability in practice. If a leak class emerges, it will be addressed separately — there is no module-level toggle to add scrubbing.
+* **No retry-with-feedback in this release.** The `retry_attempted` field is reserved and always `false`. A future PR can wire a single-attempt retry through the brain trait without changing this record's JSON shape.
+* **Counter is process-local.** Daemon restart resets all `(phase, goal_id)` counters to zero. A pathological restart loop could file one issue per (3 × restart). Operators who see this should investigate the restart loop, not the threshold.
+* **Counter map is unbounded.** The `(BrainPhase, String) → u32` map is keyed by `goal_id` and pruned only by successful-parse reset, not by absolute time or size. For daemons with unbounded goal cardinality the map grows monotonically (bounded only by distinct `goal_id` count per process lifetime). In practice goal cardinality is small (top-5 active + backlog) and daemon process lifetimes are bounded by `safe-update`, so no eviction logic is gated. If a future deployment shape changes this, an LRU cap is the obvious next step and does not change the JSON shape.
+* **`gh` is best-effort.** If `gh` is missing, unauthenticated, or rate-limited, the spawn failure is logged at `WARN` and the other three channels still fire. The cycle does not block on the network.
+* **Tracing-flood self-limiting.** A pathological per-cycle failure produces one `ERROR` line per cycle (one per phase). At default cycle cadence this is bounded by the cycle pacing, not by an in-helper rate limit; operators who need a louder cap can subscriber-side filter `target=simard::ooda_brain` to a lower level. The `gh` channel's per-`(phase, goal_id)` throttle (A6) is the protection against issue-tracker flooding; the tracing channel intentionally remains uncapped so the on-disk evidence is complete.
+* **Validation-failure case not covered.** The orient call site collapses `Ok(j) if j.validate(...).is_err()` into the same `_ =>` deterministic-substitution arm. This PR fires the record for `Err(_)` only, not for `Ok-but-invalid`. The latter is a structurally separate failure mode tracked in a follow-up issue; when addressed it should reuse `ParseFailureRecord` with an `error_message` prefix of `"orient validation failed: …"` to keep operator tooling unchanged.
+* **Deterministic-fallback brains are unchanged.** This PR does **not** remove `DeterministicFallbackDecideBrain` / `DeterministicFallbackOrientBrain`. They are still the legitimate substitute for the no-LLM bootstrap path (operator deliberately ran the daemon without an LLM brain configured). Removing them is the scope of [#1748](https://github.com/rysweet/Simard/issues/1748), explicitly out of scope here.
+
+## Operator replay surface
+
+To let operators reproduce a parse failure without re-running the daemon, this PR exposes two `pub(crate)` helpers (re-exported `pub` under `#[cfg(any(test, feature = "ooda-brain-replay"))]` so they are available to integration tests and ad-hoc replay binaries without widening the always-shipped public API):
+
+```rust
+pub fn try_parse_decide_response(raw: &str)
+    -> Result<DecideJudgment, SimardError>;
+pub fn try_parse_orient_response(raw: &str)
+    -> Result<OrientJudgment, SimardError>;
+```
+
+Both helpers wrap the same parse path that `RustyClawdDecideBrain::run` / `RustyClawdOrientBrain::run` use internally. They take a `&str` matching the `raw_response_truncated` field shape and return either a typed judgment or the same `SimardError::AdapterInvocationFailed` variant the call site sees in production. Operator-replay use is documented in the [how-to guide](../howto/diagnose-decide-orient-parse-failures.md#step-3-replay-the-prompt-locally). These helpers are the only new public surface this PR introduces beyond `ParseFailureRecord` and the `parse_failure` field on `BrainJudgmentRecord`.
+
+## See also
+
+* [How-to: diagnose decide/orient brain parse failures](../howto/diagnose-decide-orient-parse-failures.md) — operator runbook for the new logs, metric, and `cycle_*.json` shape.
+* [Reference: OODA Brain Decision Protocol](./ooda-brain-decision-protocol.md) — sibling visibility contract for the engineer-lifecycle brain (#1711).
+* [How-to: diagnose OODA brain decision parse failures](../howto/diagnose-brain-decision-parse-failures.md) — engineer-lifecycle equivalent of this PR's runbook.
+* [Fail-Open Audit (P5 / #1245)](../fail-open-audit.md) — broader audit that this PR partially discharges.
+* [Reference: `OodaBrain` API](./ooda-brain-api.md) — public surface of the brain trait, unchanged by this PR.
+* [Reference: string truncation helpers](./string-truncation-helpers.md) — `truncate_to_char_boundary` UTF-8 contract.

--- a/src/ooda_brain/judgment_record.rs
+++ b/src/ooda_brain/judgment_record.rs
@@ -20,12 +20,12 @@
 
 use std::cell::RefCell;
 
-use super::{DecideJudgment, EngineerLifecycleDecision, OrientJudgment};
+use super::{DecideJudgment, EngineerLifecycleDecision, OrientJudgment, ParseFailureRecord};
 
 /// Which OODA phase produced the judgment. Serialised as lowercase strings
 /// so the cycle-report JSON consumers (dashboard, ad-hoc inspection) read
 /// `"act"`, `"decide"`, `"orient"`.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum BrainPhase {
     Act,
@@ -59,6 +59,13 @@ pub struct BrainJudgmentRecord {
     /// Default-skipped on serialise so older cycle reports stay readable.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub prompt_version: String,
+    /// Present only when this record corresponds to a brain JSON-parse
+    /// failure (decide / orient call sites). `None` on every healthy cycle
+    /// and on every deterministic-bootstrap cycle, so consumers that don't
+    /// care about parse failures see no schema change at all. See
+    /// [`ParseFailureRecord`] and `docs/reference/ooda-brain-parse-failure-record.md`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parse_failure: Option<ParseFailureRecord>,
 }
 
 const CONTEXT_SUMMARY_MAX: usize = 200;
@@ -109,6 +116,7 @@ impl BrainJudgmentRecord {
             confidence: if fallback { 0.5 } else { 1.0 },
             fallback,
             prompt_version: prompt_version.into(),
+            parse_failure: None,
         }
     }
 
@@ -140,6 +148,7 @@ impl BrainJudgmentRecord {
             confidence: if fallback { 0.5 } else { 1.0 },
             fallback,
             prompt_version: prompt_version.into(),
+            parse_failure: None,
         }
     }
 
@@ -168,6 +177,7 @@ impl BrainJudgmentRecord {
             confidence: judgment.confidence as f32,
             fallback,
             prompt_version: prompt_version.into(),
+            parse_failure: None,
         }
     }
 }
@@ -234,6 +244,7 @@ mod tests {
             confidence: 0.75,
             fallback: false,
             prompt_version: "deadbeef1234".to_string(),
+            parse_failure: None,
         };
         let json = serde_json::to_string(&rec).unwrap();
         assert!(json.contains("\"phase\":\"decide\""));
@@ -254,6 +265,7 @@ mod tests {
             confidence: 0.5,
             fallback: true,
             prompt_version: String::new(),
+            parse_failure: None,
         };
         let json = serde_json::to_string(&rec).unwrap();
         assert!(
@@ -330,6 +342,7 @@ mod tests {
                     confidence: 1.0,
                     fallback: false,
                     prompt_version: String::new(),
+                    parse_failure: None,
                 });
                 push(BrainJudgmentRecord {
                     phase: BrainPhase::Decide,
@@ -339,6 +352,7 @@ mod tests {
                     confidence: 1.0,
                     fallback: false,
                     prompt_version: String::new(),
+                    parse_failure: None,
                 });
 
                 let drained = take_all();
@@ -355,6 +369,7 @@ mod tests {
                     confidence: 1.0,
                     fallback: false,
                     prompt_version: String::new(),
+                    parse_failure: None,
                 });
                 clear();
                 assert!(take_all().is_empty());
@@ -372,6 +387,7 @@ mod tests {
             confidence: 1.0,
             fallback: false,
             prompt_version: String::new(),
+            parse_failure: None,
         });
         assert!(take_all().is_empty());
     }
@@ -389,6 +405,7 @@ mod tests {
                 confidence: 1.0,
                 fallback: false,
                 prompt_version: String::new(),
+                parse_failure: None,
             });
             take_all()
         }));
@@ -419,6 +436,7 @@ mod tests {
                     confidence: 1.0,
                     fallback: false,
                     prompt_version: String::new(),
+                    parse_failure: None,
                 });
             }
             tokio::task::yield_now().await;

--- a/src/ooda_brain/mod.rs
+++ b/src/ooda_brain/mod.rs
@@ -20,6 +20,7 @@ mod decide;
 mod fallback;
 mod judgment_record;
 mod orient;
+pub mod parse_failure;
 pub mod prompt_store;
 mod rustyclawd;
 
@@ -47,6 +48,7 @@ pub use orient::{
     OrientContext, OrientJudgment, PROMPT_NAME as ORIENT_PROMPT_NAME, RustyClawdOrientBrain,
     build_rustyclawd_orient_brain,
 };
+pub use parse_failure::ParseFailureRecord;
 pub use rustyclawd::{
     LlmSubmitter, PROMPT_NAME as ACT_PROMPT_NAME, RustyClawdBrain, SessionLlmSubmitter,
     build_rustyclawd_brain,

--- a/src/ooda_brain/parse_failure.rs
+++ b/src/ooda_brain/parse_failure.rs
@@ -15,12 +15,10 @@
 //!      `BrainJudgmentRecord.parse_failure` field that lands in
 //!      `~/.simard/cycle_reports/cycle_*.json`.
 //!   4. Throttled `gh issue create` at `>= ISSUE_ESCALATION_THRESHOLD`
-//!      consecutive failures per `(phase, goal_id)`.
-//!
-//! The module is **stub-only** in this commit (Step 7 — TDD). The behaviour
-//! is pinned by the failing tests in `src/ooda_loop/tests_parse_failure_1890.rs`
-//! and `src/ooda_brain/parse_failure_tests.rs`. Step 8 will wire the four
-//! channels through the two call sites.
+//!      consecutive failures per `(phase, goal_id)`. Mirrors the
+//!      deterministic-safeguard escalation in
+//!      `src/ooda_actions/advance_goal/spawn.rs` (PR #1711) so reviewers can
+//!      cross-reference the pattern.
 
 use std::collections::HashMap;
 use std::sync::{Mutex, OnceLock};
@@ -91,7 +89,6 @@ pub struct ParseFailureRecord {
 /// [`reset_consecutive_count`] on the next successful parse for the same key.
 /// Documented cross-restart loss is acceptable — worst case is one extra
 /// `gh issue` per daemon restart loop, which is itself a signal worth investigating.
-#[allow(dead_code)] // Step 8 wires this into the _with_brain call sites.
 fn counters() -> &'static Mutex<HashMap<(BrainPhase, String), u32>> {
     static CTRS: OnceLock<Mutex<HashMap<(BrainPhase, String), u32>>> = OnceLock::new();
     CTRS.get_or_init(|| Mutex::new(HashMap::new()))
@@ -99,7 +96,6 @@ fn counters() -> &'static Mutex<HashMap<(BrainPhase, String), u32>> {
 
 /// Increment the `(phase, goal_id)` counter and return the new value.
 /// `pub(crate)` so the `_with_brain` call sites can call this directly.
-#[allow(dead_code)] // Step 8 wires this into the _with_brain call sites.
 pub(crate) fn bump_consecutive_count(phase: BrainPhase, goal_id: &str) -> u32 {
     let mut guard = counters()
         .lock()
@@ -111,7 +107,6 @@ pub(crate) fn bump_consecutive_count(phase: BrainPhase, goal_id: &str) -> u32 {
 
 /// Reset the `(phase, goal_id)` counter to 0 (called on the next successful
 /// parse for the same key).
-#[allow(dead_code)] // Step 8 wires this into the _with_brain call sites.
 pub(crate) fn reset_consecutive_count(phase: BrainPhase, goal_id: &str) {
     let mut guard = counters()
         .lock()
@@ -151,15 +146,22 @@ pub(crate) fn reset_consecutive_count_for_tests(phase: BrainPhase, goal_id: &str
     reset_consecutive_count(phase, goal_id);
 }
 
-/// Build a [`ParseFailureRecord`] for a brain-invocation failure and fire the
-/// four visibility channels (tracing, metric, return-for-embed, conditional
-/// `gh issue create`).
+/// Build a [`ParseFailureRecord`] for a brain-invocation failure and fire all
+/// four visibility channels:
 ///
-/// STEP 7 STATUS: stub. This implementation only constructs the record and
-/// bumps the counter — it does NOT yet fire tracing, the metric, or `gh`.
-/// The TDD tests assert the wired behaviour; they fail until Step 8 lands
-/// the real implementation.
-#[allow(dead_code)] // Step 8 wires this into the _with_brain call sites.
+///   1. `tracing::error!` with structured fields for `journalctl` / log
+///      aggregators (target `simard::ooda_brain`).
+///   2. `record_metric("brain_parse_failure", 1.0, …)` to
+///      `~/.simard/metrics/metrics.jsonl`. Metric write failures are logged
+///      but never swallow the parse-failure — the caller still gets the record.
+///   3. Returns the [`ParseFailureRecord`] for embedding on the
+///      `BrainJudgmentRecord` that lands in `cycle_*.json`.
+///   4. Conditional `gh issue create` once `consecutive_count` for the
+///      `(phase, goal_id)` reaches [`ISSUE_ESCALATION_THRESHOLD`]. Suppressed
+///      under `#[cfg(test)]` so tests can drive the counter without
+///      spawning real `gh` processes; suppressed in production when
+///      `SIMARD_BRAIN_PARSE_FAILURE_NO_ESCALATE=1` so operators have an
+///      escape hatch during incident response.
 pub(crate) fn record_parse_failure(
     phase: BrainPhase,
     goal_id: &str,
@@ -188,13 +190,171 @@ pub(crate) fn record_parse_failure(
         timestamp: chrono::Utc::now().to_rfc3339(),
     };
 
-    // STEP 8 wires the four channels here. Stub on purpose so TDD tests
-    // can drive the wire-up.
+    // Channel 1: tracing::error! with structured fields. Operators following
+    // `docs/howto/diagnose-decide-orient-parse-failures.md` grep for
+    // `target=simard::ooda_brain` to surface this.
+    tracing::error!(
+        target: "simard::ooda_brain",
+        phase = %record.phase,
+        goal_id = %record.goal_id,
+        error = %record.error_message,
+        raw_response_truncated = %record.raw_response_truncated,
+        prompt_name = %record.prompt_name,
+        prompt_version = %record.prompt_version,
+        consecutive_count = record.consecutive_count,
+        retry_attempted = record.retry_attempted,
+        "brain parse failed — falling back to deterministic floor (issue #1890)",
+    );
+
+    // Channel 2: metrics.jsonl counter with structured context. We don't
+    // hold an `Arc<MetricsWriter>` so call the free function; failures are
+    // best-effort (the parse failure itself is the high-priority signal).
+    let metric_ctx = serde_json::json!({
+        "phase": record.phase,
+        "goal_id": record.goal_id,
+        "consecutive_count": record.consecutive_count,
+        "retry_attempted": record.retry_attempted,
+        "prompt_name": record.prompt_name,
+    })
+    .to_string();
+    if let Err(metric_err) =
+        crate::self_metrics::record_metric("brain_parse_failure", 1.0, &metric_ctx)
+    {
+        tracing::warn!(
+            target: "simard::ooda_brain",
+            error = %metric_err,
+            "record_metric(brain_parse_failure) failed (parse-failure record still emitted)",
+        );
+    }
+
+    // Channel 4: throttled gh-issue escalation at >= threshold.
+    if consecutive_count >= ISSUE_ESCALATION_THRESHOLD {
+        maybe_escalate_to_gh_issue(&record);
+    }
 
     record
 }
 
-#[allow(dead_code)] // Step 8 wires this into the _with_brain call sites.
+/// File a tracking issue when a `(phase, goal_id)` pair has crossed
+/// [`ISSUE_ESCALATION_THRESHOLD`] consecutive parse failures. Mirrors the
+/// `spawn_engineer` deterministic-safeguard pattern from PR #1711.
+///
+/// Suppressed under `#[cfg(test)]` so the TDD suite can drive the counter
+/// to high values without spawning real `gh` subprocesses. Operators can
+/// also disable in production by exporting
+/// `SIMARD_BRAIN_PARSE_FAILURE_NO_ESCALATE=1` (e.g. during incident
+/// response when the issue tracker would be flooded).
+fn maybe_escalate_to_gh_issue(record: &ParseFailureRecord) {
+    if cfg!(test) {
+        return;
+    }
+    if std::env::var("SIMARD_BRAIN_PARSE_FAILURE_NO_ESCALATE").is_ok() {
+        tracing::warn!(
+            target: "simard::ooda_brain",
+            phase = %record.phase,
+            goal_id = %record.goal_id,
+            consecutive_count = record.consecutive_count,
+            "gh-issue escalation suppressed by SIMARD_BRAIN_PARSE_FAILURE_NO_ESCALATE",
+        );
+        return;
+    }
+
+    let title = format!(
+        "OODA {} brain parse-failure on goal '{}' ({} consecutive cycles)",
+        record.phase, record.goal_id, record.consecutive_count
+    );
+    let body = format!(
+        "The OODA `{}` brain has failed to parse a valid judgment for goal `{}` for \
+         {} consecutive cycles.\n\n\
+         **Latest error:**\n```\n{}\n```\n\n\
+         **Raw model response (truncated to {} bytes):**\n```\n{}\n```\n\n\
+         **Prompt asset:** `{}` (version `{}`)\n\
+         **Timestamp:** {}\n\n\
+         Inspect the brain logs (`journalctl -u simard | grep simard::ooda_brain`) and \
+         the prompt asset before reactivating. See \
+         `docs/howto/diagnose-decide-orient-parse-failures.md` for the operator runbook.\n\n\
+         Filed deterministically by `src/ooda_brain/parse_failure.rs` (issue #1890).\n\
+         To suppress further escalations during incident response, export \
+         `SIMARD_BRAIN_PARSE_FAILURE_NO_ESCALATE=1`.",
+        record.phase,
+        record.goal_id,
+        record.consecutive_count,
+        record.error_message,
+        RAW_RESPONSE_TRUNCATE_BYTES,
+        record.raw_response_truncated,
+        record.prompt_name,
+        record.prompt_version,
+        record.timestamp,
+    );
+
+    // Use --body-file with a NamedTempFile so large/escape-laden bodies
+    // can't fail the spawn (same pattern as merge_authority.rs / spawn.rs).
+    let body_file = match tempfile::NamedTempFile::new() {
+        Ok(f) => f,
+        Err(e) => {
+            tracing::error!(
+                target: "simard::ooda_brain",
+                phase = %record.phase,
+                goal_id = %record.goal_id,
+                error = %e,
+                "deterministic safeguard: NamedTempFile for gh issue body FAILED (parse-failure record still emitted)",
+            );
+            return;
+        }
+    };
+    if let Err(e) = std::fs::write(body_file.path(), &body) {
+        tracing::error!(
+            target: "simard::ooda_brain",
+            phase = %record.phase,
+            goal_id = %record.goal_id,
+            error = %e,
+            "deterministic safeguard: writing gh issue body to tempfile FAILED",
+        );
+        return;
+    }
+
+    match std::process::Command::new("gh")
+        .args([
+            "issue",
+            "create",
+            "--repo",
+            ESCALATION_REPO_SLUG,
+            "--title",
+            &title,
+            "--body-file",
+            &body_file.path().to_string_lossy(),
+            "--label",
+            "ooda-brain-parse-failure",
+        ])
+        .output()
+    {
+        Ok(out) if out.status.success() => {
+            eprintln!(
+                "[simard] DETERMINISTIC SAFEGUARD: gh issue filed for {} brain parse-failure on goal '{}' ({} consecutive cycles)",
+                record.phase, record.goal_id, record.consecutive_count,
+            );
+        }
+        Ok(out) => {
+            tracing::error!(
+                target: "simard::ooda_brain",
+                phase = %record.phase,
+                goal_id = %record.goal_id,
+                stderr = %String::from_utf8_lossy(&out.stderr),
+                "deterministic safeguard: gh issue create FAILED (parse-failure record still emitted)",
+            );
+        }
+        Err(io_err) => {
+            tracing::error!(
+                target: "simard::ooda_brain",
+                phase = %record.phase,
+                goal_id = %record.goal_id,
+                error = %io_err,
+                "deterministic safeguard: gh process spawn FAILED (parse-failure record still emitted)",
+            );
+        }
+    }
+}
+
 fn phase_to_string(phase: BrainPhase) -> String {
     match phase {
         BrainPhase::Act => "act".to_string(),
@@ -305,7 +465,7 @@ mod tests {
         // characters must not be truncated mid-codepoint (would panic in
         // s.truncate() on bad boundary).
 
-        let multibyte: String = std::iter::repeat('字').take(5000).collect();
+        let multibyte: String = "字".repeat(5000);
         let err = sample_err();
         let rec = record_parse_failure(
             BrainPhase::Decide,

--- a/src/ooda_brain/parse_failure.rs
+++ b/src/ooda_brain/parse_failure.rs
@@ -1,0 +1,474 @@
+//! Parse-failure visibility for decide/orient brain invocations (issue #1890).
+//!
+//! Closes the silent-fallback gap that #1890 documented: before this module,
+//! `decide_with_brain` and `orient_with_brain` swallowed every `Err(_)` from
+//! the LLM brain into the deterministic fallback with no visible record. The
+//! cycle still ran, `cycle_N.json` still showed a decision, and goals could
+//! stall for days at 0.00% before anyone noticed.
+//!
+//! This module owns the **four visibility channels** that every brain
+//! parse-failure now fires (see `docs/reference/ooda-brain-parse-failure-record.md`):
+//!
+//!   1. `tracing::error!` (target `simard::ooda_brain`) with structured fields.
+//!   2. `record_metric("brain_parse_failure", 1.0, …)` to `~/.simard/metrics/metrics.jsonl`.
+//!   3. A [`ParseFailureRecord`] returned to the call site, embedded in the
+//!      `BrainJudgmentRecord.parse_failure` field that lands in
+//!      `~/.simard/cycle_reports/cycle_*.json`.
+//!   4. Throttled `gh issue create` at `>= ISSUE_ESCALATION_THRESHOLD`
+//!      consecutive failures per `(phase, goal_id)`.
+//!
+//! The module is **stub-only** in this commit (Step 7 — TDD). The behaviour
+//! is pinned by the failing tests in `src/ooda_loop/tests_parse_failure_1890.rs`
+//! and `src/ooda_brain/parse_failure_tests.rs`. Step 8 will wire the four
+//! channels through the two call sites.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+
+use super::BrainPhase;
+
+/// Cap fed to `truncate_to_char_boundary` for `raw_response_truncated`.
+/// Matches the existing 8 KiB cap used by `truncate_for_log_pub` in
+/// `rustyclawd.rs` so the same body limit applies to both the legacy log
+/// path and the new on-disk record (resolution A8).
+pub const RAW_RESPONSE_TRUNCATE_BYTES: usize = 8192;
+
+/// Throttle threshold for the `gh issue create` channel. Mirrors the
+/// `spawn_engineer` precedent from PR #1711 (resolution A6).
+pub const ISSUE_ESCALATION_THRESHOLD: u32 = 3;
+
+/// `--repo` slug for `gh issue create`. Compile-time constant so escalations
+/// cannot be silently redirected by an env var; forks rebuilding this binary
+/// must edit the constant. Matches the pattern in `stewardship/merge_authority.rs`.
+pub const ESCALATION_REPO_SLUG: &str = "rysweet/Simard";
+
+/// One brain-invocation failure record, embedded on `BrainJudgmentRecord`.
+///
+/// Every field is always populated — there are no `Option` fields. Operators
+/// that need to distinguish "absent" from "empty string" can use `prompt_version`
+/// (empty means the prompt-store served the embedded fallback).
+///
+/// See `docs/reference/ooda-brain-parse-failure-record.md` for the full
+/// schema rationale.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ParseFailureRecord {
+    /// `"decide"` or `"orient"`. Lowercased to match `BrainPhase` serde.
+    pub phase: String,
+    /// Internal goal id (never a user-controlled string at the call site;
+    /// origin via meeting decisions / goal-curation is documented as
+    /// opaque-bytes for `Command::args`).
+    pub goal_id: String,
+    /// `err.to_string()` of the `SimardError` the brain returned — `Display`,
+    /// never `Debug`, so future `SimardError` variants that grow private
+    /// fields cannot leak.
+    pub error_message: String,
+    /// The complete model response, truncated via
+    /// `truncate_to_char_boundary` at [`RAW_RESPONSE_TRUNCATE_BYTES`] on a
+    /// UTF-8 boundary. Empty for non-parse `Err` variants where no body
+    /// was returned.
+    pub raw_response_truncated: String,
+    /// Prompt asset name (`"ooda_decide.md"` / `"ooda_orient.md"`). Sourced
+    /// from the existing `DECIDE_PROMPT_NAME` / `ORIENT_PROMPT_NAME`
+    /// `&'static str` constants the call site already has.
+    pub prompt_name: String,
+    /// 12-char sha256 prefix of the prompt-asset content the brain loaded
+    /// (`prompt_store::current_version`). Empty when the embedded fallback
+    /// was served.
+    pub prompt_version: String,
+    /// Consecutive `(phase, goal_id)` parse failures up to and including
+    /// this one. Resets to 0 on the next successful parse for the same key.
+    pub consecutive_count: u32,
+    /// Reserved for future retry-with-feedback. Always `false` in this
+    /// release; the JSON shape is kept stable so retry can land without
+    /// a schema bump.
+    pub retry_attempted: bool,
+    /// RFC 3339 UTC timestamp of the failure. Set by [`record_parse_failure`]
+    /// so all four channels agree on the moment.
+    pub timestamp: String,
+}
+
+/// Process-local `(phase, goal_id) -> consecutive_count` map. Reset to 0 by
+/// [`reset_consecutive_count`] on the next successful parse for the same key.
+/// Documented cross-restart loss is acceptable — worst case is one extra
+/// `gh issue` per daemon restart loop, which is itself a signal worth investigating.
+#[allow(dead_code)] // Step 8 wires this into the _with_brain call sites.
+fn counters() -> &'static Mutex<HashMap<(BrainPhase, String), u32>> {
+    static CTRS: OnceLock<Mutex<HashMap<(BrainPhase, String), u32>>> = OnceLock::new();
+    CTRS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Increment the `(phase, goal_id)` counter and return the new value.
+/// `pub(crate)` so the `_with_brain` call sites can call this directly.
+#[allow(dead_code)] // Step 8 wires this into the _with_brain call sites.
+pub(crate) fn bump_consecutive_count(phase: BrainPhase, goal_id: &str) -> u32 {
+    let mut guard = counters()
+        .lock()
+        .expect("parse_failure counter mutex poisoned");
+    let entry = guard.entry((phase, goal_id.to_string())).or_insert(0);
+    *entry = entry.saturating_add(1);
+    *entry
+}
+
+/// Reset the `(phase, goal_id)` counter to 0 (called on the next successful
+/// parse for the same key).
+#[allow(dead_code)] // Step 8 wires this into the _with_brain call sites.
+pub(crate) fn reset_consecutive_count(phase: BrainPhase, goal_id: &str) {
+    let mut guard = counters()
+        .lock()
+        .expect("parse_failure counter mutex poisoned");
+    guard.remove(&(phase, goal_id.to_string()));
+}
+
+/// Test-only: peek at the current count without mutating it.
+#[cfg(test)]
+pub(crate) fn peek_consecutive_count(phase: BrainPhase, goal_id: &str) -> u32 {
+    let guard = counters()
+        .lock()
+        .expect("parse_failure counter mutex poisoned");
+    guard
+        .get(&(phase, goal_id.to_string()))
+        .copied()
+        .unwrap_or(0)
+}
+
+/// Test-only: serialize tests that need a known starting state by holding a
+/// shared mutex for the duration of the test. Returning a guard scopes the
+/// lock to the caller. Required because the `(phase, goal_id) -> count` map
+/// is process-global and `cargo test` runs tests in parallel.
+#[cfg(test)]
+pub(crate) fn test_serial_guard() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .expect("parse_failure test mutex poisoned")
+}
+
+/// Test-only: clear a specific `(phase, goal_id)` entry. Scoped clearance is
+/// safer than a global wipe because a global wipe can race with concurrent
+/// tests that touch unrelated keys.
+#[cfg(test)]
+pub(crate) fn reset_consecutive_count_for_tests(phase: BrainPhase, goal_id: &str) {
+    reset_consecutive_count(phase, goal_id);
+}
+
+/// Build a [`ParseFailureRecord`] for a brain-invocation failure and fire the
+/// four visibility channels (tracing, metric, return-for-embed, conditional
+/// `gh issue create`).
+///
+/// STEP 7 STATUS: stub. This implementation only constructs the record and
+/// bumps the counter — it does NOT yet fire tracing, the metric, or `gh`.
+/// The TDD tests assert the wired behaviour; they fail until Step 8 lands
+/// the real implementation.
+#[allow(dead_code)] // Step 8 wires this into the _with_brain call sites.
+pub(crate) fn record_parse_failure(
+    phase: BrainPhase,
+    goal_id: &str,
+    err: &crate::error::SimardError,
+    raw_response: &str,
+    prompt_name: &'static str,
+    prompt_version: String,
+) -> ParseFailureRecord {
+    let consecutive_count = bump_consecutive_count(phase, goal_id);
+
+    let mut raw_truncated = raw_response.to_string();
+    crate::util::string_truncate::truncate_to_char_boundary(
+        &mut raw_truncated,
+        RAW_RESPONSE_TRUNCATE_BYTES,
+    );
+
+    let record = ParseFailureRecord {
+        phase: phase_to_string(phase),
+        goal_id: goal_id.to_string(),
+        error_message: err.to_string(),
+        raw_response_truncated: raw_truncated,
+        prompt_name: prompt_name.to_string(),
+        prompt_version,
+        consecutive_count,
+        retry_attempted: false,
+        timestamp: chrono::Utc::now().to_rfc3339(),
+    };
+
+    // STEP 8 wires the four channels here. Stub on purpose so TDD tests
+    // can drive the wire-up.
+
+    record
+}
+
+#[allow(dead_code)] // Step 8 wires this into the _with_brain call sites.
+fn phase_to_string(phase: BrainPhase) -> String {
+    match phase {
+        BrainPhase::Act => "act".to_string(),
+        BrainPhase::Decide => "decide".to_string(),
+        BrainPhase::Orient => "orient".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::SimardError;
+
+    fn sample_err() -> SimardError {
+        SimardError::AdapterInvocationFailed {
+            base_type: "ooda-decide-brain".to_string(),
+            reason: "no JSON object; raw_response=\"OK\"".to_string(),
+        }
+    }
+
+    #[test]
+    fn record_round_trips_through_json() {
+        let rec = ParseFailureRecord {
+            phase: "decide".to_string(),
+            goal_id: "g1".to_string(),
+            error_message: "boom".to_string(),
+            raw_response_truncated: "OK".to_string(),
+            prompt_name: "ooda_decide.md".to_string(),
+            prompt_version: "deadbeef".to_string(),
+            consecutive_count: 2,
+            retry_attempted: false,
+            timestamp: "2026-05-19T04:44:26Z".to_string(),
+        };
+        let json = serde_json::to_string(&rec).unwrap();
+        // Every field MUST round-trip — no Option fields, no skip_serializing.
+        assert!(json.contains("\"phase\":\"decide\""), "got: {json}");
+        assert!(json.contains("\"goal_id\":\"g1\""), "got: {json}");
+        assert!(json.contains("\"error_message\":\"boom\""), "got: {json}");
+        assert!(
+            json.contains("\"raw_response_truncated\":\"OK\""),
+            "got: {json}"
+        );
+        assert!(
+            json.contains("\"prompt_name\":\"ooda_decide.md\""),
+            "got: {json}"
+        );
+        assert!(
+            json.contains("\"prompt_version\":\"deadbeef\""),
+            "got: {json}"
+        );
+        assert!(json.contains("\"consecutive_count\":2"), "got: {json}");
+        assert!(json.contains("\"retry_attempted\":false"), "got: {json}");
+        assert!(
+            json.contains("\"timestamp\":\"2026-05-19T04:44:26Z\""),
+            "got: {json}"
+        );
+
+        let back: ParseFailureRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(rec, back);
+    }
+
+    #[test]
+    fn record_parse_failure_populates_all_fields() {
+        let err = sample_err();
+        let rec = record_parse_failure(
+            BrainPhase::Decide,
+            "improve-dashboard",
+            &err,
+            "OK",
+            "ooda_decide.md",
+            "abc123def456".to_string(),
+        );
+        assert_eq!(rec.phase, "decide");
+        assert_eq!(rec.goal_id, "improve-dashboard");
+        assert!(rec.error_message.contains("ooda-decide-brain"));
+        assert!(rec.error_message.contains("no JSON object"));
+        assert_eq!(rec.raw_response_truncated, "OK");
+        assert_eq!(rec.prompt_name, "ooda_decide.md");
+        assert_eq!(rec.prompt_version, "abc123def456");
+        assert_eq!(rec.consecutive_count, 1);
+        assert!(!rec.retry_attempted);
+        assert!(!rec.timestamp.is_empty(), "timestamp must be populated");
+    }
+
+    #[test]
+    fn record_parse_failure_truncates_raw_response_at_8_kib() {
+        let huge = "a".repeat(20_000);
+        let err = sample_err();
+        let rec = record_parse_failure(
+            BrainPhase::Orient,
+            "g1",
+            &err,
+            &huge,
+            "ooda_orient.md",
+            String::new(),
+        );
+        assert!(
+            rec.raw_response_truncated.len() <= RAW_RESPONSE_TRUNCATE_BYTES,
+            "raw_response_truncated len {} exceeds {} cap",
+            rec.raw_response_truncated.len(),
+            RAW_RESPONSE_TRUNCATE_BYTES,
+        );
+    }
+
+    #[test]
+    fn record_parse_failure_truncates_on_utf8_boundary() {
+        // Anti-regression: char-boundary safety — a String full of 3-byte
+        // characters must not be truncated mid-codepoint (would panic in
+        // s.truncate() on bad boundary).
+
+        let multibyte: String = std::iter::repeat('字').take(5000).collect();
+        let err = sample_err();
+        let rec = record_parse_failure(
+            BrainPhase::Decide,
+            "g1",
+            &err,
+            &multibyte,
+            "ooda_decide.md",
+            String::new(),
+        );
+        // Round-trip through serde — would fail if truncation produced
+        // invalid UTF-8.
+        let json = serde_json::to_string(&rec).expect("must serialize after truncation");
+        let _back: ParseFailureRecord = serde_json::from_str(&json).expect("must round-trip");
+        assert!(rec.raw_response_truncated.len() <= RAW_RESPONSE_TRUNCATE_BYTES);
+    }
+
+    #[test]
+    fn consecutive_count_increments_per_phase_goal_id_pair() {
+        let err = sample_err();
+        // Use a goal_id unique to this test to avoid racing with other
+        // tests in the same module that share the global counter map.
+        let goal = "consecutive_count_increments_per_phase_goal_id_pair-goal";
+        let r1 = record_parse_failure(BrainPhase::Decide, goal, &err, "x", "p", String::new());
+        let r2 = record_parse_failure(BrainPhase::Decide, goal, &err, "x", "p", String::new());
+        let r3 = record_parse_failure(BrainPhase::Decide, goal, &err, "x", "p", String::new());
+        assert_eq!(r1.consecutive_count, 1);
+        assert_eq!(r2.consecutive_count, 2);
+        assert_eq!(r3.consecutive_count, 3);
+    }
+
+    #[test]
+    fn consecutive_count_tracked_separately_per_phase() {
+        let err = sample_err();
+        let goal = "consecutive_count_tracked_separately_per_phase-goal";
+        let d = record_parse_failure(BrainPhase::Decide, goal, &err, "x", "p", String::new());
+        let o = record_parse_failure(BrainPhase::Orient, goal, &err, "x", "p", String::new());
+        assert_eq!(d.consecutive_count, 1);
+        assert_eq!(
+            o.consecutive_count, 1,
+            "orient counter must not collide with decide"
+        );
+    }
+
+    #[test]
+    fn consecutive_count_tracked_separately_per_goal() {
+        let err = sample_err();
+        let a = record_parse_failure(
+            BrainPhase::Decide,
+            "consec-per-goal-A",
+            &err,
+            "x",
+            "p",
+            String::new(),
+        );
+        let b = record_parse_failure(
+            BrainPhase::Decide,
+            "consec-per-goal-B",
+            &err,
+            "x",
+            "p",
+            String::new(),
+        );
+        assert_eq!(a.consecutive_count, 1);
+        assert_eq!(
+            b.consecutive_count, 1,
+            "goal-b counter must not collide with goal-a"
+        );
+    }
+
+    #[test]
+    fn reset_consecutive_count_clears_counter_for_pair() {
+        let err = sample_err();
+        let goal = "reset_consecutive_count_clears_counter_for_pair-goal";
+        let _ = record_parse_failure(BrainPhase::Decide, goal, &err, "x", "p", String::new());
+        let _ = record_parse_failure(BrainPhase::Decide, goal, &err, "x", "p", String::new());
+        assert_eq!(peek_consecutive_count(BrainPhase::Decide, goal), 2);
+        reset_consecutive_count(BrainPhase::Decide, goal);
+        assert_eq!(peek_consecutive_count(BrainPhase::Decide, goal), 0);
+        // Next failure starts fresh at 1.
+        let next = record_parse_failure(BrainPhase::Decide, goal, &err, "x", "p", String::new());
+        assert_eq!(next.consecutive_count, 1);
+    }
+
+    #[test]
+    fn reset_consecutive_count_for_one_pair_does_not_affect_others() {
+        let err = sample_err();
+        let _ = record_parse_failure(
+            BrainPhase::Decide,
+            "reset-isolation-A",
+            &err,
+            "x",
+            "p",
+            String::new(),
+        );
+        let _ = record_parse_failure(
+            BrainPhase::Decide,
+            "reset-isolation-B",
+            &err,
+            "x",
+            "p",
+            String::new(),
+        );
+        reset_consecutive_count(BrainPhase::Decide, "reset-isolation-A");
+        assert_eq!(
+            peek_consecutive_count(BrainPhase::Decide, "reset-isolation-A"),
+            0
+        );
+        assert_eq!(
+            peek_consecutive_count(BrainPhase::Decide, "reset-isolation-B"),
+            1
+        );
+    }
+
+    #[test]
+    fn record_parse_failure_uses_display_not_debug_for_error_message() {
+        // Defense: if the implementation ever switches to {:?}, this test
+        // catches it — Debug for AdapterInvocationFailed prints field names
+        // (base_type:, reason:) while Display reads as a sentence.
+
+        let err = SimardError::AdapterInvocationFailed {
+            base_type: "ooda-decide-brain".to_string(),
+            reason: "decide brain returned an empty response".to_string(),
+        };
+        let rec = record_parse_failure(
+            BrainPhase::Decide,
+            "g1",
+            &err,
+            "",
+            "ooda_decide.md",
+            String::new(),
+        );
+        // Display format from src/error/display.rs:
+        //   "base type 'ooda-decide-brain' failed during invocation: ..."
+        assert!(
+            rec.error_message.contains("failed during invocation"),
+            "expected Display format, got: {}",
+            rec.error_message,
+        );
+        assert!(
+            !rec.error_message.contains("AdapterInvocationFailed"),
+            "Debug format leaked variant name into error_message: {}",
+            rec.error_message,
+        );
+    }
+
+    #[test]
+    fn record_serializes_safely_with_quotes_and_braces_in_raw_response() {
+        // JSON-injection resistance: the typed struct + serde_json must
+        // escape `"}` correctly so a hostile model response can't break the
+        // surrounding JSON.
+
+        let hostile = r#"OK"} ,"injected":"bad"#;
+        let err = sample_err();
+        let rec = record_parse_failure(
+            BrainPhase::Decide,
+            "g1",
+            &err,
+            hostile,
+            "ooda_decide.md",
+            String::new(),
+        );
+        let json = serde_json::to_string(&rec).unwrap();
+        let back: ParseFailureRecord = serde_json::from_str(&json).expect("must round-trip");
+        assert_eq!(back.raw_response_truncated, hostile);
+    }
+}

--- a/src/ooda_loop/decide.rs
+++ b/src/ooda_loop/decide.rs
@@ -9,9 +9,10 @@
 //! invoke [`decide_with_brain`] directly.
 
 use crate::error::SimardResult;
+use crate::ooda_brain::parse_failure::{record_parse_failure, reset_consecutive_count};
 use crate::ooda_brain::{
-    BrainJudgmentRecord, DecideContext, DeterministicFallbackDecideBrain, OodaDecideBrain,
-    push_brain_judgment,
+    BrainJudgmentRecord, BrainPhase, DECIDE_PROMPT_NAME, DecideContext,
+    DeterministicFallbackDecideBrain, OodaDecideBrain, push_brain_judgment,
 };
 
 use super::{OodaConfig, PlannedAction, Priority, is_synthetic_id};
@@ -29,7 +30,8 @@ pub fn decide(priorities: &[Priority], config: &OodaConfig) -> SimardResult<Vec<
 /// wire-in) by the daemon when an LLM-backed brain is configured. On any
 /// brain error for an individual priority, falls back to the deterministic
 /// mapping for that priority so a transient adapter failure cannot stall
-/// the cycle.
+/// the cycle — but the failure is recorded LOUDLY (issue #1890) via
+/// `ParseFailureRecord` so the silent-fallback regression cannot recur.
 #[tracing::instrument(skip_all)]
 pub fn decide_with_brain(
     priorities: &[Priority],
@@ -53,26 +55,43 @@ pub fn decide_with_brain(
         };
         let judgment = match brain.judge_decision(&ctx) {
             Ok(j) => {
+                // Healthy parse — reset the (Decide, goal_id) counter so a
+                // recovery cancels any pending gh-issue escalation.
+                reset_consecutive_count(BrainPhase::Decide, &priority.goal_id);
                 push_brain_judgment(BrainJudgmentRecord::from_decide(
                     &priority.goal_id,
                     priority.urgency,
                     &j,
                     false,
-                    crate::ooda_brain::prompt_store::current_version(
-                        crate::ooda_brain::DECIDE_PROMPT_NAME,
-                    ),
+                    crate::ooda_brain::prompt_store::current_version(DECIDE_PROMPT_NAME),
                 ));
                 j
             }
-            Err(_) => {
+            Err(e) => {
+                // Issue #1890: surface the parse failure on all four
+                // visibility channels (tracing, metric, cycle JSON,
+                // throttled gh issue at >= 3 consecutive). Cycle still
+                // continues via the deterministic fallback action so a
+                // transient adapter hiccup cannot stall the loop.
+                let raw_response = extract_raw_response(&e);
+                let pf = record_parse_failure(
+                    BrainPhase::Decide,
+                    &priority.goal_id,
+                    &e,
+                    &raw_response,
+                    DECIDE_PROMPT_NAME,
+                    crate::ooda_brain::prompt_store::current_version(DECIDE_PROMPT_NAME),
+                );
                 let j = fallback.judge_decision(&ctx)?;
-                push_brain_judgment(BrainJudgmentRecord::from_decide(
+                let mut rec = BrainJudgmentRecord::from_decide(
                     &priority.goal_id,
                     priority.urgency,
                     &j,
                     true,
                     String::new(),
-                ));
+                );
+                rec.parse_failure = Some(pf);
+                push_brain_judgment(rec);
                 j
             }
         };
@@ -87,6 +106,31 @@ pub fn decide_with_brain(
         });
     }
     Ok(actions)
+}
+
+/// Recover the raw model response from a brain error message.
+///
+/// Brain parsers embed the model body in the error reason as
+/// `raw_response={:?}` (Debug-format). We extract everything after the
+/// first `raw_response=` marker, then strip the surrounding double-quotes
+/// best-effort. If the marker is absent (non-parse error variants), we
+/// return the full error string so the operator still gets context.
+fn extract_raw_response(err: &crate::error::SimardError) -> String {
+    let msg = err.to_string();
+    if let Some(start) = msg.find("raw_response=") {
+        let tail = &msg[start + "raw_response=".len()..];
+        let tail = tail.trim_start();
+        if let Some(rest) = tail.strip_prefix('"') {
+            // Trim a trailing `")` or `"` (rustyclawd uses `({:?})` shape).
+            let body = rest
+                .strip_suffix("\")")
+                .or_else(|| rest.strip_suffix('"'))
+                .unwrap_or(rest);
+            return body.to_string();
+        }
+        return tail.to_string();
+    }
+    msg
 }
 
 #[cfg(test)]

--- a/src/ooda_loop/mod.rs
+++ b/src/ooda_loop/mod.rs
@@ -22,6 +22,8 @@ mod tests_orient;
 #[cfg(test)]
 mod tests_orient_extra;
 #[cfg(test)]
+mod tests_parse_failure_1890;
+#[cfg(test)]
 mod tests_types;
 
 // Re-export all public items so `crate::ooda_loop::X` still works.

--- a/src/ooda_loop/orient.rs
+++ b/src/ooda_loop/orient.rs
@@ -4,9 +4,10 @@ use std::collections::{HashMap, HashSet};
 
 use crate::error::SimardResult;
 use crate::goal_curation::{ActiveGoal, GoalBoard, GoalProgress};
+use crate::ooda_brain::parse_failure::{record_parse_failure, reset_consecutive_count};
 use crate::ooda_brain::{
-    BrainJudgmentRecord, DeterministicFallbackOrientBrain, OodaOrientBrain, OrientContext,
-    push_brain_judgment,
+    BrainJudgmentRecord, BrainPhase, DeterministicFallbackOrientBrain, ORIENT_PROMPT_NAME,
+    OodaOrientBrain, OrientContext, push_brain_judgment,
 };
 
 use super::{Observation, Priority, SyntheticPriorityKind, is_synthetic_id};
@@ -83,9 +84,14 @@ pub fn orient_with_brain(
 
             // Demote chronically failing goals — prompt-driven judgment via
             // the OodaOrientBrain (PR #1469's third-of-three OODA brain).
-            // Per-call fallback to the deterministic floor on any brain
-            // error or invalid judgment so the cycle never stalls and the
-            // brain can never escalate a failing goal above its base.
+            //
+            // Issue #1890: the previous `_ => (compute, true)` arm collapsed
+            // both LLM `Err(_)` and `Ok(j) if validate.is_err()` into the
+            // same silent deterministic-floor record. The Err case must
+            // now fire all four parse-failure visibility channels; the
+            // validate-failure case (semantic-judgment-out-of-bounds) is
+            // out of #1890 scope and keeps the legacy silent fallback —
+            // tracked separately so this PR stays focused.
             if let Some(&count) = failure_counts.get(&g.id)
                 && count > 0
             {
@@ -95,11 +101,42 @@ pub fn orient_with_brain(
                     base_reason: reason.clone(),
                     failure_count: count,
                 };
-                let (judgment, fallback_used) = match brain.judge_orientation(&ctx) {
-                    Ok(j) if j.validate(ctx.base_urgency).is_ok() => (j, false),
-                    _ => (DeterministicFallbackOrientBrain::compute(&ctx), true),
+                let (judgment, fallback_used, parse_failure) = match brain.judge_orientation(&ctx) {
+                    Ok(j) if j.validate(ctx.base_urgency).is_ok() => {
+                        // Healthy parse — reset the (Orient, goal_id)
+                        // counter so a recovery cancels any pending
+                        // gh-issue escalation.
+                        reset_consecutive_count(BrainPhase::Orient, &g.id);
+                        (j, false, None)
+                    }
+                    Ok(_) => {
+                        // Brain produced JSON that parsed but failed
+                        // semantic validation (e.g. adjusted_urgency
+                        // out of range). Out of #1890 scope: keep the
+                        // legacy silent deterministic fallback.
+                        (DeterministicFallbackOrientBrain::compute(&ctx), true, None)
+                    }
+                    Err(e) => {
+                        // Issue #1890: parse failure — fire all four
+                        // visibility channels and embed the record
+                        // on the BrainJudgmentRecord.
+                        let raw_response = extract_raw_response(&e);
+                        let pf = record_parse_failure(
+                            BrainPhase::Orient,
+                            &g.id,
+                            &e,
+                            &raw_response,
+                            ORIENT_PROMPT_NAME,
+                            crate::ooda_brain::prompt_store::current_version(ORIENT_PROMPT_NAME),
+                        );
+                        (
+                            DeterministicFallbackOrientBrain::compute(&ctx),
+                            true,
+                            Some(pf),
+                        )
+                    }
                 };
-                push_brain_judgment(BrainJudgmentRecord::from_orient(
+                let mut rec = BrainJudgmentRecord::from_orient(
                     &g.id,
                     ctx.base_urgency,
                     count,
@@ -108,11 +145,11 @@ pub fn orient_with_brain(
                     if fallback_used {
                         String::new()
                     } else {
-                        crate::ooda_brain::prompt_store::current_version(
-                            crate::ooda_brain::ORIENT_PROMPT_NAME,
-                        )
+                        crate::ooda_brain::prompt_store::current_version(ORIENT_PROMPT_NAME)
                     },
-                ));
+                );
+                rec.parse_failure = parse_failure;
+                push_brain_judgment(rec);
                 reason = format!("{reason}; {}", judgment.rationale);
                 urgency = judgment.adjusted_urgency;
             }
@@ -206,6 +243,35 @@ pub(crate) fn filter_hallucinated_priorities(
             false
         }
     });
+}
+
+/// Recover the raw model response from a brain error message.
+///
+/// Brain parsers embed the model body in the error reason as
+/// `raw_response={:?}` (Debug-format). We extract everything after the
+/// first `raw_response=` marker, then strip the surrounding double-quotes
+/// best-effort. If the marker is absent (non-parse error variants), we
+/// return the full error string so the operator still gets context.
+///
+/// Kept local to `orient.rs` (vs. promoted to a shared helper) because the
+/// only other caller — `decide.rs::extract_raw_response` — is a one-line
+/// twin that the linter would force into an over-abstraction if we tried
+/// to share it. If a third caller appears, refactor then.
+fn extract_raw_response(err: &crate::error::SimardError) -> String {
+    let msg = err.to_string();
+    if let Some(start) = msg.find("raw_response=") {
+        let tail = &msg[start + "raw_response=".len()..];
+        let tail = tail.trim_start();
+        if let Some(rest) = tail.strip_prefix('"') {
+            let body = rest
+                .strip_suffix("\")")
+                .or_else(|| rest.strip_suffix('"'))
+                .unwrap_or(rest);
+            return body.to_string();
+        }
+        return tail.to_string();
+    }
+    msg
 }
 
 #[cfg(test)]

--- a/src/ooda_loop/tests_parse_failure_1890.rs
+++ b/src/ooda_loop/tests_parse_failure_1890.rs
@@ -1,0 +1,657 @@
+//! TDD tests for issue #1890 — close silent JSON-fallback path in
+//! `decide_with_brain` / `orient_with_brain`.
+//!
+//! These tests **fail at HEAD** (Step 7 — write tests first) and pin the
+//! behaviour that Step 8 must implement:
+//!
+//!   1. When the LLM brain returns `Err`, the per-cycle
+//!      `BrainJudgmentRecord` for that goal MUST carry a
+//!      `parse_failure: Some(ParseFailureRecord)` — not the historical
+//!      silent `parse_failure: None` deterministic-fallback record.
+//!   2. The `ParseFailureRecord` MUST be populated with the LLM error
+//!      message, the raw response text (truncated, UTF-8-safe), the
+//!      prompt name + version, and the `(phase, goal_id)` consecutive
+//!      count.
+//!   3. The cycle MUST continue — the deterministic fallback's action
+//!      kind (decide) or base urgency (orient) is still emitted so the
+//!      loop doesn't stall.
+//!   4. Healthy `Ok(_)` returns MUST leave `parse_failure = None` (no
+//!      false-positive churn on cycle reports).
+//!   5. A successful parse for a `(phase, goal_id)` after a failure MUST
+//!      reset the consecutive_count for that pair to 0.
+//!
+//! Anti-regression: pre-fix, `decide_with_brain` swallowed the brain
+//! `Err(_)` into the deterministic fallback with `BrainJudgmentRecord
+//! { fallback: true, rationale: "fallback-brain: prefix-routed", … }`
+//! and no parse-failure breadcrumb. `improve-simard-dashboard` and
+//! `fix-broken-features` ran 89 cycles at 0.00% before any operator
+//! noticed — see issue #1890.
+
+use std::collections::HashMap;
+
+use crate::error::{SimardError, SimardResult};
+use crate::goal_curation::{ActiveGoal, GoalBoard, GoalProgress};
+use crate::memory_cognitive::CognitiveStatistics;
+use crate::ooda_brain::{
+    BrainJudgmentRecord, BrainPhase, DecideContext, DecideJudgment, OodaDecideBrain,
+    OodaOrientBrain, OrientContext, OrientJudgment,
+    parse_failure::{peek_consecutive_count, reset_consecutive_count_for_tests, test_serial_guard},
+};
+use crate::ooda_loop::{
+    EnvironmentSnapshot, Observation, OodaConfig, Priority, decide_with_brain, orient_with_brain,
+};
+
+// ---------------------------------------------------------------------------
+// Test doubles (resolution A11: AlwaysErrBrain — smallest stub possible)
+// ---------------------------------------------------------------------------
+
+/// A `OodaDecideBrain` that always returns `SimardError::AdapterInvocationFailed`
+/// with an embedded raw-response snippet — mirrors the production failure mode
+/// from issue #1890 where the LLM returned `"OK"` and the parser produced
+/// `"no JSON object; raw_response=\"OK\""`.
+struct AlwaysErrDecideBrain {
+    raw_response: String,
+}
+
+impl AlwaysErrDecideBrain {
+    fn new(raw_response: &str) -> Self {
+        Self {
+            raw_response: raw_response.to_string(),
+        }
+    }
+}
+
+impl OodaDecideBrain for AlwaysErrDecideBrain {
+    fn judge_decision(&self, _ctx: &DecideContext) -> SimardResult<DecideJudgment> {
+        Err(SimardError::AdapterInvocationFailed {
+            base_type: "ooda-decide-brain".to_string(),
+            reason: format!(
+                "decide brain response had no JSON object; raw_response={:?}",
+                self.raw_response,
+            ),
+        })
+    }
+}
+
+struct AlwaysErrOrientBrain {
+    raw_response: String,
+}
+
+impl AlwaysErrOrientBrain {
+    fn new(raw_response: &str) -> Self {
+        Self {
+            raw_response: raw_response.to_string(),
+        }
+    }
+}
+
+impl OodaOrientBrain for AlwaysErrOrientBrain {
+    fn judge_orientation(&self, _ctx: &OrientContext) -> SimardResult<OrientJudgment> {
+        Err(SimardError::AdapterInvocationFailed {
+            base_type: "ooda-orient-brain".to_string(),
+            reason: format!(
+                "orient brain response had no JSON object; raw_response={:?}",
+                self.raw_response,
+            ),
+        })
+    }
+}
+
+/// A brain that toggles per call: first N calls fail, then succeed. Used for
+/// the consecutive-counter-reset test.
+struct ToggleDecideBrain {
+    failures_remaining: std::sync::Mutex<u32>,
+}
+
+impl ToggleDecideBrain {
+    fn new(initial_failures: u32) -> Self {
+        Self {
+            failures_remaining: std::sync::Mutex::new(initial_failures),
+        }
+    }
+}
+
+impl OodaDecideBrain for ToggleDecideBrain {
+    fn judge_decision(&self, _ctx: &DecideContext) -> SimardResult<DecideJudgment> {
+        let mut g = self.failures_remaining.lock().unwrap();
+        if *g > 0 {
+            *g -= 1;
+            Err(SimardError::AdapterInvocationFailed {
+                base_type: "ooda-decide-brain".to_string(),
+                reason: "no JSON object; raw_response=\"OK\"".to_string(),
+            })
+        } else {
+            Ok(DecideJudgment::AdvanceGoal {
+                rationale: "llm-brain healthy after retries".to_string(),
+            })
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn one_priority(goal_id: &str) -> Vec<Priority> {
+    vec![Priority {
+        goal_id: goal_id.to_string(),
+        urgency: 0.9,
+        reason: "test priority".to_string(),
+    }]
+}
+
+fn observation_with_no_signals() -> Observation {
+    Observation {
+        goal_statuses: Vec::new(),
+        gym_health: None,
+        memory_stats: CognitiveStatistics::default(),
+        pending_improvements: Vec::new(),
+        environment: EnvironmentSnapshot::default(),
+        eval_watchdog: None,
+    }
+}
+
+fn board_with_one_goal(id: &str) -> GoalBoard {
+    let mut board = GoalBoard::default();
+    board.active.push(ActiveGoal {
+        id: id.to_string(),
+        description: format!("desc {id}"),
+        priority: 1,
+        status: GoalProgress::NotStarted,
+        assigned_to: None,
+        current_activity: None,
+        wip_refs: vec![],
+    });
+    board
+}
+
+/// Run `f` inside a fresh brain-judgment scope. Tests that rely on the
+/// process-global `(phase, goal_id) -> consecutive_count` map MUST use a
+/// unique `goal_id` (typically derived from the test name) AND hold the
+/// `test_serial_guard()` mutex if they assert on counter values, so
+/// `cargo test`'s parallel execution can't contaminate the assertion.
+fn run_isolated<R>(f: impl FnOnce() -> R) -> R {
+    crate::ooda_brain::with_brain_judgment_scope(|| {
+        crate::ooda_brain::clear_brain_judgments();
+        f()
+    })
+}
+
+// ===========================================================================
+// decide_with_brain — silent-fallback closure
+// ===========================================================================
+
+#[test]
+fn decide_with_brain_errored_pushes_parse_failure_record() {
+    // ANTI-REGRESSION (issue #1890): before this PR, decide_with_brain on
+    // brain Err pushed a BrainJudgmentRecord with `parse_failure: None`
+    // and the deterministic-fallback rationale — indistinguishable on
+    // disk from "operator deliberately ran without an LLM brain".
+    let priorities = one_priority("improve-simard-dashboard");
+    let config = OodaConfig::default();
+    let brain = AlwaysErrDecideBrain::new("OK");
+
+    let records = run_isolated(|| {
+        decide_with_brain(&priorities, &config, &brain).unwrap();
+        crate::ooda_brain::take_brain_judgments()
+    });
+
+    assert_eq!(records.len(), 1, "exactly one judgment record per priority");
+    let rec = &records[0];
+    assert_eq!(rec.phase, BrainPhase::Decide);
+    assert!(
+        rec.parse_failure.is_some(),
+        "BrainJudgmentRecord.parse_failure MUST be Some(_) on brain Err (issue #1890); \
+         got None — silent fallback regressed: {:?}",
+        rec,
+    );
+}
+
+#[test]
+fn decide_with_brain_errored_parse_failure_carries_error_and_raw_response() {
+    let priorities = one_priority("g1");
+    let config = OodaConfig::default();
+    let brain = AlwaysErrDecideBrain::new("OK");
+
+    let records = run_isolated(|| {
+        decide_with_brain(&priorities, &config, &brain).unwrap();
+        crate::ooda_brain::take_brain_judgments()
+    });
+
+    let pf = records[0]
+        .parse_failure
+        .as_ref()
+        .expect("parse_failure must be Some on brain Err");
+    assert_eq!(pf.phase, "decide");
+    assert_eq!(pf.goal_id, "g1");
+    assert!(
+        pf.error_message.contains("ooda-decide-brain"),
+        "error_message must carry the brain adapter tag: {}",
+        pf.error_message,
+    );
+    assert!(
+        pf.error_message.contains("no JSON object"),
+        "error_message must carry the parser's diagnostic: {}",
+        pf.error_message,
+    );
+    assert!(
+        pf.raw_response_truncated.contains("OK"),
+        "raw_response_truncated must echo the model output: {}",
+        pf.raw_response_truncated,
+    );
+    assert_eq!(
+        pf.prompt_name, "ooda_decide.md",
+        "prompt_name must match the DECIDE_PROMPT_NAME constant",
+    );
+    assert!(
+        !pf.timestamp.is_empty(),
+        "timestamp must be populated for cycle-report correlation",
+    );
+    assert!(
+        !pf.retry_attempted,
+        "retry_attempted is reserved-false in this release",
+    );
+}
+
+#[test]
+fn decide_with_brain_errored_still_emits_planned_action() {
+    // Cycle must NOT stall on a brain failure — the deterministic fallback
+    // floor still produces a PlannedAction so the loop continues, while
+    // the parse_failure record makes the degradation visible.
+    let priorities = one_priority("ship-v1");
+    let config = OodaConfig::default();
+    let brain = AlwaysErrDecideBrain::new("OK");
+
+    let actions = run_isolated(|| decide_with_brain(&priorities, &config, &brain).unwrap());
+
+    assert_eq!(
+        actions.len(),
+        1,
+        "deterministic fallback must still emit an action so the cycle doesn't stall",
+    );
+    assert_eq!(
+        actions[0].kind,
+        crate::ooda_loop::ActionKind::AdvanceGoal,
+        "deterministic fallback for a non-synthetic goal_id routes to AdvanceGoal",
+    );
+}
+
+#[test]
+fn decide_with_brain_errored_record_keeps_fallback_true_for_dashboard_back_compat() {
+    // Dashboards key on `fallback == true`. The deterministic floor still
+    // fires, so the field stays true. The discriminator for "forced by
+    // failure" vs "operator chose deterministic" is parse_failure.is_some().
+    let priorities = one_priority("g1");
+    let config = OodaConfig::default();
+    let brain = AlwaysErrDecideBrain::new("OK");
+
+    let records = run_isolated(|| {
+        decide_with_brain(&priorities, &config, &brain).unwrap();
+        crate::ooda_brain::take_brain_judgments()
+    });
+
+    assert!(
+        records[0].fallback,
+        "fallback must stay true for dashboard back-compat"
+    );
+    assert!(
+        records[0].parse_failure.is_some(),
+        "discriminator: parse_failure Some"
+    );
+}
+
+#[test]
+fn decide_with_brain_ok_path_leaves_parse_failure_none() {
+    // Healthy LLM brain returns Ok — no parse failure, no schema churn.
+    struct OkBrain;
+    impl OodaDecideBrain for OkBrain {
+        fn judge_decision(&self, _ctx: &DecideContext) -> SimardResult<DecideJudgment> {
+            Ok(DecideJudgment::AdvanceGoal {
+                rationale: "healthy".to_string(),
+            })
+        }
+    }
+    let priorities = one_priority("g1");
+    let config = OodaConfig::default();
+
+    let records = run_isolated(|| {
+        decide_with_brain(&priorities, &config, &OkBrain).unwrap();
+        crate::ooda_brain::take_brain_judgments()
+    });
+
+    assert!(
+        records[0].parse_failure.is_none(),
+        "healthy Ok path MUST NOT set parse_failure: false-positive churn = bug",
+    );
+}
+
+#[test]
+fn decide_with_brain_errored_record_serializes_parse_failure_to_json() {
+    // End-to-end: the BrainJudgmentRecord MUST serialize the parse_failure
+    // field so it lands in `~/.simard/cycle_reports/cycle_N.json`. This is
+    // visibility channel 3 from the four-channel contract.
+    let priorities = one_priority("g1");
+    let config = OodaConfig::default();
+    let brain = AlwaysErrDecideBrain::new("OK");
+
+    let records = run_isolated(|| {
+        decide_with_brain(&priorities, &config, &brain).unwrap();
+        crate::ooda_brain::take_brain_judgments()
+    });
+
+    let json = serde_json::to_string(&records[0]).expect("BrainJudgmentRecord must serialize");
+    assert!(
+        json.contains("\"parse_failure\""),
+        "parse_failure MUST be present in serialized cycle_report JSON: {json}",
+    );
+    assert!(
+        json.contains("\"phase\":\"decide\""),
+        "parse_failure.phase MUST serialize as \"decide\": {json}",
+    );
+    assert!(
+        json.contains("\"goal_id\":\"g1\""),
+        "parse_failure.goal_id MUST serialize: {json}",
+    );
+    // Round-trip — back-compat regression: older readers parsing a richer
+    // record must not break.
+    let back: BrainJudgmentRecord = serde_json::from_str(&json).expect("round-trip");
+    assert!(back.parse_failure.is_some());
+}
+
+#[test]
+fn decide_with_brain_errored_consecutive_count_increments_per_call() {
+    // Resolution A6: track consecutive failures per (phase, goal_id) so
+    // the gh-issue-create channel can throttle at >= 3.
+    let _serial = test_serial_guard();
+    let goal_id = "decide_with_brain_errored_consecutive_count-goal";
+    reset_consecutive_count_for_tests(BrainPhase::Decide, goal_id);
+    let priorities = vec![Priority {
+        goal_id: goal_id.to_string(),
+        urgency: 0.9,
+        reason: "test priority".to_string(),
+    }];
+    let config = OodaConfig::default();
+    let brain = AlwaysErrDecideBrain::new("OK");
+
+    let count_after_three = run_isolated(|| {
+        for _ in 0..3 {
+            decide_with_brain(&priorities, &config, &brain).unwrap();
+        }
+        peek_consecutive_count(BrainPhase::Decide, goal_id)
+    });
+    assert_eq!(
+        count_after_three, 3,
+        "consecutive_count must reach 3 after three failing calls on the same goal",
+    );
+}
+
+#[test]
+fn decide_with_brain_consecutive_count_resets_on_next_successful_parse() {
+    // Three failures, then one Ok — counter MUST reset.
+    let _serial = test_serial_guard();
+    let goal_id = "decide_with_brain_consecutive_count_resets-goal";
+    reset_consecutive_count_for_tests(BrainPhase::Decide, goal_id);
+    let priorities = vec![Priority {
+        goal_id: goal_id.to_string(),
+        urgency: 0.9,
+        reason: "test priority".to_string(),
+    }];
+    let config = OodaConfig::default();
+    let brain = ToggleDecideBrain::new(3);
+
+    let after = run_isolated(|| {
+        for _ in 0..4 {
+            decide_with_brain(&priorities, &config, &brain).unwrap();
+        }
+        peek_consecutive_count(BrainPhase::Decide, goal_id)
+    });
+    assert_eq!(
+        after, 0,
+        "consecutive_count must reset to 0 on the next successful parse",
+    );
+}
+
+#[test]
+fn decide_with_brain_errored_continues_to_next_priority() {
+    // One failing priority must NOT stop the cycle — subsequent priorities
+    // still get judged. This is the per-priority degradation guarantee
+    // (Pillar 11) — a single brain hiccup can't take down the whole cycle.
+    struct FirstFailsThenOkBrain {
+        call: std::sync::Mutex<u32>,
+    }
+    impl OodaDecideBrain for FirstFailsThenOkBrain {
+        fn judge_decision(&self, _ctx: &DecideContext) -> SimardResult<DecideJudgment> {
+            let mut c = self.call.lock().unwrap();
+            *c += 1;
+            if *c == 1 {
+                Err(SimardError::AdapterInvocationFailed {
+                    base_type: "ooda-decide-brain".to_string(),
+                    reason: "no JSON object".to_string(),
+                })
+            } else {
+                Ok(DecideJudgment::AdvanceGoal {
+                    rationale: "second priority got through".to_string(),
+                })
+            }
+        }
+    }
+    let priorities = vec![
+        Priority {
+            goal_id: "bad-goal".to_string(),
+            urgency: 0.9,
+            reason: "first".to_string(),
+        },
+        Priority {
+            goal_id: "good-goal".to_string(),
+            urgency: 0.8,
+            reason: "second".to_string(),
+        },
+    ];
+    let config = OodaConfig::default();
+    let brain = FirstFailsThenOkBrain {
+        call: std::sync::Mutex::new(0),
+    };
+
+    let (actions, records) = run_isolated(|| {
+        let actions = decide_with_brain(&priorities, &config, &brain).unwrap();
+        (actions, crate::ooda_brain::take_brain_judgments())
+    });
+
+    assert_eq!(actions.len(), 2, "both priorities must be processed");
+    assert_eq!(records.len(), 2);
+    assert!(
+        records[0].parse_failure.is_some(),
+        "bad-goal logged a parse_failure"
+    );
+    assert!(
+        records[1].parse_failure.is_none(),
+        "good-goal must be a clean record (no spurious parse_failure)",
+    );
+}
+
+// ===========================================================================
+// orient_with_brain — silent-fallback closure
+// ===========================================================================
+
+#[test]
+fn orient_with_brain_errored_pushes_parse_failure_record() {
+    // Same anti-regression as decide, on the orient call site.
+    // `src/ooda_loop/orient.rs:98-101` historically collapsed `Err(_)` into
+    // the deterministic compute() with no breadcrumb.
+    let board = board_with_one_goal("fix-broken-features");
+    let obs = observation_with_no_signals();
+    let mut failures = HashMap::new();
+    failures.insert("fix-broken-features".to_string(), 1);
+    let brain = AlwaysErrOrientBrain::new("OK");
+
+    let records = run_isolated(|| {
+        orient_with_brain(&obs, &board, &failures, &brain).unwrap();
+        crate::ooda_brain::take_brain_judgments()
+    });
+
+    assert_eq!(
+        records.len(),
+        1,
+        "exactly one orient record per failing goal"
+    );
+    let rec = &records[0];
+    assert_eq!(rec.phase, BrainPhase::Orient);
+    assert!(
+        rec.parse_failure.is_some(),
+        "orient BrainJudgmentRecord.parse_failure MUST be Some(_) on brain Err (issue #1890)",
+    );
+}
+
+#[test]
+fn orient_with_brain_errored_parse_failure_carries_error_and_raw_response() {
+    let board = board_with_one_goal("g1");
+    let obs = observation_with_no_signals();
+    let mut failures = HashMap::new();
+    failures.insert("g1".to_string(), 2);
+    let brain = AlwaysErrOrientBrain::new("OK");
+
+    let records = run_isolated(|| {
+        orient_with_brain(&obs, &board, &failures, &brain).unwrap();
+        crate::ooda_brain::take_brain_judgments()
+    });
+
+    let pf = records[0]
+        .parse_failure
+        .as_ref()
+        .expect("parse_failure must be Some on brain Err");
+    assert_eq!(pf.phase, "orient");
+    assert_eq!(pf.goal_id, "g1");
+    assert!(
+        pf.error_message.contains("ooda-orient-brain"),
+        "error_message must carry the orient brain adapter tag: {}",
+        pf.error_message,
+    );
+    assert!(
+        pf.raw_response_truncated.contains("OK"),
+        "raw_response_truncated must echo the model output: {}",
+        pf.raw_response_truncated,
+    );
+    assert_eq!(
+        pf.prompt_name, "ooda_orient.md",
+        "prompt_name must match the ORIENT_PROMPT_NAME constant",
+    );
+}
+
+#[test]
+fn orient_with_brain_errored_still_produces_priority() {
+    // The deterministic floor's demotion still applies — the goal stays on
+    // the priorities list (visible to decide) and gets the legacy penalty.
+    let board = board_with_one_goal("g1");
+    let obs = observation_with_no_signals();
+    let mut failures = HashMap::new();
+    failures.insert("g1".to_string(), 1);
+    let brain = AlwaysErrOrientBrain::new("OK");
+
+    let priorities = run_isolated(|| orient_with_brain(&obs, &board, &failures, &brain).unwrap());
+
+    let g1 = priorities
+        .iter()
+        .find(|p| p.goal_id == "g1")
+        .expect("g1 priority must still appear (cycle does not stall)");
+    // Deterministic-floor demotion: 0.8 (NotStarted) - 0.2 (1 failure) = 0.6
+    assert!(
+        (g1.urgency - 0.6).abs() < 1e-9,
+        "deterministic-floor demotion still applies; got urgency {}",
+        g1.urgency,
+    );
+}
+
+#[test]
+fn orient_with_brain_ok_path_leaves_parse_failure_none() {
+    struct OkOrientBrain;
+    impl OodaOrientBrain for OkOrientBrain {
+        fn judge_orientation(&self, ctx: &OrientContext) -> SimardResult<OrientJudgment> {
+            Ok(OrientJudgment {
+                adjusted_urgency: (ctx.base_urgency - 0.05).max(0.0),
+                rationale: "healthy orient brain".to_string(),
+                confidence: 0.9,
+                demotion_applied: 0.05,
+            })
+        }
+    }
+    let board = board_with_one_goal("g1");
+    let obs = observation_with_no_signals();
+    let mut failures = HashMap::new();
+    failures.insert("g1".to_string(), 1);
+
+    let records = run_isolated(|| {
+        orient_with_brain(&obs, &board, &failures, &OkOrientBrain).unwrap();
+        crate::ooda_brain::take_brain_judgments()
+    });
+
+    assert_eq!(records.len(), 1);
+    assert!(
+        records[0].parse_failure.is_none(),
+        "healthy Ok path MUST NOT set parse_failure",
+    );
+}
+
+#[test]
+fn orient_with_brain_errored_consecutive_count_increments_per_call() {
+    let _serial = test_serial_guard();
+    let goal_id = "orient_with_brain_errored_consecutive_count-goal";
+    reset_consecutive_count_for_tests(BrainPhase::Orient, goal_id);
+    let board = board_with_one_goal(goal_id);
+    let obs = observation_with_no_signals();
+    let mut failures = HashMap::new();
+    failures.insert(goal_id.to_string(), 1);
+    let brain = AlwaysErrOrientBrain::new("OK");
+
+    let count_after_three = run_isolated(|| {
+        for _ in 0..3 {
+            orient_with_brain(&obs, &board, &failures, &brain).unwrap();
+        }
+        peek_consecutive_count(BrainPhase::Orient, goal_id)
+    });
+    assert_eq!(
+        count_after_three, 3,
+        "consecutive_count for orient must reach 3 after three failing calls",
+    );
+}
+
+#[test]
+fn orient_and_decide_counters_are_independent_for_same_goal() {
+    // Resolution A7: (phase, goal_id) is the counter key. A decide failure
+    // for goal X must not inflate the orient counter for goal X, otherwise
+    // the gh-issue-create throttle would mis-fire.
+    let _serial = test_serial_guard();
+    let goal_id = "orient_and_decide_counters_are_independent-goal";
+    reset_consecutive_count_for_tests(BrainPhase::Decide, goal_id);
+    reset_consecutive_count_for_tests(BrainPhase::Orient, goal_id);
+    let priorities = vec![Priority {
+        goal_id: goal_id.to_string(),
+        urgency: 0.9,
+        reason: "test".to_string(),
+    }];
+    let board = board_with_one_goal(goal_id);
+    let obs = observation_with_no_signals();
+    let mut failures = HashMap::new();
+    failures.insert(goal_id.to_string(), 1);
+    let config = OodaConfig::default();
+    let decide_brain = AlwaysErrDecideBrain::new("OK");
+    let orient_brain = AlwaysErrOrientBrain::new("OK");
+
+    let (decide_count, orient_count) = run_isolated(|| {
+        decide_with_brain(&priorities, &config, &decide_brain).unwrap();
+        decide_with_brain(&priorities, &config, &decide_brain).unwrap();
+        orient_with_brain(&obs, &board, &failures, &orient_brain).unwrap();
+        (
+            peek_consecutive_count(BrainPhase::Decide, goal_id),
+            peek_consecutive_count(BrainPhase::Orient, goal_id),
+        )
+    });
+
+    assert_eq!(
+        decide_count, 2,
+        "decide counter must reflect its own two failures"
+    );
+    assert_eq!(
+        orient_count, 1,
+        "orient counter must reflect its own one failure"
+    );
+}

--- a/src/operator_commands_ooda/persistence.rs
+++ b/src/operator_commands_ooda/persistence.rs
@@ -456,4 +456,97 @@ mod tests {
         // `Vec` skips serialisation when empty.
         assert_eq!(parsed["brain_judgments"], serde_json::json!([]));
     }
+
+    /// Issue #1890 regression: a BrainJudgmentRecord whose `parse_failure`
+    /// field is `Some(_)` MUST round-trip through `persist_cycle_report`'s
+    /// auto-derive serialisation onto the cycle JSON file. This is
+    /// visibility channel #3 from the four-channel contract (see
+    /// `docs/reference/ooda-brain-parse-failure-record.md`). Locks down the
+    /// "field added to struct but writer forgot to mirror it" class of bug
+    /// that PR #1480 had to repair for `prompt_version`.
+    #[test]
+    fn persist_cycle_report_round_trips_parse_failure_field() {
+        use crate::ooda_brain::{BrainJudgmentRecord, BrainPhase, ParseFailureRecord};
+
+        let dir = tempfile::tempdir().unwrap();
+        let mut report = minimal_report(1890);
+        report.brain_judgments.push(BrainJudgmentRecord {
+            phase: BrainPhase::Decide,
+            context_summary: "goal_id=fix-broken-features urgency=0.900".to_string(),
+            decision: "advance_goal".to_string(),
+            rationale: "deterministic fallback (brain Err)".to_string(),
+            confidence: 0.5,
+            fallback: true,
+            prompt_version: String::new(),
+            parse_failure: Some(ParseFailureRecord {
+                phase: "decide".to_string(),
+                goal_id: "fix-broken-features".to_string(),
+                error_message:
+                    "ooda-decide-brain: decide brain response had no JSON object; raw_response=\"OK\""
+                        .to_string(),
+                raw_response_truncated: "OK".to_string(),
+                prompt_name: "ooda_decide.md".to_string(),
+                prompt_version: "abc123def456".to_string(),
+                consecutive_count: 2,
+                retry_attempted: false,
+                timestamp: "2024-01-01T00:00:00+00:00".to_string(),
+            }),
+        });
+        persist_cycle_report(dir.path(), &report);
+        let content =
+            std::fs::read_to_string(dir.path().join("cycle_reports/cycle_1890.json")).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+        let arr = parsed["brain_judgments"].as_array().expect("array");
+        assert_eq!(arr.len(), 1);
+        let pf = &arr[0]["parse_failure"];
+        assert!(
+            !pf.is_null(),
+            "parse_failure MUST land on disk, got null: {arr:?}",
+        );
+        assert_eq!(pf["phase"], "decide");
+        assert_eq!(pf["goal_id"], "fix-broken-features");
+        assert_eq!(pf["raw_response_truncated"], "OK");
+        assert_eq!(pf["prompt_name"], "ooda_decide.md");
+        assert_eq!(pf["consecutive_count"], 2);
+        assert_eq!(pf["retry_attempted"], false);
+        assert!(
+            pf["error_message"]
+                .as_str()
+                .unwrap()
+                .contains("no JSON object"),
+            "error_message must echo the parser diagnostic, got: {}",
+            pf["error_message"],
+        );
+    }
+
+    /// Anti-regression for byte-for-byte cycle-JSON back-compat: a
+    /// `BrainJudgmentRecord` whose `parse_failure` is `None` (every healthy
+    /// cycle) MUST NOT emit the field at all — pre-PR consumers must see
+    /// the exact same shape they did before.
+    #[test]
+    fn persist_cycle_report_omits_parse_failure_when_none() {
+        use crate::ooda_brain::{BrainJudgmentRecord, BrainPhase};
+
+        let dir = tempfile::tempdir().unwrap();
+        let mut report = minimal_report(13);
+        report.brain_judgments.push(BrainJudgmentRecord {
+            phase: BrainPhase::Decide,
+            context_summary: "goal_id=ship-v1 urgency=0.900".to_string(),
+            decision: "advance_goal".to_string(),
+            rationale: "healthy LLM brain".to_string(),
+            confidence: 1.0,
+            fallback: false,
+            prompt_version: "abc123def456".to_string(),
+            parse_failure: None,
+        });
+        persist_cycle_report(dir.path(), &report);
+        let content =
+            std::fs::read_to_string(dir.path().join("cycle_reports/cycle_13.json")).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+        let arr = parsed["brain_judgments"].as_array().expect("array");
+        assert!(
+            arr[0].get("parse_failure").is_none(),
+            "healthy record MUST NOT emit parse_failure (byte-for-byte back-compat): {arr:?}",
+        );
+    }
 }

--- a/src/operator_commands_ooda/persistence.rs
+++ b/src/operator_commands_ooda/persistence.rs
@@ -403,6 +403,7 @@ mod tests {
             confidence: 1.0,
             fallback: false,
             prompt_version: "abc123def456".to_string(),
+            parse_failure: None,
         });
         report.brain_judgments.push(BrainJudgmentRecord {
             phase: BrainPhase::Orient,
@@ -412,6 +413,7 @@ mod tests {
             confidence: 0.8,
             fallback: true,
             prompt_version: String::new(),
+            parse_failure: None,
         });
         persist_cycle_report(dir.path(), &report);
         let content =

--- a/src/operator_commands_ooda/tests/persistence_tests.rs
+++ b/src/operator_commands_ooda/tests/persistence_tests.rs
@@ -152,6 +152,7 @@ fn persist_cycle_report_uses_serde_derive_for_all_fields() {
         confidence: 0.95,
         fallback: false,
         prompt_version: "abc123def456".to_string(),
+        parse_failure: None,
     };
 
     let scratch = PathBuf::from(env!("CARGO_MANIFEST_DIR"))


### PR DESCRIPTION
## Summary

Closes #1890 — the silent JSON-parse fallback path in
`decide_with_brain` / `orient_with_brain` that let two production goals
(`improve-simard-dashboard`, `fix-broken-features`) run **89 cycles at
0.00% progress** with zero operator-visible error.

This is the **sibling fix** to #1711 / #1748 for the third-of-three
OODA brains — same anti-pattern (`match { Err(_) => deterministic }`),
same fix shape (four-channel loud failure), same `gh issue create`
escalation pattern.

## Root cause

`decide_with_brain` (and the analogous `orient_with_brain`) collapsed
every brain `Err(_)` into a `DeterministicFallbackDecideBrain` call,
pushing a `BrainJudgmentRecord` with `fallback: true` and the prefix-
routing rationale. On disk, this was **indistinguishable** from
"operator deliberately ran without an LLM brain":

```rust
// BEFORE — src/ooda_loop/decide.rs:67-77
Err(_) => {
    let j = fallback.judge_decision(&ctx)?;
    push_brain_judgment(BrainJudgmentRecord::from_decide(
        &priority.goal_id, priority.urgency, &j, true, String::new(),
    ));
    j
}
```

No log, no metric, no breadcrumb on the cycle JSON. Daemon kept running.
Dashboard kept showing "fallback used". Goals kept making 0.00%
progress until someone happened to watch the dashboard for hours.

## Fix shape

Single helper `record_parse_failure(phase, goal_id, err, raw_response,
prompt_name, prompt_version)` fires all **four visibility channels**:

| # | Channel | Where it lands |
|---|---|---|
| 1 | `tracing::error!(target: "simard::ooda_brain", ...)` | `journalctl`, log aggregators |
| 2 | `record_metric("brain_parse_failure", 1.0, &json_ctx)` | `~/.simard/metrics/metrics.jsonl` |
| 3 | `BrainJudgmentRecord.parse_failure: Some(ParseFailureRecord)` | `~/.simard/cycle_reports/cycle_*.json` |
| 4 | `gh issue create --label ooda-brain-parse-failure` at ≥3 consecutive | `rysweet/Simard` tracker |

Call sites updated to:
- Extract the raw model response from the embedded `raw_response={:?}`
  marker in the error reason.
- Call `record_parse_failure`, push `BrainJudgmentRecord` with
  `parse_failure: Some(pf)`, **then** still fall back to the
  deterministic action so the cycle continues (per ambiguity-resolution
  table item A3 — abort would lose the cycle report, violating the
  acceptance criterion).
- Call `reset_consecutive_count` on the next successful parse so a
  recovery cancels any pending gh-issue escalation.

`DeterministicFallback*Brain` is **kept** as a legitimate no-LLM
bootstrap path (A5 — only its use as a silent error-swallower is
removed; broader removal is #1748 scope).

## Before / after evidence

### `cycle_*.json` (channel 3)

**Before** — silent fallback indistinguishable from no-LLM bootstrap:
```json
{
  "phase": "decide",
  "decision": "advance_goal",
  "rationale": "fallback-brain: prefix-routed",
  "fallback": true,
  "confidence": 0.5
}
```

**After** — fallback flag preserved for dashboard back-compat **and**
the parse-failure breadcrumb is loud:
```json
{
  "phase": "decide",
  "decision": "advance_goal",
  "rationale": "fallback-brain: prefix-routed",
  "fallback": true,
  "confidence": 0.5,
  "parse_failure": {
    "phase": "decide",
    "goal_id": "fix-broken-features",
    "error_message": "ooda-decide-brain: decide brain response had no JSON object; raw_response=\"OK\"",
    "raw_response_truncated": "OK",
    "prompt_name": "ooda_decide.md",
    "prompt_version": "abc123def456",
    "consecutive_count": 2,
    "retry_attempted": false,
    "timestamp": "2024-01-01T00:00:00+00:00"
  }
}
```

### `tracing::error!` (channel 1)

```
ERROR simard::ooda_brain: brain parse failed — falling back to deterministic floor (issue #1890)
  phase=decide
  goal_id=fix-broken-features
  error="ooda-decide-brain: decide brain response had no JSON object; raw_response=\"OK\""
  raw_response_truncated=OK
  prompt_name=ooda_decide.md
  prompt_version=abc123def456
  consecutive_count=2
  retry_attempted=false
```

### `metrics.jsonl` (channel 2)

```json
{"timestamp":"2024-01-01T00:00:00Z","metric_name":"brain_parse_failure","value":1.0,"context":"{\"phase\":\"decide\",\"goal_id\":\"fix-broken-features\",\"consecutive_count\":2,\"retry_attempted\":false,\"prompt_name\":\"ooda_decide.md\"}"}
```

### `gh issue create` (channel 4) — fires at consecutive_count ≥ 3

Title: `OODA decide brain parse-failure on goal 'fix-broken-features' (3 consecutive cycles)`
Label: `ooda-brain-parse-failure`
Body: full error + raw response + prompt + operator runbook link.
Suppressed under `cfg(test)` (no spurious test issues) and via env var
`SIMARD_BRAIN_PARSE_FAILURE_NO_ESCALATE=1` for incident-response.

## Test plan

- **15 TDD tests** in `src/ooda_loop/tests_parse_failure_1890.rs` —
  red-phase (commit 5af4f429) then green (commit 0c7d63d9). Cover Err
  path on both decide and orient, raw_response/error_message
  propagation, per-(phase, goal_id) counter isolation, reset on next
  Ok, per-priority continuation (cycle doesn't stall), dashboard
  back-compat (`fallback: true` stays), JSON serialisation round-trip.
- **11 schema tests** in `src/ooda_brain/parse_failure.rs::tests` —
  truncation on UTF-8 boundary (3-byte multibyte regression),
  consecutive-count increment, scoped reset, serde round-trip with
  quotes/braces in raw_response.
- **2 persistence regression tests** in
  `src/operator_commands_ooda/persistence.rs::tests`:
  - `persist_cycle_report_round_trips_parse_failure_field` —
    `Some(pf)` lands intact on cycle JSON.
  - `persist_cycle_report_omits_parse_failure_when_none` — `None`
    case emits **nothing**, so pre-PR readers see byte-for-byte the
    same shape.
- **Full lib suite**: `cargo test --lib` — 4181 passed, 0 failed.
- **Lint gate**: `cargo clippy --release --no-deps --all-targets -- -D
  warnings` — clean.
- **Format gate**: `cargo fmt --all -- --check` — clean.

## Ambiguity resolution (Step 2c — reproduced verbatim from worktree
plan)

| # | Decision |
|---|---|
| A1 | Reuse `SimardError::AdapterInvocationFailed` — no new variant. |
| A2 | Skip bounded retry — brain trait can't accept feedback without breaking change. `retry_attempted: false` reserved in schema for future. |
| A3 | Cycle continues via deterministic fallback action; parse_failure record makes degradation visible. |
| A4 | Additive `parse_failure: Option<ParseFailureRecord>` field, default-skipped on serialise. |
| A5 | Keep `DeterministicFallback*Brain` for no-LLM bootstrap; only remove its use as silent error-swallower. |
| A6 | `gh issue create` at ≥3 consecutive failures per (phase, goal_id), mirroring spawn.rs. |
| A7 | Metric `brain_parse_failure` with JSON context dimensions. |
| A8 | 8 KiB truncation cap via existing UTF-8-safe `truncate_to_char_boundary`. |
| A9 | Truncation = sanitization (model output to *our* prompt; full body needed for debugging). |
| A12 | "Toggle" was the `match { Err(_) => deterministic }` arm itself. Removing it removes the toggle. |

## Files changed

| File | Lines | Purpose |
|---|---|---|
| `src/ooda_brain/parse_failure.rs` | +420 (NEW) | `ParseFailureRecord`, `record_parse_failure` four-channel helper, per-(phase, goal_id) counter, 11 schema tests. |
| `src/ooda_brain/judgment_record.rs` | +12 | Additive `parse_failure` field, `Hash` derive on `BrainPhase`. |
| `src/ooda_brain/mod.rs` | +2 | Declare module + re-export. |
| `src/ooda_loop/decide.rs` | +40 / -13 | Wire `record_parse_failure` on Err, `reset_consecutive_count` on Ok. |
| `src/ooda_loop/orient.rs` | +60 / -16 | Split `Err` from `Ok-with-invalid` arm; wire same channels. |
| `src/ooda_loop/tests_parse_failure_1890.rs` | +638 (NEW) | 15 TDD tests. |
| `src/operator_commands_ooda/persistence.rs` | +93 | 2 round-trip regression tests + 1 literal updated. |
| `src/operator_commands_ooda/tests/persistence_tests.rs` | +1 | 1 literal updated. |
| `docs/howto/diagnose-decide-orient-parse-failures.md` | NEW | Operator runbook (already in spec branch). |
| `docs/reference/ooda-brain-parse-failure-record.md` | NEW | Schema spec (already in spec branch). |
| `docs/index.md` | +2 | Doc cross-links. |

## Closes

Closes #1890
