### PR TITLE
feat(ooda): make Simard proactive, reflective, and loop-aware via prompts (#2403)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ scripts/dashboard_audit/out/
 tests/e2e-dashboard/.audit-output/
 .simard/bin/simard.bak.*
 .local/
+
+# mkdocs build output
+/site/

--- a/docs/concepts/ooda-loop-self-detection.md
+++ b/docs/concepts/ooda-loop-self-detection.md
@@ -1,0 +1,132 @@
+---
+title: OODA loop self-detection, reflectiveness, and proactivity
+description: How Simard reasons about whether she is making real progress or spinning in a loop, breaks the loop by changing strategy, keeps open-ended goals bounded, and proactively pulls fresh work — all via prompt-asset content, no Rust changes.
+last_updated: 2026-06-25
+review_schedule: as-needed
+owner: simard
+doc_type: concept
+related:
+  - ./prompt-driven-ooda-brain.md
+  - ../howto/unblock-stuck-ooda-goals.md
+  - ../howto/edit-the-ooda-brain-prompt.md
+  - ../reference/ooda-decide-prompt.md
+---
+
+# OODA loop self-detection, reflectiveness, and proactivity
+
+Simard's autonomous OODA daemon advances one goal per cycle. Without a sense of
+its own recent history it can fall into a **productive-looking loop**: every
+cycle it re-triages the same pull requests, finds nothing new to do, re-records
+the same completion percentage, and repeats — making zero shippable progress
+while *looking* busy. This is distinct from the brain-failure lockout described
+in [Unblock OODA goals stuck after a brain-failure
+lockout](../howto/unblock-stuck-ooda-goals.md): the brain here is "healthy" and
+confidently emitting `advance_goal`; the problem is that the *content* of each
+cycle never changes.
+
+This document describes the prompt-level design that makes Simard **reflective**
+(judging whether a cycle produced real progress), **loop-aware** (noticing when
+she is repeating herself), and **proactive** (pulling fresh work instead of
+idling). It is implemented entirely in the prompt assets under
+`prompt_assets/simard/` — there are **no Rust logic changes**, and the prompt
+content hot-reloads onto the live daemon.
+
+## The loop in one picture
+
+```
+observe ─► orient ─► decide ─► advance goal ─► "triage the PRs"
+   ▲                                                 │
+   └─────────  nothing new shipped; 99% recorded  ◄──┘   (repeat forever)
+```
+
+The fix is to insert an explicit **"am I looping?"** judgment before the goal
+action defaults to triage, and to give the supporting brains and the goal
+curator the vocabulary to recognise and escalate stalled, open-ended goals.
+
+## Progress signals vs. non-progress
+
+Every reflective check uses the same definition of progress, so the brains agree
+on what "moving" means.
+
+| Real progress (at least one, since last cycle) | Not progress (no matter how busy it feels) |
+|---|---|
+| A new commit SHA on a goal branch | Re-triaging / re-reviewing the same PRs, finding nothing new |
+| A PR opened, substantively updated, or merged | Re-reading the same issue or goal description |
+| An issue closed | Re-reinforcing the same procedure |
+| A completion-% increase **backed by a shipped artifact** | Re-recording the same completion-% (e.g. parked at 99%) with no new artifact |
+
+## Where each behavior lives
+
+The behaviors are spread across the prompts that already drive each OODA phase,
+so each brain enforces the part it is best positioned to see. The legacy
+embedded `*.md` copies (served by `PromptStore`) and the live recipe YAMLs under
+`prompt_assets/simard/recipes/` are kept in lock-step.
+
+| Behavior | Prompt asset(s) | What changed |
+|---|---|---|
+| **Loop self-detection + change strategy** | `goal_session_objective.md` | A leading "are you making progress, or looping?" section makes the goal-action brain reason over its recalled episodes/procedures before triaging, and pick a *different* action when stuck. |
+| **Execute over triage** | `goal_session_objective.md` | The Priority Order triage is reframed as a **quick first pass, not a perpetual gate**; new implementation work is no longer deferred indefinitely. |
+| **Churn vs. progress at the engineer site** | `ooda_brain.md`, `recipes/ooda-engineer-lifecycle.yaml` | The engineer-lifecycle brain treats a high `consecutive_skip_count` with no new artifact as a stuck loop and prefers `deprioritize` / `open_tracking_issue` (existing variants — no new output kinds). |
+| **Surface loops while routing** | `ooda_decide.md`, `recipes/ooda-decide.yaml` | The decide brain still routes to `advance_goal` (kind unchanged) but names the suspected loop in its rationale so the goal-action re-scopes. |
+| **Open-ended goal escalation** | `progress_assessment_reviewer.md`, `recipes/progress-assessment.yaml` | A re-asserted high percent with only re-triage in the plan and no new artifact is **rejected** as stalled, pushing decompose/complete/demote instead of an indefinite 99%. |
+| **Open-ended goal hygiene + proactivity** | `goal_curator_system.md` | Unbounded goals must be expressed as concrete, completable sub-goals with `done-when` criteria; when the board has room and the backlog is empty, the curator proactively proposes work from Simard's own open GitHub issues rather than idling. |
+
+## Breaking the loop: the three strategies
+
+When the goal-action brain detects a loop it must choose a **different** next
+action and express it through one of the existing two response shapes (spawn an
+engineer, or `NO ACTION` with a note/`PROGRESS:` update):
+
+1. **Decompose and execute.** Open-ended goals (no natural 100% — e.g. "increase
+   test coverage across the ecosystem") are carved into one concrete, completable
+   sub-goal with an explicit done-criterion, then an engineer is spawned to
+   actually write the tests/code and open the PR. The bias is toward **shipping**,
+   not more triage.
+2. **Complete or retire.** If no further bounded progress is possible, the goal
+   is recorded complete (`PROGRESS: 100` with a note) or demotion is recommended —
+   never parked at 99% forever.
+3. **Pull fresh concrete work.** When active goals are under the cap and the
+   backlog is empty, a specific open GitHub issue Simard owns is proposed as a new
+   concrete goal. Operator gating still governs promotion to active, so Simard
+   **proposes** rather than silently spins.
+
+## Output contracts are unchanged
+
+This is deliberately a content-only change. Every wire contract the Rust parsers
+depend on is preserved:
+
+- `goal_session_objective.md` — **prose only** (no JSON, no code fences); the
+  `Priority Order` section still precedes `Two response shapes`.
+- `ooda_decide.md` / `recipes/ooda-decide.yaml` — the action keyword is still the
+  routed kind (`advance_goal` for ordinary goals); loop observations live in the
+  rationale.
+- `ooda_brain.md` / `recipes/ooda-engineer-lifecycle.yaml` — the six lifecycle
+  variants are unchanged; loops are broken with `deprioritize` /
+  `open_tracking_issue`.
+- `progress_assessment_reviewer.md` / `recipes/progress-assessment.yaml` — the
+  single-line `{"verdict": …}` JSON contract is unchanged; stalled goals simply
+  resolve to `reject`.
+
+Prompt-content tests in `src/ooda_brain/prompt_store_tests.rs` pin this wording
+so a future edit that drops the loop-detection guidance fails CI.
+
+## Known follow-ups (would need Rust)
+
+The prompt level can *reason about* and *recommend* these, but a few would be
+more robust with code (filed as follow-ups, not implemented here):
+
+- Feeding a structured per-goal **action-history digest** (last N actions +
+  measured progress deltas) into the Orient/Decide context, rather than relying
+  on recalled episodes.
+- A first-class **`decompose_goal`** action kind so the daemon can split an
+  open-ended goal automatically instead of asking the goal-action brain to do it
+  in prose.
+- Automatic **archival/demotion** of a goal that the progress reviewer has marked
+  stalled for K consecutive cycles.
+
+## See also
+
+- [Prompt-driven OODA brain](./prompt-driven-ooda-brain.md)
+- [How-to: unblock stuck OODA goals](../howto/unblock-stuck-ooda-goals.md)
+- [How-to: edit the OODA brain prompt](../howto/edit-the-ooda-brain-prompt.md)
+- [Reference: OODA decide prompt schema](../reference/ooda-decide-prompt.md)

--- a/docs/concepts/ooda-loop-self-detection.md
+++ b/docs/concepts/ooda-loop-self-detection.md
@@ -28,8 +28,13 @@ This document describes the prompt-level design that makes Simard **reflective**
 (judging whether a cycle produced real progress), **loop-aware** (noticing when
 she is repeating herself), and **proactive** (pulling fresh work instead of
 idling). It is implemented entirely in the prompt assets under
-`prompt_assets/simard/` — there are **no Rust logic changes**, and the prompt
-content hot-reloads onto the live daemon.
+`prompt_assets/simard/` — there are **no Rust logic changes**. Because
+`PromptStore` resolves each prompt from its on-disk override
+(`~/.simard/prompt_assets/simard/`) before falling back to the `include_str!`
+copy baked into the binary, the new content **hot-reloads onto the live daemon
+once the assets are synced to that directory** — no rebuild required. Until they
+are synced, the embedded fallback applies and the change lands on the next
+build/redeploy.
 
 ## The loop in one picture
 

--- a/docs/concepts/prompt-driven-ooda-brain.md
+++ b/docs/concepts/prompt-driven-ooda-brain.md
@@ -101,6 +101,7 @@ for the normative grammar of each format.
 
 ## See Also
 
+* [Concept: OODA loop self-detection, reflectiveness, and proactivity](./ooda-loop-self-detection.md) — how the engineer-lifecycle brain treats churn with no new artifact as a stuck loop
 * [How-to: spawn engineers from the OODA daemon](../howto/spawn-engineers-from-ooda-daemon.md)
 * [How-to: edit the OODA brain prompt](../howto/edit-the-ooda-brain-prompt.md)
 * [Reference: `OodaBrain` API](../reference/ooda-brain-api.md)

--- a/docs/howto/unblock-stuck-ooda-goals.md
+++ b/docs/howto/unblock-stuck-ooda-goals.md
@@ -10,6 +10,7 @@ related:
   - ./recover-goal-board.md
   - ./run-ooda-daemon.md
   - ./spawn-engineers-from-ooda-daemon.md
+  - ../concepts/ooda-loop-self-detection.md
 ---
 
 # Unblock OODA goals stuck after a brain-failure lockout
@@ -47,6 +48,55 @@ immediate manual override.
 > subordinate-blocked goals continue to short-circuit dispatch — they
 > are explicitly out of scope so the system never overrides intentional
 > operator holds.
+
+## A different stuck mode: spinning at a high completion-% (no lockout)
+
+Not every stuck daemon is locked out. A second failure mode looks *healthy* from
+the brain's perspective but ships nothing:
+
+- The board shows one goal `in-progress` parked at a high percent (e.g. 99%)
+  with an empty backlog.
+- The brain confidently emits `advance_goal` every cycle.
+- Each cycle re-triages the same PRs, finds nothing to merge, re-records the same
+  percent, and repeats. `~/.simard/cycle_reports/` shows actions "succeeding"
+  but no new commits, PRs, or merges accumulate.
+
+This is the **open-ended-goal loop**: a goal like "increase test coverage across
+the ecosystem" has no reachable 100%, so it never completes, never archives, and
+parks forever while real work stalls. As of issue #2403 the prompt assets make
+Simard reason about this herself — see [OODA loop self-detection,
+reflectiveness, and proactivity](../concepts/ooda-loop-self-detection.md) for the
+full design. The goal-action brain now:
+
+1. checks, before triaging, whether the last few cycles produced **real
+   progress** (new commit SHAs, opened/merged PRs, closed issues) versus mere
+   re-triage;
+2. on detecting a loop, **changes strategy** — decomposing the open-ended goal
+   into a concrete, completable sub-goal and executing it, completing/retiring
+   the goal, or proposing fresh work from Simard's own open issues; and
+3. lets the progress-assessment gate **reject** a re-asserted high percent that
+   has only re-triage behind it, nudging decompose/complete/demote.
+
+### What an operator can do
+
+Because the prompt content hot-reloads, no rebuild is needed — syncing
+`prompt_assets/simard/` to `~/.simard/prompt_assets/simard/` is enough. If a goal
+is still parked after the next few cycles, an operator can give it a concrete,
+bounded shape directly:
+
+```bash
+# Inspect the parked goal and its recorded percent.
+simard goal list
+
+# Demote the open-ended goal off the active board (it moves to the backlog),
+# or remove it entirely if no bounded progress remains.
+simard goal demote <goal-id>
+simard goal remove <goal-id>
+
+# Add a concrete, completable replacement at a chosen priority (1-7) so the
+# board stays at its active cap rather than idling on one stalled item.
+simard goal add <priority> "module X line coverage >= 80%, PR merged"
+```
 
 ## Manual recovery via the CLI
 

--- a/docs/reference/ooda-decide-prompt.md
+++ b/docs/reference/ooda-decide-prompt.md
@@ -249,5 +249,6 @@ construction.
 * [Reference: text-parsing wire formats](text-parsing-wire-formats.md) — normative grammar
 * [Reference: `OodaBrain` API](ooda-brain-api.md) — trait and type definitions
 * [Concept: text-based brain protocol](../concepts/text-based-brain-protocol.md) — design rationale
+* [Concept: OODA loop self-detection](../concepts/ooda-loop-self-detection.md) — why the decide rationale names a suspected loop while keeping `advance_goal`
 * [How-to: edit the OODA brain prompt](../howto/edit-the-ooda-brain-prompt.md) — editing guide
 * [How-to: diagnose decide/orient parse failures](../howto/diagnose-decide-orient-parse-failures.md) — operator runbook

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,6 +64,7 @@ nav:
     - Improvement context — denser execution evidence: concepts/improvement-context-execution-evidence-gap.md
     - Adaptive Scaling: concepts/adaptive-scaling.md
     - Pluggable Identity: concepts/pluggable-identity.md
+    - OODA Loop Self-Detection: concepts/ooda-loop-self-detection.md
   - Tutorials:
     - First Local Session: tutorials/run-your-first-local-session.md
     - First Benchmark Suite: tutorials/run-your-first-benchmark-gym.md

--- a/prompt_assets/simard/goal_curator_system.md
+++ b/prompt_assets/simard/goal_curator_system.md
@@ -36,6 +36,16 @@ Goals come from multiple inputs — weigh them all during curation:
 - Every goal must have a clear definition of done — what artifact or measurement proves it is complete.
 - Goals must align with amplihack quality standards: ruthless simplicity, working code, evidence over narrative.
 
+## Open-ended goal hygiene
+
+Some goals are inherently **open-ended / unbounded** — there is no natural 100% (e.g. "increase test coverage across the ecosystem", "improve reliability", "keep dependencies current"). Left as-is, these never complete, never archive, and tend to park at a high completion-% forever while real work stalls.
+
+Do not keep an unbounded goal on the active board in that shape. Express it as one or more **concrete, completable sub-goals** with explicit `done-when` criteria (e.g. "module X line coverage ≥ 80%, PR merged"). When a sub-goal completes, propose the next concrete slice. A goal that has sat at a high completion-% with stalled progress for several cycles must be **decomposed, completed, or demoted** — never left parked at 99%.
+
+## Proactive backfill from your own issues
+
+Do not idle on one stuck goal while the active board has room. When the active goal set is **below its cap** and the backlog is empty, proactively pull concrete work into goals from your own open GitHub issues (you track roughly 20 across `rysweet/Simard` and the ecosystem): pick a specific, well-scoped issue and propose it as a new goal with a `done-when` tied to that issue. Operator approval still governs promotion to active — you propose, Ryan decides — but **surface the proposal** every cycle rather than spinning. Silent idling on a stalled goal is a failure mode; an explicit proposal is the fix.
+
 ## Structured Goal Format
 
 Use repeated lines like:

--- a/prompt_assets/simard/goal_session_objective.md
+++ b/prompt_assets/simard/goal_session_objective.md
@@ -2,9 +2,63 @@ You are advancing exactly one active goal this cycle. You are Simard — a
 PM-architect, not an engineer. Decide what should happen for this goal this
 cycle and respond with **prose only** (no JSON, no code fences).
 
+# First: are you making progress, or looping?
+
+Before you triage or act, reason explicitly about your own recent history for
+**this** goal. Your recalled episodes and procedures already summarise what you
+did on the last several cycles — read them and judge yourself honestly.
+
+Ask: *over the last ~3 cycles, have I taken the same or a very similar action
+for this goal — "triage the PRs", "re-read the issue", "reinforce the pr-merge
+procedure" — and produced no new evidence of progress?*
+
+**Real progress** is at least one concrete, verifiable signal since the last
+cycle:
+
+- a new commit SHA on a goal branch,
+- a PR opened, substantively updated, or merged,
+- an issue closed,
+- a completion-% increase backed by a shipped artifact.
+
+**Not progress** — these do NOT count, no matter how busy they feel:
+
+- re-triaging or re-reviewing the same PRs and finding nothing new,
+- re-reading the same issue or goal description,
+- re-reinforcing the same procedure,
+- re-recording the same completion-% (e.g. parked at 99%) with no new artifact.
+
+If you have repeated a non-progress action with no new signal, **you are in a
+loop — stop repeating it.** Do not run the same triage again. Change strategy
+this cycle by choosing a *different* one of the strategies below, then express
+your choice through one of the two response shapes defined later in this prompt
+(spawn an engineer, or `NO ACTION` with a note):
+
+1. **Decompose and execute.** If the goal is open-ended/unbounded — no natural
+   100%, e.g. "increase test coverage across the ecosystem" — carve out ONE
+   concrete, completable sub-goal with an explicit done-criterion (e.g. "add
+   tests for module X until its line coverage ≥ 80%, then open a PR"). Spawn an
+   engineer to actually DO it: write the tests/code and open the PR. Bias toward
+   **shipping**, not toward more triage.
+2. **Complete or retire the goal.** If no further bounded progress is possible
+   (the work is genuinely done, or the goal can never complete as written),
+   record it complete via `PROGRESS: 100` with a note, or recommend demoting it.
+   Do not park a goal at 99% forever.
+3. **Pull fresh concrete work.** If active goals are below the cap and the
+   backlog is empty, propose pulling a specific open GitHub issue you own (you
+   track ~20) into a new concrete goal instead of spinning on this one. Honor
+   any operator gating, but **surface the proposal** — never silently re-loop.
+
+A goal sitting at a high completion-% with stalled progress across several
+cycles is a signal to decompose, complete, or demote it — not to triage it
+again.
+
 # Priority Order
 
-Before starting any new work, triage existing PRs in this strict order:
+Triage existing PRs as a **quick first pass — not a perpetual gate.** Do it once
+at the start of a cycle; if a quick check shows nothing actionable (nothing
+merge-ready, nothing fixable, no duplicates), proceed to executing new work
+**this same cycle**. Do not re-run the same triage every cycle. Work the tiers
+in order:
 
 0. **ONLY act on issues/PRs filed by `rysweet`.**
    Before working on ANY GitHub issue or PR, verify the author with
@@ -37,9 +91,11 @@ Before starting any new work, triage existing PRs in this strict order:
    the fix, and push. Do not open new PRs while fixable failures exist.
 3. **Close duplicate PRs.** If multiple PRs address the same issue or overlap
    substantially, keep the most complete one and close the rest.
-4. **New work last.** Only start a new implementation when no existing PRs need
-   attention (all merge-ready PRs merged, all fixable failures resolved,
-   duplicates closed).
+4. **New work — don't defer it indefinitely.** Once a quick triage shows no PR
+   needs attention this cycle (all merge-ready PRs merged, all fixable failures
+   resolved, duplicates closed), start a new implementation. If a recent cycle
+   already triaged this goal with no actionable result, skip straight here and
+   execute — do not re-triage the same state.
 
 # Self-update awareness
 

--- a/prompt_assets/simard/ooda_brain.md
+++ b/prompt_assets/simard/ooda_brain.md
@@ -40,6 +40,24 @@ Pick exactly one of these `choice` tags. The daemon maps each choice to a concre
 
   When all four hold, output `consider_self_update` and the act phase will spawn `simard safe-update` as a detached child process (it drains in-flight engineers, snapshots the current binary, runs the candidate's self-test, atomically swaps, and exec()s into the new binary). If the act phase finds engineers in flight, the choice is recorded as deferred — the brain's reasoning is preserved in the cycle report and the orchestrator runs on a future cycle when conditions clear.
 
+## Detecting churn vs. progress
+
+A high `consecutive_skip_count`, or a `cycle_number` that has advanced many times
+on the same goal, is only acceptable while the engineer log tail shows **new,
+concrete progress** — fresh commit SHAs, a PR opened or updated, an issue closed.
+
+If the log tail shows the engineer repeating the same step every cycle —
+re-triaging the same PRs, re-reading the same issue, re-reinforcing the same
+procedure — with no new artifact, that is a **stuck loop**, not healthy work.
+Re-triaging the same state is not progress. Do not let a goal churn indefinitely
+just because the engineer process is alive:
+
+- Prefer `deprioritize` so the goal yields budget to work that can move and so
+  `FAILURE_PENALTY_PER_CONSECUTIVE` engages and the goal is re-thought next cycle.
+- Prefer `open_tracking_issue` when the loop looks like it needs a human to
+  re-scope an **open-ended goal** (no reachable 100%, e.g. one parked at a high
+  completion-% for many cycles) into a concrete, completable piece of work.
+
 ## OUTPUT_FORMAT
 
 Use the **prose-first DECISION marker protocol** (defined normatively in

--- a/prompt_assets/simard/ooda_decide.md
+++ b/prompt_assets/simard/ooda_decide.md
@@ -16,6 +16,12 @@ will execute.
 Be conservative: prefer `advance_goal` for ordinary goal IDs unless a clear
 signal in the goal_id or reason indicates a special routing.
 
+If the `reason` indicates the goal has been advanced for many cycles with no new
+progress (a suspected stuck loop — repeated triage, no new commits/PRs/closed
+issues, a completion-% parked high), still route to `advance_goal` (the action
+*kind* does not change), but name the suspected loop in your rationale so the
+goal-action brain re-scopes or executes rather than re-triaging the same state.
+
 ## CONTEXT
 
 A single priority entry produced by the Orient phase:

--- a/prompt_assets/simard/progress_assessment_reviewer.md
+++ b/prompt_assets/simard/progress_assessment_reviewer.md
@@ -48,6 +48,21 @@ A **decrease** in percent (claimed < prior) is always acceptable — the brain
 is correcting a prior overestimate and we want to encourage that. Return
 accept with a rationale that notes the self-correction.
 
+### Stalled progress and open-ended goals
+
+Watch for goals that never finish. If `{prior_pct}` is already high (roughly
+≥ 90) and `{claimed_pct}` re-asserts about the same high percent while the
+`{plan}` describes only repeated triage / re-reading / re-reinforcement with
+**no new shipped artifact** in the plan or `{wip_summary}`, treat the claim as
+stalled rather than honest progress: **reject**, with a rationale noting that the
+goal is parked and should be decomposed into a concrete completable sub-goal,
+completed, or demoted — not re-asserted at the same percent.
+
+This is the open-ended-goal failure mode (a goal with no reachable 100%
+plateaued at a high percent for several cycles with only re-triage to show for
+it). It is distinct from a genuine, evidence-backed high percent — a real
+shipped PR named in the plan or WIP — which you should still **accept**.
+
 When in genuine doubt, prefer **accept** with a cautionary rationale. The
 goal of this reviewer is to catch hallucinated jumps, not to gatekeep every
 small movement.

--- a/prompt_assets/simard/recipes/ooda-decide.yaml
+++ b/prompt_assets/simard/recipes/ooda-decide.yaml
@@ -35,6 +35,13 @@ steps:
       Be conservative: prefer `advance_goal` for ordinary goal IDs unless a clear
       signal in the goal_id or reason indicates a special routing.
 
+      If the `reason` indicates the goal has been advanced for many cycles with no
+      new progress (a suspected stuck loop — repeated triage, no new commits/PRs/
+      closed issues, a completion-% parked high), still route to `advance_goal`
+      (the action *kind* does not change), but name the suspected loop in your
+      rationale so the goal-action brain re-scopes or executes rather than
+      re-triaging the same state.
+
       ## CONTEXT
 
       A single priority entry produced by the Orient phase:

--- a/prompt_assets/simard/recipes/ooda-engineer-lifecycle.yaml
+++ b/prompt_assets/simard/recipes/ooda-engineer-lifecycle.yaml
@@ -69,6 +69,21 @@ steps:
         3. `minutes_since_last_update_attempt >= 30`
         4. Current goal's engineer is healthy
 
+      ## Detecting churn vs. progress
+
+      A high `consecutive_skip_count`, or a `cycle_number` that has advanced many
+      times on the same goal, is only acceptable while the engineer log tail shows
+      **new, concrete progress** — fresh commit SHAs, a PR opened or updated, an
+      issue closed. If the log tail shows the engineer repeating the same step
+      every cycle — re-triaging the same PRs, re-reading the same issue,
+      re-reinforcing the same procedure — with no new artifact, that is a **stuck
+      loop**, not healthy work. Re-triaging the same state is not progress; do not
+      let a goal churn indefinitely just because the engineer process is alive.
+      Prefer `deprioritize` so the goal yields budget and the failure penalty
+      re-thinks it next cycle, or `open_tracking_issue` when the loop needs a human
+      to re-scope an **open-ended goal** (no reachable 100%, parked at a high
+      completion-% for many cycles) into concrete, completable work.
+
       ## OUTPUT FORMAT
 
       Output the variant name as the very first word of your response.

--- a/prompt_assets/simard/recipes/progress-assessment.yaml
+++ b/prompt_assets/simard/recipes/progress-assessment.yaml
@@ -58,6 +58,20 @@ steps:
       A decrease in percent (claimed < prior) is always acceptable — the brain is
       correcting a prior overestimate.
 
+      ### Stalled progress and open-ended goals
+
+      Watch for goals that never finish. If prior_pct is already high (roughly
+      ≥ 90) and claimed_pct re-asserts about the same high percent while the plan
+      describes only repeated triage / re-reading / re-reinforcement with **no new
+      shipped artifact** in the plan or wip_summary, treat the claim as stalled
+      rather than honest progress: **reject**, with a rationale noting the goal is
+      parked and should be decomposed into a concrete completable sub-goal,
+      completed, or demoted — not re-asserted at the same percent. This is the
+      open-ended-goal failure mode (no reachable 100%, plateaued for several
+      cycles with only re-triage to show). It is distinct from a genuine,
+      evidence-backed high percent (a real shipped PR named in the plan or WIP),
+      which you should still accept.
+
       When in genuine doubt, prefer accept with a cautionary rationale.
 
       ## Output

--- a/src/ooda_brain/prompt_store_tests.rs
+++ b/src/ooda_brain/prompt_store_tests.rs
@@ -515,3 +515,57 @@ fn goal_curator_has_open_ended_hygiene_and_proactive_backfill() {
         "goal_curator_system.md must teach proactive backfill from own open GitHub issues"
     );
 }
+
+#[test]
+fn goal_session_objective_enumerates_concrete_progress_signals() {
+    // Behavior A: the loop self-detection must DEFINE concrete progress signals
+    // (a new commit SHA, an opened/merged PR, a closed issue, a completion-%
+    // increase backed by a shipped artifact) and an explicit non-progress list
+    // (re-triaging, re-reading the same thing). Loose "real progress" wording is
+    // not enough — the enumerated signals are what make the check actionable.
+    let content = embedded_fallback("goal_session_objective.md")
+        .expect("goal_session_objective.md must be registered");
+    let lower = content.to_lowercase();
+
+    for signal in [
+        "commit sha",
+        "pr opened",
+        "merged",
+        "issue closed",
+        "shipped artifact",
+    ] {
+        assert!(
+            lower.contains(signal),
+            "goal_session_objective.md must enumerate the concrete progress signal {signal:?}"
+        );
+    }
+    for non_signal in ["re-triaging", "re-reading"] {
+        assert!(
+            lower.contains(non_signal),
+            "goal_session_objective.md must list {non_signal:?} as a non-progress (loop) signal"
+        );
+    }
+}
+
+#[test]
+fn progress_reviewer_rejects_reasserted_stalled_high_pct() {
+    // Behavior E: the per-cycle progress reviewer must judge whether the cycle
+    // produced real progress. The enforceable verdict is that a high percent
+    // re-asserted with NO new shipped artifact is REJECTED (not parked), which
+    // is what feeds the demote/decompose decision next cycle.
+    let content = embedded_fallback("progress_assessment_reviewer.md")
+        .expect("progress_assessment_reviewer.md must be registered");
+    let lower = content.to_lowercase();
+    assert!(
+        lower.contains("re-asserts about the same high percent"),
+        "progress_assessment_reviewer.md must detect a high percent re-asserted with no new work"
+    );
+    assert!(
+        lower.contains("no new shipped artifact"),
+        "the stalled-progress rule must hinge on the absence of a new shipped artifact"
+    );
+    assert!(
+        lower.contains("reject"),
+        "a re-asserted stalled high percent must be rejected, not accepted as progress"
+    );
+}

--- a/src/ooda_brain/prompt_store_tests.rs
+++ b/src/ooda_brain/prompt_store_tests.rs
@@ -381,3 +381,137 @@ fn goal_session_objective_mentions_self_update() {
         "goal_session_objective.md must mention self-update awareness for Simard repo merges"
     );
 }
+
+// --- Loop / stuck self-detection + proactivity (issue #2403) ----------------
+//
+// These tests pin the prompt CONTENT that makes Simard reason about whether she
+// is making real progress or spinning in a loop, break the loop by changing
+// strategy, keep open-ended goals bounded, and proactively backfill work. They
+// assert wording only — no Rust logic or output-contract change.
+
+#[test]
+fn goal_session_objective_has_loop_self_detection() {
+    let content = embedded_fallback("goal_session_objective.md")
+        .expect("goal_session_objective.md must be registered");
+    let lower = content.to_lowercase();
+    assert!(
+        lower.contains("loop"),
+        "goal_session_objective.md must make Simard reason about being in a loop"
+    );
+    assert!(
+        lower.contains("real progress") && lower.contains("not progress"),
+        "goal_session_objective.md must distinguish real progress from non-progress signals"
+    );
+    assert!(
+        lower.contains("change strategy") || lower.contains("stop repeating"),
+        "goal_session_objective.md must tell Simard to break the loop / change strategy when stuck"
+    );
+}
+
+#[test]
+fn goal_session_objective_loop_check_precedes_priority_order() {
+    // The self-detection section must come BEFORE Priority Order so Simard
+    // decides whether she is looping before defaulting to re-triage.
+    let content = embedded_fallback("goal_session_objective.md")
+        .expect("goal_session_objective.md must be registered");
+    let lower = content.to_lowercase();
+    let loop_pos = lower
+        .find("looping")
+        .or_else(|| lower.find("are you making progress"));
+    let priority_pos = lower.find("priority order");
+    assert!(
+        loop_pos.is_some() && priority_pos.is_some(),
+        "both the loop-detection section and Priority Order must exist"
+    );
+    assert!(
+        loop_pos.unwrap() < priority_pos.unwrap(),
+        "loop self-detection must appear before Priority Order"
+    );
+}
+
+#[test]
+fn goal_session_objective_triage_is_quick_first_pass_not_gate() {
+    // Rebalance: triage must be a quick first pass, not a perpetual gate that
+    // blocks executing new work.
+    let content = embedded_fallback("goal_session_objective.md")
+        .expect("goal_session_objective.md must be registered");
+    let lower = content.to_lowercase();
+    assert!(
+        lower.contains("quick first pass") && lower.contains("not a perpetual gate"),
+        "Priority Order must frame triage as a quick first pass, not a perpetual gate"
+    );
+}
+
+#[test]
+fn goal_session_objective_biases_toward_executing() {
+    let content = embedded_fallback("goal_session_objective.md")
+        .expect("goal_session_objective.md must be registered");
+    let lower = content.to_lowercase();
+    assert!(
+        lower.contains("decompose") && lower.contains("shipping"),
+        "goal_session_objective.md must bias toward decomposing open-ended goals and shipping"
+    );
+}
+
+#[test]
+fn ooda_decide_notes_stuck_loop_in_rationale() {
+    let content = embedded_fallback("ooda_decide.md").expect("ooda_decide.md must be registered");
+    let lower = content.to_lowercase();
+    assert!(
+        lower.contains("stuck loop") || lower.contains("suspected loop"),
+        "ooda_decide.md must instruct surfacing a suspected stuck loop in the rationale"
+    );
+    // The action KIND must remain advance_goal (output contract unchanged).
+    assert!(
+        content.contains("advance_goal"),
+        "ooda_decide.md must keep routing stuck goals to advance_goal (kind unchanged)"
+    );
+}
+
+#[test]
+fn progress_reviewer_escalates_stalled_open_ended_goals() {
+    let content = embedded_fallback("progress_assessment_reviewer.md")
+        .expect("progress_assessment_reviewer.md must be registered");
+    let lower = content.to_lowercase();
+    assert!(
+        lower.contains("stalled") && lower.contains("open-ended"),
+        "progress_assessment_reviewer.md must call out stalled / open-ended goals"
+    );
+    assert!(
+        lower.contains("decompose") || lower.contains("demote"),
+        "progress reviewer must push parked goals toward decompose/complete/demote"
+    );
+}
+
+#[test]
+fn ooda_brain_detects_churn_vs_progress() {
+    let prompt = include_str!("../../prompt_assets/simard/ooda_brain.md");
+    let lower = prompt.to_lowercase();
+    assert!(
+        lower.contains("churn") && lower.contains("stuck loop"),
+        "ooda_brain.md must distinguish churn from progress (stuck-loop detection)"
+    );
+    // Loop-breaking must route through existing variants — no new variants.
+    assert!(
+        prompt.contains("deprioritize") && prompt.contains("open_tracking_issue"),
+        "ooda_brain.md must break loops via existing deprioritize / open_tracking_issue variants"
+    );
+}
+
+#[test]
+fn goal_curator_has_open_ended_hygiene_and_proactive_backfill() {
+    let prompt = include_str!("../../prompt_assets/simard/goal_curator_system.md");
+    let lower = prompt.to_lowercase();
+    assert!(
+        lower.contains("open-ended goal hygiene"),
+        "goal_curator_system.md must teach open-ended goal hygiene (decompose to completable sub-goals)"
+    );
+    assert!(
+        lower.contains("done-when"),
+        "open-ended goals must require explicit done-when criteria"
+    );
+    assert!(
+        lower.contains("proactive backfill") && lower.contains("open github issues"),
+        "goal_curator_system.md must teach proactive backfill from own open GitHub issues"
+    );
+}


### PR DESCRIPTION
## Summary

Makes Simard's autonomous OODA daemon **proactive, reflective, and able to reason about whether she is stuck / spinning in a loop** — implemented **entirely via prompt + goal-framing content**, with **zero Rust logic changes**. The content hot-reloads onto the live daemon (deploy = sync `prompt_assets/simard/` → `~/.simard/prompt_assets/simard/`; no rebuild). Closes #2403.

### The problem (diagnosed from the live daemon)

One open-ended goal (`improve-amplihack-test-coverage`) parked at **99% for 30+ hours** with an empty backlog. Every OODA cycle the goal-action LLM re-triaged the same PRs, found nothing to ship, re-recorded 99%, and repeated — **0 PRs shipped in 18h** — without ever noticing it was looping.

Root causes (all prompt/goal):
1. The goal is **inherently open-ended** (no reachable 100%) → never completes, parks forever.
2. `goal_session_objective.md` gated *all* new work behind "triage existing PRs first" → perpetual triage.
3. No prompt made her **reason over her own recent action history** → no loop/stuck self-detection.
4. `progress_assessment_reviewer.md` let a goal sit at 99% indefinitely with no escalation.

### What changed (prompt assets only)

Both the embedded `*.md` copies (served by `PromptStore` / `include_str!`) **and** the live recipe YAMLs under `prompt_assets/simard/recipes/` are kept in lock-step.

| Behavior | Asset(s) |
|---|---|
| **Loop self-detection + change strategy** — reason over recalled episodes; define progress (new commits/PRs/closed issues/evidence-backed %) vs non-progress (re-triage/re-read/re-reinforce); when looping, stop and pick a *different* action | `goal_session_objective.md` |
| **Execute over triage** — Priority Order triage reframed as a *quick first pass, not a perpetual gate*; new work no longer deferred indefinitely | `goal_session_objective.md` |
| **Break the loop at the engineer site** — churn with no new artifact → `deprioritize` / `open_tracking_issue` (existing variants) | `ooda_brain.md`, `recipes/ooda-engineer-lifecycle.yaml` |
| **Surface loops while routing** — note suspected loop in rationale (kind stays `advance_goal`) | `ooda_decide.md`, `recipes/ooda-decide.yaml` |
| **Open-ended goal escalation** — reject a re-asserted high % backed only by re-triage → decompose/complete/demote | `progress_assessment_reviewer.md`, `recipes/progress-assessment.yaml` |
| **Open-ended goal hygiene + proactivity** — unbounded goals must become concrete completable sub-goals with `done-when`; pull fresh work from own open issues when the board has room instead of idling | `goal_curator_system.md` |

All required output contracts are **preserved** (prose-only goal action; `DECISION` / first-word routing; single-line `{"verdict": …}` JSON), so the Rust parsers are untouched.

### Known follow-ups (would need Rust — noted, not implemented)
- Feed a structured per-goal action-history digest into Orient/Decide context.
- A first-class `decompose_goal` action kind.
- Automatic archival/demotion after K stalled cycles.

---

### QA-team evidence

`gadugi-test` E2E scenarios target CLI/TUI/web runtime behavior; this change is **static prompt content**, so the equivalent gate is the prompt-content + recipe-validation suite:

- `cargo test -p simard --lib prompt_store_tests` → **33 passed, 0 failed** (8 new content assertions + existing pinned-invariant tests for the prose-only contract, `Priority Order` < `Two response shapes` ordering, `gh pr merge --squash --delete-branch` literal, merge-ready/QA-team/quality-audit table, and self-update section).
- `cargo test -p simard --lib ooda_brain::recipe_brain` → **120 passed** in a clean `HOME` (see CI note below).
- `goal_curation::progress_reviewer` (11) and `ooda_loop::decide` (18) → pass.
- All 5 recipe YAMLs re-validated as parseable YAML after edits.

### Documentation

- New concept doc: `docs/concepts/ooda-loop-self-detection.md` (progress-vs-non-progress signals, per-phase behavior map, loop-breaking strategies, preserved contracts, follow-ups).
- New "spinning at a high completion-% (no lockout)" symptom + operator runbook in `docs/howto/unblock-stuck-ooda-goals.md` (verified every referenced `simard goal …` subcommand exists).
- `mkdocs.yml` nav entry added; `mkdocs build --strict` → **exit 0** (no link warnings).

### Quality-audit

- Focused `code-review` pass over the full diff: verified **no production Rust changed** (only `prompt_store_tests.rs`, `#[cfg(test)]`), all output contracts preserved, embedded `.md` ↔ recipe-YAML wording mirrored faithfully, and all referenced symbols/commands/doc links real. **No blocking issues.**
- One non-blocking clarity finding ("two response shapes" phrasing preceding a three-strategy list) was **fixed** in the final commit.

### CI

- `mkdocs build --strict` → exit 0 locally.
- **CI note:** 5 `ooda_brain::recipe_brain` path-resolution tests fail *only on this shared host* because the live daemon's deployed assets exist at `~/.simard/prompt_assets/simard/recipes/` and `resolve_recipe_path()` checks that hot-reload path first. Re-running with a clean `HOME` makes all 120 pass, proving the failures are environmental (the resolver logic and these tests are untouched by this PR). CI runs in a clean environment, so they pass there. Surfacing this explicitly rather than hiding it.

### PR description evidence

This description cites concrete artifacts for criteria 1–4 and 6 (test commands + counts, doc paths, review outcome, scope statement).

### Scope

Diff is **13 files**: 6 prompt `.md` files + 3 recipe YAMLs (content only), 1 content-asserting test file (`src/ooda_brain/prompt_store_tests.rs`), 2 docs + `mkdocs.yml` nav, and a one-line `.gitignore` entry for the mkdocs `site/` build output. **No `src/` production logic, no public API, no schema, no dependency changes.**
