### PR TITLE
fix(cognitive-memory): fix wildcard snapshot export + corruption-recovery cross-session test (#1710, #1916)

### DIFF
--- a/src/cognitive_memory/ops.rs
+++ b/src/cognitive_memory/ops.rs
@@ -273,10 +273,26 @@ impl CognitiveMemoryOps for NativeCognitiveMemory {
         limit: u32,
         min_confidence: f64,
     ) -> SimardResult<Vec<CognitiveFact>> {
-        let q = escape_cypher(query);
-        let rows = self.query(&format!(
-            "MATCH (f:Fact) WHERE (f.concept CONTAINS '{q}' OR f.content CONTAINS '{q}') AND f.confidence >= {min_confidence} RETURN f.id, f.concept, f.content, f.confidence, f.source_id, f.tags ORDER BY f.id DESC LIMIT {limit}"
-        ))?;
+        // Treat `"*"` as "match everything" — `CONTAINS '*'` would search for
+        // the literal asterisk character, producing zero results when the
+        // caller intended a wildcard export (e.g. `export_memory_snapshot`).
+        // Issue #1710: this was the root cause of empty snapshot exports that
+        // made the corruption-recovery path lose all data.
+        let rows = if query == "*" {
+            self.query(&format!(
+                "MATCH (f:Fact) WHERE f.confidence >= {min_confidence} \
+                 RETURN f.id, f.concept, f.content, f.confidence, f.source_id, f.tags \
+                 ORDER BY f.id DESC LIMIT {limit}"
+            ))?
+        } else {
+            let q = escape_cypher(query);
+            self.query(&format!(
+                "MATCH (f:Fact) WHERE (f.concept CONTAINS '{q}' OR f.content CONTAINS '{q}') \
+                 AND f.confidence >= {min_confidence} \
+                 RETURN f.id, f.concept, f.content, f.confidence, f.source_id, f.tags \
+                 ORDER BY f.id DESC LIMIT {limit}"
+            ))?
+        };
         Ok(rows
             .iter()
             .map(|row| {
@@ -342,10 +358,22 @@ impl CognitiveMemoryOps for NativeCognitiveMemory {
     }
 
     fn recall_procedure(&self, query: &str, limit: u32) -> SimardResult<Vec<CognitiveProcedure>> {
-        let q = escape_cypher(query);
-        let rows = self.query(&format!(
-            "MATCH (p:Procedure) WHERE p.name CONTAINS '{q}' OR p.steps CONTAINS '{q}' RETURN p.id, p.name, p.steps, p.prerequisites, p.usage_count LIMIT {limit}"
-        ))?;
+        // Same wildcard treatment as `search_facts` — `"*"` means "return all"
+        // so `export_memory_snapshot` actually captures every procedure.
+        let rows = if query == "*" {
+            self.query(&format!(
+                "MATCH (p:Procedure) \
+                 RETURN p.id, p.name, p.steps, p.prerequisites, p.usage_count \
+                 LIMIT {limit}"
+            ))?
+        } else {
+            let q = escape_cypher(query);
+            self.query(&format!(
+                "MATCH (p:Procedure) WHERE p.name CONTAINS '{q}' OR p.steps CONTAINS '{q}' \
+                 RETURN p.id, p.name, p.steps, p.prerequisites, p.usage_count \
+                 LIMIT {limit}"
+            ))?
+        };
         // Each row is decoded with **loud** failure on schema drift or
         // corrupt JSON in `steps` / `prerequisites`.  The previous
         // implementation called `unwrap_or_default()` on the JSON parse
@@ -758,6 +786,36 @@ mod tests {
         mem.store_fact("rust", "fast", 0.9, &[], "src").unwrap();
         let results = mem.search_facts("python", 10, 0.0).unwrap();
         assert!(results.is_empty());
+    }
+
+    #[test]
+    fn search_facts_wildcard_returns_all() {
+        let mem = test_mem();
+        mem.store_fact("alpha", "first", 0.9, &[], "src").unwrap();
+        mem.store_fact("bravo", "second", 0.8, &[], "src").unwrap();
+        mem.store_fact("charlie", "third", 0.7, &[], "src").unwrap();
+        let results = mem.search_facts("*", 100, 0.0).unwrap();
+        assert_eq!(
+            results.len(),
+            3,
+            "wildcard '*' must return all facts, got {}",
+            results.len()
+        );
+    }
+
+    #[test]
+    fn recall_procedure_wildcard_returns_all() {
+        let mem = test_mem();
+        mem.store_procedure("deploy", &["build".into()], &[])
+            .unwrap();
+        mem.store_procedure("test", &["lint".into()], &[]).unwrap();
+        let results = mem.recall_procedure("*", 100).unwrap();
+        assert_eq!(
+            results.len(),
+            2,
+            "wildcard '*' must return all procedures, got {}",
+            results.len()
+        );
     }
 
     // ── store_procedure / recall_procedure ─────────────────────────────

--- a/tests/cognitive_memory_cross_session_recall.rs
+++ b/tests/cognitive_memory_cross_session_recall.rs
@@ -13,9 +13,13 @@
 //!   via `PersistedEnvelope` (#1917), enabling forward-compatible
 //!   migration (#1941).
 //! * `ImprovementHistory` round-trips across sessions (already hermetic).
+//! * Corruption-recovery: when the DB is corrupted between sessions,
+//!   `open_with_recovery` restores from the snapshot ladder and Session B
+//!   recalls Session A's writes (#1710 + #1916 acceptance criterion 4).
 //!
 //! **References.**
 //! * Parent task: #1916 (hermetic cross-session recall test gating every PR).
+//! * Backup-restore ordering fix: #1710 (dead-code elimination in recovery).
 //! * Schema envelope: #1917 (`PersistedEnvelope { schema_version }`).
 //! * Recovery ladder wiring: #1919 (`load_latest_snapshot` → public ctor).
 //! * Migration policy: #1941 (forward-compat decision).
@@ -535,4 +539,155 @@ fn cross_session_recall_accumulates_across_cycles() {
         "expected 6 sensory records after 2 write cycles, got {}",
         stats2.sensory_count
     );
+}
+
+// ============================================================================
+// Corruption-recovery cross-session recall (#1710 + #1916 criterion 4)
+//
+// Validates workstreams C + D together: session A writes a fact and takes
+// a snapshot, the DB is corrupted out-of-band, and session B MUST recall
+// the fact via the snapshot recovery ladder. This is the integration-level
+// complement to the unit-level `recovery_uses_backup_when_main_corrupt`
+// test in `src/cognitive_memory/tests_mod.rs`.
+// ============================================================================
+
+/// Corrupt a file by overwriting it with garbage bytes so LadybugDB
+/// refuses to open it.
+fn corrupt_file(path: &std::path::Path) {
+    use std::io::Write;
+    let mut f = std::fs::OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .open(path)
+        .unwrap_or_else(|e| panic!("open {} for corruption: {e}", path.display()));
+    let garbage = vec![0xABu8; 4096];
+    f.write_all(&garbage).expect("write garbage");
+    f.sync_all().expect("fsync garbage");
+}
+
+/// Session A writes a fact and takes a snapshot; the main DB is corrupted
+/// out-of-band; Session B opens via `open_with_recovery` and MUST recall
+/// Session A's fact through the snapshot ladder.
+///
+/// This is #1916 acceptance criterion 4 and the integration-level proof
+/// that the #1710 fix (backup-before-empty-DB ordering) works end-to-end
+/// across the snapshot recovery path, not just the backup recovery path.
+#[test]
+#[serial(cognitive_memory)]
+fn cross_session_recall_survives_db_corruption_via_snapshot() {
+    let temp = TempDir::new().expect("tempdir for hermetic state root");
+    let _guard = EnvGuard::pin(temp.path());
+
+    let snapshot_dir = temp.path().join("snapshots");
+    std::fs::create_dir_all(&snapshot_dir).expect("create hermetic snapshot dir");
+
+    let db_path = temp.path().join("cognitive_memory.ladybug");
+
+    // ─── Session A ──────────────────────────────────────────────────────
+    {
+        let mem =
+            NativeCognitiveMemory::open(temp.path()).expect("Session A: open cognitive memory");
+
+        mem.store_fact(
+            "corruption_canary",
+            "must survive DB corruption via snapshot ladder",
+            0.95,
+            &["issue-1710".to_string(), "issue-1916".to_string()],
+            "test::corruption_recovery",
+        )
+        .expect("Session A: store canary fact");
+
+        mem.store_episode(
+            "corruption-recovery-episode: session A wrote this",
+            "test::corruption_recovery",
+            None,
+        )
+        .expect("Session A: store canary episode");
+
+        mem.checkpoint()
+            .expect("Session A: WAL checkpoint before snapshot");
+
+        save_session_snapshot(&mem, "corruption-recovery-agent", &snapshot_dir)
+            .expect("Session A: save session snapshot");
+
+        // `mem` drops here, releasing the DB lock.
+    }
+
+    // Verify the snapshot was written.
+    let snapshot_count = std::fs::read_dir(&snapshot_dir)
+        .expect("list snapshot dir")
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("json"))
+        .count();
+    assert!(
+        snapshot_count > 0,
+        "Session A must have produced at least one snapshot file"
+    );
+
+    // ─── Corrupt the DB out-of-band ─────────────────────────────────────
+    assert!(db_path.exists(), "DB file must exist before corruption");
+    corrupt_file(&db_path);
+
+    // Also remove WAL files to simulate a clean corruption scenario where
+    // the WAL can't save us.
+    for entry in std::fs::read_dir(temp.path())
+        .expect("read state root")
+        .flatten()
+    {
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        if name_str.contains(".wal") {
+            let _ = std::fs::remove_file(entry.path());
+        }
+    }
+
+    // ─── Session B ──────────────────────────────────────────────────────
+    // `open_with_recovery` must:
+    //  1. Detect the corrupt DB via `open_db_with_recovery`
+    //  2. Fall through to creating a fresh empty DB (no backups/ dir exists,
+    //     only snapshots/)
+    //  3. Load the latest snapshot from snapshots/ and restore it
+    //  4. Return a functional memory with Session A's fact recallable
+    {
+        let mem = NativeCognitiveMemory::open_with_recovery(temp.path()).expect(
+            "Session B: open_with_recovery must succeed despite DB corruption \
+             by restoring from the snapshot ladder",
+        );
+
+        let facts = mem
+            .search_facts("corruption_canary", 16, 0.0)
+            .expect("Session B: search_facts after corruption recovery");
+
+        let recalled = facts
+            .iter()
+            .find(|f| f.concept == "corruption_canary")
+            .unwrap_or_else(|| {
+                panic!(
+                    "Session B failed to recall 'corruption_canary' after \
+                     DB corruption + snapshot recovery. Got {} facts: {:?}. \
+                     This means the snapshot ladder did not restore Session A's \
+                     writes after DB corruption (#1710 + #1916).",
+                    facts.len(),
+                    facts.iter().map(|f| &f.concept).collect::<Vec<_>>(),
+                )
+            });
+
+        assert_eq!(
+            recalled.content, "must survive DB corruption via snapshot ladder",
+            "Session B: recalled content must match Session A's write"
+        );
+        assert!(
+            (recalled.confidence - 0.95).abs() < 1e-6,
+            "Session B: recalled confidence ({}) must match Session A's (0.95)",
+            recalled.confidence
+        );
+
+        // Verify statistics show recovered data.
+        let stats = mem.get_statistics().expect("Session B: get_statistics");
+        assert!(
+            stats.semantic_count >= 1,
+            "Session B: at least 1 fact must be recovered, got {}",
+            stats.semantic_count
+        );
+    }
 }

--- a/tests/gadugi/cross-session-recall.yaml
+++ b/tests/gadugi/cross-session-recall.yaml
@@ -1,0 +1,60 @@
+name: "Cross-Session Cognitive Memory Recall"
+description: >
+  Outside-in gate for issue #1916: verifies that cognitive memory written by
+  Session A survives process exit and is fully recallable by Session B via the
+  snapshot recovery ladder. Also covers the corruption-recovery path from
+  issue #1710 (backup-restore ordering fix).
+version: "1.0.0"
+
+config:
+  timeout: 120000
+  retries: 1
+  parallel: false
+
+environment:
+  requires: []
+
+agents:
+  - name: "test-agent"
+    type: "cli"
+    config:
+      workingDirectory: "."
+      defaultTimeout: 120000
+      executionMode: "spawn"
+      captureOutput: true
+      ioConfig:
+        encoding: "utf8"
+        handleInteractivePrompts: false
+      logConfig:
+        logCommands: true
+        logOutput: true
+        logLevel: "info"
+
+steps:
+  - name: "Cross-session recall — clean path (session A writes, session B reads)"
+    agent: "test-agent"
+    action: "execute_command"
+    params:
+      command: >
+        cargo test --test cognitive_memory_cross_session_recall
+        cognitive_memory_cross_session_recall
+        -- --nocapture --test-threads=1
+    timeout: 120000
+    expect:
+      exitCode: 0
+      outputContains:
+        - "test cognitive_memory_cross_session_recall ... ok"
+
+  - name: "Cross-session recall — corruption-recovery path (#1710 + #1916)"
+    agent: "test-agent"
+    action: "execute_command"
+    params:
+      command: >
+        cargo test --test cognitive_memory_cross_session_recall
+        cross_session_recall_survives_db_corruption_via_snapshot
+        -- --nocapture --test-threads=1
+    timeout: 120000
+    expect:
+      exitCode: 0
+      outputContains:
+        - "test cross_session_recall_survives_db_corruption_via_snapshot ... ok"


### PR DESCRIPTION
## Summary

Fixes #1710 — cognitive memory recovery creates empty DB instead of restoring from backup
Fixes #1916 — hermetic outside-in cross-session recall test gating every PR

## Root cause found

The snapshot export in `export_memory_snapshot` calls `search_facts("*")` and `recall_procedure("*")` intending to export **all** records. However, the `NativeCognitiveMemory` implementation used `CONTAINS '*'` in the Cypher query, which searches for the **literal asterisk character** — not a wildcard. Result: every snapshot file was empty (0 facts, 0 procedures).

This meant:
- The existing corruption-recovery path (`open_with_recovery`) found snapshots on disk but restored 0 items
- After DB corruption, all cognitive memory was silently lost despite snapshots existing
- The backup-restore ordering fix from PR #1718 was correct but ineffective because there was nothing to restore

## Changes

### Bug fix: `src/cognitive_memory/ops.rs`
- `search_facts`: treat `"*"` as "return all" (skip CONTAINS filter)
- `recall_procedure`: same wildcard treatment
- 2 new unit tests: `search_facts_wildcard_returns_all`, `recall_procedure_wildcard_returns_all`

### Integration test: `tests/cognitive_memory_cross_session_recall.rs`
- New test `cross_session_recall_survives_db_corruption_via_snapshot`:
  - Session A stores a fact + takes a snapshot
  - DB is corrupted out-of-band
  - Session B opens via `open_with_recovery` and must recall the fact through the snapshot ladder
  - This is #1916 acceptance criterion 4 (corruption-recovery scenario)

### Gadugi spec: `tests/gadugi/cross-session-recall.yaml`
- Outside-in qa-team scenario covering both clean and corruption-recovery paths

## Test evidence

```
cargo test --lib wildcard
  search_facts_wildcard_returns_all ... ok
  recall_procedure_wildcard_returns_all ... ok

cargo test --test cognitive_memory_cross_session_recall
  cognitive_memory_cross_session_recall ... ok
  cross_session_recall_survives_db_corruption_via_snapshot ... ok

cargo test --lib cognitive_memory::tests_mod -- --test-threads=1
  30 passed; 0 failed

cargo clippy --lib -- -D warnings
  0 warnings
```

## Diff focused
3 files changed: 1 bug fix in ops.rs, 1 new integration test, 1 new gadugi spec. No unrelated edits.