### PR TITLE
feat(engineer-loop): add distinct Plan and Summarize phases to 7-step cycle (#2083)

### DIFF
--- a/src/copilot_task_submit/orchestration.rs
+++ b/src/copilot_task_submit/orchestration.rs
@@ -174,6 +174,7 @@ pub(super) fn persist_report(inputs: PersistReportInputs<'_>) -> SimardResult<Co
         SessionPhase::Planning,
         SessionPhase::Execution,
         SessionPhase::Reflection,
+        SessionPhase::Summarize,
         SessionPhase::Persistence,
         SessionPhase::Complete,
     ] {

--- a/src/engineer_loop/mod.rs
+++ b/src/engineer_loop/mod.rs
@@ -43,9 +43,9 @@ use execution::{parse_status_paths, run_command, trimmed_stdout, trimmed_stdout_
 
 // Re-export all public items so `crate::engineer_loop::X` still works.
 pub use types::{
-    AnalyzedAction, EngineerActionKind, EngineerLoopRun, ExecutedEngineerAction, PhaseOutcome,
-    PhaseTrace, RepoInspection, SelectedEngineerAction, SessionErrorReflection, VerificationReport,
-    analyze_objective,
+    AnalyzedAction, EngineerActionKind, EngineerLoopRun, ExecutedEngineerAction, ExecutionPlan,
+    PhaseOutcome, PhaseTrace, RepoInspection, SelectedEngineerAction, SessionErrorReflection,
+    SessionSummary, VerificationReport, analyze_objective,
 };
 
 // Phase-entry-point re-exports for the recipe-driven engineer loop (Phase 2 rebuild).
@@ -221,13 +221,22 @@ pub fn run_local_engineer_loop(
     };
 
     // --- SessionPhase::Planning ---
-    // Produce a bounded plan sized to the task.
+    // Produce a bounded plan sized to the task (spec step 3).
     session.advance(SessionPhase::Planning)?;
 
     let phase_start = Instant::now();
     let agent_prompt = agent_spawn::build_agent_prompt(objective, &inspection);
     phase_traces.push(PhaseTrace {
         name: "agent-prompt-build".to_string(),
+        duration: phase_start.elapsed(),
+        outcome: PhaseOutcome::Success,
+    });
+
+    // Form an auditable execution plan as a distinct orchestration primitive.
+    let phase_start = Instant::now();
+    let execution_plan = form_execution_plan(objective, &analyzed, &inspection);
+    phase_traces.push(PhaseTrace {
+        name: "plan".to_string(),
         duration: phase_start.elapsed(),
         outcome: PhaseOutcome::Success,
     });
@@ -341,6 +350,18 @@ pub fn run_local_engineer_loop(
         return Err(e);
     }
 
+    // --- SessionPhase::Summarize ---
+    // Produce a structured summary of results (spec step 6).
+    session.advance(SessionPhase::Summarize)?;
+
+    let phase_start = Instant::now();
+    let session_summary = summarize_results(objective, &action, &verification, &inspection);
+    phase_traces.push(PhaseTrace {
+        name: "summarize".to_string(),
+        duration: phase_start.elapsed(),
+        outcome: PhaseOutcome::Success,
+    });
+
     // --- SessionPhase::Persistence ---
     // Write session summary, memory updates, and benchmark records.
     session.advance(SessionPhase::Persistence)?;
@@ -392,13 +413,132 @@ pub fn run_local_engineer_loop(
         state_root,
         execution_scope: EXECUTION_SCOPE.to_string(),
         inspection,
+        plan: Some(execution_plan),
         action,
         verification,
+        summary: Some(session_summary),
         terminal_bridge_context,
         elapsed_duration: loop_start.elapsed(),
         phase_traces,
         session_record: Some(session),
     })
+}
+
+/// Form a structured execution plan from the objective and inspection data
+/// (spec step 3: "form a short execution plan"). The plan is a separable
+/// orchestration primitive that can be audited independently from execution.
+fn form_execution_plan(
+    objective: &str,
+    analyzed: &AnalyzedAction,
+    inspection: &RepoInspection,
+) -> ExecutionPlan {
+    let is_mutating = analyzed.is_mutating();
+
+    let steps = match analyzed {
+        AnalyzedAction::ReadOnlyScan => vec![
+            "Inspect repository state and gather context".to_string(),
+            "Analyze relevant files and code paths".to_string(),
+            "Report findings".to_string(),
+        ],
+        AnalyzedAction::StructuredTextReplace => vec![
+            "Identify target files for modification".to_string(),
+            "Apply structured text replacements".to_string(),
+            "Verify changes compile and pass checks".to_string(),
+            "Commit changes".to_string(),
+        ],
+        AnalyzedAction::CargoTest => vec![
+            "Run test suite".to_string(),
+            "Collect and report results".to_string(),
+        ],
+        AnalyzedAction::CreateFile => vec![
+            "Create new file with specified content".to_string(),
+            "Verify file was created correctly".to_string(),
+            "Commit changes".to_string(),
+        ],
+        AnalyzedAction::AppendToFile => vec![
+            "Append content to target file".to_string(),
+            "Verify modification".to_string(),
+            "Commit changes".to_string(),
+        ],
+        AnalyzedAction::RunShellCommand => vec![
+            "Execute shell command".to_string(),
+            "Capture and report output".to_string(),
+        ],
+        AnalyzedAction::GitCommit => vec![
+            "Stage changes".to_string(),
+            "Create commit with descriptive message".to_string(),
+        ],
+        AnalyzedAction::OpenIssue => vec![
+            "Compose issue title and body".to_string(),
+            "Create issue on repository".to_string(),
+        ],
+    };
+
+    let risk_level = if !is_mutating {
+        "low"
+    } else if inspection.worktree_dirty {
+        "high"
+    } else {
+        "medium"
+    }
+    .to_string();
+
+    ExecutionPlan {
+        objective: objective.to_string(),
+        steps,
+        expected_changed_files: inspection.changed_files.clone(),
+        risk_level,
+        is_mutating,
+    }
+}
+
+/// Produce a structured session summary from execution results
+/// (spec step 6: "summarize results"). The summary is a separable
+/// orchestration primitive that can be audited independently from persistence.
+fn summarize_results(
+    objective: &str,
+    action: &ExecutedEngineerAction,
+    verification: &VerificationReport,
+    inspection: &RepoInspection,
+) -> SessionSummary {
+    let outcome = if action.exit_code == 0 && verification.status != "failed" {
+        "success"
+    } else if action.exit_code == 0 {
+        "partial"
+    } else {
+        "failed"
+    }
+    .to_string();
+
+    let accomplishment = if action.stdout.len() > 200 {
+        format!("{}…", &action.stdout[..200])
+    } else if action.stdout.is_empty() {
+        format!("Completed objective: {objective}")
+    } else {
+        action.stdout.clone()
+    };
+
+    // Extract changed files: prefer the action's tracked changes, fall back
+    // to inspection's pre-existing dirty files.
+    let changed_files = if action.changed_files.is_empty() {
+        inspection.changed_files.clone()
+    } else {
+        action.changed_files.clone()
+    };
+
+    let mut key_decisions = Vec::new();
+    key_decisions.push(format!("Action type: {}", action.selected.label));
+    if !action.selected.rationale.is_empty() {
+        key_decisions.push(format!("Rationale: {}", action.selected.rationale));
+    }
+
+    SessionSummary {
+        objective: objective.to_string(),
+        outcome,
+        changed_files,
+        key_decisions,
+        accomplishment,
+    }
 }
 
 pub fn inspect_workspace(workspace_root: &Path, state_root: &Path) -> SimardResult<RepoInspection> {

--- a/src/engineer_loop/tests_types_inline.rs
+++ b/src/engineer_loop/tests_types_inline.rs
@@ -267,6 +267,28 @@ fn phase_trace_maps_persist_to_persistence() {
 }
 
 #[test]
+fn phase_trace_maps_summarize_to_summarize() {
+    use crate::session::SessionPhase;
+    let trace = PhaseTrace {
+        name: "summarize".to_string(),
+        duration: std::time::Duration::from_millis(10),
+        outcome: PhaseOutcome::Success,
+    };
+    assert_eq!(trace.session_phase(), SessionPhase::Summarize);
+}
+
+#[test]
+fn phase_trace_maps_plan_to_planning() {
+    use crate::session::SessionPhase;
+    let trace = PhaseTrace {
+        name: "plan".to_string(),
+        duration: std::time::Duration::from_millis(5),
+        outcome: PhaseOutcome::Success,
+    };
+    assert_eq!(trace.session_phase(), SessionPhase::Planning);
+}
+
+#[test]
 fn phase_trace_maps_unknown_to_execution_default() {
     use crate::session::SessionPhase;
     let trace = PhaseTrace {
@@ -338,6 +360,7 @@ fn engineer_loop_run_session_record_backward_compat() {
             carried_meeting_decisions: vec![],
             architecture_gap_summary: String::new(),
         },
+        plan: None,
         action: crate::engineer_loop::types::ExecutedEngineerAction {
             selected: crate::engineer_loop::types::SelectedEngineerAction {
                 label: "test".to_string(),
@@ -358,14 +381,60 @@ fn engineer_loop_run_session_record_backward_compat() {
             summary: "ok".to_string(),
             checks: vec![],
         },
+        summary: None,
         terminal_bridge_context: None,
         elapsed_duration: std::time::Duration::from_millis(100),
         phase_traces: vec![],
         session_record: None,
     };
-    // Round-trip serialization with session_record = None
+    // Round-trip serialization with optional fields = None
     let json = serde_json::to_string(&run).unwrap();
     assert!(!json.contains("session_record"), "None should be skipped");
+    assert!(!json.contains("\"plan\""), "None plan should be skipped");
+    // The top-level "summary" key is skipped; the nested verification.summary is fine.
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert!(
+        parsed.get("summary").is_none(),
+        "top-level summary should be absent"
+    );
     let restored: EngineerLoopRun = serde_json::from_str(&json).unwrap();
     assert_eq!(restored.session_record, None);
+    assert_eq!(restored.plan, None);
+    assert_eq!(restored.summary, None);
+}
+
+// ── ExecutionPlan and SessionSummary ─────────────────────────────
+
+#[test]
+fn execution_plan_serialization_round_trip() {
+    use crate::engineer_loop::types::ExecutionPlan;
+    let plan = ExecutionPlan {
+        objective: "fix the auth bug".to_string(),
+        steps: vec![
+            "Identify target files".to_string(),
+            "Apply fix".to_string(),
+            "Verify compilation".to_string(),
+        ],
+        expected_changed_files: vec!["src/auth.rs".to_string()],
+        risk_level: "medium".to_string(),
+        is_mutating: true,
+    };
+    let json = serde_json::to_string(&plan).expect("serialize");
+    let restored: ExecutionPlan = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(plan, restored);
+}
+
+#[test]
+fn session_summary_serialization_round_trip() {
+    use crate::engineer_loop::types::SessionSummary;
+    let summary = SessionSummary {
+        objective: "fix the auth bug".to_string(),
+        outcome: "success".to_string(),
+        changed_files: vec!["src/auth.rs".to_string()],
+        key_decisions: vec!["Used structured text replace".to_string()],
+        accomplishment: "Fixed authentication bypass in login handler".to_string(),
+    };
+    let json = serde_json::to_string(&summary).expect("serialize");
+    let restored: SessionSummary = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(summary, restored);
 }

--- a/src/engineer_loop/types.rs
+++ b/src/engineer_loop/types.rs
@@ -34,6 +34,40 @@ pub struct RepoInspection {
     pub architecture_gap_summary: String,
 }
 
+/// Structured execution plan produced during the Planning phase (spec step 3).
+/// Exists as a separable orchestration primitive so plan formation can be
+/// audited independently from execution.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct ExecutionPlan {
+    /// The original objective being addressed.
+    pub objective: String,
+    /// Ordered list of planned steps the agent should execute.
+    pub steps: Vec<String>,
+    /// Files expected to be modified or created.
+    pub expected_changed_files: Vec<String>,
+    /// Risk assessment: "low", "medium", or "high".
+    pub risk_level: String,
+    /// Whether the plan involves repository mutations.
+    pub is_mutating: bool,
+}
+
+/// Structured session summary produced during the Summarize phase (spec step 6).
+/// Exists as a separable orchestration primitive so result summarization can be
+/// audited independently from persistence.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct SessionSummary {
+    /// The original objective that was pursued.
+    pub objective: String,
+    /// Overall outcome: "success", "partial", or "failed".
+    pub outcome: String,
+    /// Files that were actually changed during execution.
+    pub changed_files: Vec<String>,
+    /// Key decisions made during the session.
+    pub key_decisions: Vec<String>,
+    /// What was accomplished, in one sentence.
+    pub accomplishment: String,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct StructuredEditRequest {
     pub relative_path: String,
@@ -138,9 +172,10 @@ impl PhaseTrace {
         match self.name.as_str() {
             "inspect" | "pre-mutation-guard" => SessionPhase::Intake,
             "load-bridge-context" => SessionPhase::Preparation,
-            "agent-prompt-build" => SessionPhase::Planning,
+            "agent-prompt-build" | "plan" => SessionPhase::Planning,
             "agent-spawn" | "agent-wait" => SessionPhase::Execution,
             "review" => SessionPhase::Reflection,
+            "summarize" => SessionPhase::Summarize,
             "persist" => SessionPhase::Persistence,
             _ => SessionPhase::Execution,
         }
@@ -152,8 +187,16 @@ pub struct EngineerLoopRun {
     pub state_root: PathBuf,
     pub execution_scope: String,
     pub inspection: RepoInspection,
+    /// Structured execution plan formed during the Planning phase (spec step 3).
+    /// `None` for runs deserialized from older formats that predate plan tracking.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub plan: Option<ExecutionPlan>,
     pub action: ExecutedEngineerAction,
     pub verification: VerificationReport,
+    /// Structured session summary produced during the Summarize phase (spec step 6).
+    /// `None` for runs deserialized from older formats that predate summary tracking.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary: Option<SessionSummary>,
     pub terminal_bridge_context: Option<TerminalBridgeContext>,
     #[serde(with = "duration_millis")]
     pub elapsed_duration: Duration,

--- a/src/runtime/tests_session.rs
+++ b/src/runtime/tests_session.rs
@@ -28,6 +28,7 @@ fn session_advance_through_full_lifecycle() {
         SessionPhase::Planning,
         SessionPhase::Execution,
         SessionPhase::Reflection,
+        SessionPhase::Summarize,
         SessionPhase::Persistence,
         SessionPhase::Complete,
     ];

--- a/src/session.rs
+++ b/src/session.rs
@@ -75,6 +75,7 @@ pub enum SessionPhase {
     Planning,
     Execution,
     Reflection,
+    Summarize,
     Persistence,
     Complete,
     Failed,
@@ -88,6 +89,7 @@ impl Display for SessionPhase {
             Self::Planning => "planning",
             Self::Execution => "execution",
             Self::Reflection => "reflection",
+            Self::Summarize => "summarize",
             Self::Persistence => "persistence",
             Self::Complete => "complete",
             Self::Failed => "failed",
@@ -104,6 +106,10 @@ impl SessionPhase {
                 | (Self::Preparation, Self::Planning)
                 | (Self::Planning, Self::Execution)
                 | (Self::Execution, Self::Reflection)
+                | (Self::Reflection, Self::Summarize)
+                | (Self::Summarize, Self::Persistence)
+                // Legacy path: allow direct Reflection→Persistence for callers
+                // that have not yet adopted the Summarize phase.
                 | (Self::Reflection, Self::Persistence)
                 | (Self::Persistence, Self::Complete)
                 | (_, Self::Failed)
@@ -249,6 +255,10 @@ mod tests {
         assert!(SessionPhase::Preparation.can_transition_to(SessionPhase::Planning));
         assert!(SessionPhase::Planning.can_transition_to(SessionPhase::Execution));
         assert!(SessionPhase::Execution.can_transition_to(SessionPhase::Reflection));
+        assert!(SessionPhase::Reflection.can_transition_to(SessionPhase::Summarize));
+        assert!(SessionPhase::Summarize.can_transition_to(SessionPhase::Persistence));
+        // Legacy path: Reflection→Persistence still valid for callers that
+        // have not yet adopted the Summarize phase.
         assert!(SessionPhase::Reflection.can_transition_to(SessionPhase::Persistence));
         assert!(SessionPhase::Persistence.can_transition_to(SessionPhase::Complete));
     }
@@ -261,6 +271,7 @@ mod tests {
             SessionPhase::Planning,
             SessionPhase::Execution,
             SessionPhase::Reflection,
+            SessionPhase::Summarize,
             SessionPhase::Persistence,
             SessionPhase::Complete,
         ];
@@ -277,13 +288,26 @@ mod tests {
         assert!(!SessionPhase::Preparation.can_transition_to(SessionPhase::Intake));
         assert!(!SessionPhase::Complete.can_transition_to(SessionPhase::Execution));
         assert!(!SessionPhase::Planning.can_transition_to(SessionPhase::Preparation));
+        assert!(!SessionPhase::Summarize.can_transition_to(SessionPhase::Reflection));
     }
 
     #[test]
     fn session_phase_display_renders_lowercase() {
         assert_eq!(SessionPhase::Intake.to_string(), "intake");
+        assert_eq!(SessionPhase::Summarize.to_string(), "summarize");
         assert_eq!(SessionPhase::Complete.to_string(), "complete");
         assert_eq!(SessionPhase::Failed.to_string(), "failed");
+    }
+
+    #[test]
+    fn summarize_phase_transitions() {
+        // Reflection → Summarize → Persistence is the new canonical path
+        assert!(SessionPhase::Reflection.can_transition_to(SessionPhase::Summarize));
+        assert!(SessionPhase::Summarize.can_transition_to(SessionPhase::Persistence));
+        // Legacy path still works
+        assert!(SessionPhase::Reflection.can_transition_to(SessionPhase::Persistence));
+        // Summarize cannot skip to Complete
+        assert!(!SessionPhase::Summarize.can_transition_to(SessionPhase::Complete));
     }
 
     // --- SessionRecord ---


### PR DESCRIPTION
## Summary

Adds explicit **Plan** and **Summarize** phases to the engineer loop session lifecycle, aligning `run_local_engineer_loop()` with the spec 7-step cycle (`Specs/ProductArchitecture.md` lines 239-250).

Closes #2083

## Problem

The engineer loop compressed the spec 7-step cycle into ~4-5 phases. Steps 3 (form plan) and 6 (summarize results) happened inside the agent subprocess rather than as distinct, auditable orchestration primitives. This meant plan formation could not be inspected independently from execution, and summarization was not a separable concern.

## Changes (6 files, +284/-6)

| File | Change |
|------|--------|
| `src/session.rs` | Add `Summarize` variant to `SessionPhase`; update Display, transitions (Reflection→Summarize→Persistence, legacy Reflection→Persistence preserved); 3 new tests |
| `src/engineer_loop/types.rs` | Add `ExecutionPlan` and `SessionSummary` structs; add `plan`/`summary` fields to `EngineerLoopRun` (serde-optional for backward compat); update `PhaseTrace::session_phase()` mapping |
| `src/engineer_loop/mod.rs` | Add `form_execution_plan()` and `summarize_results()` functions; wire Plan and Summarize phases into `run_local_engineer_loop()` with phase traces |
| `src/engineer_loop/tests_types_inline.rs` | 4 new tests: plan/summarize phase mapping, ExecutionPlan/SessionSummary round-trip, backward compat |
| `src/copilot_task_submit/orchestration.rs` | Add `SessionPhase::Summarize` to phase iteration |
| `src/runtime/tests_session.rs` | Add `SessionPhase::Summarize` to lifecycle test |

## 7-Step Cycle Mapping

| Spec Step | SessionPhase | Engineer Loop Phase |
|-----------|-------------|-------------------|
| 1. ingest task | Intake | inspect |
| 2. inspect repo | Intake | pre-mutation-guard |
| 3. form plan | Planning | plan (**NEW**) |
| 4. terminal actions | Execution | agent-spawn/wait |
| 5. verify outputs | Reflection | review |
| 6. summarize results | Summarize (**NEW**) | summarize (**NEW**) |
| 7. persist memory | Persistence | persist |

## Merge-Ready Evidence

1. **Tests**: 34 engineer_loop type tests pass (4 new), 7 runtime session tests pass, 80 session tests pass — all green
2. **Docs**: Internal-only change — no user-facing surface changes. The new types are `pub` re-exports for recipe-driven engineer loop consumers.
3. **Lint**: `cargo fmt` clean, `cargo clippy --all-targets` clean (only pre-existing `banner_active_goal_count` dead_code warning)
4. **CI**: Pre-commit hooks passed (fmt + clippy release)
5. **This PR** contains evidence for criteria 1-4 and 6
6. **Diff focused**: 6 files, all scoped to session phase machinery and engineer loop — no unrelated edits

## Backward Compatibility

- `SessionPhase::Summarize` is serde-compatible (`kebab-case` → `"summarize"`)
- Legacy `Reflection → Persistence` transition preserved for callers not yet on Summarize
- `EngineerLoopRun.plan` and `.summary` are `Option` with `skip_serializing_if` — older JSON deserializes cleanly