### PR TITLE
chore(engineer): remove wall-clock timeout on engineer subprocess (#1989)

### DIFF
--- a/src/engineer_loop/agent_spawn.rs
+++ b/src/engineer_loop/agent_spawn.rs
@@ -21,13 +21,16 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::mpsc;
 use std::thread;
-use std::time::{Duration, Instant};
 
 use crate::error::{SimardError, SimardResult};
 
 use super::types::RepoInspection;
 
-pub(crate) const AGENT_SESSION_TIMEOUT_SECS: u64 = 3600;
+// NOTE: There is intentionally no wall-clock timeout on the engineer
+// subprocess. Long-running agentic work (e.g. `amplihack copilot`) must run
+// to natural completion; a SIGKILL deadline silently drops uncommitted work
+// (see PR #1988 salvage and issue #1989). Liveness, if needed, must come from
+// agent-emitted progress signals, not from Simard wall-clock SIGKILL.
 
 /// Default upper bound on RustyClawd autonomous turns. Aligns with the
 /// `amplihack RustyClawd --auto --max-turns` complex-task guidance.
@@ -288,37 +291,15 @@ pub fn run_engineer_subprocess(
         cmd.env("COPILOT_ALLOW_ALL", "1");
     }
 
-    let mut child = cmd
+    let child = cmd
         .spawn()
         .map_err(|e| SimardError::ActionExecutionFailed {
             action: action_label.clone(),
             reason: format!("failed to spawn `{bin}`: {e}"),
         })?;
 
-    let deadline = Instant::now() + Duration::from_secs(AGENT_SESSION_TIMEOUT_SECS);
-    loop {
-        match child.try_wait() {
-            Ok(Some(_status)) => break,
-            Ok(None) => {
-                if Instant::now() >= deadline {
-                    let _ = child.kill();
-                    let _ = child.wait();
-                    return Err(SimardError::CommandTimeout {
-                        action: action_label,
-                        timeout_secs: AGENT_SESSION_TIMEOUT_SECS,
-                    });
-                }
-                thread::sleep(Duration::from_millis(250));
-            }
-            Err(e) => {
-                return Err(SimardError::ActionExecutionFailed {
-                    action: action_label,
-                    reason: format!("failed to poll child process: {e}"),
-                });
-            }
-        }
-    }
-
+    // Wait unbounded. Engineer subprocesses are agentic and must run to
+    // natural completion or natural failure; do NOT SIGKILL on a wall clock.
     let output = child
         .wait_with_output()
         .map_err(|e| SimardError::ActionExecutionFailed {
@@ -380,10 +361,14 @@ pub(crate) fn start_agent_session(
 pub(crate) fn await_agent_session(
     rx: mpsc::Receiver<SimardResult<String>>,
 ) -> SimardResult<String> {
-    rx.recv_timeout(Duration::from_secs(AGENT_SESSION_TIMEOUT_SECS + 30))
-        .map_err(|_| SimardError::ActionExecutionFailed {
+    // Unbounded recv: the engineer subprocess has no wall-clock timeout, so
+    // the channel must not impose one either. The only failure modes are:
+    // (a) the worker thread panics (sender dropped → RecvError), or
+    // (b) the subprocess returns an error which we propagate verbatim.
+    rx.recv()
+        .map_err(|e| SimardError::ActionExecutionFailed {
             action: "agent-spawn".to_string(),
-            reason: format!("agent session channel timed out after {AGENT_SESSION_TIMEOUT_SECS}s"),
+            reason: format!("agent session channel closed unexpectedly: {e}"),
         })?
         .map_err(|e| SimardError::ActionExecutionFailed {
             action: "agent-spawn".to_string(),

--- a/src/engineer_loop/tests_agent_spawn.rs
+++ b/src/engineer_loop/tests_agent_spawn.rs
@@ -4,7 +4,10 @@
 //! architecture. They cover:
 //!   1. `build_agent_prompt` content requirements
 //!   2. `AgentSession` variant serialisation (must be snake_case JSON key)
-//!   3. `AGENT_SESSION_TIMEOUT_SECS` constant value
+//!   3. (removed) Agent-session timeout — engineer subprocesses now run unbounded
+//!      so the prior `AGENT_SESSION_TIMEOUT_SECS = 3600` constant is gone.
+//!      See issue #1989 for rationale (wall-clock SIGKILL silently drops
+//!      uncommitted engineer work, e.g. PR #1988 salvage).
 //!   4. `AgentSession` is treated as a mutating action by `run_optional_review`
 //!   5. `compute_diff_for_review` for `AgentSession` uses `git diff` (not HEAD~1)
 //!   6. `run_local_engineer_loop` emits all three agent-* phase traces
@@ -13,9 +16,7 @@ use std::path::PathBuf;
 
 use serial_test::serial;
 
-use super::agent_spawn::{
-    AGENT_SESSION_TIMEOUT_SECS, DEFAULT_MAX_TURNS, build_agent_prompt, rustyclawd_argv,
-};
+use super::agent_spawn::{DEFAULT_MAX_TURNS, build_agent_prompt, rustyclawd_argv};
 use super::review_persist::compute_diff_for_review;
 use super::types::{
     EngineerActionKind, ExecutedEngineerAction, RepoInspection, SelectedEngineerAction,
@@ -160,17 +161,11 @@ fn engineer_action_kind_agent_session_round_trips() {
     assert_eq!(kind, back);
 }
 
-// ─── 3. Timeout constant ─────────────────────────────────────────────────────
-
-/// Agent session timeout must be exactly 3600 seconds (consistent with
-/// CARGO_COMMAND_TIMEOUT_SECS ordering and the architecture spec).
-#[test]
-fn agent_session_timeout_is_3600_seconds() {
-    assert_eq!(
-        AGENT_SESSION_TIMEOUT_SECS, 3600,
-        "AGENT_SESSION_TIMEOUT_SECS must be 3600"
-    );
-}
+// ─── 3. (removed) Timeout constant ───────────────────────────────────────────
+// `AGENT_SESSION_TIMEOUT_SECS` was deleted as part of removing the engineer
+// subprocess wall-clock timeout (issue #1989, PR #1988 salvage). Long-running
+// agentic processes must not be SIGKILL'd on a clock. Liveness, if ever
+// reintroduced, must be progress-signal-based, not deadline-based.
 
 // ─── 4. AgentSession is mutating ─────────────────────────────────────────────
 
@@ -361,9 +356,7 @@ fn rustyclawd_argv_matches_amplihack_auto_contract() {
     );
 }
 
-/// The agent session timeout must remain at 3600s — it bounds how long
-/// Simard will wait for the RustyClawd subprocess before SIGKILL'ing it.
-#[test]
-fn agent_session_timeout_bounded_for_subprocess_wait() {
-    assert_eq!(AGENT_SESSION_TIMEOUT_SECS, 3600);
-}
+// (removed) Agent-session subprocess wait used to be bounded by
+// `AGENT_SESSION_TIMEOUT_SECS = 3600`. Removed because wall-clock SIGKILL on
+// agentic processes silently drops uncommitted work (issue #1989, PR #1988
+// salvage). Engineer subprocesses now run unbounded.


### PR DESCRIPTION
## Problem

`AGENT_SESSION_TIMEOUT_SECS = 3600` SIGKILL'd long-running agentic subprocesses (`amplihack copilot`, RustyClawd) mid-flight, silently dropping all uncommitted work in their worktrees. We observed this directly: PR #1988 only existed because we manually salvaged 22 files / +995 lines from a worktree after the SIGKILL. The same pattern is responsible for prior 0-byte engineer logs, untraceable goal regressions, and the hallucinated-progress meta-bug.

Wall-clock SIGKILL is the wrong shape for agentic work. Per user direction: "there absolutely should not be a timeout on the engineers… or on any long-running agentic process."

## Solution

`src/engineer_loop/agent_spawn.rs`:
- Delete the `AGENT_SESSION_TIMEOUT_SECS` constant.
- Replace the `Instant + deadline + try_wait` poll loop in `run_engineer_subprocess` with a single `child.wait_with_output()` (unbounded).
- Replace `rx.recv_timeout(...)` with `rx.recv()` in `await_agent_session`; the channel cannot impose a deadline the subprocess does not have.
- Drop unused imports (`Instant`, `Duration` — still used elsewhere, kept where needed).
- Inline comment documenting why there is intentionally no timeout, with pointers to #1988 / #1989.

`src/engineer_loop/tests_agent_spawn.rs`:
- Remove the two tests pinning the deleted constant to 3600s (`agent_session_timeout_is_3600_seconds`, `agent_session_timeout_bounded_for_subprocess_wait`).
- Update module doc-comment header.

Net: 29 insertions / 51 deletions across 2 files.

## Evidence

- Build: `cargo build --release --bin simard` → green (3m 45s).
- Unit tests: `cargo test --release --lib engineer_loop` → **183 passed; 0 failed; 0 ignored** (13.7s after compile). All agent-spawn-adjacent tests pass: `build_agent_prompt`, `rustyclawd_argv`, `AgentKind` serde round-trip, `run_local_engineer_loop` phase-trace coverage.
- `cargo fmt --all -- --check` clean (re-applied via amend).
- `AGENT_SESSION_TIMEOUT_SECS` reference count after this PR: `grep -rn AGENT_SESSION_TIMEOUT_SECS src/` → 0.

## Risk / Rollback

**Risk**: A genuinely stuck `amplihack` subprocess (deadlocked, infinite reflection loop) will no longer self-kill at 1h; the operator must `kill <pid>` it.

**Mitigations**:
- The OODA daemon's existing log surfacing means stuck subprocesses are visible in `~/.simard/agent_logs/engineer-*.log` and via `ps -eo pid,etime,cmd`.
- Wall-clock timeouts are infrastructure-level, not work-level. Liveness is better signalled by progress emission (recipe step boundaries per #1971), not by a 3600s SIGKILL.
- Existing `pkill amplihack` / targeted `kill <pid>` remains as operator escape hatch.

**Rollback**: `git revert` this single commit; no data migration, no schema change.

## Scope

In: removal of the engineer-subprocess wall-clock timeout (`AGENT_SESSION_TIMEOUT_SECS`) and its two pinning tests.

Out (separate issues / PRs):
- Cargo / git command timeouts in `execution/mod.rs` — those guard infrastructure shellouts, not agentic processes.
- Meeting-close `SIMARD_MEETING_AGENT_CLOSE_TIMEOUT_SECS` — tracked in #1999.
- Architectural OODA-as-recipe refactor — tracked in #1971.
- Progress-evidence gate refactor (Rust → LLM reviewer) — separate PR in flight.

## Verdict

**Ready to merge.** Closes #1989.