### PR TITLE
test(terminal): strengthen PTY lifecycle assertion to prove command execution

### DIFF
--- a/src/terminal_session/session.rs
+++ b/src/terminal_session/session.rs
@@ -742,10 +742,20 @@ mod tests {
     /// terminal-shell session works even when the test process itself has **no
     /// controlling terminal** (`tty` reports "not a tty"), exactly as in CI /
     /// headless runners. `script` allocates its *own* PTY for the inner shell,
-    /// so an interactive (`-i`) bash still launches, echoes the command it
+    /// so an interactive (`-i`) bash still launches, executes the command it
     /// receives, and reports output back through the transcript without any
     /// parent TTY. This is the only test that exercises the real spawn /
     /// transcript-capture path the production recipe runner depends on.
+    ///
+    /// Because `script` runs bash on a PTY with terminal `ECHO` enabled, the
+    /// command line we type is copied verbatim into the transcript regardless
+    /// of whether bash ever runs it. To prove the shell genuinely *executed*
+    /// the command (not merely received and echoed it), the marker embeds a
+    /// shell arithmetic expansion: the typed line contains the literal
+    /// `$((20 + 22))`, whereas only successful execution yields the evaluated
+    /// `42`. Asserting on the evaluated form therefore cannot be satisfied by
+    /// the input echo alone — it requires real command execution plus output
+    /// capture.
     ///
     /// Skips (rather than fails) when `script` is not on PATH.
     #[test]
@@ -759,21 +769,27 @@ mod tests {
         }
 
         let workdir = tempfile::tempdir().expect("create temp working directory");
-        let marker = format!("notty-marker-{}", uuid::Uuid::now_v7().simple());
+        // Unique per-session token keeps the expected string specific to this
+        // run; the `$((20 + 22))` expansion guarantees the asserted form
+        // (`<token>-42-done`) can only come from executed output, never the
+        // verbatim PTY echo of the typed command (which carries `$((20 + 22))`).
+        let token = format!("notty-marker-{}", uuid::Uuid::now_v7().simple());
+        let typed_command = format!("echo {token}-$((20 + 22))-done");
+        let executed_output = format!("{token}-42-done");
 
         let mut session = PtyTerminalSession::launch("test-bt", DEFAULT_SHELL, workdir.path())
             .expect("launch PTY shell via script without a controlling terminal");
 
         session
-            .send_input(&format!("echo {marker}"))
+            .send_input(&typed_command)
             .expect("send echo command to PTY shell");
 
         let status = session
-            .wait_for_output(&marker, Duration::from_secs(15))
+            .wait_for_output(&executed_output, Duration::from_secs(15))
             .expect("poll transcript for expected output");
         assert!(
             matches!(status, TerminalWaitStatus::Satisfied),
-            "expected marker '{marker}' to appear in the transcript, got {status:?}"
+            "expected executed output '{executed_output}' to appear in the transcript, got {status:?}"
         );
 
         // Mirror the production recipe pattern: a trailing `exit 0` cleanly
@@ -789,8 +805,8 @@ mod tests {
             capture.exit_status
         );
         assert!(
-            capture.transcript.contains(&marker),
-            "final transcript must contain the marker '{marker}'; transcript was:\n{}",
+            capture.transcript.contains(&executed_output),
+            "final transcript must contain the executed output '{executed_output}'; transcript was:\n{}",
             capture.transcript
         );
     }


### PR DESCRIPTION
## Summary

Follow-up to the now-merged #2363 (`d3183dda`). It strengthens the
`pty_session_runs_end_to_end_without_controlling_terminal` test so its
assertions can only be satisfied by **real command execution**, not by the
PTY's input echo.

## Why

`script` runs bash on a PTY with terminal `ECHO` enabled, so the line we type
(`echo <marker>`) is copied verbatim into the transcript **whether or not bash
ever executes it**. The merged test asserted on the bare `<marker>`, which the
echoed *input* line already contains — so the two substring checks
(`wait_for_output(&marker, …)` and `capture.transcript.contains(&marker)`) pass
on input echo alone. Only `exit_status.success()` (from the trailing `exit 0`)
actually proved the shell processed input. A regression where the shell accepts
input but never executes commands could still pass two of three assertions.

This was raised as a LOW finding by an independent `code-review` pass while
driving #2363 to merge (the reviewer also compiled and ran the test 10/10
successfully and found **no** correctness/flakiness/leak/security/portability
defects — confirming the harness itself is sound).

## Fix

Embed a shell arithmetic expansion so the asserted string can only come from
**output**: the typed line carries the literal `$((20 + 22))`, whereas only
successful execution yields the evaluated `42`. Both the wait and the final
transcript check now assert on `<token>-42-done`, which the verbatim input echo
(`echo <token>-$((20 + 22))-done`) cannot contain. The unique per-session
`<token>` keeps the expected string specific to the run.

## Merge-ready evidence

1. **qa-team (gadugi):** A focused gadugi scenario covering the PTY-session
   lifecycle path was authored and **validated** with `gadugi-test validate`
   (✓ valid); the lifecycle is additionally covered by the committed outside-in
   `tests/gadugi/terminal-session.sh` (in `simard-cli-smoke.yaml`), which also
   validates ✓. A local `gadugi-test run` requires building the `simard`
   binaries, which is currently blocked on this shared host by a transient
   parallel-CMake corruption in the vendored `lbug` C++ dependency
   (`getcwd() failed` / missing `.o.d` across concurrent worktree builds); CI
   on clean runners is unaffected and is the authoritative functional gate
   (it compiles and runs this exact test).
2. **Docs:** Test-only change. No user-facing surface (no API/CLI/config/
   deployment) is touched, so no documentation update is required.
3. **quality-audit:** A ≥3-cycle SEEK→VALIDATE→FIX audit of the changed test
   (with independent multi-agent validation via the `code-review` agent) found
   zero critical/high and zero medium correctness/security findings; the single
   LOW finding is precisely what this PR fixes, leaving the final cycle clean.
4. **CI:** Must be 100% green (see checks below). CI builds and runs the test on
   clean GitHub runners, providing the authoritative compile + clippy + test
   verification (local pre-commit/pre-push clippy could not run due to the
   `lbug` build-infra contention noted above).
5. **PR description:** This section.
6. **Scope:** Diff is the single test file `src/terminal_session/session.rs`
   (+23/−7); no production code and no unrelated edits.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
