### PR TITLE
feat(cog-mem): ranked fact recall (phase-weighted) + snapshot retention/dedup

### DIFF
--- a/docs/memory.md
+++ b/docs/memory.md
@@ -1,7 +1,7 @@
 ---
 title: Memory architecture
-description: Top-level overview of Simard's six-type cognitive memory, consolidation flow, and on-disk layout. Cross-links to the canonical architecture page.
-last_updated: 2026-06-19
+description: Top-level overview of Simard's six-type cognitive memory, consolidation flow, ranked fact recall, snapshot retention, and on-disk layout. Cross-links to the canonical architecture page.
+last_updated: 2026-06-21
 owner: simard
 doc_type: concept
 ---
@@ -53,6 +53,65 @@ connected graph that can be traversed both ways (#2325). See
 [Cognitive-memory provenance](reference/cognitive-memory-provenance.md).
 
 The OODA daemon dispatches a `consolidate-memory` action whenever working-memory pressure or recent-episode density crosses a threshold. Consolidation is idempotent and runs without spawning an engineer subprocess. Procedural memories are written inline during the OODA Act phase (not during consolidation) — each successful `ActionOutcome` produces an `ooda:{kind}` procedure. Prospective memories are written each cycle by a **board-sourced reconcile**: before every preparation pass the daemon mirrors each Active goal in the live `GoalBoard` into a prospective trigger via `store_prospective`, so `check_triggers` has something to match. See [Goal–prospective memory mirror](reference/goal-prospective-memory-mirror.md) for the original `CognitiveMemoryGoalStore` mirror and [Goal-board prospective reconcile](reference/goal-board-prospective-reconcile.md) for the per-cycle board-sourced step that the live daemon actually runs.
+
+## Ranked fact recall & retention
+
+Shipped in issue [#2329](https://github.com/rysweet/Simard/issues/2329). Two
+coordinated changes wire already-available `amplihack-memory-lib` capabilities
+into Simard's cognitive-memory layer. The library dependency rev is unchanged
+(`e3ea136`).
+
+### Ranked recall in preparation
+
+The OODA preparation phase gathers `relevant_facts` with the library's
+**ranked recall** (`recall_facts_ranked`) instead of a plain keyword
+`search_facts`. Every candidate fact is scored across six signals —
+**text relevance + confidence + importance + recency + usage + graph
+proximity** — and returned in **descending score order** (the first fact is
+the best match; ordering *is* the ranking, so no numeric score is added to
+`CognitiveFact`).
+
+Simard owns *which* signals matter per OODA phase via the
+`phase_weights::weights_for_phase` mapping (in `ooda_loop`). Defaults — fields
+are `(text_relevance, confidence, importance, recency, usage, graph)`:
+
+| Phase | text_rel | confidence | importance | recency | usage | graph | Bias |
+|---|---|---|---|---|---|---|---|
+| **Observe** | 0.8 | 0.5 | 0.5 | **1.0** | 0.4 | 0.5 | Favor recency — what changed lately. |
+| **Orient** | 1.0 | 0.7 | 0.5 | 0.4 | 0.3 | 0.6 | Balanced (library default). |
+| **Decide** | 1.0 | **1.0** | 0.6 | 0.3 | 0.3 | 0.5 | Favor confidence/relevance for commitments. |
+| **Act** | 1.0 | 0.7 | 0.5 | 0.4 | 0.3 | 0.6 | Balanced. |
+| **Sleep** | 1.0 | 0.7 | 0.5 | 0.4 | 0.3 | 0.6 | Balanced (no prep recall in Sleep). |
+
+Observe is recency-biased so the brain sees the freshest state first; Decide
+is confidence-biased so commitments lean on trusted facts. The divergence
+means the same fact set can be ordered differently per phase. Preparation
+recall runs with `record_access = false`, so merely preparing a cycle does
+**not** bump a fact's usage/recency and skew later recalls. Superseded
+snapshots are never recalled (`include_superseded = false`). The plain
+`search_facts` path is unchanged and still backs the exhaustive goal-fact
+load and the PR-A filters, which apply *after* ranking.
+
+### Snapshot / goal-record retention (CallerKey dedup)
+
+Periodic snapshot and goal-record writes (goal-board images, per-goal
+records) route through the library's **CallerKey dedup**. For a stable caller
+key, the library keeps **at most one live fact**: identical content is
+**reused** (no duplicate), changed content **supersedes** the prior fact
+(old archived, `superseded_by` set, typed `SUPERSEDES` edge new → old).
+
+| Logical record | Caller key |
+|---|---|
+| Goal-board snapshot | `"goal-board:snapshot"` |
+| Per-goal record | `format!("goal-store:record:{slug}")` (slug = goal id) |
+
+This collapses the historical snapshot pile-up that the PR-A
+`goal-board:snapshot` filter was working around. A retention pass
+(`prune_superseded`) reclaims the superseded tail; it runs **non-fatally** in
+the consolidation persistence path and protects provenance-bearing facts.
+
+See [Phase-weighted ranked fact recall & snapshot retention](reference/cognitive-memory-ranked-recall.md)
+for the full API, examples, and invariants.
 
 ## Inspecting memory from the CLI
 
@@ -139,5 +198,6 @@ For multi-host coordination see [Distributed operations](distributed-operations.
 - [Prospective-trigger firing](reference/prospective-trigger-firing.md) — how the OODA objective probe and case-insensitive match make stored triggers fire
 - [Episodic keyword recall](reference/cognitive-memory-episodic-recall.md) — how stored episodes surface for a matching objective
 - [Cognitive-memory provenance](reference/cognitive-memory-provenance.md) — DERIVES_FROM / PROCEDURE_DERIVES_FROM edges linking distilled facts and procedures back to their source episodes (#2325)
+- [Phase-weighted ranked fact recall & snapshot retention](reference/cognitive-memory-ranked-recall.md) — multi-signal ranked recall with per-OODA-phase weights, plus CallerKey dedup/SUPERSEDES and pruning for snapshot/goal records (#2329)
 - [Dashboard](dashboard.md) — Memory tab
 - [Daemon mode](daemon-mode.md) — when consolidation runs

--- a/docs/reference/cognitive-memory-fact-recall.md
+++ b/docs/reference/cognitive-memory-fact-recall.md
@@ -8,6 +8,7 @@ related:
   - ./cognitive-memory-preparation-filters.md
   - ./cognitive-memory-episodic-recall.md
   - ./cognitive-memory-goal-store.md
+  - ./cognitive-memory-ranked-recall.md
   - ./ooda-procedural-memory.md
   - ../memory.md
 doc_type: reference

--- a/docs/reference/cognitive-memory-preparation-filters.md
+++ b/docs/reference/cognitive-memory-preparation-filters.md
@@ -10,6 +10,7 @@ related:
   - ./prospective-trigger-firing.md
   - ./ooda-procedural-memory.md
   - ./cognitive-memory-episodic-recall.md
+  - ./cognitive-memory-ranked-recall.md
   - ../memory.md
 ---
 

--- a/docs/reference/cognitive-memory-ranked-recall.md
+++ b/docs/reference/cognitive-memory-ranked-recall.md
@@ -1,0 +1,417 @@
+---
+title: Phase-weighted ranked fact recall & snapshot retention
+description: How OODA preparation recalls semantic facts with the library's multi-signal ranked recall (relevance + confidence + importance + recency + usage + graph), how Simard tunes the ranking per OODA phase, and how snapshot/goal-record writes deduplicate via CallerKey so repeated records SUPERSEDE instead of accumulating.
+last_updated: 2026-06-21
+owner: simard
+doc_type: reference
+related:
+  - ../memory.md
+  - ../architecture/cognitive-memory.md
+  - ../architecture/cognitive-memory-library-adapter.md
+  - ./cognitive-memory-fact-recall.md
+  - ./cognitive-memory-preparation-filters.md
+  - ./cognitive-memory-goal-store.md
+  - ./cognitive-memory-provenance.md
+---
+
+# Phase-weighted ranked fact recall & snapshot retention
+
+> Shipped in issue [#2329](https://github.com/rysweet/Simard/issues/2329)
+> (`feat(cog-mem): ranked fact recall (phase-weighted) + snapshot
+> retention/dedup`). Builds on the PR-A preparation filters
+> ([Preparation-phase memory filters](./cognitive-memory-preparation-filters.md))
+> and tokenized recall ([Tokenized fact recall in preparation](./cognitive-memory-fact-recall.md)).
+
+Simard's OODA preparation phase no longer gathers `relevant_facts` with a
+plain keyword `search_facts`. It now uses the `amplihack-memory-lib`
+**ranked recall** (`recall_facts_ranked`), which scores every candidate
+fact across six signals and returns them in descending relevance order.
+Simard owns the *policy* — a small per-OODA-phase weight table that biases
+the ranking toward what each phase cares about — while the library owns the
+*mechanism* (the scoring math).
+
+In parallel, periodic **snapshot and goal-record writes** (goal-board
+images, per-goal records) now route through the library's **CallerKey
+deduplication**. A repeated logical record SUPERSEDES its predecessor (or is
+reused unchanged) instead of piling up a new revision every cycle, and a
+retention pass reclaims the superseded tail.
+
+The library dependency rev is unchanged (`e3ea136`, `features =
+["persistent"]`); both capabilities were already present in the library and
+are simply wired through the `CognitiveMemoryOps` trait.
+
+---
+
+## Ranked recall
+
+### Scoring signals
+
+`recall_facts_ranked` ranks each candidate fact by a weighted sum of six
+normalized signals:
+
+| Signal | Meaning |
+|---|---|
+| **text_relevance** | How well the fact's `concept`/`content` matches the query keywords. |
+| **confidence** | The fact's stored confidence (how sure Simard is it is true). |
+| **importance** | The fact's stored importance/salience. |
+| **recency** | How recently the fact was created or last accessed (exponential decay, 7-day half-life by default). |
+| **usage** | How often the fact has been recalled. |
+| **graph** | Graph-proximity boost from connected facts (e.g. `DERIVES_FROM` neighbours), up to 1 hop by default. |
+
+Results are returned **already sorted in descending score order** — the
+first element is the best match. Simard does not expose the raw numeric
+score on `CognitiveFact`; ordering *is* the ranking. Callers that need
+"the most relevant N facts" simply take the first N.
+
+### Per-phase weights
+
+Each OODA phase weights those six signals differently. The defaults live in
+the Simard-owned `phase_weights::weights_for_phase` mapping (in `ooda_loop`)
+and are applied automatically — no operator action is required.
+
+| Phase | text_relevance | confidence | importance | recency | usage | graph | Bias |
+|---|---|---|---|---|---|---|---|
+| **Observe** | 0.8 | 0.5 | 0.5 | **1.0** | 0.4 | 0.5 | Favor recency — surface what changed lately. |
+| **Orient** | 1.0 | 0.7 | 0.5 | 0.4 | 0.3 | 0.6 | Balanced (library default). |
+| **Decide** | 1.0 | **1.0** | 0.6 | 0.3 | 0.3 | 0.5 | Favor confidence/relevance — commit on trusted facts. |
+| **Act** | 1.0 | 0.7 | 0.5 | 0.4 | 0.3 | 0.6 | Balanced. |
+| **Sleep** | 1.0 | 0.7 | 0.5 | 0.4 | 0.3 | 0.6 | Balanced (no prep recall runs in Sleep; included for completeness). |
+
+The **Observe** preset is recency-heavy so that the first thing the brain
+sees each cycle is the freshest declarative state. The **Decide** preset is
+confidence-heavy so that commitments lean on facts Simard is sure about. The
+divergence between these two presets means the *same* fact set can be
+ordered differently depending on the phase — that is intentional and is
+exercised by the `phase_weights_change_ordering` test.
+
+`Orient`, `Act`, and `Sleep` use the library's balanced default so that the
+only deliberate divergences are the two that matter (Observe vs Decide).
+
+### Read-only during preparation
+
+Preparation recall is performed with `record_access = false`. Gathering
+`relevant_facts` to build the prepared context does **not** bump a fact's
+`usage_count` or `last_accessed_at`. This keeps the recency/usage signals
+honest: simply *preparing* a cycle must not make a fact look "recently used"
+and skew the next recall in the same cycle. Access is only recorded when a
+fact is genuinely consumed elsewhere.
+
+### Superseded facts are never recalled
+
+Preparation recall sets `include_superseded = false` (and
+`include_archived = false`), so superseded snapshot revisions never re-enter
+the prepared context. This is what lets the CallerKey dedup (below) collapse
+the historical snapshot pile-up that the PR-A `goal-board:snapshot` filter
+was originally working around.
+
+### What ranked recall replaces (and what it does not)
+
+Ranked recall replaces **only** the per-fragment `relevant_facts` gather in
+preparation. The following are deliberately left on the plain `search_facts`
+path:
+
+- The exhaustive **goal-fact load** (`GOAL_STORE_FACT_CONCEPT`) — it is a
+  full concept load with slug-dedup, not a relevance ranking; ranking it
+  would distort which active goals are loaded.
+- All existing PR-A filters: the `goal-board:snapshot` drop, the
+  `seen_ids` dedup, the stale-slug filter, and the 10-fact truncation cap
+  all still apply *after* ranking.
+
+`search_facts` itself is unchanged and remains available for backward
+compatibility and for callers that want keyword recall without ranking.
+
+---
+
+## Snapshot / goal-record retention (CallerKey dedup)
+
+### The problem
+
+Simard writes the same *kind* of record over and over: a goal-board image
+every save, a per-goal record on every `put`. Previously each write created
+a brand-new fact node, so the store accumulated dozens of near-identical
+revisions that had to be filtered out on every read.
+
+### The mechanism
+
+Snapshot and goal-record writes now carry a stable **caller key**. For a
+given key `k`, the library guarantees **at most one live fact**:
+
+- **Identical content** → the existing fact is **reused** (no new node, no
+  duplicate).
+- **Changed content** → the old fact is **superseded**: it is archived, its
+  `superseded_by` is set to the new fact, and a typed `SUPERSEDES` edge is
+  created from the new fact to the old one.
+
+Either way the store keeps exactly one live record per logical key, and the
+full revision history remains traversable through `SUPERSEDES` edges until
+pruned.
+
+### Caller keys
+
+| Logical record | Caller key |
+|---|---|
+| Goal-board snapshot | `"goal-board:snapshot"` |
+| Per-goal record | `format!("goal-store:record:{slug}")` (slug = goal id) |
+| Generic fact snapshot | `"<snapshot_kind>"` |
+
+A single stable `goal-board:snapshot` key means every save supersedes the
+prior board image. Per-slug goal keys mean each goal's record supersedes its
+own previous revision rather than relying solely on the read-side "max
+node_id per slug" dedup loop (which remains as a defensive guard). Goal
+*carryover* records are out of scope and keep their existing write path.
+
+### Pruning superseded facts
+
+A retention pass reclaims the superseded tail. It runs **non-fatally** in the
+consolidation persistence path after the snapshot save — pruning is
+housekeeping, so a failure is logged and never aborts teardown.
+
+The retention policy:
+
+| Field | Value | Why |
+|---|---|---|
+| `include_superseded` | `true` | Reclaim archived/superseded snapshot revisions. |
+| `max_facts_per_concept` | `None` | Goal records all share one concept (`GOAL_STORE_FACT_CONCEPT`), so a per-concept cap would evict **live** goal records — not just the superseded tail — once active goals exceed the cap. `include_superseded` already makes the archived tail prunable on its own, so no cap is needed. |
+| `ttl_seconds_by_concept` | empty | No time-based eviction; retention here is purely about reclaiming superseded revisions. |
+| `min_importance_to_keep` | `0.0` | Never archive live facts on importance grounds (the library's prune test is `importance < min_importance_to_keep`, which can never fire at `0.0`). |
+| `dry_run` | `false` | Actually reclaim. |
+
+Provenance-bearing facts (those with `DERIVES_FROM` edges) are protected
+from deletion by the library, so pruning superseded snapshots never breaks a
+provenance chain. See
+[Cognitive-memory provenance](./cognitive-memory-provenance.md).
+
+---
+
+## API (`CognitiveMemoryOps` trait)
+
+Three methods were added to the backend-agnostic `CognitiveMemoryOps` trait.
+All three have **default implementations**, so existing implementors and test
+mocks compile unchanged; only `LibraryCognitiveMemory` overrides them.
+
+```rust
+/// Ranked recall. Returns facts in descending score order.
+/// Default impl delegates to `search_facts` (ignores weights), so any
+/// non-library backend keeps working with confidence-ranked keyword recall.
+fn recall_facts_ranked(
+    &self,
+    query: &str,
+    limit: u32,
+    min_confidence: f64,
+    weights: RecallWeightSet,
+) -> SimardResult<Vec<CognitiveFact>>;
+
+/// Store a fact under a stable caller key. Identical content is reused;
+/// changed content supersedes the prior live fact for this key.
+/// `caller_key` leads so call sites read `store_fact_with_caller_key(key, …)`,
+/// mirroring `store_fact`'s remaining argument order.
+/// Default impl delegates to `store_fact` (ignores the key).
+fn store_fact_with_caller_key(
+    &self,
+    caller_key: &str,
+    concept: &str,
+    content: &str,
+    confidence: f64,
+    tags: &[String],
+    source_id: &str,
+) -> SimardResult<String>;
+
+/// Prune superseded/archived facts. Returns the number reclaimed.
+/// Default impl is a no-op (`Ok(0)`).
+fn prune_superseded(&self) -> SimardResult<usize>;
+```
+
+Notes:
+
+- The trait stays `&self`. The library's `recall_facts_ranked` is
+  `&mut self` (it *can* record access); the adapter bridges that through its
+  existing `Mutex` write-lock pattern.
+- The trait takes the Simard-owned `RecallWeightSet`, **not** the library's
+  `RecallWeights`, so the trait — and every mock/implementor — stays
+  backend-agnostic. The `RecallWeightSet → RecallWeights` conversion is
+  adapter-local. `RecallWeightSet` is re-exported from the `cognitive_memory`
+  module; the `OodaPhase → RecallWeightSet` mapping lives in `ooda_loop`
+  (see below), because only that layer knows about `OodaPhase` and
+  `cognitive_memory` must stay a leaf module.
+- Ordering is conveyed by result order only — `CognitiveFact` gained no
+  score field.
+
+### `RecallWeightSet` and the phase mapping
+
+`RecallWeightSet` is Simard's per-signal weight type — a backend-agnostic
+mirror of the library's `RecallWeights` (same six fields, same order). It
+lives in `cognitive_memory` so the trait never names a library type:
+
+```rust
+pub struct RecallWeightSet {
+    pub text_relevance: f64,
+    pub confidence: f64,
+    pub importance: f64,
+    pub recency: f64,
+    pub usage: f64,
+    pub graph: f64,
+}
+
+impl Default for RecallWeightSet {
+    // library-balanced default: 1.0, 0.7, 0.5, 0.4, 0.3, 0.6
+}
+```
+
+The `OodaPhase → RecallWeightSet` mapping lives in `ooda_loop`
+(`src/ooda_loop/phase_weights.rs`) — the only layer that knows `OodaPhase`;
+`cognitive_memory` must stay a leaf and must not import `ooda_loop`. It is a
+free function returning the Simard-owned `RecallWeightSet`:
+
+```rust
+// src/ooda_loop/phase_weights.rs
+/// Weights for a given OODA phase. Observe favors recency, Decide favors
+/// confidence/relevance, and every other phase uses the balanced default.
+pub fn weights_for_phase(phase: OodaPhase) -> RecallWeightSet {
+    match phase {
+        OodaPhase::Observe => /* recency-heavy preset (recency 1.0) */,
+        OodaPhase::Decide  => /* confidence-heavy preset (confidence 1.0) */,
+        _                  => RecallWeightSet::default(), // balanced
+    }
+}
+```
+
+`cycle.rs` computes the `RecallWeightSet` for the live phase and threads it
+*down* into preparation, so the adapter — not the trait — performs the
+`RecallWeightSet → RecallWeights` conversion.
+
+The numeric defaults are pinned by a unit test so the documented table
+cannot silently drift from the code.
+
+### Phased preparation entry point
+
+A phase-aware variant threads the per-phase weights into preparation. The
+existing 3-arg and 4-arg `preparation_memory_operations*` signatures are
+kept for backward compatibility and default to the balanced `Orient`
+weights.
+
+```rust
+pub fn preparation_memory_operations_with_active_slugs_phased(
+    objective: &str,
+    session_id: &SessionId,
+    bridge: &dyn CognitiveMemoryOps,
+    active_slugs: Option<&HashSet<&str>>,
+    weights: RecallWeightSet,
+) -> SimardResult<PreparedContext>;
+```
+
+The OODA observe path calls this variant with
+`phase_weights::weights_for_phase(OodaPhase::Observe)`.
+
+---
+
+## Examples
+
+### Recall with phase weights
+
+```rust
+use crate::ooda_loop::phase_weights::weights_for_phase;
+
+// During OODA Observe — recency-biased: freshest facts first.
+let observed = bridge.recall_facts_ranked(
+    objective,
+    10,                                  // limit
+    0.0,                                 // min_confidence
+    weights_for_phase(OodaPhase::Observe),
+)?;
+
+// During OODA Decide — confidence-biased: trusted facts first.
+let decided = bridge.recall_facts_ranked(
+    objective,
+    10,
+    0.0,
+    weights_for_phase(OodaPhase::Decide),
+)?;
+```
+
+Given a recent low-confidence fact `F_new` and an old high-confidence fact
+`F_old`, `observed` orders `F_new` before `F_old` (recency wins) while
+`decided` orders `F_old` before `F_new` (confidence wins). The two orderings
+differ — that is the phase-weighting effect.
+
+### Store a snapshot under a caller key
+
+For the goal-board snapshot the caller key and the `concept` happen to be the
+same string (`"goal-board:snapshot"`); they are distinct arguments all the
+same — the key drives dedup, the concept is the stored fact's concept.
+
+```rust
+// First save: inserts one live snapshot fact.
+bridge.store_fact_with_caller_key(
+    "goal-board:snapshot",   // caller_key (stable across saves)
+    "goal-board:snapshot",   // concept
+    &board_json_v1,          // content
+    1.0,                     // confidence
+    &tags,                   // tags
+    session_id,              // source_id
+)?;
+
+// Identical save: reused — still exactly one live fact, no duplicate.
+bridge.store_fact_with_caller_key(
+    "goal-board:snapshot",
+    "goal-board:snapshot",
+    &board_json_v1,
+    1.0,
+    &tags,
+    session_id,
+)?;
+
+// Changed save: supersedes — v1 archived + `superseded_by` set + a
+// `SUPERSEDES` edge v2 -> v1; still exactly one live fact.
+bridge.store_fact_with_caller_key(
+    "goal-board:snapshot",
+    "goal-board:snapshot",
+    &board_json_v2,
+    1.0,
+    &tags,
+    session_id,
+)?;
+```
+
+### Prune the superseded tail
+
+```rust
+// Runs in the consolidation persistence path, non-fatally.
+let reclaimed = bridge.prune_superseded()?;
+tracing::debug!("pruned {reclaimed} superseded facts");
+```
+
+---
+
+## Invariants
+
+These are the guarantees the implementation upholds (and that the tests
+assert):
+
+1. **Single live record per caller key** — after any
+   `store_fact_with_caller_key(·, k)`, at most one non-archived fact has
+   `dedup_key == k`.
+2. **Supersede integrity** — a changed write archives the old fact, sets its
+   `superseded_by`, and adds a `SUPERSEDES` edge new → old.
+3. **Descending recall order** — `recall_facts_ranked` results are sorted by
+   score, highest first.
+4. **Phase divergence** — Observe and Decide weights can produce different
+   orderings of the same fact set.
+5. **Default back-compat** — a backend that does not override
+   `recall_facts_ranked` returns the same result as `search_facts` for any
+   weights.
+6. **Read-only preparation** — preparation recall (`record_access = false`)
+   leaves `usage_count` and `last_accessed_at` unchanged.
+7. **Superseded never recalled** — preparation recall
+   (`include_superseded = false`) never surfaces superseded snapshots.
+
+---
+
+## Related
+
+- [Memory architecture](../memory.md) — operator-level overview
+- [Cognitive Memory Architecture](../architecture/cognitive-memory.md) — canonical spec
+- [Library-backed Cognitive Memory](../architecture/cognitive-memory-library-adapter.md) — the `amplihack-memory-lib` backend that provides ranked recall and CallerKey dedup
+- [Tokenized fact recall in preparation](./cognitive-memory-fact-recall.md) — the keyword `search_facts` path ranked recall builds on
+- [Preparation-phase memory filters](./cognitive-memory-preparation-filters.md) — the PR-A snapshot/stale-slug filters that still apply after ranking
+- [File-backed goal store](./cognitive-memory-goal-store.md) — the goal records that now dedup via `goal-store:record:{slug}` caller keys
+- [Cognitive-memory provenance](./cognitive-memory-provenance.md) — `DERIVES_FROM` edges that protect facts from pruning

--- a/src/cognitive_memory/library_adapter.rs
+++ b/src/cognitive_memory/library_adapter.rs
@@ -40,11 +40,12 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, MutexGuard};
 
 use amplihack_memory::{
-    CognitiveMemory, EpisodicMemory, MemoryError, ProceduralMemory, ProspectiveMemory,
-    SemanticFact, WorkingMemorySlot,
+    CognitiveMemory, DedupMode, DedupOptions, EpisodicMemory, FactInput, MemoryError,
+    ProceduralMemory, ProspectiveMemory, RecallOptions, RecallWeights, RetentionPolicy,
+    SemanticFact, StoreFactOptions, WorkingMemorySlot,
 };
 
-use super::CognitiveMemoryOps;
+use super::{CognitiveMemoryOps, RecallWeightSet};
 use crate::error::{SimardError, SimardResult};
 use crate::memory_cognitive::{
     CognitiveEpisode, CognitiveFact, CognitiveProcedure, CognitiveProspective, CognitiveStatistics,
@@ -231,6 +232,20 @@ fn map_op_err(method: &str, err: MemoryError) -> SimardError {
         bridge: STORE_NAME.to_string(),
         method: method.to_string(),
         reason: err.to_string(),
+    }
+}
+
+/// Convert Simard's backend-agnostic [`RecallWeightSet`] into the library's
+/// [`RecallWeights`] (same six fields, same order). Issue #2329 — the trait
+/// stays backend-neutral, so this conversion is adapter-local.
+fn to_library_weights(w: RecallWeightSet) -> RecallWeights {
+    RecallWeights {
+        text_relevance: w.text_relevance,
+        confidence: w.confidence,
+        importance: w.importance,
+        recency: w.recency,
+        usage: w.usage,
+        graph: w.graph,
     }
 }
 
@@ -528,6 +543,108 @@ impl CognitiveMemoryOps for LibraryCognitiveMemory {
             guard.search_facts(query, limit as usize, min_confidence)
         };
         Ok(facts.into_iter().map(to_fact).collect())
+    }
+
+    fn recall_facts_ranked(
+        &self,
+        query: &str,
+        limit: u32,
+        min_confidence: f64,
+        weights: RecallWeightSet,
+    ) -> SimardResult<Vec<CognitiveFact>> {
+        // Issue #2329: ranked recall. `record_access = false` keeps this a pure
+        // read — gathering `relevant_facts` to prepare a cycle must not bump a
+        // fact's usage/recency and skew later recalls. `include_archived` /
+        // `include_superseded = false` means superseded snapshot revisions
+        // (collapsed by `store_fact_with_caller_key`) never re-enter recall. The
+        // remaining knobs are the library defaults (limit/min_confidence here,
+        // 1-hop graph, 7-day recency half-life). The library takes `&mut self`
+        // (it *can* record access), so we lock for write even though this call
+        // mutates nothing.
+        let options = RecallOptions {
+            limit: limit as usize,
+            min_confidence,
+            include_archived: false,
+            include_superseded: false,
+            record_access: false,
+            weights: to_library_weights(weights),
+            ..RecallOptions::default()
+        };
+        let mut guard = self.lock_write("recall_facts_ranked")?;
+        let scored = guard
+            .recall_facts_ranked(query, options)
+            .map_err(|e| map_op_err("recall_facts_ranked", e))?;
+        // The library already sorted by descending score; preserve that order
+        // (ordering *is* the ranking — no score is surfaced on `CognitiveFact`).
+        Ok(scored.into_iter().map(|s| to_fact(s.item)).collect())
+    }
+
+    fn store_fact_with_caller_key(
+        &self,
+        caller_key: &str,
+        concept: &str,
+        content: &str,
+        confidence: f64,
+        tags: &[String],
+        source_id: &str,
+    ) -> SimardResult<String> {
+        // Issue #2329: CallerKey dedup. Stamp the same process-wide monotonic
+        // sequence `store_fact` injects (see `FACT_SEQ_META_KEY`) so the
+        // "max node_id == newest fact" invariant the goal board / goal store /
+        // consolidation depend on still holds for caller-key writes. The fetch is
+        // done under the write lock so sequence order matches store order.
+        //
+        // `DedupMode::CallerKey(k)`: an identical-content write for `k` is reused
+        // (no new node); a changed-content write supersedes the prior live fact
+        // (archive old + `superseded_by` + `SUPERSEDES` edge new -> old). Either
+        // way exactly one live fact survives per key. The returned id is the live
+        // fact after the call.
+        let mut guard = self.lock_write("store_fact_with_caller_key")?;
+        let seq = self.fact_seq.fetch_add(1, Ordering::Relaxed);
+        let mut metadata: HashMap<String, serde_json::Value> = HashMap::with_capacity(1);
+        metadata.insert(FACT_SEQ_META_KEY.to_string(), serde_json::Value::from(seq));
+        let input = FactInput {
+            concept: concept.to_string(),
+            content: content.to_string(),
+            confidence,
+            source_id: source_id.to_string(),
+            tags: tags.to_vec(),
+            metadata,
+            dedup_key: Some(caller_key.to_string()),
+            ..FactInput::default()
+        };
+        let options = StoreFactOptions {
+            dedup: DedupOptions {
+                mode: DedupMode::CallerKey(caller_key.to_string()),
+                ..DedupOptions::default()
+            },
+            ..StoreFactOptions::default()
+        };
+        let outcome = guard
+            .upsert_fact(input, &options)
+            .map_err(|e| map_op_err("store_fact_with_caller_key", e))?;
+        Ok(outcome.node_id)
+    }
+
+    fn prune_superseded(&self) -> SimardResult<usize> {
+        // Issue #2329: reclaim the superseded tail produced by caller-key dedup.
+        // `include_superseded = true` is what makes the archived revisions
+        // prunable; `max_facts_per_concept = None` and `min_importance_to_keep =
+        // 0.0` ensure no *live* fact is evicted (all goal records share one
+        // concept, so a per-concept cap would evict live records). The library
+        // protects provenance-bearing facts from deletion.
+        let policy = RetentionPolicy {
+            max_facts_per_concept: None,
+            min_importance_to_keep: 0.0,
+            include_superseded: true,
+            dry_run: false,
+            ..RetentionPolicy::default()
+        };
+        let report = self
+            .lock_write("prune_superseded")?
+            .prune_semantic_memory(&policy)
+            .map_err(|e| map_op_err("prune_superseded", e))?;
+        Ok(report.archived + report.deleted)
     }
 
     fn episodes_for_fact(&self, fact_id: &str) -> SimardResult<Vec<String>> {

--- a/src/cognitive_memory/mod.rs
+++ b/src/cognitive_memory/mod.rs
@@ -16,6 +16,49 @@ use crate::memory_cognitive::{
     CognitiveWorkingSlot,
 };
 
+/// Per-signal weights for [`CognitiveMemoryOps::recall_facts_ranked`] (issue
+/// #2329).
+///
+/// A backend-agnostic mirror of the library's `RecallWeights` (same six fields,
+/// same order). It lives here — not in the adapter — so the trait never names a
+/// library type and every implementor/mock stays backend-neutral. The
+/// `RecallWeightSet -> amplihack_memory::RecallWeights` conversion is
+/// adapter-local. The per-[`OodaPhase`](crate::ooda_loop::OodaPhase) mapping
+/// lives in `ooda_loop::phase_weights` because only that layer knows about the
+/// OODA phases; `cognitive_memory` must stay a leaf module.
+///
+/// Each field scales one scoring term; weights are un-normalized (only relative
+/// magnitudes matter). [`Default`] is the library-balanced baseline.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RecallWeightSet {
+    /// Weight on keyword overlap between the query and the fact text.
+    pub text_relevance: f64,
+    /// Weight on the fact's confidence.
+    pub confidence: f64,
+    /// Weight on the fact's importance/salience.
+    pub importance: f64,
+    /// Weight on exponential recency decay of the last access / creation time.
+    pub recency: f64,
+    /// Weight on the sub-linear usage boost.
+    pub usage: f64,
+    /// Weight on graph-neighbor proximity (e.g. `DERIVES_FROM` neighbours).
+    pub graph: f64,
+}
+
+impl Default for RecallWeightSet {
+    /// Library-balanced default: `1.0, 0.7, 0.5, 0.4, 0.3, 0.6`.
+    fn default() -> Self {
+        Self {
+            text_relevance: 1.0,
+            confidence: 0.7,
+            importance: 0.5,
+            recency: 0.4,
+            usage: 0.3,
+            graph: 0.6,
+        }
+    }
+}
+
 /// Trait abstracting cognitive memory operations.
 ///
 /// Both [`LibraryCognitiveMemory`] (amplihack-memory-lib, lbug-backed) and
@@ -67,6 +110,72 @@ pub trait CognitiveMemoryOps: Send + Sync {
         limit: u32,
         min_confidence: f64,
     ) -> SimardResult<Vec<CognitiveFact>>;
+
+    /// Ranked (scored) recall over semantic facts (issue #2329).
+    ///
+    /// Scores every candidate fact across six signals — text relevance,
+    /// confidence, importance, recency, usage, and graph proximity — weighted by
+    /// `weights`, and returns the facts in **descending score order** (the first
+    /// element is the best match). Superseded/archived facts are excluded.
+    /// Ordering *is* the ranking; no numeric score is surfaced on
+    /// [`CognitiveFact`].
+    ///
+    /// `limit` and `min_confidence` mirror [`search_facts`](Self::search_facts).
+    ///
+    /// The default implementation delegates to
+    /// [`search_facts`](Self::search_facts) (ignoring `weights`) so non-library
+    /// backends (legacy Python bridge, IPC client, test mocks) keep working with
+    /// confidence-ranked keyword recall. Only [`LibraryCognitiveMemory`]
+    /// overrides this to call the library's ranked recall.
+    fn recall_facts_ranked(
+        &self,
+        query: &str,
+        limit: u32,
+        min_confidence: f64,
+        _weights: RecallWeightSet,
+    ) -> SimardResult<Vec<CognitiveFact>> {
+        self.search_facts(query, limit, min_confidence)
+    }
+
+    /// Store a fact under a stable `caller_key` so repeated logical records
+    /// deduplicate instead of accumulating (issue #2329).
+    ///
+    /// For a given `caller_key` the backend keeps **at most one live fact**:
+    /// identical content is **reused** (no duplicate node), changed content
+    /// **supersedes** the prior live fact (old archived, `superseded_by` set, a
+    /// typed `SUPERSEDES` edge new -> old). The remaining arguments mirror
+    /// [`store_fact`](Self::store_fact); `caller_key` leads so call sites read
+    /// `store_fact_with_caller_key(key, …)`.
+    ///
+    /// The default implementation ignores `caller_key` and delegates to
+    /// [`store_fact`](Self::store_fact), so backends without caller-key dedup
+    /// (legacy Python bridge, IPC client, test mocks) keep storing the fact
+    /// (without dedup). Only [`LibraryCognitiveMemory`] performs the dedup.
+    fn store_fact_with_caller_key(
+        &self,
+        _caller_key: &str,
+        concept: &str,
+        content: &str,
+        confidence: f64,
+        tags: &[String],
+        source_id: &str,
+    ) -> SimardResult<String> {
+        self.store_fact(concept, content, confidence, tags, source_id)
+    }
+
+    /// Prune superseded/archived facts, returning the number reclaimed
+    /// (issue #2329).
+    ///
+    /// Reclaims the superseded tail produced by
+    /// [`store_fact_with_caller_key`](Self::store_fact_with_caller_key) so the
+    /// snapshot/goal-record pile-up does not grow unbounded. Provenance-bearing
+    /// facts are protected by the backend.
+    ///
+    /// The default implementation is a no-op (`Ok(0)`) for backends without a
+    /// retention pass; only [`LibraryCognitiveMemory`] reclaims.
+    fn prune_superseded(&self) -> SimardResult<usize> {
+        Ok(0)
+    }
 
     fn store_procedure(
         &self,
@@ -338,3 +447,11 @@ mod tests_pr_2299_2300_recall_triggers;
 // procedure upsert) is preserved.
 #[cfg(test)]
 mod tests_provenance;
+
+// Issue #2329: ranked fact recall (phase-weighted) + snapshot retention/dedup.
+// Pins the new `recall_facts_ranked` (descending score order, default delegates
+// to `search_facts`), `store_fact_with_caller_key` (CallerKey reuse/supersede,
+// single live record), and `prune_superseded` (reclaims the superseded tail)
+// contracts against `LibraryCognitiveMemory`.
+#[cfg(test)]
+mod tests_ranked_recall;

--- a/src/cognitive_memory/tests_ranked_recall.rs
+++ b/src/cognitive_memory/tests_ranked_recall.rs
@@ -1,0 +1,314 @@
+//! TDD tests for ranked fact recall + CallerKey snapshot retention/dedup
+//! (issue #2329).
+//!
+//! Pins the three new `CognitiveMemoryOps` methods against the lbug-backed
+//! `LibraryCognitiveMemory::in_memory()` adapter (and the trait *default*
+//! against a non-library mock):
+//!
+//! * `recall_facts_ranked(query, limit, min_confidence, weights)` — returns
+//!   facts in **descending score order**, excludes superseded revisions, and
+//!   defaults to `search_facts` for non-library backends.
+//! * `store_fact_with_caller_key(caller_key, …)` — identical content is reused
+//!   (no duplicate node), changed content supersedes the prior live fact
+//!   (`SUPERSEDES`), leaving exactly one live fact per key.
+//! * `prune_superseded()` — reclaims the archived/superseded tail.
+
+use super::{CognitiveFact, CognitiveMemoryOps, LibraryCognitiveMemory, RecallWeightSet};
+use crate::error::SimardResult;
+use crate::memory_cognitive::{
+    CognitiveProcedure, CognitiveProspective, CognitiveStatistics, CognitiveWorkingSlot,
+};
+
+fn test_mem() -> LibraryCognitiveMemory {
+    LibraryCognitiveMemory::in_memory().expect("in-memory DB should create")
+}
+
+/// Count live (non-superseded) facts for a concept by going through ranked
+/// recall, which excludes superseded/archived revisions. `query` only affects
+/// scoring — every live fact above `min_confidence` is returned regardless of
+/// text match — so a broad query surfaces the full live set.
+fn live_facts_for_concept(mem: &LibraryCognitiveMemory, concept: &str) -> Vec<CognitiveFact> {
+    mem.recall_facts_ranked(concept, 256, 0.0, RecallWeightSet::default())
+        .expect("ranked recall")
+        .into_iter()
+        .filter(|f| f.concept == concept)
+        .collect()
+}
+
+/// Count *all* physical facts (including archived/superseded) via the wildcard
+/// `search_facts` path, which maps to `get_all_facts` and does NOT filter
+/// archived revisions.
+fn all_physical_facts(mem: &LibraryCognitiveMemory) -> Vec<CognitiveFact> {
+    mem.search_facts("*", 256, 0.0).expect("search all facts")
+}
+
+// ─── recall_facts_ranked: ordering ──────────────────────────────────────────
+
+/// Invariant #3 (descending recall order): a fact with high text relevance AND
+/// high confidence outranks a poorly-matching low-confidence fact.
+#[test]
+fn recall_facts_ranked_orders_by_descending_score() {
+    let mem = test_mem();
+    // Strong match + high confidence.
+    mem.store_fact("alpha beta", "gamma delta", 0.9, &[], "src")
+        .expect("store hi");
+    // No token overlap + low confidence.
+    mem.store_fact("omega", "sigma", 0.2, &[], "src")
+        .expect("store lo");
+
+    let ranked = mem
+        .recall_facts_ranked(
+            "alpha beta gamma delta",
+            10,
+            0.0,
+            RecallWeightSet::default(),
+        )
+        .expect("ranked recall");
+
+    assert_eq!(ranked.len(), 2, "both facts returned");
+    assert_eq!(
+        ranked[0].confidence, 0.9,
+        "highest-scored (relevant, confident) fact must come first"
+    );
+    assert_eq!(
+        ranked[1].confidence, 0.2,
+        "lowest-scored fact must come last"
+    );
+}
+
+/// `min_confidence` floors the candidate set, same as `search_facts`.
+#[test]
+fn recall_facts_ranked_respects_min_confidence() {
+    let mem = test_mem();
+    mem.store_fact("topic", "high", 0.9, &[], "src")
+        .expect("store high");
+    mem.store_fact("topic", "low", 0.1, &[], "src")
+        .expect("store low");
+
+    let ranked = mem
+        .recall_facts_ranked("topic", 10, 0.5, RecallWeightSet::default())
+        .expect("ranked recall");
+
+    assert_eq!(ranked.len(), 1, "the 0.1-confidence fact is floored out");
+    assert_eq!(ranked[0].confidence, 0.9);
+}
+
+/// Invariant #5 (default back-compat): a backend that does NOT override
+/// `recall_facts_ranked` returns exactly what `search_facts` returns, for any
+/// weights (the default impl ignores them).
+#[test]
+fn recall_facts_ranked_default_delegates_to_search_facts() {
+    let mock = SearchOnlyMock {
+        facts: vec![fact("c1", "first", 0.8), fact("c2", "second", 0.5)],
+    };
+
+    let via_search = mock.search_facts("q", 10, 0.0).unwrap();
+    // Even with non-default (Observe-like) weights, the default impl must
+    // delegate verbatim to `search_facts` — same facts, same order.
+    let weights = RecallWeightSet {
+        recency: 1.0,
+        ..RecallWeightSet::default()
+    };
+    let via_ranked = mock.recall_facts_ranked("q", 10, 0.0, weights).unwrap();
+
+    let search_concepts: Vec<&str> = via_search.iter().map(|f| f.concept.as_str()).collect();
+    let ranked_concepts: Vec<&str> = via_ranked.iter().map(|f| f.concept.as_str()).collect();
+    assert_eq!(
+        ranked_concepts, search_concepts,
+        "default recall_facts_ranked must mirror search_facts"
+    );
+}
+
+// ─── store_fact_with_caller_key: dedup / supersede ──────────────────────────
+
+/// Invariant #1 (single live record): re-storing IDENTICAL content under the
+/// same caller key REUSES the existing fact — no duplicate node is created.
+#[test]
+fn caller_key_identical_content_reuses_no_duplicate() {
+    let mem = test_mem();
+    let key = "goal-board:snapshot";
+    mem.store_fact_with_caller_key(key, "goal-board:snapshot", "BOARD_V1", 1.0, &[], "src")
+        .expect("first store");
+    mem.store_fact_with_caller_key(key, "goal-board:snapshot", "BOARD_V1", 1.0, &[], "src")
+        .expect("identical re-store");
+
+    // Reuse means NO new physical node — exactly one fact exists.
+    assert_eq!(
+        all_physical_facts(&mem).len(),
+        1,
+        "identical re-store under the same key must not create a duplicate"
+    );
+    assert_eq!(live_facts_for_concept(&mem, "goal-board:snapshot").len(), 1);
+}
+
+/// Invariants #1 + #2 (supersede integrity): re-storing CHANGED content under
+/// the same caller key supersedes the prior fact — one live record remains
+/// (the new content), the old one is archived (still physically present until
+/// pruned, and excluded from ranked recall).
+#[test]
+fn caller_key_changed_content_supersedes_prior() {
+    let mem = test_mem();
+    let key = "goal-board:snapshot";
+    mem.store_fact_with_caller_key(key, "goal-board:snapshot", "BOARD_V1", 1.0, &[], "src")
+        .expect("store v1");
+    mem.store_fact_with_caller_key(key, "goal-board:snapshot", "BOARD_V2", 1.0, &[], "src")
+        .expect("store v2 (changed)");
+
+    // Exactly one LIVE snapshot, and it is the latest content.
+    let live = live_facts_for_concept(&mem, "goal-board:snapshot");
+    assert_eq!(live.len(), 1, "supersede must leave one live snapshot");
+    assert_eq!(live[0].content, "BOARD_V2", "live fact is the new revision");
+
+    // The old revision is archived but still physically present (search_facts
+    // does not filter archived) — proving a supersede, not an in-place delete.
+    assert_eq!(
+        all_physical_facts(&mem).len(),
+        2,
+        "old revision is archived (still physical) until pruned"
+    );
+}
+
+/// Repeated changing snapshots never accumulate LIVE duplicates: after N
+/// supersedes there is still exactly one live record.
+#[test]
+fn caller_key_repeated_snapshots_keep_single_live_record() {
+    let mem = test_mem();
+    let key = "goal-board:snapshot";
+    for v in 1..=5 {
+        mem.store_fact_with_caller_key(
+            key,
+            "goal-board:snapshot",
+            &format!("BOARD_V{v}"),
+            1.0,
+            &[],
+            "src",
+        )
+        .expect("snapshot store");
+    }
+    let live = live_facts_for_concept(&mem, "goal-board:snapshot");
+    assert_eq!(live.len(), 1, "5 changing snapshots => 1 live record");
+    assert_eq!(live[0].content, "BOARD_V5");
+}
+
+// ─── prune_superseded ───────────────────────────────────────────────────────
+
+/// `prune_superseded` reclaims the archived/superseded tail: after a supersede
+/// it reports >= 1 reclaimed and the physical fact count drops back to the
+/// single live record.
+#[test]
+fn prune_superseded_reclaims_archived_tail() {
+    let mem = test_mem();
+    let key = "goal-board:snapshot";
+    mem.store_fact_with_caller_key(key, "goal-board:snapshot", "BOARD_V1", 1.0, &[], "src")
+        .expect("store v1");
+    mem.store_fact_with_caller_key(key, "goal-board:snapshot", "BOARD_V2", 1.0, &[], "src")
+        .expect("store v2");
+    assert_eq!(
+        all_physical_facts(&mem).len(),
+        2,
+        "one archived tail exists"
+    );
+
+    let reclaimed = mem.prune_superseded().expect("prune");
+    assert!(reclaimed >= 1, "at least the superseded tail is reclaimed");
+
+    // Only the live record survives; the live record itself is untouched.
+    assert_eq!(
+        all_physical_facts(&mem).len(),
+        1,
+        "superseded tail reclaimed, live record retained"
+    );
+    let live = live_facts_for_concept(&mem, "goal-board:snapshot");
+    assert_eq!(live.len(), 1);
+    assert_eq!(live[0].content, "BOARD_V2");
+}
+
+/// `prune_superseded` is a no-op (returns 0) when there is nothing superseded —
+/// it must never evict live records.
+#[test]
+fn prune_superseded_no_op_when_nothing_superseded() {
+    let mem = test_mem();
+    mem.store_fact("topic", "live", 0.9, &[], "src")
+        .expect("store");
+    let reclaimed = mem.prune_superseded().expect("prune");
+    assert_eq!(reclaimed, 0, "nothing to reclaim");
+    assert_eq!(all_physical_facts(&mem).len(), 1, "live fact retained");
+}
+
+// ─── minimal non-library mock for the default-delegation test ────────────────
+
+fn fact(concept: &str, content: &str, confidence: f64) -> CognitiveFact {
+    CognitiveFact {
+        node_id: format!("node-{concept}"),
+        concept: concept.to_string(),
+        content: content.to_string(),
+        confidence,
+        source_id: "mock".to_string(),
+        tags: vec![],
+    }
+}
+
+/// A non-library `CognitiveMemoryOps` backend that only implements
+/// `search_facts`; every other method is a stub. It does NOT override
+/// `recall_facts_ranked` / `store_fact_with_caller_key` / `prune_superseded`,
+/// so those exercise the trait defaults.
+struct SearchOnlyMock {
+    facts: Vec<CognitiveFact>,
+}
+
+impl CognitiveMemoryOps for SearchOnlyMock {
+    fn record_sensory(&self, _m: &str, _r: &str, _t: u64) -> SimardResult<String> {
+        Ok("sen".into())
+    }
+    fn prune_expired_sensory(&self) -> SimardResult<usize> {
+        Ok(0)
+    }
+    fn push_working(&self, _s: &str, _c: &str, _t: &str, _r: f64) -> SimardResult<String> {
+        Ok("wrk".into())
+    }
+    fn get_working(&self, _t: &str) -> SimardResult<Vec<CognitiveWorkingSlot>> {
+        Ok(vec![])
+    }
+    fn clear_working(&self, _t: &str) -> SimardResult<usize> {
+        Ok(0)
+    }
+    fn store_episode(
+        &self,
+        _c: &str,
+        _s: &str,
+        _m: Option<&serde_json::Value>,
+    ) -> SimardResult<String> {
+        Ok("epi".into())
+    }
+    fn consolidate_episodes(&self, _b: u32) -> SimardResult<Option<String>> {
+        Ok(None)
+    }
+    fn store_fact(
+        &self,
+        _concept: &str,
+        _content: &str,
+        _confidence: f64,
+        _tags: &[String],
+        _source_id: &str,
+    ) -> SimardResult<String> {
+        Ok("sem".into())
+    }
+    fn search_facts(&self, _q: &str, _l: u32, _c: f64) -> SimardResult<Vec<CognitiveFact>> {
+        Ok(self.facts.clone())
+    }
+    fn store_procedure(&self, _n: &str, _s: &[String], _p: &[String]) -> SimardResult<String> {
+        Ok("prc".into())
+    }
+    fn recall_procedure(&self, _q: &str, _l: u32) -> SimardResult<Vec<CognitiveProcedure>> {
+        Ok(vec![])
+    }
+    fn store_prospective(&self, _d: &str, _t: &str, _a: &str, _p: i64) -> SimardResult<String> {
+        Ok("pro".into())
+    }
+    fn check_triggers(&self, _c: &str) -> SimardResult<Vec<CognitiveProspective>> {
+        Ok(vec![])
+    }
+    fn get_statistics(&self) -> SimardResult<CognitiveStatistics> {
+        Ok(CognitiveStatistics::default())
+    }
+}

--- a/src/goal_curation/mod.rs
+++ b/src/goal_curation/mod.rs
@@ -34,3 +34,8 @@ mod tests_carryover;
 mod tests_operations;
 #[cfg(test)]
 mod tests_save_with_removals;
+
+// Issue #2329 (SimPR4): repeated goal-board snapshot saves supersede via
+// CallerKey dedup instead of accumulating live duplicates.
+#[cfg(test)]
+mod tests_snapshot_dedup;

--- a/src/goal_curation/operations.rs
+++ b/src/goal_curation/operations.rs
@@ -164,7 +164,8 @@ fn migrate_legacy_disk_file_if_present(bridge: &dyn CognitiveMemoryOps) {
             return;
         }
     };
-    if let Err(e) = bridge.store_fact(
+    if let Err(e) = bridge.store_fact_with_caller_key(
+        "goal-board:snapshot",
         "goal-board:snapshot",
         &snapshot,
         1.0,
@@ -444,7 +445,11 @@ pub fn save_goal_board(board: &GoalBoard, bridge: &dyn CognitiveMemoryOps) -> Si
         field: "board".to_string(),
         reason: format!("failed to serialize goal board: {e}"),
     })?;
-    bridge.store_fact(
+    // Issue #2329: route the board snapshot through CallerKey dedup so each save
+    // supersedes the prior board image instead of piling up a new revision every
+    // cycle. The caller key and the concept are the same stable string.
+    bridge.store_fact_with_caller_key(
+        "goal-board:snapshot",
         "goal-board:snapshot",
         &snapshot,
         1.0,
@@ -537,7 +542,9 @@ pub fn save_goal_board_with_removals(
         field: "board".to_string(),
         reason: format!("failed to serialize goal board: {e}"),
     })?;
-    bridge.store_fact(
+    // Issue #2329: CallerKey dedup — supersede the prior board image.
+    bridge.store_fact_with_caller_key(
+        "goal-board:snapshot",
         "goal-board:snapshot",
         &snapshot,
         1.0,

--- a/src/goal_curation/tests_snapshot_dedup.rs
+++ b/src/goal_curation/tests_snapshot_dedup.rs
@@ -1,0 +1,89 @@
+//! TDD test: repeated goal-board snapshot saves SUPERSEDE rather than
+//! accumulate (issue #2329, SimPR4).
+//!
+//! `save_goal_board` routes the `goal-board:snapshot` write through the
+//! library's CallerKey dedup. Saving the board repeatedly (each save changing
+//! it) must leave exactly **one live** snapshot fact — the prior revisions are
+//! superseded, not piled up — while the latest content remains readable.
+
+use serial_test::serial;
+use tempfile::TempDir;
+
+use crate::cognitive_memory::{CognitiveMemoryOps, RecallWeightSet};
+use crate::goal_curation::{
+    ActiveGoal, GoalBoard, GoalProgress, add_active_goal, load_goal_board, save_goal_board,
+};
+use crate::memory_ipc::launch_writer_bridge;
+use crate::state_root::STATE_ROOT_ENV;
+
+fn isolated_state_root() -> (TempDir, std::path::PathBuf) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path().to_path_buf();
+    unsafe {
+        std::env::set_var(STATE_ROOT_ENV, &root);
+    }
+    (tmp, root)
+}
+
+fn active_goal(id: &str, priority: u32) -> ActiveGoal {
+    ActiveGoal {
+        id: id.to_string(),
+        description: format!("{id} description"),
+        priority,
+        status: GoalProgress::NotStarted,
+        assigned_to: None,
+        current_activity: None,
+        wip_refs: vec![],
+        last_progress_update_at: None,
+    }
+}
+
+/// Count the LIVE `goal-board:snapshot` facts via ranked recall (which excludes
+/// superseded/archived revisions).
+fn live_snapshot_count(bridge: &dyn CognitiveMemoryOps) -> usize {
+    bridge
+        .recall_facts_ranked("goal-board:snapshot", 256, 0.0, RecallWeightSet::default())
+        .expect("ranked recall")
+        .into_iter()
+        .filter(|f| f.concept == "goal-board:snapshot")
+        .count()
+}
+
+#[test]
+#[serial(cognitive_memory)]
+fn repeated_snapshot_saves_supersede_not_duplicate() {
+    let (_tmp, root) = isolated_state_root();
+    let bridge = launch_writer_bridge(&root).expect("writer bridge");
+
+    // Save #1: one live snapshot.
+    let mut board = GoalBoard::new();
+    add_active_goal(&mut board, active_goal("goal-alpha", 1)).unwrap();
+    save_goal_board(&board, bridge.ops()).expect("save v1");
+    assert_eq!(
+        live_snapshot_count(bridge.ops()),
+        1,
+        "one live snapshot after first save"
+    );
+
+    // Save #2 (changed): supersedes v1 — still one live snapshot.
+    add_active_goal(&mut board, active_goal("goal-beta", 2)).unwrap();
+    save_goal_board(&board, bridge.ops()).expect("save v2");
+    assert_eq!(live_snapshot_count(bridge.ops()), 1, "v2 supersedes v1");
+
+    // Save #3 (changed): supersedes v2 — still one live snapshot.
+    add_active_goal(&mut board, active_goal("goal-gamma", 3)).unwrap();
+    save_goal_board(&board, bridge.ops()).expect("save v3");
+    assert_eq!(
+        live_snapshot_count(bridge.ops()),
+        1,
+        "repeated snapshots must supersede, never accumulate live duplicates"
+    );
+
+    // The latest snapshot content is readable and reflects all three goals.
+    let loaded = load_goal_board(bridge.ops()).expect("load board");
+    let ids: std::collections::HashSet<&str> =
+        loaded.active.iter().map(|g| g.id.as_str()).collect();
+    assert!(ids.contains("goal-alpha"));
+    assert!(ids.contains("goal-beta"));
+    assert!(ids.contains("goal-gamma"));
+}

--- a/src/goals/cognitive_memory_store.rs
+++ b/src/goals/cognitive_memory_store.rs
@@ -205,8 +205,13 @@ impl GoalStore for CognitiveMemoryGoalStore {
         let content = Self::encode(&record)?;
         let writer = launch_writer_bridge(&self.state_root)?;
 
-        // Primary storage: semantic fact (authoritative record).
-        writer.ops().store_fact(
+        // Primary storage: semantic fact (authoritative record). Issue #2329:
+        // route through CallerKey dedup keyed per goal slug so each goal's record
+        // supersedes its own previous revision instead of appending a fresh fact
+        // every `put`. The read-side "max node_id per slug" dedup remains as a
+        // defensive guard.
+        writer.ops().store_fact_with_caller_key(
+            &format!("{GOAL_STORE_FACT_CONCEPT}:{}", record.slug),
             GOAL_STORE_FACT_CONCEPT,
             &content,
             1.0,

--- a/src/memory_consolidation/mod.rs
+++ b/src/memory_consolidation/mod.rs
@@ -6,7 +6,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::cognitive_memory::CognitiveMemoryOps;
+use crate::cognitive_memory::{CognitiveMemoryOps, RecallWeightSet};
 use crate::error::SimardResult;
 use crate::goals::{GOAL_STORE_FACT_CONCEPT, GOAL_STORE_LIST_LIMIT, GoalRecord};
 use crate::memory_cognitive::{
@@ -132,6 +132,44 @@ pub fn preparation_memory_operations_with_active_slugs(
     bridge: &dyn CognitiveMemoryOps,
     active_slugs: Option<&std::collections::HashSet<&str>>,
 ) -> SimardResult<PreparedContext> {
+    // Back-compat entry point: balanced (Orient/library-default) ranked-recall
+    // weights. Phase-aware callers (the OODA cycle) use
+    // [`preparation_memory_operations_with_active_slugs_phased`] to bias the
+    // ranking per phase (issue #2329).
+    preparation_memory_operations_with_active_slugs_phased(
+        objective,
+        session_id,
+        bridge,
+        active_slugs,
+        RecallWeightSet::default(),
+    )
+}
+
+/// Preparation phase with explicit per-phase ranked-recall `weights`
+/// (issue #2329).
+///
+/// Identical to [`preparation_memory_operations_with_active_slugs`] but threads
+/// a [`RecallWeightSet`] into the ranked recall that gathers `relevant_facts`,
+/// so each OODA phase can bias the ranking toward what it cares about (Observe
+/// favors recency, Decide favors confidence). The OODA observe path calls this
+/// with [`crate::ooda_loop::phase_weights::weights_for_phase`]`(OodaPhase::Observe)`;
+/// the 3- and 4-arg entry points default to the balanced `Orient` weights for
+/// backward compatibility.
+///
+/// `relevant_facts` are gathered with the library's **ranked recall**
+/// (`recall_facts_ranked`) rather than a plain keyword `search_facts`: every
+/// candidate fact is scored across six signals and returned in descending score
+/// order, with superseded snapshot revisions excluded. The exhaustive goal-fact
+/// load and all PR-A filters (snapshot drop, `seen_ids` dedup, stale-slug drop,
+/// 10-fact cap) still run on the plain `search_facts` path *after* ranking.
+#[tracing::instrument(skip_all)]
+pub fn preparation_memory_operations_with_active_slugs_phased(
+    objective: &str,
+    session_id: &SessionId,
+    bridge: &dyn CognitiveMemoryOps,
+    active_slugs: Option<&std::collections::HashSet<&str>>,
+    weights: RecallWeightSet,
+) -> SimardResult<PreparedContext> {
     // Split compound objectives (joined with "; ") into individual fragments
     // and search each separately. The old code passed the full joined string to
     // search_facts() which uses Cypher CONTAINS — no fact matches a giant
@@ -146,7 +184,11 @@ pub fn preparation_memory_operations_with_active_slugs(
     let mut seen_ids: std::collections::HashSet<String> = std::collections::HashSet::new();
 
     for fragment in &fragments {
-        let per_fragment = bridge.search_facts(fragment, 10, 0.0)?;
+        // Issue #2329: gather candidate facts via ranked recall (relevance +
+        // recency + confidence + …, phase-weighted) instead of a plain
+        // confidence-sorted keyword `search_facts`. Facts come back in
+        // descending score order; superseded snapshot revisions are excluded.
+        let per_fragment = bridge.recall_facts_ranked(fragment, 10, 0.0, weights)?;
         for fact in per_fragment {
             // PR-A filter 1: drop goal-board:snapshot revisions even
             // when they surface from a per-fragment match. The live
@@ -778,11 +820,36 @@ pub fn consolidation_persistence(
     // rather than silently dropping data.
     bridge.consolidate_episodes(20)?;
 
+    // Issue #2329: reclaim the superseded tail left behind by caller-key snapshot
+    // dedup (goal-board snapshots, per-goal records). Pruning is housekeeping, so
+    // a failure is logged and never aborts teardown — it must not turn a
+    // successful consolidation into a failure.
+    match bridge.prune_superseded() {
+        Ok(reclaimed) if reclaimed > 0 => {
+            tracing::debug!(
+                reclaimed,
+                "consolidation_persistence: pruned superseded facts"
+            );
+        }
+        Ok(_) => {}
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "consolidation_persistence: prune_superseded failed (non-fatal)"
+            );
+        }
+    }
+
     Ok(())
 }
 
 #[cfg(test)]
 mod tests;
+
+// Issue #2329: OODA preparation gathers `relevant_facts` via ranked recall
+// (relevance/recency/confidence) rather than a confidence-sorted `search_facts`.
+#[cfg(test)]
+mod tests_ranked_prep;
 
 // PR-A (issue #2281): preparation-phase memory filters. Tests assert
 // that `goal-board:snapshot` revisions are dropped from the prepared

--- a/src/memory_consolidation/tests_ranked_prep.rs
+++ b/src/memory_consolidation/tests_ranked_prep.rs
@@ -1,0 +1,62 @@
+//! TDD test: OODA preparation gathers `relevant_facts` via ranked recall
+//! (issue #2329), not a plain confidence-sorted `search_facts`.
+//!
+//! Two facts both match the objective keyword:
+//! * `F_a` — exact text match (jaccard 1.0) but only **0.5** confidence.
+//! * `F_b` — diluted text match (jaccard 0.1) but **0.9** confidence.
+//!
+//! A plain `search_facts` orders purely by confidence and would surface `F_b`
+//! first. The library's ranked recall — where text relevance is the dominant
+//! signal under the balanced default weights — surfaces `F_a` first. Asserting
+//! `relevant_facts[0]` is the lower-confidence-but-more-relevant `F_a` proves
+//! preparation is on the ranked path.
+
+use super::{RecallWeightSet, preparation_memory_operations_with_active_slugs_phased};
+use crate::cognitive_memory::{CognitiveMemoryOps, LibraryCognitiveMemory};
+use crate::session::SessionId;
+
+fn test_session_id() -> SessionId {
+    SessionId::parse("session-01234567-89ab-cdef-0123-456789abcdef").unwrap()
+}
+
+#[test]
+fn preparation_gathers_relevant_facts_in_ranked_order() {
+    let mem = LibraryCognitiveMemory::in_memory().expect("in-memory DB");
+
+    // F_a: exact match to the objective token, LOW confidence.
+    mem.store_fact("refactor", "refactor", 0.5, &[], "src")
+        .expect("store F_a");
+    // F_b: contains the token but heavily diluted, HIGH confidence.
+    mem.store_fact(
+        "task",
+        "refactor alpha beta gamma delta epsilon zeta eta theta",
+        0.9,
+        &[],
+        "src",
+    )
+    .expect("store F_b");
+
+    let ctx = preparation_memory_operations_with_active_slugs_phased(
+        "refactor",
+        &test_session_id(),
+        &mem,
+        None,
+        RecallWeightSet::default(),
+    )
+    .expect("preparation");
+
+    assert_eq!(
+        ctx.relevant_facts.len(),
+        2,
+        "both keyword-matching facts gathered"
+    );
+    // Ranked recall (text relevance dominant) ranks the exact-match fact first,
+    // even though its confidence is lower — a confidence-sorted `search_facts`
+    // would have put the 0.9-confidence fact first.
+    assert_eq!(
+        ctx.relevant_facts[0].confidence, 0.5,
+        "preparation must use ranked recall: the most relevant fact leads, \
+         not the most confident"
+    );
+    assert_eq!(ctx.relevant_facts[0].concept, "refactor");
+}

--- a/src/ooda_loop/cycle.rs
+++ b/src/ooda_loop/cycle.rs
@@ -7,7 +7,7 @@ use crate::goal_curation::{load_goal_board, save_goal_board_with_removals};
 use crate::gym_bridge::ScoreDimensions;
 use crate::gym_scoring::GymSuiteScore;
 use crate::memory_consolidation;
-use crate::memory_consolidation::preparation_memory_operations_with_active_slugs;
+use crate::memory_consolidation::preparation_memory_operations_with_active_slugs_phased;
 use crate::self_improve::{ImprovementCycle, ImprovementPhase};
 
 use super::types::*;
@@ -255,11 +255,15 @@ fn run_ooda_cycle_inner(
         eprintln!("[simard] OODA cycle: board-sourced prospective reconcile failed: {e}");
     }
     // Reuse cycle_session_id established above — the entire cycle is one logical session.
-    let ctx = preparation_memory_operations_with_active_slugs(
+    // Issue #2329: gather `relevant_facts` with ranked recall biased toward the
+    // Observe phase (recency-favoring) so the freshest declarative state surfaces
+    // first each cycle.
+    let ctx = preparation_memory_operations_with_active_slugs_phased(
         &objective_summary,
         &cycle_session_id,
         &*bridges.memory,
         Some(&active_slugs),
+        crate::ooda_loop::phase_weights::weights_for_phase(OodaPhase::Observe),
     )?;
     eprintln!(
         "[simard] OODA cycle: prepared context ({} facts, {} triggers, {} procedures, {} episodes)",

--- a/src/ooda_loop/mod.rs
+++ b/src/ooda_loop/mod.rs
@@ -12,6 +12,7 @@ pub mod cycle;
 mod decide;
 mod observe;
 mod orient;
+pub mod phase_weights;
 mod priority_kind;
 mod review;
 mod summary;
@@ -28,6 +29,12 @@ mod tests_parse_failure_1890;
 #[cfg(test)]
 mod tests_types;
 
+// Issue #2329: Observe-vs-Decide phase weights yield different ranked-recall
+// ordering of the same fact set, exercised against the real lbug-backed
+// `LibraryCognitiveMemory` adapter.
+#[cfg(test)]
+mod tests_phase_recall;
+
 // PR-C (issue #2281, problem 3): tests for the new `cycle.rs`
 // helpers (`pattern_for`, `compose_procedure_name`,
 // `derive_triggers_from_objective`).
@@ -42,6 +49,7 @@ pub use curate::{
 pub use decide::{decide, decide_with_brain};
 pub use observe::{gather_environment, observe};
 pub use orient::{orient, orient_with_brain};
+pub use phase_weights::weights_for_phase;
 pub use priority_kind::{SyntheticPriorityKind, is_synthetic_id};
 pub use review::review_outcomes;
 pub use summary::summarize_cycle_report;

--- a/src/ooda_loop/phase_weights.rs
+++ b/src/ooda_loop/phase_weights.rs
@@ -1,0 +1,116 @@
+//! Per-OODA-phase ranked-recall weights (issue #2329).
+//!
+//! Simard owns the *policy* — which scoring signals matter in each OODA phase —
+//! while the `amplihack-memory-lib` ranked recall owns the *mechanism* (the
+//! scoring math). This module maps each [`OodaPhase`] to a
+//! [`RecallWeightSet`], applied automatically during preparation recall.
+//!
+//! `cognitive_memory` must stay a leaf module (it must not import `ooda_loop`),
+//! so the `OodaPhase -> RecallWeightSet` mapping lives here — the only layer
+//! that knows about [`OodaPhase`]. [`crate::ooda_loop::cycle`] computes the
+//! weights for the live phase and threads them down into preparation; the
+//! `RecallWeightSet -> amplihack_memory::RecallWeights` conversion is then
+//! performed adapter-local.
+//!
+//! ## Defaults (fields: text_relevance, confidence, importance, recency, usage, graph)
+//!
+//! | Phase | text_rel | confidence | importance | recency | usage | graph | Bias |
+//! |---|---|---|---|---|---|---|---|
+//! | Observe | 0.8 | 0.5 | 0.5 | **1.0** | 0.4 | 0.5 | Favor recency. |
+//! | Orient | 1.0 | 0.7 | 0.5 | 0.4 | 0.3 | 0.6 | Balanced (library default). |
+//! | Decide | 1.0 | **1.0** | 0.6 | 0.3 | 0.3 | 0.5 | Favor confidence/relevance. |
+//! | Act | 1.0 | 0.7 | 0.5 | 0.4 | 0.3 | 0.6 | Balanced. |
+//! | Sleep | 1.0 | 0.7 | 0.5 | 0.4 | 0.3 | 0.6 | Balanced (no prep recall). |
+//!
+//! Observe is recency-heavy so the brain sees the freshest declarative state
+//! first; Decide is confidence-heavy so commitments lean on trusted facts. The
+//! divergence means the same fact set can be ordered differently per phase —
+//! see [`docs/reference/cognitive-memory-ranked-recall.md`].
+
+use crate::cognitive_memory::RecallWeightSet;
+
+use super::OodaPhase;
+
+/// Ranked-recall weights for a given OODA phase.
+///
+/// `Observe` favors recency (surface what changed lately), `Decide` favors
+/// confidence/relevance (commit on trusted facts), and every other phase uses
+/// the balanced library default ([`RecallWeightSet::default`]). The numeric
+/// presets are pinned by unit tests so the documented table cannot silently
+/// drift from the code.
+pub fn weights_for_phase(phase: OodaPhase) -> RecallWeightSet {
+    match phase {
+        OodaPhase::Observe => RecallWeightSet {
+            text_relevance: 0.8,
+            confidence: 0.5,
+            importance: 0.5,
+            recency: 1.0,
+            usage: 0.4,
+            graph: 0.5,
+        },
+        OodaPhase::Decide => RecallWeightSet {
+            text_relevance: 1.0,
+            confidence: 1.0,
+            importance: 0.6,
+            recency: 0.3,
+            usage: 0.3,
+            graph: 0.5,
+        },
+        OodaPhase::Orient | OodaPhase::Act | OodaPhase::Sleep => RecallWeightSet::default(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn observe_favors_recency() {
+        let w = weights_for_phase(OodaPhase::Observe);
+        assert_eq!(w.text_relevance, 0.8);
+        assert_eq!(w.confidence, 0.5);
+        assert_eq!(w.importance, 0.5);
+        assert_eq!(w.recency, 1.0);
+        assert_eq!(w.usage, 0.4);
+        assert_eq!(w.graph, 0.5);
+        // Recency is the dominant Observe signal.
+        assert!(w.recency > w.confidence, "Observe must favor recency");
+    }
+
+    #[test]
+    fn decide_favors_confidence() {
+        let w = weights_for_phase(OodaPhase::Decide);
+        assert_eq!(w.text_relevance, 1.0);
+        assert_eq!(w.confidence, 1.0);
+        assert_eq!(w.importance, 0.6);
+        assert_eq!(w.recency, 0.3);
+        assert_eq!(w.usage, 0.3);
+        assert_eq!(w.graph, 0.5);
+        // Confidence beats recency for commitments.
+        assert!(w.confidence > w.recency, "Decide must favor confidence");
+    }
+
+    #[test]
+    fn orient_act_sleep_use_balanced_default() {
+        let default = RecallWeightSet::default();
+        assert_eq!(weights_for_phase(OodaPhase::Orient), default);
+        assert_eq!(weights_for_phase(OodaPhase::Act), default);
+        assert_eq!(weights_for_phase(OodaPhase::Sleep), default);
+    }
+
+    #[test]
+    fn observe_and_decide_diverge() {
+        // The two deliberate divergences (Observe vs Decide) must differ so the
+        // same fact set can be ordered differently per phase.
+        assert_ne!(
+            weights_for_phase(OodaPhase::Observe),
+            weights_for_phase(OodaPhase::Decide),
+        );
+        // Specifically: Observe weights recency above Decide; Decide weights
+        // confidence above Observe.
+        let o = weights_for_phase(OodaPhase::Observe);
+        let d = weights_for_phase(OodaPhase::Decide);
+        assert!(o.recency > d.recency, "Observe more recency-biased");
+        assert!(d.confidence > o.confidence, "Decide more confidence-biased");
+    }
+}

--- a/src/ooda_loop/tests_phase_recall.rs
+++ b/src/ooda_loop/tests_phase_recall.rs
@@ -1,0 +1,66 @@
+//! TDD test: Observe vs Decide phase weights produce a *different* ranked-recall
+//! ordering of the same fact set (issue #2329, invariant #4).
+//!
+//! The phase-weight numeric presets are unit-tested in
+//! [`super::phase_weights`]; this test closes the loop by feeding those presets
+//! into the real lbug-backed ranked recall and asserting the ordering actually
+//! diverges:
+//!
+//! * Two facts are stored — one with high **text relevance** but low confidence
+//!   (`F_text`), one with no text overlap but higher confidence (`F_conf`).
+//! * The **Observe** preset (recency/relevance-leaning, confidence 0.5) ranks
+//!   `F_text` first.
+//! * The **Decide** preset (confidence 1.0) ranks `F_conf` first.
+//!
+//! Recall runs with `record_access = false`, so the first (Observe) recall does
+//! not mutate usage/recency and skew the second (Decide) recall — both see the
+//! identical fact state.
+
+use crate::cognitive_memory::{CognitiveMemoryOps, LibraryCognitiveMemory};
+
+use super::OodaPhase;
+use super::phase_weights::weights_for_phase;
+
+#[test]
+fn observe_and_decide_weights_change_recall_ordering() {
+    let mem = LibraryCognitiveMemory::in_memory().expect("in-memory DB");
+
+    // F_text: high text relevance to the query (jaccard 3/4), low confidence.
+    //   text = "alpha beta gamma"  vs query "alpha beta gamma delta".
+    mem.store_fact("alpha", "beta gamma", 0.1, &[], "src")
+        .expect("store F_text");
+    // F_conf: no token overlap with the query, higher confidence.
+    mem.store_fact("omega", "sigma", 0.6, &[], "src")
+        .expect("store F_conf");
+
+    let query = "alpha beta gamma delta";
+
+    let observed = mem
+        .recall_facts_ranked(query, 10, 0.0, weights_for_phase(OodaPhase::Observe))
+        .expect("observe recall");
+    let decided = mem
+        .recall_facts_ranked(query, 10, 0.0, weights_for_phase(OodaPhase::Decide))
+        .expect("decide recall");
+
+    assert_eq!(observed.len(), 2, "both facts recalled under Observe");
+    assert_eq!(decided.len(), 2, "both facts recalled under Decide");
+
+    // Observe is relevance/recency-leaning: the text-relevant fact wins.
+    assert_eq!(
+        observed[0].confidence, 0.1,
+        "Observe must rank the text-relevant fact first"
+    );
+    // Decide is confidence-leaning: the high-confidence fact wins.
+    assert_eq!(
+        decided[0].confidence, 0.6,
+        "Decide must rank the high-confidence fact first"
+    );
+
+    // The crux of issue #2329: the SAME fact set is ordered differently per phase.
+    let observe_order: Vec<&str> = observed.iter().map(|f| f.concept.as_str()).collect();
+    let decide_order: Vec<&str> = decided.iter().map(|f| f.concept.as_str()).collect();
+    assert_ne!(
+        observe_order, decide_order,
+        "Observe and Decide weights must yield different orderings"
+    );
+}


### PR DESCRIPTION
Closes #2329.

Wires Simard's cognitive-memory **RECALL** and **RETENTION** to the
already-available `amplihack-memory-lib` ranked-recall and CallerKey
dedup/retention APIs (rev `e3ea136`, `features=["persistent"]` — **dependency
rev unchanged**).

## 1. Ranked recall in preparation (Simard-owned phase weights)
- New `CognitiveMemoryOps::recall_facts_ranked(query, limit, min_confidence, weights)`.
  Default impl delegates to `search_facts` (back-compat for the Python/IPC
  bridges & mocks); `LibraryCognitiveMemory` delegates to the library's
  `recall_facts_ranked` with `record_access=false` and superseded/archived
  excluded.
- New Simard-owned `RecallWeightSet` + per-OODA-phase mapping
  `ooda_loop::phase_weights::weights_for_phase` — **Observe** favors recency,
  **Decide** favors confidence/relevance, others balanced (library default).
  Defaults are pinned by unit tests and documented.
- The per-fragment `search_facts` gather in preparation is replaced with ranked
  recall via a new `preparation_memory_operations_with_active_slugs_phased`
  entry point; the OODA observe path threads `weights_for_phase(Observe)`. The
  existing 3-/4-arg signatures are preserved (default = balanced Orient).

## 2. Snapshot / goal-record retention (CallerKey dedup, SimPR4)
- New `store_fact_with_caller_key` (default -> `store_fact`; adapter ->
  library `upsert_fact` with `DedupMode::CallerKey`, producing `SUPERSEDES`
  edges). Goal-board snapshots key on `"goal-board:snapshot"`; per-goal records
  key on `"goal-store:record:{slug}"`. Repeats **supersede/reuse** instead of
  accumulating live duplicates.
- New `prune_superseded` (default no-op; adapter -> `prune_semantic_memory`
  with `include_superseded=true`) invoked **non-fatally** in the consolidation
  persistence path. Provenance-bearing facts are protected from deletion.

## Tests (TDD)
New tests across `cognitive_memory`, `ooda_loop`, `memory_consolidation`,
`goal_curation`:
- ranked recall returns higher-scored facts first and respects phase weights
  (Observe vs Decide produce different orderings of the same fact set);
- a repeated snapshot supersedes/reuses rather than duplicates (single live
  record), and `prune_superseded` reclaims the archived tail;
- the trait default mirrors `search_facts` for non-library backends.

## Verification
- `cargo build --release` — green
- `cargo test --lib` — green (5698 passed); targeted modules
  (cognitive_memory, ooda_loop, memory_consolidation, goal_curation) green
- relevant integration tests (memory_consolidation_lifecycle, episodic /
  prospective outside-in) green
- `cargo fmt --check` + `cargo clippy --all-targets --all-features --locked -D warnings` — clean

## Docs
`docs/memory.md` + new `docs/reference/cognitive-memory-ranked-recall.md`
(scoring signals, phase-weight defaults table, CallerKey dedup/SUPERSEDES,
pruning) with cross-links.

## Constraints honored
- `Cargo.toml` dependency rev unchanged (`e3ea136`).
- gym/knowledge files untouched.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>