### PR TITLE
fix(cog-mem): repoint dead cross-session-recall gadugi gate to live targets (closes #2344)

### DIFF
--- a/tests/gadugi/cross-session-recall.yaml
+++ b/tests/gadugi/cross-session-recall.yaml
@@ -1,13 +1,37 @@
 name: "Cross-Session Cognitive Memory Recall"
 description: >
   Outside-in gate for issue #1916: verifies that cognitive memory written by
-  Session A survives process exit and is fully recallable by Session B via the
-  snapshot recovery ladder. Also covers the corruption-recovery path from
-  issue #1710 (backup-restore ordering fix).
-version: "1.0.0"
+  one process (Session A) survives process exit and is fully recallable by a
+  *separate* process (Session B) through the on-disk "direct open" recovery
+  tier — the same path the operator uses against a live store when the OODA
+  memory daemon is down.
+
+  Repointed for issue #2344. The original target
+  `cargo test --test cognitive_memory_cross_session_recall` was deleted by the
+  de-fork (#2308 — native cognitive-memory fork removed, amplihack-memory-lib is
+  now the sole backend) and the scenario was never updated, leaving this gate
+  dead (it failed at step 1 with "no test target named …"). It now drives the
+  live process-boundary integration suite `tests/bin_simard_memory_cli.rs`: a
+  library writer seeds an on-disk store, drops it (releasing the file lock), and
+  a separate `simard` binary opens the same DB and recalls the data.
+
+  Step 1 proves the clean cross-session path: every one of the six cognitive
+  memory types written by the writer process is recalled by the reader process
+  via the direct-open tier. Step 2 proves durable graph edges (DERIVES_FROM
+  provenance) and snapshot dedup survive the same process boundary
+  (#2331 / #2332).
+
+  The raw byte-level corruption-recovery path formerly asserted here
+  (#1710, `cross_session_recall_survives_db_corruption_via_snapshot`) was a test
+  of the native store and was deleted with it by #2308. Catalog-corruption
+  recovery now lives in the amplihack-memory-lib durability suite (landed via
+  the #2335 dependency bump) and is no longer a Simard test target, so this gate
+  guards the durable-recall-survives-process-boundary capability that Simard
+  still owns directly.
+version: "1.1.0"
 
 config:
-  timeout: 120000
+  timeout: 300000
   retries: 1
   parallel: false
 
@@ -19,7 +43,7 @@ agents:
     type: "cli"
     config:
       workingDirectory: "."
-      defaultTimeout: 120000
+      defaultTimeout: 300000
       executionMode: "spawn"
       captureOutput: true
       ioConfig:
@@ -31,30 +55,52 @@ agents:
         logLevel: "info"
 
 steps:
-  - name: "Cross-session recall — clean path (session A writes, session B reads)"
+  - name: "Cross-session recall — clean path (writer process seeds, reader process recalls all six types)"
     agent: "test-agent"
     action: "execute_command"
     params:
       command: >
-        cargo test --test cognitive_memory_cross_session_recall
-        cognitive_memory_cross_session_recall
+        cargo test --test bin_simard_memory_cli
+        stats_json_reports_every_populated_type_via_direct_open
         -- --nocapture --test-threads=1
-    timeout: 120000
+    timeout: 300000
     expect:
       exitCode: 0
       outputContains:
-        - "test cognitive_memory_cross_session_recall ... ok"
+        - "test stats_json_reports_every_populated_type_via_direct_open ... ok"
 
-  - name: "Cross-session recall — corruption-recovery path (#1710 + #1916)"
+  - name: "Cross-session recall — durable edges + snapshot dedup survive the process boundary (#2331 / #2332)"
     agent: "test-agent"
     action: "execute_command"
     params:
       command: >
-        cargo test --test cognitive_memory_cross_session_recall
-        cross_session_recall_survives_db_corruption_via_snapshot
+        cargo test --test bin_simard_memory_cli
+        stats_shows_edges_and_dedup_section_via_direct_open
         -- --nocapture --test-threads=1
-    timeout: 120000
+    timeout: 300000
     expect:
       exitCode: 0
       outputContains:
-        - "test cross_session_recall_survives_db_corruption_via_snapshot ... ok"
+        - "test stats_shows_edges_and_dedup_section_via_direct_open ... ok"
+
+assertions: []
+
+cleanup:
+  - name: "Test agent cleanup"
+    agent: "test-agent"
+    action: "cleanup"
+
+metadata:
+  tags:
+    - "cli"
+    - "cognitive-memory"
+    - "cross-session-recall"
+    - "durability"
+    - "graph-edges"
+    - "dedup"
+    - "regression"
+    - "issue-1916"
+    - "issue-2344"
+  priority: "high"
+  author: "copilot"
+  test_type: "outside-in"


### PR DESCRIPTION
## Summary

Repairs the broken outside-in gate `tests/gadugi/cross-session-recall.yaml`
(issue #1916), which had been **dead since #2308**.

Both steps invoked the Cargo test target
`cargo test --test cognitive_memory_cross_session_recall`. That target (and the
two test fns it named) was deleted by **#2308** ("de-fork phase 2b: delete
native cognitive-memory fork; library is sole backend") and the scenario was
never repointed, so the gate failed immediately at step 1:

```
error: no test target named `cognitive_memory_cross_session_recall` ... exit 101
```

→ zero cross-session-recall coverage. This is **test-scenario rot, not a recall
regression** (see #2344): durable cross-session recall is healthy post-#2332.

## What changed

`tests/gadugi/cross-session-recall.yaml` repointed at the **live
process-boundary integration suite** `tests/bin_simard_memory_cli.rs`, where a
library writer seeds an on-disk store, drops it (releasing the file lock), and a
**separate `simard` binary** opens the same DB and recalls the data — a genuine
cross-session / cross-process recall exercise (the operator's tier-2 "direct
open" path):

| Step | Live target | Proves |
|------|-------------|--------|
| 1 — clean path | `stats_json_reports_every_populated_type_via_direct_open` | All six cognitive memory types written by the writer process are recalled by a separate reader process via the direct-open tier |
| 2 — durable edges/dedup | `stats_shows_edges_and_dedup_section_via_direct_open` | DERIVES_FROM provenance edges + snapshot dedup survive the same process boundary (#2331 / #2332) |

### Corruption-recovery decision (step 2 of the original)

The original step 2 ran `cross_session_recall_survives_db_corruption_via_snapshot`
(#1710). That test exercised the **native** store and was deleted with it by
#2308. Catalog-corruption recovery now lives in the **amplihack-memory-lib**
durability suite (landed via the #2335 dependency bump,
`amplihack-memory` rev `34d6a75`) and is no longer a Simard test target. Rather
than leave a coverage gap, step 2 now guards the
durable-recall-survives-process-boundary capability Simard still owns directly.

## Merge-ready evidence

**1. qa-team / gadugi scenario — validated and run**

```
$ gadugi-test validate -f tests/gadugi/cross-session-recall.yaml --strict
✓ Scenario "Cross-Session Cognitive Memory Recall" is valid

$ gadugi-test run -d tests/gadugi -s cross-session-recall
test stats_json_reports_every_populated_type_via_direct_open ... ok   (exit 0)
test stats_shows_edges_and_dedup_section_via_direct_open ... ok        (exit 0)
✓ Passed: 1  ✗ Failed: 0  — All tests passed!
```

**Underlying targets (full suite):**

```
$ cargo test --test bin_simard_memory_cli
running 8 tests ... test result: ok. 8 passed; 0 failed; 0 ignored
```

**2. Docs / surfaces** — No user-facing surface changes. The only changed
surface is the internal outside-in test gate (`tests/gadugi/cross-session-recall.yaml`);
the scenario's own `description` documents the repoint and the corruption-recovery
ownership move. No CLI/API/doc behavior changes (internal-only).

**3. Quality-audit** — 3 SEEK→VALIDATE→FIX review cycles, clean final:
(1) target correctness — both fns exist and pass; (2) schema validity +
end-to-end gate execution — `gadugi-test validate`/`run` green; (3) documentation
fidelity — description accurately reflects #2308 deletion, #2344 repoint,
#2331/#2332 edges/dedup ownership, and #2335 corruption-recovery move. No
critical/high or medium correctness/security findings.

**4. CI** — Authoritative gate. NOTE: local pre-commit/pre-push hooks
(`cargo clippy --release`, `cargo test --release --lib`) could **not** be run to
completion on the build host: the per-worktree `CARGO_TARGET_DIR` was being
deleted by an external reaper mid-build (reproducible `getcwd() failed` /
missing `.o.d` during the `lbug` C++ build). The change is **YAML-only** and
cannot affect Rust compilation or clippy. GitHub Actions CI runs these checks in
a clean, isolated environment — relying on CI as the authoritative green signal.

**6. Focused diff** — single file, `+62 / -16`:

```
 tests/gadugi/cross-session-recall.yaml | 78 ++++++++++++++++++-------
 1 file changed, 62 insertions(+), 16 deletions(-)
```

Closes #2344.