### PR TITLE
fix(dashboard): share one cognitive-memory handle so goal edits don't silently vanish

### DIFF
--- a/scripts/qa-dashboard-goal-persistence.sh
+++ b/scripts/qa-dashboard-goal-persistence.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# qa-dashboard-goal-persistence.sh
+#
+# End-to-end check for the standalone dashboard goal-board persistence fix:
+# `simard dashboard serve` must persist goals across multiple HTTP requests.
+#
+# Regression for the silent goal-board data-loss race: dashboard handlers used
+# to open a *fresh* `LibraryCognitiveMemory` per request. The lbug store holds
+# an exclusive lock for a handle's lifetime, so a per-request open/drop/reopen
+# cycle could race the previous handle's lock release, read an empty board, and
+# then persist that empty board on the next mutating request — dropping every
+# goal. `serve()` now opens the store once and shares one handle via the
+# in-process writer registry (mirroring the OODA daemon and bootstrap), so a
+# multi-request seed -> add -> promote -> read flow stays consistent.
+set -uo pipefail
+
+PORT="${QA_DASHBOARD_PORT:-18842}"
+KEY="qa-dashkey-$$"
+ROOT="$(mktemp -d "${TMPDIR:-/tmp}/qa-dash-XXXXXX")"
+LOG="$ROOT/serve.log"
+SERVE_PID=""
+
+cleanup() {
+  if [[ -n "$SERVE_PID" ]]; then
+    kill "$SERVE_PID" 2>/dev/null || true
+  fi
+  rm -rf "$ROOT" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+fail() {
+  echo "QA-DASHBOARD-GOALS: FAIL - $1"
+  [[ -f "$LOG" ]] && { echo "--- serve log tail ---"; tail -20 "$LOG"; }
+  exit 1
+}
+
+# Locate the freshly-built binary via cargo's reported target directory so the
+# script works regardless of CARGO_TARGET_DIR.
+cargo build --quiet --bin simard || fail "cargo build failed"
+TARGET_DIR="$(cargo metadata --no-deps --format-version 1 \
+  | tr ',' '\n' | grep -o '"target_directory":"[^"]*"' | head -1 | cut -d'"' -f4)"
+BIN="$TARGET_DIR/debug/simard"
+[[ -x "$BIN" ]] || fail "simard binary not found at $BIN"
+
+# Start a standalone dashboard against an isolated, hermetic state root.
+# HOME is pinned into the temp root so the login-code file the dashboard writes
+# (~/.simard/.dashkey) stays hermetic and never touches the operator's real
+# $HOME. SIMARD_DASHBOARD_TOKEN is the API bearer token used by the curl calls.
+HOME="$ROOT" SIMARD_DASHBOARD_TOKEN="$KEY" SIMARD_STATE_ROOT="$ROOT" \
+  "$BIN" dashboard serve --port="$PORT" >"$LOG" 2>&1 &
+SERVE_PID=$!
+
+# Wait for the server to accept connections (the public /login page).
+ready=""
+for _ in $(seq 1 60); do
+  if curl -fsS -o /dev/null "http://127.0.0.1:$PORT/login" 2>/dev/null; then
+    ready="1"
+    break
+  fi
+  kill -0 "$SERVE_PID" 2>/dev/null || fail "server exited before becoming ready"
+  sleep 0.5
+done
+[[ -n "$ready" ]] || fail "server not ready on port $PORT"
+
+AUTH=(-H "Authorization: Bearer $KEY" -H "Content-Type: application/json")
+api() { curl -fsS "${AUTH[@]}" "$@"; }
+
+# 1. Seed the canonical board (3 active, 2 backlog) through the HTTP handler.
+api -X POST "http://127.0.0.1:$PORT/api/goals/seed" >/dev/null \
+  || fail "seed request failed"
+
+# 2. Add a backlog item (a separate mutating request).
+add_resp="$(api -X POST "http://127.0.0.1:$PORT/api/goals" \
+  -d '{"description":"QA end-to-end persistence probe","type":"backlog"}')" \
+  || fail "add request failed"
+id="$(printf '%s' "$add_resp" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)"
+[[ -n "$id" ]] || fail "add did not return an id (response: $add_resp)"
+
+# 3. Promote the new backlog item to active (another mutating request).
+api -X POST "http://127.0.0.1:$PORT/api/goals/promote/$id" >/dev/null \
+  || fail "promote request failed"
+
+# 4. Final read on a SEPARATE request: the 3 seeded goals plus the promoted one
+#    must all still be present. A racing fresh-open read used to return an empty
+#    board here, after which a mutating handler persisted it and dropped goals.
+final="$(api "http://127.0.0.1:$PORT/api/goals")" || fail "final read failed"
+active_count="$(printf '%s' "$final" | grep -o '"active_count":[0-9]*' | head -1 | cut -d: -f2)"
+[[ "$active_count" == "4" ]] \
+  || fail "expected 4 active goals (3 seeded + 1 promoted), got '${active_count:-<none>}' (response: $final)"
+
+echo "QA-DASHBOARD-GOALS: PASS - 4 active goals persisted across 4 HTTP requests"

--- a/scripts/qa-dashboard-goal-persistence.sh
+++ b/scripts/qa-dashboard-goal-persistence.sh
@@ -4,14 +4,16 @@
 # End-to-end check for the standalone dashboard goal-board persistence fix:
 # `simard dashboard serve` must persist goals across multiple HTTP requests.
 #
-# Regression for the silent goal-board data-loss race: dashboard handlers used
-# to open a *fresh* `LibraryCognitiveMemory` per request. The lbug store holds
-# an exclusive lock for a handle's lifetime, so a per-request open/drop/reopen
-# cycle could race the previous handle's lock release, read an empty board, and
-# then persist that empty board on the next mutating request — dropping every
-# goal. `serve()` now opens the store once and shares one handle via the
-# in-process writer registry (mirroring the OODA daemon and bootstrap), so a
-# multi-request seed -> add -> promote -> read flow stays consistent.
+# End-to-end persistence regression for the goal-board: a multi-request
+# seed -> add -> promote -> read flow against a standalone dashboard must never
+# lose a goal. The silent data-loss class (#1590 / #2320) came from per-request
+# fresh `LibraryCognitiveMemory` opens racing the lbug store's exclusive
+# per-handle lock: a reopen could read an empty board and the next mutating
+# request would persist that empty board, dropping every goal. That race is now
+# prevented by the launcher's tier-2 store cache (#2334) and by `serve()`
+# registering one shared tier-0 handle (mirroring the OODA daemon and
+# bootstrap); this script guards the end-to-end persistence contract across
+# separate, hermetic HTTP requests.
 set -uo pipefail
 
 PORT="${QA_DASHBOARD_PORT:-18842}"

--- a/src/operator_commands_dashboard/mod.rs
+++ b/src/operator_commands_dashboard/mod.rs
@@ -167,8 +167,8 @@ pub(crate) fn register_dashboard_shared_writer(
         }
         Err(error) => {
             eprintln!(
-                "[simard] dashboard: cognitive memory unavailable at {} ({error}); \
-                 goal edits may not persist consistently across requests",
+                "[simard] dashboard: shared cognitive-memory handle not registered at {} \
+                 ({error}); handlers will use the IPC/tier-2 fallback",
                 state_root.display()
             );
             None

--- a/src/operator_commands_dashboard/mod.rs
+++ b/src/operator_commands_dashboard/mod.rs
@@ -114,14 +114,15 @@ pub fn serve(port: u16) -> Result<(), Box<dyn std::error::Error>> {
     }
     eprintln!("  Open http://localhost:{port} and enter the code\n");
 
-    // Open the cognitive-memory store ONCE and share that single handle across
-    // every request via the in-process writer registry. Standalone `dashboard
-    // serve` does not go through bootstrap/daemon assembly (which already do
-    // this), so without it each handler opens a *fresh* `LibraryCognitiveMemory`
-    // and the per-request open/drop/reopen cycle races the lbug store's
-    // exclusive lock — a reopen can read an empty board and a mutating handler
-    // then persists that empty board, silently losing every goal. The strong
-    // Arc is held for the lifetime of `serve` (i.e. the whole process).
+    // Open the cognitive-memory store ONCE and register it as the shared tier-0
+    // in-process writer, mirroring the OODA daemon and bootstrap assembly (which
+    // standalone `dashboard serve` does not go through). The launcher's tier-2
+    // store cache (#2334, closing the #2320 goal-board read-after-write race)
+    // already shares one handle per `state_root`, so this registration is
+    // defense-in-depth and architectural consistency: the dashboard owns its
+    // handle on the same tier-0 path the daemon uses instead of relying solely on
+    // the tier-2 fallback. The strong Arc is held for the lifetime of `serve`
+    // (i.e. the whole process) so the registry's `Weak` stays upgradeable.
     let state_root = routes::resolve_state_root();
     let _shared_writer = register_dashboard_shared_writer(&state_root);
 
@@ -146,14 +147,15 @@ pub fn serve(port: u16) -> Result<(), Box<dyn std::error::Error>> {
 /// as long as the dashboard serves requests.
 ///
 /// Mirrors the OODA daemon and bootstrap assembly, which open the library-backed
-/// store once and share one handle (the lbug store holds an exclusive lock for a
-/// handle's lifetime, so a second open of the same path within the process would
-/// fail). Sharing one handle makes dashboard reads and writes hit the same store
-/// — eliminating the fresh-open read-after-write race that otherwise lets a
-/// mutating handler persist an empty board and silently lose goals.
+/// store once and register one shared handle. Registering the dashboard's handle
+/// on the same tier-0 in-process path keeps dashboard reads and writes on one
+/// store. Same-process read-after-write consistency is also guaranteed by the
+/// launcher's tier-2 store cache (added in #2334 to close the #2320 race), so
+/// this tier-0 registration is defense-in-depth: it aligns the dashboard with
+/// the daemon/bootstrap rather than relying solely on the tier-2 fallback.
 ///
 /// Returns `None` (after logging) when the store cannot be opened, leaving
-/// handlers on their graceful direct-open fallback rather than failing to serve.
+/// handlers on their graceful tier-1/tier-2 fallback rather than failing to serve.
 pub(crate) fn register_dashboard_shared_writer(
     state_root: &Path,
 ) -> Option<Arc<dyn CognitiveMemoryOps>> {

--- a/src/operator_commands_dashboard/mod.rs
+++ b/src/operator_commands_dashboard/mod.rs
@@ -39,10 +39,12 @@ mod tests_routes_b;
 
 use std::net::SocketAddr;
 use std::path::Path;
+use std::sync::Arc;
 
+use crate::cognitive_memory::{CognitiveMemoryOps, LibraryCognitiveMemory};
 use crate::error::SimardResult;
 use crate::goal_curation::{GoalBoard, load_goal_board, save_goal_board};
-use crate::memory_ipc::{launch_writer_bridge, open_reader_bridge};
+use crate::memory_ipc::{launch_writer_bridge, open_reader_bridge, register_in_process_writer};
 
 /// Read the cognitive-memory `goal-board:snapshot` for the dashboard.
 ///
@@ -112,6 +114,17 @@ pub fn serve(port: u16) -> Result<(), Box<dyn std::error::Error>> {
     }
     eprintln!("  Open http://localhost:{port} and enter the code\n");
 
+    // Open the cognitive-memory store ONCE and share that single handle across
+    // every request via the in-process writer registry. Standalone `dashboard
+    // serve` does not go through bootstrap/daemon assembly (which already do
+    // this), so without it each handler opens a *fresh* `LibraryCognitiveMemory`
+    // and the per-request open/drop/reopen cycle races the lbug store's
+    // exclusive lock — a reopen can read an empty board and a mutating handler
+    // then persists that empty board, silently losing every goal. The strong
+    // Arc is held for the lifetime of `serve` (i.e. the whole process).
+    let state_root = routes::resolve_state_root();
+    let _shared_writer = register_dashboard_shared_writer(&state_root);
+
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()?;
@@ -126,4 +139,37 @@ pub fn serve(port: u16) -> Result<(), Box<dyn std::error::Error>> {
         axum::serve(listener, app).await?;
         Ok::<(), Box<dyn std::error::Error>>(())
     })
+}
+
+/// Open the dashboard's cognitive-memory store and register it as the shared
+/// in-process writer, returning the strong `Arc` the caller must keep alive for
+/// as long as the dashboard serves requests.
+///
+/// Mirrors the OODA daemon and bootstrap assembly, which open the library-backed
+/// store once and share one handle (the lbug store holds an exclusive lock for a
+/// handle's lifetime, so a second open of the same path within the process would
+/// fail). Sharing one handle makes dashboard reads and writes hit the same store
+/// — eliminating the fresh-open read-after-write race that otherwise lets a
+/// mutating handler persist an empty board and silently lose goals.
+///
+/// Returns `None` (after logging) when the store cannot be opened, leaving
+/// handlers on their graceful direct-open fallback rather than failing to serve.
+pub(crate) fn register_dashboard_shared_writer(
+    state_root: &Path,
+) -> Option<Arc<dyn CognitiveMemoryOps>> {
+    match LibraryCognitiveMemory::open(state_root) {
+        Ok(memory) => {
+            let writer: Arc<dyn CognitiveMemoryOps> = Arc::new(memory);
+            register_in_process_writer(state_root.to_path_buf(), Arc::clone(&writer));
+            Some(writer)
+        }
+        Err(error) => {
+            eprintln!(
+                "[simard] dashboard: cognitive memory unavailable at {} ({error}); \
+                 goal edits may not persist consistently across requests",
+                state_root.display()
+            );
+            None
+        }
+    }
 }

--- a/src/operator_commands_dashboard/tests_goals_crud.rs
+++ b/src/operator_commands_dashboard/tests_goals_crud.rs
@@ -665,8 +665,9 @@ async fn full_goal_lifecycle_crud() {
 /// save would persist that empty board, dropping every goal. That race is now
 /// prevented both by the shared tier-0 in-process writer the
 /// daemon/bootstrap/`dashboard serve` register and by the launcher's tier-2
-/// store cache (#2334); this test guards the handler-level persistence contract
-/// so a regression in either path is caught.
+/// store cache (#2334). With the tier-0 writer registered (as production does),
+/// every handler call short-circuits at tier-0, so this test guards the
+/// handler-level persistence contract on the tier-0 path the dashboard uses.
 #[tokio::test]
 #[serial_test::serial(cognitive_memory)]
 async fn repeated_handler_writes_never_silently_drop_goals() {

--- a/src/operator_commands_dashboard/tests_goals_crud.rs
+++ b/src/operator_commands_dashboard/tests_goals_crud.rs
@@ -4,35 +4,82 @@
 //! calls the async handler functions directly with constructed axum
 //! extractor wrappers.
 
+use std::sync::Arc;
+
 use axum::Json;
 use axum::extract::Path;
 use serde_json::json;
 
-use crate::cognitive_memory::LibraryCognitiveMemory;
+use crate::cognitive_memory::{CognitiveMemoryOps, LibraryCognitiveMemory};
 use crate::goal_curation::{GoalBoard, GoalProgress, save_goal_board};
+use crate::memory_ipc::{clear_in_process_writer, register_in_process_writer};
 use crate::operator_commands_dashboard::goals::*;
 use crate::operator_commands_dashboard::{
-    dashboard_goal_board_snapshot, dashboard_save_goal_board,
+    dashboard_goal_board_snapshot, dashboard_save_goal_board, register_dashboard_shared_writer,
 };
 use crate::test_support::HermeticState;
 
+/// Holds the single shared in-process cognitive-memory writer for the duration
+/// of a test and clears the global registration on drop (panic-safe).
+///
+/// Production wires the dashboard against ONE shared `LibraryCognitiveMemory`
+/// handle: the OODA daemon, bootstrap assembly, and standalone `dashboard serve`
+/// all open the store once and register it via [`register_in_process_writer`].
+/// These handler tests must mirror that. Without a shared handle every
+/// `launch_writer_bridge` / `open_reader_bridge` call opens a *fresh*
+/// `LibraryCognitiveMemory`; because the lbug store holds an exclusive lock for
+/// a handle's lifetime, a reopen races the previous handle's lock release / WAL
+/// checkpoint and can observe an empty store — making these tests flaky and
+/// diverging from the real production read-after-write path.
+struct SharedMemoryGuard {
+    writer: Arc<dyn CognitiveMemoryOps>,
+}
+
+impl SharedMemoryGuard {
+    fn register(state: &HermeticState) -> Self {
+        let writer: Arc<dyn CognitiveMemoryOps> = Arc::new(
+            LibraryCognitiveMemory::open(state.state_root()).expect("open shared cognitive memory"),
+        );
+        register_in_process_writer(state.state_root().to_path_buf(), Arc::clone(&writer));
+        Self { writer }
+    }
+
+    fn ops(&self) -> &dyn CognitiveMemoryOps {
+        self.writer.as_ref()
+    }
+}
+
+impl Drop for SharedMemoryGuard {
+    fn drop(&mut self) {
+        clear_in_process_writer();
+    }
+}
+
 /// Seed an empty goal board into the hermetic cognitive memory so handlers
 /// that read from it don't fail on a missing snapshot.
-fn init_empty_board(state: &HermeticState) {
-    let mem = LibraryCognitiveMemory::open(state.state_root()).expect("open native memory");
-    save_goal_board(&GoalBoard::new(), &mem).expect("seed empty board");
+///
+/// Returns the [`SharedMemoryGuard`] keeping the shared writer registered; the
+/// caller MUST bind it (`let _mem = init_empty_board(&state);`) so every handler
+/// call routes through the one shared handle.
+#[must_use]
+fn init_empty_board(state: &HermeticState) -> SharedMemoryGuard {
+    let guard = SharedMemoryGuard::register(state);
+    save_goal_board(&GoalBoard::new(), guard.ops()).expect("seed empty board");
+    guard
 }
 
 /// Seed a board with one active goal and one backlog item using the
 /// dashboard helpers (same read/write path the handlers use).
-fn init_board_with_goals(state: &HermeticState) {
-    // Step 1: initialize cognitive memory DB
-    {
-        let mem = LibraryCognitiveMemory::open(state.state_root()).expect("open native memory");
-        save_goal_board(&GoalBoard::new(), &mem).expect("init empty board");
-    }
+///
+/// Returns the [`SharedMemoryGuard`]; the caller MUST bind it so the shared
+/// writer stays registered for the life of the test.
+#[must_use]
+fn init_board_with_goals(state: &HermeticState) -> SharedMemoryGuard {
+    let guard = SharedMemoryGuard::register(state);
+    // Initialize the cognitive memory DB through the shared handle.
+    save_goal_board(&GoalBoard::new(), guard.ops()).expect("init empty board");
 
-    // Step 2: save the actual board through the dashboard helpers
+    // Save the actual board through the dashboard helpers (tier-0 shared writer).
     let mut board = GoalBoard::new();
     board.active.push(crate::goal_curation::ActiveGoal {
         id: "existing-goal".to_string(),
@@ -52,6 +99,7 @@ fn init_board_with_goals(state: &HermeticState) {
     });
 
     dashboard_save_goal_board(state.state_root(), &board).expect("seed board via dashboard helper");
+    guard
 }
 
 // ---------------------------------------------------------------------------
@@ -62,7 +110,7 @@ fn init_board_with_goals(state: &HermeticState) {
 #[serial_test::serial(cognitive_memory)]
 async fn seed_goals_creates_initial_goals() {
     let state = HermeticState::new();
-    init_empty_board(&state);
+    let _mem = init_empty_board(&state);
 
     let result = seed_goals().await;
     let val = &result.0;
@@ -86,7 +134,7 @@ async fn seed_goals_creates_initial_goals() {
 #[serial_test::serial(cognitive_memory)]
 async fn seed_goals_noop_when_already_seeded() {
     let state = HermeticState::new();
-    init_empty_board(&state);
+    let _mem = init_empty_board(&state);
     let _ = seed_goals().await;
 
     let result = seed_goals().await;
@@ -102,7 +150,7 @@ async fn seed_goals_noop_when_already_seeded() {
 #[serial_test::serial(cognitive_memory)]
 async fn add_goal_creates_active_goal() {
     let state = HermeticState::new();
-    init_empty_board(&state);
+    let _mem = init_empty_board(&state);
 
     let body = json!({"description": "A brand new goal", "priority": 2});
     let result = add_goal(Json(body)).await;
@@ -120,7 +168,7 @@ async fn add_goal_creates_active_goal() {
 #[serial_test::serial(cognitive_memory)]
 async fn add_goal_defaults_priority_to_3() {
     let state = HermeticState::new();
-    init_empty_board(&state);
+    let _mem = init_empty_board(&state);
 
     let body = json!({"description": "Goal without priority"});
     let _ = add_goal(Json(body)).await;
@@ -133,7 +181,7 @@ async fn add_goal_defaults_priority_to_3() {
 #[serial_test::serial(cognitive_memory)]
 async fn add_goal_rejects_empty_description() {
     let state = HermeticState::new();
-    init_empty_board(&state);
+    let _mem = init_empty_board(&state);
 
     let body = json!({"description": ""});
     let result = add_goal(Json(body)).await;
@@ -145,7 +193,7 @@ async fn add_goal_rejects_empty_description() {
 #[serial_test::serial(cognitive_memory)]
 async fn add_goal_rejects_missing_description() {
     let state = HermeticState::new();
-    init_empty_board(&state);
+    let _mem = init_empty_board(&state);
 
     let body = json!({"priority": 1});
     let result = add_goal(Json(body)).await;
@@ -161,7 +209,7 @@ async fn add_goal_rejects_missing_description() {
 #[serial_test::serial(cognitive_memory)]
 async fn add_goal_creates_backlog_item() {
     let state = HermeticState::new();
-    init_empty_board(&state);
+    let _mem = init_empty_board(&state);
 
     let body = json!({"description": "Backlog idea", "type": "backlog", "score": 0.7});
     let result = add_goal(Json(body)).await;
@@ -179,7 +227,7 @@ async fn add_goal_creates_backlog_item() {
 #[serial_test::serial(cognitive_memory)]
 async fn add_goal_backlog_defaults_score_to_half() {
     let state = HermeticState::new();
-    init_empty_board(&state);
+    let _mem = init_empty_board(&state);
 
     let body = json!({"description": "No score backlog", "type": "backlog"});
     let _ = add_goal(Json(body)).await;
@@ -196,10 +244,8 @@ async fn add_goal_backlog_defaults_score_to_half() {
 #[serial_test::serial(cognitive_memory)]
 async fn add_goal_rejects_when_at_max_active() {
     let state = HermeticState::new();
-    {
-        let mem = LibraryCognitiveMemory::open(state.state_root()).expect("open");
-        save_goal_board(&GoalBoard::new(), &mem).expect("init");
-    }
+    let mem = SharedMemoryGuard::register(&state);
+    save_goal_board(&GoalBoard::new(), mem.ops()).expect("init");
     let mut board = GoalBoard::new();
     for i in 0..crate::goal_curation::MAX_ACTIVE_GOALS {
         board.active.push(crate::goal_curation::ActiveGoal {
@@ -232,7 +278,7 @@ async fn add_goal_rejects_when_at_max_active() {
 #[serial_test::serial(cognitive_memory)]
 async fn remove_goal_removes_active_goal() {
     let state = HermeticState::new();
-    init_board_with_goals(&state);
+    let _mem = init_board_with_goals(&state);
 
     let result = remove_goal(Path("existing-goal".to_string())).await;
     assert_eq!(
@@ -245,7 +291,7 @@ async fn remove_goal_removes_active_goal() {
 #[serial_test::serial(cognitive_memory)]
 async fn remove_goal_removes_backlog_item() {
     let state = HermeticState::new();
-    init_board_with_goals(&state);
+    let _mem = init_board_with_goals(&state);
 
     let result = remove_goal(Path("backlog-item-1".to_string())).await;
     assert_eq!(
@@ -258,7 +304,7 @@ async fn remove_goal_removes_backlog_item() {
 #[serial_test::serial(cognitive_memory)]
 async fn remove_goal_returns_error_for_unknown_id() {
     let state = HermeticState::new();
-    init_board_with_goals(&state);
+    let _mem = init_board_with_goals(&state);
 
     let result = remove_goal(Path("nonexistent".to_string())).await;
     let val = &result.0;
@@ -273,7 +319,7 @@ async fn remove_goal_returns_error_for_unknown_id() {
 #[serial_test::serial(cognitive_memory)]
 async fn update_goal_status_transitions_to_completed() {
     let state = HermeticState::new();
-    init_board_with_goals(&state);
+    let _mem = init_board_with_goals(&state);
 
     let body = json!({"status": "completed"});
     let result = update_goal_status(Path("existing-goal".to_string()), Json(body)).await;
@@ -292,7 +338,7 @@ async fn update_goal_status_transitions_to_completed() {
 #[serial_test::serial(cognitive_memory)]
 async fn update_goal_status_blocked_with_reason() {
     let state = HermeticState::new();
-    init_board_with_goals(&state);
+    let _mem = init_board_with_goals(&state);
 
     let body = json!({"status": "blocked", "reason": "waiting on PR review"});
     let result = update_goal_status(Path("existing-goal".to_string()), Json(body)).await;
@@ -317,7 +363,7 @@ async fn update_goal_status_all_valid_statuses() {
     ];
     for status in valid {
         let state = HermeticState::new();
-        init_board_with_goals(&state);
+        let _mem = init_board_with_goals(&state);
         let body = json!({"status": status});
         let result = update_goal_status(Path("existing-goal".to_string()), Json(body)).await;
         assert_eq!(
@@ -331,7 +377,7 @@ async fn update_goal_status_all_valid_statuses() {
 #[serial_test::serial(cognitive_memory)]
 async fn update_goal_status_rejects_unknown_status() {
     let state = HermeticState::new();
-    init_board_with_goals(&state);
+    let _mem = init_board_with_goals(&state);
 
     let body = json!({"status": "bogus"});
     let result = update_goal_status(Path("existing-goal".to_string()), Json(body)).await;
@@ -347,7 +393,7 @@ async fn update_goal_status_rejects_unknown_status() {
 #[serial_test::serial(cognitive_memory)]
 async fn update_goal_status_requires_status_field() {
     let state = HermeticState::new();
-    init_board_with_goals(&state);
+    let _mem = init_board_with_goals(&state);
 
     let body = json!({"reason": "no status"});
     let result = update_goal_status(Path("existing-goal".to_string()), Json(body)).await;
@@ -358,7 +404,7 @@ async fn update_goal_status_requires_status_field() {
 #[serial_test::serial(cognitive_memory)]
 async fn update_goal_status_returns_error_for_nonexistent_goal() {
     let state = HermeticState::new();
-    init_board_with_goals(&state);
+    let _mem = init_board_with_goals(&state);
 
     let body = json!({"status": "completed"});
     let result = update_goal_status(Path("ghost".to_string()), Json(body)).await;
@@ -373,7 +419,7 @@ async fn update_goal_status_returns_error_for_nonexistent_goal() {
 #[serial_test::serial(cognitive_memory)]
 async fn promote_backlog_item_moves_to_active() {
     let state = HermeticState::new();
-    init_board_with_goals(&state);
+    let _mem = init_board_with_goals(&state);
 
     let result = promote_backlog_item(Path("backlog-item-1".to_string())).await;
     let val = &result.0;
@@ -399,7 +445,7 @@ async fn promote_backlog_item_moves_to_active() {
 #[serial_test::serial(cognitive_memory)]
 async fn promote_backlog_item_returns_error_when_not_found() {
     let state = HermeticState::new();
-    init_board_with_goals(&state);
+    let _mem = init_board_with_goals(&state);
 
     let result = promote_backlog_item(Path("no-such-item".to_string())).await;
     assert!(result.0["error"].as_str().unwrap().contains("not found"));
@@ -409,10 +455,8 @@ async fn promote_backlog_item_returns_error_when_not_found() {
 #[serial_test::serial(cognitive_memory)]
 async fn promote_backlog_item_rejects_when_at_max_active() {
     let state = HermeticState::new();
-    {
-        let mem = LibraryCognitiveMemory::open(state.state_root()).expect("open");
-        save_goal_board(&GoalBoard::new(), &mem).expect("init");
-    }
+    let mem = SharedMemoryGuard::register(&state);
+    save_goal_board(&GoalBoard::new(), mem.ops()).expect("init");
     let mut board = GoalBoard::new();
     for i in 0..crate::goal_curation::MAX_ACTIVE_GOALS {
         board.active.push(crate::goal_curation::ActiveGoal {
@@ -446,7 +490,7 @@ async fn promote_backlog_item_rejects_when_at_max_active() {
 #[serial_test::serial(cognitive_memory)]
 async fn demote_goal_moves_active_to_backlog() {
     let state = HermeticState::new();
-    init_board_with_goals(&state);
+    let _mem = init_board_with_goals(&state);
 
     let result = demote_goal(Path("existing-goal".to_string())).await;
     let val = &result.0;
@@ -464,7 +508,7 @@ async fn demote_goal_moves_active_to_backlog() {
 #[serial_test::serial(cognitive_memory)]
 async fn demote_goal_returns_error_when_not_found() {
     let state = HermeticState::new();
-    init_board_with_goals(&state);
+    let _mem = init_board_with_goals(&state);
 
     let result = demote_goal(Path("no-such-goal".to_string())).await;
     assert!(result.0["error"].as_str().unwrap().contains("not found"));
@@ -478,7 +522,7 @@ async fn demote_goal_returns_error_when_not_found() {
 #[serial_test::serial(cognitive_memory)]
 async fn goals_returns_active_and_backlog_lists() {
     let state = HermeticState::new();
-    init_board_with_goals(&state);
+    let _mem = init_board_with_goals(&state);
 
     let result = goals().await;
     let val = &result.0;
@@ -509,9 +553,8 @@ async fn goals_returns_active_and_backlog_lists() {
 #[serial_test::serial(cognitive_memory)]
 async fn goals_returns_empty_when_no_board() {
     let state = HermeticState::new();
-    {
-        let _mem = LibraryCognitiveMemory::open(state.state_root()).expect("open");
-    }
+    // Register the shared writer but seed no board — goals() must report empty.
+    let _mem = SharedMemoryGuard::register(&state);
 
     let result = goals().await;
     let val = &result.0;
@@ -522,10 +565,8 @@ async fn goals_returns_empty_when_no_board() {
 #[serial_test::serial(cognitive_memory)]
 async fn goals_includes_status_chip_for_active_goals() {
     let state = HermeticState::new();
-    {
-        let mem = LibraryCognitiveMemory::open(state.state_root()).expect("open");
-        save_goal_board(&GoalBoard::new(), &mem).expect("init");
-    }
+    let mem = SharedMemoryGuard::register(&state);
+    save_goal_board(&GoalBoard::new(), mem.ops()).expect("init");
     let mut board = GoalBoard::new();
     board.active.push(crate::goal_curation::ActiveGoal {
         id: "chip-test".to_string(),
@@ -558,7 +599,7 @@ async fn goals_includes_status_chip_for_active_goals() {
 #[serial_test::serial(cognitive_memory)]
 async fn full_goal_lifecycle_crud() {
     let state = HermeticState::new();
-    init_empty_board(&state);
+    let _mem = init_empty_board(&state);
 
     // 1. Seed initial goals
     let r = seed_goals().await;
@@ -610,3 +651,58 @@ async fn full_goal_lifecycle_crud() {
 }
 
 // -------------------------
+// Shared-writer wiring (regression for fresh-open goal-board data loss)
+// -------------------------
+
+/// Regression for the silent goal-board data-loss race, exercised through the
+/// real handler path (each `add_goal` does load→modify→save, exactly like the
+/// production dashboard). With the shared in-process writer registered — as the
+/// daemon, bootstrap, and standalone `dashboard serve` all do — every write
+/// must persist. Before the fix, dashboard handlers opened a *fresh*
+/// `LibraryCognitiveMemory` per call; the lbug store's exclusive per-handle lock
+/// meant a reopen could race the previous handle's release and read an empty
+/// board, after which the next save persisted that empty board and silently
+/// dropped every goal.
+#[tokio::test]
+#[serial_test::serial(cognitive_memory)]
+async fn repeated_handler_writes_never_silently_drop_goals() {
+    let state = HermeticState::new();
+    let _mem = init_empty_board(&state);
+
+    for i in 0..12 {
+        let r = add_goal(Json(json!({
+            "description": format!("Ship reliability fix for module {i}"),
+            "type": "backlog",
+        })))
+        .await;
+        assert_eq!(r.0["status"], "ok", "add_goal {i} must succeed");
+    }
+
+    let board = dashboard_goal_board_snapshot(state.state_root()).unwrap();
+    assert_eq!(
+        board.backlog.len(),
+        12,
+        "every goal added through the handler must persist (no silent drop)"
+    );
+}
+
+/// `register_dashboard_shared_writer` returns a live writer for a writable
+/// state root, and the registered handle services subsequent bridge opens.
+#[test]
+#[serial_test::serial(cognitive_memory)]
+fn register_dashboard_shared_writer_registers_usable_handle() {
+    let state = HermeticState::new();
+    let writer = register_dashboard_shared_writer(state.state_root());
+    assert!(
+        writer.is_some(),
+        "a fresh hermetic state root must yield a usable cognitive-memory writer"
+    );
+
+    // The registered writer must serve a save+read through the dashboard path.
+    dashboard_save_goal_board(state.state_root(), &GoalBoard::new()).expect("save via shared");
+    let board = dashboard_goal_board_snapshot(state.state_root()).expect("read via shared");
+    assert!(board.active.is_empty());
+
+    drop(writer);
+    clear_in_process_writer();
+}

--- a/src/operator_commands_dashboard/tests_goals_crud.rs
+++ b/src/operator_commands_dashboard/tests_goals_crud.rs
@@ -23,14 +23,17 @@ use crate::test_support::HermeticState;
 /// of a test and clears the global registration on drop (panic-safe).
 ///
 /// Production wires the dashboard against ONE shared `LibraryCognitiveMemory`
-/// handle: the OODA daemon, bootstrap assembly, and standalone `dashboard serve`
-/// all open the store once and register it via [`register_in_process_writer`].
-/// These handler tests must mirror that. Without a shared handle every
-/// `launch_writer_bridge` / `open_reader_bridge` call opens a *fresh*
-/// `LibraryCognitiveMemory`; because the lbug store holds an exclusive lock for
-/// a handle's lifetime, a reopen races the previous handle's lock release / WAL
-/// checkpoint and can observe an empty store — making these tests flaky and
-/// diverging from the real production read-after-write path.
+/// handle registered as the tier-0 in-process writer: the OODA daemon, bootstrap
+/// assembly, and standalone `dashboard serve` all open the store once and
+/// register it via [`register_in_process_writer`]. These handler tests mirror
+/// that tier-0 wiring so they exercise the same read/write path production uses.
+///
+/// Same-process read-after-write consistency is also guaranteed at the
+/// launcher's tier-2 store cache (`shared_tier2_store`, added in #2334 to close
+/// the #2320 goal-board read-after-write race), so the handlers persist
+/// correctly even without an explicit tier-0 registration. Registering the
+/// shared writer here keeps the tests aligned with the production tier-0 path
+/// rather than silently relying on the tier-2 fallback.
 struct SharedMemoryGuard {
     writer: Arc<dyn CognitiveMemoryOps>,
 }
@@ -654,15 +657,16 @@ async fn full_goal_lifecycle_crud() {
 // Shared-writer wiring (regression for fresh-open goal-board data loss)
 // -------------------------
 
-/// Regression for the silent goal-board data-loss race, exercised through the
-/// real handler path (each `add_goal` does load→modify→save, exactly like the
-/// production dashboard). With the shared in-process writer registered — as the
-/// daemon, bootstrap, and standalone `dashboard serve` all do — every write
-/// must persist. Before the fix, dashboard handlers opened a *fresh*
-/// `LibraryCognitiveMemory` per call; the lbug store's exclusive per-handle lock
-/// meant a reopen could race the previous handle's release and read an empty
-/// board, after which the next save persisted that empty board and silently
-/// dropped every goal.
+/// Exercises the real handler path (each `add_goal` does load→modify→save,
+/// exactly like the production dashboard) and asserts every write persists with
+/// no silent drop. The silent goal-board data-loss class (#1590 / #2320) came
+/// from per-call fresh `LibraryCognitiveMemory` opens racing the lbug store's
+/// exclusive per-handle lock: a reopen could read an empty board and the next
+/// save would persist that empty board, dropping every goal. That race is now
+/// prevented both by the shared tier-0 in-process writer the
+/// daemon/bootstrap/`dashboard serve` register and by the launcher's tier-2
+/// store cache (#2334); this test guards the handler-level persistence contract
+/// so a regression in either path is caught.
 #[tokio::test]
 #[serial_test::serial(cognitive_memory)]
 async fn repeated_handler_writes_never_silently_drop_goals() {

--- a/tests/qa-scenarios/dashboard-goal-persistence.yaml
+++ b/tests/qa-scenarios/dashboard-goal-persistence.yaml
@@ -1,0 +1,11 @@
+name: simard-dashboard-goal-persistence
+app_type: cli
+description: Standalone dashboard persists goals across multiple HTTP requests (no silent data loss)
+steps:
+  - action: run
+    command: "bash scripts/qa-dashboard-goal-persistence.sh"
+    timeout: 180s
+  - action: expect_stdout
+    contains: "QA-DASHBOARD-GOALS: PASS"
+  - action: expect_exit_code
+    code: 0

--- a/tests/qa-scenarios/dashboard-goal-persistence.yaml
+++ b/tests/qa-scenarios/dashboard-goal-persistence.yaml
@@ -1,11 +1,38 @@
+# Canonical agentic-test schema (name + agents[] + steps[] with params).
+#
+# The installed `gadugi-test` / `@gadugi/agentic-test` binary validates and runs
+# scenarios through `ScenarioLoader` (canonical format), which requires a `name`,
+# a `steps` array, and a non-empty `agents` array. A single `cli` agent runs the
+# hermetic regression script; the agent's command runner treats a non-zero exit
+# code as a step failure, so the script's own `exit 1` on any lost goal makes
+# this a real pass/fail gate (not a cosmetic assertion).
+#
+# This file doubles as the reusable canonical exemplar for the repo's other
+# qa scenarios, which still use the older `app_type` + `steps` shape the
+# installed binary rejects ("Scenario must have at least one agent").
 name: simard-dashboard-goal-persistence
-app_type: cli
-description: Standalone dashboard persists goals across multiple HTTP requests (no silent data loss)
+description: >-
+  Standalone dashboard persists goals across multiple HTTP requests
+  (no silent goal-board data loss).
+version: "1.0"
+config:
+  timeout: 240000
+environment:
+  requires: []
+agents:
+  - name: cli-agent
+    type: cli
+    config: {}
+metadata:
+  tags:
+    - cli
+  priority: high
 steps:
-  - action: run
-    command: "bash scripts/qa-dashboard-goal-persistence.sh"
-    timeout: 180s
-  - action: expect_stdout
-    contains: "QA-DASHBOARD-GOALS: PASS"
-  - action: expect_exit_code
-    code: 0
+  - name: Run the standalone dashboard goal-persistence regression script
+    agent: cli-agent
+    action: run
+    params:
+      command: bash
+      args:
+        - scripts/qa-dashboard-goal-persistence.sh
+    timeout: 240000


### PR DESCRIPTION
## Summary

Adds standalone-dashboard goal-board persistence hardening plus the regression
coverage and a runnable qa scenario for it.

**History / honest scoping.** This branch was originally cut against base
`83c06f5a`, where `simard dashboard serve` and the goal-CRUD handler tests opened
a **fresh** `LibraryCognitiveMemory` handle per request/call. Because the
lbug-backed store holds an exclusive lock for a handle's lifetime, the
per-request open→drop→reopen cycle raced the previous handle's lock release / WAL
checkpoint: a reopen could read an **empty board**, `load_board_or_empty()`
silently folded the error into the empty default, and the next mutating handler
persisted that empty board — **dropping every goal** (the #1590 silent-degradation
class, re-surfaced on the read-after-write path by the #2308 de-fork). At that
base the fix was load-bearing and de-flaked `full_goal_lifecycle_crud` (~80% fail
→ 30/30).

Since then, **`main` gained the launcher's tier-2 store cache via #2334**
("fix(cog-mem): end goal-board read-after-write race, closes #2320/#2316"), which
shares one `LibraryCognitiveMemory` handle per canonical `state_root` for all
same-process callers and **already prevents this data loss**. After rebasing this
branch onto current `main`, the dashboard's `serve()` change is therefore
**defense-in-depth + architectural consistency**, not the sole correctness fix —
it registers the dashboard's handle on the same **tier-0** in-process path the
OODA daemon and bootstrap assembly already use, so the dashboard owns its handle
rather than relying solely on the tier-2 fallback. The docstrings, code comments,
and qa-script header were rewritten to state this accurately (see audit cycle 1).

## Changes (4 files, focused on the dashboard goal-board persistence seam)

- **`src/operator_commands_dashboard/mod.rs`** — `serve()` opens the cognitive-memory
  store once and registers it as the shared **tier-0** in-process writer
  (`register_dashboard_shared_writer`), holding the strong `Arc` for the process
  lifetime (the registry stores a `Weak`). Graceful `None` fallback (logged) when
  the store can't open — e.g. a daemon already holds the lbug lock → handlers use
  the IPC/tier-2 ladder. Mirrors `daemon/mod.rs` and `bootstrap/assembly.rs`.
- **`src/operator_commands_dashboard/tests_goals_crud.rs`** — `SharedMemoryGuard`
  RAII registers/clears the shared writer (panic-safe), seed helpers return it
  (`#[must_use]`), all call sites bind it, 6 manual fresh-open tests converted,
  2 handler-level persistence regression tests added.
- **`scripts/qa-dashboard-goal-persistence.sh`** — hermetic end-to-end check:
  drives a real standalone dashboard through seed → add → promote → read across
  separate HTTP requests and asserts no goal is lost (`HOME`/`SIMARD_STATE_ROOT`
  pinned into a temp root).
- **`tests/qa-scenarios/dashboard-goal-persistence.yaml`** — gadugi-test scenario
  in the installed binary's canonical schema.

## Merge-readiness evidence

### (1) qa-team scenario — `gadugi-test validate` + `run` (real output)

The installed `gadugi-test` / `@gadugi/agentic-test` v1.0.0 loads scenarios through
`ScenarioLoader`'s **canonical** schema (`name` + non-empty `agents[]` + `steps[]`
with `params`). The repo's other 9 scenarios use the older `app_type` shape the
binary rejects ("Scenario must have at least one agent"); this scenario was
rewritten to the canonical schema (one `cli` agent runs the hermetic script as a
`run` step — a non-zero exit is a real step failure), and is the reusable
exemplar for the others.

```
$ gadugi-test validate -f tests/qa-scenarios/dashboard-goal-persistence.yaml
ℹ Validating scenarios...
✓ Scenario "simard-dashboard-goal-persistence" is valid
Validation Results:
✓ Valid files: 1
✗ Invalid files: 0
✓ All 1 file(s) are valid

$ gadugi-test run -s dashboard-goal-persistence -d tests/qa-scenarios --timeout 300000
ℹ Loading scenario: tests/qa-scenarios/dashboard-goal-persistence.yaml
✓ Loaded 1 scenario(s)
...
[STDOUT] QA-DASHBOARD-GOALS: PASS - 4 active goals persisted across 4 HTTP requests
Command completed with exit code 0 (duration 28869 ms)

Test Execution Results:
✓ Passed: 1
✗ Failed: 0
- Total: 1
✓ All tests passed!
```

### (2) Docs / surfaces — internal-only

No user-facing surface changes: `dashboard serve` keeps the same flags and output.
Changed surfaces are internal: dashboard goal-board persistence wiring (`serve()`
registers one tier-0 cognitive-memory handle), the handler tests, and a new qa
scenario. Internal correctness/hardening change; no doc update required.

### (3) Quality audit — 3 SEEK→VALIDATE→FIX cycles, ended clean

- **Cycle 1 — FINDINGS (1 HIGH, test-quality):** after the rebase onto
  post-#2334 `main`, the docstrings/comments/qa-header overstated the fix
  (claimed handlers still open a fresh handle per request and that `serve()`'s
  registration is the sole fix — both false once tier-2 exists). **Fixed in
  `9d54175e`**: reframed the tier-0 registration as defense-in-depth and corrected
  every stale claim.
- **Cycle 2 — CLEAN (2 LOW, diagnostic accuracy):** verified no double-open of the
  lbug DB (tier-0 short-circuits before tier-2 for the dashboard `state_root`),
  graceful daemon-present fallback (non-blocking `F_WRLCK` → `Err` → `None` →
  tier-1 IPC, no hang/panic), and no durability regression vs. the tier-2-only
  path. **Fixed in `236ffa78`**: softened the open-failure log and scoped a test
  docstring to the tier-0 path it actually exercises.
- **Cycle 3 — CLEAN (zero findings):** final pass over the four files confirmed
  every docstring/comment is factually accurate against the launcher tier model,
  the diff is coherent and focused, Arc/`Weak` lifetime and graceful fallback are
  correct, and the tests/qa-script/yaml have no false-negative path.

Final clean cycle ran against `236ffa78` (zero critical/high; zero medium
correctness/security findings).

### (4) CI

Green required on the post-rebase head `236ffa78`. CI run:
https://github.com/rysweet/Simard/actions/runs/27936200780
(fmt/clippy run in the `pre-commit` job; tests in `coverage`/`install-real`;
`e2e-dashboard` exercises the dashboard.)

### (6) Focused diff

Scoped to exactly 4 files — the dashboard goal-board persistence seam, its tests,
and one qa scenario + yaml. The earlier sibling PTY-session test commit
(`f2fbef72`) was **rebased out** so the diff is confined to this change; verified
no `src/terminal_session/session.rs` (or any other unrelated file) appears in
`git diff origin/main...HEAD`.
