### PR TITLE
fix(deps): bump amplihack-memory (285de92b) + lbug 0.15.4 — fix DETACH-DELETE SEGV crash loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 [[package]]
 name = "amplihack-memory"
 version = "0.4.0"
-source = "git+https://github.com/rysweet/amplihack-memory-lib.git?rev=34d6a75cf922ec1b838a44bba8c5b6592342bcfd#34d6a75cf922ec1b838a44bba8c5b6592342bcfd"
+source = "git+https://github.com/rysweet/amplihack-memory-lib.git?rev=285de92b9895a6fba6b53b6be3c4c99134a2d0f6#285de92b9895a6fba6b53b6be3c4c99134a2d0f6"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -1060,7 +1060,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1194,7 +1194,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2089,9 +2089,9 @@ dependencies = [
 
 [[package]]
 name = "lbug"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c983bfdf95753e2359889e3c0534580f7689302f55271bba293e72b24ba9924b"
+checksum = "7ff191ec195fb257dd7ca2adb76afd9a4b9a9f60fa27f1d87e5a958849fe9e6f"
 dependencies = [
  "cmake",
  "cxx",
@@ -2438,7 +2438,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3408,7 +3408,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3467,7 +3467,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4162,7 +4162,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5093,7 +5093,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,8 +48,8 @@ path = "src/bin/simard_tui/main.rs"
 # backend. `cognitive_memory::library_adapter::LibraryCognitiveMemory` drives it
 # behind Simard's `CognitiveMemoryOps` trait; the native LadybugDB fork has been
 # deleted. The `persistent` feature builds LadybugDB through the published
-# `lbug = "=0.15.3"` crate.
-amplihack-memory = { git = "https://github.com/rysweet/amplihack-memory-lib.git", rev = "34d6a75cf922ec1b838a44bba8c5b6592342bcfd", features = ["persistent"] }
+# `lbug = "=0.15.4"` crate.
+amplihack-memory = { git = "https://github.com/rysweet/amplihack-memory-lib.git", rev = "285de92b9895a6fba6b53b6be3c4c99134a2d0f6", features = ["persistent"] }
 rustyclawd-core = { git = "https://github.com/rysweet/RustyClawd.git", rev = "43ebaa1c1b18a5630c53f0519989a2bacd42ef62" }
 rustyclawd-tools = { git = "https://github.com/rysweet/RustyClawd.git", rev = "43ebaa1c1b18a5630c53f0519989a2bacd42ef62" }
 # De-fork (issue #2323): the gym/eval RUNNER is now the upstream
@@ -64,7 +64,7 @@ amplihack-agent-eval = { git = "https://github.com/rysweet/amplihack-rs.git", re
 # (`src/bin/simard_tui/goals.rs`), which opens a LadybugDB read-only to render
 # the goal board. The cognitive-memory backend itself no longer uses lbug
 # directly — it goes through the amplihack-memory library.
-lbug = "=0.15.3"
+lbug = "=0.15.4"
 rusqlite = { version = "=0.31.0", features = ["bundled"] }
 serde = { version = "=1.0.228", features = ["derive"] }
 serde_json = "=1.0.149"


### PR DESCRIPTION
Resolves the daemon SEGV that recurred every ~45-90 min. Root cause: lbug 0.15.3 null-derefs in detachDeleteForCSRRels (getGroup UINT32_MAX) when DETACH-DELETEing a node with relationships; triggered by retention pruning superseded fact nodes that now carry graph edges. amplihack-memory #99 makes delete_node remove incident edges before the bare-node delete (never DETACH DELETE) + lbug 0.15.4. Validated locally: 36/36 lbug_store tests incl. the crash repro. Build green; pre-push tests/clippy green.