### PR TITLE
chore(deps): upgrade LadybugDB engine lbug 0.15.4 → 0.17.1 (coordinated #100 migration)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 [[package]]
 name = "amplihack-memory"
 version = "0.4.0"
-source = "git+https://github.com/rysweet/amplihack-memory-lib.git?rev=285de92b9895a6fba6b53b6be3c4c99134a2d0f6#285de92b9895a6fba6b53b6be3c4c99134a2d0f6"
+source = "git+https://github.com/rysweet/amplihack-memory-lib.git?rev=b5e1dac54e2df984565fa01d2a5c22a829d2d317#b5e1dac54e2df984565fa01d2a5c22a829d2d317"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -2089,14 +2089,15 @@ dependencies = [
 
 [[package]]
 name = "lbug"
-version = "0.15.4"
-source = "git+https://github.com/rysweet/lbug-patched?rev=82da662e917ba44d43392f70e0a7a721b48e09b3#82da662e917ba44d43392f70e0a7a721b48e09b3"
+version = "0.17.1"
+source = "git+https://github.com/rysweet/lbug-patched?rev=1ce0c37dbdb98f998f7ea243fa617899c9d0531b#1ce0c37dbdb98f998f7ea243fa617899c9d0531b"
 dependencies = [
  "cmake",
  "cxx",
  "cxx-build",
  "rust_decimal",
  "rustversion",
+ "serde_json",
  "time",
  "uuid",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 [[package]]
 name = "amplihack-memory"
 version = "0.4.0"
-source = "git+https://github.com/rysweet/amplihack-memory-lib.git?rev=b5e1dac54e2df984565fa01d2a5c22a829d2d317#b5e1dac54e2df984565fa01d2a5c22a829d2d317"
+source = "git+https://github.com/rysweet/amplihack-memory-lib.git?rev=09998af6b925602feeba439095ac4601785b36d5#09998af6b925602feeba439095ac4601785b36d5"
 dependencies = [
  "chrono",
  "dirs 5.0.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,9 +54,9 @@ path = "src/bin/simard_tui/main.rs"
 # bumps the persistent backend lbug 0.15.4 -> 0.17.1. lbug 0.17.x reads the live
 # v40 on-disk store in place (canReadStorageVersion(40) == true), upgrading to
 # v41 on the first checkpoint, so the cognitive store is NOT lost across the
-# binary swap. NOTE: re-pin this rev to the squash-merge SHA once
-# amplihack-memory-lib PR #105 lands on main.
-amplihack-memory = { git = "https://github.com/rysweet/amplihack-memory-lib.git", rev = "b5e1dac54e2df984565fa01d2a5c22a829d2d317", features = ["persistent"] }
+# binary swap. Pinned to the squash-merge SHA of amplihack-memory-lib PR #105
+# (merged to main as 09998af6).
+amplihack-memory = { git = "https://github.com/rysweet/amplihack-memory-lib.git", rev = "09998af6b925602feeba439095ac4601785b36d5", features = ["persistent"] }
 rustyclawd-core = { git = "https://github.com/rysweet/RustyClawd.git", rev = "43ebaa1c1b18a5630c53f0519989a2bacd42ef62" }
 rustyclawd-tools = { git = "https://github.com/rysweet/RustyClawd.git", rev = "43ebaa1c1b18a5630c53f0519989a2bacd42ef62" }
 # De-fork (issue #2323): the gym/eval RUNNER is now the upstream

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,8 +48,15 @@ path = "src/bin/simard_tui/main.rs"
 # backend. `cognitive_memory::library_adapter::LibraryCognitiveMemory` drives it
 # behind Simard's `CognitiveMemoryOps` trait; the native LadybugDB fork has been
 # deleted. The `persistent` feature builds LadybugDB through the published
-# `lbug = "=0.15.4"` crate.
-amplihack-memory = { git = "https://github.com/rysweet/amplihack-memory-lib.git", rev = "285de92b9895a6fba6b53b6be3c4c99134a2d0f6", features = ["persistent"] }
+# `lbug = "=0.17.1"` crate.
+#
+# Engine upgrade (issue #100): pinned to the amplihack-memory-lib commit that
+# bumps the persistent backend lbug 0.15.4 -> 0.17.1. lbug 0.17.x reads the live
+# v40 on-disk store in place (canReadStorageVersion(40) == true), upgrading to
+# v41 on the first checkpoint, so the cognitive store is NOT lost across the
+# binary swap. NOTE: re-pin this rev to the squash-merge SHA once
+# amplihack-memory-lib PR #105 lands on main.
+amplihack-memory = { git = "https://github.com/rysweet/amplihack-memory-lib.git", rev = "b5e1dac54e2df984565fa01d2a5c22a829d2d317", features = ["persistent"] }
 rustyclawd-core = { git = "https://github.com/rysweet/RustyClawd.git", rev = "43ebaa1c1b18a5630c53f0519989a2bacd42ef62" }
 rustyclawd-tools = { git = "https://github.com/rysweet/RustyClawd.git", rev = "43ebaa1c1b18a5630c53f0519989a2bacd42ef62" }
 # De-fork (issue #2323): the gym/eval RUNNER is now the upstream
@@ -64,7 +71,7 @@ amplihack-agent-eval = { git = "https://github.com/rysweet/amplihack-rs.git", re
 # (`src/bin/simard_tui/goals.rs`), which opens a LadybugDB read-only to render
 # the goal board. The cognitive-memory backend itself no longer uses lbug
 # directly — it goes through the amplihack-memory library.
-lbug = "=0.15.4"
+lbug = "=0.17.1"
 rusqlite = { version = "=0.31.0", features = ["bundled"] }
 serde = { version = "=1.0.228", features = ["derive"] }
 serde_json = "=1.0.149"
@@ -155,10 +162,14 @@ strip = "debuginfo"
 debug = false
 
 # CSR getGroup OOB SIGSEGV fix (LadybugDB #611 / amplihack-memory #100): pin the
-# `lbug` engine to a patched build of 0.15.4 so the crash fix is part of EVERY
-# Simard build (lbug 0.15.4 always compiles its bundled lbug-src from source, so
-# this patched bundled source is what gets linked). Version-matched to 0.15.4 to
-# avoid an on-disk store-format migration. Remove once the fix lands in an
-# upstream lbug release and the dep is bumped.
+# `lbug` engine to a patched build of 0.17.1 so the crash fix is part of EVERY
+# Simard build. This `[patch.crates-io]` overrides lbug for the WHOLE dependency
+# graph, including the transitive amplihack-memory dependency, so both the direct
+# `simard-tui` lbug and the persistent GraphStore link this single patched 0.17.1
+# engine (compiled from the bundled lbug-src, so the C++ bounds-check is linked).
+# Version-matched to 0.17.1 to stay compatible with amplihack-memory's
+# `lbug = "=0.17.1"` pin. lbug 0.17.x reads the v40 store format in place, so this
+# bump carries no on-disk store-format migration risk. Remove once the fix lands
+# in an upstream lbug release and the dep is bumped.
 [patch.crates-io]
-lbug = { git = "https://github.com/rysweet/lbug-patched", rev = "82da662e917ba44d43392f70e0a7a721b48e09b3" }
+lbug = { git = "https://github.com/rysweet/lbug-patched", rev = "1ce0c37dbdb98f998f7ea243fa617899c9d0531b" }


### PR DESCRIPTION
## Summary
**PR #2 of 2** in the coordinated `lbug 0.15.4 → 0.17.1` engine upgrade.
PR #1 is amplihack-memory-lib [rysweet/amplihack-memory-lib#105](https://github.com/rysweet/amplihack-memory-lib/pull/105).

Three coordinated dependency changes in `Cargo.toml` (+ `Cargo.lock`):

| Dep | From | To |
| --- | --- | --- |
| `lbug` (direct; simard-tui goal board) | `=0.15.4` | `=0.17.1` |
| `amplihack-memory` (git rev) | `285de92b` | `b5e1dac` (lib's 0.17.1 commit) |
| `[patch.crates-io] lbug` | `lbug-patched@82da662e` (0.15.4) | `lbug-patched@1ce0c37` (0.17.1) |

The `[patch.crates-io]` overrides `lbug` for the **whole** dependency graph, so
both the direct `simard-tui` lbug and the transitive `amplihack-memory`
persistent `GraphStore` link **one** patched 0.17.1 engine (`cargo tree -i lbug`
shows a single version).

## CSR SIGSEGV fix retained (LadybugDB #611 / amplihack-memory #100)
The patched crate `rysweet/lbug-patched@v0.17.1-csr-fix` re-applies the
`getGroup(UINT32_MAX)` bounds-check to the 0.17.1 engine and:
- **Forces a from-source compile** (0.17.x otherwise downloads an *unpatched*
  prebuilt archive), so the C++ bounds-check is in every Simard build.
- **Links only the self-contained `liblbug.a`** (whole-archive), fixing a
  from-source duplicate-symbol link error (antlr4 objects were in both
  `liblbug.a` and the separate third-party archives).

## No data loss
lbug 0.17.x reads the live **v40** on-disk store in place
(`canReadStorageVersion(40) == true`), upgrading to **v41** on the first
checkpoint, so `~/.simard/cognitive` survives the binary swap. The additive
0.15.4 → 0.17.1 binding delta (`Value::Json`, …) is non-breaking — Simard's only
direct `lbug::Value` match (`simard_tui/goals.rs`) already has a `_ =>` arm.
Full migration reference: `amplihack-memory/docs/lbug_0_17_upgrade.md` (in PR #1).

## Validation (local)
- `cargo build` + `cargo build --bin simard --locked` — clean
- `cargo clippy --all-targets` — clean; **pre-push** `cargo clippy --all-targets
  --all-features --locked -- -D warnings` — **passed**
- **pre-commit + pre-push hooks all green** (incl. `cargo clippy --release` and
  `cargo test --release --lib` cognitive_memory/bootstrap/memory_ipc/memory_consolidation)
- 85 cognitive_memory/goal lib tests + cross-session/procedure/episodic recall
  integration tests — green on the patched 0.17.1 engine
- Exactly one `lbug v0.17.1` in the dependency graph

## ⚠️ Merge ordering
Land **after** amplihack-memory-lib PR #105 merges, then **re-pin** the
`amplihack-memory` rev from `b5e1dac` (PR #105 branch HEAD) to the squash-merge
SHA on `main`. The `lbug-patched` `v0.17.1-csr-fix` branch should also be merged
/ tagged so the patch ref is permanent.

> Deploy is out of scope (handled separately). The live-store upgrade runbook is
> in `amplihack-memory/docs/lbug_0_17_upgrade.md`.

🤖 Generated with GitHub Copilot CLI

---
**Update (2026-06-24T00:29Z):** amplihack-memory-lib PR #105 **MERGED** to main as `09998af6`. This branch re-pinned `amplihack-memory` rev `b5e1dac` → `09998af6` (commit `abe6c6a4`); dep tree byte-identical (`cargo metadata --locked --offline` clean). Awaiting CI on the re-pinned head before merge.