### PR TITLE
fix: daemon memory leak — prune state, cap memory store, add RSS health check (#2167)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,7 @@ pub mod remote_transfer;
 pub mod research_tracker;
 pub mod review;
 pub mod review_pipeline;
+pub mod rss_health;
 pub mod runtime;
 pub mod runtime_config;
 pub mod runtime_ipc;

--- a/src/memory/in_memory.rs
+++ b/src/memory/in_memory.rs
@@ -13,13 +13,30 @@ use super::types::{MemoryRecord, MemoryScope};
 pub struct InMemoryMemoryStore {
     records: Mutex<Vec<MemoryRecord>>,
     descriptor: BackendDescriptor,
+    /// Maximum number of records before oldest entries are evicted.
+    /// `0` means unlimited (legacy behavior).
+    max_capacity: usize,
 }
+
+/// Default max capacity for the in-memory store (issue #2167).
+/// Configurable via `SIMARD_MEMORY_STORE_MAX_CAPACITY` env var.
+const DEFAULT_MAX_CAPACITY: usize = 10_000;
 
 impl InMemoryMemoryStore {
     pub fn new(descriptor: BackendDescriptor) -> Self {
         Self {
             records: Mutex::new(Vec::new()),
             descriptor,
+            max_capacity: Self::capacity_from_env(),
+        }
+    }
+
+    /// Create a store with an explicit capacity limit.
+    pub fn with_max_capacity(descriptor: BackendDescriptor, max_capacity: usize) -> Self {
+        Self {
+            records: Mutex::new(Vec::new()),
+            descriptor,
+            max_capacity,
         }
     }
 
@@ -29,6 +46,22 @@ impl InMemoryMemoryStore {
             "runtime-port:memory-store",
             Freshness::now()?,
         )))
+    }
+
+    fn capacity_from_env() -> usize {
+        std::env::var("SIMARD_MEMORY_STORE_MAX_CAPACITY")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(DEFAULT_MAX_CAPACITY)
+    }
+
+    /// Evict the oldest records when the store exceeds `max_capacity`.
+    /// Called after each `put`. No-op when `max_capacity == 0`.
+    fn enforce_capacity(records: &mut Vec<MemoryRecord>, max_capacity: usize) {
+        if max_capacity > 0 && records.len() > max_capacity {
+            let excess = records.len() - max_capacity;
+            records.drain(..excess);
+        }
     }
 }
 
@@ -42,12 +75,14 @@ impl MemoryStore for InMemoryMemoryStore {
         if record.created_at.is_none() {
             record.created_at = Some(Utc::now());
         }
-        self.records
+        let mut records = self
+            .records
             .lock()
             .map_err(|_| SimardError::StoragePoisoned {
                 store: "memory".to_string(),
-            })?
-            .push(record);
+            })?;
+        records.push(record);
+        Self::enforce_capacity(&mut records, self.max_capacity);
         Ok(())
     }
 
@@ -234,5 +269,63 @@ mod tests {
         assert!(store.list_for_session(&sid).unwrap().is_empty());
         assert_eq!(store.count_for_session(&sid).unwrap(), 0);
         assert!(store.list_all().unwrap().is_empty());
+    }
+
+    // --- max capacity eviction (issue #2167) ---
+
+    #[test]
+    fn put_evicts_oldest_when_capacity_exceeded() {
+        let descriptor = BackendDescriptor::for_runtime_type::<InMemoryMemoryStore>(
+            "memory::in-memory",
+            "runtime-port:memory-store",
+            Freshness::now().unwrap(),
+        );
+        let store = InMemoryMemoryStore::with_max_capacity(descriptor, 3);
+        let sid = test_session_id();
+        for i in 0..5 {
+            store
+                .put(make_record(&format!("k{i}"), MemoryScope::Project, &sid))
+                .unwrap();
+        }
+        let all = store.list_all().unwrap();
+        assert_eq!(all.len(), 3, "store should cap at max_capacity");
+        // Oldest two (k0, k1) should have been evicted
+        assert_eq!(all[0].key, "k2");
+        assert_eq!(all[1].key, "k3");
+        assert_eq!(all[2].key, "k4");
+    }
+
+    #[test]
+    fn put_no_eviction_when_under_capacity() {
+        let descriptor = BackendDescriptor::for_runtime_type::<InMemoryMemoryStore>(
+            "memory::in-memory",
+            "runtime-port:memory-store",
+            Freshness::now().unwrap(),
+        );
+        let store = InMemoryMemoryStore::with_max_capacity(descriptor, 10);
+        let sid = test_session_id();
+        for i in 0..5 {
+            store
+                .put(make_record(&format!("k{i}"), MemoryScope::Project, &sid))
+                .unwrap();
+        }
+        assert_eq!(store.list_all().unwrap().len(), 5);
+    }
+
+    #[test]
+    fn zero_capacity_means_unlimited() {
+        let descriptor = BackendDescriptor::for_runtime_type::<InMemoryMemoryStore>(
+            "memory::in-memory",
+            "runtime-port:memory-store",
+            Freshness::now().unwrap(),
+        );
+        let store = InMemoryMemoryStore::with_max_capacity(descriptor, 0);
+        let sid = test_session_id();
+        for i in 0..100 {
+            store
+                .put(make_record(&format!("k{i}"), MemoryScope::Project, &sid))
+                .unwrap();
+        }
+        assert_eq!(store.list_all().unwrap().len(), 100);
     }
 }

--- a/src/ooda_loop/cycle.rs
+++ b/src/ooda_loop/cycle.rs
@@ -447,6 +447,14 @@ fn run_ooda_cycle_inner(
     }
 
     state.cycle_count += 1;
+
+    // --- Post-cycle cleanup (issue #2167) ---
+    // Prune goal_failure_counts entries for goals no longer on the board.
+    state.prune_stale_failure_counts();
+    // Release prepared_context so the allocation doesn't persist until the
+    // next cycle replaces it.
+    state.prepared_context = None;
+
     let brain_judgments = crate::ooda_brain::take_brain_judgments();
     Ok(CycleReport {
         cycle_number: state.cycle_count,

--- a/src/ooda_loop/tests_types.rs
+++ b/src/ooda_loop/tests_types.rs
@@ -263,3 +263,63 @@ fn action_outcome_construction() {
     assert!(outcome.success);
     assert_eq!(outcome.detail, "session launched");
 }
+
+// --- prune_stale_failure_counts (issue #2167) ---
+
+#[test]
+fn prune_stale_failure_counts_removes_absent_goals() {
+    let mut board = GoalBoard::new();
+    board.active.push(ActiveGoal {
+        id: "goal-keep".to_string(),
+        description: "Active goal".to_string(),
+        priority: 1,
+        status: GoalProgress::NotStarted,
+        assigned_to: None,
+        current_activity: None,
+        wip_refs: vec![],
+        last_progress_update_at: None,
+    });
+    let mut state = OodaState::new(board);
+    state.goal_failure_counts.insert("goal-keep".to_string(), 3);
+    state
+        .goal_failure_counts
+        .insert("goal-removed".to_string(), 5);
+    state
+        .goal_failure_counts
+        .insert("goal-also-gone".to_string(), 1);
+
+    state.prune_stale_failure_counts();
+
+    assert_eq!(state.goal_failure_counts.len(), 1);
+    assert_eq!(state.goal_failure_counts.get("goal-keep"), Some(&3));
+    assert!(!state.goal_failure_counts.contains_key("goal-removed"));
+    assert!(!state.goal_failure_counts.contains_key("goal-also-gone"));
+}
+
+#[test]
+fn prune_stale_failure_counts_noop_when_all_present() {
+    let mut board = GoalBoard::new();
+    board.active.push(ActiveGoal {
+        id: "g1".to_string(),
+        description: "g1".to_string(),
+        priority: 1,
+        status: GoalProgress::NotStarted,
+        assigned_to: None,
+        current_activity: None,
+        wip_refs: vec![],
+        last_progress_update_at: None,
+    });
+    let mut state = OodaState::new(board);
+    state.goal_failure_counts.insert("g1".to_string(), 2);
+    state.prune_stale_failure_counts();
+    assert_eq!(state.goal_failure_counts.len(), 1);
+}
+
+#[test]
+fn prune_stale_failure_counts_empty_board_clears_all() {
+    let mut state = OodaState::new(GoalBoard::new());
+    state.goal_failure_counts.insert("orphan-a".to_string(), 10);
+    state.goal_failure_counts.insert("orphan-b".to_string(), 20);
+    state.prune_stale_failure_counts();
+    assert!(state.goal_failure_counts.is_empty());
+}

--- a/src/ooda_loop/types.rs
+++ b/src/ooda_loop/types.rs
@@ -81,6 +81,20 @@ impl OodaState {
             engineer_worktrees: HashMap::new(),
         }
     }
+
+    /// Remove `goal_failure_counts` entries for goal IDs that are no longer
+    /// present on the active board. Prevents unbounded growth when goals are
+    /// archived or removed over many cycles (issue #2167).
+    pub fn prune_stale_failure_counts(&mut self) {
+        let active_ids: std::collections::HashSet<&str> = self
+            .active_goals
+            .active
+            .iter()
+            .map(|g| g.id.as_str())
+            .collect();
+        self.goal_failure_counts
+            .retain(|id, _| active_ids.contains(id.as_str()));
+    }
 }
 
 /// A single goal's status snapshot for observation.

--- a/src/operator_commands_ooda/daemon/mod.rs
+++ b/src/operator_commands_ooda/daemon/mod.rs
@@ -387,6 +387,18 @@ pub fn run_ooda_daemon(
     );
     // -------------------------------------------------------------------
 
+    // --- periodic engineer worktree sweep state (issue #2167) -----------
+    let worktree_sweep_interval_secs: u64 = std::env::var("SIMARD_WORKTREE_SWEEP_INTERVAL_SECS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(1800); // every 30 minutes by default
+    let mut last_worktree_sweep = Instant::now(); // startup sweep just ran
+    daemon_log(
+        &state_root,
+        &format!("[simard] OODA daemon: worktree sweep interval = {worktree_sweep_interval_secs}s"),
+    );
+    // -------------------------------------------------------------------
+
     let mut cycles_run = 0u32;
 
     loop {
@@ -527,6 +539,49 @@ pub fn run_ooda_daemon(
                 }
             }
             last_disk_health = Instant::now();
+        }
+        // -------------------------------------------------------------------
+
+        // ── RSS health check (issue #2167) ──────────────────────────────
+        if let Some(report) = crate::rss_health::check_rss_health() {
+            let rss_str = crate::rss_health::format_rss(report.rss_bytes);
+            if report.critical {
+                daemon_log(
+                    &state_root,
+                    &format!("[simard] CRITICAL: RSS = {rss_str} — exceeds hard threshold"),
+                );
+            } else if report.warn {
+                daemon_log(
+                    &state_root,
+                    &format!("[simard] WARN: RSS = {rss_str} — exceeds warn threshold"),
+                );
+            } else {
+                daemon_log(&state_root, &format!("[simard] RSS health: {rss_str}"));
+            }
+        }
+        // ── Periodic engineer worktree sweep (issue #2167) ──────────────
+        if last_worktree_sweep.elapsed() >= Duration::from_secs(worktree_sweep_interval_secs) {
+            if let Ok(parent_repo) = std::env::current_dir() {
+                match crate::engineer_worktree::sweep_orphaned_worktrees(&parent_repo, &state_root)
+                {
+                    Ok(report) => {
+                        if !report.removed_orphan_dirs.is_empty() {
+                            daemon_log(
+                                &state_root,
+                                &format!(
+                                    "[simard] periodic sweep: removed {} orphan engineer worktree(s)",
+                                    report.removed_orphan_dirs.len()
+                                ),
+                            );
+                        }
+                    }
+                    Err(e) => daemon_log(
+                        &state_root,
+                        &format!("[simard] periodic worktree sweep failed: {e}"),
+                    ),
+                }
+            }
+            last_worktree_sweep = Instant::now();
         }
         // -------------------------------------------------------------------
 

--- a/src/rss_health.rs
+++ b/src/rss_health.rs
@@ -1,0 +1,133 @@
+//! Per-cycle RSS health monitoring for the OODA daemon (issue #2167).
+//!
+//! Reads `/proc/self/statm` on Linux to report the daemon's resident set
+//! size in bytes. Configurable warn and hard thresholds trigger log output
+//! so operators are alerted before the OOM killer intervenes.
+
+use std::fs;
+
+/// RSS health check result.
+#[derive(Clone, Debug)]
+pub struct RssReport {
+    /// Resident set size in bytes.
+    pub rss_bytes: u64,
+    /// True when RSS exceeds the warn threshold.
+    pub warn: bool,
+    /// True when RSS exceeds the hard threshold.
+    pub critical: bool,
+}
+
+/// Default warn threshold: 4 GiB.
+const DEFAULT_WARN_BYTES: u64 = 4 * 1024 * 1024 * 1024;
+/// Default hard threshold: 16 GiB.
+const DEFAULT_HARD_BYTES: u64 = 16 * 1024 * 1024 * 1024;
+
+/// Read the current process's RSS from `/proc/self/statm`.
+///
+/// Returns `None` on non-Linux platforms or if the file cannot be read.
+pub fn read_rss_bytes() -> Option<u64> {
+    let content = fs::read_to_string("/proc/self/statm").ok()?;
+    // statm fields: size resident shared text lib data dt (all in pages)
+    let resident_pages: u64 = content.split_whitespace().nth(1)?.parse().ok()?;
+    let page_size = page_size();
+    Some(resident_pages * page_size)
+}
+
+/// Check RSS against configurable thresholds and log warnings.
+///
+/// Thresholds are read from environment variables:
+/// - `SIMARD_RSS_WARN_BYTES` (default: 4 GiB)
+/// - `SIMARD_RSS_HARD_BYTES` (default: 16 GiB)
+pub fn check_rss_health() -> Option<RssReport> {
+    let rss_bytes = read_rss_bytes()?;
+    let warn_threshold = env_u64("SIMARD_RSS_WARN_BYTES", DEFAULT_WARN_BYTES);
+    let hard_threshold = env_u64("SIMARD_RSS_HARD_BYTES", DEFAULT_HARD_BYTES);
+
+    let warn = rss_bytes >= warn_threshold;
+    let critical = rss_bytes >= hard_threshold;
+
+    let report = RssReport {
+        rss_bytes,
+        warn,
+        critical,
+    };
+
+    if critical {
+        tracing::error!(
+            target: "simard::rss_health",
+            rss_mb = rss_bytes / (1024 * 1024),
+            threshold_mb = hard_threshold / (1024 * 1024),
+            "CRITICAL: RSS exceeds hard threshold",
+        );
+    } else if warn {
+        tracing::warn!(
+            target: "simard::rss_health",
+            rss_mb = rss_bytes / (1024 * 1024),
+            threshold_mb = warn_threshold / (1024 * 1024),
+            "RSS exceeds warn threshold",
+        );
+    }
+
+    Some(report)
+}
+
+/// Format RSS in human-readable form for log output.
+pub fn format_rss(bytes: u64) -> String {
+    if bytes >= 1024 * 1024 * 1024 {
+        format!("{:.1} GiB", bytes as f64 / (1024.0 * 1024.0 * 1024.0))
+    } else {
+        format!("{} MiB", bytes / (1024 * 1024))
+    }
+}
+
+fn env_u64(key: &str, default: u64) -> u64 {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+fn page_size() -> u64 {
+    // sysconf(_SC_PAGESIZE) — safe, infallible on Linux.
+    #[cfg(unix)]
+    {
+        // SAFETY: sysconf(_SC_PAGESIZE) is always valid on Linux/macOS.
+        let ps = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+        if ps > 0 { ps as u64 } else { 4096 }
+    }
+    #[cfg(not(unix))]
+    {
+        4096
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_rss_mib() {
+        assert_eq!(format_rss(512 * 1024 * 1024), "512 MiB");
+    }
+
+    #[test]
+    fn format_rss_gib() {
+        assert_eq!(format_rss(4 * 1024 * 1024 * 1024), "4.0 GiB");
+    }
+
+    #[test]
+    fn read_rss_returns_some_on_linux() {
+        // On Linux CI this should succeed; on other platforms it returns None.
+        if cfg!(target_os = "linux") {
+            let rss = read_rss_bytes();
+            assert!(rss.is_some(), "should read RSS on Linux");
+            assert!(rss.unwrap() > 0, "RSS must be positive");
+        }
+    }
+
+    #[test]
+    fn check_rss_health_does_not_panic() {
+        // Just verify it doesn't crash regardless of platform.
+        let _ = check_rss_health();
+    }
+}


### PR DESCRIPTION
## Summary

Addresses all five root causes of unbounded daemon RSS growth identified in #2167.

## Changes

### 1. Prune `goal_failure_counts` after each cycle
- Added `OodaState::prune_stale_failure_counts()` — retains only entries for goals still on the active board.
- Called at the end of each OODA cycle in `cycle.rs`.

### 2. Configurable max-capacity eviction for `InMemoryMemoryStore`
- Added `max_capacity` field (default: 10,000 via `SIMARD_MEMORY_STORE_MAX_CAPACITY` env var).
- When exceeded, oldest records are drained on `put()`. Capacity of 0 means unlimited (legacy behavior).
- Added `with_max_capacity()` constructor for tests.

### 3. Per-cycle RSS health monitoring
- New `rss_health` module reads `/proc/self/statm` on Linux.
- Configurable thresholds: `SIMARD_RSS_WARN_BYTES` (default 4 GiB), `SIMARD_RSS_HARD_BYTES` (default 16 GiB).
- Emits `tracing::warn`/`tracing::error` and daemon log output each cycle.

### 4. Clear `prepared_context` at end of each cycle
- `state.prepared_context = None` added after `cycle_count` increment so the `PreparedContext` allocation is freed immediately.

### 5. Periodic worktree sweep in daemon loop
- Added periodic `sweep_orphaned_worktrees()` call (default every 30 min via `SIMARD_WORKTREE_SWEEP_INTERVAL_SECS`).
- Previously only ran at daemon startup.

## Testing

- 3 new unit tests for `prune_stale_failure_counts` (all pass)
- 3 new unit tests for `InMemoryMemoryStore` capacity eviction (all pass)
- 4 new unit tests for `rss_health` module (all pass)
- Full `cargo test --lib`: 5001 passed, 1 pre-existing failure (hermetic guard, unrelated)
- `cargo clippy`: clean
- `cargo fmt`: clean
- Pre-commit hooks: passed
- Pre-push hooks: passed (fmt + tests + clippy)

## Diff focus

7 files changed, 367 insertions, 3 deletions. All changes directly address the five memory growth vectors. No unrelated edits.

Fixes #2167