### PR TITLE
feat(ooda): fill spare capacity with parallel engineers on distinct issues (maximum safe parallelism)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -137,6 +137,7 @@ If you are changing architecture, start with the [architecture overview](./archi
 - [Adaptive scaling](./concepts/adaptive-scaling.md) — AIMD concurrency control for the OODA cycle.
 - [Goal board API reference](./reference/goal-board-api.md) — `active_goals_as_records` adapter and load/save semantics.
 - [Adaptive scaling API reference](./reference/adaptive-scaling-api.md) — AdaptiveScaler Rust API and integration.
+- [Maximum safe parallelism](./reference/maximum-safe-parallelism.md) — how the OODA daemon fills spare capacity with concurrent engineers on distinct work items, bounded by the AIMD safety cap.
 
 - [Agent composition](./architecture/agent-composition.md) - How Simard composes subordinate agents with goal assignment, supervision, and crash recovery.
 - [Cognitive memory](./architecture/cognitive-memory.md) - Six-type memory model, session lifecycle mapping, and hive mind integration.

--- a/docs/reference/goal-coverage-allocation.md
+++ b/docs/reference/goal-coverage-allocation.md
@@ -254,6 +254,9 @@ de-dups against both live engineers and already-planned actions.
 
 ## Related reading
 
+- [Maximum safe parallelism](./maximum-safe-parallelism.md) — how coverage,
+  the AIMD cap, and goal decomposition combine to fill spare machine capacity
+  with concurrent engineers on distinct work items.
 - [Adaptive scaling API](./adaptive-scaling-api.md) — the AIMD scaler that
   supplies the safety cap.
 - [Goal target-repo routing](./goal-target-repo-routing.md) — the companion

--- a/docs/reference/maximum-safe-parallelism.md
+++ b/docs/reference/maximum-safe-parallelism.md
@@ -86,9 +86,11 @@ Pressure is `max(cpu_pressure, mem_pressure)` from `/proc/stat` and
 **Production bounds.** `OodaConfig::default()` constructs the scaler as
 `AdaptiveScaler::new(base, 1, ceiling)` where `base =
 SIMARD_MAX_CONCURRENT_ACTIONS` (default **5**) and `ceiling = base × 4` (default
-**20**). The live log line `cap N` shows `current_max()`, which **starts at
-`base` and climbs additively** toward the ceiling under low pressure — so the
-machine fills over a few cycles rather than all at once. The ceiling of 20 is
+**20**). Once per cycle the daemon logs the cap it used in the coverage line
+`[simard] OODA cycle: coverage — … (cap N)`, where `N` is the scaler's
+`current_max()` (or `max_concurrent_actions` when `SIMARD_SCALING` is off). That
+cap **starts at `base` and climbs additively** toward the ceiling under low
+pressure — so the machine fills over a few cycles rather than all at once. The ceiling of 20 is
 already ample for "fill the machine"; raise both the base and ceiling together
 by setting `SIMARD_MAX_CONCURRENT_ACTIONS` (the ceiling tracks at 4× the base).
 The additive-increase + pressure/error backoff behavior is unchanged by this.

--- a/docs/reference/maximum-safe-parallelism.md
+++ b/docs/reference/maximum-safe-parallelism.md
@@ -1,0 +1,189 @@
+---
+title: Maximum safe parallelism reference
+description: How the OODA daemon fills spare machine capacity with concurrent engineers on distinct work items, bounded by the AIMD safety cap — and how a parallelizable goal is decomposed so coverage can parallelize it.
+last_updated: 2026-06-25
+owner: simard
+doc_type: reference
+status: reference
+related:
+  - ./goal-coverage-allocation.md
+  - ./adaptive-scaling-api.md
+  - ./ooda-decide-prompt.md
+  - ./simard-cli.md
+  - ../concepts/adaptive-scaling.md
+  - ../howto/spawn-engineers-from-ooda-daemon.md
+  - ../howto/configure-adaptive-scaling.md
+---
+
+# Maximum safe parallelism reference
+
+> **Goal:** When the machine has spare capacity **and** there is parallelizable
+> work, Simard fills the free slots with concurrent engineers — each on a
+> **distinct** bounded work item — up to the AIMD safety cap. No engineer slot
+> sits idle while parallelizable work remains, and the cap stays a hard,
+> resource-aware ceiling that backs off under load.
+
+This page explains the end-to-end mechanism, why "one engineer per goal" is the
+unit of parallelism, and how a single multi-issue goal is decomposed so the
+existing coverage allocator can run it in parallel.
+
+Modules: `simard::ooda_loop::{orient, decide, coverage, adaptive_scaling}`,
+`simard::ooda_actions::advance_goal`.
+Prompts: `prompt_assets/simard/goal_session_objective.md`,
+`prompt_assets/simard/ooda_decide.md` (+ `recipes/ooda-decide.yaml`).
+
+## The problem
+
+A single OODA cycle ran roughly **one** engineer even when the host had spare
+CPU/RAM and a goal bundled lots of independent, parallelizable work. For
+example, the goal `find-and-fix-recent-rysweet-filed-amplihack-rs-…` covered six
+open issues (`#804`, `#807`, `#808`, `#809`, `#810`, `#815`) that could all be
+fixed at once, yet only one engineer was working — the other five issues waited
+behind a serial triage loop. The operator expectation is the opposite: *spawn
+enough engineers to fill the machine as long as there is more independent work
+to do, and stop adding them when the machine is under pressure.*
+
+## How per-cycle parallelism actually works
+
+Each OODA cycle runs Observe → Orient → Decide → **Coverage** → Act. Parallelism
+is the number of **distinct `AdvanceGoal` actions** that survive into Act — each
+one becomes one spawned engineer.
+
+| Phase | What it produces | Parallelism contribution |
+|-------|------------------|--------------------------|
+| **Orient** (`orient` / `orient_with_brain`) | **One `Priority` per active goal** (plus a few synthetic priorities) | The number of priorities is the number of goals — Orient does not fan a single goal into many. |
+| **Decide** (`decide_with_brain`) | **One `PlannedAction` per priority** — the brain returns a single `DECISION: <variant>` per call | Caps the action list at `scaler.adjust()` (the AIMD cap). Cannot express "spawn N for this one goal" — the output schema is one decision per priority. |
+| **Coverage** (`ensure_goal_coverage`) | Guarantees **one engineer per incomplete unassigned goal**, preserves extra parallelism behind coverage, truncates to `cap` | Parallelizes across *distinct goals*, up to the cap. See [goal coverage allocation](./goal-coverage-allocation.md). |
+| **Act** (`dispatch_advance_goal`) | Spawns/heartbeats the engineer for each action | **Short-circuits when the goal already has a live engineer** (`assigned_to`), and spawning is de-duplicated per goal (`find_live_engineer_for_goal`). |
+
+**Key consequence — the unit of parallelism is the goal.** A goal has a single
+`assigned_to` slot, the Act phase heart-beats (rather than re-spawns) a goal that
+already has a live engineer, and spawning is de-duplicated per goal. So a single
+goal yields **one** engineer no matter how many `AdvanceGoal` actions name it.
+**N concurrent engineers require N distinct goals.**
+
+Multi-*goal* parallelism therefore already works: with several incomplete goals,
+coverage spawns one engineer per goal, up to the cap. The missing piece is the
+single-goal-with-many-issues case.
+
+## The AIMD safety cap (do not remove or weaken)
+
+The cap is the [`AdaptiveScaler`](./adaptive-scaling-api.md), enabled with
+`SIMARD_SCALING=auto`. It is the mechanism that already implements *"fill the
+machine while there is headroom, back off under load."* Once per cycle,
+`adjust()` samples pressure and applies the AIMD rule:
+
+- **Additive increase** (`current + 1`, clamped to `ceiling`) when system
+  pressure `< 0.3` and there are no recent 429s — climb to use spare capacity.
+- **Multiplicative decrease** (`current × 0.5`, clamped to `floor`) when
+  pressure `> 0.8` **or** a 429 / "rate limit" error landed in the last 300 s.
+- **Hold** otherwise.
+
+Pressure is `max(cpu_pressure, mem_pressure)` from `/proc/stat` and
+`/proc/meminfo`; 429/rate-limit signals come from `report_error` /
+`report_reason`.
+
+**Production bounds.** `OodaConfig::default()` constructs the scaler as
+`AdaptiveScaler::new(base, 1, ceiling)` where `base =
+SIMARD_MAX_CONCURRENT_ACTIONS` (default **5**) and `ceiling = base × 4` (default
+**20**). The live log line `cap N` shows `current_max()`, which **starts at
+`base` and climbs additively** toward the ceiling under low pressure — so the
+machine fills over a few cycles rather than all at once. The ceiling of 20 is
+already ample for "fill the machine"; raise both the base and ceiling together
+by setting `SIMARD_MAX_CONCURRENT_ACTIONS` (the ceiling tracks at 4× the base).
+The additive-increase + pressure/error backoff behavior is unchanged by this.
+
+> The cap is a **hard ceiling**: coverage never emits more than `cap` actions,
+> and the scaler shrinks the cap under CPU/memory/429 pressure. Filling the
+> machine is always resource-aware — it cannot thrash the host.
+
+## Filling spare capacity: decompose a parallelizable goal
+
+Because the unit of parallelism is the goal and the Decide schema is one
+decision per priority, the way to fill spare capacity for a single multi-issue
+goal is to turn it into **multiple distinct goals**, which coverage then
+parallelizes. This is a prompt-driven behavior of the goal-action brain
+(`goal_session_objective.md`) — no change to the AIMD cap or the dispatch
+core — so it hot-reloads from `~/.simard/prompt_assets/simard/` without a binary
+rebuild.
+
+When a goal is an umbrella over several **independent** open issues and live
+engineers are below the cap, the goal-action brain spawns one engineer whose
+bounded task is to:
+
+1. Enumerate the independent, still-open, `rysweet`-filed issues the umbrella
+   covers (the rysweet-only gate in Priority Order tier 0 still applies).
+2. Create **exactly one** concrete goal per distinct issue with an explicit
+   done-when criterion, via
+   `simard goal add <priority> [--repo <slug>] "<issue-scoped scope>; done when …"`
+   (see the [`simard goal add` CLI reference](./simard-cli.md)).
+3. Stop — the umbrella engineer does **not** fix the issues itself.
+
+On the next cycle, coverage sees the new per-issue goals and spawns one engineer
+for each, in parallel, up to the cap. The umbrella then **delegates**: it
+records progress and prefers `NO ACTION` while the per-issue goals run, and
+completes once every issue it covered is closed.
+
+```
+Cycle N     umbrella goal ──(1 engineer)──► creates goals: fix-#804 … fix-#815
+Cycle N+1   coverage covers fix-#804, fix-#807, fix-#808, … (one engineer each,
+            up to cap; AIMD raises the cap additively while pressure is low)
+Cycle N+k   each per-issue goal completes when its fix merges; umbrella → done
+```
+
+## Collision-safety (distinct work, never duplicate)
+
+Parallel engineers must work **distinct** items so they never duplicate effort
+or re-triage the same state:
+
+- **One issue per goal.** The decomposition creates exactly one goal per issue
+  and never two goals for the same issue.
+- **The umbrella delegates, it does not duplicate.** Once decomposed, the
+  umbrella engineer stops working the issues; each per-issue goal owns its issue.
+- **Per-goal de-duplication is preserved.** `find_live_engineer_for_goal` and the
+  single `assigned_to` slot still prevent two engineers on the same goal.
+- **Loop-awareness (issue #2404) is preserved.** Decomposing *is* the loop-break
+  for a "find-and-fix-N-issues" umbrella that would otherwise re-triage the same
+  list every cycle — it does not spawn parallel engineers that all re-triage the
+  same thing.
+
+## Output contracts (unchanged)
+
+The Rust parsers are untouched; the prompts keep their existing shapes:
+
+- **Decide** (`ooda_decide.md`, `recipes/ooda-decide.yaml`): first non-blank line
+  is still `DECISION: <variant>` (embedded path) / the first whitespace token is
+  still the action keyword (recipe path). The added *Parallelism* section is
+  body guidance only — it introduces **no new variant** and routes each distinct
+  goal to `advance_goal`.
+- **Goal action** (`goal_session_objective.md`): still the two response shapes —
+  a prose **Spawn an engineer** paragraph (the decomposition task uses this) or
+  `NO ACTION` on its own line, with an optional `PROGRESS: NN` marker. The
+  decomposition is a normal spawn-engineer paragraph; no new shape is added.
+
+## Invariants
+
+- **Cap is never exceeded.** Coverage emits at most `cap` actions per cycle; the
+  AIMD scaler bounds and shrinks `cap` under pressure.
+- **Resource-aware.** Additive increase only while pressure `< 0.3` and no recent
+  429s; multiplicative decrease under high pressure or rate-limit errors.
+- **Distinct engineers, distinct items.** One engineer per goal; one issue per
+  decomposed goal; no duplicate work.
+- **No idle capacity while parallelizable work remains** — given enough distinct,
+  bounded goals on the board, coverage fills every free slot up to the cap.
+- **Hot-reloadable.** The fill behavior is prompt-only; it requires no binary
+  rebuild and does not alter the AIMD cap or the dispatch core.
+
+## Related reading
+
+- [Goal coverage allocation](./goal-coverage-allocation.md) — the per-cycle
+  allocator that guarantees one engineer per incomplete goal and parallelizes
+  distinct goals up to the cap.
+- [Adaptive scaling API](./adaptive-scaling-api.md) — the AIMD scaler that
+  supplies the resource-aware safety cap.
+- [OODA Decide prompt](./ooda-decide-prompt.md) — the routing brain whose
+  *Parallelism* section explains why distinct goals are the unit of fan-out.
+- [`simard goal add` CLI reference](./simard-cli.md) — the mechanism the
+  decomposition uses to create one per-issue goal per distinct issue.
+- [Configure adaptive scaling](../howto/configure-adaptive-scaling.md) — how to
+  widen the ceiling via `SIMARD_MAX_CONCURRENT_ACTIONS`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -99,6 +99,7 @@ nav:
     - Adaptive Scaling API: reference/adaptive-scaling-api.md
     - Goal Target-Repo Routing: reference/goal-target-repo-routing.md
     - Goal Coverage Allocation: reference/goal-coverage-allocation.md
+    - Maximum Safe Parallelism: reference/maximum-safe-parallelism.md
     - Pluggable Identity API: reference/pluggable-identity-api.md
     - Meeting Close Lifecycle: reference/meeting-close-lifecycle.md
     # Hidden from nav until issue #1590 implementation lands:

--- a/prompt_assets/simard/goal_session_objective.md
+++ b/prompt_assets/simard/goal_session_objective.md
@@ -43,10 +43,14 @@ your choice through one of the two response shapes defined later in this prompt
    (the work is genuinely done, or the goal can never complete as written),
    record it complete via `PROGRESS: 100` with a note, or recommend demoting it.
    Do not park a goal at 99% forever.
-3. **Pull fresh concrete work.** If active goals are below the cap and the
-   backlog is empty, propose pulling a specific open GitHub issue you own (you
-   track ~20) into a new concrete goal instead of spinning on this one. Honor
-   any operator gating, but **surface the proposal** — never silently re-loop.
+3. **Pull fresh concrete work — and fan it out to fill spare capacity.** If
+   live engineers are below the AIMD cap and this goal is an umbrella over
+   several *independent* open issues you own (you track ~20), do **not** spin
+   one engineer serially triaging them — decompose it into one distinct
+   concrete goal per issue so the coverage allocator spawns a separate engineer
+   for each, in parallel, up to the cap. See **Maximum safe parallelism** below.
+   Honor any operator gating, but **surface the proposal** — never silently
+   re-loop.
 
 A goal sitting at a high completion-% with stalled progress across several
 cycles is a signal to decompose, complete, or demote it — not to triage it
@@ -96,6 +100,59 @@ in order:
    resolved, duplicates closed), start a new implementation. If a recent cycle
    already triaged this goal with no actionable result, skip straight here and
    execute — do not re-triage the same state.
+
+# Maximum safe parallelism — fill spare capacity, never idle while work remains
+
+Simard runs **many engineers at once** when there is parallelizable work and the
+machine has room. The daemon already spawns **one engineer per incomplete goal
+each cycle, up to the AIMD safety cap** — the resource-aware ceiling that raises
+itself additively while CPU/memory are free and backs off (halves) under
+CPU / memory / rate-limit (429) pressure. Your job here is to make sure there is
+enough *distinct, bounded* work on the board to fill that capacity, so no
+engineer slot sits idle while parallelizable work remains.
+
+**When this goal is an umbrella over several independent work items** — e.g.
+"find and fix the recent rysweet-filed amplihack-rs issues" covering issues
+`#804`, `#807`, `#808`, `#809`, `#810`, `#815` — do **not** keep one engineer
+serially triaging all of them. That leaves the machine idle. Instead,
+**decompose the umbrella into one distinct concrete goal per independent issue**
+so the coverage allocator spawns a separate engineer for each, in parallel,
+bounded by the AIMD cap.
+
+Use the normal **Spawn an engineer** response shape; the engineer's **bounded**
+task is:
+
+1. Enumerate the independent, still-open, `rysweet`-filed issues this umbrella
+   covers (verify each author with `gh issue view <N> --json author --jq
+   '.author.login'` — Priority Order tier 0 still applies; skip anything not
+   filed by `rysweet`).
+2. For **each distinct** issue, create exactly one concrete goal with an
+   explicit done-when criterion, e.g.
+   `simard goal add 2 --repo <owner/repo> "fix amplihack-rs issue #808: <one-line scope>; done when the fix is merged"`.
+   Create **one goal per issue** — never two goals for the same issue, and
+   never two engineers on the same issue.
+3. Then **stop**. The umbrella engineer does **not** fix the issues itself —
+   each per-issue goal gets its own engineer next cycle. This is the collision
+   guard: distinct engineers work distinct issues, so they never duplicate each
+   other or re-triage the same state.
+
+After you fan the umbrella out, **delegate** to the per-issue goals: on later
+cycles prefer `NO ACTION` for the umbrella (record `PROGRESS: NN` toward "all
+child issues closed") while the per-issue goals do the work, and mark the
+umbrella complete once every issue it covers is closed.
+
+**Bounds and safety — do not bypass these:**
+
+- The **AIMD cap is a hard ceiling.** It governs how many engineers actually run
+  at once and shrinks automatically under load. You never throttle goal creation
+  by hand; just keep every goal genuinely independent and bounded.
+- **Distinct work only.** One issue (or one bounded file-set) per goal. Parallel
+  engineers must work distinct items, never the same one.
+- **Loop awareness still applies.** This decomposition *is* the loop-break for a
+  "find-and-fix-N-issues" umbrella that keeps re-triaging: decompose and ship,
+  don't re-triage the same list every cycle.
+- The operator can widen the ceiling with `SIMARD_MAX_CONCURRENT_ACTIONS` (the
+  AIMD ceiling is 4× this base value); the pressure/error backoff is unchanged.
 
 # Self-update awareness
 

--- a/prompt_assets/simard/ooda_decide.md
+++ b/prompt_assets/simard/ooda_decide.md
@@ -71,6 +71,22 @@ Unknown variant tokens or a missing `DECISION:` marker cause the daemon to
 fall back to the deterministic prefix mapping (`__memory__` →
 consolidate_memory etc., else `advance_goal`).
 
+## Parallelism — how the machine gets filled
+
+You judge **one** priority per call and emit **one** `DECISION:` — that contract
+is unchanged. Per-cycle parallelism comes from the daemon dispatching MANY
+priorities at once: the Orient phase surfaces one priority per incomplete goal,
+you route each to `advance_goal`, and the coverage allocator spawns one engineer
+per goal **up to the AIMD safety cap** (the resource-aware ceiling that backs off
+under CPU / memory / 429 pressure). So when several distinct goals are
+parallelizable, routing each to `advance_goal` is exactly what fills the machine
+— there is no separate "parallel" or "spawn N" variant to emit, and you must not
+invent one. If a single goal bundles many independent work items, the
+goal-action brain (`goal_session_objective.md`) decomposes it into distinct
+per-issue goals; each then arrives here as its own priority and you route it to
+`advance_goal`. Never route two priorities to the same work item — distinct
+goals mean distinct engineers on distinct items.
+
 ## OUTPUT_FORMAT
 
 Use the **prose-first DECISION marker protocol** (matching the format the

--- a/prompt_assets/simard/recipes/ooda-decide.yaml
+++ b/prompt_assets/simard/recipes/ooda-decide.yaml
@@ -87,6 +87,21 @@ steps:
         routing; do not emit unless the daemon configuration explicitly enables
         them.
 
+      ## Parallelism — how the machine gets filled
+
+      You judge **one** priority per call and name **one** action kind — that
+      contract is unchanged. Per-cycle parallelism comes from the daemon
+      dispatching MANY priorities at once: Orient surfaces one priority per
+      incomplete goal, you route each to `advance_goal`, and the coverage
+      allocator spawns one engineer per goal **up to the AIMD safety cap** (the
+      resource-aware ceiling that backs off under CPU / memory / 429 pressure).
+      Routing each distinct goal to `advance_goal` is exactly what fills the
+      machine — there is no separate "parallel" action to emit, and you must not
+      invent one. If a single goal bundles many independent work items, the
+      goal-action brain decomposes it into distinct per-issue goals; each then
+      arrives here as its own priority routed to `advance_goal`. Distinct goals
+      mean distinct engineers on distinct items — never the same one twice.
+
       ## EXAMPLES
 
       Good — reserved synthetic ID routes to its dedicated kind:

--- a/src/ooda_brain/prompt_store_tests.rs
+++ b/src/ooda_brain/prompt_store_tests.rs
@@ -706,3 +706,168 @@ fn ooda_decide_recipe_mirrors_parallelism_note() {
         "ooda-decide.yaml must forbid inventing a new parallel action variant"
     );
 }
+
+// ── Maximum safe parallelism — additional outcome/constraint coverage (Step 7) ──
+//
+// The six tests above pin the headline guidance and the preserved output
+// contracts. These tests pin the remaining REQUIRED OUTCOME points and HARD
+// CONSTRAINTS so they cannot silently regress when the prompts are edited:
+//   * fill spare capacity — no engineer slot idle while parallelizable work remains
+//   * resource-aware AIMD backoff (additive-increase + halve under pressure) survives
+//   * each parallel engineer gets a DISTINCT, BOUNDED work item
+//   * the `rysweet`-only operator gate (Priority Order tier 0) is preserved per-issue
+//   * #2404 loop-awareness is preserved (decompose-and-ship, do not re-triage)
+//   * failures are surfaced, never silently re-looped (no silent degradation)
+
+/// Collapse all runs of whitespace to single spaces so assertions on a phrase
+/// are not defeated by Markdown line-wrapping.
+fn normalize_ws(s: &str) -> String {
+    s.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+#[test]
+fn goal_session_objective_fills_spare_capacity_no_idle() {
+    // REQUIRED OUTCOME #1: when live engineers < the AIMD cap and parallelizable
+    // work exists, fill the slots — no idle capacity while work remains.
+    let content = embedded_fallback("goal_session_objective.md")
+        .expect("goal_session_objective.md must be registered");
+    let lower = content.to_lowercase();
+    assert!(
+        lower.contains("fill spare capacity"),
+        "must teach filling spare capacity"
+    );
+    assert!(
+        lower.contains("below the aimd cap"),
+        "fan-out must trigger when live engineers are below the AIMD cap (spare capacity)"
+    );
+    assert!(
+        lower.contains("sits idle") && lower.contains("parallelizable work remains"),
+        "must assert no engineer slot sits idle while parallelizable work remains"
+    );
+}
+
+#[test]
+fn goal_session_objective_parallelism_assigns_distinct_bounded_work() {
+    // REQUIRED OUTCOME #1 & #5: each parallel engineer works a DISTINCT, BOUNDED
+    // item (one issue / one bounded file-set per goal) — never duplicating work.
+    let content = embedded_fallback("goal_session_objective.md")
+        .expect("goal_session_objective.md must be registered");
+    let lower = content.to_lowercase();
+    assert!(
+        lower.contains("done-when") || lower.contains("done when"),
+        "each per-issue goal must carry an explicit done-when criterion (bounded work)"
+    );
+    assert!(
+        lower.contains("distinct work only"),
+        "must state the distinct-work-only rule"
+    );
+    assert!(
+        lower.contains("one issue") && lower.contains("per goal"),
+        "must bound each goal to one issue (or one bounded file-set) per goal"
+    );
+}
+
+#[test]
+fn goal_session_objective_parallelism_is_resource_aware() {
+    // HARD CONSTRAINT: "fill the machine" must stay resource-aware — the AIMD cap
+    // raises additively while there is headroom and BACKS OFF under CPU / memory /
+    // 429 pressure. The prompt must keep describing that safety behavior so the
+    // "safe" in "maximum safe parallelism" is never lost.
+    let content = embedded_fallback("goal_session_objective.md")
+        .expect("goal_session_objective.md must be registered");
+    let lower = content.to_lowercase();
+    assert!(
+        lower.contains("additively"),
+        "must describe additive increase of the cap while there is headroom"
+    );
+    assert!(
+        lower.contains("backs off") && lower.contains("pressure"),
+        "must describe the cap backing off under pressure"
+    );
+    assert!(
+        content.contains("429"),
+        "must name the 429 / rate-limit backoff signal"
+    );
+    assert!(
+        lower.contains("shrinks automatically under load"),
+        "the AIMD ceiling must shrink automatically under load (never hard-thrash)"
+    );
+}
+
+#[test]
+fn goal_session_objective_parallelism_preserves_rysweet_gate() {
+    // REQUIRED OUTCOME #5: the per-issue fan-out must NOT bypass the operator's
+    // `rysweet`-only author gate (Priority Order tier 0). Each spawned engineer
+    // verifies the issue author before acting.
+    let content = embedded_fallback("goal_session_objective.md")
+        .expect("goal_session_objective.md must be registered");
+    let lower = content.to_lowercase();
+    assert!(
+        lower.contains("priority order tier 0"),
+        "the parallel fan-out must still honor Priority Order tier 0"
+    );
+    assert!(
+        lower.contains("rysweet"),
+        "the per-issue fan-out must keep the rysweet-only gate"
+    );
+    assert!(
+        content.contains("gh issue view"),
+        "each engineer must verify the issue author (gh issue view) before acting"
+    );
+}
+
+#[test]
+fn goal_session_objective_preserves_loop_awareness() {
+    // REQUIRED OUTCOME #5 (#2404): parallel engineers must not all re-triage the
+    // same thing. The decomposition IS the loop-break: decompose and ship rather
+    // than re-triaging the same list every cycle.
+    let content = embedded_fallback("goal_session_objective.md")
+        .expect("goal_session_objective.md must be registered");
+    let lower = content.to_lowercase();
+    assert!(
+        lower.contains("loop awareness still applies"),
+        "loop-awareness (#2404) must be preserved in the parallelism strategy"
+    );
+    assert!(
+        lower.contains("loop-break"),
+        "the decomposition must be framed as the loop-break"
+    );
+    assert!(
+        lower.contains("re-triage"),
+        "must warn against re-triaging the same list every cycle"
+    );
+}
+
+#[test]
+fn goal_session_objective_surfaces_not_silently_reloops() {
+    // HARD CONSTRAINT: surface failures explicitly; no silent degradation. The
+    // pull-fresh-work strategy must surface the proposal and never silently
+    // re-loop. (Phrase spans wrapped lines, so normalize whitespace first.)
+    let content = embedded_fallback("goal_session_objective.md")
+        .expect("goal_session_objective.md must be registered");
+    let norm = normalize_ws(content).to_lowercase();
+    assert!(
+        norm.contains("surface the proposal"),
+        "must surface the proposal to the operator"
+    );
+    assert!(
+        norm.contains("never silently re-loop"),
+        "must never silently re-loop (no silent degradation)"
+    );
+}
+
+#[test]
+fn ooda_decide_parallelism_is_resource_aware() {
+    // The Decide note must also frame parallelism as resource-aware: the coverage
+    // allocator spawns up to the AIMD cap, which backs off under pressure.
+    let content = embedded_fallback("ooda_decide.md").expect("ooda_decide.md must be registered");
+    let lower = content.to_lowercase();
+    assert!(
+        lower.contains("backs off") && lower.contains("pressure"),
+        "ooda_decide.md parallelism note must describe the cap backing off under pressure"
+    );
+    assert!(
+        content.contains("429"),
+        "ooda_decide.md must name the 429 backoff signal in the parallelism note"
+    );
+}

--- a/src/ooda_brain/prompt_store_tests.rs
+++ b/src/ooda_brain/prompt_store_tests.rs
@@ -569,3 +569,140 @@ fn progress_reviewer_rejects_reasserted_stalled_high_pct() {
         "a re-asserted stalled high percent must be rejected, not accepted as progress"
     );
 }
+
+// ── Maximum safe parallelism — fill spare capacity (Step 6) ──────────────
+//
+// These tests pin the prompt guidance that makes Simard fill spare machine
+// capacity with concurrent engineers on DISTINCT work items, bounded by the
+// existing AIMD safety cap. The fan-out is prompt-driven (decompose an umbrella
+// goal into distinct per-issue goals via `simard goal add`); the coverage
+// allocator + AIMD cap then parallelize them. The Rust output contracts the
+// parsers depend on (DECISION marker, Spawn-an-engineer / NO ACTION shapes)
+// must remain intact.
+
+#[test]
+fn goal_session_objective_teaches_maximum_safe_parallelism() {
+    let content = embedded_fallback("goal_session_objective.md")
+        .expect("goal_session_objective.md must be registered");
+    let lower = content.to_lowercase();
+    assert!(
+        lower.contains("maximum safe parallelism"),
+        "goal_session_objective.md must teach a Maximum-safe-parallelism strategy"
+    );
+    // Fan-out is via decomposing an umbrella into distinct per-issue goals,
+    // created with `simard goal add`, so coverage can parallelize them.
+    assert!(
+        lower.contains("simard goal add"),
+        "the fan-out must create concrete per-issue goals via `simard goal add`"
+    );
+    assert!(
+        lower.contains("decompose") && lower.contains("distinct"),
+        "must decompose an umbrella goal into distinct per-issue goals"
+    );
+    // Bounded by the EXISTING AIMD safety cap — not an unbounded spawn.
+    assert!(
+        lower.contains("aimd cap") || lower.contains("aimd safety cap"),
+        "fan-out must stay bounded by the AIMD safety cap"
+    );
+    // The operator override that widens the resource-bounded ceiling.
+    assert!(
+        content.contains("SIMARD_MAX_CONCURRENT_ACTIONS"),
+        "must point to SIMARD_MAX_CONCURRENT_ACTIONS for widening the ceiling"
+    );
+}
+
+#[test]
+fn goal_session_objective_parallelism_is_collision_safe() {
+    // Parallel engineers must work DISTINCT items — never duplicate or re-triage
+    // the same issue (preserves the #2404 loop-awareness).
+    let content = embedded_fallback("goal_session_objective.md")
+        .expect("goal_session_objective.md must be registered");
+    let lower = content.to_lowercase();
+    assert!(
+        lower.contains("one goal per issue"),
+        "collision guard: exactly one goal per distinct issue"
+    );
+    assert!(
+        lower.contains("never two engineers on the same issue"),
+        "collision guard: never two engineers on the same issue"
+    );
+    // The umbrella delegates to per-issue goals rather than duplicating them.
+    assert!(
+        lower.contains("delegate"),
+        "the umbrella must delegate to per-issue goals, not duplicate their work"
+    );
+}
+
+#[test]
+fn goal_session_objective_parallelism_keeps_response_shapes() {
+    // The fan-out must reuse the existing "Spawn an engineer" response shape and
+    // must NOT invent a new shape the Rust parser cannot read. Both documented
+    // shapes (Spawn an engineer / NO ACTION) remain intact.
+    let content = embedded_fallback("goal_session_objective.md")
+        .expect("goal_session_objective.md must be registered");
+    let lower = content.to_lowercase();
+    assert!(
+        lower.contains("spawn an engineer"),
+        "fan-out must use the existing Spawn-an-engineer response shape"
+    );
+    assert!(
+        content.contains("NO ACTION"),
+        "the NO ACTION response shape must remain documented"
+    );
+}
+
+#[test]
+fn ooda_decide_explains_parallelism_without_new_variant() {
+    let content = embedded_fallback("ooda_decide.md").expect("ooda_decide.md must be registered");
+    let lower = content.to_lowercase();
+    assert!(
+        lower.contains("parallelism"),
+        "ooda_decide.md must explain how per-cycle parallelism is achieved"
+    );
+    // Parallelism comes from routing each DISTINCT goal to advance_goal — there
+    // is NO new parallel/spawn-N variant (output contract unchanged).
+    assert!(
+        content.contains("advance_goal") && lower.contains("invent one"),
+        "parallelism must route distinct goals to advance_goal with no invented variant"
+    );
+    assert!(
+        lower.contains("aimd safety cap") || lower.contains("aimd cap"),
+        "parallelism must be bounded by the AIMD safety cap"
+    );
+}
+
+#[test]
+fn ooda_decide_first_line_decision_contract_preserved() {
+    // The Rust parser reads the FIRST non-blank line for a `DECISION:` marker.
+    // Body additions must not disturb that contract.
+    let content = embedded_fallback("ooda_decide.md").expect("ooda_decide.md must be registered");
+    let first_non_blank = content
+        .lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty())
+        .expect("ooda_decide.md must have a non-blank line");
+    assert!(
+        first_non_blank.contains("DECISION:"),
+        "first non-blank line must still assert the DECISION contract, got: {first_non_blank:?}"
+    );
+}
+
+#[test]
+fn ooda_decide_recipe_mirrors_parallelism_note() {
+    // The runtime recipe (recipe-runner-rs path) must stay in sync with the
+    // embedded ooda_decide.md prompt on the parallelism guidance.
+    let recipe = include_str!("../../prompt_assets/simard/recipes/ooda-decide.yaml");
+    let lower = recipe.to_lowercase();
+    assert!(
+        lower.contains("parallelism") && recipe.contains("advance_goal"),
+        "ooda-decide.yaml must mirror the parallelism note routing distinct goals to advance_goal"
+    );
+    assert!(
+        lower.contains("aimd safety cap") || lower.contains("aimd cap"),
+        "ooda-decide.yaml parallelism note must reference the AIMD safety cap"
+    );
+    assert!(
+        lower.contains("invent one"),
+        "ooda-decide.yaml must forbid inventing a new parallel action variant"
+    );
+}


### PR DESCRIPTION
## Summary

Make Simard use **maximum safe parallelism**: when the machine has spare
capacity (live engineers below the AIMD cap) **and** a goal bundles multiple
independent open issues, fill the free slots with concurrent engineers — each on
a **distinct** issue — up to the existing AIMD safety cap, instead of ~1 serial
engineer.

Motivating case: the goal `find-and-fix-recent-rysweet-filed-amplihack-rs-…`
covers six open issues (#804, #807, #808, #809, #810, #815) that can be fixed in
parallel, yet only one engineer was working them serially.

## Why this is prompt-only (verified architecture)

Read before changing anything (origin/main = `3ad00d2d`):

- **Orient** emits **one `Priority` per active goal** (code-driven `.map()` over
  `goals.active`) — it does not fan one goal into many.
- **Decide** (`decide_with_brain`) emits **one `PlannedAction` per priority**; the
  brain returns a single `DECISION: <variant>`. The schema **cannot** express
  multiple parallel dispatches for a single goal.
- **Act** (`dispatch_advance_goal`) **short-circuits when `goal.assigned_to` is
  set** (heartbeat) and spawning is de-duplicated per goal
  (`find_live_engineer_for_goal`). The single `assigned_to` slot makes the system
  **one-engineer-per-goal**.
- **Coverage** (`ensure_goal_coverage`) already spawns **one engineer per
  incomplete goal, up to the AIMD cap** — so multi-*goal* parallelism already
  works.

Conclusion: the unit of parallelism is the **goal**, and the architecture-aligned
way to fill the machine for a multi-issue goal is to **decompose it into distinct
per-issue goals** (via the existing `simard goal add`), which coverage + the AIMD
cap already parallelize. This needs **no core code change**, so it is prompt-only
and hot-reloads from `~/.simard/prompt_assets/simard/` — **no binary rebuild
required**. The decide-schema limitation is therefore handled at the goal level,
not by bypassing the safety cap.

The AIMD resource-safety cap is **unchanged**: additive +1 increase while
pressure < 0.3, halve on CPU/mem > 0.8 or 429/rate-limit, `floor=1`,
`ceiling = 4 × SIMARD_MAX_CONCURRENT_ACTIONS` (default base 5 → ceiling 20 —
already ample; widen via that env var).

## Changes

- `prompt_assets/simard/goal_session_objective.md` — first-class **Maximum safe
  parallelism** strategy: decompose an umbrella goal into distinct per-issue
  goals; **one issue per goal**; the umbrella **delegates** rather than
  duplicating; bounded by the AIMD cap; `rysweet`-only gate and #2404
  loop-awareness preserved.
- `prompt_assets/simard/ooda_decide.md` + `recipes/ooda-decide.yaml` —
  **Parallelism** note: fan-out comes from distinct goals each routed to
  `advance_goal`; the **one-`DECISION`-per-priority contract is unchanged** and no
  new variant is introduced.
- `docs/reference/maximum-safe-parallelism.md` — new canonical reference (+ mkdocs
  nav entry, cross-link from `goal-coverage-allocation.md`).
- `src/ooda_brain/prompt_store_tests.rs` — 13 prompt-content tests pinning the new
  guidance, the REQUIRED OUTCOMES/HARD CONSTRAINTS, and the preserved output
  contracts.

## Collision-safety

One issue per goal; the umbrella delegates and does not also fix the issues;
per-goal spawn de-dup (`assigned_to` + `find_live_engineer_for_goal`) preserved;
#2404 loop-awareness preserved (this decomposition **is** the loop-break for a
re-triage loop). Distinct engineers work distinct items — no duplication.

---

### QA-team evidence

This is a prompt + docs change; the enforceable behavioral contract is the
prompt content and the Rust output contracts, validated by unit tests
(`gadugi-test` scenarios apply to engineer code changes, not prompt/doc content).

- 13 new prompt-content tests + existing prompt suite — `48 passed; 0 failed`:
  ```
  cargo test --lib ooda_brain::prompt_store_tests
  test result: ok. 48 passed; 0 failed; 0 ignored; ... finished in 1.10s
  ```
  Headline tests (feature commit): `goal_session_objective_teaches_maximum_safe_parallelism`,
  `goal_session_objective_parallelism_is_collision_safe`,
  `goal_session_objective_parallelism_keeps_response_shapes`,
  `ooda_decide_explains_parallelism_without_new_variant`,
  `ooda_decide_first_line_decision_contract_preserved`,
  `ooda_decide_recipe_mirrors_parallelism_note`.
  Step-7 (TDD) outcome/constraint tests: `goal_session_objective_fills_spare_capacity_no_idle`,
  `goal_session_objective_parallelism_assigns_distinct_bounded_work`,
  `goal_session_objective_parallelism_is_resource_aware`,
  `goal_session_objective_parallelism_preserves_rysweet_gate`,
  `goal_session_objective_preserves_loop_awareness`,
  `goal_session_objective_surfaces_not_silently_reloops`,
  `ooda_decide_parallelism_is_resource_aware`.
- Related behavioral modules (no regression) — `61 passed; 0 failed`:
  ```
  cargo test --lib -- ooda_loop::coverage ooda_actions::goal_session \
    ooda_loop::decide ooda_actions::tests_advance_goal
  test result: ok. 61 passed; 0 failed; ...
  ```

### Documentation

- New canonical reference: `docs/reference/maximum-safe-parallelism.md`
  (problem, end-to-end mechanism, AIMD cap, one-engineer-per-goal, the
  decomposition fill path, collision-safety, output contracts, invariants,
  worked example).
- Added to mkdocs nav; cross-linked from `goal-coverage-allocation.md`.
- `mkdocs build --strict` builds clean (exit 0); the new page emits no
  warnings/broken links.

### Quality-audit

- **Ruthless simplicity / prompt-preferred:** no core code change — the existing
  coverage + AIMD machinery does the parallelization; only prompts steer the
  brain to create distinct coverable units.
- **No silent degradation:** the AIMD safety cap (CPU/mem/429 backoff) is intact;
  fill remains resource-aware and cannot thrash the host.
- **Output contracts preserved:** `DECISION:` first-line marker, the
  first-word keyword (recipe), and the Spawn-an-engineer / `NO ACTION` /
  `PROGRESS: NN` shapes are unchanged — pinned by tests.
- `cargo fmt --all -- --check` → clean; `cargo clippy --lib --tests` → clean
  (0 warnings).

### CI

Validated locally (full CI runs on this PR):
`cargo fmt --check` ✅ · `cargo clippy --lib --tests` ✅ (0 warnings) ·
prompt-content + related unit tests ✅ (48 + 61 passed) ·
`mkdocs build --strict` ✅.

### PR description evidence

This description contains all six sections with concrete artifacts (file paths,
commands, and test output).

### Scope

7 files, focused on the parallelism behavior: 3 prompt assets, 1 new doc + nav +
1 cross-link, 1 test file (test-only). No unrelated changes; no core Rust logic
modified.


## Step 7 (TDD) — outcome/constraint regression tests

Added 7 more prompt-content tests (`test(ooda): pin maximum-safe-parallelism
outcomes and safety constraints`) so every REQUIRED OUTCOME and HARD CONSTRAINT
is pinned and cannot silently regress when the prompts are edited:

- **No idle capacity** — fan-out triggers while live engineers are below the
  AIMD cap; no slot sits idle while parallelizable work remains.
- **Distinct, bounded work** — each per-issue goal carries an explicit
  done-when criterion; one issue / bounded file-set per goal.
- **Resource-aware AIMD** — additive increase with headroom; halve/back-off
  under CPU/memory/429 pressure; shrinks under load (never hard-thrash).
- **`rysweet`-only gate** — per-issue fan-out keeps Priority Order tier 0 and
  verifies the author via `gh issue view` before acting.
- **#2404 loop-awareness** — the decomposition is the loop-break; engineers do
  not re-triage the same list every cycle.
- **No silent degradation** — surface the proposal, never silently re-loop.

These are test-only Rust; they do not change the shipped binary. Green locally
(`cargo test --lib ooda_brain::prompt_store_tests` → 48 passed), `cargo fmt
--check` clean, `cargo clippy --lib --tests` clean (0 warnings).

## Deployment note

**Prompt-only + docs → hot-reload.** The behavior change lives entirely in
`prompt_assets/simard/` and hot-reloads from `~/.simard/prompt_assets/simard/`
— **no binary rebuild or daemon swap is required.** (The added prompt-content
tests are test-only Rust and do not affect the shipped binary.)

