### PR TITLE
feat: crash-atomic consolidate_episodes via BEGIN/COMMIT transaction (#2044)

### DIFF
--- a/src/cognitive_memory/mod.rs
+++ b/src/cognitive_memory/mod.rs
@@ -340,6 +340,43 @@ impl NativeCognitiveMemory {
         Ok(())
     }
 
+    /// Execute multiple Cypher statements atomically within a single
+    /// `BEGIN TRANSACTION` / `COMMIT` block on one connection.
+    ///
+    /// If any statement fails, `ROLLBACK` is issued so no partial state
+    /// is visible to subsequent reads. This is the crash-atomicity
+    /// primitive used by `consolidate_episodes` (issue #2044, goal G4).
+    fn execute_in_transaction(&self, statements: &[String]) -> SimardResult<()> {
+        let conn = self.conn()?;
+        conn.query("BEGIN TRANSACTION")
+            .map_err(|e| SimardError::BridgeCallFailed {
+                bridge: "cognitive-memory-native".into(),
+                method: "execute_in_transaction".into(),
+                reason: format!("BEGIN TRANSACTION failed: {e}"),
+            })?;
+        for stmt in statements {
+            if let Err(e) = conn.query(stmt) {
+                // Best-effort rollback — if this also fails, the
+                // original error is more informative.
+                let _ = conn.query("ROLLBACK");
+                return Err(SimardError::BridgeCallFailed {
+                    bridge: "cognitive-memory-native".into(),
+                    method: "execute_in_transaction".into(),
+                    reason: format!("{e}\nCypher: {stmt}"),
+                });
+            }
+        }
+        conn.query("COMMIT").map_err(|e| {
+            let _ = conn.query("ROLLBACK");
+            SimardError::BridgeCallFailed {
+                bridge: "cognitive-memory-native".into(),
+                method: "execute_in_transaction".into(),
+                reason: format!("COMMIT failed: {e}"),
+            }
+        })?;
+        Ok(())
+    }
+
     fn ensure_schema(&self) -> SimardResult<()> {
         for ddl in schema::SCHEMA_DDL {
             if let Err(e) = self.execute(ddl) {

--- a/src/cognitive_memory/ops.rs
+++ b/src/cognitive_memory/ops.rs
@@ -212,36 +212,28 @@ impl CognitiveMemoryOps for NativeCognitiveMemory {
         );
         let summary_id = Self::new_id("epi");
 
-        // Issue #1975 (G4): LadybugDB auto-commits each statement (no
-        // BEGIN/COMMIT). Use a compensating-action pattern: if any SET
-        // compressed = 1 fails mid-loop, delete the summary node so the
-        // caller never sees Ok(Some(summary_id)) for a partial apply.
-        self.execute(&format!(
+        // Issue #2044 (G4): wrap the summary-insert + per-source
+        // SET compressed=1 loop in a single BEGIN/COMMIT transaction
+        // so a mid-loop crash cannot produce duplicate summaries.
+        // Replaces the previous compensating-action pattern (#1975)
+        // which was vulnerable to a crash between the summary CREATE
+        // and the compensating DELETE.
+        let mut txn_stmts = Vec::with_capacity(rows.len() + 1);
+        txn_stmts.push(format!(
             "CREATE (e:Episode {{id: '{}', content: '{}', source_label: 'consolidation', temporal_index: 0, compressed: 1}})",
             escape_cypher(&summary_id),
             escape_cypher(&summary),
-        ))?;
-
+        ));
         for row in &rows {
-            if let Some(eid) = as_str(&row[0])
-                && let Err(e) = self.execute(&format!(
+            if let Some(eid) = as_str(&row[0]) {
+                txn_stmts.push(format!(
                     "MATCH (e:Episode {{id: '{}'}}) SET e.compressed = 1",
                     escape_cypher(eid)
-                ))
-            {
-                // Compensate: remove the summary node so subsequent
-                // consolidation attempts don't see a partial result.
-                let _ = self.execute(&format!(
-                    "MATCH (e:Episode {{id: '{}'}}) DELETE e",
-                    escape_cypher(&summary_id)
                 ));
-                crate::cognitive_memory::metrics::increment(
-                    "consolidation_partial_apply",
-                    "consolidate_episodes:set_compressed",
-                );
-                return Err(e);
             }
         }
+        self.execute_in_transaction(&txn_stmts)?;
+
         // Per-write barrier — one barrier for the whole consolidation op
         // (summary insert + N compress flips), not per Cypher statement.
         // Issue #1973 spec rationale (decision D5): consolidation is a

--- a/src/cognitive_memory/tests_mod.rs
+++ b/src/cognitive_memory/tests_mod.rs
@@ -360,6 +360,106 @@ fn consolidate_episodes_deduplicates() {
 }
 
 // ---------------------------------------------------------------------------
+// Issue #2044 (G4): crash-atomic `consolidate_episodes`
+//
+// Simulates a mid-consolidation crash by running the consolidation inside
+// a transaction, aborting partway, and verifying that on recovery no
+// duplicate summaries exist and the source episodes remain unconsolidated.
+// ---------------------------------------------------------------------------
+
+/// Regression test: a crash between the summary-insert and the last
+/// SET compressed=1 must not leave a partial state where a summary node
+/// exists but some source episodes are still uncompressed. After recovery
+/// (here simulated by aborting a raw transaction mid-loop), a subsequent
+/// `consolidate_episodes` call must succeed cleanly with no duplicate
+/// summaries.
+#[test]
+fn consolidate_episodes_crash_injection_no_duplicate_summaries() {
+    let mem = test_mem();
+
+    // Seed 5 episodes.
+    for i in 0..5 {
+        mem.store_episode(&format!("crash-test-event {i}"), "test", None)
+            .unwrap();
+    }
+
+    // --- Simulate a crash mid-transaction ---
+    // Open a connection, BEGIN TRANSACTION, insert the summary node,
+    // mark only 2 of 5 episodes as compressed, then ROLLBACK (simulating
+    // a crash before COMMIT).
+    {
+        let conn = lbug::Connection::new(&mem.db).expect("conn for crash injection");
+        conn.query("BEGIN TRANSACTION").expect("begin");
+        conn.query(
+            "CREATE (e:Episode {id: 'epi_crash_summary', content: '[crash summary]', source_label: 'consolidation', temporal_index: 0, compressed: 1})"
+        ).expect("summary insert");
+
+        // Mark only 2 source rows — partial apply.
+        let partial_rows = mem
+            .query("MATCH (e:Episode) WHERE e.compressed = 0 RETURN e.id ORDER BY e.id LIMIT 2")
+            .unwrap();
+        for row in &partial_rows {
+            if let Some(eid) = super::as_str(&row[0]) {
+                conn.query(&format!(
+                    "MATCH (e:Episode {{id: '{eid}'}}) SET e.compressed = 1"
+                ))
+                .expect("partial compress");
+            }
+        }
+        // Crash! — ROLLBACK instead of COMMIT.
+        conn.query("ROLLBACK").expect("rollback (simulated crash)");
+    }
+
+    // Verify: the crash-summary node must NOT be visible after rollback.
+    let ghost_rows = mem
+        .query("MATCH (e:Episode) WHERE e.id = 'epi_crash_summary' RETURN e.id")
+        .unwrap();
+    assert!(
+        ghost_rows.is_empty(),
+        "rolled-back summary must not be visible, found {} row(s)",
+        ghost_rows.len()
+    );
+
+    // Verify: all 5 source episodes remain uncompressed (compressed=0).
+    let uncompressed = mem
+        .query("MATCH (e:Episode) WHERE e.compressed = 0 RETURN count(e)")
+        .unwrap();
+    let uncompressed_count = super::as_i64(&uncompressed[0][0]).unwrap_or(0);
+    assert_eq!(
+        uncompressed_count, 5,
+        "all source episodes must remain uncompressed after crash, got {uncompressed_count}"
+    );
+
+    // --- Now run real consolidation — should succeed with no duplicates ---
+    let result = mem.consolidate_episodes(10).unwrap();
+    assert!(
+        result.is_some(),
+        "consolidation should produce a summary after crash recovery"
+    );
+
+    // Exactly 1 consolidation summary must exist.
+    let summary_rows = mem
+        .query("MATCH (e:Episode) WHERE e.source_label = 'consolidation' RETURN e.id, e.content")
+        .unwrap();
+    assert_eq!(
+        summary_rows.len(),
+        1,
+        "expected exactly 1 consolidation summary (no duplicates), found {}",
+        summary_rows.len()
+    );
+
+    // All original episodes must now be compressed.
+    let still_uncompressed = mem
+        .query("MATCH (e:Episode) WHERE e.compressed = 0 RETURN count(e)")
+        .unwrap();
+    let still_count = super::as_i64(&still_uncompressed[0][0]).unwrap_or(-1);
+    assert_eq!(
+        still_count, 0,
+        "after successful consolidation all episodes must be compressed, got {still_count}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Backup-restore recovery tests (issue #1710)
 //
 // These tests pin the contract for `open_db_with_recovery`:


### PR DESCRIPTION
## Summary

Implements #2044 (G4): wraps `consolidate_episodes` summary-insert + per-source `SET compressed=1` loop in a single LadybugDB `BEGIN TRANSACTION` / `COMMIT` block so a mid-loop crash cannot produce duplicate summaries.

## Changes

| File | Change |
|------|--------|
| `src/cognitive_memory/mod.rs` | Added `execute_in_transaction()` helper — runs N Cypher statements atomically on a single connection with BEGIN/COMMIT/ROLLBACK |
| `src/cognitive_memory/ops.rs` | Rewrote `consolidate_episodes` to use `execute_in_transaction` instead of the previous compensating-action pattern (#1975) |
| `src/cognitive_memory/tests_mod.rs` | Added crash-injection regression test that simulates mid-consolidation abort via ROLLBACK and verifies no duplicate summaries on recovery |

## How it works

Previously, `consolidate_episodes` used a compensating-action pattern: if a `SET compressed=1` failed mid-loop, it would try to delete the summary node. This was vulnerable to a crash between the summary CREATE and the compensating DELETE.

Now, all mutations (1 summary CREATE + N SET compressed=1) execute inside a single `BEGIN TRANSACTION` / `COMMIT` block on one LadybugDB connection. If any statement fails, `ROLLBACK` is issued and no partial state is visible.

## Test evidence

- **Crash-injection test**: `consolidate_episodes_crash_injection_no_duplicate_summaries` — opens a raw connection, begins a transaction, inserts a summary + partially marks episodes, then ROLLBACKs. Verifies the summary is invisible and all episodes remain uncompressed. Then runs real consolidation and asserts exactly 1 summary exists.
- All 41 `cognitive_memory` tests pass ✅
- All 15 `memory_consolidation` tests pass ✅
- Pre-push hooks: cargo fmt ✅, cargo clippy ✅, cargo test (release) ✅

## Diff focused

3 files changed, 150 insertions, 21 deletions. No unrelated edits.

Closes #2044