### PR TITLE
feat(dashboard): add per-PR readiness panel and /api/prs endpoint (#2042)

### DIFF
--- a/src/operator_commands_dashboard/index_html/part_01.rs
+++ b/src/operator_commands_dashboard/index_html/part_01.rs
@@ -23,6 +23,16 @@ pub(crate) const PART_01: &str = r#"      </div>
     </div>
   </div>
 
+  <div class="tab-content" id="tab-pr-readiness">
+    <h1 class="page-h1">PR Readiness</h1>
+    <p class="page-lede">Every open pull request under management with its CI status, review state, and remaining blockers — so you can see what is ready to merge without leaving the dashboard.</p>
+    <div class="card" style="max-width:1100px">
+      <h2>Open Pull Requests <button class="btn" onclick="fetchPrReadiness()" style="font-size:.75rem">Refresh</button></h2>
+      <div id="pr-readiness-summary" style="margin-bottom:.75rem"><span class="loading">Loading…</span></div>
+      <div id="pr-readiness-panel"><span class="loading">Loading…</span></div>
+    </div>
+  </div>
+
   <div class="tab-content" id="tab-terminal">
     <h1 class="page-h1">Terminal</h1>
     <p class="page-lede">Attach to the live terminal of a running Simard sub-agent and watch its standard output and standard error stream in real time.</p>
@@ -219,6 +229,7 @@ pub(crate) const PART_01: &str = r#"      </div>
         if(tab.dataset.tab==='thinking') {fetchThinking();tabRefreshTimers.thinking=setInterval(fetchThinking,30000);}
         if(tab.dataset.tab==='brain-failures') {fetchBrainFailures();tabRefreshTimers.brainFailures=setInterval(fetchBrainFailures,30000);}
         if(tab.dataset.tab==='merge-decisions') {fetchMergeJudge();tabRefreshTimers.mergeJudge=setInterval(fetchMergeJudge,30000);}
+        if(tab.dataset.tab==='pr-readiness') {fetchPrReadiness();tabRefreshTimers.prReadiness=setInterval(fetchPrReadiness,30000);}
         if(tab.dataset.tab==='terminal') {initAgentLogTerminal();fetchSubagentSessions();tabRefreshTimers.subagent=setInterval(fetchSubagentSessions,5000);fetchTmuxSessions();tabRefreshTimers.tmux=setInterval(fetchTmuxSessions,10000);}
       });
     });

--- a/src/operator_commands_dashboard/index_html/part_05.rs
+++ b/src/operator_commands_dashboard/index_html/part_05.rs
@@ -177,6 +177,78 @@ pub(crate) const PART_05: &str = r#"      try {
       }
     }
 
+    /* --- PR Readiness (#2042) --- */
+    async function fetchPrReadiness(){
+      const sumEl=document.getElementById('pr-readiness-summary');
+      const el=document.getElementById('pr-readiness-panel');
+      if(!el) return;
+      try {
+        const d = await apiFetch('/api/prs');
+        const prs = Array.isArray(d.prs) ? d.prs : [];
+        const summary = d.summary || {};
+
+        if(d.error){
+          sumEl.innerHTML='<div class="err" style="font-size:.85rem">'+esc(d.error)+'</div>';
+        } else {
+          sumEl.innerHTML=
+              '<div style="display:flex;gap:1rem;flex-wrap:wrap;font-size:.85rem">'
+            +   '<span>Total: <strong>'+esc(String(summary.total||0))+'</strong></span>'
+            +   '<span class="ok">Ready: <strong>'+esc(String(summary.ready||0))+'</strong></span>'
+            +   '<span class="err">Blocked: <strong>'+esc(String(summary.blocked||0))+'</strong></span>'
+            +   '<span class="warn">Pending: <strong>'+esc(String(summary.pending||0))+'</strong></span>'
+            + '</div>';
+        }
+
+        if(prs.length === 0){
+          el.innerHTML =
+              '<div style="padding:1rem;text-align:center">'
+            +   '<div style="font-size:2rem;margin-bottom:.5rem">📋</div>'
+            +   '<div style="color:#8b949e;font-size:.95rem;max-width:540px;margin:0 auto;line-height:1.6">'
+            +     'No open pull requests found. When Simard opens or manages PRs, they will appear here with their readiness status.'
+            +   '</div>'
+            + '</div>';
+          return;
+        }
+
+        const rows = prs.map(function(pr){
+          let ciBadge;
+          if(pr.ci_status==='passing')       ciBadge='<span class="ok">✓ passing</span>';
+          else if(pr.ci_status==='failing')  ciBadge='<span class="err">✗ failing</span>';
+          else if(pr.ci_status==='pending')  ciBadge='<span class="warn">⏳ pending</span>';
+          else                               ciBadge='<span style="color:#8b949e">'+esc(pr.ci_status||'none')+'</span>';
+          let reviewBadge;
+          if(pr.review_status==='approved')              reviewBadge='<span class="ok">✓ approved</span>';
+          else if(pr.review_status==='changes_requested') reviewBadge='<span class="err">✗ changes requested</span>';
+          else if(pr.review_status==='review_required')  reviewBadge='<span class="warn">⏳ review required</span>';
+          else                                           reviewBadge='<span style="color:#8b949e">'+esc(pr.review_status||'none')+'</span>';
+          const blockerList = Array.isArray(pr.blockers) && pr.blockers.length
+            ? '<div style="margin-top:.2rem;font-size:.8rem;color:#f85149">'+pr.blockers.map(function(b){return '• '+esc(b);}).join('<br>')+'</div>'
+            : '';
+          const readyBadge = pr.ready
+            ? '<span class="ok" style="font-weight:700">✓ Ready</span>'
+            : '<span class="err" style="font-weight:700">✗ Blocked</span>';
+          const draft = pr.is_draft ? ' <span class="badge" style="background:#21262d;color:#8b949e">draft</span>' : '';
+          const titleEsc = esc(String(pr.title||'').slice(0,80));
+          return '<tr data-testid="pr-row-'+pr.number+'">'
+               + '<td><a href="'+esc(pr.url||'')+'" target="_blank" style="color:var(--accent)">#'+esc(String(pr.number))+'</a>'+draft+'</td>'
+               + '<td style="max-width:320px">'+titleEsc+'</td>'
+               + '<td><code>'+esc(String(pr.base_branch||''))+'</code></td>'
+               + '<td>'+ciBadge+'</td>'
+               + '<td>'+reviewBadge+'</td>'
+               + '<td>'+readyBadge+blockerList+'</td>'
+               + '<td style="color:#8b949e;font-size:.8rem">'+formatTime(pr.updated_at)+'</td>'
+               + '</tr>';
+        }).join('');
+
+        el.innerHTML =
+            '<table class="proc-table" data-testid="pr-readiness-table">'
+          + '<thead><tr><th>PR</th><th>Title</th><th>Base</th><th>CI</th><th>Review</th><th>Status</th><th>Updated</th></tr></thead>'
+          + '<tbody>' + rows + '</tbody></table>';
+      } catch(e) {
+        el.innerHTML = '<span class="err">Failed to load PR readiness: '+esc(e.message||e)+'</span>';
+      }
+    }
+
     /* --- Merge Readiness (#1880) --- */
     async function fetchMergeReadiness(){
       const el=document.getElementById('merge-readiness-panel');

--- a/src/operator_commands_dashboard/index_html/tab_meta.rs
+++ b/src/operator_commands_dashboard/index_html/tab_meta.rs
@@ -170,6 +170,14 @@ pub const TAB_METADATA: &[TabMeta] = &[
         tooltip: "History of merge-judge verdicts for each evaluated pull request",
     },
     TabMeta {
+        slug: "pr-readiness",
+        label: "PR Readiness",
+        title: "PR Readiness · Simard",
+        h1: "PR Readiness",
+        lede: "Every open pull request under management with its CI status, review state, and remaining blockers — so you can see what is ready to merge without leaving the dashboard.",
+        tooltip: "Open PRs with CI status, review state, and merge blockers",
+    },
+    TabMeta {
         slug: "terminal",
         label: "Terminal",
         title: "Terminal · Simard",

--- a/src/operator_commands_dashboard/index_html/tests_tab_meta.rs
+++ b/src/operator_commands_dashboard/index_html/tests_tab_meta.rs
@@ -19,7 +19,7 @@ fn tab_meta_slugs_unique() {
             t.slug
         );
     }
-    assert_eq!(TAB_METADATA.len(), 13, "expected 13 tabs");
+    assert_eq!(TAB_METADATA.len(), 14, "expected 14 tabs");
 }
 
 #[test]

--- a/src/operator_commands_dashboard/mod.rs
+++ b/src/operator_commands_dashboard/mod.rs
@@ -15,6 +15,7 @@ mod merge_judge;
 mod merge_readiness;
 mod metrics;
 mod monitoring;
+mod pr_readiness;
 mod registry;
 pub(crate) mod routes;
 mod subagent;

--- a/src/operator_commands_dashboard/pr_readiness.rs
+++ b/src/operator_commands_dashboard/pr_readiness.rs
@@ -1,0 +1,468 @@
+//! Per-PR Readiness panel endpoint (#2042).
+//!
+//! Surfaces every open PR under Simard's management with its CI status,
+//! review state, and remaining blockers so an operator can assess readiness
+//! without switching to GitHub.
+//!
+//! Data sources:
+//!   - `gh pr list` for live PR metadata (title, CI checks, review state,
+//!     mergeable status, labels).
+//!
+//! ## JSON contract
+//!
+//! ```json
+//! {
+//!   "prs": [
+//!     {
+//!       "number": 2001,
+//!       "title": "feat: add PR readiness panel",
+//!       "url": "https://github.com/rysweet/Simard/pull/2001",
+//!       "author": "simard-bot",
+//!       "head_branch": "feat/pr-readiness",
+//!       "base_branch": "main",
+//!       "ci_status": "passing",
+//!       "review_status": "approved",
+//!       "mergeable": "MERGEABLE",
+//!       "labels": ["enhancement"],
+//!       "blockers": [],
+//!       "ready": true,
+//!       "created_at": "2026-05-24T10:00:00Z",
+//!       "updated_at": "2026-05-25T09:42:00Z"
+//!     }
+//!   ],
+//!   "summary": {
+//!     "total": 10,
+//!     "ready": 3,
+//!     "blocked": 5,
+//!     "pending": 2
+//!   },
+//!   "timestamp": "2026-05-25T10:00:00Z"
+//! }
+//! ```
+
+use axum::Json;
+use serde_json::{Value, json};
+
+/// Repo the panel targets.
+const HOME_REPO: &str = "rysweet/Simard";
+
+/// Maximum PRs to fetch.
+const PR_LIMIT: u32 = 50;
+
+/// Classify CI check status from the statusCheckRollup entries.
+fn classify_ci_status(checks: &[Value]) -> &'static str {
+    if checks.is_empty() {
+        return "none";
+    }
+    let mut has_pending = false;
+    for check in checks {
+        let state = check
+            .get("state")
+            .or_else(|| check.get("conclusion"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        match state {
+            "FAILURE" | "ERROR" | "TIMED_OUT" | "CANCELLED" | "ACTION_REQUIRED"
+            | "STARTUP_FAILURE" => return "failing",
+            "PENDING" | "QUEUED" | "IN_PROGRESS" | "WAITING" | "" => has_pending = true,
+            _ => {} // SUCCESS, NEUTRAL, SKIPPED — all fine
+        }
+    }
+    if has_pending { "pending" } else { "passing" }
+}
+
+/// Classify review status from reviewDecision.
+fn classify_review_status(review_decision: &str) -> &'static str {
+    match review_decision {
+        "APPROVED" => "approved",
+        "CHANGES_REQUESTED" => "changes_requested",
+        "REVIEW_REQUIRED" => "review_required",
+        "" => "none",
+        _ => "unknown",
+    }
+}
+
+/// Determine blockers for a PR.
+fn determine_blockers(
+    ci_status: &str,
+    review_status: &str,
+    mergeable: &str,
+    is_draft: bool,
+) -> Vec<String> {
+    let mut blockers = Vec::new();
+    if is_draft {
+        blockers.push("PR is a draft".to_string());
+    }
+    if ci_status == "failing" {
+        blockers.push("CI checks are failing".to_string());
+    }
+    if ci_status == "pending" {
+        blockers.push("CI checks still running".to_string());
+    }
+    if review_status == "changes_requested" {
+        blockers.push("Changes requested by reviewer".to_string());
+    }
+    if review_status == "review_required" {
+        blockers.push("Review required".to_string());
+    }
+    if mergeable == "CONFLICTING" {
+        blockers.push("Merge conflicts".to_string());
+    }
+    if mergeable == "UNKNOWN" {
+        blockers.push("Mergeability unknown".to_string());
+    }
+    blockers
+}
+
+/// Build the response JSON from raw PR data. Separated from the handler
+/// for unit testability.
+pub fn build_pr_readiness_response(raw_prs: &[Value]) -> Value {
+    let mut prs = Vec::with_capacity(raw_prs.len());
+    let mut total_ready = 0u32;
+    let mut total_blocked = 0u32;
+    let mut total_pending = 0u32;
+
+    for pr in raw_prs {
+        let number = pr.get("number").and_then(|v| v.as_u64()).unwrap_or(0);
+        let title = pr
+            .get("title")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let url = pr
+            .get("url")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let author = pr
+            .get("author")
+            .and_then(|v| v.get("login"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown")
+            .to_string();
+        let head_branch = pr
+            .get("headRefName")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let base_branch = pr
+            .get("baseRefName")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let mergeable = pr
+            .get("mergeable")
+            .and_then(|v| v.as_str())
+            .unwrap_or("UNKNOWN")
+            .to_string();
+        let is_draft = pr.get("isDraft").and_then(|v| v.as_bool()).unwrap_or(false);
+        let review_decision = pr
+            .get("reviewDecision")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let created_at = pr
+            .get("createdAt")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let updated_at = pr
+            .get("updatedAt")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        let labels: Vec<String> = pr
+            .get("labels")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|l| l.get("name").and_then(|n| n.as_str()))
+                    .map(|s| s.to_string())
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let checks: Vec<Value> = pr
+            .get("statusCheckRollup")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+
+        let ci_status = classify_ci_status(&checks);
+        let review_status = classify_review_status(review_decision);
+        let blockers = determine_blockers(ci_status, review_status, &mergeable, is_draft);
+        let ready = blockers.is_empty();
+
+        if ready {
+            total_ready += 1;
+        } else if ci_status == "pending" {
+            total_pending += 1;
+        } else {
+            total_blocked += 1;
+        }
+
+        prs.push(json!({
+            "number": number,
+            "title": title,
+            "url": url,
+            "author": author,
+            "head_branch": head_branch,
+            "base_branch": base_branch,
+            "ci_status": ci_status,
+            "review_status": review_status,
+            "mergeable": mergeable,
+            "is_draft": is_draft,
+            "labels": labels,
+            "blockers": blockers,
+            "ready": ready,
+            "created_at": created_at,
+            "updated_at": updated_at,
+        }));
+    }
+
+    json!({
+        "prs": prs,
+        "summary": {
+            "total": raw_prs.len(),
+            "ready": total_ready,
+            "blocked": total_blocked,
+            "pending": total_pending,
+        },
+        "timestamp": chrono::Utc::now().to_rfc3339(),
+    })
+}
+
+/// `GET /api/prs` handler.
+///
+/// Queries `gh pr list` for all open PRs with CI, review, and merge status,
+/// then returns a structured JSON response for the dashboard panel.
+pub(crate) async fn pr_readiness() -> Json<Value> {
+    let list_result = tokio::process::Command::new("gh")
+        .args([
+            "pr",
+            "list",
+            "--repo",
+            HOME_REPO,
+            "--state",
+            "open",
+            "--limit",
+            &PR_LIMIT.to_string(),
+            "--json",
+            "number,title,url,author,headRefName,baseRefName,mergeable,isDraft,\
+             reviewDecision,labels,statusCheckRollup,createdAt,updatedAt",
+        ])
+        .output()
+        .await;
+
+    match list_result {
+        Ok(output) if output.status.success() => {
+            let raw = String::from_utf8_lossy(&output.stdout);
+            match serde_json::from_str::<Vec<Value>>(&raw) {
+                Ok(prs) => Json(build_pr_readiness_response(&prs)),
+                Err(e) => Json(json!({
+                    "prs": [],
+                    "summary": { "total": 0, "ready": 0, "blocked": 0, "pending": 0 },
+                    "error": format!("failed to parse gh output: {e}"),
+                    "timestamp": chrono::Utc::now().to_rfc3339(),
+                })),
+            }
+        }
+        Ok(output) => {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            Json(json!({
+                "prs": [],
+                "summary": { "total": 0, "ready": 0, "blocked": 0, "pending": 0 },
+                "error": format!("gh pr list failed: {}", stderr.chars().take(300).collect::<String>()),
+                "timestamp": chrono::Utc::now().to_rfc3339(),
+            }))
+        }
+        Err(e) => Json(json!({
+            "prs": [],
+            "summary": { "total": 0, "ready": 0, "blocked": 0, "pending": 0 },
+            "error": format!("failed to run gh: {e}"),
+            "timestamp": chrono::Utc::now().to_rfc3339(),
+        })),
+    }
+}
+
+// ─────────────────────────── Tests ──────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_pr(number: u64, ci_state: &str, review: &str, mergeable: &str) -> Value {
+        json!({
+            "number": number,
+            "title": format!("test PR {number}"),
+            "url": format!("https://github.com/rysweet/Simard/pull/{number}"),
+            "author": { "login": "test-user" },
+            "headRefName": format!("feat/test-{number}"),
+            "baseRefName": "main",
+            "mergeable": mergeable,
+            "isDraft": false,
+            "reviewDecision": review,
+            "labels": [{ "name": "enhancement" }],
+            "statusCheckRollup": [{ "state": ci_state }],
+            "createdAt": "2026-05-24T10:00:00Z",
+            "updatedAt": "2026-05-25T09:00:00Z",
+        })
+    }
+
+    #[test]
+    fn ready_pr_has_no_blockers() {
+        let prs = vec![make_pr(1, "SUCCESS", "APPROVED", "MERGEABLE")];
+        let resp = build_pr_readiness_response(&prs);
+        assert_eq!(resp["prs"][0]["ready"], true);
+        assert!(resp["prs"][0]["blockers"].as_array().unwrap().is_empty());
+        assert_eq!(resp["summary"]["ready"], 1);
+        assert_eq!(resp["summary"]["blocked"], 0);
+    }
+
+    #[test]
+    fn failing_ci_is_blocker() {
+        let prs = vec![make_pr(2, "FAILURE", "APPROVED", "MERGEABLE")];
+        let resp = build_pr_readiness_response(&prs);
+        assert_eq!(resp["prs"][0]["ready"], false);
+        assert_eq!(resp["prs"][0]["ci_status"], "failing");
+        let blockers: Vec<&str> = resp["prs"][0]["blockers"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|b| b.as_str().unwrap())
+            .collect();
+        assert!(blockers.iter().any(|b| b.contains("CI")));
+        assert_eq!(resp["summary"]["blocked"], 1);
+    }
+
+    #[test]
+    fn pending_ci_is_pending_not_blocked() {
+        let prs = vec![make_pr(3, "PENDING", "APPROVED", "MERGEABLE")];
+        let resp = build_pr_readiness_response(&prs);
+        assert_eq!(resp["prs"][0]["ready"], false);
+        assert_eq!(resp["prs"][0]["ci_status"], "pending");
+        assert_eq!(resp["summary"]["pending"], 1);
+        assert_eq!(resp["summary"]["blocked"], 0);
+    }
+
+    #[test]
+    fn changes_requested_is_blocker() {
+        let prs = vec![make_pr(4, "SUCCESS", "CHANGES_REQUESTED", "MERGEABLE")];
+        let resp = build_pr_readiness_response(&prs);
+        assert_eq!(resp["prs"][0]["ready"], false);
+        let blockers: Vec<&str> = resp["prs"][0]["blockers"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|b| b.as_str().unwrap())
+            .collect();
+        assert!(blockers.iter().any(|b| b.contains("Changes requested")));
+    }
+
+    #[test]
+    fn merge_conflict_is_blocker() {
+        let prs = vec![make_pr(5, "SUCCESS", "APPROVED", "CONFLICTING")];
+        let resp = build_pr_readiness_response(&prs);
+        assert_eq!(resp["prs"][0]["ready"], false);
+        let blockers: Vec<&str> = resp["prs"][0]["blockers"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|b| b.as_str().unwrap())
+            .collect();
+        assert!(blockers.iter().any(|b| b.contains("conflict")));
+    }
+
+    #[test]
+    fn draft_pr_is_blocker() {
+        let prs = vec![json!({
+            "number": 6,
+            "title": "draft PR",
+            "url": "https://github.com/rysweet/Simard/pull/6",
+            "author": { "login": "test-user" },
+            "headRefName": "feat/draft",
+            "baseRefName": "main",
+            "mergeable": "MERGEABLE",
+            "isDraft": true,
+            "reviewDecision": "APPROVED",
+            "labels": [],
+            "statusCheckRollup": [{ "state": "SUCCESS" }],
+            "createdAt": "2026-05-24T10:00:00Z",
+            "updatedAt": "2026-05-25T09:00:00Z",
+        })];
+        let resp = build_pr_readiness_response(&prs);
+        assert_eq!(resp["prs"][0]["ready"], false);
+        let blockers: Vec<&str> = resp["prs"][0]["blockers"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|b| b.as_str().unwrap())
+            .collect();
+        assert!(blockers.iter().any(|b| b.contains("draft")));
+    }
+
+    #[test]
+    fn summary_aggregates_mixed_states() {
+        let prs = vec![
+            make_pr(1, "SUCCESS", "APPROVED", "MERGEABLE"),
+            make_pr(2, "SUCCESS", "APPROVED", "MERGEABLE"),
+            make_pr(3, "FAILURE", "APPROVED", "MERGEABLE"),
+            make_pr(4, "PENDING", "APPROVED", "MERGEABLE"),
+            make_pr(5, "SUCCESS", "CHANGES_REQUESTED", "MERGEABLE"),
+        ];
+        let resp = build_pr_readiness_response(&prs);
+        assert_eq!(resp["summary"]["total"], 5);
+        assert_eq!(resp["summary"]["ready"], 2);
+        assert_eq!(resp["summary"]["blocked"], 2);
+        assert_eq!(resp["summary"]["pending"], 1);
+    }
+
+    #[test]
+    fn empty_prs_returns_empty_response() {
+        let resp = build_pr_readiness_response(&[]);
+        assert_eq!(resp["summary"]["total"], 0);
+        assert!(resp["prs"].as_array().unwrap().is_empty());
+        assert!(resp["timestamp"].is_string());
+    }
+
+    #[test]
+    fn classify_ci_status_no_checks() {
+        assert_eq!(classify_ci_status(&[]), "none");
+    }
+
+    #[test]
+    fn classify_ci_status_all_passing() {
+        let checks = vec![json!({"state": "SUCCESS"}), json!({"state": "NEUTRAL"})];
+        assert_eq!(classify_ci_status(&checks), "passing");
+    }
+
+    #[test]
+    fn classify_ci_status_one_failure() {
+        let checks = vec![json!({"state": "SUCCESS"}), json!({"state": "FAILURE"})];
+        assert_eq!(classify_ci_status(&checks), "failing");
+    }
+
+    #[test]
+    fn classify_ci_status_pending_without_failure() {
+        let checks = vec![json!({"state": "SUCCESS"}), json!({"state": "PENDING"})];
+        assert_eq!(classify_ci_status(&checks), "pending");
+    }
+
+    #[test]
+    fn classify_review_approved() {
+        assert_eq!(classify_review_status("APPROVED"), "approved");
+    }
+
+    #[test]
+    fn classify_review_changes_requested() {
+        assert_eq!(
+            classify_review_status("CHANGES_REQUESTED"),
+            "changes_requested"
+        );
+    }
+
+    #[test]
+    fn classify_review_empty() {
+        assert_eq!(classify_review_status(""), "none");
+    }
+}

--- a/src/operator_commands_dashboard/routes.rs
+++ b/src/operator_commands_dashboard/routes.rs
@@ -21,6 +21,7 @@ use super::merge_judge::merge_judge_decisions;
 use super::merge_readiness::merge_readiness;
 use super::metrics::{memory_metrics, ooda_thinking};
 use super::monitoring::{costs, get_budget, metrics, set_budget};
+use super::pr_readiness::pr_readiness;
 use super::registry::{
     agent_graph, build_lock_force_release, build_lock_status, registry_deregister, registry_list,
     registry_reap, registry_register,
@@ -72,6 +73,7 @@ pub fn build_router() -> Router {
         .route("/api/current-work", get(current_work))
         .route("/api/ooda-thinking", get(ooda_thinking))
         .route("/api/brain-failures", get(brain_failures))
+        .route("/api/prs", get(pr_readiness))
         .route("/api/subagent-sessions", get(subagent_sessions))
         .route("/ws/chat", get(ws_chat_handler))
         .route(WS_AGENT_LOG_ROUTE, get(ws_agent_log_handler))

--- a/src/operator_commands_dashboard/tests_routes_a.rs
+++ b/src/operator_commands_dashboard/tests_routes_a.rs
@@ -649,13 +649,13 @@ mod tests {
     fn index_html_has_exactly_eleven_page_intros() {
         let count = INDEX_HTML.matches(r#"class="page-lede""#).count();
         assert_eq!(
-            count, 13,
-            "expected exactly 13 page-lede paragraphs (one per top-level tab), got {count}"
+            count, 14,
+            "expected exactly 14 page-lede paragraphs (one per top-level tab), got {count}"
         );
         let h1_count = INDEX_HTML.matches(r#"class="page-h1""#).count();
         assert_eq!(
-            h1_count, 13,
-            "expected exactly 13 page-h1 headings (one per top-level tab), got {h1_count}"
+            h1_count, 14,
+            "expected exactly 14 page-h1 headings (one per top-level tab), got {h1_count}"
         );
     }
 


### PR DESCRIPTION
## Summary

Adds a new **PR Readiness** tab to the operator dashboard that surfaces every open PR under management with CI status, review state, and remaining blockers — so an operator can assess merge readiness without leaving the dashboard.

This closes the last **MISSING** dimension in the seven-dimension coverage matrix (#1949, dimension 6).

## Changes

### Backend: `/api/prs` endpoint (`pr_readiness.rs`)
- Queries `gh pr list` with full JSON fields (CI checks, review decision, mergeable, draft status, labels)
- Classifies CI status as `passing`, `failing`, `pending`, or `none`
- Classifies review status as `approved`, `changes_requested`, `review_required`, or `none`
- Computes blockers per PR (draft, CI failing/pending, changes requested, review required, merge conflicts)
- Returns structured JSON with per-PR details and aggregate summary
- Gracefully degrades when `gh` is unavailable

### Frontend: PR Readiness tab
- Summary stats bar: total, ready, blocked, pending counts with color-coded badges
- Table with columns: PR number (linked), title, base branch, CI status, review status, readiness status with blockers, last updated
- Empty-state message when no PRs found
- Error display when API fails
- Auto-refresh every 30 seconds when tab is active

### Infrastructure
- Tab metadata in `tab_meta.rs` with lede, tooltip, and cross-check compliance
- Page count assertions updated from 13 → 14
- 15 unit tests covering all classification and aggregation logic

## Test evidence

### Unit tests (15/15 passing)
```
cargo test --release --lib pr_readiness
test result: ok. 15 passed; 0 failed
```

### Tab meta cross-checks (22/22 passing)
```
cargo test --release --lib tests_tab_meta
test result: ok. 22 passed; 0 failed
```

### Full dashboard test suite (152/152 passing)
```
cargo test --release --lib operator_commands_dashboard
test result: ok. 152 passed; 0 failed
```

### Build
```
cargo build --release — success (0 errors, 0 warnings in changed crate)
cargo fmt --all -- --check — clean
```

## Diff focused
8 files changed — all within `src/operator_commands_dashboard/`. No unrelated edits.

Closes #2042