### PR TITLE
fix(dashboard): humanize machine jargon & reconcile contradictory copy (#2358)

### DIFF
--- a/src/operator_commands_dashboard/goals_status.rs
+++ b/src/operator_commands_dashboard/goals_status.rs
@@ -60,6 +60,8 @@ const NOISE_PHRASES: &[&str] = &[
     "goal-action parse failed",
     "spawn_engineer dispatched",
     "continue_skipping",
+    "advance-goal:",
+    "no-action:",
     "ooda-brain",
     "brain:",
 ];
@@ -382,8 +384,40 @@ mod tests {
             !detail.contains("brain-error fallback"),
             "detail still leaks 'brain-error fallback': {detail}"
         );
-        assert!(detail.starts_with("advance-goal"));
+        assert!(
+            !detail.contains("advance-goal"),
+            "detail still leaks the raw 'advance-goal:' action prefix: {detail}"
+        );
         assert_eq!(full, raw, "detail_full must preserve the original verbatim");
+    }
+
+    // ---- Raw OODA action-verb prefixes are stripped (#2358) ---------------
+
+    #[test]
+    fn advance_goal_prefix_is_stripped() {
+        let raw = "advance-goal: opened PR #1685 to fix the Current Activity column";
+        let (chip, detail, _) = render_status_and_detail(Some(raw));
+        assert_eq!(chip, StatusChip::Working);
+        assert!(
+            !detail.contains("advance-goal:"),
+            "detail still leaks 'advance-goal:' prefix: {detail}"
+        );
+        assert!(detail.starts_with("opened PR #1685"), "detail: {detail}");
+    }
+
+    #[test]
+    fn no_action_prefix_is_stripped() {
+        let raw = "no-action: Another subordinate is mid-implementation on #2097";
+        let (chip, detail, _) = render_status_and_detail(Some(raw));
+        assert_eq!(chip, StatusChip::Working);
+        assert!(
+            !detail.contains("no-action:"),
+            "detail still leaks 'no-action:' prefix: {detail}"
+        );
+        assert!(
+            detail.contains("Another subordinate is mid-implementation"),
+            "detail: {detail}"
+        );
     }
 
     // ---- Failed branch ----------------------------------------------------

--- a/src/operator_commands_dashboard/index_html/mod.rs
+++ b/src/operator_commands_dashboard/index_html/mod.rs
@@ -19,12 +19,15 @@ use part_05::PART_05;
 /// Concatenated dashboard HTML/JS, assembled from per-segment string consts
 /// so that no single Rust source file exceeds the 400 LOC cap (#1266).
 ///
-/// Three template markers are substituted from [`tab_meta`]:
+/// Template markers are substituted from [`tab_meta`]:
 ///
 /// * `{{TAB_NAV}}` — the full `<div class="tabs">…</div>` nav bar, so the
 ///   one-label-per-route invariant flows from [`tab_meta::TAB_METADATA`].
 /// * `{{TAB_META_JS}}` — inline `<script>` exporting `window.__TAB_META`
 ///   so the client-side tab handler can swap `document.title` per tab.
+/// * `{{BANNED_JARGON_JS}}` — a JS array literal of [`tab_meta::BANNED_JARGON`]
+///   so the client-side `humanizeCycleSummary` strips the same jargon the
+///   ledes are forbidden from containing (#2358).
 /// * `{{DEFAULT_TITLE}}` — the `<title>` for the initial render, matching
 ///   the default-active tab.
 ///
@@ -37,6 +40,7 @@ pub(crate) fn index_html_string() -> String {
     let rendered = raw
         .replace("{{TAB_NAV}}", &tab_meta::tab_nav_html())
         .replace("{{TAB_META_JS}}", &tab_meta::tab_meta_js())
+        .replace("{{BANNED_JARGON_JS}}", &tab_meta::banned_jargon_js())
         .replace("{{DEFAULT_TITLE}}", tab_meta::default_title());
     debug_assert!(
         !rendered.contains("{{"),

--- a/src/operator_commands_dashboard/index_html/part_00.rs
+++ b/src/operator_commands_dashboard/index_html/part_00.rs
@@ -337,7 +337,7 @@ pub(crate) const PART_00: &str = r#"<!DOCTYPE html>
 
   <div class="tab-content" id="tab-costs">
     <h1 class="page-h1">Costs</h1>
-    <p class="page-lede">Token and dollar spending by model and provider, plus your daily and weekly budget caps, computed from real provider invoices rather than estimates.</p>
+    <p class="page-lede">Token and dollar spending by model and provider, plus your daily and weekly budget caps — the dollar figures are estimates based on each model's published token prices, not a provider invoice.</p>
     <div class="grid">
       <div class="card"><h2>Daily Costs <button class="btn" onclick="fetchCosts()">Refresh</button></h2><div id="costs-daily"><span class="loading">Loading…</span></div></div>
       <div class="card"><h2>Weekly Costs</h2><div id="costs-weekly"><span class="loading">Loading…</span></div></div>

--- a/src/operator_commands_dashboard/index_html/part_01.rs
+++ b/src/operator_commands_dashboard/index_html/part_01.rs
@@ -127,6 +127,57 @@ pub(crate) const PART_01: &str = r#"      </div>
       if(map[kind])return map[kind];
       return kind.replace(/[_-]+/g,' ').replace(/^./,c=>c.toUpperCase());
     }
+    /* --- Plain-English humanizers (#2358) ---
+       Jargon banned from the static ledes (tab_meta::BANNED_JARGON) is injected
+       here so the same ban extends to dynamically rendered cycle/summary text. */
+    const BANNED_JARGON={{BANNED_JARGON_JS}};
+    function humanizeGoalId(id){
+      if(!id)return'';
+      const map={'__memory__':'Memory maintenance','__improvement__':'Self-improvement','__system__':'System upkeep','__meta__':'Housekeeping'};
+      if(map[id])return map[id];
+      const m=String(id).match(/^__(.+?)__$/);
+      if(m)return m[1].replace(/[_-]+/g,' ').replace(/^./,c=>c.toUpperCase());
+      return id;
+    }
+    function humanizePeriod(p){
+      if(!p)return'';
+      const mn=['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+      let m=String(p).match(/^daily:(\d{4})-(\d{2})-(\d{2})$/);
+      if(m){
+        const y=+m[1],mo=+m[2],day=+m[3],label=mn[mo-1]+' '+day,t=new Date();
+        if(t.getFullYear()===y&&t.getMonth()+1===mo&&t.getDate()===day)return'Today ('+label+')';
+        const ys=new Date(t.getTime()-86400000);
+        if(ys.getFullYear()===y&&ys.getMonth()+1===mo&&ys.getDate()===day)return'Yesterday ('+label+')';
+        return label+', '+y;
+      }
+      if(p==='weekly:last-7-days'||p==='weekly:last_7_days')return'Last 7 days';
+      m=String(p).match(/^weekly:(.+)$/);
+      if(m)return'Week of '+m[1].replace(/[-_]/g,' ');
+      m=String(p).match(/^daily:(.+)$/);
+      if(m)return m[1];
+      return String(p);
+    }
+    function humanizeCycleSummary(text){
+      if(!text)return'';
+      let s=String(text);
+      const m=s.match(/^OODA cycle #(\d+):\s*(\d+) priorities,\s*(\d+) actions \((\d+)\/(\d+) succeeded\),\s*goals=(\d+),\s*issues=(\d+),\s*tree=(\w+)/);
+      if(m){
+        const cyc=m[1],prio=m[2],ok=m[4],tot=m[5],goals=m[6],issues=m[7],tree=m[8];
+        const treeTxt=tree==='clean'?'working tree clean':(tree==='dirty'?'uncommitted changes':'tree '+tree);
+        const pW=prio==='1'?'priority':'priorities',aW=tot==='1'?'action':'actions',gW=goals==='1'?'goal':'goals',iW=issues==='1'?'issue':'issues';
+        return 'Cycle #'+cyc+' — '+prio+' '+pW+' considered, '+ok+' of '+tot+' '+aW+' succeeded · '+goals+' '+gW+' tracked · '+issues+' open '+iW+' · '+treeTxt;
+      }
+      // Generic fallback for non-canonical / legacy summaries: drop key=value
+      // shorthand and any leftover banned-jargon token.
+      s=s.replace(/\btree=clean\b/g,'working tree clean')
+         .replace(/\btree=dirty\b/g,'uncommitted changes')
+         .replace(/\bgoals=(\d+)\b/g,'$1 goals')
+         .replace(/\bissues=(\d+)\b/g,'$1 open issues')
+         .replace(/\b([A-Za-z_]+)=([\w.-]+)\b/g,'$1 $2')
+         .replace(/^OODA cycle/i,'Cycle');
+      for(const j of (BANNED_JARGON||[])){if(j)s=s.split(j).join('');}
+      return s.replace(/\s{2,}/g,' ').trim();
+    }
     function copyLogContent(id){
       const el=document.getElementById(id);if(!el)return;
       navigator.clipboard.writeText(el.textContent||'').then(
@@ -303,7 +354,7 @@ pub(crate) const PART_01: &str = r#"      </div>
           const rpt=c.report||{};
           if(rpt.priorities?.length){
             const top=rpt.priorities[0];
-            currentFocus=`<strong>${esc(top.goal_id)}</strong> — ${esc(top.reason)} <span style="color:${top.urgency>0.7?'var(--red)':top.urgency>0.4?'var(--yellow)':'var(--green)'}">urgency ${top.urgency.toFixed(2)}</span>`;
+            currentFocus=`<strong>${esc(humanizeGoalId(top.goal_id))}</strong> — ${esc(top.reason)} <span style="color:${top.urgency>0.7?'var(--red)':top.urgency>0.4?'var(--yellow)':'var(--green)'}">urgency ${top.urgency.toFixed(2)}</span>`;
             break;
           }
         }

--- a/src/operator_commands_dashboard/index_html/part_02.rs
+++ b/src/operator_commands_dashboard/index_html/part_02.rs
@@ -12,7 +12,7 @@ pub(crate) const PART_02: &str = r#"          if(d.ooda_transcripts?.length){
           if(d.cycle_reports?.length){
             crEl.innerHTML=d.cycle_reports.map(c=>{
               const num=c.cycle_number;
-              const text=c.summary||JSON.stringify(c.report||{});
+              const text=c.summary?humanizeCycleSummary(c.summary):JSON.stringify(c.report||{});
               return`<div class="transcript-item">
                 <h3>Cycle #${num}</h3>
                 <div class="log-box" style="max-height:100px">${esc(text)}</div>

--- a/src/operator_commands_dashboard/index_html/part_03.rs
+++ b/src/operator_commands_dashboard/index_html/part_03.rs
@@ -11,11 +11,11 @@ pub(crate) const PART_03: &str = r#"        const d=await apiFetch('/api/goals')
               const detailHtml=detailText?'<span style="font-size:.8rem;margin-left:6px">'+esc(detailText)+'</span>':'';
               const full=g.detail_full||'';
               const isFailed=(chip==='Failed');
-              const expandHtml=(full&&full!==detailText)?'<details style="display:inline;margin-left:6px"'+(isFailed?' open':'')+' ><summary style="display:inline;cursor:pointer;color:'+(isFailed?'#f85149':'#8b949e')+';font-size:.7rem">'+(isFailed?'[error]':'[raw]')+'</summary><pre style="margin:.3rem 0 0;white-space:pre-wrap;font-size:.75rem;color:'+(isFailed?'#f85149':'#8b949e')+'">'+esc(full)+'</pre></details>':'';
+              const expandHtml=(full&&full!==detailText)?'<details style="display:inline;margin-left:6px"'+(isFailed?' open':'')+' ><summary style="display:inline;cursor:pointer;color:'+(isFailed?'#f85149':'#8b949e')+';font-size:.7rem">'+(isFailed?'error details':'show full log')+'</summary><pre style="margin:.3rem 0 0;white-space:pre-wrap;font-size:.75rem;color:'+(isFailed?'#f85149':'#8b949e')+'">'+esc(full)+'</pre></details>':'';
               let wipHtml='—';
               if(chip!=='Waiting'||detailText||g.wip_refs?.length){
                 let parts=[];
-                parts.push('<div style="font-size:.8rem;line-height:1.4">'+chipHtml+detailHtml+expandHtml+'</div>');
+                parts.push('<div style="font-size:.8rem;line-height:1.4">'+chipHtml+' '+detailHtml+expandHtml+'</div>');
                 if(g.wip_refs?.length) parts.push(g.wip_refs.map(r=>{
                   const icon=r.kind==='pr'?'🔀':r.kind==='issue'?'🐛':r.kind==='branch'?'🌿':r.kind==='session'?'💻':'📌';
                   return r.url?'<a href="'+esc(r.url)+'" target="_blank" style="color:var(--accent);text-decoration:none;font-size:.8rem">'+icon+' '+esc(r.label)+'</a>':'<span style="font-size:.8rem">'+icon+' '+esc(r.label)+'</span>';
@@ -212,7 +212,15 @@ pub(crate) const PART_03: &str = r#"        const d=await apiFetch('/api/goals')
         // Trend badge
         const trendIcons={growing:'↑ Growing',shrinking:'↓ Shrinking',stable:'→ Stable',unknown:'—'};
         const trendColors={growing:'#3fb950',shrinking:'#f85149',stable:'#d29922',unknown:'#8b949e'};
-        const trend=d.trend||'unknown';
+        // Derive the badge from the same signed long-term rate the panel shows
+        // below, so "↑ Growing" can never sit next to a negative rate (#2358).
+        const ltRate=(d.rate_per_hour&&typeof d.rate_per_hour.long_term_total==='number')?d.rate_per_hour.long_term_total:null;
+        let trend;
+        if(ltRate!==null){
+          trend=Math.abs(ltRate)<0.1?'stable':(ltRate>0?'growing':'shrinking');
+        }else{
+          trend=d.trend||'unknown';
+        }
         trendEl.textContent=trendIcons[trend]||'—';
         trendEl.style.color=trendColors[trend]||'#8b949e';
 
@@ -523,4 +531,5 @@ pub(crate) const PART_03: &str = r#"        const d=await apiFetch('/api/goals')
             if(v==null)return'';
             if(typeof v==='object')return`<div class="stat"><span class="label">${esc(fmtLabel(k))}</span><span class="value" style="font-size:.8rem">${esc(JSON.stringify(v))}</span></div>`;
             const isCost=k.toLowerCase().includes('cost_usd');
-            const isTokens=k.toLowerCase().includes('token');"#;
+            const isTokens=k.toLowerCase().includes('token');
+            const isPeriod=k==='period';"#;

--- a/src/operator_commands_dashboard/index_html/part_04.rs
+++ b/src/operator_commands_dashboard/index_html/part_04.rs
@@ -1,5 +1,6 @@
 pub(crate) const PART_04: &str = r#"            let fmt;
-            if(typeof v==='number'){
+            if(isPeriod){fmt=humanizePeriod(String(v));}
+            else if(typeof v==='number'){
               if(isCost) fmt='$'+v.toFixed(4);
               else if(isTokens) fmt=v.toLocaleString()+' tokens';
               else fmt=v.toLocaleString();
@@ -211,7 +212,7 @@ pub(crate) const PART_04: &str = r#"            let fmt;
           if(rpt.legacy){
             return `<div class="thinking-cycle legacy">
               <div class="cycle-header"><span class="cycle-num">Cycle #${rpt.cycle_number}</span><span class="cycle-badge">legacy</span></div>
-              <div class="cycle-summary">${esc(rpt.summary)}</div>
+              <div class="cycle-summary">${esc(humanizeCycleSummary(rpt.summary))}</div>
             </div>`;
           }
           const phases=[];
@@ -233,7 +234,7 @@ pub(crate) const PART_04: &str = r#"            let fmt;
               <div class="phase-content">
                 ${rpt.priorities.map(p=>`<div class="priority-line">
                   <span class="urgency" style="color:${p.urgency>0.7?'var(--red)':p.urgency>0.4?'var(--yellow)':'var(--green)'}">●</span>
-                  <strong>${esc(p.goal_id)}</strong> (urgency: ${p.urgency.toFixed(2)}) — ${esc(p.reason)}
+                  <strong>${esc(humanizeGoalId(p.goal_id))}</strong> (urgency: ${p.urgency.toFixed(2)}) — ${esc(p.reason)}
                 </div>`).join('')}
               </div>
             </div>`);
@@ -281,7 +282,7 @@ pub(crate) const PART_04: &str = r#"            let fmt;
           return `<div class="thinking-cycle">
             <div class="cycle-header">
               <span class="cycle-num">Cycle #${rpt.cycle_number}</span>
-              <span class="cycle-summary-inline">${esc(rpt.summary||'')}</span>
+              <span class="cycle-summary-inline">${esc(humanizeCycleSummary(rpt.summary||''))}</span>
             </div>
             <div class="cycle-phases">${phases.join('')}</div>
           </div>`;
@@ -354,7 +355,7 @@ pub(crate) const PART_04: &str = r#"            let fmt;
             const phaseColors={act:'var(--green)',decide:'#a371f7',orient:'var(--yellow)',observe:'var(--accent)',unknown:'#8b949e'};
             const pColor=phaseColors[c.phase]||'#8b949e';
             const dur=c.duration_secs!=null?c.duration_secs+'s':'—';
-            const summary=c.summary||'';
+            const summary=humanizeCycleSummary(c.summary||'');
             const shortSummary=summary.length>120?summary.substring(0,120)+'…':summary;
             return `<tr>
               <td style="font-weight:600;color:var(--accent)">${c.cycle_number}</td>

--- a/src/operator_commands_dashboard/index_html/tab_meta.rs
+++ b/src/operator_commands_dashboard/index_html/tab_meta.rs
@@ -126,7 +126,7 @@ pub const TAB_METADATA: &[TabMeta] = &[
         label: "Costs",
         title: "Costs · Simard",
         h1: "Costs",
-        lede: "Token and dollar spending by model and provider, plus your daily and weekly budget caps, computed from real provider invoices rather than estimates.",
+        lede: "Token and dollar spending by model and provider, plus your daily and weekly budget caps — the dollar figures are estimates based on each model's published token prices, not a provider invoice.",
         tooltip: "Token and dollar usage by model, plus daily and weekly budget",
     },
     TabMeta {
@@ -247,4 +247,18 @@ pub fn tab_meta_js() -> String {
     out.push_str(&payload);
     out.push_str(";</script>");
     out
+}
+
+/// Render the `{{BANNED_JARGON_JS}}` marker: a JSON array literal of
+/// [`BANNED_JARGON`] so the client-side `humanizeCycleSummary` strips the
+/// very same jargon the ledes are forbidden from containing. This keeps a
+/// single source of truth — the jargon ban now extends from the static
+/// ledes to the dynamically rendered cycle/summary text (#2358).
+pub fn banned_jargon_js() -> String {
+    // Mirror `tab_meta_js`'s `<` escaping so a future maintainer adding a term
+    // containing `</script>` cannot break out of the inline script (the terms
+    // are static constants today, so this is defense-in-depth).
+    serde_json::to_string(BANNED_JARGON)
+        .expect("BANNED_JARGON is JSON-safe")
+        .replace('<', "\\u003c")
 }

--- a/src/operator_commands_dashboard/index_html/tests_tab_meta.rs
+++ b/src/operator_commands_dashboard/index_html/tests_tab_meta.rs
@@ -6,7 +6,9 @@
 #![cfg(test)]
 
 use super::INDEX_HTML;
-use super::tab_meta::{BANNED_JARGON, TAB_METADATA, default_title, tab_meta_js, tab_nav_html};
+use super::tab_meta::{
+    BANNED_JARGON, TAB_METADATA, banned_jargon_js, default_title, tab_meta_js, tab_nav_html,
+};
 use std::collections::HashSet;
 
 #[test]
@@ -344,4 +346,96 @@ fn rendered_html_tab_click_handler_swaps_document_title() {
         INDEX_HTML.contains("__TAB_META"),
         "tab-click handler must read window.__TAB_META"
     );
+}
+
+// ----- #2358: jargon ban extends to rendered cycle/summary text -----
+
+#[test]
+fn banned_jargon_js_is_valid_json_array() {
+    let js = banned_jargon_js();
+    let parsed: serde_json::Value =
+        serde_json::from_str(&js).expect("banned_jargon_js must be valid JSON");
+    let arr = parsed
+        .as_array()
+        .expect("BANNED_JARGON renders as a JS array");
+    assert_eq!(arr.len(), BANNED_JARGON.len());
+    for banned in BANNED_JARGON {
+        assert!(
+            arr.iter().any(|v| v.as_str() == Some(*banned)),
+            "banned_jargon_js missing term {banned:?}"
+        );
+    }
+}
+
+#[test]
+fn rendered_html_injects_banned_jargon_for_summary_humanizer() {
+    // The `{{BANNED_JARGON_JS}}` marker must be substituted with the live
+    // BANNED_JARGON list so the client-side humanizer strips the same jargon
+    // the ledes are forbidden from containing (single source of truth).
+    assert!(
+        !INDEX_HTML.contains("{{BANNED_JARGON_JS}}"),
+        "the BANNED_JARGON marker was not substituted"
+    );
+    assert!(
+        INDEX_HTML.contains("const BANNED_JARGON="),
+        "rendered HTML must define the client-side BANNED_JARGON list"
+    );
+    for banned in BANNED_JARGON {
+        assert!(
+            INDEX_HTML.contains(banned),
+            "rendered HTML missing injected jargon term {banned:?} for the summary humanizer"
+        );
+    }
+}
+
+#[test]
+fn rendered_html_humanizes_cycle_summaries() {
+    // The humanizer must be defined and applied; raw `esc(rpt.summary)` must
+    // no longer reach the user-facing summary slots (that path leaked `OODA`,
+    // `goals=2`, `tree=clean`).
+    assert!(
+        INDEX_HTML.contains("function humanizeCycleSummary("),
+        "humanizeCycleSummary helper must be defined"
+    );
+    assert!(
+        INDEX_HTML.contains("humanizeCycleSummary(rpt.summary)"),
+        "Thinking legacy cycle summary must be humanized"
+    );
+    assert!(
+        INDEX_HTML.contains("humanizeCycleSummary(rpt.summary||'')"),
+        "Thinking inline cycle summary must be humanized"
+    );
+    assert!(
+        INDEX_HTML.contains("humanizeCycleSummary(c.summary||'')"),
+        "OODA cycle-history summary must be humanized"
+    );
+    assert!(
+        !INDEX_HTML.contains("esc(rpt.summary)"),
+        "raw esc(rpt.summary) still leaks the machine cycle summary"
+    );
+}
+
+#[test]
+fn rendered_html_drops_false_invoice_cost_claim() {
+    // #2358 P1: the Costs lede claimed "real provider invoices rather than
+    // estimates" while the metric is labeled "Estimated Cost". The lede must
+    // no longer make the invoice claim.
+    assert!(
+        !INDEX_HTML.contains("real provider invoices rather than estimates"),
+        "Costs lede must not claim invoice-derived figures while labeling them Estimated"
+    );
+}
+
+#[test]
+fn rendered_html_defines_token_humanizers() {
+    for needle in [
+        "function humanizeGoalId(",
+        "function humanizePeriod(",
+        "humanizeGoalId(top.goal_id)",
+    ] {
+        assert!(
+            INDEX_HTML.contains(needle),
+            "rendered HTML missing humanizer wiring: {needle}"
+        );
+    }
 }

--- a/tests/gadugi/dashboard-jargon-clarity.sh
+++ b/tests/gadugi/dashboard-jargon-clarity.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# dashboard-jargon-clarity.sh — outside-in check for issue #2358 (P1/P2).
+#
+# The live Playwright audit found machine jargon and contradictory copy across
+# the Memory, Costs, Overview, Goals and Thinking tabs. This script boots the
+# real dashboard binary, logs in, and asserts — against the served HTML and the
+# live /api/memory/recent response — that the P1/P2 fixes are present:
+#
+#   * Costs lede no longer claims "real provider invoices rather than estimates"
+#     while labeling the metric "Estimated Cost".
+#   * The cycle/summary humanizer (humanizeCycleSummary) and the token
+#     humanizers (humanizeGoalId, humanizePeriod) are wired in, and the
+#     BANNED_JARGON list is injected so the ban extends to rendered summaries.
+#   * The Memory "What Simard Remembers" counter reflects total stored memory
+#     and /api/memory/recent reports a real total instead of a hard-coded 0.
+#   * The Goals "Current Activity" raw "[raw]" marker is gone.
+set -euo pipefail
+
+PORT="${DASH_PORT:-8139}"
+DASHKEY_FILE="${HOME}/.simard/.dashkey"
+LOG="$(mktemp -t dash-jargon.XXXXXX.log)"
+CJ="$(mktemp -t dash-jargon-cookies.XXXXXX)"
+
+echo "[jargon] building simard binary…"
+cargo build --quiet --bin simard
+BIN="${CARGO_TARGET_DIR:-target}/debug/simard"
+if [[ ! -x "$BIN" ]]; then
+  echo "[jargon] FAIL: built binary not found at $BIN" >&2
+  exit 1
+fi
+
+echo "[jargon] starting dashboard on :$PORT"
+"$BIN" dashboard serve --port="$PORT" >"$LOG" 2>&1 &
+DASH_PID=$!
+cleanup() { kill "$DASH_PID" 2>/dev/null || true; rm -f "$CJ"; }
+trap cleanup EXIT
+
+up=0
+for _ in $(seq 1 30); do
+  if curl -s -o /dev/null "http://localhost:$PORT/login"; then up=1; break; fi
+  sleep 1
+done
+if [[ "$up" -ne 1 ]]; then
+  echo "[jargon] FAIL: dashboard did not come up on :$PORT" >&2
+  cat "$LOG" >&2
+  exit 1
+fi
+
+KEY="$(cat "$DASHKEY_FILE")"
+if ! curl -s -c "$CJ" -X POST -H 'Content-Type: application/json' \
+      -d "{\"code\":\"$KEY\"}" "http://localhost:$PORT/api/login" | grep -q '"ok":true'; then
+  echo "[jargon] FAIL: login rejected" >&2
+  exit 1
+fi
+
+HTML="$(curl -s -b "$CJ" "http://localhost:$PORT/")"
+RECENT="$(curl -s -b "$CJ" "http://localhost:$PORT/api/memory/recent")"
+
+fail() { echo "[jargon] FAIL: $1" >&2; exit 1; }
+
+# ── P1: Costs label vs lede consistency ──────────────────────────────────────
+grep -qF 'real provider invoices rather than estimates' <<<"$HTML" \
+  && fail "Costs lede still claims invoice-derived figures while labeling them Estimated"
+grep -qF 'the dollar figures are estimates based on' <<<"$HTML" \
+  || fail "Costs lede must state the figures are estimates"
+
+# ── P2: cycle/summary + token humanizers are wired in ────────────────────────
+grep -qF 'function humanizeCycleSummary(' <<<"$HTML" \
+  || fail "humanizeCycleSummary must be defined so OODA/key=value never leak"
+grep -qF 'humanizeCycleSummary(rpt.summary)' <<<"$HTML" \
+  || fail "Thinking tab must humanize the cycle summary"
+grep -qF 'function humanizeGoalId(' <<<"$HTML" \
+  || fail "humanizeGoalId must map sentinel ids like __memory__"
+grep -qF 'humanizeGoalId(top.goal_id)' <<<"$HTML" \
+  || fail "Overview top priority must humanize the goal id"
+grep -qF 'function humanizePeriod(' <<<"$HTML" \
+  || fail "humanizePeriod must humanize daily:/weekly: period keys"
+grep -qF 'const BANNED_JARGON=' <<<"$HTML" \
+  || fail "BANNED_JARGON must be injected so the ban extends to rendered summaries"
+
+# ── P2: Goals 'Current Activity' raw marker is gone ──────────────────────────
+grep -qF "'[raw]'" <<<"$HTML" \
+  && fail "Goals Current Activity must not render the literal [raw] marker"
+
+# ── P1: Memory panel surfaces the live stored total, never claims empty ──────
+grep -qF "(d.total||0).toLocaleString()+' total'" <<<"$HTML" \
+  || fail "Memory panel must surface the humanized stored total (#2358)"
+grep -qF 'No new memories in the last hour' <<<"$HTML" \
+  || fail "Memory empty-state must distinguish last-hour from total stored"
+grep -q '"total"' <<<"$RECENT" \
+  || fail "/api/memory/recent must expose a total stored count"
+
+echo "[jargon] PASS: dashboard jargon/clarity fixes hold (#2358 P1/P2)"

--- a/tests/gadugi/dashboard-jargon-clarity.yaml
+++ b/tests/gadugi/dashboard-jargon-clarity.yaml
@@ -1,0 +1,52 @@
+name: "Dashboard Jargon & Clarity Fixes (#2358)"
+description: "Outside-in operator check that the dashboard's P1/P2 usability fixes from issue #2358 hold: the Costs lede no longer contradicts its 'Estimated Cost' label, the cycle/summary and token humanizers are wired in (so OODA, key=value shorthand and sentinel goal ids never leak), the Memory panel surfaces the live stored total without claiming it is empty, and the Goals 'Current Activity' raw [raw] marker is gone. Boots the real dashboard binary, authenticates, and asserts the served HTML and the live /api/memory/recent response."
+version: "1.0.0"
+
+config:
+  timeout: 300000
+  retries: 0
+  parallel: false
+
+environment:
+  requires: []
+
+agents:
+  - name: "cli-agent"
+    type: "cli"
+    config:
+      workingDirectory: "."
+      defaultTimeout: 300000
+      executionMode: "spawn"
+      captureOutput: true
+      ioConfig:
+        encoding: "utf8"
+        handleInteractivePrompts: false
+      logConfig:
+        logCommands: true
+        logOutput: true
+        logLevel: "info"
+
+steps:
+  - name: "Dashboard humanizes machine jargon and reconciles contradictory copy"
+    agent: "cli-agent"
+    action: "execute_command"
+    params:
+      command: "tests/gadugi/dashboard-jargon-clarity.sh"
+    timeout: 300000
+
+assertions: []
+
+cleanup:
+  - name: "CLI agent cleanup"
+    agent: "cli-agent"
+    action: "cleanup"
+
+metadata:
+  tags:
+    - "dashboard"
+    - "usability"
+    - "jargon"
+    - "issue-2358"
+  priority: "high"
+  author: "copilot"
+  test_type: "outside-in"


### PR DESCRIPTION
## What & why

Implements the **P1 and P2** usability fixes from the evidence-backed backlog in #2358 (filed from a live Playwright audit). The dashboard was showing machine tokens and self-contradicting copy across the Memory, Costs, Overview, Goals and Thinking tabs, violating the self-serve-dashboard goal's "no jargon, useful to humans" mandate.

### P1
- **Memory counter clarity.** `/api/memory/recent` always returned `total:0` (per-item listing is unavailable on the library backend post-#2307), so the Memory tab read *"0 total — No memories stored yet"* while the store held 32k+ entries. The endpoint now reports the **real total stored** (`CognitiveStatistics::total()` via `open_reader_bridge`), the prominent counter reflects total stored, and the empty state reads *"No new memories in the last hour — N total stored."*
- **Growth badge/rate agreement.** The trend badge is now derived from the **same signed** `rate_per_hour.long_term_total` it displays, so *"↑ Growing"* can no longer sit next to a negative rate.
- **Cost label vs lede.** The Costs lede no longer claims figures are *"real provider invoices rather than estimates"* while the metric is labeled *"Estimated Cost"* — it now states the figures are estimates from published token prices.

### P2 (humanize machine tokens)
- Cost **period keys** humanized in `renderSummary`: `daily:2026-06-22` → *"Today (Jun 22)"*, `weekly:last-7-days` → *"Last 7 days"*.
- **`__memory__`** sentinel goal id → *"Memory maintenance"* on the Overview top priority and Thinking orient (`humanizeGoalId`).
- Goals **"Current Activity"**: strips the raw `advance-goal:` / `no-action:` action-verb prefixes (`goals_status.rs`), drops the literal `[raw]` expander marker, and spaces the chip from the detail.
- **Jargon ban extended from ledes to rendered summaries.** `BANNED_JARGON` (the tab-lede ban list) is injected into the page and `humanizeCycleSummary` rewrites the canonical *"OODA cycle #1159: 3 priorities, 2 actions (2/2 succeeded), goals=2, issues=20, tree=clean"* into human prose — *"Cycle #1159 — 3 priorities considered, 2 of 2 actions succeeded · 2 goals tracked · 20 open issues · working tree clean"* — at every render site (Thinking, Logs, OODA cycle history). The canonical `summarize_cycle_report` (logs/persistence) is intentionally **unchanged**.

Closes the P1 items and **P2 items 1, 2, 4, 5** of #2358. The `[deploy]` redeploy, the Overview brain-action-detail (**P2 item 3**) and the **P3** unit/number items remain tracked on the issue.

---

## Live Playwright re-verification

Re-ran a Playwright (Chromium, headless) audit against the freshly-built binary, authenticated with `~/.simard/.dashkey` (`POST /api/login`), screenshotting Memory/Costs/Overview/Goals/Thinking. Each previously-broken string now renders human-readable **against live data**:

| Tab | Before (per #2358) | After (this PR, live) |
|---|---|---|
| Overview | `Top Priority: __memory__` | **Top Priority: Memory maintenance** |
| Memory | `0 total … No memories stored yet` | **1,788 memories stored in total** · *"No new memories in the last hour — 1,788 total stored."* |
| Memory | `↑ Growing` next to `-2.6 …/hr` | **↓ Shrinking** next to **-1.6 long-term mem/hr** (agree) |
| Costs | `Period daily:2026-06-22` / `weekly:last-7-days` | **Period Today (Jun 22)** / **Last 7 days** |
| Costs | "real provider invoices" vs "Estimated Cost" | lede = "estimates from published token prices"; label = "Estimated Cost" (consistent) |
| Thinking | `OODA cycle #1159: … goals=2, … tree=clean` | **Cycle #1159 — 3 priorities considered, 2 of 2 actions succeeded · 2 goals tracked · 20 open issues · working tree clean** |
| Goals | `Workingadvance-goal: no-action: … [raw]` | chip **Skipped** + cleaned detail; no `advance-goal:`/`no-action:`/`[raw]` |

Screenshots + captured panel text were produced for all five tabs (`tab-<slug>.png`, `audit-report.json`).

---

## Merge-ready evidence

**1. qa-team / gadugi scenarios — written, validated, run.**
- New outside-in scenario `tests/gadugi/dashboard-jargon-clarity.{yaml,sh}` boots the real binary, authenticates, and asserts the served HTML + live `/api/memory/recent`.
- `gadugi-test validate -f tests/gadugi/dashboard-jargon-clarity.yaml` → `✓ Scenario "Dashboard Jargon & Clarity Fixes (#2358)" is valid`.
- `gadugi-test run -s dashboard-jargon-clarity` → `✓ Passed: 1 / ✗ Failed: 0` (25s).
- Regression: `gadugi-test run -s dashboard-memory-fidelity` → `✓ Passed: 1 / ✗ Failed: 0` (existing Memory-tab scenario still green).

**2. Docs / changed user-facing surfaces.**
Changed surfaces are operator-dashboard panel copy (Costs lede, Memory counter + empty state, cost period labels, goal-id labels, cycle-summary text, Goals Current Activity). These strings are the change itself; the Costs/Memory ledes live in the `tab_meta::TAB_METADATA` single source of truth and are enforced verbatim in the rendered HTML by the tab-identity cross-check tests. No doc in `docs/` quotes the changed copy (`docs/dashboard.md` carries only generic one-line tab descriptions), so no separate docs file needs updating.

**3. quality-audit — 3 SEEK→VALIDATE→FIX cycles, clean final.**
- **Cycle 1 (security-review):** found no exploitable issues; flagged that the new `banned_jargon_js()` didn't `<`-escape like `tab_meta_js()` (defense-in-depth) → **fixed** (mirrored the `\u003c` escaping).
- **Cycle 2 (code-review):** **no blocking issues** — verified humanizers guard null/undefined, all HTML sinks are `esc()`-wrapped, the `BANNED_JARGON` literal can't break out of `<script>`, the `memory.rs` `Result`-chain degrades to 0 safely, badge/rate derive from one value, the canonical regex matches the real summary format, and the Costs lede is byte-identical across `part_00.rs`/`tab_meta.rs`.
- **Cycle 3 (structured self-review + validation):** re-verified all seven change areas; full unit tests + 2 gadugi scenarios + live Playwright audit all green. Zero critical/high; zero medium correctness/security findings.

Both reviewers separately noted the **pre-existing** unescaped cost `${fmt}` sink (`part_04.rs`) — present before this change, fed only by server-generated period/numeric values, and **not a regression**. Left as-is to keep the diff focused (it also covers numeric cost/token rendering outside #2358's scope); tracked as a defense-in-depth follow-up.

**4. CI — 100% green (0 failures).**
The previously-tracked `operator_commands_dashboard::tests_goals_crud::full_goal_lifecycle_crud` parallel goal-board state-isolation flake (**#2360**) is resolved on `main`: the branch is now rebased onto current `main`, which carries the goal-board read-after-write/test-isolation fix from **#2334** (closes #2320/#2316). The separate in-flight flake PR **#2365** was closed as superseded. On the latest PR commit (`b113841`) every required check now passes:

| Check | Result |
|---|---|
| `pre-commit` (full `cargo test` suite) | ✅ pass (~10–11 min, no flake) |
| `coverage` | ✅ pass (~21 min) |
| `install-real` | ✅ pass (~24 min) |
| `e2e-dashboard` | ✅ pass |
| `cargo-audit` | ✅ pass |
| GitGuardian Security Checks | ✅ pass |

`mergeStateStatus` is now **`CLEAN`** with **0** non-success checks. The flake was always **independent of this diff** (which touches only dashboard JS strings, a read-only `memory_recent` total, `goals_status` string-stripping, and `tab_meta`); with the isolation fix on `main` the full suite runs green in CI. Pre-flight was also green in a stable build dir: `cargo fmt --all -- --check` ✓, `cargo clippy --all-targets --all-features --locked -- -D warnings` ✓, `scripts/check-rust-only-gate.sh --staged` ✓.

**5.** This description carries concrete evidence for criteria 1–4 and 6.

**6. Focused diff.** 10 source files + 2 test-scenario files; no unrelated edits. The canonical `summarize_cycle_report` is deliberately untouched so logs/persistence and existing `ooda` tests stay green.

---

Refs #2358. **CI confirmed 100% green** (`mergeStateStatus: CLEAN`, all 6 checks ✅, 0 failures) after the rebase onto `main`. All six merge-ready criteria are now satisfied — **ready to merge** (`--squash`).

