### PR TITLE
fix(copilot): wire memory + knowledge bridges into CopilotSdkAdapter (closes #1664)

### DIFF
--- a/src/base_type_copilot/mod.rs
+++ b/src/base_type_copilot/mod.rs
@@ -8,7 +8,7 @@
 //! structured output into [`BaseTypeOutcome`].
 
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use tempfile::NamedTempFile;
@@ -55,12 +55,36 @@ impl Default for CopilotAdapterConfig {
     }
 }
 
+/// Where a [`CopilotSdkSession`] sources its memory + knowledge enrichment
+/// bridges.
+///
+/// The default is [`EnrichmentSource::Disabled`] so that lightweight callers
+/// and unit tests incur no filesystem side effects (opening a cognitive-memory
+/// store, launching native bridges). The live production path
+/// ([`crate::session_builder::SessionBuilder`]) opts in via
+/// [`CopilotSdkAdapter::with_enrichment`], wiring the same cognitive-memory
+/// store and native knowledge bridge the rest of the runtime uses so each
+/// Copilot turn is enriched with relevant memory facts, procedures, and
+/// domain knowledge (issue #1664).
+#[derive(Clone, Debug, Default)]
+enum EnrichmentSource {
+    /// No enrichment bridges. `prepare_turn_context` runs with `None`/`None`,
+    /// emitting only the `## Objective` section.
+    #[default]
+    Disabled,
+    /// Launch the native cognitive-memory + knowledge bridges lazily on
+    /// `open_session`, reading memory from `state_root`. A launch failure logs
+    /// and degrades that bridge to `None` (never panics).
+    Native { state_root: PathBuf },
+}
+
 /// A base type factory that creates sessions driving `amplihack copilot`
 /// through the PTY infrastructure with memory and knowledge enrichment.
 #[derive(Debug)]
 pub struct CopilotSdkAdapter {
     descriptor: BaseTypeDescriptor,
     config: CopilotAdapterConfig,
+    enrichment: EnrichmentSource,
 }
 
 impl CopilotSdkAdapter {
@@ -95,12 +119,66 @@ impl CopilotSdkAdapter {
                 supported_topologies: [RuntimeTopology::SingleProcess].into_iter().collect(),
             },
             config,
+            enrichment: EnrichmentSource::default(),
         })
     }
 
     /// Access the adapter configuration.
     pub fn config(&self) -> &CopilotAdapterConfig {
         &self.config
+    }
+
+    /// Enable per-turn memory + knowledge enrichment for sessions opened by
+    /// this adapter, reading cognitive memory from `state_root`.
+    ///
+    /// Without this, sessions are created with both bridges set to `None` and
+    /// every turn runs `prepare_turn_context(objective, None, None)` — the
+    /// hardcoded-`None` regression of issue #1664 that silently dropped all
+    /// memory and knowledge enrichment in the primary production adapter.
+    ///
+    /// Bridges are launched lazily in [`BaseTypeFactory::open_session`]; a
+    /// launch failure logs and degrades to `None` so a missing knowledge pack
+    /// or an unavailable memory store never breaks turn dispatch (see
+    /// [`launch_enrichment_bridges`]).
+    #[must_use]
+    pub fn with_enrichment(mut self, state_root: PathBuf) -> Self {
+        self.enrichment = EnrichmentSource::Native { state_root };
+        self
+    }
+
+    /// Build a concrete [`CopilotSdkSession`], resolving enrichment bridges.
+    ///
+    /// Shared by [`BaseTypeFactory::open_session`] (which boxes the result)
+    /// and unit tests that need to inspect the wired bridges directly.
+    fn build_session(&self, request: BaseTypeSessionRequest) -> SimardResult<CopilotSdkSession> {
+        if !self.descriptor.supports_topology(request.topology) {
+            return Err(SimardError::UnsupportedTopology {
+                base_type: self.descriptor.id.to_string(),
+                topology: request.topology,
+            });
+        }
+
+        // Issue #1664: wire real memory + knowledge bridges instead of the
+        // previously-hardcoded `None`/`None`. When enrichment is configured
+        // the bridges are launched here (with graceful degradation) so that
+        // `prepare_turn_context` actually injects memory facts, procedures,
+        // and domain knowledge into every turn.
+        let (memory_bridge, knowledge_bridge) = match &self.enrichment {
+            EnrichmentSource::Disabled => (None, None),
+            EnrichmentSource::Native { state_root } => launch_enrichment_bridges(state_root),
+        };
+
+        Ok(CopilotSdkSession {
+            descriptor: self.descriptor.clone(),
+            config: self.config.clone(),
+            request,
+            memory_bridge,
+            knowledge_bridge,
+            is_open: false,
+            is_closed: false,
+            turn_count: 0,
+            session_uuid: None,
+        })
     }
 }
 
@@ -113,24 +191,7 @@ impl BaseTypeFactory for CopilotSdkAdapter {
         &self,
         request: BaseTypeSessionRequest,
     ) -> SimardResult<Box<dyn BaseTypeSession>> {
-        if !self.descriptor.supports_topology(request.topology) {
-            return Err(SimardError::UnsupportedTopology {
-                base_type: self.descriptor.id.to_string(),
-                topology: request.topology,
-            });
-        }
-
-        Ok(Box::new(CopilotSdkSession {
-            descriptor: self.descriptor.clone(),
-            config: self.config.clone(),
-            request,
-            memory_bridge: None,
-            knowledge_bridge: None,
-            is_open: false,
-            is_closed: false,
-            turn_count: 0,
-            session_uuid: None,
-        }))
+        Ok(Box::new(self.build_session(request)?))
     }
 }
 
@@ -202,6 +263,19 @@ impl CopilotSdkSession {
             turn_count: 0,
             session_uuid: None,
         }
+    }
+
+    /// Test-only builder that injects pre-constructed enrichment bridges so a
+    /// test can assert that `prepare_turn_context` consumes them (issue #1664).
+    #[cfg(test)]
+    fn with_test_bridges(
+        mut self,
+        memory_bridge: Option<Box<dyn CognitiveMemoryOps>>,
+        knowledge_bridge: Option<KnowledgeBridge>,
+    ) -> Self {
+        self.memory_bridge = memory_bridge;
+        self.knowledge_bridge = knowledge_bridge;
+        self
     }
 
     /// Build an enriched terminal objective from the turn input.
@@ -620,4 +694,45 @@ fn validate_command(command: &str) -> SimardResult<()> {
         });
     }
     Ok(())
+}
+
+/// Launch the cognitive-memory and knowledge bridges that enrich each Copilot
+/// turn, degrading gracefully when either is unavailable.
+///
+/// Memory is obtained via [`crate::ooda_loop::connect_memory`] (the same
+/// IPC-aware connector recipe steps use, sharing the daemon's live store when
+/// one is running and otherwise opening the library-backed store directly).
+/// Knowledge uses the in-process native transport from
+/// [`crate::bridge_launcher::launch_knowledge_bridge_native`].
+///
+/// Mirrors the honest-degradation contract of
+/// [`crate::bridge_launcher::launch_all_bridges`]: a launch failure is logged
+/// and yields `None` for that bridge so turn dispatch proceeds without that
+/// enrichment rather than aborting. Neither failure path panics.
+fn launch_enrichment_bridges(
+    state_root: &Path,
+) -> (Option<Box<dyn CognitiveMemoryOps>>, Option<KnowledgeBridge>) {
+    let memory = match crate::ooda_loop::connect_memory(state_root) {
+        Ok(memory) => Some(memory),
+        Err(error) => {
+            eprintln!(
+                "[simard] copilot adapter: cognitive-memory bridge unavailable — memory \
+                 enrichment disabled for this session: {error}"
+            );
+            None
+        }
+    };
+
+    let knowledge = match crate::bridge_launcher::launch_knowledge_bridge_native() {
+        Ok(knowledge) => Some(knowledge),
+        Err(error) => {
+            eprintln!(
+                "[simard] copilot adapter: knowledge bridge unavailable — knowledge \
+                 enrichment disabled for this session: {error}"
+            );
+            None
+        }
+    };
+
+    (memory, knowledge)
 }

--- a/src/base_type_copilot/tests.rs
+++ b/src/base_type_copilot/tests.rs
@@ -896,3 +896,267 @@ fn build_copilot_terminal_objective_with_working_dir() {
         "got: {objective}"
     );
 }
+
+// ===========================================================================
+// Memory + knowledge enrichment wiring (issue #1664)
+// ===========================================================================
+//
+// Before this fix `CopilotSdkAdapter::open_session` hardcoded both bridges to
+// `None`, so every production turn ran `prepare_turn_context(objective, None,
+// None)` and the memory-facts / known-procedures / domain-knowledge prompt
+// blocks were never reached. These tests prove (1) that supplied bridges are
+// actually consumed, (2) that the absence of bridges still produces a valid
+// objective-only prompt, (3) that a supplied bridge whose query fails surfaces
+// the error rather than silently degrading, and (4) that the production
+// `launch_enrichment_bridges` helper wires real bridges and degrades cleanly.
+
+use super::CopilotSdkSession;
+use crate::bridge::BridgeErrorPayload;
+use crate::bridge_subprocess::InMemoryBridgeTransport;
+use crate::cognitive_memory::CognitiveMemoryOps;
+use crate::knowledge_bridge::KnowledgeBridge;
+use crate::memory_bridge::CognitiveMemoryBridge;
+use serde_json::json;
+
+/// Mock cognitive-memory bridge returning a single semantic fact for any
+/// `search_facts` query and no procedures.
+fn enrichment_memory() -> Box<dyn CognitiveMemoryOps> {
+    Box::new(CognitiveMemoryBridge::new(Box::new(
+        InMemoryBridgeTransport::new("test-copilot-mem", |method, _params| match method {
+            "memory.search_facts" => Ok(json!({
+                "facts": [{
+                    "node_id": "f1",
+                    "concept": "rust-ownership",
+                    "content": "values have a single owner",
+                    "confidence": 0.92,
+                    "source_id": "s1",
+                    "tags": []
+                }]
+            })),
+            "memory.recall_procedure" => Ok(json!({"procedures": []})),
+            other => Err(BridgeErrorPayload {
+                code: -32601,
+                message: format!("unknown method: {other}"),
+            }),
+        }),
+    )))
+}
+
+/// Mock cognitive-memory bridge whose calls always error — used to verify a
+/// supplied bridge's query failure surfaces (no silent swallow) per the
+/// `prepare_turn_context` contract.
+fn failing_memory() -> Box<dyn CognitiveMemoryOps> {
+    Box::new(CognitiveMemoryBridge::new(Box::new(
+        InMemoryBridgeTransport::new("test-copilot-mem-fail", |_method, _params| {
+            Err(BridgeErrorPayload {
+                code: -32000,
+                message: "simulated memory backend failure".to_string(),
+            })
+        }),
+    )))
+}
+
+/// Mock knowledge bridge with one pack that matches a "rust" objective and a
+/// canned non-empty query answer.
+fn enrichment_knowledge() -> KnowledgeBridge {
+    KnowledgeBridge::new(Box::new(InMemoryBridgeTransport::new(
+        "test-copilot-knowledge",
+        |method, _params| match method {
+            "knowledge.list_packs" => Ok(json!({"packs": [{
+                "name": "rust-expert",
+                "description": "Rust programming language knowledge",
+                "article_count": 100,
+                "section_count": 400
+            }]})),
+            "knowledge.query" => Ok(json!({
+                "answer": "Rust enforces ownership at compile time.",
+                "sources": [{"title": "Ownership", "section": "Basics"}],
+                "confidence": 0.88
+            })),
+            other => Err(BridgeErrorPayload {
+                code: -32601,
+                message: format!("unknown method: {other}"),
+            }),
+        },
+    )))
+}
+
+/// With both bridges supplied, the enriched prompt must include the memory
+/// facts and domain knowledge sections — proving the bridges are consumed.
+#[test]
+fn enrichment_injects_memory_facts_and_knowledge_into_prompt() {
+    let session = CopilotSdkSession::new_for_test(make_request(OperatingMode::Engineer))
+        .with_test_bridges(Some(enrichment_memory()), Some(enrichment_knowledge()));
+    let input = BaseTypeTurnInput::objective_only("implement rust ownership feature");
+
+    let prompt_file = session
+        .build_meeting_prompt(&input)
+        .expect("prompt build must succeed with enrichment bridges");
+    let prompt = std::fs::read_to_string(prompt_file.path()).expect("read prompt file");
+
+    assert!(
+        prompt.contains("## Relevant Memory Facts"),
+        "enriched prompt must include the memory facts section: {prompt}"
+    );
+    assert!(
+        prompt.contains("values have a single owner"),
+        "enriched prompt must include the mock fact content: {prompt}"
+    );
+    assert!(
+        prompt.contains("## Domain Knowledge"),
+        "enriched prompt must include the domain knowledge section: {prompt}"
+    );
+    assert!(
+        prompt.contains("Rust enforces ownership at compile time."),
+        "enriched prompt must include the mock knowledge answer: {prompt}"
+    );
+}
+
+/// The PTY path also threads enrichment through `build_enriched_objective`:
+/// the on-disk prompt file (referenced by the terminal objective) must carry
+/// the same memory + knowledge sections.
+#[test]
+fn enrichment_reaches_pty_prompt_file() {
+    let session = CopilotSdkSession::new_for_test(make_request(OperatingMode::Engineer))
+        .with_test_bridges(Some(enrichment_memory()), Some(enrichment_knowledge()));
+    let input = BaseTypeTurnInput::objective_only("implement rust ownership feature");
+
+    let (objective, prompt_file) = session
+        .build_enriched_objective(&input)
+        .expect("enriched objective build must succeed");
+    // The PTY objective references the prompt file by path; the enriched
+    // content lives in that file.
+    assert!(
+        objective.contains("cat"),
+        "objective should cat the prompt file"
+    );
+    let prompt = std::fs::read_to_string(prompt_file.path()).expect("read prompt file");
+    assert!(prompt.contains("## Relevant Memory Facts"), "got: {prompt}");
+    assert!(prompt.contains("## Domain Knowledge"), "got: {prompt}");
+}
+
+/// With no bridges, the prompt is objective-only — the clean degraded path
+/// that must never break turn dispatch.
+#[test]
+fn no_enrichment_produces_objective_only_prompt() {
+    let session = CopilotSdkSession::new_for_test(make_request(OperatingMode::Engineer));
+    let input = BaseTypeTurnInput::objective_only("plain objective without enrichment");
+
+    let prompt_file = session
+        .build_meeting_prompt(&input)
+        .expect("prompt build must succeed without bridges");
+    let prompt = std::fs::read_to_string(prompt_file.path()).expect("read prompt file");
+
+    assert!(prompt.contains("plain objective without enrichment"));
+    assert!(
+        !prompt.contains("## Relevant Memory Facts"),
+        "no memory section without a memory bridge: {prompt}"
+    );
+    assert!(
+        !prompt.contains("## Domain Knowledge"),
+        "no knowledge section without a knowledge bridge: {prompt}"
+    );
+}
+
+/// A supplied bridge whose query fails must surface the error (the
+/// `prepare_turn_context` no-silent-degradation contract), not panic.
+#[test]
+fn enrichment_query_failure_propagates_not_panics() {
+    let session = CopilotSdkSession::new_for_test(make_request(OperatingMode::Engineer))
+        .with_test_bridges(Some(failing_memory()), None);
+    let input = BaseTypeTurnInput::objective_only("objective triggering failing memory");
+
+    let result = session.build_meeting_prompt(&input);
+    assert!(
+        result.is_err(),
+        "a supplied bridge whose query fails must surface an error, not silently degrade"
+    );
+}
+
+/// The production launch helper wires both real bridges when the state root
+/// can back a cognitive-memory store.
+#[test]
+#[serial_test::serial(cognitive_memory)]
+fn launch_enrichment_bridges_wires_real_bridges_for_valid_state_root() {
+    use tempfile::TempDir;
+    let tmp = TempDir::new().unwrap();
+    let state_root = tmp.path().join("state");
+    std::fs::create_dir_all(&state_root).unwrap();
+
+    let (memory, knowledge) = super::launch_enrichment_bridges(&state_root);
+    assert!(
+        memory.is_some(),
+        "cognitive-memory bridge must launch for a writable state_root"
+    );
+    assert!(
+        knowledge.is_some(),
+        "native knowledge bridge must launch in-process"
+    );
+}
+
+/// A state root that cannot back a store (a regular file) makes the memory
+/// launch fail; it must degrade to `None` without panicking, while the
+/// in-process knowledge bridge still launches.
+#[test]
+fn launch_enrichment_bridges_degrades_when_memory_unavailable() {
+    use tempfile::NamedTempFile;
+    // A regular file as `state_root` makes `<state_root>/cognitive` uncreatable.
+    let file = NamedTempFile::new().unwrap();
+
+    let (memory, knowledge) = super::launch_enrichment_bridges(file.path());
+    assert!(
+        memory.is_none(),
+        "memory bridge must degrade to None when the state_root cannot back a store"
+    );
+    assert!(
+        knowledge.is_some(),
+        "knowledge bridge must still launch when only memory is unavailable"
+    );
+}
+
+/// `open_session` (via `build_session`) must wire both bridges when the
+/// adapter has enrichment configured — the direct regression guard for the
+/// hardcoded-`None` defect of issue #1664 at the factory seam.
+#[test]
+#[serial_test::serial(cognitive_memory)]
+fn open_session_with_native_enrichment_populates_bridges() {
+    use tempfile::TempDir;
+    let tmp = TempDir::new().unwrap();
+    let state_root = tmp.path().join("state");
+    std::fs::create_dir_all(&state_root).unwrap();
+
+    let adapter = CopilotSdkAdapter::registered("copilot-enrich-wire")
+        .unwrap()
+        .with_enrichment(state_root);
+    let session = adapter
+        .build_session(make_request(OperatingMode::Engineer))
+        .expect("session must open with enrichment");
+
+    assert!(
+        session.memory_bridge.is_some(),
+        "open_session must wire the memory bridge when enrichment is Native"
+    );
+    assert!(
+        session.knowledge_bridge.is_some(),
+        "open_session must wire the knowledge bridge when enrichment is Native"
+    );
+}
+
+/// The default adapter (no `with_enrichment`) must leave both bridges `None`
+/// so unit tests and lightweight callers incur no filesystem side effects.
+#[test]
+fn open_session_without_enrichment_leaves_bridges_none() {
+    let adapter = CopilotSdkAdapter::registered("copilot-no-enrich").unwrap();
+    let session = adapter
+        .build_session(make_request(OperatingMode::Engineer))
+        .expect("session must open without enrichment");
+
+    assert!(
+        session.memory_bridge.is_none(),
+        "default adapter must not wire a memory bridge"
+    );
+    assert!(
+        session.knowledge_bridge.is_none(),
+        "default adapter must not wire a knowledge bridge"
+    );
+}

--- a/src/bootstrap/assembly.rs
+++ b/src/bootstrap/assembly.rs
@@ -305,6 +305,16 @@ pub(super) fn register_builtin_base_type(
             Ok(())
         }
         COPILOT_SDK_BASE_TYPE => {
+            // Issue #1664: the live non-meeting Copilot turn path (the OODA
+            // daemon's Orchestrator session and the review pipeline's Engineer
+            // session) opts into memory + knowledge enrichment via
+            // `SessionBuilder` + `CopilotSdkAdapter::with_enrichment`.
+            // This registry feeds the `RuntimeKernel`/gym harness instead, which
+            // must run against a *caller-specific* (often hermetic) state root —
+            // wiring `default_state_root()` here would make gym evals read the
+            // operator's real memory store. Enrichment for that path therefore
+            // needs a threaded state_root and is intentionally a scoped
+            // fast-follow (tracked with #1665), not the hardcoded-None defect.
             base_types.register(crate::base_type_copilot::CopilotSdkAdapter::registered(
                 base_type.as_str(),
             )?);

--- a/src/session_builder.rs
+++ b/src/session_builder.rs
@@ -211,8 +211,18 @@ impl SessionBuilder {
         match self.provider {
             LlmProvider::Copilot => {
                 let tag = format!("{}-copilot", self.adapter_tag);
+                // Issue #1664: enable memory + knowledge enrichment on the live
+                // production adapter so each turn is enriched with relevant
+                // memory facts, procedures, and domain knowledge. This applies
+                // to every NON-meeting Copilot session (e.g. the OODA daemon's
+                // Orchestrator session and the review pipeline's Engineer
+                // session); meeting-mode sessions returned early above via
+                // PersistentAgentProxy and are out of scope here. Reads from the
+                // default state root (shared with the OODA daemon when running);
+                // a bridge launch failure degrades gracefully to no enrichment.
                 let factory = CopilotSdkAdapter::registered(&tag)
-                    .map_err(|e| format!("CopilotSdkAdapter::registered({}): {}", tag, e))?;
+                    .map_err(|e| format!("CopilotSdkAdapter::registered({}): {}", tag, e))?
+                    .with_enrichment(crate::memory_ipc::default_state_root());
                 let mut session = factory
                     .open_session(request)
                     .map_err(|e| format!("CopilotSdkAdapter::open_session({}): {}", tag, e))?;

--- a/tests/qa-scenarios/copilot-memory-knowledge-enrichment.yaml
+++ b/tests/qa-scenarios/copilot-memory-knowledge-enrichment.yaml
@@ -1,0 +1,28 @@
+name: copilot-memory-knowledge-enrichment
+app_type: cli
+description: |
+  Validates issue #1664: the CopilotSdkAdapter now wires real memory + knowledge
+  bridges instead of hardcoding both to None. Each run step shells out to the
+  adapter's unit tests; a non-zero cargo exit fails the step. Green means:
+  - supplied bridges are consumed (memory facts + domain knowledge reach the
+    formatted turn prompt on both the meeting and PTY paths)
+  - absence of bridges still yields a valid objective-only prompt
+  - a supplied bridge whose query fails surfaces the error (no silent degrade)
+  - the production launch helper wires real bridges and degrades cleanly when
+    cognitive memory is unavailable
+  - existing session-creation behaviour is unregressed
+agents:
+  - name: cargo
+    type: cli
+    command: cargo
+steps:
+  - action: run
+    params:
+      command: cargo
+      args: ["test", "--lib", "enrichment"]
+    timeout: 300000
+  - action: run
+    params:
+      command: cargo
+      args: ["test", "--lib", "base_type_copilot::tests::session_creation_succeeds_for_engineer_mode"]
+    timeout: 300000


### PR DESCRIPTION
## Summary

Fixes #1664. The `CopilotSdkAdapter` declared `memory_bridge` / `knowledge_bridge` fields and `build_enriched_objective` / `build_meeting_prompt` correctly call `prepare_turn_context(objective, memory, knowledge)` — **but `open_session` hardcoded both bridges to `None`**. Every non-meeting Copilot turn therefore ran `prepare_turn_context(objective, None, None)`, which returns an empty `TurnContext`, so `format_turn_input` emitted only the `## Objective` section. The cognitive-memory and domain-knowledge enrichment was silently dead in the primary production adapter.

## What changed

- **`src/base_type_copilot/mod.rs`** — `EnrichmentSource` enum (`Disabled` default / `Native { state_root }`), a `with_enrichment(state_root)` builder, and a `build_session` helper (shared by `open_session` + tests) that launches bridges via `launch_enrichment_bridges(state_root)` instead of hardcoding `None`/`None`. Honest graceful degradation (mirrors `bridge_launcher::launch_all_bridges`): a launch failure **logs and yields `None`** for that bridge — never panics. Memory uses the IPC-aware `ooda_loop::connect_memory`; knowledge uses `bridge_launcher::launch_knowledge_bridge_native`.
- **`src/session_builder.rs`** — the live production path opts in: the Copilot branch chains `.with_enrichment(memory_ipc::default_state_root())`.
- **`src/bootstrap/assembly.rs`** — boundary comment documenting why the `RuntimeKernel`/gym registry path is *not* wired with `default_state_root()` (gym runs against a caller-specific/hermetic state root; wiring the default there would make benchmarks read the operator's real store). Scoped fast-follow.
- **Tests** (`src/base_type_copilot/tests.rs`) — `with_test_bridges` injector + `build_session` factory-seam guard; 8 new tests.
- **QA** — gadugi scenario `tests/qa-scenarios/copilot-memory-knowledge-enrichment.yaml`.

### Which production paths are now enriched
Every **non-meeting** Copilot session (all funnel through `SessionBuilder`):
- **OODA daemon** orchestrator session (`OperatingMode::Orchestrator`) — the path #1664's evidence cites.
- **Review pipeline** engineer session (`OperatingMode::Engineer`).

**Not** enriched here (intentional, → #1665): meeting-mode sessions (dashboard chat, `simard meeting`, lightweight meeting) return early via `PersistentAgentProxy` for `OperatingMode::Meeting` — a separate adapter that never calls `prepare_turn_context`.

The default `registered`/`with_config` constructors keep enrichment **Disabled** so unit tests and lightweight callers incur no filesystem side effects.

## Merge-ready evidence

### 1. qa-team scenarios (gadugi-test validate + run)
`gadugi-test validate` → `✓ Scenario "copilot-memory-knowledge-enrichment" is valid`.
`gadugi-test run --scenario copilot-memory-knowledge-enrichment`:
```
test result: ok. 7 passed; 0 failed; ...   (cargo test --lib enrichment)
test result: ok. 1 passed; 0 failed; ...   (session_creation_succeeds_for_engineer_mode)
Test Execution Results:  ✓ Passed: 1  ✗ Failed: 0   ✓ All tests passed!
```

### 2. Docs / changed surfaces
One new internal Rust API: `CopilotSdkAdapter::with_enrichment(PathBuf) -> Self` (doc-commented). No user-facing CLI/config/output change, so no end-user docs require updates; `EnrichmentSource` / `launch_enrichment_bridges` / `build_session` internals are documented inline.

### 3. quality-audit cycles (SEEK → VALIDATE → FIX)
Three cycles, final clean (full detail + per-cycle SHAs in the follow-up comment):
- Cycle 1 (`code-review`): no correctness/concurrency/security bugs; 1 completeness finding (registry/gym) → boundary comment.
- Cycle 2 (`rubber-duck`): caught an overclaim (dashboard/meeting are `Meeting`-mode → `PersistentAgentProxy`, not enriched) → corrected text + added `build_session` seam regression test.
- Cycle 3 (`rubber-duck`): clean (one residual comment nit → fixed).

> These cycle SHAs are pre-rebase iteration history; the branch was subsequently rebased onto latest `main` and consolidated into a single commit (`a5067f55`).

### 4. CI — green
All checks green on `a5067f55`: `pre-commit` (full `cargo test`) ✓, `coverage` ✓, `cargo-audit` ✓, `e2e-dashboard` ✓, `install-real` ✓, GitGuardian ✓. (An earlier red was 3 **pre-existing** `bin_simard_memory_cli` failures fixed on `main` by #2332 — resolved by rebasing; and one **flaky** `meeting_backend …write_auto_save_lands_under_simard_state_root` env-isolation test that passed on re-run. Neither is touched by this diff.)

### 6. Focused diff
4 source files (`base_type_copilot/{mod,tests}.rs`, `session_builder.rs`, `bootstrap/assembly.rs` — comment only) + 1 new QA scenario. No unrelated edits.

## Scope / fast-follow
#1665 (other adapters — `local-harness`, `rusty-clawd`, `claude-agent-sdk`, `ms-agent`, and the meeting `PersistentAgentProxy` — skip `prepare_turn_context` entirely) is **not** addressed here: those paths have independent construction/`run_turn` flows and need a shared enrichment hook plus per-call-site bridge plumbing, which does not generalize cheaply. The registry/gym enrichment is part of that same fast-follow.

> Note: this lands in Simard itself, so a self-update / rebuild cycle is needed post-merge for the running daemon to pick up enriched Copilot turns.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
