### PR TITLE
fix: de-flake known flaky tests — prompt_delivery env race (#2412) + goal-board state-root race (#2408, #2384)

### DIFF
--- a/docs/testing/cognitive-memory-serial-isolation.md
+++ b/docs/testing/cognitive-memory-serial-isolation.md
@@ -15,6 +15,7 @@ doc_type: reference
 related:
   - ./hermetic-tests.md
   - ./ci-resilient-test-patterns.md
+  - ./deflaking-known-flaky-tests.md
   - ./COVERAGE_BASELINE.md
   - ../reference/goal-board-api.md
   - ../reference/cognitive-memory-bridge-helpers.md

--- a/docs/testing/deflaking-known-flaky-tests.md
+++ b/docs/testing/deflaking-known-flaky-tests.md
@@ -1,0 +1,480 @@
+---
+title: De-flaking the known flaky tests (prompt-delivery env race + goal-board state-root race)
+description: >
+  How the three known-flaky tests were made deterministic under parallel
+  `cargo test`: the prompt_delivery env-var race (issue #2412) is closed by
+  sharing the prompt_delivery_env serial key on the two Auto-mode size tests,
+  and the goal-board state-root race (issues #2408 / #2384) is closed by
+  threading an explicit state root through the goal-CRUD handlers (the `_at`
+  cores) so the dashboard's read/write path never resolves the root ambiently
+  from the process environment during a test.
+last_updated: 2026-06-28
+review_schedule: when a new env-reading handler is added to the dashboard, or when serial_test is upgraded
+owner: simard
+doc_type: reference
+related:
+  - ./hermetic-tests.md
+  - ./cognitive-memory-serial-isolation.md
+  - ./ci-resilient-test-patterns.md
+  - ./COVERAGE_BASELINE.md
+  - ../reference/goal-board-api.md
+  - ../prompt-delivery.md
+---
+
+# De-flaking the known flaky tests
+
+This page documents the finished state of the work that made three known-flaky
+tests deterministic under parallel `cargo test`. It is the test-author and
+reviewer contract for the two isolation mechanisms that closed the flakes, and
+the verification gate that keeps them closed.
+
+The flakes and their fixes:
+
+| Issue | Flaky test | Root cause | Fix |
+| ----- | ---------- | ---------- | --- |
+| [#2412](https://github.com/rysweet/Simard/issues/2412) | `prompt_delivery::applied_mode_reports_inline_for_small_prompt`, `…_tempfile_for_large_prompt` | `Auto` mode reads `AMPLIHACK_PROMPT_DELIVERY` (`ENV_OVERRIDE`) and could observe a leaked `inline`/`tempfile` value set by a *concurrent* env test | Share the `prompt_delivery_env` serial key on the two Auto-mode size tests |
+| [#2408](https://github.com/rysweet/Simard/issues/2408) · [#2384](https://github.com/rysweet/Simard/issues/2384) | `operator_commands_dashboard::tests_goals_crud::full_goal_lifecycle_crud` (and siblings) | The goal-CRUD handlers resolved `SIMARD_STATE_ROOT` ambiently via `resolve_state_root()`, so a concurrent `setenv`/`remove_var` in an unrelated lib-binary test could tear the read and route a handler at the wrong state root | Thread an explicit state root through the goal-CRUD path (the `_at` handler cores) so the exercised path never reads the env |
+
+Both fixes preserve full test parallelism. Neither blanket-serializes the suite,
+and the de-flake mechanisms themselves do not change production behaviour: the
+HTTP handlers still resolve the state root from the environment exactly as
+before, and `select_mode` still reads the same env override. The suite is simply
+prevented from racing on those reads.
+
+> **One coupled bug fix.** Wiring `remove_goal` through the explicit-root core
+> surfaced a pre-existing dashboard bug: it persisted removals through the plain
+> *merge-on-write* save, which resurrected the just-removed goal. `remove_goal`
+> now uses `dashboard_save_goal_board_with_removals`, so dashboard removals
+> actually persist — matching the CLI `simard goal remove` contract. This is the
+> only production-behaviour change, and it is a fix. See the goal-board section.
+
+> **TL;DR**
+>
+> - **#2412:** add `#[serial(prompt_delivery_env)]` to the two Auto-mode size
+>   tests in `tests/prompt_delivery.rs`. They consult `ENV_OVERRIDE` through
+>   `select_mode`, so they must never run concurrently with the four tests that
+>   mutate `ENV_OVERRIDE`.
+> - **#2408 / #2384:** each goal-CRUD handler is split into a thin ambient
+>   **wrapper** (resolves the root once) and an env-free **`_at(state_root: &Path)`
+>   core**. Tests call the `_at` cores with `HermeticState::state_root()`, so the
+>   goal-board read/write path is driven by an explicit, test-owned path rather
+>   than the process-global environment.
+> - **Gate:** ≥20 consecutive parallel runs of the three tests with zero
+>   failures, plus a green `cargo test --all-features`.
+
+---
+
+## Fix #2412 — the prompt-delivery env race
+
+### The race this eliminates
+
+`tests/prompt_delivery.rs` runs many `#[test]` functions concurrently in one
+binary. Four of them mutate the process-global override variable
+`AMPLIHACK_PROMPT_DELIVERY` (exported as
+`simard::prompt_delivery::ENV_OVERRIDE`) via `set_var`/`remove_var`:
+
+- `env_override_forces_inline_for_short_prompt` — sets `inline`
+- `env_override_forces_tempfile_for_short_prompt` — sets `tempfile`
+- `invalid_env_value_falls_back_to_auto_without_panic` — sets `totally-bogus`
+- `caller_override_ignores_env_var` — sets `tempfile`, then asserts an
+  *explicit* mode beats the override
+
+These four already carry `#[serial(prompt_delivery_env)]`, so they never run
+concurrently *with each other*. (Note the last one passes an explicit mode yet
+is still keyed — it is keyed because it **writes** the env, not because it reads
+it.) The gap was the two **size-based** Auto tests:
+
+- `applied_mode_reports_inline_for_small_prompt`
+- `applied_mode_reports_tempfile_for_large_prompt`
+
+These assert that `Auto` picks `Inline` for a tiny prompt and `TempFile` for a
+large one **based on size alone**. But `Auto` consults the env override *first*
+(via `select_mode` → `std::env::var(ENV_OVERRIDE)`). When one of the four
+env-mutating tests had `AMPLIHACK_PROMPT_DELIVERY=inline` set at the instant a
+size test ran on another thread, the size test observed the leaked override and
+its mode assertion failed. That is the ~intermittent failure reported in
+[#2412](https://github.com/rysweet/Simard/issues/2412).
+
+### The rule
+
+> **Every `#[test]` in `tests/prompt_delivery.rs` that reaches `select_mode`
+> (directly, or via `apply_std`/`apply_tokio` with `PromptDelivery::Auto`)
+> shares the `prompt_delivery_env` serial key** — because that path reads
+> `ENV_OVERRIDE`, and an env read must never be concurrent with an env write.
+
+Tests that pass an **explicit** `PromptDelivery::Stdin` / `PromptDelivery::TempFile`
+/ `PromptDelivery::Inline` never consult the override and stay parallel
+(unkeyed). Only `Auto`-mode tests and the override-mutating tests need the key.
+
+### What the finished test looks like
+
+```rust
+use serial_test::serial;
+use simard::prompt_delivery::{PromptDelivery, apply_std, STDIN_PREFERRED_MAX_BYTES};
+
+#[test]
+#[serial(prompt_delivery_env)] // Auto reads ENV_OVERRIDE — must not race env writers
+fn applied_mode_reports_inline_for_small_prompt() {
+    let mut cmd = std::process::Command::new("/bin/cat");
+    let applied = apply_std(&mut cmd, b"tiny", PromptDelivery::Auto).unwrap();
+    assert_eq!(applied.mode(), PromptDelivery::Inline);
+    assert!(applied.temp_path().is_none());
+}
+
+#[test]
+#[serial(prompt_delivery_env)] // Auto reads ENV_OVERRIDE — must not race env writers
+fn applied_mode_reports_tempfile_for_large_prompt() {
+    let mut cmd = std::process::Command::new("/bin/cat");
+    let big = vec![b'x'; STDIN_PREFERRED_MAX_BYTES + 16];
+    let applied = apply_std(&mut cmd, &big, PromptDelivery::Auto).unwrap();
+    assert_eq!(applied.mode(), PromptDelivery::TempFile);
+    assert!(applied.temp_path().is_some());
+}
+```
+
+The `prompt_delivery_env` key is the same one already used by the inline unit
+tests in `src/prompt_delivery/mod.rs`, so the lock is shared across the unit and
+integration test surfaces.
+
+### Adding a new prompt-delivery test
+
+Ask one question: **does this test cause `Auto` to be selected, or does it set
+`AMPLIHACK_PROMPT_DELIVERY`?**
+
+- **Yes →** annotate it `#[serial(prompt_delivery_env)]`.
+- **No (explicit mode, no env mutation) →** leave it unkeyed so it runs in
+  parallel.
+
+---
+
+## Fix #2408 / #2384 — the goal-board state-root race
+
+[#2408](https://github.com/rysweet/Simard/issues/2408) and
+[#2384](https://github.com/rysweet/Simard/issues/2384) are the same defect:
+`full_goal_lifecycle_crud` (and its `tests_goals_crud` siblings) drives the
+dashboard goal-CRUD handlers in `src/operator_commands_dashboard/goals.rs`. Each
+handler resolved its state root **ambiently** through
+`routes::resolve_state_root()`, which reads `SIMARD_STATE_ROOT` from the
+process-global environment:
+
+```rust
+// routes.rs — ambient resolution (production default, unchanged)
+pub(crate) fn resolve_state_root() -> std::path::PathBuf {
+    std::env::var("SIMARD_STATE_ROOT")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| {
+            let home = std::env::var("HOME").unwrap_or_else(|_| "/home/azureuser".to_string());
+            std::path::PathBuf::from(home).join(".simard")
+        })
+}
+```
+
+`HermeticState` pins `SIMARD_STATE_ROOT` to a per-test `TempDir` for its
+lifetime, but the read inside the handler is still a *process-global* `getenv`.
+A concurrent `setenv`/`remove_var` in an unrelated lib-binary test (glibc
+`setenv`/`getenv` are not thread-safe) could tear that read, so a handler
+occasionally resolved to the wrong state root mid-lifecycle, the board snapshot
+came back unexpectedly empty, and the test's final assertion (`board.active.len() == 3`)
+failed.
+
+The [`cognitive_memory` serial isolation contract](./cognitive-memory-serial-isolation.md)
+serializes all env-*mutating* lib-binary tests under one key and is the suite's
+primary defence against this class. This fix adds **true isolation in depth** so
+the goal-CRUD path is correct regardless of any concurrent env tear: the
+exercised path no longer reads the environment at all.
+
+### The mechanism: ambient wrapper + env-free `_at` core
+
+Each goal-CRUD handler is split into two functions:
+
+1. A thin **wrapper** keeping the original Axum signature. It resolves the state
+   root **exactly once** via `resolve_state_root()` and delegates to the core.
+   This is the only HTTP entry point; routing is unchanged.
+2. An env-free **`_at` core** that takes the resolved root as an explicit
+   `state_root: &Path` parameter and does all the work — load board, mutate,
+   save — using *only* that path.
+
+The shared `load_board_or_empty()` helper is **replaced** by an env-free
+`load_board_or_empty_at(state_root)`, so the single ambient resolution is never
+duplicated inside a core. Every caller (`add_goal_at`, `remove_goal_at`, …) now
+threads its explicit root in, leaving the old ambient wrapper with no callers —
+so it is dropped (an unused wrapper would trip `cargo clippy -- -D warnings`):
+
+```rust
+// goals.rs
+
+/// Env-free helper. The board is read from `state_root` ONLY — never from the
+/// process environment. `state_root` MUST come from `resolve_state_root()`
+/// (production) or `HermeticState::state_root()` (tests), never from request
+/// data.
+fn load_board_or_empty_at(state_root: &std::path::Path) -> GoalBoard {
+    dashboard_goal_board_snapshot(state_root).unwrap_or_default()
+}
+```
+
+> **The single-resolution invariant.** A handler resolves the state root **once**
+> and threads that one `&Path` into every load and save it performs. Before this
+> fix, each mutating handler resolved the root *twice* — once directly (e.g.
+> `add_goal`'s `let state_root = resolve_state_root();`) and once again inside the
+> `load_board_or_empty()` it called — so the load and the save could observe two
+> different roots if an env tear landed between them. That double read is exactly
+> what this fix removes: the `_at` core takes the path as a parameter, so load and
+> save are guaranteed to use the same root.
+
+### API: the goal-CRUD handler cores
+
+All seven handlers gain a `pub(crate)` **async** `_at` core. The wrappers keep
+their existing names and Axum extractor signatures; the cores append `_at`, take
+`state_root: &Path` as the **first** parameter, and keep the wrapper's remaining
+extractor parameters (`Json<Value>`, `Path<String>`) verbatim. Each core is thus
+an exact **async twin** of its wrapper — the only difference is *where the state
+root comes from* — and a wrapper delegates with `.await`. Keeping the extractor
+parameter types lets tests call a core directly with constructed extractors
+(`Json(json!(…))`, `Path("…".into())`), exercising the same code the HTTP path
+runs.
+
+| Wrapper (HTTP entry, ambient) | Core (env-free, explicit root) |
+| ----------------------------- | ------------------------------ |
+| `goals() -> Json<Value>` | `async goals_at(state_root: &Path) -> Json<Value>` |
+| `seed_goals() -> Json<Value>` | `async seed_goals_at(state_root: &Path) -> Json<Value>` |
+| `add_goal(Json(body): Json<Value>) -> Json<Value>` | `async add_goal_at(state_root: &Path, Json(body): Json<Value>) -> Json<Value>` |
+| `remove_goal(Path(id): Path<String>) -> Json<Value>` | `async remove_goal_at(state_root: &Path, Path(id): Path<String>) -> Json<Value>` |
+| `update_goal_status(Path(id), Json(body)) -> Json<Value>` | `async update_goal_status_at(state_root: &Path, Path(id): Path<String>, Json(body): Json<Value>) -> Json<Value>` |
+| `promote_backlog_item(Path(id): Path<String>) -> Json<Value>` | `async promote_backlog_item_at(state_root: &Path, Path(id): Path<String>) -> Json<Value>` |
+| `demote_goal(Path(id): Path<String>) -> Json<Value>` | `async demote_goal_at(state_root: &Path, Path(id): Path<String>) -> Json<Value>` |
+
+Wrapper contract (illustrative — `add_goal`):
+
+```rust
+/// HTTP entry point. Resolves the state root once from the environment and
+/// delegates to the env-free core. Bound by the dashboard router.
+pub(crate) async fn add_goal(Json(body): Json<Value>) -> Json<Value> {
+    add_goal_at(&resolve_state_root(), Json(body)).await
+}
+
+/// Env-free core. Reads and writes the goal board through `state_root` only.
+///
+/// # State-root source invariant
+/// `state_root` is trusted-internal: it MUST originate from
+/// `resolve_state_root()` (production) or `HermeticState::state_root()`
+/// (tests). It MUST NEVER be derived from request data — wiring a
+/// request-controlled path here would expose path traversal.
+pub(crate) async fn add_goal_at(state_root: &Path, Json(body): Json<Value>) -> Json<Value> {
+    let mut board = load_board_or_empty_at(state_root);
+    // … validate body, mutate board (unchanged logic) …
+    match dashboard_save_goal_board(state_root, &board) {
+        Ok(()) => Json(json!({ "status": "ok", /* … */ })),
+        Err(e) => Json(json!({ "status": "error", "error": format!("save failed: {e}") })),
+    }
+}
+```
+
+The cores are `async` to mirror the wrapper signatures Axum expects; the
+goal-board read/write path itself is synchronous, so the cores simply `.await`
+nothing of their own. All existing extractor validation and status-code
+behaviour is preserved verbatim — the only change is *where the state root comes
+from*.
+
+> **Removal is the one exception to the plain save.** `remove_goal_at` persists
+> through `dashboard_save_goal_board_with_removals(state_root, &board, &[id])`
+> instead of `dashboard_save_goal_board`. The plain save is *merge-on-write*: it
+> unions the in-flight board with the persisted snapshot so a concurrent writer's
+> goals are never lost (#1915). That same merge would **resurrect** a goal the
+> operator just removed (its id is absent from the in-flight board, so
+> `merge_boards` keeps the persisted copy). Force-removing the id defeats the
+> resurrection, matching the CLI `simard goal remove` path (#1923 / #1925 /
+> #1926). The other five mutating cores are moves or additions that merge-on-write
+> resolves correctly, so they keep the plain save.
+
+The `# State-root source invariant` doc-comment shown above is **required on all
+seven cores**, not just the illustrative `add_goal_at`: it is the only thing that
+stops a future caller from wiring a request-controlled path into a core and
+opening a path-traversal hole. Treat a missing invariant comment on any `_at`
+core as a review blocker.
+
+### What the finished tests look like
+
+Two complementary tests pin the contract:
+
+1. The original `full_goal_lifecycle_crud` is **left unchanged** — it still drives
+   the **wrappers** (`seed_goals()`, `add_goal()`, …), so it keeps coverage of the
+   exact ambient-resolution path production runs. Its determinism is guaranteed by
+   the `cognitive_memory` serial group: while it holds that lock no other
+   lib-binary test can mutate `SIMARD_STATE_ROOT` (the `serial_guard` meta-test
+   proves every env mutator is in the group).
+2. A new sibling, `full_goal_lifecycle_crud_via_at_is_env_independent`, drives the
+   whole lifecycle through the **`_at` cores** with the hermetic root while a
+   second `HermeticState` (`decoy`) deliberately points the ambient
+   `SIMARD_STATE_ROOT` at a *different* directory. A correct env-free core touches
+   only the explicit `target` root; an ambient one would touch the `decoy`, so the
+   final decoy-empty assertion would fail. This is the isolation-in-depth proof:
+
+```rust
+#[tokio::test]
+#[serial_test::serial(cognitive_memory)]
+async fn full_goal_lifecycle_crud_via_at_is_env_independent() {
+    let target = HermeticState::new();
+    let _mem = init_empty_board(&target);
+    let decoy = HermeticState::new(); // ambient SIMARD_STATE_ROOT now != target
+    let root = target.state_root();
+
+    // Cores are async and take the wrapper's extractors verbatim.
+    assert_eq!(seed_goals_at(root).await.0["status"], "ok");
+    let r = add_goal_at(root, Json(json!({"description": "New backlog idea", "type": "backlog"}))).await;
+    assert_eq!(r.0["status"], "ok");
+    let backlog_id = r.0["id"].as_str().unwrap().to_string();
+
+    // promote → in-progress → completed → demote → remove, all on `root`.
+    assert_eq!(promote_backlog_item_at(root, Path(backlog_id.clone())).await.0["status"], "ok");
+    assert_eq!(update_goal_status_at(root, Path(backlog_id.clone()), Json(json!({"status": "in-progress"}))).await.0["status"], "ok");
+    assert_eq!(update_goal_status_at(root, Path(backlog_id.clone()), Json(json!({"status": "completed"}))).await.0["status"], "ok");
+    assert_eq!(demote_goal_at(root, Path(backlog_id.clone())).await.0["status"], "ok");
+    assert_eq!(remove_goal_at(root, Path(backlog_id)).await.0["status"], "ok");
+
+    // Only the 3 seeded goals remain — in the explicit root.
+    let board = dashboard_goal_board_snapshot(root).unwrap();
+    assert_eq!(board.active.len(), 3, "only seeded goals should remain active");
+
+    // The ambient/decoy root must never have been written.
+    let decoy_board = dashboard_goal_board_snapshot(decoy.state_root()).unwrap_or_default();
+    assert!(decoy_board.active.is_empty() && decoy_board.backlog.is_empty());
+}
+```
+
+`HermeticState` and `#[serial_test::serial(cognitive_memory)]` are **retained** on
+both tests, not removed: they keep the shared in-process cognitive-memory writer
+registered and keep the tests inside the watched serial group enforced by the
+[`serial_guard` meta-test](./cognitive-memory-serial-isolation.md). Removing
+either would regress that meta-test. The `_at` threading is isolation *in
+addition to* serialization, not a replacement for it. Per-core sibling tests
+(`seed_goals_at_writes_to_explicit_root_not_ambient_env`, `remove_goal_at_uses_explicit_root`, …)
+pin each core against the same `target`-vs-`decoy` contract.
+
+### Writing a new goal-CRUD handler test
+
+- Allocate a `HermeticState` and bind it for the whole test.
+- Bind the in-process writer (`let _mem = init_empty_board(&state);`).
+- Keep `#[serial_test::serial(cognitive_memory)]`.
+- To prove env-independence, call the **`_at` cores** with `state.state_root()`
+  (optionally with a `decoy` `HermeticState`); to cover the production HTTP path,
+  call the **wrappers** instead. Both are valid — choose per what the test asserts.
+
+### Production callers are unaffected
+
+The dashboard router still binds the **wrappers** (`goals`, `add_goal`, …). Each
+wrapper resolves the state root from the environment once, exactly as before, so
+the OODA daemon, bootstrap assembly, and standalone `dashboard serve` behave
+identically. Only the *test* path opts into explicit-root threading.
+
+---
+
+## Verification gate
+
+A change to either fix is merge-ready only when all of the following pass.
+
+### Targeted stress (the de-flake proof)
+
+Run the three formerly-flaky tests ≥**20 consecutive** times under parallel
+execution with **zero** failures. The repo's pre-push
+`cargo-test-race-subset` approach (issue
+[#1631](https://github.com/rysweet/Simard/issues/1631)) is the reference:
+
+```bash
+# 20 parallel runs of the WHOLE prompt-delivery binary (PR A).
+# Do NOT filter to `applied_mode_reports_`: the race only exists when the
+# env-mutating writers (`env_override_forces_*`, `invalid_env_value_*`) run
+# concurrently with the two size readers. A name-filtered run drops the writers,
+# so it would pass even without the `#[serial]` fix and prove nothing.
+for i in $(seq 1 20); do
+  cargo test --test prompt_delivery -- --test-threads=8 \
+    || { echo "FLAKE on run $i"; break; }
+done
+
+# 20 parallel runs of the WHOLE lib-test binary (PR B). The goal-board race only
+# surfaces when an unrelated env-mutating lib test runs concurrently, so the
+# subset must run inside the full binary, never name-filtered.
+#
+# On a developer box that has a real `~/.simard/prompt_assets` install, two
+# UNRELATED test groups fail environment-specifically (they read the live install
+# instead of a temp dir and do not isolate $HOME) — they pass in clean CI. Skip
+# them so the loop reports only the de-flake signal:
+for i in $(seq 1 20); do
+  ./target/debug/deps/simard-<hash> \
+    --skip ooda_brain::recipe_brain::tests::resolve_recipe_path \
+    --skip ooda_brain::recipe_brain::tests::new_returns_none_when \
+    --skip base_type_copilot::tests \
+    || { echo "FLAKE on run $i"; break; }
+done
+```
+
+**Run the whole binary, never a single-test filter.** Both races only surface
+when an unrelated env-*mutating* test runs concurrently with the test under
+proof, so a filtered run that excludes those writers can pass by luck while the
+real binary still flakes. That is why the PR A loop runs the entire
+`prompt_delivery` integration binary (writers + size readers together) and the
+PR B loop runs the entire lib-test binary (the goal-board subset alongside every
+other env-mutating lib test), not either subset in isolation.
+
+### Full suite
+
+```bash
+cargo test --all-features
+```
+
+Must pass with no regressions, including the
+[`serial_guard` meta-test](./cognitive-memory-serial-isolation.md) that enforces
+the `cognitive_memory` watched-env contract.
+
+### CI
+
+The existing `.github/workflows/verify.yml` → pre-commit pipeline must go green.
+**No CI-workflow edits** are part of this work unless strictly required.
+
+---
+
+## Configuration & environment
+
+These fixes add no new runtime configuration. The relevant variables are:
+
+| Variable | Role | Notes |
+| -------- | ---- | ----- |
+| `AMPLIHACK_PROMPT_DELIVERY` (`ENV_OVERRIDE`) | Forces `Auto` mode selection in `prompt_delivery` | Read by `select_mode`; the `prompt_delivery_env` serial key prevents test reads from racing test writes |
+| `SIMARD_STATE_ROOT` (`STATE_ROOT_ENV`) | Ambient state-root source for `resolve_state_root()` | Still read by the handler **wrappers** in production; the `_at` cores take it as an explicit `&Path` and never read the env |
+| `SIMARD_MEMORY_SOCKET` (`MEMORY_SOCKET_ENV`) | Cognitive-memory socket path | Unset by `HermeticState` so the socket follows the state root |
+
+### Local stress-run memory budget
+
+The saved workstation preference for memory-heavy local runs is
+`NODE_OPTIONS=--max-old-space-size=32768` (used by the tooling that drives the
+stress loops, not by `cargo` itself). To change it, edit
+`~/.amplihack/config`. It is not required for CI and does not affect the Rust
+tests.
+
+---
+
+## Scope
+
+**In scope:** the two isolation mechanisms above, their tests, the one coupled
+removal bug fix (`remove_goal` now persists removals via
+`save_goal_board_with_removals`, surfaced while wiring `remove_goal_at`), and this
+page.
+
+**Out of scope (confirmed):** snapshot/redeploy docs; refactoring `select_mode`
+or the goal-board logic beyond the isolation needs and that coupled removal fix;
+unrelated flaky tests (e.g. the `ooda_brain::recipe_brain` recipe-resolution and
+`base_type_copilot` copilot-spawning tests, which only fail on a developer box
+that has a live `~/.simard` install / `copilot` on `PATH` and pass/skip in clean
+CI); any change to CI workflow definitions.
+
+## Related pages
+
+- [Writing hermetic tests against cognitive memory](./hermetic-tests.md) — how a
+  single test allocates an isolated state root with `HermeticState`.
+- [serial(cognitive_memory) test isolation](./cognitive-memory-serial-isolation.md)
+  — the whole-binary watched-env contract and the `serial_guard` meta-test.
+- [CI-resilient test patterns](./ci-resilient-test-patterns.md) — companion
+  patterns (lazy config resolution, serial env-var tests).
+- [Subprocess prompt delivery](../prompt-delivery.md) — the `prompt_delivery`
+  module, `select_mode`, and `ENV_OVERRIDE`.
+- [Goal-board API](../reference/goal-board-api.md) — the dashboard goal-CRUD
+  endpoints these handlers back.

--- a/src/operator_commands_dashboard/goals.rs
+++ b/src/operator_commands_dashboard/goals.rs
@@ -4,17 +4,25 @@ use serde_json::{Value, json};
 
 use super::goals_status::render_status_and_detail;
 use super::routes::resolve_state_root;
-use super::{dashboard_goal_board_snapshot, dashboard_save_goal_board};
+use super::{
+    dashboard_goal_board_snapshot, dashboard_save_goal_board,
+    dashboard_save_goal_board_with_removals,
+};
 use crate::goal_curation::{ActiveGoal, BacklogItem, GoalBoard, GoalProgress, MAX_ACTIVE_GOALS};
 use crate::goals::goal_slug;
 use crate::memory_ipc::open_reader_bridge;
 
-/// Load the dashboard's view of the goal board from cognitive memory.
-/// Returns an empty `GoalBoard` when the snapshot is missing or the bridge
-/// cannot be opened — the dashboard always renders rather than 500ing.
-fn load_board_or_empty() -> GoalBoard {
-    let state_root = resolve_state_root();
-    dashboard_goal_board_snapshot(&state_root).unwrap_or_default()
+/// Load the dashboard's view of the goal board from the EXPLICIT `state_root`
+/// instead of resolving `SIMARD_STATE_ROOT` ambiently. Returns an empty
+/// `GoalBoard` when the snapshot is missing or the bridge cannot be opened —
+/// the dashboard always renders rather than 500ing.
+///
+/// `state_root` is trusted-internal: it originates only from a handler
+/// wrapper's `resolve_state_root()` or a test's `HermeticState`, NEVER from
+/// request data, so threading it through carries no path-traversal risk
+/// (#2408 / #2384).
+fn load_board_or_empty_at(state_root: &std::path::Path) -> GoalBoard {
+    dashboard_goal_board_snapshot(state_root).unwrap_or_default()
 }
 
 /// Returns `true` when `s` looks like a debug key=value dump rather than
@@ -69,8 +77,15 @@ fn human_source_label(concept: &str) -> &'static str {
 }
 
 pub(crate) async fn goals() -> Json<Value> {
-    let state_root = resolve_state_root();
-    let board = dashboard_goal_board_snapshot(&state_root).unwrap_or_default();
+    goals_at(&resolve_state_root()).await
+}
+
+/// Env-free core of [`goals`]: build the dashboard goal-board view from the
+/// EXPLICIT `state_root` rather than resolving `SIMARD_STATE_ROOT` ambiently
+/// (#2408 / #2384). See [`load_board_or_empty_at`] for the trusted-internal
+/// `state_root` invariant.
+pub(crate) async fn goals_at(state_root: &std::path::Path) -> Json<Value> {
+    let board = dashboard_goal_board_snapshot(state_root).unwrap_or_default();
 
     let active: Vec<Value> = board
         .active
@@ -113,7 +128,7 @@ pub(crate) async fn goals() -> Json<Value> {
 
     // Pull meeting-captured actions and decisions from cognitive memory (#415)
     // (#1686: filter out raw memory IDs and debug strings, provide clean labels)
-    if let Ok(reader) = open_reader_bridge(&state_root) {
+    if let Ok(reader) = open_reader_bridge(state_root) {
         let mem = reader.ops();
         for tag in &["goal", "action", "decision"] {
             if let Ok(facts) = mem.search_facts(tag, 20, 0.0) {
@@ -164,8 +179,14 @@ pub(crate) async fn goals() -> Json<Value> {
 }
 
 pub(crate) async fn seed_goals() -> Json<Value> {
-    let state_root = resolve_state_root();
-    let existing = dashboard_goal_board_snapshot(&state_root).unwrap_or_default();
+    seed_goals_at(&resolve_state_root()).await
+}
+
+/// Env-free core of [`seed_goals`]: seed the EXPLICIT `state_root`. See
+/// [`load_board_or_empty_at`] for the trusted-internal `state_root` invariant
+/// (#2408 / #2384).
+pub(crate) async fn seed_goals_at(state_root: &std::path::Path) -> Json<Value> {
+    let existing = dashboard_goal_board_snapshot(state_root).unwrap_or_default();
     if !existing.active.is_empty() {
         return Json(json!({"status": "already_seeded", "message": "Goals already exist"}));
     }
@@ -226,7 +247,7 @@ pub(crate) async fn seed_goals() -> Json<Value> {
         score: 0.6,
     });
 
-    match dashboard_save_goal_board(&state_root, &board) {
+    match dashboard_save_goal_board(state_root, &board) {
         Ok(()) => {
             Json(json!({"status": "ok", "message": "Seeded 3 active goals and 2 backlog items"}))
         }
@@ -235,8 +256,19 @@ pub(crate) async fn seed_goals() -> Json<Value> {
 }
 
 pub(crate) async fn add_goal(Json(body): Json<Value>) -> Json<Value> {
-    let state_root = resolve_state_root();
-    let mut board = load_board_or_empty();
+    add_goal_at(&resolve_state_root(), Json(body)).await
+}
+
+/// Env-free core of [`add_goal`]. BOTH the load (`load_board_or_empty_at`) and
+/// the save honor the EXPLICIT `state_root`, closing the #2408 double-resolution
+/// (the handler previously read `SIMARD_STATE_ROOT` once directly and again
+/// inside `load_board_or_empty`). See [`load_board_or_empty_at`] for the
+/// trusted-internal `state_root` invariant.
+pub(crate) async fn add_goal_at(
+    state_root: &std::path::Path,
+    Json(body): Json<Value>,
+) -> Json<Value> {
+    let mut board = load_board_or_empty_at(state_root);
 
     let desc = match body.get("description").and_then(|v| v.as_str()) {
         Some(d) if !d.trim().is_empty() => d.trim().to_string(),
@@ -295,15 +327,29 @@ pub(crate) async fn add_goal(Json(body): Json<Value>) -> Json<Value> {
         });
     }
 
-    match dashboard_save_goal_board(&state_root, &board) {
+    match dashboard_save_goal_board(state_root, &board) {
         Ok(()) => Json(json!({"status": "ok", "id": id})),
         Err(e) => Json(json!({"error": format!("{e}")})),
     }
 }
 
 pub(crate) async fn remove_goal(Path(id): Path<String>) -> Json<Value> {
-    let state_root = resolve_state_root();
-    let mut board = load_board_or_empty();
+    remove_goal_at(&resolve_state_root(), Path(id)).await
+}
+
+/// Env-free core of [`remove_goal`]. See [`load_board_or_empty_at`] for the
+/// trusted-internal `state_root` invariant (#2408 / #2384).
+///
+/// Persists through [`dashboard_save_goal_board_with_removals`] rather than the
+/// plain merge-on-write save: a removed goal is absent from the in-flight
+/// board, so merge-on-write would resurrect it from the persisted snapshot.
+/// Force-removing the id defeats that resurrection, matching the CLI
+/// `simard goal remove` contract (#1923 / #1925 / #1926).
+pub(crate) async fn remove_goal_at(
+    state_root: &std::path::Path,
+    Path(id): Path<String>,
+) -> Json<Value> {
+    let mut board = load_board_or_empty_at(state_root);
 
     let before_active = board.active.len();
     let before_backlog = board.backlog.len();
@@ -314,7 +360,7 @@ pub(crate) async fn remove_goal(Path(id): Path<String>) -> Json<Value> {
         return Json(json!({"error": "goal not found"}));
     }
 
-    match dashboard_save_goal_board(&state_root, &board) {
+    match dashboard_save_goal_board_with_removals(state_root, &board, std::slice::from_ref(&id)) {
         Ok(()) => Json(json!({"status": "ok"})),
         Err(e) => Json(json!({"error": format!("{e}")})),
     }
@@ -324,8 +370,17 @@ pub(crate) async fn update_goal_status(
     Path(id): Path<String>,
     Json(body): Json<Value>,
 ) -> Json<Value> {
-    let state_root = resolve_state_root();
-    let mut board = load_board_or_empty();
+    update_goal_status_at(&resolve_state_root(), Path(id), Json(body)).await
+}
+
+/// Env-free core of [`update_goal_status`]. See [`load_board_or_empty_at`] for
+/// the trusted-internal `state_root` invariant (#2408 / #2384).
+pub(crate) async fn update_goal_status_at(
+    state_root: &std::path::Path,
+    Path(id): Path<String>,
+    Json(body): Json<Value>,
+) -> Json<Value> {
+    let mut board = load_board_or_empty_at(state_root);
 
     let status_str = match body.get("status").and_then(|v| v.as_str()) {
         Some(s) => s,
@@ -362,15 +417,23 @@ pub(crate) async fn update_goal_status(
         return Json(json!({"error": "goal not found in active goals"}));
     }
 
-    match dashboard_save_goal_board(&state_root, &board) {
+    match dashboard_save_goal_board(state_root, &board) {
         Ok(()) => Json(json!({"status": "ok"})),
         Err(e) => Json(json!({"error": format!("{e}")})),
     }
 }
 
 pub(crate) async fn promote_backlog_item(Path(id): Path<String>) -> Json<Value> {
-    let state_root = resolve_state_root();
-    let mut board = load_board_or_empty();
+    promote_backlog_item_at(&resolve_state_root(), Path(id)).await
+}
+
+/// Env-free core of [`promote_backlog_item`]. See [`load_board_or_empty_at`]
+/// for the trusted-internal `state_root` invariant (#2408 / #2384).
+pub(crate) async fn promote_backlog_item_at(
+    state_root: &std::path::Path,
+    Path(id): Path<String>,
+) -> Json<Value> {
+    let mut board = load_board_or_empty_at(state_root);
 
     if board.active.len() >= MAX_ACTIVE_GOALS {
         return Json(json!({"error": format!(
@@ -398,15 +461,23 @@ pub(crate) async fn promote_backlog_item(Path(id): Path<String>) -> Json<Value> 
         last_progress_update_at: None,
     });
 
-    match dashboard_save_goal_board(&state_root, &board) {
+    match dashboard_save_goal_board(state_root, &board) {
         Ok(()) => Json(json!({"status": "ok"})),
         Err(e) => Json(json!({"error": format!("{e}")})),
     }
 }
 
 pub(crate) async fn demote_goal(Path(id): Path<String>) -> Json<Value> {
-    let state_root = resolve_state_root();
-    let mut board = load_board_or_empty();
+    demote_goal_at(&resolve_state_root(), Path(id)).await
+}
+
+/// Env-free core of [`demote_goal`]. See [`load_board_or_empty_at`] for the
+/// trusted-internal `state_root` invariant (#2408 / #2384).
+pub(crate) async fn demote_goal_at(
+    state_root: &std::path::Path,
+    Path(id): Path<String>,
+) -> Json<Value> {
+    let mut board = load_board_or_empty_at(state_root);
 
     let pos = board.active.iter().position(|g| g.id == id);
     let goal = match pos {
@@ -421,7 +492,7 @@ pub(crate) async fn demote_goal(Path(id): Path<String>) -> Json<Value> {
         score: 0.0,
     });
 
-    match dashboard_save_goal_board(&state_root, &board) {
+    match dashboard_save_goal_board(state_root, &board) {
         Ok(()) => Json(json!({"status": "ok"})),
         Err(e) => Json(json!({"error": format!("{e}")})),
     }

--- a/src/operator_commands_dashboard/mod.rs
+++ b/src/operator_commands_dashboard/mod.rs
@@ -41,7 +41,9 @@ use std::net::SocketAddr;
 use std::path::Path;
 
 use crate::error::SimardResult;
-use crate::goal_curation::{GoalBoard, load_goal_board, save_goal_board};
+use crate::goal_curation::{
+    GoalBoard, load_goal_board, save_goal_board, save_goal_board_with_removals,
+};
 use crate::memory_ipc::{launch_writer_bridge, open_reader_bridge};
 
 /// Read the cognitive-memory `goal-board:snapshot` for the dashboard.
@@ -64,6 +66,26 @@ pub(crate) fn dashboard_goal_board_snapshot(state_root: &Path) -> SimardResult<G
 pub(crate) fn dashboard_save_goal_board(state_root: &Path, board: &GoalBoard) -> SimardResult<()> {
     let writer = launch_writer_bridge(state_root)?;
     save_goal_board(board, writer.ops())
+}
+
+/// Persist a `GoalBoard` from a dashboard write handler while force-removing
+/// `force_remove_ids` from the merged snapshot.
+///
+/// Plain [`dashboard_save_goal_board`] uses merge-on-write semantics that
+/// re-add any goal *absent* from the in-flight board, so a concurrent writer's
+/// goals are never lost (#1915). That same merge resurrects a goal an operator
+/// explicitly removed: its id is absent from the in-flight board, so
+/// [`merge_boards`](crate::goal_curation) keeps the persisted copy. Routing an
+/// explicit removal through [`save_goal_board_with_removals`] filters those ids
+/// out of the merged result so the removal actually persists — matching the CLI
+/// `simard goal remove` path (#1923 / #1925 / #1926).
+pub(crate) fn dashboard_save_goal_board_with_removals(
+    state_root: &Path,
+    board: &GoalBoard,
+    force_remove_ids: &[String],
+) -> SimardResult<()> {
+    let writer = launch_writer_bridge(state_root)?;
+    save_goal_board_with_removals(board, force_remove_ids, writer.ops())
 }
 
 /// Initialize dashboard auth and print the login code to stderr.

--- a/src/operator_commands_dashboard/tests_goals_crud.rs
+++ b/src/operator_commands_dashboard/tests_goals_crud.rs
@@ -698,3 +698,316 @@ async fn repeated_handler_writes_never_silently_drop_goals() {
         "every goal added through the handler must persist (no silent drop)"
     );
 }
+
+// ===========================================================================
+// PR B — issues #2408 / #2384: env-free `_at` cores (state-root isolation)
+// ===========================================================================
+//
+// Root cause of the `full_goal_lifecycle_crud` /
+// `operator_commands_dashboard::tests_goals_crud::full_*` flake: the goal-CRUD
+// handlers resolve their state root *ambiently* via `resolve_state_root()` →
+// `std::env::var("SIMARD_STATE_ROOT")`. glibc getenv/setenv are not
+// thread-safe, so a concurrent env mutation in ANOTHER test — even in a
+// different file of the same lib-test binary — can tear a handler's read
+// mid-flight and send writes to `$HOME/.simard` instead of the hermetic temp
+// root, corrupting the board the test then reads back. `add_goal` is doubly
+// exposed: it resolves the env once directly AND again inside
+// `load_board_or_empty`.
+//
+// The fix threads an EXPLICIT `state_root: &Path` through each handler via an
+// `*_at` core; the ambient `resolve_state_root()` survives only in a thin
+// wrapper, and `add_goal`'s second resolve is killed with `load_board_or_empty_at`.
+//
+// These tests pin that contract. Each registers a shared writer + seeds a
+// board at an explicit `target` root, then constructs a SECOND `HermeticState`
+// so the ambient `SIMARD_STATE_ROOT` points at a `decoy` directory that DIFFERS
+// from `target`. A correct env-free `_at` core uses the explicit `target` it is
+// handed; an ambient one would touch the `decoy`, and the assertions below
+// fail.
+//
+// Local-binding drop order makes this sound: bindings drop in reverse
+// declaration order, so `decoy` (declared last) restores `SIMARD_STATE_ROOT`
+// to `target`'s value, then the writer guard clears, then `target` restores the
+// original env — no stale pin leaks past the test.
+//
+// This is the TDD red phase: the `*_at` functions do not exist yet, so the
+// lib-test binary will not compile until #2408/#2384's fix lands. Once the
+// cores exist and honor their explicit root, every assertion passes under
+// parallel `cargo test`.
+
+#[tokio::test]
+#[serial_test::serial(cognitive_memory)]
+async fn seed_goals_at_writes_to_explicit_root_not_ambient_env() {
+    let target = HermeticState::new();
+    let _mem = init_empty_board(&target);
+    let decoy = HermeticState::new(); // ambient SIMARD_STATE_ROOT now != target
+
+    let r = seed_goals_at(target.state_root()).await;
+    assert_eq!(
+        r.0["status"], "ok",
+        "seed_goals_at must seed the explicit root, got: {}",
+        r.0
+    );
+
+    let board = dashboard_goal_board_snapshot(target.state_root()).unwrap();
+    assert_eq!(
+        board.active.len(),
+        3,
+        "seeded goals must land in the explicit target root"
+    );
+
+    let decoy_board = dashboard_goal_board_snapshot(decoy.state_root()).unwrap_or_default();
+    assert!(
+        decoy_board.active.is_empty() && decoy_board.backlog.is_empty(),
+        "seed_goals_at must NOT touch the ambient SIMARD_STATE_ROOT (decoy) root"
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial(cognitive_memory)]
+async fn add_goal_at_loads_and_saves_explicit_root_not_ambient_env() {
+    // Guards the #2408 double-resolution in `add_goal`: BOTH the load
+    // (`load_board_or_empty_at`) and the save must honor the explicit root.
+    let target = HermeticState::new();
+    let _mem = init_board_with_goals(&target); // 1 active "existing-goal" + 1 backlog
+    let decoy = HermeticState::new();
+
+    let r = add_goal_at(
+        target.state_root(),
+        Json(json!({"description": "Explicit root goal", "type": "backlog"})),
+    )
+    .await;
+    assert_eq!(
+        r.0["status"], "ok",
+        "add_goal_at must succeed, got: {}",
+        r.0
+    );
+
+    let board = dashboard_goal_board_snapshot(target.state_root()).unwrap();
+    // Pre-existing active goal preserved => the LOAD read the explicit root,
+    // not the empty decoy (an ambient load would drop "existing-goal").
+    assert_eq!(
+        board.active.len(),
+        1,
+        "existing active goal must survive — load must honor the explicit root"
+    );
+    // Seeded backlog item + the new one => the SAVE wrote the explicit root.
+    assert_eq!(
+        board.backlog.len(),
+        2,
+        "new backlog item must persist to the explicit root alongside the seeded one"
+    );
+
+    let decoy_board = dashboard_goal_board_snapshot(decoy.state_root()).unwrap_or_default();
+    assert!(
+        decoy_board.active.is_empty() && decoy_board.backlog.is_empty(),
+        "add_goal_at must NOT touch the ambient (decoy) root"
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial(cognitive_memory)]
+async fn remove_goal_at_uses_explicit_root() {
+    let target = HermeticState::new();
+    let _mem = init_board_with_goals(&target);
+    let _decoy = HermeticState::new();
+
+    // If remove loaded from the empty decoy it would 404; success proves the
+    // load read the explicit root.
+    let r = remove_goal_at(target.state_root(), Path("existing-goal".to_string())).await;
+    assert_eq!(
+        r.0["status"], "ok",
+        "remove_goal_at must find+remove via the explicit root, got: {}",
+        r.0
+    );
+
+    let board = dashboard_goal_board_snapshot(target.state_root()).unwrap();
+    assert!(
+        board.active.iter().all(|g| g.id != "existing-goal"),
+        "removed goal must be gone from the explicit root"
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial(cognitive_memory)]
+async fn update_goal_status_at_uses_explicit_root() {
+    let target = HermeticState::new();
+    let _mem = init_board_with_goals(&target);
+    let _decoy = HermeticState::new();
+
+    let r = update_goal_status_at(
+        target.state_root(),
+        Path("existing-goal".to_string()),
+        Json(json!({"status": "completed"})),
+    )
+    .await;
+    assert_eq!(
+        r.0["status"], "ok",
+        "update_goal_status_at must update via the explicit root, got: {}",
+        r.0
+    );
+
+    let board = dashboard_goal_board_snapshot(target.state_root()).unwrap();
+    assert!(
+        matches!(board.active[0].status, GoalProgress::Completed),
+        "status change must persist to the explicit root; got {:?}",
+        board.active[0].status
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial(cognitive_memory)]
+async fn promote_backlog_item_at_uses_explicit_root() {
+    let target = HermeticState::new();
+    let _mem = init_board_with_goals(&target); // backlog "backlog-item-1"
+    let _decoy = HermeticState::new();
+
+    let r = promote_backlog_item_at(target.state_root(), Path("backlog-item-1".to_string())).await;
+    assert_eq!(
+        r.0["status"], "ok",
+        "promote_backlog_item_at must find the backlog item via the explicit root, got: {}",
+        r.0
+    );
+
+    let board = dashboard_goal_board_snapshot(target.state_root()).unwrap();
+    assert!(
+        board.active.iter().any(|g| g.id == "backlog-item-1"),
+        "promoted item must be active in the explicit root"
+    );
+    assert!(
+        board.backlog.iter().all(|g| g.id != "backlog-item-1"),
+        "promoted item must leave the backlog in the explicit root"
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial(cognitive_memory)]
+async fn demote_goal_at_uses_explicit_root() {
+    let target = HermeticState::new();
+    let _mem = init_board_with_goals(&target); // active "existing-goal"
+    let _decoy = HermeticState::new();
+
+    let r = demote_goal_at(target.state_root(), Path("existing-goal".to_string())).await;
+    assert_eq!(
+        r.0["status"], "ok",
+        "demote_goal_at must find the active goal via the explicit root, got: {}",
+        r.0
+    );
+
+    let board = dashboard_goal_board_snapshot(target.state_root()).unwrap();
+    assert!(
+        board.backlog.iter().any(|g| g.id == "existing-goal"),
+        "demoted goal must be in the backlog in the explicit root"
+    );
+    assert!(
+        board.active.iter().all(|g| g.id != "existing-goal"),
+        "demoted goal must leave the active list in the explicit root"
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial(cognitive_memory)]
+async fn goals_at_reads_explicit_root_not_ambient_env() {
+    let target = HermeticState::new();
+    let _mem = init_board_with_goals(&target);
+    let _decoy = HermeticState::new();
+
+    let r = goals_at(target.state_root()).await;
+    let v = &r.0;
+    assert_eq!(
+        v["active_count"], 1,
+        "goals_at must read the explicit root's active goals, got: {v}"
+    );
+    assert!(
+        v["active"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|g| g["id"] == "existing-goal"),
+        "goals_at must surface the seeded goal from the explicit root, got: {v}"
+    );
+}
+
+/// Deterministic, env-independent twin of `full_goal_lifecycle_crud` (the
+/// #2408 / #2384 flake): drive the entire CRUD lifecycle through the
+/// explicit-root `_at` cores while the ambient `SIMARD_STATE_ROOT` points at a
+/// DECOY directory. A correct fix makes every step touch only `target`.
+#[tokio::test]
+#[serial_test::serial(cognitive_memory)]
+async fn full_goal_lifecycle_crud_via_at_is_env_independent() {
+    let target = HermeticState::new();
+    let _mem = init_empty_board(&target);
+    let decoy = HermeticState::new();
+    let root = target.state_root();
+
+    // 1. Seed initial goals.
+    assert_eq!(seed_goals_at(root).await.0["status"], "ok");
+
+    // 2. Add a backlog item.
+    let r = add_goal_at(
+        root,
+        Json(json!({"description": "New backlog idea", "type": "backlog"})),
+    )
+    .await;
+    assert_eq!(r.0["status"], "ok");
+    let backlog_id = r.0["id"].as_str().unwrap().to_string();
+
+    // 3. Promote backlog -> active.
+    assert_eq!(
+        promote_backlog_item_at(root, Path(backlog_id.clone()))
+            .await
+            .0["status"],
+        "ok"
+    );
+
+    // 4. In-progress.
+    assert_eq!(
+        update_goal_status_at(
+            root,
+            Path(backlog_id.clone()),
+            Json(json!({"status": "in-progress"})),
+        )
+        .await
+        .0["status"],
+        "ok"
+    );
+
+    // 5. Completed.
+    assert_eq!(
+        update_goal_status_at(
+            root,
+            Path(backlog_id.clone()),
+            Json(json!({"status": "completed"})),
+        )
+        .await
+        .0["status"],
+        "ok"
+    );
+
+    // 6. Demote back to backlog.
+    assert_eq!(
+        demote_goal_at(root, Path(backlog_id.clone())).await.0["status"],
+        "ok"
+    );
+
+    // 7. Remove.
+    assert_eq!(
+        remove_goal_at(root, Path(backlog_id)).await.0["status"],
+        "ok"
+    );
+
+    // 8. Only the 3 seeded goals remain, all in the explicit root.
+    let board = dashboard_goal_board_snapshot(root).unwrap();
+    assert_eq!(
+        board.active.len(),
+        3,
+        "only the seeded goals should remain active in the explicit root"
+    );
+
+    // The ambient/decoy root must never have been written.
+    let decoy_board = dashboard_goal_board_snapshot(decoy.state_root()).unwrap_or_default();
+    assert!(
+        decoy_board.active.is_empty() && decoy_board.backlog.is_empty(),
+        "no CRUD step may touch the ambient (decoy) SIMARD_STATE_ROOT"
+    );
+}

--- a/tests/prompt_delivery.rs
+++ b/tests/prompt_delivery.rs
@@ -167,6 +167,7 @@ fn stdin_mode_roundtrips_nul_bytes_unchanged() {
 // ===========================================================================
 
 #[test]
+#[serial(prompt_delivery_env)]
 fn applied_mode_reports_inline_for_small_prompt() {
     let mut cmd = Command::new("/bin/cat");
     let applied = apply_std(&mut cmd, b"tiny", PromptDelivery::Auto).unwrap();
@@ -175,6 +176,7 @@ fn applied_mode_reports_inline_for_small_prompt() {
 }
 
 #[test]
+#[serial(prompt_delivery_env)]
 fn applied_mode_reports_tempfile_for_large_prompt() {
     let mut cmd = Command::new("/bin/cat");
     let big = vec![b'x'; STDIN_PREFERRED_MAX_BYTES + 16];

--- a/tests/prompt_delivery_env_isolation.rs
+++ b/tests/prompt_delivery_env_isolation.rs
@@ -1,0 +1,244 @@
+//! TDD red-phase guard for issue #2412 — env-var race in
+//! `tests/prompt_delivery.rs` (`AMPLIHACK_PROMPT_DELIVERY`).
+//!
+//! ## The flake
+//! The two Auto-mode *size* tests
+//! (`applied_mode_reports_inline_for_small_prompt`,
+//! `applied_mode_reports_tempfile_for_large_prompt`) call
+//! `apply_std(.., PromptDelivery::Auto)`, which consults
+//! `std::env::var(ENV_OVERRIDE)` via `select_mode`. The four env-mutating tests
+//! in the same file are already serialized under `#[serial(prompt_delivery_env)]`,
+//! but the two *readers* are NOT — so under parallel `cargo test` a reader can
+//! observe a leaked `inline`/`tempfile` value mid-flight and assert the wrong
+//! mode.
+//!
+//! ## The fix (#2412)
+//! Annotate every Auto-mode test with `#[serial(prompt_delivery_env)]` so the
+//! readers cannot run concurrently with the env writers, restoring mutual
+//! exclusion on the shared override variable.
+//!
+//! ## Why a source-parsing guard
+//! The fix *is* an attribute. This guard encodes the invariant structurally —
+//! it parses the sibling source file and asserts that **every `#[test]` whose
+//! body references `PromptDelivery::Auto` carries the `serial(prompt_delivery_env)`
+//! key** (and that the env writers stay keyed). That enforces the rule for
+//! future tests too, not just today's two. It mirrors the existing
+//! `tests/no_legacy_goal_records_references.rs` "rg-shaped" TDD acceptance test.
+//!
+//! This file FAILS until the two size tests are annotated (TDD red) and PASSES
+//! once #2412's fix lands.
+
+use std::fs;
+use std::path::PathBuf;
+
+/// The serial key both the env writers and (post-fix) the Auto-mode readers
+/// must share so `serial_test` serializes them against each other.
+const SERIAL_KEY: &str = "serial(prompt_delivery_env)";
+
+/// Substring marking a test that consults the env override (Auto mode flows
+/// through `select_mode` → `std::env::var(ENV_OVERRIDE)`).
+const AUTO_MARKER: &str = "PromptDelivery::Auto";
+
+/// Substring marking a test that *mutates* the env override.
+const ENV_WRITE_MARKER: &str = "set_var(ENV_OVERRIDE";
+
+/// A prompt exceeding `HARD_CAP_BYTES` makes `select_mode` return `TooLarge`
+/// at its first step — *before* it reads `ENV_OVERRIDE` (see
+/// `src/prompt_delivery/mod.rs::select_mode`). A test that references this cap
+/// is exercising the oversize short-circuit, so it never consults the override
+/// and is correctly exempt from the serial requirement.
+const HARD_CAP_MARKER: &str = "HARD_CAP_BYTES";
+
+/// The two concrete de-flake targets named in issue #2412.
+const SIZE_TESTS: [&str; 2] = [
+    "applied_mode_reports_inline_for_small_prompt",
+    "applied_mode_reports_tempfile_for_large_prompt",
+];
+
+fn source_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/prompt_delivery.rs")
+}
+
+/// A parsed `#[test]` function: its attribute block (joined) and its
+/// brace-balanced body text.
+#[derive(Debug)]
+struct TestFn {
+    name: String,
+    attrs: String,
+    body: String,
+}
+
+/// Extract the identifier following `fn ` up to the opening `(`.
+fn parse_fn_name(sig: &str) -> String {
+    sig.split("fn ")
+        .nth(1)
+        .unwrap_or("")
+        .split('(')
+        .next()
+        .unwrap_or("")
+        .trim()
+        .to_string()
+}
+
+/// Read a brace-balanced function body starting at `start` (the `fn` line).
+/// Returns the body text and the index of the line after the closing brace.
+/// Naive brace counting is sufficient here: the bodies in
+/// `tests/prompt_delivery.rs` keep `{`/`}` balanced inside string literals.
+fn read_body(lines: &[&str], start: usize) -> (String, usize) {
+    let mut depth: i32 = 0;
+    let mut started = false;
+    let mut body = String::new();
+    let mut i = start;
+    while i < lines.len() {
+        for ch in lines[i].chars() {
+            match ch {
+                '{' => {
+                    depth += 1;
+                    started = true;
+                }
+                '}' => depth -= 1,
+                _ => {}
+            }
+        }
+        body.push_str(lines[i]);
+        body.push('\n');
+        i += 1;
+        if started && depth <= 0 {
+            break;
+        }
+    }
+    (body, i)
+}
+
+/// Parse every `#[test]` / `#[tokio::test]` function out of `src`, capturing the
+/// contiguous attribute block immediately preceding each `fn`.
+fn parse_test_fns(src: &str) -> Vec<TestFn> {
+    let lines: Vec<&str> = src.lines().collect();
+    let mut out = Vec::new();
+    let mut pending: Vec<&str> = Vec::new();
+    let mut i = 0;
+    while i < lines.len() {
+        let trimmed = lines[i].trim_start();
+
+        if trimmed.starts_with("#[") || trimmed.starts_with("#!") {
+            pending.push(trimmed);
+            i += 1;
+            continue;
+        }
+
+        let is_fn = trimmed.starts_with("fn ")
+            || trimmed.starts_with("async fn ")
+            || trimmed.starts_with("pub fn ")
+            || trimmed.starts_with("pub async fn ")
+            || trimmed.starts_with("pub(crate) fn ");
+
+        if is_fn {
+            let attrs = pending.join("\n");
+            if attrs.contains("#[test]") || attrs.contains("tokio::test") {
+                let name = parse_fn_name(trimmed);
+                let (body, next) = read_body(&lines, i);
+                out.push(TestFn { name, attrs, body });
+                pending.clear();
+                i = next;
+                continue;
+            }
+            pending.clear();
+            i += 1;
+            continue;
+        }
+
+        // Any other non-blank, non-attribute line breaks the attribute run.
+        if !trimmed.is_empty() {
+            pending.clear();
+        }
+        i += 1;
+    }
+    out
+}
+
+fn consults_env_override(t: &TestFn) -> bool {
+    t.body.contains(AUTO_MARKER) && !t.body.contains(HARD_CAP_MARKER)
+}
+
+fn load_tests() -> Vec<TestFn> {
+    let src = fs::read_to_string(source_path())
+        .unwrap_or_else(|e| panic!("failed to read {:?}: {e}", source_path()));
+    let tests = parse_test_fns(&src);
+    assert!(
+        !tests.is_empty(),
+        "parser found no #[test] fns in tests/prompt_delivery.rs — the parser or \
+         the source layout changed; fix this guard before trusting it"
+    );
+    tests
+}
+
+/// #2412 — the two named Auto-mode size tests must be serialized on the env key.
+#[test]
+fn auto_mode_size_tests_are_serialized_on_env_key() {
+    let tests = load_tests();
+
+    for name in SIZE_TESTS {
+        let t = tests.iter().find(|t| t.name == name).unwrap_or_else(|| {
+            panic!(
+                "expected test `{name}` in tests/prompt_delivery.rs; file structure \
+                 changed — update this guard"
+            )
+        });
+
+        assert!(
+            t.body.contains(AUTO_MARKER),
+            "`{name}` is expected to exercise `{AUTO_MARKER}` (it consults the \
+             {ENV} override); if that changed, revisit issue #2412",
+            ENV = "AMPLIHACK_PROMPT_DELIVERY",
+        );
+
+        assert!(
+            t.attrs.contains(SERIAL_KEY),
+            "#2412: `{name}` calls `apply_std(.., PromptDelivery::Auto)` which reads \
+             AMPLIHACK_PROMPT_DELIVERY, so it MUST be annotated \
+             `#[serial(prompt_delivery_env)]` to avoid racing the env-mutating \
+             tests. Add the attribute to de-flake it.\nAttributes found:\n{}",
+            t.attrs
+        );
+    }
+}
+
+/// Forward-looking invariant: ANY test that reads the override (Auto mode) must
+/// be serialized on the env key, so new Auto-mode tests cannot reintroduce the
+/// #2412 race.
+#[test]
+fn every_auto_mode_test_is_serialized_on_env_key() {
+    let tests = load_tests();
+
+    let offenders: Vec<&str> = tests
+        .iter()
+        .filter(|t| consults_env_override(t) && !t.attrs.contains(SERIAL_KEY))
+        .map(|t| t.name.as_str())
+        .collect();
+
+    assert!(
+        offenders.is_empty(),
+        "#2412 invariant: every test that consults `PromptDelivery::Auto` (and thus \
+         the AMPLIHACK_PROMPT_DELIVERY env override) must carry \
+         `#[serial(prompt_delivery_env)]`. Un-serialized Auto-mode tests: {offenders:?}"
+    );
+}
+
+/// Regression guard: the env *writers* must stay serialized (they already are).
+/// Keeps both sides of the mutual-exclusion contract enforced.
+#[test]
+fn env_writer_tests_remain_serialized() {
+    let tests = load_tests();
+
+    let offenders: Vec<&str> = tests
+        .iter()
+        .filter(|t| t.body.contains(ENV_WRITE_MARKER) && !t.attrs.contains(SERIAL_KEY))
+        .map(|t| t.name.as_str())
+        .collect();
+
+    assert!(
+        offenders.is_empty(),
+        "every test that mutates AMPLIHACK_PROMPT_DELIVERY must stay \
+         `#[serial(prompt_delivery_env)]`. Un-serialized env writers: {offenders:?}"
+    );
+}


### PR DESCRIPTION
## Summary

De-flakes the three known-flaky tests so they pass reliably under parallel `cargo test`. Closes #2412, #2408, #2384.

Both fixes preserve full suite parallelism (no blanket serialization) and keep production routing/behaviour unchanged, except one coupled bug fix called out below.

### #2412 — prompt_delivery env race
The two `Auto`-mode size tests in `tests/prompt_delivery.rs` read `AMPLIHACK_PROMPT_DELIVERY` (`ENV_OVERRIDE`) via `select_mode`, but lacked the serial key the four env-mutating tests already carried — so a reader could observe a leaked `inline`/`tempfile` value under parallelism.

- Add `#[serial(prompt_delivery_env)]` to `applied_mode_reports_inline_for_small_prompt` and `applied_mode_reports_tempfile_for_large_prompt`. The oversize test stays unkeyed (its `> HARD_CAP_BYTES` prompt short-circuits before the env read).
- New `tests/prompt_delivery_env_isolation.rs` source-parsing guard fails if any `Auto`-mode test loses the key (or any env writer does), enforcing the invariant for future tests.

### #2408 / #2384 — goal-board state-root race
`full_goal_lifecycle_crud` flaked (`left: 0, right: 3`) because the dashboard goal-CRUD handlers resolved `SIMARD_STATE_ROOT` ambiently; a concurrent `setenv` in an unrelated lib test could tear the read mid-lifecycle (glibc getenv/setenv aren't thread-safe).

- Split each of the **seven** goal-CRUD handlers into a thin ambient **wrapper** (resolves the root once, still bound by the router) + an env-free **`_at(state_root: &Path, …)` core** that does all load+save through the explicit path. `load_board_or_empty` → `load_board_or_empty_at`, removing `add_goal`'s second ambient resolve.
- New per-core env-independence tests + `full_goal_lifecycle_crud_via_at_is_env_independent`, which drives the lifecycle through the `_at` cores while a **decoy** `HermeticState` points the ambient root elsewhere. The original wrapper-path `full_goal_lifecycle_crud` is retained (deterministic via the `cognitive_memory` serial group enforced by `serial_guard`).

### Coupled bug fix (only production-behaviour change)
Wiring `remove_goal_at` surfaced a pre-existing dashboard bug: it saved removals through the **merge-on-write** `save_goal_board`, which resurrects a removed goal from the persisted snapshot. `remove_goal` now uses `save_goal_board_with_removals` (new `dashboard_save_goal_board_with_removals` helper), so dashboard removals actually persist — matching the CLI `simard goal remove` contract (#1923/#1925/#1926).

## Verification
- **20/20** consecutive parallel runs of the whole `prompt_delivery` binary — 0 failures.
- **20/20** consecutive parallel runs of the whole lib-test binary — **0 in-scope failures**.
- `serial_guard` meta-test green; clippy `--release` and `--all-targets --all-features --locked -- -D warnings` green; `cargo fmt --check` clean.
- Pre-commit + pre-push hooks pass locally.

> Note: on a dev box with a live `~/.simard` install / `copilot` on PATH, the unrelated `ooda_brain::recipe_brain` recipe-resolution and `base_type_copilot` copilot-spawning tests fail environment-specifically (they don't isolate `$HOME`/PATH); they pass or skip in clean CI and are out of scope.

## Docs
`docs/testing/deflaking-known-flaky-tests.md` documents both mechanisms, the `_at` core contract, the removal fix, and the verification gate (cross-linked from `cognitive-memory-serial-isolation.md`). No snapshot docs; no CI-workflow edits; no redeploy.

## Note on PR shape
Bundles both fixes as separate, independently-bisectable commits (one per issue group). They are cleanly separable if reviewers prefer two PRs.