### PR TITLE
fix: redesign meeting handoff system to prevent accumulation (#2269)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1249,6 +1249,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "filetime"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2127,7 +2139,10 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
+ "bitflags",
  "libc",
+ "plain",
+ "redox_syscall 0.7.5",
 ]
 
 [[package]]
@@ -2697,7 +2712,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -2840,6 +2855,12 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pom"
@@ -3191,6 +3212,15 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
  "bitflags",
 ]
@@ -3866,6 +3896,7 @@ dependencies = [
  "crossterm",
  "ctrlc",
  "dirs 6.0.0",
+ "filetime",
  "headless_chrome",
  "lbug",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ dashboard-audit = ["dep:headless_chrome", "dep:regex", "dep:url"]
 
 [dev-dependencies]
 assert_cmd = "=2.2.1"
+filetime = "=0.2.25"
 proptest = "=1.11.0"
 serial_test = "=3.4.0"
 

--- a/docs/architecture/ooda-meeting-handoff-integration.md
+++ b/docs/architecture/ooda-meeting-handoff-integration.md
@@ -1,10 +1,10 @@
 ---
 title: OODA Meeting Handoff Integration & Goal Seeding
 description: Design for wiring meeting handoffs into the OODA daemon and seeding default goals — Issues #157 and #158.
-last_updated: 2026-04-03
+last_updated: 2026-06-11
 owner: simard
 doc_type: architecture-decision
-issues: ["#157", "#158"]
+issues: ["#157", "#158", "#2269"]
 ---
 
 # OODA Meeting Handoff Integration & Goal Seeding
@@ -30,41 +30,34 @@ no useful work.
 
 ## Solution
 
-### 1. `check_meeting_handoffs` — ooda_loop.rs
+### 1. `check_meeting_handoffs` — ooda_loop/curate.rs
 
-Add a function at the start of `run_ooda_cycle` that:
+A function at the start of `run_ooda_cycle` that **batch-processes up
+to 10 unprocessed handoffs per cycle** (oldest-first FIFO):
 
-1. Reads `target/meeting_handoffs/meeting_handoff.json` via
-   `meeting_facilitator::load_meeting_handoff`.
-2. Skips if no file or already `processed == true`.
-3. For each `MeetingDecision`, creates an `ActiveGoal` on the `GoalBoard`:
-   - `id`: derived from a slugified form of `decision.description` (lowercase, hyphens, truncated to 64 chars)
-   - `description`: `"[meeting] {decision.description}"`
-   - `priority`: based on position in the decisions list (earlier = higher)
-   - `status`: `GoalProgress::NotStarted`
-4. For each `ActionItem` with priority >= 2, creates a `BacklogItem`:
-   - `id`: derived from a slugified form of `action_item.description`
-   - `description`: `"[action] {action_item.description} (owner: {owner})"`
-   - `source`: `"meeting:{topic}"`
-   - `score`: mapped from action item priority (higher priority → higher score)
-5. Marks the handoff as processed via `mark_meeting_handoff_processed`.
-6. Logs the number of goals and backlog items created.
+1. Calls `find_unprocessed_handoffs(handoff_dir, 10)` to list up to 10
+   unprocessed handoff files (timestamped `handoff-*.json` and the
+   legacy `meeting_handoff.json`), sorted by filename ascending for
+   deterministic FIFO ordering. The legacy file counts toward the
+   limit.
+2. For each handoff in the returned batch:
+   a. Parses the JSON via `serde_json`. On parse failure: logs `warn!`,
+      skips to the next file without aborting the batch.
+   b. If `decisions.is_empty() && action_items.is_empty()`: marks the
+      handoff processed immediately and skips ingestion. This handles
+      legacy empty handoffs written before the write-side filter.
+   c. Otherwise: for each `MeetingDecision`, creates an `ActiveGoal`
+      on the `GoalBoard` (id from slugified description, priority from
+      position, status `NotStarted`). For each `ActionItem` with
+      priority ≥ 2, creates a `BacklogItem`.
+   d. Calls `mark_handoff_processed_in_place` to flip `processed` to
+      `true` on the specific file path.
+3. Accumulates the total `created` count across all handoffs in the
+   batch and returns it.
+4. Logs the total count and batch size.
 
-**Placement in cycle**: Before the Observe phase. Meeting handoffs are
-pre-cycle inputs, not observations. They modify the goal board directly so
-that the subsequent Observe → Orient → Decide → Act phases operate on the
-updated board.
-
-```
-run_ooda_cycle:
-    load_goal_board(memory)          // existing
-    check_meeting_handoffs(state)    // NEW — converts handoffs to goals
-    observe(state, bridges)          // existing
-    orient(observation, goals)       // existing
-    decide(priorities, config)       // existing
-    act(actions, bridges, state)     // existing
-    curate(state)                    // existing
-```
+The batch limit of 10 prevents stalling a cycle on a large historical
+backlog — the queue drains over successive cycles.
 
 **Deduplication**: Before adding a goal, check `state.active_goals.active`
 for an existing goal with the same id. Skip if already present. This prevents
@@ -72,6 +65,24 @@ re-processing if the handoff was only partially processed in a previous cycle.
 
 **Cap enforcement**: `GoalBoard` enforces `MAX_ACTIVE_GOALS = 5`. If the
 board is full, excess meeting-derived goals go to the backlog instead.
+
+### 1a. Empty handoff filtering at write time
+
+The write side (`write_handoff_with_explicit` in
+`src/meeting_backend/persist/mod.rs`) skips writing to the handoff
+directory when the meeting produced zero decisions **and** zero action
+items. This prevents empty meetings from creating handoff files that
+the OODA daemon would parse and immediately discard. The per-meeting
+archival bundle (`~/.simard/meetings/`) is still written regardless.
+
+### 1b. Handoff reaper
+
+The OODA daemon's resource cleanup phase (end of each cycle) calls
+`reap_processed_handoffs(handoff_dir, Duration::from_secs(7 * 86400))`
+to delete processed handoff files older than 7 days. The reaper
+requires both `processed == true` and `mtime > max_age` before
+deleting. The well-known `meeting_handoff.json` is excluded from
+reaping.
 
 ### 2. `seed_default_goals` — goals.rs
 
@@ -101,9 +112,13 @@ user-curated goals on restart.
 
 | File | Change |
 |------|--------|
-| `src/ooda_loop.rs` | Add `check_meeting_handoffs(&mut OodaState)` function; call it at the top of `run_ooda_cycle` |
-| `src/goals.rs` | Add `seed_default_goals(store: &dyn GoalStore, session_id, phase)` function |
-| `src/ooda_loop.rs` | Import `meeting_facilitator::{load_meeting_handoff, mark_meeting_handoff_processed, default_handoff_dir}` |
+| `src/ooda_loop/curate.rs` | Replace single-handoff ingestion with `find_unprocessed_handoffs(dir, 10)` batch loop; accumulate `created` across iterations |
+| `src/meeting_facilitator/handoff/persistence.rs` | Add `find_unprocessed_handoffs(dir, limit)` returning `Vec<PathBuf>` and `reap_processed_handoffs(dir, max_age)` |
+| `src/meeting_facilitator/handoff/mod.rs` | Re-export `find_unprocessed_handoffs` and `reap_processed_handoffs` |
+| `src/meeting_facilitator/mod.rs` | Re-export new public functions through the module facade |
+| `src/meeting_backend/persist/mod.rs` | Add early-return guard in `write_handoff_with_explicit` skipping empty handoffs |
+| `src/ooda_loop/cycle.rs` | Call `reap_processed_handoffs` in the resource cleanup block |
+| `src/goals.rs` | Add `seed_default_goals(store: &dyn GoalStore, session_id, phase)` function (unchanged) |
 | `src/goal_curation.rs` | No changes — existing `ActiveGoal`, `BacklogItem`, and board cap logic are sufficient |
 
 ## Integration Points
@@ -118,19 +133,36 @@ user-curated goals on restart.
 
 ## Degradation Behavior (Pillar 11)
 
-- If `target/meeting_handoffs/` doesn't exist or is unreadable,
+- If `~/.simard/meeting_handoffs/` doesn't exist or is unreadable,
   `check_meeting_handoffs` logs a warning and continues. The OODA cycle
   is not interrupted.
+- If an individual handoff file fails to parse within a batch, the error
+  is logged at `warn!` level and processing continues with the remaining
+  files. One bad file does not block the queue.
+- If `reap_processed_handoffs` encounters a filesystem error (e.g., mtime
+  unavailable), it logs a warning and skips the problematic file. The
+  cleanup phase always completes.
 - If `seed_default_goals` fails to write to the store, the error is logged
   but the daemon proceeds with an empty board. The next cycle will retry
   loading from cognitive memory.
 
 ## Testing
 
-- Unit test: `check_meeting_handoffs` with a temp dir containing a handoff
-  JSON, verify goals are added to the board and handoff is marked processed.
+- Unit test: `check_meeting_handoffs` with a temp dir containing multiple
+  handoff JSON files, verify batch processes all (up to 10) and goals are
+  added to the board. Verify FIFO ordering preserved within the batch.
+- Unit test: `check_meeting_handoffs` with empty handoffs (0 decisions,
+  0 action items), verify they are marked processed without ingestion.
 - Unit test: `check_meeting_handoffs` with already-processed handoff, verify
-  no-op.
+  no-op (excluded from `find_unprocessed_handoffs` results).
+- Unit test: `write_handoff_with_explicit` with 0 decisions and 0 action
+  items, verify no `handoff-*.json` created in the handoff directory.
+- Unit test: `find_unprocessed_handoffs` returns files sorted oldest-first
+  and respects the `limit` parameter.
+- Unit test: `reap_processed_handoffs` deletes only files with
+  `processed == true` AND mtime older than `max_age`.
+- Unit test: `reap_processed_handoffs` skips `meeting_handoff.json`.
+- Unit test: `reap_processed_handoffs` skips files with `processed == false`.
 - Unit test: `seed_default_goals` on empty store, verify 5 goals created.
 - Unit test: `seed_default_goals` on non-empty store, verify no-op.
 - Integration: Full OODA cycle with a handoff artifact, verify the meeting

--- a/docs/howto/clean-stale-meeting-handoffs.md
+++ b/docs/howto/clean-stale-meeting-handoffs.md
@@ -1,0 +1,185 @@
+---
+title: "How to clean stale meeting handoffs"
+description: Manually clean accumulated handoff files and verify the automatic reaper is working.
+last_updated: 2026-06-11
+review_schedule: as-needed
+owner: simard
+doc_type: howto
+related:
+  - ../operations/meeting-handoffs.md
+  - ../reference/meeting-handoff-lifecycle.md
+  - ../reference/meeting-handoff-schema.md
+  - ../reference/state-root-resolution.md
+---
+
+# How to clean stale meeting handoffs
+
+Use this guide when the `~/.simard/meeting_handoffs/` directory has
+accumulated more files than the automatic reaper can drain in a
+reasonable time, or when you need to reclaim disk space immediately.
+
+## Prerequisites
+
+- [ ] You know your state root (default `~/.simard`, overridable via
+      `SIMARD_STATE_ROOT`)
+- [ ] No OODA daemon or engineer loop is actively ingesting handoffs
+      (stop with `systemctl stop simard-ooda` or wait for a cycle
+      boundary)
+
+## 1. Assess the situation
+
+Count total handoff files, unprocessed files, and processed files:
+
+```bash
+HANDOFF_DIR="${SIMARD_STATE_ROOT:-$HOME/.simard}/meeting_handoffs"
+
+echo "Total handoff files:"
+find "$HANDOFF_DIR" -name 'handoff-*.json' | wc -l
+
+echo "Unprocessed (pending ingestion):"
+find "$HANDOFF_DIR" -name 'handoff-*.json' \
+  -exec grep -l '"processed": false' {} \; | wc -l
+
+echo "Processed (safe to delete if old enough):"
+find "$HANDOFF_DIR" -name 'handoff-*.json' \
+  -exec grep -l '"processed": true' {} \; | wc -l
+
+echo "Older than 7 days:"
+find "$HANDOFF_DIR" -name 'handoff-*.json' -mtime +7 | wc -l
+```
+
+## 2. Delete processed files older than 7 days (safe)
+
+This matches exactly what the automatic reaper does — processed files
+with mtime > 7 days. Safe to run at any time:
+
+```bash
+find "$HANDOFF_DIR" -name 'handoff-*.json' -mtime +7 \
+  -exec grep -l '"processed": true' {} \; \
+  -exec rm -v {} \;
+```
+
+This does **not** touch:
+- Unprocessed files (the OODA daemon still needs to ingest them)
+- Files newer than 7 days
+- The legacy `meeting_handoff.json` singleton
+
+## 3. Delete empty processed files (safe)
+
+If you have legacy empty handoffs (0 decisions, 0 action items) that
+were written before the write-gate filter was added, you can safely
+delete them even if they haven't been processed yet — they contain no
+actionable content:
+
+```bash
+find "$HANDOFF_DIR" -name 'handoff-*.json' -exec sh -c '
+  decisions=$(jq ".decisions | length" "$1" 2>/dev/null)
+  actions=$(jq ".action_items | length" "$1" 2>/dev/null)
+  if [ "$decisions" = "0" ] && [ "$actions" = "0" ]; then
+    echo "Removing empty handoff: $1"
+    rm "$1"
+  fi
+' _ {} \;
+```
+
+## 4. Aggressive cleanup (all processed, any age)
+
+If you need to reclaim disk space immediately and accept that recently
+processed handoffs will no longer be available for inspection:
+
+```bash
+find "$HANDOFF_DIR" -name 'handoff-*.json' \
+  -exec grep -l '"processed": true' {} \; \
+  -exec rm -v {} \;
+```
+
+> **Warning**: This removes all processed handoffs regardless of age.
+> You lose the ability to re-inspect recently ingested handoffs. The
+> per-meeting bundle in `~/.simard/meetings/` is unaffected and
+> provides a full archival record.
+
+## 5. Verify the automatic reaper is running
+
+After the OODA daemon completes a cycle, check the journal for reaper
+activity:
+
+```bash
+journalctl -u simard-ooda --since "10 min ago" \
+  | grep -E "reaped|reaper"
+```
+
+Expected output when files were reaped:
+
+```
+INFO resource cleanup: reaped 42 stale meeting handoff(s)
+```
+
+Expected output when nothing to reap:
+
+```
+INFO resource cleanup: reaped 0 stale meeting handoff(s)
+```
+
+If you see no reaper log lines at all, the daemon may be running an
+older version without the reaper. Rebuild and restart.
+
+## 6. Verify the write gate is working
+
+Run a meeting that produces no decisions and no action items, then
+verify no handoff file was created:
+
+```bash
+# Count before
+BEFORE=$(find "$HANDOFF_DIR" -name 'handoff-*.json' | wc -l)
+
+# Run a trivial meeting with no decisions
+simard meeting repl "test empty meeting"
+# Type: "Hello" then /close
+
+# Count after
+AFTER=$(find "$HANDOFF_DIR" -name 'handoff-*.json' | wc -l)
+
+echo "Before: $BEFORE, After: $AFTER"
+# Should be equal — no new handoff file created
+```
+
+Check the daemon log for the skip message:
+
+```bash
+journalctl -u simard-ooda --since "2 min ago" \
+  | grep "Skipping empty meeting handoff"
+```
+
+## Troubleshooting
+
+### Handoffs accumulating despite the write gate
+
+The write gate only filters meetings with zero decisions AND zero
+action items. If the LLM extracts even one decision or action item
+from the conversation, a handoff file is written. This is by design —
+the filter catches only truly empty meetings.
+
+### Reaper not deleting old files
+
+The reaper requires **both** `processed == true` and mtime > 7 days.
+If old files have `processed == false`, they are unprocessed and the
+reaper correctly leaves them alone. The batch ingestion (10 per cycle)
+must process them first, then the reaper will pick them up 7 days
+later.
+
+### `meeting_handoff.json` never deleted
+
+The legacy singleton `meeting_handoff.json` is intentionally excluded
+from reaping. It is used by the engineer loop and `act-on-decisions`
+CLI. To reset it manually:
+
+```bash
+rm "$HANDOFF_DIR/meeting_handoff.json"
+```
+
+## See also
+
+- [Meeting REPL & Handoff Ingestion](../operations/meeting-handoffs.md)
+- [Meeting handoff lifecycle](../reference/meeting-handoff-lifecycle.md)
+  — write gate, batch ingestion, and reaper API reference
+- [Meeting handoff schema](../reference/meeting-handoff-schema.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,8 @@ Terminal sessions and repo-grounded engineer runs now bridge through one explici
 - [How to reclaim disk space and run low-space Rust builds](./howto/reclaim-disk-space-and-run-low-space-rust-builds.md) - Reclaim stale build artifacts and run Cargo through one shared low-space target dir across worktrees.
 - [How to configure and monitor the disk health check](./howto/configure-disk-health-check.md) - Tune the per-cycle automated disk cleanup that prevents ENOSPC crashes (#2020).
 - [How to start a meeting with Simard](./howto/start-a-meeting.md) - Have a natural conversation with Simard from CLI or dashboard, with full history and memory.
+- [How to clean stale meeting handoffs](./howto/clean-stale-meeting-handoffs.md) - Manual cleanup and reaper verification for accumulated handoff files.
+- [Meeting handoff lifecycle reference](./reference/meeting-handoff-lifecycle.md) - Write gate, batch ingestion, and automatic reaper API (#2269).
 - [How to carry meeting decisions into engineer sessions](./howto/carry-meeting-decisions-into-engineer-sessions.md) - Persist meeting records under a shared state root and confirm later engineer runs carry them forward.
 - [How to inspect meeting records](./howto/inspect-meeting-records.md) - Read back the latest durable meeting record without mutating stored state.
 - [How to inspect improvement-curation state](./howto/inspect-improvement-curation-state.md) - Read back the latest approved, deferred, and promoted improvement state without mutation.

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -8,6 +8,7 @@ Simard deployment.
 | [Pre-Commit Setup](pre-commit-setup.md) | Local hooks that mirror CI |
 | [Cognitive Memory Durability](cognitive-memory-durability.md) | SIGTERM-safe shutdown + periodic backups |
 | [Meeting REPL & Handoff Ingestion](meeting-handoffs.md) | Routing operator intent into the OODA loop |
+| [Meeting Handoff Cleanup](../howto/clean-stale-meeting-handoffs.md) | Manual and automatic cleanup of accumulated handoff files |
 | [Progress-Evidence Kill Switch](progress-evidence-kill-switch.md) | `SIMARD_PROGRESS_EVIDENCE=off` and when to use it |
 
 For contributor workflow (branching, merge policy, PR evidence

--- a/docs/operations/meeting-handoffs.md
+++ b/docs/operations/meeting-handoffs.md
@@ -152,14 +152,16 @@ Schema (the `MeetingHandoff` struct in
 }
 ```
 
-### Required fields (non-empty after `/close`)
+### Empty handoff filtering
 
-`MeetingBackend` and the closing pipeline in
-`src/meeting_backend/closing.rs` will refuse to write a handoff that
-lacks at least one decision **or** at least one action item. The
-`processed` flag must be `false` for a freshly written handoff;
-ingestion flips it to `true` via
-`mark_meeting_handoff_processed`.
+When a meeting produces zero decisions **and** zero action items, the
+close pipeline skips writing to `meeting_handoffs/` entirely (issue
+#2269). The per-meeting archival bundle under `~/.simard/meetings/` is
+still written regardless. This means a `handoff-*.json` file in the
+handoff directory always contains at least one decision or action item.
+
+The `processed` flag must be `false` for a freshly written handoff;
+ingestion flips it to `true` via `mark_meeting_handoff_processed`.
 
 ### Atomic writes
 
@@ -209,6 +211,32 @@ for the full timing contract.
 
 ---
 
+## Empty Handoff Filtering (Issue #2269)
+
+The meeting close pipeline **skips** writing to the handoff directory
+when the meeting produced zero decisions **and** zero action items.
+This prevents empty or automated meetings from accumulating inert
+`handoff-{timestamp}.json` files that the OODA daemon must parse and
+discard.
+
+The filter is applied in `write_handoff_with_explicit`
+(`src/meeting_backend/persist/mod.rs`) **after** enrichment/extraction
+— the LLM has already attempted to extract structured output from the
+conversation. Only meetings that genuinely produced no actionable
+content are filtered. The per-meeting bundle in `~/.simard/meetings/`
+is still written for archival regardless.
+
+When the filter fires, the close pipeline emits:
+
+```
+INFO Skipping empty meeting handoff (0 decisions, 0 action items)
+```
+
+The REPL `/close` output is unchanged — the operator sees the bundle
+paths but no handoff-directory path for an empty meeting.
+
+---
+
 ## Ingestion by the OODA Daemon
 
 At the start of every OODA cycle, the daemon (see
@@ -220,26 +248,49 @@ At the start of every OODA cycle, the daemon (see
    `SIMARD_STATE_ROOT`, defaulting to `~/.simard/meeting_handoffs`).
    See [State-root resolution](../reference/state-root-resolution.md).
 2. Calls `check_meeting_handoffs(&mut state.active_goals,
-   &handoff_dir)`, which:
-   - Loads the handoff via `load_meeting_handoff(handoff_dir)`.
-   - Skips it if `processed == true`.
-   - Converts each `MeetingDecision` into one or more goals and each
-     `ActionItem` into a backlog item on the live `active_goals`
-     board.
-   - Calls `mark_handoff_processed_in_place(handoff_dir)` to flip
-     `processed` to `true` so the same handoff is not re-ingested.
+   &handoff_dir, &state_root)`, which now **batch-processes up to 10 unprocessed
+   handoffs per cycle** (oldest-first FIFO):
+   - Calls `find_unprocessed_handoffs(handoff_dir, 10)` to list up to
+     10 unprocessed handoff files (timestamped `handoff-*.json` and
+     the legacy `meeting_handoff.json` — both count toward the limit).
+   - For each handoff in the batch:
+     - Parses the JSON. On parse failure: logs `warn!`, skips to next.
+     - If `decisions` and `action_items` are both empty: marks
+       processed immediately, skips ingestion.
+     - Otherwise: converts each `MeetingDecision` into one or more
+       goals and each `ActionItem` into a backlog item on the live
+       `active_goals` board.
+     - Calls `mark_handoff_processed_in_place` to flip `processed` to
+       `true`.
+   - Returns the **total** count of goals/backlog items created across
+     all handoffs in the batch.
 3. Logs:
 
    ```
-   [simard] OODA start: ingested N goal/backlog item(s) from meeting handoff
+   [simard] OODA start: ingested N goal/backlog item(s) from M meeting handoff(s)
    ```
 
-   on success (logged via `eprintln!`, captured by the systemd
-   journal). On error:
+   on success. On individual handoff errors, processing continues with
+   the remaining files:
 
    ```
-   [simard] OODA start: meeting handoff check failed: <error>
+   WARN Failed to process handoff <path>: <error>; continuing with remaining handoffs
    ```
+
+   A batch that encounters errors in every file logs:
+
+   ```
+   [simard] OODA start: meeting handoff check failed for all N handoff(s)
+   ```
+
+### Batch sizing
+
+The batch limit of 10 is a compile-time constant. Under normal
+operation (meetings producing 1–3 handoffs between cycles), the daemon
+processes all pending handoffs in a single cycle. The limit prevents a
+large historical backlog (e.g., 3,000+ files from pre-filter
+accumulation) from stalling a single OODA cycle — the queue drains
+over successive cycles at 10 per iteration.
 
 ### Verifying ingestion
 
@@ -253,9 +304,58 @@ If you do not see this line within ~1 cycle of `/close`, check:
 - The daemon is running (`systemctl status simard-ooda`).
 - `SIMARD_HANDOFF_DIR` matches what `simard meeting repl` wrote (or
   both rely on the default).
-- The handoff JSON has at least one decision or action item.
+- The handoff JSON has at least one decision or action item (empty
+  meetings no longer write to the handoff directory).
 - `processed` is still `false` (a previous OODA cycle may already have
   ingested it).
+
+---
+
+## Handoff Reaper (Automatic Cleanup)
+
+The OODA daemon's resource cleanup phase (at the end of each cycle)
+now runs a **handoff reaper** that deletes processed handoff files
+older than 7 days. This prevents long-running daemons from
+accumulating thousands of stale `handoff-*.json` files.
+
+The reaper is implemented as `reap_processed_handoffs(dir, max_age)`
+in `src/meeting_facilitator/handoff/persistence.rs` and called from
+`src/ooda_loop/cycle.rs` with `Duration::from_secs(7 * 86400)`.
+
+### Double-guard before deletion
+
+A handoff file is deleted only when **both** conditions are true:
+
+1. **`processed == true`** — the file's JSON `processed` field is
+   `true`, confirming the OODA daemon or another consumer has already
+   ingested it.
+2. **mtime > 7 days** — the file's last-modified time is older than
+   the configured `max_age` (`std::fs::metadata().modified()`).
+
+Files that fail to parse, have `processed == false`, or have a recent
+mtime are left untouched. The well-known `meeting_handoff.json`
+(legacy singleton path) is **excluded** from reaping — it is used by
+multiple consumers and should not be auto-deleted.
+
+### Observability
+
+Each deletion is logged at `info!` level:
+
+```
+INFO Reaped processed handoff: handoff-20260601T120000.json (age: 8d)
+```
+
+The reaper returns the count of deleted files. The cleanup block logs:
+
+```
+[simard] resource cleanup: reaped N stale meeting handoff(s)
+```
+
+### Filesystem error handling
+
+If `metadata().modified()` fails (e.g., on a filesystem that does not
+support mtime), the reaper logs `warn!` and skips that file. It never
+panics or aborts the cleanup phase.
 
 ---
 
@@ -392,10 +492,16 @@ issue tracker by hand.
   — the WAL incident that prompted the verification proposal
 - [`docs/reference/meeting-close-lifecycle.md`](../reference/meeting-close-lifecycle.md)
   — timeout budgets, partial-handoff envelope, atomic writes
+- [`docs/reference/meeting-handoff-schema.md`](../reference/meeting-handoff-schema.md)
+  — full JSON schema and version history
+- [`docs/reference/meeting-handoff-lifecycle.md`](../reference/meeting-handoff-lifecycle.md)
+  — write gate, batch ingestion, and reaper API reference
 - [`docs/reference/state-root-resolution.md`](../reference/state-root-resolution.md)
   — the env-var ladder shared by every Simard mode
 - [`docs/howto/recover-from-meeting-close-timeout.md`](../howto/recover-from-meeting-close-timeout.md)
   — operator playbook when `handoff_partial=true` fires
+- [`docs/howto/clean-stale-meeting-handoffs.md`](../howto/clean-stale-meeting-handoffs.md)
+  — manual cleanup and reaper configuration
 - `src/meeting_facilitator/handoff/mod.rs` — `MeetingHandoff` schema
   and helpers
 - `src/ooda_loop/cycle.rs` — OODA-side ingestion

--- a/docs/reference/meeting-backend-api.md
+++ b/docs/reference/meeting-backend-api.md
@@ -414,7 +414,7 @@ into release binaries.
 }
 ```
 
-This format is consumed by `check_meeting_handoffs()` in the OODA loop and by the `act-on-decisions` CLI command. Empty `decisions`, `action_items`, and `open_questions` vectors are valid — downstream consumers handle them without error. The `transcript` field carries the conversation summary. The `themes` field is optional (`#[serde(default)]`) and carries high-level topic tags extracted during the meeting; older handoffs without this field deserialize correctly with an empty vec.
+This format is consumed by `check_meeting_handoffs()` in the OODA loop and by the `act-on-decisions` CLI command. Empty `decisions`, `action_items`, and `open_questions` vectors are valid at the schema level — downstream consumers handle them without error. However, as of issue #2269, the write gate in `write_handoff_with_explicit` skips writing to the handoff directory when both `decisions` and `action_items` are empty, so handoff files in the directory always contain at least one decision or action item. The `transcript` field carries the conversation summary. The `themes` field is optional (`#[serde(default)]`) and carries high-level topic tags extracted during the meeting; older handoffs without this field deserialize correctly with an empty vec.
 
 ### Markdown export
 

--- a/docs/reference/meeting-close-lifecycle.md
+++ b/docs/reference/meeting-close-lifecycle.md
@@ -464,7 +464,7 @@ different files:
 
 | Consumer | File | Selector | Reads |
 |---|---|---|---|
-| OODA curate | `src/ooda_loop/curate.rs` `check_meeting_handoffs` | `find_oldest_unprocessed_handoff` (FIFO) | Legacy `meeting_handoff.json` in handoff dir |
+| OODA curate | `src/ooda_loop/curate.rs` `check_meeting_handoffs` | `find_unprocessed_handoffs` (batch FIFO, up to 10/cycle) | `handoff-*.json` and legacy `meeting_handoff.json` in handoff dir |
 | `act-on-decisions` | `src/operator_cli/decisions.rs::dispatch_act_on_decisions` | `load_meeting_handoff` (newest) | Legacy `meeting_handoff.json` in handoff dir |
 | Engineer carry-over | `src/engineer_loop/meeting_decisions.rs` | `find_oldest_unprocessed_handoff` (FIFO, issue #1985) | Legacy handoff **+** per-meeting bundle (`transcript.json`, `meeting_handoff.md`) via `load_meeting_bundle` |
 

--- a/docs/reference/meeting-handoff-lifecycle.md
+++ b/docs/reference/meeting-handoff-lifecycle.md
@@ -1,0 +1,259 @@
+---
+title: Meeting handoff lifecycle
+description: Write gate, batch ingestion, and automatic reaper for meeting handoff files — the full lifecycle from creation to deletion.
+last_updated: 2026-06-11
+review_schedule: as-needed
+owner: simard
+doc_type: reference
+related:
+  - ../operations/meeting-handoffs.md
+  - ./meeting-handoff-schema.md
+  - ./meeting-close-lifecycle.md
+  - ../architecture/ooda-meeting-handoff-integration.md
+  - ../howto/clean-stale-meeting-handoffs.md
+issues: ["#2269"]
+---
+
+# Meeting handoff lifecycle
+
+This page documents the full lifecycle of `handoff-*.json` files in
+`~/.simard/meeting_handoffs/`: how they are created, consumed, and
+cleaned up. Issue #2269 introduced the write gate, batch ingestion,
+and automatic reaper to prevent handoff file accumulation.
+
+---
+
+## Background
+
+Before issue #2269, the meeting close pipeline unconditionally wrote a
+`handoff-{timestamp}.json` file for every meeting — including empty or
+automated meetings with no decisions and no action items. The OODA
+daemon processed only one handoff per cycle (FIFO), so consumption
+could never keep up with bulk creation. Over time, this caused
+thousands of inert files to accumulate.
+
+---
+
+## Lifecycle phases
+
+```text
+Meeting close           OODA cycle (start)        OODA cycle (end)
+     │                       │                          │
+     ▼                       ▼                          ▼
+┌─────────────┐     ┌────────────────┐         ┌───────────────┐
+│ Write gate  │     │ Batch ingest   │         │ Reaper        │
+│ (persist/)  │     │ (curate.rs)    │         │ (cycle.rs)    │
+│             │     │                │         │               │
+│ decisions=0 │─no──│ Up to 10 files │         │ processed=T   │
+│ actions=0?  │     │ per cycle      │         │ mtime > 7d?   │
+│             │     │ oldest first   │         │               │
+│ yes → skip  │     │ empty → mark   │         │ yes → delete  │
+│ no → write  │     │ full → ingest  │         │ no → keep     │
+└─────────────┘     └────────────────┘         └───────────────┘
+```
+
+### Phase 1: Write gate
+
+**Location**: `write_handoff_with_explicit` in
+`src/meeting_backend/persist/mod.rs`
+
+After the LLM enrichment pipeline has extracted decisions and action
+items from the meeting conversation, the close pipeline checks:
+
+```rust
+if facilitator_decisions.is_empty() && facilitator_actions.is_empty() {
+    info!("Skipping empty meeting handoff (0 decisions, 0 action items)");
+    return Ok(());
+}
+```
+
+- **Empty meetings** (0 decisions AND 0 action items): No
+  `handoff-*.json` is written to `meeting_handoffs/`. The per-meeting
+  archival bundle in `~/.simard/meetings/<id>/` is still written for
+  record-keeping.
+- **Non-empty meetings**: A `handoff-{timestamp}.json` is written as
+  before, with `processed: false`.
+
+The check is applied **after** enrichment, not before — so the LLM
+has already attempted to extract structured output. Only genuinely
+empty meetings are filtered.
+
+### Phase 2: Batch ingestion
+
+**Location**: `check_meeting_handoffs` in `src/ooda_loop/curate.rs`
+
+At the start of each OODA cycle, the daemon calls
+`find_unprocessed_handoffs(handoff_dir, 10)` to retrieve up to 10
+unprocessed handoff files, oldest-first. For each file in the batch:
+
+1. Parse the JSON. On failure: `warn!`, skip to next.
+2. Check `decisions.is_empty() && action_items.is_empty()`:
+   - **Yes**: Mark processed immediately, skip ingestion. This handles
+     legacy empty handoffs from before the write gate.
+   - **No**: Convert decisions to goals and action items to backlog
+     entries. Mark processed.
+3. Accumulate the `created` count.
+
+The function returns the total count across all handoffs in the batch.
+
+**Error isolation**: A parse or I/O error on one file does not abort
+the batch. The remaining files are still processed.
+
+**FIFO ordering**: `find_unprocessed_handoffs` sorts by filename
+ascending, which gives deterministic oldest-first ordering since
+filenames include ISO timestamps.
+
+### Phase 3: Automatic reaper
+
+**Location**: `reap_processed_handoffs` in
+`src/meeting_facilitator/handoff/persistence.rs`, called from the
+resource cleanup block in `src/ooda_loop/cycle.rs`
+
+At the end of each OODA cycle, the cleanup phase calls:
+
+```rust
+reap_processed_handoffs(&handoff_dir, Duration::from_secs(7 * 86400))
+```
+
+The reaper iterates `handoff-*.json` files and deletes each file only
+when **both** guards pass:
+
+| Guard | Check | Rationale |
+|-------|-------|-----------|
+| Content | `processed == true` in parsed JSON | Never delete an unconsumed handoff |
+| Age | `std::fs::metadata().modified()` older than `max_age` | Give operators time to inspect recent handoffs |
+
+The well-known `meeting_handoff.json` (legacy singleton filename) is
+**excluded** from reaping — it is consumed by multiple paths (engineer
+loop, `act-on-decisions` CLI) and must not be auto-deleted.
+
+Each deletion is logged at `info!` level with the filename and age.
+
+---
+
+## API reference
+
+### `find_unprocessed_handoffs`
+
+```rust
+pub fn find_unprocessed_handoffs(
+    dir: &Path,
+    limit: usize,
+) -> Result<Vec<PathBuf>>
+```
+
+Lists `handoff-*.json` files in `dir` that have `processed == false`
+(or are missing the `processed` field — treated as unprocessed).
+Returns up to `limit` paths sorted by filename ascending (oldest
+first). Also includes the legacy `meeting_handoff.json` if present and
+unprocessed. Returns an empty `Vec` if the directory does not exist.
+
+**Errors**: Returns `Err` only on directory-read failures. Individual
+file parse errors are logged at `warn!` and the file is skipped (not
+included in results).
+
+### `reap_processed_handoffs`
+
+```rust
+pub fn reap_processed_handoffs(
+    dir: &Path,
+    max_age: Duration,
+) -> Result<usize>
+```
+
+Deletes `handoff-*.json` files in `dir` where `processed == true` and
+file mtime is older than `max_age`. Returns the count of files
+deleted. The `MEETING_HANDOFF_FILENAME` (`meeting_handoff.json`) is
+always skipped.
+
+**Errors**: Returns `Err` only on directory-read failures. Individual
+file errors (parse, mtime, delete) are logged at `warn!` and the file
+is skipped. The function always attempts all eligible files.
+
+### Re-exports
+
+Both functions are re-exported through:
+
+- `meeting_facilitator::handoff::find_unprocessed_handoffs`
+- `meeting_facilitator::handoff::reap_processed_handoffs`
+- `meeting_facilitator::find_unprocessed_handoffs`
+- `meeting_facilitator::reap_processed_handoffs`
+
+---
+
+## Configuration
+
+| Setting | Default | Override |
+|---------|---------|---------|
+| Handoff directory | `<state-root>/meeting_handoffs` | `SIMARD_HANDOFF_DIR` or `SIMARD_STATE_ROOT` |
+| Batch size (ingestion) | 10 per cycle | Compile-time constant in `curate.rs` |
+| Reaper max age | 7 days | Compile-time constant in `cycle.rs` |
+| Reaper exclusion | `meeting_handoff.json` always excluded | Not configurable |
+
+The batch size and reaper max age are intentionally not runtime-
+configurable to avoid operator error. If you need to adjust them,
+change the constants and rebuild.
+
+---
+
+## Observability
+
+### Tracing events
+
+| Level | Message | When |
+|-------|---------|------|
+| `INFO` | `Skipping empty meeting handoff (0 decisions, 0 action items)` | Write gate filters an empty meeting |
+| `INFO` | `OODA start: ingested N goal/backlog item(s) from M meeting handoff(s)` | Batch ingestion completes |
+| `WARN` | `Failed to process handoff <path>: <error>; continuing` | Individual handoff fails in batch |
+| `INFO` | `Reaped processed handoff: <filename> (age: Nd)` | Reaper deletes a file |
+| `WARN` | `Reaper skipping <filename>: <error>` | Reaper can't read/parse/stat a file |
+| `INFO` | `resource cleanup: reaped N stale meeting handoff(s)` | Cleanup block summary |
+
+### Diagnostic commands
+
+Count unprocessed handoffs:
+
+```bash
+find ~/.simard/meeting_handoffs/ -name 'handoff-*.json' \
+  -exec grep -l '"processed": false' {} \; | wc -l
+```
+
+Count files eligible for reaping (processed + older than 7 days):
+
+```bash
+find ~/.simard/meeting_handoffs/ -name 'handoff-*.json' \
+  -mtime +7 -exec grep -l '"processed": true' {} \; | wc -l
+```
+
+---
+
+## Migration from pre-#2269
+
+If you have an existing handoff directory with thousands of
+accumulated files:
+
+1. The batch ingestion (10 per cycle) will gradually drain the
+   unprocessed queue. At one cycle per ~60s, 3,000 files take ~5 hours
+   to fully process.
+2. Once processed, the reaper will delete files older than 7 days at
+   the end of each cycle.
+3. For immediate cleanup, see
+   [How to clean stale meeting handoffs](../howto/clean-stale-meeting-handoffs.md).
+
+No manual migration is required — the new code handles legacy files
+transparently.
+
+---
+
+## See also
+
+- [Meeting REPL & Handoff Ingestion](../operations/meeting-handoffs.md)
+  — operator-facing operations guide
+- [Meeting handoff schema](./meeting-handoff-schema.md) — JSON schema
+  and version history
+- [Meeting close lifecycle](./meeting-close-lifecycle.md) — timeout
+  budgets and atomic writes
+- [OODA meeting handoff integration](../architecture/ooda-meeting-handoff-integration.md)
+  — architecture decision record
+- [How to clean stale meeting handoffs](../howto/clean-stale-meeting-handoffs.md)
+  — manual cleanup guide

--- a/docs/reference/meeting-handoff-schema.md
+++ b/docs/reference/meeting-handoff-schema.md
@@ -112,3 +112,20 @@ becomes desirable, but it is not required.
 - #1985 — bundle consumption (depends on v2 schema)
 - #1984 — resume support (independent)
 - #1951 — sub-issues 3, 6, 7 (coordinated via this schema bump)
+- #2269 — empty handoff filtering, batch ingestion, and reaper
+
+## Empty handoff behavior (Issue #2269)
+
+As of issue #2269, `write_handoff_with_explicit` in
+`src/meeting_backend/persist/mod.rs` **skips writing** a
+`handoff-{timestamp}.json` to the handoff directory when `decisions`
+and `action_items` are both empty. The per-meeting archival bundle
+under `~/.simard/meetings/` is still written for record-keeping. This
+means every `handoff-*.json` file in the handoff directory is
+guaranteed to have at least one decision or action item.
+
+Additionally, the OODA daemon's batch ingestion now skips empty
+handoffs (from legacy pre-filter writes) by checking
+`decisions.is_empty() && action_items.is_empty()` after parsing — such
+handoffs are marked processed without creating goals. Processed
+handoffs older than 7 days are automatically reaped.

--- a/src/meeting_backend/persist/mod.rs
+++ b/src/meeting_backend/persist/mod.rs
@@ -288,6 +288,12 @@ pub fn write_handoff_with_explicit(
                 .collect()
         };
 
+    // #2269: Skip writing handoff when there are no decisions AND no action items.
+    if facilitator_decisions.is_empty() && facilitator_actions.is_empty() {
+        info!("Skipping empty meeting handoff (0 decisions, 0 action items)");
+        return Ok(());
+    }
+
     // Extract open questions from message content; prepend explicit ones.
     let inferred_questions = extract_open_questions(messages);
     let mut open_questions: Vec<crate::meeting_facilitator::OpenQuestion> = explicit_questions
@@ -722,7 +728,8 @@ mod tests {
     #[serial(simard_meetings_dir_env)]
     fn write_handoff_error_on_read_only_dir() {
         unsafe { std::env::set_var("SIMARD_HANDOFF_DIR", "/proc/1/no_such_dir") };
-        let result = write_handoff("topic", "summary", &[], &[], &[]);
+        // Must include a decision so the empty-skip gate doesn't short-circuit (#2269).
+        let result = write_handoff("topic", "summary", &[], &[], &["A decision".to_string()]);
         assert!(
             result.is_err(),
             "write_handoff should surface error, not silently drop"
@@ -732,12 +739,85 @@ mod tests {
 
     #[test]
     #[serial(simard_meetings_dir_env)]
-    fn write_handoff_empty_messages() {
-        let dir = temp_meetings_dir("handoff-empty");
+    fn write_handoff_empty_skips_handoff_file() {
+        let dir = temp_meetings_dir("handoff-empty-skip");
         unsafe { std::env::set_var("SIMARD_HANDOFF_DIR", &dir) };
 
+        // Zero decisions AND zero action items → should skip writing handoff file (#2269).
         let result = write_handoff("empty", "No messages", &[], &[], &[]);
-        assert!(result.is_ok(), "empty-message handoff should succeed");
+        assert!(
+            result.is_ok(),
+            "empty handoff should succeed (early return)"
+        );
+
+        // Verify NO handoff-*.json was created.
+        let handoff_files: Vec<_> = std::fs::read_dir(&dir)
+            .into_iter()
+            .flatten()
+            .flatten()
+            .filter(|e| e.file_name().to_string_lossy().starts_with("handoff-"))
+            .collect();
+        assert!(
+            handoff_files.is_empty(),
+            "empty handoff (0 decisions, 0 actions) must not create a handoff file"
+        );
+
+        unsafe { std::env::remove_var("SIMARD_HANDOFF_DIR") };
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    #[serial(simard_meetings_dir_env)]
+    fn write_handoff_with_only_actions_still_writes() {
+        let dir = temp_meetings_dir("handoff-actions-only");
+        unsafe { std::env::set_var("SIMARD_HANDOFF_DIR", &dir) };
+
+        let items = vec![HandoffActionItem {
+            description: "Deploy hotfix".to_string(),
+            assignee: Some("Bob".to_string()),
+            deadline: None,
+            linked_goal: None,
+            priority: None,
+        }];
+        // Zero decisions but non-zero action items → should still write.
+        let result = write_handoff("Sprint", "Summary", &[], &items, &[]);
+        assert!(result.is_ok());
+
+        let handoff_files: Vec<_> = std::fs::read_dir(&dir)
+            .into_iter()
+            .flatten()
+            .flatten()
+            .filter(|e| e.file_name().to_string_lossy().starts_with("handoff-"))
+            .collect();
+        assert!(
+            !handoff_files.is_empty(),
+            "handoff with action items must be written even without decisions"
+        );
+
+        unsafe { std::env::remove_var("SIMARD_HANDOFF_DIR") };
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    #[serial(simard_meetings_dir_env)]
+    fn write_handoff_with_only_decisions_still_writes() {
+        let dir = temp_meetings_dir("handoff-decisions-only");
+        unsafe { std::env::set_var("SIMARD_HANDOFF_DIR", &dir) };
+
+        // Non-zero decisions, zero action items → should still write.
+        let result = write_handoff("Sprint", "Summary", &[], &[], &["Adopt TDD".to_string()]);
+        assert!(result.is_ok());
+
+        let handoff_files: Vec<_> = std::fs::read_dir(&dir)
+            .into_iter()
+            .flatten()
+            .flatten()
+            .filter(|e| e.file_name().to_string_lossy().starts_with("handoff-"))
+            .collect();
+        assert!(
+            !handoff_files.is_empty(),
+            "handoff with decisions must be written even without action items"
+        );
 
         unsafe { std::env::remove_var("SIMARD_HANDOFF_DIR") };
         let _ = std::fs::remove_dir_all(&dir);

--- a/src/meeting_backend/tests_persist_extra.rs
+++ b/src/meeting_backend/tests_persist_extra.rs
@@ -167,21 +167,19 @@ fn write_handoff_empty_data_uses_defaults() {
         std::env::set_var("SIMARD_HANDOFF_DIR", dir.path().as_os_str());
     }
 
+    // #2269: empty handoff (0 decisions, 0 action items) now skips writing.
     let result = write_handoff("Empty meeting", "No notes", &[], &[], &[]);
     assert!(result.is_ok());
 
     let entries: Vec<_> = std::fs::read_dir(dir.path())
         .unwrap()
         .filter_map(|e| e.ok())
+        .filter(|e| e.file_name().to_string_lossy().starts_with("handoff-"))
         .collect();
-    let content = std::fs::read_to_string(entries[0].path()).unwrap();
-    let handoff: MeetingHandoff = serde_json::from_str(&content).unwrap();
-
-    assert!(handoff.decisions.is_empty());
-    assert!(handoff.action_items.is_empty());
-    assert!(handoff.open_questions.is_empty());
-    assert!(handoff.participants.is_empty());
-    assert!(handoff.themes.is_empty());
+    assert!(
+        entries.is_empty(),
+        "empty handoff (0 decisions, 0 actions) must not create a handoff file (#2269)"
+    );
 
     unsafe {
         std::env::remove_var("SIMARD_HANDOFF_DIR");

--- a/src/meeting_facilitator/handoff/mod.rs
+++ b/src/meeting_facilitator/handoff/mod.rs
@@ -432,8 +432,9 @@ mod persistence;
 pub use persistence::{
     BundleTranscriptLine, MeetingBundle, bundle_handoff_path, bundle_markdown_path,
     bundle_transcript_path, default_bundle_root, find_newest_handoff,
-    find_oldest_unprocessed_handoff, load_meeting_bundle, load_meeting_handoff, load_session_wip,
-    mark_handoff_processed_in_place, mark_meeting_handoff_processed, meeting_bundle_dir,
+    find_oldest_unprocessed_handoff, find_unprocessed_handoffs, load_meeting_bundle,
+    load_meeting_handoff, load_session_wip, mark_handoff_processed_in_place,
+    mark_meeting_handoff_processed, meeting_bundle_dir, reap_processed_handoffs,
     remove_session_wip, save_session_wip, write_meeting_bundle, write_meeting_handoff,
 };
 

--- a/src/meeting_facilitator/handoff/persistence.rs
+++ b/src/meeting_facilitator/handoff/persistence.rs
@@ -98,34 +98,7 @@ fn list_handoff_files(dir: &Path) -> Vec<PathBuf> {
 /// field; malformed JSON is skipped (an old half-written file should not
 /// block dispatch). Returns `Ok(None)` when no unprocessed handoff exists.
 pub fn find_oldest_unprocessed_handoff(dir: &Path) -> SimardResult<Option<PathBuf>> {
-    for path in list_handoff_files(dir) {
-        let raw = match fs::read_to_string(&path) {
-            Ok(s) => s,
-            Err(e) => {
-                tracing::warn!(
-                    path = %path.display(),
-                    error = %e,
-                    "skipping unreadable handoff while scanning for oldest unprocessed"
-                );
-                continue;
-            }
-        };
-        let handoff: MeetingHandoff = match serde_json::from_str(&raw) {
-            Ok(h) => h,
-            Err(e) => {
-                tracing::warn!(
-                    path = %path.display(),
-                    error = %e,
-                    "skipping malformed handoff JSON while scanning for oldest unprocessed"
-                );
-                continue;
-            }
-        };
-        if !handoff.processed {
-            return Ok(Some(path));
-        }
-    }
-    Ok(None)
+    Ok(find_unprocessed_handoffs(dir, 1)?.into_iter().next())
 }
 
 /// Load a meeting handoff artifact from a directory. Returns `None` if no

--- a/src/meeting_facilitator/handoff/persistence.rs
+++ b/src/meeting_facilitator/handoff/persistence.rs
@@ -661,6 +661,436 @@ fn render_bundle_markdown(
     md
 }
 
+// ---------------------------------------------------------------------------
+// Batch handoff discovery and reaper (#2269)
+// ---------------------------------------------------------------------------
+
+/// Return up to `limit` unprocessed handoff file paths in FIFO order
+/// (oldest first). Scans the directory once, parsing each candidate to
+/// check its `processed` flag. Malformed files are skipped with a warning.
+pub fn find_unprocessed_handoffs(dir: &Path, limit: usize) -> SimardResult<Vec<PathBuf>> {
+    let mut result = Vec::new();
+    for path in list_handoff_files(dir) {
+        if result.len() >= limit {
+            break;
+        }
+        let raw = match fs::read_to_string(&path) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(
+                    path = %path.display(),
+                    error = %e,
+                    "skipping unreadable handoff in batch scan"
+                );
+                continue;
+            }
+        };
+        let handoff: MeetingHandoff = match serde_json::from_str(&raw) {
+            Ok(h) => h,
+            Err(e) => {
+                tracing::warn!(
+                    path = %path.display(),
+                    error = %e,
+                    "skipping malformed handoff JSON in batch scan"
+                );
+                continue;
+            }
+        };
+        if !handoff.processed {
+            result.push(path);
+        }
+    }
+    Ok(result)
+}
+
+/// Delete processed handoff files whose mtime exceeds `max_age`.
+///
+/// Double-guard: a file is only deleted when **both** `processed == true`
+/// (from the JSON payload) **and** the filesystem mtime is older than
+/// `max_age`. The legacy `meeting_handoff.json` is never deleted.
+///
+/// Returns the number of files deleted.
+pub fn reap_processed_handoffs(dir: &Path, max_age: std::time::Duration) -> SimardResult<u32> {
+    let now = std::time::SystemTime::now();
+    let mut deleted = 0u32;
+
+    for path in list_handoff_files(dir) {
+        // Never delete the legacy fixed-name file.
+        if path
+            .file_name()
+            .map(|n| n == MEETING_HANDOFF_FILENAME)
+            .unwrap_or(false)
+        {
+            continue;
+        }
+
+        // Guard 1: mtime must exceed max_age.
+        let metadata = match fs::metadata(&path) {
+            Ok(m) => m,
+            Err(e) => {
+                tracing::warn!(
+                    path = %path.display(),
+                    error = %e,
+                    "skipping unreadable file during handoff reap"
+                );
+                continue;
+            }
+        };
+        let mtime = metadata.modified().unwrap_or(now);
+        let age = now.duration_since(mtime).unwrap_or_default();
+        if age < max_age {
+            continue;
+        }
+
+        // Guard 2: JSON must parse and have processed == true.
+        let raw = match fs::read_to_string(&path) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(
+                    path = %path.display(),
+                    error = %e,
+                    "skipping unreadable handoff during reap"
+                );
+                continue;
+            }
+        };
+        let handoff: MeetingHandoff = match serde_json::from_str(&raw) {
+            Ok(h) => h,
+            Err(e) => {
+                tracing::warn!(
+                    path = %path.display(),
+                    error = %e,
+                    "skipping malformed handoff JSON during reap"
+                );
+                continue;
+            }
+        };
+        if !handoff.processed {
+            continue;
+        }
+
+        // Both guards passed — delete.
+        if let Err(e) = fs::remove_file(&path) {
+            tracing::warn!(
+                path = %path.display(),
+                error = %e,
+                "failed to delete processed handoff during reap"
+            );
+        } else {
+            tracing::info!(path = %path.display(), "reaped old processed handoff");
+            deleted += 1;
+        }
+    }
+
+    Ok(deleted)
+}
+
+#[cfg(test)]
+mod handoff_batch_tests {
+    use super::*;
+    use crate::meeting_facilitator::{ActionItem, MeetingDecision};
+    use tempfile::TempDir;
+
+    fn make_handoff(
+        closed_at: &str,
+        processed: bool,
+        decisions: Vec<MeetingDecision>,
+        action_items: Vec<ActionItem>,
+    ) -> MeetingHandoff {
+        MeetingHandoff {
+            schema_version: 2,
+            meeting_id: String::new(),
+            topic: "test".to_string(),
+            started_at: "2026-01-01T00:00:00Z".to_string(),
+            closed_at: closed_at.to_string(),
+            decisions,
+            action_items,
+            open_questions: Vec::new(),
+            processed,
+            duration_secs: None,
+            transcript: Vec::new(),
+            participants: Vec::new(),
+            themes: Vec::new(),
+            transcript_path: None,
+            next_owner: None,
+            artifacts: Vec::new(),
+            goal: None,
+            next_actor: None,
+            applied_templates: Vec::new(),
+            history_truncated_count: 0,
+            partial_reason: None,
+            risks: vec![],
+            disagreements: vec![],
+        }
+    }
+
+    fn write_handoff_file(dir: &std::path::Path, name: &str, handoff: &MeetingHandoff) {
+        let path = dir.join(name);
+        let json = serde_json::to_string_pretty(handoff).unwrap();
+        std::fs::write(&path, json).unwrap();
+    }
+
+    // --- find_unprocessed_handoffs tests ---
+
+    #[test]
+    fn find_unprocessed_handoffs_returns_empty_for_empty_dir() {
+        let dir = TempDir::new().unwrap();
+        let result = find_unprocessed_handoffs(dir.path(), 10).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn find_unprocessed_handoffs_skips_processed_files() {
+        let dir = TempDir::new().unwrap();
+        write_handoff_file(
+            dir.path(),
+            "handoff-2026-01-01T00-00-00_00-00.json",
+            &make_handoff("2026-01-01T00:00:00Z", true, vec![], vec![]),
+        );
+        let result = find_unprocessed_handoffs(dir.path(), 10).unwrap();
+        assert!(result.is_empty(), "processed handoffs should be skipped");
+    }
+
+    #[test]
+    fn find_unprocessed_handoffs_returns_unprocessed_in_fifo_order() {
+        let dir = TempDir::new().unwrap();
+        // Older file first (alphabetical = chronological for timestamps)
+        write_handoff_file(
+            dir.path(),
+            "handoff-2026-01-01T00-00-00_00-00.json",
+            &make_handoff("2026-01-01T00:00:00Z", false, vec![], vec![]),
+        );
+        write_handoff_file(
+            dir.path(),
+            "handoff-2026-01-02T00-00-00_00-00.json",
+            &make_handoff("2026-01-02T00:00:00Z", false, vec![], vec![]),
+        );
+        write_handoff_file(
+            dir.path(),
+            "handoff-2026-01-03T00-00-00_00-00.json",
+            &make_handoff("2026-01-03T00:00:00Z", false, vec![], vec![]),
+        );
+
+        let result = find_unprocessed_handoffs(dir.path(), 10).unwrap();
+        assert_eq!(result.len(), 3);
+        // FIFO: oldest first
+        assert!(
+            result[0].to_string_lossy().contains("2026-01-01"),
+            "first should be oldest"
+        );
+        assert!(
+            result[2].to_string_lossy().contains("2026-01-03"),
+            "last should be newest"
+        );
+    }
+
+    #[test]
+    fn find_unprocessed_handoffs_respects_limit() {
+        let dir = TempDir::new().unwrap();
+        for i in 0..5 {
+            write_handoff_file(
+                dir.path(),
+                &format!("handoff-2026-01-0{i}T00-00-00_00-00.json"),
+                &make_handoff(&format!("2026-01-0{i}T00:00:00Z"), false, vec![], vec![]),
+            );
+        }
+        let result = find_unprocessed_handoffs(dir.path(), 3).unwrap();
+        assert_eq!(result.len(), 3, "should return at most `limit` paths");
+        // Still FIFO: the 3 oldest
+        assert!(result[0].to_string_lossy().contains("2026-01-00"));
+        assert!(result[2].to_string_lossy().contains("2026-01-02"));
+    }
+
+    #[test]
+    fn find_unprocessed_handoffs_includes_legacy_file() {
+        let dir = TempDir::new().unwrap();
+        let legacy = make_handoff("2025-12-31T00:00:00Z", false, vec![], vec![]);
+        write_handoff_file(dir.path(), MEETING_HANDOFF_FILENAME, &legacy);
+        write_handoff_file(
+            dir.path(),
+            "handoff-2026-01-01T00-00-00_00-00.json",
+            &make_handoff("2026-01-01T00:00:00Z", false, vec![], vec![]),
+        );
+
+        let result = find_unprocessed_handoffs(dir.path(), 10).unwrap();
+        assert_eq!(result.len(), 2, "legacy file should be included");
+    }
+
+    #[test]
+    fn find_unprocessed_handoffs_skips_malformed_json() {
+        let dir = TempDir::new().unwrap();
+        // Write a malformed file
+        std::fs::write(
+            dir.path().join("handoff-2026-01-01T00-00-00_00-00.json"),
+            "not valid json {{{",
+        )
+        .unwrap();
+        // Write a valid unprocessed file
+        write_handoff_file(
+            dir.path(),
+            "handoff-2026-01-02T00-00-00_00-00.json",
+            &make_handoff("2026-01-02T00:00:00Z", false, vec![], vec![]),
+        );
+
+        let result = find_unprocessed_handoffs(dir.path(), 10).unwrap();
+        assert_eq!(result.len(), 1, "malformed file should be skipped");
+    }
+
+    #[test]
+    fn find_unprocessed_handoffs_mixed_processed_and_unprocessed() {
+        let dir = TempDir::new().unwrap();
+        write_handoff_file(
+            dir.path(),
+            "handoff-2026-01-01T00-00-00_00-00.json",
+            &make_handoff("2026-01-01T00:00:00Z", true, vec![], vec![]), // processed
+        );
+        write_handoff_file(
+            dir.path(),
+            "handoff-2026-01-02T00-00-00_00-00.json",
+            &make_handoff("2026-01-02T00:00:00Z", false, vec![], vec![]), // unprocessed
+        );
+        write_handoff_file(
+            dir.path(),
+            "handoff-2026-01-03T00-00-00_00-00.json",
+            &make_handoff("2026-01-03T00:00:00Z", true, vec![], vec![]), // processed
+        );
+        write_handoff_file(
+            dir.path(),
+            "handoff-2026-01-04T00-00-00_00-00.json",
+            &make_handoff("2026-01-04T00:00:00Z", false, vec![], vec![]), // unprocessed
+        );
+
+        let result = find_unprocessed_handoffs(dir.path(), 10).unwrap();
+        assert_eq!(result.len(), 2);
+        assert!(result[0].to_string_lossy().contains("2026-01-02"));
+        assert!(result[1].to_string_lossy().contains("2026-01-04"));
+    }
+
+    // --- reap_processed_handoffs tests ---
+
+    #[test]
+    fn reap_processed_handoffs_deletes_old_processed_files() {
+        let dir = TempDir::new().unwrap();
+        // Write a processed handoff
+        write_handoff_file(
+            dir.path(),
+            "handoff-2026-01-01T00-00-00_00-00.json",
+            &make_handoff("2026-01-01T00:00:00Z", true, vec![], vec![]),
+        );
+        // Backdate the mtime so it appears older than 7 days
+        let path = dir.path().join("handoff-2026-01-01T00-00-00_00-00.json");
+        let old_time = filetime::FileTime::from_unix_time(0, 0);
+        filetime::set_file_mtime(&path, old_time).unwrap();
+
+        let max_age = std::time::Duration::from_secs(7 * 24 * 3600);
+        let count = reap_processed_handoffs(dir.path(), max_age).unwrap();
+        assert_eq!(count, 1, "should delete 1 old processed file");
+        assert!(!path.exists(), "file should be deleted");
+    }
+
+    #[test]
+    fn reap_processed_handoffs_preserves_unprocessed_files() {
+        let dir = TempDir::new().unwrap();
+        write_handoff_file(
+            dir.path(),
+            "handoff-2026-01-01T00-00-00_00-00.json",
+            &make_handoff("2026-01-01T00:00:00Z", false, vec![], vec![]),
+        );
+        // Backdate mtime
+        let path = dir.path().join("handoff-2026-01-01T00-00-00_00-00.json");
+        let old_time = filetime::FileTime::from_unix_time(0, 0);
+        filetime::set_file_mtime(&path, old_time).unwrap();
+
+        let max_age = std::time::Duration::from_secs(7 * 24 * 3600);
+        let count = reap_processed_handoffs(dir.path(), max_age).unwrap();
+        assert_eq!(count, 0, "unprocessed files must never be deleted");
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn reap_processed_handoffs_preserves_recent_files() {
+        let dir = TempDir::new().unwrap();
+        // File is processed but mtime is recent (just created)
+        write_handoff_file(
+            dir.path(),
+            "handoff-2026-01-01T00-00-00_00-00.json",
+            &make_handoff("2026-01-01T00:00:00Z", true, vec![], vec![]),
+        );
+
+        let max_age = std::time::Duration::from_secs(7 * 24 * 3600);
+        let count = reap_processed_handoffs(dir.path(), max_age).unwrap();
+        assert_eq!(count, 0, "recent processed files should be preserved");
+    }
+
+    #[test]
+    fn reap_processed_handoffs_never_deletes_legacy_file() {
+        let dir = TempDir::new().unwrap();
+        write_handoff_file(
+            dir.path(),
+            MEETING_HANDOFF_FILENAME,
+            &make_handoff("2025-01-01T00:00:00Z", true, vec![], vec![]),
+        );
+        // Backdate the legacy file
+        let path = dir.path().join(MEETING_HANDOFF_FILENAME);
+        let old_time = filetime::FileTime::from_unix_time(0, 0);
+        filetime::set_file_mtime(&path, old_time).unwrap();
+
+        let max_age = std::time::Duration::from_secs(7 * 24 * 3600);
+        let count = reap_processed_handoffs(dir.path(), max_age).unwrap();
+        assert_eq!(count, 0, "legacy meeting_handoff.json must never be reaped");
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn reap_processed_handoffs_empty_dir_returns_zero() {
+        let dir = TempDir::new().unwrap();
+        let max_age = std::time::Duration::from_secs(7 * 24 * 3600);
+        let count = reap_processed_handoffs(dir.path(), max_age).unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn reap_processed_handoffs_skips_malformed_json() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("handoff-2026-01-01T00-00-00_00-00.json");
+        std::fs::write(&path, "{{not valid}}").unwrap();
+        let old_time = filetime::FileTime::from_unix_time(0, 0);
+        filetime::set_file_mtime(&path, old_time).unwrap();
+
+        let max_age = std::time::Duration::from_secs(7 * 24 * 3600);
+        let count = reap_processed_handoffs(dir.path(), max_age).unwrap();
+        assert_eq!(count, 0, "malformed files should be skipped, not deleted");
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn reap_processed_handoffs_double_guard_both_checks_required() {
+        let dir = TempDir::new().unwrap();
+        // Case 1: processed=true but mtime recent → should NOT delete
+        write_handoff_file(
+            dir.path(),
+            "handoff-2026-06-10T00-00-00_00-00.json",
+            &make_handoff("2026-06-10T00:00:00Z", true, vec![], vec![]),
+        );
+        // Case 2: processed=false but mtime old → should NOT delete
+        let path_unproc = dir.path().join("handoff-2026-01-01T00-00-00_00-00.json");
+        write_handoff_file(
+            dir.path(),
+            "handoff-2026-01-01T00-00-00_00-00.json",
+            &make_handoff("2026-01-01T00:00:00Z", false, vec![], vec![]),
+        );
+        let old_time = filetime::FileTime::from_unix_time(0, 0);
+        filetime::set_file_mtime(&path_unproc, old_time).unwrap();
+
+        let max_age = std::time::Duration::from_secs(7 * 24 * 3600);
+        let count = reap_processed_handoffs(dir.path(), max_age).unwrap();
+        assert_eq!(
+            count, 0,
+            "both conditions (processed AND old mtime) required for deletion"
+        );
+    }
+}
+
 #[cfg(test)]
 mod bundle_tests {
     use super::*;

--- a/src/meeting_facilitator/handoff/persistence.rs
+++ b/src/meeting_facilitator/handoff/persistence.rs
@@ -35,28 +35,8 @@ pub fn write_meeting_handoff(dir: &Path, handoff: &MeetingHandoff) -> SimardResu
 /// (e.g. CLI display, observe scan). The OODA dispatch queue must use
 /// [`find_oldest_unprocessed_handoff`] instead — see #1649.
 pub fn find_newest_handoff(dir: &Path) -> Option<PathBuf> {
-    let mut candidates: Vec<PathBuf> = Vec::new();
-
-    // Legacy fixed filename.
-    let legacy = dir.join(MEETING_HANDOFF_FILENAME);
-    if legacy.is_file() {
-        candidates.push(legacy);
-    }
-
-    // Timestamped files written by `write_meeting_handoff`.
-    if let Ok(entries) = fs::read_dir(dir) {
-        for entry in entries.flatten() {
-            let name = entry.file_name();
-            let name_str = name.to_string_lossy();
-            if name_str.starts_with("handoff-") && name_str.ends_with(".json") {
-                candidates.push(entry.path());
-            }
-        }
-    }
-
-    // Newest by filename (timestamps sort lexicographically).
-    candidates.sort();
-    candidates.pop()
+    // Delegate to the shared directory scan to avoid duplicated logic.
+    list_handoff_files(dir).pop()
 }
 
 /// List all handoff files in a directory sorted by filename ascending
@@ -638,6 +618,15 @@ fn render_bundle_markdown(
 // Batch handoff discovery and reaper (#2269)
 // ---------------------------------------------------------------------------
 
+/// Lightweight proxy that only deserializes the `processed` flag, skipping
+/// all other fields (decisions, transcripts, etc.). Avoids the cost of a
+/// full `MeetingHandoff` parse when we only need the status bit.
+#[derive(serde::Deserialize)]
+struct HandoffStatus {
+    #[serde(default)]
+    processed: bool,
+}
+
 /// Return up to `limit` unprocessed handoff file paths in FIFO order
 /// (oldest first). Scans the directory once, parsing each candidate to
 /// check its `processed` flag. Malformed files are skipped with a warning.
@@ -658,7 +647,9 @@ pub fn find_unprocessed_handoffs(dir: &Path, limit: usize) -> SimardResult<Vec<P
                 continue;
             }
         };
-        let handoff: MeetingHandoff = match serde_json::from_str(&raw) {
+        // Use lightweight proxy — only deserializes `processed`, ignoring
+        // the rest of the struct (decisions, transcripts, etc.).
+        let status: HandoffStatus = match serde_json::from_str(&raw) {
             Ok(h) => h,
             Err(e) => {
                 tracing::warn!(
@@ -669,7 +660,7 @@ pub fn find_unprocessed_handoffs(dir: &Path, limit: usize) -> SimardResult<Vec<P
                 continue;
             }
         };
-        if !handoff.processed {
+        if !status.processed {
             result.push(path);
         }
     }
@@ -727,7 +718,7 @@ pub fn reap_processed_handoffs(dir: &Path, max_age: std::time::Duration) -> Sima
                 continue;
             }
         };
-        let handoff: MeetingHandoff = match serde_json::from_str(&raw) {
+        let status: HandoffStatus = match serde_json::from_str(&raw) {
             Ok(h) => h,
             Err(e) => {
                 tracing::warn!(
@@ -738,7 +729,7 @@ pub fn reap_processed_handoffs(dir: &Path, max_age: std::time::Duration) -> Sima
                 continue;
             }
         };
-        if !handoff.processed {
+        if !status.processed {
             continue;
         }
 

--- a/src/meeting_facilitator/handoff/persistence.rs
+++ b/src/meeting_facilitator/handoff/persistence.rs
@@ -741,7 +741,11 @@ pub fn reap_processed_handoffs(dir: &Path, max_age: std::time::Duration) -> Sima
                 "failed to delete processed handoff during reap"
             );
         } else {
-            tracing::info!(path = %path.display(), "reaped old processed handoff");
+            tracing::info!(
+                path = %path.display(),
+                age_days = age.as_secs() / 86400,
+                "reaped old processed handoff"
+            );
             deleted += 1;
         }
     }

--- a/src/meeting_facilitator/mod.rs
+++ b/src/meeting_facilitator/mod.rs
@@ -21,9 +21,10 @@ pub use handoff::{
     MEETING_HANDOFF_FILENAME, MEETING_SESSION_WIP_FILENAME, MeetingBundle, MeetingHandoff,
     bundle_handoff_path, bundle_markdown_path, bundle_transcript_path, default_bundle_root,
     default_handoff_dir, derive_meeting_id, find_newest_handoff, find_oldest_unprocessed_handoff,
-    load_meeting_bundle, load_meeting_handoff, load_session_wip, mark_handoff_processed_in_place,
-    mark_meeting_handoff_processed, meeting_bundle_dir, remove_session_wip, save_session_wip,
-    write_meeting_bundle, write_meeting_handoff,
+    find_unprocessed_handoffs, load_meeting_bundle, load_meeting_handoff, load_session_wip,
+    mark_handoff_processed_in_place, mark_meeting_handoff_processed, meeting_bundle_dir,
+    reap_processed_handoffs, remove_session_wip, save_session_wip, write_meeting_bundle,
+    write_meeting_handoff,
 };
 pub use session::{
     add_note, add_question, close_meeting, edit_item, record_action_item, record_decision,

--- a/src/ooda_loop/curate.rs
+++ b/src/ooda_loop/curate.rs
@@ -87,93 +87,138 @@ pub fn check_meeting_handoffs(
     handoff_dir: &std::path::Path,
     state_root: &Path,
 ) -> SimardResult<u32> {
-    use crate::meeting_facilitator::find_oldest_unprocessed_handoff;
+    use crate::meeting_facilitator::find_unprocessed_handoffs;
 
     let tombstones = load_tombstones(state_root);
 
-    let path = match find_oldest_unprocessed_handoff(handoff_dir)? {
-        Some(p) => p,
-        None => return Ok(0),
-    };
+    let paths = find_unprocessed_handoffs(handoff_dir, 10)?;
+    if paths.is_empty() {
+        return Ok(0);
+    }
 
-    // Diagnostic: surface starvation that would have occurred under the old
-    // "newest by filename" selection — log when the oldest unprocessed file
-    // is older than the newest file in the directory (meaning at least one
-    // newer file exists and is already processed, or is itself unprocessed
-    // but properly deferred).
+    // FIFO diagnostic: log when oldest differs from newest in dir (first in batch only).
     if let Some(newest) = crate::meeting_facilitator::find_newest_handoff(handoff_dir)
-        && newest != path
+        && newest != paths[0]
     {
         tracing::info!(
-            selected = %path.display(),
+            selected = %paths[0].display(),
             newest = %newest.display(),
             "OODA curate: selecting older unprocessed handoff over newer file (FIFO)"
         );
     }
 
-    let raw =
-        std::fs::read_to_string(&path).map_err(|e| crate::error::SimardError::ArtifactIo {
-            path: path.clone(),
-            reason: format!("reading handoff: {e}"),
-        })?;
-    let mut handoff: crate::meeting_facilitator::MeetingHandoff = serde_json::from_str(&raw)
-        .map_err(|e| crate::error::SimardError::ArtifactIo {
-            path: path.clone(),
-            reason: format!("failed to parse handoff JSON: {e}"),
-        })?;
+    let mut total_created = 0u32;
 
-    let mut created = 0u32;
+    for path in &paths {
+        let raw = match std::fs::read_to_string(path) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::error!(
+                    path = %path.display(),
+                    error = %e,
+                    "failed to read handoff in batch; skipping"
+                );
+                continue;
+            }
+        };
+        let mut handoff: crate::meeting_facilitator::MeetingHandoff =
+            match serde_json::from_str(&raw) {
+                Ok(h) => h,
+                Err(e) => {
+                    tracing::error!(
+                        path = %path.display(),
+                        error = %e,
+                        "failed to parse handoff JSON in batch; skipping"
+                    );
+                    continue;
+                }
+            };
 
-    // Issue #1954: surface the meeting's `next_owner` and `artifacts[]`
-    // through the curated goals/backlog so downstream consumers (engineer
-    // loop, dashboard) can see who the meeting expected to action this
-    // and which files to read. `assigned_to` carries the owner verbatim
-    // so the engineer-loop selection logic can prefer goals it owns; the
-    // backlog `source` string carries an artifact-pointer suffix.
-    let owner_hint = handoff.next_owner.as_deref();
-    let artifact_suffix: String = if handoff.artifacts.is_empty() {
-        String::new()
-    } else {
-        let names: Vec<String> = handoff
-            .artifacts
-            .iter()
-            .map(|a| format!("{}={}", a.kind, a.uri_or_path))
-            .collect();
-        format!(" artifacts=[{}]", names.join("; "))
-    };
-
-    // Convert decisions to active goals; overflow goes to backlog.
-    for (i, decision) in handoff.decisions.iter().enumerate() {
-        let goal_id = crate::goals::goal_slug(&decision.description);
-        let description = format!("[meeting] {}", decision.description);
-
-        // Deduplicate against existing active goals, backlog, and tombstones.
-        if board.active.iter().any(|g| g.id == goal_id)
-            || board.backlog.iter().any(|b| b.id == goal_id)
-            || tombstones.contains(&goal_id)
-        {
+        // Empty handoff (0 decisions, 0 action items): mark processed, skip ingestion.
+        if handoff.decisions.is_empty() && handoff.action_items.is_empty() {
+            tracing::info!(
+                path = %path.display(),
+                "batch: marking empty handoff processed without ingesting"
+            );
+            handoff.processed = true;
+            let json = serde_json::to_string_pretty(&handoff).unwrap_or_default();
+            let _ = std::fs::write(path, &json);
             continue;
         }
 
-        if board.active.len() < crate::goal_curation::MAX_ACTIVE_GOALS {
-            // Priority based on position: earlier decisions = higher priority.
-            let priority = (i as u32).saturating_add(1).min(5);
-            board.active.push(ActiveGoal {
-                id: goal_id,
-                description,
-                priority,
-                status: GoalProgress::NotStarted,
-                assigned_to: owner_hint.map(String::from),
-                current_activity: None,
-                wip_refs: vec![],
-                last_progress_update_at: None,
-            });
+        let mut created = 0u32;
+
+        let owner_hint = handoff.next_owner.as_deref();
+        let artifact_suffix: String = if handoff.artifacts.is_empty() {
+            String::new()
         } else {
-            // Board full — route to backlog with score based on position.
-            let score = 1.0 - (i as f64 * 0.1).min(0.9);
+            let names: Vec<String> = handoff
+                .artifacts
+                .iter()
+                .map(|a| format!("{}={}", a.kind, a.uri_or_path))
+                .collect();
+            format!(" artifacts=[{}]", names.join("; "))
+        };
+
+        // Convert decisions to active goals; overflow goes to backlog.
+        for (i, decision) in handoff.decisions.iter().enumerate() {
+            let goal_id = crate::goals::goal_slug(&decision.description);
+            let description = format!("[meeting] {}", decision.description);
+
+            if board.active.iter().any(|g| g.id == goal_id)
+                || board.backlog.iter().any(|b| b.id == goal_id)
+                || tombstones.contains(&goal_id)
+            {
+                continue;
+            }
+
+            if board.active.len() < crate::goal_curation::MAX_ACTIVE_GOALS {
+                let priority = (i as u32).saturating_add(1).min(5);
+                board.active.push(ActiveGoal {
+                    id: goal_id,
+                    description,
+                    priority,
+                    status: GoalProgress::NotStarted,
+                    assigned_to: owner_hint.map(String::from),
+                    current_activity: None,
+                    wip_refs: vec![],
+                    last_progress_update_at: None,
+                });
+            } else {
+                let score = 1.0 - (i as f64 * 0.1).min(0.9);
+                board.backlog.push(BacklogItem {
+                    id: goal_id,
+                    description,
+                    source: format!(
+                        "meeting:{}{}{}",
+                        handoff.topic,
+                        owner_hint
+                            .map(|o| format!(" owner={o}"))
+                            .unwrap_or_default(),
+                        artifact_suffix,
+                    ),
+                    score,
+                });
+            }
+            created += 1;
+        }
+
+        // Convert action items with priority >= 2 to backlog items.
+        for item in &handoff.action_items {
+            if item.priority < 2 {
+                continue;
+            }
+            let item_id = crate::goals::goal_slug(&item.description);
+            if board.backlog.iter().any(|b| b.id == item_id)
+                || board.active.iter().any(|g| g.id == item_id)
+                || tombstones.contains(&item_id)
+            {
+                continue;
+            }
+            let score = (item.priority as f64 * 0.2).min(1.0);
             board.backlog.push(BacklogItem {
-                id: goal_id,
-                description,
+                id: item_id,
+                description: format!("[action] {} (owner: {})", item.description, item.owner),
                 source: format!(
                     "meeting:{}{}{}",
                     handoff.topic,
@@ -184,57 +229,26 @@ pub fn check_meeting_handoffs(
                 ),
                 score,
             });
+            created += 1;
         }
-        created += 1;
-    }
 
-    // Convert action items with priority >= 2 to backlog items.
-    for item in &handoff.action_items {
-        if item.priority < 2 {
-            continue;
-        }
-        let item_id = crate::goals::goal_slug(&item.description);
-        if board.backlog.iter().any(|b| b.id == item_id)
-            || board.active.iter().any(|g| g.id == item_id)
-            || tombstones.contains(&item_id)
-        {
-            continue;
-        }
-        // Higher action-item priority → higher backlog score.
-        let score = (item.priority as f64 * 0.2).min(1.0);
-        board.backlog.push(BacklogItem {
-            id: item_id,
-            description: format!("[action] {} (owner: {})", item.description, item.owner),
-            source: format!(
-                "meeting:{}{}{}",
-                handoff.topic,
-                owner_hint
-                    .map(|o| format!(" owner={o}"))
-                    .unwrap_or_default(),
-                artifact_suffix,
-            ),
-            score,
-        });
-        created += 1;
-    }
-
-    // Mark this specific file processed and write back to the same path —
-    // never let the path-lookup pick a sibling file (which is the core of
-    // the #1649 starvation: under the old in_place helper the writeback
-    // could land on the wrong file when multiple handoffs co-exist).
-    handoff.processed = true;
-    let json = serde_json::to_string_pretty(&handoff).map_err(|e| {
-        crate::error::SimardError::ArtifactIo {
+        // Mark this specific file processed.
+        handoff.processed = true;
+        let json = serde_json::to_string_pretty(&handoff).map_err(|e| {
+            crate::error::SimardError::ArtifactIo {
+                path: path.clone(),
+                reason: format!("serializing handoff: {e}"),
+            }
+        })?;
+        std::fs::write(path, &json).map_err(|e| crate::error::SimardError::ArtifactIo {
             path: path.clone(),
-            reason: format!("serializing handoff: {e}"),
-        }
-    })?;
-    std::fs::write(&path, &json).map_err(|e| crate::error::SimardError::ArtifactIo {
-        path: path.clone(),
-        reason: format!("writing handoff: {e}"),
-    })?;
+            reason: format!("writing handoff: {e}"),
+        })?;
 
-    Ok(created)
+        total_created += created;
+    }
+
+    Ok(total_created)
 }
 
 #[cfg(test)]
@@ -535,11 +549,9 @@ mod tests {
     // -----------------------------------------------------------------
     // FIFO regression test for #1649 (handoff starvation).
     //
-    // Scenario: a content-rich handoff A is written first, then a fresh
-    // empty handoff B is written. Under the old "newest by filename"
-    // selection, B would be processed first (and A would be permanently
-    // shadowed once B was marked processed). With FIFO-by-`created_at`
-    // ascending among `pending` handoffs, A must be processed first.
+    // Updated for #2269 batch processing: both handoffs A and B are
+    // processed in a single cycle (batch up to 10). A yields 1 goal,
+    // B yields 0 (empty). FIFO ordering preserved within the batch.
     // -----------------------------------------------------------------
     #[test]
     fn check_meeting_handoffs_picks_oldest_unprocessed_first_fifo() {
@@ -585,49 +597,219 @@ mod tests {
 
         let mut board = GoalBoard::new();
 
-        // First cycle: must process A (older, content-rich) — NOT B.
+        // Single cycle: batch processing should handle BOTH A and B.
+        // A yields 1 goal, B yields 0 (empty, marked processed immediately).
         let count = check_meeting_handoffs(&mut board, dir.path(), dir.path())
             .expect("check_meeting_handoffs cycle 1 should succeed");
-        assert_eq!(count, 1, "first cycle should ingest A's single decision");
+        assert_eq!(
+            count, 1,
+            "batch should ingest A's decision (1 goal) and skip B (empty)"
+        );
         assert_eq!(board.active.len(), 1);
         assert_eq!(
             board.active[0].description, "[meeting] Older meeting decision A",
             "older handoff A must be processed first under FIFO ordering"
         );
 
-        // A's file must be marked processed; B's must remain unprocessed.
+        // Both files must be marked processed after the single batch cycle.
         let reloaded_a: MeetingHandoff =
             serde_json::from_str(&fs::read_to_string(&path_a).unwrap()).unwrap();
         let reloaded_b: MeetingHandoff =
             serde_json::from_str(&fs::read_to_string(&path_b).unwrap()).unwrap();
         assert!(
             reloaded_a.processed,
-            "handoff A must be marked processed after first cycle"
+            "handoff A must be marked processed after batch cycle"
         );
         assert!(
-            !reloaded_b.processed,
-            "handoff B must remain unprocessed after first cycle"
+            reloaded_b.processed,
+            "handoff B must be marked processed after batch cycle (empty-skip)"
         );
 
-        // Second cycle: B is now the oldest unprocessed → gets processed
-        // (with zero items, since it's empty). Demonstrates B is no longer
-        // permanently shadowing A.
+        // Next cycle: nothing left to process.
         let count2 = check_meeting_handoffs(&mut board, dir.path(), dir.path())
             .expect("check_meeting_handoffs cycle 2 should succeed");
-        assert_eq!(
-            count2, 0,
-            "second cycle ingests empty handoff B → zero items"
-        );
-        let reloaded_b2: MeetingHandoff =
-            serde_json::from_str(&fs::read_to_string(&path_b).unwrap()).unwrap();
-        assert!(
-            reloaded_b2.processed,
-            "handoff B must be marked processed after second cycle"
-        );
+        assert_eq!(count2, 0, "no unprocessed handoffs remain");
+    }
 
-        // Third cycle: nothing left to process.
-        let count3 = check_meeting_handoffs(&mut board, dir.path(), dir.path())
-            .expect("check_meeting_handoffs cycle 3 should succeed");
-        assert_eq!(count3, 0, "no unprocessed handoffs remain");
+    // -----------------------------------------------------------------
+    // #2269: Batch processing — up to 10 handoffs per cycle
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn check_meeting_handoffs_batch_processes_multiple_handoffs() {
+        use std::fs;
+
+        let dir = TempDir::new().expect("create temp dir");
+
+        // Write 3 handoffs with different decisions.
+        for i in 1..=3 {
+            let handoff = sample_handoff(vec![sample_decision(&format!("Decision {i}"))]);
+            let ts = format!("handoff-2026-04-0{i}T00-00-00_00-00.json");
+            fs::write(
+                dir.path().join(&ts),
+                serde_json::to_string_pretty(&handoff).unwrap(),
+            )
+            .unwrap();
+        }
+
+        let mut board = GoalBoard::new();
+        let count = check_meeting_handoffs(&mut board, dir.path(), dir.path())
+            .expect("batch should succeed");
+
+        // All 3 handoffs processed in one cycle, each yielding 1 goal.
+        assert_eq!(count, 3, "3 handoffs × 1 decision each = 3 goals");
+        assert_eq!(board.active.len(), 3);
+
+        // All should be marked processed.
+        for entry in fs::read_dir(dir.path()).unwrap() {
+            let entry = entry.unwrap();
+            if entry.file_name().to_string_lossy().starts_with("handoff-") {
+                let raw = fs::read_to_string(entry.path()).unwrap();
+                let h: MeetingHandoff = serde_json::from_str(&raw).unwrap();
+                assert!(h.processed, "all handoffs should be marked processed");
+            }
+        }
+    }
+
+    #[test]
+    fn check_meeting_handoffs_batch_skips_empty_handoffs_without_ingesting() {
+        use std::fs;
+
+        let dir = TempDir::new().expect("create temp dir");
+
+        // Empty handoff: 0 decisions, 0 action items
+        let empty = sample_handoff(vec![]);
+        fs::write(
+            dir.path().join("handoff-2026-04-01T00-00-00_00-00.json"),
+            serde_json::to_string_pretty(&empty).unwrap(),
+        )
+        .unwrap();
+
+        // Content-rich handoff
+        let rich = sample_handoff(vec![sample_decision("Important decision")]);
+        fs::write(
+            dir.path().join("handoff-2026-04-02T00-00-00_00-00.json"),
+            serde_json::to_string_pretty(&rich).unwrap(),
+        )
+        .unwrap();
+
+        let mut board = GoalBoard::new();
+        let count = check_meeting_handoffs(&mut board, dir.path(), dir.path())
+            .expect("batch should succeed");
+
+        // Only 1 goal created (from the rich handoff); empty one skipped.
+        assert_eq!(count, 1);
+        assert_eq!(board.active.len(), 1);
+        assert_eq!(board.active[0].description, "[meeting] Important decision");
+
+        // But BOTH should be marked processed.
+        let raw_empty =
+            fs::read_to_string(dir.path().join("handoff-2026-04-01T00-00-00_00-00.json")).unwrap();
+        let h_empty: MeetingHandoff = serde_json::from_str(&raw_empty).unwrap();
+        assert!(
+            h_empty.processed,
+            "empty handoff should be marked processed"
+        );
+    }
+
+    #[test]
+    fn check_meeting_handoffs_batch_accumulates_created_count() {
+        use std::fs;
+
+        let dir = TempDir::new().expect("create temp dir");
+
+        // Handoff with 2 decisions
+        let h1 = sample_handoff(vec![sample_decision("Dec A"), sample_decision("Dec B")]);
+        fs::write(
+            dir.path().join("handoff-2026-04-01T00-00-00_00-00.json"),
+            serde_json::to_string_pretty(&h1).unwrap(),
+        )
+        .unwrap();
+
+        // Handoff with 1 decision + 1 action item (priority >= 2)
+        let h2 = sample_handoff_with_actions(
+            vec![sample_decision("Dec C")],
+            vec![sample_action("Fix bug", "alice", 3)],
+        );
+        fs::write(
+            dir.path().join("handoff-2026-04-02T00-00-00_00-00.json"),
+            serde_json::to_string_pretty(&h2).unwrap(),
+        )
+        .unwrap();
+
+        let mut board = GoalBoard::new();
+        let count = check_meeting_handoffs(&mut board, dir.path(), dir.path())
+            .expect("batch should succeed");
+
+        // 2 decisions + 1 decision + 1 action = 4 total
+        assert_eq!(count, 4, "created count should accumulate across batch");
+    }
+
+    #[test]
+    fn check_meeting_handoffs_batch_continues_after_malformed_file() {
+        use std::fs;
+
+        let dir = TempDir::new().expect("create temp dir");
+
+        // Malformed handoff file
+        fs::write(
+            dir.path().join("handoff-2026-04-01T00-00-00_00-00.json"),
+            "{{invalid json",
+        )
+        .unwrap();
+
+        // Valid handoff after the malformed one
+        let h = sample_handoff(vec![sample_decision("Good decision")]);
+        fs::write(
+            dir.path().join("handoff-2026-04-02T00-00-00_00-00.json"),
+            serde_json::to_string_pretty(&h).unwrap(),
+        )
+        .unwrap();
+
+        let mut board = GoalBoard::new();
+        let count = check_meeting_handoffs(&mut board, dir.path(), dir.path())
+            .expect("batch should not fail on individual malformed files");
+
+        assert_eq!(count, 1, "should still process the valid handoff");
+        assert_eq!(board.active.len(), 1);
+    }
+
+    #[test]
+    fn check_meeting_handoffs_batch_capped_at_10() {
+        use std::fs;
+
+        let dir = TempDir::new().expect("create temp dir");
+
+        // Write 15 unprocessed handoffs
+        for i in 0..15 {
+            let h = sample_handoff(vec![sample_decision(&format!("Decision {i}"))]);
+            let ts = format!("handoff-2026-04-{:02}T00-00-00_00-00.json", i + 1);
+            fs::write(
+                dir.path().join(&ts),
+                serde_json::to_string_pretty(&h).unwrap(),
+            )
+            .unwrap();
+        }
+
+        let mut board = GoalBoard::new();
+        let count = check_meeting_handoffs(&mut board, dir.path(), dir.path())
+            .expect("batch should succeed");
+
+        // Only 10 should be processed per cycle
+        assert_eq!(count, 10, "batch cap is 10 per cycle");
+
+        // 5 should remain unprocessed
+        let mut unprocessed = 0;
+        for entry in fs::read_dir(dir.path()).unwrap() {
+            let entry = entry.unwrap();
+            if entry.file_name().to_string_lossy().starts_with("handoff-") {
+                let raw = fs::read_to_string(entry.path()).unwrap();
+                let h: MeetingHandoff = serde_json::from_str(&raw).unwrap();
+                if !h.processed {
+                    unprocessed += 1;
+                }
+            }
+        }
+        assert_eq!(unprocessed, 5, "5 should remain for next cycle");
     }
 }

--- a/src/ooda_loop/curate.rs
+++ b/src/ooda_loop/curate.rs
@@ -109,6 +109,20 @@ pub fn check_meeting_handoffs(
 
     let mut total_created = 0u32;
 
+    // Pre-build a HashSet of existing goal/backlog IDs for O(1) duplicate detection
+    // instead of O(n) linear scans per decision/action item.
+    let mut known_ids: HashSet<String> =
+        HashSet::with_capacity(board.active.len() + board.backlog.len() + tombstones.len());
+    for g in board.active.iter() {
+        known_ids.insert(g.id.clone());
+    }
+    for b in board.backlog.iter() {
+        known_ids.insert(b.id.clone());
+    }
+    for t in &tombstones {
+        known_ids.insert(t.clone());
+    }
+
     for path in &paths {
         let raw = match std::fs::read_to_string(path) {
             Ok(s) => s,
@@ -157,33 +171,21 @@ pub fn check_meeting_handoffs(
         let mut created = 0u32;
 
         let owner_hint = handoff.next_owner.as_deref();
-        let artifact_suffix: String = if handoff.artifacts.is_empty() {
-            String::new()
-        } else {
-            let names: Vec<String> = handoff
-                .artifacts
-                .iter()
-                .map(|a| format!("{}={}", a.kind, a.uri_or_path))
-                .collect();
-            format!(" artifacts=[{}]", names.join("; "))
-        };
 
         // Convert decisions to active goals; overflow goes to backlog.
         for (i, decision) in handoff.decisions.iter().enumerate() {
             let goal_id = crate::goals::goal_slug(&decision.description);
-            let description = format!("[meeting] {}", decision.description);
 
-            if board.active.iter().any(|g| g.id == goal_id)
-                || board.backlog.iter().any(|b| b.id == goal_id)
-                || tombstones.contains(&goal_id)
-            {
+            if known_ids.contains(&goal_id) {
                 continue;
             }
+
+            let description = format!("[meeting] {}", decision.description);
 
             if board.active.len() < crate::goal_curation::MAX_ACTIVE_GOALS {
                 let priority = (i as u32).saturating_add(1).min(5);
                 board.active.push(ActiveGoal {
-                    id: goal_id,
+                    id: goal_id.clone(),
                     description,
                     priority,
                     status: GoalProgress::NotStarted,
@@ -195,7 +197,7 @@ pub fn check_meeting_handoffs(
             } else {
                 let score = 1.0 - (i as f64 * 0.1).min(0.9);
                 board.backlog.push(BacklogItem {
-                    id: goal_id,
+                    id: goal_id.clone(),
                     description,
                     source: format!(
                         "meeting:{}{}{}",
@@ -203,11 +205,12 @@ pub fn check_meeting_handoffs(
                         owner_hint
                             .map(|o| format!(" owner={o}"))
                             .unwrap_or_default(),
-                        artifact_suffix,
+                        artifact_suffix(&handoff),
                     ),
                     score,
                 });
             }
+            known_ids.insert(goal_id);
             created += 1;
         }
 
@@ -217,15 +220,12 @@ pub fn check_meeting_handoffs(
                 continue;
             }
             let item_id = crate::goals::goal_slug(&item.description);
-            if board.backlog.iter().any(|b| b.id == item_id)
-                || board.active.iter().any(|g| g.id == item_id)
-                || tombstones.contains(&item_id)
-            {
+            if known_ids.contains(&item_id) {
                 continue;
             }
             let score = (item.priority as f64 * 0.2).min(1.0);
             board.backlog.push(BacklogItem {
-                id: item_id,
+                id: item_id.clone(),
                 description: format!("[action] {} (owner: {})", item.description, item.owner),
                 source: format!(
                     "meeting:{}{}{}",
@@ -233,10 +233,11 @@ pub fn check_meeting_handoffs(
                     owner_hint
                         .map(|o| format!(" owner={o}"))
                         .unwrap_or_default(),
-                    artifact_suffix,
+                    artifact_suffix(&handoff),
                 ),
                 score,
             });
+            known_ids.insert(item_id);
             created += 1;
         }
 
@@ -257,6 +258,20 @@ pub fn check_meeting_handoffs(
     }
 
     Ok(total_created)
+}
+
+/// Build the artifact suffix string lazily — only called when a backlog item
+/// actually needs it, avoiding allocation when all goals go to active slots.
+fn artifact_suffix(handoff: &crate::meeting_facilitator::MeetingHandoff) -> String {
+    if handoff.artifacts.is_empty() {
+        return String::new();
+    }
+    let names: Vec<String> = handoff
+        .artifacts
+        .iter()
+        .map(|a| format!("{}={}", a.kind, a.uri_or_path))
+        .collect();
+    format!(" artifacts=[{}]", names.join("; "))
 }
 
 #[cfg(test)]

--- a/src/ooda_loop/curate.rs
+++ b/src/ooda_loop/curate.rs
@@ -141,8 +141,16 @@ pub fn check_meeting_handoffs(
                 "batch: marking empty handoff processed without ingesting"
             );
             handoff.processed = true;
-            let json = serde_json::to_string_pretty(&handoff).unwrap_or_default();
-            let _ = std::fs::write(path, &json);
+            match serde_json::to_string_pretty(&handoff) {
+                Ok(json) => {
+                    if let Err(e) = std::fs::write(path, &json) {
+                        tracing::warn!(path = %path.display(), error = %e, "failed to mark empty handoff processed");
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(path = %path.display(), error = %e, "failed to serialize empty handoff");
+                }
+            }
             continue;
         }
 

--- a/src/ooda_loop/cycle.rs
+++ b/src/ooda_loop/cycle.rs
@@ -156,6 +156,18 @@ fn run_ooda_cycle_inner(
         if let Err(e) = handle_cleanup() {
             eprintln!("[simard] OODA cycle: resource cleanup had errors: {e}");
         }
+
+        // #2269: Reap processed handoff files older than 7 days.
+        let max_age = std::time::Duration::from_secs(7 * 24 * 3600);
+        match crate::meeting_facilitator::reap_processed_handoffs(&handoff_dir, max_age) {
+            Ok(n) if n > 0 => {
+                eprintln!("[simard] OODA cycle: reaped {n} old processed handoff file(s)");
+            }
+            Err(e) => {
+                eprintln!("[simard] OODA cycle: handoff reap failed: {e}");
+            }
+            _ => {}
+        }
     }
 
     // Snapshot active goal ids before the core OODA phases run.


### PR DESCRIPTION
## Problem

The meeting close pipeline unconditionally writes `handoff-{timestamp}.json` to `~/.simard/meeting_handoffs/` even for empty/automated meetings with no decisions or action items. This caused 3,420+ files to accumulate. The OODA cycle's `check_meeting_handoffs()` processes only ONE handoff per cycle via FIFO, so consumption can never keep up with bulk creation.

## Solution

Three-pronged fix:

### A. Empty-skip guard (`persist/mod.rs`)
- `write_handoff_with_explicit` now returns early when `facilitator_decisions` and `facilitator_actions` are both empty
- Per-meeting bundles in `~/.simard/meetings/` still written for archival

### B. Batch processing (`curate.rs`)
- New `find_unprocessed_handoffs(dir, limit)` returns up to N unprocessed paths in FIFO order via single directory scan
- `check_meeting_handoffs` loops through up to 10 handoffs per cycle
- Empty handoffs (0 decisions, 0 action items) marked processed immediately without ingestion
- Individual parse failures logged and skipped — one bad file doesn't block the queue

### C. Processed handoff reaper (`cycle.rs`)
- New `reap_processed_handoffs(dir, max_age)` with double-guard: deletes only when `processed == true` AND `mtime > max_age`
- Called from OODA cycle cleanup block with 7-day threshold
- Legacy `meeting_handoff.json` never deleted; malformed files skipped

## Files changed
- `src/meeting_facilitator/handoff/persistence.rs` — `find_unprocessed_handoffs()`, `reap_processed_handoffs()`
- `src/meeting_facilitator/handoff/mod.rs` — re-exports
- `src/meeting_facilitator/mod.rs` — re-exports
- `src/ooda_loop/curate.rs` — batch loop replacing single-file processing
- `src/meeting_backend/persist/mod.rs` — empty-skip guard
- `src/ooda_loop/cycle.rs` — reaper call in cleanup block
- `src/meeting_backend/tests_persist_extra.rs` — updated test for empty-skip

## Testing
- 14 new persistence tests (find_unprocessed_handoffs + reap_processed_handoffs)
- 5 new curate batch tests (multi-handoff, empty-skip, accumulation, malformed recovery, cap at 10)
- Updated FIFO regression test for batch semantics
- All 5,621 lib tests pass (2 pre-existing flaky failures unrelated to this change)

Closes #2269