### PR TITLE
feat(amplihack-rs): subprocess prompt delivery via temp-file and stdin (closes #1897)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ worktrees/
 node_modules/
 test-results/
 gym-wave*-tmp/
+# Rust coverage artifacts (llvm-cov / cargo-llvm-cov)
+*.profraw
+*.profdata

--- a/docs/prompt-delivery.md
+++ b/docs/prompt-delivery.md
@@ -1,19 +1,22 @@
 # Subprocess Prompt Delivery
 
-Status: **design spec — implementation pending** · Module:
-`amplihack-utils::prompt_delivery` · Issues: closes
+Status: **implemented in Simard** (`src/prompt_delivery/`); adapter wiring
+tracked in parity follow-ups · Module: `simard::prompt_delivery` · Issues:
+closes
 [#1897](https://github.com/rysweet/Simard/issues/1897) · Parity epic:
 [#1898](https://github.com/rysweet/Simard/issues/1898)
 [#1899](https://github.com/rysweet/Simard/issues/1899)
 [#1900](https://github.com/rysweet/Simard/issues/1900)
 [#1901](https://github.com/rysweet/Simard/issues/1901)
 
-> **Canonical location.** The implementation lives in the upstream
+> **Canonical home (forward-looking).** Long-term this module is expected
+> to migrate to the upstream
 > [`amplihack-rs`](https://github.com/microsoft/amplihack) repository under
-> `crates/amplihack-utils/src/prompt_delivery.rs`. This Simard copy is the
-> parity-tracking reference held alongside Simard's adapter changes so the
-> two repos can land the work in lockstep. If the two copies diverge, the
-> `amplihack-rs` copy is authoritative.
+> `crates/amplihack-utils/src/prompt_delivery.rs` so every amplihack-derived
+> launcher can depend on it. Until that mirror lands, **the Simard copy at
+> `src/prompt_delivery/mod.rs` is authoritative** and the only build target
+> that matters for #1897. If the two copies later diverge, sync amplihack-rs
+> from Simard, not the other way around.
 
 When the Rust amplihack launcher spawns a child process (`claude`, `codex`,
 `amplifier`) it must hand that child a **prompt**. Prompts are user-controlled,
@@ -37,7 +40,7 @@ know which mode was chosen.
 ## Quick start
 
 ```rust
-use amplihack_utils::prompt_delivery::{self, PromptDelivery};
+use simard::prompt_delivery::{self, PromptDelivery};
 use tokio::process::Command;
 
 let mut cmd = Command::new("claude");
@@ -135,7 +138,7 @@ auxiliary CLI flags around the prompt.
 
 ---
 
-## Public API — `amplihack-utils::prompt_delivery`
+## Public API — `simard::prompt_delivery`
 
 ### `enum PromptDelivery`
 
@@ -486,22 +489,23 @@ reviewers grep for `Command::new("claude"`, `Command::new("codex"`, and
 
 The module ships with:
 
-* **Unit tests** (`crates/amplihack-utils/src/prompt_delivery.rs`,
-  `#[cfg(test)]` module): select-mode decision matrix, env-var parsing,
-  16 MiB cap, `NulInInlineMode` error, perm bits on Unix (`#[cfg(unix)]`).
-* **Outside-in integration test**
-  (`crates/amplihack-orchestration/tests/prompt_delivery_apostrophes.rs`):
-  spawns `/bin/cat` as a stand-in for the agent binary, pipes a 64 KiB
-  prompt containing apostrophes, double quotes, newlines, and tabs, and
-  asserts the bytes round-trip exactly across all three modes plus the
-  env-override and invalid-env-fallback paths. Gated `#[cfg(unix)]`.
+* **Unit tests** (`src/prompt_delivery/mod.rs`, `#[cfg(test)]` module):
+  select-mode decision matrix, env-var parsing, 16 MiB cap,
+  `NulInInlineMode` error, perm bits on Unix (`#[cfg(unix)]`). Env-touching
+  tests share a `#[serial(prompt_delivery_env)]` group so they can't race
+  the env-reading tests.
+* **Outside-in integration test** (`tests/prompt_delivery.rs`): spawns
+  `/bin/cat` as a stand-in for the agent binary, pipes a 64 KiB prompt
+  containing apostrophes, double quotes, newlines, and tabs, and asserts
+  the bytes round-trip exactly across all three modes plus the env-override
+  and invalid-env-fallback paths. Gated `#[cfg(unix)]`.
 
 Run with:
 
 ```bash
-cargo test -p amplihack-utils
-cargo test -p amplihack-orchestration --test prompt_delivery_apostrophes
-cargo clippy --workspace --all-targets -- -D warnings
+cargo test --lib prompt_delivery        # unit tests
+cargo test --test prompt_delivery       # integration tests
+cargo clippy --all-targets -- -D warnings
 ```
 
 > **Test-author note (Rust 2024).** The workspace is on `edition = "2024"`,
@@ -511,8 +515,9 @@ cargo clippy --workspace --all-targets -- -D warnings
 > must wrap mutation in `unsafe { std::env::set_var(...) }` and either
 > (a) serialize across the env-touching test set with a `Mutex` /
 > `serial_test` attribute, or (b) spawn a subprocess per scenario so each
-> test gets a fresh process env. The integration test in
-> `prompt_delivery_apostrophes.rs` uses approach (b).
+> test gets a fresh process env. The unit tests use approach (a) via
+> `#[serial(prompt_delivery_env)]`; the integration test in
+> `tests/prompt_delivery.rs` uses approach (b).
 
 ---
 

--- a/docs/prompt-delivery.md
+++ b/docs/prompt-delivery.md
@@ -1,0 +1,528 @@
+# Subprocess Prompt Delivery
+
+Status: **design spec — implementation pending** · Module:
+`amplihack-utils::prompt_delivery` · Issues: closes
+[#1897](https://github.com/rysweet/Simard/issues/1897) · Parity epic:
+[#1898](https://github.com/rysweet/Simard/issues/1898)
+[#1899](https://github.com/rysweet/Simard/issues/1899)
+[#1900](https://github.com/rysweet/Simard/issues/1900)
+[#1901](https://github.com/rysweet/Simard/issues/1901)
+
+> **Canonical location.** The implementation lives in the upstream
+> [`amplihack-rs`](https://github.com/microsoft/amplihack) repository under
+> `crates/amplihack-utils/src/prompt_delivery.rs`. This Simard copy is the
+> parity-tracking reference held alongside Simard's adapter changes so the
+> two repos can land the work in lockstep. If the two copies diverge, the
+> `amplihack-rs` copy is authoritative.
+
+When the Rust amplihack launcher spawns a child process (`claude`, `codex`,
+`amplifier`) it must hand that child a **prompt**. Prompts are user-controlled,
+sometimes binary-ish (apostrophes, newlines, embedded quotes) and occasionally
+very large (system prompts plus tool catalogs can exceed 64 KiB). Embedding
+arbitrary bytes directly into `argv` is unsafe and, past `ARG_MAX`, impossible.
+
+The `prompt_delivery` module is the single, sanctioned chokepoint every
+prompt-bearing subprocess invocation flows through. It selects one of three
+delivery modes — **Inline**, **Stdin**, or **TempFile** — and applies it to a
+`std::process::Command` or `tokio::process::Command` without callers needing to
+know which mode was chosen.
+
+> **Forbidden alternatives.** Callers MUST NOT invoke `sh -c`, `bash -c`, or
+> any shell wrapper. They MUST NOT format prompts into argv via `format!` or
+> string concatenation. They MUST NOT call `Command::arg(prompt)` directly.
+> The only supported path is `prompt_delivery::apply_std` / `apply_tokio`.
+
+---
+
+## Quick start
+
+```rust
+use amplihack_utils::prompt_delivery::{self, PromptDelivery};
+use tokio::process::Command;
+
+let mut cmd = Command::new("claude");
+cmd.arg("--no-color");
+
+// Hand the prompt to the helper. It picks a mode, mutates `cmd`, and
+// returns a guard that owns the prompt bytes and any temp file.
+let applied = prompt_delivery::apply_tokio(
+    &mut cmd,
+    prompt_bytes,                   // &[u8]
+    PromptDelivery::Auto,           // or ::Inline / ::Stdin / ::TempFile
+).await?;
+
+let mut child = cmd.spawn()?;
+applied.feed(child.stdin.take()).await?;   // consumes the guard;
+                                           // no-op (still Ok) for Inline.
+let status = child.wait().await?;
+```
+
+`feed` takes the guard by value, writes the owned prompt buffer to the
+child's stdin (or does nothing for `Inline` mode), and unlinks the temp
+file (if any) when it returns. If you never call `feed` — for example, an
+early-return error path — the guard's `Drop` impl performs the same
+cleanup.
+
+That is the entire user-facing surface for typical adapter code. Everything
+below is reference material for module authors, operators, and security
+reviewers.
+
+---
+
+## Delivery modes
+
+| Mode       | Wire format                                    | When chosen by `Auto`                                | Argv-visible? | File on disk? |
+| ---------- | ---------------------------------------------- | ---------------------------------------------------- | :-----------: | :-----------: |
+| `Inline`   | Prompt becomes the final `Command::arg(...)`.  | `len < 8 KiB` AND no embedded NUL byte.              |      ✅       |      ❌       |
+| `Stdin`    | Prompt written to child's stdin pipe.          | `8 KiB ≤ len < 100 KiB`, or NUL bytes present.       |      ❌       |      ❌       |
+| `TempFile` | `NamedTempFile` (`0o600`) **and** stdin pipe.  | `len ≥ 100 KiB`.                                     |      ❌       |    ✅ (`/tmp`) |
+
+A few notes on the mode semantics that surprise first-time readers:
+
+* **`TempFile` always also writes to stdin.** Upstream `claude` / `codex` /
+  `amplifier` binaries currently expose no `--prompt-file <path>` flag. The
+  temp file exists for *postmortem inspection* (debugging, crash reports,
+  audit logs) — the bytes still travel via stdin. If an upstream binary adds
+  a real `--prompt-file` flag, this module is the place to wire it in; no
+  caller code will need to change.
+* **`Inline` is the only mode that leaks the prompt to `ps`.** Anything
+  visible in `/proc/<pid>/cmdline` is visible to every UID on the host. The
+  `Auto` heuristic is therefore conservative — small prompts that *might*
+  contain secrets should be sent in `Stdin` mode via an explicit override.
+* **There is a 16 MiB hard cap.** Prompts larger than 16 MiB return
+  [`PromptDeliveryError::TooLarge`](#errors) before any file or pipe is
+  touched. This bound prevents a runaway agent from filling `/tmp`.
+
+### Auto-selection heuristic
+
+```
+fn select_mode(prompt: &[u8], caller: PromptDelivery) -> Result<PromptDelivery, _>
+```
+
+The order matters — each step is a hard invariant evaluated *before* the
+next. In particular the 16 MiB size cap fires *before* any environment
+override, so an operator cannot force-spawn a 100 MiB prompt by setting
+`AMPLIHACK_PROMPT_DELIVERY=inline`.
+
+1. **Size cap (hard invariant).** If `prompt.len() > 16 * 1024 * 1024` →
+   return `Err(TooLarge)`. Applies to every variant including explicit
+   caller overrides.
+2. **Caller override.** If `caller` is anything other than
+   `PromptDelivery::Auto`, that mode is used directly. The env var is
+   *not* consulted. (If the caller passes `Inline` and the prompt
+   contains a NUL byte, the call returns `Err(NulInInlineMode)`.)
+3. **Environment override.** Otherwise, if
+   [`AMPLIHACK_PROMPT_DELIVERY`](#environment-variable) is set to a
+   valid value other than `auto`, that wins.
+4. **NUL fork.** If the prompt contains any `0x00` byte → `Stdin` (an
+   inline NUL would truncate argv on POSIX).
+5. If `prompt.len() < 8 * 1024` → `Inline`.
+6. If `prompt.len() < 100 * 1024` → `Stdin`.
+7. Otherwise → `TempFile`.
+
+> **`Auto` is the only variant that consults `AMPLIHACK_PROMPT_DELIVERY`.**
+> Any other explicit variant bypasses the env var entirely. This includes
+> the case where a caller explicitly passes `PromptDelivery::Inline` with
+> a NUL-containing prompt — the call returns `NulInInlineMode` rather
+> than silently upgrading to `Stdin`.
+
+The 8 KiB / 100 KiB thresholds are constants in `prompt_delivery.rs`
+(`INLINE_MAX_BYTES`, `STDIN_PREFERRED_MAX_BYTES`). They are deliberately well
+below the `ARG_MAX` limits on every supported platform (Linux: 128 KiB per
+arg, 2 MiB total; macOS: 256 KiB total; Windows: 32 KiB total) so that the
+heuristic never butts up against a kernel limit even when amplihack adds
+auxiliary CLI flags around the prompt.
+
+---
+
+## Public API — `amplihack-utils::prompt_delivery`
+
+### `enum PromptDelivery`
+
+```rust
+#[non_exhaustive]
+pub enum PromptDelivery {
+    /// Let `select_mode` choose. This is the default for every adapter.
+    Auto,
+    /// Force the prompt onto argv. **Argv is world-readable via `ps`.**
+    /// Use only for short, non-sensitive prompts.
+    Inline,
+    /// Force stdin delivery. Safe default for sensitive prompts.
+    Stdin,
+    /// Force `NamedTempFile` + stdin. Useful when you want a postmortem
+    /// artifact on disk for crash reports.
+    TempFile,
+}
+```
+
+`PromptDelivery` is `Copy + Clone + Debug + PartialEq + Eq`. It implements
+`FromStr` with the case-insensitive grammar described in
+[Environment variable](#environment-variable).
+
+### `fn apply_std`
+
+```rust
+pub fn apply_std(
+    cmd: &mut std::process::Command,
+    prompt: &[u8],
+    mode: PromptDelivery,
+) -> Result<AppliedPromptStd, PromptDeliveryError>;
+```
+
+* Mutates `cmd` in place — sets `stdin(Stdio::piped())` for non-`Inline`
+  modes, appends a `--` flag terminator before any positional prompt arg in
+  `Inline` mode (so a prompt starting with `--` is never mistaken for a
+  flag), and pushes the prompt as the final argv element when applicable.
+* Returns an [`AppliedPromptStd`](#struct-appliedprompt) RAII guard. The
+  guard owns the temp file (if any) and the in-memory prompt bytes (for
+  stdin modes). It MUST outlive the child.
+* Never panics. Returns [`PromptDeliveryError`](#errors) for size violations
+  and I/O failures.
+
+### `fn apply_tokio`
+
+```rust
+#[cfg(feature = "tokio")]
+pub async fn apply_tokio(
+    cmd: &mut tokio::process::Command,
+    prompt: &[u8],
+    mode: PromptDelivery,
+) -> Result<AppliedPromptTokio, PromptDeliveryError>;
+```
+
+Same semantics as `apply_std`, but returns a `tokio`-flavored guard whose
+`feed` method drives the stdin write asynchronously. Behind the `tokio`
+cargo feature; pulled in by `amplihack-orchestration` and any other crate
+that uses async subprocess spawning.
+
+### `struct AppliedPrompt{Std,Tokio}`
+
+```rust
+#[must_use = "AppliedPrompt must outlive the child process or the temp file may unlink prematurely"]
+pub struct AppliedPromptStd { /* fields are private */ }
+
+impl AppliedPromptStd {
+    /// The mode actually selected (after size cap + caller/env override + auto heuristic).
+    pub fn mode(&self) -> PromptDelivery;
+
+    /// Path to the temp file, if mode == TempFile. `None` otherwise.
+    pub fn temp_path(&self) -> Option<&std::path::Path>;
+
+    /// Write the prompt to the child's stdin and consume the guard's owned
+    /// byte buffer. No-op (returns `Ok(())`) for `Inline` mode.
+    /// Closes stdin on completion so the child reads EOF.
+    pub fn feed(self, stdin: Option<std::process::ChildStdin>) -> std::io::Result<()>;
+
+    /// Detach: prevents the temp file from being unlinked on drop. Caller
+    /// is then responsible for invoking `std::fs::remove_file` once the
+    /// postmortem artifact is no longer needed. Returns the retained path.
+    pub fn retain_temp_file(self) -> Option<std::path::PathBuf>;
+}
+```
+
+The `Tokio` variant exposes the same surface with `async fn feed(self, ...)`.
+
+**Ownership and lifetime.** The guard owns its prompt bytes (`Vec<u8>`) for
+all non-`Inline` modes. `feed` takes `self` by value, writes the owned
+buffer to the child's stdin, and consumes the guard. If a caller never
+calls `feed`, the bytes are released when the guard drops — there is no
+"streaming from borrowed slice" mode. This makes the security contract
+auditable: the prompt is owned by the guard, then either flushed to a pipe
+or dropped, exactly once.
+
+**Drop behavior.** When the guard is dropped without `feed` being called,
+any owned `NamedTempFile` is unlinked via the `tempfile` crate's RAII drop.
+The in-memory `Vec<u8>` is released through the normal allocator path
+(no explicit memory wipe — see [Security properties](#security-properties)
+for the rationale and what *is* guaranteed).
+
+### `enum PromptDeliveryError`
+
+```rust
+#[non_exhaustive]
+#[derive(Debug, thiserror::Error)]
+pub enum PromptDeliveryError {
+    #[error("prompt exceeds 16 MiB hard cap (was {0} bytes)")]
+    TooLarge(usize),
+
+    #[error("failed to create temp file for prompt: {0}")]
+    TempFile(#[source] std::io::Error),
+
+    #[error("failed to write prompt to temp file: {0}")]
+    Write(#[source] std::io::Error),
+
+    #[error("failed to set 0600 permissions on prompt temp file: {0}")]
+    Permissions(#[source] std::io::Error),
+
+    #[error("prompt contains NUL byte but Inline mode was explicitly forced")]
+    NulInInlineMode,
+}
+```
+
+All variants are `#[non_exhaustive]`. Match with a `_ =>` arm.
+
+---
+
+## Configuration
+
+### Environment variable
+
+`AMPLIHACK_PROMPT_DELIVERY` — operator override for the auto-selection
+heuristic. Read on every call into `prompt_delivery::apply_*` via
+`std::env::var`. No process-lifetime caching — each invocation reflects the
+current env at the time of the call, which keeps test isolation simple
+(every test can `set_var`/`remove_var` in its own scope) and avoids a
+hidden first-call-wins state machine. The env var lookup is a few
+nanoseconds; it is not on any measured hot path.
+
+| Accepted value (case-insensitive) | Effect                                                       |
+| --------------------------------- | ------------------------------------------------------------ |
+| `auto`                            | Use the heuristic. **Default if unset.**                     |
+| `inline` *or* `cli`               | Force `PromptDelivery::Inline`.                              |
+| `stdin`                           | Force `PromptDelivery::Stdin`.                               |
+| `tempfile` *or* `temp-file` *or* `file` | Force `PromptDelivery::TempFile`.                      |
+| anything else                     | Warning logged once via `tracing::warn!`, falls back to `auto`. |
+
+> **Operator override loses to caller override.** If application code passes
+> an explicit `PromptDelivery::Stdin` (or any non-`Auto` variant) to
+> `apply_std`, the env var is ignored. The env var only ever influences
+> `PromptDelivery::Auto`. The "once" suppression for the invalid-value
+> warning is keyed on the value string so each distinct invalid value
+> warns the first time it is observed in the process.
+
+### Tracing
+
+The module emits these structured events. The field names are part of the
+public contract — adapters and dashboards can rely on them.
+
+| Level   | Target                              | Fields                                              |
+| ------- | ----------------------------------- | --------------------------------------------------- |
+| `debug` | `amplihack_utils::prompt_delivery`  | `mode_chosen`, `prompt_len`, `auto_override_active` |
+| `warn`  | `amplihack_utils::prompt_delivery`  | `invalid_env_value` (once per distinct value)       |
+| `error` | `amplihack_utils::prompt_delivery`  | `failed_mode`, `error` (on `PromptDeliveryError`)   |
+
+The prompt body is **never** logged. At every level you see only
+`prompt.len()`, never the bytes themselves.
+
+### Disk hygiene
+
+`TempFile` mode places files under `std::env::temp_dir()` with the prefix
+`amplihack-prompt-` and a random suffix. They are unlinked when the
+returned guard drops, except when `retain_temp_file()` is called. Operators
+who use `retain_temp_file()` for postmortem capture are responsible for
+removing the file once the diagnostic is collected; there is no background
+sweeper. Stale files left over from a crash can be cleaned with a one-off
+`find "$TMPDIR" -maxdepth 1 -name 'amplihack-prompt-*' -mtime +1 -delete`.
+
+---
+
+## Caller patterns
+
+### `claude_process` (async, tokio)
+
+```rust
+let mut cmd = tokio::process::Command::new(&claude_binary);
+cmd.args(base_args)
+   .stdout(Stdio::piped())
+   .stderr(Stdio::piped());
+
+let applied = prompt_delivery::apply_tokio(
+    &mut cmd,
+    rendered_prompt.as_bytes(),
+    PromptDelivery::Auto,
+).await?;
+
+let mut child = cmd.spawn()?;
+applied.feed(child.stdin.take()).await?;   // consumes guard;
+                                           // temp file (if any) unlinked.
+let output = child.wait_with_output().await?;
+```
+
+### `codex` and `amplifier` adapters (sync, std)
+
+```rust
+let mut cmd = std::process::Command::new(&codex_binary);
+cmd.args(["--model", model_name, "--"]);          // `--` flag terminator
+
+let applied = prompt_delivery::apply_std(
+    &mut cmd,
+    prompt_bytes,
+    PromptDelivery::Auto,
+)?;
+
+let mut child = cmd.stdout(Stdio::piped()).spawn()?;
+applied.feed(child.stdin.take())?;
+let status = child.wait()?;
+```
+
+### Forcing stdin for a sensitive prompt
+
+```rust
+let applied = prompt_delivery::apply_std(
+    &mut cmd,
+    secret_prompt,
+    PromptDelivery::Stdin,    // explicit — caller override beats env
+)?;
+```
+
+### Forcing TempFile for postmortem debugging
+
+```rust
+let applied = prompt_delivery::apply_std(
+    &mut cmd,
+    prompt,
+    PromptDelivery::TempFile,
+)?;
+let kept = applied.retain_temp_file();   // disable Drop unlink
+// `kept` is the Some(PathBuf) the operator can attach to a bug report.
+// IMPORTANT: caller must `std::fs::remove_file(&kept)` once the
+// postmortem capture is finished — `retain_temp_file()` opts out of
+// the RAII cleanup, so the file persists until manually removed.
+```
+
+---
+
+## Security properties
+
+| Property | Guarantee | Notes |
+| -------- | --------- | ----- |
+| **No shell.** | Every call site uses `Command::arg`. No `sh -c`, no `bash -c`, no string interpolation. | Eliminates shell-injection class entirely (Simard threat-model S2). |
+| **`--` flag terminator.** | `Inline` mode appends `--` before the prompt argv element if the caller has not already done so. | Prompts beginning with `-` / `--` cannot be reinterpreted as flags by the child binary (S11). |
+| **Argv-visibility advertised.** | `PromptDelivery::Inline` rustdoc warns that argv is visible to every UID on the host. | Operators consciously opt in (R-DP-1). |
+| **Temp-file permissions.** | `NamedTempFile` is created via `tempfile` with mode `0o600` on Unix; perms are asserted in CI (`#[cfg(unix)]`). | Windows uses default ACL inherited from `%TEMP%` — see [Limitations](#limitations-and-non-goals) (R-DP-2). |
+| **RAII cleanup.** | Drop on `AppliedPrompt*` unlinks the temp file unless `retain_temp_file()` is called. | Prevents `/tmp` accumulation (R-DP-3 / R-DP-4). |
+| **Single-ownership of bytes.** | Prompt bytes live in the guard's owned `Vec<u8>` and are released on `feed` or drop, exactly once. No copy is held by the helper after the call returns. | Auditable lifetime; no explicit memory wipe is performed (Rust's allocator does not guarantee scrubbing, and pulling in `zeroize` was rejected to keep the dependency surface to a single new crate). |
+| **Bounded size.** | 16 MiB hard cap rejected with `TooLarge` *before* env or caller override is consulted. | DoS mitigation against malicious or runaway prompts (S6, R-IV-3). |
+| **Env var validated.** | `AMPLIHACK_PROMPT_DELIVERY` parsed against an allow-list; invalid values warn-and-fall-back. | No panic, no privilege change (R-IV-2). |
+| **No new `unsafe`.** | Module contains no `unsafe` blocks. | Reviewable by audit. |
+| **No `set_var`.** | The helper never mutates process env. | Preserves multi-thread safety (Rust 2024 requires `unsafe` for `set_var` precisely because of this hazard). |
+
+---
+
+## Behavior reference table
+
+| Prompt size           | NUL bytes? | Env var unset | `AMPLIHACK_PROMPT_DELIVERY=inline` | Caller passes `::Stdin`   |
+| --------------------- | :--------: | ------------- | ---------------------------------- | ------------------------- |
+| 0 B – 8 KiB           |     no     | Inline        | Inline                             | Stdin (caller wins)       |
+| 0 B – 8 KiB           |    yes     | Stdin         | **Err: `NulInInlineMode`**         | Stdin                     |
+| 8 KiB – 100 KiB       |     no     | Stdin         | Inline (allowed; argv may be huge) | Stdin                     |
+| 100 KiB – 16 MiB      |     no     | TempFile      | Inline (allowed; likely fails at `exec(2)` with `E2BIG`) | Stdin |
+| > 16 MiB              |    any     | **Err: `TooLarge`** | **Err: `TooLarge`** (size cap fires before env override) | **Err: `TooLarge`** |
+
+The `Inline` row at 100 KiB+ is deliberately not auto-downgraded — an
+explicit operator override is taken at face value. If the kernel rejects
+the resulting `exec(2)` with `E2BIG`, the failure surfaces as a
+`std::io::Error` from `Command::spawn()` at the call site, **not** as a
+`PromptDeliveryError`. `PromptDeliveryError` covers only what the helper
+itself can detect prior to spawn (size cap, NUL-in-inline, temp-file I/O,
+permission failures). Errors from the spawn call itself remain the
+caller's concern.
+
+---
+
+## Limitations and non-goals
+
+* **No `--prompt-file` flag** is emitted today. Upstream binaries don't
+  accept one. `TempFile` mode pairs an on-disk artifact with stdin
+  delivery; if upstream adds the flag this module is the single edit
+  point.
+* **`copilot` adapter is currently a no-op.** The GitHub Copilot CLI in
+  amplihack's current launcher invokes Copilot in interactive REPL mode
+  rather than handing it a single prompt on argv. The apostrophe / quoting
+  bugs that motivate this module (rysweet/Simard#1871, #1879) live in the
+  *argv-prompt* delivery path, which the interactive Copilot launch does
+  not exercise. **However**, if a future Simard adapter spawns Copilot
+  non-interactively with a prompt (the path issue #1897 contemplates as
+  "switch its adapter path to call amplihack-rs subprocesses directly"),
+  that adapter MUST route through `prompt_delivery::apply_*` like every
+  other agent binary. The chokepoint contract is *every prompt-bearing
+  subprocess invocation*, not *every binary that ships in amplihack*.
+* **Env var is read on every call.** No process-lifetime caching. See
+  [Environment variable](#environment-variable) for rationale (test
+  isolation, no hidden first-call-wins state).
+* **Cross-platform `0o600`.** On Windows the helper does not attempt to
+  set NTFS ACLs; it relies on the default `%TEMP%` ACL. Operators who
+  need stricter isolation on Windows should set a per-process scratch
+  directory via `TMP` / `TEMP` with locked-down ACLs.
+
+---
+
+## Migration notes (for adapters predating this module)
+
+Pre-#1897 call sites that passed the prompt as `Command::arg(prompt)`
+should be replaced as follows.
+
+**Before:**
+
+```rust
+let status = std::process::Command::new("claude")
+    .arg("--no-color")
+    .arg(prompt)        // ❌ argv leak; breaks on >100 KiB
+    .status()?;
+```
+
+**After:**
+
+```rust
+let mut cmd = std::process::Command::new("claude");
+cmd.arg("--no-color");
+let applied = prompt_delivery::apply_std(&mut cmd, prompt.as_bytes(), PromptDelivery::Auto)?;
+let mut child = cmd.spawn()?;
+applied.feed(child.stdin.take())?;
+let status = child.wait()?;
+```
+
+PR review enforcement is the primary catch for the pre-#1897 pattern. A
+custom clippy lint to detect `Command::arg(prompt)` at build time has
+been considered but is **future work** (would require dylint or a custom
+lint driver — out of scope for issue #1897). For now, contributors and
+reviewers grep for `Command::new("claude"`, `Command::new("codex"`, and
+`Command::new("amplifier"` in PRs to confirm every spawn flows through
+`prompt_delivery`.
+
+---
+
+## Testing
+
+The module ships with:
+
+* **Unit tests** (`crates/amplihack-utils/src/prompt_delivery.rs`,
+  `#[cfg(test)]` module): select-mode decision matrix, env-var parsing,
+  16 MiB cap, `NulInInlineMode` error, perm bits on Unix (`#[cfg(unix)]`).
+* **Outside-in integration test**
+  (`crates/amplihack-orchestration/tests/prompt_delivery_apostrophes.rs`):
+  spawns `/bin/cat` as a stand-in for the agent binary, pipes a 64 KiB
+  prompt containing apostrophes, double quotes, newlines, and tabs, and
+  asserts the bytes round-trip exactly across all three modes plus the
+  env-override and invalid-env-fallback paths. Gated `#[cfg(unix)]`.
+
+Run with:
+
+```bash
+cargo test -p amplihack-utils
+cargo test -p amplihack-orchestration --test prompt_delivery_apostrophes
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+> **Test-author note (Rust 2024).** The workspace is on `edition = "2024"`,
+> which makes `std::env::set_var` and `std::env::remove_var` `unsafe`
+> because mutating env mid-process is racy in the presence of other
+> threads reading env. Tests that exercise `AMPLIHACK_PROMPT_DELIVERY`
+> must wrap mutation in `unsafe { std::env::set_var(...) }` and either
+> (a) serialize across the env-touching test set with a `Mutex` /
+> `serial_test` attribute, or (b) spawn a subprocess per scenario so each
+> test gets a fresh process env. The integration test in
+> `prompt_delivery_apostrophes.rs` uses approach (b).
+
+---
+
+## Related
+
+* [Engineer Loop argv Sanitization](reference/engineer-loop-argv-sanitization.md)
+  — separate concern (sanitizing argv segments for `gh` CLI), but shares
+  the philosophy of *one chokepoint for all subprocess input*.
+* [OODA Brain Prompt](reference/ooda-brain-prompt.md) — one of the larger
+  prompt-producing call sites that exercises the `TempFile` path in
+  practice.
+* Parity epic: rysweet/Simard#1898, #1899, #1900, #1901.
+* TDD charter: rysweet/Simard#1927.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,7 @@ mod operator_commands_review;
 mod operator_commands_terminal;
 mod persistence;
 pub mod prompt_assets;
+pub mod prompt_delivery;
 pub mod reflection;
 pub mod remote_azlin;
 pub mod remote_session;

--- a/src/prompt_delivery/mod.rs
+++ b/src/prompt_delivery/mod.rs
@@ -1,17 +1,17 @@
-//! Subprocess prompt delivery — TDD stub (issue #1897).
+//! Subprocess prompt delivery — amplihack-rs / Simard parity (issue #1897).
 //!
-//! Status: **scaffold only**. Every public function and method here is a
-//! stub returning [`unimplemented!()`]. The full contract is documented in
-//! [`docs/prompt-delivery.md`](../../docs/prompt-delivery.md); the tests in
-//! [`tests/prompt_delivery.rs`](../../tests/prompt_delivery.rs) plus the
-//! inline `#[cfg(test)] mod tests` block below pin every behaviour the
-//! implementation must satisfy.
+//! Picks one of three transports for handing a prompt to a child process
+//! (inline argv, stdin pipe, or postmortem temp file + stdin) based on size,
+//! NUL-byte presence, caller override, or the `AMPLIHACK_PROMPT_DELIVERY`
+//! environment variable.
 //!
-//! Per the TDD ordering decision (plan D10), this file is committed in its
-//! stub state alongside the failing tests. The implementation commit comes
-//! next and removes every `unimplemented!()` below.
+//! The full contract — heuristic resolution order, alias grammar, RAII
+//! lifecycle, and operational guidance — lives in
+//! [`docs/prompt-delivery.md`](../../docs/prompt-delivery.md). The inline
+//! `#[cfg(test)] mod tests` block below and `tests/prompt_delivery.rs` pin
+//! every behaviour as executable specification.
 //!
-//! ## Public surface (pinned by tests)
+//! ## Public surface
 //!
 //! * [`PromptDelivery`] — variant enum with `Auto / Inline / Stdin / TempFile`.
 //!   `FromStr` accepts the case-insensitive alias grammar from the doc.
@@ -371,8 +371,7 @@ impl AppliedPromptStd {
         })?;
         sink.write_all(&bytes)?;
         sink.flush()?;
-        // Dropping `sink` closes the pipe so the child reads EOF.
-        drop(sink);
+        // `sink` drops at end of scope, closing the pipe so the child reads EOF.
         Ok(())
     }
 
@@ -420,7 +419,7 @@ impl AppliedPromptTokio {
         sink.write_all(&bytes).await?;
         sink.flush().await?;
         sink.shutdown().await?;
-        drop(sink);
+        // `sink` drops at end of scope, closing the pipe so the child reads EOF.
         Ok(())
     }
 
@@ -455,14 +454,7 @@ pub fn apply_std(
             if !args_contain_flag_terminator(cmd.get_args()) {
                 cmd.arg("--");
             }
-            #[cfg(unix)]
-            {
-                cmd.arg(prompt_as_osstr(prompt));
-            }
-            #[cfg(not(unix))]
-            {
-                cmd.arg(prompt_as_osstr(prompt));
-            }
+            cmd.arg(prompt_as_osstr(prompt));
             Ok(AppliedPromptStd {
                 mode: PromptDelivery::Inline,
                 prompt: None,
@@ -507,14 +499,7 @@ pub async fn apply_tokio(
             // injection should pass a non-Inline mode or strip the
             // duplicate `--` themselves.
             cmd.arg("--");
-            #[cfg(unix)]
-            {
-                cmd.arg(prompt_as_osstr(prompt));
-            }
-            #[cfg(not(unix))]
-            {
-                cmd.arg(prompt_as_osstr(prompt));
-            }
+            cmd.arg(prompt_as_osstr(prompt));
             Ok(AppliedPromptTokio {
                 mode: PromptDelivery::Inline,
                 prompt: None,
@@ -543,7 +528,7 @@ pub async fn apply_tokio(
 }
 
 // ===========================================================================
-// Inline unit tests (TDD red phase)
+// Inline unit tests
 // ===========================================================================
 //
 // These tests pin the *pure* parts of the contract:

--- a/src/prompt_delivery/mod.rs
+++ b/src/prompt_delivery/mod.rs
@@ -1,0 +1,592 @@
+//! Subprocess prompt delivery — TDD stub (issue #1897).
+//!
+//! Status: **scaffold only**. Every public function and method here is a
+//! stub returning [`unimplemented!()`]. The full contract is documented in
+//! [`docs/prompt-delivery.md`](../../docs/prompt-delivery.md); the tests in
+//! [`tests/prompt_delivery.rs`](../../tests/prompt_delivery.rs) plus the
+//! inline `#[cfg(test)] mod tests` block below pin every behaviour the
+//! implementation must satisfy.
+//!
+//! Per the TDD ordering decision (plan D10), this file is committed in its
+//! stub state alongside the failing tests. The implementation commit comes
+//! next and removes every `unimplemented!()` below.
+//!
+//! ## Public surface (pinned by tests)
+//!
+//! * [`PromptDelivery`] — variant enum with `Auto / Inline / Stdin / TempFile`.
+//!   `FromStr` accepts the case-insensitive alias grammar from the doc.
+//! * [`PromptDeliveryError`] — `TooLarge`, `TempFile`, `Write`, `Permissions`,
+//!   `NulInInlineMode`. All variants are `#[non_exhaustive]`.
+//! * [`apply_std`] — mutates a [`std::process::Command`] and returns an
+//!   [`AppliedPromptStd`] RAII guard owning the temp file (if any) and the
+//!   in-memory prompt bytes (for stdin modes).
+//! * [`apply_tokio`] — async sibling for [`tokio::process::Command`].
+//! * [`select_mode`] — pure heuristic function (no I/O) exposed for unit tests
+//!   and for callers who want to inspect the choice without spawning.
+//! * [`AppliedPromptStd::feed`] / [`AppliedPromptTokio::feed`] — consumes the
+//!   guard and writes the owned prompt buffer to the child's stdin.
+//! * [`AppliedPromptStd::retain_temp_file`] — opts out of RAII cleanup so
+//!   operators can capture postmortem artifacts.
+//!
+//! ## Constants (pinned by tests)
+//!
+//! * [`INLINE_MAX_BYTES`] — `8 * 1024`. Below this, `Auto` picks `Inline`.
+//! * [`STDIN_PREFERRED_MAX_BYTES`] — `100 * 1024`. Below this (and above
+//!   `INLINE_MAX_BYTES`) `Auto` picks `Stdin`.
+//! * [`HARD_CAP_BYTES`] — `16 * 1024 * 1024`. Above this `apply_*` returns
+//!   `PromptDeliveryError::TooLarge` before *any* override is consulted.
+//! * [`ENV_OVERRIDE`] — `"AMPLIHACK_PROMPT_DELIVERY"`.
+
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::process::{ChildStdin, Command};
+use std::str::FromStr;
+
+// ---------------------------------------------------------------------------
+// Constants (test-asserted)
+// ---------------------------------------------------------------------------
+
+/// Below this size, `Auto` picks `Inline` (assuming no NUL bytes).
+pub const INLINE_MAX_BYTES: usize = 8 * 1024;
+
+/// Above `INLINE_MAX_BYTES` and below this, `Auto` picks `Stdin`.
+pub const STDIN_PREFERRED_MAX_BYTES: usize = 100 * 1024;
+
+/// Hard upper bound. Prompts above this are rejected before any I/O.
+pub const HARD_CAP_BYTES: usize = 16 * 1024 * 1024;
+
+/// Environment variable name consulted by `Auto` mode only.
+pub const ENV_OVERRIDE: &str = "AMPLIHACK_PROMPT_DELIVERY";
+
+// ---------------------------------------------------------------------------
+// Public enums
+// ---------------------------------------------------------------------------
+
+/// Delivery mode for a prompt handed to a child process.
+///
+/// `Auto` is the only variant that consults [`ENV_OVERRIDE`]. Every other
+/// variant is taken at face value (including pathological combinations like
+/// `Inline` with a NUL-containing prompt, which yields
+/// [`PromptDeliveryError::NulInInlineMode`]).
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PromptDelivery {
+    /// Use [`select_mode`] heuristic (consults env var).
+    Auto,
+    /// Force inline argv delivery. **Argv is world-readable via `ps`.**
+    Inline,
+    /// Force stdin delivery.
+    Stdin,
+    /// Force `NamedTempFile` (`0o600`) + stdin delivery. The temp file is a
+    /// postmortem artifact; the bytes still travel via stdin.
+    TempFile,
+}
+
+/// Errors returned by [`apply_std`] / [`apply_tokio`] before the child is
+/// spawned. Errors from `spawn(2)` itself (such as `E2BIG`) are surfaced by
+/// the caller as `std::io::Error` and are *not* wrapped here.
+#[non_exhaustive]
+#[derive(Debug)]
+pub enum PromptDeliveryError {
+    /// Prompt exceeds [`HARD_CAP_BYTES`]. Fires before any override is read.
+    TooLarge(usize),
+    /// `tempfile::NamedTempFile::new()` failed.
+    TempFile(std::io::Error),
+    /// Writing the prompt bytes to the temp file failed.
+    Write(std::io::Error),
+    /// Setting `0o600` permissions on the temp file failed (Unix only).
+    Permissions(std::io::Error),
+    /// Caller explicitly forced `Inline` but the prompt contains a NUL byte.
+    NulInInlineMode,
+}
+
+impl fmt::Display for PromptDeliveryError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PromptDeliveryError::TooLarge(n) => {
+                write!(
+                    f,
+                    "prompt exceeds {HARD_CAP_BYTES}-byte hard cap (was {n} bytes)"
+                )
+            }
+            PromptDeliveryError::TempFile(e) => {
+                write!(f, "failed to create temp file for prompt: {e}")
+            }
+            PromptDeliveryError::Write(e) => {
+                write!(f, "failed to write prompt to temp file: {e}")
+            }
+            PromptDeliveryError::Permissions(e) => {
+                write!(
+                    f,
+                    "failed to set 0o600 permissions on prompt temp file: {e}"
+                )
+            }
+            PromptDeliveryError::NulInInlineMode => {
+                f.write_str("prompt contains NUL byte but Inline mode was explicitly forced")
+            }
+        }
+    }
+}
+
+impl std::error::Error for PromptDeliveryError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            PromptDeliveryError::TempFile(e)
+            | PromptDeliveryError::Write(e)
+            | PromptDeliveryError::Permissions(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FromStr parsing (env var + caller-supplied strings)
+// ---------------------------------------------------------------------------
+
+/// Marker error type for failed [`PromptDelivery::from_str`] parses. The
+/// stored string is the offending input (after `trim` but before
+/// case-folding) for diagnostic logging.
+#[derive(Debug, PartialEq, Eq)]
+pub struct ParsePromptDeliveryError(pub String);
+
+impl fmt::Display for ParsePromptDeliveryError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "invalid PromptDelivery value: {:?}", self.0)
+    }
+}
+
+impl std::error::Error for ParsePromptDeliveryError {}
+
+impl FromStr for PromptDelivery {
+    type Err = ParsePromptDeliveryError;
+
+    fn from_str(_s: &str) -> Result<Self, Self::Err> {
+        unimplemented!("PromptDelivery::from_str stub — see docs/prompt-delivery.md")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// select_mode (pure heuristic)
+// ---------------------------------------------------------------------------
+
+/// Pure heuristic. Resolves an effective delivery mode from prompt length,
+/// caller-supplied mode, and (only for `Auto`) the value of [`ENV_OVERRIDE`].
+///
+/// Resolution order (each step is a hard invariant evaluated *before* the
+/// next — see `docs/prompt-delivery.md` § Auto-selection heuristic):
+///
+/// 1. Size cap: `prompt.len() > HARD_CAP_BYTES` → `Err(TooLarge)`.
+/// 2. Caller override: any non-`Auto` variant wins. Inline + NUL → `Err(NulInInlineMode)`.
+/// 3. Env override: only when caller is `Auto`. Invalid values warn-once and
+///    fall back to step 4.
+/// 4. NUL fork: prompt contains a `0x00` byte → `Stdin`.
+/// 5. `len < INLINE_MAX_BYTES` → `Inline`.
+/// 6. `len < STDIN_PREFERRED_MAX_BYTES` → `Stdin`.
+/// 7. Otherwise → `TempFile`.
+pub fn select_mode(
+    _prompt: &[u8],
+    _caller: PromptDelivery,
+) -> Result<PromptDelivery, PromptDeliveryError> {
+    unimplemented!("select_mode stub — see docs/prompt-delivery.md")
+}
+
+// ---------------------------------------------------------------------------
+// AppliedPromptStd (sync RAII guard)
+// ---------------------------------------------------------------------------
+
+/// RAII guard returned by [`apply_std`]. Owns the temp file (if any) and the
+/// in-memory prompt bytes (for non-`Inline` modes). MUST outlive the spawned
+/// child process or the temp file may be unlinked prematurely.
+#[must_use = "AppliedPromptStd must outlive the child process or the temp file may unlink prematurely"]
+pub struct AppliedPromptStd {
+    // Private fields will be filled in by the implementation commit.
+    _private: (),
+}
+
+impl AppliedPromptStd {
+    /// The mode actually selected (after size cap + caller / env override).
+    pub fn mode(&self) -> PromptDelivery {
+        unimplemented!("AppliedPromptStd::mode stub")
+    }
+
+    /// Path to the temp file, if mode == `TempFile`. `None` otherwise.
+    pub fn temp_path(&self) -> Option<&Path> {
+        unimplemented!("AppliedPromptStd::temp_path stub")
+    }
+
+    /// Write the owned prompt buffer to the child's stdin and consume the
+    /// guard. No-op for `Inline` mode (returns `Ok(())`). Closes stdin on
+    /// completion so the child reads EOF.
+    pub fn feed(self, _stdin: Option<ChildStdin>) -> std::io::Result<()> {
+        unimplemented!("AppliedPromptStd::feed stub")
+    }
+
+    /// Detach the temp file from RAII cleanup. Returns the retained path so
+    /// the caller can attach it to a bug report. **Caller must
+    /// `std::fs::remove_file` the path once the postmortem capture is
+    /// finished** — opt-in retention disables Drop unlink.
+    pub fn retain_temp_file(self) -> Option<PathBuf> {
+        unimplemented!("AppliedPromptStd::retain_temp_file stub")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AppliedPromptTokio (async RAII guard)
+// ---------------------------------------------------------------------------
+
+/// Async sibling of [`AppliedPromptStd`].
+#[must_use = "AppliedPromptTokio must outlive the child process or the temp file may unlink prematurely"]
+pub struct AppliedPromptTokio {
+    _private: (),
+}
+
+impl AppliedPromptTokio {
+    pub fn mode(&self) -> PromptDelivery {
+        unimplemented!("AppliedPromptTokio::mode stub")
+    }
+
+    pub fn temp_path(&self) -> Option<&Path> {
+        unimplemented!("AppliedPromptTokio::temp_path stub")
+    }
+
+    pub async fn feed(self, _stdin: Option<tokio::process::ChildStdin>) -> std::io::Result<()> {
+        unimplemented!("AppliedPromptTokio::feed stub")
+    }
+
+    pub fn retain_temp_file(self) -> Option<PathBuf> {
+        unimplemented!("AppliedPromptTokio::retain_temp_file stub")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// apply_std / apply_tokio
+// ---------------------------------------------------------------------------
+
+/// Apply a [`PromptDelivery`] mode to a [`std::process::Command`] and return
+/// an [`AppliedPromptStd`] guard. The command is mutated in place:
+///
+/// * `Inline`: `--` terminator (if not already present) + prompt as final argv.
+/// * `Stdin`: `cmd.stdin(Stdio::piped())`; bytes written by `feed`.
+/// * `TempFile`: `cmd.stdin(Stdio::piped())` + `NamedTempFile` (0o600) holding
+///   the prompt bytes for postmortem inspection; bytes also written to stdin
+///   by `feed`.
+pub fn apply_std(
+    _cmd: &mut Command,
+    _prompt: &[u8],
+    _mode: PromptDelivery,
+) -> Result<AppliedPromptStd, PromptDeliveryError> {
+    unimplemented!("apply_std stub — see docs/prompt-delivery.md")
+}
+
+/// Async sibling of [`apply_std`].
+pub async fn apply_tokio(
+    _cmd: &mut tokio::process::Command,
+    _prompt: &[u8],
+    _mode: PromptDelivery,
+) -> Result<AppliedPromptTokio, PromptDeliveryError> {
+    unimplemented!("apply_tokio stub — see docs/prompt-delivery.md")
+}
+
+// ===========================================================================
+// Inline unit tests (TDD red phase)
+// ===========================================================================
+//
+// These tests pin the *pure* parts of the contract:
+//   * `PromptDelivery::from_str` alias grammar
+//   * `select_mode` resolution order
+//   * Constant values (so a refactor renaming `INLINE_MAX_BYTES` doesn't
+//     silently change `Auto` behaviour)
+//
+// I/O-bearing behaviour (spawn round-trips, temp-file perms, drop cleanup)
+// lives in `tests/prompt_delivery.rs` so it can use `serial_test` and
+// `#[cfg(unix)]` gating cleanly.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    // -----------------------------------------------------------------------
+    // Constants
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn constants_match_design_spec() {
+        // Pinned by docs/prompt-delivery.md § Auto-selection heuristic.
+        assert_eq!(INLINE_MAX_BYTES, 8 * 1024);
+        assert_eq!(STDIN_PREFERRED_MAX_BYTES, 100 * 1024);
+        assert_eq!(HARD_CAP_BYTES, 16 * 1024 * 1024);
+        assert_eq!(ENV_OVERRIDE, "AMPLIHACK_PROMPT_DELIVERY");
+    }
+
+    // -----------------------------------------------------------------------
+    // PromptDelivery::from_str — case-insensitive alias grammar (plan D3)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn from_str_accepts_auto() {
+        assert_eq!(
+            "auto".parse::<PromptDelivery>().unwrap(),
+            PromptDelivery::Auto
+        );
+        assert_eq!(
+            "AUTO".parse::<PromptDelivery>().unwrap(),
+            PromptDelivery::Auto
+        );
+        assert_eq!(
+            "  Auto  ".parse::<PromptDelivery>().unwrap(),
+            PromptDelivery::Auto
+        );
+    }
+
+    #[test]
+    fn from_str_accepts_inline_aliases() {
+        for v in ["inline", "Inline", "INLINE", "cli", "CLI", "argv", "arg"] {
+            assert_eq!(
+                v.parse::<PromptDelivery>().unwrap(),
+                PromptDelivery::Inline,
+                "alias {v:?} should parse to Inline"
+            );
+        }
+    }
+
+    #[test]
+    fn from_str_accepts_stdin_aliases() {
+        for v in ["stdin", "STDIN", "Stdin", "pipe", "PIPE"] {
+            assert_eq!(
+                v.parse::<PromptDelivery>().unwrap(),
+                PromptDelivery::Stdin,
+                "alias {v:?} should parse to Stdin"
+            );
+        }
+    }
+
+    #[test]
+    fn from_str_accepts_tempfile_aliases() {
+        for v in [
+            "tempfile",
+            "TempFile",
+            "temp-file",
+            "TEMP-FILE",
+            "file",
+            "FILE",
+        ] {
+            assert_eq!(
+                v.parse::<PromptDelivery>().unwrap(),
+                PromptDelivery::TempFile,
+                "alias {v:?} should parse to TempFile"
+            );
+        }
+    }
+
+    #[test]
+    fn from_str_rejects_unknown_values() {
+        let err = "not-a-mode".parse::<PromptDelivery>().unwrap_err();
+        assert_eq!(err.0, "not-a-mode");
+    }
+
+    #[test]
+    fn from_str_rejects_empty_string() {
+        assert!("".parse::<PromptDelivery>().is_err());
+        assert!("   ".parse::<PromptDelivery>().is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // select_mode — resolution order
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn select_mode_size_cap_fires_before_caller_override() {
+        // Step 1 of the heuristic: size cap is a hard invariant evaluated
+        // before any override. Even an explicit Inline must yield TooLarge.
+        let too_big = vec![b'a'; HARD_CAP_BYTES + 1];
+        assert!(matches!(
+            select_mode(&too_big, PromptDelivery::Inline),
+            Err(PromptDeliveryError::TooLarge(_))
+        ));
+        assert!(matches!(
+            select_mode(&too_big, PromptDelivery::Stdin),
+            Err(PromptDeliveryError::TooLarge(_))
+        ));
+        assert!(matches!(
+            select_mode(&too_big, PromptDelivery::TempFile),
+            Err(PromptDeliveryError::TooLarge(_))
+        ));
+        assert!(matches!(
+            select_mode(&too_big, PromptDelivery::Auto),
+            Err(PromptDeliveryError::TooLarge(_))
+        ));
+    }
+
+    #[test]
+    fn select_mode_at_hard_cap_is_allowed() {
+        // Cap is exclusive — len == HARD_CAP_BYTES is OK.
+        let exactly_cap = vec![b'a'; HARD_CAP_BYTES];
+        let mode = select_mode(&exactly_cap, PromptDelivery::Auto).unwrap();
+        // Past STDIN_PREFERRED_MAX_BYTES → TempFile.
+        assert_eq!(mode, PromptDelivery::TempFile);
+    }
+
+    #[test]
+    fn select_mode_caller_override_short_prompts() {
+        // Step 2: caller-supplied non-Auto mode wins (when not size-capped).
+        let prompt = b"hello";
+        assert_eq!(
+            select_mode(prompt, PromptDelivery::Inline).unwrap(),
+            PromptDelivery::Inline
+        );
+        assert_eq!(
+            select_mode(prompt, PromptDelivery::Stdin).unwrap(),
+            PromptDelivery::Stdin
+        );
+        assert_eq!(
+            select_mode(prompt, PromptDelivery::TempFile).unwrap(),
+            PromptDelivery::TempFile
+        );
+    }
+
+    #[test]
+    fn select_mode_inline_with_nul_byte_errors() {
+        // Step 2 corner: explicit Inline + embedded NUL → NulInInlineMode.
+        let prompt = b"hello\0world";
+        let err = select_mode(prompt, PromptDelivery::Inline).unwrap_err();
+        assert!(matches!(err, PromptDeliveryError::NulInInlineMode));
+    }
+
+    #[test]
+    fn select_mode_auto_nul_forks_to_stdin() {
+        // Step 4: NUL fork in Auto mode → Stdin, never Inline.
+        let prompt = b"hello\0world";
+        assert_eq!(
+            select_mode(prompt, PromptDelivery::Auto).unwrap(),
+            PromptDelivery::Stdin
+        );
+    }
+
+    #[test]
+    fn select_mode_auto_inline_threshold() {
+        // Boundary at INLINE_MAX_BYTES (exclusive upper bound for Inline).
+        let just_under = vec![b'a'; INLINE_MAX_BYTES - 1];
+        assert_eq!(
+            select_mode(&just_under, PromptDelivery::Auto).unwrap(),
+            PromptDelivery::Inline
+        );
+
+        let exactly = vec![b'a'; INLINE_MAX_BYTES];
+        assert_eq!(
+            select_mode(&exactly, PromptDelivery::Auto).unwrap(),
+            PromptDelivery::Stdin,
+            "len == INLINE_MAX_BYTES must promote to Stdin (boundary is exclusive)"
+        );
+    }
+
+    #[test]
+    fn select_mode_auto_stdin_threshold() {
+        // Boundary at STDIN_PREFERRED_MAX_BYTES.
+        let just_under = vec![b'a'; STDIN_PREFERRED_MAX_BYTES - 1];
+        assert_eq!(
+            select_mode(&just_under, PromptDelivery::Auto).unwrap(),
+            PromptDelivery::Stdin
+        );
+
+        let exactly = vec![b'a'; STDIN_PREFERRED_MAX_BYTES];
+        assert_eq!(
+            select_mode(&exactly, PromptDelivery::Auto).unwrap(),
+            PromptDelivery::TempFile,
+            "len == STDIN_PREFERRED_MAX_BYTES must promote to TempFile"
+        );
+    }
+
+    #[test]
+    fn select_mode_auto_empty_prompt_inline() {
+        // Empty prompt is permitted; lands in Inline branch (smallest).
+        assert_eq!(
+            select_mode(b"", PromptDelivery::Auto).unwrap(),
+            PromptDelivery::Inline
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Env override resolution (requires mutating env; serial_test enforced)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    #[serial(prompt_delivery_env)]
+    #[cfg_attr(miri, ignore)]
+    fn select_mode_env_override_only_for_auto() {
+        // SAFETY (Rust 2024): set_var / remove_var require `unsafe` because
+        // they are not thread-safe; `#[serial]` ensures no other test in
+        // this serial group runs concurrently.
+        unsafe {
+            std::env::set_var(ENV_OVERRIDE, "stdin");
+        }
+
+        let short = b"hi";
+        assert_eq!(
+            select_mode(short, PromptDelivery::Auto).unwrap(),
+            PromptDelivery::Stdin,
+            "Auto must honor AMPLIHACK_PROMPT_DELIVERY=stdin"
+        );
+        // Non-Auto caller mode: env ignored.
+        assert_eq!(
+            select_mode(short, PromptDelivery::Inline).unwrap(),
+            PromptDelivery::Inline,
+            "explicit Inline must bypass env var"
+        );
+
+        unsafe {
+            std::env::set_var(ENV_OVERRIDE, "tempfile");
+        }
+        assert_eq!(
+            select_mode(short, PromptDelivery::Auto).unwrap(),
+            PromptDelivery::TempFile
+        );
+
+        // Invalid value → warn + fall back to Auto heuristic.
+        unsafe {
+            std::env::set_var(ENV_OVERRIDE, "bogus-value-xyz");
+        }
+        assert_eq!(
+            select_mode(short, PromptDelivery::Auto).unwrap(),
+            PromptDelivery::Inline,
+            "invalid env value must fall back to Auto heuristic, not panic"
+        );
+
+        unsafe {
+            std::env::remove_var(ENV_OVERRIDE);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Error enum — all variants present and Display-formattable
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn error_variants_have_display_messages() {
+        use std::io;
+        let cases: Vec<PromptDeliveryError> = vec![
+            PromptDeliveryError::TooLarge(123),
+            PromptDeliveryError::TempFile(io::Error::other("x")),
+            PromptDeliveryError::Write(io::Error::other("y")),
+            PromptDeliveryError::Permissions(io::Error::other("z")),
+            PromptDeliveryError::NulInInlineMode,
+        ];
+        for e in cases {
+            let msg = format!("{e}");
+            assert!(
+                !msg.is_empty(),
+                "Display impl produced empty string for {e:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn error_source_present_for_io_variants() {
+        use std::error::Error;
+        use std::io;
+        let e = PromptDeliveryError::TempFile(io::Error::other("inner"));
+        assert!(e.source().is_some());
+        let e = PromptDeliveryError::NulInInlineMode;
+        assert!(e.source().is_none());
+    }
+}

--- a/src/prompt_delivery/mod.rs
+++ b/src/prompt_delivery/mod.rs
@@ -47,16 +47,31 @@ use std::sync::OnceLock;
 use tempfile::NamedTempFile;
 use tokio::io::AsyncWriteExt as _;
 
+/// Defensive bound on the env value reported to logs. Operator-controlled
+/// input must never inflate log volume or smuggle control characters; see
+/// security review R-IV-2 / S8.
+const ENV_VALUE_LOG_BUDGET: usize = 64;
+
 /// Internal: log a one-time warning when an invalid env override value is
 /// encountered. Subsequent invalid values are silently coerced to the
-/// heuristic fallback.
+/// heuristic fallback. The reported value is truncated to
+/// [`ENV_VALUE_LOG_BUDGET`] bytes and control characters are escaped via
+/// `escape_default` so a malicious env value cannot inject newlines or ANSI
+/// escapes into the log stream.
 fn warn_invalid_env_value_once(value: &str) {
     static WARNED: OnceLock<()> = OnceLock::new();
     if WARNED.set(()).is_ok() {
+        let truncated: String = value.chars().take(ENV_VALUE_LOG_BUDGET).collect();
+        let safe: String = truncated.escape_default().collect();
+        let suffix = if value.len() > truncated.len() {
+            "...(truncated)"
+        } else {
+            ""
+        };
         tracing::warn!(
             target: "amplihack::prompt_delivery",
             env_var = ENV_OVERRIDE,
-            value = value,
+            value = %format_args!("{safe}{suffix}"),
             "invalid AMPLIHACK_PROMPT_DELIVERY value; falling back to auto heuristic. \
              Accepted values: auto, inline|cli|argv|arg, stdin|pipe, tempfile|temp-file|file"
         );
@@ -842,5 +857,17 @@ mod tests {
         assert!(e.source().is_some());
         let e = PromptDeliveryError::NulInInlineMode;
         assert!(e.source().is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // Defensive env-value log bound (security review R-IV-2 / S8)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn env_value_log_budget_pinned_at_64_bytes() {
+        // The 64-byte ceiling is a security invariant — bumping it requires
+        // re-reading the threat model in docs/prompt-delivery.md and
+        // session security-review-1897.md.
+        assert_eq!(ENV_VALUE_LOG_BUDGET, 64);
     }
 }

--- a/src/prompt_delivery/mod.rs
+++ b/src/prompt_delivery/mod.rs
@@ -240,13 +240,19 @@ impl FromStr for PromptDelivery {
         if trimmed.is_empty() {
             return Err(ParsePromptDeliveryError(trimmed.to_string()));
         }
-        let folded = trimmed.to_ascii_lowercase();
-        match folded.as_str() {
-            "auto" => Ok(PromptDelivery::Auto),
-            "inline" | "cli" | "argv" | "arg" => Ok(PromptDelivery::Inline),
-            "stdin" | "pipe" => Ok(PromptDelivery::Stdin),
-            "tempfile" | "temp-file" | "temp_file" | "file" => Ok(PromptDelivery::TempFile),
-            _ => Err(ParsePromptDeliveryError(trimmed.to_string())),
+        // Match aliases via `eq_ignore_ascii_case` so we don't allocate a
+        // lowercased copy on every env-var lookup (hot path on Auto mode).
+        let m = |alias: &str| trimmed.eq_ignore_ascii_case(alias);
+        if m("auto") {
+            Ok(PromptDelivery::Auto)
+        } else if m("inline") || m("cli") || m("argv") || m("arg") {
+            Ok(PromptDelivery::Inline)
+        } else if m("stdin") || m("pipe") {
+            Ok(PromptDelivery::Stdin)
+        } else if m("tempfile") || m("temp-file") || m("temp_file") || m("file") {
+            Ok(PromptDelivery::TempFile)
+        } else {
+            Err(ParsePromptDeliveryError(trimmed.to_string()))
         }
     }
 }

--- a/src/prompt_delivery/mod.rs
+++ b/src/prompt_delivery/mod.rs
@@ -38,9 +38,84 @@
 //! * [`ENV_OVERRIDE`] — `"AMPLIHACK_PROMPT_DELIVERY"`.
 
 use std::fmt;
+use std::io::Write as _;
 use std::path::{Path, PathBuf};
 use std::process::{ChildStdin, Command};
 use std::str::FromStr;
+use std::sync::OnceLock;
+
+use tempfile::NamedTempFile;
+use tokio::io::AsyncWriteExt as _;
+
+/// Internal: log a one-time warning when an invalid env override value is
+/// encountered. Subsequent invalid values are silently coerced to the
+/// heuristic fallback.
+fn warn_invalid_env_value_once(value: &str) {
+    static WARNED: OnceLock<()> = OnceLock::new();
+    if WARNED.set(()).is_ok() {
+        tracing::warn!(
+            target: "amplihack::prompt_delivery",
+            env_var = ENV_OVERRIDE,
+            value = value,
+            "invalid AMPLIHACK_PROMPT_DELIVERY value; falling back to auto heuristic. \
+             Accepted values: auto, inline|cli|argv|arg, stdin|pipe, tempfile|temp-file|file"
+        );
+    }
+}
+
+/// Internal helper: convert prompt bytes into an `&OsStr` for argv use.
+/// Unix-only because Rust's `OsStr::from_bytes` is gated to Unix; the
+/// integration tests are likewise `#[cfg(unix)]`.
+#[cfg(unix)]
+fn prompt_as_osstr(prompt: &[u8]) -> &std::ffi::OsStr {
+    use std::os::unix::ffi::OsStrExt;
+    std::ffi::OsStr::from_bytes(prompt)
+}
+
+#[cfg(not(unix))]
+fn prompt_as_osstr(prompt: &[u8]) -> std::ffi::OsString {
+    // On non-Unix targets fall back to UTF-8 (best-effort). amplihack
+    // primarily runs on Unix; Inline mode on Windows assumes valid UTF-8.
+    std::ffi::OsString::from(String::from_utf8_lossy(prompt).into_owned())
+}
+
+/// Internal helper: scan an iterator of OS-strings for an exact `--`
+/// terminator. Used to avoid duplicating a caller-supplied flag terminator.
+fn args_contain_flag_terminator<'a, I>(args: I) -> bool
+where
+    I: IntoIterator<Item = &'a std::ffi::OsStr>,
+{
+    args.into_iter().any(|a| a == "--")
+}
+
+/// Internal: write a `0o600` permissions bit on a freshly-created
+/// `NamedTempFile`. No-op on non-Unix.
+#[cfg(unix)]
+fn set_owner_only_permissions(file: &NamedTempFile) -> std::io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    let perms = std::fs::Permissions::from_mode(0o600);
+    std::fs::set_permissions(file.path(), perms)
+}
+
+#[cfg(not(unix))]
+fn set_owner_only_permissions(_file: &NamedTempFile) -> std::io::Result<()> {
+    Ok(())
+}
+
+/// Internal: create + populate + lock-down a postmortem temp file holding
+/// `prompt`. Wraps the three failure modes in distinct error variants so
+/// operators can diagnose temp-file vs. write vs. permission failures.
+fn build_postmortem_tempfile(prompt: &[u8]) -> Result<NamedTempFile, PromptDeliveryError> {
+    let mut file = tempfile::Builder::new()
+        .prefix("amplihack-prompt-")
+        .suffix(".txt")
+        .tempfile()
+        .map_err(PromptDeliveryError::TempFile)?;
+    file.write_all(prompt).map_err(PromptDeliveryError::Write)?;
+    file.flush().map_err(PromptDeliveryError::Write)?;
+    set_owner_only_permissions(&file).map_err(PromptDeliveryError::Permissions)?;
+    Ok(file)
+}
 
 // ---------------------------------------------------------------------------
 // Constants (test-asserted)
@@ -160,8 +235,19 @@ impl std::error::Error for ParsePromptDeliveryError {}
 impl FromStr for PromptDelivery {
     type Err = ParsePromptDeliveryError;
 
-    fn from_str(_s: &str) -> Result<Self, Self::Err> {
-        unimplemented!("PromptDelivery::from_str stub — see docs/prompt-delivery.md")
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let trimmed = s.trim();
+        if trimmed.is_empty() {
+            return Err(ParsePromptDeliveryError(trimmed.to_string()));
+        }
+        let folded = trimmed.to_ascii_lowercase();
+        match folded.as_str() {
+            "auto" => Ok(PromptDelivery::Auto),
+            "inline" | "cli" | "argv" | "arg" => Ok(PromptDelivery::Inline),
+            "stdin" | "pipe" => Ok(PromptDelivery::Stdin),
+            "tempfile" | "temp-file" | "temp_file" | "file" => Ok(PromptDelivery::TempFile),
+            _ => Err(ParsePromptDeliveryError(trimmed.to_string())),
+        }
     }
 }
 
@@ -184,10 +270,58 @@ impl FromStr for PromptDelivery {
 /// 6. `len < STDIN_PREFERRED_MAX_BYTES` → `Stdin`.
 /// 7. Otherwise → `TempFile`.
 pub fn select_mode(
-    _prompt: &[u8],
-    _caller: PromptDelivery,
+    prompt: &[u8],
+    caller: PromptDelivery,
 ) -> Result<PromptDelivery, PromptDeliveryError> {
-    unimplemented!("select_mode stub — see docs/prompt-delivery.md")
+    // Step 1 — hard cap fires before any override is considered.
+    if prompt.len() > HARD_CAP_BYTES {
+        return Err(PromptDeliveryError::TooLarge(prompt.len()));
+    }
+
+    // Step 2 — caller-supplied non-Auto mode wins.
+    match caller {
+        PromptDelivery::Inline => {
+            if prompt.contains(&0u8) {
+                return Err(PromptDeliveryError::NulInInlineMode);
+            }
+            return Ok(PromptDelivery::Inline);
+        }
+        PromptDelivery::Stdin => return Ok(PromptDelivery::Stdin),
+        PromptDelivery::TempFile => return Ok(PromptDelivery::TempFile),
+        PromptDelivery::Auto => {}
+    }
+
+    // Step 3 — env override (only consulted for Auto).
+    if let Ok(raw) = std::env::var(ENV_OVERRIDE) {
+        match PromptDelivery::from_str(&raw) {
+            Ok(PromptDelivery::Auto) => {
+                // explicit "auto" → fall through to heuristic
+            }
+            Ok(PromptDelivery::Inline) => {
+                if prompt.contains(&0u8) {
+                    return Err(PromptDeliveryError::NulInInlineMode);
+                }
+                return Ok(PromptDelivery::Inline);
+            }
+            Ok(mode @ (PromptDelivery::Stdin | PromptDelivery::TempFile)) => return Ok(mode),
+            Err(_) => warn_invalid_env_value_once(&raw),
+        }
+    }
+
+    // Step 4 — NUL fork (Auto only): silently route to stdin.
+    if prompt.contains(&0u8) {
+        return Ok(PromptDelivery::Stdin);
+    }
+
+    // Steps 5–7 — size-based heuristic. Boundaries are exclusive upper
+    // bounds so the threshold values themselves promote to the next mode.
+    if prompt.len() < INLINE_MAX_BYTES {
+        Ok(PromptDelivery::Inline)
+    } else if prompt.len() < STDIN_PREFERRED_MAX_BYTES {
+        Ok(PromptDelivery::Stdin)
+    } else {
+        Ok(PromptDelivery::TempFile)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -199,34 +333,55 @@ pub fn select_mode(
 /// child process or the temp file may be unlinked prematurely.
 #[must_use = "AppliedPromptStd must outlive the child process or the temp file may unlink prematurely"]
 pub struct AppliedPromptStd {
-    // Private fields will be filled in by the implementation commit.
-    _private: (),
+    mode: PromptDelivery,
+    /// Owned prompt bytes for stdin delivery. `None` for `Inline` (the bytes
+    /// already live in argv) or after the buffer has been consumed by
+    /// `feed`.
+    prompt: Option<Vec<u8>>,
+    /// Postmortem temp file. `Some` for `TempFile` mode (until consumed by
+    /// `retain_temp_file`). Drop unlinks the file on disk.
+    temp_file: Option<NamedTempFile>,
 }
 
 impl AppliedPromptStd {
     /// The mode actually selected (after size cap + caller / env override).
     pub fn mode(&self) -> PromptDelivery {
-        unimplemented!("AppliedPromptStd::mode stub")
+        self.mode
     }
 
     /// Path to the temp file, if mode == `TempFile`. `None` otherwise.
     pub fn temp_path(&self) -> Option<&Path> {
-        unimplemented!("AppliedPromptStd::temp_path stub")
+        self.temp_file.as_ref().map(|f| f.path())
     }
 
     /// Write the owned prompt buffer to the child's stdin and consume the
     /// guard. No-op for `Inline` mode (returns `Ok(())`). Closes stdin on
     /// completion so the child reads EOF.
-    pub fn feed(self, _stdin: Option<ChildStdin>) -> std::io::Result<()> {
-        unimplemented!("AppliedPromptStd::feed stub")
+    pub fn feed(mut self, stdin: Option<ChildStdin>) -> std::io::Result<()> {
+        let bytes = match self.prompt.take() {
+            Some(b) => b,
+            // Inline mode (no buffer captured) → nothing to write.
+            None => return Ok(()),
+        };
+        let mut sink = stdin.ok_or_else(|| {
+            std::io::Error::other(
+                "AppliedPromptStd::feed requires the child's stdin pipe \
+                 (set Command::stdin(Stdio::piped()) before spawning)",
+            )
+        })?;
+        sink.write_all(&bytes)?;
+        sink.flush()?;
+        // Dropping `sink` closes the pipe so the child reads EOF.
+        drop(sink);
+        Ok(())
     }
 
     /// Detach the temp file from RAII cleanup. Returns the retained path so
-    /// the caller can attach it to a bug report. **Caller must
-    /// `std::fs::remove_file` the path once the postmortem capture is
-    /// finished** — opt-in retention disables Drop unlink.
-    pub fn retain_temp_file(self) -> Option<PathBuf> {
-        unimplemented!("AppliedPromptStd::retain_temp_file stub")
+    /// the caller can attach it to a bug report.
+    pub fn retain_temp_file(mut self) -> Option<PathBuf> {
+        let file = self.temp_file.take()?;
+        // `keep()` disables the auto-unlink Drop and returns the path.
+        file.keep().ok().map(|(_file, path)| path)
     }
 }
 
@@ -237,24 +392,41 @@ impl AppliedPromptStd {
 /// Async sibling of [`AppliedPromptStd`].
 #[must_use = "AppliedPromptTokio must outlive the child process or the temp file may unlink prematurely"]
 pub struct AppliedPromptTokio {
-    _private: (),
+    mode: PromptDelivery,
+    prompt: Option<Vec<u8>>,
+    temp_file: Option<NamedTempFile>,
 }
 
 impl AppliedPromptTokio {
     pub fn mode(&self) -> PromptDelivery {
-        unimplemented!("AppliedPromptTokio::mode stub")
+        self.mode
     }
 
     pub fn temp_path(&self) -> Option<&Path> {
-        unimplemented!("AppliedPromptTokio::temp_path stub")
+        self.temp_file.as_ref().map(|f| f.path())
     }
 
-    pub async fn feed(self, _stdin: Option<tokio::process::ChildStdin>) -> std::io::Result<()> {
-        unimplemented!("AppliedPromptTokio::feed stub")
+    pub async fn feed(mut self, stdin: Option<tokio::process::ChildStdin>) -> std::io::Result<()> {
+        let bytes = match self.prompt.take() {
+            Some(b) => b,
+            None => return Ok(()),
+        };
+        let mut sink = stdin.ok_or_else(|| {
+            std::io::Error::other(
+                "AppliedPromptTokio::feed requires the child's stdin pipe \
+                 (set Command::stdin(Stdio::piped()) before spawning)",
+            )
+        })?;
+        sink.write_all(&bytes).await?;
+        sink.flush().await?;
+        sink.shutdown().await?;
+        drop(sink);
+        Ok(())
     }
 
-    pub fn retain_temp_file(self) -> Option<PathBuf> {
-        unimplemented!("AppliedPromptTokio::retain_temp_file stub")
+    pub fn retain_temp_file(mut self) -> Option<PathBuf> {
+        let file = self.temp_file.take()?;
+        file.keep().ok().map(|(_file, path)| path)
     }
 }
 
@@ -271,20 +443,103 @@ impl AppliedPromptTokio {
 ///   the prompt bytes for postmortem inspection; bytes also written to stdin
 ///   by `feed`.
 pub fn apply_std(
-    _cmd: &mut Command,
-    _prompt: &[u8],
-    _mode: PromptDelivery,
+    cmd: &mut Command,
+    prompt: &[u8],
+    mode: PromptDelivery,
 ) -> Result<AppliedPromptStd, PromptDeliveryError> {
-    unimplemented!("apply_std stub — see docs/prompt-delivery.md")
+    let resolved = select_mode(prompt, mode)?;
+    match resolved {
+        PromptDelivery::Inline => {
+            // Inject `--` flag terminator (unless caller already supplied one)
+            // and append the prompt as the final positional argument.
+            if !args_contain_flag_terminator(cmd.get_args()) {
+                cmd.arg("--");
+            }
+            #[cfg(unix)]
+            {
+                cmd.arg(prompt_as_osstr(prompt));
+            }
+            #[cfg(not(unix))]
+            {
+                cmd.arg(prompt_as_osstr(prompt));
+            }
+            Ok(AppliedPromptStd {
+                mode: PromptDelivery::Inline,
+                prompt: None,
+                temp_file: None,
+            })
+        }
+        PromptDelivery::Stdin => {
+            cmd.stdin(std::process::Stdio::piped());
+            Ok(AppliedPromptStd {
+                mode: PromptDelivery::Stdin,
+                prompt: Some(prompt.to_vec()),
+                temp_file: None,
+            })
+        }
+        PromptDelivery::TempFile => {
+            let file = build_postmortem_tempfile(prompt)?;
+            cmd.stdin(std::process::Stdio::piped());
+            Ok(AppliedPromptStd {
+                mode: PromptDelivery::TempFile,
+                prompt: Some(prompt.to_vec()),
+                temp_file: Some(file),
+            })
+        }
+        // `Auto` is fully resolved by `select_mode`; this branch is
+        // unreachable but keeps the match exhaustive against the
+        // `non_exhaustive` enum.
+        PromptDelivery::Auto => unreachable!("select_mode never returns Auto"),
+    }
 }
 
 /// Async sibling of [`apply_std`].
 pub async fn apply_tokio(
-    _cmd: &mut tokio::process::Command,
-    _prompt: &[u8],
-    _mode: PromptDelivery,
+    cmd: &mut tokio::process::Command,
+    prompt: &[u8],
+    mode: PromptDelivery,
 ) -> Result<AppliedPromptTokio, PromptDeliveryError> {
-    unimplemented!("apply_tokio stub — see docs/prompt-delivery.md")
+    let resolved = select_mode(prompt, mode)?;
+    match resolved {
+        PromptDelivery::Inline => {
+            // Note: tokio::process::Command does not expose `get_args()`, so
+            // we always inject `--` here. Callers wanting to skip the
+            // injection should pass a non-Inline mode or strip the
+            // duplicate `--` themselves.
+            cmd.arg("--");
+            #[cfg(unix)]
+            {
+                cmd.arg(prompt_as_osstr(prompt));
+            }
+            #[cfg(not(unix))]
+            {
+                cmd.arg(prompt_as_osstr(prompt));
+            }
+            Ok(AppliedPromptTokio {
+                mode: PromptDelivery::Inline,
+                prompt: None,
+                temp_file: None,
+            })
+        }
+        PromptDelivery::Stdin => {
+            cmd.stdin(std::process::Stdio::piped());
+            Ok(AppliedPromptTokio {
+                mode: PromptDelivery::Stdin,
+                prompt: Some(prompt.to_vec()),
+                temp_file: None,
+            })
+        }
+        PromptDelivery::TempFile => {
+            let file = build_postmortem_tempfile(prompt)?;
+            cmd.stdin(std::process::Stdio::piped());
+            Ok(AppliedPromptTokio {
+                mode: PromptDelivery::TempFile,
+                prompt: Some(prompt.to_vec()),
+                temp_file: Some(file),
+            })
+        }
+        PromptDelivery::Auto => unreachable!("select_mode never returns Auto"),
+    }
 }
 
 // ===========================================================================

--- a/src/prompt_delivery/mod.rs
+++ b/src/prompt_delivery/mod.rs
@@ -665,6 +665,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(prompt_delivery_env)]
     fn select_mode_at_hard_cap_is_allowed() {
         // Cap is exclusive — len == HARD_CAP_BYTES is OK.
         let exactly_cap = vec![b'a'; HARD_CAP_BYTES];
@@ -700,6 +701,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(prompt_delivery_env)]
     fn select_mode_auto_nul_forks_to_stdin() {
         // Step 4: NUL fork in Auto mode → Stdin, never Inline.
         let prompt = b"hello\0world";
@@ -710,6 +712,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(prompt_delivery_env)]
     fn select_mode_auto_inline_threshold() {
         // Boundary at INLINE_MAX_BYTES (exclusive upper bound for Inline).
         let just_under = vec![b'a'; INLINE_MAX_BYTES - 1];
@@ -727,6 +730,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(prompt_delivery_env)]
     fn select_mode_auto_stdin_threshold() {
         // Boundary at STDIN_PREFERRED_MAX_BYTES.
         let just_under = vec![b'a'; STDIN_PREFERRED_MAX_BYTES - 1];
@@ -744,8 +748,12 @@ mod tests {
     }
 
     #[test]
+    #[serial(prompt_delivery_env)]
     fn select_mode_auto_empty_prompt_inline() {
         // Empty prompt is permitted; lands in Inline branch (smallest).
+        // Serialised with the env-mutating test below so a leaked
+        // `AMPLIHACK_PROMPT_DELIVERY` from a parallel run can't flip the
+        // Auto path to Stdin / TempFile under our feet.
         assert_eq!(
             select_mode(b"", PromptDelivery::Auto).unwrap(),
             PromptDelivery::Inline

--- a/tests/prompt_delivery.rs
+++ b/tests/prompt_delivery.rs
@@ -1,0 +1,466 @@
+//! Outside-in integration tests for `simard::prompt_delivery` (issue #1897).
+//!
+//! These tests are the **TDD red phase** for the new subprocess prompt
+//! delivery layer. They spawn real `/bin/cat` and `/usr/bin/env` subprocesses
+//! (Unix only) to exercise the full Command-mutation + stdin-write +
+//! temp-file lifecycle end-to-end, asserting that:
+//!
+//! 1. **Round-trip integrity** — prompts containing apostrophes, double
+//!    quotes, newlines, tabs, and 64 KiB+ payloads survive delivery
+//!    byte-for-byte (the bugs from rysweet/Simard#1871 / #1879).
+//! 2. **Mode selection** — `Auto` correctly picks `Inline` / `Stdin` /
+//!    `TempFile` based on prompt size; explicit overrides win.
+//! 3. **Env override** — `AMPLIHACK_PROMPT_DELIVERY` flips `Auto` choice;
+//!    invalid values fall back gracefully.
+//! 4. **Temp-file semantics** — file exists on disk during child lifetime,
+//!    has `0o600` perms, is unlinked on Drop, persists when
+//!    `retain_temp_file()` is called.
+//! 5. **Argv hygiene** — `Inline` mode appends `--` flag terminator before
+//!    the prompt, so prompts beginning with `-` cannot be reinterpreted as
+//!    flags by the child binary.
+//! 6. **Size limits** — `> 16 MiB` returns `TooLarge` *before* spawning.
+//! 7. **NUL guard** — explicit `Inline` + NUL byte returns `NulInInlineMode`.
+//!
+//! All tests touching the env var are serialized with `serial_test` under a
+//! shared lock key `prompt_delivery_env` (also used by inline unit tests in
+//! `src/prompt_delivery/mod.rs`).
+//!
+//! The tests are gated on `#[cfg(unix)]` because they spawn `/bin/cat` and
+//! rely on Unix permission bits. CI is Linux per the repo's `.github/`
+//! workflow set; macOS local runs are also expected to pass.
+
+#![cfg(unix)]
+
+use std::io::Read;
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+use serial_test::serial;
+use simard::prompt_delivery::{
+    AppliedPromptStd, ENV_OVERRIDE, HARD_CAP_BYTES, PromptDelivery, PromptDeliveryError,
+    STDIN_PREFERRED_MAX_BYTES, apply_std, select_mode,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Spawn `/bin/cat` (no args), drive `apply_std` to feed the prompt, capture
+/// stdout, and return it. Used to verify byte-for-byte round-trip across
+/// `Stdin` and `TempFile` modes — both wire the prompt to the child's stdin.
+fn run_cat_with_prompt(prompt: &[u8], mode: PromptDelivery) -> Vec<u8> {
+    let mut cmd = Command::new("/bin/cat");
+    cmd.stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+
+    let applied =
+        apply_std(&mut cmd, prompt, mode).expect("apply_std failed for run_cat_with_prompt");
+
+    let mut child = cmd.spawn().expect("/bin/cat spawn failed");
+    let stdin = child.stdin.take();
+    applied.feed(stdin).expect("AppliedPromptStd::feed failed");
+
+    let mut stdout_buf = Vec::with_capacity(prompt.len());
+    child
+        .stdout
+        .take()
+        .expect("child stdout pipe missing")
+        .read_to_end(&mut stdout_buf)
+        .expect("reading cat stdout");
+
+    let status = child.wait().expect("cat wait failed");
+    assert!(
+        status.success(),
+        "/bin/cat exited unsuccessfully: {status:?}"
+    );
+    stdout_buf
+}
+
+/// Lock a sane test timeout so a hung subprocess fails the CI run within a
+/// minute rather than hanging the suite.
+fn assert_within<F: FnOnce() + Send + 'static>(d: Duration, label: &str, f: F) {
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        f();
+        let _ = tx.send(());
+    });
+    match rx.recv_timeout(d) {
+        Ok(()) => {}
+        Err(_) => panic!("{label} did not complete within {d:?}"),
+    }
+}
+
+// ===========================================================================
+// Round-trip integrity tests (Stdin / TempFile)
+// ===========================================================================
+
+#[test]
+fn stdin_mode_roundtrips_apostrophes_unchanged() {
+    // The shell-quoting bug from #1871: "Don't" was getting mangled.
+    let prompt = b"Don't break the build -- the engineer's job depends on it.";
+    let got = run_cat_with_prompt(prompt, PromptDelivery::Stdin);
+    assert_eq!(got, prompt);
+}
+
+#[test]
+fn tempfile_mode_roundtrips_apostrophes_unchanged() {
+    let prompt = b"Don't break the build -- the engineer's job depends on it.";
+    let got = run_cat_with_prompt(prompt, PromptDelivery::TempFile);
+    assert_eq!(got, prompt);
+}
+
+#[test]
+fn stdin_mode_roundtrips_double_quotes_unchanged() {
+    let prompt = b"\"quoted\" 'mixed' `backticks` and $variables ${expansions}";
+    let got = run_cat_with_prompt(prompt, PromptDelivery::Stdin);
+    assert_eq!(got, prompt);
+}
+
+#[test]
+fn stdin_mode_roundtrips_newlines_and_tabs_unchanged() {
+    let prompt = b"line one\nline\ttwo\r\nline three\n\nfinal";
+    let got = run_cat_with_prompt(prompt, PromptDelivery::Stdin);
+    assert_eq!(got, prompt);
+}
+
+#[test]
+fn stdin_mode_roundtrips_64kib_payload_unchanged() {
+    // The size at which `argv` delivery starts brushing against per-arg
+    // ARG_MAX on macOS (256 KiB total) and pushes claude into truncating.
+    let prompt: Vec<u8> = (0..(64 * 1024)).map(|i| (i % 256) as u8).collect();
+    assert_within(
+        Duration::from_secs(15),
+        "64 KiB stdin roundtrip",
+        move || {
+            let got = run_cat_with_prompt(&prompt, PromptDelivery::Stdin);
+            assert_eq!(got.len(), prompt.len(), "64 KiB roundtrip changed length");
+            assert_eq!(got, prompt, "64 KiB roundtrip changed content");
+        },
+    );
+}
+
+#[test]
+fn tempfile_mode_roundtrips_64kib_payload_unchanged() {
+    let prompt: Vec<u8> = (0..(64 * 1024)).map(|i| (i % 256) as u8).collect();
+    assert_within(
+        Duration::from_secs(15),
+        "64 KiB tempfile roundtrip",
+        move || {
+            let got = run_cat_with_prompt(&prompt, PromptDelivery::TempFile);
+            assert_eq!(got, prompt);
+        },
+    );
+}
+
+#[test]
+fn stdin_mode_roundtrips_nul_bytes_unchanged() {
+    // NUL bytes cannot ride argv on POSIX (truncates at NUL), but stdin can
+    // carry them fine. apply_std must not lose any bytes.
+    let prompt = b"before\0middle\0after";
+    let got = run_cat_with_prompt(prompt, PromptDelivery::Stdin);
+    assert_eq!(got, prompt);
+}
+
+// ===========================================================================
+// Mode auto-selection (sizes / explicit overrides)
+// ===========================================================================
+
+#[test]
+fn applied_mode_reports_inline_for_small_prompt() {
+    let mut cmd = Command::new("/bin/cat");
+    let applied = apply_std(&mut cmd, b"tiny", PromptDelivery::Auto).unwrap();
+    assert_eq!(applied.mode(), PromptDelivery::Inline);
+    assert!(applied.temp_path().is_none());
+}
+
+#[test]
+fn applied_mode_reports_tempfile_for_large_prompt() {
+    let mut cmd = Command::new("/bin/cat");
+    let big = vec![b'x'; STDIN_PREFERRED_MAX_BYTES + 16];
+    let applied = apply_std(&mut cmd, &big, PromptDelivery::Auto).unwrap();
+    assert_eq!(applied.mode(), PromptDelivery::TempFile);
+    assert!(
+        applied.temp_path().is_some(),
+        "TempFile mode must expose a temp_path()"
+    );
+}
+
+#[test]
+fn inline_mode_argv_ends_with_flag_terminator_then_prompt() {
+    // Argv hygiene: the prompt must NOT be reinterpretable as a flag.
+    // apply_std must inject `--` before the prompt argv element if the
+    // caller has not already done so. This is the S11 protection.
+    let mut cmd = Command::new("/bin/cat");
+    cmd.arg("--show-tabs"); // pretend this is a real flag we want to keep
+    let prompt = b"--rm -rf /";
+    let _applied = apply_std(&mut cmd, prompt, PromptDelivery::Inline).unwrap();
+
+    let args: Vec<String> = cmd
+        .get_args()
+        .map(|a| a.to_string_lossy().into_owned())
+        .collect();
+
+    // Last arg is the prompt.
+    assert_eq!(
+        args.last().map(String::as_str),
+        Some("--rm -rf /"),
+        "Inline mode must append prompt as last argv element. Got: {args:?}"
+    );
+    // The element before the prompt is `--`.
+    let n = args.len();
+    assert!(
+        n >= 2,
+        "expected at least [..., '--', <prompt>]; got {args:?}"
+    );
+    assert_eq!(
+        args[n - 2],
+        "--",
+        "Inline mode must inject `--` flag terminator before the prompt"
+    );
+}
+
+#[test]
+fn inline_mode_does_not_duplicate_flag_terminator() {
+    // If the caller already terminated with `--`, apply_std must NOT add a
+    // second `--` (that would make the second `--` itself a positional).
+    let mut cmd = Command::new("/bin/cat");
+    cmd.arg("--").arg("first-positional");
+    let prompt = b"the-prompt";
+    let _applied = apply_std(&mut cmd, prompt, PromptDelivery::Inline).unwrap();
+
+    let args: Vec<String> = cmd
+        .get_args()
+        .map(|a| a.to_string_lossy().into_owned())
+        .collect();
+
+    let dashdash_count = args.iter().filter(|a| *a == "--").count();
+    assert_eq!(
+        dashdash_count, 1,
+        "apply_std must not duplicate an existing `--` terminator. Got: {args:?}"
+    );
+    assert_eq!(args.last().map(String::as_str), Some("the-prompt"));
+}
+
+// ===========================================================================
+// Env override
+// ===========================================================================
+
+#[test]
+#[serial(prompt_delivery_env)]
+fn env_override_forces_inline_for_short_prompt() {
+    // SAFETY (Rust 2024): set_var/remove_var require unsafe — tests only.
+    unsafe {
+        std::env::set_var(ENV_OVERRIDE, "inline");
+    }
+    let mode = select_mode(b"short", PromptDelivery::Auto).expect("select_mode");
+    assert_eq!(mode, PromptDelivery::Inline);
+    unsafe {
+        std::env::remove_var(ENV_OVERRIDE);
+    }
+}
+
+#[test]
+#[serial(prompt_delivery_env)]
+fn env_override_forces_tempfile_for_short_prompt() {
+    unsafe {
+        std::env::set_var(ENV_OVERRIDE, "tempfile");
+    }
+    // Apply for a short prompt: would otherwise be Inline, env wins.
+    let mut cmd = Command::new("/bin/cat");
+    cmd.stdin(Stdio::piped()).stdout(Stdio::piped());
+    let applied = apply_std(&mut cmd, b"short", PromptDelivery::Auto).unwrap();
+    assert_eq!(applied.mode(), PromptDelivery::TempFile);
+    assert!(applied.temp_path().is_some());
+
+    // Cleanup driver: drive the child to completion so the guard releases.
+    let mut child = cmd.spawn().expect("/bin/cat spawn");
+    applied.feed(child.stdin.take()).unwrap();
+    let _ = child.wait();
+
+    unsafe {
+        std::env::remove_var(ENV_OVERRIDE);
+    }
+}
+
+#[test]
+#[serial(prompt_delivery_env)]
+fn invalid_env_value_falls_back_to_auto_without_panic() {
+    unsafe {
+        std::env::set_var(ENV_OVERRIDE, "totally-bogus");
+    }
+    // Auto must still resolve cleanly — invalid value warned-once and
+    // falls back to the heuristic.
+    let mode = select_mode(b"short", PromptDelivery::Auto).expect("must not panic");
+    assert_eq!(mode, PromptDelivery::Inline);
+    unsafe {
+        std::env::remove_var(ENV_OVERRIDE);
+    }
+}
+
+#[test]
+#[serial(prompt_delivery_env)]
+fn caller_override_ignores_env_var() {
+    unsafe {
+        std::env::set_var(ENV_OVERRIDE, "tempfile");
+    }
+    // Explicit Inline beats env override.
+    let mode = select_mode(b"short", PromptDelivery::Inline).unwrap();
+    assert_eq!(mode, PromptDelivery::Inline);
+    unsafe {
+        std::env::remove_var(ENV_OVERRIDE);
+    }
+}
+
+// ===========================================================================
+// TempFile lifecycle / permissions / retention
+// ===========================================================================
+
+#[test]
+fn tempfile_exists_during_guard_lifetime() {
+    let mut cmd = Command::new("/bin/cat");
+    cmd.stdin(Stdio::piped()).stdout(Stdio::piped());
+    let applied = apply_std(&mut cmd, b"prompt-for-disk", PromptDelivery::TempFile).unwrap();
+
+    let path = applied
+        .temp_path()
+        .expect("TempFile mode must expose temp_path")
+        .to_path_buf();
+
+    assert!(
+        path.exists(),
+        "temp file must exist while guard is alive: {path:?}"
+    );
+
+    // Drive the child to completion (feed consumes the guard).
+    let mut child = cmd.spawn().expect("/bin/cat spawn");
+    applied.feed(child.stdin.take()).unwrap();
+    let _ = child.wait();
+
+    // Guard dropped on feed → file must be unlinked.
+    assert!(
+        !path.exists(),
+        "temp file must be unlinked after guard is consumed/dropped: {path:?}"
+    );
+}
+
+#[test]
+fn tempfile_dropped_without_feed_still_unlinks() {
+    let mut cmd = Command::new("/bin/cat");
+    cmd.stdin(Stdio::piped()).stdout(Stdio::piped());
+    let path = {
+        let applied = apply_std(&mut cmd, b"prompt-dropped", PromptDelivery::TempFile).unwrap();
+        let p = applied.temp_path().unwrap().to_path_buf();
+        assert!(p.exists());
+        p
+        // applied dropped here without feed()
+    };
+    assert!(
+        !path.exists(),
+        "Drop of AppliedPromptStd must unlink the temp file: {path:?}"
+    );
+}
+
+#[test]
+fn retain_temp_file_persists_after_drop_then_caller_cleans_up() {
+    let mut cmd = Command::new("/bin/cat");
+    cmd.stdin(Stdio::piped()).stdout(Stdio::piped());
+    let applied = apply_std(&mut cmd, b"keep-me", PromptDelivery::TempFile).unwrap();
+    let retained = applied
+        .retain_temp_file()
+        .expect("TempFile mode must return Some(path) from retain_temp_file()");
+    assert!(
+        retained.exists(),
+        "retain_temp_file must leave the file on disk: {retained:?}"
+    );
+
+    // Caller-side cleanup (this is contract — operator must remove
+    // explicitly because retain disables RAII).
+    std::fs::remove_file(&retained).expect("manual cleanup must succeed");
+    assert!(!retained.exists());
+}
+
+#[test]
+#[cfg(unix)]
+fn tempfile_has_0o600_permissions() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut cmd = Command::new("/bin/cat");
+    cmd.stdin(Stdio::piped()).stdout(Stdio::piped());
+    let applied = apply_std(&mut cmd, b"perm-test", PromptDelivery::TempFile).unwrap();
+    let path = applied.temp_path().unwrap();
+    let meta = std::fs::metadata(path).expect("temp file metadata");
+    let mode = meta.permissions().mode() & 0o777;
+    assert_eq!(
+        mode, 0o600,
+        "temp file must be owner-rw-only (0o600); got 0o{mode:o}"
+    );
+
+    // Drain and drop.
+    let mut child = cmd.spawn().expect("/bin/cat spawn");
+    applied.feed(child.stdin.take()).unwrap();
+    let _ = child.wait();
+}
+
+// ===========================================================================
+// Hard cap and NUL guard
+// ===========================================================================
+
+#[test]
+fn oversize_prompt_returns_too_large_before_spawn() {
+    let mut cmd = Command::new("/bin/cat");
+    cmd.stdin(Stdio::piped()).stdout(Stdio::piped());
+    let huge = vec![b'a'; HARD_CAP_BYTES + 1];
+    let err = apply_std(&mut cmd, &huge, PromptDelivery::Auto)
+        .err()
+        .expect("oversize prompt must error before spawn");
+    match err {
+        PromptDeliveryError::TooLarge(n) => assert_eq!(n, HARD_CAP_BYTES + 1),
+        other => panic!("expected TooLarge, got {other:?}"),
+    }
+}
+
+#[test]
+fn explicit_inline_with_nul_returns_nul_in_inline_mode() {
+    let mut cmd = Command::new("/bin/cat");
+    let prompt = b"safe\0unsafe";
+    let err = apply_std(&mut cmd, prompt, PromptDelivery::Inline)
+        .err()
+        .expect("NUL in explicit Inline mode must error");
+    assert!(
+        matches!(err, PromptDeliveryError::NulInInlineMode),
+        "expected NulInInlineMode; got {err:?}"
+    );
+}
+
+// ===========================================================================
+// AppliedPromptStd must_use sanity (compile-only assertion via type system)
+// ===========================================================================
+
+#[test]
+fn applied_prompt_std_is_send() {
+    fn assert_send<T: Send>() {}
+    assert_send::<AppliedPromptStd>();
+}
+
+// ===========================================================================
+// Quoting-bug regression (#1871 / #1879): a representative engineer brief
+// ===========================================================================
+
+#[test]
+fn engineer_brief_with_mixed_quoting_roundtrips() {
+    // Shape mirrors a real engineer brief — multi-line, apostrophes,
+    // double quotes, backticks, command substitution shapes — the exact
+    // class of input that motivated this module per issues #1871 / #1879.
+    let prompt = b"## Task\n\
+        Drive issue #1897 -- `amplihack-rs` parity: subprocess prompt delivery.\n\
+        \n\
+        You'll need to:\n\
+        1. Grep for `Command::new(...)` callsites that pass prompts via `-p \"$prompt\"`.\n\
+        2. Add `select_mode` + `apply_std` plumbing.\n\
+        3. Don't forget the `--` flag terminator!\n\
+        \n\
+        Done == `cargo test -p simard --test prompt_delivery` is green.\n";
+    let got = run_cat_with_prompt(prompt, PromptDelivery::Stdin);
+    assert_eq!(got, prompt, "engineer brief must survive stdin roundtrip");
+}


### PR DESCRIPTION
## Summary

Implements the **subprocess prompt delivery** layer called out in #1897 — the amplihack-rs / Simard parity gap that left long prompts (and prompts containing apostrophes) at risk of `argv` truncation and shell-escape corruption (the failure mode behind #1871 / #1879).

This PR lands as **two commits**, one per TDD phase:

| Commit | Phase | Contents |
|---|---|---|
| `32534e8f` | RED  | Stub module + failing tests + `docs/prompt-delivery.md` |
| `22eab2ce` | GREEN | Full implementation, all 41 tests now pass |

Closes #1897. Related: #1871, #1879, #1898, #1899, #1900, #1901, parity matrix `docs/amplihack-rs-parity.md`.

## Public surface (`simard::prompt_delivery`)

| Item | Purpose |
|---|---|
| `PromptDelivery` enum | `Auto` / `Inline` / `Stdin` / `TempFile` with case-insensitive `FromStr` accepting `inline\|cli\|argv\|arg`, `stdin\|pipe`, `tempfile\|temp-file\|file`, `auto` |
| `select_mode()` | Pure heuristic — no I/O; documented resolution order pinned by unit tests |
| `apply_std()` / `apply_tokio()` | Mutate a `Command` in place and return an RAII guard |
| `AppliedPromptStd` / `AppliedPromptTokio` | RAII guards owning the temp file + prompt bytes; `feed()` writes to stdin and closes the pipe |
| `PromptDeliveryError` | `TooLarge` / `TempFile` / `Write` / `Permissions` / `NulInInlineMode`, all `#[non_exhaustive]` |
| `ENV_OVERRIDE` = `"AMPLIHACK_PROMPT_DELIVERY"` | Auto-only env override |
| Constants `INLINE_MAX_BYTES=8 KiB`, `STDIN_PREFERRED_MAX_BYTES=100 KiB`, `HARD_CAP_BYTES=16 MiB` | Test-pinned thresholds |

## Auto-selection heuristic (resolution order)

1. **Hard cap** — `prompt.len() > 16 MiB` → `Err(TooLarge)` *before any override*.
2. **Caller override** — any non-`Auto` mode wins. `Inline` + NUL → `Err(NulInInlineMode)`.
3. **Env override** — `AMPLIHACK_PROMPT_DELIVERY` consulted only for `Auto` callers. Invalid values warn-once (via `tracing::warn!`) then fall back to step 4.
4. **NUL fork** (Auto only) — prompt with `0x00` → `Stdin` (never `Inline`).
5. `len < 8 KiB` → `Inline`.
6. `len < 100 KiB` → `Stdin`.
7. Otherwise → `TempFile`.

## Argv hygiene (`Inline` mode)

- Injects `--` flag terminator before the prompt arg, unless one is already present (caller-supplied `--` is preserved without duplication).
- Prompts beginning with `-` cannot be reinterpreted as flags by the child binary.

## Temp-file semantics (`TempFile` mode)

- Created via `tempfile::Builder` with `amplihack-prompt-*.txt` naming.
- `0o600` permissions enforced explicitly on Unix.
- Prompt bytes are also piped via stdin (the file is a **postmortem artifact**, not a `--prompt-file` flag — no upstream binary accepts that flag yet; this is documented in `docs/prompt-delivery.md`).
- RAII cleanup on Drop; `retain_temp_file()` opts out (returns `PathBuf`, caller owns cleanup).

## Test evidence

```
$ cargo test -p simard --lib prompt_delivery
test result: ok. 18 passed; 0 failed
```

| Lib test | Pins |
|---|---|
| `constants_match_design_spec` | All four constants |
| `from_str_accepts_{auto,inline,stdin,tempfile}_aliases` | Full alias grammar |
| `from_str_rejects_{unknown,empty}` | Parse failure paths |
| `select_mode_size_cap_fires_before_caller_override` | Step 1 invariant |
| `select_mode_at_hard_cap_is_allowed` | Cap is exclusive |
| `select_mode_caller_override_short_prompts` | Step 2 |
| `select_mode_inline_with_nul_byte_errors` | `Inline` + NUL guard |
| `select_mode_auto_nul_forks_to_stdin` | Step 4 NUL fork |
| `select_mode_auto_{inline,stdin}_threshold` | Boundaries are exclusive |
| `select_mode_auto_empty_prompt_inline` | Empty prompt OK |
| `select_mode_env_override_only_for_auto` | Env / caller / invalid value matrix (`#[serial]`) |
| `error_variants_have_display_messages` / `error_source_present_for_io_variants` | Error impl completeness |

```
$ cargo test -p simard --test prompt_delivery
test result: ok. 23 passed; 0 failed
```

| Integration test | Pins |
|---|---|
| `stdin_mode_roundtrips_apostrophes_unchanged` | **#1871 regression** |
| `tempfile_mode_roundtrips_apostrophes_unchanged` | Same payload, TempFile mode |
| `stdin_mode_roundtrips_double_quotes_unchanged` | `"`, `'`, backticks, `$`, `${...}` |
| `stdin_mode_roundtrips_newlines_and_tabs_unchanged` | `\n`, `\t`, `\r\n` |
| `stdin_mode_roundtrips_64kib_payload_unchanged` | **Acceptance criterion — 64 KiB synthetic prompt** |
| `tempfile_mode_roundtrips_64kib_payload_unchanged` | Same payload, TempFile mode |
| `stdin_mode_roundtrips_nul_bytes_unchanged` | NUL survival via stdin |
| `applied_mode_reports_inline_for_small_prompt` | Auto → Inline for short |
| `applied_mode_reports_tempfile_for_large_prompt` | Auto → TempFile for > 100 KiB |
| `inline_mode_argv_ends_with_flag_terminator_then_prompt` | `--` injection |
| `inline_mode_does_not_duplicate_flag_terminator` | Caller-supplied `--` preserved |
| `env_override_forces_{inline,tempfile}_for_short_prompt` | Env override (Auto) |
| `caller_override_ignores_env_var` | Env ignored for non-Auto |
| `invalid_env_value_falls_back_to_auto_without_panic` | Graceful invalid handling |
| `tempfile_exists_during_guard_lifetime` | RAII contract |
| `tempfile_dropped_without_feed_still_unlinks` | Drop unlinks |
| `retain_temp_file_persists_after_drop_then_caller_cleans_up` | Opt-out retention |
| `tempfile_has_0o600_permissions` | Unix perms check |
| `oversize_prompt_returns_too_large_before_spawn` | Hard cap pre-spawn |
| `explicit_inline_with_nul_returns_nul_in_inline_mode` | NUL guard at apply_std |
| `applied_prompt_std_is_send` | `Send` bound |
| `engineer_brief_with_mixed_quoting_roundtrips` | Representative multi-line engineer brief |

## Quality gates

| Gate | Status |
|---|---|
| `cargo test -p simard --lib prompt_delivery` | ✅ 18 pass |
| `cargo test -p simard --test prompt_delivery` | ✅ 23 pass |
| `cargo clippy --lib --tests --bins -- -D warnings` | ✅ clean |
| `cargo clippy --release --no-deps -- -D warnings` (pre-commit) | ✅ clean |
| `cargo clippy --all-targets --all-features --locked -- -D warnings` (pre-push) | ✅ clean |
| `cargo fmt --all -- --check` | ✅ clean |
| `cargo test --release --lib` (cognitive_memory, bootstrap, memory_ipc, memory_consolidation) (pre-push) | ✅ pass |

## Scope discipline

**This PR lands the shared library only.** Simard's three `Command::new("amplihack")` call sites (`simard_self_improve_recipe.rs`, `simard_engineer_loop_recipe.rs`, `copilot_status_probe.rs`) pass structured `-c key=value` recipe context or short flags — *not* user-controlled prompts — so they are correctly left alone.

The amplihack-rs adapters (`crates/amplihack-orchestration/src/claude_process_builder.rs`, `crates/amplihack-launcher/src/{claude_binary_manager,copilot_launcher,codex}.rs`) will adopt this module in a separate PR against `rysweet/amplihack-rs`; the consumer recipe is documented in `docs/prompt-delivery.md`. Splitting prevents tangling with the power-steering extraction work in #1900.

## Files changed

- `src/prompt_delivery/mod.rs` — implementation (+286/-31 in this commit; module total 847 lines incl. tests + docstrings)
- `src/lib.rs` — `pub mod prompt_delivery;` (from prior commit)
- `tests/prompt_delivery.rs` — 23 integration tests (from prior commit)
- `docs/prompt-delivery.md` — full contract documentation (from prior commit)

## Out of scope (follow-ups)

- `amplihack doctor` sub-check reporting active delivery mode per adapter — small, will file a separate issue once the amplihack-rs side adopts this module.
- Wiring into `crates/amplihack-orchestration` and `crates/amplihack-launcher` — separate PR in `rysweet/amplihack-rs`.



## Step 13: Local Testing Results

Outside-in consumer-level testing executed against this PR branch
(`feat/issue-1897-drive-issue-1897-amplihack-rs-parity-subprocess-pr`,
HEAD `fc374afe`). Because this PR ships a Rust library crate (not a
Python `amplihack` CLI), the `uvx --from git+...` invocation pattern
does not apply; the equivalent outside-in test is an **external
downstream consumer crate** that imports `simard::prompt_delivery`
via a `path = ".../Simard"` dependency and drives the public API
end-to-end against a real `/bin/cat` subprocess.

Consumer crate `prompt-delivery-e2e-demo` was built at
`/tmp/prompt-delivery-e2e-demo` with `Cargo.toml`:
```toml
[dependencies]
simard = { path = "/.../Simard" }
```
The demo imports the entire public surface
(`PromptDelivery`, `apply_std`, `select_mode`) and uses the recommended
pattern (background reader thread to drain child stdout while `feed()`
writes to stdin, which is required for any payload larger than the
~64 KiB Linux pipe buffer when the child also produces output — this is
the same pattern the future amplihack-rs adapters will need).

### Scenario 1 (simple) — apostrophes + mixed quoting via `Stdin` mode

Reproduces the #1871 regression: a 60-byte prompt containing single
quotes, double quotes, backticks, `$VAR`, `${VAR}`, and a `--flag=val`
arg-shaped substring is delivered via stdin and round-tripped through
`/bin/cat`.

Command:
```bash
cd /tmp/prompt-delivery-e2e-demo && \
  cargo build --release && \
  ./target/release/prompt-delivery-e2e-demo
```

Result: **PASS**

Output (key lines):
```
== Scenario 1: apostrophes + mixed quoting (force Stdin) ==
[S1-Stdin] requested=Stdin chosen=Stdin len=60
[S1-Stdin] applied_mode=Stdin
[S1-Stdin] PASS — 60 bytes round-tripped via Stdin
```

### Scenario 2 (complex) — 200 KiB payload, Auto → `TempFile`

Exceeds the 100 KiB `STDIN_PREFERRED_MAX_BYTES` boundary so `Auto` mode
must select `TempFile`. Payload is built from a repeating chunk
containing apostrophes, double quotes, and `$vars` — all of the
shell-fragility characters in one prompt, at 200 × the size that broke
the original argv path. Byte-for-byte round-trip is asserted.

Command:
```bash
./target/release/prompt-delivery-e2e-demo
```

Result: **PASS**

Output (key lines):
```
== Scenario 2: 200 KiB payload with embedded apostrophes (Auto -> TempFile) ==
[S2-Auto] requested=Auto chosen=TempFile len=204826
[S2-Auto] applied_mode=TempFile
[S2-Auto] PASS — 204826 bytes round-tripped via TempFile
```

### Bonus Scenario 3 — short prompt, explicit `TempFile` override

Confirms caller override wins over auto-selection (a 60-byte prompt is
forced through `TempFile` mode and round-trips correctly).

Result: **PASS**

```
== Scenario 3: explicit TempFile override on short prompt ==
[S3-TempFile] requested=TempFile chosen=TempFile len=60
[S3-TempFile] applied_mode=TempFile
[S3-TempFile] PASS — 60 bytes round-tripped via TempFile

ALL SCENARIOS PASSED
```

### Regression sanity — full crate tests still green

```
$ cargo test -p simard --lib prompt_delivery
test result: ok. 19 passed; 0 failed
$ cargo test -p simard --test prompt_delivery
test result: ok. 23 passed; 0 failed
$ cargo clippy --lib --tests --bins -- -D warnings
(clean, no warnings)
```

CI status at time of testing: **all 8 checks green** (build, pre-commit
×2, install-real ×2, e2e-dashboard ×2, GitGuardian).
