### PR TITLE
fix(goal-curation): unify GoalProgress with GoalStatus — add Proposed and Paused variants (#2098)

### DIFF
--- a/docs/reference/goal-board-api.md
+++ b/docs/reference/goal-board-api.md
@@ -659,7 +659,7 @@ call site.
 | `slug` | `slugify(active.id)` or `active.id` | If the id is already slug-shaped (lowercase, dashes, no whitespace) it passes through unchanged |
 | `title` | `active.description` | Truncated to the first line, max 120 characters |
 | `rationale` | `active.current_activity.unwrap_or_default()` | Empty string when no current activity is set |
-| `status` | `Completed → GoalStatus::Completed`, all others → `GoalStatus::Active` | `NotStarted`, `InProgress`, and `Blocked` collapse to `Active` because the legacy `GoalRecord` has no equivalent variants |
+| `status` | `Completed → GoalStatus::Completed`, `Proposed → GoalStatus::Proposed`, `Paused → GoalStatus::Paused`, others → `GoalStatus::Active` | `NotStarted`, `InProgress`, and `Blocked` collapse to `Active`; `Proposed` and `Paused` map directly to their `GoalStatus` equivalents (issue #2098) |
 | `priority` | `u8::try_from(active.priority).unwrap_or(u8::MAX)` | Saturates rather than panicking on overflow |
 | `owner_identity` | `active.assigned_to.clone().unwrap_or_else(\|\| "unassigned".into())` | The literal string `"unassigned"` is used as a sentinel when no engineer is assigned |
 | `source_session_id` | Sentinel `SessionId::parse("00000000-0000-0000-0000-000000000000")?` | The all-zeros UUID indicates "synthesized from goal-board snapshot, no originating session" |

--- a/src/goal_curation/operations.rs
+++ b/src/goal_curation/operations.rs
@@ -690,9 +690,11 @@ pub fn update_goal_progress(
 /// not change progress numerically; callers pass `current` for that.
 fn progress_to_percent(p: &GoalProgress, current: u32) -> u32 {
     match p {
+        GoalProgress::Proposed => 0,
         GoalProgress::NotStarted => 0,
         GoalProgress::InProgress { percent } => *percent,
         GoalProgress::Blocked(_) => current,
+        GoalProgress::Paused => current,
         GoalProgress::Completed => 100,
     }
 }
@@ -700,9 +702,11 @@ fn progress_to_percent(p: &GoalProgress, current: u32) -> u32 {
 /// Variant label for bypass reason strings.
 fn variant_label(p: &GoalProgress) -> &'static str {
     match p {
+        GoalProgress::Proposed => "proposed",
         GoalProgress::NotStarted => "not-started",
         GoalProgress::InProgress { .. } => "in-progress",
         GoalProgress::Blocked(_) => "blocked",
+        GoalProgress::Paused => "paused",
         GoalProgress::Completed => "completed",
     }
 }
@@ -759,6 +763,8 @@ pub fn update_goal_progress_with_evidence(
     // ── Bypass set ────────────────────────────────────────────────────
     let is_bypass = matches!(proposed, GoalProgress::Blocked(_))
         || matches!(proposed, GoalProgress::NotStarted)
+        || matches!(proposed, GoalProgress::Proposed)
+        || matches!(proposed, GoalProgress::Paused)
         || new_percent <= old_percent;
 
     if is_bypass {
@@ -766,6 +772,10 @@ pub fn update_goal_progress_with_evidence(
             "bypass: blocked".to_string()
         } else if matches!(proposed, GoalProgress::NotStarted) {
             "bypass: not-started".to_string()
+        } else if matches!(proposed, GoalProgress::Proposed) {
+            "bypass: proposed".to_string()
+        } else if matches!(proposed, GoalProgress::Paused) {
+            "bypass: paused".to_string()
         } else if new_percent < old_percent {
             "bypass: non-increase (decrease)".to_string()
         } else {
@@ -974,7 +984,7 @@ static SENTINEL_SESSION_ID: LazyLock<crate::session::SessionId> = LazyLock::new(
 /// | `slug`               | `goal_slug(active.id)` (preserves slug-shaped ids unchanged)      |
 /// | `title`              | `active.description` (first line, truncated to 120 chars)         |
 /// | `rationale`          | `active.current_activity.unwrap_or_default()`                     |
-/// | `status`             | `Completed → GoalStatus::Completed`, all others → `GoalStatus::Active` |
+/// | `status`             | `Completed → GoalStatus::Completed`, `Proposed → GoalStatus::Proposed`, `Paused → GoalStatus::Paused`, others → `GoalStatus::Active` |
 /// | `priority`           | `u8::try_from(active.priority).unwrap_or(u8::MAX)`                |
 /// | `owner_identity`     | `active.assigned_to.clone().unwrap_or_else(\|\| "unassigned".into())` |
 /// | `source_session_id`  | sentinel `00000000-0000-0000-0000-000000000000`                   |
@@ -990,10 +1000,11 @@ pub fn active_goals_as_records(board: &GoalBoard) -> Vec<crate::goals::GoalRecor
             let title_first_line = active.description.lines().next().unwrap_or("");
             let title: String = title_first_line.chars().take(120).collect();
 
-            let status = if matches!(active.status, GoalProgress::Completed) {
-                crate::goals::GoalStatus::Completed
-            } else {
-                crate::goals::GoalStatus::Active
+            let status = match &active.status {
+                GoalProgress::Proposed => crate::goals::GoalStatus::Proposed,
+                GoalProgress::Paused => crate::goals::GoalStatus::Paused,
+                GoalProgress::Completed => crate::goals::GoalStatus::Completed,
+                _ => crate::goals::GoalStatus::Active,
             };
 
             let priority = u8::try_from(active.priority).unwrap_or(u8::MAX);

--- a/src/goal_curation/tests_adapter.rs
+++ b/src/goal_curation/tests_adapter.rs
@@ -10,7 +10,7 @@
 //! | `slug`               | `goal_slug(active.id)` (or `active.id` if already a slug)   |
 //! | `title`              | `active.description` (first line, truncated to 120 chars)   |
 //! | `rationale`          | `active.current_activity.unwrap_or_default()`               |
-//! | `status`             | `Completed → GoalStatus::Completed`, else `GoalStatus::Active` |
+//! | `status`             | `Completed → GoalStatus::Completed`, `Proposed → GoalStatus::Proposed`, `Paused → GoalStatus::Paused`, else `GoalStatus::Active` |
 //! | `priority`           | `u8::try_from(active.priority).unwrap_or(u8::MAX)`          |
 //! | `owner_identity`     | `active.assigned_to.clone().unwrap_or_else(\|\| "unassigned".into())` |
 //! | `source_session_id`  | sentinel `00000000-0000-0000-0000-000000000000`             |
@@ -293,4 +293,34 @@ fn wip_refs_do_not_affect_record_construction() {
     assert_eq!(records.len(), 1);
     // WIP refs are not part of GoalRecord — adapter must not panic on them.
     assert_eq!(records[0].slug, "with-wip-goal-id");
+}
+
+#[test]
+fn status_proposed_maps_to_proposed() {
+    let mut board = GoalBoard::new();
+    let mut g = active("proposed-goal-id", "A proposed goal", 1);
+    g.status = GoalProgress::Proposed;
+    board.active.push(g);
+
+    let records = active_goals_as_records(&board);
+    assert_eq!(
+        records[0].status,
+        GoalStatus::Proposed,
+        "GoalProgress::Proposed must map to GoalStatus::Proposed (issue #2098)"
+    );
+}
+
+#[test]
+fn status_paused_maps_to_paused() {
+    let mut board = GoalBoard::new();
+    let mut g = active("paused-goal-id", "A paused goal", 2);
+    g.status = GoalProgress::Paused;
+    board.active.push(g);
+
+    let records = active_goals_as_records(&board);
+    assert_eq!(
+        records[0].status,
+        GoalStatus::Paused,
+        "GoalProgress::Paused must map to GoalStatus::Paused (issue #2098)"
+    );
 }

--- a/src/goal_curation/types.rs
+++ b/src/goal_curation/types.rs
@@ -9,20 +9,33 @@ use serde::{Deserialize, Serialize};
 pub const MAX_ACTIVE_GOALS: usize = 5;
 
 /// Progress state for an active goal.
+///
+/// Variants align with the spec-mandated lifecycle statuses in
+/// [`crate::goals::GoalStatus`] (`Proposed`, `Active`/progress variants,
+/// `Paused`, `Completed`) so the operator-facing goal curation path can
+/// distinguish proposed-vs-active goals and pause goals (issue #2098).
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum GoalProgress {
+    /// Goal has been proposed but not yet accepted onto the active board.
+    Proposed,
     NotStarted,
-    InProgress { percent: u32 },
+    InProgress {
+        percent: u32,
+    },
     Blocked(String),
+    /// Goal is temporarily paused — not blocked, but deliberately on hold.
+    Paused,
     Completed,
 }
 
 impl Display for GoalProgress {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
+            Self::Proposed => f.write_str("proposed"),
             Self::NotStarted => f.write_str("not-started"),
             Self::InProgress { percent } => write!(f, "in-progress({percent}%)"),
             Self::Blocked(reason) => write!(f, "blocked: {reason}"),
+            Self::Paused => f.write_str("paused"),
             Self::Completed => f.write_str("completed"),
         }
     }
@@ -133,6 +146,11 @@ mod tests {
     // ── GoalProgress Display ────────────────────────────────────────
 
     #[test]
+    fn goal_progress_display_proposed() {
+        assert_eq!(GoalProgress::Proposed.to_string(), "proposed");
+    }
+
+    #[test]
     fn goal_progress_display_not_started() {
         assert_eq!(GoalProgress::NotStarted.to_string(), "not-started");
     }
@@ -162,6 +180,11 @@ mod tests {
     }
 
     #[test]
+    fn goal_progress_display_paused() {
+        assert_eq!(GoalProgress::Paused.to_string(), "paused");
+    }
+
+    #[test]
     fn goal_progress_display_completed() {
         assert_eq!(GoalProgress::Completed.to_string(), "completed");
     }
@@ -171,9 +194,11 @@ mod tests {
     #[test]
     fn goal_progress_serde_all_variants() {
         let variants = vec![
+            GoalProgress::Proposed,
             GoalProgress::NotStarted,
             GoalProgress::InProgress { percent: 50 },
             GoalProgress::Blocked("reason".to_string()),
+            GoalProgress::Paused,
             GoalProgress::Completed,
         ];
         for v in variants {

--- a/src/ooda_actions/advance_goal/mod.rs
+++ b/src/ooda_actions/advance_goal/mod.rs
@@ -118,6 +118,20 @@ pub(super) fn dispatch_advance_goal(
                 format!("goal '{goal_id}' is already completed"),
             );
         }
+        GoalProgress::Proposed => {
+            return make_outcome(
+                action,
+                false,
+                format!("goal '{goal_id}' is still proposed — accept it before advancing"),
+            );
+        }
+        GoalProgress::Paused => {
+            return make_outcome(
+                action,
+                false,
+                format!("goal '{goal_id}' is paused — resume it before advancing"),
+            );
+        }
         _ => {}
     }
 

--- a/src/ooda_loop/orient.rs
+++ b/src/ooda_loop/orient.rs
@@ -58,10 +58,12 @@ pub fn orient_with_brain(
             let (mut urgency, mut reason) = match &g.status {
                 GoalProgress::Blocked(r) => (1.0, format!("blocked: {r}")),
                 GoalProgress::NotStarted => (0.8, "not yet started".to_string()),
+                GoalProgress::Proposed => (0.5, "proposed — awaiting acceptance".to_string()),
                 GoalProgress::InProgress { percent } => (
                     0.6 * (1.0 - (*percent as f64 / 100.0)),
                     format!("{percent}% complete"),
                 ),
+                GoalProgress::Paused => (0.1, "paused".to_string()),
                 GoalProgress::Completed => (0.0, "completed".to_string()),
             };
 

--- a/src/operator_commands_dashboard/current_work.rs
+++ b/src/operator_commands_dashboard/current_work.rs
@@ -97,6 +97,9 @@ pub(crate) async fn current_work() -> Json<Value> {
                 .iter()
                 .map(|g| {
                     let (status_str, blocker) = match &g.status {
+                        crate::goal_curation::GoalProgress::Proposed => {
+                            ("proposed".to_string(), None)
+                        }
                         crate::goal_curation::GoalProgress::NotStarted => {
                             ("not_started".to_string(), None)
                         }
@@ -106,6 +109,7 @@ pub(crate) async fn current_work() -> Json<Value> {
                         crate::goal_curation::GoalProgress::Blocked(reason) => {
                             ("blocked".to_string(), Some(reason.clone()))
                         }
+                        crate::goal_curation::GoalProgress::Paused => ("paused".to_string(), None),
                         crate::goal_curation::GoalProgress::Completed => {
                             ("completed".to_string(), None)
                         }

--- a/src/operator_commands_dashboard/goals.rs
+++ b/src/operator_commands_dashboard/goals.rs
@@ -307,6 +307,7 @@ pub(crate) async fn update_goal_status(
     };
 
     let new_status = match status_str {
+        "proposed" => GoalProgress::Proposed,
         "not-started" => GoalProgress::NotStarted,
         "in-progress" => GoalProgress::InProgress { percent: 0 },
         "blocked" => {
@@ -317,6 +318,7 @@ pub(crate) async fn update_goal_status(
                 .to_string();
             GoalProgress::Blocked(reason)
         }
+        "paused" => GoalProgress::Paused,
         "completed" => GoalProgress::Completed,
         other => return Json(json!({"error": format!("unknown status: {other}")})),
     };

--- a/src/operator_commands_dashboard/workboard.rs
+++ b/src/operator_commands_dashboard/workboard.rs
@@ -168,6 +168,9 @@ pub(crate) async fn workboard() -> Json<Value> {
                 .iter()
                 .map(|g| {
                     let (status_str, progress_pct) = match &g.status {
+                        crate::goal_curation::GoalProgress::Proposed => {
+                            ("proposed".to_string(), 0u32)
+                        }
                         crate::goal_curation::GoalProgress::NotStarted => {
                             ("queued".to_string(), 0u32)
                         }
@@ -177,6 +180,7 @@ pub(crate) async fn workboard() -> Json<Value> {
                         crate::goal_curation::GoalProgress::Blocked(reason) => {
                             (format!("blocked: {reason}"), 0)
                         }
+                        crate::goal_curation::GoalProgress::Paused => ("paused".to_string(), 0),
                         crate::goal_curation::GoalProgress::Completed => ("done".to_string(), 100),
                     };
                     json!({

--- a/tests/ooda_daemon.rs
+++ b/tests/ooda_daemon.rs
@@ -315,10 +315,12 @@ fn daemon_runs_multiple_cycles_and_persists_state_across_them() {
     // (per PHILOSOPHY.md: no silent fallback). With a session, it progresses.
     // Either is valid; what matters is that state survives across cycles.
     match &test_goal.unwrap().status {
-        GoalProgress::InProgress { .. }
+        GoalProgress::Proposed
+        | GoalProgress::InProgress { .. }
         | GoalProgress::Completed
         | GoalProgress::NotStarted
-        | GoalProgress::Blocked(_) => {}
+        | GoalProgress::Blocked(_)
+        | GoalProgress::Paused => {}
     }
 }
 


### PR DESCRIPTION
## Summary

Unifies the dual goal status systems by adding `Proposed` and `Paused` variants to `GoalProgress` (the operator-facing enum in `src/goal_curation/types.rs`), aligning it with the spec-mandated `GoalStatus` enum in `src/goals/types.rs`.

**Spec reference:** `Specs/ProductArchitecture.md` line 658 — "distinguish active, proposed, paused, and completed priorities"

## Problem

The codebase had two parallel goal systems with inconsistent status enums:
- `GoalStatus` (`src/goals/types.rs`): `Proposed`, `Active`, `Paused`, `Completed` ✓ matches spec
- `GoalProgress` (`src/goal_curation/types.rs`): `NotStarted`, `InProgress`, `Blocked`, `Completed` ✗ missing `Proposed`/`Paused`

Operators could not distinguish proposed-vs-active goals or pause goals through the primary curation path.

## Changes (10 files, +104/-10)

| File | Change |
|------|--------|
| `src/goal_curation/types.rs` | Add `Proposed` and `Paused` variants to `GoalProgress`; update `Display` impl and serde tests |
| `src/goal_curation/operations.rs` | Update `progress_to_percent`, `variant_label`, bypass detection, and `active_goals_as_records` adapter (Proposed→GoalStatus::Proposed, Paused→GoalStatus::Paused) |
| `src/goal_curation/tests_adapter.rs` | Add 2 new tests: `status_proposed_maps_to_proposed`, `status_paused_maps_to_paused` |
| `src/ooda_loop/orient.rs` | Add urgency scoring: Proposed=0.5, Paused=0.1 |
| `src/ooda_actions/advance_goal/mod.rs` | Refuse advancing Proposed/Paused goals with actionable messages |
| `src/operator_commands_dashboard/goals.rs` | Accept "proposed"/"paused" in status update API |
| `src/operator_commands_dashboard/current_work.rs` | Render proposed/paused in current-work view |
| `src/operator_commands_dashboard/workboard.rs` | Render proposed/paused in workboard view |
| `tests/ooda_daemon.rs` | Add new variants to exhaustive match |
| `docs/reference/goal-board-api.md` | Update adapter mapping table |

## Test Evidence

- **cargo build**: ✅ Clean compilation (0 errors, 0 warnings)
- **cargo fmt**: ✅ Passed
- **cargo clippy --release**: ✅ Passed (0 warnings with `-D warnings`)
- **cargo test**: ✅ 4788 passed, 2 failed (pre-existing, unrelated: `pre_commit` module missing + hermetic guard env issue)
- **New tests**: 2 adapter tests pass (`status_proposed_maps_to_proposed`, `status_paused_maps_to_paused`)
- **All 18 adapter tests pass**, all 98 goal_curation tests pass, all 16 orient tests pass

## Merge-Ready Criteria

1. ✅ Tests written and validated (2 new adapter tests + all existing pass)
2. ✅ Docs updated (`goal-board-api.md` adapter mapping table)
3. ✅ Pre-commit hooks pass (fmt + clippy)
4. ✅ CI will validate on push
5. ✅ This PR description contains evidence for all criteria
6. ✅ Diff focused — only GoalProgress unification, no unrelated edits

Closes #2098