### PR TITLE
fix(cog-mem): unify procedure recall — distilled procedures surface in prepared context (ws2 #2295)

### DIFF
--- a/docs/reference/cognitive-memory-bootstrap-procedures.md
+++ b/docs/reference/cognitive-memory-bootstrap-procedures.md
@@ -68,7 +68,7 @@ Where:
 
 | Source                                        | Name                                                       |
 |-----------------------------------------------|------------------------------------------------------------|
-| OODA cycle: successful `AdvanceGoal` for `fix-auth-bug`, objective mentions `#2281` and `auth.rs` | `pr-merge:fix-auth-bug \| triggers: merge,pr,review,ci,2281,rs` |
+| OODA cycle: successful `AdvanceGoal` for `fix-auth-bug`, objective mentions `#2281` and `Cargo.toml` | `pr-merge:fix-auth-bug \| triggers: merge,pr,review,ci,2281,toml` |
 | OODA cycle: successful `RunImprovement` with no PR number, no file extension in objective       | `ci-fix:improve-coverage \| triggers: ci,green,failing,fix-ci,improve` |
 | Bootstrap seed                                | `pr-merge:bootstrap \| triggers: merge,pr,merge-pr,landing,ready-to-merge` |
 | Bootstrap seed                                | `ci-fix:bootstrap \| triggers: ci,green,failing,fix-ci,red` |
@@ -260,21 +260,36 @@ identifier shapes that empirically improve recall hit rate the most:
 | Pattern    | Regex                  | Capture used as trigger  |
 |------------|------------------------|--------------------------|
 | PR number  | `#(\d+)`               | The digits, e.g. `2281`  |
-| File ext   | `\.([A-Za-z][A-Za-z0-9]{0,4})\b` | The extension, e.g. `rs`, `md`, `yaml` |
+| File ext   | `\.([A-Za-z][A-Za-z0-9]{2,4})\b` | The extension, e.g. `toml`, `json`, `yaml` |
 
 Captures are lowercased and deduplicated against the base trigger
 list. The merge order is `base ++ derived`, with later duplicates
 dropped, so base triggers always appear first in the rendered name.
 
+> **Read/write floor alignment (ws2 #2295).** The file-extension
+> capture floors at **3 characters** (`{2,4}` ⇒ 3–5 chars total). This
+> deliberately matches the **read-side** floor in
+> `memory_consolidation::tokenize_objective`, which drops every
+> objective token shorter than 3 chars before issuing a recall query. A
+> 1- or 2-char derived trigger (`g`, `rs`, `md`, …) could therefore
+> never be matched by a tokenized recall — it would only sit in the
+> procedure name as visible-but-dead weight and, when it landed as the
+> trailing trigger, look exactly like the mid-word truncation symptom
+> reported in ws2 #2295. Aligning both floors removes that confusion
+> without losing any recall power.
+
 Example:
 
 ```
 ActionKind::AdvanceGoal
-objective = "merge PR #2281 fixing src/ooda_loop/cycle.rs"
+objective = "merge PR #2281 updating Cargo.toml"
 base      = ["merge", "pr", "review", "ci"]
-derived   = ["2281", "rs"]
-name      = "pr-merge:fix-cog-mem | triggers: merge,pr,review,ci,2281,rs"
+derived   = ["2281", "toml"]
+name      = "pr-merge:fix-cog-mem | triggers: merge,pr,review,ci,2281,toml"
 ```
+
+(Touching a 1–2 char extension such as `cycle.rs` adds no `rs` trigger
+under the 3-char floor; only the `#2281` PR-number capture survives.)
 
 Cost is one regex scan per stored procedure (already on a code path
 that only fires on successful outcomes — i.e. infrequently), and
@@ -303,6 +318,51 @@ usage count.
 PR-C only changes what procedures *exist* and what their *names* look
 like. The query semantics remain `CONTAINS` over name and steps.
 
+### Unified tokenized recall path (ws2 #2295)
+
+Before ws2 #2295 two recall paths coexisted and disagreed:
+
+- The OODA **preparation phase**
+  (`memory_consolidation::preparation_memory_operations_with_active_slugs`)
+  tokenized the objective and issued one `recall_procedure(token, …)`
+  call per token, deduped by `node_id` — so both bootstrap *and*
+  distilled procedures surfaced.
+- The **base-type adapter** turn preparation
+  (`base_type_turn::prepare_turn_context`, used by the engineer loop)
+  passed the **entire raw objective sentence** to a single
+  `recall_procedure(objective, 5)` call. The Cypher
+  `name CONTAINS '<full sentence>'` predicate never matched any stored
+  procedure (no procedure name embeds a natural sentence), so only the
+  bootstrap procedures — injected by other means — ever appeared in
+  `prepared context (… procedures …)`, regardless of how many cycles
+  had run. This was the cycle-238 symptom.
+
+Both call sites now share one entry point,
+`memory_consolidation::recall_procedures_for_objective(bridge,
+objective, max)` (re-exported as `simard::recall_procedures_for_objective`):
+
+1. Tokenize the objective with the shared `tokenize_objective`
+   (lowercased, 3-char floor, stopwords removed).
+2. Issue one `recall_procedure(token, max)` per token, dedup by
+   `node_id`.
+3. Sort by `usage_count` desc, then `name` asc, then `node_id` asc for
+   a fully deterministic order (names are **not** unique — repeated
+   cycles store the same composed name under different `node_id`s — so
+   `node_id` is the final tiebreaker that keeps `truncate` stable across
+   runs).
+4. Truncate to `max`.
+
+**Empty-token fallback.** When the objective produces no 3+ char tokens
+(very short or punctuation-only input), the helper issues a single
+`recall_procedure(objective, max)` call so callers that pass a
+pre-tokenized or exact-name query (e.g. the bootstrap idempotency
+check) keep working.
+
+**Case-folding contract.** `tokenize_objective` lowercases every token;
+both `BOOTSTRAP_PROCEDURES` and `compose_procedure_name` emit lowercase
+trigger text. Cypher `CONTAINS` is case-sensitive, so the all-lowercase
+invariant on both sides is what makes recall actually fire.
+
 The new naming convention means:
 
 | Objective text                       | Procedures recalled (at minimum)                |
@@ -324,8 +384,24 @@ Two log lines surface PR-C's procedural changes:
 
 ```
 [simard] cognitive memory: 3 bootstrap procedures seeded
-[simard] OODA consolidation: stored procedure 'pr-merge:fix-auth-bug | triggers: merge,pr,review,ci,2281,rs'
+[simard] OODA consolidation: stored procedure 'pr-merge:fix-auth-bug | triggers: merge,pr,review,ci,2281,toml'
 ```
+
+ws2 #2295 adds **structured `tracing` events** alongside the free-form
+`eprintln!` lines so operators can answer "which procedures fired this
+cycle?" and "is my trigger list truncated?" directly from the JSON
+journal, without tail-following or risk of shipper line-length
+truncation:
+
+```
+INFO recalled procedures for objective   procedure_count=2 tokens=[…] procedure_names="pr-merge:bootstrap … | pr-merge:g1 …"
+INFO OODA consolidation: stored procedure   procedure_name="pr-merge:fix-auth-bug | triggers: merge,pr,review,ci,2281,toml"
+```
+
+The structured `procedure_name` / `procedure_names` fields are written
+verbatim by every `fmt` layer (JSON and the default human formatter),
+so the full name is captured even if a downstream log shipper truncates
+the free-form message string.
 
 The preparation-phase line (shared with episodic recall) also reports
 procedure count:
@@ -382,8 +458,12 @@ procedure count:
 | OODA cycle procedure storage                  | `src/ooda_loop/cycle.rs` (currently at `cycle.rs:343`, the `format!("ooda:{}", outcome.action.kind)` site) |
 | Runtime pattern + trigger mapping             | `src/ooda_loop/cycle.rs` (next to the storage site)   |
 | `derive_triggers_from_objective` helper       | `src/ooda_loop/cycle.rs`                              |
+| `recall_procedures_for_objective` unified helper | `src/memory_consolidation/mod.rs` (re-exported as `simard::recall_procedures_for_objective`) |
+| `tokenize_objective` (shared read-side tokenizer / 3-char floor) | `src/memory_consolidation/mod.rs` |
+| Base-type adapter call site (now routed through the helper) | `src/base_type_turn.rs` (`prepare_turn_context`) |
 | Tests                                         | `src/cognitive_memory/bootstrap_procedures_tests.rs`, |
-|                                               | `src/ooda_loop/cycle.rs`                              |
+|                                               | `src/ooda_loop/cycle.rs`,                             |
+|                                               | `tests/cognitive_memory_procedure_recall_unified.rs` |
 
 ---
 
@@ -411,6 +491,24 @@ In `src/ooda_loop/cycle.rs` tests module:
 | `procedure_name_contains_objective_derived_triggers`          | `derive_triggers_from_objective` populates `#NNNN` PR numbers and `.ext` file extensions into the name, deduplicated against base triggers, base-first order preserved |
 | `derive_triggers_handles_no_pr_or_ext_match`                  | Objective without `#N` and without `.ext` → derived list empty, name omits extras, no panic |
 | `failed_outcomes_do_not_store_procedures`                     | Regression guard for the existing "successes only" rule |
+
+### Unified recall regression gates (ws2 #2295)
+
+In `tests/cognitive_memory_procedure_recall_unified.rs` — run against
+the live `cognitive_memory.ladybug` schema via
+`NativeCognitiveMemory::in_memory` (real `lbug::Database` + real
+`SCHEMA_DDL`, no storage-layer mocks):
+
+| Test                                                          | Coverage                                          |
+|---------------------------------------------------------------|---------------------------------------------------|
+| `distilled_procedure_with_foo_bar_trigger_surfaces_for_foo_objective` | A `foo,bar`-triggered procedure surfaces under objective `"fix the foo issue"`; recalled name is byte-for-byte intact (no mid-word truncation) |
+| `bootstrap_and_distilled_pr_merge_procedures_both_surface`    | Bootstrap **and** distilled `pr-merge` procedures both surface through the unified path |
+| `recall_is_case_insensitive_via_consistent_lowercase_folding` | Lowercase-stored procedure is hit by a SHOUTED uppercase objective (write/read case-folding invariant) |
+| `derived_triggers_no_longer_emit_sub_three_char_extensions`  | 1/2-char file extensions dropped; 3+ char extensions kept (read/write floor alignment) |
+| `distilled_procedure_surfaces_through_prepare_turn_context`  | End-to-end through the **fixed call site** `base_type_turn::prepare_turn_context` — catches a future revert even if the shared helper stays correct |
+
+Outside-in CLI gate: `tests/gadugi/procedure-recall-unified.yaml`
+drives each gate via `gadugi-test run`.
 
 ---
 

--- a/src/base_type_turn.rs
+++ b/src/base_type_turn.rs
@@ -67,7 +67,20 @@ pub fn prepare_turn_context(
     };
 
     let procedures = match memory_bridge {
-        Some(bridge) => bridge.recall_procedure(objective, MAX_PROCEDURES)?,
+        // ws2 #2295: route base-type adapter recall through the same
+        // tokenized helper the OODA preparation phase uses. The
+        // previous direct `recall_procedure(objective, MAX_PROCEDURES)`
+        // call passed the entire natural-language objective to a
+        // single Cypher CONTAINS, which never matched any stored
+        // procedure name and starved the prompt of distilled
+        // procedures regardless of how many cycles had run. See
+        // `crate::memory_consolidation::recall_procedures_for_objective`
+        // for the unification contract and case-folding invariant.
+        Some(bridge) => crate::memory_consolidation::recall_procedures_for_objective(
+            bridge,
+            objective,
+            MAX_PROCEDURES,
+        )?,
         None => Vec::new(),
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,7 +263,7 @@ pub use memory_consolidation::{
     FactExtraction, PreparedContext, consolidation_intake, consolidation_persistence,
     execution_memory_operations, intake_memory_operations, persistence_memory_operations,
     preparation_memory_operations, preparation_memory_operations_with_active_slugs,
-    reflection_memory_operations,
+    recall_procedures_for_objective, reflection_memory_operations,
 };
 pub use ooda_actions::dispatch_actions;
 pub use ooda_loop::{

--- a/src/memory_consolidation/mod.rs
+++ b/src/memory_consolidation/mod.rs
@@ -231,31 +231,14 @@ pub fn preparation_memory_operations_with_active_slugs(
     // (problem 3) are useless without this fan-out.
     let tokens = tokenize_objective(objective);
 
-    // Recall procedures that might be relevant. When the objective
-    // produces no usable tokens we still fall back to the original
-    // single-string call so callers that pass a structured query
-    // (e.g. exact procedure name) keep working.
-    let recalled_procedures = if tokens.is_empty() {
-        bridge.recall_procedure(objective, 5)?
-    } else {
-        let mut by_id: std::collections::HashMap<String, CognitiveProcedure> =
-            std::collections::HashMap::new();
-        for tok in &tokens {
-            let hits = bridge.recall_procedure(tok, 5)?;
-            for p in hits {
-                by_id.entry(p.node_id.clone()).or_insert(p);
-            }
-        }
-        let mut out: Vec<CognitiveProcedure> = by_id.into_values().collect();
-        // Highest usage_count first, then name for determinism.
-        out.sort_by(|a, b| {
-            b.usage_count
-                .cmp(&a.usage_count)
-                .then_with(|| a.name.cmp(&b.name))
-        });
-        out.truncate(5);
-        out
-    };
+    // Recall procedures via the unified tokenized helper (ws2 #2295).
+    // Both bootstrap procedures (`*-bootstrap`) seeded by
+    // `seed_bootstrap_procedures` and distilled procedures emitted each
+    // cycle by `ooda_loop::cycle::compose_procedure_name` go through the
+    // exact same `bridge.recall_procedure(token, …)` Cypher CONTAINS path
+    // so neither class can win or lose recall relative to the other.
+    let recalled_procedures =
+        recall_procedures_for_objective_with_tokens(bridge, objective, &tokens, 5)?;
 
     // PR-C (issue #2281, problem 4): episodic recall.
     //
@@ -327,7 +310,8 @@ const TOKEN_STOPWORDS: &[&str] = &[
 ];
 
 /// Tokenize the objective text into keywords for
-/// [`CognitiveMemoryOps::search_episodes_by_keywords`].
+/// [`CognitiveMemoryOps::search_episodes_by_keywords`] **and** for
+/// procedural recall via [`recall_procedures_for_objective`].
 ///
 /// Steps (in order):
 /// 1. Split on non-alphanumeric runs (so `#2281` becomes `2281`,
@@ -340,7 +324,14 @@ const TOKEN_STOPWORDS: &[&str] = &[
 /// Returns an empty vec when the objective produces no usable
 /// tokens; callers should skip the bridge call in that case
 /// (per the episodic-recall spec — no "match anything" fallback).
-fn tokenize_objective(objective: &str) -> Vec<String> {
+///
+/// Pub-crate so [`crate::base_type_turn`] can share the same tokenizer
+/// and procedural recall as the OODA cycle preparation phase. The
+/// 3-character minimum is the **read-side floor** that the write-side
+/// `derive_triggers_from_objective` aligns against — see
+/// `docs/reference/cognitive-memory-bootstrap-procedures.md` for the
+/// full contract.
+pub(crate) fn tokenize_objective(objective: &str) -> Vec<String> {
     let mut out: Vec<String> = Vec::new();
     let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
     let lowered = objective.to_ascii_lowercase();
@@ -356,6 +347,114 @@ fn tokenize_objective(objective: &str) -> Vec<String> {
         }
     }
     out
+}
+
+/// Unified procedural-recall helper used by both the OODA cycle's
+/// preparation phase ([`preparation_memory_operations_with_active_slugs`])
+/// and the base-type-adapter turn preparation
+/// ([`crate::base_type_turn::prepare_turn_context`]).
+///
+/// **Why a shared helper.** Before ws2 #2295, the two call sites used
+/// different recall strategies:
+///
+/// * Preparation phase tokenized the objective and fanned out one
+///   `recall_procedure` call per token (PR-C, #2281), which surfaces
+///   both bootstrap procedures (`pr-merge:bootstrap`, …) and distilled
+///   procedures written by the OODA cycle's
+///   [`crate::ooda_loop::cycle::compose_procedure_name`].
+/// * Base-type adapters passed the **entire raw objective** to a single
+///   `bridge.recall_procedure(objective, 5)` call. The Cypher
+///   `name CONTAINS '<full objective>'` clause never matched any
+///   stored procedure because no procedure name embeds a natural
+///   sentence. Effect: zero distilled procedures ever reached the
+///   prompt unless the operator's prompt happened to literally
+///   contain a procedure name.
+///
+/// Unifying both sites here means the same set of procedures surfaces
+/// regardless of which adapter is driving the turn, and prevents a
+/// future divergence by giving callers one obvious entry point.
+///
+/// **Case-folding contract.** [`tokenize_objective`] lowercases every
+/// token; both [`crate::cognitive_memory::bootstrap_procedures::BOOTSTRAP_PROCEDURES`]
+/// and [`crate::ooda_loop::cycle::compose_procedure_name`] emit names
+/// whose trigger portion is already lowercase. The Cypher `CONTAINS`
+/// operator is case-sensitive, so the all-lowercase invariant on both
+/// sides is what makes recall actually fire.
+///
+/// **Empty-token fallback.** When the objective produces no tokens
+/// of three or more chars (very short or punctuation-only input), we
+/// issue a single `recall_procedure(objective, max)` call so callers
+/// that pass a pre-tokenized or exact-name query keep working.
+pub fn recall_procedures_for_objective(
+    bridge: &dyn CognitiveMemoryOps,
+    objective: &str,
+    max: u32,
+) -> SimardResult<Vec<CognitiveProcedure>> {
+    let tokens = tokenize_objective(objective);
+    recall_procedures_for_objective_with_tokens(bridge, objective, &tokens, max)
+}
+
+/// Token-aware inner form of [`recall_procedures_for_objective`].
+///
+/// Lets the OODA preparation phase reuse the same tokenization it
+/// already computed for episodic recall instead of paying for a second
+/// pass over the objective string.
+pub(crate) fn recall_procedures_for_objective_with_tokens(
+    bridge: &dyn CognitiveMemoryOps,
+    objective: &str,
+    tokens: &[String],
+    max: u32,
+) -> SimardResult<Vec<CognitiveProcedure>> {
+    if tokens.is_empty() {
+        // Empty-token fallback (see doc on
+        // `recall_procedures_for_objective`).
+        let mut hits = bridge.recall_procedure(objective, max)?;
+        hits.truncate(max as usize);
+        return Ok(hits);
+    }
+
+    let per_token_cap = max;
+    let mut by_id: std::collections::HashMap<String, CognitiveProcedure> =
+        std::collections::HashMap::new();
+    for tok in tokens {
+        let hits = bridge.recall_procedure(tok, per_token_cap)?;
+        for p in hits {
+            by_id.entry(p.node_id.clone()).or_insert(p);
+        }
+    }
+    let mut out: Vec<CognitiveProcedure> = by_id.into_values().collect();
+    // Highest usage_count first, then name for determinism.
+    out.sort_by(|a, b| {
+        b.usage_count
+            .cmp(&a.usage_count)
+            .then_with(|| a.name.cmp(&b.name))
+    });
+    out.truncate(max as usize);
+
+    // Structured tracing event so the journal records exactly which
+    // procedure names surfaced. The previous summary-count-only log
+    // line ("prepared context (… N procedures …)") hid which
+    // procedures actually fired, which made it impossible for
+    // operators to tell whether distilled procedures were being
+    // recalled or only the bootstrap set. Names are emitted as a
+    // single comma-separated structured field so a downstream JSON
+    // log layer captures each name in full (no per-field truncation).
+    if !out.is_empty() {
+        let names: Vec<&str> = out.iter().map(|p| p.name.as_str()).collect();
+        tracing::info!(
+            procedure_count = out.len(),
+            tokens = ?tokens,
+            procedure_names = %names.join(" | "),
+            "recalled procedures for objective",
+        );
+    } else {
+        tracing::debug!(
+            tokens = ?tokens,
+            "no procedures recalled for objective",
+        );
+    }
+
+    Ok(out)
 }
 
 /// Execution phase: record PTY output as sensory observations.

--- a/src/memory_consolidation/mod.rs
+++ b/src/memory_consolidation/mod.rs
@@ -423,11 +423,18 @@ pub(crate) fn recall_procedures_for_objective_with_tokens(
         }
     }
     let mut out: Vec<CognitiveProcedure> = by_id.into_values().collect();
-    // Highest usage_count first, then name for determinism.
+    // Highest usage_count first, then name, then node_id for a fully
+    // deterministic order. Procedure names are NOT unique (only the
+    // graph `id` is) — repeated OODA cycles can store the same composed
+    // name under different `node_id`s. Without the `node_id` tiebreaker a
+    // `usage_count`+`name` tie would fall through to unordered
+    // `HashMap::into_values()` iteration, so `truncate` could keep a
+    // different procedure across runs and silently vary prompt contents.
     out.sort_by(|a, b| {
         b.usage_count
             .cmp(&a.usage_count)
             .then_with(|| a.name.cmp(&b.name))
+            .then_with(|| a.node_id.cmp(&b.node_id))
     });
     out.truncate(max as usize);
 

--- a/src/ooda_loop/cycle.rs
+++ b/src/ooda_loop/cycle.rs
@@ -371,8 +371,24 @@ fn run_ooda_cycle_inner(
             );
             let steps = [outcome.action.description.clone(), outcome.detail.clone()];
             if let Err(e) = bridges.memory.store_procedure(&proc_name, &steps, &[]) {
+                tracing::warn!(
+                    procedure_name = %proc_name,
+                    error = %e,
+                    "OODA consolidation: procedural memory store failed",
+                );
                 eprintln!("[simard] OODA consolidation: procedural memory failed: {e}");
             } else {
+                // ws2 #2295: structured tracing event in addition to the
+                // eprintln! line. The structured `procedure_name` field is
+                // written verbatim by every fmt layer (JSON and the
+                // default human formatter) and bypasses any line-length
+                // truncation a downstream log shipper might apply to the
+                // free-form message — making "is my trigger list
+                // truncated?" an answerable question from the journal.
+                tracing::info!(
+                    procedure_name = %proc_name,
+                    "OODA consolidation: stored procedure",
+                );
                 eprintln!("[simard] OODA consolidation: stored procedure '{proc_name}'");
             }
         }
@@ -768,9 +784,20 @@ pub fn derive_triggers_from_objective(objective: &str, action_desc: &str) -> Vec
         }
     }
 
-    // Pass 2: file extensions — `.<ext>` where `<ext>` is 1..=5 alphanumeric
+    // Pass 2: file extensions — `.<ext>` where `<ext>` is 3..=5 alphanumeric
     // characters starting with a letter, terminated by a non-alphanumeric
     // boundary or end-of-string.
+    //
+    // The 3-character lower bound aligns with the **read-side** floor
+    // enforced by `memory_consolidation::tokenize_objective`, which
+    // drops every objective-derived token shorter than 3 chars. A
+    // 1- or 2-char derived trigger (`g`, `rs`, …) can therefore never
+    // be matched by a future tokenized recall query — it would only
+    // sit in the procedure name as visible-but-dead weight and, when
+    // it appears as the trailing trigger, look exactly like the
+    // mid-word truncation symptom reported in ws2 #2295. Aligning the
+    // floors removes that confusion without losing any real recall
+    // power.
     {
         let bytes = combined.as_bytes();
         let mut i = 0;
@@ -782,7 +809,7 @@ pub fn derive_triggers_from_objective(objective: &str, action_desc: &str) -> Vec
                 }
                 let ext_len = j - i - 1;
                 let at_word_boundary = j == bytes.len() || !bytes[j].is_ascii_alphanumeric();
-                if (1..=5).contains(&ext_len) && at_word_boundary {
+                if (3..=5).contains(&ext_len) && at_word_boundary {
                     let ext = &combined[i + 1..j];
                     let key = ext.to_ascii_lowercase();
                     if seen.insert(key.clone()) {

--- a/src/ooda_loop/mod.rs
+++ b/src/ooda_loop/mod.rs
@@ -67,3 +67,4 @@ pub fn act(
 }
 
 pub use cycle::run_ooda_cycle;
+pub use cycle::{compose_procedure_name, derive_triggers_from_objective};

--- a/src/ooda_loop/tests_pr_c_procedures.rs
+++ b/src/ooda_loop/tests_pr_c_procedures.rs
@@ -110,23 +110,26 @@ fn compose_name_for_run_improvement_uses_ci_fix_pattern() {
 }
 
 /// `derive_triggers_from_objective` extracts `#NNNN` PR numbers
-/// and file extensions like `.rs`. Both must end up in the returned
+/// and file extensions like `.toml`. Both must end up in the returned
 /// list (lowercased, deduplicated), and `compose_procedure_name`
 /// folds them into the rendered name.
+///
+/// File extensions must be at least 3 characters (aligned with the
+/// read-side `tokenize_objective` floor in `memory_consolidation` —
+/// shorter tokens can never be matched by tokenized recall and only
+/// add visual noise that resembles trailing-token truncation).
 #[test]
 fn procedure_name_contains_objective_derived_triggers() {
-    let derived = derive_triggers_from_objective(
-        "merge PR #2281 fixing src/ooda_loop/cycle.rs",
-        "engineer review",
-    );
+    let derived =
+        derive_triggers_from_objective("merge PR #2281 fixing config.toml", "engineer review");
     let derived_set: std::collections::HashSet<&str> = derived.iter().map(|s| s.as_str()).collect();
     assert!(
         derived_set.contains("2281"),
         "derived triggers must include the PR number '2281'; got: {derived_set:?}"
     );
     assert!(
-        derived_set.contains("rs"),
-        "derived triggers must include the file extension 'rs'; got: {derived_set:?}"
+        derived_set.contains("toml"),
+        "derived triggers must include the file extension 'toml'; got: {derived_set:?}"
     );
 
     // End-to-end: compose_procedure_name must surface those captures
@@ -134,7 +137,7 @@ fn procedure_name_contains_objective_derived_triggers() {
     let name = compose_procedure_name(
         ActionKind::AdvanceGoal,
         Some("fix-cog-mem"),
-        "merge PR #2281 fixing src/ooda_loop/cycle.rs",
+        "merge PR #2281 fixing config.toml",
         "engineer review",
     );
     assert!(
@@ -142,8 +145,8 @@ fn procedure_name_contains_objective_derived_triggers() {
         "rendered name must contain '2281' from objective; got: {name}"
     );
     assert!(
-        name.contains("rs"),
-        "rendered name must contain 'rs' file-extension capture; got: {name}"
+        name.contains("toml"),
+        "rendered name must contain 'toml' file-extension capture; got: {name}"
     );
 
     // Base triggers must still appear FIRST in the trigger list per
@@ -189,12 +192,12 @@ fn derive_triggers_handles_no_pr_or_ext_match() {
 }
 
 /// Derived triggers must dedupe against base triggers and against
-/// each other. An objective like "merge PR #2281 #2281 .rs .rs" must
+/// each other. An objective like "merge PR #2281 #2281 .toml .toml" must
 /// not produce duplicate keywords in the rendered name.
 #[test]
 fn derived_triggers_dedupe_against_base_and_self() {
     let derived = derive_triggers_from_objective(
-        "merge merge PR #2281 #2281 file.rs cycle.rs",
+        "merge merge PR #2281 #2281 config.toml manifest.toml",
         "duplicate test",
     );
 
@@ -204,10 +207,10 @@ fn derived_triggers_dedupe_against_base_and_self() {
         count_2281, 1,
         "derived triggers must self-dedupe; '2281' appeared {count_2281} times"
     );
-    let count_rs = derived.iter().filter(|s| *s == "rs").count();
+    let count_toml = derived.iter().filter(|s| *s == "toml").count();
     assert_eq!(
-        count_rs, 1,
-        "derived triggers must self-dedupe; 'rs' appeared {count_rs} times"
+        count_toml, 1,
+        "derived triggers must self-dedupe; 'toml' appeared {count_toml} times"
     );
 
     // "merge" is a base trigger; it must NOT appear in derived (which
@@ -215,5 +218,37 @@ fn derived_triggers_dedupe_against_base_and_self() {
     assert!(
         !derived.iter().any(|s| s == "merge"),
         "derived triggers must not duplicate base triggers; got: {derived:?}"
+    );
+}
+
+/// ws2 #2295: short file-extension matches (1- or 2-char) must NOT
+/// produce derived triggers. The read-side `tokenize_objective` floors
+/// at 3 chars, so any sub-3-char trigger in a procedure name is dead
+/// weight that can never be matched — and when it lands as the
+/// trailing trigger it looks like the mid-word truncation symptom
+/// users have flagged (a name ending in `…,distill,g`).
+#[test]
+fn derive_triggers_rejects_short_file_extensions() {
+    // `.g` (1 char), `.rs` (2 chars), `.go` (2 chars), `.py` (2 chars)
+    // are all valid file-extension shapes that the read-side
+    // tokenizer cannot match. They must be dropped.
+    let derived = derive_triggers_from_objective(
+        "touch .g read cycle.rs build main.go ship script.py",
+        "short-ext probe",
+    );
+    for shorty in ["g", "rs", "go", "py"] {
+        assert!(
+            !derived.iter().any(|t| t == shorty),
+            "1- and 2-char file extensions must not be emitted as derived triggers; \
+             got '{shorty}' in {derived:?}"
+        );
+    }
+
+    // 3-char extensions are still accepted — they ARE matchable by
+    // tokenize_objective.
+    let kept = derive_triggers_from_objective("update vars.tfvars and config.toml", "");
+    assert!(
+        kept.iter().any(|t| t == "toml"),
+        "3+ char extensions must still be extracted; got: {kept:?}"
     );
 }

--- a/tests/cognitive_memory_procedure_recall_unified.rs
+++ b/tests/cognitive_memory_procedure_recall_unified.rs
@@ -46,7 +46,7 @@ use simard::cognitive_memory::bootstrap_procedures::{
 };
 use simard::cognitive_memory::{CognitiveMemoryOps, NativeCognitiveMemory};
 use simard::ooda_loop::{ActionKind, compose_procedure_name, derive_triggers_from_objective};
-use simard::recall_procedures_for_objective;
+use simard::{prepare_turn_context, recall_procedures_for_objective};
 
 // ────────────────────────────────────────────────────────────────────────────
 // Helpers
@@ -258,4 +258,53 @@ fn derived_triggers_no_longer_emit_sub_three_char_extensions() {
              got: {kept:?}"
         );
     }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Gate 5: end-to-end through the base-type adapter call site
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Gates 1–3 exercise the unified helper directly. This gate drives the
+/// **actual fixed call site** —
+/// [`simard::prepare_turn_context`] (the base-type adapter turn
+/// preparation that exhibited the cycle-238 symptom) — end to end, so a
+/// future revert of that specific call site back to a raw
+/// `recall_procedure(objective, …)` call is caught here even though the
+/// shared helper itself would still be correct.
+///
+/// Before ws2 #2295, `prepare_turn_context` passed the entire raw
+/// objective sentence to `recall_procedure`, so a distilled procedure
+/// was invisible to the prompt regardless of trigger match. This gate
+/// stores a distilled procedure and asserts it surfaces in the resulting
+/// [`simard::TurnContext::procedures`] list under a matching objective.
+#[test]
+#[serial(cognitive_memory)]
+fn distilled_procedure_surfaces_through_prepare_turn_context() {
+    let mem = NativeCognitiveMemory::in_memory()
+        .expect("construct in-memory NativeCognitiveMemory with real SCHEMA_DDL");
+
+    // Store a distilled-shape procedure whose trigger matches a token in
+    // the objective below ("payload").
+    let stored_name = make_name("payload-recall", "g7", "payload,inspect");
+    mem.store_procedure(&stored_name, &["inspect the payload".to_string()], &[])
+        .expect("store distilled procedure");
+
+    // Drive the real base-type adapter preparation path. Knowledge bridge
+    // is None (not configured) — exactly the engineer/base-type turn shape.
+    let context = prepare_turn_context("inspect the payload before shipping", Some(&mem), None)
+        .expect("prepare_turn_context must not error with a live memory bridge");
+
+    let names: Vec<&str> = context.procedures.iter().map(|p| p.name.as_str()).collect();
+    assert!(
+        names.contains(&stored_name.as_str()),
+        "distilled procedure '{stored_name}' must surface in prepare_turn_context \
+         output (the cycle-238 fix); got: {names:?}",
+    );
+
+    // The full-sentence-CONTAINS regression would return zero procedures
+    // here; assert the prompt context is non-empty as a second guard.
+    assert!(
+        !context.procedures.is_empty(),
+        "base-type adapter turn must recall at least the matching distilled procedure",
+    );
 }

--- a/tests/cognitive_memory_procedure_recall_unified.rs
+++ b/tests/cognitive_memory_procedure_recall_unified.rs
@@ -1,0 +1,261 @@
+//! Regression gate for ws2 #2295: distilled procedures must surface in
+//! the OODA preparation phase and in base-type adapter turn preparation
+//! through the same unified, tokenized recall path used by bootstrap
+//! procedures.
+//!
+//! **Why this test exists.**
+//! Prior to ws2 #2295, two recall paths coexisted:
+//!
+//! 1. `memory_consolidation::preparation_memory_operations_with_active_slugs`
+//!    tokenized the objective text (PR-C, #2281) and fanned out per-token
+//!    `recall_procedure` calls, deduped by `node_id`, and so surfaced both
+//!    bootstrap procedures and distilled procedures whose trigger lists
+//!    overlapped any token >= 3 chars.
+//! 2. `base_type_turn::prepare_turn_context` (used by the engineer /
+//!    base-type adapters) passed the **entire raw objective sentence** to
+//!    a single `recall_procedure(objective, 5)` call. The Cypher
+//!    `name CONTAINS '<full sentence>'` predicate never matched any
+//!    stored procedure because no procedure name embeds a natural
+//!    sentence. Effect: a steady-state of 3 bootstrap procedures
+//!    surfacing while the 3 distilled procedures written every cycle
+//!    were invisible to the prompt — exactly the
+//!    "only the PR-C bootstrap procedures ever appear" symptom in the
+//!    cycle 238 report.
+//!
+//! The unified helper
+//! [`simard::recall_procedures_for_objective`] is the single entry point
+//! both adapters now share. This gate locks the contract: every required
+//! invariant fails the build if it regresses.
+//!
+//! **Live schema.** The test runs against [`NativeCognitiveMemory::in_memory`]
+//! which constructs a real `lbug::Database` and executes the real
+//! `SCHEMA_DDL` for the `cognitive_memory.ladybug` schema. There is no
+//! storage-layer mock anywhere in the call path: every Cypher statement
+//! exercised below hits LadybugDB and returns rows from the real graph.
+//!
+//! **Hermetic env.** The in-memory backend already isolates itself in a
+//! `tempfile::TempDir`, so no `SIMARD_STATE_ROOT` / `$HOME` mutation is
+//! needed — the harness simply asserts on returned values.
+
+#![cfg(unix)]
+
+use serial_test::serial;
+
+use simard::cognitive_memory::bootstrap_procedures::{
+    BOOTSTRAP_PROCEDURES, seed_bootstrap_procedures,
+};
+use simard::cognitive_memory::{CognitiveMemoryOps, NativeCognitiveMemory};
+use simard::ooda_loop::{ActionKind, compose_procedure_name, derive_triggers_from_objective};
+use simard::recall_procedures_for_objective;
+
+// ────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Wrap a literal trigger string in the standard PR-C name shape
+/// `{pattern}:{scope} | triggers: {csv}` so the regression-gate
+/// procedures look structurally identical to what
+/// `compose_procedure_name` emits in production.
+fn make_name(pattern: &str, scope: &str, triggers: &str) -> String {
+    format!("{pattern}:{scope} | triggers: {triggers}")
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Gate 1: explicit user spec — `foo bar` trigger / `foo` objective
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Mirrors the explicit regression test from the task spec:
+///
+/// 1. Store a procedure whose trigger string contains `foo bar`.
+/// 2. Run recall with an objective that contains `foo`.
+/// 3. The procedure is returned.
+/// 4. Its name (and so its trigger list) is intact — byte-for-byte
+///    identical to what was stored, no mid-word truncation.
+///
+/// Uses the live `cognitive_memory.ladybug` schema via
+/// `NativeCognitiveMemory::in_memory`.
+#[test]
+#[serial(cognitive_memory)]
+fn distilled_procedure_with_foo_bar_trigger_surfaces_for_foo_objective() {
+    let mem = NativeCognitiveMemory::in_memory()
+        .expect("construct in-memory NativeCognitiveMemory with real SCHEMA_DDL");
+
+    // 1. Store a distilled-shape procedure with the user-spec trigger.
+    let stored_name = make_name("foo-recall", "ad-hoc", "foo,bar");
+    let steps = [
+        "step-1: probe foo".to_string(),
+        "step-2: verify bar".to_string(),
+    ];
+    let prereqs: [String; 0] = [];
+    mem.store_procedure(&stored_name, &steps, &prereqs)
+        .expect("store procedure with foo,bar trigger");
+
+    // 2. Recall with an objective containing `foo`.
+    let hits = recall_procedures_for_objective(&mem, "fix the foo issue", 5)
+        .expect("unified recall pipeline must not error");
+
+    // 3. The procedure is returned (no other procedure stored, so the
+    //    expected match count is exactly 1).
+    let foo_hits: Vec<_> = hits.iter().filter(|p| p.name == stored_name).collect();
+    assert_eq!(
+        foo_hits.len(),
+        1,
+        "expected exactly one hit for the 'foo,bar' procedure under objective \
+         'fix the foo issue'; got: {:?}",
+        hits.iter().map(|p| &p.name).collect::<Vec<_>>(),
+    );
+
+    // 4. The recalled name MUST be byte-for-byte identical to what was
+    //    stored. Any mid-word truncation (the cycle-238 symptom — a
+    //    name ending in `,distill,g` instead of `,distill,general`)
+    //    would fail this assertion. Use exact comparison rather than
+    //    `contains` to refuse silent shortening.
+    let recalled = foo_hits[0];
+    assert_eq!(
+        recalled.name, stored_name,
+        "trigger list must round-trip intact; storage or read path corrupted the name",
+    );
+
+    // Double-belt: the explicit `bar` trigger must appear in the
+    // recalled name. A regression that drops trailing triggers would
+    // leave `foo` in place (it's earlier) but lose `bar`.
+    assert!(
+        recalled.name.contains("bar"),
+        "recalled name must still contain the 'bar' trigger; got: {}",
+        recalled.name,
+    );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Gate 2: bootstrap AND distilled procedures both surface
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Once the bootstrap set is seeded and a distilled procedure has been
+/// written for goal `g1`, an objective like "ready to merge PR #1234"
+/// must surface BOTH a bootstrap procedure (`pr-merge:bootstrap`) AND
+/// the distilled procedure (`pr-merge:g1`) — proving the unified path
+/// no longer treats the two sources differently.
+///
+/// This is the structural fix for the cycle-238 symptom: distilled
+/// procedures were invisible because adapters bypassed the tokenizer.
+#[test]
+#[serial(cognitive_memory)]
+fn bootstrap_and_distilled_pr_merge_procedures_both_surface() {
+    let mem = NativeCognitiveMemory::in_memory()
+        .expect("construct in-memory NativeCognitiveMemory with real SCHEMA_DDL");
+
+    // Seed the canonical bootstrap set.
+    let seeded = seed_bootstrap_procedures(&mem).expect("seed bootstrap procedures");
+    assert_eq!(
+        seeded,
+        BOOTSTRAP_PROCEDURES.len(),
+        "expected all bootstrap procedures to be newly seeded into an empty store",
+    );
+
+    // Write a distilled procedure scoped to goal `g1` — exactly what
+    // `ooda_loop::cycle` does on a successful AdvanceGoal outcome.
+    let distilled_name = compose_procedure_name(
+        ActionKind::AdvanceGoal,
+        Some("g1"),
+        "merge PR #1234 review change",
+        "engineer review change",
+    );
+    mem.store_procedure(
+        &distilled_name,
+        &["engineer review change".to_string()],
+        &[],
+    )
+    .expect("store distilled procedure for g1");
+
+    // Recall under an objective that should fire BOTH the bootstrap
+    // `merge` trigger and the distilled `g1` / `merge` triggers.
+    let hits = recall_procedures_for_objective(&mem, "ready to merge PR review", 10)
+        .expect("unified recall pipeline must not error");
+
+    let names: Vec<&str> = hits.iter().map(|p| p.name.as_str()).collect();
+
+    assert!(
+        names.contains(&"pr-merge:bootstrap | triggers: merge,pr,merge-pr,landing,ready-to-merge"),
+        "the bootstrap pr-merge procedure must surface; got: {names:?}"
+    );
+    assert!(
+        names.contains(&distilled_name.as_str()),
+        "the distilled pr-merge procedure ('{distilled_name}') must surface alongside the bootstrap; got: {names:?}"
+    );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Gate 3: case-folding consistency
+// ────────────────────────────────────────────────────────────────────────────
+
+/// The write path lowercases base/derived triggers (via
+/// `derive_triggers_from_objective` and the lowercase string literals in
+/// `BOOTSTRAP_PROCEDURES`). The read path lowercases tokens via
+/// `tokenize_objective`. Cypher `CONTAINS` is case-sensitive in
+/// Kuzu/lbug, so the round-trip only works if both sides agree on
+/// lowercase. This gate proves it: store with lowercase, recall with
+/// SHOUTED uppercase, and assert a hit.
+#[test]
+#[serial(cognitive_memory)]
+fn recall_is_case_insensitive_via_consistent_lowercase_folding() {
+    let mem = NativeCognitiveMemory::in_memory()
+        .expect("construct in-memory NativeCognitiveMemory with real SCHEMA_DDL");
+
+    // Stored name uses lowercase, which is the production invariant.
+    let stored_name = make_name("foo-recall", "ad-hoc", "foo,bar");
+    mem.store_procedure(&stored_name, &["step".to_string()], &[])
+        .expect("store lowercase-triggered procedure");
+
+    // Objective text uses SHOUTED uppercase. The tokenizer must
+    // lowercase before issuing the Cypher CONTAINS, otherwise the
+    // case-sensitive backend returns zero rows.
+    let hits = recall_procedures_for_objective(&mem, "FIX THE FOO ISSUE", 5)
+        .expect("unified recall pipeline must not error");
+
+    assert!(
+        hits.iter().any(|p| p.name == stored_name),
+        "uppercase objective must still hit the lowercase-stored procedure; \
+         got: {:?}",
+        hits.iter().map(|p| &p.name).collect::<Vec<_>>(),
+    );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Gate 4: short-token derived triggers no longer pollute names
+// ────────────────────────────────────────────────────────────────────────────
+
+/// The cycle-238 "trigger list looks truncated" symptom was driven by
+/// `derive_triggers_from_objective` emitting 1- or 2-char file
+/// extensions (`.g` → `g`, `.rs` → `rs`) that the read-side tokenizer
+/// could never match (it floors at 3 chars). When such a token landed
+/// as the trailing entry it visually mimicked mid-word truncation.
+///
+/// This gate proves the floor was raised and that 1/2-char extensions
+/// no longer appear in derived triggers, while 3+ char extensions
+/// still do.
+#[test]
+fn derived_triggers_no_longer_emit_sub_three_char_extensions() {
+    // Sub-3-char extensions: must be dropped.
+    let derived = derive_triggers_from_objective(
+        "touch .g read cycle.rs build main.go ship script.py",
+        "short-ext probe",
+    );
+    for shorty in ["g", "rs", "go", "py"] {
+        assert!(
+            !derived.iter().any(|t| t == shorty),
+            "1/2-char file extension '{shorty}' must NOT appear in derived triggers; \
+             got: {derived:?}"
+        );
+    }
+
+    // 3+ char extensions: still extracted.
+    let kept =
+        derive_triggers_from_objective("update config.toml and manifest.json plus index.html", "");
+    for keep in ["toml", "json", "html"] {
+        assert!(
+            kept.iter().any(|t| t == keep),
+            "3+ char file extension '{keep}' must still appear in derived triggers; \
+             got: {kept:?}"
+        );
+    }
+}

--- a/tests/gadugi/procedure-recall-unified.yaml
+++ b/tests/gadugi/procedure-recall-unified.yaml
@@ -1,0 +1,128 @@
+name: "Cognitive Memory — Unified Procedure Recall"
+description: >
+  Outside-in gate for ws2 #2295 (PR #2297): verifies that distilled
+  procedures emitted each OODA cycle surface in the prepared prompt
+  context through the SAME unified, tokenized recall path used by the
+  bootstrap procedures. Prior to the fix, base-type adapter turns passed
+  the entire raw objective sentence to a single Cypher `name CONTAINS
+  '<full sentence>'` query that never matched any stored procedure, so
+  only bootstrap procedures ever appeared in
+  `prepared context (… procedures …)`. These steps drive the new
+  live-schema regression gates in
+  `tests/cognitive_memory_procedure_recall_unified.rs`, which exercise
+  the real `cognitive_memory.ladybug` schema (no storage-layer mocks).
+version: "1.0.0"
+
+config:
+  timeout: 180000
+  retries: 1
+  parallel: false
+
+environment:
+  requires: []
+
+agents:
+  - name: "test-agent"
+    type: "cli"
+    config:
+      workingDirectory: "."
+      defaultTimeout: 180000
+      executionMode: "spawn"
+      captureOutput: true
+      ioConfig:
+        encoding: "utf8"
+        handleInteractivePrompts: false
+      logConfig:
+        logCommands: true
+        logOutput: true
+        logLevel: "info"
+
+steps:
+  - name: "Distilled procedure with a matching trigger surfaces for a matching objective"
+    agent: "test-agent"
+    action: "execute_command"
+    params:
+      command: >
+        cargo test --test cognitive_memory_procedure_recall_unified
+        distilled_procedure_with_foo_bar_trigger_surfaces_for_foo_objective
+        -- --nocapture --test-threads=1
+    timeout: 180000
+    expect:
+      exitCode: 0
+      outputContains:
+        - "test distilled_procedure_with_foo_bar_trigger_surfaces_for_foo_objective ... ok"
+
+  - name: "Bootstrap AND distilled procedures both surface under one objective"
+    agent: "test-agent"
+    action: "execute_command"
+    params:
+      command: >
+        cargo test --test cognitive_memory_procedure_recall_unified
+        bootstrap_and_distilled_pr_merge_procedures_both_surface
+        -- --nocapture --test-threads=1
+    timeout: 180000
+    expect:
+      exitCode: 0
+      outputContains:
+        - "test bootstrap_and_distilled_pr_merge_procedures_both_surface ... ok"
+
+  - name: "Recall is case-insensitive via consistent lowercase folding"
+    agent: "test-agent"
+    action: "execute_command"
+    params:
+      command: >
+        cargo test --test cognitive_memory_procedure_recall_unified
+        recall_is_case_insensitive_via_consistent_lowercase_folding
+        -- --nocapture --test-threads=1
+    timeout: 180000
+    expect:
+      exitCode: 0
+      outputContains:
+        - "test recall_is_case_insensitive_via_consistent_lowercase_folding ... ok"
+
+  - name: "Derived triggers no longer emit sub-three-char file extensions"
+    agent: "test-agent"
+    action: "execute_command"
+    params:
+      command: >
+        cargo test --test cognitive_memory_procedure_recall_unified
+        derived_triggers_no_longer_emit_sub_three_char_extensions
+        -- --nocapture --test-threads=1
+    timeout: 180000
+    expect:
+      exitCode: 0
+      outputContains:
+        - "test derived_triggers_no_longer_emit_sub_three_char_extensions ... ok"
+
+  - name: "Distilled procedure surfaces end-to-end through the base-type adapter call site"
+    agent: "test-agent"
+    action: "execute_command"
+    params:
+      command: >
+        cargo test --test cognitive_memory_procedure_recall_unified
+        distilled_procedure_surfaces_through_prepare_turn_context
+        -- --nocapture --test-threads=1
+    timeout: 180000
+    expect:
+      exitCode: 0
+      outputContains:
+        - "test distilled_procedure_surfaces_through_prepare_turn_context ... ok"
+
+assertions: []
+
+cleanup:
+  - name: "Test agent cleanup"
+    agent: "test-agent"
+    action: "cleanup"
+
+metadata:
+  tags:
+    - "cli"
+    - "cognitive-memory"
+    - "procedural-recall"
+    - "ooda"
+    - "regression"
+    - "ws2-2295"
+  priority: "high"
+  author: "copilot"
+  test_type: "outside-in"


### PR DESCRIPTION
## Summary

Distilled procedures emitted each OODA cycle were invisible to base-type
adapter turns because `base_type_turn::prepare_turn_context` passed the
entire raw objective sentence to a single `recall_procedure(objective,
MAX_PROCEDURES)` call. The Cypher `name CONTAINS '<full sentence>'`
predicate never matches any stored procedure (no procedure name embeds
a natural sentence), so the prompt only ever surfaced bootstrap
procedures regardless of how many cycles had run — exactly the
cycle-238 symptom: *"only the PR-C bootstrap procedures ever appear in
`prepared context (… procedures …)`"*.

The fix unifies both call sites on a single tokenized, dedup'd recall
helper, raises the derived-trigger floor to match the read-side
tokenizer, and locks the invariants with live-schema regression tests.

## Investigation outcome

| Suspect | Finding |
|---|---|
| Storage truncation in Ladybug | **NOT a bug.** `cognitive_memory/schema.rs` declares `Procedure.name STRING` with no length cap; `ops.rs::escape_cypher` does not truncate; `lbug` 0.15.3 source confirms no string truncation in the storage layer. |
| `tracing` log-formatter truncation | **NOT a bug.** `tracing_subscriber::fmt::layer()` and `.json()` do not truncate fields; `trace_collector.rs` does not truncate; the `eprintln!` in `cycle.rs` prints the full name. |
| Mid-word trigger truncation (`…,distill,g`) | **Misdiagnosed.** The trailing single-char `g` is a legitimate 1-char file-extension derived trigger that the read-side `tokenize_objective` could never match (it floors at 3 chars). It only *looked* like mid-word truncation. **Fix: raise derive floor to 3 chars** so it visually matches the read-side floor. |
| Case-folding inconsistency | **NOT a bug.** `tokenize_objective` lowercases; `compose_procedure_name` and `BOOTSTRAP_PROCEDURES` emit lowercase. Consistent. Regression test locks this invariant. |
| Retrieval-path divergence | **Real bug.** OODA prep uses tokenized recall (PR-C); base-type adapters used raw-sentence recall. **Fix: unify on a shared helper.** |

## Changes

### `src/memory_consolidation/mod.rs`
- Promote `tokenize_objective` to `pub(crate)` and document the 3-char read-side floor as the contract that derived triggers must align with.
- Add `pub fn recall_procedures_for_objective` (and a token-aware inner form) so OODA prep + base-type adapters share one entry point. Empty-token fallback preserves exact-name queries (used by `seed_bootstrap_procedures` idempotency check).
- Emit a structured `tracing::info!` event listing recalled procedure names.
- **Deterministic order (quality-audit follow-up, 1c658445):** add `node_id` as the final sort tiebreaker. Procedure names are *not* unique (only the graph `id` is) — repeated OODA cycles store the same composed name under different `node_id`s, so a `usage_count`+`name` tie previously fell through to unordered `HashMap` iteration and `truncate` could keep a different procedure across runs.

### `src/base_type_turn.rs`
- Route adapter procedural recall through the unified helper so distilled procedures actually reach the prompt.

### `src/ooda_loop/cycle.rs`
- Raise the file-extension trigger floor from 1 to 3 chars (same threshold `tokenize_objective` uses).
- Add `tracing::info!(procedure_name = %proc_name, …)` alongside the `eprintln!` consolidation log so the procedure name is captured verbatim in structured form.

### `src/ooda_loop/mod.rs` / `src/lib.rs`
- Re-export `compose_procedure_name`, `derive_triggers_from_objective`, and `recall_procedures_for_objective`.

### `docs/reference/cognitive-memory-bootstrap-procedures.md`
- Document the 3-char file-extension floor and its alignment with the read-side tokenizer, the unified tokenized recall path (with the case-folding + empty-token-fallback contracts and the `node_id` determinism tiebreaker), the new structured `tracing` events, and the new test surfaces. Corrected the now-stale 1–2 char extension examples (`auth.rs`→`rs`) to 3+ char (`Cargo.toml`→`toml`).

## Tests

### `src/ooda_loop/tests_pr_c_procedures.rs`
- Update extension fixtures from `.rs` (2 chars) to `.toml` / `.json` (3+ chars).
- New regression guard `derive_triggers_rejects_short_file_extensions`.

### `tests/cognitive_memory_procedure_recall_unified.rs` (new)
Five regression gates running against the **live `cognitive_memory.ladybug` schema** via `NativeCognitiveMemory::in_memory` (real `lbug::Database` + real `SCHEMA_DDL`, **no storage-layer mocks**):

1. `distilled_procedure_with_foo_bar_trigger_surfaces_for_foo_objective` — explicit task spec: store with trigger `foo,bar`, recall with `fix the foo issue`, assert hit count == 1 and byte-for-byte name identity.
2. `bootstrap_and_distilled_pr_merge_procedures_both_surface` — seed `BOOTSTRAP_PROCEDURES`, store a distilled `pr-merge:g1`, assert both surface under `ready to merge PR review`.
3. `recall_is_case_insensitive_via_consistent_lowercase_folding` — store lowercase, recall SHOUTED uppercase, assert hit.
4. `derived_triggers_no_longer_emit_sub_three_char_extensions` — 1/2-char extensions dropped, 3+ char extensions kept.
5. `distilled_procedure_surfaces_through_prepare_turn_context` **(quality-audit follow-up, 1c658445)** — drives the **actual fixed call site** `base_type_turn::prepare_turn_context` end-to-end, so a future revert of that call site is caught even if the shared helper stays correct.

## Criterion 1 — QA-team (gadugi-test) evidence

New outside-in CLI gate `tests/gadugi/procedure-recall-unified.yaml` exercises all five regression gates.

```
$ gadugi-test validate -f tests/gadugi/procedure-recall-unified.yaml
✓ Scenario "Cognitive Memory — Unified Procedure Recall" is valid
✓ Valid files: 1   ✗ Invalid files: 0

$ gadugi-test run -d <dir>/procedure-recall-unified.yaml
✓ Loaded 1 scenario(s)
test distilled_procedure_with_foo_bar_trigger_surfaces_for_foo_objective ... ok
test bootstrap_and_distilled_pr_merge_procedures_both_surface ... ok
test recall_is_case_insensitive_via_consistent_lowercase_folding ... ok
test derived_triggers_no_longer_emit_sub_three_char_extensions ... ok
test distilled_procedure_surfaces_through_prepare_turn_context ... ok
✓ Passed: 1   ✗ Failed: 0   - Total: 1
✓ All tests passed!
```

## Criterion 3 — Quality-audit evidence (SEEK → VALIDATE → FIX)

Audited the diff (`src/memory_consolidation/mod.rs`, `src/base_type_turn.rs`, `src/ooda_loop/cycle.rs`, `tests/cognitive_memory_procedure_recall_unified.rs`) across **4 cycles**, ending clean. Base: `08db0525`; fixes committed in `1c658445`.

| Cycle | SEEK (findings) | VALIDATE | FIX |
|---|---|---|---|
| 1 | code-review: **0** correctness/security bugs. 1 *low* coverage observation — gates exercised the shared helper directly, not the `prepare_turn_context` call site that had the bug. | Confirmed: a revert of just that call site would not be caught. | Added Gate 5 end-to-end test (1c658445). |
| 2 | rubber-duck: 1 *medium* determinism — final sort ties on `usage_count`+`name`, but names are not unique, so tie-break fell to unordered `HashMap` iteration → nondeterministic prompt. 1 *low* doc nuance on the 3-char floor. | Confirmed via schema (`id` is the only unique key). | Added `node_id` tiebreaker; updated docs (1c658445). |
| 3 | code-review (final): 1 *low* doc inconsistency — stale `auth.rs`→`rs` example contradicted the new floor. Code paths A/B/C/E confirmed clean. | Confirmed internal doc contradiction. | Corrected example to `Cargo.toml`→`toml` (1c658445). |
| 4 | code-review (confirmation): **CLEAN** — zero critical/high, zero medium correctness/security, zero remaining doc contradictions. | — | — |

Final cycle is clean. Determinism fix verified: `node_id` is the dedup key, so every retained entry has a unique `node_id`, making the comparator a strict total order and `truncate` fully deterministic.

## Verification (criterion 4 — local)

```
cargo fmt --all -- --check                                  ✅ clean
cargo clippy --all-targets --all-features --locked -D warnings  ✅ clean
cargo test --lib (5682 tests)                               ✅ 5682 passed
cargo test --test cognitive_memory_procedure_recall_unified ✅ 5 passed
cargo test --lib memory_consolidation                       ✅ 50 passed
cargo test --lib ooda_loop::tests_pr_c_procedures           ✅ 9 passed
pre-push gate (release lib tests + clippy locked)           ✅ passed
```

CI on `1c658445`: all required checks green (see Checks tab).

## Merge-ready criteria

1. **QA-team** — ✅ `tests/gadugi/procedure-recall-unified.yaml`; `gadugi-test validate` + `run` output above (5/5 steps pass).
2. **Documentation** — ✅ `docs/reference/cognitive-memory-bootstrap-procedures.md` updated for every changed surface (floor, unified recall path, tracing, tests). User-facing reference doc, not just an internal note.
3. **Quality-audit** — ✅ 4 cycles (3 SEEK→VALIDATE→FIX + clean confirmation), SHAs `08db0525`→`1c658445`; table above.
4. **CI 100% green** — ✅ all required checks pass on `1c658445`.
5. **PR description with evidence** — ✅ this description (criteria 1–4, 6).
6. **Diff focused** — ✅ only the procedure-recall path, its tests, its gadugi gate, and its reference doc; no unrelated edits.

## Out of scope

Per task spec — deliberately untouched:
- The distillation pipeline / what procedures it writes.
- The OODA loop structure / cycle scheduling.
- The Ladybug graph schema (no storage change was needed).
- Fuzzy/embedding match for triggers — scope is exact/token match consistency.

Refs: ws2 #2295, PR-C #2281.

🤖 Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
