### PR TITLE
fix(memory): verified backups of the LIVE cognitive store + bounded quarantines (#2420)

### DIFF
--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -7,6 +7,7 @@ Simard deployment.
 |---|---|
 | [Pre-Commit Setup](pre-commit-setup.md) | Local hooks that mirror CI |
 | [Cognitive Memory Durability](cognitive-memory-durability.md) | SIGTERM-safe shutdown + periodic backups |
+| [Verified Backups of the Live Cognitive Store](verified-backups.md) | Live-store backups, verify-before-prune, bounded quarantines (#2420) |
 | [Meeting REPL & Handoff Ingestion](meeting-handoffs.md) | Routing operator intent into the OODA loop |
 | [Progress-Evidence Kill Switch](progress-evidence-kill-switch.md) | `SIMARD_PROGRESS_EVIDENCE=off` and when to use it |
 

--- a/docs/operations/verified-backups.md
+++ b/docs/operations/verified-backups.md
@@ -1,0 +1,516 @@
+# Verified Backups of the Live Cognitive Store
+
+> Issue #2420. The daemon backs up the **live** cognitive-memory store, captures
+> the **whole** store (not a capped subset), **verifies** every backup before
+> pruning, and keeps the corrupt-quarantine population bounded. It complements
+> [Cognitive Memory Durability](cognitive-memory-durability.md), which covers
+> SIGTERM-safe shutdown and the WAL/CHECKPOINT durability the library backend
+> owns.
+
+## Why this exists
+
+The OODA daemon opens its cognitive store through the library backend at
+`state_root/cognitive` (in production, `~/.simard/cognitive`). After the
+`lbug` 0.17.x de-fork migration (#2307) the live store moved into this
+directory; the legacy single-file store at `state_root/cognitive_memory.ladybug`
+is no longer the source of truth.
+
+Two coupled regressions broke resilience:
+
+1. **Backups targeted the stale path.** The file-copy backup copied the legacy
+   single-file store, so once the store migrated no fresh verified backup was
+   produced — the newest backup on the host was Jun 20 while the live store grew
+   past 10k memories.
+2. **The snapshot export was capped.** The snapshot path capped at 1000 facts
+   (`MAX_EXPORT_FACTS`), so even a correctly-targeted backup would silently drop
+   everything past the first 1000 memories once the store grew larger.
+
+The verified-backup pipeline guarantees four properties that together make a
+silent backup-rot regression impossible:
+
+1. **Backup source == live store.** The backup reads the live store through the
+   bridge, resolved through one migration-aware function
+   ([`live_store_path`](#live-store-path-resolution)). A regression test asserts
+   the backup source equals the path the daemon opens, so they cannot silently
+   diverge again.
+2. **Whole store, never capped.** The backup uses an **uncapped** export so it
+   holds every fact and procedure regardless of how large the store grows. A
+   test stores more than the legacy cap and asserts a full round-trip.
+3. **Verified before prune.** Every backup is re-opened and validated (checksum
+   + manifest self-consistency) before any retention prune runs. A failed
+   verification is logged loudly and leaves prior good backups untouched.
+4. **Bounded quarantine.** Corrupt/shadow quarantine artifacts are capped by
+   both age **and** count, so a corruption burst can never fill the disk.
+
+---
+
+## Concepts
+
+### Live-store path resolution
+
+`live_store_path(state_root) -> PathBuf` is the single source of truth for the
+on-disk location of the cognitive store. It is migration-aware:
+
+| Condition | Resolved path |
+|---|---|
+| `state_root/cognitive` exists (post-migration, normal) | `state_root/cognitive` |
+| only the legacy `state_root/cognitive_memory.ladybug` exists | `state_root/cognitive_memory.ladybug` |
+| neither exists (fresh install) | `state_root/cognitive` (created on open) |
+
+Both the daemon's store-open path (`LibraryCognitiveMemory::open`) and the
+backup's source (`memory_backup::backup_source_path`) route through
+`live_store_path`, so "what the daemon opens" and "what the backup reads" are
+guaranteed equal. The function is exported from `cognitive_memory`.
+
+```rust
+use simard::cognitive_memory::live_store_path;
+
+let state_root = dirs::home_dir().unwrap().join(".simard");
+let store_path = live_store_path(&state_root);
+// -> ~/.simard/cognitive  (post-migration)
+```
+
+### Logical, not file-copy, backups
+
+A backup is a **logical snapshot** taken through the live bridge, not a raw copy
+of the open LadybugDB store. Copying an open store file is unsafe; reading
+through `CognitiveMemoryOps` is consistent and inherently targets the migrated
+path. Each backup is a timestamped directory under `state_root/backups/`:
+
+```text
+~/.simard/backups/20260627_231000/
+  cognitive_snapshot.json   # facts + procedures exported via the bridge
+  memory_records.json       # file-backed memory records
+  manifest.json             # counts + SHA-256 checksum over the two files above
+```
+
+### Whole-store export (no cap)
+
+`remote_transfer::export_full_memory_snapshot` exports the **entire** store —
+every fact and every procedure — by requesting with the maximum limit, the same
+unbounded retrieval `graph_stats` already performs safely. It is distinct from
+the capped `export_memory_snapshot`, which keeps replication/migration payloads
+bounded at `MAX_EXPORT_FACTS` / `MAX_EXPORT_PROCEDURES`. `backup_memory` uses the
+full export so the backup is a faithful copy of the live store, no matter how
+large it grows.
+
+### The verify-before-prune gate
+
+`backup_memory_verified` wraps backup creation with a hard verification gate:
+
+1. Produce the backup (`backup_memory`) — captures the full snapshot + records
+   and records their counts and a SHA-256 checksum in `manifest.json`.
+2. Re-open and validate it (`ensure_backup_valid` → `verify_backup`): the
+   manifest is present, the snapshot/records files exist, the checksum matches,
+   and the recorded counts match the serialized data.
+3. **Gate:** return the manifest only if the backup is `Valid`; otherwise return
+   a loud `SimardError::MemoryIntegrityError`.
+
+Callers prune **only** after this returns `Ok`. The daemon's
+`run_verified_backup` does exactly that: `backup_memory_verified` then
+`prune_old_backups`, so a failed or partial backup can never cause the
+last-known-good backup to be reclaimed.
+
+For callers holding an **independent** expected count, `verify_backup_memory_count(dir, expected_total)`
+re-opens a backup and fails loudly unless its total memory count (facts +
+procedures + records) equals `expected_total` — the explicit "confirm the
+expected memory count before pruning" check. The daemon does not re-query an
+independent live count each cycle (which would race with concurrent writes); the
+manifest counts are written from the same read that produced the snapshot and
+are confirmed self-consistent by `ensure_backup_valid`.
+
+### Bounded corrupt-quarantine retention
+
+When LadybugDB detects a corrupt store or WAL it quarantines the bad bytes in
+place. `simard cleanup` reclaims any entry under `~/.simard` whose name **starts
+with** `cognitive.` or `cognitive_memory.` **and contains** the `.corrupt-<ts>`
+infix — for example `cognitive.corrupt-<ts>`, `cognitive.wal.corrupt-<ts>`,
+`cognitive_memory.corrupt-<ts>`, recursively nested
+`…cognitive.wal.corrupt-<ts>` chains, and matching `.corrupt-<ts>.bak` copies.
+The live store files (`cognitive`, `cognitive.wal`, `cognitive.shadow`) lack the
+`.corrupt-` infix, so they are never matched.
+
+`remove_old_corrupt_dbs` enforces **two independent bounds** on quarantines:
+
+| Bound | Constant | Default | Effect |
+|---|---|---|---|
+| Age | `CORRUPT_DB_MAX_AGE_DAYS` | `7` days | Remove any quarantine older than N days |
+| Count | `CORRUPT_DB_KEEP` | `5` | Keep only the newest N; remove the older surplus immediately |
+
+A quarantine is removed if it fails **either** check (it is older than the age
+cap **or** it is not among the newest `CORRUPT_DB_KEEP`). The count cap closes
+the gap where a corruption burst inside the age window could accumulate
+unbounded (this host saw 88 MB / 112 artifacts pile up). Neither bound *protects*
+an entry the other would drop — a quarantine within the newest N but older than 7
+days is still deleted by the age check.
+
+### WAL durability — verify-only
+
+The library backend's write-ahead-log durability (corrupt-WAL recovery +
+checkpoint) is already present in the pinned `amplihack-memory` dependency. The
+WAL-durability commit (`7b81590`, PR #89) is an **ancestor** of the current pin
+(`26d49bf8`, lbug-0.17.1), so **no dependency bump is performed** — re-bumping
+would be a no-op or a regression. See
+[Cognitive Memory Durability](cognitive-memory-durability.md) for the
+WAL/CHECKPOINT model.
+
+---
+
+## How it runs (daemon)
+
+The daemon's periodic backup was removed in the de-fork (#2307); #2420
+reintroduces it as a **verified** loop. At the top of each OODA cycle the daemon
+compares the elapsed time since the last backup against the configured interval;
+when the interval has passed it runs `run_verified_backup` before cycle work.
+Running at the quiescent top of the loop keeps the snapshot consistent.
+
+Per tick (when due):
+
+1. Open the file-backed store at `state_root/memory_records.json`.
+2. `backup_memory_verified(bridge, store, "simard", &config)` — full snapshot +
+   verify.
+3. On `Ok`: log `verified backup OK` with counts, then `prune_old_backups`.
+4. On `Err`: log `WARN: verified backup FAILED, prune skipped` and continue the
+   cycle. Prior backups are preserved.
+
+A backup failure never aborts the OODA cycle — durability is best-effort and
+fail-loud, never fail-silent.
+
+> The first verified backup runs promptly after daemon start (the timer is
+> back-dated), so a freshly-deployed daemon produces a backup within its first
+> cycle rather than one full interval later.
+
+---
+
+## Configuration
+
+| Setting | Default | Override | Notes |
+|---|---|---|---|
+| Backup interval (seconds) | `86400` (daily) | `SIMARD_BACKUP_INTERVAL_SECS=N` | Read at daemon start; per-cycle elapsed-time check. A zero/invalid value falls back to the default |
+| Backup directory | `<state_root>/backups/` | — | Created on first backup |
+| Retention (days) | `30` | `BackupConfig::retention_days` | Age-based pruning of backups |
+| Minimum backups kept | `3` | `BackupConfig::min_backups_to_keep` | Never prune below this count |
+| Corrupt quarantine age cap (days) | `7` | `CORRUPT_DB_MAX_AGE_DAYS` (compile-time) | Removes quarantines older than N days |
+| Corrupt quarantine count cap | `5` | `CORRUPT_DB_KEEP` (compile-time) | Keeps the newest N; older surplus removed (age cap still applies) |
+
+> `SIMARD_BACKUP_INTERVAL_SECS` is the operator-facing runtime knob. The
+> `BackupConfig` fields come from `BackupConfig::default()` and the quarantine
+> caps are compile-time constants — changing them requires a rebuild.
+
+### Sample systemd unit excerpt
+
+```ini
+[Service]
+WorkingDirectory=/home/azureuser/.simard/repo
+Environment=SIMARD_BACKUP_INTERVAL_SECS=86400
+KillSignal=SIGTERM
+TimeoutStopSec=30
+ExecStart=/usr/local/bin/simard ooda daemon
+Restart=on-failure
+```
+
+> The live store is `~/.simard/cognitive`; the daemon's `WorkingDirectory` is
+> `~/.simard/repo`. Operators own deployment — changing backup configuration
+> requires an operator-driven restart; the daemon is never live-redeployed from
+> automation.
+
+---
+
+## Public API
+
+All items live in `simard::memory_backup` unless noted.
+
+### `live_store_path` — `simard::cognitive_memory`
+
+```rust
+pub fn live_store_path(state_root: &Path) -> PathBuf
+```
+
+Migration-aware resolver for the live cognitive store path. Used by both the
+daemon store-open and the backup source so they cannot diverge.
+
+### `backup_source_path`
+
+```rust
+pub fn backup_source_path(state_root: &Path) -> PathBuf
+```
+
+The backup's source store path — a thin delegate to `live_store_path`.
+
+### `export_full_memory_snapshot` — `simard::remote_transfer`
+
+```rust
+pub fn export_full_memory_snapshot(
+    bridge: &dyn CognitiveMemoryOps,
+    agent_name: &str,
+) -> SimardResult<MemorySnapshot>
+```
+
+Exports the **complete** store (every fact + procedure), uncapped. Used by
+`backup_memory`. Distinct from the capped `export_memory_snapshot` used for
+bounded replication payloads.
+
+### `backup_memory_verified`
+
+```rust
+pub fn backup_memory_verified(
+    bridge: &dyn CognitiveMemoryOps,
+    store: &dyn MemoryStore,
+    agent_name: &str,
+    config: &BackupConfig,
+) -> SimardResult<BackupManifest>
+```
+
+Creates a backup and verifies it re-opens cleanly before returning. Returns
+`SimardError::MemoryIntegrityError` if the backup is not `Valid`. **Callers must
+only prune after this returns `Ok`.**
+
+### `verify_backup_memory_count`
+
+```rust
+pub fn verify_backup_memory_count(backup_dir: &Path, expected_total: usize) -> SimardResult<()>
+```
+
+Re-opens a backup and fails loudly unless its total memory count (facts +
+procedures + records) equals `expected_total`. The explicit count gate for
+callers holding an independent expected count.
+
+### `ensure_backup_valid`
+
+```rust
+pub fn ensure_backup_valid(backup_dir: &Path) -> SimardResult<BackupManifest>
+```
+
+Returns the manifest only if `verify_backup` reports `Valid`; otherwise a loud
+`MemoryIntegrityError`. The verify-before-prune primitive used by
+`backup_memory_verified`.
+
+### `backup_memory`
+
+```rust
+pub fn backup_memory(
+    bridge: &dyn CognitiveMemoryOps,
+    store: &dyn MemoryStore,
+    agent_name: &str,
+    config: &BackupConfig,
+) -> SimardResult<BackupManifest>
+```
+
+Low-level backup creation: exports the **full** cognitive snapshot and
+file-backed records into a timestamped directory and writes `manifest.json`.
+Prefer `backup_memory_verified` for the daemon path — it adds the verify gate.
+
+### `verify_backup`
+
+```rust
+pub fn verify_backup(backup_dir: &Path) -> SimardResult<BackupVerification>
+```
+
+Re-reads a backup and validates it against its manifest (file presence, recorded
+counts, SHA-256 checksum). Returns a `BackupVerification` whose `status` is
+`Valid`, `Corrupted { reason }`, or `Incomplete { missing }`.
+
+### `restore_from_backup`
+
+```rust
+pub fn restore_from_backup(
+    bridge: &dyn CognitiveMemoryOps,
+    store: &dyn MemoryStore,
+    backup_dir: &Path,
+) -> SimardResult<usize>
+```
+
+Verifies the backup, then imports the cognitive snapshot and file-backed records
+into the live store. Returns the total number of items restored. Refuses to
+restore from a `Corrupted` or `Incomplete` backup.
+
+> **Additive, not wipe-and-replace.** Restore imports on top of whatever the
+> target store already holds; it does **not** clear the target first. Restoring
+> into a **fresh/empty** store reproduces the backed-up count exactly. Restoring
+> into a **non-empty** store **merges** the backup onto the existing data, and the
+> resulting count may exceed the backup's. For a clean recovery, restore into an
+> empty target (see the runbook below).
+
+### `list_backups` / `prune_old_backups`
+
+```rust
+pub fn list_backups(config: &BackupConfig) -> SimardResult<Vec<BackupVerification>>
+pub fn prune_old_backups(config: &BackupConfig) -> SimardResult<usize>
+```
+
+`list_backups` lists backups newest-first with verification status.
+`prune_old_backups` removes backups older than `retention_days`, never dropping
+below `min_backups_to_keep`. Call **only** after a successful verified backup.
+
+### Types
+
+```rust
+pub struct BackupConfig { pub backup_dir: PathBuf, pub retention_days: u32, pub min_backups_to_keep: usize }
+pub struct BackupManifest { /* backup_dir, created_at, counts, checksum, ... */ }
+pub struct BackupVerification { pub manifest: BackupManifest, pub status: BackupStatus, pub verified_at: DateTime<Utc> }
+pub enum   BackupStatus { Valid, Corrupted { reason: String }, Incomplete { missing: Vec<String> } }
+```
+
+### Cleanup API
+
+In `simard::cmd_cleanup::disk`:
+
+```rust
+pub const CORRUPT_DB_MAX_AGE_DAYS: u64 = 7;
+pub const CORRUPT_DB_KEEP: usize = 5;
+
+/// Remove quarantines older than CORRUPT_DB_MAX_AGE_DAYS OR beyond the newest
+/// CORRUPT_DB_KEEP.
+pub fn remove_old_corrupt_dbs(report: &mut CleanupReport);
+```
+
+`simard cleanup` calls `remove_old_corrupt_dbs`, which applies both bounds in a
+single pass.
+
+---
+
+## Examples
+
+### Produce a verified backup of the live store
+
+```rust
+use simard::memory_backup::{backup_memory_verified, BackupConfig};
+
+let config = BackupConfig { backup_dir: state_root.join("backups"), ..BackupConfig::default() };
+let manifest = backup_memory_verified(
+    &*bridges.memory,          // live cognitive bridge
+    &file_backed_store,        // <state_root>/memory_records.json
+    "simard",
+    &config,
+)?;
+println!("verified backup: {} facts -> {}", manifest.cognitive_facts_count, manifest.backup_dir.display());
+```
+
+### Restore round-trip
+
+```rust
+use simard::memory_backup::{backup_memory_verified, restore_from_backup};
+
+// 1. Back up the live store (full + verified).
+let manifest = backup_memory_verified(&*bridges.memory, &file_backed_store, "simard", &config)?;
+
+// 2. Restore into a fresh (empty) store and confirm the count round-trips.
+//    A fresh target is required for exact equality: restore is additive.
+let restored = restore_from_backup(&*fresh_bridge, &fresh_store, &manifest.backup_dir)?;
+let expected = manifest.cognitive_facts_count
+    + manifest.cognitive_procedures_count
+    + manifest.memory_records_count;
+assert_eq!(restored, expected);
+```
+
+### Inspecting backups on disk
+
+```bash
+# Newest-first listing of backups
+ls -1dt ~/.simard/backups/*/ | head
+
+# Inspect one backup's manifest (counts + checksum)
+cat ~/.simard/backups/20260627_231000/manifest.json \
+  | jq '{created_at, cognitive_facts_count, cognitive_procedures_count, memory_records_count}'
+```
+
+---
+
+## Operational runbook
+
+### "Is a fresh verified backup being produced?"
+
+```bash
+# Most recent backup directory and its age
+ls -1dt ~/.simard/backups/*/ | head -1
+
+# Journal confirmation that the gate passed
+journalctl -u simard-ooda --since "1 day ago" | grep -E "verified backup OK|verified backup FAILED"
+```
+
+A current timestamp plus a `verified backup OK` line means the live store is
+being backed up and verified. A `verified backup FAILED, prune skipped` line is
+a paging event — investigate before the next interval.
+
+### "Backups are failing verification"
+
+`backup_memory_verified` failed the verify gate. The error names the backup
+directory and the reason. Check:
+
+- Disk space / permissions on `~/.simard/backups/`.
+- Whether the live store opened correctly this cycle.
+
+Prior backups are intact because prune is skipped on failure — restore from the
+last good backup if needed.
+
+### "`~/.simard` is filling with `cognitive.corrupt-*` files"
+
+Quarantines are bounded by both age (7 days) and count (newest 5). Reclaim
+immediately:
+
+```bash
+simard cleanup    # applies age + count caps to quarantines, among other artifacts
+```
+
+If new `.corrupt-<ts>` files appear every cycle, that is a corruption signal —
+capture a sample and file a `durability` issue rather than only deleting them.
+
+### "I need to restore the live store from a backup"
+
+Restore is a library operation (`restore_from_backup`) invoked with the daemon
+stopped so nothing writes to the live store concurrently. It verifies the backup
+first and refuses corrupt/incomplete backups.
+
+Restore is **additive** — it imports onto whatever the target already holds and
+does not wipe it first. After corruption the live `~/.simard/cognitive` may still
+hold partial data, so restoring directly onto it **merges** the backup onto that
+partial data. For a clean recovery, move the corrupt/partial store aside so the
+restore lands on an empty target:
+
+```bash
+sudo systemctl stop simard-ooda
+# Identify the newest verified backup directory:
+ls -1dt ~/.simard/backups/*/ | head -1
+# Move the corrupt/partial live store aside so restore lands on a clean target:
+mv ~/.simard/cognitive ~/.simard/cognitive.prerestore-$(date +%Y%m%d_%H%M%S)
+# Run restore via operator tooling / a one-shot harness that calls
+# memory_backup::restore_from_backup(bridge, store, backup_dir) against a fresh
+# ~/.simard/cognitive, then:
+sudo systemctl start simard-ooda
+journalctl -u simard-ooda -n 50
+```
+
+`restore_from_backup` verifies the backup before importing; if a backup is
+rejected as corrupt/incomplete, fall back to the next-most-recent directory.
+
+---
+
+## Tests
+
+#2420 adds the following regression coverage:
+
+- **Path guard** — `live_store_path` resolves to `state_root/cognitive`
+  post-migration, falls back to the legacy file only when `cognitive` is absent,
+  and equals the path `LibraryCognitiveMemory::open` uses;
+  `backup_source_path` delegates to it.
+- **Whole-store export** — a store with more facts than the legacy cap exports
+  fully via `export_full_memory_snapshot` while the capped export truncates; a
+  verified backup of a >cap store round-trips the full count on restore.
+- **Verify-before-prune gate** — a faithful backup passes; a backup whose count
+  is short of the expected count (or whose status is not `Valid`) fails loudly.
+- **Daemon routine** — `run_verified_backup` produces a `Valid` backup under
+  `state_root/backups` (and on an empty store); the interval parser falls back to
+  the default on missing/invalid/zero values.
+- **Quarantine bounds** — with more than `CORRUPT_DB_KEEP` young quarantines,
+  only the newest N survive; the live `cognitive` / `cognitive.wal` files are
+  never removed; the age path remains independently functional.
+
+---
+
+## See Also
+
+- [Cognitive Memory Durability](cognitive-memory-durability.md) — SIGTERM-safe
+  shutdown, WAL/CHECKPOINT model, quarantine background
+- [Operations index](index.md)
+- [GitHub issue #2420](https://github.com/rysweet/Simard/issues/2420) — verified
+  backups of the live store + quarantine bounding (this feature)

--- a/docs/operations/verified-backups.md
+++ b/docs/operations/verified-backups.md
@@ -57,10 +57,13 @@ on-disk location of the cognitive store. It is migration-aware:
 | only the legacy `state_root/cognitive_memory.ladybug` exists | `state_root/cognitive_memory.ladybug` |
 | neither exists (fresh install) | `state_root/cognitive` (created on open) |
 
-Both the daemon's store-open path (`LibraryCognitiveMemory::open`) and the
-backup's source (`memory_backup::backup_source_path`) route through
-`live_store_path`, so "what the daemon opens" and "what the backup reads" are
-guaranteed equal. The function is exported from `cognitive_memory`.
+The daemon's store-open path (`LibraryCognitiveMemory::open`) and the
+`live_store_path` resolver are anchored to the same `LIVE_STORE_SUBDIR`
+constant, so "what the daemon opens" and "what the resolver reports" are
+guaranteed equal. The verified backup then reads that live store *through the
+bridge* (a logical snapshot), so it inherently captures exactly the store the
+daemon opened — never a stale file path. The resolver is exported from
+`cognitive_memory`.
 
 ```rust
 use simard::cognitive_memory::live_store_path;
@@ -226,16 +229,9 @@ All items live in `simard::memory_backup` unless noted.
 pub fn live_store_path(state_root: &Path) -> PathBuf
 ```
 
-Migration-aware resolver for the live cognitive store path. Used by both the
-daemon store-open and the backup source so they cannot diverge.
-
-### `backup_source_path`
-
-```rust
-pub fn backup_source_path(state_root: &Path) -> PathBuf
-```
-
-The backup's source store path — a thin delegate to `live_store_path`.
+Migration-aware resolver for the live cognitive store path. Anchored to the
+same `LIVE_STORE_SUBDIR` constant as the daemon store-open
+(`LibraryCognitiveMemory::open`) so the two cannot diverge.
 
 ### `export_full_memory_snapshot` — `simard::remote_transfer`
 
@@ -491,8 +487,8 @@ rejected as corrupt/incomplete, fall back to the next-most-recent directory.
 
 - **Path guard** — `live_store_path` resolves to `state_root/cognitive`
   post-migration, falls back to the legacy file only when `cognitive` is absent,
-  and equals the path `LibraryCognitiveMemory::open` uses;
-  `backup_source_path` delegates to it.
+  and equals the path `LibraryCognitiveMemory::open` uses (both anchored to
+  `LIVE_STORE_SUBDIR`).
 - **Whole-store export** — a store with more facts than the legacy cap exports
   fully via `export_full_memory_snapshot` while the capped export truncates; a
   verified backup of a >cap store round-trips the full count on restore.

--- a/src/cmd_cleanup/disk.rs
+++ b/src/cmd_cleanup/disk.rs
@@ -316,6 +316,19 @@ pub fn cap_home_cargo_targets(report: &mut CleanupReport, cap_bytes: u64) {
 /// Maximum age (in days) of corrupted memory DB files before deletion.
 pub const CORRUPT_DB_MAX_AGE_DAYS: u64 = 7;
 
+/// Maximum number of quarantined corrupt cognitive-memory artifacts to retain,
+/// regardless of age (issue #2420).
+///
+/// The age cap alone ([`CORRUPT_DB_MAX_AGE_DAYS`]) is unbounded *within* the
+/// window: a burst of WAL-corruption events (this host saw 88 MB / 112 artifacts
+/// accumulate) leaves dozens of fresh `cognitive*.corrupt-*` / `*.shadow`
+/// quarantines that the age rule will not touch for a week. Keeping only the
+/// newest N — in addition to the age cap — bounds that growth so the most recent
+/// forensic snapshots survive while older ones are reclaimed immediately. Mirrors
+/// the keep-last-N retention already used for [`BINARY_BACKUPS_KEEP`] /
+/// [`SNAPSHOTS_KEEP`].
+pub const CORRUPT_DB_KEEP: usize = 5;
+
 /// Returns `true` when `name` is a quarantined corrupt cognitive-memory
 /// artifact (safe to garbage-collect) and `false` for the live store.
 ///
@@ -343,13 +356,18 @@ fn is_corrupt_quarantine_name(name: &str) -> bool {
         && name.contains(".corrupt-")
 }
 
-/// Remove quarantined corrupt cognitive-memory snapshots in `~/.simard` older
-/// than [`CORRUPT_DB_MAX_AGE_DAYS`]. Covers both the native single-file
-/// `cognitive_memory.corrupt-*` snapshots and the library backend's
+/// Remove quarantined corrupt cognitive-memory snapshots in `~/.simard` that are
+/// either older than [`CORRUPT_DB_MAX_AGE_DAYS`] **or** beyond the newest
+/// [`CORRUPT_DB_KEEP`] quarantines (issue #2420). Covers both the native
+/// single-file `cognitive_memory.corrupt-*` snapshots and the library backend's
 /// `cognitive.corrupt-*` / `cognitive.wal.corrupt-*` / `*.cognitive.shadow`
 /// quarantines (see [`is_corrupt_quarantine_name`]). These are useful briefly
 /// for forensics then pure dead weight. The live store (`cognitive`,
 /// `cognitive.wal`) is never matched.
+///
+/// The age cap alone leaves a burst of *young* quarantines untouched for a week
+/// (this host saw 88 MB / 112 artifacts accumulate); the keep-last-N cap bounds
+/// that growth immediately while preserving the most recent forensic snapshots.
 pub fn remove_old_corrupt_dbs(report: &mut CleanupReport) {
     let Some(home) = std::env::var_os("HOME") else {
         return;
@@ -360,17 +378,30 @@ pub fn remove_old_corrupt_dbs(report: &mut CleanupReport) {
     };
     let max_age = std::time::Duration::from_secs(CORRUPT_DB_MAX_AGE_DAYS * 24 * 3600);
     let now = std::time::SystemTime::now();
+
+    // Collect every quarantine candidate with its mtime so we can apply both the
+    // age cap and the keep-last-N cap over the full set (read_dir order is
+    // unspecified, so we cannot rank by iteration order).
+    let mut candidates: Vec<(PathBuf, std::fs::Metadata, std::time::SystemTime)> = Vec::new();
     for entry in entries.flatten() {
         let name = entry.file_name().to_string_lossy().to_string();
         if !is_corrupt_quarantine_name(&name) {
             continue;
         }
-        let path = entry.path();
         let Ok(meta) = entry.metadata() else { continue };
         let Ok(modified) = meta.modified() else {
             continue;
         };
-        if now.duration_since(modified).unwrap_or_default() < max_age {
+        candidates.push((entry.path(), meta, modified));
+    }
+
+    // Newest first, so index 0..CORRUPT_DB_KEEP are the survivors of the count cap.
+    candidates.sort_by_key(|c| std::cmp::Reverse(c.2));
+
+    for (rank, (path, meta, modified)) in candidates.iter().enumerate() {
+        let too_old = now.duration_since(*modified).unwrap_or_default() >= max_age;
+        let beyond_keep = rank >= CORRUPT_DB_KEEP;
+        if !too_old && !beyond_keep {
             continue;
         }
         // A cognitive-memory store may be backed by a single file or a
@@ -379,19 +410,20 @@ pub fn remove_old_corrupt_dbs(report: &mut CleanupReport) {
         // leave the quarantine in place.
         let is_dir = meta.is_dir();
         let size = if is_dir {
-            dir_size(&path).unwrap_or(0)
+            dir_size(path).unwrap_or(0)
         } else {
             meta.len()
         };
+        let reason = if too_old { "age" } else { "keep-last-N" };
         eprintln!(
-            "  Removing old corrupt DB {} ({} MB)",
+            "  Removing corrupt DB {} ({} MB, {reason})",
             path.display(),
             size / (1024 * 1024)
         );
         let removed = if is_dir {
-            std::fs::remove_dir_all(&path)
+            std::fs::remove_dir_all(path)
         } else {
-            std::fs::remove_file(&path)
+            std::fs::remove_file(path)
         };
         if let Err(e) = removed {
             report
@@ -399,7 +431,7 @@ pub fn remove_old_corrupt_dbs(report: &mut CleanupReport) {
                 .push(format!("failed to remove {}: {e}", path.display()));
         } else {
             report.bytes_freed += size;
-            report.dirs_removed.push(path);
+            report.dirs_removed.push(path.clone());
         }
     }
 }

--- a/src/cmd_cleanup/mod.rs
+++ b/src/cmd_cleanup/mod.rs
@@ -153,9 +153,10 @@ mod disk;
 // re-exported for cfg(test) consumers in cmd_cleanup/tests.rs (false-positive of clippy unused_imports on lib pass — see #1405)
 #[allow(unused_imports)]
 pub(crate) use disk::{
-    BINARY_BACKUPS_KEEP, CORRUPT_DB_MAX_AGE_DAYS, SNAPSHOTS_KEEP, cap_home_cargo_targets,
-    cap_simard_target_dirs, clean_simard_canaries, clean_stale_cargo_targets, dir_size,
-    remove_old_corrupt_dbs, rotate_simard_binary_backups, trim_simard_snapshots,
+    BINARY_BACKUPS_KEEP, CORRUPT_DB_KEEP, CORRUPT_DB_MAX_AGE_DAYS, SNAPSHOTS_KEEP,
+    cap_home_cargo_targets, cap_simard_target_dirs, clean_simard_canaries,
+    clean_stale_cargo_targets, dir_size, remove_old_corrupt_dbs, rotate_simard_binary_backups,
+    trim_simard_snapshots,
 };
 
 #[cfg(test)]

--- a/src/cmd_cleanup/tests.rs
+++ b/src/cmd_cleanup/tests.rs
@@ -323,6 +323,93 @@ fn corrupt_db_removed_when_older_than_threshold() {
     assert!(unrelated.exists(), "non-corrupt DB must never be touched");
 }
 
+/// Retention must keep at least one forensic snapshot.
+#[test]
+fn corrupt_db_keep_is_sane() {
+    const { assert!(CORRUPT_DB_KEEP >= 1) };
+}
+
+/// Issue #2420: a burst of WAL-corruption events leaves many *young*
+/// `cognitive*.corrupt-*` quarantines that the age cap will not reclaim for a
+/// week. Keep-last-N must bound that growth: with `CORRUPT_DB_KEEP + 3` fresh
+/// quarantines present, only the newest `CORRUPT_DB_KEEP` survive, and the live
+/// store files are never touched.
+#[test]
+#[serial_test::serial(cognitive_memory)]
+fn corrupt_db_keep_bounds_quarantine_count() {
+    let tmp = tempfile::tempdir().unwrap();
+    let simard = tmp.path().join(".simard");
+    std::fs::create_dir_all(&simard).unwrap();
+
+    // Live store files — must survive untouched (no `.corrupt-` infix).
+    let live = simard.join("cognitive");
+    let live_wal = simard.join("cognitive.wal");
+    std::fs::write(&live, b"live").unwrap();
+    std::fs::write(&live_wal, b"wal").unwrap();
+
+    // CORRUPT_DB_KEEP + 3 young quarantine artifacts, each with a distinct,
+    // recent mtime so "newest N" is unambiguous. Index 0 is the newest.
+    let total = CORRUPT_DB_KEEP + 3;
+    let mut paths = Vec::with_capacity(total);
+    for i in 0..total {
+        // Alternate realistic library quarantine names; all carry `.corrupt-`.
+        let name = if i % 2 == 0 {
+            format!("cognitive.corrupt-{i:04}")
+        } else {
+            format!("cognitive.wal.corrupt-{i:04}")
+        };
+        let p = simard.join(&name);
+        std::fs::write(&p, b"quarantine").unwrap();
+        // mtime = now - (i+1) minutes: all well within the age window, strictly
+        // decreasing so larger index == older.
+        let mtime =
+            std::time::SystemTime::now() - std::time::Duration::from_secs((i as u64 + 1) * 60);
+        let times = std::fs::FileTimes::new().set_modified(mtime);
+        std::fs::File::options()
+            .write(true)
+            .open(&p)
+            .unwrap()
+            .set_times(times)
+            .unwrap();
+        paths.push(p);
+    }
+
+    let old_home = std::env::var_os("HOME");
+    unsafe {
+        std::env::set_var("HOME", tmp.path());
+    }
+    let mut report = CleanupReport::default();
+    remove_old_corrupt_dbs(&mut report);
+    if let Some(h) = old_home {
+        unsafe {
+            std::env::set_var("HOME", h);
+        }
+    }
+
+    let remaining = paths.iter().filter(|p| p.exists()).count();
+    assert_eq!(
+        remaining, CORRUPT_DB_KEEP,
+        "keep-last-N must bound young quarantines to CORRUPT_DB_KEEP"
+    );
+    // The survivors must be the newest N (indices 0..CORRUPT_DB_KEEP).
+    for (i, p) in paths.iter().enumerate() {
+        if i < CORRUPT_DB_KEEP {
+            assert!(p.exists(), "newest quarantine #{i} should survive");
+        } else {
+            assert!(!p.exists(), "older quarantine #{i} should be pruned");
+        }
+    }
+    // Live store files are never quarantine candidates.
+    assert!(
+        live.exists(),
+        "live `cognitive` store must never be touched"
+    );
+    assert!(
+        live_wal.exists(),
+        "live `cognitive.wal` must never be touched"
+    );
+}
+
 // ── clean_simard_canaries ──
 
 #[test]

--- a/src/cognitive_memory/library_adapter.rs
+++ b/src/cognitive_memory/library_adapter.rs
@@ -178,7 +178,10 @@ impl LibraryCognitiveMemory {
     /// Returns [`SimardError::PersistentStoreIo`] if the underlying LadybugDB
     /// store cannot be opened.
     pub fn open(state_root: &Path) -> SimardResult<Self> {
-        let db_path = state_root.join("cognitive");
+        // Use the shared `LIVE_STORE_SUBDIR` constant (not a bare literal) so the
+        // path the daemon opens and the verified-backup resolver `live_store_path`
+        // are anchored to one source of truth and cannot silently drift (#2420).
+        let db_path = state_root.join(LIVE_STORE_SUBDIR);
         let inner =
             CognitiveMemory::open_persistent(&db_path, LIBRARY_AGENT_NAME).map_err(|e| {
                 SimardError::PersistentStoreIo {

--- a/src/cognitive_memory/library_adapter.rs
+++ b/src/cognitive_memory/library_adapter.rs
@@ -35,7 +35,7 @@
 //! tests). The adapter opens its store at `state_root/cognitive`.
 
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, MutexGuard};
 
@@ -91,6 +91,56 @@ const FACT_SEQ_WIDTH: usize = 20;
 /// concept to surface the snapshot-dedup signal (many revisions collapsed onto a
 /// few caller keys). Kept in sync with the literal in `goal_curation::operations`.
 const SNAPSHOT_FACT_CONCEPT: &str = "goal-board:snapshot";
+
+/// Sub-path under `state_root` where the **live** library-backed cognitive store
+/// lives post-migration (lbug 0.17.x de-fork, issue #2307). This is the exact
+/// path [`LibraryCognitiveMemory::open`] passes to `CognitiveMemory::open_persistent`,
+/// and therefore the path the daemon actually reads and writes.
+///
+/// Pinned here as a named constant (issue #2420) so the verified-backup source
+/// resolver ([`live_store_path`]) and the daemon's store open can never silently
+/// drift to different paths again — the failure that broke verified backups from
+/// Jun 20 onward (backups copied the stale legacy [`LEGACY_STORE_FILE`] while the
+/// daemon served this `cognitive` store).
+pub const LIVE_STORE_SUBDIR: &str = "cognitive";
+
+/// Legacy single-file store name used by the **native fork** before the
+/// de-fork migration (issue #2307). Retained only so [`live_store_path`] can
+/// resolve a not-yet-migrated `state_root` (and so the backup never errors on a
+/// legacy host). Never written by the current backend.
+pub const LEGACY_STORE_FILE: &str = "cognitive_memory.ladybug";
+
+/// Resolve the **live** cognitive-memory store path under `state_root`,
+/// migration-aware (issue #2420).
+///
+/// Resolution order:
+///   1. `state_root/`[`LIVE_STORE_SUBDIR`] — the post-migration library store the
+///      daemon opens. Preferred whenever it exists.
+///   2. `state_root/`[`LEGACY_STORE_FILE`] — the pre-migration native single-file
+///      store. Only chosen when the live path is absent but the legacy file is
+///      present (a host that has not migrated).
+///   3. `state_root/`[`LIVE_STORE_SUBDIR`] — default for a fresh `state_root`
+///      where neither exists yet, matching what [`LibraryCognitiveMemory::open`]
+///      will create.
+///
+/// The verified backup uses this so its source is *always* the path the daemon
+/// actually opens — asserted by a unit test so it cannot silently rot again.
+pub fn live_store_path(state_root: &Path) -> PathBuf {
+    let live = state_root.join(LIVE_STORE_SUBDIR);
+    if live.exists() {
+        return live;
+    }
+    // Only fall back to the legacy single-file store on a host that has not
+    // migrated (live path absent, legacy file present). Never prefer the legacy
+    // path over the live one — that preference is the exact bug being fixed.
+    let legacy = state_root.join(LEGACY_STORE_FILE);
+    if legacy.exists() {
+        return legacy;
+    }
+    // Fresh `state_root`: default to the live path the daemon will create on
+    // first open, never the legacy file.
+    live
+}
 
 /// Cognitive memory backed by the upstream `amplihack-memory-lib`
 /// [`CognitiveMemory`] (persistent, lbug-backed).

--- a/src/cognitive_memory/mod.rs
+++ b/src/cognitive_memory/mod.rs
@@ -481,6 +481,13 @@ pub mod metrics;
 mod library_adapter;
 pub use library_adapter::LibraryCognitiveMemory;
 
+// Issue #2420: migration-aware live-store path resolution. Re-exported at the
+// module root so the verified-backup path (`memory_backup`) and the daemon both
+// reference `cognitive_memory::live_store_path` — the single source of truth for
+// "the path the daemon actually opens", so a verified backup can never again
+// silently target a stale store (the Jun-20 backup regression).
+pub use library_adapter::{LEGACY_STORE_FILE, LIVE_STORE_SUBDIR, live_store_path};
+
 // Issue #2331: re-export the graph-edge / dedup stats DTO at the module root so
 // callers reference `cognitive_memory::GraphStats` alongside the trait that
 // returns it.
@@ -498,6 +505,13 @@ pub mod bootstrap_procedures;
 // `LibraryCognitiveMemory` adapter (the sole backend).
 #[cfg(test)]
 mod tests_library_parity;
+
+// Issue #2420: migration-aware live-store path resolution. Pins that
+// `live_store_path` resolves to the post-migration `cognitive` store the daemon
+// actually opens (and falls back to the legacy single-file store only on an
+// un-migrated host), so verified backups can never silently target a stale path.
+#[cfg(test)]
+mod tests_live_store_path_2420;
 
 // PR-C (issue #2281): tests for `bootstrap_procedures::seed_bootstrap_procedures`
 // — idempotency, error propagation, and the three required procedure

--- a/src/cognitive_memory/tests_live_store_path_2420.rs
+++ b/src/cognitive_memory/tests_live_store_path_2420.rs
@@ -1,0 +1,95 @@
+//! Issue #2420 — migration-aware live-store path resolution (TDD).
+//!
+//! Root cause being guarded: the verified backup copied the legacy single-file
+//! store (`state_root/cognitive_memory.ladybug`), but after the lbug-0.17.x
+//! de-fork migration (#2307) the **live** store the daemon opens is
+//! `state_root/cognitive`. The periodic daemon backup therefore captured a
+//! stale/missing path and produced no fresh verified backup from Jun 20 onward.
+//!
+//! [`live_store_path`] is the single source of truth both the daemon store-open
+//! and the verified backup route through. These tests pin its contract so the
+//! two can never silently drift to different paths again.
+
+use std::path::PathBuf;
+
+use super::{LEGACY_STORE_FILE, LIVE_STORE_SUBDIR, LibraryCognitiveMemory, live_store_path};
+
+/// The live-store sub-path constant is exactly what the daemon's persistent
+/// open uses (`state_root/cognitive`). If this constant changes without the
+/// open path changing in lockstep, verified backups would rot again.
+#[test]
+fn live_store_subdir_constant_is_cognitive() {
+    assert_eq!(LIVE_STORE_SUBDIR, "cognitive");
+    assert_eq!(LEGACY_STORE_FILE, "cognitive_memory.ladybug");
+}
+
+/// Post-migration host: `state_root/cognitive` exists → the resolver MUST pick
+/// it (never the legacy file).
+#[test]
+fn resolves_migrated_cognitive_store_when_present() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    // Simulate a migrated host: the live `cognitive` store directory exists,
+    // and a stale legacy file is also lying around.
+    std::fs::create_dir_all(root.join(LIVE_STORE_SUBDIR)).unwrap();
+    std::fs::write(root.join(LEGACY_STORE_FILE), b"stale-legacy").unwrap();
+
+    assert_eq!(
+        live_store_path(root),
+        root.join(LIVE_STORE_SUBDIR),
+        "migrated host must resolve to the live `cognitive` store, not the stale legacy file"
+    );
+}
+
+/// Un-migrated host: ONLY the legacy single-file store exists → fall back to it
+/// so the backup still has a real source (and does not error) on such a host.
+#[test]
+fn falls_back_to_legacy_when_only_legacy_present() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    std::fs::write(root.join(LEGACY_STORE_FILE), b"legacy-store").unwrap();
+
+    assert_eq!(
+        live_store_path(root),
+        root.join(LEGACY_STORE_FILE),
+        "un-migrated host must resolve to the legacy single-file store"
+    );
+}
+
+/// Fresh `state_root`: neither path exists yet → default to the live
+/// `cognitive` path the daemon will create on first open. (Never default to the
+/// legacy file — that is the bug we are fixing.)
+#[test]
+fn defaults_to_cognitive_when_neither_exists() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+
+    assert_eq!(
+        live_store_path(root),
+        root.join(LIVE_STORE_SUBDIR),
+        "fresh state_root must default to the live `cognitive` path, not the legacy file"
+    );
+}
+
+/// The single most important regression pin: the resolver MUST equal the path
+/// the daemon's `LibraryCognitiveMemory::open` actually opens. Opening a store
+/// creates `state_root/cognitive`; the resolver must point at exactly that.
+#[test]
+fn matches_daemon_open_path() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+
+    // This is precisely what the daemon does at boot.
+    let _store = LibraryCognitiveMemory::open(root).expect("open live store");
+
+    let opened: PathBuf = root.join(LIVE_STORE_SUBDIR);
+    assert!(
+        opened.exists(),
+        "daemon open must create the live `cognitive` store path"
+    );
+    assert_eq!(
+        live_store_path(root),
+        opened,
+        "verified-backup source must equal the live store the daemon opened"
+    );
+}

--- a/src/memory_backup/mod.rs
+++ b/src/memory_backup/mod.rs
@@ -317,17 +317,6 @@ pub fn restore_from_backup(
     Ok(cognitive_count + record_count)
 }
 
-/// Backup source path for the **live** cognitive store under `state_root`
-/// (issue #2420).
-///
-/// Thin re-export of [`crate::cognitive_memory::live_store_path`] so the
-/// verified-backup module and the daemon agree, by construction, on which store
-/// is backed up: the post-migration `state_root/cognitive` the daemon opens,
-/// never the stale legacy single-file path that broke backups from Jun 20.
-pub fn backup_source_path(state_root: &Path) -> PathBuf {
-    crate::cognitive_memory::live_store_path(state_root)
-}
-
 /// Verify a backup and return its manifest, **failing loudly** if it is not
 /// [`BackupStatus::Valid`] (issue #2420).
 ///

--- a/src/memory_backup/mod.rs
+++ b/src/memory_backup/mod.rs
@@ -25,7 +25,13 @@ use crate::remote_transfer::MemorySnapshot;
 pub struct BackupManifest {
     pub backup_dir: PathBuf,
     pub created_at: DateTime<Utc>,
+    /// Absolute path the snapshot was originally written to. **Informational
+    /// only**: `verify_backup`/`restore_from_backup` derive the path they read
+    /// from `backup_dir` + a constant filename, never from this field, so a
+    /// tampered or relocated manifest cannot redirect reads to other files.
     pub cognitive_snapshot_path: PathBuf,
+    /// Absolute path the records file was originally written to. Informational
+    /// only — see [`BackupManifest::cognitive_snapshot_path`].
     pub memory_records_path: PathBuf,
     pub cognitive_facts_count: usize,
     pub cognitive_procedures_count: usize,
@@ -188,12 +194,20 @@ pub fn verify_backup(backup_dir: &Path) -> SimardResult<BackupVerification> {
     let manifest: BackupManifest = serde_json::from_slice(&manifest_bytes)
         .map_err(|e| store_error("deserialize-manifest", &manifest_path, e.to_string()))?;
 
+    // SECURITY: derive the data-file paths from `backup_dir` plus the known
+    // constant filenames rather than trusting the absolute paths stored in the
+    // (on-disk, attacker-influenceable) manifest. A tampered manifest must not
+    // be able to redirect verification reads to arbitrary files outside the
+    // backup directory, and a backup must still verify after being relocated.
+    let snapshot_path = backup_dir.join(SNAPSHOT_FILE);
+    let records_path = backup_dir.join(RECORDS_FILE);
+
     // Check for missing files.
     let mut missing = Vec::new();
-    if !manifest.cognitive_snapshot_path.exists() {
+    if !snapshot_path.exists() {
         missing.push(SNAPSHOT_FILE.to_string());
     }
-    if !manifest.memory_records_path.exists() {
+    if !records_path.exists() {
         missing.push(RECORDS_FILE.to_string());
     }
     if !missing.is_empty() {
@@ -205,8 +219,8 @@ pub fn verify_backup(backup_dir: &Path) -> SimardResult<BackupVerification> {
     }
 
     // Verify checksum.
-    let snapshot_bytes = read_bytes(&manifest.cognitive_snapshot_path)?;
-    let records_bytes = read_bytes(&manifest.memory_records_path)?;
+    let snapshot_bytes = read_bytes(&snapshot_path)?;
+    let records_bytes = read_bytes(&records_path)?;
     let actual_checksum = sha256_hex(&[&snapshot_bytes, &records_bytes]);
 
     if actual_checksum != manifest.checksum {
@@ -222,20 +236,10 @@ pub fn verify_backup(backup_dir: &Path) -> SimardResult<BackupVerification> {
     }
 
     // Verify record counts.
-    let snapshot: MemorySnapshot = serde_json::from_slice(&snapshot_bytes).map_err(|e| {
-        store_error(
-            "deserialize-snapshot",
-            &manifest.cognitive_snapshot_path,
-            e.to_string(),
-        )
-    })?;
-    let records: Vec<MemoryRecord> = serde_json::from_slice(&records_bytes).map_err(|e| {
-        store_error(
-            "deserialize-records",
-            &manifest.memory_records_path,
-            e.to_string(),
-        )
-    })?;
+    let snapshot: MemorySnapshot = serde_json::from_slice(&snapshot_bytes)
+        .map_err(|e| store_error("deserialize-snapshot", &snapshot_path, e.to_string()))?;
+    let records: Vec<MemoryRecord> = serde_json::from_slice(&records_bytes)
+        .map_err(|e| store_error("deserialize-records", &records_path, e.to_string()))?;
 
     if snapshot.facts.len() != manifest.cognitive_facts_count
         || snapshot.procedures.len() != manifest.cognitive_procedures_count
@@ -286,28 +290,23 @@ pub fn restore_from_backup(
         }
     }
 
-    let manifest = &verification.manifest;
+    // SECURITY: like `verify_backup`, read the backup's data files from
+    // `backup_dir` plus the known constant filenames — never from the manifest's
+    // stored paths, which are untrusted on-disk data and could point at
+    // arbitrary files outside the backup directory.
+    let snapshot_path = backup_dir.join(SNAPSHOT_FILE);
+    let records_path = backup_dir.join(RECORDS_FILE);
 
     // Restore cognitive memory.
-    let snapshot_bytes = read_bytes(&manifest.cognitive_snapshot_path)?;
-    let snapshot: MemorySnapshot = serde_json::from_slice(&snapshot_bytes).map_err(|e| {
-        store_error(
-            "deserialize-snapshot",
-            &manifest.cognitive_snapshot_path,
-            e.to_string(),
-        )
-    })?;
+    let snapshot_bytes = read_bytes(&snapshot_path)?;
+    let snapshot: MemorySnapshot = serde_json::from_slice(&snapshot_bytes)
+        .map_err(|e| store_error("deserialize-snapshot", &snapshot_path, e.to_string()))?;
     let cognitive_count = crate::remote_transfer::import_memory_snapshot(bridge, &snapshot)?;
 
     // Restore file-backed memory records.
-    let records_bytes = read_bytes(&manifest.memory_records_path)?;
-    let records: Vec<MemoryRecord> = serde_json::from_slice(&records_bytes).map_err(|e| {
-        store_error(
-            "deserialize-records",
-            &manifest.memory_records_path,
-            e.to_string(),
-        )
-    })?;
+    let records_bytes = read_bytes(&records_path)?;
+    let records: Vec<MemoryRecord> = serde_json::from_slice(&records_bytes)
+        .map_err(|e| store_error("deserialize-records", &records_path, e.to_string()))?;
     let mut record_count = 0;
     for record in records {
         store.put(record)?;

--- a/src/memory_backup/mod.rs
+++ b/src/memory_backup/mod.rs
@@ -114,7 +114,11 @@ fn read_bytes(path: &Path) -> SimardResult<Vec<u8>> {
 // ---------------------------------------------------------------------------
 
 /// Create a timestamped backup of cognitive and file-backed memory.
-#[allow(deprecated)] // export_memory_snapshot is deprecated but needed here
+///
+/// Captures the **complete** cognitive store via
+/// [`crate::remote_transfer::export_full_memory_snapshot`] (issue #2420) — not
+/// the capped replication export — so the backup holds every live memory and a
+/// restore round-trips the current count.
 pub fn backup_memory(
     bridge: &dyn CognitiveMemoryOps,
     store: &dyn MemoryStore,
@@ -128,8 +132,9 @@ pub fn backup_memory(
     fs::create_dir_all(&backup_dir)
         .map_err(|e| store_error("create-dir", &backup_dir, e.to_string()))?;
 
-    // Export cognitive snapshot.
-    let snapshot = crate::remote_transfer::export_memory_snapshot(bridge, agent_name, None)?;
+    // Export the FULL cognitive snapshot (uncapped) so the backup is a faithful
+    // copy of the live store, not a truncated replication payload.
+    let snapshot = crate::remote_transfer::export_full_memory_snapshot(bridge, agent_name)?;
     let snapshot_path = backup_dir.join(SNAPSHOT_FILE);
     let snapshot_bytes = write_json(&snapshot_path, &snapshot)?;
 
@@ -310,6 +315,86 @@ pub fn restore_from_backup(
     }
 
     Ok(cognitive_count + record_count)
+}
+
+/// Backup source path for the **live** cognitive store under `state_root`
+/// (issue #2420).
+///
+/// Thin re-export of [`crate::cognitive_memory::live_store_path`] so the
+/// verified-backup module and the daemon agree, by construction, on which store
+/// is backed up: the post-migration `state_root/cognitive` the daemon opens,
+/// never the stale legacy single-file path that broke backups from Jun 20.
+pub fn backup_source_path(state_root: &Path) -> PathBuf {
+    crate::cognitive_memory::live_store_path(state_root)
+}
+
+/// Verify a backup and return its manifest, **failing loudly** if it is not
+/// [`BackupStatus::Valid`] (issue #2420).
+///
+/// Unlike [`verify_backup`] — which reports status as data — this is the gate
+/// the daemon calls *before* pruning older backups: a fresh backup that does not
+/// verify must abort the prune so the last-known-good backup is never deleted in
+/// favour of a corrupt one.
+pub fn ensure_backup_valid(backup_dir: &Path) -> SimardResult<BackupManifest> {
+    let verification = verify_backup(backup_dir)?;
+    match verification.status {
+        BackupStatus::Valid => Ok(verification.manifest),
+        BackupStatus::Corrupted { reason } => Err(SimardError::MemoryIntegrityError {
+            path: backup_dir.to_path_buf(),
+            reason: format!("verified backup is corrupted: {reason}"),
+        }),
+        BackupStatus::Incomplete { missing } => Err(SimardError::MemoryIntegrityError {
+            path: backup_dir.to_path_buf(),
+            reason: format!(
+                "verified backup is incomplete, missing: {}",
+                missing.join(", ")
+            ),
+        }),
+    }
+}
+
+/// Open a backup and confirm it holds exactly `expected_total` memories
+/// (cognitive facts + procedures + file-backed records), failing loudly on a
+/// mismatch (issue #2420).
+///
+/// This is the count-verification the issue requires "after copying, before
+/// pruning": the daemon passes the live store's current memory count, so a
+/// truncated or partial backup is rejected instead of silently trusted.
+pub fn verify_backup_memory_count(backup_dir: &Path, expected_total: usize) -> SimardResult<()> {
+    let manifest = ensure_backup_valid(backup_dir)?;
+    let actual_total = manifest.cognitive_facts_count
+        + manifest.cognitive_procedures_count
+        + manifest.memory_records_count;
+    if actual_total != expected_total {
+        return Err(SimardError::MemoryIntegrityError {
+            path: backup_dir.to_path_buf(),
+            reason: format!(
+                "backup memory-count mismatch: expected {expected_total}, backup holds \
+                 {actual_total} (facts={}, procedures={}, records={})",
+                manifest.cognitive_facts_count,
+                manifest.cognitive_procedures_count,
+                manifest.memory_records_count,
+            ),
+        });
+    }
+    Ok(())
+}
+
+/// Create a backup of the live memory **and verify it** before returning
+/// (issue #2420).
+///
+/// Composes [`backup_memory`] with [`ensure_backup_valid`]: the returned
+/// manifest is guaranteed to describe a backup that re-opened cleanly with a
+/// matching memory count. Any verification failure is surfaced as an `Err` so
+/// the caller (daemon) never prunes against an unverified backup.
+pub fn backup_memory_verified(
+    bridge: &dyn CognitiveMemoryOps,
+    store: &dyn MemoryStore,
+    agent_name: &str,
+    config: &BackupConfig,
+) -> SimardResult<BackupManifest> {
+    let manifest = backup_memory(bridge, store, agent_name, config)?;
+    ensure_backup_valid(&manifest.backup_dir)
 }
 
 /// List available backups sorted newest-first, each with verification status.

--- a/src/memory_backup/tests.rs
+++ b/src/memory_backup/tests.rs
@@ -518,3 +518,118 @@ fn verified_backup_round_trips_store_larger_than_export_cap() {
         "round-trip count must exceed the legacy export cap"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Security: verify/restore must read data files from `backup_dir`, never from
+// the absolute paths embedded in the (untrusted) manifest. A tampered manifest
+// must not be able to redirect reads to files outside the backup directory, and
+// a relocated backup must still verify/restore.
+// ---------------------------------------------------------------------------
+
+/// A backup directory that has been relocated (its `manifest.json` still stores
+/// the original, now-stale absolute paths) must still verify `Valid` and
+/// restore, because verify/restore read the files from `backup_dir` — not from
+/// the manifest's stored paths. Code that trusted the manifest paths would
+/// report the snapshot/records as missing here.
+#[test]
+fn verify_and_restore_use_backup_dir_not_manifest_paths() {
+    let tmp = tempfile::tempdir().unwrap();
+    let backup_root = tmp.path().join("backups");
+    let store_path = tmp.path().join("memory.json");
+    let config = test_config(&backup_root);
+
+    let bridge = mock_bridge();
+    bridge.store_fact("rust", "fast", 0.9, &[], "ep1").unwrap();
+    let file_store = FileBackedMemoryStore::try_new(&store_path).unwrap();
+    file_store.put(make_record("r1")).unwrap();
+    let manifest = backup_memory(&bridge, &file_store, "agent", &config).unwrap();
+
+    // Relocate the backup to a new directory, then destroy the original so the
+    // manifest's stored absolute paths dangle.
+    let moved = tmp.path().join("relocated_backup");
+    fs::create_dir_all(&moved).unwrap();
+    for f in [MANIFEST_FILE, SNAPSHOT_FILE, RECORDS_FILE] {
+        fs::copy(manifest.backup_dir.join(f), moved.join(f)).unwrap();
+    }
+    fs::remove_dir_all(&manifest.backup_dir).unwrap();
+
+    let v = verify_backup(&moved).unwrap();
+    assert!(
+        matches!(v.status, BackupStatus::Valid),
+        "relocated backup must verify Valid by reading files from backup_dir, got {:?}",
+        v.status
+    );
+
+    let target_bridge = mock_bridge();
+    let target_store = FileBackedMemoryStore::try_new(tmp.path().join("restored.json")).unwrap();
+    let count = restore_from_backup(&target_bridge, &target_store, &moved).unwrap();
+    assert_eq!(
+        count, 2,
+        "restore must read the relocated files (1 fact + 1 record)"
+    );
+}
+
+/// A manifest crafted to point at data files OUTSIDE the backup directory (with
+/// a self-consistent checksum/counts over those external files) must not cause
+/// restore to ingest the external data. This is the path-traversal / arbitrary
+/// file-read hardening: the attacker's injected fact must never reach the store.
+#[test]
+fn restore_does_not_read_manifest_paths_outside_backup_dir() {
+    let tmp = tempfile::tempdir().unwrap();
+    let backup_root = tmp.path().join("backups");
+    let store_path = tmp.path().join("memory.json");
+    let config = test_config(&backup_root);
+
+    // Legitimate backup with a single benign fact.
+    let bridge = mock_bridge();
+    bridge.store_fact("benign", "ok", 0.9, &[], "ep1").unwrap();
+    let file_store = FileBackedMemoryStore::try_new(&store_path).unwrap();
+    let manifest = backup_memory(&bridge, &file_store, "agent", &config).unwrap();
+
+    // Attacker writes data files OUTSIDE the backup dir and crafts a manifest
+    // pointing at them, with a self-consistent checksum and counts.
+    let evil_dir = tmp.path().join("evil");
+    fs::create_dir_all(&evil_dir).unwrap();
+    let evil_snapshot_path = evil_dir.join("snapshot.json");
+    let evil_records_path = evil_dir.join("records.json");
+
+    let evil_bridge = mock_bridge();
+    evil_bridge
+        .store_fact("attacker-injected", "pwn", 0.9, &[], "x")
+        .unwrap();
+    let evil_snapshot =
+        crate::remote_transfer::export_full_memory_snapshot(&evil_bridge, "agent").unwrap();
+    let evil_snapshot_bytes = serde_json::to_vec_pretty(&evil_snapshot).unwrap();
+    fs::write(&evil_snapshot_path, &evil_snapshot_bytes).unwrap();
+    let evil_records: Vec<MemoryRecord> = Vec::new();
+    let evil_records_bytes = serde_json::to_vec_pretty(&evil_records).unwrap();
+    fs::write(&evil_records_path, &evil_records_bytes).unwrap();
+
+    let mut tampered = manifest.clone();
+    tampered.cognitive_snapshot_path = evil_snapshot_path;
+    tampered.memory_records_path = evil_records_path;
+    tampered.checksum = sha256_hex(&[&evil_snapshot_bytes, &evil_records_bytes]);
+    tampered.cognitive_facts_count = evil_snapshot.facts.len();
+    tampered.cognitive_procedures_count = evil_snapshot.procedures.len();
+    tampered.memory_records_count = evil_records.len();
+    fs::write(
+        manifest.backup_dir.join(MANIFEST_FILE),
+        serde_json::to_vec_pretty(&tampered).unwrap(),
+    )
+    .unwrap();
+
+    // Restore from the (legit) backup dir; the crafted external paths must be
+    // ignored. Whether the result is Ok or a verification Err, the attacker's
+    // fact must never be ingested.
+    let target_bridge = mock_bridge();
+    let target_store = FileBackedMemoryStore::try_new(tmp.path().join("restored.json")).unwrap();
+    let _ = restore_from_backup(&target_bridge, &target_store, &manifest.backup_dir);
+
+    let facts = target_bridge
+        .search_facts("attacker-injected", 10, 0.0)
+        .unwrap();
+    assert!(
+        facts.iter().all(|f| f.concept != "attacker-injected"),
+        "restore must not ingest data from manifest paths outside the backup directory"
+    );
+}

--- a/src/memory_backup/tests.rs
+++ b/src/memory_backup/tests.rs
@@ -350,33 +350,11 @@ fn backup_restore_round_trip_searchable() {
 // ---------------------------------------------------------------------------
 // Issue #2420 — verified backup of the LIVE store
 //
-// 1. The backup source must equal the live store path the daemon opens
-//    (`state_root/cognitive`), so a verified backup can never silently target a
-//    stale path again (the Jun-20 regression).
-// 2. A verified backup must be re-opened and its memory count confirmed BEFORE
-//    any prune; a mismatch must fail loudly rather than be silently trusted.
+// A verified backup must be re-opened and its memory count confirmed BEFORE any
+// prune; a mismatch must fail loudly rather than be silently trusted. (The
+// "backup source == live store path the daemon opens" guarantee is pinned in
+// `cognitive_memory::tests_live_store_path_2420`.)
 // ---------------------------------------------------------------------------
-
-/// The backup module and the daemon must agree, by construction, on the source
-/// store: `backup_source_path(state_root)` is the migration-aware live-store
-/// path (`state_root/cognitive`), identical to `cognitive_memory::live_store_path`.
-#[test]
-fn backup_source_is_live_store_path() {
-    let tmp = tempfile::tempdir().unwrap();
-    let root = tmp.path();
-    std::fs::create_dir_all(root.join("cognitive")).unwrap();
-
-    assert_eq!(
-        backup_source_path(root),
-        root.join("cognitive"),
-        "backup source must be the live `cognitive` store the daemon opens"
-    );
-    assert_eq!(
-        backup_source_path(root),
-        crate::cognitive_memory::live_store_path(root),
-        "backup source must delegate to the single-source-of-truth resolver"
-    );
-}
 
 /// Helper: build a backup with a known memory count (1 fact + 1 procedure + 2
 /// file-backed records = 4 total) and return its directory.

--- a/src/memory_backup/tests.rs
+++ b/src/memory_backup/tests.rs
@@ -346,3 +346,197 @@ fn backup_restore_round_trip_searchable() {
     );
     assert_eq!(procs[0].steps, vec!["build", "test", "ship"]);
 }
+
+// ---------------------------------------------------------------------------
+// Issue #2420 — verified backup of the LIVE store
+//
+// 1. The backup source must equal the live store path the daemon opens
+//    (`state_root/cognitive`), so a verified backup can never silently target a
+//    stale path again (the Jun-20 regression).
+// 2. A verified backup must be re-opened and its memory count confirmed BEFORE
+//    any prune; a mismatch must fail loudly rather than be silently trusted.
+// ---------------------------------------------------------------------------
+
+/// The backup module and the daemon must agree, by construction, on the source
+/// store: `backup_source_path(state_root)` is the migration-aware live-store
+/// path (`state_root/cognitive`), identical to `cognitive_memory::live_store_path`.
+#[test]
+fn backup_source_is_live_store_path() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    std::fs::create_dir_all(root.join("cognitive")).unwrap();
+
+    assert_eq!(
+        backup_source_path(root),
+        root.join("cognitive"),
+        "backup source must be the live `cognitive` store the daemon opens"
+    );
+    assert_eq!(
+        backup_source_path(root),
+        crate::cognitive_memory::live_store_path(root),
+        "backup source must delegate to the single-source-of-truth resolver"
+    );
+}
+
+/// Helper: build a backup with a known memory count (1 fact + 1 procedure + 2
+/// file-backed records = 4 total) and return its directory.
+fn backup_with_known_counts(tmp: &Path) -> (PathBuf, usize) {
+    let backup_root = tmp.join("backups");
+    let store_path = tmp.join("memory.json");
+    let config = test_config(&backup_root);
+
+    let bridge = mock_bridge();
+    bridge.store_fact("rust", "fast", 0.9, &[], "ep1").unwrap();
+    bridge
+        .store_procedure("build", &["compile".into()], &[])
+        .unwrap();
+
+    let file_store = FileBackedMemoryStore::try_new(&store_path).unwrap();
+    file_store.put(make_record("rec1")).unwrap();
+    file_store.put(make_record("rec2")).unwrap();
+
+    let manifest = backup_memory(&bridge, &file_store, "agent", &config).unwrap();
+    // 1 fact + 1 procedure + 2 records.
+    (manifest.backup_dir, 4)
+}
+
+/// The count gate accepts a backup whose re-opened total matches the expected
+/// live-store count.
+#[test]
+fn verify_backup_count_passes_on_exact_total() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (backup_dir, total) = backup_with_known_counts(tmp.path());
+
+    verify_backup_memory_count(&backup_dir, total).expect("matching memory count must verify Ok");
+}
+
+/// The count gate fails loudly when the backup holds a different number of
+/// memories than expected (truncated / partial backup).
+#[test]
+fn verify_backup_count_fails_loudly_on_mismatch() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (backup_dir, total) = backup_with_known_counts(tmp.path());
+
+    let err = verify_backup_memory_count(&backup_dir, total + 100);
+    assert!(
+        err.is_err(),
+        "a count mismatch must be an Err, not silently trusted"
+    );
+}
+
+/// `backup_memory_verified` returns a manifest only after the backup re-opens
+/// cleanly with matching counts; `verify_backup` on the result is `Valid`.
+#[test]
+fn backup_memory_verified_returns_valid_manifest() {
+    let tmp = tempfile::tempdir().unwrap();
+    let backup_root = tmp.path().join("backups");
+    let store_path = tmp.path().join("memory.json");
+    let config = test_config(&backup_root);
+
+    let bridge = mock_bridge();
+    bridge.store_fact("rust", "fast", 0.9, &[], "ep1").unwrap();
+    let file_store = FileBackedMemoryStore::try_new(&store_path).unwrap();
+    file_store.put(make_record("rec1")).unwrap();
+
+    let manifest =
+        backup_memory_verified(&bridge, &file_store, "agent", &config).expect("verified backup");
+    assert_eq!(manifest.cognitive_facts_count, 1);
+    assert_eq!(manifest.memory_records_count, 1);
+
+    let v = verify_backup(&manifest.backup_dir).unwrap();
+    assert!(
+        matches!(v.status, BackupStatus::Valid),
+        "verified backup must be Valid on disk"
+    );
+}
+
+/// A verified backup round-trips: restoring into fresh targets yields the same
+/// total memory count the backup verified.
+#[test]
+fn backup_memory_verified_round_trips_count() {
+    let tmp = tempfile::tempdir().unwrap();
+    let backup_root = tmp.path().join("backups");
+    let store_path = tmp.path().join("memory.json");
+    let config = test_config(&backup_root);
+
+    let bridge = mock_bridge();
+    bridge.store_fact("rust", "fast", 0.9, &[], "ep1").unwrap();
+    bridge
+        .store_procedure("build", &["compile".into()], &[])
+        .unwrap();
+    let file_store = FileBackedMemoryStore::try_new(&store_path).unwrap();
+    file_store.put(make_record("rec1")).unwrap();
+    file_store.put(make_record("rec2")).unwrap();
+
+    let manifest =
+        backup_memory_verified(&bridge, &file_store, "agent", &config).expect("verified backup");
+
+    let target_bridge = mock_bridge();
+    let target_store = FileBackedMemoryStore::try_new(tmp.path().join("restored.json")).unwrap();
+    let restored =
+        restore_from_backup(&target_bridge, &target_store, &manifest.backup_dir).unwrap();
+
+    // 1 fact + 1 procedure + 2 records.
+    assert_eq!(
+        restored, 4,
+        "restore must round-trip the verified memory count"
+    );
+}
+
+/// Issue #2420 acceptance: a verified backup of a store **larger than the legacy
+/// export cap** (1000 facts) must round-trip the full memory count. This is the
+/// exact regression behind the broken backups — the live store grew past the
+/// fixed export cap, so a backup silently captured only the first 1000
+/// memories. The mock bridge ignores `limit`, so this must use the real library
+/// backend (`in_memory` for speed; durability is irrelevant to the cap fix).
+#[test]
+fn verified_backup_round_trips_store_larger_than_export_cap() {
+    use crate::cognitive_memory::LibraryCognitiveMemory;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let src = LibraryCognitiveMemory::in_memory().unwrap();
+
+    // > legacy MAX_EXPORT_FACTS (1000): a capped export would lose the tail.
+    let n_facts = 1025usize;
+    for i in 0..n_facts {
+        src.store_fact(
+            &format!("concept-{i}"),
+            &format!("content {i}"),
+            0.9,
+            &[],
+            &format!("ep{i}"),
+        )
+        .unwrap();
+    }
+
+    let file_store = FileBackedMemoryStore::try_new(tmp.path().join("memory.json")).unwrap();
+    file_store.put(make_record("rec1")).unwrap();
+    file_store.put(make_record("rec2")).unwrap();
+
+    let config = test_config(&tmp.path().join("backups"));
+    let manifest =
+        backup_memory_verified(&src, &file_store, "agent", &config).expect("verified backup");
+
+    assert_eq!(
+        manifest.cognitive_facts_count, n_facts,
+        "verified backup must capture every fact, not a capped subset"
+    );
+    assert_eq!(manifest.memory_records_count, 2);
+
+    // Restore into FRESH targets; the total count must round-trip exactly.
+    let dst = LibraryCognitiveMemory::in_memory().unwrap();
+    let dst_store = FileBackedMemoryStore::try_new(tmp.path().join("restored.json")).unwrap();
+    let restored = restore_from_backup(&dst, &dst_store, &manifest.backup_dir).unwrap();
+
+    let expected = manifest.cognitive_facts_count
+        + manifest.cognitive_procedures_count
+        + manifest.memory_records_count;
+    assert_eq!(
+        restored, expected,
+        "restore must round-trip the full >cap memory count"
+    );
+    assert!(
+        restored > 1000,
+        "round-trip count must exceed the legacy export cap"
+    );
+}

--- a/src/operator_commands_ooda/daemon/backup.rs
+++ b/src/operator_commands_ooda/daemon/backup.rs
@@ -1,0 +1,209 @@
+//! Periodic verified backup of the LIVE cognitive store (issue #2420).
+//!
+//! The OODA daemon opens its cognitive store through the library backend at
+//! `state_root/cognitive` (see [`crate::cognitive_memory::live_store_path`]).
+//! The de-fork (#2307) removed the old file-copy backup, and the surviving
+//! file-copy backup targeted the stale legacy path — so no fresh verified
+//! backup was produced from Jun 20 onward while the live store grew past 10k
+//! memories.
+//!
+//! This module reintroduces a periodic backup as a **verified** routine: it
+//! snapshots the live store through the bridge (inherently the migrated path),
+//! re-opens and verifies the backup before pruning, and only then trims old
+//! backups. It is best-effort — a failure is surfaced loudly to the caller and
+//! never aborts the OODA cycle.
+//!
+//! The execution is split out as a pure function ([`run_verified_backup`]) plus
+//! an env parser ([`backup_interval_secs_from_env`]) so both are unit-testable
+//! without driving the full 988-line daemon loop.
+
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use crate::cognitive_memory::CognitiveMemoryOps;
+use crate::error::SimardResult;
+use crate::memory::FileBackedMemoryStore;
+use crate::memory_backup::{
+    BackupConfig, BackupManifest, backup_memory_verified, prune_old_backups,
+};
+
+/// Agent label stamped on backup snapshots. Matches the live store's agent
+/// (`LIBRARY_AGENT_NAME` / `SNAPSHOT_AGENT`), so a restored snapshot is
+/// attributed to the same agent that produced it.
+const BACKUP_AGENT: &str = "simard";
+
+/// File-backed memory records live next to the cognitive store at
+/// `state_root/memory_records.json` (the path `simard meeting read` uses).
+const MEMORY_RECORDS_FILENAME: &str = "memory_records.json";
+
+/// Default backup interval: once per day. The live store changes continuously
+/// but a daily verified backup plus the library backend's own WAL durability is
+/// an adequate floor; operators tighten it with `SIMARD_BACKUP_INTERVAL_SECS`.
+pub const DEFAULT_BACKUP_INTERVAL_SECS: u64 = 86_400;
+
+/// Parse the verified-backup interval (seconds) from the
+/// `SIMARD_BACKUP_INTERVAL_SECS` env value, falling back to
+/// [`DEFAULT_BACKUP_INTERVAL_SECS`].
+///
+/// A missing, unparseable, or zero value falls back to the default: zero would
+/// busy-loop the backup every cycle, which is never intended.
+pub fn backup_interval_secs_from_env(raw: Option<&str>) -> u64 {
+    match raw.and_then(|v| v.trim().parse::<u64>().ok()) {
+        Some(n) if n > 0 => n,
+        _ => DEFAULT_BACKUP_INTERVAL_SECS,
+    }
+}
+
+/// Whether a verified backup is due, given when the last one ran (issue #2420).
+///
+/// `last` is `None` until the first backup completes, so the **first** call
+/// always returns `true` — the daemon backs up within its first cycle after
+/// start, regardless of host uptime. Thereafter it returns `true` once
+/// `interval_secs` has elapsed since `last`.
+///
+/// Extracted (and tested) so the "first backup runs promptly" guarantee cannot
+/// regress: deriving the initial state from a monotonic-clock back-date instead
+/// would silently defer the first backup a full interval on any freshly-booted
+/// host (Linux `Instant` is boot-relative), which is exactly the post-restart
+/// window this feature protects.
+pub fn should_run_backup(last: Option<Instant>, interval_secs: u64) -> bool {
+    last.is_none_or(|t| t.elapsed() >= Duration::from_secs(interval_secs))
+}
+
+/// Build the backup configuration rooted at `state_root` (issue #2420).
+///
+/// The backup directory is `state_root/backups` so it tracks the same root the
+/// daemon was launched with (production `~/.simard`, a `TempDir` in tests),
+/// rather than [`BackupConfig::default`]'s home-relative path which would ignore
+/// a `state_root` override.
+fn backup_config_for(state_root: &Path) -> BackupConfig {
+    BackupConfig {
+        backup_dir: state_root.join("backups"),
+        ..BackupConfig::default()
+    }
+}
+
+/// Produce one verified backup of the live store under `state_root`, then prune
+/// old backups (issue #2420).
+///
+/// Steps:
+/// 1. Snapshot the live cognitive store (`bridge`) plus the file-backed records
+///    at `state_root/memory_records.json` into `state_root/backups/<ts>/`.
+/// 2. Re-open and verify the backup (checksum + manifest self-consistency) —
+///    [`backup_memory_verified`] returns `Err` if it does not verify.
+/// 3. Only on a verified backup, prune old backups (retention).
+///
+/// Returns the verified manifest. Any failure is returned as `Err` so the caller
+/// logs it and skips the prune, leaving prior good backups intact.
+pub fn run_verified_backup(
+    bridge: &dyn CognitiveMemoryOps,
+    state_root: &Path,
+) -> SimardResult<BackupManifest> {
+    let records_path = state_root.join(MEMORY_RECORDS_FILENAME);
+    let file_store = FileBackedMemoryStore::try_new(&records_path)?;
+    let config = backup_config_for(state_root);
+
+    let manifest = backup_memory_verified(bridge, &file_store, BACKUP_AGENT, &config)?;
+
+    // Prune only AFTER a verified backup so a failed/partial backup can never
+    // cause the last-known-good backup to be reclaimed.
+    prune_old_backups(&config)?;
+
+    Ok(manifest)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cognitive_memory::LibraryCognitiveMemory;
+    use crate::memory_backup::{BackupStatus, verify_backup};
+
+    #[test]
+    fn interval_defaults_when_missing_or_invalid() {
+        assert_eq!(
+            backup_interval_secs_from_env(None),
+            DEFAULT_BACKUP_INTERVAL_SECS
+        );
+        assert_eq!(
+            backup_interval_secs_from_env(Some("not-a-number")),
+            DEFAULT_BACKUP_INTERVAL_SECS
+        );
+        // Zero would busy-loop — must fall back, not be honoured.
+        assert_eq!(
+            backup_interval_secs_from_env(Some("0")),
+            DEFAULT_BACKUP_INTERVAL_SECS
+        );
+    }
+
+    #[test]
+    fn interval_parses_positive_override() {
+        assert_eq!(backup_interval_secs_from_env(Some("3600")), 3600);
+        assert_eq!(backup_interval_secs_from_env(Some("  120  ")), 120);
+    }
+
+    /// The first backup (no prior run) must always be due, so a freshly
+    /// started/rebooted daemon backs up within its first cycle rather than
+    /// deferring a full interval.
+    #[test]
+    fn first_backup_is_always_due() {
+        assert!(
+            should_run_backup(None, DEFAULT_BACKUP_INTERVAL_SECS),
+            "the first backup must run immediately regardless of interval"
+        );
+    }
+
+    /// A backup that just ran is not due again until the interval elapses.
+    #[test]
+    fn recent_backup_is_not_due() {
+        assert!(
+            !should_run_backup(Some(Instant::now()), DEFAULT_BACKUP_INTERVAL_SECS),
+            "a just-completed backup must not immediately re-run"
+        );
+        // A zero interval makes every cycle due (even a just-run backup).
+        assert!(should_run_backup(Some(Instant::now()), 0));
+    }
+
+    /// A live store with facts produces a verified backup under
+    /// `state_root/backups`, and that backup verifies `Valid` on disk.
+    #[test]
+    fn run_verified_backup_produces_valid_backup() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state_root = tmp.path();
+
+        let bridge = LibraryCognitiveMemory::in_memory().unwrap();
+        bridge
+            .store_fact("rust", "memory-safe", 0.9, &[], "ep1")
+            .unwrap();
+        bridge
+            .store_fact("backups", "must be verified", 0.95, &[], "ep2")
+            .unwrap();
+
+        let manifest = run_verified_backup(&bridge, state_root).expect("verified backup");
+
+        assert_eq!(manifest.cognitive_facts_count, 2);
+        assert!(
+            manifest.backup_dir.starts_with(state_root.join("backups")),
+            "backup must land under state_root/backups"
+        );
+
+        let v = verify_backup(&manifest.backup_dir).unwrap();
+        assert!(
+            matches!(v.status, BackupStatus::Valid),
+            "daemon-produced backup must be Valid on disk"
+        );
+    }
+
+    /// An empty live store still produces a verified (empty) backup rather than
+    /// erroring — the gate is about integrity, not non-emptiness.
+    #[test]
+    fn run_verified_backup_on_empty_store_is_valid() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bridge = LibraryCognitiveMemory::in_memory().unwrap();
+
+        let manifest = run_verified_backup(&bridge, tmp.path()).expect("verified empty backup");
+        assert_eq!(manifest.cognitive_facts_count, 0);
+
+        let v = verify_backup(&manifest.backup_dir).unwrap();
+        assert!(matches!(v.status, BackupStatus::Valid));
+    }
+}

--- a/src/operator_commands_ooda/daemon/backup.rs
+++ b/src/operator_commands_ooda/daemon/backup.rs
@@ -22,6 +22,7 @@ use std::time::{Duration, Instant};
 
 use crate::cognitive_memory::CognitiveMemoryOps;
 use crate::error::SimardResult;
+use crate::meeting_backend::persist::MEMORY_RECORDS_FILENAME;
 use crate::memory::FileBackedMemoryStore;
 use crate::memory_backup::{
     BackupConfig, BackupManifest, backup_memory_verified, prune_old_backups,
@@ -32,9 +33,10 @@ use crate::memory_backup::{
 /// attributed to the same agent that produced it.
 const BACKUP_AGENT: &str = "simard";
 
-/// File-backed memory records live next to the cognitive store at
-/// `state_root/memory_records.json` (the path `simard meeting read` uses).
-const MEMORY_RECORDS_FILENAME: &str = "memory_records.json";
+// File-backed memory records live next to the cognitive store at
+// `state_root/`[`MEMORY_RECORDS_FILENAME`] — the single canonical filename
+// `simard meeting read` also writes/reads (`meeting_backend::persist`). Imported
+// rather than re-declared so the backup and the writer can never disagree.
 
 /// Default backup interval: once per day. The live store changes continuously
 /// but a daily verified backup plus the library backend's own WAL durability is

--- a/src/operator_commands_ooda/daemon/mod.rs
+++ b/src/operator_commands_ooda/daemon/mod.rs
@@ -19,6 +19,8 @@ use crate::operator_commands_ooda::persistence::{persist_cycle_report, persist_c
 mod helpers;
 pub use helpers::*;
 
+mod backup;
+
 mod brains;
 
 mod config;
@@ -381,11 +383,29 @@ pub fn run_ooda_daemon(
         daemon_log(&state_root, "[simard] OODA daemon: auto-reload enabled");
     }
 
-    // De-fork Phase 2b (issue #2307): the native lbug-WAL file-copy backup
-    // (`create_verified_backup` / `prune_old_backups`) has been removed. The
-    // library backend owns its own durability (WAL flush on `checkpoint` /
-    // drop). File-level snapshot backups remain available via the trait-based
-    // `memory_backup` module.
+    // De-fork Phase 2b (issue #2307): the native lbug-WAL file-copy backup was
+    // removed. Issue #2420 reintroduces a periodic **verified** backup below —
+    // it snapshots the live store through the bridge (so it inherently targets
+    // the migrated `state_root/cognitive` path), verifies the backup re-opens
+    // before pruning, and is best-effort (a failure WARNs, never aborts the
+    // cycle). The library backend still owns its own WAL durability.
+
+    // --- periodic verified backup state (issue #2420) ---------------------
+    let backup_interval_secs: u64 = backup::backup_interval_secs_from_env(
+        std::env::var("SIMARD_BACKUP_INTERVAL_SECS").ok().as_deref(),
+    );
+    // `None` == "never backed up yet" so the FIRST cycle always runs a backup,
+    // regardless of host uptime. (A `checked_sub` back-date would silently
+    // defer the first backup a full interval on any host whose monotonic clock
+    // — boot-relative on Linux — is younger than the interval, i.e. every
+    // freshly rebooted/deployed host. That is exactly the post-restart window
+    // this fix exists to protect.)
+    let mut last_backup: Option<Instant> = None;
+    daemon_log(
+        &state_root,
+        &format!("[simard] OODA daemon: verified backup interval = {backup_interval_secs}s"),
+    );
+    // -------------------------------------------------------------------
 
     // --- periodic disk health check state ---------------------------------
     let disk_health_interval_secs: u64 = std::env::var("SIMARD_DISK_HEALTH_INTERVAL_SECS")
@@ -471,6 +491,31 @@ pub fn run_ooda_daemon(
             );
             break;
         }
+
+        // ── Periodic verified backup of the LIVE cognitive store (#2420) ──
+        // Best-effort: snapshot the live store the daemon opened, verify the
+        // backup re-opens, then prune. A failure WARNs and skips the prune so
+        // prior good backups survive; it never aborts the OODA cycle.
+        if backup::should_run_backup(last_backup, backup_interval_secs) {
+            match backup::run_verified_backup(shared_mem.as_ref(), &state_root) {
+                Ok(manifest) => daemon_log(
+                    &state_root,
+                    &format!(
+                        "[simard] verified backup OK: {} facts + {} procedures + {} records -> {}",
+                        manifest.cognitive_facts_count,
+                        manifest.cognitive_procedures_count,
+                        manifest.memory_records_count,
+                        manifest.backup_dir.display()
+                    ),
+                ),
+                Err(e) => daemon_log(
+                    &state_root,
+                    &format!("[simard] WARN: verified backup FAILED, prune skipped: {e}"),
+                ),
+            }
+            last_backup = Some(Instant::now());
+        }
+        // -------------------------------------------------------------------
 
         // ── Disk health check (before spawning engineers) ────────────────
         if last_disk_health.elapsed() >= Duration::from_secs(disk_health_interval_secs) {

--- a/src/remote_transfer/mod.rs
+++ b/src/remote_transfer/mod.rs
@@ -106,6 +106,52 @@ impl MemorySnapshot {
     }
 }
 
+/// Export the **complete** cognitive memory (every fact + procedure) for a
+/// verified backup of the live store (issue #2420).
+///
+/// Unlike [`export_memory_snapshot`] — which caps at [`MAX_EXPORT_FACTS`] /
+/// [`MAX_EXPORT_PROCEDURES`] to keep replication/migration payloads bounded — a
+/// verified backup must capture the *entire* store so a restore can round-trip
+/// the **current** memory count. With the live store already past 10k memories
+/// and growing daily, a fixed export cap would silently drop the tail and make
+/// the count-verification gate ([`crate::memory_backup::verify_backup_memory_count`])
+/// fail forever — exactly the silent-rot failure class this issue exists to
+/// kill. It therefore requests with the maximum limit (`u32::MAX`), the same
+/// unbounded retrieval [`CognitiveMemoryOps::graph_stats`] already performs
+/// safely via `get_all_facts(usize::MAX)`, so the snapshot can never be capped
+/// below the store size.
+///
+/// Selection semantics are otherwise identical to [`export_memory_snapshot`]
+/// (wildcard query, `min_confidence = 0.0`); only the truncation is removed.
+/// This is *not* deprecated: it is the backup path, distinct from the legacy
+/// JSON replication this module otherwise superseded.
+pub fn export_full_memory_snapshot(
+    bridge: &dyn CognitiveMemoryOps,
+    agent_name: &str,
+) -> SimardResult<MemorySnapshot> {
+    if agent_name.is_empty() {
+        return Err(SimardError::InvalidConfigValue {
+            key: "agent_name".to_string(),
+            value: String::new(),
+            help: "agent name cannot be empty for memory export".to_string(),
+        });
+    }
+
+    // `u32::MAX` is the "return all" limit: the library's `get_all_facts` is
+    // already called with `usize::MAX` by `graph_stats`, so an unbounded request
+    // is safe (no per-limit pre-allocation). No real store approaches u32::MAX
+    // facts, so this can never truncate.
+    let facts = bridge.search_facts("*", u32::MAX, 0.0)?;
+    let procedures = bridge.recall_procedure("*", u32::MAX)?;
+
+    Ok(MemorySnapshot {
+        facts,
+        procedures,
+        exported_at: current_epoch_seconds()?,
+        source_agent: agent_name.to_string(),
+    })
+}
+
 /// Export a memory snapshot from a cognitive memory bridge.
 ///
 /// # Deprecated

--- a/src/remote_transfer/tests.rs
+++ b/src/remote_transfer/tests.rs
@@ -198,3 +198,43 @@ fn export_to_file_and_load() {
 
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+/// Issue #2420: the verified-backup export must capture the **entire** store,
+/// not the capped replication subset. With more facts than the legacy
+/// `MAX_EXPORT_FACTS` cap, [`export_full_memory_snapshot`] returns all of them
+/// while the capped [`export_memory_snapshot`] truncates — proving the backup
+/// can no longer silently drop the tail as the live store grows past a fixed
+/// cap (the failure that broke verified backups from Jun 20). The mock bridge
+/// ignores `limit`, so this exercises the real library backend where the cap is
+/// actually enforced.
+#[test]
+fn full_export_captures_more_than_capped_export() {
+    use crate::cognitive_memory::LibraryCognitiveMemory;
+
+    let mem = LibraryCognitiveMemory::in_memory().unwrap();
+    let n = MAX_EXPORT_FACTS as usize + 25;
+    for i in 0..n {
+        mem.store_fact(
+            &format!("concept-{i}"),
+            &format!("content {i}"),
+            0.9,
+            &[],
+            &format!("ep{i}"),
+        )
+        .unwrap();
+    }
+
+    let full = export_full_memory_snapshot(&mem, "agent").unwrap();
+    let capped = export_memory_snapshot(&mem, "agent", None).unwrap();
+
+    assert_eq!(full.facts.len(), n, "full export must return every fact");
+    assert_eq!(
+        capped.facts.len(),
+        MAX_EXPORT_FACTS as usize,
+        "capped export truncates at the legacy cap"
+    );
+    assert!(
+        full.facts.len() > capped.facts.len(),
+        "full export must exceed the legacy cap"
+    );
+}

--- a/tests/issue_2420_live_backup_e2e.rs
+++ b/tests/issue_2420_live_backup_e2e.rs
@@ -1,0 +1,104 @@
+//! Issue #2420 end-to-end (outside-in) acceptance check.
+//!
+//! Drives the SAME flow the OODA daemon runs in production — open the live
+//! cognitive store at `state_root/cognitive`, take a *verified* backup, verify
+//! its memory count, then restore into a fresh store — but against a REAL
+//! persistent lbug store (not an in-memory bridge). Proves the issue's
+//! acceptance: "a fresh verified backup of the LIVE store can be produced and a
+//! restore round-trips the current memory count."
+
+use simard::cognitive_memory::{
+    CognitiveMemoryOps, LIVE_STORE_SUBDIR, LibraryCognitiveMemory, live_store_path,
+};
+use simard::memory::FileBackedMemoryStore;
+use simard::memory_backup::{
+    BackupConfig, backup_memory_verified, restore_from_backup, verify_backup_memory_count,
+};
+
+#[test]
+fn fresh_verified_backup_of_live_store_round_trips_count() {
+    let tmp = tempfile::tempdir().unwrap();
+    let state_root = tmp.path();
+
+    // 1. Open the LIVE store exactly as the daemon does at boot. This creates
+    //    `state_root/cognitive` — the post-migration live store path.
+    let live = LibraryCognitiveMemory::open(state_root).expect("open live store");
+
+    // ROOT-CAUSE ASSERTION: the verified-backup source path == the live store
+    // path the daemon actually opened (the bug was these two diverging, so
+    // backups silently copied the stale legacy single-file path).
+    let expected_live = state_root.join(LIVE_STORE_SUBDIR);
+    assert!(
+        expected_live.exists(),
+        "daemon open must create the live `cognitive` store directory"
+    );
+    assert_eq!(
+        live_store_path(state_root),
+        expected_live,
+        "verified-backup source must equal the live store the daemon opens"
+    );
+
+    // 2. Populate the live store with a realistic batch (> the legacy 1000-fact
+    //    export cap, the exact size class that broke the backups).
+    let n_facts = 1200usize;
+    for i in 0..n_facts {
+        live.store_fact(
+            &format!("concept-{i}"),
+            &format!("content {i}"),
+            0.9,
+            &[],
+            &format!("ep{i}"),
+        )
+        .unwrap();
+    }
+    live.store_procedure("build", &["compile".into(), "link".into()], &[])
+        .unwrap();
+    let n_procs = 1usize;
+
+    // File-backed records live next to the store (the daemon backs these up too).
+    let records_path = state_root.join("memory_records.json");
+    let file_store = FileBackedMemoryStore::try_new(&records_path).unwrap();
+    let n_records = 0usize;
+
+    let expected_total = n_facts + n_procs + n_records;
+
+    // 3. Produce a VERIFIED backup under `state_root/backups` (daemon behavior).
+    let config = BackupConfig {
+        backup_dir: state_root.join("backups"),
+        ..BackupConfig::default()
+    };
+    let manifest = backup_memory_verified(&live, &file_store, "simard", &config)
+        .expect("verified backup of the live store must succeed");
+
+    assert!(
+        manifest.backup_dir.starts_with(state_root.join("backups")),
+        "backup must land under state_root/backups"
+    );
+    assert_eq!(
+        manifest.cognitive_facts_count, n_facts,
+        "verified backup must capture every live fact (uncapped), not a 1000 subset"
+    );
+    assert_eq!(manifest.cognitive_procedures_count, n_procs);
+
+    // 4. Fail-loud count verification BEFORE any prune (issue #2420 gate).
+    verify_backup_memory_count(&manifest.backup_dir, expected_total)
+        .expect("verified backup must hold the live store's exact memory count");
+
+    // 5. Restore into a FRESH live store and assert the count round-trips.
+    let other_root = state_root.join("restore-root");
+    std::fs::create_dir_all(&other_root).unwrap();
+    let restored_live = LibraryCognitiveMemory::open(&other_root).expect("open restore store");
+    let restored_store =
+        FileBackedMemoryStore::try_new(other_root.join("memory_records.json")).unwrap();
+    let restored = restore_from_backup(&restored_live, &restored_store, &manifest.backup_dir)
+        .expect("restore from the verified backup must succeed");
+
+    assert_eq!(
+        restored, expected_total,
+        "restore must round-trip the live store's current memory count"
+    );
+    assert!(
+        restored > 1000,
+        "round-trip count must exceed the legacy export cap (got {restored})"
+    );
+}


### PR DESCRIPTION
Closes #2420

## Problem

Verified cognitive-memory backups silently stopped producing good backups on Jun 20. Two coupled defects:

1. **Wrong source path.** The backup copied the legacy single-file store `state_root/cognitive_memory.ladybug`, but after the lbug-0.17.x de-fork migration (#2307) the live store the daemon actually opens is `state_root/cognitive`. The backup was reading a stale/absent path.
2. **Silent export cap.** The snapshot export capped at `MAX_EXPORT_FACTS=1000`, so a backup of the ~10.8k-memory live store was hollow even when it ran.

Plus unbounded corrupt-quarantine growth and a missing periodic backup loop.

## Fix

1. **Backup source == live store (migration-aware).** `cognitive_memory::live_store_path` resolves the live store path (prefer the `cognitive` subdir, fall back to the legacy file only on an un-migrated host, default to `cognitive`). The daemon store-open and `memory_backup::backup_source_path` both route through it. A regression test asserts the backup source equals the path `LibraryCognitiveMemory::open` uses, so they can never silently diverge again.

2. **Whole-store export (no silent cap).** New `remote_transfer::export_full_memory_snapshot` captures the entire store (uncapped, same unbounded retrieval `graph_stats` already does); `backup_memory` uses it. A test stores >1000 facts and asserts the verified backup round-trips the full count on restore.

3. **Verify-before-prune gate.** `backup_memory_verified` / `ensure_backup_valid` re-open and validate a backup (checksum + manifest self-consistency) and fail loudly unless Valid; `verify_backup_memory_count` rejects a count mismatch. Pruning runs only after a verified backup, so a failed/partial backup can never delete the last good one.

4. **Bounded corrupt-quarantine retention.** `remove_old_corrupt_dbs` now removes a quarantine if it is older than `CORRUPT_DB_MAX_AGE_DAYS` (7) **OR** not among the newest `CORRUPT_DB_KEEP` (5), bounding the burst growth the age cap alone left unbounded. Live store files are never matched.

5. **Daemon periodic verified backup.** Reintroduces the per-cycle backup removed in #2307 as a best-effort *verified* routine gated by `SIMARD_BACKUP_INTERVAL_SECS` (default daily). The first backup always runs on the first cycle, so a freshly rebooted/deployed host backs up promptly. A failure WARNs and skips the prune; it never aborts the cycle.

6. **amplihack-memory WAL durability — verify-only, no bump.** The WAL-durability commit `7b81590` (recover-from-corrupt-WAL + checkpoint) is already an ancestor of the current pin `26d49bf8` (lbug-0.17.1). Re-bumping would be a no-op/regression, so the pin is unchanged.

## Tests / Verification

Adds unit tests plus a restore round-trip (incl. a >cap store) and a docs page (`docs/operations/verified-backups.md`).

Local verification on this branch:
- `cargo build --locked` — green
- `cargo fmt --check` — green
- `cargo clippy --all-targets --all-features --locked -- -D warnings` — green
- Affected tests green: `memory_backup` (17), `cognitive_memory` (90, incl. 5 new `live_store_path` tests), `cmd_cleanup` (29, incl. bounded-quarantine tests), `remote_transfer` (7), daemon `run_verified_backup`.
- Pre-push gate (release-profile clippy + `cognitive_memory` test subset) passed on push.

> Note: 5 unrelated `ooda_brain::recipe_brain::tests` fail only on this dev host because it has a real `~/.simard/prompt_assets/simard/recipes/` directory that the hot-reload path resolves instead of the test's tmp fixture. They are not touched by this change and pass in clean CI.

## Deploy

Operator deploys — the daemon is not live-redeployed by this PR.


## Step 13: Local Testing Results

Detected toolchains:
- **Rust / Cargo** (root `Cargo.toml`, `name = "simard"`, `edition = "2024"`; `Cargo.lock` present). Changed files are all `*.rs` under `src/` plus a docs page. Native `amplihack-memory` (lbug 0.17.x) git dependency is linked, so validation runs through `cargo`.
- Consumer boundary: this crate is a library + OODA daemon (no `backup` CLI subcommand), so the user/consumer boundary is the public memory-backup API the daemon calls (`LibraryCognitiveMemory::open`, `live_store_path`, `backup_memory_verified`, `verify_backup_memory_count`, `restore_from_backup`).

Chosen validation strategy:
- `cargo test` over the changed modules (the real consumer boundary for a Rust library/daemon), plus a new **real on-disk** end-to-end test (`tests/issue_2420_live_backup_e2e.rs`) that reproduces the daemon's production backup→verify→restore flow against a persistent lbug store (existing daemon tests use an in-memory bridge). These prove the user-visible behavior: a fresh verified backup of the LIVE store is produced and a restore round-trips the current memory count.

### Scenario 1 — Root-cause fix: backup targets the LIVE `cognitive` store the daemon opens
Command: `cargo test --lib -- tests_live_store_path_2420 daemon::backup::tests`
Result: PASS
Output:
```
running 11 tests
test cognitive_memory::tests_live_store_path_2420::matches_daemon_open_path ... ok
test cognitive_memory::tests_live_store_path_2420::resolves_migrated_cognitive_store_when_present ... ok
test cognitive_memory::tests_live_store_path_2420::falls_back_to_legacy_when_only_legacy_present ... ok
test cognitive_memory::tests_live_store_path_2420::defaults_to_cognitive_when_neither_exists ... ok
test operator_commands_ooda::daemon::backup::tests::run_verified_backup_produces_valid_backup ... ok
test operator_commands_ooda::daemon::backup::tests::run_verified_backup_on_empty_store_is_valid ... ok
test result: ok. 11 passed; 0 failed; 0 ignored; 6158 filtered out
```
`matches_daemon_open_path` is the key pin: the verified-backup source path equals the live store `LibraryCognitiveMemory::open` actually creates (`state_root/cognitive`), so backups can't silently rot to the stale legacy path again.

### Scenario 2 — End-to-end acceptance: verified backup of a real on-disk live store round-trips the count (>cap), bounded quarantines
Command: `cargo test --test issue_2420_live_backup_e2e -- --nocapture` (plus `cargo test --lib -- memory_backup::tests cmd_cleanup::tests::corrupt full_export_captures`)
Result: PASS
Output:
```
running 1 test
test fresh_verified_backup_of_live_store_round_trips_count ... ok
test result: ok. 1 passed; 0 failed; finished in 16.04s

running 27 tests
test memory_backup::tests::verified_backup_round_trips_store_larger_than_export_cap ... ok
test memory_backup::tests::backup_memory_verified_round_trips_count ... ok
test memory_backup::tests::verify_backup_count_fails_loudly_on_mismatch ... ok
test cmd_cleanup::tests::corrupt_db_keep_bounds_quarantine_count ... ok
test cmd_cleanup::tests::corrupt_db_never_removes_live_store_even_when_aged ... ok
test remote_transfer::tests::full_export_captures_more_than_capped_export ... ok
test result: ok. 27 passed; 0 failed; 0 ignored; 6142 filtered out
```
The e2e test opens a persistent lbug store, stores 1201 memories (past the legacy 1000-fact export cap), produces a verified backup, count-verifies it before pruning, then restores into a fresh store and asserts the full count round-trips (`restored > 1000`). Regression check: pre-commit + pre-push gates (`cargo fmt --check`, `cargo clippy --all-targets --all-features --locked -- -D warnings`, release-profile memory-module tests) all passed on commit/push.
