### PR TITLE
feat(brain): confidence-gated escalation ladder for engineer-lifecycle (#2432)

### DIFF
--- a/docs/howto/diagnose-brain-decision-parse-failures.md
+++ b/docs/howto/diagnose-brain-decision-parse-failures.md
@@ -228,6 +228,20 @@ ladder is exhausted**. Each rung is logged loudly (`BRAIN ESCALATION …`).
 * A genuine recipe-runner failure (spawn/exit/envelope) still surfaces as a
   hard `error` — only a *parse-miss on a successful run* escalates.
 
+* **Termination `cause`**: each `brain_lifecycle_decision` row also carries a
+  `cause` label recording *why* the ladder stopped, so an early stop is not
+  mistaken for genuine exhaustion:
+
+  | `cause`               | Meaning                                                            |
+  | --------------------- | ------------------------------------------------------------------ |
+  | `ladder_recovered`    | a rung produced a parseable decision (`repaired` / `escalated`)    |
+  | `ladder_exhausted`    | every configured rung was tried; none parsed → deterministic default |
+  | `ladder_invoke_error` | a rung's own invocation failed; ladder stopped early → default      |
+  | `ladder_disabled`     | `SIMARD_BRAIN_ESCALATION_MAX_ATTEMPTS=0`; no rung attempted          |
+
+  A spike of `ladder_invoke_error` points at recipe-runner/adapter health, not
+  at the model's parse quality — diagnose those separately from `ladder_exhausted`.
+
 ## See Also
 
 * [Concept: text-based brain protocol](../concepts/text-based-brain-protocol.md)

--- a/docs/howto/diagnose-brain-decision-parse-failures.md
+++ b/docs/howto/diagnose-brain-decision-parse-failures.md
@@ -52,8 +52,10 @@ jq -rc 'select(.metric_name=="brain_lifecycle_decision") | .context | fromjson |
 
 A healthy lifecycle brain shows a mix of `parsed` outcomes (including genuine
 `continue_skipping`); a regression shows `default_malformed` dominating again
-(the symptom #2419 fixed). `is_parse_failure` in each context is `true` for any
-non-`parsed` outcome, so `count(is_parse_failure==true)/count(*)` is the rate.
+(the symptom #2419 fixed). `is_parse_failure` in each context is `true` only for
+the `default_empty` / `default_malformed` / `error` outcomes; `parsed` and the
+ladder-recovered `repaired` / `escalated` outcomes (issue #2432) are `false`, so
+`count(is_parse_failure==true)/count(*)` is the rate.
 
 ## Step 1: Find the failing cycle
 
@@ -189,6 +191,42 @@ proceeding:
 * **Adding a fallback in `dispatch_spawn_engineer` for a specific raw
   response.** The single fallback path (`ContinueSkipping`) is intentional;
   a parse failure should be visible in the logs, not silently rerouted.
+
+## Escalation ladder (issue #2432)
+
+A base parse-miss (`default_empty` / `default_malformed`) is a *low-confidence*
+signal, not an immediate verdict. Instead of defaulting on the first miss, the
+lifecycle brain runs a **bounded, confidence-gated escalation ladder** (BGML's
+progress-aware module — spend extra compute only on the weak cases):
+
+1. **Base** — the cheap attempt, exactly as before.
+2. **Schema-repair** — re-prompt feeding the malformed output back, reminding
+   the model the first word must be a valid variant (`escalation_note` context
+   var, rendered by the recipe's `{{escalation_note}}` placeholder).
+3. **Escalate** — schema-repair plus a higher-effort, step-by-step reasoning
+   instruction.
+
+The deterministic `continue_skipping` default is reached **only after the
+ladder is exhausted**. Each rung is logged loudly (`BRAIN ESCALATION …`).
+
+* **Bound**: `SIMARD_BRAIN_ESCALATION_MAX_ATTEMPTS` sets the number of rungs
+  attempted after a base miss (default `2`, hard-capped at `3`). `0` disables
+  the ladder. There is no unbounded retry.
+* **Metric**: `brain_lifecycle_decision` gains two non-failure outcomes,
+  `repaired` and `escalated` (a real decision recovered by the ladder), plus an
+  `attempts` field (base + rungs). A recovered decision does **not** count
+  toward the parse-failure numerator — that is how the ladder drops the
+  measured default/parse-failure rate. Compare the `repaired`/`escalated` share
+  against `default_*` to see the ladder working:
+
+  ```bash
+  jq -rc 'select(.metric_name=="brain_lifecycle_decision") | .context | fromjson | .outcome' \
+    ~/.simard/metrics/metrics.jsonl \
+    | sort | uniq -c
+  ```
+
+* A genuine recipe-runner failure (spawn/exit/envelope) still surfaces as a
+  hard `error` — only a *parse-miss on a successful run* escalates.
 
 ## See Also
 

--- a/prompt_assets/simard/recipes/ooda-engineer-lifecycle.yaml
+++ b/prompt_assets/simard/recipes/ooda-engineer-lifecycle.yaml
@@ -12,7 +12,11 @@
 #   goal_id, goal_description, cycle_number, consecutive_skip_count,
 #   failure_count, worktree_path, worktree_mtime_secs_ago, sentinel_pid,
 #   last_engineer_log_tail, commits_behind, in_flight_engineer_count,
-#   minutes_since_last_update_attempt
+#   minutes_since_last_update_attempt, escalation_note
+#
+# `escalation_note` (issue #2432) is empty on the base attempt and carries a
+# schema-repair / higher-effort instruction on escalation-ladder retries. When
+# empty it renders to nothing, so base behaviour is unchanged.
 #
 # Output: agent stdout — variant name as first word, followed by rationale
 
@@ -30,6 +34,8 @@ steps:
     agent: "default"
     prompt: |
       # OODA Brain — Engineer Lifecycle Decision
+
+      {{escalation_note}}
 
       ## ROLE
 

--- a/src/ooda_brain/recipe_brain.rs
+++ b/src/ooda_brain/recipe_brain.rs
@@ -299,6 +299,38 @@ impl Default for EscalationConfig {
     }
 }
 
+/// Why the confidence-gated escalation ladder stopped. Drives a precise
+/// `cause` label on the `brain_lifecycle_decision` metric so the three
+/// non-recovery terminations are distinguishable in telemetry: a ladder that
+/// genuinely ran out of rungs (`Exhausted`) reads differently from one cut
+/// short because a rung's own invocation failed (`InvokeError`) or one that
+/// was switched off by configuration (`Disabled`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LadderTermination {
+    /// A rung produced a parseable decision — `Repaired` / `Escalated`.
+    Recovered,
+    /// Every configured rung was tried; none parsed. Deterministic default.
+    Exhausted,
+    /// A rung's own invocation failed; the ladder stopped early and fell to
+    /// the deterministic default (the successful base attempt already gave a
+    /// usable, if low-confidence, signal — this is NOT a hard error).
+    InvokeError,
+    /// The ladder was disabled (`max_escalations == 0`); no rung was tried.
+    Disabled,
+}
+
+impl LadderTermination {
+    /// The `cause` label recorded on the lifecycle-decision metric.
+    pub fn cause_label(self) -> &'static str {
+        match self {
+            LadderTermination::Recovered => "ladder_recovered",
+            LadderTermination::Exhausted => "ladder_exhausted",
+            LadderTermination::InvokeError => "ladder_invoke_error",
+            LadderTermination::Disabled => "ladder_disabled",
+        }
+    }
+}
+
 /// Seam over the raw lifecycle recipe invocation so the escalation ladder is
 /// unit-testable without a live `recipe-runner-rs`. Production wires
 /// [`RecipeBrain`]; tests wire a scripted stub. Returns the raw decision text
@@ -316,7 +348,10 @@ pub trait LifecycleInvoker {
 /// `base_raw` is the (already-invoked) base attempt's raw output and
 /// `base_outcome` its parse-miss classification. Returns the final decision,
 /// its outcome (`Repaired`/`Escalated` on recovery, else the original
-/// parse-miss), and the total number of brain invocations made (base + rungs).
+/// parse-miss), the total number of brain invocations made (base + rungs), and
+/// the [`LadderTermination`] reason (so the caller can record a precise `cause`
+/// — distinguishing true exhaustion from an early stop caused by a rung's own
+/// invocation failure, or a disabled ladder).
 ///
 /// Bounded by `cfg.max_escalations`; each rung is logged loudly; the
 /// deterministic `continue_skipping` default is returned only when every rung
@@ -327,9 +362,15 @@ pub fn run_escalation_ladder(
     base_raw: &str,
     base_outcome: LifecycleParseOutcome,
     cfg: &EscalationConfig,
-) -> (EngineerLifecycleDecision, LifecycleParseOutcome, u32) {
+) -> (
+    EngineerLifecycleDecision,
+    LifecycleParseOutcome,
+    u32,
+    LadderTermination,
+) {
     let mut prior = base_raw.to_string();
     let mut attempts = 1u32; // the base attempt already happened
+    let mut invoke_failed = false;
 
     for rung_idx in 1..=cfg.max_escalations {
         let rung = if rung_idx == 1 {
@@ -369,6 +410,7 @@ pub fn run_escalation_ladder(
                     "[simard] BRAIN ESCALATION goal={} rung={:?} invoke failed: {e} — falling back to default",
                     ctx.goal_id, rung
                 );
+                invoke_failed = true;
                 break;
             }
             Ok(raw2) => {
@@ -394,7 +436,7 @@ pub fn run_escalation_ladder(
                         rung,
                         attempts
                     );
-                    return (decision, recovered, attempts);
+                    return (decision, recovered, attempts, LadderTermination::Recovered);
                 }
                 // Still a parse-miss — feed the latest malformed output into the
                 // next rung's repair note.
@@ -405,21 +447,36 @@ pub fn run_escalation_ladder(
 
     // Ladder exhausted, disabled, or an escalation invoke failed: fall to the
     // deterministic default, preserving the original parse-miss outcome for the
-    // metric numerator.
+    // metric numerator. The `termination` reason records *which* of those three
+    // paths we took so the metric `cause` label stays accurate.
+    let termination = if cfg.max_escalations == 0 {
+        LadderTermination::Disabled
+    } else if invoke_failed {
+        LadderTermination::InvokeError
+    } else {
+        LadderTermination::Exhausted
+    };
     if cfg.max_escalations > 0 {
         tracing::warn!(
             target: "simard::ooda_brain",
             goal = %ctx.goal_id,
             attempts,
             base_outcome = base_outcome.label(),
-            "brain escalation ladder exhausted without a parseable decision; deterministic default"
+            termination = ?termination,
+            "brain escalation ladder ended without a parseable decision; deterministic default"
         );
         eprintln!(
-            "[simard] BRAIN ESCALATION goal={} ladder exhausted after {attempts} attempts — deterministic default",
-            ctx.goal_id
+            "[simard] BRAIN ESCALATION goal={} ladder ended ({}) after {attempts} attempts — deterministic default",
+            ctx.goal_id,
+            termination.cause_label()
         );
     }
-    (default_continue_skipping(), base_outcome, attempts)
+    (
+        default_continue_skipping(),
+        base_outcome,
+        attempts,
+        termination,
+    )
 }
 
 /// Resolve the recipe YAML path. Checks, in order:
@@ -759,19 +816,20 @@ impl OodaBrain for RecipeBrain {
         // Parse-miss → confidence-gated escalation ladder (issue #2432). Spend
         // extra compute ONLY on this weak case.
         let cfg = EscalationConfig::from_env();
-        let (final_decision, final_outcome, attempts) =
+        let (final_decision, final_outcome, attempts, termination) =
             run_escalation_ladder(self, ctx, &base_raw, outcome, &cfg);
-        let cause = if final_outcome.is_parse_failure() {
-            "ladder_exhausted"
-        } else {
-            "ladder_recovered"
-        };
+        // NOTE: `first_word` intentionally always reflects the *base* attempt's
+        // token — it is the diagnostic record of what the cheap first pass
+        // produced (e.g. the banner regression or a malformed reply), even on a
+        // recovered row where `decision` reflects the recovering rung's choice.
+        // `termination.cause_label()` distinguishes recovered / exhausted /
+        // invoke-error / disabled so the two fields read unambiguously together.
         record_lifecycle_decision_metric(
             ctx,
             final_outcome,
             &lifecycle_first_word(&base_raw),
             lifecycle_decision_choice(&final_decision),
-            cause,
+            termination.cause_label(),
             attempts,
         );
         Ok(final_decision)
@@ -2830,6 +2888,33 @@ mod tests {
             assert!(!LifecycleParseOutcome::Escalated.is_parse_failure());
         }
 
+        #[test]
+        fn ladder_termination_cause_labels_are_distinct() {
+            assert_eq!(
+                LadderTermination::Recovered.cause_label(),
+                "ladder_recovered"
+            );
+            assert_eq!(
+                LadderTermination::Exhausted.cause_label(),
+                "ladder_exhausted"
+            );
+            assert_eq!(
+                LadderTermination::InvokeError.cause_label(),
+                "ladder_invoke_error"
+            );
+            assert_eq!(LadderTermination::Disabled.cause_label(), "ladder_disabled");
+            // The four non-equal terminations must yield four distinct labels so
+            // telemetry can tell exhaustion apart from an invoke-error stop.
+            let labels = [
+                LadderTermination::Recovered.cause_label(),
+                LadderTermination::Exhausted.cause_label(),
+                LadderTermination::InvokeError.cause_label(),
+                LadderTermination::Disabled.cause_label(),
+            ];
+            let unique: std::collections::BTreeSet<_> = labels.iter().collect();
+            assert_eq!(unique.len(), labels.len(), "cause labels must be distinct");
+        }
+
         // --- config bound ---
 
         #[test]
@@ -2861,7 +2946,7 @@ mod tests {
         fn ladder_recovers_via_schema_repair() {
             let invoker =
                 ScriptedInvoker::new(vec![Ok("reclaim_and_redispatch worktree idle 7h".into())]);
-            let (decision, outcome, attempts) = run_escalation_ladder(
+            let (decision, outcome, attempts, termination) = run_escalation_ladder(
                 &invoker,
                 &sample_ctx(),
                 "OK the engineer looks fine", // base parse-miss text
@@ -2869,6 +2954,7 @@ mod tests {
                 &EscalationConfig::default(),
             );
             assert_eq!(outcome, LifecycleParseOutcome::Repaired);
+            assert_eq!(termination, LadderTermination::Recovered);
             assert!(!outcome.is_parse_failure());
             assert_eq!(attempts, 2, "base + one schema-repair rung");
             assert!(matches!(
@@ -2886,7 +2972,7 @@ mod tests {
                 Ok("still not a variant word".into()), // schema-repair misses
                 Ok("deprioritize stale goal".into()),  // escalate recovers
             ]);
-            let (decision, outcome, attempts) = run_escalation_ladder(
+            let (decision, outcome, attempts, termination) = run_escalation_ladder(
                 &invoker,
                 &sample_ctx(),
                 "garbage",
@@ -2894,6 +2980,7 @@ mod tests {
                 &EscalationConfig::default(),
             );
             assert_eq!(outcome, LifecycleParseOutcome::Escalated);
+            assert_eq!(termination, LadderTermination::Recovered);
             assert_eq!(attempts, 3, "base + schema-repair + escalate");
             assert!(matches!(
                 decision,
@@ -2911,7 +2998,7 @@ mod tests {
         #[test]
         fn ladder_bounded_cap_exhausts_to_default() {
             let invoker = ScriptedInvoker::new(vec![Ok("nope".into()), Ok("still nope".into())]);
-            let (decision, outcome, attempts) = run_escalation_ladder(
+            let (decision, outcome, attempts, termination) = run_escalation_ladder(
                 &invoker,
                 &sample_ctx(),
                 "banner noise",
@@ -2919,6 +3006,7 @@ mod tests {
                 &EscalationConfig::default(), // 2 rungs
             );
             assert_eq!(outcome, LifecycleParseOutcome::DefaultMalformed);
+            assert_eq!(termination, LadderTermination::Exhausted);
             assert!(outcome.is_parse_failure());
             assert_eq!(attempts, 3, "base + exactly 2 bounded rungs");
             assert!(matches!(
@@ -2933,7 +3021,7 @@ mod tests {
         #[test]
         fn ladder_disabled_runs_no_escalations() {
             let invoker = ScriptedInvoker::new(vec![]);
-            let (decision, outcome, attempts) = run_escalation_ladder(
+            let (decision, outcome, attempts, termination) = run_escalation_ladder(
                 &invoker,
                 &sample_ctx(),
                 "banner noise",
@@ -2941,6 +3029,7 @@ mod tests {
                 &EscalationConfig { max_escalations: 0 },
             );
             assert_eq!(outcome, LifecycleParseOutcome::DefaultEmpty);
+            assert_eq!(termination, LadderTermination::Disabled);
             assert_eq!(attempts, 1, "only the base attempt");
             assert!(matches!(
                 decision,
@@ -2955,7 +3044,7 @@ mod tests {
         #[test]
         fn ladder_invoke_error_falls_back_to_default() {
             let invoker = ScriptedInvoker::new(vec![Err(())]);
-            let (decision, outcome, attempts) = run_escalation_ladder(
+            let (decision, outcome, attempts, termination) = run_escalation_ladder(
                 &invoker,
                 &sample_ctx(),
                 "garbage",
@@ -2964,6 +3053,12 @@ mod tests {
             );
             assert_eq!(outcome, LifecycleParseOutcome::DefaultMalformed);
             assert_eq!(attempts, 2, "base + the failed rung, then stop");
+            assert_eq!(
+                termination,
+                LadderTermination::InvokeError,
+                "an early stop caused by a rung's own invoke failure must be \
+                 distinguishable from true exhaustion in the metric cause"
+            );
             assert!(matches!(
                 decision,
                 EngineerLifecycleDecision::ContinueSkipping { .. }

--- a/src/ooda_brain/recipe_brain.rs
+++ b/src/ooda_brain/recipe_brain.rs
@@ -132,6 +132,16 @@ pub enum LifecycleParseOutcome {
     /// could be obtained. Produced on the error path of
     /// `decide_engineer_lifecycle`, not by the pure parser.
     Error,
+    /// A real decision was recovered by a SCHEMA-REPAIR re-prompt after the
+    /// base attempt produced a parse-miss (issue #2432, BGML progress-aware
+    /// escalation). Counts as a success — it is the whole point of the ladder:
+    /// it converts what would have been a silent `default_*` into a real
+    /// decision, dropping the parse-failure rate.
+    Repaired,
+    /// A real decision was recovered by a higher-effort ESCALATED re-prompt
+    /// (schema-repair + step-by-step reasoning tier) after schema-repair alone
+    /// still parse-missed (issue #2432). Also a success.
+    Escalated,
 }
 
 impl LifecycleParseOutcome {
@@ -142,14 +152,269 @@ impl LifecycleParseOutcome {
             LifecycleParseOutcome::DefaultEmpty => "default_empty",
             LifecycleParseOutcome::DefaultMalformed => "default_malformed",
             LifecycleParseOutcome::Error => "error",
+            LifecycleParseOutcome::Repaired => "repaired",
+            LifecycleParseOutcome::Escalated => "escalated",
         }
     }
 
     /// Whether this outcome counts toward the parse-failure numerator
-    /// (everything except a real parsed decision).
+    /// (everything except a real decision). `Repaired` and `Escalated` are
+    /// real decisions recovered by the ladder, so they do NOT count as
+    /// failures — that is how the escalation ladder reduces the measured
+    /// default/parse-failure rate (issue #2432).
     pub fn is_parse_failure(self) -> bool {
-        !matches!(self, LifecycleParseOutcome::Parsed)
+        matches!(
+            self,
+            LifecycleParseOutcome::DefaultEmpty
+                | LifecycleParseOutcome::DefaultMalformed
+                | LifecycleParseOutcome::Error
+        )
     }
+}
+
+// ---------------------------------------------------------------------------
+// Confidence-gated escalation ladder (issue #2432, BGML progress-aware module)
+//
+// On a base parse-miss (`DefaultEmpty`/`DefaultMalformed` — the brain's coarse
+// judgment was unparseable, i.e. low confidence) we spend EXTRA compute ONLY on
+// that weak case: a bounded sequence of re-prompts that (1) feed the malformed
+// output back asking for a valid first-word variant (schema-repair) and (2)
+// escalate to a higher-effort reasoning tier. The deterministic
+// `continue_skipping` default is reached only AFTER the ladder is exhausted —
+// replacing the previous silent default-on-first-miss behaviour (#2419 family).
+// ---------------------------------------------------------------------------
+
+/// One rung of the escalation ladder.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LadderRung {
+    /// Base attempt — cheap parse, exactly as the #2419 path.
+    Base,
+    /// Schema-repair re-prompt: feed the malformed prior output back asking for
+    /// a valid first-word variant. Same reasoning tier.
+    SchemaRepair,
+    /// Schema-repair PLUS a higher-effort, step-by-step reasoning tier bump.
+    Escalate,
+}
+
+/// Parameters for a single lifecycle recipe invocation. `prior_output` is the
+/// malformed text fed back on repair/escalate rungs (empty on `Base`).
+pub struct LadderAttempt<'a> {
+    pub rung: LadderRung,
+    pub prior_output: &'a str,
+}
+
+impl LadderAttempt<'_> {
+    /// The base (cheap) attempt — no repair note.
+    pub fn base() -> LadderAttempt<'static> {
+        LadderAttempt {
+            rung: LadderRung::Base,
+            prior_output: "",
+        }
+    }
+
+    /// The `escalation_note` context var fed to the recipe for this rung.
+    /// Empty on `Base` so base behaviour is byte-identical to pre-#2432.
+    pub fn escalation_note(&self) -> String {
+        build_escalation_note(self.rung, self.prior_output)
+    }
+}
+
+/// The closed variant token list, echoed into the schema-repair note so the
+/// model is reminded of the exact accepted first words. Kept in sync with the
+/// recipe `OPTIONS` section and `rustyclawd::VALID_VARIANTS`.
+const LIFECYCLE_VARIANT_LIST: &str = "continue_skipping, reclaim_and_redispatch, deprioritize, open_tracking_issue, mark_goal_blocked, consider_self_update";
+
+/// Build the `escalation_note` injected into the recipe prompt for a given
+/// rung. Pinned wording — see the `escalation_note_*` content-pin tests.
+pub fn build_escalation_note(rung: LadderRung, prior_output: &str) -> String {
+    if matches!(rung, LadderRung::Base) {
+        return String::new();
+    }
+    let prior = truncate(prior_output.trim(), MAX_RATIONALE_CHARS);
+    let repair = format!(
+        "## ⚠️ SCHEMA REPAIR (retry) ## \
+         Your previous response could not be parsed: its FIRST WORD was not a valid decision variant. \
+         Previous response: <<<{prior}>>> \
+         Respond again now. The VERY FIRST WORD of your reply MUST be exactly one of: {LIFECYCLE_VARIANT_LIST}. \
+         Output that variant word first, then your rationale."
+    );
+    match rung {
+        LadderRung::Base => String::new(),
+        LadderRung::SchemaRepair => repair,
+        LadderRung::Escalate => format!(
+            "{repair} ## HIGH-EFFORT RETRY ## \
+             This is a final, higher-effort attempt. Reason carefully, step by step, about the \
+             engineer's state BEFORE answering, then output the single variant word first."
+        ),
+    }
+}
+
+/// Bound on how far the escalation ladder climbs. Configurable via
+/// `SIMARD_BRAIN_ESCALATION_MAX_ATTEMPTS`, hard-capped so a misconfiguration
+/// can never turn the brain into an unbounded retry loop.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EscalationConfig {
+    /// Number of escalation rungs attempted AFTER a base parse-miss. `0`
+    /// disables the ladder (pre-#2432 default-on-first-miss behaviour).
+    pub max_escalations: u32,
+}
+
+impl EscalationConfig {
+    /// Default rungs: schema-repair, then schema-repair + high-effort.
+    pub const DEFAULT_MAX_ESCALATIONS: u32 = 2;
+    /// Absolute ceiling regardless of env configuration.
+    pub const HARD_CAP: u32 = 3;
+    /// Env var that overrides [`DEFAULT_MAX_ESCALATIONS`](Self::DEFAULT_MAX_ESCALATIONS).
+    pub const ENV_VAR: &'static str = "SIMARD_BRAIN_ESCALATION_MAX_ATTEMPTS";
+
+    /// Read the cap from the environment, clamped to `[0, HARD_CAP]`.
+    pub fn from_env() -> Self {
+        Self {
+            max_escalations: parse_max_escalations(std::env::var(Self::ENV_VAR).ok().as_deref()),
+        }
+    }
+}
+
+/// Parse the `SIMARD_BRAIN_ESCALATION_MAX_ATTEMPTS` value into a bounded rung
+/// count. Unset / unparseable → [`EscalationConfig::DEFAULT_MAX_ESCALATIONS`];
+/// always clamped to [`EscalationConfig::HARD_CAP`] so no configuration can
+/// produce an unbounded retry loop. Pure so it is unit-testable without env
+/// mutation.
+fn parse_max_escalations(raw: Option<&str>) -> u32 {
+    raw.and_then(|s| s.trim().parse::<u32>().ok())
+        .unwrap_or(EscalationConfig::DEFAULT_MAX_ESCALATIONS)
+        .min(EscalationConfig::HARD_CAP)
+}
+
+impl Default for EscalationConfig {
+    fn default() -> Self {
+        Self {
+            max_escalations: Self::DEFAULT_MAX_ESCALATIONS,
+        }
+    }
+}
+
+/// Seam over the raw lifecycle recipe invocation so the escalation ladder is
+/// unit-testable without a live `recipe-runner-rs`. Production wires
+/// [`RecipeBrain`]; tests wire a scripted stub. Returns the raw decision text
+/// (the recipe's final step output); errors propagate.
+pub trait LifecycleInvoker {
+    fn invoke_lifecycle(
+        &self,
+        ctx: &EngineerLifecycleCtx,
+        attempt: &LadderAttempt,
+    ) -> SimardResult<String>;
+}
+
+/// Drive the confidence-gated escalation ladder after a base parse-miss.
+///
+/// `base_raw` is the (already-invoked) base attempt's raw output and
+/// `base_outcome` its parse-miss classification. Returns the final decision,
+/// its outcome (`Repaired`/`Escalated` on recovery, else the original
+/// parse-miss), and the total number of brain invocations made (base + rungs).
+///
+/// Bounded by `cfg.max_escalations`; each rung is logged loudly; the
+/// deterministic `continue_skipping` default is returned only when every rung
+/// is exhausted (or an escalation invocation itself fails).
+pub fn run_escalation_ladder(
+    invoker: &dyn LifecycleInvoker,
+    ctx: &EngineerLifecycleCtx,
+    base_raw: &str,
+    base_outcome: LifecycleParseOutcome,
+    cfg: &EscalationConfig,
+) -> (EngineerLifecycleDecision, LifecycleParseOutcome, u32) {
+    let mut prior = base_raw.to_string();
+    let mut attempts = 1u32; // the base attempt already happened
+
+    for rung_idx in 1..=cfg.max_escalations {
+        let rung = if rung_idx == 1 {
+            LadderRung::SchemaRepair
+        } else {
+            LadderRung::Escalate
+        };
+        attempts += 1;
+
+        tracing::warn!(
+            target: "simard::ooda_brain",
+            goal = %ctx.goal_id,
+            rung = ?rung,
+            attempt = attempts,
+            base_outcome = base_outcome.label(),
+            "brain decision parse-miss → escalating (confidence-gated ladder, issue #2432)"
+        );
+        eprintln!(
+            "[simard] BRAIN ESCALATION goal={} rung={:?} attempt={} (parse-miss recovery)",
+            ctx.goal_id, rung, attempts
+        );
+
+        let attempt = LadderAttempt {
+            rung,
+            prior_output: &prior,
+        };
+        match invoker.invoke_lifecycle(ctx, &attempt) {
+            Err(e) => {
+                tracing::warn!(
+                    target: "simard::ooda_brain",
+                    goal = %ctx.goal_id,
+                    rung = ?rung,
+                    error = %e,
+                    "brain escalation attempt failed to invoke; stopping ladder, using deterministic default"
+                );
+                eprintln!(
+                    "[simard] BRAIN ESCALATION goal={} rung={:?} invoke failed: {e} — falling back to default",
+                    ctx.goal_id, rung
+                );
+                break;
+            }
+            Ok(raw2) => {
+                let (decision, oc) = parse_lifecycle_outcome(&raw2);
+                if !oc.is_parse_failure() {
+                    let recovered = match rung {
+                        LadderRung::SchemaRepair => LifecycleParseOutcome::Repaired,
+                        LadderRung::Escalate => LifecycleParseOutcome::Escalated,
+                        LadderRung::Base => oc,
+                    };
+                    tracing::info!(
+                        target: "simard::ooda_brain",
+                        goal = %ctx.goal_id,
+                        rung = ?rung,
+                        attempt = attempts,
+                        decision = lifecycle_decision_choice(&decision),
+                        "brain decision RECOVERED via escalation ladder (issue #2432)"
+                    );
+                    eprintln!(
+                        "[simard] BRAIN ESCALATION goal={} RECOVERED decision={} via {:?} (attempt {})",
+                        ctx.goal_id,
+                        lifecycle_decision_choice(&decision),
+                        rung,
+                        attempts
+                    );
+                    return (decision, recovered, attempts);
+                }
+                // Still a parse-miss — feed the latest malformed output into the
+                // next rung's repair note.
+                prior = raw2;
+            }
+        }
+    }
+
+    // Ladder exhausted, disabled, or an escalation invoke failed: fall to the
+    // deterministic default, preserving the original parse-miss outcome for the
+    // metric numerator.
+    if cfg.max_escalations > 0 {
+        tracing::warn!(
+            target: "simard::ooda_brain",
+            goal = %ctx.goal_id,
+            attempts,
+            base_outcome = base_outcome.label(),
+            "brain escalation ladder exhausted without a parseable decision; deterministic default"
+        );
+        eprintln!(
+            "[simard] BRAIN ESCALATION goal={} ladder exhausted after {attempts} attempts — deterministic default",
+            ctx.goal_id
+        );
+    }
+    (default_continue_skipping(), base_outcome, attempts)
 }
 
 /// Resolve the recipe YAML path. Checks, in order:
@@ -318,11 +583,22 @@ impl OodaOrientBrain for RecipeBrain {
     }
 }
 
-impl OodaBrain for RecipeBrain {
-    fn decide_engineer_lifecycle(
+impl RecipeBrain {
+    /// Invoke the engineer-lifecycle recipe once for the given ladder rung and
+    /// return the raw decision text (the recipe's final step output). On
+    /// failure returns the error PLUS a stable `cause` label
+    /// (`spawn_failed` / `nonzero_exit` / `envelope_decode_failed`) for the
+    /// `brain_lifecycle_decision` metric.
+    ///
+    /// The `escalation_note` context var (empty on `LadderRung::Base`) carries
+    /// the schema-repair / high-effort instruction; it is rendered by the
+    /// recipe's `{{escalation_note}}` placeholder. Passing it on every call
+    /// keeps base behaviour byte-identical to the #2419 path.
+    fn invoke_lifecycle_raw(
         &self,
         ctx: &EngineerLifecycleCtx,
-    ) -> SimardResult<EngineerLifecycleDecision> {
+        attempt: &LadderAttempt,
+    ) -> Result<String, (SimardError, &'static str)> {
         let sentinel = ctx
             .sentinel_pid
             .map(|p| p.to_string())
@@ -332,6 +608,7 @@ impl OodaBrain for RecipeBrain {
         } else {
             ctx.minutes_since_last_update_attempt.to_string()
         };
+        let escalation_note = attempt.escalation_note();
 
         let output = Command::new("recipe-runner-rs")
             .arg(self.recipe_path.as_os_str())
@@ -385,67 +662,114 @@ impl OodaBrain for RecipeBrain {
             ))
             .arg("-c")
             .arg(format!("minutes_since_last_update_attempt={minutes}"))
+            // issue #2432: the (possibly empty) escalation/schema-repair note.
+            .arg("-c")
+            .arg(format!(
+                "escalation_note={}",
+                sanitize_context_var(&escalation_note, 4000)
+            ))
             .output();
 
         let output = match output {
             Ok(o) => o,
             Err(e) => {
-                record_lifecycle_decision_metric(
-                    ctx,
-                    LifecycleParseOutcome::Error,
-                    "",
-                    "none",
+                return Err((
+                    SimardError::AdapterInvocationFailed {
+                        base_type: self.adapter_tag.to_string(),
+                        reason: format!("recipe-runner-rs spawn failed: {e}"),
+                    },
                     "spawn_failed",
-                );
-                return Err(SimardError::AdapterInvocationFailed {
-                    base_type: self.adapter_tag.to_string(),
-                    reason: format!("recipe-runner-rs spawn failed: {e}"),
-                });
+                ));
             }
         };
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            record_lifecycle_decision_metric(
-                ctx,
-                LifecycleParseOutcome::Error,
-                "",
-                "none",
+            return Err((
+                SimardError::AdapterInvocationFailed {
+                    base_type: self.adapter_tag.to_string(),
+                    reason: format!(
+                        "recipe exited with {}: {}",
+                        output.status,
+                        truncate(&stderr, MAX_RATIONALE_CHARS)
+                    ),
+                },
                 "nonzero_exit",
-            );
-            return Err(SimardError::AdapterInvocationFailed {
-                base_type: self.adapter_tag.to_string(),
-                reason: format!(
-                    "recipe exited with {}: {}",
-                    output.status,
-                    truncate(&stderr, MAX_RATIONALE_CHARS)
-                ),
-            });
+            ));
         }
 
-        let raw = match extract_recipe_decision_output(&output.stdout, self.adapter_tag) {
-            Ok(s) => s,
-            Err(e) => {
+        extract_recipe_decision_output(&output.stdout, self.adapter_tag)
+            .map_err(|e| (e, "envelope_decode_failed"))
+    }
+}
+
+impl LifecycleInvoker for RecipeBrain {
+    fn invoke_lifecycle(
+        &self,
+        ctx: &EngineerLifecycleCtx,
+        attempt: &LadderAttempt,
+    ) -> SimardResult<String> {
+        self.invoke_lifecycle_raw(ctx, attempt).map_err(|(e, _)| e)
+    }
+}
+
+impl OodaBrain for RecipeBrain {
+    fn decide_engineer_lifecycle(
+        &self,
+        ctx: &EngineerLifecycleCtx,
+    ) -> SimardResult<EngineerLifecycleDecision> {
+        // Base (cheap) attempt — identical to the #2419 path. A genuine
+        // recipe-runner failure still surfaces loudly as `Err` (it must NOT be
+        // masked by the ladder): only a *parse-miss* on a successful run is
+        // low-confidence enough to escalate.
+        let base_raw = match self.invoke_lifecycle_raw(ctx, &LadderAttempt::base()) {
+            Ok(raw) => raw,
+            Err((e, cause)) => {
                 record_lifecycle_decision_metric(
                     ctx,
                     LifecycleParseOutcome::Error,
                     "",
                     "none",
-                    "envelope_decode_failed",
+                    cause,
+                    1,
                 );
                 return Err(e);
             }
         };
 
-        let (decision, outcome) = parse_lifecycle_outcome(&raw);
+        let (decision, outcome) = parse_lifecycle_outcome(&base_raw);
+        if !outcome.is_parse_failure() {
+            // Parsed on the first try — no extra compute spent.
+            record_lifecycle_decision_metric(
+                ctx,
+                outcome,
+                &lifecycle_first_word(&base_raw),
+                lifecycle_decision_choice(&decision),
+                "ok",
+                1,
+            );
+            return Ok(decision);
+        }
+
+        // Parse-miss → confidence-gated escalation ladder (issue #2432). Spend
+        // extra compute ONLY on this weak case.
+        let cfg = EscalationConfig::from_env();
+        let (final_decision, final_outcome, attempts) =
+            run_escalation_ladder(self, ctx, &base_raw, outcome, &cfg);
+        let cause = if final_outcome.is_parse_failure() {
+            "ladder_exhausted"
+        } else {
+            "ladder_recovered"
+        };
         record_lifecycle_decision_metric(
             ctx,
-            outcome,
-            &lifecycle_first_word(&raw),
-            lifecycle_decision_choice(&decision),
-            "ok",
+            final_outcome,
+            &lifecycle_first_word(&base_raw),
+            lifecycle_decision_choice(&final_decision),
+            cause,
+            attempts,
         );
-        Ok(decision)
+        Ok(final_decision)
     }
 }
 
@@ -682,6 +1006,7 @@ fn build_lifecycle_metric_context(
     first_word: &str,
     decision_choice: &str,
     cause: &str,
+    attempts: u32,
 ) -> String {
     serde_json::json!({
         "goal_id": ctx.goal_id,
@@ -691,6 +1016,8 @@ fn build_lifecycle_metric_context(
         "consecutive_skip_count": ctx.consecutive_skip_count,
         "decision": decision_choice,
         "cause": cause,
+        // issue #2432: total brain invocations spent (base + escalation rungs).
+        "attempts": attempts,
     })
     .to_string()
 }
@@ -698,6 +1025,8 @@ fn build_lifecycle_metric_context(
 /// Record one `brain_lifecycle_decision` metric event (value `1.0`) per
 /// `decide_engineer_lifecycle` invocation so the parse-failure rate
 /// (`outcome != "parsed"`) is measurable from `metrics.jsonl` (issue #2419).
+/// The `attempts` field (issue #2432) records how many brain invocations the
+/// escalation ladder spent.
 ///
 /// Best-effort: a metrics-write failure is logged, never propagated — the
 /// brain decision must not fail because telemetry could not be persisted.
@@ -711,8 +1040,10 @@ fn record_lifecycle_decision_metric(
     first_word: &str,
     decision_choice: &str,
     cause: &str,
+    attempts: u32,
 ) {
-    let context = build_lifecycle_metric_context(ctx, outcome, first_word, decision_choice, cause);
+    let context =
+        build_lifecycle_metric_context(ctx, outcome, first_word, decision_choice, cause, attempts);
     if cfg!(test) {
         return;
     }
@@ -2329,6 +2660,7 @@ mod tests {
                 "reclaim_and_redispatch",
                 "reclaim_and_redispatch",
                 "ok",
+                1,
             );
             let v: serde_json::Value = serde_json::from_str(&payload).unwrap();
             assert_eq!(v["goal_id"], "fix-the-thing");
@@ -2338,6 +2670,7 @@ mod tests {
             assert_eq!(v["consecutive_skip_count"], 12);
             assert_eq!(v["decision"], "reclaim_and_redispatch");
             assert_eq!(v["cause"], "ok");
+            assert_eq!(v["attempts"], 1);
         }
 
         #[test]
@@ -2349,7 +2682,7 @@ mod tests {
                 LifecycleParseOutcome::Error,
             ] {
                 let payload =
-                    build_lifecycle_metric_context(&ctx, outcome, "", "continue_skipping", "ok");
+                    build_lifecycle_metric_context(&ctx, outcome, "", "continue_skipping", "ok", 1);
                 let v: serde_json::Value = serde_json::from_str(&payload).unwrap();
                 assert_eq!(v["outcome"], outcome.label());
                 assert_eq!(
@@ -2366,6 +2699,293 @@ mod tests {
             let huge = format!("{} rest of response", "z".repeat(500));
             let fw = lifecycle_first_word(&huge);
             assert!(fw.chars().count() <= METRIC_FIRST_WORD_CHARS + 1);
+        }
+    }
+
+    // ===================================================================
+    // Issue #2432 — confidence-gated escalation ladder (schema-repair +
+    // higher-effort tier bump) replacing the zero-retry parse→default.
+    // ===================================================================
+
+    mod issue_2432_tests {
+        use super::super::*;
+        use crate::ooda_brain::EngineerLifecycleCtx;
+        use std::collections::VecDeque;
+        use std::path::PathBuf;
+        use std::sync::Mutex;
+
+        fn sample_ctx() -> EngineerLifecycleCtx {
+            EngineerLifecycleCtx {
+                goal_id: "fix-the-thing".into(),
+                goal_description: "desc".into(),
+                cycle_number: 7,
+                consecutive_skip_count: 12,
+                failure_count: 0,
+                worktree_path: PathBuf::from("/tmp/wt"),
+                worktree_mtime_secs_ago: 60,
+                sentinel_pid: Some(42),
+                last_engineer_log_tail: "tail".into(),
+                commits_behind: 0,
+                in_flight_engineer_count: 1,
+                minutes_since_last_update_attempt: u64::MAX,
+            }
+        }
+
+        /// A scripted [`LifecycleInvoker`]: each call pops the next queued
+        /// response (`Ok(text)` or a synthesized adapter error) and records the
+        /// rung + rendered escalation note it was asked for.
+        struct ScriptedInvoker {
+            responses: Mutex<VecDeque<Result<String, ()>>>,
+            seen_rungs: Mutex<Vec<LadderRung>>,
+            seen_notes: Mutex<Vec<String>>,
+        }
+
+        impl ScriptedInvoker {
+            fn new(responses: Vec<Result<String, ()>>) -> Self {
+                Self {
+                    responses: Mutex::new(responses.into_iter().collect()),
+                    seen_rungs: Mutex::new(Vec::new()),
+                    seen_notes: Mutex::new(Vec::new()),
+                }
+            }
+            fn rungs(&self) -> Vec<LadderRung> {
+                self.seen_rungs.lock().unwrap().clone()
+            }
+            fn notes(&self) -> Vec<String> {
+                self.seen_notes.lock().unwrap().clone()
+            }
+        }
+
+        impl LifecycleInvoker for ScriptedInvoker {
+            fn invoke_lifecycle(
+                &self,
+                _ctx: &EngineerLifecycleCtx,
+                attempt: &LadderAttempt,
+            ) -> SimardResult<String> {
+                self.seen_rungs.lock().unwrap().push(attempt.rung);
+                self.seen_notes
+                    .lock()
+                    .unwrap()
+                    .push(attempt.escalation_note());
+                match self.responses.lock().unwrap().pop_front() {
+                    Some(Ok(s)) => Ok(s),
+                    Some(Err(())) => Err(SimardError::AdapterInvocationFailed {
+                        base_type: "test".into(),
+                        reason: "scripted invoke failure".into(),
+                    }),
+                    None => panic!("ScriptedInvoker called more times than scripted"),
+                }
+            }
+        }
+
+        // --- escalation note (pinned wording) ---
+
+        #[test]
+        fn escalation_note_base_is_empty() {
+            assert_eq!(build_escalation_note(LadderRung::Base, "anything"), "");
+        }
+
+        #[test]
+        fn escalation_note_schema_repair_pins_wording() {
+            let note = build_escalation_note(LadderRung::SchemaRepair, "OK looks fine to me");
+            assert!(note.contains("SCHEMA REPAIR"), "note: {note}");
+            assert!(
+                note.contains("FIRST WORD"),
+                "note must remind about first word"
+            );
+            assert!(
+                note.contains("continue_skipping")
+                    && note.contains("reclaim_and_redispatch")
+                    && note.contains("consider_self_update"),
+                "note must echo the full variant list"
+            );
+            assert!(
+                note.contains("OK looks fine to me"),
+                "note must feed the malformed prior output back"
+            );
+        }
+
+        #[test]
+        fn escalation_note_escalate_adds_high_effort() {
+            let note = build_escalation_note(LadderRung::Escalate, "junk");
+            assert!(note.contains("SCHEMA REPAIR"), "escalate still repairs");
+            assert!(
+                note.contains("HIGH-EFFORT"),
+                "escalate adds the effort tier"
+            );
+        }
+
+        // --- outcome semantics ---
+
+        #[test]
+        fn repaired_and_escalated_are_not_parse_failures() {
+            assert_eq!(LifecycleParseOutcome::Repaired.label(), "repaired");
+            assert_eq!(LifecycleParseOutcome::Escalated.label(), "escalated");
+            assert!(!LifecycleParseOutcome::Repaired.is_parse_failure());
+            assert!(!LifecycleParseOutcome::Escalated.is_parse_failure());
+        }
+
+        // --- config bound ---
+
+        #[test]
+        fn config_parse_defaults_and_clamps() {
+            assert_eq!(
+                parse_max_escalations(None),
+                EscalationConfig::DEFAULT_MAX_ESCALATIONS
+            );
+            assert_eq!(
+                parse_max_escalations(Some("garbage")),
+                EscalationConfig::DEFAULT_MAX_ESCALATIONS
+            );
+            assert_eq!(parse_max_escalations(Some("0")), 0);
+            assert_eq!(parse_max_escalations(Some("1")), 1);
+            // Hard cap: no configuration can produce an unbounded loop.
+            assert_eq!(
+                parse_max_escalations(Some("99")),
+                EscalationConfig::HARD_CAP
+            );
+            assert_eq!(parse_max_escalations(Some("  2 ")), 2);
+        }
+
+        // --- ladder behaviour ---
+
+        /// A parse-miss recovered by the FIRST (schema-repair) rung yields a
+        /// real decision, the `Repaired` outcome, and exactly 2 invocations
+        /// (base + 1 rung).
+        #[test]
+        fn ladder_recovers_via_schema_repair() {
+            let invoker =
+                ScriptedInvoker::new(vec![Ok("reclaim_and_redispatch worktree idle 7h".into())]);
+            let (decision, outcome, attempts) = run_escalation_ladder(
+                &invoker,
+                &sample_ctx(),
+                "OK the engineer looks fine", // base parse-miss text
+                LifecycleParseOutcome::DefaultMalformed,
+                &EscalationConfig::default(),
+            );
+            assert_eq!(outcome, LifecycleParseOutcome::Repaired);
+            assert!(!outcome.is_parse_failure());
+            assert_eq!(attempts, 2, "base + one schema-repair rung");
+            assert!(matches!(
+                decision,
+                EngineerLifecycleDecision::ReclaimAndRedispatch { .. }
+            ));
+            assert_eq!(invoker.rungs(), vec![LadderRung::SchemaRepair]);
+        }
+
+        /// A parse-miss that survives schema-repair is recovered by the SECOND
+        /// (higher-effort) rung → `Escalated`, 3 invocations.
+        #[test]
+        fn ladder_escalates_to_second_rung() {
+            let invoker = ScriptedInvoker::new(vec![
+                Ok("still not a variant word".into()), // schema-repair misses
+                Ok("deprioritize stale goal".into()),  // escalate recovers
+            ]);
+            let (decision, outcome, attempts) = run_escalation_ladder(
+                &invoker,
+                &sample_ctx(),
+                "garbage",
+                LifecycleParseOutcome::DefaultMalformed,
+                &EscalationConfig::default(),
+            );
+            assert_eq!(outcome, LifecycleParseOutcome::Escalated);
+            assert_eq!(attempts, 3, "base + schema-repair + escalate");
+            assert!(matches!(
+                decision,
+                EngineerLifecycleDecision::Deprioritize { .. }
+            ));
+            assert_eq!(
+                invoker.rungs(),
+                vec![LadderRung::SchemaRepair, LadderRung::Escalate]
+            );
+        }
+
+        /// Bounded cap: when every rung still parse-misses, the ladder is
+        /// exhausted and falls to the deterministic default — and never
+        /// invokes more than `max_escalations` rungs.
+        #[test]
+        fn ladder_bounded_cap_exhausts_to_default() {
+            let invoker = ScriptedInvoker::new(vec![Ok("nope".into()), Ok("still nope".into())]);
+            let (decision, outcome, attempts) = run_escalation_ladder(
+                &invoker,
+                &sample_ctx(),
+                "banner noise",
+                LifecycleParseOutcome::DefaultMalformed,
+                &EscalationConfig::default(), // 2 rungs
+            );
+            assert_eq!(outcome, LifecycleParseOutcome::DefaultMalformed);
+            assert!(outcome.is_parse_failure());
+            assert_eq!(attempts, 3, "base + exactly 2 bounded rungs");
+            assert!(matches!(
+                decision,
+                EngineerLifecycleDecision::ContinueSkipping { .. }
+            ));
+            assert_eq!(invoker.rungs().len(), 2, "no more than the configured cap");
+        }
+
+        /// Ladder disabled (`max_escalations == 0`): no escalation invocations,
+        /// straight to default — the pre-#2432 behaviour.
+        #[test]
+        fn ladder_disabled_runs_no_escalations() {
+            let invoker = ScriptedInvoker::new(vec![]);
+            let (decision, outcome, attempts) = run_escalation_ladder(
+                &invoker,
+                &sample_ctx(),
+                "banner noise",
+                LifecycleParseOutcome::DefaultEmpty,
+                &EscalationConfig { max_escalations: 0 },
+            );
+            assert_eq!(outcome, LifecycleParseOutcome::DefaultEmpty);
+            assert_eq!(attempts, 1, "only the base attempt");
+            assert!(matches!(
+                decision,
+                EngineerLifecycleDecision::ContinueSkipping { .. }
+            ));
+            assert!(invoker.rungs().is_empty(), "no rungs invoked when disabled");
+        }
+
+        /// An escalation invocation that itself FAILS must not surface as a hard
+        /// error — the ladder stops and uses the deterministic default (a base
+        /// success already gave us a usable, if low-confidence, signal).
+        #[test]
+        fn ladder_invoke_error_falls_back_to_default() {
+            let invoker = ScriptedInvoker::new(vec![Err(())]);
+            let (decision, outcome, attempts) = run_escalation_ladder(
+                &invoker,
+                &sample_ctx(),
+                "garbage",
+                LifecycleParseOutcome::DefaultMalformed,
+                &EscalationConfig::default(),
+            );
+            assert_eq!(outcome, LifecycleParseOutcome::DefaultMalformed);
+            assert_eq!(attempts, 2, "base + the failed rung, then stop");
+            assert!(matches!(
+                decision,
+                EngineerLifecycleDecision::ContinueSkipping { .. }
+            ));
+            assert_eq!(invoker.rungs(), vec![LadderRung::SchemaRepair]);
+        }
+
+        /// The schema-repair rung feeds the exact malformed prior output back
+        /// into its note so the model can fix it.
+        #[test]
+        fn ladder_feeds_prior_output_into_repair_note() {
+            let invoker = ScriptedInvoker::new(vec![Ok("continue_skipping healthy".into())]);
+            let cfg = EscalationConfig { max_escalations: 1 };
+            let _ = run_escalation_ladder(
+                &invoker,
+                &sample_ctx(),
+                "the model rambled without a variant word",
+                LifecycleParseOutcome::DefaultMalformed,
+                &cfg,
+            );
+            let notes = invoker.notes();
+            assert_eq!(notes.len(), 1);
+            assert!(
+                notes[0].contains("the model rambled without a variant word"),
+                "repair note must carry the prior output; got {}",
+                notes[0]
+            );
         }
     }
 }

--- a/src/ooda_brain/recipe_brain.rs
+++ b/src/ooda_brain/recipe_brain.rs
@@ -227,24 +227,26 @@ const LIFECYCLE_VARIANT_LIST: &str = "continue_skipping, reclaim_and_redispatch,
 /// Build the `escalation_note` injected into the recipe prompt for a given
 /// rung. Pinned wording — see the `escalation_note_*` content-pin tests.
 pub fn build_escalation_note(rung: LadderRung, prior_output: &str) -> String {
-    if matches!(rung, LadderRung::Base) {
-        return String::new();
-    }
-    let prior = truncate(prior_output.trim(), MAX_RATIONALE_CHARS);
-    let repair = format!(
-        "## ⚠️ SCHEMA REPAIR (retry) ## \
-         Your previous response could not be parsed: its FIRST WORD was not a valid decision variant. \
-         Previous response: <<<{prior}>>> \
-         Respond again now. The VERY FIRST WORD of your reply MUST be exactly one of: {LIFECYCLE_VARIANT_LIST}. \
-         Output that variant word first, then your rationale."
-    );
+    // Built lazily so the Base rung allocates nothing — base behaviour stays
+    // byte-identical to pre-#2432.
+    let schema_repair = || {
+        let prior = truncate(prior_output.trim(), MAX_RATIONALE_CHARS);
+        format!(
+            "## ⚠️ SCHEMA REPAIR (retry) ## \
+             Your previous response could not be parsed: its FIRST WORD was not a valid decision variant. \
+             Previous response: <<<{prior}>>> \
+             Respond again now. The VERY FIRST WORD of your reply MUST be exactly one of: {LIFECYCLE_VARIANT_LIST}. \
+             Output that variant word first, then your rationale."
+        )
+    };
     match rung {
         LadderRung::Base => String::new(),
-        LadderRung::SchemaRepair => repair,
+        LadderRung::SchemaRepair => schema_repair(),
         LadderRung::Escalate => format!(
-            "{repair} ## HIGH-EFFORT RETRY ## \
+            "{} ## HIGH-EFFORT RETRY ## \
              This is a final, higher-effort attempt. Reason carefully, step by step, about the \
-             engineer's state BEFORE answering, then output the single variant word first."
+             engineer's state BEFORE answering, then output the single variant word first.",
+            schema_repair()
         ),
     }
 }

--- a/src/ooda_brain/recipe_brain.rs
+++ b/src/ooda_brain/recipe_brain.rs
@@ -88,7 +88,7 @@ struct RecipeStepResult {
 /// This keeps a broken recipe-runner visible instead of masquerading as a
 /// `default_empty` parse.
 fn extract_recipe_decision_output(stdout: &[u8], adapter_tag: &str) -> SimardResult<String> {
-    let envelope: RecipeEnvelope =
+    let mut envelope: RecipeEnvelope =
         serde_json::from_slice(stdout).map_err(|e| SimardError::AdapterInvocationFailed {
             base_type: adapter_tag.to_string(),
             reason: format!("failed to deserialize recipe JSON output: {e}"),
@@ -101,10 +101,13 @@ fn extract_recipe_decision_output(stdout: &[u8], adapter_tag: &str) -> SimardRes
         });
     }
 
+    // `pop()` moves the terminal step's `output` out of the owned envelope
+    // (dropped on return anyway) instead of cloning the (potentially multi-KB)
+    // decision text on every brain invocation.
     envelope
         .step_results
-        .last()
-        .map(|s| s.output.clone())
+        .pop()
+        .map(|s| s.output)
         .ok_or_else(|| SimardError::AdapterInvocationFailed {
             base_type: adapter_tag.to_string(),
             reason: "no step results in recipe JSON output".to_string(),

--- a/tests/gadugi/brain-escalation-ladder.sh
+++ b/tests/gadugi/brain-escalation-ladder.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Outside-in scenario for issue #2432 — the engineer-lifecycle brain's
+# confidence-gated escalation ladder (schema-repair + tier bump) that replaces
+# the zero-retry parse→default introduced for the #2419 family.
+#
+# What this proves, without an LLM, at the recipe-runner boundary:
+#
+#   (a) The production recipe `ooda-engineer-lifecycle.yaml` exposes the
+#       `{{escalation_note}}` placeholder the brain injects on each rung, and
+#       documents the "empty on the base attempt" contract.
+#
+#   (b) recipe-runner-rs context-var substitution honours that contract:
+#       - base attempt (escalation_note empty)  → the note text is ABSENT, so
+#         the rendered prompt is the original base prompt (byte-identical
+#         behaviour to before the change);
+#       - escalation rung (escalation_note set) → the pinned schema-repair /
+#         high-effort instruction is injected ahead of the ROLE section.
+#       This is exactly the seam `RecipeBrain` drives one rung at a time.
+#
+#   (c) The in-tree Rust ladder is exercised end-to-end via `cargo test`
+#       (issue_2432_tests): schema-repair recovery, escalation to the second
+#       rung, bounded-cap exhaustion → deterministic default, disabled config,
+#       invoke-error fallback, prior-output feed-through, content-pinned note
+#       wording, and config clamp/bound. The #2419 metric/outcome tests
+#       (issue_2419_tests) are re-run to prove the parse-failure signal is
+#       preserved and not regressed.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+if ! command -v recipe-runner-rs >/dev/null 2>&1; then
+  echo "SKIP: recipe-runner-rs not on PATH (required for this scenario)" >&2
+  exit 0
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "SKIP: jq not on PATH (required for this scenario)" >&2
+  exit 0
+fi
+
+RECIPE="prompt_assets/simard/recipes/ooda-engineer-lifecycle.yaml"
+
+# --- (a) production recipe exposes the placeholder + documents the contract ---
+echo "== (a) recipe exposes {{escalation_note}} placeholder + base contract =="
+grep -qF '{{escalation_note}}' "$RECIPE" \
+  || { echo "FAIL: $RECIPE is missing the {{escalation_note}} placeholder" >&2; exit 1; }
+# The base attempt must render the note to nothing — documented in the recipe.
+grep -qiE 'escalation_note.*empty on the base attempt|empty on the base attempt' "$RECIPE" \
+  || { echo "FAIL: $RECIPE does not document the empty-on-base escalation_note contract" >&2; exit 1; }
+echo "OK: placeholder present and base contract documented."
+
+WORK="$(mktemp -d /tmp/simard-brain-escalation-2432.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+
+# --- (b) deterministic substitution proof (no LLM) ---------------------------
+# A bash-step fixture that embeds the SAME placeholder the production prompt
+# uses. We render it twice through recipe-runner-rs and assert the contract.
+echo "== (b) {{escalation_note}} substitution contract (base vs escalation) =="
+FIX="$WORK/escalation-note-fixture.yaml"
+cat > "$FIX" <<'EOF'
+name: "escalation-note-fixture-2432"
+description: "deterministic escalation_note substitution proof (no LLM)"
+version: "1.0.0"
+context:
+  escalation_note: ""
+steps:
+  - id: "render-prompt"
+    type: "bash"
+    command: |
+      cat <<'BODY'
+      {{escalation_note}}
+      ## ROLE
+      You are the brain of Simard's OODA daemon.
+      BODY
+    output: "rendered"
+EOF
+
+SENTINEL="SCHEMA REPAIR (retry)"
+
+# base attempt: production passes an explicit empty `-c escalation_note=` on the
+# base rung, so mirror that here (not just the fixture default) to prove the
+# placeholder substitution path itself renders the base prompt cleanly.
+BASE_OUT="$(recipe-runner-rs "$FIX" -c escalation_note= --output-format json 2>/dev/null \
+  | jq -r '.step_results | last | .output')"
+printf 'base render:\n%s\n' "$BASE_OUT"
+if printf '%s' "$BASE_OUT" | grep -qF "$SENTINEL"; then
+  echo "FAIL: base attempt unexpectedly injected an escalation note" >&2
+  exit 1
+fi
+# Guard against a false pass where substitution silently no-ops and leaves the
+# literal `{{escalation_note}}` token in the prompt: that must NEVER appear.
+if printf '%s' "$BASE_OUT" | grep -qF '{{escalation_note}}'; then
+  echo "FAIL: base render left the literal {{escalation_note}} placeholder (substitution broken)" >&2
+  exit 1
+fi
+printf '%s' "$BASE_OUT" | grep -qF '## ROLE' \
+  || { echo "FAIL: base render lost the ROLE section" >&2; exit 1; }
+echo "OK: base attempt renders the original prompt with NO escalation note."
+
+# escalation rung: escalation_note carries the pinned schema-repair instruction
+NOTE="## ⚠️ ${SENTINEL} ## Your previous response could not be parsed: its FIRST WORD was not a valid decision variant. Respond again now. The VERY FIRST WORD of your reply MUST be exactly one of: continue_skipping, reclaim_and_redispatch, deprioritize, open_tracking_issue, mark_goal_blocked, consider_self_update."
+ESC_OUT="$(recipe-runner-rs "$FIX" -c escalation_note="$NOTE" --output-format json 2>/dev/null \
+  | jq -r '.step_results | last | .output')"
+printf 'escalation render:\n%s\n' "$ESC_OUT"
+printf '%s' "$ESC_OUT" | grep -qF "$SENTINEL" \
+  || { echo "FAIL: escalation rung did not inject the schema-repair note" >&2; exit 1; }
+printf '%s' "$ESC_OUT" | grep -qF 'continue_skipping' \
+  || { echo "FAIL: escalation note is missing the variant allow-list" >&2; exit 1; }
+# The injected note must come BEFORE the ROLE section (it re-frames the task).
+NOTE_LINE="$(printf '%s\n' "$ESC_OUT" | grep -nF "$SENTINEL" | head -1 | cut -d: -f1)"
+ROLE_LINE="$(printf '%s\n' "$ESC_OUT" | grep -nF '## ROLE'   | head -1 | cut -d: -f1)"
+[ -n "$NOTE_LINE" ] && [ -n "$ROLE_LINE" ] && [ "$NOTE_LINE" -lt "$ROLE_LINE" ] \
+  || { echo "FAIL: escalation note must be injected ahead of the ROLE section" >&2; exit 1; }
+echo "OK: escalation rung injects the schema-repair instruction ahead of ROLE."
+
+# --- (c) in-tree Rust ladder + preserved #2419 metric outcomes ---------------
+echo "== (c) in-tree ladder unit tests (issue_2432_tests + issue_2419_tests) =="
+# Capture the cargo test output so we can assert tests ACTUALLY ran. A cargo
+# filter that matches zero tests still exits 0, so a future rename of the
+# `issue_24*` modules must not silently turn this rung into a no-op.
+TEST_LOG="$WORK/issue24-cargo-test.log"
+cargo test --lib --locked issue_24 -- --nocapture >"$TEST_LOG" 2>&1
+PASSED="$(grep -oE 'test result: ok\. [0-9]+ passed' "$TEST_LOG" | grep -oE '[0-9]+' | head -1)"
+PASSED="${PASSED:-0}"
+echo "issue_24 tests passed: ${PASSED}"
+[ "$PASSED" -ge 1 ] \
+  || { echo "FAIL: issue_24 filter matched zero tests — module rename silently no-op'd this rung" >&2; cat "$TEST_LOG" >&2; exit 1; }
+# Pin two representative tests by name so the ladder + the #2419 metric path are
+# both genuinely covered (not just *some* unrelated issue_24* test).
+grep -qF 'issue_2432_tests::ladder_recovers_via_schema_repair' "$TEST_LOG" \
+  || { echo "FAIL: the escalation-ladder recovery test did not run" >&2; exit 1; }
+grep -qF 'issue_2419_tests::' "$TEST_LOG" \
+  || { echo "FAIL: the #2419 metric-outcome tests did not run (parse-failure signal coverage lost)" >&2; exit 1; }
+echo "OK: escalation-ladder logic + preserved parse-failure metric outcomes pass (${PASSED} tests)."
+
+echo "PASS: brain-escalation-ladder scenario (issue #2432)"

--- a/tests/gadugi/brain-escalation-ladder.yaml
+++ b/tests/gadugi/brain-escalation-ladder.yaml
@@ -1,0 +1,56 @@
+name: "Engineer Lifecycle Brain Escalation Ladder (issue #2432)"
+description: "Outside-in proof that the engineer-lifecycle brain replaces the zero-retry parse→default with a bounded, confidence-gated escalation ladder (schema-repair + tier bump). Validates the recipe's {{escalation_note}} placeholder contract at the recipe-runner boundary (no LLM) — base attempt renders unchanged, escalation rungs inject the pinned schema-repair instruction — then runs the in-tree ladder/metric outcome tests."
+version: "1.0.0"
+
+config:
+  timeout: 300000
+  retries: 1
+  parallel: false
+
+environment:
+  requires: []
+
+agents:
+  - name: "cli-agent"
+    type: "cli"
+    config:
+      workingDirectory: "."
+      defaultTimeout: 300000
+      executionMode: "spawn"
+      captureOutput: true
+      ioConfig:
+        encoding: "utf8"
+        handleInteractivePrompts: false
+      logConfig:
+        logCommands: true
+        logOutput: true
+        logLevel: "info"
+
+steps:
+  - name: "Brain escalation ladder: recipe placeholder contract + ladder/metric outcomes"
+    agent: "cli-agent"
+    action: "execute_command"
+    params:
+      command: "tests/gadugi/brain-escalation-ladder.sh"
+    timeout: 300000
+
+assertions: []
+
+cleanup:
+  - name: "CLI agent cleanup"
+    agent: "cli-agent"
+    action: "cleanup"
+
+metadata:
+  tags:
+    - "cli"
+    - "behavior"
+    - "simard"
+    - "ooda"
+    - "engineer-lifecycle"
+    - "recipe-brain"
+    - "escalation-ladder"
+    - "issue-2432"
+  priority: "high"
+  author: "copilot"
+  test_type: "outside-in"


### PR DESCRIPTION
## Summary

Implements **#2432** — replaces the zero-retry *parse→default* in the engineer-lifecycle brain with a **bounded, confidence-gated escalation ladder** (BGML's progress-aware module: spend extra compute **only** on the weak, low-confidence cases). A base parse-miss is no longer a silent verdict — it triggers a re-prompt ladder before the deterministic default.

Part of the #2431 BGML research family. Independent of the #2433 reliability-gate PR (disjoint files). Builds on the #1980 first-word `DECISION`-less parser and the #2422 `brain_lifecycle_decision` metric (does **not** regress it).

## How it works

On a base parse-miss (`default_empty` / `default_malformed`) the brain runs up to *N* bounded rungs:

1. **Schema-repair** — re-prompt feeding the malformed output back, reminding the model the first word must be a valid variant.
2. **Escalate** — schema-repair **plus** a higher-effort, step-by-step reasoning tier.

The deterministic `continue_skipping` default is reached **only after the ladder is exhausted**. Each rung is logged loudly (`BRAIN ESCALATION …`).

- **Bounded**: `SIMARD_BRAIN_ESCALATION_MAX_ATTEMPTS` (default `2`, hard-capped at `3`, `0` disables). No unbounded retry.
- **Metric**: two new **non-failure** outcomes `repaired` / `escalated` + an `attempts` field on `brain_lifecycle_decision`. Recovered decisions do **not** count toward the parse-failure numerator — that is how the ladder drops the measured default rate (the #2419 baseline was ~99.6% default).
- **Contract preserved**: a genuine recipe-runner failure (spawn/exit/envelope) still surfaces as a hard `error`; only a *parse-miss on a successful run* escalates.
- The recipe gains an optional `{{escalation_note}}` placeholder — **empty on the base attempt**, so base behaviour is byte-identical to before.
- The subprocess call is refactored behind a `LifecycleInvoker` seam so the ladder is fully unit-testable without `recipe-runner-rs`.

## Acceptance (issue #2432)

- ✅ Parse-failure/default rate drops: `repaired`/`escalated` outcomes convert former silent defaults into real decisions.
- ✅ Escalation is bounded (configurable cap + hard cap; no latency blow-up).
- ✅ `brain_lifecycle_decision` parse-failure signal preserved and extended (gated in self-metrics).

## Tests

New `issue_2432_tests` module: schema-repair recovery (`Repaired`), escalation to the second rung (`Escalated`), bounded-cap exhaustion → default, disabled config, escalation-invoke-error fallback, prior-output fed into the repair note, **content-pinned** note wording, and config clamp/bound. Existing `issue_2419_tests` (metric/outcome) updated for the new `attempts` field and stay green. `cargo fmt --check` and `cargo clippy -- -D warnings` clean.

> Note: 5 pre-existing `resolve_recipe_path` / `RecipeBrain::new` tests fail **only** on hosts where `~/.simard/prompt_assets/...` recipes are installed (operator boxes); they are byte-identical to `main` and pass in clean CI. Unrelated to this change.


---


---

## ✅ Merge-readiness evidence

Branch head: `7575b215` (rebased on `c8d93445`). All work committed to this PR's
branch `feat/2432-brain-escalation-ladder` — no duplicate PR opened.

### 1. QA-team scenario (`gadugi-test validate` + `run`)

New outside-in scenario **`tests/gadugi/brain-escalation-ladder.{yaml,sh}`** that
proves the `{{escalation_note}}` placeholder contract at the recipe-runner
boundary (no LLM) and runs the in-tree ladder + metric tests:

- `gadugi-test validate -f tests/gadugi/brain-escalation-ladder.yaml --strict`
  → `✓ Scenario "Engineer Lifecycle Brain Escalation Ladder (issue #2432)" is valid` (1 valid, 0 invalid).
- `gadugi-test run -d tests/gadugi -s brain-escalation-ladder`
  → `✓ Passed: 1  ✗ Failed: 0  Total: 1  ✓ All tests passed!` (command exit code 0).

The scenario asserts: (a) the production recipe exposes `{{escalation_note}}` and
documents the empty-on-base contract; (b) `recipe-runner-rs` renders the **base**
attempt with **no** note and **no literal placeholder left behind**, and renders
an **escalation** rung with the pinned schema-repair instruction injected *ahead
of* `## ROLE`; (c) the in-tree `issue_2432_tests` + `issue_2419_tests` run and pass
(asserts **≥1** test actually ran and pins two representative test names, so a
module rename can't silently no-op the rung).

### 2. Docs

User/operator-facing surfaces documented in **`docs/howto/diagnose-brain-decision-parse-failures.md`**:
the escalation ladder, the `escalation_note` context var + `{{escalation_note}}`
placeholder, the `SIMARD_BRAIN_ESCALATION_MAX_ATTEMPTS` bound, the `repaired`/
`escalated` outcomes + `attempts` field, and (new in `7575b215`) the
`brain_lifecycle_decision` **`cause`** label table
(`ladder_recovered`/`ladder_exhausted`/`ladder_invoke_error`/`ladder_disabled`).

### 3. Quality-audit — 3 SEEK→VALIDATE→FIX cycles, clean final

- **Cycle 1** — code-review + security-review of the full diff + scenario.
  Security: **no vulnerabilities** (escalation note is `sanitize_context_var`-bounded;
  cap hard-limited to 3; bash scenario injection-safe). Code-review: **no bug-level
  issues**, two LOW telemetry-precision nuances. **FIX:** added
  `LadderTermination { Recovered, Exhausted, InvokeError, Disabled }` so the metric
  `cause` distinguishes an invoke-error early stop from genuine exhaustion/disabled;
  documented that `first_word` intentionally reflects the base attempt; +1 unit test.
- **Cycle 2** — regression review of the fix: confirmed **behaviour-preserving**
  (decision/outcome/attempts identical across all five paths; `Recovered` returns
  before the terminal-reason block; `Disabled` can't mask `InvokeError`). No issues.
- **Cycle 3** — final skeptical sweep over the complete landing diff:
  **zero CRITICAL/HIGH/MEDIUM**. Two LOW scenario-robustness notes → **FIX:** hardened
  the scenario to assert tests actually ran and that no literal `{{escalation_note}}`
  survives substitution.

Final cycle clean: **0 critical / 0 high / 0 medium** correctness or security findings.

### 4. CI — 100% green on `7575b215`

All required checks are **GREEN** on the current head `7575b215` (0 failures):
`build`, `pre-commit`, `coverage`, `cargo-audit`, `install-real`, `e2e-dashboard`,
and `GitGuardian Security Checks` all `SUCCESS`.

- Verify workflow run (green): https://github.com/rysweet/Simard/actions/runs/28303035765
- Coverage run (green): https://github.com/rysweet/Simard/actions/runs/28303035757
- Docs run (green): https://github.com/rysweet/Simard/actions/runs/28303035756

Locally on the integrated tree: `cargo fmt --check` clean,
`cargo clippy --all-targets --all-features --locked -- -D warnings` clean, 27
`issue_24` lib tests pass; pre-commit + pre-push hooks (rust-only gate, fmt,
release test subset, full clippy) passed on push.

> The 5 `resolve_recipe_path`/`RecipeBrain::new` tests noted above fail **only** on
> operator boxes with deployed `~/.simard/prompt_assets/` recipes; they are
> untouched by this PR and pass in clean CI (the green runs linked above).

### 5. Scope

Diff is focused on #2432 only: `src/ooda_brain/recipe_brain.rs` (escalation ladder
+ termination metric), `prompt_assets/simard/recipes/ooda-engineer-lifecycle.yaml`
(`{{escalation_note}}` placeholder), `docs/howto/diagnose-brain-decision-parse-failures.md`,
and the new `tests/gadugi/brain-escalation-ladder.{yaml,sh}` scenario. No unrelated edits.

### 6. Verdict

**Ready to merge.** All six merge-ready criteria are satisfied with concrete,
verifiable evidence: the QA-team scenario is written, validated, and run green; the
operator-facing surfaces are documented; the quality-audit ran three
SEEK→VALIDATE→FIX cycles ending on a clean 0/0/0 cycle; CI is 100% green on the head
commit `7575b215` (links above); the diff is focused on #2432 with no unrelated
edits; and the PR description carries the evidence for criteria 1–5 here. Recommending
squash-merge into `main`.


Closes #2432
