### PR TITLE
fix(read-subcommands): graceful state-root fallback for meeting/improvement-curation/review (#1909)

### DIFF
--- a/src/operator_commands/mod.rs
+++ b/src/operator_commands/mod.rs
@@ -50,10 +50,11 @@ pub(crate) use recipes::{
     print_terminal_recipe,
 };
 pub(crate) use state_root::{
-    parse_runtime_topology, prompt_root, resolved_engineer_read_state_root,
-    resolved_goal_curation_state_root, resolved_improvement_curation_read_state_root,
-    resolved_meeting_read_state_root, resolved_review_state_root, resolved_state_root,
-    resolved_terminal_read_state_root, validated_runtime_segments,
+    parse_runtime_topology, prompt_root, resolve_read_state_root_with_daemon_fallback,
+    resolved_engineer_read_state_root, resolved_goal_curation_state_root,
+    resolved_improvement_curation_read_state_root, resolved_meeting_read_state_root,
+    resolved_review_read_state_root, resolved_review_state_root, resolved_state_root,
+    resolved_terminal_read_state_root,
 };
 pub(crate) use validation::{validated_engineer_read_artifacts, validated_terminal_read_artifacts};
 

--- a/src/operator_commands/state_root.rs
+++ b/src/operator_commands/state_root.rs
@@ -118,6 +118,64 @@ pub(crate) fn resolved_goal_curation_state_root(
     )
 }
 
+/// Result of resolving a read-companion's state root with the
+/// canonical-daemon-store fallback (issue #1909).
+///
+/// `used_override` records whether the path came from the operator's
+/// explicit `[state-root]` argument (strict-mode contract) or from the
+/// daemon fallback (lenient-mode contract). Callers use this flag to
+/// decide whether missing artifacts must hard-fail (override case) or
+/// should render as `<none>` / `0` (fallback case).
+pub(crate) struct ResolvedReadStateRoot {
+    pub(crate) path: PathBuf,
+    pub(crate) used_override: bool,
+}
+
+/// Shared resolver for `<mode> read` subcommands that need to fall back
+/// to the canonical daemon store (`memory_ipc::default_state_root()`,
+/// i.e. `$SIMARD_STATE_ROOT` or `$HOME/.simard/state`) when the operator
+/// does not pass an explicit `[state-root]` argument.
+///
+/// Resolution order:
+///   1. `explicit` — when the operator passes a path, honor it after
+///      `validate_state_root` checks. Strict contract: subsequent
+///      validations (mode-specific artifact requirements) still apply.
+///   2. `memory_ipc::default_state_root()` — the canonical daemon store
+///      that the OODA daemon, the meeting greeting banner, and
+///      `goal-curation read` all share (issue #1742, #1909). Lenient
+///      contract: callers should render `<none>` / `0` instead of
+///      erroring on missing artifacts.
+///
+/// `identity`, `base_type`, and `topology` are validated even on the
+/// fallback path so bogus values still fail fast with a clear error —
+/// preserving the prior probe-resolution contract for the operator's
+/// mental model.
+pub(crate) fn resolve_read_state_root_with_daemon_fallback(
+    explicit: Option<PathBuf>,
+    identity: &str,
+    base_type: &str,
+    topology: &str,
+) -> crate::SimardResult<ResolvedReadStateRoot> {
+    match explicit {
+        Some(path) => Ok(ResolvedReadStateRoot {
+            path: crate::bootstrap::validate_state_root(path)?,
+            used_override: true,
+        }),
+        None => {
+            // Validate base_type / topology so bogus values still fail
+            // fast with a clear error (preserves the prior probe
+            // resolution contract — see goal-curation #1742).
+            let _ = validated_runtime_segments(identity, base_type, topology)?;
+            let path =
+                crate::bootstrap::validate_state_root(crate::memory_ipc::default_state_root())?;
+            Ok(ResolvedReadStateRoot {
+                path,
+                used_override: false,
+            })
+        }
+    }
+}
+
 pub(crate) fn resolved_review_state_root(
     explicit: Option<PathBuf>,
     base_type: &str,
@@ -136,10 +194,17 @@ pub(crate) fn resolved_improvement_curation_read_state_root(
     explicit: Option<PathBuf>,
     base_type: &str,
     topology: &str,
-) -> crate::SimardResult<PathBuf> {
-    let state_root = resolved_review_state_root(explicit, base_type, topology)?;
-    validate_improvement_curation_read_state_root(&state_root)?;
-    Ok(state_root)
+) -> crate::SimardResult<ResolvedReadStateRoot> {
+    let resolved = resolve_read_state_root_with_daemon_fallback(
+        explicit,
+        "simard-engineer",
+        base_type,
+        topology,
+    )?;
+    if resolved.used_override {
+        validate_improvement_curation_read_state_root(&resolved.path)?;
+    }
+    Ok(resolved)
 }
 
 pub(crate) fn resolved_engineer_read_state_root(
@@ -176,16 +241,34 @@ pub(crate) fn resolved_meeting_read_state_root(
     explicit: Option<PathBuf>,
     base_type: &str,
     topology: &str,
-) -> crate::SimardResult<PathBuf> {
-    let state_root = resolved_state_root(
+) -> crate::SimardResult<ResolvedReadStateRoot> {
+    let resolved = resolve_read_state_root_with_daemon_fallback(
         explicit,
         "simard-meeting",
         base_type,
         topology,
-        "meeting-run",
     )?;
-    validate_meeting_read_state_root(&state_root)?;
-    Ok(state_root)
+    if resolved.used_override {
+        validate_meeting_read_state_root(&resolved.path)?;
+    }
+    Ok(resolved)
+}
+
+/// Resolve the state root for `review read` with the daemon-store
+/// fallback (issue #1909). Distinct from `resolved_review_state_root`,
+/// which is reused by both `review run` and `improvement-curation run`
+/// to point at the probe-isolated sandbox.
+///
+/// `review read` itself does not require a mode-specific structural
+/// validation beyond the path checks `validate_state_root` already
+/// performs; the downstream code asserts (or — on the fallback path —
+/// gracefully reports) the presence of the review artifact directory.
+pub(crate) fn resolved_review_read_state_root(
+    explicit: Option<PathBuf>,
+    base_type: &str,
+    topology: &str,
+) -> crate::SimardResult<ResolvedReadStateRoot> {
+    resolve_read_state_root_with_daemon_fallback(explicit, "simard-engineer", base_type, topology)
 }
 
 pub(crate) fn parse_runtime_topology(value: &str) -> crate::SimardResult<RuntimeTopology> {

--- a/src/operator_commands_meeting/goal_curation.rs
+++ b/src/operator_commands_meeting/goal_curation.rs
@@ -1,8 +1,8 @@
 use std::path::PathBuf;
 
 use crate::operator_commands::{
-    GoalRegisterView, print_display, print_text, prompt_root, resolved_goal_curation_state_root,
-    validated_runtime_segments,
+    GoalRegisterView, print_display, print_text, prompt_root,
+    resolve_read_state_root_with_daemon_fallback, resolved_goal_curation_state_root,
 };
 use crate::{BootstrapConfig, BootstrapInputs, run_local_session};
 
@@ -57,37 +57,22 @@ pub fn run_goal_curation_probe(
 /// banner read from the **same** store, otherwise the operator gets two
 /// different answers to the same question (issue #1744).
 ///
-/// Resolution order:
-///   1. `state_root_override` — when the operator explicitly passes a path
-///      (e.g. to inspect the probe-isolated sandbox written by
-///      `goal-curation run`), honor it after `validate_state_root` checks.
-///   2. `memory_ipc::default_state_root()` — the canonical daemon store
-///      that both the OODA daemon and the meeting greeting banner already
-///      read from. This is `$SIMARD_STATE_ROOT` (when set) or
-///      `$HOME/.simard/state`.
-///
-/// Previously this defaulted to a probe-isolated path under
-/// `target/operator-probe-state/goal-curation-run/<identity>/<base>/<topology>/`,
-/// which is only populated when `goal-curation run` was previously executed
-/// against that exact base-type+topology pair. On a freshly-built binary
-/// the command silently reported "Active goals count: 0" while the banner
-/// showed N>0 goals from the daemon's actual store — a Pillar 11 violation.
+/// Delegates to the shared `resolve_read_state_root_with_daemon_fallback`
+/// helper so the same daemon-store fallback is applied consistently
+/// across `meeting`, `improvement-curation`, `review`, and
+/// `goal-curation` (issue #1909).
 fn resolve_goal_curation_read_state_root(
     state_root_override: Option<PathBuf>,
     base_type: &str,
     topology: &str,
 ) -> crate::SimardResult<PathBuf> {
-    match state_root_override {
-        Some(explicit) => crate::bootstrap::validate_state_root(explicit),
-        None => {
-            // Even though base-type / topology no longer drive routing for
-            // the read path, validate them so bogus values still fail fast
-            // with a clear error — preserving the prior probe-resolution
-            // contract for the operator's mental model.
-            let _ = validated_runtime_segments("simard-goal-curator", base_type, topology)?;
-            crate::bootstrap::validate_state_root(crate::memory_ipc::default_state_root())
-        }
-    }
+    let resolved = resolve_read_state_root_with_daemon_fallback(
+        state_root_override,
+        "simard-goal-curator",
+        base_type,
+        topology,
+    )?;
+    Ok(resolved.path)
 }
 
 pub fn run_goal_curation_read_probe(

--- a/src/operator_commands_meeting/improvement_curation.rs
+++ b/src/operator_commands_meeting/improvement_curation.rs
@@ -108,18 +108,54 @@ pub fn run_improvement_curation_read_probe(
     topology: &str,
     state_root_override: Option<PathBuf>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let state_root =
+    let resolved =
         resolved_improvement_curation_read_state_root(state_root_override, base_type, topology)?;
-    let (review_artifact_path, review) =
-        latest_review_artifact(&state_root)?.ok_or("expected persisted review artifact")?;
-    let memory_store = FileBackedMemoryStore::try_new(state_root.join("memory_records.json"))?;
-    let latest_record = memory_store
-        .list(MemoryScope::Decision)?
-        .into_iter()
-        .rfind(|record| record.key.ends_with("improvement-curation-record"))
-        .ok_or("expected persisted improvement decision record")?;
-    let parsed_record = PersistedImprovementRecord::parse(&latest_record.value)
-        .map_err(|error| format!("{error}"))?;
+    let state_root = resolved.path;
+
+    // When the operator passes an explicit state root, the strict
+    // mode-specific validation in `resolved_improvement_curation_read_state_root`
+    // already enforced that `review-artifacts/` and `memory_records.json`
+    // exist — so `latest_review_artifact` and the decision-record
+    // lookup must succeed or hard-fail (preserves the prior contract).
+    //
+    // When we fell back to the canonical daemon store (no explicit
+    // override), missing artifacts must render as `<none>` / `0` so
+    // `simard improvement-curation read <base> <topology>` works on a
+    // fresh machine (issue #1909).
+    let review_lookup = latest_review_artifact(&state_root)?;
+    let (review_artifact_path, review) = match review_lookup {
+        Some(pair) => pair,
+        None if resolved.used_override => {
+            return Err("expected persisted review artifact".into());
+        }
+        None => {
+            return print_improvement_curation_empty_fallback(base_type, topology, &state_root);
+        }
+    };
+
+    let memory_records_path = state_root.join("memory_records.json");
+    let parsed_record = if memory_records_path.is_file() {
+        let memory_store = FileBackedMemoryStore::try_new(&memory_records_path)?;
+        let latest = memory_store
+            .list(MemoryScope::Decision)?
+            .into_iter()
+            .rfind(|record| record.key.ends_with("improvement-curation-record"));
+        match latest {
+            Some(record) => Some(
+                PersistedImprovementRecord::parse(&record.value)
+                    .map_err(|error| format!("{error}"))?,
+            ),
+            None if resolved.used_override => {
+                return Err("expected persisted improvement decision record".into());
+            }
+            None => None,
+        }
+    } else if resolved.used_override {
+        return Err("expected persisted improvement decision record".into());
+    } else {
+        None
+    };
+
     let goal_records = {
         // Issue #1590 follow-up: read goals through the
         // `CognitiveMemoryGoalStore` so the read probe surfaces the
@@ -133,56 +169,96 @@ pub fn run_improvement_curation_read_probe(
 
     println!("Probe mode: improvement-curation-read");
     println!("Identity: simard-improvement-curator");
-    print_text(
-        "Selected base type",
-        parsed_record
-            .selected_base_type
-            .as_deref()
-            .unwrap_or(&review.selected_base_type),
-    );
-    print_text(
-        "Topology",
-        parsed_record
-            .topology
-            .as_deref()
-            .unwrap_or(&review.topology),
-    );
+    let displayed_base_type = parsed_record
+        .as_ref()
+        .and_then(|record| record.selected_base_type.as_deref())
+        .unwrap_or(&review.selected_base_type);
+    print_text("Selected base type", displayed_base_type);
+    let displayed_topology = parsed_record
+        .as_ref()
+        .and_then(|record| record.topology.as_deref())
+        .unwrap_or(&review.topology);
+    print_text("Topology", displayed_topology);
     print_display("State root", state_root.display());
     print_display("Latest review artifact", review_artifact_path.display());
     print_text("Review id", &review.review_id);
     print_text("Review target", &review.target_label);
     println!("Review proposals: {}", review.proposals.len());
-    println!(
-        "Approved proposals: {}",
-        parsed_record.approved_proposals.len()
-    );
-    if parsed_record.approved_proposals.is_empty() {
-        println!("Approved proposals: <none>");
-    } else {
-        for (index, approval) in parsed_record.approved_proposals.iter().enumerate() {
-            print_text(
-                &format!("Approved proposal {}", index + 1),
-                approval.concise_label(),
-            );
+
+    match parsed_record.as_ref() {
+        Some(record) => {
+            println!("Approved proposals: {}", record.approved_proposals.len());
+            if record.approved_proposals.is_empty() {
+                println!("Approved proposals: <none>");
+            } else {
+                for (index, approval) in record.approved_proposals.iter().enumerate() {
+                    print_text(
+                        &format!("Approved proposal {}", index + 1),
+                        approval.concise_label(),
+                    );
+                }
+            }
+            println!("Deferred proposals: {}", record.deferred_proposals.len());
+            if record.deferred_proposals.is_empty() {
+                println!("Deferred proposals: <none>");
+            } else {
+                for (index, deferral) in record.deferred_proposals.iter().enumerate() {
+                    print_text(
+                        &format!("Deferred proposal {}", index + 1),
+                        format!("{} ({})", deferral.title, deferral.rationale),
+                    );
+                }
+            }
         }
-    }
-    println!(
-        "Deferred proposals: {}",
-        parsed_record.deferred_proposals.len()
-    );
-    if parsed_record.deferred_proposals.is_empty() {
-        println!("Deferred proposals: <none>");
-    } else {
-        for (index, deferral) in parsed_record.deferred_proposals.iter().enumerate() {
-            print_text(
-                &format!("Deferred proposal {}", index + 1),
-                format!("{} ({})", deferral.title, deferral.rationale),
-            );
+        None => {
+            // Daemon-fallback path with a review artifact present but no
+            // persisted improvement-curation decision record. Render
+            // explicit empty sections (Pillar 11 — issue #1909).
+            println!("Approved proposals: 0");
+            println!("Approved proposals: <none>");
+            println!("Deferred proposals: 0");
+            println!("Deferred proposals: <none>");
         }
     }
     print_goal_section(&goal_records, GoalStatus::Active, "Active");
     print_goal_section(&goal_records, GoalStatus::Proposed, "Proposed");
-    print_text("Latest improvement record", parsed_record.concise_record());
+    match parsed_record.as_ref() {
+        Some(record) => print_text("Latest improvement record", record.concise_record()),
+        None => print_text("Latest improvement record", "<none>"),
+    }
+    Ok(())
+}
+
+/// Render the empty-state output for the daemon-fallback path when no
+/// review artifact exists yet. Mirrors the shape of the populated path
+/// so operators see "0 / <none>" instead of a hard error (issue #1909).
+fn print_improvement_curation_empty_fallback(
+    base_type: &str,
+    topology: &str,
+    state_root: &std::path::Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let goal_records = {
+        use crate::goals::GoalStore as _;
+        let store = crate::goals::CognitiveMemoryGoalStore::new(state_root.to_path_buf())?;
+        store.list()?
+    };
+
+    println!("Probe mode: improvement-curation-read");
+    println!("Identity: simard-improvement-curator");
+    print_text("Selected base type", base_type);
+    print_text("Topology", topology);
+    print_display("State root", state_root.display());
+    print_text("Latest review artifact", "<none>");
+    print_text("Review id", "<none>");
+    print_text("Review target", "<none>");
+    println!("Review proposals: 0");
+    println!("Approved proposals: 0");
+    println!("Approved proposals: <none>");
+    println!("Deferred proposals: 0");
+    println!("Deferred proposals: <none>");
+    print_goal_section(&goal_records, GoalStatus::Active, "Active");
+    print_goal_section(&goal_records, GoalStatus::Proposed, "Proposed");
+    print_text("Latest improvement record", "<none>");
     Ok(())
 }
 
@@ -239,5 +315,60 @@ mod tests {
             Some(dir.path().to_path_buf()),
         );
         assert!(result.is_err());
+    }
+
+    // ───────────────────────────────────────────────────────────────────
+    // Issue #1909: `improvement-curation read` without an explicit
+    // `[state-root]` argument must fall back to the canonical daemon
+    // state root (`$SIMARD_STATE_ROOT` or `$HOME/.simard/state`) and
+    // render an explicit empty report when no persisted review artifact
+    // exists yet — instead of hard-failing on a fresh machine.
+    // ───────────────────────────────────────────────────────────────────
+
+    fn with_simard_state_root<R>(path: &std::path::Path, run: impl FnOnce() -> R) -> R {
+        let prev = std::env::var("SIMARD_STATE_ROOT").ok();
+        // SAFETY: gated on `serial_test::serial(simard_state_root)`.
+        unsafe {
+            std::env::set_var("SIMARD_STATE_ROOT", path);
+        }
+        let result = run();
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("SIMARD_STATE_ROOT", v),
+                None => std::env::remove_var("SIMARD_STATE_ROOT"),
+            }
+        }
+        result
+    }
+
+    #[test]
+    #[serial_test::serial(simard_state_root)]
+    fn improvement_curation_read_probe_falls_back_to_default_state_root_when_no_override() {
+        let dir = TempDir::new().unwrap();
+        // Empty state root — no review-artifacts/, no memory_records.json.
+        // Pre-fix this hard-failed with `expected persisted review artifact`.
+        // Post-fix it falls back and renders empty.
+        let result = with_simard_state_root(dir.path(), || {
+            run_improvement_curation_read_probe("local-harness", "single-process", None)
+        });
+        assert!(
+            result.is_ok(),
+            "improvement-curation read should succeed via daemon fallback when \
+             no override is given and the daemon store is empty: {:?}",
+            result.err()
+        );
+    }
+
+    #[test]
+    #[serial_test::serial(simard_state_root)]
+    fn improvement_curation_read_probe_fallback_rejects_bogus_topology() {
+        let dir = TempDir::new().unwrap();
+        let result = with_simard_state_root(dir.path(), || {
+            run_improvement_curation_read_probe("local-harness", "totally-bogus-topology", None)
+        });
+        assert!(
+            result.is_err(),
+            "bogus topology should fail validation even on the daemon-fallback path"
+        );
     }
 }

--- a/src/operator_commands_meeting/probes.rs
+++ b/src/operator_commands_meeting/probes.rs
@@ -76,18 +76,26 @@ pub fn run_meeting_read_probe(
     topology: &str,
     state_root_override: Option<PathBuf>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let state_root = resolved_meeting_read_state_root(state_root_override, base_type, topology)?;
-    let memory_store = FileBackedMemoryStore::try_new(state_root.join("memory_records.json"))?;
-    let meeting_records = memory_store
-        .list(MemoryScope::Decision)?
-        .into_iter()
-        .filter(|record| crate::looks_like_persisted_meeting_record(&record.value))
-        .collect::<Vec<_>>();
-    let latest_record = meeting_records
-        .last()
-        .ok_or("expected persisted meeting decision record")?;
-    let parsed_record =
-        PersistedMeetingRecord::parse(&latest_record.value).map_err(|error| format!("{error}"))?;
+    let resolved = resolved_meeting_read_state_root(state_root_override, base_type, topology)?;
+    let state_root = resolved.path;
+
+    let memory_records_path = state_root.join("memory_records.json");
+    let meeting_records: Vec<crate::MemoryRecord> = if memory_records_path.is_file() {
+        let memory_store = FileBackedMemoryStore::try_new(memory_records_path)?;
+        memory_store
+            .list(MemoryScope::Decision)?
+            .into_iter()
+            .filter(|record| crate::looks_like_persisted_meeting_record(&record.value))
+            .collect()
+    } else {
+        // The mode-specific validation in `resolved_meeting_read_state_root`
+        // already enforces that `memory_records.json` exists when the
+        // operator passed an explicit `[state-root]` (strict contract).
+        // Here we are on the daemon-fallback path with no persisted store
+        // yet; render explicit empty sections rather than hard-failing
+        // (issue #1909).
+        Vec::new()
+    };
 
     println!("Probe mode: meeting-read");
     println!("Identity: simard-meeting");
@@ -95,14 +103,42 @@ pub fn run_meeting_read_probe(
     print_text("Topology", topology);
     print_display("State root", state_root.display());
     println!("Meeting records: {}", meeting_records.len());
-    print_text("Latest agenda", &parsed_record.agenda);
-    print_string_section("Updates", &parsed_record.updates);
-    print_string_section("Decisions", &parsed_record.decisions);
-    print_string_section("Risks", &parsed_record.risks);
-    print_string_section("Next steps", &parsed_record.next_steps);
-    print_string_section("Open questions", &parsed_record.open_questions);
-    print_meeting_goal_section(&parsed_record.goals);
-    print_text("Latest meeting record", &latest_record.value);
+
+    match meeting_records.last() {
+        Some(latest_record) => {
+            let parsed_record = PersistedMeetingRecord::parse(&latest_record.value)
+                .map_err(|error| format!("{error}"))?;
+            print_text("Latest agenda", &parsed_record.agenda);
+            print_string_section("Updates", &parsed_record.updates);
+            print_string_section("Decisions", &parsed_record.decisions);
+            print_string_section("Risks", &parsed_record.risks);
+            print_string_section("Next steps", &parsed_record.next_steps);
+            print_string_section("Open questions", &parsed_record.open_questions);
+            print_meeting_goal_section(&parsed_record.goals);
+            print_text("Latest meeting record", &latest_record.value);
+        }
+        None if resolved.used_override => {
+            // Strict override contract: explicit state roots with no
+            // persisted meeting record must fail visibly. This preserves
+            // the contract tested in
+            // `simard_meeting_read_rejects_nonexistent_and_empty_state_roots_*`.
+            return Err("expected persisted meeting decision record".into());
+        }
+        None => {
+            // Daemon-fallback path with no persisted meeting record:
+            // render explicit zero-state sections so the operator sees
+            // the empty shape rather than a hard error (Pillar 11 —
+            // issue #1909).
+            print_text("Latest agenda", "<none>");
+            print_string_section("Updates", &[]);
+            print_string_section("Decisions", &[]);
+            print_string_section("Risks", &[]);
+            print_string_section("Next steps", &[]);
+            print_string_section("Open questions", &[]);
+            print_meeting_goal_section(&[]);
+            print_text("Latest meeting record", "<none>");
+        }
+    }
     Ok(())
 }
 
@@ -235,6 +271,96 @@ mod tests {
             "local-harness",
             "single-process",
             Some(dir.path().to_path_buf()),
+        );
+    }
+
+    // ───────────────────────────────────────────────────────────────────
+    // Issue #1909: `meeting read` without an explicit `[state-root]`
+    // argument must fall back to the canonical daemon state root
+    // (`$SIMARD_STATE_ROOT` or `$HOME/.simard/state`) and render an
+    // explicit empty report when no persisted meeting record exists —
+    // instead of hard-failing the way the prior probe-style resolution
+    // did on a fresh machine.
+    // ───────────────────────────────────────────────────────────────────
+
+    /// Helper: run a closure with `SIMARD_STATE_ROOT` temporarily
+    /// pointed at the given path. Restores the previous value (or
+    /// removes the var) on completion.
+    fn with_simard_state_root<R>(path: &std::path::Path, run: impl FnOnce() -> R) -> R {
+        let prev = std::env::var("SIMARD_STATE_ROOT").ok();
+        // SAFETY: callers gate this on `serial_test::serial(simard_state_root)`
+        // so no other test mutates the same env var concurrently.
+        unsafe {
+            std::env::set_var("SIMARD_STATE_ROOT", path);
+        }
+        let result = run();
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("SIMARD_STATE_ROOT", v),
+                None => std::env::remove_var("SIMARD_STATE_ROOT"),
+            }
+        }
+        result
+    }
+
+    #[test]
+    #[serial_test::serial(simard_state_root)]
+    fn meeting_read_probe_falls_back_to_default_state_root_when_no_override() {
+        let dir = TempDir::new().unwrap();
+        // Empty state root — no memory_records.json, no records of any kind.
+        // Pre-fix this hard-failed with `meeting read requires an existing
+        // state root directory`. Post-fix it falls back and renders empty.
+        let result = with_simard_state_root(dir.path(), || {
+            run_meeting_read_probe("local-harness", "single-process", None)
+        });
+        assert!(
+            result.is_ok(),
+            "meeting read should succeed via daemon fallback when no override is given \
+             and the daemon store is empty: {:?}",
+            result.err()
+        );
+    }
+
+    #[test]
+    #[serial_test::serial(simard_state_root)]
+    fn meeting_read_probe_falls_back_and_reads_real_records() {
+        let dir = TempDir::new().unwrap();
+        // Seed a real meeting decision record into the fallback path.
+        let record = "agenda=Daily standup; updates=[Pushed PR]; decisions=[Ship Friday]; risks=[]; next_steps=[]; open_questions=[]; goals=[]";
+        let records = serde_json::json!([{
+            "key": "session-X-meeting",
+            "scope": "decision",
+            "value": record,
+            "session_id": "session-X",
+            "recorded_in": "complete"
+        }]);
+        std::fs::write(
+            dir.path().join("memory_records.json"),
+            serde_json::to_string(&records).unwrap(),
+        )
+        .unwrap();
+        let result = with_simard_state_root(dir.path(), || {
+            run_meeting_read_probe("local-harness", "single-process", None)
+        });
+        assert!(
+            result.is_ok(),
+            "meeting read should succeed via daemon fallback and surface seeded records: {:?}",
+            result.err()
+        );
+    }
+
+    #[test]
+    #[serial_test::serial(simard_state_root)]
+    fn meeting_read_probe_fallback_rejects_bogus_topology() {
+        let dir = TempDir::new().unwrap();
+        // Even on the daemon-fallback path, base_type / topology validation
+        // must still fire — preserves the prior probe-resolution contract.
+        let result = with_simard_state_root(dir.path(), || {
+            run_meeting_read_probe("local-harness", "totally-bogus-topology", None)
+        });
+        assert!(
+            result.is_err(),
+            "bogus topology should fail validation even on the daemon-fallback path"
         );
     }
 }

--- a/src/operator_commands_review.rs
+++ b/src/operator_commands_review.rs
@@ -1,7 +1,8 @@
 use std::path::PathBuf;
 
 use crate::operator_commands::{
-    print_display, print_text, prompt_root, resolved_review_state_root,
+    print_display, print_text, prompt_root, resolved_review_read_state_root,
+    resolved_review_state_root,
 };
 use crate::sanitization::sanitize_terminal_text;
 use crate::{
@@ -95,15 +96,48 @@ pub fn run_review_read_probe(
     topology: &str,
     state_root_override: Option<PathBuf>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let state_root = resolved_review_state_root(state_root_override, base_type, topology)?;
-    let (review_artifact_path, review) =
-        latest_review_artifact(&state_root)?.ok_or("expected persisted review artifact")?;
-    let memory_store = FileBackedMemoryStore::try_new(state_root.join("memory_records.json"))?;
-    let decision_records = memory_store
-        .list(MemoryScope::Decision)?
-        .into_iter()
-        .filter(|record| record.value.starts_with("review-summary |"))
-        .collect::<Vec<_>>();
+    let resolved = resolved_review_read_state_root(state_root_override, base_type, topology)?;
+    let state_root = resolved.path;
+
+    // `latest_review_artifact` returns Ok(None) when the artifact
+    // directory does not exist, so we use that to differentiate the
+    // strict-override path (must succeed or hard-fail) from the
+    // daemon-fallback path (render `<none>` / `0` — issue #1909).
+    let review_lookup = latest_review_artifact(&state_root)?;
+    let (review_artifact_path, review) = match review_lookup {
+        Some(pair) => pair,
+        None if resolved.used_override => {
+            return Err("expected persisted review artifact".into());
+        }
+        None => {
+            // Daemon-fallback path with no review artifact yet — render
+            // empty sections (Pillar 11 — issue #1909).
+            println!("Probe mode: review-read");
+            print_text("Identity", "simard-engineer");
+            print_text("Selected base type", base_type);
+            print_text("Topology", topology);
+            print_display("State root", state_root.display());
+            print_text("Latest review artifact", "<none>");
+            print_text("Latest review target", "<none>");
+            print_text("Latest review summary", "<none>");
+            println!("Review proposals: 0");
+            println!("Decision review records: 0");
+            print_text("Latest decision review record", "<none>");
+            return Ok(());
+        }
+    };
+
+    let memory_records_path = state_root.join("memory_records.json");
+    let decision_records: Vec<crate::MemoryRecord> = if memory_records_path.is_file() {
+        let memory_store = FileBackedMemoryStore::try_new(memory_records_path)?;
+        memory_store
+            .list(MemoryScope::Decision)?
+            .into_iter()
+            .filter(|record| record.value.starts_with("review-summary |"))
+            .collect()
+    } else {
+        Vec::new()
+    };
 
     println!("Probe mode: review-read");
     println!("Identity: {}", review.identity_name);
@@ -126,6 +160,11 @@ pub fn run_review_read_probe(
     println!("Decision review records: {}", decision_records.len());
     if let Some(record) = decision_records.last() {
         print_text("Latest decision review record", &record.value);
+    } else if !resolved.used_override {
+        // Daemon-fallback path: render `<none>` so the operator sees the
+        // empty shape (issue #1909). Strict-override path retains the
+        // prior silence to preserve test expectations.
+        print_text("Latest decision review record", "<none>");
     }
     Ok(())
 }
@@ -396,5 +435,60 @@ mod tests {
         assert!(inputs.identity.is_none());
         assert!(inputs.base_type.is_none());
         assert!(inputs.topology.is_none());
+    }
+
+    // ───────────────────────────────────────────────────────────────────
+    // Issue #1909: `review read` without an explicit `[state-root]`
+    // argument must fall back to the canonical daemon state root
+    // (`$SIMARD_STATE_ROOT` or `$HOME/.simard/state`) and render an
+    // explicit empty report when no persisted review artifact exists —
+    // instead of hard-failing on a fresh machine.
+    // ───────────────────────────────────────────────────────────────────
+
+    fn with_simard_state_root<R>(path: &std::path::Path, run: impl FnOnce() -> R) -> R {
+        let prev = std::env::var("SIMARD_STATE_ROOT").ok();
+        // SAFETY: gated on `serial_test::serial(simard_state_root)`.
+        unsafe {
+            std::env::set_var("SIMARD_STATE_ROOT", path);
+        }
+        let result = run();
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("SIMARD_STATE_ROOT", v),
+                None => std::env::remove_var("SIMARD_STATE_ROOT"),
+            }
+        }
+        result
+    }
+
+    #[test]
+    #[serial_test::serial(simard_state_root)]
+    fn review_read_probe_falls_back_to_default_state_root_when_no_override() {
+        let dir = tempfile::TempDir::new().unwrap();
+        // Empty state root — no review-artifacts/, no memory_records.json.
+        // Pre-fix this hard-failed with `expected persisted review artifact`.
+        // Post-fix it falls back and renders empty.
+        let result = with_simard_state_root(dir.path(), || {
+            run_review_read_probe("terminal-shell", "single-process", None)
+        });
+        assert!(
+            result.is_ok(),
+            "review read should succeed via daemon fallback when no override is given \
+             and the daemon store is empty: {:?}",
+            result.err()
+        );
+    }
+
+    #[test]
+    #[serial_test::serial(simard_state_root)]
+    fn review_read_probe_fallback_rejects_bogus_topology() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let result = with_simard_state_root(dir.path(), || {
+            run_review_read_probe("terminal-shell", "totally-bogus-topology", None)
+        });
+        assert!(
+            result.is_err(),
+            "bogus topology should fail validation even on the daemon-fallback path"
+        );
     }
 }

--- a/tests/simard_cli.rs
+++ b/tests/simard_cli.rs
@@ -4252,3 +4252,143 @@ fn simard_rejects_unknown_commands_and_missing_required_arguments_explicitly() {
         "arity failures should come from CLI validation, not the legacy bootstrap env path:\n{arity_rendered}"
     );
 }
+
+// ──────────────────────────────────────────────────────────────────────────
+// Issue #1909: `meeting read`, `improvement-curation read`, and
+// `review read` must gracefully fall back to the canonical daemon state
+// root (`$SIMARD_STATE_ROOT` or `$HOME/.simard/state`) when the operator
+// does not pass an explicit `[state-root]` argument.
+//
+// Prior behavior: these three subcommands hard-defaulted to the
+// probe-isolated path under `target/operator-probe-state/...`, which
+// only exists if the matching `run` subcommand was executed beforehand.
+// On a fresh machine, `simard meeting read local-harness single-process`
+// (no state-root) failed with:
+//     Error: invalid state root '...': meeting read requires an existing
+//     state root directory: No such file or directory (os error 2)
+//
+// Post-fix: the fallback path renders empty sections so the operator
+// sees the shape rather than a hard error. The strict-override contract
+// (passing an explicit `[state-root]` argument) is preserved.
+// ──────────────────────────────────────────────────────────────────────────
+
+#[test]
+#[ignore] // Spawns simard binary — hangs in pre-commit
+fn simard_meeting_read_falls_back_to_simard_state_root_when_no_argument() {
+    let temp_dir = TempDirGuard::new("simard-cli-1909-meeting-read-fallback");
+    // Empty state root — simulates a fresh machine with no prior
+    // `meeting run`. Pre-fix this hard-failed; post-fix it renders empty.
+    let output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("meeting")
+        .arg("read")
+        .arg("local-harness")
+        .arg("single-process")
+        .env("SIMARD_STATE_ROOT", temp_dir.path())
+        .output()
+        .expect("meeting read fallback check should launch");
+    let rendered = rendered_output(&output);
+
+    assert!(
+        output.status.success(),
+        "meeting read should succeed via SIMARD_STATE_ROOT fallback on a fresh machine:\n{rendered}"
+    );
+    for expected in [
+        "Probe mode: meeting-read",
+        "Identity: simard-meeting",
+        "Meeting records: 0",
+        "Latest agenda: <none>",
+        "Updates count: 0",
+        "Updates: <none>",
+        "Decisions count: 0",
+        "Decisions: <none>",
+        "Latest meeting record: <none>",
+    ] {
+        assert!(
+            rendered.contains(expected),
+            "meeting read fallback should make empty sections explicit with '{expected}':\n{rendered}"
+        );
+    }
+    assert!(
+        !rendered.contains("expected persisted meeting decision record"),
+        "meeting read fallback must NOT hard-fail with the strict-override error:\n{rendered}"
+    );
+}
+
+#[test]
+#[ignore] // Spawns simard binary — hangs in pre-commit
+fn simard_improvement_curation_read_falls_back_to_simard_state_root_when_no_argument() {
+    let temp_dir = TempDirGuard::new("simard-cli-1909-improvement-curation-read-fallback");
+    let output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("improvement-curation")
+        .arg("read")
+        .arg("local-harness")
+        .arg("single-process")
+        .env("SIMARD_STATE_ROOT", temp_dir.path())
+        .output()
+        .expect("improvement-curation read fallback check should launch");
+    let rendered = rendered_output(&output);
+
+    assert!(
+        output.status.success(),
+        "improvement-curation read should succeed via SIMARD_STATE_ROOT fallback on a fresh machine:\n{rendered}"
+    );
+    for expected in [
+        "Probe mode: improvement-curation-read",
+        "Identity: simard-improvement-curator",
+        "Latest review artifact: <none>",
+        "Review proposals: 0",
+        "Approved proposals: 0",
+        "Approved proposals: <none>",
+        "Deferred proposals: 0",
+        "Deferred proposals: <none>",
+        "Latest improvement record: <none>",
+    ] {
+        assert!(
+            rendered.contains(expected),
+            "improvement-curation read fallback should make empty sections explicit with '{expected}':\n{rendered}"
+        );
+    }
+    assert!(
+        !rendered.contains("expected persisted review artifact"),
+        "improvement-curation read fallback must NOT hard-fail with the strict-override error:\n{rendered}"
+    );
+}
+
+#[test]
+#[ignore] // Spawns simard binary — hangs in pre-commit
+fn simard_review_read_falls_back_to_simard_state_root_when_no_argument() {
+    let temp_dir = TempDirGuard::new("simard-cli-1909-review-read-fallback");
+    let output = Command::new(env!("CARGO_BIN_EXE_simard"))
+        .arg("review")
+        .arg("read")
+        .arg("terminal-shell")
+        .arg("single-process")
+        .env("SIMARD_STATE_ROOT", temp_dir.path())
+        .output()
+        .expect("review read fallback check should launch");
+    let rendered = rendered_output(&output);
+
+    assert!(
+        output.status.success(),
+        "review read should succeed via SIMARD_STATE_ROOT fallback on a fresh machine:\n{rendered}"
+    );
+    for expected in [
+        "Probe mode: review-read",
+        "Identity: simard-engineer",
+        "Latest review artifact: <none>",
+        "Latest review target: <none>",
+        "Latest review summary: <none>",
+        "Review proposals: 0",
+        "Decision review records: 0",
+        "Latest decision review record: <none>",
+    ] {
+        assert!(
+            rendered.contains(expected),
+            "review read fallback should make empty sections explicit with '{expected}':\n{rendered}"
+        );
+    }
+    assert!(
+        !rendered.contains("expected persisted review artifact"),
+        "review read fallback must NOT hard-fail with the strict-override error:\n{rendered}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes the `read` subcommands flagged by the cycle-1 audit (#1910): `meeting read`, `improvement-curation read`, and `review read` previously **hard-failed on a fresh machine** because they defaulted the state-root to `target/operator-probe-state/...` — a path only created by their `run` siblings. `goal-curation read` (fixed in #1742) already does the right thing — falls back to the daemon's canonical state root via `memory_ipc::default_state_root()` (`$SIMARD_STATE_ROOT` or `$HOME/.simard/state`).

This PR propagates that pattern to the three brittle companions while **preserving the strict-override contract** (an explicit `[state-root]` argument still validates strictly and hard-fails on missing artifacts).

Closes #1909.

## Approach (hybrid: strict on override, lenient on fallback)

1. New shared helper `resolve_read_state_root_with_daemon_fallback` in `src/operator_commands/state_root.rs` returns a `ResolvedReadStateRoot { path, used_override }`. Callers branch on `used_override`:
   - `true` → strict validation, hard-error on missing artifacts (preserves the contract pinned by `simard_meeting_read_rejects_nonexistent_and_empty_state_roots_before_store_access` and friends).
   - `false` → daemon fallback; render empty sections (`<none>`, `0 records`) so operators see the shape rather than an error.
2. Refactored `resolved_meeting_read_state_root` and `resolved_improvement_curation_read_state_root` to use the helper; added new `resolved_review_read_state_root`.
3. Refactored `run_meeting_read_probe`, `run_improvement_curation_read_probe`, `run_review_read_probe` to apply the hybrid policy.
4. Deduplicated `resolve_goal_curation_read_state_root` to delegate to the shared helper (single source of truth across all four read commands).

## Evidence

### Criterion 1 — qa-team scenarios

Outside-in coverage added at both layers:

**CLI-level (in `tests/simard_cli.rs`, `#[ignore]`d like all CLI-spawning tests):**
- `simard_meeting_read_falls_back_to_simard_state_root_when_no_argument`
- `simard_improvement_curation_read_falls_back_to_simard_state_root_when_no_argument`
- `simard_review_read_falls_back_to_simard_state_root_when_no_argument`

Each spawns the real `simard` binary, points `SIMARD_STATE_ROOT` at an empty tempdir, omits the `[state-root]` argument, and asserts:
- Exit status: success.
- Rendered output contains the empty-section markers (`Meeting records: 0`, `Latest agenda: <none>`, `Latest review artifact: <none>`, etc.).
- Rendered output does **not** contain the strict-override error message.

Verified passing locally:
```
$ cargo test --test simard_cli -- --ignored \
    simard_meeting_read_falls_back_to_simard_state_root \
    simard_improvement_curation_read_falls_back_to_simard_state_root \
    simard_review_read_falls_back_to_simard_state_root
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured
```

**Module-level (in the affected modules):**
- `meeting_read_probe_falls_back_to_default_state_root_when_no_override`
- `meeting_read_probe_falls_back_and_reads_real_records`
- `meeting_read_probe_fallback_rejects_bogus_topology`
- `improvement_curation_read_probe_falls_back_to_default_state_root_when_no_override`
- `improvement_curation_read_probe_fallback_rejects_bogus_topology`
- `review_read_probe_falls_back_to_default_state_root_when_no_override`
- `review_read_probe_fallback_rejects_bogus_topology`

All gated with `#[serial_test::serial(simard_state_root)]` to coordinate `SIMARD_STATE_ROOT` mutation.

### Criterion 2 — Docs / surface notes

This changes **CLI behavior on a no-argument invocation** — internal-only fix per the audit (#1910). Behavior on explicit `[state-root]` invocations is unchanged. No external-facing docs reference the broken default path, so no documentation updates required. The `goal-curation read` documentation pattern (already in code comments) now applies uniformly to all four read commands.

### Criterion 3 — quality-audit cycles

Behavioral parity with the already-shipped goal-curation fix (#1742) is the design's correctness anchor. Implementation passed:
- **Cycle 1** SEEK→VALIDATE→FIX: clippy warning for `match` on `Option<&Path>` → restructured to `if let Some(...)`.
- **Cycle 2** SEEK→VALIDATE→FIX: unused import in tests after refactor → cleaned.
- **Cycle 3** SEEK→VALIDATE→FIX: fmt drift (overlong call) → `cargo fmt --all` re-applied; clean.
- Final cycle: zero critical/high; zero medium correctness/security findings.

### Criterion 4 — CI status

Pre-push gate (the full `--all-targets --all-features --locked` clippy and the race-catching test subset for `cognitive_memory|bootstrap|memory_ipc|memory_consolidation`):
```
cargo fmt --all -- --check ...................... Passed
cargo test --release --lib (race-subset) ........ Passed
cargo clippy --all-targets --all-features --locked -- -D warnings ... Passed
```

Focused regression run:
```
$ cargo test --lib -- meeting_read improvement_curation_read review_read
test result: ok. 33 passed; 0 failed
```

Pre-existing baseline failures (verified by stashing my changes and reproducing on `c0be9acb`):
- `goal_curation_read_default_state_root_resolves_to_canonical_daemon_store` — pre-existing serial-test lock-key race (different `#[serial(simard_state_root)]` vs bare `#[serial]` keys across test files).
- `simard_goal_curation_read_*` (4 tests) — pre-existing; the tests write a legacy `goal_records.json` fixture but the codebase migrated to cognitive memory (#1590) so the fixture is no longer read. **Out of scope for #1909.**

### Criterion 6 — Diff focus

```
src/operator_commands/mod.rs                          |   9 ++-
src/operator_commands/state_root.rs                   | 106 +++++++++++++++++---
src/operator_commands_meeting/goal_curation.rs        |  41 ++++-----
src/operator_commands_meeting/improvement_curation.rs | 233 ++++++++++++++++++---
src/operator_commands_meeting/probes.rs               | 166 +++++++++++++++++--
src/operator_commands_review.rs                       | 114 +++++++++++--
tests/simard_cli.rs                                   | 140 +++++++++++++++
7 files changed, 682 insertions(+), 122 deletions(-)
```

No unrelated edits. All changes are scoped to the four read-subcommand resolvers, the shared helper, and the new tests.

## Compatibility notes

- The strict-override contract is **unchanged**. Operators who pass `[state-root]` explicitly still get the same hard-fail behavior on missing artifacts (existing CLI tests still green).
- The fallback path produces output **shape-compatible** with the populated path so downstream operator-probe scripts that grep for `Meeting records:` / `Latest review artifact:` / etc. continue to work.

## Other brittle `read` subcommands discovered?

Audited `src/operator_commands_*.rs` for the pattern — only the three flagged in #1909 (`meeting`, `improvement-curation`, `review`) needed the fix. `goal-curation read` was already correct.
