### PR TITLE
fix(cleanup): reclaim library-backend corrupt-WAL/store quarantines (#2307)

### DIFF
--- a/docs/operations/cognitive-memory-durability.md
+++ b/docs/operations/cognitive-memory-durability.md
@@ -818,6 +818,42 @@ counter.
 If the directory is growing despite successful backups, verify
 `SIMARD_DB_BACKUP_KEEP` is non-zero — `0` disables pruning entirely.
 
+### "`~/.simard` is filling up with `cognitive.corrupt-*` files"
+
+When LadybugDB detects a corrupt store or WAL it does not delete the bad
+bytes — it **quarantines** them in place so they remain available for
+forensics. With the library backend (de-fork Phase 2b, #2307) the live store
+is `~/.simard/cognitive` (plus the `cognitive.wal` write-ahead log), so the
+quarantines are named:
+
+```text
+cognitive.corrupt-<ts>                       # quarantined main store
+cognitive.wal.corrupt-<ts>                   # quarantined WAL
+cognitive.corrupt-<ts>.cognitive.shadow      # shadow side-file
+cognitive.corrupt-<ts>.bak                   # snapshot copy
+cognitive.corrupt-<ts>.cognitive.wal.corrupt-<ts>   # recursively nested chains
+```
+
+(The pre-#2307 native backend left `cognitive_memory.corrupt-<ts>`
+single-file snapshots.) Each name carries the `.corrupt-<ts>` infix; the live
+store files never do.
+
+These quarantines are pure dead weight once an incident has been reviewed.
+`simard cleanup` garbage-collects every quarantine generation older than
+`CORRUPT_DB_MAX_AGE_DAYS` (7 days) — both the legacy `cognitive_memory.corrupt-*`
+snapshots and the library backend's `cognitive.corrupt-*` /
+`cognitive.wal.corrupt-*` / `*.cognitive.shadow` families — while never touching
+the live `cognitive` / `cognitive.wal` store. Run it manually to reclaim space
+immediately, or rely on the scheduled OODA cleanup action:
+
+```bash
+simard cleanup   # reclaims quarantines older than 7 days, among other artifacts
+```
+
+If quarantines are being *created* repeatedly (new `.corrupt-<ts>` files each
+cycle), that is a corruption signal in its own right — capture a sample and
+file a `durability` issue rather than just deleting them.
+
 ### "I see `durability barrier failed` in the journal"
 
 This is the per-write fsync barrier (#1973) reporting an I/O failure

--- a/src/cmd_cleanup/disk.rs
+++ b/src/cmd_cleanup/disk.rs
@@ -316,9 +316,40 @@ pub fn cap_home_cargo_targets(report: &mut CleanupReport, cap_bytes: u64) {
 /// Maximum age (in days) of corrupted memory DB files before deletion.
 pub const CORRUPT_DB_MAX_AGE_DAYS: u64 = 7;
 
-/// Remove `~/.simard/cognitive_memory.corrupt-*` files older than the threshold.
-/// These are quarantined snapshots of corrupted DBs; useful briefly for forensics
-/// then pure dead weight.
+/// Returns `true` when `name` is a quarantined corrupt cognitive-memory
+/// artifact (safe to garbage-collect) and `false` for the live store.
+///
+/// Two backend generations leave quarantine files in `~/.simard`:
+///
+/// * **Native fork (pre-#2307).** A single-file store at
+///   `cognitive_memory.ladybug`; corrupt snapshots were renamed
+///   `cognitive_memory.corrupt-<ts>`.
+/// * **Library backend (de-fork Phase 2b, #2307).** The store lives at
+///   `cognitive` with a `cognitive.wal` write-ahead log. When LadybugDB
+///   detects corruption it quarantines the bad file in place, producing
+///   `cognitive.corrupt-<ts>`, `cognitive.wal.corrupt-<ts>`, recursively
+///   nested `…cognitive.wal.corrupt-<ts>` chains, `…cognitive.shadow`
+///   side-files, and `…corrupt-<ts>.bak` copies.
+///
+/// Every quarantine name carries the `.corrupt-<ts>` infix, while the live
+/// store files (`cognitive`, `cognitive.wal`, `cognitive.shadow`) never do.
+/// Matching on that infix — anchored to the `cognitive`/`cognitive_memory`
+/// store stem — therefore reclaims every stale quarantine generation without
+/// ever risking the live store. Before this generalization the cleanup only
+/// matched the native `cognitive_memory.corrupt-` prefix, so post-de-fork
+/// library quarantines accumulated unbounded (issue #2307 fallout).
+fn is_corrupt_quarantine_name(name: &str) -> bool {
+    (name.starts_with("cognitive.") || name.starts_with("cognitive_memory."))
+        && name.contains(".corrupt-")
+}
+
+/// Remove quarantined corrupt cognitive-memory snapshots in `~/.simard` older
+/// than [`CORRUPT_DB_MAX_AGE_DAYS`]. Covers both the native single-file
+/// `cognitive_memory.corrupt-*` snapshots and the library backend's
+/// `cognitive.corrupt-*` / `cognitive.wal.corrupt-*` / `*.cognitive.shadow`
+/// quarantines (see [`is_corrupt_quarantine_name`]). These are useful briefly
+/// for forensics then pure dead weight. The live store (`cognitive`,
+/// `cognitive.wal`) is never matched.
 pub fn remove_old_corrupt_dbs(report: &mut CleanupReport) {
     let Some(home) = std::env::var_os("HOME") else {
         return;
@@ -331,7 +362,7 @@ pub fn remove_old_corrupt_dbs(report: &mut CleanupReport) {
     let now = std::time::SystemTime::now();
     for entry in entries.flatten() {
         let name = entry.file_name().to_string_lossy().to_string();
-        if !name.starts_with("cognitive_memory.corrupt-") {
+        if !is_corrupt_quarantine_name(&name) {
             continue;
         }
         let path = entry.path();
@@ -342,13 +373,27 @@ pub fn remove_old_corrupt_dbs(report: &mut CleanupReport) {
         if now.duration_since(modified).unwrap_or_default() < max_age {
             continue;
         }
-        let size = meta.len();
+        // A cognitive-memory store may be backed by a single file or a
+        // directory, so a quarantine snapshot can be either. Size and remove
+        // accordingly; `remove_file` on a directory would otherwise fail and
+        // leave the quarantine in place.
+        let is_dir = meta.is_dir();
+        let size = if is_dir {
+            dir_size(&path).unwrap_or(0)
+        } else {
+            meta.len()
+        };
         eprintln!(
             "  Removing old corrupt DB {} ({} MB)",
             path.display(),
             size / (1024 * 1024)
         );
-        if let Err(e) = std::fs::remove_file(&path) {
+        let removed = if is_dir {
+            std::fs::remove_dir_all(&path)
+        } else {
+            std::fs::remove_file(&path)
+        };
+        if let Err(e) = removed {
             report
                 .errors
                 .push(format!("failed to remove {}: {e}", path.display()));

--- a/src/cmd_cleanup/tests.rs
+++ b/src/cmd_cleanup/tests.rs
@@ -599,3 +599,180 @@ fn kill_orphaned_cargo_processes_scans_cleanly() {
     kill_orphaned_cargo_processes(&mut report);
     assert!(report.errors.is_empty());
 }
+
+/// Set a path's modification time `days` into the past. Files are opened with
+/// write access (matching the helper above); directories must be opened
+/// read-only because a directory cannot be opened `write(true)` on Unix.
+fn backdate(path: &std::path::Path, days: u64) {
+    let when = std::time::SystemTime::now() - std::time::Duration::from_secs(days * 24 * 3600);
+    let times = std::fs::FileTimes::new().set_modified(when);
+    let f = if path.is_dir() {
+        std::fs::File::open(path).unwrap()
+    } else {
+        std::fs::File::options().write(true).open(path).unwrap()
+    };
+    f.set_times(times).unwrap();
+}
+
+/// Run `remove_old_corrupt_dbs` with `HOME` pointed at `home`, restoring the
+/// previous value afterward. Serialized by the caller's
+/// `#[serial(cognitive_memory)]` attribute so the process-wide `HOME` mutation
+/// cannot race other tests that read the cognitive-memory store.
+fn run_corrupt_cleanup_with_home(home: &std::path::Path) -> CleanupReport {
+    let old_home = std::env::var_os("HOME");
+    unsafe {
+        std::env::set_var("HOME", home);
+    }
+    let mut report = CleanupReport::default();
+    remove_old_corrupt_dbs(&mut report);
+    match old_home {
+        Some(h) => unsafe { std::env::set_var("HOME", h) },
+        None => unsafe { std::env::remove_var("HOME") },
+    }
+    report
+}
+
+/// De-fork Phase 2b (#2307) moved the store from the native single-file
+/// `cognitive_memory.ladybug` to the library backend at `cognitive`. The
+/// library quarantines corruption as `cognitive.corrupt-*`,
+/// `cognitive.wal.corrupt-*`, recursively nested `…cognitive.wal.corrupt-*`
+/// chains, `…cognitive.shadow` side-files, and `…corrupt-*.bak` copies. All
+/// of these must be reclaimed once aged — the pre-fix matcher only knew the
+/// native `cognitive_memory.corrupt-` prefix, so they leaked forever.
+#[test]
+#[serial_test::serial(cognitive_memory)]
+fn corrupt_db_removes_aged_library_backend_quarantines() {
+    let tmp = tempfile::tempdir().unwrap();
+    let simard = tmp.path().join(".simard");
+    std::fs::create_dir_all(&simard).unwrap();
+
+    let quarantines = [
+        "cognitive.corrupt-1700000000",
+        "cognitive.wal.corrupt-1700000000",
+        "cognitive.corrupt-1700000000.cognitive.shadow",
+        "cognitive.corrupt-1700000000.bak",
+        "cognitive.corrupt-1700000000.cognitive.wal.corrupt-1700000001",
+        "cognitive_memory.corrupt-1700000000", // legacy native still covered
+    ];
+    for q in &quarantines {
+        let p = simard.join(q);
+        std::fs::write(&p, b"corrupt-bytes").unwrap();
+        backdate(&p, CORRUPT_DB_MAX_AGE_DAYS + 1);
+    }
+
+    // Live store files must survive untouched (recent mtime, no `.corrupt-`).
+    let live = simard.join("cognitive");
+    let live_wal = simard.join("cognitive.wal");
+    std::fs::write(&live, b"live-store").unwrap();
+    std::fs::write(&live_wal, b"wal").unwrap();
+
+    let report = run_corrupt_cleanup_with_home(tmp.path());
+
+    for q in &quarantines {
+        assert!(
+            !simard.join(q).exists(),
+            "aged library quarantine should be removed: {q}"
+        );
+    }
+    assert!(
+        live.exists(),
+        "live `cognitive` store must never be removed"
+    );
+    assert!(
+        live_wal.exists(),
+        "live `cognitive.wal` must never be removed"
+    );
+    assert!(
+        report.bytes_freed >= ("corrupt-bytes".len() as u64) * quarantines.len() as u64,
+        "freed bytes should account for every removed quarantine"
+    );
+    assert_eq!(
+        report.dirs_removed.len(),
+        quarantines.len(),
+        "every quarantine should be reported as removed"
+    );
+    assert!(report.errors.is_empty(), "no errors expected: {report:?}");
+}
+
+/// Safety invariant: a name without the `.corrupt-` infix is the live store and
+/// must NEVER be deleted — even if it is older than the threshold. Guards
+/// against a future over-broad matcher wiping `~/.simard/cognitive` and
+/// destroying all persistent memory.
+#[test]
+#[serial_test::serial(cognitive_memory)]
+fn corrupt_db_never_removes_live_store_even_when_aged() {
+    let tmp = tempfile::tempdir().unwrap();
+    let simard = tmp.path().join(".simard");
+    std::fs::create_dir_all(&simard).unwrap();
+
+    let live_files = [
+        "cognitive",
+        "cognitive.wal",
+        "cognitive.shadow",
+        "cognitive_memory.ladybug",
+    ];
+    for f in &live_files {
+        let p = simard.join(f);
+        std::fs::write(&p, b"do-not-delete").unwrap();
+        backdate(&p, CORRUPT_DB_MAX_AGE_DAYS + 30);
+    }
+
+    let report = run_corrupt_cleanup_with_home(tmp.path());
+
+    for f in &live_files {
+        assert!(
+            simard.join(f).exists(),
+            "live store file must survive cleanup: {f}"
+        );
+    }
+    assert_eq!(report.bytes_freed, 0, "nothing should have been freed");
+    assert!(report.dirs_removed.is_empty(), "nothing should be removed");
+}
+
+/// A directory-backed store quarantine (the design documents the store as a
+/// LadybugDB `GraphStore` directory) must be removed recursively — a plain
+/// `remove_file` would fail and leak the directory.
+#[test]
+#[serial_test::serial(cognitive_memory)]
+fn corrupt_db_removes_aged_directory_quarantine() {
+    let tmp = tempfile::tempdir().unwrap();
+    let simard = tmp.path().join(".simard");
+    std::fs::create_dir_all(&simard).unwrap();
+
+    let dir_q = simard.join("cognitive.corrupt-1700000000");
+    std::fs::create_dir_all(&dir_q).unwrap();
+    std::fs::write(dir_q.join("data"), b"abcdef").unwrap();
+    std::fs::write(dir_q.join("data.wal"), b"ghij").unwrap();
+    backdate(&dir_q, CORRUPT_DB_MAX_AGE_DAYS + 1);
+
+    let report = run_corrupt_cleanup_with_home(tmp.path());
+
+    assert!(
+        !dir_q.exists(),
+        "aged directory quarantine should be removed recursively"
+    );
+    assert_eq!(
+        report.bytes_freed,
+        ("abcdef".len() + "ghij".len()) as u64,
+        "freed bytes should sum the directory contents"
+    );
+}
+
+/// Young library quarantines are kept for forensics — the age threshold applies
+/// to the new filename shapes exactly as it did to the native prefix.
+#[test]
+#[serial_test::serial(cognitive_memory)]
+fn corrupt_db_keeps_young_library_quarantine() {
+    let tmp = tempfile::tempdir().unwrap();
+    let simard = tmp.path().join(".simard");
+    std::fs::create_dir_all(&simard).unwrap();
+
+    let young = simard.join("cognitive.corrupt-1700000000");
+    std::fs::write(&young, b"recent").unwrap();
+    // No backdating: mtime is "now", inside the retention window.
+
+    let report = run_corrupt_cleanup_with_home(tmp.path());
+
+    assert!(young.exists(), "young library quarantine should survive");
+    assert_eq!(report.bytes_freed, 0);
+}

--- a/tests/qa-scenarios/cognitive-memory-corrupt-quarantine-cleanup.yaml
+++ b/tests/qa-scenarios/cognitive-memory-corrupt-quarantine-cleanup.yaml
@@ -1,0 +1,73 @@
+name: cognitive-memory-corrupt-quarantine-cleanup
+app_type: cli
+description: |
+  Verify `simard cleanup` (remove_old_corrupt_dbs) garbage-collects the library
+  backend's corrupt store/WAL quarantines introduced by the de-fork (Phase 2b,
+  issue #2307) — files named `cognitive.corrupt-*`, `cognitive.wal.corrupt-*`,
+  and `*.cognitive.shadow`. Before the fix the matcher only knew the legacy
+  `cognitive_memory.corrupt-` prefix, so these accumulated unbounded in
+  `~/.simard`. Behavior is proven by the hermetic tempdir unit tests this
+  scenario drives (no destructive action against the live host).
+agents:
+  - name: simard-cli
+    type: cli
+    command: cargo
+steps:
+  # Regression fix: aged library-backend quarantines (new filename shapes) are reclaimed,
+  # AND the critical safety invariant (live `cognitive`/`cognitive.wal` store survives).
+  # The CLI runner rejects any non-zero exit, so a failing test fails the scenario.
+  # First invocation may compile the test binary; subsequent filters reuse it.
+  - action: run
+    params:
+      command: "cargo test --locked --lib cmd_cleanup::tests::corrupt_db_removes_aged_library_backend_quarantines"
+    timeout: 600000
+  - action: wait_for_output
+    params:
+      value: "test result: ok"
+    timeout: 8000
+  - action: validate_exit_code
+    params:
+      value: "0"
+    timeout: 5000
+
+  # Safety invariant in isolation: the live store is never deleted, even when aged 30+ days.
+  - action: run
+    params:
+      command: "cargo test --locked --lib cmd_cleanup::tests::corrupt_db_never_removes_live_store_even_when_aged"
+    timeout: 300000
+  - action: wait_for_output
+    params:
+      value: "test result: ok"
+    timeout: 8000
+  - action: validate_exit_code
+    params:
+      value: "0"
+    timeout: 5000
+
+  # Directory-backed store quarantines are removed recursively (not just files).
+  - action: run
+    params:
+      command: "cargo test --locked --lib cmd_cleanup::tests::corrupt_db_removes_aged_directory_quarantine"
+    timeout: 300000
+  - action: wait_for_output
+    params:
+      value: "test result: ok"
+    timeout: 8000
+  - action: validate_exit_code
+    params:
+      value: "0"
+    timeout: 5000
+
+  # Forensics retention: young quarantines are kept within the 7-day window.
+  - action: run
+    params:
+      command: "cargo test --locked --lib cmd_cleanup::tests::corrupt_db_keeps_young_library_quarantine"
+    timeout: 300000
+  - action: wait_for_output
+    params:
+      value: "test result: ok"
+    timeout: 8000
+  - action: validate_exit_code
+    params:
+      value: "0"
+    timeout: 5000


### PR DESCRIPTION
## Problem

The de-fork (Phase 2b, **#2307**) moved the cognitive-memory store from the native single-file `cognitive_memory.ladybug` to the **library backend** at `~/.simard/cognitive` (`amplihack-memory-lib`, lbug-backed). When LadybugDB detects corruption it **quarantines** the bad bytes in place rather than deleting them:

```
cognitive.corrupt-<ts>                              # quarantined main store
cognitive.wal.corrupt-<ts>                          # quarantined WAL
cognitive.corrupt-<ts>.cognitive.shadow             # shadow side-file
cognitive.corrupt-<ts>.bak                          # snapshot copy
cognitive.corrupt-<ts>.cognitive.wal.corrupt-<ts>   # recursively nested chains
```

`cmd_cleanup::disk::remove_old_corrupt_dbs` still only matched the **old native** prefix `cognitive_memory.corrupt-`, so none of the new library-backend quarantines were ever reclaimed — they accumulated **unbounded** (observed on a live host: **77 files / 87.7 MB**, individual files up to ~31 MB). That is a slow disk-pressure leak that can itself trigger the ENOSPC WAL-corruption incident class (#1697) this subsystem defends against.

## Fix

- Generalize the matcher to **`is_corrupt_quarantine_name`**: a name anchored to the `cognitive.` / `cognitive_memory.` store stem **and** carrying the `.corrupt-<ts>` infix. Covers every quarantine generation (native + library, including nested/shadow/bak shapes).
- The live store files (`cognitive`, `cognitive.wal`, `cognitive.shadow`) **never** carry `.corrupt-`, so they can never match — the catastrophic "delete the live store" failure mode is impossible by construction.
- Handle **directory-backed** store quarantines (recursive `remove_dir_all` + `dir_size`) instead of silently failing on `remove_file`.
- The 7-day forensics-retention threshold (`CORRUPT_DB_MAX_AGE_DAYS`) is unchanged; legacy `cognitive_memory.corrupt-*` snapshots still match.

## Evidence

### 1. qa-team scenarios (criterion 1)
- Added `tests/qa-scenarios/cognitive-memory-corrupt-quarantine-cleanup.yaml` in the executable gadugi format (`params`-nested `run`/`wait_for_output`/`validate_exit_code`, integer-ms timeouts, per #2371).
- `gadugi-test validate --strict` → **valid** (1/1).
- `gadugi-test run` → **PASS** (`✓ Passed: 1 / Failed: 0 / All tests passed!`); each step drives a hermetic unit test and reports `test result: ok`:
  - `corrupt_db_removes_aged_library_backend_quarantines` — every library quarantine shape reclaimed.
  - `corrupt_db_never_removes_live_store_even_when_aged` — **safety invariant**: live store survives even when 30+ days old.
  - `corrupt_db_removes_aged_directory_quarantine` — directory quarantine removed recursively.
  - `corrupt_db_keeps_young_library_quarantine` — 7-day retention honored.
- `cargo test --lib cmd_cleanup` (runs in CI): **28 passed; 0 failed**, including the legacy `corrupt_db_removed_when_older_than_threshold` regression and the `every_env_mutating_test_is_serialized` meta-guard (all HOME-mutating tests carry `#[serial_test::serial(cognitive_memory)]`, #2365).

### 2. Docs (criterion 2)
- `docs/operations/cognitive-memory-durability.md`: new operational-runbook entry **"`~/.simard` is filling up with `cognitive.corrupt-*` files"** documenting the quarantine families and the 7-day `simard cleanup` reclaim.
- `mkdocs build --strict` → exit 0.

### 3. quality-audit (criterion 3)
3 SEEK→VALIDATE→FIX cycles + an independent code-review pass over the diff:
1. **Matcher correctness** — dual-clause matcher cannot match any live-store name and misses no documented quarantine shape.
2. **Directory-removal safety** — `DirEntry::metadata()` uses `lstat` (no symlink follow); entries are direct children of `~/.simard` (no `..`); symlinked entries take the link-only `remove_file` branch — no path-escape vs. prior behavior.
3. **Test integrity / legacy regression** — tests isolate the name-match guarantee (assert `bytes_freed == 0` for aged live files) with exact byte/`dirs_removed` counts; legacy prefix still matches.

Final cycle clean: **zero critical/high; zero medium correctness/security findings.**

### 4. CI (criterion 4)
Rebased as a single clean commit on the latest `main` (merge-base = `main` HEAD `f8c46894`), which carries the `tests_goals_crud` flake fix (#2365) that had failed the prior pre-commit run. Local gates green: `cargo fmt --all --check`, `cargo clippy --release --no-deps -D warnings`, `cargo clippy --all-targets --all-features --locked -D warnings`, race-subset release tests, `cargo test --lib cmd_cleanup` (28/28), and the serial-guard meta-test.

**CI is now 100% green on head `7794b9b0` (`mergeStateStatus: CLEAN`, 0 failures):**
- `verify` (pull_request): https://github.com/rysweet/Simard/actions/runs/27973811715 — `pre-commit` ✅ (11m37s), `install-real` ✅ (23m21s), `e2e-dashboard` ✅, `cargo-audit` ✅.
- `verify` (push): https://github.com/rysweet/Simard/actions/runs/27973811261 — green after re-running a transient crates.io download flake (`curl [16] Error in the HTTP2 framing layer` fetching `tungstenite`) on `install-real`; the re-run passed (`install-real` ✅ 24m33s, `pre-commit` ✅ 10m37s).
- `coverage`: https://github.com/rysweet/Simard/actions/runs/27973811903 — ✅ (18m57s).
- `docs`: https://github.com/rysweet/Simard/actions/runs/27973811720 — ✅.
- `GitGuardian Security Checks` ✅.

### 6. Focused diff (criterion 6)
4 files, **+337 / −6**: the cleanup fix, its tests, the runbook entry, and the QA scenario. No unrelated edits.

