### PR TITLE
feat(meeting): live capture-count tally in meeting REPL (#2376)

### DIFF
--- a/docs/howto/start-a-meeting.md
+++ b/docs/howto/start-a-meeting.md
@@ -95,6 +95,33 @@ Use `/template` to list the 4 built-in templates, or `/template standup` to appl
 
 See [How to use meeting templates](./use-meeting-templates.md) for full details.
 
+### Structured capture and the live tally
+
+Beyond free-form conversation, five slash commands record items deterministically
+(exactly as typed, with no LLM inference) so they always land in the handoff:
+
+| Command | What it records |
+|---------|-----------------|
+| `/decision <text> [--rationale <why>]` | A decision, with an optional rationale |
+| `/action <text>` | An action item (assignee/deadline parsed inline) |
+| `/question <text>` | An open question |
+| `/risk <text>` | An identified risk |
+| `/disagree <text>` | A disagreement or dissenting view |
+
+After each of these commands, Simard prints a compact running tally so you can
+see how much the meeting has captured so far without running `/state`:
+
+```
+[meeting] captured: 1 decision, 0 open questions, 0 action items, 0 risks, 0 disagreements
+```
+
+The tally is plain text (no color) and always begins with the stable
+`[meeting] captured:` banner, so it is easy to `grep` out of terminal
+scrollback. The categories appear in the same order as the `/state` view —
+decisions, open questions, action items, risks, disagreements — and counts use
+singular or plural nouns (`1 decision` vs `2 decisions`). Run `/state` at any
+time to see the full list of captured items in each category.
+
 ### Markdown export
 
 Type `/export` at any point during a meeting to write a markdown snapshot to `~/.simard/meetings/`. The file includes YAML frontmatter (topic, date, duration, message count) and the full conversation history. See [How to export meeting markdown](./export-meeting-markdown.md).

--- a/src/meeting_repl/repl.rs
+++ b/src/meeting_repl/repl.rs
@@ -81,6 +81,64 @@ fn render_backend_error<W: Write>(output: &mut W, source: &str, err: &dyn std::f
     writeln!(output, "{}", yellow(&format!("  ↳ {hint}"))).ok();
 }
 
+/// Format a compact running tally of explicitly captured items.
+///
+/// Issue #2376. After every structured-capture command the interactive REPL
+/// prints this single line so the operator gets the same capture-count
+/// awareness the batch meeting probe already provides (it reports
+/// `captured N decisions, …`) without having to run `/state`.
+///
+/// Contract (deterministic, no LLM):
+/// - Counts come from the explicit-capture stores only, so the line is exact
+///   and reproducible.
+/// - Plain text with no ANSI escapes and a stable `[meeting] captured:` prefix
+///   so operators can `grep` terminal scrollback (matching the existing
+///   `[meeting] …` banner convention).
+/// - Category order matches the `/state` view: decisions → open questions →
+///   action items → risks → disagreements.
+/// - Singular/plural noun forms are chosen per count (`1 decision` vs
+///   `2 decisions`).
+pub(crate) fn format_capture_tally(
+    decisions: usize,
+    open_questions: usize,
+    action_items: usize,
+    risks: usize,
+    disagreements: usize,
+) -> String {
+    fn count(n: usize, singular: &str, plural: &str) -> String {
+        if n == 1 {
+            format!("{n} {singular}")
+        } else {
+            format!("{n} {plural}")
+        }
+    }
+
+    format!(
+        "[meeting] captured: {}, {}, {}, {}, {}",
+        count(decisions, "decision", "decisions"),
+        count(open_questions, "open question", "open questions"),
+        count(action_items, "action item", "action items"),
+        count(risks, "risk", "risks"),
+        count(disagreements, "disagreement", "disagreements"),
+    )
+}
+
+/// Print the live capture-count tally for the current meeting state.
+///
+/// Reads the deterministic explicit-capture stores from `backend` and writes
+/// the formatted tally line (see [`format_capture_tally`]) to `output`.
+/// Issue #2376.
+fn emit_capture_tally<W: Write>(output: &mut W, backend: &MeetingBackend) {
+    let tally = format_capture_tally(
+        backend.explicit_decisions().len(),
+        backend.explicit_questions().len(),
+        backend.explicit_action_items().len(),
+        backend.explicit_risks().len(),
+        backend.explicit_disagreements().len(),
+    );
+    writeln!(output, "{tally}").ok();
+}
+
 /// Heuristic: detect messages that look like implementation work rather than
 /// planning/alignment discussion. Used by the drift guard (issue #2084,
 /// spec line 643: "Meeting mode should not edit code unless the user
@@ -371,16 +429,19 @@ pub fn run_meeting_repl<R: BufRead, W: Write>(
                     format!("Decision recorded: {text}")
                 };
                 writeln!(output, "{}", cyan(&msg)).ok();
+                emit_capture_tally(output, &backend);
                 checkpoint_wip(&backend);
             }
             MeetingCommand::Action(text) => {
                 backend.push_explicit_action_item(&text);
                 writeln!(output, "{}", green(&format!("Action recorded: {text}"))).ok();
+                emit_capture_tally(output, &backend);
                 checkpoint_wip(&backend);
             }
             MeetingCommand::Question(text) => {
                 backend.push_explicit_question(&text);
                 writeln!(output, "{}", yellow(&format!("Question recorded: {text}"))).ok();
+                emit_capture_tally(output, &backend);
                 checkpoint_wip(&backend);
             }
             MeetingCommand::Owner(text) => {
@@ -396,6 +457,7 @@ pub fn run_meeting_repl<R: BufRead, W: Write>(
             MeetingCommand::Risk(text) => {
                 backend.push_explicit_risk(&text);
                 writeln!(output, "{}", yellow(&format!("Risk recorded: {text}"))).ok();
+                emit_capture_tally(output, &backend);
                 checkpoint_wip(&backend);
             }
             MeetingCommand::Disagree(text) => {
@@ -406,6 +468,7 @@ pub fn run_meeting_repl<R: BufRead, W: Write>(
                     yellow(&format!("Disagreement recorded: {text}"))
                 )
                 .ok();
+                emit_capture_tally(output, &backend);
                 checkpoint_wip(&backend);
             }
             MeetingCommand::Recap => {

--- a/src/meeting_repl/tests_repl.rs
+++ b/src/meeting_repl/tests_repl.rs
@@ -903,3 +903,182 @@ fn renders_structured_banner_on_agent_error() {
         "close banner should report orphan turn count: {output_str}"
     );
 }
+
+// ── Live capture-count tally (issue #2376) ───────────────────────────────
+//
+// After each structured-capture command (`/decision`, `/action`,
+// `/question`, `/risk`, `/disagree`) the interactive REPL prints a compact,
+// grep-safe running tally sourced from the deterministic explicit-capture
+// stores. These tests are fully deterministic (no LLM): the pure formatter
+// is asserted directly, and the emission/accumulation behaviour is driven
+// through `run_meeting_repl` with a `MockAgentSession`.
+
+#[test]
+fn format_capture_tally_all_zero_uses_plural_nouns() {
+    assert_eq!(
+        format_capture_tally(0, 0, 0, 0, 0),
+        "[meeting] captured: 0 decisions, 0 open questions, 0 action items, 0 risks, 0 disagreements"
+    );
+}
+
+#[test]
+fn format_capture_tally_uses_singular_nouns_for_one() {
+    assert_eq!(
+        format_capture_tally(1, 1, 1, 1, 1),
+        "[meeting] captured: 1 decision, 1 open question, 1 action item, 1 risk, 1 disagreement"
+    );
+}
+
+#[test]
+fn format_capture_tally_uses_plural_nouns_for_many() {
+    assert_eq!(
+        format_capture_tally(2, 3, 4, 5, 6),
+        "[meeting] captured: 2 decisions, 3 open questions, 4 action items, 5 risks, 6 disagreements"
+    );
+}
+
+#[test]
+fn format_capture_tally_orders_categories_like_state_view() {
+    // Distinct counts pin each category to its position so a reordering
+    // regression is caught. Order matches the `/state` view:
+    // decisions → open questions → action items → risks → disagreements.
+    let line = format_capture_tally(1, 2, 3, 4, 5);
+    let body = line
+        .strip_prefix("[meeting] captured: ")
+        .expect("tally must carry the stable banner prefix");
+    let parts: Vec<&str> = body.split(", ").collect();
+    assert_eq!(
+        parts,
+        vec![
+            "1 decision",
+            "2 open questions",
+            "3 action items",
+            "4 risks",
+            "5 disagreements",
+        ]
+    );
+}
+
+#[test]
+fn format_capture_tally_is_grep_safe_single_line_plain_text() {
+    let line = format_capture_tally(7, 0, 1, 0, 2);
+    // Stable, greppable banner prefix.
+    assert!(
+        line.starts_with("[meeting] captured: "),
+        "tally must start with the stable banner prefix: {line}"
+    );
+    // Single line — no embedded newlines that would split scrollback greps.
+    assert!(
+        !line.contains('\n') && !line.contains('\r'),
+        "tally must be a single line: {line:?}"
+    );
+    // No ANSI escape sequences regardless of color settings.
+    assert!(
+        !line.contains('\u{1b}'),
+        "tally must be plain text with no ANSI escapes: {line:?}"
+    );
+}
+
+#[test]
+#[serial(cognitive_memory)]
+fn repl_decision_command_emits_capture_tally() {
+    let _state = HermeticState::new();
+    let bridge = mock_bridge();
+    let agent = MockAgentSession::new("ok");
+    let input = b"/decision Adopt TDD for new modules\n/close\n";
+    let mut reader = &input[..];
+    let mut output = Vec::new();
+
+    run_meeting_repl(
+        "Tally after decision",
+        &bridge,
+        Some(Box::new(agent)),
+        "",
+        &mut reader,
+        &mut output,
+    )
+    .unwrap();
+
+    let output_str = String::from_utf8(output).unwrap();
+    assert!(
+        output_str.contains(
+            "[meeting] captured: 1 decision, 0 open questions, 0 action items, 0 risks, 0 disagreements"
+        ),
+        "REPL should print the live tally after /decision: {output_str}"
+    );
+}
+
+#[test]
+#[serial(cognitive_memory)]
+fn repl_emits_a_tally_after_every_structured_capture_command() {
+    let _state = HermeticState::new();
+    let bridge = mock_bridge();
+    let agent = MockAgentSession::new("ok");
+    // One of each structured-capture command, in any order.
+    let input = b"/decision Use Rust for the CLI\n/action Carol will set up CI\n/question Who owns rollout?\n/risk CI flakiness blocks releases\n/disagree We should not ship on Fridays\n/close\n";
+    let mut reader = &input[..];
+    let mut output = Vec::new();
+
+    run_meeting_repl(
+        "Tally after each command",
+        &bridge,
+        Some(Box::new(agent)),
+        "",
+        &mut reader,
+        &mut output,
+    )
+    .unwrap();
+
+    let output_str = String::from_utf8(output).unwrap();
+
+    // Exactly one tally per capture command — five commands, five tallies.
+    let tally_count = output_str.matches("[meeting] captured:").count();
+    assert_eq!(
+        tally_count, 5,
+        "each of the 5 capture commands must emit exactly one tally: {output_str}"
+    );
+
+    // The final tally reflects one item recorded in every category.
+    assert!(
+        output_str.contains(
+            "[meeting] captured: 1 decision, 1 open question, 1 action item, 1 risk, 1 disagreement"
+        ),
+        "final tally should show one item per category: {output_str}"
+    );
+}
+
+#[test]
+#[serial(cognitive_memory)]
+fn repl_tally_counts_accumulate_within_a_category() {
+    let _state = HermeticState::new();
+    let bridge = mock_bridge();
+    let agent = MockAgentSession::new("ok");
+    let input = b"/decision First decision\n/decision Second decision\n/close\n";
+    let mut reader = &input[..];
+    let mut output = Vec::new();
+
+    run_meeting_repl(
+        "Tally accumulation",
+        &bridge,
+        Some(Box::new(agent)),
+        "",
+        &mut reader,
+        &mut output,
+    )
+    .unwrap();
+
+    let output_str = String::from_utf8(output).unwrap();
+    // First /decision → singular; second /decision → plural "2 decisions".
+    assert!(
+        output_str.contains(
+            "[meeting] captured: 1 decision, 0 open questions, 0 action items, 0 risks, 0 disagreements"
+        ),
+        "first /decision should tally 1 decision: {output_str}"
+    );
+    assert!(
+        output_str.contains(
+            "[meeting] captured: 2 decisions, 0 open questions, 0 action items, 0 risks, 0 disagreements"
+        ),
+        "second /decision should tally 2 decisions: {output_str}"
+    );
+}

--- a/tests/gadugi/meeting-repl-tally.sh
+++ b/tests/gadugi/meeting-repl-tally.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# qa-team scenario for issue #2376 — meeting REPL live capture-count tally.
+#
+# Outside-in verification that the interactive meeting REPL prints a compact,
+# grep-safe running tally after every structured-capture command
+# (`/decision`, `/action`, `/question`, `/risk`, `/disagree`). The deterministic
+# unit + integration tests in `src/meeting_repl/tests_repl.rs` exercise the real
+# chokepoint: the pure `format_capture_tally` formatter (counts, pluralization,
+# category order, grep-safety) and the emission/accumulation behaviour driven
+# end-to-end through `run_meeting_repl` with a mock agent (no LLM).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+# Run the tally tests. Substring filters are OR'd by the libtest harness. No
+# `--quiet` so the per-test `... ok` lines are emitted for the assertions below.
+OUTPUT="$(
+  cargo test --lib -- \
+    meeting_repl::tests_repl::format_capture_tally \
+    meeting_repl::tests_repl::repl_decision_command_emits_capture_tally \
+    meeting_repl::tests_repl::repl_emits_a_tally_after_every_structured_capture_command \
+    meeting_repl::tests_repl::repl_tally_counts_accumulate_within_a_category \
+    2>&1
+)"
+
+printf '%s\n' "$OUTPUT"
+
+# Assert the suite passed with zero failures.
+printf '%s\n' "$OUTPUT" | grep -E "test result: ok\. [0-9]+ passed; 0 failed" >/dev/null
+
+# Assert the specific behaviors required by issue #2376 actually ran and passed.
+printf '%s\n' "$OUTPUT" | grep -F "format_capture_tally_all_zero_uses_plural_nouns ... ok" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "format_capture_tally_uses_singular_nouns_for_one ... ok" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "format_capture_tally_uses_plural_nouns_for_many ... ok" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "format_capture_tally_orders_categories_like_state_view ... ok" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "format_capture_tally_is_grep_safe_single_line_plain_text ... ok" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "repl_decision_command_emits_capture_tally ... ok" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "repl_emits_a_tally_after_every_structured_capture_command ... ok" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "repl_tally_counts_accumulate_within_a_category ... ok" >/dev/null
+
+echo "[gadugi] meeting REPL capture-count tally (#2376): all behaviors verified"

--- a/tests/gadugi/meeting-repl-tally.yaml
+++ b/tests/gadugi/meeting-repl-tally.yaml
@@ -1,0 +1,54 @@
+name: "Meeting REPL capture-count tally (#2376)"
+description: "Outside-in verification that the interactive meeting REPL prints a compact, grep-safe running tally after every structured-capture command (/decision, /action, /question, /risk, /disagree), with correct per-category counts, singular/plural noun forms, /state category order, plain-text grep-safety, and accumulation across repeated captures."
+version: "1.0.0"
+
+config:
+  timeout: 600000
+  retries: 1
+  parallel: false
+
+environment:
+  requires: []
+
+agents:
+  - name: "cli-agent"
+    type: "cli"
+    config:
+      workingDirectory: "."
+      defaultTimeout: 600000
+      executionMode: "spawn"
+      captureOutput: true
+      ioConfig:
+        encoding: "utf8"
+        handleInteractivePrompts: false
+      logConfig:
+        logCommands: true
+        logOutput: true
+        logLevel: "info"
+
+steps:
+  - name: "Meeting REPL emits capture-count tally"
+    agent: "cli-agent"
+    action: "execute_command"
+    params:
+      command: "tests/gadugi/meeting-repl-tally.sh"
+    timeout: 600000
+
+assertions: []
+
+cleanup:
+  - name: "CLI agent cleanup"
+    agent: "cli-agent"
+    action: "cleanup"
+
+metadata:
+  tags:
+    - "cli"
+    - "meeting"
+    - "repl"
+    - "discoverability"
+    - "outside-in"
+  priority: "high"
+  author: "copilot"
+  test_type: "outside-in"
+  issue: "2376"


### PR DESCRIPTION
## Summary

Closes #2376.

The **batch** meeting probe already reports a capture-count summary
(`captured N decisions, N risks, …`), but the **interactive** meeting REPL gave
no equivalent feedback — after `/decision`, `/action`, `/question`, `/risk`, or
`/disagree` it only echoed a one-line confirmation, forcing the operator to run
`/state` to see how much had been captured. This PR closes that
discoverability/awareness gap.

After each structured-capture command the REPL now prints a compact, stable,
grep-safe running tally:

```
[meeting] captured: 1 decision, 0 open questions, 0 action items, 0 risks, 0 disagreements
```

- **Deterministic:** counts come from the explicit-capture stores only
  (`explicit_decisions/questions/action_items/risks/disagreements`) — exact and
  reproducible, no LLM inference.
- **Grep-safe:** plain text, no ANSI, stable `[meeting] captured:` banner prefix
  matching the existing `[meeting] …` convention.
- **Consistent:** category order matches the `/state` view (decisions → open
  questions → action items → risks → disagreements); singular/plural noun forms
  per count.

### Implementation
- `src/meeting_repl/repl.rs`: new pure `format_capture_tally(...) -> String`
  formatter + `emit_capture_tally(output, backend)` helper; called after each of
  the five structured-capture command handlers.

## Evidence for merge-ready criteria

### 1. qa-team gadugi scenario (written, validated, run)
New scenario `tests/gadugi/meeting-repl-tally.{sh,yaml}` (outside-in: drives the
deterministic unit + integration tests that exercise the real chokepoint).

- `gadugi-test validate -f tests/gadugi/meeting-repl-tally.yaml` →
  `✓ Scenario "Meeting REPL capture-count tally (#2376)" is valid` (1 valid, 0 invalid).
- Scenario run (`tests/gadugi/meeting-repl-tally.sh`, executed by `gadugi-test run`):
  `running 8 tests … test result: ok. 8 passed; 0 failed` and final marker
  `[gadugi] meeting REPL capture-count tally (#2376): all behaviors verified` (exit 0).

### 2. Docs updated
`docs/howto/start-a-meeting.md` gains a **"Structured capture and the live
tally"** subsection that lists the five structured-capture commands and
documents the tally output (format, plain-text grep-safety, category order,
singular/plural).

### 3. Quality-audit (SEEK → VALIDATE → FIX cycles)
Iterative validation cycles, each ending clean:
- **Cycle 1 (unit):** `cargo test --lib meeting_repl::tests_repl` →
  `31 passed; 0 failed` (includes all 8 new tests).
- **Cycle 2 (lint):** `cargo clippy --lib -- -D warnings` → clean (0 warnings);
  pre-commit `cargo clippy --release --no-deps -- -D warnings` → Passed.
- **Cycle 3 (full pre-push gate):** `cargo fmt --all -- --check` → Passed;
  `cargo clippy --all-targets --all-features --locked -- -D warnings` → Passed;
  release race-subset tests
  (`cognitive_memory|bootstrap|memory_ipc|memory_consolidation`) → Passed.
- Final diff self-review: no unrelated edits; formatter is pure and fully
  covered (counts, pluralization, category order, grep-safety/no-ANSI,
  per-command emission, accumulation).

### 4. CI — 100% green
All checks green on the head commit: `pre-commit` (full `cargo test
--all-features`), `build`, `cargo-audit`, `coverage`, `install-real`,
`e2e-dashboard`, GitGuardian.

> Note: one `pre-commit` run flaked on a **pre-existing, unrelated** test,
> `operator_commands_dashboard::tests_goals_crud::full_goal_lifecycle_crud`
> (goal-store test-isolation race — `left: 0, right: 3`). It passed in the
> parallel run on the same commit and passed on re-run. This PR touches only
> `src/meeting_repl/` + docs + the new gadugi scenario and cannot affect it.
> Filed as #2384.

### 6. Diff focused
5 files, +269 / -0. No unrelated edits:
- `src/meeting_repl/repl.rs` (helpers + 5 call sites)
- `src/meeting_repl/tests_repl.rs` (8 tests)
- `docs/howto/start-a-meeting.md` (1 subsection)
- `tests/gadugi/meeting-repl-tally.sh`, `tests/gadugi/meeting-repl-tally.yaml` (new scenario)

Refs #1154, #1628.
