### PR TITLE
feat: add /api/brain-failures endpoint and Brain Failures dashboard tab (#2043)

### DIFF
--- a/src/operator_commands_dashboard/brain_failures.rs
+++ b/src/operator_commands_dashboard/brain_failures.rs
@@ -1,0 +1,257 @@
+//! `/api/brain-failures` endpoint — surfaces when and how the OODA brain
+//! failed so the operator can see Simard's self-awareness gaps (issue #2043).
+//!
+//! Data sources:
+//!   1. `~/.simard/cycle_reports/cycle_*.json` — `brain_judgments[]` entries
+//!      where `fallback == true` or `parse_failure != null`.
+//!   2. `~/.simard/metrics/metrics.jsonl` — `brain_parse_failure` metric
+//!      entries for a quick summary count.
+//!
+//! The endpoint returns a flat list of recent brain failures in reverse
+//! chronological order, each entry rendered with:
+//!   - failure type (parse failure vs deterministic fallback)
+//!   - triggering component (act / decide / orient phase)
+//!   - timestamp
+//!   - whether recovery succeeded (fallback always "recovers" via the
+//!     deterministic floor; parse failures that escalated to `gh issue`
+//!     are marked as escalated)
+
+use axum::Json;
+use serde_json::{Value, json};
+
+use super::routes::resolve_state_root;
+
+/// Maximum number of cycle reports to scan (most recent first).
+const MAX_CYCLES_TO_SCAN: usize = 50;
+
+/// Maximum number of failure entries to return.
+const MAX_FAILURES_RETURNED: usize = 200;
+
+pub(crate) async fn brain_failures() -> Json<Value> {
+    let state_root = resolve_state_root();
+    let cycle_dir = state_root.join("cycle_reports");
+    let metrics_path = state_root.join("metrics").join("metrics.jsonl");
+
+    let mut failures: Vec<Value> = Vec::new();
+    let mut total_fallback_count: u64 = 0;
+    let mut total_parse_failure_count: u64 = 0;
+    let mut cycles_scanned: u32 = 0;
+
+    // Scan cycle reports for brain judgment failures.
+    if let Ok(entries) = std::fs::read_dir(&cycle_dir) {
+        let mut paths: Vec<_> = entries.filter_map(|e| e.ok()).collect();
+        paths.sort_by(|a, b| {
+            let num = |p: &std::fs::DirEntry| -> u32 {
+                p.file_name()
+                    .to_str()
+                    .unwrap_or("")
+                    .strip_prefix("cycle_")
+                    .unwrap_or("")
+                    .strip_suffix(".json")
+                    .unwrap_or("")
+                    .parse()
+                    .unwrap_or(0)
+            };
+            num(b).cmp(&num(a))
+        });
+
+        for entry in paths.into_iter().take(MAX_CYCLES_TO_SCAN) {
+            let content = match std::fs::read_to_string(entry.path()) {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+            let report: Value = match serde_json::from_str(&content) {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+
+            cycles_scanned += 1;
+            let cycle_number = report
+                .get("cycle_number")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            let cycle_timestamp = report
+                .get("timestamp")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+
+            let judgments = match report.get("brain_judgments").and_then(|v| v.as_array()) {
+                Some(arr) => arr,
+                None => continue,
+            };
+
+            for j in judgments {
+                let is_fallback = j.get("fallback").and_then(|v| v.as_bool()).unwrap_or(false);
+                let has_parse_failure =
+                    j.get("parse_failure").is_some() && !j.get("parse_failure").unwrap().is_null();
+
+                if !is_fallback && !has_parse_failure {
+                    continue;
+                }
+
+                if is_fallback {
+                    total_fallback_count += 1;
+                }
+                if has_parse_failure {
+                    total_parse_failure_count += 1;
+                }
+
+                if failures.len() >= MAX_FAILURES_RETURNED {
+                    continue; // keep counting but stop collecting
+                }
+
+                let phase = j.get("phase").and_then(|v| v.as_str()).unwrap_or("unknown");
+                let decision = j.get("decision").and_then(|v| v.as_str()).unwrap_or("");
+                let rationale = j.get("rationale").and_then(|v| v.as_str()).unwrap_or("");
+                let confidence = j.get("confidence").and_then(|v| v.as_f64()).unwrap_or(0.0);
+
+                let failure_type = if has_parse_failure {
+                    "parse_failure"
+                } else {
+                    "deterministic_fallback"
+                };
+
+                let failure_description = if has_parse_failure {
+                    let pf = j.get("parse_failure").unwrap();
+                    let err_msg = pf
+                        .get("error_message")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("unknown error");
+                    let consec = pf
+                        .get("consecutive_count")
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(0);
+                    let prompt = pf.get("prompt_name").and_then(|v| v.as_str()).unwrap_or("");
+                    format!(
+                        "The {} phase brain failed to parse a valid response from the language model \
+                         (prompt: {}, {} consecutive failure{}). Error: {}",
+                        phase,
+                        prompt,
+                        consec,
+                        if consec == 1 { "" } else { "s" },
+                        err_msg
+                    )
+                } else {
+                    format!(
+                        "The {} phase used its deterministic fallback instead of the language model brain. \
+                         Decision: {} (confidence: {:.0}%).",
+                        phase,
+                        decision,
+                        confidence * 100.0
+                    )
+                };
+
+                let recovery_succeeded = true; // fallback always recovers
+                let escalated = if has_parse_failure {
+                    let pf = j.get("parse_failure").unwrap();
+                    let consec = pf
+                        .get("consecutive_count")
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(0);
+                    consec >= 3 // ISSUE_ESCALATION_THRESHOLD
+                } else {
+                    false
+                };
+
+                let timestamp = if has_parse_failure {
+                    j.get("parse_failure")
+                        .and_then(|pf| pf.get("timestamp"))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or(cycle_timestamp)
+                } else {
+                    cycle_timestamp
+                };
+
+                failures.push(json!({
+                    "failure_type": failure_type,
+                    "failure_type_plain": if has_parse_failure {
+                        "Brain could not understand model response"
+                    } else {
+                        "Brain used safe fallback rules instead of model"
+                    },
+                    "description": failure_description,
+                    "phase": phase,
+                    "phase_plain": match phase {
+                        "act" => "Act — deciding what to do with a running engineer",
+                        "decide" => "Decide — choosing which action to take for a goal",
+                        "orient" => "Orient — ranking goal urgency after failures",
+                        _ => "Unknown phase",
+                    },
+                    "decision": decision,
+                    "rationale": rationale,
+                    "confidence": confidence,
+                    "cycle_number": cycle_number,
+                    "timestamp": timestamp,
+                    "recovery_succeeded": recovery_succeeded,
+                    "escalated": escalated,
+                    "parse_failure_detail": if has_parse_failure {
+                        j.get("parse_failure").cloned()
+                    } else {
+                        None
+                    },
+                }));
+            }
+        }
+    }
+
+    // Quick count from metrics.jsonl for the summary stat.
+    let metrics_parse_failure_count = count_brain_parse_failure_metrics(&metrics_path);
+
+    Json(json!({
+        "failures": failures,
+        "summary": {
+            "total_fallback_count": total_fallback_count,
+            "total_parse_failure_count": total_parse_failure_count,
+            "metrics_parse_failure_count": metrics_parse_failure_count,
+            "cycles_scanned": cycles_scanned,
+        },
+        "timestamp": chrono::Utc::now().to_rfc3339(),
+    }))
+}
+
+/// Count `brain_parse_failure` metric entries in `metrics.jsonl`.
+fn count_brain_parse_failure_metrics(path: &std::path::Path) -> u64 {
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(_) => return 0,
+    };
+    content
+        .lines()
+        .filter(|line| line.contains("brain_parse_failure"))
+        .count() as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn count_brain_parse_failure_metrics_empty_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("metrics.jsonl");
+        std::fs::write(&path, "").unwrap();
+        assert_eq!(count_brain_parse_failure_metrics(&path), 0);
+    }
+
+    #[test]
+    fn count_brain_parse_failure_metrics_counts_matching_lines() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("metrics.jsonl");
+        std::fs::write(
+            &path,
+            r#"{"name":"ooda_cycle","value":1}
+{"name":"brain_parse_failure","value":1}
+{"name":"brain_parse_failure","value":1}
+{"name":"other_metric","value":42}
+"#,
+        )
+        .unwrap();
+        assert_eq!(count_brain_parse_failure_metrics(&path), 2);
+    }
+
+    #[test]
+    fn count_brain_parse_failure_metrics_missing_file() {
+        let path = std::path::Path::new("/nonexistent/metrics.jsonl");
+        assert_eq!(count_brain_parse_failure_metrics(path), 0);
+    }
+}

--- a/src/operator_commands_dashboard/index_html/part_00.rs
+++ b/src/operator_commands_dashboard/index_html/part_00.rs
@@ -339,6 +339,19 @@ pub(crate) const PART_00: &str = r#"<!DOCTYPE html>
     </div>
   </div>
 
+  <div class="tab-content" id="tab-brain-failures">
+    <h1 class="page-h1">Brain Failures</h1>
+    <p class="page-lede">Every time the daemon's language-model brain returned an unparseable or invalid response and fell back to safe deterministic rules, listed with the failure type, which component triggered it, when it happened, and whether recovery succeeded.</p>
+    <div class="card" style="margin-bottom:1rem">
+      <h2>Summary <button class="btn" onclick="fetchBrainFailures()">Refresh</button></h2>
+      <div id="brain-failures-summary"><span class="loading">Loading…</span></div>
+    </div>
+    <div class="card">
+      <h2>Recent Brain Failures</h2>
+      <div id="brain-failures-list"><span class="loading">Loading…</span></div>
+    </div>
+  </div>
+
   <div class="tab-content" id="tab-chat">
     <h1 class="page-h1">Chat</h1>
     <p class="page-lede">Talk to the running Simard agent in real time — anything you say here can become a new goal, and slash-commands like /close, /goals, and /status are available.</p>

--- a/src/operator_commands_dashboard/index_html/part_01.rs
+++ b/src/operator_commands_dashboard/index_html/part_01.rs
@@ -208,6 +208,7 @@ pub(crate) const PART_01: &str = r#"      </div>
         if(tab.dataset.tab==='chat') initChat();
         if(tab.dataset.tab==='workboard') {fetchWorkboard();tabRefreshTimers.wb=setInterval(fetchWorkboard,30000);}
         if(tab.dataset.tab==='thinking') {fetchThinking();tabRefreshTimers.thinking=setInterval(fetchThinking,30000);}
+        if(tab.dataset.tab==='brain-failures') {fetchBrainFailures();tabRefreshTimers.brainFailures=setInterval(fetchBrainFailures,30000);}
         if(tab.dataset.tab==='terminal') {initAgentLogTerminal();fetchSubagentSessions();tabRefreshTimers.subagent=setInterval(fetchSubagentSessions,5000);fetchTmuxSessions();tabRefreshTimers.tmux=setInterval(fetchTmuxSessions,10000);}
       });
     });

--- a/src/operator_commands_dashboard/index_html/part_04.rs
+++ b/src/operator_commands_dashboard/index_html/part_04.rs
@@ -279,6 +279,63 @@ pub(crate) const PART_04: &str = r#"            let fmt;
       }catch(e){document.getElementById('thinking-timeline').innerHTML='<span class="err">Failed to load: '+esc(e.toString())+'</span>';}
     }
 
+    /* --- Brain Failures (issue #2043) --- */
+    async function fetchBrainFailures(){
+      try{
+        const d=await apiFetch('/api/brain-failures');
+        const sumEl=document.getElementById('brain-failures-summary');
+        const listEl=document.getElementById('brain-failures-list');
+        const s=d.summary||{};
+        const totalFallbacks=s.total_fallback_count||0;
+        const totalParseFailures=s.total_parse_failure_count||0;
+        const totalFailures=totalFallbacks+totalParseFailures;
+        const scanned=s.cycles_scanned||0;
+        const statusClass=totalParseFailures>0?'err':(totalFallbacks>0?'warn':'ok');
+        const statusText=totalFailures===0?'No brain failures detected':''+totalFailures+' failure'+(totalFailures===1?'':'s')+' found';
+        sumEl.innerHTML=`
+          <div class="stat"><span class="label">Status</span><span class="value ${statusClass}">${statusText}</span></div>
+          <div class="stat"><span class="label">Parse failures (model response unparseable)</span><span class="value ${totalParseFailures>0?'err':'ok'}">${totalParseFailures}</span></div>
+          <div class="stat"><span class="label">Deterministic fallbacks (safe rules used instead of model)</span><span class="value ${totalFallbacks>0?'warn':'ok'}">${totalFallbacks}</span></div>
+          <div class="stat"><span class="label">Cycles scanned</span><span class="value">${scanned}</span></div>
+          <div class="stat"><span class="label">Last checked</span><span class="value">${timeAgo(d.timestamp)}</span></div>`;
+        const failures=d.failures||[];
+        if(!failures.length){
+          listEl.innerHTML='<div style="color:#8b949e;padding:.5rem 0">No brain failures in the last '+scanned+' cycles. The daemon\'s language-model brain has been responding correctly.</div>';
+          return;
+        }
+        listEl.innerHTML=failures.map(f=>{
+          const typeIcon=f.failure_type==='parse_failure'?'🔴':'🟡';
+          const escBadge=f.escalated?'<span style="background:var(--red);color:#fff;padding:1px 6px;border-radius:3px;font-size:11px;margin-left:6px">escalated to issue</span>':'';
+          const recoveryBadge=f.recovery_succeeded?'<span style="color:var(--green);font-size:.8rem">✓ recovered via fallback</span>':'<span style="color:var(--red);font-size:.8rem">✗ no recovery</span>';
+          let detail='';
+          if(f.parse_failure_detail){
+            const pf=f.parse_failure_detail;
+            detail=`<div style="margin-top:.35rem;padding:.4rem .55rem;border-left:3px solid var(--red);background:rgba(255,255,255,0.03);border-radius:4px;font-size:.8rem">
+              <div><strong>Error:</strong> ${esc(pf.error_message||'')}</div>
+              <div><strong>Prompt:</strong> ${esc(pf.prompt_name||'')} (version: ${esc(pf.prompt_version||'none')})</div>
+              <div><strong>Consecutive failures:</strong> ${pf.consecutive_count||0}</div>
+              ${pf.raw_response_truncated?'<details style="margin-top:.25rem"><summary style="cursor:pointer;color:#8b949e">Raw model response</summary><pre style="white-space:pre-wrap;max-height:200px;overflow:auto;margin-top:.25rem;padding:.35rem;background:#0d1117;border:1px solid var(--border);border-radius:4px;font-size:.75rem">'+esc(pf.raw_response_truncated)+'</pre></details>':''}
+            </div>`;
+          }
+          return `<div style="padding:.6rem 0;border-bottom:1px solid var(--border)">
+            <div style="display:flex;gap:.5rem;align-items:baseline;flex-wrap:wrap">
+              <span>${typeIcon}</span>
+              <strong>${esc(f.failure_type_plain||f.failure_type)}</strong>${escBadge}
+              <span style="color:#8b949e;font-size:.8rem">Cycle #${f.cycle_number} · ${timeAgo(f.timestamp)}</span>
+              <span style="margin-left:auto">${recoveryBadge}</span>
+            </div>
+            <div style="font-size:.85rem;color:#9bb1c4;margin-top:.2rem"><strong>Component:</strong> ${esc(f.phase_plain||f.phase)}</div>
+            <div style="font-size:.85rem;color:#9bb1c4;margin-top:.15rem">${esc(f.description||'')}</div>
+            ${f.rationale?'<div style="font-size:.8rem;color:#8b949e;margin-top:.15rem"><em>Rationale: '+esc(f.rationale)+'</em></div>':''}
+            ${detail}
+          </div>`;
+        }).join('');
+      }catch(e){
+        document.getElementById('brain-failures-summary').innerHTML='<span class="err">Failed to load: '+esc(e.toString())+'</span>';
+        document.getElementById('brain-failures-list').innerHTML='';
+      }
+    }
+
     /* --- Agent log terminal (issue #947) --- */
     let agentLogTerm = null;
     let agentLogWS = null;

--- a/src/operator_commands_dashboard/index_html/tab_meta.rs
+++ b/src/operator_commands_dashboard/index_html/tab_meta.rs
@@ -151,6 +151,14 @@ pub const TAB_METADATA: &[TabMeta] = &[
         tooltip: "Live stream of the agent's reasoning between actions",
     },
     TabMeta {
+        slug: "brain-failures",
+        label: "Brain Failures",
+        title: "Brain Failures · Simard",
+        h1: "Brain Failures",
+        lede: "Every time the daemon's language-model brain returned an unparseable or invalid response and fell back to safe deterministic rules, listed with the failure type, which component triggered it, when it happened, and whether recovery succeeded.",
+        tooltip: "When and how the agent's brain failed, and whether it recovered",
+    },
+    TabMeta {
         slug: "terminal",
         label: "Terminal",
         title: "Terminal · Simard",
@@ -163,7 +171,7 @@ pub const TAB_METADATA: &[TabMeta] = &[
 /// Browser title shown on first page load. The client-side tab handler
 /// updates this when a different tab is activated. Uses `TAB_METADATA[0]`
 /// directly because [`tab_meta_slugs_unique`] asserts the table has
-/// exactly 11 entries — an empty table would already fail other tests.
+/// exactly 12 entries — an empty table would already fail other tests.
 pub fn default_title() -> &'static str {
     TAB_METADATA[0].title
 }

--- a/src/operator_commands_dashboard/index_html/tests_tab_meta.rs
+++ b/src/operator_commands_dashboard/index_html/tests_tab_meta.rs
@@ -19,7 +19,7 @@ fn tab_meta_slugs_unique() {
             t.slug
         );
     }
-    assert_eq!(TAB_METADATA.len(), 11, "expected 11 tabs");
+    assert_eq!(TAB_METADATA.len(), 12, "expected 12 tabs");
 }
 
 #[test]

--- a/src/operator_commands_dashboard/mod.rs
+++ b/src/operator_commands_dashboard/mod.rs
@@ -1,6 +1,7 @@
 mod activity;
 mod agent_log;
 mod auth;
+mod brain_failures;
 mod chat;
 mod current_work;
 mod distributed;

--- a/src/operator_commands_dashboard/routes.rs
+++ b/src/operator_commands_dashboard/routes.rs
@@ -7,6 +7,7 @@ use serde_json::{Value, json};
 use super::activity::{activity, traces};
 use super::agent_log::{WS_AGENT_LOG_ROUTE, ws_agent_log_handler};
 use super::auth::{login, login_page, require_auth};
+use super::brain_failures::brain_failures;
 use super::chat::ws_chat_handler;
 use super::current_work::current_work;
 use super::distributed::{distributed, vacate_vm};
@@ -68,6 +69,7 @@ pub fn build_router() -> Router {
         .route("/api/workboard", get(workboard))
         .route("/api/current-work", get(current_work))
         .route("/api/ooda-thinking", get(ooda_thinking))
+        .route("/api/brain-failures", get(brain_failures))
         .route("/api/subagent-sessions", get(subagent_sessions))
         .route("/ws/chat", get(ws_chat_handler))
         .route(WS_AGENT_LOG_ROUTE, get(ws_agent_log_handler))

--- a/src/operator_commands_dashboard/tests_routes_a.rs
+++ b/src/operator_commands_dashboard/tests_routes_a.rs
@@ -232,16 +232,16 @@ mod tests {
         assert!(INDEX_HTML.contains(r#"data-tab="overview" title="System health"#));
         assert!(INDEX_HTML.contains(r#"data-tab="goals" title="Active goals"#));
         assert!(INDEX_HTML.contains(r#"data-tab="terminal" title="Attach to the agent"#));
-        // All 11 tab-content containers should now carry a page-lede paragraph.
+        // All 12 tab-content containers should now carry a page-lede paragraph.
         let lede_count = INDEX_HTML.matches(r#"class="page-lede""#).count();
         assert!(
-            lede_count >= 11,
-            "expected at least 11 .page-lede paragraphs (one per tab), found {lede_count}"
+            lede_count >= 12,
+            "expected at least 12 .page-lede paragraphs (one per tab), found {lede_count}"
         );
         let h1_count = INDEX_HTML.matches(r#"class="page-h1""#).count();
         assert!(
-            h1_count >= 11,
-            "expected at least 11 .page-h1 headings (one per tab), found {h1_count}"
+            h1_count >= 12,
+            "expected at least 12 .page-h1 headings (one per tab), found {h1_count}"
         );
     }
 
@@ -276,7 +276,7 @@ mod tests {
     // shared formatter.
     // -------------------------------------------------------------------
 
-    /// Every one of the eleven top-level SPA tabs must carry a non-empty
+    /// Every one of the twelve top-level SPA tabs must carry a non-empty
     /// `title="…"` hover-tooltip. Iterates the canonical tab list so that
     /// adding/removing a tab in `part_00.rs` immediately surfaces a missing
     /// tooltip via this test rather than a silent UX regression.
@@ -295,9 +295,10 @@ mod tests {
             "chat",
             "workboard",
             "thinking",
+            "brain-failures",
             "terminal",
         ];
-        assert_eq!(tabs.len(), 11, "expected exactly 11 top-level tabs");
+        assert_eq!(tabs.len(), 12, "expected exactly 12 top-level tabs");
 
         for tab in &tabs {
             let needle = format!(r#"data-tab="{tab}" title=""#);
@@ -349,7 +350,7 @@ mod tests {
         }
     }
 
-    /// Each of the eleven `tab-content` containers (`id="tab-<name>"`)
+    /// Each of the twelve `tab-content` containers (`id="tab-<name>"`)
     /// must contain at least one `<p class="page-lede">…</p>` inside
     /// its body — i.e. between the opening `id="tab-<name>"` and the next
     /// `id="tab-` of any kind (the next sibling tab-content). Guarantees
@@ -368,6 +369,7 @@ mod tests {
             "chat",
             "workboard",
             "thinking",
+            "brain-failures",
             "terminal",
         ];
         for tab in &tabs {
@@ -634,22 +636,22 @@ mod tests {
         );
     }
 
-    /// Sanity-check on the page-lede count: there must be exactly 11
-    /// (one per tab) — a stricter bound than the existing `>= 11`
-    /// assertion. If a refactor accidentally adds a 12th, we want to
+    /// Sanity-check on the page-lede count: there must be exactly 12
+    /// (one per tab) — a stricter bound than the existing `>= 12`
+    /// assertion. If a refactor accidentally adds a 13th, we want to
     /// know immediately so we can decide whether the new container is
     /// actually a new tab or a misuse of the class.
     #[test]
     fn index_html_has_exactly_eleven_page_intros() {
         let count = INDEX_HTML.matches(r#"class="page-lede""#).count();
         assert_eq!(
-            count, 11,
-            "expected exactly 11 page-lede paragraphs (one per top-level tab), got {count}"
+            count, 12,
+            "expected exactly 12 page-lede paragraphs (one per top-level tab), got {count}"
         );
         let h1_count = INDEX_HTML.matches(r#"class="page-h1""#).count();
         assert_eq!(
-            h1_count, 11,
-            "expected exactly 11 page-h1 headings (one per top-level tab), got {h1_count}"
+            h1_count, 12,
+            "expected exactly 12 page-h1 headings (one per top-level tab), got {h1_count}"
         );
     }
 


### PR DESCRIPTION
## Summary

Adds a new `/api/brain-failures` endpoint and corresponding **Brain Failures** dashboard tab that surfaces when and how the OODA brain failed — the most operationally critical missing self-knowledge dimension identified in the coverage matrix (#1949).

Closes #2043

## What changed

### API endpoint: `/api/brain-failures`
- Scans the most recent 50 cycle reports from `~/.simard/cycle_reports/cycle_*.json`
- Extracts `brain_judgments[]` entries where `fallback == true` or `parse_failure != null`
- Returns failures in reverse chronological order with plain-English descriptions
- Includes summary stats (total parse failures, fallback count, cycles scanned)
- Counts `brain_parse_failure` entries from `metrics/metrics.jsonl`

### Dashboard tab: Brain Failures
- **Summary card**: status indicator, parse failure count, fallback count, cycles scanned
- **Failure list**: each entry shows failure type, triggering component, timestamp, recovery status
- Expandable raw model response for parse failures
- Auto-refreshes every 30s while the tab is active

### Plain-English descriptions
- `parse_failure` → "Brain could not understand model response"
- `deterministic_fallback` → "Brain used safe fallback rules instead of model"
- Phase names expanded: act/decide/orient → full English descriptions

### UX conventions (per #1993, #1995, #1996)
- Unique page title: "Brain Failures · Simard"
- One-sentence plain-English lede (no banned jargon)
- Substantive nav tooltip
- Tab metadata in single source of truth (`tab_meta.rs`)

## Files changed (9 files, focused diff)
- `brain_failures.rs` — new API endpoint + unit tests
- `routes.rs` — wire `/api/brain-failures` route
- `mod.rs` — register module
- `tab_meta.rs` — add Brain Failures tab entry
- `part_00.rs` — HTML panel markup
- `part_01.rs` — tab click handler
- `part_04.rs` — `fetchBrainFailures()` JS function
- `tests_tab_meta.rs` — tab count 11→12
- `tests_routes_a.rs` — tab count + tab list assertions 11→12

## Evidence of merge-ready criteria

1. **Tests**: 138 dashboard tests pass including all tab-identity cross-checks (tab_meta slug/label/h1/lede/tooltip uniqueness, rendered HTML correspondence, jargon ban). 3 unit tests for the brain_failures module.
2. **Docs**: Dashboard tab is self-documenting (lede, tooltip). No external docs surface changed.
3. **Quality**: cargo fmt ✓, cargo clippy -D warnings ✓ (both pre-commit and pre-push hooks passed).
4. **CI**: Pre-push hooks passed: fmt check, cognitive_memory/bootstrap/memory_ipc tests, clippy --all-targets.
5. **Diff focused**: Only brain-failures feature code + test count updates. No unrelated edits.
