### PR TITLE
fix(deps): bump amplihack-memory to 34d6a75 (durability: configurable buffer pool + catalog-corruption recovery)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 [[package]]
 name = "amplihack-memory"
 version = "0.4.0"
-source = "git+https://github.com/rysweet/amplihack-memory-lib.git?rev=e3ea136e8948d8e4c14f6edb6e1948e5411f7a38#e3ea136e8948d8e4c14f6edb6e1948e5411f7a38"
+source = "git+https://github.com/rysweet/amplihack-memory-lib.git?rev=34d6a75cf922ec1b838a44bba8c5b6592342bcfd#34d6a75cf922ec1b838a44bba8c5b6592342bcfd"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -1194,7 +1194,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3395,7 +3395,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3408,7 +3408,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3467,7 +3467,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4162,7 +4162,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5093,7 +5093,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ path = "src/bin/simard_tui/main.rs"
 # behind Simard's `CognitiveMemoryOps` trait; the native LadybugDB fork has been
 # deleted. The `persistent` feature builds LadybugDB through the published
 # `lbug = "=0.15.3"` crate.
-amplihack-memory = { git = "https://github.com/rysweet/amplihack-memory-lib.git", rev = "e3ea136e8948d8e4c14f6edb6e1948e5411f7a38", features = ["persistent"] }
+amplihack-memory = { git = "https://github.com/rysweet/amplihack-memory-lib.git", rev = "34d6a75cf922ec1b838a44bba8c5b6592342bcfd", features = ["persistent"] }
 rustyclawd-core = { git = "https://github.com/rysweet/RustyClawd.git", rev = "43ebaa1c1b18a5630c53f0519989a2bacd42ef62" }
 rustyclawd-tools = { git = "https://github.com/rysweet/RustyClawd.git", rev = "43ebaa1c1b18a5630c53f0519989a2bacd42ef62" }
 # De-fork (issue #2323): the gym/eval RUNNER is now the upstream


### PR DESCRIPTION
Resolves the live-daemon crash loop incident. amplihack-memory #96 makes the LadybugDB buffer pool / max-db-size configurable with much larger safe defaults (1 GiB / 16 GiB) and adds catalog/main-DB corruption recovery (quarantine + rebuild => `WalRecoveryOutcome::RebuiltAfterCorruption`) so a failed CHECKPOINT can no longer brick the store. Validated locally: all 22 lbug_store tests pass incl. the new corrupt-catalog recovery + config tests. Build green; pre-push tests/clippy green.