### PR TITLE
test(cognitive_memory): add inline unit tests for backup.rs, ops.rs, mod.rs (#2036)

### DIFF
--- a/src/cognitive_memory/backup.rs
+++ b/src/cognitive_memory/backup.rs
@@ -826,3 +826,382 @@ impl NativeCognitiveMemory {
         result
     }
 }
+
+// ============================================================================
+// Inline unit tests for backup.rs (issue #2036)
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cognitive_memory::CognitiveMemoryOps;
+
+    fn test_mem() -> NativeCognitiveMemory {
+        NativeCognitiveMemory::in_memory().expect("in-memory DB should create")
+    }
+
+    // ── sha256_file ────────────────────────────────────────────────────
+
+    #[test]
+    fn sha256_file_produces_64_hex_chars() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), b"hello world").unwrap();
+        let hash = sha256_file(tmp.path()).unwrap();
+        assert_eq!(hash.len(), 64, "SHA-256 hex digest must be 64 chars");
+        assert!(
+            hash.chars().all(|c| c.is_ascii_hexdigit()),
+            "must be hex chars"
+        );
+    }
+
+    #[test]
+    fn sha256_file_deterministic() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), b"deterministic content").unwrap();
+        let h1 = sha256_file(tmp.path()).unwrap();
+        let h2 = sha256_file(tmp.path()).unwrap();
+        assert_eq!(h1, h2, "same content must produce same hash");
+    }
+
+    #[test]
+    fn sha256_file_differs_for_different_content() {
+        let f1 = tempfile::NamedTempFile::new().unwrap();
+        let f2 = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(f1.path(), b"aaa").unwrap();
+        std::fs::write(f2.path(), b"bbb").unwrap();
+        let h1 = sha256_file(f1.path()).unwrap();
+        let h2 = sha256_file(f2.path()).unwrap();
+        assert_ne!(h1, h2, "different content must produce different hashes");
+    }
+
+    #[test]
+    fn sha256_file_errors_on_missing_file() {
+        let result = sha256_file(std::path::Path::new("/nonexistent/file"));
+        assert!(result.is_err());
+    }
+
+    // ── atomic_copy_with_fsync ─────────────────────────────────────────
+
+    #[test]
+    fn atomic_copy_with_fsync_creates_exact_copy() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("source.db");
+        let dst = dir.path().join("dest.db");
+        std::fs::write(&src, b"important data here").unwrap();
+
+        atomic_copy_with_fsync(&src, &dst).unwrap();
+
+        assert!(dst.exists(), "destination must exist after copy");
+        assert_eq!(
+            std::fs::read(&src).unwrap(),
+            std::fs::read(&dst).unwrap(),
+            "dst must be byte-identical to src"
+        );
+    }
+
+    #[test]
+    fn atomic_copy_with_fsync_removes_leftover_tmp() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("source.db");
+        let dst = dir.path().join("dest.db");
+        let tmp = dir.path().join("dest.db.tmp");
+        std::fs::write(&src, b"source data").unwrap();
+        std::fs::write(&tmp, b"stale tmp leftover").unwrap();
+
+        atomic_copy_with_fsync(&src, &dst).unwrap();
+
+        assert!(!tmp.exists(), "leftover .tmp must be cleaned up");
+        assert!(dst.exists());
+    }
+
+    #[test]
+    fn atomic_copy_with_fsync_errors_on_missing_src() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("missing.db");
+        let dst = dir.path().join("dest.db");
+        let result = atomic_copy_with_fsync(&src, &dst);
+        assert!(result.is_err(), "missing source must be an error");
+    }
+
+    #[test]
+    fn atomic_copy_with_fsync_overwrites_existing_dst() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("source.db");
+        let dst = dir.path().join("dest.db");
+        std::fs::write(&src, b"new content").unwrap();
+        std::fs::write(&dst, b"old content").unwrap();
+
+        atomic_copy_with_fsync(&src, &dst).unwrap();
+        assert_eq!(std::fs::read(&dst).unwrap(), b"new content");
+    }
+
+    // ── post_write_barrier ─────────────────────────────────────────────
+
+    #[test]
+    fn post_write_barrier_noop_for_in_memory() {
+        let mem = test_mem();
+        assert!(!mem.durable_writes);
+        mem.post_write_barrier("test")
+            .expect("in-memory barrier must be no-op");
+    }
+
+    #[test]
+    #[serial_test::serial(cognitive_memory)]
+    fn post_write_barrier_succeeds_on_disk() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mem = NativeCognitiveMemory::open(tmp.path()).unwrap();
+        assert!(mem.durable_writes);
+        mem.post_write_barrier("test_backup")
+            .expect("on-disk barrier must succeed");
+    }
+
+    // ── wal_paths ──────────────────────────────────────────────────────
+
+    #[test]
+    fn wal_paths_returns_two_entries() {
+        let db_path = std::path::Path::new("/tmp/cognitive_memory.ladybug");
+        let paths = NativeCognitiveMemory::wal_paths(db_path);
+        assert_eq!(paths.len(), 2);
+        for p in &paths {
+            let s = p.to_string_lossy();
+            assert!(s.contains("wal"), "WAL path should contain 'wal': {s}");
+        }
+    }
+
+    // ── preemptive_wal_cleanup ──────────────────────────────────────────
+
+    #[test]
+    fn preemptive_wal_cleanup_removes_empty_wal() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.ladybug");
+        std::fs::write(&db_path, b"db data").unwrap();
+
+        for wal in NativeCognitiveMemory::wal_paths(&db_path) {
+            std::fs::write(&wal, b"").unwrap(); // empty WAL
+        }
+
+        NativeCognitiveMemory::preemptive_wal_cleanup(&db_path).unwrap();
+
+        for wal in NativeCognitiveMemory::wal_paths(&db_path) {
+            assert!(
+                !wal.exists(),
+                "empty WAL should be removed: {}",
+                wal.display()
+            );
+        }
+    }
+
+    #[test]
+    fn preemptive_wal_cleanup_keeps_nonempty_wal() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.ladybug");
+        std::fs::write(&db_path, b"db data").unwrap();
+
+        let wals = NativeCognitiveMemory::wal_paths(&db_path);
+        std::fs::write(&wals[0], b"valid wal data").unwrap();
+
+        NativeCognitiveMemory::preemptive_wal_cleanup(&db_path).unwrap();
+
+        assert!(wals[0].exists(), "non-empty WAL must be preserved");
+    }
+
+    #[test]
+    fn preemptive_wal_cleanup_noop_when_no_wals() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.ladybug");
+        std::fs::write(&db_path, b"db data").unwrap();
+        // No WAL files exist
+        NativeCognitiveMemory::preemptive_wal_cleanup(&db_path).unwrap();
+    }
+
+    // ── is_lock_contention_error ────────────────────────────────────────
+
+    #[test]
+    fn is_lock_contention_detects_lock_message() {
+        let err = SimardError::RuntimeInitFailed {
+            component: "cognitive-memory".into(),
+            reason: "Could not set lock on file /some/path".into(),
+        };
+        assert!(NativeCognitiveMemory::is_lock_contention_error(&err));
+    }
+
+    #[test]
+    fn is_lock_contention_detects_eagain() {
+        let err = SimardError::RuntimeInitFailed {
+            component: "cognitive-memory".into(),
+            reason: "Resource temporarily unavailable".into(),
+        };
+        assert!(NativeCognitiveMemory::is_lock_contention_error(&err));
+    }
+
+    #[test]
+    fn is_lock_contention_rejects_corruption() {
+        let err = SimardError::RuntimeInitFailed {
+            component: "cognitive-memory".into(),
+            reason: "WAL header CRC mismatch".into(),
+        };
+        assert!(!NativeCognitiveMemory::is_lock_contention_error(&err));
+    }
+
+    // ── find_backups_newest_first ────────────────────────────────────────
+
+    #[test]
+    fn find_backups_newest_first_sorted_descending() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_root = dir.path();
+        let backup_dir = state_root.join("backups");
+        std::fs::create_dir_all(&backup_dir).unwrap();
+
+        let db_path = state_root.join("cognitive_memory.ladybug");
+
+        // Create backup files with known epochs
+        for epoch in [100u64, 300, 200] {
+            std::fs::write(
+                backup_dir.join(format!("cognitive_memory.ladybug.{epoch}")),
+                b"db",
+            )
+            .unwrap();
+        }
+
+        let backups = NativeCognitiveMemory::find_backups_newest_first(&db_path);
+        assert_eq!(backups.len(), 3);
+        // Should be sorted newest first: 300, 200, 100
+        let names: Vec<String> = backups
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().to_string())
+            .collect();
+        assert!(names[0].ends_with(".300"), "newest first: {names:?}");
+        assert!(names[1].ends_with(".200"), "middle: {names:?}");
+        assert!(names[2].ends_with(".100"), "oldest last: {names:?}");
+    }
+
+    #[test]
+    fn find_backups_returns_empty_when_no_backup_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("cognitive_memory.ladybug");
+        let backups = NativeCognitiveMemory::find_backups_newest_first(&db_path);
+        assert!(backups.is_empty());
+    }
+
+    // ── verify_db_health ────────────────────────────────────────────────
+
+    #[test]
+    fn verify_db_health_succeeds_on_healthy_db() {
+        let mem = test_mem();
+        NativeCognitiveMemory::verify_db_health(&mem.db).unwrap();
+    }
+
+    // ── create_verified_backup ──────────────────────────────────────────
+
+    #[test]
+    #[serial_test::serial(cognitive_memory)]
+    fn create_verified_backup_produces_valid_backup() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state_root = tmp.path().to_path_buf();
+
+        {
+            let mem = NativeCognitiveMemory::open(&state_root).unwrap();
+            mem.store_fact("backup-test", "data", 0.9, &[], "test")
+                .unwrap();
+        }
+
+        let backup_path = NativeCognitiveMemory::create_verified_backup(&state_root).unwrap();
+        assert!(backup_path.exists(), "backup file must exist");
+        assert!(
+            backup_path
+                .to_string_lossy()
+                .contains("backups/cognitive_memory.ladybug."),
+            "backup must be in backups/ dir"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial(cognitive_memory)]
+    fn create_verified_backup_errors_when_no_db_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let err = NativeCognitiveMemory::create_verified_backup(tmp.path());
+        assert!(err.is_err(), "no DB file → must error");
+    }
+
+    // ── prune_old_backups ──────────────────────────────────────────────
+
+    #[test]
+    #[serial_test::serial(cognitive_memory)]
+    fn prune_old_backups_keeps_n_newest() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state_root = tmp.path().to_path_buf();
+        let backup_dir = state_root.join("backups");
+        std::fs::create_dir_all(&backup_dir).unwrap();
+
+        for epoch in [100u64, 200, 300, 400, 500] {
+            std::fs::write(
+                backup_dir.join(format!("cognitive_memory.ladybug.{epoch}")),
+                b"db",
+            )
+            .unwrap();
+        }
+
+        let outcome = NativeCognitiveMemory::prune_old_backups(&state_root, 2);
+        assert_eq!(outcome.removed, 3, "should remove 3 oldest");
+        assert!(outcome.failed.is_empty(), "no failures expected");
+
+        // The 2 newest (500, 400) should survive
+        assert!(backup_dir.join("cognitive_memory.ladybug.500").exists());
+        assert!(backup_dir.join("cognitive_memory.ladybug.400").exists());
+        assert!(!backup_dir.join("cognitive_memory.ladybug.100").exists());
+    }
+
+    #[test]
+    fn prune_old_backups_noop_when_no_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let outcome = NativeCognitiveMemory::prune_old_backups(tmp.path(), 5);
+        assert_eq!(outcome.removed, 0);
+        assert!(outcome.failed.is_empty());
+    }
+
+    // ── with_open_lock ─────────────────────────────────────────────────
+
+    #[test]
+    fn with_open_lock_executes_closure() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.ladybug");
+        std::fs::write(&db_path, b"").unwrap();
+
+        let result = NativeCognitiveMemory::with_open_lock(&db_path, || Ok(42u32));
+        assert_eq!(result.unwrap(), 42);
+    }
+
+    #[test]
+    fn with_open_lock_propagates_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.ladybug");
+        std::fs::write(&db_path, b"").unwrap();
+
+        let result: SimardResult<()> = NativeCognitiveMemory::with_open_lock(&db_path, || {
+            Err(SimardError::RuntimeInitFailed {
+                component: "test".into(),
+                reason: "intentional".into(),
+            })
+        });
+        assert!(result.is_err());
+    }
+
+    // ── fsync_recovery_replay ──────────────────────────────────────────
+
+    #[test]
+    fn fsync_recovery_replay_succeeds_on_real_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.ladybug");
+        std::fs::write(&db_path, b"db contents for fsync test").unwrap();
+        NativeCognitiveMemory::fsync_recovery_replay(&db_path)
+            .expect("fsync_recovery_replay must succeed on a real file");
+    }
+
+    #[test]
+    fn fsync_recovery_replay_errors_on_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("nonexistent.ladybug");
+        let result = NativeCognitiveMemory::fsync_recovery_replay(&db_path);
+        assert!(result.is_err(), "missing file must error");
+    }
+}

--- a/src/cognitive_memory/mod.rs
+++ b/src/cognitive_memory/mod.rs
@@ -517,3 +517,260 @@ mod tests_lock_vs_corruption_1967;
 
 #[cfg(test)]
 mod tests_hermetic_parity;
+
+// ============================================================================
+// Inline unit tests for mod.rs (issue #2036)
+// ============================================================================
+
+#[cfg(test)]
+mod tests_inline {
+    use super::*;
+
+    // ── NativeCognitiveMemory construction ──────────────────────────────
+
+    #[test]
+    fn in_memory_creates_successfully() {
+        let mem = NativeCognitiveMemory::in_memory().expect("in_memory should succeed");
+        assert!(!mem.read_only, "in_memory handle must not be read-only");
+        assert!(!mem.durable_writes, "in_memory must skip fsync barrier");
+    }
+
+    #[test]
+    fn in_memory_schema_is_applied() {
+        let mem = NativeCognitiveMemory::in_memory().unwrap();
+        // Schema DDL creates 8 node tables; a simple count query on each
+        // should succeed (returning 0) rather than erroring with
+        // "table does not exist".
+        for table in [
+            "Fact",
+            "Decision",
+            "Goal",
+            "Episode",
+            "Sensory",
+            "WorkingMemory",
+            "Procedure",
+            "Prospective",
+        ] {
+            let rows = mem
+                .query(&format!("MATCH (n:{table}) RETURN count(n)"))
+                .unwrap_or_else(|e| panic!("count query on {table} failed: {e}"));
+            assert_eq!(rows.len(), 1, "{table} count query should return one row");
+        }
+    }
+
+    #[test]
+    #[serial_test::serial(cognitive_memory)]
+    fn open_creates_db_directory_and_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state_root = tmp.path().to_path_buf();
+        let _mem = NativeCognitiveMemory::open(&state_root).unwrap();
+        assert!(
+            state_root.join("cognitive_memory.ladybug").exists(),
+            "DB file must be created under state_root"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial(cognitive_memory)]
+    fn open_sets_durable_writes_true() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mem = NativeCognitiveMemory::open(tmp.path()).unwrap();
+        assert!(
+            mem.durable_writes,
+            "on-disk writer must enable durable_writes"
+        );
+        assert!(!mem.read_only, "writer handle must not be read-only");
+    }
+
+    #[test]
+    #[serial_test::serial(cognitive_memory)]
+    fn open_migrates_kuzu_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state_root = tmp.path().to_path_buf();
+        let db_as_dir = state_root.join("cognitive_memory.ladybug");
+        std::fs::create_dir_all(&db_as_dir).unwrap();
+        std::fs::write(db_as_dir.join("dummy"), b"kuzu data").unwrap();
+
+        let _mem = NativeCognitiveMemory::open(&state_root).unwrap();
+
+        assert!(
+            !db_as_dir.is_dir() || db_as_dir.is_file(),
+            "old KuzuDB dir should be migrated away"
+        );
+        assert!(
+            state_root
+                .join("cognitive_memory.ladybug.kuzu-backup")
+                .exists(),
+            "backup of KuzuDB dir should exist"
+        );
+    }
+
+    // ── conn / query / execute helpers ──────────────────────────────────
+
+    #[test]
+    fn conn_creates_valid_connection() {
+        let mem = NativeCognitiveMemory::in_memory().unwrap();
+        let _conn = mem.conn().expect("conn() must return Ok");
+    }
+
+    #[test]
+    fn query_returns_rows() {
+        let mem = NativeCognitiveMemory::in_memory().unwrap();
+        let rows = mem.query("RETURN 42").unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(as_i64(&rows[0][0]), Some(42));
+    }
+
+    #[test]
+    fn execute_runs_ddl_without_error() {
+        let mem = NativeCognitiveMemory::in_memory().unwrap();
+        // Schema already created; re-executing DDL with IF NOT EXISTS is idempotent.
+        mem.execute(
+            "CREATE NODE TABLE IF NOT EXISTS TestInline(id STRING PRIMARY KEY, val STRING)",
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn execute_errors_on_invalid_cypher() {
+        let mem = NativeCognitiveMemory::in_memory().unwrap();
+        let err = mem.execute("THIS IS NOT VALID CYPHER !!!");
+        assert!(err.is_err(), "invalid Cypher must return Err");
+    }
+
+    // ── new_id ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn new_id_includes_prefix() {
+        let id = NativeCognitiveMemory::new_id("test");
+        assert!(id.starts_with("test_"), "id should start with prefix_");
+        assert!(id.len() > 5, "id should include uuid suffix");
+    }
+
+    #[test]
+    fn new_id_is_unique() {
+        let ids: Vec<String> = (0..100)
+            .map(|_| NativeCognitiveMemory::new_id("u"))
+            .collect();
+        let unique: std::collections::HashSet<&str> = ids.iter().map(|s| s.as_str()).collect();
+        assert_eq!(unique.len(), 100, "100 ids must all be unique");
+    }
+
+    // ── now_secs ───────────────────────────────────────────────────────
+
+    #[test]
+    fn now_secs_returns_plausible_epoch() {
+        let ts = NativeCognitiveMemory::now_secs().unwrap();
+        // After 2024-01-01 and before 2100-01-01
+        assert!(ts > 1_704_067_200.0, "timestamp too old: {ts}");
+        assert!(ts < 4_102_444_800.0, "timestamp too far future: {ts}");
+    }
+
+    // ── checkpoint ─────────────────────────────────────────────────────
+
+    #[test]
+    fn checkpoint_succeeds_on_in_memory() {
+        let mem = NativeCognitiveMemory::in_memory().unwrap();
+        // In-memory is not read_only, so checkpoint actually attempts
+        // the CHECKPOINT statement. It should succeed.
+        mem.checkpoint().expect("checkpoint should succeed");
+    }
+
+    #[test]
+    fn checkpoint_noop_on_read_only_in_memory() {
+        // Construct a mock read-only by flipping the flag on in_memory.
+        // This tests the early return branch.
+        let mut mem = NativeCognitiveMemory::in_memory().unwrap();
+        mem.read_only = true;
+        mem.checkpoint()
+            .expect("checkpoint on read-only must be Ok(())");
+    }
+
+    // ── post_write_barrier ─────────────────────────────────────────────
+
+    #[test]
+    fn post_write_barrier_noop_when_durable_writes_false() {
+        let mem = NativeCognitiveMemory::in_memory().unwrap();
+        assert!(!mem.durable_writes);
+        mem.post_write_barrier("test_op")
+            .expect("barrier must be no-op for in-memory");
+    }
+
+    #[test]
+    #[serial_test::serial(cognitive_memory)]
+    fn post_write_barrier_succeeds_for_on_disk_writer() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mem = NativeCognitiveMemory::open(tmp.path()).unwrap();
+        assert!(mem.durable_writes);
+        mem.post_write_barrier("test_op")
+            .expect("barrier must succeed on healthy on-disk file");
+    }
+
+    // ── Value conversion helpers ───────────────────────────────────────
+
+    #[test]
+    fn as_str_extracts_string() {
+        let val = lbug::Value::String("hello".to_string());
+        assert_eq!(as_str(&val), Some("hello"));
+    }
+
+    #[test]
+    fn as_str_returns_none_for_non_string() {
+        let val = lbug::Value::Int64(42);
+        assert_eq!(as_str(&val), None);
+    }
+
+    #[test]
+    fn as_i64_extracts_int() {
+        let val = lbug::Value::Int64(99);
+        assert_eq!(as_i64(&val), Some(99));
+    }
+
+    #[test]
+    fn as_i64_returns_none_for_string() {
+        let val = lbug::Value::String("not a number".to_string());
+        assert_eq!(as_i64(&val), None);
+    }
+
+    #[test]
+    fn as_f64_extracts_double() {
+        let val = lbug::Value::Double(42.5);
+        assert_eq!(as_f64(&val), Some(42.5));
+    }
+
+    #[test]
+    fn as_f64_coerces_int64_to_f64() {
+        let val = lbug::Value::Int64(7);
+        assert_eq!(as_f64(&val), Some(7.0));
+    }
+
+    #[test]
+    fn as_f64_returns_none_for_string() {
+        let val = lbug::Value::String("nope".to_string());
+        assert_eq!(as_f64(&val), None);
+    }
+
+    // ── CognitiveMemoryOps trait defaults ──────────────────────────────
+
+    #[test]
+    fn search_episodes_starting_with_default_returns_empty() {
+        let mem = NativeCognitiveMemory::in_memory().unwrap();
+        let result = mem.search_episodes_starting_with("any", 10).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn is_read_only_returns_false_for_writer() {
+        let mem = NativeCognitiveMemory::in_memory().unwrap();
+        assert!(
+            !CognitiveMemoryOps::is_read_only(&mem),
+            "writer handle reports read_only=false"
+        );
+    }
+
+    #[test]
+    fn trait_checkpoint_delegates_to_inherent() {
+        let mem = NativeCognitiveMemory::in_memory().unwrap();
+        CognitiveMemoryOps::checkpoint(&mem).expect("trait checkpoint should succeed");
+    }
+}

--- a/src/cognitive_memory/ops.rs
+++ b/src/cognitive_memory/ops.rs
@@ -516,3 +516,402 @@ impl CognitiveMemoryOps for NativeCognitiveMemory {
         })
     }
 }
+
+// ============================================================================
+// Inline unit tests for ops.rs (issue #2036)
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_mem() -> NativeCognitiveMemory {
+        NativeCognitiveMemory::in_memory().expect("in-memory DB should create")
+    }
+
+    // ── escape_cypher ──────────────────────────────────────────────────
+
+    #[test]
+    fn escape_cypher_passthrough_for_ascii() {
+        assert_eq!(escape_cypher("hello world"), "hello world");
+    }
+
+    #[test]
+    fn escape_cypher_escapes_backslash() {
+        assert_eq!(escape_cypher("a\\b"), "a\\\\b");
+    }
+
+    #[test]
+    fn escape_cypher_escapes_single_quote() {
+        assert_eq!(escape_cypher("it's"), "it\\'s");
+    }
+
+    #[test]
+    fn escape_cypher_escapes_control_chars() {
+        assert_eq!(escape_cypher("\n"), "\\n");
+        assert_eq!(escape_cypher("\r"), "\\r");
+        assert_eq!(escape_cypher("\t"), "\\t");
+        assert_eq!(escape_cypher("\0"), "\\0");
+    }
+
+    #[test]
+    fn escape_cypher_handles_empty_string() {
+        assert_eq!(escape_cypher(""), "");
+    }
+
+    #[test]
+    fn escape_cypher_handles_mixed_special_chars() {
+        assert_eq!(
+            escape_cypher("it's a\nnew\\world\0"),
+            "it\\'s a\\nnew\\\\world\\0"
+        );
+    }
+
+    #[test]
+    fn escape_cypher_preserves_unicode() {
+        assert_eq!(escape_cypher("日本語🦀"), "日本語🦀");
+    }
+
+    // ── record_sensory / prune_expired_sensory ─────────────────────────
+
+    #[test]
+    fn record_sensory_returns_id_with_prefix() {
+        let mem = test_mem();
+        let id = mem.record_sensory("audio", "raw-bytes", 300).unwrap();
+        assert!(
+            id.starts_with("sen_"),
+            "sensory id must start with sen_: {id}"
+        );
+    }
+
+    #[test]
+    fn record_sensory_is_queryable() {
+        let mem = test_mem();
+        mem.record_sensory("visual", "frame-1", 3600).unwrap();
+        let rows = mem
+            .query("MATCH (s:Sensory) WHERE s.modality = 'visual' RETURN s.raw_data")
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(as_str(&rows[0][0]), Some("frame-1"));
+    }
+
+    #[test]
+    fn prune_expired_sensory_removes_expired() {
+        let mem = test_mem();
+        mem.record_sensory("test", "will-expire", 0).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        let pruned = mem.prune_expired_sensory().unwrap();
+        assert!(pruned >= 1, "should prune at least 1 expired entry");
+    }
+
+    #[test]
+    fn prune_expired_sensory_keeps_valid() {
+        let mem = test_mem();
+        mem.record_sensory("test", "long-lived", 99999).unwrap();
+        let pruned = mem.prune_expired_sensory().unwrap();
+        assert_eq!(pruned, 0, "non-expired sensory must not be pruned");
+        let stats = mem.get_statistics().unwrap();
+        assert_eq!(stats.sensory_count, 1);
+    }
+
+    // ── push_working / get_working / clear_working ─────────────────────
+
+    #[test]
+    fn push_working_returns_prefixed_id() {
+        let mem = test_mem();
+        let id = mem.push_working("goal", "content", "task-1", 0.8).unwrap();
+        assert!(id.starts_with("wrk_"), "working id must start with wrk_");
+    }
+
+    #[test]
+    fn get_working_returns_matching_slots() {
+        let mem = test_mem();
+        mem.push_working("goal", "g1", "task-A", 1.0).unwrap();
+        mem.push_working("ctx", "c1", "task-A", 0.5).unwrap();
+        mem.push_working("goal", "g2", "task-B", 0.9).unwrap();
+
+        let slots = mem.get_working("task-A").unwrap();
+        assert_eq!(slots.len(), 2, "only task-A slots returned");
+        assert!(
+            slots.iter().all(|s| s.task_id == "task-A"),
+            "all slots must belong to task-A"
+        );
+    }
+
+    #[test]
+    fn get_working_returns_empty_for_unknown_task() {
+        let mem = test_mem();
+        let slots = mem.get_working("nonexistent").unwrap();
+        assert!(slots.is_empty());
+    }
+
+    #[test]
+    fn clear_working_returns_count_and_removes() {
+        let mem = test_mem();
+        mem.push_working("a", "x", "task-C", 1.0).unwrap();
+        mem.push_working("b", "y", "task-C", 0.5).unwrap();
+
+        let cleared = mem.clear_working("task-C").unwrap();
+        assert_eq!(cleared, 2);
+        assert!(mem.get_working("task-C").unwrap().is_empty());
+    }
+
+    #[test]
+    fn clear_working_returns_zero_for_empty() {
+        let mem = test_mem();
+        let cleared = mem.clear_working("no-such-task").unwrap();
+        assert_eq!(cleared, 0);
+    }
+
+    // ── store_episode / consolidate_episodes ───────────────────────────
+
+    #[test]
+    fn store_episode_returns_prefixed_id() {
+        let mem = test_mem();
+        let id = mem.store_episode("event happened", "source", None).unwrap();
+        assert!(id.starts_with("epi_"), "episode id must start with epi_");
+    }
+
+    #[test]
+    fn store_episode_persists_content() {
+        let mem = test_mem();
+        mem.store_episode("test event", "my-source", None).unwrap();
+        let rows = mem
+            .query("MATCH (e:Episode) WHERE e.source_label = 'my-source' RETURN e.content")
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(as_str(&rows[0][0]), Some("test event"));
+    }
+
+    #[test]
+    fn consolidate_episodes_needs_at_least_two() {
+        let mem = test_mem();
+        mem.store_episode("solo", "src", None).unwrap();
+        assert!(mem.consolidate_episodes(10).unwrap().is_none());
+    }
+
+    #[test]
+    fn consolidate_episodes_creates_summary() {
+        let mem = test_mem();
+        mem.store_episode("alpha", "src", None).unwrap();
+        mem.store_episode("beta", "src", None).unwrap();
+        let summary_id = mem.consolidate_episodes(10).unwrap();
+        assert!(summary_id.is_some());
+        let sid = summary_id.unwrap();
+        assert!(sid.starts_with("epi_"));
+    }
+
+    #[test]
+    fn consolidate_episodes_marks_originals_compressed() {
+        let mem = test_mem();
+        for i in 0..3 {
+            mem.store_episode(&format!("e{i}"), "src", None).unwrap();
+        }
+        mem.consolidate_episodes(10).unwrap();
+        let rows = mem
+            .query("MATCH (e:Episode) WHERE e.compressed = 0 RETURN count(e)")
+            .unwrap();
+        let uncompressed = as_i64(&rows[0][0]).unwrap();
+        assert_eq!(
+            uncompressed, 0,
+            "all originals should be marked compressed=1"
+        );
+    }
+
+    // ── store_fact / search_facts ──────────────────────────────────────
+
+    #[test]
+    fn store_fact_returns_prefixed_id() {
+        let mem = test_mem();
+        let id = mem
+            .store_fact("concept", "content", 0.9, &[], "src")
+            .unwrap();
+        assert!(id.starts_with("sem_"), "fact id must start with sem_");
+    }
+
+    #[test]
+    fn store_fact_with_tags() {
+        let mem = test_mem();
+        let tags = vec!["rust".to_string(), "perf".to_string()];
+        mem.store_fact("concept", "content", 0.8, &tags, "src")
+            .unwrap();
+        let facts = mem.search_facts("concept", 10, 0.0).unwrap();
+        assert_eq!(facts.len(), 1);
+        assert_eq!(facts[0].tags, tags);
+    }
+
+    #[test]
+    fn search_facts_by_content() {
+        let mem = test_mem();
+        mem.store_fact("k", "needle in haystack", 0.9, &[], "src")
+            .unwrap();
+        let results = mem.search_facts("needle", 10, 0.0).unwrap();
+        assert_eq!(results.len(), 1);
+    }
+
+    #[test]
+    fn search_facts_respects_limit() {
+        let mem = test_mem();
+        for i in 0..5 {
+            mem.store_fact(&format!("topic{i}"), "common-content", 0.9, &[], "src")
+                .unwrap();
+        }
+        let results = mem.search_facts("common-content", 3, 0.0).unwrap();
+        assert!(results.len() <= 3, "limit must be respected");
+    }
+
+    #[test]
+    fn search_facts_empty_result_for_no_match() {
+        let mem = test_mem();
+        mem.store_fact("rust", "fast", 0.9, &[], "src").unwrap();
+        let results = mem.search_facts("python", 10, 0.0).unwrap();
+        assert!(results.is_empty());
+    }
+
+    // ── store_procedure / recall_procedure ─────────────────────────────
+
+    #[test]
+    fn store_procedure_returns_prefixed_id() {
+        let mem = test_mem();
+        let id = mem
+            .store_procedure("deploy", &["build".into(), "push".into()], &[])
+            .unwrap();
+        assert!(id.starts_with("proc_"), "procedure id prefix");
+    }
+
+    #[test]
+    fn recall_procedure_returns_steps_and_prerequisites() {
+        let mem = test_mem();
+        let steps = vec!["compile".to_string(), "test".to_string()];
+        let prereqs = vec!["install-deps".to_string()];
+        mem.store_procedure("build-flow", &steps, &prereqs).unwrap();
+
+        let procs = mem.recall_procedure("build-flow", 10).unwrap();
+        assert_eq!(procs.len(), 1);
+        assert_eq!(procs[0].steps, steps);
+        assert_eq!(procs[0].prerequisites, prereqs);
+        assert_eq!(procs[0].usage_count, 0);
+    }
+
+    #[test]
+    fn recall_procedure_empty_for_no_match() {
+        let mem = test_mem();
+        let procs = mem.recall_procedure("nonexistent", 10).unwrap();
+        assert!(procs.is_empty());
+    }
+
+    // ── store_prospective / check_triggers ─────────────────────────────
+
+    #[test]
+    fn store_prospective_returns_prefixed_id() {
+        let mem = test_mem();
+        let id = mem
+            .store_prospective("desc", "trigger", "action", 5)
+            .unwrap();
+        assert!(id.starts_with("pro_"), "prospective id prefix");
+    }
+
+    #[test]
+    fn check_triggers_matches_substring() {
+        let mem = test_mem();
+        mem.store_prospective("watch for failure", "FAIL", "alert", 1)
+            .unwrap();
+        let triggered = mem.check_triggers("build FAILED with errors").unwrap();
+        assert_eq!(triggered.len(), 1);
+        assert_eq!(triggered[0].description, "watch for failure");
+        assert_eq!(triggered[0].priority, 1);
+    }
+
+    #[test]
+    fn check_triggers_returns_empty_on_no_match() {
+        let mem = test_mem();
+        mem.store_prospective("watch for failure", "FAIL", "alert", 1)
+            .unwrap();
+        let triggered = mem.check_triggers("everything is fine").unwrap();
+        assert!(triggered.is_empty());
+    }
+
+    #[test]
+    fn check_triggers_only_returns_pending() {
+        let mem = test_mem();
+        mem.store_prospective("p1", "match-me", "act", 1).unwrap();
+        // Manually flip status to 'done' to confirm pending-only filter.
+        mem.execute(
+            "MATCH (p:Prospective) WHERE p.trigger_condition = 'match-me' SET p.status = 'done'",
+        )
+        .unwrap();
+        let triggered = mem.check_triggers("match-me").unwrap();
+        assert!(
+            triggered.is_empty(),
+            "non-pending prospectives must not trigger"
+        );
+    }
+
+    // ── get_statistics ─────────────────────────────────────────────────
+
+    #[test]
+    fn get_statistics_empty_db() {
+        let mem = test_mem();
+        let stats = mem.get_statistics().unwrap();
+        assert_eq!(stats.sensory_count, 0);
+        assert_eq!(stats.working_count, 0);
+        assert_eq!(stats.episodic_count, 0);
+        assert_eq!(stats.semantic_count, 0);
+        assert_eq!(stats.procedural_count, 0);
+        assert_eq!(stats.prospective_count, 0);
+    }
+
+    #[test]
+    fn get_statistics_reflects_all_types() {
+        let mem = test_mem();
+        mem.record_sensory("m", "d", 300).unwrap();
+        mem.push_working("s", "c", "t", 1.0).unwrap();
+        mem.store_episode("e", "l", None).unwrap();
+        mem.store_fact("f", "c", 0.5, &[], "s").unwrap();
+        mem.store_procedure("p", &[], &[]).unwrap();
+        mem.store_prospective("d", "t", "a", 1).unwrap();
+        let stats = mem.get_statistics().unwrap();
+        assert_eq!(stats.sensory_count, 1);
+        assert_eq!(stats.working_count, 1);
+        assert_eq!(stats.episodic_count, 1);
+        assert_eq!(stats.semantic_count, 1);
+        assert_eq!(stats.procedural_count, 1);
+        assert_eq!(stats.prospective_count, 1);
+    }
+
+    // ── Cypher injection safety ────────────────────────────────────────
+
+    #[test]
+    fn store_fact_with_quotes_in_all_fields() {
+        let mem = test_mem();
+        let id = mem
+            .store_fact(
+                "con'cept",
+                "con'tent",
+                0.5,
+                &["tag'1".to_string()],
+                "src'id",
+            )
+            .unwrap();
+        assert!(id.starts_with("sem_"));
+        let facts = mem.search_facts("con", 10, 0.0).unwrap();
+        assert_eq!(facts.len(), 1);
+    }
+
+    #[test]
+    fn store_episode_with_newlines() {
+        let mem = test_mem();
+        let content = "line1\nline2\ttab\rreturn";
+        mem.store_episode(content, "src", None).unwrap();
+        let stats = mem.get_statistics().unwrap();
+        assert_eq!(stats.episodic_count, 1);
+    }
+
+    // ── is_read_only ───────────────────────────────────────────────────
+
+    #[test]
+    fn is_read_only_false_for_in_memory() {
+        let mem = test_mem();
+        assert!(!mem.is_read_only());
+    }
+}


### PR DESCRIPTION
## Summary

Adds `#[cfg(test)]` inline unit test modules to the three cognitive_memory files
that had zero inline test coverage despite being the persistence backbone with
recent high-churn changes (#1998 fsync barriers, #2017 hermetic guards).

### Changes

**backup.rs** — 28 tests covering:
- `sha256_file`: determinism, hex format, error on missing file
- `atomic_copy_with_fsync`: exact copy, leftover .tmp cleanup, missing src, overwrite
- `post_write_barrier`: no-op for in-memory, success on disk
- `wal_paths`, `preemptive_wal_cleanup`: empty WAL removal, nonempty preservation
- `is_lock_contention_error`: lock message detection, EAGAIN, corruption rejection
- `find_backups_newest_first`: descending sort, empty when no dir
- `verify_db_health`, `create_verified_backup`, `prune_old_backups`
- `with_open_lock`: closure execution, error propagation
- `fsync_recovery_replay`: success on real file, error on missing

**ops.rs** — 38 tests covering:
- `escape_cypher`: passthrough, backslash, quote, control chars, unicode, mixed
- All CRUD operations: record/prune sensory, push/get/clear working,
  store/consolidate episodes, store/search facts, store/recall procedures,
  store/check_triggers prospectives
- `get_statistics`: empty and populated
- Cypher injection safety with quotes and newlines

**mod.rs** — 26 tests covering:
- `NativeCognitiveMemory` construction: `in_memory`, `open`, `durable_writes` flag
- KuzuDB migration path
- `conn`/`query`/`execute` helpers including error paths
- `new_id` uniqueness and prefix
- `now_secs` plausibility
- `checkpoint`: success, read-only no-op
- `post_write_barrier`: no-op and on-disk paths
- Value conversion helpers: `as_str`, `as_i64`, `as_f64`
- `CognitiveMemoryOps` trait defaults

### Hermetic safety

All tests use `NativeCognitiveMemory::in_memory()` or `tempdir`-based on-disk
instances — no filesystem side effects outside test scope.

### Test results

All 155 cognitive_memory tests pass (92 new + 63 pre-existing):
```
test result: ok. 155 passed; 0 failed; 0 ignored
```

### Merge-ready evidence

1. **QA scenarios**: N/A — internal test-only change, no user-facing surfaces
2. **Docs**: N/A — no user-facing changes
3. **Quality**: cargo fmt ✅, cargo clippy ✅, cargo test ✅
4. **CI**: Pre-push hooks pass (fmt, test, clippy)
5. **Diff focused**: Only test code added to 3 files, zero production logic changes

Closes #2036
Parent: #1977