### PR TITLE
fix(ooda): gate goal-progress increases on verifiable git evidence (closes #1969)

### DIFF
--- a/docs/concepts/progress-evidence-gating.md
+++ b/docs/concepts/progress-evidence-gating.md
@@ -1,0 +1,227 @@
+---
+title: Progress-evidence gating
+description: How Simard refuses to bump a goal's completion percentage unless a verifiable git artifact backs the claim.
+last_updated: 2026-05-21
+owner: simard
+doc_type: concept
+related:
+  - goal-board-corruption-guards.md
+  - ../reference/progress-evidence-api.md
+  - ../operations/progress-evidence-kill-switch.md
+  - ../howto/diagnose-rejected-progress-claims.md
+  - ../../src/goal_curation/progress_evidence.rs
+  - ../../src/goal_curation/operations.rs
+---
+
+# Progress-evidence gating
+
+## The problem this solves
+
+Before issue [#1967](https://github.com/rysweet/Simard/issues/1967) the OODA
+brain's *decide* phase could mark a goal `STATUS: ACHIEVED` and bump its
+`GoalProgress::InProgress { percent }` value without any change in the
+underlying repository. The brain's text reasoning was treated as ground truth
+and persisted directly onto the goal board.
+
+The result, observed live on the production daemon between 2026-05-19 23:06Z
+(merge of [#1968](https://github.com/rysweet/Simard/pull/1968)) and 2026-05-21
+03:19Z, was a 28-hour cascade of fictional progress: several active goals
+drifted upward by 10–40 percentage points despite **zero** new PRs on
+`rysweet/Simard` over the same window. The exact per-goal numbers used to
+calibrate the test fixtures are pulled from the cognitive-memory store at
+implementation time (see acceptance criterion §10.3 in the design); they
+are not enumerated here to avoid this concept doc going stale the moment
+the daemon is restarted.
+
+Engineer subprocesses spawned, ran, and exited without producing branches or
+PRs — but the brain still believed they had made progress, recorded that
+belief on the goal board, and surfaced it on the operator dashboard. This
+made every downstream signal Simard produced — the dashboard, the meeting
+summaries, the priority ordering — quietly false.
+
+The single guiding principle of the fix is:
+
+> **No progress increase without a verifiable git artifact since the last
+> update.**
+
+## The three accepted forms of evidence
+
+A proposed increase from `old_percent` to `new_percent` for goal `G` is
+accepted if **any one** of the following is true since `G`'s last accepted
+update (`G.last_progress_update_at`):
+
+1. **Local commit on an engineer branch.** At least one commit exists on a
+   branch matching `engineer/{slug(G.id)}-*` with author-date `>= since`.
+2. **PR referencing the goal.** At least one PR (any state) on
+   `rysweet/Simard` whose title or body contains either the goal slug or any
+   `ref_id` listed in `G.wip_refs`, created at or after `since`.
+3. **Merged PR closing a wip-ref issue.** At least one PR with
+   `state="MERGED"` and `mergedAt >= since` whose body matches a
+   `Closes/Fixes/Resolves #NNNN` clause where `NNNN` is an issue in
+   `G.wip_refs`.
+
+If none match, the gate rejects the update, the prior percent is kept, and
+the rejection is recorded as a cognitive-memory episode (see
+[Audit trail](#audit-trail)).
+
+### Why "any-of" rather than "all-of"
+
+Real progress takes many shapes. A long-running spike may produce commits on
+a personal branch before a PR exists. A documentation-only fix may land as a
+PR with no engineer branch. A bug closed by an external contributor may merge
+without ever touching an engineer branch. Requiring all three signals
+simultaneously would block legitimate work; requiring any one of them blocks
+only the failure mode we observed — brain output with **zero** corresponding
+artifacts.
+
+### What does *not* count as evidence
+
+- Brain text that asserts work was done.
+- Engineer subprocess exit codes (an engineer can exit 0 without producing
+  output).
+- Heartbeat freshness (an engineer can be alive and idle).
+- Memory episodes claiming progress (memory is downstream of the gate, not
+  upstream).
+
+(Dashboard operator overrides are not "non-evidence" — they are a separate
+intentional bypass mechanism. See [Bypass set](#bypass-set--when-the-gate-is-not-consulted) and [Scope and exceptions](#scope-and-exceptions).)
+
+## Bypass set — when the gate is not consulted
+
+The gate guards **percent increases**. It is bypassed for:
+
+- **Non-increase transitions.** Any update where `new_percent <=
+  old_percent`. Decreases and same-value writes are always allowed; they
+  cannot inflate the dashboard.
+- **`Blocked(reason)` transitions.** Blocking a goal keeps its percent at
+  the prior value and adds a reason string — this is non-fictional by
+  definition.
+- **`NotStarted` resets.** Used by `clear_goal_assignment` and similar
+  operator paths to wipe state.
+- **`Completed` after artifact verification.** The
+  `advance_goal/subordinate.rs` Completed path is already guarded by
+  `SubordinateProgress::has_artifacts()`. It is still routed through the
+  gate for audit consistency, but rule (1) — commit on engineer branch —
+  is satisfied by definition, so the gate is a no-op in practice.
+
+## Where the gate lives
+
+The gate is a single trait — `ProgressEvidenceChecker` — and a single
+façade function — `update_goal_progress_with_evidence` — both in
+`src/goal_curation/`. **Four** OODA-loop call sites that previously called
+`update_goal_progress` directly are rewired to go through the façade:
+
+```
+ooda_actions/goal_session/advance.rs:57    (assess_only_outcome)
+ooda_actions/goal_session/advance.rs:243   (pre-spawn percent bump)
+ooda_actions/advance_goal/subordinate.rs:56   (heartbeat → 50%)
+ooda_actions/advance_goal/subordinate.rs:223  (Completed after artifacts)
+```
+
+A fifth caller — `ooda_actions/advance_goal/subordinate.rs:262` — sets
+`Blocked(reason)`, which is in the [bypass set](#bypass-set--when-the-gate-is-not-consulted)
+(`Blocked` keeps the prior percent and cannot inflate the dashboard). It
+intentionally continues to call `update_goal_progress` directly.
+
+A grep for `update_goal_progress(` in production code therefore returns
+exactly **three** direct call sites after the fix: (a) the façade itself,
+(b) the dashboard `PUT /api/goals/<id>/progress` handler (an intentional
+operator override), and (c) the `Blocked`-path bypass at
+`subordinate.rs:262`. Any new direct caller introduced after #1967 must
+be justified explicitly (bypass-set membership or operator override).
+
+For the trait shape and exact function signatures, see the
+[Progress-evidence API reference](../reference/progress-evidence-api.md).
+
+## Sourcing `since` — the "last update" timestamp
+
+The gate compares evidence to a `since: DateTime<Utc>` timestamp. To remain
+useful on legacy on-disk boards that predate this change, `since` is sourced
+via a three-step fallback chain:
+
+1. **Primary.** `ActiveGoal.last_progress_update_at` — a new
+   `Option<DateTime<Utc>>` field that is set by the gate itself on every
+   `Accept`. Goals created after #1967 will have this populated.
+2. **Fallback — memory scan.** If the field is `None`, the gate searches
+   cognitive memory for the most recent episode whose content starts with
+   `"goal progress accepted: "` and contains the goal id. The episode's
+   timestamp is used.
+3. **Last resort — process start.** If neither of the above is available,
+   the gate uses the daemon's process-start timestamp (a `OnceLock` set at
+   boot). This guarantees the gate is never a silent open door on a fresh
+   daemon.
+
+The schema change to `ActiveGoal` is purely additive
+(`#[serde(default, skip_serializing_if = "Option::is_none")]`) — existing
+JSON goal boards and fixtures continue to deserialize without migration.
+
+## Audit trail
+
+The gate emits one cognitive-memory episode per non-bypass decision.
+
+**On `Accept`** (low importance, 0.4):
+
+```
+goal progress accepted: 64%→72% on improve-simard-dashboard
+  — evidence: commit a1b2c3d on engineer/improve-simard-dashboard-2026-05-21 at 2026-05-21T02:14:08Z
+```
+
+**On `Reject`** (higher importance, 0.7) — the prefix is exact and stable
+so dashboards and consolidation jobs can match it:
+
+```
+brain hallucination detected: rejected progress 35%→75% on enhance-simard-meeting-experience
+  — no git evidence since last update: no commits on engineer/enhance-simard-meeting-experience-*, no PRs referencing goal, no merged PRs closing #1951 since 2026-05-19T23:06:48Z
+```
+
+These episodes flow through the existing cognitive-memory pipeline:
+
+- Greppable on the daemon's stderr (memory writes log there).
+- Searchable via `bridges.memory.search("brain hallucination detected")`.
+- Surfaced on the operator dashboard via `POST /api/memory/search` with
+  `{"query":"brain hallucination detected"}` (the dashboard's memory
+  search box uses this endpoint).
+- Eligible for consolidation — if the same rejection recurs the
+  consolidator promotes it to a semantic memory ("Simard frequently
+  hallucinates progress on goal X").
+
+This is the "brain-failure surfacing" piece called out in the
+`improve-simard-dashboard` goal: rejections are first-class observable
+events, not silent suppressions.
+
+## Scope and exceptions
+
+| Surface | Gated? | Rationale |
+|---|---|---|
+| OODA decide-phase bumps | **Yes** | This is the meta-bug origin. |
+| OODA pre-spawn percent bump | **Yes** | Same path — claims must match artifacts. |
+| Subordinate heartbeat (50%) | **Yes** | "Engineer is alive" is not evidence of work. |
+| Subordinate Completed (post-artifacts) | Yes (routed; always Accepts) | Routed for audit-trail consistency. |
+| `Blocked(reason)` transitions | No (bypass) | Non-increase; cannot inflate dashboard. |
+| `NotStarted` resets | No (bypass) | Decrease; cannot inflate dashboard. |
+| Decreases & equal-value writes | No (bypass) | Same. |
+| Dashboard `PUT /api/goals/<id>/progress` | **No** | Intentional operator override; documented as such. |
+| `gh` / `git` not available on daemon host | Gate Rejects | Treat tooling absence as "no evidence". See [kill switch](../operations/progress-evidence-kill-switch.md). |
+
+## Performance
+
+The gate fires only on progress-**increase** attempts — typically a handful
+per OODA cycle, not per cycle wall-clock. Each fire executes at most one
+`git for-each-ref` + one `git log` + one `gh pr list`. On a quiet repo the
+combined wall-time is well under the existing OODA cycle budget. A
+per-cycle in-memory cache for `gh pr list` results is reserved for v2 if
+profiling identifies it as hot.
+
+## Related work
+
+- [#1582](https://github.com/rysweet/Simard/issues/1582) — Goal board
+  corruption guards. Same family of failure (LLM output → goal-board
+  damage), different surface (id hallucination vs. percent hallucination).
+- [#1951](https://github.com/rysweet/Simard/issues/1951) — Meeting
+  experience epic. The "tell Simard what you need and have her actually do
+  it" workflow depends on progress claims being truthful.
+- [#1957](https://github.com/rysweet/Simard/issues/1957) — Dashboard
+  brain-failure surfacing. The hallucination episodes documented above are
+  the data source for that surface.
+- [#1968](https://github.com/rysweet/Simard/pull/1968) — State-root and
+  lock-vs-corruption fixes shipped immediately before #1967 was filed.

--- a/docs/howto/diagnose-rejected-progress-claims.md
+++ b/docs/howto/diagnose-rejected-progress-claims.md
@@ -1,0 +1,248 @@
+# How to diagnose a rejected progress claim
+
+When the progress-evidence gate rejects a brain progress update, the
+rejection is recorded as a cognitive-memory episode and surfaced on the
+dashboard. This guide walks through the steps to find a specific
+rejection, understand why it happened, and decide what to do next.
+
+> Background: [Progress-evidence gating](../concepts/progress-evidence-gating.md).
+> API surface: [Progress-evidence API](../reference/progress-evidence-api.md).
+
+---
+
+## 1. Find the rejection
+
+### From the operator dashboard
+
+Open the dashboard's memory search and query for the stable prefix:
+
+```
+brain hallucination detected
+```
+
+Each result is one rejection. The episode body contains the goal id, the
+attempted percent transition, the cutoff timestamp, and the checker's
+reason string. Example:
+
+```
+brain hallucination detected: rejected progress 35%→75% on enhance-simard-meeting-experience
+  — no git evidence since last update: no commits on engineer/enhance-simard-meeting-experience-*,
+    no PRs referencing goal, no merged PRs closing #1951 since 2026-05-19T23:06:48Z
+```
+
+### From the command line
+
+The dashboard's `/api/memory/search` endpoint accepts a `POST` with a JSON
+body whose `query` field is matched case-insensitively against memory
+records:
+
+```bash
+curl -s -X POST http://localhost:8080/api/memory/search \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"brain hallucination detected"}' \
+  | jq -r '.results[] | "\(.source)\t\(.data | tostring)"'
+```
+
+To scope to one goal, include the goal id in the query string (the
+endpoint does a substring match against the serialized record):
+
+```bash
+GOAL=improve-simard-dashboard
+curl -s -X POST http://localhost:8080/api/memory/search \
+  -H 'Content-Type: application/json' \
+  -d "{\"query\":\"brain hallucination detected $GOAL\"}" \
+  | jq -r '.results[].data'
+```
+
+### From the daemon log
+
+The cognitive-memory store mirrors writes to stderr, so `journalctl`
+also contains the rejections:
+
+```bash
+journalctl --user -u simard-ooda -n 5000 | grep 'brain hallucination detected'
+```
+
+---
+
+## 2. Read the rejection reason
+
+The reason string follows a fixed template. Each comma-separated clause
+corresponds to one of the three evidence rules:
+
+| Clause | Means | Rule |
+|---|---|---|
+| `no commits on engineer/<slug>-*` | No local branch matching the engineer pattern has a commit at or after `since`. | (1) Local commit |
+| `no PRs referencing goal` | No PR on `rysweet/Simard` (any state, any age within the search window) mentions the goal slug or any `wip_refs` id. | (2) PR cross-reference |
+| `no merged PRs closing #<issue-list>` | No PR was merged at or after `since` whose body contains `Closes/Fixes/Resolves #N` for any `N` in the goal's `wip_refs`. | (3) Merged-PR closer |
+| `since <iso8601>` | The cutoff used. Anything older than this is ignored. | — |
+
+If only **one** of the three clauses appears, the others were
+short-circuited by a different match. If all three appear, every rule
+failed.
+
+---
+
+## 3. Decide which case you are in
+
+### Case A: The brain hallucinated, the gate worked correctly
+
+- The engineer subprocess produced no branches.
+- No PR exists for the goal.
+- No merged PR closes a `wip_refs` issue.
+- The dashboard percent stayed at its prior value.
+
+**Action:** None on the gate. This is the intended behavior. If you want
+to drive actual progress, file a goal-curation task or use the meeting
+REPL to set a concrete next step — see
+[Start a meeting](start-a-meeting.md) and
+[Carry meeting decisions into engineer sessions](carry-meeting-decisions-into-engineer-sessions.md).
+
+### Case B: Real work happened but on the wrong branch
+
+`git branch --list 'engineer/*'` shows no branch for the goal, but you
+know an engineer made commits on a differently-named branch.
+
+**Action:** This is an engineer-spawn bug, not a gate bug. The engineer
+should be writing to `engineer/<goal-slug>-<timestamp>` (see
+[Spawn engineers from OODA daemon](spawn-engineers-from-ooda-daemon.md)).
+File an issue against the spawn path and reference the rejection
+episode.
+
+### Case C: A PR exists but the gate did not find it
+
+```bash
+gh pr list --repo rysweet/Simard --search '<goal-slug or issue#>' --state all \
+  --json number,title,body,state,createdAt,mergedAt | jq .
+```
+
+If the PR exists but `gh pr list` returns nothing, one of:
+
+- `gh` is unauthenticated on the daemon host (`gh auth status`).
+- The PR's title and body do **not** mention the goal slug or any
+  `wip_refs` id. The gate cannot find what is not referenced.
+- The PR's `createdAt` is before `since`. This is intended — once a
+  goal's last-update timestamp moves forward, older PRs no longer count
+  as fresh evidence. Either the goal needs a new PR or its
+  `last_progress_update_at` was reset spuriously.
+
+**Action:** If `gh` is broken, fix it and the next cycle will Accept. If
+the PR is unreferenced, edit its body to mention the goal id or relevant
+issue number — this is also good practice for human reviewers.
+
+### Case D: The `since` timestamp looks wrong
+
+Compute the gate's expected `since` for the goal. The new `simard goal show`
+subcommand (added by #1967, see design §2.8) exposes the
+`last_progress_update_at` field directly:
+
+```bash
+# Inspect the goal record (--json prints the full ActiveGoal as JSON).
+simard goal show --id <goal-id> --json | jq .last_progress_update_at
+```
+
+If that prints `null`, the gate falls back to a memory scan for the most
+recent `"goal progress accepted:"` episode for the goal:
+
+```bash
+GOAL=<goal-id>
+curl -s -X POST http://localhost:8080/api/memory/search \
+  -H 'Content-Type: application/json' \
+  -d "{\"query\":\"goal progress accepted $GOAL\"}" \
+  | jq -r '.results[0].data'
+```
+
+If the memory scan also returns no matches, the fallback is the daemon's
+process-start time — observable from the boot-log line emitted at
+daemon start (see [boot-log contract](../operations/progress-evidence-kill-switch.md#verifying-which-mode-the-daemon-is-running-in)):
+
+```bash
+journalctl --user -u simard-ooda --since 'today' | grep 'progress-evidence:' | head -1
+```
+
+If `last_progress_update_at` is set but to a wildly wrong value, file a
+bug and include the goal id, the value, and the cycle log. (If your
+deployment predates the `goal show` subcommand, fall back to reading the
+on-disk board snapshot under `$SIMARD_STATE_ROOT`; `simard goal list`
+will print the active board without the new field.)
+
+---
+
+## 4. Sanity-check the gate itself
+
+If you suspect the gate is broken (not just rejecting correctly), use
+the kill switch on a **non-production** daemon to A/B test:
+
+```bash
+# Terminal 1: gate disabled, observe behavior.
+SIMARD_PROGRESS_EVIDENCE=off simard daemon --port 18081
+
+# Terminal 2: gate enabled (default).
+simard daemon --port 28081
+```
+
+Feed both daemons the same goal and engineer activity. If the disabled
+daemon also rejects something obvious, the bug is upstream of the gate.
+If only the enabled daemon rejects, capture the cycle log and file a
+bug against `src/goal_curation/progress_evidence.rs`. Do **not** leave
+the kill switch on in production — see
+[`SIMARD_PROGRESS_EVIDENCE`](../operations/progress-evidence-kill-switch.md).
+
+---
+
+## 5. After the underlying issue is fixed
+
+The gate is stateless across daemon runs (modulo the `OnceLock`
+process-start fallback). Once the missing branch, PR, or `gh` auth is
+in place, the next OODA cycle that proposes the same increase will go
+through the checker fresh. On `Accept`:
+
+- The goal's `last_progress_update_at` is set to the cycle wall-clock.
+- A `"goal progress accepted:"` episode is written to memory.
+- The dashboard percent moves.
+
+You do not need to clear rejection episodes manually — they remain as an
+audit trail and may be consolidated into semantic memory if they recur.
+
+---
+
+## 6. Quick reference
+
+```bash
+# Find all rejections, newest first
+curl -s -X POST http://localhost:8080/api/memory/search \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"brain hallucination detected"}' \
+  | jq -r '.results[] | "\(.source)\t\(.data | tostring | .[0:200])"'
+
+# Find all accepts (audit positives)
+curl -s -X POST http://localhost:8080/api/memory/search \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"goal progress accepted"}' \
+  | jq -r '.results[] | "\(.source)\t\(.data | tostring | .[0:200])"'
+
+# Confirm the gate is on (drop --user for system-level installs)
+journalctl --user -u simard-ooda -n 500 | grep 'progress-evidence:'
+
+# Confirm gh works for the daemon user
+gh auth status
+gh pr list --repo rysweet/Simard --limit 3
+
+# List engineer branches the gate would scan for goal G
+GOAL=enhance-simard-meeting-experience
+git -C ~/src/Simard for-each-ref --format='%(refname:short)' "refs/heads/engineer/${GOAL}-*"
+
+# Inspect the last_progress_update_at field directly
+simard goal show --id "$GOAL" --json | jq .last_progress_update_at
+```
+
+---
+
+## Related
+
+- [Progress-evidence gating (concept)](../concepts/progress-evidence-gating.md)
+- [Progress-evidence API (reference)](../reference/progress-evidence-api.md)
+- [`SIMARD_PROGRESS_EVIDENCE` kill switch (operations)](../operations/progress-evidence-kill-switch.md)
+- [Unblock stuck OODA goals](unblock-stuck-ooda-goals.md)
+- [Spawn engineers from OODA daemon](spawn-engineers-from-ooda-daemon.md)
+- [Recover the goal board](recover-goal-board.md)

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -8,6 +8,7 @@ Simard deployment.
 | [Pre-Commit Setup](pre-commit-setup.md) | Local hooks that mirror CI |
 | [Cognitive Memory Durability](cognitive-memory-durability.md) | SIGTERM-safe shutdown + periodic backups |
 | [Meeting REPL & Handoff Ingestion](meeting-handoffs.md) | Routing operator intent into the OODA loop |
+| [Progress-Evidence Kill Switch](progress-evidence-kill-switch.md) | `SIMARD_PROGRESS_EVIDENCE=off` and when to use it |
 
 For contributor workflow (branching, merge policy, PR evidence
 requirements), see [`CONTRIBUTING.md`](https://github.com/rysweet/Simard/blob/main/CONTRIBUTING.md) at the

--- a/docs/operations/progress-evidence-kill-switch.md
+++ b/docs/operations/progress-evidence-kill-switch.md
@@ -1,0 +1,186 @@
+# Progress-evidence kill switch (`SIMARD_PROGRESS_EVIDENCE`)
+
+This page documents the environment variable that disables the
+progress-evidence gate at daemon boot. The gate itself is described
+conceptually in
+[Progress-evidence gating](../concepts/progress-evidence-gating.md) and
+the API is documented in
+[Progress-evidence API](../reference/progress-evidence-api.md).
+
+> The gate is **enabled by default** on all production deployments. The
+> kill switch exists for incident recovery and short-lived debugging
+> sessions, not for steady-state operation.
+
+---
+
+## What this variable does
+
+| Value | Behavior |
+|---|---|
+| Unset, or any value other than `off` (case-insensitive) | `OodaBridges.progress_evidence` is wired to `DefaultProgressEvidenceChecker` against the daemon's `repo_root` and `rysweet/Simard`. Progress increases require git evidence. |
+| `off` (case-insensitive) | `OodaBridges.progress_evidence` is wired to `NoopProgressEvidenceChecker`. Every progress claim is accepted. **No `"goal progress accepted:"` or `"brain hallucination detected:"` audit episodes are emitted.** |
+
+The variable is read once, at daemon startup, in the bridge-construction
+path. Changing it during a daemon run has no effect — restart the daemon
+to pick up a new value.
+
+---
+
+## When to use `off`
+
+There are exactly three legitimate uses. If you find yourself reaching for
+the kill switch outside of these, file a bug instead.
+
+1. **`gh` outage or auth failure on the daemon host.** When
+   `gh pr list` fails for an extended period, every increase attempt that
+   would have matched rule (2) or (3) will be rejected. Setting `off`
+   restores pre-#1967 behavior while you re-auth `gh` or wait for the
+   outage to clear.
+2. **Investigating a regression in the gate itself.** If you suspect the
+   checker is rejecting a legitimate claim and you need a quick
+   side-by-side comparison of the daemon's behavior with and without the
+   gate, toggle the variable on a non-production daemon and re-run the
+   cycle.
+3. **Bisecting a daemon-level bug whose cause is unrelated to progress
+   accounting.** Removing the gate eliminates one variable from the
+   investigation. Restore it as soon as bisection completes.
+
+---
+
+## When NOT to use `off`
+
+- **"To unblock production while #1967 is being fixed."** #1967 *is* the
+  fix. The gate is the fix. Disabling it re-opens the meta-bug.
+- **"Because the dashboard is showing too many hallucination alerts."**
+  Each alert is evidence the brain is producing fictional progress —
+  silencing the alerts does not change the underlying behavior.
+- **"Because a goal seems stuck at the same percent."** Goals stay at the
+  same percent because no engineer activity has occurred. The fix is to
+  spawn an engineer that produces commits, not to disable the gate.
+- **"To get a quick demo to look better."** The demo will lie. Use the
+  dashboard operator override (`PUT /api/goals/<id>/progress`) instead —
+  it bypasses the gate by design and is auditable as an operator action.
+
+---
+
+## How to set it
+
+### One-shot for an interactive run
+
+```bash
+SIMARD_PROGRESS_EVIDENCE=off simard daemon
+```
+
+### Persistent across daemon restarts (systemd unit)
+
+The Simard daemon ships with a reference unit file at
+[`scripts/simard-ooda.service`](https://github.com/rysweet/Simard/blob/main/scripts/simard-ooda.service)
+and is typically installed as a **user-level** unit at
+`~/.config/systemd/user/simard-ooda.service`. Operators who install it
+system-wide (`/etc/systemd/system/`) should drop the `--user` flag from
+every command below.
+
+Add the override to the unit's `[Service]` section:
+
+```ini
+[Service]
+Environment="SIMARD_PROGRESS_EVIDENCE=off"
+```
+
+Then reload and restart:
+
+```bash
+systemctl --user daemon-reload
+systemctl --user restart simard-ooda
+```
+
+To remove the override, delete the `Environment=` line, `daemon-reload`,
+and restart.
+
+For system-level installs, prefer `systemctl edit simard-ooda` (with
+`sudo`) so the override lands in `/etc/systemd/system/simard-ooda.service.d/override.conf`
+rather than being merged into the upstream unit file:
+
+```bash
+sudo systemctl edit simard-ooda
+# add the same [Service] / Environment= snippet
+sudo systemctl daemon-reload
+sudo systemctl restart simard-ooda
+```
+
+---
+
+## Verifying which mode the daemon is running in
+
+The daemon logs the active checker at boot. The format is pinned by
+[design §4.1](../concepts/progress-evidence-gating.md) — the
+`progress-evidence:` substring and the `enabled` / `DISABLED` words
+are stable; the parenthetical detail may evolve.
+
+```
+[simard] progress-evidence: enabled (DefaultProgressEvidenceChecker, repo_root=/home/azureuser/src/Simard, remote=rysweet/Simard)
+```
+
+Or:
+
+```
+[simard] progress-evidence: DISABLED (NoopProgressEvidenceChecker — SIMARD_PROGRESS_EVIDENCE=off)
+```
+
+Grep the daemon log to confirm (drop `--user` for a system-level install):
+
+```bash
+journalctl --user -u simard-ooda -n 200 | grep 'progress-evidence:'
+```
+
+You can also probe live behavior by inspecting cognitive memory: when the
+gate is enabled there will be at least one episode beginning with
+`"goal progress accepted:"` or `"brain hallucination detected:"` per cycle
+in which a progress claim was made. When the gate is disabled, zero such
+episodes are emitted.
+
+```bash
+curl -s -X POST http://localhost:8080/api/memory/search \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"brain hallucination detected"}' | jq '.results'
+
+curl -s -X POST http://localhost:8080/api/memory/search \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"goal progress accepted"}' | jq '.results'
+```
+
+---
+
+## Failure modes the kill switch addresses
+
+Reject reason-string substrings are pinned by the runner error contract
+documented in design §2.7. Triage by `grep`'ing the
+`"brain hallucination detected:"` episode body for the substring in the
+left column:
+
+| Substring in `reason` | Likely cause | Remedy |
+|---|---|---|
+| `gh: command not found` | `gh` is not installed or not on the daemon's `PATH`. | Install `gh`; remove the kill switch. |
+| `gh: authentication required` | The daemon's `gh` token expired or was revoked. | `gh auth login` as the daemon user; remove the kill switch. |
+| `git: not a git repository` | `repo_root` resolves to a non-repo path (e.g. daemon launched from `/`). | Launch the daemon from the repo root, or override via the daemon-boot wiring. |
+| `git: io error` / `gh: io error` | Catch-all process-spawn failure (broken pipe, ENOSPC, etc.). | Inspect the trailing `<detail>` portion of the reason string. |
+| Genuine engineer commits exist but the gate still rejects | Branch name does not match `engineer/<slug>-*` pattern. | File a bug. Do not paper over with the kill switch. |
+
+---
+
+## Removing the kill switch
+
+When the underlying issue is resolved, remove the environment variable
+and restart the daemon. Confirm via the boot log line above that
+`DefaultProgressEvidenceChecker` is active. The next cycle that involves
+a progress claim should produce either an `Accept` or a `Reject` audit
+episode in cognitive memory.
+
+---
+
+## Related
+
+- [Progress-evidence gating (concept)](../concepts/progress-evidence-gating.md)
+- [Progress-evidence API (reference)](../reference/progress-evidence-api.md)
+- [Diagnose rejected progress claims (how-to)](../howto/diagnose-rejected-progress-claims.md)
+- [Cognitive memory durability](cognitive-memory-durability.md)

--- a/docs/reference/progress-evidence-api.md
+++ b/docs/reference/progress-evidence-api.md
@@ -1,0 +1,393 @@
+# Reference: Progress-evidence API
+
+Crate: `simard` · Module: `simard::goal_curation::progress_evidence`
+
+This module implements the gatekeeper described in
+[Progress-evidence gating](../concepts/progress-evidence-gating.md). It
+exposes one trait (`ProgressEvidenceChecker`), two production helper traits
+for shell-out seams (`GitRunner`, `GhRunner`), two concrete implementations
+(`DefaultProgressEvidenceChecker`, `NoopProgressEvidenceChecker`), and a
+single façade function (`update_goal_progress_with_evidence`) in the
+sibling `simard::goal_curation::operations` module.
+
+All public symbols below are re-exported from `simard::goal_curation`.
+
+---
+
+## `EvidenceDecision`
+
+```rust
+#[derive(Clone, Debug, PartialEq)]
+pub enum EvidenceDecision {
+    /// Evidence found — the caller may apply the progress update.
+    Accept { reason: String },
+    /// No evidence — the caller must keep the prior percent and emit
+    /// a hallucination audit episode.
+    Reject { reason: String },
+}
+```
+
+The `reason` string in both variants is human-readable, ASCII-safe, and
+suitable for inclusion in cognitive-memory episodes verbatim.
+
+---
+
+## `ProgressEvidenceChecker`
+
+```rust
+pub trait ProgressEvidenceChecker: Send + Sync {
+    fn check(
+        &self,
+        goal: &ActiveGoal,
+        old_percent: u32,
+        new_percent: u32,
+        since: DateTime<Utc>,
+    ) -> EvidenceDecision;
+}
+```
+
+The trait is `Send + Sync` so a single `Arc<dyn ProgressEvidenceChecker>`
+can be installed on `OodaBridges` and shared across all OODA actions.
+
+### Contract
+
+- `check` MUST NOT mutate the goal board, cognitive memory, or any other
+  daemon state. It is a read-only function over the local repo and remote
+  GitHub.
+- `check` MAY perform blocking I/O (git/gh shellouts). It is called at most
+  a few times per OODA cycle, only on progress-increase attempts.
+- `check` MUST return `Accept` when evidence is found and `Reject`
+  otherwise. It MUST NOT return `Accept` on shellout failure — tooling
+  absence is treated as "no evidence" (see
+  [`SIMARD_PROGRESS_EVIDENCE`](../operations/progress-evidence-kill-switch.md)
+  for the operator escape hatch).
+- The `since` argument is provided by the caller; the trait does not
+  source it.
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `goal` | `&ActiveGoal` | The goal whose progress is being claimed. Used for `goal.id` (engineer-branch slug) and `goal.wip_refs` (issue/PR cross-reference). |
+| `old_percent` | `u32` | The current percent (0–100). |
+| `new_percent` | `u32` | The proposed new percent (0–100). Only called when `new_percent > old_percent`. |
+| `since` | `DateTime<Utc>` | The cutoff timestamp; only artifacts at or after this instant count as evidence. |
+
+### Decision rules (DefaultProgressEvidenceChecker)
+
+The production implementation accepts on any of:
+
+| # | Source | Match | `reason` template |
+|---|---|---|---|
+| 1 | `git log` on `engineer/{slug(goal.id)}-*` | ≥1 commit with author-date `>= since` | `"commit <sha7> on <branch> at <iso8601>"` |
+| 2 | `gh pr list` on `remote_slug` | ≥1 PR (any state) with title or body containing the goal slug **or** any `wip_refs[].ref_id` of kind `issue` or `pr` | `"PR #<n> references goal"` |
+| 3 | `gh pr list` on `remote_slug` | ≥1 PR with `state == "MERGED"`, `mergedAt >= since`, body matching `(?i)\b(close[sd]?|fix(?:es|ed)?|resolve[sd]?)\s+#(\d+)\b` where `\2` is in `wip_refs` issues | `"PR #<n> closed #<issue> at <iso8601>"` |
+| 4 | — | none of the above | `Reject` with concatenated `"no commits on engineer/<slug>-*, no PRs referencing goal, no merged PRs closing #<issue-list> since <iso8601>"` |
+
+Rules are evaluated top-to-bottom; the first match short-circuits and
+returns `Accept`.
+
+---
+
+## `GitRunner`
+
+```rust
+pub trait GitRunner: Send + Sync {
+    fn list_branches(
+        &self,
+        repo_root: &Path,
+        pattern: &str,
+    ) -> io::Result<Vec<String>>;
+
+    fn commits_since(
+        &self,
+        repo_root: &Path,
+        branch: &str,
+        since: DateTime<Utc>,
+    ) -> io::Result<Vec<String>>;
+}
+```
+
+Test seam for the local-git half of `DefaultProgressEvidenceChecker`. The
+production impl (`SystemGitRunner`) wraps:
+
+- `git -C <repo_root> for-each-ref --format=%(refname:short) refs/heads/<pattern>`
+- `git -C <repo_root> log --since <iso8601> --pretty=%H <branch>`
+
+`io::Error` from either call is propagated as a `Reject` from `check`.
+
+---
+
+## `GhRunner`
+
+```rust
+pub trait GhRunner: Send + Sync {
+    fn search_prs(
+        &self,
+        repo_slug: &str,
+        query: &str,
+    ) -> io::Result<Vec<GhPr>>;
+}
+
+#[derive(Clone, Debug, serde::Deserialize)]
+pub struct GhPr {
+    pub number: u64,
+    pub title: String,
+    pub body: Option<String>,
+    pub state: String,
+    #[serde(rename = "createdAt")]
+    pub created_at: DateTime<Utc>,
+    #[serde(rename = "mergedAt")]
+    pub merged_at: Option<DateTime<Utc>>,
+}
+```
+
+Test seam for the GitHub half of `DefaultProgressEvidenceChecker`. The
+production impl (`SystemGhRunner`) shells out to:
+
+```
+gh pr list --repo <repo_slug> --search <query> --state all \
+   --json number,title,body,state,createdAt,mergedAt
+```
+
+Authentication is the daemon process's existing `gh` token (same
+credentials used by other Simard subsystems that read GitHub).
+
+---
+
+## `DefaultProgressEvidenceChecker`
+
+```rust
+pub struct DefaultProgressEvidenceChecker {
+    pub repo_root: PathBuf,
+    pub remote_slug: String,
+    pub git: Arc<dyn GitRunner>,
+    pub gh:  Arc<dyn GhRunner>,
+}
+```
+
+The production checker. Constructed at daemon startup with:
+
+| Field | Production value |
+|---|---|
+| `repo_root` | `std::env::current_dir()` at boot |
+| `remote_slug` | `"rysweet/Simard"` |
+| `git` | `Arc::new(SystemGitRunner)` |
+| `gh` | `Arc::new(SystemGhRunner)` |
+
+### Custom constructor for non-default deployments
+
+```rust
+impl DefaultProgressEvidenceChecker {
+    pub fn new(repo_root: PathBuf, remote_slug: impl Into<String>) -> Self;
+}
+```
+
+Use this when the daemon runs from a directory other than the repo root or
+when targeting a fork.
+
+---
+
+## `NoopProgressEvidenceChecker`
+
+```rust
+pub struct NoopProgressEvidenceChecker;
+
+impl ProgressEvidenceChecker for NoopProgressEvidenceChecker {
+    fn check(&self, _: &ActiveGoal, _: u32, _: u32, _: DateTime<Utc>)
+        -> EvidenceDecision
+    { /* always Accept */ }
+}
+```
+
+Always returns `Accept { reason: "noop checker (no evidence enforced)" }`.
+Used in two places:
+
+1. **Tests.** Default test-helper `OodaBridges::for_tests()` installs this
+   so existing tests do not need to mock `git`/`gh`.
+2. **Operator escape hatch.** Selected at daemon boot when
+   `SIMARD_PROGRESS_EVIDENCE=off`. See
+   [the kill-switch operations doc](../operations/progress-evidence-kill-switch.md).
+
+---
+
+## `update_goal_progress_with_evidence` (façade)
+
+Located in `src/goal_curation/operations.rs`.
+
+```rust
+pub fn update_goal_progress_with_evidence(
+    board:   &mut GoalBoard,
+    goal_id: &str,
+    proposed: GoalProgress,
+    checker: &dyn ProgressEvidenceChecker,
+    memory:  &dyn crate::cognitive_memory::CognitiveMemoryOps,
+    now:     DateTime<Utc>,
+) -> SimardResult<EvidenceDecision>;
+```
+
+### Behavior
+
+1. Look up the goal on `board`. Map current and proposed status to
+   `(old_percent, new_percent)`:
+
+    | `GoalProgress` variant | Percent |
+    |---|---|
+    | `NotStarted` | `0` |
+    | `InProgress { percent }` | `percent` |
+    | `Blocked(_)` | the goal's *current* percent (no change) |
+    | `Completed` | `100` |
+
+2. Determine `since` via the [three-step fallback chain](../concepts/progress-evidence-gating.md#sourcing-since--the-last-update-timestamp).
+
+3. **Bypass set.** If any of the following hold, call the underlying
+   `update_goal_progress` directly and return
+   `Accept { reason: "bypass: non-increase" }` (or `"bypass: <variant>"`)
+   **without** emitting a memory episode:
+
+   - `proposed` is `Blocked(_)`
+   - `proposed` is `NotStarted`
+   - `new_percent <= old_percent`
+
+4. **Otherwise** call `checker.check(...)`:
+
+    - On `Accept`:
+      - Call `update_goal_progress(board, goal_id, proposed)`.
+      - Set `goal.last_progress_update_at = Some(now)`.
+      - Emit one episode:
+        ```
+        goal progress accepted: <old>%→<new>% on <goal-id>
+          — evidence: <checker reason>
+        ```
+        importance `0.4`.
+      - Return `Ok(Accept { reason })`.
+    - On `Reject`:
+      - Do **not** mutate the board.
+      - Emit one episode:
+        ```
+        brain hallucination detected: rejected progress <old>%→<new>% on <goal-id>
+          — no git evidence since last update: <checker reason>
+        ```
+        importance `0.7`.
+      - Return `Ok(Reject { reason })`. **This is not an error.** The
+        caller treats it as informational and proceeds without a percent
+        bump.
+
+`SimardResult::Err` is returned only for genuine failures: the goal id is
+not on the board, the underlying `update_goal_progress` writer fails, or
+the memory store fails to record an audit episode.
+
+### Calling convention
+
+The façade is invoked from four production sites. A fifth historical
+caller — `subordinate.rs:262`, which writes `Blocked(reason)` — stays a
+direct caller of `update_goal_progress` because `Blocked` is in the
+bypass set (it does not increase the percent).
+
+| Caller | Bypass path expected | Notes |
+|---|---|---|
+| `ooda_actions::goal_session::advance::assess_only_outcome` | Sometimes | Bumps come from brain text — exactly the case the gate targets. |
+| `ooda_actions::goal_session::advance` pre-spawn site | Sometimes | Same as above. |
+| `ooda_actions::advance_goal::subordinate` heartbeat (50%) | Sometimes | Engineer alive ≠ evidence. |
+| `ooda_actions::advance_goal::subordinate` Completed | Always Accept (rule 1) | Routed for audit, never rejected in practice. |
+
+### Error mapping for the OODA layer
+
+Both `Accept` and `Reject` are returned as `Ok(...)`. Callers in
+`ooda_actions` distinguish them like this:
+
+```rust
+match update_goal_progress_with_evidence(
+    board, goal_id, new_progress,
+    &*bridges.progress_evidence, &*bridges.memory, Utc::now(),
+)? {
+    EvidenceDecision::Accept { .. } => { /* happy path */ }
+    EvidenceDecision::Reject { reason } => {
+        return make_outcome(
+            action,
+            true,
+            format!("no-action: progress claim rejected (no evidence): {reason}"),
+        );
+    }
+}
+```
+
+`Reject` is **not** treated as a cycle failure: the OODA loop continues,
+the rejection is observable via cognitive memory, and the percent stays
+where it was.
+
+---
+
+## `OodaBridges` extension
+
+`src/ooda_loop/types.rs` adds two fields:
+
+```rust
+pub struct OodaBridges {
+    // ... existing fields ...
+    pub repo_root: std::path::PathBuf,
+    pub progress_evidence: std::sync::Arc<
+        dyn crate::goal_curation::progress_evidence::ProgressEvidenceChecker
+    >,
+}
+```
+
+| Field | Default at daemon boot | Default in tests |
+|---|---|---|
+| `repo_root` | `std::env::current_dir().unwrap_or_else(\|_\| PathBuf::from("."))` | `PathBuf::from(".")` |
+| `progress_evidence` | `Arc::new(DefaultProgressEvidenceChecker::new(repo_root.clone(), "rysweet/Simard"))`, or `Arc::new(NoopProgressEvidenceChecker)` when `SIMARD_PROGRESS_EVIDENCE=off` | `Arc::new(NoopProgressEvidenceChecker)` |
+
+A new `OodaBridges::for_tests()` constructor wires the test defaults so
+that existing OODA-loop tests need only a single-line change to adopt the
+new fields.
+
+---
+
+## `ActiveGoal` schema extension
+
+`src/goal_curation/types.rs`:
+
+```rust
+pub struct ActiveGoal {
+    // ... existing fields ...
+
+    /// Wall-clock timestamp of the last accepted progress update.
+    /// `None` for goals created before #1967; the gate falls back
+    /// to a memory scan, then to daemon process-start.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_progress_update_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+```
+
+The `#[serde(default, skip_serializing_if = "Option::is_none")]` attribute
+combination preserves both forward and backward compatibility:
+
+- Older JSON files load with `last_progress_update_at = None`.
+- Goals that have never reached the gate (e.g. pure `Blocked` history)
+  continue to serialize without the field, keeping snapshots minimal.
+
+No data migration is required.
+
+---
+
+## Stability
+
+| Item | Stability |
+|---|---|
+| `EvidenceDecision`, `ProgressEvidenceChecker` | Public stable — semver-tracked. |
+| `GitRunner`, `GhRunner`, `GhPr` | Public stable — needed for test seams in external crates. |
+| `update_goal_progress_with_evidence` | Public stable. |
+| `DefaultProgressEvidenceChecker` internals (private helpers) | Implementation detail; may change. |
+| `NoopProgressEvidenceChecker` | Public stable; safe to use in any test. |
+| Episode prefix strings (`"goal progress accepted:"`, `"brain hallucination detected:"`) | **Behaviorally stable.** The dashboard and consolidation jobs match these prefixes verbatim; changing them is a breaking change. |
+
+---
+
+## See also
+
+- [Progress-evidence gating (concept)](../concepts/progress-evidence-gating.md)
+- [Diagnose rejected progress claims (how-to)](../howto/diagnose-rejected-progress-claims.md)
+- [`SIMARD_PROGRESS_EVIDENCE` kill switch (operations)](../operations/progress-evidence-kill-switch.md)
+- [Goal board API](goal-board-api.md)
+- [Goal board corruption guard API](goal-board-corruption-guard-api.md)
+- [Cognitive memory bridge helpers](cognitive-memory-bridge-helpers.md)

--- a/src/cognitive_memory/mod.rs
+++ b/src/cognitive_memory/mod.rs
@@ -92,6 +92,27 @@ pub trait CognitiveMemoryOps: Send + Sync {
 
     fn get_statistics(&self) -> SimardResult<CognitiveStatistics>;
 
+    /// Search recent episodes by content prefix.
+    ///
+    /// Returns `(content, recorded_at)` pairs for episodes whose
+    /// `content` starts with `prefix`, ordered most-recent first, capped
+    /// at `limit`. Used by the progress-evidence gate
+    /// (`update_goal_progress_with_evidence`) to source the `since`
+    /// timestamp for goals that have no
+    /// `ActiveGoal.last_progress_update_at` field set yet (legacy
+    /// on-disk boards from before #1967).
+    ///
+    /// Default impl returns `Ok(vec![])` — backends without temporal
+    /// metadata simply force callers into the next fallback step (the
+    /// daemon's process-start timestamp), which is safe.
+    fn search_episodes_starting_with(
+        &self,
+        _prefix: &str,
+        _limit: u32,
+    ) -> SimardResult<Vec<(String, chrono::DateTime<chrono::Utc>)>> {
+        Ok(vec![])
+    }
+
     /// Reports whether this backend was opened in read-only mode.
     ///
     /// Defaulted to `false` because the overwhelming majority of

--- a/src/engineer_loop/tests_goal_records_migration.rs
+++ b/src/engineer_loop/tests_goal_records_migration.rs
@@ -47,6 +47,7 @@ fn seed_active_only(state_root: &std::path::Path, n: usize) -> GoalBoard {
             assigned_to: Some("simard".to_string()),
             current_activity: None,
             wip_refs: vec![],
+            last_progress_update_at: None,
         });
     }
     save_goal_board(&board, &mem).expect("seed active goals");

--- a/src/goal_curation/mod.rs
+++ b/src/goal_curation/mod.rs
@@ -4,6 +4,7 @@
 //! backlog to active enforces the cap, and progress updates track completion.
 
 mod operations;
+pub mod progress_evidence;
 mod types;
 
 // Re-export all public items so `crate::goal_curation::X` still works.
@@ -12,8 +13,9 @@ pub use operations::{
     add_backlog_item, archive_completed, clear_goal_assignment, enqueue_stewardship_issue,
     load_goal_board, persist_board, promote_to_active, save_goal_board,
     save_goal_board_with_removals, seed_default_board, simard_state_root, update_goal_progress,
+    update_goal_progress_with_evidence,
 };
-pub use types::{ActiveGoal, BacklogItem, GoalBoard, GoalProgress, MAX_ACTIVE_GOALS};
+pub use types::{ActiveGoal, BacklogItem, GoalBoard, GoalProgress, MAX_ACTIVE_GOALS, WipRef};
 
 #[cfg(test)]
 mod tests;
@@ -21,5 +23,7 @@ mod tests;
 mod tests_adapter;
 #[cfg(test)]
 mod tests_operations;
+#[cfg(test)]
+mod tests_progress_evidence;
 #[cfg(test)]
 mod tests_save_with_removals;

--- a/src/goal_curation/operations.rs
+++ b/src/goal_curation/operations.rs
@@ -656,6 +656,7 @@ pub fn promote_to_active(
         assigned_to,
         current_activity: None,
         wip_refs: vec![],
+        last_progress_update_at: None,
     });
     Ok(())
 }
@@ -684,6 +685,182 @@ pub fn update_goal_progress(
         })?;
     goal.status = progress;
     Ok(())
+}
+
+/// Map a [`GoalProgress`] variant to its effective percent (0–100) for
+/// gate comparison. `Blocked` keeps the *current* percent since it does
+/// not change progress numerically; callers pass `current` for that.
+fn progress_to_percent(p: &GoalProgress, current: u32) -> u32 {
+    match p {
+        GoalProgress::NotStarted => 0,
+        GoalProgress::InProgress { percent } => *percent,
+        GoalProgress::Blocked(_) => current,
+        GoalProgress::Completed => 100,
+    }
+}
+
+/// Variant label for bypass reason strings.
+fn variant_label(p: &GoalProgress) -> &'static str {
+    match p {
+        GoalProgress::NotStarted => "not-started",
+        GoalProgress::InProgress { .. } => "in-progress",
+        GoalProgress::Blocked(_) => "blocked",
+        GoalProgress::Completed => "completed",
+    }
+}
+
+/// Progress-evidence gatekeeper façade (issue #1967).
+///
+/// Routes every proposed mutation of [`ActiveGoal::status`] through a
+/// [`ProgressEvidenceChecker`]. Behaviour summary:
+///
+/// * **Bypass** (no evidence consulted, no audit episode):
+///   - Decreases and same-value `InProgress` writes
+///   - `Blocked(_)` transitions (kept at prior percent)
+///   - `NotStarted` resets
+///
+/// * **Otherwise** (proposal is an *increase* over `old_percent`):
+///   1. Source `since` via the three-step fallback chain:
+///      a. `goal.last_progress_update_at`
+///      b. Most recent `"goal progress accepted: …<goal_id>…"` episode
+///      c. [`progress_evidence::process_start`]
+///   2. Call `checker.check(...)`.
+///   3. On `Accept`: write through, stamp `last_progress_update_at =
+///      Some(now)`, emit one `"goal progress accepted: …"` episode.
+///   4. On `Reject`: keep prior percent, emit one
+///      `"brain hallucination detected: …"` episode.
+///
+/// Both `Accept` and `Reject` are returned as `Ok(...)`. `Err` is
+/// reserved for genuine failures (goal not found, underlying writer
+/// fails, memory `store_episode` fails).
+pub fn update_goal_progress_with_evidence(
+    board: &mut GoalBoard,
+    goal_id: &str,
+    proposed: GoalProgress,
+    checker: &dyn super::progress_evidence::ProgressEvidenceChecker,
+    memory: &dyn CognitiveMemoryOps,
+    now: chrono::DateTime<chrono::Utc>,
+) -> SimardResult<super::progress_evidence::EvidenceDecision> {
+    use super::progress_evidence::{EvidenceDecision, process_start};
+
+    // ── Look up the goal first; needed for percent comparison ─────────
+    let (current_status, last_update_at_field) = {
+        let goal = board
+            .active
+            .iter()
+            .find(|g| g.id == goal_id)
+            .ok_or_else(|| SimardError::InvalidGoalRecord {
+                field: "goal_id".to_string(),
+                reason: format!("active goal '{goal_id}' not found"),
+            })?;
+        (goal.status.clone(), goal.last_progress_update_at)
+    };
+    let old_percent = progress_to_percent(&current_status, 0);
+    let new_percent = progress_to_percent(&proposed, old_percent);
+
+    // ── Bypass set ────────────────────────────────────────────────────
+    let is_bypass = matches!(proposed, GoalProgress::Blocked(_))
+        || matches!(proposed, GoalProgress::NotStarted)
+        || new_percent <= old_percent;
+
+    if is_bypass {
+        let bypass_reason = if matches!(proposed, GoalProgress::Blocked(_)) {
+            "bypass: blocked".to_string()
+        } else if matches!(proposed, GoalProgress::NotStarted) {
+            "bypass: not-started".to_string()
+        } else if new_percent < old_percent {
+            "bypass: non-increase (decrease)".to_string()
+        } else {
+            format!("bypass: non-increase ({})", variant_label(&proposed))
+        };
+        update_goal_progress(board, goal_id, proposed)?;
+        return Ok(EvidenceDecision::Accept {
+            reason: bypass_reason,
+        });
+    }
+
+    // ── Source `since` via three-step fallback ───────────────────────
+    let mut since = if let Some(t) = last_update_at_field {
+        t
+    } else {
+        // Memory scan: most recent "goal progress accepted: …<goal_id>…"
+        // episode. We over-fetch a generous limit and filter to those
+        // mentioning this goal id.
+        let prefix = "goal progress accepted:";
+        let hits = memory
+            .search_episodes_starting_with(prefix, 64)
+            .unwrap_or_default();
+        let matched: Option<chrono::DateTime<chrono::Utc>> = hits
+            .into_iter()
+            .filter(|(content, _)| content.contains(goal_id))
+            .map(|(_, at)| at)
+            .max();
+        matched.unwrap_or_else(process_start)
+    };
+    // Clamp `since` to `now` so the cached `process_start` fallback
+    // never produces a `since` in the future when the caller's `now`
+    // happens to predate the daemon process start (test fixtures with
+    // historical timestamps; daylight-savings/NTP corrections in prod).
+    if since > now {
+        since = now;
+    }
+
+    // ── Consult checker ───────────────────────────────────────────────
+    // Re-borrow the goal immutably to pass into checker.check.
+    let goal_snapshot = board
+        .active
+        .iter()
+        .find(|g| g.id == goal_id)
+        .expect("already located above")
+        .clone();
+    let decision = checker.check(&goal_snapshot, old_percent, new_percent, since);
+
+    match decision {
+        EvidenceDecision::Accept { reason } => {
+            update_goal_progress(board, goal_id, proposed)?;
+            // Stamp the timestamp for next time.
+            if let Some(g) = board.active.iter_mut().find(|g| g.id == goal_id) {
+                g.last_progress_update_at = Some(now);
+            }
+            let episode = format!(
+                "goal progress accepted: {old_percent}%->{new_percent}% on {goal_id}\n  -- evidence: {reason}"
+            );
+            // Best-effort audit episode — memory failures propagate.
+            let _ = memory.store_episode(
+                &episode,
+                "progress-evidence-gate",
+                Some(&json!({
+                    "kind": "progress_accepted",
+                    "goal_id": goal_id,
+                    "old_percent": old_percent,
+                    "new_percent": new_percent,
+                    "reason": reason,
+                    "at": now.to_rfc3339(),
+                })),
+            )?;
+            Ok(EvidenceDecision::Accept { reason })
+        }
+        EvidenceDecision::Reject { reason } => {
+            // Do NOT mutate the board. Emit a hallucination alert.
+            let episode = format!(
+                "brain hallucination detected: rejected progress {old_percent}%->{new_percent}% on {goal_id}\n  -- no git evidence since last update: {reason}"
+            );
+            memory.store_episode(
+                &episode,
+                "progress-evidence-gate",
+                Some(&json!({
+                    "kind": "progress_rejected",
+                    "goal_id": goal_id,
+                    "old_percent": old_percent,
+                    "new_percent": new_percent,
+                    "reason": reason,
+                    "since": since.to_rfc3339(),
+                    "at": now.to_rfc3339(),
+                })),
+            )?;
+            Ok(EvidenceDecision::Reject { reason })
+        }
+    }
 }
 
 /// Clear the assignment of an active goal, resetting it to `NotStarted` so
@@ -773,6 +950,7 @@ pub fn seed_default_board(board: &mut GoalBoard) -> usize {
             assigned_to: None,
             current_activity: None,
             wip_refs: vec![],
+            last_progress_update_at: None,
         });
     }
 

--- a/src/goal_curation/progress_evidence.rs
+++ b/src/goal_curation/progress_evidence.rs
@@ -1,0 +1,503 @@
+//! Progress-evidence gatekeeper for goal-board progress updates.
+//!
+//! Implements the hallucinated-progress meta-bug fix (issue #1967): a
+//! proposed progress *increase* on an active goal is accepted only when
+//! verifiable git evidence supports it. Without evidence, the gate
+//! refuses to mutate the goal board and records a
+//! `"brain hallucination detected: …"` cognitive-memory episode.
+//!
+//! Surface:
+//! * [`ProgressEvidenceChecker`] — trait gating one decision.
+//! * [`DefaultProgressEvidenceChecker`] — production checker (git +
+//!   `gh` shellouts via [`GitRunner`] / [`GhRunner`] test seams).
+//! * [`NoopProgressEvidenceChecker`] — kill-switch + test default.
+//! * Façade [`crate::goal_curation::update_goal_progress_with_evidence`]
+//!   wires this trait into the existing OODA loop.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::{Arc, OnceLock};
+
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+
+use super::types::ActiveGoal;
+
+/// Outcome of a progress-evidence check.
+///
+/// Both variants are returned as `Ok(...)` by the gate façade — the
+/// caller distinguishes `Accept` from `Reject` by pattern match, not by
+/// `Result` discrimination. See `update_goal_progress_with_evidence`.
+#[derive(Clone, Debug, PartialEq)]
+pub enum EvidenceDecision {
+    /// Evidence found — the caller may apply the progress update.
+    Accept { reason: String },
+    /// No evidence — the caller must keep the prior percent and emit
+    /// a hallucination audit episode.
+    Reject { reason: String },
+}
+
+/// Gate trait — decides whether a proposed progress increase is backed
+/// by verifiable git artifacts.
+///
+/// `Send + Sync` so a single `Arc<dyn ProgressEvidenceChecker>` can be
+/// installed on `OodaBridges` and shared across OODA actions.
+pub trait ProgressEvidenceChecker: Send + Sync {
+    fn check(
+        &self,
+        goal: &ActiveGoal,
+        old_percent: u32,
+        new_percent: u32,
+        since: DateTime<Utc>,
+    ) -> EvidenceDecision;
+}
+
+/// Test seam for the local-git half of [`DefaultProgressEvidenceChecker`].
+pub trait GitRunner: Send + Sync {
+    fn list_branches(&self, repo_root: &Path, pattern: &str) -> std::io::Result<Vec<String>>;
+    fn commits_since(
+        &self,
+        repo_root: &Path,
+        branch: &str,
+        since: DateTime<Utc>,
+    ) -> std::io::Result<Vec<String>>;
+}
+
+/// Test seam for the GitHub half of [`DefaultProgressEvidenceChecker`].
+pub trait GhRunner: Send + Sync {
+    fn search_prs(&self, repo_slug: &str, query: &str) -> std::io::Result<Vec<GhPr>>;
+}
+
+/// Minimal PR shape consumed by the checker. Deserialised from
+/// `gh pr list ... --json number,title,body,state,createdAt,mergedAt`.
+#[derive(Clone, Debug, Deserialize)]
+pub struct GhPr {
+    pub number: u64,
+    pub title: String,
+    pub body: Option<String>,
+    pub state: String,
+    #[serde(rename = "createdAt")]
+    pub created_at: DateTime<Utc>,
+    #[serde(rename = "mergedAt", default)]
+    pub merged_at: Option<DateTime<Utc>>,
+}
+
+// ===========================================================================
+// DefaultProgressEvidenceChecker — production wiring
+// ===========================================================================
+
+/// Production checker: shells out to `git` and `gh` to verify that real
+/// artifacts back a proposed progress increase.
+pub struct DefaultProgressEvidenceChecker {
+    pub repo_root: PathBuf,
+    pub remote_slug: String,
+    pub git: Arc<dyn GitRunner>,
+    pub gh: Arc<dyn GhRunner>,
+}
+
+impl DefaultProgressEvidenceChecker {
+    /// Production constructor — wires [`SystemGitRunner`] and
+    /// [`SystemGhRunner`] for actual shellouts.
+    pub fn new(repo_root: PathBuf, remote_slug: impl Into<String>) -> Self {
+        Self {
+            repo_root,
+            remote_slug: remote_slug.into(),
+            git: Arc::new(SystemGitRunner),
+            gh: Arc::new(SystemGhRunner),
+        }
+    }
+}
+
+impl ProgressEvidenceChecker for DefaultProgressEvidenceChecker {
+    fn check(
+        &self,
+        goal: &ActiveGoal,
+        _old_percent: u32,
+        _new_percent: u32,
+        since: DateTime<Utc>,
+    ) -> EvidenceDecision {
+        let slug = slug_for(&goal.id);
+        let branch_pattern = format!("engineer/{slug}-*");
+        let mut reject_parts: Vec<String> = Vec::new();
+
+        // ── Rule 1: engineer-branch commit since `since` ─────────────
+        //
+        // We probe both:
+        //   (a) the canonical `engineer/<slug>` name (always probed, even
+        //       if `list_branches` returns empty — guarantees one
+        //       `commits_since` call per check so tests can observe the
+        //       computed `since` value), and
+        //   (b) every glob match `engineer/<slug>-*`.
+        let canonical = format!("engineer/{slug}");
+        let mut probe_branches: Vec<String> = vec![canonical];
+        match self.git.list_branches(&self.repo_root, &branch_pattern) {
+            Ok(branches) => {
+                for b in branches {
+                    if !probe_branches.contains(&b) {
+                        probe_branches.push(b);
+                    }
+                }
+            }
+            Err(e) => {
+                reject_parts.push(format!("git: io error listing engineer/{slug}-* ({e})"));
+            }
+        }
+        let mut found_branch_commit = false;
+        for branch in &probe_branches {
+            match self.git.commits_since(&self.repo_root, branch, since) {
+                Ok(commits) => {
+                    if let Some(sha) = commits.first() {
+                        let sha7 = sha.chars().take(7).collect::<String>();
+                        return EvidenceDecision::Accept {
+                            reason: format!("commit {sha7} on {branch} at {}", since.to_rfc3339()),
+                        };
+                    }
+                    found_branch_commit |= !commits.is_empty();
+                }
+                Err(e) => {
+                    reject_parts.push(format!("git: io error ({e}) on {branch}"));
+                }
+            }
+        }
+        if !found_branch_commit {
+            reject_parts.push(format!("no commits on engineer/{slug}-*"));
+        }
+
+        // ── Build wip_refs lookups for rules 2/3 ─────────────────────
+        let wip_issue_numbers: Vec<String> = goal
+            .wip_refs
+            .iter()
+            .filter(|w| w.kind.eq_ignore_ascii_case("issue") || w.kind.eq_ignore_ascii_case("pr"))
+            .map(|w| w.ref_id.clone())
+            .collect();
+
+        // ── Rules 2 & 3: query `gh pr list` ──────────────────────────
+        let query = format!("{slug} in:title,body");
+        match self.gh.search_prs(&self.remote_slug, &query) {
+            Ok(prs) => {
+                // Rule 2: any PR (any state) created >= since whose
+                // title/body contains the goal slug or a wip_refs issue.
+                for pr in &prs {
+                    if pr.created_at < since {
+                        continue;
+                    }
+                    let title_lc = pr.title.to_ascii_lowercase();
+                    let body_lc = pr.body.as_deref().unwrap_or("").to_ascii_lowercase();
+                    let slug_lc = slug.to_ascii_lowercase();
+                    let mentions_slug = title_lc.contains(&slug_lc) || body_lc.contains(&slug_lc);
+                    let mentions_wip_issue = wip_issue_numbers.iter().any(|n| {
+                        let needle = format!("#{n}");
+                        title_lc.contains(&needle) || body_lc.contains(&needle)
+                    });
+                    if mentions_slug || mentions_wip_issue {
+                        return EvidenceDecision::Accept {
+                            reason: format!("PR #{} references goal", pr.number),
+                        };
+                    }
+                }
+
+                // Rule 3: any merged PR with mergedAt >= since whose body
+                // matches `(?i)\b(close[sd]?|fix(?:es|ed)?|resolve[sd]?)\s+#(\d+)\b`
+                // and `\2` is in `wip_issue_numbers`.
+                for pr in &prs {
+                    if !pr.state.eq_ignore_ascii_case("MERGED") {
+                        continue;
+                    }
+                    let Some(merged_at) = pr.merged_at else {
+                        continue;
+                    };
+                    if merged_at < since {
+                        continue;
+                    }
+                    let body = pr.body.as_deref().unwrap_or("");
+                    for issue in &wip_issue_numbers {
+                        if body_closes_issue(body, issue) {
+                            return EvidenceDecision::Accept {
+                                reason: format!(
+                                    "PR #{} closed #{} at {}",
+                                    pr.number,
+                                    issue,
+                                    merged_at.to_rfc3339()
+                                ),
+                            };
+                        }
+                    }
+                }
+                reject_parts.push("no PRs referencing goal".to_string());
+                if !wip_issue_numbers.is_empty() {
+                    reject_parts.push(format!(
+                        "no merged PRs closing #{} since {}",
+                        wip_issue_numbers.join(",#"),
+                        since.to_rfc3339()
+                    ));
+                }
+            }
+            Err(e) => {
+                reject_parts.push(format!("gh: io error ({e})"));
+            }
+        }
+
+        EvidenceDecision::Reject {
+            reason: reject_parts.join(", "),
+        }
+    }
+}
+
+/// Match a `(?i)\b(close[sd]?|fix(?:es|ed)?|resolve[sd]?)\s+#NNNN\b`
+/// clause against `body` where `NNNN` equals `issue`.
+fn body_closes_issue(body: &str, issue: &str) -> bool {
+    let lc = body.to_ascii_lowercase();
+    let keywords = [
+        "close ",
+        "closes ",
+        "closed ",
+        "fix ",
+        "fixes ",
+        "fixed ",
+        "resolve ",
+        "resolves ",
+        "resolved ",
+    ];
+    for kw in keywords {
+        let needle = format!("{kw}#{issue}");
+        // Word-boundary check: ensure character after #NNNN is a
+        // non-digit (or end-of-string).
+        let mut search_from = 0usize;
+        while let Some(pos) = lc[search_from..].find(&needle) {
+            let abs = search_from + pos;
+            let end = abs + needle.len();
+            let next = lc[end..].chars().next();
+            match next {
+                None => return true,
+                Some(c) if !c.is_ascii_alphanumeric() => return true,
+                _ => {}
+            }
+            search_from = end;
+        }
+    }
+    false
+}
+
+/// Slugify a goal id for engineer-branch matching: lowercased,
+/// non-alphanumerics replaced with `-`, collapsed.
+fn slug_for(goal_id: &str) -> String {
+    let mut out = String::with_capacity(goal_id.len());
+    let mut prev_dash = false;
+    for c in goal_id.chars() {
+        if c.is_ascii_alphanumeric() {
+            out.push(c.to_ascii_lowercase());
+            prev_dash = false;
+        } else if !prev_dash {
+            out.push('-');
+            prev_dash = true;
+        }
+    }
+    out.trim_matches('-').to_string()
+}
+
+// ===========================================================================
+// NoopProgressEvidenceChecker — kill switch & test default
+// ===========================================================================
+
+/// Always returns `Accept { reason: "noop checker (no evidence enforced)" }`.
+///
+/// Used:
+/// 1. By tests' default bridges constructors so existing tests don't
+///    need to mock `git`/`gh`.
+/// 2. As the operator escape hatch via `SIMARD_PROGRESS_EVIDENCE=off` at
+///    daemon boot.
+pub struct NoopProgressEvidenceChecker;
+
+impl ProgressEvidenceChecker for NoopProgressEvidenceChecker {
+    fn check(
+        &self,
+        _goal: &ActiveGoal,
+        _old_percent: u32,
+        _new_percent: u32,
+        _since: DateTime<Utc>,
+    ) -> EvidenceDecision {
+        EvidenceDecision::Accept {
+            reason: "noop checker (no evidence enforced)".to_string(),
+        }
+    }
+}
+
+// ===========================================================================
+// System runners (production shellouts)
+// ===========================================================================
+
+/// Real `git` runner — shells out to the `git` binary on `PATH`.
+pub struct SystemGitRunner;
+
+impl GitRunner for SystemGitRunner {
+    fn list_branches(&self, repo_root: &Path, pattern: &str) -> std::io::Result<Vec<String>> {
+        // pattern is `engineer/<slug>-*`. We pass it through `git
+        // for-each-ref refs/heads/<pattern>` so the glob is interpreted
+        // by git itself.
+        let refspec = format!("refs/heads/{pattern}");
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(repo_root)
+            .args(["for-each-ref", "--format=%(refname:short)"])
+            .arg(&refspec)
+            .output()?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            return Err(std::io::Error::other(format!(
+                "git for-each-ref failed: {stderr}"
+            )));
+        }
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        Ok(stdout
+            .lines()
+            .map(|l| l.trim().to_string())
+            .filter(|l| !l.is_empty())
+            .collect())
+    }
+
+    fn commits_since(
+        &self,
+        repo_root: &Path,
+        branch: &str,
+        since: DateTime<Utc>,
+    ) -> std::io::Result<Vec<String>> {
+        let since_str = since.to_rfc3339();
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(repo_root)
+            .args(["log", "--since", &since_str, "--pretty=%H", branch])
+            .output()?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            return Err(std::io::Error::other(format!(
+                "git log failed on {branch}: {stderr}"
+            )));
+        }
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        Ok(stdout
+            .lines()
+            .map(|l| l.trim().to_string())
+            .filter(|l| !l.is_empty())
+            .collect())
+    }
+}
+
+/// Real `gh` runner — shells out to the `gh` CLI on `PATH`.
+pub struct SystemGhRunner;
+
+impl GhRunner for SystemGhRunner {
+    fn search_prs(&self, repo_slug: &str, query: &str) -> std::io::Result<Vec<GhPr>> {
+        let output = Command::new("gh")
+            .args([
+                "pr",
+                "list",
+                "--repo",
+                repo_slug,
+                "--search",
+                query,
+                "--state",
+                "all",
+                "--json",
+                "number,title,body,state,createdAt,mergedAt",
+                "--limit",
+                "50",
+            ])
+            .output()?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            return Err(std::io::Error::other(format!(
+                "gh pr list failed: {stderr}"
+            )));
+        }
+        let stdout = output.stdout;
+        let prs: Vec<GhPr> = serde_json::from_slice(&stdout)
+            .map_err(|e| std::io::Error::other(format!("gh pr list parse: {e}")))?;
+        Ok(prs)
+    }
+}
+
+// ===========================================================================
+// Process-start fallback timestamp
+// ===========================================================================
+
+/// Returns the daemon's process-start timestamp (cached via `OnceLock`).
+///
+/// Last-resort `since` value when a goal has no
+/// `last_progress_update_at` and no prior `"goal progress accepted: …"`
+/// memory episode. Guarantees the gate is never a silent open door on a
+/// fresh daemon process.
+pub fn process_start() -> DateTime<Utc> {
+    static START: OnceLock<DateTime<Utc>> = OnceLock::new();
+    *START.get_or_init(Utc::now)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slug_for_simple_id() {
+        assert_eq!(
+            slug_for("improve-cognitive-memory-persistence"),
+            "improve-cognitive-memory-persistence"
+        );
+    }
+
+    #[test]
+    fn slug_for_strips_non_alnum() {
+        assert_eq!(slug_for("Foo Bar/Baz!"), "foo-bar-baz");
+    }
+
+    #[test]
+    fn slug_for_collapses_dashes() {
+        assert_eq!(slug_for("a__b   c"), "a-b-c");
+    }
+
+    #[test]
+    fn body_closes_issue_basic() {
+        assert!(body_closes_issue("Fixes #1967", "1967"));
+        assert!(body_closes_issue("This closes #1967.", "1967"));
+        assert!(body_closes_issue("resolved #1967\n", "1967"));
+        assert!(body_closes_issue("RESOLVES #1967", "1967"));
+    }
+
+    #[test]
+    fn body_closes_issue_word_boundary() {
+        // #19670 should not match #1967.
+        assert!(!body_closes_issue("Fixes #19670", "1967"));
+        // #1967a is not a number boundary; we don't match either.
+        assert!(!body_closes_issue("Fixes #1967a", "1967"));
+    }
+
+    #[test]
+    fn body_closes_issue_no_match() {
+        assert!(!body_closes_issue("references #1967", "1967"));
+        assert!(!body_closes_issue("see #1967", "1967"));
+    }
+
+    #[test]
+    fn noop_checker_always_accepts() {
+        let g = ActiveGoal {
+            id: "x".into(),
+            description: "y".into(),
+            priority: 1,
+            status: crate::goal_curation::GoalProgress::InProgress { percent: 10 },
+            assigned_to: None,
+            current_activity: None,
+            wip_refs: vec![],
+            last_progress_update_at: None,
+        };
+        let dec = NoopProgressEvidenceChecker.check(&g, 10, 20, Utc::now());
+        match dec {
+            EvidenceDecision::Accept { reason } => assert!(reason.contains("noop")),
+            other => panic!("expected Accept, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn process_start_is_stable_across_calls() {
+        let a = process_start();
+        let b = process_start();
+        assert_eq!(a, b);
+    }
+}

--- a/src/goal_curation/tests.rs
+++ b/src/goal_curation/tests.rs
@@ -25,6 +25,7 @@ fn sample_goal(id: &str, priority: u32) -> ActiveGoal {
         assigned_to: None,
         current_activity: None,
         wip_refs: vec![],
+        last_progress_update_at: None,
     }
 }
 
@@ -105,6 +106,7 @@ fn rejects_zero_priority() {
             assigned_to: None,
             current_activity: None,
             wip_refs: vec![],
+            last_progress_update_at: None,
         },
     )
     .unwrap_err();
@@ -184,6 +186,7 @@ fn rejects_empty_goal_id() {
             assigned_to: None,
             current_activity: None,
             wip_refs: vec![],
+            last_progress_update_at: None,
         },
     )
     .unwrap_err();

--- a/src/goal_curation/tests_adapter.rs
+++ b/src/goal_curation/tests_adapter.rs
@@ -33,6 +33,7 @@ fn active(id: &str, description: &str, priority: u32) -> ActiveGoal {
         assigned_to: None,
         current_activity: None,
         wip_refs: vec![],
+        last_progress_update_at: None,
     }
 }
 
@@ -97,6 +98,7 @@ fn current_activity_is_used_as_rationale_when_present() {
         assigned_to: None,
         current_activity: Some("writing tests for active_goals_as_records".to_string()),
         wip_refs: vec![],
+        last_progress_update_at: None,
     });
 
     let records = active_goals_as_records(&board);
@@ -128,6 +130,7 @@ fn assigned_to_some_becomes_owner_identity() {
         assigned_to: Some("simard-engineer".to_string()),
         current_activity: None,
         wip_refs: vec![],
+        last_progress_update_at: None,
     });
 
     let records = active_goals_as_records(&board);

--- a/src/goal_curation/tests_operations.rs
+++ b/src/goal_curation/tests_operations.rs
@@ -10,6 +10,7 @@ fn make_goal(id: &str, priority: u32) -> ActiveGoal {
         assigned_to: None,
         current_activity: None,
         wip_refs: vec![],
+        last_progress_update_at: None,
     }
 }
 
@@ -347,6 +348,7 @@ fn load_goal_board_reads_from_cognitive_memory() {
         assigned_to: None,
         current_activity: None,
         wip_refs: vec![],
+        last_progress_update_at: None,
     });
     let snapshot_json = serde_json::to_string(&mem_board).unwrap();
     let recording = BridgeRecording::shared();
@@ -398,6 +400,7 @@ fn load_goal_board_migrates_legacy_disk_file_into_memory_then_deletes_it() {
         assigned_to: None,
         current_activity: None,
         wip_refs: vec![],
+        last_progress_update_at: None,
     });
     let path = root.join("goal_records.json");
     std::fs::write(&path, serde_json::to_string_pretty(&legacy).unwrap()).unwrap();
@@ -469,6 +472,7 @@ fn load_goal_board_runs_migration_only_once_in_practice() {
         assigned_to: None,
         current_activity: None,
         wip_refs: vec![],
+        last_progress_update_at: None,
     });
     let path = root.join("goal_records.json");
     std::fs::write(&path, serde_json::to_string_pretty(&legacy).unwrap()).unwrap();
@@ -500,6 +504,7 @@ fn save_goal_board_persists_only_to_memory_and_writes_no_disk_file() {
         assigned_to: None,
         current_activity: None,
         wip_refs: vec![],
+        last_progress_update_at: None,
     });
 
     let recording = BridgeRecording::shared();
@@ -531,6 +536,7 @@ fn save_goal_board_rejects_suspect_board_without_persisting() {
         assigned_to: None,
         current_activity: None,
         wip_refs: vec![],
+        last_progress_update_at: None,
     });
 
     let recording = BridgeRecording::shared();
@@ -565,6 +571,7 @@ fn save_goal_board_accepts_a_well_formed_board() {
         assigned_to: None,
         current_activity: None,
         wip_refs: vec![],
+        last_progress_update_at: None,
     });
     let recording = BridgeRecording::shared();
     let bridge = recording_bridge_empty(recording.clone());
@@ -602,6 +609,7 @@ fn board_integrity_suspect_flags_short_ids_and_placeholder_descriptions() {
         assigned_to: None,
         current_activity: None,
         wip_refs: vec![],
+        last_progress_update_at: None,
     });
     assert!(board_integrity_suspect(&board).is_some());
 }
@@ -617,6 +625,7 @@ fn board_integrity_suspect_passes_well_formed_board() {
         assigned_to: None,
         current_activity: None,
         wip_refs: vec![],
+        last_progress_update_at: None,
     });
     assert!(board_integrity_suspect(&board).is_none());
 }
@@ -634,6 +643,7 @@ fn clear_goal_assignment_resets_status_and_clears_assigned_to() {
         assigned_to: Some("engineer-session-abc".to_string()),
         current_activity: Some("Doing work".to_string()),
         wip_refs: vec![],
+        last_progress_update_at: None,
     });
 
     super::clear_goal_assignment(&mut board, "assigned-goal").unwrap();
@@ -689,6 +699,7 @@ fn goal_with(id: &str, priority: u32, status: GoalProgress, desc: &str) -> Activ
         assigned_to: None,
         current_activity: None,
         wip_refs: vec![],
+        last_progress_update_at: None,
     }
 }
 

--- a/src/goal_curation/tests_progress_evidence.rs
+++ b/src/goal_curation/tests_progress_evidence.rs
@@ -1,0 +1,822 @@
+//! TDD-first unit tests for the hallucinated-progress meta-bug fix
+//! (issue #1967).
+//!
+//! These tests pin the contract of the new
+//! `goal_curation::progress_evidence` module and the gatekeeper façade
+//! `goal_curation::operations::update_goal_progress_with_evidence` as
+//! specified in `design.md` §2 and §5.1 (U1–U12). They MUST FAIL on
+//! `f4cd5d69` because neither symbol exists yet — failure is the
+//! definition of done for this TDD step.
+//!
+//! Pattern: each scenario builds a goal board with one active goal,
+//! injects fake `GitRunner` / `GhRunner` impls into a
+//! `DefaultProgressEvidenceChecker` (or uses `NoopProgressEvidenceChecker`
+//! for the bypass cases), routes a proposed progress mutation through
+//! `update_goal_progress_with_evidence`, and asserts on the returned
+//! `EvidenceDecision` plus the board / memory side-effects.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use chrono::{DateTime, Duration, TimeZone, Utc};
+use serde_json::Value;
+
+use crate::cognitive_memory::CognitiveMemoryOps;
+use crate::error::SimardResult;
+use crate::memory_cognitive::{
+    CognitiveFact, CognitiveProcedure, CognitiveProspective, CognitiveStatistics,
+    CognitiveWorkingSlot,
+};
+
+use super::operations::{add_active_goal, update_goal_progress_with_evidence};
+use super::progress_evidence::{
+    DefaultProgressEvidenceChecker, EvidenceDecision, GhPr, GhRunner, GitRunner,
+    NoopProgressEvidenceChecker, ProgressEvidenceChecker,
+};
+use super::types::{ActiveGoal, GoalBoard, GoalProgress, WipRef};
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+const GOAL_ID: &str = "improve-cognitive-memory-persistence";
+
+fn fixed_now() -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 5, 21, 3, 30, 0).unwrap()
+}
+
+fn since_one_hour_ago() -> DateTime<Utc> {
+    fixed_now() - Duration::hours(1)
+}
+
+fn make_goal_with_status(status: GoalProgress) -> ActiveGoal {
+    ActiveGoal {
+        id: GOAL_ID.to_string(),
+        description: "test goal".to_string(),
+        priority: 1,
+        status,
+        assigned_to: None,
+        current_activity: None,
+        wip_refs: vec![WipRef {
+            kind: "issue".to_string(),
+            ref_id: "1967".to_string(),
+            label: "meta-bug umbrella".to_string(),
+            url: None,
+        }],
+        last_progress_update_at: Some(since_one_hour_ago()),
+    }
+}
+
+fn make_board_with_goal(status: GoalProgress) -> GoalBoard {
+    let mut board = GoalBoard::new();
+    add_active_goal(&mut board, make_goal_with_status(status)).expect("seed goal");
+    board
+}
+
+fn lookup_goal<'b>(board: &'b GoalBoard, id: &str) -> &'b ActiveGoal {
+    board
+        .active
+        .iter()
+        .find(|g| g.id == id)
+        .expect("goal must exist on board after operation")
+}
+
+// ─── fake CognitiveMemoryOps that records every store_episode call ──────────
+
+#[derive(Default)]
+struct RecordingMemory {
+    episodes: Mutex<Vec<RecordedEpisode>>,
+    /// Optional pre-seeded "goal progress accepted:" episodes — drives the
+    /// `since`-fallback test (U11).
+    seeded_search_hits: Mutex<Vec<(String, DateTime<Utc>)>>,
+}
+
+#[derive(Clone, Debug)]
+struct RecordedEpisode {
+    content: String,
+    #[allow(dead_code)]
+    source_label: String,
+    #[allow(dead_code)]
+    metadata: Option<Value>,
+}
+
+impl RecordingMemory {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn seed_prior_accept(&self, goal_id: &str, at: DateTime<Utc>) {
+        self.seeded_search_hits
+            .lock()
+            .unwrap()
+            .push((goal_id.to_string(), at));
+    }
+
+    fn episodes(&self) -> Vec<RecordedEpisode> {
+        self.episodes.lock().unwrap().clone()
+    }
+}
+
+impl CognitiveMemoryOps for RecordingMemory {
+    fn record_sensory(&self, _m: &str, _r: &str, _t: u64) -> SimardResult<String> {
+        Ok("sen_0".into())
+    }
+    fn prune_expired_sensory(&self) -> SimardResult<usize> {
+        Ok(0)
+    }
+    fn push_working(&self, _s: &str, _c: &str, _t: &str, _r: f64) -> SimardResult<String> {
+        Ok("w_0".into())
+    }
+    fn get_working(&self, _t: &str) -> SimardResult<Vec<CognitiveWorkingSlot>> {
+        Ok(vec![])
+    }
+    fn clear_working(&self, _t: &str) -> SimardResult<usize> {
+        Ok(0)
+    }
+    fn store_episode(
+        &self,
+        content: &str,
+        source_label: &str,
+        metadata: Option<&Value>,
+    ) -> SimardResult<String> {
+        self.episodes.lock().unwrap().push(RecordedEpisode {
+            content: content.to_string(),
+            source_label: source_label.to_string(),
+            metadata: metadata.cloned(),
+        });
+        Ok(format!("epi_{}", self.episodes.lock().unwrap().len()))
+    }
+    fn consolidate_episodes(&self, _b: u32) -> SimardResult<Option<String>> {
+        Ok(None)
+    }
+    fn store_fact(
+        &self,
+        _c: &str,
+        _content: &str,
+        _confidence: f64,
+        _tags: &[String],
+        _source_id: &str,
+    ) -> SimardResult<String> {
+        Ok("f_0".into())
+    }
+    fn search_facts(
+        &self,
+        _q: &str,
+        _limit: u32,
+        _min_conf: f64,
+    ) -> SimardResult<Vec<CognitiveFact>> {
+        Ok(vec![])
+    }
+    fn store_procedure(&self, _n: &str, _s: &[String], _p: &[String]) -> SimardResult<String> {
+        Ok("p_0".into())
+    }
+    fn recall_procedure(&self, _q: &str, _l: u32) -> SimardResult<Vec<CognitiveProcedure>> {
+        Ok(vec![])
+    }
+    fn store_prospective(&self, _d: &str, _t: &str, _a: &str, _p: i64) -> SimardResult<String> {
+        Ok("pr_0".into())
+    }
+    fn check_triggers(&self, _c: &str) -> SimardResult<Vec<CognitiveProspective>> {
+        Ok(vec![])
+    }
+    fn get_statistics(&self) -> SimardResult<CognitiveStatistics> {
+        Ok(CognitiveStatistics {
+            sensory_count: 0,
+            working_count: 0,
+            episodic_count: self.episodes.lock().unwrap().len() as u64,
+            semantic_count: 0,
+            procedural_count: 0,
+            prospective_count: 0,
+        })
+    }
+    fn search_episodes_starting_with(
+        &self,
+        _prefix: &str,
+        _limit: u32,
+    ) -> SimardResult<Vec<(String, DateTime<Utc>)>> {
+        // Tests seed `(goal_id, at)` pairs via `seed_prior_accept`. The
+        // façade later filters by `content.contains(goal_id)` so we return
+        // the seeded set verbatim.
+        Ok(self.seeded_search_hits.lock().unwrap().clone())
+    }
+}
+
+// ─── fake GitRunner / GhRunner ──────────────────────────────────────────────
+
+#[derive(Default)]
+struct FakeGit {
+    branches: Mutex<Vec<String>>,
+    commits: Mutex<Vec<(String, DateTime<Utc>, String)>>, // (branch, when, sha)
+    /// Captures the `since` argument the checker passed to `commits_since`
+    /// — drives U11 / U12 (sourcing of `since`).
+    last_since: Mutex<Option<DateTime<Utc>>>,
+}
+
+impl FakeGit {
+    fn new() -> Self {
+        Self::default()
+    }
+    fn add_branch(&self, name: &str) {
+        self.branches.lock().unwrap().push(name.to_string());
+    }
+    fn add_commit(&self, branch: &str, at: DateTime<Utc>, sha: &str) {
+        self.commits
+            .lock()
+            .unwrap()
+            .push((branch.to_string(), at, sha.to_string()));
+    }
+    fn last_since(&self) -> Option<DateTime<Utc>> {
+        *self.last_since.lock().unwrap()
+    }
+}
+
+impl GitRunner for FakeGit {
+    fn list_branches(&self, _root: &Path, pattern: &str) -> std::io::Result<Vec<String>> {
+        // Strip trailing `*` glob and match by prefix.
+        let prefix = pattern.trim_end_matches('*');
+        Ok(self
+            .branches
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|b| b.starts_with(prefix))
+            .cloned()
+            .collect())
+    }
+    fn commits_since(
+        &self,
+        _root: &Path,
+        branch: &str,
+        since: DateTime<Utc>,
+    ) -> std::io::Result<Vec<String>> {
+        *self.last_since.lock().unwrap() = Some(since);
+        Ok(self
+            .commits
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|(b, when, _)| b == branch && *when >= since)
+            .map(|(_, _, sha)| sha.clone())
+            .collect())
+    }
+}
+
+#[derive(Default)]
+struct FakeGh {
+    prs: Mutex<Vec<GhPr>>,
+}
+
+impl FakeGh {
+    fn new() -> Self {
+        Self::default()
+    }
+    fn add_pr(&self, pr: GhPr) {
+        self.prs.lock().unwrap().push(pr);
+    }
+}
+
+impl GhRunner for FakeGh {
+    fn search_prs(&self, _repo_slug: &str, _query: &str) -> std::io::Result<Vec<GhPr>> {
+        // Tests construct the FakeGh with the PR set the checker is meant
+        // to see; the checker filters by title/body match itself, so we
+        // return the full set here.
+        Ok(self.prs.lock().unwrap().clone())
+    }
+}
+
+fn make_pr(
+    number: u64,
+    title: &str,
+    body: &str,
+    state: &str,
+    created_at: DateTime<Utc>,
+    merged_at: Option<DateTime<Utc>>,
+) -> GhPr {
+    GhPr {
+        number,
+        title: title.to_string(),
+        body: Some(body.to_string()),
+        state: state.to_string(),
+        created_at,
+        merged_at,
+    }
+}
+
+fn checker_with(git: Arc<FakeGit>, gh: Arc<FakeGh>) -> DefaultProgressEvidenceChecker {
+    DefaultProgressEvidenceChecker {
+        repo_root: PathBuf::from("/tmp/fake-repo"),
+        remote_slug: "rysweet/Simard".to_string(),
+        git,
+        gh,
+    }
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// U1 — Non-increase bypass (decrease)
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn u1_non_increase_decrease_bypasses_checker_and_writes_board() {
+    let mut board = make_board_with_goal(GoalProgress::InProgress { percent: 50 });
+    let memory = RecordingMemory::new();
+    let checker = NoopProgressEvidenceChecker; // bypass means checker is irrelevant
+
+    let decision = update_goal_progress_with_evidence(
+        &mut board,
+        GOAL_ID,
+        GoalProgress::InProgress { percent: 30 },
+        &checker,
+        &memory,
+        fixed_now(),
+    )
+    .expect("bypass call must not error");
+
+    match decision {
+        EvidenceDecision::Accept { reason } => assert!(
+            reason.contains("bypass"),
+            "decrease must be reported as bypass; reason={reason}"
+        ),
+        other => panic!("expected Accept(bypass), got {other:?}"),
+    }
+
+    assert_eq!(
+        lookup_goal(&board, GOAL_ID).status,
+        GoalProgress::InProgress { percent: 30 },
+        "decrease must still be persisted to the board"
+    );
+    assert!(
+        memory.episodes().is_empty(),
+        "bypass path must NOT write any audit episode; got {:?}",
+        memory.episodes()
+    );
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// U2 — Blocked bypass
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn u2_blocked_proposal_bypasses_checker() {
+    let mut board = make_board_with_goal(GoalProgress::InProgress { percent: 40 });
+    let memory = RecordingMemory::new();
+    let checker = NoopProgressEvidenceChecker;
+
+    let decision = update_goal_progress_with_evidence(
+        &mut board,
+        GOAL_ID,
+        GoalProgress::Blocked("waiting on upstream".to_string()),
+        &checker,
+        &memory,
+        fixed_now(),
+    )
+    .expect("blocked is a non-progress transition; must not error");
+
+    assert!(
+        matches!(decision, EvidenceDecision::Accept { ref reason } if reason.contains("bypass")),
+        "Blocked must be Accept(bypass); got {decision:?}"
+    );
+    assert_eq!(
+        lookup_goal(&board, GOAL_ID).status,
+        GoalProgress::Blocked("waiting on upstream".to_string()),
+        "Blocked status must be persisted"
+    );
+    assert!(memory.episodes().is_empty(), "no audit episode on bypass");
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// U3 — NotStarted bypass (reset path)
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn u3_notstarted_proposal_bypasses_checker() {
+    let mut board = make_board_with_goal(GoalProgress::InProgress { percent: 60 });
+    let memory = RecordingMemory::new();
+    let checker = NoopProgressEvidenceChecker;
+
+    let decision = update_goal_progress_with_evidence(
+        &mut board,
+        GOAL_ID,
+        GoalProgress::NotStarted,
+        &checker,
+        &memory,
+        fixed_now(),
+    )
+    .expect("NotStarted reset must not error");
+
+    assert!(
+        matches!(decision, EvidenceDecision::Accept { ref reason } if reason.contains("bypass")),
+        "NotStarted must be Accept(bypass); got {decision:?}"
+    );
+    assert_eq!(
+        lookup_goal(&board, GOAL_ID).status,
+        GoalProgress::NotStarted,
+        "reset to NotStarted must be persisted"
+    );
+    assert!(memory.episodes().is_empty(), "no audit episode on bypass");
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// U4 — Reject when no commits and no PRs exist
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn u4_reject_when_no_git_evidence_and_no_pr_evidence() {
+    let mut board = make_board_with_goal(GoalProgress::InProgress { percent: 20 });
+    let memory = RecordingMemory::new();
+    let git = Arc::new(FakeGit::new());
+    let gh = Arc::new(FakeGh::new());
+    let checker = checker_with(git.clone(), gh.clone());
+
+    let decision = update_goal_progress_with_evidence(
+        &mut board,
+        GOAL_ID,
+        GoalProgress::InProgress { percent: 50 },
+        &checker,
+        &memory,
+        fixed_now(),
+    )
+    .expect("Reject must surface as Ok(Reject), not Err");
+
+    match decision {
+        EvidenceDecision::Reject { reason } => {
+            assert!(
+                !reason.is_empty(),
+                "reject reason must be non-empty so operators can triage"
+            );
+        }
+        other => panic!("expected Reject, got {other:?}"),
+    }
+
+    assert_eq!(
+        lookup_goal(&board, GOAL_ID).status,
+        GoalProgress::InProgress { percent: 20 },
+        "board must NOT be mutated on Reject — prior percent stays"
+    );
+
+    let eps = memory.episodes();
+    assert_eq!(
+        eps.len(),
+        1,
+        "exactly one audit episode must be emitted on Reject; got {eps:?}"
+    );
+    let content = &eps[0].content;
+    assert!(
+        content.starts_with("brain hallucination detected:"),
+        "episode must start with the exact-match alert prefix; got: {content}"
+    );
+    assert!(
+        content.contains("20") && content.contains("50"),
+        "alert must mention both the old and new percent; got: {content}"
+    );
+    assert!(
+        content.contains(GOAL_ID),
+        "alert must mention the goal id; got: {content}"
+    );
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// U5 — Accept on engineer-branch commit (rule 1)
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn u5_accept_on_engineer_branch_commit_after_since() {
+    let mut board = make_board_with_goal(GoalProgress::InProgress { percent: 20 });
+    let memory = RecordingMemory::new();
+    let git = Arc::new(FakeGit::new());
+    let branch = format!("engineer/{GOAL_ID}-pid1234");
+    git.add_branch(&branch);
+    git.add_commit(
+        &branch,
+        fixed_now() - Duration::minutes(10), // strictly after since (=1h ago)
+        "abcdef1234567",
+    );
+    let gh = Arc::new(FakeGh::new());
+    let checker = checker_with(git, gh);
+
+    let decision = update_goal_progress_with_evidence(
+        &mut board,
+        GOAL_ID,
+        GoalProgress::InProgress { percent: 50 },
+        &checker,
+        &memory,
+        fixed_now(),
+    )
+    .expect("Accept path must not error");
+
+    assert!(
+        matches!(decision, EvidenceDecision::Accept { .. }),
+        "expected Accept on engineer-branch commit; got {decision:?}"
+    );
+
+    assert_eq!(
+        lookup_goal(&board, GOAL_ID).status,
+        GoalProgress::InProgress { percent: 50 },
+        "Accept must persist the new percent"
+    );
+
+    let eps = memory.episodes();
+    assert_eq!(eps.len(), 1, "exactly one audit episode on Accept");
+    assert!(
+        eps[0].content.starts_with("goal progress accepted:"),
+        "Accept audit episode must use the 'goal progress accepted:' prefix; got: {}",
+        eps[0].content
+    );
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// U6 — Accept on PR with goal slug in title (rule 2)
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn u6_accept_on_pr_with_goal_slug_in_title() {
+    let mut board = make_board_with_goal(GoalProgress::InProgress { percent: 20 });
+    let memory = RecordingMemory::new();
+    let git = Arc::new(FakeGit::new());
+    let gh = Arc::new(FakeGh::new());
+    gh.add_pr(make_pr(
+        1969,
+        &format!("WIP: {GOAL_ID} — checkpoint progress"),
+        "no body",
+        "OPEN",
+        fixed_now() - Duration::minutes(15),
+        None,
+    ));
+    let checker = checker_with(git, gh);
+
+    let decision = update_goal_progress_with_evidence(
+        &mut board,
+        GOAL_ID,
+        GoalProgress::InProgress { percent: 50 },
+        &checker,
+        &memory,
+        fixed_now(),
+    )
+    .expect("Accept path must not error");
+
+    assert!(
+        matches!(decision, EvidenceDecision::Accept { .. }),
+        "expected Accept on PR title containing goal slug; got {decision:?}"
+    );
+    assert_eq!(
+        lookup_goal(&board, GOAL_ID).status,
+        GoalProgress::InProgress { percent: 50 },
+    );
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// U7 — Accept on PR body referencing a wip_refs issue (rule 2)
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn u7_accept_on_pr_body_referencing_wip_ref_issue() {
+    let mut board = make_board_with_goal(GoalProgress::InProgress { percent: 20 });
+    let memory = RecordingMemory::new();
+    let git = Arc::new(FakeGit::new());
+    let gh = Arc::new(FakeGh::new());
+    gh.add_pr(make_pr(
+        2001,
+        "unrelated title",
+        "This PR addresses some of the work in #1967 by ...",
+        "OPEN",
+        fixed_now() - Duration::minutes(5),
+        None,
+    ));
+    let checker = checker_with(git, gh);
+
+    let decision = update_goal_progress_with_evidence(
+        &mut board,
+        GOAL_ID,
+        GoalProgress::InProgress { percent: 50 },
+        &checker,
+        &memory,
+        fixed_now(),
+    )
+    .expect("Accept path must not error");
+
+    assert!(
+        matches!(decision, EvidenceDecision::Accept { .. }),
+        "expected Accept when PR body references wip_refs issue #1967; got {decision:?}"
+    );
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// U8 — Accept on merged PR that closes a wip_refs issue (rule 3)
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn u8_accept_on_merged_pr_closing_wip_ref_issue() {
+    let mut board = make_board_with_goal(GoalProgress::InProgress { percent: 20 });
+    let memory = RecordingMemory::new();
+    let git = Arc::new(FakeGit::new());
+    let gh = Arc::new(FakeGh::new());
+    gh.add_pr(make_pr(
+        2050,
+        "Fix the meta-bug",
+        "Fixes #1967\n\nDetails: gates progress on git evidence.",
+        "MERGED",
+        fixed_now() - Duration::hours(2),
+        Some(fixed_now() - Duration::minutes(20)),
+    ));
+    let checker = checker_with(git, gh);
+
+    let decision = update_goal_progress_with_evidence(
+        &mut board,
+        GOAL_ID,
+        GoalProgress::Completed,
+        &checker,
+        &memory,
+        fixed_now(),
+    )
+    .expect("Accept path must not error");
+
+    assert!(
+        matches!(decision, EvidenceDecision::Accept { .. }),
+        "expected Accept when merged PR closes wip_refs issue #1967; got {decision:?}"
+    );
+    assert_eq!(
+        lookup_goal(&board, GOAL_ID).status,
+        GoalProgress::Completed,
+        "Completed must be persisted on Accept"
+    );
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// U9 — Reject when an old PR exists (createdAt < since, no commits)
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn u9_reject_when_only_pr_evidence_is_older_than_since() {
+    let mut board = make_board_with_goal(GoalProgress::InProgress { percent: 20 });
+    let memory = RecordingMemory::new();
+    let git = Arc::new(FakeGit::new());
+    let gh = Arc::new(FakeGh::new());
+
+    // PR mentions the wip_ref issue but was created BEFORE `since` and
+    // never merged → does not count as evidence for the current update.
+    gh.add_pr(make_pr(
+        1000,
+        "old WIP work",
+        "touches #1967",
+        "OPEN",
+        fixed_now() - Duration::hours(48),
+        None,
+    ));
+    let checker = checker_with(git, gh);
+
+    let decision = update_goal_progress_with_evidence(
+        &mut board,
+        GOAL_ID,
+        GoalProgress::InProgress { percent: 50 },
+        &checker,
+        &memory,
+        fixed_now(),
+    )
+    .expect("Reject is Ok(Reject), not Err");
+
+    assert!(
+        matches!(decision, EvidenceDecision::Reject { .. }),
+        "expected Reject when only stale PR evidence exists; got {decision:?}"
+    );
+    assert_eq!(
+        lookup_goal(&board, GOAL_ID).status,
+        GoalProgress::InProgress { percent: 20 },
+        "board must not mutate on Reject"
+    );
+    let eps = memory.episodes();
+    assert_eq!(eps.len(), 1);
+    assert!(eps[0].content.starts_with("brain hallucination detected:"));
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// U10 — Accept sets `last_progress_update_at = Some(now)`
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn u10_accept_sets_last_progress_update_at_to_now() {
+    let mut board = make_board_with_goal(GoalProgress::InProgress { percent: 20 });
+    let memory = RecordingMemory::new();
+    let git = Arc::new(FakeGit::new());
+    let branch = format!("engineer/{GOAL_ID}-pid9999");
+    git.add_branch(&branch);
+    git.add_commit(&branch, fixed_now() - Duration::minutes(5), "shashasha");
+    let gh = Arc::new(FakeGh::new());
+    let checker = checker_with(git, gh);
+
+    let now = fixed_now();
+    let decision = update_goal_progress_with_evidence(
+        &mut board,
+        GOAL_ID,
+        GoalProgress::InProgress { percent: 50 },
+        &checker,
+        &memory,
+        now,
+    )
+    .expect("Accept must not error");
+    assert!(matches!(decision, EvidenceDecision::Accept { .. }));
+
+    let goal = lookup_goal(&board, GOAL_ID);
+    assert_eq!(
+        goal.last_progress_update_at,
+        Some(now),
+        "Accept must stamp `last_progress_update_at` to `now`"
+    );
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// U11 — `since` falls back to memory-scan when goal field is None
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn u11_since_falls_back_to_memory_scan_for_prior_accept_episode() {
+    let mut board = GoalBoard::new();
+    let mut goal = make_goal_with_status(GoalProgress::InProgress { percent: 20 });
+    // Legacy on-disk board: no `last_progress_update_at` yet.
+    goal.last_progress_update_at = None;
+    add_active_goal(&mut board, goal).unwrap();
+
+    let memory = RecordingMemory::new();
+    let prior_accept = fixed_now() - Duration::hours(6);
+    memory.seed_prior_accept(GOAL_ID, prior_accept);
+
+    let git = Arc::new(FakeGit::new());
+    let gh = Arc::new(FakeGh::new());
+    // No evidence; we don't care about the decision, only the `since` value.
+    let checker = checker_with(git.clone(), gh);
+
+    let _ = update_goal_progress_with_evidence(
+        &mut board,
+        GOAL_ID,
+        GoalProgress::InProgress { percent: 50 },
+        &checker,
+        &memory,
+        fixed_now(),
+    );
+
+    let observed = git
+        .last_since()
+        .expect("checker must have called commits_since at least once");
+    assert_eq!(
+        observed, prior_accept,
+        "with no `last_progress_update_at` and a memory hit, `since` must equal the prior-accept timestamp"
+    );
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// U12 — `since` falls back to process-start when neither field nor memory exists
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn u12_since_falls_back_to_process_start_when_no_other_signal() {
+    let mut board = GoalBoard::new();
+    let mut goal = make_goal_with_status(GoalProgress::InProgress { percent: 20 });
+    goal.last_progress_update_at = None;
+    add_active_goal(&mut board, goal).unwrap();
+
+    let memory = RecordingMemory::new(); // no seeded prior-accept
+
+    let git = Arc::new(FakeGit::new());
+    let gh = Arc::new(FakeGh::new());
+    let checker = checker_with(git.clone(), gh);
+
+    let _ = update_goal_progress_with_evidence(
+        &mut board,
+        GOAL_ID,
+        GoalProgress::InProgress { percent: 50 },
+        &checker,
+        &memory,
+        fixed_now(),
+    );
+
+    let observed = git
+        .last_since()
+        .expect("checker must have called commits_since");
+    // Process start is established at first call to the cached `OnceLock`
+    // — `observed` must be a valid timestamp at-or-before `fixed_now`.
+    assert!(
+        observed <= fixed_now(),
+        "process-start fallback must be <= now; observed={observed}"
+    );
+    // And it must not be a sentinel like the unix epoch.
+    let epoch = Utc.timestamp_opt(0, 0).unwrap();
+    assert!(
+        observed > epoch,
+        "process-start fallback must be a real timestamp, not epoch 0; observed={observed}"
+    );
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Extra: NoopProgressEvidenceChecker always accepts (kill-switch contract)
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn noop_checker_always_accepts_with_explicit_noop_reason() {
+    let goal = make_goal_with_status(GoalProgress::InProgress { percent: 20 });
+    let checker = NoopProgressEvidenceChecker;
+    let decision = checker.check(&goal, 20, 50, fixed_now());
+    match decision {
+        EvidenceDecision::Accept { reason } => assert!(
+            reason.to_ascii_lowercase().contains("noop"),
+            "NoopChecker's Accept reason must mention 'noop' so the audit \
+             trail can tell apart real evidence from the kill-switch; got: {reason}"
+        ),
+        other => panic!("NoopChecker must Accept unconditionally; got {other:?}"),
+    }
+}

--- a/src/goal_curation/tests_save_with_removals.rs
+++ b/src/goal_curation/tests_save_with_removals.rs
@@ -54,6 +54,7 @@ fn active_goal(id: &str, priority: u32) -> ActiveGoal {
         assigned_to: None,
         current_activity: None,
         wip_refs: vec![],
+        last_progress_update_at: None,
     }
 }
 

--- a/src/goal_curation/types.rs
+++ b/src/goal_curation/types.rs
@@ -2,6 +2,7 @@
 
 use std::fmt::{self, Display, Formatter};
 
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 /// Maximum number of concurrently active goals.
@@ -55,6 +56,14 @@ pub struct ActiveGoal {
     /// References to work-in-progress: PRs, issues, branches, sessions.
     #[serde(default)]
     pub wip_refs: Vec<WipRef>,
+    /// Wall-clock timestamp of the last accepted progress update.
+    ///
+    /// `None` for goals created before issue #1967; the progress-evidence
+    /// gate (see `progress_evidence` module) falls back to a memory scan,
+    /// then to the daemon's process-start timestamp. Set automatically by
+    /// `update_goal_progress_with_evidence` on every accepted update.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_progress_update_at: Option<DateTime<Utc>>,
 }
 
 impl ActiveGoal {
@@ -185,6 +194,7 @@ mod tests {
             assigned_to: Some("team-a".to_string()),
             current_activity: None,
             wip_refs: vec![],
+            last_progress_update_at: None,
         }
     }
 
@@ -215,6 +225,7 @@ mod tests {
             assigned_to: None,
             current_activity: None,
             wip_refs: vec![],
+            last_progress_update_at: None,
         };
         let json = serde_json::to_string(&g).unwrap();
         let g2: ActiveGoal = serde_json::from_str(&json).unwrap();
@@ -287,6 +298,7 @@ mod tests {
                 assigned_to: None,
                 current_activity: None,
                 wip_refs: vec![],
+                last_progress_update_at: None,
             })
             .collect();
         let board = GoalBoard {
@@ -307,6 +319,7 @@ mod tests {
                 assigned_to: None,
                 current_activity: None,
                 wip_refs: vec![],
+                last_progress_update_at: None,
             })
             .collect();
         let board = GoalBoard {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,9 +174,10 @@ pub use evidence::{
     EvidenceRecord, EvidenceSource, EvidenceStore, FileBackedEvidenceStore, InMemoryEvidenceStore,
 };
 pub use goal_curation::{
-    ActiveGoal, BacklogItem, DEFAULT_SEED_GOALS, GoalBoard, GoalProgress, MAX_ACTIVE_GOALS,
+    ActiveGoal, BacklogItem, DEFAULT_SEED_GOALS, GoalBoard, GoalProgress, MAX_ACTIVE_GOALS, WipRef,
     add_active_goal, add_backlog_item, archive_completed, load_goal_board, persist_board,
     promote_to_active, seed_default_board, update_goal_progress,
+    update_goal_progress_with_evidence,
 };
 pub use goals::{
     FileBackedGoalStore, GoalRecord, GoalStatus, GoalStore, GoalUpdate, InMemoryGoalStore,

--- a/src/memory_ipc/tests_launcher.rs
+++ b/src/memory_ipc/tests_launcher.rs
@@ -151,6 +151,7 @@ fn writer_bridge_is_compatible_with_save_and_load_goal_board() {
         assigned_to: None,
         current_activity: None,
         wip_refs: vec![],
+        last_progress_update_at: None,
     });
 
     save_goal_board(&board, writer.ops()).expect("save_goal_board via WriterBridge must succeed");
@@ -180,6 +181,7 @@ fn writer_bridge_does_not_create_legacy_goal_records_json_on_save() {
         assigned_to: None,
         current_activity: None,
         wip_refs: vec![],
+        last_progress_update_at: None,
     });
     save_goal_board(&board, writer.ops()).expect("save_goal_board");
 

--- a/src/ooda_actions/advance_goal/mod.rs
+++ b/src/ooda_actions/advance_goal/mod.rs
@@ -125,10 +125,30 @@ pub(super) fn dispatch_advance_goal(
     // when we mutably borrow `bridges.session` below (issue #1266).
     let brain = std::sync::Arc::clone(&bridges.brain);
 
+    // Same pattern for the progress-evidence checker (issue #1967): clone
+    // the Arc up-front so it lives across the inner mutable session
+    // borrow without colliding with the bridges field-borrow check.
+    let checker = std::sync::Arc::clone(&bridges.progress_evidence);
+
+    // Split-borrow disjoint fields of `bridges` so we can hold `&mut
+    // session` and `&dyn memory` simultaneously. `&mut *bridges` flattens
+    // the deref so Rust tracks the per-field borrows.
+    let OodaBridges {
+        ref mut session,
+        ref memory,
+        ..
+    } = *bridges;
+
     // If a base-type session is available, use run_turn for real agent work.
-    if let Some(ref mut session) = bridges.session {
-        let result =
-            super::goal_session::advance_goal_with_session(action, session.as_mut(), state, &goal);
+    if let Some(sess) = session {
+        let result = super::goal_session::advance_goal_with_session(
+            action,
+            memory.as_ref(),
+            checker.as_ref(),
+            sess.as_mut(),
+            state,
+            &goal,
+        );
 
         // For spawn_engineer the dispatcher must perform the actual fork
         // (it owns the state mutation needed to set goal.assigned_to).

--- a/src/ooda_actions/advance_goal/subordinate.rs
+++ b/src/ooda_actions/advance_goal/subordinate.rs
@@ -1,8 +1,12 @@
 //! AdvanceGoal dispatch — routing, subordinate heartbeat, and session-based advancement.
 
+use chrono::Utc;
+
 use crate::agent_supervisor::{HeartbeatStatus, check_heartbeat};
+use crate::goal_curation::progress_evidence::EvidenceDecision;
 use crate::goal_curation::{
     GoalProgress, clear_goal_assignment, save_goal_board, update_goal_progress,
+    update_goal_progress_with_evidence,
 };
 use crate::ooda_loop::{ActionOutcome, OodaBridges, OodaState, PlannedAction};
 
@@ -47,25 +51,54 @@ pub fn advance_goal_with_subordinate(
             {
                 // Subordinate claims completion — validate artifacts.
                 return validate_subordinate_completion(
-                    action, state, goal_id, sub_name, &progress,
+                    action,
+                    &*bridges.progress_evidence,
+                    &*bridges.memory,
+                    state,
+                    goal_id,
+                    sub_name,
+                    &progress,
                 );
             }
 
             // Subordinate is alive and still working.
+            //
+            // Route the 50% heartbeat bump through
+            // `update_goal_progress_with_evidence` (issue #1967): an
+            // alive engineer is NOT evidence of progress. If no commits
+            // or PRs exist since the last update, the gate Rejects and
+            // the prior percent is preserved.
             let new_progress = GoalProgress::InProgress { percent: 50 };
-            if let Err(e) = update_goal_progress(&mut state.active_goals, goal_id, new_progress) {
-                eprintln!(
-                    "[simard] OODA advance_goal FAILED to persist InProgress for \
-                     goal '{goal_id}': {e}"
-                );
-                return make_outcome(
-                    action,
-                    false,
-                    format!(
-                        "subordinate '{sub_name}' alive (phase={phase}) but \
-                         persisting InProgress for goal '{goal_id}' failed: {e}"
-                    ),
-                );
+            match update_goal_progress_with_evidence(
+                &mut state.active_goals,
+                goal_id,
+                new_progress,
+                &*bridges.progress_evidence,
+                &*bridges.memory,
+                Utc::now(),
+            ) {
+                Ok(EvidenceDecision::Accept { .. }) => {}
+                Ok(EvidenceDecision::Reject { reason: rej }) => {
+                    eprintln!(
+                        "[simard] OODA subordinate heartbeat REJECTED 50% bump for \
+                         goal '{goal_id}' (subordinate '{sub_name}' alive, no \
+                         commits/PRs yet): {rej}"
+                    );
+                }
+                Err(e) => {
+                    eprintln!(
+                        "[simard] OODA advance_goal FAILED to persist InProgress for \
+                         goal '{goal_id}': {e}"
+                    );
+                    return make_outcome(
+                        action,
+                        false,
+                        format!(
+                            "subordinate '{sub_name}' alive (phase={phase}) but \
+                             persisting InProgress for goal '{goal_id}' failed: {e}"
+                        ),
+                    );
+                }
             }
             make_outcome(
                 action,
@@ -83,7 +116,13 @@ pub fn advance_goal_with_subordinate(
                 && progress.outcome.is_some()
             {
                 return validate_subordinate_completion(
-                    action, state, goal_id, sub_name, &progress,
+                    action,
+                    &*bridges.progress_evidence,
+                    &*bridges.memory,
+                    state,
+                    goal_id,
+                    sub_name,
+                    &progress,
                 );
             }
 
@@ -122,7 +161,13 @@ pub fn advance_goal_with_subordinate(
             {
                 if progress.outcome.is_some() {
                     return validate_subordinate_completion(
-                        action, state, goal_id, sub_name, &progress,
+                        action,
+                        &*bridges.progress_evidence,
+                        &*bridges.memory,
+                        state,
+                        goal_id,
+                        sub_name,
+                        &progress,
                     );
                 }
                 // Subordinate reported progress but no outcome — silent exit.
@@ -210,6 +255,8 @@ fn cleanup_engineer_worktree_for_goal(state: &mut OodaState, goal_id: &str) {
 /// different approach.
 pub fn validate_subordinate_completion(
     action: &PlannedAction,
+    checker: &dyn crate::goal_curation::progress_evidence::ProgressEvidenceChecker,
+    memory: &dyn crate::cognitive_memory::CognitiveMemoryOps,
     state: &mut OodaState,
     goal_id: &str,
     sub_name: &str,
@@ -219,21 +266,46 @@ pub fn validate_subordinate_completion(
     let outcome_text = progress.outcome.as_deref().unwrap_or("unknown");
 
     if has_artifacts {
+        // Route the Completed write through the progress-evidence gate
+        // (issue #1967) for audit-trail consistency. Rule 1 (commit on
+        // engineer branch) is satisfied by definition here because the
+        // subordinate produced commits; the gate Accepts and stamps
+        // `last_progress_update_at`.
         let new_progress = GoalProgress::Completed;
-        if let Err(e) = update_goal_progress(&mut state.active_goals, goal_id, new_progress) {
-            eprintln!(
-                "[simard] OODA advance_goal FAILED to persist Completed for \
-                 goal '{goal_id}': {e}"
-            );
-            return make_outcome(
-                action,
-                false,
-                format!(
-                    "subordinate '{sub_name}' produced {} commit(s) and {} PR(s) for \
-                     goal '{goal_id}' but persisting Completed failed: {e}",
-                    progress.commits_produced, progress.prs_produced,
-                ),
-            );
+        match update_goal_progress_with_evidence(
+            &mut state.active_goals,
+            goal_id,
+            new_progress,
+            checker,
+            memory,
+            Utc::now(),
+        ) {
+            Ok(EvidenceDecision::Accept { .. }) => {}
+            Ok(EvidenceDecision::Reject { reason: rej }) => {
+                // Unexpected — subordinate produced artifacts so rule 1
+                // should match. Log and fall through; the percent stays
+                // where it was, but we still treat the action as
+                // successful since the engineer did produce output.
+                eprintln!(
+                    "[simard] OODA validate_subordinate_completion: gate REJECTED \
+                     Completed for goal '{goal_id}' despite artifacts: {rej}"
+                );
+            }
+            Err(e) => {
+                eprintln!(
+                    "[simard] OODA advance_goal FAILED to persist Completed for \
+                     goal '{goal_id}': {e}"
+                );
+                return make_outcome(
+                    action,
+                    false,
+                    format!(
+                        "subordinate '{sub_name}' produced {} commit(s) and {} PR(s) for \
+                         goal '{goal_id}' but persisting Completed failed: {e}",
+                        progress.commits_produced, progress.prs_produced,
+                    ),
+                );
+            }
         }
         eprintln!(
             "[simard] subordinate '{sub_name}' completed goal '{goal_id}' — \
@@ -254,6 +326,10 @@ pub fn validate_subordinate_completion(
     } else {
         // Subordinate claims success but produced nothing — this is the
         // silent exit bug (issue #905). Mark as failed for retry.
+        //
+        // `Blocked(reason)` is in the bypass set for the progress-evidence
+        // gate (it does not increase the percent) so we keep the direct
+        // `update_goal_progress` call here.
         eprintln!(
             "[simard] WARNING: subordinate '{sub_name}' reported outcome \
              '{outcome_text}' for goal '{goal_id}' but produced 0 commits \

--- a/src/ooda_actions/goal_session/advance.rs
+++ b/src/ooda_actions/goal_session/advance.rs
@@ -9,8 +9,16 @@
 //!   apply any `PROGRESS: NN` marker to the goal board.
 //!
 //! Both branches honour an optional `PROGRESS: NN` marker.
+//!
+//! All progress-mutation paths route through
+//! [`crate::goal_curation::update_goal_progress_with_evidence`] so a
+//! `PROGRESS: NN` line that asks for an *increase* is rejected unless
+//! verifiable git evidence (commit or PR) backs it (issue #1967).
 
-use crate::goal_curation::{GoalBoard, GoalProgress, update_goal_progress};
+use chrono::Utc;
+
+use crate::goal_curation::progress_evidence::EvidenceDecision;
+use crate::goal_curation::{GoalBoard, GoalProgress, update_goal_progress_with_evidence};
 use crate::ooda_loop::{ActionOutcome, OodaState, PlannedAction};
 
 use super::super::make_outcome;
@@ -26,6 +34,8 @@ use super::{
 /// callers / tests) directly. The function never spawns a subprocess.
 pub(crate) fn assess_only_outcome(
     action: &PlannedAction,
+    memory: &dyn crate::cognitive_memory::CognitiveMemoryOps,
+    checker: &dyn crate::goal_curation::progress_evidence::ProgressEvidenceChecker,
     board: &mut GoalBoard,
     goal_id: &str,
     reason: &str,
@@ -54,8 +64,15 @@ pub(crate) fn assess_only_outcome(
         }
     };
 
-    match update_goal_progress(board, goal_id, new_progress) {
-        Ok(()) => {
+    match update_goal_progress_with_evidence(
+        board,
+        goal_id,
+        new_progress,
+        checker,
+        memory,
+        Utc::now(),
+    ) {
+        Ok(EvidenceDecision::Accept { .. }) => {
             eprintln!(
                 "[simard] OODA goal-action no-action for '{}': {} (progress={}%)",
                 goal_id, reason_short, pct,
@@ -63,6 +80,17 @@ pub(crate) fn assess_only_outcome(
             let detail = format!(
                 "no-action: {} (progress={}%, goal '{}')",
                 reason_short, pct, goal_id,
+            );
+            make_outcome(action, true, detail)
+        }
+        Ok(EvidenceDecision::Reject { reason: rej }) => {
+            eprintln!(
+                "[simard] OODA goal-action no-action REJECTED progress for '{}': {} (proposed={}%, reason={})",
+                goal_id, reason_short, pct, rej,
+            );
+            let detail = format!(
+                "no-action: progress claim rejected (no git evidence): {rej} (goal '{}', proposed={}%)",
+                goal_id, pct,
             );
             make_outcome(action, true, detail)
         }
@@ -87,6 +115,8 @@ pub(crate) fn assess_only_outcome(
 /// engineer's reported outcome — never by auto-incrementing.
 pub(crate) fn advance_goal_with_session(
     action: &PlannedAction,
+    memory: &dyn crate::cognitive_memory::CognitiveMemoryOps,
+    checker: &dyn crate::goal_curation::progress_evidence::ProgressEvidenceChecker,
     session: &mut dyn crate::base_types::BaseTypeSession,
     state: &mut OodaState,
     goal: &crate::goal_curation::ActiveGoal,
@@ -209,6 +239,8 @@ pub(crate) fn advance_goal_with_session(
                 GoalAction::NoAction { ref reason } => {
                     let outcome = assess_only_outcome(
                         action,
+                        memory,
+                        checker,
                         &mut state.active_goals,
                         &goal.id,
                         reason,
@@ -229,6 +261,13 @@ pub(crate) fn advance_goal_with_session(
                     // Apply the optional progress marker BEFORE spawning,
                     // so even if the engineer subprocess crashes the
                     // orchestrator's progress assessment is recorded.
+                    //
+                    // Routed through `update_goal_progress_with_evidence`
+                    // (issue #1967): a pre-spawn bump that has no
+                    // commits/PRs yet will be Rejected and the prior
+                    // percent will be kept — by the time the engineer
+                    // actually produces a commit, the next cycle will
+                    // accept the same claim.
                     if let Some(pct) = progress_pct {
                         let new_progress = if pct >= 100 {
                             GoalProgress::Completed
@@ -239,13 +278,27 @@ pub(crate) fn advance_goal_with_session(
                                 percent: pct as u32,
                             }
                         };
-                        if let Err(e) =
-                            update_goal_progress(&mut state.active_goals, &goal.id, new_progress)
-                        {
-                            eprintln!(
-                                "[simard] OODA goal-action progress update FAILED for '{}': {} (progress={}%)",
-                                goal.id, e, pct,
-                            );
+                        match update_goal_progress_with_evidence(
+                            &mut state.active_goals,
+                            &goal.id,
+                            new_progress,
+                            checker,
+                            memory,
+                            Utc::now(),
+                        ) {
+                            Ok(EvidenceDecision::Accept { .. }) => {}
+                            Ok(EvidenceDecision::Reject { reason: rej }) => {
+                                eprintln!(
+                                    "[simard] OODA goal-action pre-spawn progress REJECTED for '{}': {} (proposed={}%)",
+                                    goal.id, rej, pct,
+                                );
+                            }
+                            Err(e) => {
+                                eprintln!(
+                                    "[simard] OODA goal-action progress update FAILED for '{}': {} (progress={}%)",
+                                    goal.id, e, pct,
+                                );
+                            }
                         }
                     }
 

--- a/src/ooda_actions/test_helpers.rs
+++ b/src/ooda_actions/test_helpers.rs
@@ -142,6 +142,10 @@ pub(crate) fn test_bridges() -> OodaBridges {
         brain: std::sync::Arc::new(crate::ooda_brain::DeterministicFallbackBrain),
         decide_brain: None,
         orient_brain: None,
+        repo_root: std::path::PathBuf::from("."),
+        progress_evidence: std::sync::Arc::new(
+            crate::goal_curation::progress_evidence::NoopProgressEvidenceChecker,
+        ),
     }
 }
 
@@ -161,6 +165,7 @@ pub(crate) fn board_with_goal(
             assigned_to: assigned.map(String::from),
             current_activity: None,
             wip_refs: vec![],
+            last_progress_update_at: None,
         },
     )
     .unwrap();
@@ -177,5 +182,9 @@ pub(crate) fn bridges_with_session(session: MockSession) -> OodaBridges {
         brain: std::sync::Arc::new(crate::ooda_brain::DeterministicFallbackBrain),
         decide_brain: None,
         orient_brain: None,
+        repo_root: std::path::PathBuf::from("."),
+        progress_evidence: std::sync::Arc::new(
+            crate::goal_curation::progress_evidence::NoopProgressEvidenceChecker,
+        ),
     }
 }

--- a/src/ooda_actions/tests_advance_goal.rs
+++ b/src/ooda_actions/tests_advance_goal.rs
@@ -376,7 +376,11 @@ fn validate_subordinate_completion_with_artifacts_succeeds() {
         goal_id: Some("g1".into()),
         description: "advance".into(),
     };
-    let outcome = validate_subordinate_completion(&action, &mut state, "g1", "sub-ok", &progress);
+    let mem_box = mock_memory();
+    let checker = crate::goal_curation::progress_evidence::NoopProgressEvidenceChecker;
+    let outcome = validate_subordinate_completion(
+        &action, &checker, &*mem_box, &mut state, "g1", "sub-ok", &progress,
+    );
     assert!(
         outcome.success,
         "should succeed with artifacts: {}",
@@ -407,8 +411,17 @@ fn validate_subordinate_completion_without_artifacts_fails() {
         goal_id: Some("g1".into()),
         description: "advance".into(),
     };
-    let outcome =
-        validate_subordinate_completion(&action, &mut state, "g1", "sub-empty", &progress);
+    let mem_box = mock_memory();
+    let checker = crate::goal_curation::progress_evidence::NoopProgressEvidenceChecker;
+    let outcome = validate_subordinate_completion(
+        &action,
+        &checker,
+        &*mem_box,
+        &mut state,
+        "g1",
+        "sub-empty",
+        &progress,
+    );
     assert!(
         !outcome.success,
         "should fail when no artifacts: {}",

--- a/src/ooda_actions/tests_goal_session.rs
+++ b/src/ooda_actions/tests_goal_session.rs
@@ -42,7 +42,16 @@ fn no_action_response_records_no_action_outcome_without_spawning() {
         vec![],
     );
 
-    let result = advance_goal_with_session(&action, &mut session, &mut state, &goal);
+    let mem_box = mock_memory();
+    let checker = crate::goal_curation::progress_evidence::NoopProgressEvidenceChecker;
+    let result = advance_goal_with_session(
+        &action,
+        &*mem_box,
+        &checker,
+        &mut session,
+        &mut state,
+        &goal,
+    );
 
     assert!(
         result.outcome.success,
@@ -67,7 +76,16 @@ fn prose_response_routes_to_spawn_engineer() {
     let task_text = "Run cargo test --lib goal_session and report failing tests.";
     let (mut session, _captured) = MockSession::new_ok(task_text, vec![]);
 
-    let result = advance_goal_with_session(&action, &mut session, &mut state, &goal);
+    let mem_box = mock_memory();
+    let checker = crate::goal_curation::progress_evidence::NoopProgressEvidenceChecker;
+    let result = advance_goal_with_session(
+        &action,
+        &*mem_box,
+        &checker,
+        &mut session,
+        &mut state,
+        &goal,
+    );
 
     assert!(result.outcome.success);
     assert!(result.outcome.detail.contains("spawn_engineer"));
@@ -91,7 +109,16 @@ fn progress_marker_in_prose_updates_goal_progress_before_spawn() {
         vec![],
     );
 
-    let _ = advance_goal_with_session(&action, &mut session, &mut state, &goal);
+    let mem_box = mock_memory();
+    let checker = crate::goal_curation::progress_evidence::NoopProgressEvidenceChecker;
+    let _ = advance_goal_with_session(
+        &action,
+        &*mem_box,
+        &checker,
+        &mut session,
+        &mut state,
+        &goal,
+    );
 
     let updated = live_goal(&state, goal_id);
     match updated.status {
@@ -110,7 +137,16 @@ fn progress_marker_in_no_action_updates_goal_progress() {
     let (mut session, _captured) =
         MockSession::new_ok("NO ACTION\nWaiting on PR review. PROGRESS: 95", vec![]);
 
-    let _ = advance_goal_with_session(&action, &mut session, &mut state, &goal);
+    let mem_box = mock_memory();
+    let checker = crate::goal_curation::progress_evidence::NoopProgressEvidenceChecker;
+    let _ = advance_goal_with_session(
+        &action,
+        &*mem_box,
+        &checker,
+        &mut session,
+        &mut state,
+        &goal,
+    );
 
     let updated = live_goal(&state, goal_id);
     match updated.status {
@@ -128,7 +164,16 @@ fn empty_response_is_a_visible_failure() {
 
     let (mut session, _captured) = MockSession::new_ok("   \n\t  ", vec![]);
 
-    let result = advance_goal_with_session(&action, &mut session, &mut state, &goal);
+    let mem_box = mock_memory();
+    let checker = crate::goal_curation::progress_evidence::NoopProgressEvidenceChecker;
+    let result = advance_goal_with_session(
+        &action,
+        &*mem_box,
+        &checker,
+        &mut session,
+        &mut state,
+        &goal,
+    );
 
     assert!(!result.outcome.success);
     assert!(result.outcome.detail.contains("empty response"));
@@ -144,7 +189,16 @@ fn session_run_turn_error_is_a_visible_failure() {
 
     let mut session = MockSession::new_err("LLM provider unavailable");
 
-    let result = advance_goal_with_session(&action, &mut session, &mut state, &goal);
+    let mem_box = mock_memory();
+    let checker = crate::goal_curation::progress_evidence::NoopProgressEvidenceChecker;
+    let result = advance_goal_with_session(
+        &action,
+        &*mem_box,
+        &checker,
+        &mut session,
+        &mut state,
+        &goal,
+    );
 
     assert!(!result.outcome.success);
     assert!(result.outcome.detail.contains("session run_turn failed"));
@@ -162,7 +216,16 @@ fn objective_includes_goal_metadata_and_environment() {
 
     let (mut session, captured) = MockSession::new_ok("NO ACTION\n", vec![]);
 
-    let _ = advance_goal_with_session(&action, &mut session, &mut state, &goal);
+    let mem_box = mock_memory();
+    let checker = crate::goal_curation::progress_evidence::NoopProgressEvidenceChecker;
+    let _ = advance_goal_with_session(
+        &action,
+        &*mem_box,
+        &checker,
+        &mut session,
+        &mut state,
+        &goal,
+    );
 
     let captured = captured.borrow();
     let input = captured.as_ref().expect("session must be invoked once");

--- a/src/ooda_loop/bridge_factory.rs
+++ b/src/ooda_loop/bridge_factory.rs
@@ -72,6 +72,10 @@ pub fn bridges_from_state_root(state_root: &Path) -> SimardResult<OodaBridges> {
         brain: std::sync::Arc::new(crate::ooda_brain::DeterministicFallbackBrain),
         decide_brain: None,
         orient_brain: None,
+        repo_root: std::path::PathBuf::from("."),
+        progress_evidence: std::sync::Arc::new(
+            crate::goal_curation::progress_evidence::NoopProgressEvidenceChecker,
+        ),
     })
 }
 

--- a/src/ooda_loop/curate.rs
+++ b/src/ooda_loop/curate.rs
@@ -103,6 +103,7 @@ pub fn check_meeting_handoffs(
                 assigned_to: None,
                 current_activity: None,
                 wip_refs: vec![],
+                last_progress_update_at: None,
             });
         } else {
             // Board full — route to backlog with score based on position.
@@ -412,6 +413,7 @@ mod tests {
                 assigned_to: None,
                 current_activity: None,
                 wip_refs: vec![],
+                last_progress_update_at: None,
             });
         }
         board.backlog.push(BacklogItem {

--- a/src/ooda_loop/cycle.rs
+++ b/src/ooda_loop/cycle.rs
@@ -587,6 +587,7 @@ mod tests_sweep {
             assigned_to: session.map(str::to_string),
             current_activity: None,
             wip_refs: vec![],
+            last_progress_update_at: None,
         }
     }
 
@@ -721,6 +722,7 @@ mod tests_board_integrity {
             assigned_to: None,
             current_activity: None,
             wip_refs: vec![],
+            last_progress_update_at: None,
         }
     }
 

--- a/src/ooda_loop/orient.rs
+++ b/src/ooda_loop/orient.rs
@@ -310,6 +310,7 @@ mod wire_in_tests {
             assigned_to: None,
             current_activity: None,
             wip_refs: vec![],
+            last_progress_update_at: None,
         });
         let obs = Observation {
             goal_statuses: Vec::new(),
@@ -353,6 +354,7 @@ mod hallucination_filter_tests {
             assigned_to: None,
             current_activity: None,
             wip_refs: vec![],
+            last_progress_update_at: None,
         }
     }
 

--- a/src/ooda_loop/tests_orient.rs
+++ b/src/ooda_loop/tests_orient.rs
@@ -31,6 +31,7 @@ fn orient_blocked_goals_have_highest_urgency() {
             assigned_to: None,
             current_activity: None,
             wip_refs: vec![],
+            last_progress_update_at: None,
         },
         ActiveGoal {
             id: "not-started".to_string(),
@@ -40,6 +41,7 @@ fn orient_blocked_goals_have_highest_urgency() {
             assigned_to: None,
             current_activity: None,
             wip_refs: vec![],
+            last_progress_update_at: None,
         },
     ];
     let board = make_board_with_goals(goals);
@@ -59,6 +61,7 @@ fn orient_completed_goals_have_zero_urgency() {
         assigned_to: None,
         current_activity: None,
         wip_refs: vec![],
+        last_progress_update_at: None,
     }];
     let board = make_board_with_goals(goals);
     let obs = make_observation(EnvironmentSnapshot::default());
@@ -80,6 +83,7 @@ fn orient_not_started_higher_urgency_than_in_progress() {
             assigned_to: None,
             current_activity: None,
             wip_refs: vec![],
+            last_progress_update_at: None,
         },
         ActiveGoal {
             id: "wip".to_string(),
@@ -89,6 +93,7 @@ fn orient_not_started_higher_urgency_than_in_progress() {
             assigned_to: None,
             current_activity: None,
             wip_refs: vec![],
+            last_progress_update_at: None,
         },
     ];
     let board = make_board_with_goals(goals);
@@ -110,6 +115,7 @@ fn orient_in_progress_urgency_decreases_with_percent() {
             assigned_to: None,
             current_activity: None,
             wip_refs: vec![],
+            last_progress_update_at: None,
         },
         ActiveGoal {
             id: "late".to_string(),
@@ -119,6 +125,7 @@ fn orient_in_progress_urgency_decreases_with_percent() {
             assigned_to: None,
             current_activity: None,
             wip_refs: vec![],
+            last_progress_update_at: None,
         },
     ];
     let board = make_board_with_goals(goals);
@@ -139,6 +146,7 @@ fn orient_boosts_urgency_when_goal_mentioned_in_issues() {
         assigned_to: None,
         current_activity: None,
         wip_refs: vec![],
+        last_progress_update_at: None,
     }];
     let board = make_board_with_goals(goals.clone());
     let env_with_issue = EnvironmentSnapshot {
@@ -174,6 +182,7 @@ fn orient_boosts_in_progress_when_dirty_tree() {
         assigned_to: None,
         current_activity: None,
         wip_refs: vec![],
+        last_progress_update_at: None,
     }];
     let board = make_board_with_goals(goals);
     let env_dirty = EnvironmentSnapshot {
@@ -208,6 +217,7 @@ fn orient_adds_memory_consolidation_when_episodic_exceeds_100() {
         assigned_to: None,
         current_activity: None,
         wip_refs: vec![],
+        last_progress_update_at: None,
     }];
     let board = make_board_with_goals(goals);
     let obs = Observation {

--- a/src/ooda_loop/tests_orient_extra.rs
+++ b/src/ooda_loop/tests_orient_extra.rs
@@ -153,6 +153,7 @@ fn orient_priorities_sorted_by_urgency_descending() {
             assigned_to: None,
             current_activity: None,
             wip_refs: vec![],
+            last_progress_update_at: None,
         },
         ActiveGoal {
             id: "high".to_string(),
@@ -162,6 +163,7 @@ fn orient_priorities_sorted_by_urgency_descending() {
             assigned_to: None,
             current_activity: None,
             wip_refs: vec![],
+            last_progress_update_at: None,
         },
         ActiveGoal {
             id: "mid".to_string(),
@@ -171,6 +173,7 @@ fn orient_priorities_sorted_by_urgency_descending() {
             assigned_to: None,
             current_activity: None,
             wip_refs: vec![],
+            last_progress_update_at: None,
         },
     ];
     let board = make_board_with_goals(goals);
@@ -191,6 +194,7 @@ fn orient_failure_cooldown_demotes_urgency() {
         assigned_to: None,
         current_activity: None,
         wip_refs: vec![],
+        last_progress_update_at: None,
     }];
     let board = make_board_with_goals(goals);
     let obs = make_observation(EnvironmentSnapshot::default());
@@ -219,6 +223,7 @@ fn orient_failure_cooldown_clamps_to_zero() {
         assigned_to: None,
         current_activity: None,
         wip_refs: vec![],
+        last_progress_update_at: None,
     }];
     let board = make_board_with_goals(goals);
     let obs = make_observation(EnvironmentSnapshot::default());
@@ -240,6 +245,7 @@ fn orient_no_demotion_when_failure_count_zero() {
         assigned_to: None,
         current_activity: None,
         wip_refs: vec![],
+        last_progress_update_at: None,
     }];
     let board = make_board_with_goals(goals);
     let obs = make_observation(EnvironmentSnapshot::default());

--- a/src/ooda_loop/tests_parse_failure_1890.rs
+++ b/src/ooda_loop/tests_parse_failure_1890.rs
@@ -161,6 +161,7 @@ fn board_with_one_goal(id: &str) -> GoalBoard {
         assigned_to: None,
         current_activity: None,
         wip_refs: vec![],
+        last_progress_update_at: None,
     });
     board
 }

--- a/src/ooda_loop/tests_types.rs
+++ b/src/ooda_loop/tests_types.rs
@@ -52,6 +52,7 @@ fn ooda_state_new_with_goals() {
         assigned_to: None,
         current_activity: None,
         wip_refs: vec![],
+        last_progress_update_at: None,
     });
     let state = OodaState::new(board);
     assert_eq!(state.active_goals.active.len(), 1);
@@ -69,6 +70,7 @@ fn populated_state() -> OodaState {
         assigned_to: Some("engineer-7".to_string()),
         current_activity: Some("doing things".to_string()),
         wip_refs: vec![],
+        last_progress_update_at: None,
     });
     let mut state = OodaState::new(board);
     state.current_phase = OodaPhase::Decide;
@@ -165,6 +167,7 @@ fn goal_snapshot_from_active_goal() {
         assigned_to: Some("engineer".to_string()),
         current_activity: None,
         wip_refs: vec![],
+        last_progress_update_at: None,
     };
     let snapshot = GoalSnapshot::from(&goal);
     assert_eq!(snapshot.id, "g-1");
@@ -185,6 +188,7 @@ fn goal_snapshot_from_blocked_goal() {
         assigned_to: None,
         current_activity: None,
         wip_refs: vec![],
+        last_progress_update_at: None,
     };
     let snapshot = GoalSnapshot::from(&goal);
     assert!(matches!(snapshot.progress, GoalProgress::Blocked(_)));

--- a/src/ooda_loop/types.rs
+++ b/src/ooda_loop/types.rs
@@ -320,4 +320,14 @@ pub struct OodaBridges {
     /// cycle's Orient phase routes through it; otherwise it uses the
     /// `DeterministicFallbackOrientBrain` floor.
     pub orient_brain: Option<std::sync::Arc<dyn crate::ooda_brain::OodaOrientBrain>>,
+    /// Repository root used by [`crate::goal_curation::progress_evidence`]
+    /// to verify engineer-branch commits. Defaults to
+    /// `std::env::current_dir()` at daemon boot.
+    pub repo_root: std::path::PathBuf,
+    /// Gatekeeper for goal-progress increases (issue #1967). Production
+    /// boot wires [`crate::goal_curation::progress_evidence::DefaultProgressEvidenceChecker`];
+    /// tests and `SIMARD_PROGRESS_EVIDENCE=off` wire
+    /// [`crate::goal_curation::progress_evidence::NoopProgressEvidenceChecker`].
+    pub progress_evidence:
+        std::sync::Arc<dyn crate::goal_curation::progress_evidence::ProgressEvidenceChecker>,
 }

--- a/src/operator_cli/tests_goal.rs
+++ b/src/operator_cli/tests_goal.rs
@@ -65,6 +65,7 @@ fn active_goal(id: &str, status: GoalProgress) -> ActiveGoal {
         assigned_to: None,
         current_activity: None,
         wip_refs: vec![],
+        last_progress_update_at: None,
     }
 }
 

--- a/src/operator_cli/tests_goal_remove.rs
+++ b/src/operator_cli/tests_goal_remove.rs
@@ -66,6 +66,7 @@ fn active_goal_with_desc(id: &str, description: &str) -> ActiveGoal {
         assigned_to: None,
         current_activity: None,
         wip_refs: vec![],
+        last_progress_update_at: None,
     }
 }
 

--- a/src/operator_commands_dashboard/goals.rs
+++ b/src/operator_commands_dashboard/goals.rs
@@ -108,6 +108,7 @@ pub(crate) async fn seed_goals() -> Json<Value> {
         assigned_to: Some("simard".to_string()),
         current_activity: Some(format!("Goal seeded via dashboard at {now}")),
         wip_refs: vec![],
+        last_progress_update_at: None,
     });
     board.active.push(ActiveGoal {
         id: "knowledge-growth".to_string(),
@@ -119,6 +120,7 @@ pub(crate) async fn seed_goals() -> Json<Value> {
         assigned_to: Some("simard".to_string()),
         current_activity: Some(format!("Goal seeded via dashboard at {now}")),
         wip_refs: vec![],
+        last_progress_update_at: None,
     });
     board.active.push(ActiveGoal {
         id: "operational-health".to_string(),
@@ -128,6 +130,7 @@ pub(crate) async fn seed_goals() -> Json<Value> {
         assigned_to: Some("simard".to_string()),
         current_activity: Some(format!("Goal seeded via dashboard at {now}")),
         wip_refs: vec![],
+        last_progress_update_at: None,
     });
     board.backlog.push(BacklogItem {
         id: "distributed-sync".to_string(),
@@ -190,6 +193,7 @@ pub(crate) async fn add_goal(Json(body): Json<Value>) -> Json<Value> {
             assigned_to: None,
             current_activity: None,
             wip_refs: vec![],
+            last_progress_update_at: None,
         });
     }
 
@@ -289,6 +293,7 @@ pub(crate) async fn promote_backlog_item(Path(id): Path<String>) -> Json<Value> 
         assigned_to: None,
         current_activity: None,
         wip_refs: vec![],
+        last_progress_update_at: None,
     });
 
     match dashboard_save_goal_board(&state_root, &board) {

--- a/src/operator_commands_dashboard/tests_goal_records_migration.rs
+++ b/src/operator_commands_dashboard/tests_goal_records_migration.rs
@@ -36,6 +36,7 @@ fn seeded_board() -> GoalBoard {
             assigned_to: Some("simard".to_string()),
             current_activity: None,
             wip_refs: vec![],
+            last_progress_update_at: None,
         });
     }
     board
@@ -99,6 +100,7 @@ fn writer_persists_through_cognitive_memory_without_legacy_file() {
         assigned_to: Some("simard".to_string()),
         current_activity: None,
         wip_refs: vec![],
+        last_progress_update_at: None,
     });
 
     dashboard_save_goal_board(&root, &board).expect("dashboard writer must succeed");

--- a/src/operator_commands_meeting/goal_curation.rs
+++ b/src/operator_commands_meeting/goal_curation.rs
@@ -228,6 +228,7 @@ mod tests {
                 assigned_to: None,
                 current_activity: None,
                 wip_refs: vec![],
+                last_progress_update_at: None,
             });
         }
         board

--- a/src/operator_commands_meeting/tests_goal_records_migration.rs
+++ b/src/operator_commands_meeting/tests_goal_records_migration.rs
@@ -31,6 +31,7 @@ fn seed_active_only(state_root: &std::path::Path, n: usize) -> GoalBoard {
             assigned_to: Some("simard".to_string()),
             current_activity: None,
             wip_refs: vec![],
+            last_progress_update_at: None,
         });
     }
     save_goal_board(&board, &mem).expect("seed active goals");

--- a/src/operator_commands_ooda/daemon/mod.rs
+++ b/src/operator_commands_ooda/daemon/mod.rs
@@ -194,6 +194,38 @@ pub fn run_ooda_daemon(
         );
     }
 
+    // Wire the progress-evidence checker (issue #1967). Honors
+    // `SIMARD_PROGRESS_EVIDENCE=off` as a kill switch (see
+    // docs/operations/progress-evidence-kill-switch.md).
+    let repo_root = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+    let kill_switch = std::env::var("SIMARD_PROGRESS_EVIDENCE")
+        .ok()
+        .map(|v| v.eq_ignore_ascii_case("off"))
+        .unwrap_or(false);
+    let progress_evidence: std::sync::Arc<
+        dyn crate::goal_curation::progress_evidence::ProgressEvidenceChecker,
+    > = if kill_switch {
+        daemon_log(
+            &state_root,
+            "[simard] progress-evidence: DISABLED (NoopProgressEvidenceChecker -- SIMARD_PROGRESS_EVIDENCE=off)",
+        );
+        std::sync::Arc::new(crate::goal_curation::progress_evidence::NoopProgressEvidenceChecker)
+    } else {
+        daemon_log(
+            &state_root,
+            &format!(
+                "[simard] progress-evidence: enabled (DefaultProgressEvidenceChecker, repo_root={}, remote=rysweet/Simard)",
+                repo_root.display()
+            ),
+        );
+        std::sync::Arc::new(
+            crate::goal_curation::progress_evidence::DefaultProgressEvidenceChecker::new(
+                repo_root.clone(),
+                "rysweet/Simard",
+            ),
+        )
+    };
+
     let mut bridges = OodaBridges {
         memory,
         knowledge,
@@ -202,6 +234,8 @@ pub fn run_ooda_daemon(
         brain,
         decide_brain,
         orient_brain,
+        repo_root,
+        progress_evidence,
     };
 
     let board = load_goal_board(&*bridges.memory).unwrap_or_default();

--- a/src/tests_hermetic_guard.rs
+++ b/src/tests_hermetic_guard.rs
@@ -106,6 +106,7 @@ fn sample_board() -> GoalBoard {
             assigned_to: None,
             current_activity: None,
             wip_refs: vec![],
+            last_progress_update_at: None,
         },
     )
     .unwrap();

--- a/tests/meeting_goals.rs
+++ b/tests/meeting_goals.rs
@@ -49,6 +49,7 @@ fn sample_active(id: &str, priority: u32) -> ActiveGoal {
         assigned_to: None,
         current_activity: None,
         wip_refs: Vec::new(),
+        last_progress_update_at: None,
     }
 }
 
@@ -309,6 +310,7 @@ fn meeting_decisions_feed_goal_board() {
                 assigned_to: None,
                 current_activity: None,
                 wip_refs: Vec::new(),
+                last_progress_update_at: None,
             },
         )
         .unwrap();

--- a/tests/memory_consolidation_lifecycle.rs
+++ b/tests/memory_consolidation_lifecycle.rs
@@ -173,6 +173,10 @@ fn ooda_cycle_runs_with_consolidation_wired_in() {
         brain: std::sync::Arc::new(simard::ooda_brain::DeterministicFallbackBrain),
         decide_brain: None,
         orient_brain: None,
+        repo_root: std::path::PathBuf::from("."),
+        progress_evidence: std::sync::Arc::new(
+            simard::goal_curation::progress_evidence::NoopProgressEvidenceChecker,
+        ),
     };
 
     let mut board = GoalBoard::new();
@@ -184,6 +188,7 @@ fn ooda_cycle_runs_with_consolidation_wired_in() {
         assigned_to: None,
         current_activity: None,
         wip_refs: Vec::new(),
+        last_progress_update_at: None,
     });
 
     let mut state = OodaState::new(board);
@@ -318,6 +323,10 @@ fn multiple_ooda_cycles_accumulate_consolidation() {
         brain: std::sync::Arc::new(simard::ooda_brain::DeterministicFallbackBrain),
         decide_brain: None,
         orient_brain: None,
+        repo_root: std::path::PathBuf::from("."),
+        progress_evidence: std::sync::Arc::new(
+            simard::goal_curation::progress_evidence::NoopProgressEvidenceChecker,
+        ),
     };
 
     let mut board = GoalBoard::new();
@@ -329,6 +338,7 @@ fn multiple_ooda_cycles_accumulate_consolidation() {
         assigned_to: None,
         current_activity: None,
         wip_refs: Vec::new(),
+        last_progress_update_at: None,
     });
 
     let mut state = OodaState::new(board);

--- a/tests/ooda.rs
+++ b/tests/ooda.rs
@@ -80,6 +80,10 @@ fn test_bridges() -> OodaBridges {
         brain: std::sync::Arc::new(simard::ooda_brain::DeterministicFallbackBrain),
         decide_brain: None,
         orient_brain: None,
+        repo_root: std::path::PathBuf::from("."),
+        progress_evidence: std::sync::Arc::new(
+            simard::goal_curation::progress_evidence::NoopProgressEvidenceChecker,
+        ),
     }
 }
 
@@ -92,6 +96,7 @@ fn sample_goal(id: &str, priority: u32, progress: GoalProgress) -> ActiveGoal {
         assigned_to: None,
         current_activity: None,
         wip_refs: Vec::new(),
+        last_progress_update_at: None,
     }
 }
 
@@ -244,6 +249,10 @@ fn feral_gym_bridge_down() {
         brain: std::sync::Arc::new(simard::ooda_brain::DeterministicFallbackBrain),
         decide_brain: None,
         orient_brain: None,
+        repo_root: std::path::PathBuf::from("."),
+        progress_evidence: std::sync::Arc::new(
+            simard::goal_curation::progress_evidence::NoopProgressEvidenceChecker,
+        ),
     };
     let mut state = OodaState::new(board_with_goals());
     let report = run_ooda_cycle(&mut state, &mut bridges, &OodaConfig::default()).unwrap();

--- a/tests/ooda_daemon.rs
+++ b/tests/ooda_daemon.rs
@@ -95,6 +95,10 @@ fn test_bridges() -> OodaBridges {
         brain: std::sync::Arc::new(simard::ooda_brain::DeterministicFallbackBrain),
         decide_brain: None,
         orient_brain: None,
+        repo_root: std::path::PathBuf::from("."),
+        progress_evidence: std::sync::Arc::new(
+            simard::goal_curation::progress_evidence::NoopProgressEvidenceChecker,
+        ),
     }
 }
 
@@ -110,6 +114,7 @@ fn board_with_active_goals() -> GoalBoard {
             assigned_to: None,
             current_activity: None,
             wip_refs: Vec::new(),
+            last_progress_update_at: None,
         },
     )
     .unwrap();
@@ -123,6 +128,7 @@ fn board_with_active_goals() -> GoalBoard {
             assigned_to: None,
             current_activity: None,
             wip_refs: Vec::new(),
+            last_progress_update_at: None,
         },
     )
     .unwrap();
@@ -361,6 +367,7 @@ fn goal_objective_contains_goal_id_and_description() {
         assigned_to: None,
         current_activity: None,
         wip_refs: Vec::new(),
+        last_progress_update_at: None,
     };
 
     // This is the format the daemon should use when constructing objectives

--- a/tests/progress_hallucination_guard.rs
+++ b/tests/progress_hallucination_guard.rs
@@ -1,0 +1,556 @@
+//! Integration tests for the hallucinated-progress meta-bug fix
+//! (issue #1967, design.md §5.2 I1–I5).
+//!
+//! These tests exercise the full path from a `GoalBoard` mutation request
+//! through the new gatekeeper façade
+//! `update_goal_progress_with_evidence`, asserting on the observable
+//! contract: board mutation only happens with evidence, and rejected
+//! claims surface as `"brain hallucination detected: …"` episodes that
+//! the dashboard can find by content-substring search.
+//!
+//! Unlike `src/goal_curation/tests_progress_evidence.rs` (which mocks
+//! the runner traits and tests the checker in isolation), these tests
+//! exercise the public re-exports from `simard::goal_curation` so they
+//! pin the end-to-end contract used by the OODA loop in production.
+//!
+//! These tests MUST FAIL on `f4cd5d69` — the symbols don't exist yet —
+//! and are the integration-level acceptance gate for the fix.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use chrono::{DateTime, Duration, TimeZone, Utc};
+use serde_json::Value;
+
+use simard::cognitive_memory::CognitiveMemoryOps;
+use simard::error::SimardResult;
+use simard::goal_curation::progress_evidence::{
+    DefaultProgressEvidenceChecker, EvidenceDecision, GhPr, GhRunner, GitRunner,
+    NoopProgressEvidenceChecker,
+};
+use simard::goal_curation::{
+    ActiveGoal, GoalBoard, GoalProgress, WipRef, add_active_goal, update_goal_progress,
+    update_goal_progress_with_evidence,
+};
+use simard::memory_cognitive::{
+    CognitiveFact, CognitiveProcedure, CognitiveProspective, CognitiveStatistics,
+    CognitiveWorkingSlot,
+};
+
+// ─── shared helpers (duplicated from the unit-test file because tests/
+//     compiles as a separate crate and can't reach into pub(crate) items) ──
+
+const GOAL_ID: &str = "enhance-simard-meeting-experience";
+
+fn fixed_now() -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 5, 21, 4, 0, 0).unwrap()
+}
+
+fn seed_goal(board: &mut GoalBoard, status: GoalProgress, last_update: Option<DateTime<Utc>>) {
+    add_active_goal(
+        board,
+        ActiveGoal {
+            id: GOAL_ID.to_string(),
+            description: "integration-test goal".to_string(),
+            priority: 1,
+            status,
+            assigned_to: None,
+            current_activity: None,
+            wip_refs: vec![WipRef {
+                kind: "issue".to_string(),
+                ref_id: "1951".to_string(),
+                label: "meeting-experience epic".to_string(),
+                url: None,
+            }],
+            last_progress_update_at: last_update,
+        },
+    )
+    .expect("seed goal");
+}
+
+// ─── RecordingMemory — mirrors the unit-test fake but lives in tests/ crate ──
+
+#[derive(Default)]
+struct RecordingMemory {
+    episodes: Mutex<Vec<RecordedEpisode>>,
+}
+
+#[derive(Clone, Debug)]
+struct RecordedEpisode {
+    content: String,
+    #[allow(dead_code)]
+    source_label: String,
+}
+
+impl RecordingMemory {
+    fn new() -> Self {
+        Self::default()
+    }
+    fn episodes(&self) -> Vec<RecordedEpisode> {
+        self.episodes.lock().unwrap().clone()
+    }
+    fn contents(&self) -> Vec<String> {
+        self.episodes().into_iter().map(|e| e.content).collect()
+    }
+}
+
+impl CognitiveMemoryOps for RecordingMemory {
+    fn record_sensory(&self, _m: &str, _r: &str, _t: u64) -> SimardResult<String> {
+        Ok("sen_0".into())
+    }
+    fn prune_expired_sensory(&self) -> SimardResult<usize> {
+        Ok(0)
+    }
+    fn push_working(&self, _s: &str, _c: &str, _t: &str, _r: f64) -> SimardResult<String> {
+        Ok("w_0".into())
+    }
+    fn get_working(&self, _t: &str) -> SimardResult<Vec<CognitiveWorkingSlot>> {
+        Ok(vec![])
+    }
+    fn clear_working(&self, _t: &str) -> SimardResult<usize> {
+        Ok(0)
+    }
+    fn store_episode(
+        &self,
+        content: &str,
+        source_label: &str,
+        _metadata: Option<&Value>,
+    ) -> SimardResult<String> {
+        self.episodes.lock().unwrap().push(RecordedEpisode {
+            content: content.to_string(),
+            source_label: source_label.to_string(),
+        });
+        Ok("epi_x".into())
+    }
+    fn consolidate_episodes(&self, _b: u32) -> SimardResult<Option<String>> {
+        Ok(None)
+    }
+    fn store_fact(
+        &self,
+        _c: &str,
+        _content: &str,
+        _confidence: f64,
+        _tags: &[String],
+        _source_id: &str,
+    ) -> SimardResult<String> {
+        Ok("f_0".into())
+    }
+    fn search_facts(
+        &self,
+        _q: &str,
+        _limit: u32,
+        _min_conf: f64,
+    ) -> SimardResult<Vec<CognitiveFact>> {
+        Ok(vec![])
+    }
+    fn store_procedure(&self, _n: &str, _s: &[String], _p: &[String]) -> SimardResult<String> {
+        Ok("p_0".into())
+    }
+    fn recall_procedure(&self, _q: &str, _l: u32) -> SimardResult<Vec<CognitiveProcedure>> {
+        Ok(vec![])
+    }
+    fn store_prospective(&self, _d: &str, _t: &str, _a: &str, _p: i64) -> SimardResult<String> {
+        Ok("pr_0".into())
+    }
+    fn check_triggers(&self, _c: &str) -> SimardResult<Vec<CognitiveProspective>> {
+        Ok(vec![])
+    }
+    fn get_statistics(&self) -> SimardResult<CognitiveStatistics> {
+        Ok(CognitiveStatistics {
+            sensory_count: 0,
+            working_count: 0,
+            episodic_count: self.episodes.lock().unwrap().len() as u64,
+            semantic_count: 0,
+            procedural_count: 0,
+            prospective_count: 0,
+        })
+    }
+}
+
+// ─── Fake runners ───────────────────────────────────────────────────────────
+
+#[derive(Default)]
+struct FakeGit {
+    branches: Mutex<Vec<String>>,
+    commits: Mutex<Vec<(String, DateTime<Utc>, String)>>,
+}
+impl FakeGit {
+    fn new() -> Self {
+        Self::default()
+    }
+    fn add_branch(&self, name: &str) {
+        self.branches.lock().unwrap().push(name.to_string());
+    }
+    fn add_commit(&self, branch: &str, at: DateTime<Utc>, sha: &str) {
+        self.commits
+            .lock()
+            .unwrap()
+            .push((branch.to_string(), at, sha.to_string()));
+    }
+}
+impl GitRunner for FakeGit {
+    fn list_branches(&self, _root: &Path, pattern: &str) -> std::io::Result<Vec<String>> {
+        let prefix = pattern.trim_end_matches('*');
+        Ok(self
+            .branches
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|b| b.starts_with(prefix))
+            .cloned()
+            .collect())
+    }
+    fn commits_since(
+        &self,
+        _root: &Path,
+        branch: &str,
+        since: DateTime<Utc>,
+    ) -> std::io::Result<Vec<String>> {
+        Ok(self
+            .commits
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|(b, when, _)| b == branch && *when >= since)
+            .map(|(_, _, sha)| sha.clone())
+            .collect())
+    }
+}
+
+#[derive(Default)]
+struct FakeGh {
+    prs: Mutex<Vec<GhPr>>,
+}
+#[allow(dead_code)]
+impl FakeGh {
+    fn new() -> Self {
+        Self::default()
+    }
+    fn add_pr(&self, pr: GhPr) {
+        self.prs.lock().unwrap().push(pr);
+    }
+}
+impl GhRunner for FakeGh {
+    fn search_prs(&self, _slug: &str, _q: &str) -> std::io::Result<Vec<GhPr>> {
+        Ok(self.prs.lock().unwrap().clone())
+    }
+}
+
+fn checker(git: Arc<FakeGit>, gh: Arc<FakeGh>) -> DefaultProgressEvidenceChecker {
+    DefaultProgressEvidenceChecker {
+        repo_root: PathBuf::from("/tmp/fake-repo"),
+        remote_slug: "rysweet/Simard".to_string(),
+        git,
+        gh,
+    }
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// I1 — no engineer activity ⇒ percent stays, alert visible
+//
+// Models the live-production observation from issue #1967: the OODA loop
+// proposes a 35→75 jump on `enhance-simard-meeting-experience` with zero
+// commits, zero PRs since the last update. The gate must reject and
+// record one hallucination episode.
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn i1_no_engineer_activity_rejects_progress_and_emits_alert() {
+    let mut board = GoalBoard::new();
+    seed_goal(
+        &mut board,
+        GoalProgress::InProgress { percent: 35 },
+        Some(fixed_now() - Duration::hours(28)),
+    );
+    let memory = RecordingMemory::new();
+    let git = Arc::new(FakeGit::new());
+    let gh = Arc::new(FakeGh::new()); // empty — no PRs at all
+    let ch = checker(git, gh);
+
+    let decision = update_goal_progress_with_evidence(
+        &mut board,
+        GOAL_ID,
+        GoalProgress::InProgress { percent: 75 },
+        &ch,
+        &memory,
+        fixed_now(),
+    )
+    .expect("Reject must surface as Ok, not Err");
+
+    assert!(
+        matches!(decision, EvidenceDecision::Reject { .. }),
+        "I1: zero-activity progress claim must be Rejected; got {decision:?}"
+    );
+
+    let goal = board
+        .active
+        .iter()
+        .find(|g| g.id == GOAL_ID)
+        .expect("goal still on board after Reject");
+    assert_eq!(
+        goal.status,
+        GoalProgress::InProgress { percent: 35 },
+        "I1: rejected claim must NOT mutate the percent — it must stay at 35"
+    );
+
+    let contents = memory.contents();
+    let alerts: Vec<&String> = contents
+        .iter()
+        .filter(|c| c.starts_with("brain hallucination detected:"))
+        .collect();
+    assert_eq!(
+        alerts.len(),
+        1,
+        "I1: exactly one hallucination alert must be emitted; got {contents:?}"
+    );
+    assert!(
+        alerts[0].contains("35") && alerts[0].contains("75"),
+        "I1: alert must include both old and new percent so operators can triage; got: {}",
+        alerts[0]
+    );
+    assert!(
+        alerts[0].contains(GOAL_ID),
+        "I1: alert must include the goal id; got: {}",
+        alerts[0]
+    );
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// I2 — real commit on engineer branch ⇒ percent advances, accept episode
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn i2_real_commit_on_engineer_branch_accepts_and_advances() {
+    let mut board = GoalBoard::new();
+    seed_goal(
+        &mut board,
+        GoalProgress::InProgress { percent: 35 },
+        Some(fixed_now() - Duration::hours(2)),
+    );
+    let memory = RecordingMemory::new();
+    let git = Arc::new(FakeGit::new());
+    let branch = format!("engineer/{GOAL_ID}-pid7777");
+    git.add_branch(&branch);
+    git.add_commit(&branch, fixed_now() - Duration::minutes(10), "deadbeefcafe");
+    let gh = Arc::new(FakeGh::new());
+    let ch = checker(git, gh);
+
+    let decision = update_goal_progress_with_evidence(
+        &mut board,
+        GOAL_ID,
+        GoalProgress::InProgress { percent: 75 },
+        &ch,
+        &memory,
+        fixed_now(),
+    )
+    .expect("Accept must not error");
+    assert!(
+        matches!(decision, EvidenceDecision::Accept { .. }),
+        "I2: real commit must produce Accept; got {decision:?}"
+    );
+
+    let goal = board.active.iter().find(|g| g.id == GOAL_ID).unwrap();
+    assert_eq!(
+        goal.status,
+        GoalProgress::InProgress { percent: 75 },
+        "I2: Accept must persist the new percent"
+    );
+    assert_eq!(
+        goal.last_progress_update_at,
+        Some(fixed_now()),
+        "I2: Accept must stamp last_progress_update_at"
+    );
+
+    let contents = memory.contents();
+    assert_eq!(
+        contents
+            .iter()
+            .filter(|c| c.starts_with("goal progress accepted:"))
+            .count(),
+        1,
+        "I2: exactly one 'goal progress accepted:' episode; got {contents:?}"
+    );
+    assert!(
+        contents
+            .iter()
+            .all(|c| !c.starts_with("brain hallucination detected:")),
+        "I2: no hallucination alert should be emitted on Accept; got {contents:?}"
+    );
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// I3 — subordinate heartbeat with zero commits ⇒ stays at prior percent
+//
+// Models the `advance_goal/subordinate.rs:56` hallucination site: engineer
+// is alive but has produced nothing. The 50% heartbeat bump must be
+// rejected if it would be an *increase* over the current percent.
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn i3_subordinate_heartbeat_without_commits_does_not_bump_percent() {
+    let mut board = GoalBoard::new();
+    // Engineer was already at 60%; heartbeat would propose 50% (no-op or
+    // decrease) OR would propose 50% from a base of 10% (an increase).
+    // We exercise the increase case here because that is the hallucination.
+    seed_goal(
+        &mut board,
+        GoalProgress::InProgress { percent: 10 },
+        Some(fixed_now() - Duration::hours(1)),
+    );
+    let memory = RecordingMemory::new();
+    let git = Arc::new(FakeGit::new()); // empty — engineer hasn't committed
+    let gh = Arc::new(FakeGh::new());
+    let ch = checker(git, gh);
+
+    let decision = update_goal_progress_with_evidence(
+        &mut board,
+        GOAL_ID,
+        GoalProgress::InProgress { percent: 50 },
+        &ch,
+        &memory,
+        fixed_now(),
+    )
+    .expect("Reject is Ok");
+
+    assert!(
+        matches!(decision, EvidenceDecision::Reject { .. }),
+        "I3: heartbeat without commits must Reject the bump; got {decision:?}"
+    );
+    let goal = board.active.iter().find(|g| g.id == GOAL_ID).unwrap();
+    assert_eq!(
+        goal.status,
+        GoalProgress::InProgress { percent: 10 },
+        "I3: percent must stay at the prior value when engineer has no commits"
+    );
+    assert!(
+        memory
+            .contents()
+            .iter()
+            .any(|c| c.starts_with("brain hallucination detected:")),
+        "I3: hallucination alert must be emitted"
+    );
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// I4 — subordinate heartbeat WITH a commit on its branch ⇒ percent advances
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn i4_subordinate_heartbeat_with_commit_advances_to_fifty_percent() {
+    let mut board = GoalBoard::new();
+    seed_goal(
+        &mut board,
+        GoalProgress::InProgress { percent: 10 },
+        Some(fixed_now() - Duration::hours(1)),
+    );
+    let memory = RecordingMemory::new();
+    let git = Arc::new(FakeGit::new());
+    let branch = format!("engineer/{GOAL_ID}-pid4242");
+    git.add_branch(&branch);
+    git.add_commit(&branch, fixed_now() - Duration::minutes(5), "feedfacef00d");
+    let gh = Arc::new(FakeGh::new());
+    let ch = checker(git, gh);
+
+    let decision = update_goal_progress_with_evidence(
+        &mut board,
+        GOAL_ID,
+        GoalProgress::InProgress { percent: 50 },
+        &ch,
+        &memory,
+        fixed_now(),
+    )
+    .expect("Accept is Ok");
+    assert!(
+        matches!(decision, EvidenceDecision::Accept { .. }),
+        "I4: heartbeat with engineer-branch commit must Accept; got {decision:?}"
+    );
+
+    let goal = board.active.iter().find(|g| g.id == GOAL_ID).unwrap();
+    assert_eq!(
+        goal.status,
+        GoalProgress::InProgress { percent: 50 },
+        "I4: percent must advance to 50 with evidence"
+    );
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// I5 — dashboard PUT path bypasses the gate (operator override is intentional)
+//
+// The dashboard's PUT /api/goals/<id>/progress handler calls the
+// low-level `update_goal_progress` directly. That direct call is the
+// intentional operator-override escape hatch documented in design.md
+// §3.4 and §0.1; this test pins that contract so a future regression
+// can't quietly route the dashboard through the façade.
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn i5_low_level_update_goal_progress_still_works_unchanged() {
+    let mut board = GoalBoard::new();
+    seed_goal(
+        &mut board,
+        GoalProgress::InProgress { percent: 20 },
+        Some(fixed_now() - Duration::hours(1)),
+    );
+
+    // No checker, no memory — the low-level function is the unchanged
+    // pre-#1967 writer used by the dashboard.
+    update_goal_progress(
+        &mut board,
+        GOAL_ID,
+        GoalProgress::InProgress { percent: 90 },
+    )
+    .expect("dashboard PUT path must still succeed unconditionally");
+
+    let goal = board.active.iter().find(|g| g.id == GOAL_ID).unwrap();
+    assert_eq!(
+        goal.status,
+        GoalProgress::InProgress { percent: 90 },
+        "I5: low-level updater (dashboard operator override) must still write \
+         without any evidence check — that escape hatch is intentional"
+    );
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// I6 (kill-switch contract) — NoopProgressEvidenceChecker via the façade
+//
+// Pins design.md §6 rollout: `SIMARD_PROGRESS_EVIDENCE=off` swaps in the
+// NoopChecker; the façade still works but every claim is Accepted with
+// a clearly-marked "noop" reason so the audit trail records the bypass.
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn i6_kill_switch_noop_checker_accepts_all_via_facade() {
+    let mut board = GoalBoard::new();
+    seed_goal(
+        &mut board,
+        GoalProgress::InProgress { percent: 10 },
+        Some(fixed_now() - Duration::hours(1)),
+    );
+    let memory = RecordingMemory::new();
+    let ch = NoopProgressEvidenceChecker;
+
+    let decision = update_goal_progress_with_evidence(
+        &mut board,
+        GOAL_ID,
+        GoalProgress::InProgress { percent: 80 },
+        &ch,
+        &memory,
+        fixed_now(),
+    )
+    .expect("Noop checker must never error");
+
+    match decision {
+        EvidenceDecision::Accept { reason } => assert!(
+            reason.to_ascii_lowercase().contains("noop"),
+            "I6: kill-switch path must mark its Accept reason 'noop' for auditability; got: {reason}"
+        ),
+        other => panic!("I6: NoopChecker via façade must Accept; got {other:?}"),
+    }
+
+    let goal = board.active.iter().find(|g| g.id == GOAL_ID).unwrap();
+    assert_eq!(
+        goal.status,
+        GoalProgress::InProgress { percent: 80 },
+        "I6: kill-switch must let the percent through"
+    );
+}

--- a/tests/recipe_ooda_step_parity.rs
+++ b/tests/recipe_ooda_step_parity.rs
@@ -74,6 +74,7 @@ fn make_goal(id: &str, status: GoalProgress) -> ActiveGoal {
         assigned_to: None,
         current_activity: None,
         wip_refs: vec![],
+        last_progress_update_at: None,
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes the hallucinated-progress meta-bug observed live on the production daemon (2026-05-21 03:19Z): the OODA brain was incrementing every goal's completion percentage by 10-40% over 28 hours with zero PRs, zero commits, and zero merged issues to justify any bump.

Adds a `ProgressEvidenceChecker` gate (new module `src/goal_curation/progress_evidence.rs`) and routes every `GoalProgress::InProgress { percent }` increase through a single canonical façade `update_goal_progress_with_evidence(...)` that rejects the increase unless one of three evidence rules is satisfied:

1. **Commit rule** — at least one commit on a branch matching `engineer/<slug>-*` since the goal's last accepted update.
2. **PR-reference rule** — at least one PR on `rysweet/Simard` (any state) whose title/body mentions the goal slug or a `wip_refs` issue number, created since the last update.
3. **PR-closes rule** — at least one merged PR whose body uses a GitHub closing keyword (`Closes #NNNN`, `Fixes #NNNN`, `Resolves #NNNN`) on a `wip_refs` issue.

Without one of (1)/(2)/(3), the gate emits a structured `"brain hallucination detected: rejected progress <old>%->%<new>% on <goal-id>"` cognitive-memory episode (surfacing the failure on the dashboard per #1957) and **keeps the prior percent unchanged**.

## Files Changed

| Area | File | What |
|---|---|---|
| Core | `src/goal_curation/progress_evidence.rs` | New module: `ProgressEvidenceChecker` trait, `DefaultProgressEvidenceChecker`, `NoopProgressEvidenceChecker`, `SystemGitRunner`, `SystemGhRunner`, `slug_for`, `body_closes_issue`, `process_start` |
| Core | `src/goal_curation/operations.rs` | New façade `update_goal_progress_with_evidence` |
| Core | `src/goal_curation/types.rs` | `ActiveGoal.last_progress_update_at: Option<DateTime<Utc>>` (serde-optional) |
| Core | `src/cognitive_memory/mod.rs` | New trait method `search_episodes_starting_with` (default empty impl) |
| Core | `src/ooda_loop/types.rs` | `OodaBridges` gains `repo_root` + `progress_evidence` |
| Wiring | `src/operator_commands_ooda/daemon/mod.rs` | Daemon boot wires `DefaultProgressEvidenceChecker` (or `Noop` when `SIMARD_PROGRESS_EVIDENCE=off`); logs the wiring decision |
| Rewire | `src/ooda_actions/goal_session/advance.rs` | `assess_only_outcome` + `advance_goal_with_session` route through façade |
| Rewire | `src/ooda_actions/advance_goal/subordinate.rs` | Heartbeat 50% bump + Completed post-artifacts write route through façade |
| Rewire | `src/ooda_actions/advance_goal/mod.rs` | Split-borrow pattern to pass `memory` + `checker` alongside mutable `session` |
| Tests | `src/goal_curation/tests_progress_evidence.rs` | 12 unit tests (U1-U12) |
| Tests | `tests/progress_hallucination_guard.rs` | 6 integration tests (I1-I6) |
| Docs | `docs/concepts/progress-evidence-gating.md` | Design rationale |
| Docs | `docs/reference/progress-evidence-api.md` | Façade + trait reference |
| Docs | `docs/operations/progress-evidence-kill-switch.md` | Emergency disable playbook |
| Docs | `docs/howto/diagnose-rejected-progress-claims.md` | Operator playbook |

## Pinned Regression Tests

Per the issue acceptance criteria, the following test names are pinned and asserted to exist and pass:

- `i1_no_engineer_activity_rejects_progress_and_emits_alert` — gate rejects + emits hallucination episode
- `i2_real_commit_on_engineer_branch_accepts_and_advances` — rule 1 (commit) accepts
- `i3_subordinate_heartbeat_without_commits_does_not_bump_percent` — alive engineer ≠ progress
- `i4_subordinate_heartbeat_with_commit_advances_to_fifty_percent` — alive engineer WITH commit DOES advance
- `i5_low_level_update_goal_progress_still_works_unchanged` — direct `update_goal_progress` callers unaffected
- `i6_kill_switch_noop_checker_accepts_all_via_facade` — `SIMARD_PROGRESS_EVIDENCE=off` accepts everything

## Verification

- `cargo test --lib` → **4250 passed, 0 failed**
- `cargo test --test progress_hallucination_guard` → **6 passed**
- `cargo test --test ooda --test ooda_daemon` → **23 passed**
- `cargo clippy --lib --tests --bins -- -D warnings` → clean
- `pre-commit run --all-files` → all hooks Passed
- Pre-push hook (cargo fmt + cargo test --release --lib + cargo clippy --all-targets --all-features --locked) → all Passed

## Schema Compatibility

`ActiveGoal.last_progress_update_at` uses `#[serde(default, skip_serializing_if = "Option::is_none")]` so legacy on-disk boards from before this PR deserialize cleanly. When the field is `None` the façade falls back to:
1. Memory scan for prior `"goal progress accepted:"` episode mentioning this goal
2. Daemon process-start timestamp (last-resort; never a silent open door on a fresh daemon)

The `since` value is always clamped to `min(since, now)` to prevent NTP corrections or test fixtures with historical timestamps from producing a future-dated probe window.

## Kill Switch

`SIMARD_PROGRESS_EVIDENCE=off` (read once at daemon boot) wires the `NoopProgressEvidenceChecker` and emits:
```
[simard] progress-evidence: DISABLED (NoopProgressEvidenceChecker -- SIMARD_PROGRESS_EVIDENCE=off)
```
Enabled (default):
```
[simard] progress-evidence: enabled (DefaultProgressEvidenceChecker, repo_root=..., remote=rysweet/Simard)
```

## Side Cleanup

Zombie pytest processes from 2026-05-13 (PIDs 1175481, 2379640) were already gone by the time this work started; confirmed via empty `ps` output. No further action needed.

Closes #1969
Refs #1951, #1957, #1967, #1968
