### PR TITLE
feat(meeting): unknown-slash-command suggestions + grouped/colorized /help (#2321)

### DIFF
--- a/docs/operations/meeting-handoffs.md
+++ b/docs/operations/meeting-handoffs.md
@@ -64,22 +64,88 @@ the most recent in-progress session if one exists.
 ## REPL Commands
 
 The REPL is a thin loop over `MeetingBackend` (see
-`src/meeting_repl/repl.rs` and `src/meeting_backend/`). The following
-commands are recognized; everything else is treated as natural
-conversation with the bound LLM agent.
+`src/meeting_repl/repl.rs` and `src/meeting_backend/`). Commands are grouped
+below by purpose; everything that is **not** a recognized command is treated
+as natural conversation with the bound LLM agent. The command set is the
+single source of truth in `src/meeting_backend/command.rs` (`HELP_GROUPS`),
+shared by the CLI REPL and the dashboard chat.
+
+**Meeting control**
 
 | Command | Effect |
 |---|---|
-| (any text) | Sent to the brain as a prompt; response printed inline |
-| `/help` | Show the command list |
+| `/help` | Show the grouped, colorized command list |
+| `/close` (alias `/done`) | Finalize and write `meeting_handoff.json`; exit the REPL |
 | `/status` | Show session info (topic, started_at, current decision/action counts) |
-| `/template` | List meeting templates |
-| `/template <name>` | Apply a template (`standup`, `1on1`, `retro`, `planning`) |
-| `/theme <text>` | Record a theme for this meeting |
+| `/export` | Export the meeting transcript as markdown |
 | `/recap` | Color-coded session recap |
 | `/preview` | Preview the handoff artifact before closing |
-| `/export` | Export the meeting as markdown |
-| `/close` | Finalize and write `meeting_handoff.json`; exit the REPL |
+| `/state` | Show current decisions, questions, actions, risks, disagreements |
+
+**Capture**
+
+| Command | Effect |
+|---|---|
+| `/decision <text> [--rationale <why>]` | Record a decision (optional rationale) |
+| `/action <text>` | Record an action item (assignee/deadline parsed inline) |
+| `/question <text>` | Record an open question |
+| `/risk <text>` | Record an identified risk |
+| `/disagree <text>` | Record a disagreement or dissenting view |
+| `/theme <text>` | Record a theme for this meeting |
+| `/owner <name>` | Name the next agent/persona/human to action this handoff |
+| `/goal <text>` | Set the meeting's overarching objective |
+
+**Templates**
+
+| Command | Effect |
+|---|---|
+| `/template` | List meeting templates |
+| `/template <name>` | Apply a template (`standup`, `1on1`, `retro`, `planning`) |
+
+Any other text is sent to the brain as a prompt and the response is printed
+inline.
+
+### Grouped, colorized `/help` and unknown-command suggestions (#2321)
+
+`/help` renders the three groups above as titled, color-coded sections (the
+titles honor `NO_COLOR` via `src/meeting_repl/color.rs`, matching how `/recap`
+and `/state` colorize their headers).
+
+If you type a single slash token that looks like a command but matches none
+(e.g. a typo), the REPL **does not** forward it to the LLM. Instead it prints a
+"did you mean?" hint, suggesting the closest known command within Levenshtein
+distance 2:
+
+```text
+simard:meeting> /colse
+Unknown command '/colse'. Did you mean '/close'?
+```
+
+When nothing is close enough, it lists the available commands instead:
+
+```text
+simard:meeting> /zzzz
+Unknown command '/zzzz'. Type /help for the full list.
+
+── Meeting control ──
+  ...
+```
+
+This affordance is deliberately narrow so normal input is never hijacked:
+
+- Multi-token slash lines (`/foo some text`) stay conversation.
+- File paths and markdown that start with `/` (e.g. `/home/user/notes.md`,
+  `/etc/hosts`) stay conversation — only a `/` followed solely by ASCII
+  letters is treated as a command attempt.
+- Bare single-component absolute paths that are well-known filesystem roots
+  (`/home`, `/tmp`, `/var`, …, the FHS top-level directories) stay
+  conversation, so a path like `/home` is never mistaken for a `/done` typo.
+- Bare, argument-requiring commands typed without a payload (`/decision`,
+  `/theme`, …) still fall through to conversation, unchanged.
+- Only *argument-less* single slash-tokens are treated as command attempts.
+  A typo that carries a payload (e.g. `/decison Adopt TDD`) is left as
+  conversation rather than suggested — distinguishing a typo+payload from an
+  intentional `/word args` line is ambiguous and could hijack real input.
 
 The brain implicitly extracts decisions, action items, and open
 questions from free-form discussion; explicit operator intent

--- a/src/meeting_backend/command.rs
+++ b/src/meeting_backend/command.rs
@@ -56,9 +56,61 @@ pub enum MeetingCommand {
     /// falls through to conversation. Required by spec line 645
     /// ("surface disagreement and uncertainty"). Added in issue #2084.
     Disagree(String),
+    /// An argument-less slash token that resembles a command but matches no
+    /// known command (e.g. a typo like `/colse`). `input` echoes the
+    /// operator-typed token (original case preserved); `suggestion` is the
+    /// closest known command within Levenshtein distance 2, or `None` when
+    /// nothing is close. Rendered at the dispatch site as a "did you mean?"
+    /// hint instead of being forwarded to the LLM. Added for the meeting-REPL
+    /// UX prong (issue #2321).
+    Unknown {
+        input: String,
+        suggestion: Option<String>,
+    },
     /// Natural language — forwarded to the LLM.
     Conversation(String),
 }
+
+/// Canonical command tokens recognized by the meeting REPL. Used both as the
+/// "is this a known command?" set for unknown-command detection and as the
+/// candidate pool for did-you-mean suggestions. Includes the `/done` alias
+/// for `/close`. Kept in sync with [`HELP_GROUPS`] by a unit test.
+const KNOWN_COMMANDS: &[&str] = &[
+    "/help",
+    "/close",
+    "/done",
+    "/status",
+    "/export",
+    "/recap",
+    "/preview",
+    "/state",
+    "/template",
+    "/theme",
+    "/decision",
+    "/action",
+    "/question",
+    "/owner",
+    "/goal",
+    "/risk",
+    "/disagree",
+];
+
+/// Maximum Levenshtein distance for a typo to earn a did-you-mean suggestion.
+const SUGGESTION_MAX_DISTANCE: usize = 2;
+
+/// Well-known absolute filesystem path roots (the Filesystem Hierarchy
+/// Standard top-level directories). A bare single-component slash token that
+/// matches one of these (e.g. `/home`, `/tmp`) is almost certainly a path the
+/// operator typed, not a mistyped command — and some collide coincidentally
+/// with a command within edit distance 2 (`/home` vs `/done`). Excluding them
+/// keeps such paths as conversation instead of emitting a misleading
+/// "did you mean?" hint. None of these are themselves commands or plausible
+/// typos of commands, so the exclusion never suppresses a real suggestion.
+/// Issue #2321.
+const COMMON_PATH_ROOTS: &[&str] = &[
+    "/bin", "/boot", "/dev", "/etc", "/home", "/lib", "/lib64", "/media", "/mnt", "/opt", "/proc",
+    "/root", "/run", "/sbin", "/srv", "/sys", "/tmp", "/usr", "/var",
+];
 
 /// Parse a single line of input into a `MeetingCommand`.
 ///
@@ -153,7 +205,237 @@ pub fn parse_command(input: &str) -> MeetingCommand {
                 MeetingCommand::Disagree(arg)
             }
         }
-        _ => MeetingCommand::Conversation(trimmed.to_string()),
+        _ => classify_unrecognized(trimmed, &lower),
+    }
+}
+
+/// Classify a line that matched none of the explicit command arms.
+///
+/// A single command-like slash token (`/` followed only by ASCII letters,
+/// e.g. `/colse`) that is not a known command is treated as a mistyped
+/// command and routed to [`MeetingCommand::Unknown`] with a did-you-mean
+/// suggestion. Everything else — multi-token slash lines (`/foo bar`), file
+/// paths (`/home/user`, `/etc/hosts`, bare roots like `/tmp`), bare
+/// empty-payload known commands (`/decision`), and plain prose — stays
+/// [`MeetingCommand::Conversation`] so the operator's intent is never
+/// silently coerced.
+///
+/// Scope boundary (deliberate, per issue #2321): only *argument-less* single
+/// slash-tokens are treated as command attempts. A payload-bearing line such
+/// as `/decison Adopt TDD` is left as conversation rather than suggested,
+/// because distinguishing a typo+payload from an intentional `/word args`
+/// conversational line is ambiguous and would risk hijacking real input.
+/// Catching payload typos is tracked as a follow-up enhancement.
+fn classify_unrecognized(trimmed: &str, lower: &str) -> MeetingCommand {
+    if is_command_like(lower) && !KNOWN_COMMANDS.contains(&lower) {
+        MeetingCommand::Unknown {
+            input: trimmed.to_string(),
+            suggestion: closest_command(lower),
+        }
+    } else {
+        MeetingCommand::Conversation(trimmed.to_string())
+    }
+}
+
+/// True when `lower` is a single slash-prefixed token of ASCII letters, e.g.
+/// `/close` or `/colse`. Multi-token input (contains whitespace), file paths
+/// (extra `/`), tokens with digits or punctuation, and well-known absolute
+/// path roots (`/home`, `/tmp`, …) all return `false`, so operators can still
+/// type paths and markdown lists that start with `/`.
+///
+/// `lower` is assumed already trimmed and lowercased (as produced by
+/// [`parse_command`]).
+fn is_command_like(lower: &str) -> bool {
+    if COMMON_PATH_ROOTS.contains(&lower) {
+        return false;
+    }
+    match lower.strip_prefix('/') {
+        Some(rest) => !rest.is_empty() && rest.chars().all(|c| c.is_ascii_alphabetic()),
+        None => false,
+    }
+}
+
+/// Return the known command closest to `lower` within
+/// [`SUGGESTION_MAX_DISTANCE`], or `None` if nothing is close enough. Ties
+/// resolve to the earliest command in [`KNOWN_COMMANDS`] (so `/close` wins
+/// over its `/done` alias).
+fn closest_command(lower: &str) -> Option<String> {
+    KNOWN_COMMANDS
+        .iter()
+        .map(|&cmd| (cmd, levenshtein(lower, cmd)))
+        .filter(|&(_, dist)| dist <= SUGGESTION_MAX_DISTANCE)
+        .min_by_key(|&(_, dist)| dist)
+        .map(|(cmd, _)| cmd.to_string())
+}
+
+/// Classic Levenshtein edit distance (insertions, deletions, substitutions)
+/// using a two-row rolling buffer. Operates on `char`s so multi-byte input
+/// is counted correctly.
+fn levenshtein(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    if a.is_empty() {
+        return b.len();
+    }
+    if b.is_empty() {
+        return a.len();
+    }
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+    let mut curr: Vec<usize> = vec![0; b.len() + 1];
+    for (i, &ca) in a.iter().enumerate() {
+        curr[0] = i + 1;
+        for (j, &cb) in b.iter().enumerate() {
+            let cost = usize::from(ca != cb);
+            curr[j + 1] = (prev[j + 1] + 1).min(curr[j] + 1).min(prev[j] + cost);
+        }
+        std::mem::swap(&mut prev, &mut curr);
+    }
+    prev[b.len()]
+}
+
+/// One command shown in the grouped `/help` output.
+pub struct HelpEntry {
+    /// Canonical command token, e.g. `/decision`.
+    pub token: &'static str,
+    /// Full usage line shown to the operator, e.g.
+    /// `/decision <text> [--rationale <why>]`.
+    pub usage: &'static str,
+    /// One-line description of what the command does.
+    pub description: &'static str,
+}
+
+/// A titled group of related commands for the grouped `/help` output.
+pub struct HelpGroup {
+    pub title: &'static str,
+    pub entries: &'static [HelpEntry],
+}
+
+/// Grouped, ordered command reference rendered by `/help`. Single source of
+/// truth shared by the CLI REPL (colorized) and the dashboard chat (plain).
+/// Every user-facing command appears in exactly one group (the `/done` alias
+/// is intentionally omitted; it is documented under `/close`).
+pub const HELP_GROUPS: &[HelpGroup] = &[
+    HelpGroup {
+        title: "Meeting control",
+        entries: &[
+            HelpEntry {
+                token: "/help",
+                usage: "/help",
+                description: "Show this grouped command list",
+            },
+            HelpEntry {
+                token: "/close",
+                usage: "/close",
+                description: "End the meeting and persist the handoff (alias: /done)",
+            },
+            HelpEntry {
+                token: "/status",
+                usage: "/status",
+                description: "Show session info (topic, started_at, message count)",
+            },
+            HelpEntry {
+                token: "/export",
+                usage: "/export",
+                description: "Export the meeting transcript as markdown",
+            },
+            HelpEntry {
+                token: "/recap",
+                usage: "/recap",
+                description: "Show a color-coded session recap",
+            },
+            HelpEntry {
+                token: "/preview",
+                usage: "/preview",
+                description: "Preview the handoff artifact before closing",
+            },
+            HelpEntry {
+                token: "/state",
+                usage: "/state",
+                description: "Show current decisions, questions, actions, risks, disagreements",
+            },
+        ],
+    },
+    HelpGroup {
+        title: "Capture",
+        entries: &[
+            HelpEntry {
+                token: "/decision",
+                usage: "/decision <text> [--rationale <why>]",
+                description: "Record a decision (optional rationale)",
+            },
+            HelpEntry {
+                token: "/action",
+                usage: "/action <text>",
+                description: "Record an action item (assignee/deadline parsed inline)",
+            },
+            HelpEntry {
+                token: "/question",
+                usage: "/question <text>",
+                description: "Record an open question",
+            },
+            HelpEntry {
+                token: "/risk",
+                usage: "/risk <text>",
+                description: "Record an identified risk",
+            },
+            HelpEntry {
+                token: "/disagree",
+                usage: "/disagree <text>",
+                description: "Record a disagreement or dissenting view",
+            },
+            HelpEntry {
+                token: "/theme",
+                usage: "/theme <text>",
+                description: "Record a theme for this meeting",
+            },
+            HelpEntry {
+                token: "/owner",
+                usage: "/owner <name>",
+                description: "Name the next agent/persona/human to action this handoff",
+            },
+            HelpEntry {
+                token: "/goal",
+                usage: "/goal <text>",
+                description: "Set the meeting's overarching objective",
+            },
+        ],
+    },
+    HelpGroup {
+        title: "Templates",
+        entries: &[HelpEntry {
+            token: "/template",
+            usage: "/template [name]",
+            description: "List templates, or apply one (standup, 1on1, retro, planning)",
+        }],
+    },
+];
+
+/// Render the grouped `/help` reference as plain (uncolored) text. Used by the
+/// dashboard chat transport and as a colorless fallback. The CLI REPL applies
+/// ANSI color to the group titles separately.
+pub fn render_help_plain() -> String {
+    let mut out = String::new();
+    for (i, group) in HELP_GROUPS.iter().enumerate() {
+        if i > 0 {
+            out.push('\n');
+        }
+        out.push_str(group.title);
+        out.push_str(":\n");
+        for entry in group.entries {
+            out.push_str(&format!("  {} — {}\n", entry.usage, entry.description));
+        }
+    }
+    out.push_str("\nEverything else is natural conversation with Simard.");
+    out
+}
+
+/// Build the one-line notice shown when an operator types an unrecognized
+/// command. With a `suggestion`, offers a did-you-mean; otherwise points the
+/// operator at `/help`.
+pub fn unknown_command_notice(input: &str, suggestion: Option<&str>) -> String {
+    match suggestion {
+        Some(s) => format!("Unknown command '{input}'. Did you mean '{s}'?"),
+        None => format!("Unknown command '{input}'. Type /help for the full list."),
     }
 }
 
@@ -584,6 +866,279 @@ mod tests {
         assert_eq!(
             parse_command("/disagree    "),
             MeetingCommand::Conversation("/disagree".to_string()),
+        );
+    }
+
+    // ── Unknown-slash-command suggestions (issue #2321) ──────────────
+
+    #[test]
+    fn parse_exact_commands_are_not_unknown() {
+        // Every known no-arg command must keep parsing to its own variant,
+        // never to Unknown.
+        assert_eq!(parse_command("/help"), MeetingCommand::Help);
+        assert_eq!(parse_command("/close"), MeetingCommand::Close);
+        assert_eq!(parse_command("/done"), MeetingCommand::Close);
+        assert_eq!(parse_command("/status"), MeetingCommand::Status);
+        assert_eq!(parse_command("/export"), MeetingCommand::Export);
+        assert_eq!(parse_command("/recap"), MeetingCommand::Recap);
+        assert_eq!(parse_command("/preview"), MeetingCommand::Preview);
+        assert_eq!(parse_command("/state"), MeetingCommand::State);
+        assert_eq!(
+            parse_command("/template"),
+            MeetingCommand::Template(String::new())
+        );
+    }
+
+    #[test]
+    fn parse_typo_within_distance_two_suggests_closest() {
+        assert_eq!(
+            parse_command("/colse"),
+            MeetingCommand::Unknown {
+                input: "/colse".to_string(),
+                suggestion: Some("/close".to_string()),
+            },
+        );
+        assert_eq!(
+            parse_command("/clse"),
+            MeetingCommand::Unknown {
+                input: "/clse".to_string(),
+                suggestion: Some("/close".to_string()),
+            },
+        );
+        assert_eq!(
+            parse_command("/statsu"),
+            MeetingCommand::Unknown {
+                input: "/statsu".to_string(),
+                suggestion: Some("/status".to_string()),
+            },
+        );
+        assert_eq!(
+            parse_command("/recp"),
+            MeetingCommand::Unknown {
+                input: "/recp".to_string(),
+                suggestion: Some("/recap".to_string()),
+            },
+        );
+    }
+
+    #[test]
+    fn parse_unknown_preserves_typed_case_in_input() {
+        // The echoed `input` keeps the operator's original case; the
+        // suggestion is the canonical lowercase command.
+        assert_eq!(
+            parse_command("/COLSE"),
+            MeetingCommand::Unknown {
+                input: "/COLSE".to_string(),
+                suggestion: Some("/close".to_string()),
+            },
+        );
+    }
+
+    #[test]
+    fn parse_distant_garbage_is_unknown_with_no_suggestion() {
+        assert_eq!(
+            parse_command("/xyzzy"),
+            MeetingCommand::Unknown {
+                input: "/xyzzy".to_string(),
+                suggestion: None,
+            },
+        );
+        assert_eq!(
+            parse_command("/zzzzzzzz"),
+            MeetingCommand::Unknown {
+                input: "/zzzzzzzz".to_string(),
+                suggestion: None,
+            },
+        );
+    }
+
+    #[test]
+    fn parse_conversational_slash_with_args_is_untouched() {
+        // Multi-token slash lines remain conversation — never Unknown.
+        assert_eq!(
+            parse_command("/notarealcommand foo bar"),
+            MeetingCommand::Conversation("/notarealcommand foo bar".to_string()),
+        );
+        assert_eq!(
+            parse_command("/foo some text"),
+            MeetingCommand::Conversation("/foo some text".to_string()),
+        );
+    }
+
+    #[test]
+    fn parse_file_path_is_conversation_not_unknown() {
+        // Single tokens that are filesystem paths (extra `/`, dots, digits)
+        // must stay conversation so operators can type paths.
+        assert_eq!(
+            parse_command("/home/user/file.txt"),
+            MeetingCommand::Conversation("/home/user/file.txt".to_string()),
+        );
+        assert_eq!(
+            parse_command("/etc/hosts"),
+            MeetingCommand::Conversation("/etc/hosts".to_string()),
+        );
+        assert_eq!(
+            parse_command("/v2"),
+            MeetingCommand::Conversation("/v2".to_string()),
+        );
+    }
+
+    #[test]
+    fn parse_common_path_roots_stay_conversation() {
+        // Bare single-component absolute paths (FHS roots) must not be
+        // mistaken for commands — `/home` is within edit distance 2 of
+        // `/done`, so without the guard it would wrongly suggest `/done`.
+        for root in [
+            "/home", "/tmp", "/var", "/usr", "/etc", "/bin", "/dev", "/opt", "/proc", "/sys",
+            "/run", "/lib", "/srv", "/mnt", "/boot", "/root", "/sbin", "/media",
+        ] {
+            assert_eq!(
+                parse_command(root),
+                MeetingCommand::Conversation(root.to_string()),
+                "FHS path root {root} must stay conversation",
+            );
+        }
+        // Case-insensitive: the lowercased token still matches a known root.
+        assert_eq!(
+            parse_command("/HOME"),
+            MeetingCommand::Conversation("/HOME".to_string()),
+        );
+    }
+
+    #[test]
+    fn parse_command_typo_with_payload_stays_conversation() {
+        // Deliberate scope boundary (issue #2321): only argument-less single
+        // slash-tokens are treated as command attempts. A typo that carries a
+        // payload (`/decison Adopt TDD`) is multi-token, so it is left as
+        // conversation rather than producing a suggestion — distinguishing it
+        // from an intentional `/word args` line is ambiguous.
+        assert_eq!(
+            parse_command("/decison Adopt TDD"),
+            MeetingCommand::Conversation("/decison Adopt TDD".to_string()),
+        );
+        assert_eq!(
+            parse_command("/quesion Who owns this?"),
+            MeetingCommand::Conversation("/quesion Who owns this?".to_string()),
+        );
+    }
+
+    #[test]
+    fn parse_bare_empty_payload_commands_stay_conversation() {
+        // Known arg-requiring commands typed bare already fall through to
+        // conversation; the Unknown detection must not change that.
+        for cmd in [
+            "/decision",
+            "/action",
+            "/question",
+            "/owner",
+            "/goal",
+            "/risk",
+            "/disagree",
+            "/theme",
+        ] {
+            assert_eq!(
+                parse_command(cmd),
+                MeetingCommand::Conversation(cmd.to_string()),
+                "bare {cmd} must stay conversation",
+            );
+        }
+    }
+
+    #[test]
+    fn closest_command_respects_distance_threshold() {
+        assert_eq!(closest_command("/colse"), Some("/close".to_string()));
+        assert_eq!(closest_command("/templat"), Some("/template".to_string()));
+        // Distance 3+ → no suggestion.
+        assert_eq!(closest_command("/xyzzy"), None);
+        assert_eq!(closest_command("/qqqqqq"), None);
+    }
+
+    #[test]
+    fn levenshtein_basic_distances() {
+        assert_eq!(levenshtein("", ""), 0);
+        assert_eq!(levenshtein("close", "close"), 0);
+        assert_eq!(levenshtein("clse", "close"), 1);
+        assert_eq!(levenshtein("colse", "close"), 2);
+        assert_eq!(levenshtein("kitten", "sitting"), 3);
+    }
+
+    // ── Grouped /help (issue #2321) ──────────────────────────────────
+
+    #[test]
+    fn help_groups_have_expected_titles() {
+        let titles: Vec<&str> = HELP_GROUPS.iter().map(|g| g.title).collect();
+        assert_eq!(titles, vec!["Meeting control", "Capture", "Templates"]);
+    }
+
+    #[test]
+    fn help_groups_render_all_user_commands_exactly_once() {
+        // Every user-facing command (the canonical set minus the /done
+        // alias) must appear in exactly one group, exactly once.
+        let mut seen: Vec<&str> = Vec::new();
+        for group in HELP_GROUPS {
+            for entry in group.entries {
+                assert!(
+                    !seen.contains(&entry.token),
+                    "{} appears more than once in /help",
+                    entry.token,
+                );
+                seen.push(entry.token);
+            }
+        }
+        let mut expected: Vec<&str> = KNOWN_COMMANDS
+            .iter()
+            .copied()
+            .filter(|c| *c != "/done")
+            .collect();
+        seen.sort_unstable();
+        expected.sort_unstable();
+        assert_eq!(
+            seen, expected,
+            "grouped /help must cover every command once"
+        );
+    }
+
+    #[test]
+    fn render_help_plain_contains_groups_and_commands() {
+        let help = render_help_plain();
+        assert!(help.contains("Meeting control"));
+        assert!(help.contains("Capture"));
+        assert!(help.contains("Templates"));
+        for group in HELP_GROUPS {
+            for entry in group.entries {
+                assert!(
+                    help.contains(entry.token),
+                    "plain help missing {}",
+                    entry.token,
+                );
+            }
+        }
+        assert!(help.contains("natural conversation"));
+    }
+
+    #[test]
+    fn known_commands_superset_of_help_tokens() {
+        // Guard against drift: every displayed command is a recognized token.
+        for group in HELP_GROUPS {
+            for entry in group.entries {
+                assert!(
+                    KNOWN_COMMANDS.contains(&entry.token),
+                    "{} shown in /help but not in KNOWN_COMMANDS",
+                    entry.token,
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn unknown_command_notice_formats() {
+        assert_eq!(
+            unknown_command_notice("/colse", Some("/close")),
+            "Unknown command '/colse'. Did you mean '/close'?",
+        );
+        assert_eq!(
+            unknown_command_notice("/xyzzy", None),
+            "Unknown command '/xyzzy'. Type /help for the full list.",
         );
     }
 }

--- a/src/meeting_backend/mod.rs
+++ b/src/meeting_backend/mod.rs
@@ -33,7 +33,10 @@ use crate::cognitive_memory::CognitiveMemoryOps;
 use crate::error::SimardResult;
 
 pub use close_guard::{PartialReason, Timeout, with_timeout};
-pub use command::{MeetingCommand, parse_command};
+pub use command::{
+    HELP_GROUPS, HelpEntry, HelpGroup, MeetingCommand, parse_command, render_help_plain,
+    unknown_command_notice,
+};
 pub use types::{
     AppliedTemplate, ConversationMessage, HandoffActionItem, MeetingResponse, MeetingSummary,
     MeetingTranscript, Role, SessionStatus,

--- a/src/meeting_repl/repl.rs
+++ b/src/meeting_repl/repl.rs
@@ -13,7 +13,8 @@ use crate::meeting_backend::persist::{
     extract_risks,
 };
 use crate::meeting_backend::{
-    MeetingBackend, MeetingCommand, Role, parse_command, strip_ansi_escapes,
+    HELP_GROUPS, MeetingBackend, MeetingCommand, Role, parse_command, strip_ansi_escapes,
+    unknown_command_notice,
 };
 use crate::meeting_facilitator::MeetingSession;
 
@@ -41,6 +42,27 @@ fn checkpoint_wip(backend: &MeetingBackend) {
 /// `color::cyan` helper which already honors `NO_COLOR`.
 fn prompt_string() -> String {
     cyan(PROMPT_TEXT)
+}
+
+/// Render the grouped, colorized `/help` reference.
+///
+/// Sources the command groups from `meeting_backend::HELP_GROUPS` (single
+/// source of truth) and colors each group title cyan in the same `── Title ──`
+/// style used by `/state` and `/recap`. Honors `NO_COLOR` via the `cyan`
+/// helper. Reused for the `/help` command and the no-suggestion branch of the
+/// unknown-command hint. Issue #2321.
+fn write_help<W: Write>(output: &mut W) {
+    for group in HELP_GROUPS {
+        writeln!(output, "\n{}", cyan(&format!("── {} ──", group.title))).ok();
+        for entry in group.entries {
+            writeln!(output, "  {} — {}", entry.usage, entry.description).ok();
+        }
+    }
+    writeln!(
+        output,
+        "\nEverything else is natural conversation with Simard."
+    )
+    .ok();
 }
 
 /// Render a structured backend-error banner to the operator.
@@ -196,11 +218,20 @@ pub fn run_meeting_repl<R: BufRead, W: Write>(
 
         match parse_command(&line) {
             MeetingCommand::Help => {
+                write_help(output);
+            }
+            MeetingCommand::Unknown { input, suggestion } => {
+                // A mistyped command (e.g. `/colse`). Surface a did-you-mean
+                // hint instead of forwarding the typo to the LLM. Issue #2321.
                 writeln!(
                     output,
-                    "Commands:\n  /status    — show session info\n  /state     — show current decisions, open questions, action items, risks, disagreements\n  /template  — list meeting templates\n  /template <name> — apply a template (standup, 1on1, retro, planning)\n  /theme <text>    — record a theme for this meeting\n  /decision <text> [--rationale <why>] — record a decision (optional rationale)\n  /action <text>   — record an action item (assignee/deadline parsed inline)\n  /question <text> — record an open question deterministically\n  /risk <text>     — record an identified risk\n  /disagree <text> — record a disagreement or dissenting view\n  /owner <name>    — name the next agent/persona/human expected to action this handoff\n  /goal <text>     — set the meeting's overarching objective\n  /recap     — show color-coded session recap\n  /preview   — preview the handoff artifact\n  /export    — export meeting as markdown\n  /close     — end meeting and persist\n  /help      — this message\n\nEverything else is natural conversation with Simard."
+                    "{}",
+                    yellow(&unknown_command_notice(&input, suggestion.as_deref()))
                 )
                 .ok();
+                if suggestion.is_none() {
+                    write_help(output);
+                }
             }
             MeetingCommand::Status => {
                 let status = backend.status();

--- a/src/meeting_repl/tests_repl.rs
+++ b/src/meeting_repl/tests_repl.rs
@@ -691,6 +691,202 @@ fn repl_help_mentions_inline_recording_commands() {
     }
 }
 
+// ── Grouped /help + unknown-command suggestions (issue #2321) ─────────
+
+#[test]
+#[serial(cognitive_memory)]
+fn repl_help_is_grouped_into_sections() {
+    let _state = HermeticState::new();
+    let bridge = mock_bridge();
+    let agent = MockAgentSession::new("ok");
+    let input = b"/help\n/close\n";
+    let mut reader = &input[..];
+    let mut output = Vec::new();
+
+    run_meeting_repl(
+        "Grouped help test",
+        &bridge,
+        Some(Box::new(agent)),
+        "",
+        &mut reader,
+        &mut output,
+    )
+    .unwrap();
+
+    let output_str = String::from_utf8(output).unwrap();
+    for title in ["Meeting control", "Capture", "Templates"] {
+        assert!(
+            output_str.contains(title),
+            "grouped help should contain section '{title}': {output_str}"
+        );
+    }
+}
+
+#[test]
+#[serial(cognitive_memory)]
+fn repl_grouped_help_colorizes_section_titles() {
+    let _state = HermeticState::new();
+    // Ensure NO_COLOR is unset so ANSI escapes are emitted.
+    // SAFETY: serial_test guards against parallel access to env vars.
+    unsafe { std::env::remove_var("NO_COLOR") };
+
+    let bridge = mock_bridge();
+    let agent = MockAgentSession::new("ok");
+    let input = b"/help\n/close\n";
+    let mut reader = &input[..];
+    let mut output = Vec::new();
+
+    run_meeting_repl(
+        "Grouped help color test",
+        &bridge,
+        Some(Box::new(agent)),
+        "",
+        &mut reader,
+        &mut output,
+    )
+    .unwrap();
+
+    let output_str = String::from_utf8(output).unwrap();
+    // Section titles are wrapped in the cyan escape (\x1b[36m … \x1b[0m),
+    // matching how /state and /recap colorize their headers.
+    assert!(
+        output_str.contains("\x1b[36m── Meeting control ──\x1b[0m"),
+        "grouped help titles should be colorized cyan: {output_str:?}"
+    );
+}
+
+#[test]
+#[serial(cognitive_memory)]
+fn repl_grouped_help_honors_no_color() {
+    let _state = HermeticState::new();
+    // SAFETY: serial_test guards against parallel access to env vars.
+    unsafe { std::env::set_var("NO_COLOR", "1") };
+
+    let bridge = mock_bridge();
+    let agent = MockAgentSession::new("ok");
+    let input = b"/help\n/close\n";
+    let mut reader = &input[..];
+    let mut output = Vec::new();
+
+    run_meeting_repl(
+        "Grouped help NO_COLOR test",
+        &bridge,
+        Some(Box::new(agent)),
+        "",
+        &mut reader,
+        &mut output,
+    )
+    .unwrap();
+
+    unsafe { std::env::remove_var("NO_COLOR") };
+
+    let output_str = String::from_utf8(output).unwrap();
+    assert!(
+        output_str.contains("── Meeting control ──"),
+        "section title still present without color: {output_str}"
+    );
+    assert!(
+        !output_str.contains("\x1b["),
+        "no ANSI escapes when NO_COLOR is set: {output_str:?}"
+    );
+}
+
+#[test]
+#[serial(cognitive_memory)]
+fn repl_unknown_command_suggests_closest() {
+    let _state = HermeticState::new();
+    let bridge = mock_bridge();
+    // Distinctive sentinel so we can prove the typo was NOT forwarded to the LLM.
+    let agent = MockAgentSession::new("AGENT_REPLY_SENTINEL");
+    let input = b"/colse\n/close\n";
+    let mut reader = &input[..];
+    let mut output = Vec::new();
+
+    run_meeting_repl(
+        "Unknown command suggestion",
+        &bridge,
+        Some(Box::new(agent)),
+        "",
+        &mut reader,
+        &mut output,
+    )
+    .unwrap();
+
+    let output_str = String::from_utf8(output).unwrap();
+    assert!(
+        output_str.contains("Unknown command '/colse'. Did you mean '/close'?"),
+        "should suggest the closest command: {output_str}"
+    );
+    assert!(
+        !output_str.contains("AGENT_REPLY_SENTINEL"),
+        "a mistyped command must not be forwarded to the LLM: {output_str}"
+    );
+}
+
+#[test]
+#[serial(cognitive_memory)]
+fn repl_unknown_command_without_match_lists_commands() {
+    let _state = HermeticState::new();
+    let bridge = mock_bridge();
+    let agent = MockAgentSession::new("ok");
+    let input = b"/zzzzzzzz\n/close\n";
+    let mut reader = &input[..];
+    let mut output = Vec::new();
+
+    run_meeting_repl(
+        "Unknown command no match",
+        &bridge,
+        Some(Box::new(agent)),
+        "",
+        &mut reader,
+        &mut output,
+    )
+    .unwrap();
+
+    let output_str = String::from_utf8(output).unwrap();
+    assert!(
+        output_str.contains("Unknown command '/zzzzzzzz'."),
+        "should report the unknown command: {output_str}"
+    );
+    // No close match → fall back to listing the grouped command reference.
+    assert!(
+        output_str.contains("Meeting control") && output_str.contains("/status"),
+        "no-suggestion path should list available commands: {output_str}"
+    );
+}
+
+#[test]
+#[serial(cognitive_memory)]
+fn repl_file_path_is_not_treated_as_unknown_command() {
+    let _state = HermeticState::new();
+    let bridge = mock_bridge();
+    let agent = MockAgentSession::new("noted the path");
+    // A filesystem path starts with '/' but must remain conversation.
+    let input = b"/home/user/notes.md\n/close\n";
+    let mut reader = &input[..];
+    let mut output = Vec::new();
+
+    run_meeting_repl(
+        "File path conversation",
+        &bridge,
+        Some(Box::new(agent)),
+        "",
+        &mut reader,
+        &mut output,
+    )
+    .unwrap();
+
+    let output_str = String::from_utf8(output).unwrap();
+    assert!(
+        !output_str.contains("Unknown command"),
+        "a file path must not trigger the unknown-command hint: {output_str}"
+    );
+    assert!(
+        output_str.contains("noted the path"),
+        "a file path should be forwarded to the LLM as conversation: {output_str}"
+    );
+}
+
 #[test]
 #[serial(cognitive_memory)]
 fn repl_decision_command_records_and_confirms() {

--- a/src/operator_commands_dashboard/chat.rs
+++ b/src/operator_commands_dashboard/chat.rs
@@ -75,7 +75,9 @@ pub(crate) async fn ws_chat_handler(ws: WebSocketUpgrade) -> response::Response 
 }
 
 pub(crate) async fn handle_ws_chat(mut socket: WebSocket) {
-    use crate::meeting_backend::{MeetingBackend, MeetingCommand, parse_command};
+    use crate::meeting_backend::{
+        MeetingBackend, MeetingCommand, parse_command, render_help_plain, unknown_command_notice,
+    };
 
     // Use the full agent session (SessionBuilder) for chat.
     // The lightweight piped-subprocess path is disabled — it spawns
@@ -183,10 +185,27 @@ pub(crate) async fn handle_ws_chat(mut socket: WebSocket) {
                         break;
                     }
                     MeetingCommand::Help => {
-                        let help = "Commands: /status, /template [name], /export, /theme <text>, /decision <text>, /action <text>, /question <text>, /owner <name>, /recap, /preview, /state, /close, /help. Everything else is natural conversation with Simard.";
+                        let help = render_help_plain();
                         let _ = socket
                             .send(Message::Text(
                                 json!({"role":"system","content": help}).to_string().into(),
+                            ))
+                            .await;
+                    }
+                    MeetingCommand::Unknown { input, suggestion } => {
+                        // Mistyped command: surface a did-you-mean hint (or the
+                        // full grouped help) instead of forwarding to the LLM.
+                        // Issue #2321.
+                        let mut content = unknown_command_notice(&input, suggestion.as_deref());
+                        if suggestion.is_none() {
+                            content.push_str("\n\n");
+                            content.push_str(&render_help_plain());
+                        }
+                        let _ = socket
+                            .send(Message::Text(
+                                json!({"role":"system","content": content})
+                                    .to_string()
+                                    .into(),
                             ))
                             .await;
                     }
@@ -578,6 +597,27 @@ mod tests {
     fn chat_recognizes_help_command() {
         use crate::meeting_backend::{MeetingCommand, parse_command};
         assert!(matches!(parse_command("/help"), MeetingCommand::Help));
+    }
+
+    #[test]
+    fn chat_routes_unknown_command_with_suggestion() {
+        use crate::meeting_backend::{MeetingCommand, parse_command};
+        match parse_command("/colse") {
+            MeetingCommand::Unknown { input, suggestion } => {
+                assert_eq!(input, "/colse");
+                assert_eq!(suggestion.as_deref(), Some("/close"));
+            }
+            other => panic!("expected Unknown, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn chat_help_uses_grouped_reference() {
+        use crate::meeting_backend::render_help_plain;
+        let help = render_help_plain();
+        assert!(help.contains("Meeting control"));
+        assert!(help.contains("Capture"));
+        assert!(help.contains("Templates"));
     }
 
     #[test]

--- a/tests/gadugi/meeting-repl-ux.sh
+++ b/tests/gadugi/meeting-repl-ux.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# qa-team scenario for issue #2321 — meeting REPL UX prong.
+#
+# Outside-in verification of the two deferred UX features for goal
+# `enhance-simard-meeting-experience`:
+#
+#   1. Unknown-slash-command suggestions ("did you mean '/close'?").
+#   2. A grouped, colorized `/help`.
+#
+# The REPL-level tests drive the REAL interactive loop end-to-end:
+# `run_meeting_repl` is fed piped stdin (e.g. "/colse\n/close\n") with a mock
+# agent and its captured stdout is asserted — so the behavior is exercised
+# through the actual command dispatch, deterministically and with no live LLM
+# backend. The parser- and dispatch-level tests pin the narrow detection rules
+# (typo distance, file paths, bare empty-payload commands) and the grouped-help
+# single-source-of-truth. Substring filters are OR'd by the libtest harness;
+# `--quiet` is omitted so the per-test `... ok` lines below can be asserted.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+OUTPUT="$(
+  cargo test --lib --locked -- \
+    repl_unknown_command_suggests_closest \
+    repl_unknown_command_without_match_lists_commands \
+    repl_help_is_grouped_into_sections \
+    repl_grouped_help_colorizes_section_titles \
+    repl_grouped_help_honors_no_color \
+    repl_file_path_is_not_treated_as_unknown_command \
+    parse_typo_within_distance_two_suggests_closest \
+    parse_distant_garbage_is_unknown_with_no_suggestion \
+    parse_unknown_preserves_typed_case_in_input \
+    parse_file_path_is_conversation_not_unknown \
+    parse_common_path_roots_stay_conversation \
+    parse_command_typo_with_payload_stays_conversation \
+    parse_bare_empty_payload_commands_stay_conversation \
+    parse_conversational_slash_with_args_is_untouched \
+    parse_exact_commands_are_not_unknown \
+    closest_command_respects_distance_threshold \
+    help_groups_render_all_user_commands_exactly_once \
+    render_help_plain_contains_groups_and_commands \
+    chat_routes_unknown_command_with_suggestion \
+    chat_help_uses_grouped_reference \
+    2>&1
+)"
+
+printf '%s\n' "$OUTPUT"
+
+# Assert the suite passed with zero failures.
+printf '%s\n' "$OUTPUT" | grep -E "test result: ok\. [0-9]+ passed; 0 failed" >/dev/null
+
+# Assert the specific behaviors required by issue #2321 actually ran and passed.
+# Feature 1 — unknown-slash-command suggestions (REPL end-to-end):
+printf '%s\n' "$OUTPUT" | grep -F "repl_unknown_command_suggests_closest ... ok" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "repl_unknown_command_without_match_lists_commands ... ok" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "repl_file_path_is_not_treated_as_unknown_command ... ok" >/dev/null
+# Feature 1 — detection rules (parser-level):
+printf '%s\n' "$OUTPUT" | grep -F "parse_typo_within_distance_two_suggests_closest ... ok" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "parse_distant_garbage_is_unknown_with_no_suggestion ... ok" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "parse_file_path_is_conversation_not_unknown ... ok" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "parse_common_path_roots_stay_conversation ... ok" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "parse_command_typo_with_payload_stays_conversation ... ok" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "parse_bare_empty_payload_commands_stay_conversation ... ok" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "parse_conversational_slash_with_args_is_untouched ... ok" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "parse_exact_commands_are_not_unknown ... ok" >/dev/null
+# Feature 2 — grouped, colorized /help:
+printf '%s\n' "$OUTPUT" | grep -F "repl_help_is_grouped_into_sections ... ok" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "repl_grouped_help_colorizes_section_titles ... ok" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "repl_grouped_help_honors_no_color ... ok" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "help_groups_render_all_user_commands_exactly_once ... ok" >/dev/null
+# Dashboard chat dispatch parity:
+printf '%s\n' "$OUTPUT" | grep -F "chat_routes_unknown_command_with_suggestion ... ok" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "chat_help_uses_grouped_reference ... ok" >/dev/null
+
+echo "[gadugi] meeting REPL UX (#2321): suggestions + grouped /help verified"

--- a/tests/gadugi/meeting-repl-ux.yaml
+++ b/tests/gadugi/meeting-repl-ux.yaml
@@ -1,0 +1,54 @@
+name: "Meeting REPL UX: suggestions + grouped /help (#2321)"
+description: "Outside-in verification of the deferred meeting-REPL UX prong of goal enhance-simard-meeting-experience: unknown-slash-command suggestions ('did you mean /close?') routed through the real run_meeting_repl dispatch instead of the LLM, and a grouped, colorized /help. Pins the narrow detection rules (Levenshtein <= 2, file paths and bare empty-payload commands stay conversation) and the grouped-help single source of truth shared by the CLI REPL and dashboard chat."
+version: "1.0.0"
+
+config:
+  timeout: 600000
+  retries: 1
+  parallel: false
+
+environment:
+  requires: []
+
+agents:
+  - name: "cli-agent"
+    type: "cli"
+    config:
+      workingDirectory: "."
+      defaultTimeout: 600000
+      executionMode: "spawn"
+      captureOutput: true
+      ioConfig:
+        encoding: "utf8"
+        handleInteractivePrompts: false
+      logConfig:
+        logCommands: true
+        logOutput: true
+        logLevel: "info"
+
+steps:
+  - name: "Meeting REPL suggests typos and renders grouped /help"
+    agent: "cli-agent"
+    action: "execute_command"
+    params:
+      command: "tests/gadugi/meeting-repl-ux.sh"
+    timeout: 600000
+
+assertions: []
+
+cleanup:
+  - name: "CLI agent cleanup"
+    agent: "cli-agent"
+    action: "cleanup"
+
+metadata:
+  tags:
+    - "cli"
+    - "meeting"
+    - "repl"
+    - "ux"
+    - "outside-in"
+  priority: "high"
+  author: "copilot"
+  test_type: "outside-in"
+  issue: "2321"


### PR DESCRIPTION
## What & why

Implements the deferred **"better REPL UX" prong** of goal
`enhance-simard-meeting-experience` (parent #1149), explicitly carved out in the
"Follow-up (UX prong — not this issue)" section of #2309. Closes #2321.

The richer-handoffs prong already shipped (#2309 → merged #2313); this PR
delivers the matching UX half.

### Feature 1 — unknown-slash-command suggestions

Previously any unrecognized `/...` token silently fell through to
`MeetingCommand::Conversation` and was sent to the LLM, so a typo like `/colse`
was treated as chat. Now:

- A new `MeetingCommand::Unknown { input, suggestion }` variant is produced for
  an **argument-less, command-like** slash token (`/` + ASCII letters only)
  that matches no known command. `suggestion` is the closest known command by
  **Levenshtein distance ≤ 2**.
- Both dispatch sites render a hint **without forwarding to the LLM**:
  - With a match: `Unknown command '/colse'. Did you mean '/close'?`
  - No close match: `Unknown command '/zzzz'. Type /help for the full list.` + the grouped command list.

Deliberately narrow so real input is never hijacked: multi-token `/word args`
lines, file paths (extra `/`, dots, digits), FHS path roots (`/home`, `/tmp`,
…), and bare empty-payload commands (`/decision`, …) all stay conversation.

### Feature 2 — grouped, colorized `/help`

`HELP_GROUPS` (single source of truth in `command.rs`) drives both the CLI REPL
(cyan section titles, honoring `NO_COLOR`, matching `/recap` and `/state`) and
the dashboard chat (`render_help_plain`). Sections: **Meeting control** /
**Capture** / **Templates**, covering every command exactly once.

## Files changed (focused diff — criterion 6)

| File | Change |
|---|---|
| `src/meeting_backend/command.rs` | `Unknown` variant, `KNOWN_COMMANDS`, Levenshtein + `closest_command`, `is_command_like` (with FHS path-root guard), `HELP_GROUPS`, `render_help_plain`, `unknown_command_notice` + unit tests |
| `src/meeting_backend/mod.rs` | re-export new public items |
| `src/meeting_repl/repl.rs` | `Unknown` arm + grouped colorized `/help` (`write_help`) |
| `src/operator_commands_dashboard/chat.rs` | `Unknown` arm + grouped plain `/help` |
| `src/meeting_repl/tests_repl.rs` | REPL integration tests (suggestion, no-match, file-path, grouped + colorized help) |
| `docs/operations/meeting-handoffs.md` | grouped command reference + new behavior |
| `tests/gadugi/meeting-repl-ux.{sh,yaml}` | qa-team scenario |

No unrelated edits.

## Merge-ready evidence

### 1. qa-team / gadugi-test

New scenario `tests/gadugi/meeting-repl-ux.yaml` drives the **real**
`run_meeting_repl` dispatch (mock agent, no live LLM) plus parser/dispatch
pins.

```
$ gadugi-test validate --file tests/gadugi/meeting-repl-ux.yaml --strict
✓ Scenario "Meeting REPL UX: suggestions + grouped /help (#2321)" is valid
✓ All 1 file(s) are valid

$ gadugi-test run -d tests/gadugi -s meeting-repl-ux
Command completed with exit code 0  (duration ~38s)
Test Execution Results:  ✓ Passed: 1   ✗ Failed: 0   ✓ All tests passed!
```

### 2. Docs

`docs/operations/meeting-handoffs.md` "REPL Commands" section rewritten into the
three groups, plus a new subsection documenting the suggestion behavior, the
grouped/colorized `/help`, the FHS path-root handling, and the
argument-less-only scope boundary.

### 3. quality-audit — 3 SEEK→VALIDATE→FIX cycles, final cycle clean

- **Cycle 1** (code-review + security-review): no issues. Security confirmed the
  echoed `input` is provably `/[A-Za-z]+` (via `to_ascii_lowercase`, which
  avoids the Unicode Kelvin-sign fold), so no ANSI/terminal injection.
- **Cycle 2** (rubber-duck): found bare FHS path roots (`/home`) misclassified
  as commands (`/home`→`/done`), and `/help` colorization not directly asserted.
  **Fixed**: added `COMMON_PATH_ROOTS` guard + tests; added 2 colorization
  tests; documented the payload-typo scope boundary (intentional, per the
  issue) with a test.
- **Cycle 3** (code-review): clean. Independently recomputed Levenshtein for all
  19 roots × 17 commands (only `/home` collides, correctly suppressed); verified
  dispatch exhaustiveness, env handling, and tests.

Fixes commit: `379d1097893aa510dbf745d1dd50f054c9c0cf81`.

### 4. CI / local gates

The full `verify` workflow is **green for this commit** on run
[`27871287554`](https://github.com/rysweet/Simard/actions/runs/27871287554)
(`pre-commit`, `e2e-dashboard`, `install-real`, `cargo-audit`, `build`,
`coverage` all pass).

A second, duplicate `verify` run (triggered by the `pull_request` event on the
same commit) intermittently fails on a **known, pre-existing flaky test**,
`operator_commands_dashboard::tests_goals_crud::full_goal_lifecycle_crud` /
`meeting_backend::tests_goal_records_migration::migration_skips_slugs_already_in_cognitive_memory`
— tracked by **#2316** and **#2320**. These are cognitive-memory/goal-store
state-isolation flakes (one even surfaces a raw LadybugDB engine assertion) and
are **unrelated to this diff**, which touches none of those symbols. The
failures alternate between the two tests across runs (5662 passed; 1 failed),
confirming non-determinism rather than a regression. See the PR comment for the
full evidence trail.

Locally green (mirrors `verify.yml`):

- `cargo fmt --all -- --check` ✓
- `cargo clippy --release --no-deps -- -D warnings` ✓ (pre-commit hook)
- `cargo clippy --all-targets --all-features --locked -- -D warnings` ✓ (pre-push hook)
- `cargo test --release --lib` race subset (cognitive_memory/bootstrap/memory_ipc/memory_consolidation) ✓ (pre-push hook)
- Targeted: `cargo test --lib -- meeting_backend::command meeting_repl::tests_repl operator_commands_dashboard::chat` → **103 passed; 0 failed**.

### 6. Scope

Diff confined to the meeting REPL UX surfaces listed above. No handoff/
persistence/unrelated changes.

## Deliberate scope boundary

Only **argument-less** single slash-tokens are treated as command attempts.
Payload-bearing typos (e.g. `/decison Adopt TDD`) stay conversation, because
distinguishing a typo+payload from an intentional `/word args` line is ambiguous
and would risk hijacking real input. Tracked as a possible follow-up.
