### PR TITLE
test(cog-mem): extend serial(cognitive_memory) env-race guard to AnyVar process-wide (#2375)

### DIFF
--- a/docs/testing/cognitive-memory-serial-isolation.md
+++ b/docs/testing/cognitive-memory-serial-isolation.md
@@ -46,19 +46,18 @@ pre-commit `cargo test`.
   in an unrelated test — including the dashboard handlers' read of
   `SIMARD_STATE_ROOT`. This is var-agnostic: the *writer* and the *reader* do
   not have to touch the same variable.
-- The fix is a single rule for the guard's **watched env surface** — the
-  variables that resolve the cognitive-memory state root, the dashboard LLM
-  provider, and the meetings-persistence directory. The guard's *mutation* watch
-  (`EnvWatch::StateRootSurface` in `src/test_support/serial_guard.rs`) covers
-  `SIMARD_STATE_ROOT`, `SIMARD_MEMORY_SOCKET`, `HOME`, `SIMARD_LLM_PROVIDER`,
-  `SIMARD_MEETINGS_DIR`, `SIMARD_MEETINGS_ROOT`, `SIMARD_HANDOFF_DIR`; the *read* watch
-  (`READ_WATCHED_VARS`) is the same set **minus `HOME`** (a torn `HOME` read is
-  not the race — only a `HOME` *write* is). **Every lib-binary test that mutates
-  or reads that surface shares one serial key, `cognitive_memory`**, so no
-  mutation of it is ever concurrent with a read of
-  it. (Test *authors* should apply the same key for any other env var they
-  touch — see rule (B) — but the guard auto-enforces only the watched surface;
-  process-wide `AnyVar` enforcement is tracked follow-up, issue #2375.)
+- The fix is a single rule: **every lib-binary test that mutates *any*
+  process-global env var — or reads the cognitive-memory state-root surface —
+  shares one serial key, `cognitive_memory`**, so no env mutation is ever
+  concurrent with an env read. Since
+  [issue #2375](https://github.com/rysweet/Simard/issues/2375) the guard's
+  *mutation* watch is `EnvWatch::AnyVar` (`src/test_support/serial_guard.rs`): it
+  flags a `set_var`/`remove_var` of *any* variable that lacks the key. The
+  narrower *read* watch (`READ_WATCHED_VARS`) still targets the state-root /
+  provider / meetings surface (`SIMARD_STATE_ROOT`, `SIMARD_MEMORY_SOCKET`,
+  `SIMARD_LLM_PROVIDER`, `SIMARD_MEETINGS_DIR`, `SIMARD_MEETINGS_ROOT`,
+  `SIMARD_HANDOFF_DIR` — `HOME` excluded, because a torn `HOME` *read* is not the
+  race; only a `HOME` *write*, which can tear a `SIMARD_STATE_ROOT` read, is).
 - A **regression-guard meta-test** parses the source tree (with `syn`) and
   fails the build if a hand-written test touches that watched surface without
   the key, so an ordinary PR cannot silently reintroduce the race.
@@ -146,13 +145,13 @@ assertion.
 
 `cognitive_memory` is the **canonical key** for this property. It already
 guarded the `HermeticState` writers and the cognitive-memory readers; #2360
-extends it to cover every lib-binary test that touches the watched surface (its
-mutation watch `EnvWatch::StateRootSurface` and the read set `READ_WATCHED_VARS`
-in `src/test_support/serial_guard.rs`), making the guarantee **total for that
-surface**. The race is
-fundamentally variable-agnostic (see *Residual class & follow-up* below), so
-test authors should also key any *other* env var they mutate; auto-enforcing
-that process-wide (`EnvWatch::AnyVar`) is tracked as issue #2375.
+extends it to cover every lib-binary test that touches the watched surface (the
+read set `READ_WATCHED_VARS` in `src/test_support/serial_guard.rs`), making the
+guarantee **total for that surface**. The race is fundamentally
+variable-agnostic, so every env var a test mutates must be keyed; since
+[#2375](https://github.com/rysweet/Simard/issues/2375) the guard's *mutation*
+watch is `EnvWatch::AnyVar` and auto-enforces this process-wide (see
+*Process-wide enforcement* below).
 
 ### Annotation Decision Rule
 
@@ -165,14 +164,12 @@ if**, at run time, it does any of:
 - **(B)** Calls `set_var` / `remove_var` on **any** process-global variable.
   The race is var-agnostic, so `HOME`, `CARGO_TARGET_DIR`, `TZ`, etc. all count
   — not only `SIMARD_STATE_ROOT` and `SIMARD_MEMORY_SOCKET`. *Enforcement note:*
-  the `serial_guard` meta-test currently auto-detects (B) only for its
-  **mutation watch** `EnvWatch::StateRootSurface` (`SIMARD_STATE_ROOT`,
-  `SIMARD_MEMORY_SOCKET`, `HOME`, `SIMARD_LLM_PROVIDER`, `SIMARD_MEETINGS_DIR`,
-  `SIMARD_MEETINGS_ROOT`, `SIMARD_HANDOFF_DIR`; the rule-(C) *read* check uses `READ_WATCHED_VARS`,
-  the same set minus `HOME`);
-  for any other variable, rule (B) is an author obligation the guard does not
-  yet check. Closing that gap (`EnvWatch::AnyVar`) is tracked as issue #2375 —
-  see *Residual class & follow-up* below.
+  since [#2375](https://github.com/rysweet/Simard/issues/2375) the `serial_guard`
+  meta-test auto-detects (B) for **every** variable (`EnvWatch::AnyVar`), so this
+  is no longer only an author obligation — an unkeyed `set_var`/`remove_var` of
+  any name fails the build. The rule-(C) *read* check remains scoped to
+  `READ_WATCHED_VARS` (the state-root surface minus `HOME`). See *Process-wide
+  enforcement* below.
 - **(C)** Reads `SIMARD_STATE_ROOT` / `SIMARD_MEMORY_SOCKET` from the global
   env, directly or via `resolve_state_root()` / `memory_ipc::socket_path_for`
   default resolution.
@@ -219,41 +216,45 @@ binary with no in-process env mutators, so it is correctly left unannotated.
 
 ---
 
-## Residual class & follow-up
+## Process-wide enforcement (`EnvWatch::AnyVar`) — closed by #2375
 
-The invariant above is enforced for the guard's **watched surface** only (its
-`EnvWatch::StateRootSurface` mutation watch and the `READ_WATCHED_VARS` reads).
-The underlying hazard is variable-agnostic:
-glibc `setenv` may `realloc` (and free) the whole `environ` array when a variable
-is first added, so a concurrent `getenv` anywhere in the process can read freed
-memory **even when the writer and reader touch different variable names**.
+The invariant is now enforced for **every** process-global env mutation, not
+just the guard's original state-root watched surface. The underlying hazard is
+variable-agnostic: glibc `setenv` may `realloc` (and free) the whole `environ`
+array when a variable is first added, so a concurrent `getenv` anywhere in the
+process can read freed memory **even when the writer and reader touch different
+variable names**.
 
-Two consequences are therefore **not** closed by the #2360 work; both are tracked
-by [issue #2375](https://github.com/rysweet/Simard/issues/2375):
+[Issue #2375](https://github.com/rysweet/Simard/issues/2375) closed the residual
+class the #2360 work left open by:
 
-1. **Cross-variable tears from other serial groups.** Lib-binary tests that
-   mutate non-watched vars under a *different* serial key — e.g.
-   `SIMARD_SKIP_GYM` (`gym_runner_bridge`),
-   `NO_COLOR` (`meeting_repl`), `ENV_OVERRIDE` (`prompt_delivery`,
-   `prompt_delivery_env`), `SIMARD_NO_UPDATE_CHECK` (`update_check`,
-   `update_check_env`) — can still run concurrently with the `cognitive_memory`
-   readers. The guard does not flag them because `EnvWatch::StateRootSurface`
-   does not watch those variables.
-2. **A net-new concurrency from the migration.** Moving the `cmd_cleanup` /
-   `self_metrics` `HOME`-writers from the default `#[serial]` key into
-   `cognitive_memory` means they are no longer mutually serialized with the
-   bare-`#[serial]` non-watched mutators in (1).
+1. Switching the production audit default from `EnvWatch::StateRootSurface` to
+   **`EnvWatch::AnyVar`** (`AuditOptions::default().watched`), so the guard now
+   flags *any* `set_var`/`remove_var` in a lib-binary test that does not carry
+   the `cognitive_memory` key.
+2. Multi-keying every remaining env mutator into `cognitive_memory` (adding —
+   never removing — the key alongside any existing semantic group). This folded
+   in the previously-uncaught variables, including `SIMARD_SKIP_GYM`
+   (`gym_runner_bridge`), `NO_COLOR` (`meeting_repl`), `ENV_OVERRIDE`
+   (`prompt_delivery_env`), `SIMARD_NO_UPDATE_CHECK` (`update_check_env`),
+   `ENV_LLM_PROVIDER` (`runtime_config`), `ANTHROPIC_API_KEY` (`review_pipeline`,
+   `self_improve_executor`), `SIMARD_DASHBOARD_PORT`, `SIMARD_OPERATOR_NAME`,
+   `SIMARD_SCALING`, `SIMARD_ENGINEER_AGENT`, `SIMARD_SAFE_UPDATE_SKIP_HANDOVER`,
+   `SIMARD_DISK_PRESSURE_MIN_FREE_GB`, `SIMARD_AMPLIHACK_BIN`, and
+   `CARGO_TARGET_DIR` (the `cmd_cleanup` canary tests) — 84 tests across 24
+   modules, plus the bare-`#[serial]` / module-local `ENV_LOCK` neighbours so the
+   migration introduced no new cross-group concurrency.
 
-Both are **much rarer** than the #2360 symptom. The watched-surface tears caused
-a frequent, deterministic mis-resolution (a write to the wrong root left an empty
-board and tripped `board.active.len() == 3`, or routed an autosave into the wrong
-meetings dir), whereas the residual is an infrequent `environ`-realloc read of a
-value the assertion does not depend on. The complete fix — switching the guard to
-`EnvWatch::AnyVar` and multi-keying every remaining env mutator into
-`cognitive_memory` — touches ~30 unrelated test modules, so the work is
-deliberately incremental (each #2360 follow-up folds in the next surface that
-actually flaked: goals → provider → meetings) and the general case is tracked as
-issue #2375.
+The residual was **much rarer** than the #2360 symptom: the watched-surface
+tears caused a frequent, deterministic mis-resolution (a write to the wrong root
+left an empty board and tripped `board.active.len() == 3`, or routed an autosave
+into the wrong meetings dir), whereas this residual was an infrequent
+`environ`-realloc read of a value the assertion does not depend on. It is now
+closed **by construction**: with `AnyVar`, the `serial-guard` meta-test fails the
+build the moment any new env-mutating test omits the key. The
+`anyvar_default_isolates_every_env_writer_across_sessions` regression test pins
+the `AnyVar` default and proves an unrelated-variable writer is isolated from the
+cognitive-memory readers only when it shares the `cognitive_memory` key.
 
 ---
 
@@ -277,8 +278,9 @@ tests that do **not** also name `cognitive_memory` can still run in parallel
 with the cognitive-memory readers only if they touch no env — which, by the
 rule, they may not. The net effect for the watched surface: every reader/writer
 of it is serialized against every other, while unrelated semantic groups keep
-whatever extra parallelism they had. (Mutators of *other* env vars in unrelated
-groups are not yet folded in — see *Residual class & follow-up* above.)
+whatever extra parallelism they had. (Since #2375 the guard watches
+`EnvWatch::AnyVar`, so mutators of *other* env vars in unrelated groups are now
+folded in as well — see *Process-wide enforcement* above.)
 
 > Rule of thumb: **never remove** an existing key when adding `cognitive_memory`.
 > Append it. Removing a key silently widens concurrency for the original group.
@@ -387,15 +389,15 @@ pub(crate) struct AuditOptions {
     /// binary. Default: ["src/bin"] — each bin is a separate process.
     pub excluded_prefixes: Vec<String>,
 
-    /// Which env-var mutations trip the rule. Default:
-    /// `EnvWatch::StateRootSurface` — the cognitive-memory state-root,
-    /// provider, and meeting artifact-dir surface (`SIMARD_STATE_ROOT`,
+    /// Which env-var mutations trip the rule. Default (since #2375):
+    /// `EnvWatch::AnyVar` — any `set_var`/`remove_var` in a lib-binary test
+    /// must carry the `cognitive_memory` key. The narrower
+    /// `EnvWatch::StateRootSurface` (the cognitive-memory state-root, provider,
+    /// and meeting artifact-dir surface: `SIMARD_STATE_ROOT`,
     /// `SIMARD_MEMORY_SOCKET`, `HOME`, `SIMARD_LLM_PROVIDER`,
-    /// `SIMARD_MEETINGS_DIR`, `SIMARD_MEETINGS_ROOT`, `SIMARD_HANDOFF_DIR`; the
-    /// rule-(C) read check `READ_WATCHED_VARS` is the same set minus `HOME`).
-    /// `EnvWatch::AnyVar` (fully var-agnostic) and `EnvWatch::Vars(set)` remain
-    /// for the tracked #2375 follow-up that migrates every other env-mutating
-    /// variable.
+    /// `SIMARD_MEETINGS_DIR`, `SIMARD_MEETINGS_ROOT`, `SIMARD_HANDOFF_DIR`) and
+    /// `EnvWatch::Vars(set)` remain available for scoped audits. The rule-(C)
+    /// read check `READ_WATCHED_VARS` is the state-root surface minus `HOME`.
     pub watched: EnvWatch,
 
     /// Tests that are exempt with a written, machine-checked reason. Each
@@ -406,13 +408,13 @@ pub(crate) struct AuditOptions {
 ```
 
 `AuditOptions::default()` ships the production configuration: scan `src`,
-exclude `src/bin`, watch the **state-root / provider / meetings surface**
-(mutations of `SIMARD_STATE_ROOT`, `SIMARD_MEMORY_SOCKET`, `HOME`,
+exclude `src/bin`, watch **every process-global env mutation**
+(`EnvWatch::AnyVar`, since #2375), empty allowlist. The rule-(C) *read* check
+(`READ_WATCHED_VARS`) is narrower — the state-root / provider / meetings surface
+**minus `HOME`** (`SIMARD_STATE_ROOT`, `SIMARD_MEMORY_SOCKET`,
 `SIMARD_LLM_PROVIDER`, `SIMARD_MEETINGS_DIR`, `SIMARD_MEETINGS_ROOT`,
-`SIMARD_HANDOFF_DIR`), empty
-allowlist. The rule-(C) *read* check (`READ_WATCHED_VARS`) covers the same set
-**minus `HOME`** — a torn `HOME` *read* is not the cognitive-memory race; only a
-`HOME` *write*, which can tear a `SIMARD_STATE_ROOT` read, is.
+`SIMARD_HANDOFF_DIR`) — a torn `HOME` *read* is not the cognitive-memory race;
+only a `HOME` *write*, which can tear a `SIMARD_STATE_ROOT` read, is.
 
 ### Reading a failure
 

--- a/src/bootstrap/types.rs
+++ b/src/bootstrap/types.rs
@@ -254,6 +254,7 @@ mod tests {
 
     // ── BootstrapInputs default ──
 
+    #[serial_test::serial(cognitive_memory)]
     #[test]
     fn bootstrap_inputs_default_all_none() {
         use super::BootstrapInputs;

--- a/src/bridge_launcher.rs
+++ b/src/bridge_launcher.rs
@@ -165,6 +165,7 @@ mod tests {
         );
     }
 
+    #[serial_test::serial(cognitive_memory)]
     #[test]
     fn resolve_packs_dir_uses_env_override() {
         let original = std::env::var("SIMARD_PACKS_DIR").ok();

--- a/src/cmd_cleanup/tests.rs
+++ b/src/cmd_cleanup/tests.rs
@@ -326,7 +326,7 @@ fn corrupt_db_removed_when_older_than_threshold() {
 // ── clean_simard_canaries ──
 
 #[test]
-#[serial_test::serial]
+#[serial_test::serial(cognitive_memory)]
 fn clean_simard_canaries_removes_old_matching_only() {
     let tmp = tempfile::tempdir().unwrap();
     let base = tmp.path();
@@ -404,7 +404,7 @@ fn clean_simard_canaries_missing_base_is_noop() {
 }
 
 #[test]
-#[serial_test::serial]
+#[serial_test::serial(cognitive_memory)]
 fn clean_simard_canaries_records_error_when_removal_fails() {
     use std::os::unix::fs::PermissionsExt;
     let tmp = tempfile::tempdir().unwrap();
@@ -444,7 +444,7 @@ fn clean_simard_canaries_records_error_when_removal_fails() {
 // ── clean_stale_cargo_targets ──
 
 #[test]
-#[serial_test::serial]
+#[serial_test::serial(cognitive_memory)]
 fn clean_stale_cargo_targets_skips_configured_target() {
     // Point CARGO_TARGET_DIR at one hard-coded candidate so the function
     // `continue`s past it; the other candidate ("/tmp/cargo-target") is

--- a/src/disk_pressure/tests.rs
+++ b/src/disk_pressure/tests.rs
@@ -164,7 +164,7 @@ fn human_bytes_renders_iec_units() {
 // ------------------------------------------------------------------
 
 #[test]
-#[serial(simard_disk_pressure_env)]
+#[serial(simard_disk_pressure_env, cognitive_memory)]
 fn configured_min_free_gb_uses_default_when_unset() {
     // SAFETY: tests live in a single process; reset the var around
     // assertions. Use a unique name per test so concurrent tests can
@@ -178,7 +178,7 @@ fn configured_min_free_gb_uses_default_when_unset() {
 }
 
 #[test]
-#[serial(simard_disk_pressure_env)]
+#[serial(simard_disk_pressure_env, cognitive_memory)]
 fn configured_min_free_gb_parses_valid_value() {
     // SAFETY: env var mutation is process-wide; tests in this module
     // may race, but cargo test is the sole writer.
@@ -189,7 +189,7 @@ fn configured_min_free_gb_parses_valid_value() {
 }
 
 #[test]
-#[serial(simard_disk_pressure_env)]
+#[serial(simard_disk_pressure_env, cognitive_memory)]
 fn configured_min_free_gb_rejects_zero_and_falls_back() {
     // SAFETY: see above.
     unsafe { std::env::set_var("SIMARD_DISK_PRESSURE_MIN_FREE_GB", "0") };
@@ -199,7 +199,7 @@ fn configured_min_free_gb_rejects_zero_and_falls_back() {
 }
 
 #[test]
-#[serial(simard_disk_pressure_env)]
+#[serial(simard_disk_pressure_env, cognitive_memory)]
 fn configured_min_free_gb_rejects_garbage_and_falls_back() {
     // SAFETY: see above.
     unsafe { std::env::set_var("SIMARD_DISK_PRESSURE_MIN_FREE_GB", "twenty") };

--- a/src/engineer_loop/agent_spawn.rs
+++ b/src/engineer_loop/agent_spawn.rs
@@ -491,7 +491,7 @@ mod tests {
     }
 
     #[test]
-    #[serial(simard_amplihack_bin_env)]
+    #[serial(simard_amplihack_bin_env, cognitive_memory)]
     fn amplihack_binary_respects_env_override() {
         // Use a sentinel value that is not a real binary; verify the function
         // honours the override regardless of whether the file exists.
@@ -532,7 +532,7 @@ mod tests {
     }
 
     #[test]
-    #[serial(simard_amplihack_bin_env)]
+    #[serial(simard_amplihack_bin_env, cognitive_memory)]
     fn run_rustyclawd_subprocess_propagates_spawn_failure() {
         // Override binary to a path that does not exist; spawn must fail with
         // ActionExecutionFailed (not panic, not block).
@@ -571,7 +571,7 @@ mod tests {
     }
 
     #[test]
-    #[serial(simard_engineer_agent_env)]
+    #[serial(simard_engineer_agent_env, cognitive_memory)]
     fn agent_kind_from_env_defaults_to_copilot() {
         // Shares the `simard_engineer_agent_env` named lock with the sibling
         // tests below that also mutate `SIMARD_ENGINEER_AGENT`, so a
@@ -590,7 +590,7 @@ mod tests {
     }
 
     #[test]
-    #[serial(simard_engineer_agent_env)]
+    #[serial(simard_engineer_agent_env, cognitive_memory)]
     fn agent_kind_from_env_recognises_rustyclawd_explicitly() {
         let original = std::env::var("SIMARD_ENGINEER_AGENT").ok();
         for raw in [
@@ -614,7 +614,7 @@ mod tests {
     }
 
     #[test]
-    #[serial(simard_engineer_agent_env)]
+    #[serial(simard_engineer_agent_env, cognitive_memory)]
     fn agent_kind_from_env_recognises_copilot_case_insensitive() {
         let original = std::env::var("SIMARD_ENGINEER_AGENT").ok();
         for raw in ["copilot", "Copilot", "COPILOT", "  copilot  "] {
@@ -632,7 +632,7 @@ mod tests {
     }
 
     #[test]
-    #[serial(simard_engineer_agent_env)]
+    #[serial(simard_engineer_agent_env, cognitive_memory)]
     fn agent_kind_from_env_unknown_falls_back_to_default() {
         let original = std::env::var("SIMARD_ENGINEER_AGENT").ok();
         unsafe {

--- a/src/engineer_worktree/precommit.rs
+++ b/src/engineer_worktree/precommit.rs
@@ -100,6 +100,7 @@ mod tests {
         );
     }
 
+    #[serial_test::serial(cognitive_memory)]
     #[test]
     fn install_hooks_skips_silently_when_binary_missing() {
         let dir = tempfile::tempdir().unwrap();

--- a/src/engineer_worktree/tests_extra.rs
+++ b/src/engineer_worktree/tests_extra.rs
@@ -102,7 +102,7 @@ fn allocate_records_full_40hex_main_sha_on_branch() {
 // ---------------------------------------------------------------------------
 
 #[test]
-#[serial_test::serial]
+#[serial_test::serial(cognitive_memory)]
 fn git_capture_clears_inherited_git_env() {
     use std::sync::Mutex;
     static ENV_LOCK: Mutex<()> = Mutex::new(());

--- a/src/git_guardrails.rs
+++ b/src/git_guardrails.rs
@@ -111,6 +111,7 @@ mod tests {
         }
     }
 
+    #[serial_test::serial(cognitive_memory)]
     #[test]
     fn blocks_force_push() {
         let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
@@ -123,6 +124,7 @@ mod tests {
         assert!(result.unwrap_err().contains("GUARDRAIL BLOCKED"));
     }
 
+    #[serial_test::serial(cognitive_memory)]
     #[test]
     fn blocks_reset_hard() {
         let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
@@ -131,6 +133,7 @@ mod tests {
         assert!(result.is_err());
     }
 
+    #[serial_test::serial(cognitive_memory)]
     #[test]
     fn allows_normal_push() {
         let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
@@ -142,6 +145,7 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    #[serial_test::serial(cognitive_memory)]
     #[test]
     fn allows_commit() {
         let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
@@ -150,6 +154,7 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    #[serial_test::serial(cognitive_memory)]
     #[test]
     fn disabled_allows_everything() {
         let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
@@ -163,6 +168,7 @@ mod tests {
         reset_env();
     }
 
+    #[serial_test::serial(cognitive_memory)]
     #[test]
     fn blocks_delete_main_branch() {
         let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());

--- a/src/meeting_repl/color.rs
+++ b/src/meeting_repl/color.rs
@@ -60,7 +60,7 @@ mod tests {
     }
 
     #[test]
-    #[serial]
+    #[serial(cognitive_memory)]
     fn green_with_no_color_returns_plain() {
         with_no_color(|| {
             assert_eq!(green("hello"), "hello");
@@ -68,7 +68,7 @@ mod tests {
     }
 
     #[test]
-    #[serial]
+    #[serial(cognitive_memory)]
     fn yellow_with_no_color_returns_plain() {
         with_no_color(|| {
             assert_eq!(yellow("warn"), "warn");
@@ -76,7 +76,7 @@ mod tests {
     }
 
     #[test]
-    #[serial]
+    #[serial(cognitive_memory)]
     fn cyan_with_no_color_returns_plain() {
         with_no_color(|| {
             assert_eq!(cyan("info"), "info");
@@ -84,7 +84,7 @@ mod tests {
     }
 
     #[test]
-    #[serial]
+    #[serial(cognitive_memory)]
     fn green_without_no_color_contains_escape() {
         without_no_color(|| {
             let result = green("ok");
@@ -98,7 +98,7 @@ mod tests {
     }
 
     #[test]
-    #[serial]
+    #[serial(cognitive_memory)]
     fn yellow_without_no_color_contains_escape() {
         without_no_color(|| {
             let result = yellow("warn");
@@ -110,7 +110,7 @@ mod tests {
     }
 
     #[test]
-    #[serial]
+    #[serial(cognitive_memory)]
     fn cyan_without_no_color_contains_escape() {
         without_no_color(|| {
             let result = cyan("section");

--- a/src/ooda_loop/types.rs
+++ b/src/ooda_loop/types.rs
@@ -416,6 +416,7 @@ mod tests_ooda_config {
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
+    #[serial_test::serial(cognitive_memory)]
     #[test]
     fn ooda_config_creates_scaler_when_scaling_auto() {
         let _lock = ENV_LOCK.lock().unwrap();
@@ -428,6 +429,7 @@ mod tests_ooda_config {
         );
     }
 
+    #[serial_test::serial(cognitive_memory)]
     #[test]
     fn ooda_config_no_scaler_when_scaling_fixed() {
         let _lock = ENV_LOCK.lock().unwrap();
@@ -440,6 +442,7 @@ mod tests_ooda_config {
         );
     }
 
+    #[serial_test::serial(cognitive_memory)]
     #[test]
     fn ooda_config_no_scaler_when_scaling_unset() {
         let _lock = ENV_LOCK.lock().unwrap();
@@ -454,6 +457,7 @@ mod tests_ooda_config {
     // Issue #2327 (RED): the automatic promotion scheduler is configured via
     // two new OodaConfig fields. With the env overrides unset, they default to
     // the canonical 25-episode threshold and 50-cycle interval.
+    #[serial_test::serial(cognitive_memory)]
     #[test]
     fn ooda_config_default_distill_thresholds() {
         let _lock = ENV_LOCK.lock().unwrap();
@@ -470,6 +474,7 @@ mod tests_ooda_config {
         );
     }
 
+    #[serial_test::serial(cognitive_memory)]
     #[test]
     fn ooda_config_auto_scaler_ceiling_is_4x_max() {
         let _lock = ENV_LOCK.lock().unwrap();
@@ -486,6 +491,7 @@ mod tests_ooda_config {
         );
     }
 
+    #[serial_test::serial(cognitive_memory)]
     #[test]
     fn ooda_config_auto_scaler_adjust_returns_within_bounds() {
         let _lock = ENV_LOCK.lock().unwrap();
@@ -504,6 +510,7 @@ mod tests_ooda_config {
         );
     }
 
+    #[serial_test::serial(cognitive_memory)]
     #[test]
     fn ooda_config_scaler_skipped_on_serde_roundtrip() {
         let _lock = ENV_LOCK.lock().unwrap();

--- a/src/operator_commands_meeting/live_context.rs
+++ b/src/operator_commands_meeting/live_context.rs
@@ -127,6 +127,7 @@ mod tests {
 
     // ── resolve_operator_name ───────────────────────────────────────
 
+    #[serial_test::serial(cognitive_memory)]
     #[test]
     fn resolve_operator_name_default() {
         let _lock = ENV_MUTEX.lock().unwrap();
@@ -135,6 +136,7 @@ mod tests {
         assert_eq!(name, "operator");
     }
 
+    #[serial_test::serial(cognitive_memory)]
     #[test]
     fn resolve_operator_name_from_env() {
         let _lock = ENV_MUTEX.lock().unwrap();
@@ -144,6 +146,7 @@ mod tests {
         unsafe { std::env::remove_var("SIMARD_OPERATOR_NAME") };
     }
 
+    #[serial_test::serial(cognitive_memory)]
     #[test]
     fn resolve_operator_name_empty_env_falls_back() {
         let _lock = ENV_MUTEX.lock().unwrap();
@@ -192,6 +195,7 @@ mod tests {
 
     // ── build_live_meeting_context ──────────────────────────────────
 
+    #[serial_test::serial(cognitive_memory)]
     #[test]
     fn build_context_empty_memory() {
         let _lock = ENV_MUTEX.lock().unwrap();
@@ -202,6 +206,7 @@ mod tests {
         assert!(ctx.contains("operator"));
     }
 
+    #[serial_test::serial(cognitive_memory)]
     #[test]
     fn build_context_failing_bridge_propagates_error() {
         let _lock = ENV_MUTEX.lock().unwrap();

--- a/src/operator_commands_meeting/tests_live_context.rs
+++ b/src/operator_commands_meeting/tests_live_context.rs
@@ -7,6 +7,7 @@ static ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 // ── build_live_meeting_context ──────────────────────────────────────
 
+#[serial_test::serial(cognitive_memory)]
 #[test]
 fn defaults_with_empty_bridge() {
     let _lock = ENV_MUTEX.lock().unwrap();
@@ -40,6 +41,7 @@ fn defaults_with_empty_bridge() {
     );
 }
 
+#[serial_test::serial(cognitive_memory)]
 #[test]
 fn empty_bridge_uses_env_var_operator_name() {
     let _lock = ENV_MUTEX.lock().unwrap();
@@ -59,6 +61,7 @@ fn empty_bridge_uses_env_var_operator_name() {
     );
 }
 
+#[serial_test::serial(cognitive_memory)]
 #[test]
 fn empty_env_var_falls_back_to_generic() {
     let _lock = ENV_MUTEX.lock().unwrap();

--- a/src/operator_commands_ooda/daemon/config.rs
+++ b/src/operator_commands_ooda/daemon/config.rs
@@ -28,6 +28,7 @@ mod tests {
     /// Serialize tests that mutate `SIMARD_DASHBOARD_PORT`.
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
+    #[serial_test::serial(cognitive_memory)]
     #[test]
     fn default_values_without_env() {
         let _g = ENV_LOCK.lock().unwrap();
@@ -37,6 +38,7 @@ mod tests {
         assert_eq!(cfg.port, 8080, "default port must be 8080");
     }
 
+    #[serial_test::serial(cognitive_memory)]
     #[test]
     fn env_override_sets_port() {
         let _g = ENV_LOCK.lock().unwrap();
@@ -46,6 +48,7 @@ mod tests {
         unsafe { std::env::remove_var("SIMARD_DASHBOARD_PORT") };
     }
 
+    #[serial_test::serial(cognitive_memory)]
     #[test]
     fn invalid_env_falls_back_to_default_port() {
         let _g = ENV_LOCK.lock().unwrap();
@@ -55,6 +58,7 @@ mod tests {
         unsafe { std::env::remove_var("SIMARD_DASHBOARD_PORT") };
     }
 
+    #[serial_test::serial(cognitive_memory)]
     #[test]
     fn empty_env_falls_back_to_default_port() {
         let _g = ENV_LOCK.lock().unwrap();
@@ -74,6 +78,7 @@ mod tests {
         assert_eq!(cfg.port, 9999);
     }
 
+    #[serial_test::serial(cognitive_memory)]
     #[test]
     fn zero_port_is_valid() {
         let _g = ENV_LOCK.lock().unwrap();

--- a/src/operator_commands_ooda/tests/daemon_inline.rs
+++ b/src/operator_commands_ooda/tests/daemon_inline.rs
@@ -65,7 +65,7 @@ fn test_interruptible_sleep_mid_shutdown() {
 }
 
 #[test]
-#[serial_test::serial]
+#[serial_test::serial(cognitive_memory)]
 fn daemon_dashboard_config_default_values() {
     // Clear any env override to test the true default
     unsafe { std::env::remove_var("SIMARD_DASHBOARD_PORT") };
@@ -75,7 +75,7 @@ fn daemon_dashboard_config_default_values() {
 }
 
 #[test]
-#[serial_test::serial]
+#[serial_test::serial(cognitive_memory)]
 fn daemon_dashboard_config_env_override() {
     unsafe { std::env::set_var("SIMARD_DASHBOARD_PORT", "9090") };
     let config = DaemonDashboardConfig::default();
@@ -85,7 +85,7 @@ fn daemon_dashboard_config_env_override() {
 }
 
 #[test]
-#[serial_test::serial]
+#[serial_test::serial(cognitive_memory)]
 fn daemon_dashboard_config_invalid_env_falls_back() {
     unsafe { std::env::set_var("SIMARD_DASHBOARD_PORT", "not_a_number") };
     let config = DaemonDashboardConfig::default();

--- a/src/prompt_delivery/mod.rs
+++ b/src/prompt_delivery/mod.rs
@@ -780,7 +780,7 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    #[serial(prompt_delivery_env)]
+    #[serial(prompt_delivery_env, cognitive_memory)]
     #[cfg_attr(miri, ignore)]
     fn select_mode_env_override_only_for_auto() {
         // SAFETY (Rust 2024): set_var / remove_var require `unsafe` because
@@ -1258,7 +1258,7 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    #[serial(prompt_delivery_env)]
+    #[serial(prompt_delivery_env, cognitive_memory)]
     fn select_mode_env_auto_falls_through_to_heuristic() {
         unsafe {
             std::env::set_var(ENV_OVERRIDE, "auto");
@@ -1275,7 +1275,7 @@ mod tests {
     }
 
     #[test]
-    #[serial(prompt_delivery_env)]
+    #[serial(prompt_delivery_env, cognitive_memory)]
     fn select_mode_env_inline_with_nul_errors() {
         unsafe {
             std::env::set_var(ENV_OVERRIDE, "inline");

--- a/src/review_pipeline.rs
+++ b/src/review_pipeline.rs
@@ -352,6 +352,7 @@ mod tests {
         let deserialized: ReviewFinding = serde_json::from_str(&json).unwrap();
         assert_eq!(f, deserialized);
     }
+    #[serial_test::serial(cognitive_memory)]
     #[test]
     fn review_session_open_without_api_key_does_not_panic() {
         unsafe { std::env::remove_var("ANTHROPIC_API_KEY") };

--- a/src/runtime_config.rs
+++ b/src/runtime_config.rs
@@ -236,6 +236,7 @@ mod tests {
         unsafe { std::env::remove_var(ENV_LLM_PROVIDER) };
     }
 
+    #[serial_test::serial(cognitive_memory)]
     #[test]
     fn load_from_env_wins_when_set() {
         let tmp = TempDir::new().unwrap();
@@ -247,6 +248,7 @@ mod tests {
         });
     }
 
+    #[serial_test::serial(cognitive_memory)]
     #[test]
     fn load_from_file_when_env_unset() {
         let tmp = TempDir::new().unwrap();
@@ -261,6 +263,7 @@ mod tests {
         });
     }
 
+    #[serial_test::serial(cognitive_memory)]
     #[test]
     fn load_errors_when_neither_source_present() {
         let tmp = TempDir::new().unwrap();
@@ -273,6 +276,7 @@ mod tests {
         });
     }
 
+    #[serial_test::serial(cognitive_memory)]
     #[test]
     fn load_rejects_unknown_provider_value() {
         let tmp = TempDir::new().unwrap();
@@ -290,6 +294,7 @@ mod tests {
         });
     }
 
+    #[serial_test::serial(cognitive_memory)]
     #[test]
     fn bootstrap_from_env_writes_when_missing() {
         let tmp = TempDir::new().unwrap();
@@ -304,6 +309,7 @@ mod tests {
         });
     }
 
+    #[serial_test::serial(cognitive_memory)]
     #[test]
     fn bootstrap_from_env_skips_when_file_exists() {
         let tmp = TempDir::new().unwrap();
@@ -322,6 +328,7 @@ mod tests {
         });
     }
 
+    #[serial_test::serial(cognitive_memory)]
     #[test]
     fn bootstrap_from_env_noop_when_env_unset_and_no_file() {
         let tmp = TempDir::new().unwrap();
@@ -365,6 +372,7 @@ mod tests {
         assert_eq!(LlmProvider::RustyClawd.agent_binary_value(), "rustyclawd");
     }
 
+    #[serial_test::serial(cognitive_memory)]
     #[test]
     fn config_load_provides_usable_agent_binary_value() {
         let tmp = TempDir::new().unwrap();

--- a/src/safe_update/swap.rs
+++ b/src/safe_update/swap.rs
@@ -213,6 +213,7 @@ mod tests {
         assert!(matches!(err, SafeUpdateError::SwapFailed { .. }));
     }
 
+    #[serial_test::serial(cognitive_memory)]
     #[test]
     fn do_swap_writes_exec_handover_status_when_handover_skipped() {
         // Force the handover to be skipped so the test can observe state_dir.

--- a/src/safe_update/tests_orchestrator.rs
+++ b/src/safe_update/tests_orchestrator.rs
@@ -32,6 +32,7 @@ fn write_bin(dir: &Path, name: &str, body: &[u8]) -> PathBuf {
     p
 }
 
+#[serial_test::serial(cognitive_memory)]
 #[test]
 fn happy_path_drain_snapshot_pretest_swap_validate() {
     // Force handover to be skipped so we observe the swap + validate phases
@@ -107,6 +108,7 @@ fn happy_path_drain_snapshot_pretest_swap_validate() {
     }
 }
 
+#[serial_test::serial(cognitive_memory)]
 #[test]
 fn negative_pretest_failure_aborts_before_swap() {
     unsafe {
@@ -153,6 +155,7 @@ fn negative_pretest_failure_aborts_before_swap() {
     }
 }
 
+#[serial_test::serial(cognitive_memory)]
 #[test]
 fn negative_validate_timeout_then_rollback_restores_backup() {
     unsafe {

--- a/src/self_improve_executor/tests.rs
+++ b/src/self_improve_executor/tests.rs
@@ -180,6 +180,7 @@ fn run_autonomous_improvement_empty_proposals() {
     assert!(results.is_empty());
 }
 
+#[serial_test::serial(cognitive_memory)]
 #[test]
 fn run_autonomous_improvement_planning_unavailable() {
     unsafe { std::env::remove_var("ANTHROPIC_API_KEY") };
@@ -200,6 +201,7 @@ fn run_autonomous_improvement_planning_unavailable() {
     }
 }
 
+#[serial_test::serial(cognitive_memory)]
 #[test]
 fn run_autonomous_improvement_continues_on_non_critical_plan_failure() {
     unsafe { std::env::remove_var("ANTHROPIC_API_KEY") };
@@ -321,6 +323,7 @@ fn approval_policy_display_auto() {
     assert_eq!(p.to_string(), "auto-approve (justification: sandbox test)");
 }
 
+#[serial_test::serial(cognitive_memory)]
 #[test]
 fn auto_approve_policy_allows_execution() {
     // When auto-approve is set, proposals should NOT get ApprovalRequired.

--- a/src/stewardship/merge_authority.rs
+++ b/src/stewardship/merge_authority.rs
@@ -1062,6 +1062,7 @@ mod tests {
         LOCK.get_or_init(|| Mutex::new(()))
     }
 
+    #[serial_test::serial(cognitive_memory)]
     #[test]
     fn base_allowlist_from_env_default_is_main() {
         let _g = env_lock().lock().unwrap();
@@ -1073,6 +1074,7 @@ mod tests {
         assert_eq!(list, vec!["main".to_string()]);
     }
 
+    #[serial_test::serial(cognitive_memory)]
     #[test]
     fn base_allowlist_from_env_splits_and_trims() {
         let _g = env_lock().lock().unwrap();
@@ -1093,6 +1095,7 @@ mod tests {
         );
     }
 
+    #[serial_test::serial(cognitive_memory)]
     #[test]
     fn base_allowlist_from_env_empty_string_falls_back_to_default() {
         let _g = env_lock().lock().unwrap();

--- a/src/terminal_session/session.rs
+++ b/src/terminal_session/session.rs
@@ -697,6 +697,7 @@ mod tests {
         assert!(!path.exists(), "default Drop must delete the transcript");
     }
 
+    #[serial_test::serial(cognitive_memory)]
     #[test]
     fn env_secs_returns_default_when_unset() {
         // Use a uniquely named env var so we know it's unset.
@@ -706,6 +707,7 @@ mod tests {
         assert_eq!(env_secs(&var, 42), 42);
     }
 
+    #[serial_test::serial(cognitive_memory)]
     #[test]
     fn env_secs_returns_parsed_value_when_set() {
         let var = format!("SIMARD_ENV_SECS_TEST_{}", uuid::Uuid::now_v7().simple());
@@ -714,6 +716,7 @@ mod tests {
         unsafe { std::env::remove_var(&var) };
     }
 
+    #[serial_test::serial(cognitive_memory)]
     #[test]
     fn env_secs_returns_default_when_unparseable() {
         let var = format!("SIMARD_ENV_SECS_TEST_{}", uuid::Uuid::now_v7().simple());

--- a/src/test_support/serial_guard.rs
+++ b/src/test_support/serial_guard.rs
@@ -10,10 +10,14 @@
 //! `operator_commands_dashboard::tests_goals_crud::full_goal_lifecycle_crud`.
 //!
 //! The fix is a single rule (the "Annotation Decision Rule"): every lib-binary
-//! test that mutates or reads the cognitive-memory state-root environment, or
-//! opens cognitive memory at the env-derived default path, MUST carry the
-//! `cognitive_memory` serial key so env mutation is never concurrent with an
-//! env read.
+//! test that mutates *any* process-global environment variable, or reads the
+//! cognitive-memory state-root environment / opens cognitive memory at the
+//! env-derived default path, MUST carry the `cognitive_memory` serial key so an
+//! env mutation is never concurrent with an env read. Enforcement was widened
+//! from the state-root surface to every variable in issue
+//! [#2375](https://github.com/rysweet/Simard/issues/2375): a `setenv` on *any*
+//! name can `realloc(environ)` and free the array a concurrent `getenv` is
+//! mid-read, so the writer and reader need not touch the same variable to race.
 //!
 //! This module parses the source tree with `syn` (AST-based, robust to
 //! multi-line attributes, ordering, raw strings, and `#[cfg]` gating) and fails
@@ -92,7 +96,8 @@ const ENV_READING_HANDLERS: &[&str] = &[
 /// Which env-var mutations trip the rule.
 #[derive(Debug, Clone)]
 pub(crate) enum EnvWatch {
-    /// The shipped default: the cognitive-memory state-root resolution surface
+    /// The legacy narrower policy (the default before #2375): the
+    /// cognitive-memory state-root resolution surface
     /// — the variables `resolve_state_root()` / `socket_path_for` consult
     /// (`SIMARD_STATE_ROOT`, `SIMARD_MEMORY_SOCKET`, and the `HOME` fallback),
     /// plus `SIMARD_LLM_PROVIDER` (the dashboard agent-session / provider
@@ -111,9 +116,11 @@ pub(crate) enum EnvWatch {
     StateRootSurface,
     /// Watch a specific set of variable names.
     Vars(BTreeSet<String>),
-    /// Fully var-agnostic: any process-global mutation trips the rule. NOT the
-    /// default — enabling it requires migrating the broader env-mutating test
-    /// surface first (tracked follow-up; see the design doc).
+    /// Fully var-agnostic: any process-global mutation trips the rule. This is
+    /// the shipped default since issue #2375 — a `setenv` on any name may
+    /// `realloc`/free the whole `environ`, so every env writer must be mutually
+    /// exclusive with every cognitive-memory env reader, regardless of which
+    /// variable it touches.
     AnyVar,
 }
 
@@ -160,7 +167,7 @@ impl Default for AuditOptions {
         Self {
             roots: vec![PathBuf::from("src")],
             excluded_prefixes: vec!["src/bin".to_string()],
-            watched: EnvWatch::StateRootSurface,
+            watched: EnvWatch::AnyVar,
             allowlist: Vec::new(),
         }
     }
@@ -657,9 +664,10 @@ fn collect_rs_files(dir: &Path, out: &mut Vec<PathBuf>) {
 // The enforcement test
 // ---------------------------------------------------------------------------
 
-/// Fails the build if any hand-written lib-binary test mutates or reads the
-/// cognitive-memory state-root environment (or opens cognitive memory at the
-/// env-derived default path) without the `cognitive_memory` serial key.
+/// Fails the build if any hand-written lib-binary test mutates *any*
+/// process-global env var, or reads the cognitive-memory state-root environment
+/// (or opens cognitive memory at the env-derived default path), without the
+/// `cognitive_memory` serial key.
 ///
 /// This meta-test reads source files only; it touches no env and no cognitive
 /// memory, so it intentionally carries NO serial key.
@@ -672,8 +680,8 @@ fn every_env_mutating_test_is_serialized() {
 
     let mut report = String::new();
     report.push_str(&format!(
-        "serial-guard: {} test(s) mutate or read the cognitive-memory state-root \
-env without the `{REQUIRED_KEY}` serial key.\n\
+        "serial-guard: {} test(s) mutate a process-global env var (or read the \
+cognitive-memory state-root env) without the `{REQUIRED_KEY}` serial key.\n\
 Every such test in the lib binary must share that key so env mutation is never \
 concurrent with an env read.\n\
 See docs/testing/cognitive-memory-serial-isolation.md.\n\n",
@@ -692,4 +700,80 @@ See docs/testing/cognitive-memory-serial-isolation.md.\n\n",
         ));
     }
     panic!("{report}");
+}
+
+/// Regression guard for issue
+/// [#2375](https://github.com/rysweet/Simard/issues/2375): the production audit
+/// must treat *every* process-global env mutation as a race against the
+/// cognitive-memory state-root reader (`EnvWatch::AnyVar`), not only the
+/// state-root surface — a `setenv` on any variable can `realloc`/free the whole
+/// `environ` array while a concurrent `getenv` of `SIMARD_STATE_ROOT`/`HOME` is
+/// mid-read. This pins the shipped default and proves an unrelated env writer in
+/// another concurrent test "session" is isolated from the cognitive-memory
+/// readers only when it shares the `cognitive_memory` serial key.
+///
+/// Reads in-memory source fixtures only; it mutates no env, so it carries no
+/// serial key (and the meta-test above does not flag it).
+#[test]
+fn anyvar_default_isolates_every_env_writer_across_sessions() {
+    // The shipped production policy must stay var-agnostic, so no future edit
+    // can silently narrow it back to the state-root surface.
+    assert!(
+        matches!(AuditOptions::default().watched, EnvWatch::AnyVar),
+        "production guard must watch AnyVar so no env writer can race a \
+         cognitive-memory state-root read"
+    );
+
+    // Two fixtures model a second concurrent session that mutates an *unrelated*
+    // (non-state-root) variable: one missing the key, one carrying it.
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("fixture.rs"),
+        "#[test]\n\
+         #[serial]\n\
+         fn unrelated_writer_without_key() {\n\
+         unsafe { std::env::set_var(\"SOME_UNRELATED_VAR\", \"x\"); }\n\
+         }\n\
+         #[test]\n\
+         #[serial_test::serial(cognitive_memory)]\n\
+         fn unrelated_writer_with_key() {\n\
+         unsafe { std::env::set_var(\"SOME_UNRELATED_VAR\", \"x\"); }\n\
+         }\n",
+    )
+    .unwrap();
+
+    let opts = AuditOptions {
+        roots: vec![dir.path().to_path_buf()],
+        excluded_prefixes: Vec::new(),
+        watched: EnvWatch::AnyVar,
+        allowlist: Vec::new(),
+    };
+    let flagged: BTreeSet<String> = audit_env_mutating_tests(&opts)
+        .into_iter()
+        .map(|o| o.test_name)
+        .collect();
+    assert!(
+        flagged.contains("unrelated_writer_without_key"),
+        "AnyVar must flag an unrelated env writer lacking the key: {flagged:?}"
+    );
+    assert!(
+        !flagged.contains("unrelated_writer_with_key"),
+        "a writer sharing the cognitive_memory key must be accepted: {flagged:?}"
+    );
+
+    // Sanity: under the pre-#2375 state-root-only policy the same unrelated
+    // writer slipped through — this is precisely the residual class #2375 closes.
+    let legacy = AuditOptions {
+        watched: EnvWatch::StateRootSurface,
+        ..opts.clone()
+    };
+    let legacy_flagged: BTreeSet<String> = audit_env_mutating_tests(&legacy)
+        .into_iter()
+        .map(|o| o.test_name)
+        .collect();
+    assert!(
+        !legacy_flagged.contains("unrelated_writer_without_key"),
+        "pre-#2375 StateRootSurface policy must ignore unrelated vars: \
+         {legacy_flagged:?}"
+    );
 }

--- a/src/update_check.rs
+++ b/src/update_check.rs
@@ -342,7 +342,7 @@ mod tests {
     // thread-safe, so a concurrent mutate/read tears (e.g. this `is_none()`
     // assertion observing the var removed by `..._returns_some_when_enabled`).
     // All tests touching the var share the `update_check_env` key.
-    #[serial_test::serial(update_check_env)]
+    #[serial_test::serial(update_check_env, cognitive_memory)]
     fn run_update_check_background_returns_receiver() {
         // With check disabled, returns None
         unsafe { std::env::set_var("SIMARD_NO_UPDATE_CHECK", "1") };
@@ -353,7 +353,7 @@ mod tests {
     // ── F1: fire-and-forget (no join) ──────────────────────────────
 
     #[test]
-    #[serial_test::serial(update_check_env)]
+    #[serial_test::serial(update_check_env, cognitive_memory)]
     fn run_update_check_returns_immediately_when_disabled() {
         unsafe { std::env::set_var("SIMARD_NO_UPDATE_CHECK", "1") };
         let start = std::time::Instant::now();
@@ -384,7 +384,7 @@ mod tests {
     // ── F2: background channel returns Some when enabled ───────────
 
     #[test]
-    #[serial_test::serial(update_check_env)]
+    #[serial_test::serial(update_check_env, cognitive_memory)]
     fn run_update_check_background_returns_some_when_enabled() {
         unsafe { std::env::remove_var("SIMARD_NO_UPDATE_CHECK") };
         let rx = run_update_check_background();

--- a/tests/qa-scenarios/cognitive-memory-serial-isolation-anyvar.yaml
+++ b/tests/qa-scenarios/cognitive-memory-serial-isolation-anyvar.yaml
@@ -1,0 +1,49 @@
+name: cognitive-memory-serial-isolation-anyvar
+app_type: cli
+description: |
+  Verify the process-wide `serial(cognitive_memory)` env-race guard introduced by
+  issue #2375. The guard's production watch was widened from
+  `EnvWatch::StateRootSurface` to `EnvWatch::AnyVar`, so EVERY lib-binary test
+  that mutates ANY process-global env var must share the `cognitive_memory`
+  serial key — otherwise a `setenv` that `realloc`/frees `environ` can tear a
+  concurrent `getenv` of the cognitive-memory state root in another test. This
+  scenario drives the two hermetic meta-tests that enforce and prove the
+  invariant; both run source-only (they mutate no real env) so they are safe on
+  the live host.
+agents:
+  - name: simard-cli
+    type: cli
+    command: cargo
+steps:
+  # Green-after: with AnyVar the default and all 84 env mutators multi-keyed into
+  # `cognitive_memory`, the serial-guard meta-test must report zero offenders.
+  # First invocation may compile the test binary; the second filter reuses it.
+  - action: run
+    params:
+      command: "cargo test --locked --lib test_support::serial_guard::every_env_mutating_test_is_serialized"
+    timeout: 600000
+  - action: wait_for_output
+    params:
+      value: "test result: ok"
+    timeout: 8000
+  - action: validate_exit_code
+    params:
+      value: "0"
+    timeout: 5000
+
+  # Regression proof: the AnyVar default is pinned, and an unrelated-variable
+  # env writer is isolated from the cognitive-memory readers ONLY when it carries
+  # the `cognitive_memory` key (and the pre-#2375 StateRootSurface policy ignored
+  # it). Guards against a silent narrowing back to the state-root surface.
+  - action: run
+    params:
+      command: "cargo test --locked --lib test_support::serial_guard::anyvar_default_isolates_every_env_writer_across_sessions"
+    timeout: 300000
+  - action: wait_for_output
+    params:
+      value: "test result: ok"
+    timeout: 8000
+  - action: validate_exit_code
+    params:
+      value: "0"
+    timeout: 5000


### PR DESCRIPTION
## Problem

`serial_guard` (the `cargo test --lib` env-race meta-test) enforced the
`cognitive_memory` serial key only for the **state-root surface**
(`EnvWatch::StateRootSurface`: `SIMARD_STATE_ROOT`, `SIMARD_MEMORY_SOCKET`,
`HOME`, `SIMARD_LLM_PROVIDER`, `SIMARD_MEETINGS_*`, `SIMARD_HANDOFF_DIR`). But the
hazard is **variable-agnostic**: glibc `setenv` may `realloc`/free the whole
`environ` array when a *new* variable is first added, so a concurrent `getenv` of
the cognitive-memory state root can read freed memory **even when the writer
touches a different variable**. Lib-binary tests mutating other vars
(`SIMARD_SKIP_GYM`, `NO_COLOR`, `ENV_OVERRIDE`, `ENV_LLM_PROVIDER`,
`ANTHROPIC_API_KEY`, `SIMARD_DASHBOARD_PORT`, `SIMARD_SCALING`, …) under bare
`#[serial]`, other named keys, or module-local `ENV_LOCK` mutexes could still run
concurrently with the cognitive-memory readers — the residual class tracked by
**#2375**.

## Fix

- **Switch the production audit default** from `EnvWatch::StateRootSurface` to
  **`EnvWatch::AnyVar`** (`AuditOptions::default().watched`). The guard now flags
  any `set_var`/`remove_var` in a lib-binary test that lacks the
  `cognitive_memory` key.
- **Multi-key the 84 remaining env-mutating tests** across 24 modules into
  `cognitive_memory` — *adding* the key alongside any existing semantic group
  (e.g. `serial(prompt_delivery_env, cognitive_memory)`), **never removing** the
  original key. 51 tests that had no prior serial key (incl. those relying on a
  module-local `ENV_LOCK` mutex) gain `#[serial_test::serial(cognitive_memory)]`.
- **Regression test** `anyvar_default_isolates_every_env_writer_across_sessions`:
  pins the `AnyVar` default (so it cannot be silently narrowed back) and proves
  an unrelated-variable env writer is isolated from the cognitive-memory readers
  **only** when it carries the key (and that the pre-#2375 `StateRootSurface`
  policy ignored it).

## Evidence

Local builds use an isolated `CARGO_TARGET_DIR` (the host's `~/.cargo-targets`
LRU cap process reclaims idle target dirs mid-build).

### 1. qa-team scenarios (criterion 1)
- `tests/qa-scenarios/cognitive-memory-serial-isolation-anyvar.yaml` drives the
  two hermetic meta-tests.
- `gadugi-test validate -f … --strict` → **valid (1/1)**.
- `gadugi-test run` → **PASS (1/1)** (`✓ Passed: 1 / ✗ Failed: 0`); both
  `test_support::serial_guard::*` tests report `test result: ok`.

### 2. Docs (criterion 2)
- `docs/testing/cognitive-memory-serial-isolation.md`: "Residual class &
  follow-up" → **"Process-wide enforcement (`EnvWatch::AnyVar`) — closed by
  #2375"**; TL;DR, Annotation Decision Rule, and `AuditOptions` reference updated
  to the `AnyVar` default.
- `mkdocs build --strict` → **exit 0**.

### 3. quality-audit (criterion 3) — 4 cycles, final clean (commit `7c8b9d72`)

- **Cycle 1 — scope & duplicate-attribute scan.** Confirmed the commit touches
  exactly 27 files (24 modules + `serial_guard.rs` + doc + QA scenario); no
  duplicate `#[serial…]` attributes introduced; every `+` line outside
  `serial_guard.rs` is a serial-attribute add/edit. _Clean._
- **Cycle 2 — transform correctness.** Verified multi-key transforms append
  `cognitive_memory` without dropping any existing semantic key
  (`disk_pressure`, `prompt_delivery`, `update_check`, `engineer_loop/agent_spawn`);
  the 51 no-key insertions are placed above `#[test]` on the correct fn.
  Validated by guard **red-before (84 offenders) → green-after**. _Clean._
- **Cycle 3 — regression / deadlock / behavior.** `serial_test` v3.4.0 sorts
  keys before locking (no lock-order inversion → no deadlock); module-local
  `ENV_LOCK` mutexes are acquired inside the body, after the macro's serial lock
  (consistent global order); full suite **5778 passed / 0 failed** in 113 s
  (empirically no hang, no behavior break). _Clean._
- **Cycle 4 — independent `code-review` agent (built + ran the meta-tests).**
  Verdict: *"The change is sound. No significant issues found."* It refuted the
  deadlock risk with the `serial_test_derive` source (`raw_args.sort()`),
  confirmed no semantic key was dropped, the 51 insertions are correct with no
  duplicate attributes, the regression test is deterministic, no scope creep, and
  specifically cleared the one decoupling conversion
  (`engineer_worktree/tests_extra.rs`: `GIT_DIR` test) as safe. _Clean (final)._

Zero critical/high; zero medium correctness/security findings.

### 4. CI (criterion 4) — green on the rebased head
**Rebased onto `main`** so it inherits the two fixes that previously kept this
PR red:
- **#2391** — `quinn-proto 0.11.15` lock bump resolving **RUSTSEC-2026-0185**.
  `cargo-audit` is now **green** on this branch (it was a repo-wide advisory, not
  introduced by this diff — `Cargo.toml`/`Cargo.lock` are untouched here).
- **#2389** — removal of the orphan dead-duplicate `src/meeting_repl/colors.rs`.
  This PR's serial-attribute edits to that file are now superseded by the
  upstream deletion (the equivalent `NO_COLOR` tests live in `color.rs`, which
  retains the `cognitive_memory` key), so they were dropped during the rebase.

Full `verify` suite on the rebased head (`751c9b29`): `build`, `cargo-audit`,
`pre-commit`, `coverage`, `e2e-dashboard`, and `install-real` all **pass** —
0 failures. (The earlier `install-real` red on the pre-rebase head was a runner
**"No space left on device"** infra flake, cleared on a fresh runner.)

Local gates also green: `cargo fmt --all --check`; `cargo clippy --all-targets
--all-features --locked -- -D warnings`; `cargo test --lib --locked` ->
**5778 passed; 0 failed; 4 ignored** (113 s). serial-guard **red-before**
(84 offenders/24 files under `AnyVar`) -> **green-after**.

### 6. Focused diff (criterion 6)
26 files, **+308 / −122** (post-rebase; the now-upstream-deleted
`meeting_repl/colors.rs` edit was dropped). The 23 remaining source modules carry
**serial-attribute additions only** (verified: every `+` line outside
`serial_guard.rs` is a `#[serial…]` attribute). The guard flip, the regression
test, the runbook doc, and the QA scenario are the only other edits. No
production behavior change.

---

Closes #2375. Follow-up candidate (explicitly **out of scope** this PR): **#2383**
(RustyClawd memory+knowledge bridges inert in production).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

