### PR TITLE
fix(memory-cli): route tracing logs to stderr so --json stdout stays clean (#2340)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,12 @@ fn main() -> std::process::ExitCode {
 /// - `RUST_LOG` controls verbosity (default: info)
 /// - `SIMARD_LOG_JSON=1` enables JSON log output
 /// - `OTEL_EXPORTER_OTLP_ENDPOINT` enables OTLP span export (e.g. http://localhost:4317)
+///
+/// Human/JSON log lines are always written to **stderr** so that stdout carries
+/// only program output (e.g. the `--json` payloads emitted by `simard memory
+/// stats|dump`). Routing logs to stdout would interleave dependency log lines
+/// such as `amplihack_memory::graph::lbug_store: effective LadybugDB limits ...`
+/// ahead of the JSON, breaking machine-readable parsing (issue #2340).
 fn init_tracing() {
     let use_json = std::env::var("SIMARD_LOG_JSON")
         .map(|v| matches!(v.as_str(), "1" | "true"))
@@ -46,7 +52,12 @@ fn init_tracing() {
             .map(|t| tracing_opentelemetry::layer().with_tracer(t));
         tracing_subscriber::registry()
             .with(filter)
-            .with(tracing_subscriber::fmt::layer().json().with_target(true))
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .json()
+                    .with_target(true)
+                    .with_writer(std::io::stderr),
+            )
             .with(otel)
             .with(simard::trace_collector::SpanCollectorLayer)
             .init();
@@ -57,7 +68,11 @@ fn init_tracing() {
             .map(|t| tracing_opentelemetry::layer().with_tracer(t));
         tracing_subscriber::registry()
             .with(filter)
-            .with(tracing_subscriber::fmt::layer().with_target(true))
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .with_target(true)
+                    .with_writer(std::io::stderr),
+            )
             .with(otel)
             .with(simard::trace_collector::SpanCollectorLayer)
             .init();


### PR DESCRIPTION
## Summary

Fixes #2340. The `simard` binary's `init_tracing()` attached `tracing_subscriber::fmt::layer()`, which defaults to **stdout**. On the first cognitive-memory store open, the `amplihack_memory::graph::lbug_store` dependency emits an INFO line:

```
INFO amplihack_memory::graph::lbug_store: lbug_store: effective LadybugDB limits ... buffer_pool_bytes=... max_db_bytes=...
```

That line landed on **stdout ahead of the JSON payload** emitted by `simard memory stats|dump --json`, so `serde_json::from_str(stdout.trim())` failed in the process-boundary integration tests `tests/bin_simard_memory_cli.rs` (stats/dump/empty), reding both `main` and PR #2338.

### Fix
Route both `fmt::layer()` instances (JSON + plain) to **stderr** via `.with_writer(std::io::stderr)`. stdout now carries only program output (the `--json` payloads). This is the standard convention (logs → stderr, data → stdout) and is a deterministic fix — the leak no longer depends on subscriber init ordering across parallel test processes. The OTEL-enabled banner already used `eprintln!` (stderr), so this makes the logging path consistent.

## Merge-ready evidence

**1. qa-team / gadugi-test:** N/A justified. No new user-facing surface or scenario is introduced. The behavior is already covered end-to-end by the existing process-boundary integration tests in `tests/bin_simard_memory_cli.rs`, which spawn a real `simard` process and parse its stdout as JSON — exactly the contract this fix repairs. Those 6 tests now pass deterministically (see #4).

**2. Docs:** The change is a logging-stream detail (logs already went to a stream; they now consistently go to stderr). No user-facing doc references the log output stream. The binary's `init_tracing` doc-comment was updated to state that logs are written to stderr and why (keeps `--json` stdout clean). Changed surface: `simard` log output stream moves stdout → stderr; rationale documented inline.

**3. quality-audit:** 3 SEEK→VALIDATE→FIX cycles, final cycle clean (evidence appended in a PR comment; commit `86c37337`).

**4. CI:** Local verification on commit `86c37337`:
- `cargo test --test bin_simard_memory_cli --locked` → `6 passed; 0 failed`
- `cargo fmt --all -- --check` → clean
- pre-commit `cargo clippy --release --no-deps -- -D warnings` → Passed
CI green run linked once the verify/coverage workflows complete.

**6. Focused diff:** Single file, `src/main.rs`, +17/-2. No unrelated edits.

Closes #2340.