### PR TITLE
fix(test): close the SIMARD_HANDOFF_DIR gap in the meeting serial-isolation (#2360)

### DIFF
--- a/docs/testing/cognitive-memory-serial-isolation.md
+++ b/docs/testing/cognitive-memory-serial-isolation.md
@@ -51,7 +51,7 @@ pre-commit `cargo test`.
   provider, and the meetings-persistence directory. The guard's *mutation* watch
   (`EnvWatch::StateRootSurface` in `src/test_support/serial_guard.rs`) covers
   `SIMARD_STATE_ROOT`, `SIMARD_MEMORY_SOCKET`, `HOME`, `SIMARD_LLM_PROVIDER`,
-  `SIMARD_MEETINGS_DIR`, `SIMARD_MEETINGS_ROOT`; the *read* watch
+  `SIMARD_MEETINGS_DIR`, `SIMARD_MEETINGS_ROOT`, `SIMARD_HANDOFF_DIR`; the *read* watch
   (`READ_WATCHED_VARS`) is the same set **minus `HOME`** (a torn `HOME` read is
   not the race — only a `HOME` *write* is). **Every lib-binary test that mutates
   or reads that surface shares one serial key, `cognitive_memory`**, so no
@@ -140,7 +140,7 @@ assertion.
 > that mutates the guard's watched env surface — the cognitive-memory
 > state-root / LLM-provider / meetings-resolver variables (`SIMARD_STATE_ROOT`,
 > `SIMARD_MEMORY_SOCKET`, `HOME`, `SIMARD_LLM_PROVIDER`, `SIMARD_MEETINGS_DIR`,
-> `SIMARD_MEETINGS_ROOT`) — may run concurrently with any test that reads that
+> `SIMARD_MEETINGS_ROOT`, `SIMARD_HANDOFF_DIR`) — may run concurrently with any test that reads that
 > surface.** This is enforced by routing *every* such test through the single
 > serial key `cognitive_memory`.
 
@@ -168,7 +168,7 @@ if**, at run time, it does any of:
   the `serial_guard` meta-test currently auto-detects (B) only for its
   **mutation watch** `EnvWatch::StateRootSurface` (`SIMARD_STATE_ROOT`,
   `SIMARD_MEMORY_SOCKET`, `HOME`, `SIMARD_LLM_PROVIDER`, `SIMARD_MEETINGS_DIR`,
-  `SIMARD_MEETINGS_ROOT`; the rule-(C) *read* check uses `READ_WATCHED_VARS`,
+  `SIMARD_MEETINGS_ROOT`, `SIMARD_HANDOFF_DIR`; the rule-(C) *read* check uses `READ_WATCHED_VARS`,
   the same set minus `HOME`);
   for any other variable, rule (B) is an author obligation the guard does not
   yet check. Closing that gap (`EnvWatch::AnyVar`) is tracked as issue #2375 —
@@ -233,7 +233,7 @@ by [issue #2375](https://github.com/rysweet/Simard/issues/2375):
 
 1. **Cross-variable tears from other serial groups.** Lib-binary tests that
    mutate non-watched vars under a *different* serial key — e.g.
-   `SIMARD_HANDOFF_DIR` (`ooda_loop`), `SIMARD_SKIP_GYM` (`gym_runner_bridge`),
+   `SIMARD_SKIP_GYM` (`gym_runner_bridge`),
    `NO_COLOR` (`meeting_repl`), `ENV_OVERRIDE` (`prompt_delivery`,
    `prompt_delivery_env`), `SIMARD_NO_UPDATE_CHECK` (`update_check`,
    `update_check_env`) — can still run concurrently with the `cognitive_memory`
@@ -389,12 +389,13 @@ pub(crate) struct AuditOptions {
 
     /// Which env-var mutations trip the rule. Default:
     /// `EnvWatch::StateRootSurface` — the cognitive-memory state-root,
-    /// provider, and meetings-resolver surface (`SIMARD_STATE_ROOT`,
+    /// provider, and meeting artifact-dir surface (`SIMARD_STATE_ROOT`,
     /// `SIMARD_MEMORY_SOCKET`, `HOME`, `SIMARD_LLM_PROVIDER`,
-    /// `SIMARD_MEETINGS_DIR`, `SIMARD_MEETINGS_ROOT`; the rule-(C) read check
-    /// `READ_WATCHED_VARS` is the same set minus `HOME`). `EnvWatch::AnyVar`
-    /// (fully var-agnostic) and `EnvWatch::Vars(set)` remain for the tracked
-    /// #2375 follow-up that migrates every other env-mutating variable.
+    /// `SIMARD_MEETINGS_DIR`, `SIMARD_MEETINGS_ROOT`, `SIMARD_HANDOFF_DIR`; the
+    /// rule-(C) read check `READ_WATCHED_VARS` is the same set minus `HOME`).
+    /// `EnvWatch::AnyVar` (fully var-agnostic) and `EnvWatch::Vars(set)` remain
+    /// for the tracked #2375 follow-up that migrates every other env-mutating
+    /// variable.
     pub watched: EnvWatch,
 
     /// Tests that are exempt with a written, machine-checked reason. Each
@@ -407,7 +408,8 @@ pub(crate) struct AuditOptions {
 `AuditOptions::default()` ships the production configuration: scan `src`,
 exclude `src/bin`, watch the **state-root / provider / meetings surface**
 (mutations of `SIMARD_STATE_ROOT`, `SIMARD_MEMORY_SOCKET`, `HOME`,
-`SIMARD_LLM_PROVIDER`, `SIMARD_MEETINGS_DIR`, `SIMARD_MEETINGS_ROOT`), empty
+`SIMARD_LLM_PROVIDER`, `SIMARD_MEETINGS_DIR`, `SIMARD_MEETINGS_ROOT`,
+`SIMARD_HANDOFF_DIR`), empty
 allowlist. The rule-(C) *read* check (`READ_WATCHED_VARS`) covers the same set
 **minus `HOME`** — a torn `HOME` *read* is not the cognitive-memory race; only a
 `HOME` *write*, which can tear a `SIMARD_STATE_ROOT` read, is.
@@ -497,7 +499,7 @@ helper:
 // `std::env::var` read and send writes to HOME/.simard. The `serial_guard`
 // meta-test auto-enforces this for its watched surface (SIMARD_STATE_ROOT /
 // SIMARD_MEMORY_SOCKET / HOME / SIMARD_LLM_PROVIDER / SIMARD_MEETINGS_DIR /
-// SIMARD_MEETINGS_ROOT); keying any OTHER var is an author obligation the guard
+// SIMARD_MEETINGS_ROOT / SIMARD_HANDOFF_DIR); keying any OTHER var is an author obligation the guard
 // does not yet check (EnvWatch::AnyVar tracked as #2375).
 // See docs/testing/cognitive-memory-serial-isolation.md.
 ```
@@ -700,6 +702,30 @@ the audit gap:
 Validation: serial_guard green; the autosave reader, the bundle writers, and the
 persist mutators run together under the multi-threaded runner across 20 focused
 high-concurrency runs and four full runs with zero failures.
+
+#### Handoff-dir surface (completing the meetings migration)
+
+Moving `tests_meeting_decisions` into `cognitive_memory` exposed a coupled gap:
+those tests set **both** `SIMARD_MEETINGS_ROOT` **and** `SIMARD_HANDOFF_DIR`, and
+read the latter back through `load_carried_meeting_decisions()`. Their
+`SIMARD_HANDOFF_DIR` writers (`ooda_loop::tests_observe`,
+`operator_cli::meeting`, `meeting_facilitator::handoff::default_handoff_dir`)
+remained on a bare `#[serial]` / unkeyed — disjoint from `cognitive_memory` —
+so the reader could be torn by a concurrent handoff-dir write (the exact
+"cross-variable tear" formerly tracked as a blind spot). `SIMARD_HANDOFF_DIR` is
+therefore now part of the watched surface too:
+
+- It is added to the guard's mutation watch **and** `READ_WATCHED_VARS`, so the
+  handoff resolver/writers are enforced symmetrically with the meetings surface.
+- The remaining 10 handoff-dir writers (6 in `ooda_loop/tests_observe.rs`, 3 in
+  `operator_cli/meeting.rs`, 1 in `meeting_facilitator/handoff/mod.rs`) are
+  migrated into `cognitive_memory` (replacing bare `#[serial]` / adding the key
+  to the previously-unkeyed `default_handoff_dir_returns_path`). The
+  `meeting_backend` handoff writers already carried the key from the meetings
+  migration above.
+
+Validation: serial_guard green with all three meeting vars watched; 8 full
+`cargo test --lib --test-threads=16` runs (5799 passed, 0 failed each).
 
 > **Out of scope — `base_type_copilot` meeting tests.** These spawn the **real**
 > `copilot` subprocess and only run when the binary is on `PATH` (they skip in

--- a/src/meeting_facilitator/handoff/mod.rs
+++ b/src/meeting_facilitator/handoff/mod.rs
@@ -502,9 +502,13 @@ mod tests {
     // ── default_handoff_dir ─────────────────────────────────────────
 
     #[test]
+    #[serial_test::serial(cognitive_memory)]
     fn default_handoff_dir_returns_path() {
         // Pin SIMARD_HANDOFF_DIR so parallel tests that unsafely set env vars
-        // don't race against the env reads inside default_handoff_dir().
+        // don't race against the env reads inside default_handoff_dir(). The
+        // `cognitive_memory` serial key is the durable guard (see
+        // docs/testing/cognitive-memory-serial-isolation.md); the pin is
+        // belt-and-braces.
         let tmp = tempfile::tempdir().unwrap();
         let pinned = tmp.path().join("meeting_handoffs");
         unsafe { std::env::set_var("SIMARD_HANDOFF_DIR", &pinned) };

--- a/src/ooda_loop/tests_observe.rs
+++ b/src/ooda_loop/tests_observe.rs
@@ -29,7 +29,7 @@ fn make_gym_score(overall: f64, factual_accuracy: f64) -> GymSuiteScore {
 }
 
 #[test]
-#[serial]
+#[serial(cognitive_memory)]
 fn collect_pending_improvements_empty_when_no_signals() {
     let dir = TempDir::new().unwrap();
     // Isolate from any leftover handoff files in the default directory.
@@ -46,7 +46,7 @@ fn collect_pending_improvements_empty_when_no_signals() {
 }
 
 #[test]
-#[serial]
+#[serial(cognitive_memory)]
 fn collect_pending_improvements_detects_gym_regression() {
     let dir = TempDir::new().unwrap();
     unsafe { std::env::set_var("SIMARD_HANDOFF_DIR", dir.path()) };
@@ -82,7 +82,7 @@ fn collect_pending_improvements_detects_gym_regression() {
 }
 
 #[test]
-#[serial]
+#[serial(cognitive_memory)]
 fn collect_pending_improvements_no_regression_when_scores_stable() {
     let dir = TempDir::new().unwrap();
     unsafe { std::env::set_var("SIMARD_HANDOFF_DIR", dir.path()) };
@@ -113,7 +113,7 @@ fn collect_pending_improvements_no_regression_when_scores_stable() {
 }
 
 #[test]
-#[serial]
+#[serial(cognitive_memory)]
 fn collect_pending_improvements_no_crash_when_no_gym_health() {
     let dir = TempDir::new().unwrap();
     unsafe { std::env::set_var("SIMARD_HANDOFF_DIR", dir.path()) };
@@ -132,7 +132,7 @@ fn collect_pending_improvements_no_crash_when_no_gym_health() {
 }
 
 #[test]
-#[serial]
+#[serial(cognitive_memory)]
 fn collect_pending_improvements_no_crash_when_no_last_observation() {
     let dir = TempDir::new().unwrap();
     unsafe { std::env::set_var("SIMARD_HANDOFF_DIR", dir.path()) };
@@ -238,7 +238,7 @@ fn scan_unprocessed_handoffs_returns_false_when_no_file() {
 }
 
 #[test]
-#[serial]
+#[serial(cognitive_memory)]
 fn collect_pending_improvements_drains_review_improvements() {
     let dir = TempDir::new().unwrap();
     unsafe { std::env::set_var("SIMARD_HANDOFF_DIR", dir.path()) };

--- a/src/operator_cli/meeting.rs
+++ b/src/operator_cli/meeting.rs
@@ -346,7 +346,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(cognitive_memory)]
     fn test_meeting_resume_no_wip_errors() {
         let dir = tempfile::tempdir().expect("temp dir");
         unsafe { std::env::set_var("SIMARD_HANDOFF_DIR", dir.path()) };
@@ -361,7 +361,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(cognitive_memory)]
     fn test_meeting_resume_discard_no_wip_ok() {
         let dir = tempfile::tempdir().expect("temp dir");
         unsafe { std::env::set_var("SIMARD_HANDOFF_DIR", dir.path()) };
@@ -378,7 +378,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(cognitive_memory)]
     fn test_meeting_resume_discard_removes_wip() {
         let dir = tempfile::tempdir().expect("temp dir");
         let wip_path = dir.path().join("meeting_session_wip.json");

--- a/src/test_support/serial_guard.rs
+++ b/src/test_support/serial_guard.rs
@@ -47,7 +47,12 @@ const REQUIRED_KEY: &str = "cognitive_memory";
 /// through to `SIMARD_STATE_ROOT`; a concurrent write to either (e.g. the
 /// `write_meeting_bundle_*` bundle tests) tears a meetings-resolver read and
 /// routed `write_auto_save_lands_under_simard_state_root`'s autosave into the
-/// wrong directory (the #2360 race class, re-surfaced in CI). `HOME`
+/// wrong directory (the #2360 race class, re-surfaced in CI).
+/// `SIMARD_HANDOFF_DIR` is included for symmetry: the handoff resolver
+/// (`default_handoff_dir`, read by `load_carried_meeting_decisions`) consults
+/// it, and its writers in `ooda_loop` / `operator_cli` / `meeting_backend` race
+/// the `tests_meeting_decisions` reader (which joined `cognitive_memory` because
+/// it also writes `SIMARD_MEETINGS_ROOT`). `HOME`
 /// is NOT here: a torn *read* of `HOME` is not the cognitive-memory race; only
 /// a *write* to `HOME` (which can tear a `SIMARD_STATE_ROOT` read) is in scope,
 /// and writes are handled by [`EnvWatch`].
@@ -57,6 +62,7 @@ const READ_WATCHED_VARS: &[&str] = &[
     "SIMARD_LLM_PROVIDER",
     "SIMARD_MEETINGS_DIR",
     "SIMARD_MEETINGS_ROOT",
+    "SIMARD_HANDOFF_DIR",
 ];
 
 /// Env-reading async dashboard route handlers from
@@ -95,7 +101,12 @@ pub(crate) enum EnvWatch {
     /// `SIMARD_MEETINGS_DIR` / `SIMARD_MEETINGS_ROOT` (the meeting-persistence
     /// resolver `meetings_dir()`, which falls through to `SIMARD_STATE_ROOT`;
     /// its writers — the `write_meeting_bundle_*` / `meetings_*` tests — race
-    /// the autosave/transcript readers). This is the demonstrated race surface
+    /// the autosave/transcript readers), plus `SIMARD_HANDOFF_DIR` (the
+    /// `default_handoff_dir()` / handoff-bundle surface; its writers in
+    /// `ooda_loop` / `operator_cli` / `meeting_backend` race the
+    /// `load_carried_meeting_decisions` reader in `tests_meeting_decisions`,
+    /// which shares the `cognitive_memory` group because it also writes
+    /// `SIMARD_MEETINGS_ROOT`). This is the demonstrated race surface
     /// for #2360.
     StateRootSurface,
     /// Watch a specific set of variable names.
@@ -119,6 +130,7 @@ impl EnvWatch {
                         | "SIMARD_LLM_PROVIDER"
                         | "SIMARD_MEETINGS_DIR"
                         | "SIMARD_MEETINGS_ROOT"
+                        | "SIMARD_HANDOFF_DIR"
                 )
             }
             EnvWatch::Vars(set) => set.contains(var),


### PR DESCRIPTION
## Summary

Closes the `SIMARD_HANDOFF_DIR` gap left open after the #2360 meeting-isolation work merged in #2365. This is a **test-isolation-only** change — no production code paths change.

### Problem
The `cargo test --lib` binary runs tests concurrently in one process; glibc `setenv`/`getenv` are not thread-safe, so a test mutating a process-global env var can tear a concurrent env read in another test (the #2360 race class). The fix pattern routes every lib test that touches a *watched* env surface through one serial key, `cognitive_memory`, enforced by the `serial_guard` meta-test.

#2365 added `SIMARD_MEETINGS_DIR`/`SIMARD_MEETINGS_ROOT` to that surface and moved `engineer_loop/tests_meeting_decisions.rs` into `cognitive_memory`. But those tests **also** set and read `SIMARD_HANDOFF_DIR` (via `load_carried_meeting_decisions`), while the `SIMARD_HANDOFF_DIR` *writers* stayed on a **disjoint** bare `#[serial]`/unkeyed group. So a concurrent handoff-dir write could still tear the reader — a live race that #2365 documented as a known blind spot (tracked under #2375).

### Fix
1. Add `SIMARD_HANDOFF_DIR` to the guard's `StateRootSurface` **mutation** watch and to `READ_WATCHED_VARS` (symmetric with the meetings vars). The read watch stays "mutation set minus `HOME`".
2. Migrate the 10 remaining `SIMARD_HANDOFF_DIR` writers into `cognitive_memory`:
   - `src/ooda_loop/tests_observe.rs` — 6 tests (bare `#[serial]` → `#[serial(cognitive_memory)]`)
   - `src/operator_cli/meeting.rs` — 3 tests (bare `#[serial_test::serial]` → keyed)
   - `src/meeting_facilitator/handoff/mod.rs::default_handoff_dir_returns_path` — previously unkeyed → keyed
   - (the `meeting_backend` handoff writers already carried the key from #2365.)
3. Remove `SIMARD_HANDOFF_DIR` from the documented blind-spot list and document the closure in `docs/testing/cognitive-memory-serial-isolation.md`.

This is purely additional serialization (writers join the existing group); the review confirmed none of the remaining bare-`#[serial]` groups touch `SIMARD_HANDOFF_DIR`, so no exclusion is lost and no new race is introduced.

---

## Merge-criteria evidence

**1. QA / regression test.** This change has **no user-facing or CLI behavior** to script in a gadugi scenario — it adds serial keys to tests and extends a build-time guard. The automated regression test is the `serial_guard` meta-test `every_env_mutating_test_is_serialized`, which now watches `SIMARD_HANDOFF_DIR` and **fails the build** if any lib-binary writer of it lacks the `cognitive_memory` key. The runtime race behavior is already exercised by the #2360 goal-crud serial-isolation gadugi scenario merged in #2365.

```
test test_support::serial_guard::every_env_mutating_test_is_serialized ... ok
test result: ok. 1 passed; 0 failed; ... 5766 filtered out; finished in 3.08s
```

**2. Docs.** Internal-only change (test isolation + build-time guard); no user-facing surface. `docs/testing/cognitive-memory-serial-isolation.md` updated: all six watched-var enumerations now include `SIMARD_HANDOFF_DIR`, the blind-spot list no longer lists it, and a "Handoff-dir surface" subsection documents the closure.

**3. Quality audit (3 independent review passes, ended clean).**
   - Pass 1 — root-cause analysis: identified the composite env surface and the disjoint handoff-writer groups; enumerated all writers via the guard itself.
   - Pass 2 — `code-review` agent: "fix is correct and complete"; verified every `SIMARD_HANDOFF_DIR` mutator is keyed, multi-key serial semantics, doc accuracy, and that adding the var to `READ_WATCHED_VARS` is safe (only the production resolver reads it directly).
   - Pass 3 — `rubber-duck` agent: no blocking issues; verified two-pass call-graph propagation finds no missed same-file helper mutators, the fully-qualified `#[serial_test::serial(cognitive_memory)]` form parses correctly, and no compile/clippy/mkdocs CI-red risk. (The one scope-hygiene note — an unrelated staged file — was resolved before opening.)

**4. CI.** Locally green on this base:
   - `serial_guard` meta-test: green (0 offenders, all 3 meeting vars watched).
   - `cargo fmt --all -- --check`: pass.
   - `cargo clippy --all-targets --all-features --locked -- -D warnings`: pass.
   - `mkdocs build --strict`: pass.
   - `cargo test --lib -- --test-threads=16`: 5799 passed, 0 failed across repeated high-concurrency runs (the previously-flaky `write_auto_save_lands_under_simard_state_root` and the handoff readers/writers run together with zero failures).

**6. Focused diff.** 5 files, +65/−23, all test-isolation/guard/doc. No production code paths changed.

Refs #2360, #2375
