### PR TITLE
feat: memory health shedding and bounded subagent retention (issue #2183)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ pub mod memory_bridge;
 pub mod memory_bridge_adapter;
 pub mod memory_cognitive;
 pub mod memory_consolidation;
+pub mod memory_health;
 pub mod memory_hive;
 pub mod memory_ipc;
 pub mod memory_snapshot;

--- a/src/memory_health.rs
+++ b/src/memory_health.rs
@@ -1,0 +1,167 @@
+//! Memory pressure shedding for the OODA daemon (issue #2183).
+//!
+//! [`rss_health`] observes and logs RSS thresholds. This module
+//! *acts* on memory pressure by invoking concrete shedding steps:
+//! pruning expired sensory memory, aggressive subagent session GC,
+//! and cognitive-memory statistics logging for attribution.
+//!
+//! Called from the daemon loop when RSS exceeds the "elevated"
+//! threshold (default: 8 GiB). Each call is idempotent and safe to
+//! repeat every cycle — individual shedding steps are cheap no-ops
+//! when there is nothing to shed.
+
+use std::path::Path;
+
+use crate::cognitive_memory::CognitiveMemoryOps;
+use crate::rss_health;
+
+/// Result of one emergency-GC pass.
+#[derive(Clone, Debug, Default)]
+pub struct ShedReport {
+    /// Number of expired sensory-memory nodes pruned.
+    pub sensory_pruned: usize,
+    /// Number of subagent-session registry entries removed.
+    pub sessions_pruned: usize,
+    /// Snapshot of cognitive-memory node counts (for attribution logging).
+    pub cognitive_stats_summary: String,
+    /// RSS reading *before* shedding (bytes). `None` on non-Linux.
+    pub rss_before: Option<u64>,
+    /// RSS reading *after* shedding (bytes). `None` on non-Linux.
+    pub rss_after: Option<u64>,
+}
+
+impl ShedReport {
+    /// One-line summary for daemon log.
+    pub fn summary(&self) -> String {
+        let rss_delta = match (self.rss_before, self.rss_after) {
+            (Some(before), Some(after)) => {
+                let before_mb = before / (1024 * 1024);
+                let after_mb = after / (1024 * 1024);
+                format!(" (RSS {before_mb}→{after_mb} MiB)")
+            }
+            _ => String::new(),
+        };
+        format!(
+            "memory shed: sensory_pruned={}, sessions_pruned={}, cognitive=[{}]{}",
+            self.sensory_pruned, self.sessions_pruned, self.cognitive_stats_summary, rss_delta,
+        )
+    }
+}
+
+/// Default elevated threshold: 8 GiB.
+const DEFAULT_ELEVATED_BYTES: u64 = 8 * 1024 * 1024 * 1024;
+
+/// Read the elevated-threshold from env or return the default.
+pub fn elevated_threshold_bytes() -> u64 {
+    std::env::var("SIMARD_RSS_ELEVATED_BYTES")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_ELEVATED_BYTES)
+}
+
+/// Returns `true` when current RSS exceeds the elevated threshold and
+/// shedding should be attempted.
+pub fn should_shed() -> bool {
+    rss_health::read_rss_bytes()
+        .map(|rss| rss >= elevated_threshold_bytes())
+        .unwrap_or(false)
+}
+
+/// Run all shedding steps.
+///
+/// `memory`: cognitive-memory handle (daemon holds an `Arc<dyn CognitiveMemoryOps>`)
+/// `state_root`: for logging context
+///
+/// Each sub-step is best-effort: failures are logged but do not abort the
+/// overall pass.
+pub fn run_emergency_shed(memory: &dyn CognitiveMemoryOps, _state_root: &Path) -> ShedReport {
+    let mut report = ShedReport {
+        rss_before: rss_health::read_rss_bytes(),
+        ..Default::default()
+    };
+
+    // 1. Prune expired sensory memory (TTL-based eviction already in the
+    //    trait — we just ensure it runs at shedding time too).
+    match memory.prune_expired_sensory() {
+        Ok(n) => report.sensory_pruned = n,
+        Err(e) => tracing::warn!(
+            target: "simard::memory_health",
+            error = %e,
+            "sensory prune failed during emergency shed",
+        ),
+    }
+
+    // 2. Aggressive subagent-session GC: use the tight retention constant
+    //    (1 hour) instead of the default 24 h.
+    match crate::subagent_sessions::gc_with_retention(
+        &crate::subagent_sessions::TmuxProbe,
+        crate::subagent_sessions::TIGHT_RETENTION_SECONDS,
+    ) {
+        Ok(n) => report.sessions_pruned = n,
+        Err(e) => tracing::warn!(
+            target: "simard::memory_health",
+            error = %e,
+            "subagent session GC failed during emergency shed",
+        ),
+    }
+
+    // 3. Snapshot cognitive-memory stats for attribution.
+    match memory.get_statistics() {
+        Ok(stats) => {
+            report.cognitive_stats_summary = format!(
+                "sensory={} working={} episodic={} semantic={} procedural={} prospective={} total={}",
+                stats.sensory_count,
+                stats.working_count,
+                stats.episodic_count,
+                stats.semantic_count,
+                stats.procedural_count,
+                stats.prospective_count,
+                stats.total(),
+            );
+        }
+        Err(e) => {
+            report.cognitive_stats_summary = format!("stats unavailable: {e}");
+        }
+    }
+
+    report.rss_after = rss_health::read_rss_bytes();
+    report
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shed_report_summary_format() {
+        let report = ShedReport {
+            sensory_pruned: 5,
+            sessions_pruned: 2,
+            cognitive_stats_summary: "total=42".to_string(),
+            rss_before: Some(8 * 1024 * 1024 * 1024),
+            rss_after: Some(7 * 1024 * 1024 * 1024 + 512 * 1024 * 1024),
+        };
+        let s = report.summary();
+        assert!(s.contains("sensory_pruned=5"), "got: {s}");
+        assert!(s.contains("sessions_pruned=2"), "got: {s}");
+        assert!(s.contains("total=42"), "got: {s}");
+        assert!(s.contains("RSS"), "got: {s}");
+    }
+
+    #[test]
+    fn shed_report_summary_no_rss() {
+        let report = ShedReport {
+            cognitive_stats_summary: "n/a".to_string(),
+            ..Default::default()
+        };
+        let s = report.summary();
+        assert!(!s.contains("RSS"), "no RSS data → no RSS in summary: {s}");
+    }
+
+    #[test]
+    fn elevated_threshold_default() {
+        // When env var not set, should return 8 GiB.
+        let threshold = elevated_threshold_bytes();
+        assert_eq!(threshold, 8 * 1024 * 1024 * 1024);
+    }
+}

--- a/src/operator_commands_ooda/daemon/mod.rs
+++ b/src/operator_commands_ooda/daemon/mod.rs
@@ -542,7 +542,7 @@ pub fn run_ooda_daemon(
         }
         // -------------------------------------------------------------------
 
-        // ── RSS health check (issue #2167) ──────────────────────────────
+        // ── RSS health check (issue #2167) / memory shedding (issue #2183) ─
         if let Some(report) = crate::rss_health::check_rss_health() {
             let rss_str = crate::rss_health::format_rss(report.rss_bytes);
             if report.critical {
@@ -557,6 +557,21 @@ pub fn run_ooda_daemon(
                 );
             } else {
                 daemon_log(&state_root, &format!("[simard] RSS health: {rss_str}"));
+            }
+
+            // Emergency memory shedding when RSS exceeds the elevated
+            // threshold (default 8 GiB, env SIMARD_RSS_ELEVATED_BYTES).
+            if report.rss_bytes >= crate::memory_health::elevated_threshold_bytes() {
+                daemon_log(
+                    &state_root,
+                    &format!(
+                        "[simard] RSS {} exceeds elevated threshold — running emergency shed",
+                        rss_str
+                    ),
+                );
+                let shed =
+                    crate::memory_health::run_emergency_shed(shared_mem.as_ref(), &state_root);
+                daemon_log(&state_root, &format!("[simard] {}", shed.summary()));
             }
         }
         // ── Periodic engineer worktree sweep (issue #2167) ──────────────

--- a/src/subagent_sessions/mod.rs
+++ b/src/subagent_sessions/mod.rs
@@ -12,8 +12,17 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 
-/// Sessions ended more than this many seconds ago are GC'd.
+/// Sessions ended more than this many seconds ago are GC'd (default).
+/// Configurable via `SIMARD_SUBAGENT_RETENTION_SECONDS`.
 pub const RETENTION_SECONDS: i64 = 86_400;
+
+/// Tight retention used during emergency memory shedding (1 hour).
+pub const TIGHT_RETENTION_SECONDS: i64 = 3_600;
+
+/// Hard cap on the number of registry entries. When exceeded during
+/// `record_spawn`, ended sessions are pruned oldest-first until the
+/// count is within the cap.
+pub const MAX_SESSIONS: usize = 500;
 
 /// One row in the registry.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -144,14 +153,69 @@ pub fn save_atomic(reg: &Registry) -> io::Result<()> {
 }
 
 /// Append a new session record (load → push → save_atomic).
+///
+/// If the registry exceeds [`MAX_SESSIONS`] after the push, ended
+/// sessions are pruned oldest-first until the count is within the cap.
+/// Active (non-ended) sessions are never dropped by the cap.
 pub fn record_spawn(session: SubagentSession) -> io::Result<()> {
     let mut reg = load();
     reg.sessions.push(session);
+    enforce_cap(&mut reg);
     save_atomic(&reg)
 }
 
-/// Mark dead sessions as ended; GC entries ended >24h ago.
+/// Enforce [`MAX_SESSIONS`] by dropping the oldest ended sessions.
+fn enforce_cap(reg: &mut Registry) {
+    if reg.sessions.len() <= MAX_SESSIONS {
+        return;
+    }
+    // Sort ended sessions by ended_at ascending (oldest first) and drop
+    // enough to get under the cap. Active sessions are never touched.
+    let excess = reg.sessions.len() - MAX_SESSIONS;
+    let mut ended_indices: Vec<usize> = reg
+        .sessions
+        .iter()
+        .enumerate()
+        .filter_map(|(i, s)| s.ended_at.map(|ts| (i, ts)))
+        .collect::<Vec<_>>()
+        .into_iter()
+        .map(|(i, _ts)| i)
+        .collect();
+
+    // Sort by ended_at ascending (oldest first).
+    ended_indices.sort_by_key(|&i| reg.sessions[i].ended_at.unwrap_or(i64::MAX));
+
+    let to_remove: std::collections::HashSet<usize> =
+        ended_indices.into_iter().take(excess).collect();
+    if !to_remove.is_empty() {
+        let mut idx = 0;
+        reg.sessions.retain(|_| {
+            let keep = !to_remove.contains(&idx);
+            idx += 1;
+            keep
+        });
+        tracing::info!(
+            target: "simard::subagent_sessions",
+            removed = to_remove.len(),
+            remaining = reg.sessions.len(),
+            "enforced MAX_SESSIONS cap",
+        );
+    }
+}
+
+/// Mark dead sessions as ended; GC entries ended longer ago than
+/// [`RETENTION_SECONDS`].
+///
+/// Retention is read from `SIMARD_SUBAGENT_RETENTION_SECONDS` env var at
+/// call time, falling back to the compiled-in [`RETENTION_SECONDS`].
 pub fn poll_and_gc<R: SessionProbe>(probe: &R) -> io::Result<()> {
+    let retention = configured_retention();
+    gc_with_retention(probe, retention).map(|_| ())
+}
+
+/// Like [`poll_and_gc`] but with an explicit retention threshold. Returns
+/// the number of entries pruned.
+pub fn gc_with_retention<R: SessionProbe>(probe: &R, retention_secs: i64) -> io::Result<usize> {
     let mut reg = load();
     let now = now_epoch_seconds();
 
@@ -172,7 +236,7 @@ pub fn poll_and_gc<R: SessionProbe>(probe: &R) -> io::Result<()> {
 
     let before = reg.sessions.len();
     reg.sessions.retain(|s| match s.ended_at {
-        Some(end) => now - end <= RETENTION_SECONDS,
+        Some(end) => now - end <= retention_secs,
         None => true,
     });
     let pruned = before - reg.sessions.len();
@@ -180,11 +244,21 @@ pub fn poll_and_gc<R: SessionProbe>(probe: &R) -> io::Result<()> {
         tracing::info!(
             target: "simard::subagent_sessions",
             pruned,
-            "GC'd subagent sessions ended >24h ago",
+            retention_secs,
+            "GC'd subagent sessions older than retention threshold",
         );
     }
 
-    save_atomic(&reg)
+    save_atomic(&reg)?;
+    Ok(pruned)
+}
+
+/// Read retention from env or return the compiled-in default.
+fn configured_retention() -> i64 {
+    std::env::var("SIMARD_SUBAGENT_RETENTION_SECONDS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(RETENTION_SECONDS)
 }
 
 /// Sanitize an agent_id for use in a tmux session name.

--- a/src/subagent_sessions/tests.rs
+++ b/src/subagent_sessions/tests.rs
@@ -249,3 +249,121 @@ fn sanitize_id_output_matches_safe_charset() {
     );
     assert!(!out.is_empty());
 }
+
+// -----------------------------------------------------------------------
+// Hard cap on MAX_SESSIONS (issue #2183)
+// -----------------------------------------------------------------------
+
+#[test]
+#[serial_test::serial]
+fn record_spawn_enforces_max_sessions_cap() {
+    with_state_root("cap", |_root| {
+        // Pre-populate with MAX_SESSIONS ended sessions.
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        let mut reg = Registry {
+            sessions: Vec::new(),
+        };
+        for i in 0..MAX_SESSIONS {
+            reg.sessions.push(SubagentSession {
+                ended_at: Some(now - (i as i64)),
+                ..sample(&format!("old-{i}"), Some(now - (i as i64)))
+            });
+        }
+        save_atomic(&reg).unwrap();
+
+        // Adding one more should prune oldest ended entries.
+        record_spawn(sample("new-one", None)).unwrap();
+
+        let loaded = load();
+        assert!(
+            loaded.sessions.len() <= MAX_SESSIONS,
+            "registry must not exceed MAX_SESSIONS ({}), got {}",
+            MAX_SESSIONS,
+            loaded.sessions.len(),
+        );
+        // The new active session must be present.
+        assert!(
+            loaded.sessions.iter().any(|s| s.agent_id == "new-one"),
+            "new active session must not be evicted by cap"
+        );
+    });
+}
+
+#[test]
+#[serial_test::serial]
+fn cap_preserves_active_sessions() {
+    with_state_root("cap-active", |_root| {
+        // Fill with active (ended_at=None) sessions at the cap.
+        let mut reg = Registry {
+            sessions: Vec::new(),
+        };
+        for i in 0..MAX_SESSIONS {
+            reg.sessions.push(sample(&format!("active-{i}"), None));
+        }
+        save_atomic(&reg).unwrap();
+
+        // Adding another active session — cap enforcement can't evict
+        // active sessions, so we tolerate exceeding the cap temporarily.
+        record_spawn(sample("new-active", None)).unwrap();
+
+        let loaded = load();
+        assert_eq!(
+            loaded.sessions.len(),
+            MAX_SESSIONS + 1,
+            "all active sessions must be preserved even over the cap"
+        );
+    });
+}
+
+// -----------------------------------------------------------------------
+// gc_with_retention (issue #2183)
+// -----------------------------------------------------------------------
+
+#[test]
+#[serial_test::serial]
+fn gc_with_retention_uses_tight_threshold() {
+    with_state_root("gc-tight", |_root| {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+
+        // One session ended 2 hours ago, another ended 30 minutes ago.
+        let old = SubagentSession {
+            ended_at: Some(now - 7200),
+            ..sample("ended-2h", Some(now - 7200))
+        };
+        let recent = SubagentSession {
+            ended_at: Some(now - 1800),
+            ..sample("ended-30m", Some(now - 1800))
+        };
+        save_atomic(&Registry {
+            sessions: vec![old, recent],
+        })
+        .unwrap();
+
+        // With 1-hour tight retention, the 2h-old entry should be pruned.
+        let probe = StubProbe {
+            alive_set: HashSet::new(),
+            queries: RefCell::new(Vec::new()),
+        };
+        let pruned = gc_with_retention(&probe, TIGHT_RETENTION_SECONDS).unwrap();
+        assert_eq!(
+            pruned, 1,
+            "entry ended >1h ago should be pruned with tight retention"
+        );
+
+        let reg = load();
+        assert!(
+            reg.sessions.iter().any(|s| s.agent_id == "ended-30m"),
+            "entry ended <1h ago must be retained"
+        );
+        assert!(
+            !reg.sessions.iter().any(|s| s.agent_id == "ended-2h"),
+            "entry ended >1h ago must be pruned"
+        );
+    });
+}


### PR DESCRIPTION
## Summary

Adds memory pressure mitigation for daemon RSS growth (~1G→32G in 16-24h). Closes #2183.

## Changes

### 1. New `memory_health` module (`src/memory_health.rs`)
- Orchestrates emergency memory shedding when RSS exceeds elevated threshold (default 8 GiB, configurable via `SIMARD_RSS_ELEVATED_BYTES`)
- Prunes expired sensory memory, runs aggressive subagent session GC (1h retention instead of 24h)
- Logs cognitive-memory node counts (sensory/working/episodic/semantic/procedural/prospective) for growth attribution
- Reports before/after RSS deltas

### 2. Subagent session registry improvements (`src/subagent_sessions/mod.rs`)
- **Hard cap**: `MAX_SESSIONS=500` enforced on `record_spawn`, evicting oldest ended sessions first (active sessions never evicted)
- **Configurable retention**: `SIMARD_SUBAGENT_RETENTION_SECONDS` env var (default unchanged at 24h)
- **New `gc_with_retention()`**: allows emergency GC with tight retention (`TIGHT_RETENTION_SECONDS=3600`)

### 3. Daemon loop integration (`src/operator_commands_ooda/daemon/mod.rs`)
- RSS health check now triggers emergency shed above elevated threshold
- Logs diagnostic detail for memory growth attribution

### 4. Tests (6 new)
- `memory_health::tests::shed_report_summary_format`
- `memory_health::tests::shed_report_summary_no_rss`
- `memory_health::tests::elevated_threshold_default`
- `subagent_sessions::tests::record_spawn_enforces_max_sessions_cap`
- `subagent_sessions::tests::cap_preserves_active_sessions`
- `subagent_sessions::tests::gc_with_retention_uses_tight_threshold`

## Scope note

This PR adds guardrails and diagnostics. The primary RSS growth is likely from LadybugDB in-process graph residency and/or LLM session state — this PR adds the attribution logging (cognitive memory stats at shed time) needed to confirm the root cause, plus bounded retention to prevent unbounded registry growth. A follow-up PR should address LadybugDB eviction or daemon self-restart above a critical threshold.

## Validation
- `cargo check` ✅
- `cargo fmt` ✅
- `cargo clippy -D warnings` ✅
- `cargo test --lib memory_health rss_health subagent_sessions` — 22/22 passed ✅
- Pre-push hooks (fmt + release tests + clippy) all passed ✅

## Diff focus
5 files changed, 381 insertions, 6 deletions. All changes directly related to the memory health objective — no unrelated edits.