### PR TITLE
fix: unify meeting /decision to use structured MeetingDecision with rationale (#2086)

### DIFF
--- a/src/meeting_backend/closing.rs
+++ b/src/meeting_backend/closing.rs
@@ -178,8 +178,14 @@ impl MeetingBackend {
         // Prepend explicit decisions recorded inline via `/decision`.
         // Dedup against heuristic-extracted decisions by case-insensitive
         // string equality. Issue #1730 seam (b).
+        // Explicit decisions carry operator-supplied rationale (issue #2086)
+        // so they are preserved as-is in `structured_decisions` below.
         if !self.explicit_decisions.is_empty() {
-            let mut explicit_first: Vec<String> = self.explicit_decisions.clone();
+            let mut explicit_first: Vec<String> = self
+                .explicit_decisions
+                .iter()
+                .map(|d| d.description.clone())
+                .collect();
             for inferred in decisions.drain(..) {
                 let lower = inferred.to_lowercase();
                 if !explicit_first.iter().any(|d| d.to_lowercase() == lower) {
@@ -271,19 +277,50 @@ impl MeetingBackend {
             }
         }
 
-        // ── Build structured decisions once (issue #1954) ──
+        // ── Build structured decisions once (issue #1954, #2086) ──
         // Threaded through both the legacy handoff and the bundle so
         // rationale/participants extracted from the live conversation
         // aren't reduced to `String::new()` placeholders downstream.
+        // Explicit decisions carry operator-supplied rationale (issue #2086);
+        // non-empty rationale from the operator takes precedence over the
+        // heuristic extractor.
+        let explicit_map: std::collections::HashMap<
+            String,
+            &crate::meeting_facilitator::MeetingDecision,
+        > = self
+            .explicit_decisions
+            .iter()
+            .map(|d| (d.description.to_lowercase(), d))
+            .collect();
         let structured_decisions: Vec<crate::meeting_facilitator::MeetingDecision> = decisions
             .iter()
             .map(|d| {
-                let rationale = persist::extract_decision_rationale_pub(d, &self.history);
-                let participants = persist::extract_decision_participants_pub(d, &self.history);
-                crate::meeting_facilitator::MeetingDecision {
-                    description: d.clone(),
-                    rationale,
-                    participants,
+                if let Some(explicit) = explicit_map.get(&d.to_lowercase()) {
+                    // Use operator-supplied rationale if non-empty, otherwise
+                    // fall back to heuristic extraction from context.
+                    let rationale = if explicit.rationale.is_empty() {
+                        persist::extract_decision_rationale_pub(d, &self.history)
+                    } else {
+                        explicit.rationale.clone()
+                    };
+                    let participants = if explicit.participants.is_empty() {
+                        persist::extract_decision_participants_pub(d, &self.history)
+                    } else {
+                        explicit.participants.clone()
+                    };
+                    crate::meeting_facilitator::MeetingDecision {
+                        description: d.clone(),
+                        rationale,
+                        participants,
+                    }
+                } else {
+                    let rationale = persist::extract_decision_rationale_pub(d, &self.history);
+                    let participants = persist::extract_decision_participants_pub(d, &self.history);
+                    crate::meeting_facilitator::MeetingDecision {
+                        description: d.clone(),
+                        rationale,
+                        participants,
+                    }
                 }
             })
             .collect();
@@ -379,6 +416,17 @@ impl MeetingBackend {
         // meeting_handoff.md, transcript.json}. Independent of the legacy
         // OODA artifact above so existing downstream consumers keep working
         // while new consumers can rely on the canonical layout.
+        //
+        // Issue #2086: cap the conversation history in the bundle to
+        // MAX_HANDOFF_HISTORY recent turns. The full transcript is preserved
+        // in the standalone transcript.json written earlier; the bundle
+        // carries concise context, not the bloated transcript.
+        let handoff_history: &[super::types::ConversationMessage] =
+            if self.history.len() > super::MAX_HANDOFF_HISTORY {
+                &self.history[self.history.len() - super::MAX_HANDOFF_HISTORY..]
+            } else {
+                &self.history
+            };
         let bundle_open_questions: Vec<crate::meeting_facilitator::OpenQuestion> = open_questions
             .iter()
             .cloned()
@@ -394,7 +442,7 @@ impl MeetingBackend {
             &self.topic,
             &summary_text,
             Some(&self.started_at),
-            &self.history,
+            handoff_history,
             &action_items,
             &decisions,
             bundle_open_questions,
@@ -529,7 +577,11 @@ impl MeetingBackend {
         // `/decision` or `/action` before `/close` doesn't lose them
         // to the partial-fast-path.
         let action_items: Vec<super::types::HandoffActionItem> = self.explicit_action_items.clone();
-        let decisions: Vec<String> = self.explicit_decisions.clone();
+        let decisions: Vec<String> = self
+            .explicit_decisions
+            .iter()
+            .map(|d| d.description.clone())
+            .collect();
         let open_questions: Vec<String> = self.explicit_questions.clone();
         let themes: Vec<String> = self.themes.clone();
 
@@ -590,19 +642,45 @@ impl MeetingBackend {
             })
             .collect();
 
-        // Issue #1954: extract rationale/participants from the live
-        // history rather than emitting placeholder `String::new()`
-        // values. Same heuristics as the happy-path `close()` flow so
-        // partial closes stay informative.
+        // Issue #1954, #2086: extract rationale/participants from the live
+        // history rather than emitting placeholder `String::new()` values.
+        // Operator-supplied rationale from `/decision --rationale` takes
+        // precedence.
+        let explicit_map: std::collections::HashMap<
+            String,
+            &crate::meeting_facilitator::MeetingDecision,
+        > = self
+            .explicit_decisions
+            .iter()
+            .map(|d| (d.description.to_lowercase(), d))
+            .collect();
         let structured_decisions: Vec<crate::meeting_facilitator::MeetingDecision> = decisions
             .iter()
             .map(|d| {
-                let rationale = persist::extract_decision_rationale_pub(d, &self.history);
-                let participants = persist::extract_decision_participants_pub(d, &self.history);
-                crate::meeting_facilitator::MeetingDecision {
-                    description: d.clone(),
-                    rationale,
-                    participants,
+                if let Some(explicit) = explicit_map.get(&d.to_lowercase()) {
+                    let rationale = if explicit.rationale.is_empty() {
+                        persist::extract_decision_rationale_pub(d, &self.history)
+                    } else {
+                        explicit.rationale.clone()
+                    };
+                    let participants = if explicit.participants.is_empty() {
+                        persist::extract_decision_participants_pub(d, &self.history)
+                    } else {
+                        explicit.participants.clone()
+                    };
+                    crate::meeting_facilitator::MeetingDecision {
+                        description: d.clone(),
+                        rationale,
+                        participants,
+                    }
+                } else {
+                    let rationale = persist::extract_decision_rationale_pub(d, &self.history);
+                    let participants = persist::extract_decision_participants_pub(d, &self.history);
+                    crate::meeting_facilitator::MeetingDecision {
+                        description: d.clone(),
+                        rationale,
+                        participants,
+                    }
                 }
             })
             .collect();
@@ -672,11 +750,19 @@ impl MeetingBackend {
             partial_reason.get_or_insert(PartialReason::PersistenceError);
         }
 
+        // Issue #2086: cap bundle transcript to MAX_HANDOFF_HISTORY recent
+        // turns. Full transcript already written above.
+        let handoff_history: &[super::types::ConversationMessage] =
+            if self.history.len() > super::MAX_HANDOFF_HISTORY {
+                &self.history[self.history.len() - super::MAX_HANDOFF_HISTORY..]
+            } else {
+                &self.history
+            };
         let bundle_dir = match persist::write_handoff_bundle(
             &self.topic,
             &summary_text,
             Some(&self.started_at),
-            &self.history,
+            handoff_history,
             &action_items,
             &decisions,
             bundle_open_questions,

--- a/src/meeting_backend/command.rs
+++ b/src/meeting_backend/command.rs
@@ -23,8 +23,13 @@ pub enum MeetingCommand {
     /// extracted from the live meeting transcript. Read-only — does not close.
     State,
     /// Operator marks a decision deterministically (e.g. `/decision Adopt TDD`).
+    /// Optional `--rationale <text>` flag supplies structured rationale.
     /// Bypasses post-hoc heuristic extraction so the item cannot be missed.
-    Decision(String),
+    /// Unified to store `MeetingDecision` in issue #2086.
+    Decision {
+        text: String,
+        rationale: Option<String>,
+    },
     /// Operator records an action item inline (e.g.
     /// `/action Bob will write tests by friday`). The text is parsed for
     /// assignee/deadline using the same extractors as the heuristic path.
@@ -82,7 +87,12 @@ pub fn parse_command(input: &str) -> MeetingCommand {
             if arg.is_empty() {
                 MeetingCommand::Conversation(trimmed.to_string())
             } else {
-                MeetingCommand::Decision(arg)
+                let (text, rationale) = parse_rationale_flag(&arg);
+                if text.is_empty() {
+                    MeetingCommand::Conversation(trimmed.to_string())
+                } else {
+                    MeetingCommand::Decision { text, rationale }
+                }
             }
         }
         _ if lower.starts_with("/action ") => {
@@ -118,6 +128,29 @@ pub fn parse_command(input: &str) -> MeetingCommand {
             }
         }
         _ => MeetingCommand::Conversation(trimmed.to_string()),
+    }
+}
+
+/// Parse an optional `--rationale <text>` flag from a `/decision` argument.
+///
+/// Splits the input on `--rationale` (case-insensitive). Everything before
+/// the flag is the decision text; everything after is the rationale.
+/// Returns `(decision_text, Option<rationale>)`. If `--rationale` is
+/// absent, the rationale is `None`. Added in issue #2086.
+fn parse_rationale_flag(input: &str) -> (String, Option<String>) {
+    let lower = input.to_lowercase();
+    if let Some(idx) = lower.find("--rationale") {
+        let text = input[..idx].trim().to_string();
+        let rationale_start = idx + "--rationale".len();
+        let rationale = input[rationale_start..].trim().to_string();
+        let rationale = if rationale.is_empty() {
+            None
+        } else {
+            Some(rationale)
+        };
+        (text, rationale)
+    } else {
+        (input.to_string(), None)
     }
 }
 
@@ -274,11 +307,17 @@ mod tests {
     fn parse_decision_with_arg() {
         assert_eq!(
             parse_command("/decision Adopt TDD for new modules"),
-            MeetingCommand::Decision("Adopt TDD for new modules".to_string()),
+            MeetingCommand::Decision {
+                text: "Adopt TDD for new modules".to_string(),
+                rationale: None,
+            },
         );
         assert_eq!(
             parse_command("  /Decision   Ship phase 8  "),
-            MeetingCommand::Decision("Ship phase 8".to_string()),
+            MeetingCommand::Decision {
+                text: "Ship phase 8".to_string(),
+                rationale: None,
+            },
         );
     }
 
@@ -413,5 +452,52 @@ mod tests {
             parse_command("/goal    "),
             MeetingCommand::Conversation("/goal".to_string()),
         );
+    }
+
+    // ── /decision --rationale flag (issue #2086) ─────────────────────
+
+    #[test]
+    fn parse_decision_with_rationale_flag() {
+        assert_eq!(
+            parse_command("/decision Adopt TDD --rationale Memory safety and correctness"),
+            MeetingCommand::Decision {
+                text: "Adopt TDD".to_string(),
+                rationale: Some("Memory safety and correctness".to_string()),
+            },
+        );
+    }
+
+    #[test]
+    fn parse_decision_rationale_flag_case_insensitive() {
+        assert_eq!(
+            parse_command("/decision Use Rust --RATIONALE Performance matters"),
+            MeetingCommand::Decision {
+                text: "Use Rust".to_string(),
+                rationale: Some("Performance matters".to_string()),
+            },
+        );
+    }
+
+    #[test]
+    fn parse_decision_rationale_flag_empty_rationale() {
+        // --rationale present but no text after it → rationale is None
+        assert_eq!(
+            parse_command("/decision Adopt TDD --rationale"),
+            MeetingCommand::Decision {
+                text: "Adopt TDD".to_string(),
+                rationale: None,
+            },
+        );
+    }
+
+    #[test]
+    fn parse_rationale_flag_helper() {
+        let (text, rationale) = parse_rationale_flag("Adopt TDD --rationale Good for quality");
+        assert_eq!(text, "Adopt TDD");
+        assert_eq!(rationale, Some("Good for quality".to_string()));
+
+        let (text, rationale) = parse_rationale_flag("No flag here");
+        assert_eq!(text, "No flag here");
+        assert_eq!(rationale, None);
     }
 }

--- a/src/meeting_backend/mod.rs
+++ b/src/meeting_backend/mod.rs
@@ -38,6 +38,12 @@ pub use types::{
 /// Maximum messages kept in conversation history.
 pub(super) const MAX_HISTORY: usize = 500;
 
+/// Maximum recent messages included in the `meeting_handoff.json` artifact.
+/// Full transcript is preserved in `transcript.json`; the handoff carries
+/// only the most recent turns so downstream consumers get concise decision
+/// records instead of bloated transcripts (spec requirement, issue #2086).
+pub(super) const MAX_HANDOFF_HISTORY: usize = 50;
+
 /// Number of recent messages included verbatim in the LLM prompt.
 const RECENT_WINDOW: usize = 30;
 
@@ -149,9 +155,10 @@ pub struct MeetingBackend {
     /// handoff markdown report as the `## Agenda` section.
     applied_templates: Vec<AppliedTemplate>,
     /// Decisions recorded inline by the operator via `/decision <text>`.
-    /// Bypass post-hoc heuristic extraction so important items cannot be
-    /// missed or mangled. Issue #1730 seam (b).
-    explicit_decisions: Vec<String>,
+    /// Stores structured `MeetingDecision` with rationale so the REPL and
+    /// programmatic API share a single representation. Issue #1730 seam (b),
+    /// unified in issue #2086.
+    explicit_decisions: Vec<crate::meeting_facilitator::MeetingDecision>,
     /// Action items recorded inline by the operator via `/action <text>`.
     /// Description is taken verbatim; assignee/deadline are best-effort
     /// extracted using the same helpers as the heuristic path. Issue #1730
@@ -327,10 +334,13 @@ impl MeetingBackend {
     // ── Inline /decision /action /question (issue #1730 seam (b)) ─────
 
     /// Record a decision the operator marked deterministically with
-    /// `/decision <text>`. Trailing/leading whitespace is trimmed and empty
-    /// values are ignored. Duplicates (case-insensitive) are deduplicated so
-    /// re-typing `/decision Adopt TDD` is a no-op.
-    pub fn push_explicit_decision(&mut self, text: &str) {
+    /// `/decision <text>`. Accepts optional `rationale` — when `None`, the
+    /// rationale is stored as `""` and will be backfilled from the
+    /// conversation history at close time. Trailing/leading whitespace is
+    /// trimmed and empty values are ignored. Duplicates (case-insensitive on
+    /// description) are deduplicated so re-typing `/decision Adopt TDD` is a
+    /// no-op. Unified to store `MeetingDecision` in issue #2086.
+    pub fn push_explicit_decision(&mut self, text: &str, rationale: Option<&str>) {
         let trimmed = text.trim();
         if trimmed.is_empty() {
             return;
@@ -339,15 +349,20 @@ impl MeetingBackend {
         if self
             .explicit_decisions
             .iter()
-            .any(|d| d.to_lowercase() == lower)
+            .any(|d| d.description.to_lowercase() == lower)
         {
             return;
         }
-        self.explicit_decisions.push(trimmed.to_string());
+        self.explicit_decisions
+            .push(crate::meeting_facilitator::MeetingDecision {
+                description: trimmed.to_string(),
+                rationale: rationale.map(|r| r.trim().to_string()).unwrap_or_default(),
+                participants: Vec::new(),
+            });
     }
 
     /// Read the decisions the operator recorded inline so far.
-    pub fn explicit_decisions(&self) -> &[String] {
+    pub fn explicit_decisions(&self) -> &[crate::meeting_facilitator::MeetingDecision] {
         &self.explicit_decisions
     }
 
@@ -469,17 +484,9 @@ impl MeetingBackend {
     /// slash command so a crash loses at most the last few seconds of work.
     /// Issue #1984.
     pub fn snapshot_session(&self) -> crate::meeting_facilitator::MeetingSession {
-        use crate::meeting_facilitator::{MeetingDecision, MeetingSessionStatus};
+        use crate::meeting_facilitator::MeetingSessionStatus;
 
-        let decisions = self
-            .explicit_decisions
-            .iter()
-            .map(|d| MeetingDecision {
-                description: d.clone(),
-                rationale: String::new(),
-                participants: Vec::new(),
-            })
-            .collect();
+        let decisions = self.explicit_decisions.clone();
 
         let action_items = self
             .explicit_action_items

--- a/src/meeting_backend/tests_mod.rs
+++ b/src/meeting_backend/tests_mod.rs
@@ -388,16 +388,32 @@ fn close_summary_includes_applied_templates() {
 fn push_explicit_decision_appends_and_dedupes() {
     let agent = MockAgent::new("ok");
     let mut backend = MeetingBackend::new_session("Planning", Box::new(agent), None, String::new());
-    backend.push_explicit_decision("Adopt TDD");
-    backend.push_explicit_decision("  Adopt TDD  "); // duplicate (case-insensitive after trim)
-    backend.push_explicit_decision("ADOPT TDD"); // case-insensitive duplicate
-    backend.push_explicit_decision("Ship phase 8");
-    backend.push_explicit_decision("   "); // empty -> ignored
+    backend.push_explicit_decision("Adopt TDD", None);
+    backend.push_explicit_decision("  Adopt TDD  ", None); // duplicate (case-insensitive after trim)
+    backend.push_explicit_decision("ADOPT TDD", None); // case-insensitive duplicate
+    backend.push_explicit_decision("Ship phase 8", None);
+    backend.push_explicit_decision("   ", None); // empty -> ignored
     let decisions = backend.explicit_decisions();
-    assert_eq!(
-        decisions,
-        &["Adopt TDD".to_string(), "Ship phase 8".to_string()]
-    );
+    assert_eq!(decisions.len(), 2);
+    assert_eq!(decisions[0].description, "Adopt TDD");
+    assert_eq!(decisions[1].description, "Ship phase 8");
+    // No rationale supplied → stored as empty string
+    assert_eq!(decisions[0].rationale, "");
+    assert_eq!(decisions[1].rationale, "");
+}
+
+#[test]
+fn push_explicit_decision_with_rationale() {
+    let agent = MockAgent::new("ok");
+    let mut backend = MeetingBackend::new_session("Planning", Box::new(agent), None, String::new());
+    backend.push_explicit_decision("Adopt TDD", Some("Memory safety"));
+    backend.push_explicit_decision("Ship phase 8", None);
+    let decisions = backend.explicit_decisions();
+    assert_eq!(decisions.len(), 2);
+    assert_eq!(decisions[0].description, "Adopt TDD");
+    assert_eq!(decisions[0].rationale, "Memory safety");
+    assert_eq!(decisions[1].description, "Ship phase 8");
+    assert_eq!(decisions[1].rationale, "");
 }
 
 #[test]
@@ -464,8 +480,8 @@ fn close_summary_merges_explicit_decisions() {
     let agent = MockAgent::new("Summary text.");
     let mut backend =
         MeetingBackend::new_session("Decisions", Box::new(agent), None, String::new());
-    backend.push_explicit_decision("Adopt TDD");
-    backend.push_explicit_decision("Use Rust for CLI");
+    backend.push_explicit_decision("Adopt TDD", Some("Better quality"));
+    backend.push_explicit_decision("Use Rust for CLI", None);
     let summary = backend.close().unwrap();
     // Explicit decisions appear first, in registration order.
     assert!(summary.decisions.contains(&"Adopt TDD".to_string()));
@@ -527,7 +543,7 @@ fn snapshot_session_captures_decisions_actions_questions() {
     let agent = MockAgent::new("ok");
     let mut backend =
         MeetingBackend::new_session("Snap Items", Box::new(agent), None, String::new());
-    backend.push_explicit_decision("Use Rust");
+    backend.push_explicit_decision("Use Rust", None);
     backend.push_explicit_action_item("Alice will deploy by Friday");
     backend.push_explicit_question("What about caching?");
     backend.push_theme("performance".to_string());
@@ -551,7 +567,7 @@ fn snapshot_session_round_trips_through_wip_persistence() {
     let agent = MockAgent::new("ok");
     let mut backend =
         MeetingBackend::new_session("Round Trip", Box::new(agent), None, String::new());
-    backend.push_explicit_decision("Decided X");
+    backend.push_explicit_decision("Decided X", None);
     backend.push_explicit_question("Open Q?");
 
     let snap = backend.snapshot_session();

--- a/src/meeting_repl/repl.rs
+++ b/src/meeting_repl/repl.rs
@@ -141,7 +141,7 @@ pub fn run_meeting_repl<R: BufRead, W: Write>(
             MeetingCommand::Help => {
                 writeln!(
                     output,
-                    "Commands:\n  /status    — show session info\n  /state     — show current decisions, open questions, action items\n  /template  — list meeting templates\n  /template <name> — apply a template (standup, 1on1, retro, planning)\n  /theme <text>    — record a theme for this meeting\n  /decision <text> — record a decision deterministically (skips heuristic extraction)\n  /action <text>   — record an action item (assignee/deadline parsed inline)\n  /question <text> — record an open question deterministically\n  /owner <name>    — name the next agent/persona/human expected to action this handoff\n  /goal <text>     — set the meeting's overarching objective\n  /recap     — show color-coded session recap\n  /preview   — preview the handoff artifact\n  /export    — export meeting as markdown\n  /close     — end meeting and persist\n  /help      — this message\n\nEverything else is natural conversation with Simard."
+                    "Commands:\n  /status    — show session info\n  /state     — show current decisions, open questions, action items\n  /template  — list meeting templates\n  /template <name> — apply a template (standup, 1on1, retro, planning)\n  /theme <text>    — record a theme for this meeting\n  /decision <text> [--rationale <why>] — record a decision (optional rationale)\n  /action <text>   — record an action item (assignee/deadline parsed inline)\n  /question <text> — record an open question deterministically\n  /owner <name>    — name the next agent/persona/human expected to action this handoff\n  /goal <text>     — set the meeting's overarching objective\n  /recap     — show color-coded session recap\n  /preview   — preview the handoff artifact\n  /export    — export meeting as markdown\n  /close     — end meeting and persist\n  /help      — this message\n\nEverything else is natural conversation with Simard."
                 )
                 .ok();
             }
@@ -166,7 +166,11 @@ pub fn run_meeting_repl<R: BufRead, W: Write>(
                 let inferred_questions = extract_open_questions(messages);
                 let inferred_actions = extract_action_items(messages);
 
-                let mut decisions: Vec<String> = backend.explicit_decisions().to_vec();
+                let mut decisions: Vec<String> = backend
+                    .explicit_decisions()
+                    .iter()
+                    .map(|d| d.description.clone())
+                    .collect();
                 for d in inferred_decisions {
                     let lower = d.to_lowercase();
                     if !decisions.iter().any(|e| e.to_lowercase() == lower) {
@@ -257,9 +261,14 @@ pub fn run_meeting_repl<R: BufRead, W: Write>(
                 writeln!(output, "{}", green(&format!("Theme recorded: {text}"))).ok();
                 checkpoint_wip(&backend);
             }
-            MeetingCommand::Decision(text) => {
-                backend.push_explicit_decision(&text);
-                writeln!(output, "{}", cyan(&format!("Decision recorded: {text}"))).ok();
+            MeetingCommand::Decision { text, rationale } => {
+                backend.push_explicit_decision(&text, rationale.as_deref());
+                let msg = if let Some(ref r) = rationale {
+                    format!("Decision recorded: {text} (rationale: {r})")
+                } else {
+                    format!("Decision recorded: {text}")
+                };
+                writeln!(output, "{}", cyan(&msg)).ok();
                 checkpoint_wip(&backend);
             }
             MeetingCommand::Action(text) => {

--- a/src/operator_commands_dashboard/chat.rs
+++ b/src/operator_commands_dashboard/chat.rs
@@ -255,9 +255,13 @@ pub(crate) async fn handle_ws_chat(mut socket: WebSocket) {
                             ))
                             .await;
                     }
-                    MeetingCommand::Decision(text) => {
-                        backend.push_explicit_decision(&text);
-                        let content = format!("Decision recorded: {text}");
+                    MeetingCommand::Decision { text, rationale } => {
+                        backend.push_explicit_decision(&text, rationale.as_deref());
+                        let content = if let Some(ref r) = rationale {
+                            format!("Decision recorded: {text} (rationale: {r})")
+                        } else {
+                            format!("Decision recorded: {text}")
+                        };
                         let _ = socket
                             .send(Message::Text(
                                 json!({"role":"system","content": content})

--- a/tests/meeting_close_outside_in.rs
+++ b/tests/meeting_close_outside_in.rs
@@ -415,7 +415,7 @@ fn slow_but_successful_llm_close_produces_complete_handoff() {
          because the previous 15-second default was shorter than a \
          single LLM turn at p95.",
     );
-    backend.push_explicit_decision("Raise agent close timeout to 45s");
+    backend.push_explicit_decision("Raise agent close timeout to 45s", None);
     backend.push_explicit_action_item("Engineer will update the default and docs");
 
     let started = Instant::now();
@@ -521,7 +521,7 @@ fn close_writes_enrichment_payload_with_next_owner_and_artifacts() {
          losing rationale and participants — outside-in catches it.",
     );
 
-    backend.push_explicit_decision("Adopt outside-in tests for the close pipeline");
+    backend.push_explicit_decision("Adopt outside-in tests for the close pipeline", None);
     backend.push_explicit_action_item("Alice will write the regression test");
     backend.push_explicit_question("Should we also gate clippy on -D warnings?");
     backend.push_next_owner("engineer");
@@ -643,7 +643,7 @@ fn partial_close_preserves_structured_decisions_not_placeholders() {
         "We will adopt structured handoffs because the schema \
          downstream consumers need to link to artifacts.",
     );
-    backend.push_explicit_decision("Adopt structured handoffs");
+    backend.push_explicit_decision("Adopt structured handoffs", None);
     backend.push_explicit_action_item("Bob will write the schema migration");
     backend.push_next_owner("ooda-curate");
 


### PR DESCRIPTION
## Summary

Fixes #2086 — unifies the dual-path decision storage so the REPL `/decision` command and programmatic API share the same `MeetingDecision` struct with rationale.

## Changes

### 1. Structured `explicit_decisions` field (mod.rs)
- Changed `MeetingBackend.explicit_decisions` from `Vec<String>` to `Vec<MeetingDecision>`
- Updated `push_explicit_decision()` to accept optional `rationale` parameter
- Updated `explicit_decisions()` accessor to return `&[MeetingDecision]`

### 2. `/decision --rationale` flag (command.rs)
- Changed `MeetingCommand::Decision(String)` to `Decision { text, rationale: Option<String> }`
- Added `parse_rationale_flag()` helper for case-insensitive `--rationale` parsing
- UX: `/decision Adopt TDD --rationale Memory safety and correctness`

### 3. Close pipeline unification (closing.rs)
- Both `close()` and `finalize_partial()` now build `explicit_map` from structured decisions
- Operator-supplied rationale takes precedence over heuristic extraction
- Inferred decisions without explicit rationale still use the heuristic extractor

### 4. Handoff history cap (closing.rs, mod.rs)
- Added `MAX_HANDOFF_HISTORY = 50` constant
- Bundle `transcript.json` now includes only the last 50 turns
- Full transcript preserved in the standalone `transcript.json` written by `write_transcript()`
- Addresses spec requirement: "concise decision records, not bloated transcripts"

### 5. REPL + Dashboard updates (repl.rs, chat.rs)
- `/decision` handler passes parsed rationale to `push_explicit_decision()`
- `/state` view extracts `.description` from structured decisions
- Help text updated to document `--rationale` flag

### 6. Tests
- Updated `push_explicit_decision_appends_and_dedupes` for new signature
- Added `push_explicit_decision_with_rationale` test
- Added 4 new command parser tests (rationale flag parsing)
- Updated `close_summary_merges_explicit_decisions` to supply rationale
- Updated 3 integration tests in `meeting_close_outside_in.rs`

## Files changed (7)
- `src/meeting_backend/mod.rs` — field type + method signature
- `src/meeting_backend/command.rs` — enum variant + rationale parser
- `src/meeting_backend/closing.rs` — close pipeline + history cap
- `src/meeting_repl/repl.rs` — REPL handler + help text
- `src/operator_commands_dashboard/chat.rs` — dashboard handler
- `src/meeting_backend/tests_mod.rs` — unit tests
- `tests/meeting_close_outside_in.rs` — integration tests

## Verification
- `cargo fmt` ✅
- `cargo clippy -D warnings` ✅ (lib + release)
- `cargo test meeting_backend::command` — 32 passed ✅
- `cargo test meeting_backend::tests_mod` — 33 passed ✅
- `cargo test meeting_repl` — 42 passed ✅
- `cargo test --test meeting_close_outside_in` — 5 passed ✅
- Pre-commit hooks (fmt + clippy) ✅
- Pre-push hooks (fmt + test + clippy --all-targets) ✅
