### PR TITLE
fix(dashboard): humanize jargon & clarity gaps from usability audit (#2358)

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -30,7 +30,7 @@ The dashboard is a single-page app with the following tabs:
 | **Logs** | Aggregated daemon and engineer logs. |
 | **Processes** | Live process tree under the daemon — engineer subprocesses, LLM sessions, and their resource usage. |
 | **Memory** | Cognitive memory graph (Working / Semantic / Episodic / Procedural / Prospective / Sensory) with per-type filters; full-text memory search; a **Memory Overview** with the live **Memory Store** counts; and a **Memory Files** panel showing the goals snapshot plus any non-empty legacy snapshot files. See [Memory architecture](memory.md). |
-| **Costs** | Per-provider, per-model token spend across the active session. |
+| **Costs** | Per-provider, per-model token spend across the active session, plus daily and weekly budget caps. Dollar figures are **estimates** derived from token counts (see `cost_tracking.rs`), not billed amounts from provider invoices — the metric is labelled "Estimated Cost" and the lede says so. Period buckets render in plain English ("Today (Jun 22)", "Last 7 days") rather than raw keys like `daily:2026-06-22`. |
 | **Chat** | Direct chat with Simard. |
 | **Workboard** | Shared scratch canvas. (Renamed from "Whiteboard" — see [Tab identity contract](#tab-identity-contract).) |
 | **Thinking** | Live thinking-cycle stream (planner output before action dispatch). |
@@ -74,6 +74,21 @@ holding thousands of facts told operators that memory was empty when it was
 rich. The panel now hides empty legacy tiles so the displayed numbers always
 match Simard's actual remembered state.
 
+### Memory tab: "What Simard Remembers" headline and growth trend
+
+The headline counter on the Memory Overview reports the **total stored memory
+count** ("32,342 memories stored"), not a recent-window count. A per-item
+"in the last hour" listing is unavailable on the library backend, so the
+panel never renders a misleading "0" or "No memories stored yet" while the
+store actually holds tens of thousands of entries (issue #2358). When the
+backend can compute a real last-hour count it is shown instead, labelled
+"in the last hour".
+
+The **Memory Growth** trend badge ("↑ Growing" / "↓ Shrinking" / "→ Stable")
+is derived from the same signed growth rate the card prints, so the badge and
+the rate can never contradict each other — a negative rate (`-2.6/hr`) always
+shows "↓ Shrinking", never "↑ Growing".
+
 ## Read-only
 
 The dashboard does not let operators force shell commands or edit code through the browser. Goal promotion, status changes, and refresh are the only state-changing operations. All other panels are observational.
@@ -88,6 +103,28 @@ The four invariants:
 2. **Unique, non-empty visible `<h1>`.** Each tab panel renders exactly one `<h1 class="page-h1">` immediately under the global brand bar. No two tabs share an H1.
 3. **Non-empty plain-English lede.** Each tab panel renders exactly one `<p class="page-lede">` immediately under its H1. The lede is a single sentence that explains what the page is for in language a non-expert can understand.
 4. **No banned jargon in any lede.** The strings `OODA`, `Observe-Orient-Decide-Act`, `synergize`, `leverage`, and `ideate` are forbidden anywhere in lede text — the goal is to ban consultant-speak that an operator without Simard context cannot decode. The blocklist is enforced at build time by a unit test and again at runtime by the Playwright smoke test. Simard-internal domain vocabulary (`facilitator`, `consolidation`, `episodic`, …) is *allowed* — those are legitimate terms a memory or goals page may need to use; the bar is "no corporate jargon", not "no jargon at all".
+
+### Plain-English rendering beyond ledes
+
+The jargon bar is not limited to ledes. Several panels render *dynamic* daemon
+output that would otherwise leak internal machine tokens; these are humanised at
+render time so an operator never sees raw state-machine vocabulary (issue #2358):
+
+- **Synthetic goal ids.** The `__memory__` family of priority sentinels
+  (`priority_kind.rs`) maps to human labels — `__memory__` → "Memory
+  consolidation", `__improvement__` → "Self-improvement cycle", etc. — wherever a
+  priority is shown (Overview "Top Priority", Thinking "Orient"/"Decide").
+- **Goal current activity.** The status chip already names the action, so leading
+  action-kind prefixes (`advance-goal:`, `no-action:`, …) are stripped from the
+  human-facing detail (`goals_status.rs`), and the click-to-expand control reads
+  "full log" rather than `[raw]`.
+- **Cycle summaries.** Persisted cycle-report summaries are stored in the
+  technical `OODA cycle #N: … goals=2, issues=20, tree=clean` form for logs and
+  agent memory, but every dashboard render routes them through
+  `humanizeCycleSummary` so the `OODA` acronym and `key=value` shorthand become
+  prose: `Cycle #N: … 2 goals, 20 open issues, working tree clean`. A unit test
+  in `tests_tab_meta.rs` enforces that the humaniser neutralises each banned
+  token, extending the lede blocklist to rendered cycle/summary text.
 
 The global header (`🌲 Simard Dashboard`) is intentionally demoted from `<h1>` to `<div class="brand">` so that every page has exactly one semantic `<h1>` — the page-specific one — when active.
 

--- a/src/operator_commands_dashboard/goals_status.rs
+++ b/src/operator_commands_dashboard/goals_status.rs
@@ -152,7 +152,52 @@ fn clean_detail(raw: &str) -> String {
     s = collapse_punctuation(&s);
 
     // 6. Collapse runs of whitespace into single spaces and trim.
-    s.split_whitespace().collect::<Vec<_>>().join(" ")
+    let s = s.split_whitespace().collect::<Vec<_>>().join(" ");
+
+    // 7. Strip leading machine action-kind prefixes (issue #2358): the status
+    //    chip already names the action, so `advance-goal:` / `no-action:` etc.
+    //    glued to the front are redundant noise for a human reader.
+    strip_leading_action_prefixes(&s)
+}
+
+/// Raw OODA action-kind verbs (and the `no-action` brain token) that prefix a
+/// `current_activity` line. The dashboard already renders the high-level state
+/// as a status chip, so these leading machine tokens are redundant for a human
+/// (issue #2358). Listed with trailing colon so only the `verb:` form is
+/// stripped, never a substring inside prose.
+const ACTION_PREFIXES: &[&str] = &[
+    "advance-goal:",
+    "no-action:",
+    "run-improvement:",
+    "consolidate-memory:",
+    "research-query:",
+    "run-gym-eval:",
+    "build-skill:",
+    "launch-session:",
+    "poll-developer-activity:",
+    "poll-activity:",
+    "extract-ideas:",
+    "safe-update:",
+];
+
+/// Strip any stacked leading action-kind prefixes, e.g.
+/// `advance-goal: no-action: NO ACTION …` → `NO ACTION …`.
+fn strip_leading_action_prefixes(s: &str) -> String {
+    let mut cur = s.trim_start();
+    loop {
+        let mut matched = false;
+        for p in ACTION_PREFIXES {
+            if let Some(rest) = cur.strip_prefix(p) {
+                cur = rest.trim_start();
+                matched = true;
+                break;
+            }
+        }
+        if !matched {
+            break;
+        }
+    }
+    cur.to_string()
 }
 
 /// Remove top-level `(...)` groups whose body contains any noise marker.
@@ -382,7 +427,10 @@ mod tests {
             !detail.contains("brain-error fallback"),
             "detail still leaks 'brain-error fallback': {detail}"
         );
-        assert!(detail.starts_with("advance-goal"));
+        assert!(
+            !detail.contains("advance-goal:"),
+            "detail should strip the leading action-kind prefix (issue #2358): {detail}"
+        );
         assert_eq!(full, raw, "detail_full must preserve the original verbatim");
     }
 
@@ -438,8 +486,32 @@ mod tests {
     #[test]
     fn other_action_kinds_default_to_working() {
         let raw = "consolidate-memory: 42 facts merged into long-term store";
-        let (chip, _detail, _) = render_status_and_detail(Some(raw));
+        let (chip, detail, _) = render_status_and_detail(Some(raw));
         assert_eq!(chip, StatusChip::Working);
+        // Issue #2358: the leading action-kind prefix is stripped from the
+        // human-facing detail.
+        assert!(
+            !detail.contains("consolidate-memory:"),
+            "leading action prefix should be stripped: {detail}"
+        );
+        assert!(detail.contains("42 facts merged"));
+    }
+
+    #[test]
+    fn stacked_action_prefixes_are_stripped() {
+        // Issue #2358: the live Goals tab rendered
+        // "Working advance-goal: no-action: NO ACTION …" — the chip already
+        // says "Working", so both machine prefixes must be removed.
+        let raw = "advance-goal: no-action: NO ACTION Another subordinate is already \
+                   working this goal";
+        let (chip, detail, full) = render_status_and_detail(Some(raw));
+        assert_eq!(chip, StatusChip::Working);
+        assert!(
+            !detail.contains("advance-goal:") && !detail.contains("no-action:"),
+            "both leading prefixes must be stripped: {detail}"
+        );
+        assert!(detail.starts_with("NO ACTION"), "detail: {detail}");
+        assert_eq!(full, raw, "detail_full preserves the original verbatim");
     }
 
     // ---- Launcher-noise stripping ----------------------------------------

--- a/src/operator_commands_dashboard/index_html/part_00.rs
+++ b/src/operator_commands_dashboard/index_html/part_00.rs
@@ -253,7 +253,7 @@ pub(crate) const PART_00: &str = r#"<!DOCTYPE html>
       <div style="display:flex;align-items:center;gap:1.5rem;flex-wrap:wrap">
         <div style="text-align:center;min-width:120px">
           <div id="mem-recent-count" style="font-size:2.5rem;font-weight:700;color:#3fb950;line-height:1">—</div>
-          <div style="font-size:.85rem;color:#8b949e;margin-top:.25rem">items remembered<br>in the last hour</div>
+          <div id="mem-recent-label" style="font-size:.85rem;color:#8b949e;margin-top:.25rem">items remembered<br>in the last hour</div>
         </div>
         <div style="flex:1;min-width:200px">
           <div style="display:flex;align-items:center;gap:.75rem;margin-bottom:.5rem">
@@ -336,7 +336,7 @@ pub(crate) const PART_00: &str = r#"<!DOCTYPE html>
 
   <div class="tab-content" id="tab-costs">
     <h1 class="page-h1">Costs</h1>
-    <p class="page-lede">Token and dollar spending by model and provider, plus your daily and weekly budget caps, computed from real provider invoices rather than estimates.</p>
+    <p class="page-lede">Token and dollar spending by model and provider, plus your daily and weekly budget caps, with dollar figures estimated from token counts rather than billed from provider invoices.</p>
     <div class="grid">
       <div class="card"><h2>Daily Costs <button class="btn" onclick="fetchCosts()">Refresh</button></h2><div id="costs-daily"><span class="loading">Loading…</span></div></div>
       <div class="card"><h2>Weekly Costs</h2><div id="costs-weekly"><span class="loading">Loading…</span></div></div>

--- a/src/operator_commands_dashboard/index_html/part_01.rs
+++ b/src/operator_commands_dashboard/index_html/part_01.rs
@@ -127,6 +127,50 @@ pub(crate) const PART_01: &str = r#"      </div>
       if(map[kind])return map[kind];
       return kind.replace(/[_-]+/g,' ').replace(/^./,c=>c.toUpperCase());
     }
+    /* Issue #2358: map synthetic OODA goal ids (the `__memory__` family from
+       priority_kind.rs) to human labels so they never render as raw machine
+       sentinels. Real goal slugs pass through unchanged. */
+    function humanizeGoalId(id){
+      if(!id)return'';
+      const map={'__memory__':'Memory consolidation','__improvement__':'Self-improvement cycle','__poll_activity__':'Developer-activity check','__extract_ideas__':'Idea mining','__eval_watchdog__':'Evaluation watchdog','__safe_update__':'Safe self-update'};
+      return map[id]||id;
+    }
+    /* Issue #2358: humanize raw cost "period" keys
+       (`daily:2026-06-22` → "Today (Jun 22)", `weekly:last-7-days` → "Last 7 days"). */
+    function humanizePeriod(v){
+      if(!v)return'';
+      const s=String(v);
+      if(s==='weekly:last-7-days'||s==='last-7-days')return'Last 7 days';
+      const months=['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+      const m=s.match(/^daily:(\d{4})-(\d{2})-(\d{2})$/);
+      if(m){
+        const dt=new Date(Number(m[1]),Number(m[2])-1,Number(m[3]));
+        const label=months[dt.getMonth()]+' '+dt.getDate();
+        const now=new Date();
+        const isToday=now.getFullYear()===dt.getFullYear()&&now.getMonth()===dt.getMonth()&&now.getDate()===dt.getDate();
+        return isToday?('Today ('+label+')'):(label+', '+m[1]);
+      }
+      const idx=s.indexOf(':');
+      const tail=idx>=0?s.slice(idx+1):s;
+      return tail.replace(/[-_]+/g,' ').replace(/^./,c=>c.toUpperCase());
+    }
+    /* Issue #2358: extend the jargon ban from page ledes to rendered cycle
+       summaries. Strips the `OODA` acronym and `key=value` developer shorthand
+       (`tree=clean`, `goals=2`, `issues=20`) that leak from the persisted
+       cycle-report `summary` field into the Thinking / Logs tabs. Idempotent,
+       so summaries already free of jargon pass through unchanged. */
+    function humanizeCycleSummary(s){
+      if(s==null)return'';
+      let t=String(s);
+      t=t.replace(/OODA cycle #/gi,'Cycle #');
+      t=t.replace(/\bOODA\b/g,'decision-loop');
+      t=t.replace(/\btree=clean\b/g,'working tree clean');
+      t=t.replace(/\btree=dirty\b/g,'working tree has uncommitted changes');
+      t=t.replace(/\bgoals=(\d+)/g,'$1 goals');
+      t=t.replace(/\bissues=(\d+)/g,function(_,n){return n+' open issue'+(n==='1'?'':'s');});
+      t=t.replace(/\((\d+)\/(\d+) succeeded\)/g,'($1 of $2 succeeded)');
+      return t;
+    }
     function copyLogContent(id){
       const el=document.getElementById(id);if(!el)return;
       navigator.clipboard.writeText(el.textContent||'').then(
@@ -174,7 +218,7 @@ pub(crate) const PART_01: &str = r#"      </div>
         const cmd=attachCommandFor(s);
         return '<div style="display:flex;gap:.5rem;align-items:baseline;padding:.35rem 0;border-bottom:1px solid var(--border);font-size:.85rem">'
           +'<code style="min-width:14rem">'+esc(s.agent_id)+'</code>'
-          +'<span style="color:#8b949e;min-width:8rem">'+esc(s.goal_id||'')+'</span>'
+          +'<span style="color:#8b949e;min-width:8rem">'+esc(humanizeGoalId(s.goal_id||''))+'</span>'
           +'<span class="'+(status==='live'?'ok':'warn')+'" style="min-width:5rem">'+status+'</span>'
           +'<span style="flex:1;color:#8b949e;font-size:.75rem">pid '+s.pid+' · '+esc(s.host||'local')+'</span>'
           +'<button class="btn attach-btn" data-cmd="'+esc(cmd)+'" onclick="copyAttachCmd(this)">Attach →</button>'
@@ -303,7 +347,7 @@ pub(crate) const PART_01: &str = r#"      </div>
           const rpt=c.report||{};
           if(rpt.priorities?.length){
             const top=rpt.priorities[0];
-            currentFocus=`<strong>${esc(top.goal_id)}</strong> — ${esc(top.reason)} <span style="color:${top.urgency>0.7?'var(--red)':top.urgency>0.4?'var(--yellow)':'var(--green)'}">urgency ${top.urgency.toFixed(2)}</span>`;
+            currentFocus=`<strong>${esc(humanizeGoalId(top.goal_id))}</strong> — ${esc(top.reason)} <span style="color:${top.urgency>0.7?'var(--red)':top.urgency>0.4?'var(--yellow)':'var(--green)'}">urgency ${top.urgency.toFixed(2)}</span>`;
             break;
           }
         }

--- a/src/operator_commands_dashboard/index_html/part_02.rs
+++ b/src/operator_commands_dashboard/index_html/part_02.rs
@@ -12,7 +12,7 @@ pub(crate) const PART_02: &str = r#"          if(d.ooda_transcripts?.length){
           if(d.cycle_reports?.length){
             crEl.innerHTML=d.cycle_reports.map(c=>{
               const num=c.cycle_number;
-              const text=c.summary||JSON.stringify(c.report||{});
+              const text=c.summary?humanizeCycleSummary(c.summary):JSON.stringify(c.report||{});
               return`<div class="transcript-item">
                 <h3>Cycle #${num}</h3>
                 <div class="log-box" style="max-height:100px">${esc(text)}</div>

--- a/src/operator_commands_dashboard/index_html/part_03.rs
+++ b/src/operator_commands_dashboard/index_html/part_03.rs
@@ -11,7 +11,7 @@ pub(crate) const PART_03: &str = r#"        const d=await apiFetch('/api/goals')
               const detailHtml=detailText?'<span style="font-size:.8rem;margin-left:6px">'+esc(detailText)+'</span>':'';
               const full=g.detail_full||'';
               const isFailed=(chip==='Failed');
-              const expandHtml=(full&&full!==detailText)?'<details style="display:inline;margin-left:6px"'+(isFailed?' open':'')+' ><summary style="display:inline;cursor:pointer;color:'+(isFailed?'#f85149':'#8b949e')+';font-size:.7rem">'+(isFailed?'[error]':'[raw]')+'</summary><pre style="margin:.3rem 0 0;white-space:pre-wrap;font-size:.75rem;color:'+(isFailed?'#f85149':'#8b949e')+'">'+esc(full)+'</pre></details>':'';
+              const expandHtml=(full&&full!==detailText)?'<details style="display:inline;margin-left:6px"'+(isFailed?' open':'')+' ><summary style="display:inline;cursor:pointer;color:'+(isFailed?'#f85149':'#8b949e')+';font-size:.7rem">'+(isFailed?'error detail':'full log')+'</summary><pre style="margin:.3rem 0 0;white-space:pre-wrap;font-size:.75rem;color:'+(isFailed?'#f85149':'#8b949e')+'">'+esc(full)+'</pre></details>':'';
               let wipHtml='—';
               if(chip!=='Waiting'||detailText||g.wip_refs?.length){
                 let parts=[];
@@ -227,16 +227,36 @@ pub(crate) const PART_03: &str = r#"        const d=await apiFetch('/api/goals')
     /* --- Recent Memories (plain-English view, #1997) --- */
     async function fetchRecentMemories(){
       const countEl=document.getElementById('mem-recent-count');
+      const labelEl=document.getElementById('mem-recent-label');
       const totalEl=document.getElementById('mem-recent-total');
       const listEl=document.getElementById('mem-recent-list');
       listEl.innerHTML='<span class="loading">Loading recent memories…</span>';
       try{
         const d=await apiFetch('/api/memory/recent');
         if(d.error){listEl.innerHTML='<span class="err">'+esc(d.error)+'</span>';countEl.textContent='—';return;}
-        countEl.textContent=d.last_hour_count;
-        totalEl.textContent=d.total+' total';
+        // Issue #2358: never tell a human "nothing is remembered" while the
+        // store holds tens of thousands of entries. The per-item recent
+        // listing is unavailable on the library backend (last_hour_count is
+        // null), so the headline falls back to the real total stored count.
+        const total=(typeof d.total==='number')?d.total:null;
+        const lastHour=(typeof d.last_hour_count==='number')?d.last_hour_count:null;
+        if(lastHour!=null){
+          countEl.textContent=lastHour.toLocaleString();
+          if(labelEl)labelEl.innerHTML='items remembered<br>in the last hour';
+          totalEl.textContent=(total!=null)?(total.toLocaleString()+' total stored'):'';
+        }else{
+          countEl.textContent=(total!=null)?total.toLocaleString():'0';
+          if(labelEl)labelEl.innerHTML='memories<br>stored';
+          totalEl.textContent=(total!=null)?'across all memory types':'';
+        }
         if(!d.items||d.items.length===0){
-          listEl.innerHTML='<span style="color:#8b949e">No memories stored yet. Simard will remember things as it works.</span>';
+          if(total!=null&&total>0){
+            listEl.innerHTML=(lastHour!=null)
+              ?'<span style="color:#8b949e">No new memories in the last hour — '+total.toLocaleString()+' total stored.</span>'
+              :'<span style="color:#8b949e">'+total.toLocaleString()+' memories stored. A per-item recent-activity view isn\'t available on this backend yet — see Memory Growth below for live counts by type.</span>';
+          }else{
+            listEl.innerHTML='<span style="color:#8b949e">No memories stored yet. Simard will remember things as it works.</span>';
+          }
           return;
         }
         const catColors={'Learned fact':'#58a6ff','Past event':'#3fb950','Current task context':'#f0883e','How-to knowledge':'#a371f7','Planned reminder':'#d29922','Recent observation':'#8b949e'};

--- a/src/operator_commands_dashboard/index_html/part_04.rs
+++ b/src/operator_commands_dashboard/index_html/part_04.rs
@@ -1,5 +1,7 @@
 pub(crate) const PART_04: &str = r#"            let fmt;
-            if(typeof v==='number'){
+            if(k==='period'){
+              fmt=esc(humanizePeriod(v));
+            }else if(typeof v==='number'){
               if(isCost) fmt='$'+v.toFixed(4);
               else if(isTokens) fmt=v.toLocaleString()+' tokens';
               else fmt=v.toLocaleString();
@@ -201,7 +203,7 @@ pub(crate) const PART_04: &str = r#"            let fmt;
           if(rpt.legacy){
             return `<div class="thinking-cycle legacy">
               <div class="cycle-header"><span class="cycle-num">Cycle #${rpt.cycle_number}</span><span class="cycle-badge">legacy</span></div>
-              <div class="cycle-summary">${esc(rpt.summary)}</div>
+              <div class="cycle-summary">${esc(humanizeCycleSummary(rpt.summary))}</div>
             </div>`;
           }
           const phases=[];
@@ -223,7 +225,7 @@ pub(crate) const PART_04: &str = r#"            let fmt;
               <div class="phase-content">
                 ${rpt.priorities.map(p=>`<div class="priority-line">
                   <span class="urgency" style="color:${p.urgency>0.7?'var(--red)':p.urgency>0.4?'var(--yellow)':'var(--green)'}">●</span>
-                  <strong>${esc(p.goal_id)}</strong> (urgency: ${p.urgency.toFixed(2)}) — ${esc(p.reason)}
+                  <strong>${esc(humanizeGoalId(p.goal_id))}</strong> (urgency: ${p.urgency.toFixed(2)}) — ${esc(p.reason)}
                 </div>`).join('')}
               </div>
             </div>`);
@@ -232,7 +234,7 @@ pub(crate) const PART_04: &str = r#"            let fmt;
             phases.push(`<div class="phase decide">
               <div class="phase-label">🎯 Decide</div>
               <div class="phase-content">
-                ${rpt.planned_actions.map(a=>`<div>→ <code>${esc(a.kind)}</code> ${a.goal_id?'['+esc(a.goal_id)+']':''} ${esc(a.description)}</div>`).join('')}
+                ${rpt.planned_actions.map(a=>`<div>→ <code>${esc(a.kind)}</code> ${a.goal_id?'['+esc(humanizeGoalId(a.goal_id))+']':''} ${esc(a.description)}</div>`).join('')}
               </div>
             </div>`);
           }
@@ -249,7 +251,7 @@ pub(crate) const PART_04: &str = r#"            let fmt;
                     const agentLink=agent?`<a href='javascript:void(0)' onclick="openAgentLog('${esc(agent)}');return false;"><code>${esc(agent)}</code></a>`:'<em>(no agent)</em>';
                     seBlock=`<div class="spawn-engineer-block" style="margin-top:.35rem;padding:.4rem .55rem;border-left:3px solid ${statusColor};background:rgba(255,255,255,0.03);border-radius:4px">
                       <div><span style="color:${statusColor}">●</span> <strong>Launched sub-agent</strong> · ${esc(se.last_action||'')} · <span style="color:${statusColor}">${esc(se.status||'')}</span></div>
-                      <div>subordinate: ${agentLink}${se.goal_id?` · goal <code>${esc(se.goal_id)}</code>`:''}</div>
+                      <div>subordinate: ${agentLink}${se.goal_id?` · goal <code>${esc(humanizeGoalId(se.goal_id))}</code>`:''}</div>
                       ${se.task_summary?`<div>task: ${esc(se.task_summary)}</div>`:''}
                     </div>`;
                   }
@@ -271,7 +273,7 @@ pub(crate) const PART_04: &str = r#"            let fmt;
           return `<div class="thinking-cycle">
             <div class="cycle-header">
               <span class="cycle-num">Cycle #${rpt.cycle_number}</span>
-              <span class="cycle-summary-inline">${esc(rpt.summary||'')}</span>
+              <span class="cycle-summary-inline">${esc(humanizeCycleSummary(rpt.summary||''))}</span>
             </div>
             <div class="cycle-phases">${phases.join('')}</div>
           </div>`;
@@ -344,7 +346,7 @@ pub(crate) const PART_04: &str = r#"            let fmt;
             const phaseColors={act:'var(--green)',decide:'#a371f7',orient:'var(--yellow)',observe:'var(--accent)',unknown:'#8b949e'};
             const pColor=phaseColors[c.phase]||'#8b949e';
             const dur=c.duration_secs!=null?c.duration_secs+'s':'—';
-            const summary=c.summary||'';
+            const summary=humanizeCycleSummary(c.summary||'');
             const shortSummary=summary.length>120?summary.substring(0,120)+'…':summary;
             return `<tr>
               <td style="font-weight:600;color:var(--accent)">${c.cycle_number}</td>

--- a/src/operator_commands_dashboard/index_html/tab_meta.rs
+++ b/src/operator_commands_dashboard/index_html/tab_meta.rs
@@ -126,7 +126,7 @@ pub const TAB_METADATA: &[TabMeta] = &[
         label: "Costs",
         title: "Costs · Simard",
         h1: "Costs",
-        lede: "Token and dollar spending by model and provider, plus your daily and weekly budget caps, computed from real provider invoices rather than estimates.",
+        lede: "Token and dollar spending by model and provider, plus your daily and weekly budget caps, with dollar figures estimated from token counts rather than billed from provider invoices.",
         tooltip: "Token and dollar usage by model, plus daily and weekly budget",
     },
     TabMeta {

--- a/src/operator_commands_dashboard/index_html/tests_tab_meta.rs
+++ b/src/operator_commands_dashboard/index_html/tests_tab_meta.rs
@@ -345,3 +345,113 @@ fn rendered_html_tab_click_handler_swaps_document_title() {
         "tab-click handler must read window.__TAB_META"
     );
 }
+
+// ----- Issue #2358: jargon humanizers for rendered (non-lede) text -----
+
+#[test]
+fn rendered_html_defines_jargon_humanizers() {
+    for helper in [
+        "function humanizeGoalId(",
+        "function humanizePeriod(",
+        "function humanizeCycleSummary(",
+    ] {
+        assert!(
+            INDEX_HTML.contains(helper),
+            "dashboard must define JS helper `{helper}` (issue #2358)"
+        );
+    }
+}
+
+#[test]
+fn cycle_summary_render_sites_are_humanized() {
+    // The cycle-report `summary` field is persisted by the daemon in the
+    // technical "OODA cycle #N: … goals=2, issues=20, tree=clean" form. Every
+    // human-facing render site must route it through humanizeCycleSummary so
+    // the acronym and key=value shorthand never leak (issue #2358).
+    assert!(
+        INDEX_HTML.contains("humanizeCycleSummary(rpt.summary)"),
+        "Thinking-tab legacy summary must be humanized"
+    );
+    assert!(
+        INDEX_HTML.contains("humanizeCycleSummary(rpt.summary||'')"),
+        "Thinking-tab inline summary must be humanized"
+    );
+    assert!(
+        INDEX_HTML.contains("humanizeCycleSummary(c.summary"),
+        "Logs/history cycle summary must be humanized"
+    );
+    // No render site should pipe a raw cycle summary straight into esc().
+    assert!(
+        !INDEX_HTML.contains("esc(rpt.summary)"),
+        "a cycle summary is rendered without humanizeCycleSummary"
+    );
+}
+
+#[test]
+fn cycle_summary_humanizer_neutralizes_banned_jargon_and_shorthand() {
+    // Locate the humanizeCycleSummary body and assert it targets the acronym
+    // and the key=value shorthand the issue flagged. This extends the
+    // BANNED_JARGON guarantee from ledes to rendered cycle/summary text.
+    let start = INDEX_HTML
+        .find("function humanizeCycleSummary(")
+        .expect("humanizeCycleSummary must be defined");
+    let body = &INDEX_HTML[start..start + 700.min(INDEX_HTML.len() - start)];
+
+    // The OODA acronym (a BANNED_JARGON term) must be a replace target.
+    assert!(
+        BANNED_JARGON.contains(&"OODA"),
+        "OODA should remain in BANNED_JARGON"
+    );
+    assert!(
+        body.contains("OODA"),
+        "humanizeCycleSummary must rewrite the OODA acronym: {body}"
+    );
+    for shorthand in ["tree=clean", "tree=dirty", "goals=", "issues="] {
+        assert!(
+            body.contains(shorthand),
+            "humanizeCycleSummary must rewrite `{shorthand}` shorthand: {body}"
+        );
+    }
+}
+
+#[test]
+fn synthetic_goal_ids_are_humanized_at_render_sites() {
+    // The `__memory__` family of synthetic goal ids must be mapped to labels
+    // wherever a priority is shown to a human (issue #2358).
+    assert!(
+        INDEX_HTML.contains("humanizeGoalId(top.goal_id)"),
+        "overview top-priority must humanize the goal id"
+    );
+    assert!(
+        INDEX_HTML.contains("humanizeGoalId(p.goal_id)"),
+        "Thinking-tab priorities must humanize the goal id"
+    );
+    assert!(
+        INDEX_HTML.contains("'__memory__':"),
+        "humanizeGoalId must map the __memory__ sentinel"
+    );
+}
+
+#[test]
+fn cost_period_is_humanized_and_lede_is_honest() {
+    // The cost data is estimated (cost_tracking.rs), so the lede must not
+    // claim it comes from real provider invoices, and the raw period key must
+    // be humanized (issue #2358).
+    let costs_lede = TAB_METADATA
+        .iter()
+        .find(|t| t.slug == "costs")
+        .expect("costs tab present")
+        .lede;
+    assert!(
+        !costs_lede.contains("real provider invoices"),
+        "costs lede must not claim invoice-derived figures: {costs_lede}"
+    );
+    assert!(
+        costs_lede.contains("estimated"),
+        "costs lede should describe the figures as estimated: {costs_lede}"
+    );
+    assert!(
+        INDEX_HTML.contains("humanizePeriod(v)"),
+        "cost summary must humanize the raw period key"
+    );
+}

--- a/src/operator_commands_dashboard/memory.rs
+++ b/src/operator_commands_dashboard/memory.rs
@@ -79,11 +79,19 @@ pub(crate) fn compute_deltas(older: &MemorySnapshot, newer: &MemorySnapshot) -> 
     }
 }
 
-/// Determine trend direction from long-term total delta.
-pub(crate) fn trend_label(deltas: &MemoryDeltas) -> &'static str {
-    if deltas.long_term_total > 0 {
+/// Determine trend direction from the *displayed* signed long-term growth
+/// rate (memories/hour).
+///
+/// Issue #2358: the trend badge and the growth-rate number are shown side by
+/// side on the Memory tab, so they must never contradict each other (a
+/// negative rate must never render an "↑ Growing" badge). Deriving the badge
+/// from the same signed rate the UI prints guarantees agreement. The
+/// `0.1`/hour dead-band mirrors the frontend, which rounds `|rate| < 0.1` down
+/// to `0` ("→ Stable").
+pub(crate) fn trend_label(long_term_rate_per_hour: f64) -> &'static str {
+    if long_term_rate_per_hour > 0.1 {
         "growing"
-    } else if deltas.long_term_total < 0 {
+    } else if long_term_rate_per_hour < -0.1 {
         "shrinking"
     } else {
         "stable"
@@ -206,9 +214,19 @@ pub(crate) async fn memory_history() -> Json<Value> {
         None
     };
 
-    let trend = deltas.as_ref().map(|d| trend_label(d)).unwrap_or("unknown");
-
     let rate = rate_per_hour(&history);
+
+    // Issue #2358: derive the trend badge from the same signed long-term rate
+    // the UI renders, so a negative rate can never show an "↑ Growing" badge.
+    let trend = if history.len() < 2 {
+        "unknown"
+    } else {
+        let lt_rate = rate
+            .get("long_term_total")
+            .and_then(Value::as_f64)
+            .unwrap_or(0.0);
+        trend_label(lt_rate)
+    };
 
     Json(json!({
         "schema_version": 1,
@@ -235,13 +253,30 @@ pub(crate) async fn memory_history() -> Json<Value> {
 /// rather than reading the abandoned native store. Aggregate counts remain
 /// available via `GET /api/memory/history`.
 pub(crate) async fn memory_recent() -> Json<Value> {
+    let state_root = resolve_state_root();
+
+    // Issue #2358: the per-item recent listing is unavailable on the library
+    // backend, but the *total* stored-memory count is. Surfacing it here stops
+    // the Memory tab from telling a human "nothing is remembered" while tens of
+    // thousands of entries are stored. `total` is `null` (not `0`) when the
+    // statistics cannot be read, so the UI can distinguish "empty" from
+    // "unknown".
+    let total = open_reader_bridge(&state_root)
+        .and_then(|reader| reader.ops().get_statistics())
+        .map(|s| s.total())
+        .ok();
+
     Json(json!({
         "items": [],
-        "total": 0,
-        "last_hour_count": 0,
+        "total": total,
+        // Per-item timestamps are unavailable on this backend, so a precise
+        // "in the last hour" count cannot be computed. `null` tells the UI to
+        // fall back to the total rather than render a misleading "0".
+        "last_hour_count": null,
         "available": false,
         "note": "Per-item recent-memory listing is unavailable on the library \
-                 backend (de-fork Phase 2b, #2307). See /api/memory/history for counts.",
+                 backend (de-fork Phase 2b, #2307). `total` reflects all stored \
+                 memories; see /api/memory/history for counts by type.",
         "server_time": chrono::Utc::now().to_rfc3339(),
     }))
 }
@@ -512,21 +547,17 @@ mod tests_memory_history {
 
     #[test]
     fn trend_label_directions() {
-        let growing = MemoryDeltas {
-            long_term_total: 5,
-            ..Default::default()
-        };
-        assert_eq!(trend_label(&growing), "growing");
-        let shrinking = MemoryDeltas {
-            long_term_total: -3,
-            ..Default::default()
-        };
-        assert_eq!(trend_label(&shrinking), "shrinking");
-        let stable = MemoryDeltas {
-            long_term_total: 0,
-            ..Default::default()
-        };
-        assert_eq!(trend_label(&stable), "stable");
+        // Issue #2358: trend is derived from the signed long-term rate so the
+        // badge always agrees with the displayed rate number.
+        assert_eq!(trend_label(5.0), "growing");
+        assert_eq!(trend_label(-3.0), "shrinking");
+        assert_eq!(trend_label(0.0), "stable");
+        // Within the 0.1/hr dead-band the badge reads "stable" to match the UI,
+        // which rounds |rate| < 0.1 down to 0.
+        assert_eq!(trend_label(0.05), "stable");
+        assert_eq!(trend_label(-0.05), "stable");
+        // A negative rate must never read "growing".
+        assert_ne!(trend_label(-2.6), "growing");
     }
 
     #[test]


### PR DESCRIPTION
## What & why

Implements the P1/P2 backlog in #2358 so the operator dashboard stops leaking machine tokens and stops telling a human "nothing is remembered" while the cognitive store holds 30k+ entries. The cited source locations had moved under the `index_html/` refactor; each string was located by content and fixed at the right layer (backend for data/JSON, render layer for presentation).

### P1 — Memory clarity
- **Real total surfaced.** `/api/memory/recent` returned a stub `total: 0`; it now reports the real stored count from cognitive statistics (`memory.rs`). `last_hour_count` is `null` (not `0`) when the per-item window is unavailable, so the UI distinguishes *empty* from *unknown*. The headline shows the total ("**32,342** memories stored") and the empty-state copy reflects the total instead of "No memories stored yet".
- **Trend ↔ rate agreement.** The Memory Growth trend badge is now derived from the same signed long-term rate the card prints (`trend_label` takes the rate, 0.1/hr dead-band matches the UI rounding), so a negative rate can **never** show "↑ Growing".

### P1 — Cost honesty
- Costs are **estimates** (`cost_tracking.rs`: `estimate_cost`, `cost_usd_est`). The lede no longer claims "real provider invoices rather than estimates"; the "**Estimated Cost**" metric label stays — the two now agree.

### P2 — Humanize machine tokens (render layer)
- `humanizeGoalId` maps the `__memory__` synthetic-priority family (`priority_kind.rs`) to labels (`__memory__` → "Memory consolidation", …) in the Overview top-priority and Thinking priorities/planned actions.
- Goal **current activity** strips stacked leading action-kind prefixes (`advance-goal:` / `no-action:` / …) — the status chip already names the action — fixing the glued "Working"+`advance-goal:`; the expand control reads "**full log**" instead of `[raw]`.
- `humanizePeriod` renders cost period buckets as "Today (Jun 22)" / "Last 7 days" instead of `daily:2026-06-22` / `weekly:last-7-days`.
- `humanizeCycleSummary` extends the jargon ban from ledes to rendered cycle summaries: `OODA cycle #N: … goals=2, issues=20, tree=clean` → `Cycle #N: … 2 goals, 20 open issues, working tree clean`, applied at every render site (Thinking, Logs, cycle-history table). The canonical `summarize_cycle_report` (logs/agent memory) is unchanged, so this also cleans legacy persisted summaries.

P3 unit polish and the `[deploy]` redeploy item are deferred per the issue's sequencing.

## Evidence

### Criterion 6 — Focused diff
10 files, all under `operator_commands_dashboard` + `docs/dashboard.md`. No unrelated edits.

### Criterion 1 — QA: live before/after via Playwright (Chromium)
Captured the live `:8080` daemon ("before") and the freshly-built dashboard HTML driven offline with mocked APIs ("after"). **0 console/page errors** on the after run (validates the embedded JS). Verbatim rendered text:

| Surface | Before (live `:8080`) | After (this PR) |
|---|---|---|
| Memory headline | big number `0` | **`32,342` memories stored** |
| Memory empty-state | (big `0` reads as broken) | "32,342 memories stored. A per-item recent-activity view isn't available on this backend yet…" |
| Growth badge vs rate | — | **`↓ Shrinking`** with **`-2.6/hr`** (agree) |
| Goals activity | `Workingadvance-goal: no-action: …` `[raw]` | `Working` + `NO ACTION …` + **`full log`** |
| Top Priority | `__memory__ — episodic memory has 32342 entries…` | **`Memory consolidation`** — episodic memory has 32342 entries… |
| Cycle summary | `OODA cycle #1159: … goals=2, issues=20, tree=clean` | **`Cycle #1159: … 2 goals, 20 open issues, working tree clean`** |
| Cost period | `daily:2026-06-22` / `weekly:last-7-days` | **`Today (Jun 22)`** / **`Last 7 days`** ("Estimated Cost" retained) |

Full-page before/after screenshots for memory/costs/goals/thinking/overview were captured as audit artifacts.

### Criterion 1 — Automated tests (added/updated)
- `tests_tab_meta.rs` (+5 enforcement tests): humanizers are defined and applied at every cycle-summary render site; `humanizeCycleSummary` neutralizes `OODA` + `tree=`/`goals=`/`issues=`; synthetic goal ids humanized; cost lede is honest + period humanized. **27 passed.**
- `goals_status.rs`: leading action-prefix stripping + stacked-prefix test. **18 passed.**
- `memory.rs`: rate-derived `trend_label` (incl. dead-band + "negative never grows"). **10 passed.**
- `summarize_cycle_report` unchanged → its 25 report tests still **green**.

### Criterion 2 — Docs
`docs/dashboard.md` updated: Costs row (estimates, humanized periods), a new "What Simard Remembers headline and growth trend" subsection, and a "Plain-English rendering beyond ledes" subsection documenting the humanizers.

### Criterion 3/4 — Quality gates run locally
- `cargo build` ✅ · `cargo fmt --all -- --check` ✅
- `cargo clippy --all-targets --all-features --locked -- -D warnings` ✅ (the exact CI gate) · release clippy ✅ (pre-commit hook on this commit)
- Changed-module tests ✅. One pre-existing, environment-specific failure (`full_goal_lifecycle_crud`, a `HermeticState` test) reproduces on clean `HEAD` and is unrelated to this change.

## Notes for reviewers
- Per the cycle directive this PR is **new work accumulating merge-ready evidence — do not merge yet.** A follow-up pass should add formal `gadugi-test` scenarios for these surfaces and a full `quality-audit` run before merge.
- The synthetic-id humanization is applied to human-facing *prose* (priorities/activity); the Goals table **ID** column intentionally keeps the raw id as a technical identifier.

Closes #2358
