### PR TITLE
ci: add Rust-only policy gate to prevent new .py/.js/.ts files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,20 @@ default_install_hook_types:
 repos:
   - repo: local
     hooks:
+      # ── Rust-only policy gate (issue #2155 / #2158) ───────────────────
+      # Runs before the Rust toolchain hooks so violations fail fast
+      # without waiting for cargo fmt / clippy. Only fires when .py, .js,
+      # or .ts files are staged (or when pre-commit runs --all-files in CI).
+      - id: rust-only-policy
+        name: Rust-only policy gate (no new .py/.js/.ts — see #2155)
+        entry: scripts/check-rust-only-policy.sh
+        language: script
+        files: '\.(py|js|ts)$'
+        pass_filenames: true
+        stages:
+          - pre-commit
+          - manual
+
       # ── pre-commit (fast: < 30s incremental) ─────────────────────────
       - id: cargo-fmt
         name: cargo fmt --all -- --check

--- a/scripts/check-rust-only-policy.sh
+++ b/scripts/check-rust-only-policy.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Rust-only policy gate — see https://github.com/rysweet/Simard/issues/2155
+#
+# Blocks non-Rust files in restricted locations. Invoked by pre-commit with
+# the list of staged (or --all-files) paths matching *.py / *.js / *.ts.
+#
+# Rules:
+#   1. No new .py files under src/ or python/
+#   2. No new .js/.ts files outside npm/ and tests/e2e-dashboard/
+#
+# Existing files pending migration are allow-listed below.
+
+set -euo pipefail
+
+# ── Allow-list (existing files, tracked for migration in #2155) ──────────
+ALLOWLIST=(
+  # Python bridges (migration tracked in #2157)
+  python/bridge_server.py
+  python/simard_gym_bridge.py
+  python/simard_knowledge_bridge.py
+  # Python audit scripts (migration tracked in #2156)
+  scripts/dashboard_audit/audit_dashboard.py
+  scripts/dashboard_audit/audit_pass_01.py
+  # Root-level JS (disposition tracked in #2159)
+  bin.js
+  bin.test.js
+  readme.test.js
+)
+
+violations=()
+
+for file in "$@"; do
+  # Normalise path: strip leading ./
+  file="${file#./}"
+
+  # Skip allow-listed files
+  for allowed in "${ALLOWLIST[@]}"; do
+    if [[ "$file" == "$allowed" ]]; then
+      continue 2
+    fi
+  done
+
+  # Rule 1: .py files under src/ or python/
+  if [[ "$file" == *.py ]]; then
+    if [[ "$file" == src/* || "$file" == python/* ]]; then
+      violations+=("$file")
+    fi
+    continue
+  fi
+
+  # Rule 2: .js/.ts files outside exempt directories
+  if [[ "$file" == *.js || "$file" == *.ts ]]; then
+    if [[ "$file" != npm/* && "$file" != tests/e2e-dashboard/* ]]; then
+      violations+=("$file")
+    fi
+  fi
+done
+
+if (( ${#violations[@]} )); then
+  echo "❌ Rust-only policy violation (see #2155)"
+  echo ""
+  echo "The following files violate the Rust-only CLI policy:"
+  for v in "${violations[@]}"; do
+    echo "  - $v"
+  done
+  echo ""
+  echo "Policy: all new CLI code must be written in Rust."
+  echo "  • No new .py files under src/ or python/"
+  echo "  • No new .js/.ts files outside npm/ and tests/e2e-dashboard/"
+  echo ""
+  echo "If migrating an existing file, add it to the allow-list in"
+  echo "scripts/check-rust-only-policy.sh and reference the tracking issue."
+  echo ""
+  echo "Epic: https://github.com/rysweet/Simard/issues/2155"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Adds a CI gate that enforces the Rust-only CLI policy established in #2155. This prevents regression while the heavier migration work (#2156, #2157, #2159) proceeds.

## What it does

A pre-commit hook (`scripts/check-rust-only-policy.sh`) that blocks:

- **New `.py` files** under `src/` or `python/`
- **New `.js`/`.ts` files** outside the exempted directories (`npm/` and `tests/e2e-dashboard/`)

### Allow-listed files (pending migration)

| File | Tracking issue |
|------|---------------|
| `python/bridge_server.py` | #2157 |
| `python/simard_gym_bridge.py` | #2157 |
| `python/simard_knowledge_bridge.py` | #2157 |
| `scripts/dashboard_audit/audit_dashboard.py` | #2156 |
| `scripts/dashboard_audit/audit_pass_01.py` | #2156 |
| `bin.js` | #2159 |
| `bin.test.js` | #2159 |
| `readme.test.js` | #2159 |

### CI integration

The hook is registered in `.pre-commit-config.yaml` at the `pre-commit` stage. CI already runs `pre_commit run --all-files --hook-stage pre-commit` in the `verify.yml` workflow, so no workflow changes were needed.

### Error output

When a violation is detected, the gate produces a clear error referencing the policy and epic:

```
❌ Rust-only policy violation (see #2155)

The following files violate the Rust-only CLI policy:
  - python/new_bridge.py

Policy: all new CLI code must be written in Rust.
  • No new .py files under src/ or python/
  • No new .js/.ts files outside npm/ and tests/e2e-dashboard/
```

## Testing

Verified the script against all 8 test scenarios:
1. ✅ Allow-listed files pass
2. ✅ Files in exempt directories (`npm/`, `tests/e2e-dashboard/`) pass
3. ✅ New `.py` under `python/` → blocked
4. ✅ New `.py` under `src/` → blocked
5. ✅ New `.js` at root → blocked
6. ✅ New `.ts` under `src/` → blocked
7. ✅ `.py` under `tests/` → allowed (not restricted)
8. ✅ No matching files → passes cleanly

Full scan of all existing `.py`/`.js`/`.ts` files confirms zero false positives.

## Diff focused

2 files changed: `scripts/check-rust-only-policy.sh` (new) and `.pre-commit-config.yaml` (hook added).

Closes #2158