### PR TITLE
feat(dashboard): humanize raw action_kind values in Overview and Workboard feeds

### DIFF
--- a/src/operator_commands_dashboard/index_html/part_01.rs
+++ b/src/operator_commands_dashboard/index_html/part_01.rs
@@ -117,6 +117,12 @@ pub(crate) const PART_01: &str = r#"      </div>
       const d=parseTs(ts);if(!d)return ts==null?'—':String(ts);
       try{return d.toLocaleString();}catch(_){return d.toISOString();}
     }
+    function humanizeActionKind(kind){
+      if(!kind)return'';
+      const map={'spawn_engineer':'Launched sub-agent','progress_assessment':'Checked progress','merge_readiness_check':'Evaluated PR readiness','disk_health_check':'Checked disk health','goal_create':'Created a goal','goal_close':'Closed a goal'};
+      if(map[kind])return map[kind];
+      return kind.replace(/[_-]+/g,' ').replace(/^./,c=>c.toUpperCase());
+    }
     function copyLogContent(id){
       const el=document.getElementById(id);if(!el)return;
       navigator.clipboard.writeText(el.textContent||'').then(
@@ -310,7 +316,7 @@ pub(crate) const PART_01: &str = r#"      </div>
               ${latestActions.map(o=>`
                 <div style="padding:.2rem 0;display:flex;gap:.5rem;align-items:baseline">
                   <span>${o.success?'✅':'❌'}</span>
-                  <code style="color:var(--accent)">${esc(o.action_kind||'')}</code>
+                  <code style="color:var(--accent)">${esc(humanizeActionKind(o.action_kind))}</code>
                   <span>${esc(o.action_description||'')}</span>
                   ${o.detail?'<span style="color:#8b949e;font-size:.8rem;max-width:400px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;display:inline-block">'+esc(o.detail.substring(0,120))+'</span>':''}
                 </div>`).join('')}
@@ -346,7 +352,7 @@ pub(crate) const PART_01: &str = r#"      </div>
             <div style="padding:.25rem 0;border-bottom:1px solid var(--border);font-size:.85rem;display:flex;gap:.5rem;align-items:baseline">
               <span style="color:var(--accent);min-width:2rem;font-weight:600">#${a.cycle}</span>
               <span>${a.success?'✅':'❌'}</span>
-              <code>${esc(a.action_kind||'')}</code>
+              <code>${esc(humanizeActionKind(a.action_kind))}</code>
               <span style="flex:1">${renderActionDetail((function(){var arr=Array.from(a.detail||'');var d=arr.length>200?arr.slice(0,200).join('')+'…':arr.join('');return d||a.action_description||'';})())}</span>
             </div>`).join('');
         }else{

--- a/src/operator_commands_dashboard/index_html/part_04.rs
+++ b/src/operator_commands_dashboard/index_html/part_04.rs
@@ -151,7 +151,7 @@ pub(crate) const PART_04: &str = r#"            let fmt;
             const isCurrent=a.action==='current';
             return`<div style="display:flex;gap:.5rem;padding:.35rem 0;border-bottom:1px solid var(--border);font-size:.85rem">
               <span style="color:var(--accent);min-width:2.5rem;font-weight:600">#${a.cycle}</span>
-              <span style="min-width:5rem;color:${isCurrent?'var(--green)':'#8b949e'}">${esc(a.action)}</span>
+              <span style="min-width:5rem;color:${isCurrent?'var(--green)':'#8b949e'}">${esc(humanizeActionKind(a.action))}</span>
               <span style="flex:1">${renderActionDetail(a.result)}</span>
               ${a.at?'<span style="color:#8b949e;font-size:.75rem">'+timeAgo(a.at)+'</span>':''}
             </div>`;

--- a/tests/e2e-dashboard/specs/overview.spec.ts
+++ b/tests/e2e-dashboard/specs/overview.spec.ts
@@ -121,6 +121,11 @@ const MOCK_ACTIVITY = {
             action_kind: 'edit',
             action_description: 'Fixed bug in parser',
           },
+          {
+            success: true,
+            action_kind: 'spawn_engineer',
+            action_description: 'Dispatched engineer for task',
+          },
         ],
         priorities: [
           { goal_id: 'g1', reason: 'top-priority', urgency: 0.8 },
@@ -210,7 +215,8 @@ test.describe('Dashboard Overview - live activity surfaces @structural', () => {
     await expect(overview.recentActionsList).toBeVisible();
     const text = await overview.recentActionsList.textContent();
     expect(text).toContain('Fixed bug in parser');
-    expect(text).toContain('edit');
+    expect(text).toContain('Edit');
+    expect(text).toContain('Launched sub-agent');
     expect(text).toContain('#42');
   });
 


### PR DESCRIPTION
## Summary

Fixes #2121 — humanizes raw `action_kind` snake_case identifiers into plain-English labels in the Overview and Workboard action feeds.

This is the 4th attempt at this issue. The prior 3 PRs (#2125, #2139, #2175) all failed because they changed rendered text **without updating the Playwright e2e tests**. This PR treats the feature change and spec updates as a single atomic unit.

## Changes

### Feature: `humanizeActionKind()` function (part_01.rs)
A client-side JS mapping added alongside existing utilities (`esc()`, `timeAgo()`):

| Raw `action_kind` | Human label |
|---|---|
| `spawn_engineer` | Launched sub-agent |
| `progress_assessment` | Checked progress |
| `merge_readiness_check` | Evaluated PR readiness |
| `disk_health_check` | Checked disk health |
| `goal_create` | Created a goal |
| `goal_close` | Closed a goal |
| (unknown) | Capitalize + de-snake/de-hyphen fallback |

### Render sites updated (3 total)
1. **Overview tab — Last Cycle Actions** (part_01.rs line ~319)
2. **Overview tab — Recent Actions** (part_01.rs line ~355)
3. **Workboard tab — Recent Actions** (part_04.rs line ~154)

All sites wrap the result with `esc()` to prevent XSS.

### Playwright e2e tests updated atomically
- `overview.spec.ts`: Changed assertion from `toContain('edit')` → `toContain('Edit')` (fallback humanization)
- Added `spawn_engineer` mock outcome + `toContain('Launched sub-agent')` assertion (explicit mapping)

## What is NOT changed
- **API JSON**: `action_kind` field remains unchanged (display-only change)
- **Thinking tab**: Existing humanized rendering untouched per acceptance criteria

## Test evidence
- **Rust tests**: 246 passed, 0 failed (`cargo test --lib -- operator_commands_dashboard`)
- **Playwright structural e2e**: 52 passed; 14 failed (all pre-existing WebSocket/chat failures unrelated to this PR — agent-graph, chat-lifecycle, goals, multi-turn specs)
- **overview.spec.ts**: All 8 tests PASSED ✅
- **workboard.spec.ts**: All 3 tests PASSED ✅

## Diff focus
3 files changed, 16 insertions, 4 deletions. No unrelated edits.

Closes #2121