### PR TITLE
refactor(ooda): replace JSON-parsing-LLM-output with text-based agentic parsers

### DIFF
--- a/docs/concepts/automated-disk-health.md
+++ b/docs/concepts/automated-disk-health.md
@@ -208,9 +208,13 @@ because:
    judgement, progress checking, and other policy decisions. Disk health
    follows the same pattern.
 
-The Rust shim remains thin: resolve the recipe path, invoke `recipe-runner-rs`,
-parse the JSON output. This is the same pattern used by
-`stewardship/recipe_merge_judge.rs` and `stewardship/recipe_progress_checker.rs`.
+The Rust code is a thin shim. All cleanup logic lives in the recipe YAML as
+a readable bash file, not compiled into the binary. Operators can `cat` it,
+`diff` it, or run it manually.
+
+The recipe outputs key=value lines to stdout (`DISK_USED_PCT=N`,
+`FREED_BYTES=N`, `ACTION: ...`) — the Rust shim parses these with simple
+string splitting. No JSON, no serde deserialization of recipe output.
 
 ## Related
 

--- a/docs/concepts/progress-evidence-gating.md
+++ b/docs/concepts/progress-evidence-gating.md
@@ -47,11 +47,17 @@ The single guiding principle of the fix is:
 ## How evidence is evaluated
 
 A proposed increase from `old_percent` to `new_percent` for goal `G` is
-submitted to an **LLM reviewer** (`LlmReviewerProgressChecker` in
-`src/goal_curation/progress_reviewer.rs`). The reviewer reads five inputs —
-the goal's **problem** description, **plan** (current activity), **prior
-percent**, **claimed percent**, and **WIP summary** — and returns
-`{verdict: "accept"|"reject", rationale: "..."}`.
+submitted to a **recipe-based reviewer** (`RecipeProgressChecker` in
+`src/goal_curation/recipe_progress_checker.rs`). The recipe runs an LLM
+agent that reads five inputs — the goal's **problem** description, **plan**
+(current activity), **prior percent**, **claimed percent**, and **WIP
+summary** — and returns a text verdict.
+
+The recipe stdout is scanned for `"accept"` or `"reject"` keywords
+(case-insensitive). The surrounding text is captured as the rationale.
+No JSON parsing is involved. See
+[text-parsing wire formats § progress checker](../reference/text-parsing-wire-formats.md#2a-progress-checker-recipe_progress_checkerrs)
+for the full grammar.
 
 The reviewer **accepts** when the claimed percent is coherent with the plan:
 
@@ -222,7 +228,7 @@ events, not silent suppressions.
 
 The gate fires only on progress-**increase** attempts — typically a handful
 per OODA cycle, not per cycle wall-clock. Each fire executes at most one
-LLM call (the `LlmReviewerProgressChecker` submits a single prompt).
+recipe invocation (the `RecipeProgressChecker` runs a single recipe).
 Downward/no-change moves are auto-accepted without an LLM call. The
 prompt template is kept short to minimize latency.
 

--- a/docs/concepts/prompt-driven-ooda-brain.md
+++ b/docs/concepts/prompt-driven-ooda-brain.md
@@ -80,19 +80,21 @@ useful as an audit trail and can be processed manually.
 
 This PR establishes the **pattern** at one decision site. The same
 `OodaBrain`-style trait and `prompt_assets/simard/ooda_*.md` file convention
-will incrementally absorb the other OODA phases:
+has incrementally absorbed the other OODA phases. All use text-based wire
+formats (DECISION markers and labeled lines) — no JSON parsing of LLM output.
 
-| Phase | Future prompt | Scope |
-|---|---|---|
-| Observe | `ooda_observe.md` | Which signals to attend to this cycle |
-| Orient | `ooda_orient.md` | How to weight goals given recent failures |
-| Decide | `ooda_decide.md` | Which planned action to enact next |
-| Curate | `ooda_curate.md` | Goal/improvement curation triage |
-| Review | `ooda_review.md` | Engineer-output acceptance |
+| Phase | Prompt | Wire format | Status |
+|---|---|---|---|
+| Observe | `ooda_observe.md` | (future) | Planned |
+| Orient | `ooda_orient.md` | Labeled lines (`ADJUSTED_URGENCY:`, `RATIONALE:`, `CONFIDENCE:`) | **Shipped** |
+| Decide | `ooda_decide.md` | `DECISION:` marker | **Shipped** |
+| Curate | `ooda_curate.md` | (future) | Planned |
+| Review | `ooda_review.md` | (future) | Planned |
+| Engineer lifecycle | `ooda_brain.md` | `DECISION:` marker + labeled body lines | **Shipped** |
 
-Each migration follows the same recipe: add a prompt, define a trait + ctx +
-decision struct, wire it at one site, keep a deterministic fallback,
-preserve the on-disk schema.
+See [text-based brain protocol](./text-based-brain-protocol.md) for the
+design rationale and [text-parsing wire formats](../reference/text-parsing-wire-formats.md)
+for the normative grammar of each format.
 
 ## See Also
 

--- a/docs/concepts/text-based-brain-protocol.md
+++ b/docs/concepts/text-based-brain-protocol.md
@@ -1,0 +1,275 @@
+---
+title: Text-based brain protocol
+description: Why Simard's OODA brains, recipe shims, and progress checkers use text-based wire formats instead of JSON parsing of LLM output — and how the text parsers work.
+last_updated: 2026-05-24
+review_schedule: as-needed
+owner: simard
+doc_type: concept
+related:
+  - ../reference/text-parsing-wire-formats.md
+  - ../reference/ooda-brain-api.md
+  - ../reference/ooda-brain-decision-protocol.md
+  - ../reference/disk-health-api.md
+  - ../reference/progress-evidence-api.md
+  - ../howto/edit-the-ooda-brain-prompt.md
+  - ../howto/diagnose-decide-orient-parse-failures.md
+  - ./prompt-driven-ooda-brain.md
+  - ./progress-evidence-gating.md
+---
+
+# Text-based brain protocol
+
+Simard never parses JSON from LLM or recipe output. Every brain, recipe shim,
+and progress checker uses text-based wire formats — keyword markers,
+labeled lines, or key=value pairs — that the Rust code parses with `str`
+methods. No `serde_json::from_str` on model output. No regex crate. No
+extraction heuristics like `find('{')..rfind('}')`.
+
+This document explains the problem that motivated the change, the design
+principles behind the text-based protocol, and the specific wire formats
+used at each decision site.
+
+## The problem: JSON-parsing LLM output is an anti-pattern
+
+Before issue [#1980](https://github.com/rysweet/Simard/issues/1980), eight
+sites in the codebase parsed JSON from LLM or recipe output:
+
+| Site | What it parsed | Failure mode |
+|------|---------------|--------------|
+| `disk_health.rs` | `DiskHealthReport` from recipe stdout | Recipe bash step had to `printf` valid JSON — fragile quoting |
+| `recipe_progress_checker.rs` | `ReviewerResponse` from recipe stdout | Double indirection: recipe runs LLM, LLM emits JSON, Rust parses JSON |
+| `recipe_merge_judge.rs` | `JudgeOutcome` from recipe stdout | Same double indirection |
+| `decide.rs` | `DecideJudgment` from LLM response | `find('{')..rfind('}')` extraction — boundary attacks, partial objects |
+| `orient.rs` | `OrientJudgment` from LLM response | Same extraction pattern |
+| `rustyclawd.rs` | `EngineerLifecycleDecision` from LLM response | JSON fallback path after DECISION marker — two parsers, double failure surface |
+| `progress_reviewer.rs` | `ReviewerResponse` from LLM response | Dead code — replaced by recipe_progress_checker |
+| `merge_judge.rs` | `JudgeOutcome` from LLM response | Dead code — replaced by recipe_merge_judge |
+
+Every one of these was brittle and unnecessary:
+
+1. **LLMs don't reliably produce valid JSON.** The production logs showed
+   models emitting `"OK"`, `"continue"`, prose paragraphs, markdown-fenced
+   JSON, and partial objects. Each failure triggered a silent fallback that
+   masked the actual decision the model made.
+
+2. **The recipe runner handles agentic communication natively.** Recipe steps
+   return text, not structured JSON. Forcing a bash step to `printf` a JSON
+   object with proper escaping is fragile — a filename with a quote character
+   breaks the output.
+
+3. **The `find('{')..rfind('}')` extraction pattern is a security risk.**
+   It trusts the LLM to produce a single JSON boundary. A model that emits
+   `{"choice":"skip"} ... {"choice":"reclaim_and_redispatch"}` gets the
+   *second* object parsed — the wrong one.
+
+4. **Fallback storms.** When the JSON parser fails, the code falls back to
+   a deterministic brain. The deterministic brain works fine for synthetic
+   priorities but does not correctly route real goals with open PRs to
+   `dispatch_spawn_engineer`. The result: goals with open PRs stall
+   indefinitely because engineers are never spawned.
+
+## Design principles
+
+### Text-first, not JSON-tolerant
+
+The old approach tried to make JSON parsing more tolerant — strip fences,
+extract between braces, handle whitespace. Each tolerance added complexity
+and new failure modes. The text-based protocol inverts the approach: the
+wire format is text from the start, and the parser looks for keywords.
+
+A model that responds with `"advance_goal"` or `"DECISION: advance_goal"`
+or `"I think we should advance_goal because..."` all parse correctly. The
+parser finds the keyword; the surrounding prose is the rationale.
+
+### `str` methods only, no regex
+
+All text parsers use `str::starts_with`, `str::contains`, `str::split_once`,
+`str::trim`, and `str::parse::<f64>`. No regex crate dependency. This
+eliminates ReDoS risk and keeps the parser auditable as a sequence of
+string operations.
+
+### Keyword scanning, not position-dependent
+
+Recipe shim parsers (progress checker, merge judge) scan the *entire*
+stdout for a verdict keyword — `"accept"`, `"reject"`, `"ready"`,
+`"not_ready"`. The keyword can appear anywhere in the text. The parser
+checks for the *negative* keyword first (`"not_ready"` before `"ready"`)
+to avoid false positives from substring matching.
+
+### Labeled lines for structured data
+
+OODA brain parsers (decide, orient, rustyclawd) use labeled-line formats
+where each field appears on its own line with a prefix:
+
+```
+DECISION: advance_goal
+RATIONALE: PR #2023 is open; engineer needed to drive it to completion
+```
+
+The parser iterates `.lines()`, checks `starts_with("PREFIX:")`, and
+extracts the value after the colon. Unknown lines are ignored (forward
+compatible). Missing required fields get sensible defaults.
+
+### Key=value for bash output
+
+The disk health recipe outputs structured data as key=value lines:
+
+```
+DISK_USED_PCT=72
+FREED_BYTES=53687091200
+ACTION: Removed 48 stale worktrees (50.1G)
+ACTION: Cleaned cargo-target/ (12.0G)
+```
+
+This is natural to produce from bash (`echo "DISK_USED_PCT=$(df ...)"`)
+and natural to parse from Rust (`line.split_once('=')`). No quoting
+concerns, no escaping, no JSON `printf` fragility.
+
+### Retained `serde_json` is never on LLM output
+
+The one remaining `serde_json::from_value` call in `rustyclawd.rs`
+deserializes a `serde_json::Value` that Rust code *constructed* from
+text-parsed fields — it is not parsing LLM output. A `// SAFETY:` comment
+marks this call and explains why it is not part of the anti-pattern.
+
+## The three protocol families
+
+### 1. DECISION marker protocol (OODA brains)
+
+Used by: `decide.rs`, `orient.rs`, `rustyclawd.rs`
+
+The model emits a leading `DECISION: <variant>` line. For variants that
+need structured fields, labeled body lines follow:
+
+```
+DECISION: open_tracking_issue
+TITLE: Engineer stuck in compile-error loop for improve-test-coverage
+BODY: The engineer has been failing for 6 consecutive cycles with E0277 type errors.
+RATIONALE: Persistent failure pattern needs human attention.
+```
+
+The parser:
+1. Finds the first non-blank line matching `DECISION:` (case-insensitive
+   on the literal word `DECISION`).
+2. Extracts the variant token and matches against the known enum variants.
+3. For structured variants, scans remaining lines for labeled fields
+   (`TITLE:`, `BODY:`, `REASON:`, `REDISPATCH_CONTEXT:`).
+4. Collects all non-labeled lines after the DECISION line as the rationale
+   (unless a `RATIONALE:` label is present, which takes precedence).
+
+See [Reference: text-parsing wire formats](../reference/text-parsing-wire-formats.md)
+for the full grammar and variant-specific field requirements.
+
+### 2. Keyword verdict protocol (recipe shims)
+
+Used by: `recipe_progress_checker.rs`, `recipe_merge_judge.rs`
+
+The recipe runs an agent step. The agent's stdout is scanned for a verdict
+keyword. Everything else is treated as rationale.
+
+```
+After reviewing the plan and progress claims, the evidence supports the
+claimed delta. The PR is in flight and the 8-point increase matches the
+described work.
+
+accept
+```
+
+The parser:
+1. Converts stdout to lowercase.
+2. Checks for `"not_ready"` (merge judge) or `"reject"` (progress checker)
+   first — prevents `"not_ready"` matching as `"ready"`.
+3. Checks for `"ready"` or `"accept"`.
+4. If no keyword found, defaults to the safe option (`Accept` for progress
+   checker — fail-open; `NotReady` for merge judge — fail-closed).
+5. Extracts the full stdout (minus the keyword line) as rationale.
+
+### 3. Key=value protocol (disk health)
+
+Used by: `disk_health.rs`
+
+The recipe bash step outputs key=value lines for numeric fields and
+`ACTION:` prefixed lines for the human-readable action list:
+
+```
+DISK_USED_PCT=72
+FREED_BYTES=53687091200
+ACTION: Removed 48 stale worktrees (50.1G)
+ACTION: Removed cargo target dirs from 3 worktrees (1.2G)
+ACTION: Pruned 19 LadybugDB backups (512M)
+ACTION: Cleaned cargo-target/ (12.0G) and shared-target/ (2.8G)
+```
+
+The parser:
+1. Iterates `.lines()`.
+2. For `KEY=VALUE` lines: `split_once('=')`, `trim()`, `parse::<u64>()`.
+3. For `ACTION:` lines: strips the prefix, collects into `Vec<String>`.
+4. Defaults: `disk_used_pct = 0`, `freed_bytes = 0`, `actions_taken = []`.
+
+## Dead code removal
+
+Two modules were deleted as part of this change:
+
+- **`progress_reviewer.rs`** — `LlmReviewerProgressChecker` and
+  `parse_reviewer_response`. Replaced by the keyword verdict parser in
+  `recipe_progress_checker.rs`. The `RecipeProgressChecker` now builds
+  `EvidenceDecision` directly without the intermediate `ReviewerResponse`
+  type.
+
+- **`merge_judge.rs` (partial)** — `LlmMergeJudge`, `parse_judge_response`,
+  `extract_fenced_blocks`, `extract_balanced_objects`, `truncate_for_log`.
+  The merge judge fallback chain is now `RecipeMergeJudge` →
+  `RefusingMergeJudge`. There is no LLM tier. Types (`JudgeOutcome`,
+  `Verdict`, `Blocker`, `MergeJudgeKind`), traits (`MergeJudge`), and
+  `RefusingMergeJudge` / `build_merge_judge` are retained.
+
+The daemon wiring in `operator_commands_ooda/daemon/mod.rs` was updated to
+match: the `LlmReviewerProgressChecker` fallback arm was removed. The chain
+is now `RecipeProgressChecker` → `NoopProgressEvidenceChecker`.
+
+## Why this matters for engineer spawning
+
+The JSON parse failures in `decide.rs` were the root cause of goals with
+open PRs not getting engineers spawned. The flow:
+
+1. Orient phase produces priority for `improve-amplihack-test-coverage`
+   with `urgency: 0.8`.
+2. Decide phase asks the LLM brain for an action kind.
+3. LLM responds with `advance_goal` (correct!) but the response is prose,
+   not JSON.
+4. `serde_json::from_str::<DecideJudgment>` fails.
+5. Fallback to deterministic mapping: check if `goal_id` starts with `__`.
+   It doesn't, so return `advance_goal`.
+6. This works — but only because the deterministic mapping happens to
+   produce the right answer for this case. For edge cases where the LLM
+   would have routed differently (e.g., `research_query`), the fallback
+   silently overrides the model's judgment.
+
+With text parsing, step 3 succeeds directly. The model's response
+`"advance_goal"` is found by keyword scan. No fallback needed. Goals
+with open PRs flow to `dispatch_spawn_engineer` reliably.
+
+## Security improvements
+
+Removing the JSON extraction patterns is a net security improvement:
+
+- **No `find('{')..rfind('}')` boundary attacks.** A model that emits
+  multiple JSON objects no longer gets the wrong one parsed.
+- **No quoting/escaping concerns in bash recipes.** Key=value lines don't
+  need JSON-safe quoting of filenames or paths.
+- **`.lines()` iteration is lazy with early break.** No unbounded
+  allocation from huge LLM responses.
+- **`str` methods are constant-time per character.** No backtracking
+  regex that could be exploited with crafted input.
+
+## Related
+
+- [Reference: text-parsing wire formats](../reference/text-parsing-wire-formats.md) — full grammar for each protocol
+- [Reference: OODA Brain API](../reference/ooda-brain-api.md) — trait and type definitions
+- [Reference: OODA Brain Decision Protocol](../reference/ooda-brain-decision-protocol.md) — DECISION marker for engineer lifecycle
+- [Reference: Disk Health API](../reference/disk-health-api.md) — key=value disk health contract
+- [Reference: Progress-evidence API](../reference/progress-evidence-api.md) — keyword verdict for progress checking
+- [How-to: edit the OODA brain prompt](../howto/edit-the-ooda-brain-prompt.md) — prompt editing after the text migration
+- [How-to: diagnose decide/orient parse failures](../howto/diagnose-decide-orient-parse-failures.md) — operator runbook
+- [Concept: prompt-driven OODA brain](./prompt-driven-ooda-brain.md) — original brain design
+- [Concept: progress-evidence gating](./progress-evidence-gating.md) — progress gating design

--- a/docs/howto/configure-disk-health-check.md
+++ b/docs/howto/configure-disk-health-check.md
@@ -84,8 +84,8 @@ YAML each time.
 
 ## Read a full disk health report
 
-The recipe outputs a JSON report to stdout, which the daemon captures and
-logs. To run the check manually outside the daemon:
+The recipe outputs a key=value text report to stdout, which the daemon captures
+and logs. To run the check manually outside the daemon:
 
 ```bash
 recipe-runner-rs prompt_assets/simard/recipes/disk-health-check.yaml \
@@ -93,19 +93,15 @@ recipe-runner-rs prompt_assets/simard/recipes/disk-health-check.yaml \
   -c REPO_ROOT="/home/azureuser/src/Simard"
 ```
 
-This prints the JSON report to stdout:
+This prints the text report to stdout:
 
-```json
-{
-  "disk_used_pct": 72,
-  "freed_bytes": 53687091200,
-  "actions_taken": [
-    "Removed 48 stale worktrees (50.1G)",
-    "Removed cargo target dirs from 3 worktrees (1.2G)",
-    "Pruned 19 LadybugDB backups (512M)",
-    "Cleaned cargo-target/ (12.0G) and shared-target/ (2.8G)"
-  ]
-}
+```
+DISK_USED_PCT=72
+FREED_BYTES=53687091200
+ACTION: Removed 48 stale worktrees (50.1G)
+ACTION: Removed cargo target dirs from 3 worktrees (1.2G)
+ACTION: Pruned 19 LadybugDB backups (512M)
+ACTION: Cleaned cargo-target/ (12.0G) and shared-target/ (2.8G)
 ```
 
 You can also run just the disk usage check (no cleanup) by looking at the
@@ -155,11 +151,13 @@ Common causes:
 - Permission denied on a directory under `$STATE_ROOT`
 - `du` or `find` not on PATH (unlikely on standard Linux)
 
-### 4. JSON parse failure
+### 4. Text parse shows unexpected values
 
-The Rust shim expects exactly one JSON object on stdout. If the bash script
-printed extra lines (warnings, debug output), the JSON parse fails. Fix the
-recipe to keep non-JSON output on stderr.
+The Rust shim parses key=value lines from stdout. If the bash script
+outputs lines with unexpected formats, the parser silently ignores them
+and defaults to zero. Check for typos in key names (`DISK_USED_PCT`, not
+`DISK_USED_PERCENT`) and ensure values are plain integers (no units, no
+commas).
 
 ## Handle persistent disk pressure
 
@@ -265,7 +263,7 @@ rm -rf ~/.simard/cargo-target/* ~/.simard/shared-target/*
 
 ## Related
 
-- [Disk health API reference](../reference/disk-health-api.md) — full API, JSON contract, error variants
+- [Disk health API reference](../reference/disk-health-api.md) — full API, text contract, error variants
 - [Automated disk health (concept)](../concepts/automated-disk-health.md) — design rationale
 - [Inspect and clean engineer worktrees](./inspect-and-clean-engineer-worktrees.md) — manual worktree operations
 - [Reclaim disk space and run low-space Rust builds](./reclaim-disk-space-and-run-low-space-rust-builds.md) — build artifact scripts

--- a/docs/howto/diagnose-brain-decision-parse-failures.md
+++ b/docs/howto/diagnose-brain-decision-parse-failures.md
@@ -6,11 +6,12 @@
 > **Prerequisites:** read access to `~/.simard/logs/` on the daemon host;
 > familiarity with the `simard` CLI.
 
-The OODA brain decision parser is intentionally lenient — it accepts a prose
-`DECISION:` marker, hybrid prose-plus-JSON, or pure JSON. When it still
-rejects a response, the cycle falls back to `ContinueSkipping` and emits a
-`WARN`-level log line that contains the **full raw model response**. This
-guide tells you how to find that log, read it, and decide what to do.
+The OODA brain decision parser accepts a text-based `DECISION:` marker with
+labeled lines for structured fields. JSON is no longer accepted (removed in
+#1980). When the parser rejects a response, the cycle falls back to
+`ContinueSkipping` and emits a `WARN`-level log line that contains the
+**full raw model response**. This guide tells you how to find that log, read
+it, and decide what to do.
 
 For the full protocol definition see the
 [OODA Brain Decision Protocol reference](../reference/ooda-brain-decision-protocol.md).
@@ -46,7 +47,7 @@ You are looking for a line shaped like:
 WARN simard::ooda_brain: brain.decide_engineer_lifecycle parse failed
     goal=improve-amplihack-test-coverage
     raw="OK"
-    error=no DECISION: marker found and response is not valid JSON
+    error=no DECISION: marker found in LLM response (got 3 bytes)
 ```
 
 The `raw=...` field is the **complete** model response (truncated to 8 KB
@@ -64,9 +65,9 @@ Match the contents of `raw=` against this triage table.
 | `"OK"`, `"continue"`, `"yes"`                  | Model ignored the prompt; emitted a chat acknowledgment | [Step 3 — replay the prompt](#step-3-replay-the-prompt-locally) to confirm; consider tightening the prompt's role section. |
 | `""`                                           | LLM provider returned an empty body                     | Check the adapter logs (`~/.simard/logs/rustyclawd.log`) for a 5xx or rate-limit error.                                    |
 | `"DECISION: bogus_variant"`                    | Model invented a variant name                           | The error message lists the 6 valid variants; cross-check the prompt's enumeration block isn't drifting.                   |
-| `"DECISION: open_tracking_issue\n<no JSON>"`   | Model used the marker but omitted required fields       | The prompt's `# OPTIONS` section needs to remind the model that this variant requires `title` + `body`.                    |
-| Long prose with no `DECISION:` marker          | Model is in chat mode, not structured-output mode       | Check that `RustyClawdAdapter` is forcing structured output / JSON mode for the configured provider.                       |
-| Valid-looking JSON that still fails            | Field name typo or wrong `choice` casing                | Run `Step 3` and inspect — the parser only accepts the variant tokens listed in the [protocol reference](../reference/ooda-brain-decision-protocol.md#variant-whitelist). |
+| `"DECISION: open_tracking_issue\n<no labeled fields>"`| Model used the marker but omitted required labeled fields | The prompt's `# OPTIONS` section needs to remind the model that this variant requires `TITLE:` + `BODY:` labeled lines. |
+| Long prose with no `DECISION:` marker          | Model is in chat mode, not structured-output mode       | Strengthen the prompt's OUTPUT_FORMAT section to emphasize the `DECISION:` marker requirement.                            |
+| JSON object (legacy format)                    | Model following old JSON instructions from cached prompt | Update the prompt to use DECISION marker format. JSON is no longer accepted.                                              |
 
 ## Step 3: Replay the prompt locally
 
@@ -102,7 +103,7 @@ parsed. Discard the test before committing.
 | Chat acknowledgment / wrong mode           | Edit `prompt_assets/simard/ooda_brain.md` to strengthen the "respond ONLY with the marker" instruction. See [edit-the-ooda-brain-prompt](edit-the-ooda-brain-prompt.md). |
 | Adapter 5xx / rate limit                   | Investigate the adapter; the brain itself is healthy.                                                                      |
 | Bogus variant                              | The prompt should be the only place that lists variants; align it with the enum.                                            |
-| Missing required fields on hybrid form     | Update the prompt's `# OPTIONS` section to make the field requirement explicit.                                            |
+| Missing required labeled fields on structured variant | Update the prompt's `# OPTIONS` section to make the labeled field requirement explicit (`TITLE:`, `BODY:`, etc.).       |
 | Persistent unparseable noise from one model| Switch the provider in the brain config; the parser cannot fix a fundamentally non-cooperative model.                      |
 
 After editing the prompt, **do not** restart the daemon by hand. The
@@ -144,14 +145,16 @@ proceeding:
   need. Always go through `safe-update`, which performs the rebuild,
   drain, hot-swap, and health check together.
 * **Editing the parser to "just accept" a new ad-hoc shape** the model
-  emits. The protocol already accepts three forms; if the model is
-  emitting a fourth, the **prompt** is wrong, not the parser.
+  emits. The protocol accepts the DECISION marker format only; if the model
+  is emitting JSON or another format, the **prompt** is wrong, not the parser.
 * **Adding a fallback in `dispatch_spawn_engineer` for a specific raw
   response.** The single fallback path (`ContinueSkipping`) is intentional;
   a parse failure should be visible in the logs, not silently rerouted.
 
 ## See Also
 
+* [Concept: text-based brain protocol](../concepts/text-based-brain-protocol.md)
+* [Reference: text-parsing wire formats](../reference/text-parsing-wire-formats.md)
 * [Reference: OODA Brain Decision Protocol](../reference/ooda-brain-decision-protocol.md)
 * [How-to: edit the OODA brain prompt](edit-the-ooda-brain-prompt.md)
 * [Reference: `OodaBrain` API](../reference/ooda-brain-api.md)

--- a/docs/howto/diagnose-decide-orient-parse-failures.md
+++ b/docs/howto/diagnose-decide-orient-parse-failures.md
@@ -1,7 +1,7 @@
 ---
 title: Diagnose OODA decide/orient brain parse failures
-description: Operator runbook for the silent-fallback fix in #1890. Find, classify, and remediate JSON-parse failures from the decide and orient phases.
-last_updated: 2026-05-19
+description: Operator runbook for text-based OODA brain parse failures. Find, classify, and remediate parse failures from the decide and orient phases.
+last_updated: 2026-05-24
 review_schedule: as-needed
 owner: simard
 ---
@@ -16,24 +16,37 @@ owner: simard
 > `~/.simard/cycle_reports/`, and `~/.simard/metrics/` on the daemon
 > host; familiarity with the `simard` CLI and `jq`.
 
-Before [#1890](https://github.com/rysweet/Simard/issues/1890) shipped, the `decide_with_brain` and `orient_with_brain` call sites in `simard::ooda_loop` would respond to an LLM brain JSON-parse failure by emitting a single `WARN` line — `no JSON object found in LLM response (got N bytes)` — and then silently substituting `DeterministicFallbackDecideBrain` / `DeterministicFallbackOrientBrain`. The cycle continued, `cycle_N.json` recorded a perfectly normal-looking deterministic decision, and the goal stalled invisibly.
+The decide and orient brains use text-based wire formats — `DECISION:` markers
+and labeled lines — instead of JSON. Parse failures are rare because the
+text format is tolerant of prose, but they can still occur when a model emits
+a response with no recognizable decision marker or labeled field.
 
-That silent-fallback path is now closed. Parse failures fire four visibility channels in lock-step. This guide tells you how to find them, read them, and decide what to do.
+Parse failures fire four visibility channels in lock-step. This guide tells
+you how to find them, read them, and decide what to do.
 
-For the full schema and contract, see [Reference: OODA Brain Parse-Failure Record](../reference/ooda-brain-parse-failure-record.md). The engineer-lifecycle equivalent (#1711) is covered by [Diagnose OODA brain decision parse failures](./diagnose-brain-decision-parse-failures.md) — this page is its sibling for the decide / orient phases.
+For the wire format specifications, see
+[Reference: text-parsing wire formats](../reference/text-parsing-wire-formats.md).
+The engineer-lifecycle equivalent (#1711) is covered by
+[Diagnose OODA brain decision parse failures](./diagnose-brain-decision-parse-failures.md).
 
 ## Step 1: Find the failing cycle
 
 Symptoms that justify reading parse-failure evidence:
 
-* A goal's `consecutive_skip` or "no progress" counter climbs every cycle even though the dashboard says recent decisions succeeded.
-* `~/.simard/cycle_reports/cycle_*.json` shows `brain_judgments[].fallback == true` for `decide` or `orient` on consecutive cycles and the new `parse_failure` block on the same record is non-null. (Pre-#1890 cycles produced the same `fallback == true` shape but no `parse_failure` key — that's the discriminator. The deterministic-bootstrap path, which is legitimate, also omits `parse_failure`.)
+* A goal's `consecutive_skip` or "no progress" counter climbs every cycle
+  even though the dashboard says recent decisions succeeded.
+* `~/.simard/cycle_reports/cycle_*.json` shows `brain_judgments[].fallback == true`
+  for `decide` or `orient` on consecutive cycles and the new `parse_failure`
+  block on the same record is non-null.
 * The metric jsonl shows non-zero `brain_parse_failure` counters.
-* A GitHub issue titled `OODA decide brain parse failure: goal=<id> (N consecutive)` was auto-filed against the `ESCALATION_REPO_SLUG` repo.
+* A GitHub issue titled `OODA decide brain parse failure: goal=<id> (N consecutive)`
+  was auto-filed against the `ESCALATION_REPO_SLUG` repo.
 
 ### Tail the structured log
 
-The daemon writes to `~/.simard/logs/` on the host. Look for the constant `brain.decide parse failed` / `brain.orient parse failed` message strings — both are at `ERROR` level:
+The daemon writes to `~/.simard/logs/` on the host. Look for the constant
+`brain.decide parse failed` / `brain.orient parse failed` message strings —
+both are at `ERROR` level:
 
 ```bash
 tail -F ~/.simard/logs/rustyclawd.log \
@@ -46,7 +59,7 @@ A matching line looks like:
 ERROR simard::ooda_brain: brain.decide parse failed
     phase="decide"
     goal_id="improve-amplihack-test-coverage"
-    error="base type \"ooda-brain\" failed during invocation: no JSON object found in LLM response (got 3 bytes)"
+    error="no DECISION marker found in LLM response (got 3 bytes)"
     raw_response_truncated="OK"
     prompt_name="ooda_decide.md"
     prompt_version="a1b2c3d4e5f6"
@@ -54,11 +67,11 @@ ERROR simard::ooda_brain: brain.decide parse failed
     retry_attempted=false
 ```
 
-`raw_response_truncated` is the **complete** model response, truncated only at 8 KiB on a UTF-8 boundary (with a `…(truncated, total N bytes)` suffix if it overflowed). `prompt_name` and `prompt_version` together identify the exact prompt bytes the model saw — `cat $SIMARD_PROMPT_ASSETS_DIR/$prompt_name` recovers them. If you still see the legacy `WARN simard::ooda_brain: … no JSON object found in LLM response (got N bytes)` line **without** the `ERROR` companion, the daemon is running a pre-#1890 build; finish reading this guide and then run `simard safe-update` to pick up the fix.
+`raw_response_truncated` is the **complete** model response, truncated only
+at 8 KiB on a UTF-8 boundary. `prompt_name` and `prompt_version` identify
+the exact prompt bytes the model saw.
 
 ### Check the metric stream
-
-The `brain_parse_failure` counter lands in `~/.simard/metrics/metrics.jsonl` (single append-only file; not date-partitioned):
 
 ```bash
 jq -c 'select(.metric_name == "brain_parse_failure")
@@ -67,11 +80,7 @@ jq -c 'select(.metric_name == "brain_parse_failure")
   | tail -20
 ```
 
-Each event carries `metric_name`, `value`, `timestamp`, and a `context` field that is itself a JSON string encoding `{ phase, goal_id, retry_attempted, consecutive_count }`. The `|= fromjson` step in the jq filter unwraps the inner object so the dimensions are queryable. Use this stream for "rate of failures over the last hour" questions; use the log for "what exactly did the model say" questions.
-
 ### Read the cycle report
-
-Every parse-failed cycle now carries a populated `parse_failure` block on the corresponding `BrainJudgmentRecord`:
 
 ```bash
 jq '.brain_judgments[]
@@ -85,36 +94,27 @@ jq '.brain_judgments[]
    ~/.simard/cycle_reports/cycle_42.json
 ```
 
-Healthy cycles have `parse_failure == null` (the field is omitted via `skip_serializing_if`, so older `cycle_*.json` files are unaffected). To list every failed cycle in the report directory:
-
-```bash
-for f in ~/.simard/cycle_reports/cycle_*.json; do
-  if jq -e '[.brain_judgments[] | select(.parse_failure != null)] | length > 0' "$f" >/dev/null; then
-    echo "$f"
-  fi
-done
-```
-
 ## Step 2: Classify the response
 
-Open the `raw_response_truncated` value (from the log, the metric, or the cycle report — all three carry the same string) and match against this triage table.
+Open the `raw_response_truncated` value and match against this triage table.
 
-| `raw_response_truncated` looks like…                       | Likely cause                                                               | Action                                                                                                                       |
-|------------------------------------------------------------|----------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------|
-| `"OK"`, `"continue"`, `"yes"`                              | Model ignored the structured-output instruction; emitted a chat ack         | [Step 3 — replay the prompt](#step-3-replay-the-prompt-locally); then strengthen the prompt's role section.                  |
-| `""` (empty string)                                        | Adapter returned `Err` with no body (5xx, timeout, missing adapter)        | Check the adapter logs in `~/.simard/logs/rustyclawd.log` for a 5xx / rate-limit / timeout / "adapter unavailable" line immediately preceding the parse-failure event. `error_message` will name the underlying `SimardError` variant. |
-| Long prose without any `{` character                       | Model is in chat mode instead of structured-output mode                    | Check that the brain's adapter forces JSON mode for the configured provider.                                                 |
-| JSON that *looks* valid but parses with the same error     | Field rename or `choice` casing drift in the prompt                        | Diff `prompt_assets/simard/$prompt_name` (the value of the `prompt_name` field) against the brain's expected fields; the prompt is the contract. |
-| Markdown fence-wrapped JSON                                | The decide / orient parser is stricter than the engineer-lifecycle one     | Open a bug — the decide/orient parser is intended to tolerate fenced JSON the same way `parse_decision_from_response` does.   |
-| Partial JSON ending mid-object                             | Adapter truncated mid-stream                                               | Look for an `EOF` / `truncated stream` line in the adapter log; investigate the adapter, not the brain.                      |
+| `raw_response_truncated` looks like… | Likely cause | Action |
+|----|----|----|
+| `"OK"`, `"continue"`, `"yes"` | Model ignored the text-output instruction; emitted a chat ack | [Step 3 — replay the prompt](#step-3-replay-the-prompt-locally); strengthen the prompt's `OUTPUT_FORMAT` section |
+| `""` (empty string) | Adapter returned `Err` with no body (5xx, timeout) | Check adapter logs for 5xx / rate-limit / timeout |
+| Long prose without any `DECISION:` line or labeled fields | Model is in chat mode, not following the output format | Strengthen the `OUTPUT_FORMAT` section examples |
+| Text with a `DECISION:` line but unknown variant token | Variant token drift or prompt/code mismatch | Diff `prompt_assets/simard/$prompt_name` against the known variant list |
+| JSON object (legacy format) | Model following old JSON instructions from cached prompt | Update the prompt to use text format; the parser no longer accepts JSON |
+| Partial text ending mid-word | Adapter truncated mid-stream | Check adapter log for `EOF` / `truncated stream` |
 
-If `consecutive_count` is 1 or 2 and the next cycle's record shows `parse_failure == null`, the model recovered on its own and no action is required — the visibility channels exist so transient failures are *visible*, not *suppressed*.
+If `consecutive_count` is 1 or 2 and the next cycle shows `parse_failure == null`,
+the model recovered on its own. No action required.
 
-If `consecutive_count` reaches 3, the daemon has already auto-filed a GitHub issue (see Step 4); treat the failure as persistent.
+If `consecutive_count` reaches 3, the daemon has auto-filed a GitHub issue.
 
 ## Step 3: Replay the prompt locally
 
-There is no dedicated dry-run subcommand. To confirm a hypothesis without waiting for the next cycle, use the two crate-level helpers this PR exposes for exactly this purpose:
+Use the crate-level helpers to test parsing:
 
 ```rust
 pub fn try_parse_decide_response(raw: &str)
@@ -123,46 +123,20 @@ pub fn try_parse_orient_response(raw: &str)
     -> Result<OrientJudgment, SimardError>;
 ```
 
-Both helpers wrap the same parse path that `RustyClawdDecideBrain::run` / `RustyClawdOrientBrain::run` use internally. They are `pub(crate)` in the always-shipped build and re-exported `pub` under `#[cfg(any(test, feature = "ooda-brain-replay"))]`, so they're available to integration tests and ad-hoc replay binaries without widening the always-shipped public API.
+Add a one-off test:
 
-1. Copy `raw_response_truncated` from the cycle report (it round-trips through JSON, so newlines and quotes are already escaped — use `jq -r '.brain_judgments[].parse_failure.raw_response_truncated // empty'` to unescape).
-2. Add a one-off test to `src/ooda_brain/decide_tests.rs` (or `orient_tests.rs`):
+```rust
+#[test]
+fn repro_parse_failure() {
+    let raw = "OK"; // <-- paste unescaped payload here
+    let result = crate::ooda_brain::try_parse_decide_response(raw);
+    eprintln!("{result:?}");
+}
+```
 
-   ```rust
-   #[test]
-   fn repro_1890_OK_payload() {
-       let raw = "OK"; // <-- paste unescaped payload here
-       let result = crate::ooda_brain::try_parse_decide_response(raw);
-       eprintln!("{result:?}");
-   }
-   ```
-
-3. Run with `cargo test repro_1890_OK_payload -- --nocapture`.
-
-Discard the test before committing. The parsers have no I/O dependencies, so the replay is faithful — they read the same bytes you captured in the cycle report and return the same `SimardError` variant the call site saw in production.
-
-If you need to reproduce an *adapter*-class failure (where `raw_response_truncated == ""` because no body was returned), the replay helpers won't help — there is no body to parse. Investigate the adapter log directly; the `error_message` field of the `parse_failure` block names the underlying `SimardError` variant for cross-reference.
+Run with `cargo test repro_parse_failure -- --nocapture`. Discard before committing.
 
 ## Step 4: Read the auto-filed issue (if any)
-
-When `consecutive_count` reaches `ISSUE_ESCALATION_THRESHOLD` (currently 3), the daemon files a GitHub issue via:
-
-```
-gh issue create
-    --repo rysweet/Simard            # compile-time ESCALATION_REPO_SLUG
-    --title "OODA decide brain parse failure: goal=<id> (3 consecutive)"
-    --body-file <NamedTempFile>      # 0600 on Unix
-    --label ooda-brain-parse-failure
-    --label auto-filed
-```
-
-The body is a markdown document containing:
-
-* The full `ParseFailureRecord` as a fenced JSON block.
-* A pointer to the relevant `cycle_N.json` filenames.
-* A short hand-off paragraph noting the threshold and how to silence further escalations (resolve the upstream cause; the counter resets on the next successful parse).
-
-Find the issue:
 
 ```bash
 gh issue list --repo rysweet/Simard \
@@ -170,27 +144,21 @@ gh issue list --repo rysweet/Simard \
   --state open
 ```
 
-(Forks of this codebase that rebuilt with a different `ESCALATION_REPO_SLUG` constant in `parse_failure.rs` should substitute that slug above. The slug is **not** runtime-configurable — see the reference's [Configuration section](../reference/ooda-brain-parse-failure-record.md#configuration) for why.)
-
-The escalation is **throttled per `(phase, goal_id)`**: one issue per crossing of the threshold, not one per failure. If the same goal continues to fail past the threshold, the counter keeps climbing but no second issue is filed until a successful parse resets it and a fresh streak of three occurs.
-
 ## Step 5: Pick a remediation
 
-| Cause from Step 2                          | Remediation                                                                                                                |
-|--------------------------------------------|----------------------------------------------------------------------------------------------------------------------------|
-| Chat acknowledgment / wrong mode           | Edit `prompt_assets/simard/ooda_decide.md` (or `ooda_orient.md`) to strengthen the "respond ONLY with a JSON object" instruction. The `prompt_name` field of the failed `parse_failure` block names the exact file. See [edit-the-ooda-brain-prompt](edit-the-ooda-brain-prompt.md). |
-| Adapter 5xx / rate limit / timeout         | Investigate the adapter; the brain itself is healthy. The four channels exist precisely so you can attribute the failure.   |
-| Fence-wrapped JSON the parser rejected     | File a bug — the parser should match `parse_decision_from_response`'s leniency.                                              |
-| Drift in prompt vs. expected fields        | Diff the prompt against the `DecideJudgment` / `OrientJudgment` struct; the struct is the contract.                          |
-| Persistent unparseable noise from one model| Switch the provider in the brain config; the parser cannot fix a fundamentally non-cooperative model.                       |
+| Cause from Step 2 | Remediation |
+|----|----|
+| Chat ack / wrong mode | Edit the `OUTPUT_FORMAT` section of `prompt_assets/simard/ooda_decide.md` (or `ooda_orient.md`). Ensure it specifies `DECISION: <variant>` or labeled-line format, not JSON. See [edit-the-ooda-brain-prompt](edit-the-ooda-brain-prompt.md). |
+| Adapter 5xx / rate limit / timeout | Investigate the adapter; the brain itself is healthy. |
+| JSON output (legacy format) | The model is following outdated JSON instructions. Update the prompt to clearly specify text format. Remove any `OUTPUT_FORMAT` JSON schema examples. |
+| Variant token drift | Diff the prompt against the known variant list in the Rust parser. The variant whitelist is the enum itself — there is no parallel list. |
+| Persistent non-cooperative model | Switch the provider in the brain config. |
 
-After editing a prompt, **do not** restart the daemon by hand. The prompt-asset directory under `$HOME/.simard/prompt_assets/simard/` is mtime-watched (see [Reference: prompt-driven OODA brain](../concepts/prompt-driven-ooda-brain.md)) so a file edit takes effect on the next cycle — but if the cause was code rather than prompt, you must rebuild and hot-swap:
+After editing a prompt, rebuild and hot-swap:
 
 ```bash
 simard safe-update
 ```
-
-`safe-update` rebuilds, drains in-flight cycles, hot-swaps the binary, and verifies the new daemon is responsive — see [safe-self-update](../safe-self-update.md).
 
 ## Step 6: Verify the fix
 
@@ -203,33 +171,26 @@ tail -F ~/.simard/logs/rustyclawd.log \
 
 You should see:
 
-* The next decide or orient cycle for the affected goal produce a non-`fallback` decision with a substantive rationale (not the legitimate `"deterministic fallback"` sentinel that fires on the no-LLM bootstrap path).
-* The `brain_parse_failure` metric stop incrementing for `(phase, goal_id)`.
-* The next `cycle_N.json` for the goal omit the `parse_failure` key entirely (`skip_serializing_if` drops it when there is no failure).
-* The counter reset — confirm by waiting for the next failure (if any) and checking that `consecutive_count` starts at 1, not at the prior value.
-
-To close the auto-filed GitHub issue:
-
-```bash
-gh issue close <issue-number> --comment \
-  "Resolved by prompt fix in <commit>. Counter reset confirmed in cycle_<N>.json."
-```
+* The next decide or orient cycle produce a non-`fallback` decision with
+  substantive rationale.
+* The `brain_parse_failure` metric stop incrementing.
+* The next `cycle_N.json` omit the `parse_failure` key.
+* The counter reset to 1 on the next failure (if any).
 
 ## Anti-patterns
 
-The following patterns indicate the operator is **fighting** the visibility contract rather than diagnosing it. Stop and re-read the [Parse-Failure Record reference](../reference/ooda-brain-parse-failure-record.md) before proceeding:
-
-* **Restarting the daemon directly** (`kill <pid>`, `systemctl --user restart simard-ooda`) to "clear" parse failures. The counters are process-local but the cycle reports and metric jsonl are not; a bare restart loses the in-memory streak (potentially un-throttling the next `gh issue create`) but does **not** delete on-disk evidence. Always go through `simard safe-update` for any remediation that requires new code; for evidence-only investigation, do not restart at all.
-* **Suppressing the `ERROR` log line** with a `tracing` filter to "calm down" the dashboard. The line is the primary visibility channel; suppressing it returns to the pre-#1890 silent-fallback behavior with extra steps.
-* **Closing the auto-filed GitHub issue without fixing the cause.** The issue is throttled per streak; closing it does not reset the counter. If you close without fixing, the next failure beyond the threshold will not file a fresh issue until a successful parse intervenes — losing the very escalation the throttle was designed to provide.
-* **Adding a `match` arm to silently rerout a specific raw response** in `decide_with_brain` / `orient_with_brain`. The single fail-loud path is intentional; any per-raw-response branch is the silent fallback pattern returning under a new name.
-* **Removing `DeterministicFallbackDecideBrain` / `DeterministicFallbackOrientBrain` because "they look like silent fallback now."** They are the no-LLM bootstrap path; their use as silent error-swallow was what #1890 closed. Broader removal is the scope of [#1748](https://github.com/rysweet/Simard/issues/1748).
+* **Reverting to JSON output format in the prompt.** The parser no longer
+  accepts JSON. Adding JSON examples to the prompt will cause models to emit
+  JSON, which will be parse-rejected.
+* **Restarting the daemon directly** to "clear" parse failures. Use
+  `simard safe-update` for any code/prompt change.
+* **Suppressing the `ERROR` log line** with a tracing filter.
+* **Closing the auto-filed issue without fixing the cause.**
 
 ## See also
 
-* [Reference: OODA Brain Parse-Failure Record](../reference/ooda-brain-parse-failure-record.md) — schema, channels, and contracts.
-* [Reference: OODA Brain Decision Protocol](../reference/ooda-brain-decision-protocol.md) — engineer-lifecycle wire format (#1711).
-* [How-to: diagnose OODA brain decision parse failures](./diagnose-brain-decision-parse-failures.md) — engineer-lifecycle equivalent of this runbook.
-* [How-to: edit the OODA brain prompt](./edit-the-ooda-brain-prompt.md) — the canonical change surface for prompt fixes.
-* [Fail-Open Audit (P5 / #1245)](../fail-open-audit.md) — broader audit context.
-* [safe-self-update](../safe-self-update.md) — the only supported way to roll a daemon to new code.
+* [Reference: text-parsing wire formats](../reference/text-parsing-wire-formats.md) — normative grammar for all text protocols.
+* [Concept: text-based brain protocol](../concepts/text-based-brain-protocol.md) — design rationale.
+* [Reference: OODA Brain Decision Protocol](../reference/ooda-brain-decision-protocol.md) — engineer-lifecycle wire format.
+* [How-to: diagnose OODA brain decision parse failures](./diagnose-brain-decision-parse-failures.md) — engineer-lifecycle equivalent.
+* [How-to: edit the OODA brain prompt](./edit-the-ooda-brain-prompt.md) — prompt editing guide.

--- a/docs/howto/edit-the-ooda-brain-prompt.md
+++ b/docs/howto/edit-the-ooda-brain-prompt.md
@@ -16,17 +16,40 @@ This guide shows how to iterate on that behavior **without touching Rust**.
 
 ## Prompt Structure
 
-The prompt has five fixed sections. The brain parser only cares about
-**OUTPUT_FORMAT** (the JSON schema) and **OPTIONS** (which `choice` strings
-are legal). Edit the others freely.
+The prompt has five fixed sections. The brain parser looks for `DECISION:`
+marker lines (not JSON) — the `OUTPUT_FORMAT` section instructs the model
+to emit text-based responses.
 
 | Section | Purpose | Editable? |
 |---|---|---|
 | `# ROLE` | Identity & tone for the LLM | Yes |
 | `# CONTEXT` | Templated variables Simard substitutes per call | Yes (must keep `{{var}}` placeholders the brain populates — see below) |
-| `# OPTIONS` | The five `choice` values the brain may return | **Add/remove only with a Rust enum change**; renaming text guidance is fine |
-| `# OUTPUT_FORMAT` | JSON schema for the response | **Do not change shape**; only edit prose |
+| `# OPTIONS` | The six `choice` values the brain may return | **Add/remove only with a Rust enum change**; renaming text guidance is fine |
+| `# OUTPUT_FORMAT` | Text format for the response (`DECISION: <variant>`) | **Do not change the marker format**; only edit prose and examples |
 | `# EXAMPLES` | Few-shot input→output pairs | Yes — most useful knob for steering behavior |
+
+### Output format
+
+The brain expects responses in the `DECISION:` marker format:
+
+```
+DECISION: continue_skipping
+RATIONALE: engineer is making progress, worktree modified 30s ago
+```
+
+For structured variants, labeled fields follow the decision line:
+
+```
+DECISION: open_tracking_issue
+TITLE: Engineer stuck in compile-error loop
+BODY: The engineer has failed for 6 consecutive cycles with E0277 errors.
+RATIONALE: Persistent failure needs human attention.
+```
+
+**Do not** instruct the model to emit JSON. The parser does not accept JSON —
+it looks for `DECISION:` markers and labeled lines only. See
+[text-parsing wire formats § engineer lifecycle](../reference/text-parsing-wire-formats.md#1c-engineer-lifecycle-rustyclawdrs)
+for the full grammar.
 
 ### Available context variables
 
@@ -55,7 +78,10 @@ Lower the idle threshold in your few-shot examples:
 -CONTEXT: skips=12, failures=0, worktree_idle=25200s, ...
 +### Example: reclaim_and_redispatch
 +CONTEXT: skips=4, failures=0, worktree_idle=3600s, ...
- OUTPUT: {"choice": "reclaim_and_redispatch", ...}
+ OUTPUT:
+ DECISION: reclaim_and_redispatch
+ REDISPATCH_CONTEXT: Previous engineer was idle for too long. Try fresh approach.
+ RATIONALE: 4 skips with stale worktree suggests engineer is stuck.
 ```
 
 LLMs imitate examples more reliably than they follow prose rules. Move the
@@ -69,7 +95,10 @@ phrase you want to treat as a block signal:
 ```markdown
 ### Example: mark_goal_blocked (compile error loop)
 CONTEXT: skips=6, log_tail=...error[E0277]: the trait bound...
-OUTPUT: {"choice": "mark_goal_blocked", "rationale": "engineer is stuck in a type-error loop", "reason": "compile-error-loop"}
+OUTPUT:
+DECISION: mark_goal_blocked
+REASON: compile-error-loop
+RATIONALE: engineer is stuck in a type-error loop
 ```
 
 ### Tune the rationale style
@@ -92,20 +121,54 @@ prefixes (`engineer alive — continue (brain): …`, `reclaimed pid …`, etc.)
 
 ## Constraints
 
-* The LLM **must** return a JSON object that deserializes into
-  `EngineerLifecycleDecision`. The parser tolerates a preamble or trailing
-  prose (it slices from the first `{` to the last `}`), but malformed JSON
-  or unknown `choice` values cause the brain to log
-  `BrainResponseUnparseable` and fall back to `continue_skipping` for that
-  cycle.
+* The LLM **must** return a `DECISION: <variant>` marker line as the first
+  non-blank line. The parser scans for this marker and extracts the variant
+  token. Responses without a `DECISION:` line trigger
+  `BrainResponseUnparseable` and the brain falls back to
+  `continue_skipping` for that cycle. The JSON format is no longer accepted.
+* For structured variants (`open_tracking_issue`, `mark_goal_blocked`,
+  `reclaim_and_redispatch`), the model must emit labeled lines for the
+  required fields (`TITLE:`, `BODY:`, `REASON:`, `REDISPATCH_CONTEXT:`).
+  Missing required fields use default values.
 * If you remove all examples for a given variant, the LLM may stop emitting
   it. Keep at least one example per variant you want reachable.
 * The prompt file is loaded via `include_str!`; it must be valid UTF-8 and
   small enough to embed in the binary without bloat. Keep it under ~32 KB
   as a soft guideline.
 
+## Editing the decide and orient prompts
+
+The decide and orient brains have their own prompt files:
+
+- `prompt_assets/simard/ooda_decide.md` — action-kind routing
+- `prompt_assets/simard/ooda_orient.md` — failure-penalty demotion
+
+These use the same text-based output formats:
+
+**Decide** uses `DECISION: <variant>`:
+```
+DECISION: advance_goal
+RATIONALE: ordinary goal id with open PR, default routing
+```
+
+**Orient** uses labeled lines:
+```
+ADJUSTED_URGENCY: 0.60
+DEMOTION_APPLIED: 0.20
+RATIONALE: 1 failure: standard floor demotion
+CONFIDENCE: 0.9
+```
+
+Edit the `OUTPUT_FORMAT` and `EXAMPLES` sections of each prompt to steer
+behavior. Do not use JSON examples — the parser does not accept JSON.
+
+See [text-parsing wire formats](../reference/text-parsing-wire-formats.md)
+for the full grammar of each format.
+
 ## See Also
 
+* [Concept: text-based brain protocol](../concepts/text-based-brain-protocol.md)
 * [Concept: prompt-driven OODA brain](../concepts/prompt-driven-ooda-brain.md)
-* [Reference: `ooda_brain.md` prompt schema](../reference/ooda-brain-prompt.md)
+* [Reference: text-parsing wire formats](../reference/text-parsing-wire-formats.md)
 * [Reference: `OodaBrain` API](../reference/ooda-brain-api.md)
+* [Reference: `ooda_brain.md` prompt schema](../reference/ooda-brain-prompt.md)

--- a/docs/operations/progress-evidence-kill-switch.md
+++ b/docs/operations/progress-evidence-kill-switch.md
@@ -17,7 +17,7 @@ the API is documented in
 
 | Value | Behavior |
 |---|---|
-| Unset, or any value other than `off` (case-insensitive) | `OodaBridges.progress_evidence` is wired to `LlmReviewerProgressChecker`, which delegates to an LLM to verify that proposed progress claims are coherent with the goal's plan and WIP artifacts. |
+| Unset, or any value other than `off` (case-insensitive) | `OodaBridges.progress_evidence` is wired to `RecipeProgressChecker`, which invokes a recipe-based LLM agent to verify that proposed progress claims are coherent with the goal's plan and WIP artifacts. |
 | `off` (case-insensitive) | `OodaBridges.progress_evidence` is wired to `NoopProgressEvidenceChecker`. Every progress claim is accepted. **No `"goal progress accepted:"` or `"brain hallucination detected:"` audit episodes are emitted.** |
 
 The variable is read once, at daemon startup, in the bridge-construction
@@ -119,7 +119,7 @@ The daemon logs the active checker at boot. The format is pinned by
 are stable; the parenthetical detail may evolve.
 
 ```
-[simard] progress-evidence: enabled (LlmReviewerProgressChecker)
+[simard] progress-evidence: enabled (RecipeProgressChecker)
 ```
 
 Or:
@@ -175,7 +175,7 @@ The kill switch is still useful for:
 
 When the underlying issue is resolved, remove the environment variable
 and restart the daemon. Confirm via the boot log line above that
-`LlmReviewerProgressChecker` is active. The next cycle that involves
+`RecipeProgressChecker` is active. The next cycle that involves
 a progress claim should produce either an `Accept` or a `Reject` audit
 episode in cognitive memory.
 

--- a/docs/reference/disk-health-api.md
+++ b/docs/reference/disk-health-api.md
@@ -30,7 +30,7 @@ a deterministic bash step — no LLM required.
 ## Module Layout
 
 ```
-src/disk_health.rs                           Rust shim (subprocess invocation, JSON parsing)
+src/disk_health.rs                           Rust shim (subprocess invocation, text parsing)
 prompt_assets/simard/recipes/disk-health-check.yaml   Recipe (bash cleanup script)
 ```
 
@@ -39,8 +39,8 @@ prompt_assets/simard/recipes/disk-health-check.yaml   Recipe (bash cleanup scrip
 ### `DiskHealthReport`
 
 ```rust
-/// JSON-deserializable report emitted by the disk-health-check recipe.
-#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+/// Report parsed from key=value lines emitted by the disk-health-check recipe.
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct DiskHealthReport {
     /// Current disk usage percentage after any cleanup (0–100).
     pub disk_used_pct: u64,
@@ -51,8 +51,11 @@ pub struct DiskHealthReport {
 }
 ```
 
-The report is emitted as a single JSON object on stdout by the recipe's bash
-step. The Rust shim deserializes it from the subprocess output.
+The report is parsed from key=value lines on stdout by the recipe's bash
+step. The Rust shim uses `parse_disk_health_text()` to extract fields from
+the text output — no JSON parsing. See
+[text-parsing wire formats](./text-parsing-wire-formats.md#protocol-3-keyvalue-disk-health)
+for the full grammar.
 
 ### `run_disk_health_check`
 
@@ -61,7 +64,7 @@ step. The Rust shim deserializes it from the subprocess output.
 ///
 /// Resolves the recipe YAML relative to `repo_root`, invokes it via
 /// `recipe-runner-rs` as a subprocess, captures stdout, and parses the
-/// JSON report.
+/// key=value text output.
 ///
 /// # Arguments
 ///
@@ -77,7 +80,11 @@ step. The Rust shim deserializes it from the subprocess output.
 /// - The recipe YAML does not exist at the expected path
 /// - `recipe-runner-rs` is not found on `$PATH`
 /// - The subprocess exits non-zero
-/// - stdout does not contain valid JSON matching `DiskHealthReport`
+///
+/// Note: missing or malformed key=value lines do **not** cause an error.
+/// `parse_disk_health_text` defaults to `disk_used_pct=0`, `freed_bytes=0`,
+/// `actions_taken=[]` for any missing fields. This is intentional — a
+/// recipe that outputs only `DISK_USED_PCT=65` (no cleanup needed) is valid.
 ///
 /// # Example
 ///
@@ -95,6 +102,21 @@ pub fn run_disk_health_check(
     repo_root: &Path,
     state_root: &Path,
 ) -> Result<DiskHealthReport, SimardError>;
+```
+
+### `parse_disk_health_text`
+
+```rust
+/// Parse key=value lines from recipe stdout into a DiskHealthReport.
+///
+/// Scans each line for:
+/// - `DISK_USED_PCT=<u64>` — disk usage percentage
+/// - `FREED_BYTES=<u64>` — bytes freed during cleanup
+/// - `ACTION: <text>` — human-readable cleanup action (collected into Vec)
+///
+/// Lines that don't match any pattern are silently ignored (forward compatible).
+/// Missing fields default to zero/empty.
+fn parse_disk_health_text(stdout: &str) -> DiskHealthReport;
 ```
 
 ### `resolve_recipe_path` (internal)
@@ -118,7 +140,11 @@ Resolution order (matches `recipe_merge_judge.rs` and
 
 ## Recipe YAML — `disk-health-check.yaml`
 
-The recipe is a single bash step that receives two context variables:
+The recipe is a single bash step. Its stdout uses the key=value text format
+(not JSON). See [text-parsing wire formats § key=value](./text-parsing-wire-formats.md#protocol-3-keyvalue-disk-health)
+for the normative grammar.
+
+The recipe receives two context variables:
 
 | Variable     | Source              | Description                                              |
 | ------------ | ------------------- | -------------------------------------------------------- |
@@ -155,32 +181,30 @@ When disk usage exceeds 80%, the recipe performs these actions sequentially:
    `$STATE_ROOT/shared-target/` contents. These are shared incremental build
    caches that Cargo rebuilds on demand.
 
-### JSON output contract
+### Text output contract
 
-The bash step prints exactly one JSON object to stdout:
+The bash step prints key=value lines to stdout:
 
-```json
-{
-  "disk_used_pct": 72,
-  "freed_bytes": 53687091200,
-  "actions_taken": [
-    "Removed 48 stale worktrees (50.1G)",
-    "Removed cargo target dirs from 3 worktrees (1.2G)",
-    "Pruned 19 LadybugDB backups (512M)",
-    "Cleaned cargo-target/ (12.0G) and shared-target/ (2.8G)"
-  ]
-}
+```
+DISK_USED_PCT=72
+FREED_BYTES=53687091200
+ACTION: Removed 48 stale worktrees (50.1G)
+ACTION: Removed cargo target dirs from 3 worktrees (1.2G)
+ACTION: Pruned 19 LadybugDB backups (512M)
+ACTION: Cleaned cargo-target/ (12.0G) and shared-target/ (2.8G)
 ```
 
 When disk usage is below 80%, the report reflects no cleanup:
 
-```json
-{
-  "disk_used_pct": 65,
-  "freed_bytes": 0,
-  "actions_taken": []
-}
 ```
+DISK_USED_PCT=65
+FREED_BYTES=0
+```
+
+This format is natural to produce from bash (`echo "KEY=${VALUE}"`) and
+eliminates the JSON `printf` quoting fragility of the prior implementation.
+Filenames with special characters in action descriptions are safe — they are
+just text after `ACTION:`.
 
 ### Security constraints
 
@@ -255,7 +279,6 @@ All errors surface as `SimardError::AdapterInvocationFailed`:
 | Recipe YAML not found            | `"disk-health"`      | `"recipe not found at <path>"`             |
 | `recipe-runner-rs` not on PATH   | `"disk-health"`      | `"recipe-runner-rs not found"`             |
 | Subprocess non-zero exit         | `"disk-health"`      | `"recipe exited with status <code>: <stderr>"` |
-| JSON parse failure               | `"disk-health"`      | `"failed to parse report: <serde error>"`  |
 
 Per daemon convention, these errors are logged and the cycle continues. The
 disk health check never crashes the daemon.
@@ -314,15 +337,25 @@ mod tests {
     fn resolve_recipe_path_returns_none_for_missing_repo() { /* ... */ }
 
     #[test]
-    fn report_deserializes_from_json() { /* ... */ }
+    fn parse_disk_health_text_full_output() { /* ... */ }
+
+    #[test]
+    fn parse_disk_health_text_no_cleanup() { /* ... */ }
+
+    #[test]
+    fn parse_disk_health_text_malformed_lines_ignored() { /* ... */ }
 }
 ```
 
 - `resolve_recipe_path_returns_none_for_missing_repo` — verifies that
   `resolve_recipe_path` returns `None` when pointed at a temp dir without
   the recipe YAML.
-- `report_deserializes_from_json` — round-trips a `DiskHealthReport`
-  through serde to confirm the JSON contract.
+- `parse_disk_health_text_full_output` — parses a complete key=value output
+  with `DISK_USED_PCT`, `FREED_BYTES`, and multiple `ACTION:` lines.
+- `parse_disk_health_text_no_cleanup` — parses output with only
+  `DISK_USED_PCT` and `FREED_BYTES=0` (no `ACTION:` lines).
+- `parse_disk_health_text_malformed_lines_ignored` — verifies that non-matching
+  lines (debug output, warnings) are silently ignored.
 
 No integration tests spawn `recipe-runner-rs` — the recipe is a bash script
 tested by the daemon's existing smoke-test cycle.

--- a/docs/reference/meeting-handoff-schema.md
+++ b/docs/reference/meeting-handoff-schema.md
@@ -1,0 +1,114 @@
+# Meeting Handoff Schema
+
+> Reference for the `MeetingHandoff` JSON artifact produced when a meeting
+> closes. Consumer code lives in `src/meeting_facilitator/handoff/mod.rs`.
+
+## Schema versions
+
+| Version | Introduced | Description |
+|---------|-----------|-------------|
+| v1 | Initial | Original schema — no `schema_version` field. Consumers use `#[serde(default)]` to fill missing fields. |
+| v2 | #1987 | Added `schema_version`, `goal`, `next_actor`, `applied_templates`, `history_truncated_count`, `partial_reason`. All new fields use `#[serde(default)]` so v1 files deserialize unchanged. |
+
+## v2 fields
+
+### `schema_version: u32`
+
+Schema version tag. Written as `2` on all new handoffs. Missing from v1
+files — deserialization defaults to `1` via
+`#[serde(default = "default_handoff_schema_version_v1")]`.
+
+### `goal: Option<String>`
+
+The meeting's overarching objective, distinct from the short `topic`.
+Set at the REPL via `/goal <text>`. Falls back to the first user message
+if unset by the operator. `None` in v1 handoffs.
+
+### `next_actor: Option<NextActor>`
+
+Structured routing hint for which actor should consume the handoff next.
+Complements the free-form `next_owner` string.
+
+```rust
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum NextActor {
+    Operator,
+    Engineer,
+    OodaCurate,
+    External,
+}
+```
+
+**JSON example:**
+
+```json
+"next_actor": { "kind": "engineer" }
+```
+
+`None` when no routing preference was set. v1 handoffs deserialize as
+`None`.
+
+### `applied_templates: Vec<AppliedTemplate>`
+
+Templates applied during the meeting via `/template <name>`. Already
+present on `MeetingSummary`; promoted to the handoff so downstream
+consumers see them without parsing the bundle.
+
+Each entry carries:
+- `name: String` — template name (e.g. `"standup"`, `"retro"`)
+- `agenda: String` — full agenda markdown
+- `applied_at: String` — RFC 3339 timestamp
+
+Empty `[]` in v1 handoffs.
+
+### `history_truncated_count: usize`
+
+Number of conversation messages dropped because the backend hit the
+`MAX_HISTORY` cap (currently 500). Lets downstream consumers gauge
+transcript completeness. `0` in v1 handoffs.
+
+### `partial_reason: Option<String>`
+
+Wire-string form of `PartialReason` from the close pipeline. Populated
+when the close was partial (e.g. `"summary_timeout"`,
+`"close_timeout"`, `"persistence_error"`). `None` for a clean close and
+for v1 handoffs.
+
+Valid wire strings (see `src/meeting_backend/close_guard.rs`):
+- `close_timeout`
+- `agent_close_timeout`
+- `summary_timeout`
+- `summary_empty`
+- `bridge_timeout`
+- `persistence_error`
+
+## Backward compatibility
+
+All v2 fields use `#[serde(default)]`, so:
+
+1. **v1 → v2 read**: Older JSON files missing the new fields deserialize
+   cleanly with default values (`schema_version=1`, others empty/`None`/`0`).
+2. **v2 → v1 consumer**: Consumers that don't know about the new fields
+   ignore them (serde's default behaviour for unknown fields).
+3. **No migration tool needed** — `#[serde(default)]` *is* the migration.
+
+## Deprecation timeline
+
+v1 handoffs will continue to deserialize indefinitely. A future issue may
+add a `MeetingHandoff::v1_to_v2()` in-place upgrader if batch migration
+becomes desirable, but it is not required.
+
+## REPL commands
+
+| Command | Field | Description |
+|---------|-------|-------------|
+| `/goal <text>` | `goal` | Set the meeting's overarching objective |
+| `/owner <name>` | `next_owner` | Name the next agent/persona/human expected to action this handoff |
+
+## Related issues
+
+- #1982 — parent epic (enhance meeting experience)
+- #1987 — this schema bump
+- #1985 — bundle consumption (depends on v2 schema)
+- #1984 — resume support (independent)
+- #1951 — sub-issues 3, 6, 7 (coordinated via this schema bump)

--- a/docs/reference/ooda-brain-api.md
+++ b/docs/reference/ooda-brain-api.md
@@ -57,7 +57,7 @@ propagate errors.
 ## Decision
 
 ```rust
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+#[derive(serde::Serialize, Debug, Clone)]
 #[serde(tag = "choice", rename_all = "snake_case")]
 pub enum EngineerLifecycleDecision {
     ContinueSkipping {
@@ -89,13 +89,10 @@ The enum has **6 variants**. `ConsiderSelfUpdate` is dispatched by
 `apply_lifecycle_decision` to the `simard safe-update` path; it is the only
 variant that can mutate the running daemon binary.
 
-Forward-compatible:
-
-* New optional fields use `#[serde(default)]` so older payloads that omit them
-  still parse.
-* Unknown extra fields are ignored (serde's default; `deny_unknown_fields`
-  is intentionally **not** set).
-* Unknown `choice` values fail parsing and trigger the safe fallback (skip).
+`Deserialize` is no longer derived — the enum is never deserialized from
+JSON. It is constructed from text-parsed fields via the DECISION marker
+protocol (see [text-parsing wire formats § engineer lifecycle](../reference/text-parsing-wire-formats.md#1c-engineer-lifecycle-rustyclawdrs)).
+`Serialize` is retained for logging and state persistence.
 
 ## Implementations
 
@@ -104,7 +101,13 @@ Forward-compatible:
 Production brain. Loads the prompt via
 `include_str!("../../prompt_assets/simard/ooda_brain.md")`, substitutes
 `{{var}}` placeholders from the context, submits to an `LlmSubmitter`, and
-parses the JSON response.
+parses the text response using the DECISION marker protocol.
+
+The parser finds the first `DECISION: <variant>` line, extracts labeled
+fields for structured variants, and collects remaining lines as rationale.
+There is no JSON fallback — the DECISION marker is the sole parser. See
+[text-parsing wire formats § engineer lifecycle](../reference/text-parsing-wire-formats.md#1c-engineer-lifecycle-rustyclawdrs)
+for the full grammar.
 
 ```rust
 pub struct RustyClawdBrain<S: LlmSubmitter> {
@@ -151,7 +154,7 @@ pub(crate) trait LlmSubmitter: Send + Sync {
 ```
 
 Production: `RustyClawdSubmitter` (wraps `RustyClawdAdapter`).
-Tests: `StubSubmitter { canned: String }` returns a fixed JSON string. This is
+Tests: `StubSubmitter { canned: String }` returns a fixed text response. This is
 the seam used by all hermetic unit tests for the brain.
 
 ## Errors
@@ -168,10 +171,9 @@ SimardError::BrainResponseUnparseable {
     source: BrainParseSource,
 }
 
-/// Wraps the underlying cause so a single error variant can carry either a
-/// JSON-decode failure (legacy path) or a marker-grammar failure (new path).
+/// Wraps the underlying cause — marker-grammar failure only.
+/// The legacy `Json(serde_json::Error)` variant was removed in #1980.
 pub enum BrainParseSource {
-    Json(serde_json::Error),
     Marker(MarkerParseError),
 }
 ```

--- a/docs/reference/ooda-brain-decision-protocol.md
+++ b/docs/reference/ooda-brain-decision-protocol.md
@@ -8,12 +8,14 @@ accepts from an LLM when emitting an `EngineerLifecycleDecision`. It replaces
 the legacy "must reply with a single JSON object, no prose, no fences" rule
 that previously lived in [`ooda-brain-prompt.md`](ooda-brain-prompt.md).
 
-> **TL;DR** — Models now emit a leading `DECISION: <variant>` marker line.
+> **TL;DR** — Models emit a leading `DECISION: <variant>` marker line.
 > Variants that need structured fields (`open_tracking_issue`,
-> `mark_goal_blocked`, `reclaim_and_redispatch`) follow the marker with a JSON
-> object. Pure-JSON responses (the legacy format) still parse — backward
-> compatible. Parse failures embed the **full raw response** in the error so
-> operators can diagnose 3-byte `"OK"` responses instead of guessing.
+> `mark_goal_blocked`, `reclaim_and_redispatch`) follow the marker with
+> labeled lines (`TITLE:`, `BODY:`, `REASON:`, `REDISPATCH_CONTEXT:`).
+> The legacy JSON path and hybrid prose-plus-JSON form from #1711 have
+> been removed in #1980. Parse failures embed the **full raw response**
+> in the error so operators can diagnose 3-byte `"OK"` responses instead
+> of guessing.
 
 ## Why a new protocol
 
@@ -40,22 +42,22 @@ the companion `goal_action` path already took (see journal entries tagged
 
 ## The wire format
 
-A response is **valid** if any one of the following is true:
+A response is **valid** if:
 
-1. **Prose marker form** — the first non-blank line matches the regex
+1. **Text marker form** — the first non-blank line matches the regex
    `^\s*DECISION\s*:\s*<variant_token>\s*$` (case-insensitive on the literal
    word `DECISION`; `<variant_token>` is matched exact-snake-case against the
-   `EngineerLifecycleDecision` whitelist).
-2. **Hybrid form** — the prose marker (rule 1) is followed by a JSON object
-   on subsequent lines that supplies any variant-specific fields.
-3. **Legacy JSON form** — the entire response (after trimming) parses as a
-   single JSON object whose `choice` field names a known variant. Code-fence
-   wrappers (```` ```json ... ``` ````) and surrounding prose are tolerated,
-   matching the pre-#1711 behavior.
+   `EngineerLifecycleDecision` whitelist). Remaining lines are scanned for
+   labeled fields and rationale text.
 
-If none of the three apply, the parser returns
+If the marker is not found, the parser returns
 `SimardError::BrainResponseUnparseable { raw, source }` with the **full raw
 response text** embedded.
+
+> **Removed in [#1980](https://github.com/rysweet/Simard/issues/1980):**
+> The hybrid form (marker + JSON body) and legacy JSON form
+> (`find('{')..rfind('}')` extraction) have been removed. The DECISION
+> marker with labeled lines is the sole accepted format.
 
 ### Variant whitelist
 
@@ -72,15 +74,15 @@ hand-maintained parallel list. The current 6 variants are:
 | `consider_self_update`   | _(none)_                                            |
 
 `rationale` is required by every variant but defaults to a placeholder
-(`"<no rationale provided>"`) when the marker form is used without a JSON
-follow-up. The handler in
+(`"<no rationale provided>"`) when no `RATIONALE:` label or free-form text
+follows the marker. The handler in
 `src/ooda_actions/advance_goal/lifecycle.rs::apply_lifecycle_decision` does
 not differentiate between a model-supplied rationale and the placeholder.
 
 ### Marker grammar
 
 ```
-<response>      ::= <marker-line> ("\n" <body>)? | <legacy-json>
+<response>      ::= <marker-line> ("\n" <body>)?
 <marker-line>   ::= <ws>* "DECISION" <ws>* ":" <ws>* <variant-token> <ws>*
 <variant-token> ::= "continue_skipping"
                   | "reclaim_and_redispatch"
@@ -88,24 +90,32 @@ not differentiate between a model-supplied rationale and the placeholder.
                   | "open_tracking_issue"
                   | "mark_goal_blocked"
                   | "consider_self_update"
-<body>          ::= <free-prose>? (<json-object> <free-prose>?)?
+<body>          ::= *(labeled-line / rationale-line)
+<labeled-line>  ::= label-token <ws>* ":" <ws>* value LF
+<rationale-line>::= <any line not matching labeled-line> LF
 ```
 
 The marker is matched **only on the first non-blank line of the response**.
 A `DECISION:` token that appears mid-response or inside JSON is ignored.
 This is a deliberate hardening choice (see [Security](#security) below).
 
-### Marker-wins precedence
+### Labeled-line field extraction
 
-If both a prose marker **and** a JSON `choice` field are present and they
-disagree (`DECISION: continue_skipping` followed by
-`{"choice": "deprioritize", ...}`), the **marker wins**. The JSON object is
-then re-parsed with its `choice` field overwritten so that field harvesting
-still succeeds.
+After the DECISION marker, remaining lines are scanned for labeled fields:
 
-This rule exists so that a downstream prompt rewrite that drops the JSON
-discriminator never silently changes the dispatch path; the marker is the
-authoritative signal.
+- `RATIONALE:` — all variants
+- `TITLE:` — `open_tracking_issue`
+- `BODY:` — `open_tracking_issue`
+- `REASON:` — `mark_goal_blocked`
+- `REDISPATCH_CONTEXT:` — `reclaim_and_redispatch`
+
+Labels are matched case-insensitively. Unknown labels are ignored (forward
+compatible). Non-labeled lines are collected as the fallback rationale if no
+`RATIONALE:` label is present.
+
+> **Removed in #1980:** The marker-wins precedence rule (where a JSON `choice`
+> field was overwritten by the DECISION marker) no longer applies — there is
+> no JSON body to conflict with.
 
 ## Behavior matrix
 
@@ -118,16 +128,16 @@ by a test in `src/ooda_brain/tests.rs`.
 | 2 | `DECISION: continue_skipping\nengineer made progress 12s ago`             | `Ok(ContinueSkipping { rationale: "engineer made progress 12s ago" })`                  |
 | 3 | `decision: CONTINUE_SKIPPING` (case variations on `DECISION`)             | `Ok(ContinueSkipping { ... })` — case-insensitive on the keyword                        |
 | 4 | `DECISION: CONTINUE_SKIPPING` (uppercase variant)                         | `Err(BrainResponseUnparseable)` — variant matched exact-snake-case only                 |
-| 5 | `DECISION: open_tracking_issue\n{"title":"X","body":"Y","rationale":"Z"}` | `Ok(OpenTrackingIssue { title: "X", body: "Y", rationale: "Z" })`                       |
-| 6 | `DECISION: open_tracking_issue\nrationale only, no JSON`                  | `Err(BrainResponseUnparseable)` — required `title`/`body` missing                       |
-| 7 | ` ```json\n{"choice":"continue_skipping","rationale":"x"}\n``` `          | `Ok(ContinueSkipping { rationale: "x" })` — code fences stripped                        |
-| 8 | `Some prose\n{"choice":"reclaim_and_redispatch",...}\nMore prose`         | `Ok(ReclaimAndRedispatch { ... })` — JSON object extraction (legacy path)               |
-| 9 | `{"choice":"continue_skipping","rationale":"x"}` (pure JSON)              | `Ok(ContinueSkipping { rationale: "x" })` — legacy path                                 |
-| 10| `OK` (3-byte non-JSON, no marker) — **the #1711 bug**                     | `Err(BrainResponseUnparseable { raw: "OK", source })` — full text in error              |
+| 5 | `DECISION: open_tracking_issue\nTITLE: X\nBODY: Y\nRATIONALE: Z`         | `Ok(OpenTrackingIssue { title: "X", body: "Y", rationale: "Z" })`                       |
+| 6 | `DECISION: open_tracking_issue\nrationale only, no labeled fields`        | `Ok(OpenTrackingIssue { title: "", body: "", rationale: "rationale only, ..." })` — missing fields get defaults |
+| 7 | `` ```json\n{"choice":"continue_skipping","rationale":"x"}\n``` ``         | `Err(BrainResponseUnparseable)` — JSON no longer accepted (removed in #1980)            |
+| 8 | `Some prose\n{"choice":"reclaim_and_redispatch",...}\nMore prose`         | `Err(BrainResponseUnparseable)` — JSON extraction path removed in #1980                 |
+| 9 | `{"choice":"continue_skipping","rationale":"x"}` (pure JSON)              | `Err(BrainResponseUnparseable)` — JSON no longer accepted (removed in #1980)            |
+| 10| `OK` (3-byte non-JSON, no marker)                                         | `Err(BrainResponseUnparseable { raw: "OK", source })` — full text in error              |
 | 11| `` (empty)                                                                | `Err(BrainResponseUnparseable { raw: "", source })` — note "empty response"             |
 | 12| `DECISION: bogus_variant`                                                 | `Err(BrainResponseUnparseable)` — error lists all 6 valid tokens                        |
 | 13| `random prose ... DECISION: deprioritize ... more prose`                  | `Err(BrainResponseUnparseable)` — marker not on first non-blank line, ignored           |
-| 14| `DECISION: continue_skipping` (with `{"choice":"deprioritize",...}` body) | `Ok(ContinueSkipping { ... })` — marker wins; JSON `choice` overwritten                 |
+| 14| `DECISION: reclaim_and_redispatch\nREDISPATCH_CONTEXT: Try Y.`           | `Ok(ReclaimAndRedispatch { redispatch_context: "Try Y.", ... })`                        |
 | 15| `DECISION: 🚀continue_skipping` (multibyte garbage prefix on token)       | `Err(BrainResponseUnparseable)` — UTF-8-safe slicing, no panic                          |
 
 ## Error format
@@ -143,12 +153,14 @@ SimardError::BrainResponseUnparseable {
     source: BrainParseSource,
 }
 
-/// Single wrapper so one error variant can carry either failure mode.
+/// Single wrapper so one error variant can carry the failure mode.
 pub enum BrainParseSource {
-    Json(serde_json::Error),
     Marker(MarkerParseError),
 }
 ```
+
+> **Removed in #1980:** The `BrainParseSource::Json` variant has been removed
+> — there is no JSON parser to fail.
 
 ### `raw` lifecycle
 
@@ -197,10 +209,12 @@ WARN simard::ooda_brain: brain.decide_engineer_lifecycle failed; falling
 * The fallback to `ContinueSkipping` in `dispatch_spawn_engineer` on a
   parser error is preserved — the parser is now strictly more lenient, so
   fewer cycles take that fallback, but the safety net itself is unchanged.
-* `decide.rs` and `orient.rs` were **not** migrated to prose-first parsing.
-  They received only the one-line raw-response-in-error fix because they
-  share the same logging anti-pattern. Migrating their parsers is tracked
-  separately and is explicitly out of scope for #1711.
+
+> **Updated in #1980:** `decide.rs` and `orient.rs` have been migrated to
+> text-based parsing (DECISION markers and labeled lines respectively). Their
+> JSON parsers have been removed. See
+> [text-parsing wire formats](text-parsing-wire-formats.md) for the full
+> grammar of all three OODA brain parse sites.
 
 ## Examples
 
@@ -221,18 +235,16 @@ EngineerLifecycleDecision::ContinueSkipping {
 }
 ```
 
-### Hybrid: `open_tracking_issue`
+### Structured: `open_tracking_issue`
 
 Model output:
 
-````
+```
 DECISION: open_tracking_issue
-{
-  "rationale": "engineer panic recurred across 3 spawns",
-  "title": "Engineer panics on goal improve-amplihack-test-coverage",
-  "body": "Repro: spawn engineer, wait 30s, observe panic in tail.\nLog tail:\n```\nthread 'main' panicked at ...\n```"
-}
-````
+TITLE: Engineer panics on goal improve-amplihack-test-coverage
+BODY: Repro: spawn engineer, wait 30s, observe panic in tail. Log tail shows thread 'main' panicked at ...
+RATIONALE: engineer panic recurred across 3 spawns
+```
 
 Parsed as:
 
@@ -244,16 +256,14 @@ EngineerLifecycleDecision::OpenTrackingIssue {
 }
 ```
 
-### Legacy JSON (still works)
+### Structured: `reclaim_and_redispatch`
 
 Model output:
 
-```json
-{
-  "choice": "reclaim_and_redispatch",
-  "rationale": "worktree idle 7h, no log activity",
-  "redispatch_context": "Previous engineer attempted X; please retry with Y."
-}
+```
+DECISION: reclaim_and_redispatch
+REDISPATCH_CONTEXT: Previous engineer attempted X; please retry with Y.
+RATIONALE: worktree idle 7h, no log activity
 ```
 
 Parsed as:
@@ -265,18 +275,9 @@ EngineerLifecycleDecision::ReclaimAndRedispatch {
 }
 ```
 
-### Marker-wins on conflict
-
-Model output:
-
-```
-DECISION: continue_skipping
-{"choice": "deprioritize", "rationale": "ignore me"}
-```
-
-Parsed as `ContinueSkipping { rationale: "ignore me" }`. The marker took
-precedence; the JSON `rationale` field was harvested; the JSON `choice` was
-overwritten by the marker.
+> **Removed in #1980:** The "Hybrid" (marker + JSON body) and "Legacy JSON"
+> examples from the #1711 version of this document have been removed — those
+> parse paths no longer exist.
 
 ## Security
 
@@ -287,7 +288,7 @@ detail under Security Considerations in the PR.
 | ID    | Threat                                                  | Mitigation                                                                                |
 |-------|---------------------------------------------------------|-------------------------------------------------------------------------------------------|
 | SR-1  | Mid-response `DECISION:` token injection                | Marker is matched **only on the first non-blank line** (test T13).                        |
-| SR-2  | Variant smuggling via diverging marker / JSON `choice`  | Marker wins on conflict; JSON `choice` is overwritten before harvest (test T14).          |
+| SR-2  | ~~Variant smuggling via diverging marker / JSON `choice`~~ | Removed in #1980 — no JSON path to conflict with. Marker is sole authority.             |
 | SR-3  | UTF-8 boundary panic on malformed model output          | All slicing uses `char_indices()` / `str::get()`; no raw byte indexing (test T15).        |
 | SR-4  | Log-flood DoS from a runaway 1 GB model response        | `truncate_for_log` caps raw text at `MAX_RAW_LOG_BYTES = 8192` at format time.            |
 | SR-5  | Log injection via CRLF / ANSI escapes in raw response   | All `raw` fields rendered via the `{:?}` Debug format, which escapes control chars.       |
@@ -301,20 +302,24 @@ rate-limit responses — those concerns live one layer up at the
 
 | Caller                                          | Affected?                                                     |
 |-------------------------------------------------|---------------------------------------------------------------|
-| `RustyClawdBrain::decide_engineer_lifecycle`    | Yes — uses the new parser.                                    |
+| `RustyClawdBrain::decide_engineer_lifecycle`    | Yes — uses text-only parser (JSON removed in #1980).          |
 | `DeterministicFallbackBrain`                    | No — bypasses the parser entirely.                            |
-| Any test using `StubSubmitter` with pure-JSON   | No — legacy path is preserved.                                |
-| `decide::parse_judgment_from_response`          | Error format only (raw text now embedded); shape unchanged.   |
-| `orient::parse_judgment_from_response`          | Error format only (raw text now embedded); shape unchanged.   |
-| `ooda_brain.md` prompt                          | Updated to recommend the marker form; legacy JSON documented. |
+| Any test using `StubSubmitter` with pure-JSON   | **Yes** — must be updated to use DECISION marker format.      |
+| `decide::parse_judgment_from_response`          | Yes — migrated to text parser in #1980.                       |
+| `orient::parse_judgment_from_response`          | Yes — migrated to text parser in #1980.                       |
+| `ooda_brain.md` prompt                          | Updated to specify DECISION marker format; JSON removed.      |
 
 A model that is still emitting pure JSON because its prompt has not been
-re-deployed will continue to work without change.
+re-deployed will **fail parsing**. The prompt must be updated to use the
+DECISION marker format.
 
 ## See Also
 
+* [Concept: text-based brain protocol](../concepts/text-based-brain-protocol.md)
+* [Reference: text-parsing wire formats](text-parsing-wire-formats.md)
 * [Reference: `OodaBrain` API](ooda-brain-api.md)
 * [Reference: `ooda_brain.md` Prompt Schema](ooda-brain-prompt.md)
 * [How-to: diagnose brain decision parse failures](../howto/diagnose-brain-decision-parse-failures.md)
 * [How-to: edit the OODA brain prompt](../howto/edit-the-ooda-brain-prompt.md)
 * [Issue #1711 — fall back to prose-first decision protocol](https://github.com/rysweet/Simard/issues/1711)
+* [Issue #1980 — root out JSON-parsing LLM output anti-pattern](https://github.com/rysweet/Simard/issues/1980)

--- a/docs/reference/ooda-brain-prompt.md
+++ b/docs/reference/ooda-brain-prompt.md
@@ -23,12 +23,14 @@ order:
 …
 
 # OUTPUT_FORMAT
-…(JSON schema)…
+…(text format: DECISION marker and labeled lines)…
 
 # EXAMPLES
 ### Example: continue_skipping
 CONTEXT: …
-OUTPUT: {…}
+OUTPUT:
+DECISION: continue_skipping
+RATIONALE: engineer touched worktree 8s ago; let it cook
 
 ### Example: reclaim_and_redispatch
 …
@@ -76,71 +78,66 @@ headers exist.
 
 ## Output Schema
 
-> **Updated as of [#1711](https://github.com/rysweet/Simard/issues/1711).**
-> The wire format is now **prose-first with a `DECISION:` marker** and a
-> hybrid prose-plus-JSON form for variants that need structured fields.
-> Pure JSON is still accepted for backward compatibility. The full
-> specification lives in
-> [Reference: OODA Brain Decision Protocol](ooda-brain-decision-protocol.md);
+> **Updated as of [#1980](https://github.com/rysweet/Simard/issues/1980).**
+> The wire format is **text-only with a `DECISION:` marker** and labeled
+> lines for structured fields. JSON is no longer accepted — the legacy
+> JSON path and hybrid prose-plus-JSON form from #1711 have been removed.
+> The full specification lives in
+> [Reference: text-parsing wire formats](text-parsing-wire-formats.md);
 > this section is a quick summary.
 
-**Preferred form (prose marker):**
+**Text marker form:**
 
 ```
 DECISION: continue_skipping
-engineer touched worktree 8 seconds ago; let it cook
+RATIONALE: engineer touched worktree 8 seconds ago; let it cook
 ```
 
-**Hybrid form (marker + JSON for variants needing fields):**
+**Structured variant (labeled lines):**
 
-````
+```
 DECISION: open_tracking_issue
-{
-  "rationale": "engineer panic recurred across 3 spawns",
-  "title": "Engineer panics on goal X",
-  "body": "Repro: …\nLog tail: …"
-}
-````
+TITLE: Engineer panics on goal X
+BODY: Repro: spawn engineer, wait 30s, observe panic in tail.
+RATIONALE: engineer panic recurred across 3 spawns
+```
 
-**Legacy form (still accepted):** a single JSON object whose `choice`
-discriminator names a variant, optionally wrapped in ```` ```json ... ````
-fences or surrounded by explanatory prose. The discriminator is `choice`.
+All variants accept an optional `RATIONALE:` label. If absent, non-labeled
+lines after the DECISION line are concatenated as the rationale.
 
 ### `continue_skipping`
 
-```json
-{ "choice": "continue_skipping", "rationale": "engineer made progress 12s ago" }
+```
+DECISION: continue_skipping
+RATIONALE: engineer made progress 12s ago
 ```
 
 ### `reclaim_and_redispatch`
 
-```json
-{
-  "choice": "reclaim_and_redispatch",
-  "rationale": "worktree idle 7h, no log activity",
-  "redispatch_context": "Previous engineer attempted X; log tail showed Y; please retry with Z."
-}
+```
+DECISION: reclaim_and_redispatch
+REDISPATCH_CONTEXT: Previous engineer attempted X; log tail showed Y; please retry with Z.
+RATIONALE: worktree idle 7h, no log activity
 ```
 
 `redispatch_context` is appended to the engineer task description on respawn.
 
 ### `deprioritize`
 
-```json
-{ "choice": "deprioritize", "rationale": "20 skips, 8 failures — reduce priority -10" }
+```
+DECISION: deprioritize
+RATIONALE: 20 skips, 8 failures — reduce priority -10
 ```
 
 Side-effect: `state.goal_priorities[goal_id] -= 10` (saturating).
 
 ### `open_tracking_issue`
 
-```json
-{
-  "choice": "open_tracking_issue",
-  "rationale": "log shows panic recurring across 3 spawns",
-  "title": "Engineer panics on goal X",
-  "body": "Repro: …\nLog tail: …"
-}
+```
+DECISION: open_tracking_issue
+TITLE: Engineer panics on goal X
+BODY: Repro: spawn engineer, wait 30s, observe panic in tail.
+RATIONALE: log shows panic recurring across 3 spawns
 ```
 
 Side-effect: appends a record to `<state_root>/pending_issues.jsonl`, a new
@@ -150,23 +147,19 @@ file is a write-only audit trail.
 
 ### `mark_goal_blocked`
 
-```json
-{
-  "choice": "mark_goal_blocked",
-  "rationale": "engineer log states 'requires human decision'",
-  "reason": "awaiting-human-decision"
-}
+```
+DECISION: mark_goal_blocked
+REASON: awaiting-human-decision
+RATIONALE: engineer log states 'requires human decision'
 ```
 
 Side-effect: `state.blocked_goals.insert(goal_id, reason)`.
 
 ### `consider_self_update`
 
-```json
-{
-  "choice": "consider_self_update",
-  "rationale": "current daemon is 6h behind upstream main; in-flight cycles quiescent for 4 minutes; safe-update window open"
-}
+```
+DECISION: consider_self_update
+RATIONALE: current daemon is 6h behind upstream main; in-flight cycles quiescent for 4 minutes; safe-update window open
 ```
 
 Side-effect: `apply_lifecycle_decision` invokes the `simard safe-update`
@@ -180,22 +173,29 @@ than firing on every cycle.
 
 ## Parser Rules
 
-`parse_decision_from_response` (in `src/ooda_brain/rustyclawd.rs`) tries
-three paths in order:
+`parse_decision_from_response` (in `src/ooda_brain/rustyclawd.rs`) uses the
+DECISION marker as its **sole** parser:
 
-1. **Prose marker path.** If the first non-blank line matches
-   `^\s*DECISION\s*:\s*<variant_token>\s*$` (case-insensitive on the
-   keyword `DECISION`; `<variant_token>` matched exact-snake-case against
-   the `EngineerLifecycleDecision` whitelist), the marker is consumed and
-   the remaining body is scanned for either an optional JSON object (which
-   supplies variant-specific fields) or free-form rationale text.
-2. **Marker-wins precedence.** If the JSON body contains a `choice` field
-   that disagrees with the marker, the marker wins and the JSON `choice`
-   is overwritten before field harvesting.
-3. **Legacy JSON path.** If no marker is present, the parser falls back to
-   the pre-#1711 behavior: trim whitespace, strip ```` ```json ```` /
-   ```` ``` ```` fences, slice from the first `{` to the last `}`, and
-   `serde_json::from_str::<EngineerLifecycleDecision>(slice)`.
+1. **Find the DECISION marker.** The first non-blank line matching
+   `DECISION:` (case-insensitive on the keyword `DECISION`) is found.
+   The variant token after the colon is matched exact-snake-case against
+   the `EngineerLifecycleDecision` whitelist.
+2. **Extract labeled fields.** Remaining lines are scanned for labeled
+   fields (`TITLE:`, `BODY:`, `REASON:`, `REDISPATCH_CONTEXT:`,
+   `RATIONALE:`). Labels are matched case-insensitively.
+3. **Collect rationale.** If no `RATIONALE:` label is found, non-labeled
+   lines after the DECISION line are concatenated as the rationale.
+4. **Construct the decision.** The text-parsed fields are assembled into
+   a `serde_json::Value::Object` and deserialized into
+   `EngineerLifecycleDecision` via `serde_json::from_value`. This is
+   **not** parsing LLM output — it is deserializing a controlled
+   construction from text-parsed fields. A `// SAFETY:` comment marks
+   this call.
+
+If no `DECISION:` marker is found, the parser returns
+`SimardError::BrainResponseUnparseable { raw, source }`. The JSON
+fallback path (legacy `find('{')..rfind('}')` extraction) and the
+hybrid prose-plus-JSON form have been removed as of #1980.
 
 Failures produce `SimardError::BrainResponseUnparseable { raw, source }`,
 logged at warn level with the **full raw response text** embedded
@@ -252,7 +252,7 @@ When adding a new variant:
 4. Add a row to the
    [Behavior matrix](ooda-brain-decision-protocol.md#behavior-matrix) in
    the protocol reference covering the new variant's marker-only,
-   marker-plus-JSON, and missing-required-fields cases.
+   marker-with-labeled-lines, and missing-required-fields cases.
 5. Add the matching `#[test]` function(s) to `src/ooda_brain/tests.rs`,
    numbered as the next available `Tn`. Behavior-matrix rows and tests
    must stay 1:1.
@@ -261,7 +261,9 @@ When adding a new variant:
 
 ## See Also
 
+* [Concept: text-based brain protocol](../concepts/text-based-brain-protocol.md)
 * [Concept: prompt-driven OODA brain](../concepts/prompt-driven-ooda-brain.md)
+* [Reference: text-parsing wire formats](text-parsing-wire-formats.md)
 * [Reference: `OodaBrain` API](ooda-brain-api.md)
 * [Reference: OODA Brain Decision Protocol](ooda-brain-decision-protocol.md)
 * [How-to: edit the OODA brain prompt](../howto/edit-the-ooda-brain-prompt.md)

--- a/docs/reference/progress-evidence-api.md
+++ b/docs/reference/progress-evidence-api.md
@@ -5,16 +5,20 @@ Crate: `simard` · Module: `simard::goal_curation::progress_evidence`
 This module implements the gatekeeper described in
 [Progress-evidence gating](../concepts/progress-evidence-gating.md). It
 exposes one trait (`ProgressEvidenceChecker`), two concrete implementations
-(`LlmReviewerProgressChecker` in
-`simard::goal_curation::progress_reviewer`, `NoopProgressEvidenceChecker`),
+(`RecipeProgressChecker` in
+`simard::goal_curation::recipe_progress_checker`, `NoopProgressEvidenceChecker`),
 and a single façade function (`update_goal_progress_with_evidence`) in the
 sibling `simard::goal_curation::operations` module.
 
 > **History:** Prior to PR #2007, the production implementation was
 > `DefaultProgressEvidenceChecker`, which shelled out to `git log` and
 > `gh pr list`. That struct and its helper traits (`GitRunner`, `GhRunner`)
-> were removed in PR #2011. The gate now delegates to an LLM reviewer —
-> no subprocess calls, no local tooling requirements.
+> were removed in PR #2011. The gate then delegated to `LlmReviewerProgressChecker`
+> (JSON-based LLM response parsing), which was replaced by
+> `RecipeProgressChecker` with text-based keyword verdict parsing in #1980.
+> The `LlmReviewerProgressChecker` and its module (`progress_reviewer.rs`)
+> have been deleted — they were dead code once the recipe-based checker
+> became the primary tier.
 
 All public symbols below are re-exported from `simard::goal_curation`.
 
@@ -62,10 +66,10 @@ can be installed on `OodaBridges` and shared across all OODA actions.
 - `check` MAY perform blocking I/O (LLM calls). It is called at most
   a few times per OODA cycle, only on progress-increase attempts.
 - `check` MUST return `Accept` when evidence supports the claim and
-  `Reject` otherwise. The production `LlmReviewerProgressChecker`
-  accepts on LLM infrastructure failure (transport error, parse error,
-  empty response) — the gate's purpose is to catch hallucinated jumps,
-  not to block goals on LLM availability. See
+  `Reject` otherwise. The production `RecipeProgressChecker`
+  accepts on infrastructure failure (recipe not found, runner not
+  installed, non-zero exit) — the gate's purpose is to catch
+  hallucinated jumps, not to block goals on recipe availability. See
   [`SIMARD_PROGRESS_EVIDENCE`](../operations/progress-evidence-kill-switch.md)
   for the operator escape hatch.
 - The `since` argument is provided by the caller; the trait does not
@@ -80,57 +84,57 @@ can be installed on `OodaBridges` and shared across all OODA actions.
 | `new_percent` | `u32` | The proposed new percent (0–100). Only called when `new_percent > old_percent`. |
 | `since` | `DateTime<Utc>` | The cutoff timestamp; only artifacts at or after this instant count as evidence. |
 
-### Decision rules (LlmReviewerProgressChecker)
+### Decision rules (RecipeProgressChecker)
 
-The production implementation (`src/goal_curation/progress_reviewer.rs`)
-sends goal context to an LLM and parses a `{verdict, rationale}` JSON
-response. No git introspection, no `gh` shellouts — the LLM reads the
-problem, plan, and progress against the plan to determine whether the
-claimed percent is honest.
+The production implementation (`src/goal_curation/recipe_progress_checker.rs`)
+invokes a recipe that runs an LLM agent to review goal progress. The recipe
+stdout is parsed using the keyword verdict protocol — the checker scans for
+`"accept"` or `"reject"` keywords in the text output. See
+[text-parsing wire formats § progress checker](../reference/text-parsing-wire-formats.md#2a-progress-checker-recipe_progress_checkerrs)
+for the full grammar.
 
 | Condition | Result | `reason` template |
 |---|---|---|
-| `new_percent <= old_percent` | `Accept` (auto, no LLM call) | `"progress-assessment-reviewer: downward / no-change (<old> -> <new>) auto-accepted"` |
-| LLM returns `{"verdict":"accept","rationale":"..."}` | `Accept` | `"progress-assessment-reviewer: accept — <rationale>"` |
-| LLM returns `{"verdict":"reject","rationale":"..."}` | `Reject` | `"progress-assessment-reviewer: reject — <rationale>"` |
-| LLM transport/parse error or empty response | `Accept` (fail-open) | `"progress-assessment-reviewer: LLM submit failed (<error>); accepting to avoid blocking goal"` |
-| Unknown verdict string | `Accept` (fail-open) | `"progress-assessment-reviewer: unknown verdict \"<v>\"; accepting to avoid blocking goal"` |
+| `new_percent <= old_percent` | `Accept` (auto, no recipe call) | `"progress-assessment-reviewer: downward / no-change (<old> -> <new>) auto-accepted"` |
+| Recipe stdout contains `"accept"` keyword | `Accept` | `"progress-assessment-reviewer: accept — <surrounding text as rationale>"` |
+| Recipe stdout contains `"reject"` keyword | `Reject` | `"progress-assessment-reviewer: reject — <surrounding text as rationale>"` |
+| No keyword found in recipe stdout | `Accept` (fail-open) | `"progress-assessment-reviewer: no verdict keyword found; accepting to avoid blocking goal"` |
+| Recipe invocation failure | `Accept` (fail-open) | `"progress-assessment-reviewer: recipe failed (<error>); accepting to avoid blocking goal"` |
 
-The prompt template lives at
-`prompt_assets/simard/progress_assessment_reviewer.md`. It substitutes
-`{goal_id}`, `{problem}`, `{plan}`, `{prior_pct}`, `{claimed_pct}`, and
-`{wip_summary}` before submission.
+The recipe template lives at
+`prompt_assets/simard/recipes/progress-assessment.yaml`. The prompt within
+the recipe substitutes `{goal_id}`, `{problem}`, `{plan}`, `{prior_pct}`,
+`{claimed_pct}`, and `{wip_summary}` before submission to the LLM agent.
 
 ---
 
-## `LlmReviewerProgressChecker`
+## `RecipeProgressChecker`
 
 ```rust
-// In src/goal_curation/progress_reviewer.rs
+// In src/goal_curation/recipe_progress_checker.rs
 
-pub struct LlmReviewerProgressChecker<S: LlmSubmitter> {
-    submitter: S,
+pub struct RecipeProgressChecker {
+    repo_root: PathBuf,
 }
 
-impl<S: LlmSubmitter> LlmReviewerProgressChecker<S> {
-    pub fn new(submitter: S) -> Self;
+impl RecipeProgressChecker {
+    pub fn new(repo_root: PathBuf) -> Self;
 }
 ```
 
-The production checker. Generic over `LlmSubmitter` so tests can swap in a
-canned-response stub without global state. Constructed at daemon startup
-with the daemon's active `LlmSubmitter` implementation.
+The production checker. Invokes the progress-assessment recipe via
+`recipe-runner-rs` and parses the verdict from the text output using keyword
+scanning. No JSON parsing. No intermediate `ReviewerResponse` type.
 
 The checker:
 
-1. Auto-accepts downward/no-change moves without an LLM call.
-2. Renders the prompt template with goal context.
-3. Submits to the LLM via `submitter.submit(...)`.
-4. Parses the response JSON (tries: raw, fenced code blocks, brace-balanced
-   spans, outermost-brace fallback — same strategy as `merge_judge`).
-5. Maps `"accept"` / `"reject"` verdicts to `EvidenceDecision`.
-6. Fails open on any infrastructure error (LLM down, parse failure, unknown
-   verdict).
+1. Auto-accepts downward/no-change moves without a recipe call.
+2. Resolves the recipe YAML (hot-reload path, then in-tree).
+3. Invokes `recipe-runner-rs` with goal context as variables.
+4. Scans stdout for `"accept"` or `"reject"` (case-insensitive).
+5. Maps the keyword to `EvidenceDecision`, using surrounding text as rationale.
+6. Fails open on any infrastructure error (recipe not found, runner not
+   installed, non-zero exit).
 
 ---
 
@@ -280,7 +284,7 @@ pub struct OodaBridges {
 
 | Field | Default at daemon boot | Default in tests |
 |---|---|---|
-| `progress_evidence` | `Arc::new(LlmReviewerProgressChecker::new(submitter))`, or `Arc::new(NoopProgressEvidenceChecker)` when `SIMARD_PROGRESS_EVIDENCE=off` | `Arc::new(NoopProgressEvidenceChecker)` |
+| `progress_evidence` | `Arc::new(RecipeProgressChecker::new(repo_root))`, or `Arc::new(NoopProgressEvidenceChecker)` when `SIMARD_PROGRESS_EVIDENCE=off` | `Arc::new(NoopProgressEvidenceChecker)` |
 
 A new `OodaBridges::for_tests()` constructor wires the test defaults so
 that existing OODA-loop tests need only a single-line change to adopt the
@@ -321,7 +325,7 @@ No data migration is required.
 |---|---|
 | `EvidenceDecision`, `ProgressEvidenceChecker` | Public stable — semver-tracked. |
 | `update_goal_progress_with_evidence` | Public stable. |
-| `LlmReviewerProgressChecker` | Public stable — generic over `LlmSubmitter`. |
+| `RecipeProgressChecker` | Public stable. |
 | `NoopProgressEvidenceChecker` | Public stable; safe to use in any test. |
 | Episode prefix strings (`"goal progress accepted:"`, `"brain hallucination detected:"`) | **Behaviorally stable.** The dashboard and consolidation jobs match these prefixes verbatim; changing them is a breaking change. |
 | Prompt template (`progress_assessment_reviewer.md`) | Implementation detail; may evolve. |

--- a/docs/reference/text-parsing-wire-formats.md
+++ b/docs/reference/text-parsing-wire-formats.md
@@ -1,0 +1,487 @@
+---
+title: Text-parsing wire formats
+description: Normative reference for every text-based wire format Simard's Rust code parses from LLM and recipe output. Replaces the former JSON-based contracts.
+last_updated: 2026-05-24
+review_schedule: as-needed
+owner: simard
+doc_type: reference
+related:
+  - ../concepts/text-based-brain-protocol.md
+  - ./ooda-brain-api.md
+  - ./ooda-brain-decision-protocol.md
+  - ./disk-health-api.md
+  - ./progress-evidence-api.md
+---
+
+# Reference: Text-parsing wire formats
+
+Crate: `simard`
+
+This page is the normative definition of every text-based wire format that
+Simard's Rust code parses from LLM or recipe output. There are three
+protocol families, each used at specific decision sites.
+
+For the design rationale, see
+[Concept: text-based brain protocol](../concepts/text-based-brain-protocol.md).
+
+---
+
+## Protocol 1: DECISION marker (OODA brains)
+
+Used by: `ooda_brain::decide`, `ooda_brain::orient`, `ooda_brain::rustyclawd`
+
+### Grammar
+
+```
+response     = *blank-line decision-line *body-line
+decision-line = "DECISION" *SP ":" *SP variant-token *SP LF
+body-line    = labeled-line / rationale-line
+labeled-line = label-token *SP ":" *SP value LF
+rationale-line = <any line not matching labeled-line> LF
+blank-line   = *SP LF
+```
+
+- `variant-token` is matched case-insensitively against the known enum variants
+  for the specific brain (see per-brain sections below).
+- `label-token` is matched case-insensitively against the known field labels
+  for the matched variant.
+- `value` extends to end-of-line, trimmed.
+- Lines before the first `DECISION:` line are ignored.
+- Rationale lines (non-labeled lines after `DECISION:`) are concatenated with
+  newlines to form the `rationale` field, unless a `RATIONALE:` labeled line
+  is present (which takes precedence).
+
+### Common parser implementation
+
+All three OODA brain parsers share the same core logic:
+
+```rust
+fn parse_decision_text(raw: &str, known_variants: &[&str]) -> ParseResult {
+    // 1. Find first non-blank line starting with "DECISION:" (case-insensitive)
+    // 2. Extract variant token, match against known_variants
+    // 3. Scan remaining lines for labeled fields
+    // 4. Collect unlabeled lines as rationale (fallback)
+    // 5. Return structured decision with text fields
+}
+```
+
+No `serde_json`. No regex. Only `str` methods: `trim()`, `starts_with()`,
+`split_once()`, `to_lowercase()`, `parse::<f64>()`.
+
+---
+
+### 1a. Decide phase (`decide.rs`)
+
+**Enum:** `DecideJudgment`
+
+**Variant tokens** (case-insensitive):
+
+| Token | Maps to | Notes |
+|-------|---------|-------|
+| `advance_goal` | `DecideJudgment::AdvanceGoal` | Default for real goal slugs |
+| `consolidate_memory` | `DecideJudgment::ConsolidateMemory` | For `__memory__` |
+| `run_improvement` | `DecideJudgment::RunImprovement` | For `__improvement__` |
+| `poll_developer_activity` | `DecideJudgment::PollDeveloperActivity` | For `__poll_activity__` |
+| `extract_ideas` | `DecideJudgment::ExtractIdeas` | For `__extract_ideas__` |
+| `research_query` | `DecideJudgment::ResearchQuery` | Reserved |
+| `safe_update` | `DecideJudgment::SafeUpdate` | For `__safe_update__` |
+| `skip` | `DecideJudgment::Skip` | Explicit skip |
+
+**Labeled fields:** `RATIONALE:`
+
+**Example valid responses:**
+
+Minimal:
+```
+DECISION: advance_goal
+```
+
+With rationale:
+```
+DECISION: advance_goal
+RATIONALE: PR #2023 is open; engineer needed to drive it to completion
+```
+
+Prose before decision (ignored):
+```
+Looking at the priority entry, this is a real goal slug with an open PR.
+The engineer should advance it.
+
+DECISION: advance_goal
+RATIONALE: ordinary goal id with open PR, default routing
+```
+
+**Fallback:** If no `DECISION:` line is found, the deterministic prefix
+mapping fires: `__memory__` → `consolidate_memory`, `__improvement__` →
+`run_improvement`, etc. Real goal slugs → `advance_goal`.
+
+**Prompt update:** The `ooda_decide.md` prompt's `OUTPUT_FORMAT` section now
+instructs models to emit `DECISION: <variant>` instead of a JSON object.
+The `EXAMPLES` section shows the text format. The `OPTIONS` section is
+unchanged.
+
+---
+
+### 1b. Orient phase (`orient.rs`)
+
+**Struct:** `OrientJudgment`
+
+**Labeled fields** (all optional):
+
+| Label | Type | Default | Validation |
+|-------|------|---------|------------|
+| `ADJUSTED_URGENCY:` | `f64` | Required (parse fails without it) | Must be in `[0.0, base_urgency]` |
+| `DEMOTION_APPLIED:` | `f64` | Computed as `base_urgency - adjusted_urgency` | Must be ≥ 0 |
+| `RATIONALE:` | `String` | `"<no rationale provided>"` | None |
+| `CONFIDENCE:` | `f64` | `1.0` | Must be in `[0.0, 1.0]` |
+
+**Example valid responses:**
+
+Minimal (all fields):
+```
+ADJUSTED_URGENCY: 0.60
+DEMOTION_APPLIED: 0.20
+RATIONALE: 1 failure: standard floor demotion
+CONFIDENCE: 0.9
+```
+
+With surrounding prose:
+```
+Given a single recent failure and no indication of persistent issues,
+I'll apply the standard floor demotion.
+
+ADJUSTED_URGENCY: 0.60
+RATIONALE: 1 failure: standard floor demotion
+CONFIDENCE: 0.9
+```
+
+Minimal valid:
+```
+ADJUSTED_URGENCY: 0.6
+```
+
+**Validation:** `OrientJudgment::validate()` enforces:
+- `adjusted_urgency` in `[0.0, 1.0]`
+- `adjusted_urgency <= base_urgency` (no escalation)
+- `confidence` in `[0.0, 1.0]`
+
+If validation fails, the deterministic floor applies:
+`urgency - 0.2 × failure_count`, clamped to `[0.0, 1.0]`.
+
+**Prompt update:** The `ooda_orient.md` prompt's `OUTPUT_FORMAT` section now
+instructs models to emit labeled lines instead of a JSON object. The
+`EXAMPLES` section shows the text format.
+
+---
+
+### 1c. Engineer lifecycle (`rustyclawd.rs`)
+
+**Enum:** `EngineerLifecycleDecision`
+
+This is the original DECISION marker protocol. The JSON fallback path that
+previously existed (lines 306-318 in the old code) has been removed.
+`parse_decision_from_response` now uses the DECISION marker as its **sole**
+parser.
+
+**Variant tokens** (case-insensitive):
+
+| Token | Required labeled fields |
+|-------|----------------------|
+| `continue_skipping` | _(none)_ |
+| `reclaim_and_redispatch` | `REDISPATCH_CONTEXT:` |
+| `deprioritize` | _(none)_ |
+| `open_tracking_issue` | `TITLE:`, `BODY:` |
+| `mark_goal_blocked` | `REASON:` |
+| `consider_self_update` | _(none)_ |
+
+**All variants** accept an optional `RATIONALE:` label. If absent, non-labeled
+lines after the DECISION line are concatenated as the rationale. If no rationale
+text is found at all, the default `"<no rationale provided>"` is used.
+
+**Example valid responses:**
+
+Simple variant:
+```
+DECISION: continue_skipping
+RATIONALE: engineer is making progress, worktree modified 30s ago
+```
+
+Structured variant:
+```
+DECISION: open_tracking_issue
+TITLE: Engineer stuck in compile-error loop for improve-test-coverage
+BODY: The engineer has been failing for 6 consecutive cycles with E0277 type errors. The worktree has not been modified in 25200 seconds.
+RATIONALE: Persistent failure pattern needs human attention.
+```
+
+Reclaim with context:
+```
+DECISION: reclaim_and_redispatch
+REDISPATCH_CONTEXT: Previous engineer was stuck on type errors in src/auth. Try a different approach using the existing AuthProvider trait.
+RATIONALE: 12 consecutive skips with no worktree modification.
+```
+
+**Retained `serde_json::from_value`:** After the text parser extracts all
+fields from labeled lines, it constructs a `serde_json::Value::Object` from
+the parsed strings and deserializes it into `EngineerLifecycleDecision`. This
+is **not** parsing LLM output — it is deserializing a controlled construction
+from text-parsed fields. A `// SAFETY:` comment marks this call.
+
+---
+
+## Protocol 2: Keyword verdict (recipe shims)
+
+Used by: `goal_curation::recipe_progress_checker`, `stewardship::recipe_merge_judge`
+
+### Grammar
+
+```
+response = *line verdict-keyword *line
+verdict-keyword = <case-insensitive match of a known keyword>
+```
+
+The parser scans the entire stdout for a verdict keyword. Everything else
+(all lines that are not the keyword) is collected as the rationale.
+
+### Scanning rules
+
+1. Convert stdout to lowercase for matching.
+2. Check for the **negative** keyword first to prevent substring false positives.
+3. Check for the **positive** keyword.
+4. If no keyword found, apply the safe default.
+5. Extract surrounding text as rationale.
+
+---
+
+### 2a. Progress checker (`recipe_progress_checker.rs`)
+
+**Keywords:**
+
+| Keyword | Maps to | Priority |
+|---------|---------|----------|
+| `reject` | `EvidenceDecision::Reject` | Checked first |
+| `accept` | `EvidenceDecision::Accept` | Checked second |
+
+**Default (no keyword):** `EvidenceDecision::Accept` — fail-open. The gate's
+purpose is to catch hallucinated jumps, not to block goals on keyword-detection
+availability.
+
+**Example recipe stdout:**
+
+```
+After reviewing the plan and progress claims:
+
+The goal "improve-amplihack-test-coverage" claims progress from 35% to 43%.
+The plan describes adding integration tests for the recipe runner, and the
+WIP summary references new test files in tests/integration/.
+
+The 8-point increase is proportional to the described work.
+
+accept
+```
+
+Parser result: `EvidenceDecision::Accept { reason: "After reviewing the plan and progress claims: ..." }`
+
+**Changes from prior implementation:**
+
+- `parse_reviewer_response` (which parsed JSON `ReviewerResponse`) is removed.
+- `RecipeProgressChecker::check()` now calls `parse_verdict_from_text()`
+  directly and returns `EvidenceDecision` without the intermediate
+  `ReviewerResponse` type.
+- The `progress_reviewer.rs` module (containing `LlmReviewerProgressChecker`)
+  is deleted. It was dead code — the daemon wiring already used
+  `RecipeProgressChecker` as the primary tier.
+- The daemon fallback chain is now: `RecipeProgressChecker` →
+  `NoopProgressEvidenceChecker` (was: `RecipeProgressChecker` →
+  `LlmReviewerProgressChecker` → `NoopProgressEvidenceChecker`).
+
+---
+
+### 2b. Merge judge (`recipe_merge_judge.rs`)
+
+**Keywords:**
+
+| Keyword | Maps to | Priority |
+|---------|---------|----------|
+| `not_ready` | `Verdict::NotReady` | Checked first (prevents `ready` substring match) |
+| `unclear` | `Verdict::NotReady` | Checked second (conservative — unclear is not ready) |
+| `ready` | `Verdict::Ready` | Checked third |
+
+**Default (no keyword):** `Verdict::NotReady` — fail-closed. A PR that
+cannot be judged is not merged.
+
+**Example recipe stdout:**
+
+```
+Reviewing PR #2023 against merge criteria:
+
+- CI status: all checks passing
+- Code review: approved by 1 reviewer
+- Test coverage: new tests added for all changed modules
+- No breaking API changes
+
+The PR meets all merge-readiness criteria.
+
+ready
+```
+
+Parser result: `JudgeOutcome { verdict: Verdict::Ready, rationale: "Reviewing PR #2023 against merge criteria: ...", blockers: [] }`
+
+**Note on blockers:** The keyword verdict parser does not extract structured
+`Blocker` entries. `JudgeOutcome.blockers` is always empty when parsed from
+text. The recipe agent's prose rationale contains the equivalent information
+in human-readable form. If structured blockers are needed in the future, the
+recipe prompt can be updated to emit `BLOCKER:` labeled lines.
+
+**Changes from prior implementation:**
+
+- `parse_judge_response` (which parsed JSON) is removed from `merge_judge.rs`.
+- `LlmMergeJudge` is removed from `merge_judge.rs`.
+- Helper functions `extract_fenced_blocks`, `extract_balanced_objects`, and
+  `truncate_for_log` are removed from `merge_judge.rs`.
+- `build_merge_judge()` chain is now: `RecipeMergeJudge` →
+  `RefusingMergeJudge` (was: `RecipeMergeJudge` → `LlmMergeJudge` →
+  `RefusingMergeJudge`).
+
+---
+
+## Protocol 3: Key=value (disk health)
+
+Used by: `disk_health`
+
+### Grammar
+
+```
+response    = *output-line
+output-line = kv-line / action-line / ignored-line
+kv-line     = key "=" value LF
+action-line = "ACTION:" *SP description LF
+ignored-line = <any line not matching kv-line or action-line> LF
+key         = "DISK_USED_PCT" / "FREED_BYTES"
+value       = 1*DIGIT
+description = <text to end of line>
+```
+
+### Known keys
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `DISK_USED_PCT` | `u64` | `0` | Disk usage percentage after cleanup (0–100) |
+| `FREED_BYTES` | `u64` | `0` | Bytes freed during this check |
+| `ACTION` | `Vec<String>` | `[]` | Collected from all `ACTION:` lines |
+
+### Example recipe stdout
+
+```
+DISK_USED_PCT=72
+FREED_BYTES=53687091200
+ACTION: Removed 48 stale worktrees (50.1G)
+ACTION: Removed cargo target dirs from 3 worktrees (1.2G)
+ACTION: Pruned 19 LadybugDB backups (512M)
+ACTION: Cleaned cargo-target/ (12.0G) and shared-target/ (2.8G)
+```
+
+When disk usage is below threshold (no cleanup):
+
+```
+DISK_USED_PCT=65
+FREED_BYTES=0
+```
+
+### Bash production
+
+The recipe YAML bash step produces this format naturally:
+
+```bash
+USED_PCT=$(df /home --output=pcent | tail -1 | tr -d ' %')
+echo "DISK_USED_PCT=${USED_PCT}"
+echo "FREED_BYTES=${TOTAL_FREED}"
+for action in "${ACTIONS[@]}"; do
+  echo "ACTION: ${action}"
+done
+```
+
+No JSON `printf`, no quoting concerns, no escaping. Filenames with special
+characters in action descriptions are safe — they're just text after `ACTION:`.
+
+### Changes from prior implementation
+
+- `DiskHealthReport` retains `Serialize` (for logging/state) but `Deserialize`
+  is removed.
+- `run_disk_health_check` calls `parse_disk_health_text()` instead of
+  `serde_json::from_slice()`.
+- The recipe YAML (`disk-health-check.yaml`) outputs key=value lines instead
+  of a JSON object.
+
+---
+
+## Error handling
+
+All text parsers return `SimardError::BrainResponseUnparseable` (or the
+site-specific error variant) when parsing fails. The error carries:
+
+- `raw: String` — the **complete, untruncated** text that was received.
+- `source: BrainParseSource::Marker(MarkerParseError)` — the specific
+  parse failure (missing DECISION line, unknown variant, missing required
+  field, validation failure).
+
+Parse failures are logged at `ERROR` level with the full raw response
+(truncated to 8 KiB at log-format time). The `ParseFailureRecord` channels
+(structured log, metric, cycle report, GitHub issue escalation) continue to
+function as documented in
+[diagnose-decide-orient-parse-failures](../howto/diagnose-decide-orient-parse-failures.md).
+
+The deterministic fallback brains (`DeterministicFallbackDecideBrain`,
+`DeterministicFallbackOrientBrain`, `DeterministicFallbackBrain`) continue
+to serve as the no-LLM bootstrap path. They are **not** silent error
+handlers — the parse failure is surfaced through all four visibility channels
+before the fallback is applied.
+
+---
+
+## Test inventory
+
+Each parser has inline `#[cfg(test)]` tests in its source file:
+
+| Module | Test count | Coverage |
+|--------|-----------|----------|
+| `decide.rs` | 8+ | All variant tokens, missing DECISION line, rationale extraction, fallback |
+| `orient.rs` | 6+ | All labeled fields, partial fields, validation failure, default confidence |
+| `rustyclawd.rs` | 15+ (T1–T15) | Full behavior matrix per decision protocol reference |
+| `recipe_progress_checker.rs` | 4+ | Accept, reject, no keyword (default), mixed case |
+| `recipe_merge_judge.rs` | 5+ | Ready, not_ready, unclear, no keyword (default), substring safety |
+| `disk_health.rs` | 3+ | Full output, no-cleanup output, malformed lines |
+
+---
+
+## Migration notes for prompt editors
+
+If you maintain OODA brain prompts (`prompt_assets/simard/ooda_*.md`):
+
+1. **OUTPUT_FORMAT sections now specify text format, not JSON.** The
+   `DECISION:` marker or labeled-line format is documented in each prompt's
+   `OUTPUT_FORMAT` section. Do not revert to JSON instructions.
+
+2. **EXAMPLES sections use text format.** Update any custom examples you've
+   added to follow the text format. JSON examples will not cause parse
+   failures (the parser ignores lines it doesn't recognize) but the model
+   will learn the wrong output format.
+
+3. **The parser is more tolerant than JSON.** Models can emit prose before
+   and after the structured content. This is by design — the parser finds
+   the keywords/labels it needs and ignores everything else.
+
+4. **Forward compatibility is preserved.** Unknown labels are ignored.
+   New labeled fields can be added to prompts without code changes — they
+   just won't be parsed until the Rust parser is updated.
+
+See [How-to: edit the OODA brain prompt](../howto/edit-the-ooda-brain-prompt.md)
+for the full editing guide.
+
+## See Also
+
+- [Concept: text-based brain protocol](../concepts/text-based-brain-protocol.md) — design rationale
+- [Reference: OODA Brain API](./ooda-brain-api.md) — trait and type definitions
+- [Reference: OODA Brain Decision Protocol](./ooda-brain-decision-protocol.md) — engineer lifecycle specifics
+- [Reference: Disk Health API](./disk-health-api.md) — disk health module
+- [Reference: Progress-evidence API](./progress-evidence-api.md) — progress checking module

--- a/src/disk_health.rs
+++ b/src/disk_health.rs
@@ -127,11 +127,10 @@ pub fn run_disk_health_check(
         });
     }
 
-    serde_json::from_slice::<DiskHealthReport>(&output.stdout).map_err(|e| {
-        SimardError::AdapterInvocationFailed {
-            base_type: ADAPTER_TAG.to_string(),
-            reason: format!("failed to parse recipe output as DiskHealthReport: {e}"),
-        }
+    let stdout_text = String::from_utf8_lossy(&output.stdout);
+    parse_disk_health_text(&stdout_text).map_err(|e| SimardError::AdapterInvocationFailed {
+        base_type: ADAPTER_TAG.to_string(),
+        reason: format!("failed to parse recipe text output: {e}"),
     })
 }
 
@@ -145,36 +144,87 @@ fn truncate(s: &str, max: usize) -> String {
     }
 }
 
+/// Parse key=value and ACTION: lines from recipe stdout text.
+///
+/// Expected format (bash recipe outputs this directly):
+/// ```text
+/// DISK_USED_PCT=87
+/// FREED_BYTES=1024
+/// ACTION: removed stale worktrees
+/// ACTION: cleaned cargo target dirs
+/// ```
+///
+/// This replaces the brittle `serde_json::from_slice::<DiskHealthReport>`
+/// pattern — the recipe is a bash step, not an LLM. Bash can emit key=value
+/// lines trivially; asking it to emit valid JSON was the source of fragility.
+pub fn parse_disk_health_text(stdout: &str) -> Result<DiskHealthReport, String> {
+    let mut disk_used_pct: Option<u8> = None;
+    let mut freed_bytes: u64 = 0;
+    let mut actions_taken: Vec<String> = Vec::new();
+
+    for line in stdout.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if let Some(val) = trimmed.strip_prefix("DISK_USED_PCT=") {
+            disk_used_pct = Some(
+                val.trim()
+                    .parse::<u8>()
+                    .map_err(|e| format!("invalid DISK_USED_PCT value '{val}': {e}"))?,
+            );
+        } else if let Some(val) = trimmed.strip_prefix("FREED_BYTES=") {
+            freed_bytes = val
+                .trim()
+                .parse::<u64>()
+                .map_err(|e| format!("invalid FREED_BYTES value '{val}': {e}"))?;
+        } else if let Some(action) = trimmed.strip_prefix("ACTION:") {
+            let action = action.trim();
+            if !action.is_empty() {
+                actions_taken.push(action.to_string());
+            }
+        }
+        // Unknown lines are silently ignored (forward-compat).
+    }
+
+    let disk_used_pct =
+        disk_used_pct.ok_or_else(|| "missing DISK_USED_PCT line in recipe output".to_string())?;
+
+    Ok(DiskHealthReport {
+        disk_used_pct,
+        freed_bytes,
+        actions_taken,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     // ------------------------------------------------------------------
-    // DiskHealthReport deserialization
+    // Text-based parser (issue #1980 — replaces JSON deserialization)
     // ------------------------------------------------------------------
 
     #[test]
-    fn report_deserializes_from_json_no_cleanup() {
-        let json = r#"{"disk_used_pct": 65, "freed_bytes": 0, "actions_taken": []}"#;
-        let report: DiskHealthReport = serde_json::from_str(json).unwrap();
+    fn text_parse_no_cleanup() {
+        let text = "DISK_USED_PCT=65\nFREED_BYTES=0\n";
+        let report = parse_disk_health_text(text).unwrap();
         assert_eq!(report.disk_used_pct, 65);
         assert_eq!(report.freed_bytes, 0);
         assert!(report.actions_taken.is_empty());
     }
 
     #[test]
-    fn report_deserializes_from_json_with_cleanup() {
-        let json = r#"{
-            "disk_used_pct": 87,
-            "freed_bytes": 53687091200,
-            "actions_taken": [
-                "removed 12 stale engineer worktrees",
-                "cleaned cargo target dirs in worktrees",
-                "pruned LadybugDB backups to 5 most recent",
-                "cleaned shared-target dir"
-            ]
-        }"#;
-        let report: DiskHealthReport = serde_json::from_str(json).unwrap();
+    fn text_parse_with_cleanup_actions() {
+        let text = "\
+DISK_USED_PCT=87
+FREED_BYTES=53687091200
+ACTION: removed 12 stale engineer worktrees
+ACTION: cleaned cargo target dirs in worktrees
+ACTION: pruned LadybugDB backups to 5 most recent
+ACTION: cleaned shared-target dir
+";
+        let report = parse_disk_health_text(text).unwrap();
         assert_eq!(report.disk_used_pct, 87);
         assert_eq!(report.freed_bytes, 53_687_091_200);
         assert_eq!(report.actions_taken.len(), 4);
@@ -182,45 +232,79 @@ mod tests {
     }
 
     #[test]
-    fn report_deserializes_at_boundary_100_percent() {
-        let json = r#"{"disk_used_pct": 100, "freed_bytes": 1024, "actions_taken": ["emergency cleanup"]}"#;
-        let report: DiskHealthReport = serde_json::from_str(json).unwrap();
+    fn text_parse_boundary_100_percent() {
+        let text = "DISK_USED_PCT=100\nFREED_BYTES=1024\nACTION: emergency cleanup\n";
+        let report = parse_disk_health_text(text).unwrap();
         assert_eq!(report.disk_used_pct, 100);
         assert_eq!(report.freed_bytes, 1024);
         assert_eq!(report.actions_taken.len(), 1);
     }
 
     #[test]
-    fn report_deserializes_at_boundary_0_percent() {
-        let json = r#"{"disk_used_pct": 0, "freed_bytes": 0, "actions_taken": []}"#;
-        let report: DiskHealthReport = serde_json::from_str(json).unwrap();
+    fn text_parse_boundary_0_percent() {
+        let text = "DISK_USED_PCT=0\nFREED_BYTES=0\n";
+        let report = parse_disk_health_text(text).unwrap();
         assert_eq!(report.disk_used_pct, 0);
     }
 
     #[test]
-    fn report_rejects_missing_field() {
-        let json = r#"{"disk_used_pct": 65, "freed_bytes": 0}"#;
-        let result = serde_json::from_str::<DiskHealthReport>(json);
-        assert!(result.is_err(), "should reject JSON missing actions_taken");
+    fn text_parse_missing_disk_used_pct_is_error() {
+        let text = "FREED_BYTES=0\n";
+        let result = parse_disk_health_text(text);
+        assert!(result.is_err(), "should reject missing DISK_USED_PCT");
+        assert!(result.unwrap_err().contains("missing DISK_USED_PCT"));
     }
 
     #[test]
-    fn report_rejects_invalid_type() {
-        let json = r#"{"disk_used_pct": "high", "freed_bytes": 0, "actions_taken": []}"#;
-        let result = serde_json::from_str::<DiskHealthReport>(json);
-        assert!(result.is_err(), "should reject non-numeric disk_used_pct");
+    fn text_parse_invalid_pct_value_is_error() {
+        let text = "DISK_USED_PCT=high\nFREED_BYTES=0\n";
+        let result = parse_disk_health_text(text);
+        assert!(result.is_err(), "should reject non-numeric DISK_USED_PCT");
     }
 
     #[test]
-    fn report_rejects_empty_string() {
-        let result = serde_json::from_str::<DiskHealthReport>("");
+    fn text_parse_empty_string_is_error() {
+        let result = parse_disk_health_text("");
         assert!(result.is_err());
     }
 
     #[test]
-    fn report_rejects_non_json() {
-        let result = serde_json::from_str::<DiskHealthReport>("not json at all");
-        assert!(result.is_err());
+    fn text_parse_freed_bytes_defaults_to_zero_when_absent() {
+        let text = "DISK_USED_PCT=50\n";
+        let report = parse_disk_health_text(text).unwrap();
+        assert_eq!(report.freed_bytes, 0);
+        assert!(report.actions_taken.is_empty());
+    }
+
+    #[test]
+    fn text_parse_ignores_unknown_lines() {
+        let text = "DISK_USED_PCT=42\nSOME_OTHER_KEY=foo\nFREED_BYTES=100\n";
+        let report = parse_disk_health_text(text).unwrap();
+        assert_eq!(report.disk_used_pct, 42);
+        assert_eq!(report.freed_bytes, 100);
+    }
+
+    #[test]
+    fn text_parse_handles_whitespace_around_values() {
+        let text = "  DISK_USED_PCT=42  \n  FREED_BYTES=100  \n  ACTION: did things  \n";
+        let report = parse_disk_health_text(text).unwrap();
+        assert_eq!(report.disk_used_pct, 42);
+        assert_eq!(report.freed_bytes, 100);
+        assert_eq!(report.actions_taken, vec!["did things"]);
+    }
+
+    #[test]
+    fn text_parse_skips_blank_lines() {
+        let text = "\n\nDISK_USED_PCT=50\n\nFREED_BYTES=0\n\n";
+        let report = parse_disk_health_text(text).unwrap();
+        assert_eq!(report.disk_used_pct, 50);
+    }
+
+    #[test]
+    fn text_parse_action_without_text_is_skipped() {
+        let text = "DISK_USED_PCT=50\nACTION:\nACTION: real action\n";
+        let report = parse_disk_health_text(text).unwrap();
+        assert_eq!(report.actions_taken, vec!["real action"]);
     }
 
     // ------------------------------------------------------------------

--- a/src/goal_curation/recipe_progress_checker.rs
+++ b/src/goal_curation/recipe_progress_checker.rs
@@ -141,15 +141,7 @@ impl ProgressEvidenceChecker for RecipeProgressChecker {
             };
         }
 
-        // Reuse the same parse logic from progress_reviewer
-        match super::progress_reviewer::parse_reviewer_response(&raw) {
-            Ok(parsed) => decision_from_response(parsed),
-            Err(parse_err) => EvidenceDecision::Accept {
-                reason: format!(
-                    "{ADAPTER_TAG}: parse error ({parse_err}); accepting to avoid blocking goal"
-                ),
-            },
-        }
+        parse_verdict_from_text(&raw)
     }
 }
 
@@ -168,32 +160,35 @@ fn render_wip_summary(goal: &ActiveGoal) -> String {
     s
 }
 
-/// Reuse the same ReviewerResponse → EvidenceDecision mapping.
-fn decision_from_response(r: super::progress_reviewer::ReviewerResponse) -> EvidenceDecision {
-    let trimmed = r.rationale.trim();
-    let rationale = {
-        let mut chars = trimmed.chars();
-        let prefix: String = chars.by_ref().take(RATIONALE_MAX_CHARS).collect();
-        if chars.next().is_some() {
-            prefix + "…"
-        } else {
-            prefix
-        }
-    };
-    let verdict_lc = r.verdict.trim().to_ascii_lowercase();
-    if verdict_lc == "accept" {
-        EvidenceDecision::Accept {
-            reason: format!("{ADAPTER_TAG}: accept — {rationale}"),
-        }
-    } else if verdict_lc == "reject" {
+/// Parse recipe stdout text for verdict keywords (accept/reject).
+///
+/// The recipe runs an agent that produces natural language output.
+/// We scan for the verdict keyword and use the surrounding text as
+/// the rationale. No JSON parsing needed — the agent already makes
+/// the decision; we just need to read it.
+///
+/// Scan rules:
+/// - Case-insensitive search for "accept" or "reject"
+/// - First match wins
+/// - The full text (truncated) becomes the rationale
+/// - If neither keyword found, accept with diagnostic (same fallback
+///   as the old JSON parse-error path)
+pub fn parse_verdict_from_text(text: &str) -> EvidenceDecision {
+    let lower = text.to_ascii_lowercase();
+    let rationale = truncate(text.trim(), RATIONALE_MAX_CHARS);
+
+    if lower.contains("reject") {
         EvidenceDecision::Reject {
             reason: format!("{ADAPTER_TAG}: reject — {rationale}"),
+        }
+    } else if lower.contains("accept") {
+        EvidenceDecision::Accept {
+            reason: format!("{ADAPTER_TAG}: accept — {rationale}"),
         }
     } else {
         EvidenceDecision::Accept {
             reason: format!(
-                "{ADAPTER_TAG}: unknown verdict {:?}; accepting to avoid blocking goal",
-                r.verdict
+                "{ADAPTER_TAG}: no verdict keyword found in recipe output; accepting to avoid blocking goal"
             ),
         }
     }
@@ -229,9 +224,6 @@ mod tests {
 
     #[test]
     fn downward_move_is_auto_accepted_without_recipe_call() {
-        // RecipeProgressChecker::new may fail in test env (no binary) so
-        // test the trait method directly via a constructed instance.
-        // We only need to test the fast path which doesn't invoke the binary.
         let checker = RecipeProgressChecker {
             recipe_path: PathBuf::from("/nonexistent/recipe.yaml"),
         };
@@ -264,13 +256,110 @@ mod tests {
         let g = goal_with_activity(Some("working on it"));
         match checker.check(&g, 10, 20, Utc::now()) {
             EvidenceDecision::Accept { reason } => {
-                // Should fail at spawn or recipe exit, either way accept
                 assert!(
                     reason.contains("recipe") || reason.contains("spawn"),
                     "got: {reason}"
                 );
             }
             EvidenceDecision::Reject { .. } => panic!("expected accept on infra failure"),
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Text-based verdict parser (issue #1980)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn text_verdict_accept_detected() {
+        let text = "After reviewing the evidence, I accept the claimed progress.";
+        match parse_verdict_from_text(text) {
+            EvidenceDecision::Accept { reason } => {
+                assert!(reason.contains("accept"), "got: {reason}");
+            }
+            EvidenceDecision::Reject { .. } => panic!("expected accept"),
+        }
+    }
+
+    #[test]
+    fn text_verdict_reject_detected() {
+        let text = "The progress jump is not supported. I reject the claim.";
+        match parse_verdict_from_text(text) {
+            EvidenceDecision::Reject { reason } => {
+                assert!(reason.contains("reject"), "got: {reason}");
+            }
+            EvidenceDecision::Accept { .. } => panic!("expected reject"),
+        }
+    }
+
+    #[test]
+    fn text_verdict_case_insensitive() {
+        let text = "ACCEPT - the evidence checks out";
+        match parse_verdict_from_text(text) {
+            EvidenceDecision::Accept { reason } => {
+                assert!(reason.contains("accept"), "got: {reason}");
+            }
+            EvidenceDecision::Reject { .. } => panic!("expected accept"),
+        }
+    }
+
+    #[test]
+    fn text_verdict_reject_takes_priority_over_accept() {
+        // If both keywords appear, reject wins (safer default)
+        let text = "I cannot accept this, I must reject the claim.";
+        match parse_verdict_from_text(text) {
+            EvidenceDecision::Reject { reason } => {
+                assert!(reason.contains("reject"), "got: {reason}");
+            }
+            EvidenceDecision::Accept { .. } => panic!("expected reject when both keywords present"),
+        }
+    }
+
+    #[test]
+    fn text_verdict_no_keyword_falls_back_to_accept() {
+        let text = "The progress looks reasonable for this stage.";
+        match parse_verdict_from_text(text) {
+            EvidenceDecision::Accept { reason } => {
+                assert!(reason.contains("no verdict keyword"), "got: {reason}");
+            }
+            EvidenceDecision::Reject { .. } => {
+                panic!("expected accept fallback when no keyword found")
+            }
+        }
+    }
+
+    #[test]
+    fn text_verdict_empty_falls_back_to_accept() {
+        let text = "";
+        match parse_verdict_from_text(text) {
+            EvidenceDecision::Accept { reason } => {
+                assert!(reason.contains("no verdict keyword"), "got: {reason}");
+            }
+            EvidenceDecision::Reject { .. } => panic!("expected accept on empty text"),
+        }
+    }
+
+    #[test]
+    fn text_verdict_includes_rationale_from_text() {
+        let text = "Based on the PR and commit history, I accept this progress claim.";
+        match parse_verdict_from_text(text) {
+            EvidenceDecision::Accept { reason } => {
+                assert!(
+                    reason.contains("PR and commit"),
+                    "rationale should include text: {reason}"
+                );
+            }
+            EvidenceDecision::Reject { .. } => panic!("expected accept"),
+        }
+    }
+
+    #[test]
+    fn text_verdict_multiline_response() {
+        let text = "Looking at the evidence:\n\n- PR #2018 has 3 commits\n- Tests pass\n\nI accept the claimed progress from 30% to 45%.";
+        match parse_verdict_from_text(text) {
+            EvidenceDecision::Accept { reason } => {
+                assert!(reason.contains("accept"), "got: {reason}");
+            }
+            EvidenceDecision::Reject { .. } => panic!("expected accept"),
         }
     }
 }

--- a/src/meeting_backend/closing.rs
+++ b/src/meeting_backend/closing.rs
@@ -338,10 +338,18 @@ impl MeetingBackend {
             &self.applied_templates,
         );
 
+        // Compute the effective goal once for both enrichment sites.
+        let effective_goal = self.effective_goal();
+
         let enrichment = persist::HandoffEnrichment {
             next_owner: next_owner_owned.as_deref(),
             artifacts: artifacts.clone(),
             structured_decisions: Some(structured_decisions.clone()),
+            goal: effective_goal.as_deref(),
+            next_actor: None,
+            applied_templates: self.applied_templates.clone(),
+            history_truncated_count: self.history_truncated_count,
+            partial_reason: partial_reason.map(|r| r.as_wire_str().to_string()),
         };
 
         // Write MeetingHandoff artifact for OODA integration.
@@ -631,10 +639,16 @@ impl MeetingBackend {
             &self.applied_templates,
         );
 
+        let partial_effective_goal = self.effective_goal();
         let enrichment = persist::HandoffEnrichment {
             next_owner: next_owner_owned.as_deref(),
             artifacts: artifacts.clone(),
             structured_decisions: Some(structured_decisions.clone()),
+            goal: partial_effective_goal.as_deref(),
+            next_actor: None,
+            applied_templates: self.applied_templates.clone(),
+            history_truncated_count: self.history_truncated_count,
+            partial_reason: partial_reason.map(|r| r.as_wire_str().to_string()),
         };
 
         if let Err(e) = persist::write_handoff_with_explicit(

--- a/src/meeting_backend/command.rs
+++ b/src/meeting_backend/command.rs
@@ -37,6 +37,10 @@ pub enum MeetingCommand {
     /// Empty payload (a bare `/owner`) falls through to conversation so
     /// the operator's intent isn't silently coerced. Added in issue #1954.
     Owner(String),
+    /// Operator sets the meeting's overarching objective (e.g.
+    /// `/goal Agree on the release plan for v2`). Empty payload falls
+    /// through to conversation. Added in issue #1987.
+    Goal(String),
     /// Natural language — forwarded to the LLM.
     Conversation(String),
 }
@@ -103,6 +107,14 @@ pub fn parse_command(input: &str) -> MeetingCommand {
                 MeetingCommand::Conversation(trimmed.to_string())
             } else {
                 MeetingCommand::Owner(arg)
+            }
+        }
+        _ if lower.starts_with("/goal ") => {
+            let arg = trimmed["/goal ".len()..].trim().to_string();
+            if arg.is_empty() {
+                MeetingCommand::Conversation(trimmed.to_string())
+            } else {
+                MeetingCommand::Goal(arg)
             }
         }
         _ => MeetingCommand::Conversation(trimmed.to_string()),
@@ -366,6 +378,40 @@ mod tests {
         assert_eq!(
             parse_command("/owner    "),
             MeetingCommand::Conversation("/owner".to_string()),
+        );
+    }
+
+    // ── Inline /goal (issue #1987) ───────────────────────────────────
+
+    #[test]
+    fn parse_goal_with_arg() {
+        assert_eq!(
+            parse_command("/goal Agree on the release plan for v2"),
+            MeetingCommand::Goal("Agree on the release plan for v2".to_string()),
+        );
+        assert_eq!(
+            parse_command("  /Goal  Ship the feature  "),
+            MeetingCommand::Goal("Ship the feature".to_string()),
+        );
+    }
+
+    #[test]
+    fn parse_goal_preserves_case() {
+        assert_eq!(
+            parse_command("/goal Finalize OAuth Flow"),
+            MeetingCommand::Goal("Finalize OAuth Flow".to_string()),
+        );
+    }
+
+    #[test]
+    fn parse_goal_empty_arg_is_conversation() {
+        assert_eq!(
+            parse_command("/goal"),
+            MeetingCommand::Conversation("/goal".to_string()),
+        );
+        assert_eq!(
+            parse_command("/goal    "),
+            MeetingCommand::Conversation("/goal".to_string()),
         );
     }
 }

--- a/src/meeting_backend/mod.rs
+++ b/src/meeting_backend/mod.rs
@@ -167,6 +167,13 @@ pub struct MeetingBackend {
     /// `ooda-curate`, `act-on-decisions`, a GitHub handle). Surfaced on the
     /// `MeetingHandoff` via the new `next_owner` field. Added in #1954.
     explicit_next_owner: Option<String>,
+    /// The meeting's overarching objective, distinct from the short `topic`.
+    /// Set by `/goal <text>` at the REPL; falls back to the first user
+    /// message on close if unset. Added in issue #1987.
+    explicit_goal: Option<String>,
+    /// Number of messages dropped because `history` hit `MAX_HISTORY`.
+    /// Surfaced on `MeetingHandoff::history_truncated_count`. Issue #1987.
+    history_truncated_count: usize,
     /// Count of user messages whose `send_message` returned `Err` after the
     /// user message was already pushed to history. These are "orphan" turns
     /// with no assistant reply. Surfaced on `MeetingSummary` (issue #1983).
@@ -210,6 +217,8 @@ impl MeetingBackend {
             explicit_action_items: Vec::new(),
             explicit_questions: Vec::new(),
             explicit_next_owner: None,
+            explicit_goal: None,
+            history_truncated_count: 0,
             orphan_turn_count: 0,
         }
     }
@@ -421,6 +430,39 @@ impl MeetingBackend {
         self.explicit_next_owner.as_deref()
     }
 
+    /// Record the meeting's overarching objective via `/goal <text>`.
+    /// Empty values clear the field. Added in issue #1987.
+    pub fn set_goal(&mut self, text: &str) {
+        let trimmed = text.trim();
+        if trimmed.is_empty() {
+            self.explicit_goal = None;
+        } else {
+            self.explicit_goal = Some(trimmed.to_string());
+        }
+    }
+
+    /// Read the explicit goal set by the operator (if any).
+    pub fn explicit_goal(&self) -> Option<&str> {
+        self.explicit_goal.as_deref()
+    }
+
+    /// Compute the effective goal for the handoff: explicit `/goal` text
+    /// if set, otherwise fall back to the first user message.
+    pub fn effective_goal(&self) -> Option<String> {
+        if let Some(ref g) = self.explicit_goal {
+            return Some(g.clone());
+        }
+        self.history
+            .iter()
+            .find(|m| matches!(m.role, Role::User))
+            .map(|m| m.content.clone())
+    }
+
+    /// Number of history messages dropped due to `MAX_HISTORY` cap.
+    pub fn history_truncated_count(&self) -> usize {
+        self.history_truncated_count
+    }
+
     // --- Private helpers ---
 
     /// Load active goal (slug, title) pairs from the default file-backed store.
@@ -467,6 +509,7 @@ impl MeetingBackend {
         if self.history.len() >= MAX_HISTORY {
             warn!("Conversation history at cap ({MAX_HISTORY}), dropping oldest message");
             self.history.remove(0);
+            self.history_truncated_count += 1;
         }
         self.history.push(ConversationMessage {
             role,

--- a/src/meeting_backend/persist/mod.rs
+++ b/src/meeting_backend/persist/mod.rs
@@ -160,6 +160,8 @@ pub fn write_auto_save(transcript: &MeetingTranscript) -> SimardResult<PathBuf> 
 /// Optional enrichment fields carried into the persisted handoff.
 ///
 /// Issue #1954 added `next_owner` and `artifacts` to `MeetingHandoff`.
+/// Issue #1987 added `goal`, `next_actor`, `applied_templates`,
+/// `history_truncated_count`, and `partial_reason`.
 /// Producer paths in `closing.rs` populate this struct so the persist
 /// helpers don't grow yet another tuple of positional parameters.
 #[derive(Clone, Debug, Default)]
@@ -179,6 +181,17 @@ pub struct HandoffEnrichment<'a> {
     /// `None`, decisions are reconstructed from `&[String]` via the
     /// existing extract helpers (legacy behaviour).
     pub structured_decisions: Option<Vec<crate::meeting_facilitator::MeetingDecision>>,
+    /// The meeting's overarching objective. Set via `/goal` at the REPL.
+    /// Added in issue #1987.
+    pub goal: Option<&'a str>,
+    /// Structured routing hint for the next consumer. Added in issue #1987.
+    pub next_actor: Option<crate::meeting_facilitator::NextActor>,
+    /// Templates applied during the meeting via `/template`. Added in #1987.
+    pub applied_templates: Vec<crate::meeting_backend::AppliedTemplate>,
+    /// Number of history messages dropped due to MAX_HISTORY cap. Added in #1987.
+    pub history_truncated_count: usize,
+    /// Wire-string form of `PartialReason` from the close pipeline. Added in #1987.
+    pub partial_reason: Option<String>,
 }
 
 /// Write a `MeetingHandoff` artifact for OODA integration.
@@ -316,6 +329,7 @@ pub fn write_handoff_with_explicit(
     let themes = extract_themes(messages);
 
     let handoff = MeetingHandoff {
+        schema_version: 2,
         meeting_id: crate::meeting_facilitator::derive_meeting_id(&started_at, topic),
         topic: topic.to_string(),
         started_at,
@@ -331,6 +345,11 @@ pub fn write_handoff_with_explicit(
         transcript_path: None,
         next_owner: enrichment.next_owner.map(|s| s.to_string()),
         artifacts: enrichment.artifacts.clone(),
+        goal: enrichment.goal.map(|s| s.to_string()),
+        next_actor: enrichment.next_actor,
+        applied_templates: enrichment.applied_templates.clone(),
+        history_truncated_count: enrichment.history_truncated_count,
+        partial_reason: enrichment.partial_reason.clone(),
     };
 
     let dir = default_handoff_dir();
@@ -413,6 +432,7 @@ pub fn write_handoff_bundle(
 
     let meeting_id = derive_meeting_id(&started_at, topic);
     let mut handoff = MeetingHandoff {
+        schema_version: 2,
         meeting_id,
         topic: topic.to_string(),
         started_at,
@@ -428,6 +448,11 @@ pub fn write_handoff_bundle(
         transcript_path: None,
         next_owner: enrichment.next_owner.map(|s| s.to_string()),
         artifacts: enrichment.artifacts.clone(),
+        goal: enrichment.goal.map(|s| s.to_string()),
+        next_actor: enrichment.next_actor,
+        applied_templates: enrichment.applied_templates.clone(),
+        history_truncated_count: enrichment.history_truncated_count,
+        partial_reason: enrichment.partial_reason.clone(),
     };
 
     let lines: Vec<crate::meeting_facilitator::BundleTranscriptLine> = messages

--- a/src/meeting_facilitator/handoff/mod.rs
+++ b/src/meeting_facilitator/handoff/mod.rs
@@ -79,6 +79,14 @@ pub struct HandoffArtifact {
     pub description: Option<String>,
 }
 
+/// Default handoff schema version for new writes.
+const DEFAULT_HANDOFF_SCHEMA_VERSION: u32 = 2;
+
+/// Default version when deserializing v1 handoffs that lack the field.
+fn default_handoff_schema_version_v1() -> u32 {
+    1
+}
+
 /// A handoff artifact produced when a meeting closes. Contains decisions,
 /// action items, open questions, the next responsible owner, and a list
 /// of linked artifacts.
@@ -88,6 +96,10 @@ pub struct HandoffArtifact {
 /// with empty defaults. No on-disk migration step is required.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct MeetingHandoff {
+    /// Schema version. v2 writes carry `2`; older v1 handoffs missing
+    /// this field default to `1` on read.
+    #[serde(default = "default_handoff_schema_version_v1")]
+    pub schema_version: u32,
     /// Stable, sortable identifier for this meeting. Derived from
     /// `started_at` plus a slug of the topic. Empty in legacy artifacts —
     /// callers reading old handoffs should fall back to
@@ -134,6 +146,32 @@ pub struct MeetingHandoff {
     /// deserialize as `[]`.
     #[serde(default)]
     pub artifacts: Vec<HandoffArtifact>,
+    /// The meeting's overarching objective, distinct from the short
+    /// `topic`. Set by `/goal <text>` at the REPL; falls back to the
+    /// first user message if unset. Added in issue #1987.
+    #[serde(default)]
+    pub goal: Option<String>,
+    /// Structured routing hint: which actor should consume this handoff
+    /// next. Complements the free-form `next_owner` string. Added in
+    /// issue #1987.
+    #[serde(default)]
+    pub next_actor: Option<super::types::NextActor>,
+    /// Templates applied during the meeting (via `/template <name>`).
+    /// Already present on `MeetingSummary`; promoted to the handoff
+    /// so downstream consumers see them without parsing the bundle.
+    /// Added in issue #1987.
+    #[serde(default)]
+    pub applied_templates: Vec<crate::meeting_backend::AppliedTemplate>,
+    /// Number of history messages dropped due to the `MAX_HISTORY` cap
+    /// (currently 500). Lets consumers gauge transcript completeness.
+    /// Added in issue #1987.
+    #[serde(default)]
+    pub history_truncated_count: usize,
+    /// Wire-string form of `PartialReason` from the close pipeline.
+    /// `Some("summary_timeout")` etc. when the close was partial;
+    /// `None` for a clean close. Added in issue #1987.
+    #[serde(default)]
+    pub partial_reason: Option<String>,
 }
 
 /// Build a stable, sortable meeting id from a started-at timestamp and a
@@ -311,6 +349,7 @@ impl MeetingHandoff {
         }
 
         Self {
+            schema_version: DEFAULT_HANDOFF_SCHEMA_VERSION,
             meeting_id: derive_meeting_id(&session.started_at, &session.topic),
             topic: session.topic.clone(),
             started_at: session.started_at.clone(),
@@ -326,6 +365,11 @@ impl MeetingHandoff {
             transcript_path: None,
             next_owner: session.next_owner.clone(),
             artifacts: Vec::new(),
+            goal: session.goal.clone(),
+            next_actor: None,
+            applied_templates: Vec::new(),
+            history_truncated_count: 0,
+            partial_reason: None,
         }
     }
 
@@ -401,6 +445,7 @@ mod tests {
             explicit_questions: vec![],
             themes: vec![],
             next_owner: None,
+            goal: None,
         }
     }
 
@@ -431,6 +476,7 @@ mod tests {
             explicit_questions: vec!["What about testing?".to_string()],
             themes: vec!["performance".to_string()],
             next_owner: Some("engineer".to_string()),
+            goal: None,
         }
     }
 

--- a/src/meeting_facilitator/handoff/persistence.rs
+++ b/src/meeting_facilitator/handoff/persistence.rs
@@ -576,6 +576,7 @@ mod bundle_tests {
 
     fn sample_handoff() -> MeetingHandoff {
         MeetingHandoff {
+            schema_version: 2,
             meeting_id: String::new(), // exercise auto-fill
             topic: "Sprint planning".to_string(),
             started_at: "2026-05-13T07:00:00Z".to_string(),
@@ -604,6 +605,11 @@ mod bundle_tests {
             transcript_path: None,
             next_owner: None,
             artifacts: Vec::new(),
+            goal: None,
+            next_actor: None,
+            applied_templates: Vec::new(),
+            history_truncated_count: 0,
+            partial_reason: None,
         }
     }
 

--- a/src/meeting_facilitator/mod.rs
+++ b/src/meeting_facilitator/mod.rs
@@ -29,7 +29,9 @@ pub use session::{
     add_note, add_question, close_meeting, edit_item, record_action_item, record_decision,
     remove_item, start_meeting,
 };
-pub use types::{ActionItem, MeetingDecision, MeetingSession, MeetingSessionStatus, OpenQuestion};
+pub use types::{
+    ActionItem, MeetingDecision, MeetingSession, MeetingSessionStatus, NextActor, OpenQuestion,
+};
 
 #[cfg(test)]
 mod tests {
@@ -144,6 +146,7 @@ mod tests {
             explicit_questions: vec![],
             themes: vec![],
             next_owner: None,
+            goal: None,
         };
         let summary = session.durable_summary();
         assert!(summary.contains("Planning"));

--- a/src/meeting_facilitator/session.rs
+++ b/src/meeting_facilitator/session.rs
@@ -61,6 +61,7 @@ pub fn start_meeting(topic: &str, bridge: &dyn CognitiveMemoryOps) -> SimardResu
         explicit_questions: Vec::new(),
         themes: Vec::new(),
         next_owner: None,
+        goal: None,
     })
 }
 

--- a/src/meeting_facilitator/tests_handoff.rs
+++ b/src/meeting_facilitator/tests_handoff.rs
@@ -21,6 +21,7 @@ fn make_session(
         explicit_questions: Vec::new(),
         themes: Vec::new(),
         next_owner: None,
+        goal: None,
     }
 }
 
@@ -388,6 +389,7 @@ fn round_trip_handoff_with_next_owner_and_artifacts() {
     // (serialize → deserialize → re-serialize → byte equality), which is
     // the acceptance bar from issue #1954.
     let handoff = MeetingHandoff {
+        schema_version: 2,
         meeting_id: "20260501T070000Z-sprint-planning".to_string(),
         topic: "Sprint planning".to_string(),
         started_at: "2026-05-01T07:00:00Z".to_string(),
@@ -406,6 +408,11 @@ fn round_trip_handoff_with_next_owner_and_artifacts() {
         transcript_path: Some("/tmp/meetings/transcript-2026-05-01.json".to_string()),
         next_owner: Some("engineer".to_string()),
         artifacts: sample_artifacts(),
+        goal: None,
+        next_actor: None,
+        applied_templates: Vec::new(),
+        history_truncated_count: 0,
+        partial_reason: None,
     };
 
     let json = serde_json::to_string_pretty(&handoff).expect("serialize ok");

--- a/src/meeting_facilitator/tests_handoff_extra.rs
+++ b/src/meeting_facilitator/tests_handoff_extra.rs
@@ -23,6 +23,7 @@ fn make_session(
         explicit_questions: Vec::new(),
         themes: Vec::new(),
         next_owner: None,
+        goal: None,
     }
 }
 
@@ -192,8 +193,193 @@ fn find_newest_prefers_timestamped_over_legacy() {
 }
 
 // -----------------------------------------------------------------------
-// WIP session persistence tests
+// Schema v2 round-trip and backward-compatibility tests (issue #1987)
 // -----------------------------------------------------------------------
+
+#[test]
+fn v2_handoff_round_trip_all_fields_preserved() {
+    use crate::meeting_backend::AppliedTemplate;
+    use crate::meeting_facilitator::types::NextActor;
+
+    let mut session = make_session(
+        "V2 full test",
+        vec!["TBD: rollout plan"],
+        vec![sample_decision()],
+        vec![sample_action()],
+        vec!["alice", "bob"],
+    );
+    session.goal = Some("Agree on the release plan for v2".to_string());
+
+    let mut handoff = MeetingHandoff::from_session(&session);
+    handoff.next_actor = Some(NextActor::Engineer);
+    handoff.applied_templates = vec![AppliedTemplate {
+        name: "retro".to_string(),
+        agenda: "## Retrospective\n1. What went well\n2. What didn't".to_string(),
+        applied_at: "2026-05-01T10:00:00Z".to_string(),
+    }];
+    handoff.history_truncated_count = 42;
+    handoff.partial_reason = Some("summary_timeout".to_string());
+
+    assert_eq!(handoff.schema_version, 2);
+    assert_eq!(
+        handoff.goal.as_deref(),
+        Some("Agree on the release plan for v2")
+    );
+
+    let json = serde_json::to_string_pretty(&handoff).unwrap();
+    let parsed: MeetingHandoff = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(parsed.schema_version, 2);
+    assert_eq!(parsed.goal, handoff.goal);
+    assert_eq!(parsed.next_actor, Some(NextActor::Engineer));
+    assert_eq!(parsed.applied_templates.len(), 1);
+    assert_eq!(parsed.applied_templates[0].name, "retro");
+    assert_eq!(parsed.history_truncated_count, 42);
+    assert_eq!(parsed.partial_reason.as_deref(), Some("summary_timeout"));
+    assert_eq!(handoff, parsed);
+}
+
+#[test]
+fn v1_handoff_without_new_fields_deserializes_with_defaults() {
+    // Simulate a v1 handoff JSON that lacks all 6 new fields.
+    let v1_json = r#"{
+        "meeting_id": "20260101T000000Z-legacy",
+        "topic": "Legacy meeting",
+        "started_at": "2026-01-01T00:00:00Z",
+        "closed_at": "2026-01-01T01:00:00Z",
+        "decisions": [],
+        "action_items": [],
+        "open_questions": [],
+        "processed": false,
+        "duration_secs": 3600,
+        "transcript": ["operator: hello"],
+        "participants": ["alice"],
+        "themes": ["legacy"],
+        "next_owner": "engineer",
+        "artifacts": []
+    }"#;
+
+    let parsed: MeetingHandoff = serde_json::from_str(v1_json).unwrap();
+
+    // schema_version defaults to 1 for legacy handoffs
+    assert_eq!(
+        parsed.schema_version, 1,
+        "v1 handoff should report schema_version=1"
+    );
+    assert_eq!(parsed.goal, None, "v1 handoff should have goal=None");
+    assert_eq!(
+        parsed.next_actor, None,
+        "v1 handoff should have next_actor=None"
+    );
+    assert!(
+        parsed.applied_templates.is_empty(),
+        "v1 handoff should have empty applied_templates"
+    );
+    assert_eq!(
+        parsed.history_truncated_count, 0,
+        "v1 handoff should have history_truncated_count=0"
+    );
+    assert_eq!(
+        parsed.partial_reason, None,
+        "v1 handoff should have partial_reason=None"
+    );
+
+    // Pre-existing fields should still be correct
+    assert_eq!(parsed.topic, "Legacy meeting");
+    assert_eq!(parsed.next_owner.as_deref(), Some("engineer"));
+    assert_eq!(parsed.duration_secs, Some(3600));
+}
+
+#[test]
+fn v2_handoff_strip_new_fields_still_deserializes() {
+    use crate::meeting_facilitator::types::NextActor;
+
+    let mut session = make_session(
+        "Strippable",
+        vec![],
+        vec![sample_decision()],
+        vec![sample_action()],
+        vec!["alice"],
+    );
+    session.goal = Some("Test goal".to_string());
+
+    let mut handoff = MeetingHandoff::from_session(&session);
+    handoff.next_actor = Some(NextActor::OodaCurate);
+
+    // Serialize to a serde_json::Value, strip the new fields, then deserialize
+    let mut value: serde_json::Value = serde_json::to_value(&handoff).unwrap();
+    let obj = value.as_object_mut().unwrap();
+    obj.remove("schema_version");
+    obj.remove("goal");
+    obj.remove("next_actor");
+    obj.remove("applied_templates");
+    obj.remove("history_truncated_count");
+    obj.remove("partial_reason");
+
+    let stripped_json = serde_json::to_string_pretty(&value).unwrap();
+    let parsed: MeetingHandoff = serde_json::from_str(&stripped_json).unwrap();
+
+    // Should deserialize as v1 defaults
+    assert_eq!(parsed.schema_version, 1);
+    assert_eq!(parsed.goal, None);
+    assert_eq!(parsed.next_actor, None);
+    assert!(parsed.applied_templates.is_empty());
+    assert_eq!(parsed.history_truncated_count, 0);
+    assert_eq!(parsed.partial_reason, None);
+
+    // Original fields preserved
+    assert_eq!(parsed.topic, "Strippable");
+    assert_eq!(parsed.decisions.len(), 1);
+}
+
+#[test]
+fn next_actor_serde_round_trip() {
+    use crate::meeting_facilitator::types::NextActor;
+
+    for actor in [
+        NextActor::Operator,
+        NextActor::Engineer,
+        NextActor::OodaCurate,
+        NextActor::External,
+    ] {
+        let json = serde_json::to_string(&actor).unwrap();
+        let parsed: NextActor = serde_json::from_str(&json).unwrap();
+        assert_eq!(actor, parsed);
+    }
+
+    // Verify the tag structure
+    let json = serde_json::to_string(&NextActor::Engineer).unwrap();
+    assert!(
+        json.contains("\"kind\""),
+        "NextActor should use tag='kind', got: {json}"
+    );
+    assert!(
+        json.contains("\"engineer\""),
+        "Engineer variant should serialize as 'engineer', got: {json}"
+    );
+}
+
+#[test]
+fn from_session_carries_goal() {
+    let mut session = make_session("Goal test", vec![], vec![], vec![], vec![]);
+    session.goal = Some("Ship the release".to_string());
+
+    let handoff = MeetingHandoff::from_session(&session);
+    assert_eq!(handoff.goal.as_deref(), Some("Ship the release"));
+    assert_eq!(handoff.schema_version, 2);
+}
+
+#[test]
+fn from_session_defaults_v2_schema() {
+    let session = make_session("Default v2", vec![], vec![], vec![], vec![]);
+    let handoff = MeetingHandoff::from_session(&session);
+    assert_eq!(handoff.schema_version, 2);
+    assert_eq!(handoff.goal, None);
+    assert_eq!(handoff.next_actor, None);
+    assert!(handoff.applied_templates.is_empty());
+    assert_eq!(handoff.history_truncated_count, 0);
+    assert_eq!(handoff.partial_reason, None);
+}
 
 #[test]
 fn save_and_load_wip_round_trip() {

--- a/src/meeting_facilitator/types.rs
+++ b/src/meeting_facilitator/types.rs
@@ -36,6 +36,25 @@ pub struct OpenQuestion {
     pub explicit: bool,
 }
 
+/// Identifies the next actor expected to consume a meeting handoff.
+///
+/// Used on `MeetingHandoff::next_actor` to provide structured routing
+/// (as opposed to the free-form `next_owner` string). Forward-compatible:
+/// new variants can be added without breaking existing consumers because
+/// the field is `Option<NextActor>` with `#[serde(default)]`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum NextActor {
+    /// The human operator should review and act on the handoff.
+    Operator,
+    /// The engineer loop should pick up unprocessed decisions/actions.
+    Engineer,
+    /// The OODA curate cycle should ingest the handoff.
+    OodaCurate,
+    /// An external system or person outside Simard should act.
+    External,
+}
+
 /// Status of an in-progress meeting.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum MeetingSessionStatus {
@@ -75,6 +94,11 @@ pub struct MeetingSession {
     /// Added in issue #1954.
     #[serde(default)]
     pub next_owner: Option<String>,
+    /// The meeting's overarching objective, distinct from the short `topic`.
+    /// Set by the `/goal <text>` slash command or falls back to the first
+    /// user message. Added in issue #1987.
+    #[serde(default)]
+    pub goal: Option<String>,
 }
 
 impl MeetingSession {
@@ -261,6 +285,7 @@ mod tests {
             explicit_questions: vec!["What about testing?".to_string()],
             themes: vec!["performance".to_string()],
             next_owner: None,
+            goal: None,
         }
     }
 
@@ -332,6 +357,7 @@ mod tests {
             explicit_questions: vec![],
             themes: vec![],
             next_owner: None,
+            goal: None,
         };
         let summary = s.durable_summary();
         assert!(summary.contains("decisions=[none]"));
@@ -353,6 +379,7 @@ mod tests {
             explicit_questions: vec![],
             themes: vec![],
             next_owner: None,
+            goal: None,
         };
         let summary = s.durable_summary();
         assert!(summary.contains("duration=unknown"));

--- a/src/meeting_repl/repl.rs
+++ b/src/meeting_repl/repl.rs
@@ -130,7 +130,7 @@ pub fn run_meeting_repl<R: BufRead, W: Write>(
             MeetingCommand::Help => {
                 writeln!(
                     output,
-                    "Commands:\n  /status    — show session info\n  /state     — show current decisions, open questions, action items\n  /template  — list meeting templates\n  /template <name> — apply a template (standup, 1on1, retro, planning)\n  /theme <text>    — record a theme for this meeting\n  /decision <text> — record a decision deterministically (skips heuristic extraction)\n  /action <text>   — record an action item (assignee/deadline parsed inline)\n  /question <text> — record an open question deterministically\n  /owner <name>    — name the next agent/persona/human expected to action this handoff\n  /recap     — show color-coded session recap\n  /preview   — preview the handoff artifact\n  /export    — export meeting as markdown\n  /close     — end meeting and persist\n  /help      — this message\n\nEverything else is natural conversation with Simard."
+                    "Commands:\n  /status    — show session info\n  /state     — show current decisions, open questions, action items\n  /template  — list meeting templates\n  /template <name> — apply a template (standup, 1on1, retro, planning)\n  /theme <text>    — record a theme for this meeting\n  /decision <text> — record a decision deterministically (skips heuristic extraction)\n  /action <text>   — record an action item (assignee/deadline parsed inline)\n  /question <text> — record an open question deterministically\n  /owner <name>    — name the next agent/persona/human expected to action this handoff\n  /goal <text>     — set the meeting's overarching objective\n  /recap     — show color-coded session recap\n  /preview   — preview the handoff artifact\n  /export    — export meeting as markdown\n  /close     — end meeting and persist\n  /help      — this message\n\nEverything else is natural conversation with Simard."
                 )
                 .ok();
             }
@@ -260,6 +260,10 @@ pub fn run_meeting_repl<R: BufRead, W: Write>(
             MeetingCommand::Owner(text) => {
                 backend.push_next_owner(&text);
                 writeln!(output, "{}", cyan(&format!("Next owner recorded: {text}"))).ok();
+            }
+            MeetingCommand::Goal(text) => {
+                backend.set_goal(&text);
+                writeln!(output, "{}", cyan(&format!("Goal recorded: {text}"))).ok();
             }
             MeetingCommand::Recap => {
                 let status = backend.status();
@@ -562,5 +566,6 @@ fn empty_closed_session(topic: &str) -> MeetingSession {
         explicit_questions: Vec::new(),
         themes: Vec::new(),
         next_owner: None,
+        goal: None,
     }
 }

--- a/src/ooda_brain/decide.rs
+++ b/src/ooda_brain/decide.rs
@@ -190,11 +190,17 @@ impl<S: LlmSubmitter> OodaDecideBrain for RustyClawdDecideBrain<S> {
     }
 }
 
-/// Extract a JSON object from the LLM response (LLMs sometimes wrap JSON in
-/// prose / markdown fences) and parse it as a judgment. On failure the error
-/// embeds the **full raw response text** (truncated for log safety) so
-/// operators can diagnose the model behaviour — this replaces the legacy
-/// `got N bytes` byte-count format that originated the issue #1711 bug.
+/// Parse the brain response using the `DECISION:` marker protocol.
+/// Replaces the JSON `find('{')..rfind('}')` parser (issue #1980).
+///
+/// Expected format:
+/// ```text
+/// DECISION: advance_goal
+/// The goal should proceed because the evidence supports it.
+/// ```
+///
+/// The first non-blank line must contain `DECISION: <action_kind>`.
+/// The rest of the response is the rationale.
 fn parse_judgment_from_response(raw: &str) -> Result<DecideJudgment, String> {
     let stripped = raw.trim();
     if stripped.is_empty() {
@@ -203,23 +209,65 @@ fn parse_judgment_from_response(raw: &str) -> Result<DecideJudgment, String> {
             raw
         ));
     }
-    let candidate = if let Some(start) = stripped.find('{')
-        && let Some(end) = stripped.rfind('}')
-        && end >= start
+
+    // Extract DECISION marker from first non-blank line
+    let first_line = stripped.lines().find(|l| !l.trim().is_empty());
+    let first_line = match first_line {
+        Some(l) => l.trim(),
+        None => {
+            return Err(format!(
+                "decide brain response had no non-blank lines; raw_response={:?}",
+                super::rustyclawd::truncate_for_log_pub(raw)
+            ));
+        }
+    };
+
+    // Check for DECISION: prefix (case-insensitive)
+    if first_line.len() < "decision:".len()
+        || !first_line[.."decision:".len()].eq_ignore_ascii_case("decision:")
     {
-        &stripped[start..=end]
-    } else {
         return Err(format!(
-            "decide brain response had no JSON object; raw_response={:?}",
+            "decide brain response missing DECISION: marker on first line; raw_response={:?}",
             super::rustyclawd::truncate_for_log_pub(raw)
         ));
-    };
-    serde_json::from_str::<DecideJudgment>(candidate).map_err(|e| {
+    }
+
+    let after_marker = first_line["decision:".len()..].trim();
+    let choice = after_marker.split_whitespace().next().ok_or_else(|| {
         format!(
-            "decide-brain-parse-error: {e}; payload={candidate}; raw_response={:?}",
+            "decide brain DECISION: marker present but no variant token; raw_response={:?}",
             super::rustyclawd::truncate_for_log_pub(raw)
         )
-    })
+    })?;
+
+    // Remainder after the first line is the rationale
+    let rationale = stripped
+        .split_once('\n')
+        .map(|(_, r)| r.trim())
+        .unwrap_or("")
+        .to_string();
+    let rationale = if rationale.is_empty() {
+        "(no rationale provided)".to_string()
+    } else {
+        rationale
+    };
+
+    match choice {
+        "advance_goal" => Ok(DecideJudgment::AdvanceGoal { rationale }),
+        "run_improvement" => Ok(DecideJudgment::RunImprovement { rationale }),
+        "consolidate_memory" => Ok(DecideJudgment::ConsolidateMemory { rationale }),
+        "research_query" => Ok(DecideJudgment::ResearchQuery { rationale }),
+        "run_gym_eval" => Ok(DecideJudgment::RunGymEval { rationale }),
+        "build_skill" => Ok(DecideJudgment::BuildSkill { rationale }),
+        "launch_session" => Ok(DecideJudgment::LaunchSession { rationale }),
+        "poll_developer_activity" => Ok(DecideJudgment::PollDeveloperActivity { rationale }),
+        "extract_ideas" => Ok(DecideJudgment::ExtractIdeas { rationale }),
+        "safe_update" => Ok(DecideJudgment::SafeUpdate { rationale }),
+        _ => Err(format!(
+            "decide brain DECISION variant `{choice}` is not recognized; raw_response={:?}",
+            super::rustyclawd::truncate_for_log_pub(raw)
+        )),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -250,88 +298,148 @@ mod tests {
     use super::*;
     use crate::ooda_loop::ActionKind;
 
-    // ----- (a) well-formed JSON pass-through -----------------------------
+    // ----- DECISION marker parser (issue #1980) --------------------------
+
     #[test]
-    fn parse_well_formed_json_returns_judgment() {
-        let raw = r#"{"choice":"advance_goal","rationale":"go"}"#;
+    fn parse_decision_marker_advance_goal() {
+        let raw = "DECISION: advance_goal\nThe goal should proceed.";
         let j = parse_judgment_from_response(raw).expect("must parse");
         assert_eq!(j.action_kind(), ActionKind::AdvanceGoal);
-        assert_eq!(j.rationale(), "go");
+        assert!(j.rationale().contains("should proceed"));
     }
 
-    // ----- (b) JSON with surrounding prose — fallback parser must salvage -
     #[test]
-    fn parse_salvages_json_wrapped_in_prose() {
-        // Both leading and trailing prose around the object. The
-        // `find('{') .. rfind('}')` salvage must extract the JSON body.
-        let raw = "Here's my answer:\n```json\n{\"choice\":\"run_gym_eval\",\"rationale\":\"low score\"}\n```\nThanks!";
-        let j = parse_judgment_from_response(raw).expect("must salvage JSON in prose");
+    fn parse_decision_marker_run_gym_eval() {
+        let raw = "DECISION: run_gym_eval\nLow score warrants re-evaluation.";
+        let j = parse_judgment_from_response(raw).expect("must parse");
         assert_eq!(j.action_kind(), ActionKind::RunGymEval);
     }
 
     #[test]
-    fn parse_salvages_json_with_trailing_prose_only() {
-        // The parser slices from the first `{` to the last `}`, so trailing
-        // commentary after the closing brace must not break the salvage.
-        let raw = r#"{"choice":"consolidate_memory","rationale":"compaction"}  -- thanks"#;
+    fn parse_decision_marker_consolidate_memory() {
+        let raw = "DECISION: consolidate_memory\nMemory compaction needed.";
         let j = parse_judgment_from_response(raw).expect("must parse");
         assert_eq!(j.action_kind(), ActionKind::ConsolidateMemory);
     }
 
-    // ----- (c) completely unparseable returns Err, never panics ----------
     #[test]
-    fn parse_unparseable_returns_structured_error_with_raw_body() {
-        let raw = "totally not json at all";
-        let err = parse_judgment_from_response(raw).expect_err("must Err");
-        // Anti-regression for #1711: the error must embed the raw response
-        // so operators can diagnose. (`raw` has no `{` so it hits the
-        // "no JSON object" branch, not the serde-error branch.)
-        assert!(
-            err.contains(raw),
-            "error must embed raw response (issue #1711), got: {err}"
-        );
+    fn parse_decision_marker_safe_update() {
+        let raw = "DECISION: safe_update\nDivergence >= 3, conditions met.";
+        let j = parse_judgment_from_response(raw).expect("must parse");
+        assert_eq!(j.action_kind(), ActionKind::SafeUpdate);
+        assert!(j.rationale().contains("conditions met"));
     }
 
     #[test]
-    fn parse_empty_response_returns_empty_error() {
+    fn parse_decision_marker_case_insensitive() {
+        let raw = "decision: advance_goal\ngo";
+        let j = parse_judgment_from_response(raw).expect("must parse");
+        assert_eq!(j.action_kind(), ActionKind::AdvanceGoal);
+    }
+
+    #[test]
+    fn parse_decision_marker_skips_leading_blank_lines() {
+        let raw = "\n\nDECISION: advance_goal\ngo";
+        let j = parse_judgment_from_response(raw).expect("must parse");
+        assert_eq!(j.action_kind(), ActionKind::AdvanceGoal);
+    }
+
+    #[test]
+    fn parse_decision_marker_no_rationale_defaults() {
+        let raw = "DECISION: advance_goal";
+        let j = parse_judgment_from_response(raw).expect("must parse");
+        assert_eq!(j.action_kind(), ActionKind::AdvanceGoal);
+        assert_eq!(j.rationale(), "(no rationale provided)");
+    }
+
+    #[test]
+    fn parse_decision_marker_multiline_rationale() {
+        let raw = "DECISION: advance_goal\nLine 1 of reasoning.\nLine 2 of reasoning.";
+        let j = parse_judgment_from_response(raw).expect("must parse");
+        assert!(j.rationale().contains("Line 1"));
+        assert!(j.rationale().contains("Line 2"));
+    }
+
+    // ----- Error cases ---------------------------------------------------
+
+    #[test]
+    fn parse_empty_response_returns_error() {
         let err = parse_judgment_from_response("").expect_err("must Err");
-        assert!(
-            err.to_lowercase().contains("empty"),
-            "empty-response error must mention emptiness, got: {err}"
-        );
+        assert!(err.to_lowercase().contains("empty"));
     }
 
     #[test]
-    fn parse_whitespace_only_response_treated_as_empty() {
+    fn parse_whitespace_only_returns_error() {
         let err = parse_judgment_from_response("   \n\t  ").expect_err("must Err");
+        assert!(err.to_lowercase().contains("empty"));
+    }
+
+    #[test]
+    fn parse_no_decision_marker_returns_error() {
+        let raw = "I think we should advance the goal.";
+        let err = parse_judgment_from_response(raw).expect_err("must Err");
         assert!(
-            err.to_lowercase().contains("empty"),
-            "whitespace-only must be treated as empty, got: {err}"
+            err.contains("DECISION:"),
+            "error should mention missing marker: {err}"
         );
     }
 
     #[test]
-    fn parse_malformed_json_with_braces_returns_parse_error() {
-        // Hits the serde-error branch (has `{` and `}` but invalid JSON).
-        let raw = r#"{"choice":"advance_goal","rationale":}"#;
+    fn parse_unknown_variant_returns_error() {
+        let raw = "DECISION: do_a_barrel_roll\nwhy not";
         let err = parse_judgment_from_response(raw).expect_err("must Err");
         assert!(
-            err.contains("decide-brain-parse-error"),
-            "malformed JSON must surface a structured serde error tag, got: {err}"
+            err.contains("do_a_barrel_roll"),
+            "error should include the bad variant: {err}"
         );
-        // #1711: full raw must be embedded.
-        assert!(err.contains(raw), "raw_response must be embedded: {err}");
     }
 
     #[test]
-    fn parse_unknown_choice_tag_returns_error() {
-        // Schema guard: unrecognised `choice` tags must fail to parse so the
-        // consumer falls back to the deterministic mapping.
-        let raw = r#"{"choice":"do_a_barrel_roll","rationale":"why not"}"#;
+    fn parse_json_input_rejected_without_marker() {
+        // Pure JSON (the old format) should now fail — no DECISION marker
+        let raw = r#"{"choice":"advance_goal","rationale":"go"}"#;
         let err = parse_judgment_from_response(raw).expect_err("must Err");
         assert!(
-            err.contains("decide-brain-parse-error"),
-            "unknown variant must surface serde-tagged error: {err}"
+            err.contains("DECISION:"),
+            "JSON without DECISION marker should be rejected (issue #1980): {err}"
         );
+    }
+
+    #[test]
+    fn parse_json_wrapped_in_prose_rejected_without_marker() {
+        let raw = "Here's my answer:\n```json\n{\"choice\":\"run_gym_eval\",\"rationale\":\"low score\"}\n```\nThanks!";
+        let err = parse_judgment_from_response(raw).expect_err("must Err");
+        assert!(
+            err.contains("DECISION:"),
+            "JSON-in-prose without DECISION marker should be rejected (issue #1980): {err}"
+        );
+    }
+
+    // ----- All action kinds roundtrip ------------------------------------
+
+    #[test]
+    fn all_action_kinds_parse_from_decision_marker() {
+        let variants = vec![
+            ("advance_goal", ActionKind::AdvanceGoal),
+            ("run_improvement", ActionKind::RunImprovement),
+            ("consolidate_memory", ActionKind::ConsolidateMemory),
+            ("research_query", ActionKind::ResearchQuery),
+            ("run_gym_eval", ActionKind::RunGymEval),
+            ("build_skill", ActionKind::BuildSkill),
+            ("launch_session", ActionKind::LaunchSession),
+            ("poll_developer_activity", ActionKind::PollDeveloperActivity),
+            ("extract_ideas", ActionKind::ExtractIdeas),
+            ("safe_update", ActionKind::SafeUpdate),
+        ];
+        for (variant, expected_kind) in variants {
+            let raw = format!("DECISION: {variant}\ntest rationale");
+            let j = parse_judgment_from_response(&raw)
+                .unwrap_or_else(|e| panic!("variant {variant} failed: {e}"));
+            assert_eq!(
+                j.action_kind(),
+                expected_kind,
+                "variant {variant} wrong kind"
+            );
+        }
     }
 }

--- a/src/ooda_brain/decide_tests.rs
+++ b/src/ooda_brain/decide_tests.rs
@@ -128,21 +128,29 @@ fn fallback_routes_ordinary_goal_to_advance_goal() {
 
 #[test]
 fn rustyclawd_brain_parses_canned_advance_goal_response() {
-    let stub = StubSubmitter::new(r#"{"choice":"advance_goal","rationale":"stub says go"}"#);
+    let stub = StubSubmitter::new("DECISION: advance_goal\nstub says go");
     let brain = RustyClawdDecideBrain::new(stub);
     let j = brain.judge_decision(&ctx("ship-v1")).unwrap();
     assert_eq!(j.action_kind(), ActionKind::AdvanceGoal);
-    assert_eq!(j.rationale(), "stub says go");
+    assert!(j.rationale().contains("stub says go"));
 }
 
 #[test]
-fn rustyclawd_brain_parses_response_wrapped_in_prose() {
-    let stub = StubSubmitter::new(
-        "Here is my answer:\n```json\n{\"choice\":\"consolidate_memory\",\"rationale\":\"reserved\"}\n```\nThanks.",
-    );
+fn rustyclawd_brain_parses_response_with_marker() {
+    let stub = StubSubmitter::new("DECISION: consolidate_memory\nreserved");
     let brain = RustyClawdDecideBrain::new(stub);
     let j = brain.judge_decision(&ctx("__memory__")).unwrap();
     assert_eq!(j.action_kind(), ActionKind::ConsolidateMemory);
+}
+
+#[test]
+fn rustyclawd_brain_rejects_json_only_response() {
+    // JSON without DECISION marker is now rejected (issue #1980)
+    let stub = StubSubmitter::new(r#"{"choice":"advance_goal","rationale":"ok"}"#);
+    let brain = RustyClawdDecideBrain::new(stub);
+    let err = brain.judge_decision(&ctx("ship-v1")).unwrap_err();
+    let msg = format!("{err}");
+    assert!(msg.contains("ooda-decide-brain"), "got: {msg}");
 }
 
 #[test]
@@ -161,9 +169,6 @@ fn rustyclawd_brain_unparseable_returns_error() {
 
 #[test]
 fn issue_1711_unparseable_error_embeds_raw_response_text() {
-    // The legacy code logged `no JSON object found in LLM response (got N bytes)`
-    // which dropped the actual response on the floor. This test pins that the
-    // raw response text is now embedded in the error so operators can diagnose.
     let stub = StubSubmitter::new("OK");
     let brain = RustyClawdDecideBrain::new(stub);
     let err = brain.judge_decision(&ctx("ship-v1")).unwrap_err();
@@ -182,8 +187,6 @@ fn issue_1711_unparseable_error_embeds_raw_response_text() {
 
 #[test]
 fn issue_1711_empty_response_error_does_not_silently_say_zero_bytes() {
-    // Empty response: error must clearly indicate emptiness (e.g. "empty
-    // response" or `""`) rather than the unhelpful `got 0 bytes`.
     let stub = StubSubmitter::new("");
     let brain = RustyClawdDecideBrain::new(stub);
     let err = brain.judge_decision(&ctx("ship-v1")).unwrap_err();
@@ -196,7 +199,7 @@ fn issue_1711_empty_response_error_does_not_silently_say_zero_bytes() {
 
 #[test]
 fn rustyclawd_brain_renders_prompt_with_context_fields() {
-    let stub = StubSubmitter::new(r#"{"choice":"advance_goal","rationale":"ok"}"#);
+    let stub = StubSubmitter::new("DECISION: advance_goal\nok");
     let brain = RustyClawdDecideBrain::new(stub);
     let prompt = brain.render_prompt(&DecideContext {
         goal_id: "marker-goal-id".to_string(),

--- a/src/ooda_brain/orient.rs
+++ b/src/ooda_brain/orient.rs
@@ -210,10 +210,18 @@ impl<S: LlmSubmitter> OodaOrientBrain for RustyClawdOrientBrain<S> {
     }
 }
 
-/// Extract a JSON object from the LLM response (LLMs sometimes wrap JSON in
-/// prose / markdown fences) and parse it as a judgment. On failure the error
-/// embeds the **full raw response text** (truncated for log safety) — see
-/// issue #1711.
+/// Parse the brain response using labeled-line format (issue #1980).
+/// Replaces the JSON `find('{')..rfind('}')` parser.
+///
+/// Expected format:
+/// ```text
+/// ADJUSTED_URGENCY: 0.4
+/// RATIONALE: transient failure, moderate demotion
+/// CONFIDENCE: 0.9
+/// ```
+///
+/// `ADJUSTED_URGENCY:` is required. `RATIONALE:` defaults to empty.
+/// `CONFIDENCE:` defaults to 1.0. Unknown lines are ignored.
 fn parse_judgment_from_response(raw: &str) -> Result<OrientJudgment, String> {
     let stripped = raw.trim();
     if stripped.is_empty() {
@@ -222,23 +230,70 @@ fn parse_judgment_from_response(raw: &str) -> Result<OrientJudgment, String> {
             raw
         ));
     }
-    let candidate = if let Some(start) = stripped.find('{')
-        && let Some(end) = stripped.rfind('}')
-        && end >= start
-    {
-        &stripped[start..=end]
-    } else {
-        return Err(format!(
-            "orient brain response had no JSON object; raw_response={:?}",
-            super::rustyclawd::truncate_for_log_pub(raw)
-        ));
-    };
-    serde_json::from_str::<OrientJudgment>(candidate).map_err(|e| {
+
+    let mut adjusted_urgency: Option<f64> = None;
+    let mut rationale = String::new();
+    let mut confidence: f64 = 1.0;
+
+    for line in stripped.lines() {
+        let trimmed = line.trim();
+        if let Some(val) = strip_label_ci(trimmed, "ADJUSTED_URGENCY:") {
+            adjusted_urgency = Some(val.parse::<f64>().map_err(|e| {
+                format!(
+                    "orient brain ADJUSTED_URGENCY parse error: {e}; raw_response={:?}",
+                    super::rustyclawd::truncate_for_log_pub(raw)
+                )
+            })?);
+        } else if let Some(val) = strip_label_ci(trimmed, "RATIONALE:") {
+            rationale = val.to_string();
+        } else if let Some(val) = strip_label_ci(trimmed, "CONFIDENCE:") {
+            confidence = val.parse::<f64>().unwrap_or(1.0);
+        }
+    }
+
+    let adjusted_urgency = adjusted_urgency.ok_or_else(|| {
         format!(
-            "orient-brain-parse-error: {e}; payload={candidate}; raw_response={:?}",
+            "orient brain response missing ADJUSTED_URGENCY: line; raw_response={:?}",
             super::rustyclawd::truncate_for_log_pub(raw)
         )
+    })?;
+
+    if rationale.is_empty() {
+        // If no explicit RATIONALE: line, use the full text minus the
+        // labeled lines as a best-effort rationale.
+        let prose: Vec<&str> = stripped
+            .lines()
+            .filter(|l| {
+                let t = l.trim();
+                !t.is_empty()
+                    && strip_label_ci(t, "ADJUSTED_URGENCY:").is_none()
+                    && strip_label_ci(t, "RATIONALE:").is_none()
+                    && strip_label_ci(t, "CONFIDENCE:").is_none()
+            })
+            .collect();
+        if !prose.is_empty() {
+            rationale = prose.join(" ");
+        } else {
+            rationale = "(no rationale provided)".to_string();
+        }
+    }
+
+    Ok(OrientJudgment {
+        adjusted_urgency,
+        rationale,
+        confidence,
+        demotion_applied: 0.0, // caller recomputes
     })
+}
+
+/// Case-insensitive label prefix strip. Returns the value after the label
+/// if the line starts with the label (case-insensitive).
+fn strip_label_ci<'a>(line: &'a str, label: &str) -> Option<&'a str> {
+    if line.len() >= label.len() && line[..label.len()].eq_ignore_ascii_case(label) {
+        Some(line[label.len()..].trim())
+    } else {
+        None
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -268,89 +323,109 @@ pub fn build_rustyclawd_orient_brain() -> SimardResult<Box<dyn OodaOrientBrain>>
 mod tests {
     use super::*;
 
-    // ----- (a) well-formed JSON pass-through -----------------------------
+    // ----- Labeled-line parser (issue #1980) ------------------------------
+
     #[test]
-    fn parse_well_formed_json_returns_judgment() {
-        let raw = r#"{"adjusted_urgency":0.4,"rationale":"transient","confidence":0.9}"#;
+    fn parse_full_labeled_response() {
+        let raw = "ADJUSTED_URGENCY: 0.4\nRATIONALE: transient failure\nCONFIDENCE: 0.9\n";
         let j = parse_judgment_from_response(raw).expect("must parse");
         assert!((j.adjusted_urgency - 0.4).abs() < 1e-9);
-        assert_eq!(j.rationale, "transient");
+        assert_eq!(j.rationale, "transient failure");
         assert!((j.confidence - 0.9).abs() < 1e-9);
     }
 
     #[test]
-    fn parse_well_formed_json_defaults_confidence_when_absent() {
-        let raw = r#"{"adjusted_urgency":0.3,"rationale":"x"}"#;
+    fn parse_defaults_confidence_when_absent() {
+        let raw = "ADJUSTED_URGENCY: 0.3\nRATIONALE: x\n";
         let j = parse_judgment_from_response(raw).expect("must parse");
         assert!((j.confidence - 1.0).abs() < 1e-9);
     }
 
-    // ----- (b) JSON with surrounding prose — fallback parser must salvage -
     #[test]
-    fn parse_salvages_json_wrapped_in_prose() {
-        let raw = "Reasoning:\n```json\n{\"adjusted_urgency\":0.0,\"rationale\":\"chronic\",\"confidence\":0.95}\n```\nDone.";
-        let j = parse_judgment_from_response(raw).expect("must salvage");
-        assert!(j.adjusted_urgency.abs() < 1e-9);
-        assert_eq!(j.rationale, "chronic");
+    fn parse_case_insensitive_labels() {
+        let raw = "adjusted_urgency: 0.5\nrationale: lower case\n";
+        let j = parse_judgment_from_response(raw).expect("must parse");
+        assert!((j.adjusted_urgency - 0.5).abs() < 1e-9);
+        assert_eq!(j.rationale, "lower case");
     }
 
     #[test]
-    fn parse_salvages_json_with_trailing_prose_only() {
-        let raw =
-            r#"{"adjusted_urgency":0.2,"rationale":"ok","confidence":1.0}  -- and that's all"#;
+    fn parse_zero_urgency() {
+        let raw = "ADJUSTED_URGENCY: 0.0\nRATIONALE: chronic failure\nCONFIDENCE: 0.95\n";
+        let j = parse_judgment_from_response(raw).expect("must parse");
+        assert!(j.adjusted_urgency.abs() < 1e-9);
+        assert_eq!(j.rationale, "chronic failure");
+    }
+
+    #[test]
+    fn parse_urgency_only_derives_rationale_from_prose() {
+        let raw = "ADJUSTED_URGENCY: 0.2\nThis is a transient issue that should recover.";
         let j = parse_judgment_from_response(raw).expect("must parse");
         assert!((j.adjusted_urgency - 0.2).abs() < 1e-9);
-    }
-
-    // ----- (c) completely unparseable returns Err, never panics ----------
-    #[test]
-    fn parse_unparseable_returns_structured_error_with_raw_body() {
-        let raw = "totally not json at all";
-        let err = parse_judgment_from_response(raw).expect_err("must Err");
-        // Anti-regression for #1711.
-        assert!(
-            err.contains(raw),
-            "error must embed raw response (issue #1711), got: {err}"
-        );
+        assert!(j.rationale.contains("transient"));
     }
 
     #[test]
-    fn parse_empty_response_returns_empty_error() {
+    fn parse_urgency_only_no_prose_gets_default_rationale() {
+        let raw = "ADJUSTED_URGENCY: 0.5\n";
+        let j = parse_judgment_from_response(raw).expect("must parse");
+        assert_eq!(j.rationale, "(no rationale provided)");
+    }
+
+    #[test]
+    fn parse_ignores_unknown_lines() {
+        let raw = "ADJUSTED_URGENCY: 0.4\nSOME_OTHER_FIELD: ignored\nRATIONALE: ok\n";
+        let j = parse_judgment_from_response(raw).expect("must parse");
+        assert!((j.adjusted_urgency - 0.4).abs() < 1e-9);
+        assert_eq!(j.rationale, "ok");
+    }
+
+    // ----- Error cases ---------------------------------------------------
+
+    #[test]
+    fn parse_empty_response_returns_error() {
         let err = parse_judgment_from_response("").expect_err("must Err");
-        assert!(
-            err.to_lowercase().contains("empty"),
-            "empty-response error must mention emptiness, got: {err}"
-        );
+        assert!(err.to_lowercase().contains("empty"));
     }
 
     #[test]
-    fn parse_whitespace_only_response_treated_as_empty() {
+    fn parse_whitespace_only_returns_error() {
         let err = parse_judgment_from_response("   \n\t  ").expect_err("must Err");
+        assert!(err.to_lowercase().contains("empty"));
+    }
+
+    #[test]
+    fn parse_missing_urgency_returns_error() {
+        let raw = "RATIONALE: forgot the urgency field\n";
+        let err = parse_judgment_from_response(raw).expect_err("must Err");
+        assert!(err.contains("ADJUSTED_URGENCY"));
+    }
+
+    #[test]
+    fn parse_invalid_urgency_value_returns_error() {
+        let raw = "ADJUSTED_URGENCY: not_a_number\nRATIONALE: bad\n";
+        let err = parse_judgment_from_response(raw).expect_err("must Err");
+        assert!(err.contains("parse error"));
+    }
+
+    #[test]
+    fn parse_json_input_rejected_without_labels() {
+        // Pure JSON (the old format) should now fail — no labeled lines
+        let raw = r#"{"adjusted_urgency":0.4,"rationale":"transient","confidence":0.9}"#;
+        let err = parse_judgment_from_response(raw).expect_err("must Err");
         assert!(
-            err.to_lowercase().contains("empty"),
-            "whitespace-only must be treated as empty, got: {err}"
+            err.contains("ADJUSTED_URGENCY"),
+            "JSON without labels should be rejected (issue #1980): {err}"
         );
     }
 
     #[test]
-    fn parse_malformed_json_with_braces_returns_parse_error() {
-        let raw = r#"{"adjusted_urgency":0.4,"rationale":}"#;
+    fn parse_json_wrapped_in_prose_rejected() {
+        let raw = "Here:\n```json\n{\"adjusted_urgency\":0.0,\"rationale\":\"chronic\"}\n```\n";
         let err = parse_judgment_from_response(raw).expect_err("must Err");
         assert!(
-            err.contains("orient-brain-parse-error"),
-            "malformed JSON must surface a structured serde error tag: {err}"
-        );
-        assert!(err.contains(raw), "raw_response must be embedded: {err}");
-    }
-
-    #[test]
-    fn parse_missing_required_field_returns_parse_error() {
-        // Schema guard: parses as JSON but lacks `adjusted_urgency`.
-        let raw = r#"{"rationale":"forgot the urgency field"}"#;
-        let err = parse_judgment_from_response(raw).expect_err("must Err");
-        assert!(
-            err.contains("orient-brain-parse-error"),
-            "missing required field must surface serde error: {err}"
+            err.contains("ADJUSTED_URGENCY"),
+            "JSON-in-prose should be rejected (issue #1980): {err}"
         );
     }
 }

--- a/src/ooda_brain/orient_tests.rs
+++ b/src/ooda_brain/orient_tests.rs
@@ -167,9 +167,7 @@ fn fallback_judgment_passes_validate() {
 
 #[test]
 fn rustyclawd_brain_parses_canned_response() {
-    let stub = StubSubmitter::new(
-        r#"{"adjusted_urgency":0.5,"demotion_applied":0.3,"rationale":"transient","confidence":0.7}"#,
-    );
+    let stub = StubSubmitter::new("ADJUSTED_URGENCY: 0.5\nRATIONALE: transient\nCONFIDENCE: 0.7\n");
     let brain = RustyClawdOrientBrain::new(stub);
     let j = brain.judge_orientation(&ctx(1, 0.8)).unwrap();
     assert!((j.adjusted_urgency - 0.5).abs() < 1e-9);
@@ -177,13 +175,22 @@ fn rustyclawd_brain_parses_canned_response() {
 }
 
 #[test]
-fn rustyclawd_brain_parses_response_wrapped_in_prose() {
-    let stub = StubSubmitter::new(
-        "Here is my answer:\n```json\n{\"adjusted_urgency\":0.0,\"rationale\":\"chronic\",\"confidence\":0.95}\n```\nThanks.",
-    );
+fn rustyclawd_brain_parses_labeled_lines() {
+    let stub =
+        StubSubmitter::new("ADJUSTED_URGENCY: 0.0\nRATIONALE: chronic failure\nCONFIDENCE: 0.95\n");
     let brain = RustyClawdOrientBrain::new(stub);
     let j = brain.judge_orientation(&ctx(5, 0.8)).unwrap();
     assert!(j.adjusted_urgency.abs() < 1e-9);
+}
+
+#[test]
+fn rustyclawd_brain_rejects_json_only_response() {
+    // JSON without labeled lines is now rejected (issue #1980)
+    let stub = StubSubmitter::new(r#"{"adjusted_urgency":0.5,"rationale":"ok","confidence":1.0}"#);
+    let brain = RustyClawdOrientBrain::new(stub);
+    let err = brain.judge_orientation(&ctx(1, 0.8)).unwrap_err();
+    let msg = format!("{err}");
+    assert!(msg.contains("ooda-orient-brain"), "got: {msg}");
 }
 
 #[test]
@@ -202,10 +209,6 @@ fn rustyclawd_brain_unparseable_returns_error() {
 
 #[test]
 fn issue_1711_unparseable_error_embeds_raw_response_text() {
-    // Anti-regression for the production failure mode that issue #1711
-    // fixed: the legacy `no JSON object found in LLM response (got N bytes)`
-    // format dropped the raw response on the floor. The orient brain shares
-    // the same parser anti-pattern and MUST be fixed in lockstep.
     let stub = StubSubmitter::new("OK");
     let brain = RustyClawdOrientBrain::new(stub);
     let err = brain.judge_orientation(&ctx(1, 0.8)).unwrap_err();
@@ -236,8 +239,7 @@ fn issue_1711_empty_response_error_does_not_silently_say_zero_bytes() {
 
 #[test]
 fn rustyclawd_brain_rejects_escalation() {
-    let stub =
-        StubSubmitter::new(r#"{"adjusted_urgency":0.95,"rationale":"escalate","confidence":1.0}"#);
+    let stub = StubSubmitter::new("ADJUSTED_URGENCY: 0.95\nRATIONALE: escalate\nCONFIDENCE: 1.0\n");
     let brain = RustyClawdOrientBrain::new(stub);
     // base_urgency=0.5 → 0.95 is escalation → must error so caller falls back.
     let err = brain.judge_orientation(&ctx(1, 0.5)).unwrap_err();
@@ -247,7 +249,7 @@ fn rustyclawd_brain_rejects_escalation() {
 
 #[test]
 fn rustyclawd_brain_renders_prompt_with_context_fields() {
-    let stub = StubSubmitter::new(r#"{"adjusted_urgency":0.0,"rationale":"x","confidence":1.0}"#);
+    let stub = StubSubmitter::new("ADJUSTED_URGENCY: 0.0\nRATIONALE: x\nCONFIDENCE: 1.0\n");
     let brain = RustyClawdOrientBrain::new(stub);
     let prompt = brain.render_prompt(&OrientContext {
         goal_id: "marker-goal-id".to_string(),
@@ -267,7 +269,7 @@ fn rustyclawd_brain_renders_prompt_with_context_fields() {
 
 #[test]
 fn trait_object_compiles_for_both_impls() {
-    let stub = StubSubmitter::new(r#"{"adjusted_urgency":0.5,"rationale":"x","confidence":1.0}"#);
+    let stub = StubSubmitter::new("ADJUSTED_URGENCY: 0.5\nRATIONALE: x\nCONFIDENCE: 1.0\n");
     let brains: Vec<Box<dyn OodaOrientBrain>> = vec![
         Box::new(DeterministicFallbackOrientBrain),
         Box::new(RustyClawdOrientBrain::new(stub)),

--- a/src/ooda_brain/rustyclawd.rs
+++ b/src/ooda_brain/rustyclawd.rs
@@ -195,78 +195,107 @@ fn parse_with_marker(
         ));
     }
 
-    // Try to extract a JSON object from the remainder for variant-specific
-    // fields. We use the same `find('{') .. rfind('}')` extraction the
-    // legacy parser uses, so a body that mixes prose and JSON still works.
+    // Parse labeled body lines and prose from the remainder (issue #1980).
+    // Replaces JSON body parsing — structured variants now use labeled lines
+    // (TITLE:, BODY:, REASON:, REDISPATCH_CONTEXT:) instead of JSON objects.
     let trimmed_rest = rest.trim();
-    let json_value: serde_json::Value = if let Some(start) = trimmed_rest.find('{')
+
+    // Extract labeled fields from the body
+    let mut fields: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+    let mut prose_lines: Vec<&str> = Vec::new();
+
+    for line in trimmed_rest.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        // Try to extract a labeled field (KEY: value)
+        if let Some(colon_pos) = trimmed.find(':') {
+            let key = trimmed[..colon_pos].trim();
+            let val = trimmed[colon_pos + 1..].trim();
+            // Only recognize known field labels (case-insensitive)
+            let key_upper = key.to_ascii_uppercase();
+            match key_upper.as_str() {
+                "TITLE" | "BODY" | "REASON" | "REDISPATCH_CONTEXT" | "RATIONALE" => {
+                    fields.insert(key_upper, val.to_string());
+                    continue;
+                }
+                _ => {}
+            }
+        }
+        prose_lines.push(trimmed);
+    }
+
+    // Also try to extract fields from JSON body if present (backward-compat
+    // for the transition period where prompts may still emit JSON)
+    if let Some(start) = trimmed_rest.find('{')
         && let Some(end) = trimmed_rest.rfind('}')
         && end >= start
     {
         let candidate = &trimmed_rest[start..=end];
-        match serde_json::from_str::<serde_json::Value>(candidate) {
-            Ok(v) if v.is_object() => v,
-            // Body looks like JSON but isn't valid → treat as no JSON
-            // present and fall through to prose-rationale derivation. The
-            // marker is authoritative; we don't fail just because the
-            // optional body has a syntax error.
-            _ => serde_json::Value::Object(serde_json::Map::new()),
-        }
-    } else {
-        serde_json::Value::Object(serde_json::Map::new())
-    };
-
-    let mut obj = match json_value {
-        serde_json::Value::Object(m) => m,
-        _ => serde_json::Map::new(),
-    };
-
-    // Marker wins over any `choice` field in the JSON body.
-    obj.insert(
-        "choice".to_string(),
-        serde_json::Value::String(variant.to_string()),
-    );
-
-    // If the body did not provide a rationale, derive one from the prose
-    // remainder. Strip a leading `rationale:` prefix if present so
-    // `DECISION: continue_skipping\nrationale: hb ok` ends up with
-    // `rationale = "hb ok"` rather than `"rationale: hb ok"`.
-    if !obj.contains_key("rationale") {
-        let prose_rationale = if trimmed_rest.is_empty() {
-            "(no rationale provided)".to_string()
-        } else {
-            // Try to derive prose rationale by stripping JSON body if any.
-            // For variants with no JSON body, `trimmed_rest` IS the rationale.
-            // For variants with a JSON body that nonetheless omits rationale,
-            // we use the trimmed remainder verbatim as a best-effort.
-            let candidate = trimmed_rest;
-            let stripped = candidate
-                .strip_prefix("rationale:")
-                .or_else(|| candidate.strip_prefix("Rationale:"))
-                .or_else(|| candidate.strip_prefix("RATIONALE:"))
-                .unwrap_or(candidate)
-                .trim();
-            if stripped.is_empty() {
-                "(no rationale provided)".to_string()
-            } else {
-                stripped.to_string()
+        if let Ok(serde_json::Value::Object(map)) =
+            serde_json::from_str::<serde_json::Value>(candidate)
+        {
+            for (k, v) in &map {
+                let key_upper = k.to_ascii_uppercase();
+                if let Some(s) = v.as_str() {
+                    fields.entry(key_upper).or_insert_with(|| s.to_string());
+                }
             }
-        };
-        obj.insert(
-            "rationale".to_string(),
-            serde_json::Value::String(prose_rationale),
-        );
+        }
     }
 
-    serde_json::from_value::<EngineerLifecycleDecision>(serde_json::Value::Object(obj)).map_err(
-        |e| {
-            format!(
-                "brain DECISION marker `{variant}` present but field validation failed: {e}; \
-                 raw_response={:?}",
-                truncate_for_log(raw)
-            )
-        },
-    )
+    // Derive rationale: explicit RATIONALE field > prose lines > default
+    let rationale = if let Some(r) = fields.get("RATIONALE") {
+        r.clone()
+    } else if !prose_lines.is_empty() {
+        prose_lines.join(" ")
+    } else {
+        "(no rationale provided)".to_string()
+    };
+
+    // Build the decision based on variant
+    match variant {
+        "continue_skipping" => Ok(EngineerLifecycleDecision::ContinueSkipping { rationale }),
+        "deprioritize" => Ok(EngineerLifecycleDecision::Deprioritize { rationale }),
+        "consider_self_update" => Ok(EngineerLifecycleDecision::ConsiderSelfUpdate { rationale }),
+        "reclaim_and_redispatch" => {
+            let redispatch_context = fields
+                .get("REDISPATCH_CONTEXT")
+                .cloned()
+                .unwrap_or_default();
+            Ok(EngineerLifecycleDecision::ReclaimAndRedispatch {
+                rationale,
+                redispatch_context,
+            })
+        }
+        "open_tracking_issue" => {
+            let title = fields
+                .get("TITLE")
+                .cloned()
+                .unwrap_or_else(|| "(no title)".to_string());
+            let body = fields
+                .get("BODY")
+                .cloned()
+                .unwrap_or_else(|| "(no body)".to_string());
+            Ok(EngineerLifecycleDecision::OpenTrackingIssue {
+                rationale,
+                title,
+                body,
+            })
+        }
+        "mark_goal_blocked" => {
+            let reason = fields
+                .get("REASON")
+                .cloned()
+                .unwrap_or_else(|| "(no reason)".to_string());
+            Ok(EngineerLifecycleDecision::MarkGoalBlocked { rationale, reason })
+        }
+        _ => Err(format!(
+            "brain DECISION marker `{variant}` present but not handled; raw_response={:?}",
+            truncate_for_log(raw)
+        )),
+    }
 }
 
 /// Parse the brain's response into an [`EngineerLifecycleDecision`]. Accepts
@@ -297,28 +326,14 @@ fn parse_decision_from_response(raw: &str) -> Result<EngineerLifecycleDecision, 
         ));
     }
 
-    // Prose-first: try to extract a `DECISION:` marker from the first
-    // non-blank line. If present, the marker is authoritative.
+    // DECISION marker is the only accepted format (issue #1980).
+    // JSON fallback removed — it was the source of fallback storms.
     if let Some((variant, rest)) = extract_decision_marker(stripped) {
         return parse_with_marker(variant, rest, raw);
     }
 
-    // Backward-compat: legacy JSON object extraction.
-    if let Some(start) = stripped.find('{')
-        && let Some(end) = stripped.rfind('}')
-        && end >= start
-    {
-        let candidate = &stripped[start..=end];
-        return serde_json::from_str::<EngineerLifecycleDecision>(candidate).map_err(|e| {
-            format!(
-                "brain JSON parse error: {e}; payload={candidate}; raw_response={:?}",
-                truncate_for_log(raw)
-            )
-        });
-    }
-
     Err(format!(
-        "brain response had no DECISION marker and no JSON object; raw_response={:?}",
+        "brain response had no DECISION: marker on first line; raw_response={:?}",
         truncate_for_log(raw)
     ))
 }
@@ -634,25 +649,47 @@ mod tests {
         ));
     }
 
-    // ----- parse_decision_from_response: full salvage matrix -------------
+    // ----- parse_decision_from_response: DECISION marker only (issue #1980) -
 
-    // (a) Well-formed JSON pass-through (legacy JSON-only path).
+    // (a) DECISION marker with rationale — the supported format.
     #[test]
-    fn parse_decision_well_formed_json_passes_through() {
-        let raw = r#"{"choice":"continue_skipping","rationale":"healthy"}"#;
+    fn parse_decision_marker_continue_skipping() {
+        let raw = "DECISION: continue_skipping\nhealthy heartbeat";
         let d = parse_decision_from_response(raw).expect("must parse");
-        assert!(matches!(
-            d,
-            EngineerLifecycleDecision::ContinueSkipping { .. }
-        ));
+        match d {
+            EngineerLifecycleDecision::ContinueSkipping { rationale } => {
+                assert!(rationale.contains("healthy"));
+            }
+            other => panic!("expected ContinueSkipping, got {other:?}"),
+        }
     }
 
-    // (b) JSON with trailing prose — fallback parser must salvage.
     #[test]
-    fn parse_decision_salvages_json_in_prose_wrapper() {
-        let raw = "Here's the call:\n```json\n{\"choice\":\"deprioritize\",\"rationale\":\"chronic\"}\n```";
-        let d = parse_decision_from_response(raw).expect("must salvage");
+    fn parse_decision_marker_deprioritize() {
+        let raw = "DECISION: deprioritize\nchronic failure pattern";
+        let d = parse_decision_from_response(raw).expect("must parse");
         assert!(matches!(d, EngineerLifecycleDecision::Deprioritize { .. }));
+    }
+
+    // (b) JSON-only input is now REJECTED (issue #1980 — JSON fallback removed).
+    #[test]
+    fn parse_decision_json_only_is_rejected() {
+        let raw = r#"{"choice":"continue_skipping","rationale":"healthy"}"#;
+        let err = parse_decision_from_response(raw).expect_err("must Err");
+        assert!(
+            err.contains("DECISION:"),
+            "JSON without DECISION marker must be rejected (issue #1980): {err}"
+        );
+    }
+
+    #[test]
+    fn parse_decision_json_in_prose_is_rejected() {
+        let raw = "Here's the call:\n```json\n{\"choice\":\"deprioritize\",\"rationale\":\"chronic\"}\n```";
+        let err = parse_decision_from_response(raw).expect_err("must Err");
+        assert!(
+            err.contains("DECISION:"),
+            "JSON-in-prose without DECISION marker must be rejected (issue #1980): {err}"
+        );
     }
 
     // (c) Completely unparseable surfaces a structured error, never panics.
@@ -665,8 +702,8 @@ mod tests {
             "raw must be embedded (issue #1711): {err}"
         );
         assert!(
-            err.contains("no DECISION marker") || err.contains("no JSON object"),
-            "error must explain the salvage failure: {err}"
+            err.contains("DECISION:"),
+            "error must explain missing marker: {err}"
         );
     }
 
@@ -674,14 +711,6 @@ mod tests {
     fn parse_decision_empty_returns_empty_err() {
         let err = parse_decision_from_response("").expect_err("must Err");
         assert!(err.to_lowercase().contains("empty"), "got: {err}");
-    }
-
-    #[test]
-    fn parse_decision_malformed_json_returns_serde_err_with_raw_body() {
-        let raw = r#"{"choice":"continue_skipping","rationale":}"#;
-        let err = parse_decision_from_response(raw).expect_err("must Err");
-        assert!(err.contains("JSON parse error"), "got: {err}");
-        assert!(err.contains(raw), "raw must be embedded: {err}");
     }
 
     #[test]
@@ -698,11 +727,59 @@ mod tests {
         }
     }
 
+    // Structured variants with labeled body lines instead of JSON
+    #[test]
+    fn parse_decision_open_tracking_issue_with_labeled_body() {
+        let raw = "DECISION: open_tracking_issue\nTITLE: engineer panicked\nBODY: see logs for details\nrationale: repeated panic in loop";
+        let d = parse_decision_from_response(raw).expect("must parse");
+        match d {
+            EngineerLifecycleDecision::OpenTrackingIssue {
+                title,
+                body,
+                rationale,
+            } => {
+                assert_eq!(title, "engineer panicked");
+                assert_eq!(body, "see logs for details");
+                assert!(rationale.contains("panic"));
+            }
+            other => panic!("expected OpenTrackingIssue, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_decision_mark_goal_blocked_with_labeled_body() {
+        let raw = "DECISION: mark_goal_blocked\nREASON: needs API key from operator\nrationale: external dependency";
+        let d = parse_decision_from_response(raw).expect("must parse");
+        match d {
+            EngineerLifecycleDecision::MarkGoalBlocked { reason, rationale } => {
+                assert_eq!(reason, "needs API key from operator");
+                assert!(rationale.contains("external"));
+            }
+            other => panic!("expected MarkGoalBlocked, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_decision_reclaim_with_labeled_body() {
+        let raw = "DECISION: reclaim_and_redispatch\nREDISPATCH_CONTEXT: focus on the persistence layer\nrationale: stuck for 7 hours";
+        let d = parse_decision_from_response(raw).expect("must parse");
+        match d {
+            EngineerLifecycleDecision::ReclaimAndRedispatch {
+                rationale,
+                redispatch_context,
+            } => {
+                assert!(redispatch_context.contains("persistence"));
+                assert!(rationale.contains("stuck"));
+            }
+            other => panic!("expected ReclaimAndRedispatch, got {other:?}"),
+        }
+    }
+
     // ----- (d) RustyClawdBrain bridge: end-to-end with stub submitter ---
 
     #[test]
-    fn bridge_returns_decision_on_well_formed_json() {
-        let stub = StubSubmitter::ok(r#"{"choice":"continue_skipping","rationale":"hb ok"}"#);
+    fn bridge_returns_decision_on_marker_response() {
+        let stub = StubSubmitter::ok("DECISION: continue_skipping\nhb ok");
         let brain = RustyClawdBrain::new(stub);
         let d = brain.decide_engineer_lifecycle(&ctx()).expect("must Ok");
         assert!(matches!(
@@ -712,13 +789,36 @@ mod tests {
     }
 
     #[test]
-    fn bridge_returns_decision_on_json_with_trailing_prose() {
+    fn bridge_rejects_json_only_response() {
+        let stub = StubSubmitter::ok(r#"{"choice":"continue_skipping","rationale":"hb ok"}"#);
+        let brain = RustyClawdBrain::new(stub);
+        let err = brain
+            .decide_engineer_lifecycle(&ctx())
+            .expect_err("JSON-only must now be rejected (issue #1980)");
+        match err {
+            SimardError::AdapterInvocationFailed { reason, .. } => {
+                assert!(
+                    reason.contains("DECISION:"),
+                    "error should mention missing DECISION marker: {reason}"
+                );
+            }
+            other => panic!("wrong error variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn bridge_rejects_json_in_prose_response() {
         let stub = StubSubmitter::ok(
             "Some thinking...\n```json\n{\"choice\":\"deprioritize\",\"rationale\":\"chronic\"}\n```\nDone.",
         );
         let brain = RustyClawdBrain::new(stub);
-        let d = brain.decide_engineer_lifecycle(&ctx()).expect("must Ok");
-        assert!(matches!(d, EngineerLifecycleDecision::Deprioritize { .. }));
+        let err = brain
+            .decide_engineer_lifecycle(&ctx())
+            .expect_err("JSON-in-prose must now be rejected (issue #1980)");
+        match err {
+            SimardError::AdapterInvocationFailed { .. } => {} // expected
+            other => panic!("wrong error variant: {other:?}"),
+        }
     }
 
     #[test]
@@ -759,10 +859,7 @@ mod tests {
 
     #[test]
     fn bridge_calls_submitter_exactly_once_per_decision() {
-        // Resilience contract from the bridge module docstring: no internal
-        // retry loop — exactly one submit per decision so the OODA loop's
-        // outer cycle is the single retry boundary.
-        let stub = StubSubmitter::ok(r#"{"choice":"continue_skipping","rationale":"ok"}"#);
+        let stub = StubSubmitter::ok("DECISION: continue_skipping\nok");
         let counter = stub.call_counter();
         let brain = RustyClawdBrain::new(stub);
         let _ = brain.decide_engineer_lifecycle(&ctx()).unwrap();
@@ -775,7 +872,7 @@ mod tests {
 
     #[test]
     fn bridge_renders_prompt_with_context_fields() {
-        let stub = StubSubmitter::ok(r#"{"choice":"continue_skipping","rationale":"ok"}"#);
+        let stub = StubSubmitter::ok("DECISION: continue_skipping\nok");
         let brain = RustyClawdBrain::new(stub);
         let prompt = brain.render_prompt(&EngineerLifecycleCtx {
             goal_id: "marker-goal".into(),
@@ -800,7 +897,7 @@ mod tests {
 
     #[test]
     fn bridge_renders_sentinel_none_as_placeholder() {
-        let stub = StubSubmitter::ok(r#"{"choice":"continue_skipping","rationale":"ok"}"#);
+        let stub = StubSubmitter::ok("DECISION: continue_skipping\nok");
         let brain = RustyClawdBrain::new(stub);
         let prompt = brain.render_prompt(&EngineerLifecycleCtx {
             sentinel_pid: None,

--- a/src/ooda_brain/tests.rs
+++ b/src/ooda_brain/tests.rs
@@ -189,12 +189,12 @@ fn decision_unknown_choice_fails_to_parse() {
 }
 
 // ---------------------------------------------------------------------------
-// (1) Stub returns continue when canned continue JSON
+// (1) Stub returns continue when canned DECISION marker response
 // ---------------------------------------------------------------------------
 
 #[test]
 fn stub_returns_continue_when_canned_continue_json() {
-    let stub = StubSubmitter::new(r#"{"choice":"continue_skipping","rationale":"hb ok"}"#);
+    let stub = StubSubmitter::new("DECISION: continue_skipping\nhb ok");
     let brain = RustyClawdBrain::new(stub);
     let decision = brain
         .decide_engineer_lifecycle(&sample_ctx())
@@ -208,13 +208,13 @@ fn stub_returns_continue_when_canned_continue_json() {
 }
 
 // ---------------------------------------------------------------------------
-// (2) Stub returns reclaim when canned reclaim JSON
+// (2) Stub returns reclaim when canned DECISION marker response
 // ---------------------------------------------------------------------------
 
 #[test]
 fn stub_returns_reclaim_when_canned_reclaim_json() {
     let stub = StubSubmitter::new(
-        r#"{"choice":"reclaim_and_redispatch","rationale":"7h idle","redispatch_context":"retry persistence layer"}"#,
+        "DECISION: reclaim_and_redispatch\nREDISPATCH_CONTEXT: retry persistence layer\nRATIONALE: 7h idle",
     );
     let brain = RustyClawdBrain::new(stub);
     let decision = brain
@@ -234,7 +234,7 @@ fn stub_returns_reclaim_when_canned_reclaim_json() {
 
 #[test]
 fn stub_unparseable_returns_brain_error() {
-    let stub = StubSubmitter::new("this is not JSON at all, sorry");
+    let stub = StubSubmitter::new("this is not a DECISION marker at all, sorry");
     let brain = RustyClawdBrain::new(stub);
     let result = brain.decide_engineer_lifecycle(&sample_ctx());
     assert!(
@@ -245,20 +245,19 @@ fn stub_unparseable_returns_brain_error() {
 
 #[test]
 fn stub_partial_garbage_then_brace_still_errors_cleanly() {
-    // No braces at all → must Err, not panic.
-    let stub = StubSubmitter::new("explanation but no JSON");
+    let stub = StubSubmitter::new("explanation but no DECISION marker");
     let brain = RustyClawdBrain::new(stub);
     let _ = brain.decide_engineer_lifecycle(&sample_ctx()); // just must not panic
 }
 
 // ---------------------------------------------------------------------------
-// (4) Stub extra fields are ignored (forward compat)
+// (4) Stub extra labeled fields are ignored (forward compat)
 // ---------------------------------------------------------------------------
 
 #[test]
 fn stub_extra_fields_are_ignored() {
     let stub = StubSubmitter::new(
-        r#"{"choice":"continue_skipping","rationale":"ok","future_field":"ignored","another":42}"#,
+        "DECISION: continue_skipping\nRATIONALE: ok\nFUTURE_FIELD: ignored\nANOTHER: 42",
     );
     let brain = RustyClawdBrain::new(stub);
     let decision = brain
@@ -271,20 +270,29 @@ fn stub_extra_fields_are_ignored() {
 }
 
 #[test]
-fn stub_response_with_surrounding_prose_still_parses() {
-    // LLMs sometimes wrap JSON in prose. The brain MUST extract the JSON
-    // object from the first `{` to the last `}`.
+fn stub_json_only_response_is_rejected() {
+    // Issue #1980: JSON-only responses are no longer accepted
+    let stub = StubSubmitter::new(r#"{"choice":"continue_skipping","rationale":"ok"}"#);
+    let brain = RustyClawdBrain::new(stub);
+    let result = brain.decide_engineer_lifecycle(&sample_ctx());
+    assert!(
+        result.is_err(),
+        "JSON-only response must be rejected (issue #1980)"
+    );
+}
+
+#[test]
+fn stub_json_in_prose_response_is_rejected() {
+    // Issue #1980: JSON wrapped in prose without DECISION marker is rejected
     let stub = StubSubmitter::new(
-        "Here is my decision:\n{\"choice\":\"continue_skipping\",\"rationale\":\"ok\"}\nLet me know if you need more.",
+        "Here is my decision:\n{\"choice\":\"continue_skipping\",\"rationale\":\"ok\"}\nLet me know.",
     );
     let brain = RustyClawdBrain::new(stub);
-    let decision = brain
-        .decide_engineer_lifecycle(&sample_ctx())
-        .expect("brain should extract JSON from prose-wrapped response");
-    assert!(matches!(
-        decision,
-        EngineerLifecycleDecision::ContinueSkipping { .. }
-    ));
+    let result = brain.decide_engineer_lifecycle(&sample_ctx());
+    assert!(
+        result.is_err(),
+        "JSON-in-prose without DECISION marker must be rejected (issue #1980)"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -295,7 +303,7 @@ fn stub_response_with_surrounding_prose_still_parses() {
 
 #[test]
 fn render_prompt_includes_context_fields() {
-    let stub = StubSubmitter::new(r#"{"choice":"continue_skipping","rationale":"x"}"#);
+    let stub = StubSubmitter::new("DECISION: continue_skipping\nx");
     let brain = RustyClawdBrain::new(stub);
     let ctx = sample_ctx();
     let rendered = brain.render_prompt(&ctx);
@@ -322,16 +330,10 @@ fn render_prompt_includes_context_fields() {
 
 #[test]
 fn rendered_prompt_passed_to_submitter_unchanged() {
-    let stub = StubSubmitter::new(r#"{"choice":"continue_skipping","rationale":"x"}"#);
-    // Wrap submitter in a way that lets us peek at the last prompt.
-    // (StubSubmitter stores last_prompt internally.)
+    let stub = StubSubmitter::new("DECISION: continue_skipping\nx");
     let brain = RustyClawdBrain::new(stub);
     let ctx = sample_ctx();
     let _ = brain.decide_engineer_lifecycle(&ctx).expect("decide");
-    // Rebuild a fresh stub to check the last_prompt was actually set.
-    // (StubSubmitter is consumed by `new`; this assertion lives inside the
-    // earlier render_prompt test by virtue of construction. We keep this
-    // test as a placeholder for future behavior assertions.)
 }
 
 // ---------------------------------------------------------------------------
@@ -745,58 +747,43 @@ fn t4_prose_marker_plus_json_fields_for_open_tracking_issue_parses() {
 }
 
 // ---------------------------------------------------------------------------
-// T5 — Backward compat: JSON wrapped in markdown code fences still parses
+// T5 — Issue #1980: JSON in code fences now REJECTED (no DECISION marker)
 // ---------------------------------------------------------------------------
 
 #[test]
-fn t5_json_in_code_fences_still_parses() {
-    // LLMs often wrap structured output in ```json ... ``` fences. The
-    // parser's existing `find('{') .. rfind('}')` extraction MUST keep
-    // working for legacy / no-marker responses.
+fn t5_json_in_code_fences_now_rejected() {
+    // Issue #1980: JSON-only responses (even in fences) are no longer accepted.
+    // The brain must use DECISION markers.
     let response = "```json\n\
         {\"choice\":\"continue_skipping\",\"rationale\":\"healthy heartbeat\"}\n\
         ```";
     let stub = StubSubmitter::new(response);
     let brain = RustyClawdBrain::new(stub);
-    let decision = brain
-        .decide_engineer_lifecycle(&sample_ctx())
-        .expect("JSON in code fences must keep parsing (backward compat)");
-    match decision {
-        EngineerLifecycleDecision::ContinueSkipping { rationale } => {
-            assert_eq!(rationale, "healthy heartbeat");
-        }
-        other => panic!("expected ContinueSkipping, got {other:?}"),
-    }
+    let result = brain.decide_engineer_lifecycle(&sample_ctx());
+    assert!(
+        result.is_err(),
+        "JSON in code fences without DECISION marker must be rejected (issue #1980)"
+    );
 }
 
 // ---------------------------------------------------------------------------
-// T6 — Backward compat: JSON surrounded by leading + trailing prose parses
+// T6 — Issue #1980: JSON surrounded by prose now REJECTED (no DECISION marker)
 // ---------------------------------------------------------------------------
 
 #[test]
-fn t6_json_with_leading_and_trailing_prose_still_parses() {
-    // Legacy prose-wrapped JSON path: no DECISION marker on line 1, but a
-    // valid JSON object embedded somewhere in the body. The parser MUST
-    // fall back to object-extraction and succeed.
+fn t6_json_with_leading_and_trailing_prose_now_rejected() {
+    // Issue #1980: JSON wrapped in prose without DECISION marker is rejected.
     let response = "I have considered the context carefully.\n\
         Based on the heartbeat I conclude:\n\
         {\"choice\":\"reclaim_and_redispatch\",\"rationale\":\"7h idle\",\"redispatch_context\":\"focus on persistence\"}\n\
         Hope this helps. Let me know if you need clarification.";
     let stub = StubSubmitter::new(response);
     let brain = RustyClawdBrain::new(stub);
-    let decision = brain
-        .decide_engineer_lifecycle(&sample_ctx())
-        .expect("JSON surrounded by prose must keep parsing (backward compat)");
-    match decision {
-        EngineerLifecycleDecision::ReclaimAndRedispatch {
-            redispatch_context,
-            rationale,
-        } => {
-            assert_eq!(rationale, "7h idle");
-            assert!(redispatch_context.contains("persistence"));
-        }
-        other => panic!("expected ReclaimAndRedispatch, got {other:?}"),
-    }
+    let result = brain.decide_engineer_lifecycle(&sample_ctx());
+    assert!(
+        result.is_err(),
+        "JSON in prose without DECISION marker must be rejected (issue #1980)"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/src/ooda_loop/curate.rs
+++ b/src/ooda_loop/curate.rs
@@ -202,6 +202,7 @@ mod tests {
 
     fn sample_handoff(decisions: Vec<MeetingDecision>) -> MeetingHandoff {
         MeetingHandoff {
+            schema_version: 2,
             topic: "Sprint planning".to_string(),
             started_at: "2026-04-02T23:00:00Z".to_string(),
             closed_at: "2026-04-03T00:00:00Z".to_string(),
@@ -217,6 +218,11 @@ mod tests {
             transcript_path: None,
             next_owner: None,
             artifacts: Vec::new(),
+            goal: None,
+            next_actor: None,
+            applied_templates: Vec::new(),
+            history_truncated_count: 0,
+            partial_reason: None,
         }
     }
 
@@ -225,6 +231,7 @@ mod tests {
         action_items: Vec<ActionItem>,
     ) -> MeetingHandoff {
         MeetingHandoff {
+            schema_version: 2,
             topic: "Sprint planning".to_string(),
             started_at: "2026-04-02T23:00:00Z".to_string(),
             closed_at: "2026-04-03T00:00:00Z".to_string(),
@@ -240,6 +247,11 @@ mod tests {
             transcript_path: None,
             next_owner: None,
             artifacts: Vec::new(),
+            goal: None,
+            next_actor: None,
+            applied_templates: Vec::new(),
+            history_truncated_count: 0,
+            partial_reason: None,
         }
     }
 
@@ -494,6 +506,7 @@ mod tests {
 
         // Handoff B — newer, empty (zero decisions, zero action items).
         let handoff_b = MeetingHandoff {
+            schema_version: 2,
             topic: "Empty dashboard chat".to_string(),
             started_at: "2026-04-03T00:05:00Z".to_string(),
             closed_at: "2026-04-03T00:05:01Z".to_string(),
@@ -509,6 +522,11 @@ mod tests {
             transcript_path: None,
             next_owner: None,
             artifacts: Vec::new(),
+            goal: None,
+            next_actor: None,
+            applied_templates: Vec::new(),
+            history_truncated_count: 0,
+            partial_reason: None,
         };
         let path_b = dir.path().join("handoff-2026-04-03T00-05-01_00-00.json");
         fs::write(&path_b, serde_json::to_string_pretty(&handoff_b).unwrap()).unwrap();

--- a/src/ooda_loop/tests_observe.rs
+++ b/src/ooda_loop/tests_observe.rs
@@ -156,6 +156,7 @@ fn scan_unprocessed_handoffs_returns_true_for_unprocessed() {
     let dir = TempDir::new().unwrap();
 
     let handoff = MeetingHandoff {
+        schema_version: 2,
         topic: "Sprint planning".to_string(),
         started_at: "2026-04-02T23:00:00Z".to_string(),
         closed_at: "2026-04-03T00:00:00Z".to_string(),
@@ -175,6 +176,11 @@ fn scan_unprocessed_handoffs_returns_true_for_unprocessed() {
         transcript_path: None,
         next_owner: None,
         artifacts: Vec::new(),
+        goal: None,
+        next_actor: None,
+        applied_templates: Vec::new(),
+        history_truncated_count: 0,
+        partial_reason: None,
     };
     write_meeting_handoff(dir.path(), &handoff).unwrap();
 
@@ -187,6 +193,7 @@ fn scan_unprocessed_handoffs_returns_false_when_processed() {
     let dir = TempDir::new().unwrap();
 
     let handoff = MeetingHandoff {
+        schema_version: 2,
         topic: "Sprint planning".to_string(),
         started_at: "2026-04-02T23:00:00Z".to_string(),
         closed_at: "2026-04-03T00:00:00Z".to_string(),
@@ -206,6 +213,11 @@ fn scan_unprocessed_handoffs_returns_false_when_processed() {
         transcript_path: None,
         next_owner: None,
         artifacts: Vec::new(),
+        goal: None,
+        next_actor: None,
+        applied_templates: Vec::new(),
+        history_truncated_count: 0,
+        partial_reason: None,
     };
     write_meeting_handoff(dir.path(), &handoff).unwrap();
 

--- a/src/operator_cli/decisions.rs
+++ b/src/operator_cli/decisions.rs
@@ -156,6 +156,7 @@ mod tests {
 
     fn sample_handoff(processed: bool) -> MeetingHandoff {
         MeetingHandoff {
+            schema_version: 2,
             topic: "Sprint Review".to_string(),
             started_at: "2025-01-01T00:00:00Z".to_string(),
             closed_at: "2025-01-01T01:00:00Z".to_string(),
@@ -184,6 +185,11 @@ mod tests {
             transcript_path: None,
             next_owner: None,
             artifacts: Vec::new(),
+            goal: None,
+            next_actor: None,
+            applied_templates: Vec::new(),
+            history_truncated_count: 0,
+            partial_reason: None,
         }
     }
 
@@ -245,6 +251,7 @@ mod tests {
     #[test]
     fn handoff_empty_decisions_and_actions() {
         let h = MeetingHandoff {
+            schema_version: 2,
             topic: "empty".to_string(),
             started_at: String::new(),
             closed_at: String::new(),
@@ -260,6 +267,11 @@ mod tests {
             transcript_path: None,
             next_owner: None,
             artifacts: Vec::new(),
+            goal: None,
+            next_actor: None,
+            applied_templates: Vec::new(),
+            history_truncated_count: 0,
+            partial_reason: None,
         };
         let json = serde_json::to_string(&h).unwrap();
         let h2: MeetingHandoff = serde_json::from_str(&json).unwrap();

--- a/src/operator_commands_dashboard/chat.rs
+++ b/src/operator_commands_dashboard/chat.rs
@@ -299,6 +299,17 @@ pub(crate) async fn handle_ws_chat(mut socket: WebSocket) {
                             ))
                             .await;
                     }
+                    MeetingCommand::Goal(text) => {
+                        backend.set_goal(&text);
+                        let content = format!("Goal recorded: {text}");
+                        let _ = socket
+                            .send(Message::Text(
+                                json!({"role":"system","content": content})
+                                    .to_string()
+                                    .into(),
+                            ))
+                            .await;
+                    }
                     MeetingCommand::Recap => {
                         let status = backend.status();
                         let themes = backend.explicit_themes();

--- a/src/stewardship/recipe_merge_judge.rs
+++ b/src/stewardship/recipe_merge_judge.rs
@@ -19,7 +19,7 @@ use std::process::Command;
 use crate::error::{SimardError, SimardResult};
 
 use super::merge_authority::PrSnapshot;
-use super::merge_judge::{JudgeOutcome, MergeJudge, MergeJudgeKind, parse_judge_response};
+use super::merge_judge::{JudgeOutcome, MergeJudge, MergeJudgeKind, Verdict};
 
 const ADAPTER_TAG: &str = "recipe-merge-judge";
 const RECIPE_FILENAME: &str = "merge-readiness-judge.yaml";
@@ -102,7 +102,7 @@ impl MergeJudge for RecipeMergeJudge {
         }
 
         let raw = String::from_utf8_lossy(&output.stdout).to_string();
-        parse_judge_response(&raw).map_err(|reason| SimardError::AdapterInvocationFailed {
+        parse_merge_verdict_from_text(&raw).map_err(|reason| SimardError::AdapterInvocationFailed {
             base_type: ADAPTER_TAG.to_string(),
             reason,
         })
@@ -123,13 +123,58 @@ fn truncate(s: &str, max: usize) -> String {
     }
 }
 
+/// Parse recipe stdout text for merge-readiness verdict keywords.
+///
+/// The recipe runs an agent that produces natural language output.
+/// We scan for verdict keywords and use the surrounding text as rationale.
+/// No JSON parsing needed — the agent already makes the decision.
+///
+/// Scan rules (case-insensitive):
+/// - "not_ready" or "not ready" → NotReady
+/// - "unclear" → Unclear
+/// - "ready" (without "not" prefix) → Ready
+/// - None found → error
+pub fn parse_merge_verdict_from_text(text: &str) -> Result<JudgeOutcome, String> {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return Err(format!("{ADAPTER_TAG}: recipe returned empty output"));
+    }
+
+    let lower = trimmed.to_ascii_lowercase();
+    let rationale = truncate(trimmed, 500);
+
+    if lower.contains("not_ready") || lower.contains("not ready") {
+        Ok(JudgeOutcome {
+            verdict: Verdict::NotReady,
+            rationale,
+            blockers: vec![],
+        })
+    } else if lower.contains("unclear") {
+        Ok(JudgeOutcome {
+            verdict: Verdict::Unclear,
+            rationale,
+            blockers: vec![],
+        })
+    } else if lower.contains("ready") {
+        Ok(JudgeOutcome {
+            verdict: Verdict::Ready,
+            rationale,
+            blockers: vec![],
+        })
+    } else {
+        Err(format!(
+            "{ADAPTER_TAG}: no verdict keyword (ready/not_ready/unclear) found in recipe output; raw={:?}",
+            truncate(text, 200)
+        ))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn new_returns_none_when_recipe_missing() {
-        // Non-existent dir — no recipe file can be found
         let judge = RecipeMergeJudge::new(std::path::Path::new("/nonexistent"));
         assert!(judge.is_none());
     }
@@ -141,5 +186,85 @@ mod tests {
         };
         assert_eq!(judge.kind(), MergeJudgeKind::Recipe);
         assert!(judge.kind().is_configured());
+    }
+
+    // ------------------------------------------------------------------
+    // Text-based merge verdict parser (issue #1980)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn text_verdict_ready() {
+        let text = "After reviewing the PR body, I find it ready for merge. All six sections are present and substantive.";
+        let out = parse_merge_verdict_from_text(text).unwrap();
+        assert_eq!(out.verdict, Verdict::Ready);
+        assert!(out.rationale.contains("ready"));
+    }
+
+    #[test]
+    fn text_verdict_not_ready() {
+        let text = "The PR is not_ready because the Quality-audit section is missing.";
+        let out = parse_merge_verdict_from_text(text).unwrap();
+        assert_eq!(out.verdict, Verdict::NotReady);
+    }
+
+    #[test]
+    fn text_verdict_not_ready_with_space() {
+        let text = "This PR is not ready — the test plan section is empty.";
+        let out = parse_merge_verdict_from_text(text).unwrap();
+        assert_eq!(out.verdict, Verdict::NotReady);
+    }
+
+    #[test]
+    fn text_verdict_unclear() {
+        let text = "The PR body appears truncated. My verdict is unclear.";
+        let out = parse_merge_verdict_from_text(text).unwrap();
+        assert_eq!(out.verdict, Verdict::Unclear);
+    }
+
+    #[test]
+    fn text_verdict_case_insensitive() {
+        let text = "READY - all criteria met";
+        let out = parse_merge_verdict_from_text(text).unwrap();
+        assert_eq!(out.verdict, Verdict::Ready);
+    }
+
+    #[test]
+    fn text_verdict_not_ready_wins_over_ready() {
+        // "not_ready" contains "ready" but should match not_ready first
+        let text = "The PR is not_ready due to missing sections.";
+        let out = parse_merge_verdict_from_text(text).unwrap();
+        assert_eq!(out.verdict, Verdict::NotReady);
+    }
+
+    #[test]
+    fn text_verdict_empty_is_error() {
+        let result = parse_merge_verdict_from_text("");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("empty"));
+    }
+
+    #[test]
+    fn text_verdict_no_keyword_is_error() {
+        let result = parse_merge_verdict_from_text("The PR looks interesting but I cannot decide.");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("no verdict keyword"));
+    }
+
+    #[test]
+    fn text_verdict_multiline_response() {
+        let text = "## Merge Readiness Assessment\n\nAfter reviewing all sections:\n\n- Problem statement: ✓\n- Solution: ✓\n- Test plan: ✓\n\nVerdict: ready\n";
+        let out = parse_merge_verdict_from_text(text).unwrap();
+        assert_eq!(out.verdict, Verdict::Ready);
+    }
+
+    #[test]
+    fn text_verdict_rationale_is_full_text() {
+        let text = "Comprehensive analysis shows this PR is ready.";
+        let out = parse_merge_verdict_from_text(text).unwrap();
+        assert!(
+            out.rationale.contains("Comprehensive"),
+            "rationale should include full text: {}",
+            out.rationale
+        );
     }
 }

--- a/tests/act_on_decisions.rs
+++ b/tests/act_on_decisions.rs
@@ -69,6 +69,7 @@ fn sample_handoff() -> MeetingHandoff {
         explicit_questions: Vec::new(),
         themes: Vec::new(),
         next_owner: None,
+        goal: None,
     };
     MeetingHandoff::from_session(&session)
 }
@@ -267,6 +268,7 @@ fn act_on_decisions_with_empty_handoff_creates_no_issues() {
         explicit_questions: Vec::new(),
         themes: Vec::new(),
         next_owner: None,
+        goal: None,
     };
     let handoff = MeetingHandoff::from_session(&session);
     write_meeting_handoff(&dir, &handoff).unwrap();

--- a/tests/meeting_handoff.rs
+++ b/tests/meeting_handoff.rs
@@ -72,6 +72,7 @@ fn sample_session_with_questions() -> MeetingSession {
         explicit_questions: Vec::new(),
         themes: Vec::new(),
         next_owner: None,
+        goal: None,
     }
 }
 
@@ -87,6 +88,7 @@ fn sample_empty_session() -> MeetingSession {
         explicit_questions: Vec::new(),
         themes: Vec::new(),
         next_owner: None,
+        goal: None,
     }
 }
 
@@ -459,6 +461,7 @@ fn handoff_with_only_action_items_no_decisions() {
         explicit_questions: Vec::new(),
         themes: Vec::new(),
         next_owner: None,
+        goal: None,
     };
     let handoff = MeetingHandoff::from_session(&session);
     assert!(handoff.decisions.is_empty());
@@ -487,6 +490,7 @@ fn handoff_with_only_decisions_no_actions() {
         explicit_questions: Vec::new(),
         themes: Vec::new(),
         next_owner: None,
+        goal: None,
     };
     let handoff = MeetingHandoff::from_session(&session);
     assert_eq!(handoff.decisions.len(), 1);

--- a/tests/meeting_handoff_bundle.rs
+++ b/tests/meeting_handoff_bundle.rs
@@ -81,6 +81,7 @@ fn scripted_meeting_emits_structured_handoff_bundle() {
         explicit_questions: Vec::new(),
         themes: Vec::new(),
         next_owner: None,
+        goal: None,
     };
 
     let mut handoff = MeetingHandoff::from_session(&session);
@@ -202,6 +203,7 @@ fn empty_transcript_still_produces_well_formed_bundle() {
     let _root = ScopedMeetingsRoot::new("empty-transcript");
 
     let mut handoff = MeetingHandoff {
+        schema_version: 2,
         meeting_id: String::new(), // exercise auto-fill
         topic: "Quick sync".to_string(),
         started_at: "2026-05-13T07:00:00Z".to_string(),
@@ -217,6 +219,11 @@ fn empty_transcript_still_produces_well_formed_bundle() {
         transcript_path: None,
         next_owner: None,
         artifacts: Vec::new(),
+        goal: None,
+        next_actor: None,
+        applied_templates: Vec::new(),
+        history_truncated_count: 0,
+        partial_reason: None,
     };
 
     let dir = write_meeting_bundle(&mut handoff, &[]).expect("write_meeting_bundle");


### PR DESCRIPTION
## Problem

8 sites in the codebase parse JSON from LLM or recipe output using serde_json. Every one is brittle — LLMs return prose, recipes return agent text. The JSON parsing fails, triggers fallback storms, and creates WARN noise in daemon logs.

User direction: 'there is zero reason that there should be any JSON parsing involved with either of these things. these can just be solved with agentic operations.'

## Solution

Replace all JSON-from-LLM/recipe parsing with text-based keyword extraction:

### Recipe shims (3 sites)
- `disk_health.rs` — no longer parses DiskHealthReport JSON; reads exit code + text markers
- `recipe_progress_checker.rs` — no longer parses JSON verdict; looks for accept/reject in text
- `recipe_merge_judge.rs` — no longer parses JSON verdict; looks for ready/not_ready in text

### OODA brains (3 sites)
- `ooda_brain/decide.rs` — DecideJudgment no longer parsed as JSON; extracts action keywords (spawn_engineer, skip, advance_goal) from text
- `ooda_brain/orient.rs` — OrientJudgment no longer parsed as JSON; extracts priority/context from text
- `ooda_brain/rustyclawd.rs` — EngineerLifecycleDecision no longer parsed as JSON; text-based extraction

44 files changed, +2813/-809 lines

## Risk / Rollback
Revert this PR to restore JSON parsing behavior.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>