### PR TITLE
fix(base-types): align gpt-5 between meeting --help examples and registry validator (#1907)

### DIFF
--- a/src/bootstrap/assembly.rs
+++ b/src/bootstrap/assembly.rs
@@ -37,6 +37,35 @@ const COPILOT_SDK_BASE_TYPE: &str = "copilot-sdk";
 const CLAUDE_AGENT_SDK_BASE_TYPE: &str = "claude-agent-sdk";
 const MS_AGENT_FRAMEWORK_BASE_TYPE: &str = "ms-agent-framework";
 
+/// Canonical list of built-in base-type identifiers that have an adapter
+/// registered by [`register_builtin_base_type`].
+///
+/// This is the single source of truth for *which identifiers a manifest may
+/// declare* under `supported_base_types` and have actually wired to a real
+/// adapter at runtime. Any identifier outside this list will be silently
+/// skipped by `register_builtin_base_type` and then surface as
+/// [`crate::SimardError::AdapterNotRegistered`] when the runtime tries to
+/// look it up.
+///
+/// Operator-visible help text that advertises a base-type identifier as an
+/// example MUST only use identifiers from this list; the consistency
+/// regression test in `tests/help_base_type_consistency.rs` enforces that
+/// invariant (issue #1907).
+pub const KNOWN_BUILTIN_BASE_TYPE_IDS: &[&str] = &[
+    LOCAL_BASE_TYPE,
+    TERMINAL_SHELL_BASE_TYPE,
+    RUSTY_CLAWD_BASE_TYPE,
+    COPILOT_SDK_BASE_TYPE,
+    CLAUDE_AGENT_SDK_BASE_TYPE,
+    MS_AGENT_FRAMEWORK_BASE_TYPE,
+];
+
+/// Return the canonical list of built-in base-type identifiers. See
+/// [`KNOWN_BUILTIN_BASE_TYPE_IDS`].
+pub fn known_builtin_base_type_ids() -> &'static [&'static str] {
+    KNOWN_BUILTIN_BASE_TYPE_IDS
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct LocalSessionExecution {
     pub outcome: SessionOutcome,

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -18,8 +18,9 @@ const LOCAL_BASE_TYPE: &str = "local-harness";
 
 // Re-export all public items so `crate::bootstrap::X` still works.
 pub use assembly::{
-    LocalSessionExecution, assemble_local_runtime, assemble_local_runtime_from_handoff,
-    builtin_base_type_registry_for_manifest, latest_local_handoff, run_local_session,
+    KNOWN_BUILTIN_BASE_TYPE_IDS, LocalSessionExecution, assemble_local_runtime,
+    assemble_local_runtime_from_handoff, builtin_base_type_registry_for_manifest,
+    known_builtin_base_type_ids, latest_local_handoff, run_local_session,
 };
 pub use config::BootstrapConfig;
 pub use types::{BootstrapInputs, BootstrapMode, ConfigValue, ConfigValueSource};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,8 +147,9 @@ pub use base_types::{
 };
 pub use bootstrap::{
     BootstrapConfig, BootstrapInputs, BootstrapMode, ConfigValue, ConfigValueSource,
-    LocalSessionExecution, assemble_local_runtime, assemble_local_runtime_from_handoff,
-    bootstrap_entrypoint, builtin_base_type_registry_for_manifest, latest_local_handoff,
+    KNOWN_BUILTIN_BASE_TYPE_IDS, LocalSessionExecution, assemble_local_runtime,
+    assemble_local_runtime_from_handoff, bootstrap_entrypoint,
+    builtin_base_type_registry_for_manifest, known_builtin_base_type_ids, latest_local_handoff,
     run_local_session,
 };
 pub use bridge::{
@@ -262,7 +263,9 @@ pub use ooda_scheduler::{
 pub use test_support::TestAdapter;
 
 pub use metadata::{BackendDescriptor, Freshness, FreshnessState, Provenance};
-pub use operator_cli::{dispatch_operator_cli, operator_cli_help, operator_cli_usage};
+pub use operator_cli::{
+    all_operator_help_texts, dispatch_operator_cli, operator_cli_help, operator_cli_usage,
+};
 pub use operator_commands::{
     dispatch_legacy_gym_cli, dispatch_operator_probe, gym_usage, run_bootstrap_probe,
     run_copilot_submit_probe, run_engineer_loop_probe, run_engineer_read_probe,

--- a/src/operator_cli/meeting.rs
+++ b/src/operator_cli/meeting.rs
@@ -25,8 +25,8 @@ If no command is given, an interactive REPL is started with a timestamp topic.
 Examples:
   simard meeting --help
   simard meeting repl \"weekly sync\"
-  simard meeting run gpt-5 ring \"design review\"
-  simard meeting read gpt-5 ring
+  simard meeting run local-harness ring \"design review\"
+  simard meeting read local-harness ring
 ";
 
 pub(super) fn dispatch_meeting_command(

--- a/src/operator_cli/mod.rs
+++ b/src/operator_cli/mod.rs
@@ -172,6 +172,21 @@ pub fn operator_cli_help() -> &'static str {
     OPERATOR_CLI_HELP
 }
 
+/// Return every user-facing `--help` text block emitted by the operator CLI,
+/// paired with a stable label.
+///
+/// This is consumed by the help/registry consistency regression test in
+/// `tests/help_base_type_consistency.rs` (issue #1907) so that no help block
+/// can silently drift to advertise a base-type identifier that the runtime
+/// registry will reject. When you add a new operator-visible `--help`
+/// constant, add it here too.
+pub fn all_operator_help_texts() -> &'static [(&'static str, &'static str)] {
+    &[
+        ("operator-cli", OPERATOR_CLI_HELP),
+        ("meeting", meeting::MEETING_HELP),
+    ]
+}
+
 fn dispatch_bootstrap_command(
     mut args: impl Iterator<Item = String>,
 ) -> Result<(), Box<dyn std::error::Error>> {

--- a/tests/help_base_type_consistency.rs
+++ b/tests/help_base_type_consistency.rs
@@ -1,0 +1,214 @@
+//! Regression test for issue #1907 (base-type registry inconsistency).
+//!
+//! Every base-type identifier advertised in any user-facing `--help`
+//! example string must round-trip successfully through the built-in
+//! base-type registry that `goal-curation read`, `improvement-curation
+//! read`, and `meeting run/read` validate against. Otherwise an operator
+//! who copy-pastes the example will hit a hard
+//! `AdapterNotRegistered` error (Pillar 11 violation).
+//!
+//! The original drift: `simard meeting --help` shipped `gpt-5` in its
+//! examples but `gpt-5` was never wired through `register_builtin_base_type`,
+//! so adjacent surfaces rejected it. This test ensures the help text
+//! and the registry stay synchronized regardless of which one drifts in
+//! the future.
+
+use simard::{all_operator_help_texts, known_builtin_base_type_ids};
+
+/// Commands whose `run`/`read` subcommand takes a base-type identifier
+/// as a positional argument, paired with the index offset where the
+/// base-type token appears after the verb (0 = the very next token).
+///
+/// `bootstrap run` is intentionally offset 1 because its signature is
+/// `bootstrap run <identity> <base-type> <topology> <objective>`.
+const BASE_TYPE_BEARING_COMMANDS: &[(&str, &str, usize)] = &[
+    ("meeting", "run", 0),
+    ("meeting", "read", 0),
+    ("goal-curation", "run", 0),
+    ("goal-curation", "read", 0),
+    ("improvement-curation", "run", 0),
+    ("improvement-curation", "read", 0),
+    ("review", "run", 0),
+    ("review", "read", 0),
+    ("bootstrap", "run", 1),
+];
+
+/// Walk a help-text block and return every concrete base-type
+/// identifier it advertises in an `Examples:` line (i.e. tokens that are
+/// not angle-bracket placeholders like `<base-type>`).
+fn extract_help_base_type_examples(help_text: &str) -> Vec<(usize, String)> {
+    let mut hits = Vec::new();
+    for (lineno, line) in help_text.lines().enumerate() {
+        let words: Vec<&str> = line.split_whitespace().collect();
+        let Some(simard_pos) = words.iter().position(|w| *w == "simard") else {
+            continue;
+        };
+        for (cmd, verb, offset) in BASE_TYPE_BEARING_COMMANDS {
+            let cmd_pos = simard_pos + 1;
+            let verb_pos = simard_pos + 2;
+            let token_pos = verb_pos + 1 + offset;
+            if words.get(cmd_pos).copied() != Some(cmd) {
+                continue;
+            }
+            if words.get(verb_pos).copied() != Some(verb) {
+                continue;
+            }
+            let Some(raw_token) = words.get(token_pos) else {
+                continue;
+            };
+            let token = raw_token.trim_matches(|c: char| c == '"' || c == '\\');
+            if token.is_empty() || token.starts_with('<') {
+                continue;
+            }
+            hits.push((lineno + 1, token.to_string()));
+        }
+    }
+    hits
+}
+
+#[test]
+fn every_help_example_base_type_is_registered() {
+    let registered: Vec<&str> = known_builtin_base_type_ids().to_vec();
+    let mut violations: Vec<String> = Vec::new();
+    let mut total_examples = 0usize;
+
+    for (label, help_text) in all_operator_help_texts() {
+        for (lineno, token) in extract_help_base_type_examples(help_text) {
+            total_examples += 1;
+            if !registered.contains(&token.as_str()) {
+                violations.push(format!(
+                    "help block '{label}' line {lineno}: example uses '{token}', \
+                     which is not in the built-in base-type registry \
+                     {registered:?}. Either register the adapter for '{token}' \
+                     via `register_builtin_base_type` and add it to \
+                     `KNOWN_BUILTIN_BASE_TYPE_IDS`, or change the help example \
+                     to use a registered identifier."
+                ));
+            }
+        }
+    }
+
+    assert!(
+        total_examples > 0,
+        "extractor found zero base-type example tokens across all help \
+         blocks; this most likely means the parser regressed (or the help \
+         text format changed). Help blocks scanned: {:?}",
+        all_operator_help_texts()
+            .iter()
+            .map(|(label, _)| *label)
+            .collect::<Vec<_>>()
+    );
+
+    assert!(
+        violations.is_empty(),
+        "help <-> base-type registry drift detected (issue #1907):\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn registry_canonical_list_matches_spec() {
+    // Specs/ProductArchitecture.md §"Agent Base Type" enumerates the
+    // builtin manifest-advertised base types. If a new builtin adapter
+    // ships, both this list and the spec table need to be updated in
+    // lockstep.
+    let ids = known_builtin_base_type_ids();
+    let must_have = [
+        "local-harness",
+        "terminal-shell",
+        "rusty-clawd",
+        "copilot-sdk",
+    ];
+    for id in must_have {
+        assert!(
+            ids.contains(&id),
+            "spec-required base type '{id}' missing from \
+             KNOWN_BUILTIN_BASE_TYPE_IDS = {ids:?}"
+        );
+    }
+}
+
+// ── parser self-tests: make sure the extractor itself is correct so the
+// integration test above can't silently pass with zero matches ──
+
+#[test]
+fn extractor_returns_literal_base_type_examples() {
+    let help = "\
+Examples:
+  simard meeting run local-harness ring \"design review\"
+  simard meeting read local-harness ring
+  simard meeting --help
+  simard meeting repl \"weekly sync\"
+";
+    let hits = extract_help_base_type_examples(help);
+    let tokens: Vec<&str> = hits.iter().map(|(_, t)| t.as_str()).collect();
+    assert_eq!(
+        tokens,
+        vec!["local-harness", "local-harness"],
+        "extractor should pick up both literal base-type tokens"
+    );
+}
+
+#[test]
+fn extractor_skips_angle_bracket_placeholders() {
+    let help = "\
+  meeting run <base-type> <topology> <objective>
+  meeting read <base-type> <topology>
+";
+    let hits = extract_help_base_type_examples(help);
+    assert!(
+        hits.is_empty(),
+        "extractor must skip <placeholder> tokens, but found: {hits:?}"
+    );
+}
+
+#[test]
+fn extractor_handles_bootstrap_run_offset() {
+    // `bootstrap run <identity> <base-type> ...` — base-type is the
+    // 2nd token after the verb, not the 1st.
+    let help = "  simard bootstrap run simard-engineer terminal-shell single-process \"obj\"";
+    let hits = extract_help_base_type_examples(help);
+    let tokens: Vec<&str> = hits.iter().map(|(_, t)| t.as_str()).collect();
+    assert_eq!(tokens, vec!["terminal-shell"]);
+}
+
+#[test]
+fn extractor_skips_unrelated_run_commands() {
+    // `gym run <scenario>` and `engineer run <topology>` are not
+    // base-type-leading — the extractor must not flag their first
+    // positional as a base type.
+    let help = "\
+  simard gym run dep-analysis-cargo-audit
+  simard engineer run single-process /tmp/ws \"obj\"
+  simard ooda run --cycles=3
+";
+    let hits = extract_help_base_type_examples(help);
+    assert!(
+        hits.is_empty(),
+        "extractor must not flag positional args of unrelated commands, \
+         but found: {hits:?}"
+    );
+}
+
+#[test]
+fn extractor_flags_gpt5_in_pre_fix_meeting_help() {
+    // This is the exact pre-fix MEETING_HELP example block. The test
+    // pins the behavior: if anyone re-introduces 'gpt-5' (or any other
+    // unregistered identifier) into a meeting --help example, the
+    // integration test `every_help_example_base_type_is_registered`
+    // will catch it because the extractor reliably finds the token.
+    let pre_fix_help = "\
+Examples:
+  simard meeting --help
+  simard meeting repl \"weekly sync\"
+  simard meeting run gpt-5 ring \"design review\"
+  simard meeting read gpt-5 ring
+";
+    let hits = extract_help_base_type_examples(pre_fix_help);
+    let tokens: Vec<String> = hits.into_iter().map(|(_, t)| t).collect();
+    assert!(
+        tokens.iter().any(|t| t == "gpt-5"),
+        "extractor must surface the regressed token 'gpt-5'; \
+         found tokens = {tokens:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #1907 — the `simard meeting --help` examples advertised `gpt-5` as a base type, but `gpt-5` was never wired through `register_builtin_base_type`. Operators who copy-pasted the meeting example into the adjacent `goal-curation read` or `improvement-curation read` surfaces hit a hard `no adapter is registered for base type 'gpt-5'` error — a Pillar 11 honest-degradation violation.

**Audit context:** cycle-1 audit #1910, item #6 (MEDIUM user-impact).

## Resolution

`gpt-5` is a model name, not an execution substrate, so it was never a valid base type. This PR replaces `gpt-5` in `MEETING_HELP` examples with `local-harness` — the spec-canonical default that works without authentication and is supported by every operator role.

## Drift prevention (the surgical change beyond the one-line fix)

- Promote the canonical six built-in base-type identifiers (`local-harness`, `terminal-shell`, `rusty-clawd`, `copilot-sdk`, `claude-agent-sdk`, `ms-agent-framework`) into a single source of truth `bootstrap::KNOWN_BUILTIN_BASE_TYPE_IDS`, re-exported from the crate root as `known_builtin_base_type_ids()`.
- Expose every operator-facing `--help` text block via `all_operator_help_texts()` so a regression test can scan them.
- New integration test `tests/help_base_type_consistency.rs` scans every exposed help block, extracts every concrete base-type identifier used in a `simard <cmd> run|read <BASE_TYPE> …` example (skipping `<placeholder>` tokens and unrelated commands like `gym run`), and asserts each one round-trips through `KNOWN_BUILTIN_BASE_TYPE_IDS`. The extractor itself is covered by five self-tests including one that pins `gpt-5` as a detectable regressed token, so the integration test cannot silently pass with zero matches.

## Verification

- `cargo test --test help_base_type_consistency` → **7/7 pass**.
- **Negative control:** temporarily re-introducing `gpt-5` into `MEETING_HELP` makes the new integration test fail with a clear actionable error message naming the help block, line number, offending token, and the registered set.
- `cargo test --lib --tests` → **4154/4155 pass**; the one failure (`engineer_worktree::tests::allocate_creates_unique_worktree_under_state_root`) is a pre-existing flake unrelated to this change — passes in isolation, git is available on PATH.
- `cargo clippy --all-targets -- -D warnings` → **clean**.
- pre-commit hooks (`cargo fmt --check`, `cargo clippy --release --no-deps`) → **passed**.

## Scope discipline

This PR intentionally does NOT also tackle #1909 (`meeting`/`improvement-curation`/`review` `read` companions not honoring `SIMARD_STATE_ROOT` fallback). #1909 is a separate audit item and belongs in its own surgical PR so the cycle-1 audit gets a clean, mergeable first fix.

## Diff focus

Six files: one literal fix in `MEETING_HELP`, three small additions to expose the registry list and help texts publicly, two re-exports, plus the new test file. No unrelated edits.

Refs #1907, #1910.
