### PR TITLE
feat(cognitive-memory): PR-A — drop goal-board snapshots and stale goal-store records from preparation (#2281)

### DIFF
--- a/docs/reference/cognitive-memory-preparation-filters.md
+++ b/docs/reference/cognitive-memory-preparation-filters.md
@@ -1,0 +1,383 @@
+---
+title: Preparation-phase memory filters
+description: How the OODA preparation phase filters stale and redundant facts (goal-board:snapshot revisions, stale goal-store:record entries) out of the prepared context delivered to the brain.
+last_updated: 2026-06-14
+owner: simard
+doc_type: reference
+related:
+  - ../architecture/cognitive-memory.md
+  - ./goal-prospective-memory-mirror.md
+  - ./ooda-procedural-memory.md
+  - ./cognitive-memory-episodic-recall.md
+  - ../memory.md
+---
+
+# Preparation-phase memory filters
+
+> Shipped in issue [#2281](https://github.com/rysweet/Simard/issues/2281)
+> as PR-A (retrieval cleanup). Companion to PR-B (episode distillation)
+> and PR-C (procedural seeding + episodic recall).
+
+`preparation_memory_operations` is the function that assembles the
+`PreparedContext` delivered to the brain at the start of each OODA
+cycle. Two classes of low-value facts used to flood that context:
+
+1. **Goal-board snapshot revisions** — every cycle's
+   `goal-board:snapshot` write produced a new revision, and all
+   revisions matched the per-fragment `search_facts` call. A single
+   preparation pass could surface 8–10 near-identical JSON blobs out
+   of a 16-fact budget.
+2. **Stale `goal-store:record` facts** — old test meetings and retired
+   goals left `goal-store:record` rows behind. Slug-based dedup kept
+   only the latest revision per slug, but the *stale slugs themselves*
+   still surfaced on every cycle as low-value noise.
+
+PR-A adds two filters inside `preparation_memory_operations`:
+
+- Drop every fact whose `concept == "goal-board:snapshot"`.
+- Drop every `goal-store:record` fact whose slug is not on the **live**
+  goal-board (active or backlog).
+
+The live snapshot is already injected into the prompt by
+`advance.rs`, so removing snapshot facts from preparation costs the
+brain nothing and frees the fact budget for genuinely diverse facts.
+
+---
+
+## Filter contract
+
+### Inputs
+
+`preparation_memory_operations` takes:
+
+| Parameter      | Type                | Source                                                                 |
+|----------------|---------------------|------------------------------------------------------------------------|
+| `objective`    | `&str`              | Current cycle objective (from `state.last_objective`)                  |
+| `session_id`   | `&str`              | Current session id                                                     |
+| `bridge`       | `&dyn CognitiveMemoryOps` | Cognitive memory handle from `OodaBridges`                       |
+| `active_slugs` | `&HashSet<&str>`    | **New in PR-A** — union of `state.active_goals.active` and `.backlog` ids |
+
+The single caller (`src/ooda_loop/cycle.rs`, in `prepare_phase`)
+constructs `active_slugs` from the live goal-board state immediately
+before the call:
+
+```rust
+let active_slugs: HashSet<&str> = state
+    .active_goals
+    .active
+    .iter()
+    .map(|g| g.id.as_str())
+    .chain(state.active_goals.backlog.iter().map(|b| b.id.as_str()))
+    .collect();
+
+let prepared = preparation_memory_operations(
+    &state.last_objective,
+    &session_id,
+    &*bridges.memory,
+    &active_slugs,
+)?;
+```
+
+### Outputs
+
+`PreparedContext` keeps the same public shape; only the contents of
+`relevant_facts` change:
+
+```rust
+pub struct PreparedContext {
+    pub relevant_facts: Vec<Fact>,            // filtered (PR-A)
+    pub triggered_prospectives: Vec<Trigger>, // unchanged
+    pub recalled_procedures: Vec<Procedure>,  // unchanged in PR-A; populated by PR-C's bootstrap + naming changes
+    pub episodic_recall: Vec<CognitiveEpisode>, // added by PR-C, not PR-A — listed here for the complete final shape
+}
+```
+
+PR-A only adds the two filters described below; the
+`episodic_recall` field lands in PR-C. The struct is shown in its
+final post-PR-C shape so callers reading either doc see the same
+layout.
+
+### Filter order
+
+The two filters apply *after* the per-fragment `search_facts` calls
+and *before* the existing slug-dedup pass:
+
+```
+search_facts(per fragment, limit=10) ─┐
+                                      ├─► raw_facts
+search_facts(GOAL_STORE_FACT_CONCEPT, ┘
+              limit=256)
+
+raw_facts
+  │
+  ├─ drop where concept == "goal-board:snapshot"    ← PR-A filter 1
+  ├─ dedup goal-store:record by slug (existing)
+  ├─ drop goal-store:record where slug ∉ active_slugs ← PR-A filter 2
+  │
+  └─► relevant_facts
+```
+
+Filter 1 runs first because it eliminates a large class of facts
+before any further work. Filter 2 runs after the existing dedup so
+that the "keep latest revision per slug" semantics are preserved for
+active slugs.
+
+---
+
+## What gets dropped
+
+### `goal-board:snapshot` facts
+
+**Every** fact whose `concept` field equals `"goal-board:snapshot"`
+is dropped, regardless of timestamp, source, or content. The live
+goal-board state is already injected into the prompt by
+`src/ooda_actions/goal_session/advance.rs` under the
+`## Current Goals` section, so the snapshot facts are pure
+redundancy at preparation time.
+
+The snapshot facts remain in semantic memory — they are not deleted
+from storage. The dashboard and any consumer that queries
+`search_facts("goal-board:snapshot", ...)` directly still sees them.
+
+### Stale `goal-store:record` facts
+
+A `goal-store:record` fact is "stale" when its slug is not present in
+`active_slugs`. Stale records are dropped from the prepared context.
+
+The slug is **not** a column on the `CognitiveFact` schema. Each
+`goal-store:record` fact's `content` is a JSON-serialised
+`GoalRecord` (see `src/goals/cognitive_memory_store.rs`), and PR-A
+parses the slug from that JSON exactly the way the existing
+slug-dedup loop already does
+(`src/memory_consolidation/mod.rs:117-141`):
+
+```rust
+let record: GoalRecord = match serde_json::from_str(&fact.content) {
+    Ok(r) => r,
+    Err(e) => {
+        eprintln!(
+            "[simard] preparation: skipping unparseable goal fact \
+             (node_id={}): {e}",
+            fact.node_id
+        );
+        continue;
+    }
+};
+let slug = record.slug;
+```
+
+Unparseable facts are logged and skipped (matching the existing
+behaviour), neither retained nor dropped by the stale-slug filter —
+they simply do not reach it.
+
+Examples of stale records that are filtered:
+
+- Test meeting records like `adopt-tdd`, `decision-use-rust` that
+  were never promoted to real goals.
+- Records for goals that have since been completed and removed from
+  the active and backlog lists.
+- Records for goals that were rejected during curation.
+
+Active and backlog records pass through. The semantics of "active"
+and "backlog" follow the live `GoalBoard` state, not the snapshot
+facts in semantic memory — this is the entire point of the fix.
+
+---
+
+## What is preserved
+
+The filters are deliberately narrow. Anything **not** matching one of
+the two rules above is untouched:
+
+- All non-snapshot, non-goal-store facts (e.g. `pr-pattern`,
+  `bug-pattern`, `lesson-learned`, `commit-summary`, `code-pattern`)
+  pass through unchanged.
+- `goal-store:record` facts for slugs that *are* on the active or
+  backlog list pass through after the existing slug-dedup.
+- Triggered prospectives (`check_triggers` results) are unaffected.
+- Recalled procedures (`recall_procedure` results) are unaffected
+  by PR-A. PR-C adds new behaviour to that surface.
+
+---
+
+## Observability
+
+A single `tracing::info!` line is emitted per preparation pass with
+low-cardinality counters:
+
+```
+[simard] preparation: 0 snapshot facts, 3 stale goal-store filtered, 9 facts retained
+```
+
+Fields:
+
+| Field                              | Meaning                                              |
+|------------------------------------|------------------------------------------------------|
+| `snapshot facts`                   | Count dropped by filter 1                            |
+| `stale goal-store filtered`        | Count dropped by filter 2 (after slug-dedup)         |
+| `facts retained`                   | Final length of `PreparedContext.relevant_facts`     |
+
+Grep this line in daemon logs to confirm the filters fired and to
+spot regressions where redundant facts re-enter the prepared context.
+
+---
+
+## Where the snapshot concept constant lives
+
+The new `GOAL_BOARD_SNAPSHOT_CONCEPT` constant is defined in
+`src/goals/cognitive_memory_store.rs` next to its sibling
+`GOAL_STORE_FACT_CONCEPT`, and re-exported through `src/goals/mod.rs`
+so the consolidation layer imports both from `crate::goals`:
+
+```rust
+// src/goals/cognitive_memory_store.rs
+pub(crate) const GOAL_STORE_FACT_CONCEPT: &str = "goal-store:record";
+pub(crate) const GOAL_BOARD_SNAPSHOT_CONCEPT: &str = "goal-board:snapshot";
+
+// src/goals/mod.rs
+pub(crate) use cognitive_memory_store::{
+    GOAL_BOARD_SNAPSHOT_CONCEPT,
+    GOAL_STORE_FACT_CONCEPT,
+    GOAL_STORE_LIST_LIMIT,
+};
+
+// src/memory_consolidation/mod.rs
+use crate::goals::{
+    GOAL_BOARD_SNAPSHOT_CONCEPT,
+    GOAL_STORE_FACT_CONCEPT,
+    GOAL_STORE_LIST_LIMIT,
+    GoalRecord,
+};
+```
+
+Co-locating the two concept names with the writer
+(`save_goal_board_snapshot` lives in `src/goal_curation/operations.rs`
+but uses the constant from `crate::goals`) ensures that future
+contributors searching for "snapshot concept" find the writer, the
+reader, and the filter together.
+
+---
+
+## Fallback lever
+
+If a downstream consumer (test harness, dashboard, future agent) is
+discovered to depend on `goal-board:snapshot` facts appearing in
+preparation output, filter 1 can be relaxed to "keep most recent
+revision" with a one-line change. The relaxed form keeps the entry
+with the lexicographically maximum `node_id` (which is monotonic
+because node ids are timestamp-prefixed):
+
+```rust
+// keep only the newest revision per slug
+let snapshots = raw_facts.iter()
+    .filter(|f| f.concept == GOAL_BOARD_SNAPSHOT_CONCEPT)
+    .max_by_key(|f| f.node_id.clone());
+```
+
+PR-A ships the strict drop-all variant because no current consumer
+depends on snapshots in preparation. The lever is documented here so
+future contributors do not have to re-derive it.
+
+---
+
+## Examples
+
+### Example 1 — typical cycle
+
+Before PR-A:
+
+```
+preparation_summary: 16 facts
+  - 10× goal-board:snapshot (identical JSON blobs from cycles 41–50)
+  - 4×  goal-store:record   (active: fix-auth, refactor-mod;
+                             stale:  adopt-tdd, decision-use-rust)
+  - 2×  bug-pattern         (genuinely useful)
+```
+
+After PR-A:
+
+```
+preparation_summary: 4 facts
+  - 2× goal-store:record    (active: fix-auth, refactor-mod)
+  - 2× bug-pattern          (genuinely useful)
+```
+
+Log line:
+
+```
+[simard] preparation: 10 snapshot facts, 2 stale goal-store filtered, 4 facts retained
+```
+
+### Example 2 — only stale goal-store records
+
+Input: 5 `goal-store:record` facts for slugs `A B C D E`;
+`active_slugs = {A, B}`.
+
+After preparation: 2 facts (A and B). Log line:
+
+```
+[simard] preparation: 0 snapshot facts, 3 stale goal-store filtered, 2 facts retained
+```
+
+### Example 3 — no filters fire
+
+Input: 6 facts of mixed concepts, none `goal-board:snapshot`, all
+`goal-store:record` slugs on active list.
+
+After preparation: 6 facts. Log line:
+
+```
+[simard] preparation: 0 snapshot facts, 0 stale goal-store filtered, 6 facts retained
+```
+
+---
+
+## Code location
+
+| Item                                | File                                                   |
+|-------------------------------------|--------------------------------------------------------|
+| `preparation_memory_operations`     | `src/memory_consolidation/mod.rs`                      |
+| `PreparedContext` struct            | `src/memory_consolidation/mod.rs`                      |
+| Single call site                    | `src/ooda_loop/cycle.rs` (in `prepare_phase`)          |
+| `GOAL_BOARD_SNAPSHOT_CONCEPT` const | `src/goals/mod.rs` (re-export of `src/goals/cognitive_memory_store.rs`, alongside `GOAL_STORE_FACT_CONCEPT`) |
+| `GOAL_STORE_FACT_CONCEPT` const     | `src/goals/cognitive_memory_store.rs` (existing), re-exported via `src/goals/mod.rs` |
+| Tests                               | `src/memory_consolidation/tests.rs`                    |
+
+---
+
+## Testing
+
+Four unit tests live in `src/memory_consolidation/tests.rs`:
+
+| Test                                                  | Coverage                                          |
+|-------------------------------------------------------|---------------------------------------------------|
+| `preparation_drops_goal_board_snapshot_revisions`     | Filter 1: 5 snapshot revisions → 0 in output      |
+| `preparation_drops_stale_goal_store_records`          | Filter 2: stale slugs dropped                     |
+| `preparation_keeps_active_goal_store_records`         | Filter 2 regression: active slugs not dropped     |
+| `preparation_does_not_filter_other_concepts`          | Random concepts untouched by either filter        |
+
+Each test injects a fixture `CognitiveMemoryOps` mock that returns
+hand-built `Fact` lists and asserts the final `PreparedContext`
+contents.
+
+---
+
+## Out of scope
+
+These were considered for PR-A and explicitly deferred:
+
+- **`simard memory prune-stale` CLI command** — would let an operator
+  delete stale `goal-store:record` rows from storage rather than
+  filtering them at read time. PR-A's runtime filter resolves the
+  noise problem stated in the acceptance criteria; the storage GC is
+  an independent concern with its own design tradeoffs (replay-safety,
+  audit trail, recovery semantics) and will land as a follow-up if
+  storage growth becomes a problem.
+- **Snapshot eviction from storage** — the snapshot facts continue to
+  accumulate in semantic memory. PR-A only filters at preparation
+  time. A separate retention policy is the right home for storage
+  eviction.
+- **Per-concept fact budgets** — the existing 16-fact budget remains
+  flat across all concepts. A future PR could allocate budget
+  per-concept to guarantee diversity, but the two PR-A filters alone
+  resolve the duplication that motivated the work.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -262,7 +262,8 @@ pub use memory_cognitive::{
 pub use memory_consolidation::{
     FactExtraction, PreparedContext, consolidation_intake, consolidation_persistence,
     execution_memory_operations, intake_memory_operations, persistence_memory_operations,
-    preparation_memory_operations, reflection_memory_operations,
+    preparation_memory_operations, preparation_memory_operations_with_active_slugs,
+    reflection_memory_operations,
 };
 pub use ooda_actions::dispatch_actions;
 pub use ooda_loop::{

--- a/src/memory_consolidation/mod.rs
+++ b/src/memory_consolidation/mod.rs
@@ -74,11 +74,51 @@ pub fn intake_memory_operations(
 /// procedures. Also explicitly loads active goal records from semantic
 /// memory so goals are always available in the prepared context regardless
 /// of whether the objective text happens to match (issue #2207).
+///
+/// This is the legacy 3-argument entry point retained for backward
+/// compatibility. It applies the goal-board:snapshot filter (PR-A
+/// filter 1, issue #2281) but does **not** apply the stale-slug
+/// filter (PR-A filter 2) because that filter requires the live
+/// goal-board state to know which slugs are active. New callers
+/// should use [`preparation_memory_operations_with_active_slugs`]
+/// instead so stale `goal-store:record` facts are dropped.
 #[tracing::instrument(skip_all)]
 pub fn preparation_memory_operations(
     objective: &str,
     session_id: &SessionId,
     bridge: &dyn CognitiveMemoryOps,
+) -> SimardResult<PreparedContext> {
+    preparation_memory_operations_with_active_slugs(
+        objective, session_id, bridge,
+        // `None` opts out of the stale-slug filter so existing test
+        // fixtures (`tests.rs`) that exercise the goal-fact dedup
+        // path keep passing unchanged.
+        None,
+    )
+}
+
+/// Preparation phase, taking the live active+backlog slugs so stale
+/// `goal-store:record` facts can be filtered out.
+///
+/// `active_slugs` should be the union of `state.active_goals.active`
+/// and `state.active_goals.backlog` ids built immediately before this
+/// call from the **live** goal-board (not from snapshot facts). Pass
+/// `Some(&empty)` to drop all `goal-store:record` facts (correct when
+/// there are no live goals); pass `None` to skip the stale filter
+/// entirely (backwards-compat path used by `preparation_memory_operations`).
+///
+/// Always applies the `goal-board:snapshot` filter (PR-A filter 1)
+/// regardless of `active_slugs`: snapshot revisions are pure
+/// redundancy because `advance.rs` already injects the live goal
+/// board into the prompt.
+///
+/// Issue [#2281](https://github.com/rysweet/Simard/issues/2281), PR-A.
+#[tracing::instrument(skip_all)]
+pub fn preparation_memory_operations_with_active_slugs(
+    objective: &str,
+    session_id: &SessionId,
+    bridge: &dyn CognitiveMemoryOps,
+    active_slugs: Option<&std::collections::HashSet<&str>>,
 ) -> SimardResult<PreparedContext> {
     // Split compound objectives (joined with "; ") into individual fragments
     // and search each separately. The old code passed the full joined string to
@@ -96,6 +136,12 @@ pub fn preparation_memory_operations(
     for fragment in &fragments {
         let per_fragment = bridge.search_facts(fragment, 10, 0.0)?;
         for fact in per_fragment {
+            // PR-A filter 1: drop goal-board:snapshot revisions even
+            // when they surface from a per-fragment match. The live
+            // board is already injected by `advance.rs`.
+            if fact.concept == GOAL_BOARD_SNAPSHOT_CONCEPT {
+                continue;
+            }
             if seen_ids.insert(fact.node_id.clone()) {
                 relevant_facts.push(fact);
             }
@@ -114,7 +160,7 @@ pub fn preparation_memory_operations(
     // (highest node_id, which is UUID-v7 time-ordered). This mirrors the
     // dedup logic in CognitiveMemoryGoalStore::list_via_reader() and
     // prevents historical revisions from crowding out current goals (#2207).
-    let mut latest_by_slug: std::collections::HashMap<String, CognitiveFact> =
+    let mut latest_by_slug: std::collections::HashMap<String, (String, CognitiveFact)> =
         std::collections::HashMap::new();
     for fact in goal_facts {
         if fact.concept != GOAL_STORE_FACT_CONCEPT {
@@ -133,19 +179,36 @@ pub fn preparation_memory_operations(
         };
         let slug = record.slug;
         match latest_by_slug.get(&slug) {
-            Some(existing) if existing.node_id >= fact.node_id => {}
+            Some((_, existing)) if existing.node_id >= fact.node_id => {}
             _ => {
-                latest_by_slug.insert(slug, fact);
+                latest_by_slug.insert(slug.clone(), (slug, fact));
             }
         }
     }
 
     let existing_ids: std::collections::HashSet<String> =
         relevant_facts.iter().map(|f| f.node_id.clone()).collect();
-    for fact in latest_by_slug.into_values() {
+    let mut dropped_stale: usize = 0;
+    for (slug, fact) in latest_by_slug.into_values() {
+        // PR-A filter 2 (issue #2281): drop goal-store:record facts
+        // whose slug is not in the live active+backlog goal-board.
+        // Skipped when `active_slugs.is_none()` — backward-compat for
+        // the 3-arg `preparation_memory_operations` entry point.
+        if let Some(slugs) = active_slugs
+            && !slugs.contains(slug.as_str())
+        {
+            dropped_stale += 1;
+            continue;
+        }
         if !existing_ids.contains(&fact.node_id) {
             relevant_facts.push(fact);
         }
+    }
+    if dropped_stale > 0 {
+        tracing::debug!(
+            dropped = dropped_stale,
+            "preparation: dropped stale goal-store:record facts (slug not in active goal-board)"
+        );
     }
 
     // Check if any prospective memories are triggered by the objective.
@@ -174,6 +237,11 @@ pub fn preparation_memory_operations(
         recalled_procedures,
     })
 }
+
+/// Concept label for goal-board snapshot facts, filtered by PR-A
+/// (issue #2281). Snapshot revisions duplicate the live board that
+/// `advance.rs` already injects into the prompt.
+pub(crate) const GOAL_BOARD_SNAPSHOT_CONCEPT: &str = "goal-board:snapshot";
 
 /// Execution phase: record PTY output as sensory observations.
 ///
@@ -437,3 +505,11 @@ pub fn consolidation_persistence(
 
 #[cfg(test)]
 mod tests;
+
+// PR-A (issue #2281): preparation-phase memory filters. Tests assert
+// that `goal-board:snapshot` revisions are dropped from the prepared
+// context and that stale `goal-store:record` facts (slugs not in the
+// live goal-board) are filtered out when the caller supplies the
+// active+backlog slug set.
+#[cfg(test)]
+mod tests_pr_a;

--- a/src/memory_consolidation/tests_pr_a.rs
+++ b/src/memory_consolidation/tests_pr_a.rs
@@ -1,0 +1,375 @@
+//! TDD (RED) tests for PR-A: preparation-phase memory filters.
+//!
+//! These tests pin the contract documented in
+//! `docs/reference/cognitive-memory-preparation-filters.md` for PR-A
+//! (issue #2281, problems 1 + 5). They are written **before** the
+//! production code change and are expected to FAIL until PR-A lands.
+//!
+//! Two filters are exercised:
+//!
+//! 1. **Drop `goal-board:snapshot` facts.** The live goal board is
+//!    already injected into the prompt by `advance.rs`, so surfacing
+//!    snapshot revisions in `PreparedContext.relevant_facts` is pure
+//!    redundancy.
+//! 2. **Drop stale `goal-store:record` facts.** A record is stale
+//!    when its slug is not present in the live goal-board (active or
+//!    backlog).
+//!
+//! ## How these compile against pre-PR-A code
+//!
+//! The tests must compile against the current 3-argument
+//! `preparation_memory_operations(objective, session_id, bridge)`
+//! signature. They route through a thin shim
+//! [`prep_with_active_slugs`] that today simply calls the 3-arg
+//! function and ignores the extra argument. When PR-A switches the
+//! production signature to take `&HashSet<&str>` (or whatever the
+//! equivalent collection ends up being), the shim is updated to
+//! forward the slugs and these tests will start passing.
+//!
+//! Both flavours of the shim are kept in this module so the diff for
+//! PR-A is a single-file change in the production code path. The
+//! tests themselves do not change.
+
+use super::*;
+use crate::bridge_subprocess::InMemoryBridgeTransport;
+use crate::memory_bridge::CognitiveMemoryBridge;
+use crate::session::SessionId;
+use serde_json::json;
+use std::collections::HashSet;
+
+fn test_session_id() -> SessionId {
+    SessionId::parse("session-01234567-89ab-cdef-0123-456789abcdef").unwrap()
+}
+
+/// Shim that today calls the existing 3-arg `preparation_memory_operations`.
+///
+/// Post-PR-A, edit this shim to forward `active_slugs` into the new
+/// 4-argument production signature. The tests below already pass the
+/// slugs through it.
+fn prep_with_active_slugs(
+    objective: &str,
+    session_id: &SessionId,
+    bridge: &dyn crate::cognitive_memory::CognitiveMemoryOps,
+    active_slugs: &HashSet<&str>,
+) -> crate::error::SimardResult<PreparedContext> {
+    preparation_memory_operations_with_active_slugs(
+        objective,
+        session_id,
+        bridge,
+        Some(active_slugs),
+    )
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Bridge fixtures
+// ───────────────────────────────────────────────────────────────────────────
+
+/// Bridge that returns five `goal-board:snapshot` revisions plus one
+/// unrelated `bug-pattern` fact when queried by the objective text or
+/// by the goal-store concept. PR-A filter 1 should drop all five
+/// snapshots.
+fn snapshot_revisions_bridge() -> CognitiveMemoryBridge {
+    let transport = InMemoryBridgeTransport::new("snapshot-revs", |method, params| match method {
+        "memory.search_facts" => {
+            let query = params.get("query").and_then(|v| v.as_str()).unwrap_or("");
+            // Both the per-fragment objective search AND the
+            // goal-store search return snapshot revisions in this
+            // fixture, because in production the snapshots have been
+            // observed leaking into per-fragment matches too.
+            let mut facts: Vec<serde_json::Value> = (0..5)
+                .map(|i| {
+                    json!({
+                        "node_id": format!("snap_{:04}", i),
+                        "concept": "goal-board:snapshot",
+                        "content": format!("{{\"revision\": {}, \"active\": []}}", i),
+                        "confidence": 1.0,
+                        "source_id": "goal-curator",
+                        "tags": ["goal-board"],
+                    })
+                })
+                .collect();
+            // Add one truly useful fact to verify other concepts are
+            // not impacted by the snapshot filter.
+            if query != "goal-store:record" {
+                facts.push(json!({
+                    "node_id": "bug_001",
+                    "concept": "bug-pattern",
+                    "content": "panic when cycle.rs receives empty outcome list",
+                    "confidence": 0.8,
+                    "source_id": "distill:epi_x",
+                    "tags": ["bug"],
+                }));
+            }
+            Ok(json!({ "facts": facts }))
+        }
+        "memory.check_triggers" => Ok(json!({"prospectives": []})),
+        "memory.recall_procedure" => Ok(json!({"procedures": []})),
+        "memory.push_working" => Ok(json!({"id": "wrk_1"})),
+        _ => Err(crate::bridge::BridgeErrorPayload {
+            code: -32601,
+            message: format!("unknown: {method}"),
+        }),
+    });
+    CognitiveMemoryBridge::new(Box::new(transport))
+}
+
+/// Bridge that returns three `goal-store:record` facts: two with slugs
+/// the caller will pass in `active_slugs` ("alpha", "beta") and one
+/// with a stale slug ("ghost-of-tdd") that should be filtered out.
+fn mixed_goal_store_bridge() -> CognitiveMemoryBridge {
+    use crate::goals::{GoalRecord, GoalStatus};
+    use crate::session::SessionPhase;
+
+    let make_record = |slug: &str, title: &str| GoalRecord {
+        slug: slug.to_string(),
+        title: title.to_string(),
+        rationale: "rationale".to_string(),
+        status: GoalStatus::Active,
+        priority: 1,
+        owner_identity: "test".to_string(),
+        source_session_id: SessionId::parse("session-01234567-89ab-cdef-0123-456789abcdef")
+            .unwrap(),
+        updated_in: SessionPhase::Persistence,
+    };
+
+    let alpha = make_record("alpha", "Alpha");
+    let beta = make_record("beta", "Beta");
+    let stale = make_record("ghost-of-tdd", "Ghost-of-TDD (stale)");
+
+    let transport =
+        InMemoryBridgeTransport::new("mixed-goal-store", move |method, params| match method {
+            "memory.search_facts" => {
+                let query = params.get("query").and_then(|v| v.as_str()).unwrap_or("");
+                if query == "goal-store:record" {
+                    Ok(json!({
+                        "facts": [
+                            {
+                                "node_id": "n_alpha",
+                                "concept": "goal-store:record",
+                                "content": serde_json::to_string(&alpha).unwrap(),
+                                "confidence": 1.0,
+                                "source_id": "goal-store",
+                                "tags": ["goal-store"],
+                            },
+                            {
+                                "node_id": "n_beta",
+                                "concept": "goal-store:record",
+                                "content": serde_json::to_string(&beta).unwrap(),
+                                "confidence": 1.0,
+                                "source_id": "goal-store",
+                                "tags": ["goal-store"],
+                            },
+                            {
+                                "node_id": "n_stale",
+                                "concept": "goal-store:record",
+                                "content": serde_json::to_string(&stale).unwrap(),
+                                "confidence": 1.0,
+                                "source_id": "goal-store",
+                                "tags": ["goal-store"],
+                            },
+                        ]
+                    }))
+                } else {
+                    Ok(json!({"facts": []}))
+                }
+            }
+            "memory.check_triggers" => Ok(json!({"prospectives": []})),
+            "memory.recall_procedure" => Ok(json!({"procedures": []})),
+            "memory.push_working" => Ok(json!({"id": "wrk_1"})),
+            _ => Err(crate::bridge::BridgeErrorPayload {
+                code: -32601,
+                message: format!("unknown: {method}"),
+            }),
+        });
+    CognitiveMemoryBridge::new(Box::new(transport))
+}
+
+/// Bridge that returns a `lesson-learned` and a `pr-pattern` fact —
+/// neither of which is a `goal-store:record` or `goal-board:snapshot`.
+/// Both filters should leave these untouched.
+fn diverse_concepts_bridge() -> CognitiveMemoryBridge {
+    let transport = InMemoryBridgeTransport::new("diverse", |method, _params| match method {
+        "memory.search_facts" => Ok(json!({
+            "facts": [
+                {
+                    "node_id": "lsn_001",
+                    "concept": "lesson-learned",
+                    "content": "prefer fixture builders over inline JSON",
+                    "confidence": 0.75,
+                    "source_id": "distill:epi_a",
+                    "tags": [],
+                },
+                {
+                    "node_id": "prp_001",
+                    "concept": "pr-pattern",
+                    "content": "ci green + scope clean + docs touched + merge-ready skill",
+                    "confidence": 0.85,
+                    "source_id": "distill:epi_b",
+                    "tags": [],
+                },
+            ]
+        })),
+        "memory.check_triggers" => Ok(json!({"prospectives": []})),
+        "memory.recall_procedure" => Ok(json!({"procedures": []})),
+        "memory.push_working" => Ok(json!({"id": "wrk_1"})),
+        _ => Err(crate::bridge::BridgeErrorPayload {
+            code: -32601,
+            message: format!("unknown: {method}"),
+        }),
+    });
+    CognitiveMemoryBridge::new(Box::new(transport))
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Tests
+// ───────────────────────────────────────────────────────────────────────────
+
+/// Filter 1: every `goal-board:snapshot` fact must be dropped from
+/// `relevant_facts`. The unrelated `bug-pattern` fact must survive.
+///
+/// **Expected to FAIL pre-PR-A** because the production code today
+/// returns all 5 snapshot revisions in the prepared context.
+#[test]
+fn preparation_drops_goal_board_snapshot_revisions() {
+    let bridge = snapshot_revisions_bridge();
+    let active: HashSet<&str> = HashSet::new();
+    let ctx = prep_with_active_slugs("unrelated objective", &test_session_id(), &bridge, &active)
+        .unwrap();
+
+    let snapshots: Vec<_> = ctx
+        .relevant_facts
+        .iter()
+        .filter(|f| f.concept == "goal-board:snapshot")
+        .collect();
+    assert_eq!(
+        snapshots.len(),
+        0,
+        "goal-board:snapshot facts must be filtered from PreparedContext.relevant_facts, \
+         found {}: {:?}",
+        snapshots.len(),
+        snapshots
+            .iter()
+            .map(|f| f.node_id.clone())
+            .collect::<Vec<_>>()
+    );
+
+    // The unrelated useful fact must still be present.
+    let bug_patterns: Vec<_> = ctx
+        .relevant_facts
+        .iter()
+        .filter(|f| f.concept == "bug-pattern")
+        .collect();
+    assert!(
+        !bug_patterns.is_empty(),
+        "non-snapshot, non-goal-store facts must pass through the snapshot filter unchanged"
+    );
+}
+
+/// Filter 2: a `goal-store:record` fact whose slug is NOT in
+/// `active_slugs` must be dropped. Active slugs survive.
+///
+/// **Expected to FAIL pre-PR-A** for two reasons:
+/// (a) the production function does not yet take an `active_slugs`
+/// parameter, so the shim currently ignores it; and
+/// (b) even if it took the argument, the stale-slug filter does
+/// not exist yet — the existing slug-dedup pass would still keep
+/// `ghost-of-tdd` because it is the only revision of its slug.
+#[test]
+fn preparation_drops_stale_goal_store_records() {
+    let bridge = mixed_goal_store_bridge();
+    let mut active: HashSet<&str> = HashSet::new();
+    active.insert("alpha");
+    active.insert("beta");
+
+    let ctx = prep_with_active_slugs("unrelated objective", &test_session_id(), &bridge, &active)
+        .unwrap();
+
+    let slugs: Vec<String> = ctx
+        .relevant_facts
+        .iter()
+        .filter(|f| f.concept == "goal-store:record")
+        .filter_map(|f| {
+            serde_json::from_str::<crate::goals::GoalRecord>(&f.content)
+                .ok()
+                .map(|r| r.slug)
+        })
+        .collect();
+
+    assert!(
+        !slugs.iter().any(|s| s == "ghost-of-tdd"),
+        "stale goal-store record (slug not in active_slugs) must be filtered out; \
+         saw slugs: {slugs:?}"
+    );
+}
+
+/// Regression guard for filter 2: `goal-store:record` facts whose
+/// slug IS in `active_slugs` must remain in the prepared context.
+///
+/// **Expected to FAIL pre-PR-A** because (a) the active_slugs
+/// parameter is not yet plumbed through, and (b) the test also
+/// asserts the absence of the stale slug, which is not yet enforced.
+#[test]
+fn preparation_keeps_active_goal_store_records() {
+    let bridge = mixed_goal_store_bridge();
+    let mut active: HashSet<&str> = HashSet::new();
+    active.insert("alpha");
+    active.insert("beta");
+
+    let ctx = prep_with_active_slugs("unrelated objective", &test_session_id(), &bridge, &active)
+        .unwrap();
+
+    let slugs: std::collections::HashSet<String> = ctx
+        .relevant_facts
+        .iter()
+        .filter(|f| f.concept == "goal-store:record")
+        .filter_map(|f| {
+            serde_json::from_str::<crate::goals::GoalRecord>(&f.content)
+                .ok()
+                .map(|r| r.slug)
+        })
+        .collect();
+
+    assert!(
+        slugs.contains("alpha"),
+        "active slug 'alpha' must be retained; saw slugs: {slugs:?}"
+    );
+    assert!(
+        slugs.contains("beta"),
+        "active slug 'beta' must be retained; saw slugs: {slugs:?}"
+    );
+    assert!(
+        !slugs.contains("ghost-of-tdd"),
+        "stale slug must be filtered out (companion assertion to drop test)"
+    );
+}
+
+/// Filter contract: neither filter must drop facts whose concept is
+/// neither `goal-board:snapshot` nor `goal-store:record`. Facts like
+/// `pr-pattern`, `bug-pattern`, `lesson-learned` (the three PR-B
+/// distillation concepts) must always survive.
+///
+/// **Expected to FAIL pre-PR-A** only if the filters are mis-scoped
+/// to also affect other concepts. This is a regression guard so the
+/// PR-A author cannot accidentally widen the filter.
+#[test]
+fn preparation_does_not_filter_other_concepts() {
+    let bridge = diverse_concepts_bridge();
+    let active: HashSet<&str> = HashSet::new();
+    let ctx = prep_with_active_slugs("any objective at all", &test_session_id(), &bridge, &active)
+        .unwrap();
+
+    let concepts: std::collections::HashSet<String> = ctx
+        .relevant_facts
+        .iter()
+        .map(|f| f.concept.clone())
+        .collect();
+
+    assert!(
+        concepts.contains("lesson-learned"),
+        "lesson-learned fact must pass through filters; concepts: {concepts:?}"
+    );
+    assert!(
+        concepts.contains("pr-pattern"),
+        "pr-pattern fact must pass through filters; concepts: {concepts:?}"
+    );
+}

--- a/src/ooda_loop/cycle.rs
+++ b/src/ooda_loop/cycle.rs
@@ -7,7 +7,7 @@ use crate::goal_curation::{load_goal_board, save_goal_board_with_removals};
 use crate::gym_bridge::ScoreDimensions;
 use crate::gym_scoring::GymSuiteScore;
 use crate::memory_consolidation;
-use crate::memory_consolidation::preparation_memory_operations;
+use crate::memory_consolidation::preparation_memory_operations_with_active_slugs;
 use crate::self_improve::{ImprovementCycle, ImprovementPhase};
 
 use super::types::*;
@@ -216,9 +216,25 @@ fn run_ooda_cycle_inner(
         .map(|g| g.description.as_str())
         .collect::<Vec<_>>()
         .join("; ");
+    // PR-A (issue #2281): build the live `active_slugs` set from
+    // `active` + `backlog` so `preparation_memory_operations_with_active_slugs`
+    // can drop stale `goal-store:record` facts whose slug is no longer
+    // on the board. Using the live board (not snapshot facts) prevents
+    // a stale snapshot from resurrecting a deleted slug into recall.
+    let active_slugs: std::collections::HashSet<&str> = state
+        .active_goals
+        .active
+        .iter()
+        .map(|g| g.id.as_str())
+        .chain(state.active_goals.backlog.iter().map(|b| b.id.as_str()))
+        .collect();
     // Reuse cycle_session_id established above — the entire cycle is one logical session.
-    let ctx =
-        preparation_memory_operations(&objective_summary, &cycle_session_id, &*bridges.memory)?;
+    let ctx = preparation_memory_operations_with_active_slugs(
+        &objective_summary,
+        &cycle_session_id,
+        &*bridges.memory,
+        Some(&active_slugs),
+    )?;
     eprintln!(
         "[simard] OODA cycle: prepared context ({} facts, {} triggers, {} procedures)",
         ctx.relevant_facts.len(),


### PR DESCRIPTION
## Summary

PR-A of three for the cognitive-memory end-to-end fix (issue #2281). Cleans up two sources of low-value noise from the preparation phase of the OODA cycle's memory retrieval.

## Problems addressed

**Problem 1 — Duplicate goal-board snapshots flooding prepared context.** Before this change, `search_facts` would surface multiple revisions of the same `goal-board:snapshot` fact (up to 10 identical JSON blobs out of 16 prepared facts). The snapshot content already appears in the prompt verbatim because `advance.rs` injects the live goal board, so the snapshot facts are pure duplication.

**Problem 5 — Stale meeting goal-store noise pollutes retrieval.** Old test meetings created `goal-store:record` facts (e.g. `adopt-tdd`, `decision-use-rust`) whose slugs are no longer on the active goal board. They surfaced in every cycle's prepared facts as low-value clutter.

## Solution

Two filters on `preparation_memory_operations`:

| # | Filter | Always applied? | Notes |
|---|--------|-----------------|-------|
| 1 | drop `goal-board:snapshot` | yes | Snapshot facts are pure duplication of live state. |
| 2 | drop `goal-store:record` whose slug ∉ active+backlog | only when caller supplies `active_slugs` | Uses **live** goal board, not snapshot facts, so stale records cannot resurrect themselves. |

### API

- **New** `preparation_memory_operations_with_active_slugs(obj, sid, bridge, active_slugs: Option<&HashSet<&str>>)` — does both filters; pass `None` to skip filter 2.
- **Retained** `preparation_memory_operations(obj, sid, bridge)` as thin wrapper passing `None` — still applies filter 1 (always safe). All 12 existing callsites in `tests.rs` continue to work unchanged.

### Caller migration

`run_ooda_cycle` (`src/ooda_loop/cycle.rs:210-228`) now builds `active_slugs` from `state.active_goals.active + backlog` and calls the 4-arg entry point. Filter ordering: per-fragment search → filter 1 → existing slug dedup → filter 2.

## Tests

`src/memory_consolidation/tests_pr_a.rs` (4 cases, all green):

| Test | Verifies |
|------|----------|
| `preparation_drops_goal_board_snapshot_revisions` | 5 revisions of one snapshot slug → 0 in prepared facts |
| `preparation_drops_stale_goal_store_records` | slug not in active_slugs → dropped |
| `preparation_keeps_active_goal_store_records` | slug in active_slugs → kept |
| `preparation_does_not_filter_other_concepts` | unrelated concepts pass through unchanged |

## Verification

- `cargo test --lib`: **5646 passed, 0 failed, 4 ignored**
- `cargo clippy --all-targets --all-features --locked -- -D warnings`: clean
- `cargo fmt --all -- --check`: clean
- All pre-commit and pre-push hooks pass

## Docs

`docs/reference/cognitive-memory-preparation-filters.md` documents the filter semantics, ordering, backward-compat guarantees, and migration path for downstream callers.

## Scope

- 5 files changed (`src/memory_consolidation/mod.rs`, `src/memory_consolidation/tests_pr_a.rs`, `src/ooda_loop/cycle.rs`, `src/lib.rs`, `docs/reference/cognitive-memory-preparation-filters.md`)
- +859 / −8
- No public API removed; no behavior change for existing 3-arg callers beyond snapshot-dropping
- No schema/DB changes
- No prompt-asset changes

## Related

- Closes problems 1 + 5 of issue #2281
- Follow-up PR-B will implement episode distillation (problem 2)
- Follow-up PR-C will implement procedural seeding + episodic recall (problems 3 + 4)
- Builds on #2277 (preparation fix), #2281 (procedural+prospective storage), #2286 (synthetic priority routing)