### PR TITLE
fix: centralize cargo parallelism limit to prevent OOM (#2199)

### DIFF
--- a/src/agent_supervisor/lifecycle/spawn.rs
+++ b/src/agent_supervisor/lifecycle/spawn.rs
@@ -45,8 +45,8 @@ pub fn spawn_subordinate(config: &SubordinateConfig) -> SimardResult<Subordinate
             "SIMARD_SUBORDINATE_DEPTH",
             (config.current_depth + 1).to_string(),
         )
-        // Limit concurrent cargo parallelism per agent to prevent OOM (issue #373).
-        .env("CARGO_BUILD_JOBS", "4")
+        // Limit concurrent cargo parallelism per agent to prevent OOM (issues #373, #2199).
+        .env("CARGO_BUILD_JOBS", crate::cargo_jobs::cargo_jobs())
         .current_dir(&config.worktree_path);
     // Issue #1197: per-engineer git worktrees would otherwise force a
     // cold cargo rebuild (incl. lbug, ~40min) every spawn. Share one

--- a/src/agent_supervisor/tests_tmux.rs
+++ b/src/agent_supervisor/tests_tmux.rs
@@ -207,8 +207,20 @@ fn compute_tmux_env_seeds_required_simard_vars_from_config() {
     );
     assert_eq!(
         env_value(&env, "CARGO_BUILD_JOBS"),
-        Some("4"),
-        "CARGO_BUILD_JOBS must be capped at 4 (issue #373 OOM guard)"
+        Some("2"),
+        "CARGO_BUILD_JOBS must default to 2 (issues #373, #2199 OOM guard)"
+    );
+}
+
+#[test]
+fn compute_tmux_env_respects_simard_cargo_jobs_override() {
+    let config = make_test_config("e1", 0);
+    let parent = vec![("SIMARD_CARGO_JOBS".to_string(), "6".to_string())];
+    let env = compute_tmux_env(&config, parent);
+    assert_eq!(
+        env_value(&env, "CARGO_BUILD_JOBS"),
+        Some("6"),
+        "CARGO_BUILD_JOBS must honor SIMARD_CARGO_JOBS from parent env"
     );
 }
 

--- a/src/agent_supervisor/tmux.rs
+++ b/src/agent_supervisor/tmux.rs
@@ -131,7 +131,7 @@ fn default_cargo_target_for_worktree(
 /// 1. Always-set vars seeded from `config`:
 ///    - `SIMARD_AGENT_NAME`        = `config.agent_name`
 ///    - `SIMARD_SUBORDINATE_DEPTH` = `config.current_depth + 1`
-///    - `CARGO_BUILD_JOBS`         = `"4"` (issue #373 OOM guard)
+///    - `CARGO_BUILD_JOBS`         = `cargo_jobs_from(SIMARD_CARGO_JOBS)` (issues #373, #2199 OOM guard)
 /// 2. `CARGO_TARGET_DIR` honors a `parent_env` override; otherwise defaults
 ///    to a **per-worktree** path so concurrent engineers never share one
 ///    cargo target dir (which would deadlock cargo's file lock or corrupt
@@ -159,16 +159,23 @@ pub fn compute_tmux_env<I>(config: &SubordinateConfig, parent_env: I) -> Vec<(St
 where
     I: IntoIterator<Item = (String, String)>,
 {
+    let parent_pairs: Vec<(String, String)> = parent_env.into_iter().collect();
+
+    // Resolve CARGO_BUILD_JOBS from SIMARD_CARGO_JOBS in parent env (issues #373, #2199).
+    let simard_jobs_override = parent_pairs
+        .iter()
+        .find(|(k, _)| k == "SIMARD_CARGO_JOBS")
+        .map(|(_, v)| v.as_str());
+    let cargo_jobs = crate::cargo_jobs::cargo_jobs_from(simard_jobs_override);
+
     let mut tmux_env: Vec<(String, String)> = vec![
         ("SIMARD_AGENT_NAME".to_string(), config.agent_name.clone()),
         (
             "SIMARD_SUBORDINATE_DEPTH".to_string(),
             (config.current_depth + 1).to_string(),
         ),
-        ("CARGO_BUILD_JOBS".to_string(), "4".to_string()),
+        ("CARGO_BUILD_JOBS".to_string(), cargo_jobs),
     ];
-
-    let parent_pairs: Vec<(String, String)> = parent_env.into_iter().collect();
 
     let cargo_target = parent_pairs
         .iter()

--- a/src/cargo_jobs.rs
+++ b/src/cargo_jobs.rs
@@ -1,0 +1,84 @@
+//! Centralized cargo parallelism limit to prevent OOM (issue #2199).
+//!
+//! All Simard-spawned `cargo build` / `cargo test` invocations must use
+//! this limit via the `CARGO_BUILD_JOBS` environment variable.
+//!
+//! Operators can override the default by setting `SIMARD_CARGO_JOBS`.
+//! The value must be a positive integer; invalid values fall back to
+//! the default of 2.
+
+const DEFAULT_CARGO_JOBS: &str = "2";
+
+/// Read `SIMARD_CARGO_JOBS` from the process environment and return
+/// a validated string suitable for `CARGO_BUILD_JOBS`.
+pub fn cargo_jobs() -> String {
+    cargo_jobs_from(std::env::var("SIMARD_CARGO_JOBS").ok().as_deref())
+}
+
+/// Pure helper: validate an optional override value and return a string
+/// suitable for `CARGO_BUILD_JOBS`. Returns `DEFAULT_CARGO_JOBS` when
+/// the input is `None`, empty, non-numeric, zero, or negative.
+///
+/// This function does not touch `std::env`, so it is safe to use in
+/// pure contexts (e.g., `compute_tmux_env`).
+pub fn cargo_jobs_from(override_value: Option<&str>) -> String {
+    match override_value {
+        Some(s) if !s.trim().is_empty() => match s.trim().parse::<i32>() {
+            Ok(n) if n > 0 => n.to_string(),
+            _ => DEFAULT_CARGO_JOBS.to_string(),
+        },
+        _ => DEFAULT_CARGO_JOBS.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_when_none() {
+        assert_eq!(cargo_jobs_from(None), "2");
+    }
+
+    #[test]
+    fn default_when_empty() {
+        assert_eq!(cargo_jobs_from(Some("")), "2");
+    }
+
+    #[test]
+    fn default_when_whitespace() {
+        assert_eq!(cargo_jobs_from(Some("  ")), "2");
+    }
+
+    #[test]
+    fn default_when_non_numeric() {
+        assert_eq!(cargo_jobs_from(Some("abc")), "2");
+    }
+
+    #[test]
+    fn default_when_zero() {
+        assert_eq!(cargo_jobs_from(Some("0")), "2");
+    }
+
+    #[test]
+    fn default_when_negative() {
+        assert_eq!(cargo_jobs_from(Some("-1")), "2");
+    }
+
+    #[test]
+    fn accepts_valid_positive_integer() {
+        assert_eq!(cargo_jobs_from(Some("4")), "4");
+        assert_eq!(cargo_jobs_from(Some("1")), "1");
+        assert_eq!(cargo_jobs_from(Some("8")), "8");
+    }
+
+    #[test]
+    fn trims_whitespace_around_valid_value() {
+        assert_eq!(cargo_jobs_from(Some(" 3 ")), "3");
+    }
+
+    #[test]
+    fn default_when_float() {
+        assert_eq!(cargo_jobs_from(Some("2.5")), "2");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod bridge_circuit;
 pub mod bridge_launcher;
 pub mod bridge_subprocess;
 pub mod build_lock;
+pub mod cargo_jobs;
 pub mod cmd_cleanup;
 pub mod cmd_ensure_deps;
 pub mod cmd_install;

--- a/src/self_relaunch/canary.rs
+++ b/src/self_relaunch/canary.rs
@@ -23,6 +23,7 @@ pub fn build_canary(config: &RelaunchConfig) -> SimardResult<PathBuf> {
         .arg(target_dir)
         .arg("--manifest-path")
         .arg(config.manifest_dir.join("Cargo.toml"))
+        .env("CARGO_BUILD_JOBS", crate::cargo_jobs::cargo_jobs())
         .output()
         .map_err(|e| SimardError::BridgeSpawnFailed {
             bridge: "canary-build".to_string(),

--- a/src/self_relaunch/gates.rs
+++ b/src/self_relaunch/gates.rs
@@ -67,7 +67,7 @@ fn run_unit_test_gate(config: &RelaunchConfig) -> GateResult {
         .arg(config.manifest_dir.join("Cargo.toml"))
         .arg("--target-dir")
         .arg(&config.canary_target_dir)
-        .env("CARGO_BUILD_JOBS", "2")
+        .env("CARGO_BUILD_JOBS", crate::cargo_jobs::cargo_jobs())
         .output()
     {
         Ok(output) if output.status.success() => GateResult {


### PR DESCRIPTION
## Summary

Fixes #2199 — Simard engineers run `cargo build` without a `-j` limit, causing OOM in the 32GB cgroup on 64-core machines.

## Changes

**New module: `src/cargo_jobs.rs`**
- `cargo_jobs()`: reads `SIMARD_CARGO_JOBS` env var, returns validated string for `CARGO_BUILD_JOBS`
- `cargo_jobs_from()`: pure helper (no `std::env`) for contexts like `compute_tmux_env` that must remain deterministic
- Default: **2** (down from 4) — with multiple concurrent engineers, 4 jobs each still exceeded the 32GB cgroup limit
- Validates input: rejects empty, non-numeric, zero, negative values

**Fixed call sites (4):**
| File | Before | After |
|------|--------|-------|
| `canary.rs` | **Missing entirely** | `cargo_jobs()` |
| `spawn.rs` | Hardcoded `"4"` | `cargo_jobs()` |
| `tmux.rs` | Hardcoded `"4"` | `cargo_jobs_from(parent_env)` |
| `gates.rs` | Hardcoded `"2"` | `cargo_jobs()` |

**Tests: 10 new + 1 updated**
- 9 unit tests for `cargo_jobs_from()` validation (None, empty, whitespace, non-numeric, zero, negative, float, valid, trimming)
- 1 new tmux test: `compute_tmux_env_respects_simard_cargo_jobs_override`
- 1 updated: existing tmux assertion changed from `"4"` to `"2"`

## Also in this cycle

Closed 2 issues resolved by prior commits:
- #2206 (stale Python bridge processes) — resolved by d660fd2 which removed Python bridges
- #2079 (gym bridge broken pipe) — resolved by d660fd2 which removed Python subprocess fallback

## Diff focused
7 files changed, 114 insertions, 9 deletions. No unrelated edits.

## Verification
- `cargo check --lib` ✅
- `cargo test --lib cargo_jobs` ✅ (10 tests)
- `cargo test --lib agent_supervisor::tests_tmux` ✅ (20 tests)
- `cargo test --lib self_relaunch` ✅ (75 tests)
- Pre-commit hooks (fmt, clippy) ✅
- Pre-push hooks (clippy --all-targets, test --release --lib) ✅