### PR TITLE
docs(prompt): TDD adoption Phase 1 — tdd: attestation row + meeting spec reference (refs #2317)

### DIFF
--- a/prompt_assets/simard/engineer_system.md
+++ b/prompt_assets/simard/engineer_system.md
@@ -189,6 +189,7 @@ Whenever an engineer cycle produces code changes, the cycle is NOT complete unti
    - **Quality-audit** — cycle count, commit SHAs, final cycle clean confirmation
    - **CI** — link to the green run for every required check
    - **Scope** — diff summary with confirmation of no unrelated edits
+   - **TDD attestation** — exactly one of: `tdd: test-first ordering verified — <link to commit>` (default for in-scope PRs), `tdd-exempt: <reason from §1.1>` (exception cases), or `tdd: not applicable — PR touches no in-scope paths` (ops/docs/prompt PRs). Per `Specs/TDD_ADOPTION.md` §3 Layer 2.
    - **Verdict** — explicit "ready to merge" / "draft" / "blocked" call with rationale
 4. **Drive to merge** — once CI is fully green and the PR has evidence headings, merge via `gh pr merge --squash --delete-branch <PR>`.
 

--- a/prompt_assets/simard/meeting_system.md
+++ b/prompt_assets/simard/meeting_system.md
@@ -63,6 +63,14 @@ simard goal remove fix-critical-infrastructure-smart-orchestrator-469f243a
 simard goal set-priority adopt-tdd 1
 ```
 
+> **Note — `adopt-tdd` is a ratified, consolidated goal.** The `adopt-tdd` and
+> `adopt-tdd-for-new-modules` slugs are governed by the ratified charter
+> `Specs/TDD_ADOPTION.md`. If a handoff or the operator re-surfaces "adopt TDD",
+> link that spec and follow its phased exit criteria — do **not** re-create the
+> goal from boilerplate or open a fresh planning cycle. Once the spec's Phase-1
+> deliverables have landed, re-tombstone the slugs with
+> `simard goal remove adopt-tdd adopt-tdd-for-new-modules`.
+
 When the operator says "drop goal X", "add a goal for Y", or "bump Z to p1", run the matching command and confirm the result. Do not defer to a later session or ask whether they're sure — the operator has full authority over goals.
 
 ## Conversation Commands

--- a/tests/gadugi/tdd-adoption-prompt-refs.sh
+++ b/tests/gadugi/tdd-adoption-prompt-refs.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# qa-team scenario for issue #2317 — TDD adoption Phase 1 prompt references.
+#
+# Outside-in verification that the in-repo prompt assets now encode the
+# ratified TDD charter (Specs/TDD_ADOPTION.md):
+#
+#   1. prompt_assets/simard/meeting_system.md references Specs/TDD_ADOPTION.md
+#      near the `simard goal set-priority adopt-tdd 1` example line, so the
+#      meeting facilitator links the ratified spec instead of re-creating the
+#      `adopt-tdd` goal from boilerplate (spec §5, last exit-criterion).
+#   2. prompt_assets/simard/engineer_system.md PR-evidence heading list carries
+#      the `tdd:` / `tdd-exempt:` self-attestation row with all three ratified
+#      forms (spec §3 Layer 2).
+#
+# The validation surface for a prompt-asset edit is the prompt text itself
+# (tests cannot meaningfully precede a prompt edit — spec §1.1), so this
+# scenario asserts directly against the checked-in prompt files. It must run
+# against the in-repo prompt_assets/, never the deployed ~/.simard copy.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+MEETING="prompt_assets/simard/meeting_system.md"
+ENGINEER="prompt_assets/simard/engineer_system.md"
+SPEC="Specs/TDD_ADOPTION.md"
+
+fail() {
+  echo "[gadugi] FAIL: $1" >&2
+  exit 1
+}
+
+# Preconditions: all three files exist.
+[ -f "$MEETING" ] || fail "$MEETING not found"
+[ -f "$ENGINEER" ] || fail "$ENGINEER not found"
+[ -f "$SPEC" ] || fail "$SPEC (ratified charter) not found"
+
+# --- Deliverable 1: meeting prompt references the spec near the adopt-tdd line.
+ANCHOR_LINE="$(grep -n 'simard goal set-priority adopt-tdd 1' "$MEETING" | head -1 | cut -d: -f1)"
+[ -n "$ANCHOR_LINE" ] || fail "adopt-tdd example line missing from $MEETING"
+
+# The spec reference must appear, and within a 20-line window of the example
+# line, proving it sits "near" the boilerplate it is meant to suppress.
+REF_LINE="$(grep -n "$SPEC" "$MEETING" | head -1 | cut -d: -f1)"
+[ -n "$REF_LINE" ] || fail "$MEETING does not reference $SPEC"
+DELTA=$(( REF_LINE - ANCHOR_LINE ))
+[ "$DELTA" -lt 0 ] && DELTA=$(( -DELTA ))
+[ "$DELTA" -le 20 ] || fail "$SPEC reference is $DELTA lines from the adopt-tdd example (want <=20)"
+
+# The note must steer away from re-creating the goal from boilerplate.
+grep -Eq 'do \*\*not\*\* re-create|do not re-create' "$MEETING" \
+  || fail "$MEETING reference does not tell the facilitator to stop re-creating the goal"
+
+echo "[gadugi] meeting prompt references $SPEC at line $REF_LINE (anchor line $ANCHOR_LINE, delta $DELTA) ... ok"
+
+# --- Deliverable 2: engineer prompt carries the tdd: attestation row.
+grep -Fq 'tdd: test-first ordering verified —' "$ENGINEER" \
+  || fail "$ENGINEER missing the default 'tdd: test-first ordering verified' attestation form"
+grep -Fq 'tdd-exempt: <reason' "$ENGINEER" \
+  || fail "$ENGINEER missing the 'tdd-exempt:' attestation form"
+grep -Fq 'tdd: not applicable — PR touches no in-scope paths' "$ENGINEER" \
+  || fail "$ENGINEER missing the 'tdd: not applicable' attestation form"
+
+# The attestation row must live inside the PR-evidence heading block.
+grep -Fq 'TDD attestation' "$ENGINEER" \
+  || fail "$ENGINEER attestation row missing its evidence heading"
+
+echo "[gadugi] engineer prompt evidence headings include the tdd:/tdd-exempt: attestation row ... ok"
+
+echo "[gadugi] TDD adoption Phase 1 prompt references (#2317): all behaviors verified"

--- a/tests/gadugi/tdd-adoption-prompt-refs.yaml
+++ b/tests/gadugi/tdd-adoption-prompt-refs.yaml
@@ -1,0 +1,55 @@
+name: "TDD adoption Phase 1 prompt references (#2317)"
+description: "Outside-in verification that the in-repo prompt assets encode the ratified TDD charter: prompt_assets/simard/meeting_system.md references Specs/TDD_ADOPTION.md near the `simard goal set-priority adopt-tdd 1` example line (so the facilitator links the spec instead of re-creating the goal from boilerplate), and prompt_assets/simard/engineer_system.md carries the `tdd:`/`tdd-exempt:` self-attestation row with all three ratified forms in its PR-evidence heading list."
+version: "1.0.0"
+
+config:
+  timeout: 120000
+  retries: 1
+  parallel: false
+
+environment:
+  requires: []
+
+agents:
+  - name: "cli-agent"
+    type: "cli"
+    config:
+      workingDirectory: "."
+      defaultTimeout: 120000
+      executionMode: "spawn"
+      captureOutput: true
+      ioConfig:
+        encoding: "utf8"
+        handleInteractivePrompts: false
+      logConfig:
+        logCommands: true
+        logOutput: true
+        logLevel: "info"
+
+steps:
+  - name: "Prompt assets reference the ratified TDD spec"
+    agent: "cli-agent"
+    action: "execute_command"
+    params:
+      command: "tests/gadugi/tdd-adoption-prompt-refs.sh"
+    timeout: 120000
+
+assertions: []
+
+cleanup:
+  - name: "CLI agent cleanup"
+    agent: "cli-agent"
+    action: "cleanup"
+
+metadata:
+  tags:
+    - "cli"
+    - "prompt-assets"
+    - "meeting"
+    - "engineer"
+    - "tdd"
+    - "outside-in"
+  priority: "high"
+  author: "copilot"
+  test_type: "outside-in"
+  issue: "2317"


### PR DESCRIPTION
## TDD adoption Phase 1 — engineer-PR `tdd:` attestation row + meeting-prompt spec reference

Implements **Phase 1** of the ratified TDD adoption charter
([`Specs/TDD_ADOPTION.md`](https://github.com/rysweet/Simard/blob/main/Specs/TDD_ADOPTION.md),
RATIFIED 2026-06-20, merged in #2292). Refs #2317 · tracking #2291.

Phase 0 (the charter) is merged. This PR lands the two small, behavior-bearing
prompt-asset deliverables from spec §4/§5, plus the qa-team scenario required by
the issue. All prompt edits are PRs to in-repo `prompt_assets/` — the deployed
`~/.simard/prompt_assets/` copy was **never** touched (forbidden path).

### What changed

1. **`prompt_assets/simard/engineer_system.md`** — added the ratified
   self-attestation row to the engineer PR-body evidence-heading list, with the
   exact three forms from spec **§3 Layer 2**:
   - `tdd: test-first ordering verified — <link to commit>` (default for in-scope PRs)
   - `tdd-exempt: <reason from §1.1>` (exception cases)
   - `tdd: not applicable — PR touches no in-scope paths` (ops/docs/prompt PRs)

2. **`prompt_assets/simard/meeting_system.md`** — added a note immediately after
   the `simard goal set-priority adopt-tdd 1` example (≈line 63) that links
   `Specs/TDD_ADOPTION.md` and instructs the facilitator to **stop re-creating
   the `adopt-tdd` goal from boilerplate** (spec §5, last exit-criterion). This
   is the change that finally breaks the recurring planning churn.

3. **`tests/gadugi/tdd-adoption-prompt-refs.{yaml,sh}`** — qa-team scenario
   asserting (a) the meeting prompt references `Specs/TDD_ADOPTION.md` within 20
   lines of the `adopt-tdd` example and tells the facilitator not to re-create
   the goal, and (b) the engineer prompt carries all three attestation forms.

---

## Merge-ready evidence

### 1. QA-team (`gadugi-test`)

Scenario: `tests/gadugi/tdd-adoption-prompt-refs.yaml` (backing
`tests/gadugi/tdd-adoption-prompt-refs.sh`).

`gadugi-test validate -f tests/gadugi/tdd-adoption-prompt-refs.yaml`:
```
✓ Scenario "TDD adoption Phase 1 prompt references (#2317)" is valid
Validation Results:
✓ Valid files: 1
✗ Invalid files: 0
✓ All 1 file(s) are valid
```

`gadugi-test run -d tests/gadugi -s tdd-adoption-prompt-refs`:
```
ℹ Loading scenario: tests/gadugi/tdd-adoption-prompt-refs.yaml
✓ Loaded 1 scenario(s)
Test Execution Results:
✓ Passed: 1
✗ Failed: 0
- Total: 1
✓ All tests passed!
```

Backing-script behavior assertions:
```
[gadugi] meeting prompt references Specs/TDD_ADOPTION.md at line 68 (anchor line 63, delta 5) ... ok
[gadugi] engineer prompt evidence headings include the tdd:/tdd-exempt: attestation row ... ok
[gadugi] TDD adoption Phase 1 prompt references (#2317): all behaviors verified
```

### 2. Documentation

Prompt/doc-only change. The **user-facing surface is the spec itself**
(`Specs/TDD_ADOPTION.md`, already merged in #2292) — this PR makes the engineer
and meeting prompts *reference* that ratified charter. No additional end-user
docs are required; the two prompt files are the operative surfaces and both are
updated here. The new attestation row is self-documenting (it lists its own
allowed values and cites §3 Layer 2).

### 3. Quality-audit — SEEK→VALIDATE→FIX (3 cycles, ended clean)

- **Cycle 1 — wording fidelity.** SEEK: verify the three attestation forms match
  spec §3 Layer 2 byte-for-byte (incl. the em-dash). VALIDATE: `grep -F` each of
  the three forms against both `Specs/TDD_ADOPTION.md` and
  `engineer_system.md` → all three FOUND in both. FIX: none required.
- **Cycle 2 — hygiene.** SEEK: trailing whitespace, EOF newlines, script
  robustness. VALIDATE: no trailing whitespace in any changed/new file; both new
  files end with a newline; backing script uses `set -euo pipefail` with guarded
  arithmetic. FIX: none required.
- **Cycle 3 — scope, gates, integration.** SEEK: unrelated edits, CI registry
  for gadugi, gate compliance. VALIDATE: diff limited to 4 files (2 prompts + 2
  test files); no central scenario registry/CI workflow to update; pre-commit
  (`rust-only-gate`, `cargo fmt --check`, `cargo clippy --release --no-deps`) all
  **Passed**; gadugi validate+run green. FIX: none required.

Final cycle clean: zero critical/high, zero medium correctness/security findings.
Audited commit SHA: `268f8959`.

### 4. CI — 100% green

All required checks on this PR are green (run
https://github.com/rysweet/Simard/actions/runs/27894343272):

| Check | Result |
|---|---|
| `pre-commit` (fmt + clippy `--all-targets --all-features --locked`) | ✅ pass (10m15s) |
| `install-real` (end-to-end installer build) | ✅ pass (23m22s) |
| `e2e-dashboard` | ✅ pass |
| `cargo-audit` | ✅ pass |
| GitGuardian Security Checks | ✅ pass |

`gh pr checks 2333` reports 0 failures. Pre-push gates (`rust-only-gate`,
`cargo fmt --all --check`, the `cargo test --release --lib` race subset, and the
full `cargo clippy --all-targets --all-features --locked`) also passed locally
before push. No Rust source changed, so the verify build exercises the unchanged
tree.

### 6. Scope

Diff is focused — 4 files, +134/-0:
```
prompt_assets/simard/engineer_system.md      | +1
prompt_assets/simard/meeting_system.md       | +8
tests/gadugi/tdd-adoption-prompt-refs.sh     | new
tests/gadugi/tdd-adoption-prompt-refs.yaml   | new
```
No unrelated edits. No Rust source touched. The deployed
`~/.simard/prompt_assets/` copy was not modified.

### TDD attestation (dogfooding the new row)

`tdd: not applicable — PR touches no in-scope paths` — this PR changes only
`prompt_assets/**` and `tests/gadugi/**`; prompt-asset edits are explicitly
exempt per spec §1.1 (tests cannot meaningfully precede a prompt edit).

---

## Verdict

**Evidence-complete; hold for operator review — do NOT merge this cycle.** All
six merge-ready criteria are satisfied (qa-team green, docs accounted for,
3 clean quality-audit cycles, CI 100% green, focused diff). Per #2317 this PR
deliberately does **not** tombstone the `adopt-tdd` / `adopt-tdd-for-new-modules`
slugs and does **not** close #2291 — premature tombstoning would let the
boilerplate resurface before the prompt reference lands. Re-tombstoning the slugs
(`simard goal remove adopt-tdd adopt-tdd-for-new-modules`) and closing #2291 are
the follow-up steps that come **only after** this PR merges.
