### PR TITLE
fix(dashboard): replace raw JSON/IDs with readable rendering, add glossary (#1683, #1686, #1996)

### DIFF
--- a/src/operator_commands_dashboard/goals.rs
+++ b/src/operator_commands_dashboard/goals.rs
@@ -17,6 +17,57 @@ fn load_board_or_empty() -> GoalBoard {
     dashboard_goal_board_snapshot(&state_root).unwrap_or_default()
 }
 
+/// Returns `true` when `s` looks like a debug key=value dump rather than
+/// prose — e.g. `"priority=3 status=proposed rationale=Action…"`. Heuristic:
+/// three or more `word=` patterns in one short string (#1686).
+fn looks_like_debug_string(s: &str) -> bool {
+    let kv_count = s
+        .split_whitespace()
+        .filter(|w| {
+            let eq = w.find('=');
+            // The key must be at least 2 chars long and the value at least 1.
+            matches!(eq, Some(pos) if pos >= 2 && pos + 1 < w.len())
+        })
+        .count();
+    kv_count >= 3
+}
+
+/// Derive a short human-readable ID from content + concept instead of
+/// exposing the raw `sem_019e18ac…` node ID (#1686). Takes the first few
+/// words of the content, or falls back to the concept label.
+fn human_backlog_id(content: &str, concept: &str) -> String {
+    let words: Vec<&str> = content.split_whitespace().take(6).collect();
+    if words.len() >= 2 {
+        let slug = words.join(" ");
+        if slug.len() > 50 {
+            format!("{}…", &slug[..50].trim_end())
+        } else {
+            slug
+        }
+    } else {
+        human_source_label(concept).to_string()
+    }
+}
+
+/// Plain-English label for a cognitive-memory concept path, replacing the
+/// raw `cognitive-memory/<concept>` prefix (#1686).
+fn human_source_label(concept: &str) -> &'static str {
+    let c = concept.to_lowercase();
+    if c.contains("goal") {
+        "From goals"
+    } else if c.contains("action") {
+        "From actions"
+    } else if c.contains("decision") {
+        "From decisions"
+    } else if c.contains("meeting") {
+        "From meeting"
+    } else if c.contains("episode") {
+        "From past event"
+    } else {
+        "From memory"
+    }
+}
+
 pub(crate) async fn goals() -> Json<Value> {
     let state_root = resolve_state_root();
     let board = dashboard_goal_board_snapshot(&state_root).unwrap_or_default();
@@ -60,6 +111,7 @@ pub(crate) async fn goals() -> Json<Value> {
         .collect();
 
     // Pull meeting-captured actions and decisions from cognitive memory (#415)
+    // (#1686: filter out raw memory IDs and debug strings, provide clean labels)
     if let Ok(mem) = NativeCognitiveMemory::open_read_only(&state_root) {
         for tag in &["goal", "action", "decision"] {
             if let Ok(facts) = mem.search_facts(tag, 20, 0.0) {
@@ -74,15 +126,25 @@ pub(crate) async fn goals() -> Json<Value> {
                     if trimmed.starts_with('{') || trimmed.starts_with('[') {
                         continue;
                     }
+                    // (#1686) Skip facts whose content looks like debug key=value
+                    // strings (e.g. "priority=3 status=proposed rationale=Action…")
+                    if looks_like_debug_string(trimmed) {
+                        continue;
+                    }
                     let already_listed = active
                         .iter()
                         .chain(backlog.iter())
                         .any(|g| g.get("id").and_then(|v| v.as_str()) == Some(&fact.node_id));
                     if !already_listed {
+                        // (#1686) Derive a human-readable title from the content
+                        // instead of exposing the raw `sem_019e18ac…` node ID.
+                        let display_id = human_backlog_id(&fact.content, &fact.concept);
+                        let source_label = human_source_label(&fact.concept);
                         backlog.push(json!({
                             "id": fact.node_id,
+                            "display_id": display_id,
                             "description": fact.content,
-                            "source": format!("cognitive-memory/{}", fact.concept),
+                            "source": source_label,
                             "score": fact.confidence,
                         }));
                     }
@@ -332,5 +394,54 @@ pub(crate) async fn demote_goal(Path(id): Path<String>) -> Json<Value> {
     match dashboard_save_goal_board(&state_root, &board) {
         Ok(()) => Json(json!({"status": "ok"})),
         Err(e) => Json(json!({"error": format!("{e}")})),
+    }
+}
+
+#[cfg(test)]
+mod tests_backlog_helpers {
+    use super::*;
+
+    #[test]
+    fn debug_string_detected() {
+        assert!(looks_like_debug_string(
+            "priority=3 status=proposed rationale=Action needed"
+        ));
+    }
+
+    #[test]
+    fn normal_prose_not_detected_as_debug() {
+        assert!(!looks_like_debug_string("Fix the login page CSS"));
+        assert!(!looks_like_debug_string(
+            "Improve error handling in the auth module"
+        ));
+    }
+
+    #[test]
+    fn two_kv_pairs_not_flagged() {
+        assert!(!looks_like_debug_string("status=active priority=1"));
+    }
+
+    #[test]
+    fn human_backlog_id_from_long_content() {
+        let id = human_backlog_id(
+            "Improve the login page to handle OAuth better",
+            "goal-action",
+        );
+        assert_eq!(id, "Improve the login page to handle");
+    }
+
+    #[test]
+    fn human_backlog_id_from_short_content() {
+        let id = human_backlog_id("OK", "goal-action");
+        assert_eq!(id, "From goals");
+    }
+
+    #[test]
+    fn human_source_label_maps_concepts() {
+        assert_eq!(human_source_label("goal-action"), "From goals");
+        assert_eq!(human_source_label("action-item"), "From actions");
+        assert_eq!(human_source_label("decision-record"), "From decisions");
+        assert_eq!(human_source_label("meeting-note"), "From meeting");
+        assert_eq!(human_source_label("other-concept"), "From memory");
     }
 }

--- a/src/operator_commands_dashboard/index_html/part_00.rs
+++ b/src/operator_commands_dashboard/index_html/part_00.rs
@@ -84,6 +84,17 @@ pub(crate) const PART_00: &str = r#"<!DOCTYPE html>
     .outcome.success{background:rgba(63,185,80,0.1)}
     .outcome.failure{background:rgba(248,81,73,0.1)}
     .outcome-detail{font-size:.8rem;color:#8b949e;margin-top:.2rem;padding-left:1rem;font-family:monospace;white-space:pre-wrap;max-height:100px;overflow-y:auto}
+    abbr[title]{text-decoration:underline dotted var(--accent);text-underline-offset:2px;cursor:help;color:var(--fg)}
+    abbr[title]:hover{color:var(--accent)}
+    .glossary-toggle{cursor:pointer;color:var(--accent);font-size:.85rem;padding:.2rem .5rem;border:1px solid var(--accent);border-radius:4px;background:transparent;margin-left:.5rem}
+    .glossary-toggle:hover{background:rgba(88,166,255,0.1)}
+    .glossary-panel{display:none;position:fixed;right:0;top:0;width:340px;height:100vh;background:var(--card);border-left:1px solid var(--border);padding:1.5rem;overflow-y:auto;z-index:1000;box-shadow:-4px 0 12px rgba(0,0,0,0.3)}
+    .glossary-panel.open{display:block}
+    .glossary-panel h3{color:var(--accent);margin-bottom:1rem;display:flex;justify-content:space-between;align-items:center}
+    .glossary-panel .close-btn{cursor:pointer;color:#8b949e;font-size:1.2rem;background:none;border:none}
+    .glossary-entry{padding:.5rem 0;border-bottom:1px solid var(--border)}
+    .glossary-entry dt{color:var(--accent);font-weight:600;font-size:.9rem;margin-bottom:.2rem}
+    .glossary-entry dd{color:#8b949e;font-size:.85rem;margin:0;line-height:1.4}
   </style>
 </head>
 <body>
@@ -93,6 +104,7 @@ pub(crate) const PART_00: &str = r#"<!DOCTYPE html>
       <span id="header-version" style="font-size:.75rem;color:#8b949e"></span>
       <a href="https://github.com/rysweet/Simard" target="_blank" style="color:#8b949e;text-decoration:none;font-size:.85rem;padding:.2rem .4rem" title="Source on GitHub">⟨/⟩ Source</a>
       <a href="https://github.com/rysweet/Simard/releases/latest" target="_blank" style="color:#3fb950;text-decoration:none;font-size:.85rem;border:1px solid #3fb950;padding:.2rem .6rem;border-radius:4px">📦 Releases</a>
+      <button class="glossary-toggle" onclick="toggleGlossary()" title="Show glossary of Simard terms">📖 Glossary</button>
       <span id="clock" style="color:#8b949e;font-size:.85rem"></span>
     </div>
   </header>

--- a/src/operator_commands_dashboard/index_html/part_03.rs
+++ b/src/operator_commands_dashboard/index_html/part_03.rs
@@ -38,17 +38,21 @@ pub(crate) const PART_03: &str = r#"        const d=await apiFetch('/api/goals')
         }else{document.getElementById('goals-active').innerHTML='<span style="color:#8b949e">No active goals. Use "Seed Default Goals" or run the OODA daemon to generate goals from meetings.</span>';}
         if(d.backlog?.length){
           document.getElementById('goals-backlog').innerHTML=`<table class="proc-table">
-            <tr><th>ID</th><th>Description</th><th>Source</th><th>Score</th><th>Actions</th></tr>
-            ${d.backlog.map(b=>`<tr>
-              <td><code>${esc(b.id)}</code></td>
+            <tr><th>Title</th><th>Description</th><th>Source</th><th>Score</th><th>Actions</th></tr>
+            ${d.backlog.map(b=>{
+              const title=esc(b.display_id||b.id||'');
+              const isMemId=/^(sem|epi|wrk|pro|sns)_[0-9a-f]{8,}/.test(b.id||'');
+              const titleCell=isMemId?title:'<code>'+title+'</code>';
+              return`<tr>
+              <td>${titleCell}</td>
               <td>${esc(b.description)}</td>
-              <td>${esc(b.source||'')}</td>
-              <td>${b.score??'—'}</td>
+              <td style="font-size:.8rem;color:#8b949e">${esc(b.source||'')}</td>
+              <td>${typeof b.score==='number'?Math.round(b.score*100)+'%':(b.score??'—')}</td>
               <td>
                 <button class="btn" style="font-size:.7rem;padding:2px 6px" onclick="promoteGoal('${esc(b.id)}')">▲ Promote</button>
                 <button class="btn" style="font-size:.7rem;padding:2px 6px;margin-left:4px" onclick="removeGoal('${esc(b.id)}')">✕</button>
               </td>
-            </tr>`).join('')}
+            </tr>`}).join('')}
           </table>`;
         }else{document.getElementById('goals-backlog').innerHTML='<span style="color:#8b949e">No backlog items</span>';}
       }catch(e){document.getElementById('goals-active').innerHTML='<span class="err">Failed to load goals — check state root</span>';}

--- a/src/operator_commands_dashboard/index_html/part_04.rs
+++ b/src/operator_commands_dashboard/index_html/part_04.rs
@@ -157,23 +157,28 @@ pub(crate) const PART_04: &str = r#"            let fmt;
             </div>`;
           }).join('');
         }else{document.getElementById('wb-actions').innerHTML='<span style="color:#8b949e;font-size:.85rem">No recent actions</span>';}
-        // Task memory (rich facts)
+        // Task memory (structured table — #1683)
         const tm=d.task_memory||{};
         document.getElementById('wb-facts-count').textContent=(tm.facts_count||0)+' facts';
         if(tm.recent_facts?.length){
-          document.getElementById('wb-facts-list').innerHTML=tm.recent_facts.map(f=>{
-            const conf=typeof f.confidence==='number'?(' <span style="color:#8b949e;font-size:.75rem">('+Math.round(f.confidence*100)+'%)</span>'):'';
-            const tags=(f.tags||[]).map(t=>'<span style="background:var(--border);padding:0 .3rem;border-radius:3px;font-size:.7rem;margin-left:.3rem">'+esc(t)+'</span>').join('');
-            return'<div style="padding:.25rem 0;border-bottom:1px solid var(--border)"><strong style="color:var(--accent);font-size:.8rem">'+esc(f.concept||'')+'</strong>'+conf+tags+'<div>'+esc(f.content||'')+'</div></div>';
-          }).join('');
+          document.getElementById('wb-facts-list').innerHTML='<table class="proc-table"><tr><th>Category</th><th>Content</th><th>Confidence</th><th>Tags</th></tr>'
+            +tm.recent_facts.map(f=>{
+            const cat=esc(f.category||f.concept||'');
+            const conf=typeof f.confidence==='number'?Math.round(f.confidence*100)+'%':'—';
+            const tags=(f.tags||[]).map(t=>'<span style="background:var(--border);padding:0 .3rem;border-radius:3px;font-size:.7rem;margin-right:.3rem">'+esc(t)+'</span>').join('')||'—';
+            const content=esc((f.content||'').substring(0,200));
+            return'<tr><td style="white-space:nowrap;color:var(--accent);font-weight:600;font-size:.8rem">'+cat+'</td><td style="font-size:.85rem">'+content+'</td><td style="text-align:center;font-size:.8rem">'+conf+'</td><td>'+tags+'</td></tr>';
+          }).join('')+'</table>';
         }else{document.getElementById('wb-facts-list').innerHTML='<span style="color:#8b949e">No recent facts in memory</span>';}
-        // Working memory
+        // Working memory (human-readable — #1683)
         const wm=d.working_memory||[];
         document.getElementById('wb-wm-count').textContent=wm.length+' slots';
         if(wm.length){
-          document.getElementById('wb-wm-list').innerHTML=wm.map(s=>{
-            return'<div style="padding:.25rem 0;border-bottom:1px solid var(--border)"><span style="color:var(--accent);font-weight:600;font-size:.8rem">'+esc(s.slot_type)+'</span> <span style="color:#8b949e;font-size:.75rem">['+esc(s.task_id)+'] rel='+((s.relevance||0).toFixed(2))+'</span><div>'+esc(s.content)+'</div></div>';
-          }).join('');
+          document.getElementById('wb-wm-list').innerHTML='<table class="proc-table"><tr><th>Type</th><th>Content</th><th>Related Goal</th><th>Relevance</th></tr>'
+            +wm.map(s=>{
+            const relColor=s.relevance>=0.8?'var(--green)':s.relevance>=0.5?'var(--yellow)':'#8b949e';
+            return'<tr><td style="white-space:nowrap;color:var(--accent);font-weight:600;font-size:.8rem">'+esc(s.type_label||'Note')+'</td><td style="font-size:.85rem">'+esc((s.content||'').substring(0,200))+'</td><td style="font-size:.8rem;color:#8b949e">'+esc(s.goal||'—')+'</td><td style="text-align:center"><span style="color:'+relColor+';font-weight:600;font-size:.8rem">'+esc(s.relevance_label||'—')+'</span></td></tr>';
+          }).join('')+'</table>';
         }else{document.getElementById('wb-wm-list').innerHTML='<span style="color:#8b949e">No active working memory</span>';}
         // Cognitive statistics
         const cs=d.cognitive_statistics;

--- a/src/operator_commands_dashboard/index_html/part_05.rs
+++ b/src/operator_commands_dashboard/index_html/part_05.rs
@@ -186,6 +186,88 @@ pub(crate) const PART_05: &str = r#"      try {
     setInterval(fetchMergeReadiness,30000);
     setInterval(fetchStatus,30000);
     setInterval(fetchIssues,120000);
+
+    /* --- Glossary / Jargon tooltips (#1996) --- */
+    const GLOSSARY={
+      'OODA':'Observe-Orient-Decide-Act — the decision-making loop Simard runs each cycle to decide what to do next.',
+      'facilitator':'The meeting facilitator component that manages discussions between Simard and the user, extracting goals and action items.',
+      'consolidation':'The process of merging short-term observations into long-term memory, strengthening important facts and pruning noise.',
+      'recipe runner':'The workflow engine that executes multi-step automation recipes (build, test, deploy sequences) as part of goal work.',
+      'spawn_engineer':'An action where Simard launches a sub-agent in a separate process to work on a specific task (e.g., fixing a bug or writing code).',
+      'cognitive memory':'Simard\u2019s multi-layered memory system: sensory (raw input), working (active context), episodic (past events), semantic (learned facts), procedural (how-to), and prospective (reminders).',
+      'semantic fact':'A learned piece of knowledge stored in long-term memory, like a concept or relationship Simard has observed.',
+      'episodic memory':'A record of a specific past event — what happened, when, and the outcome.',
+      'procedural memory':'How-to knowledge — step-by-step procedures Simard has learned for completing tasks.',
+      'prospective memory':'A planned future action or reminder that Simard intends to act on later.',
+      'working memory':'Short-term context currently being used — the facts and plans relevant to whatever Simard is working on right now.',
+      'sensory buffer':'Raw, unprocessed recent observations before they are categorised into other memory types.',
+      'goal board':'The prioritised list of active goals and backlog items that Simard is tracking.',
+      'backlog':'Goals queued for later — not actively being worked on, but available to promote to active status.',
+      'hive mind':'Multi-host synchronisation: sharing knowledge across multiple Simard instances running on different machines.',
+      'daemon':'The background process that runs Simard\u2019s autonomous decision-making loop continuously.',
+      'cycle':'One complete pass through the decision loop — observe the environment, orient priorities, decide on an action, and act on it.',
+      'gym':'A training environment where Simard practices and improves its skills on synthetic scenarios.',
+    };
+    function toggleGlossary(){
+      const p=document.getElementById('glossary-panel');
+      p.classList.toggle('open');
+    }
+    function annotateJargon(el){
+      if(!el)return;
+      const walker=document.createTreeWalker(el,NodeFilter.SHOW_TEXT,null);
+      const nodes=[];
+      while(walker.nextNode()) nodes.push(walker.currentNode);
+      const terms=Object.keys(GLOSSARY).sort((a,b)=>b.length-a.length);
+      const pattern=new RegExp('\\b('+terms.map(t=>t.replace(/[.*+?^${}()|[\]\\]/g,'\\$&')).join('|')+')\\b','gi');
+      nodes.forEach(node=>{
+        if(node.parentElement&&(node.parentElement.tagName==='ABBR'||node.parentElement.tagName==='SCRIPT'||node.parentElement.tagName==='STYLE'||node.parentElement.tagName==='CODE'||node.parentElement.tagName==='INPUT'||node.parentElement.tagName==='TEXTAREA'))return;
+        const text=node.textContent;
+        if(!pattern.test(text))return;
+        pattern.lastIndex=0;
+        const frag=document.createDocumentFragment();
+        let lastIdx=0;
+        let match;
+        while((match=pattern.exec(text))!==null){
+          if(match.index>lastIdx) frag.appendChild(document.createTextNode(text.slice(lastIdx,match.index)));
+          const abbr=document.createElement('abbr');
+          const key=Object.keys(GLOSSARY).find(k=>k.toLowerCase()===match[1].toLowerCase())||match[1];
+          abbr.title=GLOSSARY[key]||'';
+          abbr.textContent=match[0];
+          frag.appendChild(abbr);
+          lastIdx=pattern.lastIndex;
+        }
+        if(lastIdx<text.length) frag.appendChild(document.createTextNode(text.slice(lastIdx)));
+        if(frag.childNodes.length>1) node.parentElement.replaceChild(frag,node);
+      });
+    }
+    // Run jargon annotation after each tab switch and data fetch
+    const origTabClickHandlers=[];
+    document.querySelectorAll('.tab').forEach(tab=>{
+      const origClick=tab.onclick;
+      tab.addEventListener('click',()=>{
+        setTimeout(()=>annotateJargon(document.querySelector('.tab-content.active')),300);
+      });
+    });
+    // Annotate overview on first load
+    setTimeout(()=>annotateJargon(document.querySelector('.tab-content.active')),500);
+  </script>
+
+  <div id="glossary-panel" class="glossary-panel">
+    <h3>Glossary <button class="close-btn" onclick="toggleGlossary()">&times;</button></h3>
+    <p style="color:#8b949e;font-size:.8rem;margin-bottom:1rem">Hover any <abbr title="Example tooltip">dotted-underlined term</abbr> in the dashboard for a quick explanation, or browse the full list below.</p>
+    <dl id="glossary-list"></dl>
+  </div>
+  <script>
+    (function(){
+      const dl=document.getElementById('glossary-list');
+      if(!dl)return;
+      Object.keys(GLOSSARY).sort().forEach(term=>{
+        const entry=document.createElement('div');
+        entry.className='glossary-entry';
+        entry.innerHTML='<dt>'+esc(term)+'</dt><dd>'+esc(GLOSSARY[term])+'</dd>';
+        dl.appendChild(entry);
+      });
+    })();
   </script>
 </body>
 </html>

--- a/src/operator_commands_dashboard/workboard.rs
+++ b/src/operator_commands_dashboard/workboard.rs
@@ -12,6 +12,43 @@ use crate::cognitive_memory::{CognitiveMemoryOps, NativeCognitiveMemory};
 // Workboard API — aggregated view of Simard's current mental state
 // ---------------------------------------------------------------------------
 
+/// Human-readable label for a working memory slot type (#1683).
+fn human_slot_type(raw: &str) -> &'static str {
+    match raw {
+        "context" | "Context" => "Task context",
+        "plan" | "Plan" => "Current plan",
+        "observation" | "Observation" => "Observation",
+        "hypothesis" | "Hypothesis" => "Hypothesis",
+        "decision" | "Decision" => "Decision",
+        "action" | "Action" => "Action taken",
+        "result" | "Result" => "Result",
+        "goal" | "Goal" => "Goal detail",
+        _ => "Note",
+    }
+}
+
+/// Human-readable category for a fact concept string (#1683).
+fn human_fact_category(concept: &str) -> &'static str {
+    let c = concept.to_lowercase();
+    if c.contains("goal") || c.contains("objective") {
+        "Goal"
+    } else if c.contains("action") || c.contains("task") {
+        "Action"
+    } else if c.contains("decision") {
+        "Decision"
+    } else if c.contains("episode") || c.contains("event") {
+        "Event"
+    } else if c.contains("observation") || c.contains("insight") {
+        "Insight"
+    } else if c.contains("meeting") || c.contains("discussion") {
+        "Meeting note"
+    } else if c.contains("snapshot") {
+        "Snapshot"
+    } else {
+        "Fact"
+    }
+}
+
 pub(crate) async fn workboard() -> Json<Value> {
     let state_root = resolve_state_root();
 
@@ -224,16 +261,25 @@ pub(crate) async fn workboard() -> Json<Value> {
             }));
         }
 
-        // Working memory slots for each active goal
+        // Working memory slots for each active goal (#1683: human-readable labels)
         if let Some(board) = &goal_board {
             for goal in &board.active {
                 if let Ok(slots) = mem.get_working(&goal.id) {
                     for slot in slots {
+                        let type_label = human_slot_type(&slot.slot_type);
+                        let goal_label = &goal.description;
+                        let relevance_label = if slot.relevance >= 0.8 {
+                            "High"
+                        } else if slot.relevance >= 0.5 {
+                            "Medium"
+                        } else {
+                            "Low"
+                        };
                         working_memory.push(json!({
-                            "id": slot.node_id,
-                            "slot_type": slot.slot_type,
+                            "type_label": type_label,
                             "content": slot.content,
-                            "task_id": slot.task_id,
+                            "goal": goal_label,
+                            "relevance_label": relevance_label,
                             "relevance": slot.relevance,
                         }));
                     }
@@ -242,6 +288,7 @@ pub(crate) async fn workboard() -> Json<Value> {
         }
 
         // Recent semantic facts (search across common tags, collect up to 20)
+        // (#1683: provide human-readable category labels instead of raw IDs)
         for tag in &[
             "action",
             "goal",
@@ -253,8 +300,9 @@ pub(crate) async fn workboard() -> Json<Value> {
             if let Ok(facts) = mem.search_facts(tag, 10, 0.0) {
                 for fact in facts {
                     if recent_facts.len() < 20 {
+                        let category = human_fact_category(&fact.concept);
                         recent_facts.push(json!({
-                            "id": fact.node_id,
+                            "category": category,
                             "concept": fact.concept,
                             "content": fact.content,
                             "confidence": fact.confidence,


### PR DESCRIPTION
## Summary

Fixes the three highest-impact dashboard readability issues that make the dashboard look like developer debug output instead of an operational overview.

### Issue #1683 — Workboard Task Memory raw JSON dump
- **Before:** Task Memory panel showed raw `concept`, `content`, `node_id` fields as unformatted text. Working Memory showed raw `slot_type`, `[task_id]`, `rel=0.85` debug output.
- **After:** Task Memory renders as a structured table with **Category**, **Content**, **Confidence%**, and **Tags** columns. Working Memory shows **Type**, **Content**, **Related Goal**, and **Relevance** (High/Medium/Low) in a clean table.
- Backend helpers `human_slot_type()` and `human_fact_category()` map internal codes to plain-English labels.

### Issue #1686 — Goals backlog raw memory IDs and debug strings
- **Before:** Backlog rows from cognitive memory showed raw `sem_019e18ac…` node IDs in `<code>` tags, verbatim `priority=3 status=proposed rationale=Action…` debug strings, and `cognitive-memory/<concept>` source labels.
- **After:** Backlog shows human-readable titles (first 6 words of content), debug key=value strings are filtered out by `looks_like_debug_string()` heuristic, sources show plain-English labels ("From goals", "From actions", etc.), scores display as percentages.

### Issue #1996 — Jargon terms need inline explanation
- **Before:** Terms like OODA, facilitator, consolidation, spawn_engineer appeared without explanation.
- **After:** A **📖 Glossary** button in the header opens a sidebar with 18 defined terms. The `annotateJargon()` JS function wraps known terms in `<abbr title="...">` elements with dotted-underline styling on every tab switch and page load.

## Files Changed (6 files, +284/-22)
- `src/operator_commands_dashboard/workboard.rs` — Backend: human-readable labels for working memory and task memory
- `src/operator_commands_dashboard/goals.rs` — Backend: debug string filtering, human backlog IDs, clean source labels + 6 unit tests
- `src/operator_commands_dashboard/index_html/part_00.rs` — CSS for abbr tooltips, glossary panel; glossary toggle button
- `src/operator_commands_dashboard/index_html/part_03.rs` — Frontend: clean backlog table rendering
- `src/operator_commands_dashboard/index_html/part_04.rs` — Frontend: structured Task Memory and Working Memory tables
- `src/operator_commands_dashboard/index_html/part_05.rs` — Glossary JS, annotateJargon(), glossary panel HTML

## Quality Evidence

1. **Tests:** 132 dashboard tests pass (126 existing + 6 new backlog helper tests). All pre-commit (fmt, clippy) and pre-push (fmt, release tests, clippy) hooks green.
2. **Docs:** Changes are to dashboard rendering only; no new user-facing CLI surfaces.
3. **Diff focused:** Only 6 files changed, all in `operator_commands_dashboard/`. No unrelated edits.

Closes #1683, closes #1686, closes #1996
Part of epic #1992