### PR TITLE
feat(dashboard): humanize raw action_kind values in Overview and Workboard

### DIFF
--- a/src/operator_commands_dashboard/index_html/part_01.rs
+++ b/src/operator_commands_dashboard/index_html/part_01.rs
@@ -117,6 +117,8 @@ pub(crate) const PART_01: &str = r#"      </div>
       const d=parseTs(ts);if(!d)return ts==null?'—':String(ts);
       try{return d.toLocaleString();}catch(_){return d.toISOString();}
     }
+    const ACTION_KIND_LABELS={spawn_engineer:'Launched sub-agent',progress_assessment:'Checked progress',merge_readiness_check:'Evaluated PR readiness',disk_health_check:'Checked disk health',goal_create:'Created a goal',goal_close:'Closed a goal'};
+    function humanizeActionKind(kind){if(!kind)return'';const label=ACTION_KIND_LABELS[kind];if(label)return label;return kind.replace(/_/g,' ').replace(/^./,c=>c.toUpperCase());}
     function copyLogContent(id){
       const el=document.getElementById(id);if(!el)return;
       navigator.clipboard.writeText(el.textContent||'').then(
@@ -310,7 +312,7 @@ pub(crate) const PART_01: &str = r#"      </div>
               ${latestActions.map(o=>`
                 <div style="padding:.2rem 0;display:flex;gap:.5rem;align-items:baseline">
                   <span>${o.success?'✅':'❌'}</span>
-                  <code style="color:var(--accent)">${esc(o.action_kind||'')}</code>
+                  <code style="color:var(--accent)">${humanizeActionKind(o.action_kind)}</code>
                   <span>${esc(o.action_description||'')}</span>
                   ${o.detail?'<span style="color:#8b949e;font-size:.8rem;max-width:400px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;display:inline-block">'+esc(o.detail.substring(0,120))+'</span>':''}
                 </div>`).join('')}
@@ -346,8 +348,8 @@ pub(crate) const PART_01: &str = r#"      </div>
             <div style="padding:.25rem 0;border-bottom:1px solid var(--border);font-size:.85rem;display:flex;gap:.5rem;align-items:baseline">
               <span style="color:var(--accent);min-width:2rem;font-weight:600">#${a.cycle}</span>
               <span>${a.success?'✅':'❌'}</span>
-              <code>${esc(a.action_kind||'')}</code>
-              <span style="flex:1">${renderActionDetail((function(){var arr=Array.from(a.detail||'');var d=arr.length>200?arr.slice(0,200).join('')+'…':arr.join('');return d||a.action_description||'';})())}</span>
+              <code>${humanizeActionKind(a.action_kind)}</code>
+              <span style="flex:1">${renderActionDetail((function(){var raw=a.detail||'';var kind=a.action_kind||'';if(kind&&raw.startsWith(kind+' dispatched:'))raw=humanizeActionKind(kind)+raw.substring(kind.length);var arr=Array.from(raw);var d=arr.length>200?arr.slice(0,200).join('')+'…':arr.join('');return d||a.action_description||'';})())}</span>
             </div>`).join('');
         }else{
           actEl.innerHTML='<span style="color:#8b949e">No structured action history yet. The agent daemon records actions each cycle.</span>';

--- a/src/operator_commands_dashboard/index_html/part_04.rs
+++ b/src/operator_commands_dashboard/index_html/part_04.rs
@@ -151,7 +151,7 @@ pub(crate) const PART_04: &str = r#"            let fmt;
             const isCurrent=a.action==='current';
             return`<div style="display:flex;gap:.5rem;padding:.35rem 0;border-bottom:1px solid var(--border);font-size:.85rem">
               <span style="color:var(--accent);min-width:2.5rem;font-weight:600">#${a.cycle}</span>
-              <span style="min-width:5rem;color:${isCurrent?'var(--green)':'#8b949e'}">${esc(a.action)}</span>
+              <span style="min-width:5rem;color:${isCurrent?'var(--green)':'#8b949e'}">${humanizeActionKind(a.action)}</span>
               <span style="flex:1">${renderActionDetail(a.result)}</span>
               ${a.at?'<span style="color:#8b949e;font-size:.75rem">'+timeAgo(a.at)+'</span>':''}
             </div>`;


### PR DESCRIPTION
## Summary

Closes #2121

Adds a `humanizeActionKind()` client-side JS utility that converts internal snake_case `action_kind` identifiers to plain-English labels, so first-time dashboard visitors see readable text instead of jargon.

## Mapping table

| Raw `action_kind` | Human label |
|---|---|
| `spawn_engineer` | Launched sub-agent |
| `progress_assessment` | Checked progress |
| `merge_readiness_check` | Evaluated PR readiness |
| `disk_health_check` | Checked disk health |
| `goal_create` | Created a goal |
| `goal_close` | Closed a goal |
| (unknown) | Capitalize + de-snake fallback |

## Changed render sites

1. **Overview tab — "Last Cycle Actions"** (`part_01.rs` ~line 315): `esc(o.action_kind)` → `humanizeActionKind(o.action_kind)`
2. **Overview tab — "Recent Actions"** (`part_01.rs` ~line 351): same, plus detail text prefix humanization (e.g. `spawn_engineer dispatched:` → `Launched sub-agent dispatched:`)
3. **Workboard tab — "Recent Actions"** (`part_04.rs` ~line 154): `esc(a.action)` → `humanizeActionKind(a.action)`

## Verification

- `cargo build` ✅
- `cargo test --lib -- dashboard`: 168 passed, 0 failed ✅
- `cargo test --lib -- index_html`: 45 passed, 0 failed ✅
- Pre-push hooks (fmt, release tests, clippy): all passed ✅
- Diff is 2 files, +6/−4 lines — focused change, no unrelated edits ✅
- Thinking tab's existing humanized rendering unchanged ✅
