### PR TITLE
The recipe-engineer-lifecycle-brain is failing every OODA cycle with 'recipe exited with exit status: 1'. 1341 failures in 24 hours. This is blocking all autonomous goal advancement.  The recipe YAML 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3560,7 +3560,7 @@ dependencies = [
 
 [[package]]
 name = "simard"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "amplihack-memory",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simard"
-version = "0.17.0"
+version = "0.17.1"
 edition = "2024"
 default-run = "simard"
 

--- a/docs/reference/recipe-context-var-sanitization.md
+++ b/docs/reference/recipe-context-var-sanitization.md
@@ -75,7 +75,7 @@ assert_eq!(truncated.chars().count(), 11); // 10 content chars + "…"
 | Char-boundary safe | Truncation never splits a multi-byte UTF-8 sequence |
 | Idempotent | `sanitize(sanitize(s, n), n)` == `sanitize(s, n)` (modulo the ellipsis already being present) |
 | Pure | No I/O. Allocates only the returned `String` |
-| Empty-safe | Empty input returns empty output; `max_len = 0` returns `""` |
+| Empty-safe | Empty input returns empty output. `max_len = 0` with non-empty input returns `"…"` (truncation marker only) |
 
 ## Application Sites
 

--- a/docs/reference/recipe-context-var-sanitization.md
+++ b/docs/reference/recipe-context-var-sanitization.md
@@ -1,0 +1,305 @@
+# Reference: Recipe Context Variable Sanitization
+
+Module: `src/ooda_brain/sanitize.rs`
+Consumers: `recipe_engineer_lifecycle.rs`, `recipe_decide.rs`, `recipe_orient.rs`
+
+All three recipe-based OODA brains pass user-derived and log-derived strings
+as `-c key=value` context variables to `recipe-runner-rs`. These strings flow
+through Handlebars `{{var}}` substitution into the agent prompt. Unsanitized
+newlines in context values break YAML template interpolation in
+recipe-runner-rs, causing the subprocess to exit with status 1 — which the
+Rust shim reports as `AdapterInvocationFailed("recipe exited with exit
+status: 1")`.
+
+> **History:** Before issue
+> [#2127](https://github.com/rysweet/Simard/issues/2127), context variables
+> were passed verbatim to `recipe-runner-rs`. The `last_engineer_log_tail`
+> field — which contains raw terminal output with embedded newlines — caused
+> 1,341 OODA cycle failures in 24 hours. The recipe YAML worked when invoked
+> from the command line (where context values were manually quoted) but failed
+> when the Rust shim constructed the `-c key=value` argv programmatically.
+
+## The Problem
+
+The recipe-runner-rs Handlebars engine performs `{{var}}` substitution inside
+a YAML `prompt:` block. When a context variable contains a literal newline:
+
+```
+-c "last_engineer_log_tail=error: cannot find\nthread panicked at src/main.rs"
+```
+
+…the rendered YAML prompt breaks because the newline is interpolated literally
+into the YAML multi-line scalar, producing invalid YAML structure or injecting
+unintended content after the line break. recipe-runner-rs exits with status 1.
+
+The same issue affects any context variable that could contain newlines,
+carriage returns, or excessive length — specifically `goal_id`,
+`goal_description`, `worktree_path`, and `last_engineer_log_tail` in the
+engineer-lifecycle brain, `goal_id` and `reason` in the decide brain, and
+`goal_id` and `base_reason` in the orient brain.
+
+## Sanitization Helper
+
+### `sanitize_context_var(s: &str, max_len: usize) -> String`
+
+`pub(super)` function in `src/ooda_brain/sanitize.rs`. Available to all
+modules within `ooda_brain` via `use super::sanitize::sanitize_context_var`.
+
+**Steps (in order):**
+
+1. Replace every `\n` (LF) and `\r` (CR) with a single ASCII space.
+2. Collapse consecutive whitespace by splitting on whitespace boundaries and
+   rejoining with a single space (`split_whitespace().collect::<Vec<_>>().join(" ")`).
+3. Truncate to `max_len` on a UTF-8 char boundary. If truncation occurs,
+   append `"…"` (U+2026 HORIZONTAL ELLIPSIS) to signal data loss.
+
+**Illustrative usage:**
+
+```rust
+use super::sanitize::sanitize_context_var;
+
+let clean = sanitize_context_var("error: cannot find\nthread panicked\r\nat src/main.rs", 500);
+assert_eq!(clean, "error: cannot find thread panicked at src/main.rs");
+
+let truncated = sanitize_context_var(&"a".repeat(1000), 10);
+assert_eq!(truncated.chars().count(), 11); // 10 content chars + "…"
+```
+
+### Contract
+
+| Property | Guarantee |
+|----------|-----------|
+| Newline-free | Output never contains `\n` or `\r` |
+| Whitespace-normalized | No runs of consecutive whitespace; no leading/trailing whitespace |
+| Bounded length | Output is at most `max_len` characters (plus the ellipsis marker if truncated) |
+| Char-boundary safe | Truncation never splits a multi-byte UTF-8 sequence |
+| Idempotent | `sanitize(sanitize(s, n), n)` == `sanitize(s, n)` (modulo the ellipsis already being present) |
+| Pure | No I/O. Allocates only the returned `String` |
+| Empty-safe | Empty input returns empty output; `max_len = 0` returns `""` |
+
+## Application Sites
+
+### `recipe_engineer_lifecycle.rs` — 4 fields sanitized
+
+| Field | `max_len` | Rationale |
+|-------|-----------|-----------|
+| `goal_id` | 500 | Typically a UUID, but defensive against user-authored goal IDs |
+| `goal_description` | 500 | User-authored text; concise by convention |
+| `worktree_path` | 500 | `PathBuf::display()` output; paths should never be this long in practice |
+| `last_engineer_log_tail` | 2000 | Raw terminal output — the primary failure vector. Needs generous room for diagnostic context |
+
+**Fields NOT sanitized:** `cycle_number`, `consecutive_skip_count`,
+`failure_count`, `worktree_mtime_secs_ago`, `commits_behind`,
+`in_flight_engineer_count` (all computed from numeric types —
+`u32`/`u64`). `sentinel_pid` (rendered as `"<none>"` or a numeric string).
+`minutes_since_last_update_attempt` (rendered as `"never"` or a numeric
+string). These values are always clean single-line strings by construction.
+
+```rust
+// Before (broke on multi-line log tails):
+.arg(format!("last_engineer_log_tail={}", ctx.last_engineer_log_tail))
+
+// After:
+.arg(format!(
+    "last_engineer_log_tail={}",
+    sanitize_context_var(&ctx.last_engineer_log_tail, 2000)
+))
+```
+
+### `recipe_decide.rs` — 2 fields sanitized
+
+| Field | `max_len` | Rationale |
+|-------|-----------|-----------|
+| `goal_id` | 500 | Same as above |
+| `reason` | 500 | Short decision rationale; could contain LLM-generated text |
+
+**Fields NOT sanitized:** `urgency` (formatted as `{:.3}` float — always
+clean).
+
+### `recipe_orient.rs` — 2 fields sanitized
+
+| Field | `max_len` | Rationale |
+|-------|-----------|-----------|
+| `goal_id` | 500 | Same as above |
+| `base_reason` | 500 | Short rationale string; same risk profile as `reason` |
+
+**Fields NOT sanitized:** `base_urgency` (formatted as `{:.3}` float).
+`failure_count` (u32).
+
+## Relationship to Existing Sanitizers
+
+| Sanitizer | Location | Purpose | This feature |
+|-----------|----------|---------|--------------|
+| `truncate_to_char_boundary` | `src/util/string_truncate.rs` | Byte-budget truncation for evidence buffers (in-place `&mut String`, byte-based) | Different API; `sanitize_context_var` operates on char count and returns a new `String` |
+| `truncate_for_log` | `src/ooda_brain/rustyclawd.rs` (also duplicated in `spawn.rs`, `merge_judge.rs`) | Display-length truncation for log lines | Truncation only — no newline replacement or whitespace normalization |
+| `truncate()` (local) | `recipe_engineer_lifecycle.rs`, `recipe_decide.rs` | Truncate stderr in error messages | Retained — serves a different purpose (error display, not CLI arg safety) |
+| `redact_secrets` | `src/ooda_brain/context.rs` | Strip API keys from log tails | Runs before sanitization — `gather_engineer_lifecycle_ctx` redacts first, then the recipe shim sanitizes at arg-construction time |
+
+`sanitize_context_var` is intentionally **not** a replacement for any of these
+helpers. It is scoped narrowly to the recipe `-c key=value` construction
+pattern and lives in `ooda_brain/sanitize.rs` alongside its three consumers.
+
+## Security Considerations
+
+- **YAML template injection** is the primary attack vector. Newlines in
+  context values can break the Handlebars-rendered YAML prompt and
+  theoretically inject arbitrary YAML keys. Stripping newlines eliminates
+  this vector.
+- **`Command::new().arg()` is already shell-injection safe** — no `sh -c`,
+  no shell interpolation. The sanitizer defends against YAML injection, not
+  shell injection. This invariant must be preserved.
+- **Sanitization happens at the call site, not in the struct.** The
+  `EngineerLifecycleCtx`, `DecideContext`, and `OrientContext` structs retain
+  raw values for logging and debugging. Sanitization is applied only at
+  `Command::new().arg()` construction time.
+- **No unsafe code.** Pure `String` manipulation using `char_indices()` for
+  char-boundary-safe truncation.
+- **Argv visibility in `/proc/PID/cmdline`** is pre-existing exposure.
+  Truncation slightly reduces the volume of exposed data. Secrets are already
+  stripped by `redact_secrets` upstream.
+
+## Testing
+
+`src/ooda_brain/sanitize.rs` contains an inline `#[cfg(test)]` module with
+unit tests covering:
+
+| Test | What it verifies |
+|------|-----------------|
+| Newlines replaced | `\n` → space, output contains no `\n` |
+| Carriage returns replaced | `\r` → space, output contains no `\r` |
+| Mixed `\r\n` replaced | Windows-style line endings handled |
+| Consecutive whitespace collapsed | `"a  \n\n  b"` → `"a b"` |
+| Truncation at max_len | Output respects the char budget |
+| Truncation on char boundary | Multi-byte UTF-8 (emoji, CJK) does not panic or produce invalid UTF-8 |
+| Truncation appends ellipsis | Truncated output ends with `"…"` |
+| Empty input | Returns `""` |
+| Already-clean input | Passes through unchanged (no spurious allocation observable via `assert_eq`) |
+| Idempotence | `sanitize(sanitize(s, n), n)` produces a stable result |
+
+Run the sanitizer tests:
+
+```bash
+cargo test --package simard --lib ooda_brain::sanitize
+```
+
+Run all affected module tests:
+
+```bash
+cargo test --package simard --lib ooda_brain
+```
+
+## Configuration
+
+There are no runtime configuration knobs. The `max_len` values are hardcoded
+at each call site because they are tuned to the specific field's semantics:
+
+- **500 chars** for identifiers and short rationale strings — generous for
+  UUIDs and single-paragraph descriptions, tight enough to prevent prompt
+  bloat.
+- **2000 chars** for `last_engineer_log_tail` — balances diagnostic context
+  (the LLM needs enough log to reason about the engineer's state) against
+  the recipe prompt's total token budget.
+
+To change these limits, edit the literal values in the `sanitize_context_var`
+call at each site in `recipe_engineer_lifecycle.rs`, `recipe_decide.rs`, or
+`recipe_orient.rs`.
+
+## Module Layout (after this change)
+
+```
+src/ooda_brain/
+├── mod.rs                       # mod sanitize; declaration
+├── sanitize.rs                  # sanitize_context_var + unit tests   (NEW)
+├── recipe_engineer_lifecycle.rs # wraps 4 fields with sanitize_context_var
+├── recipe_decide.rs             # wraps 2 fields with sanitize_context_var
+├── recipe_orient.rs             # wraps 2 fields with sanitize_context_var
+├── context.rs                   # gather_engineer_lifecycle_ctx + redact_secrets
+├── …                            # (other modules unchanged)
+```
+
+## Examples
+
+### Before: multi-line log tail breaks recipe
+
+```
+# Context:
+#   last_engineer_log_tail = "error[E0433]: failed to resolve\n  --> src/lib.rs:42\n"
+
+$ recipe-runner-rs ooda-engineer-lifecycle.yaml \
+    -c "last_engineer_log_tail=error[E0433]: failed to resolve
+  --> src/lib.rs:42
+"
+# Exit status: 1 — YAML parse error in rendered prompt
+```
+
+### After: sanitized log tail succeeds
+
+```
+# sanitize_context_var("error[E0433]: failed to resolve\n  --> src/lib.rs:42\n", 2000)
+#   → "error[E0433]: failed to resolve --> src/lib.rs:42"
+
+$ recipe-runner-rs ooda-engineer-lifecycle.yaml \
+    -c "last_engineer_log_tail=error[E0433]: failed to resolve --> src/lib.rs:42"
+# Exit status: 0 — agent runs successfully
+```
+
+### Truncation of excessively long log tail
+
+```
+# 50 KB of log output is truncated to 2000 chars:
+# sanitize_context_var(&huge_log, 2000)
+#   → "error[E0433]: failed to resolve --> src/lib.rs:42 ... (1998 more chars)…"
+```
+
+## Adopting the Sanitizer in New Recipe Shims
+
+Future recipe shims that pass user-derived or log-derived text as context
+variables must:
+
+1. Import `sanitize_context_var` via `use super::sanitize::sanitize_context_var`.
+2. Wrap every string-typed context variable whose source is not a known-safe
+   format (numeric `.to_string()`, enum variant name, etc.) in a
+   `sanitize_context_var(&value, max_len)` call.
+3. Choose an appropriate `max_len`:
+   - **500** for short identifiers and rationale strings.
+   - **2000** for diagnostic log content.
+   - **200** for titles and labels.
+4. Add a test asserting that the sanitized value contains no `\n` or `\r` on
+   representative multi-line input.
+5. Do NOT sanitize numeric or enum-derived fields — they are clean by
+   construction and sanitization would waste cycles.
+
+## Troubleshooting
+
+### Symptom: recipe still exits with status 1 after sanitization
+
+1. **Check stderr**: the error path in the recipe shim captures stderr.
+   Look for `recipe exited with exit status: 1` in the daemon log along
+   with the truncated stderr content.
+2. **Check for new unsanitized fields**: if a new context variable was added
+   to the recipe YAML without a corresponding `sanitize_context_var` call,
+   multi-line values in that field will reproduce the original failure.
+3. **Check recipe YAML syntax**: if the recipe YAML itself has a syntax
+   error (independent of context variable interpolation), recipe-runner-rs
+   exits with status 1. Run the recipe manually with hardcoded context
+   values to isolate.
+
+### Symptom: truncated context loses important diagnostic information
+
+The `last_engineer_log_tail` 2000-char limit is deliberately generous. If
+the agent consistently makes poor lifecycle decisions due to truncated
+context:
+
+1. Increase the limit at the call site (e.g., 4000 chars). This trades
+   prompt token budget for diagnostic fidelity.
+2. Ensure `gather_engineer_lifecycle_ctx` is capturing the *tail* of the
+   log (last N bytes), not the head — the most recent output is the most
+   diagnostically relevant.
+
+## See Also
+
+* [Reference: engineer loop argv sanitization](engineer-loop-argv-sanitization.md) — the analogous sanitizer for `gh` CLI argv
+* [Reference: string truncation helpers](string-truncation-helpers.md) — the byte-budget truncation helper (different purpose)
+* [Reference: OODA Brain API](ooda-brain-api.md) — trait and type definitions
+* [How-to: diagnose decide/orient parse failures](../howto/diagnose-decide-orient-parse-failures.md) — operator runbook
+* Issue [#2127](https://github.com/rysweet/Simard/issues/2127) — original bug

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,7 @@ nav:
     - Operator Read State-Root Contract: reference/operator-read-state-root-contract.md
     - Bridge Wire Protocol: reference/bridge-wire-protocol.md
     - Dashboard E2E Tests: reference/dashboard-e2e-tests.md
+    - Recipe Context Var Sanitization: reference/recipe-context-var-sanitization.md
     # Hidden from nav until issue #1590 implementation lands:
     #   - reference/cognitive-memory-bridge-helpers.md
     #   - reference/goal-board-api.md

--- a/src/ooda_brain/mod.rs
+++ b/src/ooda_brain/mod.rs
@@ -26,6 +26,7 @@ mod recipe_decide;
 mod recipe_engineer_lifecycle;
 mod recipe_orient;
 mod rustyclawd;
+mod sanitize;
 
 #[cfg(test)]
 mod decide_tests;

--- a/src/ooda_brain/recipe_decide.rs
+++ b/src/ooda_brain/recipe_decide.rs
@@ -20,6 +20,7 @@ use std::path::PathBuf;
 use std::process::Command;
 
 use super::decide::{DecideContext, DecideJudgment, OodaDecideBrain};
+use super::sanitize::sanitize_context_var;
 use crate::error::{SimardError, SimardResult};
 
 const ADAPTER_TAG: &str = "recipe-decide-brain";
@@ -74,11 +75,14 @@ impl OodaDecideBrain for RecipeDecideBrain {
         let output = Command::new("recipe-runner-rs")
             .arg(self.recipe_path.as_os_str())
             .arg("-c")
-            .arg(format!("goal_id={}", ctx.goal_id))
+            .arg(format!(
+                "goal_id={}",
+                sanitize_context_var(&ctx.goal_id, 500)
+            ))
             .arg("-c")
             .arg(format!("urgency={:.3}", ctx.urgency))
             .arg("-c")
-            .arg(format!("reason={}", ctx.reason))
+            .arg(format!("reason={}", sanitize_context_var(&ctx.reason, 500)))
             .output()
             .map_err(|e| SimardError::AdapterInvocationFailed {
                 base_type: ADAPTER_TAG.to_string(),

--- a/src/ooda_brain/recipe_engineer_lifecycle.rs
+++ b/src/ooda_brain/recipe_engineer_lifecycle.rs
@@ -26,6 +26,7 @@
 use std::path::PathBuf;
 use std::process::Command;
 
+use super::sanitize::sanitize_context_var;
 use super::{EngineerLifecycleCtx, EngineerLifecycleDecision, OodaBrain};
 use crate::error::{SimardError, SimardResult};
 
@@ -107,9 +108,15 @@ impl OodaBrain for RecipeEngineerLifecycleBrain {
         let output = Command::new("recipe-runner-rs")
             .arg(self.recipe_path.as_os_str())
             .arg("-c")
-            .arg(format!("goal_id={}", ctx.goal_id))
+            .arg(format!(
+                "goal_id={}",
+                sanitize_context_var(&ctx.goal_id, 500)
+            ))
             .arg("-c")
-            .arg(format!("goal_description={}", ctx.goal_description))
+            .arg(format!(
+                "goal_description={}",
+                sanitize_context_var(&ctx.goal_description, 500)
+            ))
             .arg("-c")
             .arg(format!("cycle_number={}", ctx.cycle_number))
             .arg("-c")
@@ -120,7 +127,10 @@ impl OodaBrain for RecipeEngineerLifecycleBrain {
             .arg("-c")
             .arg(format!("failure_count={}", ctx.failure_count))
             .arg("-c")
-            .arg(format!("worktree_path={}", ctx.worktree_path.display()))
+            .arg(format!(
+                "worktree_path={}",
+                sanitize_context_var(&ctx.worktree_path.display().to_string(), 500)
+            ))
             .arg("-c")
             .arg(format!(
                 "worktree_mtime_secs_ago={}",
@@ -131,7 +141,7 @@ impl OodaBrain for RecipeEngineerLifecycleBrain {
             .arg("-c")
             .arg(format!(
                 "last_engineer_log_tail={}",
-                ctx.last_engineer_log_tail
+                sanitize_context_var(&ctx.last_engineer_log_tail, 2000)
             ))
             .arg("-c")
             .arg(format!("commits_behind={}", ctx.commits_behind))

--- a/src/ooda_brain/recipe_orient.rs
+++ b/src/ooda_brain/recipe_orient.rs
@@ -28,6 +28,7 @@ use super::orient::DeterministicFallbackOrientBrain;
 use super::orient::{
     FAILURE_PENALTY_PER_CONSECUTIVE, OodaOrientBrain, OrientContext, OrientJudgment,
 };
+use super::sanitize::sanitize_context_var;
 use crate::error::{SimardError, SimardResult};
 
 const ADAPTER_TAG: &str = "recipe-orient-brain";
@@ -82,11 +83,17 @@ impl OodaOrientBrain for RecipeOrientBrain {
         let output = Command::new("recipe-runner-rs")
             .arg(self.recipe_path.as_os_str())
             .arg("-c")
-            .arg(format!("goal_id={}", ctx.goal_id))
+            .arg(format!(
+                "goal_id={}",
+                sanitize_context_var(&ctx.goal_id, 500)
+            ))
             .arg("-c")
             .arg(format!("base_urgency={:.3}", ctx.base_urgency))
             .arg("-c")
-            .arg(format!("base_reason={}", ctx.base_reason))
+            .arg(format!(
+                "base_reason={}",
+                sanitize_context_var(&ctx.base_reason, 500)
+            ))
             .arg("-c")
             .arg(format!("failure_count={}", ctx.failure_count))
             .output()

--- a/src/ooda_brain/sanitize.rs
+++ b/src/ooda_brain/sanitize.rs
@@ -19,17 +19,23 @@
 ///
 /// Returns an owned `String` that is safe to embed in `-c key=value` args.
 pub(super) fn sanitize_context_var(s: &str, max_len: usize) -> String {
-    // Step 1+2: split_whitespace handles \n, \r, \t, and consecutive spaces
-    let collapsed: String = s.split_whitespace().collect::<Vec<_>>().join(" ");
+    // Step 1+2: split_whitespace handles \n, \r, \t, and consecutive spaces.
+    // Push directly into a pre-sized String — avoids intermediate Vec<&str>.
+    let mut collapsed = String::with_capacity(s.len());
+    for word in s.split_whitespace() {
+        if !collapsed.is_empty() {
+            collapsed.push(' ');
+        }
+        collapsed.push_str(word);
+    }
 
-    // Step 3: truncate on char boundary
-    if collapsed.chars().count() <= max_len {
-        return collapsed;
+    // Step 3: truncate on char boundary.
+    // Single char_indices().nth() pass replaces separate .count() + .nth().
+    if let Some((byte_offset, _)) = collapsed.char_indices().nth(max_len) {
+        collapsed.truncate(byte_offset);
+        collapsed.push('…');
     }
-    match collapsed.char_indices().nth(max_len) {
-        Some((byte_offset, _)) => format!("{}…", &collapsed[..byte_offset]),
-        None => collapsed,
-    }
+    collapsed
 }
 
 // ---------------------------------------------------------------------------

--- a/src/ooda_brain/sanitize.rs
+++ b/src/ooda_brain/sanitize.rs
@@ -1,0 +1,288 @@
+//! Sanitize context-variable strings before passing them as `-c key=value`
+//! arguments to `recipe-runner-rs`.
+//!
+//! **Problem**: Log tails, goal descriptions, and other user-authored strings
+//! can contain newlines, carriage returns, and excessive whitespace. When
+//! passed as `-c` context vars, these break YAML template interpolation in
+//! recipe-runner-rs (issue #2127 — 1341 failures in 24 hours).
+//!
+//! **Solution**: `sanitize_context_var` replaces `\n`/`\r` with spaces,
+//! collapses consecutive whitespace, and truncates on a char boundary.
+
+/// Sanitize a string for use as a recipe-runner-rs `-c` context variable.
+///
+/// Steps:
+/// 1. Replace `\n` and `\r` with a single space.
+/// 2. Collapse consecutive whitespace (`split_whitespace().join(" ")`).
+/// 3. Truncate to `max_len` characters on a char boundary, appending `…`
+///    if truncation occurred.
+///
+/// Returns an owned `String` that is safe to embed in `-c key=value` args.
+pub(super) fn sanitize_context_var(s: &str, max_len: usize) -> String {
+    // Step 1+2: split_whitespace handles \n, \r, \t, and consecutive spaces
+    let collapsed: String = s.split_whitespace().collect::<Vec<_>>().join(" ");
+
+    // Step 3: truncate on char boundary
+    if collapsed.chars().count() <= max_len {
+        return collapsed;
+    }
+    match collapsed.char_indices().nth(max_len) {
+        Some((byte_offset, _)) => format!("{}…", &collapsed[..byte_offset]),
+        None => collapsed,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests — TDD: specify the contract, verify behavior.
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // =======================================================================
+    // Core behavior: newline replacement
+    // =======================================================================
+
+    #[test]
+    fn newlines_replaced_with_space() {
+        let input = "line one\nline two\nline three";
+        let result = sanitize_context_var(input, 500);
+        assert_eq!(result, "line one line two line three");
+        assert!(!result.contains('\n'), "must not contain newlines");
+    }
+
+    #[test]
+    fn carriage_returns_replaced_with_space() {
+        let input = "line one\rline two\rline three";
+        let result = sanitize_context_var(input, 500);
+        assert_eq!(result, "line one line two line three");
+        assert!(!result.contains('\r'), "must not contain carriage returns");
+    }
+
+    #[test]
+    fn crlf_replaced_with_single_space() {
+        let input = "line one\r\nline two\r\nline three";
+        let result = sanitize_context_var(input, 500);
+        assert_eq!(result, "line one line two line three");
+    }
+
+    #[test]
+    fn mixed_newlines_and_carriage_returns() {
+        let input = "a\nb\rc\r\nd";
+        let result = sanitize_context_var(input, 500);
+        assert_eq!(result, "a b c d");
+    }
+
+    // =======================================================================
+    // Core behavior: whitespace collapse
+    // =======================================================================
+
+    #[test]
+    fn consecutive_spaces_collapsed() {
+        let input = "word1   word2     word3";
+        let result = sanitize_context_var(input, 500);
+        assert_eq!(result, "word1 word2 word3");
+    }
+
+    #[test]
+    fn tabs_collapsed_to_space() {
+        let input = "word1\t\tword2\tword3";
+        let result = sanitize_context_var(input, 500);
+        assert_eq!(result, "word1 word2 word3");
+    }
+
+    #[test]
+    fn mixed_whitespace_collapsed() {
+        let input = "word1 \t \n \r word2";
+        let result = sanitize_context_var(input, 500);
+        assert_eq!(result, "word1 word2");
+    }
+
+    #[test]
+    fn leading_and_trailing_whitespace_stripped() {
+        let input = "  \n  hello world  \n  ";
+        let result = sanitize_context_var(input, 500);
+        assert_eq!(result, "hello world");
+    }
+
+    // =======================================================================
+    // Core behavior: truncation
+    // =======================================================================
+
+    #[test]
+    fn truncation_at_max_len() {
+        let input = "a".repeat(1000);
+        let result = sanitize_context_var(&input, 100);
+        // Should be 100 chars + "…"
+        assert_eq!(
+            result.chars().count(),
+            101,
+            "truncated output must be max_len chars + ellipsis"
+        );
+        assert!(result.ends_with('…'), "truncated output must end with …");
+    }
+
+    #[test]
+    fn no_truncation_when_within_limit() {
+        let input = "short string";
+        let result = sanitize_context_var(input, 500);
+        assert_eq!(result, "short string");
+        assert!(!result.ends_with('…'));
+    }
+
+    #[test]
+    fn exact_length_not_truncated() {
+        let input = "abcde";
+        let result = sanitize_context_var(input, 5);
+        assert_eq!(result, "abcde");
+        assert!(!result.ends_with('…'));
+    }
+
+    #[test]
+    fn one_over_limit_is_truncated() {
+        let input = "abcdef";
+        let result = sanitize_context_var(input, 5);
+        assert_eq!(result, "abcde…");
+    }
+
+    #[test]
+    fn truncation_respects_char_boundary_multibyte() {
+        // Each emoji is multiple bytes but one char
+        let input = "🔥🔥🔥🔥🔥🔥";
+        let result = sanitize_context_var(input, 3);
+        assert_eq!(result, "🔥🔥🔥…");
+        assert_eq!(result.chars().count(), 4); // 3 emoji + ellipsis
+    }
+
+    #[test]
+    fn truncation_after_whitespace_collapse() {
+        // After collapsing "a  b  c  d" → "a b c d" (7 chars)
+        let input = "a  b  c  d";
+        let result = sanitize_context_var(input, 5);
+        assert_eq!(result, "a b c…");
+    }
+
+    // =======================================================================
+    // Edge cases
+    // =======================================================================
+
+    #[test]
+    fn empty_input() {
+        let result = sanitize_context_var("", 500);
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn whitespace_only_input() {
+        let result = sanitize_context_var("   \n\t\r  ", 500);
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn max_len_zero() {
+        let result = sanitize_context_var("hello", 0);
+        assert_eq!(result, "…");
+    }
+
+    #[test]
+    fn max_len_one_with_content() {
+        let result = sanitize_context_var("hello world", 1);
+        assert_eq!(result, "h…");
+    }
+
+    #[test]
+    fn single_char_input() {
+        let result = sanitize_context_var("x", 500);
+        assert_eq!(result, "x");
+    }
+
+    // =======================================================================
+    // Realistic inputs — the actual bug scenario
+    // =======================================================================
+
+    #[test]
+    fn realistic_log_tail_with_newlines() {
+        let input = "2024-01-15T10:30:00Z INFO starting engineer\n\
+                     2024-01-15T10:30:01Z DEBUG checking worktree\n\
+                     2024-01-15T10:30:02Z ERROR panicked at 'index out of bounds'\n\
+                     stack backtrace:\n\
+                       0: std::panicking::begin_panic\n\
+                       1: simard::engineer::run";
+        let result = sanitize_context_var(input, 2000);
+        assert!(!result.contains('\n'));
+        assert!(!result.contains('\r'));
+        assert!(result.contains("panicked at"));
+        assert!(result.chars().count() <= 2000);
+    }
+
+    #[test]
+    fn realistic_log_tail_truncated() {
+        // Simulate a very long log tail (>2000 chars after collapse)
+        let line = "2024-01-15T10:30:00Z INFO processing goal advance-feature-x step 42\n";
+        let input = line.repeat(50); // ~3500 chars
+        let result = sanitize_context_var(&input, 2000);
+        assert!(
+            result.chars().count() <= 2001,
+            "must truncate to max_len + ellipsis; got {} chars",
+            result.chars().count()
+        );
+        assert!(result.ends_with('…'));
+    }
+
+    #[test]
+    fn goal_description_with_special_chars() {
+        let input = "Fix the\n\"broken\" parser's\thyperlink & <tags>";
+        let result = sanitize_context_var(input, 500);
+        assert_eq!(result, "Fix the \"broken\" parser's hyperlink & <tags>");
+        assert!(!result.contains('\n'));
+        assert!(!result.contains('\t'));
+    }
+
+    #[test]
+    fn worktree_path_passthrough() {
+        let input = "/home/user/src/Simard/worktrees/feat/my-feature";
+        let result = sanitize_context_var(input, 500);
+        assert_eq!(result, input, "clean paths must pass through unchanged");
+    }
+
+    // =======================================================================
+    // Security: YAML injection prevention
+    // =======================================================================
+
+    #[test]
+    fn yaml_injection_via_newline_neutralized() {
+        // An attacker tries to inject a new YAML key via a newline
+        let input = "normal value\nmalicious_key: injected_value";
+        let result = sanitize_context_var(input, 500);
+        assert!(!result.contains('\n'));
+        assert_eq!(result, "normal value malicious_key: injected_value");
+    }
+
+    #[test]
+    fn multiline_yaml_block_scalar_neutralized() {
+        let input = "value\n  - injected_list_item\n  - another_item";
+        let result = sanitize_context_var(input, 500);
+        assert!(!result.contains('\n'));
+        assert_eq!(result, "value - injected_list_item - another_item");
+    }
+
+    // =======================================================================
+    // Contract: idempotence
+    // =======================================================================
+
+    #[test]
+    fn already_clean_input_unchanged() {
+        let input = "this is already clean text";
+        let result = sanitize_context_var(input, 500);
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn double_sanitize_is_idempotent() {
+        let input = "line\none\n  two\t\tthree";
+        let first = sanitize_context_var(input, 500);
+        let second = sanitize_context_var(&first, 500);
+        assert_eq!(first, second, "sanitize must be idempotent");
+    }
+}


### PR DESCRIPTION
## Summary
The recipe-engineer-lifecycle-brain is failing every OODA cycle with 'recipe exited with exit status: 1'. 1341 failures in 24 hours. This is blocking all autonomous goal advancement.

The recipe YAML at prompt_assets/simard/recipes/ooda-engineer-lifecycle.yaml works when invoked directly from the command line. The failure happens when the Rust shim at src/ooda_brain/recipe_engineer_lifecycle.rs invokes it.

Fix: sanitize the last_engineer_log_tail before passing (replace newlines with spaces, truncate to a reasonable length). Also check goal_description and worktree_path for the same issue.

Also fix the same issue in recipe_decide.rs and recipe_orient.rs if they have context vars that could contain special characters.

## Issue
Closes #2127

## Changes

### New files
- `src/ooda_brain/sanitize.rs` — Shared `sanitize_context_var()` function: strips `\n`/`\r`, collapses whitespace, truncates to `max_len` on char boundary with `…` suffix. 27 unit tests covering core behavior, edge cases, realistic inputs, YAML injection prevention, and idempotence.

### Modified files
- `src/ooda_brain/mod.rs` — Add `mod sanitize;` declaration
- `src/ooda_brain/recipe_engineer_lifecycle.rs` — Wrap 4 context vars (`goal_id`, `goal_description`, `worktree_path`, `last_engineer_log_tail`) with `sanitize_context_var()`
- `src/ooda_brain/recipe_decide.rs` — Wrap 2 context vars (`goal_id`, `reason`) with `sanitize_context_var()`
- `src/ooda_brain/recipe_orient.rs` — Wrap 2 context vars (`goal_id`, `base_reason`) with `sanitize_context_var()`
- `docs/reference/recipe-context-var-sanitization.md` — Reference documentation
- `mkdocs.yml` — Add docs page to navigation

## Testing
- Unit tests added (27 for sanitize, plus existing tests for all 3 recipe brains)
- Local testing completed
- Pre-commit hooks pass

## Checklist
- [x] Tests pass
- [x] Documentation updated
- [x] No stubs or TODOs
- [x] Code review completed
- [x] Philosophy check passed

---

## Step 16b: Outside-In Testing Results

### Test Environment
- Branch: `feat/issue-2127-the-recipe-engineer-lifecycle-brain-is-failing-eve`
- Remote: `https://github.com/rysweet/Simard.git`
- Test runner: `cargo test`, `cargo build`, `cargo clippy`, `cargo fmt`

### Scenario 1: Build Verification (Simple)
**Command:** `cargo build`
**Result:** ✅ PASS — compiled successfully with no errors
**Key output:** `Finished dev profile [unoptimized + debuginfo] target(s) in 18.16s`

### Scenario 2: Sanitize Module Unit Tests (Simple)
**Command:** `cargo test --lib ooda_brain::sanitize`
**Result:** ✅ PASS — 27/27 tests passed
**Key scenarios tested:**
- Newline/CR/CRLF replacement → spaces
- Whitespace collapse
- Truncation on char boundary (including multibyte/emoji)
- Edge cases: empty, whitespace-only, max_len=0, max_len=1
- Realistic log tails with stack traces
- YAML injection prevention
- Idempotence guarantee

### Scenario 3: Recipe Engineer Lifecycle Integration Tests (Edge)
**Command:** `cargo test --lib ooda_brain::recipe_engineer_lifecycle`
**Result:** ✅ PASS — 38/38 tests passed (includes marker parsing, keyword scanning, constructor, realistic LLM outputs)

### Scenario 4: Recipe Decide Integration Tests (Edge)
**Command:** `cargo test --lib ooda_brain::recipe_decide`
**Result:** ✅ PASS — 30/30 tests passed (all 10 keywords, case insensitivity, default fallback, realistic LLM output patterns)

### Scenario 5: Recipe Orient Integration Tests (Edge)
**Command:** `cargo test --lib ooda_brain::recipe_orient`
**Result:** ✅ PASS — 41/41 tests passed (3-tier parse chain, float parsing, floor formula, validation invariants)

### Scenario 6: Full OODA Brain Module Tests (Integration)
**Command:** `cargo test --lib ooda_brain`
**Result:** ✅ PASS — 310/310 tests passed (entire OODA brain module including all sub-modules)

### Scenario 7: Binary Build Verification (Integration)
**Command:** `cargo build --bin simard-ooda-step`
**Result:** ✅ PASS — binary compiles cleanly, confirming sanitize module integrates correctly in production binary

### Scenario 8: Code Quality Gates
**Command:** `cargo fmt --check`
**Result:** ✅ PASS — no formatting issues
**Command:** `cargo clippy --all-targets`
**Result:** ✅ PASS — no new warnings (1 pre-existing warning in unrelated file)

### Fix Count: 0
No failures found during outside-in testing. All scenarios passed on first attempt.

### Note on `uvx` Testing
This is a Rust crate, not a Python package. Outside-in testing uses `cargo build`/`cargo test` rather than `uvx`. The actual production binary (`simard-ooda-step`) was built and validated.