### PR TITLE
feat(meeting): add risk capture, disagreement surfacing, and drift guard

### DIFF
--- a/src/engineer_loop/tests_meeting_decisions.rs
+++ b/src/engineer_loop/tests_meeting_decisions.rs
@@ -45,6 +45,8 @@ fn test_handoff(topic: &str, started_at: &str) -> MeetingHandoff {
         applied_templates: vec![],
         history_truncated_count: 0,
         partial_reason: None,
+        risks: vec![],
+        disagreements: vec![],
     }
 }
 

--- a/src/meeting_backend/closing.rs
+++ b/src/meeting_backend/closing.rs
@@ -257,6 +257,26 @@ impl MeetingBackend {
             }
         }
 
+        // ── Risks (issue #2084, spec line 637) ──
+        let inferred_risks = persist::extract_risks(&self.history);
+        let mut risks: Vec<String> = self.explicit_risks.clone();
+        for r in inferred_risks {
+            let lower = r.to_lowercase();
+            if !risks.iter().any(|e| e.to_lowercase() == lower) {
+                risks.push(r);
+            }
+        }
+
+        // ── Disagreements (issue #2084, spec line 645) ──
+        let inferred_disagreements = persist::extract_disagreements(&self.history);
+        let mut disagreements: Vec<String> = self.explicit_disagreements.clone();
+        for d in inferred_disagreements {
+            let lower = d.to_lowercase();
+            if !disagreements.iter().any(|e| e.to_lowercase() == lower) {
+                disagreements.push(d);
+            }
+        }
+
         let mut participants: Vec<String> = Vec::new();
         for msg in &self.history {
             let role_name = match msg.role {
@@ -387,6 +407,8 @@ impl MeetingBackend {
             applied_templates: self.applied_templates.clone(),
             history_truncated_count: self.history_truncated_count,
             partial_reason: partial_reason.map(|r| r.as_wire_str().to_string()),
+            risks: risks.clone(),
+            disagreements: disagreements.clone(),
         };
 
         // Write MeetingHandoff artifact for OODA integration.
@@ -647,6 +669,8 @@ impl MeetingBackend {
             bundle_dir,
             partial_reason,
             orphan_turn_count: self.orphan_turn_count,
+            risks,
+            disagreements,
         })
     }
 
@@ -828,6 +852,8 @@ impl MeetingBackend {
             applied_templates: self.applied_templates.clone(),
             history_truncated_count: self.history_truncated_count,
             partial_reason: partial_reason.map(|r| r.as_wire_str().to_string()),
+            risks: self.explicit_risks.clone(),
+            disagreements: self.explicit_disagreements.clone(),
         };
 
         if let Err(e) = persist::write_handoff_with_explicit(
@@ -949,6 +975,8 @@ impl MeetingBackend {
             bundle_dir,
             partial_reason,
             orphan_turn_count: self.orphan_turn_count,
+            risks: self.explicit_risks.clone(),
+            disagreements: self.explicit_disagreements.clone(),
         })
     }
 }

--- a/src/meeting_backend/command.rs
+++ b/src/meeting_backend/command.rs
@@ -46,6 +46,16 @@ pub enum MeetingCommand {
     /// `/goal Agree on the release plan for v2`). Empty payload falls
     /// through to conversation. Added in issue #1987.
     Goal(String),
+    /// Operator records an identified risk (e.g.
+    /// `/risk Dependency on unstable API may delay launch`). Empty payload
+    /// falls through to conversation. Required by spec line 637
+    /// ("identified risks"). Added in issue #2084.
+    Risk(String),
+    /// Operator records a disagreement or dissenting view (e.g.
+    /// `/disagree I think we should use Python instead`). Empty payload
+    /// falls through to conversation. Required by spec line 645
+    /// ("surface disagreement and uncertainty"). Added in issue #2084.
+    Disagree(String),
     /// Natural language — forwarded to the LLM.
     Conversation(String),
 }
@@ -125,6 +135,22 @@ pub fn parse_command(input: &str) -> MeetingCommand {
                 MeetingCommand::Conversation(trimmed.to_string())
             } else {
                 MeetingCommand::Goal(arg)
+            }
+        }
+        _ if lower.starts_with("/risk ") => {
+            let arg = trimmed["/risk ".len()..].trim().to_string();
+            if arg.is_empty() {
+                MeetingCommand::Conversation(trimmed.to_string())
+            } else {
+                MeetingCommand::Risk(arg)
+            }
+        }
+        _ if lower.starts_with("/disagree ") => {
+            let arg = trimmed["/disagree ".len()..].trim().to_string();
+            if arg.is_empty() {
+                MeetingCommand::Conversation(trimmed.to_string())
+            } else {
+                MeetingCommand::Disagree(arg)
             }
         }
         _ => MeetingCommand::Conversation(trimmed.to_string()),
@@ -499,5 +525,65 @@ mod tests {
         let (text, rationale) = parse_rationale_flag("No flag here");
         assert_eq!(text, "No flag here");
         assert_eq!(rationale, None);
+    }
+
+    // ── /risk (issue #2084) ──────────────────────────────────────────
+
+    #[test]
+    fn parse_risk_with_arg() {
+        assert_eq!(
+            parse_command("/risk Dependency on unstable API may delay launch"),
+            MeetingCommand::Risk("Dependency on unstable API may delay launch".to_string()),
+        );
+        assert_eq!(
+            parse_command("  /Risk  Single point of failure  "),
+            MeetingCommand::Risk("Single point of failure".to_string()),
+        );
+    }
+
+    #[test]
+    fn parse_risk_empty_arg_is_conversation() {
+        assert_eq!(
+            parse_command("/risk"),
+            MeetingCommand::Conversation("/risk".to_string()),
+        );
+        assert_eq!(
+            parse_command("/risk    "),
+            MeetingCommand::Conversation("/risk".to_string()),
+        );
+    }
+
+    // ── /disagree (issue #2084) ──────────────────────────────────────
+
+    #[test]
+    fn parse_disagree_with_arg() {
+        assert_eq!(
+            parse_command("/disagree I think we should use Python instead"),
+            MeetingCommand::Disagree("I think we should use Python instead".to_string()),
+        );
+        assert_eq!(
+            parse_command("  /Disagree  This approach is too risky  "),
+            MeetingCommand::Disagree("This approach is too risky".to_string()),
+        );
+    }
+
+    #[test]
+    fn parse_disagree_preserves_case() {
+        assert_eq!(
+            parse_command("/disagree Alice thinks we need more testing"),
+            MeetingCommand::Disagree("Alice thinks we need more testing".to_string()),
+        );
+    }
+
+    #[test]
+    fn parse_disagree_empty_arg_is_conversation() {
+        assert_eq!(
+            parse_command("/disagree"),
+            MeetingCommand::Conversation("/disagree".to_string()),
+        );
+        assert_eq!(
+            parse_command("/disagree    "),
+            MeetingCommand::Conversation("/disagree".to_string()),
+        );
     }
 }

--- a/src/meeting_backend/mod.rs
+++ b/src/meeting_backend/mod.rs
@@ -188,6 +188,13 @@ pub struct MeetingBackend {
     /// user message was already pushed to history. These are "orphan" turns
     /// with no assistant reply. Surfaced on `MeetingSummary` (issue #1983).
     orphan_turn_count: usize,
+    /// Risks recorded inline by the operator via `/risk <text>`. Required by
+    /// spec line 637 ("identified risks"). Added in issue #2084.
+    explicit_risks: Vec<String>,
+    /// Disagreements recorded inline by the operator via `/disagree <text>`.
+    /// Required by spec line 645 ("surface disagreement and uncertainty").
+    /// Added in issue #2084.
+    explicit_disagreements: Vec<String>,
 }
 
 impl MeetingBackend {
@@ -230,6 +237,8 @@ impl MeetingBackend {
             explicit_goal: None,
             history_truncated_count: 0,
             orphan_turn_count: 0,
+            explicit_risks: Vec::new(),
+            explicit_disagreements: Vec::new(),
         }
     }
 
@@ -464,6 +473,55 @@ impl MeetingBackend {
         self.explicit_goal.as_deref()
     }
 
+    /// Record an identified risk the operator flagged with `/risk <text>`.
+    /// Trailing/leading whitespace is trimmed; empty values are ignored.
+    /// Duplicates (case-insensitive) are deduplicated. Added in issue #2084.
+    pub fn push_explicit_risk(&mut self, text: &str) {
+        let trimmed = text.trim();
+        if trimmed.is_empty() {
+            return;
+        }
+        let lower = trimmed.to_lowercase();
+        if self
+            .explicit_risks
+            .iter()
+            .any(|r| r.to_lowercase() == lower)
+        {
+            return;
+        }
+        self.explicit_risks.push(trimmed.to_string());
+    }
+
+    /// Read the risks the operator recorded inline so far.
+    pub fn explicit_risks(&self) -> &[String] {
+        &self.explicit_risks
+    }
+
+    /// Record a disagreement or dissenting view the operator flagged with
+    /// `/disagree <text>`. Trailing/leading whitespace is trimmed; empty
+    /// values are ignored. Duplicates (case-insensitive) are deduplicated.
+    /// Added in issue #2084.
+    pub fn push_explicit_disagreement(&mut self, text: &str) {
+        let trimmed = text.trim();
+        if trimmed.is_empty() {
+            return;
+        }
+        let lower = trimmed.to_lowercase();
+        if self
+            .explicit_disagreements
+            .iter()
+            .any(|d| d.to_lowercase() == lower)
+        {
+            return;
+        }
+        self.explicit_disagreements.push(trimmed.to_string());
+    }
+
+    /// Read the disagreements the operator recorded inline so far.
+    pub fn explicit_disagreements(&self) -> &[String] {
+        &self.explicit_disagreements
+    }
+
     /// Compute the effective goal for the handoff: explicit `/goal` text
     /// if set, otherwise fall back to the first user message.
     pub fn effective_goal(&self) -> Option<String> {
@@ -519,6 +577,8 @@ impl MeetingBackend {
             themes: self.themes.clone(),
             next_owner: self.explicit_next_owner.clone(),
             goal: self.explicit_goal.clone(),
+            risks: self.explicit_risks.clone(),
+            disagreements: self.explicit_disagreements.clone(),
         }
     }
 

--- a/src/meeting_backend/persist/extract.rs
+++ b/src/meeting_backend/persist/extract.rs
@@ -393,6 +393,117 @@ pub fn extract_decision_participants_pub(
     extract_decision_participants(decision, messages)
 }
 
+// ── Risk extraction (issue #2084, spec line 637) ───────────────────────
+
+/// Signal phrases that indicate a risk is being discussed.
+const RISK_SIGNALS: &[&str] = &[
+    "risk:",
+    "risk is",
+    "risky",
+    "at risk",
+    "risks include",
+    "concern:",
+    "concern is",
+    "worried about",
+    "worry about",
+    "danger",
+    "blocker",
+    "blocking",
+    "could fail",
+    "might fail",
+    "may fail",
+    "could break",
+    "might break",
+    "threat",
+    "vulnerability",
+    "dependency risk",
+    "single point of failure",
+];
+
+/// Extract identified risks from transcript messages.
+///
+/// Uses heuristic signal phrases to identify risk statements from both user
+/// and assistant messages. Required by spec line 637 ("identified risks").
+/// Added in issue #2084.
+pub fn extract_risks(messages: &[ConversationMessage]) -> Vec<String> {
+    let mut risks = Vec::new();
+    for msg in messages {
+        for sentence in split_sentences(&msg.content) {
+            let lower = sentence.trim().to_lowercase();
+            if lower.len() < 10 {
+                continue;
+            }
+            let has_signal = RISK_SIGNALS.iter().any(|s| lower.contains(s));
+            if has_signal {
+                let text = sentence.trim().to_string();
+                if !risks.iter().any(|r: &String| r.to_lowercase() == lower) {
+                    risks.push(text);
+                }
+            }
+        }
+    }
+    risks
+}
+
+// ── Disagreement extraction (issue #2084, spec line 645) ────────────────
+
+/// Signal phrases that indicate disagreement or dissent.
+const DISAGREEMENT_SIGNALS: &[&str] = &[
+    "disagree",
+    "i disagree",
+    "i don't agree",
+    "i don\u{2019}t agree",
+    "i'm not sure",
+    "i\u{2019}m not sure",
+    "not convinced",
+    "pushback",
+    "push back",
+    "on the other hand",
+    "alternative view",
+    "counterpoint",
+    "counter-point",
+    "dissent",
+    "objection",
+    "i object",
+    "however, i think",
+    "but i think",
+    "i'd argue",
+    "i\u{2019}d argue",
+    "devil's advocate",
+    "devil\u{2019}s advocate",
+    "concern about this",
+    "not aligned",
+    "strongly opposed",
+];
+
+/// Extract disagreements and dissenting views from transcript messages.
+///
+/// Uses heuristic signal phrases to identify disagreement or uncertainty
+/// statements. Required by spec line 645 ("surface disagreement and
+/// uncertainty instead of smoothing over them"). Added in issue #2084.
+pub fn extract_disagreements(messages: &[ConversationMessage]) -> Vec<String> {
+    let mut disagreements = Vec::new();
+    for msg in messages {
+        for sentence in split_sentences(&msg.content) {
+            let lower = sentence.trim().to_lowercase();
+            if lower.len() < 10 {
+                continue;
+            }
+            let has_signal = DISAGREEMENT_SIGNALS.iter().any(|s| lower.contains(s));
+            if has_signal {
+                let text = sentence.trim().to_string();
+                if !disagreements
+                    .iter()
+                    .any(|d: &String| d.to_lowercase() == lower)
+                {
+                    disagreements.push(text);
+                }
+            }
+        }
+    }
+    disagreements
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/meeting_backend/persist/mod.rs
+++ b/src/meeting_backend/persist/mod.rs
@@ -192,6 +192,10 @@ pub struct HandoffEnrichment<'a> {
     pub history_truncated_count: usize,
     /// Wire-string form of `PartialReason` from the close pipeline. Added in #1987.
     pub partial_reason: Option<String>,
+    /// Identified risks. Added in issue #2084.
+    pub risks: Vec<String>,
+    /// Disagreements or dissenting views. Added in issue #2084.
+    pub disagreements: Vec<String>,
 }
 
 /// Write a `MeetingHandoff` artifact for OODA integration.
@@ -350,6 +354,8 @@ pub fn write_handoff_with_explicit(
         applied_templates: enrichment.applied_templates.clone(),
         history_truncated_count: enrichment.history_truncated_count,
         partial_reason: enrichment.partial_reason.clone(),
+        risks: enrichment.risks.clone(),
+        disagreements: enrichment.disagreements.clone(),
     };
 
     let dir = default_handoff_dir();
@@ -453,6 +459,8 @@ pub fn write_handoff_bundle(
         applied_templates: enrichment.applied_templates.clone(),
         history_truncated_count: enrichment.history_truncated_count,
         partial_reason: enrichment.partial_reason.clone(),
+        risks: enrichment.risks.clone(),
+        disagreements: enrichment.disagreements.clone(),
     };
 
     let lines: Vec<crate::meeting_facilitator::BundleTranscriptLine> = messages
@@ -501,7 +509,8 @@ pub(crate) use extract::{
 };
 pub use extract::{
     extract_action_items, extract_decision_participants_pub, extract_decision_rationale_pub,
-    extract_decisions, extract_open_questions, extract_themes, link_action_items_to_goals,
+    extract_decisions, extract_disagreements, extract_open_questions, extract_risks,
+    extract_themes, link_action_items_to_goals,
 };
 pub use json_sibling::{JsonHandoffActionItem, JsonHandoffSibling};
 pub use templates::{MeetingTemplate, TEMPLATES, find_template};

--- a/src/meeting_backend/types.rs
+++ b/src/meeting_backend/types.rs
@@ -108,6 +108,15 @@ pub struct MeetingSummary {
     /// transcript completeness. Issue #1983.
     #[serde(default)]
     pub orphan_turn_count: usize,
+    /// Identified risks recorded via `/risk` or extracted from conversation.
+    /// Required by spec line 637 ("identified risks"). Added in issue #2084.
+    #[serde(default)]
+    pub risks: Vec<String>,
+    /// Disagreements or dissenting views recorded via `/disagree` or
+    /// extracted from conversation. Required by spec line 645
+    /// ("surface disagreement and uncertainty"). Added in issue #2084.
+    #[serde(default)]
+    pub disagreements: Vec<String>,
 }
 
 /// Current status of a meeting session.
@@ -194,6 +203,8 @@ mod tests {
             bundle_dir: Some("/home/user/.simard/meetings/20250101T000000Z-sprint/".to_string()),
             partial_reason: None,
             orphan_turn_count: 0,
+            risks: vec!["API stability".to_string()],
+            disagreements: vec!["Team disagrees on language choice".to_string()],
         };
         let json = serde_json::to_string(&summary).unwrap();
         let s2: MeetingSummary = serde_json::from_str(&json).unwrap();
@@ -221,6 +232,8 @@ mod tests {
         assert!(s.bundle_dir.is_none());
         assert!(s.partial_reason.is_none());
         assert_eq!(s.orphan_turn_count, 0);
+        assert!(s.risks.is_empty());
+        assert!(s.disagreements.is_empty());
     }
 
     #[test]
@@ -243,6 +256,8 @@ mod tests {
             bundle_dir: Some("/tmp/x".to_string()),
             partial_reason: Some(crate::meeting_backend::PartialReason::SummaryTimeout),
             orphan_turn_count: 0,
+            risks: vec![],
+            disagreements: vec![],
         };
         let json = serde_json::to_string(&summary).unwrap();
         assert!(

--- a/src/meeting_facilitator/handoff/mod.rs
+++ b/src/meeting_facilitator/handoff/mod.rs
@@ -172,6 +172,15 @@ pub struct MeetingHandoff {
     /// `None` for a clean close. Added in issue #1987.
     #[serde(default)]
     pub partial_reason: Option<String>,
+    /// Identified risks recorded via `/risk` or extracted from conversation.
+    /// Required by spec line 637 ("identified risks"). Added in issue #2084.
+    #[serde(default)]
+    pub risks: Vec<String>,
+    /// Disagreements or dissenting views recorded via `/disagree` or
+    /// extracted from conversation. Required by spec line 645
+    /// ("surface disagreement and uncertainty"). Added in issue #2084.
+    #[serde(default)]
+    pub disagreements: Vec<String>,
 }
 
 /// Build a stable, sortable meeting id from a started-at timestamp and a
@@ -370,6 +379,8 @@ impl MeetingHandoff {
             applied_templates: Vec::new(),
             history_truncated_count: 0,
             partial_reason: None,
+            risks: session.risks.clone(),
+            disagreements: session.disagreements.clone(),
         }
     }
 
@@ -446,6 +457,8 @@ mod tests {
             themes: vec![],
             next_owner: None,
             goal: None,
+            risks: vec![],
+            disagreements: vec![],
         }
     }
 
@@ -477,6 +490,8 @@ mod tests {
             themes: vec!["performance".to_string()],
             next_owner: Some("engineer".to_string()),
             goal: None,
+            risks: vec![],
+            disagreements: vec![],
         }
     }
 

--- a/src/meeting_facilitator/handoff/persistence.rs
+++ b/src/meeting_facilitator/handoff/persistence.rs
@@ -713,6 +713,8 @@ mod bundle_tests {
             applied_templates: Vec::new(),
             history_truncated_count: 0,
             partial_reason: None,
+            risks: vec![],
+            disagreements: vec![],
         }
     }
 

--- a/src/meeting_facilitator/mod.rs
+++ b/src/meeting_facilitator/mod.rs
@@ -147,6 +147,8 @@ mod tests {
             themes: vec![],
             next_owner: None,
             goal: None,
+            risks: vec![],
+            disagreements: vec![],
         };
         let summary = session.durable_summary();
         assert!(summary.contains("Planning"));

--- a/src/meeting_facilitator/session.rs
+++ b/src/meeting_facilitator/session.rs
@@ -62,6 +62,8 @@ pub fn start_meeting(topic: &str, bridge: &dyn CognitiveMemoryOps) -> SimardResu
         themes: Vec::new(),
         next_owner: None,
         goal: None,
+        risks: Vec::new(),
+        disagreements: Vec::new(),
     })
 }
 

--- a/src/meeting_facilitator/tests_handoff.rs
+++ b/src/meeting_facilitator/tests_handoff.rs
@@ -22,6 +22,8 @@ fn make_session(
         themes: Vec::new(),
         next_owner: None,
         goal: None,
+        risks: Vec::new(),
+        disagreements: Vec::new(),
     }
 }
 
@@ -413,6 +415,8 @@ fn round_trip_handoff_with_next_owner_and_artifacts() {
         applied_templates: Vec::new(),
         history_truncated_count: 0,
         partial_reason: None,
+        risks: vec![],
+        disagreements: vec![],
     };
 
     let json = serde_json::to_string_pretty(&handoff).expect("serialize ok");

--- a/src/meeting_facilitator/tests_handoff_extra.rs
+++ b/src/meeting_facilitator/tests_handoff_extra.rs
@@ -24,6 +24,8 @@ fn make_session(
         themes: Vec::new(),
         next_owner: None,
         goal: None,
+        risks: Vec::new(),
+        disagreements: Vec::new(),
     }
 }
 

--- a/src/meeting_facilitator/types.rs
+++ b/src/meeting_facilitator/types.rs
@@ -99,6 +99,17 @@ pub struct MeetingSession {
     /// user message. Added in issue #1987.
     #[serde(default)]
     pub goal: Option<String>,
+    /// Identified risks recorded via `/risk <text>` or extracted from the
+    /// conversation. Required by spec line 637 ("identified risks").
+    /// Added in issue #2084.
+    #[serde(default)]
+    pub risks: Vec<String>,
+    /// Disagreements or dissenting views recorded via `/disagree <text>` or
+    /// extracted from the conversation. Required by spec line 645
+    /// ("surface disagreement and uncertainty instead of smoothing over
+    /// them"). Added in issue #2084.
+    #[serde(default)]
+    pub disagreements: Vec<String>,
 }
 
 impl MeetingSession {
@@ -137,9 +148,14 @@ impl MeetingSession {
         } else {
             "unknown".to_string()
         };
+        let risks = if self.risks.is_empty() {
+            "none".to_string()
+        } else {
+            self.risks.join("; ")
+        };
         format!(
-            "meeting topic={}; duration={}; participants=[{}]; decisions=[{}]; action_items=[{}]",
-            self.topic, duration, participants, decisions, action_items,
+            "meeting topic={}; duration={}; participants=[{}]; decisions=[{}]; action_items=[{}]; risks=[{}]",
+            self.topic, duration, participants, decisions, action_items, risks,
         )
     }
 }
@@ -286,6 +302,8 @@ mod tests {
             themes: vec!["performance".to_string()],
             next_owner: None,
             goal: None,
+            risks: vec![],
+            disagreements: vec![],
         }
     }
 
@@ -299,7 +317,7 @@ mod tests {
 
     #[test]
     fn session_explicit_questions_default() {
-        // explicit_questions and themes have #[serde(default)], so missing fields default to empty vec
+        // explicit_questions, themes, risks, disagreements have #[serde(default)], so missing fields default to empty vec
         let json = r#"{
             "topic": "test",
             "decisions": [],
@@ -312,6 +330,8 @@ mod tests {
         let s: MeetingSession = serde_json::from_str(json).unwrap();
         assert!(s.explicit_questions.is_empty());
         assert!(s.themes.is_empty());
+        assert!(s.risks.is_empty());
+        assert!(s.disagreements.is_empty());
     }
 
     #[test]
@@ -358,12 +378,15 @@ mod tests {
             themes: vec![],
             next_owner: None,
             goal: None,
+            risks: vec![],
+            disagreements: vec![],
         };
         let summary = s.durable_summary();
         assert!(summary.contains("decisions=[none]"));
         assert!(summary.contains("action_items=[none]"));
         assert!(summary.contains("participants=[none]"));
         assert!(summary.contains("duration=unknown"));
+        assert!(summary.contains("risks=[none]"));
     }
 
     #[test]
@@ -380,6 +403,8 @@ mod tests {
             themes: vec![],
             next_owner: None,
             goal: None,
+            risks: vec![],
+            disagreements: vec![],
         };
         let summary = s.durable_summary();
         assert!(summary.contains("duration=unknown"));

--- a/src/meeting_repl/repl.rs
+++ b/src/meeting_repl/repl.rs
@@ -9,7 +9,8 @@ use crate::base_types::BaseTypeSession;
 use crate::cognitive_memory::CognitiveMemoryOps;
 use crate::error::{SimardError, SimardResult};
 use crate::meeting_backend::persist::{
-    extract_action_items, extract_decisions, extract_open_questions,
+    extract_action_items, extract_decisions, extract_disagreements, extract_open_questions,
+    extract_risks,
 };
 use crate::meeting_backend::{
     MeetingBackend, MeetingCommand, Role, parse_command, strip_ansi_escapes,
@@ -80,6 +81,62 @@ fn render_backend_error<W: Write>(output: &mut W, source: &str, err: &dyn std::f
     writeln!(output, "{}", yellow(&format!("  ↳ {hint}"))).ok();
 }
 
+/// Heuristic: detect messages that look like implementation work rather than
+/// planning/alignment discussion. Used by the drift guard (issue #2084,
+/// spec line 643: "Meeting mode should not edit code unless the user
+/// explicitly transitions to engineer mode").
+///
+/// Returns `true` when the message contains strong implementation signals
+/// (code fences, build commands, file-edit directives). Discussion *about*
+/// code (e.g. "we should use Rust") does not trigger a warning.
+fn looks_like_implementation(text: &str) -> bool {
+    let lower = text.to_lowercase();
+
+    // Code fences (```rust, ```python, etc.)
+    if text.contains("```") && text.len() > 10 {
+        return true;
+    }
+
+    // Build / test / deploy commands
+    const IMPL_COMMANDS: &[&str] = &[
+        "cargo build",
+        "cargo test",
+        "cargo run",
+        "npm install",
+        "npm run",
+        "pip install",
+        "git commit",
+        "git push",
+        "make build",
+        "make test",
+        "docker build",
+        "docker run",
+        "kubectl apply",
+    ];
+    if IMPL_COMMANDS.iter().any(|cmd| lower.contains(cmd)) {
+        return true;
+    }
+
+    // File-edit directives
+    const EDIT_SIGNALS: &[&str] = &[
+        "edit src/",
+        "edit lib/",
+        "modify src/",
+        "modify lib/",
+        "change the file",
+        "update the file",
+        "write to src/",
+        "write to lib/",
+        "create src/",
+        "create lib/",
+    ];
+    if EDIT_SIGNALS.iter().any(|sig| lower.contains(sig)) {
+        return true;
+    }
+
+    false
+}
+
 /// Run the interactive meeting REPL.
 ///
 /// Creates a `MeetingBackend` and loops on stdin. Returns a `MeetingSession`
@@ -141,7 +198,7 @@ pub fn run_meeting_repl<R: BufRead, W: Write>(
             MeetingCommand::Help => {
                 writeln!(
                     output,
-                    "Commands:\n  /status    — show session info\n  /state     — show current decisions, open questions, action items\n  /template  — list meeting templates\n  /template <name> — apply a template (standup, 1on1, retro, planning)\n  /theme <text>    — record a theme for this meeting\n  /decision <text> [--rationale <why>] — record a decision (optional rationale)\n  /action <text>   — record an action item (assignee/deadline parsed inline)\n  /question <text> — record an open question deterministically\n  /owner <name>    — name the next agent/persona/human expected to action this handoff\n  /goal <text>     — set the meeting's overarching objective\n  /recap     — show color-coded session recap\n  /preview   — preview the handoff artifact\n  /export    — export meeting as markdown\n  /close     — end meeting and persist\n  /help      — this message\n\nEverything else is natural conversation with Simard."
+                    "Commands:\n  /status    — show session info\n  /state     — show current decisions, open questions, action items, risks, disagreements\n  /template  — list meeting templates\n  /template <name> — apply a template (standup, 1on1, retro, planning)\n  /theme <text>    — record a theme for this meeting\n  /decision <text> [--rationale <why>] — record a decision (optional rationale)\n  /action <text>   — record an action item (assignee/deadline parsed inline)\n  /question <text> — record an open question deterministically\n  /risk <text>     — record an identified risk\n  /disagree <text> — record a disagreement or dissenting view\n  /owner <name>    — name the next agent/persona/human expected to action this handoff\n  /goal <text>     — set the meeting's overarching objective\n  /recap     — show color-coded session recap\n  /preview   — preview the handoff artifact\n  /export    — export meeting as markdown\n  /close     — end meeting and persist\n  /help      — this message\n\nEverything else is natural conversation with Simard."
                 )
                 .ok();
             }
@@ -165,6 +222,8 @@ pub fn run_meeting_repl<R: BufRead, W: Write>(
                 let inferred_decisions = extract_decisions(messages);
                 let inferred_questions = extract_open_questions(messages);
                 let inferred_actions = extract_action_items(messages);
+                let inferred_risks = extract_risks(messages);
+                let inferred_disagreements = extract_disagreements(messages);
 
                 let mut decisions: Vec<String> = backend
                     .explicit_decisions()
@@ -255,6 +314,49 @@ pub fn run_meeting_repl<R: BufRead, W: Write>(
                     }
                 }
                 writeln!(output).ok();
+
+                // ── Risks (issue #2084, spec line 637) ──
+                let mut state_risks: Vec<String> = backend.explicit_risks().to_vec();
+                for r in inferred_risks {
+                    let lower = r.to_lowercase();
+                    if !state_risks.iter().any(|e| e.to_lowercase() == lower) {
+                        state_risks.push(r);
+                    }
+                }
+
+                writeln!(output, "{}", yellow("── Risks ──")).ok();
+                if state_risks.is_empty() {
+                    writeln!(output, "  _(none)_").ok();
+                } else {
+                    for (i, r) in state_risks.iter().enumerate() {
+                        let safe = strip_ansi_escapes(r);
+                        writeln!(output, "  {}. {safe}", i + 1).ok();
+                    }
+                }
+
+                // ── Disagreements (issue #2084, spec line 645) ──
+                let mut state_disagreements: Vec<String> =
+                    backend.explicit_disagreements().to_vec();
+                for d in inferred_disagreements {
+                    let lower = d.to_lowercase();
+                    if !state_disagreements
+                        .iter()
+                        .any(|e| e.to_lowercase() == lower)
+                    {
+                        state_disagreements.push(d);
+                    }
+                }
+
+                writeln!(output, "\n{}", yellow("── Disagreements ──")).ok();
+                if state_disagreements.is_empty() {
+                    writeln!(output, "  _(none)_").ok();
+                } else {
+                    for (i, d) in state_disagreements.iter().enumerate() {
+                        let safe = strip_ansi_escapes(d);
+                        writeln!(output, "  {}. {safe}", i + 1).ok();
+                    }
+                }
+                writeln!(output).ok();
             }
             MeetingCommand::Theme(text) => {
                 backend.push_theme(text.clone());
@@ -289,6 +391,21 @@ pub fn run_meeting_repl<R: BufRead, W: Write>(
             MeetingCommand::Goal(text) => {
                 backend.set_goal(&text);
                 writeln!(output, "{}", cyan(&format!("Goal recorded: {text}"))).ok();
+                checkpoint_wip(&backend);
+            }
+            MeetingCommand::Risk(text) => {
+                backend.push_explicit_risk(&text);
+                writeln!(output, "{}", yellow(&format!("Risk recorded: {text}"))).ok();
+                checkpoint_wip(&backend);
+            }
+            MeetingCommand::Disagree(text) => {
+                backend.push_explicit_disagreement(&text);
+                writeln!(
+                    output,
+                    "{}",
+                    yellow(&format!("Disagreement recorded: {text}"))
+                )
+                .ok();
                 checkpoint_wip(&backend);
             }
             MeetingCommand::Recap => {
@@ -397,6 +514,25 @@ pub fn run_meeting_repl<R: BufRead, W: Write>(
                 if text.is_empty() {
                     continue;
                 }
+
+                // ── Drift guard (issue #2084, spec line 643) ──
+                // Meeting mode "should not edit code unless the user
+                // explicitly transitions to engineer mode." Warn when
+                // the operator's message looks like implementation work.
+                if looks_like_implementation(&text) {
+                    writeln!(
+                        output,
+                        "{}",
+                        yellow(
+                            "[drift guard] This looks like implementation work. \
+                             Meeting mode is for planning and alignment — use /close \
+                             to transition to engineer mode, or continue if this is \
+                             intentional discussion about implementation details."
+                        )
+                    )
+                    .ok();
+                }
+
                 // Show user turn prefix
                 let user_prefix = format_turn_prefix_now(&Role::User);
                 writeln!(output, "{} {}", cyan(&user_prefix), text).ok();
@@ -481,6 +617,22 @@ pub fn run_meeting_repl<R: BufRead, W: Write>(
                 writeln!(output, "\n── Themes ──").ok();
                 for t in &summary.themes {
                     writeln!(output, "  - {t}").ok();
+                }
+            }
+
+            // Display risks (issue #2084, spec line 637)
+            if !summary.risks.is_empty() {
+                writeln!(output, "\n{}", yellow("── Risks ──")).ok();
+                for (i, r) in summary.risks.iter().enumerate() {
+                    writeln!(output, "  {}. {r}", i + 1).ok();
+                }
+            }
+
+            // Display disagreements (issue #2084, spec line 645)
+            if !summary.disagreements.is_empty() {
+                writeln!(output, "\n{}", yellow("── Disagreements ──")).ok();
+                for (i, d) in summary.disagreements.iter().enumerate() {
+                    writeln!(output, "  {}. {d}", i + 1).ok();
                 }
             }
 
@@ -601,5 +753,7 @@ fn empty_closed_session(topic: &str) -> MeetingSession {
         themes: Vec::new(),
         next_owner: None,
         goal: None,
+        risks: Vec::new(),
+        disagreements: Vec::new(),
     }
 }

--- a/src/ooda_loop/curate.rs
+++ b/src/ooda_loop/curate.rs
@@ -269,6 +269,8 @@ mod tests {
             applied_templates: Vec::new(),
             history_truncated_count: 0,
             partial_reason: None,
+            risks: vec![],
+            disagreements: vec![],
         }
     }
 
@@ -298,6 +300,8 @@ mod tests {
             applied_templates: Vec::new(),
             history_truncated_count: 0,
             partial_reason: None,
+            risks: vec![],
+            disagreements: vec![],
         }
     }
 
@@ -573,6 +577,8 @@ mod tests {
             applied_templates: Vec::new(),
             history_truncated_count: 0,
             partial_reason: None,
+            risks: vec![],
+            disagreements: vec![],
         };
         let path_b = dir.path().join("handoff-2026-04-03T00-05-01_00-00.json");
         fs::write(&path_b, serde_json::to_string_pretty(&handoff_b).unwrap()).unwrap();

--- a/src/ooda_loop/tests_observe.rs
+++ b/src/ooda_loop/tests_observe.rs
@@ -181,6 +181,8 @@ fn scan_unprocessed_handoffs_returns_true_for_unprocessed() {
         applied_templates: Vec::new(),
         history_truncated_count: 0,
         partial_reason: None,
+        risks: vec![],
+        disagreements: vec![],
     };
     write_meeting_handoff(dir.path(), &handoff).unwrap();
 
@@ -218,6 +220,8 @@ fn scan_unprocessed_handoffs_returns_false_when_processed() {
         applied_templates: Vec::new(),
         history_truncated_count: 0,
         partial_reason: None,
+        risks: vec![],
+        disagreements: vec![],
     };
     write_meeting_handoff(dir.path(), &handoff).unwrap();
 

--- a/src/operator_cli/decisions.rs
+++ b/src/operator_cli/decisions.rs
@@ -199,6 +199,8 @@ mod tests {
             applied_templates: Vec::new(),
             history_truncated_count: 0,
             partial_reason: None,
+            risks: vec![],
+            disagreements: vec![],
         }
     }
 
@@ -281,6 +283,8 @@ mod tests {
             applied_templates: Vec::new(),
             history_truncated_count: 0,
             partial_reason: None,
+            risks: vec![],
+            disagreements: vec![],
         };
         let json = serde_json::to_string(&h).unwrap();
         let h2: MeetingHandoff = serde_json::from_str(&json).unwrap();

--- a/src/operator_cli/meeting.rs
+++ b/src/operator_cli/meeting.rs
@@ -394,6 +394,8 @@ mod tests {
             themes: Vec::new(),
             next_owner: None,
             goal: None,
+            risks: Vec::new(),
+            disagreements: Vec::new(),
         };
         crate::meeting_facilitator::save_session_wip(dir.path(), &session).expect("save WIP");
         assert!(wip_path.is_file(), "WIP file should exist before discard");

--- a/src/operator_commands_dashboard/chat.rs
+++ b/src/operator_commands_dashboard/chat.rs
@@ -314,6 +314,28 @@ pub(crate) async fn handle_ws_chat(mut socket: WebSocket) {
                             ))
                             .await;
                     }
+                    MeetingCommand::Risk(text) => {
+                        backend.push_explicit_risk(&text);
+                        let content = format!("Risk recorded: {text}");
+                        let _ = socket
+                            .send(Message::Text(
+                                json!({"role":"system","content": content})
+                                    .to_string()
+                                    .into(),
+                            ))
+                            .await;
+                    }
+                    MeetingCommand::Disagree(text) => {
+                        backend.push_explicit_disagreement(&text);
+                        let content = format!("Disagreement recorded: {text}");
+                        let _ = socket
+                            .send(Message::Text(
+                                json!({"role":"system","content": content})
+                                    .to_string()
+                                    .into(),
+                            ))
+                            .await;
+                    }
                     MeetingCommand::Recap => {
                         let status = backend.status();
                         let themes = backend.explicit_themes();

--- a/tests/act_on_decisions.rs
+++ b/tests/act_on_decisions.rs
@@ -70,6 +70,8 @@ fn sample_handoff() -> MeetingHandoff {
         themes: Vec::new(),
         next_owner: None,
         goal: None,
+        risks: Vec::new(),
+        disagreements: Vec::new(),
     };
     MeetingHandoff::from_session(&session)
 }
@@ -269,6 +271,8 @@ fn act_on_decisions_with_empty_handoff_creates_no_issues() {
         themes: Vec::new(),
         next_owner: None,
         goal: None,
+        risks: Vec::new(),
+        disagreements: Vec::new(),
     };
     let handoff = MeetingHandoff::from_session(&session);
     write_meeting_handoff(&dir, &handoff).unwrap();

--- a/tests/meeting_handoff.rs
+++ b/tests/meeting_handoff.rs
@@ -73,6 +73,8 @@ fn sample_session_with_questions() -> MeetingSession {
         themes: Vec::new(),
         next_owner: None,
         goal: None,
+        risks: Vec::new(),
+        disagreements: Vec::new(),
     }
 }
 
@@ -89,6 +91,8 @@ fn sample_empty_session() -> MeetingSession {
         themes: Vec::new(),
         next_owner: None,
         goal: None,
+        risks: Vec::new(),
+        disagreements: Vec::new(),
     }
 }
 
@@ -462,6 +466,8 @@ fn handoff_with_only_action_items_no_decisions() {
         themes: Vec::new(),
         next_owner: None,
         goal: None,
+        risks: Vec::new(),
+        disagreements: Vec::new(),
     };
     let handoff = MeetingHandoff::from_session(&session);
     assert!(handoff.decisions.is_empty());
@@ -491,6 +497,8 @@ fn handoff_with_only_decisions_no_actions() {
         themes: Vec::new(),
         next_owner: None,
         goal: None,
+        risks: Vec::new(),
+        disagreements: Vec::new(),
     };
     let handoff = MeetingHandoff::from_session(&session);
     assert_eq!(handoff.decisions.len(), 1);

--- a/tests/meeting_handoff_bundle.rs
+++ b/tests/meeting_handoff_bundle.rs
@@ -82,6 +82,8 @@ fn scripted_meeting_emits_structured_handoff_bundle() {
         themes: Vec::new(),
         next_owner: None,
         goal: None,
+        risks: Vec::new(),
+        disagreements: Vec::new(),
     };
 
     let mut handoff = MeetingHandoff::from_session(&session);
@@ -224,6 +226,8 @@ fn empty_transcript_still_produces_well_formed_bundle() {
         applied_templates: Vec::new(),
         history_truncated_count: 0,
         partial_reason: None,
+        risks: vec![],
+        disagreements: vec![],
     };
 
     let dir = write_meeting_bundle(&mut handoff, &[]).expect("write_meeting_bundle");


### PR DESCRIPTION
## Summary

Implements three spec-required meeting mode features (spec lines 635-645) that were identified as missing in #2084:

1. **Risk capture** — `/risk` slash command + heuristic transcript extraction (signal phrases: "risk:", "blocker", "could fail", "single point of failure", etc.)
2. **Disagreement/uncertainty surfacing** — `/disagree` slash command + heuristic transcript extraction (signal phrases: "disagree", "not convinced", "pushback", "counterpoint", etc.)
3. **Drift guard** — Non-blocking warning when conversation messages look like implementation work (code fences, build commands, file-edit directives). Meetings should surface decisions, not execute code.

## Changes

**Types layer:**
- `MeetingSession`: added `risks: Vec<String>` and `disagreements: Vec<String>` fields
- `MeetingSummary`: added `risks` and `disagreements` fields
- `MeetingHandoff`: added `risks` and `disagreements` fields
- All new fields use `#[serde(default)]` for backward compatibility

**Command layer:**
- Added `Risk(String)` and `Disagree(String)` variants to `MeetingCommand`
- Added `/risk` and `/disagree` parsing in `parse_command()`

**Backend layer:**
- Added `explicit_risks` and `explicit_disagreements` storage on `MeetingBackend`
- Added push/read methods and `snapshot_session()` integration

**Extraction layer:**
- Added `extract_risks()` and `extract_disagreements()` heuristic functions in `persist/extract.rs`

**Closing pipeline:**
- Wired risk/disagreement extraction through both normal close and partial close paths
- Dedup explicit + inferred items before enrichment

**Persistence layer:**
- Carried risks/disagreements through `HandoffEnrichment` to both legacy and bundle handoff writers

**REPL:**
- `/risk` and `/disagree` command handlers
- Risks and disagreements sections in `/state` display
- Risks and disagreements in close summary
- Drift guard warning on implementation-like messages

**Dashboard:**
- `/risk` and `/disagree` handled in WebSocket chat

## Testing

- `cargo check` and `cargo check --tests`: clean
- `cargo test --lib`: 5436 passed, 11 failed (all pre-existing — binary mtime, disk_health, safe_update — unrelated to meeting code)
- All pre-commit and pre-push hooks pass (fmt, clippy, memory tests)
- Command parser unit tests added for `/risk` and `/disagree`
- All existing meeting integration tests updated and passing

## Files changed (23)

| File | Change |
|------|--------|
| `src/meeting_facilitator/types.rs` | Added risks/disagreements fields to MeetingSession |
| `src/meeting_backend/command.rs` | Added Risk/Disagree command variants + parser + tests |
| `src/meeting_backend/types.rs` | Added risks/disagreements to MeetingSummary |
| `src/meeting_backend/mod.rs` | Added explicit risk/disagreement storage + methods |
| `src/meeting_backend/persist/extract.rs` | Added extract_risks() and extract_disagreements() |
| `src/meeting_backend/persist/mod.rs` | Wired through HandoffEnrichment + both writers |
| `src/meeting_backend/closing.rs` | Wired through both close paths |
| `src/meeting_facilitator/handoff/mod.rs` | Added risks/disagreements to MeetingHandoff |
| `src/meeting_repl/repl.rs` | REPL handlers, state display, drift guard |
| `src/operator_commands_dashboard/chat.rs` | Dashboard WebSocket handlers |
| `src/meeting_facilitator/session.rs` | Constructor update |
| `src/meeting_facilitator/mod.rs` | Test constructor update |
| `tests/act_on_decisions.rs` | Integration test constructor updates |
| `tests/meeting_handoff.rs` | Integration test constructor updates |
| `tests/meeting_handoff_bundle.rs` | Integration test constructor updates |
| + 8 more test files | Constructor updates for new fields |

Closes #2084