### PR TITLE
fix: episodic recall + prospective triggers on library cognitive-memory backend (closes #2299, #2300)

### DIFF
--- a/docs/reference/cognitive-memory-episodic-recall.md
+++ b/docs/reference/cognitive-memory-episodic-recall.md
@@ -453,18 +453,33 @@ case-folded.
 | Item                                  | File                                                  |
 |---------------------------------------|-------------------------------------------------------|
 | `search_episodes_by_keywords` trait   | `src/cognitive_memory/mod.rs`                         |
-| `NativeCognitiveMemory` implementation| `src/cognitive_memory/ops.rs`                         |
+| `LibraryCognitiveMemory` implementation| `src/cognitive_memory/library_adapter.rs`            |
 | `PreparedContext.episodic_recall`     | `src/memory_consolidation/mod.rs`                     |
 | Tokenizer + filter + caller           | `src/memory_consolidation/mod.rs`                     |
 | Prompt injection                      | `src/ooda_actions/goal_session/advance.rs`            |
-| Tests                                 | `src/cognitive_memory/ops.rs`,                         |
+| Tests (live, library backend)         | `src/cognitive_memory/tests_pr_2299_2300_recall_triggers.rs`, |
 |                                       | `src/memory_consolidation/tests_pr_c.rs`              |
 
 ---
 
 ## Testing
 
-### Trait-level tests in `src/cognitive_memory/ops.rs`
+### Re-validation on the library backend (de-fork Phase 2b, #2308)
+
+The native `ops.rs` and its #2299 trait-level tests were **deleted** by the
+de-fork (#2308). The fix now lives query-side in
+[`LibraryCognitiveMemory::search_episodes_by_keywords`](../architecture/cognitive-memory-library-adapter.md),
+which lowercases both the stored episode `content` and every keyword before a
+Rust-side substring match — so existing verbatim-stored episodes match
+case-insensitively without a write-path migration. The live regression guards
+are in `src/cognitive_memory/tests_pr_2299_2300_recall_triggers.rs`:
+
+| Test (library backend, `LibraryCognitiveMemory::in_memory()`) | Coverage |
+|---------------------------------------------------------------|----------|
+| `episodic_recall_returns_nonzero_raw_for_objective_keyword`   | **Issue #2299:** store mixed-case content under a non-`session-` label, tokenize a realistic objective via `tokenize_objective`, call `search_episodes_by_keywords`, assert `raw > 0`. |
+| `episodic_recall_is_case_insensitive_on_library_backend`      | Minimal case-sensitivity reproduction: ALL-CAPS content recalled by a lowercased keyword returns exactly one hit. |
+
+### Historical trait-level tests in `src/cognitive_memory/ops.rs`
 
 `search_episodes_by_keywords` has **no** direct trait-level coverage on the
 base branch. This fix adds the three #2299 regression tests and backfills the

--- a/docs/reference/prospective-trigger-firing.md
+++ b/docs/reference/prospective-trigger-firing.md
@@ -1,6 +1,6 @@
 ---
 title: Prospective-trigger firing
-description: How OODA preparation makes prospective-memory triggers actually fire — the slug-phrase-enriched objective probe built in ooda_loop/cycle.rs and the case-insensitive substring match in cognitive_memory/ops.rs (issue #2300).
+description: How OODA preparation makes prospective-memory triggers actually fire — the slug-phrase-enriched objective probe built in ooda_loop/cycle.rs and the case-insensitive keyword-overlap match in cognitive_memory/library_adapter.rs (amplihack-memory-lib) (issue #2300; re-validated on the library backend after de-fork #2308).
 last_updated: 2026-06-19
 owner: simard
 doc_type: reference
@@ -314,11 +314,11 @@ assert!(triggered.is_empty());           // correct: needle absent
 
 | Item                                | File                                          |
 |-------------------------------------|-----------------------------------------------|
-| `check_triggers` (match query)      | `src/cognitive_memory/ops.rs`                 |
+| `check_triggers` (match query)      | `src/cognitive_memory/library_adapter.rs` (delegates to `amplihack-memory-lib`) |
 | `build_objective_probe`             | `src/ooda_loop/cycle.rs`                       |
 | Probe call site (prepare phase)     | `src/ooda_loop/cycle.rs`                       |
 | `prospective_trigger_for` (write)   | `src/goals/cognitive_memory_store.rs`         |
-| `store_prospective` (write)         | `src/cognitive_memory/ops.rs`                  |
+| `store_prospective` (write)         | `src/cognitive_memory/library_adapter.rs` (delegates to `amplihack-memory-lib`) |
 | Live consumer (`check_triggers(objective)`) | `src/memory_consolidation/mod.rs`     |
 
 > The live consumer in `src/memory_consolidation/mod.rs` is **not
@@ -330,6 +330,22 @@ assert!(triggered.is_empty());           // correct: needle absent
 ---
 
 ## Testing
+
+### Re-validation on the library backend (de-fork Phase 2b, #2308)
+
+The native `ops.rs` `check_triggers` Cypher and its #2300 tests were **deleted**
+by the de-fork (#2308). Matching now runs in `amplihack-memory-lib` via
+[`LibraryCognitiveMemory::check_triggers`](../architecture/cognitive-memory-library-adapter.md#documented-behavioral-divergences),
+which lowercases and tokenizes both sides and fires each matching prospective
+once (a `"triggered"` mutator). The live regression guards are in
+`src/cognitive_memory/tests_pr_2299_2300_recall_triggers.rs`:
+
+| Test (library backend, `LibraryCognitiveMemory::in_memory()`) | Coverage |
+|---------------------------------------------------------------|----------|
+| `prospective_trigger_fires_for_realistic_objective`           | **Issue #2300:** store a slug-derived (`dashes→spaces`) `goal:` prospective, probe `check_triggers` with a realistic mixed-case OODA objective, assert a `goal:` trigger fires. |
+| `prospective_trigger_fires_on_keyword_overlap_without_contiguous_phrase` | Fires on tokenized keyword overlap even when the slug phrase is not a contiguous substring — proving the library's overlap semantics, not whole-phrase `CONTAINS`. |
+
+### Historical tests (native backend, removed by #2308)
 
 | Test                                                  | File | Coverage |
 |-------------------------------------------------------|------|----------|

--- a/src/cognitive_memory/mod.rs
+++ b/src/cognitive_memory/mod.rs
@@ -249,3 +249,10 @@ mod tests_pr_b_distill;
 // consolidation cycles stop re-storing identical procedures.
 #[cfg(test)]
 mod tests_pr_2298_idempotency;
+
+// Issues #2299 / #2300: re-validate episodic recall (`search_episodes_by_keywords`)
+// and prospective triggers (`check_triggers`) against the library backend after
+// the de-fork (#2308) deleted the native fork where the original fixes lived.
+// Guards "0 raw episodes" (#2299) and "0 triggers" (#2300) regressions.
+#[cfg(test)]
+mod tests_pr_2299_2300_recall_triggers;

--- a/src/cognitive_memory/tests_pr_2299_2300_recall_triggers.rs
+++ b/src/cognitive_memory/tests_pr_2299_2300_recall_triggers.rs
@@ -1,0 +1,194 @@
+//! Re-validation regression tests for the episodic-recall (#2299) and
+//! prospective-trigger (#2300) defects against the **library** cognitive-memory
+//! backend ([`LibraryCognitiveMemory`]) — the sole backend after de-fork
+//! Phase 2b (#2308, issue #2307).
+//!
+//! ## Why these exist
+//!
+//! #2299 and #2300 were originally fixed inside Simard's now-deleted native
+//! fork (`src/cognitive_memory/ops.rs`, PRs #2301 and #2303). The de-fork
+//! (#2308) deleted that fork and made `amplihack-memory-lib` the sole backend,
+//! so the original native fixes no longer protect the live path. These tests
+//! re-prove both defects are resolved on the library backend and lock the
+//! behaviour against regression.
+//!
+//! They drive the exact recall/trigger entry points the live OODA preparation
+//! pass uses (`src/memory_consolidation/mod.rs`):
+//!
+//! * #2299 — `tokenize_objective(objective)` → `search_episodes_by_keywords`,
+//!   asserting the **raw** recall count is `> 0` (the symptom logged "0 raw").
+//! * #2300 — `store_prospective` (slug-derived `trigger_condition`) →
+//!   `check_triggers(objective)` with realistic free-text objective, asserting
+//!   the trigger fires (the symptom logged "0 triggers").
+//!
+//! These target `LibraryCognitiveMemory::in_memory()` directly so the live
+//! backend is exercised hermetically, without the bridge/IPC/mock layers (whose
+//! stub trait methods would mask the defect).
+
+use super::{CognitiveMemoryOps, LibraryCognitiveMemory};
+use crate::memory_consolidation::tokenize_objective;
+
+fn test_mem() -> LibraryCognitiveMemory {
+    LibraryCognitiveMemory::in_memory().expect("in-memory library DB should create")
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// #2299 — episodic recall must return > 0 raw on the library backend
+// ─────────────────────────────────────────────────────────────────────────
+
+/// AC (#2299) — Store an episode whose content holds a known keyword in MIXED
+/// case under a non-`session-` label, then recall it through the *live* path:
+/// `tokenize_objective(objective)` (lowercases + drops stopwords) feeds
+/// `search_episodes_by_keywords`. The raw recall count MUST be `> 0`.
+///
+/// The reported symptom was the preparation log forever printing
+/// "0 episodes recalled (0 raw, 0 session-filtered)". The native defect was
+/// case-sensitive substring matching: `tokenize_objective` lowercases tokens
+/// while `store_episode` keeps verbatim case, so a case-sensitive `CONTAINS`
+/// matched nothing. The library adapter's `search_episodes_by_keywords`
+/// lowercases *both* sides; this test pins that on the library backend so the
+/// fix survives the de-fork.
+#[test]
+fn episodic_recall_returns_nonzero_raw_for_objective_keyword() {
+    let mem = test_mem();
+
+    // Mixed-case content with the shared keywords in UPPER case; a non-`session-`
+    // source label so the "raw" count is not confounded by downstream
+    // session-filtering. UPPER-casing the shared keywords means the lowercased
+    // objective tokens can only match via the adapter's case-folding — a
+    // case-sensitive matcher would find nothing here.
+    mem.store_episode(
+        "Refactored the OODA Consolidation pass to harden DURABLE RECALL",
+        "engineer-loop",
+        None,
+    )
+    .expect("store_episode");
+
+    // Realistic free-text objective; shares keywords ("durable", "recall") with
+    // the stored episode but in different case and surrounded by other words.
+    let objective = "Improve cognitive memory persistence so durable recall survives restarts";
+    let tokens = tokenize_objective(objective);
+    assert!(
+        tokens.iter().any(|t| t == "durable" || t == "recall"),
+        "sanity: tokenizer must yield the shared keyword(s); got {tokens:?}"
+    );
+
+    let raw = mem
+        .search_episodes_by_keywords(&tokens, 5)
+        .expect("search_episodes_by_keywords");
+
+    assert!(
+        !raw.is_empty(),
+        "episodic recall must return > 0 raw episodes when the objective shares \
+         a keyword with stored episode content (issue #2299, the '0 raw' \
+         defect); tokens={tokens:?}"
+    );
+}
+
+/// AC (#2299, pointed) — A purely case-mismatched recall: content stored in
+/// ALL-CAPS, recalled with a lowercased single keyword. This is the minimal
+/// reproduction of the case-sensitivity defect and would return zero under the
+/// pre-fix case-sensitive matcher.
+#[test]
+fn episodic_recall_is_case_insensitive_on_library_backend() {
+    let mem = test_mem();
+
+    mem.store_episode("DEPLOYED THE AUTHENTICATION SERVICE", "engineer-loop", None)
+        .expect("store_episode");
+
+    let raw = mem
+        .search_episodes_by_keywords(&["authentication".to_string()], 5)
+        .expect("search_episodes_by_keywords");
+
+    assert_eq!(
+        raw.len(),
+        1,
+        "a lowercased keyword must match ALL-CAPS episode content \
+         (case-insensitive substring recall, issue #2299)"
+    );
+    assert!(
+        raw[0].content.contains("AUTHENTICATION"),
+        "the matched episode must be the one that was stored"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// #2300 — prospective triggers must fire on the library backend
+// ─────────────────────────────────────────────────────────────────────────
+
+/// AC (#2300) — Store a prospective whose `trigger_condition` is a goal slug
+/// with dashes turned to spaces (exactly what
+/// `goals::cognitive_memory_store::prospective_trigger_for` derives), then probe
+/// `check_triggers` with a realistic free-text OODA objective that mentions the
+/// goal phrase (mixed case, embedded in a longer sentence rather than passed
+/// verbatim). The trigger MUST fire.
+///
+/// The reported symptom was the preparation log forever printing "0 triggers".
+/// The native defect combined case-sensitive matching with a probe that did not
+/// carry the slug phrase. The library's `check_triggers` matches on lowercased
+/// keyword overlap, so a realistic objective that shares tokens with the trigger
+/// condition fires it; this test pins that on the library backend.
+#[test]
+fn prospective_trigger_fires_for_realistic_objective() {
+    let mem = test_mem();
+
+    // Slug `improve-cognitive-memory-persistence` → trigger condition
+    // `improve cognitive memory persistence` (dashes→spaces); the description
+    // carries the `goal:` prefix the live goal store uses.
+    mem.store_prospective(
+        "goal: improve cognitive memory persistence",
+        "improve cognitive memory persistence",
+        "resume work on the goal",
+        1,
+    )
+    .expect("store_prospective");
+
+    // Realistic OODA objective: free text, MIXED case, the goal phrase embedded
+    // in a longer sentence rather than passed verbatim/lowercased.
+    let objective =
+        "Continue to Improve Cognitive Memory persistence and durable recall this OODA cycle";
+
+    let triggered = mem.check_triggers(objective).expect("check_triggers");
+
+    assert!(
+        triggered.iter().any(|p| p.description.starts_with("goal:")),
+        "a stored goal prospective must fire when the OODA objective mentions \
+         its slug phrase (issue #2300, the '0 triggers' defect); got {} \
+         triggers: {:?}",
+        triggered.len(),
+        triggered.iter().map(|p| &p.description).collect::<Vec<_>>()
+    );
+}
+
+/// AC (#2300, keyword-overlap) — The trigger must fire even when the objective
+/// shares the trigger's keywords without containing the slug phrase as a
+/// contiguous substring. This proves the live match is tokenized keyword
+/// overlap (the library's contract), not whole-phrase `CONTAINS`, so realistic
+/// OODA objectives that paraphrase the goal still fire.
+#[test]
+fn prospective_trigger_fires_on_keyword_overlap_without_contiguous_phrase() {
+    let mem = test_mem();
+
+    mem.store_prospective(
+        "goal: fix broken authentication",
+        "fix broken authentication",
+        "resume work on the goal",
+        1,
+    )
+    .expect("store_prospective");
+
+    // The trigger tokens (fix / broken / authentication) all appear, but never
+    // as the contiguous phrase "fix broken authentication".
+    let objective =
+        "Authentication is broken in the login flow; we need to fix the regression today";
+
+    let triggered = mem.check_triggers(objective).expect("check_triggers");
+
+    assert!(
+        triggered.iter().any(|p| p.description.starts_with("goal:")),
+        "the goal prospective must fire on keyword overlap even without the \
+         contiguous slug phrase (issue #2300); got {} triggers: {:?}",
+        triggered.len(),
+        triggered.iter().map(|p| &p.description).collect::<Vec<_>>()
+    );
+}

--- a/tests/gadugi/episodic-recall-and-triggers.yaml
+++ b/tests/gadugi/episodic-recall-and-triggers.yaml
@@ -1,0 +1,116 @@
+name: "Cognitive Memory — Episodic Recall & Prospective Triggers"
+description: >
+  Outside-in gate re-validating the episodic-recall (#2299) and
+  prospective-trigger (#2300) defects against the library cognitive-memory
+  backend, the sole backend after de-fork Phase 2b (#2308). The original native
+  `src/cognitive_memory/ops.rs` fixes (PRs #2301, #2303) were deleted by the
+  de-fork; these steps drive the user-observable OODA preparation phase
+  (`preparation_memory_operations`) — the same path that emits
+  `prepared context (… triggers …)` and
+  `preparation: … episodes recalled (R raw, …)` — and assert recall and triggers
+  are non-zero on the library backend. Steps drive the live regression gates in
+  `tests/episodic_recall_outside_in.rs` (#2299) and
+  `tests/prospective_triggers_outside_in.rs` (#2300).
+version: "1.0.0"
+
+config:
+  timeout: 180000
+  retries: 1
+  parallel: false
+
+environment:
+  requires: []
+
+agents:
+  - name: "test-agent"
+    type: "cli"
+    config:
+      workingDirectory: "."
+      defaultTimeout: 180000
+      executionMode: "spawn"
+      captureOutput: true
+      ioConfig:
+        encoding: "utf8"
+        handleInteractivePrompts: false
+      logConfig:
+        logCommands: true
+        logOutput: true
+        logLevel: "info"
+
+steps:
+  - name: "#2299 — preparation recalls a mixed-case episode case-insensitively (raw > 0)"
+    agent: "test-agent"
+    action: "execute_command"
+    params:
+      command: >
+        cargo test --test episodic_recall_outside_in
+        preparation_recalls_episode_case_insensitively
+        -- --nocapture --test-threads=1
+    timeout: 180000
+    expect:
+      exitCode: 0
+      outputContains:
+        - "test preparation_recalls_episode_case_insensitively ... ok"
+
+  - name: "#2299 — keyword union, session-noise filtering, and no match-all"
+    agent: "test-agent"
+    action: "execute_command"
+    params:
+      command: >
+        cargo test --test episodic_recall_outside_in
+        preparation_unions_keywords_filters_session_noise_and_excludes_nonmatches
+        -- --nocapture --test-threads=1
+    timeout: 180000
+    expect:
+      exitCode: 0
+      outputContains:
+        - "test preparation_unions_keywords_filters_session_noise_and_excludes_nonmatches ... ok"
+
+  - name: "#2300 — preparation fires a goal prospective for a realistic objective"
+    agent: "test-agent"
+    action: "execute_command"
+    params:
+      command: >
+        cargo test --test prospective_triggers_outside_in
+        preparation_fires_goal_prospective_for_realistic_objective
+        -- --nocapture --test-threads=1
+    timeout: 180000
+    expect:
+      exitCode: 0
+      outputContains:
+        - "test preparation_fires_goal_prospective_for_realistic_objective ... ok"
+
+  - name: "#2300 — trigger fires on keyword overlap and not on an unrelated objective"
+    agent: "test-agent"
+    action: "execute_command"
+    params:
+      command: >
+        cargo test --test prospective_triggers_outside_in
+        preparation_fires_on_keyword_overlap_and_not_on_unrelated_objective
+        -- --nocapture --test-threads=1
+    timeout: 180000
+    expect:
+      exitCode: 0
+      outputContains:
+        - "test preparation_fires_on_keyword_overlap_and_not_on_unrelated_objective ... ok"
+
+assertions: []
+
+cleanup:
+  - name: "Test agent cleanup"
+    agent: "test-agent"
+    action: "cleanup"
+
+metadata:
+  tags:
+    - "cli"
+    - "cognitive-memory"
+    - "episodic-recall"
+    - "prospective-triggers"
+    - "ooda"
+    - "regression"
+    - "issue-2299"
+    - "issue-2300"
+  priority: "high"
+  author: "copilot"
+  test_type: "outside-in"

--- a/tests/prospective_triggers_outside_in.rs
+++ b/tests/prospective_triggers_outside_in.rs
@@ -1,0 +1,160 @@
+//! Outside-in regression gate for the "prospective triggers never fire" defect
+//! (issue #2300), re-validated against the library cognitive-memory backend
+//! after the de-fork (#2308) deleted the native `src/cognitive_memory/ops.rs`.
+//!
+//! **Why this exists.** The de-fork added `tests/episodic_recall_outside_in.rs`
+//! to gate the *episodic-recall* axis of the OODA preparation log line, but left
+//! the *trigger* axis ungated once the native `ops.rs` #2300 tests were deleted.
+//! This file restores user-observable coverage for triggers: it drives the same
+//! preparation phase (`preparation_memory_operations`) an operator watches and
+//! asserts the trigger count is non-zero. The defect made the prepared-context
+//! line read:
+//!
+//! ```text
+//! prepared context (0 facts, 0 triggers, 5 procedures, 0 episodes)
+//! ```
+//!
+//! every OODA cycle. `preparation_memory_operations` passes the **raw objective**
+//! to `bridge.check_triggers(objective)`; the library backend lowercases and
+//! tokenises both sides and fires each matching prospective once. These tests
+//! store a goal prospective exactly as `goals::cognitive_memory_store` does
+//! (slug with dashes→spaces, `goal:` description prefix) and assert it surfaces
+//! in `PreparedContext.triggered_prospectives`.
+//!
+//! Run observably with:
+//! ```bash
+//! cargo test --test prospective_triggers_outside_in -- --nocapture
+//! ```
+
+use simard::cognitive_memory::{CognitiveMemoryOps, LibraryCognitiveMemory};
+use simard::memory_consolidation::preparation_memory_operations;
+use simard::session::SessionId;
+
+/// Hermetic in-memory cognitive store backed by the library — the sole backend
+/// after de-fork Phase 2b. No disk, no env, no `$HOME` leakage.
+fn new_mem() -> LibraryCognitiveMemory {
+    LibraryCognitiveMemory::in_memory().expect("in-memory cognitive store should open")
+}
+
+/// Deterministic session id so the `session-` self-noise filter (episodic axis)
+/// has a stable label and never interferes with the trigger assertions.
+fn session() -> SessionId {
+    SessionId::parse("session-00000000-0000-0000-0000-000000000001")
+        .expect("literal session id should parse")
+}
+
+/// Store a goal prospective exactly as `goals::cognitive_memory_store` does for
+/// an Active goal: description carries the `goal:` prefix and the
+/// `trigger_condition` is the goal slug with dashes turned to spaces.
+fn store_goal_prospective(mem: &LibraryCognitiveMemory, slug: &str) {
+    let trigger_condition = slug.replace('-', " ");
+    mem.store_prospective(
+        &format!("goal: {trigger_condition}"),
+        &trigger_condition,
+        "resume work on the goal",
+        1,
+    )
+    .expect("store_prospective should succeed");
+}
+
+/// Scenario 1 (simple) — the basic user-facing behaviour the de-fork must
+/// preserve. Store one Active-goal prospective, then run the preparation phase
+/// with a realistic mixed-case objective that mentions the goal phrase. Before
+/// the fix this produced `0 triggers`; after it the prospective fires.
+#[test]
+fn preparation_fires_goal_prospective_for_realistic_objective() {
+    let mem = new_mem();
+    let session = session();
+
+    // Goal slug `improve-cognitive-memory-persistence` → trigger condition
+    // `improve cognitive memory persistence`.
+    store_goal_prospective(&mem, "improve-cognitive-memory-persistence");
+
+    // Objective as an operator would phrase it: free text, mixed case, the goal
+    // phrase embedded in a longer sentence (not passed verbatim/lowercased).
+    let objective =
+        "Continue to Improve Cognitive Memory persistence and durable recall this OODA cycle";
+
+    let ctx = preparation_memory_operations(objective, &session, &mem)
+        .expect("preparation should succeed");
+
+    eprintln!(
+        "[scenario-1] triggered_prospectives = {} trigger(s)",
+        ctx.triggered_prospectives.len()
+    );
+
+    assert!(
+        ctx.triggered_prospectives
+            .iter()
+            .any(|p| p.description.starts_with("goal:")),
+        "preparation must surface the goal prospective as a trigger (raw count > 0) — \
+         this is the #2300 '0 triggers' defect; got {} trigger(s): {:?}",
+        ctx.triggered_prospectives.len(),
+        ctx.triggered_prospectives
+            .iter()
+            .map(|p| &p.description)
+            .collect::<Vec<_>>()
+    );
+}
+
+/// Scenario 2 (complex) — keyword-overlap firing plus a no-false-fire
+/// regression, both through the same public preparation entry point.
+///
+/// The objective shares the trigger's keywords (fix / broken / authentication)
+/// without ever stating the contiguous slug phrase, proving the library match is
+/// tokenised keyword overlap (so realistic OODA paraphrases still fire). A
+/// second, unrelated objective must NOT fire the trigger (no match-all).
+#[test]
+fn preparation_fires_on_keyword_overlap_and_not_on_unrelated_objective() {
+    let mem = new_mem();
+    let session = session();
+
+    store_goal_prospective(&mem, "fix-broken-authentication");
+
+    // Keywords present, but never the contiguous phrase "fix broken authentication".
+    let related = "Authentication is broken in the login flow; we need to fix the regression today";
+    let ctx =
+        preparation_memory_operations(related, &session, &mem).expect("preparation should succeed");
+
+    eprintln!(
+        "[scenario-2] related objective fired {} trigger(s)",
+        ctx.triggered_prospectives.len()
+    );
+    assert!(
+        ctx.triggered_prospectives
+            .iter()
+            .any(|p| p.description.starts_with("goal:")),
+        "the goal prospective must fire on keyword overlap even without the \
+         contiguous slug phrase (issue #2300); got {:?}",
+        ctx.triggered_prospectives
+            .iter()
+            .map(|p| &p.description)
+            .collect::<Vec<_>>()
+    );
+
+    // No-false-fire regression: an unrelated objective on a FRESH store (the
+    // library's `check_triggers` is a fire-once mutator, so re-probing the same
+    // store would not re-fire) must surface zero goal triggers.
+    let fresh = new_mem();
+    store_goal_prospective(&fresh, "fix-broken-authentication");
+    let unrelated = "Provision the staging database and rotate the TLS certificates";
+    let none = preparation_memory_operations(unrelated, &session, &fresh)
+        .expect("preparation should succeed for an unrelated objective");
+
+    eprintln!(
+        "[scenario-2] unrelated objective fired {} trigger(s)",
+        none.triggered_prospectives.len()
+    );
+    assert!(
+        !none
+            .triggered_prospectives
+            .iter()
+            .any(|p| p.description.starts_with("goal:")),
+        "an unrelated objective must not fire the goal prospective (no match-all \
+         regression); got {:?}",
+        none.triggered_prospectives
+            .iter()
+            .map(|p| &p.description)
+            .collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
## Summary

Re-validates the two cognitive-memory recall/trigger defects against the **library** backend after the de-fork:

- **#2299** — *episodic-recall-returns-zero* (`preparation: … 0 episodes recalled (0 raw, …)`)
- **#2300** — *prospective-triggers-never-fire* (`prepared context (… 0 triggers …)`)

Both were originally fixed inside Simard's **native** cognitive-memory fork `src/cognitive_memory/ops.rs` (PRs #2301, #2303). The de-fork **#2308** (issue #2307) **deleted that fork** and made `amplihack-memory-lib`'s `LibraryCognitiveMemory` (`src/cognitive_memory/library_adapter.rs`) the **sole** backend — so the original native fixes no longer guard the live path.

**Finding:** both defects are **already fixed on the library backend** and require **no production code change**:
- `LibraryCognitiveMemory::search_episodes_by_keywords` lowercases both the stored episode `content` and every keyword (Rust query-side), so existing verbatim-stored episodes match case-insensitively — `raw > 0` (#2299).
- `check_triggers` delegates to the library's lowercased, tokenized **keyword-overlap** matcher, which fires goal prospectives for realistic OODA objectives (#2300).

This PR **locks that behaviour against regression** (unit + outside-in + gadugi gates) and **reconciles the reference docs** from the deleted `ops.rs` to the live library adapter. Distillation idempotency is untouched.

Issue **#2307** was closed separately as completed-by-#2308.

## Changes (test + docs only — no production code)

| File | What |
|------|------|
| `src/cognitive_memory/tests_pr_2299_2300_recall_triggers.rs` | New unit guards on `LibraryCognitiveMemory::in_memory()`: case-insensitive episodic recall `raw > 0` (#2299) and prospective triggers firing incl. keyword-overlap-without-contiguous-phrase (#2300). |
| `tests/prospective_triggers_outside_in.rs` | New **outside-in** gate driving `preparation_memory_operations` and asserting `triggered_prospectives > 0` — fills the trigger-axis gap the de-fork's `episodic_recall_outside_in.rs` left, plus a no-false-fire regression. |
| `tests/gadugi/episodic-recall-and-triggers.yaml` | New gadugi outside-in scenario wrapping both the #2299 and #2300 gates. |
| `src/cognitive_memory/mod.rs` | Adds the `#[cfg(test)] mod` declaration only. |
| `docs/reference/cognitive-memory-episodic-recall.md`, `docs/reference/prospective-trigger-firing.md` | Reconcile Code-location / Testing tables from the deleted `ops.rs` to `library_adapter.rs` (amplihack-memory-lib); point at the new live regression tests. |

## Merge-ready evidence

**1. gadugi-test scenarios — written, validated, run**
- `gadugi-test validate -f tests/gadugi/episodic-recall-and-triggers.yaml` → `✓ Scenario "Cognitive Memory — Episodic Recall & Prospective Triggers" is valid`.
- `gadugi-test run -d tests/gadugi -s episodic-recall-and-triggers` → `✓ Passed: 1  ✗ Failed: 0  ✓ All tests passed!` (4 steps: 2× #2299, 2× #2300).

**2. Docs** — two reference docs updated (changed surface = cognitive-memory recall/trigger references). No other user-facing surface changed (test-only code).

**3. quality-audit — 3 SEEK→VALIDATE→FIX cycles, ended clean**
- *Cycle 1:* independent `code-review` pass flagged that the first #2299 unit test's shared token (`recall`) also matched case-sensitively, so it didn't truly exercise case-folding. **Fixed** by upper-casing the shared keywords in the stored content (`DURABLE RECALL`) so the lowercased objective tokens can only match via the adapter's case-folding; a case-sensitive matcher now returns 0. Re-ran → pass.
- *Cycle 2:* self-audit of robustness (tokenizer output guarded by a sanity assert; fire-once `check_triggers` handled via fresh store in the no-false-fire case), scope (only 6 files; distillation idempotency untouched), and gadugi test-name/`outputContains` mapping → clean.
- *Cycle 3:* final consistency + lint pass (docstrings match behaviour; `cargo fmt --check` clean) → clean.

**4. CI / local green gates** (CI will run on this PR):
- `cargo fmt --all -- --check` → clean.
- `cargo clippy --all-targets --all-features --locked -- -D warnings` → clean.
- `cargo test --lib cognitive_memory` → **58 passed, 0 failed** (incl. the 4 new unit tests).
- `cargo test --test prospective_triggers_outside_in` → **2 passed**; `cargo test --test episodic_recall_outside_in` → **2 passed**.
- `cargo test --lib memory_consolidation` → 49 passed; `cargo test --lib goals` → 212 passed.
- Pre-commit + pre-push hooks (fmt, release clippy, release test subset, full `--all-targets` clippy) all **Passed** on commit and push.
- Note: a full local `cargo test --lib` run showed 2 unrelated failures (`subagent_sessions::…poll_and_gc…`, `operator_commands_dashboard::…add_goal_creates_backlog_item`). Both are **pre-existing parallel-contention/hermetic-state flakes** tied to running against a live `\$HOME/.simard` on the dev box — they **pass in isolation** and are not touched by this additive change.

**5. Evidence** — this description.

**6. Diff focused** — 6 files (`+514/-6`), confined to `src/cognitive_memory/`, `tests/`, and the two relevant reference docs. No production code change; no unrelated edits.

Closes #2299
Closes #2300