### PR TITLE
fix(dashboard): stop Memory tab showing empty legacy file tiles (#1681)

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -29,7 +29,7 @@ The dashboard is a single-page app with the following tabs:
 | **Traces** | Live-tailed engineer subprocess traces and OODA cycle traces (xterm.js terminal). |
 | **Logs** | Aggregated daemon and engineer logs. |
 | **Processes** | Live process tree under the daemon — engineer subprocesses, LLM sessions, and their resource usage. |
-| **Memory** | Cognitive memory graph (Working / Semantic / Episodic / Procedural / Prospective / Sensory) with per-type filters; full-text memory search; memory overview and per-type file listings. See [Memory architecture](memory.md). |
+| **Memory** | Cognitive memory graph (Working / Semantic / Episodic / Procedural / Prospective / Sensory) with per-type filters; full-text memory search; a **Memory Overview** with the live **Memory Store** counts; and a **Memory Files** panel showing the goals snapshot plus any non-empty legacy snapshot files. See [Memory architecture](memory.md). |
 | **Costs** | Per-provider, per-model token spend across the active session. |
 | **Chat** | Direct chat with Simard. |
 | **Workboard** | Shared scratch canvas. (Renamed from "Whiteboard" — see [Tab identity contract](#tab-identity-contract).) |
@@ -49,6 +49,30 @@ Goals — active priorities and backlog:
 Memory — six cognitive memory types with filters and search:
 
 ![Memory tab](assets/dashboard-memory.png)
+
+### Memory tab: live store vs. legacy snapshots
+
+The **Memory Overview** card is the source of truth. Its **Memory Store**
+section reports the live cognitive-memory counts straight from the native
+graph store: recent observations, what Simard is currently thinking about,
+events remembered, facts learned, known procedures, and planned actions.
+
+The **Memory Files** panel sits beside it and is intentionally minimal:
+
+- **Goals (snapshot)** — a point-in-time count of active and backlog goals,
+  sourced from cognitive memory (not a disk file). It links to the **Goals**
+  tab for the full board.
+- **Legacy snapshots** — a single collapsed disclosure ("Legacy snapshots
+  (superseded by the Memory Store)") that lists the retired JSON snapshot
+  files (`memory_records.json`, `evidence_records.json`, `latest_handoff.json`)
+  **only when a file actually has content**. When none of them qualify, the
+  panel shows a one-line note instead.
+
+This matters because those JSON files were superseded by the native Memory
+Store. Rendering them as permanent "0 records / 0 B" tiles next to a store
+holding thousands of facts told operators that memory was empty when it was
+rich. The panel now hides empty legacy tiles so the displayed numbers always
+match Simard's actual remembered state.
 
 ## Read-only
 

--- a/src/operator_commands_dashboard/index_html/part_02.rs
+++ b/src/operator_commands_dashboard/index_html/part_02.rs
@@ -159,7 +159,7 @@ pub(crate) const PART_02: &str = r#"          if(d.ooda_transcripts?.length){
         const d=await apiFetch('/api/memory');
         let overviewHtml=`
           <div class="stat"><span class="label">Total Facts</span><span class="value">${d.total_facts}</span></div>
-          <div class="stat"><span class="label">Last Memory Compaction</span><span class="value">${d.last_consolidation?timeAgo(d.last_consolidation)+' ('+formatTime(d.last_consolidation)+')':'Never'}</span></div>
+          <div class="stat"><span class="label">Last Memory Compaction</span><span class="value">${d.last_consolidation?timeAgo(d.last_consolidation)+' ('+formatTime(d.last_consolidation)+')':'Not tracked yet'}</span></div>
           <div class="stat"><span class="label">State Root</span><span class="value" style="font-size:.8rem;word-break:break-all">${esc(d.state_root)}</span></div>`;
         if(d.native_memory){
           const nm=d.native_memory;
@@ -174,19 +174,45 @@ pub(crate) const PART_02: &str = r#"          if(d.ooda_transcripts?.length){
           <div class="stat"><span class="label"><strong>Total Native</strong></span><span class="value"><strong>${nm.total}</strong></span></div>`;
         }
         document.getElementById('mem-overview').innerHTML=overviewHtml;
-        const files=[
-          {key:'memory_records',label:'Memory Records'},
-          {key:'evidence_records',label:'Evidence Records'},
-          {key:'goal_records',label:'Goal Records (agent memory)'},
-          {key:'handoff',label:'Latest Handoff'}];
-        document.getElementById('mem-files').innerHTML=files.map(f=>{
+        // Memory Files panel (#1681). The Memory Store above is the live
+        // source of truth; the JSON snapshot files below are legacy and were
+        // superseded by it. Rendering empty "0 records / 0 B" tiles next to a
+        // populated store told the operator memory was empty when it was not,
+        // so legacy file tiles now render only when a file actually has
+        // content. The goals snapshot is sourced from cognitive memory (not a
+        // file) and is always shown with a link back to the Goals tab.
+        const goals=d.goal_records||{};
+        let filesHtml=`<div class="mem-file">
+            <h3>Goals (snapshot) ${goals.count!==undefined?'<span class="badge">'+goals.count+'</span>':''}</h3>
+            <p style="margin:.25rem 0 0;font-size:.8rem;color:#8b949e">A point-in-time count of active and backlog goals. Open the <a href="javascript:void(0)" onclick="document.querySelector('.tab[data-tab=goals]').click();return false" style="color:var(--accent)">Goals tab</a> for the full board.</p>
+          </div>`;
+        const legacy=[
+          {key:'memory_records',label:'Memory records'},
+          {key:'evidence_records',label:'Evidence records'},
+          {key:'handoff',label:'Latest handoff'}];
+        // A legacy file is worth showing only when it has bytes on disk AND,
+        // for the JSON record files that report a count, at least one record —
+        // so an empty "[]" snapshot never resurfaces the "0 records" misread.
+        const legacyWithData=legacy.filter(f=>{
           const info=d[f.key]||{};
-          const modStr=info.modified?timeAgo(info.modified):(info.source?esc(info.source):'N/A');
-          const sizeBadge=(info.size_bytes!==undefined)?'<span class="badge">'+fmtB(info.size_bytes||0)+'</span>':'';
-          return`<div class="mem-file">
-            <h3>${f.label} ${info.count!==undefined?'<span class="badge">'+info.count+' records</span>':''} ${sizeBadge}</h3>
-            <div class="stat"><span class="label">${info.source?'Source':'Modified'}</span><span class="value">${modStr}</span></div>
-          </div>`;}).join('');
+          if((info.size_bytes||0)<=0) return false;
+          if(info.count!==undefined && info.count<=0) return false;
+          return true;
+        });
+        if(legacyWithData.length){
+          const cards=legacyWithData.map(f=>{
+            const info=d[f.key]||{};
+            const modStr=info.modified?timeAgo(info.modified):'N/A';
+            const countBadge=info.count!==undefined?'<span class="badge">'+info.count+' records</span>':'';
+            return`<div class="mem-file">
+              <h3>${esc(f.label)} ${countBadge} <span class="badge">${fmtB(info.size_bytes||0)}</span></h3>
+              <div class="stat"><span class="label">Modified</span><span class="value">${modStr}</span></div>
+            </div>`;}).join('');
+          filesHtml+=`<details style="margin-top:.5rem"><summary style="cursor:pointer;color:#8b949e;font-size:.85rem;user-select:none">Legacy snapshots (superseded by the Memory Store)</summary><div style="margin-top:.5rem">${cards}</div></details>`;
+        }else{
+          filesHtml+=`<p style="margin:.5rem 0 0;font-size:.8rem;color:#8b949e">No legacy snapshot files with content — memory now lives in the Memory Store above.</p>`;
+        }
+        document.getElementById('mem-files').innerHTML=filesHtml;
       }catch(e){document.getElementById('mem-overview').innerHTML='<span class="err">Failed to load memory data — check state root path</span>';}
     }
 

--- a/src/operator_commands_dashboard/tests_routes_a.rs
+++ b/src/operator_commands_dashboard/tests_routes_a.rs
@@ -571,6 +571,96 @@ mod tests {
         );
     }
 
+    /// Regression for #1681. The Memory tab's "Memory Files" panel used to
+    /// render four fixed tiles — including legacy JSON snapshot files
+    /// (`memory_records`, `evidence_records`, `handoff`) — unconditionally.
+    /// When those retired files were empty the panel showed
+    /// "Memory Records 0 records 0 B / Evidence Records 0 records 0 B /
+    /// Latest Handoff 0 B" right next to a populated native Memory Store,
+    /// telling the operator memory was empty when it was rich. The fix only
+    /// surfaces a legacy file when it actually has bytes, always shows the
+    /// goals snapshot, and uses plain-language labels.
+    #[test]
+    fn index_html_memory_files_hides_empty_legacy_tiles() {
+        // The old jargon label and the unconditional four-tile array are gone.
+        assert!(
+            !INDEX_HTML.contains("Goal Records (agent memory)"),
+            "the legacy 'Goal Records (agent memory)' tile label must be \
+             replaced with plain language"
+        );
+
+        // Legacy tiles are gated on real content so empty files never render.
+        // The guard must reference size_bytes and the record count.
+        assert!(
+            INDEX_HTML.contains("legacyWithData"),
+            "memory panel must filter legacy files to those with content"
+        );
+        assert!(
+            INDEX_HTML.contains("(info.size_bytes||0)<=0"),
+            "legacy file tiles must be gated on non-zero size_bytes so empty \
+             '0 B' files never render (#1681)"
+        );
+        assert!(
+            INDEX_HTML.contains("info.count<=0"),
+            "legacy JSON files that report a count must have at least one \
+             record to render, so an empty '[]' never shows '0 records' (#1681)"
+        );
+
+        // The single collapsed disclosure replaces the always-on tiles, using
+        // plain language (no 'LadybugDB' jargon — it is the 'Memory Store').
+        assert!(
+            INDEX_HTML.contains("Legacy snapshots (superseded by the Memory Store)"),
+            "legacy files must collapse into a single plain-language disclosure"
+        );
+        assert!(
+            !INDEX_HTML.contains("superseded by LadybugDB"),
+            "operator-facing labels must avoid the 'LadybugDB' jargon"
+        );
+    }
+
+    /// #1681: the goals snapshot tile is always shown (it is sourced from
+    /// cognitive memory, not a disk file) and links back to the Goals tab so
+    /// an operator can reach the full board in one click.
+    #[test]
+    fn index_html_memory_files_goals_snapshot_links_to_goals_tab() {
+        assert!(
+            INDEX_HTML.contains("Goals (snapshot)"),
+            "the goals snapshot tile must use the plain 'Goals (snapshot)' label"
+        );
+        let pos = INDEX_HTML
+            .find("Goals (snapshot)")
+            .expect("'Goals (snapshot)' tile must exist on the Memory tab");
+        let window_end = (pos + 400).min(INDEX_HTML.len());
+        let window = &INDEX_HTML[pos..window_end];
+        assert!(
+            window.contains("data-tab=goals"),
+            "the goals snapshot tile must link to the Goals tab — window: {window:?}"
+        );
+    }
+
+    /// #1681: "Last Memory Compaction" must not display the literal "Never"
+    /// when no timestamp source exists — consolidation has demonstrably run,
+    /// so "Never" is anti-information. The honest fallback is "Not tracked
+    /// yet", and the absolute-timestamp branch still routes through formatTime.
+    #[test]
+    fn index_html_last_consolidation_not_never() {
+        let pos = INDEX_HTML
+            .find("Last Memory Compaction")
+            .expect("'Last Memory Compaction' stat must exist on the Memory tab");
+        let window_end = (pos + 400).min(INDEX_HTML.len());
+        let window = &INDEX_HTML[pos..window_end];
+        assert!(
+            !window.contains("'Never'"),
+            "Last Memory Compaction must not fall back to the literal 'Never' \
+             — window: {window:?}"
+        );
+        assert!(
+            window.contains("Not tracked yet"),
+            "Last Memory Compaction must fall back to 'Not tracked yet' when \
+             the timestamp source is missing — window: {window:?}"
+        );
+    }
+
     /// The cluster topology panel (part_05.rs) refresh timestamp must
     /// render via `formatTime`. This was the third migrated call site.
     #[test]

--- a/tests/gadugi/dashboard-memory-fidelity.sh
+++ b/tests/gadugi/dashboard-memory-fidelity.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# dashboard-memory-fidelity.sh — outside-in check for issue #1681.
+#
+# The Memory tab used to render four always-on "Memory Files" tiles, including
+# retired JSON snapshot files (memory_records / evidence_records / handoff).
+# When those files were empty the panel showed "0 records / 0 B" tiles right
+# next to a populated native Memory Store, telling the operator memory was
+# empty when it was rich. This script boots the real dashboard binary, logs in,
+# and asserts — against the served HTML and the live /api/memory response —
+# that the misleading tiles are gone, the live Memory Store counts are exposed,
+# and the goals snapshot uses plain language with a link to the Goals tab.
+set -euo pipefail
+
+PORT="${DASH_PORT:-8137}"
+DASHKEY_FILE="${HOME}/.simard/.dashkey"
+LOG="$(mktemp -t dash-fidelity.XXXXXX.log)"
+CJ="$(mktemp -t dash-fidelity-cookies.XXXXXX)"
+
+echo "[fidelity] building simard binary…"
+cargo build --quiet --bin simard
+BIN="${CARGO_TARGET_DIR:-target}/debug/simard"
+if [[ ! -x "$BIN" ]]; then
+  echo "[fidelity] FAIL: built binary not found at $BIN" >&2
+  exit 1
+fi
+
+echo "[fidelity] starting dashboard on :$PORT"
+"$BIN" dashboard serve --port="$PORT" >"$LOG" 2>&1 &
+DASH_PID=$!
+cleanup() { kill "$DASH_PID" 2>/dev/null || true; rm -f "$CJ"; }
+trap cleanup EXIT
+
+# Wait for the server to accept connections.
+up=0
+for _ in $(seq 1 30); do
+  if curl -s -o /dev/null "http://localhost:$PORT/login"; then up=1; break; fi
+  sleep 1
+done
+if [[ "$up" -ne 1 ]]; then
+  echo "[fidelity] FAIL: dashboard did not come up on :$PORT" >&2
+  cat "$LOG" >&2
+  exit 1
+fi
+
+KEY="$(cat "$DASHKEY_FILE")"
+if ! curl -s -c "$CJ" -X POST -H 'Content-Type: application/json' \
+      -d "{\"code\":\"$KEY\"}" "http://localhost:$PORT/api/login" | grep -q '"ok":true'; then
+  echo "[fidelity] FAIL: login rejected" >&2
+  exit 1
+fi
+
+HTML="$(curl -s -b "$CJ" "http://localhost:$PORT/")"
+MEM="$(curl -s -b "$CJ" "http://localhost:$PORT/api/memory")"
+
+fail() { echo "[fidelity] FAIL: $1" >&2; exit 1; }
+
+# ── Served HTML: the fixed Memory Files panel ────────────────────────────────
+grep -q 'Goals (snapshot)' <<<"$HTML" \
+  || fail "goals snapshot tile missing plain-language label"
+grep -q 'data-tab=goals' <<<"$HTML" \
+  || fail "goals snapshot must link back to the Goals tab"
+grep -q 'Legacy snapshots (superseded by the Memory Store)' <<<"$HTML" \
+  || fail "legacy files must collapse into a single plain-language disclosure"
+grep -q 'legacyWithData' <<<"$HTML" \
+  || fail "legacy tiles must be gated to files that actually have content"
+grep -q '(info.size_bytes||0)<=0' <<<"$HTML" \
+  || fail "legacy gating must require non-zero size_bytes (#1681)"
+grep -q 'info.count<=0' <<<"$HTML" \
+  || fail "legacy JSON files must have records to render, never '0 records' (#1681)"
+
+# ── Served HTML: the misleading artifacts must be gone ───────────────────────
+grep -q 'Goal Records (agent memory)' <<<"$HTML" \
+  && fail "legacy 'Goal Records (agent memory)' jargon tile still present"
+grep -qF ")':'Never'" <<<"$HTML" \
+  && fail "Last Memory Compaction must not fall back to the literal 'Never'"
+grep -q 'superseded by LadybugDB' <<<"$HTML" \
+  && fail "operator labels must avoid the 'LadybugDB' jargon"
+
+# ── Live API: the source of truth that the panel renders ─────────────────────
+grep -q '"native_memory"' <<<"$MEM" \
+  || fail "/api/memory must expose native_memory counts (the Memory Store)"
+grep -q '"total_facts"' <<<"$MEM" \
+  || fail "/api/memory must expose total_facts"
+
+echo "[fidelity] PASS: Memory tab data-fidelity holds (#1681)"

--- a/tests/gadugi/dashboard-memory-fidelity.yaml
+++ b/tests/gadugi/dashboard-memory-fidelity.yaml
@@ -1,0 +1,52 @@
+name: "Dashboard Memory-Tab Data Fidelity (#1681)"
+description: "Outside-in operator check that the Memory tab no longer renders misleading empty legacy-file tiles, exposes the live Memory Store counts, and uses plain-language labels with a link to the Goals tab. Boots the real dashboard binary, authenticates, and asserts the served HTML and the live /api/memory response."
+version: "1.0.0"
+
+config:
+  timeout: 300000
+  retries: 0
+  parallel: false
+
+environment:
+  requires: []
+
+agents:
+  - name: "cli-agent"
+    type: "cli"
+    config:
+      workingDirectory: "."
+      defaultTimeout: 300000
+      executionMode: "spawn"
+      captureOutput: true
+      ioConfig:
+        encoding: "utf8"
+        handleInteractivePrompts: false
+      logConfig:
+        logCommands: true
+        logOutput: true
+        logLevel: "info"
+
+steps:
+  - name: "Memory tab hides empty legacy tiles and exposes the live store"
+    agent: "cli-agent"
+    action: "execute_command"
+    params:
+      command: "tests/gadugi/dashboard-memory-fidelity.sh"
+    timeout: 300000
+
+assertions: []
+
+cleanup:
+  - name: "CLI agent cleanup"
+    agent: "cli-agent"
+    action: "cleanup"
+
+metadata:
+  tags:
+    - "dashboard"
+    - "memory"
+    - "data-fidelity"
+    - "issue-1681"
+  priority: "high"
+  author: "copilot"
+  test_type: "outside-in"


### PR DESCRIPTION
## What & why

Closes #1681.

The dashboard **Memory** tab's "Memory Files" panel rendered four always-on
tiles, including the retired `memory_records.json`, `evidence_records.json`,
and `latest_handoff.json` snapshot files. Those JSON sources were superseded
by the native cognitive **Memory Store**. When they were empty the panel
showed:

> Evidence Records **0 records 0 B** / Modified N/A
> Latest Handoff **0 B** / Modified N/A

…directly beside a Memory Store holding **thousands of facts**. The natural
read is *"memory is empty"* when memory is in fact rich — the Memory tab is
exactly the panel a non-Simard operator opens to answer *"is the system
remembering anything?"*, and it was telegraphing the wrong answer.

## The fix (issue option **b**)

Reworked `fetchMemory()` in `index_html/part_02.rs` so the displayed numbers
match Simard's actual remembered state:

- **Goals (snapshot)** — always shown (sourced from cognitive memory, not a
  file), relabeled from the jargon *"Goal Records (agent memory)"* to plain
  language, with a one-sentence intro that **links back to the Goals tab**.
- **Legacy snapshots** — the three legacy JSON files collapse into a single
  *"Legacy snapshots (superseded by the Memory Store)"* `<details>` disclosure
  that renders a file **only when it has bytes on disk AND (for the record
  files that report a count) at least one record** — so an empty `[]` snapshot
  never resurfaces the "0 records" misread. When nothing qualifies, a one-line
  note replaces the misleading tiles.
- **Last Memory Compaction** — the "Never" fallback (consolidation has
  demonstrably run) is replaced with the honest *"Not tracked yet"* when no
  timestamp source exists; the absolute-timestamp branch still routes through
  `formatTime()`.

### Scope
Strictly the Memory Files panel. Sibling **#1679** (Workboard "Working Memory
0 slots") was investigated and **deliberately left out**: it reads a different,
active-goal-scoped source (`mem.get_working(&goal.id)`), not the Memory Files
panel — a separate root cause, not shared wiring.

## Before / after (Playwright, real server, same `~/.simard` state root)

| | Memory Files panel |
|---|---|
| **Before** | `Evidence Records 0 records 0 B` · `Latest Handoff 0 B` · `Goal Records (agent memory)` rendered as permanent tiles next to a populated store |
| **After** | `Goals (snapshot)` (+ Goals-tab link) · `▶ Legacy snapshots (superseded by the Memory Store)` (collapsed; only the non-empty `Memory records` file inside). Memory Store shows the real **3,564 facts / 39,401 total** |

Validation assertions (after): non-zero native records render **PASS** · no
misleading 0-record legacy card **PASS** · non-empty legacy file still shown
in the disclosure **PASS** · empty Evidence/Handoff tiles **not rendered**.

---

## Merge-ready evidence

### 1. qa-team / gadugi scenarios — written, validated, run
New outside-in scenario `tests/gadugi/dashboard-memory-fidelity.{yaml,sh}` boots
the real dashboard binary, authenticates, and asserts the served HTML +
`/api/memory`.

```
$ gadugi-test validate -f tests/gadugi/dashboard-memory-fidelity.yaml
✓ Scenario "Dashboard Memory-Tab Data Fidelity (#1681)" is valid
✓ All 1 file(s) are valid

$ gadugi-test run -d tests/gadugi -s dashboard-memory-fidelity
Command completed with exit code 0 (duration 26617 ms)
Test Execution Results:
✓ Passed: 1   ✗ Failed: 0   - Total: 1
✓ All tests passed!
```

Plus Rust regression tests over the rendered HTML in `tests_routes_a.rs`
(`index_html_memory_files_hides_empty_legacy_tiles`,
`index_html_memory_files_goals_snapshot_links_to_goals_tab`,
`index_html_last_consolidation_not_never`) — `cargo test --lib
operator_commands_dashboard` → **318 passed; 0 failed**.

### 2. Docs updated
`docs/dashboard.md` — Memory tab row + new subsection *"Memory tab: live store
vs. legacy snapshots"* documenting the panel behaviour.

### 3. quality-audit — 3 SEEK→VALIDATE→FIX cycles, ended clean
- **Cycle 1** — SEEK via adversarial `code-review` + `rubber-duck` agents.
  VALIDATE: no blocking issues; design faithful to #1681. FIX: tightened the
  legacy filter to also require `count > 0` (kills the "0 records / N B" edge
  case for empty `[]` files) and made the empty-state copy honest. → commit
  `06141e23`.
- **Cycle 2** — SEEK (manual XSS/logic audit): every interpolated value is a
  backend integer or `esc()`-wrapped/static; the one unescaped
  `timeAgo(info.modified)` is pre-existing and backend-controlled; filter
  logic sound. VALIDATE: 318 dashboard tests green. FIX: none (clean).
- **Cycle 3** — SEEK (scope/focus audit). VALIDATE: clean worktree, 5-file
  diff, zero backend/whiteboard leakage, #1679 correctly excluded. FIX: none.
- **Final cycle clean**: zero critical/high; zero medium correctness/security.

Two non-blocking items are recorded as **follow-ups** (both pre-existing
backend behaviours, not introduced here): "Last Memory Compaction" still
derives from legacy-file mtimes (no real consolidation timestamp exists yet);
and "Goals (snapshot)" shows `0` on a goal-board read failure (conflates "no
goals" with "read error").

### 4. CI — 100% green
All checks pass on the PR run
([actions/runs/27858386186](https://github.com/rysweet/Simard/actions/runs/27858386186)):
`pre-commit` (10m23s — full clippy `-D warnings` + release test subset),
`build`, `coverage` (21m19s), `e2e-dashboard` (Playwright structural + Python
smoke), `install-real` (23m), `cargo-audit`, and GitGuardian. 0 failures
(`gh pr checks` exit 0).

### 6. Focused diff
5 files: `index_html/part_02.rs` (the panel), `tests_routes_a.rs` (regression
tests), `docs/dashboard.md` (docs), `tests/gadugi/dashboard-memory-fidelity.{sh,yaml}`
(scenario). No backend, no unrelated edits.

> ⚠️ Not auto-merging. CI is green; holding for human review per the workflow.
