### PR TITLE
feat: add TDD ordering check script and CI gate (#1927)

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -145,6 +145,25 @@ jobs:
           CARGO_PROFILE_DEV_INCREMENTAL: "false"
         run: cargo test --test install_real -- --nocapture
 
+  tdd-ordering:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    timeout-minutes: 5
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check TDD commit ordering (pilot paths)
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          bash scripts/check-tdd-ordering.sh \
+            "${{ github.event.pull_request.base.sha }}" \
+            "${{ github.event.pull_request.head.sha }}"
+
   e2e-dashboard:
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/scripts/check-tdd-ordering.sh
+++ b/scripts/check-tdd-ordering.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# scripts/check-tdd-ordering.sh
+#
+# Enforces TDD authoring order for PRs touching pilot paths.
+# See issue #1927 for the charter.
+#
+# Usage: check-tdd-ordering.sh <base-sha> <head-sha>
+#
+# Environment:
+#   PR_BODY  — (optional) pull-request body text; checked for tdd-exempt trailer.
+#
+# Exits 0 on pass (correct ordering, exempt, or no pilot-path changes).
+# Exits 1 on violation with a message naming the offending commit.
+
+set -euo pipefail
+
+BASE_SHA="${1:?Usage: check-tdd-ordering.sh <base-sha> <head-sha>}"
+HEAD_SHA="${2:?Usage: check-tdd-ordering.sh <base-sha> <head-sha>}"
+
+# Pilot paths per issue #1927 §2
+PILOT_PATHS=(
+  "src/meeting_backend/"
+  "src/meeting_repl/"
+  "src/meeting_facilitator/"
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Returns 0 if any commit message or PR_BODY contains a tdd-exempt trailer.
+check_tdd_exempt() {
+  if [[ -n "${PR_BODY:-}" ]]; then
+    if printf '%s' "$PR_BODY" | grep -qE 'tdd-exempt:\s*\S'; then
+      echo "✓ tdd-exempt trailer found in PR body"
+      return 0
+    fi
+  fi
+
+  local sha
+  while IFS= read -r sha; do
+    if git log -1 --format='%B' "$sha" | grep -qE 'tdd-exempt:\s*\S'; then
+      echo "✓ tdd-exempt trailer found in commit $(git log -1 --format='%h' "$sha")"
+      return 0
+    fi
+  done < <(git log --reverse --format='%H' "${BASE_SHA}..${HEAD_SHA}")
+
+  return 1
+}
+
+# Returns 0 if the commit modifies .rs files under any pilot path.
+touches_pilot_production() {
+  local sha="$1"
+  local files
+  files=$(git diff-tree --no-commit-id --name-only -r "$sha" 2>/dev/null || true)
+  if [[ -z "$files" ]]; then
+    return 1
+  fi
+  local p
+  for p in "${PILOT_PATHS[@]}"; do
+    if echo "$files" | grep -q "^${p}.*\.rs$"; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Returns 0 if the commit adds #[test] or #[tokio::test] lines, or touches
+# test files under tests/ related to the meeting subsystem.
+is_test_commit() {
+  local sha="$1"
+
+  # Added lines containing test attributes anywhere in the diff.
+  if git diff-tree -p "$sha" 2>/dev/null \
+       | grep '^+' | grep -v '^+++' \
+       | grep -qE '#\[(tokio::)?test\]'; then
+    return 0
+  fi
+
+  # Touches integration-test files whose names reference the meeting subsystem.
+  if git diff-tree --no-commit-id --name-only -r "$sha" 2>/dev/null \
+       | grep -qiE '^tests/.*meeting'; then
+    return 0
+  fi
+
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+main() {
+  echo "=== TDD Ordering Check ==="
+  echo "Base: ${BASE_SHA:0:12}"
+  echo "Head: ${HEAD_SHA:0:12}"
+  echo "Pilot paths: ${PILOT_PATHS[*]}"
+  echo ""
+
+  # Collect commits in chronological order.
+  local commits=()
+  while IFS= read -r sha; do
+    commits+=("$sha")
+  done < <(git log --reverse --format='%H' "${BASE_SHA}..${HEAD_SHA}")
+
+  if [[ ${#commits[@]} -eq 0 ]]; then
+    echo "✓ No commits in range — nothing to check."
+    exit 0
+  fi
+
+  echo "Commits in range: ${#commits[@]}"
+
+  # Fast path: no pilot-path changes at all.
+  local has_pilot=false
+  for sha in "${commits[@]}"; do
+    if touches_pilot_production "$sha"; then
+      has_pilot=true
+      break
+    fi
+  done
+
+  if [[ "$has_pilot" == "false" ]]; then
+    echo "✓ No commits touch pilot paths — nothing to enforce."
+    exit 0
+  fi
+
+  # Check for the escape-hatch trailer.
+  if check_tdd_exempt; then
+    exit 0
+  fi
+
+  # Walk commits chronologically and enforce ordering.
+  local seen_test=false
+
+  for sha in "${commits[@]}"; do
+    local short
+    short=$(git log -1 --format='%h %s' "$sha")
+
+    # Test detection runs first so a mixed commit sets the flag before
+    # the pilot-path check below reads it.
+    if is_test_commit "$sha"; then
+      seen_test=true
+      echo "  ✓ $short — test commit"
+    fi
+
+    if touches_pilot_production "$sha"; then
+      if [[ "$seen_test" == "false" ]]; then
+        echo "  ✗ $short — pilot-path production change (no preceding test)"
+        echo ""
+        echo "VIOLATION: Commit $(git log -1 --format='%h' "$sha") modifies"
+        echo "pilot-path production code but no test commit appears before it."
+        echo ""
+        echo "  Offending commit: $(git log -1 --format='%H %s' "$sha")"
+        echo "  Pilot-path files changed:"
+        local p
+        for p in "${PILOT_PATHS[@]}"; do
+          git diff-tree --no-commit-id --name-only -r "$sha" \
+            | grep "^${p}" | sed 's/^/    /' || true
+        done
+        echo ""
+        echo "To fix, either:"
+        echo "  1. Reorder commits so a test commit appears before this one, or"
+        echo "  2. Add a 'tdd-exempt:<reason>' trailer to the PR body or a commit"
+        echo "     message (valid reasons: doc-only, one-line fix, generated code,"
+        echo "     pure refactor)."
+        exit 1
+      else
+        echo "  ✓ $short — pilot-path change (test already seen)"
+      fi
+    fi
+
+    # Non-pilot, non-test commits are irrelevant.
+    if ! is_test_commit "$sha" && ! touches_pilot_production "$sha"; then
+      echo "  · $short — no pilot-path or test changes"
+    fi
+  done
+
+  echo ""
+  echo "✓ TDD ordering check passed."
+  exit 0
+}
+
+main

--- a/tests/check_tdd_ordering_test.sh
+++ b/tests/check_tdd_ordering_test.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+# tests/check_tdd_ordering_test.sh
+#
+# Test harness for scripts/check-tdd-ordering.sh.
+# Creates temporary git repos with various commit orderings and verifies the
+# script produces the correct exit code for each scenario.
+#
+# Usage: bash tests/check_tdd_ordering_test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/scripts/check-tdd-ordering.sh"
+
+PASS=0
+FAIL=0
+ERRORS=""
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+setup_repo() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  cd "$tmpdir"
+  git init --initial-branch=main -q
+  git config user.email "test@test.com"
+  git config user.name "Test"
+  git config core.hooksPath /dev/null
+  mkdir -p src/meeting_backend src/meeting_repl src/meeting_facilitator tests
+  echo "// initial" > src/meeting_backend/mod.rs
+  echo "// initial" > src/meeting_repl/mod.rs
+  echo "// initial" > src/meeting_facilitator/mod.rs
+  git add -A && git commit -q -m "Initial commit"
+  echo "$tmpdir"
+}
+
+cleanup_repo() { rm -rf "$1"; }
+
+run_test() {
+  local name="$1" expected_exit="$2"
+  local base_sha head_sha actual_exit output
+
+  base_sha=$(git log --reverse --format='%H' | head -1)
+  head_sha=$(git log --format='%H' -1)
+
+  set +e
+  output=$("$CHECK_SCRIPT" "$base_sha" "$head_sha" 2>&1)
+  actual_exit=$?
+  set -e
+
+  if [[ "$actual_exit" -eq "$expected_exit" ]]; then
+    echo "  PASS: $name (exit=$actual_exit)"
+    ((PASS++)) || true
+  else
+    echo "  FAIL: $name (expected exit=$expected_exit, got exit=$actual_exit)"
+    echo "  --- output ---"
+    echo "$output" | sed 's/^/  | /'
+    echo "  ---"
+    ((FAIL++)) || true
+    ERRORS="${ERRORS}\n  FAIL: $name"
+  fi
+}
+
+# ── test cases ───────────────────────────────────────────────────────────────
+
+echo "=== TDD Ordering Check — Test Harness ==="
+echo ""
+
+# 1. Correct order: test commit before production commit → PASS
+echo "Test 1: test commit before production commit"
+tmpdir=$(setup_repo)
+cd "$tmpdir"
+cat >> src/meeting_backend/mod.rs <<'RUST'
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() { assert!(true); }
+}
+RUST
+git add -A && git commit -q -m "Add test for meeting_backend"
+cat >> src/meeting_backend/mod.rs <<'RUST'
+
+pub fn handle_meeting() -> bool { true }
+RUST
+git add -A && git commit -q -m "Add handle_meeting function"
+run_test "test-before-production" 0
+cleanup_repo "$tmpdir"
+
+# 2. Wrong order: production before test → FAIL
+echo "Test 2: production commit before test commit"
+tmpdir=$(setup_repo)
+cd "$tmpdir"
+cat >> src/meeting_backend/mod.rs <<'RUST'
+
+pub fn handle_meeting() -> bool { true }
+RUST
+git add -A && git commit -q -m "Add handle_meeting function"
+cat >> src/meeting_backend/mod.rs <<'RUST'
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() { assert!(true); }
+}
+RUST
+git add -A && git commit -q -m "Add test for meeting_backend"
+run_test "production-before-test" 1
+cleanup_repo "$tmpdir"
+
+# 3. tdd-exempt trailer in commit message → PASS
+echo "Test 3: tdd-exempt trailer in commit message"
+tmpdir=$(setup_repo)
+cd "$tmpdir"
+cat >> src/meeting_repl/mod.rs <<'RUST'
+
+pub fn start_repl() {}
+RUST
+git add -A && git commit -q -m "Fix typo in meeting_repl
+
+tdd-exempt: one-line fix"
+run_test "tdd-exempt-commit" 0
+cleanup_repo "$tmpdir"
+
+# 4. No pilot-path changes → PASS
+echo "Test 4: no pilot-path changes"
+tmpdir=$(setup_repo)
+cd "$tmpdir"
+mkdir -p src
+echo "pub fn unrelated() {}" > src/lib.rs
+git add -A && git commit -q -m "Unrelated change"
+run_test "no-pilot-changes" 0
+cleanup_repo "$tmpdir"
+
+# 5. tdd-exempt in PR body (env var) → PASS
+echo "Test 5: tdd-exempt trailer in PR body"
+tmpdir=$(setup_repo)
+cd "$tmpdir"
+cat >> src/meeting_facilitator/mod.rs <<'RUST'
+
+pub fn facilitate() {}
+RUST
+git add -A && git commit -q -m "Add facilitate function"
+PR_BODY=$'This is a simple fix.\n\ntdd-exempt: pure refactor' \
+  run_test "tdd-exempt-pr-body" 0
+cleanup_repo "$tmpdir"
+
+# 6. Mixed commit (test + production in same commit) → PASS (lenient)
+echo "Test 6: test and production in same commit (lenient — passes)"
+tmpdir=$(setup_repo)
+cd "$tmpdir"
+cat >> src/meeting_backend/mod.rs <<'RUST'
+
+pub fn process() -> u32 { 42 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_process() { assert_eq!(process(), 42); }
+}
+RUST
+git add -A && git commit -q -m "Add process with inline test"
+run_test "mixed-commit" 0
+cleanup_repo "$tmpdir"
+
+# 7. Production-only commit, no tests anywhere → FAIL
+echo "Test 7: production-only commit, no tests"
+tmpdir=$(setup_repo)
+cd "$tmpdir"
+cat >> src/meeting_backend/mod.rs <<'RUST'
+
+pub fn new_feature() -> bool { true }
+RUST
+git add -A && git commit -q -m "Add new feature without tests"
+run_test "production-only" 1
+cleanup_repo "$tmpdir"
+
+# 8. Integration test in tests/ before production → PASS
+echo "Test 8: integration test in tests/ before production"
+tmpdir=$(setup_repo)
+cd "$tmpdir"
+cat > tests/meeting_close_test.rs <<'RUST'
+#[test]
+fn meeting_close_works() { assert!(true); }
+RUST
+git add -A && git commit -q -m "Add meeting close integration test"
+cat >> src/meeting_backend/mod.rs <<'RUST'
+
+pub fn close_meeting() -> bool { true }
+RUST
+git add -A && git commit -q -m "Implement close_meeting"
+run_test "integration-test-before-prod" 0
+cleanup_repo "$tmpdir"
+
+# 9. #[tokio::test] attribute recognised → PASS
+echo "Test 9: #[tokio::test] recognised as test commit"
+tmpdir=$(setup_repo)
+cd "$tmpdir"
+cat >> src/meeting_repl/mod.rs <<'RUST'
+
+#[cfg(test)]
+mod tests {
+    #[tokio::test]
+    async fn async_test() { assert!(true); }
+}
+RUST
+git add -A && git commit -q -m "Add async test"
+cat >> src/meeting_repl/mod.rs <<'RUST'
+
+pub async fn run_repl() {}
+RUST
+git add -A && git commit -q -m "Add run_repl"
+run_test "tokio-test-recognised" 0
+cleanup_repo "$tmpdir"
+
+# 10. Empty commit range → PASS
+echo "Test 10: empty commit range"
+tmpdir=$(setup_repo)
+cd "$tmpdir"
+sha=$(git log --format='%H' -1)
+set +e
+output=$("$CHECK_SCRIPT" "$sha" "$sha" 2>&1)
+rc=$?
+set -e
+if [[ "$rc" -eq 0 ]]; then
+  echo "  PASS: empty-range (exit=0)"
+  ((PASS++)) || true
+else
+  echo "  FAIL: empty-range (expected 0, got $rc)"
+  ((FAIL++)) || true
+  ERRORS="${ERRORS}\n  FAIL: empty-range"
+fi
+cleanup_repo "$tmpdir"
+
+# 11. Multiple pilot paths — test for one, production for another → PASS
+echo "Test 11: test in meeting_backend, production in meeting_repl (cross-module)"
+tmpdir=$(setup_repo)
+cd "$tmpdir"
+cat >> src/meeting_backend/mod.rs <<'RUST'
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn cross_module_test() { assert!(true); }
+}
+RUST
+git add -A && git commit -q -m "Add cross-module test"
+cat >> src/meeting_repl/mod.rs <<'RUST'
+
+pub fn repl_feature() {}
+RUST
+git add -A && git commit -q -m "Add repl feature"
+run_test "cross-module-test-before-prod" 0
+cleanup_repo "$tmpdir"
+
+# 12. Non-.rs file under pilot path → not flagged
+echo "Test 12: non-.rs file under pilot path (not enforced)"
+tmpdir=$(setup_repo)
+cd "$tmpdir"
+echo "# README" > src/meeting_backend/README.md
+git add -A && git commit -q -m "Add README to meeting_backend"
+run_test "non-rs-ignored" 0
+cleanup_repo "$tmpdir"
+
+# ── summary ──────────────────────────────────────────────────────────────────
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+if [[ $FAIL -gt 0 ]]; then
+  echo -e "Failures:$ERRORS"
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Implements the CI enforcement gate specified in #1927 §3: `scripts/check-tdd-ordering.sh` wired into the verify workflow.

## What it does

**`scripts/check-tdd-ordering.sh <base-sha> <head-sha>`** — walks `git log --reverse base..head` and enforces that PRs touching pilot-path `.rs` files have at least one test commit (`#[test]` or `#[tokio::test]`) appearing before the first production-code commit.

### Pilot paths (per #1927 §2)
- `src/meeting_backend/`
- `src/meeting_repl/`
- `src/meeting_facilitator/`

### Exception mechanism
Add a `tdd-exempt:<reason>` trailer to any commit message or the PR body:
```
tdd-exempt: one-line fix
tdd-exempt: doc-only
tdd-exempt: generated code
tdd-exempt: pure refactor
```

### CI integration
New `tdd-ordering` job in `.github/workflows/verify.yml`:
- Runs only on `pull_request` events
- Uses `fetch-depth: 0` for full history
- Passes `base.sha`, `head.sha`, and PR body to the script
- Lightweight (no Rust build required) — completes in seconds

## Test harness

`tests/check_tdd_ordering_test.sh` — 12 scenarios using temporary git repos:

| # | Scenario | Expected |
|---|----------|----------|
| 1 | Test commit before production | ✓ pass |
| 2 | Production commit before test | ✗ fail |
| 3 | `tdd-exempt:` in commit message | ✓ pass |
| 4 | No pilot-path changes | ✓ pass |
| 5 | `tdd-exempt:` in PR body (env var) | ✓ pass |
| 6 | Mixed commit (test + prod same commit) | ✓ pass (lenient) |
| 7 | Production only, no tests | ✗ fail |
| 8 | Integration test in `tests/` before prod | ✓ pass |
| 9 | `#[tokio::test]` recognized | ✓ pass |
| 10 | Empty commit range | ✓ pass |
| 11 | Cross-module (test in one pilot path, prod in another) | ✓ pass |
| 12 | Non-`.rs` file under pilot path | ✓ pass (not enforced) |

All 12 pass locally.

## Files changed
- `scripts/check-tdd-ordering.sh` — new (the check script)
- `tests/check_tdd_ordering_test.sh` — new (test harness)
- `.github/workflows/verify.yml` — added `tdd-ordering` job

tdd-exempt: new CI tooling - no production behavior change

Closes #1927