### PR TITLE
feat(memory): close the episodic→procedural learning loop (#2441, #2458)

### DIFF
--- a/docs/concepts/procedural-learning-loop.md
+++ b/docs/concepts/procedural-learning-loop.md
@@ -1,0 +1,157 @@
+---
+title: Closing the procedural-learning loop
+description: How Simard turns recurring successful episodes into reusable skills and recurring verified failures into Reflexion-style lessons, then recalls and applies both to condition future action — closing the episodic→procedural self-improvement loop. Covers the verified-signal gate (Verdict), the skill-reuse half (#2441), the failure-lesson half (#2458), lesson naming, recurrence gating, and the reuse/repeat-failure metrics.
+last_updated: 2026-06-28
+owner: simard
+doc_type: concept
+status: implemented
+related:
+  - ../memory.md
+  - ../architecture/cognitive-memory.md
+  - ../reference/procedural-learning-loop.md
+  - ../reference/ooda-procedural-memory.md
+  - ../reference/cognitive-memory-ranked-episodic-recall.md
+  - ../reference/automatic-distillation-scheduler.md
+  - ../reference/cognitive-memory-provenance.md
+  - ../howto/inspect-the-procedural-learning-loop.md
+---
+
+# Closing the procedural-learning loop
+
+> **Status: implemented**, with one honest boundary. The skill-reuse half
+> (#2441) — usage-ranked recall, apply-time reinforcement, and the
+> `brain_skill_reuse` / `brain_new_procedure` metrics — is live. The
+> failure→lesson half (#2458) — reflection storage, recurrence-gated lesson
+> distillation, and `brain_repeat_failure` — is implemented and tested, but its
+> **production trigger requires an external failure signal (FU1)**: today no
+> engineer-loop verdict reports `failed`, so the gate (which never fires on
+> self-judged success) stays closed until FU1 lands. The executable contract,
+> including the FU1 wiring, is
+> [Procedural-learning loop API](../reference/procedural-learning-loop.md); the
+> operator guide is
+> [Inspect the procedural-learning loop](../howto/inspect-the-procedural-learning-loop.md).
+
+Simard already *stored* procedural memory. What was missing was the **loop**:
+a procedure had to be recalled, applied to condition the next action, and
+reinforced when it helped — and a failure had to become a durable lesson that
+a later, similar task actually consults. Storing without recall-and-apply is a
+write-only memory. This feature closes both halves of that loop and gates
+all learning on an **external verified signal** so Simard never trains on her
+own optimistic self-assessment.
+
+## The loop
+
+```
+            ┌──────────────────────── recall + apply ───────────────────────┐
+            ▼                                                                │
+   ┌─────────────────┐     verified success      ┌──────────────────────┐   │
+   │ OODA preparation │ ───────────────────────▶ │  Procedural memory    │  │
+   │ (orient/decide)  │ ◀──────────────────────── │  • skills  (ooda:…)   │  │
+   └─────────────────┘     usage-ranked recall    │  • lessons (lesson:…) │  │
+            │                                      └──────────────────────┘   │
+            │ act                                            ▲                 │
+            ▼                                                │ distill         │
+   ┌─────────────────┐   Verdict::VerifiedSuccess   ────────┘ (recurring)      │
+   │   OODA act +     │ ─────────────────────────────────────────────────────┘
+   │  verification    │   Verdict::VerifiedFailure ─▶ reflection episode ─▶ lesson
+   │  (external sig.) │   Verdict::Unverified      ─▶ learn nothing (fail-safe)
+   └─────────────────┘
+```
+
+The loop has two halves that share one store, one recall path, and one gate.
+
+### Half 1 — skill reuse (#2441)
+
+1. **Distill on verified success.** When an action sequence completes with a
+   `Verdict::VerifiedSuccess`, the OODA Act phase abstracts it into a named
+   procedure (an `ooda:<kind>:<triggers>` *skill*).
+2. **Usage-ranked recall.** OODA preparation recalls procedures whose name or
+   steps match the current objective, ordered by `usage_count` (descending) so
+   the procedures that have helped most often surface first.
+3. **Apply + reinforce.** When a recalled procedure is surfaced into the
+   cycle's prompt — i.e. *applied* to condition the next decision — its
+   `usage_count` is reinforced and a `brain_skill_reuse` metric is recorded.
+   Reinforcement is what makes a procedure that keeps working rise to the top
+   of recall; this is the feedback edge that was previously missing.
+
+### Half 2 — failure lessons (#2458)
+
+1. **Reflect on verified failure.** When an action ends in a
+   `Verdict::VerifiedFailure { error_class }`, Simard writes a short
+   Reflexion-style **reflection** — what was attempted, the external verdict,
+   and what to try differently — stored as an episodic note tagged
+   `reflection` / `failure` and keyed by `(goal_type, error_class)`.
+2. **Distill recurring failures into lessons.** A *one-off* failure is noise; a
+   *recurring* one is a pattern. When the same `(goal_type, error_class)`
+   reflection recurs at least `LESSON_RECURRENCE_THRESHOLD` times (default
+   **2**), it is distilled into a `lesson:<goal_type>:<error_class>` procedure
+   via the provenance write path, so the lesson links back to the reflections
+   it came from.
+3. **Recall + condition.** Because a lesson is just a procedure with a
+   descriptive name, it co-ranks with skills through the *same* usage-ranked
+   recall. A later attempt on the previously-failed goal-type surfaces the
+   lesson into orient/decide, conditioning Simard to avoid the repeat.
+4. **Watch for repeats.** If a `VerifiedFailure` recurs on a goal-type that
+   *already* has a lesson, a `brain_repeat_failure` metric fires — the lesson
+   did not take, which is a measurable self-improvement regression.
+
+## The verified-signal gate
+
+The single most important design decision is that **all** learning — skill
+distillation, reflection, and lesson distillation — is gated on an injected
+[`Verdict`](../reference/procedural-learning-loop.md#verdict), never on
+Simard's self-reported `ActionOutcome.success`.
+
+| `Verdict` | Source | Learning effect |
+|---|---|---|
+| `VerifiedSuccess` | external check passed (`VerificationReport.status`, real subprocess exit, gym eval) | distil/reinforce a **skill** |
+| `VerifiedFailure { error_class }` | external check failed | write a **reflection**; maybe distil a **lesson** |
+| `Unverified` | no external signal available | **learn nothing** (fail-safe) |
+
+This closes a self-approval feedback hazard: a model that grades its own work
+will, over many cycles, reinforce whatever it *believes* worked. Training a
+durable memory on that signal compounds the error (cf. *Large Language Models
+Cannot Self-Correct Reasoning Yet*, [arXiv:2310.01798](https://arxiv.org/abs/2310.01798)).
+By gating on a real, external verdict and defaulting to `Unverified` ⇒ no
+learning, Simard only ever durably remembers what an outside check confirmed.
+
+`Unverified` is the safe default precisely *because* it is the most common
+state today: when the full verification signal (FU1) is absent, the loop
+records nothing rather than guessing.
+
+## What is already there, and what will close the loop
+
+Several pieces already exist; the proposed loop is what connects them.
+
+| Capability | Status today | Role in the proposed loop |
+|---|---|---|
+| `store_procedure` on success | exists (#2280) | distil-on-success — to be **gated on `Verdict`** |
+| Usage-ranked recall | exists (#2329/#2395) | will order skills *and* lessons by `usage_count` |
+| Reinforce-on-use (`reinforce_access`) | exists (#2395) | the apply→reinforce feedback edge to wire in |
+| Provenance writes (`store_procedure_with_provenance`) | exists (#2325/#2327) | will link lessons back to their reflections |
+| **Failure → reflection → lesson** | **missing** | **Half 2 (#2458)** |
+| **Verified-signal gate (`Verdict`)** | **missing** | **fail-safe gate (R10)** |
+| **Reuse / repeat-failure metrics** | **missing** | **observability of the loop** |
+
+The loop deliberately reuses the existing distillation and recall
+infrastructure rather than introducing a parallel store. Lessons are ordinary
+procedures distinguished only by a **naming convention**
+(`lesson:<goal_type>:<error_class>`), so no schema change is required and they
+will flow through recall, ranking, reinforcement, and provenance unchanged. See
+[Why a naming convention, not a new column](../reference/procedural-learning-loop.md#lesson-naming).
+
+## Boundaries
+
+- The loop does **not** build the full external verification signal (FU1). It
+  consumes whatever verified signal exists and treats its absence as
+  `Unverified`.
+- Lessons generalize over one `(goal_type, error_class)` pair at a time. Broad
+  cross-goal generalization is out of scope for this pass.
+- No new storage backend, schema overhaul, or live redeploy is involved.
+
+## See also
+
+- [Procedural-learning loop API](../reference/procedural-learning-loop.md) — the executable contract.
+- [Inspect the procedural-learning loop](../howto/inspect-the-procedural-learning-loop.md) — operator guide.
+- [OODA procedural memory](../reference/ooda-procedural-memory.md) — the store/recall substrate.
+- [Memory architecture](../memory.md) — where this sits among the six memory types.

--- a/docs/howto/inspect-the-procedural-learning-loop.md
+++ b/docs/howto/inspect-the-procedural-learning-loop.md
@@ -1,0 +1,196 @@
+---
+title: Inspect the procedural-learning loop
+description: Operator guide for Simard's closed episodic→procedural learning loop — confirming skills are recalled and reused, watching verified failures become Reflexion-style reflections and recurring failures become lessons, reading the brain_skill_reuse / brain_new_procedure / brain_repeat_failure metrics, listing skill vs lesson procedures, tuning the lesson recurrence threshold, and verifying that the verified-signal gate suppresses learning when no external signal exists.
+last_updated: 2026-06-28
+owner: simard
+doc_type: howto
+status: implemented
+related:
+  - ../concepts/procedural-learning-loop.md
+  - ../reference/procedural-learning-loop.md
+  - ../reference/ooda-procedural-memory.md
+  - ../reference/simard-memory-cli.md
+  - ../reference/automatic-distillation-scheduler.md
+  - ../howto/configure-episode-hygiene-and-promotion.md
+  - ../memory.md
+---
+
+# Inspect the procedural-learning loop
+
+> **Status: implemented**, with one boundary. The skill-reuse half is live:
+> `brain_skill_reuse` (apply-time reuse) and `brain_new_procedure` (new
+> skill/lesson stored) are written to `~/.simard/metrics/metrics.jsonl`, and the
+> `SIMARD_LESSON_RECURRENCE_THRESHOLD` knob is read by `OodaConfig`. The
+> failure→lesson surface (stored reflections, recurring `lesson:` procedures, and
+> `brain_repeat_failure`) is implemented and tested, but **does not fire in
+> production until an external failure signal (FU1) exists** — today no
+> engineer-loop verdict reports `failed`, and the gate never fires on self-judged
+> success. So you will see `brain_skill_reuse` / `brain_new_procedure` events
+> now, but not reflections / lessons / `brain_repeat_failure` until FU1 lands.
+> Applies to issues
+> [#2441](https://github.com/rysweet/Simard/issues/2441) and
+> [#2458](https://github.com/rysweet/Simard/issues/2458). For the design see
+> [Closing the procedural-learning loop](../concepts/procedural-learning-loop.md).
+
+Once implemented, Simard will turn recurring **verified** successes into
+reusable *skills* and recurring **verified** failures into *lessons*, then
+recall and apply both to condition future cycles. This guide shows how to watch
+that loop run, read its metrics, list what it has learned, and tune the one knob
+it will expose.
+
+The loop will need no configuration to work — the defaults are intended to be
+production-ready. Tune only when you have a reason.
+
+## When to use this
+
+- You want to confirm distilled procedures are actually being **recalled and
+  reused**, not just stored.
+- You want to see a repeated failure become a durable lesson.
+- You are auditing whether a goal-type keeps failing *despite* a lesson
+  (`brain_repeat_failure`).
+- You want to tune how many repeats it takes before a failure becomes a lesson.
+
+## Watch skills get reused (#2441)
+
+Each OODA cycle logs which procedures it recalled for the current objective.
+Tail the daemon journal and look for the structured recall line:
+
+```text
+recalled procedures for objective  procedure_count=3 procedure_names="ooda:fix-ci:cargo … | lesson:fix-ci-linker-oom:cargo_test_failure | ooda:triage:pr"
+```
+
+When a recalled procedure is **applied** (surfaced into the cycle's prompt),
+its `usage_count` is reinforced and a reuse metric is recorded. Confirm reuse
+is happening:
+
+```bash
+grep brain_skill_reuse ~/.simard/metrics/metrics.jsonl | tail
+```
+
+```json
+{"metric_name":"brain_skill_reuse","value":1.0,"context":"{\"procedure_id\":\"proc_4f2a\",\"kind\":\"skill\"}"}
+```
+
+A healthy loop shows `brain_skill_reuse` events accumulating and the
+`usage_count` of useful procedures climbing over time. If you see procedures
+stored but **no** `brain_skill_reuse` events, the loop is write-only — recall
+or apply is not firing; check that preparation is recalling for the objective
+(the `recalled procedures for objective` line above).
+
+## Watch failures become lessons (#2458)
+
+On a **verified** failure, Simard writes a short reflection (what was
+attempted, the external verdict, what to try next) as a `reflection`/`failure`
+episode. A *one-off* failure stops there. When the same
+`(goal_type, error_class)` recurs at least the recurrence threshold (default
+**2**) times, the reflection is distilled into a `lesson:` procedure.
+
+Watch the failure path in the journal:
+
+```text
+[simard] reflection-lessons: recorded failure reflection (goal_type=fix-ci-linker-oom error_class=cargo_test_failure)
+[simard] reflection-lessons: recurrence 2 >= threshold 2 → distilled lesson 'lesson:fix-ci-linker-oom:cargo_test_failure'
+```
+
+The lesson is now an ordinary procedure, so it appears in the next cycle's
+recall for matching objectives and co-ranks with skills by `usage_count`.
+
+## List skills vs lessons
+
+Lessons are procedures whose name starts with `lesson:`; skills start with
+`ooda:`. Use the existing read-only memory CLI to dump procedural memory and
+filter by prefix (see [Memory introspection CLI](../reference/simard-memory-cli.md)):
+
+```bash
+# sample procedural-memory rows (most-used first)
+simard memory dump --type=procedural --limit=50
+
+# lessons only
+simard memory dump --type=procedural --limit=50 | grep 'lesson:'
+
+# skills only
+simard memory dump --type=procedural --limit=50 | grep 'ooda:'
+```
+
+Each lesson's name encodes the `goal_type` and `error_class` it guards
+against: `lesson:<goal_type>:<error_class>`.
+
+## Read the loop metrics
+
+All three loop metrics are appended to `~/.simard/metrics/metrics.jsonl` and
+are also surfaced through brain introspection
+([Brain Introspection API](../reference/brain-introspection-api.md)).
+
+| Metric | What a rising count means |
+|---|---|
+| `brain_skill_reuse` | recalled procedures are being applied — the loop is closed and working |
+| `brain_new_procedure` | new skills/lessons are being learned |
+| `brain_repeat_failure` | **regression**: a goal-type failed again *despite* an existing lesson |
+
+Quick health check:
+
+```bash
+for m in brain_skill_reuse brain_new_procedure brain_repeat_failure; do
+  printf '%-22s %s\n' "$m" "$(grep -c "\"metric_name\":\"$m\"" ~/.simard/metrics/metrics.jsonl)"
+done
+```
+
+A persistently climbing `brain_repeat_failure` for one `goal_type` means the
+lesson is not changing behaviour — inspect that lesson's `steps` and the
+reflections behind it (its `PROCEDURE_DERIVES_FROM` provenance, see
+[Cognitive-memory provenance](../reference/cognitive-memory-provenance.md)).
+
+## Tune the recurrence threshold
+
+The only knob is how many repeats it takes before a failure becomes a lesson.
+Default is `2` (one-off failures are never distilled).
+
+```bash
+# require three repeats before distilling a lesson (less eager)
+export SIMARD_LESSON_RECURRENCE_THRESHOLD=3
+
+# distil a lesson from the first failure (NOT recommended — turns noise into lessons)
+export SIMARD_LESSON_RECURRENCE_THRESHOLD=1
+```
+
+The value is read into `OodaConfig.lesson_recurrence_threshold` at daemon
+start. Leave it at `2` unless lessons are too noisy (raise it) — there is no
+supported value that disables reflections; only lesson *distillation* is gated.
+
+## Verify the verified-signal gate
+
+The loop only learns from an **external** verdict. When no verification signal
+is available, the verdict is `Unverified` and Simard learns nothing — this is
+intentional fail-safe behaviour, not a bug.
+
+To confirm the gate is holding, run a cycle whose action produces no external
+verification and check that **no** new procedure and **no** reflection were
+written for it:
+
+```bash
+# count procedures + reflection episodes before and after a self-assessed-only cycle
+simard memory stats     # note procedural + episodic counts
+# … run one cycle with no external verification …
+simard memory stats     # counts for procedural/lesson must be unchanged
+```
+
+If you see procedures or reflections appear from a cycle that had no external
+check, the gate is leaking — that is a defect (the gate must be a no-op on
+`Verdict::Unverified`). See the gating invariant in the
+[API reference](../reference/procedural-learning-loop.md#the-verified-signal-gate).
+
+## Troubleshooting
+
+| Symptom | Likely cause | What to check |
+|---|---|---|
+| Procedures stored but `brain_skill_reuse` never fires | recall/apply not wired to objective | `recalled procedures for objective` journal line; objective tokens vs procedure names |
+| Repeated failures never become lessons | threshold too high, or `error_class` not stable across runs | `SIMARD_LESSON_RECURRENCE_THRESHOLD`; that `normalize_error_class` yields the same key each time |
+| `brain_repeat_failure` climbing for one goal-type | the lesson is not changing behaviour | the lesson's `steps`; its source reflections via provenance |
+| Nothing learned at all | every verdict is `Unverified` | whether the action path produces a `VerificationReport` with a real `status` |
+
+## See also
+
+- [Closing the procedural-learning loop](../concepts/procedural-learning-loop.md) — the design.
+- [Procedural-learning loop API](../reference/procedural-learning-loop.md) — the contract.
+- [OODA procedural memory](../reference/ooda-procedural-memory.md) — the store/recall substrate.
+- [Configure episode hygiene and promotion](../howto/configure-episode-hygiene-and-promotion.md) — the related distillation scheduler.

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -20,7 +20,7 @@ For the full canonical specification (schema, consolidation rules, hive event bu
 | **Working** | Task-scoped (cleared at task end) | The 20-slot active task context: goal, constraints, plan steps, current execution state. |
 | **Episodic** | Persistent, autobiographical | "What happened this session" — every cycle, every action, every observation. |
 | **Semantic** | Persistent, deduplicated | Facts and learned concepts promoted from episodic memory ("the test harness uses CARGO_TARGET_DIR"). |
-| **Procedural** | Persistent, indexed by trigger, deduplicated by name | Learned how-to: action sequences that worked for a given situation. Written by the OODA Act phase for successful outcomes. Storing an identically-named procedure is idempotent (#2298). See [OODA procedural memory](reference/ooda-procedural-memory.md) and [Procedural-memory store idempotency](reference/cognitive-memory-procedural-idempotency.md). |
+| **Procedural** | Persistent, indexed by trigger, deduplicated by name | Learned how-to: action sequences that worked for a given situation. Today holds **skills** (`ooda:…`) written by the OODA Act phase for successful outcomes. **Proposed (#2441/#2458):** gate that learning on an external verdict, add **lessons** (`lesson:<goal_type>:<error_class>`) distilled from recurring *verified* failures, recall by usage rank, and reinforce on reuse — the closed procedural-learning loop. Storing an identically-named procedure is idempotent (#2298). See [Closing the procedural-learning loop](concepts/procedural-learning-loop.md) (proposed), [OODA procedural memory](reference/ooda-procedural-memory.md), and [Procedural-memory store idempotency](reference/cognitive-memory-procedural-idempotency.md). |
 | **Prospective** | Persistent, time/event-indexed | Future intentions: Active goals as trigger-action pairs, meeting action items. See [Goal–prospective memory mirror](reference/goal-prospective-memory-mirror.md). |
 
 ## Consolidation flow
@@ -31,9 +31,21 @@ Sensory   ──(attention)──▶  Episodic
 Working   ──(task end)───▶  Episodic
 Episodic  ──(distill)────▶  Semantic    (DERIVES_FROM edge back to source episode, #2325)
 Episodic  ──(distill)────▶  Procedural  (PROCEDURE_DERIVES_FROM edge, #2327)
-OODA Act  ──(success)────▶  Procedural    (#2280)
+OODA Act  ──(success)────▶  Procedural    (skill, #2280)
+OODA Act  ──(verified success)──▶  Procedural  (skill — gated on Verdict; proposed #2441)
+OODA Act  ──(verified failure)──▶  Episodic (reflection) ──(recurring ≥2)──▶ Procedural (lesson; proposed #2458)
 Goal put  ──(Active)─────▶  Prospective   (#2207/#2280)
 ```
+
+> **Proposed (#2441/#2458) — not yet implemented.** A planned change would gate
+> all procedural learning on an **external verified signal**
+> (`Verdict::VerifiedSuccess` / `VerifiedFailure` / `Unverified`): an
+> `Unverified` outcome would learn nothing, so Simard never trains procedural
+> memory on her own self-assessment. Recalled procedures would be reinforced
+> when applied, and recurring *verified* failures would become durable lessons
+> that future similar goals consult — closing the episodic→procedural loop. See
+> [Closing the procedural-learning loop](concepts/procedural-learning-loop.md) and
+> [Procedural-learning loop API](reference/procedural-learning-loop.md).
 
 A deterministic **episode ingestion policy** runs before every
 `store_episode` write: it drops operational-noise episodes (session

--- a/docs/reference/ooda-procedural-memory.md
+++ b/docs/reference/ooda-procedural-memory.md
@@ -8,6 +8,9 @@ related:
   - ../architecture/cognitive-memory.md
   - ./cognitive-memory-ranked-episodic-recall.md
   - ./cognitive-memory-procedural-idempotency.md
+  - ./procedural-learning-loop.md
+  - ../concepts/procedural-learning-loop.md
+  - ../howto/inspect-the-procedural-learning-loop.md
   - ./goal-prospective-memory-mirror.md
   - ./ooda-brain-api.md
   - ./ooda-engineer-lifecycle-recipe.md

--- a/docs/reference/procedural-learning-loop.md
+++ b/docs/reference/procedural-learning-loop.md
@@ -1,0 +1,458 @@
+---
+title: Procedural-learning loop API
+description: Rust API reference and executable contract for Simard's closed episodic→procedural learning loop — the Verdict verified-signal gate and verified_outcome() mapping, the reflection_lessons module (record_failure_reflection, count_recurring_failures, maybe_distill_lesson, lesson_name and the lesson:<goal_type>:<error_class> naming convention, goal-type/error-class normalization), the LESSON_RECURRENCE_THRESHOLD / SIMARD_LESSON_RECURRENCE_THRESHOLD configuration, the brain_skill_reuse / brain_new_procedure / brain_repeat_failure metrics, the OODA cycle wiring, and the test→acceptance mapping for issues #2441 and #2458.
+last_updated: 2026-06-28
+owner: simard
+doc_type: reference
+status: implemented
+related:
+  - ../memory.md
+  - ../concepts/procedural-learning-loop.md
+  - ./ooda-procedural-memory.md
+  - ./cognitive-memory-ranked-episodic-recall.md
+  - ./cognitive-memory-provenance.md
+  - ./automatic-distillation-scheduler.md
+  - ./cognitive-memory-procedural-idempotency.md
+  - ../howto/inspect-the-procedural-learning-loop.md
+---
+
+# Procedural-learning loop API
+
+> **Status: implemented.** This page is the as-built reference for issues
+> [#2441](https://github.com/rysweet/Simard/issues/2441) (skill-reuse loop) and
+> [#2458](https://github.com/rysweet/Simard/issues/2458) (failure→lesson). The
+> types, module, config, metrics, and tests below exist in the tree.
+>
+> Module: `src/memory_consolidation/reflection_lessons.rs` (gate, normalization,
+> lesson naming, reflection/lesson distillation, metrics) with memory-backed
+> acceptance tests in `src/memory_consolidation/tests_reflection_lessons.rs` and
+> end-to-end reuse-loop guards in `src/cognitive_memory/tests_procedural_loop.rs`.
+> Config field: `OodaConfig.lesson_recurrence_threshold`
+> (`src/ooda_loop/types.rs`). The reuse-reinforcement seam is the existing
+> `reinforce_prepared_context` (`src/memory_consolidation/mod.rs`); new-procedure
+> emission is at the OODA procedure-store seam (`src/ooda_loop/cycle.rs`); metrics
+> are written through the existing `record_metric` in `src/self_metrics/mod.rs`.
+>
+> **FU1 boundary (honest scope).** The *mechanics* of the failure→lesson half are
+> implemented and tested, but their **production trigger** requires an external
+> failure signal. Today the only engineer-loop
+> [`VerificationReport`](#verified_outcome) yields `verified`/`unverified`
+> (a git-artifact probe), never `failed`, so [`verified_outcome`] never returns
+> `VerifiedFailure` in production yet. Per both issues' stated sequencing
+> ("hard dependency on FU1"), wiring `record_failure_reflection` /
+> `maybe_distill_lesson` / `brain_repeat_failure` to a real failure verdict is a
+> one-call change deferred to FU1 — see [OODA cycle wiring](#ooda-cycle-wiring).
+> The loop is **never** gated on self-judged `ActionOutcome.success` (R10).
+
+This page is the executable contract for the proposed procedural-learning loop.
+For the rationale and the end-to-end picture see
+[Closing the procedural-learning loop](../concepts/procedural-learning-loop.md);
+for operations see
+[Inspect the procedural-learning loop](../howto/inspect-the-procedural-learning-loop.md).
+
+The change is designed to be **additive and backward-compatible**: the
+[`CognitiveMemoryOps`](./ooda-procedural-memory.md) trait is unchanged, the
+`CognitiveProcedure` shape is unchanged (no new column), and lessons are
+ordinary procedures distinguished by a name prefix. Existing snapshots, IPC
+payloads, and persisted nodes deserialize unchanged.
+
+---
+
+## The verified-signal gate
+
+### `Verdict`
+
+The external-signal classification that gates **all** learning. Self-judged
+`ActionOutcome.success` is never used as the gate.
+
+```rust
+/// External verification verdict for an action sequence.
+///
+/// Sourced from a real outside signal (engineer-loop `VerificationReport`,
+/// a verified subprocess exit, or a gym eval) — never from the model's own
+/// `ActionOutcome.success`. `Unverified` is the fail-safe default: when no
+/// external signal is available, the loop learns nothing.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Verdict {
+    /// An external check confirmed success → distil/reinforce a skill.
+    VerifiedSuccess,
+    /// An external check confirmed failure → reflect, maybe distil a lesson.
+    /// `error_class` is the normalized failure class (e.g. `cargo_test_failure`).
+    VerifiedFailure { error_class: String },
+    /// No external signal available → learn nothing (fail-safe).
+    Unverified,
+}
+```
+
+> **Naming.** This type will live in the `reflection_lessons` module and is
+> always referred to as `reflection_lessons::Verdict`. It is intentionally
+> distinct from the unrelated existing `stewardship::merge_judge::Verdict`; the
+> two never appear in the same scope, and module-qualified references keep them
+> unambiguous. (If a bare `Verdict` import would ever collide at a call site,
+> alias it — e.g. `use reflection_lessons::Verdict as LearnVerdict`.)
+
+### `verified_outcome`
+
+Maps an engineer-loop [`VerificationReport`](./runtime-contracts.md) to a
+`Verdict`. The mapping is **conservative**: anything that is not an
+unambiguous external pass/fail becomes `Unverified`.
+
+```rust
+/// Derive the learning gate from an external verification report.
+///
+/// - `status` of `passed` / `verified` / `success` (case-insensitive) and at
+///   least one recorded check → `VerifiedSuccess`.
+/// - `status` of `failed` / `error` → `VerifiedFailure { error_class }`, where
+///   `error_class` is derived from the first failing check (or `summary`),
+///   normalized via [`normalize_error_class`].
+/// - anything else (empty status, `skipped`, `unknown`, no checks) →
+///   `Unverified`.
+pub fn verified_outcome(report: &VerificationReport) -> Verdict;
+```
+
+`VerificationReport` is the existing engineer-loop type
+(`src/engineer_loop/types.rs`):
+
+```rust
+pub struct VerificationReport {
+    pub status: String,       // "passed" | "failed" | "skipped" | …
+    pub summary: String,
+    pub checks: Vec<String>,  // e.g. ["cargo test: 247 passed", …]
+}
+```
+
+> **Gating invariant (R10).** Every learning entry point — skill distillation,
+> failure reflection, and lesson distillation — takes a `Verdict` and is a
+> **no-op on `Verdict::Unverified`**. There is no code path that distils or
+> reflects from `ActionOutcome.success` alone.
+
+---
+
+## Lesson naming
+
+Lessons are **not** a new node type and do **not** add a column to
+`CognitiveProcedure`. A lesson is an ordinary procedure whose name follows a
+reserved convention:
+
+```text
+lesson:<goal_type>:<error_class>
+```
+
+`lesson_name` is the single constructor; both keys are normalized first.
+
+```rust
+/// Reserved name prefix marking a procedure as a failure-derived lesson.
+pub const LESSON_NAME_PREFIX: &str = "lesson:";
+
+/// Compose the canonical lesson procedure name for a (goal_type, error_class).
+/// Both keys are normalized via [`normalize_goal_type`] / [`normalize_error_class`].
+pub fn lesson_name(goal_type: &str, error_class: &str) -> String;
+
+/// `true` if `name` is a lesson (failure-derived) procedure.
+pub fn is_lesson(name: &str) -> bool; // name.starts_with(LESSON_NAME_PREFIX)
+```
+
+### Why a naming convention, not a new column
+
+`CognitiveProcedure` is `{ node_id, name, steps, prerequisites, usage_count }`
+— there is no metadata column to carry a `skill` / `lesson` tag, and adding one
+would ripple through the library schema, snapshots, and IPC payloads. The
+naming convention sidesteps all of that:
+
+| Property | How the convention delivers it |
+|---|---|
+| **Recall** | `recall_procedure` matches name/steps with `CONTAINS`; the `goal_type` / `error_class` tokens in the name make lessons match the same objectives that produced them. |
+| **Ranking** | Lessons co-rank with skills by `usage_count` in [`recall_procedures_for_objective`](./ooda-procedural-memory.md) — no separate ranking path. |
+| **Classification** | `is_lesson(name)` is a pure string check; metrics and dashboards filter on the `lesson:` prefix. |
+| **Back-compat** | Zero schema change; legacy procedures (no prefix) are simply non-lessons. |
+
+### Normalization
+
+Both keys are normalized to plain, deterministic, unit-testable strings:
+
+```rust
+/// Normalize an objective string into a goal-type key:
+/// lowercased, non-alphanumeric runs collapsed to single `-`.
+/// Deterministic and idempotent (e.g. "Fix CI linker OOM!" → "fix-ci-linker-oom").
+pub fn normalize_goal_type(objective: &str) -> String;
+
+/// Normalize a raw failure descriptor into an error-class key with the same
+/// rules but a `_` separator (e.g. "Cargo Test FAILED" → "cargo_test_failed").
+/// Deterministic and idempotent. No semantic remapping is applied — the key is
+/// a pure lowercase/alphanumeric transform, so it stays stable run-to-run.
+pub fn normalize_error_class(raw: &str) -> String;
+```
+
+Normalization is idempotent: `normalize_goal_type(normalize_goal_type(x)) ==
+normalize_goal_type(x)` (and likewise for `normalize_error_class`), because the
+chosen separators (`-` / `_`) are themselves non-alphanumeric and re-split to the
+same tokens.
+
+---
+
+## The `reflection_lessons` module
+
+`src/memory_consolidation/reflection_lessons.rs`. All entry points take a
+`&dyn CognitiveMemoryOps` and a `Verdict`, and are no-ops on `Unverified`.
+
+### `record_failure_reflection`
+
+Writes a Reflexion-style reflection for a verified failure as an episodic note
+tagged `reflection` / `failure`, keyed by `(goal_type, error_class)`. Returns
+the stored episode id (the provenance anchor for any future lesson), or `None`
+if the verdict was not a `VerifiedFailure`.
+
+```rust
+/// Generate and store a verbal failure reflection.
+///
+/// No-op (returns `Ok(None)`) unless `verdict` is `VerifiedFailure`.
+/// The stored episode content is a short, structured reflection:
+///   "Attempted <objective>. External verdict: failed (<error_class>).
+///    Next time: <hint>."
+/// keyed/tagged so [`count_recurring_failures`] can find it.
+pub fn record_failure_reflection(
+    memory: &dyn CognitiveMemoryOps,
+    objective: &str,
+    verdict: &Verdict,
+    hint: &str,
+) -> SimardResult<Option<String>>;
+```
+
+The reflection text is built by a pure helper so it can be asserted directly:
+
+```rust
+/// Build the verbal reflection body (attempted / external verdict / next time).
+/// Pure and deterministic — extracted for unit testing.
+pub fn reflection_text(objective: &str, error_class: &str, hint: &str) -> String;
+```
+
+### `count_recurring_failures`
+
+Counts stored failure reflections matching a `(goal_type, error_class)` key.
+
+```rust
+/// Count `reflection`/`failure` episodes recorded for this (goal_type, error_class).
+pub fn count_recurring_failures(
+    memory: &dyn CognitiveMemoryOps,
+    goal_type: &str,
+    error_class: &str,
+) -> SimardResult<u32>;
+```
+
+### `maybe_distill_lesson`
+
+Distils a recurring failure into a `lesson:` procedure **only** when the
+reflection count reaches the threshold. This is the recurrence gate that keeps
+one-off failures out of procedural memory.
+
+```rust
+/// Distil a lesson from recurring reflections, gated on recurrence.
+///
+/// Returns `Ok(None)` when:
+///   - the reflection count is `< threshold` (one-off failure), or
+///   - `verdict` is not `VerifiedFailure`.
+/// When the count is `>= threshold`, stores a `lesson:<goal_type>:<error_class>`
+/// procedure via `store_procedure_with_provenance` (linking the source
+/// reflection episodes with `PROCEDURE_DERIVES_FROM` edges, #2325) and returns
+/// the lesson node id. Storing is idempotent by name (#2298): a recurring
+/// (goal_type, error_class) reinforces the existing lesson's `usage_count`
+/// rather than duplicating it.
+pub fn maybe_distill_lesson(
+    memory: &dyn CognitiveMemoryOps,
+    verdict: &Verdict,
+    objective: &str,
+    threshold: u32,
+    source_episode_ids: &[String],
+) -> SimardResult<Option<String>>;
+```
+
+### `has_lesson_for`
+
+Read helper used by the repeat-failure metric — does a lesson already exist for
+this goal-type/error-class?
+
+```rust
+/// `true` if a `lesson:<goal_type>:<error_class>` procedure already exists.
+/// Uses exact-name equality on recall hits (not a bare `CONTAINS` is_empty),
+/// mirroring `procedure_exists` (#2298).
+pub fn has_lesson_for(
+    memory: &dyn CognitiveMemoryOps,
+    goal_type: &str,
+    error_class: &str,
+) -> SimardResult<bool>;
+```
+
+---
+
+## Configuration
+
+### `LESSON_RECURRENCE_THRESHOLD`
+
+```rust
+/// Minimum number of `(goal_type, error_class)` reflections before a recurring
+/// failure is distilled into a `lesson:` procedure. `1` would turn every
+/// one-off failure into a lesson; `2` is the smallest value that excludes
+/// singletons.
+pub const LESSON_RECURRENCE_THRESHOLD: u32 = 2;
+```
+
+### `OodaConfig.lesson_recurrence_threshold`
+
+The threshold is an `OodaConfig` field, populated from the environment with the
+same `env_u32(key, default)` pattern as the distillation scheduler fields:
+
+```rust
+pub struct OodaConfig {
+    // …
+    /// Recurrence threshold before a repeated failure becomes a lesson
+    /// (`SIMARD_LESSON_RECURRENCE_THRESHOLD`, default 2).
+    #[serde(default = "default_lesson_recurrence_threshold")]
+    pub lesson_recurrence_threshold: u32,
+    // …
+}
+
+fn default_lesson_recurrence_threshold() -> u32 {
+    LESSON_RECURRENCE_THRESHOLD // 2
+}
+```
+
+| Setting | Env var | Default | Effect |
+|---|---|---|---|
+| Lesson recurrence threshold | `SIMARD_LESSON_RECURRENCE_THRESHOLD` | `2` | Reflections per `(goal_type, error_class)` before a lesson is distilled. `1` ⇒ lessons from one-off failures (not recommended); higher ⇒ require more repeats. |
+
+No configuration will be required — the default value (`2`) is the intended
+production default. The verified-signal gate has no toggle: it is a load-bearing
+invariant, not a tunable.
+
+---
+
+## Metrics
+
+Three metrics, all written via
+[`record_metric(name, value, context)`](./brain-introspection-api.md) to
+`~/.simard/metrics/metrics.jsonl`. `value` is always `1.0` (a count event);
+`context` is a compact JSON object.
+
+| Metric name | Fires when | `context` fields |
+|---|---|---|
+| `brain_skill_reuse` | a recalled procedure is **applied** (surfaced into the cycle prompt) and reinforced | `{ "procedure_id", "kind" }` where `kind` is `skill` or `lesson` |
+| `brain_new_procedure` | a new skill or lesson procedure is stored for the first time (not a reinforcing re-store) | `{ "procedure_id", "name", "kind" }` |
+| `brain_repeat_failure` | a `VerifiedFailure` occurs on a goal-type that **already** has a matching `lesson:` procedure | `{ "goal_type", "error_class", "lesson_id" }` |
+
+`brain_repeat_failure` is the loop's self-regression signal: a lesson exists but
+the failure repeated anyway, so the lesson did not take. See
+[Inspect the procedural-learning loop](../howto/inspect-the-procedural-learning-loop.md#read-the-loop-metrics).
+
+Example records (`metrics.jsonl`):
+
+```json
+{"timestamp":"2026-06-28T05:30:00Z","metric_name":"brain_skill_reuse","value":1.0,"context":"{\"procedure_id\":\"proc_4f2a\",\"kind\":\"lesson\"}"}
+{"timestamp":"2026-06-28T05:31:12Z","metric_name":"brain_new_procedure","value":1.0,"context":"{\"procedure_id\":\"proc_91c\",\"name\":\"lesson:fix-ci-linker-oom:cargo_test_failure\",\"kind\":\"lesson\"}"}
+{"timestamp":"2026-06-28T05:42:55Z","metric_name":"brain_repeat_failure","value":1.0,"context":"{\"goal_type\":\"fix-ci-linker-oom\",\"error_class\":\"cargo_test_failure\",\"lesson_id\":\"proc_91c\"}"}
+```
+
+---
+
+## OODA cycle wiring
+
+The loop has three production seams today and one FU1-gated seam.
+
+**Wired now (honest signals):**
+
+1. **Apply → reinforce → `brain_skill_reuse`.** When recalled procedures are
+   surfaced into a cycle's prompt, `reinforce_prepared_context`
+   (`src/memory_consolidation/mod.rs`, invoked from `advance.rs`) bumps each
+   recalled procedure's `usage_count` and emits `brain_skill_reuse` via
+   [`record_skill_reuse`]. This is the measurable close of the recall→rerank
+   loop — applying a recalled procedure is, definitionally, reuse.
+2. **New procedure → `brain_new_procedure`.** When the OODA consolidation seam
+   (`src/ooda_loop/cycle.rs`) stores a *new* procedure (not a reinforcing
+   re-store), it emits `brain_new_procedure` via [`record_new_procedure`].
+
+**Implemented + tested, FU1-gated for production trigger:**
+
+3. **Failure → reflection → lesson, and `brain_repeat_failure`.**
+   [`record_failure_reflection`], [`maybe_distill_lesson`], [`has_lesson_for`],
+   and [`record_repeat_failure`] are fully implemented and covered by
+   `tests_reflection_lessons.rs`. They are **no-ops on every non-`VerifiedFailure`
+   verdict** (R10), so they cannot fire from self-judged success. Production today
+   has no external *failure* verdict (the engineer-loop `VerificationReport` only
+   yields `verified`/`unverified`), so these do not trigger yet. Once FU1 supplies
+   a real failure signal, the wiring is the illustrative block below — calling
+   the existing, tested entry points behind a single `verified_outcome(...)`:
+
+```rust
+// FU1 wiring (illustrative): only a *real* external verdict drives learning.
+let verdict = reflection_lessons::verified_outcome(&report); // engineer-loop report
+match &verdict {
+    Verdict::VerifiedSuccess => {
+        // distil/reinforce the successful sequence as a skill (gated on the
+        // external verdict, never on outcome.success).
+    }
+    Verdict::VerifiedFailure { error_class } => {
+        let ep = reflection_lessons::record_failure_reflection(
+            mem, &objective, &verdict, &next_time_hint,
+        )?;
+        let gt = reflection_lessons::normalize_goal_type(&objective);
+        if reflection_lessons::has_lesson_for(mem, &gt, error_class)? {
+            reflection_lessons::record_repeat_failure(&gt, error_class, &lesson_id);
+        }
+        reflection_lessons::maybe_distill_lesson(
+            mem, &verdict, &objective,
+            config.lesson_recurrence_threshold, ep.as_slice(),
+        )?;
+    }
+    Verdict::Unverified => { /* learn nothing — fail-safe */ }
+}
+```
+
+> **Why the skill-distillation gate is not flipped yet.** The existing OODA
+> consolidation stores procedures on a cycle's self-assessed `outcome.success`
+> (pre-existing #2281 behaviour). `ActionOutcome` carries no `VerificationReport`,
+> so there is no external verdict at that seam to gate on today. Rather than
+> regress to a *dishonest* gate, the verified-signal gate
+> ([`should_distill_skill`] / [`verified_outcome`]) ships ready for the FU1 seam
+> where a real report exists. R10 is preserved: no learning path is gated on
+> self-judged success.
+
+---
+
+## Backward compatibility
+
+| Aspect | Before | After |
+|---|---|---|
+| `CognitiveMemoryOps` trait | unchanged | unchanged (no new methods) |
+| `CognitiveProcedure` shape | `{node_id,name,steps,prerequisites,usage_count}` | unchanged (lessons are name-prefixed) |
+| Schema / snapshots / IPC | — | unchanged; no DDL |
+| Skill distillation gate | self-judged `outcome.success` | gate **implemented** ([`verified_outcome`]/[`should_distill_skill`]); production flip deferred to FU1 (no external verdict at the OODA outcome seam yet) — R10 preserved |
+| Failure handling | none | reflection + recurrence-gated lesson (implemented + tested; production trigger FU1-gated) |
+| Metrics | — | `brain_skill_reuse` (wired), `brain_new_procedure` (wired), `brain_repeat_failure` (FU1-gated) |
+
+---
+
+## Test → acceptance mapping
+
+The contract is enforced by the tests below — pure gate/normalization/metric
+contracts in `reflection_lessons`'s inline `#[cfg(test)] mod tests`, memory-backed
+behaviour in `src/memory_consolidation/tests_reflection_lessons.rs`, and the
+end-to-end reuse-loop guards in `src/cognitive_memory/tests_procedural_loop.rs`.
+
+| # | Acceptance criterion | Test | Status |
+|---|---|---|---|
+| AC-1 (#2441) | Usage-ranked recall: a higher-`usage_count` matching procedure outranks a lower one | `recall_procedure_ranks_more_used_procedure_first` | ✅ |
+| AC-2 (#2441) | Distill→recall→apply reinforces `usage_count` (0→1); applying records `brain_skill_reuse` | `reinforce_prepared_context_bumps_surfaced_fact_and_procedure_usage` (reinforce); `reuse_feeds_back_into_recall_order_closes_the_loop` (loop); `metric_contexts_have_expected_shapes` (metric shape) | ✅ |
+| AC-3 (#2441) | A later similar objective recalls and applies the distilled skill | `reuse_feeds_back_into_recall_order_closes_the_loop` | ✅ |
+| AC-4 (#2458) | A `VerifiedFailure` produces a `reflection:failure` episode | `verified_failure_writes_reflection` | ✅ |
+| AC-5 (#2458) | A recurring `(goal_type,error_class)` (≥ threshold) becomes a retrievable `lesson:` procedure | `recurring_failure_becomes_recallable_lesson` | ✅ |
+| AC-6 (#2458) | A one-off failure (count = 1) does **not** become a lesson | `one_off_failure_is_not_a_lesson` | ✅ |
+| AC-7 (#2441/#2458) | A subsequent attempt on the failed goal-type surfaces the lesson | `recurring_failure_becomes_recallable_lesson` (recall assertion) | ✅ |
+| AC-8 (R10) | `Verdict::Unverified` distils/reflects nothing | `unverified_and_success_write_no_reflection`, `unverified_distills_no_lesson_even_with_reflections` | ✅ |
+| AC-9 (R9) | `brain_repeat_failure` records when a `VerifiedFailure` recurs on a goal-type with an existing lesson | `metric_contexts_have_expected_shapes` (metric surface); production emission **FU1-gated** | ⏳ FU1 |
+| AC-10 | `verified_outcome` maps pass/fail/unknown reports to the correct `Verdict` | `verified_outcome_mapping` | ✅ |
+| AC-11 | `normalize_goal_type` / `normalize_error_class` are deterministic and idempotent | `normalization_is_idempotent` | ✅ |
+
+AC-1–AC-8, AC-10, AC-11 are green under `cargo test`. AC-9's metric *surface*
+(context shape + emitter) is tested; its production emission awaits FU1's
+external failure verdict (see [OODA cycle wiring](#ooda-cycle-wiring)). No
+snapshot/architecture-snapshot docs are added, and no live redeploy is part of
+this change.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ nav:
     - OODA Loop Self-Detection: concepts/ooda-loop-self-detection.md
     - Reconcile-and-Self-Deploy: concepts/reconcile-and-self-deploy.md
     - Deploy-Aware Done-Gate: concepts/deploy-aware-done-gate.md
+    - Closing the Procedural-Learning Loop: concepts/procedural-learning-loop.md
   - Tutorials:
     - First Local Session: tutorials/run-your-first-local-session.md
     - First Benchmark Suite: tutorials/run-your-first-benchmark-gym.md
@@ -91,6 +92,7 @@ nav:
     - Diagnose a Rejected Goal Completion: howto/diagnose-a-rejected-goal-completion.md
     - Configure Brain Introspection: howto/configure-brain-introspection.md
     - Triage Stale Pull Requests: howto/triage-stale-pull-requests.md
+    - Inspect the Procedural-Learning Loop: howto/inspect-the-procedural-learning-loop.md
   - Reference:
     - CLI Reference: reference/simard-cli.md
     - Self-Deploy API: reference/self-deploy-api.md
@@ -99,6 +101,7 @@ nav:
     - Cognitive-memory provenance (DERIVES_FROM): reference/cognitive-memory-provenance.md
     - Episode Ingestion Classifier API: reference/episode-ingestion-classifier.md
     - Automatic Distillation Scheduler API: reference/automatic-distillation-scheduler.md
+    - Procedural-Learning Loop API: reference/procedural-learning-loop.md
     - Goal-board prospective reconcile: reference/goal-board-prospective-reconcile.md
     - Runtime Contracts: reference/runtime-contracts.md
     - Operator Read State-Root Contract: reference/operator-read-state-root-contract.md

--- a/src/cognitive_memory/mod.rs
+++ b/src/cognitive_memory/mod.rs
@@ -570,3 +570,13 @@ mod tests_graph_stats;
 // `LibraryCognitiveMemory`.
 #[cfg(test)]
 mod tests_ranked_episodic;
+
+// Issue #2441: close the episodic->procedural skill-reuse loop. End-to-end guards
+// that reuse feeds back into recall ordering through the Simard `CognitiveMemoryOps`
+// surface — a recalled+reinforced procedure ranks higher on a later recall ("close
+// the loop, don't just store") — while a freshly distilled (`usage_count == 0`)
+// procedure stays recallable for its first reuse. The distill/recall/reinforce
+// halves are already wired; these pin that they compose (existing tests only cover
+// each half in isolation).
+#[cfg(test)]
+mod tests_procedural_loop;

--- a/src/cognitive_memory/tests_procedural_loop.rs
+++ b/src/cognitive_memory/tests_procedural_loop.rs
@@ -1,0 +1,148 @@
+//! End-to-end guard tests for the episodic->procedural skill-reuse loop
+//! (issue #2441), exercised through the Simard `CognitiveMemoryOps` surface
+//! against `LibraryCognitiveMemory::in_memory()` (the sole real backend).
+//!
+//! The reuse loop has three already-wired halves:
+//!
+//!   1. **distill**  — a recurring/successful episode pattern is stored as a
+//!      procedure (`store_procedure*`; see `memory_consolidation::distillation`).
+//!   2. **recall**   — `recall_procedure(query, limit)` returns matching
+//!      procedures ordered by `usage_count` **descending** (the library's
+//!      `search_procedures` sorts reused procedures first), so reuse influences
+//!      what is surfaced.
+//!   3. **reinforce**— `reinforce_access(id, MemoryKind::Procedure)` bumps a
+//!      recalled procedure's persisted `usage_count` at apply time
+//!      (`memory_consolidation::reinforce_prepared_context`).
+//!
+//! Existing tests cover each half *in isolation* (`tests_ranked_episodic` proves
+//! the `usage_count` increment; the library proves the usage sort). These tests
+//! close that coverage gap by asserting the halves COMPOSE end-to-end through the
+//! Simard adapter: reinforcing a recalled procedure must change a *later*
+//! recall's ORDER — i.e. reuse feeds back into recall ("close the loop, don't
+//! just store"). They are regression guards — green while the loop is closed, red
+//! if a refactor (an unranked search, a dropped reinforcement, or a library bump
+//! that drops the usage sort) silently re-opens it.
+//!
+//! The genuinely *new* #2441/#2458 behavior — gating distillation on a verified
+//! signal (#2441) and promoting recurring failures to lessons (#2458) — lives in
+//! [`crate::memory_consolidation::reflection_lessons`] (with memory-backed
+//! acceptance tests alongside it).
+
+use super::{CognitiveMemoryOps, LibraryCognitiveMemory, MemoryKind};
+
+fn test_mem() -> LibraryCognitiveMemory {
+    LibraryCognitiveMemory::in_memory().expect("in-memory DB should create")
+}
+
+fn steps() -> Vec<String> {
+    vec!["step one".to_string(), "step two".to_string()]
+}
+
+fn prereqs() -> Vec<String> {
+    Vec::new()
+}
+
+/// Find a recalled procedure's raw node id by name (the id `reinforce_access`
+/// consumes for `MemoryKind::Procedure`).
+fn node_id_for<'a>(
+    recalled: &'a [crate::memory_cognitive::CognitiveProcedure],
+    name: &str,
+) -> &'a str {
+    recalled
+        .iter()
+        .find(|p| p.name == name)
+        .unwrap_or_else(|| panic!("procedure {name:?} must be present in recall"))
+        .node_id
+        .as_str()
+}
+
+/// Rank-by-reuse: two procedures that match the query `"merge"` with equal token
+/// overlap differ ONLY in `usage_count`; the more-reused one must surface first
+/// through the Simard adapter's `recall_procedure`. Guards that reuse ordering is
+/// observable end-to-end (not just that `usage_count` increments).
+#[test]
+fn recall_procedure_ranks_more_used_procedure_first() {
+    let mem = test_mem();
+    mem.store_procedure("merge conflict resolver", &steps(), &prereqs())
+        .expect("store a");
+    mem.store_procedure("merge branch updater", &steps(), &prereqs())
+        .expect("store b");
+
+    // Reuse "merge branch updater" three times; the other stays at usage_count 0.
+    let initial = mem.recall_procedure("merge", 10).expect("recall");
+    let reused_id = node_id_for(&initial, "merge branch updater").to_string();
+    for _ in 0..3 {
+        mem.reinforce_access(&reused_id, MemoryKind::Procedure)
+            .expect("reinforce reused procedure");
+    }
+
+    let ranked = mem
+        .recall_procedure("merge", 10)
+        .expect("recall after reuse");
+    let names: Vec<&str> = ranked.iter().map(|p| p.name.as_str()).collect();
+    assert!(
+        names.contains(&"merge branch updater") && names.contains(&"merge conflict resolver"),
+        "both equally-matching procedures must be recalled, got {names:?}"
+    );
+    assert_eq!(
+        ranked[0].name, "merge branch updater",
+        "the more-reused procedure must rank first; got {names:?}"
+    );
+}
+
+/// Closed-loop end-to-end (#2441): applying (reusing) the currently lowest-ranked
+/// matching procedure enough times must lift it to the TOP of a later recall —
+/// proving reuse feeds back into recall ordering through the Simard adapter.
+#[test]
+fn reuse_feeds_back_into_recall_order_closes_the_loop() {
+    let mem = test_mem();
+    mem.store_procedure("merge conflict resolver", &steps(), &prereqs())
+        .expect("store a");
+    mem.store_procedure("merge branch updater", &steps(), &prereqs())
+        .expect("store b");
+
+    let first = mem.recall_procedure("merge", 10).expect("recall");
+    assert!(
+        first.len() >= 2,
+        "both procedures recalled, got {}",
+        first.len()
+    );
+
+    // "Apply" whichever procedure is currently ranked LAST, repeatedly.
+    let underdog_name = first.last().expect("non-empty").name.clone();
+    let underdog_id = first.last().expect("non-empty").node_id.clone();
+    for _ in 0..5 {
+        mem.reinforce_access(&underdog_id, MemoryKind::Procedure)
+            .expect("reinforce applied procedure");
+    }
+
+    let second = mem.recall_procedure("merge", 10).expect("recall again");
+    assert_eq!(
+        second[0].name, underdog_name,
+        "a heavily-reused procedure must climb to the top of recall — reuse must \
+         feed back into ranking, closing the episodic->procedural loop"
+    );
+}
+
+/// A freshly distilled procedure (`usage_count == 0`) must remain recallable for
+/// its FIRST reuse: a usage-ordered recall must not drop zero-usage matches (they
+/// simply sort after reused ones). Guards that a future scoring change can't make
+/// brand-new procedures unrecallable and re-open the loop on first use.
+#[test]
+fn recall_surfaces_zero_usage_procedure_smoothing_guard() {
+    let mem = test_mem();
+    mem.store_procedure("bootstrap fresh skill", &steps(), &prereqs())
+        .expect("store");
+
+    let recalled = mem.recall_procedure("bootstrap", 10).expect("recall");
+    assert!(
+        recalled
+            .iter()
+            .any(|p| p.name == "bootstrap fresh skill" && p.usage_count == 0),
+        "a usage_count==0 procedure must remain recallable for its first reuse; got {:?}",
+        recalled
+            .iter()
+            .map(|p| (&p.name, p.usage_count))
+            .collect::<Vec<_>>()
+    );
+}

--- a/src/memory_consolidation/mod.rs
+++ b/src/memory_consolidation/mod.rs
@@ -366,6 +366,11 @@ pub fn preparation_memory_operations_with_active_slugs_phased(
 /// write is logged and skipped rather than failing the cycle. Backends without
 /// access tracking (legacy bridge, mocks) get the trait's no-op default, so this
 /// is a silent no-op there.
+///
+/// Applying a recalled procedure also emits the `brain_skill_reuse` metric
+/// (#2441) via [`reflection_lessons::record_skill_reuse`] — the measurable half
+/// of "recall/apply, don't just store". That emitter is itself best-effort and a
+/// `cfg!(test)` no-op.
 pub fn reinforce_prepared_context(memory: &dyn CognitiveMemoryOps, ctx: &PreparedContext) {
     let reinforce = |node_id: &str, kind: MemoryKind| {
         if let Err(e) = memory.reinforce_access(node_id, kind) {
@@ -377,6 +382,11 @@ pub fn reinforce_prepared_context(memory: &dyn CognitiveMemoryOps, ctx: &Prepare
     }
     for proc in &ctx.recalled_procedures {
         reinforce(&proc.node_id, MemoryKind::Procedure);
+        // #2441: applying a recalled procedure IS a skill reuse — emit the
+        // measurable `brain_skill_reuse` signal alongside the reinforcement that
+        // closes the recall->rerank loop. Best-effort and a `cfg!(test)` no-op
+        // inside the emitter, so the broad suite never writes metrics here.
+        reflection_lessons::record_skill_reuse(&proc.node_id, &proc.name);
     }
     for ep in &ctx.episodic_recall {
         reinforce(&ep.node_id, MemoryKind::Episode);
@@ -919,6 +929,13 @@ mod tests_pr_a;
 // recipe. See `docs/architecture/episode-distillation.md`.
 pub mod distillation;
 
+// Issues #2441/#2458: the verified-signal gate, failure→lesson distillation, and
+// loop metrics that close the episodic→procedural learning loop. Lessons are
+// name-prefixed procedures (`lesson:<goal_type>:<error_class>`); all learning
+// entry points are no-ops on `Verdict::Unverified`. See
+// `docs/reference/procedural-learning-loop.md`.
+pub mod reflection_lessons;
+
 // Issue #2327: episode-ingestion classifier — the deterministic policy that
 // runs before every `store_episode` intake site, dropping operational noise,
 // down-scoping bookkeeping, and storing meaningful episodics with
@@ -953,3 +970,10 @@ mod classifier_tests;
 // / DistillReport.procedure_count) that stores procedures with provenance.
 #[cfg(test)]
 mod promotion_scheduler_tests;
+
+// Issues #2441/#2458: memory-backed acceptance tests for the failure→lesson half
+// of the procedural-learning loop (reflection storage, recurrence-gated lesson
+// distillation, the load-bearing `Unverified` no-op). The pure gate /
+// normalization / metric contracts live in `reflection_lessons`'s inline tests.
+#[cfg(test)]
+mod tests_reflection_lessons;

--- a/src/memory_consolidation/reflection_lessons.rs
+++ b/src/memory_consolidation/reflection_lessons.rs
@@ -1,0 +1,532 @@
+//! Verified-signal gate + failure→lesson distillation for the procedural-learning
+//! loop (issues #2441, #2458).
+//!
+//! This module is the small, pure-where-possible policy layer that closes the
+//! episodic→procedural loop:
+//!
+//! * **#2441 (skill reuse):** on an externally *verified* success the successful
+//!   action sequence is distilled into a reusable procedure (a "skill"), and
+//!   *applying* a recalled procedure emits [`record_skill_reuse`] — the
+//!   measurable half of "reuse, don't just store".
+//! * **#2458 (failure→lesson):** on an externally *verified* failure a verbal
+//!   Reflexion-style reflection is stored ([`record_failure_reflection`]); when
+//!   the same `(goal_type, error_class)` failure has **recurred**
+//!   (`>= LESSON_RECURRENCE_THRESHOLD`) it is distilled into a `lesson:` procedure
+//!   ([`maybe_distill_lesson`]). A one-off failure must NOT become a lesson.
+//!
+//! ## Load-bearing invariant (R10)
+//!
+//! Every learning entry point takes a [`Verdict`] and is a **no-op on
+//! [`Verdict::Unverified`]**. The verdict is sourced from a real external signal
+//! ([`verified_outcome`] maps an engineer-loop [`VerificationReport`]); the
+//! brain's own self-judged `ActionOutcome.success` is never the gate. When no
+//! external signal is available the loop learns nothing (fail-safe OFF). This is
+//! the caveat both issues call out (cf. *LLMs Cannot Self-Correct Yet*).
+//!
+//! ## Lessons are name-prefixed procedures, not a new node type
+//!
+//! A lesson is an ordinary [`CognitiveProcedure`](crate::memory_cognitive::CognitiveProcedure)
+//! whose name follows the reserved `lesson:<goal_type>:<error_class>` convention
+//! ([`lesson_name`]). This keeps the change additive: the `CognitiveMemoryOps`
+//! trait and the procedure schema are unchanged, lessons co-rank with skills by
+//! `usage_count`, and `is_lesson(name)` is a pure prefix check used by metrics.
+//!
+//! ## Metrics
+//!
+//! Each metric pairs a **pure context builder** (unit-tested, no I/O) with a
+//! best-effort emitter that is a no-op under `cfg!(test)` so the broad test
+//! suite never writes to `~/.simard/metrics/metrics.jsonl` — mirroring
+//! [`super::distillation`]'s reliability-gate metric.
+
+use crate::cognitive_memory::CognitiveMemoryOps;
+use crate::engineer_loop::VerificationReport;
+use crate::error::SimardResult;
+
+/// External verification verdict for an action sequence (#2441/#2458).
+///
+/// Sourced from a real outside signal (engineer-loop [`VerificationReport`], a
+/// verified subprocess exit, or a gym eval) — never from the model's own
+/// `ActionOutcome.success`. [`Verdict::Unverified`] is the fail-safe default:
+/// when no external signal is available, the loop learns nothing.
+///
+/// Intentionally distinct from the unrelated `stewardship::merge_judge::Verdict`;
+/// the two never share a scope and are always module-qualified.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Verdict {
+    /// An external check confirmed success → distil/reinforce a skill.
+    VerifiedSuccess,
+    /// An external check confirmed failure → reflect, maybe distil a lesson.
+    /// `error_class` is the normalized failure class (e.g. `cargo_test_failed`).
+    VerifiedFailure {
+        /// Normalized failure category used as part of the recurrence key.
+        error_class: String,
+    },
+    /// No external signal available → learn nothing (fail-safe).
+    Unverified,
+}
+
+/// Minimum number of `(goal_type, error_class)` reflections before a recurring
+/// failure is distilled into a `lesson:` procedure (AMB-6). `1` would turn every
+/// one-off failure into a lesson; `2` is the smallest value that excludes
+/// singletons.
+pub const LESSON_RECURRENCE_THRESHOLD: u32 = 2;
+
+/// Environment override for the lesson recurrence threshold (mirrors the
+/// distillation scheduler's `SIMARD_DISTILL_*` knobs).
+pub const LESSON_RECURRENCE_THRESHOLD_ENV: &str = "SIMARD_LESSON_RECURRENCE_THRESHOLD";
+
+/// Reserved name prefix marking a procedure as a failure-derived lesson.
+pub const LESSON_NAME_PREFIX: &str = "lesson:";
+
+// ── verified-signal gate ────────────────────────────────────────────────────
+
+/// #2441 gate: distil the successful action sequence into a reusable skill only
+/// on a verified success. `VerifiedFailure`/`Unverified` => `false` (fail-safe).
+pub fn should_distill_skill(verdict: &Verdict) -> bool {
+    matches!(verdict, Verdict::VerifiedSuccess)
+}
+
+/// #2458 gate: promote a failure reflection to a procedural lesson only when the
+/// verdict is a `VerifiedFailure` AND the `(goal_type, error_class)` failure has
+/// recurred `recurrence_count >= threshold` times. Success/unverified verdicts —
+/// and failures below the threshold (one-offs) — never produce a lesson.
+pub fn should_distill_lesson(verdict: &Verdict, recurrence_count: u32, threshold: u32) -> bool {
+    matches!(verdict, Verdict::VerifiedFailure { .. }) && recurrence_count >= threshold
+}
+
+/// Derive the learning gate from an external verification report (AC-10).
+///
+/// Conservative — anything that is not an unambiguous external pass/fail becomes
+/// [`Verdict::Unverified`]:
+///
+/// - `status` of `passed` / `verified` / `success` (case-insensitive) **and** at
+///   least one recorded check → [`Verdict::VerifiedSuccess`].
+/// - `status` of `failed` / `error` → [`Verdict::VerifiedFailure`] with
+///   `error_class` derived from the first failing check (or the summary),
+///   normalized via [`normalize_error_class`].
+/// - anything else (empty/`skipped`/`unverified`/`unknown` status, or no checks)
+///   → [`Verdict::Unverified`].
+pub fn verified_outcome(report: &VerificationReport) -> Verdict {
+    let status = report.status.trim().to_lowercase();
+    match status.as_str() {
+        "passed" | "verified" | "success" if !report.checks.is_empty() => Verdict::VerifiedSuccess,
+        "failed" | "error" => {
+            let raw = report
+                .checks
+                .first()
+                .map(String::as_str)
+                .filter(|s| !s.trim().is_empty())
+                .unwrap_or(report.summary.as_str());
+            Verdict::VerifiedFailure {
+                error_class: normalize_error_class(raw),
+            }
+        }
+        _ => Verdict::Unverified,
+    }
+}
+
+// ── normalization + lesson naming ───────────────────────────────────────────
+
+/// Normalize an objective string into a goal-type key: lowercased with
+/// non-alphanumeric runs collapsed to single `-` (AC-11). Deterministic and
+/// idempotent (`-` is itself non-alphanumeric, so re-splitting reproduces the
+/// same tokens).
+pub fn normalize_goal_type(objective: &str) -> String {
+    join_alnum_tokens(objective, '-')
+}
+
+/// Normalize a raw failure descriptor into an error-class key: lowercased with
+/// non-alphanumeric runs collapsed to single `_` (AC-11). Deterministic and
+/// idempotent (e.g. `"Cargo Test FAILED"` → `"cargo_test_failed"`).
+pub fn normalize_error_class(raw: &str) -> String {
+    join_alnum_tokens(raw, '_')
+}
+
+/// Lowercase, split on non-alphanumeric runs, drop empties, and rejoin with
+/// `sep`. The shared engine behind [`normalize_goal_type`] / [`normalize_error_class`].
+fn join_alnum_tokens(raw: &str, sep: char) -> String {
+    raw.to_lowercase()
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .filter(|t| !t.is_empty())
+        .collect::<Vec<_>>()
+        .join(&sep.to_string())
+}
+
+/// Compose the canonical `lesson:<goal_type>:<error_class>` procedure name. Both
+/// keys are normalized first so the same logical failure always maps to one name.
+pub fn lesson_name(goal_type: &str, error_class: &str) -> String {
+    format!(
+        "{LESSON_NAME_PREFIX}{}:{}",
+        normalize_goal_type(goal_type),
+        normalize_error_class(error_class),
+    )
+}
+
+/// `true` if `name` is a lesson (failure-derived) procedure.
+pub fn is_lesson(name: &str) -> bool {
+    name.starts_with(LESSON_NAME_PREFIX)
+}
+
+/// `skill` / `lesson` kind label for a procedure name (used by the metrics).
+pub fn procedure_kind(name: &str) -> &'static str {
+    if is_lesson(name) { "lesson" } else { "skill" }
+}
+
+// ── reflection text + recurrence marker ─────────────────────────────────────
+
+/// A unique, fully-delimited content marker keyed by `(goal_type, error_class)`.
+/// Embedded in every reflection episode so [`count_recurring_failures`] can find
+/// exactly the reflections for one logical failure via a substring search. The
+/// surrounding brackets make the match collision-safe across key prefixes
+/// (`fix` vs `fix-ci`).
+fn reflection_marker(goal_type: &str, error_class: &str) -> String {
+    format!(
+        "[reflect-key={}|{}]",
+        normalize_goal_type(goal_type),
+        normalize_error_class(error_class),
+    )
+}
+
+/// Build the verbal reflection body (attempted / external verdict / next time).
+/// Pure and deterministic — extracted for unit testing (AC-4).
+pub fn reflection_text(objective: &str, error_class: &str, hint: &str) -> String {
+    format!(
+        "Reflection (verified failure). Attempted: {objective}. \
+         External verdict: failed ({error_class}). Next time: {hint}.",
+    )
+}
+
+// ── memory-backed entry points (all no-ops on Unverified, R10) ──────────────
+
+/// Generate and store a verbal failure reflection for a *verified* failure as an
+/// episodic note (source label `reflection:failure`), keyed by
+/// `(goal_type, error_class)` so [`count_recurring_failures`] can find it
+/// (#2458, AC-4).
+///
+/// No-op (returns `Ok(None)`) unless `verdict` is [`Verdict::VerifiedFailure`].
+/// Returns the stored episode id — the provenance anchor for a future lesson.
+pub fn record_failure_reflection(
+    memory: &dyn CognitiveMemoryOps,
+    objective: &str,
+    verdict: &Verdict,
+    hint: &str,
+) -> SimardResult<Option<String>> {
+    let Verdict::VerifiedFailure { error_class } = verdict else {
+        return Ok(None);
+    };
+    let goal_type = normalize_goal_type(objective);
+    let marker = reflection_marker(&goal_type, error_class);
+    let content = format!("{} {marker}", reflection_text(objective, error_class, hint));
+    let metadata = serde_json::json!({
+        "kind": "reflection",
+        "failure": true,
+        "goal_type": goal_type,
+        "error_class": error_class,
+    });
+    let id = memory.store_episode(&content, "reflection:failure", Some(&metadata))?;
+    Ok(Some(id))
+}
+
+/// Count stored `reflection:failure` episodes recorded for this
+/// `(goal_type, error_class)` key (#2458). Implemented as an exact-marker
+/// substring search so it is collision-safe across key prefixes.
+pub fn count_recurring_failures(
+    memory: &dyn CognitiveMemoryOps,
+    goal_type: &str,
+    error_class: &str,
+) -> SimardResult<u32> {
+    let marker = reflection_marker(goal_type, error_class);
+    let hits = memory.search_episodes_by_keywords(std::slice::from_ref(&marker), u32::MAX)?;
+    let count = hits.iter().filter(|e| e.content.contains(&marker)).count();
+    Ok(count as u32)
+}
+
+/// `true` if a `lesson:<goal_type>:<error_class>` procedure already exists
+/// (#2458). Uses exact-name equality on recall hits (mirrors `procedure_exists`,
+/// #2298), not a bare `CONTAINS` emptiness check.
+pub fn has_lesson_for(
+    memory: &dyn CognitiveMemoryOps,
+    goal_type: &str,
+    error_class: &str,
+) -> SimardResult<bool> {
+    memory.procedure_exists(&lesson_name(goal_type, error_class))
+}
+
+/// Distil a lesson from recurring reflections, gated on recurrence (#2458).
+///
+/// Returns `Ok(None)` when the verdict is not a [`Verdict::VerifiedFailure`] or
+/// the recurrence count is `< threshold` (a one-off failure, AC-6). When the
+/// count is `>= threshold` (AC-5) it stores a `lesson:<goal_type>:<error_class>`
+/// procedure via `store_procedure_with_provenance` (linking the source
+/// reflection episodes with `PROCEDURE_DERIVES_FROM` edges, #2325) and returns
+/// the lesson node id. Storing is idempotent by name (#2298): a recurring
+/// failure reinforces the existing lesson's `usage_count` rather than
+/// duplicating it. A *newly* created lesson emits `brain_new_procedure`.
+pub fn maybe_distill_lesson(
+    memory: &dyn CognitiveMemoryOps,
+    verdict: &Verdict,
+    objective: &str,
+    threshold: u32,
+    source_episode_ids: &[String],
+) -> SimardResult<Option<String>> {
+    let Verdict::VerifiedFailure { error_class } = verdict else {
+        return Ok(None);
+    };
+    let goal_type = normalize_goal_type(objective);
+    let count = count_recurring_failures(memory, &goal_type, error_class)?;
+    if !should_distill_lesson(verdict, count, threshold) {
+        return Ok(None);
+    }
+    let name = lesson_name(&goal_type, error_class);
+    let newly = !memory.procedure_exists(&name)?;
+    let steps = vec![
+        format!(
+            "Recurring failure ({count}x) on goal-type '{goal_type}' with error \
+             class '{error_class}'. Recall this lesson before re-attempting."
+        ),
+        "Inspect the prior reflections (PROCEDURE_DERIVES_FROM) before acting.".to_string(),
+    ];
+    let id = memory.store_procedure_with_provenance(&name, &steps, &[], source_episode_ids)?;
+    if newly {
+        record_new_procedure(&id, &name);
+    }
+    Ok(Some(id))
+}
+
+// ── metrics ─────────────────────────────────────────────────────────────────
+
+/// `brain_skill_reuse` — a recalled procedure was applied and reinforced (#2441).
+pub const SKILL_REUSE_METRIC: &str = "brain_skill_reuse";
+
+/// `brain_new_procedure` — a new skill or lesson procedure was stored (#2441/#2458).
+pub const NEW_PROCEDURE_METRIC: &str = "brain_new_procedure";
+
+/// `brain_repeat_failure` — a verified failure recurred on a goal-type that
+/// already carries a lesson (#2458): the loop's self-regression signal.
+pub const REPEAT_FAILURE_METRIC: &str = "brain_repeat_failure";
+
+/// Build the `{procedure_id, kind}` context for a `brain_skill_reuse` data point.
+/// Pure — no I/O.
+pub fn skill_reuse_context(procedure_id: &str, procedure_name: &str) -> String {
+    serde_json::json!({
+        "procedure_id": procedure_id,
+        "kind": procedure_kind(procedure_name),
+    })
+    .to_string()
+}
+
+/// Build the `{procedure_id, name, kind}` context for a `brain_new_procedure`
+/// data point. Pure — no I/O.
+pub fn new_procedure_context(procedure_id: &str, procedure_name: &str) -> String {
+    serde_json::json!({
+        "procedure_id": procedure_id,
+        "name": procedure_name,
+        "kind": procedure_kind(procedure_name),
+    })
+    .to_string()
+}
+
+/// Build the `{goal_type, error_class, lesson_id}` context for a
+/// `brain_repeat_failure` data point. Pure — no I/O. Keys are normalized first.
+pub fn repeat_failure_context(goal_type: &str, error_class: &str, lesson_id: &str) -> String {
+    serde_json::json!({
+        "goal_type": normalize_goal_type(goal_type),
+        "error_class": normalize_error_class(error_class),
+        "lesson_id": lesson_id,
+    })
+    .to_string()
+}
+
+/// Emit `brain_skill_reuse` (= `1.0`) for one applied recalled procedure (#2441).
+///
+/// Best-effort: a metrics-write failure is logged, never propagated — the reuse
+/// already happened. A `cfg!(test)` no-op so the broad suite never writes
+/// metrics (the metric *shape* is covered by [`skill_reuse_context`]); mirrors
+/// [`super::distillation`]'s reliability-gate metric.
+pub fn record_skill_reuse(procedure_id: &str, procedure_name: &str) {
+    emit(
+        SKILL_REUSE_METRIC,
+        &skill_reuse_context(procedure_id, procedure_name),
+    );
+}
+
+/// Emit `brain_new_procedure` (= `1.0`) when a new skill/lesson procedure is
+/// first stored (#2441/#2458). Best-effort + `cfg!(test)` no-op.
+pub fn record_new_procedure(procedure_id: &str, procedure_name: &str) {
+    emit(
+        NEW_PROCEDURE_METRIC,
+        &new_procedure_context(procedure_id, procedure_name),
+    );
+}
+
+/// Emit `brain_repeat_failure` (= `1.0`) when a verified failure recurs on a
+/// goal-type that already carries a lesson (#2458). Best-effort + `cfg!(test)`
+/// no-op. The caller establishes the precondition via [`has_lesson_for`].
+pub fn record_repeat_failure(goal_type: &str, error_class: &str, lesson_id: &str) {
+    emit(
+        REPEAT_FAILURE_METRIC,
+        &repeat_failure_context(goal_type, error_class, lesson_id),
+    );
+}
+
+/// Shared best-effort, `cfg!(test)`-guarded metric write for this module.
+fn emit(metric: &str, context: &str) {
+    if cfg!(test) {
+        return;
+    }
+    if let Err(e) = crate::self_metrics::record_metric(metric, 1.0, context) {
+        tracing::warn!(
+            target: "simard::reflection_lessons",
+            metric,
+            error = %e,
+            "record_metric failed (loop event still occurred)",
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cargo_failure() -> Verdict {
+        Verdict::VerifiedFailure {
+            error_class: "cargo_test_failed".to_string(),
+        }
+    }
+
+    #[test]
+    fn skill_distilled_only_on_verified_success() {
+        assert!(should_distill_skill(&Verdict::VerifiedSuccess));
+        assert!(!should_distill_skill(&cargo_failure()));
+        assert!(!should_distill_skill(&Verdict::Unverified));
+    }
+
+    #[test]
+    fn lesson_distilled_only_on_recurring_verified_failure() {
+        assert!(!should_distill_lesson(
+            &cargo_failure(),
+            1,
+            LESSON_RECURRENCE_THRESHOLD
+        ));
+        assert!(should_distill_lesson(
+            &cargo_failure(),
+            LESSON_RECURRENCE_THRESHOLD,
+            LESSON_RECURRENCE_THRESHOLD
+        ));
+        assert!(should_distill_lesson(
+            &cargo_failure(),
+            5,
+            LESSON_RECURRENCE_THRESHOLD
+        ));
+        assert!(!should_distill_lesson(
+            &Verdict::VerifiedSuccess,
+            5,
+            LESSON_RECURRENCE_THRESHOLD
+        ));
+        assert!(!should_distill_lesson(
+            &Verdict::Unverified,
+            5,
+            LESSON_RECURRENCE_THRESHOLD
+        ));
+    }
+
+    #[test]
+    fn recurrence_threshold_excludes_singletons() {
+        assert_eq!(LESSON_RECURRENCE_THRESHOLD, 2);
+    }
+
+    /// AC-10: `verified_outcome` maps pass/fail/unknown reports to the right
+    /// verdict, conservatively defaulting to `Unverified`.
+    #[test]
+    fn verified_outcome_mapping() {
+        let pass = VerificationReport {
+            status: "verified".to_string(),
+            summary: "ok".to_string(),
+            checks: vec!["git: 1 new commit".to_string()],
+        };
+        assert_eq!(verified_outcome(&pass), Verdict::VerifiedSuccess);
+
+        // pass status but no checks → not trustworthy → Unverified.
+        let pass_no_checks = VerificationReport {
+            status: "passed".to_string(),
+            summary: String::new(),
+            checks: vec![],
+        };
+        assert_eq!(verified_outcome(&pass_no_checks), Verdict::Unverified);
+
+        let fail = VerificationReport {
+            status: "FAILED".to_string(),
+            summary: "cargo test failed".to_string(),
+            checks: vec!["cargo test: 3 failed".to_string()],
+        };
+        assert_eq!(
+            verified_outcome(&fail),
+            Verdict::VerifiedFailure {
+                error_class: "cargo_test_3_failed".to_string()
+            }
+        );
+
+        for s in ["unverified", "skipped", "", "unknown"] {
+            let r = VerificationReport {
+                status: s.to_string(),
+                summary: "x".to_string(),
+                checks: vec!["c".to_string()],
+            };
+            assert_eq!(verified_outcome(&r), Verdict::Unverified, "status {s:?}");
+        }
+    }
+
+    /// AC-11: normalization is deterministic and idempotent.
+    #[test]
+    fn normalization_is_idempotent() {
+        let gt = normalize_goal_type("Fix CI linker OOM!");
+        assert_eq!(gt, "fix-ci-linker-oom");
+        assert_eq!(normalize_goal_type(&gt), gt);
+
+        let ec = normalize_error_class("Cargo Test FAILED");
+        assert_eq!(ec, "cargo_test_failed");
+        assert_eq!(normalize_error_class(&ec), ec);
+    }
+
+    #[test]
+    fn lesson_name_and_is_lesson() {
+        let name = lesson_name("Fix CI", "Cargo Test FAILED");
+        assert_eq!(name, "lesson:fix-ci:cargo_test_failed");
+        assert!(is_lesson(&name));
+        assert!(!is_lesson("merge branch updater"));
+        assert_eq!(procedure_kind(&name), "lesson");
+        assert_eq!(procedure_kind("merge branch updater"), "skill");
+    }
+
+    #[test]
+    fn reflection_text_is_structured() {
+        let t = reflection_text("rebuild index", "build_failed", "pin the toolchain");
+        assert!(t.contains("Attempted: rebuild index"));
+        assert!(t.contains("failed (build_failed)"));
+        assert!(t.contains("Next time: pin the toolchain"));
+    }
+
+    #[test]
+    fn metric_contexts_have_expected_shapes() {
+        let reuse: serde_json::Value =
+            serde_json::from_str(&skill_reuse_context("p1", "lesson:g:e")).unwrap();
+        assert_eq!(reuse["procedure_id"], "p1");
+        assert_eq!(reuse["kind"], "lesson");
+
+        let newp: serde_json::Value =
+            serde_json::from_str(&new_procedure_context("p2", "deploy-service")).unwrap();
+        assert_eq!(newp["procedure_id"], "p2");
+        assert_eq!(newp["name"], "deploy-service");
+        assert_eq!(newp["kind"], "skill");
+
+        let rep: serde_json::Value =
+            serde_json::from_str(&repeat_failure_context("Fix CI", "Cargo FAILED", "p3")).unwrap();
+        assert_eq!(rep["goal_type"], "fix-ci");
+        assert_eq!(rep["error_class"], "cargo_failed");
+        assert_eq!(rep["lesson_id"], "p3");
+
+        assert_eq!(SKILL_REUSE_METRIC, "brain_skill_reuse");
+        assert_eq!(NEW_PROCEDURE_METRIC, "brain_new_procedure");
+        assert_eq!(REPEAT_FAILURE_METRIC, "brain_repeat_failure");
+    }
+}

--- a/src/memory_consolidation/tests_reflection_lessons.rs
+++ b/src/memory_consolidation/tests_reflection_lessons.rs
@@ -1,0 +1,226 @@
+//! Memory-backed acceptance tests for the failure→lesson half of the
+//! procedural-learning loop (issue #2458), exercised through the Simard
+//! [`CognitiveMemoryOps`] surface against `LibraryCognitiveMemory::in_memory()`
+//! (the sole real backend).
+//!
+//! These pin the acceptance contract from
+//! `docs/reference/procedural-learning-loop.md`:
+//!
+//! | AC | guard |
+//! |----|-------|
+//! | AC-4 | a `VerifiedFailure` writes a `reflection:failure` episode |
+//! | AC-5 | a recurring `(goal_type, error_class)` (>= threshold) becomes a `lesson:` procedure |
+//! | AC-6 | a one-off failure (count = 1) does **not** become a lesson |
+//! | AC-7 | a lesson is recallable for a later objective mentioning the goal-type |
+//! | AC-8 | `Verdict::Unverified` (and `VerifiedSuccess`) distil/reflect nothing |
+//!
+//! The pure gate/normalization/metric contracts (AC-10, AC-11) live in the
+//! module's inline `#[cfg(test)] mod tests`.
+
+use super::reflection_lessons::{
+    LESSON_RECURRENCE_THRESHOLD, Verdict, count_recurring_failures, has_lesson_for, lesson_name,
+    maybe_distill_lesson, record_failure_reflection,
+};
+use crate::cognitive_memory::{CognitiveMemoryOps, LibraryCognitiveMemory};
+
+fn mem() -> LibraryCognitiveMemory {
+    LibraryCognitiveMemory::in_memory().expect("in-memory DB should create")
+}
+
+fn cargo_failure() -> Verdict {
+    Verdict::VerifiedFailure {
+        error_class: "cargo_test_failed".to_string(),
+    }
+}
+
+const OBJECTIVE: &str = "Fix CI linker OOM in the release build";
+
+/// AC-4: a verified failure stores a `reflection:failure` episode that
+/// `count_recurring_failures` can find by its (goal_type, error_class) key.
+#[test]
+fn verified_failure_writes_reflection() {
+    let m = mem();
+    let verdict = cargo_failure();
+
+    let id = record_failure_reflection(&m, OBJECTIVE, &verdict, "pin the toolchain")
+        .expect("reflection store ok");
+    assert!(id.is_some(), "a verified failure must write a reflection");
+
+    let count = count_recurring_failures(
+        &m,
+        "fix-ci-linker-oom-in-the-release-build",
+        "cargo_test_failed",
+    )
+    .expect("count ok");
+    assert_eq!(count, 1, "exactly the one reflection just stored");
+}
+
+/// AC-8: neither an unverified outcome nor a verified *success* writes a
+/// reflection — the fail-safe gate (R10) learns nothing without a real failure
+/// signal.
+#[test]
+fn unverified_and_success_write_no_reflection() {
+    let m = mem();
+
+    assert!(
+        record_failure_reflection(&m, OBJECTIVE, &Verdict::Unverified, "h")
+            .expect("ok")
+            .is_none(),
+        "unverified must not reflect"
+    );
+    assert!(
+        record_failure_reflection(&m, OBJECTIVE, &Verdict::VerifiedSuccess, "h")
+            .expect("ok")
+            .is_none(),
+        "a verified success must not reflect"
+    );
+    let count = count_recurring_failures(
+        &m,
+        "fix-ci-linker-oom-in-the-release-build",
+        "cargo_test_failed",
+    )
+    .expect("count ok");
+    assert_eq!(count, 0);
+}
+
+/// AC-6: a one-off failure (count = 1, below the default threshold of 2) does
+/// NOT become a lesson — recurrence gating keeps procedural memory clean.
+#[test]
+fn one_off_failure_is_not_a_lesson() {
+    let m = mem();
+    let verdict = cargo_failure();
+
+    let ep = record_failure_reflection(&m, OBJECTIVE, &verdict, "pin toolchain")
+        .expect("ok")
+        .expect("some id");
+
+    let lesson = maybe_distill_lesson(&m, &verdict, OBJECTIVE, LESSON_RECURRENCE_THRESHOLD, &[ep])
+        .expect("distill ok");
+    assert!(
+        lesson.is_none(),
+        "a single failure must not become a lesson"
+    );
+    assert!(
+        !has_lesson_for(
+            &m,
+            "fix-ci-linker-oom-in-the-release-build",
+            "cargo_test_failed"
+        )
+        .expect("ok"),
+        "no lesson should exist after one failure"
+    );
+}
+
+/// AC-5 + AC-7: a recurring failure (>= threshold reflections) becomes a
+/// retrievable `lesson:` procedure that a later matching objective recalls.
+#[test]
+fn recurring_failure_becomes_recallable_lesson() {
+    let m = mem();
+    let verdict = cargo_failure();
+
+    // Two verified failures on the same (goal_type, error_class).
+    let mut sources = Vec::new();
+    for _ in 0..LESSON_RECURRENCE_THRESHOLD {
+        let ep = record_failure_reflection(&m, OBJECTIVE, &verdict, "pin the toolchain")
+            .expect("ok")
+            .expect("some id");
+        sources.push(ep);
+    }
+
+    let lesson_id = maybe_distill_lesson(
+        &m,
+        &verdict,
+        OBJECTIVE,
+        LESSON_RECURRENCE_THRESHOLD,
+        &sources,
+    )
+    .expect("distill ok")
+    .expect("recurring failure must become a lesson");
+    assert!(!lesson_id.is_empty());
+
+    let goal_type = "fix-ci-linker-oom-in-the-release-build";
+    assert!(
+        has_lesson_for(&m, goal_type, "cargo_test_failed").expect("ok"),
+        "the lesson must exist after the recurrence threshold is reached"
+    );
+
+    // AC-7: a later objective sharing a goal-type token recalls the lesson.
+    let expected = lesson_name(goal_type, "cargo_test_failed");
+    let recalled = m.recall_procedure("linker", 10).expect("recall");
+    assert!(
+        recalled.iter().any(|p| p.name == expected),
+        "the lesson {expected:?} must surface for a related objective; got {:?}",
+        recalled.iter().map(|p| &p.name).collect::<Vec<_>>()
+    );
+}
+
+/// AC-8 (lesson path): `maybe_distill_lesson` is a no-op on `Unverified` even if
+/// reflections happen to exist — the gate is load-bearing, not advisory.
+#[test]
+fn unverified_distills_no_lesson_even_with_reflections() {
+    let m = mem();
+    let verdict = cargo_failure();
+    for _ in 0..LESSON_RECURRENCE_THRESHOLD {
+        record_failure_reflection(&m, OBJECTIVE, &verdict, "h").expect("ok");
+    }
+
+    let lesson = maybe_distill_lesson(
+        &m,
+        &Verdict::Unverified,
+        OBJECTIVE,
+        LESSON_RECURRENCE_THRESHOLD,
+        &[],
+    )
+    .expect("ok");
+    assert!(lesson.is_none(), "Unverified must distil nothing (R10)");
+}
+
+/// Lesson stores are idempotent by name (#2298): distilling the same recurring
+/// failure twice reinforces the single lesson rather than duplicating it.
+#[test]
+fn lesson_store_is_idempotent() {
+    let m = mem();
+    let verdict = cargo_failure();
+    for _ in 0..LESSON_RECURRENCE_THRESHOLD {
+        record_failure_reflection(&m, OBJECTIVE, &verdict, "h").expect("ok");
+    }
+
+    let first = maybe_distill_lesson(&m, &verdict, OBJECTIVE, LESSON_RECURRENCE_THRESHOLD, &[])
+        .expect("ok")
+        .expect("lesson");
+    let second = maybe_distill_lesson(&m, &verdict, OBJECTIVE, LESSON_RECURRENCE_THRESHOLD, &[])
+        .expect("ok")
+        .expect("lesson again");
+    assert_eq!(first, second, "idempotent store returns the same node id");
+
+    let goal_type = "fix-ci-linker-oom-in-the-release-build";
+    let expected = lesson_name(goal_type, "cargo_test_failed");
+    let matches = m
+        .recall_procedure("cargo", 50)
+        .expect("recall")
+        .into_iter()
+        .filter(|p| p.name == expected)
+        .count();
+    assert_eq!(matches, 1, "the lesson must not be duplicated");
+}
+
+/// The recurrence marker is key-scoped: reflections for one
+/// (goal_type, error_class) do not inflate another's count (collision-safe even
+/// across prefix-overlapping goal types).
+#[test]
+fn recurrence_count_is_key_scoped() {
+    let m = mem();
+    let v = cargo_failure();
+    record_failure_reflection(&m, "Fix CI", &v, "h").expect("ok");
+    record_failure_reflection(&m, "Fix CI runner flake", &v, "h").expect("ok");
+
+    assert_eq!(
+        count_recurring_failures(&m, "fix-ci", "cargo_test_failed").expect("ok"),
+        1,
+        "only the exact-key reflection counts, not the prefix-overlapping one"
+    );
+    assert_eq!(
+        count_recurring_failures(&m, "fix-ci-runner-flake", "cargo_test_failed").expect("ok"),
+        1
+    );
+}

--- a/src/ooda_loop/cycle.rs
+++ b/src/ooda_loop/cycle.rs
@@ -432,28 +432,38 @@ fn run_ooda_cycle_inner(
                     eprintln!("[simard] OODA consolidation: procedural recall failed: {e}");
                     false
                 });
-            if let Err(e) = bridges.memory.store_procedure(&proc_name, &steps, &[]) {
-                tracing::warn!(
-                    procedure_name = %proc_name,
-                    error = %e,
-                    "OODA consolidation: procedural memory store failed",
-                );
-                eprintln!("[simard] OODA consolidation: procedural memory failed: {e}");
-            } else if already_present {
-                eprintln!("[simard] OODA consolidation: reinforced procedure '{proc_name}'");
-            } else {
-                // ws2 #2295: structured tracing event in addition to the
-                // eprintln! line. The structured `procedure_name` field is
-                // written verbatim by every fmt layer (JSON and the
-                // default human formatter) and bypasses any line-length
-                // truncation a downstream log shipper might apply to the
-                // free-form message — making "is my trigger list
-                // truncated?" an answerable question from the journal.
-                tracing::info!(
-                    procedure_name = %proc_name,
-                    "OODA consolidation: stored procedure",
-                );
-                eprintln!("[simard] OODA consolidation: stored procedure '{proc_name}'");
+            match bridges.memory.store_procedure(&proc_name, &steps, &[]) {
+                Err(e) => {
+                    tracing::warn!(
+                        procedure_name = %proc_name,
+                        error = %e,
+                        "OODA consolidation: procedural memory store failed",
+                    );
+                    eprintln!("[simard] OODA consolidation: procedural memory failed: {e}");
+                }
+                Ok(_) if already_present => {
+                    eprintln!("[simard] OODA consolidation: reinforced procedure '{proc_name}'");
+                }
+                Ok(proc_id) => {
+                    // ws2 #2295: structured tracing event in addition to the
+                    // eprintln! line. The structured `procedure_name` field is
+                    // written verbatim by every fmt layer (JSON and the
+                    // default human formatter) and bypasses any line-length
+                    // truncation a downstream log shipper might apply to the
+                    // free-form message — making "is my trigger list
+                    // truncated?" an answerable question from the journal.
+                    tracing::info!(
+                        procedure_name = %proc_name,
+                        "OODA consolidation: stored procedure",
+                    );
+                    eprintln!("[simard] OODA consolidation: stored procedure '{proc_name}'");
+                    // #2441/#2458: a brand-new skill/lesson procedure was stored
+                    // (not a reinforcing re-store) — emit the brain_new_procedure
+                    // metric. Best-effort and a `cfg!(test)` no-op.
+                    crate::memory_consolidation::reflection_lessons::record_new_procedure(
+                        &proc_id, &proc_name,
+                    );
+                }
             }
         }
     }

--- a/src/ooda_loop/types.rs
+++ b/src/ooda_loop/types.rs
@@ -245,6 +245,11 @@ pub struct OodaConfig {
     /// 50). Issue #2327, R4.
     #[serde(default = "default_distill_interval_cycles")]
     pub distill_interval_cycles: u32,
+    /// Recurrence threshold before a repeated *verified* failure becomes a
+    /// `lesson:` procedure (`SIMARD_LESSON_RECURRENCE_THRESHOLD`, default 2).
+    /// Issues #2441/#2458. `1` would distil one-off failures (not recommended).
+    #[serde(default = "default_lesson_recurrence_threshold")]
+    pub lesson_recurrence_threshold: u32,
     /// AIMD adaptive scaler. Populated when `SIMARD_SCALING=auto`.
     /// Skipped during (de)serialization — reconstructed from env on boot.
     #[serde(skip)]
@@ -257,6 +262,10 @@ fn default_distill_min_episodes() -> u32 {
 
 fn default_distill_interval_cycles() -> u32 {
     crate::memory_consolidation::scheduler::DistillSchedule::DEFAULT_INTERVAL_CYCLES
+}
+
+fn default_lesson_recurrence_threshold() -> u32 {
+    crate::memory_consolidation::reflection_lessons::LESSON_RECURRENCE_THRESHOLD
 }
 
 impl Default for OodaConfig {
@@ -288,6 +297,10 @@ impl Default for OodaConfig {
             distill_interval_cycles: env_u32(
                 "SIMARD_DISTILL_INTERVAL_CYCLES",
                 default_distill_interval_cycles(),
+            ),
+            lesson_recurrence_threshold: env_u32(
+                crate::memory_consolidation::reflection_lessons::LESSON_RECURRENCE_THRESHOLD_ENV,
+                default_lesson_recurrence_threshold(),
             ),
             scaler,
         }
@@ -512,6 +525,20 @@ mod tests_ooda_config {
         assert_eq!(
             config.distill_interval_cycles, 50,
             "default distill interval must be 50 cycles"
+        );
+    }
+
+    // Issues #2441/#2458: the lesson recurrence threshold defaults to 2 (the
+    // smallest value that excludes one-off failures) with its env override unset.
+    #[serial_test::serial(cognitive_memory)]
+    #[test]
+    fn ooda_config_default_lesson_recurrence_threshold() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        unsafe { std::env::remove_var("SIMARD_LESSON_RECURRENCE_THRESHOLD") };
+        let config = OodaConfig::default();
+        assert_eq!(
+            config.lesson_recurrence_threshold, 2,
+            "default lesson recurrence threshold must be 2"
         );
     }
 


### PR DESCRIPTION
## Summary

Closes Simard's **episodic→procedural learning loop**, reusing the existing
distillation/recall infra. Adds a single cohesive policy module,
`memory_consolidation::reflection_lessons`, plus its tests, config, metrics, and
two honest production wirings. Addresses #2441 and #2458.

### #2441 — skill reuse (wired and live)
- `brain_skill_reuse` emitted at the apply-time reinforcement seam
  (`reinforce_prepared_context`): applying a recalled procedure **is** reuse.
- `brain_new_procedure` emitted when the OODA Act seam stores a *new* procedure.
- End-to-end loop guards (`tests_procedural_loop.rs`) prove recall → apply →
  rerank actually closes (a reused procedure climbs to the top of a later recall).

### #2458 — failure → lesson (implemented + tested; production trigger FU1-gated)
- `Verdict` verified-signal gate + `verified_outcome(&VerificationReport)`. Every
  learning entry point is a **no-op on `Unverified` (R10)** — never gated on
  self-judged `ActionOutcome.success`.
- `record_failure_reflection` / `count_recurring_failures` /
  `maybe_distill_lesson` / `has_lesson_for`: recurring (≥ threshold) verified
  failures become name-prefixed `lesson:<goal_type>:<error_class>` procedures
  (idempotent by name, #2298), recallable for later matching objectives; one-off
  failures do not.
- `brain_repeat_failure` metric surface;
  `OodaConfig.lesson_recurrence_threshold` (`SIMARD_LESSON_RECURRENCE_THRESHOLD`,
  default 2).

### Honest scope (FU1 boundary)
Both issues sequence after **FU1** (an external failure signal). Today the only
engineer-loop `VerificationReport` yields `verified`/`unverified`, never
`failed`, so `verified_outcome` never returns `VerifiedFailure` in production
yet — the failure-path mechanics are fully implemented and tested but their
production trigger is one `verified_outcome(...)` call away, deferred to FU1. The
loop is **never** gated on self-judged success. See the reference doc's
"OODA cycle wiring" and "Test → acceptance mapping" sections.

## Design notes
- **Additive**: lessons are name-prefixed procedures — no `CognitiveMemoryOps`
  trait, schema, snapshot, or IPC change.
- Metrics are best-effort and `cfg!(test)` no-ops (mirrors the distillation
  reliability-gate metric), so the suite never writes to `~/.simard/metrics`.

## Tests / gates
- 15 new `reflection_lessons` tests (AC-1..AC-8, AC-10, AC-11) + e2e loop guards — all green.
- Full lib test suite green (the only 2 failures on this dev box are a
  pre-existing `~/.simard` HOME-hermeticity issue in unrelated
  `ooda_brain::recipe_brain` tests; both pass with a clean HOME, as in CI).
- `cargo clippy --all-targets --all-features --locked -- -D warnings` clean.
- `cargo fmt --check` clean; `mkdocs build --strict` clean.
- Pre-push hooks (release race-subset tests + full clippy) passed on push.

No snapshot/architecture-snapshot docs; no live redeploy.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>