### PR TITLE
feat(prompts): self-maintain dependency pins — bump own Cargo.toml rev after landing upstream (#2403 follow-on)

### DIFF
--- a/docs/howto/self-maintain-dependency-pins.md
+++ b/docs/howto/self-maintain-dependency-pins.md
@@ -1,0 +1,339 @@
+---
+title: How to keep Simard's own dependency pins up to date
+description: "A reactive done-gate and proactive reconcile that make Simard bump her own Cargo.toml git-rev pins after she lands a change upstream, so the fixes she ships actually run in her own daemon. Prompt-first, no Rust logic."
+last_updated: 2026-06-26
+review_schedule: as-needed
+owner: simard
+doc_type: howto
+status: active
+related:
+  - ../safe-self-update.md
+  - ../reference/pr-finalization-pipeline.md
+  - ../howto/route-a-goal-to-its-target-repo.md
+  - ../ecosystem-map.md
+---
+
+# How to keep Simard's own dependency pins up to date
+
+> **Status: active.** This document describes shipped behaviour. The
+> dependency-pin done-gate and proactive reconcile are implemented entirely in
+> prompt assets (`goal_session_objective.md`, `engineer_system.md`,
+> `progress_assessment_reviewer.md`, and the `progress-assessment.yaml` recipe
+> mirror); this guide is both the operator reference and the spec the
+> prompt-content pin tests enforce.
+
+Simard's root `Cargo.toml` pins several of the tools she maintains by **exact
+git rev**, not by branch:
+
+| Crate (in `Cargo.toml`) | Upstream repo | Default branch |
+| --- | --- | --- |
+| `amplihack-agent-eval` | `rysweet/amplihack-rs` | `main` |
+| `amplihack-memory` | `rysweet/amplihack-memory-lib` | `main` |
+| `rustyclawd-core` | `rysweet/RustyClawd` | `main` |
+| `rustyclawd-tools` | `rysweet/RustyClawd` | `main` |
+
+Two of those crates — `rustyclawd-core` and `rustyclawd-tools` — pin the **same
+upstream repo at the same rev**, so they must always be bumped together (see
+[Bump-PR conventions](#bump-pr-conventions-and-de-duplication)).
+
+A git-rev pin is reproducible, but it is also **frozen**. When Simard lands a
+fix in one of those upstream repos, her own pin keeps pointing at the *old*
+commit, so the fix she just merged is **not in her own build**. The motivating
+case: `amplihack-agent-eval` was pinned ~22 commits behind `amplihack-rs`
+`main`, which meant roughly nine merged PRs were absent from the very daemon
+that wrote them.
+
+This guide describes the two behaviours that close that gap. Both are
+expressed **entirely in prompt assets** — there is no new Rust subsystem, no new
+CLI command, and no change to any parser contract.
+
+> **The finish line moves.** Under this feature, opening (or even merging) the
+> *upstream* PR is **not** "done". A goal that changes a Simard
+> build-dependency is done only once
+> the fix is **running in Simard's own build** — i.e. her own pin has been
+> bumped, `cargo build` is green, and the bump PR has landed on
+> `rysweet/Simard`. This is the source-side complement of
+> [Safe Self-Update](../safe-self-update.md), which swaps the *running binary*.
+
+---
+
+## The two triggers at a glance
+
+```mermaid
+flowchart TD
+    subgraph A[Reactive done-gate]
+      A1([engineer lands upstream change]) --> A2[bump own Cargo.toml rev<br/>to merged main commit]
+      A2 --> A3[cargo build verifies]
+      A3 --> A4[open / update bump PR<br/>vs rysweet/Simard]
+      A4 --> A5[land bump PR]
+      A5 --> A6([goal DONE])
+    end
+    subgraph B[Proactive reconcile]
+      B1([idle / research time]) --> B2[compare each pinned rev<br/>to upstream default HEAD]
+      B2 -->|behind| B3[open / update bump follow-up]
+      B2 -->|current| B4([nothing to do])
+    end
+```
+
+| | Trigger A — Reactive | Trigger B — Proactive |
+| --- | --- | --- |
+| **Fires when** | An engineer merges a change to a repo Simard depends on | Simard has spare, low-priority "ok to be idle" research time |
+| **Priority** | Blocks the originating goal from being "done" | Low — a follow-up, never preempts real work |
+| **Output** | Same goal stays open until the own-pin bump lands | A new bump follow-up goal/PR |
+| **Lives in** | `goal_session_objective.md` + `engineer_system.md` + `progress_assessment_reviewer.md` | `engineer_system.md` (dependency-drift) + a note in `goal_session_objective.md` |
+
+---
+
+## Trigger A — the reactive done-gate
+
+When an engineer **lands** (merges to the upstream default branch) a change to
+one of the three repos Simard pins by git rev — `amplihack-rs`,
+`amplihack-memory-lib`, or `RustyClawd` — the *same goal* is not complete until
+Simard has also:
+
+1. **Bumped her own pin.** Edit the matching `rev = "…"` in the root
+   `Cargo.toml` to the merged `main` commit SHA.
+2. **Verified the build.** `cargo build` (low-space variant when disk is tight —
+   `scripts/cargo-low-space build`) must succeed against the new rev. A bump
+   that does not build is rolled back, not shipped.
+3. **Opened (or updated) the bump PR** against `rysweet/Simard` — see
+   [Bump-PR conventions](#bump-pr-conventions-and-de-duplication).
+4. **Landed the bump PR.** It rides the same
+   [PR-finalization review pipeline](../reference/pr-finalization-pipeline.md)
+   and merge-ready gate as any other Simard change (CI-green → merge), exactly
+   like [making Simard own each PR to landing (#2410)](../reference/pr-finalization-pipeline.md).
+
+Only after step 4 is the originating goal allowed to report `done`.
+
+The actual **redeploy** of the running daemon (swapping the binary, hot-reloading
+prompts) remains **operator-gated** — it is the operator's step, performed via
+[Safe Self-Update](../safe-self-update.md), and is *not* required for the
+automated goal to be marked done. The done-gate guarantees the fix is *in the
+shipped source build*; the operator decides when to roll it out.
+
+### Where this gate lives
+
+| Prompt asset | Responsibility |
+| --- | --- |
+| `prompt_assets/simard/goal_session_objective.md` | **Encodes** the done-gate: a goal that lands an upstream change to a build-dependency repo is not done until the own-pin bump lands and `cargo build` passes. Stays **prose only** (preserves the `NO ACTION` marker and `PROGRESS: NN` line the goal-session parser reads). |
+| `prompt_assets/simard/engineer_system.md` | **Tells** the engineer that landed the upstream change to follow through with the own-`Cargo.toml` bump + build-verify + bump PR. |
+| `prompt_assets/simard/progress_assessment_reviewer.md` | **Rejects** a premature `done` — see [Reviewer enforcement](#reviewer-enforcement). |
+
+This is a **new done-gate that runs *after* landing**, alongside #2410. It
+composes additively with the already-shipped behaviours:
+
+- **#2404 loop-awareness** — the bump is concrete forward progress, not a loop.
+- **#2405 per-issue fan-out** — a bump follow-up is just another work item.
+- **#2410 own-PRs-to-landing** — the bump PR is owned to landing like any PR.
+- **#2413 crusty / pr-guide finalization** — the bump PR runs the same
+  finalization pipeline before merge.
+
+### Does the done-gate hold the goal open, or spawn a follow-up?
+
+**Trigger A holds the *originating* goal open** — that is what makes "landing
+upstream is not done" meaningful. It deliberately does *not* spawn a separate
+goal; coupling the bump to the goal that caused it is the point.
+
+This does **not** trip loop-awareness (#2404). Loop/stall detection flags
+*repetition without progress*. The done-gate instead appends a **bounded,
+monotonic sequence of new artifacts** — one rev-bump commit, one `cargo build`,
+one bump PR — each concrete forward progress on a *different* file
+(`Cargo.toml`) and a *different* PR than the upstream change. If that bounded
+sequence itself gets stuck (e.g. the bump PR cannot land), it surfaces through
+the **normal stall path** and is escalated like any other blocked PR — it is
+never retried indefinitely. Contrast with Trigger B, which *is* a separate
+low-priority follow-up precisely because nothing is holding a goal open.
+
+---
+
+## Trigger B — the proactive reconcile
+
+When Simard has low-priority idle/research time (the same budget she uses for
+self-maintenance), she periodically checks each rev-pinned git dependency for
+**drift**: is the pinned rev behind the upstream default branch?
+
+For each dependency she compares the pinned rev to the upstream `HEAD`:
+
+```bash
+# Current pin (from Cargo.toml)
+PINNED=59548a96049ab8d558110bcaf9c82a4316f1bbf0
+
+# Upstream default-branch HEAD
+git ls-remote https://github.com/rysweet/amplihack-rs.git main
+
+# How far behind is the pin? (GitHub compare API: base=pin, head=main)
+gh api repos/rysweet/amplihack-rs/compare/$PINNED...main \
+  --jq '{status, behind: .behind_by, ahead: .ahead_by}'
+```
+
+`status: "behind"` (or `ahead > 0`) means the pin is stale. Simard then opens —
+or updates — a **bump follow-up** that does exactly what Trigger A does:
+re-point the rev to the new `main`, verify `cargo build`, and ship it through
+the normal landing pipeline.
+
+This trigger is **low priority by construction**. It never preempts an active
+engineering goal; it only fills spare capacity. It is described in
+`engineer_system.md` (the "dependency-drift" self-maintenance directive) and
+**noted** as acceptable idle-time work in `goal_session_objective.md`.
+
+This is the **upstream-repo analog of the self-update Simard already has.**
+`goal_session_objective.md` already carries a "Self-update awareness" section in
+which the OODA brain detects *Simard-repo* drift via `compute_commits_behind()`
+and triggers `simard safe-update` when no engineers are in flight. Trigger B
+points that same "detect drift, reconcile when idle" posture at the **repos
+Simard pins** instead of the Simard repo itself — it reuses the existing idle
+self-maintenance idea rather than inventing a new scheduler.
+
+---
+
+## Bump-PR conventions and de-duplication
+
+Both triggers can want to bump the *same* dependency, and the daemon runs
+multiple engineers concurrently (#2405). To avoid a pile of duplicate bump PRs,
+the bump uses a **deterministic naming convention keyed on the upstream repo**
+— *not* on the crate — so that crates sharing a repo collapse into one PR:
+
+| Field | Value |
+| --- | --- |
+| Branch | `chore/bump-<upstream-repo>-pin` (e.g. `chore/bump-rustyclawd-pin`) |
+| PR title | `chore(deps): bump <upstream-repo> pin to <short-sha>` |
+| Base | `rysweet/Simard` `main` |
+
+`<upstream-repo>` is the source repository, lower-cased (`amplihack-rs`,
+`amplihack-memory-lib`, `rustyclawd`). Each bump PR updates **every** crate that
+pins that repo:
+
+| `<upstream-repo>` | Crates bumped together in one PR |
+| --- | --- |
+| `amplihack-rs` | `amplihack-agent-eval` |
+| `amplihack-memory-lib` | `amplihack-memory` |
+| `rustyclawd` | `rustyclawd-core` **and** `rustyclawd-tools` |
+
+> **One PR per upstream repo — bump shared crates atomically.** When several
+> crates pin the same repo at the same rev (today `rustyclawd-core` and
+> `rustyclawd-tools` both pin `RustyClawd` at `43ebaa1`), the bump PR re-points
+> **all** of them to the new rev in the **same commit**. Never open a branch per
+> crate: that would split one upstream commit across two PRs and let the build
+> see two different `RustyClawd` revs at once.
+
+**Before opening a bump PR, check for an existing open one:**
+
+```bash
+# Is a bump PR already open for this upstream repo?
+gh pr list --repo rysweet/Simard --state open \
+  --head "chore/bump-rustyclawd-pin" \
+  --json number,title,headRefName
+```
+
+- **Found** → **update it**: re-point every crate from that repo to the latest
+  `main`, re-run `cargo build`, force-update the branch, and refresh the PR
+  body. Do **not** open a second PR.
+- **Not found** → open a fresh PR with the convention above.
+
+> **Cross-repo safety.** The upstream change lives in another repo
+> (`amplihack-rs`, `RustyClawd`, …); the **bump PR is always opened against
+> `rysweet/Simard`**, because `Cargo.toml` lives in Simard. This is the same
+> separation as [routing a goal to its target repo](./route-a-goal-to-its-target-repo.md):
+> work happens where the file being changed lives.
+
+---
+
+## Reviewer enforcement
+
+`progress_assessment_reviewer.md` **is** the gate that stops a premature
+`done`. Its output contract is **unchanged** — a single-line JSON object
+`{"verdict": "accept" | "reject", "rationale": "…"}` — and the `verdict` token
+stays exactly `accept` / `reject` (lowercase) so the Rust reviewer parser keeps
+working.
+
+The reviewer cannot diff git revs itself (it sees only the problem, plan,
+prior/claimed percent, and a WIP summary). So the rule **is** phrased as
+**evidence-absence**, not rev-comparison:
+
+> Reject a `done` / 100% claim when the problem or plan describes **landing an
+> upstream change to a Simard build-dependency repo**, but the plan / WIP
+> summary shows **no evidence** of *both* (a) the own `Cargo.toml` rev bump to
+> the merged commit and (b) a verified `cargo build`.
+
+Example rejection the reviewer **emits** (matching the spaced JSON form the
+existing reviewer prompt already uses):
+
+```json
+{"verdict": "reject", "rationale": "Upstream PR merged to amplihack-rs main, but no evidence the own Cargo.toml amplihack-agent-eval rev was bumped and cargo build re-verified; landing upstream is not done until the fix ships in Simard's own build."}
+```
+
+If the WIP summary *does* show the bump landed and the build passed, the
+reviewer accepts as normal.
+
+---
+
+## Operator: rolling a bump into the running daemon
+
+Landing the bump PR puts the fix in the **source build**. To get it into the
+**running daemon**, an operator:
+
+1. Pulls the merged bump on the host and rebuilds, or
+2. Runs [Safe Self-Update](../safe-self-update.md)
+   (`simard safe-update`) which downloads, self-tests, swaps, and validates the
+   new binary.
+
+Prompt-asset changes (this feature is all prompts) are **hot-reloaded** by
+syncing the assets into the live state root:
+
+```bash
+rsync -a prompt_assets/simard/ ~/.simard/prompt_assets/simard/
+```
+
+No daemon restart is required for the prompt changes to take effect on the next
+OODA cycle. The binary-level dependency bump still requires a rebuild/redeploy
+as above.
+
+---
+
+## Verify end-to-end
+
+1. **Confirm the pins and their upstreams:**
+
+   ```bash
+   grep -nE 'git = .*(amplihack-rs|amplihack-memory-lib|RustyClawd)' Cargo.toml
+   ```
+
+2. **Check one dependency for drift:**
+
+   ```bash
+   PINNED=$(grep 'amplihack-agent-eval' Cargo.toml | grep -oE '[0-9a-f]{40}')
+   gh api repos/rysweet/amplihack-rs/compare/$PINNED...main --jq '.behind_by'
+   ```
+
+   A non-zero result means the pin is stale and Trigger B should produce a bump
+   follow-up.
+
+3. **After a bump lands, confirm the rev moved and the build is green:**
+
+   ```bash
+   git -C ~/src/Simard pull
+   grep -n 'amplihack-agent-eval' ~/src/Simard/Cargo.toml   # rev now == merged main
+   cargo build --quiet                                       # succeeds
+   ```
+
+4. **Confirm no duplicate bump PRs are open:**
+
+   ```bash
+   gh pr list --repo rysweet/Simard --state open \
+     --search 'in:title "chore(deps): bump"'
+   ```
+
+   At most one open PR per **upstream repo** (so `rustyclawd-core` and
+   `rustyclawd-tools` never appear in two separate bump PRs).
+
+---
+
+## Related reading
+
+- [Safe Self-Update](../safe-self-update.md) — the binary-swap half of
+  "ship it into her own running build"; this guide is the source-pin half.
+- [PR-finalization review pipeline](../reference/pr-finalization-pipeline.md) —
+  the gate every bump PR passes before merge.
+- [How to route a goal to its target ecosystem repo](./route-a-goal-to-its-target-repo.md) —
+  the same "work where the file lives" separation, applied to upstream goals.
+- [Ecosystem map](../ecosystem-map.md) — the repos Simard stewards and depends on.

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,6 +33,7 @@ Terminal sessions and repo-grounded engineer runs now bridge through one explici
 - [How to recover a corrupted or missing goal board](./howto/recover-goal-board.md) — cognitive-memory-only recovery commands.
 - [How to troubleshoot the file-backed goal store](./howto/troubleshoot-goal-store.md) — operator playbook for goal_store.json issues.
 - [How to configure adaptive scaling](./howto/configure-adaptive-scaling.md) — enable and tune AIMD concurrency scaling.
+- [How to keep Simard's own dependency pins up to date](./howto/self-maintain-dependency-pins.md) — the reactive done-gate and proactive reconcile that bump Simard's own `Cargo.toml` git-rev pins after she lands a change upstream, so the fix runs in her own build (companion to [Safe Self-Update](./safe-self-update.md)).
 
 - [How to run the OODA daemon](./howto/run-ooda-daemon.md) - Start the continuous OODA loop for autonomous goal-driven operation and act on meeting decisions.
 - [How to diagnose OODA decide/orient brain parse failures](./howto/diagnose-decide-orient-parse-failures.md) - Runbook for the silent-fallback fix (#1890): find the ERROR log, read the `parse_failure` cycle-report block, and remediate.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,7 @@ nav:
     - Configure Episode Hygiene and Promotion: howto/configure-episode-hygiene-and-promotion.md
     - Dashboard E2E Tests: howto/run-dashboard-e2e-tests.md
     - Route a Goal to its Target Repo: howto/route-a-goal-to-its-target-repo.md
+    - Self-Maintain Dependency Pins: howto/self-maintain-dependency-pins.md
   - Reference:
     - CLI Reference: reference/simard-cli.md
     - Memory introspection CLI: reference/simard-memory-cli.md

--- a/prompt_assets/simard/engineer_system.md
+++ b/prompt_assets/simard/engineer_system.md
@@ -280,6 +280,56 @@ has an open PR (yours or a prior engineer's):
   `cycle_summary.engineer_summary` (e.g. "PR #819 blocked on required review
   from rysweet") and stop — do not open a fresh PR and do not silently re-loop.
 
+### After landing an upstream build-dependency change — bump your own pin
+
+Simard's root `Cargo.toml` pins the tools she maintains by **exact git rev**:
+`amplihack-agent-eval` → `rysweet/amplihack-rs`, `amplihack-memory` →
+`rysweet/amplihack-memory-lib`, and `rustyclawd-core` / `rustyclawd-tools` →
+`rysweet/RustyClawd`. Those pins are **frozen**: a fix you merge upstream is
+**not** in Simard's own build until the matching pin is moved. So when your cycle
+**lands a change in one of those upstream build-dependency repos, you are not
+done when the upstream PR merges** — follow through in the **same cycle** and
+**bump your own pin**:
+
+1. Edit the matching `rev = ...` line in the root **`Cargo.toml`** to the merged
+  upstream `main` commit SHA.
+2. Re-verify with **`cargo build`** (use the low-space variant
+  `scripts/cargo-low-space build` when disk is tight). A bump that does **not**
+  build is rolled back, not shipped.
+3. Open — or update — a **bump PR** against **`rysweet/Simard`** and drive it to
+  landing through the same merge-ready gate as any other PR.
+
+**Bump-PR convention (deterministic, keyed on the upstream repo) and de-dup.** To
+avoid duplicate bump PRs across concurrent engineers, key the bump on the
+**upstream repo**, not the crate:
+
+- Branch: `chore/bump-<upstream-repo>-pin` (e.g. `chore/bump-rustyclawd-pin`).
+- PR title: `chore(deps): bump <upstream-repo> pin to <short-sha>`.
+- Base: `rysweet/Simard` `main`.
+
+Before opening, check for an existing one:
+`gh pr list --repo rysweet/Simard --state open --head "chore/bump-<upstream-repo>-pin"`.
+If a bump PR for that repo is **already open**, **update it** (re-point the rev,
+re-run `cargo build`, refresh the branch and body) — never open a second.
+
+**Bump shared crates atomically.** When several crates pin the **same** upstream
+repo, re-point them **together in one commit**: `rustyclawd-core` and
+`rustyclawd-tools` both pin `RustyClawd`, so a `RustyClawd` bump moves both in the
+same PR — never split one upstream commit across two PRs. The daemon **redeploy**
+stays operator-gated; landing the bump PR is your finish line, not redeploying.
+
+### Proactive dependency-drift self-maintenance (low-priority)
+
+As **low-priority** self-maintenance that fills spare idle/research time (and
+never preempts an active goal), watch for **dependency-drift**: a pinned rev that
+has **fallen behind** its upstream default branch. Detect it with runtime git
+tooling — no new Rust subsystem — e.g.
+`git ls-remote https://github.com/<owner>/<repo>.git main` compared against the
+pinned rev (or `gh api repos/<owner>/<repo>/compare/<pinned>...main --jq .behind_by`).
+When a pin has drifted, open or update the same **bump PR** as above to re-point
+the rev, `cargo build`-verify, and land it. Full reference:
+`docs/howto/self-maintain-dependency-pins.md`.
+
 ### Allowed exceptions (must be recorded in `cycle_summary.engineer_summary`)
 
 A code-producing cycle MAY end without a merged PR only in the following cases — and only if the cycle's `engineer_summary` field explicitly records which case applied and the supporting evidence:

--- a/prompt_assets/simard/goal_session_objective.md
+++ b/prompt_assets/simard/goal_session_objective.md
@@ -135,6 +135,41 @@ blocked on required review from rysweet" or "PR #821 blocked on a failing check
 I cannot fix: <name>") and move on. Do **not** mark the goal done, and do
 **not** silently re-loop re-opening or re-triaging it.
 
+# Dependency-pin done-gate — landing upstream is not done until the fix ships in your own build
+
+Simard's root `Cargo.toml` pins several tools she maintains by **exact git rev**
+(not branch): `amplihack-agent-eval` → `rysweet/amplihack-rs`, `amplihack-memory`
+→ `rysweet/amplihack-memory-lib`, and `rustyclawd-core` / `rustyclawd-tools` →
+`rysweet/RustyClawd`. A git-rev pin is **frozen**: when an engineer lands a
+change in one of those upstream **build-dependency** repos, Simard's own pin
+keeps pointing at the *old* commit, so the fix she just merged is **not** in her
+own **running build**.
+
+So for any goal whose deliverable lands a change in one of those build-dependency
+repos, **opening the upstream PR is not the finish line** — and neither is
+merging it upstream. The goal **is not done until** that fix is shipped into
+Simard's own **running build**:
+
+1. **Bump her own pin.** Edit the matching `rev = ...` line in the root
+   `Cargo.toml` to the merged upstream `main` commit.
+2. **Verify the build.** `cargo build` must succeed against the new rev; a bump
+   that does not build is rolled back, not shipped.
+3. **Land the bump PR.** Open (or update) a **bump PR** against `rysweet/Simard`
+   and drive it to landing through the same merge-ready gate as any other PR
+   (dispatch the engineer to do the bump + build + PR).
+
+This is a **new done-gate that runs AFTER landing**, composing additively with —
+not replacing — the rule that a fix/implement goal is **complete only when its PR
+is MERGED and the linked issue is CLOSED**: both gates apply. Do not record
+`PROGRESS: 100` for an upstream-build-dependency goal while the matching
+`Cargo.toml` pin still points at the old rev.
+
+The actual **redeploy** of the running daemon stays **operator-gated** (the
+operator runs `simard safe-update`); it is **not required for** the goal to be
+marked done. The done-gate guarantees the fix is in the shipped source build; the
+operator decides when to roll the new binary out. Full reference:
+`docs/howto/self-maintain-dependency-pins.md`.
+
 # CI-fix priority — repair your own red PRs before opening new ones
 
 If one of your own open PRs has failing or BLOCKED CI, fixing that PR is
@@ -262,6 +297,17 @@ that a self-update is needed. The OODA brain will detect the drift via
 `compute_commits_behind()` and trigger `simard safe-update` when no engineers
 are in flight. Do not block on this — just be aware that merged Simard PRs
 require a subsequent rebuild cycle.
+
+## Proactive dependency-drift reconcile
+
+The same "detect drift, reconcile when idle" posture applies to the upstream
+repos Simard **pins**, not just the Simard repo itself. As **low-priority
+self-maintenance** that fits spare "ok to be idle" research time (and never
+preempts an active goal), periodically check whether any rev-pinned
+build-dependency has **fallen behind** its upstream default branch; if so, open
+or update a bump follow-up that re-points the rev, runs `cargo build`, and lands
+it through the normal pipeline. This **dependency-drift** reconcile is the
+upstream-repo analog of the Self-update awareness above.
 
 # Two response shapes
 

--- a/prompt_assets/simard/progress_assessment_reviewer.md
+++ b/prompt_assets/simard/progress_assessment_reviewer.md
@@ -89,6 +89,20 @@ This does **not** block honest *partial* deltas while a PR is in flight (e.g.
 prior 60% → claimed 70% with an open PR is fine). It blocks only **completion**
 claims that an un-merged PR cannot support.
 
+### Landing upstream is not done until the own-pin bump ships
+
+Simard pins several **build-dependency** repos (`amplihack-rs`,
+`amplihack-memory-lib`, `RustyClawd`) by exact git rev in her own `Cargo.toml`,
+so a fix she merges *upstream* is not in her own build until that pin is bumped.
+You cannot diff git revs yourself, so apply this as an **evidence-absence** rule:
+when the `{problem}` or `{plan}` describes **landing an upstream change to a
+Simard build-dependency repo** and `{claimed_pct}` is at or near 100, but the
+`{plan}` / `{wip_summary}` show **no evidence** of *both* (a) the own
+`Cargo.toml` rev bumped to the merged commit and (b) a verified `cargo build`,
+then **reject**: **landing upstream is not done** until the fix ships in Simard's
+own build. If the WIP summary *does* show the own-pin bump landed and the build
+passed, accept as normal.
+
 When in genuine doubt, prefer **accept** with a cautionary rationale. The
 goal of this reviewer is to catch hallucinated jumps, not to gatekeep every
 small movement.

--- a/prompt_assets/simard/recipes/progress-assessment.yaml
+++ b/prompt_assets/simard/recipes/progress-assessment.yaml
@@ -91,6 +91,18 @@ steps:
       PR is in flight (e.g. 60% → 70% with an open PR is fine) — only completion
       claims an un-merged PR cannot support.
 
+      ### Landing upstream is not done until the own-pin bump ships
+
+      Simard pins several **build-dependency** repos (amplihack-rs,
+      amplihack-memory-lib, RustyClawd) by exact git rev in her own Cargo.toml,
+      so a fix she merges **upstream** is not in her own build until that pin is
+      bumped. You cannot diff git revs, so apply an **evidence-absence** rule:
+      when the problem or plan describes landing an upstream change to a Simard
+      build-dependency repo and claimed_pct is at or near 100, but the plan or
+      wip_summary show **no evidence** of both (a) the own Cargo.toml rev bumped
+      to the merged commit and (b) a verified cargo build, then **reject**:
+      landing upstream is not done until the fix ships in Simard's own build.
+
       When in genuine doubt, prefer accept with a cautionary rationale.
 
       ## Output

--- a/src/ooda_brain/prompt_store_tests.rs
+++ b/src/ooda_brain/prompt_store_tests.rs
@@ -1321,3 +1321,378 @@ fn goal_session_objective_finalization_preserves_prose_contract() {
         "goal_session_objective.md is prose-only — it must not gain a JSON verdict contract"
     );
 }
+
+// ── Self-maintaining dependency pins (#2403 follow-on, prompt-only) ──────────
+//
+// Simard's root `Cargo.toml` pins several tools she maintains by EXACT git rev,
+// not by branch:
+//
+//   amplihack-agent-eval -> rysweet/amplihack-rs        (rev = 59548a96…)
+//   amplihack-memory     -> rysweet/amplihack-memory-lib (rev = 26d49bf8…)
+//   rustyclawd-core      -> rysweet/RustyClawd          (rev = 43ebaa1c…)
+//   rustyclawd-tools     -> rysweet/RustyClawd          (rev = 43ebaa1c…)
+//
+// A git-rev pin is FROZEN: when Simard lands a fix in one of those upstream
+// repos, her own pin keeps pointing at the OLD commit, so the fix she just
+// merged is NOT in her own running build. (The motivating case: amplihack-agent-eval
+// pinned ~22 commits behind amplihack-rs main → ~9 merged PRs absent from her
+// own daemon.)
+//
+// The fix is two prompt-only behaviours, fully specified in
+// `docs/howto/self-maintain-dependency-pins.md`:
+//
+//   (A) REACTIVE done-gate — when an engineer LANDS an upstream change to a
+//       build-dependency repo, the SAME goal is not "done" until Simard has also
+//       bumped the matching `Cargo.toml` rev to the merged commit, verified
+//       `cargo build`, and LANDED that bump PR against `rysweet/Simard`. Opening
+//       the upstream PR is NOT the finish line; shipping it into her own running
+//       build is. (Daemon redeploy stays operator-gated.)
+//   (B) PROACTIVE reconcile — as low-priority idle/research-time self-maintenance,
+//       detect when a pinned rev has fallen behind its upstream default branch and
+//       open/update a bump follow-up.
+//
+// These assertions FAIL until the prompt edits land. The feature is PROMPT-ONLY
+// (no Rust logic change) and must COMPOSE additively with #2404 loop-awareness,
+// #2405 per-issue fan-out, #2410 own-PRs-to-landing, and #2413 finalization — the
+// dep-bump is a NEW done-gate that runs AFTER landing, alongside #2410. Output
+// contracts are PRESERVED: `goal_session_objective.md` stays prose-only (NO ACTION
+// / PROGRESS markers intact); `progress_assessment_reviewer.md` and its recipe
+// mirror keep the single-line `{"verdict": …}` JSON the Rust parser reads. Phrases
+// are checked after `normalize_ws` + lowercase so Markdown wrapping cannot defeat
+// them. `engineer_system.md` is asserted via `engineer_system_md()` (include_str!),
+// exactly like the existing engineer-system pins above.
+
+/// The progress-assessment recipe-runner recipe, read at compile time — the
+/// runtime mirror of `progress_assessment_reviewer.md` (asserted inline exactly
+/// like `progress_assessment_recipe_mirrors_done_gate`).
+fn progress_assessment_recipe() -> &'static str {
+    include_str!("../../prompt_assets/simard/recipes/progress-assessment.yaml")
+}
+
+// ── (A) Reactive done-gate in goal_session_objective.md ──────────────────────
+
+#[test]
+fn goal_session_objective_has_dependency_pin_done_gate() {
+    // The OODA brain must carry an explicit dependency-pin done-gate: landing an
+    // upstream change to a build-dependency is not the finish line; the fix must
+    // ship into Simard's own running build.
+    let content = embedded_fallback("goal_session_objective.md")
+        .expect("goal_session_objective.md must be registered");
+    let norm = normalize_ws(content).to_lowercase();
+    assert!(
+        norm.contains("dependency-pin done-gate"),
+        "goal_session_objective.md must declare an explicit dependency-pin done-gate"
+    );
+    assert!(
+        norm.contains("build-dependency"),
+        "the gate must scope to Simard's build-dependency (git-rev-pinned) repos"
+    );
+    assert!(
+        norm.contains("opening the upstream pr is not the finish line"),
+        "must teach that opening/merging the UPSTREAM PR is not the finish line"
+    );
+    assert!(
+        norm.contains("running build"),
+        "the deliverable is the fix shipping into Simard's own running build"
+    );
+}
+
+#[test]
+fn goal_session_objective_dep_gate_requires_bump_build_and_landing() {
+    // The gate's concrete steps: bump the own Cargo.toml rev, verify `cargo build`,
+    // and LAND the bump PR — the goal is not done until all three hold.
+    let content = embedded_fallback("goal_session_objective.md")
+        .expect("goal_session_objective.md must be registered");
+    let norm = normalize_ws(content).to_lowercase();
+    assert!(
+        norm.contains("is not done until"),
+        "the gate must state the goal is not done until the own-pin bump ships"
+    );
+    assert!(
+        norm.contains("cargo.toml"),
+        "the gate must direct bumping the matching rev in the root Cargo.toml"
+    );
+    assert!(
+        norm.contains("bump"),
+        "the gate must direct a rev bump of the own dependency pin"
+    );
+    assert!(
+        norm.contains("cargo build"),
+        "the gate must require `cargo build` to verify the new rev before shipping"
+    );
+    assert!(
+        norm.contains("bump pr"),
+        "the gate must require opening/landing a bump PR for the own pin change"
+    );
+}
+
+#[test]
+fn goal_session_objective_dep_gate_redeploy_is_operator_gated() {
+    // The done-gate guarantees the fix is in the SOURCE build; the actual daemon
+    // redeploy stays operator-gated and is NOT required for the goal to be done.
+    let content = embedded_fallback("goal_session_objective.md")
+        .expect("goal_session_objective.md must be registered");
+    let norm = normalize_ws(content).to_lowercase();
+    assert!(
+        norm.contains("operator-gated"),
+        "the daemon redeploy must be described as operator-gated"
+    );
+    assert!(
+        norm.contains("not required for") || norm.contains("not required to"),
+        "the operator redeploy must be explicitly NOT required for the goal to be done"
+    );
+}
+
+#[test]
+fn goal_session_objective_has_proactive_dependency_drift_note() {
+    // (B) Proactive reconcile must be NOTED as acceptable low-priority idle/research
+    // self-maintenance — the upstream-repo analog of the existing Self-update awareness.
+    let content = embedded_fallback("goal_session_objective.md")
+        .expect("goal_session_objective.md must be registered");
+    let norm = normalize_ws(content).to_lowercase();
+    assert!(
+        norm.contains("dependency-drift"),
+        "must note a proactive dependency-drift reconcile activity"
+    );
+    assert!(
+        norm.contains("fallen behind"),
+        "drift means a pinned rev has fallen behind its upstream default branch"
+    );
+    assert!(
+        norm.contains("low-priority"),
+        "the proactive reconcile must be framed as LOW-priority (never preempts real work)"
+    );
+    assert!(
+        norm.contains("self-maintenance"),
+        "the proactive reconcile is self-maintenance / idle-time work"
+    );
+}
+
+#[test]
+fn goal_session_objective_dep_gate_preserves_prose_contract() {
+    // Output-contract guard: the new gate must stay additive PROSE — it must NOT
+    // introduce a JSON verdict shape, and must keep the NO ACTION / PROGRESS
+    // markers the goal-session parser reads. (Combined with a new-behaviour
+    // assertion so the test fails until the gate lands.)
+    let content = embedded_fallback("goal_session_objective.md")
+        .expect("goal_session_objective.md must be registered");
+    let norm = normalize_ws(content).to_lowercase();
+    assert!(
+        norm.contains("dependency-pin done-gate"),
+        "precondition: the dependency-pin done-gate must be present"
+    );
+    assert!(
+        !content.contains("\"verdict\""),
+        "goal_session_objective.md is prose-only — the dep-gate must not add a JSON verdict contract"
+    );
+    assert!(
+        content.contains("NO ACTION"),
+        "the prose `NO ACTION` marker the parser reads must be preserved"
+    );
+    assert!(
+        content.contains("PROGRESS:"),
+        "the prose `PROGRESS: NN` marker the parser reads must be preserved"
+    );
+}
+
+#[test]
+fn goal_session_objective_dep_gate_composes_with_2410_done_gate() {
+    // Regression/compose guard: the dep-pin done-gate builds ON TOP of the #2410
+    // merged-AND-closed done-gate — both must coexist, not replace one another.
+    let content = embedded_fallback("goal_session_objective.md")
+        .expect("goal_session_objective.md must be registered");
+    let norm = normalize_ws(content).to_lowercase();
+    assert!(
+        norm.contains("complete only when its pr is merged and the linked issue is closed"),
+        "must preserve the #2410 merged-AND-closed done-gate"
+    );
+    assert!(
+        norm.contains("dependency-pin done-gate"),
+        "the new dependency-pin done-gate must compose alongside the #2410 done-gate"
+    );
+}
+
+// ── (A) Engineer follow-through + (B) drift directive in engineer_system.md ──
+
+#[test]
+fn engineer_system_bumps_own_pin_after_landing_upstream() {
+    // The engineer that LANDED an upstream change must follow through in the same
+    // cycle: bump the own Cargo.toml rev and re-verify the build.
+    let norm = normalize_ws(engineer_system_md()).to_lowercase();
+    assert!(
+        norm.contains("bump your own pin"),
+        "engineer_system.md must direct bumping Simard's own pin after landing upstream"
+    );
+    assert!(
+        norm.contains("not done when the upstream pr merges"),
+        "the engineer is not done when the upstream PR merges — the fix isn't in her build yet"
+    );
+    assert!(
+        norm.contains("cargo.toml"),
+        "the engineer must edit the matching rev in the root Cargo.toml"
+    );
+    assert!(
+        norm.contains("cargo build"),
+        "the engineer must re-verify with `cargo build` (a bump that does not build is rolled back)"
+    );
+}
+
+#[test]
+fn engineer_system_dep_bump_pr_convention_and_dedup() {
+    // The bump PR uses a deterministic, upstream-repo-keyed naming convention and
+    // is de-duplicated: an already-open bump PR is UPDATED, never duplicated.
+    let norm = normalize_ws(engineer_system_md()).to_lowercase();
+    assert!(
+        norm.contains("chore/bump-"),
+        "must use the deterministic `chore/bump-<upstream-repo>-pin` branch convention"
+    );
+    assert!(
+        norm.contains("chore(deps): bump"),
+        "must use the `chore(deps): bump <upstream-repo> pin to <short-sha>` title convention"
+    );
+    assert!(
+        norm.contains("rysweet/simard"),
+        "the bump PR is opened against rysweet/Simard (where Cargo.toml lives)"
+    );
+    assert!(
+        norm.contains("already open") && norm.contains("update it"),
+        "an already-open bump PR for that repo must be UPDATED, not duplicated"
+    );
+}
+
+#[test]
+fn engineer_system_dep_bump_atomic_for_shared_repo() {
+    // Crates that pin the SAME upstream repo must be bumped together in one commit:
+    // rustyclawd-core and rustyclawd-tools both pin RustyClawd, so a bump moves both
+    // in the same PR — never split one upstream commit across two PRs.
+    let norm = normalize_ws(engineer_system_md()).to_lowercase();
+    assert!(
+        norm.contains("rustyclawd-core") && norm.contains("rustyclawd-tools"),
+        "must name the two crates that share the RustyClawd repo pin"
+    );
+    assert!(
+        norm.contains("together in one commit"),
+        "crates sharing an upstream repo must be re-pointed together in one commit"
+    );
+}
+
+#[test]
+fn engineer_system_has_proactive_dependency_drift_directive() {
+    // (B) The proactive reconcile lives as a low-priority dependency-drift directive
+    // in engineer_system.md: compare each pinned rev to the upstream default branch.
+    let norm = normalize_ws(engineer_system_md()).to_lowercase();
+    assert!(
+        norm.contains("dependency-drift"),
+        "engineer_system.md must carry a dependency-drift self-maintenance directive"
+    );
+    assert!(
+        norm.contains("fallen behind"),
+        "drift detection means a pinned rev has fallen behind its upstream default branch"
+    );
+    assert!(
+        norm.contains("ls-remote"),
+        "drift detection must use runtime git tooling (e.g. `git ls-remote`) — no new Rust subsystem"
+    );
+    assert!(
+        norm.contains("low-priority"),
+        "the drift directive must be low-priority and never preempt an active goal"
+    );
+}
+
+#[test]
+fn engineer_system_dep_bump_preserves_2410_landing() {
+    // Regression/compose guard: the dep-bump follow-through builds ON TOP of #2410 —
+    // the continue-existing-PR-never-duplicate guidance must remain.
+    let norm = normalize_ws(engineer_system_md()).to_lowercase();
+    assert!(
+        norm.contains("continue it, never duplicate it"),
+        "must preserve the #2410 continue-existing-PR-never-duplicate guidance"
+    );
+    assert!(
+        norm.contains("bump your own pin"),
+        "the new dep-bump follow-through must compose alongside the #2410 landing guidance"
+    );
+}
+
+// ── (A) Reviewer enforcement in progress_assessment_reviewer.md (+ recipe) ───
+
+#[test]
+fn progress_reviewer_rejects_unbumped_dep_after_upstream_landing() {
+    // The reviewer cannot diff git revs (text-only, fails open on unknown verdicts),
+    // so the rule is EVIDENCE-ABSENCE: reject a done/100% claim that describes landing
+    // an upstream build-dependency change but shows no evidence of BOTH the own
+    // Cargo.toml rev bump AND a verified `cargo build`.
+    let content = embedded_fallback("progress_assessment_reviewer.md")
+        .expect("progress_assessment_reviewer.md must be registered");
+    let norm = normalize_ws(content).to_lowercase();
+    assert!(
+        norm.contains("build-dependency"),
+        "the reviewer must recognise an upstream build-dependency landing claim"
+    );
+    assert!(
+        norm.contains("landing upstream is not done"),
+        "the reviewer must encode that landing upstream is not done until the own-pin bump ships"
+    );
+    assert!(
+        norm.contains("cargo.toml") && norm.contains("cargo build"),
+        "the rejection must hinge on missing evidence of the Cargo.toml rev bump + cargo build"
+    );
+    assert!(
+        norm.contains("no evidence"),
+        "the rule must be phrased as evidence-absence (the reviewer cannot diff revs)"
+    );
+    assert!(
+        norm.contains("reject"),
+        "a premature done/100% upstream-landing claim must be rejected"
+    );
+}
+
+#[test]
+fn progress_reviewer_dep_gate_preserves_json_contract() {
+    // Output-contract guard: the new rule must NOT change the single-line verdict
+    // JSON the Rust reviewer parser reads. Combined with a new-behaviour assertion
+    // so the test fails until the rule lands.
+    let content = embedded_fallback("progress_assessment_reviewer.md")
+        .expect("progress_assessment_reviewer.md must be registered");
+    let norm = normalize_ws(content).to_lowercase();
+    assert!(
+        norm.contains("landing upstream is not done"),
+        "precondition: the dep-bump rejection rule must be present"
+    );
+    assert!(
+        content.contains("\"verdict\""),
+        "the single-line verdict JSON output contract must be preserved"
+    );
+    assert!(
+        content.contains("\"accept\"") && content.contains("\"reject\""),
+        "the verdict tokens must stay exactly \"accept\" / \"reject\" for the Rust parser"
+    );
+}
+
+#[test]
+fn progress_assessment_recipe_mirrors_dep_bump_gate() {
+    // The runtime recipe-runner recipe must stay in sync with the embedded
+    // progress_assessment_reviewer.md on the dep-bump evidence gate.
+    let recipe = progress_assessment_recipe();
+    let norm = normalize_ws(recipe).to_lowercase();
+    assert!(
+        norm.contains("build-dependency"),
+        "progress-assessment.yaml must mirror the upstream build-dependency landing gate"
+    );
+    assert!(
+        norm.contains("landing upstream is not done"),
+        "recipe mirror: landing upstream is not done until the own-pin bump ships"
+    );
+    assert!(
+        norm.contains("cargo.toml") && norm.contains("cargo build"),
+        "recipe mirror: the gate hinges on the Cargo.toml rev bump + cargo build evidence"
+    );
+    assert!(
+        norm.contains("no evidence"),
+        "recipe mirror: evidence-absence formulation must be preserved"
+    );
+    assert!(
+        recipe.contains("\"verdict\""),
+        "progress-assessment.yaml must keep the verdict JSON output contract"
+    );
+}


### PR DESCRIPTION
## Problem

Simard's root `Cargo.toml` pins the tools she maintains by **exact git rev** (not branch):

| Crate | Upstream repo |
| --- | --- |
| `amplihack-agent-eval` | `rysweet/amplihack-rs` |
| `amplihack-memory` | `rysweet/amplihack-memory-lib` |
| `rustyclawd-core` / `rustyclawd-tools` | `rysweet/RustyClawd` |

A rev pin is **frozen**: when Simard lands a fix in one of those upstream repos, her own pin keeps pointing at the *old* commit, so the fix she just merged is **not in her own running build**. Motivating case: `amplihack-agent-eval` was pinned ~22 commits behind `amplihack-rs` `main` — roughly **9 merged PRs absent from the very daemon that wrote them**. Opening (or even merging) the upstream PR was being treated as "done"; shipping it into her own build was not.

## What changed (PROMPT-ONLY — no Rust logic)

Two behaviours, expressed entirely in `prompt_assets/simard/*` (+ the recipe mirror). This composes **additively** with #2404 loop-awareness, #2405 per-issue fan-out, #2410 own-PRs-to-landing, and #2413 finalization — the dep-bump is a **new done-gate that runs AFTER landing**, alongside #2410.

**(A) Reactive done-gate.** A goal that lands an upstream change to a build-dependency repo is **not done until** Simard also:
1. bumps the matching `rev = …` in the root `Cargo.toml` to the merged commit,
2. verifies `cargo build`, and
3. lands a **bump PR** against `rysweet/Simard` (same merge-ready gate as any PR).

Daemon redeploy stays **operator-gated** and is **not required** for the goal to be "done" (the gate guarantees the fix is in the shipped source build).
- `goal_session_objective.md` — new "Dependency-pin done-gate" section (prose-only).
- `engineer_system.md` — the engineer that landed upstream follows through with the bump + build-verify + bump PR.
- `progress_assessment_reviewer.md` (+ `recipes/progress-assessment.yaml` mirror) — **rejects** a done/100% upstream-landing claim that shows **no evidence** of the own-pin bump + `cargo build` (evidence-absence rule, since the reviewer cannot diff revs).

**(B) Proactive reconcile.** Low-priority self-maintenance directive (`engineer_system.md`, noted in `goal_session_objective.md`): detect when a pinned rev has **fallen behind** its upstream default branch (`git ls-remote` / `gh ... compare`) and open/update a bump follow-up.

**Bump-PR conventions (de-dup + atomic).** Keyed on the upstream repo, not the crate: branch `chore/bump-<repo>-pin`, title `chore(deps): bump <repo> pin to <sha>`, base `rysweet/Simard`. An already-open bump PR for that repo is **updated, never duplicated**; crates sharing a repo (`rustyclawd-core` + `rustyclawd-tools`) are bumped **together in one commit**.

## Output contracts preserved
- `goal_session_objective.md` stays **prose-only** — `NO ACTION` / `PROGRESS: NN` markers intact, no JSON verdict added.
- `progress_assessment_reviewer.md` + recipe keep the single-line `{"verdict": "accept"|"reject", "rationale": …}` JSON the Rust parser reads; verdict tokens unchanged.
- New prompt-content pin tests assert the wording after `normalize_ws` + lowercase so Markdown wrapping can't defeat them.

## Test plan / evidence
- **Prompt-content tests:** `cargo test --lib prompt_store` → **81 passed, 0 failed** (incl. 11 new dependency-pin tests: done-gate, prose-contract, operator-gated, #2410 composition, engineer bump/de-dup/atomic, drift directive, reviewer evidence-absence + JSON-contract, recipe mirror).
- **Docs:** `mkdocs build --strict` → exit 0 (new `docs/howto/self-maintain-dependency-pins.md` builds clean; linked from `docs/index.md` + nav). New howto's internal links verified to resolve.
- **Lint/format:** `cargo fmt --check` clean; `cargo clippy --all-targets --all-features --locked -- -D warnings` → exit 0.
- **Rust-only gate:** `scripts/check-rust-only-gate.sh` passed (no new .py/.js/.ts).
- **Pre-commit + pre-push hooks:** all passed on commit and push.

## Scope
8 files: 4 prompt assets, 1 recipe, 1 new howto + 2 doc-nav lines, and the prompt-content pin tests. No production Rust logic changed.

## Operator note
Prompt changes are hot-reloaded by syncing assets — no daemon restart needed:
```bash
rsync -a prompt_assets/simard/ ~/.simard/prompt_assets/simard/
```
This PR does **not** redeploy the daemon. Follow-on to #2403; see `docs/howto/self-maintain-dependency-pins.md`.
