### PR TITLE
feat(tdd): add check-tdd-ordering.sh CI gate for meeting pilot (#1927)

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -23,6 +23,23 @@ env:
   CARGO_PROFILE_TEST_BUILD_OVERRIDE_DEBUG: "false"
 
 jobs:
+  tdd-ordering:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Check out repository (full history for log traversal)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run TDD ordering check
+        run: |
+          bash scripts/check-tdd-ordering.sh \
+            "${{ github.event.pull_request.base.sha }}" \
+            "${{ github.event.pull_request.head.sha }}"
+
   pre-commit:
     runs-on: ubuntu-latest
     timeout-minutes: 120

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,10 +11,11 @@ they are the same gates CI enforces.
 
 1. [Local Pre-Commit Workflow](#local-pre-commit-workflow)
 2. [Merge Policy: No `--admin` Merges](#merge-policy-no---admin-merges)
-3. [Cognitive Memory Durability (Per-Write Barrier + SIGTERM + Periodic Backups)](#cognitive-memory-durability-per-write-barrier--sigterm--periodic-backups)
-4. [Local Data Retention Disclosure](#local-data-retention-disclosure)
-5. [Pre-Existing Test Failure Disposition](#pre-existing-test-failure-disposition)
-6. [Real-Meeting & Dashboard E2E Verification](#real-meeting--dashboard-e2e-verification)
+3. [TDD Discipline (Pilot)](#tdd-discipline-pilot)
+4. [Cognitive Memory Durability (Per-Write Barrier + SIGTERM + Periodic Backups)](#cognitive-memory-durability-per-write-barrier--sigterm--periodic-backups)
+5. [Local Data Retention Disclosure](#local-data-retention-disclosure)
+6. [Pre-Existing Test Failure Disposition](#pre-existing-test-failure-disposition)
+7. [Real-Meeting & Dashboard E2E Verification](#real-meeting--dashboard-e2e-verification)
 
 ---
 
@@ -191,6 +192,51 @@ Before requesting merge:
 - [ ] CI on the PR is green.
 - [ ] Pre-existing failures inherited from `main` are either fixed in this PR or tracked by a linked GitHub issue.
 - [ ] PR body contains evidence of any required E2E verification (see workstream-specific docs).
+
+---
+
+## TDD Discipline (Pilot)
+
+Simard follows a **test-first authoring order** for new behavior in the
+pilot-scope modules listed below. This is enforced by the `tdd-ordering`
+CI job (`scripts/check-tdd-ordering.sh`) on every PR targeting `main`.
+See [#1927](https://github.com/rysweet/Simard/issues/1927) for the full
+charter, rationale, and exception list.
+
+### Pilot Scope
+
+The following paths are currently in the TDD pilot:
+
+- `src/meeting_backend/`
+- `src/meeting_repl/`
+- `src/meeting_facilitator/`
+
+### What the Check Requires
+
+For each pilot path touched by a PR, **at least one test-adding commit
+must appear before any production-code commit** in `git log --reverse`.
+The script checks for `#[test]`, `#[tokio::test]`, `assert!` macros,
+and `#[cfg(test)]` annotations in the added lines.
+
+### Exemptions
+
+If the change falls into one of the explicit exception categories from
+the charter (one-line fixes, doc-only, generated code, pure refactors),
+add a `tdd-exempt:<reason>` trailer to any commit in the PR:
+
+```
+git commit --trailer "tdd-exempt:one-line fix - constant rename"
+```
+
+The reason must be non-empty. The CI job will accept the trailer and
+skip the ordering check for the entire PR.
+
+### Local Verification
+
+```bash
+# From the repo root, before pushing:
+bash scripts/check-tdd-ordering.sh $(git merge-base origin/main HEAD) HEAD
+```
 
 ---
 

--- a/scripts/check-tdd-ordering.sh
+++ b/scripts/check-tdd-ordering.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# check-tdd-ordering.sh — Verify TDD commit ordering for pilot-scope paths.
+#
+# For each pilot path touched by the PR, at least one test-adding commit must
+# appear *before* any production-code commit in `git log --reverse`.  A commit
+# carrying a `tdd-exempt:<reason>` trailer (with a non-empty reason) exempts
+# the entire PR for that path.
+#
+# Usage:
+#   scripts/check-tdd-ordering.sh <base-sha> <head-sha>
+#
+# See issue #1927 for the full charter.
+
+set -euo pipefail
+
+# ── Pilot paths (§2 of the charter) ─────────────────────────────────────────
+PILOT_PATHS=(
+  "src/meeting_backend/"
+  "src/meeting_repl/"
+  "src/meeting_facilitator/"
+)
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+die()  { echo "::error::$*" >&2; exit 1; }
+warn() { echo "::warning::$*" >&2; }
+info() { echo "$*"; }
+
+usage() {
+  echo "Usage: $0 <base-sha> <head-sha>" >&2
+  exit 1
+}
+
+# Return 0 if a file path is inside one of the pilot directories.
+in_pilot_scope() {
+  local file="$1"
+  for p in "${PILOT_PATHS[@]}"; do
+    if [[ "$file" == "$p"* ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Return 0 if a file path looks like a test file.
+# Matches: files under tests/, files ending in _test.rs or _tests.rs,
+# files in a test_support/ directory, or files whose path contains /tests/.
+is_test_file() {
+  local file="$1"
+  # Integration tests live under tests/ at the repo root.
+  [[ "$file" == tests/* ]] && return 0
+  # Unit-test modules conventionally end with _test.rs or _tests.rs, or live
+  # in a test_support/ subtree.
+  [[ "$file" == *_test.rs ]] && return 0
+  [[ "$file" == *_tests.rs ]] && return 0
+  [[ "$file" == */test_support/* ]] && return 0
+  [[ "$file" == */tests/* ]] && return 0
+  # Inline #[cfg(test)] modules live inside production files — but the commit
+  # diff is what matters, not the filename. We check for test additions at
+  # the diff level separately.
+  return 1
+}
+
+# Return 0 if a commit adds or modifies test code (heuristic: the diff adds
+# lines containing #[test], #[tokio::test], or common test macros).
+commit_adds_tests() {
+  local sha="$1"
+  shift
+  local paths=("$@")
+  # Look at added lines in the diff for this commit, scoped to the given paths.
+  # We also include tests/ at the repo root since integration tests for pilot
+  # modules may live there.
+  local diff_output
+  diff_output=$(git diff-tree -p "$sha" -- "${paths[@]}" tests/ 2>/dev/null || true)
+  if echo "$diff_output" | grep -qE '^\+.*#\[(test|tokio::test)\]'; then
+    return 0
+  fi
+  if echo "$diff_output" | grep -qE '^\+.*(assert_eq!|assert!|assert_ne!|#\[cfg\(test\)\])'; then
+    return 0
+  fi
+  return 1
+}
+
+# Return 0 if a commit touches production (non-test) files in any pilot path.
+commit_touches_prod() {
+  local sha="$1"
+  shift
+  local paths=("$@")
+  local files
+  files=$(git diff-tree --no-commit-id -r --name-only "$sha" -- "${paths[@]}")
+  while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    if ! is_test_file "$f"; then
+      return 0
+    fi
+  done <<< "$files"
+  return 1
+}
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+
+[[ $# -eq 2 ]] || usage
+
+BASE_SHA="$1"
+HEAD_SHA="$2"
+
+info "TDD ordering check (issue #1927)"
+info "  base: $BASE_SHA"
+info "  head: $HEAD_SHA"
+info "  pilot paths: ${PILOT_PATHS[*]}"
+info ""
+
+# Collect commits in chronological (oldest-first) order.
+COMMITS=$(git log --reverse --format='%H' "$BASE_SHA".."$HEAD_SHA" --)
+
+if [ -z "$COMMITS" ]; then
+  info "No commits in range — nothing to check."
+  exit 0
+fi
+
+# ── Check for tdd-exempt trailer ─────────────────────────────────────────────
+# If any commit in the range carries a valid tdd-exempt trailer, the PR is
+# exempt and we exit early.
+for sha in $COMMITS; do
+  trailer=$(git log -1 --format='%(trailers:key=tdd-exempt,valueonly)' "$sha" 2>/dev/null || true)
+  trailer=$(echo "$trailer" | xargs)  # trim whitespace
+  if [ -n "$trailer" ]; then
+    info "✓ tdd-exempt trailer found on $sha: $trailer"
+    info "  Skipping TDD ordering check."
+    exit 0
+  fi
+done
+
+# ── Determine which pilot paths are touched ──────────────────────────────────
+ALL_FILES=$(git diff --name-only "$BASE_SHA".."$HEAD_SHA" --)
+declare -A TOUCHED_PILOTS
+
+for f in $ALL_FILES; do
+  for p in "${PILOT_PATHS[@]}"; do
+    if [[ "$f" == "$p"* ]]; then
+      TOUCHED_PILOTS["$p"]=1
+    fi
+  done
+done
+
+if [ ${#TOUCHED_PILOTS[@]} -eq 0 ]; then
+  info "No pilot-scope paths touched — nothing to check."
+  exit 0
+fi
+
+info "Pilot paths touched: ${!TOUCHED_PILOTS[*]}"
+info ""
+
+# ── For each touched pilot path, verify ordering ─────────────────────────────
+FAILED=0
+
+for pilot in "${!TOUCHED_PILOTS[@]}"; do
+  info "Checking $pilot ..."
+  test_seen=false
+  prod_before_test=false
+  first_prod_sha=""
+
+  for sha in $COMMITS; do
+    # Does this commit touch files in this pilot path?
+    files_in_pilot=$(git diff-tree --no-commit-id -r --name-only "$sha" -- "$pilot" 2>/dev/null || true)
+    [ -z "$files_in_pilot" ] && continue
+
+    # Check if this commit adds test code for this pilot path.
+    if commit_adds_tests "$sha" "$pilot"; then
+      test_seen=true
+    fi
+
+    # Check if this commit touches production code in this pilot path.
+    if commit_touches_prod "$sha" "$pilot"; then
+      if ! $test_seen; then
+        prod_before_test=true
+        first_prod_sha="$sha"
+      fi
+    fi
+  done
+
+  if $prod_before_test; then
+    short=$(git log -1 --format='%h %s' "$first_prod_sha")
+    echo "::error::TDD FAIL for $pilot — production code commit appears before any test commit."
+    echo "::error::  First offending commit: $short"
+    echo "::error::  Add a test-first commit or use a tdd-exempt:<reason> trailer."
+    echo "::error::  See: https://github.com/rysweet/Simard/issues/1927"
+    FAILED=1
+  else
+    info "  ✓ $pilot — test-first ordering satisfied (or only test changes)."
+  fi
+done
+
+echo ""
+if [ "$FAILED" -ne 0 ]; then
+  die "TDD ordering check failed. See errors above."
+else
+  info "✓ All pilot paths pass TDD ordering check."
+fi


### PR DESCRIPTION
## Summary

Implements the TDD commit-ordering CI gate chartered in #1927.

### Changes

1. **`scripts/check-tdd-ordering.sh`** — Given a PR's base and head SHAs, inspects `git log --reverse` for commits touching the pilot paths (`src/meeting_backend/`, `src/meeting_repl/`, `src/meeting_facilitator/`) and verifies at least one test-adding commit appears before any production-code commit. Accepts a `tdd-exempt:<reason>` trailer (non-empty reason required) as an escape hatch.

2. **`.github/workflows/verify.yml`** — New `tdd-ordering` job that runs on `pull_request` events with `fetch-depth: 0` (full history), passing `${{ github.event.pull_request.base.sha }}` and `${{ github.event.pull_request.head.sha }}` to the script.

3. **`CONTRIBUTING.md`** — New "TDD Discipline (Pilot)" section documenting the pilot scope, check requirements, exemption mechanism, and local verification command.

### Diff focused
Only 3 files changed, all directly related to the TDD gate. No unrelated edits.

### CI
The `tdd-ordering` job is gated on `pull_request` events only and has a 5-minute timeout. It does not affect push-triggered runs. The script exits cleanly when no pilot paths are touched.

### Local verification
```
$ bash scripts/check-tdd-ordering.sh $(git merge-base origin/main HEAD) HEAD
TDD ordering check (issue #1927)
  base: da46dcaa...
  head: HEAD
  pilot paths: src/meeting_backend/ src/meeting_repl/ src/meeting_facilitator/
No commits in range — nothing to check.
```

Closes #1927