### PR TITLE
feat(ci): add Rust-only gate to prevent new Python/JS/TS files (#2158)

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
+      - name: Rust-only gate (no new .py / .js / .ts)
+        run: scripts/check-rust-only-gate.sh
+
       - name: Prepare Rust runner (free disk, swap, mold, rust)
         uses: ./.github/actions/rust-runner-prep
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,17 @@ repos:
   - repo: local
     hooks:
       # ── pre-commit (fast: < 30s incremental) ─────────────────────────
+      - id: rust-only-gate
+        name: Rust-only gate — no new .py / .js / .ts outside allow-list
+        entry: scripts/check-rust-only-gate.sh --staged
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages:
+          - pre-commit
+          - pre-push
+          - manual
+
       - id: cargo-fmt
         name: cargo fmt --all -- --check
         entry: cargo fmt --all -- --check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,12 +9,29 @@ they are the same gates CI enforces.
 
 ## Table of Contents
 
-1. [Local Pre-Commit Workflow](#local-pre-commit-workflow)
-2. [Merge Policy: No `--admin` Merges](#merge-policy-no---admin-merges)
-3. [Cognitive Memory Durability (Per-Write Barrier + SIGTERM + Periodic Backups)](#cognitive-memory-durability-per-write-barrier--sigterm--periodic-backups)
-4. [Local Data Retention Disclosure](#local-data-retention-disclosure)
-5. [Pre-Existing Test Failure Disposition](#pre-existing-test-failure-disposition)
-6. [Real-Meeting & Dashboard E2E Verification](#real-meeting--dashboard-e2e-verification)
+1. [Rust-Only Policy](#rust-only-policy)
+2. [Local Pre-Commit Workflow](#local-pre-commit-workflow)
+3. [Merge Policy: No `--admin` Merges](#merge-policy-no---admin-merges)
+4. [Cognitive Memory Durability (Per-Write Barrier + SIGTERM + Periodic Backups)](#cognitive-memory-durability-per-write-barrier--sigterm--periodic-backups)
+5. [Local Data Retention Disclosure](#local-data-retention-disclosure)
+6. [Pre-Existing Test Failure Disposition](#pre-existing-test-failure-disposition)
+7. [Real-Meeting & Dashboard E2E Verification](#real-meeting--dashboard-e2e-verification)
+
+---
+
+## Rust-Only Policy
+
+Simard is migrating to a Rust-only codebase ([#2155](https://github.com/rysweet/Simard/issues/2155)).
+**New `.py` files under `src/` or `python/`, and new `.js`/`.ts` files outside
+`npm/` and `tests/e2e-dashboard/`, are not permitted.**
+
+A CI gate (`scripts/check-rust-only-gate.sh`) enforces this on every PR and
+as a pre-commit hook. A small set of pre-existing files is allow-listed until
+they are individually migrated — see the script for the current list.
+
+If you need to add a non-Rust file that falls outside the allow-list, open an
+issue explaining the need and add the file to the allow-list in
+`scripts/check-rust-only-gate.sh` with a comment referencing the issue.
 
 ---
 

--- a/scripts/check-rust-only-gate.sh
+++ b/scripts/check-rust-only-gate.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# check-rust-only-gate.sh — Enforce the Rust-only policy (issue #2155).
+#
+# Fails if any .py file under src/ or python/, or any .js/.ts file outside
+# exempted directories, is found that is NOT in the allow-list of pre-existing
+# files. This prevents new non-Rust source files from being added while the
+# migration proceeds.
+#
+# Usage:
+#   scripts/check-rust-only-gate.sh          # check working tree
+#   scripts/check-rust-only-gate.sh --staged # check only staged files (pre-commit)
+
+set -euo pipefail
+
+# ── Allow-list: pre-existing files that are permitted until migrated ──────────
+# Each entry is tracked by the Rust-only epic (#2155). Remove entries as the
+# corresponding rewrite issues (#2156, #2157) are completed.
+ALLOWED_PY_FILES=(
+  "python/bridge_server.py"
+  "python/simard_gym_bridge.py"
+  "python/simard_knowledge_bridge.py"
+)
+
+ALLOWED_JS_TS_FILES=(
+  "bin.js"
+  "bin.test.js"
+  "readme.test.js"
+)
+
+# Directories where JS/TS is permitted (e.g., npm wrapper, e2e test fixtures).
+EXEMPT_JS_TS_DIRS=(
+  "npm/"
+  "tests/e2e-dashboard/"
+)
+
+# ── Collect file list ─────────────────────────────────────────────────────────
+MODE="${1:-}"
+
+if [[ "$MODE" == "--staged" ]]; then
+  # Pre-commit: only check staged additions/modifications.
+  FILE_LIST=$(git diff --cached --name-only --diff-filter=ACR 2>/dev/null || true)
+else
+  # CI / manual: scan the full tree.
+  FILE_LIST=$(git ls-files 2>/dev/null || find . -type f | sed 's|^\./||')
+fi
+
+# ── Helper: check if a value is in an array ──────────────────────────────────
+in_array() {
+  local needle="$1"; shift
+  for item in "$@"; do
+    [[ "$item" == "$needle" ]] && return 0
+  done
+  return 1
+}
+
+# ── Helper: check if a path starts with any exempt prefix ────────────────────
+in_exempt_dir() {
+  local path="$1"; shift
+  for prefix in "$@"; do
+    [[ "$path" == "$prefix"* ]] && return 0
+  done
+  return 1
+}
+
+# ── Check for prohibited Python files ────────────────────────────────────────
+violations=()
+
+while IFS= read -r file; do
+  [[ -z "$file" ]] && continue
+
+  # Python files under src/ or python/
+  if [[ "$file" == src/*.py || "$file" == python/*.py ]] || \
+     [[ "$file" == src/**/*.py || "$file" == python/**/*.py ]]; then
+    if ! in_array "$file" "${ALLOWED_PY_FILES[@]}"; then
+      violations+=("PYTHON  $file")
+    fi
+  fi
+
+  # JS/TS files outside exempted directories
+  if [[ "$file" == *.js || "$file" == *.ts ]]; then
+    if ! in_exempt_dir "$file" "${EXEMPT_JS_TS_DIRS[@]}"; then
+      if ! in_array "$file" "${ALLOWED_JS_TS_FILES[@]}"; then
+        violations+=("JS/TS   $file")
+      fi
+    fi
+  fi
+done <<< "$FILE_LIST"
+
+# ── Report ───────────────────────────────────────────────────────────────────
+if [[ ${#violations[@]} -gt 0 ]]; then
+  echo "❌ Rust-only policy violation detected (see https://github.com/rysweet/Simard/issues/2155)"
+  echo ""
+  echo "The following non-Rust files are not in the allow-list:"
+  echo ""
+  for v in "${violations[@]}"; do
+    echo "  • $v"
+  done
+  echo ""
+  echo "This project is migrating to Rust-only. New .py files under src/ or python/"
+  echo "and new .js/.ts files outside npm/ and tests/e2e-dashboard/ are not permitted."
+  echo ""
+  echo "If this file is intentionally needed, add it to the allow-list in"
+  echo "scripts/check-rust-only-gate.sh and document the reason."
+  exit 1
+fi
+
+echo "✅ Rust-only gate passed — no prohibited non-Rust files found."
+exit 0


### PR DESCRIPTION
## Summary

Add a CI gate that enforces the Rust-only migration policy ([#2155](https://github.com/rysweet/Simard/issues/2155)), preventing new `.py` files under `src/` or `python/` and new `.js`/`.ts` files outside exempted directories.

Closes #2158

## Changes

| File | Purpose |
|------|---------|
| `scripts/check-rust-only-gate.sh` | Shell script that scans tracked files for prohibited non-Rust additions, with allow-list for pre-existing files |
| `.pre-commit-config.yaml` | New `rust-only-gate` hook (pre-commit + pre-push stages) |
| `.github/workflows/verify.yml` | CI step runs the gate immediately after checkout (before Rust toolchain setup — instant feedback) |
| `CONTRIBUTING.md` | New "Rust-Only Policy" section documenting the gate and how to handle exceptions |

## How it works

- **Python gate**: Fails if any `.py` file exists under `src/` or `python/` that is not in the allow-list
- **JS/TS gate**: Fails if any `.js`/`.ts` file exists outside `npm/` and `tests/e2e-dashboard/` that is not in the allow-list
- **Allow-list**: Pre-existing files (`python/bridge_server.py`, `python/simard_gym_bridge.py`, `python/simard_knowledge_bridge.py`, `bin.js`, `bin.test.js`, `readme.test.js`) are tracked for migration under #2155
- **Two enforcement points**: pre-commit hook (local) + CI step (remote)

## Verification

Tested locally:
- ✅ Current tree passes the gate (existing allowed files not flagged)
- ✅ Adding `src/sneaky.py` (staged) → gate fails with clear error message
- ✅ Adding `python/new_bad.py` (tracked) → gate fails
- ✅ Adding `src/bad.js` (staged) → gate fails
- ✅ Adding `tests/e2e-dashboard/specs/ok.ts` (staged, exempted dir) → not flagged
- ✅ Pre-commit hooks pass (rust-only-gate, cargo-fmt, cargo-clippy)
- ✅ Pre-push hooks pass (rust-only-gate, cargo-fmt, cargo-test-race-subset, cargo-clippy)

## Merge-readiness

- **Diff focused**: 4 files, 145 additions, all directly related to #2158
- **Docs updated**: CONTRIBUTING.md has new Rust-Only Policy section
- **CI**: Awaiting green run on this PR