### PR TITLE
fix(gym): integrate structured 5-dimension evidence-quality assessment (#2090)

### DIFF
--- a/docs/reference/runtime-contracts.md
+++ b/docs/reference/runtime-contracts.md
@@ -421,10 +421,30 @@ Fresh per-run reports expose these public scorecard fields under `scorecard`:
 - `correctness_checks_passed`
 - `correctness_checks_total`
 - `evidence_quality`
+- `evidence_quality_assessment`
 - `unnecessary_action_count`
 - `retry_count`
 - `human_review_notes`
 - `measurement_notes`
+
+`evidence_quality` is a coarse legacy categorical (`sufficient` when at least four
+evidence records were exported, otherwise `thin`) retained for the reporting and
+run-comparison paths. `evidence_quality_assessment` is the structured, comparable
+evidence-quality signal required by the scoring strategy and is the field to prefer
+when comparing changes to prompts and policies. It contains:
+
+- `dimensions`: the five canonical scoring dimensions, each in `[0.0, 1.0]`:
+  - `factual_accuracy`: correctness-check pass rate
+  - `specificity`: total evidence "units" — each record contributes up to one
+    unit scaled by detail richness (saturating at 80 characters), with the
+    summed units saturating at four; empty-detail records contribute nothing
+  - `temporal_awareness`: fraction of exported memory records carrying a creation timestamp
+  - `source_attribution`: how strongly evidence is attributed to a concrete source
+    (base-type sources count fully, generic runtime sources partially)
+  - `confidence_calibration`: `1.0` minus capped penalties for unnecessary actions and
+    retries; unmeasured metrics incur no penalty
+- `overall`: the mean of the five dimensions
+- `category`: a coarse tier derived from `overall` (`strong` ≥ 0.75, `moderate` ≥ 0.5, else `weak`)
 
 The current counting boundary is:
 

--- a/src/gym/executor.rs
+++ b/src/gym/executor.rs
@@ -262,6 +262,15 @@ fn build_and_write_report(
     let report_txt = run_dir.join("report.txt");
     let review_json = run_dir.join("review.json");
     let derived_metrics = derive_benchmark_metrics(&metric_facts);
+    let evidence_quality_assessment =
+        crate::gym_scoring::assess_evidence_quality(&crate::gym_scoring::EvidenceQualityInputs {
+            correctness_checks_passed: checks.iter().filter(|check| check.passed).count(),
+            correctness_checks_total: checks.len(),
+            evidence_records: &arts.exported.evidence_records,
+            memory_records: &arts.exported.memory_records,
+            unnecessary_action_count: derived_metrics.unnecessary_action_count,
+            retry_count: derived_metrics.retry_count,
+        });
     let measurement_notes = vec![
         "v1 benchmark foundation derives evidence from runtime, memory, and handoff artifacts rather than a task-specific code-change judge".to_string(),
         "Attempt and action metrics derive from benchmark-controlled gym-runner facts only; they intentionally do not classify arbitrary adapter-level subcommands inside the scenario objective.".to_string(),
@@ -297,6 +306,7 @@ fn build_and_write_report(
             } else {
                 "thin".to_string()
             },
+            evidence_quality_assessment,
             correctness_checks_passed: checks.iter().filter(|check| check.passed).count(),
             correctness_checks_total: checks.len(),
             unnecessary_action_count: derived_metrics.unnecessary_action_count,

--- a/src/gym/tests_reporting_more.rs
+++ b/src/gym/tests_reporting_more.rs
@@ -5,6 +5,7 @@ use crate::gym::types::{
     BenchmarkComparisonStatus, BenchmarkHandoffReport, BenchmarkRunReport, BenchmarkRuntimeReport,
     BenchmarkScenario, BenchmarkScorecard,
 };
+use crate::gym_scoring::EvidenceQualityAssessment;
 use crate::runtime::RuntimeTopology;
 use std::path::PathBuf;
 fn make_summary(
@@ -125,6 +126,7 @@ fn make_test_run_report() -> BenchmarkRunReport {
         scorecard: BenchmarkScorecard {
             task_completed: true,
             evidence_quality: "sufficient".to_string(),
+            evidence_quality_assessment: EvidenceQualityAssessment::default(),
             correctness_checks_passed: 1,
             correctness_checks_total: 2,
             unnecessary_action_count: Some(3),

--- a/src/gym/tests_types.rs
+++ b/src/gym/tests_types.rs
@@ -1,4 +1,6 @@
 use super::types::*;
+use crate::gym_bridge::ScoreDimensions;
+use crate::gym_scoring::EvidenceQualityAssessment;
 use crate::runtime::RuntimeTopology;
 #[test]
 fn benchmark_class_display_all_variants() {
@@ -225,6 +227,13 @@ fn benchmark_scorecard_fields() {
     let s = BenchmarkScorecard {
         task_completed: true,
         evidence_quality: "sufficient".to_string(),
+        evidence_quality_assessment: EvidenceQualityAssessment::from_dimensions(ScoreDimensions {
+            factual_accuracy: 0.8,
+            specificity: 0.6,
+            temporal_awareness: 0.4,
+            source_attribution: 1.0,
+            confidence_calibration: 0.7,
+        }),
         correctness_checks_passed: 7,
         correctness_checks_total: 10,
         unnecessary_action_count: Some(2),
@@ -238,6 +247,9 @@ fn benchmark_scorecard_fields() {
     assert_eq!(s.retry_count, None);
     assert_eq!(s.human_review_notes.len(), 1);
     assert_eq!(s.measurement_notes.len(), 2);
+    assert!((s.evidence_quality_assessment.dimensions.factual_accuracy - 0.8).abs() < 1e-9);
+    assert!((s.evidence_quality_assessment.overall - 0.7).abs() < 1e-9);
+    assert_eq!(s.evidence_quality_assessment.category, "moderate");
 }
 
 #[test]

--- a/src/gym/tests_types_extra.rs
+++ b/src/gym/tests_types_extra.rs
@@ -1,4 +1,5 @@
 use super::types::*;
+use crate::gym_scoring::EvidenceQualityAssessment;
 
 #[test]
 fn test_benchmark_class_display() {
@@ -131,6 +132,7 @@ fn test_benchmark_scorecard_serialize() {
     let scorecard = BenchmarkScorecard {
         task_completed: true,
         evidence_quality: "high".to_string(),
+        evidence_quality_assessment: EvidenceQualityAssessment::default(),
         correctness_checks_passed: 8,
         correctness_checks_total: 10,
         unnecessary_action_count: Some(2),
@@ -141,6 +143,7 @@ fn test_benchmark_scorecard_serialize() {
     let json = serde_json::to_string(&scorecard).unwrap();
     assert!(json.contains(r##""task_completed":true"##));
     assert!(json.contains(r##""correctness_checks_passed":8"##));
+    assert!(json.contains(r##""evidence_quality_assessment":"##));
 }
 
 #[test]

--- a/src/gym/types.rs
+++ b/src/gym/types.rs
@@ -2,6 +2,7 @@ use std::fmt::{self, Display, Formatter};
 
 use serde::Serialize;
 
+use crate::gym_scoring::EvidenceQualityAssessment;
 use crate::runtime::RuntimeTopology;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
@@ -138,10 +139,18 @@ pub struct BenchmarkHandoffReport {
     pub restored_session_objective: Option<String>,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct BenchmarkScorecard {
     pub task_completed: bool,
+    /// Coarse legacy categorical (`sufficient`/`thin`) retained for the
+    /// reporting and run-comparison paths. Prefer [`Self::evidence_quality_assessment`]
+    /// for meaningful, comparable evidence-quality signal.
     pub evidence_quality: String,
+    /// Structured 5-dimension evidence-quality assessment. This is the key
+    /// scoring field per `Specs/ProductArchitecture.md` (lines 204-213): it
+    /// distinguishes quality differences between runs that the binary
+    /// categorical cannot.
+    pub evidence_quality_assessment: EvidenceQualityAssessment,
     pub correctness_checks_passed: usize,
     pub correctness_checks_total: usize,
     pub unnecessary_action_count: Option<u32>,
@@ -150,7 +159,7 @@ pub struct BenchmarkScorecard {
     pub measurement_notes: Vec<String>,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct BenchmarkRunReport {
     pub suite_id: String,
     pub scenario: BenchmarkScenario,

--- a/src/gym_history/tests.rs
+++ b/src/gym_history/tests.rs
@@ -244,6 +244,7 @@ use crate::gym::{
     BenchmarkArtifactPaths, BenchmarkClass, BenchmarkHandoffReport, BenchmarkRunReport,
     BenchmarkRuntimeReport, BenchmarkScenario, BenchmarkScorecard,
 };
+use crate::gym_scoring::EvidenceQualityAssessment;
 use crate::runtime::RuntimeTopology;
 
 fn make_report(
@@ -275,6 +276,7 @@ fn make_report(
         scorecard: BenchmarkScorecard {
             task_completed: passed,
             evidence_quality: evidence.to_string(),
+            evidence_quality_assessment: EvidenceQualityAssessment::default(),
             correctness_checks_passed: checks_passed,
             correctness_checks_total: checks_total,
             unnecessary_action_count: None,

--- a/src/gym_scoring/mod.rs
+++ b/src/gym_scoring/mod.rs
@@ -2,8 +2,10 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::evidence::{EvidenceRecord, EvidenceSource};
 use crate::gym::BenchmarkRunReport;
 use crate::gym_bridge::{GymScenarioResult, GymSuiteResult, ScoreDimensions};
+use crate::memory::MemoryRecord;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GymSuiteScore {
@@ -56,6 +58,148 @@ pub struct ImprovementTrend {
     pub overall_direction: TrendDirection,
     pub overall_delta: f64,
     pub dimension_trends: Vec<DimensionTrend>,
+}
+
+/// Structured evidence-quality assessment carried by a benchmark scorecard.
+///
+/// Replaces the coarse binary `sufficient`/`thin` categorical with the five
+/// canonical scoring dimensions (see [`ScoreDimensions`]), an `overall` mean,
+/// and a human-readable `category`. This makes evidence quality a meaningful
+/// key scoring field that can distinguish quality differences between runs,
+/// as required by the scoring strategy in `Specs/ProductArchitecture.md`.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct EvidenceQualityAssessment {
+    pub dimensions: ScoreDimensions,
+    pub overall: f64,
+    pub category: String,
+}
+
+impl EvidenceQualityAssessment {
+    /// Build an assessment from dimensions, deriving `overall` (their mean) and
+    /// the human-readable `category`.
+    pub fn from_dimensions(dimensions: ScoreDimensions) -> Self {
+        let overall = dimensions.mean();
+        let category = evidence_quality_category(overall).to_string();
+        Self {
+            dimensions,
+            overall,
+            category,
+        }
+    }
+}
+
+/// Map an overall evidence-quality score in `[0.0, 1.0]` to a coarse tier.
+pub fn evidence_quality_category(overall: f64) -> &'static str {
+    if overall >= 0.75 {
+        "strong"
+    } else if overall >= 0.5 {
+        "moderate"
+    } else {
+        "weak"
+    }
+}
+
+/// Raw signals captured during a benchmark run, used to derive a structured
+/// [`EvidenceQualityAssessment`].
+pub struct EvidenceQualityInputs<'a> {
+    pub correctness_checks_passed: usize,
+    pub correctness_checks_total: usize,
+    pub evidence_records: &'a [EvidenceRecord],
+    pub memory_records: &'a [MemoryRecord],
+    pub unnecessary_action_count: Option<u32>,
+    pub retry_count: Option<u32>,
+}
+
+/// Evidence-record count at which the quantity signal saturates to `1.0`.
+const EVIDENCE_COUNT_TARGET: f64 = 4.0;
+/// Evidence `detail` length (chars) at which the richness signal saturates.
+const EVIDENCE_DETAIL_TARGET: f64 = 80.0;
+/// Penalty per unnecessary action / retry when deriving calibration.
+const CALIBRATION_PENALTY_PER_EVENT: f64 = 0.1;
+/// Maximum calibration penalty contributed by either actions or retries.
+const CALIBRATION_PENALTY_CAP: f64 = 0.5;
+
+/// Derive a structured [`EvidenceQualityAssessment`] from raw run signals.
+///
+/// Each dimension is bounded to `[0.0, 1.0]` and responds to a distinct,
+/// observable signal so two runs can be compared dimension-by-dimension:
+///
+/// - `factual_accuracy`: correctness-check pass rate.
+/// - `specificity`: total evidence "units" — each record contributes up to one
+///   unit scaled by its detail richness (saturating at [`EVIDENCE_DETAIL_TARGET`]
+///   characters), with the summed units saturating at [`EVIDENCE_COUNT_TARGET`].
+///   Empty-detail records contribute nothing.
+/// - `temporal_awareness`: fraction of memory records carrying a creation
+///   timestamp (temporal grounding).
+/// - `source_attribution`: how strongly evidence is attributed to a concrete
+///   source — base-type sources count fully, generic runtime sources partially.
+/// - `confidence_calibration`: `1.0` minus capped penalties for unnecessary
+///   actions and retries; unmeasured metrics incur no penalty.
+pub fn assess_evidence_quality(inputs: &EvidenceQualityInputs) -> EvidenceQualityAssessment {
+    let factual_accuracy = if inputs.correctness_checks_total > 0 {
+        inputs.correctness_checks_passed as f64 / inputs.correctness_checks_total as f64
+    } else {
+        0.0
+    };
+
+    let evidence_count = inputs.evidence_records.len();
+    // Each evidence record contributes up to one "evidence unit" scaled by its
+    // detail richness (saturating at EVIDENCE_DETAIL_TARGET chars); the summed
+    // units saturate at EVIDENCE_COUNT_TARGET. Empty-detail records contribute
+    // nothing, so neither sparse evidence nor many empty records score well.
+    let specificity = (inputs
+        .evidence_records
+        .iter()
+        .map(|record| {
+            (record.detail.trim().chars().count() as f64 / EVIDENCE_DETAIL_TARGET).min(1.0)
+        })
+        .sum::<f64>()
+        / EVIDENCE_COUNT_TARGET)
+        .min(1.0);
+
+    let temporal_awareness = if inputs.memory_records.is_empty() {
+        0.0
+    } else {
+        let grounded = inputs
+            .memory_records
+            .iter()
+            .filter(|record| record.created_at.is_some())
+            .count();
+        grounded as f64 / inputs.memory_records.len() as f64
+    };
+
+    let source_attribution = if evidence_count == 0 {
+        0.0
+    } else {
+        inputs
+            .evidence_records
+            .iter()
+            .map(|record| match record.source {
+                EvidenceSource::BaseType(_) => 1.0,
+                EvidenceSource::Runtime => 0.5,
+            })
+            .sum::<f64>()
+            / evidence_count as f64
+    };
+
+    let confidence_calibration =
+        (1.0 - penalty(inputs.unnecessary_action_count) - penalty(inputs.retry_count)).max(0.0);
+
+    EvidenceQualityAssessment::from_dimensions(ScoreDimensions {
+        factual_accuracy,
+        specificity,
+        temporal_awareness,
+        source_attribution,
+        confidence_calibration,
+    })
+}
+
+/// Capped calibration penalty for a measured event count. `None` (unmeasured)
+/// yields no penalty.
+fn penalty(count: Option<u32>) -> f64 {
+    count
+        .map(|c| (c as f64 * CALIBRATION_PENALTY_PER_EVENT).min(CALIBRATION_PENALTY_CAP))
+        .unwrap_or(0.0)
 }
 
 /// Aggregate scenario results into a suite-level score. Empty input yields zeroed score.
@@ -221,14 +365,17 @@ fn classify_trend(delta: f64) -> TrendDirection {
 ///
 /// Maps the benchmark scorecard into scoring dimensions so that
 /// [`detect_regression`] and [`track_improvement`] can consume executor output
-/// directly. The overall score is the correctness-check pass rate. Dimension
-/// values are derived from scorecard signals:
+/// directly. The overall score is the correctness-check pass rate. The five
+/// dimensions are taken from the scorecard's structured
+/// [`EvidenceQualityAssessment`] (see [`assess_evidence_quality`]), so the
+/// regression/improvement pipeline operates on the same meaningful assessment
+/// that the executor records.
 ///
-/// - `factual_accuracy`: correctness-check pass rate
-/// - `specificity`: evidence quality mapped to 0.0 / 0.5 / 1.0
-/// - `temporal_awareness`: correctness-check pass rate (benchmarks test temporal aspects)
-/// - `source_attribution`: evidence quality indicator
-/// - `confidence_calibration`: 1.0 minus penalty for unnecessary actions and retries
+/// Note: `GymSuiteScore.overall` remains the correctness-check pass rate (task
+/// correctness), which is intentionally distinct from
+/// `evidence_quality_assessment.overall`. Evidence-quality-only changes surface
+/// through the per-dimension values consumed by [`detect_regression`], not
+/// through `overall`.
 pub fn suite_score_from_benchmark_report(report: &BenchmarkRunReport) -> GymSuiteScore {
     let checks_total = report.scorecard.correctness_checks_total;
     let checks_passed = report.scorecard.correctness_checks_passed;
@@ -238,34 +385,14 @@ pub fn suite_score_from_benchmark_report(report: &BenchmarkRunReport) -> GymSuit
         0.0
     };
 
-    let evidence_score = match report.scorecard.evidence_quality.as_str() {
-        "sufficient" => 1.0,
-        "thin" => 0.5,
-        _ => 0.0,
-    };
-
-    let action_penalty = report
-        .scorecard
-        .unnecessary_action_count
-        .map(|c| (c as f64 * 0.1).min(0.5))
-        .unwrap_or(0.0);
-    let retry_penalty = report
-        .scorecard
-        .retry_count
-        .map(|c| (c as f64 * 0.1).min(0.5))
-        .unwrap_or(0.0);
-    let calibration = (1.0 - action_penalty - retry_penalty).max(0.0);
-
     GymSuiteScore {
         suite_id: report.suite_id.clone(),
         overall: pass_rate,
-        dimensions: ScoreDimensions {
-            factual_accuracy: pass_rate,
-            specificity: evidence_score,
-            temporal_awareness: pass_rate,
-            source_attribution: evidence_score,
-            confidence_calibration: calibration,
-        },
+        dimensions: report
+            .scorecard
+            .evidence_quality_assessment
+            .dimensions
+            .clone(),
         scenario_count: 1,
         scenarios_passed: if report.passed { 1 } else { 0 },
         pass_rate: if report.passed { 1.0 } else { 0.0 },

--- a/src/gym_scoring/tests.rs
+++ b/src/gym_scoring/tests.rs
@@ -316,6 +316,28 @@ fn make_report(
     unnecessary: Option<u32>,
     retries: Option<u32>,
 ) -> BenchmarkRunReport {
+    let pass_rate = if checks_total > 0 {
+        checks_passed as f64 / checks_total as f64
+    } else {
+        0.0
+    };
+    let evidence_score = match evidence {
+        "sufficient" => 1.0,
+        "thin" => 0.5,
+        _ => 0.0,
+    };
+    let action_penalty = unnecessary
+        .map(|c| (c as f64 * 0.1).min(0.5))
+        .unwrap_or(0.0);
+    let retry_penalty = retries.map(|c| (c as f64 * 0.1).min(0.5)).unwrap_or(0.0);
+    let calibration = (1.0 - action_penalty - retry_penalty).max(0.0);
+    let assessment = EvidenceQualityAssessment::from_dimensions(ScoreDimensions {
+        factual_accuracy: pass_rate,
+        specificity: evidence_score,
+        temporal_awareness: pass_rate,
+        source_attribution: evidence_score,
+        confidence_calibration: calibration,
+    });
     BenchmarkRunReport {
         suite_id: suite.to_string(),
         scenario: BenchmarkScenario {
@@ -336,6 +358,7 @@ fn make_report(
         scorecard: BenchmarkScorecard {
             task_completed: passed,
             evidence_quality: evidence.to_string(),
+            evidence_quality_assessment: assessment,
             correctness_checks_passed: checks_passed,
             correctness_checks_total: checks_total,
             unnecessary_action_count: unnecessary,
@@ -376,6 +399,30 @@ fn make_report(
             review_json: String::new(),
         },
     }
+}
+
+#[test]
+fn suite_score_uses_structured_dimensions_not_legacy_string() {
+    // The legacy categorical says "sufficient" (which the old binary mapping
+    // would have turned into specificity 1.0), but the structured assessment
+    // deliberately carries low dimensions. suite_score must reflect the
+    // structured assessment, proving it is decoupled from the legacy string.
+    let mut report = make_report("s1", "sc1", true, 5, 10, "sufficient", 1000, None, None);
+    report.scorecard.evidence_quality_assessment =
+        EvidenceQualityAssessment::from_dimensions(ScoreDimensions {
+            factual_accuracy: 0.1,
+            specificity: 0.2,
+            temporal_awareness: 0.3,
+            source_attribution: 0.4,
+            confidence_calibration: 0.5,
+        });
+    let score = suite_score_from_benchmark_report(&report);
+    assert_eq!(report.scorecard.evidence_quality, "sufficient");
+    assert!((score.dimensions.factual_accuracy - 0.1).abs() < 1e-9);
+    assert!((score.dimensions.specificity - 0.2).abs() < 1e-9);
+    assert!((score.dimensions.temporal_awareness - 0.3).abs() < 1e-9);
+    assert!((score.dimensions.source_attribution - 0.4).abs() < 1e-9);
+    assert!((score.dimensions.confidence_calibration - 0.5).abs() < 1e-9);
 }
 
 #[test]
@@ -507,4 +554,304 @@ fn benchmark_report_flows_to_improvement_tracking() {
     let trend = track_improvement(&reports_over_time);
     assert_eq!(trend.run_count, 5);
     assert_eq!(trend.overall_direction, TrendDirection::Improving);
+}
+
+// ── assess_evidence_quality tests ───────────────────────────────────
+
+use crate::base_types::BaseTypeId;
+use crate::memory::MemoryScope;
+use crate::session::{SessionId, SessionPhase};
+use chrono::Utc;
+use uuid::Uuid;
+
+fn sid() -> SessionId {
+    SessionId::from_uuid(Uuid::nil())
+}
+
+fn evidence(detail: &str, source: EvidenceSource) -> EvidenceRecord {
+    EvidenceRecord {
+        id: "ev".to_string(),
+        session_id: sid(),
+        phase: SessionPhase::Execution,
+        detail: detail.to_string(),
+        source,
+    }
+}
+
+fn memory(timestamped: bool) -> MemoryRecord {
+    MemoryRecord {
+        key: "k".to_string(),
+        scope: MemoryScope::Benchmark,
+        value: "v".to_string(),
+        session_id: sid(),
+        recorded_in: SessionPhase::Execution,
+        created_at: if timestamped { Some(Utc::now()) } else { None },
+    }
+}
+
+#[test]
+fn evidence_quality_category_tiers() {
+    assert_eq!(evidence_quality_category(1.0), "strong");
+    assert_eq!(evidence_quality_category(0.75), "strong");
+    assert_eq!(evidence_quality_category(0.74), "moderate");
+    assert_eq!(evidence_quality_category(0.5), "moderate");
+    assert_eq!(evidence_quality_category(0.49), "weak");
+    assert_eq!(evidence_quality_category(0.0), "weak");
+}
+
+#[test]
+fn assessment_from_dimensions_computes_overall_and_category() {
+    let a = EvidenceQualityAssessment::from_dimensions(ScoreDimensions {
+        factual_accuracy: 1.0,
+        specificity: 1.0,
+        temporal_awareness: 1.0,
+        source_attribution: 1.0,
+        confidence_calibration: 1.0,
+    });
+    assert!((a.overall - 1.0).abs() < 1e-9);
+    assert_eq!(a.category, "strong");
+}
+
+#[test]
+fn assess_factual_accuracy_is_check_pass_rate() {
+    let inputs = EvidenceQualityInputs {
+        correctness_checks_passed: 3,
+        correctness_checks_total: 4,
+        evidence_records: &[],
+        memory_records: &[],
+        unnecessary_action_count: None,
+        retry_count: None,
+    };
+    let a = assess_evidence_quality(&inputs);
+    assert!((a.dimensions.factual_accuracy - 0.75).abs() < 1e-9);
+}
+
+#[test]
+fn assess_factual_accuracy_zero_checks_is_zero() {
+    let inputs = EvidenceQualityInputs {
+        correctness_checks_passed: 0,
+        correctness_checks_total: 0,
+        evidence_records: &[],
+        memory_records: &[],
+        unnecessary_action_count: None,
+        retry_count: None,
+    };
+    assert_eq!(
+        assess_evidence_quality(&inputs).dimensions.factual_accuracy,
+        0.0
+    );
+}
+
+#[test]
+fn assess_specificity_rewards_quantity_and_detail() {
+    let long = "x".repeat(80);
+    let rich: Vec<EvidenceRecord> = (0..4)
+        .map(|_| evidence(&long, EvidenceSource::Runtime))
+        .collect();
+    let inputs = EvidenceQualityInputs {
+        correctness_checks_passed: 0,
+        correctness_checks_total: 1,
+        evidence_records: &rich,
+        memory_records: &[],
+        unnecessary_action_count: None,
+        retry_count: None,
+    };
+    // 4 records, each 80-char detail -> 4 units / 4 target -> specificity 1.0
+    assert!((assess_evidence_quality(&inputs).dimensions.specificity - 1.0).abs() < 1e-9);
+}
+
+#[test]
+fn assess_specificity_penalizes_sparse_thin_evidence() {
+    let thin = vec![evidence("x", EvidenceSource::Runtime)];
+    let inputs = EvidenceQualityInputs {
+        correctness_checks_passed: 0,
+        correctness_checks_total: 1,
+        evidence_records: &thin,
+        memory_records: &[],
+        unnecessary_action_count: None,
+        retry_count: None,
+    };
+    // single 1-char record -> (1/80) unit / 4 target
+    let expected = (1.0 / 80.0) / 4.0;
+    assert!((assess_evidence_quality(&inputs).dimensions.specificity - expected).abs() < 1e-9);
+}
+
+#[test]
+fn assess_specificity_zero_without_evidence() {
+    let inputs = EvidenceQualityInputs {
+        correctness_checks_passed: 0,
+        correctness_checks_total: 1,
+        evidence_records: &[],
+        memory_records: &[],
+        unnecessary_action_count: None,
+        retry_count: None,
+    };
+    assert_eq!(assess_evidence_quality(&inputs).dimensions.specificity, 0.0);
+}
+
+#[test]
+fn assess_temporal_awareness_is_timestamp_fraction() {
+    let mems = vec![memory(true), memory(false), memory(true), memory(false)];
+    let inputs = EvidenceQualityInputs {
+        correctness_checks_passed: 0,
+        correctness_checks_total: 1,
+        evidence_records: &[],
+        memory_records: &mems,
+        unnecessary_action_count: None,
+        retry_count: None,
+    };
+    assert!(
+        (assess_evidence_quality(&inputs)
+            .dimensions
+            .temporal_awareness
+            - 0.5)
+            .abs()
+            < 1e-9
+    );
+}
+
+#[test]
+fn assess_temporal_awareness_zero_without_memory() {
+    let inputs = EvidenceQualityInputs {
+        correctness_checks_passed: 0,
+        correctness_checks_total: 1,
+        evidence_records: &[],
+        memory_records: &[],
+        unnecessary_action_count: None,
+        retry_count: None,
+    };
+    assert_eq!(
+        assess_evidence_quality(&inputs)
+            .dimensions
+            .temporal_awareness,
+        0.0
+    );
+}
+
+#[test]
+fn assess_source_attribution_weights_base_type_above_runtime() {
+    let recs = vec![
+        evidence(
+            "a",
+            EvidenceSource::BaseType(BaseTypeId::new("local-harness")),
+        ),
+        evidence("b", EvidenceSource::Runtime),
+    ];
+    let inputs = EvidenceQualityInputs {
+        correctness_checks_passed: 0,
+        correctness_checks_total: 1,
+        evidence_records: &recs,
+        memory_records: &[],
+        unnecessary_action_count: None,
+        retry_count: None,
+    };
+    // (1.0 + 0.5) / 2 = 0.75
+    assert!(
+        (assess_evidence_quality(&inputs)
+            .dimensions
+            .source_attribution
+            - 0.75)
+            .abs()
+            < 1e-9
+    );
+}
+
+#[test]
+fn assess_confidence_calibration_applies_capped_penalties() {
+    let inputs = EvidenceQualityInputs {
+        correctness_checks_passed: 1,
+        correctness_checks_total: 1,
+        evidence_records: &[],
+        memory_records: &[],
+        unnecessary_action_count: Some(3),
+        retry_count: Some(2),
+    };
+    // 0.3 + 0.2 penalty -> 0.5
+    assert!(
+        (assess_evidence_quality(&inputs)
+            .dimensions
+            .confidence_calibration
+            - 0.5)
+            .abs()
+            < 1e-9
+    );
+}
+
+#[test]
+fn assess_confidence_calibration_clamped_at_zero() {
+    let inputs = EvidenceQualityInputs {
+        correctness_checks_passed: 1,
+        correctness_checks_total: 1,
+        evidence_records: &[],
+        memory_records: &[],
+        unnecessary_action_count: Some(10),
+        retry_count: Some(10),
+    };
+    assert_eq!(
+        assess_evidence_quality(&inputs)
+            .dimensions
+            .confidence_calibration,
+        0.0
+    );
+}
+
+#[test]
+fn assess_confidence_calibration_unmeasured_is_neutral() {
+    let inputs = EvidenceQualityInputs {
+        correctness_checks_passed: 1,
+        correctness_checks_total: 1,
+        evidence_records: &[],
+        memory_records: &[],
+        unnecessary_action_count: None,
+        retry_count: None,
+    };
+    assert!(
+        (assess_evidence_quality(&inputs)
+            .dimensions
+            .confidence_calibration
+            - 1.0)
+            .abs()
+            < 1e-9
+    );
+}
+
+#[test]
+fn assess_distinguishes_strong_from_weak_runs() {
+    let long = "detailed runtime observation".repeat(4);
+    let strong_ev: Vec<EvidenceRecord> = (0..4)
+        .map(|_| {
+            evidence(
+                &long,
+                EvidenceSource::BaseType(BaseTypeId::new("local-harness")),
+            )
+        })
+        .collect();
+    let strong_mem = vec![memory(true), memory(true)];
+    let strong = assess_evidence_quality(&EvidenceQualityInputs {
+        correctness_checks_passed: 4,
+        correctness_checks_total: 4,
+        evidence_records: &strong_ev,
+        memory_records: &strong_mem,
+        unnecessary_action_count: Some(0),
+        retry_count: Some(0),
+    });
+
+    let weak_ev = vec![evidence("x", EvidenceSource::Runtime)];
+    let weak = assess_evidence_quality(&EvidenceQualityInputs {
+        correctness_checks_passed: 1,
+        correctness_checks_total: 4,
+        evidence_records: &weak_ev,
+        memory_records: &[memory(false)],
+        unnecessary_action_count: Some(3),
+        retry_count: Some(2),
+    });
+
+    assert!(
+        strong.overall > weak.overall,
+        "structured assessment must give the richer run a higher overall score: {} vs {}",
+        strong.overall,
+        weak.overall
+    );
+    assert_eq!(strong.category, "strong");
+    assert_eq!(weak.category, "weak");
 }

--- a/src/self_improve/tests_hypothesis.rs
+++ b/src/self_improve/tests_hypothesis.rs
@@ -14,6 +14,7 @@ use crate::gym::{
     BenchmarkRunReport, BenchmarkRuntimeReport, BenchmarkScenario, BenchmarkScorecard,
 };
 use crate::gym_history::{GymSignal, ScenarioSignal};
+use crate::gym_scoring::EvidenceQualityAssessment;
 use crate::improvements::EvidenceRef;
 use crate::review::{ImprovementProposal, ReviewArtifact, ReviewEvidenceSummary, ReviewTargetKind};
 use crate::runtime::RuntimeTopology;
@@ -57,6 +58,7 @@ fn synthetic_report(
         scorecard: BenchmarkScorecard {
             task_completed: passed,
             evidence_quality: "ok".to_string(),
+            evidence_quality_assessment: EvidenceQualityAssessment::default(),
             correctness_checks_passed: 0,
             correctness_checks_total: failed_check_ids.len(),
             unnecessary_action_count: Some(2),

--- a/tests/review.rs
+++ b/tests/review.rs
@@ -259,6 +259,29 @@ fn fresh_benchmark_runs_stop_emitting_metric_gap_review_proposals() {
         "fresh benchmark reviews should stop proposing retry_count work once the metric is measured: {titles:#?}"
     );
 
+    let assessment = &report.scorecard.evidence_quality_assessment;
+    let dims = &assessment.dimensions;
+    for (name, value) in [
+        ("factual_accuracy", dims.factual_accuracy),
+        ("specificity", dims.specificity),
+        ("temporal_awareness", dims.temporal_awareness),
+        ("source_attribution", dims.source_attribution),
+        ("confidence_calibration", dims.confidence_calibration),
+    ] {
+        assert!(
+            (0.0..=1.0).contains(&value),
+            "structured evidence-quality dimension {name} must be in [0.0, 1.0], got {value}: {assessment:#?}"
+        );
+    }
+    assert!(
+        (assessment.overall - dims.mean()).abs() < 1e-9,
+        "structured assessment overall must equal the dimension mean: {assessment:#?}"
+    );
+    assert!(
+        !assessment.category.is_empty(),
+        "structured assessment must carry a category label: {assessment:#?}"
+    );
+
     if temp_root.exists() {
         fs::remove_dir_all(PathBuf::from(&temp_root)).expect("temp root should be removable");
     }


### PR DESCRIPTION
## Summary

Closes the spec-vs-implementation gap in **#2090**. The benchmark scorecard
recorded evidence quality only as a binary `sufficient`/`thin` string derived
from `evidence_records.len() >= 4`. The five canonical scoring dimensions
already existed in `gym_scoring`/`gym_bridge` but were **never integrated** into
`BenchmarkScorecard`, so evidence quality could not distinguish meaningful
differences between runs — violating `Specs/ProductArchitecture.md` lines
204–213, which require evidence quality to be a key scoring field that "enables
comparing changes to prompts and policies."

## Changes (scoped to the gym scoring/executor path)

- **`src/gym_scoring/mod.rs`**: new `EvidenceQualityAssessment`
  (`dimensions` + `overall` + `category`), `EvidenceQualityInputs`,
  `assess_evidence_quality()`, and `evidence_quality_category()`. Each of the
  five dimensions is bounded to `[0,1]` and derived from **real run artifacts**
  (correctness checks, exported evidence/memory records, action/retry metrics),
  so two runs are comparable dimension-by-dimension:
  - `factual_accuracy` = correctness-check pass rate
  - `specificity` = summed per-record "evidence units" (detail richness
    saturating at 80 chars), capped at 4 units — empty-detail records score 0
  - `temporal_awareness` = fraction of memory records carrying a timestamp
  - `source_attribution` = base-type sources count fully, runtime sources partially
  - `confidence_calibration` = 1.0 minus capped penalties for unnecessary
    actions and retries (unmeasured ⇒ no penalty)
- **`src/gym_scoring/mod.rs`**: `suite_score_from_benchmark_report` now reads
  dimensions from the carried assessment instead of mapping the binary string,
  so `detect_regression`/`track_improvement` operate on the real assessment.
  `GymSuiteScore.overall` intentionally remains task-correctness pass rate
  (documented as distinct from `evidence_quality_assessment.overall`).
- **`src/gym/types.rs`**: `BenchmarkScorecard` carries
  `evidence_quality_assessment`. The legacy `evidence_quality` string is retained
  for the reporting/comparison path. `Eq` dropped from
  `BenchmarkScorecard`/`BenchmarkRunReport` (now hold `f64`; `PartialEq` kept).
- **`src/gym/executor.rs`** (+ `self_improve` test fixture): populate the
  structured assessment from run artifacts.
- **`docs/reference/runtime-contracts.md`**: documents `evidence_quality_assessment`.

Relationship to `3b025dc6` (which wired `BenchmarkRunReport` into `gym_scoring`):
that commit mapped the *binary string* into dimensions downstream. This PR
completes the integration by making `BenchmarkScorecard` itself carry the real
structured assessment, and rewires the downstream scorer to consume it.

Rebased onto latest `main` (`v0.21.0`); fixed the new `BenchmarkScorecard`
construction site that `main` added in `src/self_improve/tests_hypothesis.rs`.

## Merge-ready evidence

**1. Tests (qa surface).** This change touches **no** user-facing CLI/TUI/MCP
surface — it adds a field to the internal benchmark `report.json` consumed by the
gym scoring pipeline — so the validation surface is the Rust test suite (the
repo's idiomatic gate), not `gadugi-test` agentic scenarios (internal-only
justification, per criterion 2). Added/extended:
- `gym_scoring` unit tests for `assess_evidence_quality` (each dimension, empty
  inputs, category tiers, strong-vs-weak ordering) plus a decoupling test
  proving `suite_score_from_benchmark_report` reflects the structured dimensions,
  not the legacy `sufficient`/`thin` string.
- Extended scorecard struct + serialize tests (`gym/tests_types*`).
- End-to-end executor assertion in `tests/review.rs` (dimensions in `[0,1]`,
  `overall == mean`, non-empty `category`).
- Results (local): full `--all-features` lib test binary **compiles**;
  `gym_scoring` lib tests **43 passed, 0 failed**; `cargo test --lib gym` →
  **517 passed**; `cargo test --test review` → **7 passed**.

**2. Docs.** `docs/reference/runtime-contracts.md` updated to document the new
`scorecard.evidence_quality_assessment` field and each dimension.

**3. Review cycles (3, ending clean).** Independent automated reviews on the
implementation:
- **code-review** — verified `[0,1]` bounds, empty-input guards, `Eq`-removal
  safety (no `HashSet`/`Ord` consumers), serialize/deserialize compatibility
  (`StoredBenchmarkScorecard` has no `deny_unknown_fields`). No issues.
- **security-review** — no integer-overflow/NaN/div-by-zero/panic/DoS issues;
  widening casts only, all divisions guarded. No vulnerabilities.
- **rubber-duck (semantics)** — no blockers; raised that the old `specificity`
  blend could reward empty records. **Fixed**: `specificity` now sums per-record
  evidence units so empty-detail records score 0; added the decoupling test and
  documented `overall` semantics. Final state clean.

Commits: `6a137783` (squash-ready single commit).

**4. CI.** Locally reproduced the gates on the pre-rebase commit
(`cargo fmt --all -- --check` ✓; `cargo clippy --all-targets --all-features
--locked -- -D warnings` ✓ — the heavy pre-push variant mirroring `verify.yml`;
release lib-test subset ✓) and re-ran `clippy --all-features --lib --tests
-- -D warnings` ✓ after the rebase. Awaiting CI confirmation on this PR.

**6. Focused diff.** 11 files: the gym scoring/executor path + their tests, one
`self_improve` test fixture (rebase compatibility), and the one doc surface. No
unrelated edits.

Refs #2090
