### PR TITLE
docs(base-type-adapters): correct enrich_turn_input contract description (#1665 follow-up)

### DIFF
--- a/docs/reference/base-type-adapters.md
+++ b/docs/reference/base-type-adapters.md
@@ -181,10 +181,12 @@ cannot silently diverge again:
   and `knowledge` (`KnowledgeBridge`) bridges. Each session that supports
   enrichment stores one and exposes it through `BaseTypeSession::enrichment()` /
   `enrichment_mut()`.
-- `enrich_turn_input(input, memory, knowledge)` — folds the input's
-  `prompt_preamble`, `identity_context`, and `objective` into a single
-  objective, calls `prepare_turn_context`, and renders the result via
-  `format_turn_input`. Returns the formatted prompt string.
+- `enrich_turn_input(input, memory, knowledge)` — recalls memory facts/
+  procedures and domain knowledge for the input's `objective` via
+  `prepare_turn_context`, renders them with `render_enrichment_block`, and
+  returns a new `BaseTypeTurnInput` with that block injected into
+  `prompt_preamble` (the `objective` and `identity_context` are preserved
+  unchanged, so stateful adapters keep a clean conversation history).
 - `BaseTypeSession::enrich_input(&self, input)` — the provided trait method
   every adapter inherits. It delegates to the session's configured
   `EnrichmentBridges` (or to a no-op enrichment when none are configured).


### PR DESCRIPTION
## Summary

Follow-up to #2361 (issue #1665). The `Normalized enrichment entry point` section of `docs/reference/base-type-adapters.md` described `enrich_turn_input` inaccurately. This corrects the contract description to match the shipped implementation in `src/base_type_turn.rs`.

**Before (inaccurate):** "folds the input's `prompt_preamble`, `identity_context`, and `objective` into a single objective, calls `prepare_turn_context`, and renders the result via `format_turn_input`. Returns the formatted prompt string."

**After (accurate):** recalls memory facts/procedures and domain knowledge for the input's `objective` via `prepare_turn_context`, renders them with `render_enrichment_block`, and returns a new `BaseTypeTurnInput` with that block injected into `prompt_preamble` (the `objective` and `identity_context` are preserved unchanged).

This matches the actual signature `enrich_turn_input(input, memory, knowledge) -> SimardResult<BaseTypeTurnInput>` and its body (injects into `prompt_preamble`, preserves objective/identity, returns a `BaseTypeTurnInput` — it does **not** return a formatted string nor call `format_turn_input`).

## Merge-ready criteria

1. **qa-team scenarios** — N/A. Docs-only change; no behavioral surface to exercise. The behavior this doc describes is already covered by `tests/base_type_enrichment.rs` and the `base_type_turn` unit tests landed in #2361.
2. **Docs** — this PR *is* the docs correction. Changed surface: `docs/reference/base-type-adapters.md` (one bullet). No user-facing/runtime code changed.
3. **quality-audit** — N/A for a pure documentation accuracy fix (no code/logic). Correctness verified by reading the merged `src/base_type_turn.rs::enrich_turn_input` signature + body against the new text.
4. **CI** — must be 100% green (this PR).
5. **Evidence** — provided here (criteria 1–4, 6).
6. **Scope** — 1 file, 6 insertions / 4 deletions. Documentation only; no unrelated edits.

🤖 Docs-only follow-up; the originating fix (#2361) is already merged.