### PR TITLE
fix(goal-curator): surface ranked goal titles in reflection output

### DIFF
--- a/src/agent_program/goal_curator/mod.rs
+++ b/src/agent_program/goal_curator/mod.rs
@@ -42,14 +42,21 @@ impl AgentProgram for GoalCuratorProgram {
         outcome: &BaseTypeOutcome,
     ) -> SimardResult<String> {
         let plan = StructuredGoalPlan::parse(&context.objective)?;
+        let top_goals = plan.concise_top_five();
+        let goal_list = if top_goals.is_empty() {
+            "<none>".to_string()
+        } else {
+            top_goals
+        };
         Ok(format!(
-            "Goal curator '{}' processed {} goal updates through '{}' on '{}' from '{}'. Active top goals after curation: {}. Outcome summary: {}.",
+            "Goal curator '{}' processed {} goal updates through '{}' on '{}' from '{}'. Active top goals after curation ({} active): [{}]. Outcome summary: {}.",
             self.descriptor.identity,
             plan.goals.len(),
             context.selected_base_type,
             context.topology,
             context.runtime_node,
             plan.active_goal_count(),
+            goal_list,
             outcome.execution_summary,
         ))
     }

--- a/src/agent_program/goal_curator/tests.rs
+++ b/src/agent_program/goal_curator/tests.rs
@@ -84,6 +84,43 @@ fn goal_curator_reflection_summary_includes_goal_count() {
 }
 
 #[test]
+fn goal_curator_reflection_summary_surfaces_ranked_goal_titles() {
+    let program = GoalCuratorProgram::try_default().expect("create test program");
+    let context = test_context(
+        "goal: Ship v1 | priority=1 | status=active | rationale=deadline\ngoal: Add tests | priority=2 | status=active | rationale=quality",
+    );
+    let summary = program
+        .reflection_summary(&context, &test_outcome())
+        .expect("reflection_summary should succeed");
+    // Spec line 664: reflection must surface actual goal titles, not just a count
+    assert!(
+        summary.contains("Ship v1"),
+        "reflection must include actual goal title 'Ship v1', got: {summary}"
+    );
+    assert!(
+        summary.contains("Add tests"),
+        "reflection must include actual goal title 'Add tests', got: {summary}"
+    );
+    assert!(
+        summary.contains("p1:Ship v1"),
+        "reflection must include priority-prefixed goal, got: {summary}"
+    );
+}
+
+#[test]
+fn goal_curator_reflection_summary_shows_none_when_no_active_goals() {
+    let program = GoalCuratorProgram::try_default().expect("create test program");
+    let context = test_context("goal: Old task | priority=1 | status=completed");
+    let summary = program
+        .reflection_summary(&context, &test_outcome())
+        .expect("reflection_summary should succeed");
+    assert!(
+        summary.contains("<none>"),
+        "reflection with no active goals should show <none>, got: {summary}"
+    );
+}
+
+#[test]
 fn goal_curator_persistence_summary_includes_counts() {
     let program = GoalCuratorProgram::try_default().expect("create test program");
     let context = test_context(


### PR DESCRIPTION
## Summary
Fix goal curator's `reflection_summary()` to surface the actual ranked top-goal list instead of just a count.

## Problem
Per spec line 664, reflection must surface "an active top-goal list surfaced through reflection". However, `reflection_summary()` only called `active_goal_count()`, outputting e.g. `Active top goals after curation: 3` — just a number, not the actual goals.

## Fix
Replaced `active_goal_count()` with `concise_top_five()` in the reflection format string, so the output now includes priority-ranked goal titles and rationales: e.g. `Active top goals after curation (2 active): [p1:Ship v1 (deadline) | p2:Add tests (quality)]`.

When no active goals exist, displays `<none>` instead of `0`.

## Files Changed
- `src/agent_program/goal_curator/mod.rs` — `reflection_summary()` now calls `concise_top_five()`
- `src/agent_program/goal_curator/tests.rs` — 2 new tests verifying ranked titles appear and `<none>` case

## Tests
All 23 goal_curator tests pass:
```
test result: ok. 23 passed; 0 failed; 0 ignored; 0 measured; 4951 filtered out
```

Fixes #2089