### PR TITLE
feat(prompts): add bounded PR-finalization review pipeline (crusty loop → pr-guide → final review) before merge-ready

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -139,6 +139,7 @@ If you are changing architecture, start with the [architecture overview](./archi
 - [Adaptive scaling API reference](./reference/adaptive-scaling-api.md) — AdaptiveScaler Rust API and integration.
 - [Maximum safe parallelism](./reference/maximum-safe-parallelism.md) — how the OODA daemon fills spare capacity with concurrent engineers on distinct work items, bounded by the AIMD safety cap.
 - [Concurrent engineer dispatch](./reference/concurrent-engineer-dispatch.md) — how the Act phase dispatches spawn-path AdvanceGoal actions concurrently (per-goal LLM sessions, atomic claim, semaphore cap) so multiple engineers start in a single OODA round.
+- [PR-finalization review pipeline](./reference/pr-finalization-pipeline.md) — the bounded, ordered review pipeline every engineer runs before merge: a high-end-model crusty review→fix loop, the pr-guide illustrated walkthrough (graceful-skip), a final lightweight review, then the existing merge-ready gate → merge → close issue.
 
 - [Agent composition](./architecture/agent-composition.md) - How Simard composes subordinate agents with goal assignment, supervision, and crash recovery.
 - [Cognitive memory](./architecture/cognitive-memory.md) - Six-type memory model, session lifecycle mapping, and hive mind integration.

--- a/docs/reference/pr-finalization-pipeline.md
+++ b/docs/reference/pr-finalization-pipeline.md
@@ -1,0 +1,312 @@
+---
+title: PR-finalization review pipeline reference
+description: The bounded, ordered review pipeline every Simard engineer runs at the end of a PR — a high-end-model crusty review→fix loop, the pr-guide illustrated walkthrough, a final lightweight review, then the existing merge-ready gate → merge → close issue. Prompt-driven, hot-reloads, builds on #2404/#2405/#2410.
+last_updated: 2026-06-26
+owner: simard
+doc_type: reference
+status: reference
+related:
+  - ../howto/edit-the-engineer-system-prompt.md
+  - ./concurrent-engineer-dispatch.md
+  - ./maximum-safe-parallelism.md
+  - ../howto/spawn-engineers-from-ooda-daemon.md
+  - ../concepts/prompt-driven-tdd-discipline.md
+---
+
+# PR-finalization review pipeline reference
+
+> **Goal:** Before any PR an engineer opens is merged, run an **ordered,
+> bounded** finalization pipeline — (1) a **crusty-old-engineer** review→fix
+> loop on a **high-end reasoning model**, fixing every actionable finding and
+> re-reviewing the *latest* PR state until crusty is satisfied or a cap is hit;
+> (2) the **pr-guide** illustrated walkthrough (graceful-skip where unavailable);
+> (3) a **final lightweight review** pass; then (4) the existing **merge-ready**
+> gate → merge → close issue. The loop runs **inside one engineer's PR
+> finalization** — it never spins the OODA goal-action brain.
+
+This pipeline is **prompt-driven**. This change **adds** it as a new ordered
+section in `prompt_assets/simard/engineer_system.md` (the engineer's
+PR-finalization instructions) and **adds a short cross-reference note** in
+`prompt_assets/simard/goal_session_objective.md` (so the OODA brain knows
+finalization runs *inside* the engineer and does not spin the goal-action
+cycle); the gate is enforced **before** merge. Both prompt edits are net-new
+content this change introduces — they do not exist today. The engineer-lifecycle
+recipe (`recipes/ooda-engineer-lifecycle.yaml`) is **unchanged** — it dispatches
+the engineer that reads `engineer_system.md`, so no recipe edit is required. The
+change introduces **no new Rust decision logic** and **hot-reloads** from
+`~/.simard/prompt_assets/simard/` — see [Deployment](#deployment).
+
+It builds **on top of** three earlier behaviors and must not regress them:
+
+- **Loop-awareness (#2404)** — the engineer does the review loop *internally*;
+  the goal-action brain only dispatches and checks, so the OODA cycle does not
+  re-loop on a goal whose engineer is mid-finalization.
+- **Parallel fan-out (#2405)** — finalization is per-PR and per-engineer, so
+  multiple engineers can finalize their own PRs concurrently up to the AIMD cap
+  (see [concurrent engineer dispatch](./concurrent-engineer-dispatch.md)).
+- **Own-PRs-to-landing (#2410)** — finalization is the work that *precedes* the
+  existing "drive to merge" landing behavior; it does not replace it.
+
+## Where it sits in the engineer flow
+
+The pipeline slots into the engineer's **Definition of Done** between "PR opened
+with evidence headings" and "Drive to merge". The merge step is now **gated on
+the pipeline having run**:
+
+```
+commit → push → open/update PR (evidence headings)
+        │
+        ▼
+┌─────────────────────────────────────────────────────────────┐
+│  PR-FINALIZATION PIPELINE  (this reference)                  │
+│                                                             │
+│  1. CRUSTY REVIEW→FIX LOOP   (high-end model, bounded cap)  │
+│       review → fix every finding → push → re-review LATEST  │
+│       … repeat until satisfied OR cap reached               │
+│  2. PR-GUIDE                 (illustrated guide; skip-OK)   │
+│  3. FINAL REVIEW             (one lightweight pass)         │
+└─────────────────────────────────────────────────────────────┘
+        │
+        ▼
+  4. MERGE-READY skill → simard merge-pr / gh pr merge → close issue   (#2410)
+```
+
+Stages 1–3 run **only after** the PR is open and the six merge-ready evidence
+headings are present; stage 4 is the pre-existing
+[Merge-Ready Contract](../howto/edit-the-engineer-system-prompt.md) path and is
+unchanged except that it now runs **last**.
+
+## Stage 1 — crusty review→fix loop (high-end model)
+
+The engineer invokes the **crusty-old-engineer** skill to review the PR's
+diff/changes, then fixes **every actionable finding** and re-reviews, looping
+until crusty is satisfied or the cap is reached.
+
+| Property | Behavior |
+|----------|----------|
+| **Reviewer** | `crusty-old-engineer` skill — a curmudgeonly senior-engineer reviewer that surfaces correctness, maintainability, and long-term-consequence findings. |
+| **Model** | A **high-end reasoning model**, pinned explicitly (the engineer itself runs the Copilot CLI default/auto model, so crusty is invoked through a `copilot --model "$SIMARD_REVIEW_MODEL"` subprocess to force the high-end model). Default `gpt-5.4`; see [Configuration](#configuration). |
+| **Per-iteration input** | The **latest** PR state — the engineer re-fetches the current diff each iteration (`gh pr diff <PR>`); it never re-reviews a stale diff. |
+| **Fix discipline** | Every **actionable / blocking** finding is fixed in code and pushed to the **same PR branch** before the next review. |
+| **Termination** | Crusty reports **no blocking/actionable findings** (satisfied), OR the iteration cap is reached. See [Bounded loop & blocker semantics](#bounded-loop--blocker-semantics). |
+| **Satisfied signal** | A **structural sentinel** verdict (the review's first output line is exactly `NO BLOCKING FINDINGS`) gates "satisfied" — not free-text — so a chatty review cannot accidentally pass the gate. |
+
+Each iteration is, in order: **re-fetch latest diff → crusty review on the
+high-end model → if blocking findings remain, fix + push → loop**. The loop
+operates on the freshly-pushed state every time (no TOCTOU on a stale diff).
+
+### Trivial-PR filtering (cost awareness)
+
+The full loop is expensive (a high-end reasoning model, multiple passes), so it
+runs **only on non-trivial PRs**. A **trivial** PR — docs/comments-only, or a
+small change (roughly **< 3 files / < ~30 changed lines**) — gets a **single
+lightweight pass**, not the loop. This mirrors pr-guide's own trivial filter and
+keeps the high-end loop's spend within the daemon's pre-existing daily budget
+(`SIMARD_DAILY_BUDGET_USD`, default `500`, tracked by the OODA loop — **not**
+read or enforced by this pipeline; see [Configuration](#configuration)).
+
+## Stage 2 — pr-guide (illustrated walkthrough)
+
+The engineer runs the **pr-guide** skill to generate or update the PR's
+illustrated guide — an end-of-workflow walkthrough of the change.
+
+> **Graceful degradation (the only sanctioned skip).** `pr-guide` ships in the
+> amplihack-rs amplifier bundle and is available to engineers working in repos
+> that ship that bundle. In a repo where the `pr-guide` skill is **not
+> available**, the engineer **logs a note** ("pr-guide unavailable in
+> `<owner/repo>`, skipping illustrated guide") and **continues** the pipeline.
+> It does **not** hard-fail. This is the *only* place in the pipeline where a
+> missing step is tolerated; crusty and merge-ready failures always surface as
+> blockers.
+
+pr-guide applies its own trivial/small-PR filter, so a one-line or doc-only PR
+may legitimately produce no guide.
+
+## Stage 3 — final review (one lightweight pass)
+
+After the guide is generated, the engineer reviews the PR **once more** — a
+single, lightweight correctness/consistency pass to catch anything the guide
+generation or the last fix introduced. This is **one pass, no loop**, on the
+engineer's default model (it may be a single crusty pass or the existing
+`review_pipeline`). It is a final sanity check, not a second review→fix loop.
+
+## Stage 4 — merge-ready → merge → close issue
+
+Only after stages 1–3 does the engineer run the final **merge-ready** gate and
+land the PR through the **gated merge authority** described in the
+[Merge-Ready Contract](../howto/edit-the-engineer-system-prompt.md) and #2410:
+
+> **Layering note.** The six merge-ready *criteria and evidence headings* are
+> **not** new work introduced at stage 4 — they are gathered when the PR is first
+> opened (the engineer's Definition-of-Done step 3, *"PR opened with evidence
+> headings"*, in `engineer_system.md`). What stage 4 adds is the final
+> **gate + merge**: re-verify that the evidence headings are present and CI is
+> green, then merge. Stages 1–3 run *between* "PR opened with evidence" and this
+> gate; the gate is the step they precede, not a re-collection of evidence.
+
+- `rysweet/Simard` PR → `simard merge-pr <PR>` (re-checks the objective gates and
+  the merge-readiness judge before invoking `gh pr merge --squash --delete-branch`).
+- Cross-repo PR → verify the six criteria yourself, then
+  `gh pr merge --squash --delete-branch <PR> --repo <owner/repo>`.
+
+Then **close the linked issue** (`Closes #<N>` auto-close for same-repo; explicit
+`gh issue close <N> --repo <owner/repo>` for cross-repo). A fix/implement goal is
+**done only when its PR is merged and the issue is closed** — unchanged from
+#2410.
+
+## Configuration
+
+This change introduces **two net-new** knobs (`SIMARD_REVIEW_MODEL`,
+`SIMARD_REVIEW_MAX_ITERS`) that **do not exist today** — they are read by the
+new PR-finalization section of the engineer prompt; **no Rust threading is
+required** — the engineer subprocess inherits the daemon's environment.
+`SIMARD_DAILY_BUDGET_USD` is a **pre-existing** daemon knob (already read by the
+OODA loop) shown here for context only; this pipeline does not read it.
+
+| Variable | New? | Default | Range / Allowlist | Purpose |
+|----------|------|---------|-------------------|---------|
+| `SIMARD_REVIEW_MODEL` | **net-new** | `gpt-5.4` | Validated against an allowlist (`gpt-5.4`, `gpt-5.4-mini`, …) before being passed to `copilot --model`; an unrecognized value falls back to the default. | The high-end reasoning model the crusty review loop runs on. Defined and read by the new engineer-prompt section. |
+| `SIMARD_REVIEW_MAX_ITERS` | **net-new** | `3` | Integer, bounded to `[1, 5]`. | Hard cap on crusty review→fix iterations before the loop must terminate. Defined and read by the new engineer-prompt section. |
+| `SIMARD_DAILY_BUDGET_USD` | pre-existing | `500` | — | **Pre-existing** Simard knob, read by the OODA-loop budget tracker (`src/ooda_loop/types.rs`, default `500.0`) — **not** introduced or consumed by this pipeline. It is the daemon-wide spend ceiling, not a per-pipeline gate; the trivial-PR filter and the iteration cap are what actually bound *this* loop's spend. |
+
+> **Model verification.** `gpt-5.4` is the verified high-end default — it is
+> accepted by `copilot --model gpt-5.4` on the enterprise Copilot endpoint. If
+> you change `SIMARD_REVIEW_MODEL`, confirm the new string is accepted by the CLI
+> (`copilot --model <X> -p "reply OK"`) before deploying; an unaccepted value
+> falls back to the default rather than failing the pipeline.
+
+### Examples
+
+Run the default pipeline (high-end crusty review on `gpt-5.4`, cap 3) — no
+configuration needed; this is the shipped default.
+
+Pin a different high-end model and widen the cap to 5 for a session:
+
+```bash
+export SIMARD_REVIEW_MODEL=gpt-5.4
+export SIMARD_REVIEW_MAX_ITERS=5
+```
+
+Confirm a candidate model string before adopting it:
+
+```bash
+copilot --model gpt-5.4 -p "Reply with exactly: OK" --allow-all-tools
+# expect: OK
+```
+
+## Bounded loop & blocker semantics
+
+The crusty loop **must terminate**. It ends when either:
+
+1. **Crusty is satisfied** — the sentinel verdict `NO BLOCKING FINDINGS` is
+   emitted on the latest PR state. The engineer proceeds to stage 2.
+2. **The cap is reached** (`SIMARD_REVIEW_MAX_ITERS`, default 3) **with findings
+   still open.** The engineer then, in order:
+   - posts the **remaining findings as a PR comment** (so they are visible on the
+     PR), and
+   - surfaces a **goal blocker** in `cycle_summary.engineer_summary`
+     (e.g. "PR #819 blocked: crusty review not satisfied after 3 iterations —
+     remaining findings posted on the PR"),
+   - and **does NOT merge.** Silent merge-past-unsatisfied-findings is forbidden.
+
+This honesty rule mirrors the existing #2410 blocker contract: an un-satisfiable
+review is an **external/quality blocker to surface**, never a reason to silently
+land the PR.
+
+## Output-contract preservation
+
+The pipeline is **additive prose only**. It preserves every output contract the
+Rust parsers depend on:
+
+| Surface | Contract | Effect of this pipeline |
+|---------|----------|-------------------------|
+| Engineer system prompt | Free prose (no parser) | New ordered section added; no parsed shape. |
+| `goal_session_objective.md` | **Prose-only** goal-action output | A short cross-reference note added; still prose-only, parsed shape unchanged. |
+| `ooda_decide` | `DECISION:` keyword | Untouched. |
+| Progress-assessment reviewer | JSON | Untouched. |
+
+Prompt-content tests in `src/ooda_brain/prompt_store_tests.rs` assert the new
+pipeline anchors are baked into the embedded prompts (content assertions only —
+no parser or logic changes).
+
+## Security model
+
+The review→merge automation is guarded by a small set of controls. The
+**genuinely enforced** controls are GitHub branch protection and the
+repo-scoped token; the prompt-level guardrails are defense-in-depth.
+
+> **Operational prerequisite — required.** On **any repo where this pipeline can
+> merge**, server-side **GitHub branch protection** (required status checks +
+> required reviews) and a **least-privilege, repo-scoped token** MUST be
+> configured. These are the only controls that are actually enforced; the
+> prompt guardrails below assume they are in place.
+
+- **Command injection** — every shell expansion is quoted (`"$VAR"`); the review
+  prompt is built via heredoc; PR title/body/diff are passed as **data**, never
+  interpolated into the command string.
+- **Model allowlist** — `SIMARD_REVIEW_MODEL` is validated against an allowlist
+  before reaching `--model`; `SIMARD_REVIEW_MAX_ITERS` is integer-bounds-checked
+  to `[1, 5]`.
+- **Prompt-injection / TOCTOU** — merge is gated on the **structural sentinel**
+  verdict, not free text; the diff is **re-fetched** each loop iteration and
+  again before merge.
+- **Authorization** — self-PR-only (the PR the engineer created/owns); `--admin`
+  / `-f` and protected-branch bypass are forbidden; never merge with required
+  checks failing.
+- **No leakage** — PR comments contain only findings text; env vars, tokens, and
+  full prompts are never echoed; the subprocess command is scrubbed of env before
+  any logging.
+- **No silent degradation** — only `pr-guide` unavailability may be skipped (and
+  it is logged). Crusty and merge failures surface as blockers and never
+  silent-pass to merge.
+
+## Deployment
+
+This is a **prompt-only change** to `prompt_assets/simard/*.md`, so it
+**hot-reloads** from `~/.simard/prompt_assets/simard/` — **no binary rebuild or
+daemon redeploy** is required for the runtime behavior. (The accompanying
+prompt-content assertions in `src/ooda_brain/prompt_store_tests.rs` are compiled
+into the test binary via `include_str!`, so they re-bake on `cargo test`; that is
+a test-only build, not a runtime redeploy.)
+
+Contrast [concurrent engineer dispatch](./concurrent-engineer-dispatch.md), which
+*is* a Rust core change requiring a rebuild + redeploy. For this pipeline, the
+operator deploys by syncing the prompt assets; the live daemon picks them up on
+the next engineer cycle.
+
+## Invariants
+
+- **Ordered.** For every non-trivial PR: crusty loop → pr-guide → final review →
+  merge-ready → merge → close — in that order, with merge gated on the prior
+  stages.
+- **Bounded.** The crusty loop terminates within `SIMARD_REVIEW_MAX_ITERS`
+  iterations; cap-with-findings posts a PR comment + goal blocker and does **not**
+  merge.
+- **Latest-state.** Each loop iteration reviews the freshly-pushed PR state, never
+  a stale diff.
+- **High-end.** The crusty pass runs on the pinned `SIMARD_REVIEW_MODEL`
+  (default `gpt-5.4`), independent of the engineer's default model.
+- **Cost-aware.** Trivial PRs get a single pass; the trivial filter and the
+  iteration cap keep the high-end model's spend bounded, well inside the
+  daemon-wide `SIMARD_DAILY_BUDGET_USD` (which this pipeline does not itself
+  read).
+- **Per-engineer.** The loop runs inside one engineer's finalization; the OODA
+  brain only dispatches/checks — #2404 loop-awareness and #2405 fan-out are
+  preserved.
+- **Graceful-skip scope.** Only `pr-guide` unavailability is skippable; all other
+  failures surface explicitly.
+
+## Related reading
+
+- [How to edit the engineer system prompt](../howto/edit-the-engineer-system-prompt.md)
+  — where the PR-finalization section and the Merge-Ready Contract live.
+- [Concurrent engineer dispatch](./concurrent-engineer-dispatch.md) — how multiple
+  engineers (each finalizing their own PR) start concurrently in one OODA round.
+- [Maximum safe parallelism](./maximum-safe-parallelism.md) — the AIMD cap that
+  bounds how many engineers (and therefore finalization loops) run at once.
+- [How OODA spawns engineer agents](../howto/spawn-engineers-from-ooda-daemon.md)
+  — the dispatch path that hands a goal to the engineer that then runs this
+  pipeline.
+- [Concept: prompt-driven TDD discipline](../concepts/prompt-driven-tdd-discipline.md)
+  — the same prompt-first philosophy this pipeline follows (quality enforced in
+  the prompt, not in Rust).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,7 @@ nav:
     - Goal Coverage Allocation: reference/goal-coverage-allocation.md
     - Maximum Safe Parallelism: reference/maximum-safe-parallelism.md
     - Concurrent Engineer Dispatch: reference/concurrent-engineer-dispatch.md
+    - PR-Finalization Review Pipeline: reference/pr-finalization-pipeline.md
     - Pluggable Identity API: reference/pluggable-identity-api.md
     - Meeting Close Lifecycle: reference/meeting-close-lifecycle.md
     - Azure DevOps ACL Self-Escalation Guard: reference/ado-acl-self-escalation-guard.md

--- a/prompt_assets/simard/engineer_system.md
+++ b/prompt_assets/simard/engineer_system.md
@@ -191,7 +191,66 @@ Whenever an engineer cycle produces code changes, the cycle is NOT complete unti
    - **Scope** — diff summary with confirmation of no unrelated edits
    - **TDD attestation** — exactly one of: `tdd: test-first ordering verified — <link to commit>` (default for in-scope PRs), `tdd-exempt: <reason from §1.1>` (exception cases), or `tdd: not applicable — PR touches no in-scope paths` (ops/docs/prompt PRs). Per `Specs/TDD_ADOPTION.md` §3 Layer 2.
    - **Verdict** — explicit "ready to merge" / "draft" / "blocked" call with rationale
-4. **Drive to merge** — once CI is fully green and the PR has evidence headings, merge through the gated authority. For a `rysweet/Simard` PR the merge verb is `simard merge-pr <PR>`, which re-checks the objective gates (base-branch allow-list, `mergeable == MERGEABLE`, all required checks green) and the merge-readiness judge before it invokes the underlying `gh pr merge --squash --delete-branch` — do not run `gh pr merge` directly to bypass those gates. For a PR in another repo (e.g. amplihack-rs) `simard merge-pr` does not apply; verify the six criteria yourself, then `gh pr merge --squash --delete-branch <PR> --repo <owner/repo>`.
+4. **PR-finalization pipeline** — before the merge-ready gate, run the ordered, bounded **PR-finalization pipeline** on the open PR: a **crusty-old-engineer** review→fix loop on a high-end model → **pr-guide** → a final review. It runs **before merge-ready**; the merge step (step 5) runs **only after the PR-finalization pipeline** has completed. See [PR-finalization pipeline](#pr-finalization-pipeline) below for the full, bounded contract.
+5. **Drive to merge** — once CI is fully green, the PR has evidence headings, AND the PR-finalization pipeline has run, merge through the gated authority. For a `rysweet/Simard` PR the merge verb is `simard merge-pr <PR>`, which re-checks the objective gates (base-branch allow-list, `mergeable == MERGEABLE`, all required checks green) and the merge-readiness judge before it invokes the underlying `gh pr merge --squash --delete-branch` — do not run `gh pr merge` directly to bypass those gates. For a PR in another repo (e.g. amplihack-rs) `simard merge-pr` does not apply; verify the six criteria yourself, then `gh pr merge --squash --delete-branch <PR> --repo <owner/repo>`.
+
+### PR-finalization pipeline
+
+Every PR you open runs through an **ordered, bounded PR-finalization pipeline**
+**before merge-ready** — after the fix is implemented and the PR is opened/updated,
+but before you drive it to merge (step 5 above). The merge step runs **only after the
+PR-finalization pipeline** has completed. The pipeline orchestrates three named skills
+in order — **crusty-old-engineer**, then **pr-guide**, then a **final review** — and
+only then the existing **merge-ready** gate. Full reference:
+`docs/reference/pr-finalization-pipeline.md`.
+
+The full pipeline runs on a **non-trivial PR**. A **trivial** PR (docs/comments-only,
+or roughly < 3 files / < ~30 changed lines) gets a **single lightweight pass** instead
+of the loop — a high-end review is expensive, so be **cost**-aware. (This stays well
+inside the daemon-wide `SIMARD_DAILY_BUDGET_USD`, default 500, which this pipeline does
+not itself read; the trivial filter and the iteration cap are what bound this loop's
+spend.)
+
+**Stage 1 — crusty review→fix loop (high-end model).** Invoke the
+**crusty-old-engineer** skill to review the PR's diff/changes on a **high-end**
+reasoning model. The engineer itself runs the Copilot default/auto model, so crusty
+MUST be pinned to the high-end model via a `copilot --model "$SIMARD_REVIEW_MODEL"`
+subprocess. The model is configurable via **`$SIMARD_REVIEW_MODEL`** and defaults to the
+verified **gpt-5.4** (confirmed accepted by `copilot --model gpt-5.4`). Each iteration,
+in order:
+
+1. Re-fetch the **latest PR state** (`gh pr diff <PR>`) — never re-review a **stale diff**.
+2. Run crusty on the high-end model over that latest diff.
+3. Fix **every actionable finding** crusty raises in code and push to the **same PR branch**.
+4. **Re-review** the freshly-pushed state.
+
+Loop until crusty emits the structural sentinel verdict `NO BLOCKING FINDINGS`
+(satisfied) OR the bounded iteration **cap** is reached. The cap is configurable via
+**`$SIMARD_REVIEW_MAX_ITERS`** (**default 3**, bounded to `[1, 5]`); it MUST terminate
+the loop so a review→fix loop can never run forever. Each iteration operates on the
+freshly-pushed PR state — no TOCTOU on a stale diff.
+
+**If the cap is reached with findings still open:** post the **remaining findings as a
+PR comment** (so they are visible on the PR), surface a goal **blocker** in
+`cycle_summary.engineer_summary` (e.g. "PR #819 blocked: crusty review not satisfied
+after 3 iterations — remaining findings posted on the PR"), and **do not merge.**
+Silently merging past unsatisfied crusty findings is forbidden.
+
+**Stage 2 — pr-guide (illustrated walkthrough).** Run the **pr-guide** skill to
+generate/update the PR's illustrated guide. **Graceful degradation — the only sanctioned
+skip:** if **pr-guide unavailable** in the target repo, log a note ("pr-guide unavailable
+in `<owner/repo>`, **skipping illustrated guide**") and continue. A missing pr-guide
+**does not hard-fail** the pipeline. Every other failure (crusty, merge) surfaces as a
+blocker, never a silent skip.
+
+**Stage 3 — final review (one pass, no loop).** After the guide is generated, review the
+PR once more — a single, lightweight correctness/consistency **final review** on your
+default model (a single crusty pass or the existing `review_pipeline`). This is **one
+pass, no loop** — a final sanity check, not a second review→fix loop.
+
+**Stage 4 — merge-ready.** Only after stages 1–3 do you run the existing **merge-ready**
+gate (step 5) and land the PR: merge through the gated authority, then close the linked
+issue.
 
 ### Own the PR you were dispatched for — continue it, never duplicate it
 

--- a/prompt_assets/simard/goal_session_objective.md
+++ b/prompt_assets/simard/goal_session_objective.md
@@ -105,6 +105,19 @@ that PR to landing**, in preference to starting anything new:
 Prefer finishing an in-flight PR you own over starting a fresh one. A goal that
 has an open PR is *in progress*, not *done*.
 
+## Finalization runs inside the engineer — don't spin the goal-action on it
+
+Each engineer drives an ordered **PR-finalization pipeline** on its own PR before
+merge — a high-end crusty review→fix loop, then pr-guide, then a final review, then
+merge-ready (full reference: `docs/reference/pr-finalization-pipeline.md`).
+**Finalization runs inside the engineer**'s own cycle: the goal-action brain (you)
+**only dispatches and checks** — it **does not run that loop** itself. So when a goal
+already has a live engineer mid-finalization, do **not** re-dispatch it or re-loop on it
+**while its engineer is finalizing** its PR — that would just spin the OODA cycle. Treat
+"engineer is finalizing PR #<n>" as *in progress*: check back next cycle, and spend this
+cycle's spare capacity on a *different* goal. This preserves the **#2404** loop-awareness
+contract — the engineer owns the review→fix loop; the brain dispatches and waits.
+
 # Done-gate — a fix/implement goal is done ONLY when merged AND closed
 
 For any goal whose deliverable is a fix or an implementation, the goal is

--- a/src/ooda_brain/prompt_store_tests.rs
+++ b/src/ooda_brain/prompt_store_tests.rs
@@ -1024,3 +1024,300 @@ fn progress_assessment_recipe_mirrors_done_gate() {
         "progress-assessment.yaml must keep the verdict JSON output contract"
     );
 }
+
+// ── PR-finalization review pipeline (#2410 follow-on) ───────────────────────
+//
+// These tests pin the prompt-content contract for the new, bounded, ordered
+// PR-finalization pipeline every engineer runs at the end of a PR, AFTER the
+// fix is implemented and the PR is opened/updated but BEFORE merge-ready:
+//
+//   1. CRUSTY REVIEW→FIX LOOP on a HIGH-END model (`$SIMARD_REVIEW_MODEL`,
+//      default `gpt-5.4`), fixing every actionable finding and re-reviewing the
+//      LATEST PR state until crusty emits the sentinel `NO BLOCKING FINDINGS`
+//      or a bounded cap (`$SIMARD_REVIEW_MAX_ITERS`, default 3) is reached.
+//   2. PR-GUIDE illustrated walkthrough (graceful-skip where unavailable).
+//   3. FINAL REVIEW — one lightweight pass, no loop.
+//   4. MERGE-READY → merge → close issue (the pre-existing #2410 landing path).
+//
+// The spec is `docs/reference/pr-finalization-pipeline.md`. The pipeline is
+// PROMPT-ONLY: it is added to `engineer_system.md` (engineer PR-finalization
+// instructions) with a short cross-reference note in `goal_session_objective.md`
+// (so the OODA brain knows finalization runs INSIDE the engineer and must not
+// spin the goal-action cycle — preserving #2404 loop-awareness, #2405 fan-out,
+// and #2410 own-PRs-to-landing). These assertions FAIL until the prompt edits
+// land. `engineer_system.md` is not registered for `embedded_fallback` (no
+// prompt_store logic change), so it is asserted via `include_str!` exactly like
+// `engineer_system_continues_existing_pr_no_duplicate` above. Phrases are
+// checked after `normalize_ws` so Markdown line-wrapping cannot defeat them.
+
+/// The engineer system prompt, read at compile time (not registered for
+/// `embedded_fallback`, so assert its content directly like the existing
+/// `engineer_system_continues_existing_pr_no_duplicate` test).
+fn engineer_system_md() -> &'static str {
+    include_str!("../../prompt_assets/simard/engineer_system.md")
+}
+
+#[test]
+fn engineer_system_has_pr_finalization_pipeline_section() {
+    // A discrete, named PR-finalization pipeline section that names every skill
+    // it orchestrates, in order.
+    let norm = normalize_ws(engineer_system_md()).to_lowercase();
+    assert!(
+        norm.contains("pr-finalization pipeline"),
+        "engineer_system.md must add an explicit, named PR-finalization pipeline section"
+    );
+    assert!(
+        norm.contains("crusty-old-engineer"),
+        "the pipeline must name the crusty-old-engineer review skill"
+    );
+    assert!(
+        norm.contains("pr-guide"),
+        "the pipeline must name the pr-guide illustrated-walkthrough skill"
+    );
+    assert!(
+        norm.contains("merge-ready"),
+        "the pipeline must name the existing merge-ready final gate"
+    );
+}
+
+#[test]
+fn engineer_system_crusty_loop_uses_high_end_model() {
+    // Stage 1 runs crusty on a HIGH-END reasoning model, pinned via a configurable
+    // env var with a verified high-end default, invoked through a pinned subprocess
+    // (the engineer itself runs the default/auto model).
+    let norm = normalize_ws(engineer_system_md()).to_lowercase();
+    assert!(
+        norm.contains("review→fix loop"),
+        "stage 1 must be described as a crusty review→fix loop"
+    );
+    assert!(
+        norm.contains("high-end"),
+        "the crusty loop must run on a high-end reasoning model"
+    );
+    assert!(
+        norm.contains("$simard_review_model"),
+        "the high-end model must be configurable via $SIMARD_REVIEW_MODEL"
+    );
+    assert!(
+        norm.contains("gpt-5.4"),
+        "the high-end model must default to the verified gpt-5.4"
+    );
+    assert!(
+        norm.contains("copilot --model"),
+        "crusty must be pinned to the high-end model via a copilot --model subprocess"
+    );
+}
+
+#[test]
+fn engineer_system_crusty_loop_is_bounded() {
+    // The loop MUST terminate: a bounded, configurable iteration cap.
+    let norm = normalize_ws(engineer_system_md()).to_lowercase();
+    assert!(
+        norm.contains("$simard_review_max_iters"),
+        "the iteration cap must be configurable via $SIMARD_REVIEW_MAX_ITERS"
+    );
+    assert!(
+        norm.contains("default 3"),
+        "the iteration cap must have a sensible default of 3"
+    );
+    assert!(
+        norm.contains("cap"),
+        "the loop must declare a bounded cap to prevent infinite review→fix loops"
+    );
+}
+
+#[test]
+fn engineer_system_crusty_loop_reviews_latest_state() {
+    // Each iteration operates on the freshly-pushed PR state, gated by a
+    // structural sentinel verdict (not free text) — no TOCTOU on a stale diff.
+    let norm = normalize_ws(engineer_system_md()).to_lowercase();
+    assert!(
+        norm.contains("latest pr state"),
+        "each loop iteration must review the latest PR state"
+    );
+    assert!(
+        norm.contains("stale diff"),
+        "the loop must never re-review a stale diff"
+    );
+    assert!(
+        norm.contains("no blocking findings"),
+        "the satisfied signal must be the structural sentinel verdict NO BLOCKING FINDINGS"
+    );
+}
+
+#[test]
+fn engineer_system_crusty_loop_fixes_every_finding() {
+    // Fix discipline: every actionable finding is fixed and pushed before the
+    // next review, then crusty re-runs.
+    let norm = normalize_ws(engineer_system_md()).to_lowercase();
+    assert!(
+        norm.contains("every actionable finding"),
+        "the loop must fix every actionable finding crusty raises"
+    );
+    assert!(
+        norm.contains("same pr branch"),
+        "fixes must be pushed to the same PR branch before re-review"
+    );
+    assert!(
+        norm.contains("re-review"),
+        "the loop must re-review after pushing fixes"
+    );
+}
+
+#[test]
+fn engineer_system_cap_reached_surfaces_blocker_not_merge() {
+    // Bounded + honest: if the cap is hit with findings still open, record them
+    // on the PR AND surface a goal blocker — never silently merge.
+    let norm = normalize_ws(engineer_system_md()).to_lowercase();
+    assert!(
+        norm.contains("remaining findings as a pr comment"),
+        "cap-reached must post the remaining findings as a PR comment"
+    );
+    assert!(
+        norm.contains("blocker"),
+        "cap-reached-with-findings must surface a goal blocker"
+    );
+    assert!(
+        norm.contains("engineer_summary"),
+        "the blocker must be surfaced in cycle_summary.engineer_summary"
+    );
+    assert!(
+        norm.contains("do not merge"),
+        "the engineer must NOT merge past unsatisfied crusty findings"
+    );
+}
+
+#[test]
+fn engineer_system_trivial_pr_filter_is_cost_aware() {
+    // Cost awareness: the full high-end loop runs only on non-trivial PRs; a
+    // trivial PR gets a single lightweight pass.
+    let norm = normalize_ws(engineer_system_md()).to_lowercase();
+    assert!(
+        norm.contains("non-trivial pr"),
+        "the full crusty loop must run only on non-trivial PRs"
+    );
+    assert!(
+        norm.contains("single lightweight pass"),
+        "a trivial PR must get a single lightweight pass, not the full loop"
+    );
+    assert!(
+        norm.contains("cost"),
+        "the pipeline must note cost awareness (high-end review is expensive)"
+    );
+}
+
+#[test]
+fn engineer_system_pr_guide_degrades_gracefully() {
+    // Stage 2: run pr-guide; if unavailable in the target repo, log a note and
+    // continue. This is the ONLY sanctioned skip — it must not hard-fail.
+    let norm = normalize_ws(engineer_system_md()).to_lowercase();
+    assert!(
+        norm.contains("pr-guide unavailable"),
+        "the pipeline must handle pr-guide being unavailable in the target repo"
+    );
+    assert!(
+        norm.contains("skipping illustrated guide"),
+        "pr-guide unavailability must be a logged skip of the illustrated guide"
+    );
+    assert!(
+        norm.contains("does not hard-fail"),
+        "a missing pr-guide must degrade gracefully, not hard-fail the pipeline"
+    );
+}
+
+#[test]
+fn engineer_system_final_review_is_one_pass_no_loop() {
+    // Stage 3: a single, lightweight final correctness/consistency pass after the
+    // guide — explicitly NOT a second review→fix loop.
+    let norm = normalize_ws(engineer_system_md()).to_lowercase();
+    assert!(
+        norm.contains("final review"),
+        "the pipeline must include a final review pass after pr-guide"
+    );
+    assert!(
+        norm.contains("one pass, no loop"),
+        "the final review must be one lightweight pass, not a second loop"
+    );
+}
+
+#[test]
+fn engineer_system_pipeline_gates_merge_ready() {
+    // The pipeline runs BEFORE merge-ready, and the merge step is gated on the
+    // pipeline having run — order-independent, semantic assertions.
+    let norm = normalize_ws(engineer_system_md()).to_lowercase();
+    assert!(
+        norm.contains("before merge-ready"),
+        "stages 1–3 must run before the merge-ready gate"
+    );
+    assert!(
+        norm.contains("only after the pr-finalization pipeline"),
+        "the merge step must be gated on the PR-finalization pipeline having run"
+    );
+}
+
+#[test]
+fn engineer_system_pipeline_preserves_2410_landing() {
+    // Regression guard: the new pipeline builds ON TOP of #2410 — the
+    // own-PR-to-landing and merged-AND-closed done-gate guidance must remain.
+    let norm = normalize_ws(engineer_system_md()).to_lowercase();
+    assert!(
+        norm.contains("continue it, never duplicate it"),
+        "must preserve #2410 continue-existing-PR-never-duplicate guidance"
+    );
+    assert!(
+        norm.contains("not done until its pr is merged and the linked issue is closed"),
+        "must preserve the #2410 merged-AND-closed done-gate"
+    );
+}
+
+#[test]
+fn goal_session_objective_finalization_runs_inside_engineer() {
+    // The OODA brain must know finalization runs INSIDE the engineer's cycle: the
+    // goal-action only dispatches/checks and must not spin while an engineer is
+    // mid-finalization (preserving #2404 loop-awareness).
+    let content = embedded_fallback("goal_session_objective.md")
+        .expect("goal_session_objective.md must be registered");
+    let norm = normalize_ws(content).to_lowercase();
+    assert!(
+        norm.contains("pr-finalization pipeline"),
+        "goal_session_objective.md must reference the engineer's PR-finalization pipeline"
+    );
+    assert!(
+        norm.contains("finalization runs inside the engineer"),
+        "the note must state finalization runs inside the engineer's cycle"
+    );
+    assert!(
+        norm.contains("only dispatches and checks"),
+        "the goal-action brain only dispatches and checks; it does not run the loop"
+    );
+    assert!(
+        norm.contains("does not run that loop"),
+        "the brain must not run the review loop itself"
+    );
+    assert!(
+        norm.contains("while its engineer is finalizing"),
+        "the brain must not re-dispatch/re-loop a goal while its engineer is finalizing"
+    );
+    assert!(
+        norm.contains("#2404"),
+        "the note must tie back to #2404 loop-awareness it preserves"
+    );
+}
+
+#[test]
+fn goal_session_objective_finalization_preserves_prose_contract() {
+    // The cross-reference note must stay additive prose: it must NOT introduce a
+    // JSON verdict shape into the prose-only goal-action output, and it must not
+    // regress the #2410 own-open-PRs-to-landing guidance it builds on.
+    let content = embedded_fallback("goal_session_objective.md")
+        .expect("goal_session_objective.md must be registered");
+    let norm = normalize_ws(content).to_lowercase();
+    assert!(
+        norm.contains("own your open prs all the way to landing"),
+        "the finalization note must not regress the #2410 own-PRs-to-landing guidance"
+    );
+    assert!(
+        !content.contains("\"verdict\""),
+        "goal_session_objective.md is prose-only — it must not gain a JSON verdict contract"
+    );
+}


### PR DESCRIPTION
## What & why

Adds an **ordered, bounded PR-finalization review pipeline** that every Simard
engineer runs on its open PR **after the fix is implemented / PR opened** but
**before merge-ready**:

1. **CRUSTY REVIEW→FIX LOOP (high-end model).** Invoke `crusty-old-engineer` on
   the PR diff via a pinned `copilot --model "$SIMARD_REVIEW_MODEL"` subprocess
   (default **`gpt-5.4`**, verified accepted by `copilot --model gpt-5.4`). Fix
   **every actionable finding**, push to the **same PR branch**, re-fetch the
   **latest PR state** (`gh pr diff`, never a stale diff), and **re-review** —
   looping until the sentinel verdict `NO BLOCKING FINDINGS` or a bounded cap
   **`$SIMARD_REVIEW_MAX_ITERS`** (default **3**, `[1,5]`). Cap-with-findings
   posts the **remaining findings as a PR comment** + surfaces a goal blocker in
   `cycle_summary.engineer_summary` and **does not merge**.
2. **PR-GUIDE.** Run `pr-guide`; if **pr-guide unavailable** in the target repo,
   log "skipping illustrated guide" and continue — **does not hard-fail** (the
   only sanctioned skip).
3. **FINAL REVIEW.** One lightweight correctness/consistency pass — **one pass,
   no loop**.
4. **MERGE-READY.** Only after stages 1–3 run the existing `merge-ready` gate →
   merge → close issue (the #2410 landing behavior).

**Cost-aware:** the full loop runs only on a **non-trivial PR**; a trivial PR
gets a **single lightweight pass**. The trivial filter + iteration cap bound the
high-end model spend (well inside the pre-existing daemon-wide
`SIMARD_DAILY_BUDGET_USD`, which this pipeline does not itself read).

**Prompt-only / hot-reloads.** The pipeline is added to
`prompt_assets/simard/engineer_system.md`; a short cross-reference note in
`prompt_assets/simard/goal_session_objective.md` tells the OODA brain that
**finalization runs inside the engineer** (the goal-action **only dispatches and
checks**, **does not run that loop**, and must not re-dispatch a goal **while its
engineer is finalizing**) — preserving **#2404** loop-awareness, **#2405**
fan-out, and **#2410** own-PRs-to-landing. No Rust decision logic changes.

Relates to #1708 (wires `crusty-old-engineer` into Simard's review discipline as
a mandatory pre-merge loop rather than an ad-hoc human invocation).

## Deployment

**Prompt-only for runtime behavior → hot-reloads** from
`~/.simard/prompt_assets/simard/`; **no binary rebuild or daemon redeploy**
required for the new behavior. (The accompanying content assertions are
`include_str!`-compiled test code, re-baked on `cargo test` only.) Operator
deploys by syncing the prompt assets. **Do not redeploy the live daemon.**

## QA-team evidence

This is a **prompt-content** change; its behavioral test surface is the Rust
prompt-content assertions (the project's prompt-TDD discipline), not a
`gadugi-test` CLI/TUI scenario. Added **12 new content tests** in
`src/ooda_brain/prompt_store_tests.rs` pinning every contract anchor (named
skills, high-end model + env knobs + `gpt-5.4` default, bounded cap + default 3,
latest-state/stale-diff/sentinel, fix-every-finding, cap→PR-comment+blocker+
do-not-merge, trivial-PR cost filter, pr-guide graceful-skip, final-review
one-pass, merge-ready gating) plus regression guards for #2410/#2404.

```
cargo test --lib -- engineer_system goal_session_objective
  -> 43 passed; 0 failed
cargo test --lib prompt_store_tests
  -> 67 passed; 0 failed
```

## Documentation

- New reference page `docs/reference/pr-finalization-pipeline.md` (ordered/bounded
  contract, configuration, security model, deployment, invariants).
- Linked from `docs/index.md` and added to `mkdocs.yml` nav.
- All internal cross-links verified to resolve to existing pages.

## Quality-audit

Validation performed (all green, target dir warm):

- `cargo fmt --all -- --check` — clean
- `cargo clippy --release --no-deps -- -D warnings` — clean
- `cargo clippy --all-targets --all-features --locked -- -D warnings` (CI-mirror) — clean
- `cargo build --release --bin simard` — succeeds
- `cargo test --lib prompt_store_tests` — 67 passed
- pre-push race subset (`cognitive_memory|bootstrap|memory_ipc|memory_consolidation`) — 276 passed
- pre-commit + pre-push hooks — all passed on commit & push

The change is **additive prose** (engineer prompt section + a prose-only
cross-reference note) plus test/doc; it preserves every parser output contract
(engineer prose, goal_session prose-only with no JSON `verdict`, `DECISION:`
keyword, progress-reviewer JSON — all untouched and still asserted green).

## CI

CI runs on this PR; all local CI-mirroring gates above are green. Will confirm
the green run before merge.

## Scope

6 files, additive: `prompt_assets/simard/engineer_system.md` (+pipeline section),
`prompt_assets/simard/goal_session_objective.md` (+cross-ref note),
`src/ooda_brain/prompt_store_tests.rs` (+12 content tests),
`docs/reference/pr-finalization-pipeline.md` (new), `docs/index.md`,
`mkdocs.yml`. **No Rust `src/` logic changes** (only test-module content
assertions). No unrelated edits.

## TDD attestation

`tdd: test-first ordering verified` — the prompt-content assertions were authored
first (failing against the unmodified prompts), then the `engineer_system.md` /
`goal_session_objective.md` edits were made to satisfy them; commit d66611f4.

## Verdict

**ready to merge** (pending green CI). Bounded, honest (cap → blocker, never
silent-merge), cost-aware, and graceful only where specified (pr-guide). No
daemon redeploy required — prompt-only hot-reload.
