### PR TITLE
fix(disk-health): parse recipe JSON envelope instead of text stdout

### DIFF
--- a/docs/concepts/automated-disk-health.md
+++ b/docs/concepts/automated-disk-health.md
@@ -1,12 +1,13 @@
 ---
 title: Automated disk health management
 description: Design rationale for Simard's per-cycle disk health check — why it exists, what it cleans, and how it interacts with existing subsystems.
-last_updated: 2026-05-24
+last_updated: 2026-06-05
 review_schedule: as-needed
 owner: simard
 doc_type: concept
 related:
   - ../howto/configure-disk-health-check.md
+  - ../reference/disk-health-api.md
   - ../reference/engineer-worktree-isolation.md
   - ./goal-board-persistence.md
 ---
@@ -210,12 +211,50 @@ The Rust code is a thin shim. The cleanup prompt lives in the recipe YAML as
 a readable agent step, not compiled into the binary. Operators can `cat` it,
 `diff` it, or review the agent's decisions in logs.
 
-The recipe outputs key=value lines to stdout (`DISK_USED_PCT=N`,
-`FREED_BYTES=N`, `ACTION: ...`) — the Rust shim parses these with simple
-string splitting. No JSON, no serde deserialization of recipe output.
+### Two-layer output: JSON envelope → text markers
+
+The agent step outputs key=value text markers to stdout (`DISK_USED_PCT=N`,
+`FREED_BYTES=N`, `ACTION: ...`). However, these markers are embedded in the
+agent's conversational output — the step may also contain LLM reasoning,
+`df` output, and other noise.
+
+The Rust shim does not read `recipe-runner-rs` text-format stdout directly.
+Text-format stdout only contains the recipe summary line (e.g.,
+`Recipe: disk-health-check SUCCESS`), not the agent step output where the
+markers live.
+
+Instead, the shim passes `--output-format json` to `recipe-runner-rs`, which
+wraps each step's output in a structured JSON envelope:
+
+```json
+{
+  "success": true,
+  "step_results": [
+    {
+      "step_id": "check-disk-usage",
+      "output": "Running df -h /home...\nDISK_USED_PCT=72\nFREED_BYTES=0\n..."
+    }
+  ]
+}
+```
+
+The shim deserializes the envelope into `RecipeOutput` / `StepResult` structs
+via serde, extracts `step_results[0].output`, and feeds that string to
+`parse_disk_health_text()` — the same simple key=value line parser. This
+two-layer approach keeps the recipe output format simple (text markers from
+bash/agent) while giving the Rust shim reliable access to each step's actual
+output.
+
+> **Historical note (issue #2212):** Prior to this fix, the shim read
+> `recipe-runner-rs` text-format stdout directly. That stream only contained
+> the summary line, not the step output. `parse_disk_health_text()` never found
+> `DISK_USED_PCT` in the summary line, causing 946 consecutive false failures
+> and allowing the disk to fill to 100%. The fix was surgical: add
+> `--output-format json`, deserialize the envelope, extract step output.
 
 ## Related
 
 - [Configure disk health check (how-to)](../howto/configure-disk-health-check.md) — operator guide
+- [Disk health API (reference)](../reference/disk-health-api.md) — module API, structs, data flow
 - [Per-Engineer Worktree Isolation](../reference/engineer-worktree-isolation.md) — worktree lifecycle
 - [Daemon mode](../daemon-mode.md) — OODA cycle overview

--- a/docs/howto/configure-disk-health-check.md
+++ b/docs/howto/configure-disk-health-check.md
@@ -1,12 +1,13 @@
 ---
 title: Configure and monitor the disk health check
 description: Operator guide for Simard's per-cycle disk health check — tuning thresholds, reading reports, and recovering from disk exhaustion.
-last_updated: 2026-05-24
+last_updated: 2026-06-05
 review_schedule: as-needed
 owner: simard
 doc_type: howto
 related:
   - ../concepts/automated-disk-health.md
+  - ../reference/disk-health-api.md
   - ./inspect-and-clean-engineer-worktrees.md
   - ./reclaim-disk-space-and-run-low-space-rust-builds.md
 ---
@@ -79,8 +80,34 @@ YAML each time.
 
 ## Read a full disk health report
 
-The recipe outputs a key=value text report to stdout, which the daemon captures
-and logs. To run the check manually outside the daemon:
+The recipe outputs key=value text markers inside the agent step's output.
+The Rust shim accesses this via the `--output-format json` envelope from
+`recipe-runner-rs`. To run the check manually and see the raw JSON envelope:
+
+```bash
+recipe-runner-rs prompt_assets/simard/recipes/disk-health-check.yaml \
+  --output-format json \
+  -c STATE_ROOT="$HOME/.simard" \
+  -c REPO_ROOT="/home/azureuser/src/Simard"
+```
+
+This prints a JSON envelope containing the step output:
+
+```json
+{
+  "success": true,
+  "step_results": [
+    {
+      "step_id": "check-disk-usage",
+      "output": "DISK_USED_PCT=72\nFREED_BYTES=53687091200\nACTION: Removed 48 stale worktrees (50.1G)\nACTION: Removed cargo target dirs from 3 worktrees (1.2G)\nACTION: Pruned 19 LadybugDB backups (512M)\nACTION: Cleaned cargo-target/ (12.0G) and shared-target/ (2.8G)\n"
+    }
+  ]
+}
+```
+
+The Rust shim extracts `step_results[0].output` and parses the key=value
+markers from that string. To see only the text-format summary (without the
+JSON envelope), omit `--output-format json`:
 
 ```bash
 recipe-runner-rs prompt_assets/simard/recipes/disk-health-check.yaml \
@@ -88,16 +115,10 @@ recipe-runner-rs prompt_assets/simard/recipes/disk-health-check.yaml \
   -c REPO_ROOT="/home/azureuser/src/Simard"
 ```
 
-This prints the text report to stdout:
-
-```
-DISK_USED_PCT=72
-FREED_BYTES=53687091200
-ACTION: Removed 48 stale worktrees (50.1G)
-ACTION: Removed cargo target dirs from 3 worktrees (1.2G)
-ACTION: Pruned 19 LadybugDB backups (512M)
-ACTION: Cleaned cargo-target/ (12.0G) and shared-target/ (2.8G)
-```
+> **Note:** The text-format output only contains the recipe summary line
+> (e.g., `Recipe: disk-health-check SUCCESS`), not the step output. This is
+> why the daemon uses `--output-format json` — to access the actual agent
+> output containing the `DISK_USED_PCT` markers.
 
 You can also run just the disk usage check (no cleanup) by looking at the
 partition directly:
@@ -148,11 +169,34 @@ Common causes:
 
 ### 4. Text parse shows unexpected values
 
-The Rust shim parses key=value lines from stdout. If the agent
-outputs lines with unexpected formats, the parser silently ignores them
-and defaults to zero. Check for typos in key names (`DISK_USED_PCT`, not
-`DISK_USED_PERCENT`) and ensure values are plain integers (no units, no
-commas).
+The Rust shim extracts the agent step output from the `--output-format json`
+envelope and parses key=value lines from it. The agent's output may include
+conversational text, `df` output, and other noise alongside the markers —
+the parser ignores lines it doesn't recognize.
+
+If values are wrong, check the JSON envelope to see the raw agent output:
+
+```bash
+recipe-runner-rs prompt_assets/simard/recipes/disk-health-check.yaml \
+  --output-format json \
+  -c STATE_ROOT="$HOME/.simard" \
+  -c REPO_ROOT="/home/azureuser/src/Simard" | python3 -m json.tool
+```
+
+Look at `step_results[0].output` — the markers (`DISK_USED_PCT`, `FREED_BYTES`,
+`ACTION:`) must appear on their own lines. Check for typos in key names and
+ensure values are plain integers (no units, no commas).
+
+### 5. JSON deserialization failed
+
+If the daemon logs a parse error mentioning JSON or serde, this means
+`recipe-runner-rs --output-format json` returned malformed output. Check:
+
+- `recipe-runner-rs` version supports `--output-format json` (introduced in
+  the same version as the JSON envelope)
+- The recipe YAML is syntactically valid
+- There is no shell wrapper around `recipe-runner-rs` that strips or modifies
+  stdout
 
 ## Handle persistent disk pressure
 
@@ -235,8 +279,9 @@ You should see one `disk health:` line per OODA cycle (default: every 60s).
 To run cleanup outside the daemon without waiting for a cycle:
 
 ```bash
-# Run the recipe directly
+# Run the recipe directly (JSON envelope mode, same as daemon)
 recipe-runner-rs prompt_assets/simard/recipes/disk-health-check.yaml \
+  --output-format json \
   -c STATE_ROOT="$HOME/.simard" \
   -c REPO_ROOT="/home/azureuser/src/Simard"
 ```
@@ -259,5 +304,6 @@ rm -rf ~/.simard/cargo-target/* ~/.simard/shared-target/*
 ## Related
 
 - [Automated disk health (concept)](../concepts/automated-disk-health.md) — design rationale
+- [Disk health API (reference)](../reference/disk-health-api.md) — module API, structs, data flow
 - [Inspect and clean engineer worktrees](./inspect-and-clean-engineer-worktrees.md) — manual worktree operations
 - [Reclaim disk space and run low-space Rust builds](./reclaim-disk-space-and-run-low-space-rust-builds.md) — build artifact scripts

--- a/docs/reference/disk-health-api.md
+++ b/docs/reference/disk-health-api.md
@@ -1,0 +1,228 @@
+---
+title: Disk health API
+description: Reference for the disk_health module — JSON envelope deserialization, text marker parsing, and the DiskHealthReport struct.
+last_updated: 2026-06-05
+review_schedule: as-needed
+owner: simard
+doc_type: reference
+related:
+  - ../concepts/automated-disk-health.md
+  - ../howto/configure-disk-health-check.md
+  - ./base-type-adapters.md
+---
+
+# Disk health API
+
+**Module:** `src/disk_health.rs`
+
+The `disk_health` module is a thin Rust shim that invokes `recipe-runner-rs`
+to run the disk health check recipe, deserializes the JSON envelope, extracts
+the agent step output, and parses text markers into a structured
+`DiskHealthReport`.
+
+## Data flow
+
+```
+recipe-runner-rs --output-format json
+       │
+       ▼
+JSON envelope (stdout)
+  { success, step_results: [{ step_id, output }] }
+       │
+       ▼
+serde_json::from_slice::<RecipeOutput>()
+       │
+       ▼
+step_results[0].output  (agent's raw text output)
+       │
+       ▼
+parse_disk_health_text()  (key=value line parser)
+       │
+       ▼
+DiskHealthReport { disk_used_pct, freed_bytes, actions_taken }
+```
+
+## Public API
+
+### `run_disk_health_check(repo_root, state_root) → SimardResult<DiskHealthReport>`
+
+Entry point. Resolves the recipe YAML, spawns `recipe-runner-rs` with
+`--output-format json`, deserializes the JSON envelope, extracts the first
+step's output, and parses it into a `DiskHealthReport`.
+
+**Parameters:**
+
+| Parameter    | Type     | Description                                                  |
+| ------------ | -------- | ------------------------------------------------------------ |
+| `repo_root`  | `&Path`  | Repository root — used to locate the recipe YAML file        |
+| `state_root` | `&Path`  | Simard state directory (`~/.simard`) — passed as context var |
+
+**Returns:** `SimardResult<DiskHealthReport>`
+
+**Errors** (`SimardError::AdapterInvocationFailed`):
+
+| Condition                         | Error reason                                      |
+| --------------------------------- | ------------------------------------------------- |
+| Recipe YAML not found             | `"recipe file disk-health-check.yaml not found…"` |
+| `recipe-runner-rs` not on PATH    | `"recipe-runner-rs spawn failed: …"`              |
+| Recipe exited non-zero            | `"recipe exited with <code>: <stderr>"`           |
+| JSON deserialization failed        | `"failed to deserialize recipe JSON output: …"`   |
+| Empty step_results                | `"no step results in recipe JSON output"`         |
+| Text markers missing DISK_USED_PCT | `"failed to parse recipe text output: …"`        |
+
+No fallback. If the recipe fails for any reason, the error propagates to the
+caller (the OODA daemon), which logs a warning and continues the cycle.
+
+### `DiskHealthReport`
+
+```rust
+#[derive(Debug, Clone, PartialEq)]
+pub struct DiskHealthReport {
+    pub disk_used_pct: u8,
+    pub freed_bytes: u64,
+    pub actions_taken: Vec<String>,
+}
+```
+
+> **Implementation note:** The struct no longer derives `Deserialize`. Prior to
+> issue #2212, the shim attempted to deserialize `DiskHealthReport` directly
+> from stdout JSON. After the fix, the struct is built by
+> `parse_disk_health_text()` from the extracted step output string — serde is
+> used only for the `RecipeOutput` / `StepResult` envelope structs.
+
+| Field           | Type           | Description                                       |
+| --------------- | -------------- | ------------------------------------------------- |
+| `disk_used_pct` | `u8`           | Current disk usage percentage (0–100)             |
+| `freed_bytes`   | `u64`          | Total bytes freed during this check (0 if none)   |
+| `actions_taken` | `Vec<String>`  | Human-readable list of cleanup actions performed  |
+
+**Methods:**
+
+- `cleanup_performed() → bool` — returns `true` if `freed_bytes > 0` or
+  `actions_taken` is non-empty.
+- `summary() → String` — one-line summary for daemon log. Format:
+  `"disk health: N% used, freed M bytes, K actions"` or
+  `"disk health: N% used, no cleanup needed"`.
+
+### `RecipeOutput` (internal)
+
+Serde struct for deserializing the `recipe-runner-rs --output-format json`
+envelope. Not public — used internally by `run_disk_health_check()`.
+
+```rust
+#[derive(Deserialize)]
+struct RecipeOutput {
+    #[allow(dead_code)]
+    success: bool,
+    step_results: Vec<StepResult>,
+}
+
+#[derive(Deserialize)]
+struct StepResult {
+    #[allow(dead_code)]
+    step_id: String,
+    output: String,
+}
+```
+
+The shim reads `step_results[0].output` — the first (and typically only)
+step's output string. This contains the agent's raw text including its
+reasoning, tool output, and the `DISK_USED_PCT` / `FREED_BYTES` / `ACTION:`
+markers that `parse_disk_health_text()` extracts.
+
+### `parse_disk_health_text(stdout) → Result<DiskHealthReport, String>`
+
+Parses key=value text markers from the agent step output.
+
+**Expected markers:**
+
+```text
+DISK_USED_PCT=72
+FREED_BYTES=53687091200
+ACTION: Removed 48 stale worktrees (50.1G)
+ACTION: Cleaned cargo-target/ (12.0G) and shared-target/ (2.8G)
+```
+
+**Parsing rules:**
+
+- `DISK_USED_PCT=N` — required. Must be a valid `u8`. Missing → error.
+- `FREED_BYTES=N` — optional. Defaults to 0 if absent.
+- `ACTION: text` — optional. Empty text after colon is skipped.
+- Unknown lines are silently ignored (forward-compatible with agent noise).
+- Leading/trailing whitespace on each line is trimmed.
+- Blank lines are skipped.
+
+The parser tolerates noisy agent output — LLM reasoning, `df` output, bash
+prompts — because it only matches lines starting with the exact marker
+prefixes. This is why the agent can freely reason and run commands as long as
+it emits the markers somewhere in its output.
+
+### `resolve_recipe_path(repo_root) → Option<PathBuf>`
+
+Resolves the recipe YAML path. Checks in order:
+
+1. **Hot-reload:** `~/.simard/prompt_assets/simard/recipes/disk-health-check.yaml`
+2. **In-tree:** `<repo_root>/prompt_assets/simard/recipes/disk-health-check.yaml`
+
+Returns `None` if neither path exists.
+
+## Recipe invocation details
+
+The shim invokes `recipe-runner-rs` with these arguments:
+
+```
+recipe-runner-rs <recipe_path> --output-format json -c state_root=<state_root>
+```
+
+- `--output-format json` — required. Without this flag, stdout only contains
+  the summary line (`Recipe: disk-health-check SUCCESS`), not the step output.
+- `-c state_root=<path>` — context variable passed to the recipe YAML.
+- `AMPLIHACK_AGENT_BINARY` env var — set from `RuntimeConfig` so the recipe
+  uses the correct agent binary.
+
+## Test coverage
+
+The module has comprehensive inline tests:
+
+| Category                    | Count | Description                                               |
+| --------------------------- | ----- | --------------------------------------------------------- |
+| `parse_disk_health_text`    | 12    | All marker combinations, edge cases, error paths          |
+| `DiskHealthReport` methods  | 5     | `cleanup_performed()` (3 cases) and `summary()` (2 cases) |
+| `resolve_recipe_path`       | 2     | Missing dir, in-tree recipe found                         |
+| `run_disk_health_check`     | 2     | Recipe not found, runner unavailable/invalid recipe       |
+| JSON envelope deserialization | 1   | Full pipeline: JSON → RecipeOutput → parse → report       |
+| Noisy agent output          | 1     | Markers embedded in LLM conversation text                 |
+| `truncate` helper           | 5     | Short, exact, long, empty, zero-max                       |
+
+## Why `--output-format json` and not text
+
+The `recipe-runner-rs` text-format stdout contains only the recipe-level
+summary line:
+
+```
+Recipe: disk-health-check SUCCESS
+```
+
+This summary line does not include the individual step outputs. The agent step
+runs `df`, checks disk usage, performs cleanup, and emits `DISK_USED_PCT`
+markers — but all of that output lives inside the step, not in the recipe
+summary.
+
+The `--output-format json` flag wraps each step's output in the JSON envelope,
+making it accessible to the calling process. This is the same pattern used by
+`stewardship::recipe_merge_judge`, which also needs to read structured data
+from recipe step output.
+
+## Implementation notes
+
+When implementing the fix (issue #2212), update the module doc comment at the
+top of `src/disk_health.rs`. The current `//!` comment says "Parses stdout
+JSON into `DiskHealthReport`", which reflects the pre-fix behavior. After the
+fix, update it to describe the two-layer pipeline: deserialize the JSON
+envelope, extract step output, parse text markers into `DiskHealthReport`.
+
+## Related
+
+- [Automated disk health (concept)](../concepts/automated-disk-health.md) — design rationale
+- [Configure disk health check (how-to)](../howto/configure-disk-health-check.md) — operator guide
+- [Base type adapters](./base-type-adapters.md) — adapter pattern context

--- a/src/disk_health.rs
+++ b/src/disk_health.rs
@@ -1,16 +1,18 @@
-//! Recipe-runner-backed disk health check (issue #2020).
+//! Recipe-runner-backed disk health check (issue #2020, fix #2212).
 //!
-//! Invokes `recipe-runner-rs` executing
+//! Invokes `recipe-runner-rs --output-format json` executing
 //! `prompt_assets/simard/recipes/disk-health-check.yaml` as a subprocess,
 //! checks disk usage, triggers cleanup when usage exceeds 80%, and returns
-//! a structured JSON report.
+//! a structured [`DiskHealthReport`].
 //!
 //! The recipe YAML contains the deterministic bash cleanup logic; this
 //! module is a thin Rust shim that:
 //!   1. Resolves the recipe path (hot-reload → in-tree fallback)
-//!   2. Spawns `recipe-runner-rs` with `-c` context vars
-//!   3. Parses stdout JSON into [`DiskHealthReport`]
-//!   4. Logs results to daemon.log
+//!   2. Spawns `recipe-runner-rs` with `--output-format json` and `-c` context vars
+//!   3. Deserializes the JSON envelope into [`RecipeOutput`]
+//!   4. Extracts `step_results[0].output` (the agent's text output)
+//!   5. Parses `DISK_USED_PCT`/`FREED_BYTES`/`ACTION:` markers into [`DiskHealthReport`]
+//!   6. Logs results to daemon.log
 //!
 //! Follows the same pattern as `stewardship::recipe_merge_judge`.
 
@@ -25,10 +27,26 @@ use crate::runtime_config::RuntimeConfig;
 const ADAPTER_TAG: &str = "disk-health-check";
 const RECIPE_FILENAME: &str = "disk-health-check.yaml";
 
+/// JSON envelope returned by `recipe-runner-rs --output-format json`.
+#[derive(Debug, Deserialize)]
+pub(crate) struct RecipeOutput {
+    pub success: bool,
+    pub step_results: Vec<StepResult>,
+}
+
+/// A single step's result inside the [`RecipeOutput`] envelope.
+#[derive(Debug, Deserialize)]
+pub(crate) struct StepResult {
+    #[allow(dead_code)] // Part of JSON contract; used in tests.
+    pub step_id: String,
+    pub output: String,
+}
+
 /// Structured report returned by the disk-health-check recipe.
 ///
-/// The recipe's bash step outputs this as JSON to stdout.
-#[derive(Debug, Clone, Deserialize, PartialEq)]
+/// Built by parsing text markers (`DISK_USED_PCT=`, `FREED_BYTES=`,
+/// `ACTION:`) from the agent step output extracted from the JSON envelope.
+#[derive(Debug, Clone, PartialEq)]
 pub struct DiskHealthReport {
     /// Current disk usage percentage (0–100).
     pub disk_used_pct: u8,
@@ -110,6 +128,8 @@ pub fn run_disk_health_check(
 
     let output = Command::new("recipe-runner-rs")
         .arg(recipe_path.as_os_str())
+        .arg("--output-format")
+        .arg("json")
         .env("AMPLIHACK_AGENT_BINARY", agent_binary)
         .arg("-c")
         .arg(format!("state_root={}", state_root.display()))
@@ -131,8 +151,30 @@ pub fn run_disk_health_check(
         });
     }
 
-    let stdout_text = String::from_utf8_lossy(&output.stdout);
-    parse_disk_health_text(&stdout_text).map_err(|e| SimardError::AdapterInvocationFailed {
+    let envelope: RecipeOutput = serde_json::from_slice(&output.stdout).map_err(|e| {
+        SimardError::AdapterInvocationFailed {
+            base_type: ADAPTER_TAG.to_string(),
+            reason: format!("failed to deserialize recipe JSON output: {e}"),
+        }
+    })?;
+
+    if !envelope.success {
+        return Err(SimardError::AdapterInvocationFailed {
+            base_type: ADAPTER_TAG.to_string(),
+            reason: "recipe reported success=false in JSON output".to_string(),
+        });
+    }
+
+    let step_output = envelope
+        .step_results
+        .first()
+        .map(|s| s.output.as_str())
+        .ok_or_else(|| SimardError::AdapterInvocationFailed {
+            base_type: ADAPTER_TAG.to_string(),
+            reason: "no step results in recipe JSON output".to_string(),
+        })?;
+
+    parse_disk_health_text(step_output).map_err(|e| SimardError::AdapterInvocationFailed {
         base_type: ADAPTER_TAG.to_string(),
         reason: format!("failed to parse recipe text output: {e}"),
     })
@@ -451,6 +493,113 @@ ACTION: cleaned shared-target dir
             }
             other => panic!("expected AdapterInvocationFailed, got: {other:?}"),
         }
+    }
+
+    // ------------------------------------------------------------------
+    // JSON envelope deserialization (issue #2212 — TDD: tests written first)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn json_envelope_deserialization() {
+        // Full pipeline: JSON envelope → RecipeOutput → step_results[0].output → parse_disk_health_text → DiskHealthReport
+        let json = r#"{
+            "success": true,
+            "step_results": [{
+                "step_id": "disk-health-step",
+                "output": "DISK_USED_PCT=72\nFREED_BYTES=1024\nACTION: cleaned worktrees\n"
+            }]
+        }"#;
+        let envelope: RecipeOutput = serde_json::from_str(json).unwrap();
+        assert!(envelope.success);
+        assert_eq!(envelope.step_results.len(), 1);
+        assert_eq!(envelope.step_results[0].step_id, "disk-health-step");
+
+        let report = parse_disk_health_text(&envelope.step_results[0].output).unwrap();
+        assert_eq!(report.disk_used_pct, 72);
+        assert_eq!(report.freed_bytes, 1024);
+        assert_eq!(report.actions_taken, vec!["cleaned worktrees"]);
+    }
+
+    #[test]
+    fn json_envelope_empty_step_results() {
+        // When step_results is empty, extracting step output should fail gracefully.
+        let json = r#"{"success": true, "step_results": []}"#;
+        let envelope: RecipeOutput = serde_json::from_str(json).unwrap();
+        assert!(envelope.step_results.is_empty());
+    }
+
+    #[test]
+    fn json_envelope_multiple_steps_uses_first() {
+        // Only step_results[0].output is used for parsing.
+        let json = r#"{
+            "success": true,
+            "step_results": [
+                {"step_id": "step-1", "output": "DISK_USED_PCT=55\nFREED_BYTES=0\n"},
+                {"step_id": "step-2", "output": "some other output"}
+            ]
+        }"#;
+        let envelope: RecipeOutput = serde_json::from_str(json).unwrap();
+        assert_eq!(envelope.step_results.len(), 2);
+
+        let report = parse_disk_health_text(&envelope.step_results[0].output).unwrap();
+        assert_eq!(report.disk_used_pct, 55);
+    }
+
+    // ------------------------------------------------------------------
+    // Noisy agent output (issue #2212 — markers in LLM conversation text)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn parse_markers_from_agent_output_with_noise() {
+        // The agent's step output contains LLM reasoning, df output, and
+        // bash prompts — the parser must extract markers from this noise.
+        let noisy_output = "\
+I'll check the disk usage now.
+
+Running df -h to check disk space...
+
+Filesystem      Size  Used Avail Use% Mounted on
+/dev/sda1       100G   72G   28G  72% /
+
+The disk is at 72% usage, which is below the 80% threshold.
+No cleanup actions are needed.
+
+DISK_USED_PCT=72
+FREED_BYTES=0
+";
+        let report = parse_disk_health_text(noisy_output).unwrap();
+        assert_eq!(report.disk_used_pct, 72);
+        assert_eq!(report.freed_bytes, 0);
+        assert!(report.actions_taken.is_empty());
+    }
+
+    #[test]
+    fn parse_markers_from_noisy_output_with_cleanup() {
+        let noisy_output = "\
+Checking disk usage...
+
+Filesystem      Size  Used Avail Use% Mounted on
+/dev/sda1       100G   87G   13G  87% /
+
+Disk usage is at 87%, exceeding 80% threshold. Performing cleanup.
+
+Removing stale worktrees...
+Done. Removed 12 worktrees.
+
+Cleaning cargo target directories...
+Done.
+
+DISK_USED_PCT=87
+FREED_BYTES=53687091200
+ACTION: removed 12 stale engineer worktrees
+ACTION: cleaned cargo target dirs
+";
+        let report = parse_disk_health_text(noisy_output).unwrap();
+        assert_eq!(report.disk_used_pct, 87);
+        assert_eq!(report.freed_bytes, 53_687_091_200);
+        assert_eq!(report.actions_taken.len(), 2);
+        assert!(report.actions_taken[0].contains("worktrees"));
+        assert!(report.actions_taken[1].contains("cargo"));
     }
 
     // ------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The disk health shim (`src/disk_health.rs`) was reading recipe-runner-rs **text-format stdout**, which only contains the summary line (`Recipe: disk-health-check SUCCESS`), not the agent's step output where `DISK_USED_PCT` markers live. This caused **946 consecutive false failures** and allowed the disk to fill to 100% (373G/393G).

The agent itself worked perfectly every time — the integration was broken.

## Root Cause

- `--output-format text` (default): stdout has only the recipe summary
- `--output-format json`: stdout has full JSON with `step_results[].output` containing the agent's actual output
- The shim was using text format and looking for markers that were never there

## Fix

- Add `RecipeOutput` and `StepResult` deserialization structs
- Pass `--output-format json` to recipe-runner-rs
- Extract `step_results[0].output` and parse markers from that
- Add `success` field check (fail fast if recipe reports failure)
- Remove deterministic bash fallback (no silent degradation)
- Add `docs/reference/disk-health-api.md` reference doc
- Update concept and howto docs for JSON envelope architecture

## Testing

- 31 disk_health tests passing
- Clippy clean, fmt clean
- Pre-commit and pre-push hooks all pass

## Evidence

- Tests: `cargo test --lib disk_health` — 31 passed, 0 failed
- Clippy: `cargo clippy -- -W clippy::all` — 0 warnings
- Fmt: `cargo fmt --all -- --check` — clean
