### PR TITLE
fix(cog-mem): make prospective triggers fire during OODA preparation (#2300)

### DIFF
--- a/docs/architecture/cognitive-memory.md
+++ b/docs/architecture/cognitive-memory.md
@@ -106,7 +106,7 @@ Planning   → store_prospective("re-run gym after self-improve", "self_improve_
 After work → check_triggers("fix auth bug: started engineer")  # returns triggered goal items
 ```
 
-See [Goal–prospective memory mirror](../reference/goal-prospective-memory-mirror.md) for the dual-write contract and reconciliation API.
+See [Goal–prospective memory mirror](../reference/goal-prospective-memory-mirror.md) for the dual-write contract and reconciliation API, and [Prospective-trigger firing](../reference/prospective-trigger-firing.md) for how stored triggers are matched against the OODA objective probe (issue #2300).
 
 ## Session Lifecycle Mapping
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -69,5 +69,6 @@ For multi-host coordination see [Distributed operations](distributed-operations.
 - [Cognitive Memory Architecture](architecture/cognitive-memory.md) (canonical, full detail)
 - [OODA procedural memory](reference/ooda-procedural-memory.md) — how successful OODA outcomes become procedures
 - [Goal–prospective memory mirror](reference/goal-prospective-memory-mirror.md) — how Active goals become prospective triggers
+- [Prospective-trigger firing](reference/prospective-trigger-firing.md) — how the OODA objective probe and case-insensitive match make stored triggers fire
 - [Dashboard](dashboard.md) — Memory tab
 - [Daemon mode](daemon-mode.md) — when consolidation runs

--- a/docs/reference/cognitive-memory-preparation-filters.md
+++ b/docs/reference/cognitive-memory-preparation-filters.md
@@ -7,6 +7,7 @@ doc_type: reference
 related:
   - ../architecture/cognitive-memory.md
   - ./goal-prospective-memory-mirror.md
+  - ./prospective-trigger-firing.md
   - ./ooda-procedural-memory.md
   - ./cognitive-memory-episodic-recall.md
   - ../memory.md

--- a/docs/reference/goal-prospective-memory-mirror.md
+++ b/docs/reference/goal-prospective-memory-mirror.md
@@ -8,6 +8,7 @@ related:
   - ./cognitive-memory-goal-store.md
   - ./goal-board-api.md
   - ./ooda-procedural-memory.md
+  - ./prospective-trigger-firing.md
   - ../concepts/goal-board-persistence.md
   - ../howto/reconcile-goal-prospective-drift.md
   - ../memory.md
@@ -195,6 +196,9 @@ Called by `put()` before every mirror write, and by
 
 ## Related reading
 
+- [Prospective-trigger firing](./prospective-trigger-firing.md) — the
+  read side: how the OODA objective probe is shaped and matched so the
+  prospective triggers written here actually fire (issue #2300).
 - [Goal fact dedup in preparation](../concepts/goal-fact-dedup-in-preparation.md)
   — how `preparation_memory_operations` loads and deduplicates goal
   facts using the shared constants.

--- a/docs/reference/prospective-trigger-firing.md
+++ b/docs/reference/prospective-trigger-firing.md
@@ -1,0 +1,378 @@
+---
+title: Prospective-trigger firing
+description: How OODA preparation makes prospective-memory triggers actually fire — the slug-phrase-enriched objective probe built in ooda_loop/cycle.rs and the case-insensitive substring match in cognitive_memory/ops.rs (issue #2300).
+last_updated: 2026-06-19
+owner: simard
+doc_type: reference
+related:
+  - ./goal-prospective-memory-mirror.md
+  - ./cognitive-memory-preparation-filters.md
+  - ./ooda-procedural-memory.md
+  - ../architecture/cognitive-memory.md
+  - ../memory.md
+---
+
+# Prospective-trigger firing
+
+> Shipped in issue [#2300](https://github.com/rysweet/Simard/issues/2300)
+> (fix the "prospective triggers never fire" defect). Companion to the
+> write side documented in
+> [Goal–prospective memory mirror](./goal-prospective-memory-mirror.md)
+> (issues [#2207](https://github.com/rysweet/Simard/issues/2207) /
+> [#2280](https://github.com/rysweet/Simard/issues/2280)).
+
+Active goals are mirrored into prospective memory as trigger-action pairs
+(see the [mirror reference](./goal-prospective-memory-mirror.md)). For
+those triggers to be useful they must **fire**: every OODA preparation
+pass calls `check_triggers(objective)` and surfaces the matches as
+`PreparedContext.triggered_prospectives`. This page documents the read
+side — how the objective probe is shaped so stored triggers match, and
+how the match itself is performed.
+
+---
+
+## The defect this fixes
+
+Before #2300, preparation logged the same line every cycle:
+
+```
+[simard] OODA cycle: prepared context (0 facts, 0 triggers, 5 procedures, 0 episodes)
+```
+
+The `0 triggers` was permanent: `check_triggers` never matched a stored
+prospective even though Active goals were being written correctly.
+
+**Root cause — classification (b), a read/match mismatch.** The write
+path was already correct and proven by the passing
+`put_active_goal_creates_prospective_trigger` test in
+`src/goals/cognitive_memory_store.rs`: putting an Active goal stores a
+`Prospective` whose `trigger_condition` is the goal **slug-phrase** (the
+slug with dashes replaced by spaces, e.g. `"fix authentication bug"`).
+Neither "nothing writes a trigger" (a) nor "both" applied.
+
+The failure was entirely on the read side, where two independent
+divergences each broke the substring match:
+
+1. **Content divergence (primary).** The OODA objective probe was built
+   only from active-goal **descriptions** joined with `"; "`. A goal's
+   free-text description (`"Fix the broken auth flow in the parser"`)
+   does not contain the slug-phrase (`"fix authentication bug"`)
+   verbatim, so the predicate `'{probe}' CONTAINS trigger_condition`
+   could not match.
+2. **Case divergence (secondary).** The match was case-sensitive.
+   Descriptions are written in natural title case (`"Fix ..."`) while
+   `trigger_condition` is lowercased by `goal_slug`, so even a probe that
+   happened to contain the right words would miss on case alone.
+
+The fix addresses both: it **enriches the probe** so the stored
+`trigger_condition` substring is guaranteed present, and **folds the
+match to case-insensitive** as a robustness safety net.
+
+The two changes are not co-equal. The probe enrichment is the
+**load-bearing** fix: the appended slug-phrase is byte-identical to the
+already-lowercase `trigger_condition`, so the goal-trigger path fires
+*even under the old case-sensitive predicate*. Case-folding is genuinely
+**defensive** — for the goal path it changes nothing, and it exists to
+generalise the guarantee to any prospective whose `trigger_condition`
+casing might differ from the probe (for example a non-goal prospective
+written with a mixed-case condition). This is why the sections below frame
+the content fix as primary and the case fix as a safety net.
+
+---
+
+## The match contract
+
+`check_triggers(content)` runs a single read-only Cypher query and
+returns every pending `Prospective` whose `trigger_condition` is a
+substring of `content`, compared case-insensitively:
+
+```rust
+fn check_triggers(&self, content: &str) -> SimardResult<Vec<CognitiveProspective>>;
+```
+
+```cypher
+MATCH (p:Prospective)
+WHERE p.status = 'pending'
+  AND toLower('{c}') CONTAINS toLower(p.trigger_condition)
+RETURN p.id, p.description, p.trigger_condition,
+       p.action_on_trigger, p.status, p.priority
+```
+
+where `{c}` is `escape_cypher(content)` — the caller-supplied probe,
+escaped exactly once at this boundary.
+
+Properties:
+
+- **Direction:** `content CONTAINS trigger_condition`. The probe is the
+  haystack; the stored trigger phrase is the needle. A short trigger
+  phrase matches a long objective, not the reverse.
+- **Case-insensitive:** both sides are wrapped in `toLower(...)`. A
+  mixed-case probe matches a lowercase `trigger_condition` and vice
+  versa.
+- **Pending only:** resolved/triggered entries are never returned. The
+  status lifecycle is `pending → triggered → resolved`.
+- **Read-only:** the method only issues `self.query(...)`. It performs no
+  writes and no `execute`.
+
+### Escaping and fold order (security invariant)
+
+`check_triggers` is the single escaping chokepoint for the probe. The
+ordering is **escape → interpolate → fold**:
+
+```rust
+let c = escape_cypher(content);        // 1. escape the literal once
+// 2. interpolate into the query string as '{c}'
+// 3. toLower('{c}') ... toLower(p.trigger_condition)   ← fold in Cypher
+```
+
+- Only the `'{c}'` literal is attacker-reachable; it is escaped before
+  interpolation. `p.trigger_condition` is a schema-controlled column
+  (written through the equally escaped `store_prospective`), so wrapping
+  it in `toLower(...)` introduces no new injection surface.
+- Folding happens **in Cypher** via `toLower(...)`, never by lowercasing
+  the raw string in Rust before escaping. If a future change folds in
+  Rust instead, it must be `escape_cypher(content.to_lowercase())` —
+  escape the already-lowercased string, never `to_lowercase()` an
+  already-escaped string.
+
+Quotes, backslashes, and newlines in the probe produce a valid,
+non-breaking query (they match nothing rather than altering the query),
+and this is covered by an injection-regression test.
+
+---
+
+## The objective probe: `build_objective_probe`
+
+For triggers to fire, the probe handed to `check_triggers` must contain
+the stored `trigger_condition` substring. `src/ooda_loop/cycle.rs`
+builds that probe with a small pure helper:
+
+```rust
+/// Build the OODA objective probe from the live active goals.
+///
+/// For each active goal the probe includes BOTH the goal's free-text
+/// description AND its slug-phrase (`goal_slug(id)` with dashes replaced
+/// by spaces). The slug-phrase is byte-identical to the
+/// `trigger_condition` written by the prospective mirror, which
+/// guarantees `check_triggers` can substring-match the stored trigger.
+///
+/// Pure in-memory string assembly: builds NO Cypher and performs NO
+/// escaping or interpolation. The result flows through
+/// `preparation_memory_operations_with_active_slugs` → `check_triggers`,
+/// where it is escaped exactly once.
+fn build_objective_probe(active: &[ActiveGoal]) -> String;
+```
+
+The helper replaces the previous inline construction in the prepare
+phase, which joined descriptions only:
+
+```rust
+// Before #2300 — descriptions only; never contained the slug-phrase.
+let objective_summary: String = state
+    .active_goals
+    .active
+    .iter()
+    .map(|g| g.description.as_str())
+    .collect::<Vec<_>>()
+    .join("; ");
+
+// After #2300 — descriptions + slug-phrases.
+let objective_summary = build_objective_probe(&state.active_goals.active);
+```
+
+### The slug-phrase invariant
+
+The probe and the stored trigger **must use the identical transform** or
+the substring match silently fails again. Both derive the phrase from the
+goal slug with dashes replaced by spaces:
+
+| Side  | Location | Expression |
+|-------|----------|------------|
+| Write | `prospective_trigger_for()` in `src/goals/cognitive_memory_store.rs` | `record.slug.replace('-', " ")` |
+| Read  | `build_objective_probe()` in `src/ooda_loop/cycle.rs` | `goal_slug(&g.id).replace('-', ' ')` |
+
+The stored `record.slug` is itself derived from `g.id`: the
+`GoalBoard → GoalRecord` adapter `active_goals_as_records()` in
+`src/goal_curation/operations.rs` sets `slug: goal_slug(&active.id)`. The
+write side then builds the trigger from that slug
+(`record.slug.replace('-', " ")`), making it exactly
+`goal_slug(g.id).replace('-', " ")`. The read side computes the same
+`goal_slug(&g.id).replace('-', ' ')`, so the two phrases are
+byte-identical **by construction** — this is why the probe must call
+`goal_slug(&g.id)` rather than using the raw `g.id` (which is not
+guaranteed to already be normalised; the adapter normalises it precisely
+because it may not be). Any future change must keep all three call sites
+in lock-step: the adapter's `goal_slug(&active.id)`,
+`prospective_trigger_for()`, and `build_objective_probe()`.
+
+### Probe shape
+
+The probe concatenates, per active goal, the description followed by the
+slug-phrase, so a single string carries both the human-readable objective
+text (useful for the fact/procedure/episode probes that share it) and the
+exact trigger needles:
+
+```
+Fix the broken auth flow in the parser fix authentication bug; \
+Refactor the gym scoring module refactor gym scoring
+```
+
+The leading description preserves the existing behaviour for the semantic
+fact search and procedure/episode recall that consume the same
+`objective_summary`; the appended slug-phrase is what makes the
+prospective trigger fire.
+
+---
+
+## End-to-end flow
+
+```
+GoalStore::put(Active goal "Fix authentication bug")
+  └─ store_prospective(
+        description       = "goal:Fix authentication bug",
+        trigger_condition = "fix authentication bug",   ← slug-phrase
+        action_on_trigger = "Pursue goal: ...",
+        priority          = 1)
+              │
+              ▼ (next OODA cycle, prepare phase)
+build_objective_probe(active)
+  = "... Fix authentication bug fix authentication bug; ..."   ← contains needle
+              │
+              ▼
+preparation_memory_operations_with_active_slugs(objective = probe, …)
+  └─ check_triggers(probe)
+        MATCH (p:Prospective)
+        WHERE p.status='pending'
+          AND toLower(probe) CONTAINS toLower("fix authentication bug")
+        → 1 row
+              │
+              ▼
+PreparedContext.triggered_prospectives = [ "goal:Fix authentication bug" ]
+```
+
+Log line after the fix (note the non-zero trigger count):
+
+```
+[simard] OODA cycle: prepared context (3 facts, 1 triggers, 5 procedures, 0 episodes)
+```
+
+---
+
+## Examples
+
+### Example 1 — single active goal fires
+
+Stored prospective: `trigger_condition = "fix authentication bug"`.
+
+```rust
+let probe = build_objective_probe(&[active("fix-authentication-bug",
+                                           "Fix the broken auth flow")]);
+// probe contains "fix authentication bug"
+let triggered = mem.check_triggers(&probe).unwrap();
+assert!(!triggered.is_empty());          // fires
+```
+
+### Example 2 — case-insensitive match
+
+A title-cased probe still matches a lowercase trigger:
+
+```rust
+mem.store_prospective("goal:Ship release", "ship release", "act", 1).unwrap();
+let triggered = mem.check_triggers("Time to SHIP RELEASE now").unwrap();
+assert_eq!(triggered.len(), 1);          // fires despite case
+```
+
+### Example 3 — no active goals, nothing fires
+
+```rust
+let probe = build_objective_probe(&[]);  // ""
+let triggered = mem.check_triggers(&probe).unwrap();
+assert!(triggered.is_empty());           // correct: no goals → no triggers
+```
+
+### Example 4 — unrelated objective does not match
+
+```rust
+mem.store_prospective("goal:Ship release", "ship release", "act", 1).unwrap();
+let triggered = mem.check_triggers("review the dashboard layout").unwrap();
+assert!(triggered.is_empty());           // correct: needle absent
+```
+
+---
+
+## Code location
+
+| Item                                | File                                          |
+|-------------------------------------|-----------------------------------------------|
+| `check_triggers` (match query)      | `src/cognitive_memory/ops.rs`                 |
+| `build_objective_probe`             | `src/ooda_loop/cycle.rs`                       |
+| Probe call site (prepare phase)     | `src/ooda_loop/cycle.rs`                       |
+| `prospective_trigger_for` (write)   | `src/goals/cognitive_memory_store.rs`         |
+| `store_prospective` (write)         | `src/cognitive_memory/ops.rs`                  |
+| Live consumer (`check_triggers(objective)`) | `src/memory_consolidation/mod.rs`     |
+
+> The live consumer in `src/memory_consolidation/mod.rs` is **not
+> modified** by #2300. It already passed the probe through to
+> `check_triggers`; the fix changes only what the probe *contains*
+> (cycle.rs) and how the match *compares* (ops.rs). Distillation and
+> episodic-recall code in that module are out of scope.
+
+---
+
+## Testing
+
+| Test                                                  | File | Coverage |
+|-------------------------------------------------------|------|----------|
+| Probe contains each active goal's slug-phrase         | `src/ooda_loop/cycle.rs` | `build_objective_probe` appends `goal_slug(id).replace('-', ' ')` per goal |
+| End-to-end fire (the regression reproduction)         | `src/cognitive_memory/ops.rs` | Store an Active-goal-style prospective, probe with a realistic enriched objective, assert `triggered > 0` |
+| Case-insensitive match                                | `src/cognitive_memory/ops.rs` | Mixed-case probe vs lowercase `trigger_condition` → fires |
+| Injection regression                                  | `src/cognitive_memory/ops.rs` | Probe with `'`, `\`, and newline → valid, non-breaking query, no match |
+
+The end-to-end test is the **TDD red** for #2300: it fails on `main`
+(0 triggers) and passes after the probe enrichment lands.
+
+### Existing tests that must stay green
+
+The case-fold is a permissive superset — anything that matched
+case-sensitively still matches once both sides are folded — so the
+pre-existing trigger tests in `src/cognitive_memory/ops.rs`
+(`check_triggers_matches_substring`, `check_triggers_returns_empty_on_no_match`,
+`check_triggers_only_returns_pending`) remain green. For example,
+`check_triggers_matches_substring` stores `trigger_condition = "FAIL"` and
+probes with `"build FAILED with errors"`; it matches under both the old
+case-sensitive predicate and the new folded one. The write-side proof
+(`put_active_goal_creates_prospective_trigger` in
+`src/goals/cognitive_memory_store.rs`) and the seven `escape_cypher_*`
+tests are likewise unaffected. Run the full suite with `cargo test`.
+
+---
+
+## Out of scope
+
+Deliberately excluded from #2300:
+
+- **Bootstrap seed triggers.** The fix repairs the existing
+  write → read → match path. It does **not** seed any prospective
+  triggers at startup; that is a separate concern.
+- **Distillation and episodic recall.** No changes to
+  `src/memory_consolidation/` distillation logic or episodic-recall
+  paths — those are owned by separate workstreams.
+- **Probe-length capping.** `CONTAINS` is `O(n·m)`; the active-goal count
+  is operationally small, so no cap is applied. A per-description length
+  cap is a possible future optimisation, not a requirement.
+
+---
+
+## Related reading
+
+- [Goal–prospective memory mirror](./goal-prospective-memory-mirror.md)
+  — the write side: how Active goals become prospective triggers and how
+  the slug-phrase `trigger_condition` is produced.
+- [Preparation-phase memory filters](./cognitive-memory-preparation-filters.md)
+  — the surrounding preparation pass and the shared `objective` probe and
+  `active_slugs` set.
+- [OODA procedural memory](./ooda-procedural-memory.md) — the sibling
+  recall surface that consumes the same objective string.
+- [Cognitive memory architecture](../architecture/cognitive-memory.md)
+  — the six-type memory model and the prospective lifecycle.
+- [Memory architecture](../memory.md) — the six memory types overview.

--- a/src/cognitive_memory/ops.rs
+++ b/src/cognitive_memory/ops.rs
@@ -506,9 +506,15 @@ impl CognitiveMemoryOps for NativeCognitiveMemory {
     }
 
     fn check_triggers(&self, content: &str) -> SimardResult<Vec<CognitiveProspective>> {
+        // Escape first, then interpolate, then case-fold both sides. Folding
+        // makes matching case-insensitive (#2300) so a goal's lowercase
+        // slug-phrase `trigger_condition` fires even when the OODA objective
+        // probe mentions the phrase in its original (mixed) case. The single
+        // escape chokepoint is preserved: `toLower` wraps the already-escaped
+        // literal, and `p.trigger_condition` is a schema-controlled column.
         let c = escape_cypher(content);
         let rows = self.query(&format!(
-            "MATCH (p:Prospective) WHERE p.status = 'pending' AND '{c}' CONTAINS p.trigger_condition RETURN p.id, p.description, p.trigger_condition, p.action_on_trigger, p.status, p.priority"
+            "MATCH (p:Prospective) WHERE p.status = 'pending' AND toLower('{c}') CONTAINS toLower(p.trigger_condition) RETURN p.id, p.description, p.trigger_condition, p.action_on_trigger, p.status, p.priority"
         ))?;
         Ok(rows
             .iter()
@@ -1001,6 +1007,84 @@ mod tests {
         assert!(
             triggered.is_empty(),
             "non-pending prospectives must not trigger"
+        );
+    }
+
+    // ── #2300 regression: prospective-triggers-never-fire ───────────────
+    //
+    // Root cause (b): the read/match path never fires a stored trigger when
+    // the OODA objective probe mentions the goal phrase in its original
+    // (mixed) case. An Active goal writes a prospective whose
+    // `trigger_condition` is the lowercase slug-phrase
+    // (`prospective_trigger_for` = `goal_slug(id).replace('-', " ")`), but a
+    // realistic objective probe carries the goal's phrase in mixed case.
+    // Under a case-SENSITIVE `CONTAINS`, the trigger never fires.
+
+    /// RED for #2300: storing an Active-goal-style prospective and probing
+    /// `check_triggers` with a realistic, mixed-case objective that contains
+    /// the goal phrase MUST fire the trigger. Fails on `main` (case-sensitive
+    /// CONTAINS); passes once matching is case-folded.
+    #[test]
+    fn check_triggers_fires_for_active_goal_objective() {
+        let mem = test_mem();
+        // Mirrors the live write path: description prefixed with `goal:`,
+        // trigger_condition is the lowercase slug-phrase.
+        mem.store_prospective(
+            "goal:Fix Authentication Bug",
+            "fix authentication bug",
+            "Pursue goal: Fix Authentication Bug",
+            1,
+        )
+        .unwrap();
+
+        // Realistic OODA objective text — same words, original (mixed) case.
+        let triggered = mem
+            .check_triggers("Investigate and Fix Authentication Bug in the login flow")
+            .unwrap();
+
+        assert!(
+            !triggered.is_empty(),
+            "an Active-goal prospective must fire when the objective probe \
+             mentions the goal phrase (case-insensitively); got {} triggers",
+            triggered.len()
+        );
+        assert!(
+            triggered.iter().any(|p| p.description.starts_with("goal:")),
+            "the fired trigger must be the goal: prospective"
+        );
+    }
+
+    /// RED for #2300: `check_triggers` matching MUST be case-insensitive.
+    /// A lowercase `trigger_condition` must fire against an UPPERCASE probe.
+    #[test]
+    fn check_triggers_is_case_insensitive() {
+        let mem = test_mem();
+        mem.store_prospective("watch", "deploy ci pipeline", "act", 2)
+            .unwrap();
+        let triggered = mem.check_triggers("DEPLOY CI PIPELINE now").unwrap();
+        assert_eq!(
+            triggered.len(),
+            1,
+            "trigger matching must be case-insensitive"
+        );
+        assert_eq!(triggered[0].trigger_condition, "deploy ci pipeline");
+    }
+
+    /// Security regression for #2300: a probe laden with Cypher-significant
+    /// characters (quote, backslash, newline, statement terminators) must not
+    /// break the generated query nor spuriously match. The single escape
+    /// chokepoint (`escape_cypher`) must remain intact under case-folding.
+    #[test]
+    fn check_triggers_handles_injection_chars_safely() {
+        let mem = test_mem();
+        mem.store_prospective("watch", "needle", "act", 1).unwrap();
+        let probe = "trouble '; MATCH (n) DETACH DELETE n; -- \\ \n \" end";
+        let triggered = mem
+            .check_triggers(probe)
+            .expect("injection-laden probe must not break the query");
+        assert!(
+            triggered.is_empty(),
+            "no trigger should match the injection probe"
         );
     }
 

--- a/src/ooda_loop/cycle.rs
+++ b/src/ooda_loop/cycle.rs
@@ -38,6 +38,39 @@ pub fn run_ooda_cycle(
     crate::ooda_brain::with_brain_judgment_scope(|| run_ooda_cycle_inner(state, bridges, config))
 }
 
+/// Build the OODA objective probe from the active goals.
+///
+/// The probe is fed to `check_triggers` (and fact/episode recall) during the
+/// Prepare phase. It concatenates, per active goal:
+///
+///   1. the free-text `description` — drives targeted fact/episode recall, and
+///   2. the goal's **slug-phrase** — `goal_slug(id)` with dashes→spaces.
+///
+/// The slug-phrase is exactly what `prospective_trigger_for`
+/// (`src/goals/cognitive_memory_store.rs`) writes as a goal's
+/// `trigger_condition`. Including it here is what lets `check_triggers` fire a
+/// goal's prospective memory (#2300, root cause (b)). Before this, the probe
+/// carried only free-text descriptions, which never contain the slug-derived
+/// trigger substring — so `check_triggers` matched nothing and the
+/// prospective subsystem was dead ("0 triggers" every OODA cycle).
+fn build_objective_probe(active: &[crate::goal_curation::ActiveGoal]) -> String {
+    let mut parts: Vec<String> = Vec::with_capacity(active.len() * 2);
+    for g in active {
+        let description = g.description.trim();
+        if !description.is_empty() {
+            parts.push(description.to_string());
+        }
+        // Byte-identical to the written `trigger_condition`: the store path
+        // uses `goal_slug(&active.id).replace('-', " ")` via
+        // `active_goals_as_records` + `prospective_trigger_for`.
+        let trigger_phrase = crate::goals::goal_slug(&g.id).replace('-', " ");
+        if !trigger_phrase.is_empty() {
+            parts.push(trigger_phrase);
+        }
+    }
+    parts.join("; ")
+}
+
 fn run_ooda_cycle_inner(
     state: &mut OodaState,
     bridges: &mut OodaBridges,
@@ -208,14 +241,10 @@ fn run_ooda_cycle_inner(
     eprintln!("[simard] OODA cycle: Observe complete");
 
     // --- Prepare: gather relevant context from cognitive memory ---
-    // Build an objective summary from active goals so memory retrieval is targeted.
-    let objective_summary: String = state
-        .active_goals
-        .active
-        .iter()
-        .map(|g| g.description.as_str())
-        .collect::<Vec<_>>()
-        .join("; ");
+    // Build an objective summary from active goals so memory retrieval is
+    // targeted. Includes each goal's slug-phrase so prospective `check_triggers`
+    // can fire the goal's trigger (#2300) — see `build_objective_probe`.
+    let objective_summary: String = build_objective_probe(&state.active_goals.active);
     // PR-A (issue #2281): build the live `active_slugs` set from
     // `active` + `backlog` so `preparation_memory_operations_with_active_slugs`
     // can drop stale `goal-store:record` facts whose slug is no longer
@@ -1245,5 +1274,96 @@ mod tests_board_integrity {
             .filter(|id| !post_active.contains(*id) && !archived.contains(*id))
             .collect();
         assert!(vanished.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod tests_objective_probe {
+    use super::build_objective_probe;
+    use crate::cognitive_memory::{CognitiveMemoryOps, NativeCognitiveMemory};
+    use crate::goal_curation::{ActiveGoal, GoalProgress};
+
+    fn active_goal(id: &str, description: &str) -> ActiveGoal {
+        ActiveGoal {
+            id: id.to_string(),
+            description: description.to_string(),
+            priority: 1,
+            status: GoalProgress::InProgress { percent: 0 },
+            assigned_to: None,
+            current_activity: None,
+            wip_refs: vec![],
+            last_progress_update_at: None,
+        }
+    }
+
+    /// The probe MUST contain each active goal's slug-phrase — the exact
+    /// substring `prospective_trigger_for` writes as the goal's
+    /// `trigger_condition`. Without it `check_triggers` can never fire a
+    /// goal's prospective memory during OODA preparation (#2300, cause (b)).
+    #[test]
+    fn probe_contains_goal_slug_phrase() {
+        let active = vec![active_goal(
+            "fix-authentication-bug",
+            "Investigate and repair the broken login path",
+        )];
+        let probe = build_objective_probe(&active);
+        let slug_phrase = crate::goals::goal_slug("fix-authentication-bug").replace('-', " ");
+        assert!(
+            probe.contains(&slug_phrase),
+            "probe must contain slug-phrase {slug_phrase:?}; got {probe:?}"
+        );
+    }
+
+    /// The probe must still carry the free-text description so targeted
+    /// fact/episode recall keeps working.
+    #[test]
+    fn probe_retains_goal_description() {
+        let active = vec![active_goal(
+            "deploy-ci-pipeline",
+            "Stand up the CI pipeline",
+        )];
+        let probe = build_objective_probe(&active);
+        assert!(
+            probe.contains("Stand up the CI pipeline"),
+            "probe must retain the goal description; got {probe:?}"
+        );
+    }
+
+    /// End-to-end (#2300): an Active goal's prospective — stored with the
+    /// slug-derived `trigger_condition` exactly as the live write path does —
+    /// MUST fire when `check_triggers` is probed with the objective summary
+    /// built by `build_objective_probe`. The goal's free-text description is
+    /// deliberately unrelated to the slug to prove the slug-phrase enrichment
+    /// (not the description) is what makes the trigger fire.
+    #[test]
+    fn objective_probe_fires_stored_goal_trigger() {
+        let mem = NativeCognitiveMemory::in_memory().expect("in-memory DB");
+
+        let goal_id = "improve-retrieval-latency";
+        // Mirror the live write path's trigger_condition derivation
+        // (active_goals_as_records + prospective_trigger_for).
+        let trigger_condition = crate::goals::goal_slug(goal_id).replace('-', " ");
+        mem.store_prospective(
+            "goal:Improve retrieval latency",
+            &trigger_condition,
+            "Pursue goal: Improve retrieval latency",
+            1,
+        )
+        .unwrap();
+
+        // Description shares no words with the slug, so only the appended
+        // slug-phrase can satisfy CONTAINS.
+        let active = vec![active_goal(goal_id, "Make the system snappier for users")];
+        let probe = build_objective_probe(&active);
+
+        let triggered = mem.check_triggers(&probe).unwrap();
+        assert!(
+            triggered
+                .iter()
+                .any(|p| p.trigger_condition == trigger_condition),
+            "objective probe must fire the stored goal trigger; probe={probe:?}, \
+             got {} triggers",
+            triggered.len()
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes the **prospective-triggers-never-fire** defect (#2300): memory preparation logged `prepared context (… 0 triggers …)` every OODA cycle and the prospective subsystem was dead.

## Root cause — (b) read/match mismatch

The **write** path works: an Active goal is mirrored to prospective memory with `trigger_condition = goal_slug(id)` (dashes→spaces, lowercase) via `prospective_trigger_for` (`src/goals/cognitive_memory_store.rs:280`), where `slug = goal_slug(&active.id)` (`active_goals_as_records`, `src/goal_curation/operations.rs:1175`).

The **read/match** path diverged:

1. **Probe never carried the trigger substring (load-bearing).** The live OODA objective probe (`objective_summary` in `src/ooda_loop/cycle.rs`) was built **only** from each goal's free-text `description`, joined with `"; "`. It never contained the slug-derived phrase, so the predicate `'{probe}' CONTAINS trigger_condition` could not match.
2. **Case-sensitive match (secondary).** `check_triggers` (`src/cognitive_memory/ops.rs:508`) used a case-sensitive `CONTAINS`, so even a phrase present in different case would miss.

This was confirmed with failing-first tests that store an Active-goal-style prospective and probe `check_triggers` with realistic objective text — they returned **0 triggers** on `main`.

## Fix (confined to `src/ooda_loop/` + `src/cognitive_memory/`)

- **`src/ooda_loop/cycle.rs`** — new `build_objective_probe(active)` appends each active goal's slug-phrase (`goal_slug(&g.id).replace('-', " ")`, **byte-identical** to the written `trigger_condition`) to the description text, then rewires the Prepare-phase probe to use it. This is the load-bearing fix and fires triggers even under a case-sensitive predicate.
- **`src/cognitive_memory/ops.rs`** — `check_triggers` now folds both sides: `toLower('{c}') CONTAINS toLower(p.trigger_condition)`. Ordering is **escape → interpolate → fold**, preserving the single `escape_cypher` chokepoint (the only attacker-reachable literal is escaped before being wrapped in `toLower`). Defensive safety net for mixed-case / non-goal prospectives.

## Tests (TDD, failing-first)

- `check_triggers_fires_for_active_goal_objective` — store goal prospective, probe with mixed-case objective → must fire. *(RED on main: 0 triggers)*
- `check_triggers_is_case_insensitive` — lowercase trigger vs UPPERCASE probe. *(RED on main)*
- `objective_probe_fires_stored_goal_trigger` — end-to-end: `build_objective_probe` → `check_triggers` fires, with a description that shares **no** words with the slug (proves the slug-phrase enrichment is what fires it).
- `probe_contains_goal_slug_phrase`, `probe_retains_goal_description` — probe-shape contracts.
- `check_triggers_handles_injection_chars_safely` — injection-regression guard (quote/backslash/newline/terminators) confirming the escape chokepoint holds under folding.

Existing case-sensitive trigger tests (`check_triggers_matches_substring`, `check_triggers_returns_empty_on_no_match`, `check_triggers_only_returns_pending`) and goal-store write-path tests (`put_active_goal_creates_prospective_trigger`, `put_completed_goal_resolves_stale_prospective`) remain green.

## Verification

- `cargo fmt --check`: clean
- `cargo clippy --lib --tests` and release `-D warnings` (pre-commit/pre-push): clean
- `cargo test --lib`: **5687 passed, 0 failed, 4 ignored** (an initial flake in `operator_cli::tests_goal_remove` — a pre-existing process-global `std::env::set_var(STATE_ROOT_ENV)` parallelism race, unrelated to this change — passed in isolation and on a clean re-run).

## Scope

Does **not** touch `src/memory_consolidation/` (distillation) or episodic-recall paths — owned by separate workstreams.

Docs: adds `docs/reference/prospective-trigger-firing.md` and links it from the cognitive-memory references.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

---

## Step 13: Local Testing Results

> **Note on method:** Simard is a **Rust crate**, not the `amplihack` Python package, so the
> templated `uvx --from git+...@<branch> amplihack <command>` pattern does not apply. Outside-in
> testing was performed by **freshly cloning the published PR branch from GitHub** (HEAD `619cfa6`)
> and exercising the real Simard code as an operator would — driving the same production
> `preparation_memory_operations_with_active_slugs` function the OODA cycle calls and observing the
> user-visible `prepared context (… triggers …)` log line.
>
> `git clone --branch fix/issue-2300-fix-the-prospective-triggers-never-fire-defect-in https://github.com/rysweet/Simard.git` → HEAD `619cfa6`

### Scenario 1 (simple) — #2300 regression tests fire the trigger write+read+match path
Command: `cargo test --lib -- check_triggers objective_probe probe_contains_goal_slug_phrase probe_retains_goal_description` (run in the fresh GitHub clone of the PR branch)
Result: **PASS**
Output (key lines):
```
test cognitive_memory::ops::tests::check_triggers_fires_for_active_goal_objective ... ok
test cognitive_memory::ops::tests::check_triggers_is_case_insensitive ... ok
test cognitive_memory::ops::tests::check_triggers_handles_injection_chars_safely ... ok
test ooda_loop::cycle::tests_objective_probe::objective_probe_fires_stored_goal_trigger ... ok
test ooda_loop::cycle::tests_objective_probe::probe_contains_goal_slug_phrase ... ok
test ooda_loop::cycle::tests_objective_probe::probe_retains_goal_description ... ok
test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 5678 filtered out
```

### Scenario 2 (complex) — end-to-end OODA preparation reproduces the user-visible log line
Drives the production `preparation_memory_operations_with_active_slugs` (the exact function
`run_ooda_cycle_inner` calls) with a goal-derived prospective stored via the live write path
(`trigger_condition = goal_slug(id).replace('-', " ")`). Contrasts the **old** probe shape
(description only) against the **new** `build_objective_probe` shape (description + slug-phrase).
Command: `cargo run --example trigger_fire_demo` (example added in the throwaway clone; uses only public crate API)
Result: **PASS**
Output:
```
OLD probe (description only): "Investigate the broken login redirect reported by users"
[simard] OODA cycle: prepared context (0 facts, 0 triggers, 0 procedures, 0 episodes)

NEW probe (build_objective_probe shape): "Investigate the broken login redirect reported by users; fix authentication bug"
[simard] OODA cycle: prepared context (0 facts, 1 triggers, 0 procedures, 0 episodes)
fired trigger -> node_id="pro_019ede0a…" condition="fix authentication bug" action="Pursue goal: Fix Authentication Bug"

RESULT: PASS — trigger fires with build_objective_probe (1 trigger), and the pre-fix probe shape yields 0 (dead path reproduced).
```
The OLD probe reproduces the exact issue symptom ("0 triggers" every cycle); the NEW probe fires the
goal's prospective — confirming the fix is load-bearing end-to-end through the production code path.

### Regression check — full library suite on the fresh PR branch
Command: `cargo test --lib`
Result: **PASS** (with 1 pre-existing, unrelated parallelism flake)
Output: `5686 passed; 1 failed; 4 ignored`. The single failure,
`operator_commands_dashboard::tests_goals_crud::full_goal_lifecycle_crud`, is a known-class
parallel-execution flake (serial-gated hermetic LadybugDB instances in shared `/tmp`, same category
as the `operator_cli::tests_goal_remove` race already noted above). It is **outside the changed code
paths** (dashboard goal-CRUD, not the OODA probe path) and passed **deterministically**: 27/27 in its
module (`cargo test --lib tests_goals_crud`) and 3/3 on isolated repeat. A deterministic code change
cannot produce a flaky failure, so this is environmental, not a #2300 regression.

**Both scenarios passed.** The prospective-trigger subsystem is verified functional end-to-end from the published PR branch.
