### PR TITLE
fix(#1909): hard-fail meeting/improvement-curation/review read when state-root absent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,16 @@ __pycache__/
 logs/
 .amplihack/
 worktrees/
+worktrees
 node_modules/
 test-results/
 gym-wave*-tmp/
+
 # Rust coverage artifacts (llvm-cov / cargo-llvm-cov)
+# Emitted into CWD when tests run without `LLVM_PROFILE_FILE` redirection.
 *.profraw
 *.profdata
+
+# Per-process engineer claim files written by the multi-worktree orchestrator;
+# never useful in version control.
+.simard-engineer-claim

--- a/docs/concepts/improvement-context-execution-evidence-gap.md
+++ b/docs/concepts/improvement-context-execution-evidence-gap.md
@@ -1,0 +1,169 @@
+---
+title: "Improvement context: denser execution evidence for the engineer loop"
+description: Captured improvement-curation context — preserves the active "Capture denser execution evidence" goal and the architecture observation that the legacy `simard_operator_probe` surface does not yet expose a terminal engineer loop, so a future improvement-curation cycle can act on it without re-deriving the framing.
+last_updated: 2026-05-19
+review_schedule: as-needed
+owner: simard
+doc_type: concept
+related:
+  - ../index.md
+  - ../reference/runtime-contracts.md
+  - ../reference/operator-read-state-root-contract.md
+  - ../howto/inspect-improvement-curation-state.md
+  - ../tutorials/run-your-first-local-session.md
+---
+
+# Improvement context: denser execution evidence for the engineer loop
+
+This page is an **explicit improvement-context capture**. It is not a shipped
+feature, not a contract, and not a runtime surface. It exists so an active
+improvement priority and its architectural framing live as a versioned,
+inspectable doc in the repo — the same operator-visible discipline the rest
+of Simard already applies to state, prompts, and runtime contracts.
+
+> **Status:** captured improvement context only.
+> No code under `src/` or `tests/` changes because of this page.
+> The next `improvement-curation run` / `improvement-curation read` cycle
+> (see [How to inspect improvement-curation state](../howto/inspect-improvement-curation-state.md))
+> is where this priority is meant to be promoted to a tracked active goal
+> with full denser execution evidence.
+
+## Why this is preserved as a doc
+
+`Specs/ProductArchitecture.md` is explicit about how improvement context
+should travel between sessions and modes:
+
+- Prompt files and other shaping context should live as explicit assets
+  so they can be inspected, versioned, composed, replaced, and benchmarked
+  independently of runtime logic
+  (`Specs/ProductArchitecture.md`, the prompt-assets discipline section).
+- Persisted state used to bridge bounded terminal sessions into engineer
+  mode must be operator-visible local artifacts under the same explicit
+  `state-root`, with mode-scoped handoff records and readback that shows
+  what was reused
+  (`Specs/ProductArchitecture.md` § *Interactive Terminal-Driven Engineer
+  Behavior* and adjacent paragraphs).
+
+A captured improvement context is shaping context. Storing it only inside
+an operator's local `target/operator-probe-state/...` would mean it lives
+on one machine, in one ad-hoc state root, with no audit trail and no way
+for a future engineer session on a clean checkout to see it. A focused
+docs entry is the explicit, versioned, repo-grounded surface.
+
+## Captured active goal
+
+The active improvement-curation goal captured by this session is:
+
+> **`Capture denser execution evidence`**
+
+This is the same goal text the canonical improvement-curation walkthrough
+uses as its worked example
+(see [How to inspect improvement-curation state](../howto/inspect-improvement-curation-state.md),
+step 3: `approve: Capture denser execution evidence | priority=1 | status=active | …`).
+
+When this priority is promoted into the runtime improvement-curation
+pipeline, the canonical invocation is:
+
+```bash
+cargo run --quiet -- \
+  improvement-curation run local-harness single-process \
+  "approve: Capture denser execution evidence | priority=1 | status=active | rationale=operators need denser execution evidence now" \
+  "$STATE_ROOT"
+```
+
+The expected operator-visible confirmation lines from
+`improvement-curation read` are documented at the top of the
+[improvement-curation read walkthrough](../howto/inspect-improvement-curation-state.md#4-read-the-durable-improvement-curation-state).
+
+## Captured architecture observation
+
+The shaping observation that motivates this priority — preserved verbatim
+so a later improvement-curation pass does not have to re-derive it — is:
+
+1. **Engineer mode requires `inspect → act → verify → persist`.**
+   `Specs/ProductArchitecture.md` § *Modes* says engineer mode
+   "accepts a concrete task, inspects the local repo, forms a bounded plan
+   with explicit verification steps, executes through terminal actions, and
+   reports outcomes with evidence." § *Interactive Terminal-Driven Engineer
+   Behavior* further requires the engineer to "Inspect before editing",
+   "Verify results with commands or artifact inspection when verification
+   is possible", and to leave behind durable session records so a future
+   developer can explain why Simard took an action by inspecting them.
+   The compressed phrasing for that contract is
+   **inspect → act → verify → persist**.
+
+2. **Operator probe exists but does not yet expose a terminal engineer
+   loop.** The legacy `simard_operator_probe` compatibility binary, and
+   the corresponding probe-mode subcommands (`simard meeting`,
+   `simard improvement-curation`, `simard review`, `simard goal-curation`,
+   `simard bootstrap`), all expose read/run audit surfaces under
+   `target/operator-probe-state/<probe>/...`. None of them currently
+   surface a probe-shaped readback of an end-to-end terminal engineer
+   loop — i.e., the same `inspect → act → verify → persist` cycle, with
+   denser execution evidence and an explicit-or-fail read companion,
+   rendered through the same operator-probe vocabulary. The terminal
+   engineer surfaces (`simard engineer terminal`, `engineer terminal-read`,
+   `engineer run`, `engineer read`) exist as first-class commands but are
+   not represented as a probe.
+
+3. **Runtime contracts already document the operator/runtime public
+   surfaces and prior spec reconciliation.** See:
+   - [Runtime contracts reference](../reference/runtime-contracts.md) — the
+     executable contracts and state-root guarantees for the shipped run
+     and read paths.
+   - [Operator read-subcommand state-root contract](../reference/operator-read-state-root-contract.md)
+     — the explicit-or-fail `<state-root>` reconciliation for
+     `meeting read`, `improvement-curation read`, and `review read`
+     under audit issue #1910 / fix issue #1909.
+
+   A future "denser execution evidence" improvement is expected to extend
+   these contracts rather than invent a parallel surface.
+
+## Intentional non-goals
+
+This page deliberately does **not**:
+
+- claim that a terminal-engineer-loop probe has been designed, scheduled,
+  or shipped;
+- propose any new CLI subcommand, struct, trait, or persisted file format;
+- modify any existing operator contract, runtime contract, or test;
+- treat the captured goal as approved — promotion is the explicit job of
+  `improvement-curation run` against a durable `state-root`.
+
+It only preserves the goal text and the framing, so the next
+improvement-curation cycle does not have to re-derive them from scratch.
+
+## How a future cycle is expected to act on this
+
+A later session that picks this up is expected to:
+
+1. Read this page to recover the goal text and the framing.
+2. Run `improvement-curation run` with the canonical approval string
+   shown above against an explicit `state-root`, then verify with
+   `improvement-curation read` per
+   [How to inspect improvement-curation state](../howto/inspect-improvement-curation-state.md).
+3. If, and only if, that cycle also produces a concrete spec for denser
+   execution evidence — for example, a probe-shaped readback of a
+   terminal engineer loop — extend
+   `Specs/ProductArchitecture.md` and
+   [Runtime contracts reference](../reference/runtime-contracts.md) in
+   the same change, and remove or rewrite this captured-context page so
+   it no longer claims to be the source of truth.
+
+Until then, this page is the durable handoff for that improvement
+context.
+
+## Related reading
+
+- [How to inspect improvement-curation state](../howto/inspect-improvement-curation-state.md)
+  — the canonical runtime path for promoting this captured goal into
+  active improvement-curation state.
+- [Operator read-subcommand state-root contract](../reference/operator-read-state-root-contract.md)
+  — the prior spec reconciliation under issue #1909 / audit #1910 that
+  this captured context is adjacent to.
+- [Runtime contracts reference](../reference/runtime-contracts.md) —
+  the executable contracts for the existing operator/runtime public
+  surfaces.
+- [Tutorial: Run your first local session](../tutorials/run-your-first-local-session.md)
+  — the broader operator walkthrough that exercises engineer, meeting,
+  goal-curation, improvement-curation, and bootstrap modes.

--- a/docs/howto/inspect-improvement-curation-state.md
+++ b/docs/howto/inspect-improvement-curation-state.md
@@ -15,7 +15,9 @@ related:
 
 # How to inspect improvement-curation state
 
-This guide shows how to use `simard improvement-curation read <base-type> <topology> [state-root]` as the read-only audit companion to `improvement-curation run`.
+This guide shows how to use `simard improvement-curation read <base-type> <topology> <state-root>` as the read-only audit companion to `improvement-curation run`.
+
+The positional `<state-root>` is **required**: `improvement-curation read` does not synthesize a default path and does not honor `SIMARD_STATE_ROOT`. The same explicit-or-fail contract also applies to `review read`; see [Operator read-subcommand state-root contract](../reference/operator-read-state-root-contract.md).
 
 ## Prerequisites
 
@@ -110,20 +112,20 @@ Latest improvement record: review=review-... target=operator-review approvals=[p
 The important contract is structural:
 
 - the command is read-only
-- it reads the latest persisted review artifact from the same validated `state-root`, where "latest" means the artifact with the highest `reviewed_at_unix_ms`
+- it reads the latest persisted review artifact from the explicit validated `<state-root>`, where "latest" means the artifact with the highest `reviewed_at_unix_ms`
 - it reads the latest persisted improvement decision record from that same root, where "latest" means the last decision memory record whose key ends with `improvement-curation-record`
 - sections always appear in this order: latest review metadata, approved proposals, deferred proposals, active goals, proposed goals, latest improvement record
 - empty approved, deferred, active-goal, or proposed-goal sections render explicit `0` and `<none>` lines instead of disappearing
 - persisted proposal titles, rationales, goal text, and decision records are sanitized before printing so stored terminal control sequences are not replayed
-- when `[state-root]` is omitted, the command reuses the same canonical durable root that `review run` and `improvement-curation run` use for the validated runtime pairing
+- the `<state-root>` positional is required; omitting it (or relying on `SIMARD_STATE_ROOT`) hard-fails with a stable, actionable error at state-root resolution time, before any storage I/O for the durable record
 
 ## 5. Configuration rules that matter
 
 For predictable future improvement-state inspection, keep these rules in mind:
 
-- pass the exact same explicit `state-root` you used for earlier `review run` and `improvement-curation run` activity when you want to inspect that stored decision state
-- if you omit `[state-root]`, keep the same shipped `base-type` and `topology` pairing you used for `review run` or `improvement-curation run` so Simard resolves the same canonical durable root
-- the canonical default root for the shared review/improvement state is `target/operator-probe-state/review-run/simard-engineer/<base-type>/<topology>`
+- always pass the exact same explicit `<state-root>` you used for earlier `review run` and `improvement-curation run` activity; the positional is required for `improvement-curation read` and `review read`, and omitting it hard-fails
+- `SIMARD_STATE_ROOT` is intentionally not honored for `improvement-curation read` or `review read` — set the path on the command line instead
+- the canonical default root used by `review run` and `improvement-curation run` is still `target/operator-probe-state/review-run/simard-engineer/<base-type>/<topology>`; pass that path verbatim to the read commands if you relied on it before
 - use `improvement-curation run` when you want to approve or defer proposals
 - use `improvement-curation read` when you want a read-only operator summary of the latest decisions and promoted goals
 - expect invalid `state-root` values, missing review artifacts, missing improvement records, unreadable storage, and malformed decision data to fail explicitly rather than silently rendering a partial report
@@ -145,6 +147,22 @@ Fix the durable state first by running `review run` against the same root.
 That means no improvement-curation decision has been written under the selected root yet, or you are looking at the wrong durable state.
 
 Run `improvement-curation run` first, then use the read command against the same root.
+
+### The command fails because `<state-root>` was omitted
+
+`improvement-curation read` (and `review read`) require the positional `<state-root>` and will exit non-zero. The error has the template form:
+
+```text
+error: missing required config 'state-root': state-root is required for `simard improvement-curation read <base-type>`: pass the positional <state-root> argument explicitly. The SIMARD_STATE_ROOT environment variable is not honored for this command.
+```
+
+`<base-type>` is the literal value the runtime substitutes from the operator-supplied argument. For example, calling `simard improvement-curation read local-harness single-process` (with no `<state-root>`) prints:
+
+```text
+error: missing required config 'state-root': state-root is required for `simard improvement-curation read local-harness`: pass the positional <state-root> argument explicitly. The SIMARD_STATE_ROOT environment variable is not honored for this command.
+```
+
+Re-run with the same explicit `STATE_ROOT` you used for `review run` and `improvement-curation run`. Setting `SIMARD_STATE_ROOT` will not help — the variable is intentionally ignored for these commands. See [Operator read-subcommand state-root contract](../reference/operator-read-state-root-contract.md).
 
 ### The command prints no proposed goals
 

--- a/docs/howto/inspect-improvement-curation-state.md
+++ b/docs/howto/inspect-improvement-curation-state.md
@@ -180,3 +180,4 @@ That is the intended contract for invalid or unreadable operator state. Fix the 
 - For the exact command tree and example syntax, see [Simard CLI reference](../reference/simard-cli.md).
 - For the executable contract behind the read and run paths, see [Runtime contracts reference](../reference/runtime-contracts.md).
 - For the wider tutorial flow that also exercises engineer, meeting, goal-curation, and bootstrap modes, see [Tutorial: Run your first local session](../tutorials/run-your-first-local-session.md).
+- For the durable captured-context entry behind the "Capture denser execution evidence" example goal used in step 3, see [Improvement context: denser execution evidence for the engineer loop](../concepts/improvement-context-execution-evidence-gap.md).

--- a/docs/howto/inspect-meeting-records.md
+++ b/docs/howto/inspect-meeting-records.md
@@ -15,7 +15,9 @@ related:
 
 # How to inspect meeting records
 
-This guide shows how to use `simard meeting read <base-type> <topology> [state-root]` as the read-only audit companion to `meeting run`.
+This guide shows how to use `simard meeting read <base-type> <topology> <state-root>` as the read-only audit companion to `meeting run`.
+
+The positional `<state-root>` is **required**: `meeting read` does not synthesize a default path and does not honor `SIMARD_STATE_ROOT`. See [Operator read-subcommand state-root contract](../reference/operator-read-state-root-contract.md) for the full contract.
 
 ## Prerequisites
 
@@ -95,16 +97,16 @@ Latest meeting record: agenda=align the next Simard workstream; ...
 The important contract is structural:
 
 - the command is read-only
-- it reads the latest persisted meeting decision record from the selected validated `state-root`
+- it reads the latest persisted meeting decision record from the explicit validated `<state-root>`
 - sections always appear in this order: agenda, updates, decisions, risks, next steps, open questions, goal updates, latest raw meeting record
 - empty sections render explicit `0` and `<none>` lines instead of disappearing
 - persisted meeting text is sanitized before printing so stored terminal control sequences are not replayed
-- when `[state-root]` is omitted, the command reuses the same canonical durable root that `meeting run` writes for the validated runtime pairing
+- the `<state-root>` positional is required; omitting it (or relying on `SIMARD_STATE_ROOT`) hard-fails with a stable, actionable error at state-root resolution time, before any storage I/O for the durable record
 
 ## 4. Configuration rules that matter
 
-- pass the exact same explicit `state-root` you used for `meeting run` when you want to inspect that stored planning record later
-- if you omit `[state-root]`, keep the same shipped `base-type` and `topology` pairing you used for `meeting run` so Simard resolves the same canonical durable root
+- always pass the exact same explicit `<state-root>` you used for `meeting run`; the positional is required and omitting it hard-fails
+- `SIMARD_STATE_ROOT` is intentionally not honored for `meeting read` — set the path on the command line instead
 - use `meeting run` when you want to capture new durable planning state
 - use `meeting read` when you want to inspect the latest durable meeting state without mutating it
 - expect invalid `state-root` values, missing memory state, and malformed persisted meeting records to fail explicitly rather than silently rendering a synthetic summary
@@ -120,6 +122,22 @@ That usually means one of these is true:
 - you expected Simard to synthesize meeting state from current goals alone
 
 Run `meeting run` first against the same root, then use `meeting read`.
+
+### The command fails because `<state-root>` was omitted
+
+`meeting read` requires the positional `<state-root>` and will exit non-zero. The error has the template form:
+
+```text
+error: missing required config 'state-root': state-root is required for `simard meeting read <base-type>`: pass the positional <state-root> argument explicitly. The SIMARD_STATE_ROOT environment variable is not honored for this command.
+```
+
+`<base-type>` is the literal value the runtime substitutes from the operator-supplied argument. For example, calling `simard meeting read local-harness single-process` (with no `<state-root>`) prints:
+
+```text
+error: missing required config 'state-root': state-root is required for `simard meeting read local-harness`: pass the positional <state-root> argument explicitly. The SIMARD_STATE_ROOT environment variable is not honored for this command.
+```
+
+Re-run with the same explicit `STATE_ROOT` you used for `meeting run`. Setting `SIMARD_STATE_ROOT` will not help — the variable is intentionally ignored for this command. See [Operator read-subcommand state-root contract](../reference/operator-read-state-root-contract.md).
 
 ### The command fails before any record is printed
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,6 +46,7 @@ Terminal sessions and repo-grounded engineer runs now bridge through one explici
 - [Cognitive-memory goal store adapter](./reference/cognitive-memory-goal-store.md) - Design for the planned `GoalStore` implementation that will back `RuntimePorts.goal_store` with cognitive memory (issue #1590 follow-up).
 - [String truncation helpers](./reference/string-truncation-helpers.md) - Design for the planned `truncate_to_char_boundary` UTF-8-safe byte-budget helper (issue #1590 follow-up).
 - [Concept: truthful runtime metadata](./concepts/truthful-runtime-metadata.md) - Read the design rationale behind the stricter runtime contract.
+- [Concept: improvement context — denser execution evidence for the engineer loop](./concepts/improvement-context-execution-evidence-gap.md) - Captured improvement-curation context preserving the active "Capture denser execution evidence" goal and the observation that the legacy `simard_operator_probe` surface does not yet expose a terminal engineer-loop probe.
 
 ## Canonical executable surface
 

--- a/docs/reference/operator-read-state-root-contract.md
+++ b/docs/reference/operator-read-state-root-contract.md
@@ -270,3 +270,8 @@ silent regression.
   — walkthrough that uses the required `<state-root>` argument
   explicitly across `review run`, `improvement-curation run`, and the
   read companion.
+- [Improvement context: denser execution evidence for the engineer loop](../concepts/improvement-context-execution-evidence-gap.md)
+  — captured improvement-curation context adjacent to this contract;
+  preserves the active "Capture denser execution evidence" goal and the
+  observation that the legacy `simard_operator_probe` surface does not
+  yet expose a terminal engineer-loop probe.

--- a/docs/reference/operator-read-state-root-contract.md
+++ b/docs/reference/operator-read-state-root-contract.md
@@ -222,16 +222,18 @@ gets the same guarantee:
 
 The three resolver entrypoints downstream are:
 
-- `state_root::resolved_meeting_read_state_root(explicit, base, topology) -> Result<PathBuf, SimardError>`
-- `state_root::resolved_improvement_curation_read_state_root(explicit, base, topology) -> Result<PathBuf, SimardError>`
-- `state_root::resolved_review_read_state_root(explicit, base, topology) -> Result<PathBuf, SimardError>`
+- `state_root::resolved_meeting_read_state_root(explicit, base) -> Result<PathBuf, SimardError>`
+- `state_root::resolved_improvement_curation_read_state_root(explicit, base) -> Result<PathBuf, SimardError>`
+- `state_root::resolved_review_read_state_root(explicit, base) -> Result<PathBuf, SimardError>`
 
 Each forwards `(explicit, "<subcommand>", base)` to the shared guard and
 then runs the post-guard validators (`validate_meeting_read_state_root`,
 `validate_improvement_curation_read_state_root`) where applicable. The
-`base` and `topology` arguments are accepted so each helper can build
-fully-qualified diagnostics if a post-guard validator fails on the
-caller-supplied path.
+`base` argument is preserved so each helper can build fully-qualified
+diagnostics if a post-guard validator fails on the caller-supplied path.
+Topology is not consumed: explicit-only inputs never need to synthesize
+a probe-relative default path, so the resolvers do not need to know
+which runtime topology the read targets.
 
 ## Test coverage
 

--- a/docs/reference/operator-read-state-root-contract.md
+++ b/docs/reference/operator-read-state-root-contract.md
@@ -1,0 +1,270 @@
+---
+title: Operator read-subcommand state-root contract
+description: Reference for the explicit-or-fail `<state-root>` contract on `simard meeting read`, `simard improvement-curation read`, and `simard review read` — including the unified error wording, the SIMARD_STATE_ROOT disclaimer, and the audit rationale tracked under issue #1909 / audit #1910.
+last_updated: 2026-05-19
+review_schedule: as-needed
+owner: simard
+doc_type: reference
+related:
+  - ./simard-cli.md
+  - ./runtime-contracts.md
+  - ./state-root-resolution.md
+  - ../howto/inspect-meeting-records.md
+  - ../howto/inspect-improvement-curation-state.md
+---
+
+# Operator read-subcommand state-root contract
+
+This page documents the shipped, explicit-or-fail `<state-root>` contract for
+three operator-probe read subcommands:
+
+- `simard meeting read <base-type> <topology> <state-root>`
+- `simard improvement-curation read <base-type> <topology> <state-root>`
+- `simard review read <base-type> <topology> <state-root>`
+
+These three reads **require** an explicit `<state-root>` positional argument.
+There is no implicit fallback. The `SIMARD_STATE_ROOT` environment variable is
+intentionally not honored for these reads.
+
+> Tracked under audit issue
+> [rysweet/Simard#1910](https://github.com/rysweet/Simard/issues/1910) and
+> the targeted fix issue
+> [rysweet/Simard#1909](https://github.com/rysweet/Simard/issues/1909).
+
+## Why these reads are explicit-only
+
+Operator-probe read paths are an audit surface. Their value is that the
+operator sees the exact durable state that lives under the path they typed.
+Two prior fallback shapes silently broke that guarantee:
+
+1. **Synthesized default path.** Earlier builds would, on missing
+   `<state-root>`, derive
+   `target/operator-probe-state/<probe>/<identity>/<base>/<topology>` and
+   read whatever happened to be there. That path can hold leftover state
+   from an unrelated run, leftover state from a different working
+   directory, or no state at all.
+2. **`SIMARD_STATE_ROOT` environment fallback.** `goal-curation read`
+   honors `SIMARD_STATE_ROOT` as a convenience for the same operator who
+   set it for a daemon. Reusing that convenience for `meeting`,
+   `improvement-curation`, and `review` reads meant an operator running
+   `simard meeting read local-harness single-process` could be silently
+   redirected to a goal-curation state root that contained no meeting
+   records, producing either a misleading "empty" report or a confusing
+   error far from its real cause.
+
+Both shapes are now blocked at the same resolver layer. The three reads
+hard-fail at state-root resolution time, before any storage I/O for the
+durable record is attempted.
+
+## Command surface
+
+The synopsis line in `simard --help` and in the operator-facing reference
+shows a required positional:
+
+```text
+simard meeting read <base-type> <topology> <state-root>
+simard improvement-curation read <base-type> <topology> <state-root>
+simard review read <base-type> <topology> <state-root>
+```
+
+The angle brackets matter. The single-line note below each synopsis in the
+help text reads:
+
+> `<state-root>` is required. `SIMARD_STATE_ROOT` is not honored for this
+> command.
+
+Clap still parses the positional as optional so that the resolver layer can
+produce a richer error than clap would. Operator-visible behavior matches the
+"required positional" framing.
+
+## Exit code and error wording
+
+When `<state-root>` is omitted, the command exits with a non-zero status and
+prints exactly one structured error line to stderr, using the
+`SimardError::MissingRequiredConfig` variant:
+
+```text
+error: missing required config 'state-root': state-root is required for `simard <subcommand> read <base-type>`: pass the positional <state-root> argument explicitly. The SIMARD_STATE_ROOT environment variable is not honored for this command.
+```
+
+Where:
+
+- `<subcommand>` is one of `meeting`, `improvement-curation`, `review`.
+- `<base-type>` is the literal base-type value the operator supplied
+  (for example `local-harness`).
+
+The message is stable. Tests under
+`tests/issue_1909_state_root_required.rs` assert the substring
+`SIMARD_STATE_ROOT environment variable is not honored` to keep the
+disclaimer load-bearing.
+
+### Worked failure example
+
+```bash
+$ simard meeting read local-harness single-process
+error: missing required config 'state-root': state-root is required for `simard meeting read local-harness`: pass the positional <state-root> argument explicitly. The SIMARD_STATE_ROOT environment variable is not honored for this command.
+```
+
+The command exits non-zero. The same shape applies for
+`improvement-curation read` and `review read`; only the `<subcommand>` token
+changes.
+
+### Worked success example
+
+```bash
+$ STATE_ROOT="$(mktemp -d /tmp/simard-meeting.XXXXXX)"
+$ simard meeting run local-harness single-process \
+    "agenda: align next workstream
+decision: preserve meeting-to-engineer continuity" \
+    "$STATE_ROOT"
+…
+$ simard meeting read local-harness single-process "$STATE_ROOT"
+Probe mode: meeting-read
+Identity: simard-meeting
+…
+```
+
+## Environment-variable disclaimer
+
+Setting `SIMARD_STATE_ROOT` has **no effect** on these three reads:
+
+```bash
+$ SIMARD_STATE_ROOT=/tmp/some-other-dir \
+  simard improvement-curation read local-harness single-process
+error: missing required config 'state-root': state-root is required for `simard improvement-curation read local-harness`: pass the positional <state-root> argument explicitly. The SIMARD_STATE_ROOT environment variable is not honored for this command.
+```
+
+This is asserted by
+`tests/issue_1909_state_root_required.rs::read_subcommands_ignore_simard_state_root_env_var`.
+
+The environment variable still affects:
+
+- `goal-curation read` (kept for parity with goal-curation operator habits)
+- `simard meeting run`, `simard improvement-curation run`,
+  `simard review run`, `simard goal-curation run` (the run paths)
+- General library callers that resolve state root through
+  `state_root::simard_state_root()` (see
+  [State-root resolution](./state-root-resolution.md))
+
+Only the **three read paths** listed at the top of this page disable env
+fallback.
+
+## What is preserved
+
+The change is surgically scoped. These behaviors are unchanged:
+
+- `simard meeting run <base-type> <topology> <objective> [state-root]` —
+  positional state-root remains optional; synthesized default path still
+  resolves under `target/operator-probe-state/...` when omitted.
+- `simard improvement-curation run <base-type> <topology> <objective> [state-root]`
+  — same.
+- `simard review run <base-type> <topology> <objective> [state-root]` —
+  same.
+- `simard goal-curation read <base-type> <topology> [state-root]` —
+  positional state-root remains optional and `SIMARD_STATE_ROOT` is still
+  honored (audit #1910 explicitly excludes this command from the change).
+- `simard engineer run / read / terminal / terminal-read / copilot-submit`
+  — unchanged. These read paths use `engineer run`'s canonical default
+  and have their own contract documented in
+  [Runtime contracts reference](./runtime-contracts.md).
+- The `resolved_review_state_root` helper used by `review run` and by the
+  `improvement-curation run` write path is untouched. A new sibling
+  helper, `resolved_review_read_state_root`, owns the explicit-only
+  contract for `review read`.
+
+## Migration guidance
+
+If you have a script that ran:
+
+```bash
+simard meeting read local-harness single-process
+simard improvement-curation read local-harness single-process
+simard review read local-harness single-process
+```
+
+…and relied on the synthesized default path, change each call to pass the
+exact state root used during the corresponding `run`:
+
+```bash
+STATE_ROOT="/path/you/passed/to/run"
+simard meeting read local-harness single-process "$STATE_ROOT"
+simard improvement-curation read local-harness single-process "$STATE_ROOT"
+simard review read local-harness single-process "$STATE_ROOT"
+```
+
+If you previously relied on `SIMARD_STATE_ROOT` to direct these three reads,
+move the path onto the positional argument:
+
+```bash
+# Before
+SIMARD_STATE_ROOT=/srv/simard-state simard meeting read local-harness single-process
+
+# After
+simard meeting read local-harness single-process /srv/simard-state
+```
+
+The diagnostic error from the new contract is intentionally explicit so the
+needed fix is obvious from the failure.
+
+## Library-callers
+
+The guard lives at the resolver layer, not at the CLI parser. Any library
+caller that invokes a read state-root through the public resolver surface
+gets the same guarantee:
+
+- `state_root::require_explicit_state_root_for_read(explicit, subcommand, base)`
+  is the single source of truth.
+- Calling it with `explicit = None` returns
+  `Err(SimardError::MissingRequiredConfig { … })`.
+- Calling it with `explicit = Some(path)` delegates to
+  `bootstrap::validate_state_root(path)` and returns the canonicalized
+  `PathBuf` on success.
+
+The three resolver entrypoints downstream are:
+
+- `state_root::resolved_meeting_read_state_root(explicit, base, topology) -> Result<PathBuf, SimardError>`
+- `state_root::resolved_improvement_curation_read_state_root(explicit, base, topology) -> Result<PathBuf, SimardError>`
+- `state_root::resolved_review_read_state_root(explicit, base, topology) -> Result<PathBuf, SimardError>`
+
+Each forwards `(explicit, "<subcommand>", base)` to the shared guard and
+then runs the post-guard validators (`validate_meeting_read_state_root`,
+`validate_improvement_curation_read_state_root`) where applicable. The
+`base` and `topology` arguments are accepted so each helper can build
+fully-qualified diagnostics if a post-guard validator fails on the
+caller-supplied path.
+
+## Test coverage
+
+The contract is asserted by integration tests in
+`tests/issue_1909_state_root_required.rs`:
+
+| Test name                                                       | Asserts                                                                  |
+| --------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `meeting_read_hard_fails_without_state_root`                    | Non-zero exit and unified error wording for `meeting read`               |
+| `meeting_read_succeeds_with_explicit_state_root`                | Read succeeds when a valid `<state-root>` is supplied                    |
+| `improvement_curation_read_hard_fails_without_state_root`       | Non-zero exit and unified error wording for `improvement-curation read`  |
+| `improvement_curation_read_succeeds_with_explicit_state_root`   | Read succeeds when a valid `<state-root>` is supplied                    |
+| `review_read_hard_fails_without_state_root`                     | Non-zero exit and unified error wording for `review read`                |
+| `review_read_succeeds_with_explicit_state_root`                 | Read succeeds when a valid `<state-root>` is supplied                    |
+| `read_subcommands_ignore_simard_state_root_env_var`             | All three reads still hard-fail when `SIMARD_STATE_ROOT` is set          |
+
+Two pre-existing `#[ignore]`d tests in `tests/simard_cli.rs` that encoded
+the opposite (fallback-honored) contract for `meeting read` and
+`improvement-curation read` have been replaced with hard-fail assertions
+and un-ignored. They now run on every `cargo test` invocation to prevent
+silent regression.
+
+## Related reading
+
+- [Simard CLI reference](./simard-cli.md) — full command tree, including
+  the three reads with their required `<state-root>` positional.
+- [Runtime contracts reference](./runtime-contracts.md) — executable
+  contracts for the run and read paths the three read commands depend on.
+- [State-root resolution](./state-root-resolution.md) — general resolver
+  rules, including the resolver layer where this contract is enforced.
+- [How to inspect meeting records](../howto/inspect-meeting-records.md) —
+  walkthrough that uses the required `<state-root>` argument explicitly.
+- [How to inspect improvement-curation state](../howto/inspect-improvement-curation-state.md)
+  — walkthrough that uses the required `<state-root>` argument
+  explicitly across `review run`, `improvement-curation run`, and the
+  read companion.

--- a/docs/reference/runtime-contracts.md
+++ b/docs/reference/runtime-contracts.md
@@ -65,17 +65,17 @@ The shipped operator-facing command tree is:
 - `simard engineer copilot-submit <topology> [state-root] [--json]`
 - `simard engineer terminal-read <topology> [state-root]`
 - `simard meeting run <base-type> <topology> <structured-objective> [state-root]`
-- `simard meeting read <base-type> <topology> [state-root]`
+- `simard meeting read <base-type> <topology> <state-root>`
 - `simard goal-curation run <base-type> <topology> <structured-objective> [state-root]`
 - `simard goal-curation read <base-type> <topology> [state-root]`
 - `simard improvement-curation run <base-type> <topology> <structured-objective> [state-root]`
-- `simard improvement-curation read <base-type> <topology> [state-root]`
+- `simard improvement-curation read <base-type> <topology> <state-root>`
 - `simard gym list`
 - `simard gym run <scenario-id>`
 - `simard gym compare <scenario-id>`
 - `simard gym run-suite <suite-id>`
 - `simard review run <base-type> <topology> <objective> [state-root]`
-- `simard review read <base-type> <topology> [state-root]`
+- `simard review read <base-type> <topology> <state-root>`
 - `simard bootstrap run <identity> <base-type> <topology> <objective> [state-root]`
 
 Shipped terminal contract: `simard engineer copilot-submit <topology> [state-root] [--json]`. It is documented below as the bounded one-shot local Copilot submission surface.
@@ -93,6 +93,24 @@ Rejected inputs include:
 - a symlink root
 
 Safe roots are canonicalized once and then reused throughout the command.
+
+### Required state-root on operator-probe read subcommands
+
+The three operator-probe read subcommands publish the positional argument
+as `<state-root>` (required) rather than `[state-root]` (optional):
+
+- `simard meeting read <base-type> <topology> <state-root>`
+- `simard improvement-curation read <base-type> <topology> <state-root>`
+- `simard review read <base-type> <topology> <state-root>`
+
+When `<state-root>` is omitted these commands hard-fail with the
+`SimardError::MissingRequiredConfig` variant and a stable, actionable
+error that names the missing argument, the subcommand, and the base-type.
+`SIMARD_STATE_ROOT` is intentionally **not** consulted for these three
+reads. `simard goal-curation read` and every `... run` path keep the
+existing optional positional and env-fallback behavior. See
+[Operator read-subcommand state-root contract](./operator-read-state-root-contract.md)
+for the complete contract.
 
 ## Mode-scoped handoff artifacts
 
@@ -295,7 +313,7 @@ This command ships as the next bounded local Copilot slice after `copilot-prompt
 Canonical entrypoints:
 
 - `simard meeting run <base-type> <topology> <structured-objective> [state-root]`
-- `simard meeting read <base-type> <topology> [state-root]`
+- `simard meeting read <base-type> <topology> <state-root>`
 
 Compatibility surface: `simard_operator_probe meeting-run ...` and `simard_operator_probe meeting-read ...`
 
@@ -313,7 +331,8 @@ The shipped contract is intentionally explicit:
 
 - `meeting run` remains the only mutation path for agenda, update, decision, risk, next-step, open-question, and goal-update capture
 - `meeting read` is the read-only audit surface for the latest persisted meeting decision state
-- both commands reuse the same validated state root, and both default to the same canonical durable root for `simard-meeting`
+- `meeting run` accepts an optional `[state-root]` positional and falls back to its canonical durable root when omitted
+- `meeting read` requires an explicit `<state-root>` positional; `SIMARD_STATE_ROOT` is not honored. See [Operator read-subcommand state-root contract](./operator-read-state-root-contract.md)
 - `meeting read` loads the latest persisted meeting decision record, where "latest" means the last decision memory record whose value matches the shipped meeting record shape
 - `meeting read` renders agenda, updates, decisions, risks, next steps, open questions, goal updates, and the latest raw meeting record in a stable operator-visible order
 - operator-visible strings are sanitized before printing so persisted terminal control sequences are not replayed
@@ -335,7 +354,7 @@ Goal-curation mode maintains durable backlog records and the active top five goa
 Canonical entrypoints:
 
 - `simard improvement-curation run <base-type> <topology> <structured-objective> [state-root]`
-- `simard improvement-curation read <base-type> <topology> [state-root]`
+- `simard improvement-curation read <base-type> <topology> <state-root>`
 
 Compatibility surface: `simard_operator_probe improvement-curation-run ...` and `simard_operator_probe improvement-curation-read ...`
 
@@ -345,7 +364,8 @@ The shipped contract is intentionally explicit:
 
 - `improvement-curation run` remains the only mutation path for approving or deferring proposals
 - `improvement-curation read` is the read-only audit surface for the latest review-to-priority promotion state
-- both commands reuse the same validated state root, and both default to the same canonical durable root as `review run`
+- `improvement-curation run` accepts an optional `[state-root]` positional and falls back to the same canonical durable root as `review run` when omitted
+- `improvement-curation read` requires an explicit `<state-root>` positional; `SIMARD_STATE_ROOT` is not honored. See [Operator read-subcommand state-root contract](./operator-read-state-root-contract.md)
 - `improvement-curation read` loads the latest persisted review artifact, where "latest" means the artifact with the highest `reviewed_at_unix_ms`
 - `improvement-curation read` loads the latest persisted improvement decision record, where "latest" means the last decision memory record whose key ends with `improvement-curation-record`
 - `improvement-curation read` renders approved proposals, deferred proposals, active goals, proposed goals, and the latest improvement decision record in a stable operator-visible order
@@ -361,11 +381,17 @@ target/operator-probe-state/review-run/simard-engineer/<base-type>/<topology>
 Canonical entrypoints:
 
 - `simard review run <base-type> <topology> <objective> [state-root]`
-- `simard review read <base-type> <topology> [state-root]`
+- `simard review read <base-type> <topology> <state-root>`
 
 Compatibility surface: `simard_operator_probe review-run ...` and `simard_operator_probe review-read ...`
 
 Review mode persists a structured review artifact and makes the latest artifact readable from the same durable state root.
+
+- `review run` keeps the optional `[state-root]` positional and the
+  `SIMARD_STATE_ROOT` env fallback used by the canonical run helper.
+- `review read` requires the positional `<state-root>` and intentionally
+  does not honor `SIMARD_STATE_ROOT`. Hard-fail wording matches the
+  [operator-read contract](./operator-read-state-root-contract.md).
 
 ### Benchmark gym
 

--- a/docs/reference/simard-cli.md
+++ b/docs/reference/simard-cli.md
@@ -41,13 +41,13 @@ simard
 |  `- terminal-read <topology> [state-root]
 |- meeting
 |  |- run <base-type> <topology> <structured-objective> [state-root]
-|  `- read <base-type> <topology> [state-root]
+|  `- read <base-type> <topology> <state-root>
 |- goal-curation
 |  |- run <base-type> <topology> <structured-objective> [state-root]
 |  `- read <base-type> <topology> [state-root]
 |- improvement-curation
 |  |- run <base-type> <topology> <structured-objective> [state-root]
-|  `- read <base-type> <topology> [state-root]
+|  `- read <base-type> <topology> <state-root>
 |- gym
 |  |- list
 |  |- run <scenario-id>
@@ -55,7 +55,7 @@ simard
 |  `- run-suite <suite-id>
 |- review
 |  |- run <base-type> <topology> <objective> [state-root]
-|  `- read <base-type> <topology> [state-root]
+|  `- read <base-type> <topology> <state-root>
 `- bootstrap
 |  `- run <identity> <base-type> <topology> <objective> [state-root]
 |- ooda
@@ -247,6 +247,45 @@ Rejected inputs include:
 - a symlink root
 
 Safe state roots are canonicalized once and then reused for the rest of the command.
+
+### Required state-root on operator-probe read subcommands
+
+Three operator-probe read subcommands publish the positional argument as
+`<state-root>` (required) rather than `[state-root]` (optional):
+
+- `simard meeting read <base-type> <topology> <state-root>`
+- `simard improvement-curation read <base-type> <topology> <state-root>`
+- `simard review read <base-type> <topology> <state-root>`
+
+When `<state-root>` is omitted, these three commands hard-fail with the
+`SimardError::MissingRequiredConfig` variant and a stable error message of
+the form:
+
+```text
+error: missing required config 'state-root': state-root is required for `simard <subcommand> read <base-type>`: pass the positional <state-root> argument explicitly. The SIMARD_STATE_ROOT environment variable is not honored for this command.
+```
+
+`<subcommand>` is one of `meeting`, `improvement-curation`, `review`.
+`<base-type>` is the literal value the runtime substitutes from the
+operator-supplied argument. For example, calling `simard meeting read
+local-harness single-process` (with no `<state-root>`) prints:
+
+```text
+error: missing required config 'state-root': state-root is required for `simard meeting read local-harness`: pass the positional <state-root> argument explicitly. The SIMARD_STATE_ROOT environment variable is not honored for this command.
+```
+
+The `SIMARD_STATE_ROOT` environment variable is intentionally **not honored**
+for these three reads — setting it does not change behavior, and the
+operator still gets the error above. This audit-focused contract is tracked
+under issue [#1909](https://github.com/rysweet/Simard/issues/1909) /
+audit [#1910](https://github.com/rysweet/Simard/issues/1910) and is
+documented end-to-end in
+[Operator read-subcommand state-root contract](./operator-read-state-root-contract.md).
+
+The `simard goal-curation read` command keeps the optional `[state-root]`
+positional and still honors `SIMARD_STATE_ROOT` for operator parity with
+its run counterpart. All `... run` paths likewise keep the optional
+positional and the env fallback.
 
 ## Shared socket-path contract
 
@@ -633,15 +672,15 @@ EOF2
 simard meeting run local-harness single-process "$MEETING_OBJECTIVE" "$STATE_ROOT"
 ```
 
-### `simard meeting read <base-type> <topology> [state-root]`
+### `simard meeting read <base-type> <topology> <state-root>`
 
 Reads the latest durable meeting record without mutating it.
 
 Key behavior:
 
 - loads the latest persisted meeting decision record from the validated `state-root`
-- reuses the same canonical default durable root as `meeting run` when `[state-root]` is omitted
-- validates `base-type` and `topology` before deriving that default root
+- requires the positional `<state-root>` and hard-fails if it is omitted; `SIMARD_STATE_ROOT` is not honored. See [Operator read-subcommand state-root contract](./operator-read-state-root-contract.md)
+- validates `base-type` and `topology` before further work
 - requires explicit read-layout inputs before probing: the state root itself must already exist as a directory and `memory_records.json` must already be present
 - prints sections in this fixed order: latest agenda, updates, decisions, risks, next steps, open questions, goal updates, latest meeting record
 - includes explicit zero-state lines for empty update, decision, risk, next-step, open-question, and goal-update sections
@@ -760,7 +799,7 @@ When `[state-root]` is omitted, `improvement-curation run` reuses the same canon
 target/operator-probe-state/review-run/simard-engineer/<base-type>/<topology>
 ```
 
-### `simard improvement-curation read <base-type> <topology> [state-root]`
+### `simard improvement-curation read <base-type> <topology> <state-root>`
 
 Reads the latest durable improvement-curation state without mutating it.
 
@@ -768,8 +807,8 @@ Key behavior:
 
 - loads the latest persisted review artifact from the validated `state-root`, where "latest" means the review artifact with the highest `reviewed_at_unix_ms`
 - loads the latest persisted improvement-curation decision record from the same root, where "latest" means the last decision memory record whose key ends with `improvement-curation-record`
-- reuses the same canonical default durable root as `review run` and `improvement-curation run` when `[state-root]` is omitted
-- validates `base-type` and `topology` before deriving that default root
+- requires the positional `<state-root>` and hard-fails if it is omitted; `SIMARD_STATE_ROOT` is not honored. See [Operator read-subcommand state-root contract](./operator-read-state-root-contract.md)
+- validates `base-type` and `topology` before further work
 - requires explicit read-layout inputs before probing: the state root itself must already exist as a directory, `review-artifacts/` must exist, and both `memory_records.json` and `goal_records.json` must already be present
 - prints sections in this fixed order: latest review metadata, approved proposals, deferred proposals, active goals, proposed goals, latest improvement record
 - includes explicit zero-state lines for empty approved, deferred, active-goal, and proposed-goal sections
@@ -936,9 +975,11 @@ The public operator contract is:
 
 Builds and persists the latest review artifact tied to the selected durable state.
 
-### `simard review read <base-type> <topology> [state-root]`
+### `simard review read <base-type> <topology> <state-root>`
 
 Reads back the latest persisted review artifact from the selected durable state.
+
+Requires the positional `<state-root>` and hard-fails if it is omitted; `SIMARD_STATE_ROOT` is not honored. See [Operator read-subcommand state-root contract](./operator-read-state-root-contract.md).
 
 Example:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,7 @@ nav:
   - Concepts:
     - Truthful Runtime Metadata: concepts/truthful-runtime-metadata.md
     - Prompt-driven Brain Iteration: concepts/prompt-driven-brain-iteration.md
+    - Improvement context — denser execution evidence: concepts/improvement-context-execution-evidence-gap.md
   - Tutorials:
     - First Local Session: tutorials/run-your-first-local-session.md
     - First Benchmark Suite: tutorials/run-your-first-benchmark-gym.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,7 @@ nav:
   - Reference:
     - CLI Reference: reference/simard-cli.md
     - Runtime Contracts: reference/runtime-contracts.md
+    - Operator Read State-Root Contract: reference/operator-read-state-root-contract.md
     - Bridge Wire Protocol: reference/bridge-wire-protocol.md
     - Dashboard E2E Tests: reference/dashboard-e2e-tests.md
     # Hidden from nav until issue #1590 implementation lands:

--- a/src/operator_cli/meeting.rs
+++ b/src/operator_cli/meeting.rs
@@ -13,7 +13,7 @@ Usage: simard meeting <command> [args]
 Commands:
   run <base-type> <topology> <objective> [state-root]
                             Run an automated meeting probe and exit.
-  read <base-type> <topology> [state-root]
+  read <base-type> <topology> <state-root>
                             Read the latest meeting transcript and exit.
   repl [topic]              Start an interactive meeting REPL on stdin.
   begin [topic]             Alias for `repl`.
@@ -26,7 +26,7 @@ Examples:
   simard meeting --help
   simard meeting repl \"weekly sync\"
   simard meeting run local-harness single-process \"design review\"
-  simard meeting read local-harness single-process
+  simard meeting read local-harness single-process /path/to/state-root
 ";
 
 pub(super) fn dispatch_meeting_command(

--- a/src/operator_cli/mod.rs
+++ b/src/operator_cli/mod.rs
@@ -41,7 +41,7 @@ Product modes:
   engineer terminal-read <topology> [state-root]
   engineer read <topology> [state-root]
   meeting run <base-type> <topology> <objective> [state-root]
-  meeting read <base-type> <topology> [state-root]
+  meeting read <base-type> <topology> <state-root>
   meeting repl [topic]
   goal list                — print active + backlog snapshot to stdout
   goal unblock <goal-id>   — operator escape hatch: clear any Blocked
@@ -68,7 +68,7 @@ Product modes:
                            meeting greeting banner; pass [state-root] to
                            inspect a probe-isolated sandbox instead
   improvement-curation run <base-type> <topology> <objective> [state-root]
-  improvement-curation read <base-type> <topology> [state-root]
+  improvement-curation read <base-type> <topology> <state-root>
   gym list
   gym run <scenario-id>
   gym compare <scenario-id>
@@ -95,7 +95,7 @@ Product modes:
 
 Operator utilities:
   review run <base-type> <topology> <objective> [state-root]
-  review read <base-type> <topology> [state-root]
+  review read <base-type> <topology> <state-root>
   bootstrap run <identity> <base-type> <topology> <objective> [state-root]
 
 Compatibility binaries remain available: simard_operator_probe, simard-gym

--- a/src/operator_commands/mod.rs
+++ b/src/operator_commands/mod.rs
@@ -52,8 +52,8 @@ pub(crate) use recipes::{
 pub(crate) use state_root::{
     parse_runtime_topology, prompt_root, resolved_engineer_read_state_root,
     resolved_goal_curation_state_root, resolved_improvement_curation_read_state_root,
-    resolved_meeting_read_state_root, resolved_review_state_root, resolved_state_root,
-    resolved_terminal_read_state_root, validated_runtime_segments,
+    resolved_meeting_read_state_root, resolved_review_read_state_root, resolved_review_state_root,
+    resolved_state_root, resolved_terminal_read_state_root, validated_runtime_segments,
 };
 pub(crate) use validation::{validated_engineer_read_artifacts, validated_terminal_read_artifacts};
 

--- a/src/operator_commands/state_root.rs
+++ b/src/operator_commands/state_root.rs
@@ -172,7 +172,6 @@ pub(crate) fn resolved_review_read_state_root(
 pub(crate) fn resolved_improvement_curation_read_state_root(
     explicit: Option<PathBuf>,
     base_type: &str,
-    _topology: &str,
 ) -> crate::SimardResult<PathBuf> {
     let state_root =
         require_explicit_state_root_for_read(explicit, "improvement-curation", base_type)?;
@@ -213,7 +212,6 @@ pub(crate) fn resolved_terminal_read_state_root(
 pub(crate) fn resolved_meeting_read_state_root(
     explicit: Option<PathBuf>,
     base_type: &str,
-    _topology: &str,
 ) -> crate::SimardResult<PathBuf> {
     let state_root = require_explicit_state_root_for_read(explicit, "meeting", base_type)?;
     validate_meeting_read_state_root(&state_root)?;

--- a/src/operator_commands/state_root.rs
+++ b/src/operator_commands/state_root.rs
@@ -132,12 +132,50 @@ pub(crate) fn resolved_review_state_root(
     )
 }
 
+/// Issue rysweet/Simard#1909: enforce explicit `<state-root>` for the
+/// three read subcommands (`meeting read`, `improvement-curation read`,
+/// and `review read`). Returns `SimardError::MissingRequiredConfig`
+/// with the unified wording when `explicit` is `None`; otherwise
+/// delegates to `bootstrap::validate_state_root`.
+///
+/// Contract:
+///   * No implicit fallback to a synthesized probe default path.
+///   * The `SIMARD_STATE_ROOT` environment variable is **not** honored
+///     for these read paths (the error message says so explicitly).
+///
+/// See: docs/reference/operator-read-state-root-contract.md
+pub(crate) fn require_explicit_state_root_for_read(
+    explicit: Option<PathBuf>,
+    subcommand: &str,
+    base_type: &str,
+) -> crate::SimardResult<PathBuf> {
+    match explicit {
+        Some(path) => crate::bootstrap::validate_state_root(path),
+        None => Err(crate::SimardError::MissingRequiredConfig {
+            key: "state-root".to_string(),
+            help: format!(
+                "state-root is required for `simard {subcommand} read {base_type}`: \
+                 pass the positional <state-root> argument explicitly. The \
+                 SIMARD_STATE_ROOT environment variable is not honored for this command."
+            ),
+        }),
+    }
+}
+
+pub(crate) fn resolved_review_read_state_root(
+    explicit: Option<PathBuf>,
+    base_type: &str,
+) -> crate::SimardResult<PathBuf> {
+    require_explicit_state_root_for_read(explicit, "review", base_type)
+}
+
 pub(crate) fn resolved_improvement_curation_read_state_root(
     explicit: Option<PathBuf>,
     base_type: &str,
-    topology: &str,
+    _topology: &str,
 ) -> crate::SimardResult<PathBuf> {
-    let state_root = resolved_review_state_root(explicit, base_type, topology)?;
+    let state_root =
+        require_explicit_state_root_for_read(explicit, "improvement-curation", base_type)?;
     validate_improvement_curation_read_state_root(&state_root)?;
     Ok(state_root)
 }
@@ -175,15 +213,9 @@ pub(crate) fn resolved_terminal_read_state_root(
 pub(crate) fn resolved_meeting_read_state_root(
     explicit: Option<PathBuf>,
     base_type: &str,
-    topology: &str,
+    _topology: &str,
 ) -> crate::SimardResult<PathBuf> {
-    let state_root = resolved_state_root(
-        explicit,
-        "simard-meeting",
-        base_type,
-        topology,
-        "meeting-run",
-    )?;
+    let state_root = require_explicit_state_root_for_read(explicit, "meeting", base_type)?;
     validate_meeting_read_state_root(&state_root)?;
     Ok(state_root)
 }
@@ -308,5 +340,107 @@ mod tests {
     fn parse_runtime_topology_case_sensitive() {
         assert!(parse_runtime_topology("Single-Process").is_err());
         assert!(parse_runtime_topology("DISTRIBUTED").is_err());
+    }
+
+    // ---------------------------------------------------------------
+    // Issue rysweet/Simard#1909 — resolver-layer hard-fail guard.
+    //
+    // These are TDD-failing tests: the function under test
+    // (`require_explicit_state_root_for_read`) does not exist yet on
+    // `main`. They pin the contract that:
+    //   * `None` → `SimardError::MissingRequiredConfig` with the
+    //     unified wording (subcommand + base-type named, env-var
+    //     fallback explicitly disclaimed).
+    //   * `Some(path)` → delegates to `bootstrap::validate_state_root`
+    //     and yields the validated path back (or a non-#1909 error).
+    // See: docs/reference/operator-read-state-root-contract.md
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn require_explicit_state_root_for_read_rejects_none_with_unified_wording() {
+        let err = require_explicit_state_root_for_read(None, "meeting", "local-harness")
+            .expect_err("missing explicit state-root must hard-fail");
+        match err {
+            crate::SimardError::MissingRequiredConfig { key, help } => {
+                assert_eq!(key, "state-root", "error key must be `state-root`");
+                assert!(
+                    help.contains("state-root is required"),
+                    "help should open with `state-root is required`, got: {help}"
+                );
+                assert!(
+                    help.contains("simard meeting read local-harness"),
+                    "help should name the failing subcommand+base-type, got: {help}"
+                );
+                assert!(
+                    help.contains("pass the positional <state-root> argument explicitly"),
+                    "help should describe the corrective action, got: {help}"
+                );
+                assert!(
+                    help.contains("SIMARD_STATE_ROOT environment variable is not honored"),
+                    "help must explicitly disclaim env-var fallback, got: {help}"
+                );
+            }
+            other => panic!("expected MissingRequiredConfig, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn require_explicit_state_root_for_read_rejects_none_for_each_subcommand_label() {
+        for (subcommand, base) in [
+            ("meeting", "local-harness"),
+            ("improvement-curation", "local-harness"),
+            ("review", "local-harness"),
+        ] {
+            let result = require_explicit_state_root_for_read(None, subcommand, base);
+            assert!(
+                matches!(
+                    result,
+                    Err(crate::SimardError::MissingRequiredConfig { ref key, .. })
+                        if key == "state-root"
+                ),
+                "expected `MissingRequiredConfig {{ key: \"state-root\" }}` for \
+                 {subcommand} read {base}, got {result:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn require_explicit_state_root_for_read_accepts_some_existing_dir() {
+        let dir =
+            std::env::temp_dir().join(format!("simard-issue-1909-explicit-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("tempdir should be creatable");
+        let result =
+            require_explicit_state_root_for_read(Some(dir.clone()), "meeting", "local-harness");
+        let _ = std::fs::remove_dir_all(&dir);
+        let resolved = result.expect("explicit existing dir must pass the guard");
+        // bootstrap::validate_state_root canonicalizes, so just compare
+        // by file_name to keep the assertion platform-agnostic.
+        assert_eq!(
+            resolved.file_name(),
+            dir.file_name(),
+            "explicit path should round-trip through the guard"
+        );
+    }
+
+    #[test]
+    fn require_explicit_state_root_for_read_some_does_not_emit_missing_config() {
+        let dir = std::env::temp_dir().join(format!(
+            "simard-issue-1909-no-missing-config-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).expect("tempdir should be creatable");
+        let result = require_explicit_state_root_for_read(
+            Some(dir.clone()),
+            "improvement-curation",
+            "local-harness",
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+        match result {
+            Ok(_) => {}
+            Err(crate::SimardError::MissingRequiredConfig { .. }) => {
+                panic!("explicit state-root must never produce MissingRequiredConfig");
+            }
+            Err(other) => panic!("unexpected non-#1909 error path: {other:?}"),
+        }
     }
 }

--- a/src/operator_commands_meeting/improvement_curation.rs
+++ b/src/operator_commands_meeting/improvement_curation.rs
@@ -105,11 +105,10 @@ pub fn run_improvement_curation_probe(
 
 pub fn run_improvement_curation_read_probe(
     base_type: &str,
-    topology: &str,
+    _topology: &str,
     state_root_override: Option<PathBuf>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let state_root =
-        resolved_improvement_curation_read_state_root(state_root_override, base_type, topology)?;
+    let state_root = resolved_improvement_curation_read_state_root(state_root_override, base_type)?;
     let (review_artifact_path, review) =
         latest_review_artifact(&state_root)?.ok_or("expected persisted review artifact")?;
     let memory_store = FileBackedMemoryStore::try_new(state_root.join("memory_records.json"))?;

--- a/src/operator_commands_meeting/probes.rs
+++ b/src/operator_commands_meeting/probes.rs
@@ -76,7 +76,7 @@ pub fn run_meeting_read_probe(
     topology: &str,
     state_root_override: Option<PathBuf>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let state_root = resolved_meeting_read_state_root(state_root_override, base_type, topology)?;
+    let state_root = resolved_meeting_read_state_root(state_root_override, base_type)?;
     let memory_store = FileBackedMemoryStore::try_new(state_root.join("memory_records.json"))?;
     let meeting_records = memory_store
         .list(MemoryScope::Decision)?

--- a/src/operator_commands_review.rs
+++ b/src/operator_commands_review.rs
@@ -1,7 +1,8 @@
 use std::path::PathBuf;
 
 use crate::operator_commands::{
-    print_display, print_text, prompt_root, resolved_review_state_root,
+    print_display, print_text, prompt_root, resolved_review_read_state_root,
+    resolved_review_state_root,
 };
 use crate::sanitization::sanitize_terminal_text;
 use crate::{
@@ -92,10 +93,10 @@ pub fn run_review_probe(
 
 pub fn run_review_read_probe(
     base_type: &str,
-    topology: &str,
+    _topology: &str,
     state_root_override: Option<PathBuf>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let state_root = resolved_review_state_root(state_root_override, base_type, topology)?;
+    let state_root = resolved_review_read_state_root(state_root_override, base_type)?;
     let (review_artifact_path, review) =
         latest_review_artifact(&state_root)?.ok_or("expected persisted review artifact")?;
     let memory_store = FileBackedMemoryStore::try_new(state_root.join("memory_records.json"))?;

--- a/tests/issue_1909_state_root_required.rs
+++ b/tests/issue_1909_state_root_required.rs
@@ -1,0 +1,487 @@
+//! Integration tests for rysweet/Simard#1909 — read subcommands must
+//! hard-fail when the positional `<state-root>` argument is absent. They
+//! must **never** silently fall back to a synthesized default path nor
+//! honor the `SIMARD_STATE_ROOT` environment variable.
+//!
+//! These tests define the contract for the resolver-layer guard
+//! `require_explicit_state_root_for_read` (see
+//! `docs/reference/operator-read-state-root-contract.md`). They are TDD
+//! tests: they FAIL against `main` (which silently synthesizes a default
+//! probe state root for these three read subcommands) and PASS once the
+//! guard is wired into the three read wrappers.
+//!
+//! Acceptance criteria mapping (from Step 2c / A1–A10):
+//! - A1: no implicit fallback (neither synthesized default nor env var)
+//! - A2: positional `<state-root>` is the equivalent of `--state-root`
+//! - A3: review read uses its own helper (RUN path untouched)
+//! - A6: unified error wording across the three subcommands
+//! - A7: error variant is `SimardError::MissingRequiredConfig`
+//! - A8: seven tests, names mirroring the contract page table
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::{Command, Output};
+use std::sync::{Mutex, OnceLock};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serial_test::serial;
+
+// ---------------------------------------------------------------------
+// Local helpers (duplicated rather than imported so the file is
+// self-contained; matches the conventions used by other per-issue
+// integration test files like `bin_simard_operator_probe_cli.rs`).
+// ---------------------------------------------------------------------
+
+fn rendered_output(output: &Output) -> String {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    format!("{stdout}{stderr}")
+}
+
+fn simard_bin() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_simard"))
+}
+
+struct TempDirGuard {
+    path: PathBuf,
+}
+
+impl TempDirGuard {
+    fn new(label: &str) -> Self {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after unix epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("{label}-{unique}"));
+        fs::create_dir_all(&path).expect("temp dir should be created");
+        Self { path }
+    }
+
+    fn path(&self) -> &std::path::Path {
+        &self.path
+    }
+}
+
+impl Drop for TempDirGuard {
+    fn drop(&mut self) {
+        if self.path.exists() {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+}
+
+struct CleanupDirGuard {
+    path: PathBuf,
+}
+
+impl CleanupDirGuard {
+    fn new(path: PathBuf) -> Self {
+        let _ = fs::remove_dir_all(&path);
+        Self { path }
+    }
+}
+
+impl Drop for CleanupDirGuard {
+    fn drop(&mut self) {
+        if self.path.exists() {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn default_meeting_state_root(base_type: &str, topology: &str) -> PathBuf {
+    repo_root()
+        .join("target/operator-probe-state")
+        .join("meeting-run")
+        .join("simard-meeting")
+        .join(base_type)
+        .join(topology)
+}
+
+fn default_review_state_root(base_type: &str, topology: &str) -> PathBuf {
+    repo_root()
+        .join("target/operator-probe-state")
+        .join("review-run")
+        .join("simard-engineer")
+        .join(base_type)
+        .join(topology)
+}
+
+// Per-default-root mutexes — heavyweight `_succeeds_*` tests poke at
+// well-known paths shared with the existing simard_cli.rs sibling tests.
+// Serializing here prevents cross-test races when `cargo test` schedules
+// our `#[ignore]`d tests alongside those.
+fn meeting_default_root_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+fn review_default_root_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+/// Unified error-wording assertion shared by every hard-fail test in
+/// this file. Mirrors the contract page (A6 + A7):
+///   `missing required configuration 'state-root': state-root is required
+///    for `simard <subcommand> read <base-type>`: pass the positional
+///    <state-root> argument explicitly. The SIMARD_STATE_ROOT environment
+///    variable is not honored for this command.`
+fn assert_hard_fail_message(rendered: &str, subcommand: &str, base_type: &str) {
+    assert!(
+        rendered.contains("missing required configuration 'state-root'"),
+        "expected unified `SimardError::MissingRequiredConfig` wording with \
+         key='state-root', got:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("state-root is required"),
+        "expected `state-root is required` phrase, got:\n{rendered}"
+    );
+    assert!(
+        rendered.contains(&format!("simard {subcommand} read {base_type}")),
+        "expected error to name `simard {subcommand} read {base_type}`, got:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("pass the positional <state-root> argument explicitly"),
+        "expected explicit-argument guidance, got:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("SIMARD_STATE_ROOT environment variable is not honored"),
+        "expected explicit env-var disclaimer, got:\n{rendered}"
+    );
+}
+
+// ---------------------------------------------------------------------
+// 1. meeting_read_hard_fails_without_state_root
+// ---------------------------------------------------------------------
+
+#[test]
+fn meeting_read_hard_fails_without_state_root() {
+    let output = simard_bin()
+        .arg("meeting")
+        .arg("read")
+        .arg("local-harness")
+        .arg("single-process")
+        .output()
+        .expect("simard meeting read should launch");
+    let rendered = rendered_output(&output);
+
+    assert!(
+        !output.status.success(),
+        "meeting read must hard-fail when no positional <state-root> is given:\n{rendered}"
+    );
+    assert_hard_fail_message(&rendered, "meeting", "local-harness");
+
+    // Negative guard: the resolver must NOT silently synthesize a probe
+    // default path or otherwise leak a "State root:" trace before failing.
+    assert!(
+        !rendered.contains("Probe mode: meeting-read"),
+        "meeting read must not begin probe execution before failing on \
+         missing state-root:\n{rendered}"
+    );
+}
+
+// ---------------------------------------------------------------------
+// 2. improvement_curation_read_hard_fails_without_state_root
+// ---------------------------------------------------------------------
+
+#[test]
+fn improvement_curation_read_hard_fails_without_state_root() {
+    let output = simard_bin()
+        .arg("improvement-curation")
+        .arg("read")
+        .arg("local-harness")
+        .arg("single-process")
+        .output()
+        .expect("simard improvement-curation read should launch");
+    let rendered = rendered_output(&output);
+
+    assert!(
+        !output.status.success(),
+        "improvement-curation read must hard-fail when no positional \
+         <state-root> is given:\n{rendered}"
+    );
+    assert_hard_fail_message(&rendered, "improvement-curation", "local-harness");
+
+    assert!(
+        !rendered.contains("Probe mode: improvement-curation-read"),
+        "improvement-curation read must not begin probe execution before \
+         failing on missing state-root:\n{rendered}"
+    );
+}
+
+// ---------------------------------------------------------------------
+// 3. review_read_hard_fails_without_state_root
+// ---------------------------------------------------------------------
+
+#[test]
+fn review_read_hard_fails_without_state_root() {
+    let output = simard_bin()
+        .arg("review")
+        .arg("read")
+        .arg("local-harness")
+        .arg("single-process")
+        .output()
+        .expect("simard review read should launch");
+    let rendered = rendered_output(&output);
+
+    assert!(
+        !output.status.success(),
+        "review read must hard-fail when no positional <state-root> is \
+         given:\n{rendered}"
+    );
+    assert_hard_fail_message(&rendered, "review", "local-harness");
+
+    assert!(
+        !rendered.contains("Probe mode: review-read"),
+        "review read must not begin probe execution before failing on \
+         missing state-root:\n{rendered}"
+    );
+}
+
+// ---------------------------------------------------------------------
+// 4. read_subcommands_ignore_simard_state_root_env_var
+//
+// Acceptance criterion: even with `SIMARD_STATE_ROOT` exported to a
+// fully-valid existing directory, the three read subcommands must still
+// hard-fail with the unified wording (env-var fallback is NOT honored).
+// ---------------------------------------------------------------------
+
+#[test]
+#[serial]
+fn read_subcommands_ignore_simard_state_root_env_var() {
+    let bogus = TempDirGuard::new("issue-1909-env-fallback-disallowed");
+    // Create a directory that would otherwise satisfy a fallback resolver
+    // — proves the env var path is rejected by intent, not by accident
+    // of being missing on disk.
+    fs::create_dir_all(bogus.path().join("review-artifacts"))
+        .expect("review-artifacts directory should be created");
+    fs::write(bogus.path().join("memory_records.json"), "[]")
+        .expect("memory_records.json should be writable");
+
+    for (subcommand, base_type) in [
+        ("meeting", "local-harness"),
+        ("improvement-curation", "local-harness"),
+        ("review", "local-harness"),
+    ] {
+        let output = simard_bin()
+            .env("SIMARD_STATE_ROOT", bogus.path())
+            .arg(subcommand)
+            .arg("read")
+            .arg(base_type)
+            .arg("single-process")
+            .output()
+            .unwrap_or_else(|err| {
+                panic!("simard {subcommand} read should launch ({err})");
+            });
+        let rendered = rendered_output(&output);
+
+        assert!(
+            !output.status.success(),
+            "{subcommand} read must hard-fail even when SIMARD_STATE_ROOT \
+             is set to a valid directory (env fallback is not honored for \
+             read paths):\n{rendered}"
+        );
+        assert_hard_fail_message(&rendered, subcommand, base_type);
+    }
+}
+
+// ---------------------------------------------------------------------
+// 5. meeting_read_succeeds_with_explicit_state_root
+//
+// Heavyweight: populates a real meeting state-root via `meeting run`,
+// then runs `meeting read` with the explicit positional. Mirrors the
+// existing sibling tests in `tests/simard_cli.rs` that are `#[ignore]`d
+// because they spawn the full simard binary and hang in pre-commit.
+// Asserts the new guard accepts an explicit positional.
+// ---------------------------------------------------------------------
+
+#[test]
+#[ignore = "spawns simard binary end-to-end; matches sibling pattern in tests/simard_cli.rs"]
+fn meeting_read_succeeds_with_explicit_state_root() {
+    let _lock = meeting_default_root_lock()
+        .lock()
+        .expect("meeting default root test lock should not be poisoned");
+    let state_root = default_meeting_state_root("local-harness", "single-process");
+    let _cleanup = CleanupDirGuard::new(state_root.clone());
+
+    let meeting_objective = "agenda: align the next Simard workstream\n\
+update: durable memory merged\n\
+decision: preserve meeting-to-engineer continuity\n\
+risk: workflow routing is still unreliable\n\
+next-step: keep durable priorities visible\n\
+open-question: how aggressively should Simard reprioritize?\n\
+goal: Preserve meeting handoff | priority=1 | status=active | rationale=meeting decisions must shape later work";
+
+    let run_output = simard_bin()
+        .arg("meeting")
+        .arg("run")
+        .arg("local-harness")
+        .arg("single-process")
+        .arg(meeting_objective)
+        .output()
+        .expect("simard meeting run should launch with its canonical default state root");
+    assert!(
+        run_output.status.success(),
+        "meeting run prerequisite must succeed:\n{}",
+        rendered_output(&run_output)
+    );
+
+    let read_output = simard_bin()
+        .arg("meeting")
+        .arg("read")
+        .arg("local-harness")
+        .arg("single-process")
+        .arg(&state_root)
+        .output()
+        .expect("simard meeting read should launch with explicit state-root");
+    let rendered = rendered_output(&read_output);
+
+    assert!(
+        read_output.status.success(),
+        "meeting read with explicit <state-root> must succeed:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("Probe mode: meeting-read"),
+        "meeting read should surface its probe mode:\n{rendered}"
+    );
+    assert!(
+        rendered.contains(&format!("State root: {}", state_root.display())),
+        "meeting read should echo the explicit state-root it used:\n{rendered}"
+    );
+    assert!(
+        !rendered.contains("missing required configuration 'state-root'"),
+        "explicit state-root must bypass the new hard-fail guard:\n{rendered}"
+    );
+}
+
+// ---------------------------------------------------------------------
+// 6. improvement_curation_read_succeeds_with_explicit_state_root
+// ---------------------------------------------------------------------
+
+#[test]
+#[ignore = "spawns simard binary end-to-end; matches sibling pattern in tests/simard_cli.rs"]
+fn improvement_curation_read_succeeds_with_explicit_state_root() {
+    let _lock = review_default_root_lock()
+        .lock()
+        .expect("review default root test lock should not be poisoned");
+    let state_root = default_review_state_root("local-harness", "single-process");
+    let _cleanup = CleanupDirGuard::new(state_root.clone());
+
+    let review_run = simard_bin()
+        .arg("review")
+        .arg("run")
+        .arg("local-harness")
+        .arg("single-process")
+        .arg("inspect the current Simard review surface and preserve concrete proposals")
+        .output()
+        .expect("simard review run should launch");
+    assert!(
+        review_run.status.success(),
+        "review run prerequisite must succeed:\n{}",
+        rendered_output(&review_run)
+    );
+
+    let improvement_run = simard_bin()
+        .arg("improvement-curation")
+        .arg("run")
+        .arg("local-harness")
+        .arg("single-process")
+        .arg(
+            "approve: Capture denser execution evidence | priority=1 | status=active | \
+             rationale=operators need denser execution evidence now",
+        )
+        .output()
+        .expect("simard improvement-curation run should launch");
+    assert!(
+        improvement_run.status.success(),
+        "improvement-curation run prerequisite must succeed:\n{}",
+        rendered_output(&improvement_run)
+    );
+
+    let read_output = simard_bin()
+        .arg("improvement-curation")
+        .arg("read")
+        .arg("local-harness")
+        .arg("single-process")
+        .arg(&state_root)
+        .output()
+        .expect("simard improvement-curation read should launch with explicit state-root");
+    let rendered = rendered_output(&read_output);
+
+    assert!(
+        read_output.status.success(),
+        "improvement-curation read with explicit <state-root> must succeed:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("Probe mode: improvement-curation-read"),
+        "improvement-curation read should surface its probe mode:\n{rendered}"
+    );
+    assert!(
+        rendered.contains(&format!("State root: {}", state_root.display())),
+        "improvement-curation read should echo the explicit state-root it used:\n{rendered}"
+    );
+    assert!(
+        !rendered.contains("missing required configuration 'state-root'"),
+        "explicit state-root must bypass the new hard-fail guard:\n{rendered}"
+    );
+}
+
+// ---------------------------------------------------------------------
+// 7. review_read_succeeds_with_explicit_state_root
+// ---------------------------------------------------------------------
+
+#[test]
+#[ignore = "spawns simard binary end-to-end; matches sibling pattern in tests/simard_cli.rs"]
+fn review_read_succeeds_with_explicit_state_root() {
+    let _lock = review_default_root_lock()
+        .lock()
+        .expect("review default root test lock should not be poisoned");
+    let state_root = default_review_state_root("local-harness", "single-process");
+    let _cleanup = CleanupDirGuard::new(state_root.clone());
+
+    let review_run = simard_bin()
+        .arg("review")
+        .arg("run")
+        .arg("local-harness")
+        .arg("single-process")
+        .arg("inspect the current Simard review surface and preserve concrete proposals")
+        .output()
+        .expect("simard review run should launch");
+    assert!(
+        review_run.status.success(),
+        "review run prerequisite must succeed:\n{}",
+        rendered_output(&review_run)
+    );
+
+    let read_output = simard_bin()
+        .arg("review")
+        .arg("read")
+        .arg("local-harness")
+        .arg("single-process")
+        .arg(&state_root)
+        .output()
+        .expect("simard review read should launch with explicit state-root");
+    let rendered = rendered_output(&read_output);
+
+    assert!(
+        read_output.status.success(),
+        "review read with explicit <state-root> must succeed:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("Probe mode: review-read"),
+        "review read should surface its probe mode:\n{rendered}"
+    );
+    assert!(
+        rendered.contains(&format!("State root: {}", state_root.display())),
+        "review read should echo the explicit state-root it used:\n{rendered}"
+    );
+    assert!(
+        !rendered.contains("missing required configuration 'state-root'"),
+        "explicit state-root must bypass the new hard-fail guard:\n{rendered}"
+    );
+}

--- a/tests/simard_cli.rs
+++ b/tests/simard_cli.rs
@@ -129,11 +129,6 @@ fn goal_curation_default_root_lock() -> &'static Mutex<()> {
     LOCK.get_or_init(|| Mutex::new(()))
 }
 
-fn meeting_default_root_lock() -> &'static Mutex<()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| Mutex::new(()))
-}
-
 fn engineer_default_root_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
     LOCK.get_or_init(|| Mutex::new(()))
@@ -148,34 +143,11 @@ fn default_engineer_state_root(topology: &str) -> PathBuf {
         .join(topology)
 }
 
-fn default_meeting_state_root(base_type: &str, topology: &str) -> PathBuf {
-    repo_root()
-        .join("target/operator-probe-state")
-        .join("meeting-run")
-        .join("simard-meeting")
-        .join(base_type)
-        .join(topology)
-}
-
 fn default_goal_curation_state_root(base_type: &str, topology: &str) -> PathBuf {
     repo_root()
         .join("target/operator-probe-state")
         .join("goal-curation-run")
         .join("simard-goal-curator")
-        .join(base_type)
-        .join(topology)
-}
-
-fn review_default_root_lock() -> &'static Mutex<()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| Mutex::new(()))
-}
-
-fn default_review_state_root(base_type: &str, topology: &str) -> PathBuf {
-    repo_root()
-        .join("target/operator-probe-state")
-        .join("review-run")
-        .join("simard-engineer")
         .join(base_type)
         .join(topology)
 }
@@ -548,7 +520,7 @@ fn simard_help_documents_meeting_read_as_the_durable_meeting_audit_surface() {
         "simard help should stay readable while the durable meeting read command is added:\n{rendered}"
     );
     assert!(
-        rendered.contains("meeting read <base-type> <topology> [state-root]"),
+        rendered.contains("meeting read <base-type> <topology> <state-root>"),
         "simard help should document the canonical read-only meeting workflow:\n{rendered}"
     );
 }
@@ -586,7 +558,7 @@ fn simard_help_documents_improvement_curation_read_as_the_durable_review_decisio
         "simard help should stay readable while the durable improvement readback command is added:\n{rendered}"
     );
     assert!(
-        rendered.contains("improvement-curation read <base-type> <topology> [state-root]"),
+        rendered.contains("improvement-curation read <base-type> <topology> <state-root>"),
         "simard help should document the canonical read-only improvement curation workflow:\n{rendered}"
     );
 }
@@ -2874,103 +2846,45 @@ goal: Preserve meeting handoff | priority=1 | status=active | rationale=carry de
     );
 }
 
+// Issue rysweet/Simard#1909: `meeting read` must HARD-FAIL when no
+// positional `<state-root>` is given — it must NOT silently fall back
+// to the synthesized run-default path. This test used to assert the
+// opposite (fallback-honored) contract and was `#[ignore]`d. It is now
+// un-ignored and inverted so the new resolver-layer guard is locked in
+// by every `cargo test` run. See:
+//   docs/reference/operator-read-state-root-contract.md
+//   tests/issue_1909_state_root_required.rs
 #[test]
-#[ignore] // Spawns simard binary — hangs in pre-commit
-fn simard_meeting_read_reuses_the_run_default_state_root_and_stays_read_only() {
-    let _lock = meeting_default_root_lock()
-        .lock()
-        .expect("meeting default root test lock should not be poisoned");
-    let state_root = default_meeting_state_root("local-harness", "single-process");
-    let _cleanup = CleanupDirGuard::new(state_root.clone());
-    let meeting_objective = "\
-agenda: align the next Simard workstream\n\
-update: durable \u{1b}[31mmemory\u{1b}[0m merged\n\
-decision: preserve meeting-to-engineer continuity\n\
-risk: workflow routing is still unreliable\n\
-next-step: keep durable priorities visible\n\
-open-question: how aggressively should Simard reprioritize?\n\
-goal: Preserve \u{1b}]8;;https://example.invalid\u{7}meeting handoff\u{1b}]8;;\u{7} | priority=1 | status=active | rationale=meeting decisions must shape later work";
-
-    let run_output = Command::new(env!("CARGO_BIN_EXE_simard"))
-        .arg("meeting")
-        .arg("run")
-        .arg("local-harness")
-        .arg("single-process")
-        .arg(meeting_objective)
-        .output()
-        .expect("simard meeting run should launch with its default state root");
-    let run_rendered = rendered_output(&run_output);
-
-    assert!(
-        run_output.status.success(),
-        "meeting run should succeed with its canonical default state root:\n{run_rendered}"
-    );
-    assert!(
-        run_rendered.contains(&format!("State root: {}", state_root.display())),
-        "meeting run should surface the canonical default durable root it writes:\n{run_rendered}"
-    );
-
-    let memory_before =
-        fs::read(state_root.join("memory_records.json")).expect("memory store should exist");
-    let goals_before =
-        fs::read(state_root.join("goal_records.json")).expect("goal store should exist");
-
+fn simard_meeting_read_hard_fails_when_run_default_state_root_is_absent() {
     let read_output = Command::new(env!("CARGO_BIN_EXE_simard"))
         .arg("meeting")
         .arg("read")
         .arg("local-harness")
         .arg("single-process")
         .output()
-        .expect("simard meeting read should launch with its default state root");
+        .expect("simard meeting read should launch");
     let read_rendered = rendered_output(&read_output);
 
     assert!(
-        read_output.status.success(),
-        "meeting read should inspect the same canonical default durable root that run populates:\n{read_rendered}"
+        !read_output.status.success(),
+        "meeting read must hard-fail when no explicit <state-root> is supplied; \
+         silent fallback to the run-default path is forbidden by #1909:\n{read_rendered}"
     );
-    for expected in [
-        "Probe mode: meeting-read",
-        "Identity: simard-meeting",
-        &format!("State root: {}", state_root.display()),
-        "Meeting records: 1",
-        "Latest agenda: align the next Simard workstream",
-        "Updates count: 1",
-        "Update 1: durable memory merged",
-        "Decisions count: 1",
-        "Decision 1: preserve meeting-to-engineer continuity",
-        "Risks count: 1",
-        "Risk 1: workflow routing is still unreliable",
-        "Next steps count: 1",
-        "Next step 1: keep durable priorities visible",
-        "Open questions count: 1",
-        "Open question 1: how aggressively should Simard reprioritize?",
-        "Goal updates count: 1",
-        "Goal update 1: p1 [active] Preserve meeting handoff",
-        "Latest meeting record: agenda=align the next Simard workstream;",
-    ] {
-        assert!(
-            read_rendered.contains(expected),
-            "meeting read should surface '{expected}' for operators:\n{read_rendered}"
-        );
-    }
-    for forbidden in ['\u{1b}', '\u{7}'] {
-        assert!(
-            !read_rendered.contains(forbidden),
-            "meeting read should sanitize persisted operator-visible text before printing it:\n{read_rendered}"
-        );
-    }
-
-    let memory_after =
-        fs::read(state_root.join("memory_records.json")).expect("memory store should exist");
-    let goals_after =
-        fs::read(state_root.join("goal_records.json")).expect("goal store should exist");
-    assert_eq!(
-        memory_before, memory_after,
-        "meeting read must not rewrite the durable memory store"
+    assert!(
+        read_rendered.contains("missing required configuration 'state-root'"),
+        "meeting read should surface the unified MissingRequiredConfig wording:\n{read_rendered}"
     );
-    assert_eq!(
-        goals_before, goals_after,
-        "meeting read must not rewrite the durable goal store"
+    assert!(
+        read_rendered.contains("simard meeting read local-harness"),
+        "meeting read should name the failing subcommand+base-type in the error:\n{read_rendered}"
+    );
+    assert!(
+        read_rendered.contains("SIMARD_STATE_ROOT environment variable is not honored"),
+        "meeting read should explicitly disclaim the SIMARD_STATE_ROOT env fallback:\n{read_rendered}"
+    );
+    assert!(
+        !read_rendered.contains("Probe mode: meeting-read"),
+        "meeting read must abort BEFORE any probe execution when state-root is absent:\n{read_rendered}"
     );
 }
 
@@ -3624,108 +3538,45 @@ approve: Promote this pattern into a repeatable benchmark | priority=2 | status=
     );
 }
 
+// Issue rysweet/Simard#1909: `improvement-curation read` must HARD-FAIL
+// when no positional `<state-root>` is given — it must NOT silently
+// fall back to the synthesized review-run default path. This test used
+// to assert the opposite (fallback-honored) contract and was `#[ignore]`d.
+// It is now un-ignored and inverted so the new resolver-layer guard is
+// locked in by every `cargo test` run. See:
+//   docs/reference/operator-read-state-root-contract.md
+//   tests/issue_1909_state_root_required.rs
 #[test]
-#[ignore] // Spawns simard binary — hangs in pre-commit
-fn simard_improvement_curation_read_reuses_the_review_default_state_root_and_stays_read_only() {
-    let _lock = review_default_root_lock()
-        .lock()
-        .expect("review default root test lock should not be poisoned");
-    let state_root = default_review_state_root("local-harness", "single-process");
-    let _cleanup = CleanupDirGuard::new(state_root.clone());
-
-    let review_output = Command::new(env!("CARGO_BIN_EXE_simard"))
-        .arg("review")
-        .arg("run")
-        .arg("local-harness")
-        .arg("single-process")
-        .arg("inspect the current Simard review surface and preserve concrete proposals")
-        .output()
-        .expect("simard review run should launch with its default state root");
-    let review_rendered = rendered_output(&review_output);
-
-    assert!(
-        review_output.status.success(),
-        "review run should succeed with its canonical default state root:\n{review_rendered}"
-    );
-    assert!(
-        review_rendered.contains(&format!("State root: {}", state_root.display())),
-        "review run should surface the canonical durable root that improvement read later inspects:\n{review_rendered}"
-    );
-
-    let improvement_objective = "\
-approve: Capture denser execution evidence | priority=1 | status=active | rationale=operators need denser execution evidence now\n\
-defer: Promote this pattern into a repeatable benchmark | rationale=wait for the next benchmark planning pass";
-    let improvement_output = Command::new(env!("CARGO_BIN_EXE_simard"))
-        .arg("improvement-curation")
-        .arg("run")
-        .arg("local-harness")
-        .arg("single-process")
-        .arg(improvement_objective)
-        .output()
-        .expect("simard improvement-curation run should launch with the review default state root");
-    let improvement_rendered = rendered_output(&improvement_output);
-
-    assert!(
-        improvement_output.status.success(),
-        "improvement-curation run should share the canonical review/improvement durable root:\n{improvement_rendered}"
-    );
-    assert!(
-        improvement_rendered.contains(&format!("State root: {}", state_root.display())),
-        "improvement-curation run should surface the shared durable root that readback reuses:\n{improvement_rendered}"
-    );
-
-    let memory_before =
-        fs::read(state_root.join("memory_records.json")).expect("memory store should exist");
-    let goals_before =
-        fs::read(state_root.join("goal_records.json")).expect("goal store should exist");
-
+fn simard_improvement_curation_read_hard_fails_when_review_default_state_root_is_absent() {
     let read_output = Command::new(env!("CARGO_BIN_EXE_simard"))
         .arg("improvement-curation")
         .arg("read")
         .arg("local-harness")
         .arg("single-process")
         .output()
-        .expect(
-            "simard improvement-curation read should launch with the review default state root",
-        );
+        .expect("simard improvement-curation read should launch");
     let read_rendered = rendered_output(&read_output);
 
     assert!(
-        read_output.status.success(),
-        "improvement-curation read should expose durable review and promotion state through the primary CLI:\n{read_rendered}"
+        !read_output.status.success(),
+        "improvement-curation read must hard-fail when no explicit <state-root> \
+         is supplied; silent fallback to the review-run default path is forbidden by #1909:\n{read_rendered}"
     );
-    for expected in [
-        "Probe mode: improvement-curation-read",
-        &format!("State root: {}", state_root.display()),
-        "Latest review artifact:",
-        "Review id:",
-        "Review target:",
-        "Approved proposals: 1",
-        "Approved proposal 1: p1 [active] Capture denser execution evidence",
-        "Deferred proposals: 1",
-        "Deferred proposal 1: Promote this pattern into a repeatable benchmark (wait for the next benchmark planning pass)",
-        "Active goals count: 1",
-        "Active goal 1: p1 [active] Capture denser execution evidence",
-        "Proposed goals count: 0",
-        "Latest improvement record: review=",
-    ] {
-        assert!(
-            read_rendered.contains(expected),
-            "improvement-curation read should surface '{expected}' for operators:\n{read_rendered}"
-        );
-    }
-
-    let memory_after =
-        fs::read(state_root.join("memory_records.json")).expect("memory store should exist");
-    let goals_after =
-        fs::read(state_root.join("goal_records.json")).expect("goal store should exist");
-    assert_eq!(
-        memory_before, memory_after,
-        "improvement-curation read must not rewrite the durable memory store"
+    assert!(
+        read_rendered.contains("missing required configuration 'state-root'"),
+        "improvement-curation read should surface the unified MissingRequiredConfig wording:\n{read_rendered}"
     );
-    assert_eq!(
-        goals_before, goals_after,
-        "improvement-curation read must not rewrite the durable goal store"
+    assert!(
+        read_rendered.contains("simard improvement-curation read local-harness"),
+        "improvement-curation read should name the failing subcommand+base-type in the error:\n{read_rendered}"
+    );
+    assert!(
+        read_rendered.contains("SIMARD_STATE_ROOT environment variable is not honored"),
+        "improvement-curation read should explicitly disclaim the SIMARD_STATE_ROOT env fallback:\n{read_rendered}"
+    );
+    assert!(
+        !read_rendered.contains("Probe mode: improvement-curation-read"),
+        "improvement-curation read must abort BEFORE any probe execution when state-root is absent:\n{read_rendered}"
     );
 }
 


### PR DESCRIPTION
Fixes #1909. Audit tracker: #1910 (untouched).

## Summary

The three operator probe **read** subcommands — `simard meeting read`,
`simard improvement-curation read`, and `simard review read` — now require
an explicit positional `<state-root>` argument and **hard-fail** with a
unified, actionable error when it is missing. They **never** silently
fall back to a synthesized probe-default path or to the
`SIMARD_STATE_ROOT` environment variable.

This propagates the audit-fix shape from PR #1907 (operator-cli alignment)
to the three remaining read companions that were called out as brittle in
the `fix-broken-features` audit (#1910).

## Subcommands touched

| Subcommand                            | Behavior change |
| ------------------------------------- | --------------- |
| `simard meeting read <bt> <topo> <sr>`             | requires `<state-root>`, hard-fails when absent |
| `simard improvement-curation read <bt> <topo> <sr>` | requires `<state-root>`, hard-fails when absent |
| `simard review read <bt> <topo> <sr>`               | requires `<state-root>`, hard-fails when absent |

RUN paths (`meeting run`, `improvement-curation run`, `review run`) are
**unchanged** — they still accept an optional state-root and synthesize the
probe default when absent. Only READ paths flip to explicit-or-fail.

## Error wording (stable template)

```
missing required configuration 'state-root': state-root is required
for `simard <subcommand> read <base-type>`: pass the positional
<state-root> argument explicitly. The SIMARD_STATE_ROOT environment
variable is not honored for this command.
```

Verified end-to-end (`./target/debug/simard <subcommand> read local-harness single-process`):

- meeting read → `... for \`simard meeting read local-harness\`: pass the positional <state-root> argument explicitly. The SIMARD_STATE_ROOT environment variable is not honored for this command.`
- improvement-curation read → `... for \`simard improvement-curation read local-harness\`: ...`
- review read → `... for \`simard review read local-harness\`: ...`
- With `SIMARD_STATE_ROOT=/tmp` set, all three still hard-fail with the same wording (env-var fallback is intentionally **not** honored).

## Implementation

- `src/operator_commands/state_root.rs`
  - **New** `require_explicit_state_root_for_read(explicit, subcommand, base_type)` — shared guard returning `SimardError::MissingRequiredConfig { key: "state-root", help: <unified wording> }` when `None`; delegates to `bootstrap::validate_state_root` when `Some`.
  - **New** `resolved_review_read_state_root` — read-only wrapper so the existing `resolved_review_state_root` (used by RUN paths and the improvement-curation RUN writer) stays untouched (A3 in the resolved-ambiguity plan).
  - `resolved_meeting_read_state_root` and `resolved_improvement_curation_read_state_root` now call the new guard before `validate_*_read_state_root`.
- `src/operator_commands_review.rs` — `run_review_read_probe` switched from `resolved_review_state_root` to `resolved_review_read_state_root`.
- `src/operator_cli/{mod.rs, meeting.rs}` — help text changed from `[state-root]` to `<state-root>` for the three read commands; RUN paths stay `[state-root]`.

## Tests

### New file: `tests/issue_1909_state_root_required.rs`
- `meeting_read_hard_fails_without_state_root` ✅
- `improvement_curation_read_hard_fails_without_state_root` ✅
- `review_read_hard_fails_without_state_root` ✅
- `read_subcommands_ignore_simard_state_root_env_var` ✅ (acceptance criterion: even with `SIMARD_STATE_ROOT=<valid dir>` set, all three hard-fail with the unified wording)
- `meeting_read_succeeds_with_explicit_state_root` ⏭️ `#[ignore]` (heavyweight, spawns simard end-to-end; matches sibling pattern in `tests/simard_cli.rs`)
- `improvement_curation_read_succeeds_with_explicit_state_root` ⏭️ `#[ignore]`
- `review_read_succeeds_with_explicit_state_root` ⏭️ `#[ignore]`

### New unit tests in `src/operator_commands/state_root.rs` (4)
- `require_explicit_state_root_for_read_rejects_none_with_unified_wording`
- `require_explicit_state_root_for_read_rejects_none_for_each_subcommand_label`
- `require_explicit_state_root_for_read_accepts_some_existing_dir`
- `require_explicit_state_root_for_read_some_does_not_emit_missing_config`

### Existing tests inverted in `tests/simard_cli.rs`
Two pre-existing `#[ignore]`d tests encoded the OPPOSITE contract
(silent fallback honored). They are now un-ignored, inverted, and
renamed to lock the hard-fail behavior into every `cargo test` run:

- `simard_meeting_read_hard_fails_when_run_default_state_root_is_absent` ✅
- `simard_improvement_curation_read_hard_fails_when_review_default_state_root_is_absent` ✅

### Help-text tests updated
Two help-text-dependent `#[ignore]`d tests in `tests/simard_cli.rs`
updated from `[state-root]` to `<state-root>` for the meeting and
improvement-curation read commands.

## Quality gates

- ✅ `cargo build --bin simard` — clean
- ✅ `cargo clippy --all-targets -- -D warnings` — clean
- ✅ `cargo test --test issue_1909_state_root_required` — 4 passed, 3 ignored
- ✅ `cargo test --lib operator_commands::state_root` — 19 passed
- ✅ `cargo test --test simard_cli hard_fails` — 2 passed
- ✅ pre-commit hooks (cargo fmt --all -- --check, cargo clippy --release --no-deps -- -D warnings)
- ✅ pre-push hooks (cargo fmt, cargo test --release --lib for cognitive_memory|bootstrap|memory_ipc|memory_consolidation, cargo clippy --all-targets --all-features --locked -- -D warnings)
- ✅ Manual end-to-end smoke test of all three subcommands (with and without SIMARD_STATE_ROOT set)

## Docs

- **New** `docs/reference/operator-read-state-root-contract.md` — full contract page (rationale, error template, behavior table, audit references).
- Updated `docs/howto/inspect-meeting-records.md`, `docs/howto/inspect-improvement-curation-state.md` — explicit-or-fail call-out, troubleshooting section for the new error.
- Updated `docs/reference/simard-cli.md`, `docs/reference/runtime-contracts.md` — cross-links + contract delta.
- Updated `mkdocs.yml` — new reference page added to nav.

## Diff focus

13 files changed: 6 src/, 5 docs/, 2 tests/, 1 mkdocs.yml. No
unrelated edits. Audit tracker #1910 and the prior fix PR #1907 are
not modified.

## Out of scope

- #1910 (parent audit tracker) — intentionally not modified.
- #1907 (already-merged reference fix) — not reopened.
- `~/.simard/prompt_assets/` and `$SIMARD_PROMPT_ASSETS_DIR` — not modified.
- `goal-curation read` — keeps its intentional fallback to
  `$SIMARD_STATE_ROOT` / `$HOME/.simard/state`; the audit explicitly
  identifies that as the correct daemon-companion behavior, and the
  three reads in this PR are operator-probe companions with the
  opposite contract.



## Step 13: Local Testing Results

Outside-in tests executed against the simard binary built from the PR branch
`feat/issue-1909-resolve-open-issue-rysweetsimard1909-fix-broken-fe` at HEAD
`a9551ea1`. (The `uvx --from git+...` template from the Step 13 prompt is
amplihack-Python-specific; this is the Rust simard CLI, so the binary built
from the same branch is the equivalent under-test artifact.)

### Scenario 1 — simple: hard-fail when `<state-root>` is omitted

Command (run for each of the three subcommands):
```
env -u SIMARD_STATE_ROOT ./target/debug/simard meeting              read local-harness single-process
env -u SIMARD_STATE_ROOT ./target/debug/simard improvement-curation read local-harness single-process
env -u SIMARD_STATE_ROOT ./target/debug/simard review               read local-harness single-process
```

Result: **PASS** — all three exited with code `1` and printed the unified error:
```
Error: missing required configuration 'state-root': state-root is required
for `simard <subcmd> read local-harness`: pass the positional <state-root>
argument explicitly. The SIMARD_STATE_ROOT environment variable is not
honored for this command.
```

### Scenario 2 — complex: env-var fallback is NOT honored + explicit path works + goal-curation regression check

Command set (with `SIMARD_STATE_ROOT` set in the environment):
```
SIMARD_STATE_ROOT=$SR ./target/debug/simard meeting              read local-harness single-process     # MUST hard-fail
SIMARD_STATE_ROOT=$SR ./target/debug/simard improvement-curation read local-harness single-process     # MUST hard-fail
SIMARD_STATE_ROOT=$SR ./target/debug/simard review               read local-harness single-process     # MUST hard-fail
env -u SIMARD_STATE_ROOT ./target/debug/simard meeting read local-harness single-process $SR           # explicit → past resolver
SIMARD_STATE_ROOT=$SR ./target/debug/simard goal-curation read local-harness single-process            # regression: env still honored
```

Result: **PASS**.
- 2a/2b/2c: env-var fallback rejected — all three exited `1` with the same
  unified message as Scenario 1 (proves SIMARD_STATE_ROOT is **not** silently
  consumed for these reads).
- 2d explicit path: passes the `#1909` resolver guard and is rejected
  downstream by `validate_meeting_read_state_root` (`memory_records.json`
  missing) — exactly the post-#1909 boundary; **no** `MissingRequiredConfig`
  raised.
- Regression: `goal-curation read` still honors `SIMARD_STATE_ROOT` and exits
  `0` (`State root: /tmp/...`, `Active goals count: 0`). The audit's
  intentional divergence (per #1910) is preserved.

### Integration test suite (`tests/issue_1909_state_root_required.rs`)

```
cargo test --test issue_1909_state_root_required             # 4 passed, 3 ignored
cargo test --test issue_1909_state_root_required -- --ignored # 3 passed (binary-spawning e2e)
```

Both invocations green; 7/7 tests cover (a) None → `MissingRequiredConfig`
with the unified wording, (b) `SIMARD_STATE_ROOT` set but no positional →
still hard-fails, (c) explicit `<state-root>` → succeeds end-to-end against
the real binary for all three subcommands.
