### PR TITLE
feat(dashboard): humanize raw action_kind values in Overview and Workboard feeds

### DIFF
--- a/src/operator_commands_dashboard/index_html/part_01.rs
+++ b/src/operator_commands_dashboard/index_html/part_01.rs
@@ -99,6 +99,36 @@ pub(crate) const PART_01: &str = r#"      </div>
       if(!text)return {};
       return JSON.parse(text);
     }
+    const ACTION_KIND_LABELS={
+      'spawn_engineer':'Launched sub-agent',
+      'advance-goal':'Advanced goal',
+      'run-improvement':'Ran improvement',
+      'consolidate-memory':'Consolidated memory',
+      'research-query':'Researched query',
+      'run-gym-eval':'Ran gym evaluation',
+      'build-skill':'Built skill',
+      'launch-session':'Launched session',
+      'poll-developer-activity':'Polled developer activity',
+      'extract-ideas':'Extracted ideas',
+      'safe-update':'Safe update',
+      'progress_assessment':'Checked progress',
+      'merge_readiness_check':'Evaluated PR readiness',
+      'disk_health_check':'Checked disk health',
+      'goal_create':'Created a goal',
+      'goal_close':'Closed a goal',
+      'goal_reflect':'Goal reflection',
+      'ooda_cycle':'Decision cycle',
+      'meeting_decision':'Meeting decision',
+      'noop':'No action taken',
+      'cycle-summary':'Cycle summary',
+      'current':'Current action',
+    };
+    function humanizeActionKind(kind){
+      if(!kind)return'';
+      const label=ACTION_KIND_LABELS[kind];
+      if(label)return label;
+      return kind.replace(/[-_]/g,' ').replace(/^./,c=>c.toUpperCase());
+    }
     function timeAgo(ts){
       if(!ts)return'—';
       const d=parseTs(ts);if(!d||isNaN(d))return String(ts);
@@ -310,7 +340,7 @@ pub(crate) const PART_01: &str = r#"      </div>
               ${latestActions.map(o=>`
                 <div style="padding:.2rem 0;display:flex;gap:.5rem;align-items:baseline">
                   <span>${o.success?'✅':'❌'}</span>
-                  <code style="color:var(--accent)">${esc(o.action_kind||'')}</code>
+                  <code style="color:var(--accent)">${humanizeActionKind(o.action_kind)}</code>
                   <span>${esc(o.action_description||'')}</span>
                   ${o.detail?'<span style="color:#8b949e;font-size:.8rem;max-width:400px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;display:inline-block">'+esc(o.detail.substring(0,120))+'</span>':''}
                 </div>`).join('')}
@@ -346,7 +376,7 @@ pub(crate) const PART_01: &str = r#"      </div>
             <div style="padding:.25rem 0;border-bottom:1px solid var(--border);font-size:.85rem;display:flex;gap:.5rem;align-items:baseline">
               <span style="color:var(--accent);min-width:2rem;font-weight:600">#${a.cycle}</span>
               <span>${a.success?'✅':'❌'}</span>
-              <code>${esc(a.action_kind||'')}</code>
+              <code>${humanizeActionKind(a.action_kind)}</code>
               <span style="flex:1">${renderActionDetail((function(){var arr=Array.from(a.detail||'');var d=arr.length>200?arr.slice(0,200).join('')+'…':arr.join('');return d||a.action_description||'';})())}</span>
             </div>`).join('');
         }else{

--- a/src/operator_commands_dashboard/index_html/part_04.rs
+++ b/src/operator_commands_dashboard/index_html/part_04.rs
@@ -151,7 +151,7 @@ pub(crate) const PART_04: &str = r#"            let fmt;
             const isCurrent=a.action==='current';
             return`<div style="display:flex;gap:.5rem;padding:.35rem 0;border-bottom:1px solid var(--border);font-size:.85rem">
               <span style="color:var(--accent);min-width:2.5rem;font-weight:600">#${a.cycle}</span>
-              <span style="min-width:5rem;color:${isCurrent?'var(--green)':'#8b949e'}">${esc(a.action)}</span>
+              <span style="min-width:5rem;color:${isCurrent?'var(--green)':'#8b949e'}">${humanizeActionKind(a.action)}</span>
               <span style="flex:1">${renderActionDetail(a.result)}</span>
               ${a.at?'<span style="color:#8b949e;font-size:.75rem">'+timeAgo(a.at)+'</span>':''}
             </div>`;
@@ -260,7 +260,7 @@ pub(crate) const PART_04: &str = r#"            let fmt;
                   const linkIcon=hasArtifact?'<span style="color:#2ea043;margin-right:4px" title="produced artifact">🔗</span>':'';
                   const assessBadge=(!hasArtifact&&isAssessmentOnly)?' <span class="badge-assessment" style="background:#fb8500;color:#fff;padding:1px 6px;border-radius:3px;font-size:11px;margin-left:6px">assessment only</span>':'';
                   return `<div class="outcome ${o.success?'success':'failure'}">
-                    ${o.success?'✅':'❌'} <code>${esc(o.action_kind)}</code> — ${esc(o.action_description)}${assessBadge}
+                    ${o.success?'✅':'❌'} <code>${humanizeActionKind(o.action_kind)}</code> — ${esc(o.action_description)}${assessBadge}
                     <div class="outcome-detail">${linkIcon}${esc(det.substring(0,300))}${det.length>300?'…':''}</div>
                     ${seBlock}
                   </div>`;


### PR DESCRIPTION
## Summary

Closes #2121.

Adds a client-side `humanizeActionKind()` mapping function that converts raw internal `action_kind` identifiers (e.g. `spawn_engineer`, `advance-goal`, `consolidate-memory`) to plain-English labels in the dashboard action feeds.

## Changes

**2 files changed** — `part_01.rs`, `part_04.rs` (display-only, no API changes)

### New: `humanizeActionKind(kind)` helper (part_01.rs)
Static lookup table covering all `ActionKind` enum variants plus legacy snake_case kinds (`spawn_engineer`, `progress_assessment`, `disk_health_check`, etc.). Falls back to capitalize + de-snake for unknown kinds.

### Updated render sites
| # | Location | Tab | Before | After |
|---|----------|-----|--------|-------|
| 1 | part_01.rs L313 | Overview — Last Cycle Actions | `esc(o.action_kind)` | `humanizeActionKind(o.action_kind)` |
| 2 | part_01.rs L349 | Overview — Recent Actions | `esc(a.action_kind)` | `humanizeActionKind(a.action_kind)` |
| 3 | part_04.rs L154 | Workboard — Recent Actions | `esc(a.action)` | `humanizeActionKind(a.action)` |
| 4 | part_04.rs L263 | Thinking — Cycle Outcomes | `esc(o.action_kind)` | `humanizeActionKind(o.action_kind)` |

## Merge-readiness evidence

1. **Tests**: `cargo test --lib` — 4992 passed, 0 failed
2. **Pre-commit**: cargo fmt + clippy passed
3. **Pre-push**: cargo fmt + cargo test (memory subset) + clippy all-targets passed
4. **Diff focused**: 2 files, 34 insertions, 4 deletions — no unrelated edits
5. **Docs**: No user-facing doc surfaces changed (internal display labels only)
6. **API unchanged**: JSON `action_kind` field untouched — display-only change