### PR TITLE
feat(prompts): crusty review on gpt-5.5/claude-opus-4.8 (high reasoning, 1M context)

### DIFF
--- a/docs/reference/pr-finalization-pipeline.md
+++ b/docs/reference/pr-finalization-pipeline.md
@@ -85,7 +85,7 @@ until crusty is satisfied or the cap is reached.
 | Property | Behavior |
 |----------|----------|
 | **Reviewer** | `crusty-old-engineer` skill — a curmudgeonly senior-engineer reviewer that surfaces correctness, maintainability, and long-term-consequence findings. |
-| **Model** | A **high-end reasoning model**, pinned explicitly (the engineer itself runs the Copilot CLI default/auto model, so crusty is invoked through a `copilot --model "$SIMARD_REVIEW_MODEL"` subprocess to force the high-end model). Default `gpt-5.4`; see [Configuration](#configuration). |
+| **Model** | A **high-end reasoning model**, pinned explicitly (the engineer itself runs the Copilot CLI default/auto model, so crusty is invoked through a `copilot --model "$SIMARD_REVIEW_MODEL" --reasoning-effort high --context long_context` subprocess to force the high-end model at **high** reasoning effort over the **1M-token** context tier). Default `gpt-5.5`; see [Configuration](#configuration). |
 | **Per-iteration input** | The **latest** PR state — the engineer re-fetches the current diff each iteration (`gh pr diff <PR>`); it never re-reviews a stale diff. |
 | **Fix discipline** | Every **actionable / blocking** finding is fixed in code and pushed to the **same PR branch** before the next review. |
 | **Termination** | Crusty reports **no blocking/actionable findings** (satisfied), OR the iteration cap is reached. See [Bounded loop & blocker semantics](#bounded-loop--blocker-semantics). |
@@ -165,32 +165,34 @@ OODA loop) shown here for context only; this pipeline does not read it.
 
 | Variable | New? | Default | Range / Allowlist | Purpose |
 |----------|------|---------|-------------------|---------|
-| `SIMARD_REVIEW_MODEL` | **net-new** | `gpt-5.4` | Validated against an allowlist (`gpt-5.4`, `gpt-5.4-mini`, …) before being passed to `copilot --model`; an unrecognized value falls back to the default. | The high-end reasoning model the crusty review loop runs on. Defined and read by the new engineer-prompt section. |
+| `SIMARD_REVIEW_MODEL` | **net-new** | `gpt-5.5` | Validated against an allowlist (`gpt-5.5`, `claude-opus-4.8`) before being passed to `copilot --model … --reasoning-effort high --context long_context`; an unrecognized value falls back to the default. | The high-end reasoning model the crusty review loop runs on. Defined and read by the new engineer-prompt section. |
 | `SIMARD_REVIEW_MAX_ITERS` | **net-new** | `3` | Integer, bounded to `[1, 5]`. | Hard cap on crusty review→fix iterations before the loop must terminate. Defined and read by the new engineer-prompt section. |
 | `SIMARD_DAILY_BUDGET_USD` | pre-existing | `500` | — | **Pre-existing** Simard knob, read by the OODA-loop budget tracker (`src/ooda_loop/types.rs`, default `500.0`) — **not** introduced or consumed by this pipeline. It is the daemon-wide spend ceiling, not a per-pipeline gate; the trivial-PR filter and the iteration cap are what actually bound *this* loop's spend. |
 
-> **Model verification.** `gpt-5.4` is the verified high-end default — it is
-> accepted by `copilot --model gpt-5.4` on the enterprise Copilot endpoint. If
-> you change `SIMARD_REVIEW_MODEL`, confirm the new string is accepted by the CLI
-> (`copilot --model <X> -p "reply OK"`) before deploying; an unaccepted value
+> **Model verification.** `gpt-5.5` is the verified high-end default and
+> `claude-opus-4.8` is the verified premium alternative — both are accepted by
+> `copilot --model <m> --reasoning-effort high --context long_context` on the
+> enterprise Copilot endpoint. If you change `SIMARD_REVIEW_MODEL`, confirm the new
+> string is accepted by the CLI (`copilot --model <X> --reasoning-effort high
+> --context long_context -p "reply OK"`) before deploying; an unaccepted value
 > falls back to the default rather than failing the pipeline.
 
 ### Examples
 
-Run the default pipeline (high-end crusty review on `gpt-5.4`, cap 3) — no
-configuration needed; this is the shipped default.
+Run the default pipeline (high-end crusty review on `gpt-5.5` at high reasoning
+effort + 1M context, cap 3) — no configuration needed; this is the shipped default.
 
-Pin a different high-end model and widen the cap to 5 for a session:
+Pin the premium model and widen the cap to 5 for a session:
 
 ```bash
-export SIMARD_REVIEW_MODEL=gpt-5.4
+export SIMARD_REVIEW_MODEL=claude-opus-4.8
 export SIMARD_REVIEW_MAX_ITERS=5
 ```
 
 Confirm a candidate model string before adopting it:
 
 ```bash
-copilot --model gpt-5.4 -p "Reply with exactly: OK" --allow-all-tools
+copilot --model gpt-5.5 --reasoning-effort high --context long_context -p "Reply with exactly: OK" --allow-all-tools
 # expect: OK
 ```
 
@@ -285,7 +287,8 @@ the next engineer cycle.
 - **Latest-state.** Each loop iteration reviews the freshly-pushed PR state, never
   a stale diff.
 - **High-end.** The crusty pass runs on the pinned `SIMARD_REVIEW_MODEL`
-  (default `gpt-5.4`), independent of the engineer's default model.
+  (default `gpt-5.5`, at `--reasoning-effort high --context long_context`),
+  independent of the engineer's default model.
 - **Cost-aware.** Trivial PRs get a single pass; the trivial filter and the
   iteration cap keep the high-end model's spend bounded, well inside the
   daemon-wide `SIMARD_DAILY_BUDGET_USD` (which this pipeline does not itself

--- a/prompt_assets/simard/engineer_system.md
+++ b/prompt_assets/simard/engineer_system.md
@@ -214,10 +214,16 @@ spend.)
 **Stage 1 — crusty review→fix loop (high-end model).** Invoke the
 **crusty-old-engineer** skill to review the PR's diff/changes on a **high-end**
 reasoning model. The engineer itself runs the Copilot default/auto model, so crusty
-MUST be pinned to the high-end model via a `copilot --model "$SIMARD_REVIEW_MODEL"`
-subprocess. The model is configurable via **`$SIMARD_REVIEW_MODEL`** and defaults to the
-verified **gpt-5.4** (confirmed accepted by `copilot --model gpt-5.4`). Each iteration,
-in order:
+MUST be pinned to the high-end model via a
+`copilot --model "$SIMARD_REVIEW_MODEL" --reasoning-effort high --context long_context`
+subprocess — the **high** reasoning-effort level and the **1M-token `long_context`**
+tier are required so the review reasons hard over the full diff. The model is
+configurable via **`$SIMARD_REVIEW_MODEL`** and defaults to the verified **gpt-5.5**;
+the sanctioned high-end allowlist is **`gpt-5.5`** and **`claude-opus-4.8`** (both
+confirmed accepted by `copilot --model <m> --reasoning-effort high --context long_context`;
+`claude-opus-4.8` is the premium, higher-cost option). An unrecognized
+`$SIMARD_REVIEW_MODEL` falls back to the default rather than failing the pipeline.
+Each iteration, in order:
 
 1. Re-fetch the **latest PR state** (`gh pr diff <PR>`) — never re-review a **stale diff**.
 2. Run crusty on the high-end model over that latest diff.

--- a/src/ooda_brain/prompt_store_tests.rs
+++ b/src/ooda_brain/prompt_store_tests.rs
@@ -1032,7 +1032,8 @@ fn progress_assessment_recipe_mirrors_done_gate() {
 // fix is implemented and the PR is opened/updated but BEFORE merge-ready:
 //
 //   1. CRUSTY REVIEW→FIX LOOP on a HIGH-END model (`$SIMARD_REVIEW_MODEL`,
-//      default `gpt-5.4`), fixing every actionable finding and re-reviewing the
+//      default `gpt-5.5`, run with --reasoning-effort high --context long_context),
+//      fixing every actionable finding and re-reviewing the
 //      LATEST PR state until crusty emits the sentinel `NO BLOCKING FINDINGS`
 //      or a bounded cap (`$SIMARD_REVIEW_MAX_ITERS`, default 3) is reached.
 //   2. PR-GUIDE illustrated walkthrough (graceful-skip where unavailable).
@@ -1099,8 +1100,12 @@ fn engineer_system_crusty_loop_uses_high_end_model() {
         "the high-end model must be configurable via $SIMARD_REVIEW_MODEL"
     );
     assert!(
-        norm.contains("gpt-5.4"),
-        "the high-end model must default to the verified gpt-5.4"
+        norm.contains("gpt-5.5"),
+        "the high-end model must default to the verified gpt-5.5"
+    );
+    assert!(
+        norm.contains("reasoning-effort high") && norm.contains("long_context"),
+        "crusty must run with --reasoning-effort high and --context long_context"
     );
     assert!(
         norm.contains("copilot --model"),


### PR DESCRIPTION
Upgrades the PR-finalization **crusty review→fix loop** to a top-tier reasoning model per operator direction (replacing the `gpt-5.4` default).

- `SIMARD_REVIEW_MODEL` default `gpt-5.4` → **`gpt-5.5`**; allowlist **{`gpt-5.5`, `claude-opus-4.8`}**.
- Invocation now pins: `copilot --model "$SIMARD_REVIEW_MODEL" --reasoning-effort high --context long_context` (high reasoning effort + 1M-token context tier).
- `claude-opus-4.8` is the verified premium alternative.

Both verified accepted by `copilot --model <m> --reasoning-effort high --context long_context`. Loop bounds unchanged (cap 3, budget guard). Docs + prompt-content pin tests updated. Prompt-only + docs + test pins.