### PR TITLE
refactor(engineer-loop): use SessionPhase state machine via SessionRecord (#2100)

### DIFF
--- a/docs/architecture/engineer-agent-orchestration.md
+++ b/docs/architecture/engineer-agent-orchestration.md
@@ -58,23 +58,34 @@ OODA daemon
     │  advance_goal → task description
     ▼
 Engineer loop (run_local_engineer_loop)
+    │  Creates a SessionRecord (SessionPhase state machine)
     │
-    ├── Phase 1: inspect_workspace()           ← unchanged
-    │       → RepoInspection (branch, dirty files, active goals, …)
+    ├── SessionPhase::Intake
+    │   ├── inspect_workspace()
+    │   │       → RepoInspection (branch, dirty files, active goals, …)
+    │   └── pre-mutation guard (abort if mutating + dirty worktree)
     │
-    ├── Phase 2: build agent prompt            ← new
+    ├── SessionPhase::Preparation
+    │   └── load terminal bridge context
+    │
+    ├── SessionPhase::Planning
+    │   └── build agent prompt
     │       combines objective + RepoInspection into a natural-language prompt
     │
-    ├── Phase 3: spawn_agent_for_goal()        ← new (replaces select+execute+verify)
-    │       spawns copilot agent session
-    │       waits up to 3600 s for completion
-    │       returns execution_summary string
+    ├── SessionPhase::Execution
+    │   ├── spawn_agent_for_goal()
+    │   │       spawns copilot agent session
+    │   │       waits for completion (unbounded)
+    │   │       returns execution_summary string
+    │   └── agent-wait (blocks until session completes)
     │
-    ├── Phase 4: run_optional_review()         ← unchanged
-    │       diff-based review if agent mutated files
+    ├── SessionPhase::Reflection
+    │   └── run_optional_review()
+    │           diff-based review if agent mutated files
     │
-    └── Phase 5: persist_engineer_loop_artifacts()  ← unchanged
-            writes EngineerLoopRun → cycle report
+    └── SessionPhase::Persistence → Complete
+        └── persist_artifacts_with_session()
+                writes memory, evidence, handoff snapshot
 ```
 
 The three old phases (select, execute, verify) are collapsed into a single

--- a/src/engineer_loop/mod.rs
+++ b/src/engineer_loop/mod.rs
@@ -33,8 +33,10 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
+use crate::base_types::BaseTypeId;
 use crate::error::{SimardError, SimardResult};
 use crate::runtime::RuntimeTopology;
+use crate::session::{SessionPhase, SessionRecord, UuidSessionIdGenerator};
 use crate::terminal_engineer_bridge::{SHARED_EXPLICIT_STATE_ROOT_SOURCE, TerminalBridgeContext};
 
 use execution::{parse_status_paths, run_command, trimmed_stdout, trimmed_stdout_allow_empty};
@@ -49,6 +51,7 @@ pub use types::{
 // Phase-entry-point re-exports for the recipe-driven engineer loop (Phase 2 rebuild).
 // These let `simard-engineer-step` (in src/bin/) drive each phase via JSON IPC.
 pub use agent_spawn::spawn_agent_for_goal;
+use review_persist::persist_artifacts_with_session;
 pub use review_persist::{
     persist_engineer_loop_artifacts, persist_error_reflection, run_optional_review,
 };
@@ -98,6 +101,22 @@ pub fn run_local_engineer_loop(
     let state_root = state_root.into();
     let mut phase_traces = Vec::new();
 
+    // Create a SessionRecord to track the session through the spec's
+    // SessionPhase state machine (issue #2100). The session starts at Intake
+    // and advances through Preparation → Planning → Execution → Reflection →
+    // Persistence → Complete, mirroring RuntimeKernel::execute_session.
+    let session_ids = UuidSessionIdGenerator;
+    let mut session = SessionRecord::new(
+        crate::identity::OperatingMode::Engineer,
+        objective.to_string(),
+        BaseTypeId::new(ENGINEER_BASE_TYPE),
+        &session_ids,
+    );
+    let session_id_str = session.id.to_string();
+
+    // --- SessionPhase::Intake ---
+    // Normalize the request, detect mode, and identify workspace context.
+
     let phase_start = Instant::now();
     let inspection = inspect_workspace(workspace_root.as_ref(), &state_root);
     let inspection = match &inspection {
@@ -116,6 +135,7 @@ pub fn run_local_engineer_loop(
                 outcome: PhaseOutcome::Failed(e.to_string()),
             });
             let err = inspection.unwrap_err();
+            let _ = session.advance(SessionPhase::Failed);
             persist_error_reflection(
                 &state_root,
                 &SessionErrorReflection {
@@ -123,6 +143,7 @@ pub fn run_local_engineer_loop(
                     failed_phase: "inspect".to_string(),
                     error_message: err.to_string(),
                     phase_traces: phase_traces.clone(),
+                    session_id: Some(session_id_str.clone()),
                 },
             );
             return Err(err);
@@ -144,6 +165,7 @@ pub fn run_local_engineer_loop(
         let err = SimardError::DirtyWorktree {
             changed_files: inspection.changed_files.clone(),
         };
+        let _ = session.advance(SessionPhase::Failed);
         persist_error_reflection(
             &state_root,
             &SessionErrorReflection {
@@ -151,10 +173,15 @@ pub fn run_local_engineer_loop(
                 failed_phase: phase_name.to_string(),
                 error_message: err.to_string(),
                 phase_traces: phase_traces.clone(),
+                session_id: Some(session_id_str.clone()),
             },
         );
         return Err(err);
     }
+
+    // --- SessionPhase::Preparation ---
+    // Gather current state, constraints, and existing memory relevant to the task.
+    session.advance(SessionPhase::Preparation)?;
 
     let phase_start = Instant::now();
     let terminal_bridge_context =
@@ -178,6 +205,7 @@ pub fn run_local_engineer_loop(
     let terminal_bridge_context = match terminal_bridge_context {
         Ok(ctx) => ctx,
         Err(e) => {
+            let _ = session.advance(SessionPhase::Failed);
             persist_error_reflection(
                 &state_root,
                 &SessionErrorReflection {
@@ -185,13 +213,17 @@ pub fn run_local_engineer_loop(
                     failed_phase: "load-bridge-context".to_string(),
                     error_message: e.to_string(),
                     phase_traces: phase_traces.clone(),
+                    session_id: Some(session_id_str.clone()),
                 },
             );
             return Err(e);
         }
     };
 
-    // Phase: agent-prompt-build
+    // --- SessionPhase::Planning ---
+    // Produce a bounded plan sized to the task.
+    session.advance(SessionPhase::Planning)?;
+
     let phase_start = Instant::now();
     let agent_prompt = agent_spawn::build_agent_prompt(objective, &inspection);
     phase_traces.push(PhaseTrace {
@@ -199,6 +231,10 @@ pub fn run_local_engineer_loop(
         duration: phase_start.elapsed(),
         outcome: PhaseOutcome::Success,
     });
+
+    // --- SessionPhase::Execution ---
+    // Perform shell actions, file changes, and tool calls while recording evidence.
+    session.advance(SessionPhase::Execution)?;
 
     // Phase: agent-spawn — start background thread that runs the
     // `amplihack RustyClawd --auto` subprocess. Spawning is infallible
@@ -245,6 +281,7 @@ pub fn run_local_engineer_loop(
                 duration: phase_start.elapsed(),
                 outcome: PhaseOutcome::Failed(e.to_string()),
             });
+            let _ = session.advance(SessionPhase::Failed);
             persist_error_reflection(
                 &state_root,
                 &SessionErrorReflection {
@@ -252,6 +289,7 @@ pub fn run_local_engineer_loop(
                     failed_phase: "agent-wait".to_string(),
                     error_message: e.to_string(),
                     phase_traces: phase_traces.clone(),
+                    session_id: Some(session_id_str.clone()),
                 },
             );
             return Err(e);
@@ -263,6 +301,10 @@ pub fn run_local_engineer_loop(
         summary: action.stdout.clone(),
         checks: vec![],
     };
+
+    // --- SessionPhase::Reflection ---
+    // Compare results against the objective and capture what succeeded/failed.
+    session.advance(SessionPhase::Reflection)?;
 
     // Optional LLM-driven review gate: only runs for mutating actions
     // when an LLM session is available (requires ANTHROPIC_API_KEY).
@@ -285,6 +327,7 @@ pub fn run_local_engineer_loop(
         }
     }
     if let Err(e) = review_result {
+        let _ = session.advance(SessionPhase::Failed);
         persist_error_reflection(
             &state_root,
             &SessionErrorReflection {
@@ -292,16 +335,21 @@ pub fn run_local_engineer_loop(
                 failed_phase: "review".to_string(),
                 error_message: e.to_string(),
                 phase_traces: phase_traces.clone(),
+                session_id: Some(session_id_str.clone()),
             },
         );
         return Err(e);
     }
 
+    // --- SessionPhase::Persistence ---
+    // Write session summary, memory updates, and benchmark records.
+    session.advance(SessionPhase::Persistence)?;
+
     let phase_start = Instant::now();
-    let persist_result = persist_engineer_loop_artifacts(
+    let persist_result = persist_artifacts_with_session(
         &state_root,
         topology,
-        objective,
+        &mut session,
         &inspection,
         &action,
         &verification,
@@ -324,6 +372,7 @@ pub fn run_local_engineer_loop(
         }
     }
     if let Err(e) = persist_result {
+        let _ = session.advance(SessionPhase::Failed);
         persist_error_reflection(
             &state_root,
             &SessionErrorReflection {
@@ -331,10 +380,13 @@ pub fn run_local_engineer_loop(
                 failed_phase: "persist".to_string(),
                 error_message: e.to_string(),
                 phase_traces: phase_traces.clone(),
+                session_id: Some(session_id_str.clone()),
             },
         );
         return Err(e);
     }
+
+    // Session has been advanced to Complete by persist_artifacts_with_session.
 
     Ok(EngineerLoopRun {
         state_root,
@@ -345,6 +397,7 @@ pub fn run_local_engineer_loop(
         terminal_bridge_context,
         elapsed_duration: loop_start.elapsed(),
         phase_traces,
+        session_record: Some(session),
     })
 }
 

--- a/src/engineer_loop/review_persist.rs
+++ b/src/engineer_loop/review_persist.rs
@@ -101,10 +101,6 @@ pub fn persist_engineer_loop_artifacts(
     verification: &VerificationReport,
     terminal_bridge_context: Option<&TerminalBridgeContext>,
 ) -> SimardResult<()> {
-    let memory_store = FileBackedMemoryStore::try_new(state_root.join("memory_records.json"))?;
-    let evidence_store =
-        FileBackedEvidenceStore::try_new(state_root.join("evidence_records.json"))?;
-
     let session_ids = UuidSessionIdGenerator;
     let mut session = SessionRecord::new(
         crate::identity::OperatingMode::Engineer,
@@ -113,20 +109,55 @@ pub fn persist_engineer_loop_artifacts(
         &session_ids,
     );
     session.advance(SessionPhase::Preparation)?;
+    session.advance(SessionPhase::Planning)?;
+    session.advance(SessionPhase::Execution)?;
+    session.advance(SessionPhase::Reflection)?;
+    session.advance(SessionPhase::Persistence)?;
+
+    persist_artifacts_with_session(
+        state_root,
+        topology,
+        &mut session,
+        inspection,
+        action,
+        verification,
+        terminal_bridge_context,
+    )
+}
+
+/// Persist engineer loop artifacts using an existing [`SessionRecord`].
+///
+/// The session must be at [`SessionPhase::Persistence`] when called. This
+/// variant is used by `run_local_engineer_loop` to maintain a single session
+/// identity from intake through completion (issue #2100).
+///
+/// The function writes scratch memory, execution evidence, summary/decision
+/// memory, prunes bounded scopes, advances the session to `Complete`, and
+/// creates a handoff snapshot.
+pub(crate) fn persist_artifacts_with_session(
+    state_root: &Path,
+    topology: RuntimeTopology,
+    session: &mut SessionRecord,
+    inspection: &RepoInspection,
+    action: &ExecutedEngineerAction,
+    verification: &VerificationReport,
+    terminal_bridge_context: Option<&TerminalBridgeContext>,
+) -> SimardResult<()> {
+    let memory_store = FileBackedMemoryStore::try_new(state_root.join("memory_records.json"))?;
+    let evidence_store =
+        FileBackedEvidenceStore::try_new(state_root.join("evidence_records.json"))?;
 
     let scratch_key = format!("{}-engineer-loop-scratch", session.id);
     memory_store.put(MemoryRecord {
         key: scratch_key.clone(),
         scope: MemoryScope::SessionScratch,
-        value: objective_metadata(objective),
+        value: objective_metadata(&session.objective),
         session_id: session.id.clone(),
         recorded_in: SessionPhase::Preparation,
         created_at: None,
     })?;
     session.attach_memory(scratch_key);
 
-    session.advance(SessionPhase::Planning)?;
-    session.advance(SessionPhase::Execution)?;
     let evidence_details = vec![
         format!("repo-root={}", inspection.repo_root.display()),
         format!("repo-branch={}", inspection.branch),
@@ -200,9 +231,6 @@ pub fn persist_engineer_loop_artifacts(
         })?;
         session.attach_evidence(evidence_id);
     }
-
-    session.advance(SessionPhase::Reflection)?;
-    session.advance(SessionPhase::Persistence)?;
 
     let summary_key = format!("{}-engineer-loop-summary", session.id);
     memory_store.put(MemoryRecord {
@@ -367,6 +395,7 @@ mod tests {
                 duration: std::time::Duration::from_millis(100),
                 outcome: super::super::types::PhaseOutcome::Success,
             }],
+            session_id: Some("session-test-persist".to_string()),
         };
         persist_error_reflection(dir.path(), &reflection);
 
@@ -379,6 +408,7 @@ mod tests {
         assert_eq!(restored.failed_phase, "agent-wait");
         assert_eq!(restored.error_message, "LLM timeout after 60s");
         assert_eq!(restored.phase_traces.len(), 1);
+        assert_eq!(restored.session_id.as_deref(), Some("session-test-persist"));
     }
 
     #[test]
@@ -390,6 +420,7 @@ mod tests {
             failed_phase: "inspect".to_string(),
             error_message: "not a repo".to_string(),
             phase_traces: vec![],
+            session_id: None,
         };
         persist_error_reflection(&nested, &reflection);
         assert!(nested.join("error_reflection.json").exists());
@@ -403,6 +434,7 @@ mod tests {
             failed_phase: "inspect".to_string(),
             error_message: "error".to_string(),
             phase_traces: vec![],
+            session_id: None,
         };
         // Path containing null bytes cannot be created — best-effort swallows the error
         persist_error_reflection(std::path::Path::new("/dev/null/impossible"), &reflection);

--- a/src/engineer_loop/tests_types_inline.rs
+++ b/src/engineer_loop/tests_types_inline.rs
@@ -176,6 +176,107 @@ fn is_mutating_false_for_run_shell_command() {
     assert!(!AnalyzedAction::RunShellCommand.is_mutating());
 }
 
+// ── PhaseTrace::session_phase mapping (issue #2100) ──────────────
+
+#[test]
+fn phase_trace_maps_inspect_to_intake() {
+    use crate::session::SessionPhase;
+    let trace = PhaseTrace {
+        name: "inspect".to_string(),
+        duration: std::time::Duration::from_millis(10),
+        outcome: PhaseOutcome::Success,
+    };
+    assert_eq!(trace.session_phase(), SessionPhase::Intake);
+}
+
+#[test]
+fn phase_trace_maps_pre_mutation_guard_to_intake() {
+    use crate::session::SessionPhase;
+    let trace = PhaseTrace {
+        name: "pre-mutation-guard".to_string(),
+        duration: std::time::Duration::from_millis(1),
+        outcome: PhaseOutcome::Failed("dirty".to_string()),
+    };
+    assert_eq!(trace.session_phase(), SessionPhase::Intake);
+}
+
+#[test]
+fn phase_trace_maps_load_bridge_context_to_preparation() {
+    use crate::session::SessionPhase;
+    let trace = PhaseTrace {
+        name: "load-bridge-context".to_string(),
+        duration: std::time::Duration::from_millis(5),
+        outcome: PhaseOutcome::Success,
+    };
+    assert_eq!(trace.session_phase(), SessionPhase::Preparation);
+}
+
+#[test]
+fn phase_trace_maps_agent_prompt_build_to_planning() {
+    use crate::session::SessionPhase;
+    let trace = PhaseTrace {
+        name: "agent-prompt-build".to_string(),
+        duration: std::time::Duration::from_millis(2),
+        outcome: PhaseOutcome::Success,
+    };
+    assert_eq!(trace.session_phase(), SessionPhase::Planning);
+}
+
+#[test]
+fn phase_trace_maps_agent_spawn_to_execution() {
+    use crate::session::SessionPhase;
+    let trace = PhaseTrace {
+        name: "agent-spawn".to_string(),
+        duration: std::time::Duration::from_millis(100),
+        outcome: PhaseOutcome::Success,
+    };
+    assert_eq!(trace.session_phase(), SessionPhase::Execution);
+}
+
+#[test]
+fn phase_trace_maps_agent_wait_to_execution() {
+    use crate::session::SessionPhase;
+    let trace = PhaseTrace {
+        name: "agent-wait".to_string(),
+        duration: std::time::Duration::from_secs(30),
+        outcome: PhaseOutcome::Success,
+    };
+    assert_eq!(trace.session_phase(), SessionPhase::Execution);
+}
+
+#[test]
+fn phase_trace_maps_review_to_reflection() {
+    use crate::session::SessionPhase;
+    let trace = PhaseTrace {
+        name: "review".to_string(),
+        duration: std::time::Duration::from_millis(500),
+        outcome: PhaseOutcome::Success,
+    };
+    assert_eq!(trace.session_phase(), SessionPhase::Reflection);
+}
+
+#[test]
+fn phase_trace_maps_persist_to_persistence() {
+    use crate::session::SessionPhase;
+    let trace = PhaseTrace {
+        name: "persist".to_string(),
+        duration: std::time::Duration::from_millis(50),
+        outcome: PhaseOutcome::Success,
+    };
+    assert_eq!(trace.session_phase(), SessionPhase::Persistence);
+}
+
+#[test]
+fn phase_trace_maps_unknown_to_execution_default() {
+    use crate::session::SessionPhase;
+    let trace = PhaseTrace {
+        name: "some-unknown-phase".to_string(),
+        duration: std::time::Duration::from_millis(1),
+        outcome: PhaseOutcome::Success,
+    };
+    assert_eq!(trace.session_phase(), SessionPhase::Execution);
+}
+
 // ── SessionErrorReflection ───────────────────────────────────────
 
 #[test]
@@ -189,6 +290,7 @@ fn session_error_reflection_serialization_round_trip() {
             duration: std::time::Duration::from_millis(42),
             outcome: PhaseOutcome::Success,
         }],
+        session_id: Some("session-test-001".to_string()),
     };
     let json = serde_json::to_string(&reflection).expect("serialize");
     let restored: SessionErrorReflection = serde_json::from_str(&json).expect("deserialize");
@@ -202,9 +304,68 @@ fn session_error_reflection_captures_all_fields() {
         failed_phase: "review".to_string(),
         error_message: "review blocked".to_string(),
         phase_traces: vec![],
+        session_id: None,
     };
     assert_eq!(reflection.objective, "update config");
     assert_eq!(reflection.failed_phase, "review");
     assert_eq!(reflection.error_message, "review blocked");
     assert!(reflection.phase_traces.is_empty());
+}
+
+#[test]
+fn session_error_reflection_session_id_backward_compat() {
+    // Old JSON without session_id field must deserialize with session_id = None
+    let json =
+        r#"{"objective":"test","failed_phase":"inspect","error_message":"err","phase_traces":[]}"#;
+    let restored: SessionErrorReflection = serde_json::from_str(json).expect("deserialize");
+    assert_eq!(restored.session_id, None);
+}
+
+#[test]
+fn engineer_loop_run_session_record_backward_compat() {
+    // EngineerLoopRun without session_record field should deserialize with None
+    let run = EngineerLoopRun {
+        state_root: std::path::PathBuf::from("/tmp"),
+        execution_scope: "local-only".to_string(),
+        inspection: crate::engineer_loop::types::RepoInspection {
+            workspace_root: std::path::PathBuf::from("/tmp"),
+            repo_root: std::path::PathBuf::from("/tmp"),
+            branch: "main".to_string(),
+            head: "abc".to_string(),
+            worktree_dirty: false,
+            changed_files: vec![],
+            active_goals: vec![],
+            carried_meeting_decisions: vec![],
+            architecture_gap_summary: String::new(),
+        },
+        action: crate::engineer_loop::types::ExecutedEngineerAction {
+            selected: crate::engineer_loop::types::SelectedEngineerAction {
+                label: "test".to_string(),
+                rationale: "test".to_string(),
+                argv: vec![],
+                plan_summary: "test".to_string(),
+                verification_steps: vec![],
+                expected_changed_files: vec![],
+                kind: crate::engineer_loop::types::EngineerActionKind::ReadOnlyScan,
+            },
+            exit_code: 0,
+            stdout: String::new(),
+            stderr: String::new(),
+            changed_files: vec![],
+        },
+        verification: crate::engineer_loop::types::VerificationReport {
+            status: "ok".to_string(),
+            summary: "ok".to_string(),
+            checks: vec![],
+        },
+        terminal_bridge_context: None,
+        elapsed_duration: std::time::Duration::from_millis(100),
+        phase_traces: vec![],
+        session_record: None,
+    };
+    // Round-trip serialization with session_record = None
+    let json = serde_json::to_string(&run).unwrap();
+    assert!(!json.contains("session_record"), "None should be skipped");
+    let restored: EngineerLoopRun = serde_json::from_str(&json).unwrap();
+    assert_eq!(restored.session_record, None);
 }

--- a/src/engineer_loop/types.rs
+++ b/src/engineer_loop/types.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use crate::goals::GoalRecord;
+use crate::session::{SessionPhase, SessionRecord};
 use crate::terminal_engineer_bridge::TerminalBridgeContext;
 
 use std::path::PathBuf;
@@ -127,6 +128,25 @@ pub struct PhaseTrace {
     pub outcome: PhaseOutcome,
 }
 
+impl PhaseTrace {
+    /// Maps this trace's ad-hoc phase name to the corresponding [`SessionPhase`].
+    ///
+    /// The engineer loop's internal phase names predate the session orchestration
+    /// state machine. This method provides the structured mapping required by
+    /// the spec (ProductArchitecture.md §Session Orchestration).
+    pub fn session_phase(&self) -> SessionPhase {
+        match self.name.as_str() {
+            "inspect" | "pre-mutation-guard" => SessionPhase::Intake,
+            "load-bridge-context" => SessionPhase::Preparation,
+            "agent-prompt-build" => SessionPhase::Planning,
+            "agent-spawn" | "agent-wait" => SessionPhase::Execution,
+            "review" => SessionPhase::Reflection,
+            "persist" => SessionPhase::Persistence,
+            _ => SessionPhase::Execution,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct EngineerLoopRun {
     pub state_root: PathBuf,
@@ -138,6 +158,11 @@ pub struct EngineerLoopRun {
     #[serde(with = "duration_millis")]
     pub elapsed_duration: Duration,
     pub phase_traces: Vec<PhaseTrace>,
+    /// The session record tracking phase progression through the spec's
+    /// SessionPhase state machine (Intake → … → Complete). `None` for
+    /// runs deserialized from older formats that predate session tracking.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_record: Option<SessionRecord>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -219,4 +244,8 @@ pub struct SessionErrorReflection {
     pub error_message: String,
     /// Phase traces collected up to the point of failure.
     pub phase_traces: Vec<PhaseTrace>,
+    /// Session ID for correlating the failed session with persisted artifacts.
+    /// `None` for reflections created before session tracking was added.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
 }


### PR DESCRIPTION
## Summary

Refactors `run_local_engineer_loop()` to create a `SessionRecord` and advance through the spec's `SessionPhase` state machine (Intake → Preparation → Planning → Execution → Reflection → Persistence → Complete) instead of using ad-hoc string-named phases.

Closes #2100. Also closes #2085 (meeting subprocess timeout guard resolved by 76a51a50).

## What changed

### `src/engineer_loop/mod.rs`
- Creates a `SessionRecord` at loop start using `UuidSessionIdGenerator`
- Advances the session through `SessionPhase` transitions at each stage, matching the `RuntimeKernel::execute_session` contract
- Marks session as `Failed` on error paths with `session.advance(SessionPhase::Failed)`
- Passes session to new `persist_artifacts_with_session()` for unified session identity (single session ID from intake to complete)
- Includes `session_record` in the returned `EngineerLoopRun`
- Adds `session_id` to all `SessionErrorReflection` constructions for failed-session correlation

### `src/engineer_loop/types.rs`
- `PhaseTrace::session_phase()` method: maps ad-hoc phase names (inspect, agent-spawn, etc.) to the spec's `SessionPhase` enum values
- `EngineerLoopRun.session_record: Option<SessionRecord>`: carries the session record through to callers (backward-compatible via `#[serde(default)]`)
- `SessionErrorReflection.session_id: Option<String>`: session ID for correlating failed sessions

### `src/engineer_loop/review_persist.rs`
- Extracted `persist_artifacts_with_session()` (pub(crate)): accepts an existing `SessionRecord` at Persistence phase, writes evidence/memory/handoff, and advances to Complete
- `persist_engineer_loop_artifacts()` is now a thin backward-compatible wrapper that creates its own session and delegates to the inner function

### `docs/architecture/engineer-agent-orchestration.md`
- Updated data flow diagram from numbered ad-hoc phases to `SessionPhase` state machine labels

## Phase mapping

| Ad-hoc phase name    | SessionPhase  |
|---------------------|---------------|
| inspect             | Intake        |
| pre-mutation-guard  | Intake        |
| load-bridge-context | Preparation   |
| agent-prompt-build  | Planning      |
| agent-spawn         | Execution     |
| agent-wait          | Execution     |
| review              | Reflection    |
| persist             | Persistence   |

## Testing

- **212 engineer_loop tests pass** (201 existing + 11 new)
- **4691 full lib tests pass** (1 pre-existing flaky failure in `engineer_worktree::precommit` unrelated to this change)
- New tests cover: PhaseTrace→SessionPhase mapping for all 8 ad-hoc phase names + unknown fallback, SessionErrorReflection session_id serialization, EngineerLoopRun session_record backward-compat deserialization

## Backward compatibility

- `PhaseTrace` struct unchanged — new mapping is via method, not field
- `EngineerLoopRun.session_record` uses `Option` + `#[serde(default)]` — old serialized data deserializes cleanly
- `SessionErrorReflection.session_id` uses `Option` + `#[serde(default)]` — old JSON without the field deserializes as None
- `persist_engineer_loop_artifacts()` public signature unchanged — all existing callers (tests, recipe steps) continue to work