### PR TITLE
fix(cog-mem): repoint broken cross-session-recall gadugi gate to live targets (#2344)

### DIFF
--- a/tests/gadugi/cross-session-recall.yaml
+++ b/tests/gadugi/cross-session-recall.yaml
@@ -1,13 +1,19 @@
 name: "Cross-Session Cognitive Memory Recall"
 description: >
   Outside-in gate for issue #1916: verifies that cognitive memory written by
-  Session A survives process exit and is fully recallable by Session B via the
-  snapshot recovery ladder. Also covers the corruption-recovery path from
-  issue #1710 (backup-restore ordering fix).
-version: "1.0.0"
+  Session A survives process exit and is fully recallable by a *separate*
+  Session B process via the on-disk direct-open tier. Steps 1-2 drive the
+  process-boundary CLI tests in `tests/bin_simard_memory_cli.rs` — Session A
+  seeds a store and releases its lock, then a fresh `simard` process opens and
+  recalls every cognitive-memory type. Step 3 guards the corruption-recovery
+  path from issue #1710 (backup-restore ordering) against the surviving
+  library-backed `memory_backup` guard, after the native
+  `cognitive_memory_cross_session_recall` target was deleted by the de-fork in
+  #2308 (see issue #2344).
+version: "1.1.0"
 
 config:
-  timeout: 120000
+  timeout: 180000
   retries: 1
   parallel: false
 
@@ -19,7 +25,7 @@ agents:
     type: "cli"
     config:
       workingDirectory: "."
-      defaultTimeout: 120000
+      defaultTimeout: 180000
       executionMode: "spawn"
       captureOutput: true
       ioConfig:
@@ -31,30 +37,66 @@ agents:
         logLevel: "info"
 
 steps:
-  - name: "Cross-session recall — clean path (session A writes, session B reads)"
+  - name: "#1916 — clean path: Session B recalls all six types from Session A's store via direct open (JSON)"
     agent: "test-agent"
     action: "execute_command"
     params:
       command: >
-        cargo test --test cognitive_memory_cross_session_recall
-        cognitive_memory_cross_session_recall
+        cargo test --test bin_simard_memory_cli
+        stats_json_reports_every_populated_type_via_direct_open
         -- --nocapture --test-threads=1
-    timeout: 120000
+    timeout: 180000
     expect:
       exitCode: 0
       outputContains:
-        - "test cognitive_memory_cross_session_recall ... ok"
+        - "test stats_json_reports_every_populated_type_via_direct_open ... ok"
 
-  - name: "Cross-session recall — corruption-recovery path (#1710 + #1916)"
+  - name: "#1916 — clean path: cross-process access banner ('via direct open') with human count table"
     agent: "test-agent"
     action: "execute_command"
     params:
       command: >
-        cargo test --test cognitive_memory_cross_session_recall
-        cross_session_recall_survives_db_corruption_via_snapshot
+        cargo test --test bin_simard_memory_cli
+        stats_human_shows_count_table_and_access_banner
         -- --nocapture --test-threads=1
-    timeout: 120000
+    timeout: 180000
     expect:
       exitCode: 0
       outputContains:
-        - "test cross_session_recall_survives_db_corruption_via_snapshot ... ok"
+        - "test stats_human_shows_count_table_and_access_banner ... ok"
+
+  - name: "#1710 — corruption-recovery: restore refuses a tampered backup snapshot (library backup guard)"
+    agent: "test-agent"
+    action: "execute_command"
+    params:
+      command: >
+        cargo test --lib
+        restore_rejects_corrupted_backup
+        -- --nocapture --test-threads=1
+    timeout: 180000
+    expect:
+      exitCode: 0
+      outputContains:
+        - "test memory_backup::tests::restore_rejects_corrupted_backup ... ok"
+
+assertions: []
+
+cleanup:
+  - name: "Test agent cleanup"
+    agent: "test-agent"
+    action: "cleanup"
+
+metadata:
+  tags:
+    - "cli"
+    - "cognitive-memory"
+    - "cross-session-recall"
+    - "direct-open"
+    - "corruption-recovery"
+    - "regression"
+    - "issue-1916"
+    - "issue-1710"
+    - "issue-2344"
+  priority: "high"
+  author: "copilot"
+  test_type: "outside-in"


### PR DESCRIPTION
## Summary

Repairs the dead outside-in gate `tests/gadugi/cross-session-recall.yaml` (issue #2344). The gate invoked `cargo test --test cognitive_memory_cross_session_recall`, a target **deleted by #2308** (de-fork phase 2b). It failed immediately (`error: no test target named ...`, exit 101) and provided **zero** cross-session-recall coverage for issue #1916.

This is test-scenario rot, not a recall regression — the capability is independently healthy (per #2344). The fix repoints the gate to **live targets that exist on `main`**.

## Changes (diff: 1 file, YAML only)

`tests/gadugi/cross-session-recall.yaml`:
- **Step 1 — clean path (JSON):** `bin_simard_memory_cli::stats_json_reports_every_populated_type_via_direct_open`. Session A seeds a store and drops its lock; a **separate `simard` process** opens it and recalls all six cognitive types via the on-disk **direct-open** tier — a true cross-process write-A/read-B proof for #1916.
- **Step 2 — clean path (human banner):** `bin_simard_memory_cli::stats_human_shows_count_table_and_access_banner`. Asserts the `via direct open` cross-process access banner + count table.
- **Step 3 — corruption-recovery (#1710):** `memory_backup::tests::restore_rejects_corrupted_backup`. The surviving library-backed backup/restore guard (restore refuses a tampered snapshot), replacing the deleted native `cross_session_recall_survives_db_corruption_via_snapshot`. Per #2344 this is the sanctioned "equivalent against the library backend."
- Aligned structure with the healthy `episodic-recall-and-triggers.yaml` gate (added `assertions`/`cleanup`/`metadata`; bumped version 1.0.0 → 1.1.0).

## Merge-ready evidence

**(1) qa-team / gadugi scenarios — PASS**
- `gadugi-test validate tests/gadugi/cross-session-recall.yaml` → ✓ *"Scenario 'Cross-Session Cognitive Memory Recall' is valid"* (1 valid, 0 invalid).
- `gadugi-test run -d tests/gadugi -s cross-session-recall` → **✓ Passed: 1, ✗ Failed: 0, "All tests passed!"** All three steps exit 0 with the asserted `... ok` lines:
  - `test stats_json_reports_every_populated_type_via_direct_open ... ok`
  - `test stats_human_shows_count_table_and_access_banner ... ok`
  - `test memory_backup::tests::restore_rejects_corrupted_backup ... ok`
- Pre-fix break reproduced: `cargo test --test cognitive_memory_cross_session_recall` → `error: no test target named cognitive_memory_cross_session_recall`, exit 101.

**(2) Docs** — No user-facing surface changed. Only an internal CI/QA test-scenario gate (`tests/gadugi/*.yaml`) was repointed; documented here as the changed surface.

**(3) quality-audit — 3 cycles, clean final**
- Cycle 1 (SEEK targets exist & pass / VALIDATE / FIX): all three repointed targets run green locally; no fix needed.
- Cycle 2 (SEEK assertion fidelity): each `outputContains` line matches `cargo test` stdout exactly (integration fns print bare names; lib fn prints full module path `memory_backup::tests::...`); no fix.
- Cycle 3 (SEEK coverage/regression): corruption-recovery (#1710) coverage is preserved via the library backup guard rather than dropped; schema validates; structure matches the healthy episodic gate. Final cycle: zero critical/high; zero medium correctness/security findings.

**(4) CI — green** — `verify` run for this commit: `pre-commit` ✓ (full `cargo test --all-features --locked`, which exercises all three repointed targets), `install-real` ✓, `e2e-dashboard` ✓, `cargo-audit` ✓, GitGuardian ✓. One earlier duplicate run hit a known-flaky, unrelated test (`operator_commands_dashboard::tests_goals_crud::full_goal_lifecycle_crud`, a dashboard goal-board count assertion sensitive to concurrent writers — the identical commit passed pre-commit in the other run); re-run to clear.

**(6) Diff focused** — One file, YAML only; no unrelated edits.

Closes #2344


---

### CI status (final)

**Authoritative PR run [`27925005256`](https://github.com/rysweet/Simard/actions/runs/27925005256) — 100% GREEN for commit `8209ff35`:**
- `pre-commit` ✓ — runs `cargo test --all-features --locked`, exercising all three repointed targets ([job](https://github.com/rysweet/Simard/actions/runs/27925005256/job/82625664330))
- `install-real` ✓ ([job](https://github.com/rysweet/Simard/actions/runs/27925005256/job/82626555430))
- `e2e-dashboard` ✓ ([job](https://github.com/rysweet/Simard/actions/runs/27925005256/job/82626555432))
- `cargo-audit` ✓ · GitGuardian ✓

**Duplicate push-triggered run [`27924993045`](https://github.com/rysweet/Simard/actions/runs/27924993045):** `pre-commit` red on a **pre-existing flaky-test cluster** (state-isolation under parallel `--lib` load — ambient/global goal-board state root not fully serialized). Nondeterministic: the *same commit* passed in the PR run; across re-runs different members of the cluster flaked (`full_goal_lifecycle_crud`, `update_goal_status_transitions_to_completed`, `migration_skips_slugs_already_in_cognitive_memory`). Tracked by #2316 / **#2320** (reopened with this evidence). These tests predate this branch and are entirely unrelated to this YAML-only diff (which changes zero Rust). The authoritative PR run is green.
