### PR TITLE
fix(test): update version assertion in cli_golden to unblock coverage workflow

### DIFF
--- a/tests/cli_golden.rs
+++ b/tests/cli_golden.rs
@@ -102,7 +102,7 @@ fn version_string_is_semver() {
             .unwrap_or_else(|_| panic!("non-numeric version component '{part}' in {VERSION}"));
     }
     assert_eq!(
-        VERSION, "0.17.0",
+        VERSION, "0.17.1",
         "bump this assertion when version changes"
     );
 }


### PR DESCRIPTION
## Problem

Commit 92af7586 bumped `Cargo.toml` version to `0.17.1` but did not update the version assertion in `tests/cli_golden.rs:105`, which still expected `"0.17.0"`. This causes every `coverage.yml` CI run to fail before producing `coverage-summary.json`, blocking issue #2123 at its first acceptance criterion.

## Fix

Single-line change: update the `assert_eq!` in `version_string_is_semver()` from `"0.17.0"` to `"0.17.1"`.

## Verification

- `cargo test --test cli_golden` — **12/12 passed** locally
- Pre-commit hooks (fmt, clippy): **passed**
- Pre-push hooks (release tests, clippy all-targets): **passed**
- Diff is focused: 1 file changed, 1 insertion, 1 deletion

## Merge-ready evidence

1. **QA scenarios**: N/A — no user-facing surface changed; this is a test-internal assertion fix.
2. **Docs**: N/A — no user-facing surface changed.
3. **Quality audit**: Single mechanical change (version string literal), no correctness/security surface.
4. **CI**: Pre-commit and pre-push hooks green; awaiting CI pipeline confirmation.
5. **PR description**: This description.
6. **Diff focused**: Only `tests/cli_golden.rs` changed, single line.

Unblocks #2123