### PR TITLE
Update .github with 19 changed files (#2252)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,8 +51,23 @@ jobs:
       - name: Package binary
         if: steps.tag_check.outputs.exists == 'false'
         run: |
+          # Enumerate every [[bin]] target name from cargo metadata so the
+          # tarball ships the FULL Simard binary set (simard plus simard-tui,
+          # simard-gym, and the rest) — not just the main daemon binary.
+          # Without this, the consumer-side multi-binary self-update (#2252)
+          # would have nothing extra to install.
+          mapfile -t BIN_TARGETS < <(
+            cargo metadata --no-deps --format-version 1 \
+              | jq -r '.packages[].targets[] | select(.kind[] == "bin") | .name'
+          )
+          if [ "${#BIN_TARGETS[@]}" -eq 0 ]; then
+            echo "::error::No [[bin]] targets found in cargo metadata" >&2
+            exit 1
+          fi
+          echo "Packaging binaries: ${BIN_TARGETS[*]}"
           cd target/release
-          tar czf simard-linux-x86_64.tar.gz simard
+          # Tar exactly the built binaries that exist for this platform.
+          tar czf simard-linux-x86_64.tar.gz "${BIN_TARGETS[@]}"
           sha256sum simard-linux-x86_64.tar.gz > simard-linux-x86_64.tar.gz.sha256
 
       - name: Create release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3892,7 +3892,7 @@ dependencies = [
 
 [[package]]
 name = "simard"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "amplihack-agent-eval",
  "amplihack-memory",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simard"
-version = "0.22.0"
+version = "0.23.0"
 edition = "2024"
 default-run = "simard"
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -93,6 +93,7 @@ Bare `simard` prints the unified help text instead of attempting a hidden enviro
 
 - [How to monitor Simard with the TUI](./howto/monitor-simard-with-tui.md) - Launch `simard-tui` and read daemon health, goals, and system stats from a single terminal pane.
 - [simard-tui reference](./reference/simard-tui.md) - Full specification of tabs, data sources, refresh behaviour, environment variables, and security model.
+- [Multi-binary self-update reference](./reference/multi-binary-self-update.md) - How `simard update` now replaces the **full** binary set (`simard` plus `simard-tui`, `simard-gym`, and the rest), the dynamic discovery and `InstallReport` main-fatal/aux-best-effort contract, the SHA-256 checksum gate, and the matching release-packaging producer contract (#2252).
 
 ## Compatibility binaries
 

--- a/docs/reference/multi-binary-self-update.md
+++ b/docs/reference/multi-binary-self-update.md
@@ -1,0 +1,545 @@
+---
+title: Multi-binary self-update reference
+description: Reference for the multi-binary self-update path that replaces every Simard executable (simard plus simard-tui, simard-gym, and the rest of the auxiliary binary set) on `simard update`, the dynamic binary discovery, the InstallReport main-fatal/aux-best-effort contract, the SHA-256 checksum gate, the zip-slip and https-only transport hardening, and the matching release-packaging producer contract.
+last_updated: 2026-06-28
+review_schedule: as-needed
+owner: simard
+doc_type: reference
+status: implemented
+related:
+  - ./self-deploy-api.md
+  - ./update-check.md
+  - ../safe-self-update.md
+  - ../howto/check-for-updates.md
+  - ../reference/simard-cli.md
+  - ../../src/cmd_self_update/download.rs
+  - ../../src/cmd_self_update/update.rs
+  - ../../.github/workflows/release.yml
+---
+
+# Multi-binary self-update reference
+
+> **Status: implemented.** `simard update` replaces the **entire** Simard
+> binary set — the main `simard` daemon binary **and** every auxiliary
+> executable shipped in the release tarball (`simard-tui`, `simard-gym`,
+> `simard-ooda-step`, the `simard-audit-*` tools, and so on) — not just the
+> daemon binary. The dynamic discovery, the `InstallReport`
+> main-fatal/aux-best-effort contract, and the checksum/extraction/transport
+> hardening live in
+> [`src/cmd_self_update/download.rs`](https://github.com/rysweet/Simard/blob/main/src/cmd_self_update/download.rs)
+> and [`src/cmd_self_update/update.rs`](https://github.com/rysweet/Simard/blob/main/src/cmd_self_update/update.rs).
+> The producer side — packaging the full binary set into each platform tarball —
+> lives in
+> [`.github/workflows/release.yml`](https://github.com/rysweet/Simard/blob/main/.github/workflows/release.yml).
+> Closes [#2252](https://github.com/rysweet/Simard/issues/2252).
+
+This reference specifies the behaviour, public API, configuration, security
+model, and the producer/consumer contract for the multi-binary self-update
+path. For the brain-orchestrated, drain → snapshot → pre-test → swap → validate
+flow that wraps a single swap, see [Safe Self-Update](../safe-self-update.md).
+For the build-from-source merged-but-not-running path, see the
+[self-deploy API reference](./self-deploy-api.md).
+
+## Contents
+
+- [Why](#why)
+- [The binary set](#the-binary-set)
+- [`simard update` behaviour](#simard-update-behaviour)
+- [API reference](#api-reference)
+  - [`InstallReport`](#installreport)
+  - [`find_all_binaries_in_dir`](#find_all_binaries_in_dir)
+  - [`install_binary`](#install_binary)
+  - [`install_binaries`](#install_binaries)
+  - [`verify_sha256`](#verify_sha256)
+  - [`download_to_temp` (shared primitive)](#download_to_temp-shared-primitive)
+- [Failure semantics](#failure-semantics)
+- [Security model](#security-model)
+- [Release packaging contract](#release-packaging-contract)
+- [Backward compatibility](#backward-compatibility)
+- [Examples](#examples)
+- [Configuration & environment](#configuration--environment)
+- [Tests](#tests)
+- [See also](#see-also)
+
+## Why
+
+Before this change, `simard update` downloaded a release tarball, found the
+single file named `simard` inside it, and swapped **only** that file over the
+running daemon binary. Every other shipped executable — most visibly
+`simard-tui`, the operator's monitoring dashboard, but also `simard-gym` and
+the `simard-*-step` / `simard-audit-*` helpers — was left at whatever version
+the operator last installed by hand.
+
+The result was a split-brain install: a freshly self-updated `simard` daemon
+running next to a stale `simard-tui` that spoke an older wire format, or stale
+`simard-*-step` helpers the daemon shells out to. The fix makes
+`simard update` replace **the full set of executables present in the release
+tarball**, so the whole installed surface advances together in one step.
+
+There are two halves, and **both must ship together** or the feature is a
+silent no-op:
+
+1. **Producer** (`release.yml`): the tarball must actually *contain* the full
+   binary set. A release that packages only `simard` gives the consumer nothing
+   extra to install.
+2. **Consumer** (`download.rs` / `update.rs`): the update path must discover and
+   install every executable the tarball contains.
+
+> **Landing note.** This reference documents symbols that do not exist on the
+> default branch yet (`find_all_binaries_in_dir`, `install_binary`,
+> `install_binaries`, `InstallReport`, `verify_sha256`, and
+> `tests_download.rs`); the current tree still has the single-binary
+> `find_binary_in_dir`. The doc must land in the **same PR** as the
+> producer + consumer code so its API links and `status: implemented` are not
+> dangling references.
+
+## The binary set
+
+The set is **discovered dynamically**, never hard-coded. The update path
+installs *every executable extracted from the tarball*, whatever it is named.
+This keeps the feature correct as the binary set evolves (for example, when a
+new `simard-*` helper is added or removed) with no change to the self-update
+code.
+
+At the time of writing the producer packages these Cargo `bin` targets:
+
+| Binary | Role | Replacement policy |
+| --- | --- | --- |
+| `simard` | Main daemon / operator CLI | **Main — fatal** |
+| `simard-tui` | Terminal monitoring dashboard | Auxiliary — best-effort |
+| `simard-gym` | Benchmark suite runner | Auxiliary — best-effort |
+| `simard-ooda-step` | Single OODA-step helper | Auxiliary — best-effort |
+| `simard-improve-step` | Improvement-step helper | Auxiliary — best-effort |
+| `simard-engineer-step` | Engineer-step helper | Auxiliary — best-effort |
+| `simard-self-improve-recipe` | Self-improve recipe driver | Auxiliary — best-effort |
+| `simard-engineer-loop-recipe` | Engineer-loop recipe driver | Auxiliary — best-effort |
+| `simard-audit-pass01` | Audit pass-1 tool | Auxiliary — best-effort |
+| `simard-audit-dashboard` | Audit dashboard | Auxiliary — best-effort |
+| `simard_operator_probe` | Operator self-probe helper (note: underscore-named) | Auxiliary — best-effort |
+
+The table is **illustrative, not authoritative**. The authoritative set is
+whatever `cargo metadata` reports as `bin` targets at release time (see
+[Release packaging contract](#release-packaging-contract)) and, on the consumer
+side, whatever executables the downloaded tarball contains. `simard` is the only
+name with special status: it is the **main** binary and its replacement is
+fatal. Every other extracted executable is **auxiliary** and best-effort.
+
+> **Design note — which targets ship.** The `cargo metadata` enumeration ships
+> **every** `bin` target, including helper/probe binaries such as
+> `simard_operator_probe` (and any future test-only or internal helper bins). If
+> some targets should not be distributed to operators, the producer `jq` filter
+> must gain an explicit exclude list — discovery alone will ship them. Decide
+> the ship/no-ship policy as part of this change rather than leaving it implicit.
+> Note also that target names are not uniformly hyphenated (`simard_operator_probe`
+> uses underscores), so the consumer's basename match and de-duplication must be
+> name-agnostic.
+
+### Install location
+
+Each binary is installed next to the running `simard` — i.e. into the parent
+directory of `std::env::current_exe()`. Auxiliary binaries are matched by their
+**basename only** and written into that same trusted directory (never to a path
+derived from a tarball entry; see [Security model](#security-model)).
+
+## `simard update` behaviour
+
+```text
+simard update
+
+  Download the latest published release for this platform, verify its
+  checksum, then replace the full set of installed Simard binaries:
+
+    * simard (main) is swapped first; failure aborts the update with the
+      previous binary left in place.
+    * every auxiliary binary in the tarball is then installed best-effort;
+      a single aux failure is logged and does not abort the update.
+
+  After the swap, the new `simard` runs its own `self-test`. On success the
+  process exec()s into the new `simard`. On failure the new binaries remain
+  installed but the relaunch is skipped.
+```
+
+The command is unchanged on the surface — operators still run `simard update`.
+What changed is the breadth of the swap and the order of operations:
+
+1. **Resolve** the latest release for this platform (unchanged).
+2. **Download** the platform tarball over https-only transport.
+3. **Verify** the tarball against the published `.sha256` **before** extraction.
+   A mismatch aborts and cleans up the temp directory.
+4. **Extract** into a private temp directory with zip-slip defenses.
+5. **Discover** every executable in the extracted tree.
+6. **Install** the main binary (fatal on error), then each auxiliary binary
+   (best-effort).
+7. **Confirm** each installed binary is present on disk — a post-install
+   existence check over exactly what discovery installed; there is no external
+   "expected" manifest, since the set is dynamic — then print the
+   `InstallReport`.
+8. **Self-test** the new `simard` (main binary only), then `exec()` into it via
+   `self_relaunch::handover` — both unchanged.
+
+## API reference
+
+All items live in `src/cmd_self_update/download.rs` unless noted. They are
+`pub(crate)` — this is an internal contract consumed by `update.rs`, not a
+public library surface — and are documented here as the implementation spec.
+
+### `InstallReport`
+
+The result of installing the full binary set.
+
+```rust
+/// Outcome of installing the full binary set from an extracted tarball.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct InstallReport {
+    /// `true` once the MAIN binary (`simard`) is installed. `false` means the
+    /// update aborted: the caller MUST NOT relaunch.
+    pub main_installed: bool,
+    /// Basenames of auxiliary binaries that were installed successfully.
+    pub aux_installed: Vec<String>,
+    /// Auxiliary binaries that failed to install, as `(basename, reason)`.
+    /// Logged and surfaced to the operator; never aborts the update.
+    pub aux_failed: Vec<(String, String)>,
+}
+```
+
+`main_installed == false` is only ever returned together with an `Err` from
+[`install_binaries`](#install_binaries) — the main binary is fatal, so a `false`
+here always means "abort, do not relaunch". `aux_failed` being non-empty is a
+**successful** update with a warning.
+
+### `find_all_binaries_in_dir`
+
+Replaces the old single-binary `find_binary_in_dir`. Discovers **all**
+executables in the extracted tree.
+
+```rust
+/// Discover every executable file in an extracted tarball tree (max depth 3).
+///
+/// On Unix, "executable" means a regular file with any execute bit set. The
+/// returned paths are de-duplicated by basename (first match by directory walk
+/// order wins) so a tarball can never ask to install two different files to the
+/// same destination name. The main binary `simard` is guaranteed to sort first
+/// in the returned vec when present.
+///
+/// Returns an error only if the tree contains no `simard` binary at all.
+pub(crate) fn find_all_binaries_in_dir(
+    dir: &Path,
+) -> Result<Vec<PathBuf>, Box<dyn std::error::Error>>;
+```
+
+Notes:
+
+- Depth is capped at 3, matching the previous `find_binary_in_dir` behaviour.
+- Directories named `simard` are ignored — only regular files count, exactly as
+  before.
+- A tree with auxiliary binaries but **no** `simard` is an error (a tarball that
+  cannot update the daemon is rejected outright).
+
+### `install_binary`
+
+Atomically install one binary into the trusted install directory.
+
+```rust
+/// Install a single binary `src` to `dest`. Sequence:
+///   1. If `dest` exists, move it aside to `dest.old` (best-effort cleanup of a
+///      stale `.old` first).
+///   2. `rename(src, dest)` — O(1) on the same filesystem.
+///   3. On `EXDEV` (cross-device), fall back to `copy(src, dest)`.
+///   4. On Unix, `chmod 0o755` the installed file.
+///   5. On success, remove the `dest.old` backup.
+/// On failure after step 1, the `.old` backup is restored over `dest`.
+pub(crate) fn install_binary(
+    src: &Path,
+    dest: &Path,
+) -> Result<(), Box<dyn std::error::Error>>;
+```
+
+This is the existing main-binary swap logic, factored out so it can be reused
+per binary. The `0o755` chmod is applied **only** to binaries chosen by
+discovery — never to arbitrary extracted files.
+
+### `install_binaries`
+
+Orchestrate the full-set install with the main-fatal / aux-best-effort policy.
+
+```rust
+/// Install every discovered binary into `install_dir`.
+///
+/// - The binary whose basename is `simard` is installed FIRST and is FATAL:
+///   any error returns `Err` with an `InstallReport { main_installed: false, .. }`
+///   and the caller must abort (no relaunch).
+/// - Every other binary is installed BEST-EFFORT: a failure is recorded in
+///   `aux_failed` and the loop continues.
+///
+/// Returns `Ok(InstallReport)` once the main binary is installed, regardless of
+/// auxiliary outcomes.
+pub(crate) fn install_binaries(
+    binaries: &[PathBuf],
+    install_dir: &Path,
+) -> Result<InstallReport, Box<dyn std::error::Error>>;
+```
+
+### `verify_sha256`
+
+Checksum gate run **before** extraction.
+
+```rust
+/// Verify a downloaded tarball against its published `<asset>.sha256`.
+///
+/// Fetches the sidecar checksum for `asset_url`, computes the SHA-256 of
+/// `archive_path`, and compares. On mismatch (or a missing/unreadable sidecar)
+/// returns an error WITHOUT extracting, and the caller cleans up the temp dir.
+pub(crate) fn verify_sha256(
+    archive_path: &Path,
+    asset_url: &str,
+) -> Result<(), Box<dyn std::error::Error>>;
+```
+
+The release workflow already publishes `<asset>.tar.gz.sha256` next to every
+tarball (see [Release packaging contract](#release-packaging-contract)); this
+function closes the gap where the consumer never downloaded **or** checked it.
+`verify_sha256` resolves the sidecar by appending `.sha256` to `asset_url`,
+fetches it over the same https-only transport, and compares before extraction.
+Because the check lives inside the shared `download_to_temp`, the
+`safe-update` path inherits it too (see [Backward compatibility](#backward-compatibility)).
+
+### `download_to_temp` (shared primitive)
+
+`download_to_temp` is shared by **both** consumers of the self-update download
+path and its signature must **not** change:
+
+- `download_and_replace` — the `simard update` path.
+- `handle_self_update_download_only` — the `simard safe-update` path
+  (`src/cmd_self_update/update.rs`).
+
+It still returns a single `PathBuf` to the **main** `simard` candidate. This is
+a hard constraint: `safe-update`'s `SafeUpdateOrchestrator::new(cfg, candidate,
+install)` consumes exactly one candidate path, so the multi-binary work must not
+change what `download_to_temp` returns. The responsibilities split as:
+
+- `download_to_temp` — download → `verify_sha256` → extract, returning the main
+  `simard` candidate and leaving the rest of the extracted tree in its private
+  temp dir.
+- `download_and_replace` — calls `download_to_temp`, then runs
+  [`find_all_binaries_in_dir`](#find_all_binaries_in_dir) over the extracted tree
+  and [`install_binaries`](#install_binaries) for the full set. **Only this path
+  advances auxiliary binaries.**
+
+Consequently `safe-update` inherits the download/extraction/transport hardening
+(R1–R3) for free but, by construction, still swaps only the main binary — see
+[Backward compatibility](#backward-compatibility).
+
+## Failure semantics
+
+| Situation | Behaviour |
+| --- | --- |
+| Checksum mismatch / missing `.sha256` | **Abort before extraction.** Temp dir removed. Install untouched. |
+| Tarball contains no `simard` | **Abort.** `find_all_binaries_in_dir` errors. Install untouched. |
+| Main `simard` swap fails (e.g. permission denied) | **Fatal.** `Err` returned, `main_installed: false`, no relaunch. Previous binaries remain. Operator is told to retry with `sudo`. |
+| An auxiliary binary swap fails | **Non-fatal.** Recorded in `aux_failed`, logged, update continues and relaunches. |
+| Tarball is an **old single-`simard`** archive | Main installs; `aux_installed` is empty; **not** an error (aux-missing is expected for old releases). |
+| New `simard` `self-test` fails after install | New binaries remain installed; relaunch skipped; non-zero exit (unchanged behaviour). |
+
+The guiding rule: **the core update must never be blocked by an auxiliary
+binary.** A missing or unwritable `simard-tui` degrades the dashboard, not the
+daemon.
+
+## Security model
+
+The multi-binary discovery widens the attack surface (more files written from a
+downloaded archive), so the path is hardened on three axes. All apply to the
+main binary too — they are not aux-only.
+
+| # | Control | What it prevents |
+| --- | --- | --- |
+| R1 | **SHA-256 verification before extraction.** Compute the digest of the downloaded tarball, compare to the published `.sha256`, abort + clean up on mismatch. | Unauthenticated / tampered code execution. Previously the producer published the `.sha256` sidecar but the consumer never fetched **or** verified it (the self-update code had no checksum logic at all). |
+| R2 | **Zip-slip defense.** Install by **basename only** into the trusted install dir; canonicalize within the install root; reject any entry that is an absolute path, contains `..`, or is a symlink. | A malicious archive writing outside the install directory or following a symlink to overwrite an arbitrary file. |
+| R3 | **https-only transport.** Enforce an `https://` URL and, because the download follows redirects (`curl -L`), pass `curl --proto =https --proto-redir =https --tlsv1.2` so a redirect can never downgrade to `http://`. | Protocol downgrade and redirect-to-http MITM. |
+| R4 | **Scoped `chmod`.** `0o755` is applied only to executables chosen by discovery, never to arbitrary extracted files. | Granting execute to attacker-planted data files. |
+| R5 | **Strict asset matching.** Keep the exact platform-suffix + `.tar.gz` asset match when selecting the release asset. | Asset spoofing via look-alike asset names. |
+| R6 | **SHA-pinned Actions.** The release workflow keeps every GitHub Action pinned by commit SHA. | Supply-chain compromise of a tag-mutable action. |
+
+No secrets ever appear in logs or issue comments. The "try `sudo`, fail cleanly"
+behaviour is preserved — the update path never auto-escalates; it installs into
+a private temp dir and renames into place, cleaning up on every exit path.
+
+## Release packaging contract
+
+The producer side (`.github/workflows/release.yml`) packages the **full binary
+set** into each platform tarball, instead of only `simard`. Without this, the
+consumer refactor installs nothing extra.
+
+The "Package binary" step enumerates Cargo `bin` targets dynamically rather than
+naming a literal `simard`:
+
+```bash
+# Enumerate every [[bin]] target name from cargo metadata.
+mapfile -t BIN_TARGETS < <(
+  cargo metadata --no-deps --format-version 1 \
+    | jq -r '.packages[].targets[] | select(.kind[] == "bin") | .name'
+)
+
+cd target/release
+# Tar exactly the built binaries that exist for this platform.
+TARBALL="simard-${PLATFORM_SUFFIX}.tar.gz"
+tar czf "$TARBALL" "${BIN_TARGETS[@]}"
+sha256sum "$TARBALL" > "$TARBALL.sha256"
+```
+
+> **Scope note.** The current `release.yml` builds a **single** `linux-x86_64`
+> job with no platform matrix, and `PLATFORM_SUFFIX` is shown generically above
+> for forward-compatibility. The only change [#2252](https://github.com/rysweet/Simard/issues/2252)
+> makes to the producer is replacing the literal `tar czf … simard` with the
+> enumerated `"${BIN_TARGETS[@]}"`; adding the other platform suffixes listed
+> below (`linux-aarch64`, `macos-*`, `windows-x86_64`) is a separate,
+> out-of-scope change even though `platform_suffix()` already resolves them on
+> the consumer side.
+
+Contract guarantees:
+
+- The tarball contains **every** built `bin` target, with `simard` always
+  present.
+- A `<asset>.tar.gz.sha256` sidecar is published next to every tarball (already
+  true; the consumer now verifies it — see [R1](#security-model)).
+- The platform suffix (`linux-x86_64`, `linux-aarch64`, `macos-x86_64`,
+  `macos-aarch64`, `windows-x86_64`) is unchanged, so existing
+  [`platform_suffix()`](https://github.com/rysweet/Simard/blob/main/src/cmd_self_update/platform.rs)
+  asset matching keeps working.
+
+## Backward compatibility
+
+- **Old tarballs that contain only `simard`** still update cleanly: the main
+  binary installs and `aux_installed` is empty. Aux-missing is non-fatal by
+  design.
+- **Operators on a host with a hand-installed `simard-tui`** get it replaced
+  automatically on the next `simard update`, ending the split-brain state.
+- **`simard safe-update`** (the brain-orchestrated path) shares
+  `download_to_temp`, so it inherits the **download/extraction hardening**
+  (R1 checksum gate, R2 zip-slip defense, R3 https-only transport) for free. It
+  does **not** advance the full binary set: `SafeUpdateOrchestrator` operates on
+  a single candidate binary and a single install path, and extending it to the
+  multi-binary set is **out of scope for [#2252](https://github.com/rysweet/Simard/issues/2252)**
+  (future work). Its drain/snapshot/pre-test/validate/rollback envelope is
+  unchanged. See [Safe Self-Update](../safe-self-update.md).
+- The `simard update` CLI flags and exit codes are unchanged.
+
+## Examples
+
+### Operator: update the whole install in one step
+
+```console
+$ simard update
+simard self-update (current: v0.42.0)
+New version available: v0.42.0 → v0.43.0
+Downloading simard v0.43.0...
+Verifying checksum... ok
+Extracting...
+Replacing binaries...
+  simard               installed (main)
+  simard-tui           installed
+  simard-gym           installed
+  simard-ooda-step     installed
+  simard-audit-pass01  installed
+  …                    (remaining auxiliary binaries)
+Updated 9 binaries: v0.42.0 → v0.43.0
+Running self-test on new binary...
+Self-test passed.
+Relaunching into v0.43.0...
+```
+
+### Auxiliary failure is non-fatal
+
+If `simard-tui` cannot be written (for example it is open and locked on
+Windows), the update still completes:
+
+```console
+$ simard update
+...
+Replacing binaries...
+  simard               installed (main)
+  simard-tui           SKIPPED: Failed to install new binary: Permission denied
+  simard-gym           installed
+  …                    (remaining auxiliary binaries)
+Updated 8 binaries (1 skipped): v0.42.0 → v0.43.0
+WARNING: 1 auxiliary binary was not updated: simard-tui
+Run 'simard update' again after closing it, or reinstall it manually.
+Running self-test on new binary...
+Self-test passed.
+Relaunching into v0.43.0...
+```
+
+### Checksum mismatch aborts before extraction
+
+```console
+$ simard update
+simard self-update (current: v0.42.0)
+New version available: v0.42.0 → v0.43.0
+Downloading simard v0.43.0...
+Verifying checksum... MISMATCH
+error: downloaded archive failed SHA-256 verification; aborting update
+       (expected 9f86d0…, got 2c26b4…). No binaries were changed.
+```
+
+### Updating from an old single-binary release
+
+```console
+$ simard update
+...
+Extracting...
+Replacing binaries...
+  simard  installed (main)
+Updated 1 binary: v0.41.0 → v0.42.0
+Running self-test on new binary...
+Self-test passed.
+Relaunching into v0.42.0...
+```
+
+## Configuration & environment
+
+The multi-binary path adds **no** new configuration knobs and **no** new
+environment variables. It inherits the existing self-update environment:
+
+- Platform/asset resolution: [`platform.rs`](https://github.com/rysweet/Simard/blob/main/src/cmd_self_update/platform.rs)
+  (`GITHUB_REPO`, `platform_suffix()`).
+- `CURRENT_VERSION` from `env!("CARGO_PKG_VERSION")`.
+- The brain-triggering doctrine and `UpdateConfig` knobs that govern *when*
+  `safe-update` fires are documented in
+  [Safe Self-Update → Configuration](../safe-self-update.md#configuration) and
+  the [self-deploy API reference](./self-deploy-api.md#updateconfig-self-deploy-fields).
+
+## Tests
+
+Unit tests live in
+[`src/cmd_self_update/tests_download.rs`](https://github.com/rysweet/Simard/blob/main/src/cmd_self_update/tests_download.rs)
+and run hermetically (no network, no live release):
+
+- **Discovery**: `find_all_binaries_in_dir` finds the main binary plus multiple
+  auxiliary binaries at root, nested, and at the depth-3 boundary; still errors
+  when no `simard` is present; ignores directories named `simard`;
+  de-duplicates by basename.
+- **Install**: `install_binary` covers the same-filesystem `rename` path, the
+  cross-device `copy` fallback, the `.old` backup/restore, and the `0o755`
+  permission set (Unix).
+- **Report paths**: happy path (main + all aux installed); missing-aux =
+  no-error (`aux_installed` partial, no `aux_failed`); missing-main = fatal
+  (`Err`, `main_installed: false`); an aux failure is logged into `aux_failed`
+  without aborting.
+- **Security**: checksum mismatch aborts before extraction; a zip-slip entry
+  (absolute path, `..`, or symlink) is rejected; a non-https URL is refused.
+- **Shared-primitive regression**: `download_to_temp` still returns a single
+  `PathBuf` to the main `simard` candidate, preserving the `safe-update`
+  single-candidate contract.
+
+Everything passes `cargo test --all-features --locked`, `cargo clippy
+--all-targets --all-features --locked -- -D warnings`, and `cargo fmt --all --
+--check` under the repository's pre-commit/pre-push hooks and `verify.yml` CI.
+
+## See also
+
+- [Safe Self-Update](../safe-self-update.md) — the drain → snapshot → pre-test →
+  swap → validate → rollback envelope around a swap.
+- [Self-deploy API reference](./self-deploy-api.md) — the build-from-source,
+  merged-but-not-running deploy path.
+- [Update-check reference](./update-check.md) — how Simard notices a newer
+  release is available.
+- [How to check for updates](../howto/check-for-updates.md) — operator runbook.

--- a/src/cmd_self_update/download.rs
+++ b/src/cmd_self_update/download.rs
@@ -24,8 +24,8 @@ pub(crate) struct InstallReport {
 }
 
 /// Private temp directory the self-update flow downloads and extracts into.
-/// Shared by `download_to_temp` (which fills it) and `download_and_replace`
-/// (which discovers the extracted binary set inside it).
+/// Filled by `download_and_extract`; both `download_to_temp` and
+/// `download_and_replace` then discover the extracted binary set inside it.
 fn update_tmp_dir() -> PathBuf {
     std::env::temp_dir().join(format!("simard-update-{}", std::process::id()))
 }
@@ -46,13 +46,10 @@ pub(crate) fn download_and_replace(
         .ok_or("Cannot determine install directory from current executable")?
         .to_path_buf();
 
-    // Download → verify checksum → extract into the private temp dir. The
-    // returned path is the main `simard` candidate; the rest of the extracted
-    // tree stays in the temp dir for discovery below.
-    let _main_candidate = download_to_temp(url, version)?;
-    let tmp_dir = update_tmp_dir();
-
-    // Discover EVERY executable in the extracted tree (main + auxiliaries).
+    // Download → verify checksum → extract into the private temp dir, then
+    // discover EVERY executable in the extracted tree (main + auxiliaries) with
+    // a single filesystem walk.
+    let tmp_dir = download_and_extract(url, version)?;
     let binaries = find_all_binaries_in_dir(&tmp_dir)?;
 
     println!("Replacing {} binary(ies)...", binaries.len());
@@ -78,16 +75,12 @@ pub(crate) fn download_and_replace(
     Ok(report)
 }
 
-/// Download and extract the simard release into a temp directory, returning
-/// the path to the extracted **main** `simard` binary. Used by both
-/// `download_and_replace` (which then installs the full binary set) and the
-/// safe-update flow (which copies the main candidate to an install path and
-/// runs a pre-test before swapping). Its signature is a hard contract: it
-/// must keep returning a single `PathBuf` to the main candidate.
-pub(crate) fn download_to_temp(
-    url: &str,
-    version: &str,
-) -> Result<PathBuf, Box<dyn std::error::Error>> {
+/// Download → verify checksum → extract the release into the private temp dir,
+/// returning the populated temp directory. Shared by `download_to_temp` and
+/// `download_and_replace` so the download/verify/extract work runs once and the
+/// binary-discovery walk that follows it also runs exactly once per update
+/// (previously `download_and_replace` walked the extracted tree twice).
+fn download_and_extract(url: &str, version: &str) -> Result<PathBuf, Box<dyn std::error::Error>> {
     let tmp_dir = update_tmp_dir();
     fs::create_dir_all(&tmp_dir)?;
     let archive_path = tmp_dir.join("simard.tar.gz");
@@ -171,6 +164,19 @@ pub(crate) fn download_to_temp(
         return Err("Extraction failed".into());
     }
 
+    Ok(tmp_dir)
+}
+
+/// Download and extract the simard release into a temp directory, returning
+/// the path to the extracted **main** `simard` binary. Used by the
+/// `safe-update` flow (which copies the main candidate to an install path and
+/// runs a pre-test before swapping). Its signature is a hard contract: it must
+/// keep returning a single `PathBuf` to the main candidate.
+pub(crate) fn download_to_temp(
+    url: &str,
+    version: &str,
+) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let tmp_dir = download_and_extract(url, version)?;
     // Return the main `simard` candidate (discovery guarantees it sorts first).
     let binaries = find_all_binaries_in_dir(&tmp_dir)?;
     binaries

--- a/src/cmd_self_update/download.rs
+++ b/src/cmd_self_update/download.rs
@@ -1,59 +1,102 @@
 //! Binary download, extraction, and replacement logic.
+//!
+//! `simard update` replaces the **full** Simard binary set (`simard` plus
+//! `simard-tui`, `simard-gym`, and the rest of the auxiliary binaries shipped in
+//! the release tarball), not just the main daemon binary (issue #2252). See
+//! `docs/reference/multi-binary-self-update.md` for the full contract.
 
+use std::collections::HashSet;
+use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
 
 use super::platform::CURRENT_VERSION;
 
-/// Download and extract the binary, replacing the current executable.
+/// Outcome of installing the full binary set from an extracted tarball.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct InstallReport {
+    /// `true` once the MAIN binary (`simard`) is installed. `false` means the
+    /// update aborted: the caller MUST NOT relaunch.
+    pub main_installed: bool,
+    /// Basenames of auxiliary binaries that were installed successfully.
+    pub aux_installed: Vec<String>,
+    /// Auxiliary binaries that failed to install, as `(basename, reason)`.
+    /// Logged and surfaced to the operator; never aborts the update.
+    pub aux_failed: Vec<(String, String)>,
+}
+
+/// Private temp directory the self-update flow downloads and extracts into.
+/// Shared by `download_to_temp` (which fills it) and `download_and_replace`
+/// (which discovers the extracted binary set inside it).
+fn update_tmp_dir() -> PathBuf {
+    std::env::temp_dir().join(format!("simard-update-{}", std::process::id()))
+}
+
+/// Download and extract the release, replacing the full set of installed
+/// Simard binaries. The main `simard` swap is fatal; auxiliary binaries are
+/// installed best-effort.
 pub(crate) fn download_and_replace(
     url: &str,
     version: &str,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<InstallReport, Box<dyn std::error::Error>> {
     let current_exe =
         std::env::current_exe().map_err(|e| format!("Cannot determine current executable: {e}"))?;
-    let new_bin = download_to_temp(url, version)?;
+    let install_dir = current_exe
+        .parent()
+        .ok_or("Cannot determine install directory from current executable")?
+        .to_path_buf();
 
-    // Replace current binary — atomic rename, with copy for cross-device installs
-    println!("Replacing binary...");
-    let backup = current_exe.with_extension("old");
-    if backup.exists() {
-        let _ = fs::remove_file(&backup);
+    // Download → verify checksum → extract into the private temp dir. The
+    // returned path is the main `simard` candidate; the rest of the extracted
+    // tree stays in the temp dir for discovery below.
+    let _main_candidate = download_to_temp(url, version)?;
+    let tmp_dir = update_tmp_dir();
+
+    // Discover EVERY executable in the extracted tree (main + auxiliaries).
+    let binaries = find_all_binaries_in_dir(&tmp_dir)?;
+
+    println!("Replacing {} binary(ies)...", binaries.len());
+    let report = install_binaries(&binaries, &install_dir)?;
+
+    // Post-install confirmation: every binary discovery installed must now be
+    // present on disk. The set is dynamic, so this checks exactly what we
+    // installed rather than a static manifest.
+    let main_dest = install_dir.join("simard");
+    if !main_dest.exists() {
+        return Err(format!("Main binary missing after install: {}", main_dest.display()).into());
     }
-    fs::rename(&current_exe, &backup)
-        .map_err(|e| format!("Failed to backup current binary (try running with sudo): {e}"))?;
-
-    // rename is O(1) on same filesystem; copy handles cross-device moves
-    if fs::rename(&new_bin, &current_exe).is_err() {
-        fs::copy(&new_bin, &current_exe)
-            .map_err(|e| format!("Failed to install new binary: {e}"))?;
+    for name in &report.aux_installed {
+        let dest = install_dir.join(name);
+        if !dest.exists() {
+            return Err(format!("Auxiliary binary reported installed but missing: {name}").into());
+        }
     }
 
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(&current_exe, fs::Permissions::from_mode(0o755))?;
-    }
+    // Clean up the temp directory (archive + any leftover extracted files).
+    let _ = fs::remove_dir_all(&tmp_dir);
 
-    // Clean up
-    let _ = fs::remove_file(&backup);
-    if let Some(parent) = new_bin.parent() {
-        let _ = fs::remove_dir_all(parent);
+    if report.aux_installed.is_empty() {
+        println!("Updated simard: {CURRENT_VERSION} → {version}");
+    } else {
+        println!(
+            "Updated simard + {} auxiliary binary(ies): {CURRENT_VERSION} → {version}",
+            report.aux_installed.len()
+        );
     }
-
-    println!("Updated simard: {CURRENT_VERSION} → {version}");
-    Ok(())
+    Ok(report)
 }
 
 /// Download and extract the simard release into a temp directory, returning
-/// the path to the extracted binary. Used by both `download_and_replace`
-/// (which then rename()s into the live install) and the safe-update flow
-/// (which copies to a candidate path and runs pre-test before swapping).
+/// the path to the extracted **main** `simard` binary. Used by both
+/// `download_and_replace` (which then installs the full binary set) and the
+/// safe-update flow (which copies the main candidate to an install path and
+/// runs a pre-test before swapping). Its signature is a hard contract: it
+/// must keep returning a single `PathBuf` to the main candidate.
 pub(crate) fn download_to_temp(
     url: &str,
     version: &str,
 ) -> Result<PathBuf, Box<dyn std::error::Error>> {
-    let tmp_dir = std::env::temp_dir().join(format!("simard-update-{}", std::process::id()));
+    let tmp_dir = update_tmp_dir();
     fs::create_dir_all(&tmp_dir)?;
     let archive_path = tmp_dir.join("simard.tar.gz");
 
@@ -74,6 +117,13 @@ pub(crate) fn download_to_temp(
             .args([
                 "-sS",
                 "-L",
+                // R3: https-only transport — refuse a plaintext URL and never
+                // let a redirect downgrade the scheme to http://.
+                "--proto",
+                "=https",
+                "--proto-redir",
+                "=https",
+                "--tlsv1.2",
                 "--connect-timeout",
                 "15",
                 "--max-time",
@@ -99,6 +149,14 @@ pub(crate) fn download_to_temp(
         return Err(format!("Download failed after 3 attempts: {last_err}").into());
     }
 
+    // R1: verify the downloaded tarball against its published `.sha256` sidecar
+    // BEFORE extracting anything. A mismatch (or missing sidecar) aborts.
+    println!("Verifying checksum...");
+    if let Err(e) = verify_sha256(&archive_path, url) {
+        let _ = fs::remove_dir_all(&tmp_dir);
+        return Err(format!("Checksum verification failed: {e}").into());
+    }
+
     println!("Extracting...");
     let tar_status = std::process::Command::new("tar")
         .args([
@@ -120,96 +178,290 @@ pub(crate) fn download_to_temp(
         let _ = fs::remove_dir_all(&tmp_dir);
         return Err("Extraction failed".into());
     }
-    find_binary_in_dir(&tmp_dir)
+
+    // Return the main `simard` candidate (discovery guarantees it sorts first).
+    let binaries = find_all_binaries_in_dir(&tmp_dir)?;
+    binaries
+        .into_iter()
+        .next()
+        .ok_or_else(|| "Binary 'simard' not found in downloaded archive".into())
 }
 
-/// Find the simard binary in an extracted directory tree (max depth 3).
-pub(crate) fn find_binary_in_dir(dir: &Path) -> Result<PathBuf, Box<dyn std::error::Error>> {
-    use std::ffi::OsStr;
-    fn search(dir: &Path, depth: u32) -> Option<PathBuf> {
+/// On Unix an "executable" is a regular file with any execute bit set. The
+/// `DirEntry::metadata` call does not traverse symlinks (and callers skip
+/// symlinks before reaching here anyway).
+#[cfg(unix)]
+fn is_executable_file(entry: &fs::DirEntry) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    entry
+        .metadata()
+        .map(|m| m.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+/// On non-Unix targets there is no execute bit, so treat regular files as
+/// candidates but exclude the archive and its checksum sidecar that share the
+/// temp directory.
+#[cfg(not(unix))]
+fn is_executable_file(entry: &fs::DirEntry) -> bool {
+    !matches!(
+        entry.path().extension().and_then(|e| e.to_str()),
+        Some("gz") | Some("tar") | Some("sha256")
+    )
+}
+
+/// Discover every executable file in an extracted tarball tree (max depth 3).
+///
+/// On Unix, "executable" means a regular file with any execute bit set. The
+/// returned paths are de-duplicated by basename (shallowest directory-walk
+/// match wins) so a tarball can never ask to install two different files to the
+/// same destination name. The main binary `simard` is hoisted to the front of
+/// the returned vec when present.
+///
+/// Returns an error only if the tree contains no `simard` binary at all.
+pub(crate) fn find_all_binaries_in_dir(
+    dir: &Path,
+) -> Result<Vec<PathBuf>, Box<dyn std::error::Error>> {
+    fn collect(
+        dir: &Path,
+        depth: u32,
+        seen: &mut HashSet<std::ffi::OsString>,
+        out: &mut Vec<PathBuf>,
+    ) {
         if depth > 3 {
-            return None;
+            return;
         }
-        let entries = fs::read_dir(dir).ok()?;
-        let target = OsStr::new("simard");
+        let Ok(entries) = fs::read_dir(dir) else {
+            return;
+        };
+        // Process files in this directory before recursing so that a shallower
+        // basename match always wins the de-duplication.
+        let mut subdirs: Vec<PathBuf> = Vec::new();
         for entry in entries.flatten() {
-            let path = entry.path();
-            if path.is_file() && entry.file_name() == target {
-                return Some(path);
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            // R2: a symlink (file or dir) is never followed — neither installed
+            // nor descended into. This blocks zip-slip via symlinked entries.
+            if file_type.is_symlink() {
+                continue;
             }
-            if path.is_dir()
-                && let Some(found) = search(&path, depth + 1)
-            {
-                return Some(found);
+            if file_type.is_dir() {
+                subdirs.push(entry.path());
+                continue;
+            }
+            if file_type.is_file() && is_executable_file(&entry) && seen.insert(entry.file_name()) {
+                out.push(entry.path());
             }
         }
-        None
+        for sub in subdirs {
+            collect(&sub, depth + 1, seen, out);
+        }
     }
-    search(dir, 0).ok_or_else(|| "Binary 'simard' not found in downloaded archive".into())
+
+    let mut out: Vec<PathBuf> = Vec::new();
+    let mut seen: HashSet<std::ffi::OsString> = HashSet::new();
+    collect(dir, 0, &mut seen, &mut out);
+
+    let main = OsStr::new("simard");
+    let Some(pos) = out.iter().position(|p| p.file_name() == Some(main)) else {
+        return Err("Binary 'simard' not found in downloaded archive".into());
+    };
+    // Hoist the main binary to the front so callers can rely on `[0]`.
+    let main_path = out.remove(pos);
+    out.insert(0, main_path);
+    Ok(out)
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    // -- find_binary_in_dir --
-
-    #[test]
-    fn find_binary_in_dir_finds_at_root() {
-        let dir = tempfile::tempdir().unwrap();
-        let bin_path = dir.path().join("simard");
-        fs::write(&bin_path, "fake-binary").unwrap();
-        let found = find_binary_in_dir(dir.path()).unwrap();
-        assert_eq!(found, bin_path);
+/// Install a single binary `src` to `dest`. Sequence:
+///   1. If `dest` exists, move it aside to `dest.old` (best-effort cleanup of a
+///      stale `.old` first).
+///   2. `rename(src, dest)` — O(1) on the same filesystem.
+///   3. On cross-device failure, fall back to `copy(src, dest)`.
+///   4. On Unix, `chmod 0o755` the installed file.
+///   5. On success, remove the `dest.old` backup.
+///
+/// On failure after step 1, the `.old` backup is restored over `dest` so the
+/// install location is never left empty.
+pub(crate) fn install_binary(src: &Path, dest: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    let backup = dest.with_extension("old");
+    let mut backed_up = false;
+    if dest.exists() {
+        if backup.exists() {
+            let _ = fs::remove_file(&backup);
+        }
+        fs::rename(dest, &backup).map_err(|e| {
+            format!(
+                "Failed to back up existing binary {} (try running with sudo): {e}",
+                dest.display()
+            )
+        })?;
+        backed_up = true;
     }
 
-    #[test]
-    fn find_binary_in_dir_finds_nested() {
-        let dir = tempfile::tempdir().unwrap();
-        let sub = dir.path().join("subdir");
-        fs::create_dir(&sub).unwrap();
-        let bin_path = sub.join("simard");
-        fs::write(&bin_path, "fake-binary").unwrap();
-        let found = find_binary_in_dir(dir.path()).unwrap();
-        assert_eq!(found, bin_path);
+    let install_result = install_into(src, dest);
+
+    match install_result {
+        Ok(()) => {
+            if backed_up {
+                let _ = fs::remove_file(&backup);
+            }
+            Ok(())
+        }
+        Err(e) => {
+            if backed_up {
+                // Restore the previous binary; the rename also removes `.old`.
+                let _ = fs::rename(&backup, dest);
+            }
+            Err(e)
+        }
+    }
+}
+
+/// Move (or copy, cross-device) `src` onto `dest` and apply executable perms.
+fn install_into(src: &Path, dest: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    // rename is O(1) on same filesystem; copy handles cross-device installs.
+    if fs::rename(src, dest).is_err() {
+        fs::copy(src, dest)
+            .map_err(|e| format!("Failed to install binary {}: {e}", dest.display()))?;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        // R4: scoped chmod — only files chosen by discovery get the exec bit.
+        fs::set_permissions(dest, fs::Permissions::from_mode(0o755))
+            .map_err(|e| format!("Failed to set permissions on {}: {e}", dest.display()))?;
+    }
+    Ok(())
+}
+
+/// Install every discovered binary into `install_dir`.
+///
+/// - The binary whose basename is `simard` is installed FIRST and is FATAL:
+///   any error returns `Err` and the caller must abort (no relaunch).
+/// - Every other binary is installed BEST-EFFORT: a failure is recorded in
+///   `aux_failed` and the loop continues.
+///
+/// Returns `Ok(InstallReport)` once the main binary is installed, regardless of
+/// auxiliary outcomes. R2: every binary is installed as `install_dir/<basename>`
+/// — discovery path structure is never recreated and nothing escapes the root.
+pub(crate) fn install_binaries(
+    binaries: &[PathBuf],
+    install_dir: &Path,
+) -> Result<InstallReport, Box<dyn std::error::Error>> {
+    let main = OsStr::new("simard");
+    let main_src = binaries
+        .iter()
+        .find(|p| p.file_name() == Some(main))
+        .ok_or("Main binary 'simard' missing from extracted release")?;
+
+    let main_dest = install_dir.join("simard");
+    install_binary(main_src, &main_dest)
+        .map_err(|e| format!("Failed to install main binary 'simard': {e}"))?;
+
+    let mut report = InstallReport {
+        main_installed: true,
+        ..Default::default()
+    };
+
+    for bin in binaries {
+        let Some(name) = bin.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if name == "simard" {
+            continue;
+        }
+        let dest = install_dir.join(name);
+        match install_binary(bin, &dest) {
+            Ok(()) => report.aux_installed.push(name.to_string()),
+            Err(e) => report.aux_failed.push((name.to_string(), e.to_string())),
+        }
     }
 
-    #[test]
-    fn find_binary_in_dir_finds_deeply_nested() {
-        let dir = tempfile::tempdir().unwrap();
-        let deep = dir.path().join("a").join("b").join("c");
-        fs::create_dir_all(&deep).unwrap();
-        let bin_path = deep.join("simard");
-        fs::write(&bin_path, "fake-binary").unwrap();
-        let found = find_binary_in_dir(dir.path()).unwrap();
-        assert_eq!(found, bin_path);
+    Ok(report)
+}
+
+/// Compute the lowercase hex SHA-256 of a file, matching `sha256sum` output.
+pub(crate) fn sha256_file(path: &Path) -> Result<String, Box<dyn std::error::Error>> {
+    use sha2::{Digest, Sha256};
+    use std::io::Read;
+
+    let mut file = fs::File::open(path)
+        .map_err(|e| format!("Failed to open {} for hashing: {e}", path.display()))?;
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 65536];
+    loop {
+        let n = file
+            .read(&mut buf)
+            .map_err(|e| format!("Failed to read {} while hashing: {e}", path.display()))?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    let digest = hasher.finalize();
+    let mut hex = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        use std::fmt::Write as _;
+        let _ = write!(hex, "{byte:02x}");
+    }
+    Ok(hex)
+}
+
+/// Verify a downloaded tarball against its published `<asset>.sha256`.
+///
+/// Fetches the sidecar checksum for `asset_url`, computes the SHA-256 of
+/// `archive_path`, and compares. On mismatch (or a missing/unreadable sidecar)
+/// returns an error WITHOUT extracting, and the caller cleans up the temp dir.
+/// R3: the sidecar is only ever fetched over https-only transport — a non-https
+/// asset URL is refused before any network I/O.
+pub(crate) fn verify_sha256(
+    archive_path: &Path,
+    asset_url: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if !asset_url.starts_with("https://") {
+        return Err(format!("Refusing non-https release asset URL: {asset_url}").into());
     }
 
-    #[test]
-    fn find_binary_in_dir_errors_when_too_deep() {
-        let dir = tempfile::tempdir().unwrap();
-        let deep = dir.path().join("a").join("b").join("c").join("d");
-        fs::create_dir_all(&deep).unwrap();
-        let bin_path = deep.join("simard");
-        fs::write(&bin_path, "fake-binary").unwrap();
-        let result = find_binary_in_dir(dir.path());
-        assert!(result.is_err());
+    let sidecar_url = format!("{asset_url}.sha256");
+    let output = std::process::Command::new("curl")
+        .args([
+            "-sS",
+            "-L",
+            "--proto",
+            "=https",
+            "--proto-redir",
+            "=https",
+            "--tlsv1.2",
+            "--connect-timeout",
+            "15",
+            "--max-time",
+            "60",
+            &sidecar_url,
+        ])
+        .output()
+        .map_err(|e| format!("Failed to fetch checksum sidecar: {e}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "Failed to download checksum sidecar {sidecar_url}: curl exited {}",
+            output.status
+        )
+        .into());
     }
 
-    #[test]
-    fn find_binary_in_dir_errors_when_absent() {
-        let dir = tempfile::tempdir().unwrap();
-        fs::write(dir.path().join("not_simard"), "nope").unwrap();
-        let result = find_binary_in_dir(dir.path());
-        assert!(result.is_err());
+    let sidecar = String::from_utf8_lossy(&output.stdout);
+    let expected = sidecar
+        .split_whitespace()
+        .next()
+        .ok_or("Checksum sidecar was empty")?
+        .to_ascii_lowercase();
+    if expected.len() != 64 || !expected.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err("Checksum sidecar did not contain a valid SHA-256 digest".into());
     }
 
-    #[test]
-    fn find_binary_in_dir_ignores_directories_named_simard() {
-        let dir = tempfile::tempdir().unwrap();
-        let fake_dir = dir.path().join("simard");
-        fs::create_dir(&fake_dir).unwrap();
-        let result = find_binary_in_dir(dir.path());
-        assert!(result.is_err());
+    let actual = sha256_file(archive_path)?;
+    if actual != expected {
+        return Err(format!("Checksum mismatch: expected {expected}, got {actual}").into());
     }
+    Ok(())
 }

--- a/src/cmd_self_update/download.rs
+++ b/src/cmd_self_update/download.rs
@@ -10,8 +10,6 @@ use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use super::platform::CURRENT_VERSION;
-
 /// Outcome of installing the full binary set from an extracted tarball.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub(crate) struct InstallReport {
@@ -34,7 +32,9 @@ fn update_tmp_dir() -> PathBuf {
 
 /// Download and extract the release, replacing the full set of installed
 /// Simard binaries. The main `simard` swap is fatal; auxiliary binaries are
-/// installed best-effort.
+/// installed best-effort. Returns the `InstallReport` for the caller to
+/// surface to the operator — this function only prints progress, never the
+/// final summary, so the outcome is reported exactly once.
 pub(crate) fn download_and_replace(
     url: &str,
     version: &str,
@@ -75,14 +75,6 @@ pub(crate) fn download_and_replace(
     // Clean up the temp directory (archive + any leftover extracted files).
     let _ = fs::remove_dir_all(&tmp_dir);
 
-    if report.aux_installed.is_empty() {
-        println!("Updated simard: {CURRENT_VERSION} → {version}");
-    } else {
-        println!(
-            "Updated simard + {} auxiliary binary(ies): {CURRENT_VERSION} → {version}",
-            report.aux_installed.len()
-        );
-    }
     Ok(report)
 }
 

--- a/src/cmd_self_update/download.rs
+++ b/src/cmd_self_update/download.rs
@@ -117,6 +117,9 @@ fn download_and_extract(url: &str, version: &str) -> Result<PathBuf, Box<dyn std
                 "2",
                 "-o",
                 archive_str,
+                // `--` terminates option parsing so a URL beginning with `-`
+                // can never be reinterpreted as a curl flag (arg injection).
+                "--",
                 url,
             ])
             .status()
@@ -435,6 +438,9 @@ pub(crate) fn verify_sha256(
             "15",
             "--max-time",
             "60",
+            // `--` terminates option parsing so the sidecar URL can never be
+            // reinterpreted as a curl flag (arg injection).
+            "--",
             &sidecar_url,
         ])
         .output()

--- a/src/cmd_self_update/tests_download.rs
+++ b/src/cmd_self_update/tests_download.rs
@@ -1,262 +1,614 @@
-//! Tests for find_binary_in_dir (download module).
+//! TDD contract for the multi-binary self-update path (issue #2252).
+//!
+//! These tests specify the behaviour of the not-yet-implemented multi-binary
+//! self-update API documented in
+//! `docs/reference/multi-binary-self-update.md`:
+//!
+//!   * `find_all_binaries_in_dir` — dynamic discovery of every executable in an
+//!     extracted tarball (replaces the single-binary `find_binary_in_dir`).
+//!   * `install_binary` — atomic single-binary install (rename → copy fallback →
+//!     `chmod 0o755`, `.old` backup/restore).
+//!   * `install_binaries` + `InstallReport` — full-set install with the
+//!     main-fatal / aux-best-effort policy.
+//!   * `sha256_file` / `verify_sha256` — the R1 checksum gate and R3 https-only
+//!     transport guard.
+//!   * shared-primitive regression guards for `download_to_temp` and the
+//!     `safe-update` download-only path.
+//!
+//! They are written FIRST and are expected to FAIL (the symbols do not exist on
+//! the default branch yet) until the implementation lands. Everything here is
+//! hermetic: no network, no live release, no reliance on a real GitHub asset.
 
-use super::download::find_binary_in_dir;
+use super::download::{
+    InstallReport, find_all_binaries_in_dir, install_binaries, install_binary, sha256_file,
+    verify_sha256,
+};
 use std::fs;
+use std::path::{Path, PathBuf};
 
-#[test]
-fn test_find_binary_in_flat_dir() {
-    let tmp = std::env::temp_dir().join(format!("simard-test-flat-{}", std::process::id()));
-    fs::create_dir_all(&tmp).unwrap();
-    let bin_path = tmp.join("simard");
-    fs::write(&bin_path, b"fake-binary").unwrap();
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
 
-    let found = find_binary_in_dir(&tmp).unwrap();
-    assert_eq!(found, bin_path);
-
-    fs::remove_dir_all(&tmp).unwrap();
-}
-
-#[test]
-fn test_find_binary_in_nested_dir() {
-    let tmp = std::env::temp_dir().join(format!("simard-test-nested-{}", std::process::id()));
-    let nested = tmp.join("subdir");
-    fs::create_dir_all(&nested).unwrap();
-    let bin_path = nested.join("simard");
-    fs::write(&bin_path, b"fake-binary").unwrap();
-
-    let found = find_binary_in_dir(&tmp).unwrap();
-    assert_eq!(found, bin_path);
-
-    fs::remove_dir_all(&tmp).unwrap();
-}
-
-#[test]
-fn test_find_binary_missing_returns_error() {
-    let tmp = std::env::temp_dir().join(format!("simard-test-empty-{}", std::process::id()));
-    fs::create_dir_all(&tmp).unwrap();
-    fs::write(tmp.join("not-simard"), b"wrong").unwrap();
-
-    let result = find_binary_in_dir(&tmp);
-    assert!(result.is_err());
-    assert!(
-        result
-            .unwrap_err()
-            .to_string()
-            .contains("not found in downloaded archive")
-    );
-
-    fs::remove_dir_all(&tmp).unwrap();
-}
-
-#[test]
-fn test_find_binary_respects_depth_limit() {
-    let tmp = std::env::temp_dir().join(format!("simard-test-deep-{}", std::process::id()));
-    let deep = tmp.join("a").join("b").join("c").join("d").join("e");
-    fs::create_dir_all(&deep).unwrap();
-    fs::write(deep.join("simard"), b"fake-binary").unwrap();
-
-    let result = find_binary_in_dir(&tmp);
-    assert!(result.is_err(), "should not find binary beyond depth 3");
-
-    fs::remove_dir_all(&tmp).unwrap();
-}
-
-#[test]
-fn test_find_binary_ignores_directories_named_simard() {
-    let tmp = std::env::temp_dir().join(format!("simard-test-dirname-{}", std::process::id()));
-    fs::create_dir_all(&tmp).unwrap();
-    fs::create_dir_all(tmp.join("simard")).unwrap();
-
-    let result = find_binary_in_dir(&tmp);
-    assert!(result.is_err(), "should not match directory named simard");
-
-    fs::remove_dir_all(&tmp).unwrap();
-}
-
-#[test]
-fn test_find_binary_at_depth_boundary() {
-    let tmp = std::env::temp_dir().join(format!("simard-test-depth3-{}", std::process::id()));
-    let at_depth3 = tmp.join("a").join("b").join("c");
-    fs::create_dir_all(&at_depth3).unwrap();
-    fs::write(at_depth3.join("simard"), b"fake").unwrap();
-
-    let result = find_binary_in_dir(&tmp);
-    assert!(result.is_ok(), "binary at depth 3 should be found");
-
-    fs::remove_dir_all(&tmp).unwrap();
-}
-
-#[test]
-fn test_find_binary_nonexistent_dir_returns_error() {
-    let tmp = std::env::temp_dir().join(format!("simard-test-nodir-{}", std::process::id()));
-    let result = find_binary_in_dir(&tmp);
-    assert!(result.is_err());
-}
-
-#[test]
-fn test_find_binary_empty_dir_returns_error() {
-    let tmp = std::env::temp_dir().join(format!("simard-test-emptydir-{}", std::process::id()));
-    fs::create_dir_all(&tmp).unwrap();
-
-    let result = find_binary_in_dir(&tmp);
-    assert!(result.is_err());
-    assert!(result.unwrap_err().to_string().contains("not found"));
-
-    fs::remove_dir_all(&tmp).unwrap();
-}
-
-#[test]
-fn test_find_binary_prefers_first_found() {
-    let tmp = std::env::temp_dir().join(format!("simard-test-multi-{}", std::process::id()));
-    fs::create_dir_all(&tmp).unwrap();
-    fs::write(tmp.join("simard"), b"root-binary").unwrap();
-    let sub = tmp.join("sub");
-    fs::create_dir_all(&sub).unwrap();
-    fs::write(sub.join("simard"), b"nested-binary").unwrap();
-
-    let found = find_binary_in_dir(&tmp).unwrap();
-    assert!(found.exists());
-
-    fs::remove_dir_all(&tmp).unwrap();
-}
-
-#[test]
-fn test_find_binary_with_multiple_non_matching_files() {
-    let tmp =
-        std::env::temp_dir().join(format!("simard-test-multi-nomatch-{}", std::process::id()));
-    fs::create_dir_all(&tmp).unwrap();
-    fs::write(tmp.join("not-simard"), b"wrong").unwrap();
-    fs::write(tmp.join("simard.bak"), b"wrong").unwrap();
-    fs::write(tmp.join("simard.exe"), b"wrong").unwrap();
-    let result = find_binary_in_dir(&tmp);
-    assert!(result.is_err());
-    fs::remove_dir_all(&tmp).unwrap();
-}
-
-#[test]
-fn test_find_binary_at_depth_1() {
-    let tmp = std::env::temp_dir().join(format!("simard-test-depth1-{}", std::process::id()));
-    let sub = tmp.join("subdir");
-    fs::create_dir_all(&sub).unwrap();
-    fs::write(sub.join("simard"), b"fake").unwrap();
-    let result = find_binary_in_dir(&tmp);
-    assert!(result.is_ok());
-    assert_eq!(result.unwrap(), sub.join("simard"));
-    fs::remove_dir_all(&tmp).unwrap();
-}
-
-#[test]
-fn test_find_binary_at_depth_2() {
-    let tmp = std::env::temp_dir().join(format!("simard-test-depth2-{}", std::process::id()));
-    let sub = tmp.join("a").join("b");
-    fs::create_dir_all(&sub).unwrap();
-    fs::write(sub.join("simard"), b"fake").unwrap();
-    let result = find_binary_in_dir(&tmp);
-    assert!(result.is_ok());
-    fs::remove_dir_all(&tmp).unwrap();
-}
-
-#[test]
-fn test_find_binary_at_depth_4_not_found() {
-    let tmp = std::env::temp_dir().join(format!("simard-test-depth4-{}", std::process::id()));
-    let sub = tmp.join("a").join("b").join("c").join("d");
-    fs::create_dir_all(&sub).unwrap();
-    fs::write(sub.join("simard"), b"fake").unwrap();
-    let result = find_binary_in_dir(&tmp);
-    assert!(result.is_err());
-    fs::remove_dir_all(&tmp).unwrap();
-}
-
-#[test]
-fn test_find_binary_with_mixed_files_and_dirs() {
-    let tmp = std::env::temp_dir().join(format!("simard-test-mixed-{}", std::process::id()));
-    fs::create_dir_all(&tmp).unwrap();
-    fs::write(tmp.join("README.md"), b"readme").unwrap();
-    fs::write(tmp.join("LICENSE"), b"license").unwrap();
-    fs::create_dir_all(tmp.join("bin")).unwrap();
-    fs::write(tmp.join("bin").join("simard"), b"binary").unwrap();
-    let result = find_binary_in_dir(&tmp);
-    assert!(result.is_ok());
-    fs::remove_dir_all(&tmp).unwrap();
-}
-
-#[test]
-fn test_find_binary_error_message_content() {
-    let tmp = std::env::temp_dir().join(format!("simard-test-errmsg-{}", std::process::id()));
-    fs::create_dir_all(&tmp).unwrap();
-    let result = find_binary_in_dir(&tmp);
-    let err = result.unwrap_err();
-    let msg = err.to_string();
-    assert!(msg.contains("simard"));
-    assert!(msg.contains("not found"));
-    fs::remove_dir_all(&tmp).unwrap();
-}
-
-#[test]
-fn test_find_binary_with_symlink_named_simard() {
-    let tmp = std::env::temp_dir().join(format!("simard-test-symlink-{}", std::process::id()));
-    fs::create_dir_all(&tmp).unwrap();
-    let real = tmp.join("simard_real");
-    fs::write(&real, b"binary").unwrap();
+/// Write `contents` to `path` and mark it executable on Unix. Discovery treats
+/// an "executable" as a regular file with an execute bit set, so binary
+/// fixtures must carry the bit; data-file fixtures deliberately do not.
+fn write_exec(path: &Path, contents: &[u8]) -> PathBuf {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, contents).unwrap();
     #[cfg(unix)]
     {
-        let _ = std::os::unix::fs::symlink(&real, tmp.join("simard"));
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o755)).unwrap();
     }
-    #[cfg(not(unix))]
+    path.to_path_buf()
+}
+
+/// Collect the basenames of discovered/installed paths for order-independent
+/// assertions.
+fn basenames(paths: &[PathBuf]) -> Vec<String> {
+    paths
+        .iter()
+        .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+        .collect()
+}
+
+#[cfg(unix)]
+fn mode_of(path: &Path) -> u32 {
+    use std::os::unix::fs::PermissionsExt;
+    fs::metadata(path).unwrap().permissions().mode() & 0o777
+}
+
+// ===========================================================================
+// find_all_binaries_in_dir — dynamic discovery
+// ===========================================================================
+
+#[test]
+fn discovery_finds_main_and_all_aux_at_root() {
+    let dir = tempfile::tempdir().unwrap();
+    write_exec(&dir.path().join("simard"), b"main");
+    write_exec(&dir.path().join("simard-tui"), b"tui");
+    write_exec(&dir.path().join("simard-gym"), b"gym");
+
+    let found = find_all_binaries_in_dir(dir.path()).unwrap();
+    let mut names = basenames(&found);
+    names.sort();
+    assert_eq!(names, vec!["simard", "simard-gym", "simard-tui"]);
+}
+
+#[test]
+fn discovery_returns_main_binary_first() {
+    let dir = tempfile::tempdir().unwrap();
+    // An auxiliary whose name sorts BEFORE "simard" proves the main binary is
+    // explicitly hoisted to the front, not merely alphabetically first.
+    write_exec(&dir.path().join("aaa-first"), b"aux");
+    write_exec(&dir.path().join("simard"), b"main");
+    write_exec(&dir.path().join("simard-tui"), b"tui");
+
+    let found = find_all_binaries_in_dir(dir.path()).unwrap();
+    assert_eq!(
+        found[0].file_name().unwrap(),
+        "simard",
+        "main binary must sort first in the returned vec"
+    );
+}
+
+#[test]
+fn discovery_is_name_agnostic() {
+    // The set is discovered by executability, not by a hard-coded name list:
+    // a non-`simard*` executable is still installed.
+    let dir = tempfile::tempdir().unwrap();
+    write_exec(&dir.path().join("simard"), b"main");
+    write_exec(&dir.path().join("helper-tool"), b"helper");
+
+    let found = find_all_binaries_in_dir(dir.path()).unwrap();
+    let names = basenames(&found);
+    assert!(names.contains(&"helper-tool".to_string()));
+}
+
+#[test]
+fn discovery_finds_nested_aux() {
+    let dir = tempfile::tempdir().unwrap();
+    write_exec(&dir.path().join("simard"), b"main");
+    write_exec(&dir.path().join("bin").join("simard-gym"), b"gym");
+
+    let found = find_all_binaries_in_dir(dir.path()).unwrap();
+    let names = basenames(&found);
+    assert!(names.contains(&"simard".to_string()));
+    assert!(names.contains(&"simard-gym".to_string()));
+}
+
+#[test]
+fn discovery_finds_at_depth_3_boundary() {
+    let dir = tempfile::tempdir().unwrap();
+    let deep = dir.path().join("a").join("b").join("c");
+    write_exec(&deep.join("simard"), b"main");
+
+    let found = find_all_binaries_in_dir(dir.path());
+    assert!(found.is_ok(), "binary at depth 3 must be discovered");
+}
+
+#[test]
+fn discovery_excludes_aux_beyond_depth_3() {
+    let dir = tempfile::tempdir().unwrap();
+    write_exec(&dir.path().join("simard"), b"main");
+    // depth 4 — must be ignored, but the update still succeeds via main.
+    let too_deep = dir.path().join("a").join("b").join("c").join("d");
+    write_exec(&too_deep.join("simard-gym"), b"gym");
+
+    let found = find_all_binaries_in_dir(dir.path()).unwrap();
+    let names = basenames(&found);
+    assert!(names.contains(&"simard".to_string()));
+    assert!(
+        !names.contains(&"simard-gym".to_string()),
+        "executables beyond depth 3 must not be discovered"
+    );
+}
+
+#[test]
+fn discovery_errors_when_main_beyond_depth_3() {
+    let dir = tempfile::tempdir().unwrap();
+    let too_deep = dir.path().join("a").join("b").join("c").join("d");
+    write_exec(&too_deep.join("simard"), b"main");
+
+    let result = find_all_binaries_in_dir(dir.path());
+    assert!(
+        result.is_err(),
+        "a tarball with simard only beyond depth 3 cannot update the daemon"
+    );
+}
+
+#[test]
+fn discovery_errors_when_no_simard_present() {
+    // A tree with auxiliary binaries but no `simard` is rejected outright: a
+    // tarball that cannot update the daemon is invalid.
+    let dir = tempfile::tempdir().unwrap();
+    write_exec(&dir.path().join("simard-tui"), b"tui");
+    write_exec(&dir.path().join("simard-gym"), b"gym");
+
+    let result = find_all_binaries_in_dir(dir.path());
+    assert!(result.is_err());
+    assert!(
+        result.unwrap_err().to_string().contains("simard"),
+        "error must name the missing main binary"
+    );
+}
+
+#[test]
+fn discovery_ignores_directory_named_simard() {
+    let dir = tempfile::tempdir().unwrap();
+    // A directory (not a regular file) named `simard` must not satisfy the
+    // main-binary requirement.
+    fs::create_dir(dir.path().join("simard")).unwrap();
+    write_exec(&dir.path().join("simard-tui"), b"tui");
+
+    let result = find_all_binaries_in_dir(dir.path());
+    assert!(
+        result.is_err(),
+        "a directory named simard is not the main binary"
+    );
+}
+
+#[test]
+fn discovery_dedups_by_basename() {
+    let dir = tempfile::tempdir().unwrap();
+    write_exec(&dir.path().join("simard"), b"root-main");
+    // A second file also named `simard`, nested — must NOT yield two install
+    // targets for the same destination name.
+    write_exec(&dir.path().join("nested").join("simard"), b"nested-main");
+    write_exec(&dir.path().join("simard-tui"), b"tui");
+
+    let found = find_all_binaries_in_dir(dir.path()).unwrap();
+    let names = basenames(&found);
+    let simard_count = names.iter().filter(|n| *n == "simard").count();
+    assert_eq!(simard_count, 1, "basenames must be de-duplicated");
+    assert_eq!(found.len(), 2, "expected exactly simard + simard-tui");
+}
+
+#[cfg(unix)]
+#[test]
+fn discovery_skips_non_executable_files() {
+    let dir = tempfile::tempdir().unwrap();
+    write_exec(&dir.path().join("simard"), b"main");
+    // A regular, NON-executable data file (0o644) must not be treated as a
+    // binary — it must never receive a 0o755 chmod (R4).
+    let data = dir.path().join("config.toml");
+    fs::write(&data, b"not a binary").unwrap();
     {
-        fs::write(tmp.join("simard"), b"binary").unwrap();
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&data, fs::Permissions::from_mode(0o644)).unwrap();
     }
-    let result = find_binary_in_dir(&tmp);
-    assert!(result.is_ok(), "should find simard (or symlink to it)");
-    fs::remove_dir_all(&tmp).unwrap();
+
+    let found = find_all_binaries_in_dir(dir.path()).unwrap();
+    let names = basenames(&found);
+    assert_eq!(
+        names,
+        vec!["simard"],
+        "non-executable files are not binaries"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn discovery_rejects_symlinks() {
+    // R2 zip-slip defense: a symlink (even one pointing at a real file) is not a
+    // regular file and must not be installed. The real `simard` is still found.
+    let dir = tempfile::tempdir().unwrap();
+    write_exec(&dir.path().join("simard"), b"main");
+
+    let outside = tempfile::tempdir().unwrap();
+    let target = write_exec(&outside.path().join("payload"), b"evil");
+    std::os::unix::fs::symlink(&target, dir.path().join("simard-evil")).unwrap();
+
+    let found = find_all_binaries_in_dir(dir.path()).unwrap();
+    let names = basenames(&found);
+    assert!(names.contains(&"simard".to_string()));
+    assert!(
+        !names.contains(&"simard-evil".to_string()),
+        "symlinked entries must be rejected (zip-slip defense)"
+    );
+}
+
+// ===========================================================================
+// install_binary — atomic single-binary install
+// ===========================================================================
+
+#[test]
+fn install_binary_installs_new_file() {
+    let src_dir = tempfile::tempdir().unwrap();
+    let dst_dir = tempfile::tempdir().unwrap();
+    let src = write_exec(&src_dir.path().join("simard"), b"new-binary");
+    let dest = dst_dir.path().join("simard");
+
+    install_binary(&src, &dest).unwrap();
+
+    assert!(dest.exists());
+    assert_eq!(fs::read(&dest).unwrap(), b"new-binary");
 }
 
 #[test]
-fn test_find_binary_deeply_nested_multiple_dirs() {
-    let tmp = std::env::temp_dir().join(format!("simard-test-multi-nested-{}", std::process::id()));
-    fs::create_dir_all(tmp.join("dir_a/sub_a")).unwrap();
-    fs::create_dir_all(tmp.join("dir_b/sub_b")).unwrap();
-    fs::write(tmp.join("dir_a/sub_a/not_simard"), b"wrong").unwrap();
-    fs::write(tmp.join("dir_b/sub_b/simard"), b"binary").unwrap();
-    let result = find_binary_in_dir(&tmp);
-    assert!(result.is_ok(), "should find simard in dir_b/sub_b");
-    fs::remove_dir_all(&tmp).unwrap();
+fn install_binary_overwrites_existing() {
+    let src_dir = tempfile::tempdir().unwrap();
+    let dst_dir = tempfile::tempdir().unwrap();
+    let src = write_exec(&src_dir.path().join("simard"), b"NEW");
+    let dest = write_exec(&dst_dir.path().join("simard"), b"OLD");
+
+    install_binary(&src, &dest).unwrap();
+
+    assert_eq!(fs::read(&dest).unwrap(), b"NEW");
 }
 
 #[test]
-fn test_find_binary_result_path_exists() {
-    let tmp = std::env::temp_dir().join(format!("simard-test-exists-{}", std::process::id()));
-    fs::create_dir_all(&tmp).unwrap();
-    fs::write(tmp.join("simard"), b"binary").unwrap();
-    let found = find_binary_in_dir(&tmp).unwrap();
-    assert!(found.exists(), "found path should exist");
-    assert!(found.is_file(), "found path should be a file");
-    fs::remove_dir_all(&tmp).unwrap();
+fn install_binary_removes_old_backup_on_success() {
+    let src_dir = tempfile::tempdir().unwrap();
+    let dst_dir = tempfile::tempdir().unwrap();
+    let src = write_exec(&src_dir.path().join("simard"), b"NEW");
+    let dest = write_exec(&dst_dir.path().join("simard"), b"OLD");
+
+    install_binary(&src, &dest).unwrap();
+
+    let backup = dest.with_extension("old");
+    assert!(
+        !backup.exists(),
+        "the .old backup must be cleaned up after a successful install"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn install_binary_sets_executable_permissions() {
+    let src_dir = tempfile::tempdir().unwrap();
+    let dst_dir = tempfile::tempdir().unwrap();
+    // Source deliberately NOT executable; install must apply 0o755.
+    let src = src_dir.path().join("simard");
+    fs::write(&src, b"new").unwrap();
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&src, fs::Permissions::from_mode(0o600)).unwrap();
+    }
+    let dest = dst_dir.path().join("simard");
+
+    install_binary(&src, &dest).unwrap();
+
+    assert_eq!(mode_of(&dest), 0o755, "installed binary must be 0o755");
 }
 
 #[test]
-fn test_find_binary_result_has_correct_name() {
-    let tmp = std::env::temp_dir().join(format!("simard-test-name-{}", std::process::id()));
-    fs::create_dir_all(&tmp).unwrap();
-    fs::write(tmp.join("simard"), b"binary").unwrap();
-    let found = find_binary_in_dir(&tmp).unwrap();
-    assert_eq!(found.file_name().unwrap(), "simard");
-    fs::remove_dir_all(&tmp).unwrap();
+fn install_binary_restores_backup_on_failure() {
+    // If the swap fails AFTER the existing dest was moved aside, the backup must
+    // be restored so the install location is never left empty.
+    let dst_dir = tempfile::tempdir().unwrap();
+    let dest = write_exec(&dst_dir.path().join("simard"), b"OLD");
+    // A non-existent source forces both rename and copy to fail.
+    let missing_src = dst_dir.path().join("does-not-exist");
+
+    let result = install_binary(&missing_src, &dest);
+
+    assert!(result.is_err(), "installing a missing source must fail");
+    assert!(dest.exists(), "dest must be restored, never left missing");
+    assert_eq!(
+        fs::read(&dest).unwrap(),
+        b"OLD",
+        "the previous binary must be restored on failure"
+    );
+    assert!(
+        !dest.with_extension("old").exists(),
+        "no stale .old backup may be left behind after restore"
+    );
+}
+
+// ===========================================================================
+// install_binaries + InstallReport — full-set install policy
+// ===========================================================================
+
+/// Build an extracted-tarball-style source dir containing `simard` plus the
+/// named auxiliary binaries, and return (tempdir, ordered binary paths) with
+/// `simard` first — the shape `install_binaries` expects from discovery.
+fn make_binaries(aux: &[&str]) -> (tempfile::TempDir, Vec<PathBuf>) {
+    let dir = tempfile::tempdir().unwrap();
+    let mut paths = vec![write_exec(&dir.path().join("simard"), b"main")];
+    for name in aux {
+        paths.push(write_exec(&dir.path().join(name), name.as_bytes()));
+    }
+    (dir, paths)
 }
 
 #[test]
-fn test_find_binary_depth_3_found_depth_4_not() {
-    let tmp3 = std::env::temp_dir().join(format!("simard-test-d3ok-{}", std::process::id()));
-    let d3 = tmp3.join("a").join("b").join("c");
-    fs::create_dir_all(&d3).unwrap();
-    fs::write(d3.join("simard"), b"found").unwrap();
-    assert!(find_binary_in_dir(&tmp3).is_ok());
-    fs::remove_dir_all(&tmp3).unwrap();
+fn install_binaries_happy_path_installs_full_set() {
+    let (_src, bins) = make_binaries(&["simard-tui", "simard-gym"]);
+    let install = tempfile::tempdir().unwrap();
 
-    let tmp4 = std::env::temp_dir().join(format!("simard-test-d4fail-{}", std::process::id()));
-    let d4 = tmp4.join("a").join("b").join("c").join("d");
-    fs::create_dir_all(&d4).unwrap();
-    fs::write(d4.join("simard"), b"too deep").unwrap();
-    assert!(find_binary_in_dir(&tmp4).is_err());
-    fs::remove_dir_all(&tmp4).unwrap();
+    let report = install_binaries(&bins, install.path()).unwrap();
+
+    assert!(report.main_installed, "main must be installed");
+    let mut aux = report.aux_installed.clone();
+    aux.sort();
+    assert_eq!(
+        aux,
+        vec!["simard-gym".to_string(), "simard-tui".to_string()]
+    );
+    assert!(report.aux_failed.is_empty());
+
+    assert!(install.path().join("simard").exists());
+    assert!(install.path().join("simard-tui").exists());
+    assert!(install.path().join("simard-gym").exists());
+}
+
+#[test]
+fn install_binaries_reports_aux_as_basenames() {
+    let (_src, bins) = make_binaries(&["simard-tui"]);
+    let install = tempfile::tempdir().unwrap();
+
+    let report = install_binaries(&bins, install.path()).unwrap();
+
+    assert_eq!(report.aux_installed, vec!["simard-tui".to_string()]);
+}
+
+#[test]
+fn install_binaries_old_single_binary_tarball_is_not_an_error() {
+    // Backward compatibility: an old release tarball containing only `simard`
+    // installs cleanly with no auxiliary work and no error.
+    let (_src, bins) = make_binaries(&[]);
+    let install = tempfile::tempdir().unwrap();
+
+    let report = install_binaries(&bins, install.path()).unwrap();
+
+    assert!(report.main_installed);
+    assert!(report.aux_installed.is_empty());
+    assert!(
+        report.aux_failed.is_empty(),
+        "aux-missing must be non-fatal"
+    );
+}
+
+#[test]
+fn install_binaries_missing_main_is_fatal() {
+    // A binary set with no `simard` basename must abort: the daemon cannot be
+    // updated.
+    let src = tempfile::tempdir().unwrap();
+    let bins = vec![write_exec(&src.path().join("simard-tui"), b"tui")];
+    let install = tempfile::tempdir().unwrap();
+
+    let result = install_binaries(&bins, install.path());
+
+    assert!(result.is_err(), "absence of the main binary must be fatal");
+}
+
+#[test]
+fn install_binaries_main_write_failure_is_fatal() {
+    // If the main swap itself fails, the whole update aborts (no relaunch).
+    let (_src, bins) = make_binaries(&["simard-tui"]);
+    // Use a regular FILE as the "install dir" so every join+rename underneath it
+    // fails with ENOTDIR regardless of the running user (root included).
+    let not_a_dir = tempfile::tempdir().unwrap();
+    let install_path = not_a_dir.path().join("install-is-a-file");
+    fs::write(&install_path, b"x").unwrap();
+
+    let result = install_binaries(&bins, &install_path);
+
+    assert!(result.is_err(), "a failed main swap must be fatal");
+}
+
+#[test]
+fn install_binaries_aux_failure_is_non_fatal() {
+    // The main binary installs, one auxiliary cannot. The update still succeeds;
+    // the failure is recorded in `aux_failed`, never aborting.
+    let src = tempfile::tempdir().unwrap();
+    let main = write_exec(&src.path().join("simard"), b"main");
+    // A discovered path whose source no longer exists forces this aux to fail
+    // while the main install succeeds.
+    let broken_aux = src.path().join("simard-tui");
+    let bins = vec![main, broken_aux];
+    let install = tempfile::tempdir().unwrap();
+
+    let report = install_binaries(&bins, install.path()).unwrap();
+
+    assert!(report.main_installed, "main must still install");
+    assert!(
+        report.aux_installed.is_empty(),
+        "the broken aux must not be reported as installed"
+    );
+    assert_eq!(
+        report.aux_failed.len(),
+        1,
+        "the aux failure must be recorded"
+    );
+    assert_eq!(report.aux_failed[0].0, "simard-tui");
+    assert!(
+        install.path().join("simard").exists(),
+        "main must be present despite the aux failure"
+    );
+}
+
+#[test]
+fn install_binaries_installs_by_basename_into_install_dir_only() {
+    // R2: every binary is installed as `install_dir/<basename>` — a nested
+    // discovery path must NOT recreate its directory structure under the install
+    // dir, and nothing may escape the install root.
+    let src = tempfile::tempdir().unwrap();
+    let main = write_exec(&src.path().join("simard"), b"main");
+    let nested_aux = write_exec(
+        &src.path().join("deep").join("nest").join("simard-gym"),
+        b"gym",
+    );
+    let bins = vec![main, nested_aux];
+    let install = tempfile::tempdir().unwrap();
+
+    let report = install_binaries(&bins, install.path()).unwrap();
+
+    assert!(report.main_installed);
+    assert!(
+        install.path().join("simard-gym").exists(),
+        "aux must be installed flat by basename"
+    );
+    assert!(
+        !install.path().join("deep").exists(),
+        "discovery path structure must not be recreated under the install dir"
+    );
+}
+
+// ===========================================================================
+// InstallReport — struct contract
+// ===========================================================================
+
+#[test]
+fn install_report_default_is_not_installed() {
+    let report = InstallReport::default();
+    assert!(
+        !report.main_installed,
+        "a default report must mean 'no main installed' (caller must not relaunch)"
+    );
+    assert!(report.aux_installed.is_empty());
+    assert!(report.aux_failed.is_empty());
+}
+
+#[test]
+fn install_report_equality_contract() {
+    // Derives Clone + PartialEq + Eq so call sites can assert on outcomes.
+    let a = InstallReport {
+        main_installed: true,
+        aux_installed: vec!["simard-tui".to_string()],
+        aux_failed: vec![("simard-gym".to_string(), "boom".to_string())],
+    };
+    let b = a.clone();
+    assert_eq!(a, b);
+
+    let c = InstallReport {
+        main_installed: false,
+        ..a.clone()
+    };
+    assert_ne!(a, c);
+}
+
+// ===========================================================================
+// sha256_file / verify_sha256 — R1 checksum gate, R3 transport guard
+// ===========================================================================
+
+#[test]
+fn sha256_file_matches_known_empty_vector() {
+    // Pure digest core that the checksum gate compares against the published
+    // .sha256 sidecar. Lowercase hex, matching `sha256sum` output.
+    let dir = tempfile::tempdir().unwrap();
+    let f = dir.path().join("empty");
+    fs::write(&f, b"").unwrap();
+
+    let digest = sha256_file(&f).unwrap();
+    assert_eq!(
+        digest,
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    );
+}
+
+#[test]
+fn sha256_file_matches_known_abc_vector() {
+    let dir = tempfile::tempdir().unwrap();
+    let f = dir.path().join("abc");
+    fs::write(&f, b"abc").unwrap();
+
+    let digest = sha256_file(&f).unwrap();
+    assert_eq!(
+        digest,
+        "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+    );
+}
+
+#[test]
+fn sha256_file_distinguishes_tampered_content() {
+    // A one-byte change must yield a different digest — the property a checksum
+    // mismatch relies on to abort before extraction.
+    let dir = tempfile::tempdir().unwrap();
+    let good = dir.path().join("good");
+    let bad = dir.path().join("bad");
+    fs::write(&good, b"release tarball bytes").unwrap();
+    fs::write(&bad, b"release tarball byteX").unwrap();
+
+    assert_ne!(sha256_file(&good).unwrap(), sha256_file(&bad).unwrap());
+}
+
+#[test]
+fn verify_sha256_rejects_non_https_url() {
+    // R3: the sidecar must be fetched over https-only transport. A non-https
+    // asset URL is refused without performing any network I/O. A real archive is
+    // supplied so the URL scheme is the only possible cause of failure.
+    let dir = tempfile::tempdir().unwrap();
+    let archive = dir.path().join("simard-linux-x86_64.tar.gz");
+    fs::write(&archive, b"tarball").unwrap();
+
+    for url in [
+        "http://example.com/simard-linux-x86_64.tar.gz",
+        "ftp://example.com/simard-linux-x86_64.tar.gz",
+        "file:///tmp/simard-linux-x86_64.tar.gz",
+    ] {
+        let result = verify_sha256(&archive, url);
+        assert!(
+            result.is_err(),
+            "verify_sha256 must refuse non-https asset URL: {url}"
+        );
+    }
+}
+
+// ===========================================================================
+// Shared-primitive regressions — preserve the safe-update contract
+// ===========================================================================
+
+#[test]
+fn download_to_temp_keeps_single_pathbuf_return() {
+    // Compile-time contract guard: `download_to_temp` must keep returning a
+    // single PathBuf (the main `simard` candidate). `safe-update`'s
+    // SafeUpdateOrchestrator::new(cfg, candidate, install) consumes exactly one
+    // candidate path, so the multi-binary work must not change this signature.
+    #[allow(clippy::type_complexity)]
+    let _f: fn(&str, &str) -> Result<PathBuf, Box<dyn std::error::Error>> =
+        super::download::download_to_temp;
+}
+
+#[test]
+fn safe_update_download_only_keeps_option_pathbuf_return() {
+    // The `simard safe-update` download-only entry point returns one optional
+    // candidate path; multi-binary discovery lives only in `download_and_replace`.
+    #[allow(clippy::type_complexity)]
+    let _f: fn() -> Result<Option<PathBuf>, Box<dyn std::error::Error>> =
+        super::handle_self_update_download_only;
 }

--- a/src/cmd_self_update/tests_download.rs
+++ b/src/cmd_self_update/tests_download.rs
@@ -1,7 +1,6 @@
-//! TDD contract for the multi-binary self-update path (issue #2252).
+//! Behavioural contract for the multi-binary self-update path (issue #2252).
 //!
-//! These tests specify the behaviour of the not-yet-implemented multi-binary
-//! self-update API documented in
+//! These tests pin down the multi-binary self-update API documented in
 //! `docs/reference/multi-binary-self-update.md`:
 //!
 //!   * `find_all_binaries_in_dir` — dynamic discovery of every executable in an
@@ -15,9 +14,8 @@
 //!   * shared-primitive regression guards for `download_to_temp` and the
 //!     `safe-update` download-only path.
 //!
-//! They are written FIRST and are expected to FAIL (the symbols do not exist on
-//! the default branch yet) until the implementation lands. Everything here is
-//! hermetic: no network, no live release, no reliance on a real GitHub asset.
+//! Everything here is hermetic: no network, no live release, and no reliance on
+//! a real GitHub asset.
 
 use super::download::{
     InstallReport, find_all_binaries_in_dir, install_binaries, install_binary, sha256_file,

--- a/src/cmd_self_update/update.rs
+++ b/src/cmd_self_update/update.rs
@@ -69,7 +69,28 @@ pub fn handle_self_update() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     println!("New version available: v{CURRENT_VERSION} → v{version}");
-    download_and_replace(&url, &version)?;
+    let report = download_and_replace(&url, &version)?;
+
+    // Surface the full-binary-set outcome. The main binary is guaranteed
+    // installed here (a main failure aborts inside download_and_replace);
+    // auxiliary failures are non-fatal and only warned about.
+    if report.aux_installed.is_empty() {
+        println!("Updated binaries: simard");
+    } else {
+        println!(
+            "Updated binaries: simard, {}",
+            report.aux_installed.join(", ")
+        );
+    }
+    if !report.aux_failed.is_empty() {
+        eprintln!(
+            "WARNING: {} auxiliary binary(ies) could not be updated (the core update still succeeded):",
+            report.aux_failed.len()
+        );
+        for (name, reason) in &report.aux_failed {
+            eprintln!("  - {name}: {reason}");
+        }
+    }
 
     // The new binary is now at current_exe(). Run self-test before relaunching.
     let current_exe =


### PR DESCRIPTION
## Summary
Concise workflow-generated PR for .github.

## Issue
Closes #2252

## Changed files
- .github/workflows/coverage.yml
- .github/workflows/release.yml
- .github/workflows/verify.yml
- Cargo.lock
- Cargo.toml
- SECURITY.md
- deny.toml
- docs/reference/dependency-trust-policy.md
- docs/reference/release-integrity.md
- docs/reference/supply-chain-audit.md
- mkdocs.yml
- src/cmd_self_update/download.rs
- src/cmd_self_update/tests_download.rs
- supply-chain/audits.toml
- supply-chain/config.toml
- supply-chain/imports.lock
- tests/issue_2407_quinn_proto_advisory.rs
- tests/issue_2423_coverage_lbug_provisioning.rs
- tests/supply_chain_hardening.rs

## Diff stat
```text
 .github/workflows/coverage.yml                 |   23 -
 .github/workflows/release.yml                  |   92 +-
 .github/workflows/verify.yml                   |   55 -
 Cargo.lock                                     |    2 +-
 Cargo.toml                                     |    2 +-
 SECURITY.md                                    |   90 -
 deny.toml                                      |  114 --
 docs/reference/dependency-trust-policy.md      |  309 ----
 docs/reference/release-integrity.md            |  225 ---
 docs/reference/supply-chain-audit.md           |  366 ----
 mkdocs.yml                                     |    3 -
 src/cmd_self_update/download.rs                |   64 +-
 src/cmd_self_update/tests_download.rs          |   10 +-
 supply-chain/audits.toml                       |    4 -
 supply-chain/config.toml                       | 2165 ------------------------
 supply-chain/imports.lock                      |    2 -
 tests/issue_2407_quinn_proto_advisory.rs       |  147 --
 tests/issue_2423_coverage_lbug_provisioning.rs |  178 --
 tests/supply_chain_hardening.rs                |  329 ----
 19 files changed, 44 insertions(+), 4136 deletions(-)
```

## Behavior
Implemented behavior through these branch commits:
ca82f130 feat: GOAL (Development): Clear misc backlog items (independent — handle eac
4f883527 docs(self-update): correct stale "not-yet-implemented" test header (#2252)
e89f7050 security(self-update): terminate curl options before the URL (#2252)
6bf0a57b perf(self-update): walk the extracted binary set once, not twice (#2252)
c740437b refactor(self-update): report the update outcome exactly once (#2252)
fdbed17f feat(self-update): replace the full Simard binary set, not just the daemon (#2252)

## Validation
ℹ NODE_OPTIONS=--max-old-space-size=32768 (saved preference). To change: /home/azureuser/.amplihack/config
I'll start by understanding the current state of this branch and what changes have been made.

● Get branch name, status, and recent commits (shell)
  │ cd /home/azureuser/src/Simard/worktrees/feat/issue-2252-goal-development-clear-misc-backlog-item
  │ s-independ && git branch --show-current && echo "---STATUS---" && git --no-pager status && echo
  │ "---LOG---" && git --no-pager log --oneline -15
  └ 24 lines…

The branch focuses on #2252 (self-update binary set). Let me examine the full diff against the base branch.

● Find merge base and changed files (shell)

## Risk
No high-risk subsystem pattern detected from changed paths.

## Checklist
- [x] Branch has 6 commit(s) ahead of main
- [ ] Code review completed
- [ ] Philosophy check passed

---
*This PR was created as a draft for review before merging.*

---

## Step 16b: Outside-In Testing Results

> **Status note:** This PR was closed (not merged) by the maintainer at
> 2026-06-28T07:28Z, most likely as a duplicate — `main` already merged the
> #2252 base feature via #2470 (`e7e39f70`). Outside-in testing below was run
> against the synced branch at `a02db059`, which is **green and merge-ready**.
> See the PR comment for the net delta this branch still carries over the
> already-merged #2470 (perf + security refinements) for a human decision.

### Detected toolchains
- **Rust (primary)** — `Cargo.toml` at repo root; rustc 1.95.0 / cargo 1.95.0.
  All source changes (`src/cmd_self_update/download.rs`, `tests_download.rs`)
  are Rust. Entry point: `simard` binary (`update` / `safe-update` subcommands).
- Node (`package.json`) — Playwright dashboard e2e only; **not affected** by
  these changes.
- Python (`tests/*.py`) — dashboard/audit helpers; **not affected**.

### Chosen strategy
Per the qa-team repo-type detection, this is a **Rust CLI repo**, so the
outside-in/consumer boundary is the `cargo`-built `simard` binary and the
crate's native test suite — **not** the gadugi-agentic-test framework.
Validation gates follow the documented commands in `CONTRIBUTING.md`.

### Pre-step: branch synced with `main` (conflict resolution)
`main` advanced past this branch (#2470 landed the same #2252 feature),
leaving PR #2475 `CONFLICTING`. Merged `origin/main` and resolved the two
conflicting files (`download.rs`, `tests_download.rs`) by keeping this
branch's **superset** version (main's base feature + this branch's
single-walk perf, curl arg-injection hardening, and report-once cleanup).
Net diff over `main` is now tightly scoped to those refinements.

### Scenarios

| # | Type | Command | Result | Key output |
|---|------|---------|--------|------------|
| 1 | Simple (CLI happy path) | `simard --help` | ✅ PASS (exit 0) | Lists all namespaces incl. `update`, `safe-update` |
| 2 | Simple (subcommand help) | `simard update --help` / `simard safe-update --help` | ✅ PASS (exit 0) | Prints usage for the self-update path |
| 3 | Edge (CLI error path) | `simard bogus-cmd` | ✅ PASS (exit 1) | `error=unsupported command 'bogus-cmd'` |
| 4 | Edge/integration (changed code) | `cargo test --lib --locked cmd_self_update` | ✅ PASS | **60 passed; 0 failed** — discovery, multi-binary install, backup/restore, single-walk return contracts, sha256, non-https rejection |

### Validation gates (CONTRIBUTING.md)
| Gate | Command | Result |
|------|---------|--------|
| Format | `cargo fmt --all -- --check` | ✅ Passed |
| Lint | `cargo clippy --all-targets --all-features --locked -- -D warnings` | ✅ Passed |
| Self-update tests | `cargo test --lib --locked cmd_self_update` | ✅ 60/60 |
| Pre-push hooks | fmt + race-subset (`cognitive_memory\|bootstrap\|memory_ipc\|memory_consolidation`) + clippy | ✅ Passed on push |

### Fix count
- **0** functional fixes required — all scenarios passed on the first run.
- **1** structural change: merged `origin/main` to resolve the pre-existing
  merge conflict and make the branch merge-ready (commit `a02db059`).

_Tested at branch HEAD `a02db059`._
