### PR TITLE
fix(ooda-brain): recover real engineer-lifecycle decisions + instrument parse-failure rate (#2419)

### DIFF
--- a/docs/howto/diagnose-brain-decision-parse-failures.md
+++ b/docs/howto/diagnose-brain-decision-parse-failures.md
@@ -26,6 +26,35 @@ what to do.
 For the full protocol definition see the
 [OODA Brain Decision Protocol reference](../reference/ooda-brain-decision-protocol.md).
 
+> **Fixed in [#2419](https://github.com/rysweet/Simard/issues/2419):** The
+> lifecycle brain previously parsed `recipe-runner-rs`'s **default `text`
+> output**, which prints only a summary banner (`Recipe: … SUCCESS …`) to
+> stdout — the agent's decision text is not on stdout in text mode. First-word
+> extraction always saw `Recipe:`, so ~99.6% of decisions silently defaulted
+> to `ContinueSkipping`. The brain now invokes `--output-format json` and
+> extracts the real decision from the JSON envelope, and emits one
+> `brain_lifecycle_decision` metric per call. **Before reaching for the log
+> triage below, measure the parse-failure rate directly from the metric** (see
+> [Measure the parse-failure rate](#measure-the-parse-failure-rate)).
+
+## Measure the parse-failure rate
+
+Each `decide_engineer_lifecycle` call appends a `brain_lifecycle_decision`
+event to `~/.simard/metrics/metrics.jsonl`. The `outcome` label is the signal:
+`parsed` (a real decision) vs `default_empty` / `default_malformed` / `error`
+(a parse failure). To compute the rate over the recorded window:
+
+```bash
+jq -rc 'select(.metric_name=="brain_lifecycle_decision") | .context | fromjson | .outcome' \
+  ~/.simard/metrics/metrics.jsonl \
+  | sort | uniq -c
+```
+
+A healthy lifecycle brain shows a mix of `parsed` outcomes (including genuine
+`continue_skipping`); a regression shows `default_malformed` dominating again
+(the symptom #2419 fixed). `is_parse_failure` in each context is `true` for any
+non-`parsed` outcome, so `count(is_parse_failure==true)/count(*)` is the rate.
+
 ## Step 1: Find the failing cycle
 
 Symptoms that justify reading parse-failure logs:

--- a/docs/reference/recipe-brain-api.md
+++ b/docs/reference/recipe-brain-api.md
@@ -91,8 +91,24 @@ fn decide_engineer_lifecycle(
 ) -> SimardResult<EngineerLifecycleDecision>
 ```
 
-Invokes `recipe-runner-rs` with the full lifecycle context as `-c` vars.
-Parses stdout via `parse_lifecycle_from_text()`.
+Invokes `recipe-runner-rs` with the full lifecycle context as `-c` vars and
+**`--output-format json`**, then extracts the agent's decision text from the
+final `step_results[].output` of the JSON envelope before running first-word
+extraction via `parse_lifecycle_outcome()`.
+
+> **Fixed in [#2419](https://github.com/rysweet/Simard/issues/2419):** This
+> call site previously read recipe-runner-rs's **default `text` output**,
+> which prints only a human summary banner (`Recipe: … SUCCESS …`) to stdout —
+> the agent's decision text is not on stdout in text mode. First-word
+> extraction therefore always saw `Recipe:`, matched no variant, and silently
+> defaulted to `ContinueSkipping` on ~99.6% of invocations, so non-default
+> decisions (`reclaim_and_redispatch`, `deprioritize`, …) never fired. The fix
+> switches to `--output-format json` + envelope extraction, mirroring the
+> already-correct `disk_health.rs` path.
+
+Every invocation emits one `brain_lifecycle_decision` metric event (see
+[Lifecycle decision metric](#lifecycle-decision-metric)) so the parse-failure
+rate is measurable from `metrics.jsonl`.
 
 ---
 
@@ -173,6 +189,51 @@ Extra fields use defaults:
 > extraction, and `LIFECYCLE_KEYWORDS` constant have been deleted. The
 > lifecycle prompt now instructs the LLM to output the variant name as its
 > first word.
+
+### `parse_lifecycle_outcome`
+
+```rust
+pub fn parse_lifecycle_outcome(
+    text: &str,
+) -> (EngineerLifecycleDecision, LifecycleParseOutcome)
+```
+
+Canonical lifecycle parser (added in
+[#2419](https://github.com/rysweet/Simard/issues/2419)). Identical first-word
+extraction to `parse_lifecycle_from_text`, but additionally returns a
+`LifecycleParseOutcome` classifying *how* the decision was produced:
+
+| Variant | Meaning |
+|---------|---------|
+| `Parsed` | First word matched a known variant — a real decision. |
+| `DefaultEmpty` | Output was empty/whitespace → defaulted to `ContinueSkipping`. |
+| `DefaultMalformed` | Output non-empty but first word matched no variant → defaulted. |
+| `Error` | recipe-runner invocation/envelope decode failed (set on the error path, not by the pure parser). |
+
+`LifecycleParseOutcome::is_parse_failure()` is `true` for everything except
+`Parsed`. This split is what makes the parse-failure rate measurable —
+previously a genuine `continue_skipping` decision and a silent fallback were
+indistinguishable. `parse_lifecycle_from_text` is the decision-only wrapper
+over this function.
+
+### Lifecycle decision metric
+
+`decide_engineer_lifecycle` records one `brain_lifecycle_decision` metric
+(value `1.0`) per invocation via `self_metrics::record_metric`. The context
+JSON carries:
+
+| Field | Description |
+|-------|-------------|
+| `goal_id` | Goal under inspection. |
+| `outcome` | `parsed` \| `default_empty` \| `default_malformed` \| `error`. |
+| `is_parse_failure` | `true` for any `outcome != "parsed"` (the numerator). |
+| `first_word` | First whitespace-delimited token of the decision text (bounded). |
+| `consecutive_skip_count` | Skip streak for this goal at decision time. |
+| `decision` | Resulting `EngineerLifecycleDecision` choice tag. |
+| `cause` | `ok` on the happy path; `spawn_failed` / `nonzero_exit` / `envelope_decode_failed` on the error path. |
+
+Parse-failure rate over a window:
+`count(is_parse_failure == true) / count(*)`.
 
 ---
 

--- a/docs/reference/text-parsing-wire-formats.md
+++ b/docs/reference/text-parsing-wire-formats.md
@@ -149,9 +149,20 @@ If validation fails, the deterministic floor applies.
 **Enum:** `EngineerLifecycleDecision`
 
 **Parser:** `parse_lifecycle_from_text(text) -> EngineerLifecycleDecision`
+(thin wrapper over `parse_lifecycle_outcome`, which also returns a
+`LifecycleParseOutcome` for metrics).
 
 Extracts the first whitespace-delimited word, lowercases it, and matches
 against the 6 lifecycle variant names. Defaults to `ContinueSkipping`.
+
+> **Fixed in [#2419](https://github.com/rysweet/Simard/issues/2419):** The
+> `text` passed to this parser is the agent decision text extracted from the
+> `recipe-runner-rs --output-format json` envelope
+> (`step_results[].output`), **not** raw stdout. recipe-runner-rs's default
+> `text` mode prints only a summary banner to stdout, so reading raw stdout
+> made first-word extraction always see `Recipe:` and silently default
+> (~99.6% of calls). Each call now also emits a `brain_lifecycle_decision`
+> metric whose `outcome` label measures the parse-failure rate.
 
 **Keywords:**
 

--- a/src/ooda_brain/recipe_brain.rs
+++ b/src/ooda_brain/recipe_brain.rs
@@ -14,6 +14,8 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use serde::Deserialize;
+
 use super::decide::{DecideContext, DecideJudgment, OodaDecideBrain};
 use super::orient::{
     FAILURE_PENALTY_PER_CONSECUTIVE, OodaOrientBrain, OrientContext, OrientJudgment,
@@ -32,6 +34,123 @@ const LIFECYCLE_ADAPTER_TAG: &str = "recipe-engineer-lifecycle-brain";
 
 /// Cap on raw response text embedded in error messages and rationale fields.
 const MAX_RATIONALE_CHARS: usize = 500;
+
+/// Metric name emitted once per `decide_engineer_lifecycle` invocation so the
+/// lifecycle-brain parse-failure rate is measurable from `metrics.jsonl`
+/// (issue #2419). `value` is always `1.0`; the `outcome` label in the context
+/// JSON is the numerator/denominator signal.
+const LIFECYCLE_DECISION_METRIC: &str = "brain_lifecycle_decision";
+
+/// Cap on the `first_word` token recorded in the metric context. Generous
+/// enough to capture any legitimate variant name plus stray punctuation, but
+/// bounded so a runaway model response can't bloat the metrics file.
+const METRIC_FIRST_WORD_CHARS: usize = 64;
+
+// ---------------------------------------------------------------------------
+// recipe-runner-rs JSON envelope (issue #2419)
+//
+// recipe-runner-rs in its DEFAULT `text` output mode prints only a human
+// summary banner ("Recipe: <name> ... SUCCESS ...") to stdout — the agent
+// step's actual decision text is NOT on stdout. Parsing the first word of
+// that banner always yields "Recipe:", which matches no lifecycle variant, so
+// every decision silently defaulted to `continue_skipping` (~99.6% of calls).
+//
+// The fix mirrors the already-correct `disk_health.rs` path: invoke with
+// `--output-format json` and pull the real decision text out of the JSON
+// envelope's final step result before first-word extraction.
+// ---------------------------------------------------------------------------
+
+/// JSON envelope returned by `recipe-runner-rs --output-format json`.
+#[derive(Debug, Deserialize)]
+struct RecipeEnvelope {
+    success: bool,
+    #[serde(default)]
+    step_results: Vec<RecipeStepResult>,
+}
+
+/// A single step's result inside the [`RecipeEnvelope`].
+#[derive(Debug, Deserialize)]
+struct RecipeStepResult {
+    #[allow(dead_code)] // Part of the JSON contract; asserted in tests.
+    #[serde(default)]
+    step_id: String,
+    #[serde(default)]
+    output: String,
+}
+
+/// Extract the decision text the agent actually produced from the
+/// `recipe-runner-rs --output-format json` stdout envelope.
+///
+/// Returns the FINAL step's `output` (the decision step is always terminal in
+/// the OODA brain recipes). Surfaces an [`SimardError::AdapterInvocationFailed`]
+/// — rather than silently returning empty text — when the envelope cannot be
+/// decoded, the recipe reported `success=false`, or no step produced output.
+/// This keeps a broken recipe-runner visible instead of masquerading as a
+/// `default_empty` parse.
+fn extract_recipe_decision_output(stdout: &[u8], adapter_tag: &str) -> SimardResult<String> {
+    let envelope: RecipeEnvelope =
+        serde_json::from_slice(stdout).map_err(|e| SimardError::AdapterInvocationFailed {
+            base_type: adapter_tag.to_string(),
+            reason: format!("failed to deserialize recipe JSON output: {e}"),
+        })?;
+
+    if !envelope.success {
+        return Err(SimardError::AdapterInvocationFailed {
+            base_type: adapter_tag.to_string(),
+            reason: "recipe reported success=false in JSON output".to_string(),
+        });
+    }
+
+    envelope
+        .step_results
+        .last()
+        .map(|s| s.output.clone())
+        .ok_or_else(|| SimardError::AdapterInvocationFailed {
+            base_type: adapter_tag.to_string(),
+            reason: "no step results in recipe JSON output".to_string(),
+        })
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle decision outcome classification (issue #2419)
+// ---------------------------------------------------------------------------
+
+/// Outcome of a single `decide_engineer_lifecycle` parse, used as the
+/// `outcome` label on the [`LIFECYCLE_DECISION_METRIC`] metric so the
+/// parse-failure rate (`outcome != parsed`) is measurable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LifecycleParseOutcome {
+    /// First word matched a known variant — a real decision was parsed.
+    Parsed,
+    /// Recipe output was empty/whitespace-only → defaulted to
+    /// `continue_skipping`.
+    DefaultEmpty,
+    /// Recipe output was non-empty but the first word matched no variant →
+    /// defaulted to `continue_skipping`.
+    DefaultMalformed,
+    /// recipe-runner-rs invocation or envelope decoding failed — no decision
+    /// could be obtained. Produced on the error path of
+    /// `decide_engineer_lifecycle`, not by the pure parser.
+    Error,
+}
+
+impl LifecycleParseOutcome {
+    /// Stable label string recorded in the metric context.
+    pub fn label(self) -> &'static str {
+        match self {
+            LifecycleParseOutcome::Parsed => "parsed",
+            LifecycleParseOutcome::DefaultEmpty => "default_empty",
+            LifecycleParseOutcome::DefaultMalformed => "default_malformed",
+            LifecycleParseOutcome::Error => "error",
+        }
+    }
+
+    /// Whether this outcome counts toward the parse-failure numerator
+    /// (everything except a real parsed decision).
+    pub fn is_parse_failure(self) -> bool {
+        !matches!(self, LifecycleParseOutcome::Parsed)
+    }
+}
 
 /// Resolve the recipe YAML path. Checks, in order:
 ///   1. `~/.simard/prompt_assets/simard/recipes/<recipe_filename>` (hot-reload)
@@ -103,6 +222,13 @@ impl RecipeBrain {
 
 impl OodaDecideBrain for RecipeBrain {
     fn judge_decision(&self, ctx: &DecideContext) -> SimardResult<DecideJudgment> {
+        // KNOWN LIMITATION (issue #2421): this phase still reads recipe-runner-rs
+        // DEFAULT `text` stdout (the summary banner), so `parse_action_from_text`
+        // always sees `Recipe:` and silently defaults to `AdvanceGoal`. It shares
+        // the exact root cause fixed for the lifecycle phase in issue #2419 but is
+        // deferred there to bound the behavioral blast radius (top-level action
+        // routing). Tracked + to be fixed via `--output-format json` + envelope
+        // extraction in #2421.
         let output = Command::new("recipe-runner-rs")
             .arg(self.recipe_path.as_os_str())
             .env("AMPLIHACK_AGENT_BINARY", self.agent_binary)
@@ -141,6 +267,12 @@ impl OodaDecideBrain for RecipeBrain {
 
 impl OodaOrientBrain for RecipeBrain {
     fn judge_orientation(&self, ctx: &OrientContext) -> SimardResult<OrientJudgment> {
+        // KNOWN LIMITATION (issue #2421): like `judge_decision` above, this reads
+        // recipe-runner-rs DEFAULT `text` stdout. Worse than a benign default —
+        // `parse_orient_from_text` scans the banner for the first decimal in
+        // [0, base_urgency] and the banner's timing string (e.g. `(0.0s)`) yields
+        // `0.0`, silently demoting urgency to a scraped timing value rather than
+        // the LLM's judgment. Same #2419 root cause; fix tracked in #2421.
         let output = Command::new("recipe-runner-rs")
             .arg(self.recipe_path.as_os_str())
             .env("AMPLIHACK_AGENT_BINARY", self.agent_binary)
@@ -203,6 +335,10 @@ impl OodaBrain for RecipeBrain {
 
         let output = Command::new("recipe-runner-rs")
             .arg(self.recipe_path.as_os_str())
+            // issue #2419: text mode prints only a summary banner to stdout —
+            // the agent decision text is only exposed via the JSON envelope.
+            .arg("--output-format")
+            .arg("json")
             .env("AMPLIHACK_AGENT_BINARY", self.agent_binary)
             .arg("-c")
             .arg(format!(
@@ -249,14 +385,34 @@ impl OodaBrain for RecipeBrain {
             ))
             .arg("-c")
             .arg(format!("minutes_since_last_update_attempt={minutes}"))
-            .output()
-            .map_err(|e| SimardError::AdapterInvocationFailed {
-                base_type: self.adapter_tag.to_string(),
-                reason: format!("recipe-runner-rs spawn failed: {e}"),
-            })?;
+            .output();
+
+        let output = match output {
+            Ok(o) => o,
+            Err(e) => {
+                record_lifecycle_decision_metric(
+                    ctx,
+                    LifecycleParseOutcome::Error,
+                    "",
+                    "none",
+                    "spawn_failed",
+                );
+                return Err(SimardError::AdapterInvocationFailed {
+                    base_type: self.adapter_tag.to_string(),
+                    reason: format!("recipe-runner-rs spawn failed: {e}"),
+                });
+            }
+        };
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
+            record_lifecycle_decision_metric(
+                ctx,
+                LifecycleParseOutcome::Error,
+                "",
+                "none",
+                "nonzero_exit",
+            );
             return Err(SimardError::AdapterInvocationFailed {
                 base_type: self.adapter_tag.to_string(),
                 reason: format!(
@@ -267,9 +423,29 @@ impl OodaBrain for RecipeBrain {
             });
         }
 
-        let raw = String::from_utf8(output.stdout)
-            .unwrap_or_else(|e| String::from_utf8_lossy(e.as_bytes()).into_owned());
-        Ok(parse_lifecycle_from_text(&raw))
+        let raw = match extract_recipe_decision_output(&output.stdout, self.adapter_tag) {
+            Ok(s) => s,
+            Err(e) => {
+                record_lifecycle_decision_metric(
+                    ctx,
+                    LifecycleParseOutcome::Error,
+                    "",
+                    "none",
+                    "envelope_decode_failed",
+                );
+                return Err(e);
+            }
+        };
+
+        let (decision, outcome) = parse_lifecycle_outcome(&raw);
+        record_lifecycle_decision_metric(
+            ctx,
+            outcome,
+            &lifecycle_first_word(&raw),
+            lifecycle_decision_choice(&decision),
+            "ok",
+        );
+        Ok(decision)
     }
 }
 
@@ -398,46 +574,72 @@ fn deterministic_floor(base_urgency: f64, failure_count: u32) -> OrientJudgment 
 
 /// Parse recipe output for a lifecycle decision variant as the first word.
 /// Case-insensitive match. Defaults to `ContinueSkipping`.
+///
+/// Thin decision-only wrapper over [`parse_lifecycle_outcome`]. Retained as
+/// the documented parser entry point used by the operator replay runbook
+/// (`docs/howto/diagnose-brain-decision-parse-failures.md`, Step 3) and the
+/// `parse_*_from_text` reference trio. Production now routes through
+/// [`parse_lifecycle_outcome`] to capture the parse outcome for the
+/// `brain_lifecycle_decision` metric, so in non-test builds this wrapper has
+/// no internal caller.
+#[cfg_attr(not(test), allow(dead_code))]
 pub fn parse_lifecycle_from_text(text: &str) -> EngineerLifecycleDecision {
+    parse_lifecycle_outcome(text).0
+}
+
+/// Parse recipe output into a lifecycle decision AND a
+/// [`LifecycleParseOutcome`] classification.
+///
+/// The outcome distinguishes a genuinely parsed decision (`Parsed`) from the
+/// two distinct ways the parser falls back to `ContinueSkipping`:
+/// `DefaultEmpty` (no text at all) and `DefaultMalformed` (text present but
+/// the first word is not a known variant). This is what makes the
+/// parse-failure rate measurable per issue #2419 — before this split, a real
+/// `continue_skipping` decision and a silent fallback were indistinguishable.
+pub fn parse_lifecycle_outcome(text: &str) -> (EngineerLifecycleDecision, LifecycleParseOutcome) {
     let trimmed = text.trim();
     if trimmed.is_empty() {
-        return default_continue_skipping();
+        return (
+            default_continue_skipping(),
+            LifecycleParseOutcome::DefaultEmpty,
+        );
     }
     let first_word = trimmed.split_whitespace().next().unwrap_or("");
+    let rest = || truncate(trimmed[first_word.len()..].trim(), MAX_RATIONALE_CHARS);
 
     // Use eq_ignore_ascii_case instead of to_ascii_lowercase() — avoids a
     // heap-allocated String on every call.
-    if first_word.eq_ignore_ascii_case("continue_skipping") {
-        let rest = truncate(trimmed[first_word.len()..].trim(), MAX_RATIONALE_CHARS);
-        EngineerLifecycleDecision::ContinueSkipping { rationale: rest }
+    let decision = if first_word.eq_ignore_ascii_case("continue_skipping") {
+        EngineerLifecycleDecision::ContinueSkipping { rationale: rest() }
     } else if first_word.eq_ignore_ascii_case("deprioritize") {
-        let rest = truncate(trimmed[first_word.len()..].trim(), MAX_RATIONALE_CHARS);
-        EngineerLifecycleDecision::Deprioritize { rationale: rest }
+        EngineerLifecycleDecision::Deprioritize { rationale: rest() }
     } else if first_word.eq_ignore_ascii_case("consider_self_update") {
-        let rest = truncate(trimmed[first_word.len()..].trim(), MAX_RATIONALE_CHARS);
-        EngineerLifecycleDecision::ConsiderSelfUpdate { rationale: rest }
+        EngineerLifecycleDecision::ConsiderSelfUpdate { rationale: rest() }
     } else if first_word.eq_ignore_ascii_case("reclaim_and_redispatch") {
-        let rest = truncate(trimmed[first_word.len()..].trim(), MAX_RATIONALE_CHARS);
         EngineerLifecycleDecision::ReclaimAndRedispatch {
-            rationale: rest,
+            rationale: rest(),
             redispatch_context: String::new(),
         }
     } else if first_word.eq_ignore_ascii_case("open_tracking_issue") {
-        let rest = truncate(trimmed[first_word.len()..].trim(), MAX_RATIONALE_CHARS);
+        let rest = rest();
         EngineerLifecycleDecision::OpenTrackingIssue {
             title: "OODA stuck".to_string(),
             body: rest.clone(),
             rationale: rest,
         }
     } else if first_word.eq_ignore_ascii_case("mark_goal_blocked") {
-        let rest = truncate(trimmed[first_word.len()..].trim(), MAX_RATIONALE_CHARS);
+        let rest = rest();
         EngineerLifecycleDecision::MarkGoalBlocked {
             reason: rest.clone(),
             rationale: rest,
         }
     } else {
-        default_continue_skipping()
-    }
+        return (
+            default_continue_skipping(),
+            LifecycleParseOutcome::DefaultMalformed,
+        );
+    };
+    (decision, LifecycleParseOutcome::Parsed)
 }
 
 fn default_continue_skipping() -> EngineerLifecycleDecision {
@@ -445,6 +647,82 @@ fn default_continue_skipping() -> EngineerLifecycleDecision {
         rationale: format!(
             "{LIFECYCLE_ADAPTER_TAG}: no decision keyword found in recipe output; defaulting to continue_skipping"
         ),
+    }
+}
+
+/// The first whitespace-delimited token of `text`, bounded for metric storage.
+fn lifecycle_first_word(text: &str) -> String {
+    truncate(
+        text.split_whitespace().next().unwrap_or(""),
+        METRIC_FIRST_WORD_CHARS,
+    )
+}
+
+/// The snake_case `choice` tag of a decision, matching the
+/// `EngineerLifecycleDecision` serde representation. Used as the `decision`
+/// field of the metric context.
+fn lifecycle_decision_choice(decision: &EngineerLifecycleDecision) -> &'static str {
+    match decision {
+        EngineerLifecycleDecision::ContinueSkipping { .. } => "continue_skipping",
+        EngineerLifecycleDecision::ReclaimAndRedispatch { .. } => "reclaim_and_redispatch",
+        EngineerLifecycleDecision::Deprioritize { .. } => "deprioritize",
+        EngineerLifecycleDecision::OpenTrackingIssue { .. } => "open_tracking_issue",
+        EngineerLifecycleDecision::MarkGoalBlocked { .. } => "mark_goal_blocked",
+        EngineerLifecycleDecision::ConsiderSelfUpdate { .. } => "consider_self_update",
+    }
+}
+
+/// Build the JSON `context` payload for the `brain_lifecycle_decision` metric.
+///
+/// Separated from the I/O so the payload shape can be unit-tested without
+/// touching the real `metrics.jsonl`.
+fn build_lifecycle_metric_context(
+    ctx: &EngineerLifecycleCtx,
+    outcome: LifecycleParseOutcome,
+    first_word: &str,
+    decision_choice: &str,
+    cause: &str,
+) -> String {
+    serde_json::json!({
+        "goal_id": ctx.goal_id,
+        "outcome": outcome.label(),
+        "is_parse_failure": outcome.is_parse_failure(),
+        "first_word": first_word,
+        "consecutive_skip_count": ctx.consecutive_skip_count,
+        "decision": decision_choice,
+        "cause": cause,
+    })
+    .to_string()
+}
+
+/// Record one `brain_lifecycle_decision` metric event (value `1.0`) per
+/// `decide_engineer_lifecycle` invocation so the parse-failure rate
+/// (`outcome != "parsed"`) is measurable from `metrics.jsonl` (issue #2419).
+///
+/// Best-effort: a metrics-write failure is logged, never propagated — the
+/// brain decision must not fail because telemetry could not be persisted.
+///
+/// No-op under `cfg!(test)` so unit tests never append to the operator's real
+/// `~/.simard/metrics/metrics.jsonl` (which would corrupt the very
+/// before/after measurement this metric exists to capture).
+fn record_lifecycle_decision_metric(
+    ctx: &EngineerLifecycleCtx,
+    outcome: LifecycleParseOutcome,
+    first_word: &str,
+    decision_choice: &str,
+    cause: &str,
+) {
+    let context = build_lifecycle_metric_context(ctx, outcome, first_word, decision_choice, cause);
+    if cfg!(test) {
+        return;
+    }
+    if let Err(e) = crate::self_metrics::record_metric(LIFECYCLE_DECISION_METRIC, 1.0, &context) {
+        tracing::warn!(
+            target: "simard::ooda_brain",
+            error = %e,
+            outcome = outcome.label(),
+            "failed to record brain_lifecycle_decision metric (decision unaffected)",
+        );
     }
 }
 
@@ -1841,6 +2119,253 @@ mod tests {
                 minutes.to_string()
             };
             assert_eq!(rendered, "42");
+        }
+    }
+
+    // ===================================================================
+    // Issue #2419 — outcome classification, JSON envelope extraction, and
+    // the brain_lifecycle_decision metric context.
+    // ===================================================================
+
+    mod issue_2419_tests {
+        use super::super::*;
+        use crate::ooda_brain::EngineerLifecycleCtx;
+        use std::path::PathBuf;
+
+        fn sample_ctx() -> EngineerLifecycleCtx {
+            EngineerLifecycleCtx {
+                goal_id: "fix-the-thing".into(),
+                goal_description: "desc".into(),
+                cycle_number: 7,
+                consecutive_skip_count: 12,
+                failure_count: 0,
+                worktree_path: PathBuf::from("/tmp/wt"),
+                worktree_mtime_secs_ago: 60,
+                sentinel_pid: Some(42),
+                last_engineer_log_tail: "tail".into(),
+                commits_behind: 0,
+                in_flight_engineer_count: 1,
+                minutes_since_last_update_attempt: u64::MAX,
+            }
+        }
+
+        // --- Outcome branch 1: parsed (happy-path keyword extraction) ---
+
+        #[test]
+        fn outcome_parsed_real_decision() {
+            let (decision, outcome) =
+                parse_lifecycle_outcome("reclaim_and_redispatch worktree idle 7h, log truncated");
+            assert_eq!(outcome, LifecycleParseOutcome::Parsed);
+            assert!(!outcome.is_parse_failure());
+            assert_eq!(outcome.label(), "parsed");
+            match decision {
+                EngineerLifecycleDecision::ReclaimAndRedispatch { rationale, .. } => {
+                    assert!(rationale.contains("idle"));
+                }
+                other => panic!("expected ReclaimAndRedispatch, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn outcome_parsed_for_every_variant() {
+            let cases = [
+                ("continue_skipping healthy", "continue_skipping"),
+                ("reclaim_and_redispatch wedged", "reclaim_and_redispatch"),
+                ("deprioritize stale", "deprioritize"),
+                ("open_tracking_issue panic", "open_tracking_issue"),
+                ("mark_goal_blocked no key", "mark_goal_blocked"),
+                ("consider_self_update behind", "consider_self_update"),
+            ];
+            for (text, choice) in cases {
+                let (decision, outcome) = parse_lifecycle_outcome(text);
+                assert_eq!(
+                    outcome,
+                    LifecycleParseOutcome::Parsed,
+                    "'{text}' must classify as parsed"
+                );
+                assert_eq!(lifecycle_decision_choice(&decision), choice);
+            }
+        }
+
+        // --- Outcome branch 2: default_empty ---
+
+        #[test]
+        fn outcome_default_empty_for_empty_string() {
+            let (decision, outcome) = parse_lifecycle_outcome("");
+            assert_eq!(outcome, LifecycleParseOutcome::DefaultEmpty);
+            assert!(outcome.is_parse_failure());
+            assert_eq!(outcome.label(), "default_empty");
+            assert!(matches!(
+                decision,
+                EngineerLifecycleDecision::ContinueSkipping { .. }
+            ));
+        }
+
+        #[test]
+        fn outcome_default_empty_for_whitespace_only() {
+            let (_, outcome) = parse_lifecycle_outcome("   \n\t  ");
+            assert_eq!(outcome, LifecycleParseOutcome::DefaultEmpty);
+        }
+
+        // --- Outcome branch 3: default_malformed ---
+
+        #[test]
+        fn outcome_default_malformed_for_unknown_first_word() {
+            let (decision, outcome) = parse_lifecycle_outcome("OK the engineer looks fine to me");
+            assert_eq!(outcome, LifecycleParseOutcome::DefaultMalformed);
+            assert!(outcome.is_parse_failure());
+            assert_eq!(outcome.label(), "default_malformed");
+            assert!(matches!(
+                decision,
+                EngineerLifecycleDecision::ContinueSkipping { .. }
+            ));
+        }
+
+        #[test]
+        fn outcome_default_malformed_for_text_mode_banner_regression() {
+            // This is the EXACT shape recipe-runner-rs emits to stdout in its
+            // default `text` mode. Before issue #2419 the brain parsed this
+            // banner directly, so the first word was always "Recipe:" → every
+            // decision silently defaulted. This regression test pins that the
+            // banner classifies as a parse failure (so the metric counts it),
+            // and the JSON-envelope fix below proves the real decision is
+            // recovered instead.
+            let banner = "Recipe: ooda-engineer-lifecycle (v1.0.0)\nSteps: 1\n\n\
+                          Recipe 'ooda-engineer-lifecycle': SUCCESS (0.0s)\n  \
+                          [completed] engineer-lifecycle-decision (0.0s)\n";
+            let (decision, outcome) = parse_lifecycle_outcome(banner);
+            assert_eq!(outcome, LifecycleParseOutcome::DefaultMalformed);
+            assert_eq!(lifecycle_first_word(banner), "Recipe:");
+            assert!(matches!(
+                decision,
+                EngineerLifecycleDecision::ContinueSkipping { .. }
+            ));
+        }
+
+        // --- Outcome branch 4: error (label + numerator semantics) ---
+
+        #[test]
+        fn outcome_error_label_and_failure_semantics() {
+            assert_eq!(LifecycleParseOutcome::Error.label(), "error");
+            assert!(LifecycleParseOutcome::Error.is_parse_failure());
+        }
+
+        // --- JSON envelope extraction (the root-cause fix) ---
+
+        #[test]
+        fn envelope_extraction_recovers_real_decision() {
+            // A realistic --output-format json envelope. The decision text the
+            // banner hid is in step_results[].output; extracting it and parsing
+            // yields a real (non-default) decision.
+            let json = r#"{
+                "recipe_name": "ooda-engineer-lifecycle",
+                "success": true,
+                "step_results": [
+                    {"step_id": "engineer-lifecycle-decision",
+                     "output": "reclaim_and_redispatch worktree idle 7h",
+                     "error": "", "duration": 0.01}
+                ],
+                "context": {"lifecycle_result": "reclaim_and_redispatch worktree idle 7h"}
+            }"#;
+            let extracted =
+                extract_recipe_decision_output(json.as_bytes(), LIFECYCLE_ADAPTER_TAG).unwrap();
+            assert_eq!(extracted, "reclaim_and_redispatch worktree idle 7h");
+            let (_, outcome) = parse_lifecycle_outcome(&extracted);
+            assert_eq!(
+                outcome,
+                LifecycleParseOutcome::Parsed,
+                "the JSON-envelope fix must recover a parseable decision"
+            );
+        }
+
+        #[test]
+        fn envelope_extraction_uses_final_step() {
+            // Multi-step recipe: the decision is the terminal step's output.
+            let json = r#"{
+                "success": true,
+                "step_results": [
+                    {"step_id": "pre", "output": "prelude noise", "error": "", "duration": 0.0},
+                    {"step_id": "decide", "output": "deprioritize stale goal", "error": "", "duration": 0.0}
+                ]
+            }"#;
+            let extracted =
+                extract_recipe_decision_output(json.as_bytes(), LIFECYCLE_ADAPTER_TAG).unwrap();
+            assert_eq!(extracted, "deprioritize stale goal");
+        }
+
+        #[test]
+        fn envelope_extraction_errors_on_success_false() {
+            let json = r#"{"success": false, "step_results": []}"#;
+            let err =
+                extract_recipe_decision_output(json.as_bytes(), LIFECYCLE_ADAPTER_TAG).unwrap_err();
+            assert!(matches!(err, SimardError::AdapterInvocationFailed { .. }));
+        }
+
+        #[test]
+        fn envelope_extraction_errors_on_empty_step_results() {
+            let json = r#"{"success": true, "step_results": []}"#;
+            let err =
+                extract_recipe_decision_output(json.as_bytes(), LIFECYCLE_ADAPTER_TAG).unwrap_err();
+            assert!(matches!(err, SimardError::AdapterInvocationFailed { .. }));
+        }
+
+        #[test]
+        fn envelope_extraction_errors_on_garbage() {
+            // The text-mode banner is NOT valid JSON — decoding must fail
+            // loudly (error outcome) rather than be mistaken for empty output.
+            let banner = b"Recipe: x\nSUCCESS\n";
+            let err = extract_recipe_decision_output(banner, LIFECYCLE_ADAPTER_TAG).unwrap_err();
+            assert!(matches!(err, SimardError::AdapterInvocationFailed { .. }));
+        }
+
+        // --- Metric context payload ---
+
+        #[test]
+        fn metric_context_has_required_fields() {
+            let ctx = sample_ctx();
+            let payload = build_lifecycle_metric_context(
+                &ctx,
+                LifecycleParseOutcome::Parsed,
+                "reclaim_and_redispatch",
+                "reclaim_and_redispatch",
+                "ok",
+            );
+            let v: serde_json::Value = serde_json::from_str(&payload).unwrap();
+            assert_eq!(v["goal_id"], "fix-the-thing");
+            assert_eq!(v["outcome"], "parsed");
+            assert_eq!(v["is_parse_failure"], false);
+            assert_eq!(v["first_word"], "reclaim_and_redispatch");
+            assert_eq!(v["consecutive_skip_count"], 12);
+            assert_eq!(v["decision"], "reclaim_and_redispatch");
+            assert_eq!(v["cause"], "ok");
+        }
+
+        #[test]
+        fn metric_context_marks_failures() {
+            let ctx = sample_ctx();
+            for outcome in [
+                LifecycleParseOutcome::DefaultEmpty,
+                LifecycleParseOutcome::DefaultMalformed,
+                LifecycleParseOutcome::Error,
+            ] {
+                let payload =
+                    build_lifecycle_metric_context(&ctx, outcome, "", "continue_skipping", "ok");
+                let v: serde_json::Value = serde_json::from_str(&payload).unwrap();
+                assert_eq!(v["outcome"], outcome.label());
+                assert_eq!(
+                    v["is_parse_failure"],
+                    true,
+                    "{} must count toward the parse-failure numerator",
+                    outcome.label()
+                );
+            }
+        }
+
+        #[test]
+        fn first_word_is_bounded() {
+            let huge = format!("{} rest of response", "z".repeat(500));
+            let fw = lifecycle_first_word(&huge);
+            assert!(fw.chars().count() <= METRIC_FIRST_WORD_CHARS + 1);
         }
     }
 }

--- a/src/self_metrics/mod.rs
+++ b/src/self_metrics/mod.rs
@@ -49,8 +49,19 @@ pub fn record_metric(
     fs::create_dir_all(&dir)?;
     let path = metrics_file_path();
     let mut file = OpenOptions::new().create(true).append(true).open(&path)?;
-    let line = serde_json::to_string(&entry)?;
-    writeln!(file, "{line}")?;
+    let mut line = serde_json::to_string(&entry)?;
+    line.push('\n');
+    // Write the whole record (body + newline) in a single `write_all` so it is
+    // ONE `O_APPEND` `write()` syscall, not the two that `writeln!` on an
+    // unbuffered file emits (the JSON body, then "\n"). Engineer subprocesses
+    // share `$HOME` and append to this file concurrently; a two-syscall write
+    // lets records interleave into glued/blank lines, which the line-by-line
+    // readers (`query_metrics`/`recent_metrics`/`daily_report`) then silently
+    // `continue` past — dropping records. Records are well under `PIPE_BUF`, so
+    // a single append write is atomic. Newly consequential now that
+    // `brain_lifecycle_decision` is emitted per decision per in-flight engineer
+    // (issue #2419), making this the dominant writer to `metrics.jsonl`.
+    file.write_all(line.as_bytes())?;
     Ok(())
 }
 

--- a/src/self_metrics/tests.rs
+++ b/src/self_metrics/tests.rs
@@ -55,6 +55,61 @@ fn record_and_query_metric() {
     });
 }
 
+/// Regression test (issue #2419): concurrent `record_metric` appends from many
+/// threads must not corrupt or drop records. Before the single-`write_all`
+/// fix, `writeln!` on the unbuffered `O_APPEND` file emitted two `write()`
+/// syscalls per record (body, then newline), so concurrent writers interleaved
+/// into glued/blank lines that the line-by-line readers silently dropped —
+/// undercutting the `brain_lifecycle_decision` parse-failure measurement this
+/// metric exists to provide. With the fix, every record is one atomic append.
+#[test]
+#[serial]
+fn concurrent_record_metric_no_corruption_or_loss() {
+    with_temp_home(|| {
+        const THREADS: usize = 8;
+        const PER_THREAD: usize = 250;
+
+        let mut handles = Vec::with_capacity(THREADS);
+        for t in 0..THREADS {
+            handles.push(std::thread::spawn(move || {
+                for i in 0..PER_THREAD {
+                    // Non-trivial context (stringified JSON) mirrors the real
+                    // brain_lifecycle_decision payload shape and width.
+                    let ctx = format!(
+                        r#"{{"thread":{t},"seq":{i},"outcome":"parsed","goal_id":"g-{t}-{i}"}}"#
+                    );
+                    record_metric("brain_lifecycle_decision", 1.0, &ctx).unwrap();
+                }
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        // Every record must be present and parseable — no glued/dropped lines.
+        let entries = query_metrics("brain_lifecycle_decision", None).unwrap();
+        assert_eq!(
+            entries.len(),
+            THREADS * PER_THREAD,
+            "all concurrent records must survive intact (no corruption/loss)"
+        );
+
+        // The raw file must contain no blank/glued lines either: every
+        // non-empty line parses as exactly one MetricEntry.
+        let raw = fs::read_to_string(metrics_file_path()).unwrap();
+        let mut clean = 0usize;
+        for line in raw.lines() {
+            if line.trim().is_empty() {
+                panic!("found a blank line — indicates an interleaved append");
+            }
+            serde_json::from_str::<MetricEntry>(line)
+                .expect("every line must be a single well-formed MetricEntry");
+            clean += 1;
+        }
+        assert_eq!(clean, THREADS * PER_THREAD);
+    });
+}
+
 #[test]
 #[serial(cognitive_memory)]
 fn query_metrics_with_since_filter() {

--- a/src/self_metrics/tests.rs
+++ b/src/self_metrics/tests.rs
@@ -62,8 +62,15 @@ fn record_and_query_metric() {
 /// into glued/blank lines that the line-by-line readers silently dropped —
 /// undercutting the `brain_lifecycle_decision` parse-failure measurement this
 /// metric exists to provide. With the fix, every record is one atomic append.
+///
+/// Uses the `cognitive_memory` serial key (not a bare `#[serial]`): this test
+/// mutates `HOME` via `with_temp_home`, so it must share the same lock as every
+/// other `HOME`/state-root test to keep env writes off-limits during concurrent
+/// env reads (see `test_support::serial_guard`). A bare `#[serial]` would run on
+/// a *different* lock, letting this test's 2000 appends race other tests' temp
+/// `HOME` and pollute their metrics files.
 #[test]
-#[serial]
+#[serial(cognitive_memory)]
 fn concurrent_record_metric_no_corruption_or_loss() {
     with_temp_home(|| {
         const THREADS: usize = 8;

--- a/tests/gadugi/lifecycle-brain-decision.sh
+++ b/tests/gadugi/lifecycle-brain-decision.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Outside-in scenario for issue #2419 — the engineer-lifecycle brain
+# decision-keyword parse failure.
+#
+# Root cause: RecipeBrain::decide_engineer_lifecycle invoked recipe-runner-rs
+# in its DEFAULT `text` output mode, which prints only a summary banner
+# ("Recipe: <name> ... SUCCESS ...") to stdout. The agent's actual decision
+# text is NOT on stdout in text mode — it is only exposed via
+# `--output-format json` (step_results[].output). First-word extraction over
+# the banner therefore always saw "Recipe:", matched no lifecycle variant, and
+# silently defaulted to continue_skipping on ~99.6% of invocations.
+#
+# This scenario validates the contract at the recipe-runner boundary WITHOUT
+# an LLM: a deterministic bash-step recipe emits a known decision keyword, and
+# we assert that
+#   (a) text mode hides it behind the banner (the bug), and
+#   (b) json mode exposes it as the final step output (the fix), whose first
+#       word IS a real lifecycle variant.
+#
+# It also exercises the in-tree Rust parser/metric path via `cargo test` so the
+# four metric outcomes (parsed | default_empty | default_malformed | error)
+# and the happy-path keyword extraction are validated end-to-end.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+if ! command -v recipe-runner-rs >/dev/null 2>&1; then
+  echo "SKIP: recipe-runner-rs not on PATH (required for this scenario)" >&2
+  exit 0
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "SKIP: jq not on PATH (required for this scenario)" >&2
+  exit 0
+fi
+
+WORK="$(mktemp -d /tmp/simard-lifecycle-brain-2419.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+
+RECIPE="$WORK/lifecycle-fixture.yaml"
+DECISION="reclaim_and_redispatch worktree idle 7h, log truncated mid-tool-call"
+
+cat > "$RECIPE" <<EOF
+name: "lifecycle-fixture-2419"
+description: "deterministic lifecycle decision fixture (no LLM)"
+version: "1.0.0"
+context: {}
+steps:
+  - id: "engineer-lifecycle-decision"
+    type: "bash"
+    command: |
+      echo '${DECISION}'
+    output: "lifecycle_result"
+EOF
+
+# --- (a) text mode reproduces the bug: first word is the banner, not a variant
+TEXT_OUT="$(recipe-runner-rs "$RECIPE" 2>/dev/null)"
+printf '%s\n' "$TEXT_OUT"
+TEXT_FIRST_WORD="$(printf '%s\n' "$TEXT_OUT" | awk 'NF{print $1; exit}')"
+echo "text-mode first word: ${TEXT_FIRST_WORD}"
+if [ "$TEXT_FIRST_WORD" = "reclaim_and_redispatch" ]; then
+  echo "FAIL: text mode unexpectedly exposed the decision as the first word" >&2
+  exit 1
+fi
+# The banner's first token is "Recipe:" — proving raw stdout is unparseable.
+printf '%s\n' "$TEXT_OUT" | grep -qE '^Recipe:' \
+  || { echo "FAIL: expected a 'Recipe:' summary banner in text mode" >&2; exit 1; }
+
+# --- (b) json mode exposes the real decision as the final step output (the fix)
+JSON_OUT="$(recipe-runner-rs "$RECIPE" --output-format json 2>/dev/null)"
+printf '%s' "$JSON_OUT" | jq -e '.success == true' >/dev/null \
+  || { echo "FAIL: recipe did not report success in json mode" >&2; exit 1; }
+
+STEP_OUTPUT="$(printf '%s' "$JSON_OUT" | jq -r '.step_results | last | .output')"
+echo "json-mode final step output: ${STEP_OUTPUT}"
+JSON_FIRST_WORD="$(printf '%s\n' "$STEP_OUTPUT" | awk 'NF{print $1; exit}')"
+echo "json-mode first word: ${JSON_FIRST_WORD}"
+[ "$JSON_FIRST_WORD" = "reclaim_and_redispatch" ] \
+  || { echo "FAIL: json-mode first word is not the expected lifecycle variant" >&2; exit 1; }
+
+# Also assert the captured context var equals the step output (recipe contract).
+CTX_VAL="$(printf '%s' "$JSON_OUT" | jq -r '.context.lifecycle_result')"
+[ "$CTX_VAL" = "$DECISION" ] \
+  || { echo "FAIL: context.lifecycle_result did not match emitted decision" >&2; exit 1; }
+
+echo "OK: text mode hides the decision behind the banner; json mode exposes it."
+
+# --- (c) in-tree Rust parser + metric outcome coverage (the four branches)
+echo "Running in-tree parser/metric unit tests (issue_2419_tests)..."
+cargo test --lib --locked issue_2419_tests -- --nocapture >/dev/null
+echo "OK: parser outcome classification + metric context tests pass."
+
+echo "PASS: lifecycle-brain-decision scenario (issue #2419)"

--- a/tests/gadugi/lifecycle-brain-decision.yaml
+++ b/tests/gadugi/lifecycle-brain-decision.yaml
@@ -1,0 +1,55 @@
+name: "Engineer Lifecycle Brain Decision Parse (issue #2419)"
+description: "Outside-in proof that the engineer-lifecycle brain recovers real decisions from recipe-runner-rs JSON output instead of silently defaulting to continue_skipping. Reproduces the text-mode banner bug and validates the json-mode fix at the recipe-runner boundary (no LLM), then runs the in-tree parser/metric outcome tests."
+version: "1.0.0"
+
+config:
+  timeout: 300000
+  retries: 1
+  parallel: false
+
+environment:
+  requires: []
+
+agents:
+  - name: "cli-agent"
+    type: "cli"
+    config:
+      workingDirectory: "."
+      defaultTimeout: 300000
+      executionMode: "spawn"
+      captureOutput: true
+      ioConfig:
+        encoding: "utf8"
+        handleInteractivePrompts: false
+      logConfig:
+        logCommands: true
+        logOutput: true
+        logLevel: "info"
+
+steps:
+  - name: "Lifecycle brain decision: text-mode bug vs json-mode fix + parser/metric outcomes"
+    agent: "cli-agent"
+    action: "execute_command"
+    params:
+      command: "tests/gadugi/lifecycle-brain-decision.sh"
+    timeout: 300000
+
+assertions: []
+
+cleanup:
+  - name: "CLI agent cleanup"
+    agent: "cli-agent"
+    action: "cleanup"
+
+metadata:
+  tags:
+    - "cli"
+    - "behavior"
+    - "simard"
+    - "ooda"
+    - "engineer-lifecycle"
+    - "recipe-brain"
+    - "issue-2419"
+  priority: "high"
+  author: "copilot"
+  test_type: "outside-in"


### PR DESCRIPTION
Closes #2419

> ## 🔄 Update (rebase onto main + coverage fix — commit `64d6ff3b`)
>
> Rebased onto latest `origin/main` and fixed the one **real** CI failure. Net state below.
>
> **(a) Rebased onto `main` (incl. #2427 `lbug` link fix).** The earlier red `pre-commit` was the repo-wide `could not find native static library 'lbug'` link error while compiling the `lbug` *dependency* (issue #2423) — not this PR's code. That fix (#2427) is now on `main`, so the rebased branch links clean. Verified locally: `cargo clippy --release --no-deps -- -D warnings` ✓ and the full pre-push `cargo clippy --all-targets --all-features --locked -- -D warnings` ✓.
>
> **(b) Fixed the real `coverage` failure — a serial-key bug this PR introduced.** The new `concurrent_record_metric_no_corruption_or_loss` test mutates `HOME` (via `with_temp_home`) but carried a **bare `#[serial]`**, placing it on a *different* serial lock than every other `HOME`/state-root test. Its 2000 concurrent appends then raced other tests' temp `HOME`, polluting their metrics files — `collect_and_record_all_records_four_metrics` saw **2003** lines (expected 4), the concurrent test itself saw **2001** (expected 2000) — and tripped the `serial_guard::every_env_mutating_test_is_serialized` contract. Fix: share the `#[serial(cognitive_memory)]` key (the exact remedy the guard prints). After the fix:
> ```
> cargo test --lib self_metrics::            → 10 passed; 0 failed
> cargo test --lib -- serial_guard           → every_env_mutating_test_is_serialized ... ok
> ```
> (This corrects the original PR body's CI note, which had not yet diagnosed this failure.)
>
> **(c) The 5 `resolve_recipe_path`/`new_*` lib tests are host-only and pass on CI.** They fail *only* on this build host because it has a populated `~/.simard/prompt_assets/` (the hot-reload path resolves there). Re-run under an isolated `HOME` → **7 passed; 0 failed**. They are byte-identical to `main` and untouched by this diff. `cargo-audit` is now green on this commit (the earlier failure was a transient advisory-DB blip, unrelated to this diff).
>
> **(d) Duplicate reconciled.** #2424 (instrumentation-only, on another engineer's branch) was **closed as superseded** — it lacked the root-cause fix and its broader decide/orient instrumentation belongs with the deferred #2421 fix, not bolted onto this focused PR. Only #2422 lands for #2419.
>
> **(e) Fresh gadugi evidence (commit `64d6ff3b`).**
> ```
> gadugi-test validate -f tests/gadugi/lifecycle-brain-decision.yaml --strict  → ✓ Valid files: 1
> gadugi-test run -d tests/gadugi -s lifecycle-brain-decision                  → ✓ Passed: 1, Failed: 0 (exit 0, 37s)
> ```


## Problem

`RecipeBrain::decide_engineer_lifecycle` invoked `recipe-runner-rs` in its **default `text` output mode**. In text mode, recipe-runner-rs prints only a human summary banner to stdout — the agent's actual decision text is **not** on stdout; it is only exposed via `--output-format json` (the JSON envelope's `step_results[].output`):

```
Recipe: ooda-engineer-lifecycle (v1.0.0)
Steps: 1

Recipe 'ooda-engineer-lifecycle': SUCCESS (0.0s)
  [completed] engineer-lifecycle-decision (0.0s)
```

First-word extraction therefore always saw `Recipe:`, matched no lifecycle variant, and silently defaulted to `ContinueSkipping` on **~99.6% of invocations (493/495 measured in #2419)**. Non-default decisions (`reclaim_and_redispatch` / `deprioritize` / `open_tracking_issue` / `mark_goal_blocked` / `consider_self_update`) **never fired**, so stuck/looping engineers were never reclaimed.

## Root cause & fix

The fix mirrors the already-correct `src/disk_health.rs` path:

- `decide_engineer_lifecycle` now passes `--output-format json`, deserializes the envelope (`extract_recipe_decision_output`), takes the **final step's `output`**, and runs first-word extraction on the **real decision text**.

## Instrumentation (acceptance criterion)

Each invocation records one `brain_lifecycle_decision` metric (value `1.0`) via `self_metrics::record_metric`, with a context JSON carrying the numerator/denominator/cause:

| field | values |
|-------|--------|
| `outcome` | `parsed` \| `default_empty` \| `default_malformed` \| `error` |
| `is_parse_failure` | `true` for any `outcome != parsed` (the numerator) |
| `goal_id`, `first_word` (bounded), `consecutive_skip_count`, `decision`, `cause` | context |

Parse-failure rate = `count(is_parse_failure==true) / count(*)`. The metric write is a no-op under `cfg!(test)` so unit tests never pollute the real `~/.simard/metrics/metrics.jsonl` (which would corrupt this very measurement). `parse_lifecycle_outcome` is the new canonical parser returning `(decision, outcome)`; `parse_lifecycle_from_text` is the documented decision-only wrapper.

## Before / after parse-failure-rate measurement

Measured at the recipe-runner boundary (no LLM): for each of the 6 lifecycle variants, a deterministic fixture recipe emits `<variant> <rationale>`, and we compare the first word of the **old** path (raw text stdout) vs the **new** path (JSON-envelope step output):

```
variant                  BEFORE first_word   AFTER first_word
continue_skipping        Recipe:             continue_skipping
reclaim_and_redispatch   Recipe:             reclaim_and_redispatch
deprioritize             Recipe:             deprioritize
open_tracking_issue      Recipe:             open_tracking_issue
mark_goal_blocked        Recipe:             mark_goal_blocked
consider_self_update     Recipe:             consider_self_update
-----------------------------------------------------------------
BEFORE (raw text stdout): parse-failure rate = 6/6 = 100.0%
AFTER  (json envelope)  : parse-failure rate = 0/6 = 0%
```

This corroborates the production observation (493/495 ≈ 99.6%): the wire format guaranteed ~100% spurious default. After the fix, the only remaining `continue_skipping` outcomes are **genuine** model decisions (`outcome=parsed`), now distinguishable from failures via the metric.

## Tightly-coupled correctness fix (found in quality audit)

`self_metrics::record_metric` wrote each record with `writeln!` on an **unbuffered `O_APPEND` file = two `write()` syscalls** (body, then `\n`). Engineer subprocesses share `$HOME` and append to `metrics.jsonl` concurrently; a two-syscall write lets records interleave into glued/blank lines that the line-by-line readers silently drop — corrupting the very measurement this PR adds. Fixed to a single `write_all` (one atomic append; records are well under `PIPE_BUF`).

Empirically validated by a new regression test: against the old code **837/2000** concurrent records survived; with the fix **2000/2000**, zero corrupt/blank lines.

## Scope (decide/orient deferred → #2421)

The `decide` and `orient` brains share the identical text-vs-json root cause (and `orient` actively *corrupts* urgency by scraping `0.0` from the banner's `(0.0s)` timing). Changing them has a broader behavioral blast radius (top-level action routing + urgency scheduling) and warrants its own validation, so it is deferred and tracked in **#2421**, with `KNOWN LIMITATION (#2421)` code-comment references at both call sites. This keeps the diff focused on #2419.

---

## Merge-readiness evidence

**1. qa-team / gadugi scenarios** — New outside-in scenario `tests/gadugi/lifecycle-brain-decision.{yaml,sh}` proving (a) text mode hides the decision behind the banner and (b) json mode recovers it, plus the in-tree parser/metric outcome tests.
- `gadugi-test validate -f tests/gadugi/lifecycle-brain-decision.yaml --strict` → ✓ valid
- `gadugi-test run -d tests/gadugi -s lifecycle-brain-decision` → ✓ Passed: 1, Failed: 0

**2. Docs** — Updated `docs/reference/recipe-brain-api.md` (lifecycle method + `parse_lifecycle_outcome` + metric table), `docs/reference/text-parsing-wire-formats.md` (§1c JSON-envelope source), and `docs/howto/diagnose-brain-decision-parse-failures.md` (a `jq` recipe to measure the rate from `metrics.jsonl`). `mkdocs build --strict` → ✓.

**3. quality-audit (3 SEEK→VALIDATE→FIX cycles, clean final)** —
- Cycle 1 → finding: decide/orient share the bug → filed #2421 + code-comment refs.
- Cycle 2 → finding: non-atomic metric append → fixed (`write_all`) + concurrency regression test.
- Cycle 3 (final) → **zero** critical/high/medium correctness/security findings; verdict: clean & merge-ready.
- Security review → no vulnerabilities (serde input bounded, metric values serde-escaped, `sanitize_context_var` intact, gadugi script safe).

**4. CI** — Locally verified: `cargo fmt --all -- --check` ✓; `cargo clippy --all-targets --all-features --locked -- -D warnings` ✓; `cargo test --lib` for the touched modules (`ooda_brain::` 345 pass, `self_metrics::` 10 pass incl. the new concurrency test, `spawn`/related 70 pass) ✓. (5 `resolve_recipe_path`/`new_*` tests fail **only on this build host** because it has a populated `~/.simard/prompt_assets/`; they are byte-identical to `main`, untouched by this diff, and pass under an isolated `HOME` — i.e. they are green on a clean CI runner.) Full CI runs on this PR.

**6. Diff focused** — 8 files; production change is confined to `src/ooda_brain/recipe_brain.rs` (lifecycle method + parser/metric helpers) and the one-line `src/self_metrics/mod.rs` atomic-append fix; the rest is tests + docs + the gadugi scenario.

## Post-merge note

This changes the running OODA brain, so a **Simard self-update** (`simard safe-update`) is required after merge for the daemon to pick up the fix. Prompt assets are unchanged (the bug was in the Rust shim, not the prompt), so no prompt hot-reload is needed.

---

## ✅ CI (criterion 4) — all green on `64d6ff3b`

Check suite: https://github.com/rysweet/Simard/actions/runs/28295170892 — `build` ✓, `pre-commit` ✓ (×2), `coverage` ✓, `cargo-audit` ✓ (×2), `e2e-dashboard` ✓ (×2), `install-real` ✓ (×2), GitGuardian ✓. `mergeStateStatus=CLEAN`. The merge-readiness judge (run in JSON mode) returned `verdict: ready`. Landing was performed with `gh pr merge --squash` because `simard merge-pr` is currently blocked by a text-vs-json parse bug in the `recipe-merge-judge` brain (filed as #2430 — same root cause class as this PR).
