### PR TITLE
fix(dashboard): make Workboard/Overview agree with Terminal/Memory/Thinking (#1678, #1679, #1680)

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -32,7 +32,7 @@ The dashboard is a single-page app with the following tabs:
 | **Memory** | Cognitive memory graph (Working / Semantic / Episodic / Procedural / Prospective / Sensory) with per-type filters; full-text memory search; a **Memory Overview** with the live **Memory Store** counts; and a **Memory Files** panel showing the goals snapshot plus any non-empty legacy snapshot files. See [Memory architecture](memory.md). |
 | **Costs** | Per-provider, per-model token spend across the active session. |
 | **Chat** | Direct chat with Simard. |
-| **Workboard** | Shared scratch canvas. (Renamed from "Whiteboard" — see [Tab identity contract](#tab-identity-contract).) |
+| **Workboard** | Kanban view of current goals plus live mental-state panels — Active Engineers, Working Memory, and the OODA cycle counter — read from the same sources as the Terminal, Memory, and Thinking tabs so the panels stay consistent. (Renamed from "Whiteboard" — see [Tab identity contract](#tab-identity-contract).) |
 | **Thinking** | Live thinking-cycle stream (planner output before action dispatch). |
 | **Terminal** | Browser-attached PTY into the daemon host. |
 

--- a/scripts/dashboard_audit/scenarios/dashboard-state-consistency.yaml
+++ b/scripts/dashboard_audit/scenarios/dashboard-state-consistency.yaml
@@ -1,0 +1,35 @@
+name: Dashboard state consistency (#1678, #1679, #1680)
+description: >
+  Verifies that the Whiteboard/Workboard and Overview panels report the same
+  state as the Terminal, Memory, and Thinking tabs. Drives the live dashboard
+  JSON APIs (and the served SPA) and asserts active-engineer count, the
+  working-memory count source, and the cycle number all agree across panels.
+  Regression guard for the three dashboard self-contradiction bugs in epic #1992.
+version: "1.0"
+tags: [dashboard, consistency, regression, audit-1662-followup]
+config:
+  timeout: 60000
+agents:
+  - name: cli-agent
+    type: cli
+    config:
+      shell: bash
+      workingDirectory: .
+      captureOutput: true
+steps:
+  - name: Verify dashboard panels agree across tabs
+    agent: cli-agent
+    action: run
+    params:
+      command: "bash scripts/dashboard_audit/verify_state_consistency.sh"
+    description: >
+      Authenticate to the running dashboard and compare /api/workboard against
+      /api/subagent-sessions, /api/memory/graph, /api/activity, and /api/status.
+verifications:
+  - type: output
+    target: stdout
+    expected: "PASS: Whiteboard/Overview agree with Terminal/Memory/Thinking"
+    operator: contains
+    description: >
+      The verifier prints PASS only when engineers, the working-memory count
+      source, and the cycle number are consistent across every panel.

--- a/scripts/dashboard_audit/verify_state_consistency.sh
+++ b/scripts/dashboard_audit/verify_state_consistency.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+#
+# Dashboard state-consistency verification (issues #1678, #1679, #1680).
+#
+# Asserts that the Whiteboard/Workboard and Overview panels agree with the
+# Terminal/Memory/Thinking tabs by comparing the live JSON APIs (and the served
+# SPA) that back them:
+#
+#   #1678  /api/workboard .spawned_engineers       == /api/subagent-sessions .live
+#   #1679  the Workboard working-memory count binds to the authoritative
+#          working_count statistic (same source as the Memory tab):
+#            - served HTML binds `wb-wm-count` to `cognitive_statistics.working_count`
+#            - /api/workboard .cognitive_statistics.working_count
+#              == /api/memory/graph .stats.working
+#   #1680  every "Cycle #N" source agrees:
+#          /api/workboard .cycle.number
+#          == /api/activity .daemon.current_cycle
+#          == /api/status   .daemon_health.cycle_number
+#          == max(/api/activity .recent_cycles[].cycle_number)   (Thinking tab)
+#
+# Usage: verify_state_consistency.sh [BASE_URL] [DASHKEY]
+#   BASE_URL  default $DASHBOARD_URL or http://localhost:8080
+#   DASHKEY   default $DASHBOARD_KEY or $(cat ~/.simard/.dashkey)
+#
+# Exits 0 when all three panels are consistent, 1 otherwise.
+set -euo pipefail
+
+BASE_URL="${1:-${DASHBOARD_URL:-http://localhost:8080}}"
+DASHKEY="${2:-${DASHBOARD_KEY:-$(cat "${HOME}/.simard/.dashkey")}}"
+
+work_dir="$(mktemp -d)"
+trap 'rm -rf "${work_dir}"' EXIT
+
+cookie="$(curl -s -i -X POST "${BASE_URL}/api/login" \
+  -H 'content-type: application/json' \
+  -d "{\"code\":\"${DASHKEY}\"}" \
+  | sed -n 's/.*simard_session=\([^;]*\).*/\1/p' | tr -d '\r')"
+
+if [[ -z "${cookie}" ]]; then
+  echo "FAIL: could not authenticate to ${BASE_URL} (bad dashkey?)" >&2
+  exit 1
+fi
+
+auth=(-H "Cookie:simard_session=${cookie}")
+curl -s "${auth[@]}" "${BASE_URL}/api/workboard"          > "${work_dir}/workboard.json"
+curl -s "${auth[@]}" "${BASE_URL}/api/subagent-sessions"  > "${work_dir}/subagents.json"
+curl -s "${auth[@]}" "${BASE_URL}/api/activity"           > "${work_dir}/activity.json"
+curl -s "${auth[@]}" "${BASE_URL}/api/status"             > "${work_dir}/status.json"
+curl -s "${auth[@]}" "${BASE_URL}/api/memory/graph"       > "${work_dir}/memgraph.json"
+curl -s "${auth[@]}" "${BASE_URL}/"                       > "${work_dir}/index.html"
+
+WORK_DIR="${work_dir}" python3 - <<'PY'
+import json, os, sys
+
+d = os.environ["WORK_DIR"]
+
+
+def load(name):
+    with open(os.path.join(d, name)) as fh:
+        return json.load(fh)
+
+
+wb = load("workboard.json")
+sa = load("subagents.json")
+ac = load("activity.json")
+st = load("status.json")
+mg = load("memgraph.json")
+with open(os.path.join(d, "index.html")) as fh:
+    html = fh.read()
+
+failures = []
+
+# --- #1678: active engineers ---
+engineers = len(wb.get("spawned_engineers", []))
+live = len(sa.get("live", []))
+ok_1678 = engineers == live
+print(f"#1678 engineers: workboard={engineers} subagent_live={live} -> {'OK' if ok_1678 else 'MISMATCH'}")
+if not ok_1678:
+    failures.append("#1678")
+
+# --- #1679: working-memory count sourced from working_count ---
+wb_wc = (wb.get("cognitive_statistics") or {}).get("working_count")
+mem_wc = (mg.get("stats") or {}).get("working")
+bound = "d.cognitive_statistics.working_count" in html
+source_ok = wb_wc is not None and wb_wc == mem_wc
+ok_1679 = bound and source_ok
+print(
+    f"#1679 working memory: workboard.working_count={wb_wc} memory.working={mem_wc} "
+    f"served_html_binds_working_count={bound} -> {'OK' if ok_1679 else 'MISMATCH'}"
+)
+if not ok_1679:
+    failures.append("#1679")
+
+# --- #1680: cycle number agreement ---
+wb_cycle = (wb.get("cycle") or {}).get("number")
+ac_cycle = (ac.get("daemon") or {}).get("current_cycle")
+st_cycle = (st.get("daemon_health") or {}).get("cycle_number")
+report_cycles = [
+    (c.get("report") or {}).get("cycle_number") or c.get("cycle_number") or 0
+    for c in ac.get("recent_cycles", [])
+]
+thinking_max = max(report_cycles) if report_cycles else None
+shown = {wb_cycle, ac_cycle, st_cycle}
+ok_1680 = len(shown) == 1 and (thinking_max is None or wb_cycle == thinking_max)
+print(
+    f"#1680 cycle: workboard={wb_cycle} activity={ac_cycle} status={st_cycle} "
+    f"thinking_max={thinking_max} -> {'OK' if ok_1680 else 'MISMATCH'}"
+)
+if not ok_1680:
+    failures.append("#1680")
+
+if failures:
+    print("FAIL: dashboard panels disagree: " + ", ".join(failures))
+    sys.exit(1)
+print("PASS: Whiteboard/Overview agree with Terminal/Memory/Thinking")
+PY

--- a/src/operator_commands_dashboard/activity.rs
+++ b/src/operator_commands_dashboard/activity.rs
@@ -1,7 +1,7 @@
 use axum::Json;
 use serde_json::{Value, json};
 
-use super::current_work::read_recent_cycle_reports;
+use super::current_work::{read_recent_cycle_reports, resolve_display_cycle_number};
 use super::logs::read_tail;
 use super::routes::{resolve_state_root, run_gh_json};
 
@@ -92,11 +92,13 @@ pub(crate) async fn activity() -> Json<Value> {
         .ok()
         .and_then(|s| serde_json::from_str(&s).ok());
 
-    let current_cycle = daemon_health
+    // Restart-scoped counter from daemon_health; reconciled to the durable
+    // counter below once the state root is known (#1680).
+    let health_cycle = daemon_health
         .as_ref()
         .and_then(|h| h.get("cycle_number"))
-        .cloned()
-        .unwrap_or(json!(null));
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
 
     let daemon_status = daemon_health
         .as_ref()
@@ -119,6 +121,10 @@ pub(crate) async fn activity() -> Json<Value> {
     // --- 2. Recent cycle reports ---
     let state_root = resolve_state_root();
     let recent_cycles = read_recent_cycle_reports(&state_root, 10);
+
+    // Display the durable cycle number so the Overview header agrees with the
+    // Thinking tab and Recent Actions feed instead of the restart-scoped one (#1680).
+    let current_cycle = json!(resolve_display_cycle_number(&state_root, health_cycle));
 
     // --- 3. Open PRs & assigned issues (concurrent) ---
     let (open_prs, assigned_issues) = tokio::join!(

--- a/src/operator_commands_dashboard/current_work.rs
+++ b/src/operator_commands_dashboard/current_work.rs
@@ -296,6 +296,32 @@ pub(crate) fn read_recent_cycle_reports(state_root: &std::path::Path, n: usize) 
         .collect()
 }
 
+/// The highest persisted cycle number from `cycle_*.json` reports, if any.
+///
+/// This is the durable, monotonic counter that survives daemon restarts — the
+/// same number the Thinking tab and the Recent Actions feed display. Returns
+/// `None` when no cycle reports exist yet (e.g. a fresh install).
+pub(crate) fn latest_persisted_cycle_number(state_root: &std::path::Path) -> Option<u64> {
+    read_recent_cycle_reports(state_root, 1)
+        .first()
+        .and_then(|r| r.get("cycle_number"))
+        .and_then(|v| v.as_u64())
+}
+
+/// Resolve the cycle number to *display* across every dashboard panel.
+///
+/// `daemon_health.json` carries a restart-scoped counter (`cycles_run + 1`)
+/// that resets to 1 each time the daemon process starts, while the persisted
+/// cycle reports carry the durable counter. Showing the restart-scoped value
+/// made Overview / Whiteboard / System Status disagree with Thinking and the
+/// Recent Actions feed (#1680). Prefer the durable counter; fall back to the
+/// health value only when no reports exist yet.
+pub(crate) fn resolve_display_cycle_number(state_root: &std::path::Path, health_cycle: u64) -> u64 {
+    latest_persisted_cycle_number(state_root)
+        .map(|persisted| persisted.max(health_cycle))
+        .unwrap_or(health_cycle)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -440,6 +466,56 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let reports = read_recent_cycle_reports(dir.path(), 10);
         assert!(reports.is_empty());
+    }
+
+    // ---- resolve_display_cycle_number (#1680) ------------------------------
+
+    #[test]
+    fn latest_persisted_cycle_number_returns_highest() {
+        let dir = tempfile::tempdir().unwrap();
+        let cycle_dir = dir.path().join("cycle_reports");
+        std::fs::create_dir_all(&cycle_dir).unwrap();
+        for i in [1u32, 5, 3] {
+            std::fs::write(
+                cycle_dir.join(format!("cycle_{i}.json")),
+                format!(r#"{{"cycle_number":{i}}}"#),
+            )
+            .unwrap();
+        }
+        assert_eq!(latest_persisted_cycle_number(dir.path()), Some(5));
+    }
+
+    #[test]
+    fn latest_persisted_cycle_number_none_when_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(latest_persisted_cycle_number(dir.path()), None);
+    }
+
+    #[test]
+    fn resolve_display_prefers_persisted_over_restart_scoped() {
+        // Persistent reports reach 369 while the daemon_health restart-scoped
+        // counter is only 1 after a restart — the dashboard must show 369.
+        let dir = tempfile::tempdir().unwrap();
+        let cycle_dir = dir.path().join("cycle_reports");
+        std::fs::create_dir_all(&cycle_dir).unwrap();
+        std::fs::write(cycle_dir.join("cycle_369.json"), r#"{"cycle_number":369}"#).unwrap();
+        assert_eq!(resolve_display_cycle_number(dir.path(), 1), 369);
+    }
+
+    #[test]
+    fn resolve_display_falls_back_to_health_when_no_reports() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(resolve_display_cycle_number(dir.path(), 7), 7);
+    }
+
+    #[test]
+    fn resolve_display_uses_health_when_higher_than_reports() {
+        // Defensive: never show a number lower than the latest health value.
+        let dir = tempfile::tempdir().unwrap();
+        let cycle_dir = dir.path().join("cycle_reports");
+        std::fs::create_dir_all(&cycle_dir).unwrap();
+        std::fs::write(cycle_dir.join("cycle_2.json"), r#"{"cycle_number":2}"#).unwrap();
+        assert_eq!(resolve_display_cycle_number(dir.path(), 9), 9);
     }
 
     #[test]

--- a/src/operator_commands_dashboard/index_html/part_04.rs
+++ b/src/operator_commands_dashboard/index_html/part_04.rs
@@ -170,16 +170,20 @@ pub(crate) const PART_04: &str = r#"            let fmt;
             return'<tr><td style="white-space:nowrap;color:var(--accent);font-weight:600;font-size:.8rem">'+cat+'</td><td style="font-size:.85rem">'+content+'</td><td style="text-align:center;font-size:.8rem">'+conf+'</td><td>'+tags+'</td></tr>';
           }).join('')+'</table>';
         }else{document.getElementById('wb-facts-list').innerHTML='<span style="color:#8b949e">No recent facts in memory</span>';}
-        // Working memory (human-readable — #1683)
+        // Working memory (human-readable — #1683).
+        // Count comes from the authoritative working_count statistic — the same
+        // value the Memory tab shows — so the two panels can no longer disagree
+        // (#1679). The list below shows the slots tied to active goals as detail.
         const wm=d.working_memory||[];
-        document.getElementById('wb-wm-count').textContent=wm.length+' slots';
+        const wmCount=(d.cognitive_statistics&&d.cognitive_statistics.working_count!=null)?d.cognitive_statistics.working_count:wm.length;
+        document.getElementById('wb-wm-count').textContent=wmCount+' slots';
         if(wm.length){
           document.getElementById('wb-wm-list').innerHTML='<table class="proc-table"><tr><th>Type</th><th>Content</th><th>Related Goal</th><th>Relevance</th></tr>'
             +wm.map(s=>{
             const relColor=s.relevance>=0.8?'var(--green)':s.relevance>=0.5?'var(--yellow)':'#8b949e';
             return'<tr><td style="white-space:nowrap;color:var(--accent);font-weight:600;font-size:.8rem">'+esc(s.type_label||'Note')+'</td><td style="font-size:.85rem">'+esc((s.content||'').substring(0,200))+'</td><td style="font-size:.8rem;color:#8b949e">'+esc(s.goal||'—')+'</td><td style="text-align:center"><span style="color:'+relColor+';font-weight:600;font-size:.8rem">'+esc(s.relevance_label||'—')+'</span></td></tr>';
           }).join('')+'</table>';
-        }else{document.getElementById('wb-wm-list').innerHTML='<span style="color:#8b949e">No active working memory</span>';}
+        }else{document.getElementById('wb-wm-list').innerHTML=wmCount>0?'<span style="color:#8b949e">'+wmCount+' working slot'+(wmCount===1?'':'s')+' in memory — open the Memory tab for details</span>':'<span style="color:#8b949e">No active working memory</span>';}
         // Cognitive statistics
         const cs=d.cognitive_statistics;
         if(cs){

--- a/src/operator_commands_dashboard/routes.rs
+++ b/src/operator_commands_dashboard/routes.rs
@@ -150,7 +150,13 @@ async fn status() -> Json<Value> {
         "timestamp": chrono::Utc::now().to_rfc3339(),
     });
 
-    if let Some(h) = daemon_health {
+    if let Some(mut h) = daemon_health {
+        // Reconcile the displayed cycle number to the durable counter so the
+        // Overview "System Status" line agrees with the Thinking tab (#1680).
+        let health_cycle = h.get("cycle_number").and_then(|v| v.as_u64()).unwrap_or(0);
+        let display_cycle =
+            super::current_work::resolve_display_cycle_number(&resolve_state_root(), health_cycle);
+        h["cycle_number"] = json!(display_cycle);
         status_json["daemon_health"] = h;
     }
 

--- a/src/operator_commands_dashboard/tests_attach.rs
+++ b/src/operator_commands_dashboard/tests_attach.rs
@@ -60,3 +60,20 @@ fn index_html_has_attach_button_class_or_label() {
         "INDEX_HTML must render Attach buttons (class=\"attach-btn\" + label \"Attach\")"
     );
 }
+
+#[test]
+fn index_html_workboard_working_memory_count_uses_working_count() {
+    // #1679: the Workboard "Working Memory" count must read the authoritative
+    // working_count statistic (the same value the Memory tab shows), not the
+    // length of the per-active-goal working_memory array, so the two panels
+    // can no longer disagree.
+    assert!(
+        INDEX_HTML.contains("d.cognitive_statistics.working_count"),
+        "INDEX_HTML must bind the Workboard working-memory count to \
+         cognitive_statistics.working_count (#1679)"
+    );
+    assert!(
+        INDEX_HTML.contains("wmCount+' slots'"),
+        "INDEX_HTML must render the working-memory count from wmCount (#1679)"
+    );
+}

--- a/src/operator_commands_dashboard/workboard.rs
+++ b/src/operator_commands_dashboard/workboard.rs
@@ -3,9 +3,9 @@ use serde_json::{Value, json};
 
 use super::current_work::format_recent_actions_for_cycle;
 use super::current_work::read_recent_cycle_reports;
+use super::current_work::resolve_display_cycle_number;
 use super::dashboard_goal_board_snapshot;
 use super::routes::resolve_state_root;
-use crate::agent_registry::{AgentRegistry, FileBackedAgentRegistry};
 use crate::memory_ipc::open_reader_bridge;
 
 // ---------------------------------------------------------------------------
@@ -49,6 +49,34 @@ fn human_fact_category(concept: &str) -> &'static str {
     }
 }
 
+/// Build the Whiteboard "Active Engineers" rows from the live subagent-session
+/// registry — the same source the Terminal tab reads via `/api/subagent-sessions`
+/// (#1678). Only sessions without an `ended_at` are considered live, matching
+/// that endpoint's `live` filter, so the two panels can no longer disagree.
+fn live_engineers_json(reg: &crate::subagent_sessions::Registry) -> Vec<Value> {
+    let mut live: Vec<&crate::subagent_sessions::SubagentSession> = reg
+        .sessions
+        .iter()
+        .filter(|s| s.ended_at.is_none())
+        .collect();
+    live.sort_by_key(|s| std::cmp::Reverse(s.created_at));
+    live.iter()
+        .map(|s| {
+            let alive = std::path::Path::new(&format!("/proc/{}", s.pid)).exists();
+            let started_at = chrono::DateTime::from_timestamp(s.created_at, 0)
+                .map(|dt| dt.to_rfc3339())
+                .unwrap_or_default();
+            json!({
+                "pid": s.pid,
+                "task": format!("{} ({})", s.goal_id, s.agent_id),
+                "alive": alive,
+                "host": s.host,
+                "started_at": started_at,
+            })
+        })
+        .collect()
+}
+
 pub(crate) async fn workboard() -> Json<Value> {
     let state_root = resolve_state_root();
 
@@ -67,6 +95,11 @@ pub(crate) async fn workboard() -> Json<Value> {
         .and_then(|h| h.get("cycle_number"))
         .and_then(|v| v.as_u64())
         .unwrap_or(0);
+
+    // The value displayed as "Cycle #N" must be the durable counter (matching
+    // the Thinking tab), not the restart-scoped `cycle_number` from
+    // daemon_health, which is reused below only for the uptime estimate (#1680).
+    let display_cycle_number = resolve_display_cycle_number(&state_root, cycle_number);
 
     let cycle_phase = daemon_health
         .as_ref()
@@ -139,7 +172,7 @@ pub(crate) async fn workboard() -> Json<Value> {
     };
 
     let cycle_info = json!({
-        "number": cycle_number,
+        "number": display_cycle_number,
         "phase": cycle_phase,
         "started_at": started_at_str,
         "duration_ms": cycle_duration_ms,
@@ -196,24 +229,12 @@ pub(crate) async fn workboard() -> Json<Value> {
         })
         .unwrap_or_default();
 
-    // --- 3. Spawned engineers from agent registry ---
-    let reg = FileBackedAgentRegistry::new(&state_root);
-    let spawned_engineers: Vec<Value> = reg
-        .list()
-        .unwrap_or_default()
-        .iter()
-        .map(|e| {
-            let alive = std::path::Path::new(&format!("/proc/{}", e.pid)).exists();
-            json!({
-                "pid": e.pid,
-                "task": format!("{} ({})", e.role, e.id),
-                "alive": alive,
-                "state": format!("{:?}", e.state),
-                "started_at": e.start_time.to_rfc3339(),
-                "last_heartbeat": e.last_heartbeat.to_rfc3339(),
-            })
-        })
-        .collect();
+    // --- 3. Active engineers from the live subagent-session registry (#1678) ---
+    // Previously this read FileBackedAgentRegistry, a separate source that was
+    // routinely empty while live engineers ran — making the Whiteboard claim
+    // "No spawned engineers" while the Terminal tab listed several. Read the
+    // same registry the Terminal tab does so the two panels always agree.
+    let spawned_engineers = live_engineers_json(&crate::subagent_sessions::load());
 
     // --- 4. Recent actions from cycle reports ---
     let recent_reports = read_recent_cycle_reports(&state_root, 5);
@@ -334,4 +355,67 @@ pub(crate) async fn workboard() -> Json<Value> {
         "cognitive_statistics": cognitive_stats,
         "timestamp": chrono::Utc::now().to_rfc3339(),
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::subagent_sessions::{Registry, SubagentSession};
+
+    fn session(pid: u32, created_at: i64, ended_at: Option<i64>) -> SubagentSession {
+        SubagentSession {
+            agent_id: format!("engineer-self-serve-dashboard-improvement-{pid}"),
+            session_name: format!("simard-engineer-{pid}"),
+            host: "local".to_string(),
+            pid,
+            created_at,
+            ended_at,
+            goal_id: "self-serve-dashboard-improvement".to_string(),
+        }
+    }
+
+    #[test]
+    fn live_engineers_excludes_ended_sessions() {
+        let reg = Registry {
+            sessions: vec![
+                session(100, 10, None),
+                session(200, 20, Some(99)), // ended — must be filtered out
+                session(300, 30, None),
+            ],
+        };
+        let engineers = live_engineers_json(&reg);
+        assert_eq!(
+            engineers.len(),
+            2,
+            "only live (ended_at=None) sessions shown"
+        );
+        // Sorted newest-first by created_at, matching /api/subagent-sessions.
+        assert_eq!(engineers[0]["pid"], 300);
+        assert_eq!(engineers[1]["pid"], 100);
+    }
+
+    #[test]
+    fn live_engineers_render_expected_fields() {
+        let reg = Registry {
+            sessions: vec![session(2269169, 1781939412, None)],
+        };
+        let engineers = live_engineers_json(&reg);
+        assert_eq!(engineers.len(), 1);
+        let e = &engineers[0];
+        assert_eq!(e["pid"], 2269169);
+        assert!(
+            e["task"]
+                .as_str()
+                .unwrap()
+                .contains("self-serve-dashboard-improvement")
+        );
+        assert!(e["started_at"].as_str().unwrap().starts_with("2026-"));
+        assert!(e["alive"].is_boolean());
+    }
+
+    #[test]
+    fn live_engineers_empty_registry_yields_no_rows() {
+        let reg = Registry { sessions: vec![] };
+        assert!(live_engineers_json(&reg).is_empty());
+    }
 }


### PR DESCRIPTION
## Summary

The Workboard and Overview panels read state from **different sources** than the
Terminal, Memory, and Thinking tabs, so the dashboard contradicted itself about
engineers, working memory, and the cycle counter — directly defeating the goal
of understanding Simard's internal state (epic #1992).

| Bug | Panel | Was | Now |
|-----|-------|-----|-----|
| #1678 | Workboard "Active Engineers" | `0` / "No spawned engineers" | live count, matches Terminal |
| #1679 | Workboard "Working Memory" count | `0 slots` (per-goal array length) | `working_count`, matches Memory tab |
| #1680 | Overview/Workboard/System Status "Cycle #N" | restart-scoped (`#9`) | durable counter, matches Thinking |

## Root causes & fix

- **#1678** — `/api/workboard` read engineers from `FileBackedAgentRegistry`
  (routinely empty) while the Terminal reads `subagent_sessions::load()`.
  New pure helper `live_engineers_json()` reads the same live registry
  (`ended_at == None`, newest-first).
- **#1679** — the Workboard count rendered the **per-active-goal**
  `working_memory` array length (often 0), not the authoritative `working_count`
  the Memory tab shows. The frontend now binds `wb-wm-count` to
  `cognitive_statistics.working_count`. *(After the de-fork #2307 the library
  backend exposes `working_count` but no global working-slot scan, so the count
  is sourced from the statistic; the per-goal slots remain as detail, with a
  pointer to the Memory tab when no active-goal detail is present.)*
- **#1680** — `daemon_health.cycle_number` is a **restart-scoped** counter
  (`cycles_run + 1`); the **durable** counter lives in the `cycle_*.json`
  reports (what the Thinking tab shows). New
  `resolve_display_cycle_number(state_root, health_cycle) =
  max(latest cycle_*.json number, health_cycle)`, used for every "Cycle #N"
  across `/api/workboard`, `/api/activity`, `/api/status`. The restart-scoped
  value is kept only for the separate uptime estimate.

## Merge-ready evidence

### 1. qa-team scenarios (gadugi-test)
New `scripts/dashboard_audit/scenarios/dashboard-state-consistency.yaml` driving
`scripts/dashboard_audit/verify_state_consistency.sh`.

```
$ gadugi-test validate -d scripts/dashboard_audit/scenarios
✓ All 1 file(s) are valid
$ DASHBOARD_URL=<fixed> gadugi-test run -d scripts/dashboard_audit/scenarios
✓ Passed: 1   ✗ Failed: 0   ✓ All tests passed!
```

**Live before/after** (deployed binary on :8080 vs this build on :8099, same state):
```
OLD :8080   #1678 engineers: workboard=0  subagent_live=9                       -> MISMATCH
            #1679 working memory: workboard.working_count=9 memory.working=9
                  served_html_binds_working_count=False                          -> MISMATCH
            #1680 cycle: workboard=9 activity=9 status=9 thinking_max=1159        -> MISMATCH
            FAIL (exit 1)

FIXED :8099 #1678 engineers: workboard=9  subagent_live=9                        -> OK
            #1679 working memory: workboard.working_count=9 memory.working=9
                  served_html_binds_working_count=True                           -> OK
            #1680 cycle: workboard=1159 activity=1159 status=1159 thinking_max=1159 -> OK
            PASS (exit 0)
```

Rust unit tests (9 new): `live_engineers_*` (3), `resolve_display_*` /
`latest_persisted_*` (5), and `index_html_workboard_working_memory_count_uses_working_count`
(1) — all pass.

### 2. Documentation
User-facing labels/structure unchanged — this is a data-correctness fix.
`docs/dashboard.md` Workboard description clarified to note its panels read from
the same sources as Terminal/Memory/Thinking.

### 3. quality-audit
3 SEEK→VALIDATE→FIX cycles (engineers / working-memory / cycle-number). Final
cycle clean: zero critical/high; zero medium correctness/security. No user input
reaches any query; uptime semantics preserved (still restart-scoped); no-daemon
case unchanged.

### 4. CI
Local gates mirroring `verify.yml` (isolated target dir, rebased on `origin/main`):
- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --all-features --locked -- -D warnings` — clean
- `cargo test --lib` — **5605+ passed**; the only failures are **pre-existing,
  non-hermetic** tests that **pass in isolation** and live in modules this PR
  does not touch — `subagent_sessions::tests::*` and
  `operator_commands_dashboard::tests_goals_crud::full_goal_lifecycle_crud`.
  They mutate the process-global `SIMARD_STATE_ROOT` / shared `$HOME/.simard`
  state and flake in this **live** engineer environment (a real daemon is
  concurrently writing those files); a different one fails each run. CI's clean
  environment confirms.

### 6. Focused diff
4 backend handlers/helpers + 1 frontend binding + unit tests, 1 qa scenario +
verifier, 1 doc line. No backend schema or memory-backend changes.

## Notes
Please **do not self-merge** — opening for review with evidence per the six
merge-ready criteria.

Closes #1678
Closes #1679
Closes #1680
Refs #1992
