### PR TITLE
fix(terminal): make engineer terminal 127 failures actionable instead of bare exit codes (#2077)

### DIFF
--- a/docs/reference/base-type-adapters.md
+++ b/docs/reference/base-type-adapters.md
@@ -106,7 +106,7 @@ A PTY-backed shell adapter that runs a configurable local command through the te
 > *literal shell commands* rather than natural-language LLM prompts, it does
 > not fold memory/knowledge markdown into its command stream.
 
-**Failure diagnostics:** when the PTY shell exits non-zero, the adapter returns an actionable error rather than a bare status. Exit code `127` is reported as a command that could not be resolved on `PATH` (use an absolute path or install the command), `126` as a found-but-not-executable command, and the shell's own diagnostic line (e.g. `bash: say: command not found`) is included so the offending command is named. The child PTY is launched with a usable `PATH` (falling back to the standard system bin directories when the inherited environment has none).
+**Failure diagnostics:** when the PTY shell exits non-zero — or a `wait-for` checkpoint fails because the command was missing — the adapter returns an actionable error rather than a bare status. Exit code `127` is reported as a command that could not be resolved on `PATH` (use an absolute path or install the command), `126` as a found-but-not-executable command, and the shell's own diagnostic line (e.g. `bash: say: command not found`) is included so the offending command is named. The child PTY is launched with a usable `PATH` (falling back to the standard system bin directories when the inherited environment has none).
 
 ### `rusty-clawd` — `RustyClawdAdapter`
 

--- a/docs/reference/base-type-adapters.md
+++ b/docs/reference/base-type-adapters.md
@@ -97,7 +97,7 @@ A PTY-backed shell adapter that runs a configurable local command through the te
 
 **Configuration** (`HarnessConfig`):
 - `command` — shell command to run for each turn (optional; if absent, objective text passes directly to terminal session)
-- `shell` — shell override (default: `/usr/bin/bash`)
+- `shell` — shell override (default: `/usr/bin/bash`, falling back to `$SHELL`/`/bin/bash`/`/bin/sh` when that path is absent)
 - `working_directory` — working directory for command execution
 
 > **Enrichment note (#1665):** The harness exposes the normalized
@@ -105,6 +105,8 @@ A PTY-backed shell adapter that runs a configurable local command through the te
 > so it participates in the shared enrichment contract. Because it executes
 > *literal shell commands* rather than natural-language LLM prompts, it does
 > not fold memory/knowledge markdown into its command stream.
+
+**Failure diagnostics:** when the PTY shell exits non-zero, the adapter returns an actionable error rather than a bare status. Exit code `127` is reported as a command that could not be resolved on `PATH` (use an absolute path or install the command), `126` as a found-but-not-executable command, and the shell's own diagnostic line (e.g. `bash: say: command not found`) is included so the offending command is named. The child PTY is launched with a usable `PATH` (falling back to the standard system bin directories when the inherited environment has none).
 
 ### `rusty-clawd` — `RustyClawdAdapter`
 

--- a/docs/reference/simard-cli.md
+++ b/docs/reference/simard-cli.md
@@ -561,6 +561,8 @@ Key behavior:
 - persists `latest_terminal_handoff.json` and compatibility `latest_handoff.json` under the shared root
 - fails visibly for unsupported topology and invalid state-root inputs
 - fails explicitly if a requested wait checkpoint never appears instead of pretending the terminal interaction succeeded
+- when the underlying shell exits non-zero, reports an actionable error instead of a bare status code: exit `127` is explained as a command that could not be found on `PATH` (and `126` as a found-but-not-executable command), and the shell's own diagnostic line (for example `bash: say: command not found`) is surfaced so the offending command is named
+- launches the child PTY with a usable `PATH` (falling back to the standard system bin directories when the inherited environment has none) and resolves the default shell against `$SHELL`/`/bin/bash`/`/bin/sh` when the platform default is absent, so ordinary commands do not silently fail with exit `127`
 - keeps `simard_operator_probe terminal-run ...` available for compatibility
 
 Example:

--- a/docs/reference/simard-cli.md
+++ b/docs/reference/simard-cli.md
@@ -560,7 +560,7 @@ Key behavior:
 - prints explicit next-step guidance for continuing into `engineer run` with the same `state-root`
 - persists `latest_terminal_handoff.json` and compatibility `latest_handoff.json` under the shared root
 - fails visibly for unsupported topology and invalid state-root inputs
-- fails explicitly if a requested wait checkpoint never appears instead of pretending the terminal interaction succeeded
+- fails explicitly if a requested wait checkpoint never appears instead of pretending the terminal interaction succeeded; when that failure is caused by a missing or non-executable command, the shell's own diagnostic (for example `command not found`) is surfaced in the error so the offending command is named
 - when the underlying shell exits non-zero, reports an actionable error instead of a bare status code: exit `127` is explained as a command that could not be found on `PATH` (and `126` as a found-but-not-executable command), and the shell's own diagnostic line (for example `bash: say: command not found`) is surfaced so the offending command is named
 - launches the child PTY with a usable `PATH` (falling back to the standard system bin directories when the inherited environment has none) and resolves the default shell against `$SHELL`/`/bin/bash`/`/bin/sh` when the platform default is absent, so ordinary commands do not silently fail with exit `127`
 - keeps `simard_operator_probe terminal-run ...` available for compatibility

--- a/src/terminal_session/evidence.rs
+++ b/src/terminal_session/evidence.rs
@@ -47,6 +47,29 @@ pub(crate) fn terminal_checkpoint_evidence(steps: &[TerminalStep]) -> Vec<String
         .collect()
 }
 
+/// Extract a human-meaningful failure hint from a terminal transcript, such as
+/// a shell "command not found" or "Permission denied" diagnostic. Returns the
+/// most recent matching line (sanitised and compacted) so an operator sees
+/// *why* a session failed instead of only a bare exit code. Returns `None` when
+/// no recognised failure marker is present.
+pub(crate) fn terminal_failure_hint(transcript: &str) -> Option<String> {
+    const MARKERS: &[&str] = &[
+        "command not found",
+        ": not found",
+        "permission denied",
+        "no such file or directory",
+    ];
+    transcript_content_lines(transcript)
+        .into_iter()
+        .rev()
+        .map(sanitize_terminal_text)
+        .find(|line| {
+            let lowered = line.to_ascii_lowercase();
+            MARKERS.iter().any(|marker| lowered.contains(marker))
+        })
+        .map(|line| compact_terminal_evidence_value(&line, 200))
+}
+
 pub(crate) fn terminal_last_output_line(
     transcript: &str,
     steps: &[TerminalStep],
@@ -177,6 +200,50 @@ mod tests {
     fn compact_terminal_evidence_value_replaces_newlines_and_truncates() {
         let raw = "line1\nline2\tline3";
         assert_eq!(compact_terminal_evidence_value(raw, 12), "line1\\nline2...");
+    }
+
+    // -- terminal_failure_hint (regression for #2077) --
+
+    #[test]
+    fn terminal_failure_hint_extracts_bash_command_not_found() {
+        let transcript = "Script started on 2026-06-22\nbash-5.2$ say hello\nbash: say: command not found\nbash-5.2$ exit\nScript done on 2026-06-22";
+        assert_eq!(
+            terminal_failure_hint(transcript).as_deref(),
+            Some("bash: say: command not found")
+        );
+    }
+
+    #[test]
+    fn terminal_failure_hint_extracts_posix_sh_not_found() {
+        let transcript = "sh: 1: say: not found";
+        assert_eq!(
+            terminal_failure_hint(transcript).as_deref(),
+            Some("sh: 1: say: not found")
+        );
+    }
+
+    #[test]
+    fn terminal_failure_hint_extracts_permission_denied() {
+        let transcript = "bash: ./blocked.sh: Permission denied";
+        assert_eq!(
+            terminal_failure_hint(transcript).as_deref(),
+            Some("bash: ./blocked.sh: Permission denied")
+        );
+    }
+
+    #[test]
+    fn terminal_failure_hint_returns_none_for_clean_transcript() {
+        let transcript = "bash-5.2$ echo hello\nhello\nbash-5.2$ exit";
+        assert_eq!(terminal_failure_hint(transcript), None);
+    }
+
+    #[test]
+    fn terminal_failure_hint_returns_most_recent_marker_line() {
+        let transcript = "bash: first: command not found\nbash-5.2$ echo ok\nok\nbash: second: command not found";
+        assert_eq!(
+            terminal_failure_hint(transcript).as_deref(),
+            Some("bash: second: command not found")
+        );
     }
 
     // ---------------------------------------------------------------------

--- a/src/terminal_session/execution.rs
+++ b/src/terminal_session/execution.rs
@@ -260,6 +260,51 @@ mod tests {
         );
     }
 
+    /// An *external* binary (not a shell builtin) must resolve through the child
+    /// PTY's inherited PATH, exercising the PATH handling rather than relying on
+    /// a builtin like `echo`. `uname` lives on PATH on every supported target.
+    #[test]
+    fn run_terminal_script_resolves_external_binary_on_path() {
+        let spec = TerminalTurnSpec::parse("uname -s", "terminal-shell").unwrap();
+        let cwd = std::env::current_dir().unwrap();
+
+        let transcript = run_terminal_script("terminal-shell", &spec, &cwd)
+            .expect("an external PATH-resolved binary should complete the terminal turn");
+        let expected_os = if cfg!(target_os = "macos") {
+            "Darwin"
+        } else {
+            "Linux"
+        };
+        assert!(
+            transcript.contains(expected_os),
+            "transcript should contain `uname -s` output '{expected_os}': {transcript}"
+        );
+    }
+
+    /// A non-bash interpreter (`/bin/sh`) must launch successfully. The launch
+    /// path passes bash-specific `--noprofile --norc` only to bash; POSIX sh
+    /// gets a bare `-i`, so falling back to `/bin/sh` no longer aborts with the
+    /// very exit code this fix targets. Guards against regressing the
+    /// shell-aware launch flags.
+    #[cfg(unix)]
+    #[test]
+    fn run_terminal_script_succeeds_with_posix_sh() {
+        if !std::path::Path::new("/bin/sh").exists() {
+            return;
+        }
+        let spec =
+            TerminalTurnSpec::parse("shell: /bin/sh\necho sh-2077-ok", "terminal-shell").unwrap();
+        assert_eq!(spec.shell, "/bin/sh");
+        let cwd = std::env::current_dir().unwrap();
+
+        let transcript = run_terminal_script("terminal-shell", &spec, &cwd)
+            .expect("POSIX /bin/sh must launch and complete the terminal turn");
+        assert!(
+            transcript.contains("sh-2077-ok"),
+            "transcript should contain the echoed output: {transcript}"
+        );
+    }
+
     // -- describe_terminal_failure --
 
     fn exit_status_with_code(code: i32) -> ExitStatus {

--- a/src/terminal_session/execution.rs
+++ b/src/terminal_session/execution.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::process::ExitStatus;
 
 use crate::base_types::{
     BaseTypeDescriptor, BaseTypeOutcome, BaseTypeSessionRequest, BaseTypeTurnInput,
@@ -7,8 +8,8 @@ use crate::error::{SimardError, SimardResult};
 use crate::sanitization::objective_metadata;
 
 use super::evidence::{
-    terminal_checkpoint_evidence, terminal_last_output_line, terminal_step_evidence,
-    transcript_preview,
+    terminal_checkpoint_evidence, terminal_failure_hint, terminal_last_output_line,
+    terminal_step_evidence, transcript_preview,
 };
 use super::session::PtyTerminalSession;
 use super::types::{TerminalStep, TerminalTurnSpec, TerminalWaitStatus};
@@ -123,14 +124,47 @@ fn run_terminal_script(
     if !capture.exit_status.success() {
         return Err(SimardError::AdapterInvocationFailed {
             base_type: base_type.to_string(),
-            reason: format!(
-                "terminal-shell session exited with status {}",
-                capture.exit_status
+            reason: describe_terminal_failure(
+                &capture.exit_status,
+                &capture.transcript,
+                &spec.steps,
             ),
         });
     }
 
     Ok(capture.transcript)
+}
+
+/// Build an actionable failure message for a non-zero terminal-shell exit.
+///
+/// A bare `exit status: 127` tells an operator nothing. This explains what the
+/// well-known shell exit codes mean (127 = command not found, 126 = not
+/// executable) and surfaces the shell's own diagnostic line (e.g.
+/// `bash: say: command not found`) — or the last terminal output — so the
+/// failure can be diagnosed without re-running the session.
+fn describe_terminal_failure(
+    exit_status: &ExitStatus,
+    transcript: &str,
+    steps: &[TerminalStep],
+) -> String {
+    let mut reason = format!("terminal-shell session exited with status {exit_status}");
+    match exit_status.code() {
+        Some(127) => reason.push_str(
+            " — exit code 127 means a command in the terminal session could not be found on PATH; \
+             verify the command is installed and on PATH, or invoke it with an absolute path",
+        ),
+        Some(126) => reason.push_str(
+            " — exit code 126 means a command was found but is not executable; \
+             check the file permissions",
+        ),
+        _ => {}
+    }
+    if let Some(hint) = terminal_failure_hint(transcript) {
+        reason.push_str(&format!(" (shell reported: {hint})"));
+    } else if let Some(last) = terminal_last_output_line(transcript, steps) {
+        reason.push_str(&format!(" (last terminal output: {last})"));
+    }
+    reason
 }
 
 pub(crate) fn resolve_working_directory(
@@ -166,7 +200,116 @@ pub(crate) fn resolve_working_directory(
 
 #[cfg(test)]
 mod tests {
+    use super::super::types::TerminalTurnSpec;
     use super::*;
+
+    // -- run_terminal_script: failure diagnostics (regression for #2077) --
+
+    /// Regression for #2077: `engineer terminal "say hello"` exited 127 with a
+    /// bare `terminal-shell session exited with status exit status: 127` that
+    /// gave the operator no clue what failed. A missing-binary turn must now
+    /// surface an actionable message: the 127 meaning *and* the shell's own
+    /// "command not found" diagnostic naming the offending command.
+    #[test]
+    fn run_terminal_script_surfaces_command_not_found_for_missing_binary() {
+        let spec =
+            TerminalTurnSpec::parse("definitely-not-a-real-binary-2077 hello", "terminal-shell")
+                .unwrap();
+        let cwd = std::env::current_dir().unwrap();
+
+        let error = run_terminal_script("terminal-shell", &spec, &cwd)
+            .expect_err("a missing binary must fail the terminal turn");
+        let message = error.to_string();
+
+        assert!(
+            message.contains("127"),
+            "error must report the exit code: {message}"
+        );
+        assert!(
+            message.contains("could not be found on PATH"),
+            "error must explain exit code 127: {message}"
+        );
+        assert!(
+            message.to_ascii_lowercase().contains("command not found")
+                || message.to_ascii_lowercase().contains("not found"),
+            "error must surface the shell diagnostic: {message}"
+        );
+        assert!(
+            message.contains("definitely-not-a-real-binary-2077"),
+            "error must name the offending command: {message}"
+        );
+        assert!(
+            !message.ends_with("exit status: 127"),
+            "error must not be the bare opaque 127 message: {message}"
+        );
+    }
+
+    /// The success path must remain intact: a valid command resolves on PATH
+    /// and completes the terminal turn, returning its transcript.
+    #[test]
+    fn run_terminal_script_succeeds_for_valid_command() {
+        let spec =
+            TerminalTurnSpec::parse("echo simard-terminal-2077-ok", "terminal-shell").unwrap();
+        let cwd = std::env::current_dir().unwrap();
+
+        let transcript = run_terminal_script("terminal-shell", &spec, &cwd)
+            .expect("a valid command should complete the terminal turn");
+        assert!(
+            transcript.contains("simard-terminal-2077-ok"),
+            "transcript should contain the echoed output: {transcript}"
+        );
+    }
+
+    // -- describe_terminal_failure --
+
+    fn exit_status_with_code(code: i32) -> ExitStatus {
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::ExitStatusExt;
+            // Encode the code into the wait-status byte (code << 8).
+            ExitStatus::from_raw(code << 8)
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = code;
+            unimplemented!("exit_status_with_code is only used on unix test targets");
+        }
+    }
+
+    #[test]
+    fn describe_terminal_failure_explains_127_with_shell_hint() {
+        let transcript = "bash-5.2$ say hello\nbash: say: command not found\nbash-5.2$ exit";
+        let steps = vec![TerminalStep::Input("say hello".to_string())];
+
+        let reason = describe_terminal_failure(&exit_status_with_code(127), transcript, &steps);
+
+        assert!(reason.contains("status"), "{reason}");
+        assert!(reason.contains("could not be found on PATH"), "{reason}");
+        assert!(reason.contains("bash: say: command not found"), "{reason}");
+    }
+
+    #[test]
+    fn describe_terminal_failure_explains_126_not_executable() {
+        let transcript = "bash: ./blocked.sh: Permission denied";
+        let reason = describe_terminal_failure(&exit_status_with_code(126), transcript, &[]);
+
+        assert!(reason.contains("not executable"), "{reason}");
+        assert!(
+            reason.to_ascii_lowercase().contains("permission denied"),
+            "{reason}"
+        );
+    }
+
+    #[test]
+    fn describe_terminal_failure_falls_back_to_last_output_without_marker() {
+        let transcript = "bash-5.2$ run-thing\nthing failed with code 3\nbash-5.2$ exit";
+        let steps = vec![TerminalStep::Input("run-thing".to_string())];
+
+        let reason = describe_terminal_failure(&exit_status_with_code(3), transcript, &steps);
+
+        assert!(reason.contains("last terminal output"), "{reason}");
+        assert!(reason.contains("thing failed with code 3"), "{reason}");
+    }
 
     // -- resolve_working_directory --
 

--- a/src/terminal_session/execution.rs
+++ b/src/terminal_session/execution.rs
@@ -99,19 +99,24 @@ fn run_terminal_script(
                 match session.wait_for_output(expected, spec.wait_timeout)? {
                     TerminalWaitStatus::Satisfied => {}
                     TerminalWaitStatus::ExitedEarly(status) => {
+                        let transcript = session.read_transcript().unwrap_or_default();
                         return Err(SimardError::AdapterInvocationFailed {
                             base_type: base_type.to_string(),
                             reason: format!(
-                                "terminal-shell session exited with status {status} before expected output '{expected}' appeared"
+                                "terminal-shell session exited with status {status} before expected output '{expected}' appeared{}{}",
+                                exit_code_guidance(&status),
+                                transcript_diagnostic_suffix(&transcript, &spec.steps),
                             ),
                         });
                     }
                     TerminalWaitStatus::TimedOut => {
+                        let transcript = session.read_transcript().unwrap_or_default();
                         return Err(SimardError::AdapterInvocationFailed {
                             base_type: base_type.to_string(),
                             reason: format!(
-                                "terminal-shell did not emit expected output '{expected}' within {}s",
-                                spec.wait_timeout.as_secs()
+                                "terminal-shell did not emit expected output '{expected}' within {}s{}",
+                                spec.wait_timeout.as_secs(),
+                                transcript_diagnostic_suffix(&transcript, &spec.steps),
                             ),
                         });
                     }
@@ -147,24 +152,44 @@ fn describe_terminal_failure(
     transcript: &str,
     steps: &[TerminalStep],
 ) -> String {
-    let mut reason = format!("terminal-shell session exited with status {exit_status}");
+    format!(
+        "terminal-shell session exited with status {exit_status}{}{}",
+        exit_code_guidance(exit_status),
+        transcript_diagnostic_suffix(transcript, steps),
+    )
+}
+
+/// Human-readable explanation for the well-known shell exit codes, or an empty
+/// string for codes without a canonical meaning (including signal-terminated
+/// processes, where `code()` is `None`).
+fn exit_code_guidance(exit_status: &ExitStatus) -> &'static str {
     match exit_status.code() {
-        Some(127) => reason.push_str(
+        Some(127) => {
             " — exit code 127 means a command in the terminal session could not be found on PATH; \
-             verify the command is installed and on PATH, or invoke it with an absolute path",
-        ),
-        Some(126) => reason.push_str(
+             verify the command is installed and on PATH, or invoke it with an absolute path"
+        }
+        Some(126) => {
             " — exit code 126 means a command was found but is not executable; \
-             check the file permissions",
-        ),
-        _ => {}
+             check the file permissions"
+        }
+        _ => "",
     }
+}
+
+/// Pull the most relevant diagnostic out of the transcript so terminal failures
+/// — including those surfaced while waiting for expected output — name the
+/// offending command instead of leaving the operator with a bare status or
+/// timeout. Prefers an explicit shell diagnostic (`command not found`,
+/// `permission denied`, …); otherwise falls back to the last terminal output.
+/// Returns an empty string when the transcript yields nothing useful.
+fn transcript_diagnostic_suffix(transcript: &str, steps: &[TerminalStep]) -> String {
     if let Some(hint) = terminal_failure_hint(transcript) {
-        reason.push_str(&format!(" (shell reported: {hint})"));
+        format!(" (shell reported: {hint})")
     } else if let Some(last) = terminal_last_output_line(transcript, steps) {
-        reason.push_str(&format!(" (last terminal output: {last})"));
+        format!(" (last terminal output: {last})")
+    } else {
+        String::new()
     }
-    reason
 }
 
 pub(crate) fn resolve_working_directory(
@@ -241,6 +266,38 @@ mod tests {
         assert!(
             !message.ends_with("exit status: 127"),
             "error must not be the bare opaque 127 message: {message}"
+        );
+    }
+
+    /// Regression for #2077 (wait-step path): a missing command paired with a
+    /// `wait-for` step must still surface the actionable diagnostic. Previously
+    /// this reported only a generic `did not emit expected output ... within Ns`
+    /// timeout, hiding the shell's own `command not found` line. The error must
+    /// now name the offending command and include the shell diagnostic.
+    #[test]
+    fn run_terminal_script_surfaces_diagnostic_when_wait_step_times_out() {
+        let spec = TerminalTurnSpec::parse(
+            "wait-timeout-seconds: 1\ncommand: definitely-not-a-real-binary-2077 hello\nwait-for: never-seen-marker-2077",
+            "terminal-shell",
+        )
+        .unwrap();
+        let cwd = std::env::current_dir().unwrap();
+
+        let error = run_terminal_script("terminal-shell", &spec, &cwd)
+            .expect_err("a missing binary before a wait-for must fail the terminal turn");
+        let message = error.to_string();
+
+        assert!(
+            message.to_ascii_lowercase().contains("not found"),
+            "wait-step failure must surface the shell diagnostic: {message}"
+        );
+        assert!(
+            message.contains("definitely-not-a-real-binary-2077"),
+            "wait-step failure must name the offending command: {message}"
+        );
+        assert!(
+            message.contains("shell reported:"),
+            "wait-step failure must include the transcript diagnostic suffix: {message}"
         );
     }
 

--- a/src/terminal_session/integration_tests.rs
+++ b/src/terminal_session/integration_tests.rs
@@ -5,6 +5,7 @@ mod tests {
     use std::path::PathBuf;
     use std::time::Duration;
 
+    use crate::terminal_session::parsing::default_shell;
     use crate::terminal_session::types::{TerminalStep, TerminalTurnSpec};
 
     // ── Parsing: simple recipes ──────────────────────────────────────
@@ -18,7 +19,7 @@ mod tests {
             spec.steps,
             vec![TerminalStep::Input("echo hello world".into())]
         );
-        assert_eq!(spec.shell, "/usr/bin/bash");
+        assert_eq!(spec.shell, default_shell());
         assert_eq!(spec.wait_timeout, Duration::from_secs(5));
         assert!(spec.working_directory.is_none());
     }
@@ -137,7 +138,7 @@ mod tests {
         // "shell:" with no value should not set shell; default used instead.
         let raw = "shell:\ncommand: echo ok";
         let spec = TerminalTurnSpec::parse(raw, "test").unwrap();
-        assert_eq!(spec.shell, "/usr/bin/bash");
+        assert_eq!(spec.shell, default_shell());
     }
 
     #[test]

--- a/src/terminal_session/parsing.rs
+++ b/src/terminal_session/parsing.rs
@@ -52,7 +52,7 @@ impl TerminalTurnSpec {
         }
 
         Ok(Self {
-            shell: shell.unwrap_or_else(|| DEFAULT_SHELL.to_string()),
+            shell: shell.unwrap_or_else(default_shell),
             working_directory,
             wait_timeout,
             steps,
@@ -72,6 +72,30 @@ impl TerminalTurnSpec {
             .filter(|step| matches!(step, TerminalStep::WaitFor(_)))
             .count()
     }
+}
+
+/// Resolve the shell to launch when the agent program does not specify one.
+///
+/// Prefers the platform default ([`DEFAULT_SHELL`]); when that binary is absent
+/// (e.g. a distro that ships bash at `/bin/bash`, or a minimal image with only
+/// `/bin/sh`), falls back to `$SHELL` and then well-known POSIX shells so the
+/// terminal session does not strand on a missing interpreter and surface a bare
+/// exit code 127. Each candidate is validated with [`normalize_shell`] so only
+/// a safe, absolute, executable path is ever returned.
+pub(crate) fn default_shell() -> String {
+    let mut candidates = vec![DEFAULT_SHELL.to_string()];
+    if let Ok(env_shell) = std::env::var("SHELL") {
+        candidates.push(env_shell);
+    }
+    candidates.push("/bin/bash".to_string());
+    candidates.push("/bin/sh".to_string());
+
+    for candidate in candidates {
+        if let Ok(valid) = normalize_shell(&candidate, "terminal-shell") {
+            return valid;
+        }
+    }
+    DEFAULT_SHELL.to_string()
 }
 
 pub(crate) fn parse_wait_timeout(value: &str, base_type: &str) -> SimardResult<Duration> {
@@ -327,5 +351,35 @@ mod tests {
         .expect("terminal turn should parse");
 
         assert_eq!(spec.wait_timeout, std::time::Duration::from_secs(30));
+    }
+
+    // -- default_shell (regression for #2077) --
+
+    #[test]
+    fn default_shell_returns_usable_absolute_executable() {
+        let shell = default_shell();
+        let resolved = PathBuf::from(&shell);
+        assert!(
+            resolved.is_absolute(),
+            "default shell must be absolute: {shell}"
+        );
+        assert!(
+            resolved.is_file(),
+            "default shell must resolve to an existing file: {shell}"
+        );
+        // It must round-trip through the same validation applied to
+        // operator-supplied shells, so the launch path never sees an unsafe or
+        // missing interpreter.
+        assert_eq!(
+            normalize_shell(&shell, "terminal-shell").unwrap(),
+            shell,
+            "default shell must satisfy normalize_shell"
+        );
+    }
+
+    #[test]
+    fn parse_uses_default_shell_when_unspecified() {
+        let spec = TerminalTurnSpec::parse("command: echo ok", "terminal-shell").unwrap();
+        assert_eq!(spec.shell, default_shell());
     }
 }

--- a/src/terminal_session/parsing.rs
+++ b/src/terminal_session/parsing.rs
@@ -80,8 +80,13 @@ impl TerminalTurnSpec {
 /// (e.g. a distro that ships bash at `/bin/bash`, or a minimal image with only
 /// `/bin/sh`), falls back to `$SHELL` and then well-known POSIX shells so the
 /// terminal session does not strand on a missing interpreter and surface a bare
-/// exit code 127. Each candidate is validated with [`normalize_shell`] so only
-/// a safe, absolute, executable path is ever returned.
+/// exit code 127. Each candidate is validated with [`normalize_shell`], so the
+/// first returned value is always a safe, absolute, executable path.
+///
+/// If no candidate validates (an extremely broken host with neither bash nor
+/// sh), it returns [`DEFAULT_SHELL`] unchanged as a last resort — the launch
+/// will then fail loudly with the now-actionable "command not found" diagnostic
+/// rather than silently doing nothing.
 pub(crate) fn default_shell() -> String {
     let mut candidates = vec![DEFAULT_SHELL.to_string()];
     if let Ok(env_shell) = std::env::var("SHELL") {

--- a/src/terminal_session/session.rs
+++ b/src/terminal_session/session.rs
@@ -429,10 +429,26 @@ fn interactive_shell_flags(shell: &str) -> &'static str {
         .file_name()
         .and_then(|name| name.to_str())
         .unwrap_or("");
-    if name == "bash" {
+    if is_bash_shell(name) {
         "--noprofile --norc -i"
     } else {
         "-i"
+    }
+}
+
+/// Whether `name` is the bash interpreter, tolerating versioned basenames such
+/// as `bash5` or `bash-5.2` while excluding unrelated names that merely start
+/// with "bash" (e.g. `bashful`). The `--noprofile --norc` long options are
+/// bash-only; applying them to a non-bash shell makes the interactive launch
+/// abort with the very exit code this fix is meant to eliminate.
+fn is_bash_shell(name: &str) -> bool {
+    match name.strip_prefix("bash") {
+        Some("") => true,
+        Some(rest) => rest
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_ascii_digit() || c == '-'),
+        None => false,
     }
 }
 
@@ -597,12 +613,35 @@ mod tests {
     }
 
     #[test]
+    fn interactive_shell_flags_treats_versioned_bash_as_bash() {
+        // Versioned bash basenames still honour the bash-only startup-file
+        // options, so a `$SHELL`/distro fallback to e.g. `bash5` stays
+        // deterministic rather than silently running profile/rc files.
+        assert_eq!(
+            interactive_shell_flags("/usr/local/bin/bash5"),
+            "--noprofile --norc -i"
+        );
+        assert_eq!(
+            interactive_shell_flags("/opt/homebrew/bin/bash-5.2"),
+            "--noprofile --norc -i"
+        );
+        assert!(is_bash_shell("bash"));
+        assert!(is_bash_shell("bash5"));
+        assert!(is_bash_shell("bash-5.2"));
+    }
+
+    #[test]
     fn interactive_shell_flags_uses_posix_options_for_non_bash() {
         // `--noprofile`/`--norc` are bash-specific; POSIX sh and other shells
         // must get a bare interactive invocation or they abort on launch.
         assert_eq!(interactive_shell_flags("/bin/sh"), "-i");
         assert_eq!(interactive_shell_flags("/usr/bin/dash"), "-i");
         assert_eq!(interactive_shell_flags("/usr/bin/zsh"), "-i");
+        // Names that merely start with "bash" but are not bash must not get the
+        // bash-only options.
+        assert_eq!(interactive_shell_flags("/usr/games/bashful"), "-i");
+        assert!(!is_bash_shell("bashful"));
+        assert!(!is_bash_shell("sh"));
     }
 
     // ── has_active_work_processes ─────────────────────────────────────────────

--- a/src/terminal_session/session.rs
+++ b/src/terminal_session/session.rs
@@ -55,7 +55,7 @@ impl PtyTerminalSession {
         shell: &str,
         working_directory: &Path,
     ) -> SimardResult<Self> {
-        let launch_command = format!("{shell} --noprofile --norc -i");
+        let launch_command = format!("{shell} {}", interactive_shell_flags(shell));
         Self::launch_command(base_type, &launch_command, working_directory)
     }
 
@@ -415,6 +415,27 @@ fn child_path_override(inherited: Option<&OsStr>) -> Option<&'static str> {
     }
 }
 
+/// Interactive launch flags appropriate for the given shell.
+///
+/// bash honours `--noprofile --norc` to skip startup files for a clean,
+/// deterministic PTY session. POSIX `sh`/dash reject those long options
+/// (`sh: Illegal option --`), so any non-bash interpreter — including the
+/// `/bin/sh`/`$SHELL` fallbacks resolved by `default_shell` — gets a bare
+/// interactive invocation instead. Without this, falling back to a non-bash
+/// shell would itself fail with the very exit code this fix is meant to
+/// eliminate.
+fn interactive_shell_flags(shell: &str) -> &'static str {
+    let name = Path::new(shell)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("");
+    if name == "bash" {
+        "--noprofile --norc -i"
+    } else {
+        "-i"
+    }
+}
+
 /// Process names that indicate active LLM work is in progress.
 #[cfg(unix)]
 const WORK_PROCESS_NAMES: &[&str] = &["copilot", "node", "amplihack"];
@@ -559,6 +580,29 @@ mod tests {
             child_path_override(Some(OsStr::new(""))),
             Some(DEFAULT_PATH)
         );
+    }
+
+    // ── interactive_shell_flags ───────────────────────────────────────────────
+
+    #[test]
+    fn interactive_shell_flags_uses_bash_options_for_bash() {
+        assert_eq!(
+            interactive_shell_flags("/usr/bin/bash"),
+            "--noprofile --norc -i"
+        );
+        assert_eq!(
+            interactive_shell_flags("/bin/bash"),
+            "--noprofile --norc -i"
+        );
+    }
+
+    #[test]
+    fn interactive_shell_flags_uses_posix_options_for_non_bash() {
+        // `--noprofile`/`--norc` are bash-specific; POSIX sh and other shells
+        // must get a bare interactive invocation or they abort on launch.
+        assert_eq!(interactive_shell_flags("/bin/sh"), "-i");
+        assert_eq!(interactive_shell_flags("/usr/bin/dash"), "-i");
+        assert_eq!(interactive_shell_flags("/usr/bin/zsh"), "-i");
     }
 
     // ── has_active_work_processes ─────────────────────────────────────────────

--- a/src/terminal_session/session.rs
+++ b/src/terminal_session/session.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsStr;
 use std::fs::{self, File, OpenOptions};
 use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
@@ -7,7 +8,7 @@ use std::time::{Duration, Instant};
 
 use crate::error::{SimardError, SimardResult};
 
-use super::types::{PTY_LAUNCHER, TerminalSessionCapture, TerminalWaitStatus};
+use super::types::{DEFAULT_PATH, PTY_LAUNCHER, TerminalSessionCapture, TerminalWaitStatus};
 use super::workflow_guard::{WorkflowRestoreGuard, capture_workflow_restore_guards};
 
 struct TranscriptGuard {
@@ -88,9 +89,15 @@ impl PtyTerminalSession {
                 .arg(launch_command)
                 .arg(&transcript_path);
         }
+        command.current_dir(working_directory).env("TERM", "dumb");
+        // Ensure the child PTY has a usable PATH so ordinary commands resolve to
+        // real binaries instead of failing with exit code 127. Only override when
+        // the inherited PATH is missing or empty so operator-provided PATHs (and
+        // any PATH set by the launching service) are preserved untouched.
+        if let Some(path) = child_path_override(std::env::var_os("PATH").as_deref()) {
+            command.env("PATH", path);
+        }
         let mut child = command
-            .current_dir(working_directory)
-            .env("TERM", "dumb")
             .stdin(Stdio::piped())
             .stdout(Stdio::null())
             .stderr(Stdio::null())
@@ -396,6 +403,18 @@ impl PtyTerminalSession {
     }
 }
 
+/// Decide whether the child PTY needs an explicit `PATH` override.
+///
+/// Returns the fallback [`DEFAULT_PATH`] when the inherited value is missing or
+/// empty so ordinary commands resolve instead of failing with exit code 127;
+/// returns `None` when the inherited `PATH` is usable and must be preserved.
+fn child_path_override(inherited: Option<&OsStr>) -> Option<&'static str> {
+    match inherited {
+        Some(value) if !value.is_empty() => None,
+        _ => Some(DEFAULT_PATH),
+    }
+}
+
 /// Process names that indicate active LLM work is in progress.
 #[cfg(unix)]
 const WORK_PROCESS_NAMES: &[&str] = &["copilot", "node", "amplihack"];
@@ -517,6 +536,30 @@ fn env_secs(var: &str, default: u64) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── child_path_override ───────────────────────────────────────────────────
+
+    #[test]
+    fn child_path_override_preserves_usable_path() {
+        assert_eq!(
+            child_path_override(Some(OsStr::new("/usr/bin:/bin"))),
+            None,
+            "a non-empty inherited PATH must be preserved untouched"
+        );
+    }
+
+    #[test]
+    fn child_path_override_falls_back_when_missing() {
+        assert_eq!(child_path_override(None), Some(DEFAULT_PATH));
+    }
+
+    #[test]
+    fn child_path_override_falls_back_when_empty() {
+        assert_eq!(
+            child_path_override(Some(OsStr::new(""))),
+            Some(DEFAULT_PATH)
+        );
+    }
 
     // ── has_active_work_processes ─────────────────────────────────────────────
 

--- a/src/terminal_session/types.rs
+++ b/src/terminal_session/types.rs
@@ -7,6 +7,11 @@ pub(crate) const DEFAULT_SHELL: &str = "/bin/bash";
 #[cfg(not(target_os = "macos"))]
 pub(crate) const DEFAULT_SHELL: &str = "/usr/bin/bash";
 pub(crate) const PTY_LAUNCHER: &str = "script";
+/// Fallback `PATH` for the child PTY when the inherited environment has none.
+/// Prevents ordinary commands from failing with exit code 127 in stripped
+/// service environments where `PATH` is unset or empty.
+pub(crate) const DEFAULT_PATH: &str =
+    "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
 pub(crate) const WAIT_STEP_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -51,6 +56,16 @@ mod tests {
     #[test]
     fn pty_launcher_constant() {
         assert_eq!(PTY_LAUNCHER, "script");
+    }
+
+    #[test]
+    fn default_path_lists_standard_bin_directories() {
+        for dir in ["/usr/bin", "/bin"] {
+            assert!(
+                DEFAULT_PATH.split(':').any(|entry| entry == dir),
+                "DEFAULT_PATH must include {dir}: {DEFAULT_PATH}"
+            );
+        }
     }
 
     #[test]

--- a/tests/qa-scenarios/terminal-missing-binary-error.yaml
+++ b/tests/qa-scenarios/terminal-missing-binary-error.yaml
@@ -1,0 +1,29 @@
+name: simard-terminal-missing-binary-error
+app_type: cli
+description: |
+  Regression for #2077 — `simard engineer terminal "say hello"` previously
+  exited with a bare "terminal-shell session exited with status exit status:
+  127" that told the operator nothing. After the fix, a missing-binary
+  objective must surface an actionable error that (a) explains exit code 127
+  means a command could not be resolved on PATH, (b) includes the shell's own
+  "command not found" diagnostic, and (c) names the offending command.
+
+  Schema note: the pinned `@gadugi/agentic-test` CLI runner only fails a
+  scenario when a `run` step exits non-zero (its `validate_*` steps do not gate
+  pass/fail, and command text is read from `params.command`). The assertions
+  are therefore encoded in the exit code of a single `bash -lc` wrapper: it
+  prints the captured output for visibility and exits zero only when all three
+  required diagnostic fragments are present, so the scenario fails loudly if
+  the clear-error behaviour regresses.
+metadata:
+  tags:
+    - cli
+agents:
+  - name: cli-agent
+    type: cli
+    command: bash
+steps:
+  - action: run
+    params:
+      command: "bash -lc 'OUT=$(cargo run --quiet -- engineer terminal single-process \"simard-nonexistent-cmd-2077 hi\" 2>&1); echo \"$OUT\"; echo \"$OUT\" | grep -q \"could not be found on PATH\" && echo \"$OUT\" | grep -q \"command not found\" && echo \"$OUT\" | grep -q \"simard-nonexistent-cmd-2077\"'"
+    timeout: 300000

--- a/tests/qa-scenarios/terminal-missing-binary-error.yaml
+++ b/tests/qa-scenarios/terminal-missing-binary-error.yaml
@@ -12,9 +12,9 @@ description: |
   scenario when a `run` step exits non-zero (its `validate_*` steps do not gate
   pass/fail, and command text is read from `params.command`). The assertions
   are therefore encoded in the exit code of a single `bash -lc` wrapper: it
-  prints the captured output for visibility and exits zero only when all three
-  required diagnostic fragments are present, so the scenario fails loudly if
-  the clear-error behaviour regresses.
+  prints the captured output for visibility and exits zero only when the CLI
+  itself exited non-zero *and* all three required diagnostic fragments are
+  present, so the scenario fails loudly if the clear-error behaviour regresses.
 metadata:
   tags:
     - cli
@@ -25,5 +25,5 @@ agents:
 steps:
   - action: run
     params:
-      command: "bash -lc 'OUT=$(cargo run --quiet -- engineer terminal single-process \"simard-nonexistent-cmd-2077 hi\" 2>&1); echo \"$OUT\"; echo \"$OUT\" | grep -q \"could not be found on PATH\" && echo \"$OUT\" | grep -q \"command not found\" && echo \"$OUT\" | grep -q \"simard-nonexistent-cmd-2077\"'"
+      command: "bash -lc 'OUT=$(cargo run --quiet -- engineer terminal single-process \"simard-nonexistent-cmd-2077 hi\" 2>&1); RC=$?; echo \"$OUT\"; test \"$RC\" -ne 0 && echo \"$OUT\" | grep -q \"could not be found on PATH\" && echo \"$OUT\" | grep -q \"command not found\" && echo \"$OUT\" | grep -q \"simard-nonexistent-cmd-2077\"'"
     timeout: 300000

--- a/tests/qa-scenarios/terminal-valid-command.yaml
+++ b/tests/qa-scenarios/terminal-valid-command.yaml
@@ -1,0 +1,24 @@
+name: simard-terminal-valid-command
+app_type: cli
+description: |
+  Companion to the #2077 missing-binary regression: a valid command must still
+  resolve on PATH and complete the bounded `engineer terminal` session
+  end-to-end through the PTY, returning its output with a successful phase.
+
+  Schema note: the pinned `@gadugi/agentic-test` CLI runner only gates on
+  `run`-step exit codes and reads command text from `params.command`, so the
+  assertion is encoded in the exit code of a `bash -lc` wrapper that exits zero
+  only when the session reports "Session phase: complete" and the echoed marker
+  is present in the captured output.
+metadata:
+  tags:
+    - cli
+agents:
+  - name: cli-agent
+    type: cli
+    command: bash
+steps:
+  - action: run
+    params:
+      command: "bash -lc 'OUT=$(cargo run --quiet -- engineer terminal single-process \"echo simard-terminal-2077-ok\" 2>&1); echo \"$OUT\"; echo \"$OUT\" | grep -q \"Session phase: complete\" && echo \"$OUT\" | grep -q \"simard-terminal-2077-ok\"'"
+    timeout: 300000

--- a/tests/qa-scenarios/terminal-valid-command.yaml
+++ b/tests/qa-scenarios/terminal-valid-command.yaml
@@ -4,12 +4,14 @@ description: |
   Companion to the #2077 missing-binary regression: a valid command must still
   resolve on PATH and complete the bounded `engineer terminal` session
   end-to-end through the PTY, returning its output with a successful phase.
+  Uses an *external* binary (`uname -s`) rather than a shell builtin so the
+  scenario actually exercises child-PTY PATH resolution.
 
   Schema note: the pinned `@gadugi/agentic-test` CLI runner only gates on
   `run`-step exit codes and reads command text from `params.command`, so the
   assertion is encoded in the exit code of a `bash -lc` wrapper that exits zero
-  only when the session reports "Session phase: complete" and the echoed marker
-  is present in the captured output.
+  only when the session reports "Session phase: complete" and the external
+  command's output (`Linux`/`Darwin`) is present in the captured output.
 metadata:
   tags:
     - cli
@@ -20,5 +22,5 @@ agents:
 steps:
   - action: run
     params:
-      command: "bash -lc 'OUT=$(cargo run --quiet -- engineer terminal single-process \"echo simard-terminal-2077-ok\" 2>&1); echo \"$OUT\"; echo \"$OUT\" | grep -q \"Session phase: complete\" && echo \"$OUT\" | grep -q \"simard-terminal-2077-ok\"'"
+      command: "bash -lc 'OUT=$(cargo run --quiet -- engineer terminal single-process \"uname -s\" 2>&1); echo \"$OUT\"; echo \"$OUT\" | grep -q \"Session phase: complete\" && echo \"$OUT\" | grep -qE \"Linux|Darwin\"'"
     timeout: 300000


### PR DESCRIPTION
## Summary

Fixes #2077 — `simard engineer terminal single-process "say hello"` (and any
`engineer terminal` objective whose command is missing from `PATH`) failed with
an opaque

```
base type 'terminal-shell' failed during invocation: harness terminal turn failed: ... terminal-shell session exited with status exit status: 127
```

that gave the operator no clue *what* failed. The `terminal-shell` base type
feeds the objective text directly to an interactive PTY shell
(`script -qefc "<shell> --noprofile --norc -i"`); a command that isn't on
`PATH` makes the shell exit 127, and the old code surfaced only the bare status.

### What changed (scope: `src/terminal_session/*`)

- **Actionable failures** (`execution.rs::describe_terminal_failure`): on a
  non-zero shell exit, the error now explains the well-known codes
  (127 = command not found on `PATH`, 126 = found-but-not-executable) and
  appends the shell's own diagnostic line.
- **Wait-step failures are actionable too** (`execution.rs`): a missing command
  paired with a `wait-for` checkpoint previously reported only a generic
  `did not emit expected output ... within Ns` timeout, hiding the shell's
  `command not found` line. Both the `ExitedEarly` and `TimedOut` branches now
  read the transcript and surface the same diagnostic, via reusable
  `exit_code_guidance` + `transcript_diagnostic_suffix` helpers.
- **Shell diagnostic extraction** (`evidence.rs::terminal_failure_hint`): pulls
  the most recent `command not found` / `not found` / `permission denied` /
  `no such file or directory` line out of the (sanitized) transcript, naming the
  offending command; falls back to the last terminal output otherwise.
- **Usable child PATH** (`session.rs::child_path_override` + `types.rs::DEFAULT_PATH`):
  the child PTY gets a sane default `PATH` **only** when the inherited `PATH` is
  empty/missing; operator/service-provided `PATH`s are preserved untouched.
- **Robust default shell** (`parsing.rs::default_shell`): prefers the platform
  default, then `$SHELL`/`/bin/bash`/`/bin/sh`, each validated through
  `normalize_shell` so the session doesn't strand on a missing interpreter.
- **Shell-aware launch flags** (`session.rs::interactive_shell_flags` + `is_bash_shell`):
  bash (including versioned basenames like `bash5` / `bash-5.2`, excluding
  unrelated names like `bashful`) gets `--noprofile --norc -i`; POSIX
  `sh`/dash/others get a bare `-i`, so the `/bin/sh` fallback above doesn't
  itself abort on unknown long options.

Before → after (real CLI output):

```
# before
Error: ... terminal-shell session exited with status exit status: 127
# after
Error: ... terminal-shell session exited with status exit status: 127 — exit code 127 means a command in the terminal session could not be found on PATH; verify the command is installed and on PATH, or invoke it with an absolute path (shell reported: bash: say: command not found)
```

### Commits

- `8d14499a` fix(terminal): make terminal-shell failures actionable instead of bare exit codes (#2077)
- `870f6241` harden(terminal): shell-aware launch flags + strengthen #2077 regressions
- `ef465017` harden(terminal): surface diagnostics on wait-step failures + versioned-bash flags (#2077)

Rebased onto `main` (`0c594cd1`) to clear the prior `CONFLICTING/DIRTY`
state; the PR is now **MERGEABLE**. Conflicts were in the two terminal test
commits that landed on main concurrently (#2363 PTY-lifecycle-without-controlling-terminal,
#2372 assert-executed-output) and a docs paragraph (#1665 enrichment note);
all were integrated, keeping both sides.

---

## Merge-ready evidence

### 1. qa-team scenarios — written, validated, run
Two CLI scenarios under `tests/qa-scenarios/`:
- `terminal-missing-binary-error.yaml` — asserts the CLI exits **non-zero** *and*
  the actionable 127 diagnostic (explanation + `command not found` + offending
  command name) is present for a missing binary.
- `terminal-valid-command.yaml` — runs an **external** binary (`uname -s`, not a
  shell builtin) so it exercises child-PTY PATH resolution, and asserts the
  session reaches `Session phase: complete`.

Both run the real `cargo run -- engineer terminal ...` end-to-end. (The pinned
`@gadugi/agentic-test` runner gates on a `run` step's exit code and reads the
command from `params.command`; assertions are encoded in a `bash -lc` wrapper's
exit code so the scenarios fail loudly on regression.)

```
$ gadugi-test validate -f <each scenario> --strict
✓ Scenario "simard-terminal-missing-binary-error" is valid
✓ Scenario "simard-terminal-valid-command" is valid
✓ All file(s) are valid

$ gadugi-test run -d <both scenarios>
Test Execution Results:
✓ Passed: 2   ✗ Failed: 0   - Total: 2
✓ All tests passed!
```

### 2. Docs updated (user-facing)
- `docs/reference/simard-cli.md` — `engineer terminal` "Key behavior": documents
  the actionable 127/126 errors, surfaced shell diagnostic, child-PATH fallback,
  default-shell resolution, and that wait-checkpoint failures caused by a missing
  command also surface the diagnostic.
- `docs/reference/base-type-adapters.md` — `terminal-shell` adapter:
  **Failure diagnostics** note (now covering wait-step failures) + default-shell
  fallback.

### 3. Quality-audit — 4 SEEK→VALIDATE→FIX cycles (final clean)
- **Cycle 1 (code-review):** verified the rebase integrated correctly — main's
  new `pty_session_runs_end_to_end_without_controlling_terminal` test (#2363/#2372)
  is present and passes with the new launch path; nothing dropped/doubly-applied;
  `child_path_override` lifetime, signal-exit handling, and CLI-contract surfacing
  all correct. **No significant issues.**
- **Cycle 2 (security-review):** traced injection / secret-exposure / PATH /
  panic surfaces to ground truth (`normalize_shell`, `sanitize_terminal_text`,
  `truncate_to_char_boundary`, `child_path_override`/`DEFAULT_PATH`).
  **No vulnerabilities** — the resolved shell (incl. `$SHELL` fallback) is always
  validated (safe-char allowlist, absolute, executable), surfaced text is
  sanitized + secret-redacted and only logged, and the PATH override only applies
  to an empty inherited PATH using root-owned dirs. **Clean.**
- **Cycle 3 (rubber-duck) — found + FIXED:** a missing command before a `wait-for`
  step bypassed the actionable diagnostics (generic timeout only). VALIDATE→FIX:
  wired `transcript_diagnostic_suffix`/`exit_code_guidance` into both wait-failure
  branches + regression test; also treated versioned bash basenames as bash and
  strengthened both qa-scenarios (external binary; assert non-zero CLI exit).
- **Cycle 4 (final confirmation):** re-ran the full `terminal_session` suite —
  **86 passed, 0 failed** (84 → 86 with the two new regressions). `cargo fmt
  --all --check` clean; `cargo clippy --all-targets --all-features` clean.
  gadugi-test re-validated + re-run (2/2). **No remaining issues.**

### 4. CI
- **cargo-audit: green** — the prior red was `RUSTSEC-2026-0185` (`quinn-proto`),
  an ecosystem advisory unrelated to this terminal change; it was fixed on `main`
  by #2391 (`quinn-proto` → 0.11.15). This branch's `Cargo.lock` is byte-identical
  to `main` (`git diff main -- Cargo.lock` is empty), so the rebase inherits the
  fix and `cargo audit` now exits 0 (remaining items are allowed unmaintained/
  unsound warnings only).
- Full CI run: all checks green on verify run https://github.com/rysweet/Simard/actions/runs/27992667074 and https://github.com/rysweet/Simard/actions/runs/27992665087 — build, pre-commit (build + `cargo test --all-features --locked` + clippy), cargo-audit, coverage, e2e-dashboard, install-real, GitGuardian all **pass** on `ef465017`

Local gates (clean): `cargo fmt --all --check`; `cargo clippy --all-targets
--all-features`; `cargo test --lib terminal_session::` → **86 passed, 0 failed**.

### 6. Focused diff
Only `src/terminal_session/*` (6 files), `docs/reference/{simard-cli,base-type-adapters}.md`,
and the two qa-scenarios. `git diff main -- Cargo.lock Cargo.toml` is empty.
No unrelated edits.

---

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
