### PR TITLE
fix(tui): tab/arrow navigation, numeral key conflict, meeting input wrapping

### DIFF
--- a/src/bin/simard_tui/app.rs
+++ b/src/bin/simard_tui/app.rs
@@ -1736,6 +1736,28 @@ mod tests {
         assert_eq!(app.cursor_position, 1);
     }
 
+    #[test]
+    fn meeting_home_moves_cursor_to_start() {
+        let mut app = App::new("simard-ooda.service".to_string());
+        app.active_tab = Tab::Meeting;
+        app.meeting_status = MeetingStatus::Running;
+        app.meeting_input = "hello".to_string();
+        app.cursor_position = 3;
+        app.handle_key(key_code(KeyCode::Home));
+        assert_eq!(app.cursor_position, 0);
+    }
+
+    #[test]
+    fn meeting_end_moves_cursor_to_end() {
+        let mut app = App::new("simard-ooda.service".to_string());
+        app.active_tab = Tab::Meeting;
+        app.meeting_status = MeetingStatus::Running;
+        app.meeting_input = "hello".to_string();
+        app.cursor_position = 1;
+        app.handle_key(key_code(KeyCode::End));
+        assert_eq!(app.cursor_position, 5);
+    }
+
     // ── Tab/BackTab cycling ────────────────────────────────────────
 
     #[test]

--- a/src/bin/simard_tui/ui.rs
+++ b/src/bin/simard_tui/ui.rs
@@ -51,7 +51,9 @@ pub fn draw(f: &mut Frame, app: &App) {
         Tab::Stats => tabs::stats::draw(f, app, chunks[1]),
     }
 
-    let footer = Paragraph::new("Alt+1\u{2025}6: tabs | \u{2190}/\u{2192}: cycle | q: quit")
-        .style(Style::default().fg(Color::DarkGray));
+    let footer = Paragraph::new(
+        "Alt+1\u{2025}6: tabs | Tab/Shift+Tab: cycle | \u{2190}/\u{2192}: cycle | q: quit",
+    )
+    .style(Style::default().fg(Color::DarkGray));
     f.render_widget(footer, chunks[2]);
 }


### PR DESCRIPTION
Closes #2249

- Tab/Shift+Tab/Left/Right arrow tab cycling
- Numeral keys require Alt/Ctrl modifier; bare digits route to meeting input
- Meeting input area 5 lines tall with text wrapping
- Footer help text updated to document Tab/Shift+Tab
- Home/End cursor movement tests added

All 198 TUI tests pass.