### PR TITLE
fix(cog-mem): make procedural store idempotent on exact name (#2298)

### DIFF
--- a/docs/architecture/episode-distillation.md
+++ b/docs/architecture/episode-distillation.md
@@ -9,6 +9,7 @@ related:
   - ../reference/cognitive-memory-preparation-filters.md
   - ../reference/cognitive-memory-episodic-recall.md
   - ../reference/ooda-procedural-memory.md
+  - ../reference/cognitive-memory-procedural-idempotency.md
   - ../memory.md
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,6 +48,7 @@ Terminal sessions and repo-grounded engineer runs now bridge through one explici
 - [LightweightChatSession reference](./reference/lightweight-chat-session.md) - Direct-subprocess session used for Copilot-provider meeting turns (no PTY overhead).
 - [Terminal session idle detection](./reference/terminal-session-idle-detection.md) - How Simard determines when a PTY session is genuinely idle vs. silently computing.
 - [Cognitive memory bridge helpers](./reference/cognitive-memory-bridge-helpers.md) - `launch_writer_bridge` / `open_reader_bridge` resolution ladder; design notes for the planned in-process Arc shortcut and strict no-silent-degradation contract (issue #1590 follow-up).
+- [Procedural-memory store idempotency](./reference/cognitive-memory-procedural-idempotency.md) - `store_procedure` deduplicates on exact name so repeated OODA consolidation cycles stop re-storing identical procedures, ending the 0% compression / frozen procedural-store defect (issue #2298).
 - [Cognitive-memory goal store adapter](./reference/cognitive-memory-goal-store.md) - Superseded design for the planned `GoalStore` implementation that was replaced by the file-backed store (issue #2182).
 - [File-backed goal store reference](./reference/file-backed-goal-store.md) - Production GoalStore with flock locking at goal_store.json (issue #2182).
 - [String truncation helpers](./reference/string-truncation-helpers.md) - Design for the planned `truncate_to_char_boundary` UTF-8-safe byte-budget helper (issue #1590 follow-up).

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -20,7 +20,7 @@ For the full canonical specification (schema, consolidation rules, hive event bu
 | **Working** | Task-scoped (cleared at task end) | The 20-slot active task context: goal, constraints, plan steps, current execution state. |
 | **Episodic** | Persistent, autobiographical | "What happened this session" — every cycle, every action, every observation. |
 | **Semantic** | Persistent, deduplicated | Facts and learned concepts promoted from episodic memory ("the test harness uses CARGO_TARGET_DIR"). |
-| **Procedural** | Persistent, indexed by trigger | Learned how-to: action sequences that worked for a given situation. Written by the OODA Act phase for successful outcomes (`ooda:{kind}`). See [OODA procedural memory](reference/ooda-procedural-memory.md). |
+| **Procedural** | Persistent, indexed by trigger, deduplicated by name | Learned how-to: action sequences that worked for a given situation. Written by the OODA Act phase for successful outcomes. Storing an identically-named procedure is idempotent (#2298). See [OODA procedural memory](reference/ooda-procedural-memory.md) and [Procedural-memory store idempotency](reference/cognitive-memory-procedural-idempotency.md). |
 | **Prospective** | Persistent, time/event-indexed | Future intentions: Active goals as trigger-action pairs, meeting action items. See [Goal–prospective memory mirror](reference/goal-prospective-memory-mirror.md). |
 
 ## Consolidation flow
@@ -68,6 +68,7 @@ For multi-host coordination see [Distributed operations](distributed-operations.
 
 - [Cognitive Memory Architecture](architecture/cognitive-memory.md) (canonical, full detail)
 - [OODA procedural memory](reference/ooda-procedural-memory.md) — how successful OODA outcomes become procedures
+- [Procedural-memory store idempotency](reference/cognitive-memory-procedural-idempotency.md) — exact-name dedup that stops repeated cycles re-storing identical procedures (#2298)
 - [Goal–prospective memory mirror](reference/goal-prospective-memory-mirror.md) — how Active goals become prospective triggers
 - [Dashboard](dashboard.md) — Memory tab
 - [Daemon mode](daemon-mode.md) — when consolidation runs

--- a/docs/reference/cognitive-memory-bootstrap-procedures.md
+++ b/docs/reference/cognitive-memory-bootstrap-procedures.md
@@ -6,6 +6,7 @@ owner: simard
 doc_type: reference
 related:
   - ./ooda-procedural-memory.md
+  - ./cognitive-memory-procedural-idempotency.md
   - ./cognitive-memory-preparation-filters.md
   - ./cognitive-memory-episodic-recall.md
   - ../architecture/cognitive-memory.md
@@ -286,14 +287,20 @@ If either pattern fails to match (no `#N`, no `.ext`), the derived
 list is simply empty and the rendered name omits the extras — there
 is no fallback or wildcard.
 
-### Intentional accumulation (still applies)
+### Intentional accumulation (revised by #2298)
 
-The "one procedure node per successful cycle" semantics from
-[OODA procedural memory](./ooda-procedural-memory.md) still hold.
-Multiple successful `AdvanceGoal` runs against the same goal produce
-multiple `pr-merge:{goal_id} | triggers: …` rows with identical
-names. `recall_procedure` returns all of them ranked by relevance and
-usage count.
+The "one procedure node per successful cycle" semantics described here
+were **superseded by issue
+[#2298](https://github.com/rysweet/Simard/issues/2298)**. `store_procedure`
+is now idempotent on exact name: multiple successful `AdvanceGoal` runs
+against the same goal that derive the **same** `pr-merge:{goal_id} |
+triggers: …` name collapse to a single node (with `usage_count`
+incremented), rather than creating duplicate rows. Runs that derive
+**distinct** names still accumulate distinct nodes. `recall_procedure`
+returns the de-duplicated set (recall does not currently rank by
+`usage_count` — rows return in store order under its `CONTAINS`/`LIMIT`
+query; `usage_count` is recorded for future ranking). See
+[Procedural-memory store idempotency](./cognitive-memory-procedural-idempotency.md).
 
 ---
 

--- a/docs/reference/cognitive-memory-procedural-idempotency.md
+++ b/docs/reference/cognitive-memory-procedural-idempotency.md
@@ -1,0 +1,386 @@
+---
+title: Procedural-memory store idempotency
+description: How store_procedure deduplicates on exact procedure name so repeated OODA consolidation cycles stop re-storing identical procedures, ending the 0% compression / frozen procedural-store defect.
+last_updated: 2026-06-19
+owner: simard
+doc_type: reference
+related:
+  - ./ooda-procedural-memory.md
+  - ./cognitive-memory-bootstrap-procedures.md
+  - ../architecture/episode-distillation.md
+  - ../architecture/cognitive-memory.md
+  - ../memory.md
+---
+
+# Procedural-memory store idempotency
+
+> Shipped in issue [#2298](https://github.com/rysweet/Simard/issues/2298).
+> Supersedes the "one procedure node per successful cycle / intentional
+> accumulation" behaviour described in
+> [OODA procedural memory](./ooda-procedural-memory.md) and
+> [Bootstrap procedures and trigger naming](./cognitive-memory-bootstrap-procedures.md)
+> for the case of **identically-named** procedures.
+
+`store_procedure` is **idempotent on the exact procedure name**. Storing a
+procedure whose `name` already exists is a no-op for node creation: no new
+`Procedure` node is written, and the existing node id is returned. Genuinely
+new procedures (distinct names) still accumulate exactly as before.
+
+This closes the non-idempotency defect in which every OODA consolidation
+cycle re-stored the same handful of procedures
+(`consolidate:ad-hoc`, `pr-merge:adopt-tdd`, `pr-merge:fix-broken-features`),
+producing 0% procedural compression and a procedural store that only ever
+recalled the 5 bootstrap procedures even as the node table grew unbounded.
+
+---
+
+## The defect (before #2298)
+
+Procedural learning runs in the OODA Act phase: every **successful**
+`ActionOutcome` is stored as a procedure via `store_procedure`
+(`src/ooda_loop/cycle.rs`). The procedure name is derived from the action
+pattern, goal scope, and triggers by `compose_procedure_name`, e.g.:
+
+```
+consolidate:ad-hoc | triggers: consolidate,memory,distill,g
+```
+
+Because the same actions (`ConsolidateMemory`, the two seeded `pr-merge`
+patterns, …) succeed on most cycles, `compose_procedure_name` produces the
+**same name** cycle after cycle. The pre-#2298 `store_procedure`
+implementation issued an unconditional `CREATE` with a fresh
+`new_id("proc")` and had no dedup on `name`; the `Procedure` table keys on
+`id`, not `name`, so the database did not dedup either:
+
+```cypher
+-- pre-#2298: one new node every call, regardless of name collision
+CREATE (p:Procedure {id: 'proc_<fresh-uuid>', name: '<name>', ...})
+```
+
+Symptoms operators saw:
+
+- The daemon logged the same line every consolidation cycle:
+  ```
+  [simard] OODA consolidation: stored procedure 'consolidate:ad-hoc | triggers: consolidate,memory,distill,g'
+  ```
+- `get_statistics().procedural_count` grew every cycle, but
+  `recall_procedure` only ever surfaced the 5 bootstrap procedures (the
+  duplicates were the same names ranked the same way).
+- Procedural compression sat at **0%** — no learned procedures ever
+  *accumulated* in a meaningful, queryable way; the store was effectively
+  frozen.
+
+### What was NOT the cause
+
+Two of the three originally-suspected candidates were investigated and
+ruled out — they are correct and are left untouched:
+
+| Candidate | Verdict |
+|-----------|---------|
+| `mark_episode_distilled` not persisting | **Not the cause.** `SET e.distilled = 1` + `post_write_barrier` persist correctly and idempotently (`ops.rs`). |
+| `list_undistilled_episodes` re-returning the same episodes | **Not the cause.** The `WHERE e.distilled = 0` gate excludes marked rows (`ops.rs`). |
+| Procedural-store upsert creating new nodes instead of updating | **Confirmed root cause.** `store_procedure` had no name dedup. |
+
+Note that **episode distillation** (which writes *facts*, not procedures —
+see [Episode distillation](../architecture/episode-distillation.md)) was
+already idempotent via the `distilled` marker. The frozen-procedural symptom
+came entirely from the OODA procedural-learning write path, not from the
+distillation pass.
+
+---
+
+## Behaviour (after #2298)
+
+### Dedup key: exact `name` equality
+
+The deduplication key is the **full procedure name string**, compared for
+exact equality. The name already encodes the procedure's identity:
+
+```
+{pattern}:{scope} | triggers: {comma-separated-keywords}
+```
+
+(See [Bootstrap procedures and trigger naming](./cognitive-memory-bootstrap-procedures.md)
+for how the name is composed.) Two stores with identical pattern, scope, and
+trigger list therefore produce identical names and dedup to a single node.
+Two stores that differ in any of those fields produce distinct names and
+remain distinct nodes — learning still accumulates.
+
+Exact equality (not the `CONTAINS` substring match used by
+`recall_procedure`) is used deliberately: a substring/`CONTAINS` probe could
+falsely match an unrelated procedure that merely shares trigger tokens, which
+would suppress a genuinely new procedure. This mirrors the exact-name filter
+the bootstrap seeder already applies (`seed_bootstrap_procedures`).
+
+### `store_procedure` is a read-before-write upsert
+
+```rust
+fn store_procedure(
+    &self,
+    name: &str,
+    steps: &[String],
+    prerequisites: &[String],
+) -> SimardResult<String>;
+```
+
+Contract:
+
+1. **Existing name** → no `CREATE`. The existing node's id is returned, that
+   node's `usage_count` is incremented (`SET p.usage_count = p.usage_count + 1`),
+   and the standard `post_write_barrier` still runs. Calling again with the
+   same name returns the **same id**. This path is therefore *not* a pure
+   no-op: it is idempotent on the **node count** while deliberately recording
+   the recurrence (see *Reinforcement signal: `usage_count`* below).
+2. **New name** → a `Procedure` node is created exactly as before
+   (`CREATE … usage_count: 0`, followed by `post_write_barrier`), and the
+   new id is returned.
+3. The method remains **total and idempotent on node count**: any number of
+   calls with the same `name` leave the `Procedure` node count unchanged
+   after the first (only `usage_count` advances).
+
+The existence check is a single indexed lookup using the same
+`escape_cypher` escaping as the create path:
+
+```cypher
+MATCH (p:Procedure) WHERE p.name = '<escaped-name>' RETURN p.id LIMIT 1
+```
+
+Because idempotency lives **inside** `store_procedure`, every caller inherits
+it — the OODA cycle, the bootstrap seeder, and any future writer — without
+each caller needing its own recall-then-store guard.
+
+### Reinforcement signal: `usage_count`
+
+On the existing-name path, `store_procedure` bumps the stored procedure's
+`usage_count` (`SET p.usage_count = p.usage_count + 1`) so that a recurring
+procedure still records its reinforcement/recurrence for future ranking by
+`recall_procedure`. This is a counter update on a single existing row, **not**
+a new node. Idempotency is defined over the *node count*, not over
+`usage_count`; regression tests assert node-count stability and never assert
+a frozen `usage_count`.
+
+### Trait surface is unchanged
+
+The `CognitiveMemoryOps::store_procedure` signature
+(`-> SimardResult<String>`) is **unchanged**. The fix is internal to
+`NativeCognitiveMemory`, so none of the other implementations
+(`CognitiveMemoryBridge`, `RemoteCognitiveMemory`, `SharedMemory`, and the
+test/meeting stubs) change shape, and no IPC/wire-protocol change is needed
+to convey a "created vs. existing" flag across process boundaries.
+
+---
+
+## OODA log honesty
+
+The OODA consolidation call site (`src/ooda_loop/cycle.rs`) emits the
+`stored procedure` line **only when a procedure is actually created**, not on
+every cycle. It performs the same exact-name pre-check the seeder uses
+(`recall_procedure(name, N)` filtered to `h.name == name`) and logs only on
+the create path:
+
+```
+# first time a given name is learned:
+[simard] OODA consolidation: stored procedure 'consolidate:ad-hoc | triggers: consolidate,memory,distill,g'
+
+# subsequent cycles producing the same name: no "stored procedure" line
+```
+
+The underlying `store_procedure` call is left in place on both paths and
+stays safe either way — the pre-check governs the log line, while
+`store_procedure`'s internal dedup governs correctness. A failure to store is
+still logged on the existing best-effort error branch:
+
+```
+[simard] OODA consolidation: procedural memory failed: <error>
+```
+
+### Cost: a second existence lookup on the OODA path
+
+Keeping the trait signature unchanged (no "created vs. existing" return flag)
+means the create-vs-existing decision is discovered by *querying*, not by
+reading a value the caller already holds. Two lookups therefore run per
+successful outcome on the OODA path:
+
+1. the log-guard pre-check in `cycle.rs`
+   (`recall_procedure(name, N)` filtered to `h.name == name`), which decides
+   whether to emit the `stored procedure` log line, and
+2. the existence `MATCH` **inside** `store_procedure`, which decides whether
+   to `CREATE`.
+
+This duplication is the deliberate, accepted cost of leaving the trait shape
+(and the IPC/wire surface) untouched. It is bounded — two indexed single-row
+lookups per successful action, on a consolidation path that already performs
+network/LLM work each cycle, so it is not a hot loop. A future optimisation
+could collapse the two by having `store_procedure` return a `created: bool`,
+but that changes the trait and ripples through all seven implementations,
+which #2298 explicitly avoids.
+
+---
+
+## Effect on compression
+
+Procedural "compression" is an **observable consequence** of dedup, not a
+separately-computed metric. Before #2298, repeated identical stores meant the
+ratio of distinct-recallable procedures to total stores stayed at ~0%. After
+#2298, identical stores collapse to one node, so the procedural store
+reflects only genuinely distinct learned procedures and recall returns an
+accumulating, de-duplicated set. There is no hardcoded `0%` path to remove —
+the number simply stops being pinned to zero once duplicates no longer land.
+
+---
+
+## Examples
+
+### Example 1 — repeated consolidation cycle (the fixed case)
+
+```
+Cycle N:
+  ConsolidateMemory succeeds
+  compose_procedure_name → "consolidate:ad-hoc | triggers: consolidate,memory,distill,g"
+  store_procedure(name, steps, &[])
+    → name absent → CREATE node proc_abc, usage_count = 0
+  log: [simard] OODA consolidation: stored procedure 'consolidate:ad-hoc | ...'
+
+Cycle N+1 (same objective shape):
+  ConsolidateMemory succeeds
+  compose_procedure_name → identical name
+  store_procedure(name, steps, &[])
+    → name present → NO new node, returns proc_abc, usage_count = 1
+  (no "stored procedure" log line)
+
+get_statistics().procedural_count: unchanged across N → N+1
+recall_procedure("consolidate memory", 5): one consolidate:ad-hoc entry
+```
+
+### Example 2 — genuinely new procedure still accumulates
+
+```
+store_procedure("pr-merge:fix-auth | triggers: merge,pr,2310,rs", steps, &[])
+  → new name → CREATE → procedural_count increments
+store_procedure("pr-merge:fix-cache | triggers: merge,pr,2311,rs", steps, &[])
+  → different name → CREATE → procedural_count increments again
+```
+
+Distinct learning is preserved; only exact-name repeats are deduped.
+
+### Example 3 — bootstrap seeding stays idempotent
+
+`seed_bootstrap_procedures` already filtered by exact name before storing, so
+its count semantics are unchanged. With the in-`store_procedure` guard now
+present, the seeder is idempotent even if its own pre-filter were removed —
+restarting the daemon never duplicates the 5 bootstrap procedures.
+
+---
+
+## Code location
+
+| Item | File |
+|------|------|
+| `store_procedure` (idempotent upsert) | `src/cognitive_memory/ops.rs` (`NativeCognitiveMemory`) |
+| `store_procedure` trait method (signature unchanged) | `src/cognitive_memory/mod.rs` (`CognitiveMemoryOps`) |
+| OODA call site + log guard | `src/ooda_loop/cycle.rs` (procedural-learning loop) |
+| `compose_procedure_name` (name derivation, unchanged) | `src/ooda_loop/cycle.rs` |
+| Bootstrap seeder (exact-name precedent) | `src/cognitive_memory/bootstrap_procedures.rs` |
+| `mark_episode_distilled` / `list_undistilled_episodes` (unchanged) | `src/cognitive_memory/ops.rs` |
+
+---
+
+## Testing
+
+The fix is delivered test-first (TDD). The regression test is written and
+**fails on the pre-#2298 code** (the duplication assertion), then passes once
+the dedup lands.
+
+### Regression test (store layer)
+
+Against `NativeCognitiveMemory::in_memory()` (the `test_mem()` helper in
+`src/cognitive_memory/tests_pr_2298_idempotency.rs`) — **not** the
+`EpisodeMock`/`ProcMock` stubs, whose `store_procedure` is a no-op that would
+hide the bug:
+
+| Test | Coverage |
+|------|----------|
+| `store_procedure_is_idempotent_on_exact_name` | Store the same name twice → wildcard recall filtered to that name has count **1** (pre-fix: 2 → fails). |
+| `store_procedure_returns_stable_id_for_duplicate` | Second store of an identical name returns the **same id** as the first (pre-fix: a fresh `proc_…` id → fails). |
+| `store_procedure_preserves_distinct_named_procedures` | Two different names → two distinct nodes (guards against over-dedup). |
+| `repeated_ooda_consolidation_does_not_re_store_procedures` | Faithful symptom reproduction: the three daemon-log procedures stored on two cycles → one node each (pre-fix: two each → fails). |
+| `store_procedure_reinforces_usage_count_on_duplicate` | Duplicate store leaves node count stable but increments `usage_count` (reinforcement signal). |
+
+> **`"*"` recall caveat.** `recall_procedure("*", N)` applies a hard `LIMIT N`
+> with **no ordering** — it returns rows in store order, capped at `N`. Any
+> count assertion built on it must pass an `N` strictly greater than the total
+> number of procedures in the test store, or rows are silently truncated and a
+> real duplicate could be missed. The tests size `N` accordingly (e.g. recall
+> with a generous limit, or filter `recall_procedure(name, N)` to the specific
+> name and assert the filtered count) rather than trusting a small fixed `N`.
+
+### Combined-invariant test
+
+`consolidation_cycle_is_idempotent_and_keeps_episodes_distilled` asserts both
+halves of the issue in one pass: after a deterministic
+distillation/consolidation pass over a fixed episode set,
+
+1. processed episodes are absent from `list_undistilled_episodes(N)` (the
+   already-correct distillation marker, guarded against regression), **and**
+2. a second identical procedural pass leaves the `Procedure` node count
+   unchanged.
+
+### Existing suites that must stay green
+
+- `src/cognitive_memory/bootstrap_procedures_tests.rs` — seeding stays
+  idempotent (`seed_is_idempotent`, `seed_skips_existing_procedures_by_name`).
+- `src/cognitive_memory/ops.rs` round-trip tests
+  (`store_procedure_returns_prefixed_id`,
+  `recall_procedure_returns_steps_and_prerequisites`).
+- Hermetic-guard tests (`tests_hermetic_parity.rs`, the
+  `assert_hermetic_for` guard at the top of `store_procedure`).
+- `cargo test` for the `cognitive_memory`, `memory_consolidation`, and
+  `ooda_loop` modules.
+
+---
+
+## Migration / backwards compatibility
+
+- **Existing duplicate rows** written by pre-#2298 cycles remain in the
+  database. They are still recalled; they are not retroactively merged.
+  `store_procedure` simply stops *adding* new duplicates from this point on.
+  A future `simard memory dedup-procedures` hygiene command could collapse
+  the historical duplicates; #2298 does not delete data.
+- **Trait shape** is unchanged — no method added, no signature changed, no
+  IPC/wire-protocol change.
+- **Tests** that previously relied on "each successful cycle adds a new
+  procedure node" for an identical name are updated to assert node-count
+  stability across repeats.
+
+---
+
+## Out of scope
+
+- **Episodic recall and trigger derivation** (`search_episodes_by_keywords`,
+  `compose_procedure_name`, `check_triggers`) — owned by separate
+  workstreams; untouched here.
+- **`mark_episode_distilled` / `list_undistilled_episodes`** — already
+  correct; only regression-guarded.
+- **A typed `triggers` column or a `UNIQUE(name)` schema constraint** — the
+  read-before-write guard achieves idempotency without a schema migration; a
+  DB-level uniqueness constraint is a possible future hardening.
+- **A dedicated procedural-compression metric** — compression is treated as
+  an observable outcome of dedup, not a new computed field.
+- **Pruning historical duplicate rows** — left in place; a follow-up hygiene
+  CLI can collapse them.
+
+---
+
+## Related reading
+
+- [OODA procedural memory](./ooda-procedural-memory.md) — how successful
+  OODA outcomes become procedures.
+- [Bootstrap procedures and trigger naming](./cognitive-memory-bootstrap-procedures.md) —
+  the naming convention that defines the dedup key and the exact-name seeder
+  precedent.
+- [Episode distillation](../architecture/episode-distillation.md) — the
+  (already-idempotent) fact-distillation pass, distinct from procedural
+  learning.
+- [Cognitive Memory Architecture](../architecture/cognitive-memory.md) — the
+  six memory types and their lifecycle.
+- [Memory architecture (operator summary)](../memory.md).

--- a/docs/reference/ooda-procedural-memory.md
+++ b/docs/reference/ooda-procedural-memory.md
@@ -51,8 +51,18 @@ Act phase
 
 ## Procedure naming convention
 
-Each procedure is named `ooda:{action_kind}`, where `action_kind` is the
-`Display` representation of the `ActionKind` enum:
+> **Superseded since #2281.** The live OODA write path now derives procedure
+> names via `compose_procedure_name` (goal-scoped, trigger-bearing — e.g.
+> `pr-merge:{goal_id} | triggers: merge,pr,review`), **not** the
+> `ooda:{action_kind}` form shown below. That full name string is also the
+> dedup key for #2298 idempotency. See
+> [Bootstrap procedures and trigger naming](./cognitive-memory-bootstrap-procedures.md)
+> and
+> [Procedural-memory store idempotency](./cognitive-memory-procedural-idempotency.md).
+> The original #2280 scheme below is retained for historical context.
+
+Each procedure was originally named `ooda:{action_kind}` (the #2280 scheme),
+where `action_kind` is the `Display` representation of the `ActionKind` enum:
 
 | ActionKind             | Procedure name              |
 |------------------------|-----------------------------|
@@ -70,11 +80,18 @@ Each procedure is named `ooda:{action_kind}`, where `action_kind` is the
 The `ooda:` prefix distinguishes OODA-learned procedures from any
 future manually-imported or meeting-derived procedures.
 
-**Intentional accumulation**: when the same `ActionKind` succeeds in
-multiple cycles, each `store_procedure` call creates a new
-procedure node. `recall_procedure` returns all matches ranked by
-relevance, so earlier successes remain queryable. This accumulation
-reflects the evolving understanding of what works for each action type.
+**Accumulation semantics (updated by #2298)**: when the same
+`ActionKind` succeeds in multiple cycles and produces the **same
+procedure name**, `store_procedure` is now idempotent on exact name —
+no duplicate node is created (it bumps `usage_count` instead). When a
+success produces a **distinct** name, a new procedure node is created
+and accumulates. `recall_procedure` returns the de-duplicated set (it
+does not currently rank by `usage_count` — rows come back in store
+order under its `CONTAINS`/`LIMIT` query), so distinct learned
+procedures remain queryable. See
+[Procedural-memory store idempotency](./cognitive-memory-procedural-idempotency.md).
+Prior to #2298 every store created a new node even for identical names,
+which froze the procedural store at 0% compression.
 
 ---
 

--- a/src/cognitive_memory/bootstrap_procedures.rs
+++ b/src/cognitive_memory/bootstrap_procedures.rs
@@ -25,7 +25,7 @@
 //! that exceeds PR-C's scope; the in-name encoding is a deliberate
 //! single-PR shortcut.
 
-use crate::cognitive_memory::{CognitiveMemoryOps, procedure_exists};
+use crate::cognitive_memory::CognitiveMemoryOps;
 use crate::error::SimardResult;
 
 /// A single bootstrap procedure: fully-rendered name (including
@@ -116,14 +116,16 @@ pub const BOOTSTRAP_PROCEDURES: &[BootstrapProcedure] = &[
 
 /// Seed [`BOOTSTRAP_PROCEDURES`] into cognitive memory if missing.
 ///
-/// For each procedure we ask [`procedure_exists`] — an exact-name probe over
-/// `recall_procedure` — whether it is already present, and
+/// For each procedure we ask [`CognitiveMemoryOps::procedure_exists`] — an
+/// exact-name probe — whether it is already present, and
 /// `store_procedure(name, steps, prerequisites)` it only if not. Returns the
 /// count of procedures newly stored (`0` if all were already present).
 ///
-/// The exact-name filter matters: `recall_procedure` matches on Cypher
+/// The exact-name semantics matter: `recall_procedure` matches on Cypher
 /// `CONTAINS`, so bootstrap procedures that share trigger tokens would
-/// otherwise over-report presence and starve later seeds.
+/// otherwise over-report presence and starve later seeds. `procedure_exists`
+/// encapsulates that exact-name filter (and lets the native backend answer it
+/// with a direct `LIMIT 1` lookup instead of a recall fan-out).
 ///
 /// **Idempotent**: safe to call on every daemon start; subsequent
 /// calls after the first all return `Ok(0)`.
@@ -138,7 +140,7 @@ pub const BOOTSTRAP_PROCEDURES: &[BootstrapProcedure] = &[
 pub fn seed_bootstrap_procedures(bridge: &dyn CognitiveMemoryOps) -> SimardResult<usize> {
     let mut seeded = 0usize;
     for proc in BOOTSTRAP_PROCEDURES {
-        if !procedure_exists(bridge, proc.name())? {
+        if !bridge.procedure_exists(proc.name())? {
             bridge.store_procedure(proc.name(), &proc.steps(), &proc.prerequisites())?;
             seeded += 1;
         }

--- a/src/cognitive_memory/bootstrap_procedures.rs
+++ b/src/cognitive_memory/bootstrap_procedures.rs
@@ -25,7 +25,7 @@
 //! that exceeds PR-C's scope; the in-name encoding is a deliberate
 //! single-PR shortcut.
 
-use crate::cognitive_memory::CognitiveMemoryOps;
+use crate::cognitive_memory::{CognitiveMemoryOps, procedure_exists};
 use crate::error::SimardResult;
 
 /// A single bootstrap procedure: fully-rendered name (including
@@ -116,16 +116,14 @@ pub const BOOTSTRAP_PROCEDURES: &[BootstrapProcedure] = &[
 
 /// Seed [`BOOTSTRAP_PROCEDURES`] into cognitive memory if missing.
 ///
-/// For each procedure, we first call
-/// `recall_procedure(name, 1)` — but because `recall_procedure`
-/// is allowed to return tokenized partial matches (PR-C makes the
-/// call site tokenize objectives so a query like `"merge PR #2281"`
-/// hits `pr-merge:bootstrap | triggers: …`), we filter the recall
-/// hits to **exact name matches** before deciding whether to skip.
-/// If any hit has `p.name == procedure.name()` the procedure is
-/// considered present and skipped. Otherwise we
-/// `store_procedure(name, steps, prerequisites)`. Returns the count
-/// of procedures newly stored (`0` if all were already present).
+/// For each procedure we ask [`procedure_exists`] — an exact-name probe over
+/// `recall_procedure` — whether it is already present, and
+/// `store_procedure(name, steps, prerequisites)` it only if not. Returns the
+/// count of procedures newly stored (`0` if all were already present).
+///
+/// The exact-name filter matters: `recall_procedure` matches on Cypher
+/// `CONTAINS`, so bootstrap procedures that share trigger tokens would
+/// otherwise over-report presence and starve later seeds.
 ///
 /// **Idempotent**: safe to call on every daemon start; subsequent
 /// calls after the first all return `Ok(0)`.
@@ -140,15 +138,7 @@ pub const BOOTSTRAP_PROCEDURES: &[BootstrapProcedure] = &[
 pub fn seed_bootstrap_procedures(bridge: &dyn CognitiveMemoryOps) -> SimardResult<usize> {
     let mut seeded = 0usize;
     for proc in BOOTSTRAP_PROCEDURES {
-        // Pull a generous candidate set then filter to exact-name
-        // matches — tokenized recall semantics mean a name-shaped
-        // query may surface OTHER procedures that share trigger
-        // tokens (`bootstrap`, `merge`, …). A simple `is_empty()`
-        // check on the raw recall would over-report presence and
-        // never seed the second and third bootstrap procedures.
-        let hits = bridge.recall_procedure(proc.name(), 16)?;
-        let already_present = hits.iter().any(|h| h.name == proc.name());
-        if !already_present {
+        if !procedure_exists(bridge, proc.name())? {
             bridge.store_procedure(proc.name(), &proc.steps(), &proc.prerequisites())?;
             seeded += 1;
         }

--- a/src/cognitive_memory/mod.rs
+++ b/src/cognitive_memory/mod.rs
@@ -80,6 +80,30 @@ pub trait CognitiveMemoryOps: Send + Sync {
 
     fn recall_procedure(&self, query: &str, limit: u32) -> SimardResult<Vec<CognitiveProcedure>>;
 
+    /// Returns `true` if a procedure with this **exact** `name` already exists.
+    ///
+    /// [`recall_procedure`](Self::recall_procedure) matches names with Cypher
+    /// `CONTAINS`, so a name-shaped query can surface *other* procedures that
+    /// merely share trigger tokens (`merge`, `bootstrap`, …) or are
+    /// superstrings. An identity check — "does *this* procedure already
+    /// exist?" — must therefore filter recall hits down to exact-name
+    /// equality; a bare `is_empty()` would over-report presence. Centralizing
+    /// the contract here keeps the bootstrap seeder and the OODA consolidation
+    /// log in lockstep (issue #2298).
+    ///
+    /// The default implementation pays for that filter with an
+    /// [`EXACT_NAME_RECALL_LIMIT`]-wide recall plus a linear exact-name scan,
+    /// and decodes each hit's `steps`/`prerequisites` JSON only to discard it.
+    /// Backends that can answer existence directly (e.g.
+    /// [`NativeCognitiveMemory`]) should override this with an exact-name probe
+    /// that returns no payload and stops at the first match.
+    fn procedure_exists(&self, name: &str) -> SimardResult<bool> {
+        Ok(self
+            .recall_procedure(name, EXACT_NAME_RECALL_LIMIT)?
+            .iter()
+            .any(|hit| hit.name == name))
+    }
+
     fn store_prospective(
         &self,
         description: &str,
@@ -189,28 +213,14 @@ pub trait CognitiveMemoryOps: Send + Sync {
     }
 }
 
-/// Recall fan-out used by [`procedure_exists`]. [`CognitiveMemoryOps::recall_procedure`]
-/// ranks by a `CONTAINS` match on the procedure name, so an exact-name lookup
-/// may have to look past several superstring / trigger-sharing hits before it
-/// finds (or rules out) the exact one. 16 clears the bootstrap set plus a
-/// realistic cycle's worth of trigger-token collisions.
+/// Recall fan-out for the default [`CognitiveMemoryOps::procedure_exists`].
+/// [`CognitiveMemoryOps::recall_procedure`] ranks by a `CONTAINS` match on the
+/// procedure name, so an exact-name lookup may have to look past several
+/// superstring / trigger-sharing hits before it finds (or rules out) the exact
+/// one. 16 clears the bootstrap set plus a realistic cycle's worth of
+/// trigger-token collisions. Backends that override `procedure_exists` with a
+/// direct exact-name probe do not pay this fan-out.
 const EXACT_NAME_RECALL_LIMIT: u32 = 16;
-
-/// Returns `true` if a procedure with this **exact** `name` already exists.
-///
-/// [`CognitiveMemoryOps::recall_procedure`] matches names with Cypher
-/// `CONTAINS`, so a name-shaped query can surface *other* procedures that merely
-/// share trigger tokens (`merge`, `bootstrap`, …) or are superstrings. Callers
-/// that need an identity check — "does *this* procedure already exist?" — must
-/// filter the recall hits down to exact-name equality; a bare `is_empty()` on
-/// the raw recall would over-report presence. Centralizing the filter here keeps
-/// the bootstrap seeder and the OODA consolidation log in lockstep (issue #2298).
-pub fn procedure_exists(memory: &dyn CognitiveMemoryOps, name: &str) -> SimardResult<bool> {
-    Ok(memory
-        .recall_procedure(name, EXACT_NAME_RECALL_LIMIT)?
-        .iter()
-        .any(|hit| hit.name == name))
-}
 
 // ============================================================================
 // NativeCognitiveMemory — LadybugDB backend

--- a/src/cognitive_memory/mod.rs
+++ b/src/cognitive_memory/mod.rs
@@ -189,6 +189,29 @@ pub trait CognitiveMemoryOps: Send + Sync {
     }
 }
 
+/// Recall fan-out used by [`procedure_exists`]. [`CognitiveMemoryOps::recall_procedure`]
+/// ranks by a `CONTAINS` match on the procedure name, so an exact-name lookup
+/// may have to look past several superstring / trigger-sharing hits before it
+/// finds (or rules out) the exact one. 16 clears the bootstrap set plus a
+/// realistic cycle's worth of trigger-token collisions.
+const EXACT_NAME_RECALL_LIMIT: u32 = 16;
+
+/// Returns `true` if a procedure with this **exact** `name` already exists.
+///
+/// [`CognitiveMemoryOps::recall_procedure`] matches names with Cypher
+/// `CONTAINS`, so a name-shaped query can surface *other* procedures that merely
+/// share trigger tokens (`merge`, `bootstrap`, …) or are superstrings. Callers
+/// that need an identity check — "does *this* procedure already exist?" — must
+/// filter the recall hits down to exact-name equality; a bare `is_empty()` on
+/// the raw recall would over-report presence. Centralizing the filter here keeps
+/// the bootstrap seeder and the OODA consolidation log in lockstep (issue #2298).
+pub fn procedure_exists(memory: &dyn CognitiveMemoryOps, name: &str) -> SimardResult<bool> {
+    Ok(memory
+        .recall_procedure(name, EXACT_NAME_RECALL_LIMIT)?
+        .iter()
+        .any(|hit| hit.name == name))
+}
+
 // ============================================================================
 // NativeCognitiveMemory — LadybugDB backend
 // ============================================================================

--- a/src/cognitive_memory/mod.rs
+++ b/src/cognitive_memory/mod.rs
@@ -947,3 +947,9 @@ mod tests_inline {
 // column migration applied.
 #[cfg(test)]
 mod tests_pr_b_distill;
+
+// Issue #2298: procedural-memory non-idempotency regression. `store_procedure`
+// must be an idempotent upsert keyed on exact `name` so repeated OODA
+// consolidation cycles stop re-storing identical procedures.
+#[cfg(test)]
+mod tests_pr_2298_idempotency;

--- a/src/cognitive_memory/ops.rs
+++ b/src/cognitive_memory/ops.rs
@@ -399,6 +399,22 @@ impl CognitiveMemoryOps for NativeCognitiveMemory {
         Ok(id)
     }
 
+    /// Issue #2298: exact-name existence probe used by the bootstrap seeder and
+    /// the OODA consolidation log. Overrides the trait default — which fans out
+    /// a `CONTAINS` recall and JSON-decodes every hit's `steps`/`prerequisites`
+    /// only to compare names — with a direct exact-equality lookup that returns
+    /// no payload and stops at the first match (`LIMIT 1`). This is the same
+    /// authoritative check `store_procedure` performs before deciding whether to
+    /// reinforce or create, and unlike the recall fan-out it cannot be starved
+    /// by trigger-token collisions exceeding the recall limit.
+    fn procedure_exists(&self, name: &str) -> SimardResult<bool> {
+        let escaped_name = escape_cypher(name);
+        let rows = self.query(&format!(
+            "MATCH (p:Procedure) WHERE p.name = '{escaped_name}' RETURN p.id LIMIT 1"
+        ))?;
+        Ok(!rows.is_empty())
+    }
+
     fn recall_procedure(&self, query: &str, limit: u32) -> SimardResult<Vec<CognitiveProcedure>> {
         // Same wildcard treatment as `search_facts` — `"*"` means "return all"
         // so `export_memory_snapshot` actually captures every procedure.
@@ -991,6 +1007,48 @@ mod tests {
         let mem = test_mem();
         let procs = mem.recall_procedure("nonexistent", 10).unwrap();
         assert!(procs.is_empty());
+    }
+
+    // ── procedure_exists (native exact-name probe, issue #2298) ─────────
+
+    #[test]
+    fn procedure_exists_true_for_exact_name() {
+        let mem = test_mem();
+        mem.store_procedure("deploy-prod", &["build".into()], &[])
+            .unwrap();
+        assert!(
+            mem.procedure_exists("deploy-prod").unwrap(),
+            "exact name must report present"
+        );
+    }
+
+    #[test]
+    fn procedure_exists_false_when_absent() {
+        let mem = test_mem();
+        assert!(
+            !mem.procedure_exists("never-stored").unwrap(),
+            "absent name must report missing"
+        );
+    }
+
+    #[test]
+    fn procedure_exists_is_exact_not_contains() {
+        // The native override must match on exact equality, not the
+        // `CONTAINS` semantics of `recall_procedure`. A substring or
+        // superstring of an existing name must NOT count as present —
+        // otherwise the idempotency probe would conflate distinct
+        // trigger-sharing procedures (issue #2298).
+        let mem = test_mem();
+        mem.store_procedure("deploy-prod", &["build".into()], &[])
+            .unwrap();
+        assert!(
+            !mem.procedure_exists("deploy").unwrap(),
+            "substring of an existing name must not report present"
+        );
+        assert!(
+            !mem.procedure_exists("deploy-prod-eu").unwrap(),
+            "superstring of an existing name must not report present"
+        );
     }
 
     // ── store_prospective / check_triggers ─────────────────────────────

--- a/src/cognitive_memory/ops.rs
+++ b/src/cognitive_memory/ops.rs
@@ -328,6 +328,42 @@ impl CognitiveMemoryOps for NativeCognitiveMemory {
         #[cfg(test)]
         self.assert_hermetic_for("NativeCognitiveMemory::store_procedure");
 
+        // Issue #2298: procedural memory was "frozen" — every OODA
+        // consolidation cycle re-stored the identical procedures
+        // (`consolidate:ad-hoc`, `pr-merge:adopt-tdd`, …) because this
+        // method ran an unconditional `CREATE` with a fresh `new_id`, and
+        // the `Procedure` table keys on `id` (not `name`), so the DB never
+        // deduped. Duplicate-named nodes piled up, compression stayed at
+        // 0%, and recall only ever surfaced the bootstrap set.
+        //
+        // Make the store an idempotent upsert keyed on the exact `name`:
+        // if a procedure with this exact name already exists, bump its
+        // `usage_count` (preserving the reinforcement signal) and return
+        // the existing id instead of minting a new node.
+        let escaped_name = escape_cypher(name);
+        let existing = self.query(&format!(
+            "MATCH (p:Procedure) WHERE p.name = '{escaped_name}' \
+             RETURN p.id ORDER BY p.id LIMIT 1"
+        ))?;
+        if let Some(row) = existing.first() {
+            let existing_id = as_str(&row[0])
+                .ok_or_else(|| SimardError::BridgeCallFailed {
+                    bridge: "cognitive-memory-native".into(),
+                    method: "store_procedure".into(),
+                    reason: format!(
+                        "existing procedure '{name}' column 0 (id) was not a string: {:?}",
+                        row[0]
+                    ),
+                })?
+                .to_string();
+            self.execute(&format!(
+                "MATCH (p:Procedure {{id: '{}'}}) SET p.usage_count = p.usage_count + 1",
+                escape_cypher(&existing_id),
+            ))?;
+            self.post_write_barrier("store_procedure")?;
+            return Ok(existing_id);
+        }
+
         let id = Self::new_id("proc");
         // Errors propagated (no silent `unwrap_or_default()`) so a
         // serialize failure cannot land a row whose `steps` column is the

--- a/src/cognitive_memory/tests_pr_2298_idempotency.rs
+++ b/src/cognitive_memory/tests_pr_2298_idempotency.rs
@@ -1,0 +1,306 @@
+//! TDD (RED) regression tests for issue #2298 — procedural-memory
+//! non-idempotency defect ("procedural memory is frozen").
+//!
+//! ## Symptom
+//!
+//! Every OODA consolidation cycle re-stores the *identical* procedures
+//! (`consolidate:ad-hoc`, `pr-merge:adopt-tdd`, `pr-merge:fix-broken-features`).
+//! The daemon logs `OODA consolidation: stored procedure '…'` on every
+//! cycle, compression stays at 0%, and only the 5 bootstrap procedures
+//! are ever recalled because the store keeps growing duplicate nodes.
+//!
+//! ## Confirmed root cause
+//!
+//! [`NativeCognitiveMemory::store_procedure`](super::ops) issues an
+//! unconditional `CREATE (p:Procedure { id: <fresh new_id> … })` with no
+//! dedup on `name`, and the `Procedure` table keys on `id` (not `name`),
+//! so the DB does not dedup either. Calling it twice with the same
+//! `(name, steps, prerequisites)` produces two nodes.
+//!
+//! The PR-B episode-distillation invariants (`mark_episode_distilled` /
+//! `list_undistilled_episodes`, issue #2281) are already correct — these
+//! tests guard them as a regression but do not change them.
+//!
+//! ## Expected RED signal (pre-fix)
+//!
+//! * `store_procedure_is_idempotent_on_exact_name` — recall count is 2,
+//!   expected 1. FAILS.
+//! * `store_procedure_returns_stable_id_for_duplicate` — the second call
+//!   returns a different `proc_…` id. FAILS.
+//! * `repeated_ooda_consolidation_does_not_re_store_procedures` — each of
+//!   the three symptom procedures has 2 nodes after two cycles. FAILS.
+//! * `consolidation_cycle_is_idempotent_and_keeps_episodes_distilled` —
+//!   the procedure-count assertion fails (duplicates); the episode-mark
+//!   assertions already pass (PR-B). FAILS overall on duplication.
+//!
+//! ## Expected GREEN signal (post-fix)
+//!
+//! `store_procedure` becomes an idempotent upsert keyed on exact `name`:
+//! a second store with the same name creates no new node and returns the
+//! existing id. All tests below pass; genuinely new names still create
+//! new nodes (`store_procedure_preserves_distinct_named_procedures`).
+//!
+//! These tests target `NativeCognitiveMemory::in_memory()` directly so
+//! the native override — where the bug lives — is exercised without the
+//! bridge/IPC/mock layers (whose stub `store_procedure` impls would hide
+//! the defect).
+
+use super::{CognitiveMemoryOps, NativeCognitiveMemory};
+
+fn test_mem() -> NativeCognitiveMemory {
+    NativeCognitiveMemory::in_memory().expect("in-memory DB should create")
+}
+
+/// Count the procedures whose `name` is *exactly* `name`.
+///
+/// Uses the `"*"` wildcard recall (returns every procedure, `LIMIT`-only)
+/// with a generous limit and then filters in Rust to exact equality. We
+/// deliberately avoid `recall_procedure(name, …)` because its `CONTAINS`
+/// matcher would also surface superstring names and mask duplicates.
+fn count_exact(mem: &NativeCognitiveMemory, name: &str) -> usize {
+    mem.recall_procedure("*", 10_000)
+        .expect("recall_procedure(\"*\") must succeed")
+        .into_iter()
+        .filter(|p| p.name == name)
+        .count()
+}
+
+/// AC#1 — Re-storing a procedure with an identical name MUST NOT create a
+/// second node. The store is an upsert keyed on exact `name`.
+///
+/// Pre-fix: `store_procedure` runs an unconditional `CREATE` with a fresh
+/// id, so the wildcard recall returns two rows for the same name → the
+/// `assert_eq!(…, 1)` fails. This is the primary RED gate.
+#[test]
+fn store_procedure_is_idempotent_on_exact_name() {
+    let mem = test_mem();
+    let name = "consolidate:ad-hoc | triggers: consolidate,memory,distill,g";
+    let steps = [
+        "assess working memory".to_string(),
+        "distill episodes".to_string(),
+    ];
+
+    mem.store_procedure(name, &steps, &[]).expect("first store");
+    mem.store_procedure(name, &steps, &[])
+        .expect("second (identical) store");
+
+    assert_eq!(
+        count_exact(&mem, name),
+        1,
+        "storing the same-named procedure twice must leave exactly one \
+         node (idempotent upsert on `name`); duplicate nodes are the \
+         issue #2298 'frozen procedural memory' defect"
+    );
+}
+
+/// AC#4 — `store_procedure` MUST return a *stable* id across duplicate
+/// calls: the second store of an existing name returns the id of the
+/// already-stored node rather than minting a new `proc_…` id.
+///
+/// Pre-fix: the second call mints a fresh `Self::new_id("proc")`, so the
+/// two ids differ → the `assert_eq!` fails.
+#[test]
+fn store_procedure_returns_stable_id_for_duplicate() {
+    let mem = test_mem();
+    let name = "pr-merge:adopt-tdd | triggers: pr,merge,tdd,test";
+    let steps = ["write failing test".to_string(), "implement".to_string()];
+
+    let id_first = mem.store_procedure(name, &steps, &[]).expect("first store");
+    let id_second = mem
+        .store_procedure(name, &steps, &[])
+        .expect("second (identical) store");
+
+    assert_eq!(
+        id_first, id_second,
+        "a duplicate store must return the existing node id (got first={id_first:?}, \
+         second={id_second:?}); a changing id proves a new node was created"
+    );
+}
+
+/// AC#2 — The idempotency fix MUST NOT over-dedup: genuinely different
+/// procedure names still accumulate as distinct nodes so the system can
+/// keep learning. This guards against a fix that collapses everything.
+///
+/// Passes both pre- and post-fix; it is the safety rail that proves the
+/// dedup key is *exact name* and nothing coarser.
+#[test]
+fn store_procedure_preserves_distinct_named_procedures() {
+    let mem = test_mem();
+    let name_a = "consolidate:ad-hoc | triggers: consolidate,memory,distill,g";
+    let name_b = "pr-merge:fix-broken-features | triggers: pr,merge,fix,feature";
+
+    mem.store_procedure(name_a, &["a1".to_string()], &[])
+        .expect("store A");
+    mem.store_procedure(name_b, &["b1".to_string()], &[])
+        .expect("store B");
+
+    assert_eq!(count_exact(&mem, name_a), 1, "procedure A must exist once");
+    assert_eq!(count_exact(&mem, name_b), 1, "procedure B must exist once");
+
+    let total = mem.recall_procedure("*", 10_000).expect("recall all").len();
+    assert_eq!(
+        total, 2,
+        "two distinct names must produce two distinct nodes — the fix \
+         must dedup on exact name, not collapse unrelated procedures"
+    );
+}
+
+/// AC#1 (headline) — Faithful reproduction of the reported symptom: the
+/// three procedures named in the daemon log are "stored" on two
+/// successive consolidation cycles. After the second cycle each name must
+/// still resolve to exactly one node.
+///
+/// Pre-fix: each `store_procedure` call appends a node, so every name has
+/// two nodes after two cycles → all three `assert_eq!(…, 1)` checks fail.
+#[test]
+fn repeated_ooda_consolidation_does_not_re_store_procedures() {
+    let mem = test_mem();
+
+    // The exact procedure identities from the issue #2298 daemon log.
+    let procedures: [(&str, [String; 2]); 3] = [
+        (
+            "consolidate:ad-hoc | triggers: consolidate,memory,distill,g",
+            ["assess working memory".to_string(), "distill".to_string()],
+        ),
+        (
+            "pr-merge:adopt-tdd | triggers: pr,merge,tdd,test",
+            ["write failing test".to_string(), "implement".to_string()],
+        ),
+        (
+            "pr-merge:fix-broken-features | triggers: pr,merge,fix,feature",
+            ["diagnose".to_string(), "repair".to_string()],
+        ),
+    ];
+
+    // Two identical OODA consolidation cycles, exactly as the daemon does.
+    for _cycle in 0..2 {
+        for (name, steps) in &procedures {
+            mem.store_procedure(name, steps, &[])
+                .expect("OODA procedural store");
+        }
+    }
+
+    for (name, _) in &procedures {
+        assert_eq!(
+            count_exact(&mem, name),
+            1,
+            "procedure '{name}' must exist exactly once after two identical \
+             consolidation cycles; >1 means the cycle is re-storing it every \
+             pass (issue #2298, 0% compression)"
+        );
+    }
+
+    let total = mem.recall_procedure("*", 10_000).expect("recall all").len();
+    assert_eq!(
+        total, 3,
+        "exactly the three distinct procedures must be present after two \
+         cycles, not six"
+    );
+}
+
+/// Combined invariant (AC#1 + AC#3) — A consolidation pass that (a) stores
+/// procedures via procedural learning and (b) marks the processed episodes
+/// distilled must be idempotent on *both* axes when re-run on the same
+/// inputs:
+///
+/// 1. the procedure store does not grow (no duplicate nodes), and
+/// 2. the processed episodes stay marked distilled and never reappear in
+///    `list_undistilled_episodes`.
+///
+/// Pre-fix: invariant (1) is violated — the procedure count doubles — so
+/// the procedure assertion fails. Invariant (2) already holds (PR-B,
+/// issue #2281) and is guarded here against future regression.
+#[test]
+fn consolidation_cycle_is_idempotent_and_keeps_episodes_distilled() {
+    let mem = test_mem();
+
+    // Seed an episode window that a consolidation cycle would process.
+    let episode_ids: Vec<String> = (0..4)
+        .map(|i| {
+            mem.store_episode(&format!("episode {i}: did some work"), "test", None)
+                .expect("store_episode")
+        })
+        .collect();
+
+    let proc_name = "consolidate:ad-hoc | triggers: consolidate,memory,distill,g";
+    let proc_steps = ["assess".to_string(), "distill".to_string()];
+
+    // One consolidation cycle: learn the procedure, then mark every
+    // episode in the window as distilled. Runs identically each cycle.
+    let run_cycle = |mem: &NativeCognitiveMemory| {
+        mem.store_procedure(proc_name, &proc_steps, &[])
+            .expect("procedural learning store");
+        for id in &episode_ids {
+            mem.mark_episode_distilled(id)
+                .expect("mark_episode_distilled");
+        }
+    };
+
+    run_cycle(&mem);
+    run_cycle(&mem); // identical second cycle — must be a no-op everywhere
+
+    // Invariant 1: procedural store did not grow.
+    assert_eq!(
+        count_exact(&mem, proc_name),
+        1,
+        "two identical consolidation cycles must leave exactly one \
+         '{proc_name}' node; duplicates are the issue #2298 defect"
+    );
+
+    // Invariant 2: every processed episode is (and stays) distilled.
+    let undistilled = mem
+        .list_undistilled_episodes(100)
+        .expect("list_undistilled_episodes");
+    let undistilled_ids: std::collections::HashSet<&str> =
+        undistilled.iter().map(|e| e.node_id.as_str()).collect();
+    for id in &episode_ids {
+        assert!(
+            !undistilled_ids.contains(id.as_str()),
+            "episode {id} was processed by the cycle and must remain \
+             marked distilled (absent from list_undistilled_episodes); \
+             still-undistilled rows would be re-distilled every cycle"
+        );
+    }
+    assert!(
+        undistilled.is_empty(),
+        "all 4 processed episodes must be distilled after the cycle; \
+         still undistilled: {undistilled_ids:?}"
+    );
+}
+
+/// Reinforcement signal — the existing-name path is an idempotent *upsert*,
+/// not a pure no-op. Re-storing a procedure with an identical name bumps the
+/// stored node's `usage_count` so the recurrence signal that
+/// `recall_procedure` ranks on is preserved across cycles. Node count stays
+/// at one (guarded by the tests above); only the counter advances.
+///
+/// This locks the documented contract (see
+/// `docs/reference/cognitive-memory-procedural-idempotency.md`): idempotency
+/// is defined over the *node count*, deliberately not over `usage_count`.
+#[test]
+fn store_procedure_reinforces_usage_count_on_duplicate() {
+    let mem = test_mem();
+    let name = "consolidate:ad-hoc | triggers: consolidate,memory,distill,g";
+    let steps = ["assess".to_string(), "distill".to_string()];
+
+    mem.store_procedure(name, &steps, &[])
+        .expect("first store (create)");
+    mem.store_procedure(name, &steps, &[])
+        .expect("second store (reinforce)");
+    mem.store_procedure(name, &steps, &[])
+        .expect("third store (reinforce)");
+
+    let proc = mem
+        .recall_procedure("*", 10_000)
+        .expect("recall all")
+        .into_iter()
+        .find(|p| p.name == name)
+        .expect("procedure must exist");
+
+    assert_eq!(
+        proc.usage_count, 2,
+        "three identical stores = one create (usage_count 0) plus two \
+         reinforcements (+1 each); usage_count must record the 2 recurrences \
+         while the node count stays at exactly one"
+    );
+}

--- a/src/ooda_loop/cycle.rs
+++ b/src/ooda_loop/cycle.rs
@@ -370,22 +370,17 @@ fn run_ooda_cycle_inner(
                 &outcome.action.description,
             );
             let steps = [outcome.action.description.clone(), outcome.detail.clone()];
-            // Issue #2298: `store_procedure` is now an idempotent upsert, so
-            // re-storing an existing procedure creates no new node (it only
-            // bumps `usage_count`). The old log unconditionally claimed
-            // "stored procedure" every cycle, which made frozen procedural
-            // memory look like fresh learning. Pre-check for an existing
-            // exact-name procedure — mirroring the bootstrap seeder, since
-            // `recall_procedure` uses `CONTAINS` and can surface superstring
-            // names — and log "reinforced" rather than "stored" when the
-            // procedure already existed.
-            let already_present = match bridges.memory.recall_procedure(&proc_name, 16) {
-                Ok(hits) => hits.iter().any(|h| h.name == proc_name),
-                Err(e) => {
-                    eprintln!("[simard] OODA consolidation: procedural recall failed: {e}");
-                    false
-                }
-            };
+            // Issue #2298: `store_procedure` is an idempotent upsert, so an
+            // existing procedure is only reinforced (its `usage_count` bumps),
+            // never re-created. Probe first so the log distinguishes the two —
+            // otherwise frozen procedural memory reads as fresh learning. A
+            // recall failure is non-fatal and defaults to the "stored" wording.
+            let already_present =
+                crate::cognitive_memory::procedure_exists(&*bridges.memory, &proc_name)
+                    .unwrap_or_else(|e| {
+                        eprintln!("[simard] OODA consolidation: procedural recall failed: {e}");
+                        false
+                    });
             if let Err(e) = bridges.memory.store_procedure(&proc_name, &steps, &[]) {
                 eprintln!("[simard] OODA consolidation: procedural memory failed: {e}");
             } else if already_present {

--- a/src/ooda_loop/cycle.rs
+++ b/src/ooda_loop/cycle.rs
@@ -370,8 +370,26 @@ fn run_ooda_cycle_inner(
                 &outcome.action.description,
             );
             let steps = [outcome.action.description.clone(), outcome.detail.clone()];
+            // Issue #2298: `store_procedure` is now an idempotent upsert, so
+            // re-storing an existing procedure creates no new node (it only
+            // bumps `usage_count`). The old log unconditionally claimed
+            // "stored procedure" every cycle, which made frozen procedural
+            // memory look like fresh learning. Pre-check for an existing
+            // exact-name procedure — mirroring the bootstrap seeder, since
+            // `recall_procedure` uses `CONTAINS` and can surface superstring
+            // names — and log "reinforced" rather than "stored" when the
+            // procedure already existed.
+            let already_present = match bridges.memory.recall_procedure(&proc_name, 16) {
+                Ok(hits) => hits.iter().any(|h| h.name == proc_name),
+                Err(e) => {
+                    eprintln!("[simard] OODA consolidation: procedural recall failed: {e}");
+                    false
+                }
+            };
             if let Err(e) = bridges.memory.store_procedure(&proc_name, &steps, &[]) {
                 eprintln!("[simard] OODA consolidation: procedural memory failed: {e}");
+            } else if already_present {
+                eprintln!("[simard] OODA consolidation: reinforced procedure '{proc_name}'");
             } else {
                 eprintln!("[simard] OODA consolidation: stored procedure '{proc_name}'");
             }

--- a/src/ooda_loop/cycle.rs
+++ b/src/ooda_loop/cycle.rs
@@ -375,12 +375,13 @@ fn run_ooda_cycle_inner(
             // never re-created. Probe first so the log distinguishes the two —
             // otherwise frozen procedural memory reads as fresh learning. A
             // recall failure is non-fatal and defaults to the "stored" wording.
-            let already_present =
-                crate::cognitive_memory::procedure_exists(&*bridges.memory, &proc_name)
-                    .unwrap_or_else(|e| {
-                        eprintln!("[simard] OODA consolidation: procedural recall failed: {e}");
-                        false
-                    });
+            let already_present = bridges
+                .memory
+                .procedure_exists(&proc_name)
+                .unwrap_or_else(|e| {
+                    eprintln!("[simard] OODA consolidation: procedural recall failed: {e}");
+                    false
+                });
             if let Err(e) = bridges.memory.store_procedure(&proc_name, &steps, &[]) {
                 eprintln!("[simard] OODA consolidation: procedural memory failed: {e}");
             } else if already_present {


### PR DESCRIPTION
Fixes #2298.

## Symptom

Procedural memory was **frozen**. Every OODA consolidation cycle re-stored the
*identical* procedures and the daemon logged, every cycle:

```
[simard] OODA consolidation: stored procedure 'consolidate:ad-hoc | triggers: consolidate,memory,distill,g'
```

Result: 0% procedural compression, the node table grew unbounded, and
`recall_procedure` only ever surfaced the 5 bootstrap procedures — no learned
procedures ever accumulated in a queryable way.

## Root cause (confirmed)

`NativeCognitiveMemory::store_procedure` (`src/cognitive_memory/ops.rs`) issued
an **unconditional `CREATE`** with a fresh `new_id("proc")`, and the `Procedure`
table keys on `id`, **not** `name`. So neither the code nor the DB deduped:
calling it twice with the same `(name, steps, prerequisites)` produced two
nodes. Because `compose_procedure_name` yields the *same* name for the same
successful action cycle after cycle, duplicates piled up forever.

The two other candidates were investigated and **ruled out** (left untouched):

| Candidate | Verdict |
|-----------|---------|
| `mark_episode_distilled` not persisting | Not the cause — `SET e.distilled = 1` + write barrier persist correctly. |
| `list_undistilled_episodes` re-returning episodes | Not the cause — the `WHERE e.distilled = 0` gate excludes marked rows. |
| Procedural-store upsert creating new nodes | **Confirmed root cause.** |

## The fix

`store_procedure` is now an **idempotent upsert keyed on the exact `name`**:

**Before**
```cypher
-- one new node every call, regardless of name collision
CREATE (p:Procedure {id: 'proc_<fresh-uuid>', name: '<name>', ..., usage_count: 0})
```

**After**
```text
read-before-write on exact name:
  existing name -> NO new node; bump usage_count
                   (SET p.usage_count = p.usage_count + 1); return existing id
  new name      -> CREATE as before (usage_count: 0); return new id
```

- Dedup key is **exact `name` equality** (not `recall_procedure`'s `CONTAINS`),
  mirroring the bootstrap seeder. Distinct names still accumulate, so learning
  is preserved.
- Idempotency lives **inside** `store_procedure`, so every caller (OODA cycle,
  bootstrap seeder, future writers) inherits it.
- The trait signature is **unchanged** (`-> SimardResult<String>`), so there is
  no IPC/wire-protocol change and no ripple through the other impls/stubs.
- The existing-name path bumps `usage_count` to preserve the
  reinforcement/recurrence signal — idempotency is defined over **node count**,
  not over `usage_count`.

Also fixes the misleading daemon log: the OODA call site
(`src/ooda_loop/cycle.rs`) now pre-checks for an existing exact-name procedure
and logs `reinforced procedure '<name>'` instead of `stored procedure '<name>'`
when nothing new was created.

## Tests (TDD — failing test first)

Added `src/cognitive_memory/tests_pr_2298_idempotency.rs`, committed **before**
the fix as a RED regression (commit `test(cog-mem): failing idempotency …`).
The tests target `NativeCognitiveMemory::in_memory()` directly — not the
bridge/IPC/mock stubs whose no-op `store_procedure` would hide the defect:

- `store_procedure_is_idempotent_on_exact_name` — count stays 1 (pre-fix: 2).
- `store_procedure_returns_stable_id_for_duplicate` — second store returns the
  existing id (pre-fix: a fresh `proc_…` id).
- `store_procedure_preserves_distinct_named_procedures` — no over-dedup.
- `repeated_ooda_consolidation_does_not_re_store_procedures` — faithful symptom
  reproduction across two cycles → one node each (pre-fix: two each).
- `store_procedure_reinforces_usage_count_on_duplicate` — node count stable,
  `usage_count` advances.
- `consolidation_cycle_is_idempotent_and_keeps_episodes_distilled` — combined
  invariant: procedure count stable **and** processed episodes stay distilled
  (absent from `list_undistilled_episodes`).

### Verification

- New tests: RED (4 of 5 fail) pre-fix → all GREEN post-fix.
- `cargo test --lib` for the affected modules: `cognitive_memory` (184),
  `ooda_loop` (202), `memory_consolidation` (50) — all pass.
- Integration: `ooda`, `ooda_daemon`, `memory_durable`,
  `memory_consolidation_lifecycle` — all pass.
- `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` — clean
  (pre-commit + pre-push gates passed).

## Docs

Adds `docs/reference/cognitive-memory-procedural-idempotency.md` and updates the
OODA / bootstrap / memory references whose "intentional accumulation of
identical names" wording this supersedes.

## Out of scope

Episodic-recall, trigger derivation (`compose_procedure_name`), and
`mark_episode_distilled` / `list_undistilled_episodes` are owned by separate
workstreams and are only regression-guarded here. Historical duplicate rows
from pre-fix cycles are left in place (a future hygiene CLI can collapse them);
this change only stops *adding* new duplicates.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

---

## Step 13: Local Testing Results

**Outside-in testing, adapted for a Rust crate.** This repository is the
`simard` Rust crate, not a Python `amplihack` package, so the
`uvx --from git+...@<branch> amplihack <command>` template does not apply. The
equivalent outside-in test builds the crate **from this PR branch** and runs the
**real persistent LadybugDB-backed `NativeCognitiveMemory`** — the exact backend
the OODA daemon uses — through the public crate API, as separate OS processes.
The daemon's own `simard ooda run` path hard-requires an LLM provider
(`LlmProvider::resolve()`), so it cannot reach the consolidation step in a
credential-less environment; this harness exercises the same `store_procedure` /
`procedure_exists` / `mark_episode_distilled` code the daemon calls, without an
LLM. A throwaway `examples/` helper (the project's established cross-process test
pattern, e.g. `cross_session_recall_helper.rs`) opened `NativeCognitiveMemory::open(state_root)`
and simulated OODA consolidation cycles.

`Pre-fix expectation` (per the committed RED regression in
`tests_pr_2298_idempotency.rs`): each procedure would have `count=2` and
`TOTAL_PROCS=6` after two cycles (duplicate nodes, 0% compression). `Post-fix`
runs below show `count=1` / `TOTAL_PROCS=3` with reinforcement.

### Scenario 1 — simple: two consolidation cycles re-store the same procedures
Command: `cargo build --example issue_2298_idempotency_helper` (built from PR branch `fix/issue-2298-...`), then ran the binary twice against one fresh on-disk LadybugDB state root:
`target/debug/examples/issue_2298_idempotency_helper --state-root <tmp> --phase cycle` (×2)
Result: **PASS**
Output (key lines):
```
== CYCLE 1 (fresh DB) ==
[cycle] OODA consolidation: stored procedure 'consolidate:ad-hoc | triggers: consolidate,memory,distill,g'
[cycle] OODA consolidation: stored procedure 'pr-merge:adopt-tdd | triggers: pr,merge,tdd,test'
[cycle] OODA consolidation: stored procedure 'pr-merge:fix-broken-features | triggers: pr,merge,fix,feature'
PROC ... count=1 usage=0   (×3)
TOTAL_PROCS 3
== CYCLE 2 (same DB, separate process) ==
[cycle] OODA consolidation: reinforced procedure 'consolidate:ad-hoc | triggers: consolidate,memory,distill,g'
[cycle] OODA consolidation: reinforced procedure 'pr-merge:adopt-tdd | triggers: pr,merge,tdd,test'
[cycle] OODA consolidation: reinforced procedure 'pr-merge:fix-broken-features | triggers: pr,merge,fix,feature'
PROC ... count=1 usage=1   (×3)
TOTAL_PROCS 3
```
The exact issue symptom line — `OODA consolidation: stored procedure 'consolidate:ad-hoc | triggers: consolidate,memory,distill,g'` — now logs **`reinforced`** on the second cycle. Node count stays `1` (was `2` pre-fix); `TOTAL_PROCS` stays `3` (was `6`); `usage_count` records the recurrence.

### Scenario 2 — complex: cross-process persistence of dedup + episode-distilled marks
Command: three **separate OS processes** against the same on-disk state root (true daemon-restart scenario):
1. `... --phase cycle --seed-episodes`  (store 3 procs + 4 episodes, mark all distilled)
2. `... --phase cycle`                  (2nd consolidation, no new episodes)
3. `... --phase report`                 (FRESH handle — verify persistence)
Result: **PASS**
Output (key lines):
```
== PROCESS A: cycle --seed-episodes ==
[cycle] OODA consolidation: stored procedure '...'   (×3)
[cycle] marked 4 episodes distilled
TOTAL_PROCS 3 | UNDISTILLED 0
== PROCESS B: cycle ==
[cycle] OODA consolidation: reinforced procedure '...'   (×3)
PROC ... count=1 usage=1 (×3) | TOTAL_PROCS 3 | UNDISTILLED 0
== PROCESS C: report (fresh handle) ==
PROC ... count=1 usage=1 (×3)
TOTAL_PROCS 3
UNDISTILLED 0
```
Across three process restarts: procedures dedup (`count=1`, `TOTAL_PROCS=3`, never `6`), `usage_count` reinforcement persists, and the 4 episodes stay distilled (`UNDISTILLED=0` from the independent reader process) — proving `mark_episode_distilled` persists so distillation will not re-process the same episodes every cycle.

### Regression check
- `cargo test --lib cognitive_memory::tests_pr_2298_idempotency` → **6 passed, 0 failed**.
- Full `cargo test --lib` → **5689 passed**. One unrelated flake
  (`operator_commands_dashboard::tests_goals_crud::goals_includes_status_chip_for_active_goals`)
  fails only under parallel execution (it falls back to a shared `~/.simard`
  read-only DB — cross-test state-root pollution) and **passes in isolation**;
  it does not touch procedures and is unrelated to #2298.

Both scenarios passed. The temporary helper was removed after testing; the fix's
permanent regression guard is the committed `tests_pr_2298_idempotency.rs` suite.
