### PR TITLE
test(ooda): cover engineer-lifecycle spawn helpers and starttime guard (#1735)

### DIFF
--- a/src/ooda_actions/advance_goal/spawn.rs
+++ b/src/ooda_actions/advance_goal/spawn.rs
@@ -619,3 +619,139 @@ fn numeric_kill(pid: i32) -> std::io::Result<()> {
         Err(std::io::Error::last_os_error())
     }
 }
+
+// ─────────────────────────── Tests ───────────────────────────
+//
+// Unit coverage for the deterministic *private* helpers in this module that
+// previously had none: `build_engineer_name`, `truncate_for_log`, and
+// `read_sentinel_pid`. Being module-private, these can only be exercised from
+// an in-file `#[cfg(test)]` block. Every test is hermetic — pure string logic
+// or a `tempfile` sentinel — and never mutates process-global state, so they
+// are safe under cargo's default parallel runner.
+//
+// The public surface (`is_brain_failure_marker`, `dispatch_spawn_engineer`,
+// and `find_live_engineer_for_goal` including its starttime-guard branches) is
+// covered by `src/ooda_actions/tests_advance_goal.rs`.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engineer_worktree::ENGINEER_CLAIM_FILE;
+    use std::fs;
+    use std::path::Path;
+
+    // ── build_engineer_name ────────────────────────────────────────────────
+
+    #[test]
+    fn build_engineer_name_has_prefix_and_epoch_suffix() {
+        let name = build_engineer_name("improve-test-coverage");
+        let suffix = name
+            .strip_prefix("engineer-improve-test-coverage-")
+            .expect("name must start with `engineer-<goal>-`");
+        // The trailing component is a unix-epoch second count.
+        suffix
+            .parse::<u64>()
+            .expect("epoch suffix must parse as u64");
+    }
+
+    #[test]
+    fn build_engineer_name_handles_empty_goal_id() {
+        // Degenerate but must not panic: empty goal id yields the double dash.
+        let name = build_engineer_name("");
+        assert!(
+            name.starts_with("engineer--"),
+            "empty goal id should render `engineer--<epoch>`, got {name:?}"
+        );
+        name.strip_prefix("engineer--")
+            .and_then(|s| s.parse::<u64>().ok())
+            .expect("epoch suffix must parse even with empty goal id");
+    }
+
+    // ── truncate_for_log ───────────────────────────────────────────────────
+
+    #[test]
+    fn truncate_for_log_passes_short_strings_through_unchanged() {
+        let s = "a short, safe log line";
+        assert_eq!(truncate_for_log(s), s);
+    }
+
+    #[test]
+    fn truncate_for_log_passes_exactly_max_length_unchanged() {
+        // 256 ASCII bytes is the inclusive boundary — must be returned as-is
+        // with no ellipsis appended.
+        let s = "x".repeat(256);
+        let out = truncate_for_log(&s);
+        assert_eq!(out, s);
+        assert!(!out.ends_with('…'));
+    }
+
+    #[test]
+    fn truncate_for_log_truncates_and_appends_ellipsis_for_ascii() {
+        let s = "y".repeat(300);
+        let out = truncate_for_log(&s);
+        assert!(out.ends_with('…'), "truncated output must end with U+2026");
+        // 256 retained bytes + 3-byte ellipsis.
+        assert_eq!(out.len(), 256 + '…'.len_utf8());
+        assert_eq!(out.chars().count(), 257);
+    }
+
+    #[test]
+    fn truncate_for_log_respects_utf8_char_boundaries() {
+        // '€' is 3 bytes; byte index 256 falls in the middle of a char, so the
+        // cut must back off to byte 255 (85 whole chars) rather than panic.
+        let s = "€".repeat(100);
+        assert_eq!(s.len(), 300);
+        let out = truncate_for_log(&s);
+        assert!(out.ends_with('…'));
+        // 85 retained '€' chars + the ellipsis. The result is valid UTF-8 by
+        // construction (it is a `String`); the assertion guards the off-by-one
+        // boundary back-off in the loop.
+        assert_eq!(out.chars().count(), 86);
+        assert_eq!(out, format!("{}…", "€".repeat(85)));
+    }
+
+    // ── read_sentinel_pid ──────────────────────────────────────────────────
+
+    fn write_claim(dir: &Path, contents: &str) {
+        fs::create_dir_all(dir).unwrap();
+        fs::write(dir.join(ENGINEER_CLAIM_FILE), contents).unwrap();
+    }
+
+    #[test]
+    fn read_sentinel_pid_reads_first_line_with_starttime() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_claim(tmp.path(), "12345\n9876543\n");
+        assert_eq!(read_sentinel_pid(tmp.path()), Some(12345));
+    }
+
+    #[test]
+    fn read_sentinel_pid_reads_pid_only_sentinel() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_claim(tmp.path(), "777\n");
+        assert_eq!(read_sentinel_pid(tmp.path()), Some(777));
+    }
+
+    #[test]
+    fn read_sentinel_pid_trims_whitespace() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_claim(tmp.path(), "  42  \n");
+        assert_eq!(read_sentinel_pid(tmp.path()), Some(42));
+    }
+
+    #[test]
+    fn read_sentinel_pid_missing_file_is_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert_eq!(read_sentinel_pid(tmp.path()), None);
+    }
+
+    #[test]
+    fn read_sentinel_pid_empty_or_unparseable_is_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_claim(tmp.path(), "");
+        assert_eq!(read_sentinel_pid(tmp.path()), None);
+
+        let tmp2 = tempfile::tempdir().unwrap();
+        write_claim(tmp2.path(), "not-a-pid\n0\n");
+        assert_eq!(read_sentinel_pid(tmp2.path()), None);
+    }
+}

--- a/src/ooda_actions/tests_advance_goal.rs
+++ b/src/ooda_actions/tests_advance_goal.rs
@@ -528,4 +528,69 @@ mod inflight_tests {
         // Goal "fo" does NOT match (prefix is "fo-" which doesn't match "foo-1234").
         assert!(find_live_engineer_for_goal(tmp.path(), "fo").is_none());
     }
+
+    #[test]
+    fn find_live_engineer_returns_none_when_claim_unparseable() {
+        // A non-numeric first line is not a recycled-but-dead PID (covered by
+        // `..._when_claim_dead`); it exercises the *parse-failure* `continue`
+        // branch where the sentinel is corrupt rather than stale.
+        let tmp = tempdir().unwrap();
+        let root = tmp.path().join(crate::engineer_worktree::WORKTREES_SUBDIR);
+        fs::create_dir_all(&root).unwrap();
+        let corrupt = root.join("corrupt-goal-1-ff");
+        fs::create_dir_all(&corrupt).unwrap();
+        fs::write(
+            corrupt.join(crate::engineer_worktree::ENGINEER_CLAIM_FILE),
+            "not-a-pid\n",
+        )
+        .unwrap();
+        assert!(find_live_engineer_for_goal(tmp.path(), "corrupt-goal").is_none());
+    }
+
+    #[test]
+    fn find_live_engineer_rejects_starttime_mismatch() {
+        // Live PID but a recorded starttime that can never match a real
+        // process (`1` jiffies). This drives the starttime-guard branch that
+        // the existing PID-only sentinels never reach: on Linux the /proc
+        // lookup mismatches and on /proc-less platforms it returns None — both
+        // `continue`, so no live engineer is reported.
+        let tmp = tempdir().unwrap();
+        let root = tmp.path().join(crate::engineer_worktree::WORKTREES_SUBDIR);
+        fs::create_dir_all(&root).unwrap();
+        let recycled = root.join("recycled-goal-1-aa");
+        fs::create_dir_all(&recycled).unwrap();
+        fs::write(
+            recycled.join(crate::engineer_worktree::ENGINEER_CLAIM_FILE),
+            format!("{}\n1\n", std::process::id()),
+        )
+        .unwrap();
+        assert!(find_live_engineer_for_goal(tmp.path(), "recycled-goal").is_none());
+    }
+
+    #[test]
+    fn find_live_engineer_accepts_matching_starttime_when_recorded() {
+        // The success arm of the starttime guard: a live PID whose recorded
+        // starttime matches the live process. Only meaningful where /proc
+        // exposes the starttime (Linux CI); elsewhere the PID-only success
+        // path already covers acceptance, so skip rather than model a platform
+        // we can't observe.
+        let live = std::process::id() as i32;
+        let Some(starttime) = crate::engineer_worktree::read_pid_starttime_public(live) else {
+            return;
+        };
+        let tmp = tempdir().unwrap();
+        let root = tmp.path().join(crate::engineer_worktree::WORKTREES_SUBDIR);
+        fs::create_dir_all(&root).unwrap();
+        let wt = root.join("verified-goal-1-bb");
+        fs::create_dir_all(&wt).unwrap();
+        fs::write(
+            wt.join(crate::engineer_worktree::ENGINEER_CLAIM_FILE),
+            format!("{live}\n{starttime}\n"),
+        )
+        .unwrap();
+        assert_eq!(
+            find_live_engineer_for_goal(tmp.path(), "verified-goal"),
+            Some(wt)
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Adds **14 deterministic unit tests** for previously-untested code in the OODA
engineer-lifecycle dispatch path (`src/ooda_actions/advance_goal/`), a high-risk
area explicitly called out in **#1735** (ooda-brain / engineer_loop are among the
five lowest-coverage, highest-risk modules to attack).

This is a **test-only** change — no production code is modified.

### What is now covered

`src/ooda_actions/advance_goal/spawn.rs` — module-private helpers that could only
be reached via an in-file `#[cfg(test)]` block (zero prior coverage):

- **`build_engineer_name`** — `engineer-<goal>-<epoch>` shape; empty-goal edge.
- **`truncate_for_log`** — short pass-through; exact-256-byte boundary;
  ASCII ellipsis truncation; and the **UTF-8 char-boundary back-off** (regression
  guard for the byte-index decrement loop, exercised with multi-byte `€`).
- **`read_sentinel_pid`** — PID-only and PID+starttime sentinels, whitespace
  trimming, and missing / empty / unparseable → `None`.

`src/ooda_actions/tests_advance_goal.rs` — new branch coverage co-located with the
existing `find_live_engineer_for_goal` tests:

- the **parse-failure** branch (corrupt, non-numeric claim);
- the **starttime-guard** branches that the existing PID-only fixtures never
  reached: a recycled-PID **mismatch is rejected**, and a **matching recorded
  starttime is accepted** (skipped on `/proc`-less platforms via runtime probe).

## Why this scope

Triage of the `improve-amplihack-test-coverage` goal found PR #2353 already owns
`cmd_cleanup` (#1753). This PR targets a **different, non-overlapping** module in
the prioritized high-risk set (#1735) — the OODA engineer-lifecycle dispatch —
so the two advance the goal in parallel without duplication.

## Merge-ready evidence

### 1. qa-team scenarios — N/A (justified)

Test-only change introducing **no new user-facing behavior**. There is no
runtime/CLI/dashboard surface for a `gadugi-test` scenario to exercise — the diff
only adds `#[cfg(test)]` assertions over existing internal helpers. Per the
goal's own acceptance criteria, qa scenarios are required only for
*newly-introduced user-facing behavior*, of which there is none. No
`gadugi-test validate` / `run` artifact applies.

### 2. Docs — internal-only (justified)

No user-facing surface changed. **Complete list of changed surfaces:**
`src/ooda_actions/advance_goal/spawn.rs` (added a `#[cfg(test)] mod tests`) and
`src/ooda_actions/tests_advance_goal.rs` (added 3 tests). Both are internal test
modules; no public API, CLI, config, or dashboard surface is touched, so no doc
update is required.

### 3. Quality-audit — 3 SEEK→VALIDATE→FIX cycles, clean final cycle

Audited the two changed test modules against the implementations they exercise
(`build_engineer_name`, `truncate_for_log`, `read_sentinel_pid`, and
`find_live_engineer_for_goal` + `read_pid_starttime_public`/`is_pid_alive_public`):

- **Cycle 1 — assertion correctness vs implementation.** Verified every assertion
  matches behavior: epoch-suffix parse, the `len() <= 256` boundary, the UTF-8
  back-off (`€` ×100 = 300 bytes; cut 256 → 255 = 85×3 → 85 chars + ellipsis = 86),
  and each `read_sentinel_pid` first-line/trim/missing/empty/unparseable case.
  **Zero findings.**
- **Cycle 2 — robustness / flakiness / platform.** Confirmed the starttime-mismatch
  test cannot false-accept (recorded `1` jiffies can never equal a live
  late-started process's starttime) and never sends a signal (`kill(pid,0)`
  existence probe only); the starttime-accept test self-skips on `/proc`-less
  platforms and uses an immutable per-process starttime. **Zero findings.**
- **Cycle 3 — test-quality / coverage / no-regression.** Confirmed the new tests
  hit genuinely-distinct branches (parse-failure `continue` vs dead-PID branch)
  with no duplication, and are hermetic (per-test `tempfile::tempdir`, no env
  mutation, no shared global state, no network), hence parallel-safe.
  **Zero findings.**

The final cycle is clean: **zero critical/high and zero medium correctness/security
findings**, so no code fixes were required. An **independent `code-review` pass**
re-ran all tests and corroborated the verdict ("No significant issues found. The
diff is clean for merge."), confirming the starttime-accept test actually executes
(not skipped) on the Linux runner. Audited at the merge commit
`a755a757c2f0b5648b6ec0580584ce8e3f9f7a58`.

### 4. CI — 100% green (authoritative gate)

All checks pass on head `a755a757c2f0b5648b6ec0580584ce8e3f9f7a58` (rebased onto
current `main`):

- **verify / install-real** → https://github.com/rysweet/Simard/actions/runs/27934682657 (success)
- **verify / install-real** (push) → https://github.com/rysweet/Simard/actions/runs/27934679956 (success)
- **coverage** → https://github.com/rysweet/Simard/actions/runs/27934682529 (success)
- `pre-commit` (fmt + clippy), `cargo-audit`, `e2e-dashboard`, GitGuardian — all green.

Local confirmation (isolated target): `cargo fmt --all -- --check` clean;
`cargo test --lib ooda_actions` → **69 passed, 0 failed** (4 pre-existing ignored);
`cargo test --lib ooda_actions::advance_goal::spawn::tests` → **11 passed**.

### 6. Diff focused

**2 files, +201 lines, test-only**, no production edits, rebased cleanly onto
current `main` with no unrelated changes.

Refs #1735
