### PR TITLE
dashboard: add OTEL glossary tooltips and time-series trend charts

### DIFF
--- a/src/operator_commands_dashboard/index_html/part_01.rs
+++ b/src/operator_commands_dashboard/index_html/part_01.rs
@@ -17,6 +17,10 @@ pub(crate) const PART_01: &str = r#"      </div>
   <div class="tab-content" id="tab-merge-decisions">
     <h1 class="page-h1">Merge Decisions</h1>
     <p class="page-lede">A record of every pull request the merge judge has evaluated — which PRs were approved, rejected, or deferred, along with the reasoning and timestamp for each decision.</p>
+    <div class="card" style="max-width:980px;margin-bottom:1rem">
+      <h2>Decision Trend</h2>
+      <div id="merge-judge-trend"><span style="color:#8b949e;font-size:.85rem">Trend chart will appear once decision data is available.</span></div>
+    </div>
     <div class="card" style="max-width:980px">
       <h2>Decision History <button class="btn" onclick="fetchMergeJudge()" style="font-size:.75rem">Refresh</button></h2>
       <div id="merge-judge-panel"><span class="loading">Loading…</span></div>

--- a/src/operator_commands_dashboard/index_html/part_04.rs
+++ b/src/operator_commands_dashboard/index_html/part_04.rs
@@ -303,7 +303,7 @@ pub(crate) const PART_04: &str = r#"            let fmt;
         if(trend.detail){trendHtml+=`<div style="color:#8b949e;font-size:.8rem">${esc(trend.detail)}</div>`;}
         trendHtml+='</div>';
         trendEl.innerHTML=trendHtml;
-        // Duration bar chart (inline SVG)
+        // Duration trend line chart (inline SVG) — #2223
         if(cycles.length){
           const durations=cycles.map(c=>c.duration_secs||0).reverse();
           const nums=cycles.map(c=>c.cycle_number).reverse();
@@ -315,10 +315,26 @@ pub(crate) const PART_04: &str = r#"            let fmt;
             const h=Math.max(2,(d/maxD)*chartH);
             const x=i*(barW+2);
             const color=d===0?borderClr:'var(--accent)';
-            return `<rect x="${x}" y="${chartH-h}" width="${barW}" height="${h}" fill="${color}" rx="1"><title>Cycle ${nums[i]}: ${d}s</title></rect>`;
+            return `<rect x="${x}" y="${chartH-h}" width="${barW}" height="${h}" fill="${color}" rx="1" opacity="0.4"><title>Cycle ${nums[i]}: ${d}s</title></rect>`;
           }).join('');
           const svgW=durations.length*(barW+2);
-          trendEl.innerHTML+=`<div style="margin-top:.5rem;overflow-x:auto"><svg width="${svgW}" height="${chartH+16}" style="display:block"><g>${bars}</g><line x1="0" y1="${chartH}" x2="${svgW}" y2="${chartH}" stroke="${borderClr}" stroke-width="1"/></svg></div>`;
+          // Compute trend line points
+          const linePoints=durations.map((d,i)=>{
+            const x=i*(barW+2)+barW/2;
+            const y=chartH-Math.max(2,(d/maxD)*chartH)+1;
+            return `${x},${y}`;
+          }).join(' ');
+          // Moving average line (window=3) for smoothed trend
+          const maWindow=Math.min(3,Math.max(1,Math.floor(durations.length/3)));
+          const maPoints=durations.map((d,i)=>{
+            const start=Math.max(0,i-maWindow+1);
+            const slice=durations.slice(start,i+1);
+            const avg=slice.reduce((a,b)=>a+b,0)/slice.length;
+            const x=i*(barW+2)+barW/2;
+            const y=chartH-Math.max(2,(avg/maxD)*chartH)+1;
+            return `${x},${y}`;
+          }).join(' ');
+          trendEl.innerHTML+=`<div style="margin-top:.5rem;overflow-x:auto" data-testid="ooda-cycle-trend-chart"><svg width="${svgW}" height="${chartH+16}" style="display:block"><g>${bars}</g><polyline points="${linePoints}" fill="none" stroke="var(--accent)" stroke-width="1.5" opacity="0.7"/><polyline points="${maPoints}" fill="none" stroke="var(--green)" stroke-width="2" stroke-dasharray="4,2" data-testid="ooda-trend-line"><title>Moving average trend</title></polyline><line x1="0" y1="${chartH}" x2="${svgW}" y2="${chartH}" stroke="${borderClr}" stroke-width="1"/></svg><div style="display:flex;gap:1rem;font-size:.75rem;color:#8b949e;margin-top:.3rem"><span><span style="color:var(--accent)">━</span> Duration per cycle</span><span><span style="color:var(--green)">╌</span> Moving average</span></div></div>`;
         }
         // History table
         if(!cycles.length){histEl.innerHTML='<span style="color:#8b949e">No cycle history available. Run the agent daemon to generate cycle data.</span>';return;}

--- a/src/operator_commands_dashboard/index_html/part_05.rs
+++ b/src/operator_commands_dashboard/index_html/part_05.rs
@@ -111,12 +111,58 @@ pub(crate) const PART_05: &str = r#"      try {
     /* --- Merge Judge Decisions (#2041) --- */
     async function fetchMergeJudge(){
       const el=document.getElementById('merge-judge-panel');
+      const trendEl=document.getElementById('merge-judge-trend');
       if(!el) return;
       try {
         const d = await apiFetch('/api/merge-judge');
         const persistenceAvailable = !!d.persistence_available;
         const decisions = Array.isArray(d.decisions) ? d.decisions : [];
         const summary = d.summary || {};
+
+        // Render approval-rate-over-time trend chart (#2223)
+        if(trendEl){
+          if(decisions.length>=2){
+            const sorted=decisions.slice().sort(function(a,b){return (a.evaluated_at||'').localeCompare(b.evaluated_at||'');});
+            const chartW=Math.min(600,Math.max(200,sorted.length*30));
+            const chartH=80;
+            const pad=2;
+            let cumApproved=0,cumTotal=0;
+            const rates=sorted.map(function(dec){
+              cumTotal++;
+              if(dec.verdict==='ready') cumApproved++;
+              return {rate:cumTotal>0?cumApproved/cumTotal:0,label:'PR #'+(dec.pr_number||'?'),time:dec.evaluated_at||''};
+            });
+            const stepX=rates.length>1?(chartW-pad*2)/(rates.length-1):0;
+            const points=rates.map(function(r,i){
+              const x=pad+i*stepX;
+              const y=chartH-pad-(r.rate*(chartH-pad*2));
+              return x+','+y;
+            }).join(' ');
+            const dots=rates.map(function(r,i){
+              const x=pad+i*stepX;
+              const y=chartH-pad-(r.rate*(chartH-pad*2));
+              const pct=Math.round(r.rate*100);
+              return '<circle cx="'+x+'" cy="'+y+'" r="3" fill="var(--green)" stroke="var(--bg)" stroke-width="1"><title>'+esc(r.label)+': '+pct+'% approved ('+r.time+')</title></circle>';
+            }).join('');
+            const finalRate=rates.length?Math.round(rates[rates.length-1].rate*100):0;
+            trendEl.innerHTML='<div style="display:flex;align-items:center;gap:1rem;margin-bottom:.5rem">'
+              +'<span style="font-size:.85rem;color:#8b949e">Cumulative approval rate over time</span>'
+              +'<strong style="color:var(--green)">'+finalRate+'%</strong>'
+              +'</div>'
+              +'<div style="overflow-x:auto" data-testid="merge-judge-trend-chart">'
+              +'<svg width="'+chartW+'" height="'+(chartH+4)+'" style="display:block">'
+              +'<line x1="'+pad+'" y1="'+(chartH/2)+'" x2="'+(chartW-pad)+'" y2="'+(chartH/2)+'" stroke="var(--border)" stroke-width="1" stroke-dasharray="4,4"/>'
+              +'<polyline points="'+points+'" fill="none" stroke="var(--green)" stroke-width="2" data-testid="merge-trend-line"/>'
+              +dots
+              +'<line x1="'+pad+'" y1="'+chartH+'" x2="'+(chartW-pad)+'" y2="'+chartH+'" stroke="var(--border)" stroke-width="1"/>'
+              +'</svg>'
+              +'<div style="display:flex;justify-content:space-between;font-size:.7rem;color:#8b949e;margin-top:.2rem"><span>0%</span><span>50%</span><span>100%</span></div></div>';
+          }else if(!persistenceAvailable){
+            trendEl.innerHTML='<span style="color:#8b949e;font-size:.85rem">Trend chart will appear once decision data is available.</span>';
+          }else{
+            trendEl.innerHTML='<span style="color:#8b949e;font-size:.85rem">Need at least 2 decisions to render a trend chart.</span>';
+          }
+        }
 
         if(!persistenceAvailable && decisions.length === 0){
           el.innerHTML =
@@ -349,6 +395,8 @@ pub(crate) const PART_05: &str = r#"      try {
       'daemon':'The background process that runs Simard\u2019s autonomous decision-making loop continuously.',
       'cycle':'One complete pass through the decision loop — observe the environment, orient priorities, decide on an action, and act on it.',
       'gym':'A training environment where Simard practices and improves its skills on synthetic scenarios.',
+      'OTEL':'OpenTelemetry — an open standard for collecting distributed traces, metrics, and logs from software systems.',
+      'OpenTelemetry':'An open-source observability framework for generating, collecting, and exporting telemetry data (traces, metrics, logs) from distributed systems.',
     };
     function toggleGlossary(){
       const p=document.getElementById('glossary-panel');


### PR DESCRIPTION
## Summary

Addresses two cycle-4 dashboard gaps identified in the audit (#2220):

### OTEL/OpenTelemetry glossary tooltips (fixes #2222)

Added `OTEL` and `OpenTelemetry` entries to the dashboard's `GLOSSARY` object. The existing `annotateJargon()` function automatically wraps these terms with `<abbr>` tooltips wherever they appear (primarily in the Traces tab's heading, status display, and setup instructions). Hovering any instance shows a plain-English definition. The terms also appear in the slide-out glossary panel.

### Time-series trend charts (fixes #2223)

**OODA Cycles tab** — Upgraded the existing duration bar chart to a combined bar + line chart with:
- A per-cycle duration line (solid accent color)
- A moving-average trend line (dashed green) for smoothed trend visibility
- A legend distinguishing the two series
- `data-testid="ooda-cycle-trend-chart"` and `data-testid="ooda-trend-line"` for e2e testability

**Merge Decisions tab** — Added a new "Decision Trend" card above the existing "Decision History" card containing:
- A cumulative approval-rate-over-time SVG line chart (renders when ≥2 decisions exist)
- Interactive dot tooltips showing PR number, approval %, and timestamp
- A 50% reference line and axis labels (0%/50%/100%)
- Graceful empty states when persistence is unavailable or data is insufficient
- `data-testid="merge-judge-trend-chart"` and `data-testid="merge-trend-line"` for e2e testability

## Files changed (3 files, 71 insertions, 3 deletions)

| File | Change |
|------|--------|
| `src/operator_commands_dashboard/index_html/part_05.rs` | Added OTEL/OpenTelemetry glossary entries; added approval-rate trend chart in `fetchMergeJudge()` |
| `src/operator_commands_dashboard/index_html/part_04.rs` | Upgraded OODA cycles bar chart to bar+line with moving-average trend line |
| `src/operator_commands_dashboard/index_html/part_01.rs` | Added `merge-judge-trend` container div in the Merge Decisions tab |

## Merge-ready evidence

1. **Tests**: All 256 `operator_commands_dashboard` tests and all 22 `tests_tab_meta` cross-check tests pass (0 failures).
2. **Docs**: Changes are internal dashboard UI — no user-facing documentation surfaces affected.
3. **Pre-commit**: `cargo fmt`, `cargo clippy` (release + all-features), rust-only gate all pass.
4. **Pre-push**: `cargo test --release` (cognitive_memory/bootstrap/memory_ipc/memory_consolidation) + `cargo clippy --all-targets --all-features` all pass.
6. **Diff focused**: 3 files changed, all within `index_html/`, no unrelated edits.

Fixes #2222
Fixes #2223