### PR TITLE
fix(ci): make pre-commit clippy --release link the lbug native static lib (#2426)

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -59,6 +59,12 @@ jobs:
           # across concurrent PRs.
           save-if: ${{ github.ref == 'refs/heads/main' }}
           cache-on-failure: true
+          # Persist the pre-commit clippy wrapper's stable lbug prebuilt so the
+          # version-pinned download happens once per cache lifetime instead of
+          # on every run (issue #2426). This dir lives outside registry/src on
+          # purpose, so it isn't otherwise covered by the cargo cache.
+          cache-directories: |
+            ~/.cache/simard-lbug-precommit
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -69,7 +75,47 @@ jobs:
         run: python -m pip install --upgrade pip pre-commit
 
       - name: Run pre-commit stage
-        run: python -m pre_commit run --all-files --show-diff-on-failure --hook-stage pre-commit
+        id: precommit_stage
+        # `--verbose` so the cargo-clippy-precommit hook's output (including the
+        # lbug native-lib resolution marker on stderr) is captured even on
+        # success, which the regression-guard step below asserts on. Tee'd to a
+        # log so the assertion runs without re-invoking the expensive release
+        # clippy.
+        run: |
+          set -o pipefail
+          mkdir -p target/ci-logs
+          python -m pre_commit run --all-files --show-diff-on-failure --verbose \
+            --hook-stage pre-commit 2>&1 | tee target/ci-logs/precommit-stage.log
+
+      - name: Assert pre-commit clippy compiled/linked lbug (regression guard #2426)
+        # Guards against silent reintroduction of issue #2426 (pre-commit clippy
+        # --release failing with "could not find native static library `lbug`").
+        # `if: always()` so the explicit #2426 annotation still fires when the
+        # pre-commit stage failed (a real regression fails that step first, which
+        # would otherwise skip this guard). Cheap: greps the captured log, no
+        # recompilation.
+        if: always()
+        run: |
+          outcome="${{ steps.precommit_stage.outcome }}"
+          if [ "$outcome" != "success" ] && [ "$outcome" != "failure" ]; then
+            echo "pre-commit stage did not run (outcome=$outcome); skipping #2426 guard"
+            exit 0
+          fi
+          log=target/ci-logs/precommit-stage.log
+          test -f "$log" || { echo "::error::missing pre-commit stage log"; exit 1; }
+          if grep -qiE "could not find native static library .?lbug" "$log"; then
+            echo "::error::REGRESSION (#2426): pre-commit clippy --release failed to link the lbug native static library"
+            exit 1
+          fi
+          if [ "$outcome" != "success" ]; then
+            echo "pre-commit stage failed for a non-lbug reason; see the failing hook above"
+            exit 0
+          fi
+          if ! grep -q "\[clippy-precommit-release\] SUCCESS: cargo clippy --release linked lbug" "$log"; then
+            echo "::error::pre-commit clippy --release did not report linking lbug; the lbug link-path wrapper may have regressed"
+            exit 1
+          fi
+          echo "OK: pre-commit clippy --release compiled and linked lbug (issue #2426 guard passed)"
 
       - name: Run cargo test (streamed, captured for artifact)
         id: cargo_test

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -66,6 +66,22 @@ jobs:
           cache-directories: |
             ~/.cache/simard-lbug-precommit
 
+      - name: Provision lbug native static library link path (#2426 / #2423)
+        # Pin the lbug native-static-lib path for every cargo invocation in this
+        # job. lbug 0.17.1 caches its prebuilt `liblbug.a` under registry/src,
+        # which this cache restores around but evicts — so the cached release
+        # build-script output points at a missing archive. Provision a stable
+        # copy, point lbug at it via its external-lib interface, and drop the
+        # stale cached lbug build outputs so the build script re-runs and adopts
+        # the pinned path. Runs after the cache restore on purpose.
+        shell: bash
+        run: |
+          lib_dir="$HOME/.cache/simard-lbug-precommit/lib"
+          scripts/provision-lbug-prebuilt.sh "$lib_dir" >/dev/null
+          echo "LBUG_LIBRARY_DIR=$lib_dir" >> "$GITHUB_ENV"
+          echo "LBUG_INCLUDE_DIR=$lib_dir" >> "$GITHUB_ENV"
+          rm -rf target/*/build/lbug-* target/*/.fingerprint/lbug-* 2>/dev/null || true
+
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
@@ -202,6 +218,21 @@ jobs:
           # the single writer to avoid cache contention.
           save-if: false
           cache-on-failure: true
+          cache-directories: |
+            ~/.cache/simard-lbug-precommit
+
+      - name: Provision lbug native static library link path (#2426 / #2423)
+        # `cargo test --test install_real` (and the `cargo install` it shells
+        # out to) build lbug in the release profile and hit the same evicted
+        # registry-src prebuilt as the pre-commit clippy gate. Pin the link path
+        # for the whole job so both link lbug deterministically.
+        shell: bash
+        run: |
+          lib_dir="$HOME/.cache/simard-lbug-precommit/lib"
+          scripts/provision-lbug-prebuilt.sh "$lib_dir" >/dev/null
+          echo "LBUG_LIBRARY_DIR=$lib_dir" >> "$GITHUB_ENV"
+          echo "LBUG_INCLUDE_DIR=$lib_dir" >> "$GITHUB_ENV"
+          rm -rf target/*/build/lbug-* target/*/.fingerprint/lbug-* 2>/dev/null || true
 
       - name: Run install verification (cargo install + --version + ensure-deps + self-install)
         env:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -223,9 +223,9 @@ jobs:
 
       - name: Provision lbug native static library link path (#2426 / #2423)
         # `cargo test --test install_real` (and the `cargo install` it shells
-        # out to) build lbug in the release profile and hit the same evicted
-        # registry-src prebuilt as the pre-commit clippy gate. Pin the link path
-        # for the whole job so both link lbug deterministically.
+        # out to) build lbug and hit the same evicted registry-src prebuilt as
+        # the pre-commit clippy gate. Pin the link path for the whole job so
+        # both link lbug deterministically, regardless of profile.
         shell: bash
         run: |
           lib_dir="$HOME/.cache/simard-lbug-precommit/lib"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,12 @@ repos:
 
       - id: cargo-clippy-precommit
         name: cargo clippy --release --no-deps -- -D warnings (pre-commit)
-        entry: cargo clippy --release --no-deps -- -D warnings
+        # Runs through a wrapper that guarantees the `lbug` native static lib is
+        # on the linker search path. CI's cargo cache evicts lbug's registry-src
+        # prebuilt while the cached release build-script output still references
+        # it, which otherwise reds `cargo clippy --release` on every Rust PR
+        # (issue #2426). The wrapper is a no-op for warm local checks.
+        entry: scripts/clippy-precommit-release.sh
         language: system
         pass_filenames: false
         always_run: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ a summary, not the source of truth.
 | Hook id | Stage(s) | Command |
 |---|---|---|
 | `cargo-fmt` | `pre-commit`, `pre-push`, `manual` | `cargo fmt --all -- --check` |
-| `cargo-clippy-precommit` | `pre-commit`, `manual` | `cargo clippy --release --no-deps -- -D warnings` |
+| `cargo-clippy-precommit` | `pre-commit`, `manual` | `cargo clippy --release --no-deps -- -D warnings` (via [`scripts/clippy-precommit-release.sh`](scripts/clippy-precommit-release.sh)) |
 | `cargo-clippy` | `pre-push`, `manual` | `cargo clippy --all-targets --all-features --locked -- -D warnings` |
 | `cargo-test-race-subset` | `pre-push`, `manual` | `cargo test --release --lib -- --test-threads=$(nproc) cognitive_memory bootstrap memory_ipc memory_consolidation` |
 
@@ -83,6 +83,19 @@ The two-tier clippy gate is intentional: the `--release --no-deps`
 hook gives instant feedback at commit time; the `--all-targets
 --all-features --locked` hook reuses the warm `target/` after the
 race-test compile and runs at push time, mirroring CI exactly.
+
+The `cargo-clippy-precommit` hook runs through a thin wrapper,
+[`scripts/clippy-precommit-release.sh`](scripts/clippy-precommit-release.sh),
+which guarantees the `lbug` (LadybugDB) native static library is on the linker
+search path before invoking `cargo clippy --release` (issue #2426). `lbug`
+0.17.1 caches its prebuilt `liblbug.a` inside the cargo *registry source*
+directory; CI's cargo cache persists `target/` but not `registry/src`, so on a
+cache restore the cached release build-script output points at an evicted
+archive and clippy fails with `could not find native static library `lbug``.
+The wrapper provisions a stable copy of `liblbug.a` (reusing an existing
+registry prebuilt, otherwise downloading the same release asset the `build` and
+`coverage` jobs use) and points `lbug` at it via `LBUG_LIBRARY_DIR`. It is a
+no-op for warm local checks, so the budgets below still hold.
 
 Realistic budgets (warm caches, dev host with the workspace already
 built):

--- a/scripts/clippy-precommit-release.sh
+++ b/scripts/clippy-precommit-release.sh
@@ -46,12 +46,9 @@
 set -euo pipefail
 
 log() { printf '[clippy-precommit-release] %s\n' "$*" >&2; }
-die() { log "ERROR: $*"; exit 1; }
 
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 cd "$REPO_ROOT"
-
-CARGO_HOME_DIR="${CARGO_HOME:-$HOME/.cargo}"
 
 # Resolve the cargo target directory (honours CARGO_TARGET_DIR, used by the
 # per-engineer worktree isolation that relocates target/ out of the worktree).
@@ -64,111 +61,10 @@ STABLE_LIB_FILE="$STABLE_LIB_DIR/liblbug.a"
 
 static_lib_name="liblbug.a"
 
-# lbug crate version (and matching LadybugDB native release tag) parsed from
-# Cargo.toml, so the prebuilt asset is fetched deterministically — no
-# unauthenticated `releases/latest` API call (rate-limited on shared CI egress
-# IPs) and no version skew with the crate we actually compile against.
-lbug_version() {
-  sed -nE 's/^lbug[[:space:]]*=[[:space:]]*"=?([0-9]+\.[0-9]+\.[0-9]+)".*/\1/p' \
-    "$REPO_ROOT/Cargo.toml" | head -n1
-}
-
-# Name of the prebuilt static archive for this OS/arch, mirroring lbug's own
-# scripts/download-liblbug.sh selection logic.
-prebuilt_asset_name() {
-  local os arch variant="${LBUG_LINUX_VARIANT:-compat}"
-  os="$(uname -s)"
-  arch="$(uname -m)"
-  case "$os" in
-    Linux)
-      case "$arch" in
-        x86_64) arch="x86_64" ;;
-        aarch64 | arm64) arch="aarch64" ;;
-        *) return 1 ;;
-      esac
-      printf 'liblbug-static-linux-%s-%s.tar.gz' "$arch" "$variant"
-      ;;
-    Darwin)
-      case "$arch" in
-        x86_64) arch="x86_64" ;;
-        arm64) arch="arm64" ;;
-        *) return 1 ;;
-      esac
-      printf 'liblbug-static-osx-%s.tar.gz' "$arch"
-      ;;
-    *) return 1 ;;
-  esac
-}
-
 # ── 1. Provision a stable liblbug.a (+ headers) ──────────────────────────────
-find_registry_prebuilt() {
-  # Echo the directory of an existing prebuilt liblbug.a in the cargo registry,
-  # if any (fast, offline path for developers who already built lbug once).
-  find "$CARGO_HOME_DIR/registry/src" \
-    -path "*/lbug-*/.cache/lbug-prebuilt/*/lib/$static_lib_name" \
-    2>/dev/null | head -n1
-}
-
-download_prebuilt() {
-  # Fetch the version-pinned LadybugDB release *asset* directly (a tarball, not
-  # an executable script) — the same static archive lbug's build script and the
-  # build/coverage jobs consume. Pinning the version avoids the
-  # `api.github.com/.../releases/latest` lookup and an unpinned `curl | bash`.
-  local version repo asset url
-  version="$(lbug_version || true)"
-  [ -n "$version" ] || die "could not determine lbug version from Cargo.toml"
-  asset="$(prebuilt_asset_name || true)"
-  [ -n "$asset" ] || die "unsupported OS/arch for prebuilt liblbug ($(uname -sm))"
-  repo="${LBUG_GITHUB_REPOSITORY:-LadybugDB/ladybug}"
-  url="https://github.com/$repo/releases/download/v$version/$asset"
-
-  mkdir -p "$STABLE_LIB_DIR"
-  # Download + extract in a temp dir, then place liblbug.a LAST so a partial
-  # download/extract never leaves a half-written archive (or a lib without its
-  # headers) that a later run would trust.
-  local tmp
-  tmp="$(mktemp -d "${TMPDIR:-/tmp}/simard-lbug-dl.XXXXXX")"
-  log "downloading prebuilt static liblbug $version ($asset)"
-  if ! curl -fSL "$url" -o "$tmp/$asset"; then rm -rf "$tmp"; die "download failed: $url"; fi
-  if ! tar xzf "$tmp/$asset" -C "$tmp"; then rm -rf "$tmp"; die "extract failed: $asset"; fi
-  [ -f "$tmp/$static_lib_name" ] || { rm -rf "$tmp"; die "archive $asset missing $static_lib_name"; }
-  install_prebuilt_from "$tmp"
-  rm -rf "$tmp"
-}
-
-# Copy headers first, then the static lib atomically, so that the existence of
-# liblbug.a always implies the headers are already present.
-install_prebuilt_from() {
-  local src="$1"
-  cp -f "$src"/lbug.h "$STABLE_LIB_DIR/" 2>/dev/null || true
-  cp -f "$src"/lbug.hpp "$STABLE_LIB_DIR/" 2>/dev/null || true
-  cp -f "$src/$static_lib_name" "$STABLE_LIB_DIR/.$static_lib_name.tmp"
-  mv -f "$STABLE_LIB_DIR/.$static_lib_name.tmp" "$STABLE_LIB_FILE"
-}
-
-ensure_stable_prebuilt() {
-  if [ -f "$STABLE_LIB_FILE" ]; then
-    return 0
-  fi
-  mkdir -p "$STABLE_LIB_DIR"
-
-  local reg
-  reg="$(find_registry_prebuilt || true)"
-  if [ -n "$reg" ]; then
-    local src_dir
-    src_dir="$(dirname "$reg")"
-    log "copying prebuilt liblbug from $src_dir"
-    install_prebuilt_from "$src_dir"
-  fi
-
-  if [ ! -f "$STABLE_LIB_FILE" ]; then
-    download_prebuilt
-  fi
-
-  [ -f "$STABLE_LIB_FILE" ] || die "failed to provision $STABLE_LIB_FILE"
-}
-
-ensure_stable_prebuilt
+# Delegated to the shared provisioner (also used by CI) so the link path is
+# defined in exactly one place.
+"$REPO_ROOT/scripts/provision-lbug-prebuilt.sh" "$STABLE_LIB_DIR" >/dev/null
 log "lbug native static lib resolved: $STABLE_LIB_FILE"
 
 export LBUG_LIBRARY_DIR="$STABLE_LIB_DIR"

--- a/scripts/clippy-precommit-release.sh
+++ b/scripts/clippy-precommit-release.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+#
+# clippy-precommit-release.sh — run the pre-commit `cargo clippy --release`
+# gate with the `lbug` native static library reliably on the linker search
+# path.
+#
+# Why this wrapper exists (issue #2426 / #2423)
+# ---------------------------------------------
+# `lbug` 0.17.1's build script downloads a prebuilt `liblbug.a` into the cargo
+# *registry source* directory:
+#
+#     ~/.cargo/registry/src/<hash>/lbug-0.17.1/.cache/lbug-prebuilt/latest/lib/
+#
+# and emits `cargo:rustc-link-search=native=<that dir>` plus
+# `cargo:rustc-link-lib=static:+whole-archive=lbug`.
+#
+# CI's cargo cache (Swatinem/rust-cache) persists `target/` — including the
+# cached lbug build-script output that *references* that registry-src path —
+# but it does NOT persist `registry/src`. On a cache restore the prebuilt
+# archive is gone, yet cargo treats lbug as fresh and reuses the cached
+# build-script output, so `cargo clippy --release` fails with:
+#
+#     error: could not find native static library `lbug`, perhaps an -L flag is missing?
+#
+# The `build`/`coverage` jobs don't hit this on every run because they
+# (re)provision lbug for the dev profile; the verify pre-commit job runs
+# `cargo clippy --release` first and reds out before anything else compiles.
+#
+# What this wrapper does
+# ----------------------
+# 1. Ensures a stable `liblbug.a` (+ headers) exists outside registry/src —
+#    copied from an existing registry prebuilt when available, otherwise
+#    downloaded as the version-pinned LadybugDB release asset (the same static
+#    archive the build & coverage jobs consume).
+# 2. Exports `LBUG_LIBRARY_DIR`/`LBUG_INCLUDE_DIR` — lbug's first-class
+#    "external prebuilt" interface — so any build-script (re)run resolves lbug
+#    from the stable copy deterministically.
+# 3. Forces an lbug build-script re-run ONLY when the cached release
+#    link-search is genuinely stale (none of the referenced search dirs
+#    actually contains `liblbug.a`). Warm local checks stay fully incremental.
+# 4. Runs `cargo clippy --release --no-deps -- -D warnings`, after asserting the
+#    native lib is resolvable so the regression can't return silently.
+#
+# Safe to run locally and in CI; idempotent.
+
+set -euo pipefail
+
+log() { printf '[clippy-precommit-release] %s\n' "$*" >&2; }
+die() { log "ERROR: $*"; exit 1; }
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$REPO_ROOT"
+
+CARGO_HOME_DIR="${CARGO_HOME:-$HOME/.cargo}"
+
+# Resolve the cargo target directory (honours CARGO_TARGET_DIR, used by the
+# per-engineer worktree isolation that relocates target/ out of the worktree).
+TARGET_DIR="${CARGO_TARGET_DIR:-$REPO_ROOT/target}"
+
+# Stable location for the lbug native lib, deliberately OUTSIDE registry/src so
+# it survives cargo-cache restores and registry re-extraction.
+STABLE_LIB_DIR="${SIMARD_LBUG_LIB_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/simard-lbug-precommit/lib}"
+STABLE_LIB_FILE="$STABLE_LIB_DIR/liblbug.a"
+
+static_lib_name="liblbug.a"
+
+# lbug crate version (and matching LadybugDB native release tag) parsed from
+# Cargo.toml, so the prebuilt asset is fetched deterministically — no
+# unauthenticated `releases/latest` API call (rate-limited on shared CI egress
+# IPs) and no version skew with the crate we actually compile against.
+lbug_version() {
+  sed -nE 's/^lbug[[:space:]]*=[[:space:]]*"=?([0-9]+\.[0-9]+\.[0-9]+)".*/\1/p' \
+    "$REPO_ROOT/Cargo.toml" | head -n1
+}
+
+# Name of the prebuilt static archive for this OS/arch, mirroring lbug's own
+# scripts/download-liblbug.sh selection logic.
+prebuilt_asset_name() {
+  local os arch variant="${LBUG_LINUX_VARIANT:-compat}"
+  os="$(uname -s)"
+  arch="$(uname -m)"
+  case "$os" in
+    Linux)
+      case "$arch" in
+        x86_64) arch="x86_64" ;;
+        aarch64 | arm64) arch="aarch64" ;;
+        *) return 1 ;;
+      esac
+      printf 'liblbug-static-linux-%s-%s.tar.gz' "$arch" "$variant"
+      ;;
+    Darwin)
+      case "$arch" in
+        x86_64) arch="x86_64" ;;
+        arm64) arch="arm64" ;;
+        *) return 1 ;;
+      esac
+      printf 'liblbug-static-osx-%s.tar.gz' "$arch"
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+# ── 1. Provision a stable liblbug.a (+ headers) ──────────────────────────────
+find_registry_prebuilt() {
+  # Echo the directory of an existing prebuilt liblbug.a in the cargo registry,
+  # if any (fast, offline path for developers who already built lbug once).
+  find "$CARGO_HOME_DIR/registry/src" \
+    -path "*/lbug-*/.cache/lbug-prebuilt/*/lib/$static_lib_name" \
+    2>/dev/null | head -n1
+}
+
+download_prebuilt() {
+  # Fetch the version-pinned LadybugDB release *asset* directly (a tarball, not
+  # an executable script) — the same static archive lbug's build script and the
+  # build/coverage jobs consume. Pinning the version avoids the
+  # `api.github.com/.../releases/latest` lookup and an unpinned `curl | bash`.
+  local version repo asset url
+  version="$(lbug_version || true)"
+  [ -n "$version" ] || die "could not determine lbug version from Cargo.toml"
+  asset="$(prebuilt_asset_name || true)"
+  [ -n "$asset" ] || die "unsupported OS/arch for prebuilt liblbug ($(uname -sm))"
+  repo="${LBUG_GITHUB_REPOSITORY:-LadybugDB/ladybug}"
+  url="https://github.com/$repo/releases/download/v$version/$asset"
+
+  mkdir -p "$STABLE_LIB_DIR"
+  # Download + extract in a temp dir, then place liblbug.a LAST so a partial
+  # download/extract never leaves a half-written archive (or a lib without its
+  # headers) that a later run would trust.
+  local tmp
+  tmp="$(mktemp -d "${TMPDIR:-/tmp}/simard-lbug-dl.XXXXXX")"
+  log "downloading prebuilt static liblbug $version ($asset)"
+  if ! curl -fSL "$url" -o "$tmp/$asset"; then rm -rf "$tmp"; die "download failed: $url"; fi
+  if ! tar xzf "$tmp/$asset" -C "$tmp"; then rm -rf "$tmp"; die "extract failed: $asset"; fi
+  [ -f "$tmp/$static_lib_name" ] || { rm -rf "$tmp"; die "archive $asset missing $static_lib_name"; }
+  install_prebuilt_from "$tmp"
+  rm -rf "$tmp"
+}
+
+# Copy headers first, then the static lib atomically, so that the existence of
+# liblbug.a always implies the headers are already present.
+install_prebuilt_from() {
+  local src="$1"
+  cp -f "$src"/lbug.h "$STABLE_LIB_DIR/" 2>/dev/null || true
+  cp -f "$src"/lbug.hpp "$STABLE_LIB_DIR/" 2>/dev/null || true
+  cp -f "$src/$static_lib_name" "$STABLE_LIB_DIR/.$static_lib_name.tmp"
+  mv -f "$STABLE_LIB_DIR/.$static_lib_name.tmp" "$STABLE_LIB_FILE"
+}
+
+ensure_stable_prebuilt() {
+  if [ -f "$STABLE_LIB_FILE" ]; then
+    return 0
+  fi
+  mkdir -p "$STABLE_LIB_DIR"
+
+  local reg
+  reg="$(find_registry_prebuilt || true)"
+  if [ -n "$reg" ]; then
+    local src_dir
+    src_dir="$(dirname "$reg")"
+    log "copying prebuilt liblbug from $src_dir"
+    install_prebuilt_from "$src_dir"
+  fi
+
+  if [ ! -f "$STABLE_LIB_FILE" ]; then
+    download_prebuilt
+  fi
+
+  [ -f "$STABLE_LIB_FILE" ] || die "failed to provision $STABLE_LIB_FILE"
+}
+
+ensure_stable_prebuilt
+log "lbug native static lib resolved: $STABLE_LIB_FILE"
+
+export LBUG_LIBRARY_DIR="$STABLE_LIB_DIR"
+export LBUG_INCLUDE_DIR="$STABLE_LIB_DIR"
+
+# ── 2. Force a build-script re-run only when the cached output is stale ───────
+# Stale == cargo has a cached release lbug build-script output, but NONE of the
+# `rustc-link-search` dirs it references actually contains liblbug.a (the CI
+# cache-eviction case). When warm/local the registry-src prebuilt is present so
+# this is a no-op and the check stays incremental.
+release_lbug_stale() {
+  local found_output=0 has_lib=0 out dir
+  shopt -s nullglob
+  for out in "$TARGET_DIR"/release/build/lbug-*/output; do
+    found_output=1
+    while IFS= read -r dir; do
+      [ -n "$dir" ] || continue
+      if [ -f "$dir/$static_lib_name" ]; then
+        has_lib=1
+      fi
+    done < <(sed -n 's/^cargo:rustc-link-search=native=//p' "$out")
+  done
+  shopt -u nullglob
+  # Stale only when there IS cached output but the static lib is unresolvable.
+  [ "$found_output" = "1" ] && [ "$has_lib" = "0" ]
+}
+
+if release_lbug_stale; then
+  log "stale cached lbug link-search (liblbug.a evicted); forcing build-script re-run"
+  rm -rf "$TARGET_DIR"/release/build/lbug-* "$TARGET_DIR"/release/.fingerprint/lbug-* 2>/dev/null || true
+fi
+
+# ── 3. Run the actual gate ───────────────────────────────────────────────────
+log "running: cargo clippy --release --no-deps -- -D warnings"
+set +e
+cargo clippy --release --no-deps -- -D warnings
+rc=$?
+set -e
+
+if [ "$rc" -eq 0 ]; then
+  # Stable, greppable success marker for the CI regression-guard assertion.
+  log "SUCCESS: cargo clippy --release linked lbug (lib: $STABLE_LIB_FILE)"
+fi
+exit "$rc"

--- a/scripts/provision-lbug-prebuilt.sh
+++ b/scripts/provision-lbug-prebuilt.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+#
+# provision-lbug-prebuilt.sh — ensure a stable prebuilt `liblbug.a` (+ headers)
+# exists in a given directory, outside the cargo registry-source tree.
+#
+# Usage:
+#   scripts/provision-lbug-prebuilt.sh [lib_dir]
+#
+# Prints the resolved library directory on stdout. Diagnostics go to stderr.
+#
+# This is the single source of truth for the lbug native-static-lib link path
+# used by the pre-commit clippy wrapper (scripts/clippy-precommit-release.sh)
+# and by CI (.github/workflows/verify.yml). See issue #2426 / #2423: lbug
+# 0.17.1 caches its prebuilt archive inside `~/.cargo/registry/src/.../
+# lbug-0.17.1/.cache/lbug-prebuilt/...`, which CI's cargo cache evicts while
+# keeping the cached build-script output that references it — so release builds
+# fail with "could not find native static library `lbug`". Pointing lbug at a
+# stable copy via `LBUG_LIBRARY_DIR`/`LBUG_INCLUDE_DIR` makes the link path
+# deterministic.
+
+set -euo pipefail
+
+log() { printf '[provision-lbug] %s\n' "$*" >&2; }
+die() {
+  log "ERROR: $*"
+  exit 1
+}
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+CARGO_HOME_DIR="${CARGO_HOME:-$HOME/.cargo}"
+
+LIB_DIR="${1:-${SIMARD_LBUG_LIB_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/simard-lbug-precommit/lib}}"
+LIB_FILE="$LIB_DIR/liblbug.a"
+static_lib_name="liblbug.a"
+
+# lbug crate version (== matching LadybugDB native release tag) parsed from
+# Cargo.toml, so the prebuilt asset is fetched deterministically — no
+# unauthenticated `releases/latest` API call and no version skew with the crate
+# we actually compile against.
+lbug_version() {
+  sed -nE 's/^lbug[[:space:]]*=[[:space:]]*"=?([0-9]+\.[0-9]+\.[0-9]+)".*/\1/p' \
+    "$REPO_ROOT/Cargo.toml" | head -n1
+}
+
+# Name of the prebuilt static archive for this OS/arch, mirroring lbug's own
+# scripts/download-liblbug.sh selection logic.
+prebuilt_asset_name() {
+  local os arch variant="${LBUG_LINUX_VARIANT:-compat}"
+  os="$(uname -s)"
+  arch="$(uname -m)"
+  case "$os" in
+    Linux)
+      case "$arch" in
+        x86_64) arch="x86_64" ;;
+        aarch64 | arm64) arch="aarch64" ;;
+        *) return 1 ;;
+      esac
+      printf 'liblbug-static-linux-%s-%s.tar.gz' "$arch" "$variant"
+      ;;
+    Darwin)
+      case "$arch" in
+        x86_64) arch="x86_64" ;;
+        arm64) arch="arm64" ;;
+        *) return 1 ;;
+      esac
+      printf 'liblbug-static-osx-%s.tar.gz' "$arch"
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+find_registry_prebuilt() {
+  # Echo the directory of an existing prebuilt liblbug.a in the cargo registry,
+  # if any (fast, offline path for developers who already built lbug once).
+  find "$CARGO_HOME_DIR/registry/src" \
+    -path "*/lbug-*/.cache/lbug-prebuilt/*/lib/$static_lib_name" \
+    2>/dev/null | head -n1
+}
+
+# Copy headers first, then the static lib atomically, so that the existence of
+# liblbug.a always implies the headers are already present.
+install_prebuilt_from() {
+  local src="$1"
+  cp -f "$src"/lbug.h "$LIB_DIR/" 2>/dev/null || true
+  cp -f "$src"/lbug.hpp "$LIB_DIR/" 2>/dev/null || true
+  cp -f "$src/$static_lib_name" "$LIB_DIR/.$static_lib_name.tmp"
+  mv -f "$LIB_DIR/.$static_lib_name.tmp" "$LIB_FILE"
+}
+
+download_prebuilt() {
+  # Fetch the version-pinned LadybugDB release *asset* directly (a tarball, not
+  # an executable script) — the same static archive lbug's build script and the
+  # build/coverage jobs consume.
+  local version asset repo url
+  version="$(lbug_version || true)"
+  [ -n "$version" ] || die "could not determine lbug version from Cargo.toml"
+  asset="$(prebuilt_asset_name || true)"
+  [ -n "$asset" ] || die "unsupported OS/arch for prebuilt liblbug ($(uname -sm))"
+  repo="${LBUG_GITHUB_REPOSITORY:-LadybugDB/ladybug}"
+  url="https://github.com/$repo/releases/download/v$version/$asset"
+
+  mkdir -p "$LIB_DIR"
+  # Download + extract in a temp dir, then place liblbug.a LAST so a partial
+  # download/extract never leaves a half-written archive (or a lib without its
+  # headers) that a later run would trust.
+  local tmp
+  tmp="$(mktemp -d "${TMPDIR:-/tmp}/simard-lbug-dl.XXXXXX")"
+  log "downloading prebuilt static liblbug $version ($asset)"
+  if ! curl -fSL "$url" -o "$tmp/$asset"; then rm -rf "$tmp"; die "download failed: $url"; fi
+  if ! tar xzf "$tmp/$asset" -C "$tmp"; then rm -rf "$tmp"; die "extract failed: $asset"; fi
+  [ -f "$tmp/$static_lib_name" ] || { rm -rf "$tmp"; die "archive $asset missing $static_lib_name"; }
+  install_prebuilt_from "$tmp"
+  rm -rf "$tmp"
+}
+
+ensure_prebuilt() {
+  if [ -f "$LIB_FILE" ]; then
+    return 0
+  fi
+  mkdir -p "$LIB_DIR"
+
+  local reg
+  reg="$(find_registry_prebuilt || true)"
+  if [ -n "$reg" ]; then
+    log "copying prebuilt liblbug from $(dirname "$reg")"
+    install_prebuilt_from "$(dirname "$reg")"
+  fi
+
+  if [ ! -f "$LIB_FILE" ]; then
+    download_prebuilt
+  fi
+
+  [ -f "$LIB_FILE" ] || die "failed to provision $LIB_FILE"
+}
+
+ensure_prebuilt
+log "lbug native static lib resolved: $LIB_FILE"
+printf '%s\n' "$LIB_DIR"

--- a/tests/cli_golden.rs
+++ b/tests/cli_golden.rs
@@ -102,7 +102,7 @@ fn version_string_is_semver() {
             .unwrap_or_else(|_| panic!("non-numeric version component '{part}' in {VERSION}"));
     }
     assert_eq!(
-        VERSION, "0.21.0",
+        VERSION, "0.22.0",
         "bump this assertion when version changes"
     );
 }

--- a/tests/no_legacy_goal_records_references.rs
+++ b/tests/no_legacy_goal_records_references.rs
@@ -95,6 +95,12 @@ fn no_legacy_goal_records_json_references_outside_migration_files() {
             // The flock-based store has migration code that renames the
             // legacy file to the new canonical path (#2182).
             "store.rs",
+            // The #2405 goal-decomposition feature mentions the legacy file in
+            // (a) a `parent_goal_id` doc comment explaining serde backward
+            // compatibility with pre-#2405 snapshots and (b) a test comment on
+            // the same compatibility. Both are intentional historical context.
+            "types.rs",
+            "tests_decompose.rs",
         ],
     );
 

--- a/tests/qa-scenarios/precommit-clippy-lbug-link.yaml
+++ b/tests/qa-scenarios/precommit-clippy-lbug-link.yaml
@@ -1,0 +1,80 @@
+name: precommit-clippy-lbug-link
+app_type: cli
+description: |
+  Regression coverage for issue #2426 — the pre-commit `cargo clippy --release`
+  hook must compile/link the `lbug` native static library instead of failing
+  with "could not find native static library `lbug`".
+
+  Validates the fix end to end (the CLI runner rejects any non-zero exit, so
+  every `run` step below is also an assertion):
+  1. The clippy-precommit hook entry routes through the lbug link-path wrapper.
+  2. The wrapper resolves a real `liblbug.a`, runs `cargo clippy --release` to a
+     clean lint-free finish (exit 0 ⇒ lbug compiled and linked), and emits its
+     resolution + success markers.
+  3. The CI workflow wires an explicit #2426 regression guard.
+agents:
+  - name: shell
+    type: cli
+    command: bash
+steps:
+  # 1. The pre-commit config drives clippy through the wrapper, not a bare
+  #    `cargo clippy` invocation that lacks the lbug link path.
+  - action: run
+    params:
+      command: "grep -nq 'entry: scripts/clippy-precommit-release.sh' .pre-commit-config.yaml"
+    timeout: 15000
+  - action: validate_exit_code
+    params:
+      value: "0"
+    timeout: 5000
+
+  # 2. Run the wrapper (the real release clippy gate), capturing combined
+  #    output. Exit 0 only happens when lbug compiled and linked cleanly.
+  - action: run
+    params:
+      command: "scripts/clippy-precommit-release.sh > /tmp/qa-precommit-clippy-lbug.log 2>&1"
+    timeout: 1200000
+  - action: validate_exit_code
+    params:
+      value: "0"
+    timeout: 5000
+
+  # 3. The wrapper resolved a real native static lib ...
+  - action: run
+    params:
+      command: "grep -q 'lbug native static lib resolved' /tmp/qa-precommit-clippy-lbug.log"
+    timeout: 15000
+  - action: validate_exit_code
+    params:
+      value: "0"
+    timeout: 5000
+
+  # ... and reported clippy --release linked lbug (the CI guard's success marker).
+  - action: run
+    params:
+      command: "grep -q 'SUCCESS: cargo clippy --release linked lbug' /tmp/qa-precommit-clippy-lbug.log"
+    timeout: 15000
+  - action: validate_exit_code
+    params:
+      value: "0"
+    timeout: 5000
+
+  # 4. The clippy run did NOT hit the #2426 native-lib failure.
+  - action: run
+    params:
+      command: "bash -c '! grep -qiE \"could not find native static library .?lbug\" /tmp/qa-precommit-clippy-lbug.log'"
+    timeout: 15000
+  - action: validate_exit_code
+    params:
+      value: "0"
+    timeout: 5000
+
+  # 5. CI has an explicit, greppable regression guard for #2426.
+  - action: run
+    params:
+      command: "grep -nq 'regression guard #2426' .github/workflows/verify.yml"
+    timeout: 15000
+  - action: validate_exit_code
+    params:
+      value: "0"
+    timeout: 5000


### PR DESCRIPTION
## Problem

The CI `pre-commit` job's `cargo clippy --release --no-deps -- -D warnings` hook fails on **every Rust-touching PR** with:

```
    Checking lbug v0.17.1
error: could not find native static library `lbug`, perhaps an -L flag is missing?
error: could not compile `lbug` (lib) due to 1 previous error
```

so the pre-commit gate is permanently red on Rust PRs and provides no signal. The same root cause (shared with #2423) also reds the `install-real` job when the gate is unblocked.

## Root cause (verified)

`lbug` 0.17.1's build script downloads its prebuilt `liblbug.a` **into the cargo registry-source dir** (`~/.cargo/registry/src/<hash>/lbug-0.17.1/.cache/lbug-prebuilt/latest/lib/`) and emits `cargo:rustc-link-search=native=<that dir>` + `rustc-link-lib=static:+whole-archive=lbug`.

CI's Swatinem cargo cache persists `target/` (including the cached build-script `output` that references that registry-src path) but **not** `registry/src`. On a cache restore the prebuilt archive is evicted, while cargo treats `lbug` as fresh and reuses the cached build-script output — so any release/`--release` build can't find `liblbug.a`. The verify pre-commit job runs `clippy --release` first, so it reds before anything else compiles. Confirmed via `git` history: the pre-commit job was green at `57f93fb3` (the cache **writer** run) and red on every subsequent main run (cache **restorers**); the dev profile was only intermittently healthy depending on whether cargo happened to re-run lbug's build script.

## Fix

Pin the lbug native-static-lib link path deterministically for the whole verify workflow:

- **`scripts/provision-lbug-prebuilt.sh`** (new) — single source of truth for a stable `liblbug.a` (+ headers) outside `registry/src`: reuses an existing registry prebuilt, otherwise downloads the **version-pinned** LadybugDB release asset (parsed from `Cargo.toml`; no `releases/latest` API, no `curl | bash`), with atomic install (headers first, lib last).
- **`scripts/clippy-precommit-release.sh`** (new) — the `cargo-clippy-precommit` hook now runs through this wrapper, which provisions the stable lib (delegating to the script above), points `lbug` at it via its first-class `LBUG_LIBRARY_DIR`/`LBUG_INCLUDE_DIR` interface, forces an lbug build-script re-run only when the cached release link-search is genuinely stale, then runs the clippy gate. **No-op for warm local checks.**
- **`.pre-commit-config.yaml`** — route the `cargo-clippy-precommit` hook `entry` at the wrapper.
- **`.github/workflows/verify.yml`** — a "Provision lbug native static library link path" step (after cache-restore) in **both** the `pre-commit` and `install-real` jobs: provisions the stable lib, exports `LBUG_LIBRARY_DIR`/`LBUG_INCLUDE_DIR` for the job, and drops stale cached lbug build outputs so every cargo invocation re-runs lbug's build script against the pinned path. Also caches that dir, runs the pre-commit stage with `--verbose`, and adds an explicit **"regression guard #2426"** step that fails loudly (with a `::error::` annotation) if clippy ever again can't link `lbug`.
- **`CONTRIBUTING.md`** — document the wrapper and why it exists.
- **`tests/qa-scenarios/precommit-clippy-lbug-link.yaml`** (new) — gadugi-test regression scenario.

Repairing the gate also **unmasked two pre-existing regressions** (from #2405, c12ab585) that the permanently-red clippy step had been hiding — exactly the "masks real regressions" failure mode #2426 describes. Fixing them is required for #2426's acceptance ("the pre-commit gate is green/meaningful again"):

- **`tests/cli_golden.rs`** — `version_string_is_semver` golden assertion bumped `0.21.0` → `0.22.0` (matches the current crate version; `Cargo.toml` itself is unchanged).
- **`tests/no_legacy_goal_records_references.rs`** — added `types.rs` and `tests_decompose.rs` to the migration test's allow-list for the two intentional historical `goal_records.json` references #2405 added (consistent with its existing entries, e.g. `tests.rs`, `cognitive_memory_store.rs`).

## Merge-ready evidence

### 1. QA-team (gadugi-test)
`tests/qa-scenarios/precommit-clippy-lbug-link.yaml` — validated and run:
```
$ gadugi-test validate -f tests/qa-scenarios/precommit-clippy-lbug-link.yaml
✓ Scenario "precommit-clippy-lbug-link" is valid
$ gadugi-test run -d tests/qa-scenarios -s precommit-clippy-lbug-link
✓ Passed: 1   ✗ Failed: 0   ✓ All tests passed!
```
It runs the real wrapper, asserts exit 0 (⇒ `lbug` compiled+linked), asserts the resolution/SUCCESS markers and the absence of the `could not find native static library lbug` error, and asserts the hook wiring + CI guard are present. Also manually verified: warm-local incremental (~16s), CI-recovery cold build via the external branch (3m17s, no cmake source build), version-pinned download (HTTP 200, `liblbug.a` + headers), and staleness detection (cold/warm/evicted unit cases).

### 2. Documentation
`CONTRIBUTING.md` "Local Pre-Commit Workflow" documents the wrapper and the lbug link-path rationale. User-facing surface changed: the developer pre-commit workflow (documented); everything else is CI config.

### 3. Quality-audit (SEEK→VALIDATE→FIX, ended clean)
Four review cycles:
- Cycle 1 — MEDIUM (unauthenticated/rate-limited download + unpinned `curl|bash`) + LOW (regression-guard skipped on failure). **Fixed** (version-pinned direct asset download; `cache-directories`; `if: always()` outcome-gated assert).
- Cycle 2 — confirmed sound vs lbug 0.17.1's real `build.rs`/release assets; LOW (partial-tar extraction; misleading "missing log"). **Fixed** (temp-dir extract + atomic `mv`; outcome-gated guard).
- Cycle 3 — **CLEAN**.
- Cycle 4 (job-wide provisioning + install-real) — **CLEAN** (verified env propagation to `cargo install`, `rm` glob safety, step ordering, static-link rpath inertness).

### 4. CI — 100% green
All required checks pass on the final commit (`4c127657`). Green run: **https://github.com/rysweet/Simard/actions/runs/28284349380** — `pre-commit` ✓ (incl. the regression-guard step, `cargo test`, pre-push clippy, build), `install-real` ✓, `e2e-dashboard` ✓, `cargo-audit` ✓, GitGuardian ✓. PR `mergeable: MERGEABLE`, `mergeStateStatus: CLEAN`. The PR's own pre-commit check is green. Local commit-time + push-time gates also pass (rust-only-gate, `cargo fmt --check`, clippy `--release` via wrapper, full `--all-targets --all-features --locked` clippy, race-subset tests).

### 6. Scope — focused, reconciled
8 files, all in service of fixing #2426/#2423; no incidental edits. Complete final diffstat:
```
 .github/workflows/verify.yml                       | 79 ++++-
 .pre-commit-config.yaml                            |  7 +-
 CONTRIBUTING.md                                    | 15 +-
 scripts/clippy-precommit-release.sh                | 111 +++++
 scripts/provision-lbug-prebuilt.sh                 | 138 +++++
 tests/cli_golden.rs                                |  2 +-
 tests/no_legacy_goal_records_references.rs         |  6 +
 tests/qa-scenarios/precommit-clippy-lbug-link.yaml | 80 +++++
```
Files 1–5 + the qa scenario are the lbug link-path fix; `tests/cli_golden.rs` and `tests/no_legacy_goal_records_references.rs` are the two regressions the fix unmasks (see Fix section). These are **not** unrelated drift — they are required to make the now-meaningful pre-commit gate green, which is #2426's stated acceptance. `Cargo.toml` is unchanged.

## Verdict

**Ready to merge.** All six merge-ready criteria are satisfied with concrete evidence above: QA scenario validated+run green; docs updated; four quality-audit cycles ending CLEAN; CI 100% green (run 28284349380) with the PR MERGEABLE/CLEAN; evidence provided for every criterion; and a focused, fully-reconciled 8-file diff whose only "extra" edits are the documented regressions this fix unmasks. No open blockers.

Closes #2426
