### PR TITLE
fix: LRU-rotate ~/.cargo-targets/ to prevent home partition fill

### DIFF
--- a/src/cmd_cleanup/disk.rs
+++ b/src/cmd_cleanup/disk.rs
@@ -245,6 +245,74 @@ pub fn rotate_simard_binary_backups(report: &mut CleanupReport) {
     }
 }
 
+/// LRU-rotate `~/.cargo-targets/` subdirectories when total size exceeds
+/// `cap_bytes`. Each engineer worktree gets a per-worktree subdirectory here
+/// (set by `DEFAULT_CARGO_TARGETS_HOME_SUBDIR` in `agent_supervisor/tmux.rs`).
+/// Without capping, these accumulate at ~8-16 GB each and can fill the home
+/// partition entirely (observed 2026-05-29: 131 GB across 15 worktrees, 0
+/// bytes available on /home).
+pub fn cap_home_cargo_targets(report: &mut CleanupReport, cap_bytes: u64) {
+    let Some(home) = std::env::var_os("HOME") else {
+        return;
+    };
+    let targets_root = PathBuf::from(home).join(".cargo-targets");
+    let Ok(entries) = std::fs::read_dir(&targets_root) else {
+        return;
+    };
+    let current_target = std::env::var("CARGO_TARGET_DIR").ok();
+    let mut candidates: Vec<(PathBuf, u64, std::time::SystemTime)> = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        // Never delete the active CARGO_TARGET_DIR.
+        if let Some(ref current) = current_target
+            && Path::new(current) == path
+        {
+            continue;
+        }
+        let size = dir_size(&path).unwrap_or(0);
+        let mtime = entry
+            .metadata()
+            .and_then(|m| m.modified())
+            .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+        candidates.push((path, size, mtime));
+    }
+    let total: u64 = candidates.iter().map(|(_, s, _)| s).sum();
+    if total <= cap_bytes {
+        return;
+    }
+    eprintln!(
+        "  ~/.cargo-targets/ total {} MB exceeds cap {} MB — rotating LRU",
+        total / (1024 * 1024),
+        cap_bytes / (1024 * 1024)
+    );
+    // Sort oldest-first; remove until under 80% of cap.
+    candidates.sort_by_key(|(_, _, mtime)| *mtime);
+    let target_after = cap_bytes * 8 / 10;
+    let mut current_total = total;
+    for (path, size, _mtime) in candidates {
+        if current_total <= target_after {
+            break;
+        }
+        eprintln!(
+            "  Rotating LRU home target {} ({} MB)",
+            path.display(),
+            size / (1024 * 1024)
+        );
+        if let Err(e) = std::fs::remove_dir_all(&path) {
+            report
+                .errors
+                .push(format!("failed to rotate {}: {e}", path.display()));
+        } else {
+            report.bytes_freed += size;
+            current_total = current_total.saturating_sub(size);
+            report.dirs_removed.push(path);
+        }
+    }
+}
+
 /// Maximum age (in days) of corrupted memory DB files before deletion.
 pub const CORRUPT_DB_MAX_AGE_DAYS: u64 = 7;
 

--- a/src/cmd_cleanup/mod.rs
+++ b/src/cmd_cleanup/mod.rs
@@ -56,6 +56,11 @@ pub fn handle_cleanup() -> Result<(), Box<dyn std::error::Error>> {
     // 3b. LRU-rotate /tmp/simard-*-target dirs over the cap (P4 / #1244).
     cap_simard_target_dirs(&mut report, 10 * 1024 * 1024 * 1024);
 
+    // 3c. LRU-rotate ~/.cargo-targets/ dirs over the cap.
+    // Each engineer worktree gets ~8-16 GB; cap at 30 GB total to prevent
+    // filling the home partition (incident 2026-05-29: 131 GB, 0 avail).
+    cap_home_cargo_targets(&mut report, 30 * 1024 * 1024 * 1024);
+
     // 4. Kill orphaned cargo processes (running > 30 min with no parent simard)
     kill_orphaned_cargo_processes(&mut report);
 
@@ -148,9 +153,9 @@ mod disk;
 // re-exported for cfg(test) consumers in cmd_cleanup/tests.rs (false-positive of clippy unused_imports on lib pass — see #1405)
 #[allow(unused_imports)]
 pub(crate) use disk::{
-    BINARY_BACKUPS_KEEP, CORRUPT_DB_MAX_AGE_DAYS, SNAPSHOTS_KEEP, cap_simard_target_dirs,
-    clean_simard_canaries, clean_stale_cargo_targets, dir_size, remove_old_corrupt_dbs,
-    rotate_simard_binary_backups, trim_simard_snapshots,
+    BINARY_BACKUPS_KEEP, CORRUPT_DB_MAX_AGE_DAYS, SNAPSHOTS_KEEP, cap_home_cargo_targets,
+    cap_simard_target_dirs, clean_simard_canaries, clean_stale_cargo_targets, dir_size,
+    remove_old_corrupt_dbs, rotate_simard_binary_backups, trim_simard_snapshots,
 };
 
 #[cfg(test)]


### PR DESCRIPTION
## Problem

Engineer worktrees each get a per-worktree `CARGO_TARGET_DIR` under `~/.cargo-targets/` (~8-16 GB each). The existing cleanup only capped `/tmp/simard-*-target` dirs, leaving `~/.cargo-targets/` unbounded.

**Observed 2026-05-29**: 131 GB across 15 stale worktree targets filled the 393 GB home partition to 0 bytes available, causing:
- LadybugDB ENOSPC write failures
- 125+ consecutive backup failures
- All OODA activity halted for ~11 hours
- Daemon cycling every 5 min producing only error logs

## Fix

Adds `cap_home_cargo_targets()` with a 30 GB cap (keeps ~2-3 active worktrees, LRU-evicts the rest). Wired into `simard cleanup` pipeline at step 3c, alongside the existing `/tmp` target capping.

## Testing

- `cargo check --release` ✓
- `simard cleanup` runs successfully with the new step
- Binary deployed and daemon restarted

## Files changed

- `src/cmd_cleanup/disk.rs`: Added `cap_home_cargo_targets()`
- `src/cmd_cleanup/mod.rs`: Wired into cleanup pipeline + re-export