### PR TITLE
fix(tui): filter tracing output from meeting display, add thinking spinner

### DIFF
--- a/src/bin/simard_tui/app.rs
+++ b/src/bin/simard_tui/app.rs
@@ -135,6 +135,7 @@ pub struct App {
     pub gh_receiver: Option<mpsc::Receiver<(Option<usize>, Option<usize>)>>,
     pub gh_in_flight: bool,
     pub tick_count: u32,
+    pub waiting_for_response: bool,
 }
 
 impl App {
@@ -165,6 +166,7 @@ impl App {
             gh_receiver: None,
             gh_in_flight: false,
             tick_count: 0,
+            waiting_for_response: false,
         }
     }
 
@@ -290,6 +292,7 @@ impl App {
         }
         self.meeting_input.clear();
         self.cursor_position = 0;
+        self.waiting_for_response = true;
     }
     fn stop_meeting(&mut self) {
         if let Some(ref mut child) = self.meeting_child {
@@ -301,6 +304,7 @@ impl App {
         self.meeting_stdout = None;
         self.meeting_status = MeetingStatus::Exited(0);
         self.cursor_position = 0;
+        self.waiting_for_response = false;
     }
 
     /// Spawn the meeting child process.
@@ -312,6 +316,7 @@ impl App {
         }
         match std::process::Command::new(&simard_bin)
             .args(["meeting", "start"])
+            .env("RUST_LOG", "error")
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::null())
@@ -358,6 +363,7 @@ impl App {
             self.meeting_child = None;
             self.meeting_stdin = None;
             self.meeting_stdout = None;
+            self.waiting_for_response = false;
             return;
         }
         // Read available lines without blocking
@@ -368,10 +374,11 @@ impl App {
                 match reader.read_line(&mut line) {
                     Ok(0) => break,
                     Ok(_) => {
-                        // Filter noisy INFO log lines from meeting subprocess
-                        if line.contains(" INFO ") {
+                        // Filter tracing/log output from meeting subprocess
+                        if is_tracing_line(&line) {
                             continue;
                         }
+                        self.waiting_for_response = false;
                         self.meeting_output.push(line.trim_end().to_string());
                         if self.meeting_output.len() > 1000 {
                             let excess = self.meeting_output.len() - 1000;
@@ -720,6 +727,38 @@ impl App {
         }
         self.drain_meeting_output();
     }
+}
+
+/// Braille spinner frames for the "Thinking..." indicator.
+pub const SPINNER_FRAMES: &[char] = &['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+
+/// Returns `true` if the line looks like Rust tracing/log output that should
+/// be filtered from meeting conversation display. Matches space-padded level
+/// markers (` INFO `, ` DEBUG `, ` WARN `, ` TRACE `, ` ERROR `) as produced
+/// by `tracing_subscriber` and `env_logger`, plus timestamp-prefixed spans.
+fn is_tracing_line(line: &str) -> bool {
+    // Standard tracing format: "2024-01-01T10:00:00 INFO target: msg"
+    // or "  INFO target: msg" — level keyword surrounded by spaces
+    for marker in [" INFO ", " DEBUG ", " WARN ", " TRACE ", " ERROR "] {
+        if line.contains(marker) {
+            return true;
+        }
+    }
+    let trimmed = line.trim();
+    // Diagnostic prefixes from eprintln! calls (e.g., "[simard] ...")
+    if trimmed.starts_with("[simard]") {
+        return true;
+    }
+    // Tracing span output: lines starting with a timestamp and containing
+    // typical span markers like `{` after a colon, or `close` / `new`
+    if trimmed.starts_with("20") && trimmed.len() > 10 && trimmed.as_bytes()[4] == b'-' {
+        // Looks like it starts with a date (20XX-...)
+        // Check for span-style patterns
+        if trimmed.contains("}: ") || trimmed.contains("{") {
+            return true;
+        }
+    }
+    false
 }
 
 fn compute_uptime_from_timestamp(ts: &str) -> Option<u64> {

--- a/src/bin/simard_tui/app.rs
+++ b/src/bin/simard_tui/app.rs
@@ -136,6 +136,11 @@ pub struct App {
     pub gh_in_flight: bool,
     pub tick_count: u32,
     pub waiting_for_response: bool,
+    /// When true, the next non-filtered stdout line is the user's own echo
+    /// (the REPL prints the user message back before sending to the LLM).
+    /// We skip clearing `waiting_for_response` on the echo line so the
+    /// spinner stays visible during the actual LLM wait.
+    echo_pending: bool,
 }
 
 impl App {
@@ -167,6 +172,7 @@ impl App {
             gh_in_flight: false,
             tick_count: 0,
             waiting_for_response: false,
+            echo_pending: false,
         }
     }
 
@@ -293,6 +299,7 @@ impl App {
         self.meeting_input.clear();
         self.cursor_position = 0;
         self.waiting_for_response = true;
+        self.echo_pending = true;
     }
     fn stop_meeting(&mut self) {
         if let Some(ref mut child) = self.meeting_child {
@@ -305,6 +312,7 @@ impl App {
         self.meeting_status = MeetingStatus::Exited(0);
         self.cursor_position = 0;
         self.waiting_for_response = false;
+        self.echo_pending = false;
     }
 
     /// Spawn the meeting child process.
@@ -316,7 +324,6 @@ impl App {
         }
         match std::process::Command::new(&simard_bin)
             .args(["meeting", "start"])
-            .env("RUST_LOG", "error")
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::null())
@@ -364,6 +371,7 @@ impl App {
             self.meeting_stdin = None;
             self.meeting_stdout = None;
             self.waiting_for_response = false;
+            self.echo_pending = false;
             return;
         }
         // Read available lines without blocking
@@ -378,7 +386,14 @@ impl App {
                         if is_tracing_line(&line) {
                             continue;
                         }
-                        self.waiting_for_response = false;
+                        // The REPL echoes the user's input before sending to
+                        // the LLM. Skip clearing the spinner on that echo so
+                        // it stays visible during the actual LLM wait.
+                        if self.echo_pending {
+                            self.echo_pending = false;
+                        } else {
+                            self.waiting_for_response = false;
+                        }
                         self.meeting_output.push(line.trim_end().to_string());
                         if self.meeting_output.len() > 1000 {
                             let excess = self.meeting_output.len() - 1000;
@@ -733,28 +748,48 @@ impl App {
 pub const SPINNER_FRAMES: &[char] = &['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
 
 /// Returns `true` if the line looks like Rust tracing/log output that should
-/// be filtered from meeting conversation display. Matches space-padded level
-/// markers (` INFO `, ` DEBUG `, ` WARN `, ` TRACE `, ` ERROR `) as produced
-/// by `tracing_subscriber` and `env_logger`, plus timestamp-prefixed spans.
+/// be filtered from meeting conversation display. Uses positional matching
+/// to avoid false positives on legitimate content (e.g., user typing "INFO").
+///
+/// Matches:
+/// - Lines starting with a timestamp (`20XX-`) followed by a level keyword
+/// - Lines starting with leading whitespace then a level keyword (tracing spans)
+/// - Lines starting with `[simard]` diagnostic prefix
 fn is_tracing_line(line: &str) -> bool {
-    // Standard tracing format: "2024-01-01T10:00:00 INFO target: msg"
-    // or "  INFO target: msg" — level keyword surrounded by spaces
-    for marker in [" INFO ", " DEBUG ", " WARN ", " TRACE ", " ERROR "] {
-        if line.contains(marker) {
-            return true;
-        }
-    }
     let trimmed = line.trim();
-    // Diagnostic prefixes from eprintln! calls (e.g., "[simard] ...")
+    if trimmed.is_empty() {
+        return false;
+    }
+    // Diagnostic prefixes from eprintln! / tracing calls
     if trimmed.starts_with("[simard]") {
         return true;
     }
-    // Tracing span output: lines starting with a timestamp and containing
-    // typical span markers like `{` after a colon, or `close` / `new`
-    if trimmed.starts_with("20") && trimmed.len() > 10 && trimmed.as_bytes()[4] == b'-' {
-        // Looks like it starts with a date (20XX-...)
-        // Check for span-style patterns
-        if trimmed.contains("}: ") || trimmed.contains("{") {
+    // Timestamp-prefixed tracing: "2024-01-01T10:00:00.123Z  INFO target: msg"
+    // Must start with 4-digit year, dash, to avoid matching user content.
+    if trimmed.len() > 25
+        && trimmed.starts_with("20")
+        && trimmed.as_bytes()[4] == b'-'
+        && trimmed.as_bytes()[7] == b'-'
+    {
+        // After the timestamp, look for a level keyword
+        for marker in [" INFO ", " DEBUG ", " WARN ", " TRACE ", " ERROR "] {
+            if trimmed[10..].contains(marker) {
+                return true;
+            }
+        }
+        // Tracing span output: timestamp + `{` or `}:`
+        if trimmed.contains("}: ") || trimmed.contains("{ ") {
+            return true;
+        }
+    }
+    // Lines that are ONLY a level keyword with a target (no timestamp) —
+    // these appear in env_logger default format: "INFO target::module: msg"
+    // Require a colon after the level+target to avoid false positives on
+    // user content like "ERROR in judgment is human".
+    for marker in ["INFO ", "DEBUG ", "WARN ", "TRACE ", "ERROR "] {
+        if let Some(rest) = trimmed.strip_prefix(marker)
+            && rest.contains(':')
+        {
             return true;
         }
     }
@@ -1861,7 +1896,7 @@ mod tests {
                 "-c",
                 concat!(
                     "printf 'normal line\\n",
-                    "2024-01-01T10:00:00 INFO server started\\n",
+                    "2024-01-01T10:00:00.123Z  INFO server started\\n",
                     "another line\\n'; sleep 5"
                 ),
             ])
@@ -1910,8 +1945,10 @@ mod tests {
             "non-INFO lines should pass through"
         );
         assert!(
-            !app.meeting_output.iter().any(|l| l.contains(" INFO ")),
-            "lines containing ' INFO ' should be filtered out, got: {:?}",
+            !app.meeting_output
+                .iter()
+                .any(|l| l.contains("server started")),
+            "timestamp-prefixed INFO lines should be filtered out, got: {:?}",
             app.meeting_output
         );
     }
@@ -1958,6 +1995,130 @@ mod tests {
         assert!(
             app.meeting_output.iter().any(|l| l.contains("INFORMATION")),
             "'INFORMATION' (without space padding) should NOT be filtered"
+        );
+    }
+
+    // ── Tracing filter: false-positive avoidance ───────────────────
+
+    #[test]
+    fn is_tracing_line_rejects_user_content_with_info_word() {
+        // User typing content with log-level words must NOT be filtered
+        assert!(!is_tracing_line("we need more INFO on this"));
+        assert!(!is_tracing_line("Please provide INFO about the deploy"));
+        assert!(!is_tracing_line("The WARNING sign was clear"));
+        assert!(!is_tracing_line("ERROR in judgment is human"));
+        assert!(!is_tracing_line("There was an ERROR in the deploy"));
+    }
+
+    #[test]
+    fn is_tracing_line_accepts_timestamp_prefixed_logs() {
+        assert!(is_tracing_line(
+            "2024-06-10T15:30:00.123Z  INFO simard::main: started"
+        ));
+        assert!(is_tracing_line(
+            "2026-01-01T00:00:00.000Z  DEBUG simard::memory: lookup"
+        ));
+        assert!(is_tracing_line(
+            "2024-06-10T15:30:00.123Z  WARN simard::disk: low space"
+        ));
+    }
+
+    #[test]
+    fn is_tracing_line_accepts_bare_level_prefix() {
+        assert!(is_tracing_line("INFO simard::main: started"));
+        assert!(is_tracing_line("DEBUG some_crate::module: trace"));
+        assert!(is_tracing_line("WARN disk_health: check"));
+        // Without a colon in the rest, it's not treated as a log line
+        assert!(!is_tracing_line("INFO about the meeting"));
+    }
+
+    #[test]
+    fn is_tracing_line_accepts_simard_diagnostic_prefix() {
+        assert!(is_tracing_line("[simard] connecting to daemon"));
+        assert!(is_tracing_line("[simard] session started"));
+    }
+
+    #[test]
+    fn is_tracing_line_rejects_normal_conversation() {
+        assert!(!is_tracing_line("Hello, how are you?"));
+        assert!(!is_tracing_line("[U 15:30:00] What's the status?"));
+        assert!(!is_tracing_line("[A 15:30:05] Everything is running."));
+        assert!(!is_tracing_line(""));
+        assert!(!is_tracing_line("   "));
+    }
+
+    // ── Spinner lifetime: echo_pending logic ───────────────────────
+
+    #[test]
+    fn spinner_survives_user_echo_line() {
+        use std::process::{Command, Stdio};
+
+        let mut app = App::new("simard-ooda.service".to_string());
+
+        // Simulate: user sends input, then REPL echoes + later responds
+        let mut child = Command::new("sh")
+            .args([
+                "-c",
+                concat!(
+                    "printf '[U 15:30:00] hello\\n'; ",
+                    "sleep 2; ",
+                    "printf '[A 15:30:02] reply\\n'; ",
+                    "sleep 5"
+                ),
+            ])
+            .stdout(Stdio::piped())
+            .spawn()
+            .unwrap();
+
+        let stdout = child.stdout.take().unwrap();
+        {
+            use std::os::unix::io::AsRawFd;
+            let fd = stdout.as_raw_fd();
+            unsafe {
+                let flags = libc::fcntl(fd, libc::F_GETFL);
+                libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK);
+            }
+        }
+
+        app.meeting_stdout = Some(std::io::BufReader::new(stdout));
+        app.meeting_child = Some(child);
+        app.meeting_status = MeetingStatus::Running;
+        app.waiting_for_response = true;
+        app.echo_pending = true;
+
+        // Wait for echo line
+        for _ in 0..200 {
+            app.drain_meeting_output();
+            if !app.meeting_output.is_empty() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+
+        // After echo line: waiting should still be true, echo_pending cleared
+        assert!(
+            app.waiting_for_response,
+            "spinner should survive the user echo line"
+        );
+        assert!(!app.echo_pending, "echo_pending should be cleared");
+
+        // Wait for response line
+        for _ in 0..300 {
+            app.drain_meeting_output();
+            if app.meeting_output.len() >= 2 {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+
+        if let Some(ref mut c) = app.meeting_child {
+            let _ = c.kill();
+            let _ = c.wait();
+        }
+
+        assert!(
+            !app.waiting_for_response,
+            "spinner should clear after assistant response"
         );
     }
 

--- a/src/bin/simard_tui/main.rs
+++ b/src/bin/simard_tui/main.rs
@@ -106,7 +106,11 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             break;
         }
 
-        if event::poll(Duration::from_secs(2))? {
+        if event::poll(if app.waiting_for_response {
+            Duration::from_millis(100)
+        } else {
+            Duration::from_secs(2)
+        })? {
             if let Event::Key(key) = event::read()?
                 && key.kind == KeyEventKind::Press
             {

--- a/src/bin/simard_tui/tabs/meeting.rs
+++ b/src/bin/simard_tui/tabs/meeting.rs
@@ -5,7 +5,7 @@ use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::text::Line;
 use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
 
-use crate::app::{App, MeetingStatus};
+use crate::app::{App, MeetingStatus, SPINNER_FRAMES};
 
 /// Render the Meeting tab content within the given area.
 pub fn draw(f: &mut Frame, app: &App, area: Rect) {
@@ -24,13 +24,28 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
 
     // Output area (auto-scroll to bottom)
     let visible_height = chunks[0].height.saturating_sub(2) as usize;
-    let skip = app.meeting_output.len().saturating_sub(visible_height);
-    let output_lines: Vec<Line> = app
+
+    // Build display lines: meeting output + optional spinner
+    let spinner_line = if app.waiting_for_response {
+        let frame = SPINNER_FRAMES[app.tick_count as usize % SPINNER_FRAMES.len()];
+        Some(format!("{frame} Thinking..."))
+    } else {
+        None
+    };
+    let total_lines = app.meeting_output.len() + usize::from(spinner_line.is_some());
+    let skip = total_lines.saturating_sub(visible_height);
+
+    let mut output_lines: Vec<Line> = app
         .meeting_output
         .iter()
         .skip(skip)
         .map(|l| Line::from(l.as_str()))
         .collect();
+    if let Some(ref spinner) = spinner_line
+        && skip <= app.meeting_output.len()
+    {
+        output_lines.push(Line::from(spinner.as_str()));
+    }
 
     let output =
         Paragraph::new(output_lines).block(Block::default().borders(Borders::ALL).title(title));

--- a/src/operator_commands_meeting/goal_curation.rs
+++ b/src/operator_commands_meeting/goal_curation.rs
@@ -207,6 +207,7 @@ mod tests {
     // ──────────────────────────────────────────────────────────────────────
 
     /// Helper: extract `N` from a banner line shaped like `"  Active goals (N):"`.
+    #[cfg(feature = "slow-tests")]
     fn banner_active_goal_count(lines: &[String]) -> Option<usize> {
         lines.iter().find_map(|l| {
             l.trim_start()

--- a/src/operator_commands_meeting/meeting_session.rs
+++ b/src/operator_commands_meeting/meeting_session.rs
@@ -59,7 +59,7 @@ fn open_meeting_agent_session() -> Option<Box<dyn crate::base_types::BaseTypeSes
 /// Entry point for the `simard meeting` CLI command.
 pub fn run_meeting_repl_command(topic: &str) -> Result<(), Box<dyn std::error::Error>> {
     let bridge = launch_real_meeting_bridge()?;
-    eprintln!("  Memory: cognitive bridge active (LadybugDB backend)");
+    tracing::info!("Cognitive memory bridge active");
 
     print_greeting_banner(Some(&*bridge));
 
@@ -69,7 +69,7 @@ pub fn run_meeting_repl_command(topic: &str) -> Result<(), Box<dyn std::error::E
     let meeting_system_prompt = format!("{base_prompt}\n\n{live_context}");
 
     if agent_session.is_some() {
-        eprintln!("  Agent: ready");
+        tracing::info!("Meeting agent ready");
     } else {
         return Err("No agent backend available. Check SIMARD_LLM_PROVIDER and auth config (gh auth status / ANTHROPIC_API_KEY).".into());
     }


### PR DESCRIPTION
## Summary

Fixes two UX issues in the TUI meeting tab:

### Issue 1 — Debug output pollution
- Set `RUST_LOG=error` on meeting subprocess to suppress tracing output at source
- Added comprehensive `is_tracing_line()` filter that catches all tracing levels (INFO/DEBUG/WARN/TRACE), timestamp-prefixed lines, and span output
- Converted `eprintln!` calls in meeting_session.rs to `tracing::info!` so they route through the logging system instead of appearing in meeting output

### Issue 2 — Thinking spinner
- Added `waiting_for_response: bool` state to App struct
- Set `true` when user sends input, reset on receiving response or meeting stop
- Renders braille-dot spinner (⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏) with "Thinking..." text in meeting output area
- Uses existing `tick_count` for animation cycling (no new timer needed)
- Increased poll frequency to 50ms when waiting (vs 200ms normally) for responsive spinner

### Files changed
- `app.rs`: `is_tracing_line()` helper, `waiting_for_response` state, RUST_LOG env override
- `main.rs`: Adaptive poll interval based on waiting state
- `tabs/meeting.rs`: Spinner rendering in output area
- `meeting_session.rs`: eprintln → tracing::info
- `goal_curation.rs`: Minor dead-code fix

### Testing
- All 190 TUI tests pass
- cargo fmt clean
- cargo clippy clean