### PR TITLE
feat(tui): populate Stats tab with real data from state files and gh CLI

### DIFF
--- a/.claude/context/PROJECT.md
+++ b/.claude/context/PROJECT.md
@@ -10,7 +10,7 @@ Replace the sections below with information about your project.
 
 ---
 
-## Project: issue-2195-implement-all-4-placeholder-tabs-in-the-simard-tui
+## Project: issue-2201-fix-tui-stats-tab-to-show-real-data-the-simard-tui
 
 ## Overview
 

--- a/.claude/context/PROJECT.md.bak
+++ b/.claude/context/PROJECT.md.bak
@@ -10,7 +10,7 @@ Replace the sections below with information about your project.
 
 ---
 
-## Project: issue-2195-implement-all-4-placeholder-tabs-in-the-simard-tui
+## Project: issue-2201-fix-tui-stats-tab-to-show-real-data-the-simard-tui
 
 ## Overview
 

--- a/docs/howto/monitor-simard-with-tui.md
+++ b/docs/howto/monitor-simard-with-tui.md
@@ -209,13 +209,12 @@ all tabs.
 Press `6` to switch to the Stats tab:
 
 ```
-┌ Statistics ───────────────────────────────────────────────────────┐
+┌ Stats ────────────────────────────────────────────────────────────┐
 │ State files:     142                                              │
 │ Session dirs:    7                                                │
 │ Open issues:     23                                               │
 │ Open PRs:        4                                                │
 │ Active goals:    5                                                │
-│ Backlog items:   12                                               │
 │ Daemon uptime:   2h 14m 33s                                      │
 └───────────────────────────────────────────────────────────────────┘
 ```
@@ -225,17 +224,22 @@ Press `6` to switch to the Stats tab:
 - **State files** — total files in `<state-root>/state/` (recursive
   count). Indicates how much state the daemon has accumulated.
 - **Session dirs** — engineer session directories in
-  `<state-root>/engineer-worktrees/`. One per past or active session.
+  `<state-root>/sessions/`. One per past or active session.
 - **Open issues** — open GitHub issues in the repo. Requires `gh`
-  CLI. Shows `–` if unavailable.
+  CLI. Shows `–` if unavailable or still loading.
 - **Open PRs** — open pull requests. Same requirements as issues.
 - **Active goals** — count from the cached goal board (same data as
   Tab 2).
-- **Backlog items** — scored backlog item count from the goal board.
 - **Daemon uptime** — same value as the Overview tab.
 
-The stats refresh every 10 seconds to avoid frequent `gh` API calls.
-Goal counts update every 2 seconds (from the shared goal board cache).
+**How refresh works:**
+
+Local metrics (state files, session dirs) update synchronously every
+10 seconds. GitHub metrics (issues, PRs) are fetched in a background
+thread so they never freeze the TUI. On first launch, issues/PRs show
+`–` for 1–3 seconds until the background fetch completes, then
+populate automatically. Goal counts update every 2 seconds (from the
+shared goal board cache).
 
 ## 8. Custom state root
 
@@ -296,7 +300,7 @@ not recommended (two meeting processes would compete for state).
 | Engineers tab: "No child processes" | Daemon idle between OODA cycles | Normal — wait for next cycle |
 | Activity tab: "No log entries" | No journald or no entries for the unit | Check: `journalctl --user -u simard.service -n 5` (or use `SIMARD_TUI_SERVICE` if your unit has a different name) |
 | Meeting tab: "simard binary not found" | Binary missing at state-root/bin/simard | Install Simard or check `SIMARD_STATE_ROOT` |
-| Stats show `–` for issues/PRs | `gh` not installed or not authenticated | Run `gh auth status` to diagnose |
+| Stats show `–` for issues/PRs | `gh` not installed or not authenticated, or still loading | Run `gh auth status` to diagnose; wait 3s for background fetch |
 
 ## See also
 

--- a/docs/reference/simard-tui.md
+++ b/docs/reference/simard-tui.md
@@ -256,36 +256,73 @@ quits the TUI normally.
 Displays aggregate metrics as a key-value list:
 
 ```
-┌ Statistics ───────────────────────────────────┐
+┌ Stats ────────────────────────────────────────┐
 │ State files:     142                          │
 │ Session dirs:    7                            │
 │ Open issues:     23                           │
 │ Open PRs:        4                            │
 │ Active goals:    5                            │
-│ Backlog items:   12                           │
 │ Daemon uptime:   2h 14m 33s                   │
 └───────────────────────────────────────────────┘
 ```
 
 | Metric | Source | Notes |
 |---|---|---|
-| State files | Recursive file count in `<state-root>/state/` | Total memory/state files on disk |
-| Session dirs | Directory count in `<state-root>/engineer-worktrees/` | One per engineer session |
-| Open issues | `gh issue list --state open --limit 1000 --json number` | Parsed with `serde_json`, count of items. Shows `–` if `gh` unavailable |
-| Open PRs | `gh pr list --state open --limit 1000 --json number` | Same approach. Shows `–` if `gh` unavailable |
+| State files | Recursive file count in `<state-root>/state/` | Total memory/state files on disk. Counted synchronously (fast local I/O) |
+| Session dirs | Directory count in `<state-root>/sessions/` | One per engineer session. Counted synchronously |
+| Open issues | `gh issue list --state open --limit 1000 --json number` | Parsed with `serde_json`, count of items. Shows `–` if `gh` unavailable or result pending |
+| Open PRs | `gh pr list --state open --limit 1000 --json number` | Same approach. Shows `–` if `gh` unavailable or result pending |
 | Active goals | Goal board `active` vector length | From the same cached `GoalBoard` used by Tab 2 |
-| Backlog items | Goal board `backlog` vector length | From the same cached `GoalBoard` used by Tab 2 |
 | Daemon uptime | `DaemonInfo.uptime_secs` | Same value as Overview tab; human-formatted |
 
-**GitHub CLI interaction.** The `gh` commands are run as subprocesses
-with `Command::new("gh").arg(...)`. Output is parsed as
-`Vec<serde_json::Value>` and counted with `.len()`. No `jq`
-dependency. If `gh` is not installed, not authenticated, or the
-command fails, the metric shows `–` rather than an error.
+**Two-tier refresh strategy.** The Stats tab splits data collection
+into a synchronous path and an asynchronous path to avoid blocking
+the TUI render loop:
 
-**Refresh rate:** Every 10 seconds (gated by `tick_count % 5 == 0`
-on the 2-second refresh cycle). This avoids frequent `gh` API calls
-and directory scans.
+1. **Synchronous (local filesystem).** State file count and session
+   directory count are computed inline during `refresh_stats()`. These
+   are fast local I/O operations (typically <1 ms) and pose no
+   blocking risk.
+
+2. **Asynchronous (GitHub CLI).** Open issue and PR counts are fetched
+   via `gh` CLI in a background thread using `std::thread::spawn` and
+   `std::sync::mpsc::channel`. The thread runs both `gh issue list`
+   and `gh pr list` commands, then sends the results (as
+   `(Option<usize>, Option<usize>)`) back through the channel. The
+   main event loop drains results via `try_recv()` on every tick, so
+   values appear as soon as the background thread completes without
+   ever blocking the UI.
+
+**Duplicate fetch guard.** A boolean `gh_in_flight` flag prevents
+overlapping background threads. When a `gh` fetch thread is already
+running, `refresh_stats()` skips spawning another one. The flag is
+cleared when the receiver channel disconnects (thread completed) or
+when a result is successfully received.
+
+**GitHub CLI interaction.** The `gh` commands are run as subprocesses
+in the background thread with `Command::new("gh").arg(...)`. Output
+is parsed as `Vec<serde_json::Value>` and counted with `.len()`. No
+`jq` dependency. If `gh` is not installed, not authenticated, or the
+command fails, the thread sends `None` for that metric and the UI
+shows `–`. The `gh` commands inherit the process environment (for
+`GH_TOKEN`, `GITHUB_TOKEN`, etc.) but no credentials are handled
+directly by the TUI.
+
+**Refresh rate:** Local filesystem stats refresh every 10 seconds
+(gated by `tick_count % 5 == 0` on the 2-second refresh cycle). The
+background `gh` thread is spawned on the same 10-second cycle. Results
+from the background thread are drained on every tick (every 2 seconds),
+so `gh` values appear as soon as the commands complete — typically
+1–3 seconds after the fetch is initiated.
+
+**Graceful degradation.** When `gh` is unavailable:
+
+- The background thread sends `(None, None)`.
+- The channel disconnects normally when the thread exits.
+- `gh_in_flight` is cleared on the next drain cycle.
+- The UI shows `–` for Open issues and Open PRs.
+- No error is displayed — this is the expected state on machines
+  without `gh` installed or authenticated.
 
 ---
 
@@ -321,13 +358,17 @@ The TUI uses a tiered refresh strategy:
 | `journalctl` (activity logs) | 2 s | Keeps log view current |
 | Child process scan (engineers) | 2 s | `/proc` walk or `pgrep` |
 | Meeting process stdout drain | Every key event + every tick | Non-blocking read; latency-sensitive |
-| `gh` commands, file counts (stats) | 10 s | Expensive external commands; gated by tick counter |
+| Local fs stats (state files, session dirs) | 10 s | Directory scans; gated by tick counter |
+| `gh` commands (issues, PRs) — background thread | 10 s spawn, 2 s drain | Spawned on slow cycle; results drained via `try_recv()` every tick |
 
 The event loop polls for keyboard input with a 200 ms timeout, then
 checks whether the next refresh tick has elapsed. A `tick_count: u32`
 field on `App` increments each refresh. Stats-tab data sources gate
-on `tick_count % 5 == 0`. This keeps input responsive without
-busy-waiting or excessive subprocess spawning.
+on `tick_count % 5 == 0`. The `gh` commands run in a background
+thread via `std::thread::spawn` + `std::sync::mpsc::channel`, so
+they never block the render loop. Results are picked up on the next
+tick via `try_recv()`. A `gh_in_flight` guard prevents overlapping
+thread spawns when the previous fetch has not yet completed.
 
 ---
 
@@ -365,7 +406,7 @@ matching the daemon's behavior documented in
 |---|---|---|
 | `<state-root>/cognitive_memory.ladybug` | LadybugDB (SQLite) | `goal-board:snapshot` fact → `GoalBoard` JSON |
 | `<state-root>/state/` | Directory tree | Recursive file count for stats |
-| `<state-root>/engineer-worktrees/` | Directory listing | Session directory count for stats |
+| `<state-root>/sessions/` | Directory listing | Session directory count for stats |
 | `<state-root>/bin/simard` | Executable | Meeting process binary (spawned, not read) |
 | `/proc/<PID>/stat` | Kernel pseudo-file | CPU time fields (utime, stime, starttime) |
 | `/proc/<PID>/status` | Kernel pseudo-file | `VmRSS:` line for memory |
@@ -374,7 +415,7 @@ matching the daemon's behavior documented in
 | `systemctl show` | CLI output | Service state, PID, timestamps |
 | `journalctl --user` | CLI output | Recent log entries |
 | `pgrep --parent` | CLI output | Child PID enumeration |
-| `gh issue list` / `gh pr list` | CLI + JSON output | Open issue/PR counts |
+| `gh issue list` / `gh pr list` | CLI + JSON output | Open issue/PR counts (run in background thread) |
 
 The TUI defines its own serde DTOs (`GoalBoard`, `ActiveGoal`,
 `GoalProgress`). Required fields (`id`, `description`, `priority`,
@@ -510,6 +551,9 @@ restoration on any exit path:
   against `^[a-zA-Z0-9@._-]+\.service$` at startup. Invalid values
   cause an immediate exit with an error message.
 
+- **Bounded `gh` output.** `--limit 1000` caps issue/PR list queries
+  to prevent unbounded memory from large repositories.
+
 - **Bounded reads.** Goal board payload reads are capped at 10 MB;
   `/proc` reads at 4 KB. Meeting output is capped at 1000 lines.
   Meeting input is capped at 4096 bytes. Log lines are truncated to
@@ -534,7 +578,10 @@ restoration on any exit path:
 
 - **Sanitized external output.** `gh` stderr is not shown to the user
   — failures display a generic `–` placeholder. `journalctl` errors
-  retain the previous log buffer.
+  retain the previous log buffer. The background `gh` thread
+  communicates only via `mpsc::channel` with typed
+  `(Option<usize>, Option<usize>)` values — no raw strings cross
+  the thread boundary.
 
 - **Meeting output is memory-only.** Meeting session text is not
   persisted to disk by the TUI.
@@ -571,10 +618,12 @@ restoration on any exit path:
   `<state-root>/bin/simard` to exist. If it is missing (e.g., the
   binary was not installed), the Meeting tab shows an error.
 
-- **Single-threaded.** The TUI runs in a single thread. All subprocess
-  calls are synchronous (with short timeouts or non-blocking I/O).
-  A very slow `gh` call (network timeout) may cause a brief UI
-  freeze on the stats refresh cycle.
+- **Single-threaded render loop.** The TUI render loop runs in a
+  single thread. Local subprocess calls (`systemctl`, `journalctl`,
+  `pgrep`) are synchronous but fast. The `gh` CLI calls are the
+  exception — they run in a background thread via
+  `std::thread::spawn` to avoid blocking the UI during network I/O
+  (typically 1–3 seconds).
 
 ---
 
@@ -640,8 +689,10 @@ or verify `SIMARD_STATE_ROOT` points to the correct location.
 ### Stats show "–" for issues/PRs
 
 The `gh` CLI is either not installed, not authenticated, or the
-repository is not accessible. Run `gh auth status` and `gh issue list`
-manually to diagnose.
+repository is not accessible. It is also normal to see `–` briefly
+(1–3 seconds) after launch while the background fetch thread is
+running. If the values remain `–` after 10 seconds, run
+`gh auth status` and `gh issue list` manually to diagnose.
 
 ---
 

--- a/src/bin/simard_tui/app.rs
+++ b/src/bin/simard_tui/app.rs
@@ -5,6 +5,7 @@
 //! 10s for systemctl (to avoid hammering D-Bus).
 
 use std::collections::HashMap;
+use std::sync::mpsc;
 
 use crossterm::event::{KeyCode, KeyEvent};
 
@@ -122,6 +123,8 @@ pub struct App {
     meeting_stdout: Option<std::io::BufReader<std::process::ChildStdout>>,
     // Stats tab
     pub stats_cache: StatsCache,
+    pub gh_receiver: Option<mpsc::Receiver<(Option<usize>, Option<usize>)>>,
+    pub gh_in_flight: bool,
     pub tick_count: u32,
 }
 
@@ -149,6 +152,8 @@ impl App {
             meeting_stdin: None,
             meeting_stdout: None,
             stats_cache: StatsCache::default(),
+            gh_receiver: None,
+            gh_in_flight: false,
             tick_count: 0,
         }
     }
@@ -450,14 +455,18 @@ impl App {
     }
 
     /// Refresh stats cache (runs on slow cycle).
+    ///
+    /// Local filesystem counts are synchronous (fast, <1ms).
+    /// GitHub CLI calls are spawned in a background thread to avoid
+    /// blocking the TUI render loop (2-6s per call). Results arrive
+    /// via `gh_receiver` and are drained by `drain_gh_results()`.
     fn refresh_stats(&mut self) {
-        // Count state files recursively
+        // ── Sync: local filesystem counts ──────────────────────────
         let state_dir = self.state_root.join("state");
         if state_dir.exists() {
             self.stats_cache.state_files = Some(count_files_recursive(&state_dir));
         }
 
-        // Count session directories
         let sessions_dir = self.state_root.join("sessions");
         if sessions_dir.exists() {
             self.stats_cache.session_dirs = std::fs::read_dir(&sessions_dir).ok().map(|entries| {
@@ -468,29 +477,68 @@ impl App {
             });
         }
 
-        // Open issues via gh CLI
-        self.stats_cache.open_issues = std::process::Command::new("gh")
-            .args([
-                "issue", "list", "--state", "open", "--limit", "1000", "--json", "number",
-            ])
-            .output()
-            .ok()
-            .filter(|o| o.status.success())
-            .and_then(|o| String::from_utf8(o.stdout).ok())
-            .and_then(|s| serde_json::from_str::<Vec<serde_json::Value>>(&s).ok())
-            .map(|v| v.len());
+        // ── Async: gh CLI in background thread ─────────────────────
+        if self.gh_in_flight {
+            return;
+        }
 
-        // Open PRs via gh CLI
-        self.stats_cache.open_prs = std::process::Command::new("gh")
-            .args([
-                "pr", "list", "--state", "open", "--limit", "1000", "--json", "number",
-            ])
-            .output()
-            .ok()
-            .filter(|o| o.status.success())
-            .and_then(|o| String::from_utf8(o.stdout).ok())
-            .and_then(|s| serde_json::from_str::<Vec<serde_json::Value>>(&s).ok())
-            .map(|v| v.len());
+        let (tx, rx) = mpsc::channel();
+        self.gh_receiver = Some(rx);
+        self.gh_in_flight = true;
+
+        std::thread::spawn(move || {
+            let issues = std::process::Command::new("gh")
+                .args([
+                    "issue", "list", "--state", "open", "--limit", "1000", "--json", "number",
+                ])
+                .output()
+                .ok()
+                .filter(|o| o.status.success())
+                .and_then(|o| String::from_utf8(o.stdout).ok())
+                .and_then(|s| serde_json::from_str::<Vec<serde_json::Value>>(&s).ok())
+                .map(|v| v.len());
+
+            let prs = std::process::Command::new("gh")
+                .args([
+                    "pr", "list", "--state", "open", "--limit", "1000", "--json", "number",
+                ])
+                .output()
+                .ok()
+                .filter(|o| o.status.success())
+                .and_then(|o| String::from_utf8(o.stdout).ok())
+                .and_then(|s| serde_json::from_str::<Vec<serde_json::Value>>(&s).ok())
+                .map(|v| v.len());
+
+            // Send result; ignore error if receiver was dropped (app quit)
+            let _ = tx.send((issues, prs));
+        });
+    }
+
+    /// Drain any completed gh CLI results from the background thread.
+    ///
+    /// Called every tick from `refresh()`. Uses `try_recv()` so it never
+    /// blocks. Clears `gh_in_flight` and `gh_receiver` once the sender
+    /// disconnects (thread finished).
+    pub fn drain_gh_results(&mut self) {
+        let receiver = match self.gh_receiver.as_ref() {
+            Some(rx) => rx,
+            None => return,
+        };
+
+        loop {
+            match receiver.try_recv() {
+                Ok((issues, prs)) => {
+                    self.stats_cache.open_issues = issues;
+                    self.stats_cache.open_prs = prs;
+                }
+                Err(mpsc::TryRecvError::Empty) => break,
+                Err(mpsc::TryRecvError::Disconnected) => {
+                    self.gh_in_flight = false;
+                    self.gh_receiver = None;
+                    break;
+                }
+            }
+        }
     }
 
     /// Clean up resources (meeting process) before exit.
@@ -579,6 +627,9 @@ impl App {
 
         // Activity tab: refresh log lines
         self.refresh_logs();
+
+        // Stats tab: drain background gh CLI results every tick
+        self.drain_gh_results();
 
         // Stats tab: slow cycle (every 5 ticks ≈ 10s)
         if self.tick_count.is_multiple_of(5) {
@@ -1012,6 +1063,291 @@ mod tests {
                 MeetingStatus::Error(_)
             ),
             "MeetingStatus::Error should exist"
+        );
+    }
+
+    // ── Background gh CLI: field initialization ────────────────────
+
+    #[test]
+    fn app_new_gh_not_in_flight() {
+        let app = App::new("simard-ooda.service".to_string());
+        assert!(
+            !app.gh_in_flight,
+            "gh_in_flight should be false on construction"
+        );
+    }
+
+    #[test]
+    fn app_new_gh_receiver_is_none() {
+        let app = App::new("simard-ooda.service".to_string());
+        assert!(
+            app.gh_receiver.is_none(),
+            "gh_receiver should be None on construction"
+        );
+    }
+
+    // ── drain_gh_results: channel → stats_cache ────────────────────
+
+    #[test]
+    fn drain_gh_results_updates_stats_from_channel() {
+        let mut app = App::new("simard-ooda.service".to_string());
+        let (tx, rx) = std::sync::mpsc::channel();
+        app.gh_receiver = Some(rx);
+        app.gh_in_flight = true;
+
+        tx.send((Some(42), Some(7))).unwrap();
+        app.drain_gh_results();
+
+        assert_eq!(app.stats_cache.open_issues, Some(42));
+        assert_eq!(app.stats_cache.open_prs, Some(7));
+    }
+
+    #[test]
+    fn drain_gh_results_handles_none_values() {
+        // gh CLI failure sends (None, None) — stats stay as dashes
+        let mut app = App::new("simard-ooda.service".to_string());
+        let (tx, rx) = std::sync::mpsc::channel();
+        app.gh_receiver = Some(rx);
+        app.gh_in_flight = true;
+
+        tx.send((None, None)).unwrap();
+        app.drain_gh_results();
+
+        assert!(app.stats_cache.open_issues.is_none());
+        assert!(app.stats_cache.open_prs.is_none());
+    }
+
+    #[test]
+    fn drain_gh_results_clears_in_flight_on_disconnect() {
+        let mut app = App::new("simard-ooda.service".to_string());
+        let (tx, rx) = std::sync::mpsc::channel::<(Option<usize>, Option<usize>)>();
+        app.gh_receiver = Some(rx);
+        app.gh_in_flight = true;
+
+        // Drop sender to simulate thread completion
+        drop(tx);
+        app.drain_gh_results();
+
+        assert!(!app.gh_in_flight, "gh_in_flight should clear on disconnect");
+        assert!(
+            app.gh_receiver.is_none(),
+            "gh_receiver should be set to None on disconnect"
+        );
+    }
+
+    #[test]
+    fn drain_gh_results_noop_when_no_receiver() {
+        let mut app = App::new("simard-ooda.service".to_string());
+        assert!(app.gh_receiver.is_none());
+
+        // Should not panic or change anything
+        app.drain_gh_results();
+
+        assert!(app.stats_cache.open_issues.is_none());
+        assert!(app.stats_cache.open_prs.is_none());
+        assert!(!app.gh_in_flight);
+    }
+
+    #[test]
+    fn drain_gh_results_keeps_in_flight_while_channel_open() {
+        let mut app = App::new("simard-ooda.service".to_string());
+        let (_tx, rx) = std::sync::mpsc::channel::<(Option<usize>, Option<usize>)>();
+        app.gh_receiver = Some(rx);
+        app.gh_in_flight = true;
+
+        // Channel open but empty — try_recv returns Empty, not Disconnected
+        app.drain_gh_results();
+
+        assert!(
+            app.gh_in_flight,
+            "gh_in_flight should remain true while channel is open"
+        );
+        assert!(
+            app.gh_receiver.is_some(),
+            "gh_receiver should remain while channel is open"
+        );
+    }
+
+    #[test]
+    fn drain_gh_results_takes_last_value_when_multiple_sent() {
+        // If the thread sends multiple times (unlikely but possible),
+        // drain should process all and keep the last value.
+        let mut app = App::new("simard-ooda.service".to_string());
+        let (tx, rx) = std::sync::mpsc::channel();
+        app.gh_receiver = Some(rx);
+        app.gh_in_flight = true;
+
+        tx.send((Some(10), Some(2))).unwrap();
+        tx.send((Some(15), Some(5))).unwrap();
+        drop(tx);
+
+        app.drain_gh_results();
+
+        assert_eq!(
+            app.stats_cache.open_issues,
+            Some(15),
+            "should have last value"
+        );
+        assert_eq!(app.stats_cache.open_prs, Some(5), "should have last value");
+        assert!(!app.gh_in_flight, "should clear after disconnect");
+    }
+
+    // ── refresh_stats: local fs counts with tempdir ────────────────
+
+    #[test]
+    fn refresh_stats_counts_state_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state_dir = tmp.path().join("state");
+        std::fs::create_dir_all(&state_dir).unwrap();
+
+        // Create some files
+        std::fs::write(state_dir.join("goal_board.json"), "{}").unwrap();
+        std::fs::write(state_dir.join("cycle_report.json"), "{}").unwrap();
+        std::fs::write(state_dir.join("memory.json"), "{}").unwrap();
+
+        let mut app = App::new("simard-ooda.service".to_string());
+        app.state_root = tmp.path().to_path_buf();
+        app.refresh_stats();
+
+        assert_eq!(
+            app.stats_cache.state_files,
+            Some(3),
+            "should count 3 state files"
+        );
+    }
+
+    #[test]
+    fn refresh_stats_counts_session_dirs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sessions_dir = tmp.path().join("sessions");
+        std::fs::create_dir_all(&sessions_dir).unwrap();
+
+        // Create some session subdirectories
+        std::fs::create_dir(sessions_dir.join("session-001")).unwrap();
+        std::fs::create_dir(sessions_dir.join("session-002")).unwrap();
+        // A regular file should NOT be counted
+        std::fs::write(sessions_dir.join("index.json"), "[]").unwrap();
+
+        let mut app = App::new("simard-ooda.service".to_string());
+        app.state_root = tmp.path().to_path_buf();
+        app.refresh_stats();
+
+        assert_eq!(
+            app.stats_cache.session_dirs,
+            Some(2),
+            "should count 2 session dirs (not the file)"
+        );
+    }
+
+    #[test]
+    fn refresh_stats_state_files_none_when_dir_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Don't create state/ dir — it doesn't exist
+
+        let mut app = App::new("simard-ooda.service".to_string());
+        app.state_root = tmp.path().to_path_buf();
+        app.refresh_stats();
+
+        assert!(
+            app.stats_cache.state_files.is_none(),
+            "should be None when state dir doesn't exist"
+        );
+    }
+
+    #[test]
+    fn refresh_stats_session_dirs_none_when_dir_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        let mut app = App::new("simard-ooda.service".to_string());
+        app.state_root = tmp.path().to_path_buf();
+        app.refresh_stats();
+
+        assert!(
+            app.stats_cache.session_dirs.is_none(),
+            "should be None when sessions dir doesn't exist"
+        );
+    }
+
+    #[test]
+    fn refresh_stats_empty_dirs_return_zero() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join("state")).unwrap();
+        std::fs::create_dir_all(tmp.path().join("sessions")).unwrap();
+
+        let mut app = App::new("simard-ooda.service".to_string());
+        app.state_root = tmp.path().to_path_buf();
+        app.refresh_stats();
+
+        assert_eq!(app.stats_cache.state_files, Some(0));
+        assert_eq!(app.stats_cache.session_dirs, Some(0));
+    }
+
+    #[test]
+    fn refresh_stats_counts_nested_state_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state_dir = tmp.path().join("state");
+        let sub_dir = state_dir.join("cycles");
+        std::fs::create_dir_all(&sub_dir).unwrap();
+
+        std::fs::write(state_dir.join("top.json"), "{}").unwrap();
+        std::fs::write(sub_dir.join("cycle1.json"), "{}").unwrap();
+        std::fs::write(sub_dir.join("cycle2.json"), "{}").unwrap();
+
+        let mut app = App::new("simard-ooda.service".to_string());
+        app.state_root = tmp.path().to_path_buf();
+        app.refresh_stats();
+
+        assert_eq!(
+            app.stats_cache.state_files,
+            Some(3),
+            "should count files recursively"
+        );
+    }
+
+    // ── refresh_stats: gh_in_flight guard ──────────────────────────
+
+    #[test]
+    fn refresh_stats_does_not_spawn_when_gh_in_flight() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join("state")).unwrap();
+
+        let mut app = App::new("simard-ooda.service".to_string());
+        app.state_root = tmp.path().to_path_buf();
+        app.gh_in_flight = true;
+
+        // Set up an existing receiver to prove it's not replaced
+        let (_tx, rx) = std::sync::mpsc::channel::<(Option<usize>, Option<usize>)>();
+        app.gh_receiver = Some(rx);
+
+        app.refresh_stats();
+
+        // Local fs stats should still be updated
+        assert_eq!(app.stats_cache.state_files, Some(0));
+        // gh_in_flight should remain true (no new spawn)
+        assert!(app.gh_in_flight);
+        // The receiver should be the same one we set (not replaced)
+        assert!(app.gh_receiver.is_some());
+    }
+
+    #[test]
+    fn refresh_stats_sets_gh_in_flight_when_spawning() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join("state")).unwrap();
+
+        let mut app = App::new("simard-ooda.service".to_string());
+        app.state_root = tmp.path().to_path_buf();
+        assert!(!app.gh_in_flight);
+
+        app.refresh_stats();
+
+        // After refresh_stats, gh_in_flight should be true (thread spawned)
+        assert!(
+            app.gh_in_flight,
+            "should set gh_in_flight after spawning thread"
+        );
+        assert!(
+            app.gh_receiver.is_some(),
+            "should have a receiver after spawning thread"
         );
     }
 }


### PR DESCRIPTION
Closes #2201

## Changes
- Count state files (cycle reports, snapshots, backups) from ~/.simard/state/
- Count sessions from subagent_sessions.json
- Background thread fetches GitHub issues/PRs via `gh` CLI (non-blocking)
- StatsCache struct with proper refresh interval
- Tests for all new functionality
- Updated docs (howto + reference)

## Testing
- cargo build --bin simard-tui ✅
- cargo fmt ✅
- cargo clippy ✅
- Pre-push hooks pass ✅