### PR TITLE
fix(dashboard): show correct agent status when daemon is running

### DIFF
--- a/src/operator_commands_dashboard/index_html/part_01.rs
+++ b/src/operator_commands_dashboard/index_html/part_01.rs
@@ -265,7 +265,7 @@ pub(crate) const PART_01: &str = r#"      </div>
         const d=await apiFetch('/api/activity');
         const el=document.getElementById('agent-live-status');
         const daemon=d.daemon||{};
-        const isRunning=daemon.status==='healthy';
+        const isRunning=daemon.status==='healthy'||daemon.status==='running';
         const heartbeat=daemon.last_heartbeat?timeAgo(daemon.last_heartbeat):'never';
         const cycle=daemon.current_cycle||'?';
 


### PR DESCRIPTION
## Summary

Fixes #2145 — Dashboard Overview tab displayed "Agent Stopped" even when the OODA daemon was actively running.

## Root Cause

The OODA daemon writes two status values to `daemon_health.json`:
- `"status": "running"` — at the **start** of each cycle (active processing)
- `"status": "healthy"` — at the **end** of each cycle (sleeping between cycles)

The `/api/activity` endpoint passes this raw status through to the frontend. However, `fetchAgentOverview()` only checked `daemon.status === "healthy"`, so during active cycles the dashboard incorrectly rendered "Agent Stopped" with a red indicator.

## Fix

Accept both `"healthy"` and `"running"` as valid active states in the frontend `isRunning` check.

## Evidence

1. **Tests**: All 152 dashboard tests pass (`cargo test --lib operator_commands_dashboard`)
2. **Pre-commit**: `cargo fmt` + `cargo clippy` pass
3. **Pre-push**: Release clippy + memory tests pass
4. **Diff**: Single-line change in `src/operator_commands_dashboard/index_html/part_01.rs`

## Merge-ready criteria

- [x] Diff focused — 1 file, 1 line changed
- [x] CI: pre-commit (fmt, clippy) and pre-push (release clippy, tests) green
- [x] No docs update needed (internal rendering logic only)
