### PR TITLE
fix: disable incremental compilation for release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ serial_test = "3.4.0"
 lto = "thin"
 codegen-units = 1
 strip = "symbols"
+incremental = false
 
 # Dev/test profiles: minimal debuginfo philosophy.
 #


### PR DESCRIPTION
Release incremental artifacts for 507 deps accumulate without bound, growing the main target dir to 300G+ within 24-48h (observed twice: 2026-05-29 and 2026-06-01). Dev profile already had `incremental=false`; release was missing it.

With this change, release builds are clean each time (~1.6G peak vs 300G+ accumulated).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>