### PR TITLE
feat(cognitive-memory): PR-B — distill recent episodes into semantic facts (#2281)

### DIFF
--- a/docs/architecture/episode-distillation.md
+++ b/docs/architecture/episode-distillation.md
@@ -1,0 +1,480 @@
+---
+title: Episode distillation
+description: How Simard periodically distills batches of recent episodes into semantic facts using an LLM-backed recipe, what concept labels are produced, when the distillation pass fires, and how distilled episodes are marked to prevent reprocessing.
+last_updated: 2026-06-14
+owner: simard
+doc_type: concept
+related:
+  - ./cognitive-memory.md
+  - ../reference/cognitive-memory-preparation-filters.md
+  - ../reference/cognitive-memory-episodic-recall.md
+  - ../reference/ooda-procedural-memory.md
+  - ../memory.md
+---
+
+# Episode distillation
+
+> Shipped in issue [#2281](https://github.com/rysweet/Simard/issues/2281)
+> as PR-B (episode distillation). Builds on PR-A (preparation filters)
+> and feeds PR-C (episodic recall) with a higher-quality semantic store.
+
+Episode distillation is the periodic process that scans recent
+**episodic** memory and extracts **semantic facts** from it using a
+deterministic LLM recipe. It is the missing half of memory
+consolidation: prior to PR-B, `consolidate_episodes` only performed
+textual dedup, which left the consolidation compression ratio at 0%
+every cycle because raw episodes rarely have identical text. PR-B
+adds true semantic distillation alongside the existing textual pass.
+
+The pass runs inside the `ConsolidateMemory` action handler — the
+same action the `__memory__` synthetic priority dispatches to. No new
+synthetic priority is added. The existing deterministic-brain routing
+locked in by issue [#2286](https://github.com/rysweet/Simard/issues/2286)
+is preserved.
+
+---
+
+## Why distillation matters
+
+Semantic memory is the layer the OODA brain reads first during
+preparation. Facts are higher signal than raw episodes because:
+
+- Each fact has a confidence score, a concept label, and source-id
+  provenance — facts can be ranked, filtered, and traced.
+- Facts are short and substring-searchable, so `search_facts` returns
+  meaningfully diverse results within the prepared-context budget.
+- Facts accumulate across runs even after episodes are pruned.
+
+Without distillation, the only writers to semantic memory were
+`goal-store:record` (goal mirror) and rare manual stores. The bulk of
+operational knowledge — what worked, what broke, what was tried —
+sat in episodic memory where it was hard to retrieve and easy to lose
+during consolidation. PR-B closes that gap.
+
+---
+
+## Pipeline overview
+
+```
+Episodic memory (newest first)
+  │
+  │  list_undistilled_episodes(50)
+  ▼
+Batch of up to 50 episodes where distilled = 0
+  │
+  ├─ if batch.len() < 20  →  skip pass, no LLM call, no markers
+  │
+  ▼
+Serialize as JSON, invoke recipe-runner-rs
+  │
+  ▼
+prompt_assets/simard/recipes/distill-episodes.yaml
+  │  classifies each episode into:
+  │    - pr-pattern        (PR-shaped events, merge sequences, review patterns)
+  │    - bug-pattern       (bug reproductions, root causes, recurring failures)
+  │    - lesson-learned    (decisions, tradeoffs, things that surprised the engineer)
+  │    - skip              (truly low-signal — startup logs, retries, etc.)
+  ▼
+Recipe output: { "facts": [ { concept, content, source_episode_id }, ... ] }
+  │
+  ▼
+For each fact:
+    store_fact(concept, content, confidence=0.7,
+               concepts=[concept], source=format!("distill:{source_episode_id}"))
+  │
+  ▼
+For EVERY input episode (even those classified "skip"):
+    mark_episode_distilled(node_id)
+```
+
+The mark-everything rule prevents prompt-replay loops: an episode
+classified "skip" once will not be re-fed to the LLM on the next
+pass. If the entire batch errors, *no* markers are set — the batch
+retries on the next pass.
+
+---
+
+## When the pass fires
+
+The pass runs inside `dispatch_consolidate_memory`
+(`src/ooda_actions/simple_actions.rs`), alongside the existing
+textual `consolidate_episodes(20)` call. Both run on every
+`ConsolidateMemory` action; failure of one does not abort the other.
+
+`ConsolidateMemory` is dispatched when the OODA brain emits a
+`__memory__` synthetic priority, which the priority router maps to
+the `ConsolidateMemory` action kind. The brain emits `__memory__`
+opportunistically — typically once every several cycles, governed by
+the existing memory-pressure heuristics.
+
+### Threshold gate
+
+Even when the action fires, the distillation pass itself is gated by
+a minimum batch size:
+
+| Constant                  | Default | Source file                                   |
+|---------------------------|---------|-----------------------------------------------|
+| `DISTILL_BATCH_SIZE`      | 50      | `src/memory_consolidation/distillation.rs`    |
+| `DISTILL_MIN_EPISODES`    | 20      | `src/memory_consolidation/distillation.rs`    |
+
+If `list_undistilled_episodes(DISTILL_BATCH_SIZE)` returns fewer than
+`DISTILL_MIN_EPISODES` rows, the pass is **skipped entirely**:
+
+- No recipe is invoked.
+- No `store_fact` is called.
+- No `mark_episode_distilled` is called.
+
+This is intentional. Distillation is a many-to-few operation; running
+it on 3 episodes wastes an LLM call for little quality gain. The
+batch waits for the next pass.
+
+---
+
+## The recipe
+
+`prompt_assets/simard/recipes/distill-episodes.yaml` is a one-step
+recipe with a single LLM agent. It follows the same shape as
+`recipe_merge_judge` and `recipe_progress_checker`:
+
+- **Input context variable**: `episodes` — JSON array of objects with
+  `{ id, source_label, temporal_index, content }`. The
+  `temporal_index` is the monotonic `i64` clock that ships on every
+  `CognitiveEpisode` row; it is **not** a wall-clock timestamp. The
+  recipe only needs ordering, not human-readable time, so no
+  `chrono::DateTime` conversion is performed at the boundary.
+- **Prompt**: instructs the agent to classify each episode into one
+  of the three concept labels (or `skip`) and emit a JSON object
+  `{ "facts": [ { "concept": "...", "content": "...",
+  "source_episode_id": "..." } ] }`.
+- **Output**: parsed by the Rust caller; non-conforming output causes
+  the caller to return `Err` (which then triggers the "no markers
+  set" retry behaviour above).
+
+The Rust-side invocation reuses the existing
+`Command::new("recipe-runner-rs")` shape demonstrated by
+[`stewardship::recipe_merge_judge::RecipeMergeJudge`](../../src/stewardship/recipe_merge_judge.rs)
+and
+[`goal_curation::recipe_progress_checker::RecipeProgressChecker`](../../src/goal_curation/recipe_progress_checker.rs):
+the binary takes the recipe path as a positional arg followed by
+zero or more `-c key=value` pairs and `AMPLIHACK_AGENT_BINARY` in
+the environment. The episodes payload is passed as a single context
+entry; whether it is inlined as `-c episodes=<json>` or written to a
+temp file and passed as `-c episodes_path=<path>` is an
+implementation detail decided at PR-B coding time by what
+`recipe-runner-rs` actually supports for array values. Both shapes
+satisfy the contract documented here.
+
+The recipe is loaded with the same resolution order Simard uses
+elsewhere:
+
+1. `~/.simard/prompt_assets/simard/recipes/distill-episodes.yaml`
+   (user override)
+2. `<repo>/prompt_assets/simard/recipes/distill-episodes.yaml`
+   (in-tree default)
+
+### Concept labels
+
+The recipe is constrained to exactly three labels:
+
+| Label             | Use                                                                   |
+|-------------------|-----------------------------------------------------------------------|
+| `pr-pattern`      | Pull-request shaped events: merge sequences, CI patterns, PR scope    |
+| `bug-pattern`     | Bug reproductions, root causes, recurring failure modes               |
+| `lesson-learned`  | Decisions made, tradeoffs encountered, engineer-surprising outcomes   |
+
+A fourth pseudo-label `skip` is allowed in the agent's reasoning but
+must not appear in the `facts` array — skipped episodes simply
+contribute no fact.
+
+The label set is deliberately small to keep search-time signal
+useful. Adding labels expands the search surface without immediately
+improving fact relevance; new labels should be added only when a
+clear retrieval pattern motivates them.
+
+---
+
+## Trait surface
+
+PR-B adds two methods to `CognitiveMemoryOps`
+(`src/cognitive_memory/mod.rs`), both with default no-op
+implementations so legacy bridges keep compiling:
+
+```rust
+pub trait CognitiveMemoryOps {
+    // ... existing methods ...
+
+    /// Mark an episode as distilled so subsequent distillation passes skip it.
+    /// Default impl is a no-op for backends that do not support metadata mutation.
+    fn mark_episode_distilled(&self, node_id: &str) -> SimardResult<()> {
+        Ok(())
+    }
+
+    /// Return up to `limit` undistilled episodes, newest first.
+    /// Default impl returns empty, which makes the distillation pass a no-op
+    /// for backends that do not track the `distilled` flag.
+    fn list_undistilled_episodes(&self, limit: u32) -> SimardResult<Vec<CognitiveEpisode>> {
+        Ok(vec![])
+    }
+}
+```
+
+`NativeCognitiveMemory` overrides both with real implementations
+against the lbug-backed `Episode` schema.
+
+### Schema
+
+The `Episode` node gains one column:
+
+| Column      | Type   | Default | Meaning                                                |
+|-------------|--------|---------|--------------------------------------------------------|
+| `distilled` | `i64`  | `0`     | `1` once an episode has been processed by distillation |
+
+The migration is **lazy**: legacy rows with no `distilled` column read
+as `0` (undistilled), so the first post-upgrade pass naturally
+processes everything. No offline migration step is required.
+
+### `compressed` vs `distilled` are independent
+
+The episode schema already has a `compressed: bool` column written by
+the textual `consolidate_episodes` pass. PR-B's `distilled: i64` is
+**independent** of it:
+
+- `consolidate_episodes` (textual dedup) writes `compressed`.
+- `distill_recent_episodes` (semantic many-to-few) writes `distilled`.
+- An episode can land in any of the four states `(compressed,
+  distilled) ∈ {(0,0), (0,1), (1,0), (1,1)}` depending on which
+  passes have processed it.
+
+Neither flag implies the other. The two passes co-exist inside
+`ConsolidateMemory` and are emitted on separate log lines so an
+operator can attribute work to the correct pass.
+
+---
+
+## Public functions
+
+### `distill_recent_episodes`
+
+```rust
+pub fn distill_recent_episodes(
+    memory: &dyn CognitiveMemoryOps,
+    repo_root: &Path,
+) -> SimardResult<DistillReport>;
+```
+
+Runs one distillation pass. Returns a `DistillReport` describing what
+happened.
+
+### `DistillReport`
+
+```rust
+pub struct DistillReport {
+    /// Number of undistilled episodes pulled from the store.
+    pub input_count: u32,
+    /// Number of facts emitted by the recipe.
+    pub fact_count: u32,
+    /// Number of episodes marked distilled after the pass.
+    pub marked_count: u32,
+}
+
+impl DistillReport {
+    /// The pass was skipped under threshold; no work was done.
+    pub fn skipped() -> Self { Self { input_count: 0, fact_count: 0, marked_count: 0 } }
+
+    pub fn was_skipped(&self) -> bool {
+        self.input_count == 0 && self.fact_count == 0 && self.marked_count == 0
+    }
+}
+```
+
+### Reduction ratio
+
+The textual `consolidate_episodes` step reports a **compression
+ratio** (input bytes vs. output bytes after dedup), which sits at 0%
+in unmodified runs because raw episodes rarely share identical text.
+Distillation reports a different metric — a **reduction ratio** —
+because the operation is many-to-few semantic extraction, not
+textual deduplication:
+
+```
+distill: 25 episodes → 3 facts, 25 marked (reduction 88%)
+```
+
+Where `reduction = 1 - (fact_count / input_count)`. The two ratios
+measure different things and must not be summed or compared
+directly; they are emitted on separate log lines so an operator can
+tell which pass — textual or semantic — is doing the work on a given
+cycle.
+
+---
+
+## Observability
+
+The pass emits two log lines:
+
+```
+[simard] distill: 25 episodes pulled (batch size 50, min 20)
+[simard] distill: 25 episodes → 3 facts, 25 marked
+```
+
+When skipped:
+
+```
+[simard] distill: 10 episodes pulled, below min 20, skipped
+```
+
+When the recipe errors:
+
+```
+[simard] distill: 25 episodes pulled, recipe error: <message>, no markers set, retry next pass
+```
+
+These are low-cardinality `tracing::info!` lines suitable for
+grep-based monitoring.
+
+---
+
+## Examples
+
+### Example 1 — typical pass
+
+Episodic memory has 30 undistilled episodes after a busy
+goal-curation phase:
+
+```
+1. dispatch_consolidate_memory runs.
+2. consolidate_episodes(20) does textual dedup (existing behaviour).
+3. distill_recent_episodes:
+     - list_undistilled_episodes(50) returns 30 episodes
+     - 30 ≥ 20 → proceed
+     - recipe emits 4 facts: 2 pr-pattern, 1 bug-pattern, 1 lesson-learned
+     - store_fact called 4 times
+     - mark_episode_distilled called 30 times
+     - returns DistillReport { input: 30, fact: 4, marked: 30 }
+```
+
+Log:
+
+```
+[simard] distill: 30 episodes pulled (batch size 50, min 20)
+[simard] distill: 30 episodes → 4 facts, 30 marked
+```
+
+### Example 2 — under threshold
+
+Only 8 undistilled episodes since last pass:
+
+```
+distill: 8 episodes pulled, below min 20, skipped
+```
+
+`DistillReport::skipped()` is returned; the textual pass still runs.
+
+### Example 3 — recipe error
+
+Recipe runner exits non-zero or returns malformed JSON:
+
+```
+distill: 40 episodes pulled, recipe error: invalid JSON output, no markers set, retry next pass
+```
+
+`mark_episode_distilled` is **not** called. The same 40 episodes are
+eligible on the next pass.
+
+---
+
+## Tuning the constants
+
+Defaults reflect a balance between LLM cost and freshness:
+
+| Constant                | Default | Lower bound | Upper bound | Effect of change                                  |
+|-------------------------|---------|-------------|-------------|---------------------------------------------------|
+| `DISTILL_BATCH_SIZE`    | 50      | 10          | 200         | Higher → fewer LLM calls, larger prompts          |
+| `DISTILL_MIN_EPISODES`  | 20      | 5           | `BATCH_SIZE` | Higher → less frequent passes, more amortization |
+
+To tune at build time, edit the constants in
+`src/memory_consolidation/distillation.rs`. There is no runtime
+configuration knob in PR-B; operational experience may motivate a
+config-file or env-var override in a future PR.
+
+---
+
+## Interaction with other memory layers
+
+| Layer              | Effect of PR-B                                                                  |
+|--------------------|---------------------------------------------------------------------------------|
+| Episodic memory    | New `distilled` column. Episodes are **not** deleted; only marked.              |
+| Semantic memory    | New facts arrive with concepts `pr-pattern`, `bug-pattern`, `lesson-learned`.   |
+| Procedural memory  | Untouched. (PR-C touches procedural memory.)                                     |
+| Prospective memory | Untouched.                                                                       |
+| Working memory     | Untouched.                                                                       |
+| Sensory memory     | Untouched.                                                                       |
+| Preparation        | New fact concepts are searchable by `preparation_memory_operations`. PR-A's     |
+|                    | filters do **not** touch the three new concepts, so they flow through normally. |
+| Episodic recall    | PR-C's episodic recall benefits from distilled summaries (better substring hits).|
+
+---
+
+## Code location
+
+| Item                                | File                                                   |
+|-------------------------------------|--------------------------------------------------------|
+| `distill_recent_episodes`           | `src/memory_consolidation/distillation.rs`             |
+| `DistillReport`                     | `src/memory_consolidation/distillation.rs`             |
+| `DISTILL_BATCH_SIZE` / `DISTILL_MIN_EPISODES` | `src/memory_consolidation/distillation.rs`   |
+| Recipe                              | `prompt_assets/simard/recipes/distill-episodes.yaml`   |
+| Dispatcher hook                     | `src/ooda_actions/simple_actions.rs` (`dispatch_consolidate_memory`) |
+| Trait methods                       | `src/cognitive_memory/mod.rs`                          |
+| `NativeCognitiveMemory` impls       | `src/cognitive_memory/ops.rs`                          |
+| Episode schema                      | `src/cognitive_memory/schema.rs`                       |
+| Tests                               | `src/memory_consolidation/distillation_tests.rs`,      |
+|                                     | `src/cognitive_memory/ops.rs` (round-trip tests)       |
+
+---
+
+## Testing
+
+### Trait round-trip tests
+
+In `src/cognitive_memory/ops.rs`:
+
+| Test                                              | Coverage                                                    |
+|---------------------------------------------------|-------------------------------------------------------------|
+| `list_undistilled_episodes_returns_newest_first`  | Ordering: newest by `node_id` descending. Because episode node ids are UUID-v7 (time-prefixed), `ORDER BY e.id DESC` is monotonically newest-first without consulting `temporal_index`. |
+| `mark_episode_distilled_round_trips`              | `mark` then `list` excludes the marked row                  |
+| `list_undistilled_respects_limit`                 | `limit` parameter honoured                                  |
+
+### Distillation pass tests
+
+In `src/memory_consolidation/distillation_tests.rs`:
+
+| Test                                                          | Coverage                                              |
+|---------------------------------------------------------------|-------------------------------------------------------|
+| `distillation_skipped_under_min_threshold`                    | 10 episodes < 20 → no LLM call, no markers            |
+| `distillation_stores_facts_and_marks_originals`               | 25 episodes → 3 facts stored, **25** markers set       |
+| `distillation_handles_recipe_error_without_marking`           | recipe Err → no facts, no markers, retry on next pass  |
+| `distillation_marks_episodes_classified_as_skip`              | 5 episodes, 0 facts from recipe, still 5 markers       |
+| `distillation_does_not_touch_compressed_flag`                 | Asserts the `compressed` column is untouched: textual and semantic passes are independent (see "`compressed` vs `distilled` are independent" above). |
+
+The skip-threshold test uses a recipe-runner stub that **panics** if
+called, proving the LLM path was bypassed.
+
+---
+
+## Out of scope
+
+These were considered and deferred to follow-up issues:
+
+- **Episode eviction after distillation** — PR-B marks episodes as
+  distilled but does not delete them. A future retention policy can
+  use the `distilled` flag plus an age threshold to safely evict.
+- **A dedicated `__distill__` synthetic priority** — PR-B reuses
+  `__memory__` to avoid touching the deterministic-brain routing
+  contract. Splitting into its own priority is a refactor for later
+  if `__memory__` becomes overloaded.
+- **Confidence scores from the LLM** — emitted facts use a fixed
+  `0.7` confidence. A future iteration can let the recipe return a
+  per-fact confidence score.
+- **Distilling old (pre-`distilled` column) episodes in bulk** — the
+  lazy migration treats them as undistilled, so they flow through
+  the normal pass; no special bulk-distill mode is provided.

--- a/docs/architecture/episode-distillation.md
+++ b/docs/architecture/episode-distillation.md
@@ -152,9 +152,11 @@ recipe with a single LLM agent. It follows the same shape as
 
 The Rust-side invocation reuses the existing
 `Command::new("recipe-runner-rs")` shape demonstrated by
-[`stewardship::recipe_merge_judge::RecipeMergeJudge`](../../src/stewardship/recipe_merge_judge.rs)
+`stewardship::recipe_merge_judge::RecipeMergeJudge`
+(`src/stewardship/recipe_merge_judge.rs`)
 and
-[`goal_curation::recipe_progress_checker::RecipeProgressChecker`](../../src/goal_curation/recipe_progress_checker.rs):
+`goal_curation::recipe_progress_checker::RecipeProgressChecker`
+(`src/goal_curation/recipe_progress_checker.rs`):
 the binary takes the recipe path as a positional arg followed by
 zero or more `-c key=value` pairs and `AMPLIHACK_AGENT_BINARY` in
 the environment. The episodes payload is passed as a single context

--- a/prompt_assets/simard/recipes/distill-episodes.yaml
+++ b/prompt_assets/simard/recipes/distill-episodes.yaml
@@ -1,0 +1,103 @@
+# distill-episodes.yaml — Recipe for PR-B episode distillation (issue #2281).
+#
+# Periodic many-to-few extraction: given a batch of up to 50 recent
+# episodes, classify each into one of three concept labels (or `skip`)
+# and emit a single JSON envelope of derived facts.
+#
+# Context vars (passed via -c):
+#   episodes — JSON array of objects with
+#     { id, source_label, temporal_index, content }
+#
+# Output: agent stdout containing a single JSON object of the form:
+#   {
+#     "facts": [
+#       { "concept": "pr-pattern" | "bug-pattern" | "lesson-learned",
+#         "content": "<short, declarative summary>",
+#         "source_episode_id": "<id of the episode this fact derives from>" }
+#     ]
+#   }
+#
+# See docs/architecture/episode-distillation.md for the full contract,
+# concept-label semantics, and retry-safety invariants.
+
+name: "distill-episodes"
+description: "Distill a batch of recent episodes into semantic facts"
+version: "1.0.0"
+author: "Simard"
+tags: ["simard", "memory", "distillation"]
+
+context: {}
+
+steps:
+  - id: "distill"
+    type: "agent"
+    agent: "default"
+    prompt: |
+      You are the **semantic distiller** for Simard's cognitive memory.
+      You are given a batch of recent **episodes** (events that happened
+      during prior OODA cycles) and you produce a small number of
+      durable **semantic facts** that will be stored alongside the
+      episodes for future retrieval.
+
+      ## Input
+
+      The batch of episodes is a JSON array. Each entry has:
+
+      - `id` — opaque episode identifier you must echo back as
+        `source_episode_id` when you derive a fact from it.
+      - `source_label` — short tag describing where the episode came
+        from (e.g. `goal-curator`, `consolidation-persistence`).
+      - `temporal_index` — monotonic ordering key (NOT a wall-clock
+        timestamp; you only need it for ordering, if at all).
+      - `content` — the free-text payload of the episode.
+
+      ```json
+      {{episodes}}
+      ```
+
+      ## Your job
+
+      Walk the episodes and decide which are worth distilling. For each
+      episode you keep, emit **exactly one** fact with:
+
+      - `concept` — one of:
+        - `pr-pattern` — pull-request shaped events: merge sequences,
+          CI patterns, review patterns, scope-creep observations.
+        - `bug-pattern` — bug reproductions, root causes, recurring
+          failure modes, environmental fragility.
+        - `lesson-learned` — decisions made, tradeoffs encountered,
+          things that surprised the engineer, retrospective insights.
+      - `content` — a **short, declarative** sentence capturing the
+        durable lesson (≤ 200 chars is ideal). NOT a transcript; NOT a
+        timestamp; just the takeaway.
+      - `source_episode_id` — the `id` from the source episode,
+        verbatim.
+
+      Episodes that are pure noise (startup logs, simple retries,
+      progress chatter, exact duplicates of earlier episodes) should be
+      **skipped** — do NOT emit a fact for them. The system records
+      that you saw them via a separate mechanism, so dropping low-value
+      episodes is the correct call.
+
+      ## Output
+
+      Return **only** the following JSON object — no surrounding prose,
+      no markdown fence, no commentary:
+
+      ```json
+      {
+        "facts": [
+          {
+            "concept": "pr-pattern" | "bug-pattern" | "lesson-learned",
+            "content": "<short declarative sentence>",
+            "source_episode_id": "<id from input>"
+          }
+        ]
+      }
+      ```
+
+      If nothing in the batch is worth keeping, emit `{"facts": []}`.
+
+      Do not invent new concept labels. Do not invent episode ids. Do
+      not include the literal string `skip` in the `concept` field —
+      skipped episodes simply contribute no entry to the `facts` array.

--- a/src/cognitive_memory/mod.rs
+++ b/src/cognitive_memory/mod.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 
 use crate::error::{SimardError, SimardResult};
 use crate::memory_cognitive::{
-    CognitiveFact, CognitiveProcedure, CognitiveProspective, CognitiveStatistics,
+    CognitiveEpisode, CognitiveFact, CognitiveProcedure, CognitiveProspective, CognitiveStatistics,
     CognitiveWorkingSlot,
 };
 
@@ -97,6 +97,26 @@ pub trait CognitiveMemoryOps: Send + Sync {
     /// status transitions (legacy Python bridge, test stubs).
     fn resolve_prospective(&self, _node_id: &str) -> SimardResult<()> {
         Ok(())
+    }
+
+    /// Mark an episode as distilled so subsequent distillation passes
+    /// skip it. Default impl is a no-op for backends that do not
+    /// support metadata mutation (legacy Python bridge, test stubs).
+    /// Issue #2281, PR-B.
+    fn mark_episode_distilled(&self, _node_id: &str) -> SimardResult<()> {
+        Ok(())
+    }
+
+    /// Return up to `limit` undistilled episodes, newest first.
+    ///
+    /// Default impl returns empty, which makes the distillation pass a
+    /// no-op for backends that do not track the `distilled` flag.
+    /// `NativeCognitiveMemory` overrides this to query the
+    /// `Episode.distilled = 0` set ordered by `id DESC` (which is
+    /// chronological because UUID-v7 ids are time-prefixed).
+    /// Issue #2281, PR-B.
+    fn list_undistilled_episodes(&self, _limit: u32) -> SimardResult<Vec<CognitiveEpisode>> {
+        Ok(vec![])
     }
 
     fn get_statistics(&self) -> SimardResult<CognitiveStatistics>;
@@ -419,6 +439,26 @@ impl NativeCognitiveMemory {
             if let Err(e) = self.execute(ddl) {
                 let msg = format!("{e}");
                 if !msg.contains("already exists") {
+                    return Err(e);
+                }
+            }
+        }
+        // Lazy schema migrations: each ALTER is idempotent and is run
+        // unconditionally; errors signalling "the column is already
+        // there" are swallowed because the CREATE statement above may
+        // have already provided the column on fresh DBs. lbug's
+        // wording for this case is `"already has property <name>"`
+        // (Kuzu-derived) — accept that and the more standard SQL
+        // wordings so the migration is portable to future backends.
+        for migration in schema::SCHEMA_MIGRATIONS {
+            if let Err(e) = self.execute(migration) {
+                let msg = format!("{e}").to_lowercase();
+                let benign = msg.contains("already exists")
+                    || msg.contains("already has")
+                    || msg.contains("duplicate column")
+                    || msg.contains("column already")
+                    || msg.contains("property already");
+                if !benign {
                     return Err(e);
                 }
             }
@@ -867,3 +907,11 @@ mod tests_inline {
         CognitiveMemoryOps::checkpoint(&mem).expect("trait checkpoint should succeed");
     }
 }
+
+// PR-B (issue #2281): episode-distillation trait-method tests against
+// the `NativeCognitiveMemory` backend. Verifies that
+// `mark_episode_distilled` and `list_undistilled_episodes` round-trip
+// against the lbug-backed Episode table with the lazy `distilled`
+// column migration applied.
+#[cfg(test)]
+mod tests_pr_b_distill;

--- a/src/cognitive_memory/ops.rs
+++ b/src/cognitive_memory/ops.rs
@@ -2,7 +2,7 @@
 
 use crate::error::{SimardError, SimardResult};
 use crate::memory_cognitive::{
-    CognitiveFact, CognitiveProcedure, CognitiveProspective, CognitiveStatistics,
+    CognitiveEpisode, CognitiveFact, CognitiveProcedure, CognitiveProspective, CognitiveStatistics,
     CognitiveWorkingSlot,
 };
 
@@ -533,6 +533,48 @@ impl CognitiveMemoryOps for NativeCognitiveMemory {
         ))?;
         self.post_write_barrier("resolve_prospective")?;
         Ok(())
+    }
+
+    /// PR-B (issue #2281): mark an episode as distilled so subsequent
+    /// distillation passes skip it. Idempotent — re-marking a row
+    /// already at `distilled = 1` is a no-op.
+    fn mark_episode_distilled(&self, node_id: &str) -> SimardResult<()> {
+        #[cfg(test)]
+        self.assert_hermetic_for("NativeCognitiveMemory::mark_episode_distilled");
+
+        let id = escape_cypher(node_id);
+        self.execute(&format!(
+            "MATCH (e:Episode) WHERE e.id = '{id}' SET e.distilled = 1"
+        ))?;
+        self.post_write_barrier("mark_episode_distilled")?;
+        Ok(())
+    }
+
+    /// PR-B (issue #2281): return up to `limit` undistilled episodes,
+    /// newest first.
+    ///
+    /// Ordering is `e.id DESC` because Episode ids are UUID-v7
+    /// (time-prefixed) and so lex-descending equals
+    /// chronologically-newest-first without consulting
+    /// `temporal_index`. The `WHERE e.distilled = 0` clause is the
+    /// undistilled gate; legacy rows whose column defaults to `0`
+    /// from the lazy schema migration are included automatically.
+    fn list_undistilled_episodes(&self, limit: u32) -> SimardResult<Vec<CognitiveEpisode>> {
+        let rows = self.query(&format!(
+            "MATCH (e:Episode) WHERE e.distilled = 0 \
+             RETURN e.id, e.content, e.source_label, e.temporal_index, e.compressed \
+             ORDER BY e.id DESC LIMIT {limit}"
+        ))?;
+        Ok(rows
+            .into_iter()
+            .map(|row| CognitiveEpisode {
+                node_id: as_str(&row[0]).unwrap_or("").to_string(),
+                content: as_str(&row[1]).unwrap_or("").to_string(),
+                source_label: as_str(&row[2]).unwrap_or("").to_string(),
+                temporal_index: as_i64(&row[3]).unwrap_or(0),
+                compressed: as_i64(&row[4]).unwrap_or(0) != 0,
+            })
+            .collect())
     }
 
     fn get_statistics(&self) -> SimardResult<CognitiveStatistics> {

--- a/src/cognitive_memory/schema.rs
+++ b/src/cognitive_memory/schema.rs
@@ -8,12 +8,25 @@ pub(crate) const SCHEMA_DDL: &[&str] = &[
     "CREATE NODE TABLE IF NOT EXISTS Fact(id STRING PRIMARY KEY, concept STRING, content STRING, confidence DOUBLE DEFAULT 0.0, source_id STRING DEFAULT '', tags STRING DEFAULT '')",
     "CREATE NODE TABLE IF NOT EXISTS Decision(id STRING PRIMARY KEY, description STRING, rationale STRING DEFAULT '', outcome STRING DEFAULT '', session_id STRING DEFAULT '')",
     "CREATE NODE TABLE IF NOT EXISTS Goal(id STRING PRIMARY KEY, description STRING, priority INT64 DEFAULT 0, status STRING DEFAULT 'pending')",
-    "CREATE NODE TABLE IF NOT EXISTS Episode(id STRING PRIMARY KEY, content STRING, source_label STRING DEFAULT '', temporal_index INT64 DEFAULT 0, compressed INT64 DEFAULT 0)",
+    "CREATE NODE TABLE IF NOT EXISTS Episode(id STRING PRIMARY KEY, content STRING, source_label STRING DEFAULT '', temporal_index INT64 DEFAULT 0, compressed INT64 DEFAULT 0, distilled INT64 DEFAULT 0)",
     "CREATE NODE TABLE IF NOT EXISTS Sensory(id STRING PRIMARY KEY, modality STRING, raw_data STRING, observation_order INT64 DEFAULT 0, expires_at DOUBLE DEFAULT 0.0)",
     "CREATE NODE TABLE IF NOT EXISTS WorkingMemory(id STRING PRIMARY KEY, slot_type STRING, content STRING, task_id STRING DEFAULT '', relevance DOUBLE DEFAULT 0.0)",
     "CREATE NODE TABLE IF NOT EXISTS Procedure(id STRING PRIMARY KEY, name STRING, steps STRING DEFAULT '', prerequisites STRING DEFAULT '', usage_count INT64 DEFAULT 0)",
     "CREATE NODE TABLE IF NOT EXISTS Prospective(id STRING PRIMARY KEY, description STRING, trigger_condition STRING, action_on_trigger STRING, status STRING DEFAULT 'pending', priority INT64 DEFAULT 0)",
 ];
+
+/// Idempotent ALTER TABLE statements that bring an existing database
+/// schema up to the current version. Each statement must be safe to
+/// run on a fresh DB (where the column already exists from the CREATE
+/// statement above) — the lazy-migration logic in
+/// `NativeCognitiveMemory::ensure_schema` swallows
+/// "already exists" / "duplicate property" errors so both legacy and
+/// new DBs converge to the same shape.
+///
+/// PR-B (issue #2281): adds `distilled INT64 DEFAULT 0` to the
+/// `Episode` table for episode distillation tracking.
+pub(crate) const SCHEMA_MIGRATIONS: &[&str] =
+    &["ALTER TABLE Episode ADD distilled INT64 DEFAULT 0"];
 
 #[cfg(test)]
 mod tests {
@@ -30,6 +43,26 @@ mod tests {
             assert!(
                 stmt.contains("IF NOT EXISTS"),
                 "DDL should be idempotent: {stmt}"
+            );
+        }
+    }
+
+    #[test]
+    fn migrations_target_existing_tables() {
+        // Each ALTER must target a table created above so a fresh DB
+        // applies CREATE first and the duplicate-column error from
+        // ALTER is swallowed by ensure_schema().
+        for migration in SCHEMA_MIGRATIONS {
+            assert!(
+                migration.contains("Episode")
+                    || migration.contains("Fact")
+                    || migration.contains("Decision")
+                    || migration.contains("Goal")
+                    || migration.contains("Sensory")
+                    || migration.contains("WorkingMemory")
+                    || migration.contains("Procedure")
+                    || migration.contains("Prospective"),
+                "migration must target a known table: {migration}"
             );
         }
     }

--- a/src/cognitive_memory/tests_pr_b_distill.rs
+++ b/src/cognitive_memory/tests_pr_b_distill.rs
@@ -1,0 +1,132 @@
+//! TDD (RED) tests for PR-B trait surface additions.
+//!
+//! Covers the two new `CognitiveMemoryOps` methods documented in
+//! `docs/architecture/episode-distillation.md` §"Trait surface":
+//!
+//! * `mark_episode_distilled(node_id) -> SimardResult<()>`
+//! * `list_undistilled_episodes(limit) -> SimardResult<Vec<CognitiveEpisode>>`
+//!
+//! Both methods MUST land with a default no-op impl so legacy bridges
+//! keep compiling. `NativeCognitiveMemory` MUST override them against
+//! the lbug-backed `Episode` schema, which gains a lazy `distilled
+//! INT64 DEFAULT 0` column.
+//!
+//! These tests target `NativeCognitiveMemory::in_memory()` directly so
+//! the override behaviour is exercised without going through the
+//! bridge layer.
+//!
+//! ## Expected red signal
+//!
+//! Before PR-B lands, the default trait impls return `Ok(vec![])` and
+//! `Ok(())` respectively, so every assertion that expects non-empty
+//! results or post-mark filtering will fail. The lazy schema migration
+//! is also untested today — this file is the contract.
+
+use super::{CognitiveMemoryOps, NativeCognitiveMemory};
+
+fn test_mem() -> NativeCognitiveMemory {
+    NativeCognitiveMemory::in_memory().expect("in-memory DB should create")
+}
+
+/// `list_undistilled_episodes` MUST return episodes newest-first by
+/// node id descending. Because Episode ids are UUID-v7 (time-prefixed)
+/// in production, lex-descending == chronologically-newest-first
+/// without consulting `temporal_index`.
+#[test]
+fn list_undistilled_episodes_returns_newest_first() {
+    let mem = test_mem();
+    let ids: Vec<String> = (0..5)
+        .map(|i| {
+            mem.store_episode(&format!("episode {i}"), "test", None)
+                .expect("store_episode")
+        })
+        .collect();
+
+    let listed = mem
+        .list_undistilled_episodes(10)
+        .expect("list_undistilled_episodes");
+
+    assert_eq!(
+        listed.len(),
+        5,
+        "all 5 freshly-stored episodes must be undistilled"
+    );
+
+    // Returned newest-first; the last id stored must be the first
+    // entry in the listing.
+    let listed_ids: Vec<&str> = listed.iter().map(|e| e.node_id.as_str()).collect();
+    let last_stored = ids.last().unwrap().as_str();
+    assert_eq!(
+        listed_ids[0], last_stored,
+        "newest stored episode must appear first in the listing; \
+         listed: {listed_ids:?}, ids: {ids:?}"
+    );
+}
+
+/// `mark_episode_distilled` followed by `list_undistilled_episodes`
+/// must exclude the marked row. The mark MUST be durable across
+/// subsequent reads (no in-memory-only state).
+#[test]
+fn mark_episode_distilled_round_trips() {
+    let mem = test_mem();
+    let id_a = mem.store_episode("alpha", "test", None).unwrap();
+    let id_b = mem.store_episode("beta", "test", None).unwrap();
+    let id_c = mem.store_episode("gamma", "test", None).unwrap();
+
+    mem.mark_episode_distilled(&id_b)
+        .expect("mark_episode_distilled");
+
+    let listed = mem.list_undistilled_episodes(10).unwrap();
+    let listed_ids: std::collections::HashSet<&str> =
+        listed.iter().map(|e| e.node_id.as_str()).collect();
+    assert!(
+        listed_ids.contains(id_a.as_str()),
+        "alpha must remain undistilled"
+    );
+    assert!(
+        !listed_ids.contains(id_b.as_str()),
+        "beta must be excluded after mark_episode_distilled; listed: {listed_ids:?}"
+    );
+    assert!(
+        listed_ids.contains(id_c.as_str()),
+        "gamma must remain undistilled"
+    );
+}
+
+/// The `limit` parameter MUST be honoured: requesting 2 from a store
+/// of 5 undistilled rows returns exactly 2.
+#[test]
+fn list_undistilled_respects_limit() {
+    let mem = test_mem();
+    for i in 0..5 {
+        mem.store_episode(&format!("e{i}"), "src", None).unwrap();
+    }
+    let listed = mem.list_undistilled_episodes(2).unwrap();
+    assert_eq!(
+        listed.len(),
+        2,
+        "limit=2 must cap the result list at 2 rows"
+    );
+}
+
+/// Lazy migration: pre-PR-B rows (which lack the `distilled` column)
+/// must be treated as undistilled (default `0`). This is verified
+/// indirectly: every freshly stored episode in this test predates
+/// any `mark_episode_distilled` call, so all must appear in the
+/// undistilled list. Combined with the dedicated round-trip test
+/// above, this proves the migration is implicit (no offline step).
+#[test]
+fn list_undistilled_includes_pre_migration_rows_as_undistilled() {
+    let mem = test_mem();
+    for i in 0..3 {
+        mem.store_episode(&format!("legacy {i}"), "legacy", None)
+            .unwrap();
+    }
+    let listed = mem.list_undistilled_episodes(10).unwrap();
+    assert_eq!(
+        listed.len(),
+        3,
+        "rows stored without ever calling mark_episode_distilled must \
+         appear in the undistilled listing (lazy migration default = 0)"
+    );
+}

--- a/src/memory_consolidation/distillation.rs
+++ b/src/memory_consolidation/distillation.rs
@@ -1,0 +1,508 @@
+//! Episode distillation: extract semantic facts from batches of recent
+//! episodes via an LLM recipe.
+//!
+//! See `docs/architecture/episode-distillation.md` for the full design
+//! (issue #2281, PR-B). This module:
+//!
+//! 1. Pulls up to [`DISTILL_BATCH_SIZE`] undistilled episodes from the
+//!    cognitive-memory backend, newest first.
+//! 2. If fewer than [`DISTILL_MIN_EPISODES`] are present, skips the
+//!    pass entirely — no LLM call, no markers.
+//! 3. Otherwise invokes a pluggable [`DistillRecipeRunner`] that
+//!    classifies each episode into one of three concept labels
+//!    (`pr-pattern`, `bug-pattern`, `lesson-learned`) or `skip`.
+//! 4. Stores each emitted fact via `store_fact`.
+//! 5. Marks EVERY input episode (including those classified `skip`) as
+//!    distilled so the same low-value batch is not re-fed to the LLM.
+//!
+//! On recipe error: NO facts are stored AND NO markers are set; the
+//! batch is fully eligible for retry on the next pass.
+
+use std::path::Path;
+use std::process::Command;
+
+use crate::cognitive_memory::CognitiveMemoryOps;
+use crate::error::{SimardError, SimardResult};
+use crate::memory_cognitive::CognitiveEpisode;
+
+/// Maximum number of episodes pulled per distillation pass.
+pub const DISTILL_BATCH_SIZE: u32 = 50;
+
+/// Minimum number of undistilled episodes that must be present for a
+/// pass to fire. Below this, the pass is a no-op (no LLM call, no
+/// markers). Distillation is many-to-few; running it on a handful of
+/// episodes wastes an LLM call for little quality gain.
+pub const DISTILL_MIN_EPISODES: u32 = 20;
+
+/// Default per-fact confidence written via `store_fact`. The recipe
+/// itself does not produce confidence scores; this is the canonical
+/// "moderately confident, machine-distilled" value used by all PR-B
+/// facts so downstream filtering can recognize the source.
+pub const DISTILL_FACT_CONFIDENCE: f64 = 0.7;
+
+/// A single semantic fact emitted by the recipe runner for one batch
+/// of episodes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DistilledFact {
+    /// One of `pr-pattern`, `bug-pattern`, `lesson-learned`. The
+    /// recipe is constrained to this label set by its prompt.
+    pub concept: String,
+    /// Free-text content of the fact. Stored verbatim via `store_fact`.
+    pub content: String,
+    /// `node_id` of the source episode (used to compose the
+    /// `source_id` of the resulting fact as `distill:{id}` for
+    /// provenance).
+    pub source_episode_id: String,
+}
+
+/// Pluggable LLM-side runner for the distillation recipe.
+///
+/// The trait exists so tests can substitute a deterministic stub.
+/// Production code uses [`RecipeRunnerSubprocess`] which shells out
+/// to `recipe-runner-rs`.
+pub trait DistillRecipeRunner {
+    fn run(&self, episodes: &[CognitiveEpisode]) -> SimardResult<Vec<DistilledFact>>;
+}
+
+/// Report describing what one distillation pass actually did.
+///
+/// Two terminal shapes:
+///
+/// - **Skipped**: `input_count == fact_count == marked_count == 0`
+///   (under threshold). Use [`DistillReport::skipped`] / `was_skipped`.
+/// - **Ran**: `input_count >= DISTILL_MIN_EPISODES`. `fact_count`
+///   is the number of `store_fact` calls; `marked_count` is the number
+///   of `mark_episode_distilled` calls (equal to `input_count` on
+///   success, `0` on recipe error).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct DistillReport {
+    /// Number of undistilled episodes pulled from the store.
+    pub input_count: u32,
+    /// Number of facts emitted by the recipe.
+    pub fact_count: u32,
+    /// Number of episodes marked distilled after the pass.
+    pub marked_count: u32,
+}
+
+impl DistillReport {
+    /// The pass was skipped under threshold; no work was done.
+    pub fn skipped() -> Self {
+        Self::default()
+    }
+
+    /// `true` when the pass did not fire (input/output/marks all zero).
+    pub fn was_skipped(&self) -> bool {
+        self.input_count == 0 && self.fact_count == 0 && self.marked_count == 0
+    }
+
+    /// Reduction ratio (`1 - fact_count / input_count`) as a fraction
+    /// in `[0.0, 1.0]`. Returns `0.0` when `input_count == 0` (the
+    /// skipped case) to avoid a divide-by-zero in the observability
+    /// log line.
+    pub fn reduction(&self) -> f64 {
+        if self.input_count == 0 {
+            0.0
+        } else {
+            1.0 - (self.fact_count as f64 / self.input_count as f64)
+        }
+    }
+}
+
+/// Run one distillation pass using the supplied runner.
+///
+/// This is the testable entry point. Production code calls
+/// [`distill_recent_episodes`] which wraps the subprocess runner.
+///
+/// Contract (see `docs/architecture/episode-distillation.md`):
+///
+/// - Under threshold → returns `Ok(DistillReport::skipped())`; runner
+///   is NOT invoked; no markers set; no facts stored.
+/// - Above threshold + recipe success → all input episodes are marked
+///   distilled (even when the recipe yielded zero facts).
+/// - Above threshold + recipe error → returns `Err(...)`; no markers
+///   set; no facts stored.
+#[tracing::instrument(skip_all)]
+pub fn distill_recent_episodes_with_runner(
+    memory: &dyn CognitiveMemoryOps,
+    runner: &dyn DistillRecipeRunner,
+) -> SimardResult<DistillReport> {
+    let episodes = memory.list_undistilled_episodes(DISTILL_BATCH_SIZE)?;
+    let pulled = episodes.len() as u32;
+
+    if pulled < DISTILL_MIN_EPISODES {
+        tracing::info!(
+            target: "simard::distill",
+            pulled,
+            min = DISTILL_MIN_EPISODES,
+            "distill: {pulled} episodes pulled, below min {DISTILL_MIN_EPISODES}, skipped"
+        );
+        eprintln!(
+            "[simard] distill: {pulled} episodes pulled, below min {DISTILL_MIN_EPISODES}, skipped"
+        );
+        return Ok(DistillReport::skipped());
+    }
+
+    tracing::info!(
+        target: "simard::distill",
+        pulled,
+        batch = DISTILL_BATCH_SIZE,
+        min = DISTILL_MIN_EPISODES,
+        "distill: {pulled} episodes pulled (batch size {DISTILL_BATCH_SIZE}, min {DISTILL_MIN_EPISODES})"
+    );
+    eprintln!(
+        "[simard] distill: {pulled} episodes pulled (batch size {DISTILL_BATCH_SIZE}, min {DISTILL_MIN_EPISODES})"
+    );
+
+    // Run the recipe. On error, return immediately WITHOUT marking
+    // any episodes — the batch is fully retry-eligible on the next
+    // pass. This is the retry-safety invariant under test in
+    // `distillation_handles_recipe_error_without_marking`.
+    let facts = match runner.run(&episodes) {
+        Ok(f) => f,
+        Err(e) => {
+            tracing::warn!(
+                target: "simard::distill",
+                pulled,
+                error = %e,
+                "distill: {pulled} episodes pulled, recipe error, no markers set, retry next pass"
+            );
+            eprintln!(
+                "[simard] distill: {pulled} episodes pulled, recipe error: {e}, no markers set, retry next pass"
+            );
+            return Err(e);
+        }
+    };
+
+    // Store every fact. Each fact's source_id encodes the originating
+    // episode for provenance (search_facts can be filtered/grepped on
+    // the `distill:` prefix to identify machine-distilled facts).
+    let mut stored = 0u32;
+    for fact in &facts {
+        let concepts = [fact.concept.clone()];
+        let source = format!("distill:{}", fact.source_episode_id);
+        memory.store_fact(
+            &fact.concept,
+            &fact.content,
+            DISTILL_FACT_CONFIDENCE,
+            &concepts,
+            &source,
+        )?;
+        stored += 1;
+    }
+
+    // Mark EVERY input episode distilled — even those the recipe
+    // classified `skip` (they contribute no fact but must not be
+    // re-fed to the LLM on the next pass). The mark-everything rule
+    // is the prompt-replay-loop guard documented in
+    // `episode-distillation.md` §"Pipeline overview".
+    let mut marked = 0u32;
+    for ep in &episodes {
+        memory.mark_episode_distilled(&ep.node_id)?;
+        marked += 1;
+    }
+
+    let reduction_pct = (1.0 - stored as f64 / pulled as f64) * 100.0;
+    tracing::info!(
+        target: "simard::distill",
+        pulled,
+        stored,
+        marked,
+        reduction_pct,
+        "distill: {pulled} episodes → {stored} facts, {marked} marked (reduction {reduction_pct:.0}%)"
+    );
+    eprintln!("[simard] distill: {pulled} episodes → {stored} facts, {marked} marked");
+
+    Ok(DistillReport {
+        input_count: pulled,
+        fact_count: stored,
+        marked_count: marked,
+    })
+}
+
+/// Production entry point: run one distillation pass using the
+/// `recipe-runner-rs` subprocess.
+///
+/// Returns `Ok(DistillReport::skipped())` when the runner cannot be
+/// constructed (e.g. `recipe-runner-rs` not on PATH, no recipe file,
+/// no agent binary). This matches the "skip gracefully" behaviour of
+/// other recipe shims (`RecipeProgressChecker`, `RecipeMergeJudge`)
+/// so distillation never blocks the OODA cycle.
+#[tracing::instrument(skip_all)]
+pub fn distill_recent_episodes(
+    memory: &dyn CognitiveMemoryOps,
+    repo_root: &Path,
+) -> SimardResult<DistillReport> {
+    match RecipeRunnerSubprocess::new(repo_root) {
+        Some(runner) => distill_recent_episodes_with_runner(memory, &runner),
+        None => {
+            tracing::info!(
+                target: "simard::distill",
+                "distill: recipe-runner-rs unavailable or recipe file missing; skipping pass"
+            );
+            Ok(DistillReport::skipped())
+        }
+    }
+}
+
+const RECIPE_FILENAME: &str = "distill-episodes.yaml";
+
+fn resolve_recipe_path(repo_root: &Path) -> Option<std::path::PathBuf> {
+    if let Some(home) = dirs::home_dir() {
+        let hot = home
+            .join(".simard")
+            .join("prompt_assets/simard/recipes")
+            .join(RECIPE_FILENAME);
+        if hot.is_file() {
+            return Some(hot);
+        }
+    }
+    let in_tree = repo_root
+        .join("prompt_assets/simard/recipes")
+        .join(RECIPE_FILENAME);
+    if in_tree.is_file() {
+        return Some(in_tree);
+    }
+    None
+}
+
+/// Concrete subprocess-based recipe runner. Shells out to
+/// `recipe-runner-rs` with the episodes JSON inlined as a single
+/// `-c episodes=<json>` context entry.
+pub struct RecipeRunnerSubprocess {
+    recipe_path: std::path::PathBuf,
+    agent_binary: &'static str,
+}
+
+impl RecipeRunnerSubprocess {
+    /// Construct a runner if all preconditions are met. Returns
+    /// `None` when:
+    ///
+    /// - The recipe file is not found in either the hot-reload or
+    ///   in-tree location.
+    /// - No agent binary is configured (no `AMPLIHACK_AGENT_BINARY`
+    ///   env var, no fallback path).
+    /// - `recipe-runner-rs` is not on `PATH`.
+    pub fn new(repo_root: &Path) -> Option<Self> {
+        let recipe_path = resolve_recipe_path(repo_root)?;
+        let agent_binary = crate::session_builder::LlmProvider::resolve_agent_binary()?;
+        if Command::new("recipe-runner-rs")
+            .arg("--version")
+            .env("AMPLIHACK_AGENT_BINARY", agent_binary)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .is_err()
+        {
+            return None;
+        }
+        Some(Self {
+            recipe_path,
+            agent_binary,
+        })
+    }
+}
+
+impl DistillRecipeRunner for RecipeRunnerSubprocess {
+    fn run(&self, episodes: &[CognitiveEpisode]) -> SimardResult<Vec<DistilledFact>> {
+        // Serialize episodes as a compact JSON array. Each entry
+        // exposes the four fields the recipe prompt references:
+        // `id`, `source_label`, `temporal_index`, `content`.
+        let payload: Vec<serde_json::Value> = episodes
+            .iter()
+            .map(|e| {
+                serde_json::json!({
+                    "id": e.node_id,
+                    "source_label": e.source_label,
+                    "temporal_index": e.temporal_index,
+                    "content": e.content,
+                })
+            })
+            .collect();
+        let payload_json = serde_json::to_string(&payload).map_err(|e| {
+            SimardError::BridgeError(format!(
+                "distill: failed to serialize episodes payload: {e}"
+            ))
+        })?;
+
+        let output = Command::new("recipe-runner-rs")
+            .arg(self.recipe_path.as_os_str())
+            .env("AMPLIHACK_AGENT_BINARY", self.agent_binary)
+            .arg("-c")
+            .arg(format!("episodes={payload_json}"))
+            .output()
+            .map_err(|e| {
+                SimardError::BridgeError(format!("distill: recipe-runner-rs spawn failed: {e}"))
+            })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+            return Err(SimardError::BridgeError(format!(
+                "distill: recipe exited with {}: {}",
+                output.status,
+                truncate(&stderr, 240)
+            )));
+        }
+
+        let raw = String::from_utf8_lossy(&output.stdout).to_string();
+        parse_recipe_output(&raw)
+    }
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        let truncated: String = s.chars().take(max).collect();
+        format!("{truncated}…")
+    }
+}
+
+/// Parse the recipe's stdout into a list of [`DistilledFact`].
+///
+/// The recipe is expected to emit a JSON object of shape
+/// `{ "facts": [ { "concept": "...", "content": "...",
+/// "source_episode_id": "..." } ] }`. Because the underlying LLM may
+/// wrap the JSON in prose, we scan for the first balanced `{...}`
+/// substring containing a `"facts"` key and parse that.
+///
+/// Returns `Err` when no parseable object is found — the caller
+/// treats `Err` as the retry-safe "no markers set" path.
+fn parse_recipe_output(raw: &str) -> SimardResult<Vec<DistilledFact>> {
+    let trimmed = raw.trim();
+    // Fast path — recipe stdout IS the JSON object.
+    if let Ok(parsed) = serde_json::from_str::<RecipeEnvelope>(trimmed) {
+        return Ok(parsed.into_facts());
+    }
+    // Slow path — find the first balanced `{...}` substring and try
+    // each one until something parses. Cheap because the output is
+    // small.
+    if let Some(start) = trimmed.find('{') {
+        let mut depth = 0i32;
+        let bytes = trimmed.as_bytes();
+        for i in start..bytes.len() {
+            match bytes[i] {
+                b'{' => depth += 1,
+                b'}' => {
+                    depth -= 1;
+                    if depth == 0
+                        && let Ok(parsed) =
+                            serde_json::from_str::<RecipeEnvelope>(&trimmed[start..=i])
+                    {
+                        return Ok(parsed.into_facts());
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    Err(SimardError::BridgeError(format!(
+        "distill: recipe output did not contain a parseable {{ \"facts\": [...] }} object; raw: {}",
+        truncate(raw, 200)
+    )))
+}
+
+#[derive(serde::Deserialize)]
+struct RecipeEnvelope {
+    facts: Vec<RecipeFact>,
+}
+
+#[derive(serde::Deserialize)]
+struct RecipeFact {
+    concept: String,
+    content: String,
+    source_episode_id: String,
+}
+
+impl RecipeEnvelope {
+    fn into_facts(self) -> Vec<DistilledFact> {
+        // Keep only the three documented concepts so the recipe cannot
+        // sneak new labels past the contract. Everything else (incl.
+        // `skip` if it ever lands here) is dropped.
+        self.facts
+            .into_iter()
+            .filter(|f| {
+                matches!(
+                    f.concept.as_str(),
+                    "pr-pattern" | "bug-pattern" | "lesson-learned"
+                )
+            })
+            .map(|f| DistilledFact {
+                concept: f.concept,
+                content: f.content,
+                source_episode_id: f.source_episode_id,
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+
+    #[test]
+    fn report_skipped_is_was_skipped() {
+        assert!(DistillReport::skipped().was_skipped());
+    }
+
+    #[test]
+    fn report_with_work_is_not_was_skipped() {
+        let r = DistillReport {
+            input_count: 25,
+            fact_count: 3,
+            marked_count: 25,
+        };
+        assert!(!r.was_skipped());
+    }
+
+    #[test]
+    fn reduction_is_zero_when_no_inputs() {
+        assert_eq!(DistillReport::skipped().reduction(), 0.0);
+    }
+
+    #[test]
+    fn reduction_is_88_percent_for_25_to_3() {
+        let r = DistillReport {
+            input_count: 25,
+            fact_count: 3,
+            marked_count: 25,
+        };
+        let pct = r.reduction() * 100.0;
+        assert!((pct - 88.0).abs() < 0.1, "expected ~88%, got {pct}");
+    }
+
+    #[test]
+    fn parse_recipe_output_accepts_plain_object() {
+        let raw =
+            r#"{"facts":[{"concept":"pr-pattern","content":"x","source_episode_id":"epi_1"}]}"#;
+        let facts = parse_recipe_output(raw).unwrap();
+        assert_eq!(facts.len(), 1);
+        assert_eq!(facts[0].concept, "pr-pattern");
+    }
+
+    #[test]
+    fn parse_recipe_output_extracts_json_from_prose() {
+        let raw = r#"Sure, here is the JSON:
+            {"facts":[{"concept":"bug-pattern","content":"y","source_episode_id":"epi_2"}]}
+            That's all."#;
+        let facts = parse_recipe_output(raw).unwrap();
+        assert_eq!(facts.len(), 1);
+        assert_eq!(facts[0].concept, "bug-pattern");
+    }
+
+    #[test]
+    fn parse_recipe_output_drops_unknown_concepts() {
+        let raw = r#"{"facts":[
+            {"concept":"made-up-label","content":"a","source_episode_id":"epi_1"},
+            {"concept":"lesson-learned","content":"b","source_episode_id":"epi_2"}
+        ]}"#;
+        let facts = parse_recipe_output(raw).unwrap();
+        assert_eq!(facts.len(), 1, "made-up-label must be filtered out");
+        assert_eq!(facts[0].concept, "lesson-learned");
+    }
+
+    #[test]
+    fn parse_recipe_output_errors_when_no_object() {
+        let raw = "no json here at all";
+        assert!(parse_recipe_output(raw).is_err());
+    }
+}

--- a/src/memory_consolidation/distillation_tests.rs
+++ b/src/memory_consolidation/distillation_tests.rs
@@ -1,0 +1,506 @@
+//! TDD (RED) tests for PR-B: episode distillation.
+//!
+//! These tests pin the contract documented in
+//! `docs/architecture/episode-distillation.md` for PR-B (issue #2281,
+//! problem 2). They are written **before** the production code change
+//! and are expected to FAIL until PR-B lands.
+//!
+// Test scaffolding intentionally uses a couple of mildly complex
+// shapes (tuple-vec mock + Reverse-by-temporal-index sort) that
+// clippy flags but rewriting would obscure the test intent.
+#![allow(clippy::type_complexity)]
+#![allow(clippy::unnecessary_sort_by)]
+//!
+//! ## What PR-B introduces
+//!
+//! * A new module `crate::memory_consolidation::distillation` with:
+//!   * `pub struct DistillReport { input_count, fact_count, marked_count }`
+//!   * `pub fn distill_recent_episodes(memory, repo_root) -> SimardResult<DistillReport>`
+//!   * `pub const DISTILL_BATCH_SIZE: u32` (default 50)
+//!   * `pub const DISTILL_MIN_EPISODES: u32` (default 20)
+//! * Two new methods on `CognitiveMemoryOps` with default no-ops:
+//!   * `fn mark_episode_distilled(&self, node_id: &str) -> SimardResult<()>`
+//!   * `fn list_undistilled_episodes(&self, limit: u32) -> SimardResult<Vec<CognitiveEpisode>>`
+//! * A pluggable recipe runner for the LLM-side distillation step so
+//!   tests can substitute a deterministic stub.
+//!
+//! ## How these compile against pre-PR-B code
+//!
+//! Every reference to the new API is gated behind the symbol path
+//! `crate::memory_consolidation::distillation::*` and the new trait
+//! methods. Because those items do not exist yet, the file will fail
+//! to compile.
+//!
+//! That is the intended TDD red signal — the unresolved-path errors
+//! are concrete, deterministic, and unmistakable. PR-B's first commit
+//! adds the empty types and stubs; this file becomes the contract that
+//! drives the rest of the work.
+//!
+//! Each test below has a header comment listing the precise symbols
+//! that must exist for it to even build, so a future contributor can
+//! satisfy them one at a time.
+
+// `distillation` module does not exist yet (PR-B introduces it).
+use crate::memory_consolidation::distillation::{
+    DISTILL_BATCH_SIZE, DISTILL_MIN_EPISODES, DistillRecipeRunner,
+    distill_recent_episodes_with_runner,
+};
+
+use crate::cognitive_memory::CognitiveMemoryOps;
+use crate::error::{SimardError, SimardResult};
+use crate::memory_cognitive::{
+    CognitiveEpisode, CognitiveFact, CognitiveProcedure, CognitiveProspective, CognitiveStatistics,
+    CognitiveWorkingSlot,
+};
+
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+// ───────────────────────────────────────────────────────────────────────────
+// Pluggable recipe runner trait
+// ───────────────────────────────────────────────────────────────────────────
+//
+// PR-B exposes `DistillRecipeRunner` so tests can inject a deterministic
+// stand-in for `recipe-runner-rs`. Production code will provide a
+// concrete impl that shells out; tests use the stubs in this file.
+//
+// The trait is referenced via the `distill_recent_episodes_with_runner`
+// entry point; the public `distill_recent_episodes(memory, repo_root)`
+// remains the operator-facing call and is covered by integration
+// tests elsewhere.
+
+/// Stub runner that classifies every episode into the supplied facts.
+/// Records the call count so tests can assert the LLM was invoked.
+struct FixedFactsRunner {
+    facts: Vec<(String, String, String)>, // (concept, content, source_episode_id)
+    call_count: AtomicU32,
+}
+
+impl DistillRecipeRunner for FixedFactsRunner {
+    fn run(
+        &self,
+        episodes: &[CognitiveEpisode],
+    ) -> SimardResult<Vec<crate::memory_consolidation::distillation::DistilledFact>> {
+        self.call_count.fetch_add(1, Ordering::SeqCst);
+        let _ = episodes; // every episode contributes via the fixed-fact set
+        Ok(self
+            .facts
+            .iter()
+            .map(
+                |(c, content, src)| crate::memory_consolidation::distillation::DistilledFact {
+                    concept: c.clone(),
+                    content: content.clone(),
+                    source_episode_id: src.clone(),
+                },
+            )
+            .collect())
+    }
+}
+
+/// Stub runner that always returns a recipe error. Records call count
+/// so the "no markers set" test can verify that the LLM path WAS
+/// invoked but produced no usable output.
+struct ErroringRunner {
+    call_count: AtomicU32,
+}
+
+impl DistillRecipeRunner for ErroringRunner {
+    fn run(
+        &self,
+        _episodes: &[CognitiveEpisode],
+    ) -> SimardResult<Vec<crate::memory_consolidation::distillation::DistilledFact>> {
+        self.call_count.fetch_add(1, Ordering::SeqCst);
+        Err(SimardError::BridgeError(
+            "stub: recipe runner deliberately failed".to_string(),
+        ))
+    }
+}
+
+/// Stub runner that PANICS if invoked. Used by the under-threshold
+/// test to prove the LLM path was bypassed entirely.
+struct PanickingRunner;
+
+impl DistillRecipeRunner for PanickingRunner {
+    fn run(
+        &self,
+        _episodes: &[CognitiveEpisode],
+    ) -> SimardResult<Vec<crate::memory_consolidation::distillation::DistilledFact>> {
+        panic!("distillation must not invoke the LLM under the min-episode threshold");
+    }
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// In-memory CognitiveMemoryOps mock with mutable episode store
+// ───────────────────────────────────────────────────────────────────────────
+
+/// A minimal `CognitiveMemoryOps` implementation that lets tests load
+/// an arbitrary set of episodes, observe `store_fact` / `mark_episode_distilled`
+/// calls, and assert post-state.
+///
+/// Wraps state in `Mutex` so the trait's `&self` signature is honoured
+/// while still allowing tests to mutate.
+#[derive(Default)]
+struct EpisodeMock {
+    episodes: Mutex<Vec<EpisodeRow>>,
+    facts: Mutex<Vec<(String, String, f64, Vec<String>, String)>>, // (concept, content, conf, tags, source)
+    mark_calls: Mutex<Vec<String>>,
+}
+
+#[derive(Clone)]
+struct EpisodeRow {
+    node_id: String,
+    content: String,
+    source_label: String,
+    temporal_index: i64,
+    compressed: bool,
+    distilled: bool,
+}
+
+impl EpisodeMock {
+    fn with_episodes(rows: Vec<EpisodeRow>) -> Self {
+        Self {
+            episodes: Mutex::new(rows),
+            ..Self::default()
+        }
+    }
+
+    fn facts_stored(&self) -> Vec<(String, String)> {
+        self.facts
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|(c, content, _, _, _)| (c.clone(), content.clone()))
+            .collect()
+    }
+
+    fn marks(&self) -> Vec<String> {
+        self.mark_calls.lock().unwrap().clone()
+    }
+
+    fn compressed_flags(&self) -> Vec<(String, bool)> {
+        self.episodes
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|e| (e.node_id.clone(), e.compressed))
+            .collect()
+    }
+}
+
+impl CognitiveMemoryOps for EpisodeMock {
+    fn record_sensory(&self, _m: &str, _r: &str, _t: u64) -> SimardResult<String> {
+        Ok("sen_x".to_string())
+    }
+    fn prune_expired_sensory(&self) -> SimardResult<usize> {
+        Ok(0)
+    }
+    fn push_working(&self, _s: &str, _c: &str, _t: &str, _r: f64) -> SimardResult<String> {
+        Ok("wrk_x".to_string())
+    }
+    fn get_working(&self, _t: &str) -> SimardResult<Vec<CognitiveWorkingSlot>> {
+        Ok(vec![])
+    }
+    fn clear_working(&self, _t: &str) -> SimardResult<usize> {
+        Ok(0)
+    }
+    fn store_episode(
+        &self,
+        _c: &str,
+        _s: &str,
+        _m: Option<&serde_json::Value>,
+    ) -> SimardResult<String> {
+        Ok("epi_new".to_string())
+    }
+    fn consolidate_episodes(&self, _b: u32) -> SimardResult<Option<String>> {
+        Ok(None)
+    }
+    fn store_fact(
+        &self,
+        concept: &str,
+        content: &str,
+        confidence: f64,
+        tags: &[String],
+        source_id: &str,
+    ) -> SimardResult<String> {
+        self.facts.lock().unwrap().push((
+            concept.to_string(),
+            content.to_string(),
+            confidence,
+            tags.to_vec(),
+            source_id.to_string(),
+        ));
+        Ok(format!("sem_{}", self.facts.lock().unwrap().len()))
+    }
+    fn search_facts(&self, _q: &str, _l: u32, _c: f64) -> SimardResult<Vec<CognitiveFact>> {
+        Ok(vec![])
+    }
+    fn store_procedure(&self, _n: &str, _s: &[String], _p: &[String]) -> SimardResult<String> {
+        Ok("prc_x".to_string())
+    }
+    fn recall_procedure(&self, _q: &str, _l: u32) -> SimardResult<Vec<CognitiveProcedure>> {
+        Ok(vec![])
+    }
+    fn store_prospective(&self, _d: &str, _t: &str, _a: &str, _p: i64) -> SimardResult<String> {
+        Ok("pro_x".to_string())
+    }
+    fn check_triggers(&self, _c: &str) -> SimardResult<Vec<CognitiveProspective>> {
+        Ok(vec![])
+    }
+    fn get_statistics(&self) -> SimardResult<CognitiveStatistics> {
+        Ok(CognitiveStatistics::default())
+    }
+
+    // === PR-B trait method overrides ===
+
+    fn list_undistilled_episodes(&self, limit: u32) -> SimardResult<Vec<CognitiveEpisode>> {
+        let eps = self.episodes.lock().unwrap();
+        let mut out: Vec<EpisodeRow> = eps.iter().filter(|e| !e.distilled).cloned().collect();
+        // Newest first by temporal_index descending (UUID-v7 ids are
+        // time-prefixed in production; in tests we just sort by
+        // temporal_index).
+        out.sort_by(|a, b| b.temporal_index.cmp(&a.temporal_index));
+        out.truncate(limit as usize);
+        Ok(out
+            .into_iter()
+            .map(|r| CognitiveEpisode {
+                node_id: r.node_id,
+                content: r.content,
+                source_label: r.source_label,
+                temporal_index: r.temporal_index,
+                compressed: r.compressed,
+            })
+            .collect())
+    }
+
+    fn mark_episode_distilled(&self, node_id: &str) -> SimardResult<()> {
+        self.mark_calls.lock().unwrap().push(node_id.to_string());
+        let mut eps = self.episodes.lock().unwrap();
+        if let Some(e) = eps.iter_mut().find(|e| e.node_id == node_id) {
+            e.distilled = true;
+        }
+        Ok(())
+    }
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Helpers
+// ───────────────────────────────────────────────────────────────────────────
+
+fn episode(idx: i64, label: &str, content: &str) -> EpisodeRow {
+    EpisodeRow {
+        node_id: format!("epi_{idx:05}"),
+        content: content.to_string(),
+        source_label: label.to_string(),
+        temporal_index: idx,
+        compressed: false,
+        distilled: false,
+    }
+}
+
+fn n_episodes(n: usize) -> Vec<EpisodeRow> {
+    (0..n as i64)
+        .map(|i| episode(i, "goal-curator", &format!("event {i}")))
+        .collect()
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Tests
+// ───────────────────────────────────────────────────────────────────────────
+
+/// Under-threshold gate: when fewer than `DISTILL_MIN_EPISODES`
+/// undistilled episodes are present, the pass MUST be skipped without
+/// invoking the recipe runner or calling `mark_episode_distilled`.
+///
+/// The `PanickingRunner` proves the LLM path is not taken.
+#[test]
+fn distillation_skipped_under_min_threshold() {
+    let n = (DISTILL_MIN_EPISODES as usize).saturating_sub(1);
+    assert!(n >= 1, "DISTILL_MIN_EPISODES must be > 1 for this test");
+    let mock = EpisodeMock::with_episodes(n_episodes(n));
+    let runner = PanickingRunner;
+
+    let report = distill_recent_episodes_with_runner(&mock, &runner).unwrap();
+
+    assert!(
+        report.was_skipped(),
+        "report must signal skipped when input < DISTILL_MIN_EPISODES; got {report:?}"
+    );
+    assert_eq!(report.input_count, 0);
+    assert_eq!(report.fact_count, 0);
+    assert_eq!(report.marked_count, 0);
+    assert!(
+        mock.marks().is_empty(),
+        "no episodes must be marked distilled when the pass is skipped"
+    );
+    assert!(
+        mock.facts_stored().is_empty(),
+        "no facts must be stored when the pass is skipped"
+    );
+}
+
+/// Above-threshold happy path: 25 episodes (≥ MIN) → recipe returns
+/// 3 facts → 3 `store_fact` calls AND **all 25** episodes marked
+/// distilled (the mark-everything rule prevents replay loops).
+#[test]
+fn distillation_stores_facts_and_marks_originals() {
+    let n = DISTILL_MIN_EPISODES as usize + 5;
+    let mock = EpisodeMock::with_episodes(n_episodes(n));
+    let runner = FixedFactsRunner {
+        facts: vec![
+            (
+                "pr-pattern".to_string(),
+                "enable auto-merge before final review".to_string(),
+                "epi_00001".to_string(),
+            ),
+            (
+                "bug-pattern".to_string(),
+                "empty outcome list panics cycle.rs".to_string(),
+                "epi_00007".to_string(),
+            ),
+            (
+                "lesson-learned".to_string(),
+                "prefer keyword overlap over embeddings for episodic recall".to_string(),
+                "epi_00012".to_string(),
+            ),
+        ],
+        call_count: AtomicU32::new(0),
+    };
+
+    let report = distill_recent_episodes_with_runner(&mock, &runner).unwrap();
+
+    assert!(
+        !report.was_skipped(),
+        "above-threshold pass must not be skipped"
+    );
+    assert_eq!(
+        report.input_count as usize,
+        n.min(DISTILL_BATCH_SIZE as usize)
+    );
+    assert_eq!(report.fact_count, 3, "3 facts emitted by the recipe stub");
+    assert_eq!(
+        report.marked_count as usize,
+        n.min(DISTILL_BATCH_SIZE as usize),
+        "every input episode (including those classified 'skip') must be marked distilled"
+    );
+    assert_eq!(
+        runner.call_count.load(Ordering::SeqCst),
+        1,
+        "the recipe runner must be invoked exactly once per pass"
+    );
+
+    let stored = mock.facts_stored();
+    let concepts: std::collections::HashSet<&str> =
+        stored.iter().map(|(c, _)| c.as_str()).collect();
+    assert!(concepts.contains("pr-pattern"));
+    assert!(concepts.contains("bug-pattern"));
+    assert!(concepts.contains("lesson-learned"));
+
+    let marks_set: std::collections::HashSet<String> = mock.marks().into_iter().collect();
+    assert_eq!(
+        marks_set.len() as u32,
+        report.marked_count,
+        "each marked episode must be marked exactly once"
+    );
+}
+
+/// Recipe error path: when the recipe runner returns Err, NO facts
+/// are stored AND NO episodes are marked distilled. The batch is
+/// eligible for retry on the next pass.
+#[test]
+fn distillation_handles_recipe_error_without_marking() {
+    let n = DISTILL_MIN_EPISODES as usize + 5;
+    let mock = EpisodeMock::with_episodes(n_episodes(n));
+    let runner = ErroringRunner {
+        call_count: AtomicU32::new(0),
+    };
+
+    let report = distill_recent_episodes_with_runner(&mock, &runner);
+
+    // Two acceptable shapes — Err returned, or Ok with zero work
+    // recorded — depending on whether PR-B's author treats recipe
+    // failure as fatal or as "skip this pass". Either shape MUST
+    // leave the store untouched.
+    match report {
+        Err(_) => {}
+        Ok(r) => {
+            assert_eq!(r.fact_count, 0, "no facts on recipe error");
+            assert_eq!(r.marked_count, 0, "no marks on recipe error");
+        }
+    }
+    assert_eq!(
+        runner.call_count.load(Ordering::SeqCst),
+        1,
+        "the recipe runner must be invoked once (the failure happens inside)"
+    );
+    assert!(
+        mock.facts_stored().is_empty(),
+        "no facts must be stored when the recipe errors"
+    );
+    assert!(
+        mock.marks().is_empty(),
+        "no markers must be set when the recipe errors — retry-safety invariant"
+    );
+}
+
+/// Mark-everything rule: even when the recipe classifies every input
+/// as "skip" and returns zero facts, all input episodes MUST be
+/// marked distilled. Otherwise the same low-value episodes would be
+/// resubmitted to the LLM forever.
+#[test]
+fn distillation_marks_episodes_classified_as_skip() {
+    let n = DISTILL_MIN_EPISODES as usize;
+    let mock = EpisodeMock::with_episodes(n_episodes(n));
+    let runner = FixedFactsRunner {
+        facts: vec![], // recipe found nothing useful
+        call_count: AtomicU32::new(0),
+    };
+
+    let report = distill_recent_episodes_with_runner(&mock, &runner).unwrap();
+
+    assert!(
+        !report.was_skipped(),
+        "above-threshold pass must not be skipped"
+    );
+    assert_eq!(report.fact_count, 0);
+    assert_eq!(
+        report.marked_count as usize, n,
+        "every input episode must be marked distilled even when the recipe yielded no facts"
+    );
+    assert!(mock.facts_stored().is_empty());
+    assert_eq!(mock.marks().len(), n);
+}
+
+/// Independence invariant: distillation MUST NOT touch the
+/// `compressed` flag. That flag is owned by the textual
+/// `consolidate_episodes` pass; the two passes are independent so
+/// their outputs can be attributed in observability.
+#[test]
+fn distillation_does_not_touch_compressed_flag() {
+    let n = DISTILL_MIN_EPISODES as usize + 2;
+    let mut rows = n_episodes(n);
+    // Pre-mark two episodes as compressed; distillation must leave
+    // those flags exactly as it found them.
+    rows[0].compressed = true;
+    rows[3].compressed = true;
+    let pre_compressed: Vec<(String, bool)> = rows
+        .iter()
+        .map(|r| (r.node_id.clone(), r.compressed))
+        .collect();
+    let mock = EpisodeMock::with_episodes(rows);
+    let runner = FixedFactsRunner {
+        facts: vec![(
+            "lesson-learned".to_string(),
+            "passes are independent".to_string(),
+            "epi_00000".to_string(),
+        )],
+        call_count: AtomicU32::new(0),
+    };
+
+    distill_recent_episodes_with_runner(&mock, &runner).unwrap();
+
+    let post = mock.compressed_flags();
+    assert_eq!(
+        post, pre_compressed,
+        "compressed flags must be identical before and after distillation"
+    );
+}

--- a/src/memory_consolidation/mod.rs
+++ b/src/memory_consolidation/mod.rs
@@ -513,3 +513,11 @@ mod tests;
 // active+backlog slug set.
 #[cfg(test)]
 mod tests_pr_a;
+
+// PR-B (issue #2281): episode distillation — periodic many-to-few
+// extraction of semantic facts from recent episodes via an LLM
+// recipe. See `docs/architecture/episode-distillation.md`.
+pub mod distillation;
+
+#[cfg(test)]
+mod distillation_tests;

--- a/src/ooda_actions/simple_actions.rs
+++ b/src/ooda_actions/simple_actions.rs
@@ -6,15 +6,54 @@ use crate::skill_builder::extract_skill_candidates;
 
 use super::{SKILL_MIN_USAGE, make_outcome};
 
-/// ConsolidateMemory: batch-consolidate episodic memory entries.
+/// ConsolidateMemory: batch-consolidate episodic memory entries and
+/// distill recent episodes into semantic facts.
+///
+/// Runs TWO independent passes:
+///
+/// 1. **Textual dedup** via `consolidate_episodes(20)` — collapses
+///    identical episodes into a single summary; sets `compressed = 1`.
+/// 2. **Semantic distillation** via
+///    `memory_consolidation::distillation::distill_recent_episodes` —
+///    pulls up to 50 undistilled episodes and extracts semantic facts
+///    via an LLM recipe; sets `distilled = 1`. Issue #2281, PR-B.
+///
+/// The two passes are independent: a failure of one does not abort
+/// the other. The outcome message reports both so the operator can
+/// attribute work to the correct pass.
 pub(super) fn dispatch_consolidate_memory(
     action: &PlannedAction,
     bridges: &OodaBridges,
 ) -> ActionOutcome {
-    match bridges.memory.consolidate_episodes(20) {
-        Ok(_) => make_outcome(action, true, "consolidated up to 20 episodes".to_string()),
-        Err(e) => make_outcome(action, false, format!("consolidation failed: {e}")),
-    }
+    // Pass 1: textual dedup. Errors here are fatal for the outcome
+    // because they signal a backend problem that would also affect
+    // pass 2.
+    let consolidate_msg = match bridges.memory.consolidate_episodes(20) {
+        Ok(_) => "consolidated up to 20 episodes".to_string(),
+        Err(e) => {
+            return make_outcome(action, false, format!("consolidation failed: {e}"));
+        }
+    };
+
+    // Pass 2: semantic distillation. Errors here are logged but do
+    // not fail the outcome — distillation depends on external LLM
+    // infrastructure (recipe-runner-rs + agent binary) that may be
+    // intentionally unavailable in some deployments. The
+    // `Ok(skipped)` shape is the graceful no-op path.
+    let repo_root = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+    let distill_msg = match crate::memory_consolidation::distillation::distill_recent_episodes(
+        &*bridges.memory,
+        &repo_root,
+    ) {
+        Ok(report) if report.was_skipped() => "distill skipped (below min threshold)".to_string(),
+        Ok(report) => format!(
+            "distill: {} episodes → {} facts, {} marked",
+            report.input_count, report.fact_count, report.marked_count
+        ),
+        Err(e) => format!("distill failed (non-fatal): {e}"),
+    };
+
+    make_outcome(action, true, format!("{consolidate_msg}; {distill_msg}"))
 }
 
 /// ResearchQuery: list available knowledge packs.


### PR DESCRIPTION
## Summary

PR-B of three for the cognitive-memory end-to-end fix (issue #2281). Closes problem 2: **episode distillation**.

Before this change, `consolidate_episodes` only did textual dedup, which kept the compression ratio at 0% every cycle because raw episodes rarely share identical text. Operational knowledge (what worked, what broke, what was tried) sat trapped in episodic memory where it was hard to retrieve and easy to lose during eviction. PR-B closes that gap with a periodic many-to-few extraction pass that converts batches of recent episodes into durable semantic facts via an LLM recipe.

## Pipeline (see `docs/architecture/episode-distillation.md` for full design)

```
list_undistilled_episodes(50)
  → if len < 20: skip pass entirely (no LLM, no markers)
  → else: invoke recipe-runner-rs with episodes payload
    → for each emitted fact: store_fact(concept, content, conf=0.7, source=distill:<id>)
    → for EVERY input episode: mark_episode_distilled(node_id)  ← even skip-classified
  → on recipe error: NO facts stored, NO markers set (retry-safe)
```

Concept labels constrained to exactly: `pr-pattern`, `bug-pattern`, `lesson-learned`.

## Files

| File | Role |
|------|------|
| `src/memory_consolidation/distillation.rs` (new) | Module with `DistillReport`, `DistillRecipeRunner` trait, `RecipeRunnerSubprocess`, and the two public entry points |
| `src/memory_consolidation/distillation_tests.rs` (new) | 5 contract tests covering threshold gating, happy path, recipe-error, skip-classified, compressed-flag independence |
| `src/cognitive_memory/tests_pr_b_distill.rs` (new) | 4 native-backend round-trip tests against `NativeCognitiveMemory` |
| `src/cognitive_memory/mod.rs` | New trait methods (default no-op) + `CognitiveEpisode` import |
| `src/cognitive_memory/ops.rs` | Native overrides for `mark_episode_distilled` and `list_undistilled_episodes` |
| `src/cognitive_memory/schema.rs` | `distilled INT64 DEFAULT 0` added to Episode CREATE + new `SCHEMA_MIGRATIONS` list |
| `src/ooda_actions/simple_actions.rs` | `dispatch_consolidate_memory` now runs both textual dedup AND distillation |
| `prompt_assets/simard/recipes/distill-episodes.yaml` (new) | LLM recipe |
| `docs/architecture/episode-distillation.md` (new) | 480-line architecture doc |

## Lazy schema migration

The new `distilled` column is added two ways for the lazy migration:
- **Fresh DBs** — included in the `CREATE NODE TABLE IF NOT EXISTS` statement.
- **Pre-PR-B DBs** — `ensure_schema()` runs `ALTER TABLE Episode ADD distilled INT64 DEFAULT 0` after the CREATEs and swallows lbug's *"already has property distilled"* error (along with `already exists` / `duplicate column` / `column already` / `property already` so the migration is portable to future backends).

## Independence: `compressed` vs `distilled`

The textual `consolidate_episodes` pass writes `compressed`; PR-B's distillation writes `distilled`. They are independent flags — an episode can land in any of the four states `(compressed, distilled) ∈ {(0,0), (0,1), (1,0), (1,1)}`. A dedicated test (`distillation_does_not_touch_compressed_flag`) pins this.

## Retry safety

If the recipe-runner subprocess fails (or its stdout doesn't parse), `distill_recent_episodes_with_runner` returns `Err`. The caller observes NO `store_fact` calls AND NO `mark_episode_distilled` calls, so the entire batch is fully eligible for retry on the next pass. The mark-everything rule applies ONLY on recipe success.

## Verification

- `cargo test --lib`: **5660 passed, 0 failed, 4 ignored** (+14 vs PR-A baseline of 5646)
- `cargo clippy --lib --all-targets --offline -- -D warnings`: clean
- `cargo fmt --all -- --check`: clean
- All pre-commit + pre-push hooks pass

## Scope

- 10 files changed, +1907 / −8
- No public API removed
- Two new trait methods land with default no-op implementations so legacy bridges (Python IPC, in-memory test stubs) compile and behave identically
- Schema migration is fully lazy — no operator step required

## Related

- Builds on PR-A (#2290) for preparation filters
- Follow-up PR-C will implement procedural seeding + episodic recall (problems 3 + 4)