### PR TITLE
test(trace_collector): raise line coverage 42.68% -> 95.51% (#1751)

### DIFF
--- a/docs/testing/COVERAGE_BASELINE.md
+++ b/docs/testing/COVERAGE_BASELINE.md
@@ -65,6 +65,36 @@ The seven `bin_simard_*` integration tests live under `tests/` and exercise
 each CLI's argument-parsing and error-envelope surface deterministically
 (no network, no external services).
 
+## Group: `trace_collector` — `src/trace_collector.rs`
+
+Tracking issue: [#1751](https://github.com/rysweet/Simard/issues/1751)
+(parent: [#1735](https://github.com/rysweet/Simard/issues/1735))
+
+| Metric             | Baseline (2026-05-14) | After #1751 |
+| ------------------ | --------------------: | ----------: |
+| Aggregate line cov |                42.68% |      95.51% |
+| Files in group     |                     1 |           1 |
+| Lines covered      |               35 / 82 |   149 / 156 |
+
+Per-file post-#1751 line coverage:
+
+| File                     | Line cov | Func cov | Region cov |
+| ------------------------ | -------: | -------: | ---------: |
+| `src/trace_collector.rs` |   95.51% |   90.91% |     95.49% |
+
+> The new unit tests drive a full span lifecycle through `SpanCollectorLayer`
+> (`on_new_span` → `on_close`), drain the ring buffer with real records, and
+> exercise the `SpanRecord` `Clone` / `Debug` / `Serialize` derives — all
+> deterministically (no network, no external services). The line total rises
+> from 82 to 156 because the in-file `#[cfg(test)]` module is counted.
+
+### How to reproduce locally
+
+```bash
+cargo llvm-cov --lib --summary-only
+# then read the `src/trace_collector.rs` row
+```
+
 ## Other groups
 
 Tracked, but not yet attacked by a landed PR:
@@ -72,7 +102,6 @@ Tracked, but not yet attacked by a landed PR:
 | Group        | Tracking issue                                                  |
 | ------------ | --------------------------------------------------------------- |
 | `engineer`   | [#1750](https://github.com/rysweet/Simard/issues/1750)          |
-| `operator`   | [#1751](https://github.com/rysweet/Simard/issues/1751)          |
 | `runtime`    | [#1752](https://github.com/rysweet/Simard/issues/1752)          |
 | `meeting`    | [#1753](https://github.com/rysweet/Simard/issues/1753)          |
 

--- a/src/trace_collector.rs
+++ b/src/trace_collector.rs
@@ -117,6 +117,8 @@ impl<S: Subscriber + for<'a> LookupSpan<'a>> Layer<S> for SpanCollectorLayer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tracing_subscriber::Registry;
+    use tracing_subscriber::layer::SubscriberExt;
 
     #[test]
     fn drain_recent_empty_returns_empty() {
@@ -133,5 +135,118 @@ mod tests {
     #[test]
     fn ring_size_is_reasonable() {
         const { assert!(RING_SIZE >= 64) };
+    }
+
+    /// Drive a full span lifecycle through the layer so that `on_new_span`
+    /// records a start `Instant`, `on_close` builds a `SpanRecord` (covering
+    /// both `map_or` closures and the ring write), and `drain_recent` then
+    /// returns the cloned record. The span is given a unique name so the
+    /// assertion is robust against the shared global ring buffer.
+    #[test]
+    fn span_lifecycle_is_recorded_and_drained() {
+        let subscriber = Registry::default().with(SpanCollectorLayer);
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!("tc_lifecycle_marker", answer = 42, label = "probe");
+            span.in_scope(|| {});
+            drop(span);
+        });
+
+        let records = drain_recent(RING_SIZE);
+        let marker = records
+            .iter()
+            .find(|r| r.name == "tc_lifecycle_marker")
+            .expect("closed span should be recorded in the ring buffer");
+
+        assert_eq!(marker.level, "INFO");
+        assert!(
+            marker.target.starts_with("simard"),
+            "unexpected target: {}",
+            marker.target
+        );
+        // `on_close` populates `timestamp_epoch_ms` from the system clock.
+        assert!(marker.timestamp_epoch_ms > 0);
+        // `span.fields()` exposes the static `FieldSet` (the field *names*),
+        // which `on_close` captures via its Debug representation.
+        assert!(
+            marker.fields.contains("answer") && marker.fields.contains("label"),
+            "fields should list the span's field names, got: {}",
+            marker.fields
+        );
+    }
+
+    /// Opening and closing a span through the layer must produce a drainable,
+    /// cloneable record. This complements the lifecycle test by asserting the
+    /// non-empty drain path (the `push` branch in `drain_recent`) and the
+    /// `SpanRecord::clone` derive.
+    #[test]
+    fn drain_recent_returns_non_empty_after_span() {
+        let subscriber = Registry::default().with(SpanCollectorLayer);
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::warn_span!("tc_nonempty_probe");
+            span.in_scope(|| {});
+            drop(span);
+        });
+
+        let records = drain_recent(RING_SIZE);
+        assert!(
+            records.iter().any(|r| r.name == "tc_nonempty_probe"),
+            "expected the recorded span to be drained"
+        );
+        // Exercise SpanRecord::clone explicitly (drain already clones, but make
+        // the dependency on Clone explicit and verify equality of cloned data).
+        if let Some(r) = records.first() {
+            let cloned = r.clone();
+            assert_eq!(cloned.name, r.name);
+            assert_eq!(cloned.level, r.level);
+        }
+    }
+
+    /// Cover the derived `Debug` and `serde::Serialize` implementations on
+    /// `SpanRecord`, which are part of the file's public surface and otherwise
+    /// never exercised by the layer paths.
+    #[test]
+    fn span_record_debug_and_serialize() {
+        let record = SpanRecord {
+            name: "unit".to_string(),
+            target: "simard::trace_collector".to_string(),
+            level: "INFO".to_string(),
+            duration_us: 1234,
+            fields: "{key=value}".to_string(),
+            timestamp_epoch_ms: 99,
+        };
+
+        let debug = format!("{record:?}");
+        assert!(debug.contains("unit"));
+        assert!(debug.contains("1234"));
+
+        let json = serde_json::to_string(&record).expect("SpanRecord should serialize");
+        assert!(json.contains("\"name\":\"unit\""));
+        assert!(json.contains("\"duration_us\":1234"));
+        assert!(json.contains("\"timestamp_epoch_ms\":99"));
+
+        // Clone derive coverage.
+        let cloned = record.clone();
+        assert_eq!(cloned.duration_us, record.duration_us);
+    }
+
+    /// `drain_recent` must cap the returned count at the requested limit even
+    /// when more records are present, and never panic for a zero limit.
+    #[test]
+    fn drain_recent_respects_limit_bounds() {
+        let subscriber = Registry::default().with(SpanCollectorLayer);
+        tracing::subscriber::with_default(subscriber, || {
+            for _ in 0..3 {
+                let span = tracing::info_span!("tc_limit_probe");
+                span.in_scope(|| {});
+                drop(span);
+            }
+        });
+
+        // A zero limit yields nothing and must not panic.
+        assert!(drain_recent(0).is_empty());
+
+        // A small limit returns at most that many records.
+        let limited = drain_recent(2);
+        assert!(limited.len() <= 2);
     }
 }


### PR DESCRIPTION
## Summary

Raises line coverage of `src/trace_collector.rs` (the in-process `tracing` span
collector backing the dashboard `/api/traces` endpoint) from the established
**42.68%** baseline to **95.51%**, satisfying the ≥70% target in #1751.

This is a **test-only** change — no production logic was modified.

`Closes #1751` · `Refs #1735` (parent epic)

## What was uncovered → now covered

The baseline left 47/82 lines and 6/10 functions uncovered. New deterministic
unit tests exercise:

- **Full span lifecycle through `SpanCollectorLayer`** — `on_new_span` (stores
  the start `Instant`) and `on_close` (builds a `SpanRecord`, covering both
  `map_or` closures and the ring-buffer write).
- **`drain_recent` over a populated ring** — the `push` branch and the
  `SpanRecord::clone` derive.
- **`SpanRecord` `Debug` and `serde::Serialize` derives.**
- **`drain_recent` limit / zero-limit boundary behavior.**

All tests are hermetic (no network, no sleeps, no external services) and robust
against the process-global ring buffer (unique span names + whole-ring scans).

---

## Merge-ready evidence

### 1. qa-team scenarios (gadugi-test) — N/A, justified
This change introduces **no new user-facing behavior** (no CLI, API, config, or
agent surface). It adds pure Rust `#[cfg(test)]` unit tests to an internal
module. gadugi/qa-team scenarios target observable product behavior and do not
apply. Verification is via `cargo test` / `cargo llvm-cov`:

```
running 6 tests
test trace_collector::tests::drain_recent_empty_returns_empty ... ok
test trace_collector::tests::drain_recent_respects_limit_bounds ... ok
test trace_collector::tests::drain_recent_returns_non_empty_after_span ... ok
test trace_collector::tests::ring_size_is_reasonable ... ok
test trace_collector::tests::span_lifecycle_is_recorded_and_drained ... ok
test trace_collector::tests::span_record_debug_and_serialize ... ok
test result: ok. 5743 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out
```
(All 6 also pass in CI — see the `verify` log.)

### 2. Docs — internal-only, justified (+ baseline doc updated)
No user-facing surface changed (test-only, internal module) — internal-only
justification path. Additionally, `docs/testing/COVERAGE_BASELINE.md` (the
project's coverage tracker, which instructs "Update this file whenever a
coverage-targeted PR lands") gains a `trace_collector` group section with the
before/after numbers, and the now-landed #1751 row is removed from the
"not yet attacked" table.

### 3. Quality audit — 3 cycles, final clean
- **Cycle 1 (SEEK):** initial run surfaced a real false assumption — an
  assertion expected `span.fields()` to contain field *values*, but it returns
  the static `FieldSet` of field *names*. Fixed the assertion. An independent
  `code-review` agent pass then found **no significant issues**, empirically
  validating: global-ring flakiness is impossible (≤5 ring writes vs 512 slots;
  `SpanCollectorLayer` is installed only in `src/main.rs`, a binary excluded
  from `--lib` tests), assertion correctness (`module_path` target, `FieldSet`
  Debug names), race/deadlock freedom, and determinism.
- **Cycle 2 (VALIDATE):** full lib suite **5743 passed / 0 failed**; `clippy
  --all-targets --all-features --locked -- -D warnings` clean; `cargo fmt
  --all -- --check` clean; coverage 95.51%.
- **Cycle 3 (FIX):** tidied two misleading test doc-comments; re-verified fmt
  clean. Final cycle clean — zero critical/high; zero medium correctness/security.

Commit: `788a33fb`.

### 4. CI — 100% green
`#2340` (the pre-existing `tests/bin_simard_memory_cli.rs` failure) has been
fixed by **#2342** (*route tracing logs to stderr so `--json` stdout stays
clean*), which merged to `main` as `a3efe82f`. This branch was **rebased onto
that updated `main`** — the single coverage commit now sits on parent
`a3efe82f` — and the full `verify` run is **100% green with 0 failures**:

- **pre-commit** (fmt + clippy `-D warnings` + full `cargo test`, including the
  previously-failing `tests/bin_simard_memory_cli.rs`): **pass** —
  [run 27917471799](https://github.com/rysweet/Simard/actions/runs/27917471799/job/82605232735)
- **coverage**: **pass** —
  [run 27917471772](https://github.com/rysweet/Simard/actions/runs/27917471772/job/82605232702)
- **install-real**: **pass** —
  [run 27917471799](https://github.com/rysweet/Simard/actions/runs/27917471799/job/82605796794)
- **build / cargo-audit / e2e-dashboard / GitGuardian Security Checks**: **pass**

The earlier red `verify` was caused **solely** by the pre-existing, unrelated
`#2340` failure; with #2342 merged and this branch rebased, that integration
target now passes and the entire run is green. This remains a **test-only**
diff (`src/trace_collector.rs` tests + `docs/testing/COVERAGE_BASELINE.md`) with
no production-logic changes.

### 5. Concrete evidence
Provided for criteria 1–4 and 6 throughout this description.

### 6. Diff focused
Two files only: `src/trace_collector.rs` (tests appended to the existing
`#[cfg(test)]` module) and `docs/testing/COVERAGE_BASELINE.md` (coverage
tracker update). No unrelated edits; no production-logic changes.

---

## Coverage detail

`cargo llvm-cov --lib --summary-only`, row `src/trace_collector.rs`:

| Metric   | Baseline (commit `aa701b18`) |            After |
| -------- | ---------------------------: | ---------------: |
| Line     |               42.68% (35/82) | 95.51% (149/156) |
| Function |                40.00% (4/10) |   90.91% (20/22) |
| Region   |              38.52% (47/122) | 95.49% (233/244) |

Workspace **TOTAL line coverage 83.74% → 83.80%** — no regression (acceptance
criterion: "No regression in workspace total line coverage"). The line total
for the file rises from 82 to 156 because the in-file `#[cfg(test)]` module is
counted by llvm-cov.

### Reproduce locally
```bash
cargo llvm-cov --lib --summary-only   # read the src/trace_collector.rs row
```

