### PR TITLE
fix(dashboard): humanize P3 units, urgency scales & brain-failure shorthand (#2358)

### DIFF
--- a/src/operator_commands_dashboard/brain_failures.rs
+++ b/src/operator_commands_dashboard/brain_failures.rs
@@ -103,7 +103,8 @@ pub(crate) async fn brain_failures() -> Json<Value> {
                 let phase = j.get("phase").and_then(|v| v.as_str()).unwrap_or("unknown");
                 let decision = j.get("decision").and_then(|v| v.as_str()).unwrap_or("");
                 let rationale = j.get("rationale").and_then(|v| v.as_str()).unwrap_or("");
-                let confidence = j.get("confidence").and_then(|v| v.as_f64()).unwrap_or(0.0);
+                let confidence_opt = j.get("confidence").and_then(|v| v.as_f64());
+                let confidence = confidence_opt.unwrap_or(0.0);
 
                 let failure_type = if has_parse_failure {
                     "parse_failure"
@@ -132,13 +133,7 @@ pub(crate) async fn brain_failures() -> Json<Value> {
                         err_msg
                     )
                 } else {
-                    format!(
-                        "The {} phase used its deterministic fallback instead of the language model brain. \
-                         Decision: {} (confidence: {:.0}%).",
-                        phase,
-                        decision,
-                        confidence * 100.0
-                    )
+                    fallback_description(phase, decision, confidence_opt)
                 };
 
                 let recovery_succeeded = true; // fallback always recovers
@@ -178,7 +173,7 @@ pub(crate) async fn brain_failures() -> Json<Value> {
                         _ => "Unknown phase",
                     },
                     "decision": decision,
-                    "rationale": rationale,
+                    "rationale": humanize_rationale(rationale),
                     "confidence": confidence,
                     "cycle_number": cycle_number,
                     "timestamp": timestamp,
@@ -221,6 +216,74 @@ fn count_brain_parse_failure_metrics(path: &std::path::Path) -> u64 {
         .count() as u64
 }
 
+/// Humanize a raw machine decision token (e.g. `consolidate_memory`) into
+/// plain words (`consolidate memory`) for operator display. P3 of #2358 —
+/// keeps bare snake/kebab identifiers out of the human-facing Brain Failures
+/// description. Returns an empty string for an empty/whitespace input.
+fn humanize_decision(raw: &str) -> String {
+    let d = raw.trim();
+    if d.is_empty() {
+        return String::new();
+    }
+    d.replace(['_', '-'], " ")
+}
+
+/// Build the plain-English Brain Failures description for a deterministic
+/// (non-parse) fallback. P3 of #2358 — no machine jargon (`deterministic
+/// fallback`, snake_case decision tokens), and the confidence figure is only
+/// shown when it was actually recorded so an absent value never reads as a
+/// real "0%".
+fn fallback_description(phase: &str, decision: &str, confidence: Option<f64>) -> String {
+    let decision_human = humanize_decision(decision);
+    let chose = if decision_human.is_empty() {
+        String::new()
+    } else {
+        format!(" It chose to {decision_human}.")
+    };
+    let conf = match confidence {
+        Some(c) => format!(
+            " The rules were {:.0}% confident in that choice.",
+            c * 100.0
+        ),
+        None => String::new(),
+    };
+    format!(
+        "The {phase} phase used its built-in safety rules instead of the language model.{chose}{conf}"
+    )
+}
+
+/// Humanize a raw brain `rationale` marker for operator display. P3 of #2358 —
+/// the canonical rationale strings (set in `ooda_brain`) are insider shorthand
+/// like `deterministic-brain: prefix-routed`; this maps them to plain English
+/// at the display layer only. The persisted/canonical rationale is unchanged so
+/// logs and `ooda_brain` tests stay green. Unknown rationales are passed
+/// through with the machine `<x>-brain:` prefix stripped and common shorthand
+/// expanded, so no raw token reaches the operator.
+fn humanize_rationale(raw: &str) -> String {
+    let r = raw.trim();
+    if r.is_empty() {
+        return String::new();
+    }
+    match r {
+        "deterministic-brain: prefix-routed" | "fallback-brain: prefix-routed" => {
+            "Chosen by Simard's built-in routing rules (no language model was needed).".to_string()
+        }
+        "deterministic-brain: no LLM configured" => {
+            "Used the built-in rules because no language model is configured.".to_string()
+        }
+        other => {
+            let body = other
+                .split_once("-brain:")
+                .map(|(_, rest)| rest.trim())
+                .unwrap_or(other);
+            body.replace("prefix-routed", "chosen by built-in routing rules")
+                .replace("no LLM configured", "no language model configured")
+                .trim()
+                .to_string()
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -253,5 +316,88 @@ mod tests {
     fn count_brain_parse_failure_metrics_missing_file() {
         let path = std::path::Path::new("/nonexistent/metrics.jsonl");
         assert_eq!(count_brain_parse_failure_metrics(path), 0);
+    }
+
+    #[test]
+    fn humanize_decision_spaces_machine_tokens() {
+        assert_eq!(
+            humanize_decision("consolidate_memory"),
+            "consolidate memory"
+        );
+        assert_eq!(humanize_decision("run-improvement"), "run improvement");
+        assert_eq!(humanize_decision("  "), "");
+        assert_eq!(humanize_decision(""), "");
+        // No machine separators -> unchanged.
+        assert_eq!(humanize_decision("continue"), "continue");
+    }
+
+    #[test]
+    fn humanize_rationale_maps_known_markers() {
+        assert_eq!(
+            humanize_rationale("deterministic-brain: prefix-routed"),
+            "Chosen by Simard's built-in routing rules (no language model was needed)."
+        );
+        assert_eq!(
+            humanize_rationale("fallback-brain: prefix-routed"),
+            "Chosen by Simard's built-in routing rules (no language model was needed)."
+        );
+        assert_eq!(
+            humanize_rationale("deterministic-brain: no LLM configured"),
+            "Used the built-in rules because no language model is configured."
+        );
+    }
+
+    #[test]
+    fn humanize_rationale_strips_brain_prefix_and_passes_prose() {
+        // Unknown "<x>-brain:" markers get the machine prefix stripped and
+        // shorthand expanded; no raw "*-brain:" / "prefix-routed" token leaks.
+        let out = humanize_rationale("orient-brain: prefix-routed");
+        assert!(!out.contains("-brain:"), "leaked machine prefix: {out}");
+        assert!(!out.contains("prefix-routed"), "leaked shorthand: {out}");
+        // Plain-English rationale (already human) passes through unchanged.
+        assert_eq!(
+            humanize_rationale("llm-brain: high-leverage progress"),
+            "high-leverage progress"
+        );
+        assert_eq!(humanize_rationale(""), "");
+    }
+
+    #[test]
+    fn fallback_description_is_plain_and_jargon_free() {
+        let d = fallback_description("decide", "consolidate_memory", Some(0.5));
+        assert_eq!(
+            d,
+            "The decide phase used its built-in safety rules instead of the language model. \
+             It chose to consolidate memory. The rules were 50% confident in that choice."
+        );
+        // No machine jargon survives.
+        for banned in [
+            "deterministic fallback",
+            "language model brain",
+            "consolidate_memory",
+        ] {
+            assert!(
+                !d.contains(banned),
+                "description leaked jargon {banned:?}: {d}"
+            );
+        }
+    }
+
+    #[test]
+    fn fallback_description_omits_absent_confidence_and_empty_decision() {
+        // Absent confidence must NOT render as a real "0%".
+        let d = fallback_description("orient", "", None);
+        assert_eq!(
+            d,
+            "The orient phase used its built-in safety rules instead of the language model."
+        );
+        assert!(
+            !d.contains('%'),
+            "absent confidence must not show a percentage: {d}"
+        );
+        assert!(
+            !d.contains("It chose to"),
+            "empty decision must omit the choice clause: {d}"
+        );
     }
 }

--- a/src/operator_commands_dashboard/index_html/part_01.rs
+++ b/src/operator_commands_dashboard/index_html/part_01.rs
@@ -178,6 +178,26 @@ pub(crate) const PART_01: &str = r#"      </div>
       for(const j of (BANNED_JARGON||[])){if(j)s=s.split(j).join('');}
       return s.replace(/\s{2,}/g,' ').trim();
     }
+    // P3 (#2358): render a raw second count as a human duration, e.g.
+    // 37440s -> "10h 24m", 624m worth of seconds -> "10h 24m", 90s -> "1m".
+    function humanizeDuration(secs){
+      let s=Math.round(Number(secs)||0);
+      if(s<=0)return'0m';
+      if(s<60)return s+'s';
+      const m=Math.floor(s/60);
+      if(m<60)return m+'m';
+      const h=Math.floor(m/60),rm=m%60;
+      if(h<24)return rm?h+'h '+rm+'m':h+'h';
+      const days=Math.floor(h/24),rh=h%24;
+      return rh?days+'d '+rh+'h':days+'d';
+    }
+    // P3 (#2358): turn a bare 0-1 urgency float into a qualitative phrase with
+    // an explicit scale, e.g. 0.50 -> "medium urgency (0.50 of 1.0)".
+    function urgencyPhrase(u){
+      const n=(typeof u==='number'&&isFinite(u))?u:0;
+      const word=n>0.7?'high':n>0.4?'medium':'low';
+      return word+' urgency ('+n.toFixed(2)+' of 1.0)';
+    }
     function copyLogContent(id){
       const el=document.getElementById(id);if(!el)return;
       navigator.clipboard.writeText(el.textContent||'').then(
@@ -354,7 +374,7 @@ pub(crate) const PART_01: &str = r#"      </div>
           const rpt=c.report||{};
           if(rpt.priorities?.length){
             const top=rpt.priorities[0];
-            currentFocus=`<strong>${esc(humanizeGoalId(top.goal_id))}</strong> — ${esc(top.reason)} <span style="color:${top.urgency>0.7?'var(--red)':top.urgency>0.4?'var(--yellow)':'var(--green)'}">urgency ${top.urgency.toFixed(2)}</span>`;
+            currentFocus=`<strong>${esc(humanizeGoalId(top.goal_id))}</strong> — ${esc(top.reason)} <span style="color:${top.urgency>0.7?'var(--red)':top.urgency>0.4?'var(--yellow)':'var(--green)'}">${urgencyPhrase(top.urgency)}</span>`;
             break;
           }
         }

--- a/src/operator_commands_dashboard/index_html/part_03.rs
+++ b/src/operator_commands_dashboard/index_html/part_03.rs
@@ -235,8 +235,8 @@ pub(crate) const PART_03: &str = r#"        const d=await apiFetch('/api/goals')
             {key:'working',label:'Working',color:'#f0883e'},
             {key:'sensory',label:'Sensory',color:'#8b949e'},
           ];
-          const intervalMin=Math.round((dl.interval_secs||0)/60);
-          const intervalLabel=intervalMin>0?' ('+intervalMin+'m)':'';
+          const intervalSecs=dl.interval_secs||0;
+          const intervalLabel=intervalSecs>0?' ('+humanizeDuration(intervalSecs)+')':'';
           deltasEl.innerHTML=cats.map(c=>{
             const v=dl[c.key]||0;
             const sign=v>0?'+':'';

--- a/src/operator_commands_dashboard/index_html/part_04.rs
+++ b/src/operator_commands_dashboard/index_html/part_04.rs
@@ -234,7 +234,7 @@ pub(crate) const PART_04: &str = r#"            let fmt;
               <div class="phase-content">
                 ${rpt.priorities.map(p=>`<div class="priority-line">
                   <span class="urgency" style="color:${p.urgency>0.7?'var(--red)':p.urgency>0.4?'var(--yellow)':'var(--green)'}">●</span>
-                  <strong>${esc(humanizeGoalId(p.goal_id))}</strong> (urgency: ${p.urgency.toFixed(2)}) — ${esc(p.reason)}
+                  <strong>${esc(humanizeGoalId(p.goal_id))}</strong> · ${urgencyPhrase(p.urgency)} — ${esc(p.reason)}
                 </div>`).join('')}
               </div>
             </div>`);

--- a/src/operator_commands_dashboard/index_html/tests_tab_meta.rs
+++ b/src/operator_commands_dashboard/index_html/tests_tab_meta.rs
@@ -439,3 +439,33 @@ fn rendered_html_defines_token_humanizers() {
         );
     }
 }
+
+#[test]
+fn rendered_html_humanizes_p3_units_and_scales() {
+    // #2358 P3: durations and bare-float urgency scores must be humanized.
+    for needle in [
+        "function humanizeDuration(",
+        "function urgencyPhrase(",
+        "humanizeDuration(intervalSecs)",
+        "urgencyPhrase(top.urgency)",
+        "urgencyPhrase(p.urgency)",
+    ] {
+        assert!(
+            INDEX_HTML.contains(needle),
+            "rendered HTML missing P3 humanizer wiring: {needle}"
+        );
+    }
+    // The bare-minute interval label and bare urgency floats must be gone.
+    assert!(
+        !INDEX_HTML.contains("intervalMin"),
+        "memory growth interval still renders a bare minute count"
+    );
+    assert!(
+        !INDEX_HTML.contains("urgency ${top.urgency.toFixed(2)}"),
+        "Overview still renders a bare unexplained urgency float"
+    );
+    assert!(
+        !INDEX_HTML.contains("(urgency: ${p.urgency.toFixed(2)})"),
+        "Thinking priorities still render a bare unexplained urgency float"
+    );
+}

--- a/tests/gadugi/dashboard-p3-units-and-scales.sh
+++ b/tests/gadugi/dashboard-p3-units-and-scales.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# dashboard-p3-units-and-scales.sh — outside-in check for issue #2358 (P3).
+#
+# The live Playwright audit found unfriendly units and unexplained raw numbers
+# that survived the P1/P2 humanization landed by #2373:
+#
+#   * Memory growth interval rendered a bare minute count: "since prev sample
+#     (624m)" instead of a human duration like "10h 24m".
+#   * Bare 0-1 urgency floats with no scale: "urgency 0.50" (Overview) and
+#     "(urgency: 0.50)" (Thinking priorities).
+#   * Brain Failures surfaced machine shorthand: "deterministic-brain:
+#     prefix-routed" and a bare "Decision: consolidate_memory (confidence: 50%)".
+#
+# This script boots the real dashboard binary, logs in, and asserts — against
+# the served HTML and the live /api/brain-failures response — that the P3 fixes
+# are present and the bare/jargon forms are gone.
+set -euo pipefail
+
+PORT="${DASH_PORT:-8147}"
+DASHKEY_FILE="${HOME}/.simard/.dashkey"
+LOG="$(mktemp -t dash-p3.XXXXXX.log)"
+CJ="$(mktemp -t dash-p3-cookies.XXXXXX)"
+
+echo "[p3] building simard binary…"
+cargo build --quiet --bin simard
+BIN="${CARGO_TARGET_DIR:-target}/debug/simard"
+if [[ ! -x "$BIN" ]]; then
+  echo "[p3] FAIL: built binary not found at $BIN" >&2
+  exit 1
+fi
+
+echo "[p3] starting dashboard on :$PORT"
+"$BIN" dashboard serve --port="$PORT" >"$LOG" 2>&1 &
+DASH_PID=$!
+cleanup() { kill "$DASH_PID" 2>/dev/null || true; rm -f "$CJ"; }
+trap cleanup EXIT
+
+up=0
+for _ in $(seq 1 30); do
+  if curl -s -o /dev/null "http://localhost:$PORT/login"; then up=1; break; fi
+  sleep 1
+done
+if [[ "$up" -ne 1 ]]; then
+  echo "[p3] FAIL: dashboard did not come up on :$PORT" >&2
+  cat "$LOG" >&2
+  exit 1
+fi
+
+KEY="$(cat "$DASHKEY_FILE")"
+if ! curl -s -c "$CJ" -X POST -H 'Content-Type: application/json' \
+      -d "{\"code\":\"$KEY\"}" "http://localhost:$PORT/api/login" | grep -q '"ok":true'; then
+  echo "[p3] FAIL: login rejected" >&2
+  exit 1
+fi
+
+HTML="$(curl -s -b "$CJ" "http://localhost:$PORT/")"
+BRAIN="$(curl -s -b "$CJ" "http://localhost:$PORT/api/brain-failures")"
+
+fail() { echo "[p3] FAIL: $1" >&2; exit 1; }
+
+# ── P3: memory growth interval is a human duration, not a bare minute count ──
+grep -qF 'function humanizeDuration(' <<<"$HTML" \
+  || fail "humanizeDuration must be defined so durations render as e.g. '10h 24m'"
+grep -qF 'humanizeDuration(intervalSecs)' <<<"$HTML" \
+  || fail "Memory growth interval must render via humanizeDuration"
+grep -qF 'intervalMin' <<<"$HTML" \
+  && fail "Memory growth interval still renders a bare minute count (intervalMin)"
+
+# ── P3: urgency floats carry a qualitative word and an explicit 0-1 scale ────
+grep -qF 'function urgencyPhrase(' <<<"$HTML" \
+  || fail "urgencyPhrase must be defined so urgency scores explain their scale"
+grep -qF 'urgencyPhrase(top.urgency)' <<<"$HTML" \
+  || fail "Overview current focus must render urgency via urgencyPhrase"
+grep -qF 'urgencyPhrase(p.urgency)' <<<"$HTML" \
+  || fail "Thinking priorities must render urgency via urgencyPhrase"
+grep -qF 'urgency ${top.urgency.toFixed(2)}' <<<"$HTML" \
+  && fail "Overview still renders a bare unexplained urgency float"
+grep -qF '(urgency: ${p.urgency.toFixed(2)})' <<<"$HTML" \
+  && fail "Thinking priorities still render a bare unexplained urgency float"
+
+# ── P3: Brain Failures never leak machine shorthand to the operator ──────────
+grep -qF 'deterministic-brain: prefix-routed' <<<"$BRAIN" \
+  && fail "Brain Failures rationale still leaks 'deterministic-brain: prefix-routed'"
+grep -qF 'fallback-brain: prefix-routed' <<<"$BRAIN" \
+  && fail "Brain Failures rationale still leaks 'fallback-brain: prefix-routed'"
+
+echo "[p3] PASS: dashboard P3 unit/number humanization holds (#2358 P3)"

--- a/tests/gadugi/dashboard-p3-units-and-scales.yaml
+++ b/tests/gadugi/dashboard-p3-units-and-scales.yaml
@@ -1,0 +1,52 @@
+name: "Dashboard P3 Units & Scales (#2358)"
+description: "Outside-in operator check that the dashboard's P3 usability fixes from issue #2358 hold: the Memory growth interval renders a human duration (humanizeDuration) instead of a bare minute count, the Overview and Thinking urgency scores carry a qualitative word and an explicit 0-1 scale (urgencyPhrase) instead of a bare float, and the Brain Failures view never leaks machine shorthand like 'deterministic-brain: prefix-routed'. Boots the real dashboard binary, authenticates, and asserts the served HTML and the live /api/brain-failures response."
+version: "1.0.0"
+
+config:
+  timeout: 300000
+  retries: 0
+  parallel: false
+
+environment:
+  requires: []
+
+agents:
+  - name: "cli-agent"
+    type: "cli"
+    config:
+      workingDirectory: "."
+      defaultTimeout: 300000
+      executionMode: "spawn"
+      captureOutput: true
+      ioConfig:
+        encoding: "utf8"
+        handleInteractivePrompts: false
+      logConfig:
+        logCommands: true
+        logOutput: true
+        logLevel: "info"
+
+steps:
+  - name: "Dashboard humanizes units, scales and brain-failure shorthand"
+    agent: "cli-agent"
+    action: "execute_command"
+    params:
+      command: "tests/gadugi/dashboard-p3-units-and-scales.sh"
+    timeout: 300000
+
+assertions: []
+
+cleanup:
+  - name: "CLI agent cleanup"
+    agent: "cli-agent"
+    action: "cleanup"
+
+metadata:
+  tags:
+    - "dashboard"
+    - "usability"
+    - "jargon"
+    - "issue-2358"
+  priority: "high"
+  author: "copilot"
+  test_type: "outside-in"


### PR DESCRIPTION
## What & why

Closes out the remaining **P3** items of the evidence-backed #2358 usability backlog. The **P1/P2** items already landed in merged **#2373**; this PR is scoped to the residual P3 unit/number/jargon humanization (confirmed as the only non-`[deploy]` backlog in the issue author's latest comment). All changes are **render-layer only** — the canonical rationale/decision strings in `ooda_brain` are deliberately unchanged so logs, persistence and the `ooda_brain` tests stay green.

### P3 fixes (verbatim issue item → fix)

| #2358 P3 item | Before (live) | After (this PR, live) |
|---|---|---|
| Memory growth interval `since prev sample (624m)` | `since prev sample (624m)` | **`since prev sample (10h 24m)`** via new JS `humanizeDuration` |
| Overview bare urgency float | `urgency 0.50` | **`medium urgency (0.50 of 1.0)`** via new JS `urgencyPhrase` (qualitative word + explicit 0–1 scale) |
| Thinking priorities bare urgency float | `(urgency: 0.50)` | **`· medium urgency (0.50 of 1.0)`** |
| Brain Failures decision/confidence | `Decision: consolidate_memory (confidence: 50%)` | **`It chose to consolidate memory. The rules were 50% confident in that choice.`** (decision token de-jargoned; confidence shown only when actually recorded) |
| Brain Failures rationale | `deterministic-brain: prefix-routed` | **`Chosen by Simard's built-in routing rules (no language model was needed).`** |

`urgencyPhrase`'s word thresholds (`>0.7`/`>0.4`) match the existing colour thresholds, so badge colour and text always agree, and it is null/NaN-safe — replacing the prior `.toFixed(2)` that would *throw* on a non-numeric `urgency`. The brain-failures description also drops the insider phrases "deterministic fallback"/"language model brain", and an **absent** confidence no longer renders as a real "0%".

### Files
- `src/operator_commands_dashboard/index_html/part_01.rs` — new `humanizeDuration` + `urgencyPhrase` helpers; Overview current-focus rewired.
- `src/operator_commands_dashboard/index_html/part_03.rs` — Memory growth interval uses `humanizeDuration`.
- `src/operator_commands_dashboard/index_html/part_04.rs` — Thinking priorities use `urgencyPhrase`.
- `src/operator_commands_dashboard/brain_failures.rs` — `/api/brain-failures` display: `humanize_decision`, `fallback_description`, `humanize_rationale` + unit tests.
- `src/operator_commands_dashboard/index_html/tests_tab_meta.rs` — INDEX_HTML cross-check that the new helpers are wired and old bare patterns are gone.
- `tests/gadugi/dashboard-p3-units-and-scales.{yaml,sh}` — new outside-in scenario.

---

## Merge-ready evidence

**1. qa-team / gadugi scenarios — written, validated, run.**
- New outside-in scenario `tests/gadugi/dashboard-p3-units-and-scales.{yaml,sh}` boots the real binary, authenticates with `~/.simard/.dashkey`, and asserts the served HTML (`humanizeDuration`/`urgencyPhrase` wired, bare patterns gone) + the live `/api/brain-failures` response (no `deterministic-brain: prefix-routed` / `fallback-brain: prefix-routed` leak).
- `gadugi-test validate -f tests/gadugi/dashboard-p3-units-and-scales.yaml` → `✓ Scenario "Dashboard P3 Units & Scales (#2358)" is valid`.
- `gadugi-test run -d tests/gadugi -s dashboard-p3-units-and-scales` → `✓ Passed: 1 / ✗ Failed: 0`.
- Regression: `gadugi-test run -d tests/gadugi -s dashboard-jargon-clarity` (the #2373 scenario) → `✓ Passed: 1 / ✗ Failed: 0`.

**Live Playwright (Chromium headless) re-verification** against a freshly-built binary (non-`:8080` port; the live `:8080` daemon was **not** touched — see `[deploy]` below), `page.evaluate` of the new helpers and a live `/api/brain-failures` read over **50 real failures**:
```
humanizeDuration(37440)            => "10h 24m"
humanizeDuration(3600)             => "1h"
humanizeDuration(90000)            => "1d 1h"
urgencyPhrase(0.50)                => "medium urgency (0.50 of 1.0)"
urgencyPhrase(0.85)                => "high urgency (0.85 of 1.0)"
urgencyPhrase(0.20)                => "low urgency (0.20 of 1.0)"
brain_failures: 50 failures, raw-marker leaks = []
sample description => "The decide phase used its built-in safety rules instead of the language model. It chose to consolidate memory. The rules were 50% confident in that choice."
sample rationale   => "Chosen by Simard's built-in routing rules (no language model was needed)."
```

**2. Docs / changed user-facing surfaces.**
The changed surfaces are operator-dashboard panel copy (Memory growth interval, Overview/Thinking urgency, Brain Failures description + rationale). These strings are the change itself; no `docs/` file quotes them (`docs/dashboard.md` carries only generic one-line tab descriptions), so no separate docs file needs updating. The new helpers are locked into the served HTML by the `tests_tab_meta::rendered_html_humanizes_p3_units_and_scales` cross-check.

**3. quality-audit — 3 SEEK→VALIDATE→FIX cycles, clean final.**
- **Cycle 1 (code-review + security-review):** both found **no blocking issues**. Security confirmed `humanizeDuration`/`urgencyPhrase` can only emit digits + fixed words/punctuation (no HTML metacharacters) into their innerHTML sinks, `f.description`/`f.rationale` remain `esc()`-wrapped, the raw `decision` token is never rendered, and the Rust helpers have no panic path. Both noted the change *hardens* the prior `.toFixed` throw-risk.
- **Cycle 2 (rubber-duck, anti-sycophancy):** no blockers; raised 3 valid clarity findings → **fixed**: (a) dropped insider "deterministic fallback"/"language model brain" jargon from the description, (b) removed the redundant "(out of 100%)", (c) absent confidence now omits the figure instead of reading as a real "0%". Refactored the inline description into a unit-tested `fallback_description`.
- **Cycle 3 (re-validate):** `cargo fmt --all -- --check` ✓, `cargo clippy --all-targets --all-features --locked -- -D warnings` ✓, `cargo test --lib operator_commands_dashboard` = **359 passed / 0 failed** (incl. 6 new tests), both gadugi scenarios ✓, live Playwright audit ✓. Zero critical/high; zero medium correctness/security findings.

**4. CI.** Pre-flight green locally: `cargo fmt --all -- --check` ✓; `cargo clippy --all-targets --all-features --locked -- -D warnings` ✓; the `pre-commit` hook (rust-only gate + fmt + `clippy --release`) passed on commit; `pre-push` (fmt + `cargo test --release --lib (cognitive_memory|bootstrap|memory_ipc|memory_consolidation)`) passed on push. Awaiting full CI on this PR — will confirm 100% green before requesting merge.

**5.** This description carries concrete evidence for criteria 1–4 and 6.

**6. Focused diff.** 5 source files (4 dashboard render/handler + 1 test) + 2 new test-scenario files; no unrelated edits. Canonical `ooda_brain` strings untouched so logs/persistence and brain tests stay green.

---

Refs #2358 (P3). The **[deploy]** redeploy of the live `:8080` daemon remains intentionally **deferred** (an engineer is currently in flight; restarting the daemon would disrupt the active OODA cycle). **Do not merge yet** — opening for merge-gating review.
