### PR TITLE
fix(decide): route EvalWatchdog to RunGymEval, add defense guard (#2227)

### DIFF
--- a/src/ooda_brain/decide.rs
+++ b/src/ooda_brain/decide.rs
@@ -138,9 +138,8 @@ impl OodaDecideBrain for DeterministicFallbackDecideBrain {
             }
             Some(SyntheticPriorityKind::ExtractIdeas) => DecideJudgment::ExtractIdeas { rationale },
             Some(SyntheticPriorityKind::SafeUpdate) => DecideJudgment::SafeUpdate { rationale },
-            Some(SyntheticPriorityKind::EvalWatchdog) | None => {
-                DecideJudgment::AdvanceGoal { rationale }
-            }
+            Some(SyntheticPriorityKind::EvalWatchdog) => DecideJudgment::RunGymEval { rationale },
+            None => DecideJudgment::AdvanceGoal { rationale },
         };
         Ok(judgment)
     }

--- a/src/ooda_brain/decide_tests.rs
+++ b/src/ooda_brain/decide_tests.rs
@@ -5,7 +5,7 @@
 //! DeterministicFallbackDecideBrain routing table.
 
 use super::{DecideContext, DecideJudgment, DeterministicFallbackDecideBrain, OodaDecideBrain};
-use crate::ooda_loop::ActionKind;
+use crate::ooda_loop::{ActionKind, SyntheticPriorityKind};
 
 fn ctx(goal_id: &str) -> DecideContext {
     DecideContext {
@@ -102,3 +102,33 @@ fn fallback_routes_ordinary_goal_to_advance_goal() {
 // (Wire-in tests live in `src/ooda_loop/decide.rs` since `decide_with_brain`
 // is a private module item; co-locating tests with the function avoids
 // adding a public re-export just for tests.)
+
+// ---------------------------------------------------------------------------
+// Issue #2227: EvalWatchdog must NOT produce AdvanceGoal
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fallback_routes_eval_watchdog_to_run_gym_eval() {
+    let brain = DeterministicFallbackDecideBrain;
+    let j = brain.judge_decision(&ctx("__eval_watchdog__")).unwrap();
+    assert_eq!(
+        j.action_kind(),
+        ActionKind::RunGymEval,
+        "EvalWatchdog must route to RunGymEval, not AdvanceGoal (issue #2227)"
+    );
+}
+
+#[test]
+fn all_synthetic_priorities_produce_non_advance_goal_actions() {
+    // Every synthetic priority gets goal_id=None in decide_with_brain.
+    // AdvanceGoal requires goal_id, so no synthetic must route there.
+    let brain = DeterministicFallbackDecideBrain;
+    for kind in SyntheticPriorityKind::all() {
+        let j = brain.judge_decision(&ctx(kind.synthetic_id())).unwrap();
+        assert_ne!(
+            j.action_kind(),
+            ActionKind::AdvanceGoal,
+            "synthetic priority {kind:?} must not route to AdvanceGoal (would fail at dispatch with goal_id=None)"
+        );
+    }
+}

--- a/src/ooda_loop/decide.rs
+++ b/src/ooda_loop/decide.rs
@@ -15,7 +15,7 @@ use crate::ooda_brain::{
     DeterministicFallbackDecideBrain, OodaDecideBrain, push_brain_judgment,
 };
 
-use super::{OodaConfig, PlannedAction, Priority, is_synthetic_id};
+use super::{ActionKind, OodaConfig, PlannedAction, Priority, is_synthetic_id};
 
 /// Decide using the deterministic fallback brain. This is the entrypoint
 /// the daemon's Act phase calls today; it preserves the pre-#1458 routing
@@ -100,7 +100,7 @@ pub fn decide_with_brain(
                 j
             }
         };
-        actions.push(PlannedAction {
+        let planned = PlannedAction {
             kind: judgment.action_kind(),
             goal_id: if is_synthetic_id(&priority.goal_id) {
                 None
@@ -108,7 +108,18 @@ pub fn decide_with_brain(
                 Some(priority.goal_id.clone())
             },
             description: priority.reason.clone(),
-        });
+        };
+        // Defense-in-depth: AdvanceGoal without goal_id is unroutable at
+        // dispatch (issue #2227). Skip rather than push an action that will
+        // always fail.
+        if planned.kind == ActionKind::AdvanceGoal && planned.goal_id.is_none() {
+            tracing::warn!(
+                priority_goal_id = %priority.goal_id,
+                "skipping AdvanceGoal with goal_id=None (synthetic priority mis-routed)"
+            );
+            continue;
+        }
+        actions.push(planned);
     }
     Ok(actions)
 }
@@ -553,5 +564,66 @@ mod tests {
             1,
             "without scaler, max_concurrent_actions=1 should cap to 1"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Issue #2227: eval-watchdog routing and defense-in-depth guard
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn decide_maps_eval_watchdog_to_run_gym_eval() {
+        let priorities = vec![Priority {
+            goal_id: "__eval_watchdog__".to_string(),
+            urgency: 1.0,
+            reason: "eval signal stale".to_string(),
+        }];
+        let config = OodaConfig::default();
+        let actions = decide(&priorities, &config).unwrap();
+        assert_eq!(actions.len(), 1);
+        assert_eq!(
+            actions[0].kind,
+            ActionKind::RunGymEval,
+            "EvalWatchdog must route to RunGymEval, not AdvanceGoal (issue #2227)"
+        );
+        assert!(actions[0].goal_id.is_none());
+    }
+
+    #[test]
+    fn decide_guard_skips_advance_goal_with_no_goal_id() {
+        // A mis-routing brain that always returns AdvanceGoal, even for
+        // synthetic priorities. The defense-in-depth guard must skip.
+        struct AlwaysAdvanceBrain;
+        impl OodaDecideBrain for AlwaysAdvanceBrain {
+            fn judge_decision(
+                &self,
+                _ctx: &DecideContext,
+            ) -> crate::error::SimardResult<DecideJudgment> {
+                Ok(DecideJudgment::AdvanceGoal {
+                    rationale: "mis-routed".to_string(),
+                })
+            }
+        }
+        let priorities = vec![
+            Priority {
+                goal_id: "__memory__".to_string(),
+                urgency: 0.8,
+                reason: "synthetic".to_string(),
+            },
+            Priority {
+                goal_id: "real-goal".to_string(),
+                urgency: 0.7,
+                reason: "real".to_string(),
+            },
+        ];
+        let config = OodaConfig::default();
+        let actions = decide_with_brain(&priorities, &config, &AlwaysAdvanceBrain).unwrap();
+        // The synthetic priority should be skipped, the real goal should pass.
+        assert_eq!(
+            actions.len(),
+            1,
+            "guard must skip synthetic AdvanceGoal+None"
+        );
+        assert_eq!(actions[0].goal_id, Some("real-goal".to_string()));
+        assert_eq!(actions[0].kind, ActionKind::AdvanceGoal);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #2227 — OODA decide phase produces `AdvanceGoal` action with `goal_id=None`, causing 1/5 actions to fail every cycle.

## Root Cause

`DeterministicFallbackDecideBrain` mapped `EvalWatchdog` to `AdvanceGoal`, but synthetic priorities get `goal_id=None` in `decide_with_brain`. The dispatcher rejects `AdvanceGoal` without a `goal_id`, so this action always failed.

## Changes

### Root cause fix (`src/ooda_brain/decide.rs`)
- `EvalWatchdog` → `RunGymEval` (was `AdvanceGoal`)
- `RunGymEval` doesn't require a `goal_id` — it runs the gym suite

### Defense-in-depth guard (`src/ooda_loop/decide.rs`)
- After constructing `PlannedAction`, skip any `AdvanceGoal` with `goal_id=None`
- Emits `tracing::warn!` so the mis-routing is visible in logs

### Tests
- `fallback_routes_eval_watchdog_to_run_gym_eval` — brain routing test
- `all_synthetic_priorities_produce_non_advance_goal_actions` — invariant test
- `decide_maps_eval_watchdog_to_run_gym_eval` — end-to-end wire-in
- `decide_guard_skips_advance_goal_with_no_goal_id` — defense guard test

## Verification
After deploying, `ooda.log` should show 5/5 actions succeeding (was 4/5).