### PR TITLE
fix(ci): provision lbug native lib in coverage job + RUSTSEC-2026-0185 guard (#2423, #2407)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -45,6 +45,29 @@ jobs:
           shared-key: simard-coverage
           save-if: ${{ github.ref == 'refs/heads/main' }}
           cache-on-failure: true
+          # Persist the stable lbug prebuilt outside the cargo registry/src tree
+          # so the version-pinned download happens once per cache lifetime, the
+          # same way verify.yml does (#2426 / #2423).
+          cache-directories: |
+            ~/.cache/simard-lbug-precommit
+
+      - name: Provision lbug native static library link path (#2426 / #2423)
+        # `cargo +nightly llvm-cov --workspace` runs a fresh build that compiles
+        # lbug and hits the same evicted registry-src prebuilt as the pre-commit
+        # clippy gate and verify.yml's install-real job: the cargo cache restores
+        # around the registry archive but evicts it, while keeping the cached
+        # build-script output that references it — so the link fails with "could
+        # not find native static library `lbug`". Provision a stable copy, point
+        # lbug at it via LBUG_LIBRARY_DIR/LBUG_INCLUDE_DIR, and drop the stale
+        # cached lbug build outputs so the build script re-runs and adopts the
+        # pinned path. Runs after the cache restore on purpose, before coverage.
+        shell: bash
+        run: |
+          lib_dir="$HOME/.cache/simard-lbug-precommit/lib"
+          scripts/provision-lbug-prebuilt.sh "$lib_dir" >/dev/null
+          echo "LBUG_LIBRARY_DIR=$lib_dir" >> "$GITHUB_ENV"
+          echo "LBUG_INCLUDE_DIR=$lib_dir" >> "$GITHUB_ENV"
+          rm -rf target/*/build/lbug-* target/*/.fingerprint/lbug-* 2>/dev/null || true
 
       - name: Run coverage
         run: |

--- a/tests/issue_2407_quinn_proto_advisory.rs
+++ b/tests/issue_2407_quinn_proto_advisory.rs
@@ -1,0 +1,147 @@
+//! TDD acceptance guards for issue #2407 — RUSTSEC-2026-0185.
+//!
+//! Advisory: `quinn-proto` < 0.11.15 is vulnerable to remote memory
+//! exhaustion (RUSTSEC-2026-0185). The directed fix is to bump the dependency
+//! *out of the vulnerable range* via the lockfile — NOT to add a blanket
+//! `cargo audit` ignore.
+//!
+//! # What these guards encode (verify-and-close contract)
+//!
+//! #2407 is a **verify-and-close** item: `main`'s `Cargo.lock` already pins
+//! `quinn-proto 0.11.15` (the first fixed release), so these guards are
+//! expected to be GREEN on the fixed tree. They are written as regression
+//! guards so that:
+//!
+//!   1. A future `cargo update` that re-introduces a `quinn-proto < 0.11.15`
+//!      transitively turns the lockfile red here (not just in nightly
+//!      `cargo audit`), and
+//!   2. Nobody "resolves" the advisory by silencing it: RUSTSEC-2026-0185 must
+//!      never appear in `.cargo/audit.toml`'s ignore list.
+//!
+//! These read the raw manifests (rg-shaped) so an operator running the same
+//! `grep` gets the same answer. They do not import the crate, so they stay
+//! decoupled from the heavy `simard` build.
+
+use std::fs;
+use std::path::PathBuf;
+
+/// First `quinn-proto` release that is OUT of the RUSTSEC-2026-0185 vulnerable
+/// range (`>= 0.11.15`).
+const QUINN_PROTO_FIXED: (u64, u64, u64) = (0, 11, 15);
+
+/// The advisory id that must be resolved by the lockfile pin, never silenced.
+const ADVISORY_ID: &str = "RUSTSEC-2026-0185";
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn read_repo_file(rel: &str) -> String {
+    let path = repo_root().join(rel);
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("could not read {} ({e})", path.display()))
+}
+
+/// Parse an `x.y.z` semver core into a comparable tuple. Pre-release/build
+/// metadata (after `-`/`+`) is ignored — sufficient for advisory range checks.
+fn parse_semver(v: &str) -> (u64, u64, u64) {
+    let core = v.split(['-', '+']).next().unwrap_or(v);
+    let mut parts = core.split('.').map(|p| p.parse::<u64>().unwrap_or(0));
+    (
+        parts.next().unwrap_or(0),
+        parts.next().unwrap_or(0),
+        parts.next().unwrap_or(0),
+    )
+}
+
+/// Return every locked `version` for a given `[[package]]` `name` in
+/// `Cargo.lock`. A crate may legitimately appear more than once (multiple
+/// major lines); ALL occurrences must be out of the vulnerable range.
+fn locked_versions(lockfile: &str, crate_name: &str) -> Vec<String> {
+    let needle = format!("name = \"{crate_name}\"");
+    let mut versions = Vec::new();
+    let mut lines = lockfile.lines().peekable();
+    while let Some(line) = lines.next() {
+        if line.trim() != needle {
+            continue;
+        }
+        // The `version = "..."` line follows `name = "..."` within the same
+        // `[[package]]` table. Scan forward until we hit it or the next table.
+        for following in lines.by_ref() {
+            let t = following.trim();
+            if let Some(rest) = t.strip_prefix("version = \"") {
+                if let Some(end) = rest.find('"') {
+                    versions.push(rest[..end].to_string());
+                }
+                break;
+            }
+            if t.starts_with("[[package]]") {
+                break; // malformed entry without a version; stop scanning.
+            }
+        }
+    }
+    versions
+}
+
+// ── #2407 primary contract: lockfile pins quinn-proto out of range ─────────
+
+#[test]
+fn quinn_proto_locked_out_of_rustsec_2026_0185_range() {
+    let lock = read_repo_file("Cargo.lock");
+    let versions = locked_versions(&lock, "quinn-proto");
+
+    assert!(
+        !versions.is_empty(),
+        "quinn-proto not found in Cargo.lock — update this guard if the dep \
+         was removed entirely (which also resolves RUSTSEC-2026-0185)"
+    );
+
+    for v in &versions {
+        let parsed = parse_semver(v);
+        assert!(
+            parsed >= QUINN_PROTO_FIXED,
+            "quinn-proto {v} is inside the RUSTSEC-2026-0185 vulnerable range \
+             (< {}.{}.{}). Bump it out of range via the lockfile \
+             (`cargo update -p quinn-proto`) — do NOT add an audit ignore.",
+            QUINN_PROTO_FIXED.0,
+            QUINN_PROTO_FIXED.1,
+            QUINN_PROTO_FIXED.2,
+        );
+    }
+}
+
+// ── #2407 anti-suppression contract: never silence the advisory ────────────
+
+#[test]
+fn rustsec_2026_0185_is_not_blanket_ignored() {
+    // The audit config is optional; absence trivially satisfies the contract.
+    let path = repo_root().join(".cargo/audit.toml");
+    let Ok(contents) = fs::read_to_string(&path) else {
+        return;
+    };
+
+    assert!(
+        !contents.contains(ADVISORY_ID),
+        "{ADVISORY_ID} must not appear in .cargo/audit.toml — #2407 requires \
+         resolving the advisory by bumping quinn-proto out of the vulnerable \
+         range, not by suppressing `cargo audit`."
+    );
+}
+
+#[test]
+fn cargo_audit_workflow_runs_without_ignore_flag() {
+    // The `cargo-audit` CI job must run a bare `cargo audit` (config-driven),
+    // not paper over RUSTSEC-2026-0185 with an inline `--ignore` flag.
+    let verify = read_repo_file(".github/workflows/verify.yml");
+    assert!(
+        verify.contains("cargo audit"),
+        "verify.yml lost its `cargo audit` job — the advisory gate for #2407 \
+         must stay wired."
+    );
+    assert!(
+        !verify.contains(&format!("--ignore {ADVISORY_ID}"))
+            && !verify.contains("--ignore RUSTSEC"),
+        "cargo audit must not be invoked with an inline `--ignore` flag in \
+         verify.yml — resolution for #2407 is the lockfile pin, not a CLI \
+         suppression."
+    );
+}

--- a/tests/issue_2423_coverage_lbug_provisioning.rs
+++ b/tests/issue_2423_coverage_lbug_provisioning.rs
@@ -1,0 +1,178 @@
+//! TDD red-phase acceptance test for issue #2423 — coverage CI must provision
+//! the `lbug` native static library the same way the (now-fixed) pre-commit
+//! clippy gate and `verify.yml` do (#2426 / #2427).
+//!
+//! # The failure this pins
+//!
+//! `lbug 0.17.1` caches its prebuilt `liblbug.a` inside the cargo
+//! registry-source tree. CI's cargo cache evicts that archive while keeping
+//! the build-script output that references it, so a fresh build fails with
+//! "could not find native static library `lbug`". The fix (#2427) provisions a
+//! stable copy via `scripts/provision-lbug-prebuilt.sh` and pins the link path
+//! through `LBUG_LIBRARY_DIR` / `LBUG_INCLUDE_DIR`.
+//!
+//! `.github/workflows/coverage.yml` runs a fresh `cargo +nightly llvm-cov
+//! --workspace` build and restores the same Swatinem cache, so it shares the
+//! exact eviction failure mode — yet it currently lacks the provisioning step.
+//! These assertions are RED until that step is added to the `coverage` job,
+//! then GREEN, encoding the directed parity with `verify.yml`.
+//!
+//! Implemented as raw-text contract checks (rg-shaped) so an operator grepping
+//! the workflow gets the same answer, and so the guard does not depend on the
+//! heavy `simard`/`lbug` build to run.
+
+use std::fs;
+use std::path::PathBuf;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn read_repo_file(rel: &str) -> String {
+    let path = repo_root().join(rel);
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("could not read {} ({e})", path.display()))
+}
+
+fn coverage_workflow() -> String {
+    read_repo_file(".github/workflows/coverage.yml")
+}
+
+// ── Provisioning is wired into the coverage job ────────────────────────────
+
+#[test]
+fn coverage_workflow_invokes_lbug_provision_script() {
+    let wf = coverage_workflow();
+    assert!(
+        wf.contains("scripts/provision-lbug-prebuilt.sh"),
+        "coverage.yml must invoke scripts/provision-lbug-prebuilt.sh in the \
+         coverage job (mirroring verify.yml's install-real step) so the \
+         `cargo +nightly llvm-cov` build links liblbug.a deterministically \
+         (#2423)."
+    );
+}
+
+#[test]
+fn coverage_workflow_exports_lbug_link_env() {
+    let wf = coverage_workflow();
+    assert!(
+        wf.contains("LBUG_LIBRARY_DIR=") && wf.contains("LBUG_INCLUDE_DIR="),
+        "coverage.yml must export LBUG_LIBRARY_DIR and LBUG_INCLUDE_DIR (#2423) \
+         so lbug resolves the stable prebuilt link path."
+    );
+    assert!(
+        wf.contains("GITHUB_ENV"),
+        "the lbug link-path env vars must be written to $GITHUB_ENV so they \
+         apply to the subsequent coverage build step, exactly like verify.yml."
+    );
+}
+
+#[test]
+fn coverage_workflow_evicts_stale_lbug_build_artifacts() {
+    let wf = coverage_workflow();
+    assert!(
+        wf.contains("target/*/build/lbug-*") && wf.contains("target/*/.fingerprint/lbug-*"),
+        "coverage.yml must drop stale `target/*/build/lbug-*` and \
+         `target/*/.fingerprint/lbug-*` outputs before the coverage build so \
+         the cached build-script output cannot reference an evicted archive \
+         (#2423). Eviction must stay workspace-relative — never widen to $HOME."
+    );
+}
+
+// ── Persistence: cache the prebuilt dir like verify.yml does ───────────────
+
+#[test]
+fn coverage_workflow_caches_lbug_prebuilt_dir() {
+    let wf = coverage_workflow();
+    assert!(
+        wf.contains("simard-lbug-precommit"),
+        "coverage.yml's rust-cache step should list the \
+         `~/.cache/simard-lbug-precommit` prebuilt dir under cache-directories \
+         (parity with verify.yml) so the provisioning is cached where the \
+         cache persists."
+    );
+}
+
+// ── Ordering: provision AFTER cache restore, BEFORE the coverage build ──────
+
+#[test]
+fn lbug_provision_runs_after_cache_restore_and_before_coverage_build() {
+    let wf = coverage_workflow();
+
+    let provision_at = wf
+        .find("scripts/provision-lbug-prebuilt.sh")
+        .expect("coverage.yml must invoke the lbug provision script (#2423)");
+    let cache_at = wf.find("simard-coverage").expect(
+        "coverage.yml must keep its Swatinem rust-cache step \
+                 (shared-key: simard-coverage)",
+    );
+    // Anchor the build position on the `Run coverage` step name, not on a bare
+    // `llvm-cov` substring: the workflow also has an earlier `Install
+    // cargo-llvm-cov` step (which legitimately precedes provisioning), so a
+    // loose `llvm-cov` match would point at the install step and mis-order the
+    // check. The `Run coverage` step is the actual `cargo +nightly llvm-cov`
+    // build that must see the exported LBUG_* env.
+    let build_at = wf.find("Run coverage").expect(
+        "coverage.yml must keep the `cargo +nightly llvm-cov` coverage \
+                 build step (named `Run coverage`)",
+    );
+
+    assert!(
+        cache_at < provision_at,
+        "the lbug provision step must run AFTER the cargo cache restore so it \
+         can evict stale cached lbug-* outputs (#2423)."
+    );
+    assert!(
+        provision_at < build_at,
+        "the lbug provision step must run BEFORE `cargo +nightly llvm-cov` so \
+         LBUG_LIBRARY_DIR/LBUG_INCLUDE_DIR are exported for the build (#2423)."
+    );
+}
+
+// ── Parity: coverage uses the same single-source provisioner as verify.yml ──
+
+#[test]
+fn coverage_provisioning_matches_verify_workflow_mechanism() {
+    let coverage = coverage_workflow();
+    let verify = read_repo_file(".github/workflows/verify.yml");
+
+    for token in [
+        "scripts/provision-lbug-prebuilt.sh",
+        "LBUG_LIBRARY_DIR=",
+        "LBUG_INCLUDE_DIR=",
+        "target/*/build/lbug-*",
+        "target/*/.fingerprint/lbug-*",
+    ] {
+        assert!(
+            verify.contains(token),
+            "verify.yml regressed: lost `{token}` from its lbug provisioning. \
+             coverage.yml is supposed to mirror it (#2423/#2427)."
+        );
+        assert!(
+            coverage.contains(token),
+            "coverage.yml must mirror verify.yml's lbug provisioning but is \
+             missing `{token}` (#2423)."
+        );
+    }
+}
+
+// ── Security: provisioning must not loosen the workflow's locked-down posture ─
+
+#[test]
+fn coverage_workflow_keeps_least_privilege_posture() {
+    let wf = coverage_workflow();
+    assert!(
+        wf.contains("permissions: {}"),
+        "coverage.yml must keep its top-level `permissions: {{}}` — the #2423 \
+         provisioning step adds no new permissions or token access."
+    );
+    assert!(
+        !wf.contains("releases/latest"),
+        "lbug provisioning must stay version-pinned (Cargo.toml-derived), \
+         never `releases/latest`."
+    );
+    assert!(
+        !wf.contains("secrets."),
+        "the lbug provisioning step reads only the repo and $GITHUB_ENV — it \
+         must not reference any `secrets.*`."
+    );
+}


### PR DESCRIPTION
## Summary

Resolves two repo-wide CI/dependency advisories from the goal *"Fix CI/dependency advisories"*:

- **#2423** — `coverage.yml` shares the same `lbug` native-static-lib eviction failure mode that #2426/#2427 fixed elsewhere, but lacked the provisioning step. Aligned it with the (now-fixed) pre-commit clippy gate and `verify.yml`'s `install-real` job.
- **#2407** (RUSTSEC-2026-0185, `quinn-proto` remote memory exhaustion) — **verify-and-close**: `main`'s `Cargo.lock` already pins `quinn-proto 0.11.15` (the first fixed release; vulnerable range is `< 0.11.15`) and `cargo audit` is clean. Added a regression guard so it cannot silently regress or be "resolved" by suppression.

## Changes

### `.github/workflows/coverage.yml` (#2423)
The `coverage` job runs a fresh `cargo +nightly llvm-cov --workspace` build and restores the same Swatinem cache as `verify.yml`. `lbug 0.17.1` caches its prebuilt `liblbug.a` under the cargo registry-src tree, which the cache evicts while keeping the build-script output that references it → `could not find native static library` lbug``. This PR adds, mirroring #2427 verbatim (no new mechanism, no new permissions/secrets):

1. `cache-directories: ~/.cache/simard-lbug-precommit` on the existing rust-cache step, so the version-pinned prebuilt persists across runs.
2. A **"Provision lbug native static library link path"** step (after cache restore, before the coverage build) that runs `scripts/provision-lbug-prebuilt.sh`, exports `LBUG_LIBRARY_DIR`/`LBUG_INCLUDE_DIR` to `$GITHUB_ENV`, and evicts stale `target/*/build/lbug-*` + `target/*/.fingerprint/lbug-*`.

### `tests/issue_2423_coverage_lbug_provisioning.rs` (new)
Lightweight raw-text contract guards: the `coverage` job invokes the provision script, exports the link env to `$GITHUB_ENV`, evicts stale lbug build artifacts, caches the prebuilt dir, runs provisioning **after** cache restore and **before** the coverage build, mirrors `verify.yml`'s mechanism, and keeps least-privilege posture (`permissions: {}`, version-pinned download, no `secrets.*`).

### `tests/issue_2407_quinn_proto_advisory.rs` (new)
Regression guards: every locked `quinn-proto` is `>= 0.11.15`; `RUSTSEC-2026-0185` never appears in `.cargo/audit.toml`; `cargo audit` is invoked without an inline `--ignore`. Turns the lockfile red locally if a future `cargo update` re-introduces the vulnerable range — no blanket audit-ignore.

## Verification

- `cargo audit` → exit 0, **0 occurrences of RUSTSEC-2026-0185**, `quinn-proto 0.11.15` locked.
- `cargo test --test issue_2407_quinn_proto_advisory --test issue_2423_coverage_lbug_provisioning` → **10 passed** (3 + 7).
- `actionlint` + `shellcheck` clean on `coverage.yml` and `verify.yml`.
- Pre-commit + pre-push gates green locally: rust-only-gate, `cargo fmt --all --check`, `cargo clippy --release` (lbug linked), `cargo clippy --all-targets --all-features --locked -- -D warnings`, release race-subset tests.

## Constraints honored

No `Cargo.toml` dependency edits · no blanket audit-ignore · no snapshot/generated-doc churn · no redeploy · no rework of merged #2417/#2427.

Closes #2407
Closes #2423

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>