### PR TITLE
fix(distill): strip ANSI escapes before facts scan so log-noised step output still parses (#2461)

### DIFF
--- a/src/memory_consolidation/distillation.rs
+++ b/src/memory_consolidation/distillation.rs
@@ -937,7 +937,16 @@ pub(crate) fn parse_recipe_output_full(raw: &str) -> SimardResult<DistillOutput>
 /// inside JSON string literals, respecting `\"` escapes) so a brace inside a
 /// fact's `content` cannot corrupt depth accounting.
 fn scan_for_facts_object(text: &str) -> Option<DistillOutput> {
-    let trimmed = text.trim();
+    // Strip ANSI escape sequences first. `recipe-runner-rs` / the agent binary
+    // render their tracing logs into the captured step `output` with ANSI colour
+    // codes — the t=7919 distill parse-failure's step output began with a dimmed
+    // `\x1b[2m<RFC3339 timestamp>` prefix. A raw `ESC` (`0x1b`) byte is invalid
+    // inside a JSON document, so when those codes colourise or interleave the
+    // agent's `{ "facts": [...] }` answer `serde_json` rejects the span and the
+    // whole 20-episode batch silently defers. Removing the escapes before the
+    // balanced-brace scan recovers the buried payload (issues #2461 / #2401).
+    let cleaned = strip_ansi_escapes(text);
+    let trimmed = cleaned.trim();
     // Fast path — the text IS the JSON object.
     if let Ok(parsed) = serde_json::from_str::<RecipeEnvelope>(trimmed) {
         return Some(parsed.into_output());
@@ -1007,6 +1016,75 @@ fn balanced_object_spans(s: &str) -> Vec<(usize, usize)> {
         }
     }
     spans
+}
+
+/// Strip ANSI escape sequences (CSI/SGR colour codes, OSC strings, and other
+/// simple `ESC x` two-byte escapes) from `s`.
+///
+/// `recipe-runner-rs` and the agent binary render their tracing logs into the
+/// captured step `output` with ANSI colour codes — the t=7919 distill
+/// parse-failure's step output began with a dimmed `\x1b[2m<RFC3339 timestamp>`
+/// prefix. A raw `ESC` (`0x1b`) byte is never valid inside a JSON document, so
+/// when those codes colourise or interleave the agent's `{ "facts": [...] }`
+/// answer, `serde_json` rejects the span and the batch silently defers (the
+/// "step output did not contain a parseable { facts } object" parse-failure).
+/// Removing the escapes before the balanced-brace scan recovers the payload.
+///
+/// Only RAW `0x1b` bytes are removed: a legitimately JSON-escaped `\u001b`
+/// inside fact content is the ASCII run `\`,`u`,`0`,`0`,`1`,`b` (no raw ESC) and
+/// is left untouched. Multi-byte UTF-8 content is preserved verbatim because
+/// every byte that is not part of an ASCII escape sequence is copied as-is.
+/// Returns the input unchanged (borrowed, no allocation) when it carries no
+/// `ESC` byte — the overwhelmingly common clean-output case.
+fn strip_ansi_escapes(s: &str) -> std::borrow::Cow<'_, str> {
+    let bytes = s.as_bytes();
+    if !bytes.contains(&0x1b) {
+        return std::borrow::Cow::Borrowed(s);
+    }
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] != 0x1b {
+            out.push(bytes[i]);
+            i += 1;
+            continue;
+        }
+        // Consume the `ESC` and classify the sequence that follows.
+        i += 1;
+        match bytes.get(i) {
+            // CSI: `ESC [` params/intermediates until a final byte 0x40..=0x7e
+            // (e.g. `\x1b[2m`, `\x1b[0m`, `\x1b[38;5;245m`).
+            Some(b'[') => {
+                i += 1;
+                while i < bytes.len() && !(0x40..=0x7e).contains(&bytes[i]) {
+                    i += 1;
+                }
+                if i < bytes.len() {
+                    i += 1; // consume the final byte
+                }
+            }
+            // OSC: `ESC ]` … terminated by BEL (`0x07`) or ST (`ESC \`).
+            Some(b']') => {
+                i += 1;
+                while i < bytes.len() {
+                    if bytes[i] == 0x07 {
+                        i += 1;
+                        break;
+                    }
+                    if bytes[i] == 0x1b && bytes.get(i + 1) == Some(&b'\\') {
+                        i += 2;
+                        break;
+                    }
+                    i += 1;
+                }
+            }
+            // Any other two-byte escape (charset select, etc.) — drop `ESC` + 1.
+            Some(_) => i += 1,
+            // Trailing lone `ESC` — nothing else to drop.
+            None => {}
+        }
+    }
+    std::borrow::Cow::Owned(String::from_utf8_lossy(&out).into_owned())
 }
 
 /// The `recipe-runner-rs` 0.3.6 `--output-format json` envelope. Only the
@@ -1524,5 +1602,79 @@ mod unit_tests {
         // answer and must parse to zero facts (not an error).
         let facts = parse_recipe_output(r#"{"facts":[]}"#).unwrap();
         assert!(facts.is_empty());
+    }
+
+    // ── t=7919: ANSI-coded tracing-log noise in step output ──────────────
+
+    #[test]
+    fn strip_ansi_escapes_removes_csi_and_preserves_text_and_utf8() {
+        let esc = '\u{1b}';
+        let input = format!("{esc}[2mdim{esc}[0m plain {esc}[38;5;245mgrey{esc}[0m — café");
+        assert_eq!(strip_ansi_escapes(&input), "dim plain grey — café");
+        // No ESC byte → returned borrowed with no allocation.
+        assert!(matches!(
+            strip_ansi_escapes("no escapes here"),
+            std::borrow::Cow::Borrowed(_)
+        ));
+        // A JSON-escaped `\u001b` in content is an ASCII run (not a raw ESC) and
+        // must be left untouched so legitimate fact content is never mangled.
+        assert_eq!(
+            strip_ansi_escapes(r"literal \u001b stays"),
+            r"literal \u001b stays"
+        );
+    }
+
+    #[test]
+    fn parse_recipe_output_recovers_facts_from_ansi_log_noise() {
+        // The t=7919 cycle: the distill step output carried ANSI-coded tracing
+        // log lines (the failing excerpt began `\x1b[2m2026-06-28T06:38:25…`)
+        // with the agent's facts object colourised inline. The raw ESC bytes
+        // interleaved with the JSON made `serde_json` reject the span, so the
+        // whole batch silently deferred. ANSI stripping recovers it.
+        let esc = '\u{1b}';
+        let raw = format!(
+            "{esc}[2m2026-06-28T06:38:25.928376Z{esc}[0m {esc}[36m DEBUG{esc}[0m thinking…\n\
+             {{\"facts\":[{{\"concept\":\"{esc}[33mbug-pattern{esc}[0m\",\
+             \"content\":\"ansi noise must be stripped\",\"source_episode_id\":\"epi_7\"}}]}}"
+        );
+        let facts = parse_recipe_output(&raw).expect("must recover facts past ANSI noise");
+        assert_eq!(facts.len(), 1);
+        assert_eq!(facts[0].concept, "bug-pattern");
+        assert_eq!(facts[0].content, "ansi noise must be stripped");
+    }
+
+    #[test]
+    fn parse_recipe_output_full_recovers_facts_from_ansi_coded_step_output() {
+        // Exact production t=7919 path: the `--output-format json` envelope's
+        // `distill` step `output` string is ANSI-coded tracing log noise
+        // (begins with the dimmed `\x1b[2m<timestamp>` prefix from the failing
+        // cycle) with the agent's facts object colourised inline. Before ANSI
+        // stripping this raised "step output did not contain a parseable
+        // { facts } object" and the 20-episode batch deferred for a full cycle;
+        // now the buried object is mined out of the step output and parsed.
+        let esc = '\u{1b}';
+        let step_output = format!(
+            "{esc}[2m2026-06-28T06:38:25.928376Z{esc}[0m {esc}[32m INFO{esc}[0m \
+             {esc}[2msimard::distill{esc}[0m: distilling 20 episodes\n\
+             {{{esc}[0m\"facts\":[{{\"concept\":\"{esc}[33mlesson-learned{esc}[0m\",\
+             \"content\":\"strip ansi before the facts scan\",\
+             \"source_episode_id\":\"epi_42\"}}]}}\n"
+        );
+        let envelope = serde_json::json!({
+            "recipe_name": "distill-episodes",
+            "success": true,
+            "step_results": [{
+                "step_id": "distill",
+                "status": "completed",
+                "output": step_output,
+                "error": ""
+            }]
+        })
+        .to_string();
+        let out = parse_recipe_output_full(&envelope).expect("ANSI-coded step output must parse");
+        assert_eq!(out.facts.len(), 1);
+        assert_eq!(out.facts[0].concept, "lesson-learned");
+        assert_eq!(out.facts[0].content, "strip ansi before the facts scan");
+        assert_eq!(out.facts[0].source_episode_id, "epi_42");
     }
 }

--- a/tests/qa-scenarios/distill-ansi-step-output-parse.yaml
+++ b/tests/qa-scenarios/distill-ansi-step-output-parse.yaml
@@ -1,0 +1,66 @@
+name: distill-ansi-step-output-parse
+app_type: cli
+description: |
+  Verify episode→fact distillation recovers the agent's `{ "facts": [...] }`
+  answer when the `--output-format json` envelope's `distill` step `output`
+  carries ANSI-coded tracing-log noise instead of clean JSON (the t=7919 cycle:
+  the failing step output began with a dimmed `\x1b[2m2026-06-28T06:38:25…`
+  timestamp prefix). Raw `ESC` (0x1b) bytes are invalid inside JSON, so before
+  the fix a colourised / log-interleaved facts object failed `serde_json` and a
+  full 20-episode batch silently deferred for a cycle. `scan_for_facts_object`
+  now strips ANSI escapes before the balanced-brace scan, recovering the buried
+  payload. Proven by the hermetic in-process unit tests this scenario drives
+  (no network, no live host mutation). The CLI runner rejects any non-zero exit,
+  so a failing test fails the scenario.
+agents:
+  - name: simard-cli
+    type: cli
+    command: cargo
+steps:
+  # Production path: the recipe-runner-rs JSON envelope's distill-step output is
+  # ANSI-coded log noise with the facts object colourised inline; the parser
+  # mines and parses it instead of erroring "step output did not contain a
+  # parseable { facts } object". First invocation may compile the test binary.
+  - action: run
+    params:
+      command: "cargo test --locked --lib memory_consolidation::distillation::unit_tests::parse_recipe_output_full_recovers_facts_from_ansi_coded_step_output"
+    timeout: 600000
+  - action: wait_for_output
+    params:
+      value: "test result: ok"
+    timeout: 8000
+  - action: validate_exit_code
+    params:
+      value: "0"
+    timeout: 5000
+
+  # Facts-only wrapper: ANSI log lines (exact failing `\x1b[2m`+timestamp
+  # excerpt) around the facts object are stripped and the facts recovered.
+  - action: run
+    params:
+      command: "cargo test --locked --lib memory_consolidation::distillation::unit_tests::parse_recipe_output_recovers_facts_from_ansi_log_noise"
+    timeout: 300000
+  - action: wait_for_output
+    params:
+      value: "test result: ok"
+    timeout: 8000
+  - action: validate_exit_code
+    params:
+      value: "0"
+    timeout: 5000
+
+  # Stripper unit: CSI/SGR codes are removed, plain + multi-byte UTF-8 text is
+  # preserved, and a JSON-escaped `\u001b` (ASCII run, not a raw ESC) is left
+  # untouched so legitimate fact content is never mangled.
+  - action: run
+    params:
+      command: "cargo test --locked --lib memory_consolidation::distillation::unit_tests::strip_ansi_escapes_removes_csi_and_preserves_text_and_utf8"
+    timeout: 300000
+  - action: wait_for_output
+    params:
+      value: "test result: ok"
+    timeout: 8000
+  - action: validate_exit_code
+    params:
+      value: "0"
+    timeout: 5000


### PR DESCRIPTION
## Problem (fresh signal, t=7919)

Episode→fact distillation runs `recipe-runner-rs --output-format json` (#2402) and mines the agent's `{ "facts": [...] }` answer out of the envelope's `step_results[].output` string via `scan_for_facts_object` (balanced-brace scan). **This cycle the `distill` step `output` carried ANSI-coded tracing-log lines instead of clean JSON** — the failure excerpt began:

```
\x1b[2m2026-06-28T06:38:25.928376Z…
```

Raw `ESC` (`0x1b`) bytes are invalid inside a JSON document, so when those colour codes colourise / interleave the facts object, `serde_json` rejects the span, `scan_for_facts_object` returns `None`, and **a full 20-episode batch silently defers for an entire consolidation cycle**. This is the same `ParseFailure` class catalogued by #2461 (t=7517) and #2468 (t=7713), but a **new, distinct root cause** (ANSI/log noise, not banner-shadowing).

### Root cause confirmed empirically

A raw ANSI-interleaved facts object fails `serde_json`; after stripping ANSI escapes the identical bytes parse:

```
raw-span parses?      false
stripped-span parses? true   → concept="lesson-learned"
```

## Fix

Add `strip_ansi_escapes` (CSI/SGR colour codes, OSC strings, simple two-byte escapes) and apply it at the top of `scan_for_facts_object`, **before** the balanced-brace scan, so a colourised / log-interleaved facts object is recovered. It is:

- **Zero-cost on the clean path** — returns `Cow::Borrowed` unchanged when the input carries no `ESC` byte (the overwhelmingly common case), so no existing behaviour and no allocation changes.
- **Content-safe** — only RAW `0x1b` bytes are removed. A legitimately JSON-escaped `\u001b` inside fact content is a pure-ASCII run and is left untouched; multi-byte UTF-8 is preserved verbatim.

### Dedup — what this does NOT duplicate

Verified all related issues are `rysweet`-authored. This PR is **complementary** to the already-merged / tracked work:

| Item | Status | Scope |
|------|--------|-------|
| #2402 | merged | `--output-format json` envelope + unwrap |
| #2464 | merged (closed #2461) | `distill_success_rate` / `distill_parse_success_rate` metrics + **last-non-empty** parser salvage |
| #2468 | open | bounded **in-cycle retry** (remediation *c*) |

The **metric already exists** (#2464), so no counter is duplicated. The **last-non-empty salvage** (#2464) does not strip ANSI, so it could not recover this case. This change **deterministically** recovers ANSI-obscured-but-present facts objects, shrinking the transient `ParseFailure` population that #2468's retry must cover. (When the step output contains *no* facts object at all, behaviour is unchanged — the `ParseFailure` metric still records it correctly and #2468's retry remains the right remedy.)

---

## Merge-ready evidence

### 1. qa-team scenarios
New scenario `tests/qa-scenarios/distill-ansi-step-output-parse.yaml` drives the three hermetic unit tests through the gadugi CLI runner.

- **validate**: `gadugi-test validate -f tests/qa-scenarios/distill-ansi-step-output-parse.yaml --strict` → `✓ Scenario "distill-ansi-step-output-parse" is valid` (1 valid, 0 invalid).
- **run**: `gadugi-test run -d tests/qa-scenarios -s distill-ansi-step-output-parse` → `✓ Passed: 1 / ✗ Failed: 0` — all three steps reported `test result: ok` + exit 0.

### 2. Docs / changed surfaces
No user-facing surface changes. The fix is **internal-only** to the distillation parser (`scan_for_facts_object` / new private `strip_ansi_escapes`). No public API, CLI flag, output format, or config changed — the only observable effect is fewer silent batch deferrals. Changed surfaces: `src/memory_consolidation/distillation.rs` (private fn + 1 call site + 3 tests), `tests/qa-scenarios/distill-ansi-step-output-parse.yaml` (new test).

### 3. quality-audit (≥3 SEEK→VALIDATE→FIX cycles, clean final)
- **Cycle 1** — diff self-review: isolated change (153 insertions, 1 deletion), no findings.
- **Cycle 2** — edge-case audit (CSI/OSC truncation, lone trailing ESC, escaped `\u001b`, multi-byte UTF-8, byte-index slicing on the reallocated string): all guarded with `bytes.get(i)` / bounds checks; no panic, no over-read. Independently confirmed by a code-review agent: *"No significant issues found."*
- **Cycle 3** — regression: all 61 distillation module tests pass (incl. last-object-wins banner, brace-in-content, unmatched-quote-in-prose); `cargo fmt --check` clean; `cargo clippy --all-targets --all-features --locked -- -D warnings` clean. Final cycle clean.

### 4. CI
Local mirror of CI gates all green: pre-commit (Rust-only gate, `cargo fmt --all -- --check`, `cargo clippy --release --no-deps -- -D warnings`) and pre-push (`cargo clippy --all-targets --all-features --locked -- -D warnings`) all **Passed**. Full `cargo test --locked --lib`: the 61 distillation tests + 3 new tests pass; the only failures observed locally (`ooda_brain::recipe_brain::resolve_recipe_path_*`, `operator_commands_ooda` daemon mtime, `safe_update`) reproduce **identically on clean `main` with this change stashed** — they are pre-existing host-environment artifacts (deployed `~/.simard/prompt_assets/.../recipes` + clock/mtime sensitivity), unrelated to this diff. CI on a clean runner is authoritative; will confirm green below.

### 6. Focused diff
Two files: the parser fix + its tests, and one qa-scenario. No unrelated edits. Measured numbers live only in this PR body / memory — no snapshot or findings docs committed.
