### PR TITLE
fix(cognitive-memory): close two model gaps — prospective count and procedural storage (#2280)

### DIFF
--- a/docs/architecture/cognitive-memory.md
+++ b/docs/architecture/cognitive-memory.md
@@ -1,7 +1,7 @@
 ---
 title: Cognitive Memory Architecture
 description: How Simard uses the 6-type cognitive psychology memory model implemented natively in Rust with LadybugDB, including the hive mind for multi-agent knowledge sharing.
-last_updated: 2026-04-13
+last_updated: 2026-06-12
 owner: simard
 doc_type: concept
 ---
@@ -81,11 +81,14 @@ Reusable step-by-step action sequences.
 - **Content**: Named procedures with ordered steps and prerequisites
 - **Usage tracking**: `usage_count` increments on each recall
 - **Use**: Encode successful patterns for reuse
+- **Written by**: OODA cycle Act phase — each successful `ActionOutcome` is stored as an `ooda:{kind}` procedure (issue [#2280](https://github.com/rysweet/Simard/issues/2280))
 
 ```
-After success → store_procedure("fix-and-verify", ["read file", "edit", "cargo test", "commit"])
-Before task   → recall_procedure("how to fix a bug", limit=5)
+After success → store_procedure("ooda:advance-goal", ["planned: spawn engineer", "result: tests pass"])
+Before task   → recall_procedure("advance-goal", limit=5)
 ```
+
+See [OODA procedural memory reference](../reference/ooda-procedural-memory.md) for the full naming convention and content format.
 
 ### Prospective Memory
 
@@ -95,11 +98,15 @@ Future-oriented trigger-action pairs.
 - **Content**: Description, trigger condition, action, priority
 - **Status**: `pending` → `triggered` → `resolved`
 - **Use**: Schedule future actions based on conditions
+- **Written by**: `CognitiveMemoryGoalStore::put()` — Active goals are dual-written as prospective entries with `goal:` prefix (issues [#2207](https://github.com/rysweet/Simard/issues/2207), [#2280](https://github.com/rysweet/Simard/issues/2280)); meeting action items
 
 ```
+Goal added → store_prospective("goal:Fix auth bug", "fix auth bug", "Pursue goal: Fix auth bug (p1, CI red)", priority=1)
 Planning   → store_prospective("re-run gym after self-improve", "self_improve_complete", "run_gym_suite", priority=2)
-After work → check_triggers("self_improve_complete: score improved 3%")  # returns triggered items
+After work → check_triggers("fix auth bug: started engineer")  # returns triggered goal items
 ```
+
+See [Goal–prospective memory mirror](../reference/goal-prospective-memory-mirror.md) for the dual-write contract and reconciliation API.
 
 ## Session Lifecycle Mapping
 
@@ -124,11 +131,15 @@ flowchart LR
         S2[record_sensory<br/>pty_output]
         W4[push_working<br/>state]
     end
+    subgraph OODA-Act
+        PR1[store_procedure<br/>successful outcome]
+    end
+    subgraph Goal-Store
+        PS1[store_prospective<br/>active goal]
+    end
     subgraph Reflection
         E1[store_episode]
         F2[store_fact]
-        PR1[store_procedure]
-        PS1[store_prospective]
     end
     subgraph Persistence
         C1[consolidate_episodes]
@@ -136,16 +147,18 @@ flowchart LR
         PE[prune_expired_sensory]
     end
 
-    Intake --> Preparation --> Planning --> Execution --> Reflection --> Persistence
+    Intake --> Preparation --> Planning --> Execution --> OODA-Act --> Goal-Store --> Reflection --> Persistence
 ```
 
 | Phase | Memory Operations |
 |-------|------------------|
 | **Intake** | `record_sensory(objective)`, `push_working(goal)` |
-| **Preparation** | `search_facts(objective)`, `check_triggers(objective)`, `push_working(context)` |
+| **Preparation** | `search_facts(objective)`, `check_triggers(objective)`, `recall_procedure(task_domain)`, `push_working(context)` |
 | **Planning** | `recall_procedure(task_domain)`, `push_working(plan)` |
 | **Execution** | `record_sensory(pty_output)`, `push_working(state)` |
-| **Reflection** | `store_episode(transcript)`, `store_fact(extracted)`, `store_procedure(successful_sequence)`, `store_prospective(future_intention)` |
+| **OODA Act** | `store_procedure(successful_outcome)` — each successful `ActionOutcome` stored as `ooda:{kind}` ([#2280](https://github.com/rysweet/Simard/issues/2280)) |
+| **Goal Store** | `store_prospective(active_goal)` — Active goals dual-written as prospective triggers ([#2207](https://github.com/rysweet/Simard/issues/2207)/[#2280](https://github.com/rysweet/Simard/issues/2280)) |
+| **Reflection** | `store_episode(transcript)`, `store_fact(extracted)` |
 | **Persistence** | `consolidate_episodes(10)`, `clear_working(task_id)`, `prune_expired_sensory()` |
 
 ## Hive Mind Integration (Planned — Not Yet Implemented)
@@ -241,8 +254,8 @@ Key methods:
 | `consolidate_episodes` | Summarize old episodes |
 | `store_fact` | Store a semantic fact with confidence |
 | `search_facts` | Search by keywords with confidence filter |
-| `store_procedure` | Store a reusable action sequence |
+| `store_procedure` | Store a reusable action sequence. Called by the OODA Act phase for successful outcomes — see [OODA procedural memory](../reference/ooda-procedural-memory.md) |
 | `recall_procedure` | Recall procedures matching a query |
-| `store_prospective` | Store a future trigger-action pair |
+| `store_prospective` | Store a future trigger-action pair. Called by `CognitiveMemoryGoalStore::put()` for Active goals — see [Goal–prospective memory mirror](../reference/goal-prospective-memory-mirror.md) |
 | `check_triggers` | Check if any prospective memories match |
 | `get_statistics` | Get counts for all memory types |

--- a/docs/howto/reconcile-goal-prospective-drift.md
+++ b/docs/howto/reconcile-goal-prospective-drift.md
@@ -1,22 +1,21 @@
 ---
 title: How to reconcile goal–prospective memory drift
 description: Operator guide for detecting and fixing inconsistencies between goal records in semantic memory and their prospective memory mirror entries.
-last_updated: 2026-06-10
+last_updated: 2026-06-12
 owner: simard
 doc_type: howto
 related:
   - ../reference/goal-prospective-memory-mirror.md
   - ../reference/cognitive-memory-goal-store.md
+  - ../reference/ooda-procedural-memory.md
   - ../howto/troubleshoot-goal-store.md
   - ../howto/unblock-stuck-ooda-goals.md
 ---
 
 # How to reconcile goal–prospective memory drift
 
-> **Implementation status:** This document describes the target design
-> being built in issue
-> [#2207](https://github.com/rysweet/Simard/issues/2207). It must be
-> merged alongside the implementation code — not before.
+> Shipped in issues [#2207](https://github.com/rysweet/Simard/issues/2207)
+> and [#2280](https://github.com/rysweet/Simard/issues/2280).
 
 The `CognitiveMemoryGoalStore` maintains a prospective-memory mirror for
 Active goals so they surface via `check_triggers` during OODA preparation

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -1,7 +1,7 @@
 ---
 title: Memory architecture
 description: Top-level overview of Simard's six-type cognitive memory, consolidation flow, and on-disk layout. Cross-links to the canonical architecture page.
-last_updated: 2026-04-24
+last_updated: 2026-06-12
 owner: simard
 doc_type: concept
 ---
@@ -20,8 +20,8 @@ For the full canonical specification (schema, consolidation rules, hive event bu
 | **Working** | Task-scoped (cleared at task end) | The 20-slot active task context: goal, constraints, plan steps, current execution state. |
 | **Episodic** | Persistent, autobiographical | "What happened this session" — every cycle, every action, every observation. |
 | **Semantic** | Persistent, deduplicated | Facts and learned concepts promoted from episodic memory ("the test harness uses CARGO_TARGET_DIR"). |
-| **Procedural** | Persistent, indexed by trigger | Learned how-to: action sequences that worked for a given situation. |
-| **Prospective** | Persistent, time/event-indexed | Future intentions: "when CI is green for #1209, post a follow-up comment." |
+| **Procedural** | Persistent, indexed by trigger | Learned how-to: action sequences that worked for a given situation. Written by the OODA Act phase for successful outcomes (`ooda:{kind}`). See [OODA procedural memory](reference/ooda-procedural-memory.md). |
+| **Prospective** | Persistent, time/event-indexed | Future intentions: Active goals as trigger-action pairs, meeting action items. See [Goal–prospective memory mirror](reference/goal-prospective-memory-mirror.md). |
 
 ## Consolidation flow
 
@@ -29,10 +29,11 @@ For the full canonical specification (schema, consolidation rules, hive event bu
 Sensory   ──(attention)──▶  Episodic
 Working   ──(task end)───▶  Episodic
 Episodic  ──(consolidate)─▶ Semantic
-Episodic  ──(repeated success)──▶ Procedural
+OODA Act  ──(success)────▶  Procedural    (#2280)
+Goal put  ──(Active)─────▶  Prospective   (#2207/#2280)
 ```
 
-The OODA daemon dispatches a `consolidate-memory` action whenever working-memory pressure or recent-episode density crosses a threshold. Consolidation is idempotent and runs without spawning an engineer subprocess.
+The OODA daemon dispatches a `consolidate-memory` action whenever working-memory pressure or recent-episode density crosses a threshold. Consolidation is idempotent and runs without spawning an engineer subprocess. Procedural memories are written inline during the OODA Act phase (not during consolidation) — each successful `ActionOutcome` produces an `ooda:{kind}` procedure. Prospective memories are written by `CognitiveMemoryGoalStore::put()` whenever a goal transitions to Active.
 
 ## Cross-session recall
 
@@ -66,5 +67,7 @@ For multi-host coordination see [Distributed operations](distributed-operations.
 ## Related
 
 - [Cognitive Memory Architecture](architecture/cognitive-memory.md) (canonical, full detail)
+- [OODA procedural memory](reference/ooda-procedural-memory.md) — how successful OODA outcomes become procedures
+- [Goal–prospective memory mirror](reference/goal-prospective-memory-mirror.md) — how Active goals become prospective triggers
 - [Dashboard](dashboard.md) — Memory tab
 - [Daemon mode](daemon-mode.md) — when consolidation runs

--- a/docs/reference/goal-prospective-memory-mirror.md
+++ b/docs/reference/goal-prospective-memory-mirror.md
@@ -1,12 +1,13 @@
 ---
 title: Goal–prospective memory mirror
 description: API reference for the prospective-memory mirror in CognitiveMemoryGoalStore — how put() dual-writes prospective entries for Active goals, error propagation, reconcile_prospectives(), and shared constants.
-last_updated: 2026-06-10
+last_updated: 2026-06-12
 owner: simard
 doc_type: reference
 related:
   - ./cognitive-memory-goal-store.md
   - ./goal-board-api.md
+  - ./ooda-procedural-memory.md
   - ../concepts/goal-board-persistence.md
   - ../howto/reconcile-goal-prospective-drift.md
   - ../memory.md
@@ -14,11 +15,9 @@ related:
 
 # Goal–prospective memory mirror
 
-> **Implementation status:** This document describes the target design
-> being built in issue
-> [#2207](https://github.com/rysweet/Simard/issues/2207). It must be
-> merged alongside the implementation code — not before. Until the PR
-> lands, the source code does not yet match the API described here.
+> Shipped in issue [#2207](https://github.com/rysweet/Simard/issues/2207)
+> and extended in [#2280](https://github.com/rysweet/Simard/issues/2280)
+> (test coverage for the prospective mirror).
 
 When `CognitiveMemoryGoalStore::put()` writes a goal record to semantic
 memory, it also maintains a **mirror** in prospective memory so that

--- a/docs/reference/ooda-procedural-memory.md
+++ b/docs/reference/ooda-procedural-memory.md
@@ -1,0 +1,234 @@
+---
+title: OODA procedural memory
+description: How the OODA cycle stores successful action outcomes as procedural memories, enabling Simard to recall what worked in past cycles during future preparation phases.
+last_updated: 2026-06-12
+owner: simard
+doc_type: reference
+related:
+  - ../architecture/cognitive-memory.md
+  - ./goal-prospective-memory-mirror.md
+  - ./ooda-brain-api.md
+  - ./ooda-engineer-lifecycle-recipe.md
+  - ../memory.md
+---
+
+# OODA procedural memory
+
+Shipped in issue [#2280](https://github.com/rysweet/Simard/issues/2280).
+
+After the OODA Act phase dispatches actions and collects outcomes, each
+**successful** outcome is stored as a procedural memory. This enables
+Simard to recall effective action sequences in future OODA cycles via
+`recall_procedure` during the preparation phase.
+
+---
+
+## Overview
+
+Procedural memory is the cognitive memory type for "how-to" knowledge —
+named, reusable step sequences that encode what worked. Before issue
+#2280, procedural memories were never written by any production code
+path. The `store_procedure` API existed and was tested at the unit
+level, but no caller invoked it. This left the procedural memory table
+permanently empty.
+
+The OODA cycle's Act phase is the natural site for procedural learning:
+it dispatches actions, observes outcomes, and knows which succeeded.
+After execution, the cycle now iterates over outcomes and stores each
+successful one as a procedure.
+
+```
+Act phase
+  │
+  ├─ dispatch actions → outcomes[]
+  ├─ execution_memory_operations(outcome.detail)   ← existing
+  ├─ store_procedure(outcome) for each success      ← NEW (#2280)
+  │
+  └─ review_outcomes(outcomes)
+```
+
+---
+
+## Procedure naming convention
+
+Each procedure is named `ooda:{action_kind}`, where `action_kind` is the
+`Display` representation of the `ActionKind` enum:
+
+| ActionKind             | Procedure name              |
+|------------------------|-----------------------------|
+| `AdvanceGoal`          | `ooda:advance-goal`         |
+| `RunImprovement`       | `ooda:run-improvement`      |
+| `ConsolidateMemory`    | `ooda:consolidate-memory`   |
+| `ResearchQuery`        | `ooda:research-query`       |
+| `RunGymEval`           | `ooda:run-gym-eval`         |
+| `BuildSkill`           | `ooda:build-skill`          |
+| `LaunchSession`        | `ooda:launch-session`       |
+| `PollDeveloperActivity`| `ooda:poll-developer-activity` |
+| `ExtractIdeas`         | `ooda:extract-ideas`        |
+| `SafeUpdate`           | `ooda:safe-update`          |
+
+The `ooda:` prefix distinguishes OODA-learned procedures from any
+future manually-imported or meeting-derived procedures.
+
+**Intentional accumulation**: when the same `ActionKind` succeeds in
+multiple cycles, each `store_procedure` call creates a new
+procedure node. `recall_procedure` returns all matches ranked by
+relevance, so earlier successes remain queryable. This accumulation
+reflects the evolving understanding of what works for each action type.
+
+---
+
+## Procedure content
+
+Each stored procedure contains two steps:
+
+| Step index | Content | Source |
+|------------|---------|--------|
+| 0 | `outcome.action.description` | What was **planned** — the natural-language description from the Decide phase |
+| 1 | `outcome.detail` | What **happened** — the execution output captured during Act |
+
+Prerequisites are empty (`&[]`) because OODA actions are self-contained
+dispatches — the cycle handles sequencing and precondition checking.
+
+### Example
+
+After a successful `AdvanceGoal` action:
+
+```rust
+store_procedure(
+    "ooda:advance-goal",
+    &[
+        "Advance goal 'fix-auth-bug': spawn engineer to fix the null check in auth.rs".into(),
+        "Engineer session completed: edited auth.rs:42, all tests pass, committed abc1234".into(),
+    ],
+    &[],  // no prerequisites
+)
+```
+
+This produces a `Procedure` node:
+
+```
+Procedure {
+    name: "ooda:advance-goal",
+    steps: [
+        "Advance goal 'fix-auth-bug': spawn engineer to fix the null check in auth.rs",
+        "Engineer session completed: edited auth.rs:42, all tests pass, committed abc1234",
+    ],
+    prerequisites: [],
+    usage_count: 0,
+}
+```
+
+---
+
+## When procedures are NOT stored
+
+- **Failed outcomes** (`outcome.success == false`): failed actions
+  represent "what doesn't work" — this is negative knowledge, not
+  procedural memory. Failed outcomes are still captured in episodic
+  memory via the existing `execution_memory_operations` and
+  `reflection_memory_operations` calls.
+
+- **Bridge/memory errors**: if `store_procedure` fails, the error is
+  logged to stderr and the cycle continues. Memory failures never crash
+  the OODA loop. This matches the best-effort pattern used by every
+  other memory call in `cycle.rs`:
+
+  ```
+  [simard] OODA consolidation: procedural memory failed: <error>
+  ```
+
+---
+
+## Recall during preparation
+
+Procedural memories are available to future OODA cycles through
+`recall_procedure(query, limit)` during the preparation phase. The
+query is matched against procedure names and step content using
+keyword-based search with n-gram reranking (the same algorithm as
+`search_facts`).
+
+Typical preparation usage:
+
+```rust
+let procedures = memory.recall_procedure("advance-goal", 5)?;
+for proc in &procedures {
+    println!("Procedure: {} ({} uses)", proc.name, proc.usage_count);
+    for (i, step) in proc.steps.iter().enumerate() {
+        println!("  {}: {}", i, step);
+    }
+}
+```
+
+This enables the Orient and Decide phases to consider past successful
+approaches when selecting actions for the current cycle.
+
+---
+
+## Code location
+
+| Item | File |
+|------|------|
+| Procedural storage loop | `src/ooda_loop/cycle.rs` (after `execution_memory_operations` loop) |
+| `store_procedure` trait method | `src/cognitive_memory/mod.rs` (`CognitiveMemoryOps`) |
+| `store_procedure` implementation | `src/cognitive_memory/ops.rs` (`NativeCognitiveMemory`) |
+| `recall_procedure` implementation | `src/cognitive_memory/ops.rs` (`NativeCognitiveMemory`) |
+| `ActionOutcome` / `ActionKind` types | `src/ooda_loop/types.rs` |
+| Mock handlers | `tests/ooda.rs`, `tests/ooda_daemon.rs`, `tests/memory_consolidation_lifecycle.rs` |
+
+---
+
+## Testing
+
+### Unit test
+
+`successful_outcome_stores_procedural_memory` in the OODA test suite
+verifies that after a cycle containing a successful outcome, the mock
+transport receives a `memory.store_procedure` call (or when using
+`NativeCognitiveMemory` directly, that `get_statistics().procedural_count`
+increases).
+
+### Mock transport handler
+
+All OODA-related integration tests include a `memory.store_procedure`
+handler in their mock transport to prevent spurious `-32601 Method not
+found` errors:
+
+```rust
+"memory.store_procedure" => Ok(json!({"id": "proc_new"})),
+```
+
+This handler is present in:
+- `tests/ooda.rs`
+- `tests/ooda_daemon.rs`
+- `tests/memory_consolidation_lifecycle.rs`
+
+---
+
+## Relationship to other memory types
+
+| Memory type | What it captures from OODA | When |
+|-------------|---------------------------|------|
+| **Sensory** | Raw PTY output, objective text | Observation phase |
+| **Working** | Current goal, plan, execution state | Throughout cycle |
+| **Episodic** | Full session transcripts, action logs | Reflection phase |
+| **Semantic** | Extracted facts about codebase, patterns | Reflection phase |
+| **Procedural** | Successful action sequences | After Act phase (**#2280**) |
+| **Prospective** | Active goals as future triggers | Goal store `put()` (**#2207/#2280**) |
+
+Before issue #2280, the procedural and prospective rows were
+effectively dead — the storage APIs existed but no production code
+called them from the OODA loop. Issue #2280 closes both gaps.
+
+---
+
+## Related reading
+
+- [Cognitive Memory Architecture](../architecture/cognitive-memory.md) —
+  the six memory types and their lifecycle.
+- [Goal–prospective memory mirror](./goal-prospective-memory-mirror.md) —
+  the companion fix for prospective memory (goals as triggers).
+- [Memory architecture (operator summary)](../memory.md) — top-level
+  memory overview.
+- [OODA Brain API](./ooda-brain-api.md) — the brain that drives
+  Orient/Decide/Act.

--- a/src/goals/cognitive_memory_store.rs
+++ b/src/goals/cognitive_memory_store.rs
@@ -765,6 +765,44 @@ mod tests {
         );
     }
 
+    /// Issue #2280 Gap 1: put(Active) must increment prospective_count in
+    /// get_statistics(). This is the quantitative assertion that complements
+    /// the qualitative `put_active_goal_creates_prospective_trigger` test.
+    #[test]
+    #[serial_test::serial(cognitive_memory)]
+    fn put_active_goal_increments_prospective_count() {
+        let root = fresh_state_root("prospective-count");
+        let store = CognitiveMemoryGoalStore::new(root.clone()).expect("store should build");
+
+        // Put a Proposed goal first to create the DB without a prospective node.
+        store
+            .put(record("Setup baseline", GoalStatus::Proposed, 2))
+            .expect("put proposed goal");
+
+        {
+            let reader = crate::memory_ipc::open_reader_bridge(&root).expect("reader bridge");
+            let before = reader.ops().get_statistics().expect("get_statistics");
+            assert_eq!(
+                before.prospective_count, 0,
+                "Proposed goal must not create a prospective node"
+            );
+        }
+
+        // Put an Active goal — this must create a prospective memory node.
+        store
+            .put(record("Implement caching layer", GoalStatus::Active, 1))
+            .expect("put active goal");
+
+        // Open a fresh reader to see the write.
+        let reader = crate::memory_ipc::open_reader_bridge(&root).expect("reader bridge");
+        let after = reader.ops().get_statistics().expect("get_statistics");
+        assert!(
+            after.prospective_count > 0,
+            "put(Active) must increment prospective_count; got {}",
+            after.prospective_count
+        );
+    }
+
     #[test]
     #[serial_test::serial(cognitive_memory)]
     fn cognitive_memory_goal_store_put_overwrites_existing_slug_with_latest_record() {

--- a/src/ooda_loop/cycle.rs
+++ b/src/ooda_loop/cycle.rs
@@ -337,6 +337,17 @@ fn run_ooda_cycle_inner(
         }
     }
 
+    // --- Memory consolidation: procedural learning from successful actions ---
+    for outcome in &outcomes {
+        if outcome.success {
+            let proc_name = format!("ooda:{}", outcome.action.kind);
+            let steps = [outcome.action.description.clone(), outcome.detail.clone()];
+            if let Err(e) = bridges.memory.store_procedure(&proc_name, &steps, &[]) {
+                eprintln!("[simard] OODA consolidation: procedural memory failed: {e}");
+            }
+        }
+    }
+
     // --- Review: analyze outcomes and propose improvements ---
     let review_proposals = review_outcomes(&outcomes, act_elapsed);
 

--- a/tests/memory_consolidation_lifecycle.rs
+++ b/tests/memory_consolidation_lifecycle.rs
@@ -133,6 +133,7 @@ fn full_mock_memory_transport() -> InMemoryBridgeTransport {
         "memory.check_triggers" => Ok(json!({"prospectives": []})),
         "memory.clear_working" => Ok(json!({"count": 0})),
         "memory.prune_expired_sensory" => Ok(json!({"count": 0})),
+        "memory.store_procedure" => Ok(json!({"id": "proc_new"})),
         _ => Err(BridgeErrorPayload {
             code: -32601,
             message: format!("unknown: {method}"),

--- a/tests/ooda.rs
+++ b/tests/ooda.rs
@@ -38,6 +38,7 @@ fn mock_memory_transport() -> InMemoryBridgeTransport {
         "memory.check_triggers" => Ok(json!({"prospectives": []})),
         "memory.clear_working" => Ok(json!({"count": 0})),
         "memory.prune_expired_sensory" => Ok(json!({"count": 0})),
+        "memory.store_procedure" => Ok(json!({"id": "proc_new"})),
         _ => Err(BridgeErrorPayload {
             code: -32601,
             message: format!("unknown: {method}"),
@@ -400,4 +401,90 @@ fn install_skill_refuses_overwrite() {
             .contains("already exists")
     );
     let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Issue #2280 Gap 2: Successful OODA outcomes must store procedural memories.
+/// After `run_ooda_cycle` with at least one successful outcome, the cycle
+/// should call `store_procedure` for each success. This test uses an
+/// `AtomicUsize` counter to verify the call was made.
+#[test]
+fn successful_outcome_stores_procedural_memory() {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let procedure_calls = Arc::new(AtomicUsize::new(0));
+    let counter = procedure_calls.clone();
+
+    let counting_memory =
+        InMemoryBridgeTransport::new("proc-counter-mem", move |method, _params| match method {
+            "memory.store_procedure" => {
+                counter.fetch_add(1, Ordering::SeqCst);
+                Ok(json!({"id": "proc_new"}))
+            }
+            "memory.search_facts" => Ok(json!({"facts": []})),
+            "memory.store_fact" => Ok(json!({"id": "sem_1"})),
+            "memory.store_episode" => Ok(json!({"id": "epi_1"})),
+            "memory.get_statistics" => Ok(json!({
+                "sensory_count": 5, "working_count": 3, "episodic_count": 12,
+                "semantic_count": 8, "procedural_count": 2, "prospective_count": 1
+            })),
+            "memory.consolidate_episodes" => Ok(json!({"id": null})),
+            "memory.recall_procedure" => Ok(json!({"procedures": []})),
+            "memory.record_sensory" => Ok(json!({"id": "sen_1"})),
+            "memory.push_working" => Ok(json!({"id": "wrk_1"})),
+            "memory.get_working" => Ok(json!({"slots": []})),
+            "memory.check_triggers" => Ok(json!({"prospectives": []})),
+            "memory.clear_working" => Ok(json!({"count": 0})),
+            "memory.prune_expired_sensory" => Ok(json!({"count": 0})),
+            _ => Err(BridgeErrorPayload {
+                code: -32601,
+                message: format!("unknown: {method}"),
+            }),
+        });
+
+    // Custom decide brain that routes all priorities to ConsolidateMemory,
+    // which succeeds with the mock transport (no session required).
+    struct AlwaysConsolidateBrain;
+    impl simard::ooda_brain::OodaDecideBrain for AlwaysConsolidateBrain {
+        fn judge_decision(
+            &self,
+            _ctx: &simard::ooda_brain::DecideContext,
+        ) -> simard::error::SimardResult<simard::ooda_brain::DecideJudgment> {
+            Ok(simard::ooda_brain::DecideJudgment::ConsolidateMemory {
+                rationale: "test: force consolidate for success".into(),
+            })
+        }
+    }
+
+    let mut bridges = OodaBridges {
+        memory: Box::new(CognitiveMemoryBridge::new(Box::new(counting_memory))),
+        knowledge: KnowledgeBridge::new(Box::new(mock_knowledge_transport())),
+        gym: GymBridge::new(Box::new(mock_gym_transport())),
+        session: None,
+        brain: std::sync::Arc::new(simard::ooda_brain::DeterministicLifecycleBrain),
+        decide_brain: Some(std::sync::Arc::new(AlwaysConsolidateBrain)),
+        orient_brain: None,
+        repo_root: std::path::PathBuf::from("."),
+        progress_evidence: std::sync::Arc::new(
+            simard::goal_curation::progress_evidence::NoopProgressEvidenceChecker,
+        ),
+    };
+
+    let mut state = OodaState::new(board_with_goals());
+    let report = run_ooda_cycle(&mut state, &mut bridges, &OodaConfig::default()).unwrap();
+
+    // The cycle must have produced at least one successful outcome.
+    let successes = report.outcomes.iter().filter(|o| o.success).count();
+    assert!(
+        successes > 0,
+        "test setup: need at least one successful outcome"
+    );
+
+    // Each successful outcome must have triggered a store_procedure call.
+    let calls = procedure_calls.load(Ordering::SeqCst);
+    assert_eq!(
+        calls, successes,
+        "store_procedure must be called once per successful outcome; \
+         expected {successes} calls, got {calls}"
+    );
 }

--- a/tests/ooda_daemon.rs
+++ b/tests/ooda_daemon.rs
@@ -49,6 +49,7 @@ fn mock_memory() -> CognitiveMemoryBridge {
             "memory.check_triggers" => Ok(json!({"prospectives": []})),
             "memory.clear_working" => Ok(json!({"count": 0})),
             "memory.prune_expired_sensory" => Ok(json!({"count": 0})),
+            "memory.store_procedure" => Ok(json!({"id": "proc_new"})),
             _ => Err(BridgeErrorPayload {
                 code: -32601,
                 message: format!("unknown: {method}"),


### PR DESCRIPTION
## Summary

Closes two cognitive memory model gaps identified in issue #2270 analysis:

### Gap 1: Goals ARE prospective memories (verification)
`put()` already mirrors Active goals → prospective memory nodes (lines 224-239 of `cognitive_memory_store.rs`). Added test `put_active_goal_increments_prospective_count` that asserts `get_statistics().prospective_count > 0` after `put(Active)` — confirming prospective storage works.

### Gap 2: Procedural memory from successful OODA outcomes (new code)
Added `store_procedure` loop in `cycle.rs` after execution memory operations:
- Iterates `outcomes`, calls `store_procedure` for each `outcome.success == true`
- Procedure name: `ooda:{kind}` (e.g., `ooda:advance-goal`)
- Steps: `[description, detail]` — captures intent + outcome
- Best-effort error handling (eprintln, matches existing pattern)

### Mock updates
Added `memory.store_procedure` handler to 3 test mocks to prevent spurious errors.

### New test
`successful_outcome_stores_procedural_memory` — uses AtomicUsize counter to verify `store_procedure` called once per successful outcome.

## Files Changed (10)
- `src/ooda_loop/cycle.rs` — +11 lines: procedural learning loop
- `src/goals/cognitive_memory_store.rs` — +38 lines: prospective count test
- `tests/ooda.rs` — +87 lines: procedural memory test + mock handler
- `tests/ooda_daemon.rs` — +1 line: mock handler
- `tests/memory_consolidation_lifecycle.rs` — +1 line: mock handler
- `docs/` — 5 doc files updated/created

## Testing
- All integration tests pass (ooda, ooda_daemon, memory_consolidation_lifecycle)
- New unit test passes (put_active_goal_increments_prospective_count)
- `cargo build` — zero warnings