### PR TITLE
fix(dashboard): clarify memory totals and reconcile cost label/lede (#2358)

### DIFF
--- a/src/operator_commands_dashboard/index_html/part_00.rs
+++ b/src/operator_commands_dashboard/index_html/part_00.rs
@@ -336,7 +336,7 @@ pub(crate) const PART_00: &str = r#"<!DOCTYPE html>
 
   <div class="tab-content" id="tab-costs">
     <h1 class="page-h1">Costs</h1>
-    <p class="page-lede">Token and dollar spending by model and provider, plus your daily and weekly budget caps, computed from real provider invoices rather than estimates.</p>
+    <p class="page-lede">Token and dollar spending by model and provider, plus your daily and weekly budget caps. Figures are estimated from token counts and typical model pricing, not billed from provider invoices.</p>
     <div class="grid">
       <div class="card"><h2>Daily Costs <button class="btn" onclick="fetchCosts()">Refresh</button></h2><div id="costs-daily"><span class="loading">Loading…</span></div></div>
       <div class="card"><h2>Weekly Costs</h2><div id="costs-weekly"><span class="loading">Loading…</span></div></div>

--- a/src/operator_commands_dashboard/index_html/part_03.rs
+++ b/src/operator_commands_dashboard/index_html/part_03.rs
@@ -159,12 +159,20 @@ pub(crate) const PART_03: &str = r#"        const d=await apiFetch('/api/goals')
           trendEl.textContent='';
           return;
         }
-        // Trend badge
+        // Long-term growth rate over the observed window. Computed up front so the
+        // trend badge below is derived from the SAME number shown in the rate
+        // readout — the arrow direction can never contradict the rate sign (#2358).
+        const mgSnaps=d.snapshots||[];
+        const ltRate=(d.rate_per_hour&&d.rate_per_hour.long_term_total)||0;
+        const ltRateDisp=Math.abs(ltRate)<0.1?'0':ltRate.toFixed(1);
+
+        // Trend badge — direction follows the displayed rate sign.
         const trendIcons={growing:'↑ Growing',shrinking:'↓ Shrinking',stable:'→ Stable',unknown:'—'};
         const trendColors={growing:'#3fb950',shrinking:'#f85149',stable:'#d29922',unknown:'#8b949e'};
-        const trend=d.trend||'unknown';
-        trendEl.textContent=trendIcons[trend]||'—';
-        trendEl.style.color=trendColors[trend]||'#8b949e';
+        let trend='unknown';
+        if(mgSnaps.length>=2){trend=Math.abs(ltRate)<0.1?'stable':(ltRate>0?'growing':'shrinking');}
+        trendEl.textContent=trendIcons[trend];
+        trendEl.style.color=trendColors[trend];
 
         // Delta badges
         if(d.deltas){
@@ -190,15 +198,11 @@ pub(crate) const PART_03: &str = r#"        const d=await apiFetch('/api/goals')
           deltasEl.innerHTML='<span style="color:#8b949e;font-size:.85rem">Not enough samples yet — growth data appears after two snapshots</span>';
         }
 
-        // Growth rate
-        if(d.rate_per_hour){
-          const r=d.rate_per_hour.long_term_total||0;
-          const rDisp=Math.abs(r)<0.1?'0':r.toFixed(1);
-          rateEl.innerHTML='<div style="font-size:1.5rem;font-weight:700;color:#58a6ff;line-height:1">'+rDisp+'</div><div style="font-size:.75rem;color:#8b949e;margin-top:.15rem">long-term mem/hr</div>';
-        }
+        // Growth rate readout — reuses the value the trend badge was derived from.
+        rateEl.innerHTML='<div style="font-size:1.5rem;font-weight:700;color:#58a6ff;line-height:1">'+ltRateDisp+'</div><div style="font-size:.75rem;color:#8b949e;margin-top:.15rem">long-term mem/hr</div>';
 
         // SVG sparkline from snapshots
-        const snaps=d.snapshots||[];
+        const snaps=mgSnaps;
         if(snaps.length>=2){
           const vals=snaps.map(s=>s.long_term_total||0);
           const minV=Math.min(...vals);
@@ -233,10 +237,24 @@ pub(crate) const PART_03: &str = r#"        const d=await apiFetch('/api/goals')
       try{
         const d=await apiFetch('/api/memory/recent');
         if(d.error){listEl.innerHTML='<span class="err">'+esc(d.error)+'</span>';countEl.textContent='—';return;}
+        // Total stored memory. /api/memory/recent reports 0 on the library backend
+        // (per-item listing unavailable, #2307), so fall back to the authoritative
+        // total from /api/memory/history's newest snapshot — otherwise the panel
+        // claims "0 total / no memories" while tens of thousands are stored (#2358).
+        let totalStored=d.total||0;
+        if(!totalStored){
+          try{
+            const h=await apiFetch('/api/memory/history');
+            const hs=h.snapshots||[];
+            if(hs.length){totalStored=hs[hs.length-1].total||0;}
+          }catch(_){}
+        }
         countEl.textContent=d.last_hour_count;
-        totalEl.textContent=d.total+' total';
+        totalEl.textContent=totalStored>0?(totalStored.toLocaleString()+' total stored'):'';
         if(!d.items||d.items.length===0){
-          listEl.innerHTML='<span style="color:#8b949e">No memories stored yet. Simard will remember things as it works.</span>';
+          listEl.innerHTML=totalStored>0
+            ?'<span style="color:#8b949e">No new memories in the last hour — '+totalStored.toLocaleString()+' total stored. Simard keeps remembering as it works.</span>'
+            :'<span style="color:#8b949e">No memories stored yet. Simard will remember things as it works.</span>';
           return;
         }
         const catColors={'Learned fact':'#58a6ff','Past event':'#3fb950','Current task context':'#f0883e','How-to knowledge':'#a371f7','Planned reminder':'#d29922','Recent observation':'#8b949e'};

--- a/src/operator_commands_dashboard/index_html/part_03.rs
+++ b/src/operator_commands_dashboard/index_html/part_03.rs
@@ -237,24 +237,34 @@ pub(crate) const PART_03: &str = r#"        const d=await apiFetch('/api/goals')
       try{
         const d=await apiFetch('/api/memory/recent');
         if(d.error){listEl.innerHTML='<span class="err">'+esc(d.error)+'</span>';countEl.textContent='—';return;}
-        // Total stored memory. /api/memory/recent reports 0 on the library backend
-        // (per-item listing unavailable, #2307), so fall back to the authoritative
-        // total from /api/memory/history's newest snapshot — otherwise the panel
-        // claims "0 total / no memories" while tens of thousands are stored (#2358).
+        // Total stored memory. /api/memory/recent reports only the last-hour window
+        // (0 and available:false on the library backend, where per-item listing is
+        // unavailable, #2307). Prefer the authoritative total from /api/memory/history's
+        // newest snapshot so the panel never claims "0 total / no memories" while
+        // tens of thousands are stored (#2358); never under-report (Math.max).
+        const recentAvailable=d.available!==false;
         let totalStored=d.total||0;
-        if(!totalStored){
+        if(!totalStored||!recentAvailable){
           try{
             const h=await apiFetch('/api/memory/history');
             const hs=h.snapshots||[];
-            if(hs.length){totalStored=hs[hs.length-1].total||0;}
+            if(hs.length){totalStored=Math.max(totalStored,hs[hs.length-1].total||0);}
           }catch(_){}
         }
-        countEl.textContent=d.last_hour_count;
+        // The big "last hour" count is only meaningful when the recent listing is
+        // actually available; show — (unknown) rather than a misleading 0 otherwise.
+        countEl.textContent=recentAvailable?d.last_hour_count:'—';
         totalEl.textContent=totalStored>0?(totalStored.toLocaleString()+' total stored'):'';
         if(!d.items||d.items.length===0){
-          listEl.innerHTML=totalStored>0
-            ?'<span style="color:#8b949e">No new memories in the last hour — '+totalStored.toLocaleString()+' total stored. Simard keeps remembering as it works.</span>'
-            :'<span style="color:#8b949e">No memories stored yet. Simard will remember things as it works.</span>';
+          let msg;
+          if(totalStored>0){
+            msg=recentAvailable
+              ?'No new memories in the last hour — '+totalStored.toLocaleString()+' total stored. Simard keeps remembering as it works.'
+              :'Recent-memory listing is unavailable on this backend — '+totalStored.toLocaleString()+' total stored.';
+          }else{
+            msg='No memories stored yet. Simard will remember things as it works.';
+          }
+          listEl.innerHTML='<span style="color:#8b949e">'+msg+'</span>';
           return;
         }
         const catColors={'Learned fact':'#58a6ff','Past event':'#3fb950','Current task context':'#f0883e','How-to knowledge':'#a371f7','Planned reminder':'#d29922','Recent observation':'#8b949e'};

--- a/src/operator_commands_dashboard/index_html/tab_meta.rs
+++ b/src/operator_commands_dashboard/index_html/tab_meta.rs
@@ -126,7 +126,7 @@ pub const TAB_METADATA: &[TabMeta] = &[
         label: "Costs",
         title: "Costs · Simard",
         h1: "Costs",
-        lede: "Token and dollar spending by model and provider, plus your daily and weekly budget caps, computed from real provider invoices rather than estimates.",
+        lede: "Token and dollar spending by model and provider, plus your daily and weekly budget caps. Figures are estimated from token counts and typical model pricing, not billed from provider invoices.",
         tooltip: "Token and dollar usage by model, plus daily and weekly budget",
     },
     TabMeta {

--- a/tests/e2e-dashboard/specs/tabs.spec.ts
+++ b/tests/e2e-dashboard/specs/tabs.spec.ts
@@ -146,6 +146,25 @@ async function mockAllApis(page: import('@playwright/test').Page) {
       body: JSON.stringify({ items: [], total: 0, last_hour_count: 0, server_time: new Date().toISOString() }),
     }),
   );
+  await page.route('**/api/memory/history', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        schema_version: 1,
+        snapshots: [
+          { timestamp: new Date(Date.now() - 3600_000).toISOString(), epoch_secs: Date.now() / 1000 - 3600, sensory: 0, working: 0, episodic: 100, semantic: 50, procedural: 5, prospective: 2, total: 160, long_term_total: 157 },
+          { timestamp: new Date().toISOString(), epoch_secs: Date.now() / 1000, sensory: 0, working: 0, episodic: 110, semantic: 52, procedural: 5, prospective: 2, total: 172, long_term_total: 169 },
+        ],
+        deltas: { sensory: 0, working: 0, episodic: 10, semantic: 2, procedural: 0, prospective: 0, total: 12, long_term_total: 12, interval_secs: 3600 },
+        rate_per_hour: { total: 12.0, long_term_total: 12.0, episodic: 10.0, semantic: 2.0, procedural: 0.0, prospective: 0.0 },
+        trend: 'growing',
+        snapshot_count: 2,
+        sample_interval_seconds: 300,
+        timestamp: new Date().toISOString(),
+      }),
+    }),
+  );
   await page.route('**/api/memory/graph', (route) =>
     route.fulfill({
       status: 200,

--- a/tests/gadugi/dashboard-2358-clarity.sh
+++ b/tests/gadugi/dashboard-2358-clarity.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# dashboard-2358-clarity.sh — outside-in operator check for issue #2358 (P1).
+#
+# Two P1 clarity fixes are verified here:
+#
+#   (1) Memory-count clarity — the "What Simard Remembers" panel must not claim
+#       "0 total / No memories stored yet" while the Memory Store actually holds
+#       memories. /api/memory/recent reports only the last-hour window (0 on the
+#       library backend), so the panel now falls back to the authoritative total
+#       from /api/memory/history's newest snapshot and renders "N total stored"
+#       with the empty-state copy "No new memories in the last hour — N total
+#       stored". The Memory-Growth trend badge must also agree in direction with
+#       the displayed long-term rate sign (no "↑ Growing" beside a negative rate).
+#
+#   (2) Cost label consistency — the Costs lede must agree with the value label.
+#       Costs are estimates (token-count × typical pricing), so the lede must say
+#       so and must NOT claim they are "real provider invoices", which would
+#       contradict the "Estimated Cost" value label.
+#
+# This boots the real dashboard binary, authenticates, and asserts against the
+# served HTML and the live /api/memory/{recent,history} responses.
+set -euo pipefail
+
+PORT="${DASH_PORT:-8139}"
+DASHKEY_FILE="${HOME}/.simard/.dashkey"
+LOG="$(mktemp -t dash-2358.XXXXXX.log)"
+CJ="$(mktemp -t dash-2358-cookies.XXXXXX)"
+
+echo "[2358] building simard binary…"
+cargo build --quiet --bin simard
+BIN="${CARGO_TARGET_DIR:-target}/debug/simard"
+if [[ ! -x "$BIN" ]]; then
+  echo "[2358] FAIL: built binary not found at $BIN" >&2
+  exit 1
+fi
+
+echo "[2358] starting dashboard on :$PORT"
+"$BIN" dashboard serve --port="$PORT" >"$LOG" 2>&1 &
+DASH_PID=$!
+cleanup() { kill "$DASH_PID" 2>/dev/null || true; rm -f "$CJ" "$LOG"; }
+trap cleanup EXIT
+
+up=0
+for _ in $(seq 1 30); do
+  if curl -s -o /dev/null "http://localhost:$PORT/login"; then up=1; break; fi
+  sleep 1
+done
+if [[ "$up" -ne 1 ]]; then
+  echo "[2358] FAIL: dashboard did not come up on :$PORT" >&2
+  cat "$LOG" >&2
+  exit 1
+fi
+
+KEY="$(cat "$DASHKEY_FILE")"
+if ! curl -s -c "$CJ" -X POST -H 'Content-Type: application/json' \
+      -d "{\"code\":\"$KEY\"}" "http://localhost:$PORT/api/login" | grep -q '"ok":true'; then
+  echo "[2358] FAIL: login rejected" >&2
+  exit 1
+fi
+
+HTML="$(curl -s -b "$CJ" "http://localhost:$PORT/")"
+RECENT="$(curl -s -b "$CJ" "http://localhost:$PORT/api/memory/recent")"
+HISTORY="$(curl -s -b "$CJ" "http://localhost:$PORT/api/memory/history")"
+
+fail() { echo "[2358] FAIL: $1" >&2; exit 1; }
+
+# ── P1.2 Cost label/lede consistency (served template) ───────────────────────
+grep -qF 'Figures are estimated from token counts and typical model pricing' <<<"$HTML" \
+  || fail "Costs lede must state figures are estimated (agree with 'Estimated Cost')"
+grep -qF 'Estimated Cost' <<<"$HTML" \
+  || fail "Costs value label 'Estimated Cost' must be present"
+if grep -qF 'real provider invoices' <<<"$HTML"; then
+  fail "Costs lede must NOT claim 'real provider invoices' — contradicts 'Estimated Cost'"
+fi
+
+# ── P1.1 Memory total-stored semantics (served template) ─────────────────────
+grep -qF 'No new memories in the last hour' <<<"$HTML" \
+  || fail "Memory empty-state must read 'No new memories in the last hour — N total stored'"
+grep -qF 'total stored' <<<"$HTML" \
+  || fail "Memory panel must label the count as 'total stored'"
+grep -qF 'hs[hs.length-1].total' <<<"$HTML" \
+  || fail "Recent panel must fall back to /api/memory/history newest-snapshot total"
+
+# ── P1.1 Trend badge agrees with rate sign (served template) ─────────────────
+grep -qF "ltRate>0?'growing':'shrinking'" <<<"$HTML" \
+  || fail "Trend badge must be derived from the displayed long-term rate sign"
+
+# ── Live API: endpoints expose the fields the panel relies on ────────────────
+grep -q '"total"' <<<"$RECENT"     || fail "/api/memory/recent must expose 'total'"
+grep -q '"available"' <<<"$RECENT" || fail "/api/memory/recent must expose 'available'"
+grep -q '"snapshots"' <<<"$HISTORY"   || fail "/api/memory/history must expose 'snapshots'"
+grep -q '"rate_per_hour"' <<<"$HISTORY" || fail "/api/memory/history must expose 'rate_per_hour'"
+
+# ── Live API: total-stored fallback and trend/rate agreement (data-driven) ───
+python3 - "$RECENT" "$HISTORY" <<'PY'
+import json, sys
+recent = json.loads(sys.argv[1])
+history = json.loads(sys.argv[2])
+snaps = history.get("snapshots") or []
+recent_total = recent.get("total", 0) or 0
+hist_total = (snaps[-1].get("total", 0) if snaps else 0) or 0
+rate_lt = (history.get("rate_per_hour") or {}).get("long_term_total", 0.0) or 0.0
+
+print(f"[2358] recent.total(window)={recent_total}  history.newest.total={hist_total}  rate_lt={rate_lt:.2f}")
+
+# Total-stored fallback: the panel renders max(recent_total, hist_total). When
+# the store is non-empty the fallback must surface a number >= the window count,
+# never the misleading 0.
+total_shown = recent_total if recent_total else hist_total
+if hist_total > 0:
+    assert total_shown >= hist_total, f"panel would hide stored memories: shows {total_shown}, stored {hist_total}"
+    assert total_shown > 0, "panel must not show 0 total while memories are stored"
+    print(f"[2358] OK: panel surfaces {total_shown} total stored (not 0)")
+else:
+    print("[2358] NOTE: memory store empty in this env — total-stored path proven by template assertions")
+
+# Trend/rate agreement: replicate the client logic and assert the badge arrow can
+# never contradict the displayed rate sign.
+if abs(rate_lt) < 0.1:
+    badge = "stable"
+elif rate_lt > 0:
+    badge = "growing"
+else:
+    badge = "shrinking"
+assert not (rate_lt < -0.1 and badge == "growing"), "badge 'growing' beside negative rate"
+assert not (rate_lt > 0.1 and badge == "shrinking"), "badge 'shrinking' beside positive rate"
+print(f"[2358] OK: trend badge '{badge}' agrees with rate {rate_lt:.2f}/hr")
+PY
+
+echo "[2358] PASS: memory total-stored semantics and cost label/lede consistency hold (#2358)"

--- a/tests/gadugi/dashboard-2358-clarity.sh
+++ b/tests/gadugi/dashboard-2358-clarity.sh
@@ -76,6 +76,8 @@ fi
 # ── P1.1 Memory total-stored semantics (served template) ─────────────────────
 grep -qF 'No new memories in the last hour' <<<"$HTML" \
   || fail "Memory empty-state must read 'No new memories in the last hour — N total stored'"
+grep -qF 'Recent-memory listing is unavailable on this backend' <<<"$HTML" \
+  || fail "Memory empty-state must surface total stored even when the recent listing is unavailable"
 grep -qF 'total stored' <<<"$HTML" \
   || fail "Memory panel must label the count as 'total stored'"
 grep -qF 'hs[hs.length-1].total' <<<"$HTML" \

--- a/tests/gadugi/dashboard-2358-clarity.yaml
+++ b/tests/gadugi/dashboard-2358-clarity.yaml
@@ -1,0 +1,53 @@
+name: "Dashboard Memory/Cost Clarity (#2358)"
+description: "Outside-in operator check for the two P1 findings in issue #2358. Boots the real dashboard binary, authenticates, and asserts that the Memory tab surfaces the authoritative total-stored count (rather than '0 total / No memories stored yet'), the Memory-Growth trend badge agrees in direction with the displayed long-term rate sign, and the Costs lede agrees with the 'Estimated Cost' value label."
+version: "1.0.0"
+
+config:
+  timeout: 300000
+  retries: 0
+  parallel: false
+
+environment:
+  requires: []
+
+agents:
+  - name: "cli-agent"
+    type: "cli"
+    config:
+      workingDirectory: "."
+      defaultTimeout: 300000
+      executionMode: "spawn"
+      captureOutput: true
+      ioConfig:
+        encoding: "utf8"
+        handleInteractivePrompts: false
+      logConfig:
+        logCommands: true
+        logOutput: true
+        logLevel: "info"
+
+steps:
+  - name: "Memory total-stored semantics and cost label/lede consistency"
+    agent: "cli-agent"
+    action: "execute_command"
+    params:
+      command: "tests/gadugi/dashboard-2358-clarity.sh"
+    timeout: 300000
+
+assertions: []
+
+cleanup:
+  - name: "CLI agent cleanup"
+    agent: "cli-agent"
+    action: "cleanup"
+
+metadata:
+  tags:
+    - "dashboard"
+    - "memory"
+    - "costs"
+    - "data-fidelity"
+    - "issue-2358"
+  priority: "high"
+  author: "copilot"
+  test_type: "outside-in"


### PR DESCRIPTION
## Summary

Implements the two **P1** findings from issue #2358 (operator-dashboard usability) in a single focused PR. Scope is intentionally limited to P1 only — no P2/P3 or deploy items.

### P1.1 — Memory-count clarity (Memory tab)
The "What Simard Remembers" panel claimed **"0 total / No memories stored yet"** while the Memory Store actually held hundreds/thousands of entries. Root cause: `/api/memory/recent` only reports the last-hour window and, on the library backend, always returns `total:0, last_hour_count:0, available:false` (per-item listing unavailable, #2307). The authoritative counts live in `/api/memory/history`.

- `fetchRecentMemories()` now falls back to the newest `/api/memory/history` snapshot `total` (via `Math.max`, so it never under-reports) and renders **"N total stored"**.
- When the recent listing is unavailable, the big "last hour" count shows **"—"** (unknown) instead of a misleading `0`, and the empty-state reads **"Recent-memory listing is unavailable on this backend — N total stored"**. When the endpoint is available, it reads **"No new memories in the last hour — N total stored"**.
- The Memory-Growth **trend badge** previously used the backend last-interval `trend` while the rate readout used the windowed `rate_per_hour.long_term_total`, so it could render **"↑ Growing" beside a negative rate** (e.g. `-3.9 long-term mem/hr`). The badge is now derived from the **same** displayed long-term rate value, so direction and sign always agree.

### P1.2 — Cost label consistency (Costs tab)
The Costs lede claimed costs are *"computed from real provider invoices rather than estimates"*, contradicting the **"Estimated Cost"** value label. Costs are in fact estimates (`src/cost_tracking.rs`: `estimate_cost`, `cost_usd_est`, ~4-chars/token approximation × hardcoded average pricing). The lede now agrees with the label (updated byte-identically in both `tab_meta.rs` and `part_00.rs` to satisfy the rendered-lede cross-check test).

Closes the two P1 items of #2358.

## Files changed
- `src/operator_commands_dashboard/index_html/part_03.rs` — memory panel total-stored fallback + availability-aware copy; trend badge derived from displayed rate.
- `src/operator_commands_dashboard/index_html/part_00.rs`, `tab_meta.rs` — cost lede corrected (byte-identical).
- `tests/e2e-dashboard/specs/tabs.spec.ts` — deterministic `/api/memory/history` mock for the new fetch path.
- `tests/gadugi/dashboard-2358-clarity.{yaml,sh}` — new outside-in operator scenario.

Commits: `ab63ceb6`, `effeaa0e`, `58f45acd`.

---

## Merge-ready evidence

### 1. qa-team scenarios (gadugi-test)
New scenario `tests/gadugi/dashboard-2358-clarity.yaml` (+ `.sh`) boots the real dashboard binary, authenticates via `~/.simard/.dashkey`, and asserts both fixes against served HTML and live `/api/memory/{recent,history}`.

```
$ gadugi-test validate -f tests/gadugi/dashboard-2358-clarity.yaml
✓ Scenario "Dashboard Memory/Cost Clarity (#2358)" is valid
✓ All 1 file(s) are valid

$ gadugi-test run -d tests/gadugi -s dashboard-2358-clarity
[2358] recent.total(window)=0  history.newest.total=791  rate_lt=-3.89
[2358] OK: panel surfaces 791 total stored (not 0)
[2358] OK: trend badge 'shrinking' agrees with rate -3.89/hr
[2358] PASS: memory total-stored semantics and cost label/lede consistency hold (#2358)
✓ Passed: 1   ✗ Failed: 0   ✓ All tests passed!
```

**Playwright** (structural e2e + live rendered-DOM capture against a freshly built local instance):
```
$ npx playwright test --config tests/e2e-dashboard/playwright.config.ts tabs --project structural
14 passed (0 JS errors)

# Live rendered DOM (real instance, 791 stored, rate -3.9/hr):
memory.recent_count_big      = "—"
memory.recent_total_label    = "791 total stored"
memory.recent_list_text      = "Recent-memory listing is unavailable on this backend — 791 total stored."
memory.growth_trend_badge    = "↓ Shrinking"     (agrees with...)
memory.growth_rate_readout   = "-3.9 long-term mem/hr"
costs.lede                   = "...Figures are estimated from token counts and typical model pricing, not billed from provider invoices."
pageErrors                   = []
```
Before this PR the same live data rendered "0 total / No memories stored yet" and "↑ Growing" beside the `-3.9` rate.

### 2. Documentation
User-facing copy changes are the fix itself (dashboard lede + panel text). No separate docs surface documents this dashboard copy. Internal-only note: the gadugi scenario + e2e mock document the intended behavior; no `docs/` page references the changed strings.

### 3. quality-audit (≥3 SEEK→VALIDATE→FIX cycles, final clean)
- **Cycle 1** — code-review + security-review: clean, no substantive findings.
- **Cycle 2** — fresh-lens review: 2 non-blocking correctness findings (panel presented `available:false` window as a factual `0`; history fallback could under-report). **Both fixed** in `58f45acd` (availability-aware `—`/copy + `Math.max`).
- **Cycle 3** — final code-review: **clean — zero critical, zero high, zero medium correctness/security findings**. Independently ran `cargo check --lib` (EXIT 0) and `node --check` on the two modified JS functions.

### 4. CI
Local gates green (pre-commit + pre-push hooks):
- `cargo fmt --all -- --check` — Passed
- `cargo clippy --release --no-deps -- -D warnings` (pre-commit) — Passed
- `cargo clippy --all-targets --all-features --locked -- -D warnings` (pre-push) — Passed
- `cargo test --release --lib (cognitive_memory|bootstrap|memory_ipc|memory_consolidation)` (pre-push) — Passed
- `cargo test --lib operator_commands_dashboard` — **318 passed, 0 failed** (incl. `rendered_html_contains_every_lede`, `index_html_contains_growth_card`, `tab_meta_ledes_*`).

CI on this PR will be the authoritative full-suite gate.

### 6. Diff focus
6 files, +248/−16. Limited to the two P1 fixes plus their tests/mock. No P2/P3, no unrelated edits, no changes under `~/.simard/prompt_assets/`.

---

🔎 Not merging — opened for review per the merge-readiness gate.
