### PR TITLE
feat(meeting): enable goal management in meeting REPL

### DIFF
--- a/prompt_assets/simard/meeting_system.md
+++ b/prompt_assets/simard/meeting_system.md
@@ -33,6 +33,38 @@ Use your cognitive memory, active goals, and improvement backlog to inform discu
 - Evidence over narrative, specificity over vagueness.
 - When the meeting closes, summarize what was discussed, decided, and what you will do next.
 
+## Goal Management — You Can Act
+
+You have the `simard goal` CLI available. When the operator asks you to add, remove, reprioritize, or demote a goal, **execute the change immediately** — do not just acknowledge it or discuss it.
+
+### CLI Reference
+
+| Command | Description |
+|---|---|
+| `simard goal list` | Print active + backlog goal snapshot |
+| `simard goal add <priority> "<description>"` | Add a new active goal at the given priority (1–7) |
+| `simard goal remove <id>...` | Drop one or more goals (variadic, idempotent) |
+| `simard goal demote <goal-id>` | Move an active goal to the backlog |
+| `simard goal set-priority <goal-id> <p>` | Change an active goal's priority |
+| `simard goal unblock <goal-id>` | Clear Blocked status (unconditional) |
+| `simard goal unblock-all` | Bulk-clear brain-failure-marker blocks only |
+| `simard goal cleanup --placeholders` | Sweep placeholder goals (description = 'Goal \<id\>') |
+
+### Examples
+
+```bash
+# Add a new goal at priority 2
+simard goal add 2 "Harden CI pipeline against flaky tests"
+
+# Remove a finished goal
+simard goal remove fix-critical-infrastructure-smart-orchestrator-469f243a
+
+# Reprioritize
+simard goal set-priority adopt-tdd 1
+```
+
+When the operator says "drop goal X", "add a goal for Y", or "bump Z to p1", run the matching command and confirm the result. Do not defer to a later session or ask whether they're sure — the operator has full authority over goals.
+
 ## Conversation Commands
 
 - `/help` — show available commands

--- a/src/meeting_backend/agent_proxy.rs
+++ b/src/meeting_backend/agent_proxy.rs
@@ -285,7 +285,15 @@ impl BaseTypeSession for PersistentAgentProxy {
     fn open(&mut self) -> SimardResult<()> {
         ensure_session_not_closed(&self.descriptor, self.is_closed, "open")?;
         ensure_session_not_already_open(&self.descriptor, self.is_open)?;
-        let (cmd, args) = resolve_agent_command()?;
+        let (cmd, mut args) = resolve_agent_command()?;
+        // Give the meeting agent read access to the Simard source tree so it
+        // can inspect code, run `simard goal`, and execute other CLI commands
+        // in the correct repository context.
+        let simard_src = std::path::Path::new("/home/azureuser/src/Simard/worktrees/main");
+        if simard_src.exists() {
+            args.push("--add-dir".to_string());
+            args.push(simard_src.to_string_lossy().into_owned());
+        }
         self.agent_cmd = cmd;
         self.agent_base_args = args;
         self.validate_agent()?;


### PR DESCRIPTION
## Problem

The meeting agent cannot execute `simard goal` commands during conversations. When asked to 'drop goal X' or 'add a goal for Y', it explores the codebase instead of running the commands.

**Root causes:**
1. The prompt had **no mention** of `simard goal` CLI commands — the agent didn't know they exist
2. The agent wasn't given `--add-dir` for codebase context needed to run CLI tools

Re-implements the feature from closed PR #2239 (which failed pre-commit).

## Fix

### Prompt changes (`prompt_assets/simard/meeting_system.md`)
- Added **"Goal Management — You Can Act"** section with full `simard goal` CLI reference table
- Concrete examples for add, remove, and set-priority commands
- Explicit instruction: execute the change immediately, do not just acknowledge

### Code changes (`src/meeting_backend/agent_proxy.rs`)
- Added `--add-dir` pointing to the Simard source tree in `open()` so the agent has codebase context during meetings

## Merge-Ready Evidence

1. **QA**: Prompt-only + 1-line arg change — no new user-facing API surfaces; existing tests cover `PersistentAgentProxy::new()`, `strip_copilot_noise`, and `resolve_agent_command`. The `--add-dir` addition is guarded by `if simard_src.exists()` so it's a no-op in CI/test environments.
2. **Docs**: The prompt change IS the documentation — it teaches the meeting agent the CLI reference.
3. **Quality**: cargo check ✅, cargo clippy ✅, cargo fmt ✅, pre-commit ✅, pre-push (tests + clippy) ✅.
4. **CI**: Pre-push hooks passed (cargo test, clippy with -D warnings). CI will run on PR.
5. **Evidence**: See above.
6. **Diff focused**: 2 files changed, 41 insertions, 1 deletion — strictly goal management feature, no unrelated edits.