### PR TITLE
refactor: replace brittle bash disk-health-check with agentic recipe step (#2051)

### DIFF
--- a/docs/concepts/automated-disk-health.md
+++ b/docs/concepts/automated-disk-health.md
@@ -57,15 +57,15 @@ contribute to exhaustion.
 
 ### Recipe-driven, not hardcoded
 
-The cleanup logic is a recipe YAML with a bash step, not compiled Rust. This
+The cleanup logic is a recipe YAML with an agent step, not compiled Rust. This
 means:
 
-- **Hot-reloadable thresholds.** Operators can change the 80% trigger, 24h
-  worktree age, or backup retention count by editing the YAML. No rebuild,
-  no restart. The daemon re-reads the recipe each cycle.
-- **Inspectable and auditable.** The cleanup script is a readable bash file,
-  not compiled into the binary. Operators can `cat` it, `diff` it, or run
-  it manually.
+- **Hot-reloadable policy.** Operators can change the cleanup guidelines,
+  threshold language, or target priorities by editing the YAML prompt. No
+  rebuild, no restart. The daemon re-reads the recipe each cycle.
+- **Inspectable and auditable.** The cleanup prompt is a readable YAML file,
+  not compiled into the binary. Operators can `cat` it, `diff` it, or review
+  the agent's reasoning in logs.
 - **Consistent with Simard's architecture.** Simard's design philosophy is
   recipes for policy, Rust for machinery. The disk health check follows this
   pattern exactly — the recipe defines *what* to clean and *when*, the Rust
@@ -194,23 +194,22 @@ because:
    are operational knobs that operators should be able to change without
    rebuilding Simard. A YAML file is editable; compiled Rust is not.
 
-2. **Bash is the natural language for filesystem operations.** `find`,
-   `du`, `stat`, `rm` — these are filesystem primitives. Writing them in
-   Rust adds `std::fs` boilerplate, `walkdir` dependencies, and error
-   handling code that doesn't improve correctness over the equivalent
-   4-line bash pipeline.
+2. **Agent-driven cleanup is adaptive.** The agent uses `df`, `find`, and
+   `rm` via bash tools, but the *logic* of what to clean and how aggressively
+   is agentic — it adapts to disk pressure level rather than following a
+   hardcoded script.
 
 3. **Recipes are inspectable.** An operator debugging disk issues can
-   `cat` the recipe YAML and see exactly what will be deleted. With
-   compiled Rust, they'd need the source code or docs.
+   `cat` the recipe YAML and see exactly what the agent is instructed to
+   do. The agent's reasoning is logged for auditability.
 
 4. **Consistency.** Simard already uses recipes for merge readiness
    judgement, progress checking, and other policy decisions. Disk health
    follows the same pattern.
 
-The Rust code is a thin shim. All cleanup logic lives in the recipe YAML as
-a readable bash file, not compiled into the binary. Operators can `cat` it,
-`diff` it, or run it manually.
+The Rust code is a thin shim. The cleanup prompt lives in the recipe YAML as
+a readable agent step, not compiled into the binary. Operators can `cat` it,
+`diff` it, or review the agent's decisions in logs.
 
 The recipe outputs key=value lines to stdout (`DISK_USED_PCT=N`,
 `FREED_BYTES=N`, `ACTION: ...`) — the Rust shim parses these with simple

--- a/docs/howto/configure-disk-health-check.md
+++ b/docs/howto/configure-disk-health-check.md
@@ -62,22 +62,18 @@ All thresholds live in the recipe YAML — no Rust recompile needed:
 $EDITOR prompt_assets/simard/recipes/disk-health-check.yaml
 ```
 
-The tunables are environment variables set at the top of the bash step:
+The tunables are described in the agent prompt within the recipe YAML. The
+agent uses its judgment based on the guidelines in the prompt:
 
-| Variable               | Default  | What it controls                                   |
+| Guideline              | Default  | What it controls                                   |
 | ---------------------- | -------- | -------------------------------------------------- |
-| `DISK_THRESHOLD_PCT`   | `80`     | Disk usage percentage that triggers cleanup         |
-| `WORKTREE_MAX_AGE_H`   | `24`     | Hours before a worktree is eligible for removal     |
-| `BACKUP_RETENTION`     | `5`      | Number of LadybugDB backups to keep                 |
+| Cleanup threshold      | `80%`    | Disk usage percentage that triggers cleanup         |
+| Worktree max age       | `24h`    | Hours before a worktree is eligible for removal     |
+| Backup retention       | `~5`     | Approximate number of LadybugDB backups to keep     |
 
-Example — lower the threshold to 70% and keep 10 backups:
-
-```yaml
-# In disk-health-check.yaml, modify the bash step env:
-env:
-  DISK_THRESHOLD_PCT: "70"
-  BACKUP_RETENTION: "10"
-```
+To change these, edit the agent prompt in the recipe YAML. For example,
+change "80%" to "70%" in the prompt text, or adjust the backup retention
+guidance.
 
 Changes take effect on the next OODA cycle — the daemon re-reads the recipe
 YAML each time.
@@ -153,7 +149,7 @@ Common causes:
 
 ### 4. Text parse shows unexpected values
 
-The Rust shim parses key=value lines from stdout. If the bash script
+The Rust shim parses key=value lines from stdout. If the agent
 outputs lines with unexpected formats, the parser silently ignores them
 and defaults to zero. Check for typos in key names (`DISK_USED_PCT`, not
 `DISK_USED_PERCENT`) and ensure values are plain integers (no units, no

--- a/docs/reference/disk-health-api.md
+++ b/docs/reference/disk-health-api.md
@@ -25,13 +25,13 @@ per OODA cycle, *before* spawning any engineer subprocesses. It prevents the
 proactively freeing disk when the home partition exceeds 80% usage.
 
 The Rust code is a thin shim. All cleanup logic lives in the recipe YAML as
-a deterministic bash step — no LLM required.
+an agent step that adaptively decides what to clean based on disk pressure.
 
 ## Module Layout
 
 ```
 src/disk_health.rs                           Rust shim (subprocess invocation, text parsing)
-prompt_assets/simard/recipes/disk-health-check.yaml   Recipe (bash cleanup script)
+prompt_assets/simard/recipes/disk-health-check.yaml   Recipe (agent cleanup step)
 ```
 
 ## Public API — `src/disk_health.rs`
@@ -51,7 +51,7 @@ pub struct DiskHealthReport {
 }
 ```
 
-The report is parsed from key=value lines on stdout by the recipe's bash
+The report is parsed from key=value lines on stdout by the recipe's agent
 step. The Rust shim uses `parse_disk_health_text()` to extract fields from
 the text output — no JSON parsing. See
 [text-parsing wire formats](./text-parsing-wire-formats.md#protocol-3-keyvalue-disk-health)
@@ -140,7 +140,7 @@ Resolution order (matches `recipe_merge_judge.rs` and
 
 ## Recipe YAML — `disk-health-check.yaml`
 
-The recipe is a single bash step. Its stdout uses the key=value text format
+The recipe is a single agent step. Its stdout uses the key=value text format
 (not JSON). See [text-parsing wire formats § key=value](./text-parsing-wire-formats.md#protocol-3-keyvalue-disk-health)
 for the normative grammar.
 
@@ -183,7 +183,7 @@ When disk usage exceeds 80%, the recipe performs these actions sequentially:
 
 ### Text output contract
 
-The bash step prints key=value lines to stdout:
+The agent step prints key=value lines to stdout:
 
 ```
 DISK_USED_PCT=72

--- a/prompt_assets/simard/recipes/disk-health-check.yaml
+++ b/prompt_assets/simard/recipes/disk-health-check.yaml
@@ -1,21 +1,23 @@
-# disk-health-check.yaml — Deterministic disk cleanup recipe (no LLM).
+# disk-health-check.yaml — Agent-based disk health check.
 #
-# Invoked by src/disk_health.rs via recipe-runner-rs. Checks disk usage on
-# the home partition and triggers cleanup when usage exceeds 80%.
+# Invoked by src/disk_health.rs via recipe-runner-rs. An agent checks disk
+# usage on the home partition and uses its judgment to clean up when usage
+# exceeds 80%.
 #
 # Context vars (passed via -c):
 #   state_root  — path to ~/.simard (worktrees, backups, cargo dirs live here)
 #
 # Output: text markers to stdout (one per line):
-#   DISK_USED_PCT=<0-100>
+#   DISK_USED_PCT=<0-255>
 #   FREED_BYTES=<int>
 #   ACTION: <description>   (one line per action taken; omitted if none)
 #
-# Design: single bash step — no LLM, fully deterministic, hot-reloadable.
+# Design: single agent step — the LLM decides what to clean and how
+# aggressively based on disk pressure. No hardcoded find/rm scripts.
 
 name: "disk-health-check"
-description: "Check disk usage and clean stale artifacts when usage exceeds 80%"
-version: "1.0.0"
+description: "Agent-based disk health check and adaptive cleanup"
+version: "2.0.0"
 author: "Simard"
 tags: ["simard", "disk", "maintenance", "ops"]
 
@@ -24,120 +26,83 @@ context:
 
 steps:
   - id: "check-and-clean"
-    type: "bash"
-    command: |
-      #!/usr/bin/env bash
-      set -euo pipefail
+    type: "agent"
+    agent: "default"
+    prompt: |
+      You are a disk health maintenance agent for Simard. Your job is to check
+      disk usage and, if needed, clean up stale artifacts to free space. You have
+      bash tools available to run shell commands.
 
-      STATE_ROOT="${state_root:-$HOME/.simard}"
-      THRESHOLD=80
-      # Emergency mode: keep fewer backups than normal (SIMARD_DB_BACKUP_KEEP
-      # defaults to 24) to reclaim space aggressively under disk pressure.
-      BACKUP_KEEP=5
+      ## Procedure
 
-      actions=()
+      1. **Measure current disk usage.** Run a single command to capture both the
+         usage percentage and available bytes:
+         ```
+         df -B1 --output=pcent,avail "$HOME" | tail -1
+         ```
+         Parse the percentage (strip the `%` sign) and the available-bytes value.
+         Store the available bytes as `AVAIL_BEFORE` for the delta calculation.
 
-      # ── Helper: record a cleanup action ─────────────────────────────────
-      record_action() {
-        actions+=("$1")
-      }
+      2. **If usage is below 80%**, no cleanup is needed. Print the output markers
+         and stop immediately — do not scan any directories:
+         ```
+         DISK_USED_PCT=<current percentage>
+         FREED_BYTES=0
+         ```
 
-      # ── Helper: current disk usage percentage ──────────────────────────
-      get_disk_pct() {
-        local pct
-        pct=$(df --output=pcent "$HOME" 2>/dev/null | tail -1 | tr -d ' %')
-        if [ -z "$pct" ]; then
-          pct=$(df "$HOME" | tail -1 | awk '{gsub(/%/,""); print $5}')
-        fi
-        echo "$pct"
-      }
+      3. **If usage is 80% or above**, free space using the cleanup targets below.
+         Be more aggressive when disk pressure is higher (e.g., 95% warrants
+         removing more than 82% does). Process targets in the order listed — they
+         are sorted by typical space yield (largest first). After each target
+         category, re-check usage with `df -B1 --output=pcent "$HOME" | tail -1`.
+         If usage has dropped below 80%, skip the remaining categories.
 
-      # ── Helper: available disk space in 1K blocks ──────────────────────
-      get_avail_kb() {
-        local kb
-        kb=$(df --output=avail "$HOME" 2>/dev/null | tail -1 | tr -d ' ')
-        if [ -z "$kb" ]; then
-          kb=$(df "$HOME" | tail -1 | awk '{print $4}')
-        fi
-        echo "$kb"
-      }
+      4. **After cleanup** (or after early termination), run one final
+         `df -B1 --output=pcent,avail "$HOME" | tail -1`. Compute freed bytes as
+         `AVAIL_AFTER - AVAIL_BEFORE`. If the delta is negative, report 0.
 
-      # ── 1. Measure current disk usage ──────────────────────────────────
-      disk_pct=$(get_disk_pct)
+      ## Cleanup Targets (ordered by typical yield)
 
-      # ── 2. If below threshold, report and exit ─────────────────────────
-      if [ "$disk_pct" -lt "$THRESHOLD" ]; then
-        printf 'DISK_USED_PCT=%d\nFREED_BYTES=0\n' "$disk_pct"
-        exit 0
-      fi
+      All cleanup targets live under `{{state_root}}`. Do NOT delete anything
+      outside this directory tree.
 
-      # ── 3. Clean stale engineer worktrees (>24h, no active process) ────
-      avail_before=$(get_avail_kb)
-      WORKTREE_DIR="$STATE_ROOT/engineer-worktrees"
-      if [ -d "$WORKTREE_DIR" ]; then
-        while IFS= read -r -d '' wt; do
-          # Skip symlinks
-          [ -L "$wt" ] && continue
+      1. **`{{state_root}}/cargo-target/`** and **`{{state_root}}/shared-target/`** —
+         Shared Cargo build caches. Remove `incremental/` and `debug/` subdirectories
+         first (use `find <dir> -maxdepth 1 -name incremental -o -name debug` then
+         `rm -rf`). Under extreme pressure, remove the entire directories.
 
-          # Check for active claim file with a live PID
-          claim="$wt/.simard-engineer-claim"
-          if [ -f "$claim" ]; then
-            pid=$(head -1 "$claim" 2>/dev/null || true)
-            if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
-              continue  # Active process — skip
-            fi
-          fi
+      2. **`{{state_root}}/engineer-worktrees/`** — Enumerate once with a single
+         `find` pass. For each subdirectory, check modification time and the
+         `.simard-engineer-claim` file in one go:
+         - If the worktree is older than 24 hours AND (the `.simard-engineer-claim`
+           file is missing OR the PID on its first line is dead per `kill -0`),
+           remove the entire worktree.
+         - For worktrees that are kept (still active or <24h old), remove only
+           their `target/` subdirectory if it exists — these Cargo build dirs are
+           large and always safe to delete.
 
-          rm -rf "$wt"
-          record_action "removed stale worktree: $(basename "$wt")"
-        done < <(find "$WORKTREE_DIR" -mindepth 1 -maxdepth 1 -type d -not -type l -mmin +1440 -print0 2>/dev/null)
-      fi
+      3. **`{{state_root}}/backups/`** — Database backup files. List by modification
+         time (`ls -1t`), keep approximately 5 most recent, remove the rest. Under
+         extreme disk pressure you may keep fewer, but never delete all backups.
 
-      # ── 4. Remove cargo target dirs inside remaining engineer worktrees ─
-      if [ -d "$WORKTREE_DIR" ]; then
-        while IFS= read -r -d '' tgt; do
-          [ -L "$tgt" ] && continue
-          rm -rf "$tgt"
-          record_action "removed worktree target: $(basename "$(dirname "$tgt")")/target"
-        done < <(find "$WORKTREE_DIR" -mindepth 2 -maxdepth 2 -type d -name target -print0 2>/dev/null)
-      fi
+      ## Required Output Format
 
-      # ── 5. Prune LadybugDB backups to keep only N most recent ──────────
-      BACKUP_DIR="$STATE_ROOT/backups"
-      if [ -d "$BACKUP_DIR" ]; then
-        backup_count=$(find "$BACKUP_DIR" -maxdepth 1 -type f | wc -l)
-        if [ "$backup_count" -gt "$BACKUP_KEEP" ]; then
-          # Sort by mtime, delete oldest beyond BACKUP_KEEP
-          while IFS= read -r -d '' old; do
-            [ -L "$old" ] && continue
-            rm -f "$old"
-            record_action "pruned backup: $(basename "$old")"
-          done < <(find "$BACKUP_DIR" -maxdepth 1 -type f -not -type l -printf '%T@\t%p\0' \
-                   | sort -z -t$'\t' -k1,1n \
-                   | head -z -n -"$BACKUP_KEEP" \
-                   | cut -z -f2-)
-        fi
-      fi
+      Your **final** output must contain these text markers, each on its own line.
+      The Rust shim (`parse_disk_health_text` in `src/disk_health.rs`) parses these
+      markers from your stdout. Any other lines are silently ignored.
 
-      # ── 6. Clean cargo-target and shared-target caches ─────────────────
-      for cache_dir in "$STATE_ROOT/cargo-target" "$STATE_ROOT/shared-target"; do
-        if [ -d "$cache_dir" ]; then
-          find "$cache_dir" -type d -name incremental -exec rm -rf {} + 2>/dev/null || true
-          find "$cache_dir" -type d -name debug -exec rm -rf {} + 2>/dev/null || true
-          record_action "cleaned cache: $(basename "$cache_dir") (incremental+debug)"
-        fi
-      done
+      ```
+      DISK_USED_PCT=<integer 0-255>
+      FREED_BYTES=<integer, bytes freed>
+      ACTION: <one-line description of action taken>
+      ```
 
-      # ── 7. Re-measure disk and compute freed bytes from df delta ───────
-      disk_pct_after=$(get_disk_pct)
-      avail_after=$(get_avail_kb)
-      freed_kb=$((avail_after - avail_before))
-      if [ "$freed_kb" -lt 0 ]; then freed_kb=0; fi
-      freed_bytes=$((freed_kb * 1024))
+      - `DISK_USED_PCT` is **required**. Use the post-cleanup percentage (or the
+        current percentage if no cleanup was needed).
+      - `FREED_BYTES` defaults to 0 if omitted. Use the actual `df` delta.
+      - `ACTION:` lines are optional. Emit one per cleanup action you took. If the
+        text after `ACTION:` is empty, it will be skipped.
 
-      # Emit text markers (parsed by parse_disk_health_text in src/disk_health.rs)
-      printf 'DISK_USED_PCT=%d\nFREED_BYTES=%d\n' "$disk_pct_after" "$freed_bytes"
-      for a in "${actions[@]}"; do
-        printf 'ACTION: %s\n' "$a"
-      done
+      Print these markers as plain text in your response — not inside code fences
+      or markdown formatting.
     output: "disk_health_report"


### PR DESCRIPTION
Replaces the hardcoded bash script in disk-health-check.yaml with a single agent step. The agent uses its judgment to check disk usage, identify stale worktrees/targets/backups, and clean up adaptively. No more hardcoded find/rm commands. Closes #2051.