### PR TITLE
feat(meeting): structured handoff schema v2 with NextActor enum (#1987)

### DIFF
--- a/docs/reference/meeting-handoff-schema.md
+++ b/docs/reference/meeting-handoff-schema.md
@@ -1,0 +1,150 @@
+# Meeting Handoff Schema v2
+
+> Reference for the `MeetingHandoff` JSON artifact produced when a meeting closes.
+> Schema version: **2** (issue #1987). Backward-compatible with v1.
+
+## Overview
+
+The meeting handoff artifact is the primary machine-readable output of a
+closed meeting session. It is consumed by:
+
+- **Engineer loop** — routes action items into the work queue.
+- **OODA curation** — feeds decisions/questions into the observe pipeline.
+- **`act-on-decisions`** — files GitHub issues from action items.
+- **Dashboard** — renders meeting summaries for operator review.
+
+## JSON Shape
+
+```jsonc
+{
+  // ── Identity ────────────────────────────────────────────────
+  "meeting_id":   "20260115T100000Z-sprint-planning",  // sortable id
+  "topic":        "Sprint Planning",
+  "started_at":   "2026-01-15T10:00:00Z",              // RFC 3339
+  "closed_at":    "2026-01-15T11:00:00Z",              // RFC 3339
+
+  // ── Schema version (v2, issue #1987) ────────────────────────
+  "schema_version": 2,       // 1 for legacy; absent → defaults to 1
+
+  // ── Core content ────────────────────────────────────────────
+  "decisions": [
+    {
+      "description": "Adopt TDD for new modules",
+      "rationale":   "Better quality",
+      "participants": ["alice"]
+    }
+  ],
+  "action_items": [
+    {
+      "description":     "Set up CI",
+      "owner":           "bob",
+      "priority":        1,
+      "due_description": "Friday",
+      "linked_issue":    null
+    }
+  ],
+  "open_questions": [
+    { "text": "What is our SLO target?", "explicit": true }
+  ],
+
+  // ── Enrichment ──────────────────────────────────────────────
+  "participants":  ["alice", "bob", "operator", "simard"],
+  "themes":        ["testing", "performance"],
+  "transcript":    ["summary text"],
+  "transcript_path": "/home/user/.simard/meetings/.../transcript.json",
+
+  // ── Routing (v1 + v2) ──────────────────────────────────────
+  "next_owner": "engineer",          // free-form (v1, kept for compat)
+  "next_actor": "engineer",          // typed enum (v2, see NextActor)
+
+  // ── Meeting objective (v2) ─────────────────────────────────
+  "goal": "Ship handoff schema v2",  // set via /goal command; null if unset
+
+  // ── Applied templates (v2) ─────────────────────────────────
+  "applied_templates": [
+    {
+      "name": "standup",
+      "agenda": "## Standup\n- Yesterday...",
+      "applied_at": "2026-01-15T10:01:00Z"
+    }
+  ],
+
+  // ── History metadata (v2) ──────────────────────────────────
+  "history_truncated_count": 0,      // turns dropped by MAX_HISTORY cap
+
+  // ── Close status (v2) ─────────────────────────────────────
+  "partial_reason": null,            // null = clean close; string = reason
+
+  // ── Artifacts (v1.5+) ─────────────────────────────────────
+  "artifacts": [
+    {
+      "kind": "transcript",
+      "uri_or_path": "/path/to/transcript.json",
+      "description": "Meeting transcript JSON"
+    },
+    {
+      "kind": "bundle",
+      "uri_or_path": "/path/to/bundle/",
+      "description": "Per-meeting handoff bundle directory"
+    }
+  ],
+
+  // ── Processing state ───────────────────────────────────────
+  "processed":     false,
+  "duration_secs": 3600
+}
+```
+
+## New Fields in v2
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `schema_version` | `u32` | `1` | Schema version tag. `2` for the enriched schema. |
+| `goal` | `string?` | `null` | Meeting's overarching objective (set via `/goal`). |
+| `next_actor` | `NextActor?` | `null` | Typed routing tag superseding `next_owner`. |
+| `applied_templates` | `AppliedTemplate[]` | `[]` | Templates applied during the meeting. |
+| `history_truncated_count` | `usize` | `0` | Conversation turns dropped by history cap. |
+| `partial_reason` | `string?` | `null` | Machine-readable partial-close reason. |
+
+## `NextActor` Enum
+
+The `next_actor` field uses a discriminated enum serialized as a
+`snake_case` string (simple variants) or `{"variant": value}` (data
+variants):
+
+| Variant | Wire value | Description |
+|---------|-----------|-------------|
+| `Engineer` | `"engineer"` | The Simard engineer loop. |
+| `OodaCurate` | `"ooda_curate"` | The OODA curation pipeline. |
+| `ActOnDecisions` | `"act_on_decisions"` | The `act-on-decisions` CLI. |
+| `Human(name)` | `{"human": "alice"}` | A specific human. |
+| `Other(name)` | `{"other": "custom-agent"}` | Arbitrary persona. |
+
+## Backward Compatibility
+
+All v2 fields use `#[serde(default)]`. A v1 JSON (missing the new fields)
+deserializes cleanly into a `MeetingHandoff` with:
+
+- `schema_version` = `1`
+- `goal` = `None`
+- `next_actor` = `None`
+- `applied_templates` = `[]`
+- `history_truncated_count` = `0`
+- `partial_reason` = `None`
+
+No migration step is required. Consumers should check `schema_version`
+before relying on v2-only fields.
+
+## REPL Commands
+
+| Command | Effect |
+|---------|--------|
+| `/goal <text>` | Sets the meeting's `goal` field. |
+| `/owner <name>` | Sets `next_owner` and derives `next_actor`. |
+
+## Related Issues
+
+- **#1987** — Structured handoff schema v2 (this document).
+- **#1982** — Parent epic: enhance Simard meeting experience.
+- **#1985** — Per-meeting bundle consumer (depends on v2 schema).
+- **#1954** — Prior `next_owner` + artifacts work (v1.5).

--- a/src/meeting_backend/closing.rs
+++ b/src/meeting_backend/closing.rs
@@ -342,6 +342,11 @@ impl MeetingBackend {
             next_owner: next_owner_owned.as_deref(),
             artifacts: artifacts.clone(),
             structured_decisions: Some(structured_decisions.clone()),
+            applied_templates: self.applied_templates.clone(),
+            history_truncated_count: self.history.len().saturating_sub(super::MAX_HISTORY),
+            partial_reason: partial_reason.as_ref().map(|r| r.as_wire_str()),
+            goal: self.explicit_goal.as_deref(),
+            next_actor: next_owner_owned.as_deref().map(next_actor_from_owner_str),
         };
 
         // Write MeetingHandoff artifact for OODA integration.
@@ -635,6 +640,11 @@ impl MeetingBackend {
             next_owner: next_owner_owned.as_deref(),
             artifacts: artifacts.clone(),
             structured_decisions: Some(structured_decisions.clone()),
+            applied_templates: self.applied_templates.clone(),
+            history_truncated_count: self.history.len().saturating_sub(super::MAX_HISTORY),
+            partial_reason: partial_reason.as_ref().map(|r| r.as_wire_str()),
+            goal: self.explicit_goal.as_deref(),
+            next_actor: next_owner_owned.as_deref().map(next_actor_from_owner_str),
         };
 
         if let Err(e) = persist::write_handoff_with_explicit(
@@ -835,4 +845,32 @@ fn build_handoff_artifacts(
         });
     }
     out
+}
+
+/// Map a free-form `next_owner` string to a typed [`NextActor`] enum variant.
+///
+/// Well-known persona names (`"engineer"`, `"ooda-curate"`,
+/// `"act-on-decisions"`) are recognized case-insensitively and mapped to
+/// the corresponding discriminated variant. Strings that look like a
+/// GitHub `@handle` (single token, alphanumeric + hyphens) are mapped to
+/// `Human`. Everything else falls into `Other`.
+fn next_actor_from_owner_str(owner: &str) -> crate::meeting_facilitator::NextActor {
+    use crate::meeting_facilitator::NextActor;
+    match owner.trim().to_ascii_lowercase().as_str() {
+        "engineer" => NextActor::Engineer,
+        "ooda-curate" | "ooda_curate" => NextActor::OodaCurate,
+        "act-on-decisions" | "act_on_decisions" => NextActor::ActOnDecisions,
+        other => {
+            // Single-token handles that look human-ish → Human variant.
+            if !other.contains(' ')
+                && other
+                    .chars()
+                    .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+            {
+                NextActor::Human(owner.trim().to_string())
+            } else {
+                NextActor::Other(owner.trim().to_string())
+            }
+        }
+    }
 }

--- a/src/meeting_backend/command.rs
+++ b/src/meeting_backend/command.rs
@@ -37,6 +37,11 @@ pub enum MeetingCommand {
     /// Empty payload (a bare `/owner`) falls through to conversation so
     /// the operator's intent isn't silently coerced. Added in issue #1954.
     Owner(String),
+    /// Operator records the meeting's overarching objective (e.g.
+    /// `/goal Ship handoff schema v2`). Flows into the handoff `goal`
+    /// field. Empty payload falls through to conversation. Added in
+    /// issue #1987.
+    Goal(String),
     /// Natural language — forwarded to the LLM.
     Conversation(String),
 }
@@ -103,6 +108,14 @@ pub fn parse_command(input: &str) -> MeetingCommand {
                 MeetingCommand::Conversation(trimmed.to_string())
             } else {
                 MeetingCommand::Owner(arg)
+            }
+        }
+        _ if lower.starts_with("/goal ") => {
+            let arg = trimmed["/goal ".len()..].trim().to_string();
+            if arg.is_empty() {
+                MeetingCommand::Conversation(trimmed.to_string())
+            } else {
+                MeetingCommand::Goal(arg)
             }
         }
         _ => MeetingCommand::Conversation(trimmed.to_string()),
@@ -366,6 +379,32 @@ mod tests {
         assert_eq!(
             parse_command("/owner    "),
             MeetingCommand::Conversation("/owner".to_string()),
+        );
+    }
+
+    // ── Inline /goal (issue #1987) ───────────────────────────────────
+
+    #[test]
+    fn parse_goal_with_arg() {
+        assert_eq!(
+            parse_command("/goal Ship handoff schema v2"),
+            MeetingCommand::Goal("Ship handoff schema v2".to_string()),
+        );
+        assert_eq!(
+            parse_command("  /Goal  Resolve blocking issues  "),
+            MeetingCommand::Goal("Resolve blocking issues".to_string()),
+        );
+    }
+
+    #[test]
+    fn parse_goal_empty_arg_is_conversation() {
+        assert_eq!(
+            parse_command("/goal"),
+            MeetingCommand::Conversation("/goal".to_string()),
+        );
+        assert_eq!(
+            parse_command("/goal    "),
+            MeetingCommand::Conversation("/goal".to_string()),
         );
     }
 }

--- a/src/meeting_backend/mod.rs
+++ b/src/meeting_backend/mod.rs
@@ -167,6 +167,9 @@ pub struct MeetingBackend {
     /// `ooda-curate`, `act-on-decisions`, a GitHub handle). Surfaced on the
     /// `MeetingHandoff` via the new `next_owner` field. Added in #1954.
     explicit_next_owner: Option<String>,
+    /// Overarching objective of this meeting, set via `/goal <text>`.
+    /// Flows into the handoff schema v2 `goal` field. Added in #1987.
+    explicit_goal: Option<String>,
     /// Count of user messages whose `send_message` returned `Err` after the
     /// user message was already pushed to history. These are "orphan" turns
     /// with no assistant reply. Surfaced on `MeetingSummary` (issue #1983).
@@ -210,6 +213,7 @@ impl MeetingBackend {
             explicit_action_items: Vec::new(),
             explicit_questions: Vec::new(),
             explicit_next_owner: None,
+            explicit_goal: None,
             orphan_turn_count: 0,
         }
     }
@@ -419,6 +423,23 @@ impl MeetingBackend {
     /// Read the next-owner value the operator set inline (if any).
     pub fn explicit_next_owner(&self) -> Option<&str> {
         self.explicit_next_owner.as_deref()
+    }
+
+    /// Record the meeting's overarching objective via `/goal <text>`.
+    /// Trimmed; empty values clear the value. Surfaced into the `goal`
+    /// field of the resulting `MeetingHandoff`. Added in issue #1987.
+    pub fn push_goal(&mut self, text: &str) {
+        let trimmed = text.trim();
+        if trimmed.is_empty() {
+            self.explicit_goal = None;
+        } else {
+            self.explicit_goal = Some(trimmed.to_string());
+        }
+    }
+
+    /// Read the goal the operator set inline (if any).
+    pub fn explicit_goal(&self) -> Option<&str> {
+        self.explicit_goal.as_deref()
     }
 
     // --- Private helpers ---

--- a/src/meeting_backend/persist/mod.rs
+++ b/src/meeting_backend/persist/mod.rs
@@ -179,6 +179,17 @@ pub struct HandoffEnrichment<'a> {
     /// `None`, decisions are reconstructed from `&[String]` via the
     /// existing extract helpers (legacy behaviour).
     pub structured_decisions: Option<Vec<crate::meeting_facilitator::MeetingDecision>>,
+    /// Templates applied during the meeting (`/template` command).
+    /// Carried into the handoff v2 `applied_templates` field.
+    pub applied_templates: Vec<crate::meeting_backend::AppliedTemplate>,
+    /// Number of history turns that were truncated by the MAX_HISTORY cap.
+    pub history_truncated_count: usize,
+    /// Wire-format string of the partial-close reason, if any.
+    pub partial_reason: Option<&'a str>,
+    /// The meeting's overarching objective set via `/goal`.
+    pub goal: Option<&'a str>,
+    /// Typed next-actor tag (v2). Supersedes `next_owner` for routing.
+    pub next_actor: Option<crate::meeting_facilitator::NextActor>,
 }
 
 /// Write a `MeetingHandoff` artifact for OODA integration.
@@ -331,6 +342,12 @@ pub fn write_handoff_with_explicit(
         transcript_path: None,
         next_owner: enrichment.next_owner.map(|s| s.to_string()),
         artifacts: enrichment.artifacts.clone(),
+        schema_version: 2,
+        goal: enrichment.goal.map(|s| s.to_string()),
+        next_actor: enrichment.next_actor.clone(),
+        applied_templates: enrichment.applied_templates.clone(),
+        history_truncated_count: enrichment.history_truncated_count,
+        partial_reason: enrichment.partial_reason.map(|s| s.to_string()),
     };
 
     let dir = default_handoff_dir();
@@ -428,6 +445,12 @@ pub fn write_handoff_bundle(
         transcript_path: None,
         next_owner: enrichment.next_owner.map(|s| s.to_string()),
         artifacts: enrichment.artifacts.clone(),
+        schema_version: 2,
+        goal: enrichment.goal.map(|s| s.to_string()),
+        next_actor: enrichment.next_actor.clone(),
+        applied_templates: enrichment.applied_templates.clone(),
+        history_truncated_count: enrichment.history_truncated_count,
+        partial_reason: enrichment.partial_reason.map(|s| s.to_string()),
     };
 
     let lines: Vec<crate::meeting_facilitator::BundleTranscriptLine> = messages

--- a/src/meeting_facilitator/handoff/mod.rs
+++ b/src/meeting_facilitator/handoff/mod.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 
-use super::types::{ActionItem, MeetingDecision, MeetingSession, OpenQuestion};
+use super::types::{ActionItem, MeetingDecision, MeetingSession, NextActor, OpenQuestion};
 
 /// Well-known filename for meeting handoff artifacts.
 pub const MEETING_HANDOFF_FILENAME: &str = "meeting_handoff.json";
@@ -79,6 +79,12 @@ pub struct HandoffArtifact {
     pub description: Option<String>,
 }
 
+/// Default value for `MeetingHandoff::schema_version` when deserializing
+/// legacy (v1) JSON that lacks the field.
+fn default_schema_version() -> u32 {
+    1
+}
+
 /// A handoff artifact produced when a meeting closes. Contains decisions,
 /// action items, open questions, the next responsible owner, and a list
 /// of linked artifacts.
@@ -134,6 +140,38 @@ pub struct MeetingHandoff {
     /// deserialize as `[]`.
     #[serde(default)]
     pub artifacts: Vec<HandoffArtifact>,
+
+    // ── Handoff schema v2 fields (issue #1987) ─────────────────────
+    /// Schema version tag. `2` for the enriched schema introduced in
+    /// issue #1987; absent (defaults to `1`) in legacy handoffs.
+    #[serde(default = "default_schema_version")]
+    pub schema_version: u32,
+    /// The overarching objective the meeting set out to achieve, recorded
+    /// by the `/goal` REPL command. Absent when the operator did not set
+    /// one.
+    #[serde(default)]
+    pub goal: Option<String>,
+    /// Typed next-actor routing tag. Supersedes the free-form
+    /// `next_owner` string with a discriminated enum so downstream
+    /// consumers can route deterministically. Both fields are emitted;
+    /// `next_owner` is kept for backward compat.
+    #[serde(default)]
+    pub next_actor: Option<NextActor>,
+    /// Templates applied during the meeting (name + agenda text).
+    /// Lets downstream consumers reconstruct the agenda without
+    /// re-reading the template catalogue.
+    #[serde(default)]
+    pub applied_templates: Vec<crate::meeting_backend::AppliedTemplate>,
+    /// Number of conversation turns that were truncated from `transcript`
+    /// due to the `MAX_HISTORY` cap. Zero when the full history fits.
+    #[serde(default)]
+    pub history_truncated_count: usize,
+    /// When the close pipeline produced a partial handoff (timeout,
+    /// persistence error, …), this field carries the machine-readable
+    /// reason string (e.g. `"close_timeout"`, `"summary_timeout"`).
+    /// `None` on a clean close.
+    #[serde(default)]
+    pub partial_reason: Option<String>,
 }
 
 /// Build a stable, sortable meeting id from a started-at timestamp and a
@@ -326,6 +364,15 @@ impl MeetingHandoff {
             transcript_path: None,
             next_owner: session.next_owner.clone(),
             artifacts: Vec::new(),
+            // v2 fields default to safe values in the facilitator path;
+            // the backend closing path overwrites them via direct struct
+            // construction.
+            schema_version: 2,
+            goal: session.goal.clone(),
+            next_actor: None,
+            applied_templates: Vec::new(),
+            history_truncated_count: 0,
+            partial_reason: None,
         }
     }
 
@@ -401,6 +448,7 @@ mod tests {
             explicit_questions: vec![],
             themes: vec![],
             next_owner: None,
+            goal: None,
         }
     }
 
@@ -431,6 +479,7 @@ mod tests {
             explicit_questions: vec!["What about testing?".to_string()],
             themes: vec!["performance".to_string()],
             next_owner: Some("engineer".to_string()),
+            goal: None,
         }
     }
 

--- a/src/meeting_facilitator/handoff/persistence.rs
+++ b/src/meeting_facilitator/handoff/persistence.rs
@@ -604,6 +604,12 @@ mod bundle_tests {
             transcript_path: None,
             next_owner: None,
             artifacts: Vec::new(),
+            schema_version: 2,
+            goal: None,
+            next_actor: None,
+            applied_templates: Vec::new(),
+            history_truncated_count: 0,
+            partial_reason: None,
         }
     }
 

--- a/src/meeting_facilitator/mod.rs
+++ b/src/meeting_facilitator/mod.rs
@@ -29,7 +29,9 @@ pub use session::{
     add_note, add_question, close_meeting, edit_item, record_action_item, record_decision,
     remove_item, start_meeting,
 };
-pub use types::{ActionItem, MeetingDecision, MeetingSession, MeetingSessionStatus, OpenQuestion};
+pub use types::{
+    ActionItem, MeetingDecision, MeetingSession, MeetingSessionStatus, NextActor, OpenQuestion,
+};
 
 #[cfg(test)]
 mod tests {
@@ -144,6 +146,7 @@ mod tests {
             explicit_questions: vec![],
             themes: vec![],
             next_owner: None,
+            goal: None,
         };
         let summary = session.durable_summary();
         assert!(summary.contains("Planning"));

--- a/src/meeting_facilitator/session.rs
+++ b/src/meeting_facilitator/session.rs
@@ -61,6 +61,7 @@ pub fn start_meeting(topic: &str, bridge: &dyn CognitiveMemoryOps) -> SimardResu
         explicit_questions: Vec::new(),
         themes: Vec::new(),
         next_owner: None,
+        goal: None,
     })
 }
 

--- a/src/meeting_facilitator/tests_handoff.rs
+++ b/src/meeting_facilitator/tests_handoff.rs
@@ -21,6 +21,7 @@ fn make_session(
         explicit_questions: Vec::new(),
         themes: Vec::new(),
         next_owner: None,
+        goal: None,
     }
 }
 
@@ -406,6 +407,12 @@ fn round_trip_handoff_with_next_owner_and_artifacts() {
         transcript_path: Some("/tmp/meetings/transcript-2026-05-01.json".to_string()),
         next_owner: Some("engineer".to_string()),
         artifacts: sample_artifacts(),
+        schema_version: 2,
+        goal: None,
+        next_actor: None,
+        applied_templates: Vec::new(),
+        history_truncated_count: 0,
+        partial_reason: None,
     };
 
     let json = serde_json::to_string_pretty(&handoff).expect("serialize ok");

--- a/src/meeting_facilitator/tests_handoff_extra.rs
+++ b/src/meeting_facilitator/tests_handoff_extra.rs
@@ -23,6 +23,7 @@ fn make_session(
         explicit_questions: Vec::new(),
         themes: Vec::new(),
         next_owner: None,
+        goal: None,
     }
 }
 
@@ -258,4 +259,119 @@ fn save_wip_overwrites_previous() {
     let loaded = load_session_wip(dir.path()).unwrap().unwrap();
     assert_eq!(loaded.topic, "Second");
     assert_eq!(loaded.notes, vec!["updated"]);
+}
+
+// -----------------------------------------------------------------------
+// Handoff schema v2 serde round-trip tests (issue #1987)
+// -----------------------------------------------------------------------
+
+#[test]
+fn v2_round_trip_serde() {
+    use crate::meeting_facilitator::types::NextActor;
+
+    let session = make_session(
+        "v2 test",
+        vec!["TBD: what next?"],
+        vec![sample_decision()],
+        vec![sample_action()],
+        vec!["alice"],
+    );
+    let mut handoff = MeetingHandoff::from_session(&session);
+    handoff.schema_version = 2;
+    handoff.goal = Some("Ship handoff schema v2".to_string());
+    handoff.next_actor = Some(NextActor::Engineer);
+    handoff.history_truncated_count = 42;
+    handoff.partial_reason = Some("close_timeout".to_string());
+
+    let json = serde_json::to_string_pretty(&handoff).unwrap();
+    let deser: MeetingHandoff = serde_json::from_str(&json).unwrap();
+    assert_eq!(handoff, deser);
+    assert_eq!(deser.schema_version, 2);
+    assert_eq!(deser.goal.as_deref(), Some("Ship handoff schema v2"));
+    assert_eq!(deser.next_actor, Some(NextActor::Engineer));
+    assert_eq!(deser.history_truncated_count, 42);
+    assert_eq!(deser.partial_reason.as_deref(), Some("close_timeout"));
+}
+
+#[test]
+fn v1_json_missing_v2_fields_defaults_cleanly() {
+    // Simulates deserializing a legacy v1 handoff that has none of the v2 fields.
+    let v1_json = r#"{
+        "meeting_id": "20260101T000000Z-legacy",
+        "topic": "Legacy meeting",
+        "started_at": "2026-01-01T00:00:00Z",
+        "closed_at": "2026-01-01T01:00:00Z",
+        "decisions": [],
+        "action_items": [],
+        "open_questions": [],
+        "processed": false,
+        "transcript": ["summary text"],
+        "participants": ["alice"],
+        "themes": ["testing"]
+    }"#;
+    let handoff: MeetingHandoff = serde_json::from_str(v1_json).unwrap();
+    assert_eq!(
+        handoff.schema_version, 1,
+        "missing schema_version should default to 1"
+    );
+    assert_eq!(handoff.goal, None);
+    assert_eq!(handoff.next_actor, None);
+    assert!(handoff.applied_templates.is_empty());
+    assert_eq!(handoff.history_truncated_count, 0);
+    assert_eq!(handoff.partial_reason, None);
+    assert!(handoff.artifacts.is_empty());
+    assert_eq!(handoff.next_owner, None);
+}
+
+#[test]
+fn v2_strip_to_v1_compat() {
+    use crate::meeting_facilitator::types::NextActor;
+
+    // Build a v2 handoff, serialize it, strip the v2-only fields,
+    // and verify the remainder still deserializes as a valid MeetingHandoff
+    // (all v2 fields fall back to defaults).
+    let session = make_session(
+        "v2 compat",
+        vec![],
+        vec![sample_decision()],
+        vec![],
+        vec!["bob"],
+    );
+    let mut handoff = MeetingHandoff::from_session(&session);
+    handoff.goal = Some("Test compat".to_string());
+    handoff.next_actor = Some(NextActor::Human("alice".to_string()));
+    handoff.history_truncated_count = 10;
+    handoff.partial_reason = Some("summary_timeout".to_string());
+
+    let mut val: serde_json::Value = serde_json::to_value(&handoff).unwrap();
+    let obj = val.as_object_mut().unwrap();
+    obj.remove("schema_version");
+    obj.remove("goal");
+    obj.remove("next_actor");
+    obj.remove("applied_templates");
+    obj.remove("history_truncated_count");
+    obj.remove("partial_reason");
+
+    let stripped_json = serde_json::to_string_pretty(&val).unwrap();
+    let deser: MeetingHandoff = serde_json::from_str(&stripped_json).unwrap();
+    // V2 fields should all revert to defaults.
+    assert_eq!(deser.schema_version, 1);
+    assert_eq!(deser.goal, None);
+    assert_eq!(deser.next_actor, None);
+    assert!(deser.applied_templates.is_empty());
+    assert_eq!(deser.history_truncated_count, 0);
+    assert_eq!(deser.partial_reason, None);
+    // V1 fields should survive.
+    assert_eq!(deser.topic, "v2 compat");
+    assert_eq!(deser.decisions.len(), 1);
+}
+
+#[test]
+fn from_session_populates_goal() {
+    let mut session = make_session("Goal test", vec![], vec![], vec![], vec![]);
+    session.goal = Some("Resolve blocking issues".to_string());
+
+    let handoff = MeetingHandoff::from_session(&session);
+    assert_eq!(handoff.goal.as_deref(), Some("Resolve blocking issues"));
+    assert_eq!(handoff.schema_version, 2);
 }

--- a/src/meeting_facilitator/types.rs
+++ b/src/meeting_facilitator/types.rs
@@ -4,6 +4,29 @@ use std::fmt::{self, Display, Formatter};
 
 use serde::{Deserialize, Serialize};
 
+/// Identifies the next actor expected to consume a meeting handoff.
+///
+/// Supersedes the free-form `next_owner: Option<String>` field with a
+/// typed enum so downstream consumers can route deterministically.
+/// Custom values are captured via the `Other(String)` variant, preserving
+/// backward compatibility with arbitrary strings.
+///
+/// Added in handoff schema v2 (issue #1987).
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NextActor {
+    /// The Simard engineer loop.
+    Engineer,
+    /// The OODA curation pipeline.
+    OodaCurate,
+    /// The `act-on-decisions` CLI subcommand.
+    ActOnDecisions,
+    /// A specific human (GitHub handle or display name).
+    Human(String),
+    /// An arbitrary persona / agent name not covered by the well-known set.
+    Other(String),
+}
+
 /// A single decision recorded during a meeting.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct MeetingDecision {
@@ -75,6 +98,12 @@ pub struct MeetingSession {
     /// Added in issue #1954.
     #[serde(default)]
     pub next_owner: Option<String>,
+    /// The overarching objective of this meeting, set via `/goal <text>`.
+    /// Flows into the handoff schema v2 `goal` field so downstream
+    /// consumers know what the meeting was trying to achieve. Added in
+    /// issue #1987.
+    #[serde(default)]
+    pub goal: Option<String>,
 }
 
 impl MeetingSession {
@@ -261,6 +290,7 @@ mod tests {
             explicit_questions: vec!["What about testing?".to_string()],
             themes: vec!["performance".to_string()],
             next_owner: None,
+            goal: None,
         }
     }
 
@@ -332,6 +362,7 @@ mod tests {
             explicit_questions: vec![],
             themes: vec![],
             next_owner: None,
+            goal: None,
         };
         let summary = s.durable_summary();
         assert!(summary.contains("decisions=[none]"));
@@ -353,6 +384,7 @@ mod tests {
             explicit_questions: vec![],
             themes: vec![],
             next_owner: None,
+            goal: None,
         };
         let summary = s.durable_summary();
         assert!(summary.contains("duration=unknown"));

--- a/src/meeting_repl/repl.rs
+++ b/src/meeting_repl/repl.rs
@@ -261,6 +261,10 @@ pub fn run_meeting_repl<R: BufRead, W: Write>(
                 backend.push_next_owner(&text);
                 writeln!(output, "{}", cyan(&format!("Next owner recorded: {text}"))).ok();
             }
+            MeetingCommand::Goal(text) => {
+                backend.push_goal(&text);
+                writeln!(output, "{}", cyan(&format!("Goal recorded: {text}"))).ok();
+            }
             MeetingCommand::Recap => {
                 let status = backend.status();
                 writeln!(output, "\n── Meeting Recap ──").ok();
@@ -562,5 +566,6 @@ fn empty_closed_session(topic: &str) -> MeetingSession {
         explicit_questions: Vec::new(),
         themes: Vec::new(),
         next_owner: None,
+        goal: None,
     }
 }

--- a/src/ooda_loop/curate.rs
+++ b/src/ooda_loop/curate.rs
@@ -217,6 +217,12 @@ mod tests {
             transcript_path: None,
             next_owner: None,
             artifacts: Vec::new(),
+            schema_version: 2,
+            goal: None,
+            next_actor: None,
+            applied_templates: Vec::new(),
+            history_truncated_count: 0,
+            partial_reason: None,
         }
     }
 
@@ -240,6 +246,12 @@ mod tests {
             transcript_path: None,
             next_owner: None,
             artifacts: Vec::new(),
+            schema_version: 2,
+            goal: None,
+            next_actor: None,
+            applied_templates: Vec::new(),
+            history_truncated_count: 0,
+            partial_reason: None,
         }
     }
 
@@ -509,6 +521,12 @@ mod tests {
             transcript_path: None,
             next_owner: None,
             artifacts: Vec::new(),
+            schema_version: 2,
+            goal: None,
+            next_actor: None,
+            applied_templates: Vec::new(),
+            history_truncated_count: 0,
+            partial_reason: None,
         };
         let path_b = dir.path().join("handoff-2026-04-03T00-05-01_00-00.json");
         fs::write(&path_b, serde_json::to_string_pretty(&handoff_b).unwrap()).unwrap();

--- a/src/ooda_loop/tests_observe.rs
+++ b/src/ooda_loop/tests_observe.rs
@@ -175,6 +175,12 @@ fn scan_unprocessed_handoffs_returns_true_for_unprocessed() {
         transcript_path: None,
         next_owner: None,
         artifacts: Vec::new(),
+        schema_version: 2,
+        goal: None,
+        next_actor: None,
+        applied_templates: Vec::new(),
+        history_truncated_count: 0,
+        partial_reason: None,
     };
     write_meeting_handoff(dir.path(), &handoff).unwrap();
 
@@ -206,6 +212,12 @@ fn scan_unprocessed_handoffs_returns_false_when_processed() {
         transcript_path: None,
         next_owner: None,
         artifacts: Vec::new(),
+        schema_version: 2,
+        goal: None,
+        next_actor: None,
+        applied_templates: Vec::new(),
+        history_truncated_count: 0,
+        partial_reason: None,
     };
     write_meeting_handoff(dir.path(), &handoff).unwrap();
 

--- a/src/operator_cli/decisions.rs
+++ b/src/operator_cli/decisions.rs
@@ -184,6 +184,12 @@ mod tests {
             transcript_path: None,
             next_owner: None,
             artifacts: Vec::new(),
+            schema_version: 2,
+            goal: None,
+            next_actor: None,
+            applied_templates: Vec::new(),
+            history_truncated_count: 0,
+            partial_reason: None,
         }
     }
 
@@ -260,6 +266,12 @@ mod tests {
             transcript_path: None,
             next_owner: None,
             artifacts: Vec::new(),
+            schema_version: 2,
+            goal: None,
+            next_actor: None,
+            applied_templates: Vec::new(),
+            history_truncated_count: 0,
+            partial_reason: None,
         };
         let json = serde_json::to_string(&h).unwrap();
         let h2: MeetingHandoff = serde_json::from_str(&json).unwrap();

--- a/src/operator_commands_dashboard/chat.rs
+++ b/src/operator_commands_dashboard/chat.rs
@@ -299,6 +299,17 @@ pub(crate) async fn handle_ws_chat(mut socket: WebSocket) {
                             ))
                             .await;
                     }
+                    MeetingCommand::Goal(text) => {
+                        backend.push_goal(&text);
+                        let content = format!("Goal recorded: {text}");
+                        let _ = socket
+                            .send(Message::Text(
+                                json!({"role":"system","content": content})
+                                    .to_string()
+                                    .into(),
+                            ))
+                            .await;
+                    }
                     MeetingCommand::Recap => {
                         let status = backend.status();
                         let themes = backend.explicit_themes();

--- a/tests/act_on_decisions.rs
+++ b/tests/act_on_decisions.rs
@@ -69,6 +69,7 @@ fn sample_handoff() -> MeetingHandoff {
         explicit_questions: Vec::new(),
         themes: Vec::new(),
         next_owner: None,
+        goal: None,
     };
     MeetingHandoff::from_session(&session)
 }
@@ -267,6 +268,7 @@ fn act_on_decisions_with_empty_handoff_creates_no_issues() {
         explicit_questions: Vec::new(),
         themes: Vec::new(),
         next_owner: None,
+        goal: None,
     };
     let handoff = MeetingHandoff::from_session(&session);
     write_meeting_handoff(&dir, &handoff).unwrap();

--- a/tests/meeting_handoff.rs
+++ b/tests/meeting_handoff.rs
@@ -72,6 +72,7 @@ fn sample_session_with_questions() -> MeetingSession {
         explicit_questions: Vec::new(),
         themes: Vec::new(),
         next_owner: None,
+        goal: None,
     }
 }
 
@@ -87,6 +88,7 @@ fn sample_empty_session() -> MeetingSession {
         explicit_questions: Vec::new(),
         themes: Vec::new(),
         next_owner: None,
+        goal: None,
     }
 }
 
@@ -459,6 +461,7 @@ fn handoff_with_only_action_items_no_decisions() {
         explicit_questions: Vec::new(),
         themes: Vec::new(),
         next_owner: None,
+        goal: None,
     };
     let handoff = MeetingHandoff::from_session(&session);
     assert!(handoff.decisions.is_empty());
@@ -487,6 +490,7 @@ fn handoff_with_only_decisions_no_actions() {
         explicit_questions: Vec::new(),
         themes: Vec::new(),
         next_owner: None,
+        goal: None,
     };
     let handoff = MeetingHandoff::from_session(&session);
     assert_eq!(handoff.decisions.len(), 1);

--- a/tests/meeting_handoff_bundle.rs
+++ b/tests/meeting_handoff_bundle.rs
@@ -81,6 +81,7 @@ fn scripted_meeting_emits_structured_handoff_bundle() {
         explicit_questions: Vec::new(),
         themes: Vec::new(),
         next_owner: None,
+        goal: None,
     };
 
     let mut handoff = MeetingHandoff::from_session(&session);
@@ -217,6 +218,12 @@ fn empty_transcript_still_produces_well_formed_bundle() {
         transcript_path: None,
         next_owner: None,
         artifacts: Vec::new(),
+        schema_version: 2,
+        goal: None,
+        next_actor: None,
+        applied_templates: Vec::new(),
+        history_truncated_count: 0,
+        partial_reason: None,
     };
 
     let dir = write_meeting_bundle(&mut handoff, &[]).expect("write_meeting_bundle");


### PR DESCRIPTION
## Summary

Implements structured handoff schema v2 per #1987 — the foundational schema change blocking #1985 (per-meeting bundle consumer). Part of epic #1982.

### Changes

**New fields on `MeetingHandoff`** (all `#[serde(default)]` for v1 compat):
- `schema_version: u32` — `2` for new handoffs; defaults to `1` for legacy JSON
- `goal: Option<String>` — meeting objective set via `/goal` REPL command
- `next_actor: Option<NextActor>` — typed routing enum superseding free-form `next_owner`
- `applied_templates: Vec<AppliedTemplate>` — templates used during the meeting
- `history_truncated_count: usize` — turns dropped by MAX_HISTORY cap
- `partial_reason: Option<String>` — machine-readable partial-close reason

**`NextActor` enum** (`types.rs`): `Engineer`, `OodaCurate`, `ActOnDecisions`, `Human(String)`, `Other(String)`

**`/goal` REPL command** (`command.rs`, `repl.rs`, dashboard `chat.rs`): records the meeting's overarching objective

**Wiring**: `HandoffEnrichment` extended with v2 fields; `write_handoff_with_explicit` and `write_handoff_bundle` populate them; `closing.rs` happy-path and partial-path both supply the new enrichment.

### Evidence of merge-ready criteria

1. **Serde tests**: 4 new tests in `tests_handoff_extra.rs` — v2↔v2 round-trip, v1→v2 defaults, v2→strip→v1 compat, from_session goal propagation. 2 new tests for `/goal` command parsing.
2. **Docs**: `docs/reference/meeting-handoff-schema.md` documents v2 schema, NextActor enum, backward compat, and REPL commands.
3. **CI gates**: `cargo fmt` ✅, `cargo clippy` ✅, `cargo test` 4550 passed (1 pre-existing env failure unrelated to this PR).
4. **Diff focused**: 20 files, 558 insertions — all meeting handoff related, no unrelated edits.

Closes #1987
Part of #1982