### PR TITLE
test: add unit tests for identity module (#2213)

### DIFF
--- a/src/identity/coverage_tests.rs
+++ b/src/identity/coverage_tests.rs
@@ -1,0 +1,629 @@
+//! Extended unit tests for the `identity` module.
+//!
+//! Covers validation edge cases, trimming behaviour, request/contract
+//! propagation, composite identity invariants, and serde boundaries
+//! that the existing inline tests do not exercise.
+//! No `skip_if_no_llm_provider` — every test here runs deterministically.
+
+use super::*;
+use crate::base_types::{BaseTypeCapability, BaseTypeId, capability_set};
+use crate::memory::MemoryScope;
+use crate::metadata::{Freshness, Provenance};
+use crate::prompt_assets::PromptAssetRef;
+use std::collections::BTreeSet;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn test_contract() -> ManifestContract {
+    ManifestContract::new(
+        "test::entrypoint",
+        "a -> b",
+        vec!["key:value".to_string()],
+        Provenance::new("test-source", "test-locator"),
+        Freshness::now().unwrap(),
+    )
+    .unwrap()
+}
+
+fn simple_manifest(name: &str) -> IdentityManifest {
+    IdentityManifest::new(
+        name,
+        "1.0",
+        vec![],
+        vec![BaseTypeId::new("local-harness")],
+        capability_set([]),
+        OperatingMode::Engineer,
+        MemoryPolicy::default(),
+        test_contract(),
+    )
+    .unwrap()
+}
+
+// ===========================================================================
+// OperatingMode — serde boundary
+// ===========================================================================
+
+#[test]
+fn operating_mode_display_matches_serde_for_all_variants() {
+    let modes = [
+        OperatingMode::Engineer,
+        OperatingMode::Meeting,
+        OperatingMode::Curator,
+        OperatingMode::Improvement,
+        OperatingMode::Gym,
+        OperatingMode::Orchestrator,
+    ];
+    for mode in modes {
+        let display = mode.to_string();
+        let json = serde_json::to_string(&mode).unwrap();
+        // serde produces `"engineer"`, Display produces `engineer`
+        assert_eq!(
+            format!("\"{display}\""),
+            json,
+            "Display and serde should agree for {mode:?}"
+        );
+    }
+}
+
+#[test]
+fn operating_mode_deserialization_rejects_unknown_string() {
+    let result: Result<OperatingMode, _> = serde_json::from_str("\"unknown-mode\"");
+    assert!(result.is_err(), "unknown mode should fail deserialization");
+}
+
+#[test]
+fn operating_mode_deserialization_rejects_empty_string() {
+    let result: Result<OperatingMode, _> = serde_json::from_str("\"\"");
+    assert!(result.is_err(), "empty string should fail deserialization");
+}
+
+// ===========================================================================
+// MemoryPolicy — scope inequality
+// ===========================================================================
+
+#[test]
+fn memory_policy_different_scopes_are_not_equal() {
+    let a = MemoryPolicy {
+        allow_project_writes: false,
+        summary_scope: MemoryScope::SessionSummary,
+    };
+    let b = MemoryPolicy {
+        allow_project_writes: false,
+        summary_scope: MemoryScope::Decision,
+    };
+    assert_ne!(a, b, "policies with different scopes should not be equal");
+}
+
+#[test]
+fn memory_policy_same_values_are_equal() {
+    let a = MemoryPolicy::default();
+    let b = MemoryPolicy::default();
+    assert_eq!(a, b);
+}
+
+// ===========================================================================
+// ManifestContract — trimming and edge cases
+// ===========================================================================
+
+#[test]
+fn contract_trims_whitespace_from_entrypoint() {
+    let contract = ManifestContract::new(
+        "  test::entrypoint  ",
+        "a -> b",
+        vec!["key:value".to_string()],
+        Provenance::new("src", "loc"),
+        Freshness::now().unwrap(),
+    )
+    .unwrap();
+    assert_eq!(contract.entrypoint, "test::entrypoint");
+}
+
+#[test]
+fn contract_trims_whitespace_from_composition() {
+    let contract = ManifestContract::new(
+        "test::entry",
+        "  a -> b  ",
+        vec!["key:value".to_string()],
+        Provenance::new("src", "loc"),
+        Freshness::now().unwrap(),
+    )
+    .unwrap();
+    assert_eq!(contract.composition, "a -> b");
+}
+
+#[test]
+fn contract_trims_whitespace_from_precedence_entries() {
+    let contract = ManifestContract::new(
+        "test::entry",
+        "a -> b",
+        vec!["  layer:test  ".to_string()],
+        Provenance::new("src", "loc"),
+        Freshness::now().unwrap(),
+    )
+    .unwrap();
+    assert_eq!(contract.precedence[0], "layer:test");
+}
+
+#[test]
+fn contract_rejects_duplicate_precedence_after_trimming() {
+    let err = ManifestContract::new(
+        "test::entry",
+        "a -> b",
+        vec!["key:value".to_string(), "  key:value  ".to_string()],
+        Provenance::new("src", "loc"),
+        Freshness::now().unwrap(),
+    )
+    .unwrap_err();
+    assert!(
+        err.to_string().contains("duplicate"),
+        "should detect duplicate after trimming: {err}"
+    );
+}
+
+#[test]
+fn contract_accepts_precedence_with_colon_at_end() {
+    // "key:" has a colon so should pass the colon check
+    let result = ManifestContract::new(
+        "test::entry",
+        "a -> b",
+        vec!["key:".to_string()],
+        Provenance::new("src", "loc"),
+        Freshness::now().unwrap(),
+    );
+    assert!(
+        result.is_ok(),
+        "precedence 'key:' contains ':' and should pass"
+    );
+}
+
+#[test]
+fn contract_accepts_precedence_with_colon_at_start() {
+    let result = ManifestContract::new(
+        "test::entry",
+        "a -> b",
+        vec![":value".to_string()],
+        Provenance::new("src", "loc"),
+        Freshness::now().unwrap(),
+    );
+    assert!(
+        result.is_ok(),
+        "precedence ':value' contains ':' and should pass"
+    );
+}
+
+#[test]
+fn contract_trims_provenance_fields() {
+    let contract = ManifestContract::new(
+        "test::entry",
+        "a -> b",
+        vec!["key:value".to_string()],
+        Provenance::new("  my-source  ", "  my-locator  "),
+        Freshness::now().unwrap(),
+    )
+    .unwrap();
+    assert_eq!(contract.provenance.source, "my-source");
+    assert_eq!(contract.provenance.locator, "my-locator");
+}
+
+#[test]
+fn contract_multiple_valid_precedence_entries() {
+    let contract = ManifestContract::new(
+        "test::entry",
+        "a -> b",
+        vec![
+            "layer:base".to_string(),
+            "identity:simard".to_string(),
+            "env:prod".to_string(),
+        ],
+        Provenance::new("src", "loc"),
+        Freshness::now().unwrap(),
+    )
+    .unwrap();
+    assert_eq!(contract.precedence.len(), 3);
+}
+
+// ===========================================================================
+// IdentityManifest::new — field initialization
+// ===========================================================================
+
+#[test]
+fn manifest_new_initializes_components_to_empty_vec() {
+    let manifest = simple_manifest("test");
+    assert!(
+        manifest.components.is_empty(),
+        "new() should not populate components"
+    );
+}
+
+#[test]
+fn manifest_new_stores_name_and_version() {
+    let manifest = IdentityManifest::new(
+        "my-identity",
+        "2.3.4",
+        vec![],
+        vec![BaseTypeId::new("local-harness")],
+        capability_set([]),
+        OperatingMode::Gym,
+        MemoryPolicy::default(),
+        test_contract(),
+    )
+    .unwrap();
+    assert_eq!(manifest.name, "my-identity");
+    assert_eq!(manifest.version, "2.3.4");
+    assert_eq!(manifest.default_mode, OperatingMode::Gym);
+}
+
+// ===========================================================================
+// IdentityManifest::with_components — trimming
+// ===========================================================================
+
+#[test]
+fn manifest_with_components_trims_whitespace() {
+    let manifest = simple_manifest("parent")
+        .with_components(["  child-a  ", "  child-b  "])
+        .unwrap();
+    assert_eq!(manifest.components, vec!["child-a", "child-b"]);
+}
+
+#[test]
+fn manifest_with_components_many_components_succeeds() {
+    let names: Vec<String> = (0..10).map(|i| format!("child-{i}")).collect();
+    let manifest = simple_manifest("parent")
+        .with_components(names.clone())
+        .unwrap();
+    assert_eq!(manifest.components.len(), 10);
+    assert_eq!(manifest.components, names);
+}
+
+// ===========================================================================
+// IdentityManifest::compose — single component and propagation
+// ===========================================================================
+
+#[test]
+fn compose_single_component_preserves_identity() {
+    let child = simple_manifest("only-child");
+    let composed = IdentityManifest::compose(
+        "parent",
+        "3.0",
+        vec![child.clone()],
+        OperatingMode::Meeting,
+        test_contract(),
+    )
+    .unwrap();
+    assert_eq!(composed.name, "parent");
+    assert_eq!(composed.version, "3.0");
+    assert_eq!(composed.default_mode, OperatingMode::Meeting);
+    assert_eq!(composed.components, vec!["only-child"]);
+    assert_eq!(composed.memory_policy, child.memory_policy);
+}
+
+#[test]
+fn compose_three_components_unions_capabilities() {
+    let mut c1 = simple_manifest("c1");
+    c1.required_capabilities = capability_set([BaseTypeCapability::PromptAssets]);
+    let mut c2 = simple_manifest("c2");
+    c2.required_capabilities = capability_set([BaseTypeCapability::Memory]);
+    let mut c3 = simple_manifest("c3");
+    c3.required_capabilities = capability_set([
+        BaseTypeCapability::Evidence,
+        BaseTypeCapability::PromptAssets,
+    ]);
+
+    let composed = IdentityManifest::compose(
+        "three-way",
+        "1.0",
+        vec![c1, c2, c3],
+        OperatingMode::Engineer,
+        test_contract(),
+    )
+    .unwrap();
+
+    assert!(
+        composed
+            .required_capabilities
+            .contains(&BaseTypeCapability::PromptAssets)
+    );
+    assert!(
+        composed
+            .required_capabilities
+            .contains(&BaseTypeCapability::Memory)
+    );
+    assert!(
+        composed
+            .required_capabilities
+            .contains(&BaseTypeCapability::Evidence)
+    );
+    assert_eq!(composed.required_capabilities.len(), 3);
+}
+
+#[test]
+fn compose_preserves_contract_from_caller() {
+    let child = simple_manifest("child");
+    let contract = ManifestContract::new(
+        "custom::entry",
+        "x -> y",
+        vec!["layer:custom".to_string()],
+        Provenance::new("custom-src", "custom-loc"),
+        Freshness::now().unwrap(),
+    )
+    .unwrap();
+    let composed = IdentityManifest::compose(
+        "parent",
+        "1.0",
+        vec![child],
+        OperatingMode::Engineer,
+        contract.clone(),
+    )
+    .unwrap();
+    assert_eq!(composed.contract.entrypoint, "custom::entry");
+    assert_eq!(composed.contract.composition, "x -> y");
+}
+
+// ===========================================================================
+// compose_with_precedence — conflict logging
+// ===========================================================================
+
+#[test]
+fn compose_with_precedence_two_manifests_with_conflicts() {
+    let m1 = IdentityManifest::new(
+        "high",
+        "1.0",
+        vec![PromptAssetRef::new("shared", "a.md")],
+        vec![BaseTypeId::new("shared-bt")],
+        capability_set([BaseTypeCapability::Memory]),
+        OperatingMode::Engineer,
+        MemoryPolicy::default(),
+        test_contract(),
+    )
+    .unwrap();
+    let m2 = IdentityManifest::new(
+        "low",
+        "1.0",
+        vec![PromptAssetRef::new("shared", "b.md")],
+        vec![BaseTypeId::new("shared-bt")],
+        capability_set([BaseTypeCapability::Evidence]),
+        OperatingMode::Engineer,
+        MemoryPolicy::default(),
+        test_contract(),
+    )
+    .unwrap();
+
+    let resolved = compose_with_precedence(vec![m1, m2]);
+
+    // One conflict per shared field
+    assert!(
+        resolved.conflict_log.len() >= 2,
+        "expected conflicts from shared asset and base type"
+    );
+    // Capabilities are unioned
+    assert!(resolved.capabilities.contains(&BaseTypeCapability::Memory));
+    assert!(
+        resolved
+            .capabilities
+            .contains(&BaseTypeCapability::Evidence)
+    );
+}
+
+#[test]
+fn compose_with_precedence_no_conflicts_empty_log() {
+    let m1 = IdentityManifest::new(
+        "alpha",
+        "1.0",
+        vec![PromptAssetRef::new("asset-a", "a.md")],
+        vec![BaseTypeId::new("bt-a")],
+        capability_set([]),
+        OperatingMode::Engineer,
+        MemoryPolicy::default(),
+        test_contract(),
+    )
+    .unwrap();
+    let m2 = IdentityManifest::new(
+        "beta",
+        "1.0",
+        vec![PromptAssetRef::new("asset-b", "b.md")],
+        vec![BaseTypeId::new("bt-b")],
+        capability_set([]),
+        OperatingMode::Engineer,
+        MemoryPolicy::default(),
+        test_contract(),
+    )
+    .unwrap();
+
+    let resolved = compose_with_precedence(vec![m1, m2]);
+    assert!(resolved.conflict_log.is_empty());
+    assert_eq!(resolved.prompt_assets.len(), 2);
+    assert_eq!(resolved.base_types.len(), 2);
+}
+
+// ===========================================================================
+// BuiltinIdentityLoader — catalog invariants
+// ===========================================================================
+
+#[test]
+fn builtin_loader_composite_engineer_has_five_components() {
+    let loader = BuiltinIdentityLoader;
+    let manifest = loader
+        .load(&IdentityLoadRequest::new(
+            "simard-composite-engineer",
+            "0.1.0",
+            test_contract(),
+        ))
+        .unwrap();
+    assert_eq!(
+        manifest.components.len(),
+        5,
+        "composite engineer should have exactly 5 sub-identities"
+    );
+}
+
+#[test]
+fn builtin_loader_composite_engineer_component_names() {
+    let loader = BuiltinIdentityLoader;
+    let manifest = loader
+        .load(&IdentityLoadRequest::new(
+            "simard-composite-engineer",
+            "0.1.0",
+            test_contract(),
+        ))
+        .unwrap();
+    let names: Vec<&str> = manifest.components.iter().map(|s| s.as_str()).collect();
+    assert!(names.contains(&"simard-engineer"));
+    assert!(names.contains(&"simard-meeting"));
+    assert!(names.contains(&"simard-gym"));
+    assert!(names.contains(&"simard-goal-curator"));
+    assert!(names.contains(&"simard-improvement-curator"));
+}
+
+#[test]
+fn builtin_loader_version_propagates_from_request() {
+    let loader = BuiltinIdentityLoader;
+    let manifest = loader
+        .load(&IdentityLoadRequest::new(
+            "simard-engineer",
+            "99.88.77",
+            test_contract(),
+        ))
+        .unwrap();
+    assert_eq!(manifest.version, "99.88.77");
+}
+
+#[test]
+fn builtin_loader_contract_propagates_from_request() {
+    let contract = ManifestContract::new(
+        "custom::ep",
+        "x -> y",
+        vec!["layer:custom".to_string()],
+        Provenance::new("custom-src", "custom-loc"),
+        Freshness::now().unwrap(),
+    )
+    .unwrap();
+    let loader = BuiltinIdentityLoader;
+    let manifest = loader
+        .load(&IdentityLoadRequest::new(
+            "simard-engineer",
+            "1.0",
+            contract,
+        ))
+        .unwrap();
+    assert_eq!(manifest.contract.entrypoint, "custom::ep");
+}
+
+#[test]
+fn builtin_loader_all_single_identities_have_capabilities() {
+    let loader = BuiltinIdentityLoader;
+    let names = [
+        "simard-engineer",
+        "simard-meeting",
+        "simard-gym",
+        "simard-goal-curator",
+        "simard-improvement-curator",
+    ];
+    for name in names {
+        let manifest = loader
+            .load(&IdentityLoadRequest::new(name, "0.1.0", test_contract()))
+            .unwrap();
+        assert!(
+            !manifest.required_capabilities.is_empty(),
+            "{name} should have required capabilities"
+        );
+        assert!(
+            manifest
+                .required_capabilities
+                .contains(&BaseTypeCapability::PromptAssets),
+            "{name} should require PromptAssets"
+        );
+        assert!(
+            manifest
+                .required_capabilities
+                .contains(&BaseTypeCapability::Memory),
+            "{name} should require Memory"
+        );
+    }
+}
+
+#[test]
+fn builtin_loader_engineer_has_expected_base_types() {
+    let loader = BuiltinIdentityLoader;
+    let manifest = loader
+        .load(&IdentityLoadRequest::new(
+            "simard-engineer",
+            "0.1.0",
+            test_contract(),
+        ))
+        .unwrap();
+    let bt_names: Vec<&str> = manifest
+        .supported_base_types
+        .iter()
+        .map(|bt| bt.as_str())
+        .collect();
+    assert!(bt_names.contains(&"local-harness"));
+    assert!(bt_names.contains(&"terminal-shell"));
+    assert!(bt_names.contains(&"rusty-clawd"));
+    assert!(bt_names.contains(&"copilot-sdk"));
+    assert!(bt_names.contains(&"claude-agent-sdk"));
+    assert!(bt_names.contains(&"ms-agent-framework"));
+}
+
+#[test]
+fn builtin_loader_engineer_has_terminal_shell_but_meeting_does_not() {
+    let loader = BuiltinIdentityLoader;
+    let engineer = loader
+        .load(&IdentityLoadRequest::new(
+            "simard-engineer",
+            "0.1.0",
+            test_contract(),
+        ))
+        .unwrap();
+    let meeting = loader
+        .load(&IdentityLoadRequest::new(
+            "simard-meeting",
+            "0.1.0",
+            test_contract(),
+        ))
+        .unwrap();
+    assert!(engineer.supports_base_type(&BaseTypeId::new("terminal-shell")));
+    assert!(!meeting.supports_base_type(&BaseTypeId::new("terminal-shell")));
+}
+
+#[test]
+fn builtin_loader_each_identity_has_unique_prompt_asset() {
+    let loader = BuiltinIdentityLoader;
+    let names = [
+        "simard-engineer",
+        "simard-meeting",
+        "simard-gym",
+        "simard-goal-curator",
+        "simard-improvement-curator",
+    ];
+    let mut seen_asset_ids = BTreeSet::new();
+    for name in names {
+        let manifest = loader
+            .load(&IdentityLoadRequest::new(name, "0.1.0", test_contract()))
+            .unwrap();
+        assert_eq!(
+            manifest.prompt_assets.len(),
+            1,
+            "{name} should have exactly one prompt asset"
+        );
+        let asset_id = manifest.prompt_assets[0].id.as_str().to_string();
+        assert!(
+            seen_asset_ids.insert(asset_id.clone()),
+            "{name} prompt asset id '{asset_id}' should be unique"
+        );
+    }
+}
+
+// ===========================================================================
+// IdentityLoadRequest — construction
+// ===========================================================================
+
+#[test]
+fn identity_load_request_stores_all_fields() {
+    let contract = test_contract();
+    let req = IdentityLoadRequest::new("my-id", "2.0.0", contract.clone());
+    assert_eq!(req.identity, "my-id");
+    assert_eq!(req.package_version, "2.0.0");
+    assert_eq!(req.contract, contract);
+}

--- a/src/identity/mod.rs
+++ b/src/identity/mod.rs
@@ -4,6 +4,10 @@ mod loader;
 mod manifest;
 mod types;
 
+#[cfg(test)]
+#[path = "coverage_tests.rs"]
+mod coverage_tests;
+
 // Re-export all public items so `crate::identity::X` still works.
 pub use contract::ManifestContract;
 pub use loader::{BuiltinIdentityLoader, IdentityLoadRequest, IdentityLoader};

--- a/src/identity_auth.rs
+++ b/src/identity_auth.rs
@@ -220,6 +220,10 @@ pub fn identity_for_operation(operation: &str) -> Option<AuthIdentity> {
 }
 
 #[cfg(test)]
+#[path = "identity_auth_tests.rs"]
+mod coverage_tests;
+
+#[cfg(test)]
 mod tests {
     use super::*;
 

--- a/src/identity_auth_tests.rs
+++ b/src/identity_auth_tests.rs
@@ -1,0 +1,268 @@
+//! Extended unit tests for the `identity_auth` module.
+//!
+//! Covers Display impls, email validation edge cases, field trimming,
+//! exhaustive operation validation, and serde boundaries.
+//! No `skip_if_no_llm_provider` — every test here runs deterministically.
+
+use super::*;
+
+// ===========================================================================
+// AuthIdentity — Display
+// ===========================================================================
+
+#[test]
+fn auth_identity_display_copilot() {
+    assert_eq!(AuthIdentity::CopilotAuth.to_string(), "copilot-auth");
+}
+
+#[test]
+fn auth_identity_display_commit() {
+    assert_eq!(AuthIdentity::CommitAuth.to_string(), "commit-auth");
+}
+
+// ===========================================================================
+// AuthIdentity — serde
+// ===========================================================================
+
+#[test]
+fn auth_identity_serde_roundtrip() {
+    let variants = [AuthIdentity::CopilotAuth, AuthIdentity::CommitAuth];
+    for variant in variants {
+        let json = serde_json::to_string(&variant).unwrap();
+        let back: AuthIdentity = serde_json::from_str(&json).unwrap();
+        assert_eq!(variant, back, "roundtrip failed for {variant:?}");
+    }
+}
+
+// ===========================================================================
+// DualIdentityConfig — field trimming
+// ===========================================================================
+
+#[test]
+fn dual_identity_config_trims_whitespace() {
+    let config =
+        DualIdentityConfig::new("  copilot-user  ", "  commit-user  ", "  user@x.com  ").unwrap();
+    assert_eq!(config.copilot_user, "copilot-user");
+    assert_eq!(config.commit_user, "commit-user");
+    assert_eq!(config.commit_email, "user@x.com");
+}
+
+// ===========================================================================
+// DualIdentityConfig — email validation edge cases
+// ===========================================================================
+
+#[test]
+fn email_rejects_missing_at_sign() {
+    let err = DualIdentityConfig::new("user", "bot", "no-at-sign.com").unwrap_err();
+    assert!(err.to_string().contains("@"), "error should mention @");
+}
+
+#[test]
+fn email_rejects_empty_local_part() {
+    let err = DualIdentityConfig::new("user", "bot", "@example.com").unwrap_err();
+    assert!(err.to_string().contains("@"));
+}
+
+#[test]
+fn email_rejects_empty_domain() {
+    let err = DualIdentityConfig::new("user", "bot", "user@").unwrap_err();
+    assert!(err.to_string().contains("@"));
+}
+
+#[test]
+fn email_rejects_domain_without_dot() {
+    let err = DualIdentityConfig::new("user", "bot", "user@localhost").unwrap_err();
+    assert!(err.to_string().contains("domain"));
+}
+
+#[test]
+fn email_rejects_just_at() {
+    let err = DualIdentityConfig::new("user", "bot", "@").unwrap_err();
+    assert!(err.to_string().contains("@"));
+}
+
+#[test]
+fn email_accepts_valid_noreply_address() {
+    let config =
+        DualIdentityConfig::new("user", "bot", "123+user@users.noreply.github.com").unwrap();
+    assert_eq!(config.commit_email, "123+user@users.noreply.github.com");
+}
+
+// ===========================================================================
+// DualIdentityConfig — empty field rejection
+// ===========================================================================
+
+#[test]
+fn config_rejects_empty_commit_user() {
+    let err = DualIdentityConfig::new("user", "", "user@x.com").unwrap_err();
+    assert!(err.to_string().contains("empty"));
+}
+
+#[test]
+fn config_rejects_whitespace_only_copilot_user() {
+    let err = DualIdentityConfig::new("   ", "bot", "bot@x.com").unwrap_err();
+    assert!(err.to_string().contains("empty"));
+}
+
+#[test]
+fn config_rejects_whitespace_only_commit_email() {
+    let err = DualIdentityConfig::new("user", "bot", "   ").unwrap_err();
+    assert!(err.to_string().contains("empty"));
+}
+
+// ===========================================================================
+// DualIdentityConfig — serde roundtrip
+// ===========================================================================
+
+#[test]
+fn dual_identity_config_serde_roundtrip() {
+    let config = DualIdentityConfig::new("copilot-u", "commit-u", "c@x.com").unwrap();
+    let json = serde_json::to_string(&config).unwrap();
+    let back: DualIdentityConfig = serde_json::from_str(&json).unwrap();
+    assert_eq!(config, back);
+}
+
+// ===========================================================================
+// validate_identity_for_operation — exhaustive
+// ===========================================================================
+
+#[test]
+fn copilot_auth_accepts_all_copilot_operations() {
+    let ops = [
+        "copilot-chat",
+        "copilot-completions",
+        "copilot-submit",
+        "bridge-call",
+    ];
+    for op in ops {
+        validate_identity_for_operation(AuthIdentity::CopilotAuth, op)
+            .unwrap_or_else(|e| panic!("CopilotAuth should accept '{op}': {e}"));
+    }
+}
+
+#[test]
+fn commit_auth_accepts_all_commit_operations() {
+    let ops = ["git-commit", "git-push", "git-tag", "pr-create"];
+    for op in ops {
+        validate_identity_for_operation(AuthIdentity::CommitAuth, op)
+            .unwrap_or_else(|e| panic!("CommitAuth should accept '{op}': {e}"));
+    }
+}
+
+#[test]
+fn copilot_auth_rejects_all_commit_operations() {
+    let ops = ["git-commit", "git-push", "git-tag", "pr-create"];
+    for op in ops {
+        let err = validate_identity_for_operation(AuthIdentity::CopilotAuth, op).unwrap_err();
+        assert!(
+            err.to_string().contains("commit-auth"),
+            "CopilotAuth rejection of '{op}' should mention commit-auth"
+        );
+    }
+}
+
+#[test]
+fn commit_auth_rejects_all_copilot_operations() {
+    let ops = [
+        "copilot-chat",
+        "copilot-completions",
+        "copilot-submit",
+        "bridge-call",
+    ];
+    for op in ops {
+        let err = validate_identity_for_operation(AuthIdentity::CommitAuth, op).unwrap_err();
+        assert!(
+            err.to_string().contains("copilot-auth"),
+            "CommitAuth rejection of '{op}' should mention copilot-auth"
+        );
+    }
+}
+
+// ===========================================================================
+// identity_for_operation — exhaustive
+// ===========================================================================
+
+#[test]
+fn identity_for_operation_all_copilot_ops() {
+    let ops = [
+        "copilot-chat",
+        "copilot-completions",
+        "copilot-submit",
+        "bridge-call",
+    ];
+    for op in ops {
+        assert_eq!(
+            identity_for_operation(op),
+            Some(AuthIdentity::CopilotAuth),
+            "'{op}' should resolve to CopilotAuth"
+        );
+    }
+}
+
+#[test]
+fn identity_for_operation_all_commit_ops() {
+    let ops = ["git-commit", "git-push", "git-tag", "pr-create"];
+    for op in ops {
+        assert_eq!(
+            identity_for_operation(op),
+            Some(AuthIdentity::CommitAuth),
+            "'{op}' should resolve to CommitAuth"
+        );
+    }
+}
+
+#[test]
+fn identity_for_operation_unknown_returns_none() {
+    assert_eq!(identity_for_operation("build"), None);
+    assert_eq!(identity_for_operation("test"), None);
+    assert_eq!(identity_for_operation(""), None);
+}
+
+// ===========================================================================
+// env_for_identity — value correctness
+// ===========================================================================
+
+#[test]
+fn copilot_env_uses_copilot_user_value() {
+    let config = DualIdentityConfig::new("my-copilot", "my-commit", "c@x.com").unwrap();
+    let env = env_for_identity(AuthIdentity::CopilotAuth, &config);
+    assert_eq!(env.len(), 1);
+    assert_eq!(
+        env[0],
+        ("GITHUB_USER".to_string(), "my-copilot".to_string())
+    );
+}
+
+#[test]
+fn commit_env_uses_commit_user_and_email() {
+    let config = DualIdentityConfig::new("cop", "my-commit", "me@x.com").unwrap();
+    let env = env_for_identity(AuthIdentity::CommitAuth, &config);
+    let map: std::collections::HashMap<&str, &str> =
+        env.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
+    assert_eq!(map["GIT_AUTHOR_NAME"], "my-commit");
+    assert_eq!(map["GIT_AUTHOR_EMAIL"], "me@x.com");
+    assert_eq!(map["GIT_COMMITTER_NAME"], "my-commit");
+    assert_eq!(map["GIT_COMMITTER_EMAIL"], "me@x.com");
+}
+
+// ===========================================================================
+// default_identity_config — smoke
+// ===========================================================================
+
+#[test]
+fn default_identity_config_validates() {
+    let config = default_identity_config();
+    assert!(!config.copilot_user.is_empty());
+    assert!(!config.commit_user.is_empty());
+    assert!(config.commit_email.contains('@'));
+    assert!(config.commit_email.contains('.'));
+}
+
+#[test]
+fn default_identity_config_summary_contains_both_users() {
+    let config = default_identity_config();
+    let summary = config.summary();
+    assert!(summary.contains(&config.copilot_user));
+    assert!(summary.contains(&config.commit_user));
+    assert!(summary.contains(&config.commit_email));
+}

--- a/src/identity_composition.rs
+++ b/src/identity_composition.rs
@@ -147,6 +147,10 @@ pub fn compose_identity(
 }
 
 #[cfg(test)]
+#[path = "identity_composition_tests.rs"]
+mod coverage_tests;
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::agent_roles::identity_for_role;

--- a/src/identity_composition_tests.rs
+++ b/src/identity_composition_tests.rs
@@ -1,0 +1,179 @@
+//! Extended unit tests for the `identity_composition` module.
+//!
+//! Covers Display formatting, multi-subordinate compositions, zero-depth
+//! subordinates, and field propagation through compose_identity.
+//! No `skip_if_no_llm_provider` — every test here runs deterministically.
+
+use super::*;
+use crate::agent_roles::{AgentRole, identity_for_role};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn test_primary() -> crate::identity::IdentityManifest {
+    identity_for_role(AgentRole::Engineer).expect("primary manifest should be valid")
+}
+
+fn test_sub(role: AgentRole, name_suffix: &str, depth: u32) -> SubordinateIdentity {
+    let mut manifest = identity_for_role(role).expect("subordinate manifest should be valid");
+    manifest.name = format!("{}-{name_suffix}", role.identity_name());
+    SubordinateIdentity {
+        manifest,
+        role,
+        max_depth: depth,
+    }
+}
+
+// ===========================================================================
+// SubordinateIdentity — Display
+// ===========================================================================
+
+#[test]
+fn subordinate_identity_display_format() {
+    let sub = test_sub(AgentRole::Reviewer, "alpha", 3);
+    let display = sub.to_string();
+    assert!(
+        display.contains("role=reviewer"),
+        "should contain role: {display}"
+    );
+    assert!(
+        display.contains("depth=3"),
+        "should contain depth: {display}"
+    );
+    assert!(
+        display.contains(&sub.manifest.name),
+        "should contain name: {display}"
+    );
+}
+
+#[test]
+fn subordinate_identity_display_zero_depth() {
+    let sub = test_sub(AgentRole::GymRunner, "zero", 0);
+    let display = sub.to_string();
+    assert!(
+        display.contains("depth=0"),
+        "should show depth=0: {display}"
+    );
+}
+
+// ===========================================================================
+// CompositeIdentity — Display
+// ===========================================================================
+
+#[test]
+fn composite_identity_display_no_subordinates() {
+    let primary = test_primary();
+    let composite = compose_identity(primary.clone(), vec![]).unwrap();
+    let display = composite.to_string();
+    assert!(
+        display.starts_with("CompositeIdentity(primary="),
+        "should start correctly: {display}"
+    );
+    assert!(
+        !display.contains("subordinates="),
+        "no subordinates section when empty: {display}"
+    );
+    assert!(display.ends_with(')'), "should end with ): {display}");
+}
+
+#[test]
+fn composite_identity_display_with_subordinates() {
+    let primary = test_primary();
+    let sub = test_sub(AgentRole::Reviewer, "1", 2);
+    let composite = compose_identity(primary, vec![sub]).unwrap();
+    let display = composite.to_string();
+    assert!(display.contains("subordinates=["));
+    assert!(display.contains("role=reviewer"));
+}
+
+#[test]
+fn composite_identity_display_multiple_subordinates_comma_separated() {
+    let primary = test_primary();
+    let sub1 = test_sub(AgentRole::Reviewer, "a", 1);
+    let sub2 = test_sub(AgentRole::GymRunner, "b", 2);
+    let composite = compose_identity(primary, vec![sub1, sub2]).unwrap();
+    let display = composite.to_string();
+    // Should have comma separation between subordinates
+    assert!(
+        display.contains(", "),
+        "subordinates should be comma-separated: {display}"
+    );
+    assert!(display.contains("role=reviewer"));
+    assert!(display.contains("role=gym-runner"));
+}
+
+// ===========================================================================
+// compose_identity — multi-subordinate
+// ===========================================================================
+
+#[test]
+fn compose_identity_three_subordinates_succeeds() {
+    let primary = test_primary();
+    let sub1 = test_sub(AgentRole::Reviewer, "1", 1);
+    let sub2 = test_sub(AgentRole::GymRunner, "2", 2);
+    let sub3 = test_sub(AgentRole::Facilitator, "3", 0);
+    let composite = compose_identity(primary, vec![sub1, sub2, sub3]).unwrap();
+    assert_eq!(composite.subordinates.len(), 3);
+}
+
+#[test]
+fn compose_identity_preserves_subordinate_details() {
+    let primary = test_primary();
+    let sub = test_sub(AgentRole::Reviewer, "detail", 5);
+    let sub_name = sub.manifest.name.clone();
+    let composite = compose_identity(primary, vec![sub]).unwrap();
+    assert_eq!(composite.subordinates[0].manifest.name, sub_name);
+    assert_eq!(composite.subordinates[0].role, AgentRole::Reviewer);
+    assert_eq!(composite.subordinates[0].max_depth, 5);
+}
+
+#[test]
+fn compose_identity_same_role_different_names_succeeds() {
+    let primary = test_primary();
+    let sub1 = test_sub(AgentRole::Reviewer, "first", 1);
+    let sub2 = test_sub(AgentRole::Reviewer, "second", 1);
+    assert_ne!(
+        sub1.manifest.name, sub2.manifest.name,
+        "precondition: names must differ"
+    );
+    let composite = compose_identity(primary, vec![sub1, sub2]).unwrap();
+    assert_eq!(composite.subordinates.len(), 2);
+}
+
+#[test]
+fn compose_identity_zero_depth_subordinate_accepted() {
+    let primary = test_primary();
+    let sub = test_sub(AgentRole::GymRunner, "leaf", 0);
+    let composite = compose_identity(primary, vec![sub]).unwrap();
+    assert_eq!(composite.subordinates[0].max_depth, 0);
+}
+
+// ===========================================================================
+// compose_identity — error messages
+// ===========================================================================
+
+#[test]
+fn compose_identity_name_collision_error_mentions_memory_isolation() {
+    let primary = test_primary();
+    let mut sub = test_sub(AgentRole::Reviewer, "1", 1);
+    sub.manifest.name = primary.name.clone();
+    let err = compose_identity(primary, vec![sub]).unwrap_err();
+    assert!(
+        err.to_string().contains("memory isolation"),
+        "error should mention memory isolation: {err}"
+    );
+}
+
+#[test]
+fn compose_identity_duplicate_name_error_mentions_unique() {
+    let primary = test_primary();
+    let sub1 = test_sub(AgentRole::Reviewer, "dup", 1);
+    let mut sub2 = test_sub(AgentRole::GymRunner, "other", 1);
+    sub2.manifest.name = sub1.manifest.name.clone();
+    let err = compose_identity(primary, vec![sub1, sub2]).unwrap_err();
+    assert!(
+        err.to_string().contains("unique"),
+        "error should mention unique: {err}"
+    );
+}


### PR DESCRIPTION
## Summary

Add 67 deterministic unit tests for the identity module — the second target in #2213 (following the goals module tests in #2215).

### New test files

| File | Tests | Coverage |
|------|-------|----------|
| `src/identity/coverage_tests.rs` | 31 | ManifestContract trimming/edge cases, IdentityManifest field init & composition, compose_with_precedence conflict logging, BuiltinIdentityLoader catalog invariants, OperatingMode serde boundaries, MemoryPolicy scope inequality |
| `src/identity_auth_tests.rs` | 25 | AuthIdentity Display/serde, DualIdentityConfig trimming/serde, email validation edge cases, exhaustive operation validation, env_for_identity values, default config smoke tests |
| `src/identity_composition_tests.rs` | 11 | SubordinateIdentity/CompositeIdentity Display formatting, multi-subordinate composition, zero-depth subordinates, field propagation, error message assertions |

### What's covered

- **Validation edge cases**: whitespace trimming in contracts/configs, duplicate precedence after trim, malformed precedence entries, email validation (missing @, empty local/domain, no dot, just @)
- **Serde boundaries**: OperatingMode Display-vs-serde consistency, deserialization rejection of unknown strings, AuthIdentity and DualIdentityConfig roundtrips
- **Catalog invariants**: composite engineer has exactly 5 components with expected names, version/contract propagation from requests, all identities share required capabilities
- **Composition**: single-component compose, three-component capability union, contract preservation, conflict logging through compose_with_precedence
- **Identity auth**: exhaustive validation of all COPILOT_OPERATIONS and COMMIT_OPERATIONS, identity resolution for all known operations
- **Identity composition**: Display formatting with 0/1/N subordinates, error messages mention memory isolation and uniqueness

### Quality evidence

1. **Tests**: All 67 new tests pass. Full suite: 5,348 passed, 0 failed, 4 ignored.
2. **Docs**: No user-facing surfaces changed (test-only PR).
3. **Diff focused**: Only test files added + 3 lines of `#[cfg(test)]` wiring per parent module.
4. **No LLM dependency**: All tests are deterministic — no `skip_if_no_llm_provider` guards.

Closes the identity module target from #2213.