### PR TITLE
docs: update stale git-evidence references to reflect LLM reviewer (#2007 follow-up)

### DIFF
--- a/docs/concepts/progress-evidence-gating.md
+++ b/docs/concepts/progress-evidence-gating.md
@@ -177,16 +177,16 @@ The gate emits one cognitive-memory episode per non-bypass decision.
 **On `Accept`** (low importance, 0.4):
 
 ```
-goal progress accepted: 64%→72% on improve-simard-dashboard
-  — evidence: progress-assessment-reviewer: accept — PR #1998 in flight, 8pt delta matches plan
+goal progress accepted: 64%->72% on improve-simard-dashboard
+  -- evidence: progress-assessment-reviewer: accept — PR #1998 in flight, 8pt delta matches plan
 ```
 
 **On `Reject`** (higher importance, 0.7) — the prefix is exact and stable
 so dashboards and consolidation jobs can match it:
 
 ```
-brain hallucination detected: rejected progress 35%→75% on enhance-simard-meeting-experience
-  — no git evidence since last update: progress-assessment-reviewer: reject — 75% claim with no plan and no WIP; likely hallucinated
+brain hallucination detected: rejected progress 35%->75% on enhance-simard-meeting-experience
+  -- reviewer rationale: progress-assessment-reviewer: reject — 75% claim with no plan and no WIP; likely hallucinated
 ```
 
 These episodes flow through the existing cognitive-memory pipeline:

--- a/docs/concepts/progress-evidence-gating.md
+++ b/docs/concepts/progress-evidence-gating.md
@@ -1,7 +1,7 @@
 ---
 title: Progress-evidence gating
-description: How Simard refuses to bump a goal's completion percentage unless a verifiable git artifact backs the claim.
-last_updated: 2026-05-21
+description: How Simard refuses to bump a goal's completion percentage unless an LLM reviewer confirms the claim is coherent with the plan.
+last_updated: 2026-05-22
 owner: simard
 doc_type: concept
 related:
@@ -44,35 +44,50 @@ The single guiding principle of the fix is:
 > **No progress increase without a verifiable git artifact since the last
 > update.**
 
-## The three accepted forms of evidence
+## How evidence is evaluated
 
 A proposed increase from `old_percent` to `new_percent` for goal `G` is
-accepted if **any one** of the following is true since `G`'s last accepted
-update (`G.last_progress_update_at`):
+submitted to an **LLM reviewer** (`LlmReviewerProgressChecker` in
+`src/goal_curation/progress_reviewer.rs`). The reviewer reads five inputs —
+the goal's **problem** description, **plan** (current activity), **prior
+percent**, **claimed percent**, and **WIP summary** — and returns
+`{verdict: "accept"|"reject", rationale: "..."}`.
 
-1. **Local commit on an engineer branch.** At least one commit exists on a
-   branch matching `engineer/{slug(G.id)}-*` with author-date `>= since`.
-2. **PR referencing the goal.** At least one PR (any state) on
-   `rysweet/Simard` whose title or body contains either the goal slug or any
-   `ref_id` listed in `G.wip_refs`, created at or after `since`.
-3. **Merged PR closing a wip-ref issue.** At least one PR with
-   `state="MERGED"` and `mergedAt >= since` whose body matches a
-   `Closes/Fixes/Resolves #NNNN` clause where `NNNN` is an issue in
-   `G.wip_refs`.
+The reviewer **accepts** when the claimed percent is coherent with the plan:
 
-If none match, the gate rejects the update, the prior percent is kept, and
-the rejection is recorded as a cognitive-memory episode (see
-[Audit trail](#audit-trail)).
+- The plan describes work in flight, and the delta is small and proportional.
+- The plan describes plausibly complete work, and the claimed percent matches.
+- The plan is empty but WIP references list concrete artifacts and the delta
+  is modest.
 
-### Why "any-of" rather than "all-of"
+The reviewer **rejects** when the claimed percent looks hallucinated:
 
-Real progress takes many shapes. A long-running spike may produce commits on
-a personal branch before a PR exists. A documentation-only fix may land as a
-PR with no engineer branch. A bug closed by an external contributor may merge
-without ever touching an engineer branch. Requiring all three signals
-simultaneously would block legitimate work; requiring any one of them blocks
-only the failure mode we observed — brain output with **zero** corresponding
-artifacts.
+- A large delta with no matching plan or WIP.
+- A 100% claim with no shipped artifact in the plan or WIP.
+- A claim that contradicts the plan (e.g. "blocked on review" but claims 90%).
+
+On **LLM infrastructure failure** (transport error, parse error, empty
+response), the reviewer **accepts** with a diagnostic rationale. The gate's
+purpose is to catch hallucinated jumps, not to block goals on LLM
+availability.
+
+> **History:** Prior to PR #2007/#2011, evidence was gathered via `git log`
+> and `gh pr list` shellouts (the `DefaultProgressEvidenceChecker`). Per user
+> direction: "the progress assessment should be an LLM reviewing the problem,
+> the plan, and the progress against the plan, that's all." The git/gh
+> shellout code was removed entirely in PR #2011.
+
+### Why LLM review rather than git-artifact matching
+
+The original three-rule git/gh matcher was brittle in practice. Real progress
+takes many shapes that do not always produce engineer branches or PRs by the
+time the brain makes a progress claim. An LLM reviewer can assess whether a
+claimed delta is *proportional to the described plan* — a judgment call that
+a fixed-rule state machine cannot make.
+
+The trade-off is that the reviewer depends on LLM availability. The fail-open
+design means an LLM outage degrades to pre-#1967 behavior (all claims
+accepted) rather than blocking all goals.
 
 ### What does *not* count as evidence
 
@@ -163,7 +178,7 @@ The gate emits one cognitive-memory episode per non-bypass decision.
 
 ```
 goal progress accepted: 64%→72% on improve-simard-dashboard
-  — evidence: commit a1b2c3d on engineer/improve-simard-dashboard-2026-05-21 at 2026-05-21T02:14:08Z
+  — evidence: progress-assessment-reviewer: accept — PR #1998 in flight, 8pt delta matches plan
 ```
 
 **On `Reject`** (higher importance, 0.7) — the prefix is exact and stable
@@ -171,7 +186,7 @@ so dashboards and consolidation jobs can match it:
 
 ```
 brain hallucination detected: rejected progress 35%→75% on enhance-simard-meeting-experience
-  — no git evidence since last update: no commits on engineer/enhance-simard-meeting-experience-*, no PRs referencing goal, no merged PRs closing #1951 since 2026-05-19T23:06:48Z
+  — no git evidence since last update: progress-assessment-reviewer: reject — 75% claim with no plan and no WIP; likely hallucinated
 ```
 
 These episodes flow through the existing cognitive-memory pipeline:
@@ -201,16 +216,15 @@ events, not silent suppressions.
 | `NotStarted` resets | No (bypass) | Decrease; cannot inflate dashboard. |
 | Decreases & equal-value writes | No (bypass) | Same. |
 | Dashboard `PUT /api/goals/<id>/progress` | **No** | Intentional operator override; documented as such. |
-| `gh` / `git` not available on daemon host | Gate Rejects | Treat tooling absence as "no evidence". See [kill switch](../operations/progress-evidence-kill-switch.md). |
+| `gh` / `git` not available on daemon host | N/A | The LLM reviewer does not shell out to `gh` or `git`. |
 
 ## Performance
 
 The gate fires only on progress-**increase** attempts — typically a handful
 per OODA cycle, not per cycle wall-clock. Each fire executes at most one
-`git for-each-ref` + one `git log` + one `gh pr list`. On a quiet repo the
-combined wall-time is well under the existing OODA cycle budget. A
-per-cycle in-memory cache for `gh pr list` results is reserved for v2 if
-profiling identifies it as hot.
+LLM call (the `LlmReviewerProgressChecker` submits a single prompt).
+Downward/no-change moves are auto-accepted without an LLM call. The
+prompt template is kept short to minimize latency.
 
 ## Related work
 

--- a/docs/howto/diagnose-rejected-progress-claims.md
+++ b/docs/howto/diagnose-rejected-progress-claims.md
@@ -25,9 +25,8 @@ attempted percent transition, the cutoff timestamp, and the checker's
 reason string. Example:
 
 ```
-brain hallucination detected: rejected progress 35%→75% on enhance-simard-meeting-experience
-  — no git evidence since last update: no commits on engineer/enhance-simard-meeting-experience-*,
-    no PRs referencing goal, no merged PRs closing #1951 since 2026-05-19T23:06:48Z
+brain hallucination detected: rejected progress 35%->75% on enhance-simard-meeting-experience
+  -- reviewer rationale: progress-assessment-reviewer: reject — 75% claim with no plan and no WIP; likely hallucinated
 ```
 
 ### From the command line
@@ -71,8 +70,8 @@ The reason string follows a fixed template. The LLM reviewer returns a
 short rationale explaining why the progress claim was rejected:
 
 ```
-brain hallucination detected: rejected progress 35%→75% on enhance-simard-meeting-experience
-  — no git evidence since last update: progress-assessment-reviewer: reject — 75% claim with no plan and no WIP; likely hallucinated
+brain hallucination detected: rejected progress 35%->75% on enhance-simard-meeting-experience
+  -- reviewer rationale: progress-assessment-reviewer: reject — 75% claim with no plan and no WIP; likely hallucinated
 ```
 
 The `progress-assessment-reviewer:` prefix identifies that the rejection
@@ -199,9 +198,9 @@ the kill switch on in production — see
 ## 5. After the underlying issue is fixed
 
 The gate is stateless across daemon runs (modulo the `OnceLock`
-process-start fallback). Once the missing branch, PR, or `gh` auth is
-in place, the next OODA cycle that proposes the same increase will go
-through the checker fresh. On `Accept`:
+process-start fallback). Once the underlying plan or WIP is updated to
+reflect actual work, the next OODA cycle that proposes the same increase
+will go through the checker fresh. On `Accept`:
 
 - The goal's `last_progress_update_at` is set to the cycle wall-clock.
 - A `"goal progress accepted:"` episode is written to memory.

--- a/docs/howto/diagnose-rejected-progress-claims.md
+++ b/docs/howto/diagnose-rejected-progress-claims.md
@@ -67,19 +67,26 @@ journalctl --user -u simard-ooda -n 5000 | grep 'brain hallucination detected'
 
 ## 2. Read the rejection reason
 
-The reason string follows a fixed template. Each comma-separated clause
-corresponds to one of the three evidence rules:
+The reason string follows a fixed template. The LLM reviewer returns a
+short rationale explaining why the progress claim was rejected:
 
-| Clause | Means | Rule |
-|---|---|---|
-| `no commits on engineer/<slug>-*` | No local branch matching the engineer pattern has a commit at or after `since`. | (1) Local commit |
-| `no PRs referencing goal` | No PR on `rysweet/Simard` (any state, any age within the search window) mentions the goal slug or any `wip_refs` id. | (2) PR cross-reference |
-| `no merged PRs closing #<issue-list>` | No PR was merged at or after `since` whose body contains `Closes/Fixes/Resolves #N` for any `N` in the goal's `wip_refs`. | (3) Merged-PR closer |
-| `since <iso8601>` | The cutoff used. Anything older than this is ignored. | — |
+```
+brain hallucination detected: rejected progress 35%→75% on enhance-simard-meeting-experience
+  — no git evidence since last update: progress-assessment-reviewer: reject — 75% claim with no plan and no WIP; likely hallucinated
+```
 
-If only **one** of the three clauses appears, the others were
-short-circuited by a different match. If all three appear, every rule
-failed.
+The `progress-assessment-reviewer:` prefix identifies that the rejection
+came from the LLM reviewer. The rationale after the dash is the reviewer's
+one-sentence explanation.
+
+Common rejection patterns:
+
+| Rationale pattern | Means |
+|---|---|
+| Large delta with no plan/WIP | The brain claimed a big jump but the goal has no current activity or WIP references. |
+| 100% claim with no shipped artifact | The brain marked the goal complete but the plan doesn't mention a shipped PR or merged change. |
+| Claim contradicts plan | The plan says "blocked" or "investigating" but the brain claimed high progress. |
+| No plan, big jump | The goal has no `current_activity` set and the percent jumped significantly. |
 
 ---
 
@@ -87,9 +94,8 @@ failed.
 
 ### Case A: The brain hallucinated, the gate worked correctly
 
-- The engineer subprocess produced no branches.
-- No PR exists for the goal.
-- No merged PR closes a `wip_refs` issue.
+- The goal has no current plan or WIP references.
+- The brain claimed a large delta despite no described work.
 - The dashboard percent stayed at its prior value.
 
 **Action:** None on the gate. This is the intended behavior. If you want
@@ -98,37 +104,37 @@ REPL to set a concrete next step — see
 [Start a meeting](start-a-meeting.md) and
 [Carry meeting decisions into engineer sessions](carry-meeting-decisions-into-engineer-sessions.md).
 
-### Case B: Real work happened but on the wrong branch
+### Case B: The plan is set but the reviewer misjudged
 
-`git branch --list 'engineer/*'` shows no branch for the goal, but you
-know an engineer made commits on a differently-named branch.
+The goal has a meaningful `current_activity` and/or WIP references, but
+the reviewer still rejected the claim. This could mean:
 
-**Action:** This is an engineer-spawn bug, not a gate bug. The engineer
-should be writing to `engineer/<goal-slug>-<timestamp>` (see
-[Spawn engineers from OODA daemon](spawn-engineers-from-ooda-daemon.md)).
-File an issue against the spawn path and reference the rejection
-episode.
+- The plan text is too vague for the reviewer to correlate with the
+  claimed delta (e.g. "working on stuff" → 80%).
+- The WIP references are stale or don't match what the brain described.
 
-### Case C: A PR exists but the gate did not find it
+**Action:** Update the goal's `current_activity` to accurately describe
+the work being done. The reviewer compares the claimed delta against the
+plan — a clearer plan leads to better accept/reject decisions. If the
+reviewer is consistently wrong despite good plans, file a bug against the
+prompt template at `prompt_assets/simard/progress_assessment_reviewer.md`.
+
+### Case C: The reviewer accepted on infrastructure failure
+
+The LLM reviewer fails open — if the LLM endpoint is down or returns
+unparseable output, the gate accepts with a diagnostic rationale containing
+`"LLM submit failed"` or `"parse error"`. This is by design (the gate
+should not block goals on LLM availability), but if it happens frequently:
 
 ```bash
-gh pr list --repo rysweet/Simard --search '<goal-slug or issue#>' --state all \
-  --json number,title,body,state,createdAt,mergedAt | jq .
+curl -s -X POST http://localhost:8080/api/memory/search \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"LLM submit failed"}' \
+  | jq -r '.results[].data'
 ```
 
-If the PR exists but `gh pr list` returns nothing, one of:
-
-- `gh` is unauthenticated on the daemon host (`gh auth status`).
-- The PR's title and body do **not** mention the goal slug or any
-  `wip_refs` id. The gate cannot find what is not referenced.
-- The PR's `createdAt` is before `since`. This is intended — once a
-  goal's last-update timestamp moves forward, older PRs no longer count
-  as fresh evidence. Either the goal needs a new PR or its
-  `last_progress_update_at` was reset spuriously.
-
-**Action:** If `gh` is broken, fix it and the next cycle will Accept. If
-the PR is unreferenced, edit its body to mention the goal id or relevant
-issue number — this is also good practice for human reviewers.
+**Action:** Investigate the LLM endpoint availability. Frequent fail-open
+accepts mean the gate is effectively disabled.
 
 ### Case D: The `since` timestamp looks wrong
 
@@ -221,18 +227,17 @@ curl -s -X POST http://localhost:8080/api/memory/search \
   -d '{"query":"goal progress accepted"}' \
   | jq -r '.results[] | "\(.source)\t\(.data | tostring | .[0:200])"'
 
+# Find LLM infrastructure failures (fail-open accepts)
+curl -s -X POST http://localhost:8080/api/memory/search \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"LLM submit failed"}' \
+  | jq -r '.results[] | "\(.source)\t\(.data | tostring | .[0:200])"'
+
 # Confirm the gate is on (drop --user for system-level installs)
 journalctl --user -u simard-ooda -n 500 | grep 'progress-evidence:'
 
-# Confirm gh works for the daemon user
-gh auth status
-gh pr list --repo rysweet/Simard --limit 3
-
-# List engineer branches the gate would scan for goal G
-GOAL=enhance-simard-meeting-experience
-git -C ~/src/Simard for-each-ref --format='%(refname:short)' "refs/heads/engineer/${GOAL}-*"
-
 # Inspect the last_progress_update_at field directly
+GOAL=enhance-simard-meeting-experience
 simard goal show --id "$GOAL" --json | jq .last_progress_update_at
 ```
 

--- a/docs/operations/progress-evidence-kill-switch.md
+++ b/docs/operations/progress-evidence-kill-switch.md
@@ -17,7 +17,7 @@ the API is documented in
 
 | Value | Behavior |
 |---|---|
-| Unset, or any value other than `off` (case-insensitive) | `OodaBridges.progress_evidence` is wired to `DefaultProgressEvidenceChecker` against the daemon's `repo_root` and `rysweet/Simard`. Progress increases require git evidence. |
+| Unset, or any value other than `off` (case-insensitive) | `OodaBridges.progress_evidence` is wired to `LlmReviewerProgressChecker`, which delegates to an LLM to verify that proposed progress claims are coherent with the goal's plan and WIP artifacts. |
 | `off` (case-insensitive) | `OodaBridges.progress_evidence` is wired to `NoopProgressEvidenceChecker`. Every progress claim is accepted. **No `"goal progress accepted:"` or `"brain hallucination detected:"` audit episodes are emitted.** |
 
 The variable is read once, at daemon startup, in the bridge-construction
@@ -31,13 +31,14 @@ to pick up a new value.
 There are exactly three legitimate uses. If you find yourself reaching for
 the kill switch outside of these, file a bug instead.
 
-1. **`gh` outage or auth failure on the daemon host.** When
-   `gh pr list` fails for an extended period, every increase attempt that
-   would have matched rule (2) or (3) will be rejected. Setting `off`
-   restores pre-#1967 behavior while you re-auth `gh` or wait for the
-   outage to clear.
+1. **LLM outage or model-provider failure on the daemon host.** When
+   the LLM endpoint is unavailable for an extended period, the reviewer
+   will fail open (accept with a diagnostic rationale), so the kill switch
+   is less urgent than it was with the old `gh`-based checker. However,
+   if you want to eliminate the LLM calls entirely during an outage to
+   reduce noise in audit logs, set `off`.
 2. **Investigating a regression in the gate itself.** If you suspect the
-   checker is rejecting a legitimate claim and you need a quick
+   reviewer is rejecting a legitimate claim and you need a quick
    side-by-side comparison of the daemon's behavior with and without the
    gate, toggle the variable on a non-production daemon and re-run the
    cycle.
@@ -118,7 +119,7 @@ The daemon logs the active checker at boot. The format is pinned by
 are stable; the parenthetical detail may evolve.
 
 ```
-[simard] progress-evidence: enabled (DefaultProgressEvidenceChecker, repo_root=/home/azureuser/src/Simard, remote=rysweet/Simard)
+[simard] progress-evidence: enabled (LlmReviewerProgressChecker)
 ```
 
 Or:
@@ -153,18 +154,20 @@ curl -s -X POST http://localhost:8080/api/memory/search \
 
 ## Failure modes the kill switch addresses
 
-Reject reason-string substrings are pinned by the runner error contract
-documented in design §2.7. Triage by `grep`'ing the
-`"brain hallucination detected:"` episode body for the substring in the
-left column:
+The LLM reviewer fails open by design — LLM transport errors, JSON parse
+errors, and empty responses all result in `Accept` with a diagnostic
+rationale (see [Progress-evidence API](../reference/progress-evidence-api.md)).
+This means the kill switch is **less critical** for infrastructure failures
+than it was with the old `DefaultProgressEvidenceChecker` (which rejected
+on `gh`/`git` errors).
 
-| Substring in `reason` | Likely cause | Remedy |
-|---|---|---|
-| `gh: command not found` | `gh` is not installed or not on the daemon's `PATH`. | Install `gh`; remove the kill switch. |
-| `gh: authentication required` | The daemon's `gh` token expired or was revoked. | `gh auth login` as the daemon user; remove the kill switch. |
-| `git: not a git repository` | `repo_root` resolves to a non-repo path (e.g. daemon launched from `/`). | Launch the daemon from the repo root, or override via the daemon-boot wiring. |
-| `git: io error` / `gh: io error` | Catch-all process-spawn failure (broken pipe, ENOSPC, etc.). | Inspect the trailing `<detail>` portion of the reason string. |
-| Genuine engineer commits exist but the gate still rejects | Branch name does not match `engineer/<slug>-*` pattern. | File a bug. Do not paper over with the kill switch. |
+The kill switch is still useful for:
+
+| Scenario | When to use kill switch |
+|---|---|
+| LLM reviewer producing excessive false rejections | Disable while debugging the prompt; restore when fixed. |
+| Investigating daemon behavior unrelated to progress | Remove one variable from the investigation. |
+| Daemon deployed without LLM access (e.g. air-gapped test) | The reviewer already fails open, but `off` avoids LLM call attempts entirely. |
 
 ---
 
@@ -172,7 +175,7 @@ left column:
 
 When the underlying issue is resolved, remove the environment variable
 and restart the daemon. Confirm via the boot log line above that
-`DefaultProgressEvidenceChecker` is active. The next cycle that involves
+`LlmReviewerProgressChecker` is active. The next cycle that involves
 a progress claim should produce either an `Accept` or a `Reject` audit
 episode in cognitive memory.
 

--- a/docs/reference/progress-evidence-api.md
+++ b/docs/reference/progress-evidence-api.md
@@ -202,8 +202,8 @@ pub fn update_goal_progress_with_evidence(
       - Set `goal.last_progress_update_at = Some(now)`.
       - Emit one episode:
         ```
-        goal progress accepted: <old>%→<new>% on <goal-id>
-          — evidence: <checker reason>
+        goal progress accepted: <old>%-><new>% on <goal-id>
+          -- evidence: <checker reason>
         ```
         importance `0.4`.
       - Return `Ok(Accept { reason })`.
@@ -211,8 +211,8 @@ pub fn update_goal_progress_with_evidence(
       - Do **not** mutate the board.
       - Emit one episode:
         ```
-        brain hallucination detected: rejected progress <old>%→<new>% on <goal-id>
-          — no git evidence since last update: <checker reason>
+        brain hallucination detected: rejected progress <old>%-><new>% on <goal-id>
+          -- reviewer rationale: <checker reason>
         ```
         importance `0.7`.
       - Return `Ok(Reject { reason })`. **This is not an error.** The

--- a/docs/reference/progress-evidence-api.md
+++ b/docs/reference/progress-evidence-api.md
@@ -4,11 +4,17 @@ Crate: `simard` · Module: `simard::goal_curation::progress_evidence`
 
 This module implements the gatekeeper described in
 [Progress-evidence gating](../concepts/progress-evidence-gating.md). It
-exposes one trait (`ProgressEvidenceChecker`), two production helper traits
-for shell-out seams (`GitRunner`, `GhRunner`), two concrete implementations
-(`DefaultProgressEvidenceChecker`, `NoopProgressEvidenceChecker`), and a
-single façade function (`update_goal_progress_with_evidence`) in the
+exposes one trait (`ProgressEvidenceChecker`), two concrete implementations
+(`LlmReviewerProgressChecker` in
+`simard::goal_curation::progress_reviewer`, `NoopProgressEvidenceChecker`),
+and a single façade function (`update_goal_progress_with_evidence`) in the
 sibling `simard::goal_curation::operations` module.
+
+> **History:** Prior to PR #2007, the production implementation was
+> `DefaultProgressEvidenceChecker`, which shelled out to `git log` and
+> `gh pr list`. That struct and its helper traits (`GitRunner`, `GhRunner`)
+> were removed in PR #2011. The gate now delegates to an LLM reviewer —
+> no subprocess calls, no local tooling requirements.
 
 All public symbols below are re-exported from `simard::goal_curation`.
 
@@ -52,17 +58,18 @@ can be installed on `OodaBridges` and shared across all OODA actions.
 ### Contract
 
 - `check` MUST NOT mutate the goal board, cognitive memory, or any other
-  daemon state. It is a read-only function over the local repo and remote
-  GitHub.
-- `check` MAY perform blocking I/O (git/gh shellouts). It is called at most
+  daemon state. It is a read-only decision function.
+- `check` MAY perform blocking I/O (LLM calls). It is called at most
   a few times per OODA cycle, only on progress-increase attempts.
-- `check` MUST return `Accept` when evidence is found and `Reject`
-  otherwise. It MUST NOT return `Accept` on shellout failure — tooling
-  absence is treated as "no evidence" (see
+- `check` MUST return `Accept` when evidence supports the claim and
+  `Reject` otherwise. The production `LlmReviewerProgressChecker`
+  accepts on LLM infrastructure failure (transport error, parse error,
+  empty response) — the gate's purpose is to catch hallucinated jumps,
+  not to block goals on LLM availability. See
   [`SIMARD_PROGRESS_EVIDENCE`](../operations/progress-evidence-kill-switch.md)
-  for the operator escape hatch).
+  for the operator escape hatch.
 - The `since` argument is provided by the caller; the trait does not
-  source it.
+  source it (the LLM reviewer ignores it — decisions are prompt-based).
 
 ### Parameters
 
@@ -73,118 +80,57 @@ can be installed on `OodaBridges` and shared across all OODA actions.
 | `new_percent` | `u32` | The proposed new percent (0–100). Only called when `new_percent > old_percent`. |
 | `since` | `DateTime<Utc>` | The cutoff timestamp; only artifacts at or after this instant count as evidence. |
 
-### Decision rules (DefaultProgressEvidenceChecker)
+### Decision rules (LlmReviewerProgressChecker)
 
-The production implementation accepts on any of:
+The production implementation (`src/goal_curation/progress_reviewer.rs`)
+sends goal context to an LLM and parses a `{verdict, rationale}` JSON
+response. No git introspection, no `gh` shellouts — the LLM reads the
+problem, plan, and progress against the plan to determine whether the
+claimed percent is honest.
 
-| # | Source | Match | `reason` template |
-|---|---|---|---|
-| 1 | `git log` on `engineer/{slug(goal.id)}-*` | ≥1 commit with author-date `>= since` | `"commit <sha7> on <branch> at <iso8601>"` |
-| 2 | `gh pr list` on `remote_slug` | ≥1 PR (any state) with title or body containing the goal slug **or** any `wip_refs[].ref_id` of kind `issue` or `pr` | `"PR #<n> references goal"` |
-| 3 | `gh pr list` on `remote_slug` | ≥1 PR with `state == "MERGED"`, `mergedAt >= since`, body matching `(?i)\b(close[sd]?|fix(?:es|ed)?|resolve[sd]?)\s+#(\d+)\b` where `\2` is in `wip_refs` issues | `"PR #<n> closed #<issue> at <iso8601>"` |
-| 4 | — | none of the above | `Reject` with concatenated `"no commits on engineer/<slug>-*, no PRs referencing goal, no merged PRs closing #<issue-list> since <iso8601>"` |
+| Condition | Result | `reason` template |
+|---|---|---|
+| `new_percent <= old_percent` | `Accept` (auto, no LLM call) | `"progress-assessment-reviewer: downward / no-change (<old> -> <new>) auto-accepted"` |
+| LLM returns `{"verdict":"accept","rationale":"..."}` | `Accept` | `"progress-assessment-reviewer: accept — <rationale>"` |
+| LLM returns `{"verdict":"reject","rationale":"..."}` | `Reject` | `"progress-assessment-reviewer: reject — <rationale>"` |
+| LLM transport/parse error or empty response | `Accept` (fail-open) | `"progress-assessment-reviewer: LLM submit failed (<error>); accepting to avoid blocking goal"` |
+| Unknown verdict string | `Accept` (fail-open) | `"progress-assessment-reviewer: unknown verdict \"<v>\"; accepting to avoid blocking goal"` |
 
-Rules are evaluated top-to-bottom; the first match short-circuits and
-returns `Accept`.
-
----
-
-## `GitRunner`
-
-```rust
-pub trait GitRunner: Send + Sync {
-    fn list_branches(
-        &self,
-        repo_root: &Path,
-        pattern: &str,
-    ) -> io::Result<Vec<String>>;
-
-    fn commits_since(
-        &self,
-        repo_root: &Path,
-        branch: &str,
-        since: DateTime<Utc>,
-    ) -> io::Result<Vec<String>>;
-}
-```
-
-Test seam for the local-git half of `DefaultProgressEvidenceChecker`. The
-production impl (`SystemGitRunner`) wraps:
-
-- `git -C <repo_root> for-each-ref --format=%(refname:short) refs/heads/<pattern>`
-- `git -C <repo_root> log --since <iso8601> --pretty=%H <branch>`
-
-`io::Error` from either call is propagated as a `Reject` from `check`.
+The prompt template lives at
+`prompt_assets/simard/progress_assessment_reviewer.md`. It substitutes
+`{goal_id}`, `{problem}`, `{plan}`, `{prior_pct}`, `{claimed_pct}`, and
+`{wip_summary}` before submission.
 
 ---
 
-## `GhRunner`
+## `LlmReviewerProgressChecker`
 
 ```rust
-pub trait GhRunner: Send + Sync {
-    fn search_prs(
-        &self,
-        repo_slug: &str,
-        query: &str,
-    ) -> io::Result<Vec<GhPr>>;
+// In src/goal_curation/progress_reviewer.rs
+
+pub struct LlmReviewerProgressChecker<S: LlmSubmitter> {
+    submitter: S,
 }
 
-#[derive(Clone, Debug, serde::Deserialize)]
-pub struct GhPr {
-    pub number: u64,
-    pub title: String,
-    pub body: Option<String>,
-    pub state: String,
-    #[serde(rename = "createdAt")]
-    pub created_at: DateTime<Utc>,
-    #[serde(rename = "mergedAt")]
-    pub merged_at: Option<DateTime<Utc>>,
+impl<S: LlmSubmitter> LlmReviewerProgressChecker<S> {
+    pub fn new(submitter: S) -> Self;
 }
 ```
 
-Test seam for the GitHub half of `DefaultProgressEvidenceChecker`. The
-production impl (`SystemGhRunner`) shells out to:
+The production checker. Generic over `LlmSubmitter` so tests can swap in a
+canned-response stub without global state. Constructed at daemon startup
+with the daemon's active `LlmSubmitter` implementation.
 
-```
-gh pr list --repo <repo_slug> --search <query> --state all \
-   --json number,title,body,state,createdAt,mergedAt
-```
+The checker:
 
-Authentication is the daemon process's existing `gh` token (same
-credentials used by other Simard subsystems that read GitHub).
-
----
-
-## `DefaultProgressEvidenceChecker`
-
-```rust
-pub struct DefaultProgressEvidenceChecker {
-    pub repo_root: PathBuf,
-    pub remote_slug: String,
-    pub git: Arc<dyn GitRunner>,
-    pub gh:  Arc<dyn GhRunner>,
-}
-```
-
-The production checker. Constructed at daemon startup with:
-
-| Field | Production value |
-|---|---|
-| `repo_root` | `std::env::current_dir()` at boot |
-| `remote_slug` | `"rysweet/Simard"` |
-| `git` | `Arc::new(SystemGitRunner)` |
-| `gh` | `Arc::new(SystemGhRunner)` |
-
-### Custom constructor for non-default deployments
-
-```rust
-impl DefaultProgressEvidenceChecker {
-    pub fn new(repo_root: PathBuf, remote_slug: impl Into<String>) -> Self;
-}
-```
-
-Use this when the daemon runs from a directory other than the repo root or
-when targeting a fork.
+1. Auto-accepts downward/no-change moves without an LLM call.
+2. Renders the prompt template with goal context.
+3. Submits to the LLM via `submitter.submit(...)`.
+4. Parses the response JSON (tries: raw, fenced code blocks, brace-balanced
+   spans, outermost-brace fallback — same strategy as `merge_judge`).
+5. Maps `"accept"` / `"reject"` verdicts to `EvidenceDecision`.
+6. Fails open on any infrastructure error (LLM down, parse failure, unknown
+   verdict).
 
 ---
 
@@ -204,7 +150,7 @@ Always returns `Accept { reason: "noop checker (no evidence enforced)" }`.
 Used in two places:
 
 1. **Tests.** Default test-helper `OodaBridges::for_tests()` installs this
-   so existing tests do not need to mock `git`/`gh`.
+   so existing tests do not need to provide an `LlmSubmitter` implementation.
 2. **Operator escape hatch.** Selected at daemon boot when
    `SIMARD_PROGRESS_EVIDENCE=off`. See
    [the kill-switch operations doc](../operations/progress-evidence-kill-switch.md).
@@ -334,8 +280,7 @@ pub struct OodaBridges {
 
 | Field | Default at daemon boot | Default in tests |
 |---|---|---|
-| `repo_root` | `std::env::current_dir().unwrap_or_else(\|_\| PathBuf::from("."))` | `PathBuf::from(".")` |
-| `progress_evidence` | `Arc::new(DefaultProgressEvidenceChecker::new(repo_root.clone(), "rysweet/Simard"))`, or `Arc::new(NoopProgressEvidenceChecker)` when `SIMARD_PROGRESS_EVIDENCE=off` | `Arc::new(NoopProgressEvidenceChecker)` |
+| `progress_evidence` | `Arc::new(LlmReviewerProgressChecker::new(submitter))`, or `Arc::new(NoopProgressEvidenceChecker)` when `SIMARD_PROGRESS_EVIDENCE=off` | `Arc::new(NoopProgressEvidenceChecker)` |
 
 A new `OodaBridges::for_tests()` constructor wires the test defaults so
 that existing OODA-loop tests need only a single-line change to adopt the
@@ -375,11 +320,11 @@ No data migration is required.
 | Item | Stability |
 |---|---|
 | `EvidenceDecision`, `ProgressEvidenceChecker` | Public stable — semver-tracked. |
-| `GitRunner`, `GhRunner`, `GhPr` | Public stable — needed for test seams in external crates. |
 | `update_goal_progress_with_evidence` | Public stable. |
-| `DefaultProgressEvidenceChecker` internals (private helpers) | Implementation detail; may change. |
+| `LlmReviewerProgressChecker` | Public stable — generic over `LlmSubmitter`. |
 | `NoopProgressEvidenceChecker` | Public stable; safe to use in any test. |
 | Episode prefix strings (`"goal progress accepted:"`, `"brain hallucination detected:"`) | **Behaviorally stable.** The dashboard and consolidation jobs match these prefixes verbatim; changing them is a breaking change. |
+| Prompt template (`progress_assessment_reviewer.md`) | Implementation detail; may evolve. |
 
 ---
 

--- a/src/goal_curation/operations.rs
+++ b/src/goal_curation/operations.rs
@@ -843,7 +843,7 @@ pub fn update_goal_progress_with_evidence(
         EvidenceDecision::Reject { reason } => {
             // Do NOT mutate the board. Emit a hallucination alert.
             let episode = format!(
-                "brain hallucination detected: rejected progress {old_percent}%->{new_percent}% on {goal_id}\n  -- no git evidence since last update: {reason}"
+                "brain hallucination detected: rejected progress {old_percent}%->{new_percent}% on {goal_id}\n  -- reviewer rationale: {reason}"
             );
             memory.store_episode(
                 &episode,

--- a/src/goal_curation/progress_evidence.rs
+++ b/src/goal_curation/progress_evidence.rs
@@ -35,7 +35,7 @@ pub enum EvidenceDecision {
 }
 
 /// Gate trait — decides whether a proposed progress increase is backed
-/// by verifiable git artifacts.
+/// by sufficient evidence (LLM-reviewed or heuristic).
 ///
 /// `Send + Sync` so a single `Arc<dyn ProgressEvidenceChecker>` can be
 /// installed on `OodaBridges` and shared across OODA actions.
@@ -57,7 +57,7 @@ pub trait ProgressEvidenceChecker: Send + Sync {
 ///
 /// Used:
 /// 1. By tests' default bridges constructors so existing tests don't
-///    need to mock `git`/`gh`.
+///    need to provide an `LlmSubmitter` implementation.
 /// 2. As the operator escape hatch via `SIMARD_PROGRESS_EVIDENCE=off` at
 ///    daemon boot.
 pub struct NoopProgressEvidenceChecker;

--- a/src/ooda_actions/advance_goal/subordinate.rs
+++ b/src/ooda_actions/advance_goal/subordinate.rs
@@ -65,9 +65,9 @@ pub fn advance_goal_with_subordinate(
             //
             // Route the 50% heartbeat bump through
             // `update_goal_progress_with_evidence` (issue #1967): an
-            // alive engineer is NOT evidence of progress. If no commits
-            // or PRs exist since the last update, the gate Rejects and
-            // the prior percent is preserved.
+            // alive engineer is NOT evidence of progress. If the reviewer
+            // cannot confirm meaningful progress since the last update,
+            // the gate Rejects and the prior percent is preserved.
             let new_progress = GoalProgress::InProgress { percent: 50 };
             match update_goal_progress_with_evidence(
                 &mut state.active_goals,

--- a/src/ooda_actions/goal_session/advance.rs
+++ b/src/ooda_actions/goal_session/advance.rs
@@ -13,7 +13,7 @@
 //! All progress-mutation paths route through
 //! [`crate::goal_curation::update_goal_progress_with_evidence`] so a
 //! `PROGRESS: NN` line that asks for an *increase* is rejected unless
-//! verifiable git evidence (commit or PR) backs it (issue #1967).
+//! the LLM-backed reviewer confirms it (issue #1967, #2007).
 
 use chrono::Utc;
 
@@ -89,7 +89,7 @@ pub(crate) fn assess_only_outcome(
                 goal_id, reason_short, pct, rej,
             );
             let detail = format!(
-                "no-action: progress claim rejected (no git evidence): {rej} (goal '{}', proposed={}%)",
+                "no-action: progress claim rejected (reviewer): {rej} (goal '{}', proposed={}%)",
                 goal_id, pct,
             );
             make_outcome(action, true, detail)

--- a/src/ooda_loop/types.rs
+++ b/src/ooda_loop/types.rs
@@ -320,9 +320,8 @@ pub struct OodaBridges {
     /// cycle's Orient phase routes through it; otherwise it uses the
     /// `DeterministicFallbackOrientBrain` floor.
     pub orient_brain: Option<std::sync::Arc<dyn crate::ooda_brain::OodaOrientBrain>>,
-    /// Repository root used by [`crate::goal_curation::progress_evidence`]
-    /// to verify engineer-branch commits. Defaults to
-    /// `std::env::current_dir()` at daemon boot.
+    /// Repository root used by engineer loops and review persistence.
+    /// Defaults to `std::env::current_dir()` at daemon boot.
     pub repo_root: std::path::PathBuf,
     /// Gatekeeper for goal-progress increases (issue #1967). Production
     /// boot wires [`crate::goal_curation::progress_reviewer::LlmReviewerProgressChecker`];


### PR DESCRIPTION
## Problem

PR #2007 replaced `DefaultProgressEvidenceChecker` (git/gh shellouts) with
`LlmReviewerProgressChecker` (single LLM call). PR #2011 removed the dead
code. However, doc comments and log messages across 5 files still referenced
"git artifacts", "git evidence", and "git/gh" mocking — all stale after
the LLM reviewer swap.

## Changes

| File | What changed |
|------|-------------|
| `progress_evidence.rs` | Trait doc: "verifiable git artifacts" → "sufficient evidence (LLM-reviewed or heuristic)" |
| `progress_evidence.rs` | NoopChecker doc: "mock git/gh" → "provide an LlmSubmitter" |
| `operations.rs` | Reject episode: "no git evidence since last update" → "reviewer rationale" |
| `subordinate.rs` | Heartbeat comment: "no commits or PRs" → "reviewer cannot confirm" |
| `advance.rs` | Module doc + reject log: "verifiable git evidence" → "LLM-backed reviewer" |
| `types.rs` | `repo_root` doc: "used by progress_evidence" → "used by engineer loops" |

## Evidence

- `cargo check` ✅
- `cargo test --lib -- goal_curation` — 143 passed, 0 failed ✅
- `cargo fmt --check` ✅
- Pre-commit (fmt + clippy) ✅
- Pre-push (fmt + tests + clippy --all-targets) ✅

## Risk

**Minimal.** Doc comments and log strings only — no logic changes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>