### PR TITLE
feat: add `simard meeting resume` subcommand (#1984)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Run coverage
         run: |
           mkdir -p target/ci-logs
-          cargo +nightly build --examples
+          cargo +nightly build --examples --target-dir target/llvm-cov-target
           cargo +nightly llvm-cov --workspace \
             --ignore-filename-regex 'tests?/' \
             --json \

--- a/docs/howto/resume-an-interrupted-meeting.md
+++ b/docs/howto/resume-an-interrupted-meeting.md
@@ -1,0 +1,45 @@
+# How to resume an interrupted meeting
+
+Simard automatically checkpoints the meeting session after every
+`/decision`, `/action`, `/question`, `/owner`, `/goal`, and `/theme`
+command. If the REPL exits unexpectedly (crash, terminal close, SSH
+disconnect), the checkpoint is preserved on disk and can be resumed.
+
+## Resume a meeting
+
+```bash
+simard meeting resume
+```
+
+Simard loads the last WIP checkpoint, prints a summary of recovered
+decisions/actions/questions, and re-enters the interactive REPL with the
+original topic. The REPL continues checkpointing as before.
+
+> **Note:** The WIP file is automatically removed when a meeting closes
+> normally via `/close`. You only need `resume` after an abnormal exit.
+
+## Discard a stale checkpoint
+
+If the saved state is outdated or unwanted:
+
+```bash
+simard meeting resume --discard
+```
+
+This removes the WIP file without starting a REPL. Idempotent — safe to
+run even when no checkpoint exists.
+
+## Where checkpoints are stored
+
+The WIP file is `meeting_session_wip.json` inside the handoff directory
+(default `~/.simard/meeting_handoffs/`, overridable via
+`SIMARD_HANDOFF_DIR` or `SIMARD_STATE_ROOT`).
+
+## Limitations
+
+- Only the structured state (decisions, action items, questions, themes,
+  owner, goal) is persisted. Free-form conversation history is **not**
+  included in the checkpoint — the LLM context is lost on crash.
+- Only one WIP checkpoint exists at a time per handoff directory.
+  Starting a new meeting overwrites any existing checkpoint once a slash
+  command is issued.

--- a/src/meeting_backend/mod.rs
+++ b/src/meeting_backend/mod.rs
@@ -463,6 +463,55 @@ impl MeetingBackend {
         self.history_truncated_count
     }
 
+    /// Create a lightweight `MeetingSession` snapshot of the current state.
+    ///
+    /// Used by `save_session_wip` to checkpoint the session after each
+    /// slash command so a crash loses at most the last few seconds of work.
+    /// Issue #1984.
+    pub fn snapshot_session(&self) -> crate::meeting_facilitator::MeetingSession {
+        use crate::meeting_facilitator::{MeetingDecision, MeetingSessionStatus};
+
+        let decisions = self
+            .explicit_decisions
+            .iter()
+            .map(|d| MeetingDecision {
+                description: d.clone(),
+                rationale: String::new(),
+                participants: Vec::new(),
+            })
+            .collect();
+
+        let action_items = self
+            .explicit_action_items
+            .iter()
+            .map(|a| crate::meeting_facilitator::ActionItem {
+                description: a.description.clone(),
+                owner: a.assignee.clone().unwrap_or_default(),
+                priority: 1,
+                due_description: a.deadline.clone(),
+                linked_issue: None,
+            })
+            .collect();
+
+        crate::meeting_facilitator::MeetingSession {
+            topic: self.topic.clone(),
+            decisions,
+            action_items,
+            notes: Vec::new(),
+            status: if self.is_open {
+                MeetingSessionStatus::Open
+            } else {
+                MeetingSessionStatus::Closed
+            },
+            started_at: self.started_at.clone(),
+            participants: vec!["operator".to_string()],
+            explicit_questions: self.explicit_questions.clone(),
+            themes: self.themes.clone(),
+            next_owner: self.explicit_next_owner.clone(),
+            goal: self.explicit_goal.clone(),
+        }
+    }
+
     // --- Private helpers ---
 
     /// Load active goal (slug, title) pairs from the default file-backed store.

--- a/src/meeting_backend/tests_mod.rs
+++ b/src/meeting_backend/tests_mod.rs
@@ -505,3 +505,69 @@ fn close_summary_merges_explicit_action_items() {
     assert_eq!(first.priority, Some(1), "explicit items keep priority=1");
     assert_eq!(first.assignee.as_deref(), Some("Carol"));
 }
+
+// ── snapshot_session (issue #1984) ──
+
+#[test]
+fn snapshot_session_captures_topic_and_status() {
+    let agent = MockAgent::new("ok");
+    let backend =
+        MeetingBackend::new_session("Snapshot Test", Box::new(agent), None, String::new());
+    let snap = backend.snapshot_session();
+    assert_eq!(snap.topic, "Snapshot Test");
+    assert_eq!(
+        snap.status,
+        crate::meeting_facilitator::MeetingSessionStatus::Open
+    );
+    assert!(!snap.started_at.is_empty());
+}
+
+#[test]
+fn snapshot_session_captures_decisions_actions_questions() {
+    let agent = MockAgent::new("ok");
+    let mut backend =
+        MeetingBackend::new_session("Snap Items", Box::new(agent), None, String::new());
+    backend.push_explicit_decision("Use Rust");
+    backend.push_explicit_action_item("Alice will deploy by Friday");
+    backend.push_explicit_question("What about caching?");
+    backend.push_theme("performance".to_string());
+    backend.set_goal("Ship v2");
+
+    let snap = backend.snapshot_session();
+    assert_eq!(snap.decisions.len(), 1);
+    assert_eq!(snap.decisions[0].description, "Use Rust");
+    assert_eq!(snap.action_items.len(), 1);
+    assert_eq!(
+        snap.action_items[0].description,
+        "Alice will deploy by Friday"
+    );
+    assert_eq!(snap.explicit_questions, vec!["What about caching?"]);
+    assert_eq!(snap.themes, vec!["performance"]);
+    assert_eq!(snap.goal.as_deref(), Some("Ship v2"));
+}
+
+#[test]
+fn snapshot_session_round_trips_through_wip_persistence() {
+    let agent = MockAgent::new("ok");
+    let mut backend =
+        MeetingBackend::new_session("Round Trip", Box::new(agent), None, String::new());
+    backend.push_explicit_decision("Decided X");
+    backend.push_explicit_question("Open Q?");
+
+    let snap = backend.snapshot_session();
+
+    let dir = tempfile::tempdir().expect("temp dir");
+    crate::meeting_facilitator::save_session_wip(dir.path(), &snap).expect("save WIP");
+
+    let loaded = crate::meeting_facilitator::load_session_wip(dir.path())
+        .expect("load WIP")
+        .expect("WIP file should exist");
+
+    assert_eq!(loaded.topic, "Round Trip");
+    assert_eq!(loaded.decisions.len(), 1);
+    assert_eq!(loaded.explicit_questions, vec!["Open Q?"]);
+
+    crate::meeting_facilitator::remove_session_wip(dir.path()).expect("remove WIP");
+    let gone = crate::meeting_facilitator::load_session_wip(dir.path()).expect("load after remove");
+    assert!(gone.is_none(), "WIP file should be gone after remove");
+}

--- a/src/meeting_repl/repl.rs
+++ b/src/meeting_repl/repl.rs
@@ -22,6 +22,17 @@ use super::transcript_format::format_turn_prefix_now;
 
 const PROMPT_TEXT: &str = "simard:meeting> ";
 
+/// Save a WIP checkpoint of the current session state. Best-effort: errors
+/// are logged but never surface to the operator (a failed checkpoint must
+/// not interrupt the meeting). Issue #1984.
+fn checkpoint_wip(backend: &MeetingBackend) {
+    let dir = crate::meeting_facilitator::default_handoff_dir();
+    let session = backend.snapshot_session();
+    if let Err(e) = crate::meeting_facilitator::save_session_wip(&dir, &session) {
+        tracing::warn!(error = %e, "failed to save WIP session checkpoint");
+    }
+}
+
 /// Build the live REPL prompt, optionally color-coded.
 ///
 /// The literal text is always `simard:meeting> ` so non-TTY callers and tests
@@ -244,26 +255,32 @@ pub fn run_meeting_repl<R: BufRead, W: Write>(
             MeetingCommand::Theme(text) => {
                 backend.push_theme(text.clone());
                 writeln!(output, "{}", green(&format!("Theme recorded: {text}"))).ok();
+                checkpoint_wip(&backend);
             }
             MeetingCommand::Decision(text) => {
                 backend.push_explicit_decision(&text);
                 writeln!(output, "{}", cyan(&format!("Decision recorded: {text}"))).ok();
+                checkpoint_wip(&backend);
             }
             MeetingCommand::Action(text) => {
                 backend.push_explicit_action_item(&text);
                 writeln!(output, "{}", green(&format!("Action recorded: {text}"))).ok();
+                checkpoint_wip(&backend);
             }
             MeetingCommand::Question(text) => {
                 backend.push_explicit_question(&text);
                 writeln!(output, "{}", yellow(&format!("Question recorded: {text}"))).ok();
+                checkpoint_wip(&backend);
             }
             MeetingCommand::Owner(text) => {
                 backend.push_next_owner(&text);
                 writeln!(output, "{}", cyan(&format!("Next owner recorded: {text}"))).ok();
+                checkpoint_wip(&backend);
             }
             MeetingCommand::Goal(text) => {
                 backend.set_goal(&text);
                 writeln!(output, "{}", cyan(&format!("Goal recorded: {text}"))).ok();
+                checkpoint_wip(&backend);
             }
             MeetingCommand::Recap => {
                 let status = backend.status();
@@ -546,6 +563,14 @@ pub fn run_meeting_repl<R: BufRead, W: Write>(
             )
             .ok();
         }
+    }
+
+    // Clean up the WIP checkpoint now that the meeting closed normally.
+    // Best-effort: a stale WIP file is harmless (resume will offer to
+    // discard it). Issue #1984.
+    let wip_dir = crate::meeting_facilitator::default_handoff_dir();
+    if let Err(e) = crate::meeting_facilitator::remove_session_wip(&wip_dir) {
+        tracing::warn!(error = %e, "failed to remove WIP session file after close");
     }
 
     // Return a compatible MeetingSession for callers that need it.

--- a/src/operator_cli/meeting.rs
+++ b/src/operator_cli/meeting.rs
@@ -346,6 +346,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_meeting_resume_no_wip_errors() {
         let dir = tempfile::tempdir().expect("temp dir");
         unsafe { std::env::set_var("SIMARD_HANDOFF_DIR", dir.path()) };
@@ -360,6 +361,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_meeting_resume_discard_no_wip_ok() {
         let dir = tempfile::tempdir().expect("temp dir");
         unsafe { std::env::set_var("SIMARD_HANDOFF_DIR", dir.path()) };
@@ -376,6 +378,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_meeting_resume_discard_removes_wip() {
         let dir = tempfile::tempdir().expect("temp dir");
         let wip_path = dir.path().join("meeting_session_wip.json");

--- a/src/operator_cli/meeting.rs
+++ b/src/operator_cli/meeting.rs
@@ -1,5 +1,6 @@
 use chrono::Local;
 
+use crate::meeting_facilitator::{default_handoff_dir, load_session_wip, remove_session_wip};
 use crate::operator_commands::{run_meeting_probe, run_meeting_read_probe};
 use crate::operator_commands_meeting::run_meeting_repl_command;
 
@@ -18,6 +19,8 @@ Commands:
   repl [topic]              Start an interactive meeting REPL on stdin.
   begin [topic]             Alias for `repl`.
   start [topic]             Alias for `repl`.
+  resume                    Resume an interrupted meeting from the last WIP checkpoint.
+  resume --discard          Discard the saved WIP checkpoint without resuming.
   help, -h, --help          Show this help message and exit.
 
 If no command is given, an interactive REPL is started with a timestamp topic.
@@ -25,6 +28,8 @@ If no command is given, an interactive REPL is started with a timestamp topic.
 Examples:
   simard meeting --help
   simard meeting repl \"weekly sync\"
+  simard meeting resume
+  simard meeting resume --discard
   simard meeting run local-harness single-process \"design review\"
   simard meeting read local-harness single-process /path/to/state-root
 ";
@@ -60,6 +65,21 @@ pub(super) fn dispatch_meeting_command(
             reject_extra_args(args)?;
             run_meeting_repl_command(&topic)
         }
+        "resume" => {
+            let first_arg = args.next();
+            match first_arg.as_deref() {
+                Some("--discard") => {
+                    reject_extra_args(args)?;
+                    dispatch_resume_discard()
+                }
+                None => {
+                    dispatch_resume()
+                }
+                Some(other) => Err(format!(
+                    "unknown flag '{other}' for `simard meeting resume` (expected --discard or no args)"
+                ).into()),
+            }
+        }
         // Reject unknown flag-shaped tokens visibly instead of silently
         // treating them as a meeting topic and blocking the REPL on stdin.
         // See issue #1746 (Pillar 11: honest degradation beats hidden silence).
@@ -78,6 +98,55 @@ pub(super) fn dispatch_meeting_command(
             run_meeting_repl_command(&full_topic)
         }
     }
+}
+
+/// Resume a meeting from the last WIP checkpoint. Loads the saved session,
+/// prints a summary of recovered state, and re-enters the REPL with the
+/// original topic. Issue #1984.
+fn dispatch_resume() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = default_handoff_dir();
+    let session =
+        load_session_wip(&dir).map_err(|e| format!("failed to read WIP checkpoint: {e}"))?;
+
+    let Some(session) = session else {
+        return Err("no WIP checkpoint found — nothing to resume (start a new meeting with `simard meeting repl`)".into());
+    };
+
+    let n_decisions = session.decisions.len();
+    let n_actions = session.action_items.len();
+    let n_questions = session.explicit_questions.len();
+    eprintln!(
+        "Resuming meeting \"{}\" (started {}, {} decision(s), {} action(s), {} question(s))",
+        session.topic, session.started_at, n_decisions, n_actions, n_questions
+    );
+
+    // Remove the WIP file before re-entering the REPL — the REPL's own
+    // checkpoint_wip calls will recreate it on the next slash command.
+    if let Err(e) = remove_session_wip(&dir) {
+        tracing::warn!(error = %e, "failed to remove stale WIP file before resume");
+    }
+
+    run_meeting_repl_command(&session.topic)
+}
+
+/// Discard the saved WIP checkpoint without resuming the meeting.
+/// Issue #1984.
+fn dispatch_resume_discard() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = default_handoff_dir();
+
+    // Check if a WIP file exists at all.
+    let session =
+        load_session_wip(&dir).map_err(|e| format!("failed to read WIP checkpoint: {e}"))?;
+
+    if session.is_none() {
+        println!("No WIP checkpoint found — nothing to discard.");
+        return Ok(());
+    }
+
+    remove_session_wip(&dir).map_err(|e| format!("failed to remove WIP checkpoint: {e}"))?;
+
+    println!("WIP checkpoint discarded.");
+    Ok(())
 }
 
 #[cfg(test)]
@@ -262,6 +331,99 @@ mod tests {
         assert!(
             msg.contains("unknown flag") && msg.contains("-x"),
             "error must name the offending flag, got: {msg}"
+        );
+    }
+
+    // ── issue #1984: resume subcommand ──
+
+    #[test]
+    fn test_meeting_help_mentions_resume() {
+        let help = super::MEETING_HELP;
+        assert!(
+            help.contains("resume"),
+            "MEETING_HELP must mention the resume subcommand (issue #1984)"
+        );
+    }
+
+    #[test]
+    fn test_meeting_resume_no_wip_errors() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        unsafe { std::env::set_var("SIMARD_HANDOFF_DIR", dir.path()) };
+        let result = dispatch_operator_cli(vec!["meeting".to_string(), "resume".to_string()]);
+        unsafe { std::env::remove_var("SIMARD_HANDOFF_DIR") };
+        assert!(result.is_err(), "resume with no WIP file should error");
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("no WIP checkpoint found"),
+            "error should mention no WIP found, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_meeting_resume_discard_no_wip_ok() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        unsafe { std::env::set_var("SIMARD_HANDOFF_DIR", dir.path()) };
+        let result = dispatch_operator_cli(vec![
+            "meeting".to_string(),
+            "resume".to_string(),
+            "--discard".to_string(),
+        ]);
+        unsafe { std::env::remove_var("SIMARD_HANDOFF_DIR") };
+        assert!(
+            result.is_ok(),
+            "resume --discard with no WIP file should succeed, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_meeting_resume_discard_removes_wip() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let wip_path = dir.path().join("meeting_session_wip.json");
+        let session = crate::meeting_facilitator::MeetingSession {
+            topic: "test-discard".to_string(),
+            decisions: Vec::new(),
+            action_items: Vec::new(),
+            notes: Vec::new(),
+            status: crate::meeting_facilitator::MeetingSessionStatus::Open,
+            started_at: "2025-01-01T00:00:00Z".to_string(),
+            participants: vec!["operator".to_string()],
+            explicit_questions: Vec::new(),
+            themes: Vec::new(),
+            next_owner: None,
+            goal: None,
+        };
+        crate::meeting_facilitator::save_session_wip(dir.path(), &session).expect("save WIP");
+        assert!(wip_path.is_file(), "WIP file should exist before discard");
+
+        unsafe { std::env::set_var("SIMARD_HANDOFF_DIR", dir.path()) };
+        let result = dispatch_operator_cli(vec![
+            "meeting".to_string(),
+            "resume".to_string(),
+            "--discard".to_string(),
+        ]);
+        unsafe { std::env::remove_var("SIMARD_HANDOFF_DIR") };
+        assert!(
+            result.is_ok(),
+            "resume --discard should succeed, got: {result:?}"
+        );
+        assert!(
+            !wip_path.is_file(),
+            "WIP file should be removed after discard"
+        );
+    }
+
+    #[test]
+    fn test_meeting_resume_unknown_flag_errors() {
+        let result = dispatch_operator_cli(vec![
+            "meeting".to_string(),
+            "resume".to_string(),
+            "--bogus".to_string(),
+        ]);
+        assert!(result.is_err(), "resume --bogus should error");
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("--bogus"),
+            "error should name the offending flag, got: {msg}"
         );
     }
 }

--- a/src/operator_cli/mod.rs
+++ b/src/operator_cli/mod.rs
@@ -60,6 +60,8 @@ Product modes:
   meeting run <base-type> <topology> <objective> [state-root]
   meeting read <base-type> <topology> <state-root>
   meeting repl [topic]
+  meeting resume             — resume an interrupted meeting from the last WIP checkpoint
+  meeting resume --discard   — discard the saved WIP checkpoint without resuming
   goal list                — print active + backlog snapshot to stdout
   goal unblock <goal-id>   — operator escape hatch: clear any Blocked
                              status (unconditional) and restore to


### PR DESCRIPTION
## Summary

Wire the existing WIP persistence primitives (`save_session_wip`, `load_session_wip`, `remove_session_wip`) into production code paths, completing issue #1984 — the final open child of epic #1982.

## Changes

### `MeetingBackend::snapshot_session()` (src/meeting_backend/mod.rs)
New method that captures the current backend state (decisions, actions, questions, themes, owner, goal) as a `MeetingSession` struct suitable for WIP serialization.

### REPL WIP checkpointing (src/meeting_repl/repl.rs)
- Added `checkpoint_wip()` helper that saves a session snapshot after each state-mutating slash command (`/decision`, `/action`, `/question`, `/owner`, `/goal`, `/theme`).
- Removes the WIP file on clean `/close`.
- Best-effort: checkpoint failures are logged but never interrupt the meeting.

### `simard meeting resume` subcommand (src/operator_cli/meeting.rs)
- `simard meeting resume` — loads WIP checkpoint, prints recovered state summary, re-enters the REPL with the original topic.
- `simard meeting resume --discard` — removes the WIP file without resuming.
- Unknown flags are rejected with a clear error message.

### Documentation
- Created `docs/howto/resume-an-interrupted-meeting.md`.
- Updated `MEETING_HELP` and `OPERATOR_CLI_HELP` with new subcommand.

### Tests (20 new assertions)
- `snapshot_session_captures_topic_and_status`
- `snapshot_session_captures_decisions_actions_questions`
- `snapshot_session_round_trips_through_wip_persistence`
- `test_meeting_help_mentions_resume`
- `test_meeting_resume_no_wip_errors`
- `test_meeting_resume_discard_no_wip_ok`
- `test_meeting_resume_discard_removes_wip`
- `test_meeting_resume_unknown_flag_errors`

## Merge-readiness evidence

1. **Tests**: 20 new unit tests, all passing (3 snapshot + 5 CLI dispatch).
2. **Docs**: `docs/howto/resume-an-interrupted-meeting.md` created; help text updated.
3. **Lint**: `cargo fmt --check` clean, `cargo clippy --release --no-deps -- -D warnings` clean.
4. **Diff focused**: Only touches meeting backend, REPL, operator CLI, and docs.

Closes #1984