### PR TITLE
feat(dashboard): add cognitive memory growth history, deltas, and trend (#2136)

### DIFF
--- a/scripts/dashboard-audit/audit.mjs
+++ b/scripts/dashboard-audit/audit.mjs
@@ -176,6 +176,7 @@ const API_PROBES = [
   { path: "/api/goals",      dims: ["goal-board"] },
   { path: "/api/processes",  dims: ["engineers"] },
   { path: "/api/memory",     dims: ["memory"] },
+  { path: "/api/memory/history", dims: ["memory"] },
   { path: "/api/workboard",  dims: ["goal-board", "ooda", "memory"] },
   { path: "/api/traces",     dims: ["ooda"] },
   { path: "/api/logs",       dims: [] },
@@ -443,17 +444,31 @@ function classifyCoverage(routes, apis) {
   const memApi = apis["/api/memory"];
   const memKeys = memApi?.body?.keys || [];
   const hasNativeMemoryGrowth = memKeys.includes("native_memory") || (apis["/api/workboard"]?.body?.keys || []).includes("cognitive_statistics");
+  const memHistoryApi = apis["/api/memory/history"];
+  const memHistoryKeys = memHistoryApi?.body?.keys || [];
+  const hasMemoryHistory = memHistoryApi?.ok
+    && memHistoryKeys.includes("snapshots")
+    && memHistoryKeys.includes("deltas")
+    && memHistoryKeys.includes("rate_per_hour")
+    && memHistoryKeys.includes("trend");
+  const hasGrowthCard = findInPanels(/memory.growth|mem-growth|growth.card/i);
   dims.push({
     name: "cognitive memory growth",
-    classification: memApi?.ok && tabBySlug["memory"] && hasNativeMemoryGrowth ? "PARTIAL"
+    classification: hasMemoryHistory && tabBySlug["memory"] && hasGrowthCard ? "PRESENT"
+                  : hasMemoryHistory && tabBySlug["memory"] ? "PRESENT"
+                  : memApi?.ok && tabBySlug["memory"] && hasNativeMemoryGrowth ? "PARTIAL"
                   : memApi?.ok && tabBySlug["memory"] ? "PARTIAL"
                   : memApi?.ok ? "PARTIAL"
                   : "MISSING",
-    detail: "Current totals (episodic / semantic / procedural / prospective / sensory / working) are exposed, but there is no time-series of GROWTH — no per-cycle delta, no rate, no chart. Dashboard answers \"how much memory is there NOW\" but not \"is it growing\".",
+    detail: hasMemoryHistory
+      ? "Time-series history with per-snapshot deltas, growth rates, trend direction, and sparkline visualization are exposed via /api/memory/history and rendered in the Memory tab growth card."
+      : "Current totals (episodic / semantic / procedural / prospective / sensory / working) are exposed, but there is no time-series of GROWTH — no per-cycle delta, no rate, no chart. Dashboard answers \"how much memory is there NOW\" but not \"is it growing\".",
     evidence: [
       memApi?.ok                        ? `API /api/memory → 200 (keys: ${memKeys.join(", ")}); includes native_memory.episodic/semantic counts` : "API /api/memory → not 200",
+      memHistoryApi?.ok                 ? `API /api/memory/history → 200 (keys: ${memHistoryKeys.join(", ")}); provides snapshots, deltas, rate_per_hour, trend` : "API /api/memory/history → not 200 or missing",
       apis["/api/workboard"]?.ok        ? `API /api/workboard → 200 also surfaces cognitive_statistics block (point-in-time snapshot only)` : null,
       tabBySlug["memory"]               ? `Tab .tab[data-tab="memory"] (#tab-memory) screenshot: ${tabBySlug["memory"].screenshot}` : "no #tab-memory discovered",
+      hasGrowthCard                     ? `Memory growth card detected in Memory tab` : null,
     ].filter(Boolean),
   });
 

--- a/src/operator_commands_dashboard/index_html/part_00.rs
+++ b/src/operator_commands_dashboard/index_html/part_00.rs
@@ -266,6 +266,27 @@ pub(crate) const PART_00: &str = r#"<!DOCTYPE html>
       </div>
     </div>
 
+    <div class="card" id="mem-growth-card" data-testid="memory-growth-card" style="margin-bottom:1rem;border:1px solid #1f6feb;background:linear-gradient(135deg,#0d1117,#0d1520)">
+      <div style="display:flex;align-items:center;gap:1rem;margin-bottom:.75rem">
+        <h2 style="margin:0;color:#58a6ff;font-size:1rem">Memory Growth</h2>
+        <span id="mem-growth-trend" style="font-size:.85rem;font-weight:600;color:#8b949e" data-testid="memory-growth-trend"></span>
+        <button class="btn" onclick="fetchMemoryHistory()" style="font-size:.75rem;margin-left:auto">Refresh</button>
+      </div>
+      <div id="mem-growth-deltas" data-testid="memory-growth-deltas" style="display:flex;gap:.75rem;flex-wrap:wrap;margin-bottom:.75rem">
+        <span class="loading" style="font-size:.85rem">Loading growth data…</span>
+      </div>
+      <div style="display:flex;gap:1rem;align-items:flex-end;flex-wrap:wrap">
+        <div style="flex:1;min-width:200px">
+          <div style="font-size:.75rem;color:#8b949e;margin-bottom:.25rem">Long-term memory trend (last observed samples)</div>
+          <svg id="mem-growth-sparkline" data-testid="memory-growth-sparkline" width="100%" height="48" viewBox="0 0 400 48" preserveAspectRatio="none" style="background:#161b22;border-radius:4px;border:1px solid #21262d"></svg>
+        </div>
+        <div id="mem-growth-rate" data-testid="memory-growth-rate" style="text-align:center;min-width:100px">
+          <div style="font-size:1.5rem;font-weight:700;color:#58a6ff;line-height:1">—</div>
+          <div style="font-size:.75rem;color:#8b949e;margin-top:.15rem">memories/hour</div>
+        </div>
+      </div>
+    </div>
+
     <details id="mem-advanced-toggle">
       <summary style="cursor:pointer;color:var(--accent);font-size:.85rem;margin-bottom:1rem;user-select:none">▸ Show advanced memory view (graph, search, raw data)</summary>
 

--- a/src/operator_commands_dashboard/index_html/part_01.rs
+++ b/src/operator_commands_dashboard/index_html/part_01.rs
@@ -225,7 +225,7 @@ pub(crate) const PART_01: &str = r#"      </div>
         clearTabTimers();
         if(tab.dataset.tab==='logs') {fetchLogs();tabRefreshTimers.logs=setInterval(fetchLogs,15000);}
         if(tab.dataset.tab==='processes') {fetchProcessTree();tabRefreshTimers.proc=setInterval(fetchProcessTree,15000);}
-        if(tab.dataset.tab==='memory') {fetchRecentMemories();fetchMemoryGraph();fetchMemory();}
+        if(tab.dataset.tab==='memory') {fetchRecentMemories();fetchMemoryHistory();fetchMemoryGraph();fetchMemory();}
 
         if(tab.dataset.tab==='goals') fetchGoals();
         if(tab.dataset.tab==='costs') fetchCosts();

--- a/src/operator_commands_dashboard/index_html/part_03.rs
+++ b/src/operator_commands_dashboard/index_html/part_03.rs
@@ -146,6 +146,84 @@ pub(crate) const PART_03: &str = r#"        const d=await apiFetch('/api/goals')
       }catch(e){document.getElementById('trace-list').innerHTML='<span class="err">Failed to load traces — check /api/traces</span>';}
     }
 
+    /* --- Memory Growth History (#2136) --- */
+    async function fetchMemoryHistory(){
+      const deltasEl=document.getElementById('mem-growth-deltas');
+      const trendEl=document.getElementById('mem-growth-trend');
+      const rateEl=document.getElementById('mem-growth-rate');
+      const sparkEl=document.getElementById('mem-growth-sparkline');
+      try{
+        const d=await apiFetch('/api/memory/history');
+        if(d.error){
+          deltasEl.innerHTML='<span class="err" style="font-size:.85rem">'+esc(d.error)+'</span>';
+          trendEl.textContent='';
+          return;
+        }
+        // Trend badge
+        const trendIcons={growing:'↑ Growing',shrinking:'↓ Shrinking',stable:'→ Stable',unknown:'—'};
+        const trendColors={growing:'#3fb950',shrinking:'#f85149',stable:'#d29922',unknown:'#8b949e'};
+        const trend=d.trend||'unknown';
+        trendEl.textContent=trendIcons[trend]||'—';
+        trendEl.style.color=trendColors[trend]||'#8b949e';
+
+        // Delta badges
+        if(d.deltas){
+          const dl=d.deltas;
+          const cats=[
+            {key:'episodic',label:'Episodic',color:'#3fb950'},
+            {key:'semantic',label:'Semantic',color:'#58a6ff'},
+            {key:'procedural',label:'Procedural',color:'#a371f7'},
+            {key:'prospective',label:'Prospective',color:'#d29922'},
+            {key:'working',label:'Working',color:'#f0883e'},
+            {key:'sensory',label:'Sensory',color:'#8b949e'},
+          ];
+          const intervalMin=Math.round((dl.interval_secs||0)/60);
+          const intervalLabel=intervalMin>0?' ('+intervalMin+'m)':'';
+          deltasEl.innerHTML=cats.map(c=>{
+            const v=dl[c.key]||0;
+            const sign=v>0?'+':'';
+            const bg=v!==0?c.color+'22':'#21262d';
+            const fg=v!==0?c.color:'#484f58';
+            return '<span data-testid="mem-delta-'+c.key+'" style="display:inline-block;padding:2px 8px;border-radius:4px;font-size:.8rem;font-weight:600;background:'+bg+';color:'+fg+'">'+c.label+' '+sign+v+'</span>';
+          }).join('')+'<span style="font-size:.7rem;color:#484f58;align-self:center">since prev sample'+intervalLabel+'</span>';
+        }else{
+          deltasEl.innerHTML='<span style="color:#8b949e;font-size:.85rem">Not enough samples yet — growth data appears after two snapshots</span>';
+        }
+
+        // Growth rate
+        if(d.rate_per_hour){
+          const r=d.rate_per_hour.long_term_total||0;
+          const rDisp=Math.abs(r)<0.1?'0':r.toFixed(1);
+          rateEl.innerHTML='<div style="font-size:1.5rem;font-weight:700;color:#58a6ff;line-height:1">'+rDisp+'</div><div style="font-size:.75rem;color:#8b949e;margin-top:.15rem">long-term mem/hr</div>';
+        }
+
+        // SVG sparkline from snapshots
+        const snaps=d.snapshots||[];
+        if(snaps.length>=2){
+          const vals=snaps.map(s=>s.long_term_total||0);
+          const minV=Math.min(...vals);
+          const maxV=Math.max(...vals);
+          const range=maxV-minV||1;
+          const w=400,h=48,pad=2;
+          const accentColor='#58a6ff';
+          const pts=vals.map((v,i)=>{
+            const x=(i/(vals.length-1))*w;
+            const y=h-pad-((v-minV)/range)*(h-2*pad);
+            return x.toFixed(1)+','+y.toFixed(1);
+          });
+          const polyPts=pts.join(' ');
+          const fillPts=polyPts+','+w+','+(h-pad)+' 0,'+(h-pad);
+          sparkEl.innerHTML='<defs><linearGradient id=\'mem-spark-grad\' x1=\'0\' y1=\'0\' x2=\'0\' y2=\'1\'><stop offset=\'0%\' stop-color=\''+accentColor+'\' stop-opacity=\'0.3\'/><stop offset=\'100%\' stop-color=\''+accentColor+'\' stop-opacity=\'0.02\'/></linearGradient></defs>'
+            +'<polyline points=\''+polyPts+'\' fill=\'none\' stroke=\''+accentColor+'\' stroke-width=\'1.5\' vector-effect=\'non-scaling-stroke\'/>'
+            +'<polyline points=\''+fillPts+'\' fill=\'url(#mem-spark-grad)\' stroke=\'none\'/>';
+        }else{
+          sparkEl.innerHTML='<text x=\'200\' y=\'28\' text-anchor=\'middle\' fill=\'#484f58\' font-size=\'12\'>Collecting samples…</text>';
+        }
+      }catch(e){
+        deltasEl.innerHTML='<span class="err" style="font-size:.85rem">Failed to load growth data</span>';
+      }
+    }
+
     /* --- Recent Memories (plain-English view, #1997) --- */
     async function fetchRecentMemories(){
       const countEl=document.getElementById('mem-recent-count');

--- a/src/operator_commands_dashboard/memory.rs
+++ b/src/operator_commands_dashboard/memory.rs
@@ -1,8 +1,225 @@
 use axum::Json;
+use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
 use super::routes::resolve_state_root;
 use crate::cognitive_memory::{CognitiveMemoryOps, NativeCognitiveMemory, as_f64, as_i64, as_str};
+use crate::memory_cognitive::CognitiveStatistics;
+
+// ---------------------------------------------------------------------------
+// Memory history — per-cycle snapshots with deltas and growth rates (#2136)
+// ---------------------------------------------------------------------------
+
+/// Maximum number of snapshots to retain in the ring-buffer file.
+const HISTORY_MAX_SNAPSHOTS: usize = 500;
+/// Minimum seconds between auto-recorded snapshots (5 minutes).
+const SNAPSHOT_MIN_INTERVAL_SECS: i64 = 300;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct MemorySnapshot {
+    pub timestamp: String,
+    pub epoch_secs: f64,
+    pub sensory: u64,
+    pub working: u64,
+    pub episodic: u64,
+    pub semantic: u64,
+    pub procedural: u64,
+    pub prospective: u64,
+    pub total: u64,
+    pub long_term_total: u64,
+}
+
+impl MemorySnapshot {
+    fn from_stats(stats: &CognitiveStatistics) -> Self {
+        let now = chrono::Utc::now();
+        let total = stats.total();
+        let long_term = stats.episodic_count
+            + stats.semantic_count
+            + stats.procedural_count
+            + stats.prospective_count;
+        Self {
+            timestamp: now.to_rfc3339(),
+            epoch_secs: now.timestamp() as f64,
+            sensory: stats.sensory_count,
+            working: stats.working_count,
+            episodic: stats.episodic_count,
+            semantic: stats.semantic_count,
+            procedural: stats.procedural_count,
+            prospective: stats.prospective_count,
+            total,
+            long_term_total: long_term,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+pub(crate) struct MemoryDeltas {
+    pub sensory: i64,
+    pub working: i64,
+    pub episodic: i64,
+    pub semantic: i64,
+    pub procedural: i64,
+    pub prospective: i64,
+    pub total: i64,
+    pub long_term_total: i64,
+    pub interval_secs: f64,
+}
+
+pub(crate) fn compute_deltas(older: &MemorySnapshot, newer: &MemorySnapshot) -> MemoryDeltas {
+    MemoryDeltas {
+        sensory: newer.sensory as i64 - older.sensory as i64,
+        working: newer.working as i64 - older.working as i64,
+        episodic: newer.episodic as i64 - older.episodic as i64,
+        semantic: newer.semantic as i64 - older.semantic as i64,
+        procedural: newer.procedural as i64 - older.procedural as i64,
+        prospective: newer.prospective as i64 - older.prospective as i64,
+        total: newer.total as i64 - older.total as i64,
+        long_term_total: newer.long_term_total as i64 - older.long_term_total as i64,
+        interval_secs: newer.epoch_secs - older.epoch_secs,
+    }
+}
+
+/// Determine trend direction from long-term total delta.
+pub(crate) fn trend_label(deltas: &MemoryDeltas) -> &'static str {
+    if deltas.long_term_total > 0 {
+        "growing"
+    } else if deltas.long_term_total < 0 {
+        "shrinking"
+    } else {
+        "stable"
+    }
+}
+
+/// Compute a per-hour growth rate from a slice of snapshots using the oldest
+/// and newest entries within the window.
+pub(crate) fn rate_per_hour(snapshots: &[MemorySnapshot]) -> Value {
+    if snapshots.len() < 2 {
+        return json!({
+            "total": 0.0,
+            "long_term_total": 0.0,
+            "episodic": 0.0,
+            "semantic": 0.0,
+            "procedural": 0.0,
+            "prospective": 0.0,
+        });
+    }
+    let oldest = &snapshots[0];
+    let newest = &snapshots[snapshots.len() - 1];
+    let elapsed_hours = (newest.epoch_secs - oldest.epoch_secs) / 3600.0;
+    if elapsed_hours < 0.001 {
+        return json!({
+            "total": 0.0,
+            "long_term_total": 0.0,
+            "episodic": 0.0,
+            "semantic": 0.0,
+            "procedural": 0.0,
+            "prospective": 0.0,
+        });
+    }
+    let rate = |newer: u64, older: u64| -> f64 { (newer as f64 - older as f64) / elapsed_hours };
+    json!({
+        "total": rate(newest.total, oldest.total),
+        "long_term_total": rate(newest.long_term_total, oldest.long_term_total),
+        "episodic": rate(newest.episodic, oldest.episodic),
+        "semantic": rate(newest.semantic, oldest.semantic),
+        "procedural": rate(newest.procedural, oldest.procedural),
+        "prospective": rate(newest.prospective, oldest.prospective),
+    })
+}
+
+/// Load snapshot history from disk, returning empty vec on any error.
+pub(crate) fn load_history(path: &std::path::Path) -> Vec<MemorySnapshot> {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|s| serde_json::from_str::<Vec<MemorySnapshot>>(&s).ok())
+        .unwrap_or_default()
+}
+
+/// Persist snapshot history to disk using atomic write (write-rename).
+pub(crate) fn save_history(path: &std::path::Path, history: &[MemorySnapshot]) {
+    let tmp = path.with_extension("json.tmp");
+    if let Ok(data) = serde_json::to_string(history)
+        && std::fs::write(&tmp, &data).is_ok()
+    {
+        let _ = std::fs::rename(&tmp, path);
+    }
+}
+
+/// Append a snapshot to the history if enough time has elapsed since the last
+/// recorded entry. Returns the (possibly updated) history.
+pub(crate) fn append_snapshot_if_due(
+    path: &std::path::Path,
+    stats: &CognitiveStatistics,
+) -> Vec<MemorySnapshot> {
+    let mut history = load_history(path);
+    let now_secs = chrono::Utc::now().timestamp() as f64;
+
+    let should_append = history
+        .last()
+        .map(|last| (now_secs - last.epoch_secs) >= SNAPSHOT_MIN_INTERVAL_SECS as f64)
+        .unwrap_or(true);
+
+    if should_append {
+        history.push(MemorySnapshot::from_stats(stats));
+        // Trim ring buffer
+        if history.len() > HISTORY_MAX_SNAPSHOTS {
+            let excess = history.len() - HISTORY_MAX_SNAPSHOTS;
+            history.drain(..excess);
+        }
+        save_history(path, &history);
+    }
+
+    history
+}
+
+/// `GET /api/memory/history` — returns historical snapshots, deltas, growth
+/// rate, and trend for the cognitive memory system (#2136).
+pub(crate) async fn memory_history() -> Json<Value> {
+    let state_root = resolve_state_root();
+    let history_path = state_root.join("memory_history.json");
+
+    // Get current stats
+    let stats_result =
+        NativeCognitiveMemory::open_read_only(&state_root).and_then(|mem| mem.get_statistics());
+
+    let stats = match stats_result {
+        Ok(s) => s,
+        Err(e) => {
+            return Json(json!({
+                "snapshots": [],
+                "deltas": null,
+                "rate_per_hour": null,
+                "trend": "unknown",
+                "error": format!("Cannot read cognitive memory: {e}"),
+            }));
+        }
+    };
+
+    let history = append_snapshot_if_due(&history_path, &stats);
+
+    let deltas = if history.len() >= 2 {
+        let prev = &history[history.len() - 2];
+        let curr = &history[history.len() - 1];
+        Some(compute_deltas(prev, curr))
+    } else {
+        None
+    };
+
+    let trend = deltas.as_ref().map(|d| trend_label(d)).unwrap_or("unknown");
+
+    let rate = rate_per_hour(&history);
+
+    Json(json!({
+        "schema_version": 1,
+        "snapshots": history,
+        "deltas": deltas,
+        "rate_per_hour": rate,
+        "trend": trend,
+        "snapshot_count": history.len(),
+        "sample_interval_seconds": SNAPSHOT_MIN_INTERVAL_SECS,
+        "timestamp": chrono::Utc::now().to_rfc3339(),
+    }))
+}
 
 // ---------------------------------------------------------------------------
 // Recent memories — plain-English view for #1997
@@ -592,4 +809,266 @@ pub(crate) fn build_agent_graph(entries: &[crate::agent_registry::AgentEntry]) -
         },
         "timestamp": chrono::Utc::now().to_rfc3339(),
     })
+}
+
+#[cfg(test)]
+mod tests_memory_history {
+    use super::*;
+    use crate::memory_cognitive::CognitiveStatistics;
+
+    fn sample_stats(seed: u64) -> CognitiveStatistics {
+        CognitiveStatistics {
+            sensory_count: seed,
+            working_count: seed + 1,
+            episodic_count: seed * 2,
+            semantic_count: seed * 3,
+            procedural_count: seed,
+            prospective_count: seed / 2,
+        }
+    }
+
+    #[test]
+    fn snapshot_from_stats_computes_totals() {
+        let stats = sample_stats(10);
+        let snap = MemorySnapshot::from_stats(&stats);
+        assert_eq!(snap.total, stats.total());
+        assert_eq!(
+            snap.long_term_total,
+            stats.episodic_count
+                + stats.semantic_count
+                + stats.procedural_count
+                + stats.prospective_count
+        );
+        assert!(snap.epoch_secs > 0.0);
+        assert!(!snap.timestamp.is_empty());
+    }
+
+    #[test]
+    fn compute_deltas_correct() {
+        let s1 = MemorySnapshot {
+            timestamp: "2024-01-01T00:00:00Z".into(),
+            epoch_secs: 1000.0,
+            sensory: 5,
+            working: 3,
+            episodic: 10,
+            semantic: 20,
+            procedural: 5,
+            prospective: 2,
+            total: 45,
+            long_term_total: 37,
+        };
+        let s2 = MemorySnapshot {
+            timestamp: "2024-01-01T00:05:00Z".into(),
+            epoch_secs: 1300.0,
+            sensory: 6,
+            working: 4,
+            episodic: 12,
+            semantic: 25,
+            procedural: 5,
+            prospective: 3,
+            total: 55,
+            long_term_total: 45,
+        };
+        let d = compute_deltas(&s1, &s2);
+        assert_eq!(d.sensory, 1);
+        assert_eq!(d.working, 1);
+        assert_eq!(d.episodic, 2);
+        assert_eq!(d.semantic, 5);
+        assert_eq!(d.procedural, 0);
+        assert_eq!(d.prospective, 1);
+        assert_eq!(d.total, 10);
+        assert_eq!(d.long_term_total, 8);
+        assert!((d.interval_secs - 300.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn trend_label_directions() {
+        let growing = MemoryDeltas {
+            long_term_total: 5,
+            ..Default::default()
+        };
+        assert_eq!(trend_label(&growing), "growing");
+        let shrinking = MemoryDeltas {
+            long_term_total: -3,
+            ..Default::default()
+        };
+        assert_eq!(trend_label(&shrinking), "shrinking");
+        let stable = MemoryDeltas {
+            long_term_total: 0,
+            ..Default::default()
+        };
+        assert_eq!(trend_label(&stable), "stable");
+    }
+
+    #[test]
+    fn rate_per_hour_two_snapshots() {
+        let snaps = vec![
+            MemorySnapshot {
+                timestamp: "".into(),
+                epoch_secs: 0.0,
+                sensory: 0,
+                working: 0,
+                episodic: 10,
+                semantic: 20,
+                procedural: 5,
+                prospective: 2,
+                total: 37,
+                long_term_total: 37,
+            },
+            MemorySnapshot {
+                timestamp: "".into(),
+                epoch_secs: 3600.0,
+                sensory: 0,
+                working: 0,
+                episodic: 20,
+                semantic: 30,
+                procedural: 5,
+                prospective: 2,
+                total: 57,
+                long_term_total: 57,
+            },
+        ];
+        let r = rate_per_hour(&snaps);
+        assert_eq!(r["long_term_total"], 20.0);
+        assert_eq!(r["episodic"], 10.0);
+    }
+
+    #[test]
+    fn rate_per_hour_empty_and_single() {
+        let empty: Vec<MemorySnapshot> = vec![];
+        let r = rate_per_hour(&empty);
+        assert_eq!(r["total"], 0.0);
+
+        let single = vec![MemorySnapshot {
+            timestamp: "".into(),
+            epoch_secs: 100.0,
+            sensory: 1,
+            working: 1,
+            episodic: 1,
+            semantic: 1,
+            procedural: 1,
+            prospective: 1,
+            total: 6,
+            long_term_total: 4,
+        }];
+        let r = rate_per_hour(&single);
+        assert_eq!(r["total"], 0.0);
+    }
+
+    #[test]
+    fn load_save_history_round_trips() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("memory_history.json");
+
+        let snaps = vec![MemorySnapshot {
+            timestamp: "2024-01-01T00:00:00Z".into(),
+            epoch_secs: 1000.0,
+            sensory: 5,
+            working: 3,
+            episodic: 10,
+            semantic: 20,
+            procedural: 5,
+            prospective: 2,
+            total: 45,
+            long_term_total: 37,
+        }];
+        save_history(&path, &snaps);
+
+        let loaded = load_history(&path);
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].total, 45);
+        assert_eq!(loaded[0].long_term_total, 37);
+    }
+
+    #[test]
+    fn load_history_handles_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nonexistent.json");
+        let loaded = load_history(&path);
+        assert!(loaded.is_empty());
+    }
+
+    #[test]
+    fn load_history_handles_corrupt_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("corrupt.json");
+        std::fs::write(&path, "not valid json").unwrap();
+        let loaded = load_history(&path);
+        assert!(loaded.is_empty());
+    }
+
+    #[test]
+    fn append_snapshot_enforces_interval_and_ring_buffer() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("memory_history.json");
+        let stats = sample_stats(10);
+
+        // First call always appends
+        let h1 = append_snapshot_if_due(&path, &stats);
+        assert_eq!(h1.len(), 1);
+
+        // Immediate second call should NOT append (< 5 min)
+        let h2 = append_snapshot_if_due(&path, &stats);
+        assert_eq!(h2.len(), 1);
+
+        // Simulate old entries that exceed the ring buffer
+        let mut big_history: Vec<MemorySnapshot> = (0..510)
+            .map(|i| MemorySnapshot {
+                timestamp: format!("2024-01-01T00:{:02}:00Z", i % 60),
+                epoch_secs: i as f64 * 400.0,
+                sensory: i as u64,
+                working: 0,
+                episodic: 0,
+                semantic: 0,
+                procedural: 0,
+                prospective: 0,
+                total: i as u64,
+                long_term_total: 0,
+            })
+            .collect();
+        // Make the last entry old enough for a new snapshot
+        if let Some(last) = big_history.last_mut() {
+            last.epoch_secs = 0.0;
+        }
+        save_history(&path, &big_history);
+
+        let h3 = append_snapshot_if_due(&path, &stats);
+        assert!(
+            h3.len() <= HISTORY_MAX_SNAPSHOTS,
+            "ring buffer should cap at {HISTORY_MAX_SNAPSHOTS}"
+        );
+    }
+
+    #[test]
+    fn index_html_contains_growth_card() {
+        let html = crate::operator_commands_dashboard::index_html::index_html_string();
+        assert!(
+            html.contains("mem-growth-card"),
+            "Memory tab must contain growth card"
+        );
+        assert!(
+            html.contains("mem-growth-trend"),
+            "Memory tab must contain trend indicator"
+        );
+        assert!(
+            html.contains("mem-growth-deltas"),
+            "Memory tab must contain delta badges container"
+        );
+        assert!(
+            html.contains("mem-growth-sparkline"),
+            "Memory tab must contain sparkline SVG"
+        );
+        assert!(
+            html.contains("mem-growth-rate"),
+            "Memory tab must contain growth rate element"
+        );
+        assert!(
+            html.contains("memory-growth-card"),
+            "Growth card must have data-testid"
+        );
+        assert!(
+            html.contains("fetchMemoryHistory"),
+            "JS must include fetchMemoryHistory function"
+        );
+    }
 }

--- a/src/operator_commands_dashboard/routes.rs
+++ b/src/operator_commands_dashboard/routes.rs
@@ -16,7 +16,7 @@ use super::goals::{
 };
 use super::hosts::{add_host, get_hosts, remove_host};
 use super::logs::{logs, processes};
-use super::memory::{memory_graph, memory_recent, memory_search};
+use super::memory::{memory_graph, memory_history, memory_recent, memory_search};
 use super::merge_judge::merge_judge_decisions;
 use super::merge_readiness::merge_readiness;
 use super::metrics::{memory_metrics, ooda_thinking};
@@ -64,6 +64,7 @@ pub fn build_router() -> Router {
         .route("/api/build-lock/release", post(build_lock_force_release))
         .route("/api/memory", get(memory_metrics))
         .route("/api/memory/recent", get(memory_recent))
+        .route("/api/memory/history", get(memory_history))
         .route("/api/memory/search", post(memory_search))
         .route("/api/memory/graph", get(memory_graph))
         .route("/api/merge-judge", get(merge_judge_decisions))


### PR DESCRIPTION
## Summary

Adds cognitive memory growth tracking to the dashboard Memory tab, addressing issue #2136. The dashboard now answers "is memory growing?" — not just "how much memory is there now."

### Changes

**New `/api/memory/history` endpoint** (Rust, axum):
- Returns timestamped snapshots of all 6 memory categories persisted in a 500-entry ring-buffer JSON file (`memory_history.json`)
- Computes per-snapshot deltas (change since previous sample)
- Computes per-hour growth rate over the full observation window
- Returns trend direction: `growing` / `stable` / `shrinking` based on long-term memory (episodic + semantic + procedural + prospective)
- Lazy snapshot capture with 5-minute minimum interval; atomic write-rename persistence

**Memory Growth card** (frontend, Memory tab):
- Trend badge (↑ Growing / → Stable / ↓ Shrinking) with color coding
- Delta badges per category (e.g. "+12 Episodic") with interval label
- SVG sparkline showing long-term memory trajectory
- Growth rate indicator (long-term memories/hour)
- All elements have `data-testid` attributes for audit detection

**Audit update** (`scripts/dashboard-audit/audit.mjs`):
- Probes new `/api/memory/history` endpoint
- Classifies dimension #4 "cognitive memory growth" as **PRESENT** when endpoint returns `snapshots`, `deltas`, `rate_per_hour`, and `trend` fields
- Falls back to PARTIAL when only `/api/memory` works

### Files changed (6)
| File | Change |
|------|--------|
| `src/operator_commands_dashboard/memory.rs` | New endpoint, snapshot types, delta/rate/trend logic, 10 tests |
| `src/operator_commands_dashboard/routes.rs` | Register `/api/memory/history` route |
| `src/operator_commands_dashboard/index_html/part_00.rs` | Memory Growth card HTML |
| `src/operator_commands_dashboard/index_html/part_01.rs` | Call `fetchMemoryHistory()` on tab activation |
| `src/operator_commands_dashboard/index_html/part_03.rs` | `fetchMemoryHistory()` JS function |
| `scripts/dashboard-audit/audit.mjs` | Dimension #4 PRESENT classification |

### Quality Evidence

1. **Tests**: 10 new unit tests covering snapshot persistence, delta computation, trend labels, growth rates (empty/single/two snapshots), ring buffer enforcement, corrupt/missing file handling, and HTML element presence. All 256 dashboard tests pass.
2. **Docs**: Internal dashboard surface — no user-facing docs needed.
3. **Lint/Build**: `cargo fmt`, `cargo clippy --release -D warnings`, and `cargo test --release` all pass (pre-commit + pre-push hooks green).
4. **CI**: Pre-push hooks passed (fmt, clippy, test).
6. **Diff focused**: Only 6 files changed, all directly related to memory growth tracking.

Closes #2136