### PR TITLE
fix(deps): bump amplihack-memory to WAL-durability fix (#89)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,7 +58,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 [[package]]
 name = "amplihack-memory"
 version = "0.4.0"
-source = "git+https://github.com/rysweet/amplihack-memory-lib.git?rev=ece725b1ac7e1c34cc254529879b291df1ed9ec7#ece725b1ac7e1c34cc254529879b291df1ed9ec7"
+source = "git+https://github.com/rysweet/amplihack-memory-lib.git?rev=7b81590896f3a93399d3d29f2ada2601971c6864#7b81590896f3a93399d3d29f2ada2601971c6864"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -1048,7 +1048,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1182,7 +1182,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2426,7 +2426,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3383,7 +3383,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3396,7 +3396,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3455,7 +3455,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4149,7 +4149,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5080,7 +5080,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ path = "src/bin/simard_tui/main.rs"
 # behind Simard's `CognitiveMemoryOps` trait; the native LadybugDB fork has been
 # deleted. The `persistent` feature builds LadybugDB through the published
 # `lbug = "=0.15.3"` crate.
-amplihack-memory = { git = "https://github.com/rysweet/amplihack-memory-lib.git", rev = "ece725b1ac7e1c34cc254529879b291df1ed9ec7", features = ["persistent"] }
+amplihack-memory = { git = "https://github.com/rysweet/amplihack-memory-lib.git", rev = "7b81590896f3a93399d3d29f2ada2601971c6864", features = ["persistent"] }
 rustyclawd-core = { git = "https://github.com/rysweet/RustyClawd.git", rev = "43ebaa1c1b18a5630c53f0519989a2bacd42ef62" }
 rustyclawd-tools = { git = "https://github.com/rysweet/RustyClawd.git", rev = "43ebaa1c1b18a5630c53f0519989a2bacd42ef62" }
 # De-fork phase 2b (issue #2307): the native cognitive-memory fork is gone, but


### PR DESCRIPTION
Bumps amplihack-memory to 7b81590 (amplihack-memory-lib#89): persistent store now recovers from a corrupt WAL instead of crashing, auto-checkpoints every 128 writes + on Drop. Fixes a live incident where an unclean daemon shutdown left the cognitive store unopenable (lbug wal_record.cpp UNREACHABLE_CODE) and lost uncheckpointed data. Validated by a kill-9 restart test.