### PR TITLE
feat(#2159): document Rust-only exemptions for JS/TS periphery

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -1,6 +1,11 @@
 #!/usr/bin/env node
 "use strict";
 
+// RUST-ONLY EXEMPTION (issue #2159, epic #2155)
+// npx entry point — distribution glue that downloads and runs the Rust binary.
+// Same exemption rationale as npm/bin.js: not runtime code, required by the
+// npm/npx distribution channel.
+
 const { existsSync, mkdirSync, chmodSync, unlinkSync, readFileSync, writeFileSync } = require("fs");
 const { execFileSync } = require("child_process");
 const { join } = require("path");

--- a/bin.test.js
+++ b/bin.test.js
@@ -1,6 +1,10 @@
 #!/usr/bin/env node
 "use strict";
 
+// RUST-ONLY EXEMPTION (issue #2159, epic #2155)
+// Tests for the npx wrapper. Same exemption rationale as bin.js:
+// distribution glue, not runtime code.
+
 // Unit tests for bin.js npx wrapper.
 // Validates gh release download approach for private repos.
 // Run: node bin.test.js

--- a/npm/bin.js
+++ b/npm/bin.js
@@ -1,6 +1,12 @@
 #!/usr/bin/env node
 "use strict";
 
+// RUST-ONLY EXEMPTION (issue #2159, epic #2155)
+// This file is distribution glue, not runtime code. It executes only during
+// `npm install` to download and install the correct prebuilt Rust binary.
+// The npm ecosystem requires JavaScript for package install scripts.
+// Rewriting this would mean abandoning npm as a distribution channel.
+
 const { existsSync, mkdirSync, chmodSync } = require("fs");
 const { execFileSync, execSync } = require("child_process");
 const { join } = require("path");

--- a/npm/bin.test.js
+++ b/npm/bin.test.js
@@ -1,6 +1,10 @@
 #!/usr/bin/env node
 "use strict";
 
+// RUST-ONLY EXEMPTION (issue #2159, epic #2155)
+// Tests for the npm distribution shim. Same exemption rationale as npm/bin.js:
+// distribution glue, not runtime code.
+
 // Unit tests for bin.js helper functions.
 // Run: node npm/bin.test.js
 

--- a/readme.test.js
+++ b/readme.test.js
@@ -1,6 +1,10 @@
 #!/usr/bin/env node
 "use strict";
 
+// RUST-ONLY EXEMPTION (issue #2159, epic #2155)
+// Documentation validation tool, not runtime code. Tests that README.md
+// contains required sections. No Rust equivalent needed for doc linting.
+
 // TDD tests for README.md documentation requirements.
 // Validates that README contains required sections for:
 //   - npx install method (at top of Install section)

--- a/tests/e2e-dashboard/RUST_ONLY_EXEMPTION.md
+++ b/tests/e2e-dashboard/RUST_ONLY_EXEMPTION.md
@@ -1,0 +1,31 @@
+# Rust-Only Exemption: Playwright E2E Tests
+
+**Issue**: [#2159](https://github.com/rysweet/Simard/issues/2159)
+**Epic**: [#2155](https://github.com/rysweet/Simard/issues/2155) (enforce Rust-only)
+**Status**: EXEMPT
+
+## Rationale
+
+These are **test tooling**, not production code. Playwright is the
+industry-standard browser automation framework and has no Rust equivalent
+with comparable maturity. These tests validate the dashboard UI, which is
+itself a web application requiring JavaScript. Rewriting browser automation
+tests in Rust would sacrifice test quality for language purity.
+
+## Scope
+
+All `.ts` files under `tests/e2e-dashboard/` are covered by this exemption:
+
+- `playwright.config.ts` — test configuration
+- `fixtures/*.ts` — test fixtures
+- `pages/*.ts` — page object models
+- `specs/*.ts` — test specifications
+
+The `smoke_python/` subdirectory contains Python smoke tests that are
+separately tracked under the Rust-only epic.
+
+## CI Enforcement
+
+A pre-commit hook (`no-new-js-ts`) prevents new `.js`/`.ts` files from being
+added outside the exempted directories (`npm/`, `tests/e2e-dashboard/`, and
+the root-level distribution shims). See `.pre-commit-config.yaml`.

--- a/tests/e2e-dashboard/playwright.config.ts
+++ b/tests/e2e-dashboard/playwright.config.ts
@@ -1,3 +1,10 @@
+// RUST-ONLY EXEMPTION (issue #2159, epic #2155)
+// Playwright e2e tests are test tooling, not production code. Playwright is
+// the industry-standard browser automation framework with no Rust equivalent
+// of comparable maturity. These tests validate the dashboard UI (a web app
+// that inherently requires JS). Rewriting browser automation in Rust would
+// sacrifice test quality for language purity.
+
 import { defineConfig, devices } from '@playwright/test';
 
 const PORT = Number(process.env.SIMARD_DASHBOARD_PORT ?? 18787);


### PR DESCRIPTION
## Summary

Explicitly dispositions all JS/TS files per the Rust-only policy meeting decision.

**Exempted (with documented rationale):**
- `npm/bin.js`, `npm/bin.test.js` — npm distribution shim (not runtime code)
- `bin.js`, `bin.test.js` — npx entry point (distribution glue)
- `readme.test.js` — documentation validation tool
- `tests/e2e-dashboard/**/*.ts` — Playwright e2e tests (test tooling, no mature Rust alternative)

## Changes

1. Added `RUST-ONLY EXEMPTION` header comments to all 6 JS/TS source files documenting why each is exempt
2. Created `tests/e2e-dashboard/RUST_ONLY_EXEMPTION.md` with full rationale for the Playwright test suite
3. CI gate already exists: `scripts/check-rust-only-gate.sh` + pre-commit hook `rust-only-gate` prevents new JS/TS files outside exempted directories

## Acceptance Criteria (from #2159)

- [x] Exemption rationale documented in code comments and RUST_ONLY_EXEMPTION.md
- [x] Comments added to `npm/bin.js` and `tests/e2e-dashboard/`
- [x] CI rule enforced: `rust-only-gate` pre-commit hook blocks new .js/.ts files outside `npm/` and `tests/e2e-dashboard/` (plus root-level allow-list)

## References

Closes #2159
Part of #2155 (Epic: enforce Rust-only)
