### PR TITLE
refactor(goal-curation): replace git-shelling evidence-gate with LLM reviewer (#1970 follow-up)

### DIFF
--- a/prompt_assets/simard/progress_assessment_reviewer.md
+++ b/prompt_assets/simard/progress_assessment_reviewer.md
@@ -1,0 +1,111 @@
+# Progress-assessment reviewer
+
+You are an LLM reviewer judging whether a proposed progress update on a Simard
+goal is honest. You read three things — the **problem**, the **plan**, and the
+**progress against the plan** — and return a single JSON verdict.
+
+No git introspection. No PR-list scraping. No tool calls. You just read the
+text the daemon gives you and decide whether the proposed new percent is a
+reasonable reflection of the work done so far.
+
+## Input contract
+
+The daemon will substitute these placeholders into the prompt before sending it:
+
+- `{goal_id}` — short slug identifying the goal (for logs / your rationale)
+- `{problem}` — the goal description, i.e. *what we are trying to achieve*
+- `{plan}` — the current activity / plan field on the goal (what is being
+  done right now to reach that goal). May be empty for very new goals.
+- `{prior_pct}` — the last accepted percent for this goal (integer 0–100)
+- `{claimed_pct}` — the proposed new percent the brain wants to write
+  (integer 0–100)
+- `{wip_summary}` — a short, free-text summary of any WIP references the
+  goal carries (PR numbers, branch names, issue links). May be empty.
+
+## How to judge
+
+You are deciding **accept** vs **reject**. Be honest, not generous.
+
+Accept when the claimed percent is *coherent with the plan*:
+- The plan describes work in flight, and the claimed delta is small and
+  proportional to that work (e.g. plan says "designing the schema, halfway
+  through" and prior 40% → claimed 55% is fine).
+- The plan describes work that is plausibly complete, and the claimed
+  percent matches (e.g. plan says "shipped PR #1234" and claimed jumps to
+  100% — that is fine).
+- The plan field is empty but the WIP summary lists concrete artifacts
+  (an open PR, a real engineer branch) and the delta is modest.
+
+Reject when the claimed percent looks hallucinated:
+- A large delta with no matching plan or WIP (e.g. prior 5% → claimed 88%
+  and the plan is empty or vague).
+- A 100% claim with no shipped artifact in the plan or WIP.
+- A claim that contradicts the plan (e.g. plan says "blocked on review"
+  but the brain claims 90%).
+- The plan describes work that does not match the goal at all.
+
+A **decrease** in percent (claimed < prior) is always acceptable — the brain
+is correcting a prior overestimate and we want to encourage that. Return
+accept with a rationale that notes the self-correction.
+
+When in genuine doubt, prefer **accept** with a cautionary rationale. The
+goal of this reviewer is to catch hallucinated jumps, not to gatekeep every
+small movement.
+
+## Output contract
+
+Return a single JSON object on a single line, no prose, no markdown fences:
+
+```json
+{"verdict": "accept", "rationale": "<one short sentence citing the plan/wip>"}
+```
+
+or
+
+```json
+{"verdict": "reject", "rationale": "<one short sentence explaining the gap>"}
+```
+
+`verdict` MUST be exactly `"accept"` or `"reject"`. `rationale` MUST be a
+single short sentence (the daemon truncates beyond 240 chars).
+
+## Examples
+
+Good — modest delta backed by concrete WIP:
+
+```
+{goal_id} = "improve-cognitive-memory-persistence"
+{problem} = "Harden memory consolidation and ensure durable recall across sessions"
+{plan}    = "Engineer is implementing per-write fsync barrier; PR #1998 open and MERGEABLE"
+{prior_pct} = "55"
+{claimed_pct} = "65"
+{wip_summary} = "pr=1998 branch=feat/issue-1973-*"
+```
+
+Response: `{"verdict": "accept", "rationale": "PR #1998 in flight, 10pt delta matches plan"}`
+
+Bad — large jump with no plan:
+
+```
+{goal_id} = "self-serve-dashboard-improvement"
+{problem} = "Use your own dashboard to understand your operations"
+{plan}    = ""
+{prior_pct} = "5"
+{claimed_pct} = "88"
+{wip_summary} = ""
+```
+
+Response: `{"verdict": "reject", "rationale": "88% claim with no plan and no WIP; likely hallucinated"}`
+
+Good — self-correction downward:
+
+```
+{goal_id} = "fix-broken-features"
+{problem} = "Audit and fix broken Simard features"
+{plan}    = "Re-scoping after discovering the audit was incomplete"
+{prior_pct} = "80"
+{claimed_pct} = "55"
+{wip_summary} = ""
+```
+
+Response: `{"verdict": "accept", "rationale": "downward self-correction during re-scope"}`

--- a/src/goal_curation/mod.rs
+++ b/src/goal_curation/mod.rs
@@ -5,6 +5,7 @@
 
 mod operations;
 pub mod progress_evidence;
+pub mod progress_reviewer;
 mod types;
 
 // Re-export all public items so `crate::goal_curation::X` still works.

--- a/src/goal_curation/progress_reviewer.rs
+++ b/src/goal_curation/progress_reviewer.rs
@@ -1,0 +1,497 @@
+//! LLM-backed [`ProgressEvidenceChecker`] — replaces the git-shelling
+//! [`super::progress_evidence::DefaultProgressEvidenceChecker`] (PR #1970).
+//!
+//! Per user direction (post-PR #1970 review): "the progress assessment
+//! should be an llm reviewing the problem, the plan, and the progress
+//! against the plan, thats all." This module implements exactly that —
+//! no git introspection, no `gh pr list` shellouts, no Rust state-machine
+//! gate. A single LLM call reads `{problem, plan, prior_pct, claimed_pct,
+//! wip_summary}` and returns `{verdict, rationale}`.
+//!
+//! The trait stays in [`super::progress_evidence`]; this module only
+//! provides a new implementation. The kill-switch
+//! [`super::progress_evidence::NoopProgressEvidenceChecker`] continues to
+//! work via `SIMARD_PROGRESS_EVIDENCE=off`.
+//!
+//! Prompt template: `prompt_assets/simard/progress_assessment_reviewer.md`.
+//! Response shape: `{"verdict": "accept"|"reject", "rationale": "..."}`.
+//!
+//! Failure handling: on LLM transport error, JSON parse error, or empty
+//! response, the reviewer **accepts** with a diagnostic rationale. The
+//! purpose of this gate is to catch hallucinated progress jumps — not to
+//! block goals on LLM infrastructure issues.
+
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+
+use super::progress_evidence::{EvidenceDecision, ProgressEvidenceChecker};
+use super::types::ActiveGoal;
+use crate::ooda_brain::LlmSubmitter;
+use crate::ooda_brain::prompt_store;
+
+pub const PROMPT_NAME: &str = "progress_assessment_reviewer.md";
+const ADAPTER_TAG: &str = "progress-assessment-reviewer";
+
+/// Max chars retained from the LLM rationale before the gate truncates.
+/// The prompt asks for one short sentence; this is a safety net.
+const RATIONALE_MAX_CHARS: usize = 240;
+
+/// JSON contract from the prompt template. Kept private — callers only
+/// see the `EvidenceDecision` returned by [`ProgressEvidenceChecker::check`].
+#[derive(Debug, Deserialize)]
+struct ReviewerResponse {
+    verdict: String,
+    rationale: String,
+}
+
+/// LLM-backed checker. Generic over `LlmSubmitter` so tests can swap in a
+/// canned-response stub without any global state.
+pub struct LlmReviewerProgressChecker<S: LlmSubmitter> {
+    submitter: S,
+}
+
+impl<S: LlmSubmitter> LlmReviewerProgressChecker<S> {
+    pub fn new(submitter: S) -> Self {
+        Self { submitter }
+    }
+
+    fn render_prompt(&self, goal: &ActiveGoal, prior_pct: u32, claimed_pct: u32) -> String {
+        let plan = goal
+            .current_activity
+            .as_deref()
+            .unwrap_or("")
+            .trim()
+            .to_string();
+        let wip_summary = render_wip_summary(goal);
+        prompt_store::global()
+            .load(PROMPT_NAME)
+            .replace("{goal_id}", &goal.id)
+            .replace("{problem}", &goal.description)
+            .replace("{plan}", &plan)
+            .replace("{prior_pct}", &prior_pct.to_string())
+            .replace("{claimed_pct}", &claimed_pct.to_string())
+            .replace("{wip_summary}", &wip_summary)
+    }
+}
+
+impl<S: LlmSubmitter> ProgressEvidenceChecker for LlmReviewerProgressChecker<S> {
+    fn check(
+        &self,
+        goal: &ActiveGoal,
+        old_percent: u32,
+        new_percent: u32,
+        _since: DateTime<Utc>,
+    ) -> EvidenceDecision {
+        // Downward self-correction is always accepted (per prompt rules).
+        if new_percent <= old_percent {
+            return EvidenceDecision::Accept {
+                reason: format!(
+                    "{ADAPTER_TAG}: downward / no-change ({old_percent} -> {new_percent}) auto-accepted"
+                ),
+            };
+        }
+
+        let prompt = self.render_prompt(goal, old_percent, new_percent);
+        let raw = match self.submitter.submit(&prompt) {
+            Ok(r) => r,
+            Err(e) => {
+                // Infra failure — accept with diagnostic so we don't block
+                // goals on LLM transport hiccups.
+                return EvidenceDecision::Accept {
+                    reason: format!(
+                        "{ADAPTER_TAG}: LLM submit failed ({e}); accepting to avoid blocking goal"
+                    ),
+                };
+            }
+        };
+
+        match parse_reviewer_response(&raw) {
+            Ok(parsed) => decision_from_response(parsed),
+            Err(parse_err) => EvidenceDecision::Accept {
+                reason: format!(
+                    "{ADAPTER_TAG}: parse error ({parse_err}); accepting to avoid blocking goal"
+                ),
+            },
+        }
+    }
+}
+
+fn render_wip_summary(goal: &ActiveGoal) -> String {
+    if goal.wip_refs.is_empty() {
+        return String::new();
+    }
+    goal.wip_refs
+        .iter()
+        .map(|w| format!("{:?}", w))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn decision_from_response(r: ReviewerResponse) -> EvidenceDecision {
+    let mut rationale = r.rationale.trim().to_string();
+    if rationale.chars().count() > RATIONALE_MAX_CHARS {
+        rationale = rationale
+            .chars()
+            .take(RATIONALE_MAX_CHARS)
+            .collect::<String>()
+            + "…";
+    }
+    let verdict_lc = r.verdict.trim().to_ascii_lowercase();
+    if verdict_lc == "accept" {
+        EvidenceDecision::Accept {
+            reason: format!("{ADAPTER_TAG}: accept — {rationale}"),
+        }
+    } else if verdict_lc == "reject" {
+        EvidenceDecision::Reject {
+            reason: format!("{ADAPTER_TAG}: reject — {rationale}"),
+        }
+    } else {
+        // Unknown verdict string — accept with diagnostic.
+        EvidenceDecision::Accept {
+            reason: format!(
+                "{ADAPTER_TAG}: unknown verdict {:?}; accepting to avoid blocking goal",
+                r.verdict
+            ),
+        }
+    }
+}
+
+/// Parse the LLM response into a [`ReviewerResponse`].
+///
+/// Strategy mirrors `merge_judge::parse_judge_response`:
+///   1. Try parsing the trimmed input as-is.
+///   2. Look inside fenced code blocks.
+///   3. Scan for the first brace-balanced `{...}` that parses cleanly.
+///   4. Fall back to outermost-brace strategy.
+fn parse_reviewer_response(raw: &str) -> Result<ReviewerResponse, String> {
+    let stripped = raw.trim();
+    if stripped.is_empty() {
+        return Err(format!(
+            "{ADAPTER_TAG} returned an empty response (raw={:?})",
+            raw
+        ));
+    }
+    // 1. as-is
+    if let Ok(parsed) = serde_json::from_str::<ReviewerResponse>(stripped) {
+        return Ok(parsed);
+    }
+    // 2. fenced blocks
+    for candidate in extract_fenced_blocks(stripped) {
+        if let Ok(parsed) = serde_json::from_str::<ReviewerResponse>(candidate.trim()) {
+            return Ok(parsed);
+        }
+    }
+    // 3. brace-balanced spans
+    for candidate in extract_balanced_objects(stripped) {
+        if let Ok(parsed) = serde_json::from_str::<ReviewerResponse>(candidate) {
+            return Ok(parsed);
+        }
+    }
+    // 4. outermost braces fallback
+    if let (Some(first), Some(last)) = (stripped.find('{'), stripped.rfind('}')) {
+        if first < last {
+            if let Ok(parsed) = serde_json::from_str::<ReviewerResponse>(&stripped[first..=last]) {
+                return Ok(parsed);
+            }
+        }
+    }
+    Err(format!(
+        "{ADAPTER_TAG} response had no parseable JSON object; raw={:?}",
+        truncate_for_err(raw)
+    ))
+}
+
+fn extract_fenced_blocks(s: &str) -> Vec<&str> {
+    let mut out = Vec::new();
+    let mut remainder = s;
+    while let Some(open) = remainder.find("```") {
+        let after_open = &remainder[open + 3..];
+        let body_start = after_open.find('\n').map(|n| n + 1).unwrap_or(0);
+        let body_region = &after_open[body_start..];
+        if let Some(close) = body_region.find("```") {
+            out.push(&body_region[..close]);
+            let consumed = open + 3 + body_start + close + 3;
+            if consumed >= remainder.len() {
+                break;
+            }
+            remainder = &remainder[consumed..];
+        } else {
+            break;
+        }
+    }
+    out
+}
+
+fn extract_balanced_objects(s: &str) -> Vec<&str> {
+    let bytes = s.as_bytes();
+    let mut spans = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'{' {
+            let mut depth: i32 = 0;
+            let mut in_str = false;
+            let mut escape = false;
+            let mut j = i;
+            while j < bytes.len() {
+                let c = bytes[j];
+                if in_str {
+                    if escape {
+                        escape = false;
+                    } else if c == b'\\' {
+                        escape = true;
+                    } else if c == b'"' {
+                        in_str = false;
+                    }
+                } else if c == b'"' {
+                    in_str = true;
+                } else if c == b'{' {
+                    depth += 1;
+                } else if c == b'}' {
+                    depth -= 1;
+                    if depth == 0 {
+                        spans.push(&s[i..=j]);
+                        i = j;
+                        break;
+                    }
+                }
+                j += 1;
+            }
+        }
+        i += 1;
+    }
+    spans
+}
+
+fn truncate_for_err(s: &str) -> String {
+    const MAX: usize = 400;
+    if s.chars().count() <= MAX {
+        s.to_string()
+    } else {
+        s.chars().take(MAX).collect::<String>() + "…"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::{SimardError, SimardResult};
+    use crate::goal_curation::types::GoalProgress;
+
+    struct StubSubmitter {
+        response: SimardResult<String>,
+    }
+
+    impl LlmSubmitter for StubSubmitter {
+        fn submit(&self, _rendered_prompt: &str) -> SimardResult<String> {
+            match &self.response {
+                Ok(s) => Ok(s.clone()),
+                Err(e) => Err(SimardError::AdapterInvocationFailed {
+                    base_type: ADAPTER_TAG.to_string(),
+                    reason: format!("{e}"),
+                }),
+            }
+        }
+    }
+
+    fn goal_with_activity(activity: Option<&str>) -> ActiveGoal {
+        ActiveGoal {
+            id: "test-goal".to_string(),
+            description: "do the thing".to_string(),
+            priority: 1,
+            status: GoalProgress::InProgress { percent: 10 },
+            assigned_to: None,
+            current_activity: activity.map(String::from),
+            wip_refs: vec![],
+            last_progress_update_at: None,
+        }
+    }
+
+    fn now() -> DateTime<Utc> {
+        Utc::now()
+    }
+
+    #[test]
+    fn downward_move_is_always_accepted_without_llm_call() {
+        // Submitter that would panic if called — proves the early-return path.
+        struct PanickingSubmitter;
+        impl LlmSubmitter for PanickingSubmitter {
+            fn submit(&self, _: &str) -> SimardResult<String> {
+                panic!("LLM should not be called for downward moves");
+            }
+        }
+        let c = LlmReviewerProgressChecker::new(PanickingSubmitter);
+        let g = goal_with_activity(None);
+        match c.check(&g, 80, 50, now()) {
+            EvidenceDecision::Accept { reason } => {
+                assert!(reason.contains("downward"));
+            }
+            EvidenceDecision::Reject { .. } => panic!("expected accept"),
+        }
+    }
+
+    #[test]
+    fn no_change_is_accepted_without_llm_call() {
+        struct PanickingSubmitter;
+        impl LlmSubmitter for PanickingSubmitter {
+            fn submit(&self, _: &str) -> SimardResult<String> {
+                panic!("LLM should not be called for no-change");
+            }
+        }
+        let c = LlmReviewerProgressChecker::new(PanickingSubmitter);
+        let g = goal_with_activity(None);
+        assert!(matches!(
+            c.check(&g, 60, 60, now()),
+            EvidenceDecision::Accept { .. }
+        ));
+    }
+
+    #[test]
+    fn llm_accept_response_yields_accept_decision() {
+        let stub = StubSubmitter {
+            response: Ok(r#"{"verdict": "accept", "rationale": "matches plan"}"#.to_string()),
+        };
+        let c = LlmReviewerProgressChecker::new(stub);
+        let g = goal_with_activity(Some("working on it"));
+        match c.check(&g, 30, 45, now()) {
+            EvidenceDecision::Accept { reason } => {
+                assert!(reason.contains("matches plan"), "got: {reason}");
+            }
+            EvidenceDecision::Reject { .. } => panic!("expected accept"),
+        }
+    }
+
+    #[test]
+    fn llm_reject_response_yields_reject_decision() {
+        let stub = StubSubmitter {
+            response: Ok(r#"{"verdict": "reject", "rationale": "no plan, big jump"}"#.to_string()),
+        };
+        let c = LlmReviewerProgressChecker::new(stub);
+        let g = goal_with_activity(None);
+        match c.check(&g, 5, 90, now()) {
+            EvidenceDecision::Reject { reason } => {
+                assert!(reason.contains("no plan"), "got: {reason}");
+            }
+            EvidenceDecision::Accept { .. } => panic!("expected reject"),
+        }
+    }
+
+    #[test]
+    fn llm_submit_failure_falls_back_to_accept() {
+        // Use a dedicated submitter that returns a real SimardError variant
+        // (StubSubmitter takes Ok(String), not Err - keep tests honest).
+        struct ErrSubmitter;
+        impl LlmSubmitter for ErrSubmitter {
+            fn submit(&self, _: &str) -> SimardResult<String> {
+                Err(SimardError::AdapterInvocationFailed {
+                    base_type: "x".into(),
+                    reason: "transport timeout".into(),
+                })
+            }
+        }
+        let c = LlmReviewerProgressChecker::new(ErrSubmitter);
+        let g = goal_with_activity(None);
+        match c.check(&g, 10, 20, now()) {
+            EvidenceDecision::Accept { reason } => {
+                assert!(reason.contains("LLM submit failed"), "got: {reason}");
+                assert!(reason.contains("transport timeout"), "got: {reason}");
+            }
+            EvidenceDecision::Reject { .. } => panic!("expected accept on infra failure"),
+        }
+    }
+
+    #[test]
+    fn parse_error_falls_back_to_accept() {
+        let stub = StubSubmitter {
+            response: Ok("this is not json at all".to_string()),
+        };
+        let c = LlmReviewerProgressChecker::new(stub);
+        let g = goal_with_activity(None);
+        match c.check(&g, 10, 20, now()) {
+            EvidenceDecision::Accept { reason } => {
+                assert!(reason.contains("parse error"), "got: {reason}");
+            }
+            EvidenceDecision::Reject { .. } => panic!("expected accept on parse failure"),
+        }
+    }
+
+    #[test]
+    fn unknown_verdict_falls_back_to_accept() {
+        let stub = StubSubmitter {
+            response: Ok(r#"{"verdict": "maybe", "rationale": "shrug"}"#.to_string()),
+        };
+        let c = LlmReviewerProgressChecker::new(stub);
+        let g = goal_with_activity(None);
+        match c.check(&g, 10, 20, now()) {
+            EvidenceDecision::Accept { reason } => {
+                assert!(reason.contains("unknown verdict"), "got: {reason}");
+            }
+            EvidenceDecision::Reject { .. } => panic!("expected accept on unknown verdict"),
+        }
+    }
+
+    #[test]
+    fn parser_handles_fenced_json() {
+        let raw = "Here is my verdict:\n```json\n{\"verdict\":\"reject\",\"rationale\":\"hallucinated\"}\n```\nDone.";
+        let parsed = parse_reviewer_response(raw).expect("parse ok");
+        assert_eq!(parsed.verdict, "reject");
+        assert_eq!(parsed.rationale, "hallucinated");
+    }
+
+    #[test]
+    fn parser_handles_brace_balanced_inside_prose() {
+        let raw = "Brain says: {\"verdict\":\"accept\",\"rationale\":\"ok\"} and that's that.";
+        let parsed = parse_reviewer_response(raw).expect("parse ok");
+        assert_eq!(parsed.verdict, "accept");
+    }
+
+    #[test]
+    fn parser_rejects_empty_response() {
+        assert!(parse_reviewer_response("").is_err());
+        assert!(parse_reviewer_response("   ").is_err());
+    }
+
+    #[test]
+    fn render_prompt_substitutes_all_placeholders() {
+        let stub = StubSubmitter {
+            response: Ok(r#"{"verdict":"accept","rationale":"ok"}"#.to_string()),
+        };
+        let c = LlmReviewerProgressChecker::new(stub);
+        let mut g = goal_with_activity(Some("a plan that says things"));
+        g.id = "my-goal-id".into();
+        g.description = "a problem description".into();
+        let rendered = c.render_prompt(&g, 25, 40);
+        assert!(rendered.contains("my-goal-id"), "missing goal_id");
+        assert!(
+            rendered.contains("a problem description"),
+            "missing problem"
+        );
+        assert!(rendered.contains("a plan that says things"), "missing plan");
+        assert!(rendered.contains("25"), "missing prior_pct");
+        assert!(rendered.contains("40"), "missing claimed_pct");
+        // No literal placeholder leftovers
+        assert!(
+            !rendered.contains("{goal_id}"),
+            "unsubstituted goal_id placeholder"
+        );
+        assert!(
+            !rendered.contains("{problem}"),
+            "unsubstituted problem placeholder"
+        );
+        assert!(
+            !rendered.contains("{plan}"),
+            "unsubstituted plan placeholder"
+        );
+        assert!(
+            !rendered.contains("{prior_pct}"),
+            "unsubstituted prior_pct placeholder"
+        );
+        assert!(
+            !rendered.contains("{claimed_pct}"),
+            "unsubstituted claimed_pct placeholder"
+        );
+        assert!(
+            !rendered.contains("{wip_summary}"),
+            "unsubstituted wip_summary placeholder"
+        );
+    }
+}

--- a/src/goal_curation/progress_reviewer.rs
+++ b/src/goal_curation/progress_reviewer.rs
@@ -188,12 +188,11 @@ fn parse_reviewer_response(raw: &str) -> Result<ReviewerResponse, String> {
         }
     }
     // 4. outermost braces fallback
-    if let (Some(first), Some(last)) = (stripped.find('{'), stripped.rfind('}')) {
-        if first < last {
-            if let Ok(parsed) = serde_json::from_str::<ReviewerResponse>(&stripped[first..=last]) {
-                return Ok(parsed);
-            }
-        }
+    if let (Some(first), Some(last)) = (stripped.find('{'), stripped.rfind('}'))
+        && first < last
+        && let Ok(parsed) = serde_json::from_str::<ReviewerResponse>(&stripped[first..=last])
+    {
+        return Ok(parsed);
     }
     Err(format!(
         "{ADAPTER_TAG} response had no parseable JSON object; raw={:?}",

--- a/src/ooda_brain/prompt_store.rs
+++ b/src/ooda_brain/prompt_store.rs
@@ -63,6 +63,8 @@ const EMBEDDED_DECIDE: &str = include_str!("../../prompt_assets/simard/ooda_deci
 const EMBEDDED_ORIENT: &str = include_str!("../../prompt_assets/simard/ooda_orient.md");
 const EMBEDDED_MERGE_JUDGE: &str =
     include_str!("../../prompt_assets/simard/merge_readiness_judge.md");
+const EMBEDDED_PROGRESS_REVIEWER: &str =
+    include_str!("../../prompt_assets/simard/progress_assessment_reviewer.md");
 
 /// Look up the embedded fallback for a known prompt name. Returns `None` for
 /// unknown names so callers can surface a configuration error rather than
@@ -73,6 +75,7 @@ pub fn embedded_fallback(name: &str) -> Option<&'static str> {
         "ooda_decide.md" => Some(EMBEDDED_DECIDE),
         "ooda_orient.md" => Some(EMBEDDED_ORIENT),
         "merge_readiness_judge.md" => Some(EMBEDDED_MERGE_JUDGE),
+        "progress_assessment_reviewer.md" => Some(EMBEDDED_PROGRESS_REVIEWER),
         _ => None,
     }
 }

--- a/src/operator_commands_ooda/daemon/mod.rs
+++ b/src/operator_commands_ooda/daemon/mod.rs
@@ -194,9 +194,13 @@ pub fn run_ooda_daemon(
         );
     }
 
-    // Wire the progress-evidence checker (issue #1967). Honors
-    // `SIMARD_PROGRESS_EVIDENCE=off` as a kill switch (see
-    // docs/operations/progress-evidence-kill-switch.md).
+    // Wire the progress-evidence checker (issue #1967; replaced 2026-05-22
+    // per user direction to use an LLM reviewer instead of the original
+    // git-shelling state-machine gate). Honors `SIMARD_PROGRESS_EVIDENCE=off`
+    // as a kill switch (see docs/operations/progress-evidence-kill-switch.md).
+    //
+    // The reviewer takes {problem, plan, prior_pct, claimed_pct, wip} and
+    // returns {verdict, rationale}. No git/gh shellouts.
     let repo_root = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
     let kill_switch = std::env::var("SIMARD_PROGRESS_EVIDENCE")
         .ok()
@@ -211,19 +215,32 @@ pub fn run_ooda_daemon(
         );
         std::sync::Arc::new(crate::goal_curation::progress_evidence::NoopProgressEvidenceChecker)
     } else {
-        daemon_log(
-            &state_root,
-            &format!(
-                "[simard] progress-evidence: enabled (DefaultProgressEvidenceChecker, repo_root={}, remote=rysweet/Simard)",
-                repo_root.display()
-            ),
-        );
-        std::sync::Arc::new(
-            crate::goal_curation::progress_evidence::DefaultProgressEvidenceChecker::new(
-                repo_root.clone(),
-                "rysweet/Simard",
-            ),
-        )
+        match LlmProvider::resolve() {
+            Ok(reviewer_provider) => {
+                daemon_log(
+                    &state_root,
+                    "[simard] progress-evidence: enabled (LlmReviewerProgressChecker -- problem+plan+progress LLM reviewer)",
+                );
+                let reviewer_submitter =
+                    crate::ooda_brain::SessionLlmSubmitter::new(reviewer_provider);
+                std::sync::Arc::new(
+                    crate::goal_curation::progress_reviewer::LlmReviewerProgressChecker::new(
+                        reviewer_submitter,
+                    ),
+                )
+            }
+            Err(e) => {
+                daemon_log(
+                    &state_root,
+                    &format!(
+                        "[simard] progress-evidence: NO LLM PROVIDER ({e}); falling back to NoopProgressEvidenceChecker (no gating)"
+                    ),
+                );
+                std::sync::Arc::new(
+                    crate::goal_curation::progress_evidence::NoopProgressEvidenceChecker,
+                )
+            }
+        }
     };
 
     let mut bridges = OodaBridges {


### PR DESCRIPTION
## Problem

PR #1970 introduced `DefaultProgressEvidenceChecker` — a Rust state-machine
that shells out to `git log` + `gh` to decide whether engineer-claimed
progress is real. The user's response on review (2026-05-22):

> "wtf is an evidence gate? I thought you were shifting things to use the
> recipes and agentic assessments"
>
> "the progress assessment should be an llm reviewing the problem, the
> plan, and the progress against the plan, thats all"

That gate is exactly the anti-pattern that issue #1971 (OODA-as-recipe)
names: a brittle Rust state-machine patched in to compensate for the loop
behaviour belonging in an agentic loop.

## Solution

New `LlmReviewerProgressChecker` impl of `ProgressEvidenceChecker`:

- Single LLM call (`amplihack` subprocess via existing `SessionLlmSubmitter`)
- Input: `{goal_id, problem (description), plan (current_activity), prior_pct, claimed_pct, wip_summary (PRs/issues/branches/sessions)}`
- Output: `{verdict: accept|reject, rationale: String}` parsed via the same
  multi-strategy parser as `merge_judge` (as-is → fenced → balanced → outermost)
- Downward self-correction (`claimed_pct < prior_pct`) auto-accepted without LLM call
- No change (`claimed_pct == prior_pct`) auto-accepted without LLM call
- Infrastructure failure (LLM submit error) → accept with diagnostic
- Parse error / unknown verdict → accept with diagnostic
  (Rationale: don't block goals on transport hiccups; the gate's job is to
  catch hallucinated jumps, not to be a brittle infra dependency)

Production wiring in `daemon/mod.rs`:

```rust
let kill_switch = std::env::var("SIMARD_PROGRESS_EVIDENCE").ok()
    .map(|v| v.eq_ignore_ascii_case("off")).unwrap_or(false);
let progress_evidence = if kill_switch {
    Arc::new(NoopProgressEvidenceChecker)
} else {
    match LlmProvider::resolve() {
        Ok(p) => Arc::new(LlmReviewerProgressChecker::new(
            SessionLlmSubmitter::new(p))),
        Err(_) => Arc::new(NoopProgressEvidenceChecker), // no LLM → no gate
    }
};
```

Existing `SIMARD_PROGRESS_EVIDENCE=off` kill-switch preserved.

`DefaultProgressEvidenceChecker` retained but unwired — dead code cleanup
in a follow-up PR to keep this diff focused on the swap.

## Evidence

### Build
```
cargo build --release --bin simard
   Compiling simard v0.17.0 (/home/azureuser/src/Simard/worktrees/main)
    Finished `release` profile [optimized] target(s) in 1m 57s
```

### Tests
```
cargo test --release --lib goal_curation::progress_reviewer
running 11 tests
test ...::downward_move_is_always_accepted_without_llm_call ... ok
test ...::no_change_is_accepted_without_llm_call ... ok
test ...::llm_accept_response_yields_accept_decision ... ok
test ...::llm_reject_response_yields_reject_decision ... ok
test ...::llm_submit_failure_falls_back_to_accept ... ok
test ...::parse_error_falls_back_to_accept ... ok
test ...::unknown_verdict_falls_back_to_accept ... ok
test ...::parser_handles_fenced_json ... ok
test ...::parser_handles_brace_balanced_inside_prose ... ok
test ...::parser_rejects_empty_response ... ok
test ...::render_prompt_substitutes_all_placeholders ... ok
test result: ok. 11 passed; 0 failed
```

Broader regression:
```
cargo test --release --lib goal_curation
test result: ok. 162 passed; 0 failed; 0 ignored; 0 measured; 4169 filtered out
```

### Format
```
cargo fmt   # clean
```

## Risk / Rollback

**Risk: low.** Trait + kill-switch preserved. On LLM-provider unavailable,
behaviour falls back to `Noop` (no gating) with a daemon-log line — matches
prior behaviour when `SIMARD_PROGRESS_EVIDENCE=off`.

**Rollback**: revert this PR; daemon resumes using
`DefaultProgressEvidenceChecker` (still in tree, just unwired).

**Kill-switch (already exists)**: `SIMARD_PROGRESS_EVIDENCE=off` forces
`NoopProgressEvidenceChecker`. Operators can disable gating instantly without
a redeploy.

## Scope

5 files changed, +645/-16:
- `prompt_assets/simard/progress_assessment_reviewer.md` — NEW prompt (4148 chars, 3 worked examples)
- `src/goal_curation/progress_reviewer.rs` — NEW module (~440 lines incl. 11 tests)
- `src/goal_curation/mod.rs` — `pub mod progress_reviewer;`
- `src/ooda_brain/prompt_store.rs` — register `progress_assessment_reviewer.md` in `embedded_fallback()`
- `src/operator_commands_ooda/daemon/mod.rs` — swap checker wiring

## Linked issues

- Follow-up to: #1970 (introduced the git-shelling gate)
- Cross-refs: #1971 (architectural — OODA-as-recipe, 2-4 week refactor)
- Pattern reference: `src/stewardship/merge_judge.rs::LlmMergeJudge`

🤖 Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>