### PR TITLE
feat(ooda): enforce merge-ready criteria in goal session objective

### DIFF
--- a/prompt_assets/simard/goal_session_objective.md
+++ b/prompt_assets/simard/goal_session_objective.md
@@ -6,25 +6,43 @@ cycle and respond with **prose only** (no JSON, no code fences).
 
 Before starting any new work, triage existing PRs in this strict order:
 
-1. **Merge green PRs first.** If any open PR has all checks passing and is
-   approved, merge it immediately (`gh pr merge --squash --delete-branch`).
+1. **Drive open PRs to merge-ready.** For each open PR related to this goal,
+   the engineer must verify ALL merge-ready criteria before merging:
+   - qa-team scenarios written, validated (`gadugi-test validate`), and run (`gadugi-test run`)
+   - User-facing docs updated if the change affects APIs, config, CLI, or deployment
+   - quality-audit completed ≥3 SEEK→VALIDATE→FIX cycles, ended on a clean final cycle
+   - All CI checks green (0 failures)
+   - PR description updated with concrete evidence for all criteria
+   - Diff contains no unrelated changes
+   If a PR is CI-green but missing merge-ready evidence, tell the engineer to
+   run the merge-ready process on it — do NOT merge without evidence.
+   Once all criteria are met, merge via `gh pr merge --squash --delete-branch`.
 2. **Fix failing PRs second.** For each red PR, diagnose the CI failure, apply
    the fix, and push. Do not open new PRs while fixable failures exist.
 3. **Close duplicate PRs.** If multiple PRs address the same issue or overlap
    substantially, keep the most complete one and close the rest.
 4. **New work last.** Only start a new implementation when no existing PRs need
-   attention (all green PRs merged, all fixable failures resolved, duplicates
-   closed).
+   attention (all merge-ready PRs merged, all fixable failures resolved,
+   duplicates closed).
+
+# Self-update awareness
+
+When you merge a PR to the **Simard** repository's main branch, the running
+binary is now behind origin/main. After merging, tell the engineer to note
+that a self-update is needed. The OODA brain will detect the drift via
+`compute_commits_behind()` and trigger `simard safe-update` when no engineers
+are in flight. Do not block on this — just be aware that merged Simard PRs
+require a subsequent rebuild cycle.
 
 # Two response shapes
 
 1. **Spawn an engineer.** Write one paragraph describing what an engineer
    subprocess should do next for this goal. Be concrete: cite files,
-   commands, issue numbers when relevant. The engineer is a full coding
-   agent — it can run `gh issue create`, `gh pr comment`, `cargo test`,
-   edit files, open PRs, etc. So if the next step is "open a follow-up
-   issue against rysweet/Simard titled X with body Y", say that in prose
-   and the engineer will run the `gh` command itself.
+   commands, issue numbers, PR numbers when relevant. The engineer is a
+   full coding agent — it can run `gh issue create`, `gh pr comment`,
+   `gh pr merge`, `cargo test`, edit files, open PRs, etc. When telling
+   the engineer to merge a PR, always instruct it to verify merge-ready
+   criteria first.
 
 2. **No action this cycle.** Write the literal phrase `NO ACTION` on its
    own line, then optionally a short prose explanation on the following

--- a/src/ooda_brain/prompt_store_tests.rs
+++ b/src/ooda_brain/prompt_store_tests.rs
@@ -349,3 +349,33 @@ fn goal_session_objective_disk_override_works() {
         "# CUSTOM GOAL OBJECTIVE\n"
     );
 }
+
+#[test]
+fn goal_session_objective_requires_merge_ready_criteria() {
+    let content = embedded_fallback("goal_session_objective.md")
+        .expect("goal_session_objective.md must be registered");
+    let lower = content.to_lowercase();
+    assert!(
+        lower.contains("merge-ready") || lower.contains("merge_ready"),
+        "Priority Order must require merge-ready criteria verification before merging"
+    );
+    assert!(
+        lower.contains("qa-team") || lower.contains("qa_team"),
+        "merge-ready criteria must mention qa-team scenarios"
+    );
+    assert!(
+        lower.contains("quality-audit") || lower.contains("quality_audit"),
+        "merge-ready criteria must mention quality-audit cycles"
+    );
+}
+
+#[test]
+fn goal_session_objective_mentions_self_update() {
+    let content = embedded_fallback("goal_session_objective.md")
+        .expect("goal_session_objective.md must be registered");
+    let lower = content.to_lowercase();
+    assert!(
+        lower.contains("self-update") || lower.contains("self_update"),
+        "goal_session_objective.md must mention self-update awareness for Simard repo merges"
+    );
+}


### PR DESCRIPTION
## Summary

Updates the OODA PM prompt (`goal_session_objective.md`) that drives Simard's advance-goal decisions.

### Changes

**Merge-ready enforcement** — Previously the prompt said "merge green PRs immediately" without requiring evidence. Now tier 1 requires full merge-ready criteria verification before any merge:
- qa-team scenarios written, validated, and run
- User-facing docs updated
- quality-audit ≥3 SEEK→VALIDATE→FIX cycles ending clean  
- CI green, PR description with evidence, no unrelated diff

**Self-update awareness** — New section reminding the PM that after merging Simard PRs to main, the running binary is behind and a safe-update cycle is needed. The OODA brain's `compute_commits_behind()` detects drift and triggers `simard safe-update` when no engineers are in flight.

**Engineer instructions** — Updated the "spawn engineer" shape to explicitly say "verify merge-ready criteria first" when instructing an engineer to merge.

### Tests
- 2 new tests: `goal_session_objective_requires_merge_ready_criteria` and `goal_session_objective_mentions_self_update`
- All 25 prompt_store_tests pass

### Addresses
- User requirement: PRs must meet merge-ready skill criteria before completion
- User requirement: Simard needs to account for self-update timing after merges