### PR TITLE
test(gym): make gym-list qa-scenario executable by installed gadugi-test (follow-up to #2362)

### DIFF
--- a/tests/qa-scenarios/gym-list.yaml
+++ b/tests/qa-scenarios/gym-list.yaml
@@ -6,30 +6,62 @@ agents:
     type: cli
     command: cargo
 steps:
+  # Execute `simard gym list`. The CLI runner rejects any non-zero exit, so this
+  # step already enforces a clean exit 0 and proves the trimmed gym still emits a
+  # benchmark listing.
   - action: run
-    command: "cargo run --quiet -- gym list"
-    timeout: 60s
-  - action: expect_stdout
-    contains: "Simard benchmark scenarios:"
+    params:
+      command: "cargo run --quiet -- gym list"
+    # Generous timeout: `cargo run` performs a freshness check and the gym
+    # initialises its lbug-backed graph store before listing, which can take a
+    # few minutes on a loaded machine even when the binary is already built.
+    timeout: 600000
+  # Header proves the command produced the benchmark listing. Each
+  # wait_for_output step fails the scenario if its pattern is absent.
+  - action: wait_for_output
+    params:
+      value: "Simard benchmark scenarios:"
+    timeout: 8000
   # One representative scenario from each of the four V1 benchmark classes.
-  - action: expect_stdout
-    contains: "repo-exploration-local"
-  - action: expect_stdout
-    contains: "doc-generation-public-fn"
-  - action: expect_stdout
-    contains: "safe-change-add-enum-variant"
-  - action: expect_stdout
-    contains: "session-quality-memory-export"
-  - action: expect_stdout
-    contains: "interactive-terminal-driving"
+  - action: wait_for_output
+    params:
+      value: "repo-exploration-local"
+    timeout: 8000
+  - action: wait_for_output
+    params:
+      value: "doc-generation-public-fn"
+    timeout: 8000
+  - action: wait_for_output
+    params:
+      value: "safe-change-add-enum-variant"
+    timeout: 8000
+  - action: wait_for_output
+    params:
+      value: "session-quality-memory-export"
+    timeout: 8000
+  - action: wait_for_output
+    params:
+      value: "interactive-terminal-driving"
+    timeout: 8000
   # The four sanctioned class labels are emitted for the curated scenarios.
-  - action: expect_stdout
-    contains: "repo-exploration"
-  - action: expect_stdout
-    contains: "documentation"
-  - action: expect_stdout
-    contains: "safe-code-change"
-  - action: expect_stdout
-    contains: "session-quality"
-  - action: expect_exit_code
-    code: 0
+  - action: wait_for_output
+    params:
+      value: "class=repo-exploration"
+    timeout: 8000
+  - action: wait_for_output
+    params:
+      value: "class=documentation"
+    timeout: 8000
+  - action: wait_for_output
+    params:
+      value: "class=safe-code-change"
+    timeout: 8000
+  - action: wait_for_output
+    params:
+      value: "class=session-quality"
+    timeout: 8000
+  # Re-confirm the listing command exited cleanly (exit code 0).
+  - action: validate_exit_code
+    params:
+      value: "0"
+    timeout: 5000


### PR DESCRIPTION
## Summary

Follow-up to #2362 (which shrank the gym benchmark suite to the V1 high-signal
set and closed #2087). #2362 added `tests/qa-scenarios/gym-list.yaml`, which
passes `gadugi-test validate --strict` — but the **installed** gadugi-test
(`@gadugi/agentic-test` v1.0.0) runtime **cannot execute it**, so the qa-scenario
never actually exercises `gym list`. It validates but is a **no-op**.

### Root cause

The gadugi-test orchestrator (`adapters/scenarioAdapter.js` →
`adaptStepToOrchestrator` → `agents/CLIAgent.js`) builds each step's command
from a **`params`** object (`params.command`) and asserts output via the
**`wait_for_output`** action (which *fails the run* if a pattern never appears).
The top-level `command:` / `contains:` / `expect_stdout:` fields used by the
merged scenario are ignored, so the runner executes an **empty command** and the
run fails with `The argument 'file' cannot be empty`. The strict validator only
checks that the YAML parses and has name/steps/agents — it does not exercise the
executor, which is why the no-op passed `validate --strict`.

### Fix

Rewrite the steps into the runtime-executable, genuinely-enforcing schema
(verified empirically against the installed binary):

- `run` with `params.command: "cargo run --quiet -- gym list"` — the CLI runner
  rejects any non-zero exit (`expectedExitCodes:[0]`), so **exit 0 is enforced**.
- one `wait_for_output` per curated scenario id (`repo-exploration-local`,
  `doc-generation-public-fn`, `safe-change-add-enum-variant`,
  `session-quality-memory-export`, `interactive-terminal-driving`) and per
  sanctioned class label (`class=repo-exploration`, `class=documentation`,
  `class=safe-code-change`, `class=session-quality`) — a **missing string fails
  the scenario**.

Net diff: **1 file** (`tests/qa-scenarios/gym-list.yaml`), no production code.

---

## Merge-readiness evidence

### 1. qa-team scenarios (gadugi-test) — validate AND run

- `gadugi-test validate -f tests/qa-scenarios/gym-list.yaml --strict` →
  `✓ Scenario "simard-gym-list" is valid` (1 valid, 0 invalid).
- `gadugi-test run` (against this branch's built binary) →
  **`✓ Passed: 1  ✗ Failed: 0  ✓ All tests passed!`**
  (session `4e3ed541-...`). The run executed `cargo run --quiet -- gym list`
  → **exit code 0** (duration ~24 s), then asserted all 5 representative ids and
  all 4 `class=` labels via `wait_for_output`. (gadugi-test v1.0.0's `run`
  subcommand takes `-d <dir>`, so the scenario is run from a single-file
  directory.)
- **Enforcement proven by a negative control:** an otherwise-identical scenario
  asserting a string the command never prints → **`✗ Failed: 1`**. The pass is
  therefore meaningful, not a false-positive.
- Independently reproduced by a code-review agent, which ran
  `cargo run --quiet -- gym list` (exit 0) and confirmed every asserted string
  appears in both `src/gym/scenarios/data.rs` and the live output.

### 2. Docs / changed surfaces

- No user-facing surface change. This is a **test-config-only** edit to an
  existing qa-scenario (internal QA harness). The `gym list` output and the gym
  suite are unchanged from #2362.

### 3. quality-audit (SEEK → VALIDATE → FIX)

- The gym suite reduction itself was audited over 3 cycles in #2362
  (cycle 1 fixed an e2e assertion + dead comment at `063b7c3b`; cycles 2 & 3
  CLEAN). This follow-up touches only the qa-scenario YAML.
- A focused independent review of this 1-file change returned **VERDICT: CLEAN**
  — traced the full gadugi runtime path (`run.js` → `ScenarioLoader` →
  `adaptScenarioToComplex`/`adaptStepToOrchestrator` → `CLIAgent.executeStep`),
  confirmed `params.command`/`wait_for_output` mapping, spawn-path output
  buffering, integer-ms timeouts, regex-safe patterns, 1-file diff, and no
  secrets. Zero critical/high; zero medium correctness/security.

### 4. CI

- Pending → will be confirmed 100% green before merge. This change is YAML-only
  (not compiled or executed by CI), so CI matches the green run on the parent
  `main` commit.

### 6. Focused diff

- Exactly one file: `tests/qa-scenarios/gym-list.yaml`. No edits outside scope.

---

> After this lands on `Simard` `main`, a `simard safe-update` self-update will be
> needed to propagate the change to deployed environments.
