### PR TITLE
fix(tui): detect non-TTY stdout and fall back to /dev/tty

### DIFF
--- a/.claude/context/PROJECT.md
+++ b/.claude/context/PROJECT.md
@@ -10,7 +10,7 @@ Replace the sections below with information about your project.
 
 ---
 
-## Project: issue-2182-fix-four-gaps-in-pr-2190-on-branch-featissue-2182
+## Project: issue-2204-fix-simard-tui-crash-no-such-device-or-address-os
 
 ## Overview
 

--- a/.claude/context/PROJECT.md.bak
+++ b/.claude/context/PROJECT.md.bak
@@ -10,7 +10,7 @@ Replace the sections below with information about your project.
 
 ---
 
-## Project: issue-2201-fix-tui-stats-tab-to-show-real-data-the-simard-tui
+## Project: issue-2204-fix-simard-tui-crash-no-such-device-or-address-os
 
 ## Overview
 

--- a/docs/howto/monitor-simard-with-tui.md
+++ b/docs/howto/monitor-simard-with-tui.md
@@ -1,7 +1,7 @@
 ---
 title: Monitor Simard with the TUI dashboard
 description: "How to launch simard-tui, navigate tabs, monitor engineers, read logs, run meetings, and check stats — all from a single terminal pane."
-last_updated: 2026-06-03
+last_updated: 2026-06-04
 review_schedule: as-needed
 owner: simard
 doc_type: howto
@@ -22,6 +22,12 @@ conduct meetings, and review statistics.
 
 - Simard daemon running via `simard ooda run` or the systemd service.
 - `simard-tui` binary built (`cargo build --bin simard-tui`).
+- **An interactive terminal** — stdout must be a TTY, or a controlling
+  terminal (`/dev/tty`) must be available. If running over SSH, use
+  `ssh -t` to allocate a pseudo-TTY. If running in a container, use
+  `docker run -it`. The TUI detects non-TTY stdout and falls back to
+  `/dev/tty` automatically; if neither is available, it exits with a
+  clear error message.
 - A terminal that supports 256-color output (most modern terminals).
 - For the Activity tab: `journalctl` available (systemd host).
 - For the Stats tab: `gh` CLI installed and authenticated (optional — metrics show `–` without it).
@@ -277,6 +283,40 @@ The only resource the TUI locks is the meeting process stdin/stdout —
 running two TUI instances with active Meeting tabs simultaneously is
 not recommended (two meeting processes would compete for state).
 
+## 11. Running from non-interactive environments
+
+`simard-tui` automatically detects when stdout is not a terminal and
+falls back to `/dev/tty` (the process's controlling terminal). This
+means it works in most environments where a human is at a keyboard,
+even if stdout has been redirected:
+
+```bash
+# These all work — /dev/tty fallback kicks in automatically:
+simard-tui | tee tui.log          # stdout piped, /dev/tty used
+simard-tui > /dev/null            # stdout redirected, /dev/tty used
+ssh -t host simard-tui            # SSH with PTY allocation
+docker run -it image simard-tui   # Container with TTY
+tmux new-session simard-tui       # Inside tmux
+```
+
+**Environments without any terminal** (no stdout TTY and no
+`/dev/tty`) are not supported — the TUI exits immediately with:
+
+```
+simard-tui requires a terminal. Run from an interactive shell or use: ssh -t host simard-tui
+```
+
+Examples of no-terminal environments:
+
+- `ssh host simard-tui` (without `-t`)
+- `nohup simard-tui &`
+- Cron jobs
+- CI/CD pipelines
+- Agent sessions without PTY allocation
+
+For headless monitoring in these environments, use the web dashboard
+or `simard` CLI commands instead.
+
 ## Keyboard reference
 
 | Key | Context | Action |
@@ -292,6 +332,7 @@ not recommended (two meeting processes would compete for state).
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
+| `simard-tui requires a terminal` | No TTY available (stdout is not a terminal and `/dev/tty` cannot be opened) | Run from an interactive shell, use `ssh -t host simard-tui`, or allocate a PTY with `docker run -it` |
 | All fields show `–` or `unavailable` | Daemon not running or systemctl not available | Start the daemon: `simard ooda run` |
 | Goals tab is empty | `cognitive_memory.ladybug` missing or no snapshot fact | Use `simard goal-curation read` to inspect goals via IPC |
 | Terminal looks broken after exit | Rare: panic before `TerminalGuard` drop | Run `reset` to restore terminal |

--- a/docs/reference/simard-tui.md
+++ b/docs/reference/simard-tui.md
@@ -1,7 +1,7 @@
 ---
 title: "simard-tui: Terminal monitoring dashboard"
 description: "Reference for the standalone TUI binary that monitors the Simard daemon, goals, engineers, and activity from a single terminal pane."
-last_updated: 2026-06-03
+last_updated: 2026-06-04
 review_schedule: as-needed
 owner: simard
 doc_type: reference
@@ -58,10 +58,17 @@ SIMARD_STATE_ROOT=/srv/simard simard-tui
 
 # Monitor a non-default systemd service
 SIMARD_TUI_SERVICE=simard-staging.service simard-tui
+
+# Run over SSH (allocate a PTY with -t)
+ssh -t host simard-tui
 ```
 
 The TUI opens in full-screen mode with the **Overview** tab selected.
 Press number keys `1`–`6` to switch tabs, `q` to quit.
+
+If stdout is not a terminal (e.g., piped or redirected), `simard-tui`
+automatically falls back to `/dev/tty`. If no terminal is available at
+all, it exits with: `simard-tui requires a terminal.`
 
 ---
 
@@ -521,9 +528,11 @@ and `/proc/<PID>/status` for `VmRSS`.
 `simard-tui` uses a `TerminalGuard` pattern to guarantee terminal
 restoration on any exit path:
 
-1. **`TerminalGuard` struct** — enables raw mode and enters the
-   alternate screen in its constructor; disables raw mode and leaves
-   the alternate screen in its `Drop` implementation.
+1. **`TerminalGuard` struct** — a zero-sized RAII guard created by
+   `setup_terminal()` after it enables raw mode and enters the
+   alternate screen. The guard's only job is cleanup: its `Drop`
+   implementation disables raw mode and leaves the alternate screen
+   (delegating to `restore_terminal()`).
 
 2. **Chained panic hook** — installs a panic hook that restores the
    terminal before delegating to the default handler. This prevents
@@ -536,6 +545,61 @@ restoration on any exit path:
 4. **RAII meeting cleanup** — The `App` struct implements `Drop` to
    kill and wait on the meeting child process. This handles panics,
    early returns, and any exit path that bypasses explicit cleanup.
+
+### TTY detection and `/dev/tty` fallback
+
+`setup_terminal()` detects whether stdout is connected to a real
+terminal before enabling raw mode. This prevents the `ENXIO` ("No
+such device or address", OS error 6) crash that occurred when
+`simard-tui` was launched from a non-interactive context (e.g., a
+Copilot agent session, a subprocess pipeline, SSH without `-t`, or
+`nohup`).
+
+**Detection flow:**
+
+1. `std::io::stdout().is_terminal()` — checks via the `IsTerminal`
+   trait (which calls `isatty(1)` on Unix).
+2. If stdout **is** a TTY → use `io::stdout()` as the terminal
+   backend writer. This is the normal interactive case.
+3. If stdout is **not** a TTY → attempt to open `/dev/tty` with
+   read+write access as the backend writer instead.
+4. If `/dev/tty` also fails (no controlling terminal at all — e.g.,
+   inside a container with no TTY, or a detached `nohup` session) →
+   exit immediately with a clear error message:
+
+   ```
+   simard-tui requires a terminal. Run from an interactive shell or use: ssh -t host simard-tui
+   ```
+
+**Backend type.** `setup_terminal()` returns
+`Terminal<CrosstermBackend<Box<dyn Write>>>`. Both `io::Stdout` and
+`fs::File` implement `Write`, so the backend is polymorphic over the
+underlying writer. This has no effect on downstream code — ratatui
+0.29's `Frame` type is not generic over the backend, so all `draw()`
+call sites are unchanged.
+
+**Cleanup routing.** A static `AtomicBool` flag (`USING_DEV_TTY`) is
+set to `true` when the `/dev/tty` fallback path is taken. Both
+`TerminalGuard::drop()` and the panic hook consult this flag to
+determine where to write the `LeaveAlternateScreen` escape sequence:
+
+- `USING_DEV_TTY == false` → write to `io::stdout()` (normal path).
+- `USING_DEV_TTY == true` → open `/dev/tty` and write there.
+
+The flag uses `Ordering::Relaxed` because it is set once during
+`setup_terminal()` (before the event loop starts) and only read
+during cleanup. There is no dependent memory ordering.
+
+**`restore_terminal()` helper.** A shared `fn restore_terminal()`
+encapsulates the cleanup logic (disable raw mode + leave alternate
+screen on the correct writer). Both `TerminalGuard::drop()` and the
+panic hook delegate to this function, eliminating duplicated cleanup
+code.
+
+**`enable_raw_mode()` / `disable_raw_mode()`.** These crossterm
+functions are process-global — they operate on fd 0 (stdin) or
+`/dev/tty` internally, independent of which writer the backend uses.
+They work correctly in both the stdout and `/dev/tty` paths.
 
 ---
 
@@ -590,6 +654,15 @@ restoration on any exit path:
 
 ## Limitations
 
+- **Requires a terminal.** `simard-tui` needs either a TTY-connected
+  stdout or an accessible `/dev/tty`. When neither is available (fully
+  headless environments like CI, cron, or `nohup`), the TUI exits with
+  a descriptive error. Use the web dashboard for headless monitoring.
+
+- **`/dev/tty` fallback is Unix-only.** The `/dev/tty` fallback path
+  uses a Unix-specific device file. On non-Unix platforms (if ever
+  supported), only the stdout-is-a-TTY path would work.
+
 - **OODA cycle count** is not available on disk — the daemon does not
   persist a counter file. The Overview tab shows `N/A`. This can be
   extracted from journal logs in a future iteration.
@@ -628,6 +701,34 @@ restoration on any exit path:
 ---
 
 ## Troubleshooting
+
+### "No such device or address (os error 6)" crash
+
+**This issue is fixed.** Prior to the TTY detection feature,
+`simard-tui` would crash with `ENXIO` (OS error 6) when stdout was
+not connected to a terminal — for example, when launched from a
+Copilot agent session, piped into another process, run via `nohup`,
+or over SSH without the `-t` flag.
+
+`setup_terminal()` now detects non-TTY stdout and falls back to
+`/dev/tty`. If you still see this error, it means no controlling
+terminal exists at all. Solutions:
+
+- **SSH:** Use `ssh -t host simard-tui` to allocate a pseudo-TTY.
+- **Subprocess/agent:** Launch `simard-tui` inside `script -qc
+  'simard-tui' /dev/null` to allocate a PTY, or use `tmux`/`screen`.
+- **Container:** Ensure the container has a TTY allocated (`docker
+  run -it ...`).
+- **`nohup`/`cron`:** TUI applications are inherently interactive.
+  Use the web dashboard instead for headless monitoring.
+
+### "simard-tui requires a terminal" error
+
+This message appears when `simard-tui` detects that neither stdout
+nor `/dev/tty` provides a usable terminal. The TUI requires an
+interactive terminal for raw mode input and alternate screen output.
+See the solutions above for "No such device or address" — they apply
+to this case as well.
 
 ### "Service unavailable" on Overview tab
 

--- a/src/bin/simard_tui/main.rs
+++ b/src/bin/simard_tui/main.rs
@@ -10,7 +10,9 @@ mod tabs;
 mod types;
 mod ui;
 
-use std::io::{self, Stdout};
+use std::io::IsTerminal;
+use std::io::{self, Write};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use crossterm::event::{self, Event, KeyEventKind};
@@ -18,20 +20,57 @@ use crossterm::terminal::{self, EnterAlternateScreen, LeaveAlternateScreen};
 use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
 
+static USING_DEV_TTY: AtomicBool = AtomicBool::new(false);
+
+/// Restore terminal to normal state. Shared by `TerminalGuard::drop` and panic hook.
+fn restore_terminal() {
+    let _ = terminal::disable_raw_mode();
+    if USING_DEV_TTY.load(Ordering::Relaxed) {
+        if let Ok(mut tty) = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open("/dev/tty")
+        {
+            let _ = crossterm::execute!(tty, LeaveAlternateScreen);
+        }
+    } else {
+        let _ = crossterm::execute!(io::stdout(), LeaveAlternateScreen);
+    }
+}
+
 /// RAII guard that restores terminal state on drop.
 struct TerminalGuard;
 
 impl Drop for TerminalGuard {
     fn drop(&mut self) {
-        let _ = terminal::disable_raw_mode();
-        let _ = crossterm::execute!(io::stdout(), LeaveAlternateScreen);
+        restore_terminal();
     }
 }
 
-fn setup_terminal() -> io::Result<Terminal<CrosstermBackend<Stdout>>> {
+fn setup_terminal() -> io::Result<Terminal<CrosstermBackend<Box<dyn Write>>>> {
+    let mut writer: Box<dyn Write> = if io::stdout().is_terminal() {
+        Box::new(io::stdout())
+    } else {
+        let tty = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open("/dev/tty")
+            .map_err(|_| {
+                io::Error::other(
+                    "simard-tui requires a terminal. \
+                     Run from an interactive shell or use: ssh -t host simard-tui",
+                )
+            })?;
+        USING_DEV_TTY.store(true, Ordering::Relaxed);
+        Box::new(tty)
+    };
+
     terminal::enable_raw_mode()?;
-    crossterm::execute!(io::stdout(), EnterAlternateScreen)?;
-    Terminal::new(CrosstermBackend::new(io::stdout()))
+    if let Err(e) = crossterm::execute!(writer, EnterAlternateScreen) {
+        let _ = terminal::disable_raw_mode();
+        return Err(e);
+    }
+    Terminal::new(CrosstermBackend::new(writer))
 }
 
 fn main() {
@@ -45,8 +84,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     // Chain panic hook to restore terminal before default panic output.
     let original_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
-        let _ = terminal::disable_raw_mode();
-        let _ = crossterm::execute!(io::stdout(), LeaveAlternateScreen);
+        restore_terminal();
         original_hook(info);
     }));
 
@@ -81,4 +119,128 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// Serializes tests that share global `USING_DEV_TTY` state.
+    static TEST_MUTEX: Mutex<()> = Mutex::new(());
+
+    /// USING_DEV_TTY must exist as a static AtomicBool and default to false.
+    #[test]
+    fn using_dev_tty_defaults_to_false() {
+        let _lock = TEST_MUTEX.lock().unwrap();
+        // Reset to known clean state (other tests may have run first).
+        USING_DEV_TTY.store(false, Ordering::Relaxed);
+        assert!(
+            !USING_DEV_TTY.load(Ordering::Relaxed),
+            "USING_DEV_TTY should be false after reset"
+        );
+    }
+
+    /// restore_terminal() must exist and not panic regardless of USING_DEV_TTY state.
+    #[test]
+    fn restore_terminal_does_not_panic_when_flag_false() {
+        let _lock = TEST_MUTEX.lock().unwrap();
+        USING_DEV_TTY.store(false, Ordering::Relaxed);
+        restore_terminal();
+    }
+
+    /// restore_terminal() must not panic when USING_DEV_TTY is true,
+    /// even if /dev/tty is not available (best-effort cleanup).
+    #[test]
+    fn restore_terminal_does_not_panic_when_flag_true() {
+        let _lock = TEST_MUTEX.lock().unwrap();
+        USING_DEV_TTY.store(true, Ordering::Relaxed);
+        restore_terminal();
+        USING_DEV_TTY.store(false, Ordering::Relaxed);
+    }
+
+    /// setup_terminal() return type must be Terminal<CrosstermBackend<Box<dyn Write>>>,
+    /// NOT Terminal<CrosstermBackend<Stdout>>. This ensures the backend is
+    /// polymorphic over stdout vs /dev/tty file handles.
+    #[test]
+    fn setup_terminal_returns_boxed_write_backend() {
+        // Type-level assertion: if this compiles, the return type is correct.
+        // Verify function signature without calling it to avoid terminal side effects.
+        #[allow(clippy::type_complexity)]
+        let _: fn() -> io::Result<Terminal<CrosstermBackend<Box<dyn Write>>>> = setup_terminal;
+    }
+
+    /// When stdout is NOT a TTY and /dev/tty is also unavailable,
+    /// setup_terminal() must return an error with a helpful message
+    /// containing "requires a terminal".
+    #[test]
+    fn setup_terminal_error_message_is_actionable() {
+        use std::io::IsTerminal;
+
+        let _lock = TEST_MUTEX.lock().unwrap();
+        USING_DEV_TTY.store(false, Ordering::Relaxed);
+
+        // Skip this test if stdout IS a terminal (interactive run).
+        if std::io::stdout().is_terminal() {
+            return;
+        }
+
+        match setup_terminal() {
+            Ok(_term) => {
+                // /dev/tty was available — that's fine, clean up.
+                assert!(
+                    USING_DEV_TTY.load(Ordering::Relaxed),
+                    "USING_DEV_TTY should be true when stdout is not a TTY and /dev/tty was used"
+                );
+                restore_terminal();
+                USING_DEV_TTY.store(false, Ordering::Relaxed);
+            }
+            Err(e) => {
+                let msg = e.to_string();
+                assert!(
+                    msg.contains("requires a terminal"),
+                    "Error should mention 'requires a terminal', got: {msg}"
+                );
+            }
+        }
+    }
+
+    /// When stdout is not a TTY but /dev/tty IS available,
+    /// setup_terminal() must succeed and set USING_DEV_TTY to true.
+    #[test]
+    fn setup_terminal_falls_back_to_dev_tty() {
+        use std::io::IsTerminal;
+
+        let _lock = TEST_MUTEX.lock().unwrap();
+        USING_DEV_TTY.store(false, Ordering::Relaxed);
+
+        // Skip if stdout is already a TTY (no fallback needed).
+        if std::io::stdout().is_terminal() {
+            return;
+        }
+
+        // Skip if /dev/tty is not accessible (e.g., CI container).
+        if std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open("/dev/tty")
+            .is_err()
+        {
+            return;
+        }
+
+        let result = setup_terminal();
+        assert!(
+            result.is_ok(),
+            "setup_terminal() should succeed via /dev/tty fallback"
+        );
+        assert!(
+            USING_DEV_TTY.load(Ordering::Relaxed),
+            "USING_DEV_TTY should be true after /dev/tty fallback"
+        );
+
+        // Cleanup
+        restore_terminal();
+        USING_DEV_TTY.store(false, Ordering::Relaxed);
+    }
 }


### PR DESCRIPTION
## Summary

When `simard-tui` is launched without a controlling terminal (e.g., from a Copilot session, subprocess, or SSH without `-t`), crossterm's `enable_raw_mode()` fails with `No such device or address (os error 6)`.

## Changes

- **TTY detection**: Check `std::io::IsTerminal` before enabling raw mode
- **Fallback**: Open `/dev/tty` as the terminal backend when stdout is not a TTY
- **Clear error**: Print actionable message if neither stdout nor `/dev/tty` is available
- **DRY cleanup**: Add `restore_terminal()` helper shared by `TerminalGuard::drop` and panic hook
- **Polymorphic backend**: Return `Terminal<CrosstermBackend<Box<dyn Write>>>` from `setup_terminal()`
- **Tests**: 6 new tests with Mutex serialization for global state safety
- **Docs**: Updated troubleshooting and TTY detection guidance

## Testing

- `cargo test --bin simard-tui` — 149 tests pass
- `cargo clippy --all-targets --all-features` — clean
- `cargo fmt` — clean

Closes #2204