### PR TITLE
feat(memory): ISAO reliability gate on consolidation (#2433)

### DIFF
--- a/docs/architecture/episode-distillation.md
+++ b/docs/architecture/episode-distillation.md
@@ -328,19 +328,46 @@ pub struct DistillReport {
     pub input_count: u32,
     /// Number of facts emitted by the recipe.
     pub fact_count: u32,
+    /// Number of procedures emitted by the recipe.
+    pub procedure_count: u32,
     /// Number of episodes marked distilled after the pass.
     pub marked_count: u32,
-}
-
-impl DistillReport {
-    /// The pass was skipped under threshold; no work was done.
-    pub fn skipped() -> Self { Self { input_count: 0, fact_count: 0, marked_count: 0 } }
-
-    pub fn was_skipped(&self) -> bool {
-        self.input_count == 0 && self.fact_count == 0 && self.marked_count == 0
-    }
+    /// Number of candidate facts blocked by the reliability gate (issue #2433).
+    pub quarantined_count: u32,
 }
 ```
+
+`fact_count + quarantined_count` is the total number of candidate facts the
+recipe emitted for the pass; `quarantined_count` counts the candidates the
+ISAO reliability gate either quarantined (low score) or refused to promote
+because a stronger prior already existed on the concept.
+
+## Reliability gate (issue #2433)
+
+Before a distilled fact is promoted into semantic memory it is **self-assessed**
+and gated on `Fact.confidence` — turning the formerly-constant `0.7` into a
+live, computed signal (BGML's *information self-assessment ownership*, ISAO).
+
+`assess_fact_reliability(fact, episodes, batch_facts) -> f64` scores each
+candidate in `[0.0, 1.0]` from cheap local signals (no extra LLM call):
+
+| Signal | Weight | Meaning |
+|--------|--------|---------|
+| Provenance grounding | 0.5 | `source_episode_id` is one of the episodes fed to the recipe this pass (not hallucinated). |
+| Content quality | ≤0.3 | Non-empty; ≥3 words. |
+| Concept validity | 0.1 | Concept is one of `pr-pattern` / `bug-pattern` / `lesson-learned`. |
+| Corroboration | 0.1 | ≥2 facts agree on the same concept this pass. |
+
+A candidate scoring below `DISTILL_RELIABILITY_THRESHOLD` (0.5) is **quarantined**
+— not written. A surviving candidate is written with its *computed* confidence,
+but never **clobbers** a higher-confidence existing fact on the same concept
+(`search_facts(concept, _, score)` is consulted first). A nominal grounded,
+known-concept, ≥3-word fact scores `0.9` — at or above the legacy baseline — so
+good facts keep their prior behaviour.
+
+Each pass records a `distill_reliability_gate` metric whose value is the
+block-rate (`quarantined / candidate_facts`), with the counts in the context
+payload, so the gate's effect is measurable before/after from `metrics.jsonl`.
 
 ### Reduction ratio
 

--- a/docs/architecture/episode-distillation.md
+++ b/docs/architecture/episode-distillation.md
@@ -353,17 +353,27 @@ candidate in `[0.0, 1.0]` from cheap local signals (no extra LLM call):
 
 | Signal | Weight | Meaning |
 |--------|--------|---------|
-| Provenance grounding | 0.5 | `source_episode_id` is one of the episodes fed to the recipe this pass (not hallucinated). |
-| Content quality | ≤0.3 | Non-empty; ≥3 words. |
+| Provenance grounding | 0.5 | `source_episode_id` is one of the episodes fed to the recipe this pass (not hallucinated). **Necessary**: without it a fact tops out at 0.4 and is always quarantined. |
+| Content quality | ≤0.3 | Empty / whitespace-only content is a **hard gate** (score `0.0`); otherwise ≥3 words earns the full 0.3. |
 | Concept validity | 0.1 | Concept is one of `pr-pattern` / `bug-pattern` / `lesson-learned`. |
-| Corroboration | 0.1 | ≥2 facts agree on the same concept this pass. |
+| Corroboration | 0.1 | ≥2 facts agree on the same concept this pass — awarded **only to grounded facts** so hallucinated provenance can't ride on a sibling's corroboration. |
 
 A candidate scoring below `DISTILL_RELIABILITY_THRESHOLD` (0.5) is **quarantined**
-— not written. A surviving candidate is written with its *computed* confidence,
-but never **clobbers** a higher-confidence existing fact on the same concept
-(`search_facts(concept, _, score)` is consulted first). A nominal grounded,
+— not written. Because grounding (0.5) is necessary to reach the threshold, a
+hallucinated-provenance fact scores at most `0.4` (even with corroboration) and
+an empty fact scores `0.0`; both are quarantined. A nominal grounded,
 known-concept, ≥3-word fact scores `0.9` — at or above the legacy baseline — so
 good facts keep their prior behaviour.
+
+A surviving candidate is written with its *computed* confidence, but never
+**downgrades** a stronger existing copy of the **same fact**. The don't-clobber
+guard matches on fact *identity* (concept **and** content), not the concept
+label alone: the recipe emits only three concept labels and every good fact
+scores identically, so a concept-only guard would quarantine every distinct fact
+after the first one stored under a label and silently neuter distillation.
+Identity matching blocks only a genuine re-distillation of the same content at a
+lower-or-equal confidence, while distinct lessons that share a label accumulate
+(`search_facts(concept, _, score)` is consulted, then filtered on content).
 
 Each pass records a `distill_reliability_gate` metric whose value is the
 block-rate (`quarantined / candidate_facts`), with the counts in the context

--- a/src/memory_consolidation/distillation.rs
+++ b/src/memory_consolidation/distillation.rs
@@ -278,24 +278,42 @@ pub fn distill_recent_episodes_with_runner(
         }
 
         // Protect past experience: do not let a weaker new fact supersede a
-        // stronger existing fact on the same concept (BGML ISAO integrity).
-        // `search_facts` is queried with the new confidence as `min_confidence`
-        // so it returns only the priors that would block; the explicit
-        // comparison is belt-and-suspenders against a backend that ignores the
-        // filter.
+        // stronger existing *version of the same fact* (BGML ISAO integrity).
+        //
+        // The match is on fact IDENTITY (concept + content), NOT the concept
+        // label alone. The distillation recipe emits at most three concept
+        // labels (`pr-pattern` / `bug-pattern` / `lesson-learned`) and every
+        // grounded, well-formed fact scores identically, so a concept-only
+        // guard would treat each distilled fact as a duplicate of the first one
+        // stored under that label and quarantine every subsequent DISTINCT fact
+        // — silently neutering distillation after the first pass (issue #2433).
+        // Identity matching instead blocks only a genuine re-distillation of the
+        // *same* content at a lower-or-equal confidence, while letting distinct
+        // lessons that happen to share a label accumulate.
+        //
+        // `search_facts` is queried with the new confidence as `min_confidence`,
+        // so it returns only priors strong enough to block; production
+        // `search_facts` matches the concept label against the same live graph
+        // these writes target, so an in-pass sibling is visible here too. The
+        // explicit `>=` comparison is belt-and-suspenders against a backend that
+        // ignores the `min_confidence` filter.
         let existing = memory
             .search_facts(&fact.concept, 5, confidence)
             .unwrap_or_default();
-        if existing.iter().any(|f| f.confidence >= confidence) {
+        let new_content = fact.content.trim();
+        if existing
+            .iter()
+            .any(|f| f.content.trim() == new_content && f.confidence >= confidence)
+        {
             quarantined += 1;
             tracing::info!(
                 target: "simard::distill",
                 concept = %fact.concept,
                 confidence,
-                "distill: existing fact on concept has >= confidence; not clobbering prior"
+                "distill: an equal-or-stronger copy of this fact already exists; not downgrading prior"
             );
             eprintln!(
-                "[simard] distill: kept stronger prior on concept={} (new confidence={:.2} would clobber)",
+                "[simard] distill: kept stronger prior for concept={} (new confidence={:.2} would downgrade an identical fact)",
                 fact.concept, confidence
             );
             continue;
@@ -376,32 +394,47 @@ pub fn distill_recent_episodes_with_runner(
 /// | Signal | Weight | Rationale |
 /// |--------|--------|-----------|
 /// | **Provenance grounding** | 0.5 | The cited `source_episode_id` must be one of the episodes actually fed to the recipe this pass. A source outside the batch is unverifiable / hallucinated provenance — the strongest unreliability signal. |
-/// | **Content quality** | ≤0.3 | Empty content carries no information; ≥3 words is the minimum for a usable fact. |
+/// | **Content quality** | ≤0.3 | Empty / whitespace-only content carries no information and is a HARD gate (score `0.0`); otherwise ≥3 words earns the full weight. |
 /// | **Concept validity** | 0.1 | The recipe is constrained to [`KNOWN_DISTILL_CONCEPTS`]; an off-set concept means the model went off-spec. |
-/// | **Corroboration** | 0.1 | Multiple distilled facts agreeing on the same concept this pass is independent agreement across source episodes. |
+/// | **Corroboration** | 0.1 | ≥2 distilled facts agreeing on the same concept this pass — independent agreement across source episodes. Awarded ONLY to grounded facts so hallucinated provenance can't ride on a sibling's corroboration. |
 ///
 /// A nominal fact (grounded, ≥3 words, known concept) scores `0.9` — at or
 /// above the legacy [`DISTILL_FACT_CONFIDENCE`] baseline — so good facts keep
-/// their downstream behaviour, while a hallucinated-provenance or empty fact
-/// scores ≤`0.4` and is quarantined by [`DISTILL_RELIABILITY_THRESHOLD`].
+/// their downstream behaviour. Because grounding (0.5) is necessary to clear
+/// [`DISTILL_RELIABILITY_THRESHOLD`] (0.5), a hallucinated-provenance fact tops
+/// out at `0.4` (content + concept) — even WITH corroboration — and an empty
+/// fact scores `0.0`; both are quarantined.
 pub fn assess_fact_reliability(
     fact: &DistilledFact,
     episodes: &[CognitiveEpisode],
     batch_facts: &[DistilledFact],
 ) -> f64 {
+    // (0) Hard gate: empty / whitespace-only content carries no information and
+    // is quarantined unconditionally, regardless of how trustworthy its
+    // provenance looks (issue #2433). Without this, a grounded-but-empty fact
+    // (0.5 grounding + 0.1 concept = 0.6) would clear the gate, violating the
+    // documented "empty content is quarantined" invariant.
+    let words = fact.content.split_whitespace().count();
+    if words == 0 {
+        return 0.0;
+    }
+
     let mut score = 0.0_f64;
 
-    // (1) Provenance grounding.
+    // (1) Provenance grounding — the dominant, *necessary* signal. A source
+    // outside the batch is unverifiable / hallucinated provenance. The weights
+    // below are tuned so that WITHOUT this 0.5 a fact can never reach
+    // `DISTILL_RELIABILITY_THRESHOLD` (0.5): an ungrounded fact tops out at
+    // 0.3 content + 0.1 concept = 0.4 and is always quarantined.
     let grounded = episodes.iter().any(|e| e.node_id == fact.source_episode_id);
     if grounded {
         score += 0.5;
     }
 
-    // (2) Content quality.
-    let words = fact.content.split_whitespace().count();
+    // (2) Content quality (content is non-empty here — see the hard gate above).
     if words >= 3 {
         score += 0.3;
-    } else if words >= 1 {
+    } else {
         score += 0.15;
     }
 
@@ -415,12 +448,17 @@ pub fn assess_fact_reliability(
     }
 
     // (4) Corroboration: ≥2 facts this pass agreeing on the same concept.
-    let corroboration = batch_facts
-        .iter()
-        .filter(|f| f.concept.eq_ignore_ascii_case(&fact.concept))
-        .count();
-    if corroboration >= 2 {
-        score += 0.1;
+    // Awarded ONLY to grounded facts — an ungrounded (hallucinated-provenance)
+    // fact must not ride on the corroboration of legitimate same-concept facts
+    // to sneak over the gate (it would otherwise reach 0.3 + 0.1 + 0.1 = 0.5).
+    if grounded {
+        let corroboration = batch_facts
+            .iter()
+            .filter(|f| f.concept.eq_ignore_ascii_case(&fact.concept))
+            .count();
+        if corroboration >= 2 {
+            score += 0.1;
+        }
     }
 
     score.clamp(0.0, 1.0)

--- a/src/memory_consolidation/distillation.rs
+++ b/src/memory_consolidation/distillation.rs
@@ -11,7 +11,12 @@
 //! 3. Otherwise invokes a pluggable [`DistillRecipeRunner`] that
 //!    classifies each episode into one of three concept labels
 //!    (`pr-pattern`, `bug-pattern`, `lesson-learned`) or `skip`.
-//! 4. Stores each emitted fact via `store_fact`.
+//! 4. Self-assesses each candidate fact's reliability (issue #2433,
+//!    BGML's ISAO) and GATES on `Fact.confidence`: low-reliability facts
+//!    are quarantined (not promoted) and a weaker new fact never clobbers
+//!    a stronger existing fact on the same concept. Surviving facts are
+//!    stored via `store_fact_with_provenance` with the *computed*
+//!    confidence rather than a constant.
 //! 5. Marks EVERY input episode (including those classified `skip`) as
 //!    distilled so the same low-value batch is not re-fed to the LLM.
 //!
@@ -34,11 +39,26 @@ pub const DISTILL_BATCH_SIZE: u32 = 50;
 /// episodes wastes an LLM call for little quality gain.
 pub const DISTILL_MIN_EPISODES: u32 = 20;
 
-/// Default per-fact confidence written via `store_fact`. The recipe
-/// itself does not produce confidence scores; this is the canonical
-/// "moderately confident, machine-distilled" value used by all PR-B
-/// facts so downstream filtering can recognize the source.
+/// Legacy per-fact confidence baseline. Before issue #2433 every distilled
+/// fact was written with this exact constant, so `Fact.confidence` carried no
+/// information. It is retained as the **nominal baseline**: a fully-grounded,
+/// known-concept, well-formed fact scores at or above this value under
+/// [`assess_fact_reliability`], preserving downstream filtering behaviour for
+/// good facts while letting weak ones drop below the gate.
 pub const DISTILL_FACT_CONFIDENCE: f64 = 0.7;
+
+/// ISAO reliability gate threshold (issue #2433). Candidate facts whose
+/// self-assessed reliability score is below this are **quarantined** — not
+/// promoted into semantic memory — rather than written with a blind constant
+/// confidence. Tuned so a fact with valid in-batch provenance, a known
+/// concept label, and non-trivial content clears the bar, while a fact with
+/// hallucinated provenance or empty content does not.
+pub const DISTILL_RELIABILITY_THRESHOLD: f64 = 0.5;
+
+/// The closed concept-label set the distillation recipe is constrained to.
+/// A fact whose concept is outside this set is off-spec and loses the
+/// concept-validity component of its reliability score.
+pub const KNOWN_DISTILL_CONCEPTS: &[&str] = &["pr-pattern", "bug-pattern", "lesson-learned"];
 
 /// A single semantic fact emitted by the recipe runner for one batch
 /// of episodes.
@@ -121,6 +141,12 @@ pub struct DistillReport {
     pub procedure_count: u32,
     /// Number of episodes marked distilled after the pass.
     pub marked_count: u32,
+    /// Number of candidate facts blocked by the ISAO reliability gate
+    /// (issue #2433): quarantined for low self-assessed reliability OR
+    /// skipped to avoid clobbering a higher-confidence existing fact.
+    /// `fact_count + quarantined_count` is the total candidate count the
+    /// recipe emitted for this pass.
+    pub quarantined_count: u32,
 }
 
 impl DistillReport {
@@ -135,6 +161,7 @@ impl DistillReport {
             && self.fact_count == 0
             && self.procedure_count == 0
             && self.marked_count == 0
+            && self.quarantined_count == 0
     }
 
     /// Reduction ratio (`1 - fact_count / input_count`) as a fraction
@@ -216,20 +243,69 @@ pub fn distill_recent_episodes_with_runner(
     };
     let DistillOutput { facts, procedures } = output;
 
-    // Store every fact via the provenance write path. Each fact's textual
-    // `source_id` retains the `distill:{episode}` prefix for back-compat
-    // (search_facts can be filtered/grepped on it to identify machine-distilled
-    // facts), while the originating episode id is ALSO threaded through as
-    // `source_episode_ids` so a `DERIVES_FROM` edge links the fact back to the
-    // episode it was distilled from (issue #2325). The concept doubles as the
-    // fact's tag, matching the legacy `store_fact` call this replaced.
+    // ISAO-style reliability gate (issue #2433, BGML §IV). Before promoting a
+    // distilled fact into semantic memory we SELF-ASSESS its reliability and
+    // gate on `Fact.confidence` instead of writing a blind constant:
+    //   * low-reliability candidates are QUARANTINED (not stored) so they can
+    //     never corrupt the integrity of past experience, and
+    //   * a weaker new fact never CLOBBERS a higher-confidence existing fact on
+    //     the same concept (mirrors the cross-session dedup guard in
+    //     `memory_consolidation::mod`).
+    // Surviving facts are written with the *computed* confidence, turning the
+    // formerly-dormant `confidence` column into a live consolidation→recall
+    // signal. The originating episode id is still threaded through as
+    // provenance (`source_episode_ids`) for the DERIVES_FROM edge (issue #2325).
     let mut stored = 0u32;
+    let mut quarantined = 0u32;
     for fact in &facts {
+        let confidence = assess_fact_reliability(fact, &episodes, &facts);
+
+        if confidence < DISTILL_RELIABILITY_THRESHOLD {
+            quarantined += 1;
+            tracing::warn!(
+                target: "simard::distill",
+                concept = %fact.concept,
+                source_episode_id = %fact.source_episode_id,
+                confidence,
+                threshold = DISTILL_RELIABILITY_THRESHOLD,
+                "distill: quarantined low-reliability fact (below threshold), not promoted"
+            );
+            eprintln!(
+                "[simard] distill: quarantined low-reliability fact concept={} confidence={:.2} < {:.2}",
+                fact.concept, confidence, DISTILL_RELIABILITY_THRESHOLD
+            );
+            continue;
+        }
+
+        // Protect past experience: do not let a weaker new fact supersede a
+        // stronger existing fact on the same concept (BGML ISAO integrity).
+        // `search_facts` is queried with the new confidence as `min_confidence`
+        // so it returns only the priors that would block; the explicit
+        // comparison is belt-and-suspenders against a backend that ignores the
+        // filter.
+        let existing = memory
+            .search_facts(&fact.concept, 5, confidence)
+            .unwrap_or_default();
+        if existing.iter().any(|f| f.confidence >= confidence) {
+            quarantined += 1;
+            tracing::info!(
+                target: "simard::distill",
+                concept = %fact.concept,
+                confidence,
+                "distill: existing fact on concept has >= confidence; not clobbering prior"
+            );
+            eprintln!(
+                "[simard] distill: kept stronger prior on concept={} (new confidence={:.2} would clobber)",
+                fact.concept, confidence
+            );
+            continue;
+        }
+
         let source = format!("distill:{}", fact.source_episode_id);
         memory.store_fact_with_provenance(
             &fact.concept,
             &fact.content,
-            DISTILL_FACT_CONFIDENCE,
+            confidence,
             &source,
             Some(std::slice::from_ref(&fact.concept)),
             None,
@@ -237,6 +313,11 @@ pub fn distill_recent_episodes_with_runner(
         )?;
         stored += 1;
     }
+
+    // Before/after measurement of the gate's block-rate (issue #2433
+    // acceptance). Best-effort, no-op under `cfg!(test)` so unit tests never
+    // append to the operator's real metrics file.
+    record_reliability_gate_metric(facts.len() as u32, quarantined, stored);
 
     // Store every procedure via the provenance write path (issue #2327, R5).
     // `source_episode_ids` are threaded so a `PROCEDURE_DERIVES_FROM` edge links
@@ -284,7 +365,113 @@ pub fn distill_recent_episodes_with_runner(
         fact_count: stored,
         procedure_count: stored_procs,
         marked_count: marked,
+        quarantined_count: quarantined,
     })
+}
+
+/// Self-assess the reliability of one distilled fact (issue #2433, BGML's
+/// *information self-assessment ownership*, §IV). Returns a confidence score in
+/// `[0.0, 1.0]` from cheap, locally-available signals — no extra LLM call:
+///
+/// | Signal | Weight | Rationale |
+/// |--------|--------|-----------|
+/// | **Provenance grounding** | 0.5 | The cited `source_episode_id` must be one of the episodes actually fed to the recipe this pass. A source outside the batch is unverifiable / hallucinated provenance — the strongest unreliability signal. |
+/// | **Content quality** | ≤0.3 | Empty content carries no information; ≥3 words is the minimum for a usable fact. |
+/// | **Concept validity** | 0.1 | The recipe is constrained to [`KNOWN_DISTILL_CONCEPTS`]; an off-set concept means the model went off-spec. |
+/// | **Corroboration** | 0.1 | Multiple distilled facts agreeing on the same concept this pass is independent agreement across source episodes. |
+///
+/// A nominal fact (grounded, ≥3 words, known concept) scores `0.9` — at or
+/// above the legacy [`DISTILL_FACT_CONFIDENCE`] baseline — so good facts keep
+/// their downstream behaviour, while a hallucinated-provenance or empty fact
+/// scores ≤`0.4` and is quarantined by [`DISTILL_RELIABILITY_THRESHOLD`].
+pub fn assess_fact_reliability(
+    fact: &DistilledFact,
+    episodes: &[CognitiveEpisode],
+    batch_facts: &[DistilledFact],
+) -> f64 {
+    let mut score = 0.0_f64;
+
+    // (1) Provenance grounding.
+    let grounded = episodes.iter().any(|e| e.node_id == fact.source_episode_id);
+    if grounded {
+        score += 0.5;
+    }
+
+    // (2) Content quality.
+    let words = fact.content.split_whitespace().count();
+    if words >= 3 {
+        score += 0.3;
+    } else if words >= 1 {
+        score += 0.15;
+    }
+
+    // (3) Concept validity.
+    let concept = fact.concept.trim();
+    if KNOWN_DISTILL_CONCEPTS
+        .iter()
+        .any(|c| c.eq_ignore_ascii_case(concept))
+    {
+        score += 0.1;
+    }
+
+    // (4) Corroboration: ≥2 facts this pass agreeing on the same concept.
+    let corroboration = batch_facts
+        .iter()
+        .filter(|f| f.concept.eq_ignore_ascii_case(&fact.concept))
+        .count();
+    if corroboration >= 2 {
+        score += 0.1;
+    }
+
+    score.clamp(0.0, 1.0)
+}
+
+/// Build the JSON `context` payload for the `distill_reliability_gate` metric.
+/// Separated from the I/O so the payload shape is unit-testable without
+/// touching the real `metrics.jsonl`.
+fn build_reliability_gate_context(candidate_facts: u32, quarantined: u32, promoted: u32) -> String {
+    let block_rate = if candidate_facts == 0 {
+        0.0
+    } else {
+        quarantined as f64 / candidate_facts as f64
+    };
+    serde_json::json!({
+        "candidate_facts": candidate_facts,
+        "promoted": promoted,
+        "quarantined": quarantined,
+        "block_rate": block_rate,
+        "threshold": DISTILL_RELIABILITY_THRESHOLD,
+    })
+    .to_string()
+}
+
+/// Record one `distill_reliability_gate` metric event per distillation pass so
+/// the block-rate (`quarantined / candidate_facts`) is measurable from
+/// `metrics.jsonl` (issue #2433 acceptance: a before/after measurement of the
+/// gate). The metric `value` is the block-rate fraction.
+///
+/// Best-effort: a metrics-write failure is logged, never propagated. No-op
+/// under `cfg!(test)` so unit tests never append to the operator's real
+/// `~/.simard/metrics/metrics.jsonl`.
+fn record_reliability_gate_metric(candidate_facts: u32, quarantined: u32, promoted: u32) {
+    if cfg!(test) {
+        return;
+    }
+    let block_rate = if candidate_facts == 0 {
+        0.0
+    } else {
+        quarantined as f64 / candidate_facts as f64
+    };
+    let context = build_reliability_gate_context(candidate_facts, quarantined, promoted);
+    if let Err(e) =
+        crate::self_metrics::record_metric("distill_reliability_gate", block_rate, &context)
+    {
+        tracing::warn!(
+            target: "simard::distill",
+            error = %e,
+            "failed to record distill_reliability_gate metric (distillation unaffected)",
+        );
+    }
 }
 
 /// Production entry point: run one distillation pass using the
@@ -723,6 +910,25 @@ mod unit_tests {
     use super::*;
 
     #[test]
+    fn reliability_gate_metric_context_shape() {
+        // 5 candidates, 2 quarantined → block_rate 0.4.
+        let payload = build_reliability_gate_context(5, 2, 3);
+        let v: serde_json::Value = serde_json::from_str(&payload).unwrap();
+        assert_eq!(v["candidate_facts"], 5);
+        assert_eq!(v["promoted"], 3);
+        assert_eq!(v["quarantined"], 2);
+        assert_eq!(v["block_rate"], 0.4);
+        assert_eq!(v["threshold"], DISTILL_RELIABILITY_THRESHOLD);
+    }
+
+    #[test]
+    fn reliability_gate_metric_context_zero_candidates_is_zero_rate() {
+        let payload = build_reliability_gate_context(0, 0, 0);
+        let v: serde_json::Value = serde_json::from_str(&payload).unwrap();
+        assert_eq!(v["block_rate"], 0.0);
+    }
+
+    #[test]
     fn report_skipped_is_was_skipped() {
         assert!(DistillReport::skipped().was_skipped());
     }
@@ -734,6 +940,7 @@ mod unit_tests {
             fact_count: 3,
             procedure_count: 0,
             marked_count: 25,
+            quarantined_count: 0,
         };
         assert!(!r.was_skipped());
     }
@@ -750,6 +957,7 @@ mod unit_tests {
             fact_count: 3,
             procedure_count: 0,
             marked_count: 25,
+            quarantined_count: 0,
         };
         let pct = r.reduction() * 100.0;
         assert!((pct - 88.0).abs() < 0.1, "expected ~88%, got {pct}");

--- a/src/memory_consolidation/distillation_tests.rs
+++ b/src/memory_consolidation/distillation_tests.rs
@@ -273,16 +273,38 @@ impl CognitiveMemoryOps for EpisodeMock {
         Ok(format!("sem_{}", self.facts.lock().unwrap().len()))
     }
     fn search_facts(&self, q: &str, _l: u32, min_conf: f64) -> SimardResult<Vec<CognitiveFact>> {
-        // Issue #2433: return seeded priors whose concept matches the query and
-        // whose confidence clears `min_conf`, so the don't-clobber guard sees
-        // the stronger existing fact. Default (no seed) → empty, preserving the
+        // Issue #2433: model the production library faithfully — `search_facts`
+        // matches the concept label and reads the SAME live graph that
+        // `store_fact*` writes to. So return BOTH seeded priors AND facts
+        // already stored earlier in this same pass, filtered by concept == query
+        // and confidence >= min_conf. Reflecting in-pass writes is exactly what
+        // lets the don't-clobber guard's identity check observe an in-batch
+        // sibling (the case the earlier concept-only guard silently regressed
+        // on). Default (no seed, nothing stored yet) → empty, preserving the
         // pre-#2433 behaviour the other tests rely on.
-        let seeded = self.seeded_facts.lock().unwrap();
-        Ok(seeded
+        let mut out: Vec<CognitiveFact> = self
+            .seeded_facts
+            .lock()
+            .unwrap()
             .iter()
             .filter(|f| f.concept == q && f.confidence >= min_conf)
             .cloned()
-            .collect())
+            .collect();
+        for (concept, content, conf, _tags, source) in self.facts.lock().unwrap().iter() {
+            if concept == q && *conf >= min_conf {
+                out.push(CognitiveFact {
+                    node_id: format!("sem_stored_{concept}"),
+                    concept: concept.clone(),
+                    content: content.clone(),
+                    confidence: *conf,
+                    source_id: source.clone(),
+                    tags: vec![concept.clone()],
+                    usage_count: 0,
+                    last_accessed_at: None,
+                });
+            }
+        }
+        Ok(out)
     }
     fn store_procedure(&self, _n: &str, _s: &[String], _p: &[String]) -> SimardResult<String> {
         Ok("prc_x".to_string())
@@ -1176,11 +1198,11 @@ fn facts_only_wrapper_reads_real_prose_prefixed_envelope() {
 //   * a weaker new fact never clobbers a stronger existing fact on the concept.
 
 /// Build a pre-existing `CognitiveFact` for seeding the mock's `search_facts`.
-fn seeded_fact(concept: &str, confidence: f64) -> CognitiveFact {
+fn seeded_fact(concept: &str, content: &str, confidence: f64) -> CognitiveFact {
     CognitiveFact {
         node_id: format!("sem_seed_{concept}"),
         concept: concept.to_string(),
-        content: format!("prior {concept}"),
+        content: content.to_string(),
         confidence,
         source_id: "prior".to_string(),
         tags: vec![concept.to_string()],
@@ -1307,6 +1329,68 @@ fn reliability_score_unknown_concept_loses_weight() {
     );
 }
 
+/// Hallucinated provenance must not ride on a same-concept sibling's
+/// corroboration to clear the gate: an ungrounded fact stays at 0.4 (content +
+/// concept only) even when corroboration is present, because the corroboration
+/// bonus is awarded only to grounded facts (issue #2433).
+#[test]
+fn reliability_score_ungrounded_corroborated_still_below_threshold() {
+    let episodes = vec![CognitiveEpisode {
+        node_id: "epi_00001".to_string(),
+        content: "event 1".to_string(),
+        source_label: "goal-curator".to_string(),
+        temporal_index: 1,
+        compressed: false,
+    }];
+    // Two same-concept facts → corroboration is present in the batch, but the
+    // fact under test cites an episode NOT in the batch (hallucinated provenance).
+    let batch = vec![
+        DistilledFact {
+            concept: "bug-pattern".to_string(),
+            content: "looks plausible but provenance is fake".to_string(),
+            source_episode_id: "epi_99999".to_string(), // ungrounded
+        },
+        DistilledFact {
+            concept: "bug-pattern".to_string(),
+            content: "a grounded sibling on the same concept".to_string(),
+            source_episode_id: "epi_00001".to_string(),
+        },
+    ];
+    let score = assess_fact_reliability(&batch[0], &episodes, &batch);
+    assert!(
+        (score - 0.4).abs() < 1e-9,
+        "ungrounded + corroborated must stay at 0.3 content + 0.1 concept = 0.4; got {score}"
+    );
+    assert!(
+        score < DISTILL_RELIABILITY_THRESHOLD,
+        "hallucinated provenance must be quarantined regardless of corroboration"
+    );
+}
+
+/// Empty / whitespace-only content is quarantined unconditionally — even with
+/// valid provenance and a known concept it scores 0.0 (issue #2433 hard gate).
+#[test]
+fn reliability_score_empty_content_is_zero() {
+    let episodes = vec![CognitiveEpisode {
+        node_id: "epi_00001".to_string(),
+        content: "event 1".to_string(),
+        source_label: "goal-curator".to_string(),
+        temporal_index: 1,
+        compressed: false,
+    }];
+    let fact = DistilledFact {
+        concept: "pr-pattern".to_string(),
+        content: "   ".to_string(),                 // whitespace only
+        source_episode_id: "epi_00001".to_string(), // grounded, but empty
+    };
+    let score = assess_fact_reliability(&fact, &episodes, std::slice::from_ref(&fact));
+    assert_eq!(
+        score, 0.0,
+        "empty content must score 0.0 regardless of provenance"
+    );
+    assert!(score < DISTILL_RELIABILITY_THRESHOLD);
+}
+
 /// End-to-end gate: a hallucinated-provenance fact is QUARANTINED — not stored
 /// — while the grounded fact in the same batch is promoted. Every episode is
 /// still marked distilled (the quarantine does not break the replay guard).
@@ -1350,22 +1434,28 @@ fn distillation_quarantines_low_reliability_fact() {
     );
 }
 
-/// Integrity guard: a weaker new fact must not clobber a stronger existing fact
-/// on the same concept. The seeded 0.95 prior on `pr-pattern` blocks the new
-/// 0.9 candidate, while a concept with no prior is promoted normally.
+/// Integrity guard: a weaker new fact must not downgrade a stronger existing
+/// copy of the SAME fact (identity = concept + content). The seeded 0.95 prior
+/// has identical content to the candidate the recipe re-emits at a computed
+/// 0.9, so it is blocked; a distinct fact on another concept is promoted.
 #[test]
 fn distillation_does_not_clobber_stronger_prior() {
     let n = DISTILL_MIN_EPISODES as usize + 5;
     let mock = EpisodeMock::with_episodes_and_seeded_facts(
         n_episodes(n),
-        vec![seeded_fact("pr-pattern", 0.95)],
+        // Same concept AND same content as the candidate below, but stronger.
+        vec![seeded_fact(
+            "pr-pattern",
+            "enable auto-merge before final review",
+            0.95,
+        )],
     );
     let runner = FixedFactsRunner {
         facts: vec![
             (
                 "pr-pattern".to_string(),
                 "enable auto-merge before final review".to_string(),
-                "epi_00001".to_string(), // computed 0.9 < 0.95 prior → blocked
+                "epi_00001".to_string(), // computed 0.9 < identical 0.95 prior → blocked
             ),
             (
                 "bug-pattern".to_string(),
@@ -1384,15 +1474,63 @@ fn distillation_does_not_clobber_stronger_prior() {
     );
     assert_eq!(
         report.quarantined_count, 1,
-        "the weaker pr-pattern candidate is blocked"
+        "the weaker identical pr-pattern candidate is blocked"
     );
 
-    let stored: Vec<String> = mock.facts_stored().into_iter().map(|(c, _)| c).collect();
+    let stored: Vec<(String, String, f64)> = mock.stored_facts_full();
     assert!(
-        !stored.contains(&"pr-pattern".to_string()),
-        "the stronger 0.95 prior must be preserved, not clobbered by the 0.9 candidate"
+        !stored.iter().any(|(c, content, _)| c == "pr-pattern"
+            && content == "enable auto-merge before final review"),
+        "the stronger 0.95 prior must be preserved, not downgraded by the 0.9 candidate"
     );
-    assert!(stored.contains(&"bug-pattern".to_string()));
+    assert!(stored.iter().any(|(c, _, _)| c == "bug-pattern"));
+}
+
+/// Regression (issue #2433): two DISTINCT facts that share a concept label must
+/// BOTH be promoted. The recipe emits only three concept labels and every
+/// grounded, well-formed fact scores identically, so an earlier concept-level
+/// don't-clobber guard quarantined every same-concept fact after the first —
+/// silently neutering distillation. The identity-level guard, plus a mock whose
+/// `search_facts` reflects in-pass writes (as production does), proves distinct
+/// same-concept facts accumulate. This test FAILS under the concept-only guard.
+#[test]
+fn distillation_promotes_distinct_same_concept_facts() {
+    let n = DISTILL_MIN_EPISODES as usize + 5;
+    let mock = EpisodeMock::with_episodes(n_episodes(n));
+    let runner = FixedFactsRunner {
+        facts: vec![
+            (
+                "pr-pattern".to_string(),
+                "enable auto-merge before final review".to_string(),
+                "epi_00001".to_string(),
+            ),
+            (
+                "pr-pattern".to_string(),
+                "rebase onto main before requesting review".to_string(),
+                "epi_00002".to_string(),
+            ),
+        ],
+        call_count: AtomicU32::new(0),
+    };
+
+    let report = distill_recent_episodes_with_runner(&mock, &runner).unwrap();
+
+    assert_eq!(
+        report.fact_count, 2,
+        "two distinct pr-pattern facts must both be promoted, not deduped by label"
+    );
+    assert_eq!(
+        report.quarantined_count, 0,
+        "distinct same-concept facts must not be quarantined as clobbering priors"
+    );
+
+    let contents: Vec<String> = mock
+        .stored_facts_full()
+        .into_iter()
+        .map(|(_, content, _)| content)
+        .collect();
+    assert!(contents.contains(&"enable auto-merge before final review".to_string()));
+    assert!(contents.contains(&"rebase onto main before requesting review".to_string()));
 }
 
 /// Confidence written to semantic memory is the *computed* reliability score,

--- a/src/memory_consolidation/distillation_tests.rs
+++ b/src/memory_consolidation/distillation_tests.rs
@@ -42,8 +42,9 @@
 
 // `distillation` module does not exist yet (PR-B introduces it).
 use crate::memory_consolidation::distillation::{
-    DISTILL_BATCH_SIZE, DISTILL_MIN_EPISODES, DistillRecipeRunner,
-    distill_recent_episodes_with_runner,
+    DISTILL_BATCH_SIZE, DISTILL_FACT_CONFIDENCE, DISTILL_MIN_EPISODES,
+    DISTILL_RELIABILITY_THRESHOLD, DistillRecipeRunner, DistilledFact, KNOWN_DISTILL_CONCEPTS,
+    assess_fact_reliability, distill_recent_episodes_with_runner,
 };
 
 use crate::cognitive_memory::CognitiveMemoryOps;
@@ -150,6 +151,11 @@ struct EpisodeMock {
     /// provenance test can assert the originating episode id was threaded
     /// through to the provenance write (creating a DERIVES_FROM edge).
     prov_calls: Mutex<Vec<(String, String, Vec<String>)>>,
+    /// Issue #2433: pre-existing facts returned by `search_facts`, keyed by
+    /// concept, so the reliability gate's "don't clobber a stronger prior"
+    /// guard can be exercised. Empty by default → existing tests are
+    /// unaffected (the gate finds no prior to protect).
+    seeded_facts: Mutex<Vec<CognitiveFact>>,
 }
 
 #[derive(Clone)]
@@ -168,6 +174,29 @@ impl EpisodeMock {
             episodes: Mutex::new(rows),
             ..Self::default()
         }
+    }
+
+    /// Like [`with_episodes`](Self::with_episodes) but pre-seeds the facts that
+    /// `search_facts` will return, so the reliability gate's don't-clobber
+    /// guard (issue #2433) can be tested.
+    fn with_episodes_and_seeded_facts(rows: Vec<EpisodeRow>, seeded: Vec<CognitiveFact>) -> Self {
+        Self {
+            episodes: Mutex::new(rows),
+            seeded_facts: Mutex::new(seeded),
+            ..Self::default()
+        }
+    }
+
+    /// Every stored fact as `(concept, content, confidence)` — unlike
+    /// [`facts_stored`](Self::facts_stored) this keeps the confidence so the
+    /// reliability-gate tests can assert the *computed* (non-constant) score.
+    fn stored_facts_full(&self) -> Vec<(String, String, f64)> {
+        self.facts
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|(c, content, conf, _, _)| (c.clone(), content.clone(), *conf))
+            .collect()
     }
 
     fn facts_stored(&self) -> Vec<(String, String)> {
@@ -243,8 +272,17 @@ impl CognitiveMemoryOps for EpisodeMock {
         ));
         Ok(format!("sem_{}", self.facts.lock().unwrap().len()))
     }
-    fn search_facts(&self, _q: &str, _l: u32, _c: f64) -> SimardResult<Vec<CognitiveFact>> {
-        Ok(vec![])
+    fn search_facts(&self, q: &str, _l: u32, min_conf: f64) -> SimardResult<Vec<CognitiveFact>> {
+        // Issue #2433: return seeded priors whose concept matches the query and
+        // whose confidence clears `min_conf`, so the don't-clobber guard sees
+        // the stronger existing fact. Default (no seed) → empty, preserving the
+        // pre-#2433 behaviour the other tests rely on.
+        let seeded = self.seeded_facts.lock().unwrap();
+        Ok(seeded
+            .iter()
+            .filter(|f| f.concept == q && f.confidence >= min_conf)
+            .cloned()
+            .collect())
     }
     fn store_procedure(&self, _n: &str, _s: &[String], _p: &[String]) -> SimardResult<String> {
         Ok("prc_x".to_string())
@@ -1126,4 +1164,261 @@ fn facts_only_wrapper_reads_real_prose_prefixed_envelope() {
         .expect("facts-only wrapper must parse the real envelope");
     assert_eq!(facts.len(), 1);
     assert_eq!(facts[0].concept, "bug-pattern");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Issue #2433: ISAO-style reliability gate on consolidation
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// Distillation now SELF-ASSESSES each candidate fact's reliability and gates on
+// `Fact.confidence` instead of writing a blind constant (BGML's ISAO, §IV):
+//   * low-reliability candidates are quarantined (not promoted), and
+//   * a weaker new fact never clobbers a stronger existing fact on the concept.
+
+/// Build a pre-existing `CognitiveFact` for seeding the mock's `search_facts`.
+fn seeded_fact(concept: &str, confidence: f64) -> CognitiveFact {
+    CognitiveFact {
+        node_id: format!("sem_seed_{concept}"),
+        concept: concept.to_string(),
+        content: format!("prior {concept}"),
+        confidence,
+        source_id: "prior".to_string(),
+        tags: vec![concept.to_string()],
+        usage_count: 0,
+        last_accessed_at: None,
+    }
+}
+
+/// A nominal fact — valid in-batch provenance, ≥3 words, known concept —
+/// scores at or above the legacy baseline (0.9) so good facts keep their
+/// downstream behaviour.
+#[test]
+fn reliability_score_nominal_fact_is_above_baseline() {
+    let episodes = vec![CognitiveEpisode {
+        node_id: "epi_00001".to_string(),
+        content: "event 1".to_string(),
+        source_label: "goal-curator".to_string(),
+        temporal_index: 1,
+        compressed: false,
+    }];
+    let fact = DistilledFact {
+        concept: "pr-pattern".to_string(),
+        content: "enable auto-merge before final review".to_string(),
+        source_episode_id: "epi_00001".to_string(),
+    };
+    let score = assess_fact_reliability(&fact, &episodes, std::slice::from_ref(&fact));
+    assert!(
+        (score - 0.9).abs() < 1e-9,
+        "grounded + ≥3 words + known concept must score 0.9; got {score}"
+    );
+    assert!(
+        score >= DISTILL_FACT_CONFIDENCE,
+        "a nominal fact must clear the legacy baseline for continuity"
+    );
+    assert!(score >= DISTILL_RELIABILITY_THRESHOLD);
+}
+
+/// Hallucinated provenance (source episode NOT in the batch) loses the 0.5
+/// grounding weight and drops below the gate even with good content.
+#[test]
+fn reliability_score_ungrounded_fact_is_below_threshold() {
+    let episodes = vec![CognitiveEpisode {
+        node_id: "epi_00001".to_string(),
+        content: "event 1".to_string(),
+        source_label: "goal-curator".to_string(),
+        temporal_index: 1,
+        compressed: false,
+    }];
+    let fact = DistilledFact {
+        concept: "bug-pattern".to_string(),
+        content: "this content looks plausible enough".to_string(),
+        source_episode_id: "epi_99999".to_string(), // not in batch
+    };
+    let score = assess_fact_reliability(&fact, &episodes, std::slice::from_ref(&fact));
+    assert!(
+        score < DISTILL_RELIABILITY_THRESHOLD,
+        "ungrounded provenance must fall below the gate; got {score}"
+    );
+    assert!(
+        (score - 0.4).abs() < 1e-9,
+        "0.3 content + 0.1 concept = 0.4; got {score}"
+    );
+}
+
+/// Corroboration: ≥2 facts agreeing on the same concept this pass adds a 0.1
+/// independent-agreement bonus, taking a nominal fact to a perfect 1.0.
+#[test]
+fn reliability_score_corroboration_bonus_applies() {
+    let episodes = vec![
+        CognitiveEpisode {
+            node_id: "epi_00001".to_string(),
+            content: "event 1".to_string(),
+            source_label: "goal-curator".to_string(),
+            temporal_index: 1,
+            compressed: false,
+        },
+        CognitiveEpisode {
+            node_id: "epi_00002".to_string(),
+            content: "event 2".to_string(),
+            source_label: "goal-curator".to_string(),
+            temporal_index: 2,
+            compressed: false,
+        },
+    ];
+    let batch = vec![
+        DistilledFact {
+            concept: "pr-pattern".to_string(),
+            content: "small PRs merge faster".to_string(),
+            source_episode_id: "epi_00001".to_string(),
+        },
+        DistilledFact {
+            concept: "pr-pattern".to_string(),
+            content: "auto-merge avoids stale reviews".to_string(),
+            source_episode_id: "epi_00002".to_string(),
+        },
+    ];
+    let score = assess_fact_reliability(&batch[0], &episodes, &batch);
+    assert!(
+        (score - 1.0).abs() < 1e-9,
+        "corroborated nominal fact = 1.0; got {score}"
+    );
+    assert!(KNOWN_DISTILL_CONCEPTS.contains(&"pr-pattern"));
+}
+
+/// An off-spec concept loses the concept-validity component.
+#[test]
+fn reliability_score_unknown_concept_loses_weight() {
+    let episodes = vec![CognitiveEpisode {
+        node_id: "epi_00001".to_string(),
+        content: "event 1".to_string(),
+        source_label: "goal-curator".to_string(),
+        temporal_index: 1,
+        compressed: false,
+    }];
+    let fact = DistilledFact {
+        concept: "made-up-concept".to_string(),
+        content: "grounded but off spec concept".to_string(),
+        source_episode_id: "epi_00001".to_string(),
+    };
+    let score = assess_fact_reliability(&fact, &episodes, std::slice::from_ref(&fact));
+    assert!(
+        (score - 0.8).abs() < 1e-9,
+        "0.5 grounded + 0.3 content = 0.8; got {score}"
+    );
+}
+
+/// End-to-end gate: a hallucinated-provenance fact is QUARANTINED — not stored
+/// — while the grounded fact in the same batch is promoted. Every episode is
+/// still marked distilled (the quarantine does not break the replay guard).
+#[test]
+fn distillation_quarantines_low_reliability_fact() {
+    let n = DISTILL_MIN_EPISODES as usize + 5;
+    let mock = EpisodeMock::with_episodes(n_episodes(n));
+    let runner = FixedFactsRunner {
+        facts: vec![
+            (
+                "pr-pattern".to_string(),
+                "enable auto-merge before final review".to_string(),
+                "epi_00001".to_string(), // grounded → promoted
+            ),
+            (
+                "bug-pattern".to_string(),
+                "looks plausible but provenance is fake".to_string(),
+                "epi_99999".to_string(), // NOT in batch → quarantined
+            ),
+        ],
+        call_count: AtomicU32::new(0),
+    };
+
+    let report = distill_recent_episodes_with_runner(&mock, &runner).unwrap();
+
+    assert_eq!(report.fact_count, 1, "only the grounded fact is promoted");
+    assert_eq!(
+        report.quarantined_count, 1,
+        "the hallucinated-provenance fact is gated"
+    );
+    assert_eq!(
+        report.marked_count as usize, n,
+        "all episodes still marked distilled"
+    );
+
+    let stored: Vec<String> = mock.facts_stored().into_iter().map(|(c, _)| c).collect();
+    assert!(stored.contains(&"pr-pattern".to_string()));
+    assert!(
+        !stored.contains(&"bug-pattern".to_string()),
+        "the low-reliability fact must NOT be promoted into semantic memory"
+    );
+}
+
+/// Integrity guard: a weaker new fact must not clobber a stronger existing fact
+/// on the same concept. The seeded 0.95 prior on `pr-pattern` blocks the new
+/// 0.9 candidate, while a concept with no prior is promoted normally.
+#[test]
+fn distillation_does_not_clobber_stronger_prior() {
+    let n = DISTILL_MIN_EPISODES as usize + 5;
+    let mock = EpisodeMock::with_episodes_and_seeded_facts(
+        n_episodes(n),
+        vec![seeded_fact("pr-pattern", 0.95)],
+    );
+    let runner = FixedFactsRunner {
+        facts: vec![
+            (
+                "pr-pattern".to_string(),
+                "enable auto-merge before final review".to_string(),
+                "epi_00001".to_string(), // computed 0.9 < 0.95 prior → blocked
+            ),
+            (
+                "bug-pattern".to_string(),
+                "empty outcome list panics cycle.rs".to_string(),
+                "epi_00007".to_string(), // no prior → promoted
+            ),
+        ],
+        call_count: AtomicU32::new(0),
+    };
+
+    let report = distill_recent_episodes_with_runner(&mock, &runner).unwrap();
+
+    assert_eq!(
+        report.fact_count, 1,
+        "only the un-conflicted fact is promoted"
+    );
+    assert_eq!(
+        report.quarantined_count, 1,
+        "the weaker pr-pattern candidate is blocked"
+    );
+
+    let stored: Vec<String> = mock.facts_stored().into_iter().map(|(c, _)| c).collect();
+    assert!(
+        !stored.contains(&"pr-pattern".to_string()),
+        "the stronger 0.95 prior must be preserved, not clobbered by the 0.9 candidate"
+    );
+    assert!(stored.contains(&"bug-pattern".to_string()));
+}
+
+/// Confidence written to semantic memory is the *computed* reliability score,
+/// not the legacy constant — turning `confidence` into a live signal.
+#[test]
+fn distilled_fact_confidence_is_computed_not_constant() {
+    let n = DISTILL_MIN_EPISODES as usize + 5;
+    let mock = EpisodeMock::with_episodes(n_episodes(n));
+    let runner = FixedFactsRunner {
+        facts: vec![(
+            "pr-pattern".to_string(),
+            "enable auto-merge before final review".to_string(),
+            "epi_00001".to_string(),
+        )],
+        call_count: AtomicU32::new(0),
+    };
+
+    let report = distill_recent_episodes_with_runner(&mock, &runner).unwrap();
+    assert_eq!(report.fact_count, 1);
+
+    let stored = mock.stored_facts_full();
+    assert_eq!(stored.len(), 1);
+    let (concept, _, confidence) = &stored[0];
+    assert_eq!(concept, "pr-pattern");
+    assert!(
+        (confidence - 0.9).abs() < 1e-9,
+        "confidence must be the computed score 0.9, not a constant; got {confidence}"
+    );
 }


### PR DESCRIPTION
## Summary

Implements **#2433** — an ISAO-style reliability gate on memory consolidation, derived from BGML (TPAMI 2024, *information self-assessment ownership*). Distillation now **self-assesses** each candidate fact's reliability and **gates on `Fact.confidence`** instead of writing a blind constant `0.7`, so low-reliability information is quarantined rather than corrupting past experience.

Part of the #2431 BGML research family. Independent of the #2432 escalation-ladder PR (disjoint files).

## What changed

- **`assess_fact_reliability(fact, episodes, batch_facts) -> f64`** scores each candidate in `[0,1]` from cheap local signals (no extra LLM call):
  | Signal | Weight |
  |--------|--------|
  | Provenance grounding (source episode is in this batch — **necessary**; without it a fact tops out at 0.4) | 0.5 |
  | Content quality (≥3 words; **empty content is a hard gate → 0.0**) | ≤0.3 |
  | Concept validity (known label) | 0.1 |
  | Cross-source corroboration (≥2 facts agree on the concept; **grounded facts only**) | 0.1 |

  A nominal grounded, known-concept, ≥3-word fact scores **0.9** — at/above the legacy `DISTILL_FACT_CONFIDENCE` baseline, so good facts are unaffected. A hallucinated-provenance fact scores ≤**0.4** (even with corroboration) and an empty fact **0.0** — both quarantined.
- **Gate**: candidates below `DISTILL_RELIABILITY_THRESHOLD` (0.5) are **quarantined** (not promoted). Survivors are written with their **computed** confidence.
- **Protect priors (identity-level)**: a weaker/equal new fact never downgrades a stronger existing copy of the **same fact** — matched on concept **and content**, not the 3-value concept label alone (a label-only guard would quarantine every distinct fact after the first and neuter distillation).
- `DistillReport` gains `quarantined_count`; a `distill_reliability_gate` self-metric records the block-rate for before/after measurement.
- Durable docs updated in `docs/architecture/episode-distillation.md`.

## Acceptance (issue #2433)

- ✅ Distilled facts written with a meaningful, computed `confidence` (not a constant).
- ✅ Low-reliability candidates demonstrably blocked; high-confidence priors not clobbered by weaker copies (tests).
- ✅ Block-rate recorded via self-metrics.

---

## Merge-ready evidence

### 1. QA-team (internal-only justification)

This change is **purely internal library logic** in `src/memory_consolidation/distillation.rs`. It is invoked only by the OODA autonomous loop (`src/ooda_actions/simple_actions.rs`) and the background consolidation scheduler (`src/memory_consolidation/scheduler.rs`). **No CLI subcommand, TUI screen, dashboard element, or API endpoint** is added or changed (verified: no `distill`/`consolidat` references in CLI command definitions). The repo's gadugi `tests/qa-scenarios/*` exercise CLI/TUI/dashboard/terminal surfaces; **none apply** to internal distillation. The gate's behaviour is observable only via internal metrics (`metrics.jsonl` → `distill_reliability_gate`) and the semantic-fact store, both covered by Rust unit/integration tests. → **No new user-facing surface; gadugi-test scenarios are N/A.**

### 3. Quality-audit — 3 SEEK→VALIDATE→FIX cycles, ended clean

- **Cycle 1 — SEEK** (independent `code-review` + `rubber-duck` agents + manual diff review). **VALIDATE**: confirmed two real defects —
  - **(HIGH)** the don't-clobber guard deduped by the 3-value *concept label*; since the recipe emits one fact per episode across only `pr-pattern`/`bug-pattern`/`lesson-learned` and every grounded fact scores identically (and prod store+search share one live graph), the 2nd same-concept fact in a pass was quarantined — silently **neutering distillation after the first pass**.
  - **(MEDIUM)** the threshold (0.5) equalled the grounding weight, so an *ungrounded* (hallucinated-provenance) fact reached exactly 0.5 via content+concept+corroboration and was **admitted**; a grounded empty-content fact reached 0.6.
  - **FIX** (commit `6a298bd3`): content-identity clobber guard; hard empty-content gate (→0.0); corroboration awarded to grounded facts only; mock `search_facts` now reflects in-pass writes (the test-fidelity gap that hid defect 1); +3 regression tests.
- **Cycle 2 — VALIDATE**: `cargo fmt --check` clean; `cargo clippy --all-targets -- -D warnings` clean (dev **and** release); `cargo test -p simard memory_consolidation` **107 passing** (was 104). Pre-push release gate (`cognitive_memory|bootstrap|memory_ipc|memory_consolidation` subset) **Passed**.
- **Cycle 3 — SEEK (final, post-fix)**: independent `code-review` agent re-reviewed the fixed diff and traced every documented score and guard path → **zero critical/high; zero medium correctness/security findings.** Verified distinct same-concept facts accumulate, weaker/equal identical re-distillation is blocked, ungrounded ceiling = 0.4, empty = 0.0, nominal = 0.9 / corroborated = 1.0 / unknown-concept = 0.8.

New/updated tests: `distillation_promotes_distinct_same_concept_facts` (fails on the old label-only guard), `reliability_score_ungrounded_corroborated_still_below_threshold`, `reliability_score_empty_content_is_zero`, and the rewritten `distillation_does_not_clobber_stronger_prior` (now identity-level).

### 4. CI

All required checks green on the prior head (`58a26e84`): `build`, `pre-commit`, `coverage`, `install-real`, `cargo-audit`, `e2e-dashboard`, `GitGuardian`. Re-validated after the fix push (`6a298bd3`) — see the checks panel on this PR.

### 6. Scope

Focused diff — **3 files**: `src/memory_consolidation/distillation.rs`, `src/memory_consolidation/distillation_tests.rs`, `docs/architecture/episode-distillation.md`. No unrelated edits.

Closes #2433
