### PR TITLE
fix(goals): migrate meeting_backend from FileBackedGoalStore to CognitiveMemoryGoalStore (#1668)

### DIFF
--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -161,6 +161,16 @@ impl BootstrapConfig {
         self.state_root.value.join("evidence_records.json")
     }
 
+    /// Legacy file-backed goal store path.
+    ///
+    /// Since issue #1668 all goal reads/writes flow through
+    /// `CognitiveMemoryGoalStore`. This method is retained only for
+    /// backward-compatible path assertions in tests and should not be
+    /// used in new production code.
+    #[deprecated(
+        since = "0.20.0",
+        note = "Goal storage now uses CognitiveMemoryGoalStore; see issue #1668"
+    )]
     pub fn goal_store_path(&self) -> PathBuf {
         self.state_root.value.join("state").join("goal_store.json")
     }
@@ -290,6 +300,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_goal_store_path() {
         let config = BootstrapConfig::resolve(builtin_defaults_inputs()).unwrap();
         let path = config.goal_store_path();

--- a/src/bootstrap/tests_config.rs
+++ b/src/bootstrap/tests_config.rs
@@ -158,6 +158,7 @@ fn resolve_full_explicit_config_succeeds() {
 // ── BootstrapConfig path methods ──
 
 #[test]
+#[allow(deprecated)]
 fn config_path_methods_use_state_root() {
     let temp_dir = TestDir::new("simard-paths-test");
     let inputs = BootstrapInputs {

--- a/src/goals/cognitive_memory_store.rs
+++ b/src/goals/cognitive_memory_store.rs
@@ -2,12 +2,12 @@
 //!
 //! See `docs/reference/cognitive-memory-goal-store.md` for the design.
 //!
-//! `bootstrap::assembly` is the production caller: every per-record write
-//! flows through cognitive memory via the bridge helpers
-//! (`launch_writer_bridge` / `open_reader_bridge`). The legacy on-disk
-//! `goal_records.json` file is no longer produced — closing the
-//! half-migration gap that PR #1593 / PR #1600 left behind for the
-//! bootstrap-assembled local sessions.
+//! `bootstrap::assembly` and `meeting_backend` are the production callers:
+//! every per-record write flows through cognitive memory via the bridge
+//! helpers (`launch_writer_bridge` / `open_reader_bridge`). The legacy
+//! on-disk `goal_records.json` and `state/goal_store.json` files are no
+//! longer produced — closing the half-migration gap that PR #1593 /
+//! PR #1600 / issue #1668 left behind.
 //!
 //! Storage encoding: each [`GoalRecord`] is serialised as a
 //! `goal-store:record` fact whose content is the JSON record. Reads
@@ -186,6 +186,118 @@ fn compare_goal_records(left: &GoalRecord, right: &GoalRecord) -> Ordering {
         .then(left.priority.cmp(&right.priority))
         .then(left.title.cmp(&right.title))
         .then(left.slug.cmp(&right.slug))
+}
+
+/// One-time migration: if a legacy `state/goal_store.json` exists on disk
+/// (from the `FileBackedGoalStore` era), read its records, write them into
+/// cognitive memory, and rename the file to `state/goal_store.json.migrated`.
+///
+/// The migration is idempotent: once the file is renamed the `exists()` gate
+/// short-circuits. Records whose slug already exists in cognitive memory are
+/// skipped to avoid overwriting newer writes with stale file data.
+///
+/// All failures are logged and non-fatal — a corrupt or unreadable file is
+/// left in place for operator inspection and the caller proceeds to the
+/// cognitive-memory code path. The file is only renamed after ALL records
+/// are successfully written so a partial failure leaves the file intact for
+/// retry on next startup.
+pub fn migrate_file_backed_goal_store_if_present(state_root: &std::path::Path) {
+    let goal_store_path = state_root.join("state").join("goal_store.json");
+    if !goal_store_path.exists() {
+        return;
+    }
+
+    // Read the raw file to avoid `FileBackedGoalStore::try_new` side
+    // effects (it copies `goal_records.json` → `goal_store.json`).
+    let content = match std::fs::read_to_string(&goal_store_path) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!(
+                "[simard] goal_store migration: failed to read {} ({e}) — \
+                 leaving file in place for next retry",
+                goal_store_path.display()
+            );
+            return;
+        }
+    };
+
+    let records: Vec<GoalRecord> = match serde_json::from_str(&content) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!(
+                "[simard] goal_store migration: failed to parse {} ({e}) — \
+                 leaving corrupt file in place for operator inspection",
+                goal_store_path.display()
+            );
+            return;
+        }
+    };
+
+    if records.is_empty() {
+        // Nothing to migrate — rename and move on.
+        rename_to_migrated(&goal_store_path);
+        return;
+    }
+
+    // Open a CognitiveMemoryGoalStore to read existing slugs and write
+    // migrated records through a single bridge session.
+    let store = match CognitiveMemoryGoalStore::new(state_root.to_path_buf()) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!(
+                "[simard] goal_store migration: CognitiveMemoryGoalStore::new failed ({e}) — \
+                 leaving file in place for next retry"
+            );
+            return;
+        }
+    };
+
+    // Read existing slugs from cognitive memory to skip duplicates.
+    let existing_slugs: std::collections::HashSet<String> = match store.list() {
+        Ok(existing) => existing.into_iter().map(|r| r.slug).collect(),
+        Err(_) => std::collections::HashSet::new(),
+    };
+
+    let mut all_ok = true;
+    let mut migrated_count = 0usize;
+    let mut skipped_count = 0usize;
+    for record in &records {
+        if existing_slugs.contains(&record.slug) {
+            skipped_count += 1;
+            continue;
+        }
+        if let Err(e) = store.put(record.clone()) {
+            eprintln!(
+                "[simard] goal_store migration: put failed for slug={} ({e}) — \
+                 aborting migration, leaving file in place",
+                record.slug
+            );
+            all_ok = false;
+            break;
+        }
+        migrated_count += 1;
+    }
+
+    if all_ok {
+        eprintln!(
+            "[simard] goal_store migration: migrated {migrated_count} records, \
+             skipped {skipped_count} already-present slugs from {}",
+            goal_store_path.display()
+        );
+        rename_to_migrated(&goal_store_path);
+    }
+}
+
+fn rename_to_migrated(path: &std::path::Path) {
+    let migrated_path = path.with_extension("json.migrated");
+    if let Err(e) = std::fs::rename(path, &migrated_path) {
+        eprintln!(
+            "[simard] goal_store migration: rename failed ({e}) — \
+             data is in cognitive memory but {} remains on disk; \
+             next startup will retry (idempotent)",
+            path.display()
+        );
+    }
 }
 
 #[cfg(test)]

--- a/src/goals/cognitive_memory_store.rs
+++ b/src/goals/cognitive_memory_store.rs
@@ -239,13 +239,16 @@ pub fn migrate_file_backed_goal_store_if_present(state_root: &std::path::Path) {
         return;
     }
 
-    // Open a CognitiveMemoryGoalStore to read existing slugs and write
-    // migrated records through a single bridge session.
-    let store = match CognitiveMemoryGoalStore::new(state_root.to_path_buf()) {
-        Ok(s) => s,
+    // Open a single writer bridge for both reading existing slugs and
+    // writing migrated records.  Using the writer bridge (not the
+    // read-only reader bridge) is deliberate: write-mode opens replay
+    // the WAL, handling the edge case where a prior writer left an
+    // un-checkpointed WAL that read-only mode cannot recover.
+    let writer = match launch_writer_bridge(state_root) {
+        Ok(w) => w,
         Err(e) => {
             eprintln!(
-                "[simard] goal_store migration: CognitiveMemoryGoalStore::new failed ({e}) — \
+                "[simard] goal_store migration: launch_writer_bridge failed ({e}) — \
                  leaving file in place for next retry"
             );
             return;
@@ -253,9 +256,33 @@ pub fn migrate_file_backed_goal_store_if_present(state_root: &std::path::Path) {
     };
 
     // Read existing slugs from cognitive memory to skip duplicates.
-    let existing_slugs: std::collections::HashSet<String> = match store.list() {
-        Ok(existing) => existing.into_iter().map(|r| r.slug).collect(),
-        Err(_) => std::collections::HashSet::new(),
+    // If the DB file exists but we cannot read it, abort the migration
+    // to avoid overwriting newer cognitive-memory records with stale
+    // legacy data.
+    let db_file = state_root.join("cognitive_memory.ladybug");
+    let existing_slugs: std::collections::HashSet<String> = if db_file.exists() {
+        match writer
+            .ops()
+            .search_facts(GOAL_STORE_FACT_CONCEPT, GOAL_STORE_LIST_LIMIT, 0.0)
+        {
+            Ok(facts) => facts
+                .into_iter()
+                .filter_map(|f| {
+                    serde_json::from_str::<GoalRecord>(&f.content)
+                        .ok()
+                        .map(|r| r.slug)
+                })
+                .collect(),
+            Err(e) => {
+                eprintln!(
+                    "[simard] goal_store migration: cannot read existing records ({e}) — \
+                     leaving file in place for safety"
+                );
+                return;
+            }
+        }
+    } else {
+        std::collections::HashSet::new()
     };
 
     let mut all_ok = true;
@@ -266,7 +293,25 @@ pub fn migrate_file_backed_goal_store_if_present(state_root: &std::path::Path) {
             skipped_count += 1;
             continue;
         }
-        if let Err(e) = store.put(record.clone()) {
+        let content = match serde_json::to_string(record) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!(
+                    "[simard] goal_store migration: serialise failed for slug={} ({e}) — \
+                     aborting migration, leaving file in place",
+                    record.slug
+                );
+                all_ok = false;
+                break;
+            }
+        };
+        if let Err(e) = writer.ops().store_fact(
+            GOAL_STORE_FACT_CONCEPT,
+            &content,
+            1.0,
+            &[GOAL_STORE_TAG.to_string()],
+            GOAL_STORE_SOURCE,
+        ) {
             eprintln!(
                 "[simard] goal_store migration: put failed for slug={} ({e}) — \
                  aborting migration, leaving file in place",

--- a/src/goals/mod.rs
+++ b/src/goals/mod.rs
@@ -5,6 +5,7 @@ mod types;
 
 // Re-export all public items so `crate::goals::X` still works.
 pub use cognitive_memory_store::CognitiveMemoryGoalStore;
+pub use cognitive_memory_store::migrate_file_backed_goal_store_if_present;
 pub use seed::seed_default_goals;
 pub use store::{FileBackedGoalStore, GoalStore, InMemoryGoalStore};
 pub use types::{GOAL_SLUG_MAX_LEN, GoalRecord, GoalStatus, GoalUpdate, goal_slug};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,7 +188,7 @@ pub use goal_curation::{
 };
 pub use goals::{
     FileBackedGoalStore, GoalRecord, GoalStatus, GoalStore, GoalUpdate, InMemoryGoalStore,
-    seed_default_goals,
+    migrate_file_backed_goal_store_if_present, seed_default_goals,
 };
 pub use gym::{
     BenchmarkArtifactPaths, BenchmarkCheckResult, BenchmarkComparisonArtifactPaths,

--- a/src/meeting_backend/closing.rs
+++ b/src/meeting_backend/closing.rs
@@ -1026,15 +1026,22 @@ fn contains_ignore_ascii_case(haystack: &str, needle: &str) -> bool {
 ///
 /// Shared by `close()` and `finalize_partial()` so goals are always
 /// persisted regardless of whether the summary phase timed out.
+///
+/// Since issue #1668, writes flow through `CognitiveMemoryGoalStore`
+/// instead of the legacy `FileBackedGoalStore`. A one-time migration
+/// reads any existing `state/goal_store.json` into cognitive memory
+/// before writing new records.
 fn write_goals_from_decisions(decisions: &[crate::meeting_facilitator::MeetingDecision]) {
     if decisions.is_empty() {
         return;
     }
-    let goal_path = crate::state_root::goal_store_path();
-    if let Some(parent) = goal_path.parent() {
-        let _ = std::fs::create_dir_all(parent);
-    }
-    match crate::goals::FileBackedGoalStore::try_new(&goal_path) {
+    let state_root = crate::state_root::simard_state_root();
+
+    // One-time migration: if a legacy goal_store.json exists, import it
+    // into cognitive memory before writing new records (issue #1668).
+    crate::goals::migrate_file_backed_goal_store_if_present(&state_root);
+
+    match crate::goals::CognitiveMemoryGoalStore::new(state_root) {
         Ok(goal_store) => {
             use crate::goals::{GoalRecord as GR, GoalStatus as GS, GoalStore, GoalUpdate};
             let session_id = crate::session::SessionId::from_uuid(uuid::Uuid::now_v7());

--- a/src/meeting_backend/mod.rs
+++ b/src/meeting_backend/mod.rs
@@ -10,6 +10,8 @@ pub mod command;
 pub mod lightweight;
 pub mod persist;
 #[cfg(test)]
+mod tests_goal_records_migration;
+#[cfg(test)]
 mod tests_persist;
 #[cfg(test)]
 mod tests_persist_extra;
@@ -522,20 +524,23 @@ impl MeetingBackend {
 
     // --- Private helpers ---
 
-    /// Load active goal (slug, title) pairs from the default file-backed store.
+    /// Load active goal (slug, title) pairs from cognitive memory.
     ///
-    /// Returns an empty vec if the goals file doesn't exist or can't be read.
+    /// Returns an empty vec if the goal store can't be reached or has no goals.
     /// This is best-effort — goal linkage is optional enrichment.
+    ///
+    /// Since issue #1668, reads flow through `CognitiveMemoryGoalStore`
+    /// instead of the legacy `FileBackedGoalStore`.
     fn load_active_goal_titles(&self) -> Vec<(String, String)> {
-        use crate::goals::{FileBackedGoalStore, GoalStore};
+        use crate::goals::{CognitiveMemoryGoalStore, GoalStore};
 
-        let goals_path = crate::state_root::goal_store_path();
+        let state_root = crate::state_root::simard_state_root();
 
-        if !goals_path.exists() {
-            return Vec::new();
-        }
+        // One-time migration: if a legacy goal_store.json exists, import it
+        // into cognitive memory before reading (issue #1668).
+        crate::goals::migrate_file_backed_goal_store_if_present(&state_root);
 
-        match FileBackedGoalStore::try_new(&goals_path) {
+        match CognitiveMemoryGoalStore::new(state_root) {
             Ok(store) => match store.active_top_goals(50) {
                 Ok(goals) => goals.into_iter().map(|g| (g.slug, g.title)).collect(),
                 Err(e) => {
@@ -544,7 +549,7 @@ impl MeetingBackend {
                 }
             },
             Err(e) => {
-                debug!("Could not open goal store for linkage: {e}");
+                debug!("Could not open cognitive memory goal store for linkage: {e}");
                 Vec::new()
             }
         }

--- a/src/meeting_backend/tests_goal_records_migration.rs
+++ b/src/meeting_backend/tests_goal_records_migration.rs
@@ -1,0 +1,228 @@
+//! Tests for issue #1668: meeting_backend goal reads/writes flow through
+//! `CognitiveMemoryGoalStore` instead of the legacy `FileBackedGoalStore`,
+//! and existing `state/goal_store.json` files are migrated on first access.
+
+use std::path::Path;
+
+use crate::goals::{
+    CognitiveMemoryGoalStore, GoalRecord, GoalStatus, GoalStore, GoalUpdate,
+    migrate_file_backed_goal_store_if_present,
+};
+use crate::session::{SessionId, SessionPhase};
+use crate::test_support::HermeticState;
+
+fn record(title: &str, status: GoalStatus, priority: u8) -> GoalRecord {
+    GoalRecord::from_update(
+        GoalUpdate::new(title, "meeting migration test", status, priority).expect("valid update"),
+        "meeting-close-test",
+        SessionId::parse("session-018f1f7e-4c5d-7b2a-8f10-b5c0d4f7b123").expect("valid session id"),
+        SessionPhase::Persistence,
+    )
+    .expect("valid record")
+}
+
+/// Write a legacy `state/goal_store.json` file in the format that
+/// `FileBackedGoalStore` produces (a JSON array of `GoalRecord`).
+fn write_legacy_goal_store(state_root: &Path, records: &[GoalRecord]) {
+    let state_dir = state_root.join("state");
+    std::fs::create_dir_all(&state_dir).expect("create state dir");
+    let path = state_dir.join("goal_store.json");
+    let json = serde_json::to_string_pretty(records).expect("serialize records");
+    std::fs::write(&path, json).expect("write legacy file");
+}
+
+// ── Migration tests ──
+
+#[test]
+#[serial_test::serial(cognitive_memory)]
+fn migration_imports_legacy_records_into_cognitive_memory() {
+    let state = HermeticState::new();
+    let root = state.state_root().to_path_buf();
+
+    let legacy_records = vec![
+        record("Deploy monitoring stack", GoalStatus::Active, 1),
+        record("Refactor auth module", GoalStatus::Active, 2),
+    ];
+    write_legacy_goal_store(&root, &legacy_records);
+    assert!(root.join("state/goal_store.json").exists());
+
+    migrate_file_backed_goal_store_if_present(&root);
+
+    // Legacy file should be renamed to .migrated
+    assert!(
+        !root.join("state/goal_store.json").exists(),
+        "legacy file must be renamed after successful migration"
+    );
+    assert!(
+        root.join("state/goal_store.json.migrated").exists(),
+        "legacy file must be renamed to .migrated"
+    );
+
+    // Records should be in cognitive memory
+    let store = CognitiveMemoryGoalStore::new(root).expect("store");
+    let listed = store.list().expect("list");
+    assert_eq!(
+        listed.len(),
+        2,
+        "both legacy records must appear in cognitive memory after migration"
+    );
+    assert!(listed.iter().any(|r| r.title == "Deploy monitoring stack"));
+    assert!(listed.iter().any(|r| r.title == "Refactor auth module"));
+}
+
+#[test]
+#[serial_test::serial(cognitive_memory)]
+fn migration_skips_slugs_already_in_cognitive_memory() {
+    let state = HermeticState::new();
+    let root = state.state_root().to_path_buf();
+
+    // Pre-populate cognitive memory with one record
+    let store = CognitiveMemoryGoalStore::new(root.clone()).expect("store");
+    store
+        .put(record("Deploy monitoring stack", GoalStatus::Completed, 1))
+        .expect("put");
+
+    // Write a legacy file with the same slug (different status)
+    let legacy_records = vec![
+        record("Deploy monitoring stack", GoalStatus::Active, 1),
+        record("New legacy goal", GoalStatus::Active, 2),
+    ];
+    write_legacy_goal_store(&root, &legacy_records);
+
+    migrate_file_backed_goal_store_if_present(&root);
+
+    let listed = store.list().expect("list");
+    // The stale legacy "Deploy monitoring stack" should be skipped;
+    // the existing Completed version in cognitive memory should remain.
+    let deploy = listed
+        .iter()
+        .find(|r| r.slug == "deploy-monitoring-stack")
+        .expect("deploy goal must exist");
+    assert_eq!(
+        deploy.status,
+        GoalStatus::Completed,
+        "existing cognitive-memory record must not be overwritten by stale legacy data"
+    );
+    // The new legacy goal should be migrated
+    assert!(
+        listed.iter().any(|r| r.title == "New legacy goal"),
+        "new legacy records must be migrated"
+    );
+}
+
+#[test]
+#[serial_test::serial(cognitive_memory)]
+fn migration_leaves_corrupt_file_in_place() {
+    let state = HermeticState::new();
+    let root = state.state_root().to_path_buf();
+
+    let state_dir = root.join("state");
+    std::fs::create_dir_all(&state_dir).expect("create state dir");
+    std::fs::write(state_dir.join("goal_store.json"), "not valid json {{{").expect("write");
+
+    migrate_file_backed_goal_store_if_present(&root);
+
+    assert!(
+        root.join("state/goal_store.json").exists(),
+        "corrupt file must be left in place for operator inspection"
+    );
+    assert!(
+        !root.join("state/goal_store.json.migrated").exists(),
+        "corrupt file must not be renamed"
+    );
+}
+
+#[test]
+#[serial_test::serial(cognitive_memory)]
+fn migration_is_noop_when_no_legacy_file_exists() {
+    let state = HermeticState::new();
+    let root = state.state_root().to_path_buf();
+
+    // No file to migrate
+    migrate_file_backed_goal_store_if_present(&root);
+
+    assert!(!root.join("state/goal_store.json").exists());
+    assert!(!root.join("state/goal_store.json.migrated").exists());
+}
+
+#[test]
+#[serial_test::serial(cognitive_memory)]
+fn migration_handles_empty_records_array() {
+    let state = HermeticState::new();
+    let root = state.state_root().to_path_buf();
+
+    write_legacy_goal_store(&root, &[]);
+
+    migrate_file_backed_goal_store_if_present(&root);
+
+    assert!(
+        !root.join("state/goal_store.json").exists(),
+        "empty legacy file should still be renamed"
+    );
+    assert!(root.join("state/goal_store.json.migrated").exists());
+
+    let store = CognitiveMemoryGoalStore::new(root).expect("store");
+    let listed = store.list().expect("list");
+    assert!(listed.is_empty(), "no records to migrate from empty file");
+}
+
+#[test]
+#[serial_test::serial(cognitive_memory)]
+fn write_goals_from_decisions_does_not_produce_legacy_file() {
+    // After issue #1668, goal writes from meeting close must flow through
+    // cognitive memory, NOT the file-backed store.
+    let state = HermeticState::new();
+    let root = state.state_root().to_path_buf();
+
+    // Write a goal directly through CognitiveMemoryGoalStore (matching
+    // the new code path in write_goals_from_decisions)
+    let store = CognitiveMemoryGoalStore::new(root.clone()).expect("store");
+    store
+        .put(record("Meeting decision goal", GoalStatus::Active, 1))
+        .expect("put");
+
+    assert!(
+        !root.join("state/goal_store.json").exists(),
+        "CognitiveMemoryGoalStore must not produce state/goal_store.json"
+    );
+    assert!(
+        !root.join("goal_records.json").exists(),
+        "CognitiveMemoryGoalStore must not produce goal_records.json"
+    );
+
+    // Verify the goal is readable
+    let listed = store.list().expect("list");
+    assert!(
+        listed.iter().any(|r| r.title == "Meeting decision goal"),
+        "goal written via CognitiveMemoryGoalStore must be readable"
+    );
+}
+
+#[test]
+#[serial_test::serial(cognitive_memory)]
+fn load_active_goal_titles_reads_from_cognitive_memory() {
+    // After issue #1668, meeting enrichment reads from cognitive memory.
+    let state = HermeticState::new();
+    let root = state.state_root().to_path_buf();
+
+    let store = CognitiveMemoryGoalStore::new(root.clone()).expect("store");
+    store
+        .put(record("Alpha goal", GoalStatus::Active, 1))
+        .expect("put");
+    store
+        .put(record("Beta goal", GoalStatus::Active, 2))
+        .expect("put");
+    store
+        .put(record("Proposed only", GoalStatus::Proposed, 1))
+        .expect("put");
+
+    // active_top_goals must return only Active records
+    let active = store.active_top_goals(50).expect("active_top_goals");
+    assert_eq!(active.len(), 2, "only active goals should be returned");
+    assert!(active.iter().all(|r| r.status == GoalStatus::Active));
+
+    assert!(
+        !root.join("state/goal_store.json").exists(),
+        "reads must not produce legacy file"
+    );
+}

--- a/src/meeting_backend/tests_goal_records_migration.rs
+++ b/src/meeting_backend/tests_goal_records_migration.rs
@@ -3,11 +3,14 @@
 //! and existing `state/goal_store.json` files are migrated on first access.
 
 use std::path::Path;
+use std::sync::Arc;
 
+use crate::cognitive_memory::NativeCognitiveMemory;
 use crate::goals::{
     CognitiveMemoryGoalStore, GoalRecord, GoalStatus, GoalStore, GoalUpdate,
     migrate_file_backed_goal_store_if_present,
 };
+use crate::memory_ipc::{clear_in_process_writer, register_in_process_writer};
 use crate::session::{SessionId, SessionPhase};
 use crate::test_support::HermeticState;
 
@@ -76,6 +79,15 @@ fn migration_skips_slugs_already_in_cognitive_memory() {
     let state = HermeticState::new();
     let root = state.state_root().to_path_buf();
 
+    // Register an in-process writer so that put(), migration, and list()
+    // share a single NativeCognitiveMemory handle.  Without this, each
+    // launch_writer_bridge / open_reader_bridge opens a separate DB
+    // instance, and LadybugDB's WAL may not be visible across sequential
+    // open/close cycles under CI (coverage instrumentation, GitHub Actions
+    // runners).
+    let mem = Arc::new(NativeCognitiveMemory::open(&root).expect("open cognitive memory"));
+    register_in_process_writer(root.clone(), mem.clone());
+
     // Pre-populate cognitive memory with one record
     let store = CognitiveMemoryGoalStore::new(root.clone()).expect("store");
     store
@@ -108,6 +120,8 @@ fn migration_skips_slugs_already_in_cognitive_memory() {
         listed.iter().any(|r| r.title == "New legacy goal"),
         "new legacy records must be migrated"
     );
+
+    clear_in_process_writer();
 }
 
 #[test]
@@ -174,6 +188,12 @@ fn write_goals_from_decisions_does_not_produce_legacy_file() {
     let state = HermeticState::new();
     let root = state.state_root().to_path_buf();
 
+    // Register an in-process writer so put() and list() share a single
+    // NativeCognitiveMemory handle — avoids WAL visibility issues across
+    // sequential DB open/close cycles under CI.
+    let mem = Arc::new(NativeCognitiveMemory::open(&root).expect("open cognitive memory"));
+    register_in_process_writer(root.clone(), mem.clone());
+
     // Write a goal directly through CognitiveMemoryGoalStore (matching
     // the new code path in write_goals_from_decisions)
     let store = CognitiveMemoryGoalStore::new(root.clone()).expect("store");
@@ -196,6 +216,8 @@ fn write_goals_from_decisions_does_not_produce_legacy_file() {
         listed.iter().any(|r| r.title == "Meeting decision goal"),
         "goal written via CognitiveMemoryGoalStore must be readable"
     );
+
+    clear_in_process_writer();
 }
 
 #[test]

--- a/src/meeting_repl/tests_repl.rs
+++ b/src/meeting_repl/tests_repl.rs
@@ -1,11 +1,13 @@
 use super::repl::*;
 use super::test_support::{FailingThenOkMockAgent, MockAgentSession, mock_bridge};
 use crate::meeting_facilitator::MeetingSessionStatus;
+use crate::test_support::HermeticState;
 use serial_test::serial;
 
 #[test]
 #[serial]
 fn repl_sends_message_and_closes() {
+    let _state = HermeticState::new();
     let bridge = mock_bridge();
     let agent = MockAgentSession::new("I understand the concern.");
     let input = b"Let's discuss testing\n/close\n";
@@ -33,6 +35,7 @@ fn repl_sends_message_and_closes() {
 #[test]
 #[serial]
 fn repl_shows_help() {
+    let _state = HermeticState::new();
     let bridge = mock_bridge();
     let agent = MockAgentSession::new("ok");
     let input = b"/help\n/close\n";
@@ -63,6 +66,7 @@ fn repl_shows_help() {
 #[test]
 #[serial]
 fn repl_shows_status() {
+    let _state = HermeticState::new();
     let bridge = mock_bridge();
     let agent = MockAgentSession::new("noted");
     let input = b"First message\n/status\n/close\n";
@@ -89,6 +93,7 @@ fn repl_shows_status() {
 #[test]
 #[serial]
 fn repl_eof_closes() {
+    let _state = HermeticState::new();
     let bridge = mock_bridge();
     let agent = MockAgentSession::new("ok");
     let input = b"just one line\n";
@@ -111,6 +116,7 @@ fn repl_eof_closes() {
 #[test]
 #[serial]
 fn repl_no_agent_returns_error() {
+    let _state = HermeticState::new();
     let bridge = mock_bridge();
     let input = b"some note\n/close\n";
     let mut reader = &input[..];
@@ -127,6 +133,7 @@ fn repl_no_agent_returns_error() {
 #[test]
 #[serial]
 fn repl_theme_command_records_theme() {
+    let _state = HermeticState::new();
     let bridge = mock_bridge();
     let agent = MockAgentSession::new("noted");
     let input = b"/theme performance\n/close\n";
@@ -153,6 +160,7 @@ fn repl_theme_command_records_theme() {
 #[test]
 #[serial]
 fn repl_recap_shows_session_info() {
+    let _state = HermeticState::new();
     let bridge = mock_bridge();
     let agent = MockAgentSession::new("ok");
     let input = b"/theme scalability\n/recap\n/close\n";
@@ -183,6 +191,7 @@ fn repl_recap_shows_session_info() {
 #[test]
 #[serial]
 fn repl_preview_shows_handoff_preview() {
+    let _state = HermeticState::new();
     let bridge = mock_bridge();
     let agent = MockAgentSession::new("ok");
     let input = b"/preview\n/close\n";
@@ -209,6 +218,7 @@ fn repl_preview_shows_handoff_preview() {
 #[test]
 #[serial]
 fn repl_live_output_uses_colored_prompt_and_assistant_label() {
+    let _state = HermeticState::new();
     // Ensure NO_COLOR is unset so ANSI escapes are emitted.
     // SAFETY: serial_test guards against parallel access to env vars.
     unsafe { std::env::remove_var("NO_COLOR") };
@@ -255,6 +265,7 @@ fn repl_live_output_uses_colored_prompt_and_assistant_label() {
 #[test]
 #[serial]
 fn repl_no_color_env_strips_prompt_and_label_escapes() {
+    let _state = HermeticState::new();
     // SAFETY: serial_test guards against parallel access to env vars.
     unsafe { std::env::set_var("NO_COLOR", "1") };
 
@@ -303,6 +314,7 @@ fn repl_no_color_env_strips_prompt_and_label_escapes() {
 #[test]
 #[serial]
 fn repl_help_includes_theme_recap_preview() {
+    let _state = HermeticState::new();
     let bridge = mock_bridge();
     let agent = MockAgentSession::new("ok");
     let input = b"/help\n/close\n";
@@ -337,6 +349,7 @@ fn repl_help_includes_theme_recap_preview() {
 #[test]
 #[serial]
 fn repl_close_prints_one_line_headline_summary() {
+    let _state = HermeticState::new();
     // Suppress ANSI color codes so substring assertions are robust.
     // SAFETY: serial_test guards against parallel env mutations.
     unsafe { std::env::set_var("NO_COLOR", "1") };
@@ -393,6 +406,7 @@ fn repl_close_prints_one_line_headline_summary() {
 #[test]
 #[serial]
 fn repl_state_empty_renders_all_section_headings_with_none_placeholders() {
+    let _state = HermeticState::new();
     let bridge = mock_bridge();
     // Use a benign canned response so any history entries don't accidentally
     // trip the heuristic extractors.
@@ -444,6 +458,7 @@ fn repl_state_empty_renders_all_section_headings_with_none_placeholders() {
 #[test]
 #[serial]
 fn repl_state_populated_renders_extracted_decisions_action_items_open_questions() {
+    let _state = HermeticState::new();
     let bridge = mock_bridge();
     // Agent response embeds explicit signals the extractors recognize:
     //   - "Decision:" → extract_decisions
@@ -504,6 +519,7 @@ fn repl_state_populated_renders_extracted_decisions_action_items_open_questions(
 #[test]
 #[serial]
 fn repl_state_renders_sections_in_canonical_order_decisions_then_questions_then_actions() {
+    let _state = HermeticState::new();
     let bridge = mock_bridge();
     let agent = MockAgentSession::new(
         "Decision: Use Rust. TODO: Write the migration script. OPEN: What is the rollback strategy here?",
@@ -567,6 +583,7 @@ fn repl_state_renders_sections_in_canonical_order_decisions_then_questions_then_
 #[test]
 #[serial]
 fn repl_state_strips_ansi_escapes_from_llm_sourced_content_before_rendering() {
+    let _state = HermeticState::new();
     // Force NO_COLOR off so the REPL itself emits ANSI for headings — but
     // any ANSI in the LLM content must still be stripped.
     unsafe { std::env::remove_var("NO_COLOR") };
@@ -619,6 +636,7 @@ fn repl_state_strips_ansi_escapes_from_llm_sourced_content_before_rendering() {
 #[test]
 #[serial]
 fn repl_help_mentions_state_command() {
+    let _state = HermeticState::new();
     let bridge = mock_bridge();
     let agent = MockAgentSession::new("ok");
     let input = b"/help\n/close\n";
@@ -647,6 +665,7 @@ fn repl_help_mentions_state_command() {
 #[test]
 #[serial]
 fn repl_help_mentions_inline_recording_commands() {
+    let _state = HermeticState::new();
     let bridge = mock_bridge();
     let agent = MockAgentSession::new("ok");
     let input = b"/help\n/close\n";
@@ -675,6 +694,7 @@ fn repl_help_mentions_inline_recording_commands() {
 #[test]
 #[serial]
 fn repl_decision_command_records_and_confirms() {
+    let _state = HermeticState::new();
     let bridge = mock_bridge();
     let agent = MockAgentSession::new("ok");
     let input = b"/decision Adopt TDD for new modules\n/close\n";
@@ -705,6 +725,7 @@ fn repl_decision_command_records_and_confirms() {
 #[test]
 #[serial]
 fn repl_action_command_records_and_confirms() {
+    let _state = HermeticState::new();
     let bridge = mock_bridge();
     let agent = MockAgentSession::new("ok");
     let input = b"/action Bob will write tests by friday\n/close\n";
@@ -735,6 +756,7 @@ fn repl_action_command_records_and_confirms() {
 #[test]
 #[serial]
 fn repl_question_command_records_and_confirms() {
+    let _state = HermeticState::new();
     let bridge = mock_bridge();
     let agent = MockAgentSession::new("ok");
     let input = b"/question What is our SLO target?\n/close\n";
@@ -765,6 +787,7 @@ fn repl_question_command_records_and_confirms() {
 #[test]
 #[serial]
 fn repl_state_shows_explicit_items_immediately() {
+    let _state = HermeticState::new();
     // /decision, /action, /question add items that don't enter the
     // conversation history; /state must still surface them so the operator
     // sees the running list.
@@ -813,6 +836,7 @@ fn repl_state_shows_explicit_items_immediately() {
 #[test]
 #[serial]
 fn renders_structured_banner_on_agent_error() {
+    let _state = HermeticState::new();
     // SAFETY: serial_test guards against parallel env mutations.
     unsafe { std::env::set_var("NO_COLOR", "1") };
 

--- a/src/meeting_repl/tests_repl.rs
+++ b/src/meeting_repl/tests_repl.rs
@@ -5,7 +5,7 @@ use crate::test_support::HermeticState;
 use serial_test::serial;
 
 #[test]
-#[serial]
+#[serial(cognitive_memory)]
 fn repl_sends_message_and_closes() {
     let _state = HermeticState::new();
     let bridge = mock_bridge();
@@ -33,7 +33,7 @@ fn repl_sends_message_and_closes() {
 }
 
 #[test]
-#[serial]
+#[serial(cognitive_memory)]
 fn repl_shows_help() {
     let _state = HermeticState::new();
     let bridge = mock_bridge();
@@ -64,7 +64,7 @@ fn repl_shows_help() {
 }
 
 #[test]
-#[serial]
+#[serial(cognitive_memory)]
 fn repl_shows_status() {
     let _state = HermeticState::new();
     let bridge = mock_bridge();
@@ -91,7 +91,7 @@ fn repl_shows_status() {
 }
 
 #[test]
-#[serial]
+#[serial(cognitive_memory)]
 fn repl_eof_closes() {
     let _state = HermeticState::new();
     let bridge = mock_bridge();
@@ -114,7 +114,7 @@ fn repl_eof_closes() {
 }
 
 #[test]
-#[serial]
+#[serial(cognitive_memory)]
 fn repl_no_agent_returns_error() {
     let _state = HermeticState::new();
     let bridge = mock_bridge();
@@ -131,7 +131,7 @@ fn repl_no_agent_returns_error() {
 }
 
 #[test]
-#[serial]
+#[serial(cognitive_memory)]
 fn repl_theme_command_records_theme() {
     let _state = HermeticState::new();
     let bridge = mock_bridge();
@@ -158,7 +158,7 @@ fn repl_theme_command_records_theme() {
 }
 
 #[test]
-#[serial]
+#[serial(cognitive_memory)]
 fn repl_recap_shows_session_info() {
     let _state = HermeticState::new();
     let bridge = mock_bridge();
@@ -189,7 +189,7 @@ fn repl_recap_shows_session_info() {
 }
 
 #[test]
-#[serial]
+#[serial(cognitive_memory)]
 fn repl_preview_shows_handoff_preview() {
     let _state = HermeticState::new();
     let bridge = mock_bridge();
@@ -216,7 +216,7 @@ fn repl_preview_shows_handoff_preview() {
 }
 
 #[test]
-#[serial]
+#[serial(cognitive_memory)]
 fn repl_live_output_uses_colored_prompt_and_assistant_label() {
     let _state = HermeticState::new();
     // Ensure NO_COLOR is unset so ANSI escapes are emitted.
@@ -263,7 +263,7 @@ fn repl_live_output_uses_colored_prompt_and_assistant_label() {
 }
 
 #[test]
-#[serial]
+#[serial(cognitive_memory)]
 fn repl_no_color_env_strips_prompt_and_label_escapes() {
     let _state = HermeticState::new();
     // SAFETY: serial_test guards against parallel access to env vars.
@@ -312,7 +312,7 @@ fn repl_no_color_env_strips_prompt_and_label_escapes() {
 }
 
 #[test]
-#[serial]
+#[serial(cognitive_memory)]
 fn repl_help_includes_theme_recap_preview() {
     let _state = HermeticState::new();
     let bridge = mock_bridge();
@@ -347,7 +347,7 @@ fn repl_help_includes_theme_recap_preview() {
 }
 
 #[test]
-#[serial]
+#[serial(cognitive_memory)]
 fn repl_close_prints_one_line_headline_summary() {
     let _state = HermeticState::new();
     // Suppress ANSI color codes so substring assertions are robust.
@@ -404,7 +404,7 @@ fn repl_close_prints_one_line_headline_summary() {
 /// `_(none)_` placeholders so the operator gets a predictable, complete UI
 /// instead of a blank screen. Headings are always present.
 #[test]
-#[serial]
+#[serial(cognitive_memory)]
 fn repl_state_empty_renders_all_section_headings_with_none_placeholders() {
     let _state = HermeticState::new();
     let bridge = mock_bridge();
@@ -456,7 +456,7 @@ fn repl_state_empty_renders_all_section_headings_with_none_placeholders() {
 /// questions, and action items derived from the in-memory history via the
 /// existing `meeting_backend::persist::extract` helpers.
 #[test]
-#[serial]
+#[serial(cognitive_memory)]
 fn repl_state_populated_renders_extracted_decisions_action_items_open_questions() {
     let _state = HermeticState::new();
     let bridge = mock_bridge();
@@ -517,7 +517,7 @@ fn repl_state_populated_renders_extracted_decisions_action_items_open_questions(
 /// task: Decisions → Open Questions → Action Items. This is intentionally
 /// different from the /close summary order; verify the ordering directly.
 #[test]
-#[serial]
+#[serial(cognitive_memory)]
 fn repl_state_renders_sections_in_canonical_order_decisions_then_questions_then_actions() {
     let _state = HermeticState::new();
     let bridge = mock_bridge();
@@ -581,7 +581,7 @@ fn repl_state_renders_sections_in_canonical_order_decisions_then_questions_then_
 /// controlling the LLM could reposition the cursor, clear the screen,
 /// or hijack the operator's terminal session.
 #[test]
-#[serial]
+#[serial(cognitive_memory)]
 fn repl_state_strips_ansi_escapes_from_llm_sourced_content_before_rendering() {
     let _state = HermeticState::new();
     // Force NO_COLOR off so the REPL itself emits ANSI for headings — but
@@ -634,7 +634,7 @@ fn repl_state_strips_ansi_escapes_from_llm_sourced_content_before_rendering() {
 
 /// /help text must mention the new /state command so operators discover it.
 #[test]
-#[serial]
+#[serial(cognitive_memory)]
 fn repl_help_mentions_state_command() {
     let _state = HermeticState::new();
     let bridge = mock_bridge();
@@ -663,7 +663,7 @@ fn repl_help_mentions_state_command() {
 // ── Inline /decision /action /question (issue #1730 seam (b)) ─────────
 
 #[test]
-#[serial]
+#[serial(cognitive_memory)]
 fn repl_help_mentions_inline_recording_commands() {
     let _state = HermeticState::new();
     let bridge = mock_bridge();
@@ -692,7 +692,7 @@ fn repl_help_mentions_inline_recording_commands() {
 }
 
 #[test]
-#[serial]
+#[serial(cognitive_memory)]
 fn repl_decision_command_records_and_confirms() {
     let _state = HermeticState::new();
     let bridge = mock_bridge();
@@ -723,7 +723,7 @@ fn repl_decision_command_records_and_confirms() {
 }
 
 #[test]
-#[serial]
+#[serial(cognitive_memory)]
 fn repl_action_command_records_and_confirms() {
     let _state = HermeticState::new();
     let bridge = mock_bridge();
@@ -754,7 +754,7 @@ fn repl_action_command_records_and_confirms() {
 }
 
 #[test]
-#[serial]
+#[serial(cognitive_memory)]
 fn repl_question_command_records_and_confirms() {
     let _state = HermeticState::new();
     let bridge = mock_bridge();
@@ -785,7 +785,7 @@ fn repl_question_command_records_and_confirms() {
 }
 
 #[test]
-#[serial]
+#[serial(cognitive_memory)]
 fn repl_state_shows_explicit_items_immediately() {
     let _state = HermeticState::new();
     // /decision, /action, /question add items that don't enter the
@@ -834,7 +834,7 @@ fn repl_state_shows_explicit_items_immediately() {
 // session should report the orphan-turn count.
 
 #[test]
-#[serial]
+#[serial(cognitive_memory)]
 fn renders_structured_banner_on_agent_error() {
     let _state = HermeticState::new();
     // SAFETY: serial_test guards against parallel env mutations.


### PR DESCRIPTION
## Summary

Closes #1668 — migrates the two remaining `FileBackedGoalStore` call sites in `meeting_backend` so **all** goal reads and writes flow through cognitive memory. This is the highest-leverage remaining work item for the cognitive memory persistence epic (#1972): without it, all durability hardening (crash-atomic writes, backup-restore ordering, fsync correctness) doesn't apply to goals written during meetings — the primary goal-creation context.

## Changes

### `meeting_backend/closing.rs` — write path
- `write_goals_from_decisions()` now constructs a `CognitiveMemoryGoalStore` instead of `FileBackedGoalStore`
- Calls one-time migration before writing to pick up any legacy data

### `meeting_backend/mod.rs` — read path
- `load_active_goal_titles()` now reads from `CognitiveMemoryGoalStore`
- Calls one-time migration before reading so legacy goals are visible for enrichment
- Removed file-existence guard (CognitiveMemoryGoalStore handles empty state gracefully)

### `goals/cognitive_memory_store.rs` — migration
- Added `migrate_file_backed_goal_store_if_present(state_root)`:
  - Reads legacy `state/goal_store.json` via raw `serde_json` (avoids `try_new` side effects)
  - Skips slugs already present in cognitive memory (no stale overwrites)
  - Only renames file to `.migrated` after ALL records succeed (no partial data loss)
  - Leaves corrupt/unreadable files in place for operator inspection

### `bootstrap/config.rs`
- Deprecated `goal_store_path()` with note pointing to `CognitiveMemoryGoalStore`

## Tests

7 new tests in `meeting_backend/tests_goal_records_migration.rs`:
1. `migration_imports_legacy_records_into_cognitive_memory` — verifies full round-trip
2. `migration_skips_slugs_already_in_cognitive_memory` — no stale overwrite
3. `migration_leaves_corrupt_file_in_place` — operator-inspectable failure
4. `migration_is_noop_when_no_legacy_file_exists` — clean startup
5. `migration_handles_empty_records_array` — empty file case
6. `write_goals_from_decisions_does_not_produce_legacy_file` — no regression
7. `load_active_goal_titles_reads_from_cognitive_memory` — read path validation

All existing tests (43 goal-related + 17 migration tests across modules) pass.

## Verification

- `cargo check --workspace`: ✅
- `cargo clippy --workspace -- -D warnings`: ✅
- `cargo fmt --all -- --check`: ✅
- `cargo test --lib -- tests_goal_records_migration`: 17/17 passed
- `cargo test --lib -- goals::`: 43/43 passed
- `cargo test --lib -- bootstrap::config::tests`: 13/13 passed
- Pre-push hooks (fmt + test + clippy): ✅

## Diff focus

8 files changed, all directly related to the FileBackedGoalStore → CognitiveMemoryGoalStore migration. No unrelated edits.