### PR TITLE
docs: link TDD discipline concept doc from main index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -49,6 +49,7 @@ Terminal sessions and repo-grounded engineer runs now bridge through one explici
 - [Concept: truthful runtime metadata](./concepts/truthful-runtime-metadata.md) - Read the design rationale behind the stricter runtime contract.
 - [Concept: improvement context — denser execution evidence for the engineer loop](./concepts/improvement-context-execution-evidence-gap.md) - Captured improvement-curation context preserving the active "Capture denser execution evidence" goal and the observation that the legacy `simard_operator_probe` surface does not yet expose a terminal engineer-loop probe.
 - [Concept: automated disk health management](./concepts/automated-disk-health.md) - Design rationale for the per-cycle disk health check that prevents disk exhaustion (#2020).
+- [Concept: prompt-driven TDD discipline](./concepts/prompt-driven-tdd-discipline.md) - Why TDD commit ordering is enforced through the engineer system prompt, not CI scripts or git history parsing.
 
 ## Canonical executable surface
 


### PR DESCRIPTION
## Summary

Adds the prompt-driven TDD discipline concept doc (`docs/concepts/prompt-driven-tdd-discipline.md`) to the main documentation index (`docs/index.md`). The concept doc was created in commit `2a9c3e80` but was not discoverable from the docs start page.

Also created issue #2160 to audit recent engineer PRs for TDD commit-ordering compliance.

## Verification findings

### 1. Engineer system prompt loading (prompt_store.rs)

`prompt_store.rs` does **not** load `engineer_system.md` — it only handles OODA brain prompts (`ooda_brain.md`, `ooda_decide.md`, `ooda_orient.md`, etc.) via `include_str!` embedded fallbacks. The engineer system prompt is loaded at session start via `FilePromptAssetStore`, referenced through `PromptAssetRef::new("engineer-system", "simard/engineer_system.md")` in both `src/agent_roles.rs:103` and `src/identity/loader.rs:42`. The full file is loaded without truncation — the TDD rule at line 204 is included. No code path skips or truncates the Quality Standards section.

### 2. Concept doc discoverability

`docs/concepts/prompt-driven-tdd-discipline.md` was **not** linked from `docs/index.md`. This PR adds the link. The concept doc is also cross-linked from `docs/howto/edit-the-engineer-system-prompt.md` (line 84).

### 3. Audit issue

Created #2160 to audit the last 5 engineer PRs for TDD commit-ordering compliance.

## Changed surfaces

- `docs/index.md` — added one line linking the TDD concept doc (docs-only, internal)

## Merge-ready evidence

1. **QA scenarios**: N/A — docs-only change with no user-facing behavior change.
2. **Docs updated**: This PR *is* the docs update.
3. **Quality audit**: Single-line docs addition; no code changes to audit.
4. **CI**: Pre-push hooks passed (fmt, clippy, tests).
5. **Diff focused**: One line added to docs/index.md, no unrelated edits.

Refs #2160