### PR TITLE
fix(#2132): propagate AMPLIHACK_AGENT_BINARY from config.toml to all subprocesses

### DIFF
--- a/docs/concepts/config-driven-subprocess-env.md
+++ b/docs/concepts/config-driven-subprocess-env.md
@@ -1,0 +1,208 @@
+---
+title: "Config-driven subprocess environment propagation"
+description: Design rationale for reading ~/.simard/config.toml to set AMPLIHACK_AGENT_BINARY on recipe-runner-rs subprocesses, replacing the unreliable env-var-only approach.
+last_updated: 2026-05-27
+review_schedule: as-needed
+owner: simard
+doc_type: concept
+related:
+  - ../reference/subprocess-env-propagation.md
+  - ../howto/configure-llm-provider.md
+  - ../reference/disk-health-api.md
+  - ./truthful-runtime-metadata.md
+---
+
+# Config-driven subprocess environment propagation
+
+On 2026-05-27, Simard's recipe-runner shims (decide, orient, engineer
+lifecycle, merge judge, progress checker, and disk health) were invoking
+`recipe-runner-rs` without setting `AMPLIHACK_AGENT_BINARY` in the child
+process environment. The recipe runner defaulted to `claude`, which is the
+wrong binary on Copilot-based deployments.
+
+This document explains the problem, the design of the fix, and why
+`~/.simard/config.toml` is the single source of truth.
+
+## The problem
+
+### Environment variables don't survive process boundaries
+
+Simard launches `recipe-runner-rs` as a subprocess from six different Rust
+shims. Each shim calls `Command::new("recipe-runner-rs")` and passes recipe
+context via `-c` flags. None of them set `AMPLIHACK_AGENT_BINARY` on the
+child process.
+
+The recipe runner reads `AMPLIHACK_AGENT_BINARY` to decide which agent
+binary to use. When the variable is absent, it defaults to `claude` — a
+binary that does not exist on Copilot-based deployments. The result: every
+recipe invocation fails with "binary not found" unless the operator
+manually exports the variable in their shell.
+
+This is fragile for three reasons:
+
+1. **tmux does not propagate env** — The OODA daemon often runs inside
+   tmux. `tmux new-session` does not forward parent env vars to the
+   server-attached pane. An operator who sets `AMPLIHACK_AGENT_BINARY=copilot`
+   in their shell sees it disappear when the daemon starts.
+
+2. **systemd does not propagate env** — Production daemons run under
+   systemd. The unit file must explicitly list every env var. Missing one
+   means silent failure at runtime, not at deployment time.
+
+3. **Subprocess spawning is deep** — Simard spawns `recipe-runner-rs`,
+   which may itself spawn further processes. Each hop is another opportunity
+   for env vars to vanish. A config file read at the point of use is
+   reliable across any depth of subprocess nesting.
+
+### The existing config.toml already had the answer
+
+`RuntimeConfig::load()` reads `~/.simard/config.toml` and resolves the
+`llm_provider` field through a well-defined precedence chain:
+
+1. `SIMARD_LLM_PROVIDER` env var (wins when set)
+2. `~/.simard/config.toml` (used when env unset)
+3. Error (no silent default)
+
+This mechanism already existed and was used by `SessionBuilder` and
+`LlmProvider::resolve()`. The recipe-runner shims simply weren't using it.
+
+## Design
+
+### One new method: `LlmProvider::agent_binary_value()`
+
+Each `LlmProvider` variant maps to a binary name:
+
+| `LlmProvider` variant | `agent_binary_value()` | Meaning                     |
+| ---------------------- | ---------------------- | --------------------------- |
+| `Copilot`              | `"copilot"`            | GitHub Copilot SDK via `gh` |
+| `RustyClawd`           | `"rustyclawd"`         | Anthropic / RustyClawd      |
+
+The method returns `&'static str` — no allocation, no user input, no
+injection risk. The mapping matches `to_toml_string()` in `runtime_config.rs`.
+
+### Each shim reads config once at construction
+
+The five struct-based shims (`RecipeDecideBrain`, `RecipeOrientBrain`,
+`RecipeEngineerLifecycleBrain`, `RecipeMergeJudge`, `RecipeProgressChecker`)
+store an `agent_binary: &'static str` field. The field is populated in `new()` by:
+
+```rust
+let agent_binary = RuntimeConfig::load()
+    .ok()?
+    .llm_provider
+    .agent_binary_value();
+```
+
+If config loading fails (no env var AND no config.toml), `new()` returns
+`None` — the same behaviour as when the recipe binary is not found. The
+caller falls back to the deterministic brain, which is the correct
+degradation path.
+
+The stored field is then applied to both Commands (version check and
+execution):
+
+```rust
+Command::new("recipe-runner-rs")
+    .env("AMPLIHACK_AGENT_BINARY", &self.agent_binary)
+    // ... existing args ...
+```
+
+### disk_health.rs propagates with `?`
+
+`run_disk_health_check` is a function, not a struct. It loads config at
+call time and propagates failure via `?`:
+
+```rust
+let agent_binary = RuntimeConfig::load()?.llm_provider.agent_binary_value();
+```
+
+A config failure here returns `SimardResult::Err`, which the daemon handles
+with its existing warn-and-continue pattern. This is the correct behaviour —
+if config is missing, the operator needs to know, not have the system guess.
+
+## Why not just set the env var?
+
+Three alternatives were considered and rejected:
+
+### Alternative 1: Set `AMPLIHACK_AGENT_BINARY` globally at daemon startup
+
+This would use `std::env::set_var()` in `main()`. Rejected because:
+
+- `set_var` modifies the **parent** process environment, not just the child.
+  This is a safety hazard in multi-threaded code.
+- It doesn't help subprocesses launched through tmux or systemd —
+  `set_var` only affects the current process tree.
+
+### Alternative 2: Read env var in each shim
+
+This would check `std::env::var("AMPLIHACK_AGENT_BINARY")` in each shim.
+Rejected because:
+
+- The env var might not be set (the original problem).
+- We'd need a fallback, and the fallback would be... reading config.toml.
+  So we'd have two codepaths for the same information.
+- `RuntimeConfig::load()` already does the env → config → error resolution.
+
+### Alternative 3: Pass `AMPLIHACK_AGENT_BINARY` through recipe context vars
+
+This would use `-c agent_binary=copilot` instead of `.env()`. Rejected
+because:
+
+- `AMPLIHACK_AGENT_BINARY` is an environment variable consumed by the
+  recipe runner itself, not a recipe-level context variable.
+- The recipe runner reads its own env, not its context vars, for this
+  setting.
+
+## Tradeoffs
+
+### Config must exist for recipe brains to activate
+
+If `~/.simard/config.toml` does not exist AND `SIMARD_LLM_PROVIDER` is not
+set, the recipe brain `new()` methods return `None`. This means no recipe
+brain is available, and the OODA loop falls back to the deterministic brain.
+
+This is intentional. The project's design rule — no silent defaults —
+means that a missing provider must surface as a visible degradation (recipe
+brain unavailable), not as a wrong provider (defaulting to `claude`).
+
+Operators who encounter this see a log line explaining which brains are
+active. The fix is to write the config file:
+
+```bash
+mkdir -p ~/.simard
+echo 'llm_provider = "copilot"' > ~/.simard/config.toml
+```
+
+Or set the env var:
+
+```bash
+export SIMARD_LLM_PROVIDER=copilot
+```
+
+### Config is read once per struct, not once per call
+
+The struct-based shims read config in `new()` and cache the result. If an
+operator changes `config.toml` while the daemon is running, the change is
+not picked up until the next daemon restart (which recreates the structs).
+
+This is acceptable because:
+
+1. LLM provider changes are rare — they happen during deployment, not
+   during operation.
+2. The daemon already rebuilds brain structs on restart.
+3. Per-call config reads would add filesystem I/O on every OODA cycle
+   for no practical benefit.
+
+### `disk_health.rs` reads config per-call
+
+Unlike the struct-based shims, `run_disk_health_check` reads config each
+time it's called. This is because the function has no persistent state —
+it's a stateless helper called once per cycle. The filesystem read is
+negligible compared to the subprocess spawn that follows.
+
+## Related
+
+- [Subprocess environment propagation API](../reference/subprocess-env-propagation.md) — full API surface
+- [Configure LLM provider (how-to)](../howto/configure-llm-provider.md) — operator guide
+- [Disk health API reference](../reference/disk-health-api.md) — env propagation in disk health
+- [Truthful runtime metadata](./truthful-runtime-metadata.md) — the no-silent-defaults principle

--- a/docs/howto/configure-llm-provider.md
+++ b/docs/howto/configure-llm-provider.md
@@ -1,0 +1,286 @@
+---
+title: Configure the LLM provider for Simard
+description: Operator guide for setting up ~/.simard/config.toml so Simard's recipe-runner subprocesses use the correct agent binary.
+last_updated: 2026-05-27
+review_schedule: as-needed
+owner: simard
+doc_type: howto
+related:
+  - ../reference/subprocess-env-propagation.md
+  - ../concepts/config-driven-subprocess-env.md
+  - ../howto/configure-bootstrap-and-inspect-reflection.md
+  - ../reference/runtime-contracts.md
+  - ../howto/configure-disk-health-check.md
+---
+
+# Configure the LLM provider for Simard
+
+Simard reads `~/.simard/config.toml` to determine which LLM provider to use.
+This config drives two things: which agent adapter `SessionBuilder` creates,
+and which binary `recipe-runner-rs` subprocesses invoke via
+`AMPLIHACK_AGENT_BINARY`.
+
+This guide shows how to set, verify, and troubleshoot the LLM provider
+configuration.
+
+## When to use this
+
+Use this guide when:
+
+- You are deploying Simard for the first time
+- Recipe-runner shims fail with "binary not found" or "recipe-runner-rs spawn failed"
+- The daemon falls back to deterministic brains when recipe brains should be active
+- You are switching between Copilot and RustyClawd deployments
+- You see `missing required config: SIMARD_LLM_PROVIDER` in logs
+
+## Set the LLM provider
+
+### Option 1: config file (recommended)
+
+Create `~/.simard/config.toml` with the `llm_provider` key:
+
+```bash
+mkdir -p ~/.simard
+cat > ~/.simard/config.toml << 'EOF'
+# Simard runtime configuration
+# Loaded by every Simard process at startup. Subprocesses
+# (engineer, meeting REPL, etc.) read this file so the
+# operator does not have to plumb env vars through tmux,
+# systemd, or ssh wrappers.
+llm_provider = "copilot"
+EOF
+```
+
+Accepted values:
+
+| Value         | Agent binary | Provider                                     |
+| ------------- | ------------ | -------------------------------------------- |
+| `"copilot"`   | `copilot`    | GitHub Copilot SDK via `gh` auth             |
+| `"rustyclawd"`| `rustyclawd` | RustyClawd / Anthropic (needs `ANTHROPIC_API_KEY`) |
+
+The config file is the recommended approach because it survives:
+
+- tmux session creation (which does not propagate parent env)
+- systemd service restarts (no need to list env vars in unit files)
+- SSH sessions (no need for `.bashrc` exports)
+- Subprocess nesting (recipe-runner spawning further processes)
+
+### Option 2: environment variable
+
+Set `SIMARD_LLM_PROVIDER` in the shell that launches the daemon:
+
+```bash
+export SIMARD_LLM_PROVIDER=copilot
+simard ooda run ...
+```
+
+The env var **wins over** the config file when both are set. This is useful
+for temporary overrides or testing, but the config file is more reliable for
+production.
+
+### Auto-bootstrap from env
+
+If you launch the daemon with `SIMARD_LLM_PROVIDER` set but no config.toml
+exists, Simard writes the config file automatically on first startup. This
+is a one-time bootstrap — subsequent runs read the file directly.
+
+```bash
+# First run: env var is set, config.toml doesn't exist
+export SIMARD_LLM_PROVIDER=copilot
+simard ooda run ...
+# → writes ~/.simard/config.toml with llm_provider = "copilot"
+
+# Second run: env var not needed, config.toml is read
+simard ooda run ...
+# → reads ~/.simard/config.toml
+```
+
+## Verify the configuration
+
+### Check the config file
+
+```bash
+cat ~/.simard/config.toml
+```
+
+Expected output:
+
+```toml
+# Simard runtime configuration
+llm_provider = "copilot"
+```
+
+### Check the env var (if using option 2)
+
+```bash
+echo $SIMARD_LLM_PROVIDER
+```
+
+### Verify recipe brains are active
+
+After starting the daemon, check the log for brain selection:
+
+```bash
+grep -E "decide brain|orient brain|engineer lifecycle" ~/.simard/ooda.log | tail -5
+```
+
+When config is correct and `recipe-runner-rs` is installed:
+
+```
+[simard] decide brain: recipe (ooda-decide.yaml)
+[simard] orient brain: recipe (ooda-orient.yaml)
+```
+
+When config is missing or `recipe-runner-rs` is not installed:
+
+```
+[simard] decide brain: deterministic (recipe brain not available)
+[simard] orient brain: deterministic (recipe brain not available)
+```
+
+### Verify disk health check
+
+```bash
+grep "disk health" ~/.simard/ooda.log | tail -3
+```
+
+When config is correct:
+
+```
+[simard] disk health: 72% used, freed 0 bytes, 0 actions
+```
+
+When config is missing:
+
+```
+[simard] disk health check failed: missing required config: SIMARD_LLM_PROVIDER ...
+```
+
+## Troubleshoot
+
+### "missing required config: SIMARD_LLM_PROVIDER"
+
+Neither `SIMARD_LLM_PROVIDER` env var nor `~/.simard/config.toml` is set.
+
+**Fix:** Create the config file:
+
+```bash
+mkdir -p ~/.simard
+echo 'llm_provider = "copilot"' > ~/.simard/config.toml
+```
+
+### "recipe-runner-rs spawn failed"
+
+`recipe-runner-rs` is not on `$PATH`, or `AMPLIHACK_AGENT_BINARY` resolved
+to a binary that doesn't exist.
+
+**Check:** Verify the binary exists:
+
+```bash
+which recipe-runner-rs
+recipe-runner-rs --version
+```
+
+**Check:** Verify the agent binary exists:
+
+```bash
+# For copilot provider:
+which copilot
+
+# For rustyclawd provider:
+which rustyclawd
+```
+
+### Recipe brains fall back to deterministic
+
+This happens when either:
+
+1. `RuntimeConfig::load()` fails (config missing) — the shim's `new()` returns `None`
+2. `recipe-runner-rs` is not installed — the version check fails
+3. The recipe YAML file is missing — `resolve_recipe_path()` returns `None`
+
+**Diagnose:** Check each condition:
+
+```bash
+# 1. Config exists?
+cat ~/.simard/config.toml
+
+# 2. recipe-runner-rs installed?
+which recipe-runner-rs
+
+# 3. Recipe files exist?
+ls prompt_assets/simard/recipes/ooda-decide.yaml
+ls prompt_assets/simard/recipes/ooda-orient.yaml
+```
+
+### Config file has wrong provider
+
+If you set `llm_provider = "rustyclawd"` but are running on a Copilot
+deployment (or vice versa), recipe invocations will fail with binary-not-found
+errors for the wrong binary.
+
+**Fix:** Update the config file to match your deployment:
+
+```bash
+echo 'llm_provider = "copilot"' > ~/.simard/config.toml
+```
+
+Then restart the daemon.
+
+### Changes to config.toml not taking effect
+
+The struct-based recipe shims (decide, orient, engineer lifecycle, merge
+judge, progress checker) read config once at construction time and cache
+the result. Changes to `config.toml` while the daemon is running are not
+picked up until the daemon restarts.
+
+**Fix:** Restart the daemon after changing `config.toml`.
+
+The disk health check reads config on every call, so it picks up changes
+immediately — but for consistency, restart the daemon after any config
+change.
+
+## Understand the resolution order
+
+Simard resolves the LLM provider through this chain:
+
+```
+1. SIMARD_LLM_PROVIDER env var (wins when set)
+       ↓ (not set)
+2. ~/.simard/config.toml → llm_provider key
+       ↓ (file missing or key absent)
+3. Error — no silent default
+```
+
+The env var always wins. This is intentional — it allows temporary overrides
+without modifying the config file. But for production, the config file is
+the primary mechanism.
+
+There is **no silent default**. If neither source provides a value, Simard
+fails with an explicit error rather than guessing. This follows the project's
+no-silent-defaults principle (see [truthful runtime metadata](../concepts/truthful-runtime-metadata.md)).
+
+## How it flows to subprocesses
+
+When a recipe shim spawns `recipe-runner-rs`, it sets
+`AMPLIHACK_AGENT_BINARY` on the child process using the value from
+`LlmProvider::agent_binary_value()`:
+
+```
+~/.simard/config.toml                    (llm_provider = "copilot")
+    → RuntimeConfig::load()              (LlmProvider::Copilot)
+    → LlmProvider::agent_binary_value()  ("copilot")
+    → Command::env("AMPLIHACK_AGENT_BINARY", "copilot")
+    → recipe-runner-rs reads env         (uses 'copilot' binary)
+```
+
+This happens automatically. The operator's only responsibility is to set
+`llm_provider` once in `config.toml`.
+
+## Related
+
+- [Subprocess environment propagation API](../reference/subprocess-env-propagation.md) — full API surface
+- [Config-driven subprocess env (concept)](../concepts/config-driven-subprocess-env.md) — design rationale
+- [Configure bootstrap and inspect reflection](./configure-bootstrap-and-inspect-reflection.md) — broader runtime configuration
+- [Configure disk health check](./configure-disk-health-check.md) — disk health uses the same config
+- [Runtime contracts reference](../reference/runtime-contracts.md) — overall runtime contract

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,6 +50,9 @@ Terminal sessions and repo-grounded engineer runs now bridge through one explici
 - [Concept: improvement context — denser execution evidence for the engineer loop](./concepts/improvement-context-execution-evidence-gap.md) - Captured improvement-curation context preserving the active "Capture denser execution evidence" goal and the observation that the legacy `simard_operator_probe` surface does not yet expose a terminal engineer-loop probe.
 - [Concept: automated disk health management](./concepts/automated-disk-health.md) - Design rationale for the per-cycle disk health check that prevents disk exhaustion (#2020).
 - [Disk health API reference](./reference/disk-health-api.md) - Full API surface for `simard::disk_health`, the recipe YAML contract, and daemon integration.
+- [How to configure the LLM provider](./howto/configure-llm-provider.md) - Set up `~/.simard/config.toml` so recipe-runner subprocesses use the correct agent binary (#2132).
+- [Concept: config-driven subprocess environment propagation](./concepts/config-driven-subprocess-env.md) - Design rationale for reading config.toml to set `AMPLIHACK_AGENT_BINARY` on subprocesses.
+- [Subprocess environment propagation API reference](./reference/subprocess-env-propagation.md) - `LlmProvider::agent_binary_value()` and the shim integration pattern.
 
 ## Canonical executable surface
 

--- a/docs/reference/disk-health-api.md
+++ b/docs/reference/disk-health-api.md
@@ -276,6 +276,7 @@ All errors surface as `SimardError::AdapterInvocationFailed`:
 
 | Scenario                         | `base_type`          | `reason`                                   |
 | -------------------------------- | -------------------- | ------------------------------------------ |
+| Runtime config unavailable       | `"disk-health"`      | `"missing required config: SIMARD_LLM_PROVIDER ..."` |
 | Recipe YAML not found            | `"disk-health"`      | `"recipe not found at <path>"`             |
 | `recipe-runner-rs` not on PATH   | `"disk-health"`      | `"recipe-runner-rs not found"`             |
 | Subprocess non-zero exit         | `"disk-health"`      | `"recipe exited with status <code>: <stderr>"` |
@@ -289,6 +290,14 @@ disk health check never crashes the daemon.
 | -------------------- | --------------------------------------------------------- | ------------- |
 | `SIMARD_STATE_ROOT`  | Root for all cleanup targets                              | `~/.simard/`  |
 | `CARGO_TARGET_DIR`   | If set, shared target is at this path instead of default  | (not set)     |
+
+`run_disk_health_check` also reads `RuntimeConfig` (env var
+`SIMARD_LLM_PROVIDER` → `~/.simard/config.toml`) to set
+`AMPLIHACK_AGENT_BINARY` on the `recipe-runner-rs` subprocess. If neither
+source provides the LLM provider, the function returns
+`SimardError::MissingRequiredConfig`. See
+[subprocess environment propagation](./subprocess-env-propagation.md) for
+the full contract.
 
 The cleanup thresholds (80%, 24h, 5 backups) are defined in the recipe YAML,
 not in Rust. To change them, edit `disk-health-check.yaml` — no recompile

--- a/docs/reference/subprocess-env-propagation.md
+++ b/docs/reference/subprocess-env-propagation.md
@@ -1,0 +1,255 @@
+---
+title: Subprocess environment propagation API
+description: Reference for how Simard's recipe-runner shims read ~/.simard/config.toml and propagate AMPLIHACK_AGENT_BINARY to recipe-runner-rs subprocesses.
+last_updated: 2026-05-27
+review_schedule: as-needed
+owner: simard
+doc_type: reference
+related:
+  - ../concepts/config-driven-subprocess-env.md
+  - ../howto/configure-llm-provider.md
+  - ./disk-health-api.md
+  - ./runtime-contracts.md
+---
+
+# Subprocess environment propagation API
+
+Module: `simard::session_builder` (method), `simard::runtime_config` (config loading)
+Source: `src/session_builder.rs`, `src/runtime_config.rs`, plus all recipe shim files
+
+Simard's recipe-runner shims set `AMPLIHACK_AGENT_BINARY` on every
+`recipe-runner-rs` subprocess using the `llm_provider` value from
+`RuntimeConfig`. This ensures the recipe runner invokes the correct agent
+binary (`copilot` or `rustyclawd`) regardless of the parent process's
+environment.
+
+## `LlmProvider::agent_binary_value()`
+
+```rust
+impl LlmProvider {
+    /// The string value for `AMPLIHACK_AGENT_BINARY` env var on subprocesses.
+    pub fn agent_binary_value(&self) -> &'static str {
+        match self {
+            Self::Copilot => "copilot",
+            Self::RustyClawd => "rustyclawd",
+        }
+    }
+}
+```
+
+Returns a static string suitable for passing to `Command::env()`. The
+mapping is:
+
+| `LlmProvider` variant | `agent_binary_value()` | `to_toml_string()` |
+| ---------------------- | ---------------------- | ------------------- |
+| `Copilot`              | `"copilot"`            | `"copilot"`         |
+| `RustyClawd`           | `"rustyclawd"`         | `"rustyclawd"`      |
+
+The values intentionally match `to_toml_string()` — both represent the same
+provider identity in different contexts (subprocess env vs. config file).
+
+## Config resolution chain
+
+All shims resolve the agent binary through the same chain:
+
+```
+RuntimeConfig::load()
+  → SIMARD_LLM_PROVIDER env var (if set)
+  → ~/.simard/config.toml llm_provider key (if file exists)
+  → Error (no silent default)
+```
+
+This chain is defined in `src/runtime_config.rs`. See the module-level
+documentation for the full resolution order and anti-pattern guards.
+
+## Affected shims
+
+### Struct-based recipe shims
+
+These shims store `agent_binary: &'static str` as a struct field, populated once
+in `new()`:
+
+| Struct                            | Source file                                  | Version-check Command | Execution Command       |
+| --------------------------------- | -------------------------------------------- | --------------------- | ----------------------- |
+| `RecipeDecideBrain`               | `src/ooda_brain/recipe_decide.rs`            | `--version`           | `judge_decision()`      |
+| `RecipeOrientBrain`               | `src/ooda_brain/recipe_orient.rs`            | `--version`           | `judge_orientation()`   |
+| `RecipeEngineerLifecycleBrain`    | `src/ooda_brain/recipe_engineer_lifecycle.rs` | `--version`          | `decide_engineer_lifecycle()` |
+| `RecipeMergeJudge`                | `src/stewardship/recipe_merge_judge.rs`      | `--version`           | `judge()`               |
+| `RecipeProgressChecker`           | `src/goal_curation/recipe_progress_checker.rs` | `--version`         | `check()`               |
+
+Each struct follows this pattern in `new()`:
+
+```rust
+pub fn new(repo_root: &Path) -> Option<Self> {
+    let recipe_path = resolve_recipe_path(repo_root)?;
+    let agent_binary = RuntimeConfig::load()
+        .ok()?
+        .llm_provider
+        .agent_binary_value()
+        .to_string();
+
+    // Version check uses a local variable (self doesn't exist yet)
+    if Command::new("recipe-runner-rs")
+        .arg("--version")
+        .env("AMPLIHACK_AGENT_BINARY", &agent_binary)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_err()
+    {
+        return None;
+    }
+
+    Some(Self {
+        recipe_path,
+        agent_binary,
+    })
+}
+```
+
+And this pattern in execution methods:
+
+```rust
+let output = Command::new("recipe-runner-rs")
+    .arg(self.recipe_path.as_os_str())
+    .env("AMPLIHACK_AGENT_BINARY", &self.agent_binary)
+    // ... recipe-specific -c context vars ...
+    .output()?;
+```
+
+### Function-based shim: `disk_health.rs`
+
+`run_disk_health_check` is a standalone function, not a struct. It reads
+config at call time:
+
+```rust
+pub fn run_disk_health_check(
+    repo_root: &Path,
+    state_root: &Path,
+) -> SimardResult<DiskHealthReport> {
+    let agent_binary = RuntimeConfig::load()?
+        .llm_provider
+        .agent_binary_value();
+
+    // ...
+    let output = Command::new("recipe-runner-rs")
+        .arg(recipe_path.as_os_str())
+        .env("AMPLIHACK_AGENT_BINARY", agent_binary)
+        .arg("-c")
+        .arg(format!("state_root={}", state_root.display()))
+        .output()?;
+    // ...
+}
+```
+
+Config failure propagates as `SimardResult::Err` via `?`. The daemon's
+existing warn-and-continue handler catches it.
+
+## Failure modes
+
+### Config unavailable in struct `new()`
+
+If `RuntimeConfig::load()` fails (no env var AND no config.toml), `.ok()?`
+converts the error to `None`, and `new()` returns `None`. The caller falls
+back to the deterministic brain — the same behaviour as when
+`recipe-runner-rs` is not installed.
+
+This is visible in the daemon's brain selection log:
+
+```
+[simard] decide brain: deterministic (recipe brain not available)
+```
+
+### Config unavailable in `disk_health.rs`
+
+If `RuntimeConfig::load()` fails, `run_disk_health_check` returns
+`SimardResult::Err`. The daemon logs the error and continues the OODA
+cycle:
+
+```
+[simard] disk health check failed: missing required config: SIMARD_LLM_PROVIDER ...
+```
+
+### Wrong provider in config
+
+If `config.toml` says `llm_provider = "copilot"` but the operator intends
+`rustyclawd`, the recipe runner will invoke the wrong binary. This is an
+operator configuration error, not a Simard bug. The fix is to update
+`config.toml` and restart the daemon.
+
+## Environment variable contract
+
+The recipe-runner shims set exactly one env var on child processes:
+
+| Variable                  | Value source                          | Scope        |
+| ------------------------- | ------------------------------------- | ------------ |
+| `AMPLIHACK_AGENT_BINARY`  | `LlmProvider::agent_binary_value()`   | Child only   |
+
+The shims use `Command::env()` (child process scope), never
+`std::env::set_var()` (parent process scope). This is a safety invariant —
+modifying the parent environment in multi-threaded code is undefined
+behaviour in Rust.
+
+No other env vars are added or modified by this feature. Existing env vars
+(`SIMARD_STATE_ROOT`, `CARGO_TARGET_DIR`, etc.) continue to be inherited
+naturally from the parent process.
+
+## Security considerations
+
+| Property              | Guarantee                                                     |
+| --------------------- | ------------------------------------------------------------- |
+| No user input         | `agent_binary_value()` returns hardcoded `&'static str`       |
+| No injection          | Values are `"copilot"` or `"rustyclawd"` — no interpolation   |
+| Child-only scope      | `Command::env()` never modifies parent process environment    |
+| No credentials        | `AMPLIHACK_AGENT_BINARY` is a selector, not a secret          |
+| Audit trail           | Config source is logged at daemon startup via `bootstrap_from_env` |
+
+## Tests
+
+### `LlmProvider::agent_binary_value()` unit test
+
+```rust
+#[test]
+fn agent_binary_value_returns_expected_strings() {
+    assert_eq!(LlmProvider::Copilot.agent_binary_value(), "copilot");
+    assert_eq!(LlmProvider::RustyClawd.agent_binary_value(), "rustyclawd");
+}
+```
+
+### Struct test literals
+
+Each struct-based shim's existing test constructs a bare struct literal.
+These tests include the new `agent_binary` field:
+
+```rust
+let brain = RecipeDecideBrain {
+    recipe_path: PathBuf::from("/nonexistent/recipe.yaml"),
+    agent_binary: "copilot",
+};
+```
+
+This ensures the struct compiles with the new field and that tests use an
+explicit value rather than inheriting from the environment.
+
+## Configuration
+
+To set the LLM provider that flows into `AMPLIHACK_AGENT_BINARY`:
+
+```bash
+# Option 1: config file (recommended — survives tmux, systemd, ssh)
+mkdir -p ~/.simard
+echo 'llm_provider = "copilot"' > ~/.simard/config.toml
+
+# Option 2: env var (wins over config file when set)
+export SIMARD_LLM_PROVIDER=copilot
+```
+
+See [Configure LLM provider](../howto/configure-llm-provider.md) for the
+full operator guide.
+
+## Related
+
+- [Config-driven subprocess env (concept)](../concepts/config-driven-subprocess-env.md) — design rationale
+- [Configure LLM provider (how-to)](../howto/configure-llm-provider.md) — operator guide
+- [Disk health API](./disk-health-api.md) — disk health integration
+- [Runtime contracts](./runtime-contracts.md) — broader runtime contract surface

--- a/src/disk_health.rs
+++ b/src/disk_health.rs
@@ -20,6 +20,7 @@ use std::process::Command;
 use serde::Deserialize;
 
 use crate::error::{SimardError, SimardResult};
+use crate::runtime_config::RuntimeConfig;
 
 const ADAPTER_TAG: &str = "disk-health-check";
 const RECIPE_FILENAME: &str = "disk-health-check.yaml";
@@ -105,8 +106,11 @@ pub fn run_disk_health_check(
             ),
         })?;
 
+    let agent_binary = RuntimeConfig::load()?.llm_provider.agent_binary_value();
+
     let output = Command::new("recipe-runner-rs")
         .arg(recipe_path.as_os_str())
+        .env("AMPLIHACK_AGENT_BINARY", agent_binary)
         .arg("-c")
         .arg(format!("state_root={}", state_root.display()))
         .output()

--- a/src/disk_health.rs
+++ b/src/disk_health.rs
@@ -432,7 +432,11 @@ ACTION: cleaned shared-target dir
         std::fs::create_dir_all(&recipe_dir).unwrap();
         std::fs::write(recipe_dir.join(RECIPE_FILENAME), "name: test").unwrap();
 
+        // Ensure RuntimeConfig::load() succeeds (CI has no config.toml).
+        // SAFETY: test-only, single-threaded access to env var.
+        unsafe { std::env::set_var("SIMARD_LLM_PROVIDER", "copilot") };
         let result = run_disk_health_check(tmp.path(), tmp.path());
+        unsafe { std::env::remove_var("SIMARD_LLM_PROVIDER") };
         assert!(result.is_err());
         let err = result.unwrap_err();
         match &err {

--- a/src/goal_curation/recipe_progress_checker.rs
+++ b/src/goal_curation/recipe_progress_checker.rs
@@ -57,14 +57,17 @@ fn resolve_recipe_path(repo_root: &std::path::Path) -> Option<PathBuf> {
 /// Recipe-runner-backed progress evidence checker.
 pub struct RecipeProgressChecker {
     recipe_path: PathBuf,
+    agent_binary: &'static str,
 }
 
 impl RecipeProgressChecker {
     pub fn new(repo_root: &std::path::Path) -> Option<Self> {
         let recipe_path = resolve_recipe_path(repo_root)?;
+        let agent_binary = crate::session_builder::LlmProvider::resolve_agent_binary()?;
         // Verify recipe-runner-rs is available
         if Command::new("recipe-runner-rs")
             .arg("--version")
+            .env("AMPLIHACK_AGENT_BINARY", agent_binary)
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .status()
@@ -72,7 +75,10 @@ impl RecipeProgressChecker {
         {
             return None;
         }
-        Some(Self { recipe_path })
+        Some(Self {
+            recipe_path,
+            agent_binary,
+        })
     }
 }
 
@@ -103,6 +109,7 @@ impl ProgressEvidenceChecker for RecipeProgressChecker {
 
         let result = Command::new("recipe-runner-rs")
             .arg(self.recipe_path.as_os_str())
+            .env("AMPLIHACK_AGENT_BINARY", self.agent_binary)
             .arg("-c")
             .arg(format!("goal_id={}", goal.id))
             .arg("-c")
@@ -226,6 +233,7 @@ mod tests {
     fn downward_move_is_auto_accepted_without_recipe_call() {
         let checker = RecipeProgressChecker {
             recipe_path: PathBuf::from("/nonexistent/recipe.yaml"),
+            agent_binary: "copilot",
         };
         let g = goal_with_activity(None);
         match checker.check(&g, 80, 50, Utc::now()) {
@@ -240,6 +248,7 @@ mod tests {
     fn no_change_is_auto_accepted() {
         let checker = RecipeProgressChecker {
             recipe_path: PathBuf::from("/nonexistent/recipe.yaml"),
+            agent_binary: "copilot",
         };
         let g = goal_with_activity(None);
         assert!(matches!(
@@ -252,6 +261,7 @@ mod tests {
     fn upward_claim_with_missing_binary_falls_back_to_accept() {
         let checker = RecipeProgressChecker {
             recipe_path: PathBuf::from("/nonexistent/recipe.yaml"),
+            agent_binary: "copilot",
         };
         let g = goal_with_activity(Some("working on it"));
         match checker.check(&g, 10, 20, Utc::now()) {

--- a/src/ooda_brain/recipe_decide.rs
+++ b/src/ooda_brain/recipe_decide.rs
@@ -51,14 +51,17 @@ fn resolve_recipe_path(repo_root: &std::path::Path) -> Option<PathBuf> {
 /// Recipe-runner-backed decide brain.
 pub struct RecipeDecideBrain {
     recipe_path: PathBuf,
+    agent_binary: &'static str,
 }
 
 impl RecipeDecideBrain {
     /// Construct if recipe file and recipe-runner-rs binary are both available.
     pub fn new(repo_root: &std::path::Path) -> Option<Self> {
         let recipe_path = resolve_recipe_path(repo_root)?;
+        let agent_binary = crate::session_builder::LlmProvider::resolve_agent_binary()?;
         if Command::new("recipe-runner-rs")
             .arg("--version")
+            .env("AMPLIHACK_AGENT_BINARY", agent_binary)
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .status()
@@ -66,7 +69,10 @@ impl RecipeDecideBrain {
         {
             return None;
         }
-        Some(Self { recipe_path })
+        Some(Self {
+            recipe_path,
+            agent_binary,
+        })
     }
 }
 
@@ -74,6 +80,7 @@ impl OodaDecideBrain for RecipeDecideBrain {
     fn judge_decision(&self, ctx: &DecideContext) -> SimardResult<DecideJudgment> {
         let output = Command::new("recipe-runner-rs")
             .arg(self.recipe_path.as_os_str())
+            .env("AMPLIHACK_AGENT_BINARY", self.agent_binary)
             .arg("-c")
             .arg(format!(
                 "goal_id={}",
@@ -445,6 +452,7 @@ mod tests {
         // Construct with a fake path to bypass the recipe file check
         let brain = RecipeDecideBrain {
             recipe_path: PathBuf::from("/nonexistent/recipe.yaml"),
+            agent_binary: "copilot",
         };
         let ctx = DecideContext {
             goal_id: "test-goal".to_string(),

--- a/src/ooda_brain/recipe_engineer_lifecycle.rs
+++ b/src/ooda_brain/recipe_engineer_lifecycle.rs
@@ -71,14 +71,17 @@ fn resolve_recipe_path(repo_root: &std::path::Path) -> Option<PathBuf> {
 /// Recipe-runner-backed engineer lifecycle brain.
 pub struct RecipeEngineerLifecycleBrain {
     recipe_path: PathBuf,
+    agent_binary: &'static str,
 }
 
 impl RecipeEngineerLifecycleBrain {
     /// Construct if recipe file and recipe-runner-rs binary are both available.
     pub fn new(repo_root: &std::path::Path) -> Option<Self> {
         let recipe_path = resolve_recipe_path(repo_root)?;
+        let agent_binary = crate::session_builder::LlmProvider::resolve_agent_binary()?;
         if Command::new("recipe-runner-rs")
             .arg("--version")
+            .env("AMPLIHACK_AGENT_BINARY", agent_binary)
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .status()
@@ -86,7 +89,10 @@ impl RecipeEngineerLifecycleBrain {
         {
             return None;
         }
-        Some(Self { recipe_path })
+        Some(Self {
+            recipe_path,
+            agent_binary,
+        })
     }
 }
 
@@ -107,6 +113,7 @@ impl OodaBrain for RecipeEngineerLifecycleBrain {
 
         let output = Command::new("recipe-runner-rs")
             .arg(self.recipe_path.as_os_str())
+            .env("AMPLIHACK_AGENT_BINARY", self.agent_binary)
             .arg("-c")
             .arg(format!(
                 "goal_id={}",
@@ -927,6 +934,7 @@ mod tests {
     fn decide_lifecycle_with_missing_binary_returns_error() {
         let brain = RecipeEngineerLifecycleBrain {
             recipe_path: PathBuf::from("/nonexistent/recipe.yaml"),
+            agent_binary: "copilot",
         };
         let ctx = EngineerLifecycleCtx {
             goal_id: "test-goal".into(),

--- a/src/ooda_brain/recipe_orient.rs
+++ b/src/ooda_brain/recipe_orient.rs
@@ -59,14 +59,17 @@ fn resolve_recipe_path(repo_root: &std::path::Path) -> Option<PathBuf> {
 /// Recipe-runner-backed orient brain.
 pub struct RecipeOrientBrain {
     recipe_path: PathBuf,
+    agent_binary: &'static str,
 }
 
 impl RecipeOrientBrain {
     /// Construct if recipe file and recipe-runner-rs binary are both available.
     pub fn new(repo_root: &std::path::Path) -> Option<Self> {
         let recipe_path = resolve_recipe_path(repo_root)?;
+        let agent_binary = crate::session_builder::LlmProvider::resolve_agent_binary()?;
         if Command::new("recipe-runner-rs")
             .arg("--version")
+            .env("AMPLIHACK_AGENT_BINARY", agent_binary)
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .status()
@@ -74,7 +77,10 @@ impl RecipeOrientBrain {
         {
             return None;
         }
-        Some(Self { recipe_path })
+        Some(Self {
+            recipe_path,
+            agent_binary,
+        })
     }
 }
 
@@ -82,6 +88,7 @@ impl OodaOrientBrain for RecipeOrientBrain {
     fn judge_orientation(&self, ctx: &OrientContext) -> SimardResult<OrientJudgment> {
         let output = Command::new("recipe-runner-rs")
             .arg(self.recipe_path.as_os_str())
+            .env("AMPLIHACK_AGENT_BINARY", self.agent_binary)
             .arg("-c")
             .arg(format!(
                 "goal_id={}",
@@ -800,6 +807,7 @@ mod tests {
     fn judge_orientation_with_missing_binary_returns_error() {
         let brain = RecipeOrientBrain {
             recipe_path: PathBuf::from("/nonexistent/recipe.yaml"),
+            agent_binary: "copilot",
         };
         let ctx = OrientContext {
             goal_id: "test-goal".into(),

--- a/src/runtime_config.rs
+++ b/src/runtime_config.rs
@@ -127,10 +127,7 @@ impl RuntimeConfig {
 
     /// Serialize to TOML for writing to disk.
     pub fn to_toml_string(&self) -> String {
-        let provider_str = match self.llm_provider {
-            LlmProvider::Copilot => "copilot",
-            LlmProvider::RustyClawd => "rustyclawd",
-        };
+        let provider_str = self.llm_provider.agent_binary_value();
         format!(
             "# Simard runtime configuration\n\
              # Loaded by every Simard process at startup. Subprocesses\n\
@@ -349,5 +346,33 @@ mod tests {
         let body = "# top comment\n\n# llm_provider = \"rustyclawd\"\nllm_provider = \"copilot\"\n";
         let cfg = RuntimeConfig::from_toml_str(body).unwrap();
         assert_eq!(cfg.llm_provider, LlmProvider::Copilot);
+    }
+
+    // ------------------------------------------------------------------
+    // agent_binary_value mapping (issue #2132)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn agent_binary_value_matches_toml_string_for_copilot() {
+        assert_eq!(LlmProvider::Copilot.agent_binary_value(), "copilot");
+    }
+
+    #[test]
+    fn agent_binary_value_matches_toml_string_for_rustyclawd() {
+        assert_eq!(LlmProvider::RustyClawd.agent_binary_value(), "rustyclawd");
+    }
+
+    #[test]
+    fn config_load_provides_usable_agent_binary_value() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(
+            tmp.path().join(CONFIG_FILE_NAME),
+            "llm_provider = \"copilot\"\n",
+        )
+        .unwrap();
+        with_clean_env(|| {
+            let cfg = RuntimeConfig::load_from(tmp.path()).unwrap();
+            assert_eq!(cfg.llm_provider.agent_binary_value(), "copilot");
+        });
     }
 }

--- a/src/session_builder.rs
+++ b/src/session_builder.rs
@@ -44,6 +44,25 @@ impl LlmProvider {
     pub fn resolve() -> SimardResult<Self> {
         Ok(crate::runtime_config::RuntimeConfig::load()?.llm_provider)
     }
+
+    /// The string value for `AMPLIHACK_AGENT_BINARY` env var on subprocesses.
+    ///
+    /// Each recipe-runner shim sets this on its `Command` so nested agents
+    /// use the correct binary (issue #2132).
+    pub fn agent_binary_value(&self) -> &'static str {
+        match self {
+            Self::Copilot => "copilot",
+            Self::RustyClawd => "rustyclawd",
+        }
+    }
+
+    /// Load config and return the agent binary name, or `None` if config is unavailable.
+    ///
+    /// Convenience wrapper used by recipe-runner shim `new()` constructors
+    /// that return `Option<Self>` and want config failure → `None`.
+    pub fn resolve_agent_binary() -> Option<&'static str> {
+        Some(Self::resolve().ok()?.agent_binary_value())
+    }
 }
 
 /// Builds and opens a `BaseTypeSession` for any operating mode.
@@ -262,5 +281,19 @@ mod tests {
 
         let request = builder.build_request();
         assert_eq!(request.topology, RuntimeTopology::SingleProcess);
+    }
+
+    // ------------------------------------------------------------------
+    // agent_binary_value (issue #2132)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn copilot_agent_binary_value_returns_copilot() {
+        assert_eq!(LlmProvider::Copilot.agent_binary_value(), "copilot");
+    }
+
+    #[test]
+    fn rustyclawd_agent_binary_value_returns_rustyclawd() {
+        assert_eq!(LlmProvider::RustyClawd.agent_binary_value(), "rustyclawd");
     }
 }

--- a/src/stewardship/recipe_merge_judge.rs
+++ b/src/stewardship/recipe_merge_judge.rs
@@ -49,14 +49,17 @@ fn resolve_recipe_path(repo_root: &std::path::Path) -> Option<PathBuf> {
 /// Recipe-runner-backed merge-readiness judge.
 pub struct RecipeMergeJudge {
     recipe_path: PathBuf,
+    agent_binary: &'static str,
 }
 
 impl RecipeMergeJudge {
     /// Construct if recipe file and recipe-runner-rs binary are both available.
     pub fn new(repo_root: &std::path::Path) -> Option<Self> {
         let recipe_path = resolve_recipe_path(repo_root)?;
+        let agent_binary = crate::session_builder::LlmProvider::resolve_agent_binary()?;
         if Command::new("recipe-runner-rs")
             .arg("--version")
+            .env("AMPLIHACK_AGENT_BINARY", agent_binary)
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .status()
@@ -64,7 +67,10 @@ impl RecipeMergeJudge {
         {
             return None;
         }
-        Some(Self { recipe_path })
+        Some(Self {
+            recipe_path,
+            agent_binary,
+        })
     }
 }
 
@@ -77,6 +83,7 @@ impl MergeJudge for RecipeMergeJudge {
     ) -> SimardResult<JudgeOutcome> {
         let output = Command::new("recipe-runner-rs")
             .arg(self.recipe_path.as_os_str())
+            .env("AMPLIHACK_AGENT_BINARY", self.agent_binary)
             .arg("-c")
             .arg(format!("pr_number={pr_number}"))
             .arg("-c")
@@ -183,6 +190,7 @@ mod tests {
     fn kind_returns_recipe() {
         let judge = RecipeMergeJudge {
             recipe_path: PathBuf::from("/nonexistent/recipe.yaml"),
+            agent_binary: "copilot",
         };
         assert_eq!(judge.kind(), MergeJudgeKind::Recipe);
         assert!(judge.kind().is_configured());

--- a/tests/cli_golden.rs
+++ b/tests/cli_golden.rs
@@ -102,7 +102,7 @@ fn version_string_is_semver() {
             .unwrap_or_else(|_| panic!("non-numeric version component '{part}' in {VERSION}"));
     }
     assert_eq!(
-        VERSION, "0.17.0",
+        VERSION, "0.17.1",
         "bump this assertion when version changes"
     );
 }


### PR DESCRIPTION
## Problem

Simard's recipe-runner subprocesses (brains, disk health, meeting) rely on the `AMPLIHACK_AGENT_BINARY` env var. When missing from systemd env, recipe-runner defaults to broken `claude` binary — caused 1341+ brain failures in 24 hours.

## Fix

Read `~/.simard/config.toml` `llm_provider` value and set `AMPLIHACK_AGENT_BINARY` on all `Command::new("recipe-runner-rs")` calls. Config is the single source of truth; env vars override for testing.

### Changes
- `runtime_config.rs`: Added `LlmProvider::agent_binary_value()` method + tests
- `recipe_decide.rs`, `recipe_orient.rs`, `recipe_engineer_lifecycle.rs`: Set `.env("AMPLIHACK_AGENT_BINARY", ...)` from config
- `recipe_progress_checker.rs`, `recipe_merge_judge.rs`: Same
- `disk_health.rs`: Same
- `session_builder.rs`: Reads config.toml as fallback

Closes #2132