### PR TITLE
fix(disk): strip debuginfo from dev/test builds, fix disk health to clean target/

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,7 @@ incremental = false
 [profile.dev]
 debug = "line-tables-only"
 incremental = false
+strip = "debuginfo"
 
 [profile.dev.package."*"]
 debug = false
@@ -124,6 +125,7 @@ debug = false
 [profile.test]
 debug = "line-tables-only"
 incremental = false
+strip = "debuginfo"
 
 [profile.test.package."*"]
 debug = false

--- a/prompt_assets/simard/recipes/disk-health-check.yaml
+++ b/prompt_assets/simard/recipes/disk-health-check.yaml
@@ -23,6 +23,7 @@ tags: ["simard", "disk", "maintenance", "ops"]
 
 context:
   state_root: "~/.simard"
+  repo_path: "/home/azureuser/src/Simard/worktrees/main"
 
 steps:
   - id: "check-and-clean"
@@ -63,23 +64,23 @@ steps:
 
       ## Cleanup Targets (ordered by typical yield)
 
-      All cleanup targets live under `{{state_root}}`. Do NOT delete anything
-      outside this directory tree.
+      Cleanup targets span both `{{state_root}}` and the source worktree.
 
-      1. **`{{state_root}}/cargo-target/`** and **`{{state_root}}/shared-target/`** —
-         Shared Cargo build caches. Remove `incremental/` and `debug/` subdirectories
-         first (use `find <dir> -maxdepth 1 -name incremental -o -name debug` then
-         `rm -rf`). Under extreme pressure, remove the entire directories.
+      1. **Cargo `target/` directories** — the single biggest disk consumer.
+         These accumulate incremental build artifacts that grow without bound.
+         Scan ALL of these paths for `target/` directories:
+         - `{{repo_path}}/target/` (main worktree build cache)
+         - `{{repo_path}}/worktrees/*/target/` (engineer worktree build caches)
+         - `{{state_root}}/cargo-target/` and `{{state_root}}/shared-target/`
+         For each found `target/` dir: remove `incremental/` and `debug/` subdirs
+         first. Under extreme pressure (>90%), remove the entire `target/` dir.
+         These are always safe to delete — cargo rebuilds them automatically.
 
-      2. **`{{state_root}}/engineer-worktrees/`** — Enumerate once with a single
-         `find` pass. For each subdirectory, check modification time and the
-         `.simard-engineer-claim` file in one go:
-         - If the worktree is older than 24 hours AND (the `.simard-engineer-claim`
-           file is missing OR the PID on its first line is dead per `kill -0`),
+      2. **`{{repo_path}}/worktrees/`** (inner engineer worktrees) — For each
+         subdirectory, check modification time and `.simard-engineer-claim` file:
+         - If older than 24h AND (claim file missing OR PID is dead per `kill -0`),
            remove the entire worktree.
-         - For worktrees that are kept (still active or <24h old), remove only
-           their `target/` subdirectory if it exists — these Cargo build dirs are
-           large and always safe to delete.
+         - For kept worktrees, still remove their `target/` subdirectory.
 
       3. **`{{state_root}}/backups/`** — Database backup files. List by modification
          time (`ls -1t`), keep approximately 5 most recent, remove the rest. Under

--- a/src/disk_health.rs
+++ b/src/disk_health.rs
@@ -133,6 +133,8 @@ pub fn run_disk_health_check(
         .env("AMPLIHACK_AGENT_BINARY", agent_binary)
         .arg("-c")
         .arg(format!("state_root={}", state_root.display()))
+        .arg("-c")
+        .arg(format!("repo_path={}", repo_root.display()))
         .output()
         .map_err(|e| SimardError::AdapterInvocationFailed {
             base_type: ADAPTER_TAG.to_string(),


### PR DESCRIPTION
## Problem

Disk filled to 100% (393GB partition) causing OODA cycle failures with 'No space left on device'. Root cause: `target/debug/` grew to **267GB** and the disk health recipe never cleaned it — it only scanned `~/.simard/`.

## Fix

**1. Build size reduction (36GB → 9.6GB, -73%)**
- Add `strip = "debuginfo"` to `[profile.dev]` and `[profile.test]` in Cargo.toml
- DWARF debug info was the dominant space consumer (deps went from 29GB to 4.1GB)
- Panics still show file:line via `debug = "line-tables-only"`

**2. Disk health recipe now cleans the actual hogs**
- Pass `repo_path` context var to disk-health-check recipe
- Recipe now scans `target/` in main worktree + engineer worktrees + `~/.simard/`
- `target/` cleanup is first priority (largest yield)

## Testing
- All 31 disk_health tests pass
- Clean build measured at 9.6GB vs 36GB before
- fmt, clippy, pre-push tests all pass