### PR TITLE
feat(brain): periodic brain self-examination + memory-hygiene pass (#2419)

### DIFF
--- a/docs/architecture/brain-introspection.md
+++ b/docs/architecture/brain-introspection.md
@@ -1,0 +1,180 @@
+---
+title: Brain introspection + memory hygiene
+description: Design rationale for Simard's periodic brain self-examination and memory-hygiene pass (#2419) — why a daemon interval task (not a standing goal or per-cycle hook), the bridge-reachability finding that drives the safe-first increment split, the cadence/knobs, and the safety model for bounded reversible pruning.
+last_updated: 2026-06-27
+review_schedule: as-needed
+owner: simard
+doc_type: explanation
+related:
+  - ../reference/brain-introspection-api.md
+  - ../howto/configure-brain-introspection.md
+  - ./episode-ingestion-policy.md
+  - ../reference/automatic-distillation-scheduler.md
+---
+
+# Brain introspection + memory hygiene
+
+> Shipped in issue [#2419](https://github.com/rysweet/Simard/issues/2419).
+
+Simard runs a **standing brain self-examination + memory-hygiene** pass on its
+own periodic cadence (default daily). The pass examines the OODA brain's
+decision quality, mines recent activity for recurring patterns, safely trims a
+bounded amount of low-value memory, consolidates episodic memory into
+semantic/procedural memory, and writes actionable findings to a GitHub issue.
+
+This page explains *why* the feature is built the way it is. For the executable
+contract (APIs, structs, markers, config) see the
+[Brain introspection API](../reference/brain-introspection-api.md). For operator
+tasks see [Configure brain introspection](../howto/configure-brain-introspection.md).
+
+## What problem this solves
+
+Simard accumulates memory and emits decision metrics continuously, but nothing
+periodically *steps back* to ask: is the brain's decision quality drifting? Are
+the same blockers recurring? Is memory filling with stale, superseded, or
+duplicate entries? Per-cycle distillation (issue
+[#2327](https://github.com/rysweet/Simard/issues/2327)) handles incremental
+promotion, but it is **not** an introspection layer — it does not analyze brain
+health, mine cross-episode patterns, or prune by value.
+
+The brain-introspection pass is that higher-level, lower-frequency layer. It
+*uses* the existing infra (distillation, statistics, sensory prune) rather than
+duplicating it.
+
+## Why a periodic daemon task (the cadence decision)
+
+The goal says "runs REGULARLY." Three mechanisms were considered:
+
+| Option | Verdict | Why |
+| --- | --- | --- |
+| **(a) Periodic daemon task on its own interval** | **Chosen** | Mirrors the proven, tested `SIMARD_DISK_HEALTH_INTERVAL_SECS` / worktree-sweep pattern in `operator_commands_ooda/daemon/mod.rs`. Deterministic cadence, minimal/testable Rust, fail-open. |
+| (b) Standing low-priority OODA goal | Rejected as the *cadence* source | A low-priority goal can starve indefinitely behind higher-value goals — the wrong fit for a hygiene cadence that must run on schedule. |
+| (c) A recipe the brain invokes ad hoc | Rejected as the *cadence* source | No schedule guarantee; the brain may never choose it. |
+
+Options (b) and (c) are the *content* path — the daemon task **dispatches** the
+`brain-introspection` recipe as a `recipe-runner-rs` subprocess for the agentic
+reasoning. The daemon owns the clock; the recipe owns the judgment. This is
+exactly the disk-health split (deterministic Rust scheduler + agentic recipe).
+
+## Split of labor
+
+```
+┌─────────────────────────────┐        ┌──────────────────────────────┐
+│ Rust hook (daemon-side)      │        │ Recipe (recipe-runner-rs)    │
+│ src/brain_introspection.rs   │        │ brain-introspection.yaml     │
+├─────────────────────────────┤        ├──────────────────────────────┤
+│ • get_statistics()          │ stats  │ • brain-health analysis      │
+│ • prune_expired_sensory()   │──────▶ │ • pattern mining             │
+│   (non-discretionary;       │ cap    │ • prune-CANDIDATE recommend  │
+│    NOT capped)              │──────▶ │   (≤ max_prune cap)          │
+│ • consolidate_episodes()    │        │ • create/update gh issue     │
+│ • measure consolidated Δ    │        │                              │
+│ • record_metric() × N       │ ◀──────│   emits text markers          │
+│ • parse markers             │ markers│                              │
+└─────────────────────────────┘        └──────────────────────────────┘
+```
+
+Recipe agents cannot call `CognitiveMemoryOps` trait methods, so **all real
+memory operations run in the hook**. The recipe reasons over the real numbers
+the hook already measured (passed as `-c stats=<json>`) and *recommends* prunes;
+it never deletes.
+
+## The bridge-reachability finding (drives the increment split)
+
+The single most important design fact: the daemon's `bridges.memory` is a
+`CognitiveMemoryBridge` — a **JSON-RPC IPC client** — not the in-process
+`LibraryCognitiveMemory`. Over that bridge:
+
+- `prune_superseded()` falls through to the **default trait impl `Ok(0)` — a
+  no-op**. Only `LibraryCognitiveMemory` reclaims superseded rows.
+- `graph_stats()` returns the **empty default**.
+- `backup_memory()` needs a `&dyn MemoryStore`; daemon-side there is **no
+  store** — it lives in the bridge *server* process.
+
+So the naïve design — "bounded destructive superseded-prune + backup in the
+daemon Rust hook" — would **silently delete nothing while reporting success**: a
+hollow-success / silent-degradation bug the codebase explicitly warns against.
+
+### Resolution: a safe-first increment
+
+| | First increment (shipped) | Follow-up |
+| --- | --- | --- |
+| Sensory prune (transient) | ✅ `prune_expired_sensory`, RPC-backed, non-discretionary TTL cleanup (exempt from cap) | — |
+| Consolidation | ✅ `consolidate_episodes`, RPC-backed, additive; count measured via stats delta | — |
+| Superseded/low-value prune | 📝 **recommended** as `PRUNE_CANDIDATE` (≤ cap) in the issue | 🔜 backed-up destructive prune via new server RPCs (cap-bounded) |
+| Backup before destructive ops | n/a (no destructive ops daemon-side) | 🔜 `memory.backup` server RPC |
+
+The follow-up (filed as an issue) adds `memory.prune_superseded` +
+`memory.backup` RPCs **on the bridge server**, where the store actually lives,
+to enable backed-up, bounded, reversible deletion. Until then, the pass is
+read-mostly and the only daemon-side deletion is transient sensory rows.
+
+## Safety model
+
+The SAFETY constraints from issue #2419 are honored as follows:
+
+- **Bounded recommendations.** `enforce_prune_cap(requested, cap)` clamps the
+  number of **value-bearing prune candidates** the recipe may recommend to
+  `SIMARD_BRAIN_INTROSPECTION_MAX_PRUNE` (default 25, absolute). It is passed to
+  the recipe as `-c max_prune=<cap>` and clamps the returned count. `cap = 0` ⇒
+  zero recommendations. The cap does **not** throttle `prune_expired_sensory`,
+  which removes only already-expired transient rows (non-discretionary TTL
+  cleanup). When destructive value-bearing prune lands as a follow-up, it too
+  will be clamped by this cap.
+- **Never deletes high-value / provenance-bearing memory.** The only daemon-side
+  deletion is `prune_expired_sensory` (already-expired transient rows). Valuable
+  memory is never touched; superseded candidates are surfaced for review (capped
+  at `max_prune`), not deleted.
+- **Additive consolidation.** `consolidate_episodes` distills episodic →
+  semantic/procedural; it stores, it does not lose. The hook measures the result
+  as the post−pre delta of (semantic + procedural) counts, since
+  `consolidate_episodes` itself returns `Option<String>`, not a count.
+- **Reversible (follow-up).** When destructive superseded prune lands, it backs
+  up affected rows first (via the server `memory.backup` RPC) and aborts the
+  prune (non-fatal) if backup fails.
+- **Off by explicit `0`; conservative defaults.** Daily cadence, cap 25.
+
+## Output: issue, not snapshot doc
+
+Per the no-point-in-time-docs rule, each run writes findings to a **GitHub
+issue** on `rysweet/Simard` (label `brain-introspection`) and to
+`self_metrics`. The issue uses a **stable title** so repeated runs *update*
+rather than spam. The only durable repo document is this reference page and the
+[API reference](../reference/brain-introspection-api.md) — both describe the
+pass and its knobs, not a point-in-time finding.
+
+## Baseline and regression detection
+
+Each run records `brain_introspection_*` metrics to `metrics.jsonl`. The
+brain-health step compares the current run against the rolling window of the
+previous `SIMARD_BRAIN_INTROSPECTION_BASELINE_RUNS` runs (default 7) and emits
+`REGRESSION:` lines when a signal worsens materially. The **first run** finds no
+prior entries and reports `BRAIN_HEALTH: no prior baseline`, establishing the
+baseline for subsequent runs.
+
+## Relationship to per-cycle distillation
+
+This pass **does not duplicate** the per-cycle distillation scheduler
+([#2327](https://github.com/rysweet/Simard/issues/2327)). That scheduler runs
+every OODA cycle and handles incremental episode→fact/procedure promotion. The
+introspection pass is a higher-level, lower-frequency layer that *invokes the
+same* `consolidate_episodes` entry as one of its steps and adds the analysis +
+hygiene that the per-cycle path intentionally omits.
+
+## Configuration knobs
+
+| Knob | Env var | Default |
+| --- | --- | ---: |
+| Cadence | `SIMARD_BRAIN_INTROSPECTION_INTERVAL_SECS` | `86400` (24h; `0` = disabled) |
+| Safe-prune cap | `SIMARD_BRAIN_INTROSPECTION_MAX_PRUNE` | `25` (absolute) |
+| Baseline window | `SIMARD_BRAIN_INTROSPECTION_BASELINE_RUNS` | `7` runs |
+
+See [Configure brain introspection](../howto/configure-brain-introspection.md)
+for tuning and observability.
+
+## Related
+
+- [Brain introspection API](../reference/brain-introspection-api.md) — the executable contract
+- [Configure brain introspection](../howto/configure-brain-introspection.md) — operator guide
+- [Automatic distillation scheduler API](../reference/automatic-distillation-scheduler.md) — the per-cycle consolidation reused here
+- [Episode ingestion policy & promotion](./episode-ingestion-policy.md) — the memory hygiene/promotion model this pass sits above

--- a/docs/howto/configure-brain-introspection.md
+++ b/docs/howto/configure-brain-introspection.md
@@ -1,0 +1,259 @@
+---
+title: Configure and monitor brain introspection
+description: Operator guide for Simard's periodic brain self-examination and memory-hygiene pass (#2419) — enabling/disabling the cadence, tuning the prune cap and baseline window, reading the brain-introspection GitHub issue and metrics, manually triggering a run, and diagnosing failures.
+last_updated: 2026-06-27
+review_schedule: as-needed
+owner: simard
+doc_type: howto
+related:
+  - ../architecture/brain-introspection.md
+  - ../reference/brain-introspection-api.md
+  - ./configure-disk-health-check.md
+  - ./configure-episode-hygiene-and-promotion.md
+---
+
+# Configure and monitor brain introspection
+
+Simard runs a periodic **brain self-examination + memory-hygiene** pass on its
+own interval (default daily). Each run examines OODA brain decision quality,
+mines recent activity for patterns, safely trims a bounded amount of memory,
+consolidates episodes, and writes findings to a GitHub issue.
+
+This guide shows how to enable, tune, observe, and troubleshoot the pass. For
+design rationale see [Brain introspection + memory
+hygiene](../architecture/brain-introspection.md); for the API contract see the
+[Brain introspection API](../reference/brain-introspection-api.md).
+
+## When to use this
+
+Use this guide when:
+
+- You want to change how often the pass runs (or disable it)
+- You want to change the safe-prune cap or the regression baseline window
+- The daemon logged `brain introspection: …` and you want to read the findings
+- The daemon logged `brain introspection failed` and you need to diagnose it
+- You want to run the introspection pass manually without waiting for the cadence
+
+## Enable, disable, and tune
+
+All knobs are environment variables, read once at daemon start (set them before
+launching the daemon):
+
+| Knob            | Env var                                      | Default | What it controls                                            |
+| --------------- | -------------------------------------------- | ------: | ----------------------------------------------------------- |
+| Cadence         | `SIMARD_BRAIN_INTROSPECTION_INTERVAL_SECS`   | `86400` | Seconds between runs; **`0` disables the pass**             |
+| Safe-prune cap  | `SIMARD_BRAIN_INTROSPECTION_MAX_PRUNE`       | `25`    | Ceiling on value-bearing prune **recommendations** per run (does not throttle expired-sensory cleanup) |
+| Baseline window | `SIMARD_BRAIN_INTROSPECTION_BASELINE_RUNS`   | `7`     | Number of prior runs used as the regression baseline        |
+
+Examples:
+
+```bash
+# Run every 6 hours instead of daily
+export SIMARD_BRAIN_INTROSPECTION_INTERVAL_SECS=21600
+
+# Disable the pass entirely
+export SIMARD_BRAIN_INTROSPECTION_INTERVAL_SECS=0
+
+# Allow more value-bearing prune recommendations per run (still absolute)
+export SIMARD_BRAIN_INTROSPECTION_MAX_PRUNE=50
+
+# Compare against the last 14 runs instead of 7
+export SIMARD_BRAIN_INTROSPECTION_BASELINE_RUNS=14
+```
+
+Confirm the configured interval at daemon start:
+
+```bash
+grep "brain introspection interval" ~/.simard/ooda.log | tail -1
+# [2026-06-27T09:00:00Z] [simard] OODA daemon: brain introspection interval = 86400s
+```
+
+> **The cap is absolute, not a percentage.** A cap of `25` means the recipe may
+> recommend at most 25 **value-bearing** memories for removal in a single run,
+> regardless of total memory size. This is the core SAFETY bound. It does **not**
+> throttle expired-sensory cleanup (`prune_expired_sensory` removes only
+> already-expired transient rows — non-discretionary, never capped), and no
+> value-bearing memory is auto-deleted in this increment at all (candidates are
+> recommended, not removed).
+
+## Observe a run
+
+The daemon logs a one-liner per run:
+
+```bash
+grep "brain introspection" ~/.simard/ooda.log | tail -5
+```
+
+Typical output:
+
+```
+[2026-06-27T09:00:01Z] brain introspection: 3 health findings, 2 patterns, 4 prune candidates, 11 sensory pruned, 6 consolidated, issue=https://github.com/rysweet/Simard/issues/2531
+```
+
+The full findings live in the **GitHub issue**, not in the log or a repo doc:
+
+```bash
+# Open issues this pass has filed/updated (stable title ⇒ deduped)
+gh issue list --repo rysweet/Simard --label brain-introspection
+```
+
+The issue contains the brain-health summary, detected patterns, the
+`PRUNE_CANDIDATE` list (memories recommended for review, **not** auto-deleted),
+and the consolidation result. Repeated runs **update** the same issue rather
+than opening new ones.
+
+## Read the metrics
+
+Each run appends to `~/.simard/metrics/metrics.jsonl`:
+
+```bash
+grep brain_introspection ~/.simard/metrics/metrics.jsonl | tail -8
+```
+
+| Metric                                | Meaning                                        |
+| ------------------------------------- | ---------------------------------------------- |
+| `brain_introspection_live_memories`   | non-sensory live memory count at run start (working + episodic + semantic + procedural + prospective) |
+| `brain_introspection_sensory_pruned`  | already-expired transient sensory rows removed |
+| `brain_introspection_prune_requested` | value-bearing prune candidates recommended     |
+| `brain_introspection_consolidated`    | facts/procedures added (hook-measured delta)   |
+
+These accumulate the rolling baseline; a run compares itself to the previous
+`SIMARD_BRAIN_INTROSPECTION_BASELINE_RUNS` runs and reports `REGRESSION:` lines
+in the issue when a signal worsens. The **first run** reports
+`BRAIN_HEALTH: no prior baseline`.
+
+## Manually trigger a run
+
+To run the agentic recipe directly (the same way the daemon invokes it), use
+`recipe-runner-rs` with the JSON envelope:
+
+```bash
+recipe-runner-rs prompt_assets/simard/recipes/brain-introspection.yaml \
+  --output-format json \
+  -c state_root="$HOME/.simard" \
+  -c repo_path="/home/azureuser/src/Simard" \
+  -c max_prune=25 \
+  -c baseline_runs=7 \
+  -c stats='{}'
+```
+
+This prints a JSON envelope whose `step_results[*].output` strings contain the
+text markers the Rust shim parses:
+
+```json
+{
+  "success": true,
+  "step_results": [
+    {
+      "step_id": "brain-health",
+      "output": "BRAIN_HEALTH: fallback rate 1.1% (baseline 1.0%) — nominal\nREGRESSION: 0-succeeded-action cycles up 3x vs baseline\n"
+    },
+    {
+      "step_id": "output",
+      "output": "PRUNE_REQUESTED=4\nCONSOLIDATED_FACTS=6\nISSUE_URL=https://github.com/rysweet/Simard/issues/2531\n"
+    }
+  ]
+}
+```
+
+> **Note:** Running the recipe directly exercises only the *agentic* half
+> (analysis + issue). The deterministic memory operations
+> (`get_statistics`, `prune_expired_sensory`, `consolidate_episodes`)
+> run in the Rust hook (`run_brain_introspection`), which the daemon calls on its
+> interval. To exercise the **whole** pass on demand (without waiting a day),
+> start the daemon with a short interval, observe one run, then restore the
+> default:
+>
+> ```bash
+> # Fire the full hook ~1 minute after daemon start, for dev/testing only
+> SIMARD_BRAIN_INTROSPECTION_INTERVAL_SECS=60 simard daemon
+> grep "brain introspection" ~/.simard/ooda.log | tail -1
+> ```
+>
+> A first-class on-demand `simard` subcommand that runs the hook once is a
+> documented follow-up; until then the short-interval override is the way to
+> exercise the deterministic half end-to-end.
+
+To see only the recipe summary line (no step output), omit `--output-format json`:
+
+```bash
+recipe-runner-rs prompt_assets/simard/recipes/brain-introspection.yaml \
+  -c state_root="$HOME/.simard" -c repo_path="/home/azureuser/src/Simard"
+# Recipe: brain-introspection SUCCESS
+```
+
+## Diagnose a failed run
+
+If the daemon logs `brain introspection failed`, check these in order:
+
+### 1. `recipe-runner-rs` not installed
+
+```bash
+which recipe-runner-rs
+```
+
+If missing, the pass cannot run but the daemon continues (fail-open). The
+deterministic hygiene (steps 1–3) still runs because it executes **before** the
+recipe spawn. Install `recipe-runner-rs` from the amplihack toolchain.
+
+### 2. Recipe YAML missing
+
+```bash
+ls -la prompt_assets/simard/recipes/brain-introspection.yaml
+```
+
+If absent (deleted, or a detached worktree without it), the shim returns
+`AdapterInvocationFailed` and the daemon warns and continues. The hook also
+checks the hot-reload path `~/.simard/prompt_assets/simard/recipes/brain-introspection.yaml`
+first.
+
+### 3. `gh` not authenticated (issue step fails)
+
+```bash
+gh auth status
+```
+
+The `output` step uses `gh issue` to create/update the brain-introspection
+issue. If `gh` is unauthenticated, the run still completes the analysis and
+hygiene but emits no `ISSUE_URL=`; `summary()` shows `issue=none`.
+
+### 4. Parse error mentioning BRAIN_HEALTH
+
+The parser **requires** at least one non-empty `BRAIN_HEALTH:` line. If the
+agent emitted none (e.g. it failed to read `metrics.jsonl`), the shim returns a
+parse error. Inspect the raw output:
+
+```bash
+recipe-runner-rs prompt_assets/simard/recipes/brain-introspection.yaml \
+  --output-format json \
+  -c state_root="$HOME/.simard" -c repo_path="/home/azureuser/src/Simard" \
+  | python3 -m json.tool
+```
+
+Check that `~/.simard/metrics/metrics.jsonl` and `~/.simard/ooda.log` exist and
+are readable.
+
+## Verify safety
+
+The cap bounds the number of **value-bearing** prune *recommendations* per run,
+and no value-bearing memory is auto-deleted in this increment at all. To confirm
+the bound is respected, check the recommendation count against the cap:
+
+```bash
+grep brain_introspection_prune_requested ~/.simard/metrics/metrics.jsonl | tail -1
+grep brain_introspection_sensory_pruned ~/.simard/metrics/metrics.jsonl | tail -1
+```
+
+`prune_requested` is always `<= SIMARD_BRAIN_INTROSPECTION_MAX_PRUNE`.
+`sensory_pruned` counts only already-expired transient rows and is **not** bound
+by the cap — that cleanup is non-discretionary (the rows are past their TTL).
+Superseded and low-value memories are **recommended** in the issue, never
+auto-deleted in this increment (see the
+[safety model](../architecture/brain-introspection.md#safety-model)).
+
+## Related
+
+- [Brain introspection + memory hygiene (architecture)](../architecture/brain-introspection.md) — design rationale and safety model
+- [Brain introspection API (reference)](../reference/brain-introspection-api.md) — module API, structs, markers, config
+- [Configure and monitor the disk health check](./configure-disk-health-check.md) — the sibling periodic-recipe pass
+- [Configure episode hygiene and promotion](./configure-episode-hygiene-and-promotion.md) — the per-cycle consolidation this pass reuses

--- a/docs/reference/brain-introspection-api.md
+++ b/docs/reference/brain-introspection-api.md
@@ -1,0 +1,548 @@
+---
+title: Brain introspection API
+description: Rust API reference for Simard's periodic brain self-examination and memory-hygiene pass — the run_brain_introspection daemon hook, the BrainIntrospectionReport struct, the enforce_prune_cap pure bound, parse_brain_introspection_text marker parsing, resolve_recipe_path, the brain-introspection recipe contract, and the SIMARD_BRAIN_INTROSPECTION_* configuration knobs.
+last_updated: 2026-06-27
+review_schedule: as-needed
+owner: simard
+doc_type: reference
+related:
+  - ../architecture/brain-introspection.md
+  - ../howto/configure-brain-introspection.md
+  - ./disk-health-api.md
+  - ./automatic-distillation-scheduler.md
+  - ./ooda-brain-parse-failure-record.md
+---
+
+# Brain introspection API
+
+> Shipped in issue [#2419](https://github.com/rysweet/Simard/issues/2419).
+> Hook: `src/brain_introspection.rs`; daemon wiring:
+> `src/operator_commands_ooda/daemon/mod.rs`; recipe:
+> `prompt_assets/simard/recipes/brain-introspection.yaml`; standing prompt:
+> `prompt_assets/simard/brain_introspection.md`; prompt pin:
+> `src/ooda_brain/prompt_store.rs`.
+
+**Module:** `src/brain_introspection.rs`
+
+The `brain_introspection` module is a periodic daemon hook that performs a
+higher-level **brain self-examination + memory-hygiene** pass on its own
+env-gated interval (default daily). It is the cadence-level introspection layer
+that *uses* the existing per-cycle infra (distillation, statistics, sensory
+prune) rather than duplicating it.
+
+Each run:
+
+1. **Brain health** — examines OODA brain decision quality (record-fallback
+   rate, the `brain_lifecycle_decision` parse-failure rate from issue #2419,
+   SIGTERM/degraded/quarantine events, cycles with 0/N succeeded actions) and
+   surfaces anomalies and regressions versus a rolling baseline.
+2. **Patterns** — mines recent episodes/cycle-reports for recurring failures,
+   goal types that land vs. stall, and repeated tool/recipe errors.
+3. **Optimize / prune (SAFE)** — performs only the non-discretionary
+   `prune_expired_sensory` cleanup daemon-side (already-expired transient rows)
+   and emits **capped prune *recommendations*** (`PRUNE_CANDIDATE`) for
+   superseded / low-value / duplicate value-bearing memories. The cap bounds the
+   recommendation count, not the expired-sensory cleanup. See
+   [Safety model](#safety-model) for why destructive superseded deletes are a
+   follow-up, not this increment.
+4. **Consolidate** — runs additive distillation (`consolidate_episodes`),
+   reusing the same pipeline the per-cycle scheduler drives.
+5. **Output** — writes findings to a **GitHub issue** on `rysweet/Simard`
+   (label `brain-introspection`, stable title for dedup) and records metrics to
+   `self_metrics`. No snapshot repo doc is ever written (no-point-in-time-docs
+   rule); the only durable repo doc is the
+   [reference page](../architecture/brain-introspection.md).
+
+This page is the executable contract. For design rationale (cadence choice, the
+bridge-reachability finding, the increment split) see
+[Brain introspection + memory hygiene](../architecture/brain-introspection.md).
+
+---
+
+## Data flow
+
+```
+daemon loop (interval gate, mod.rs)
+       │   SIMARD_BRAIN_INTROSPECTION_INTERVAL_SECS elapsed
+       ▼
+run_brain_introspection(&*bridges.memory, &repo_root, &state_root, None)
+       │
+       ├─ 1. mem.get_statistics()            → stats_before (RPC-backed)
+       │       live_memories = non-sensory modality sum (working + episodic +
+       │       semantic + procedural + prospective); record_metric(…)
+       │
+       ├─ 2. mem.prune_expired_sensory()?    → sensory_pruned
+       │        (already-expired transient rows; non-discretionary TTL
+       │         cleanup — NOT throttled by the cap)
+       │
+       ├─ 3. mem.consolidate_episodes(batch)?        → additive distillation
+       │        mem.get_statistics()        → stats_after
+       │        consolidated_facts = (semantic+procedural)_after
+       │                             − (semantic+procedural)_before  (≥ 0)
+       │
+       ├─ 4. spawn recipe-runner-rs brain-introspection.yaml
+       │        --output-format json
+       │        -c state_root=… -c repo_path=…
+       │        -c max_prune=<cap> -c baseline_runs=<n> -c stats=<json>
+       │        (max_prune = enforce_prune_cap ceiling on *recommendations*)
+       │             │
+       │             ▼
+       │   JSON envelope (stdout)
+       │     { success, step_results: [{ step_id, output }] }
+       │             │
+       │             ▼
+       │   parse_brain_introspection_text(step output)
+       │
+       ├─ 5. record final metrics; prune_requested = min(recipe count, cap);
+       │     consolidated_facts is the hook-measured delta (recipe marker is
+       │     an advisory echo); issue_url present
+       ▼
+BrainIntrospectionReport { live_memories, sensory_pruned, consolidated_facts,
+                           prune_requested, brain_health, patterns,
+                           regressions, issue_url }
+```
+
+**Split of labor.** The **Rust hook (daemon-side)** owns the verified,
+RPC-backed memory operations, the deterministic prune cap, and metric writes.
+The **recipe (subprocess)** owns LLM judgment (brain-health analysis, pattern
+mining, prune-candidate identification) and the GitHub-issue output. Recipe
+agents cannot call `CognitiveMemoryOps` trait methods, so every real memory
+operation runs in the hook; the recipe only *recommends*.
+
+---
+
+## Public API
+
+### `run_brain_introspection(mem, repo_root, state_root, home_override) → SimardResult<BrainIntrospectionReport>`
+
+Entry point, called from the daemon loop. Reads memory statistics, performs the
+bounded safe hygiene (sensory prune + additive consolidation), spawns the
+agentic recipe, parses its markers, records metrics, and returns the report.
+
+```rust
+pub fn run_brain_introspection(
+    mem: &dyn CognitiveMemoryOps,
+    repo_root: &Path,
+    state_root: &Path,
+    home_override: Option<&Path>,
+) -> SimardResult<BrainIntrospectionReport>;
+```
+
+**Parameters:**
+
+| Parameter       | Type                       | Description                                                                 |
+| --------------- | -------------------------- | --------------------------------------------------------------------------- |
+| `mem`           | `&dyn CognitiveMemoryOps`  | The daemon's memory bridge; the daemon passes `&*bridges.memory`            |
+| `repo_root`     | `&Path`                    | Repository root — used to locate the recipe YAML                            |
+| `state_root`    | `&Path`                    | Simard state directory (`~/.simard`) — passed as a recipe context var       |
+| `home_override` | `Option<&Path>`            | Test seam for `resolve_recipe_path` hot-reload resolution; `None` in prod   |
+
+> **Signature delta from `disk_health`.** Unlike
+> `run_disk_health_check` (a pure scheduler that holds no memory handle), this
+> hook takes `mem: &dyn CognitiveMemoryOps` because the real memory operations
+> (`get_statistics`, `prune_expired_sensory`, `consolidate_episodes`) run
+> in-process over the bridge. The daemon already has `bridges.memory` in scope,
+> so the call site is `run_brain_introspection(&*bridges.memory, …)`.
+
+**Returns:** `SimardResult<BrainIntrospectionReport>`
+
+**Errors:**
+
+Steps 1–3 are memory RPCs; a failure there returns the underlying `SimardError`
+(e.g. transport/`get_statistics`/`prune_expired_sensory`/`consolidate_episodes`
+failures) **before** the recipe is ever spawned. Steps 4–5 (recipe spawn + parse)
+return `SimardError::AdapterInvocationFailed`:
+
+| Stage | Condition                          | Error reason                                            |
+| ----- | ---------------------------------- | ------------------------------------------------------- |
+| 1–3   | Memory RPC failed                  | underlying `SimardError` (transport/op-specific)        |
+| 4     | Recipe YAML not found              | `"recipe file brain-introspection.yaml not found…"`     |
+| 4     | `recipe-runner-rs` not on PATH     | `"recipe-runner-rs spawn failed: …"`                    |
+| 4     | Recipe exited non-zero             | `"recipe exited with <code>: <stderr>"`                 |
+| 5     | JSON deserialization failed        | `"failed to deserialize recipe JSON output: …"`         |
+| 5     | Empty step_results                 | `"no step results in recipe JSON output"`               |
+| 5     | Text markers missing BRAIN_HEALTH  | `"failed to parse recipe text output: …"`               |
+
+No fallback. The deterministic memory operations (steps 1–3) run **before** the
+recipe spawn, so a recipe failure never voids the bounded hygiene already
+performed. Any error — memory RPC or recipe — propagates to the daemon, which
+logs a `WARN` and continues the loop, mirroring the disk-health hook's fail-open
+behavior.
+
+### `BrainIntrospectionReport`
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrainIntrospectionReport {
+    /// Non-sensory live memory count (hook-measured; includes consolidated).
+    pub live_memories: u64,
+    /// Already-expired transient sensory rows actually removed daemon-side by
+    /// `prune_expired_sensory` (non-discretionary TTL cleanup; NOT capped).
+    pub sensory_pruned: usize,
+    /// Facts/procedures added by consolidation, measured by the hook as the
+    /// post−pre delta of (semantic + procedural) counts from `get_statistics`.
+    /// The recipe's `CONSOLIDATED_FACTS=` marker is an advisory echo only.
+    pub consolidated_facts: u64,
+    /// Number of value-bearing prune *candidates* the recipe recommended,
+    /// clamped to the cap (`min(recipe count, cap)`). Never auto-deleted.
+    pub prune_requested: usize,
+    /// Brain-health findings (>=1; e.g. "fallback rate 4.2% (baseline 1.1%)").
+    pub brain_health: Vec<String>,
+    /// Detected recurring patterns from episode/cycle-report mining.
+    pub patterns: Vec<String>,
+    /// Regressions vs. the rolling baseline (0..n).
+    pub regressions: Vec<String>,
+    /// URL of the created/updated brain-introspection issue, if emitted.
+    pub issue_url: Option<String>,
+}
+```
+
+| Field                | Type             | Description                                                       |
+| -------------------- | ---------------- | ---------------------------------------------------------------- |
+| `live_memories`      | `u64`            | Non-sensory live memory count (hook-measured; includes the consolidation delta) |
+| `sensory_pruned`     | `usize`          | Already-expired transient sensory rows removed daemon-side (non-discretionary; **not** capped) |
+| `consolidated_facts` | `u64`            | Hook-measured (semantic + procedural) delta from the consolidation pass; recipe marker is advisory |
+| `prune_requested`    | `usize`          | Count of value-bearing prune *candidates* recommended, clamped ≤ cap (never auto-deleted) |
+| `brain_health`       | `Vec<String>`    | Brain-health summary lines (at least one required)               |
+| `patterns`           | `Vec<String>`    | Recurring-pattern findings (may be empty)                        |
+| `regressions`        | `Vec<String>`    | Regressions detected against the rolling baseline                |
+| `issue_url`          | `Option<String>` | The GitHub issue the run created or updated, if any              |
+
+**Methods:**
+
+- `actionable() → bool` — `true` if any prune candidate, regression, or
+  consolidation occurred (i.e. the run produced work or signal).
+- `summary() → String` — one-line daemon-log summary. Format:
+  `"brain introspection: L live memories, N health findings, M patterns, P prune candidates, S sensory pruned, C consolidated, issue=<url|none>"`.
+
+### `enforce_prune_cap(requested, cap) → usize`
+
+The pure, deterministic safety bound — extracted so it can be tested without
+standing up memory. Clamps any requested prune count to the configured cap and
+never exceeds it.
+
+```rust
+/// Returns `min(requested, cap)`. A `cap` of 0 always returns 0
+/// (introspection performs zero prunes when the cap is disabled).
+pub fn enforce_prune_cap(requested: usize, cap: usize) -> usize {
+    requested.min(cap)
+}
+```
+
+| `requested` | `cap` | result | rationale                          |
+| ----------: | ----: | -----: | ---------------------------------- |
+|           5 |    25 |      5 | under cap — honor request          |
+|          25 |    25 |     25 | at cap — honor request             |
+|          40 |    25 |     25 | over cap — clamp to cap            |
+|          10 |     0 |      0 | cap disabled — prune nothing       |
+
+This bound governs the **maximum number of value-bearing prune candidates** the
+recipe may recommend — it is passed to the recipe as `-c max_prune=<cap>`, and
+the recipe's returned count is clamped to it (`prune_requested = min(recipe
+count, cap)`). It does **not** throttle `prune_expired_sensory`: that operation
+removes only already-expired transient rows (past their TTL), which is
+non-discretionary cleanup and therefore exempt from the cap. The SAFETY
+invariant of issue #2419 is thus: *no single run recommends more than `cap`
+value-bearing prunes, and the only daemon-side deletion is non-discretionary
+expired-sensory cleanup.* (A future bounded destructive prune of value-bearing
+memory — see [Safety model](#safety-model) — will also be clamped by this cap
+once the backed-up server RPC lands.)
+
+### `parse_brain_introspection_text(stdout) → Result<BrainIntrospectionReport, String>`
+
+Parses text markers from the agent step output. See
+[Marker grammar](#marker-grammar). Unknown lines are silently ignored
+(forward-compatible with LLM reasoning noise), exactly like
+`parse_disk_health_text`.
+
+### `resolve_recipe_path(repo_root, home_override) → Option<PathBuf>`
+
+Resolves the recipe YAML path. Checks in order:
+
+1. **Hot-reload:** `<home>/.simard/prompt_assets/simard/recipes/brain-introspection.yaml`
+   (`home_override` overrides `$HOME` in tests).
+2. **In-tree:** `<repo_root>/prompt_assets/simard/recipes/brain-introspection.yaml`
+
+Returns `None` if neither path exists. `RECIPE_FILENAME` (`"brain-introspection.yaml"`)
+and `ADAPTER_TAG` (`"brain-introspection"`) are module constants, matching the
+disk-health module's layout.
+
+---
+
+## Marker grammar
+
+The recipe emits plain-text markers, one per line, in the final agent step
+output. The Rust shim parses them out of the `--output-format json` envelope's
+`step_results[*].output` strings.
+
+```text
+BRAIN_HEALTH: <line>        # >=1 required; missing → parse error
+PATTERN: <line>            # 0..n
+REGRESSION: <line>         # 0..n
+PRUNE_CANDIDATE: <line>    # 0..n human-readable candidate descriptions
+PRUNE_REQUESTED=<u64>      # count of candidates (defaults to 0)
+CONSOLIDATED_FACTS=<u64>   # advisory echo only; hook delta is authoritative
+ISSUE_URL=<url>            # optional
+```
+
+**Parsing rules** (identical philosophy to the disk-health parser):
+
+- `BRAIN_HEALTH:` — at least one line **required**. Empty text after the colon
+  is skipped; if no non-empty `BRAIN_HEALTH:` line is present, parsing errors.
+- `PRUNE_REQUESTED=N` — optional `u64`, default `0`; the hook clamps it to the
+  cap before storing it as `prune_requested`.
+- `CONSOLIDATED_FACTS=N` — optional `u64`, default `0`. **Advisory only:** the
+  authoritative `consolidated_facts` is the hook-measured (semantic + procedural)
+  stats delta, since `consolidate_episodes` returns `Option<String>`, not a count
+  the recipe could observe. The marker is retained for human readability in the
+  raw envelope.
+- `ISSUE_URL=` — optional; sets `issue_url` to `Some(url)`.
+- `PATTERN:` / `REGRESSION:` / `PRUNE_CANDIDATE:` — optional, repeatable; empty
+  bodies skipped.
+- Unknown lines are silently ignored. Leading/trailing whitespace trimmed;
+  blank lines skipped.
+
+> **Why `PRUNE_REQUESTED` and not `PRUNED`.** The recipe never deletes
+> superseded memories in this increment — it *recommends* candidates. The marker
+> name reflects that the count is requested/recommended, not executed. The
+> daemon-side `sensory_pruned` field (transient sensory only) is the sole
+> actually-deleted count and is measured by the hook, not parsed from the
+> recipe. Likewise `consolidated_facts` is measured by the hook (a stats delta),
+> not taken from the recipe marker.
+
+---
+
+## Recipe invocation details
+
+The shim invokes `recipe-runner-rs` with:
+
+```
+recipe-runner-rs <recipe_path> --output-format json \
+  -c state_root=<state_root> \
+  -c repo_path=<repo_root> \
+  -c max_prune=<cap> \
+  -c baseline_runs=<n> \
+  -c stats=<json>
+```
+
+- `--output-format json` — required, so step output (not just the recipe
+  summary line) is accessible. Same rationale as disk-health and
+  `stewardship::recipe_merge_judge`.
+- `-c stats=<json>` — the measured `CognitiveStatistics` (live counts, sensory
+  pruned, consolidated) serialized to JSON, so the agentic pass reasons over
+  **real** numbers the hook already gathered rather than re-deriving them.
+- `-c baseline_runs=<n>` — the rolling-baseline window
+  (`SIMARD_BRAIN_INTROSPECTION_BASELINE_RUNS`, default 7) the brain-health step
+  compares against.
+- `AMPLIHACK_AGENT_BINARY` env var — set from `RuntimeConfig` so the recipe uses
+  the correct agent binary.
+
+### Recipe steps (`brain-introspection.yaml`)
+
+A **single comprehensive agent step** (`id: brain-introspection`) performs all
+five phases, mirroring the proven `disk-health-check.yaml` single-step pattern
+(the LLM runs `bash`/`gh` internally rather than relying on multi-step recipe
+sequencing):
+
+| Phase | within the step   | emits                                              |
+| ----- | ----------------- | -------------------------------------------------- |
+| 1     | brain-health      | `BRAIN_HEALTH:`, `REGRESSION:`                     |
+| 2     | patterns          | `PATTERN:`                                         |
+| 3     | prune-recommend   | `PRUNE_CANDIDATE:`, `PRUNE_REQUESTED=`             |
+| 4     | consolidate       | `CONSOLIDATED_FACTS=` (advisory)                   |
+| 5     | output            | `ISSUE_URL=`                                       |
+
+Phase 1 reads `~/.simard/metrics/metrics.jsonl` and the daemon log, computing
+the record-fallback rate, the `brain_lifecycle_decision` parse-failure rate,
+SIGTERM/degraded/quarantine counts, and 0-succeeded-action cycles, then compares
+them to the baseline window. Phase 5 creates or **updates** a GitHub issue
+(stable title ⇒ dedup, no spam) via `gh issue` and emits its URL. The
+`CONSOLIDATED_FACTS=` line is an advisory echo for the issue body — the hook does
+**not** trust it for the `consolidated_facts` field; the hook's own post−pre
+`get_statistics` delta is authoritative. The Rust shim parses the markers from
+the concatenation of all `step_results[*].output` strings, so the single step's
+output is consumed in full.
+
+---
+
+## Daemon wiring
+
+The hook mirrors the disk-health / worktree-sweep periodic-task pattern in
+`src/operator_commands_ooda/daemon/mod.rs`. Interval state is initialized
+alongside the other periodic tasks:
+
+```rust
+// --- periodic brain introspection state (issue #2419) -----------------
+let brain_introspection_interval_secs: u64 =
+    crate::brain_introspection::interval_secs_from_env(
+        std::env::var("SIMARD_BRAIN_INTROSPECTION_INTERVAL_SECS")
+            .ok()
+            .as_deref(),
+    ); // daily by default; a valid 0 disables the pass
+let mut last_brain_introspection = Instant::now(); // first run after one interval
+daemon_log(
+    &state_root,
+    &format!(
+        "[simard] OODA daemon: brain introspection interval = {brain_introspection_interval_secs}s"
+    ),
+);
+// ----------------------------------------------------------------------
+```
+
+and the loop hook is added after the worktree sweep, gated by the tested
+`should_run_introspection` helper:
+
+```rust
+// ── Periodic brain introspection + memory hygiene (issue #2419) ──
+if crate::brain_introspection::should_run_introspection(
+    last_brain_introspection.elapsed(),
+    brain_introspection_interval_secs,
+) {
+    match crate::brain_introspection::run_brain_introspection(
+        &*bridges.memory,
+        &bridges.repo_root,
+        &state_root,
+        None,
+    ) {
+        Ok(report) => {
+            daemon_log(&state_root, &format!("[simard] {}", report.summary()));
+        }
+        Err(e) => daemon_log(
+            &state_root,
+            &format!("[simard] WARN: brain introspection failed: {e}"),
+        ),
+    }
+    last_brain_introspection = Instant::now();
+}
+// ----------------------------------------------------------------
+```
+
+- **`> 0` gate** — `should_run_introspection` returns `false` whenever the
+  interval is `0`, disabling the pass entirely. The default is `86_400` (24h).
+- Unlike disk-health, `last_brain_introspection` is **not** back-dated to fire
+  on the first loop iteration — the first introspection runs one full interval
+  after daemon start (it has nothing useful to say at t=0, and the baseline is
+  empty).
+
+---
+
+## Configuration
+
+All knobs are env-driven, read once at daemon start (matching the disk-health /
+worktree-sweep pattern):
+
+| Knob            | Env var                                      | Default | Notes                                                       |
+| --------------- | -------------------------------------------- | ------: | ----------------------------------------------------------- |
+| Cadence         | `SIMARD_BRAIN_INTROSPECTION_INTERVAL_SECS`   | `86400` | Seconds between runs; `0` = disabled                        |
+| Safe-prune cap  | `SIMARD_BRAIN_INTROSPECTION_MAX_PRUNE`       | `25`    | Absolute ceiling on the number of value-bearing prune *recommendations* per run (does not throttle expired-sensory cleanup) |
+| Baseline window | `SIMARD_BRAIN_INTROSPECTION_BASELINE_RUNS`   | `7`     | Rolling number of prior runs used as the regression baseline |
+
+The cap is an **absolute count**, not a percentage — simplest to reason about
+and test. A percentage cap is a documented follow-up (it would be additive).
+
+---
+
+## Metrics
+
+The hook writes to `~/.simard/metrics/metrics.jsonl` via
+`self_metrics::record_metric(name, value, context)` (where `context` is a plain
+`&str`). The metric names are:
+
+| Metric                                | Value                                                                 |
+| ------------------------------------- | --------------------------------------------------------------------- |
+| `brain_introspection_live_memories`   | non-sensory live memory count at run start: `working + episodic + semantic + procedural + prospective` (sensory excluded, so transient churn doesn't move the baseline) |
+| `brain_introspection_sensory_pruned`  | already-expired sensory rows removed (non-discretionary cleanup)       |
+| `brain_introspection_prune_requested` | value-bearing prune candidates recommended (clamped ≤ cap)            |
+| `brain_introspection_consolidated`    | hook-measured (semantic + procedural) delta from consolidation        |
+
+These accumulate the rolling baseline the next run's brain-health step compares
+against (via `self_metrics::query_metrics` / `recent_metrics`). The first run
+finds no prior entries and reports `BRAIN_HEALTH: no prior baseline`.
+
+---
+
+## Safety model
+
+The first increment performs **no destructive superseded/semantic deletes
+daemon-side**. This is a deliberate consequence of a bridge-reachability fact,
+not a missing feature:
+
+The daemon's `bridges.memory` is a `CognitiveMemoryBridge` (a JSON-RPC IPC
+client), **not** the in-process `LibraryCognitiveMemory`. Over that bridge:
+
+- `prune_superseded()` uses the **default trait impl `Ok(0)` — a no-op**
+  (`cognitive_memory/mod.rs`); only `LibraryCognitiveMemory` actually reclaims.
+- `graph_stats()` returns the **empty default**.
+- `backup_memory()` requires a `&dyn MemoryStore`, which does not exist
+  daemon-side (the store lives in the bridge **server** process).
+
+Therefore, calling `prune_superseded` in the daemon hook would delete nothing
+while reporting success — a silent-degradation / hollow-success bug the codebase
+explicitly guards against. The safe resolution:
+
+- **Daemon-side, this increment:** only `prune_expired_sensory()` runs as a
+  deletion (it is RPC-backed and removes only already-expired transient rows —
+  non-discretionary TTL cleanup, so it is **exempt from the cap**, not throttled
+  by it). `consolidate_episodes()` runs (RPC-backed, additive). Superseded /
+  low-value / duplicate **value-bearing** memories become **`PRUNE_CANDIDATE`
+  recommendations** in the GitHub issue, capped at `enforce_prune_cap`, and are
+  reviewed before any deletion.
+- **Follow-up (issue):** add `memory.prune_superseded` + `memory.backup` RPCs on
+  the bridge **server** (where the store lives) to enable backed-up, bounded,
+  reversible destructive prune of value-bearing memory. That destructive prune
+  *will* be clamped by `enforce_prune_cap`. Until then the run is read-mostly and
+  the only daemon-side deletion is non-discretionary expired-sensory cleanup.
+
+**Invariants asserted by tests:**
+
+- `enforce_prune_cap` never returns more than `cap`; `cap = 0` ⇒ `0`. It bounds
+  the recipe's recommendation count (`-c max_prune`), not the sensory cleanup.
+- No code path in the hook calls `prune_superseded` or a destructive
+  semantic/procedural delete.
+- `consolidate_episodes` is additive (distillation), never lossy.
+- The pass is off when the interval is `0`; default cadence is daily; the cap is
+  conservative (25).
+
+---
+
+## Test coverage
+
+| Category                          | Description                                                                         |
+| --------------------------------- | ----------------------------------------------------------------------------------- |
+| `enforce_prune_cap`               | `req < cap`, `== cap`, `> cap`, `cap = 0` → never exceeds; `cap = 0` ⇒ 0; asserts the cap bounds the recipe's `-c max_prune` recommendation count |
+| `run_brain_introspection`         | Stub `CognitiveMemoryOps` (InMemory transport, mirrors `memory_bridge/tests.rs`): asserts stats read, **unbounded** `prune_expired_sensory` call (no cap applied), `consolidated_facts` measured as the post−pre semantic+procedural delta, recipe spawn path; recipe-runner-missing → graceful WARN |
+| `no_destructive_value_prune`      | Asserts no hook path calls `prune_superseded` or a destructive semantic/procedural delete (the only deletion is expired-sensory cleanup) |
+| `resolve_recipe_path`             | Hot-reload (via `home_override`) vs. in-tree resolution; neither present → `None`    |
+| `parse_brain_introspection_text`  | Happy path; missing-required (`BRAIN_HEALTH`) → error; noisy LLM output tolerated    |
+| Daemon interval gating            | `0` disables; elapsed triggers — mirrors the disk-health interval test              |
+| Prompt content-pin                | `embedded_fallback("brain_introspection.md")` is `Some`; prompt mentions brain-health, patterns, bounded-safe-prune, consolidation, gh-issue; recipe YAML content-pinned via `include_str!` |
+
+---
+
+## Increment boundary
+
+**First increment (this page):** the safe read + bounded-sensory-prune +
+additive-consolidate + recommend hook, the recipe, the prompt, the
+[reference doc](../architecture/brain-introspection.md), and the tests above.
+
+**Follow-ups (filed as issues):**
+
+- **(A)** `memory.prune_superseded` + `memory.backup` bridge **server** RPCs to
+  enable backed-up, bounded destructive superseded prune.
+- **(B)** Percentage-based prune cap (additive to the absolute cap).
+- **(C)** Restore-from-backup CLI for reversibility.
+- **(D)** A metrics-dashboard panel for the `brain_introspection_*` series.
+
+---
+
+## Related
+
+- [Brain introspection + memory hygiene (architecture)](../architecture/brain-introspection.md) —
+  cadence rationale, bridge-reachability finding, safety model
+- [Configure brain introspection (how-to)](../howto/configure-brain-introspection.md) —
+  operator tuning, reading the issue, diagnosing failures
+- [Disk health API](./disk-health-api.md) — the periodic-recipe hook pattern this mirrors
+- [Automatic distillation scheduler API](./automatic-distillation-scheduler.md) —
+  the per-cycle consolidation this pass reuses (and does not duplicate)
+- [OODA brain parse-failure record](./ooda-brain-parse-failure-record.md) — the
+  `brain_lifecycle_decision` / parse-failure signal the brain-health step reads

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,7 @@ nav:
     - Gym Eval Engine — Library Adapter: architecture/gym-eval-library-adapter.md
     - Agent Composition: architecture/agent-composition.md
     - Implementation Plan: architecture/implementation-plan.md
+    - Brain Introspection + Memory Hygiene: architecture/brain-introspection.md
   - Concepts:
     - Truthful Runtime Metadata: concepts/truthful-runtime-metadata.md
     - Prompt-driven Brain Iteration: concepts/prompt-driven-brain-iteration.md
@@ -84,6 +85,7 @@ nav:
     - Dashboard E2E Tests: howto/run-dashboard-e2e-tests.md
     - Route a Goal to its Target Repo: howto/route-a-goal-to-its-target-repo.md
     - Self-Maintain Dependency Pins: howto/self-maintain-dependency-pins.md
+    - Configure Brain Introspection: howto/configure-brain-introspection.md
   - Reference:
     - CLI Reference: reference/simard-cli.md
     - Memory introspection CLI: reference/simard-memory-cli.md
@@ -106,6 +108,7 @@ nav:
     - Pluggable Identity API: reference/pluggable-identity-api.md
     - Meeting Close Lifecycle: reference/meeting-close-lifecycle.md
     - Azure DevOps ACL Self-Escalation Guard: reference/ado-acl-self-escalation-guard.md
+    - Brain Introspection API: reference/brain-introspection-api.md
     # Hidden from nav until issue #1590 implementation lands:
     #   - reference/cognitive-memory-bridge-helpers.md
     #   - reference/goal-board-api.md

--- a/prompt_assets/simard/brain_introspection.md
+++ b/prompt_assets/simard/brain_introspection.md
@@ -1,0 +1,119 @@
+# Brain self-examination + memory hygiene (standing introspection prompt)
+
+You are Simard's **brain-introspection** agent. On a regular cadence (default
+daily) you perform a higher-level *self-examination + memory-hygiene* pass over
+your own cognition. You **reuse** the existing per-cycle infrastructure
+(distillation, statistics, expired-sensory cleanup) — you do **not** re-run or
+duplicate per-cycle distillation. The Rust daemon hook has already performed the
+verified, RPC-backed memory operations (expired-sensory prune, additive
+consolidation) and handed you the measured numbers in `-c stats=<json>`. Your
+job is the *judgment* layer: analyze, mine patterns, recommend safe prunes, and
+write the findings to a GitHub issue.
+
+You have `bash`, `gh`, and read access to `~/.simard/`. Be concrete and
+evidence-linked. Every claim should cite a number, a log line, or a metric.
+
+## Context vars
+
+- `{{state_root}}` — Simard state dir (`~/.simard`): metrics, logs, memory.
+- `{{repo_path}}` — repository root.
+- `{{max_prune}}` — **hard cap** on how many value-bearing prune candidates you
+  may recommend this run. Never exceed it.
+- `{{baseline_runs}}` — rolling window (number of prior runs) for regressions.
+- `{{stats}}` — JSON the hook already measured this run: `live_memories`,
+  `sensory_pruned`, `consolidated_facts`. Reason over these real numbers; do not
+  re-derive them.
+
+## The five phases
+
+### 1. BRAIN HEALTH
+
+Examine OODA brain decision quality across phases (orient / decide / act +
+engineer-lifecycle). Read `~/.simard/metrics/metrics.jsonl` and
+`~/.simard/ooda.log` (or the daemon log). Compute and report:
+
+- `record_fallback` rate (fallback decisions / total decisions).
+- `brain_lifecycle_decision` **parse-failure rate** (issue #2419 metric).
+- SIGTERM / degraded / quarantine events.
+- Cycles with **0 of N** succeeded actions.
+
+Compare each against the **rolling baseline** of the previous
+`{{baseline_runs}}` introspection runs (the `brain_introspection_*` metric
+series). Surface anomalies and regressions. If there is no prior baseline (first
+run), say so explicitly and emit `BRAIN_HEALTH: no prior baseline`.
+
+### 2. PATTERNS
+
+Mine recent episodes / cycle-reports for recurring patterns:
+
+- Repeated failures or blockers.
+- Goal types that consistently **land** vs. consistently **stall**.
+- Repeated tool / recipe errors.
+- What correlates with successful PR landings.
+
+### 3. OPTIMIZE / PRUNE (SAFE, BOUNDED — recommendation only)
+
+Identify stale, low-value, redundant, or superseded memories: superseded facts,
+low-confidence / low-usage facts past a threshold, duplicate procedures, expired
+prospectives. **Do not delete anything in this phase.** This increment is
+recommendation-only: emit at most `{{max_prune}}` `PRUNE_CANDIDATE:` lines and
+set `PRUNE_REQUESTED=` to the count. The pass is **safe and bounded** — never
+recommend pruning provenance-bearing, high-value, or high-usage memories, and
+always respect the cap. Destructive prune happens later, off a backed-up,
+human-reviewed RPC.
+
+(The non-discretionary expired-sensory cleanup and the additive consolidation
+were already performed safely by the daemon hook — that is the only deletion,
+and it only touches already-expired transient rows.)
+
+### 4. CONSOLIDATE
+
+The hook already ran additive distillation (episodic → semantic / procedural)
+this cycle; `{{stats}}.consolidated_facts` reports how many facts/procedures it
+promoted. Summarize what was consolidated and call out any high-value episodes
+that should be promoted to durable facts/procedures (dedup via caller keys).
+Echo the count as `CONSOLIDATED_FACTS=` for the issue body (advisory — the hook's
+measured delta is authoritative).
+
+### 5. OUTPUT (GitHub issue + metrics — NO snapshot doc)
+
+Per the **no-point-in-time-docs** rule, write findings to a **GitHub issue**,
+never a committed snapshot markdown file. Use a stable title and the
+`brain-introspection` label so repeated runs **update** (dedup) rather than spam:
+
+```
+TITLE="Brain introspection — standing self-examination"
+# Find an existing open issue with the brain-introspection label + this title:
+gh issue list --repo rysweet/Simard --label brain-introspection --state open \
+  --search "Brain introspection — standing self-examination in:title" --json number,url
+# If found, update it (gh issue comment / gh issue edit --body-file …);
+# otherwise create it:
+gh issue create --repo rysweet/Simard --label brain-introspection \
+  --title "$TITLE" --body-file <body>
+```
+
+Include in the issue body: the brain-health summary (with baseline deltas), the
+detected patterns, the prune candidates, the consolidation summary, and concrete
+**actionable follow-ups** (metrics to add, prompts to fix, memories to prune) —
+proposed as checklist items or spun out as their own issues. Emit the issue URL
+as `ISSUE_URL=`.
+
+## Required output markers
+
+Your final output **must** contain these plain-text markers, each on its own
+line (the Rust shim `parse_brain_introspection_text` parses them; any other
+lines are ignored). Print them as plain text, not inside code fences.
+
+```
+BRAIN_HEALTH: <one finding per line>     # at least one REQUIRED
+PATTERN: <one pattern per line>          # zero or more
+REGRESSION: <one regression per line>    # zero or more
+PRUNE_CANDIDATE: <one candidate per line># zero or more (<= max_prune)
+PRUNE_REQUESTED=<count, <= max_prune>    # defaults to 0
+CONSOLIDATED_FACTS=<count>               # advisory echo only
+ISSUE_URL=<url of the created/updated issue>
+```
+
+- `BRAIN_HEALTH:` is **required** — at least one non-empty line.
+- `PRUNE_REQUESTED=` must be `<= {{max_prune}}`. Pruning is SAFE and BOUNDED.
+- Never emit a snapshot doc; route everything to the issue and/or metrics.

--- a/prompt_assets/simard/recipes/brain-introspection.yaml
+++ b/prompt_assets/simard/recipes/brain-introspection.yaml
@@ -1,0 +1,152 @@
+# brain-introspection.yaml — Agent-based periodic brain self-examination +
+# memory-hygiene pass (issue #2419).
+#
+# Invoked by src/brain_introspection.rs via recipe-runner-rs on its own daemon
+# interval (SIMARD_BRAIN_INTROSPECTION_INTERVAL_SECS, default 24h). The Rust
+# hook has ALREADY performed the verified, RPC-backed memory operations
+# (expired-sensory prune + additive consolidation) and recorded baseline
+# metrics; this recipe owns the LLM judgment layer + the GitHub-issue output.
+#
+# It REUSES the existing distillation/statistics/expired-sensory infra (the
+# numbers arrive via `-c stats`) and does NOT duplicate per-cycle distillation.
+#
+# Context vars (passed via -c):
+#   state_root     — path to ~/.simard (metrics, logs, memory live here)
+#   repo_path      — repository root
+#   max_prune      — HARD cap on value-bearing prune *recommendations* per run
+#   baseline_runs  — rolling window (prior runs) used as the regression baseline
+#   stats          — JSON the hook measured this run: live_memories,
+#                    sensory_pruned, consolidated_facts
+#
+# Output: text markers to stdout (one per line), parsed by
+# `parse_brain_introspection_text` in src/brain_introspection.rs:
+#   BRAIN_HEALTH: <line>        (>=1 REQUIRED)
+#   PATTERN: <line>             (0..n)
+#   REGRESSION: <line>          (0..n)
+#   PRUNE_CANDIDATE: <line>     (0..n, <= max_prune)
+#   PRUNE_REQUESTED=<count>     (<= max_prune; defaults to 0)
+#   CONSOLIDATED_FACTS=<count>  (advisory echo only)
+#   ISSUE_URL=<url>
+#
+# Design: a single agent step (mirrors disk-health-check.yaml) — the LLM runs
+# bash/gh internally to read metrics/logs, mine patterns, recommend SAFE BOUNDED
+# prunes, and create/update the dedup'd brain-introspection issue. Pruning is
+# RECOMMENDATION-ONLY in this increment; the only deletion (expired-sensory) and
+# the additive consolidation already happened safely in the daemon hook.
+
+name: "brain-introspection"
+description: "Periodic brain self-examination + memory hygiene (health, patterns, safe prune, consolidate, issue)"
+version: "1.0.0"
+author: "Simard"
+tags: ["simard", "memory", "introspection", "self-examination", "hygiene"]
+
+context:
+  state_root: "~/.simard"
+  repo_path: "/home/azureuser/src/Simard/worktrees/main"
+  max_prune: "25"
+  baseline_runs: "7"
+  stats: "{}"
+
+steps:
+  - id: "brain-introspection"
+    type: "agent"
+    agent: "default"
+    prompt: |
+      You are Simard's **brain-introspection** agent. On a regular cadence you
+      perform a higher-level self-examination + memory-hygiene pass over your own
+      cognition. You REUSE the existing per-cycle infrastructure (distillation,
+      statistics, expired-sensory cleanup) — you do NOT duplicate per-cycle
+      distillation. The Rust daemon hook has already performed the verified,
+      RPC-backed memory operations and handed you the measured numbers in
+      `stats`. Your job is the judgment layer. You have bash + gh tools.
+
+      ## Context
+
+      - state_root: `{{state_root}}` (metrics, logs, memory)
+      - repo_path: `{{repo_path}}`
+      - max_prune: `{{max_prune}}` — HARD cap on prune candidates you may
+        recommend. Never exceed it. Pruning here is SAFE and BOUNDED.
+      - baseline_runs: `{{baseline_runs}}` — rolling window for regressions.
+      - stats (hook-measured this run): `{{stats}}` — has `live_memories`,
+        `sensory_pruned`, `consolidated_facts`. Reason over these real numbers.
+
+      ## Phase 1 — BRAIN HEALTH
+
+      Examine OODA brain decision quality across phases (orient / decide / act +
+      engineer-lifecycle). Read `{{state_root}}/metrics/metrics.jsonl` and the
+      daemon log (`{{state_root}}/ooda.log` or `{{state_root}}/daemon.log`).
+      Compute and report:
+        - `record_fallback` rate (fallback decisions / total decisions),
+        - `brain_lifecycle_decision` parse-failure rate (issue #2419 metric),
+        - SIGTERM / degraded / quarantine events,
+        - cycles with 0 of N succeeded actions.
+      Compare each to the rolling baseline of the previous `{{baseline_runs}}`
+      runs (the `brain_introspection_*` metric series). Surface anomalies and
+      regressions. If there is no prior baseline (first run), emit
+      `BRAIN_HEALTH: no prior baseline`.
+
+      ## Phase 2 — PATTERNS
+
+      Mine recent episodes / cycle-reports for recurring patterns: repeated
+      failures or blockers, goal types that consistently land vs. stall,
+      repeated tool/recipe errors, and what correlates with successful PR
+      landings.
+
+      ## Phase 3 — OPTIMIZE / PRUNE (SAFE, BOUNDED — recommendation only)
+
+      Identify stale, low-value, redundant, or superseded memories (superseded
+      facts, low-confidence/low-usage facts past a threshold, duplicate
+      procedures, expired prospectives). DO NOT delete anything — this increment
+      is recommendation-only. Emit at most `{{max_prune}}` `PRUNE_CANDIDATE:`
+      lines and set `PRUNE_REQUESTED=` to the count. NEVER recommend pruning
+      provenance-bearing, high-value, or high-usage memories. Respect the cap.
+
+      ## Phase 4 — CONSOLIDATE
+
+      The hook already ran additive distillation (episodic -> semantic /
+      procedural) this cycle; `stats.consolidated_facts` reports how many it
+      promoted. Summarize what was consolidated and flag high-value episodes
+      worth promoting to durable facts/procedures (dedup via caller keys). Echo
+      the count as `CONSOLIDATED_FACTS=` (advisory).
+
+      ## Phase 5 — OUTPUT (GitHub issue + metrics, NO snapshot doc)
+
+      Per the no-point-in-time-docs rule, write findings to a GitHub issue, never
+      a committed snapshot markdown file. Use a STABLE title and the
+      `brain-introspection` label so repeated runs UPDATE (dedup) rather than
+      spam:
+
+        TITLE="Brain introspection — standing self-examination"
+        gh issue list --repo rysweet/Simard --label brain-introspection \
+          --state open --search "$TITLE in:title" --json number,url
+        # If an open issue exists, update it (gh issue comment / gh issue edit);
+        # otherwise create it:
+        gh issue create --repo rysweet/Simard --label brain-introspection \
+          --title "$TITLE" --body-file <body-file>
+
+      The issue body must contain: the brain-health summary (with baseline
+      deltas), detected patterns, the prune candidates, the consolidation
+      summary, and concrete actionable follow-ups (metrics to add, prompts to
+      fix, memories to prune) — as checklist items or spun-out issues. Emit the
+      resulting issue URL as `ISSUE_URL=`.
+
+      ## Required output markers
+
+      Your FINAL output must contain these plain-text markers, each on its own
+      line (printed as plain text, NOT inside code fences). Any other lines are
+      ignored by the Rust shim.
+
+      ```
+      BRAIN_HEALTH: <one finding per line>      # at least one REQUIRED
+      PATTERN: <one pattern per line>           # zero or more
+      REGRESSION: <one regression per line>     # zero or more
+      PRUNE_CANDIDATE: <one candidate per line> # zero or more, <= max_prune
+      PRUNE_REQUESTED=<count, <= max_prune>     # defaults to 0
+      CONSOLIDATED_FACTS=<count>                # advisory echo only
+      ISSUE_URL=<url of the created/updated issue>
+      ```
+
+      `BRAIN_HEALTH:` is REQUIRED (at least one non-empty line). `PRUNE_REQUESTED`
+      must be `<= {{max_prune}}`. Never emit a snapshot doc — route everything to
+      the brain-introspection issue and/or metrics.
+    output: "brain_introspection_report"

--- a/src/brain_introspection.rs
+++ b/src/brain_introspection.rs
@@ -1,0 +1,537 @@
+//! Periodic **brain self-examination + memory-hygiene** pass (issue #2419).
+//!
+//! A higher-level introspection layer the OODA daemon runs on its own env-gated
+//! interval (default daily). It *uses* the existing per-cycle infrastructure
+//! (distillation, statistics, expired-sensory prune) rather than duplicating it,
+//! mirroring the [`crate::disk_health`] periodic-recipe hook pattern.
+//!
+//! ## Split of labor
+//!
+//! * The **Rust hook** ([`run_memory_hygiene`] / [`run_brain_introspection`])
+//!   owns the verified, RPC-backed memory operations (`get_statistics`,
+//!   `prune_expired_sensory`, `consolidate_episodes`), the deterministic prune
+//!   cap ([`enforce_prune_cap`]), and metric writes.
+//! * The **agentic recipe** (a `recipe-runner-rs` subprocess) owns LLM judgment
+//!   — brain-health analysis, pattern mining, prune-candidate identification —
+//!   and the GitHub-issue output.
+//!
+//! ## Safety model (first increment)
+//!
+//! The first increment is **read + safe-consolidate + recommend**. The only
+//! daemon-side deletion is the non-discretionary [`CognitiveMemoryOps::
+//! prune_expired_sensory`] cleanup of already-expired transient rows — which is
+//! TTL cleanup and therefore **not** clamped by the cap. Value-bearing pruning
+//! (superseded / low-value / duplicate memories) is **recommendation-only**:
+//! the recipe emits capped `PRUNE_CANDIDATE` lines for human review.
+//!
+//! The hook deliberately never calls [`CognitiveMemoryOps::prune_superseded`]
+//! daemon-side: over the daemon's IPC bridge that call is an `Ok(0)` no-op (only
+//! the in-process `LibraryCognitiveMemory` reclaims), so invoking it would be a
+//! silent-degradation hazard. Backed-up, bounded destructive prune is a
+//! documented follow-up that adds the RPC on the bridge **server**.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use tracing::warn;
+
+use crate::cognitive_memory::CognitiveMemoryOps;
+use crate::error::{SimardError, SimardResult};
+use crate::runtime_config::RuntimeConfig;
+
+/// Stable adapter / issue-dedup label for this pass.
+const ADAPTER_TAG: &str = "brain-introspection";
+/// Recipe asset filename (resolved hot-reload-first, then in-tree).
+const RECIPE_FILENAME: &str = "brain-introspection.yaml";
+/// Episodic batch size handed to `consolidate_episodes` per run.
+const CONSOLIDATE_BATCH: u32 = 50;
+
+/// Default cadence: run the pass once every 24 hours.
+pub const DEFAULT_INTERVAL_SECS: u64 = 86_400;
+/// Default ceiling on the number of value-bearing prune *recommendations* a
+/// single run may surface (absolute count; does NOT throttle expired-sensory).
+pub const DEFAULT_MAX_PRUNE: usize = 25;
+/// Default rolling-baseline window (number of prior runs) for regressions.
+pub const DEFAULT_BASELINE_RUNS: u32 = 7;
+
+// ───────────────────────────────────────────────────────────────────────────
+// Config knobs — env parsing
+// ───────────────────────────────────────────────────────────────────────────
+
+/// Parse `SIMARD_BRAIN_INTROSPECTION_INTERVAL_SECS`. A valid `0` is honored as
+/// "disabled" (does NOT fall back to the default); garbage/empty → default.
+pub fn interval_secs_from_env(raw: Option<&str>) -> u64 {
+    raw.and_then(|v| v.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_INTERVAL_SECS)
+}
+
+/// Parse `SIMARD_BRAIN_INTROSPECTION_MAX_PRUNE`; garbage/unset → default.
+pub fn max_prune_from_env(raw: Option<&str>) -> usize {
+    raw.and_then(|v| v.trim().parse::<usize>().ok())
+        .unwrap_or(DEFAULT_MAX_PRUNE)
+}
+
+/// Parse `SIMARD_BRAIN_INTROSPECTION_BASELINE_RUNS`; garbage/unset → default.
+pub fn baseline_runs_from_env(raw: Option<&str>) -> u32 {
+    raw.and_then(|v| v.trim().parse::<u32>().ok())
+        .unwrap_or(DEFAULT_BASELINE_RUNS)
+}
+
+/// Daemon interval gate. `interval_secs == 0` disables the pass entirely;
+/// otherwise the pass is due once `elapsed >= interval`.
+pub fn should_run_introspection(elapsed: Duration, interval_secs: u64) -> bool {
+    interval_secs > 0 && elapsed >= Duration::from_secs(interval_secs)
+}
+
+/// The pure, deterministic safety bound: `min(requested, cap)`.
+///
+/// Bounds the recipe's value-bearing prune *recommendation* count (passed as
+/// `-c max_prune=<cap>`). A `cap` of 0 always yields 0 (introspection performs
+/// no value-bearing prune recommendations when disabled). It does **not**
+/// throttle [`CognitiveMemoryOps::prune_expired_sensory`].
+pub fn enforce_prune_cap(requested: usize, cap: usize) -> usize {
+    requested.min(cap)
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Safe, RPC-backed memory hygiene (deterministic, no subprocess)
+// ───────────────────────────────────────────────────────────────────────────
+
+/// Outcome of the deterministic, daemon-side memory-hygiene pass.
+#[derive(Debug, Clone, Serialize)]
+pub struct MemoryHygieneOutcome {
+    /// Non-sensory live memory count plus the facts consolidation added.
+    pub live_memories: u64,
+    /// Already-expired transient sensory rows removed (non-discretionary TTL
+    /// cleanup — NOT clamped by the prune cap).
+    pub sensory_pruned: usize,
+    /// Facts/procedures added by consolidation, measured as the post−pre delta
+    /// of `(semantic + procedural)` counts from `get_statistics`.
+    pub consolidated_facts: u64,
+}
+
+/// Run the safe, bounded, RPC-backed memory-hygiene core.
+///
+/// Sequence (each a memory RPC whose failure propagates):
+/// 1. `get_statistics()` → pre-snapshot (non-sensory live count).
+/// 2. `prune_expired_sensory()` → remove already-expired transient rows
+///    (uncapped, non-discretionary TTL cleanup).
+/// 3. `consolidate_episodes(batch)` → additive distillation (episodic →
+///    semantic/procedural), reusing the per-cycle pipeline.
+/// 4. `get_statistics()` → post-snapshot; `consolidated_facts` is the post−pre
+///    `(semantic + procedural)` delta.
+///
+/// Never calls [`CognitiveMemoryOps::prune_superseded`] (no destructive
+/// value-prune daemon-side; see the module-level safety model).
+pub fn run_memory_hygiene(
+    mem: &dyn CognitiveMemoryOps,
+    batch_size: u32,
+) -> SimardResult<MemoryHygieneOutcome> {
+    let before = mem.get_statistics()?;
+
+    // Non-discretionary TTL cleanup of already-expired transient rows. NOT
+    // throttled by the prune cap — these rows are already past their TTL.
+    let sensory_pruned = mem.prune_expired_sensory()?;
+
+    // Additive distillation (episodic → semantic/procedural). Reuses the same
+    // pipeline the per-cycle scheduler drives; we do NOT re-implement it.
+    let _ = mem.consolidate_episodes(batch_size)?;
+
+    let after = mem.get_statistics()?;
+
+    let sem_proc_before = before.semantic_count + before.procedural_count;
+    let sem_proc_after = after.semantic_count + after.procedural_count;
+    let consolidated_facts = sem_proc_after.saturating_sub(sem_proc_before);
+
+    // Non-sensory live memories at run start, plus the facts consolidation
+    // promoted this run (distillation is additive, so the count never shrinks).
+    let non_sensory_before = before.working_count
+        + before.episodic_count
+        + before.semantic_count
+        + before.procedural_count
+        + before.prospective_count;
+    let live_memories = non_sensory_before + consolidated_facts;
+
+    Ok(MemoryHygieneOutcome {
+        live_memories,
+        sensory_pruned,
+        consolidated_facts,
+    })
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Report + marker grammar
+// ───────────────────────────────────────────────────────────────────────────
+
+/// Structured result of one brain-introspection run.
+///
+/// The memory-count fields (`live_memories`, `sensory_pruned`,
+/// `consolidated_facts`) are **hook-measured**; the narrative fields
+/// (`brain_health`, `patterns`, `regressions`, `issue_url`) and the clamped
+/// `prune_requested` come from the agentic recipe's text markers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrainIntrospectionReport {
+    /// Non-sensory live memory count (hook-measured; includes consolidated).
+    pub live_memories: u64,
+    /// Already-expired transient sensory rows removed daemon-side (uncapped).
+    pub sensory_pruned: usize,
+    /// Hook-measured `(semantic + procedural)` consolidation delta. The recipe's
+    /// `CONSOLIDATED_FACTS=` marker is an advisory echo only.
+    pub consolidated_facts: u64,
+    /// Value-bearing prune *candidates* recommended, clamped to the cap. Never
+    /// auto-deleted in this increment.
+    pub prune_requested: usize,
+    /// Brain-health findings (≥1 from a successful recipe run).
+    pub brain_health: Vec<String>,
+    /// Recurring patterns mined from recent episodes / cycle reports.
+    pub patterns: Vec<String>,
+    /// Regressions detected against the rolling baseline.
+    pub regressions: Vec<String>,
+    /// URL of the created/updated brain-introspection issue, if emitted.
+    pub issue_url: Option<String>,
+}
+
+impl BrainIntrospectionReport {
+    /// Whether the run produced actionable work or signal.
+    pub fn actionable(&self) -> bool {
+        self.prune_requested > 0 || !self.regressions.is_empty() || self.consolidated_facts > 0
+    }
+
+    /// One-line summary suitable for the daemon log.
+    pub fn summary(&self) -> String {
+        format!(
+            "brain introspection: {} live memories, {} health findings, {} patterns, \
+             {} prune candidates, {} sensory pruned, {} consolidated, issue={}",
+            self.live_memories,
+            self.brain_health.len(),
+            self.patterns.len(),
+            self.prune_requested,
+            self.sensory_pruned,
+            self.consolidated_facts,
+            self.issue_url.as_deref().unwrap_or("none"),
+        )
+    }
+}
+
+/// Parse the recipe's plain-text markers from the agent step output.
+///
+/// Grammar (one marker per line; unknown lines silently ignored):
+/// ```text
+/// BRAIN_HEALTH: <line>        # >=1 required; missing → parse error
+/// PATTERN: <line>            # 0..n
+/// REGRESSION: <line>         # 0..n
+/// PRUNE_CANDIDATE: <line>    # 0..n (human-readable; not stored as a field)
+/// PRUNE_REQUESTED=<usize>    # count of candidates (defaults to 0)
+/// CONSOLIDATED_FACTS=<u64>   # advisory echo only; hook delta is authoritative
+/// ISSUE_URL=<url>            # optional
+/// ```
+///
+/// The hook-measured fields are left at `0`/`None`; the caller fills them in.
+pub fn parse_brain_introspection_text(stdout: &str) -> Result<BrainIntrospectionReport, String> {
+    let mut brain_health: Vec<String> = Vec::new();
+    let mut patterns: Vec<String> = Vec::new();
+    let mut regressions: Vec<String> = Vec::new();
+    let mut prune_requested: usize = 0;
+    let mut consolidated_facts: u64 = 0;
+    let mut issue_url: Option<String> = None;
+
+    for line in stdout.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if let Some(v) = trimmed.strip_prefix("BRAIN_HEALTH:") {
+            let v = v.trim();
+            if !v.is_empty() {
+                brain_health.push(v.to_string());
+            }
+        } else if let Some(v) = trimmed.strip_prefix("PATTERN:") {
+            let v = v.trim();
+            if !v.is_empty() {
+                patterns.push(v.to_string());
+            }
+        } else if let Some(v) = trimmed.strip_prefix("REGRESSION:") {
+            let v = v.trim();
+            if !v.is_empty() {
+                regressions.push(v.to_string());
+            }
+        } else if trimmed.strip_prefix("PRUNE_CANDIDATE:").is_some() {
+            // Human-readable candidate description for the issue body; the count
+            // is carried by PRUNE_REQUESTED, so nothing to store here.
+        } else if let Some(v) = trimmed.strip_prefix("PRUNE_REQUESTED=") {
+            prune_requested = v
+                .trim()
+                .parse::<usize>()
+                .map_err(|e| format!("invalid PRUNE_REQUESTED value '{}': {e}", v.trim()))?;
+        } else if let Some(v) = trimmed.strip_prefix("CONSOLIDATED_FACTS=") {
+            // Advisory echo: the hook's measured delta is authoritative, so a
+            // malformed value is tolerated rather than failing the parse.
+            if let Ok(n) = v.trim().parse::<u64>() {
+                consolidated_facts = n;
+            }
+        } else if let Some(v) = trimmed.strip_prefix("ISSUE_URL=") {
+            let v = v.trim();
+            if !v.is_empty() {
+                issue_url = Some(v.to_string());
+            }
+        }
+        // Unknown lines are silently ignored (forward-compatible with LLM noise).
+    }
+
+    if brain_health.is_empty() {
+        return Err("missing required BRAIN_HEALTH line in recipe output".to_string());
+    }
+
+    Ok(BrainIntrospectionReport {
+        live_memories: 0,
+        sensory_pruned: 0,
+        consolidated_facts,
+        prune_requested,
+        brain_health,
+        patterns,
+        regressions,
+        issue_url,
+    })
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Recipe resolution + invocation
+// ───────────────────────────────────────────────────────────────────────────
+
+/// JSON envelope returned by `recipe-runner-rs --output-format json`.
+#[derive(Debug, Deserialize)]
+struct RecipeOutput {
+    success: bool,
+    step_results: Vec<StepResult>,
+}
+
+/// A single step's result inside the [`RecipeOutput`] envelope.
+#[derive(Debug, Deserialize)]
+struct StepResult {
+    #[allow(dead_code)] // Part of the JSON contract; not consumed by the hook.
+    step_id: String,
+    output: String,
+}
+
+/// Resolve the recipe YAML path. Checks, in order:
+///   1. `<home>/.simard/prompt_assets/simard/recipes/<name>` (hot-reload path)
+///   2. `<repo_root>/prompt_assets/simard/recipes/<name>` (in-tree)
+///
+/// `home_override` lets tests supply a fake home directory without mutating the
+/// process-wide `HOME`. Returns `None` if neither path exists.
+pub(crate) fn resolve_recipe_path(
+    repo_root: &Path,
+    home_override: Option<&Path>,
+) -> Option<PathBuf> {
+    let home = home_override.map(PathBuf::from).or_else(dirs::home_dir);
+    if let Some(home) = home {
+        let hot = home
+            .join(".simard")
+            .join("prompt_assets/simard/recipes")
+            .join(RECIPE_FILENAME);
+        if hot.is_file() {
+            return Some(hot);
+        }
+    }
+    let in_tree = repo_root
+        .join("prompt_assets/simard/recipes")
+        .join(RECIPE_FILENAME);
+    if in_tree.is_file() {
+        return Some(in_tree);
+    }
+    None
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    let mut chars = s.chars();
+    let prefix: String = chars.by_ref().take(max).collect();
+    if chars.next().is_some() {
+        prefix + "…"
+    } else {
+        prefix
+    }
+}
+
+fn record_metric_best_effort(name: &str, value: f64) {
+    if let Err(e) = crate::self_metrics::record_metric(name, value, ADAPTER_TAG) {
+        warn!("brain introspection: failed to record metric {name}: {e}");
+    }
+}
+
+/// Spawn the agentic `brain-introspection` recipe and parse its markers.
+///
+/// Returns `Err(SimardError::AdapterInvocationFailed)` on every failure mode
+/// (recipe missing, spawn failure, non-zero exit, bad JSON, missing markers);
+/// [`run_brain_introspection`] treats those as best-effort and degrades.
+fn run_agentic_recipe(
+    repo_root: &Path,
+    state_root: &Path,
+    home_override: Option<&Path>,
+    cap: usize,
+    baseline_runs: u32,
+    hygiene: &MemoryHygieneOutcome,
+) -> SimardResult<BrainIntrospectionReport> {
+    let recipe_path = resolve_recipe_path(repo_root, home_override).ok_or_else(|| {
+        SimardError::AdapterInvocationFailed {
+            base_type: ADAPTER_TAG.to_string(),
+            reason: format!(
+                "recipe file {RECIPE_FILENAME} not found in hot-reload or in-tree paths"
+            ),
+        }
+    })?;
+
+    let agent_binary = RuntimeConfig::load()?.llm_provider.agent_binary_value();
+    let stats_json = serde_json::to_string(hygiene).unwrap_or_else(|_| "{}".to_string());
+
+    let output = Command::new("recipe-runner-rs")
+        .arg(recipe_path.as_os_str())
+        .arg("--output-format")
+        .arg("json")
+        .env("AMPLIHACK_AGENT_BINARY", agent_binary)
+        .arg("-c")
+        .arg(format!("state_root={}", state_root.display()))
+        .arg("-c")
+        .arg(format!("repo_path={}", repo_root.display()))
+        .arg("-c")
+        .arg(format!("max_prune={cap}"))
+        .arg("-c")
+        .arg(format!("baseline_runs={baseline_runs}"))
+        .arg("-c")
+        .arg(format!("stats={stats_json}"))
+        .output()
+        .map_err(|e| SimardError::AdapterInvocationFailed {
+            base_type: ADAPTER_TAG.to_string(),
+            reason: format!("recipe-runner-rs spawn failed: {e}"),
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(SimardError::AdapterInvocationFailed {
+            base_type: ADAPTER_TAG.to_string(),
+            reason: format!(
+                "recipe exited with {}: {}",
+                output.status,
+                truncate(&stderr, 500)
+            ),
+        });
+    }
+
+    let envelope: RecipeOutput = serde_json::from_slice(&output.stdout).map_err(|e| {
+        SimardError::AdapterInvocationFailed {
+            base_type: ADAPTER_TAG.to_string(),
+            reason: format!("failed to deserialize recipe JSON output: {e}"),
+        }
+    })?;
+
+    if !envelope.success {
+        return Err(SimardError::AdapterInvocationFailed {
+            base_type: ADAPTER_TAG.to_string(),
+            reason: "recipe reported success=false in JSON output".to_string(),
+        });
+    }
+
+    if envelope.step_results.is_empty() {
+        return Err(SimardError::AdapterInvocationFailed {
+            base_type: ADAPTER_TAG.to_string(),
+            reason: "no step results in recipe JSON output".to_string(),
+        });
+    }
+
+    // Markers may be emitted across several steps, so parse the concatenation.
+    let combined = envelope
+        .step_results
+        .iter()
+        .map(|s| s.output.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    parse_brain_introspection_text(&combined).map_err(|e| SimardError::AdapterInvocationFailed {
+        base_type: ADAPTER_TAG.to_string(),
+        reason: format!("failed to parse recipe text output: {e}"),
+    })
+}
+
+/// Full periodic brain-introspection hook, called from the daemon loop.
+///
+/// Runs the deterministic, safe [`run_memory_hygiene`] core first (its memory
+/// RPC failures propagate), records baseline metrics, then spawns the agentic
+/// recipe **best-effort**: a recipe failure is logged at `WARN` and the run
+/// still returns the hygiene outcomes (the agentic layer must never block safe
+/// memory hygiene). The recipe's value-bearing prune recommendation count is
+/// clamped via [`enforce_prune_cap`].
+pub fn run_brain_introspection(
+    mem: &dyn CognitiveMemoryOps,
+    repo_root: &Path,
+    state_root: &Path,
+    home_override: Option<&Path>,
+) -> SimardResult<BrainIntrospectionReport> {
+    // Steps 1–3: deterministic, safe hygiene. Memory RPC failures propagate
+    // before any subprocess is spawned.
+    let hygiene = run_memory_hygiene(mem, CONSOLIDATE_BATCH)?;
+
+    record_metric_best_effort(
+        "brain_introspection_live_memories",
+        hygiene.live_memories as f64,
+    );
+    record_metric_best_effort(
+        "brain_introspection_sensory_pruned",
+        hygiene.sensory_pruned as f64,
+    );
+    record_metric_best_effort(
+        "brain_introspection_consolidated",
+        hygiene.consolidated_facts as f64,
+    );
+
+    let cap = max_prune_from_env(
+        std::env::var("SIMARD_BRAIN_INTROSPECTION_MAX_PRUNE")
+            .ok()
+            .as_deref(),
+    );
+    let baseline_runs = baseline_runs_from_env(
+        std::env::var("SIMARD_BRAIN_INTROSPECTION_BASELINE_RUNS")
+            .ok()
+            .as_deref(),
+    );
+
+    let mut report = BrainIntrospectionReport {
+        live_memories: hygiene.live_memories,
+        sensory_pruned: hygiene.sensory_pruned,
+        consolidated_facts: hygiene.consolidated_facts,
+        prune_requested: 0,
+        brain_health: Vec::new(),
+        patterns: Vec::new(),
+        regressions: Vec::new(),
+        issue_url: None,
+    };
+
+    // Steps 4–5: agentic recipe (best-effort). Any failure → WARN + graceful.
+    match run_agentic_recipe(
+        repo_root,
+        state_root,
+        home_override,
+        cap,
+        baseline_runs,
+        &hygiene,
+    ) {
+        Ok(parsed) => {
+            report.brain_health = parsed.brain_health;
+            report.patterns = parsed.patterns;
+            report.regressions = parsed.regressions;
+            report.prune_requested = enforce_prune_cap(parsed.prune_requested, cap);
+            report.issue_url = parsed.issue_url;
+            // `consolidated_facts` stays hook-measured (recipe marker advisory).
+        }
+        Err(e) => {
+            warn!("brain introspection: agentic recipe degraded (safe hygiene preserved): {e}");
+        }
+    }
+
+    record_metric_best_effort(
+        "brain_introspection_prune_requested",
+        report.prune_requested as f64,
+    );
+
+    Ok(report)
+}

--- a/src/brain_introspection_tests.rs
+++ b/src/brain_introspection_tests.rs
@@ -1,0 +1,798 @@
+//! TDD (RED) tests for the periodic **brain self-examination + memory hygiene**
+//! pass (issue #2419).
+//!
+//! Written **before** the production code. Expected to FAIL until
+//! `crate::brain_introspection` (the module), `prompt_assets/simard/recipes/
+//! brain-introspection.yaml`, and `prompt_assets/simard/brain_introspection.md`
+//! land. The unresolved-path / unresolved-import / missing-`include_str!`
+//! errors are the intended, deterministic RED signal under `cargo test`.
+//!
+//! `cargo build` / `cargo build --release` stay GREEN — this module is
+//! `#[cfg(test)]`, so the not-yet-existing references are never compiled into
+//! the library or the daemon binary (mirrors
+//! `memory_consolidation/promotion_scheduler_tests.rs`).
+//!
+//! ## Contract pinned by these tests
+//!
+//! The first increment is **SAFE: read + safe-consolidate + recommend**. The
+//! daemon-side Rust hook owns the verified, RPC-backed memory ops + the
+//! deterministic prune cap + metrics; the agentic recipe (a `recipe-runner-rs`
+//! subprocess) owns LLM judgment + the GitHub-issue output. Crucially:
+//!
+//!   * `prune_expired_sensory()` (already-expired transient rows) is
+//!     **non-discretionary TTL cleanup — NOT clamped by the cap**.
+//!   * `enforce_prune_cap` bounds ONLY the recipe's *value-bearing prune
+//!     recommendation* count (`-c max_prune`).
+//!   * `consolidate_episodes()` is additive distillation; the authoritative
+//!     `consolidated_facts` is the post−pre `(semantic+procedural)` stats delta
+//!     (the call returns `Option<String>`, not a count).
+//!   * NO destructive superseded/semantic deletes happen daemon-side
+//!     (`prune_superseded` over the IPC bridge is a `Ok(0)` no-op — calling it
+//!     would be a silent-degradation hazard, so the hook must not call it).
+//!
+//! ```ignore
+//! // crate::brain_introspection — surface under test
+//! pub const DEFAULT_INTERVAL_SECS: u64 = 86_400;
+//! pub const DEFAULT_MAX_PRUNE: usize = 25;
+//! pub const DEFAULT_BASELINE_RUNS: u32 = 7;
+//!
+//! pub fn interval_secs_from_env(raw: Option<&str>) -> u64;
+//! pub fn max_prune_from_env(raw: Option<&str>) -> usize;
+//! pub fn baseline_runs_from_env(raw: Option<&str>) -> u32;
+//! pub fn should_run_introspection(elapsed: Duration, interval_secs: u64) -> bool;
+//! pub fn enforce_prune_cap(requested: usize, cap: usize) -> usize;
+//!
+//! pub struct MemoryHygieneOutcome {
+//!     pub live_memories: u64, pub sensory_pruned: usize, pub consolidated_facts: u64,
+//! }
+//! pub fn run_memory_hygiene(mem: &dyn CognitiveMemoryOps, batch_size: u32)
+//!     -> SimardResult<MemoryHygieneOutcome>;
+//!
+//! pub struct BrainIntrospectionReport {
+//!     pub live_memories: u64, pub sensory_pruned: usize, pub consolidated_facts: u64,
+//!     pub prune_requested: usize, pub brain_health: Vec<String>,
+//!     pub patterns: Vec<String>, pub regressions: Vec<String>,
+//!     pub issue_url: Option<String>,
+//! }
+//! impl BrainIntrospectionReport { pub fn summary(&self) -> String; }
+//!
+//! pub fn parse_brain_introspection_text(stdout: &str)
+//!     -> Result<BrainIntrospectionReport, String>;
+//! pub(crate) fn resolve_recipe_path(repo_root: &Path, home_override: Option<&Path>)
+//!     -> Option<PathBuf>;
+//! pub fn run_brain_introspection(mem: &dyn CognitiveMemoryOps, repo_root: &Path,
+//!     state_root: &Path, home_override: Option<&Path>)
+//!     -> SimardResult<BrainIntrospectionReport>;
+//! ```
+
+#![allow(clippy::bool_assert_comparison)]
+
+use crate::brain_introspection::{
+    BrainIntrospectionReport, DEFAULT_BASELINE_RUNS, DEFAULT_INTERVAL_SECS, DEFAULT_MAX_PRUNE,
+    baseline_runs_from_env, enforce_prune_cap, interval_secs_from_env, max_prune_from_env,
+    parse_brain_introspection_text, resolve_recipe_path, run_brain_introspection,
+    run_memory_hygiene, should_run_introspection,
+};
+use crate::cognitive_memory::CognitiveMemoryOps;
+use crate::error::SimardResult;
+use crate::memory_cognitive::{
+    CognitiveFact, CognitiveProcedure, CognitiveProspective, CognitiveStatistics,
+    CognitiveWorkingSlot,
+};
+use crate::ooda_brain::prompt_store::embedded_fallback;
+
+use std::path::Path;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::time::Duration;
+
+const RECIPE_FILENAME: &str = "brain-introspection.yaml";
+const PROMPT_NAME: &str = "brain_introspection.md";
+
+// ───────────────────────────────────────────────────────────────────────────
+// Stub CognitiveMemoryOps — instruments the safe memory-hygiene ops.
+//
+// `get_statistics` returns a live, mutating snapshot so that a read BEFORE and
+// AFTER `consolidate_episodes` yields the post−pre fact delta. `prune_superseded`
+// is overridden purely to assert the hook NEVER calls it (no destructive
+// value-prune daemon-side).
+// ───────────────────────────────────────────────────────────────────────────
+struct HygieneStub {
+    stats: Mutex<CognitiveStatistics>,
+    /// Facts the (additive) distillation pass adds per `consolidate_episodes`.
+    facts_added_per_consolidate: u64,
+    /// Expired transient rows `prune_expired_sensory` removes (uncapped).
+    sensory_to_prune: usize,
+    sensory_prune_calls: AtomicU32,
+    consolidate_calls: AtomicU32,
+    stats_reads: AtomicU32,
+    /// Set true iff the destructive superseded-prune was (wrongly) invoked.
+    superseded_prune_called: AtomicBool,
+}
+
+impl HygieneStub {
+    fn new(stats: CognitiveStatistics, facts_added: u64, sensory_to_prune: usize) -> Self {
+        Self {
+            stats: Mutex::new(stats),
+            facts_added_per_consolidate: facts_added,
+            sensory_to_prune,
+            sensory_prune_calls: AtomicU32::new(0),
+            consolidate_calls: AtomicU32::new(0),
+            stats_reads: AtomicU32::new(0),
+            superseded_prune_called: AtomicBool::new(false),
+        }
+    }
+}
+
+impl CognitiveMemoryOps for HygieneStub {
+    fn record_sensory(&self, _m: &str, _r: &str, _t: u64) -> SimardResult<String> {
+        Ok("sen_x".to_string())
+    }
+
+    fn prune_expired_sensory(&self) -> SimardResult<usize> {
+        self.sensory_prune_calls.fetch_add(1, Ordering::SeqCst);
+        let mut s = self.stats.lock().unwrap();
+        let pruned = self.sensory_to_prune.min(s.sensory_count as usize);
+        s.sensory_count -= pruned as u64;
+        Ok(pruned)
+    }
+
+    fn push_working(&self, _s: &str, _c: &str, _t: &str, _r: f64) -> SimardResult<String> {
+        Ok("wrk_x".to_string())
+    }
+
+    fn get_working(&self, _t: &str) -> SimardResult<Vec<CognitiveWorkingSlot>> {
+        Ok(vec![])
+    }
+
+    fn clear_working(&self, _t: &str) -> SimardResult<usize> {
+        Ok(0)
+    }
+
+    fn store_episode(
+        &self,
+        _c: &str,
+        _s: &str,
+        _m: Option<&serde_json::Value>,
+    ) -> SimardResult<String> {
+        Ok("epi_x".to_string())
+    }
+
+    fn consolidate_episodes(&self, _b: u32) -> SimardResult<Option<String>> {
+        self.consolidate_calls.fetch_add(1, Ordering::SeqCst);
+        let mut s = self.stats.lock().unwrap();
+        // Additive distillation: episodic -> semantic. Episodic shrinks by the
+        // number distilled, semantic grows. Never a lossy delete.
+        let moved = self.facts_added_per_consolidate.min(s.episodic_count);
+        s.episodic_count -= moved;
+        s.semantic_count += self.facts_added_per_consolidate;
+        Ok(Some("distilled-batch".to_string()))
+    }
+
+    fn store_fact(
+        &self,
+        _concept: &str,
+        _content: &str,
+        _confidence: f64,
+        _tags: &[String],
+        _source_id: &str,
+    ) -> SimardResult<String> {
+        Ok("sem_x".to_string())
+    }
+
+    fn search_facts(&self, _q: &str, _l: u32, _c: f64) -> SimardResult<Vec<CognitiveFact>> {
+        Ok(vec![])
+    }
+
+    fn store_procedure(&self, _n: &str, _s: &[String], _p: &[String]) -> SimardResult<String> {
+        Ok("prc_x".to_string())
+    }
+
+    fn recall_procedure(&self, _q: &str, _l: u32) -> SimardResult<Vec<CognitiveProcedure>> {
+        Ok(vec![])
+    }
+
+    fn store_prospective(&self, _d: &str, _t: &str, _a: &str, _p: i64) -> SimardResult<String> {
+        Ok("pro_x".to_string())
+    }
+
+    fn check_triggers(&self, _c: &str) -> SimardResult<Vec<CognitiveProspective>> {
+        Ok(vec![])
+    }
+
+    fn get_statistics(&self) -> SimardResult<CognitiveStatistics> {
+        self.stats_reads.fetch_add(1, Ordering::SeqCst);
+        Ok(self.stats.lock().unwrap().clone())
+    }
+
+    // SAFETY assertion seam: the first increment must NOT call this over the
+    // daemon's IPC bridge (it is a `Ok(0)` no-op there — a silent-degradation
+    // hazard). Any call flips the flag and the `no_destructive_value_prune`
+    // test fails.
+    fn prune_superseded(&self) -> SimardResult<usize> {
+        self.superseded_prune_called.store(true, Ordering::SeqCst);
+        Ok(0)
+    }
+}
+
+fn stats(
+    sensory: u64,
+    working: u64,
+    episodic: u64,
+    semantic: u64,
+    procedural: u64,
+    prospective: u64,
+) -> CognitiveStatistics {
+    CognitiveStatistics {
+        sensory_count: sensory,
+        working_count: working,
+        episodic_count: episodic,
+        semantic_count: semantic,
+        procedural_count: procedural,
+        prospective_count: prospective,
+    }
+}
+
+// ===========================================================================
+// 1. Config knobs — env parsing + defaults
+// ===========================================================================
+
+#[test]
+fn defaults_match_design_contract() {
+    assert_eq!(DEFAULT_INTERVAL_SECS, 86_400, "cadence defaults to 24h");
+    assert_eq!(DEFAULT_MAX_PRUNE, 25, "prune cap defaults to 25");
+    assert_eq!(
+        DEFAULT_BASELINE_RUNS, 7,
+        "baseline window defaults to 7 runs"
+    );
+}
+
+#[test]
+fn interval_secs_unset_uses_default() {
+    assert_eq!(interval_secs_from_env(None), DEFAULT_INTERVAL_SECS);
+}
+
+#[test]
+fn interval_secs_parses_valid_value() {
+    assert_eq!(interval_secs_from_env(Some("3600")), 3600);
+}
+
+#[test]
+fn interval_secs_zero_is_honored_as_disabled_value() {
+    // 0 is a *valid* parse (means "disabled"); it must NOT fall back to default.
+    assert_eq!(interval_secs_from_env(Some("0")), 0);
+}
+
+#[test]
+fn interval_secs_garbage_falls_back_to_default() {
+    assert_eq!(
+        interval_secs_from_env(Some("not-a-number")),
+        DEFAULT_INTERVAL_SECS
+    );
+    assert_eq!(interval_secs_from_env(Some("")), DEFAULT_INTERVAL_SECS);
+}
+
+#[test]
+fn max_prune_env_parsing() {
+    assert_eq!(max_prune_from_env(None), DEFAULT_MAX_PRUNE);
+    assert_eq!(max_prune_from_env(Some("10")), 10);
+    assert_eq!(max_prune_from_env(Some("0")), 0);
+    assert_eq!(max_prune_from_env(Some("bogus")), DEFAULT_MAX_PRUNE);
+}
+
+#[test]
+fn baseline_runs_env_parsing() {
+    assert_eq!(baseline_runs_from_env(None), DEFAULT_BASELINE_RUNS);
+    assert_eq!(baseline_runs_from_env(Some("3")), 3);
+    assert_eq!(baseline_runs_from_env(Some("bogus")), DEFAULT_BASELINE_RUNS);
+}
+
+// ===========================================================================
+// 2. Daemon interval gating — 0 disables; elapsed >= interval triggers
+// ===========================================================================
+
+#[test]
+fn gating_disabled_when_interval_zero() {
+    // Disabled regardless of how much time has elapsed.
+    assert_eq!(
+        should_run_introspection(Duration::from_secs(10_000_000), 0),
+        false,
+        "interval 0 must disable the pass entirely"
+    );
+}
+
+#[test]
+fn gating_triggers_when_elapsed_reaches_interval() {
+    assert_eq!(
+        should_run_introspection(Duration::from_secs(86_400), 86_400),
+        true
+    );
+    assert_eq!(
+        should_run_introspection(Duration::from_secs(90_000), 86_400),
+        true
+    );
+}
+
+#[test]
+fn gating_holds_when_not_yet_elapsed() {
+    assert_eq!(
+        should_run_introspection(Duration::from_secs(100), 86_400),
+        false
+    );
+}
+
+// ===========================================================================
+// 3. enforce_prune_cap — bounds the recipe's value-bearing recommendation count
+// ===========================================================================
+
+#[test]
+fn cap_passes_through_when_below_cap() {
+    assert_eq!(enforce_prune_cap(3, 25), 3);
+}
+
+#[test]
+fn cap_allows_exactly_cap() {
+    assert_eq!(enforce_prune_cap(25, 25), 25);
+}
+
+#[test]
+fn cap_clamps_when_above_cap() {
+    assert_eq!(enforce_prune_cap(100, 25), 25);
+}
+
+#[test]
+fn cap_zero_yields_zero_recommendations() {
+    // cap=0 => no value-bearing prune recommendations are honored.
+    assert_eq!(enforce_prune_cap(50, 0), 0);
+}
+
+#[test]
+fn cap_never_exceeds_cap_or_request_property() {
+    for requested in 0usize..200 {
+        for cap in 0usize..50 {
+            let got = enforce_prune_cap(requested, cap);
+            assert!(got <= cap, "result {got} must not exceed cap {cap}");
+            assert!(
+                got <= requested,
+                "result {got} must not exceed request {requested}"
+            );
+        }
+    }
+}
+
+// ===========================================================================
+// 4. parse_brain_introspection_text — recipe marker grammar
+// ===========================================================================
+
+#[test]
+fn parse_happy_full_marker_set() {
+    let text = "\
+BRAIN_HEALTH: record_fallback rate 2.0% (baseline 1.8%)
+BRAIN_HEALTH: brain_lifecycle_decision parse-failure rate 0.5%
+PATTERN: ci-fix goals consistently land; refactor goals stall
+PATTERN: repeated `gh pr merge` permission errors
+REGRESSION: 0-succeeded-action cycles up from 1 to 4
+PRUNE_REQUESTED=12
+CONSOLIDATED_FACTS=4
+ISSUE_URL=https://github.com/rysweet/Simard/issues/9999
+";
+    let report = parse_brain_introspection_text(text).expect("valid marker set must parse");
+    assert_eq!(report.brain_health.len(), 2);
+    assert!(report.brain_health[0].contains("record_fallback"));
+    assert_eq!(report.patterns.len(), 2);
+    assert_eq!(report.regressions.len(), 1);
+    assert_eq!(report.prune_requested, 12);
+    assert_eq!(
+        report.issue_url.as_deref(),
+        Some("https://github.com/rysweet/Simard/issues/9999")
+    );
+}
+
+#[test]
+fn parse_requires_at_least_one_brain_health_line() {
+    let text = "PATTERN: something\nPRUNE_REQUESTED=0\n";
+    let err = parse_brain_introspection_text(text).expect_err("missing BRAIN_HEALTH must error");
+    assert!(
+        err.to_lowercase().contains("brain_health"),
+        "error should name the missing required marker, got: {err}"
+    );
+}
+
+#[test]
+fn parse_empty_is_error() {
+    assert!(parse_brain_introspection_text("").is_err());
+}
+
+#[test]
+fn parse_ignores_unknown_lines_forward_compat() {
+    let text = "\
+SOME_FUTURE_MARKER=whatever
+BRAIN_HEALTH: ok
+RANDOM noise line
+PRUNE_REQUESTED=3
+";
+    let report = parse_brain_introspection_text(text).unwrap();
+    assert_eq!(report.brain_health.len(), 1);
+    assert_eq!(report.prune_requested, 3);
+}
+
+#[test]
+fn parse_prune_requested_defaults_to_zero_when_absent() {
+    let report = parse_brain_introspection_text("BRAIN_HEALTH: ok\n").unwrap();
+    assert_eq!(report.prune_requested, 0);
+    assert!(report.issue_url.is_none());
+    assert!(report.patterns.is_empty());
+    assert!(report.regressions.is_empty());
+}
+
+#[test]
+fn parse_handles_whitespace_around_values() {
+    let text = "  BRAIN_HEALTH:  trimmed health  \n  PRUNE_REQUESTED= 7 \n";
+    let report = parse_brain_introspection_text(text).unwrap();
+    assert_eq!(report.brain_health, vec!["trimmed health".to_string()]);
+    assert_eq!(report.prune_requested, 7);
+}
+
+#[test]
+fn parse_invalid_prune_requested_is_error() {
+    let text = "BRAIN_HEALTH: ok\nPRUNE_REQUESTED=lots\n";
+    assert!(parse_brain_introspection_text(text).is_err());
+}
+
+// ===========================================================================
+// 5. BrainIntrospectionReport::summary — one-line daemon log
+// ===========================================================================
+
+#[test]
+fn summary_mentions_key_counts() {
+    let report = BrainIntrospectionReport {
+        live_memories: 142,
+        sensory_pruned: 9,
+        consolidated_facts: 4,
+        prune_requested: 12,
+        brain_health: vec!["ok".to_string()],
+        patterns: vec!["p".to_string()],
+        regressions: vec![],
+        issue_url: Some("https://github.com/rysweet/Simard/issues/1".to_string()),
+    };
+    let s = report.summary();
+    assert!(
+        s.contains("142"),
+        "summary should report live memory count: {s}"
+    );
+    assert!(
+        s.to_lowercase().contains("sensory"),
+        "summary should mention sensory prune: {s}"
+    );
+    assert!(
+        s.to_lowercase().contains("consolidat"),
+        "summary should mention consolidation: {s}"
+    );
+}
+
+// ===========================================================================
+// 6. resolve_recipe_path — hot-reload vs in-tree (home_override)
+// ===========================================================================
+
+#[test]
+fn resolve_recipe_path_none_when_absent() {
+    let home = tempfile::tempdir().unwrap();
+    assert!(resolve_recipe_path(Path::new("/nonexistent/repo"), Some(home.path())).is_none());
+}
+
+#[test]
+fn resolve_recipe_path_finds_in_tree() {
+    let tmp = tempfile::tempdir().unwrap();
+    let recipe_dir = tmp.path().join("prompt_assets/simard/recipes");
+    std::fs::create_dir_all(&recipe_dir).unwrap();
+    std::fs::write(
+        recipe_dir.join(RECIPE_FILENAME),
+        "name: brain-introspection",
+    )
+    .unwrap();
+
+    // home_override points at an EMPTY home so the hot-reload path misses and
+    // resolution falls through to the in-tree copy.
+    let empty_home = tempfile::tempdir().unwrap();
+    let resolved = resolve_recipe_path(tmp.path(), Some(empty_home.path()))
+        .expect("in-tree recipe must resolve");
+    assert!(resolved.ends_with(RECIPE_FILENAME));
+}
+
+#[test]
+fn resolve_recipe_path_prefers_hot_reload_over_in_tree() {
+    // Both present -> hot-reload (~/.simard/...) wins.
+    let home = tempfile::tempdir().unwrap();
+    let hot_dir = home.path().join(".simard/prompt_assets/simard/recipes");
+    std::fs::create_dir_all(&hot_dir).unwrap();
+    std::fs::write(hot_dir.join(RECIPE_FILENAME), "name: hot").unwrap();
+
+    let repo = tempfile::tempdir().unwrap();
+    let in_tree_dir = repo.path().join("prompt_assets/simard/recipes");
+    std::fs::create_dir_all(&in_tree_dir).unwrap();
+    std::fs::write(in_tree_dir.join(RECIPE_FILENAME), "name: in-tree").unwrap();
+
+    let resolved = resolve_recipe_path(repo.path(), Some(home.path())).unwrap();
+    assert!(
+        resolved.starts_with(home.path()),
+        "hot-reload path under HOME must take precedence: {resolved:?}"
+    );
+}
+
+// ===========================================================================
+// 7. run_memory_hygiene — the SAFE, RPC-backed core (deterministic, no subprocess)
+// ===========================================================================
+
+#[test]
+fn hygiene_reads_stats_prunes_sensory_and_measures_consolidation_delta() {
+    // sensory=1000, working=2, episodic=10, semantic=5, procedural=3, prospective=1
+    // distillation adds 4 semantic facts; ALL 1000 expired sensory rows pruned.
+    let stub = HygieneStub::new(stats(1000, 2, 10, 5, 3, 1), 4, 1000);
+
+    let outcome = run_memory_hygiene(&stub, 50).expect("hygiene must succeed on a healthy stub");
+
+    // Stats were read at least twice (pre + post) to compute the delta.
+    assert!(
+        stub.stats_reads.load(Ordering::SeqCst) >= 2,
+        "must read statistics before AND after consolidation"
+    );
+    // Distillation ran exactly once (the higher-level pass invokes it once).
+    assert_eq!(stub.consolidate_calls.load(Ordering::SeqCst), 1);
+
+    // consolidated_facts = post(semantic+procedural) - pre(semantic+procedural)
+    //                    = (9+3) - (5+3) = 4
+    assert_eq!(
+        outcome.consolidated_facts, 4,
+        "consolidated_facts must be the measured (semantic+procedural) delta, not a marker echo"
+    );
+
+    // live_memories excludes sensory: 2 + 10 + 9 + 3 + 1 = 25
+    assert_eq!(
+        outcome.live_memories, 25,
+        "live_memories must be the non-sensory modality sum (post-state)"
+    );
+}
+
+#[test]
+fn hygiene_sensory_prune_is_unbounded_by_cap() {
+    // 1000 expired sensory rows is FAR above DEFAULT_MAX_PRUNE (25). Past-TTL
+    // cleanup is non-discretionary and must NOT be clamped by the prune cap.
+    let stub = HygieneStub::new(stats(1000, 0, 0, 0, 0, 0), 0, 1000);
+    let outcome = run_memory_hygiene(&stub, 50).unwrap();
+    assert_eq!(
+        outcome.sensory_pruned, 1000,
+        "expired-sensory cleanup must run uncapped (no enforce_prune_cap applied)"
+    );
+    assert!(
+        outcome.sensory_pruned > DEFAULT_MAX_PRUNE,
+        "test must demonstrate sensory prune exceeding the cap"
+    );
+}
+
+#[test]
+fn hygiene_performs_no_destructive_value_prune() {
+    // The first increment must never call the destructive superseded-prune
+    // daemon-side (it is a no-op over the IPC bridge — a silent-degradation
+    // hazard). Value-bearing pruning is recommendation-only via the recipe.
+    let stub = HygieneStub::new(stats(10, 1, 5, 5, 2, 0), 1, 5);
+    let _ = run_memory_hygiene(&stub, 50).unwrap();
+    assert_eq!(
+        stub.superseded_prune_called.load(Ordering::SeqCst),
+        false,
+        "run_memory_hygiene must NOT call prune_superseded (no destructive daemon-side delete)"
+    );
+}
+
+#[test]
+fn hygiene_consolidation_is_additive_not_lossy() {
+    // Distillation moves episodic -> semantic; the live (non-sensory) total must
+    // not shrink as a result of consolidation alone.
+    let before = stats(0, 0, 20, 0, 0, 0);
+    let before_live = before.working_count
+        + before.episodic_count
+        + before.semantic_count
+        + before.procedural_count
+        + before.prospective_count;
+    let stub = HygieneStub::new(before, 6, 0);
+    let outcome = run_memory_hygiene(&stub, 50).unwrap();
+    assert!(
+        outcome.live_memories >= before_live,
+        "additive distillation must not reduce live memory count: {} < {}",
+        outcome.live_memories,
+        before_live
+    );
+}
+
+// ===========================================================================
+// 8. run_brain_introspection — full hook, agentic layer best-effort (graceful)
+// ===========================================================================
+
+#[test]
+fn run_is_graceful_when_recipe_not_found() {
+    // No recipe on disk -> the deterministic hygiene pass STILL runs and the
+    // hook returns Ok (the agentic layer is best-effort; its absence must not
+    // block safe memory hygiene). issue_url is None (recipe never ran).
+    let stub = HygieneStub::new(stats(500, 1, 10, 4, 2, 0), 3, 500);
+    let empty_home = tempfile::tempdir().unwrap();
+
+    let report = run_brain_introspection(
+        &stub,
+        Path::new("/nonexistent/repo"),
+        Path::new("/nonexistent/state"),
+        Some(empty_home.path()),
+    )
+    .expect("missing recipe must degrade gracefully, not error");
+
+    assert_eq!(stub.sensory_prune_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(report.sensory_pruned, 500);
+    assert_eq!(report.consolidated_facts, 3);
+    assert_eq!(report.live_memories, 1 + 10 + 7 + 2); // working+episodic+(4+3)+prospective
+    assert!(
+        report.issue_url.is_none(),
+        "no issue when the recipe never ran"
+    );
+}
+
+#[test]
+#[serial_test::serial(cognitive_memory)]
+fn run_is_graceful_when_recipe_runner_unavailable() {
+    // Recipe resolves (temp in-tree copy) but `recipe-runner-rs` is missing OR
+    // rejects the deliberately-invalid recipe. Either way the agentic step fails
+    // and the hook must WARN + still return Ok with the hygiene outcomes filled.
+    let repo = tempfile::tempdir().unwrap();
+    let recipe_dir = repo.path().join("prompt_assets/simard/recipes");
+    std::fs::create_dir_all(&recipe_dir).unwrap();
+    std::fs::write(recipe_dir.join(RECIPE_FILENAME), "name: test").unwrap();
+
+    let empty_home = tempfile::tempdir().unwrap();
+    let state = tempfile::tempdir().unwrap();
+    let stub = HygieneStub::new(stats(300, 0, 8, 2, 1, 0), 2, 300);
+
+    let report = run_brain_introspection(&stub, repo.path(), state.path(), Some(empty_home.path()))
+        .expect("a failed agentic recipe must degrade gracefully");
+
+    // The safe, deterministic hygiene ran regardless of the agentic failure.
+    assert_eq!(report.sensory_pruned, 300);
+    assert_eq!(report.consolidated_facts, 2);
+    assert!(report.issue_url.is_none());
+    // And no destructive value-prune happened on this path either.
+    assert_eq!(stub.superseded_prune_called.load(Ordering::SeqCst), false);
+}
+
+// ===========================================================================
+// 9. Prompt content-pin — embedded_fallback must register the standing prompt
+// ===========================================================================
+
+#[test]
+fn prompt_has_embedded_fallback() {
+    assert!(
+        embedded_fallback(PROMPT_NAME).is_some(),
+        "prompt_store::embedded_fallback must register {PROMPT_NAME}"
+    );
+}
+
+#[test]
+fn prompt_fallback_is_nonempty() {
+    let content = embedded_fallback(PROMPT_NAME).expect("prompt must be registered");
+    assert!(
+        !content.trim().is_empty(),
+        "embedded prompt must not be empty"
+    );
+}
+
+#[test]
+fn prompt_covers_the_five_introspection_phases() {
+    let content = embedded_fallback(PROMPT_NAME)
+        .expect("prompt must be registered")
+        .to_lowercase();
+    assert!(
+        content.contains("brain health") || content.contains("brain-health"),
+        "prompt must describe the BRAIN HEALTH phase"
+    );
+    assert!(
+        content.contains("pattern"),
+        "prompt must describe the PATTERNS phase"
+    );
+    // Safe, BOUNDED pruning (recommendation-only in the first increment).
+    assert!(content.contains("prune"), "prompt must describe pruning");
+    assert!(
+        content.contains("bound") || content.contains("cap") || content.contains("safe"),
+        "prompt must stress SAFE/BOUNDED pruning"
+    );
+    assert!(
+        content.contains("consolidat") || content.contains("distill"),
+        "prompt must describe the CONSOLIDATE phase"
+    );
+    assert!(
+        content.contains("issue"),
+        "prompt must route findings to a GitHub issue (no snapshot doc)"
+    );
+}
+
+#[test]
+fn prompt_forbids_snapshot_doc_output() {
+    // Per the no-point-in-time-docs rule, output goes to an issue/metrics, not a
+    // committed snapshot markdown file.
+    let content = embedded_fallback(PROMPT_NAME)
+        .expect("prompt must be registered")
+        .to_lowercase();
+    assert!(
+        content.contains("issue") || content.contains("metric"),
+        "prompt must direct output to an issue and/or metrics"
+    );
+}
+
+// ===========================================================================
+// 10. Recipe YAML content-pin — runtime recipe mirrors the prompt's contract
+//
+// `include_str!` of a not-yet-existing file is a COMPILE error: that is the
+// intended RED until the recipe asset lands.
+// ===========================================================================
+
+const RECIPE_YAML: &str = include_str!("../prompt_assets/simard/recipes/brain-introspection.yaml");
+
+#[test]
+fn recipe_yaml_is_nonempty() {
+    assert!(
+        !RECIPE_YAML.trim().is_empty(),
+        "recipe yaml must not be empty"
+    );
+}
+
+#[test]
+fn recipe_yaml_covers_all_phases_and_markers() {
+    let lower = RECIPE_YAML.to_lowercase();
+    // Phases.
+    assert!(
+        lower.contains("brain") && lower.contains("health"),
+        "recipe must include the brain-health step"
+    );
+    assert!(
+        lower.contains("pattern"),
+        "recipe must include the pattern-mining step"
+    );
+    assert!(
+        lower.contains("prune"),
+        "recipe must include the prune-recommendation step"
+    );
+    assert!(
+        lower.contains("consolidat") || lower.contains("distill"),
+        "recipe must reference consolidation/distillation"
+    );
+    // Output contract markers the Rust parser consumes.
+    assert!(
+        RECIPE_YAML.contains("BRAIN_HEALTH"),
+        "recipe must emit the required BRAIN_HEALTH marker"
+    );
+    assert!(
+        RECIPE_YAML.contains("PRUNE_REQUESTED"),
+        "recipe must emit the PRUNE_REQUESTED count marker"
+    );
+    assert!(
+        RECIPE_YAML.contains("ISSUE_URL"),
+        "recipe must emit the ISSUE_URL marker"
+    );
+}
+
+#[test]
+fn recipe_yaml_writes_to_github_issue_with_dedup_label() {
+    let lower = RECIPE_YAML.to_lowercase();
+    assert!(
+        lower.contains("gh issue") || (lower.contains("gh ") && lower.contains("issue")),
+        "output step must create/update a GitHub issue via gh"
+    );
+    assert!(
+        lower.contains("brain-introspection"),
+        "recipe must use a stable `brain-introspection` label for issue dedup"
+    );
+}
+
+#[test]
+fn recipe_yaml_passes_through_prune_cap_context() {
+    // The Rust hook supplies `-c max_prune=<cap>`; the recipe must thread it so
+    // recommendations stay bounded.
+    assert!(
+        RECIPE_YAML.contains("max_prune"),
+        "recipe must consume the max_prune cap context var"
+    );
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,13 @@ pub mod cmd_ensure_deps;
 pub mod cmd_install;
 pub mod cmd_self_update;
 pub mod cognitive_memory;
+// Issue #2419: periodic brain self-examination + memory-hygiene pass — a
+// higher-level introspection layer that reuses the existing distillation /
+// statistics / expired-sensory infra (mirrors `disk_health`). Tests live in a
+// `#[cfg(test)]` sibling so release/debug builds never compile them.
+pub mod brain_introspection;
+#[cfg(test)]
+mod brain_introspection_tests;
 mod copilot_status_probe;
 mod copilot_task_submit;
 pub mod cost_tracking;

--- a/src/ooda_brain/prompt_store.rs
+++ b/src/ooda_brain/prompt_store.rs
@@ -69,6 +69,8 @@ const EMBEDDED_GOAL_SESSION_OBJECTIVE: &str =
     include_str!("../../prompt_assets/simard/goal_session_objective.md");
 const EMBEDDED_GOAL_DECOMPOSITION: &str =
     include_str!("../../prompt_assets/simard/goal_decomposition.md");
+const EMBEDDED_BRAIN_INTROSPECTION: &str =
+    include_str!("../../prompt_assets/simard/brain_introspection.md");
 
 /// Look up the embedded fallback for a known prompt name. Returns `None` for
 /// unknown names so callers can surface a configuration error rather than
@@ -82,6 +84,7 @@ pub fn embedded_fallback(name: &str) -> Option<&'static str> {
         "progress_assessment_reviewer.md" => Some(EMBEDDED_PROGRESS_REVIEWER),
         "goal_session_objective.md" => Some(EMBEDDED_GOAL_SESSION_OBJECTIVE),
         "goal_decomposition.md" => Some(EMBEDDED_GOAL_DECOMPOSITION),
+        "brain_introspection.md" => Some(EMBEDDED_BRAIN_INTROSPECTION),
         _ => None,
     }
 }

--- a/src/operator_commands_ooda/daemon/mod.rs
+++ b/src/operator_commands_ooda/daemon/mod.rs
@@ -390,6 +390,23 @@ pub fn run_ooda_daemon(
     );
     // -------------------------------------------------------------------
 
+    // --- periodic brain introspection + memory hygiene state (issue #2419) ---
+    let brain_introspection_interval_secs: u64 = crate::brain_introspection::interval_secs_from_env(
+        std::env::var("SIMARD_BRAIN_INTROSPECTION_INTERVAL_SECS")
+            .ok()
+            .as_deref(),
+    );
+    // NOT back-dated like disk-health: the first introspection runs one full
+    // interval after start (nothing useful to say at t=0; baseline is empty).
+    let mut last_brain_introspection = Instant::now();
+    daemon_log(
+        &state_root,
+        &format!(
+            "[simard] OODA daemon: brain introspection interval = {brain_introspection_interval_secs}s"
+        ),
+    );
+    // -------------------------------------------------------------------
+
     let mut cycles_run = 0u32;
 
     loop {
@@ -530,6 +547,34 @@ pub fn run_ooda_daemon(
                 }
             }
             last_worktree_sweep = Instant::now();
+        }
+        // -------------------------------------------------------------------
+
+        // ── Periodic brain introspection + memory hygiene (issue #2419) ──
+        // Higher-level self-examination pass: safe RPC-backed memory hygiene
+        // (expired-sensory prune + additive consolidation) plus an agentic
+        // recipe that surfaces brain-health/patterns, recommends bounded prunes,
+        // and writes findings to a dedup'd GitHub issue. Best-effort: a recipe
+        // failure WARNs and the safe hygiene still ran.
+        if crate::brain_introspection::should_run_introspection(
+            last_brain_introspection.elapsed(),
+            brain_introspection_interval_secs,
+        ) {
+            match crate::brain_introspection::run_brain_introspection(
+                &*bridges.memory,
+                &bridges.repo_root,
+                &state_root,
+                None,
+            ) {
+                Ok(report) => {
+                    daemon_log(&state_root, &format!("[simard] {}", report.summary()));
+                }
+                Err(e) => daemon_log(
+                    &state_root,
+                    &format!("[simard] WARN: brain introspection failed: {e}"),
+                ),
+            }
+            last_brain_introspection = Instant::now();
         }
         // -------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Closes #2419. Adds a standing, env-gated **periodic brain self-examination + memory-hygiene** pass: every cadence (default 24h) Simard steps back, examines her own OODA brain decision quality, mines recurring patterns, safely consolidates + bounded-prunes memory, and writes findings to a dedup'd GitHub issue. It is wired as a **daemon interval task** that mirrors the existing disk-health / worktree-sweep pattern and **reuses** (does not duplicate) the existing distillation / statistics / expired-sensory infrastructure.

## Cadence decision (the INVESTIGATE-FIRST question)

Implemented as a **periodic daemon task on its own interval** (`SIMARD_BRAIN_INTROSPECTION_INTERVAL_SECS`), dispatching the `brain-introspection` recipe rather than inlining logic in Rust. This best matches "runs REGULARLY", reuses a proven scheduling hook, keeps the Rust surface minimal/testable, and lets the brain do the introspective reasoning via the prompt. The first run fires one full interval after daemon start (empty baseline at t=0).

## Split of labor

| Layer | Owns |
| ----- | ---- |
| **Rust hook** (`run_memory_hygiene` / `run_brain_introspection`) | verified RPC-backed memory ops (`get_statistics`, `prune_expired_sensory`, `consolidate_episodes`), the deterministic prune cap, metric writes |
| **Recipe** (`recipe-runner-rs` subprocess) | LLM judgment — brain-health, patterns, prune candidates — and the GitHub-issue output |

## Safety model (first, SAFE increment: read + safe-consolidate + recommend)

- The only daemon-side deletion is `prune_expired_sensory` (already-expired transient rows; non-discretionary TTL cleanup — **exempt from the cap**).
- Consolidation is **additive** distillation; never lossy.
- Value-bearing pruning is **recommendation-only** (capped `PRUNE_CANDIDATE` lines), bounded by `enforce_prune_cap` (default 25, absolute).
- The hook **never** calls `prune_superseded` daemon-side: over the IPC bridge it is an `Ok(0)` no-op, so calling it would be a silent-degradation hazard. Backed-up, bounded destructive prune is a documented follow-up.
- The agentic layer is **best-effort**: a recipe failure WARNs and the safe hygiene still runs (graceful degradation).

## What's in this PR

- **`src/brain_introspection.rs`** — env knobs + defaults, interval gate (`should_run_introspection`), `enforce_prune_cap`, `run_memory_hygiene`, `BrainIntrospectionReport` + marker parser, hot-reload→in-tree recipe resolution, and the best-effort `run_brain_introspection` hook.
- **`prompt_assets/simard/recipes/brain-introspection.yaml`** + **`prompt_assets/simard/brain_introspection.md`** — the five-phase agentic pass (BRAIN HEALTH → PATTERNS → safe bounded PRUNE → CONSOLIDATE → ISSUE output) with a content-pinned marker contract; prompt registered in `ooda_brain::prompt_store` embedded fallbacks.
- **Daemon wiring** in `operator_commands_ooda/daemon/mod.rs` (interval state + loop hook).
- **Durable docs only** (no snapshot doc): reference / architecture / how-to pages, un-hidden in `mkdocs.yml` nav.

## Configuration knobs

| Env var | Default | Purpose |
| ------- | ------: | ------- |
| `SIMARD_BRAIN_INTROSPECTION_INTERVAL_SECS` | `86400` | Cadence; `0` disables |
| `SIMARD_BRAIN_INTROSPECTION_MAX_PRUNE` | `25` | Absolute ceiling on value-bearing prune recommendations per run |
| `SIMARD_BRAIN_INTROSPECTION_BASELINE_RUNS` | `7` | Rolling regression baseline window |

## Acceptance criteria

- ✅ New brain-introspection recipe/prompt wired to run on a cadence, reusing existing distillation/metrics/prune infra (no per-cycle distill duplication).
- ✅ One run produces a brain-health summary, detected patterns, a SAFE bounded prune (recommendation-only this increment), a consolidation pass, and an actionable GitHub-issue/metric output (no snapshot doc).
- ✅ Tests cover the scheduling hook + the safe-prune bound + the no-destructive-prune invariant + graceful degradation + prompt & recipe content-pins.

## Testing

- `cargo test --lib brain_introspection` → **40 passed**.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features --locked -D warnings` → clean.
- `mkdocs build --strict` → passes.
- prompt_assets / prompt_delivery / ooda_daemon integration suites → green; full test-target compile clean.

## Follow-ups (deferred, to be filed as issues)

- (A) `memory.prune_superseded` + `memory.backup` **bridge-server** RPCs to enable backed-up, bounded destructive superseded prune (clamped by the same cap).
- (B) Percentage-based prune cap (additive to the absolute cap).
- (C) Restore-from-backup CLI for reversibility.
- (D) A metrics-dashboard panel for the `brain_introspection_*` series.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>