### PR TITLE
fix(dashboard): don't open a competing cognitive-memory handle when a daemon is running (#2366)

### DIFF
--- a/src/operator_commands_dashboard/mod.rs
+++ b/src/operator_commands_dashboard/mod.rs
@@ -39,12 +39,10 @@ mod tests_routes_b;
 
 use std::net::SocketAddr;
 use std::path::Path;
-use std::sync::Arc;
 
-use crate::cognitive_memory::{CognitiveMemoryOps, LibraryCognitiveMemory};
 use crate::error::SimardResult;
 use crate::goal_curation::{GoalBoard, load_goal_board, save_goal_board};
-use crate::memory_ipc::{launch_writer_bridge, open_reader_bridge, register_in_process_writer};
+use crate::memory_ipc::{launch_writer_bridge, open_reader_bridge};
 
 /// Read the cognitive-memory `goal-board:snapshot` for the dashboard.
 ///
@@ -114,17 +112,17 @@ pub fn serve(port: u16) -> Result<(), Box<dyn std::error::Error>> {
     }
     eprintln!("  Open http://localhost:{port} and enter the code\n");
 
-    // Open the cognitive-memory store ONCE and register it as the shared tier-0
-    // in-process writer, mirroring the OODA daemon and bootstrap assembly (which
-    // standalone `dashboard serve` does not go through). The launcher's tier-2
-    // store cache (#2334, closing the #2320 goal-board read-after-write race)
-    // already shares one handle per `state_root`, so this registration is
-    // defense-in-depth and architectural consistency: the dashboard owns its
-    // handle on the same tier-0 path the daemon uses instead of relying solely on
-    // the tier-2 fallback. The strong Arc is held for the lifetime of `serve`
-    // (i.e. the whole process) so the registry's `Weak` stays upgradeable.
-    let state_root = routes::resolve_state_root();
-    let _shared_writer = register_dashboard_shared_writer(&state_root);
+    // Standalone `dashboard serve` does NOT open or register its own
+    // cognitive-memory handle. Every dashboard read/write goes through the
+    // launcher resolution ladder (`open_reader_bridge` / `launch_writer_bridge`),
+    // consulted per request: it routes to a running daemon's IPC socket (tier-1)
+    // when one is serving this `state_root`, and otherwise to the tier-2
+    // shared-store cache (#2334), which already gives this process a single
+    // handle per `state_root` with read-after-write consistency. Eagerly
+    // registering a dashboard-owned tier-0 handle here would shadow the tier-1
+    // socket for the whole process lifetime, turning the dashboard into a second
+    // concurrent cross-process writer that silently drops goals whenever a daemon
+    // runs on the same `state_root` (issue #2366).
 
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -140,38 +138,4 @@ pub fn serve(port: u16) -> Result<(), Box<dyn std::error::Error>> {
         axum::serve(listener, app).await?;
         Ok::<(), Box<dyn std::error::Error>>(())
     })
-}
-
-/// Open the dashboard's cognitive-memory store and register it as the shared
-/// in-process writer, returning the strong `Arc` the caller must keep alive for
-/// as long as the dashboard serves requests.
-///
-/// Mirrors the OODA daemon and bootstrap assembly, which open the library-backed
-/// store once and register one shared handle. Registering the dashboard's handle
-/// on the same tier-0 in-process path keeps dashboard reads and writes on one
-/// store. Same-process read-after-write consistency is also guaranteed by the
-/// launcher's tier-2 store cache (added in #2334 to close the #2320 race), so
-/// this tier-0 registration is defense-in-depth: it aligns the dashboard with
-/// the daemon/bootstrap rather than relying solely on the tier-2 fallback.
-///
-/// Returns `None` (after logging) when the store cannot be opened, leaving
-/// handlers on their graceful tier-1/tier-2 fallback rather than failing to serve.
-pub(crate) fn register_dashboard_shared_writer(
-    state_root: &Path,
-) -> Option<Arc<dyn CognitiveMemoryOps>> {
-    match LibraryCognitiveMemory::open(state_root) {
-        Ok(memory) => {
-            let writer: Arc<dyn CognitiveMemoryOps> = Arc::new(memory);
-            register_in_process_writer(state_root.to_path_buf(), Arc::clone(&writer));
-            Some(writer)
-        }
-        Err(error) => {
-            eprintln!(
-                "[simard] dashboard: shared cognitive-memory handle not registered at {} \
-                 ({error}); handlers will use the IPC/tier-2 fallback",
-                state_root.display()
-            );
-            None
-        }
-    }
 }

--- a/src/operator_commands_dashboard/tests_goals_crud.rs
+++ b/src/operator_commands_dashboard/tests_goals_crud.rs
@@ -15,7 +15,7 @@ use crate::goal_curation::{GoalBoard, GoalProgress, save_goal_board};
 use crate::memory_ipc::{clear_in_process_writer, register_in_process_writer};
 use crate::operator_commands_dashboard::goals::*;
 use crate::operator_commands_dashboard::{
-    dashboard_goal_board_snapshot, dashboard_save_goal_board, register_dashboard_shared_writer,
+    dashboard_goal_board_snapshot, dashboard_save_goal_board,
 };
 use crate::test_support::HermeticState;
 
@@ -689,25 +689,4 @@ async fn repeated_handler_writes_never_silently_drop_goals() {
         12,
         "every goal added through the handler must persist (no silent drop)"
     );
-}
-
-/// `register_dashboard_shared_writer` returns a live writer for a writable
-/// state root, and the registered handle services subsequent bridge opens.
-#[test]
-#[serial_test::serial(cognitive_memory)]
-fn register_dashboard_shared_writer_registers_usable_handle() {
-    let state = HermeticState::new();
-    let writer = register_dashboard_shared_writer(state.state_root());
-    assert!(
-        writer.is_some(),
-        "a fresh hermetic state root must yield a usable cognitive-memory writer"
-    );
-
-    // The registered writer must serve a save+read through the dashboard path.
-    dashboard_save_goal_board(state.state_root(), &GoalBoard::new()).expect("save via shared");
-    let board = dashboard_goal_board_snapshot(state.state_root()).expect("read via shared");
-    assert!(board.active.is_empty());
-
-    drop(writer);
-    clear_in_process_writer();
 }


### PR DESCRIPTION
Fixes #2366. Follow-up to #2354 (found via post-merge quality audit).

## The regression

#2354 made standalone `simard dashboard serve()` **eagerly** open its own direct
`LibraryCognitiveMemory` handle and register it as the **tier-0** in-process
writer. The launcher resolution ladder checks tier-0 **before** the tier-1 daemon
socket (`launcher.rs:330`/`390` precede `342`/`400`). So when a daemon already
serves the same `state_root` (`$HOME/.simard` by default), the standalone
dashboard **bypassed the daemon socket** and wrote directly to the lbug store — a
second concurrent cross-process writer → divergent views and **silent goal-board
data loss**. The same config is **safe on pre-#2354 main** (no tier-0 entry →
handlers route through the daemon socket).

The PR assumed a second open would fail on the lbug lock (→ `None` → fallback);
it does **not** — confirmed by repro:
```
B serve log "shared handle not registered": 0   # B's direct open SUCCEEDED
A adds 3 backlog; B adds 3 backlog
A sees backlog=5, B sees backlog=5              # expected 8 — divergent / partial loss
Cold reopen (fresh process): active=0 backlog=0 # TOTAL silent loss
```

## The fix — remove the eager registration

The eager tier-0 registration was also **redundant**: the launcher's tier-2
shared-store cache (#2334) already gives the standalone dashboard one handle per
`state_root` with read-after-write consistency (verified — the goal-persistence
qa passes on pre-#2354 main, which has no such registration).

So `serve()` now opens/registers **nothing**. Every dashboard read/write flows
through the launcher ladder (`open_reader_bridge` / `launch_writer_bridge`),
consulted **per request**:
- a running daemon's IPC socket (tier-1) when one serves the `state_root`, else
- the tier-2 shared-store cache (single handle per `state_root`).

Because the ladder is consulted per request and the dashboard never holds a
shadowing tier-0 handle, this closes #2366 for **both** start orderings
(daemon-first *and* dashboard-first-then-daemon) — a strictly more robust fix
than gating the registration on socket presence (which would leave the
dashboard-first ordering racy).

- `operator_commands_dashboard/mod.rs` — drop the `serve()` tier-0 registration
  and the now-unused `register_dashboard_shared_writer` helper + imports.
- `tests_goals_crud.rs` — drop the helper-specific unit test (the helper is
  gone). The handler-path persistence regression test
  (`repeated_handler_writes_never_silently_drop_goals`) and the qa scenario
  remain.

Net: **2 files, +13 / −70** (a simplification — reverts #2354's redundant +
buggy production change while keeping its valuable test/qa coverage).

## Merge-readiness evidence

### (1) Tests / qa — PASS
- `cargo test --lib operator_commands_dashboard::tests_goals_crud` → **28 passed; 0 failed**.
- Standalone qa scenario `scripts/qa-dashboard-goal-persistence.sh` (now exercising the tier-2 path) → `QA-DASHBOARD-GOALS: PASS - 4 active goals persisted across 4 HTTP requests`.
- Bin check: standalone `serve()` performs **no** eager lbug store-open at startup; the store opens lazily via tier-2 on the first request. Pre-fix repro (two direct writers) reproduced total loss; post-fix the dashboard never opens a competing handle.

### (2) Docs / surfaces — internal-only
No user-facing surface change: `dashboard serve` keeps the same flags/output.
Internal correctness/simplification of how the standalone dashboard accesses
cognitive memory. No doc update required.

### (3) Quality audit — origin of this PR + follow-up review
- **SEEK:** post-merge code review of #2354 traced the launcher ladder and flagged the tier-0 eager registration bypassing the tier-1 daemon socket.
- **VALIDATE:** reproduced empirically (second-process open succeeds; two direct writers drop the whole board; cold reopen 0/0).
- **FIX (cycle 1):** gated registration on daemon-socket presence.
- **REVIEW (cycle 2):** a follow-up review found the gate still raced the *dashboard-first-then-daemon* ordering (the stale tier-0 shadows a later daemon socket). **FIX (cycle 3):** removed the registration entirely, which is both simpler and closes both orderings; re-verified tests + qa + bin behavior. `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean.

### (4) CI
Runs on this head; fmt + `clippy --all-targets` verified locally.

### (6) Focused diff
2 files — the `serve()` cognitive-memory wiring + its tests. No unrelated edits.
