### PR TITLE
fix(tui): improve UX — help text, cursor visibility, tab styling

### DIFF
--- a/src/bin/simard_tui/tabs/meeting.rs
+++ b/src/bin/simard_tui/tabs/meeting.rs
@@ -36,8 +36,29 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
         Paragraph::new(output_lines).block(Block::default().borders(Borders::ALL).title(title));
     f.render_widget(output, chunks[0]);
 
-    // Input prompt
-    let input_text = format!("> {}", app.meeting_input);
+    // Input prompt with visible cursor
+    let (before_cursor, after_cursor) = app.meeting_input.split_at(app.cursor_position);
+    let input_text = if app.meeting_status == MeetingStatus::Running {
+        use ratatui::style::{Modifier, Style};
+        use ratatui::text::Span;
+        // Show cursor as reversed char (or block at end)
+        let cursor_char = after_cursor.chars().next().unwrap_or(' ');
+        let after_skip = if after_cursor.is_empty() {
+            ""
+        } else {
+            &after_cursor[cursor_char.len_utf8()..]
+        };
+        Line::from(vec![
+            Span::raw(format!("> {before_cursor}")),
+            Span::styled(
+                cursor_char.to_string(),
+                Style::default().add_modifier(Modifier::REVERSED),
+            ),
+            Span::raw(after_skip.to_string()),
+        ])
+    } else {
+        Line::from(format!("> {}", app.meeting_input))
+    };
     let input = Paragraph::new(input_text)
         .block(Block::default().borders(Borders::ALL).title("Input"))
         .wrap(Wrap { trim: false });

--- a/src/bin/simard_tui/tabs/overview.rs
+++ b/src/bin/simard_tui/tabs/overview.rs
@@ -52,7 +52,7 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
         ]),
         Line::from(""),
         Line::from(Span::styled(
-            " Press 1-6 to switch tabs, q to quit",
+            " Alt+1\u{2013}6 / Tab / \u{2190}\u{2192} to switch tabs, q to quit",
             Style::default().fg(Color::DarkGray),
         )),
     ];

--- a/src/bin/simard_tui/ui.rs
+++ b/src/bin/simard_tui/ui.rs
@@ -37,8 +37,9 @@ pub fn draw(f: &mut Frame, app: &App) {
         .highlight_style(
             Style::default()
                 .fg(Color::Yellow)
-                .add_modifier(Modifier::BOLD),
-        );
+                .add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
+        )
+        .divider("|");
 
     f.render_widget(tabs_widget, chunks[0]);
 
@@ -51,7 +52,9 @@ pub fn draw(f: &mut Frame, app: &App) {
         Tab::Stats => tabs::stats::draw(f, app, chunks[1]),
     }
 
-    let footer = Paragraph::new("Alt+1\u{2025}6: tabs | \u{2190}/\u{2192}: cycle | q: quit")
-        .style(Style::default().fg(Color::DarkGray));
+    let footer = Paragraph::new(
+        "Alt+1\u{2013}6: tabs | Tab/Shift+Tab: cycle | \u{2190}/\u{2192}: prev/next | q: quit",
+    )
+    .style(Style::default().fg(Color::DarkGray));
     f.render_widget(footer, chunks[2]);
 }


### PR DESCRIPTION
## Summary

Fixes three TUI UX issues in the simard-tui dashboard. Closes #2249.

## Changes

### 1. Fix stale help text (overview tab)
The overview tab displayed "Press 1-6 to switch tabs" but the actual shortcuts are Alt+1-6 (bare digits are no-ops outside meeting input). Updated to: **"Alt+1–6 / Tab / ←→ to switch tabs, q to quit"**.

### 2. Update footer with complete keybinding documentation  
The footer only mentioned `Alt+1…6` and `←/→`. Now shows all navigation methods: **"Alt+1–6: tabs | Tab/Shift+Tab: cycle | ←/→: prev/next | q: quit"**.

### 3. Add visible cursor in meeting REPL input
When the meeting is running, the cursor position is now shown with **reversed-video styling** on the character at the insertion point. This makes Left/Right cursor movement visible to the user, fixing the problem where cursor position was invisible after moving it.

### 4. Improve tab bar visual separation
- Added `Modifier::UNDERLINED` to the active tab highlight (in addition to bold+yellow)
- Added pipe `|` divider between tabs for clearer visual separation

## Files Changed
- `src/bin/simard_tui/tabs/overview.rs` — Fix help text
- `src/bin/simard_tui/ui.rs` — Update footer text, tab highlight styling, divider
- `src/bin/simard_tui/tabs/meeting.rs` — Add visible cursor rendering

## Verification
- `cargo fmt --check` ✅ clean
- `cargo clippy --bin simard-tui -- -D warnings` ✅ no warnings  
- `cargo test --bin simard-tui` ✅ all 190 tests pass (including `input_area_uses_length_5`, `long_input_wraps_to_second_line`, and all tab cycling tests)
- Diff is focused — only 3 files changed, 31 insertions, 7 deletions