### PR TITLE
feat(#2135): add /api/ooda-cycles endpoint and cycle history visualization

### DIFF
--- a/scripts/dashboard-audit/audit.mjs
+++ b/scripts/dashboard-audit/audit.mjs
@@ -189,7 +189,7 @@ const API_PROBES = [
   { path: "/api/pr/1880",        dims: ["per-pr"],      expectMissing: true },
   { path: "/api/brain-failures", dims: ["brain-failure"], expectMissing: true },
   { path: "/api/failures",       dims: ["brain-failure"], expectMissing: true },
-  { path: "/api/ooda-cycles",    dims: ["ooda"],        expectMissing: true },
+  { path: "/api/ooda-cycles",    dims: ["ooda"] },
 ];
 
 async function probeApis(api) {
@@ -406,17 +406,21 @@ function classifyCoverage(routes, apis) {
   // 2. OODA cycle health
   const oodaStatusKeys = apis["/api/status"]?.body?.keys || [];
   const oodaCycleEvidence = oodaStatusKeys.includes("daemon_health") || oodaStatusKeys.includes("ooda_daemon");
+  const oodaCyclesEndpoint = apiOk("/api/ooda-cycles");
   dims.push({
     name: "OODA cycle health",
-    classification: oodaCycleEvidence && tabBySlug["overview"] ? "PARTIAL"
+    classification: oodaCyclesEndpoint && oodaCycleEvidence && tabBySlug["thinking"] ? "PRESENT"
+                  : oodaCycleEvidence && tabBySlug["overview"] ? "PARTIAL"
                   : oodaCycleEvidence ? "PARTIAL"
                   : "MISSING",
-    detail: "Cycle number, phase, last summary, and timestamp are exposed via /api/status.daemon_health, but there is no dedicated OODA tab showing phase transitions over time, no /api/ooda-cycles endpoint, and no inline visualisation of the OODA loop.",
+    detail: oodaCyclesEndpoint
+      ? "Per-cycle history with duration trend is exposed via /api/ooda-cycles; current cycle state via /api/status.daemon_health; visualisation in the Thinking tab."
+      : "Cycle number, phase, last summary, and timestamp are exposed via /api/status.daemon_health, but there is no dedicated OODA tab showing phase transitions over time, no /api/ooda-cycles endpoint, and no inline visualisation of the OODA loop.",
     evidence: [
       apiOk("/api/status")        ? `API /api/status surfaces daemon_health.cycle_number, daemon_health.cycle_phase, daemon_health.actions_taken, daemon_health.cycle_duration_secs (keys: ${oodaStatusKeys.join(", ")})` : "API /api/status → not 200",
-      apis["/api/ooda-cycles"]    ? `API /api/ooda-cycles → ${apis["/api/ooda-cycles"].status} (no per-cycle history endpoint)` : null,
+      oodaCyclesEndpoint           ? `API /api/ooda-cycles → 200 (per-cycle history with duration trend)` : (apis["/api/ooda-cycles"] ? `API /api/ooda-cycles → ${apis["/api/ooda-cycles"].status}` : null),
       tabBySlug["overview"]       ? `Tab #tab-overview screenshot: ${tabBySlug["overview"].screenshot}` : "no #tab-overview discovered",
-      tabBySlug["thinking"]       ? `Tab #tab-thinking present — but classified separately from OODA cycle metrics: ${tabBySlug["thinking"].screenshot}` : null,
+      tabBySlug["thinking"]       ? `Tab #tab-thinking present with cycle history visualisation: ${tabBySlug["thinking"].screenshot}` : null,
     ].filter(Boolean),
   });
 

--- a/src/operator_commands_dashboard/index_html/part_00.rs
+++ b/src/operator_commands_dashboard/index_html/part_00.rs
@@ -333,6 +333,11 @@ pub(crate) const PART_00: &str = r#"<!DOCTYPE html>
   <div class="tab-content" id="tab-thinking">
     <h1 class="page-h1">Thinking</h1>
     <p class="page-lede">A live stream of the daemon's internal reasoning between actions, showing what it considered before deciding what to do next.</p>
+    <div class="card" style="margin-bottom:1rem">
+      <h2>Cycle History <button class="btn" onclick="fetchOodaCycles()">Refresh</button></h2>
+      <div id="ooda-cycle-trend" style="margin-bottom:.75rem"><span class="loading">Loading…</span></div>
+      <div id="ooda-cycle-history"><span class="loading">Loading…</span></div>
+    </div>
     <div class="card">
       <h2>Agent Internal Reasoning <button class="btn" onclick="fetchThinking()">Refresh</button></h2>
       <div id="thinking-timeline"><span class="loading">Loading…</span></div>

--- a/src/operator_commands_dashboard/index_html/part_01.rs
+++ b/src/operator_commands_dashboard/index_html/part_01.rs
@@ -226,7 +226,7 @@ pub(crate) const PART_01: &str = r#"      </div>
         if(tab.dataset.tab==='traces') fetchTraces();
         if(tab.dataset.tab==='chat') initChat();
         if(tab.dataset.tab==='workboard') {fetchWorkboard();tabRefreshTimers.wb=setInterval(fetchWorkboard,30000);}
-        if(tab.dataset.tab==='thinking') {fetchThinking();tabRefreshTimers.thinking=setInterval(fetchThinking,30000);}
+        if(tab.dataset.tab==='thinking') {fetchThinking();fetchOodaCycles();tabRefreshTimers.thinking=setInterval(fetchThinking,30000);tabRefreshTimers.oodaCycles=setInterval(fetchOodaCycles,30000);}
         if(tab.dataset.tab==='brain-failures') {fetchBrainFailures();tabRefreshTimers.brainFailures=setInterval(fetchBrainFailures,30000);}
         if(tab.dataset.tab==='merge-decisions') {fetchMergeJudge();tabRefreshTimers.mergeJudge=setInterval(fetchMergeJudge,30000);}
         if(tab.dataset.tab==='pr-readiness') {fetchPrReadiness();tabRefreshTimers.prReadiness=setInterval(fetchPrReadiness,30000);}

--- a/src/operator_commands_dashboard/index_html/part_04.rs
+++ b/src/operator_commands_dashboard/index_html/part_04.rs
@@ -279,6 +279,72 @@ pub(crate) const PART_04: &str = r#"            let fmt;
       }catch(e){document.getElementById('thinking-timeline').innerHTML='<span class="err">Failed to load: '+esc(e.toString())+'</span>';}
     }
 
+    /* --- OODA Cycle History (issue #2135) --- */
+    async function fetchOodaCycles(){
+      try{
+        const d=await apiFetch('/api/ooda-cycles');
+        const trendEl=document.getElementById('ooda-cycle-trend');
+        const histEl=document.getElementById('ooda-cycle-history');
+        const cycles=d.cycles||[];
+        const trend=d.duration_trend||{};
+        // Render trend summary
+        const trendColors={improving:'var(--green)',degrading:'var(--red)',stable:'var(--yellow)',insufficient_data:'#8b949e'};
+        const trendLabels={improving:'↓ Improving',degrading:'↑ Degrading',stable:'→ Stable',insufficient_data:'— Not enough data'};
+        const dir=trend.direction||'insufficient_data';
+        const trendColor=trendColors[dir]||'#8b949e';
+        let trendHtml=`<div style="display:flex;gap:1.5rem;align-items:center;flex-wrap:wrap">
+          <div><strong style="color:${trendColor}">${trendLabels[dir]||dir}</strong></div>
+          <div style="color:#8b949e;font-size:.85rem">${d.total_cycles||0} cycles recorded</div>`;
+        if(trend.recent_avg_secs!=null){
+          trendHtml+=`<div style="font-size:.85rem">Recent avg: <strong>${trend.recent_avg_secs}s</strong></div>
+            <div style="font-size:.85rem">Older avg: <strong>${trend.older_avg_secs}s</strong></div>
+            <div style="font-size:.85rem">Change: <strong style="color:${trendColor}">${trend.change_pct>0?'+':''}${trend.change_pct}%</strong></div>`;
+        }
+        if(trend.detail){trendHtml+=`<div style="color:#8b949e;font-size:.8rem">${esc(trend.detail)}</div>`;}
+        trendHtml+='</div>';
+        trendEl.innerHTML=trendHtml;
+        // Duration bar chart (inline SVG)
+        if(cycles.length){
+          const durations=cycles.map(c=>c.duration_secs||0).reverse();
+          const nums=cycles.map(c=>c.cycle_number).reverse();
+          const maxD=Math.max(...durations,1);
+          const barW=Math.max(6,Math.min(24,Math.floor(600/durations.length)));
+          const chartH=80;
+          const borderClr='var(--border)';
+          const bars=durations.map((d,i)=>{
+            const h=Math.max(2,(d/maxD)*chartH);
+            const x=i*(barW+2);
+            const color=d===0?borderClr:'var(--accent)';
+            return `<rect x="${x}" y="${chartH-h}" width="${barW}" height="${h}" fill="${color}" rx="1"><title>Cycle ${nums[i]}: ${d}s</title></rect>`;
+          }).join('');
+          const svgW=durations.length*(barW+2);
+          trendEl.innerHTML+=`<div style="margin-top:.5rem;overflow-x:auto"><svg width="${svgW}" height="${chartH+16}" style="display:block"><g>${bars}</g><line x1="0" y1="${chartH}" x2="${svgW}" y2="${chartH}" stroke="${borderClr}" stroke-width="1"/></svg></div>`;
+        }
+        // History table
+        if(!cycles.length){histEl.innerHTML='<span style="color:#8b949e">No cycle history available. Run the agent daemon to generate cycle data.</span>';return;}
+        histEl.innerHTML=`<div style="overflow-x:auto"><table class="proc-table">
+          <tr><th>#</th><th>Phase</th><th>Duration</th><th>Actions</th><th>Summary</th><th>Time</th></tr>
+          ${cycles.map(c=>{
+            const phaseColors={act:'var(--green)',decide:'#a371f7',orient:'var(--yellow)',observe:'var(--accent)',unknown:'#8b949e'};
+            const pColor=phaseColors[c.phase]||'#8b949e';
+            const dur=c.duration_secs!=null?c.duration_secs+'s':'—';
+            const summary=c.summary||'';
+            const shortSummary=summary.length>120?summary.substring(0,120)+'…':summary;
+            return `<tr>
+              <td style="font-weight:600;color:var(--accent)">${c.cycle_number}</td>
+              <td><span style="color:${pColor}">${esc(c.phase)}</span></td>
+              <td>${dur}</td>
+              <td>${c.action_count||0}</td>
+              <td style="font-size:.8rem;max-width:400px">${esc(shortSummary)}</td>
+              <td style="color:#8b949e;font-size:.8rem;white-space:nowrap">${c.timestamp?timeAgo(c.timestamp):'—'}</td>
+            </tr>`;}).join('')}
+        </table></div>`;
+      }catch(e){
+        const el=document.getElementById('ooda-cycle-history');
+        if(el) el.innerHTML='<span class="err">Failed to load cycle history: '+esc(e.toString())+'</span>';
+      }
+    }
+
     /* --- Brain Failures (issue #2043) --- */
     async function fetchBrainFailures(){
       try{

--- a/src/operator_commands_dashboard/mod.rs
+++ b/src/operator_commands_dashboard/mod.rs
@@ -15,6 +15,7 @@ mod merge_judge;
 mod merge_readiness;
 mod metrics;
 mod monitoring;
+mod ooda_cycles;
 mod pr_readiness;
 mod registry;
 pub(crate) mod routes;

--- a/src/operator_commands_dashboard/ooda_cycles.rs
+++ b/src/operator_commands_dashboard/ooda_cycles.rs
@@ -1,0 +1,374 @@
+//! `/api/ooda-cycles` endpoint — per-cycle history with duration trend
+//! (issue #2135).
+//!
+//! Returns the last N OODA cycles from `cycle_reports/cycle_*.json` with:
+//!   - cycle_number, phase (final phase of the cycle), duration_secs,
+//!     actions_taken, summary, timestamp.
+//!
+//! This lets the dashboard render a time-series of cycle durations and
+//! actions so Simard-as-reader can answer: "Are my cycles getting faster
+//! or slower?" and "Did my last cycle improve things?"
+
+use axum::Json;
+use serde_json::{Value, json};
+
+use super::current_work::read_recent_cycle_reports;
+use super::routes::resolve_state_root;
+
+/// Maximum number of cycles to return (most recent first).
+const MAX_CYCLES: usize = 50;
+
+pub(crate) async fn ooda_cycles() -> Json<Value> {
+    let state_root = resolve_state_root();
+    let raw_reports = read_recent_cycle_reports(&state_root, MAX_CYCLES);
+
+    let mut cycles: Vec<Value> = Vec::new();
+    let mut durations: Vec<f64> = Vec::new();
+
+    for entry in &raw_reports {
+        let cycle_number = entry
+            .get("cycle_number")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+
+        // The entry is either {cycle_number, report: {...}} or {cycle_number, summary: "..."}
+        let report = entry.get("report");
+
+        let timestamp = report
+            .and_then(|r| r.get("timestamp"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        let duration_secs = report
+            .and_then(|r| r.get("duration_secs"))
+            .and_then(|v| v.as_f64())
+            .or_else(|| {
+                report
+                    .and_then(|r| r.get("cycle_duration_secs"))
+                    .and_then(|v| v.as_f64())
+            });
+
+        let actions_taken = extract_actions_taken(report);
+
+        let summary = report
+            .and_then(|r| r.get("summary"))
+            .and_then(|v| v.as_str())
+            .or_else(|| entry.get("summary").and_then(|v| v.as_str()))
+            .unwrap_or("")
+            .to_string();
+
+        // Determine the final phase from outcomes or planned_actions
+        let phase = extract_final_phase(report);
+
+        let action_count = actions_taken.len();
+
+        if let Some(d) = duration_secs {
+            durations.push(d);
+        }
+
+        cycles.push(json!({
+            "cycle_number": cycle_number,
+            "phase": phase,
+            "duration_secs": duration_secs,
+            "actions_taken": actions_taken,
+            "action_count": action_count,
+            "summary": summary,
+            "timestamp": timestamp,
+        }));
+    }
+
+    // Compute trend: average of first half vs second half of durations.
+    let trend = compute_duration_trend(&durations);
+
+    Json(json!({
+        "cycles": cycles,
+        "total_cycles": cycles.len(),
+        "duration_trend": trend,
+        "timestamp": chrono::Utc::now().to_rfc3339(),
+    }))
+}
+
+/// Extract a list of action descriptions from a cycle report.
+fn extract_actions_taken(report: Option<&Value>) -> Vec<String> {
+    let mut actions = Vec::new();
+    let report = match report {
+        Some(r) => r,
+        None => return actions,
+    };
+
+    // Prefer outcomes (completed actions)
+    if let Some(outcomes) = report.get("outcomes").and_then(|v| v.as_array()) {
+        for o in outcomes {
+            let kind = o
+                .get("action_kind")
+                .and_then(|v| v.as_str())
+                .unwrap_or("action");
+            let desc = o
+                .get("action_description")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let success = o.get("success").and_then(|v| v.as_bool()).unwrap_or(true);
+            let status = if success { "ok" } else { "failed" };
+            actions.push(format!("{kind} [{status}]: {desc}"));
+        }
+        return actions;
+    }
+
+    // Fall back to planned_actions
+    if let Some(planned) = report.get("planned_actions").and_then(|v| v.as_array()) {
+        for a in planned {
+            let kind = a.get("kind").and_then(|v| v.as_str()).unwrap_or("action");
+            let desc = a.get("description").and_then(|v| v.as_str()).unwrap_or("");
+            actions.push(format!("{kind}: {desc}"));
+        }
+    }
+
+    actions
+}
+
+/// Determine the final phase reached in a cycle from the report structure.
+fn extract_final_phase(report: Option<&Value>) -> String {
+    let report = match report {
+        Some(r) => r,
+        None => return "unknown".to_string(),
+    };
+
+    if report
+        .get("outcomes")
+        .and_then(|v| v.as_array())
+        .map(|a| !a.is_empty())
+        == Some(true)
+    {
+        return "act".to_string();
+    }
+    if report
+        .get("planned_actions")
+        .and_then(|v| v.as_array())
+        .map(|a| !a.is_empty())
+        == Some(true)
+    {
+        return "decide".to_string();
+    }
+    if report
+        .get("priorities")
+        .and_then(|v| v.as_array())
+        .map(|a| !a.is_empty())
+        == Some(true)
+    {
+        return "orient".to_string();
+    }
+    if report.get("observation").is_some() {
+        return "observe".to_string();
+    }
+
+    "unknown".to_string()
+}
+
+/// Compute a simple duration trend: "improving" if the second half is
+/// faster, "degrading" if slower, "stable" if within 10%, or "insufficient"
+/// if fewer than 4 data points.
+fn compute_duration_trend(durations: &[f64]) -> Value {
+    if durations.len() < 4 {
+        return json!({
+            "direction": "insufficient_data",
+            "detail": "Need at least 4 cycles with duration data to compute trend",
+        });
+    }
+
+    let mid = durations.len() / 2;
+    // durations is newest-first, so second half = older cycles
+    let recent_avg: f64 = durations[..mid].iter().sum::<f64>() / mid as f64;
+    let older_avg: f64 = durations[mid..].iter().sum::<f64>() / (durations.len() - mid) as f64;
+
+    if older_avg == 0.0 {
+        return json!({
+            "direction": "insufficient_data",
+            "detail": "Older cycles have zero duration",
+        });
+    }
+
+    let change_pct = ((recent_avg - older_avg) / older_avg) * 100.0;
+
+    let direction = if change_pct < -10.0 {
+        "improving"
+    } else if change_pct > 10.0 {
+        "degrading"
+    } else {
+        "stable"
+    };
+
+    json!({
+        "direction": direction,
+        "recent_avg_secs": (recent_avg * 10.0).round() / 10.0,
+        "older_avg_secs": (older_avg * 10.0).round() / 10.0,
+        "change_pct": (change_pct * 10.0).round() / 10.0,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_final_phase_from_outcomes() {
+        let report = json!({
+            "outcomes": [{"action_kind": "advance-goal", "success": true}],
+        });
+        assert_eq!(extract_final_phase(Some(&report)), "act");
+    }
+
+    #[test]
+    fn extract_final_phase_from_planned_actions() {
+        let report = json!({
+            "planned_actions": [{"kind": "advance-goal", "description": "test"}],
+        });
+        assert_eq!(extract_final_phase(Some(&report)), "decide");
+    }
+
+    #[test]
+    fn extract_final_phase_from_priorities() {
+        let report = json!({
+            "priorities": [{"goal_id": "g1", "urgency": 0.8}],
+        });
+        assert_eq!(extract_final_phase(Some(&report)), "orient");
+    }
+
+    #[test]
+    fn extract_final_phase_from_observation() {
+        let report = json!({
+            "observation": {"goal_count": 3},
+        });
+        assert_eq!(extract_final_phase(Some(&report)), "observe");
+    }
+
+    #[test]
+    fn extract_final_phase_none_returns_unknown() {
+        assert_eq!(extract_final_phase(None), "unknown");
+    }
+
+    #[test]
+    fn extract_final_phase_empty_report() {
+        let report = json!({});
+        assert_eq!(extract_final_phase(Some(&report)), "unknown");
+    }
+
+    #[test]
+    fn extract_actions_taken_from_outcomes() {
+        let report = json!({
+            "outcomes": [
+                {"action_kind": "advance-goal", "action_description": "opened PR", "success": true},
+                {"action_kind": "consolidate-memory", "action_description": "merged 10 facts", "success": false},
+            ],
+        });
+        let actions = extract_actions_taken(Some(&report));
+        assert_eq!(actions.len(), 2);
+        assert!(actions[0].contains("advance-goal"));
+        assert!(actions[0].contains("[ok]"));
+        assert!(actions[1].contains("[failed]"));
+    }
+
+    #[test]
+    fn extract_actions_taken_from_planned() {
+        let report = json!({
+            "planned_actions": [{"kind": "advance-goal", "description": "do thing"}],
+        });
+        let actions = extract_actions_taken(Some(&report));
+        assert_eq!(actions.len(), 1);
+        assert!(actions[0].contains("advance-goal"));
+    }
+
+    #[test]
+    fn extract_actions_taken_none() {
+        assert!(extract_actions_taken(None).is_empty());
+    }
+
+    #[test]
+    fn compute_trend_insufficient_data() {
+        let trend = compute_duration_trend(&[1.0, 2.0]);
+        assert_eq!(
+            trend.get("direction").and_then(|v| v.as_str()),
+            Some("insufficient_data")
+        );
+    }
+
+    #[test]
+    fn compute_trend_improving() {
+        // newer cycles are faster (smaller duration)
+        let durations = vec![10.0, 12.0, 20.0, 25.0];
+        let trend = compute_duration_trend(&durations);
+        assert_eq!(
+            trend.get("direction").and_then(|v| v.as_str()),
+            Some("improving")
+        );
+    }
+
+    #[test]
+    fn compute_trend_degrading() {
+        // newer cycles are slower
+        let durations = vec![25.0, 30.0, 10.0, 12.0];
+        let trend = compute_duration_trend(&durations);
+        assert_eq!(
+            trend.get("direction").and_then(|v| v.as_str()),
+            Some("degrading")
+        );
+    }
+
+    #[test]
+    fn compute_trend_stable() {
+        let durations = vec![10.0, 10.5, 10.2, 10.3];
+        let trend = compute_duration_trend(&durations);
+        assert_eq!(
+            trend.get("direction").and_then(|v| v.as_str()),
+            Some("stable")
+        );
+    }
+
+    #[test]
+    fn ooda_cycles_reads_from_disk() {
+        // Integration test: create temp cycle reports and verify the handler reads them.
+        let dir = tempfile::tempdir().unwrap();
+        let cycle_dir = dir.path().join("cycle_reports");
+        std::fs::create_dir_all(&cycle_dir).unwrap();
+
+        let report1 = json!({
+            "cycle_number": 1,
+            "timestamp": "2026-05-27T10:00:00Z",
+            "duration_secs": 120.0,
+            "summary": "First cycle",
+            "observation": {"goal_count": 2},
+            "priorities": [{"goal_id": "g1", "urgency": 0.8, "reason": "test"}],
+            "planned_actions": [{"kind": "advance-goal", "description": "test", "goal_id": "g1"}],
+            "outcomes": [{"action_kind": "advance-goal", "action_description": "opened PR", "success": true}],
+        });
+        std::fs::write(
+            cycle_dir.join("cycle_1.json"),
+            serde_json::to_string(&report1).unwrap(),
+        )
+        .unwrap();
+
+        let report2 = json!({
+            "cycle_number": 2,
+            "timestamp": "2026-05-27T10:10:00Z",
+            "duration_secs": 90.0,
+            "summary": "Second cycle",
+            "outcomes": [{"action_kind": "consolidate-memory", "action_description": "merged facts", "success": true}],
+        });
+        std::fs::write(
+            cycle_dir.join("cycle_2.json"),
+            serde_json::to_string(&report2).unwrap(),
+        )
+        .unwrap();
+
+        // read_recent_cycle_reports should find both
+        let reports = read_recent_cycle_reports(dir.path(), 50);
+        assert_eq!(reports.len(), 2);
+
+        // Verify newest first
+        let first_num = reports[0]
+            .get("cycle_number")
+            .and_then(|v| v.as_u64())
+            .unwrap();
+        assert_eq!(first_num, 2);
+    }
+}

--- a/src/operator_commands_dashboard/routes.rs
+++ b/src/operator_commands_dashboard/routes.rs
@@ -21,6 +21,7 @@ use super::merge_judge::merge_judge_decisions;
 use super::merge_readiness::merge_readiness;
 use super::metrics::{memory_metrics, ooda_thinking};
 use super::monitoring::{costs, get_budget, metrics, set_budget};
+use super::ooda_cycles::ooda_cycles;
 use super::pr_readiness::pr_readiness;
 use super::registry::{
     agent_graph, build_lock_force_release, build_lock_status, registry_deregister, registry_list,
@@ -72,6 +73,7 @@ pub fn build_router() -> Router {
         .route("/api/workboard", get(workboard))
         .route("/api/current-work", get(current_work))
         .route("/api/ooda-thinking", get(ooda_thinking))
+        .route("/api/ooda-cycles", get(ooda_cycles))
         .route("/api/brain-failures", get(brain_failures))
         .route("/api/prs", get(pr_readiness))
         .route("/api/subagent-sessions", get(subagent_sessions))


### PR DESCRIPTION
## Summary

Implements the OODA cycle history endpoint and dashboard visualization (issue #2135) so Simard-as-reader can answer: "Are my cycles getting faster or slower?" and "Did my last cycle improve things?"

## Changes

### Backend: `/api/ooda-cycles` endpoint (`ooda_cycles.rs`)
- Returns last 50 cycles with: `cycle_number`, `phase`, `duration_secs`, `actions_taken`, `summary`, `timestamp`
- Computes duration trend (improving/degrading/stable) by comparing recent vs older cycle averages
- Reuses existing `read_recent_cycle_reports()` for disk reads — no new file format or data source

### Frontend: Cycle History visualization (Thinking tab)
- **Trend summary**: direction indicator, cycle count, average durations, % change
- **SVG bar chart**: inline duration bars for visual trend (responsive width)
- **History table**: cycle#, phase (color-coded), duration, action count, summary, timestamp
- Auto-refreshes every 30s when Thinking tab is active

### Audit script update (`audit.mjs`)
- OODA cycle health dimension #2 now classifies as **PRESENT** when `/api/ooda-cycles` → 200, daemon_health evidence exists, and thinking tab is present
- Removed `expectMissing` flag from `/api/ooda-cycles` probe

## Tests
- 14 unit tests in `ooda_cycles::tests` covering:
  - Phase extraction (act/decide/orient/observe/unknown)
  - Action parsing from outcomes and planned_actions
  - Duration trend computation (improving/degrading/stable/insufficient)
  - Integration test with temp cycle report files
- All 182 existing dashboard tests pass
- All 22 tab_meta cross-check tests pass
- `cargo fmt`, `cargo clippy`, `cargo build` all clean

## PR #2139 e2e-dashboard failure note
The `e2e-dashboard` CI failure on PR #2139 is a case-sensitivity mismatch: the test expects lowercase `"edit"` but the humanized action_kind renders as `"Edit"`. This is a bug in PR #2139's e2e test assertion, not a pre-existing flake. Unrelated to this PR.

Closes #2135