### PR TITLE
fix(tui): fix meeting tab INFO spam, input wrapping, and key routing

### DIFF
--- a/src/bin/simard_tui/app.rs
+++ b/src/bin/simard_tui/app.rs
@@ -47,10 +47,13 @@ impl Tab {
         }
     }
 
-    /// Map an Alt+digit key event to a tab. Alt+1 → Overview, Alt+2 → Goals, etc.
-    /// Bare digits (without ALT) are ignored to avoid stealing input on the Meeting tab.
+    /// Map an Alt+digit or Ctrl+digit key event to a tab.
+    /// Bare digits (without ALT/CTRL) are ignored to avoid stealing input on the Meeting tab.
     pub fn from_key(key: &KeyEvent) -> Option<Tab> {
-        if !key.modifiers.contains(KeyModifiers::ALT) {
+        if !key
+            .modifiers
+            .intersects(KeyModifiers::ALT | KeyModifiers::CONTROL)
+        {
             return None;
         }
         match key.code {
@@ -122,6 +125,7 @@ pub struct App {
     // Meeting tab
     pub meeting_status: MeetingStatus,
     pub meeting_input: String,
+    pub cursor_position: usize,
     pub meeting_output: Vec<String>,
     meeting_child: Option<std::process::Child>,
     meeting_stdin: Option<std::process::ChildStdin>,
@@ -152,6 +156,7 @@ impl App {
             log_lines: Vec::new(),
             meeting_status: MeetingStatus::NotStarted,
             meeting_input: String::new(),
+            cursor_position: 0,
             meeting_output: Vec::new(),
             meeting_child: None,
             meeting_stdin: None,
@@ -165,26 +170,77 @@ impl App {
 
     /// Handle a key press event.
     ///
-    /// - `Alt+1`–`Alt+6`: switch tabs (always, even in meeting mode)
-    /// - `←`/`→`: cycle tabs with wrapping (always)
+    /// - `Alt+1`–`Alt+6` / `Ctrl+1`–`Ctrl+6`: switch tabs (always)
+    /// - `Tab`/`Shift+Tab`: cycle tabs forward/backward (always)
     /// - On Meeting tab with Running: chars → input, Enter → send,
-    ///   Backspace → delete, Esc → stop meeting
+    ///   Backspace → delete, Left/Right → cursor, Esc → stop meeting
+    /// - `←`/`→`: cycle tabs with wrapping (when not in active meeting)
     /// - `q`/`Q`: quit (unless meeting is Running on Meeting tab)
     pub fn handle_key(&mut self, key: KeyEvent) {
         let code = key.code;
 
-        // Alt+digit tab switch always works regardless of mode
+        // Alt+digit or Ctrl+digit tab switch always works regardless of mode
         if let Some(tab) = Tab::from_key(&key) {
             self.active_tab = tab;
             return;
         }
 
-        // Left/Right arrow tab cycling always works
+        // Tab/Shift+Tab tab cycling always works
         let tab_count = ALL_TABS.len();
         let current_idx = ALL_TABS
             .iter()
             .position(|t| *t == self.active_tab)
             .unwrap_or(0);
+        match code {
+            KeyCode::Tab => {
+                self.active_tab = ALL_TABS[(current_idx + 1) % tab_count];
+                return;
+            }
+            KeyCode::BackTab => {
+                self.active_tab = ALL_TABS[(current_idx + tab_count - 1) % tab_count];
+                return;
+            }
+            _ => {}
+        }
+
+        // Meeting-specific input routing (before arrow tab cycling)
+        if self.active_tab == Tab::Meeting && self.meeting_status == MeetingStatus::Running {
+            match code {
+                KeyCode::Enter => self.send_meeting_input(),
+                KeyCode::Backspace if self.cursor_position > 0 => {
+                    let prev = self.meeting_input[..self.cursor_position]
+                        .char_indices()
+                        .next_back()
+                        .map(|(i, _)| i)
+                        .unwrap_or(0);
+                    self.meeting_input.remove(prev);
+                    self.cursor_position = prev;
+                }
+                KeyCode::Left if self.cursor_position > 0 => {
+                    self.cursor_position = self.meeting_input[..self.cursor_position]
+                        .char_indices()
+                        .next_back()
+                        .map(|(i, _)| i)
+                        .unwrap_or(0);
+                }
+                KeyCode::Right if self.cursor_position < self.meeting_input.len() => {
+                    self.cursor_position = self.meeting_input[self.cursor_position..]
+                        .char_indices()
+                        .nth(1)
+                        .map(|(i, _)| self.cursor_position + i)
+                        .unwrap_or(self.meeting_input.len());
+                }
+                KeyCode::Esc => self.stop_meeting(),
+                KeyCode::Char(c) if self.meeting_input.len() < 4096 => {
+                    self.meeting_input.insert(self.cursor_position, c);
+                    self.cursor_position += c.len_utf8();
+                }
+                _ => {}
+            }
+            return;
+        }
+
+        // Left/Right arrow tab cycling (outside active meeting)
         match code {
             KeyCode::Right => {
                 self.active_tab = ALL_TABS[(current_idx + 1) % tab_count];
@@ -195,22 +251,6 @@ impl App {
                 return;
             }
             _ => {}
-        }
-
-        // Meeting-specific input routing
-        if self.active_tab == Tab::Meeting && self.meeting_status == MeetingStatus::Running {
-            match code {
-                KeyCode::Enter => self.send_meeting_input(),
-                KeyCode::Backspace => {
-                    self.meeting_input.pop();
-                }
-                KeyCode::Esc => self.stop_meeting(),
-                KeyCode::Char(c) if self.meeting_input.len() < 4096 => {
-                    self.meeting_input.push(c);
-                }
-                _ => {}
-            }
-            return;
         }
 
         // Default key handling
@@ -243,9 +283,8 @@ impl App {
             }
         }
         self.meeting_input.clear();
+        self.cursor_position = 0;
     }
-
-    /// Stop the meeting process.
     fn stop_meeting(&mut self) {
         if let Some(ref mut child) = self.meeting_child {
             let _ = child.kill();
@@ -255,6 +294,7 @@ impl App {
         self.meeting_stdin = None;
         self.meeting_stdout = None;
         self.meeting_status = MeetingStatus::Exited(0);
+        self.cursor_position = 0;
     }
 
     /// Spawn the meeting child process.
@@ -322,6 +362,10 @@ impl App {
                 match reader.read_line(&mut line) {
                     Ok(0) => break,
                     Ok(_) => {
+                        // Filter noisy INFO log lines from meeting subprocess
+                        if line.contains(" INFO ") {
+                            continue;
+                        }
                         self.meeting_output.push(line.trim_end().to_string());
                         if self.meeting_output.len() > 1000 {
                             let excess = self.meeting_output.len() - 1000;
@@ -988,6 +1032,7 @@ mod tests {
         app.active_tab = Tab::Meeting;
         app.meeting_status = MeetingStatus::Running;
         app.meeting_input = "hello".to_string();
+        app.cursor_position = app.meeting_input.len();
         app.handle_key(key_code(KeyCode::Backspace));
         assert_eq!(app.meeting_input, "hell");
     }
@@ -1007,6 +1052,7 @@ mod tests {
         app.active_tab = Tab::Meeting;
         app.meeting_status = MeetingStatus::Running;
         app.meeting_input = "hello world".to_string();
+        app.cursor_position = app.meeting_input.len();
         app.handle_key(key_code(KeyCode::Enter));
         assert!(app.meeting_input.is_empty());
     }
@@ -1017,6 +1063,7 @@ mod tests {
         app.active_tab = Tab::Meeting;
         app.meeting_status = MeetingStatus::Running;
         app.meeting_input = "test input".to_string();
+        app.cursor_position = app.meeting_input.len();
         let before = app.meeting_output.len();
         app.handle_key(key_code(KeyCode::Enter));
         assert!(app.meeting_output.len() > before);
@@ -1068,6 +1115,7 @@ mod tests {
         app.active_tab = Tab::Meeting;
         app.meeting_status = MeetingStatus::Running;
         app.meeting_input = "x".repeat(4096);
+        app.cursor_position = app.meeting_input.len();
         app.handle_key(key('a'));
         assert!(app.meeting_input.len() <= 4096);
     }
@@ -1079,6 +1127,7 @@ mod tests {
         app.active_tab = Tab::Meeting;
         app.meeting_status = MeetingStatus::Running;
         app.meeting_input = "overflow".to_string();
+        app.cursor_position = app.meeting_input.len();
         app.handle_key(key_code(KeyCode::Enter));
         assert!(app.meeting_output.len() <= 1000);
     }
@@ -1493,13 +1542,17 @@ mod tests {
 
     #[test]
     fn handle_key_arrows_work_during_meeting_running() {
-        // Arrow keys should cycle tabs even when meeting is running
+        // Arrow keys should move cursor in input, NOT cycle tabs, when meeting is running
         let mut app = App::new("simard-ooda.service".to_string());
         app.active_tab = Tab::Meeting; // index 4
         app.meeting_status = MeetingStatus::Running;
 
         app.handle_key(key_code(KeyCode::Right));
-        assert_eq!(app.active_tab, Tab::Stats); // index 5
+        assert_eq!(
+            app.active_tab,
+            Tab::Meeting,
+            "arrow should stay on Meeting tab"
+        );
     }
 
     // ── BUG1: Bare digit regression ────────────────────────────────
@@ -1535,6 +1588,122 @@ mod tests {
     }
 
     // ── BUG2: load_pid_categories ──────────────────────────────────
+
+    // ── Cursor movement tests ──────────────────────────────────────
+
+    #[test]
+    fn meeting_cursor_left_right_movement() {
+        let mut app = App::new("simard-ooda.service".to_string());
+        app.active_tab = Tab::Meeting;
+        app.meeting_status = MeetingStatus::Running;
+        // Type "abc"
+        app.handle_key(key('a'));
+        app.handle_key(key('b'));
+        app.handle_key(key('c'));
+        assert_eq!(app.cursor_position, 3);
+
+        // Move left twice
+        app.handle_key(key_code(KeyCode::Left));
+        assert_eq!(app.cursor_position, 2);
+        app.handle_key(key_code(KeyCode::Left));
+        assert_eq!(app.cursor_position, 1);
+
+        // Insert 'X' at position 1
+        app.handle_key(key('X'));
+        assert_eq!(app.meeting_input, "aXbc");
+        assert_eq!(app.cursor_position, 2);
+
+        // Move right
+        app.handle_key(key_code(KeyCode::Right));
+        assert_eq!(app.cursor_position, 3);
+    }
+
+    #[test]
+    fn meeting_cursor_left_at_start_is_noop() {
+        let mut app = App::new("simard-ooda.service".to_string());
+        app.active_tab = Tab::Meeting;
+        app.meeting_status = MeetingStatus::Running;
+        assert_eq!(app.cursor_position, 0);
+        app.handle_key(key_code(KeyCode::Left));
+        assert_eq!(app.cursor_position, 0);
+    }
+
+    #[test]
+    fn meeting_cursor_right_at_end_is_noop() {
+        let mut app = App::new("simard-ooda.service".to_string());
+        app.active_tab = Tab::Meeting;
+        app.meeting_status = MeetingStatus::Running;
+        app.handle_key(key('a'));
+        assert_eq!(app.cursor_position, 1);
+        app.handle_key(key_code(KeyCode::Right));
+        assert_eq!(app.cursor_position, 1); // still at end
+    }
+
+    #[test]
+    fn meeting_backspace_at_cursor_middle() {
+        let mut app = App::new("simard-ooda.service".to_string());
+        app.active_tab = Tab::Meeting;
+        app.meeting_status = MeetingStatus::Running;
+        app.meeting_input = "abcd".to_string();
+        app.cursor_position = 2; // after 'b'
+        app.handle_key(key_code(KeyCode::Backspace));
+        assert_eq!(app.meeting_input, "acd");
+        assert_eq!(app.cursor_position, 1);
+    }
+
+    // ── Tab/BackTab cycling ────────────────────────────────────────
+
+    #[test]
+    fn tab_key_cycles_forward() {
+        let mut app = App::new("simard-ooda.service".to_string());
+        assert_eq!(app.active_tab, Tab::Overview);
+        app.handle_key(key_code(KeyCode::Tab));
+        assert_eq!(app.active_tab, Tab::Goals);
+    }
+
+    #[test]
+    fn backtab_cycles_backward() {
+        let mut app = App::new("simard-ooda.service".to_string());
+        app.active_tab = Tab::Goals;
+        app.handle_key(key_code(KeyCode::BackTab));
+        assert_eq!(app.active_tab, Tab::Overview);
+    }
+
+    #[test]
+    fn tab_key_works_during_meeting_running() {
+        // Tab key should still cycle tabs even when meeting is active
+        let mut app = App::new("simard-ooda.service".to_string());
+        app.active_tab = Tab::Meeting;
+        app.meeting_status = MeetingStatus::Running;
+        app.handle_key(key_code(KeyCode::Tab));
+        assert_eq!(app.active_tab, Tab::Stats);
+    }
+
+    // ── Ctrl+digit tab switch ──────────────────────────────────────
+
+    #[test]
+    fn ctrl_digit_switches_tab() {
+        let mut app = App::new("simard-ooda.service".to_string());
+        assert_eq!(app.active_tab, Tab::Overview);
+        let ctrl_3 = KeyEvent::new(KeyCode::Char('3'), KeyModifiers::CONTROL);
+        app.handle_key(ctrl_3);
+        assert_eq!(app.active_tab, Tab::Engineers);
+    }
+
+    // ── Arrows still cycle tabs when meeting is NOT running ────────
+
+    #[test]
+    fn arrows_cycle_tabs_when_meeting_not_running() {
+        let mut app = App::new("simard-ooda.service".to_string());
+        app.active_tab = Tab::Meeting;
+        // meeting_status defaults to NotStarted
+        app.handle_key(key_code(KeyCode::Right));
+        assert_eq!(
+            app.active_tab,
+            Tab::Stats,
+            "arrows should cycle tabs when meeting is not running"
+        );
+    }
 
     #[test]
     fn load_pid_categories_valid_json() {

--- a/src/bin/simard_tui/tabs/meeting.rs
+++ b/src/bin/simard_tui/tabs/meeting.rs
@@ -3,7 +3,7 @@
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::text::Line;
-use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
 
 use crate::app::{App, MeetingStatus};
 
@@ -11,7 +11,7 @@ use crate::app::{App, MeetingStatus};
 pub fn draw(f: &mut Frame, app: &App, area: Rect) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Min(3), Constraint::Length(3)])
+        .constraints([Constraint::Min(3), Constraint::Length(5)])
         .split(area);
 
     // Title shows meeting status
@@ -38,7 +38,8 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
 
     // Input prompt
     let input_text = format!("> {}", app.meeting_input);
-    let input =
-        Paragraph::new(input_text).block(Block::default().borders(Borders::ALL).title("Input"));
+    let input = Paragraph::new(input_text)
+        .block(Block::default().borders(Borders::ALL).title("Input"))
+        .wrap(Wrap { trim: false });
     f.render_widget(input, chunks[1]);
 }


### PR DESCRIPTION
## Summary

Fixes three TUI meeting bugs described in #2224.

### BUG A — INFO message spam
Filter lines containing ` INFO ` in `drain_meeting_output()` before pushing to `meeting_output`, suppressing noisy log lines from the meeting subprocess.

### BUG B — Input box no wrap
- Import `Wrap` from `ratatui::widgets`
- Add `.wrap(Wrap { trim: false })` to input Paragraph
- Increase input area constraint from `Length(3)` to `Length(5)` for 3 visible lines plus borders

### BUG C — Number keys intercepted for tab navigation
- Add `cursor_position: usize` field to `App` for UTF-8-safe cursor tracking
- Restructure `handle_key()`: meeting input routing now takes priority over arrow tab cycling when meeting is active and running
- Left/Right arrows move cursor within input during active meeting
- Add `Tab`/`Shift+Tab` (BackTab) for tab cycling (always works)
- Add `Ctrl+digit` tab switching alongside existing `Alt+digit`
- Character insertion uses `String::insert()` at cursor position with `len_utf8()` for Unicode safety
- Backspace removes char at cursor position using char boundary detection

### Tests
- Updated `handle_key_arrows_work_during_meeting_running` to assert correct behavior (stays on Meeting tab)
- Added 9 new tests: cursor movement (left/right/bounds), mid-string backspace, Tab/BackTab cycling, Ctrl+digit switching, arrows-cycle-when-not-running

### Files changed
- `src/bin/simard_tui/app.rs` — key handling, cursor_position field, tests
- `src/bin/simard_tui/tabs/meeting.rs` — wrap + constraint

### Verification
- `cargo test --bin simard-tui`: 172 tests pass (0 failures)
- `cargo clippy --bin simard-tui -- -D warnings`: clean
- Pre-commit hooks: passed (fmt, clippy)
- Pre-push hooks: passed (release tests, full clippy)
- Diff is focused on the two files specified in #2224; no unrelated edits

### Surfaces changed
All changes are internal TUI binary (`simard-tui`). No user-facing API, CLI flags, or documentation surfaces changed — internal-only.

Closes #2224