### PR TITLE
fix(dashboard): parse-guard renderCostTrace title attribute (#2351)

### DIFF
--- a/src/operator_commands_dashboard/index_html/part_03.rs
+++ b/src/operator_commands_dashboard/index_html/part_03.rs
@@ -153,11 +153,15 @@ pub(crate) const PART_03: &str = r#"        const d=await apiFetch('/api/goals')
       return String(id).replace(/^session-/,'').slice(0,8);
     }
     /* A single cost-ledger trace row: When (relative+absolute), What
-       (call type / model / tokens / cost), and Who (context + session). */
+       (call type / model / tokens / cost), and Who (context + session).
+       `abs` is parse-guarded (mirrors renderGenericTrace) so formatTime's
+       raw-passthrough branch can never feed an unescaped quote into the
+       double-quoted `title` attribute below (#2351). */
     function renderCostTrace(data){
       data=data||{};
+      const parsed=parseTs(data.timestamp);
       const when=data.timestamp?timeAgo(data.timestamp):'—';
-      const abs=data.timestamp?formatTime(data.timestamp):'';
+      const abs=parsed?formatTime(data.timestamp):'';
       const pt=Number(data.prompt_tokens_est)||0;
       const ct=Number(data.completion_tokens_est)||0;
       const total=pt+ct;

--- a/src/operator_commands_dashboard/tests_routes_a.rs
+++ b/src/operator_commands_dashboard/tests_routes_a.rs
@@ -852,6 +852,49 @@ mod tests {
         );
     }
 
+    /// Defense-in-depth (#2351): the cost row's hover `title` is a
+    /// double-quoted HTML attribute fed by `abs`. `esc()` escapes
+    /// `&<>` (element-content safe) but NOT `"`, so a quote-bearing
+    /// `abs` would break out of the attribute. `formatTime` only ever
+    /// returns its raw input on a parse failure, so `abs` MUST be
+    /// guarded by a successful `parseTs` (mirroring `renderGenericTrace`)
+    /// — never assigned unconditionally from `formatTime`. This makes
+    /// the raw-passthrough branch unreachable in the attribute context.
+    #[test]
+    fn index_html_cost_trace_title_attr_is_parse_guarded() {
+        let body = js_fn_body("function renderCostTrace(data){");
+        // The absolute timestamp must be computed up front via parseTs…
+        assert!(
+            body.contains("parseTs(data.timestamp)"),
+            "renderCostTrace must normalise the timestamp via parseTs so the \
+             title-attribute value can be parse-guarded — body: {body:?}"
+        );
+        // …and `abs` must only call formatTime when the parse succeeded,
+        // exactly like renderGenericTrace. The unguarded form
+        // `abs=data.timestamp?formatTime(...)` would let a raw, unparseable
+        // (possibly quote-bearing) timestamp reach the title attribute.
+        assert!(
+            body.contains("const abs=parsed?formatTime(data.timestamp):''"),
+            "renderCostTrace must guard `abs` with the parse result \
+             (`const abs=parsed?formatTime(data.timestamp):''`) so formatTime's \
+             raw-input passthrough can never feed an unescaped quote into the \
+             double-quoted title attribute (#2351) — body: {body:?}"
+        );
+        assert!(
+            !body.contains("const abs=data.timestamp?formatTime"),
+            "renderCostTrace must NOT assign `abs` directly from formatTime on a \
+             truthy-but-unparsed timestamp — that is the #2351 attribute-injection \
+             gap. body: {body:?}"
+        );
+        // The title attribute itself is still double-quoted and fed by `abs`,
+        // so the guard above is what keeps it safe.
+        assert!(
+            body.contains(r#"'<span title="'+esc(abs)+'"#),
+            "the cost-row hover title must remain a double-quoted attribute fed by \
+             the parse-guarded `abs` — body: {body:?}"
+        );
+    }
+
     /// The fmtCostUsd helper keeps sub-cent estimates meaningful (4 dp)
     /// while showing larger amounts at 2 dp.
     #[test]

--- a/tests/gadugi/dashboard-traces-cost-title-escaping.sh
+++ b/tests/gadugi/dashboard-traces-cost-title-escaping.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# dashboard-traces-cost-title-escaping.sh — outside-in check for issue #2351.
+#
+# The Traces tab's cost rows render an absolute timestamp into a *double-quoted*
+# HTML `title` attribute:  '<span title="'+esc(abs)+'" …>'. The shared esc()
+# helper escapes &<> (element-content safe) but NOT the double-quote character,
+# so a quote-bearing `abs` would break out of the attribute. `formatTime` only
+# returns its raw input on a parse failure, so the attribute is only safe if
+# `abs` is guarded by a successful parse — exactly the guard renderGenericTrace
+# already uses. PR #2345 left renderCostTrace assigning `abs` directly from
+# formatTime on any truthy timestamp; #2351 hardens it to mirror the guard.
+#
+# This script boots the real dashboard binary, logs in, and asserts against the
+# served HTML that renderCostTrace:
+#   * normalises the timestamp up front via parseTs, and
+#   * only calls formatTime when the parse succeeded (parsed ? … : ''), so the
+#     raw-passthrough branch can never reach the double-quoted title attribute,
+# while the readable cost-row contract from #1682/#2345 stays intact.
+set -euo pipefail
+
+PORT="${DASH_PORT:-8142}"
+DASHKEY_FILE="${HOME}/.simard/.dashkey"
+LOG="$(mktemp -t dash-title-esc.XXXXXX.log)"
+CJ="$(mktemp -t dash-title-esc-cookies.XXXXXX)"
+
+echo "[title-esc] building simard binary…"
+cargo build --quiet --bin simard
+BIN="${CARGO_TARGET_DIR:-target}/debug/simard"
+if [[ ! -x "$BIN" ]]; then
+  echo "[title-esc] FAIL: built binary not found at $BIN" >&2
+  exit 1
+fi
+
+echo "[title-esc] starting dashboard on :$PORT"
+"$BIN" dashboard serve --port="$PORT" >"$LOG" 2>&1 &
+DASH_PID=$!
+cleanup() { kill "$DASH_PID" 2>/dev/null || true; rm -f "$CJ"; }
+trap cleanup EXIT
+
+# Wait for the server to accept connections.
+up=0
+for _ in $(seq 1 30); do
+  if curl -s -o /dev/null "http://localhost:$PORT/login"; then up=1; break; fi
+  sleep 1
+done
+if [[ "$up" -ne 1 ]]; then
+  echo "[title-esc] FAIL: dashboard did not come up on :$PORT" >&2
+  cat "$LOG" >&2
+  exit 1
+fi
+
+KEY="$(cat "$DASHKEY_FILE")"
+if ! curl -s -c "$CJ" -X POST -H 'Content-Type: application/json' \
+      -d "{\"code\":\"$KEY\"}" "http://localhost:$PORT/api/login" | grep -q '"ok":true'; then
+  echo "[title-esc] FAIL: login rejected" >&2
+  exit 1
+fi
+
+HTML="$(curl -s -b "$CJ" "http://localhost:$PORT/")"
+
+fail() { echo "[title-esc] FAIL: $1" >&2; exit 1; }
+
+# ── The cost renderer must exist and still feed `abs` into a quoted title ─────
+grep -qF 'function renderCostTrace(data)' <<<"$HTML" \
+  || fail "renderCostTrace(data) helper must exist"
+grep -qF "'<span title=\"'+esc(abs)+'\"" <<<"$HTML" \
+  || fail "cost rows must render the absolute time into a double-quoted title attribute fed by abs"
+
+# ── #2351 guard: `abs` is parse-guarded, never assigned directly from a ───────
+#    truthy-but-unparsed timestamp (which could carry a literal double-quote).
+grep -qF 'const parsed=parseTs(data.timestamp)' <<<"$HTML" \
+  || fail "renderCostTrace must normalise the timestamp via parseTs before computing abs (#2351)"
+grep -qF "const abs=parsed?formatTime(data.timestamp):''" <<<"$HTML" \
+  || fail "renderCostTrace must guard abs with the parse result so formatTime's raw-input passthrough cannot reach the title attribute (#2351)"
+if grep -qF "const abs=data.timestamp?formatTime(data.timestamp)" <<<"$HTML"; then
+  fail "renderCostTrace must NOT assign abs directly from formatTime on a truthy-but-unparsed timestamp — that is the #2351 attribute-injection gap"
+fi
+
+# ── Regression guard: the readable cost-row contract (#1682/#2345) is intact ──
+grep -qF 'timeAgo(data.timestamp)' <<<"$HTML" \
+  || fail "cost rows must still render relative time via timeAgo (#1682)"
+grep -qF 'fmtCostUsd(data.cost_usd_est)' <<<"$HTML" \
+  || fail "cost rows must still show the estimated dollar cost (#1682)"
+
+echo "[title-esc] PASS: renderCostTrace title attribute is parse-guarded (#2351)"

--- a/tests/gadugi/dashboard-traces-cost-title-escaping.yaml
+++ b/tests/gadugi/dashboard-traces-cost-title-escaping.yaml
@@ -1,0 +1,54 @@
+name: "Dashboard Traces-Tab Cost Title-Attribute Escaping (#2351)"
+description: "Outside-in defense-in-depth check that the Traces tab's cost renderer cannot break out of the double-quoted title attribute. Boots the real dashboard binary, authenticates, and asserts the served HTML guards the absolute-timestamp value (`abs`) behind a successful parseTs — mirroring renderGenericTrace — so formatTime's raw-input passthrough can never feed an unescaped double-quote into the title attribute, while keeping the readable cost-row contract from #1682/#2345 intact."
+version: "1.0.0"
+
+config:
+  timeout: 300000
+  retries: 0
+  parallel: false
+
+environment:
+  requires: []
+
+agents:
+  - name: "cli-agent"
+    type: "cli"
+    config:
+      workingDirectory: "."
+      defaultTimeout: 300000
+      executionMode: "spawn"
+      captureOutput: true
+      ioConfig:
+        encoding: "utf8"
+        handleInteractivePrompts: false
+      logConfig:
+        logCommands: true
+        logOutput: true
+        logLevel: "info"
+
+steps:
+  - name: "Cost-row title attribute is parse-guarded (no quote break-out)"
+    agent: "cli-agent"
+    action: "execute_command"
+    params:
+      command: "tests/gadugi/dashboard-traces-cost-title-escaping.sh"
+    timeout: 300000
+
+assertions: []
+
+cleanup:
+  - name: "CLI agent cleanup"
+    agent: "cli-agent"
+    action: "cleanup"
+
+metadata:
+  tags:
+    - "dashboard"
+    - "traces"
+    - "cost"
+    - "security"
+    - "escaping"
+    - "issue-2351"
+  priority: "high"
+  author: "copilot"
+  test_type: "outside-in"


### PR DESCRIPTION
Closes #2351.

## Problem

The Traces-tab cost renderer (`renderCostTrace`, `part_03.rs`) writes the absolute timestamp into a **double-quoted HTML `title` attribute**:

```js
const whenHtml='<span title="'+esc(abs)+'" ...>'+esc(when)+'</span>';
```

`esc()` escapes `&`, `<`, `>` via `textContent` — correct for *element-content* context — but it does **not** escape `"`. Here `esc(abs)` lands inside a double-quoted attribute. Because `formatTime()` returns its **raw input** when `parseTs` fails, a quote-bearing timestamp would break out of the `title` attribute.

This was **not reachable today** (cost-ledger timestamps are strict RFC3339 written by `cost_tracking.rs`, which always parse and yield `toLocaleString()` — never a `"`). This PR is the defense-in-depth hardening so the renderer stays robust if the ledger timestamp format ever loosens.

## Change

Mirror `renderGenericTrace`'s existing guard — compute the parse result up front and only call `formatTime` when it succeeds:

```js
const parsed=parseTs(data.timestamp);
const when=data.timestamp?timeAgo(data.timestamp):'—';
const abs=parsed?formatTime(data.timestamp):'';   // was: data.timestamp?formatTime(...)
```

Now `abs` is only ever a successfully-parsed, formatted timestamp (no quotes possible) or `''`, making `formatTime`'s raw-passthrough branch **unreachable** in the attribute context. `when` is unchanged — it lands in element-content (`esc(when)` between `>...<`), where quotes are harmless.

## Merge-ready evidence

### 1. qa-team / gadugi scenarios — written, validated, run ✅
New outside-in scenario `tests/gadugi/dashboard-traces-cost-title-escaping.{yaml,sh}` boots the real dashboard binary, authenticates with the dashkey, and asserts the served HTML guards `abs` behind `parseTs` while keeping the readable cost-row contract (#1682/#2345) intact.

```
$ gadugi-test validate -f tests/gadugi/dashboard-traces-cost-title-escaping.yaml
✓ Scenario "Dashboard Traces-Tab Cost Title-Attribute Escaping (#2351)" is valid
✓ All 1 file(s) are valid

$ gadugi-test run -d tests/gadugi -s dashboard-traces-cost-title-escaping
Command completed with exit code 0 (duration 25296ms)
Test Execution Results:  ✓ Passed: 1   ✗ Failed: 0   ✓ All tests passed!
```

### 2. Docs / changed surfaces — internal-only justification ✅
No user-facing API, CLI, or doc surface changes. The edit is **dashboard-internal JavaScript** embedded in a Rust string literal. The rendered `title` hover-tooltip is visually identical for all valid (parseable) timestamps; only the unreachable raw-passthrough branch is closed. No docs update required.

### 3. quality-audit — 3 SEEK→VALIDATE→FIX cycles, clean final ✅
Reviewed at commit `98e89b15`. (Performed as manual multi-pass review — the workflow skill is not invoked inside this recipe-managed session.)
- **Cycle 1 — correctness:** `abs` is the only dynamic attribute value in the renderer (all other attributes are static `style="…"`). With the guard, `abs ∈ { toLocaleString() output, '' }` — neither can contain `"`. `when` is element-content, so its `timeAgo` raw-passthrough is harmless. SEEK found the attribute fully closed; no fix needed.
- **Cycle 2 — test quality:** Added a negative-assertion contract test (asserts the guarded form present AND the vulnerable form absent). **Verified it fails without the fix** (reverted the line → test panicked with the #2351 message → restored). gadugi adds a served-HTML layer. No fix needed.
- **Cycle 3 — security & scope:** Defense-in-depth only; no new attack surface; diff limited to the one renderer + its tests. Clean final cycle: zero critical/high, zero medium correctness/security findings.

### 4. CI green ✅
All checks green on this PR (run https://github.com/rysweet/Simard/actions/runs/27930516939): `pre-commit` ✅, `coverage` ✅, `e2e-dashboard` ✅ (Playwright structural + tab-identity), `install-real` ✅, `cargo-audit` ✅, GitGuardian ✅.

Local equivalents, run before push:
- `scripts/check-rust-only-gate.sh` → passed (no new .py/.js/.ts)
- `cargo fmt -- --check` → passed
- `cargo clippy --release --no-deps -- -D warnings` (pre-commit) → passed
- `cargo clippy --all-targets --all-features --locked -- -D warnings` (pre-push) → passed
- `cargo test` dashboard modules → 69 passed, 0 failed (incl. new `index_html_cost_trace_title_attr_is_parse_guarded`)

### 6. Focused diff ✅
2 source files + 2 test fixtures; `+49 / -2` in source. No unrelated edits.

| File | Change |
|------|--------|
| `src/operator_commands_dashboard/index_html/part_03.rs` | parse-guard `abs` (+ explanatory comment) |
| `src/operator_commands_dashboard/tests_routes_a.rs` | contract test |
| `tests/gadugi/dashboard-traces-cost-title-escaping.{yaml,sh}` | outside-in scenario |

