### PR TITLE
fix(engineer-loop): replace hardcoded agent-completed with post-hoc verification (#1670)

### DIFF
--- a/src/engineer_loop/execution/mod.rs
+++ b/src/engineer_loop/execution/mod.rs
@@ -23,6 +23,13 @@ pub(crate) fn run_command(cwd: &Path, argv: &[&str]) -> SimardResult<CommandOutp
     run_command_inner(cwd, argv, /* allow_nonzero_exit = */ false)
 }
 
+/// Like [`run_command`] but tolerates non-zero exit codes. Returns `Ok` with
+/// whatever stdout was captured even when the child exits non-zero. Still
+/// returns `Err` for spawn failures, empty argv, or timeout.
+pub(crate) fn run_command_allow_failure(cwd: &Path, argv: &[&str]) -> SimardResult<CommandOutput> {
+    run_command_inner(cwd, argv, /* allow_nonzero_exit = */ true)
+}
+
 fn run_command_inner(
     cwd: &Path,
     argv: &[&str],

--- a/src/engineer_loop/mod.rs
+++ b/src/engineer_loop/mod.rs
@@ -39,7 +39,10 @@ use crate::runtime::RuntimeTopology;
 use crate::session::{SessionPhase, SessionRecord, UuidSessionIdGenerator};
 use crate::terminal_engineer_bridge::{SHARED_EXPLICIT_STATE_ROOT_SOURCE, TerminalBridgeContext};
 
-use execution::{parse_status_paths, run_command, trimmed_stdout, trimmed_stdout_allow_empty};
+use execution::{
+    parse_status_paths, run_command, run_command_allow_failure, trimmed_stdout,
+    trimmed_stdout_allow_empty,
+};
 
 // Re-export all public items so `crate::engineer_loop::X` still works.
 pub use types::{
@@ -305,11 +308,7 @@ pub fn run_local_engineer_loop(
         }
     };
 
-    let verification = VerificationReport {
-        status: "agent-completed".to_string(),
-        summary: action.stdout.clone(),
-        checks: vec![],
-    };
+    let verification = verify_agent_spawn_artifacts(&inspection, objective);
 
     // --- SessionPhase::Reflection ---
     // Compare results against the objective and capture what succeeded/failed.
@@ -422,6 +421,165 @@ pub fn run_local_engineer_loop(
         phase_traces,
         session_record: Some(session),
     })
+}
+
+/// Extract issue/PR numbers referenced in an objective string.
+/// Matches patterns like `#1234`, `issue #1234`, `PR #1234`.
+fn extract_referenced_numbers(objective: &str) -> Vec<u64> {
+    let mut numbers = Vec::new();
+    // Simple byte scan for `#` followed by digits.
+    let bytes = objective.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'#' {
+            let start = i + 1;
+            let mut end = start;
+            while end < bytes.len() && bytes[end].is_ascii_digit() {
+                end += 1;
+            }
+            if end > start {
+                if let Ok(n) = objective[start..end].parse::<u64>() {
+                    if !numbers.contains(&n) {
+                        numbers.push(n);
+                    }
+                }
+            }
+            i = end;
+        } else {
+            i += 1;
+        }
+    }
+    numbers
+}
+
+/// Count status paths that are new relative to a pre-spawn baseline.
+fn count_new_status_paths(before: &[String], after: &[String]) -> Vec<String> {
+    after
+        .iter()
+        .filter(|p| !before.contains(p))
+        .cloned()
+        .collect()
+}
+
+/// Synthesize a [`VerificationReport`] from observable side-effects after an
+/// agent session completes (issue #1670). Replaces the previous hardcoded
+/// `"agent-completed"` status with post-hoc verification that checks:
+///
+/// 1. New commits since `inspection.head` (via `git rev-list --count`).
+/// 2. New/changed files in the worktree (via `git status --short`).
+/// 3. Referenced issue/PR metadata (best-effort via `gh`, non-blocking).
+///
+/// Status is `"verified"` when at least one check finds a measurable artifact;
+/// `"unverified"` otherwise.
+fn verify_agent_spawn_artifacts(
+    inspection: &RepoInspection,
+    objective: &str,
+) -> VerificationReport {
+    let repo_root = &inspection.repo_root;
+    let pre_head = &inspection.head;
+    let mut checks: Vec<String> = Vec::new();
+
+    // 1. Count new commits since the pre-spawn HEAD.
+    let new_commit_count = run_command_allow_failure(
+        repo_root,
+        &["git", "rev-list", "--count", &format!("{pre_head}..HEAD")],
+    )
+    .ok()
+    .and_then(|out| out.stdout.trim().parse::<u64>().ok())
+    .unwrap_or(0);
+
+    if new_commit_count > 0 {
+        // Also grab the one-line summaries for the checks list.
+        let log_lines = run_command_allow_failure(
+            repo_root,
+            &["git", "log", "--oneline", &format!("{pre_head}..HEAD")],
+        )
+        .ok()
+        .map(|out| out.stdout.trim().to_string())
+        .unwrap_or_default();
+        checks.push(format!(
+            "git: {new_commit_count} new commit(s) since {pre_head}"
+        ));
+        if !log_lines.is_empty() {
+            // Cap at first 5 lines to keep the report bounded.
+            let capped: String = log_lines.lines().take(5).collect::<Vec<_>>().join("; ");
+            checks.push(format!("git-log: {capped}"));
+        }
+    }
+
+    // 2. Detect new/changed files in the worktree.
+    let post_status = run_command_allow_failure(
+        repo_root,
+        &["git", "status", "--short", "--untracked-files=all"],
+    )
+    .ok()
+    .map(|out| parse_status_paths(&out.stdout))
+    .unwrap_or_default();
+
+    let new_files = count_new_status_paths(&inspection.changed_files, &post_status);
+    if !new_files.is_empty() {
+        checks.push(format!(
+            "git-status: {} new changed file(s): {}",
+            new_files.len(),
+            new_files
+                .iter()
+                .take(5)
+                .cloned()
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+
+    // 3. Best-effort GH metadata probe for referenced issues/PRs.
+    let referenced = extract_referenced_numbers(objective);
+    for num in referenced.iter().take(3) {
+        // Try PR first, then issue. Both are non-blocking.
+        if let Some(info) = gh_resource_info(repo_root, "pr", *num) {
+            checks.push(format!("gh: PR #{num} {info}"));
+        } else if let Some(info) = gh_resource_info(repo_root, "issue", *num) {
+            checks.push(format!("gh: issue #{num} {info}"));
+        }
+    }
+
+    // Determine status: verified if at least one check found a measurable
+    // artifact from git (commits or file changes). GH metadata alone is
+    // informational and does not flip the status.
+    let has_git_evidence = new_commit_count > 0 || !new_files.is_empty();
+    let status = if has_git_evidence {
+        "verified"
+    } else {
+        "unverified"
+    }
+    .to_string();
+
+    let summary = if checks.is_empty() {
+        "No observable artifacts detected after agent session".to_string()
+    } else {
+        checks.join("; ")
+    };
+
+    VerificationReport {
+        status,
+        summary,
+        checks,
+    }
+}
+
+/// Best-effort query of a GH PR or issue. Returns a short info string on
+/// success, `None` on any failure (missing `gh` CLI, auth issues, etc.).
+fn gh_resource_info(repo_root: &Path, kind: &str, number: u64) -> Option<String> {
+    let num_str = number.to_string();
+    let result = run_command_allow_failure(
+        repo_root,
+        &["gh", kind, "view", &num_str, "--json", "state,title"],
+    );
+    match result {
+        Ok(out) => {
+            let text = out.stdout.trim().to_string();
+            if text.is_empty() { None } else { Some(text) }
+        }
+        Err(_) => None,
+    }
 }
 
 /// Form a structured execution plan from the objective and inspection data

--- a/src/engineer_loop/mod.rs
+++ b/src/engineer_loop/mod.rs
@@ -437,12 +437,11 @@ fn extract_referenced_numbers(objective: &str) -> Vec<u64> {
             while end < bytes.len() && bytes[end].is_ascii_digit() {
                 end += 1;
             }
-            if end > start {
-                if let Ok(n) = objective[start..end].parse::<u64>() {
-                    if !numbers.contains(&n) {
-                        numbers.push(n);
-                    }
-                }
+            if end > start
+                && let Ok(n) = objective[start..end].parse::<u64>()
+                && !numbers.contains(&n)
+            {
+                numbers.push(n);
             }
             i = end;
         } else {

--- a/src/engineer_loop/tests_mod.rs
+++ b/src/engineer_loop/tests_mod.rs
@@ -165,3 +165,88 @@ fn analyze_objective_is_case_insensitive() {
 }
 
 // ---- is_meeting_decision_record tests ----
+
+// ---- extract_referenced_numbers tests (issue #1670) ----
+
+#[test]
+fn extract_referenced_numbers_finds_issue_numbers() {
+    let nums = super::extract_referenced_numbers("Fix issue #1670 and close #42");
+    assert_eq!(nums, vec![1670, 42]);
+}
+
+#[test]
+fn extract_referenced_numbers_deduplicates() {
+    let nums = super::extract_referenced_numbers("#5 is related to #5 and #5");
+    assert_eq!(nums, vec![5]);
+}
+
+#[test]
+fn extract_referenced_numbers_empty_when_none() {
+    let nums = super::extract_referenced_numbers("no references here");
+    assert!(nums.is_empty());
+}
+
+#[test]
+fn extract_referenced_numbers_ignores_bare_hash() {
+    let nums = super::extract_referenced_numbers("# heading with no number");
+    assert!(nums.is_empty());
+}
+
+// ---- count_new_status_paths tests (issue #1670) ----
+
+#[test]
+fn count_new_status_paths_finds_new_files() {
+    let before = vec!["a.rs".to_string()];
+    let after = vec!["a.rs".to_string(), "b.rs".to_string(), "c.rs".to_string()];
+    let new = super::count_new_status_paths(&before, &after);
+    assert_eq!(new, vec!["b.rs".to_string(), "c.rs".to_string()]);
+}
+
+#[test]
+fn count_new_status_paths_empty_when_no_change() {
+    let before = vec!["a.rs".to_string()];
+    let after = vec!["a.rs".to_string()];
+    let new = super::count_new_status_paths(&before, &after);
+    assert!(new.is_empty());
+}
+
+#[test]
+fn count_new_status_paths_empty_inputs() {
+    let new = super::count_new_status_paths(&[], &[]);
+    assert!(new.is_empty());
+}
+
+// ---- verify_agent_spawn_artifacts contract tests (issue #1670) ----
+
+#[test]
+fn verification_report_status_is_verified_or_unverified_never_agent_completed() {
+    // Construct a verification report via the function under test, pointed at
+    // the real repo root. Since we haven't made commits, this will be
+    // "unverified" (or "verified" if the worktree is dirty). Either way,
+    // "agent-completed" must never appear.
+    let inspection = super::types::RepoInspection {
+        workspace_root: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")),
+        repo_root: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")),
+        branch: "test".to_string(),
+        head: "HEAD".to_string(),
+        worktree_dirty: false,
+        changed_files: vec![],
+        active_goals: vec![],
+        carried_meeting_decisions: vec![],
+        architecture_gap_summary: String::new(),
+    };
+    let report = super::verify_agent_spawn_artifacts(&inspection, "test objective");
+    assert!(
+        report.status == "verified" || report.status == "unverified",
+        "status must be verified or unverified, got: {}",
+        report.status
+    );
+    assert_ne!(report.status, "agent-completed");
+    // When status is "verified", checks must be non-empty.
+    if report.status == "verified" {
+        assert!(
+            !report.checks.is_empty(),
+            "verified status requires at least one check"
+        );
+    }
+}

--- a/tests/engineer_loop.rs
+++ b/tests/engineer_loop.rs
@@ -284,15 +284,15 @@ fn engineer_loop_probe_reports_repo_state_runs_verified_action_and_persists_trut
         rendered.contains("Changed files after action: <none>"),
         "non-mutating engineer-loop runs should say when they changed nothing:\n{rendered}"
     );
-    // The agent-spawn pipeline reports `agent-completed` because the
-    // verification work is performed by the spawned agent inside its own
-    // session, not by deterministic post-hoc checks owned by the engineer
-    // loop. Both `verified` (deterministic) and `agent-completed` (delegated)
-    // are honest verification outcomes; the loop must surface one of them.
+    // Post-hoc verification (issue #1670) synthesizes checks from observable
+    // side-effects. In CI the engineer probe runs against the real repo, so
+    // git artifacts may or may not be present depending on whether the agent
+    // made commits. Either `verified` or `unverified` is an honest outcome;
+    // the retired `agent-completed` status is no longer accepted.
     assert!(
         rendered.contains("Verification status: verified")
-            || rendered.contains("Verification status: agent-completed"),
-        "engineer-loop probe should only claim verified or agent-completed outcomes after explicit checks:\n{rendered}"
+            || rendered.contains("Verification status: unverified"),
+        "engineer-loop probe must report verified or unverified (not agent-completed):\n{rendered}"
     );
     assert!(
         !rendered.contains("Azlin"),
@@ -342,8 +342,8 @@ fn engineer_loop_probe_reports_repo_state_runs_verified_action_and_persists_trut
     );
     assert!(
         evidence_payload.contains("verification-status=verified")
-            || evidence_payload.contains("verification-status=agent-completed"),
-        "evidence payload should preserve verification status:\n{evidence_payload}"
+            || evidence_payload.contains("verification-status=unverified"),
+        "evidence payload should preserve verification status (verified or unverified):\n{evidence_payload}"
     );
     assert!(
         memory_payload.contains("engineer-loop-summary"),
@@ -351,8 +351,8 @@ fn engineer_loop_probe_reports_repo_state_runs_verified_action_and_persists_trut
     );
     assert!(
         handoff_payload.contains("verification-status=verified")
-            || handoff_payload.contains("verification-status=agent-completed"),
-        "handoff payload should preserve verified or agent-completed outcome status for truthful resume behavior:\n{handoff_payload}"
+            || handoff_payload.contains("verification-status=unverified"),
+        "handoff payload should preserve verified or unverified outcome status for truthful resume behavior:\n{handoff_payload}"
     );
     assert!(
         evidence_payload.contains("carried-meeting-decisions=<none>"),

--- a/tests/goal_stewardship.rs
+++ b/tests/goal_stewardship.rs
@@ -163,12 +163,12 @@ goal: Keep outside-in verification strong | priority=2 | status=active | rationa
     );
     assert!(engineer_rendered.contains("decisions=[preserve meeting-to-engineer continuity]"));
     assert!(engineer_rendered.contains("next_steps=[keep durable priorities visible]"));
-    // Either deterministic verification (`verified`) or delegated agent
-    // verification (`agent-completed`) is acceptable as long as the loop
-    // surfaces an explicit verification outcome rather than silently passing.
+    // Either deterministic verification (`verified`) or post-hoc no-artifact
+    // detection (`unverified`) is acceptable as long as the loop surfaces an
+    // explicit verification outcome rather than silently passing.
     assert!(
         engineer_rendered.contains("Verification status: verified")
-            || engineer_rendered.contains("Verification status: agent-completed"),
+            || engineer_rendered.contains("Verification status: unverified"),
         "engineer loop must still surface bounded verification while reading curated goals:\n{engineer_rendered}"
     );
 }
@@ -237,6 +237,6 @@ open-question: what changes after meeting {meeting_number}?"
     assert!(engineer_rendered.contains("Carried meeting decision 3: agenda=alignment meeting 4;"));
     assert!(
         engineer_rendered.contains("Verification status: verified")
-            || engineer_rendered.contains("Verification status: agent-completed")
+            || engineer_rendered.contains("Verification status: unverified")
     );
 }

--- a/tests/improvement_curation.rs
+++ b/tests/improvement_curation.rs
@@ -148,13 +148,13 @@ approve: Promote this pattern into a repeatable benchmark | priority=2 | status=
     assert!(
         engineer_rendered.contains("Active goal 1: p1 [active] Capture denser execution evidence")
     );
-    // PR #1536 ("refactor(engineer-loop): remove plan-parse-execute, replace
-    // with agentic orchestration") removed the verification subsystem and
-    // hardcoded the post-action status to "agent-completed". This assertion
-    // was masked by the cross-process durability bug (issue #1590) — the
-    // earlier "Active goals count: 1" assertion failed first. After the
-    // #1590 fix the test reaches this line and we pin the current contract.
-    assert!(engineer_rendered.contains("Verification status: agent-completed"));
+    // Issue #1670: post-hoc verification replaces the retired "agent-completed"
+    // status. The probe runs against the real repo so either outcome is valid.
+    assert!(
+        engineer_rendered.contains("Verification status: verified")
+            || engineer_rendered.contains("Verification status: unverified"),
+        "engineer loop must report verified or unverified (not agent-completed):\n{engineer_rendered}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes #1670 — the engineer loop's agent-spawn path unconditionally reported `status: "agent-completed"` with `checks: vec![]`, meaning every spawned engineer claimed success regardless of outcome. This poisoned the OODA feedback loop because reflection consumed `verification.status` to decide whether to re-spawn or advance.

## Changes

### Core fix (`src/engineer_loop/mod.rs`)
Replaced the hardcoded `VerificationReport` with `verify_agent_spawn_artifacts()` that synthesizes checks from observable side-effects after the agent session completes:

1. **Commit detection**: `git rev-list --count <pre_head>..HEAD` — counts new commits since the pre-spawn HEAD (deterministic, no wall-clock skew)
2. **File change detection**: `git status --short` delta against `inspection.changed_files` — detects newly touched paths
3. **GH metadata probe**: Best-effort `gh pr view` / `gh issue view` for referenced `#N` numbers (non-blocking, informational only)

Status is `"verified"` when at least one git artifact (commit or file change) is found, `"unverified"` otherwise. The `"agent-completed"` status string is **fully retired**.

### Supporting changes
- `run_command_allow_failure()` (`execution/mod.rs`) — tolerant subprocess wrapper for git/gh commands that may fail
- `extract_referenced_numbers()` — pure helper to parse `#N` patterns from objectives
- `count_new_status_paths()` — pure helper to diff pre/post file lists

### Test updates
- **8 new unit tests** covering helpers and the verification contract
- **`tests/engineer_loop.rs`**: Replaced `agent-completed` disjunctions with `verified || unverified`
- **`tests/goal_stewardship.rs`**: Same replacement
- **`tests/improvement_curation.rs`**: Same replacement

## Evidence

1. **Tests**: `cargo test --lib` — 5221 passed, 0 failed from this change (1 pre-existing hermetic guard failure unrelated to this PR)
2. **Compilation**: `cargo check` clean with no warnings from changed files
3. **Formatting**: `cargo fmt` applied
4. **Diff focused**: 6 files changed, 279 insertions, 29 deletions — all directly related to #1670
5. **Surfaces changed**: `VerificationReport.status` values (internal), no user-facing API changes. Internal-only: the status field is consumed by reflection/persistence within the engineer loop.
