### PR TITLE
fix(dashboard): clarity P1 — memory totals, growth-trend agreement, cost honesty (#2358)

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -30,7 +30,7 @@ The dashboard is a single-page app with the following tabs:
 | **Logs** | Aggregated daemon and engineer logs. |
 | **Processes** | Live process tree under the daemon — engineer subprocesses, LLM sessions, and their resource usage. |
 | **Memory** | Cognitive memory graph (Working / Semantic / Episodic / Procedural / Prospective / Sensory) with per-type filters; full-text memory search; a **Memory Overview** with the live **Memory Store** counts; and a **Memory Files** panel showing the goals snapshot plus any non-empty legacy snapshot files. See [Memory architecture](memory.md). |
-| **Costs** | Per-provider, per-model token spend across the active session. |
+| **Costs** | Per-provider, per-model token spend across the active session. Dollar figures are **estimates derived from token usage**, not billed provider invoices. |
 | **Chat** | Direct chat with Simard. |
 | **Workboard** | Shared scratch canvas. (Renamed from "Whiteboard" — see [Tab identity contract](#tab-identity-contract).) |
 | **Thinking** | Live thinking-cycle stream (planner output before action dispatch). |

--- a/src/operator_commands_dashboard/index_html/part_00.rs
+++ b/src/operator_commands_dashboard/index_html/part_00.rs
@@ -253,7 +253,7 @@ pub(crate) const PART_00: &str = r#"<!DOCTYPE html>
       <div style="display:flex;align-items:center;gap:1.5rem;flex-wrap:wrap">
         <div style="text-align:center;min-width:120px">
           <div id="mem-recent-count" style="font-size:2.5rem;font-weight:700;color:#3fb950;line-height:1">—</div>
-          <div style="font-size:.85rem;color:#8b949e;margin-top:.25rem">items remembered<br>in the last hour</div>
+          <div style="font-size:.85rem;color:#8b949e;margin-top:.25rem">memories<br>stored</div>
         </div>
         <div style="flex:1;min-width:200px">
           <div style="display:flex;align-items:center;gap:.75rem;margin-bottom:.5rem">
@@ -336,7 +336,7 @@ pub(crate) const PART_00: &str = r#"<!DOCTYPE html>
 
   <div class="tab-content" id="tab-costs">
     <h1 class="page-h1">Costs</h1>
-    <p class="page-lede">Token and dollar spending by model and provider, plus your daily and weekly budget caps, computed from real provider invoices rather than estimates.</p>
+    <p class="page-lede">Token and dollar spending by model and provider, plus your daily and weekly budget caps. Dollar amounts are estimates derived from token usage, not actual provider invoices.</p>
     <div class="grid">
       <div class="card"><h2>Daily Costs <button class="btn" onclick="fetchCosts()">Refresh</button></h2><div id="costs-daily"><span class="loading">Loading…</span></div></div>
       <div class="card"><h2>Weekly Costs</h2><div id="costs-weekly"><span class="loading">Loading…</span></div></div>

--- a/src/operator_commands_dashboard/index_html/part_03.rs
+++ b/src/operator_commands_dashboard/index_html/part_03.rs
@@ -159,10 +159,17 @@ pub(crate) const PART_03: &str = r#"        const d=await apiFetch('/api/goals')
           trendEl.textContent='';
           return;
         }
-        // Trend badge
+        // Trend badge — derived from the SAME long-term rate rendered below so
+        // the badge direction can never contradict the displayed mem/hr sign (#2358).
         const trendIcons={growing:'↑ Growing',shrinking:'↓ Shrinking',stable:'→ Stable',unknown:'—'};
         const trendColors={growing:'#3fb950',shrinking:'#f85149',stable:'#d29922',unknown:'#8b949e'};
-        const trend=d.trend||'unknown';
+        const ltRate=d.rate_per_hour?(d.rate_per_hour.long_term_total||0):null;
+        const ltRateDisp=ltRate===null?null:(Math.abs(ltRate)<0.1?0:ltRate);
+        // Whenever a long-term rate is shown the badge is derived from it (same
+        // gate as the rate render below) so the two can never disagree (#2358).
+        const trend=ltRateDisp!==null
+          ?(ltRateDisp>0?'growing':(ltRateDisp<0?'shrinking':'stable'))
+          :(d.trend||'unknown');
         trendEl.textContent=trendIcons[trend]||'—';
         trendEl.style.color=trendColors[trend]||'#8b949e';
 
@@ -190,10 +197,9 @@ pub(crate) const PART_03: &str = r#"        const d=await apiFetch('/api/goals')
           deltasEl.innerHTML='<span style="color:#8b949e;font-size:.85rem">Not enough samples yet — growth data appears after two snapshots</span>';
         }
 
-        // Growth rate
+        // Growth rate (same value feeds the trend badge above)
         if(d.rate_per_hour){
-          const r=d.rate_per_hour.long_term_total||0;
-          const rDisp=Math.abs(r)<0.1?'0':r.toFixed(1);
+          const rDisp=ltRateDisp===0?'0':ltRate.toFixed(1);
           rateEl.innerHTML='<div style="font-size:1.5rem;font-weight:700;color:#58a6ff;line-height:1">'+rDisp+'</div><div style="font-size:.75rem;color:#8b949e;margin-top:.15rem">long-term mem/hr</div>';
         }
 
@@ -232,11 +238,24 @@ pub(crate) const PART_03: &str = r#"        const d=await apiFetch('/api/goals')
       listEl.innerHTML='<span class="loading">Loading recent memories…</span>';
       try{
         const d=await apiFetch('/api/memory/recent');
-        if(d.error){listEl.innerHTML='<span class="err">'+esc(d.error)+'</span>';countEl.textContent='—';return;}
-        countEl.textContent=d.last_hour_count;
-        totalEl.textContent=d.total+' total';
+        if(d.error){listEl.innerHTML='<span class="err">'+esc(d.error)+'</span>';countEl.textContent='—';totalEl.textContent='';return;}
+        // Headline reflects TOTAL stored memory. The recent-window count is
+        // unavailable on the library backend, so a bare "0" here misreads as
+        // "nothing remembered" while tens of thousands of memories exist (#2358).
+        const memTotal=Number(d.total)||0;
+        countEl.textContent=memTotal;
+        totalEl.textContent='';
         if(!d.items||d.items.length===0){
-          listEl.innerHTML='<span style="color:#8b949e">No memories stored yet. Simard will remember things as it works.</span>';
+          if(memTotal>0){
+            // Per-item recent listing is unavailable on the library backend, so
+            // we can't honestly claim the last hour was empty — state the total.
+            // The recent-window wording is used only when that window is known.
+            listEl.innerHTML=(d.available===false)
+              ?'<span style="color:#8b949e">Recent-memory list isn\'t available yet — '+memTotal+' total stored.</span>'
+              :'<span style="color:#8b949e">No new memories in the last hour — '+memTotal+' total stored.</span>';
+          }else{
+            listEl.innerHTML='<span style="color:#8b949e">No memories stored yet. Simard will remember things as it works.</span>';
+          }
           return;
         }
         const catColors={'Learned fact':'#58a6ff','Past event':'#3fb950','Current task context':'#f0883e','How-to knowledge':'#a371f7','Planned reminder':'#d29922','Recent observation':'#8b949e'};

--- a/src/operator_commands_dashboard/index_html/tab_meta.rs
+++ b/src/operator_commands_dashboard/index_html/tab_meta.rs
@@ -126,7 +126,7 @@ pub const TAB_METADATA: &[TabMeta] = &[
         label: "Costs",
         title: "Costs · Simard",
         h1: "Costs",
-        lede: "Token and dollar spending by model and provider, plus your daily and weekly budget caps, computed from real provider invoices rather than estimates.",
+        lede: "Token and dollar spending by model and provider, plus your daily and weekly budget caps. Dollar amounts are estimates derived from token usage, not actual provider invoices.",
         tooltip: "Token and dollar usage by model, plus daily and weekly budget",
     },
     TabMeta {

--- a/src/operator_commands_dashboard/memory.rs
+++ b/src/operator_commands_dashboard/memory.rs
@@ -235,9 +235,18 @@ pub(crate) async fn memory_history() -> Json<Value> {
 /// rather than reading the abandoned native store. Aggregate counts remain
 /// available via `GET /api/memory/history`.
 pub(crate) async fn memory_recent() -> Json<Value> {
+    // Per-item recent listing is unavailable on the library backend, but the
+    // aggregate total IS knowable via statistics. Surface it so the Memory tab
+    // headline can't read "nothing stored" while tens of thousands of memories
+    // exist (#2358).
+    let state_root = resolve_state_root();
+    let total = open_reader_bridge(&state_root)
+        .and_then(|reader| reader.ops().get_statistics())
+        .map(|s| s.total())
+        .unwrap_or(0);
     Json(json!({
         "items": [],
-        "total": 0,
+        "total": total,
         "last_hour_count": 0,
         "available": false,
         "note": "Per-item recent-memory listing is unavailable on the library \

--- a/tests/gadugi/dashboard-clarity-2358.sh
+++ b/tests/gadugi/dashboard-clarity-2358.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# dashboard-clarity-2358.sh — outside-in check for the P1 clarity fixes in
+# issue #2358.
+#
+# Three operator-facing confusions are asserted away here, against the served
+# dashboard HTML/JS of the real binary:
+#
+#   1. Memory tab "nothing remembered" lie — the headline used to render the
+#      recent-window count (a bare 0 on the library backend) while tens of
+#      thousands of memories were stored, and the empty-state said "No memories
+#      stored yet". The headline must now reflect the TOTAL, and the empty-state
+#      must read "No new memories in the last hour — N total stored".
+#   2. Growth badge vs rate sign — the "↑ Growing" badge could render next to a
+#      negative "long-term mem/hr" rate. The badge must be derived from the same
+#      displayed long-term rate so the two can never contradict.
+#   3. Cost honesty — the Costs lede claimed figures were "computed from real
+#      provider invoices rather than estimates" while the metric is labeled
+#      "Estimated Cost". The lede must no longer make the invoice claim.
+set -euo pipefail
+
+PORT="${DASH_PORT:-8139}"
+DASHKEY_FILE="${HOME}/.simard/.dashkey"
+LOG="$(mktemp -t dash-clarity.XXXXXX.log)"
+CJ="$(mktemp -t dash-clarity-cookies.XXXXXX)"
+
+echo "[clarity] building simard binary…"
+cargo build --quiet --bin simard
+BIN="${CARGO_TARGET_DIR:-target}/debug/simard"
+if [[ ! -x "$BIN" ]]; then
+  echo "[clarity] FAIL: built binary not found at $BIN" >&2
+  exit 1
+fi
+
+echo "[clarity] starting dashboard on :$PORT"
+"$BIN" dashboard serve --port="$PORT" >"$LOG" 2>&1 &
+DASH_PID=$!
+cleanup() { kill "$DASH_PID" 2>/dev/null || true; rm -f "$CJ"; }
+trap cleanup EXIT
+
+# Wait for the server to accept connections.
+up=0
+for _ in $(seq 1 30); do
+  if curl -s -o /dev/null "http://localhost:$PORT/login"; then up=1; break; fi
+  sleep 1
+done
+if [[ "$up" -ne 1 ]]; then
+  echo "[clarity] FAIL: dashboard did not come up on :$PORT" >&2
+  cat "$LOG" >&2
+  exit 1
+fi
+
+KEY="$(cat "$DASHKEY_FILE")"
+if ! curl -s -c "$CJ" -X POST -H 'Content-Type: application/json' \
+      -d "{\"code\":\"$KEY\"}" "http://localhost:$PORT/api/login" | grep -q '"ok":true'; then
+  echo "[clarity] FAIL: login rejected" >&2
+  exit 1
+fi
+
+HTML="$(curl -s -b "$CJ" "http://localhost:$PORT/")"
+
+fail() { echo "[clarity] FAIL: $1" >&2; exit 1; }
+
+# ── 1. Memory headline reflects total stored, not the recent-window count ────
+grep -q 'countEl.textContent=memTotal' <<<"$HTML" \
+  || fail "memory headline must render the total stored count (memTotal)"
+grep -q 'memories<br>stored' <<<"$HTML" \
+  || fail "memory headline label must read 'memories stored'"
+grep -q 'No new memories in the last hour' <<<"$HTML" \
+  || fail "empty-state must explain the recent window without claiming nothing is stored"
+grep -q "Recent-memory list isn" <<<"$HTML" \
+  || fail "empty-state must stay honest when the recent window is unavailable"
+grep -q 'total stored' <<<"$HTML" \
+  || fail "empty-state must surface the total stored count"
+grep -q 'items remembered' <<<"$HTML" \
+  && fail "stale 'items remembered / in the last hour' headline label still present"
+
+# ── 2. Growth badge is derived from the displayed long-term rate ─────────────
+grep -q "ltRateDisp>0?'growing'" <<<"$HTML" \
+  || fail "trend badge must be derived from the long-term rate so it can't contradict the rate sign"
+
+# ── 3. Cost lede honesty matches the 'Estimated Cost' metric label ───────────
+grep -q 'Estimated Cost' <<<"$HTML" \
+  || fail "cost metric must keep its honest 'Estimated Cost' label"
+grep -q 'real provider invoices rather than estimates' <<<"$HTML" \
+  && fail "cost lede still falsely claims figures come from real provider invoices"
+grep -q 'estimates derived from token usage' <<<"$HTML" \
+  || fail "cost lede must state the figures are estimates derived from token usage"
+
+echo "[clarity] PASS: memory totals, growth-trend agreement, and cost honesty hold (#2358)"

--- a/tests/gadugi/dashboard-clarity-2358.yaml
+++ b/tests/gadugi/dashboard-clarity-2358.yaml
@@ -1,0 +1,53 @@
+name: "Dashboard Clarity — Memory totals, growth-trend agreement, cost honesty (#2358)"
+description: "Outside-in operator check for the P1 clarity fixes from issue #2358: the Memory tab headline reflects total stored memory (not a bare 0), the empty-state reads 'No new memories in the last hour — N total stored', the Memory Growth badge is derived from the displayed long-term rate so it can never contradict the rate sign, and the Costs lede no longer claims 'real provider invoices' while the metric is labeled 'Estimated Cost'. Boots the real dashboard binary, authenticates, and asserts the served HTML/JS."
+version: "1.0.0"
+
+config:
+  timeout: 300000
+  retries: 0
+  parallel: false
+
+environment:
+  requires: []
+
+agents:
+  - name: "cli-agent"
+    type: "cli"
+    config:
+      workingDirectory: "."
+      defaultTimeout: 300000
+      executionMode: "spawn"
+      captureOutput: true
+      ioConfig:
+        encoding: "utf8"
+        handleInteractivePrompts: false
+      logConfig:
+        logCommands: true
+        logOutput: true
+        logLevel: "info"
+
+steps:
+  - name: "Memory totals, growth-trend agreement, and cost honesty hold"
+    agent: "cli-agent"
+    action: "execute_command"
+    params:
+      command: "tests/gadugi/dashboard-clarity-2358.sh"
+    timeout: 300000
+
+assertions: []
+
+cleanup:
+  - name: "CLI agent cleanup"
+    agent: "cli-agent"
+    action: "cleanup"
+
+metadata:
+  tags:
+    - "dashboard"
+    - "memory"
+    - "costs"
+    - "clarity"
+    - "issue-2358"
+  priority: "high"
+  author: "copilot"
+  test_type: "outside-in"


### PR DESCRIPTION
## Summary

Implements the three **P1** items from the live Playwright audit in #2358 (filed by `rysweet`). Each was an operator-facing confusion on the Simard dashboard; this PR is scoped tightly to those three and leaves the P2/P3 items (jargon humanization, units) as follow-ups.

| # | Confusion (before) | Fix (after) |
|---|---|---|
| 1 | Memory tab headline showed a bare **`0`** + *"No memories stored yet"* while 32k+ memories were stored | Headline shows **total stored** (`N memories stored`); empty-state stays honest about the recent window |
| 2 | Memory Growth badge **"↑ Growing"** rendered next to a **negative** rate **"-2.6 long-term mem/hr"** | Badge is derived from the *same* displayed long-term rate, so sign and direction can't disagree |
| 3 | Costs lede claimed figures come from *"real provider invoices rather than estimates"* while the metric is labeled **"Estimated Cost"** | Lede now says figures are *"estimates derived from token usage, not actual provider invoices"* |

### What changed
- **`memory.rs`** — `GET /api/memory/recent` now sources `total` from `get_statistics().total()`. Per-item listing remains unavailable on the library backend, but the aggregate count *is* knowable, so the headline no longer claims "nothing stored".
- **`part_03.rs`** — `fetchRecentMemories` renders the total as the headline and uses availability-aware empty-state copy. `fetchMemoryHistory` derives the trend badge from the same `rate_per_hour.long_term_total` value (and identical `<0.1 → stable` rounding) used to render the rate number.
- **`part_00.rs` / `tab_meta.rs`** — the Costs lede (kept byte-identical across both files, per the `rendered_html_contains_every_lede` test invariant) reconciled with the "Estimated Cost" label. Cost figures are estimates in code (`cost_usd_est`, `estimate_cost`).
- **`docs/dashboard.md`** — Costs row updated to state the dollar figures are estimates.
- **`tests/gadugi/dashboard-clarity-2358.{yaml,sh}`** — new outside-in scenario.

---

## Merge-readiness evidence

### 1. qa-team scenarios (gadugi)
New outside-in scenario `tests/gadugi/dashboard-clarity-2358.yaml` + driver `dashboard-clarity-2358.sh` boots the real binary, authenticates with the dashkey, and asserts the served HTML/JS for all three fixes (9 positive + 2 negative assertions).

```
$ gadugi-test validate -f tests/gadugi/dashboard-clarity-2358.yaml
✓ Scenario "Dashboard Clarity — ... (#2358)" is valid
✓ All 1 file(s) are valid

$ gadugi-test run -d tests/gadugi -s dashboard-clarity-2358
Command completed with exit code 0
✓ Passed: 1   ✗ Failed: 0   ✓ All tests passed!
```

### 2. Docs
`docs/dashboard.md` Costs row updated to match the cost-honesty fix. The other changed surfaces are operator dashboard copy (Memory headline/empty-state, Memory Growth badge) whose behavioral contract is captured by the new gadugi scenario; the generic tab descriptions in `docs/dashboard.md` remain accurate.

### 3. quality-audit (3 SEEK→VALIDATE→FIX cycles, clean final)
- **Cycle 1 — SEEK** (independent `code-review` + `rubber-duck` reviewers). **FIX:** (a) gated the trend badge on the same condition as the rate render (`rate present`) so badge↔rate agreement holds for *all* inputs, not just `snapshots≥2`; (b) made the empty-state availability-aware so it never asserts "no new memories in the last hour" when the recent window is genuinely unavailable.
- **Cycle 2 — SEEK** (`code-review` re-read full diff, compiled, ran tab_meta + memory suites). **Result:** "No significant issues found." Confirmed `ltRate.toFixed(1)` cannot throw, lede byte-identical (173 bytes each), no banned jargon, e2e mock path safe.
- **Cycle 3 — SEEK (self-audit) + FIX:** coerced the headline value to a number (`Number(d.total)||0`) so the `innerHTML` empty-state can't be influenced by a non-numeric `total`. **Final cycle clean:** zero critical/high; zero medium correctness/security findings.

### 4. CI
Local gates green on the final source:
- `cargo build` ✓ · `cargo clippy --lib` ✓ (0 warnings)
- Targeted suites: `index_html` (22) ✓, `memory` (10) ✓, `tests_routes_a` (39) ✓, `cost_tracking` (5) ✓ — including `rendered_html_contains_every_lede`, `tab_meta_ledes_no_banned_jargon`, `index_html_contains_growth_card`.
- The `pre-commit` (build/test/clippy) and `e2e-dashboard` jobs — the ones that validate this change — are the relevant gates.

**Known unrelated red check — `cargo-audit`:** fails on **RUSTSEC-2026-0185** (`quinn-proto` 0.11.14, high/7.5, *"Remote memory exhaustion … unbounded out-of-order stream reassembly"*), a transitive dependency via `reqwest → quinn → quinn-proto`. The advisory was **published 2026-06-22 (today)**; the fix is upstream `quinn-proto >= 0.11.15`. This PR makes **no `Cargo.toml`/`Cargo.lock` changes**, so the failure is repo-wide (every open PR and `main` as of today) and not caused by this diff. Deliberately **not** bundling a dependency bump into a UI-copy PR (keeps the diff focused — criterion 6); tracked separately in #2387 for its own dependency-bump PR.

- Two pre-existing local-only flakes, neither caused by this diff: `tests_goals_crud::full_goal_lifecycle_crud` and `goal_stewardship.rs` integration tests fail/hang **only on this shared dev box** because a live daemon mutates the shared `~/.simard` state, breaking their env-var-based hermetic isolation. Both fail identically on the clean baseline (`git stash`) and pass in a clean CI runner (which has no live daemon).

### 5 & 6. Evidence + focused diff
Diff is **7 files, +184/-14**, all on-topic; no unrelated edits. (Note: an unrelated `src/meeting_backend/*` change from another agent active in this shared worktree was deliberately excluded from the commit.)

---

## Before / After (Playwright, Chromium headless)

Captured by logging into the dashboard with `~/.simard/.dashkey` and mocking the audit's live data (memory holds 32,342 entries; growth deltas positive; server trend "growing"; long-term rate **-2.6**; `available:false`).

### Memory tab

**Before** — headline reads `0` + *"No memories stored yet"* while 32k+ exist, and the **"↑ Growing"** badge contradicts the **-2.6** rate:

![Memory tab before](https://raw.githubusercontent.com/rysweet/Simard/0e62fc4f0f487270adfaf14fd055731fb677d806/memory-before.png)

**After** — headline shows **`32342` memories stored**, honest empty-state, and the badge **"↓ Shrinking"** now agrees with the **-2.6** rate:

![Memory tab after](https://raw.githubusercontent.com/rysweet/Simard/0e62fc4f0f487270adfaf14fd055731fb677d806/memory-after.png)

### Costs tab

**Before** — lede claims *"real provider invoices rather than estimates"* directly above an **"Estimated Cost"** metric:

![Costs tab before](https://raw.githubusercontent.com/rysweet/Simard/0e62fc4f0f487270adfaf14fd055731fb677d806/costs-before.png)

**After** — lede reconciled with the metric: *"estimates derived from token usage, not actual provider invoices"*:

![Costs tab after](https://raw.githubusercontent.com/rysweet/Simard/0e62fc4f0f487270adfaf14fd055731fb677d806/costs-after.png)

### Captured rendered text (deterministic)

| field | before | after |
|---|---|---|
| memory headline count | `0` | `32342` |
| memory empty-state | `No memories stored yet. Simard will remember things as it works.` | `Recent-memory list isn't available yet — 32342 total stored.` |
| growth badge | `↑ Growing` | `↓ Shrinking` |
| growth rate | `-2.6 long-term mem/hr` | `-2.6 long-term mem/hr` |
| costs lede | `…computed from real provider invoices rather than estimates.` | `…Dollar amounts are estimates derived from token usage, not actual provider invoices.` |

> Screenshots are hosted on the non-PR branch `evidence/dashboard-clarity-2358-shots` (not part of the merge diff).

---

**Do not merge yet** — opening this PR is the deliverable for this cycle; merge-readiness is pending the CI run on this push. Closes the P1 portion of #2358.
