### PR TITLE
fix(rustyclawd): wire memory+knowledge enrichment in production (#2383)

### DIFF
--- a/docs/reference/base-type-adapters.md
+++ b/docs/reference/base-type-adapters.md
@@ -119,11 +119,18 @@ The RustyClawd session backend. Supports both single-process and multi-process t
 | Memory enrichment | Yes — automatic per-turn via shared `enrich_input` (#1665) |
 | Knowledge enrichment | Yes — automatic per-turn via shared `enrich_input` (#1665) |
 
-> **Enrichment note (#1665):** Each `run_turn` routes the input through the
-> shared `BaseTypeSession::enrich_input` entry point before dispatching to the
-> RustyClawd client, so recalled memory facts/procedures and domain knowledge
-> are folded into the turn objective. Prior to #1665 only the Copilot adapter
-> enriched its turns; this adapter ran with empty memory/knowledge context.
+> **Enrichment note (#1665, #2383):** Each `run_turn` routes the input through
+> the shared `BaseTypeSession::enrich_input` entry point before dispatching to
+> the RustyClawd client, so recalled memory facts/procedures and domain
+> knowledge are injected into the turn's system prompt (the objective stays the
+> bare user message, keeping the conversation history clean). Prior to #1665
+> only the Copilot adapter enriched its turns. The entry point alone is not
+> enough, though: the session's `EnrichmentBridges` must also be **populated**.
+> Until #2383, `SessionBuilder`'s RustyClawd arm built sessions with empty
+> bridges, so production enrichment was a permanent no-op. The production path
+> now opts in via `RustyClawdAdapter::with_enrichment(default_state_root())`
+> (mirroring the Copilot wiring from #1664), so live RustyClawd turns recall
+> real memory + knowledge. See [Production wiring](#production-wiring-1664-2383).
 
 ### `copilot-sdk` — `CopilotSdkAdapter`
 
@@ -194,13 +201,41 @@ cannot silently diverge again:
 | Adapter | `enrich_input` exposed | Applied in `run_turn` |
 |---------|------------------------|-----------------------|
 | `copilot-sdk` | Yes | Yes (PTY and meeting paths) |
-| `rusty-clawd` | Yes | Yes (folded into the turn objective) |
+| `rusty-clawd` | Yes | Yes (injected into the system prompt; production bridges wired by #2383) |
 | `terminal-shell` (harness) | Yes | No — runs literal shell commands |
 | `claude-agent-sdk` / `ms-agent-framework` | Yes | No — `run_turn` is unimplemented |
 
 **Honest degradation:** If a configured bridge call fails during enrichment, the
 error propagates rather than silently degrading (PHILOSOPHY.md). A `None` bridge
 is not a failure — it simply yields an unenriched, objective-only prompt.
+
+### Production wiring (#1664, #2383)
+
+Exposing `enrich_input` (above) is necessary but **not sufficient** for
+production enrichment: a session only recalls memory + knowledge when its
+`EnrichmentBridges` are actually populated. Adapters that support production
+enrichment provide a `with_enrichment(state_root)` builder that, on
+`open_session`, launches the native cognitive-memory + knowledge bridges (with
+graceful degradation) via the shared `EnrichmentSource` policy in
+`base_type_turn`:
+
+- `EnrichmentSource::Disabled` (default) — empty bridges, no filesystem side
+  effects. This keeps lightweight callers and unit tests cheap.
+- `EnrichmentSource::Native { state_root }` — launches real bridges through the
+  single shared `launch_enrichment_bridges` helper (one launcher, no per-adapter
+  duplication). A launch failure logs and degrades that bridge to `None`.
+
+`SessionBuilder` opts both production adapters in by reading the default state
+root (shared with the OODA daemon when running):
+
+| Adapter | Production builder | Wired in `SessionBuilder` |
+|---------|--------------------|---------------------------|
+| `copilot-sdk` | `CopilotSdkAdapter::with_enrichment` | Yes — `with_enrichment(default_state_root())` (#1664) |
+| `rusty-clawd` | `RustyClawdAdapter::with_enrichment` | Yes — `with_enrichment(default_state_root())` (#2383) |
+
+Before #2383, RustyClawd had no `with_enrichment` builder and its
+`SessionBuilder` arm injected no bridges, so every production RustyClawd turn
+recalled nothing despite the #1665 entry point being wired through `run_turn`.
 
 ## Bootstrap Wiring
 

--- a/src/base_type_copilot/mod.rs
+++ b/src/base_type_copilot/mod.rs
@@ -13,15 +13,19 @@ use std::process::Command;
 
 use tempfile::NamedTempFile;
 
-use crate::base_type_turn::{EnrichmentBridges, TurnContext, format_turn_input, parse_turn_output};
+use crate::base_type_turn::{
+    EnrichmentBridges, EnrichmentSource, TurnContext, format_turn_input, parse_turn_output,
+};
 use crate::base_types::{
     BaseTypeCapability, BaseTypeDescriptor, BaseTypeFactory, BaseTypeId, BaseTypeOutcome,
     BaseTypeSession, BaseTypeSessionRequest, BaseTypeTurnInput, capability_set,
     ensure_session_not_already_open, ensure_session_not_closed, ensure_session_open,
 };
+#[cfg(test)]
 use crate::cognitive_memory::CognitiveMemoryOps;
 use crate::error::{SimardError, SimardResult};
 use crate::identity::OperatingMode;
+#[cfg(test)]
 use crate::knowledge_bridge::KnowledgeBridge;
 use crate::metadata::{BackendDescriptor, Freshness};
 use crate::runtime::RuntimeTopology;
@@ -55,31 +59,15 @@ impl Default for CopilotAdapterConfig {
     }
 }
 
-/// Where a [`CopilotSdkSession`] sources its memory + knowledge enrichment
-/// bridges.
-///
-/// The default is [`EnrichmentSource::Disabled`] so that lightweight callers
-/// and unit tests incur no filesystem side effects (opening a cognitive-memory
-/// store, launching native bridges). The live production path
-/// ([`crate::session_builder::SessionBuilder`]) opts in via
-/// [`CopilotSdkAdapter::with_enrichment`], wiring the same cognitive-memory
-/// store and native knowledge bridge the rest of the runtime uses so each
-/// Copilot turn is enriched with relevant memory facts, procedures, and
-/// domain knowledge (issue #1664).
-#[derive(Clone, Debug, Default)]
-enum EnrichmentSource {
-    /// No enrichment bridges. `prepare_turn_context` runs with `None`/`None`,
-    /// emitting only the `## Objective` section.
-    #[default]
-    Disabled,
-    /// Launch the native cognitive-memory + knowledge bridges lazily on
-    /// `open_session`, reading memory from `state_root`. A launch failure logs
-    /// and degrades that bridge to `None` (never panics).
-    Native { state_root: PathBuf },
-}
-
 /// A base type factory that creates sessions driving `amplihack copilot`
 /// through the PTY infrastructure with memory and knowledge enrichment.
+///
+/// Enrichment is sourced via the shared [`EnrichmentSource`] policy
+/// ([`crate::base_type_turn`]): [`EnrichmentSource::Disabled`] by default so
+/// lightweight callers and unit tests incur no filesystem side effects, and
+/// [`EnrichmentSource::Native`] (opted into via [`CopilotSdkAdapter::with_enrichment`])
+/// for the live production path, wiring the same cognitive-memory store and
+/// native knowledge bridge the rest of the runtime uses (issue #1664).
 #[derive(Debug)]
 pub struct CopilotSdkAdapter {
     descriptor: BaseTypeDescriptor,
@@ -139,7 +127,7 @@ impl CopilotSdkAdapter {
     /// Bridges are launched lazily in [`BaseTypeFactory::open_session`]; a
     /// launch failure logs and degrades to `None` so a missing knowledge pack
     /// or an unavailable memory store never breaks turn dispatch (see
-    /// [`launch_enrichment_bridges`]).
+    /// [`crate::base_type_turn::launch_enrichment_bridges`]).
     #[must_use]
     pub fn with_enrichment(mut self, state_root: PathBuf) -> Self {
         self.enrichment = EnrichmentSource::Native { state_root };
@@ -160,20 +148,18 @@ impl CopilotSdkAdapter {
 
         // Issue #1664: wire real memory + knowledge bridges instead of the
         // previously-hardcoded `None`/`None`. When enrichment is configured
-        // the bridges are launched here (with graceful degradation) and stored
-        // in the normalized `EnrichmentBridges` bundle (issue #1665) so that
-        // the shared `enrich_input` entry point actually injects memory facts,
-        // procedures, and domain knowledge into every turn.
-        let (memory, knowledge) = match &self.enrichment {
-            EnrichmentSource::Disabled => (None, None),
-            EnrichmentSource::Native { state_root } => launch_enrichment_bridges(state_root),
-        };
+        // the bridges are launched here (with graceful degradation) via the
+        // shared [`EnrichmentSource::resolve`] and stored in the normalized
+        // `EnrichmentBridges` bundle (issue #1665) so that the shared
+        // `enrich_input` entry point actually injects memory facts, procedures,
+        // and domain knowledge into every turn.
+        let enrichment = self.enrichment.resolve();
 
         Ok(CopilotSdkSession {
             descriptor: self.descriptor.clone(),
             config: self.config.clone(),
             request,
-            enrichment: EnrichmentBridges { memory, knowledge },
+            enrichment,
             is_open: false,
             is_closed: false,
             turn_count: 0,
@@ -316,6 +302,15 @@ impl CopilotSdkSession {
     /// With no bridges configured (the production default until #1664 wires
     /// them through), `enrich_input` returns the input unchanged, so the output
     /// is byte-identical to the pre-#1665 Copilot prompt.
+    ///
+    /// Decision (issue #2383, MEDIUM observation): the current ordering folds
+    /// the recalled enrichment (carried in `prompt_preamble`) and identity
+    /// context ahead of the bare objective under a single `## Objective`
+    /// heading. This is intentionally kept as-is. It is well-formed, matches the
+    /// preamble→identity→objective layering every other adapter uses, and
+    /// reordering would alter the production prompt for every Copilot turn —
+    /// out of scope for the RustyClawd wiring fix and a model-behavior risk not
+    /// worth taking without evidence. KEEP.
     fn render_enriched_prompt(&self, input: &BaseTypeTurnInput) -> SimardResult<String> {
         let enriched = self.enrich_input(input)?;
 
@@ -708,45 +703,4 @@ fn validate_command(command: &str) -> SimardResult<()> {
         });
     }
     Ok(())
-}
-
-/// Launch the cognitive-memory and knowledge bridges that enrich each Copilot
-/// turn, degrading gracefully when either is unavailable.
-///
-/// Memory is obtained via [`crate::ooda_loop::connect_memory`] (the same
-/// IPC-aware connector recipe steps use, sharing the daemon's live store when
-/// one is running and otherwise opening the library-backed store directly).
-/// Knowledge uses the in-process native transport from
-/// [`crate::bridge_launcher::launch_knowledge_bridge_native`].
-///
-/// Mirrors the honest-degradation contract of
-/// [`crate::bridge_launcher::launch_all_bridges`]: a launch failure is logged
-/// and yields `None` for that bridge so turn dispatch proceeds without that
-/// enrichment rather than aborting. Neither failure path panics.
-fn launch_enrichment_bridges(
-    state_root: &Path,
-) -> (Option<Box<dyn CognitiveMemoryOps>>, Option<KnowledgeBridge>) {
-    let memory = match crate::ooda_loop::connect_memory(state_root) {
-        Ok(memory) => Some(memory),
-        Err(error) => {
-            eprintln!(
-                "[simard] copilot adapter: cognitive-memory bridge unavailable — memory \
-                 enrichment disabled for this session: {error}"
-            );
-            None
-        }
-    };
-
-    let knowledge = match crate::bridge_launcher::launch_knowledge_bridge_native() {
-        Ok(knowledge) => Some(knowledge),
-        Err(error) => {
-            eprintln!(
-                "[simard] copilot adapter: knowledge bridge unavailable — knowledge \
-                 enrichment disabled for this session: {error}"
-            );
-            None
-        }
-    };
-
-    (memory, knowledge)
 }

--- a/src/base_type_copilot/tests.rs
+++ b/src/base_type_copilot/tests.rs
@@ -906,9 +906,12 @@ fn build_copilot_terminal_objective_with_working_dir() {
 // None)` and the memory-facts / known-procedures / domain-knowledge prompt
 // blocks were never reached. These tests prove (1) that supplied bridges are
 // actually consumed, (2) that the absence of bridges still produces a valid
-// objective-only prompt, (3) that a supplied bridge whose query fails surfaces
-// the error rather than silently degrading, and (4) that the production
-// `launch_enrichment_bridges` helper wires real bridges and degrades cleanly.
+// objective-only prompt, and (3) that a supplied bridge whose query fails
+// surfaces the error rather than silently degrading. The production
+// `launch_enrichment_bridges` helper now lives in `base_type_turn` (shared with
+// the RustyClawd adapter, issue #2383); its real-bridge / degradation tests
+// live there alongside it, and `open_session_with_native_enrichment_*` below
+// still guards the Copilot factory seam.
 
 use super::CopilotSdkSession;
 use crate::bridge::BridgeErrorPayload;

--- a/src/base_type_copilot/tests.rs
+++ b/src/base_type_copilot/tests.rs
@@ -1073,47 +1073,6 @@ fn enrichment_query_failure_propagates_not_panics() {
     );
 }
 
-/// The production launch helper wires both real bridges when the state root
-/// can back a cognitive-memory store.
-#[test]
-#[serial_test::serial(cognitive_memory)]
-fn launch_enrichment_bridges_wires_real_bridges_for_valid_state_root() {
-    use tempfile::TempDir;
-    let tmp = TempDir::new().unwrap();
-    let state_root = tmp.path().join("state");
-    std::fs::create_dir_all(&state_root).unwrap();
-
-    let (memory, knowledge) = super::launch_enrichment_bridges(&state_root);
-    assert!(
-        memory.is_some(),
-        "cognitive-memory bridge must launch for a writable state_root"
-    );
-    assert!(
-        knowledge.is_some(),
-        "native knowledge bridge must launch in-process"
-    );
-}
-
-/// A state root that cannot back a store (a regular file) makes the memory
-/// launch fail; it must degrade to `None` without panicking, while the
-/// in-process knowledge bridge still launches.
-#[test]
-fn launch_enrichment_bridges_degrades_when_memory_unavailable() {
-    use tempfile::NamedTempFile;
-    // A regular file as `state_root` makes `<state_root>/cognitive` uncreatable.
-    let file = NamedTempFile::new().unwrap();
-
-    let (memory, knowledge) = super::launch_enrichment_bridges(file.path());
-    assert!(
-        memory.is_none(),
-        "memory bridge must degrade to None when the state_root cannot back a store"
-    );
-    assert!(
-        knowledge.is_some(),
-        "knowledge bridge must still launch when only memory is unavailable"
-    );
-}
-
 /// `open_session` (via `build_session`) must wire both bridges when the
 /// adapter has enrichment configured — the direct regression guard for the
 /// hardcoded-`None` defect of issue #1664 at the factory seam.

--- a/src/base_type_rustyclawd/adapter.rs
+++ b/src/base_type_rustyclawd/adapter.rs
@@ -1,4 +1,6 @@
-use crate::base_type_turn::EnrichmentBridges;
+use std::path::PathBuf;
+
+use crate::base_type_turn::EnrichmentSource;
 use crate::base_types::{
     BaseTypeDescriptor, BaseTypeFactory, BaseTypeId, BaseTypeSession, BaseTypeSessionRequest,
     standard_session_capabilities,
@@ -12,6 +14,13 @@ use super::session::RustyClawdSession;
 #[derive(Debug)]
 pub struct RustyClawdAdapter {
     pub(super) descriptor: BaseTypeDescriptor,
+    /// Where this adapter sources per-turn memory + knowledge enrichment.
+    ///
+    /// [`EnrichmentSource::Disabled`] by default so lightweight callers and
+    /// unit tests incur no filesystem side effects; the live production path
+    /// ([`crate::session_builder::SessionBuilder`]) opts in via
+    /// [`RustyClawdAdapter::with_enrichment`] (issue #2383).
+    enrichment: EnrichmentSource,
 }
 
 impl RustyClawdAdapter {
@@ -33,7 +42,29 @@ impl RustyClawdAdapter {
                 .into_iter()
                 .collect(),
             },
+            enrichment: EnrichmentSource::default(),
         })
+    }
+
+    /// Enable per-turn memory + knowledge enrichment for sessions opened by
+    /// this adapter, reading cognitive memory from `state_root`.
+    ///
+    /// Without this, sessions are created with both bridges set to `None` and
+    /// every turn runs through `enrich_input` with an empty
+    /// [`crate::base_type_turn::EnrichmentBridges`] — the no-op of issue #2383
+    /// that left RustyClawd recalling no memory facts/procedures or domain
+    /// knowledge in production even though the #1665 `enrich_input` entry point
+    /// was already wired through `run_turn`.
+    ///
+    /// Mirrors [`crate::base_type_copilot::CopilotSdkAdapter::with_enrichment`]:
+    /// bridges are launched lazily in [`BaseTypeFactory::open_session`] via the
+    /// shared [`EnrichmentSource::resolve`]; a launch failure logs and degrades
+    /// to `None` so a missing knowledge pack or an unavailable memory store
+    /// never breaks turn dispatch.
+    #[must_use]
+    pub fn with_enrichment(mut self, state_root: PathBuf) -> Self {
+        self.enrichment = EnrichmentSource::Native { state_root };
+        self
     }
 }
 
@@ -53,6 +84,11 @@ impl BaseTypeFactory for RustyClawdAdapter {
             });
         }
 
+        // Issue #2383: populate the session's enrichment bridges from the
+        // configured source (graceful degradation inside `resolve`) so the
+        // shared `enrich_input` entry point actually injects memory facts,
+        // procedures, and domain knowledge into every production turn — instead
+        // of the empty `EnrichmentBridges::new()` that made enrichment inert.
         Ok(Box::new(RustyClawdSession {
             descriptor: self.descriptor.clone(),
             request,
@@ -61,7 +97,7 @@ impl BaseTypeFactory for RustyClawdAdapter {
             client: None,
             rt: None,
             conversation_history: Vec::new(),
-            enrichment: EnrichmentBridges::new(),
+            enrichment: self.enrichment.resolve(),
         }))
     }
 }
@@ -306,6 +342,179 @@ mod tests {
         assert_eq!(
             session.descriptor().id.as_str(),
             adapter.descriptor().id.as_str()
+        );
+    }
+
+    // ── Issue #2383: production memory + knowledge enrichment wiring ──
+
+    fn enrichment_test_request() -> BaseTypeSessionRequest {
+        use crate::base_types::BaseTypeSessionRequest;
+        use crate::identity::OperatingMode;
+        use crate::runtime::{RuntimeAddress, RuntimeNodeId};
+        use crate::session::SessionId;
+
+        BaseTypeSessionRequest {
+            session_id: SessionId::from_uuid(uuid::Uuid::now_v7()),
+            mode: OperatingMode::Engineer,
+            topology: RuntimeTopology::SingleProcess,
+            prompt_assets: vec![],
+            runtime_node: RuntimeNodeId::new("test-node"),
+            mailbox_address: RuntimeAddress::new("test-addr"),
+        }
+    }
+
+    /// Mock memory bridge mirroring `tests/base_type_enrichment.rs`: returns a
+    /// single fact and procedure for any query so the rendered prompt is
+    /// deterministic.
+    fn mock_memory_bridge() -> Box<dyn crate::cognitive_memory::CognitiveMemoryOps> {
+        use crate::bridge::BridgeErrorPayload;
+        use crate::bridge_subprocess::InMemoryBridgeTransport;
+        use crate::memory_bridge::CognitiveMemoryBridge;
+        use serde_json::json;
+
+        let transport =
+            InMemoryBridgeTransport::new("rc-test-memory", |method, params| match method {
+                "memory.search_facts" => {
+                    let query = params.get("query").and_then(|v| v.as_str()).unwrap_or("");
+                    Ok(
+                        json!({"facts": [{"node_id": "sem_001", "concept": "testing",
+                    "content": format!("relevant fact about '{query}'"),
+                    "confidence": 0.85, "source_id": "src_1", "tags": ["test"]}]}),
+                    )
+                }
+                "memory.recall_procedure" => Ok(json!({"procedures": [{"node_id": "proc_001",
+                    "name": "build-and-test", "steps": ["cargo build", "cargo test"],
+                    "prerequisites": ["rust toolchain"], "usage_count": 5}]})),
+                "memory.search_episodes_by_keywords" => Ok(json!({"episodes": []})),
+                _ => Err(BridgeErrorPayload {
+                    code: -32601,
+                    message: format!("unknown method: {method}"),
+                }),
+            });
+        Box::new(CognitiveMemoryBridge::new(Box::new(transport)))
+    }
+
+    /// The production-wiring regression guard for issue #2383: a RustyClawd
+    /// session built through `with_enrichment` (the same seam `SessionBuilder`
+    /// uses) must have non-empty bridges, instead of the empty
+    /// `EnrichmentBridges::new()` that made enrichment a permanent no-op.
+    #[test]
+    #[serial_test::serial(cognitive_memory)]
+    fn production_session_with_enrichment_has_nonempty_bridges() {
+        use tempfile::TempDir;
+        let tmp = TempDir::new().unwrap();
+        let state_root = tmp.path().join("state");
+        std::fs::create_dir_all(&state_root).unwrap();
+
+        let session = RustyClawdAdapter::registered("rc-enrich")
+            .unwrap()
+            .with_enrichment(state_root)
+            .open_session(enrichment_test_request())
+            .expect("session must open with enrichment");
+
+        let bridges = session
+            .enrichment()
+            .expect("RustyClawd session must expose enrichment bridges");
+        assert!(
+            bridges.is_configured(),
+            "with_enrichment must populate the session's bridges (issue #2383)"
+        );
+        assert!(
+            bridges.memory.is_some(),
+            "open_session must wire the memory bridge when enrichment is Native"
+        );
+        assert!(
+            bridges.knowledge.is_some(),
+            "open_session must wire the knowledge bridge when enrichment is Native"
+        );
+    }
+
+    /// The default adapter (no `with_enrichment`) must leave both bridges `None`
+    /// so unit tests and lightweight callers incur no filesystem side effects.
+    #[test]
+    fn production_session_without_enrichment_has_empty_bridges() {
+        let session = RustyClawdAdapter::registered("rc-no-enrich")
+            .unwrap()
+            .open_session(enrichment_test_request())
+            .expect("session must open without enrichment");
+
+        let bridges = session
+            .enrichment()
+            .expect("RustyClawd session must expose enrichment bridges");
+        assert!(
+            !bridges.is_configured(),
+            "default adapter must not wire any enrichment bridge"
+        );
+        assert!(bridges.memory.is_none());
+        assert!(bridges.knowledge.is_none());
+    }
+
+    /// With a memory bridge injected, `enrich_input` must inject the rendered
+    /// `## Relevant Memory Facts` block into `prompt_preamble` while keeping the
+    /// objective bare — proving the wired bridges flow through the shared
+    /// `enrich_input` entry point for RustyClawd.
+    #[test]
+    fn enrich_input_injects_memory_facts_block_with_bridge() {
+        use crate::base_types::BaseTypeTurnInput;
+
+        let mut session = RustyClawdAdapter::registered("rc-enrich-input")
+            .unwrap()
+            .open_session(enrichment_test_request())
+            .unwrap();
+
+        session
+            .enrichment_mut()
+            .expect("RustyClawd must support enrichment injection")
+            .memory = Some(mock_memory_bridge());
+
+        let input = BaseTypeTurnInput::objective_only("implement error handling");
+        let enriched = session.enrich_input(&input).expect("enrich_input");
+
+        assert!(
+            enriched
+                .prompt_preamble
+                .contains("## Relevant Memory Facts"),
+            "enriched preamble must contain the memory facts block, got:\n{}",
+            enriched.prompt_preamble
+        );
+        assert!(
+            enriched.prompt_preamble.contains("[testing]"),
+            "enriched preamble must render the recalled fact concept"
+        );
+        assert!(
+            enriched
+                .prompt_preamble
+                .contains("relevant fact about 'implement error handling'"),
+            "enriched preamble must render the recalled fact content"
+        );
+        assert!(
+            enriched.prompt_preamble.contains("## Known Procedures"),
+            "enriched preamble must render recalled procedures"
+        );
+        // The objective stays bare so the conversation history stays clean.
+        assert_eq!(enriched.objective, "implement error handling");
+    }
+
+    /// Without a configured bridge, `enrich_input` is a no-op: the objective is
+    /// preserved and no memory block is fabricated.
+    #[test]
+    fn enrich_input_is_noop_without_bridge() {
+        use crate::base_types::BaseTypeTurnInput;
+
+        let session = RustyClawdAdapter::registered("rc-noop")
+            .unwrap()
+            .open_session(enrichment_test_request())
+            .unwrap();
+
+        let input = BaseTypeTurnInput::objective_only("implement error handling");
+        let enriched = session.enrich_input(&input).expect("enrich_input");
+
+        assert_eq!(enriched.objective, "implement error handling");
+        assert!(
+            !enriched
+                .prompt_preamble
+                .contains("## Relevant Memory Facts"),
+            "no bridge configured must not fabricate memory facts"
         );
     }
 }

--- a/src/base_type_rustyclawd/execution.rs
+++ b/src/base_type_rustyclawd/execution.rs
@@ -22,6 +22,13 @@ const DEFAULT_SYSTEM_PROMPT: &str =
 /// injected into `prompt_preamble`, so an otherwise-empty turn (no identity, no
 /// caller preamble) must still retain the default base prompt rather than being
 /// replaced by the bare enrichment block.
+///
+/// Decision (issue #2383, MEDIUM observation): the no-identity + non-empty
+/// preamble case intentionally renders `"{DEFAULT_SYSTEM_PROMPT}\n\n{preamble}"`
+/// (keeping the base prompt, dropping the dangling `---` the older form left
+/// behind). This is the correct, intended behavior — it was already adopted on
+/// `main` by #2361/#1665 and is pinned by the `system_prompt_*` tests below — so
+/// no change is made here.
 fn compose_system_prompt(prompt_preamble: &str, identity_context: &str) -> String {
     if identity_context.is_empty() {
         let base = DEFAULT_SYSTEM_PROMPT.trim();

--- a/src/base_type_turn.rs
+++ b/src/base_type_turn.rs
@@ -10,6 +10,7 @@
 //! 3. **Parse** — extract structured [`TurnOutput`] from raw LLM text output.
 
 use std::fmt::Write;
+use std::path::{Path, PathBuf};
 
 use crate::base_types::BaseTypeTurnInput;
 use crate::cognitive_memory::CognitiveMemoryOps;
@@ -230,6 +231,95 @@ impl std::fmt::Debug for EnrichmentBridges {
             .field("knowledge", &self.knowledge.is_some())
             .finish()
     }
+}
+
+/// Where a base-type session sources its memory + knowledge enrichment bridges.
+///
+/// The default is [`EnrichmentSource::Disabled`] so that lightweight callers and
+/// unit tests incur no filesystem side effects (opening a cognitive-memory
+/// store, launching native bridges). The live production path
+/// ([`crate::session_builder::SessionBuilder`]) opts in via each adapter's
+/// `with_enrichment` builder, wiring the same cognitive-memory store and native
+/// knowledge bridge the rest of the runtime uses so each turn is enriched with
+/// relevant memory facts, procedures, and domain knowledge.
+///
+/// This is the single, shared home for the enrichment-source policy used by
+/// every adapter that supports production enrichment (Copilot — issue #1664;
+/// RustyClawd — issue #2383). Centralizing it here keeps the launch + degrade
+/// behavior identical across adapters instead of being duplicated per adapter.
+#[derive(Clone, Debug, Default)]
+pub enum EnrichmentSource {
+    /// No enrichment bridges. [`EnrichmentSource::resolve`] yields an empty
+    /// [`EnrichmentBridges`], so `enrich_input` returns the input unchanged and
+    /// only the `## Objective` section is emitted.
+    #[default]
+    Disabled,
+    /// Launch the native cognitive-memory + knowledge bridges lazily (on
+    /// `open_session`), reading memory from `state_root`. A launch failure logs
+    /// and degrades that bridge to `None` (never panics).
+    Native { state_root: PathBuf },
+}
+
+impl EnrichmentSource {
+    /// Resolve this source into concrete [`EnrichmentBridges`].
+    ///
+    /// [`EnrichmentSource::Disabled`] yields an empty bundle (no side effects).
+    /// [`EnrichmentSource::Native`] launches the native cognitive-memory +
+    /// knowledge bridges via [`launch_enrichment_bridges`], degrading any
+    /// unavailable bridge to `None` without panicking.
+    pub fn resolve(&self) -> EnrichmentBridges {
+        match self {
+            EnrichmentSource::Disabled => EnrichmentBridges::new(),
+            EnrichmentSource::Native { state_root } => {
+                let (memory, knowledge) = launch_enrichment_bridges(state_root);
+                EnrichmentBridges { memory, knowledge }
+            }
+        }
+    }
+}
+
+/// Launch the cognitive-memory and knowledge bridges that enrich each turn,
+/// degrading gracefully when either is unavailable.
+///
+/// Memory is obtained via [`crate::ooda_loop::connect_memory`] (the same
+/// IPC-aware connector recipe steps use, sharing the daemon's live store when
+/// one is running and otherwise opening the library-backed store directly).
+/// Knowledge uses the in-process native transport from
+/// [`crate::bridge_launcher::launch_knowledge_bridge_native`].
+///
+/// Mirrors the honest-degradation contract of
+/// [`crate::bridge_launcher::launch_all_bridges`]: a launch failure is logged
+/// and yields `None` for that bridge so turn dispatch proceeds without that
+/// enrichment rather than aborting. Neither failure path panics.
+///
+/// Shared by every adapter that supports production enrichment (Copilot —
+/// issue #1664; RustyClawd — issue #2383) so the launcher exists exactly once.
+pub fn launch_enrichment_bridges(
+    state_root: &Path,
+) -> (Option<Box<dyn CognitiveMemoryOps>>, Option<KnowledgeBridge>) {
+    let memory = match crate::ooda_loop::connect_memory(state_root) {
+        Ok(memory) => Some(memory),
+        Err(error) => {
+            eprintln!(
+                "[simard] base-type adapter: cognitive-memory bridge unavailable — memory \
+                 enrichment disabled for this session: {error}"
+            );
+            None
+        }
+    };
+
+    let knowledge = match crate::bridge_launcher::launch_knowledge_bridge_native() {
+        Ok(knowledge) => Some(knowledge),
+        Err(error) => {
+            eprintln!(
+                "[simard] base-type adapter: knowledge bridge unavailable — knowledge \
+                 enrichment disabled for this session: {error}"
+            );
+            None
+        }
+    };
+
+    (memory, knowledge)
 }
 
 /// Enrich a turn input with recalled memory facts/procedures and domain
@@ -538,5 +628,79 @@ CONFIDENCE: 0.85";
         assert!(debug.contains("EnrichmentBridges"));
         assert!(debug.contains("memory: false"));
         assert!(debug.contains("knowledge: false"));
+    }
+
+    // ── EnrichmentSource / launch_enrichment_bridges ────────────────
+
+    #[test]
+    fn enrichment_source_default_is_disabled() {
+        let source = EnrichmentSource::default();
+        assert!(matches!(source, EnrichmentSource::Disabled));
+        // Disabled resolves to an empty, unconfigured bundle (no side effects).
+        let bridges = source.resolve();
+        assert!(!bridges.is_configured());
+    }
+
+    /// The production launch helper wires both real bridges when the state root
+    /// can back a cognitive-memory store. Shared by Copilot (#1664) and
+    /// RustyClawd (#2383); lives with the launcher it exercises.
+    #[test]
+    #[serial_test::serial(cognitive_memory)]
+    fn launch_enrichment_bridges_wires_real_bridges_for_valid_state_root() {
+        use tempfile::TempDir;
+        let tmp = TempDir::new().unwrap();
+        let state_root = tmp.path().join("state");
+        std::fs::create_dir_all(&state_root).unwrap();
+
+        let (memory, knowledge) = launch_enrichment_bridges(&state_root);
+        assert!(
+            memory.is_some(),
+            "cognitive-memory bridge must launch for a writable state_root"
+        );
+        assert!(
+            knowledge.is_some(),
+            "native knowledge bridge must launch in-process"
+        );
+    }
+
+    /// `EnrichmentSource::Native` resolves into a fully-configured bundle for a
+    /// writable state root — the policy seam shared by every production adapter.
+    #[test]
+    #[serial_test::serial(cognitive_memory)]
+    fn enrichment_source_native_resolves_configured_bridges() {
+        use tempfile::TempDir;
+        let tmp = TempDir::new().unwrap();
+        let state_root = tmp.path().join("state");
+        std::fs::create_dir_all(&state_root).unwrap();
+
+        let bridges = EnrichmentSource::Native { state_root }.resolve();
+        assert!(
+            bridges.memory.is_some(),
+            "Native source must wire the memory bridge for a writable state_root"
+        );
+        assert!(
+            bridges.knowledge.is_some(),
+            "Native source must wire the knowledge bridge in-process"
+        );
+    }
+
+    /// A state root that cannot back a store (a regular file) makes the memory
+    /// launch fail; it must degrade to `None` without panicking, while the
+    /// in-process knowledge bridge still launches.
+    #[test]
+    fn launch_enrichment_bridges_degrades_when_memory_unavailable() {
+        use tempfile::NamedTempFile;
+        // A regular file as `state_root` makes `<state_root>/cognitive` uncreatable.
+        let file = NamedTempFile::new().unwrap();
+
+        let (memory, knowledge) = launch_enrichment_bridges(file.path());
+        assert!(
+            memory.is_none(),
+            "memory bridge must degrade to None when the state_root cannot back a store"
+        );
+        assert!(
+            knowledge.is_some(),
+            "knowledge bridge must still launch when only memory is unavailable"
+        );
     }
 }

--- a/src/session_builder.rs
+++ b/src/session_builder.rs
@@ -199,6 +199,32 @@ impl SessionBuilder {
             return Ok(Box::new(proxy));
         }
 
+        // Non-meeting: build the per-turn adapter session — with production
+        // memory + knowledge enrichment wired in — then open it. The build and
+        // open steps are separated so the enrichment wiring (which needs no
+        // auth) is testable without a live backend; see `build_enriched_session`.
+        let (mut session, adapter) = self.build_enriched_session()?;
+        session
+            .open()
+            .map_err(|e| format!("{adapter}::session.open: {e}"))?;
+        Ok(session)
+    }
+
+    /// Build the per-turn adapter session and populate its memory + knowledge
+    /// enrichment bridges, returning the **unopened** session plus the adapter
+    /// name (for diagnostics).
+    ///
+    /// `session.open()` is intentionally left to the caller because it requires
+    /// a live backend / credentials. The enrichment bridges, by contrast, are
+    /// wired here in `open_session` and need no auth — so this is the exact
+    /// production seam that regressed in #2383 (the `RustyClawd` arm built
+    /// sessions with empty bridges). The `*_provider_wires_enrichment_*` tests
+    /// assert against this method, so dropping a `with_enrichment` call is
+    /// caught without standing up a live backend.
+    ///
+    /// Not called for [`OperatingMode::Meeting`] — [`SessionBuilder::open`]
+    /// handles meeting mode via [`PersistentAgentProxy`] before reaching here.
+    fn build_enriched_session(self) -> Result<(Box<dyn BaseTypeSession>, &'static str), String> {
         // Inline request construction to move prompt_assets instead of cloning.
         let request = BaseTypeSessionRequest {
             session_id: SessionId::from_uuid(uuid::Uuid::now_v7()),
@@ -223,13 +249,10 @@ impl SessionBuilder {
                 let factory = CopilotSdkAdapter::registered(&tag)
                     .map_err(|e| format!("CopilotSdkAdapter::registered({}): {}", tag, e))?
                     .with_enrichment(crate::memory_ipc::default_state_root());
-                let mut session = factory
+                let session = factory
                     .open_session(request)
                     .map_err(|e| format!("CopilotSdkAdapter::open_session({}): {}", tag, e))?;
-                session
-                    .open()
-                    .map_err(|e| format!("CopilotSdkAdapter::session.open({}): {}", tag, e))?;
-                Ok(session)
+                Ok((session, "CopilotSdkAdapter"))
             }
             LlmProvider::RustyClawd => {
                 let tag = format!("{}-rustyclawd", self.adapter_tag);
@@ -246,13 +269,10 @@ impl SessionBuilder {
                 let factory = RustyClawdAdapter::registered(&tag)
                     .map_err(|e| format!("RustyClawdAdapter::registered({}): {}", tag, e))?
                     .with_enrichment(crate::memory_ipc::default_state_root());
-                let mut session = factory
+                let session = factory
                     .open_session(request)
                     .map_err(|e| format!("RustyClawdAdapter::open_session({}): {}", tag, e))?;
-                session
-                    .open()
-                    .map_err(|e| format!("RustyClawdAdapter::session.open({}): {}", tag, e))?;
-                Ok(session)
+                Ok((session, "RustyClawdAdapter"))
             }
         }
     }
@@ -336,5 +356,70 @@ mod tests {
     #[test]
     fn rustyclawd_agent_binary_value_returns_rustyclawd() {
         assert_eq!(LlmProvider::RustyClawd.agent_binary_value(), "rustyclawd");
+    }
+
+    // ------------------------------------------------------------------
+    // Production enrichment wiring through SessionBuilder (issue #2383)
+    //
+    // These assert against the exact production seam that regressed: the
+    // `with_enrichment(...)` call inside `SessionBuilder`'s provider arms.
+    // Deleting that call (the #2383 defect) drops both bridges to None, so
+    // `is_configured()` flips to false and these tests fail — unlike the
+    // adapter-level tests, which exercise the builder method directly and
+    // would stay green. `build_enriched_session` stops before the
+    // auth-requiring `session.open()`, so no live backend is needed.
+    // ------------------------------------------------------------------
+
+    #[test]
+    #[serial_test::serial(cognitive_memory)]
+    fn rustyclawd_provider_wires_enrichment_through_session_builder() {
+        // Hermetic: pin SIMARD_STATE_ROOT to a TempDir so `default_state_root()`
+        // (hardcoded inside `build_enriched_session`) resolves under temp_dir
+        // rather than $HOME/.simard — keeping cognitive-memory writes off the
+        // operator's live store and clear of the hermetic-test guard.
+        let _hermetic = crate::test_support::HermeticState::new();
+
+        let (session, adapter) =
+            SessionBuilder::new(OperatingMode::Engineer, LlmProvider::RustyClawd)
+                .node_id("test-node")
+                .address("test://local")
+                .adapter_tag("test-adapter")
+                .build_enriched_session()
+                .expect("build_enriched_session must succeed for RustyClawd");
+
+        assert_eq!(adapter, "RustyClawdAdapter");
+        let bridges = session
+            .enrichment()
+            .expect("RustyClawd session must expose enrichment bridges");
+        assert!(
+            bridges.is_configured(),
+            "SessionBuilder must wire memory + knowledge enrichment for the \
+             RustyClawd provider (issue #2383); empty bridges means the \
+             with_enrichment(...) call was dropped"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial(cognitive_memory)]
+    fn copilot_provider_wires_enrichment_through_session_builder() {
+        // Hermetic: see the RustyClawd variant above.
+        let _hermetic = crate::test_support::HermeticState::new();
+
+        let (session, adapter) = SessionBuilder::new(OperatingMode::Engineer, LlmProvider::Copilot)
+            .node_id("test-node")
+            .address("test://local")
+            .adapter_tag("test-adapter")
+            .build_enriched_session()
+            .expect("build_enriched_session must succeed for Copilot");
+
+        assert_eq!(adapter, "CopilotSdkAdapter");
+        let bridges = session
+            .enrichment()
+            .expect("Copilot session must expose enrichment bridges");
+        assert!(
+            bridges.is_configured(),
+            "SessionBuilder must wire memory + knowledge enrichment for the \
+             Copilot provider (issue #1664)"
+        );
     }
 }

--- a/src/session_builder.rs
+++ b/src/session_builder.rs
@@ -233,8 +233,19 @@ impl SessionBuilder {
             }
             LlmProvider::RustyClawd => {
                 let tag = format!("{}-rustyclawd", self.adapter_tag);
+                // Issue #2383: enable memory + knowledge enrichment on the
+                // RustyClawd production adapter, mirroring the Copilot path
+                // above (#1664). #1665 routed `RustyClawd::run_turn` through the
+                // shared `enrich_input` entry point, but production sessions
+                // were built with empty bridges, so enrichment was a permanent
+                // no-op. Wiring `with_enrichment` here populates the bridges so
+                // each turn recalls relevant memory facts, procedures, and
+                // domain knowledge. Reads from the default state root (shared
+                // with the OODA daemon when running); a bridge launch failure
+                // degrades gracefully to no enrichment.
                 let factory = RustyClawdAdapter::registered(&tag)
-                    .map_err(|e| format!("RustyClawdAdapter::registered({}): {}", tag, e))?;
+                    .map_err(|e| format!("RustyClawdAdapter::registered({}): {}", tag, e))?
+                    .with_enrichment(crate::memory_ipc::default_state_root());
                 let mut session = factory
                     .open_session(request)
                     .map_err(|e| format!("RustyClawdAdapter::open_session({}): {}", tag, e))?;

--- a/tests/base_type_enrichment.rs
+++ b/tests/base_type_enrichment.rs
@@ -196,10 +196,11 @@ fn enrichment_is_noop_without_configured_bridge() {
 /// empty bridges, so enrichment was inert in production.
 ///
 /// This drives both production-wired adapters through their `with_enrichment`
-/// builders (the same seam `SessionBuilder` uses) against a real, writable
-/// state root and asserts they launch identical, non-empty memory + knowledge
-/// bridges — the parity that must hold so RustyClawd cannot silently regress to
-/// no-enrichment again.
+/// builders against a real, writable state root and asserts they launch
+/// identical, non-empty memory + knowledge bridges — the parity that must hold
+/// so RustyClawd cannot silently regress to no-enrichment again. The
+/// `SessionBuilder`-level seam itself (the line that actually regressed) is
+/// covered by `session_builder`'s `*_provider_wires_enrichment_*` tests.
 #[test]
 #[serial_test::serial(cognitive_memory)]
 fn production_wiring_launches_bridges_for_builder_adapters() {

--- a/tests/base_type_enrichment.rs
+++ b/tests/base_type_enrichment.rs
@@ -185,3 +185,60 @@ fn enrichment_is_noop_without_configured_bridge() {
         );
     }
 }
+
+/// Production-wiring parity gate (issue #2383).
+///
+/// The cross-adapter tests above inject a *mock* bridge through
+/// `enrichment_mut`, which proves `enrich_input` consumes bridges but not that
+/// the production factory seam (`with_enrichment` + `open_session`) actually
+/// launches them. Before #2383 only `CopilotSdkAdapter` exposed
+/// `with_enrichment`; RustyClawd's `SessionBuilder` arm built sessions with
+/// empty bridges, so enrichment was inert in production.
+///
+/// This drives both production-wired adapters through their `with_enrichment`
+/// builders (the same seam `SessionBuilder` uses) against a real, writable
+/// state root and asserts they launch identical, non-empty memory + knowledge
+/// bridges — the parity that must hold so RustyClawd cannot silently regress to
+/// no-enrichment again.
+#[test]
+#[serial_test::serial(cognitive_memory)]
+fn production_wiring_launches_bridges_for_builder_adapters() {
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    let tmp = TempDir::new().unwrap();
+    let state_root = tmp.path().join("state");
+    std::fs::create_dir_all(&state_root).unwrap();
+
+    fn assert_wired(name: &str, session: &dyn BaseTypeSession) {
+        let bridges = session
+            .enrichment()
+            .unwrap_or_else(|| panic!("adapter '{name}' must expose enrichment bridges"));
+        assert!(
+            bridges.memory.is_some(),
+            "adapter '{name}' production wiring must launch the memory bridge"
+        );
+        assert!(
+            bridges.knowledge.is_some(),
+            "adapter '{name}' production wiring must launch the knowledge bridge"
+        );
+    }
+
+    let build = |state_root: PathBuf| -> Vec<(&'static str, Box<dyn BaseTypeSession>)> {
+        let copilot = CopilotSdkAdapter::registered("copilot-sdk")
+            .unwrap()
+            .with_enrichment(state_root.clone())
+            .open_session(test_request())
+            .unwrap();
+        let rustyclawd = RustyClawdAdapter::registered("rusty-clawd")
+            .unwrap()
+            .with_enrichment(state_root)
+            .open_session(test_request())
+            .unwrap();
+        vec![("copilot-sdk", copilot), ("rusty-clawd", rustyclawd)]
+    };
+
+    for (name, session) in build(state_root) {
+        assert_wired(name, session.as_ref());
+    }
+}

--- a/tests/gadugi/adapter-enrichment-parity.yaml
+++ b/tests/gadugi/adapter-enrichment-parity.yaml
@@ -92,6 +92,20 @@ steps:
       outputContains:
         - "test enrichment_is_noop_without_configured_bridge ... ok"
 
+  - name: "Production wiring launches non-empty bridges for builder adapters (Copilot + RustyClawd, #2383)"
+    agent: "test-agent"
+    action: "execute_command"
+    params:
+      command: >
+        cargo test --test base_type_enrichment
+        production_wiring_launches_bridges_for_builder_adapters
+        -- --nocapture --test-threads=1
+    timeout: 180000
+    expect:
+      exitCode: 0
+      outputContains:
+        - "test production_wiring_launches_bridges_for_builder_adapters ... ok"
+
   - name: "Shared enrich_turn_input / render_enrichment_block unit coverage"
     agent: "test-agent"
     action: "execute_command"
@@ -121,6 +135,7 @@ metadata:
     - "knowledge-enrichment"
     - "regression"
     - "issue-1665"
+    - "issue-2383"
   priority: "high"
   author: "copilot"
   test_type: "outside-in"

--- a/tests/qa-scenarios/rustyclawd-memory-knowledge-enrichment.yaml
+++ b/tests/qa-scenarios/rustyclawd-memory-knowledge-enrichment.yaml
@@ -1,0 +1,39 @@
+name: rustyclawd-memory-knowledge-enrichment
+app_type: cli
+description: |
+  Validates issue #2383: the RustyClawdAdapter now wires real memory + knowledge
+  bridges in production instead of constructing every session with an empty
+  EnrichmentBridges. #1665 routed RustyClawd::run_turn through the shared
+  enrich_input entry point, but SessionBuilder's RustyClawd arm never injected
+  bridges, so enrichment was a permanent no-op for the primary production
+  adapter. Each step shells out to the relevant tests; a non-zero cargo exit
+  fails the step. Green means:
+  - a RustyClawd session built via with_enrichment (the SessionBuilder seam)
+    has non-empty memory + knowledge bridges
+  - the default adapter (no with_enrichment) leaves both bridges None
+  - enrich_input injects the rendered "## Relevant Memory Facts" block into the
+    turn's prompt_preamble while keeping the objective bare
+  - enrichment is a no-op when no bridge is configured (no fabricated facts)
+  - the cross-adapter production-wiring parity gate holds: Copilot and RustyClawd
+    launch identical, non-empty bridges through their with_enrichment builders
+  - existing RustyClawd session-creation behaviour is unregressed
+agents:
+  - name: cargo
+    type: cli
+    command: cargo
+steps:
+  - action: run
+    params:
+      command: cargo
+      args: ["test", "--lib", "base_type_rustyclawd::adapter::tests", "--", "--test-threads=1"]
+    timeout: 300000
+  - action: run
+    params:
+      command: cargo
+      args: ["test", "--test", "base_type_enrichment", "production_wiring_launches_bridges_for_builder_adapters", "--", "--test-threads=1"]
+    timeout: 300000
+  - action: run
+    params:
+      command: cargo
+      args: ["test", "--lib", "base_type_turn::tests::enrichment_source"]
+    timeout: 300000


### PR DESCRIPTION
## Summary

Closes #2383.

`#1665` added the normalized `BaseTypeSession::enrich_input` entry point and routed `RustyClawd::run_turn` through it, but the **bridges were never populated for RustyClawd in production**, so enrichment was a permanent no-op there: `SessionBuilder`'s `RustyClawd` arm injected no bridges and `RustyClawdAdapter` had no `with_enrichment` builder. RustyClawd recalled **no** memory facts/procedures or domain knowledge for any production turn — the exact "silently runs without enrichment" defect #1665 set out to eliminate, still present for this adapter.

This PR mirrors the #1664 Copilot wiring for RustyClawd, sharing a single launcher.

### Worktree note
The engineer worktree started 44 commits behind `main` (predating #1664/#1665). It was fast-forwarded to `main` (`266aff9d`) so this PR's diff is exactly the RustyClawd wiring.

## Changes

1. **Shared enrichment source (no duplication).** Promoted `EnrichmentSource` + `launch_enrichment_bridges` from `base_type_copilot` into shared `base_type_turn`, adding `EnrichmentSource::resolve()`. There is now **one** launcher used by every production adapter; its log text is adapter-agnostic. Copilot now resolves via `self.enrichment.resolve()`.
2. **RustyClawd production wiring.** `RustyClawdAdapter` gained an `EnrichmentSource` field + `with_enrichment(state_root)` builder; `open_session` populates the session's `EnrichmentBridges` via `resolve()` (graceful degradation preserved).
3. **SessionBuilder.** Refactored `open()` to extract `build_enriched_session()` (factory + `with_enrichment` + `open_session`, returning the unopened session). The `LlmProvider::RustyClawd` arm now calls `.with_enrichment(crate::memory_ipc::default_state_root())`, exactly like the Copilot path.
4. **Tests.** RustyClawd production session has non-empty bridges; `enrich_input` injects a `## Relevant Memory Facts` block; no-op when disabled. Added `SessionBuilder`-level regression tests (`{rustyclawd,copilot}_provider_wires_enrichment_through_session_builder`) that drive the exact regressed seam and assert `enrichment().is_configured()` (hermetic via `HermeticState`). Extended the cross-adapter parity gate (`tests/base_type_enrichment.rs`) with a production-wiring test proving Copilot + RustyClawd launch identical, non-empty bridges. Launcher unit tests moved alongside the launcher.
5. **Decisions on the two MEDIUM observations** (acceptance criterion: decision recorded):
   - `compose_system_prompt` `---` change: **already resolved on `main`** by #2361/#1665 (keeps `DEFAULT_SYSTEM_PROMPT`, drops the dangling `---`); pinned by the `system_prompt_*` tests. Intended — no change. (Documented at `src/base_type_rustyclawd/execution.rs`.)
   - `render_enriched_prompt` ordering (Copilot): **KEEP** current preamble→identity→objective order. Out of scope for the RustyClawd wiring fix and a model-behavior risk not worth taking without evidence. (Documented at `src/base_type_copilot/mod.rs`.)

## Merge-ready evidence

### 1. QA scenarios (written, validated, run)
- New `tests/qa-scenarios/rustyclawd-memory-knowledge-enrichment.yaml`; new step in `tests/gadugi/adapter-enrichment-parity.yaml`.
- `gadugi-test validate -f ...` — both **valid**.
- `gadugi-test run` —
  - gadugi parity scenario (6 steps incl. `production_wiring_launches_bridges_for_builder_adapters`): `✓ Passed: 1 / ✗ Failed: 0`.
  - rustyclawd qa-scenario: `✓ Passed: 1 / ✗ Failed: 0`.

### 2. Docs
- `docs/reference/base-type-adapters.md`: corrected the RustyClawd enrichment note (entry point ≠ populated bridges) and added a **Production wiring (#1664, #2383)** section + table.

### 3. quality-audit — 3 SEEK→VALIDATE→FIX cycles, clean final
- **Cycle 1 (MEDIUM, fixed in `b513d128`):** regression tests exercised the adapter builder directly, not `SessionBuilder::open()` — the exact line that regressed; deleting `.with_enrichment(...)` would have kept all tests green. Fix: extracted `build_enriched_session()` and added `SessionBuilder`-seam tests asserting `enrichment().is_configured()`.
- **Cycle 2 (HIGH, fixed in `b513d128`):** those `SessionBuilder` tests used the hardcoded `default_state_root()` → panicked via the hermetic guard on a no-daemon machine and mutated the operator's live store when a daemon existed. Fix: wrapped both in `test_support::HermeticState::new()` (pins `SIMARD_STATE_ROOT` to a TempDir, unsets `SIMARD_MEMORY_SOCKET`); verified hermetic under a throwaway `$HOME`.
- **Cycle 3 (clean, `bdb6993d`):** verification pass — **zero CRITICAL/HIGH, zero MEDIUM correctness/security**. Only a stale test-module comment (from relocating the launcher tests) was corrected.

### 4. CI — 100% green
All checks pass on the pushed tip (`bdb6993d`), 0 failures: `verify` (pre-commit/full clippy+tests `✓ 12m23s`, cargo-audit, install-real `✓`, e2e-dashboard), `coverage ✓`, GitGuardian ✓.
Run: https://github.com/rysweet/Simard/actions/runs/28066740120

### 6. Diff focused
- 11 files, all on the enrichment-wiring path; no unrelated edits.

## Local validation
- `cargo fmt --all -- --check` ✓
- `cargo clippy --all-targets --all-features --locked -- -D warnings` ✓ (and `--release --no-deps`)
- `cargo test --lib` ✓ **5793 passed, 0 failed** (plus the new SessionBuilder + adapter + shared-module tests)
- `cargo test --test base_type_enrichment` ✓ 5 passed (incl. new production-wiring parity test)
- pre-commit + pre-push hooks ✓
