### PR TITLE
security: pin actions to SHA, pin crate versions, restrict permissions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - "src/**"
 
+permissions: {}
+
 env:
   CARGO_BUILD_JOBS: 4
   CARGO_PROFILE_DEV_DEBUG: "line-tables-only"
@@ -24,21 +26,21 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Prepare Rust runner (free disk, swap, mold)
         uses: ./.github/actions/rust-runner-prep
 
       - name: Install Rust nightly toolchain
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2 # nightly
         with:
           components: llvm-tools-preview
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
+        uses: taiki-e/install-action@81ee9698f20724138a785d788c7567d40f14cd2d # cargo-llvm-cov
 
       - name: Cache cargo registry and build artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: simard-coverage
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -55,7 +57,7 @@ jobs:
 
       - name: Upload coverage summary
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: coverage-summary-${{ github.run_id }}-${{ github.run_attempt }}
           path: target/ci-logs/coverage-summary.json
@@ -64,7 +66,7 @@ jobs:
 
       - name: Post coverage comment on PR
         if: success() && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,9 +20,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
 
@@ -34,7 +34,7 @@ jobs:
 
       - name: Upload artifact
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: site/
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,16 +11,16 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           submodules: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -4,6 +4,8 @@ on:
   push:
   pull_request:
 
+permissions: {}
+
 env:
   # ubuntu-latest runners have 4 vCPUs and 16GB RAM. With line-tables-only
   # debug info + 4GB swap, we can compile with all 4 cores instead of 2,
@@ -26,10 +28,12 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    permissions:
+      contents: read
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Rust-only gate (no new .py / .js / .ts)
         run: scripts/check-rust-only-gate.sh
@@ -40,7 +44,7 @@ jobs:
           rust-components: rustfmt,clippy
 
       - name: Cache cargo registry and build artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           # Bumped 2026-05-10: previous `simard-ci` cache held stale test
           # binaries from before tests were renamed/deleted (notably
@@ -57,7 +61,7 @@ jobs:
           cache-on-failure: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.x"
 
@@ -98,7 +102,7 @@ jobs:
         run: cargo build --bin simard --locked
 
       - name: Upload simard binary artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: simard-bin-${{ github.run_id }}-${{ github.run_attempt }}
           path: target/debug/simard
@@ -107,7 +111,7 @@ jobs:
 
       - name: Upload cargo-test log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: cargo-test-log-${{ github.run_id }}-${{ github.run_attempt }}
           path: target/ci-logs/cargo-test.log
@@ -117,21 +121,19 @@ jobs:
   install-real:
     runs-on: ubuntu-latest
     timeout-minutes: 120
-    # Wait for pre-commit so the Swatinem cache is warm (single-writer model)
-    # and the cargo registry / git deps don't have to be re-fetched. The
-    # actual `cargo install --path .` still runs in its own isolated target
-    # dir, but the dep download cost drops from minutes to seconds.
     needs: pre-commit
+    permissions:
+      contents: read
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Prepare Rust runner (free disk, swap, mold, rust)
         uses: ./.github/actions/rust-runner-prep
 
       - name: Cache cargo registry and build artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: simard-ci-v2
           # Read-only on PRs and non-pre-commit jobs; pre-commit on main is
@@ -159,10 +161,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
 
@@ -173,7 +175,7 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: Download simard binary from pre-commit job
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: simard-bin-${{ github.run_id }}-${{ github.run_attempt }}
           path: target/debug
@@ -204,7 +206,7 @@ jobs:
       # launched here on a dedicated port so we don't race the TS suite's
       # webServer lifecycle.
       - name: Set up Python for tab-identity smoke test
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.x"
 
@@ -247,7 +249,7 @@ jobs:
 
       - name: Upload Playwright report on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: playwright-report-${{ github.run_id }}-${{ github.run_attempt }}
           path: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,44 +48,44 @@ path = "src/bin/simard_tui/main.rs"
 amplihack-memory = { git = "https://github.com/rysweet/amplihack-memory-lib.git" }
 rustyclawd-core = { git = "https://github.com/rysweet/RustyClawd.git" }
 rustyclawd-tools = { git = "https://github.com/rysweet/RustyClawd.git" }
-lbug = "0.15"
-rusqlite = { version = "0.31", features = ["bundled"] }
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.145"
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "process", "io-util", "time", "net", "macros", "sync"] }
-axum = { version = "0.8", features = ["ws"] }
-tower-http = { version = "0.6", features = ["cors", "auth"] }
-uuid = { version = "1.18.1", features = ["v4", "v7"] }
-chrono = "0.4"
-dirs = "6"
-crc32fast = "1"
-sha2 = "0.10"
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
-ctrlc = { version = "3.4", features = ["termination"] }
-nix = { version = "0.29", features = ["signal", "fs"] }
-opentelemetry = "0.27"
-opentelemetry-otlp = "0.27"
-tracing-opentelemetry = "0.28"
-opentelemetry_sdk = { version = "0.27", features = ["rt-tokio"] }
-tempfile = "3"
-ratatui = "0.29"
-crossterm = "0.28"
-headless_chrome = { version = "1", optional = true, default-features = false }
-regex = { version = "1", optional = true }
-url = { version = "2", optional = true }
+lbug = "=0.15.3"
+rusqlite = { version = "=0.31.0", features = ["bundled"] }
+serde = { version = "=1.0.228", features = ["derive"] }
+serde_json = "=1.0.149"
+tokio = { version = "=1.52.1", features = ["rt", "rt-multi-thread", "process", "io-util", "time", "net", "macros", "sync"] }
+axum = { version = "=0.8.9", features = ["ws"] }
+tower-http = { version = "=0.6.8", features = ["cors", "auth"] }
+uuid = { version = "=1.23.1", features = ["v4", "v7"] }
+chrono = "=0.4.44"
+dirs = "=6.0.0"
+crc32fast = "=1.5.0"
+sha2 = "=0.10.9"
+tracing = "=0.1.44"
+tracing-subscriber = { version = "=0.3.23", features = ["json", "env-filter"] }
+ctrlc = { version = "=3.5.2", features = ["termination"] }
+nix = { version = "=0.29.0", features = ["signal", "fs"] }
+opentelemetry = "=0.27.1"
+opentelemetry-otlp = "=0.27.0"
+tracing-opentelemetry = "=0.28.0"
+opentelemetry_sdk = { version = "=0.27.1", features = ["rt-tokio"] }
+tempfile = "=3.27.0"
+ratatui = "=0.29.0"
+crossterm = "=0.28.1"
+headless_chrome = { version = "=1.0.21", optional = true, default-features = false }
+regex = { version = "=1.12.3", optional = true }
+url = { version = "=2.5.8", optional = true }
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2"
+libc = "=0.2.185"
 
 [features]
 slow-tests = []
 dashboard-audit = ["dep:headless_chrome", "dep:regex", "dep:url"]
 
 [dev-dependencies]
-assert_cmd = "2"
-proptest = "1"
-serial_test = "3.4.0"
+assert_cmd = "=2.2.1"
+proptest = "=1.11.0"
+serial_test = "=3.4.0"
 
 [profile.release]
 lto = "thin"


### PR DESCRIPTION
## Summary

Supply-chain hardening across all CI workflows and Cargo.toml. Closes #2237.

## Changes

### 1. GitHub Actions pinned to commit SHAs
All 25 `uses:` references across `coverage.yml`, `verify.yml`, `release.yml`, and `docs.yml` are now pinned to full 40-char commit SHAs with trailing version comments for maintainability:
- `actions/checkout@v4` → `actions/checkout@34e1148...# v4`
- `Swatinem/rust-cache@v2` → `Swatinem/rust-cache@e18b497...# v2`
- etc.

Local composite actions (`./.github/actions/rust-runner-prep`) left as-is (repo-local, no supply-chain risk).

### 2. Top-level `permissions: {}` added
- `coverage.yml` — added restrictive default; job already had explicit `contents: read` + `pull-requests: write`
- `verify.yml` — added restrictive default; added explicit `permissions: { contents: read }` to `pre-commit` and `install-real` jobs (`e2e-dashboard` already had it)
- `release.yml` and `docs.yml` already had top-level permissions

### 3. Cargo.toml exact version pins
All crate dependencies pinned to exact versions using `=` prefix (e.g., `serde = "=1.0.228"`). Git dependencies left as-is (already pinned to a repo). Versions match what was already resolved in `Cargo.lock`.

### 4. `cargo audit` results
2 transitive advisories via `ratatui 0.29.0` — not actionable in this PR:
- `paste 1.0.15` — RUSTSEC-2024-0436 (unmaintained)
- `lru 0.12.5` — RUSTSEC-2026-0002 (unsound IterMut)

Both require an upstream `ratatui` update to resolve.

## Verification
- `cargo check --locked` ✓ — lock file consistent with pinned deps
- `cargo clippy --release --no-deps -D warnings` ✓ — pre-commit hook passed
- `cargo fmt` ✓
- `cargo audit` — ran, findings documented above

## Diff focused
5 files changed, 62 insertions, 58 deletions. Config-level only — no application logic touched.