### PR TITLE
feat(brain): trustworthy-confidence primitive + external-signal completion gate (#2457, #2456)

### DIFF
--- a/docs/concepts/trustworthy-confidence-and-external-completion.md
+++ b/docs/concepts/trustworthy-confidence-and-external-completion.md
@@ -1,0 +1,187 @@
+---
+title: "Concept: trustworthy confidence + external-signal completion"
+description: Why Simard's brain attaches a usable, calibrated confidence to its Decide and engineer-lifecycle judgments (verbalized confidence + self-consistency), and why goal completion is verified against external signals (merged PR, closed issue, CI, deploy) instead of subordinate self-reports. Together these make the escalation ladder (#2432) and consolidation gate (#2433) trust the right judgments and stop the daemon from archiving unproven work.
+last_updated: 2026-06-28
+review_schedule: as-needed
+owner: simard
+doc_type: concept
+status: design — not yet implemented
+related:
+  - deploy-aware-done-gate.md
+  - prompt-driven-ooda-brain.md
+  - progress-evidence-gating.md
+  - ../reference/trustworthy-confidence-api.md
+  - ../reference/external-signal-completion-gate.md
+  - ../reference/completion-evidence-gate-api.md
+  - ../howto/interpret-brain-confidence-and-verify-completion.md
+  - ../../src/ooda_brain/orient.rs
+  - ../../src/ooda_brain/decide.rs
+  - ../../src/ooda_brain/judgment_record.rs
+  - ../../src/goal_curation/completion_gate.rs
+---
+
+# Concept: trustworthy confidence + external-signal completion
+
+> **Status: design specification — not yet implemented (issues
+> [#2457](https://github.com/rysweet/Simard/issues/2457) and
+> [#2456](https://github.com/rysweet/Simard/issues/2456), both open).**
+>
+> This document describes the **intended** design and the *why* behind it.
+> Nothing here ships yet: the verbalized-confidence fields on
+> [`DecideJudgment`](https://github.com/rysweet/Simard/blob/main/src/ooda_brain/decide.rs)
+> and
+> [`EngineerLifecycleDecision`](https://github.com/rysweet/Simard/blob/main/src/ooda_brain/mod.rs),
+> the `self_consistency` sampler, the `self_metrics::calibration` ECE spine, and
+> the external-signal completion ladder in `completion_gate.rs` are all
+> **planned, not live**. The precedent it builds on —
+> [`OrientJudgment.confidence`](https://github.com/rysweet/Simard/blob/main/src/ooda_brain/orient.rs)
+> and
+> [`BrainJudgmentRecord.confidence`](https://github.com/rysweet/Simard/blob/main/src/ooda_brain/judgment_record.rs)
+> — does exist today. See the
+> [trustworthy-confidence API](../reference/trustworthy-confidence-api.md) and the
+> [external-signal completion gate](../reference/external-signal-completion-gate.md)
+> for the proposed typed surfaces.
+
+> Simard's brain should attach a **usable confidence** to the judgments that
+> matter, and refuse to call a goal **done** on a subordinate's word. Confidence
+> is earned (verbalized *and* corroborated by self-consistency); completion is
+> verified (against merged PRs, closed issues, green CI, and live deploys).
+
+## The two problems this solves
+
+These are two halves of one trust problem: *do not act on a signal more than it
+deserves*.
+
+### 1. Decisions had no usable confidence (#2457)
+
+The Orient phase already carries a self-reported `confidence` (see
+[`OrientJudgment`](https://github.com/rysweet/Simard/blob/main/src/ooda_brain/orient.rs)),
+but the two **commitment** phases do not:
+
+- **Decide** (`DecideJudgment`) — which action kind to run this cycle.
+- **Engineer-lifecycle** (`EngineerLifecycleDecision`) — whether to reclaim a
+  wedged worktree, open a tracking issue, mark a goal blocked, etc.
+
+Downstream machinery that *should* spend more compute on shaky judgments and
+trust solid ones has nothing to read:
+
+- The [confidence-gated escalation ladder (#2432)](prompt-driven-ooda-brain.md)
+  escalates only on a hard parse-miss — a binary proxy for "low confidence."
+- The [consolidation / ISAO reliability gate (#2433)](../reference/cognitive-memory-provenance.md)
+  needs a per-judgment confidence to set `CognitiveFact.confidence` honestly.
+
+Without a real number, "I'm 0.55 sure" and "I'm 0.98 sure" are indistinguishable.
+
+### 2. "Done" is a self-report (#2456)
+
+The completion path trusts **artifact existence** — "a commit or a PR exists,
+therefore the goal is complete." That is exactly the subordinate-self-report
+trust the daemon should not extend: an open PR, a local commit, or an
+engineer's "I finished" string is *weak* evidence. Goals can be archived as
+`Completed` with red CI, an unmerged PR, or a still-open linked issue.
+
+The [deploy-aware done-gate (#2450)](deploy-aware-done-gate.md) already raised
+the bar for *archival* (merged PR + closed issue + verified deploy). #2456 would
+extend that same philosophy **upstream** to the moment a goal is first marked
+complete, so weak signals never reach the archive gate as `Completed` in the
+first place.
+
+## How trustworthy confidence works (#2457)
+
+Two independent signals are combined, cheaply by default and expensively only
+when it matters.
+
+1. **Verbalized confidence** — the brain reports a `0.0–1.0` probability
+   alongside its choice ("Just-Ask-for-Calibration"). It rides the existing
+   wire format: a `CONFIDENCE:` line for the prose-parsed Decide (`DECISION:`
+   marker) and engineer-lifecycle (first-word match) phases, and the
+   `"confidence"` JSON key for Orient.
+2. **Self-consistency** — for **high-stakes / irreversible** judgments with
+   budget headroom, the brain is sampled `K` times (default 3) and
+   `confidence = modal_count / K`. Agreement *is* the calibration signal; a
+   3/3 sweep is trusted, a 1/3/1 split is not.
+
+The result would be recorded on the judgment, surfaced on
+[`BrainJudgmentRecord.confidence`](https://github.com/rysweet/Simard/blob/main/src/ooda_brain/judgment_record.rs)
+in cycle reports, fed to the #2432 ladder and the #2433 gate, and scored for
+**calibration** (Expected Calibration Error) against the only objective
+outcome available: the #2456 verification result.
+
+### Confidence unlocks privilege — so it fails *closed*
+
+Confidence is consumed by gates that *grant* trust (more compute, fact
+promotion, fewer re-checks). Therefore a confidence that was **solicited but
+could not be trusted** — absent when requested, malformed, or out of `[0,1]` —
+collapses to a **low-trust floor**, never to `1.0`. The cheerful
+`default_confidence() = 1.0` is reserved for genuinely deterministic and legacy
+paths (the deterministic floor brain, and old cycle reports that predate the
+field). This is the single most important safety property of the primitive:
+**you cannot earn trust by emitting garbage.**
+
+## How external-signal completion works (#2456)
+
+Completion would be decided by a **signal-strength ladder**, not by counting
+artifacts:
+
+| Strength | Signals | Effect |
+| --- | --- | --- |
+| **Strong** | merged PR · closed linked issue · green CI · build/test exit-success · satisfied goal-graph postcondition · deploy-verified ([#2450 gate](deploy-aware-done-gate.md)) | Can complete |
+| **Weak** | open PR exists · local commit exists · subordinate "done" text | Never sufficient alone |
+
+- Subordinate claims done **and ≥1 strong signal** ⇒ `Completed`.
+- Subordinate claims done, a strong signal is **derivable but refuted** (CI red,
+  exit ≠ 0, issue still open) ⇒ recorded `refuted`, routed to
+  `OpenTrackingIssue`, **not** completed or archived.
+- Subordinate claims done, **no strong signal derivable** ⇒ the honest
+  `CompletedUnverified` outcome — held for review, **not archivable**.
+
+> **Shipped vs. design.** Today the gate emits the `unverified_no_signal`
+> *outcome* (via `goal_completion_verification`) and keeps such goals
+> **blocked-and-retained** (held for review, never archived). The distinct
+> persisted `GoalProgress::CompletedUnverified` *state* — which would ripple
+> through ~60 exhaustive `match GoalProgress` sites — is kept as forward design;
+> see the [gate reference](../reference/external-signal-completion-gate.md).
+
+This would reuse the [`CompletionEvidenceGate`](../reference/completion-evidence-gate-api.md)
+(it is the deploy-verified strong signal), rather than duplicating it.
+
+## The shared spine: outcomes calibrate confidence
+
+The two halves would close a loop. The #2456 verification verdict would be the
+**ground truth** that scores #2457's confidence:
+
+```
+brain judgment ──confidence──▶ self_metrics::calibration (ECE)
+       │                                   ▲
+       ▼                                   │ realized outcome
+   action runs ─▶ external signals ─▶ completion verdict (verified / refuted)
+```
+
+- `verified` → realized outcome `1`
+- `refuted` → realized outcome `0`
+- `unverified_no_signal` / `error` → excluded from calibration (no ground truth)
+
+Expected Calibration Error (`brain_confidence_ece`) over a rolling window tells
+operators whether the brain's stated confidence *means* anything. A
+well-calibrated brain that says "0.7" is right ~70% of the time.
+
+## What this is **not**
+
+- **Confidence is advisory, never a hard gate on irreversible action.** A high
+  confidence number cannot *by itself* complete a goal, archive it, or authorize
+  a destructive lifecycle action — those require external evidence (above). This
+  prevents a confidently-wrong brain from talking itself into harm.
+- **It does not reimplement #2432 or #2433.** Those ladders/gates already exist
+  and are merged; #2457 would only *produce and expose* the confidence they
+  consume.
+- **It does not replace the [deploy-aware done-gate](deploy-aware-done-gate.md).**
+  #2456 would extend the same evidence philosophy to the earlier "mark complete"
+  decision and *consume* the deploy gate's verdict as one strong signal.
+
+## See also
+
+- [Trustworthy-confidence API reference](../reference/trustworthy-confidence-api.md)
+- [External-signal completion gate reference](../reference/external-signal-completion-gate.md)
+- [How-to: interpret brain confidence and verify completion](../howto/interpret-brain-confidence-and-verify-completion.md)
+- [Concept: deploy-aware done-gate](deploy-aware-done-gate.md)
+- [Concept: prompt-driven OODA brain](prompt-driven-ooda-brain.md)

--- a/docs/howto/interpret-brain-confidence-and-verify-completion.md
+++ b/docs/howto/interpret-brain-confidence-and-verify-completion.md
@@ -1,0 +1,166 @@
+---
+title: How to interpret brain confidence and verify goal completion
+description: Operator runbook for the trustworthy-confidence primitive (#2457) and the external-signal completion gate (#2456) — read per-judgment confidence in cycle reports, check brain calibration (ECE) and the goal_false_completion_rate, understand the hold-for-review handling of unverified completions, and tune the self-consistency / high-stakes / verification knobs.
+last_updated: 2026-06-28
+review_schedule: as-needed
+owner: simard
+doc_type: howto
+status: partially implemented
+related:
+  - ../concepts/trustworthy-confidence-and-external-completion.md
+  - ../reference/trustworthy-confidence-api.md
+  - ../reference/external-signal-completion-gate.md
+  - ../howto/diagnose-a-rejected-goal-completion.md
+  - ../reference/completion-evidence-gate-api.md
+---
+
+# How to interpret brain confidence and verify goal completion
+
+> **Status: partially implemented (issues
+> [#2457](https://github.com/rysweet/Simard/issues/2457) and
+> [#2456](https://github.com/rysweet/Simard/issues/2456), both open).**
+>
+> This runbook documents the operator interface for the
+> trustworthy-confidence primitive
+> ([`src/ooda_brain/confidence.rs`](https://github.com/rysweet/Simard/blob/main/src/ooda_brain/confidence.rs) —
+> **shipped**, exported from `crate::ooda_brain`; the self-consistency vote lives
+> in that same file, not a separate `self_consistency.rs`) and the external-signal
+> completion gate in
+> [`src/goal_curation/completion_gate.rs`](https://github.com/rysweet/Simard/blob/main/src/goal_curation/completion_gate.rs).
+> The `goal_completion_verification` and `goal_false_completion_rate` metrics are
+> emitted live by the gate today. What is **not yet wired**: the live brain does
+> not yet *populate* per-judgment `confidence` from a verbalized score, so
+> `brain_confidence_ece` and the cycle-report `confidence` fields below describe
+> the **target** interface and stay at their placeholder values until the
+> verbalized-confidence solicitation lands. No-signal completions are **held for
+> review** (blocked, not archived) today; the distinct `completed-unverified`
+> persisted state is forward design (see the
+> [gate reference](../reference/external-signal-completion-gate.md)). See the
+> [concept](../concepts/trustworthy-confidence-and-external-completion.md) for
+> the why.
+
+You want to know **how much to trust** a brain decision, or **why a goal did not
+complete**. This guide shows where these numbers *will* live and which knobs
+*will* tune them once the feature ships.
+
+## 1. Read per-judgment confidence in a cycle report
+
+Once shipped, every Decide and engineer-lifecycle judgment will record a real
+confidence. Cycle reports live under `~/.simard/cycle_reports/cycle_*.json`:
+
+```bash
+jq '.brain_judgments[] | {phase, decision, confidence, fallback}' \
+  ~/.simard/cycle_reports/cycle_*.json | tail -20
+```
+
+```json
+{ "phase": "decide",  "decision": "advance_goal",          "confidence": 0.82, "fallback": false }
+{ "phase": "act",     "decision": "reclaim_and_redispatch", "confidence": 0.67, "fallback": false }
+{ "phase": "act",     "decision": "continue_skipping",      "confidence": 0.0,  "fallback": true  }
+```
+
+How to read it:
+
+- **`confidence: 0.82`** — verbalized confidence (or, for high-stakes judgments,
+  `modal_count / K` from self-consistency).
+- **`0.67`** — a 2/3 self-consistency split on an irreversible lifecycle action:
+  the brain agreed twice out of three samples.
+- **`confidence: 0.0` with `fallback: true`** — the brain *fell back* to the
+  deterministic mapping after an LLM failure, or a solicited confidence was
+  missing/malformed. Per the
+  [fail-closed policy](../reference/trustworthy-confidence-api.md#default-policy),
+  an *un-trustworthy* confidence reads as `0.0`, never `1.0`. Treat it as "the
+  brain could not stand behind this."
+
+> A value of exactly `1.0` means either a genuinely deterministic decision or a
+> legacy record predating the field — **not** "maximally confident LLM."
+
+## 2. Check whether confidence *means* anything (calibration)
+
+A confidence number is only useful if it is calibrated. The brain scores its own
+Expected Calibration Error against the [completion verdict](#4-understand-why-a-goal-did-not-complete):
+
+```bash
+jq -r 'select(.metric_name=="brain_confidence_ece") | "\(.timestamp) ECE=\(.value)"' \
+  ~/.simard/metrics/metrics.jsonl | tail -10
+```
+
+- **Lower is better.** ECE near `0.0` means "when the brain says 0.7, it is right
+  ~70% of the time."
+- A rising ECE means stated confidence is drifting from reality — inspect recent
+  prompts or model changes.
+- ECE is computed over a rolling window of 50 verifiable judgments with 10 bins
+  (see the [reference](../reference/trustworthy-confidence-api.md#calibration-expected-calibration-error)).
+  `unverified_no_signal` / `error` completions carry no ground truth and are
+  excluded.
+
+## 3. Tune the confidence knobs
+
+| Goal | Knob | Default | Effect |
+| --- | --- | --- | --- |
+| Spend more on shaky high-stakes calls | `SIMARD_BRAIN_SELF_CONSISTENCY_K` | `3` | Higher K = finer-grained confidence, more cost. `1` disables sampling. |
+| Change what counts as "high-stakes" (Decide) | `SIMARD_BRAIN_HIGH_STAKES_URGENCY` | `0.8` | Lower = more decisions sampled. |
+| Stop ECE recording | `SIMARD_BRAIN_CONFIDENCE_CALIBRATION` | `on` | `off` keeps confidence, skips the metric. |
+
+The sampler **never exceeds the daily/weekly budget** (`SIMARD_DAILY_BUDGET_USD`
+/ `SIMARD_WEEKLY_BUDGET_USD`): under budget pressure it transparently degrades to
+`K = 1` rather than skipping the decision.
+
+```bash
+# Be stricter: sample 5x and treat urgency ≥ 0.6 as high-stakes.
+SIMARD_BRAIN_SELF_CONSISTENCY_K=5 SIMARD_BRAIN_HIGH_STAKES_URGENCY=0.6 simard daemon
+```
+
+## 4. Understand why a goal did not complete
+
+The [external-signal completion gate](../reference/external-signal-completion-gate.md)
+refuses to mark a goal `Completed` on a self-report alone. A goal you expected to
+be done can land in one of three states:
+
+| You see | Meaning | What to do |
+| --- | --- | --- |
+| Goal stays active with a blocker | A strong signal was **refuted** (CI red, exit ≠ 0, issue still open). A tracking issue is opened. | Fix the failing signal; see [diagnose a rejected goal completion](./diagnose-a-rejected-goal-completion.md). |
+| Status `completed-unverified` | Subordinate claimed done, but **no strong signal** corroborates it. Held for review, **not archived**. | Provide a strong signal (merge the PR, land green CI) or close it out manually. |
+| Status `completed` | A strong signal (merged PR / closed issue / green CI / verified deploy) corroborated the claim. | Nothing — it will archive normally. |
+
+Find unverified completions on the board:
+
+```bash
+simard goal-curation read | grep -i 'completed-unverified'
+```
+
+## 5. Watch the false-completion rate
+
+```bash
+jq -r 'select(.metric_name=="goal_false_completion_rate") | "\(.timestamp) rate=\(.value)"' \
+  ~/.simard/metrics/metrics.jsonl | tail -10
+
+# Per-event verdicts (verified / refuted / unverified_no_signal / error):
+jq -r 'select(.metric_name=="goal_completion_verification") | "\(.context)"' \
+  ~/.simard/metrics/metrics.jsonl | tail -20
+```
+
+`goal_false_completion_rate = refuted / (verified + refuted)` over the last 50
+*checkable* completions. A non-zero rate means subordinates are claiming done on
+work that external signals contradict — exactly the behaviour this gate exists to
+catch. A rate trending up warrants tightening engineer prompts or review.
+
+## 6. Roll back the completion ladder (emergency only)
+
+If the stricter gate is blocking legitimate completions during an incident, you
+can restore the legacy artifact-existence behaviour **without a redeploy**:
+
+```bash
+SIMARD_COMPLETION_VERIFICATION=lenient simard daemon   # legacy behaviour
+SIMARD_COMPLETION_VERIFICATION=off      simard daemon   # disable the ladder entirely
+```
+
+Prefer `lenient` over `off`, and revert as soon as the incident clears — `strict`
+is the safe default that keeps unproven work out of the archive.
+
+## See also
+
+- [Concept: trustworthy confidence + external-signal completion](../concepts/trustworthy-confidence-and-external-completion.md)
+- [Trustworthy-confidence API reference](../reference/trustworthy-confidence-api.md)
+- [External-signal completion gate reference](../reference/external-signal-completion-gate.md)
+- [How to diagnose a rejected goal completion](./diagnose-a-rejected-goal-completion.md)

--- a/docs/reference/external-signal-completion-gate.md
+++ b/docs/reference/external-signal-completion-gate.md
@@ -1,0 +1,357 @@
+---
+title: External-signal completion gate reference
+description: Reference for the external-signal completion gate (#2456) — the signal-strength classifier that decides goal completion from strong external signals (merged PR, closed issue, green CI, build/test exit-success, satisfied postcondition, verified deploy) instead of weak self-reports, the refuted→OpenTrackingIssue routing, the goal_completion_verification / goal_false_completion_rate metrics, the hold-for-review handling of no-signal completions (with GoalProgress::CompletedUnverified kept as future design), and how it extends (not duplicates) the deploy-aware CompletionEvidenceGate (#2450).
+last_updated: 2026-06-28
+review_schedule: as-needed
+owner: simard
+doc_type: reference
+status: partially implemented
+related:
+  - ../concepts/trustworthy-confidence-and-external-completion.md
+  - ../concepts/deploy-aware-done-gate.md
+  - ./completion-evidence-gate-api.md
+  - ./trustworthy-confidence-api.md
+  - ./progress-evidence-api.md
+  - ../howto/interpret-brain-confidence-and-verify-completion.md
+  - ../../src/goal_curation/completion_gate.rs
+  - ../../src/goal_curation/operations.rs
+  - ../../src/goal_curation/types.rs
+---
+
+# External-signal completion gate reference
+
+> **Status: partially implemented (issue [#2456](https://github.com/rysweet/Simard/issues/2456), open).**
+>
+> **Shipped now** — a verification-outcome classifier that *extends* the
+> deploy-aware [`CompletionEvidenceGate`](./completion-evidence-gate-api.md)
+> (#2450) without duplicating it, in
+> [`src/goal_curation/completion_gate.rs`](https://github.com/rysweet/Simard/blob/main/src/goal_curation/completion_gate.rs):
+> the
+> [`VerificationOutcome`](#verificationoutcome-shipped) enum
+> (`Verified` / `UnverifiedNoSignal` / `Refuted` / `Error`); `classify_outcome`
+> and `classify_from_missing` mapping a `CompletionVerdict` to an outcome;
+> `has_derivable_signal` (a goal has an external signal iff it has a PR ref, an
+> issue ref, or is self-affecting); `record_completion_verification` emitting
+> `goal_completion_verification` and `record_false_completion_rate` emitting the
+> `goal_false_completion_rate` time-series via `self_metrics::record_metric`; and
+> `false_completion_rate` = `refuted / (verified + refuted)`. `archive_completed_evidence_aware`
+> records the per-event outcome and the per-batch rate for every completion
+> candidate. All are unit-tested.
+>
+> **Exists already** (the #2450 precedent this extends):
+> [`CompletionEvidence`](https://github.com/rysweet/Simard/blob/main/src/goal_curation/completion_gate.rs)
+> (`pr_merged`, `issue_closed`, `self_affecting`, `deployed`),
+> [`CompletionVerdict`](https://github.com/rysweet/Simard/blob/main/src/goal_curation/completion_gate.rs)
+> (`Complete` / `Blocked`), the injected `EvidenceSource` seam, and
+> [`GoalProgress`](https://github.com/rysweet/Simard/blob/main/src/goal_curation/types.rs).
+>
+> **Future design (NOT in this slice)** — the more invasive surface below is kept
+> as forward design because it would change load-bearing contracts: the
+> `SignalStrength` taxonomy and new strong-signal fields on `CompletionEvidence`
+> (`checks_passed`, `exit_success`, `postcondition_satisfied`), the
+> `CompletionVerdict::Unverified` arm, and the `GoalProgress::CompletedUnverified`
+> state (which would ripple through ~60 exhaustive `match GoalProgress` sites).
+> The shipped slice deliberately marks no-signal completions *unverified at the
+> metric level* and keeps them blocked-and-retained (never archived) rather than
+> minting a new persistent goal state.
+
+This reference specifies the typed surface of the external-signal completion
+gate (#2456). For the rationale, see
+[trustworthy confidence + external-signal completion](../concepts/trustworthy-confidence-and-external-completion.md).
+
+## Contents
+
+- [What changes](#what-changes)
+- [Signal-strength taxonomy](#signal-strength-taxonomy)
+- [`CompletionEvidence` (extended)](#completionevidence-extended)
+- [`VerificationOutcome` (shipped)](#verificationoutcome-shipped)
+- [`CompletionVerdict` (extended)](#completionverdict-extended)
+- [`GoalProgress::CompletedUnverified`](#goalprogresscompletedunverified)
+- [Refuted completions route to `OpenTrackingIssue`](#refuted-completions-route-to-opentrackingissue)
+- [Verification metrics](#verification-metrics)
+- [Relationship to the deploy-aware done-gate (#2450)](#relationship-to-the-deploy-aware-done-gate-2450)
+- [Environment knobs](#environment-knobs)
+- [Compatibility & wire stability](#compatibility-and-wire-stability)
+
+## What changes
+
+The current "mark complete" decision trusts **artifact existence** — a commit
+or a PR existing is treated as completion. #2456 would replace that with a
+signal-strength ladder: **mere existence would no longer be sufficient.** A goal
+would reach `Completed` only when a subordinate's done-claim is corroborated by
+at least one *strong* external signal; otherwise it would land in the honest
+[`CompletedUnverified`](#goalprogresscompletedunverified) state (held for review,
+never archived) or be `refuted` and routed to a tracking issue.
+
+## Signal-strength taxonomy
+
+```rust
+/// How much trust a completion signal earns.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SignalStrength {
+    /// Independently verifiable; can complete a goal.
+    Strong,
+    /// Self-report-adjacent; never sufficient on its own.
+    Weak,
+}
+```
+
+| Strength | Signal | Source |
+| --- | --- | --- |
+| **Strong** | merged PR | `EvidenceSource::pr_merged` (existing) |
+| **Strong** | closed linked issue | `EvidenceSource::issue_closed` (existing) |
+| **Strong** | verified deploy | `EvidenceSource::is_deployed` / [#2450 gate](./completion-evidence-gate-api.md) |
+| **Strong** | green CI / checks passed | `EvidenceSource::checks_passed` (new) |
+| **Strong** | build/test exit-success | engineer run exit status (new) |
+| **Strong** | satisfied goal-graph postcondition | goal-graph predicate (new) |
+| **Weak** | open (un-merged) PR exists | wip-ref scan |
+| **Weak** | local commit exists | git log |
+| **Weak** | subordinate "I finished" text | progress-claim string |
+
+> Strong signals are gathered through the same injected
+> [`EvidenceSource`](./completion-evidence-gate-api.md#evidence-sources) seam the
+> deploy-aware gate already uses, so the ladder runs hermetically in tests with
+> no network and no live `gh`.
+
+## `CompletionEvidence` (extended)
+
+The existing struct would gain the new strong-signal facts. Existing fields are
+unchanged. The struct today carries only `pr_merged`, `issue_closed`,
+`self_affecting`, and `deployed`.
+
+```rust
+#[derive(Clone, Debug, PartialEq)]
+pub struct CompletionEvidence {
+    pub pr_merged: bool,        // existing
+    pub issue_closed: bool,     // existing
+    pub self_affecting: bool,   // existing
+    pub deployed: bool,         // existing
+    // --- new in #2456 ---
+    /// CI / required checks are green for the goal's merged change.
+    pub checks_passed: bool,
+    /// The engineer run that claimed completion exited 0 (build/tests passed).
+    pub exit_success: bool,
+    /// A goal-graph postcondition predicate for this goal is satisfied.
+    pub postcondition_satisfied: bool,
+}
+
+impl CompletionEvidence {
+    /// `true` if **any** strong signal is present.
+    pub fn has_strong_signal(&self) -> bool;
+    /// `true` if a strong signal was *derivable* (checkable) but failed
+    /// (e.g. CI red, exit ≠ 0, issue still open after a merged PR).
+    pub fn is_refuted(&self) -> bool;
+}
+```
+
+## `VerificationOutcome` (shipped)
+
+The per-completion verdict used for [metrics](#verification-metrics) and for the
+[calibration ground truth](./trustworthy-confidence-api.md#calibration-expected-calibration-error).
+Shipped today in
+[`completion_gate.rs`](https://github.com/rysweet/Simard/blob/main/src/goal_curation/completion_gate.rs)
+(the broader-design name in earlier drafts was `CompletionVerification`; the
+variants are identical).
+
+```rust
+// src/goal_curation/completion_gate.rs — SHIPPED
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum VerificationOutcome {
+    /// ≥1 external postcondition was satisfied (gate said Complete).
+    Verified,
+    /// No external postcondition is derivable — held unverified, not trusted.
+    UnverifiedNoSignal,
+    /// A derivable external signal contradicted the completion claim.
+    Refuted,
+    /// A signal lookup failed (gh/git/drift query error) this cycle.
+    Error,
+}
+
+impl VerificationOutcome {
+    pub fn metric_label(&self) -> &'static str; // "verified" | "unverified_no_signal" | "refuted" | "error"
+    pub fn metric_code(&self) -> f64;           // 0.0 | 1.0 | 2.0 | 3.0
+    pub fn is_false_completion(&self) -> bool;  // true only for Refuted
+}
+
+/// Classify a gate verdict for one goal.
+pub fn classify_outcome(goal: &ActiveGoal, verdict: &CompletionVerdict) -> VerificationOutcome;
+/// Classify directly from a blocked verdict's missing-evidence list.
+pub fn classify_from_missing(goal: &ActiveGoal, missing: &[MissingEvidence]) -> VerificationOutcome;
+/// A goal has an external signal iff it has a PR ref, an issue ref, or is self-affecting.
+pub fn has_derivable_signal(goal: &ActiveGoal) -> bool;
+```
+
+Classification rules over the existing `CompletionVerdict`:
+
+| Verdict | Goal has derivable signal? | `VerificationOutcome` |
+| --- | --- | --- |
+| `Complete` | — | `Verified` |
+| `Blocked` containing `CouldNotVerify` | — | `Error` |
+| `Blocked` (no `CouldNotVerify`) | yes | `Refuted` |
+| `Blocked` (no `CouldNotVerify`) | no | `UnverifiedNoSignal` |
+
+`Error` dominates: a `CouldNotVerify` blocker classifies as `Error` even when a
+real refutation signal is also present (the truth is simply unknown this cycle).
+
+## `CompletionVerdict` (extended)
+
+The existing two-arm verdict gains a third arm for the honest-unverified case.
+`Complete` and `Blocked` are unchanged.
+
+```rust
+#[derive(Clone, Debug, PartialEq)]
+pub enum CompletionVerdict {
+    /// ≥1 strong signal present — completion/archive may proceed.
+    Complete(CompletionEvidence),
+    /// A strong clause is checkable but failed — keep active, record blocker.
+    Blocked {
+        evidence: CompletionEvidence,
+        missing: Vec<MissingEvidence>,
+    },
+    // --- new in #2456 ---
+    /// Claimed done with no strong signal derivable — neither proven nor
+    /// refuted. Maps to `GoalProgress::CompletedUnverified`.
+    Unverified(CompletionEvidence),
+}
+```
+
+Decision table (subordinate claims done). **A refuted checkable signal takes
+precedence:** if any strong signal is *refuted*, the goal is not completed even
+when another strong signal is present.
+
+| Strong signal present? | Strong signal refuted? | Verdict | `GoalProgress` | `CompletionVerification` |
+| --- | --- | --- | --- | --- |
+| yes | no | `Complete` | `Completed` | `Verified` |
+| yes | yes | `Blocked` → tracking issue | unchanged (stays active) | `Refuted` |
+| no | yes | `Blocked` → tracking issue | unchanged (stays active) | `Refuted` |
+| no | no | `Unverified` | `CompletedUnverified` | `UnverifiedNoSignal` |
+| lookup failed | — | `Blocked { CouldNotVerify }` | unchanged | `Error` |
+
+## `GoalProgress::CompletedUnverified`
+
+A new, additive variant **proposed** for
+[`GoalProgress`](https://github.com/rysweet/Simard/blob/main/src/goal_curation/types.rs)
+(today the enum ends at `Completed`).
+
+```rust
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum GoalProgress {
+    Proposed,
+    NotStarted,
+    InProgress { percent: u32 },
+    Blocked(String),
+    Paused,
+    Completed,
+    /// Subordinate reported done, but no strong external signal corroborates
+    /// it. Held for human review — explicitly distinct from `Completed`, and
+    /// **not archivable**.
+    CompletedUnverified,
+}
+
+impl Display for GoalProgress {
+    // Self::CompletedUnverified => "completed-unverified"
+}
+```
+
+**Not archivable.** The archive-candidate predicate
+[`completion_gate.rs::is_complete_candidate`](https://github.com/rysweet/Simard/blob/main/src/goal_curation/completion_gate.rs)
+would continue to match `Completed` (or `InProgress { percent >= 100 }`)
+**only**, and
+[`archive_completed_with_evidence`](https://github.com/rysweet/Simard/blob/main/src/goal_curation/completion_gate.rs)
+would archive just those candidates — `CompletedUnverified` is deliberately
+excluded so unproven work is never silently archived. It would surface on the
+operator dashboard as `completed-unverified` and be held until a strong signal
+arrives (promoting it to `Completed`) or review re-routes it.
+
+> **Exhaustive matches to update.** Adding the variant would ripple through
+> every exhaustive `match GoalProgress` (orient demotion, advance-goal,
+> goal-session, the operator dashboard current-work / workboard / goals views,
+> and the string-parse round-trip). All must be updated to handle
+> `CompletedUnverified` explicitly; none should silently absorb it into a `_`
+> arm.
+
+## Refuted completions route to `OpenTrackingIssue`
+
+When a done-claim is **refuted** (a strong signal was checkable and failed — CI
+red, exit ≠ 0, merged PR but the linked issue is still open), the goal would
+**not** be completed or archived. The blocker would be recorded and the
+engineer-lifecycle path would emit
+[`OpenTrackingIssue`](./ooda-brain-decision-protocol.md) so a human sees the
+false-done claim. This would reuse the existing lifecycle action; no new
+routing machinery is added.
+
+## Verification metrics
+
+The shipped sink is the existing
+[`self_metrics::record_metric`](https://github.com/rysweet/Simard/blob/main/src/goal_curation/completion_gate.rs)
+(`~/.simard/metrics/metrics.jsonl`).
+
+- **Per-event (shipped):**
+  `record_completion_verification(outcome)` emits
+  `record_metric("goal_completion_verification", outcome.metric_code(), outcome.metric_label())`
+  for every completion candidate evaluated by
+  `archive_completed_evidence_aware`. `metric_code()` encodes the
+  [`VerificationOutcome`](#verificationoutcome-shipped) variant
+  (`verified=0`, `unverified_no_signal=1`, `refuted=2`, `error=3`).
+- **Rolling rate (shipped):**
+  `false_completion_rate(&[VerificationOutcome]) -> Option<f64>` computes
+
+  ```
+  false_completion_rate = refuted / (verified + refuted)
+  ```
+
+  `unverified_no_signal` and `error` are **excluded from the denominator** — the
+  rate measures *wrong* completions among *checkable* ones, so signal-less goals
+  do not dilute it. `record_false_completion_rate(&outcomes)` emits this per
+  archival batch as the dedicated `goal_false_completion_rate` time-series metric
+  (value = the rate; `context = "refuted=R checkable=C"` so a reader can re-pool a
+  rate across batches). `archive_completed_evidence_aware` calls it once per pass;
+  it is a no-op when the batch had nothing checkable.
+
+These per-event outcomes are also the ground-truth feed for the brain's
+[calibration / ECE](./trustworthy-confidence-api.md#calibration-expected-calibration-error)
+(`verified → true`, `refuted → false`; the rest excluded).
+
+## Relationship to the deploy-aware done-gate (#2450)
+
+This gate **extends, and does not duplicate,**
+[`CompletionEvidenceGate`](./completion-evidence-gate-api.md):
+
+- The deploy-aware gate guards **archival** (merged PR + closed issue + verified
+  deploy). #2456 guards the earlier **"mark complete"** decision so weak signals
+  never reach the archive gate as `Completed`.
+- **Semantics differ by stage, deliberately.** Mark-complete uses **OR** (any one
+  strong signal corroborates the done-claim → `Completed`); archival still
+  enforces the deploy-gate's **AND** (merged PR + closed issue + verified deploy).
+  A goal marked `Completed` via a single strong signal must still clear the AND
+  gate before it archives.
+- "Deploy-verified" (`!DeployDrift::needs_deploy`) is consumed as **one strong
+  signal** in the ladder above.
+- Both share the injected `EvidenceSource` seam and the goal types in
+  `src/goal_curation/types.rs`.
+
+## Environment knobs
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `SIMARD_COMPLETION_VERIFICATION` | `strict` | `strict` = require a strong signal to reach `Completed` (weak ⇒ `CompletedUnverified`); `lenient` = legacy artifact-existence behaviour (for rollback only); `off` = disable the ladder. |
+| `SIMARD_COMPLETION_EVIDENCE` | (existing) | The deploy-aware archive gate kill-switch ([#2450](./completion-evidence-gate-api.md#kill-switch)); honored unchanged. |
+
+## Compatibility and wire stability
+
+- **Additive serde.** `GoalProgress::CompletedUnverified` is a new variant;
+  legacy goal-board snapshots never contain it, and it only deserializes on new
+  code. Existing variants serialize byte-identically.
+- **Verdict back-compat.** `Complete` / `Blocked` shapes are unchanged; only the
+  new `Unverified` arm and the new `CompletionEvidence` fields are added.
+- **Rollback.** `SIMARD_COMPLETION_VERIFICATION=lenient` restores the prior
+  artifact-existence completion behaviour without a redeploy, for emergency use.
+
+## See also
+
+- [Concept: trustworthy confidence + external-signal completion](../concepts/trustworthy-confidence-and-external-completion.md)
+- [Concept: deploy-aware done-gate](../concepts/deploy-aware-done-gate.md)
+- [Completion-evidence gate API reference](./completion-evidence-gate-api.md)
+- [Trustworthy-confidence API reference](./trustworthy-confidence-api.md)
+- [How-to: interpret brain confidence and verify completion](../howto/interpret-brain-confidence-and-verify-completion.md)

--- a/docs/reference/trustworthy-confidence-api.md
+++ b/docs/reference/trustworthy-confidence-api.md
@@ -1,0 +1,382 @@
+---
+title: Trustworthy-confidence API reference
+description: Reference for the brain's trustworthy-confidence primitive — the confidence field on DecideJudgment and EngineerLifecycleDecision, the verbalized-confidence wire format, the default_confidence / LOW_TRUST_CONFIDENCE policy, the self-consistency K-sampler, the calibration (ECE) metric spine, the environment knobs, and the downstream consumers (the #2432 escalation ladder and the #2433 consolidation gate).
+last_updated: 2026-06-28
+review_schedule: as-needed
+owner: simard
+doc_type: reference
+status: partially implemented
+related:
+  - ../concepts/trustworthy-confidence-and-external-completion.md
+  - ../concepts/prompt-driven-ooda-brain.md
+  - ./external-signal-completion-gate.md
+  - ./ooda-brain-decision-protocol.md
+  - ./ooda-decide-prompt.md
+  - ../../src/ooda_brain/decide.rs
+  - ../../src/ooda_brain/mod.rs
+  - ../../src/ooda_brain/orient.rs
+  - ../../src/ooda_brain/judgment_record.rs
+  - ../../src/self_metrics/mod.rs
+---
+
+# Trustworthy-confidence API reference
+
+> **Status: partially implemented (issue [#2457](https://github.com/rysweet/Simard/issues/2457), open).**
+>
+> **Shipped now** — the trustworthy-confidence *primitive* in
+> [`src/ooda_brain/confidence.rs`](https://github.com/rysweet/Simard/blob/main/src/ooda_brain/confidence.rs)
+> (re-exported from `crate::ooda_brain`): the fail-closed default policy
+> (`default_confidence` / `LOW_TRUST_CONFIDENCE` / `confidence_or_low_trust`),
+> `validate_confidence` / `clamp_confidence`; the high-stakes + irreversibility gates
+> (`HIGH_STAKES_URGENCY`, `is_high_stakes`, `is_irreversible_lifecycle`,
+> `should_self_consistency_sample`, `effective_k`); the self-consistency vote
+> (`self_consistency_vote` → `Vote { choice, agreement, modal_count, k }`,
+> `SELF_CONSISTENCY_K`, `lifecycle_conservative_rank`); the calibration spine
+> (`CalibrationWindow` → `ece()`, `ECE_WINDOW`, `ECE_BINS`, `ECE_METRIC =
+> "brain_confidence_ece"`); and the verbalized-confidence carriers
+> `JudgedDecision` / `JudgedLifecycle` (see
+> [the confidence carrier](#the-confidence-carrier)). All are unit-tested.
+>
+> **Exists already** (the precedents this builds on):
+> [`OrientJudgment::confidence`](https://github.com/rysweet/Simard/blob/main/src/ooda_brain/orient.rs)
+> with its private `default_confidence() -> f64` and `validate` pattern;
+> [`DecideJudgment`](https://github.com/rysweet/Simard/blob/main/src/ooda_brain/decide.rs)
+> and
+> [`EngineerLifecycleDecision`](https://github.com/rysweet/Simard/blob/main/src/ooda_brain/mod.rs);
+> [`BrainJudgmentRecord.confidence: f32`](https://github.com/rysweet/Simard/blob/main/src/ooda_brain/judgment_record.rs);
+> and
+> [`self_metrics::record_metric`](https://github.com/rysweet/Simard/blob/main/src/self_metrics/mod.rs).
+>
+> **Follow-up (not in this slice):** threading the verbalized/vote confidence
+> all the way through the brain trait return types into the live
+> `BrainJudgmentRecord` and the #2432 escalation ladder, and soliciting a
+> `CONFIDENCE:` line in `ooda_decide.md` / `ooda_brain.md`. The carriers and the
+> primitive exist so that wiring is a small, additive follow-up; today the
+> production parse path still records the deterministic `1.0` / fallback `0.5`
+> placeholders.
+
+This reference specifies the typed surface of the trustworthy-confidence
+primitive (#2457). For the rationale, see
+[trustworthy confidence + external-signal completion](../concepts/trustworthy-confidence-and-external-completion.md).
+
+## Contents
+
+- [The confidence carrier](#the-confidence-carrier)
+- [Default policy: `default_confidence` vs `LOW_TRUST_CONFIDENCE`](#default-policy)
+- [Verbalized-confidence wire format](#verbalized-confidence-wire-format)
+- [Validation](#validation)
+- [Self-consistency sampling](#self-consistency-sampling)
+- [High-stakes trigger](#high-stakes-trigger)
+- [Budget gating](#budget-gating)
+- [Calibration: Expected Calibration Error](#calibration-expected-calibration-error)
+- [`BrainJudgmentRecord` integration](#brainjudgmentrecord-integration)
+- [Downstream consumers (#2432, #2433)](#downstream-consumers)
+- [Environment knobs](#environment-knobs)
+- [Compatibility & wire stability](#compatibility-and-wire-stability)
+
+## The confidence carrier
+
+`OrientJudgment` already has a native `confidence: f64`. The two commitment-phase
+judgments — `DecideJudgment` and `EngineerLifecycleDecision` — are **internally
+tagged** enums (`#[serde(tag = "choice")]`) that today carry only `rationale`.
+Rather than edit every variant (and the ~90 match/construction sites across the
+live #2432 escalation ladder, which would also force dropping the `Eq` derive),
+the shipped primitive attaches confidence with a thin **carrier** that wraps the
+existing judgment with `#[serde(flatten)]`:
+
+```rust
+// src/ooda_brain/confidence.rs — SHIPPED
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct JudgedDecision {
+    #[serde(flatten)]
+    pub judgment: DecideJudgment,
+    #[serde(default = "default_confidence")]
+    pub confidence: f64,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct JudgedLifecycle {
+    #[serde(flatten)]
+    pub decision: EngineerLifecycleDecision,
+    #[serde(default = "default_confidence")]
+    pub confidence: f64,
+}
+```
+
+Each exposes `new(inner, confidence)` and a `validate()` that rejects a
+non-finite or out-of-range confidence.
+
+### Why a flatten carrier, not a per-variant field
+
+`#[serde(flatten)]` over an internally-tagged enum keeps the JSON **flat** —
+`{"choice":"advance_goal","rationale":"…","confidence":0.8}` — *identical* to what
+a per-variant field would emit. This is verified by a round-trip test
+(`judged_decision_serializes_flat_with_confidence`).
+
+> An earlier draft of this doc claimed a wrapper would nest the payload as
+> `{"choice":{…}}` and break the cycle-report consumers. That is **incorrect**:
+> `flatten` does not nest. Because the wire shape is preserved *and* the inner
+> enum is untouched, the carrier is strictly more contract-preserving than a
+> per-variant field — `DecideJudgment` / `EngineerLifecycleDecision` keep their
+> `Eq` derive and every existing `matches!` / destructure / construction site
+> compiles unchanged, and the bare inner enum still deserializes from the
+> carrier's JSON (`bare_decide_judgment_still_parses_from_judged_wire`).
+
+A per-variant `confidence` field remains a viable future refactor if a phase
+needs the value inline on the enum; the carrier is the lower-risk path taken
+here.
+
+## Default policy
+
+[`src/ooda_brain/confidence.rs`](https://github.com/rysweet/Simard/blob/main/src/ooda_brain/confidence.rs)
+defines the policy that makes confidence safe to consume:
+
+```rust
+// src/ooda_brain/confidence.rs — SHIPPED
+/// The cheerful default. Returned ONLY for paths where high confidence is
+/// genuinely warranted and carries no privilege risk:
+///   * the deterministic floor brains (always-confident by construction), and
+///   * legacy JSON / cycle reports written before the field existed.
+pub fn default_confidence() -> f64 { 1.0 }
+
+/// The fail-closed floor. Returned whenever a confidence was *solicited* from
+/// an LLM but could not be trusted: absent when the prompt asked for it,
+/// unparseable, non-finite, or outside [0.0, 1.0].
+pub const LOW_TRUST_CONFIDENCE: f64 = 0.0;
+
+/// Canonical fail-closed resolver for a solicited confidence: a present, finite,
+/// in-range value passes through; anything else degrades to LOW_TRUST_CONFIDENCE.
+pub fn confidence_or_low_trust(parsed: Option<f64>) -> f64;
+```
+
+> **Critical (SR-1).** Confidence is consumed by gates that *unlock* privilege
+> (extra compute, fact promotion, fewer re-verifications). A malformed or
+> missing-when-requested confidence must therefore degrade to
+> `LOW_TRUST_CONFIDENCE`, **never** to `1.0`. `serde(default = default_confidence)`
+> is used only for the *deserialization* of trusted/legacy records; the live LLM
+> parsers apply the fail-closed rule above. In particular, a **fallback to the
+> deterministic mapping after an LLM parse failure is a low-trust event**
+> (`LOW_TRUST_CONFIDENCE`, not `1.0`): `default_confidence() = 1.0` applies only
+> when the deterministic brain is the *configured* floor and no LLM was attempted.
+> You cannot earn trust by emitting garbage.
+
+## Verbalized-confidence wire format
+
+The primitive does **not** change the phase wire formats; it rides them.
+
+| Phase | Wire | Confidence carrier |
+| --- | --- | --- |
+| Orient | JSON object | existing `"confidence"` key (unchanged) |
+| Decide | `DECISION:` marker + prose ([protocol](./ooda-decide-prompt.md)) | optional `CONFIDENCE: <0..1>` line |
+| Engineer-lifecycle | first-word match ([protocol](./ooda-brain-decision-protocol.md)) | optional `CONFIDENCE: <0..1>` line |
+
+Parsing rules for the `CONFIDENCE:` line (Decide / lifecycle):
+
+- **Present and valid** (`0.0 ≤ x ≤ 1.0`, finite) ⇒ used verbatim.
+- **Present but invalid** (non-numeric, non-finite, out of range) ⇒
+  `LOW_TRUST_CONFIDENCE`, logged as a soft parse warning (not a hard parse
+  failure — the choice still stands).
+- **Absent** ⇒ `LOW_TRUST_CONFIDENCE` when the prompt solicited it.
+  `default_confidence()` applies only on the *configured* deterministic floor
+  (no LLM attempted); a *fallback to* the deterministic mapping after an LLM
+  parse failure is a low-trust event (`LOW_TRUST_CONFIDENCE`, not `1.0`).
+
+Because the engineer-lifecycle phase matches only the **first word**
+([#2144 protocol](./ooda-brain-decision-protocol.md)), its parser additionally
+scans subsequent lines for the optional `CONFIDENCE:` line; the first-word match
+itself is unchanged.
+
+The prompt wording that solicits the line would be added to
+`prompt_assets/simard/ooda_decide.md` and `prompt_assets/simard/ooda_brain.md`
+(neither solicits it today) and covered by planned content-pin tests (see
+[Compatibility & wire stability](#compatibility-and-wire-stability)).
+
+Example Decide response:
+
+```
+DECISION: advance_goal
+CONFIDENCE: 0.82
+Goal g-2457 has a green CI run and an open PR ready to merge; advancing.
+```
+
+## Validation
+
+Each judgment would expose a `validate()` that rejects non-finite or
+out-of-range confidence, analogous to `OrientJudgment::validate` (which applies
+the same finite / `[0,1]` check to its `adjusted_urgency`). Callers validate
+defensively and fall back to the deterministic floor on rejection, so a
+misbehaving LLM cannot inject a poisoned confidence:
+
+```rust
+pub fn validate(&self) -> Result<(), String> {
+    let c = self.confidence();
+    if !c.is_finite() || !(0.0..=1.0).contains(&c) {
+        return Err(format!("confidence {c} out of [0, 1]"));
+    }
+    Ok(())
+}
+```
+
+## Self-consistency sampling
+
+The shipped `self_consistency_vote` in `src/ooda_brain/confidence.rs` takes K
+already-sampled judgments and returns the modal choice with
+`confidence = modal_count / k`.
+
+```rust
+// src/ooda_brain/confidence.rs — SHIPPED
+pub struct Vote<K> {
+    /// The winning choice (modal sample; ties broken by `rank`).
+    pub choice: K,
+    /// modal_count / k, in (0.0, 1.0] — the agreement confidence proxy.
+    pub agreement: f64,
+    pub modal_count: usize,
+    pub k: usize,
+}
+
+/// Majority-vote over `samples`; `None` for an empty slice. Ties break toward
+/// the highest `rank` (then first-seen) so the result is deterministic.
+pub fn self_consistency_vote<K, R>(samples: &[K], rank: R) -> Option<Vote<K>>
+where
+    K: Eq + Clone,
+    R: Fn(&K) -> i64;
+
+/// Canonical `rank` for lifecycle decisions: the more escalating/irreversible
+/// the choice, the higher the rank, so a tie resolves the cautious way.
+pub fn lifecycle_conservative_rank(decision: &EngineerLifecycleDecision) -> i64;
+```
+
+`K = 3` (the default `SELF_CONSISTENCY_K`) yields confidences in `{1/3, 2/3, 1}`
+and avoids 1-of-2 ties. The vote requires only `K: Eq + Clone` (an O(K²) count),
+so the brain enums need no `Hash` derive — preserving their contract.
+
+> The caller is responsible for drawing the K samples (e.g. K calls to the brain)
+> and for the budget gate below; `self_consistency_vote` is the pure tally over
+> the results.
+
+### High-stakes trigger
+
+K-sampling is reserved for consequential, hard-to-undo judgments; everything
+else takes a single verbalized-confidence call.
+
+- **Decide phase** — `is_high_stakes(urgency)` is true when
+  `urgency >= HIGH_STAKES_URGENCY` (default `0.8`).
+- **Engineer-lifecycle phase** — `is_irreversible_lifecycle(&decision)` is true
+  only for `OpenTrackingIssue`, `ReclaimAndRedispatch`, `MarkGoalBlocked`;
+  `ContinueSkipping`, `Deprioritize`, `ConsiderSelfUpdate` take a single call.
+
+`should_self_consistency_sample(urgency, have_budget)` and
+`JudgedLifecycle::warrants_self_consistency(urgency, have_budget)` combine these
+with the budget gate below.
+
+```rust
+pub const HIGH_STAKES_URGENCY: f64 = 0.8;
+pub const SELF_CONSISTENCY_K: usize = 3;
+```
+
+### Budget gating
+
+Before drawing `K` samples the caller checks remaining budget headroom using the
+same guard the OODA cycle already uses
+([`cost_tracking::daily_summary`](https://github.com/rysweet/Simard/blob/main/src/cost_tracking.rs)
+/ `weekly_summary` against `OodaConfig::daily_budget_usd` / `weekly_budget_usd`).
+`effective_k(have_budget_headroom)` returns `SELF_CONSISTENCY_K` with headroom
+and **`1`** without — degrading to a single verbalized-confidence call rather
+than skipping the decision. Calibration spend never stalls the loop, and a
+decision is always produced.
+
+## Calibration: Expected Calibration Error
+
+The shipped `CalibrationWindow` (in `src/ooda_brain/confidence.rs`) scores how
+*meaningful* the stated confidence is, using the #2456 completion verdict as
+ground truth.
+
+```rust
+// src/ooda_brain/confidence.rs — SHIPPED
+pub const ECE_WINDOW: usize = 50; // most-recent samples
+pub const ECE_BINS: usize = 10;   // equal-width [0,1] bins
+pub const ECE_METRIC: &str = "brain_confidence_ece";
+
+pub struct CalibrationWindow { /* bounded ring of (predicted, outcome) */ }
+
+impl CalibrationWindow {
+    pub fn new() -> Self;                       // ECE_WINDOW / ECE_BINS
+    pub fn with_params(capacity: usize, bins: usize) -> Self;
+    pub fn record(&mut self, predicted: f64, outcome: bool);
+    /// Sample-weighted mean over non-empty bins of |avg_confidence − accuracy|.
+    /// `None` while empty.
+    pub fn ece(&self) -> Option<f64>;
+    /// Best-effort emit of the current ECE via record_metric(ECE_METRIC, …).
+    pub fn record_ece_metric(&self) -> Option<f64>;
+}
+```
+
+- Realized outcome is sourced from the
+  [external-signal completion gate](./external-signal-completion-gate.md):
+  `verified → true`, `refuted → false`. `unverified_no_signal` and `error` carry
+  no ground truth and are simply **not recorded**.
+- The rolling ECE is emitted via
+  `self_metrics::record_metric("brain_confidence_ece", ece, context)`.
+
+A lower ECE is better; `0.0` means the brain's stated confidence exactly tracks
+its hit-rate per bin.
+
+## `BrainJudgmentRecord` integration
+
+[`BrainJudgmentRecord.confidence: f32`](https://github.com/rysweet/Simard/blob/main/src/ooda_brain/judgment_record.rs)
+already exists today, but is currently populated with **fixed placeholders**
+(`1.0` non-fallback / `0.5` fallback, and `0.0` for phases with no native
+confidence field). This spec would source it from the judgment's `confidence()`
+(cast `f64 → f32`, mirroring the Orient `from_orient` precedent that already
+reads `judgment.confidence`); a fallback would then record `LOW_TRUST_CONFIDENCE`
+(`0.0`), **not** the current `0.5`. Cycle reports under
+`~/.simard/cycle_reports/cycle_*.json` would therefore show the real
+per-judgment confidence with no schema change.
+
+## Downstream consumers
+
+#2457 will **produce and expose** confidence; it does not reimplement the
+consumers (both already merged):
+
+- **Escalation ladder (#2432).** A low verbalized confidence or low
+  self-consistency agreement is the explicit "spend more compute here" signal
+  the [bounded escalation ladder](../concepts/prompt-driven-ooda-brain.md)
+  consumes — generalizing its prior parse-miss-only trigger.
+- **Consolidation / ISAO gate (#2433).** The verbalized score is made available
+  so consolidation can set `CognitiveFact.confidence` from the judgment that
+  produced a fact, rather than a constant.
+
+The full ladder / gate logic remains owned by #2432 / #2433.
+
+## Environment knobs
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `SIMARD_BRAIN_SELF_CONSISTENCY_K` | `3` | K for high-stakes self-consistency; `1` disables sampling (verbalized-only). Hard-capped at a small bound to protect budget. |
+| `SIMARD_BRAIN_HIGH_STAKES_URGENCY` | `0.8` | Decide-phase urgency threshold above which self-consistency engages. |
+| `SIMARD_BRAIN_CONFIDENCE_CALIBRATION` | `on` | `off` skips ECE recording (judgments still carry confidence). |
+| `SIMARD_DAILY_BUDGET_USD` | `500` | Existing budget guard the sampler honors before drawing K samples. |
+| `SIMARD_WEEKLY_BUDGET_USD` | `2500` | Existing weekly budget guard. |
+
+All knobs are read once per process at config build, alongside the existing
+`OodaConfig` env reads.
+
+## Compatibility and wire stability
+
+- **Serde back-compat.** `#[serde(default = default_confidence)]` lets old cycle
+  reports and deterministic-fallback JSON (which never wrote `confidence`)
+  deserialize unchanged; new records add the flat `"confidence"` key.
+- **Prompt content-pins.** Planned content-pin tests would assert the exact
+  `CONFIDENCE:` solicitation wording in `ooda_decide.md` / `ooda_brain.md`, so a
+  prompt edit that drops the ask fails CI.
+- **Determinism preserved.** With `SIMARD_BRAIN_SELF_CONSISTENCY_K=1` and no
+  `CONFIDENCE:` line, the brain behaves exactly as before this feature, except
+  that the recorded confidence is the honest `LOW_TRUST_CONFIDENCE` for solicited
+  LLM paths and `1.0` for the deterministic floor.
+
+## See also
+
+- [Concept: trustworthy confidence + external-signal completion](../concepts/trustworthy-confidence-and-external-completion.md)
+- [External-signal completion gate reference](./external-signal-completion-gate.md)
+- [OODA Decide prompt reference](./ooda-decide-prompt.md)
+- [OODA Brain decision protocol](./ooda-brain-decision-protocol.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,6 +69,7 @@ nav:
     - Reconcile-and-Self-Deploy: concepts/reconcile-and-self-deploy.md
     - Deploy-Aware Done-Gate: concepts/deploy-aware-done-gate.md
     - Closing the Procedural-Learning Loop: concepts/procedural-learning-loop.md
+    - Trustworthy Confidence + External Completion: concepts/trustworthy-confidence-and-external-completion.md
   - Tutorials:
     - First Local Session: tutorials/run-your-first-local-session.md
     - First Benchmark Suite: tutorials/run-your-first-benchmark-gym.md
@@ -90,6 +91,7 @@ nav:
     - Self-Maintain Dependency Pins: howto/self-maintain-dependency-pins.md
     - Verify and Roll Back a Self-Deploy: howto/verify-and-roll-back-a-self-deploy.md
     - Diagnose a Rejected Goal Completion: howto/diagnose-a-rejected-goal-completion.md
+    - Interpret Brain Confidence and Verify Completion: howto/interpret-brain-confidence-and-verify-completion.md
     - Configure Brain Introspection: howto/configure-brain-introspection.md
     - Triage Stale Pull Requests: howto/triage-stale-pull-requests.md
     - Inspect the Procedural-Learning Loop: howto/inspect-the-procedural-learning-loop.md
@@ -97,6 +99,8 @@ nav:
     - CLI Reference: reference/simard-cli.md
     - Self-Deploy API: reference/self-deploy-api.md
     - Completion-Evidence Gate API: reference/completion-evidence-gate-api.md
+    - Trustworthy-Confidence API: reference/trustworthy-confidence-api.md
+    - External-Signal Completion Gate: reference/external-signal-completion-gate.md
     - Memory introspection CLI: reference/simard-memory-cli.md
     - Cognitive-memory provenance (DERIVES_FROM): reference/cognitive-memory-provenance.md
     - Episode Ingestion Classifier API: reference/episode-ingestion-classifier.md

--- a/src/goal_curation/completion_gate.rs
+++ b/src/goal_curation/completion_gate.rs
@@ -80,6 +80,192 @@ impl CompletionVerdict {
     }
 }
 
+// ===========================================================================
+// #2456 — external-signal verification outcome (extends, does not replace, the
+// #2450 deploy-aware done-gate above). Classifies the gate's verdict into a
+// measurable category so the false-completion rate can be tracked, and so a
+// goal with **no derivable external signal** is recorded as honestly
+// *unverified* rather than conflated with a verified completion.
+// ===========================================================================
+
+/// The outcome of verifying a claimed-complete goal against external signals.
+///
+/// Mirrors the metric vocabulary in issue #2456
+/// (`goal_completion_verification ∈ {verified, unverified_no_signal, refuted,
+/// error}`). Intrinsic self-report is never sufficient: a goal is `Verified`
+/// only when an external postcondition held.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum VerificationOutcome {
+    /// At least one external postcondition was satisfied (gate said Complete).
+    Verified,
+    /// No external postcondition is derivable for this goal — held as unverified
+    /// rather than trusted on self-report alone.
+    UnverifiedNoSignal,
+    /// A derivable external signal contradicted the completion claim
+    /// (e.g. PR not merged, issue still open, self-change not deployed). This is
+    /// a false completion the subordinate self-reported as done.
+    Refuted,
+    /// Verification could not be performed this cycle (a git/gh/drift query
+    /// failed). Distinct from a refutation: the truth is simply unknown.
+    Error,
+}
+
+impl VerificationOutcome {
+    /// Stable lowercase label for the metric `context` and logs.
+    pub fn metric_label(&self) -> &'static str {
+        match self {
+            Self::Verified => "verified",
+            Self::UnverifiedNoSignal => "unverified_no_signal",
+            Self::Refuted => "refuted",
+            Self::Error => "error",
+        }
+    }
+
+    /// Numeric encoding for the `f64` metric value, so a time series can be
+    /// filtered/aggregated without re-parsing the context string.
+    pub fn metric_code(&self) -> f64 {
+        match self {
+            Self::Verified => 0.0,
+            Self::UnverifiedNoSignal => 1.0,
+            Self::Refuted => 2.0,
+            Self::Error => 3.0,
+        }
+    }
+
+    /// Whether this outcome is a false completion (claimed done, signal refuted).
+    /// This is the numerator of the `goal_false_completion_rate`.
+    pub fn is_false_completion(&self) -> bool {
+        matches!(self, Self::Refuted)
+    }
+}
+
+/// Metric name under which each completion-verification outcome is emitted.
+pub const COMPLETION_VERIFICATION_METRIC: &str = "goal_completion_verification";
+
+/// Metric name under which the per-batch false-completion rate (#2456 headline
+/// metric) is emitted: the share of *checkable* completions in one archival
+/// pass that a derivable external signal refuted. Distinct from the per-event
+/// [`COMPLETION_VERIFICATION_METRIC`] so a time series can read the rate
+/// directly without re-deriving it from the event stream.
+pub const FALSE_COMPLETION_RATE_METRIC: &str = "goal_false_completion_rate";
+
+/// Whether any *external* completion signal is derivable for this goal: a
+/// tracked PR, a tracked issue, or a self-affecting change (whose deploy state
+/// the drift detector can resolve). When none of these exist, a blocked verdict
+/// means "nothing to verify", not "verification failed".
+pub fn has_derivable_signal(goal: &ActiveGoal) -> bool {
+    let has_ref_of = |kind: &str| {
+        goal.wip_refs
+            .iter()
+            .any(|r| r.kind.eq_ignore_ascii_case(kind))
+    };
+    has_ref_of("pr") || has_ref_of("issue") || is_self_affecting(goal)
+}
+
+/// Classify a gate verdict into a [`VerificationOutcome`] for one goal.
+pub fn classify_outcome(goal: &ActiveGoal, verdict: &CompletionVerdict) -> VerificationOutcome {
+    match verdict {
+        CompletionVerdict::Complete(_) => VerificationOutcome::Verified,
+        CompletionVerdict::Blocked { missing, .. } => classify_from_missing(goal, missing),
+    }
+}
+
+/// Classify the blocked-verdict's missing-evidence list into an outcome. A
+/// [`MissingEvidence::CouldNotVerify`] dominates as `Error`; otherwise a goal
+/// with at least one derivable signal is `Refuted`, and a goal with none is
+/// `UnverifiedNoSignal`.
+pub fn classify_from_missing(
+    goal: &ActiveGoal,
+    missing: &[MissingEvidence],
+) -> VerificationOutcome {
+    if missing
+        .iter()
+        .any(|m| matches!(m, MissingEvidence::CouldNotVerify { .. }))
+    {
+        VerificationOutcome::Error
+    } else if has_derivable_signal(goal) {
+        VerificationOutcome::Refuted
+    } else {
+        VerificationOutcome::UnverifiedNoSignal
+    }
+}
+
+/// Emit one completion-verification outcome via
+/// [`crate::self_metrics::record_metric`]. Best-effort: a metric-write failure
+/// is swallowed so it never blocks or crashes the OODA cycle.
+///
+/// No-op under `cfg!(test)` so unit tests never append to the operator's real
+/// `~/.simard/metrics/metrics.jsonl` (mirroring `record_lifecycle_decision_metric`
+/// in the brain) — writing real telemetry from tests would corrupt the very
+/// before/after measurement this metric exists to capture.
+pub fn record_completion_verification(outcome: VerificationOutcome) {
+    if cfg!(test) {
+        return;
+    }
+    let _ = crate::self_metrics::record_metric(
+        COMPLETION_VERIFICATION_METRIC,
+        outcome.metric_code(),
+        outcome.metric_label(),
+    );
+}
+
+/// Emit the per-batch [`false_completion_rate`] over `outcomes` via
+/// [`crate::self_metrics::record_metric`] under [`FALSE_COMPLETION_RATE_METRIC`].
+/// A no-op when nothing in the batch was *checkable* (no verified/refuted
+/// outcome) — there is no rate to report. The metric `context` carries the
+/// `refuted`/`checkable` counts so a downstream reader can re-aggregate a
+/// pooled rate across batches rather than averaging per-batch rates. Best-effort
+/// and `cfg!(test)`-guarded for the same reason as
+/// [`record_completion_verification`].
+pub fn record_false_completion_rate(outcomes: &[VerificationOutcome]) {
+    let Some(rate) = false_completion_rate(outcomes) else {
+        return;
+    };
+    if cfg!(test) {
+        return;
+    }
+    let refuted = outcomes
+        .iter()
+        .filter(|o| matches!(o, VerificationOutcome::Refuted))
+        .count();
+    let checkable = outcomes
+        .iter()
+        .filter(|o| {
+            matches!(
+                o,
+                VerificationOutcome::Refuted | VerificationOutcome::Verified
+            )
+        })
+        .count();
+    let _ = crate::self_metrics::record_metric(
+        FALSE_COMPLETION_RATE_METRIC,
+        rate,
+        &format!("refuted={refuted} checkable={checkable}"),
+    );
+}
+
+/// The false-completion rate over a set of outcomes: `refuted / (verified +
+/// refuted)` — the share of *checkable* completions that were wrong. Signal-less
+/// (`UnverifiedNoSignal`) and `Error` outcomes are excluded from the denominator
+/// so they do not dilute the rate. `None` when nothing was checkable. This is
+/// the headline metric #2456 asks to trend down.
+pub fn false_completion_rate(outcomes: &[VerificationOutcome]) -> Option<f64> {
+    let refuted = outcomes
+        .iter()
+        .filter(|o| matches!(o, VerificationOutcome::Refuted))
+        .count();
+    let verified = outcomes
+        .iter()
+        .filter(|o| matches!(o, VerificationOutcome::Verified))
+        .count();
+    let checkable = refuted + verified;
+    if checkable == 0 {
+        return None;
+    }
+    Some(refuted as f64 / checkable as f64)
+}
+
 /// Injected evidence lookups. The production impl resolves PR/issue state via
 /// `gh` and `is_deployed` via the reconciliation detector; tests inject a
 /// canned source.
@@ -422,6 +608,12 @@ impl EvidenceSource for GhCliEvidenceSource {
 /// [`archive_completed`](super::archive_completed).
 ///
 /// Returns `(archived, blocked)`; `blocked` is always empty in legacy mode.
+///
+/// With the gate on, every candidate's [`VerificationOutcome`] is emitted via
+/// [`record_completion_verification`], and the per-batch
+/// [`false_completion_rate`] is emitted via [`record_false_completion_rate`], so
+/// the false-completion rate (#2456) is measurable both per-event and as a
+/// ready-made rate. Recording is best-effort and never affects the return value.
 pub fn archive_completed_evidence_aware(
     board: &mut GoalBoard,
     source: &dyn EvidenceSource,
@@ -431,7 +623,26 @@ pub fn archive_completed_evidence_aware(
         return (archived, Vec::new());
     }
     let gate = CompletionEvidenceGate::new(source);
-    archive_completed_with_evidence(board, &gate)
+    let (archived, blocked) = archive_completed_with_evidence(board, &gate);
+
+    // Instrument the completion-verification outcome per #2456: a goal that
+    // archived was externally verified; a blocked goal is either refuted (a
+    // derivable signal said "not done") or unverifiable for lack of any signal.
+    let mut outcomes: Vec<VerificationOutcome> = Vec::with_capacity(archived.len() + blocked.len());
+    for _ in &archived {
+        outcomes.push(VerificationOutcome::Verified);
+    }
+    for (goal, missing) in &blocked {
+        outcomes.push(classify_from_missing(goal, missing));
+    }
+    for outcome in &outcomes {
+        record_completion_verification(*outcome);
+    }
+    // The headline #2456 metric: the share of *checkable* completions this pass
+    // that an external signal refuted. No-op when nothing was checkable.
+    record_false_completion_rate(&outcomes);
+
+    (archived, blocked)
 }
 
 #[cfg(test)]

--- a/src/goal_curation/completion_gate/tests.rs
+++ b/src/goal_curation/completion_gate/tests.rs
@@ -10,8 +10,11 @@ use crate::goal_curation::archive_completed;
 use crate::goal_curation::types::{ActiveGoal, GoalBoard, GoalProgress, WipRef};
 
 use super::{
-    CompletionEvidenceGate, CompletionVerdict, EvidenceSource, MissingEvidence,
-    archive_completed_with_evidence, completion_evidence_enabled, is_self_affecting,
+    COMPLETION_VERIFICATION_METRIC, CompletionEvidenceGate, CompletionVerdict, EvidenceSource,
+    FALSE_COMPLETION_RATE_METRIC, MissingEvidence, VerificationOutcome,
+    archive_completed_with_evidence, classify_from_missing, classify_outcome,
+    completion_evidence_enabled, false_completion_rate, has_derivable_signal, is_self_affecting,
+    record_completion_verification, record_false_completion_rate,
 };
 
 /// Canned, hermetic [`EvidenceSource`]. Each field is `Result<bool, String>` so
@@ -351,6 +354,176 @@ fn ooda_decide_prompt_pins_done_gate_wording() {
         ),
         "ooda_decide.md must pin the STATUS: ACHIEVED evidence sentence"
     );
+}
+
+// --- #2456 verification outcome (extends the gate, does not duplicate it) ----
+
+/// A goal targeting another repo's surface, with no PR/issue refs — so it has
+/// NO derivable external completion signal.
+fn no_signal_goal(id: &str) -> ActiveGoal {
+    let mut g = simard_goal(id, GoalProgress::Completed);
+    g.repo = Some("amplihack-rs".to_string());
+    g.description = "improve amplihack-rs internals".to_string();
+    g.wip_refs = vec![];
+    g
+}
+
+#[test]
+fn outcome_verified_when_gate_completes() {
+    let gate = CompletionEvidenceGate::new(FakeEvidence::ok(true, true, true));
+    let goal = simard_goal("g", GoalProgress::Completed);
+    let verdict = gate.evaluate(&goal);
+    assert_eq!(
+        classify_outcome(&goal, &verdict),
+        VerificationOutcome::Verified
+    );
+}
+
+#[test]
+fn outcome_refuted_when_derivable_signal_contradicts_claim() {
+    // Self-affecting goal (routes to Simard) claimed done, but PR not merged:
+    // a derivable signal says "not done" → a false completion.
+    let goal = simard_goal("g", GoalProgress::Completed);
+    let gate = CompletionEvidenceGate::new(FakeEvidence::ok(false, true, true));
+    let verdict = gate.evaluate(&goal);
+    assert_eq!(
+        classify_outcome(&goal, &verdict),
+        VerificationOutcome::Refuted
+    );
+    assert!(VerificationOutcome::Refuted.is_false_completion());
+}
+
+#[test]
+fn outcome_unverified_when_no_external_signal_derivable() {
+    // No PR/issue ref and not self-affecting: nothing to verify against. The
+    // gate blocks, but the honest label is "unverified", NOT "refuted" — and
+    // certainly not silently verified on the self-report.
+    let goal = no_signal_goal("g");
+    assert!(!has_derivable_signal(&goal));
+    let gate = CompletionEvidenceGate::new(FakeEvidence::ok(false, true, true));
+    let verdict = gate.evaluate(&goal);
+    assert_eq!(
+        classify_outcome(&goal, &verdict),
+        VerificationOutcome::UnverifiedNoSignal
+    );
+}
+
+#[test]
+fn outcome_error_when_verification_query_failed() {
+    // A transient gh/git failure is "unknown", distinct from a refutation —
+    // even when the goal does have a derivable signal.
+    let goal = simard_goal("g", GoalProgress::Completed);
+    let gate = CompletionEvidenceGate::new(FakeEvidence {
+        pr_merged: Err("gh timed out".to_string()),
+        issue_closed: Ok(true),
+        deployed: Ok(true),
+    });
+    let verdict = gate.evaluate(&goal);
+    assert_eq!(
+        classify_outcome(&goal, &verdict),
+        VerificationOutcome::Error
+    );
+}
+
+#[test]
+fn classify_from_missing_prioritizes_could_not_verify() {
+    // CouldNotVerify dominates even alongside a real refutation signal.
+    let goal = simard_goal("g", GoalProgress::Completed);
+    let missing = vec![
+        MissingEvidence::PrNotMerged,
+        MissingEvidence::CouldNotVerify {
+            detail: "boom".to_string(),
+        },
+    ];
+    assert_eq!(
+        classify_from_missing(&goal, &missing),
+        VerificationOutcome::Error
+    );
+}
+
+#[test]
+fn has_derivable_signal_detects_pr_issue_or_self_affecting() {
+    // Self-affecting (default repo) → signal via deploy state.
+    assert!(has_derivable_signal(&simard_goal(
+        "g",
+        GoalProgress::Completed
+    )));
+
+    // Off-repo with a tracked PR → signal via the PR.
+    let mut pr_goal = no_signal_goal("g");
+    pr_goal.wip_refs = vec![WipRef {
+        kind: "pr".to_string(),
+        ref_id: "42".to_string(),
+        label: "the fix".to_string(),
+        url: None,
+    }];
+    assert!(has_derivable_signal(&pr_goal));
+
+    // Off-repo, no refs → no derivable signal.
+    assert!(!has_derivable_signal(&no_signal_goal("g")));
+}
+
+#[test]
+fn false_completion_rate_is_refuted_share_of_checkable() {
+    use VerificationOutcome::*;
+    // No checkable outcomes → None.
+    assert!(false_completion_rate(&[]).is_none());
+    assert!(false_completion_rate(&[UnverifiedNoSignal, Error]).is_none());
+    assert_eq!(false_completion_rate(&[Verified, Verified]).unwrap(), 0.0);
+    assert_eq!(false_completion_rate(&[Refuted, Refuted]).unwrap(), 1.0);
+    // Signal-less / error are excluded from the denominator: refuted 1 of
+    // (verified 1 + refuted 1) = 0.5, NOT 1/4.
+    let mixed = [Verified, Refuted, UnverifiedNoSignal, Error];
+    assert!((false_completion_rate(&mixed).unwrap() - 0.5).abs() < 1e-12);
+}
+
+#[test]
+fn outcome_metric_labels_and_codes_are_stable() {
+    // Pin the metric vocabulary from issue #2456.
+    assert_eq!(
+        COMPLETION_VERIFICATION_METRIC,
+        "goal_completion_verification"
+    );
+    assert_eq!(FALSE_COMPLETION_RATE_METRIC, "goal_false_completion_rate");
+    assert_eq!(VerificationOutcome::Verified.metric_label(), "verified");
+    assert_eq!(
+        VerificationOutcome::UnverifiedNoSignal.metric_label(),
+        "unverified_no_signal"
+    );
+    assert_eq!(VerificationOutcome::Refuted.metric_label(), "refuted");
+    assert_eq!(VerificationOutcome::Error.metric_label(), "error");
+    // Codes are distinct so a time series can aggregate by value.
+    let codes = [
+        VerificationOutcome::Verified.metric_code(),
+        VerificationOutcome::UnverifiedNoSignal.metric_code(),
+        VerificationOutcome::Refuted.metric_code(),
+        VerificationOutcome::Error.metric_code(),
+    ];
+    for (i, a) in codes.iter().enumerate() {
+        for b in &codes[i + 1..] {
+            assert!((a - b).abs() > f64::EPSILON, "codes must be distinct");
+        }
+    }
+}
+
+#[test]
+fn metric_recorders_are_test_safe_noops_across_batch_shapes() {
+    use VerificationOutcome::*;
+    // Both recorders are cfg!(test)-guarded no-ops, so they must never write the
+    // operator's real metrics.jsonl from a unit test — and must not panic on any
+    // batch shape, including empty / non-checkable batches (no rate to emit).
+    record_completion_verification(Verified);
+    record_completion_verification(Refuted);
+    record_completion_verification(UnverifiedNoSignal);
+    record_completion_verification(Error);
+
+    record_false_completion_rate(&[]);
+    record_false_completion_rate(&[UnverifiedNoSignal, Error]); // not checkable → None
+    record_false_completion_rate(&[Verified, Refuted, UnverifiedNoSignal, Error]);
+
+    // The value the batch recorder would emit is exactly false_completion_rate.
+    let mixed = [Verified, Refuted, UnverifiedNoSignal, Error];
+    assert!((false_completion_rate(&mixed).unwrap() - 0.5).abs() < 1e-12);
 }
 
 // --- helpers ----------------------------------------------------------------

--- a/src/goal_curation/mod.rs
+++ b/src/goal_curation/mod.rs
@@ -38,9 +38,12 @@ pub use decompose::{
 pub use edges::{children_of, edges_of_type, node_of, parse_goal_edge, write_edge, write_node};
 
 pub use completion_gate::{
-    CompletionEvidence, CompletionEvidenceGate, CompletionVerdict, EvidenceSource,
-    GhCliEvidenceSource, MissingEvidence, archive_completed_evidence_aware,
-    archive_completed_with_evidence, completion_evidence_enabled, is_self_affecting,
+    COMPLETION_VERIFICATION_METRIC, CompletionEvidence, CompletionEvidenceGate, CompletionVerdict,
+    EvidenceSource, FALSE_COMPLETION_RATE_METRIC, GhCliEvidenceSource, MissingEvidence,
+    VerificationOutcome, archive_completed_evidence_aware, archive_completed_with_evidence,
+    classify_from_missing, classify_outcome, completion_evidence_enabled, false_completion_rate,
+    has_derivable_signal, is_self_affecting, record_completion_verification,
+    record_false_completion_rate,
 };
 
 #[cfg(test)]

--- a/src/ooda_brain/confidence.rs
+++ b/src/ooda_brain/confidence.rs
@@ -1,0 +1,433 @@
+//! Trustworthy-confidence primitive for the OODA brain (issue #2457).
+//!
+//! The brain decisions that gate everything — [`DecideJudgment`] and
+//! [`EngineerLifecycleDecision`] — historically carried only a `rationale`;
+//! only [`super::OrientJudgment`] had a native `confidence`. The escalation
+//! ladder (#2432) and the consolidation gate (#2433) both *assume* a usable
+//! confidence signal that the code did not produce. This module supplies that
+//! signal, drawing on two results that survive the #2455 critique:
+//!
+//! - **Verbalized confidence** (*Just Ask for Calibration*, EMNLP 2023,
+//!   [2305.14975]): ask the model to *state* a 0–1 probability; for RLHF
+//!   models this is better-calibrated than token log-probs. Represented here by
+//!   the [`JudgedDecision`] / [`JudgedLifecycle`] wrappers, which attach a
+//!   validated `confidence` to the existing tagged-enum judgments **without
+//!   changing their wire shape** (`#[serde(flatten)]` keeps the JSON flat:
+//!   `{"choice":..,"rationale":..,"confidence":..}`).
+//! - **Self-consistency** (*Self-Consistency*, ICLR 2023, [2203.11171]): sample
+//!   K decisions and majority-vote; the agreement fraction is a confidence
+//!   proxy that needs no external feedback. Implemented by
+//!   [`self_consistency_vote`], bounded by [`SELF_CONSISTENCY_K`] and gated to
+//!   high-stakes/irreversible decisions ([`should_self_consistency_sample`],
+//!   [`is_irreversible_lifecycle`]) so the K× cost stays confined.
+//!
+//! Calibration is measured against realized outcomes with [`CalibrationWindow`]
+//! (rolling expected-calibration-error over [`ECE_WINDOW`] samples and
+//! [`ECE_BINS`] equal-width bins) — the honest check on whether a stated
+//! confidence means anything on Simard's own outcomes.
+//!
+//! Everything here is pure and dependency-light so it is exhaustively
+//! unit-testable and free of the LLM/runtime coupling of the brain itself.
+
+use std::collections::VecDeque;
+
+use serde::{Deserialize, Serialize};
+
+use super::{DecideJudgment, EngineerLifecycleDecision};
+
+// ---------------------------------------------------------------------------
+// Tunable constants (named, not magic numbers)
+// ---------------------------------------------------------------------------
+
+/// A priority is "high-stakes" — and thus eligible for the K× self-consistency
+/// vote — when its urgency is at or above this threshold. There is no discrete
+/// `Priority` *tier* in the codebase (`Priority` is a struct with `urgency:
+/// f64`), so the gate is a numeric threshold rather than a tier name.
+pub const HIGH_STAKES_URGENCY: f64 = 0.8;
+
+/// Number of independent samples drawn for a self-consistency vote. `3` avoids
+/// the binary-tie pathology of an even K while keeping the cost multiplier
+/// bounded. Degrades to `1` (single verbalized confidence) when the budget has
+/// no headroom — see [`effective_k`].
+pub const SELF_CONSISTENCY_K: usize = 3;
+
+/// Rolling window length over which the expected-calibration-error is computed.
+pub const ECE_WINDOW: usize = 50;
+
+/// Number of equal-width confidence bins used by the ECE computation.
+pub const ECE_BINS: usize = 10;
+
+/// Metric name under which the rolling ECE is emitted via
+/// [`crate::self_metrics::record_metric`].
+pub const ECE_METRIC: &str = "brain_confidence_ece";
+
+// ---------------------------------------------------------------------------
+// Confidence scalars
+// ---------------------------------------------------------------------------
+
+/// The default confidence used when a wire payload omits the field. `1.0`
+/// mirrors [`super::OrientJudgment`] so the deterministic fallback's
+/// "always confident" output round-trips cleanly and old JSON keeps parsing.
+///
+/// **Trust boundary.** `default_confidence` is the cheerful default used only
+/// where high confidence is genuinely warranted: deserializing a trusted/legacy
+/// record that predates the field, and the *configured* deterministic floor
+/// brain (always-confident by construction). It must **never** be returned for
+/// a confidence that was *solicited* from an LLM but came back absent or
+/// malformed — that path must fail closed to [`LOW_TRUST_CONFIDENCE`]. See
+/// [`confidence_or_low_trust`].
+pub fn default_confidence() -> f64 {
+    1.0
+}
+
+/// The fail-closed floor. Returned whenever a confidence was *solicited* from an
+/// LLM but could not be trusted: absent when the prompt asked for it,
+/// unparseable, non-finite, or outside `[0, 1]`.
+///
+/// Confidence is consumed by gates that *unlock* privilege (extra compute, fact
+/// promotion, fewer re-verifications), so a missing-or-malformed value must
+/// degrade to the **least** privileged number, never to `1.0`. You cannot earn
+/// trust by emitting garbage.
+pub const LOW_TRUST_CONFIDENCE: f64 = 0.0;
+
+/// Reject a confidence that is non-finite or outside `[0, 1]`. Callers treat a
+/// rejection the same way they treat any other invalid judgment: fall back to
+/// the deterministic floor rather than trust a malformed signal.
+pub fn validate_confidence(confidence: f64) -> Result<(), String> {
+    if !confidence.is_finite() {
+        return Err(format!("confidence must be finite, got {confidence}"));
+    }
+    if !(0.0..=1.0).contains(&confidence) {
+        return Err(format!("confidence {confidence} out of [0, 1]"));
+    }
+    Ok(())
+}
+
+/// Resolve a *solicited* confidence to a trusted scalar, failing closed. Maps a
+/// present-and-valid `[0, 1]` finite value through unchanged, and **any** other
+/// case (absent, non-finite, out of range) to [`LOW_TRUST_CONFIDENCE`]. This is
+/// the canonical policy for confidences parsed out of an LLM reply: it can never
+/// turn a missing or poisoned value into a privilege-granting high confidence.
+pub fn confidence_or_low_trust(parsed: Option<f64>) -> f64 {
+    match parsed {
+        Some(c) if validate_confidence(c).is_ok() => c,
+        _ => LOW_TRUST_CONFIDENCE,
+    }
+}
+
+/// Clamp any float into `[0, 1]`, mapping NaN to `0.0`. Used where a usable
+/// (if conservative) number is preferable to an error — e.g. deriving a
+/// `Fact.confidence` for the consolidation gate (#2433).
+pub fn clamp_confidence(confidence: f64) -> f64 {
+    if confidence.is_nan() {
+        0.0
+    } else {
+        confidence.clamp(0.0, 1.0)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// High-stakes / irreversibility gating
+// ---------------------------------------------------------------------------
+
+/// Whether a priority's urgency clears the [`HIGH_STAKES_URGENCY`] threshold.
+pub fn is_high_stakes(urgency: f64) -> bool {
+    urgency.is_finite() && urgency >= HIGH_STAKES_URGENCY
+}
+
+/// Whether an engineer-lifecycle decision is irreversible / escalating, and so
+/// worth the extra self-consistency samples even when the priority urgency is
+/// not itself high. Reclaiming a worktree, opening a tracking issue, and
+/// marking a goal blocked are all hard to walk back; merely continuing to skip
+/// or deprioritizing are cheap and reversible.
+pub fn is_irreversible_lifecycle(decision: &EngineerLifecycleDecision) -> bool {
+    matches!(
+        decision,
+        EngineerLifecycleDecision::OpenTrackingIssue { .. }
+            | EngineerLifecycleDecision::ReclaimAndRedispatch { .. }
+            | EngineerLifecycleDecision::MarkGoalBlocked { .. }
+    )
+}
+
+/// Whether to spend the K× self-consistency vote on this decision: only when it
+/// is consequential (high-stakes urgency) **and** the budget has headroom. With
+/// no headroom we still decide — just with a single verbalized-confidence
+/// sample (see [`effective_k`]).
+pub fn should_self_consistency_sample(urgency: f64, have_budget_headroom: bool) -> bool {
+    is_high_stakes(urgency) && have_budget_headroom
+}
+
+/// The effective sample count given budget headroom: the full
+/// [`SELF_CONSISTENCY_K`] when there is room, otherwise `1` (degrade to a
+/// single sample, never to *no* decision).
+pub fn effective_k(have_budget_headroom: bool) -> usize {
+    if have_budget_headroom {
+        SELF_CONSISTENCY_K
+    } else {
+        1
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Self-consistency vote
+// ---------------------------------------------------------------------------
+
+/// Result of a self-consistency vote over K samples.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Vote<K> {
+    /// The winning choice (modal sample; ties broken by the caller's rank).
+    pub choice: K,
+    /// Vote agreement = `modal_count / k` in `[0, 1]`. This is the confidence
+    /// proxy that needs no external feedback.
+    pub agreement: f64,
+    /// Number of samples that agreed on [`Vote::choice`].
+    pub modal_count: usize,
+    /// Total number of samples considered.
+    pub k: usize,
+}
+
+/// Majority-vote over `samples`, returning the modal choice and the agreement
+/// fraction as confidence. `None` for an empty slice.
+///
+/// Ties (multiple choices sharing the maximum count) are broken
+/// deterministically: the choice with the highest `rank` wins, and among equal
+/// ranks the one that appeared **first** in `samples` wins. Pass a `rank` that
+/// scores the more conservative / more escalating option higher so a tie
+/// resolves the safe way rather than arbitrarily.
+pub fn self_consistency_vote<K, R>(samples: &[K], rank: R) -> Option<Vote<K>>
+where
+    K: Eq + Clone,
+    R: Fn(&K) -> i64,
+{
+    if samples.is_empty() {
+        return None;
+    }
+    // Count occurrences by linear scan. K is tiny here (K ≤ SELF_CONSISTENCY_K),
+    // so an O(n²) count avoids requiring `K: Hash` — keeping the brain decision
+    // enums free of any extra derive (contract preservation).
+    let count_of = |target: &K| -> usize { samples.iter().filter(|s| *s == target).count() };
+    let max_count = samples.iter().map(&count_of).max().unwrap_or(0);
+
+    // First-seen order index for stable tie-breaking among equal ranks.
+    let first_index = |target: &K| -> i64 {
+        samples
+            .iter()
+            .position(|s| s == target)
+            .unwrap_or(usize::MAX) as i64
+    };
+
+    // Among the modal choices, pick the highest `(rank, earliest-first-seen)`.
+    // A composite key sidesteps the "last maximum wins" rule of `max_by`:
+    // higher rank wins; on equal rank the smaller first-seen index wins
+    // (negated so "earlier" sorts larger). Duplicate modal samples share a key,
+    // so the choice is deterministic regardless of which copy is returned.
+    let choice = samples
+        .iter()
+        .filter(|s| count_of(s) == max_count)
+        .max_by_key(|s| (rank(s), -first_index(s)))
+        .cloned()?;
+
+    Some(Vote {
+        agreement: max_count as f64 / samples.len() as f64,
+        modal_count: max_count,
+        k: samples.len(),
+        choice,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Verbalized-confidence wrappers (native confidence on the brain judgments)
+// ---------------------------------------------------------------------------
+
+/// A [`DecideJudgment`] carrying a brain-stated confidence. `#[serde(flatten)]`
+/// keeps the wire shape identical to the bare judgment plus a sibling
+/// `confidence` field, so old prompts/JSON (no `confidence`) still parse and the
+/// bare [`DecideJudgment`] still deserializes from the same bytes.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct JudgedDecision {
+    #[serde(flatten)]
+    pub judgment: DecideJudgment,
+    #[serde(default = "default_confidence")]
+    pub confidence: f64,
+}
+
+impl JudgedDecision {
+    pub fn new(judgment: DecideJudgment, confidence: f64) -> Self {
+        Self {
+            judgment,
+            confidence,
+        }
+    }
+
+    /// Validate the attached confidence (finite, `[0, 1]`).
+    pub fn validate(&self) -> Result<(), String> {
+        validate_confidence(self.confidence)
+    }
+}
+
+/// An [`EngineerLifecycleDecision`] carrying a brain-stated confidence. Same
+/// flatten/back-compat properties as [`JudgedDecision`].
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct JudgedLifecycle {
+    #[serde(flatten)]
+    pub decision: EngineerLifecycleDecision,
+    #[serde(default = "default_confidence")]
+    pub confidence: f64,
+}
+
+impl JudgedLifecycle {
+    pub fn new(decision: EngineerLifecycleDecision, confidence: f64) -> Self {
+        Self {
+            decision,
+            confidence,
+        }
+    }
+
+    /// Validate the attached confidence (finite, `[0, 1]`).
+    pub fn validate(&self) -> Result<(), String> {
+        validate_confidence(self.confidence)
+    }
+
+    /// Whether this decision warrants the K× self-consistency vote given the
+    /// driving priority urgency and the budget headroom.
+    pub fn warrants_self_consistency(&self, urgency: f64, have_budget_headroom: bool) -> bool {
+        have_budget_headroom
+            && (is_high_stakes(urgency) || is_irreversible_lifecycle(&self.decision))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Calibration: rolling expected-calibration-error (ECE)
+// ---------------------------------------------------------------------------
+
+/// A bounded rolling window of `(predicted_confidence, realized_outcome)` pairs
+/// used to compute the expected-calibration-error of the brain's stated
+/// confidences. `realized_outcome` is the objective ground truth — for the
+/// completion gate (#2456) this is `verified → true`, `refuted → false`;
+/// signal-less outcomes are simply not recorded.
+#[derive(Clone, Debug)]
+pub struct CalibrationWindow {
+    samples: VecDeque<(f64, bool)>,
+    capacity: usize,
+    bins: usize,
+}
+
+impl Default for CalibrationWindow {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CalibrationWindow {
+    /// A window with the module defaults ([`ECE_WINDOW`], [`ECE_BINS`]).
+    pub fn new() -> Self {
+        Self::with_params(ECE_WINDOW, ECE_BINS)
+    }
+
+    /// A window with explicit capacity and bin count. Both are clamped to at
+    /// least 1 so the structure is always usable.
+    pub fn with_params(capacity: usize, bins: usize) -> Self {
+        Self {
+            samples: VecDeque::new(),
+            capacity: capacity.max(1),
+            bins: bins.max(1),
+        }
+    }
+
+    /// Record one prediction/outcome pair. The predicted confidence is clamped
+    /// into `[0, 1]`; the oldest sample is evicted once the window is full.
+    pub fn record(&mut self, predicted: f64, outcome: bool) {
+        if self.samples.len() == self.capacity {
+            self.samples.pop_front();
+        }
+        self.samples
+            .push_back((clamp_confidence(predicted), outcome));
+    }
+
+    pub fn len(&self) -> usize {
+        self.samples.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.samples.is_empty()
+    }
+
+    /// Expected calibration error over equal-width bins: the sample-weighted
+    /// mean of `|mean_confidence − accuracy|` per bin. `None` while empty.
+    /// `0.0` means perfectly calibrated; `1.0` is the worst case.
+    pub fn ece(&self) -> Option<f64> {
+        let total = self.samples.len();
+        if total == 0 {
+            return None;
+        }
+        let mut bin_conf_sum = vec![0.0_f64; self.bins];
+        let mut bin_hit_sum = vec![0.0_f64; self.bins];
+        let mut bin_count = vec![0_usize; self.bins];
+
+        for &(conf, outcome) in &self.samples {
+            // conf is already clamped to [0,1]; map 1.0 into the last bin.
+            let mut idx = (conf * self.bins as f64).floor() as usize;
+            if idx >= self.bins {
+                idx = self.bins - 1;
+            }
+            bin_conf_sum[idx] += conf;
+            bin_hit_sum[idx] += if outcome { 1.0 } else { 0.0 };
+            bin_count[idx] += 1;
+        }
+
+        let mut ece = 0.0;
+        for b in 0..self.bins {
+            let n = bin_count[b];
+            if n == 0 {
+                continue;
+            }
+            let mean_conf = bin_conf_sum[b] / n as f64;
+            let accuracy = bin_hit_sum[b] / n as f64;
+            ece += (n as f64 / total as f64) * (mean_conf - accuracy).abs();
+        }
+        Some(ece)
+    }
+
+    /// Emit the current ECE via [`crate::self_metrics::record_metric`] under
+    /// [`ECE_METRIC`]. Best-effort and a no-op while the window is empty;
+    /// returns the value that was recorded (if any).
+    pub fn record_ece_metric(&self) -> Option<f64> {
+        let ece = self.ece()?;
+        let _ = crate::self_metrics::record_metric(
+            ECE_METRIC,
+            ece,
+            &format!("n={} bins={}", self.len(), self.bins),
+        );
+        Some(ece)
+    }
+}
+
+/// Convenience: the inverse-of-correct rate over realized outcomes — the share
+/// of recorded samples whose outcome was `false`. With outcomes sourced from
+/// the #2456 gate (`refuted → false`) this is the false-completion rate the
+/// issue asks to trend down.
+pub fn false_outcome_rate(outcomes: &[bool]) -> Option<f64> {
+    if outcomes.is_empty() {
+        return None;
+    }
+    let bad = outcomes.iter().filter(|o| !**o).count();
+    Some(bad as f64 / outcomes.len() as f64)
+}
+
+/// Tie-break rank for an [`EngineerLifecycleDecision`]: the more escalating /
+/// irreversible the action, the higher the rank, so a self-consistency tie
+/// resolves toward the safer (more cautious) choice. Provided as the canonical
+/// `rank` argument to [`self_consistency_vote`] for lifecycle decisions.
+pub fn lifecycle_conservative_rank(decision: &EngineerLifecycleDecision) -> i64 {
+    match decision {
+        EngineerLifecycleDecision::MarkGoalBlocked { .. } => 5,
+        EngineerLifecycleDecision::OpenTrackingIssue { .. } => 4,
+        EngineerLifecycleDecision::ReclaimAndRedispatch { .. } => 3,
+        EngineerLifecycleDecision::ConsiderSelfUpdate { .. } => 2,
+        EngineerLifecycleDecision::Deprioritize { .. } => 1,
+        EngineerLifecycleDecision::ContinueSkipping { .. } => 0,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/ooda_brain/confidence/tests.rs
+++ b/src/ooda_brain/confidence/tests.rs
@@ -1,0 +1,385 @@
+//! Unit tests for the trustworthy-confidence primitive (issue #2457).
+//!
+//! These were written test-first against the issue's acceptance criteria:
+//! - the brain judgments carry a *populated, validated* confidence;
+//! - a self-consistency vote exists, is bounded by K, and exposes vote
+//!   agreement as confidence;
+//! - a calibration (ECE) measure over predicted-vs-realized outcomes exists.
+
+use super::*;
+use crate::ooda_brain::{DecideJudgment, EngineerLifecycleDecision};
+
+fn skip(r: &str) -> EngineerLifecycleDecision {
+    EngineerLifecycleDecision::ContinueSkipping {
+        rationale: r.into(),
+    }
+}
+fn blocked(r: &str) -> EngineerLifecycleDecision {
+    EngineerLifecycleDecision::MarkGoalBlocked {
+        rationale: r.into(),
+        reason: "x".into(),
+    }
+}
+fn reclaim(r: &str) -> EngineerLifecycleDecision {
+    EngineerLifecycleDecision::ReclaimAndRedispatch {
+        rationale: r.into(),
+        redispatch_context: String::new(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Confidence scalars
+// ---------------------------------------------------------------------------
+
+#[test]
+fn default_confidence_is_one() {
+    assert!((default_confidence() - 1.0).abs() < 1e-12);
+}
+
+#[test]
+fn validate_confidence_accepts_unit_interval_and_boundaries() {
+    assert!(validate_confidence(0.0).is_ok());
+    assert!(validate_confidence(1.0).is_ok());
+    assert!(validate_confidence(0.5).is_ok());
+}
+
+#[test]
+fn validate_confidence_rejects_out_of_range_and_nonfinite() {
+    assert!(validate_confidence(-0.0001).is_err());
+    assert!(validate_confidence(1.0001).is_err());
+    assert!(validate_confidence(f64::NAN).is_err());
+    assert!(validate_confidence(f64::INFINITY).is_err());
+    assert!(validate_confidence(f64::NEG_INFINITY).is_err());
+}
+
+#[test]
+fn clamp_confidence_maps_nan_to_zero_and_clamps_range() {
+    assert_eq!(clamp_confidence(f64::NAN), 0.0);
+    assert_eq!(clamp_confidence(-5.0), 0.0);
+    assert_eq!(clamp_confidence(5.0), 1.0);
+    assert!((clamp_confidence(0.42) - 0.42).abs() < 1e-12);
+}
+
+#[test]
+fn low_trust_confidence_is_the_zero_floor() {
+    // The fail-closed floor must be the least-privileged value, distinct from the
+    // cheerful default — so a malformed/absent solicited confidence can never
+    // unlock privilege.
+    assert_eq!(LOW_TRUST_CONFIDENCE, 0.0);
+    assert!(LOW_TRUST_CONFIDENCE < default_confidence());
+}
+
+#[test]
+fn confidence_or_low_trust_fails_closed() {
+    // Present and valid → used verbatim.
+    assert!((confidence_or_low_trust(Some(0.73)) - 0.73).abs() < 1e-12);
+    assert_eq!(confidence_or_low_trust(Some(0.0)), 0.0);
+    assert_eq!(confidence_or_low_trust(Some(1.0)), 1.0);
+    // Absent / out of range / non-finite → fail closed to LOW_TRUST_CONFIDENCE,
+    // NEVER to default_confidence() (1.0).
+    assert_eq!(confidence_or_low_trust(None), LOW_TRUST_CONFIDENCE);
+    assert_eq!(confidence_or_low_trust(Some(1.5)), LOW_TRUST_CONFIDENCE);
+    assert_eq!(confidence_or_low_trust(Some(-0.1)), LOW_TRUST_CONFIDENCE);
+    assert_eq!(
+        confidence_or_low_trust(Some(f64::NAN)),
+        LOW_TRUST_CONFIDENCE
+    );
+    assert_eq!(
+        confidence_or_low_trust(Some(f64::INFINITY)),
+        LOW_TRUST_CONFIDENCE
+    );
+}
+
+// ---------------------------------------------------------------------------
+// High-stakes / irreversibility gating
+// ---------------------------------------------------------------------------
+
+#[test]
+fn high_stakes_threshold_is_inclusive() {
+    assert!(is_high_stakes(HIGH_STAKES_URGENCY));
+    assert!(is_high_stakes(0.95));
+    assert!(!is_high_stakes(0.79));
+    assert!(!is_high_stakes(f64::NAN));
+}
+
+#[test]
+fn irreversible_lifecycle_covers_escalating_actions_only() {
+    assert!(is_irreversible_lifecycle(&blocked("b")));
+    assert!(is_irreversible_lifecycle(&reclaim("r")));
+    assert!(is_irreversible_lifecycle(
+        &EngineerLifecycleDecision::OpenTrackingIssue {
+            rationale: "r".into(),
+            title: "t".into(),
+            body: "b".into(),
+        }
+    ));
+    // Cheap / reversible actions are not gated as irreversible.
+    assert!(!is_irreversible_lifecycle(&skip("s")));
+    assert!(!is_irreversible_lifecycle(
+        &EngineerLifecycleDecision::Deprioritize {
+            rationale: "d".into()
+        }
+    ));
+    assert!(!is_irreversible_lifecycle(
+        &EngineerLifecycleDecision::ConsiderSelfUpdate {
+            rationale: "u".into()
+        }
+    ));
+}
+
+#[test]
+fn self_consistency_is_gated_by_stakes_and_budget() {
+    assert!(should_self_consistency_sample(0.9, true));
+    assert!(!should_self_consistency_sample(0.9, false)); // no budget
+    assert!(!should_self_consistency_sample(0.2, true)); // not high-stakes
+}
+
+#[test]
+fn effective_k_degrades_to_one_without_budget() {
+    assert_eq!(effective_k(true), SELF_CONSISTENCY_K);
+    assert_eq!(effective_k(false), 1);
+    // K must be odd and >= 3 to avoid binary ties; assert via a non-constant
+    // expression so the check is a real runtime assertion.
+    assert_eq!(effective_k(true) % 2, 1, "K must be odd to avoid ties");
+}
+
+// ---------------------------------------------------------------------------
+// Self-consistency vote
+// ---------------------------------------------------------------------------
+
+#[test]
+fn vote_on_empty_is_none() {
+    let empty: Vec<EngineerLifecycleDecision> = vec![];
+    assert!(self_consistency_vote(&empty, lifecycle_conservative_rank).is_none());
+}
+
+#[test]
+fn unanimous_vote_has_full_agreement() {
+    let samples = vec![skip("a"), skip("a"), skip("a")];
+    let v = self_consistency_vote(&samples, lifecycle_conservative_rank).unwrap();
+    assert_eq!(v.choice, skip("a"));
+    assert!((v.agreement - 1.0).abs() < 1e-12);
+    assert_eq!(v.modal_count, 3);
+    assert_eq!(v.k, 3);
+}
+
+#[test]
+fn majority_vote_reports_agreement_fraction() {
+    // 2 of 3 agree → agreement 2/3, modal choice wins.
+    let samples = vec![skip("a"), skip("a"), blocked("b")];
+    let v = self_consistency_vote(&samples, lifecycle_conservative_rank).unwrap();
+    assert_eq!(v.choice, skip("a"));
+    assert!((v.agreement - 2.0 / 3.0).abs() < 1e-9);
+    assert_eq!(v.modal_count, 2);
+}
+
+#[test]
+fn tie_breaks_toward_more_conservative_choice() {
+    // 1 vs 1 tie: the conservative-rank picks MarkGoalBlocked over ContinueSkipping.
+    let samples = vec![skip("a"), blocked("b")];
+    let v = self_consistency_vote(&samples, lifecycle_conservative_rank).unwrap();
+    assert_eq!(v.choice, blocked("b"));
+    assert!((v.agreement - 0.5).abs() < 1e-12);
+    assert_eq!(v.modal_count, 1);
+}
+
+#[test]
+fn tie_with_equal_rank_breaks_toward_first_seen() {
+    // Equal rank → deterministic first-seen wins (constant rank).
+    let samples = vec!["x".to_string(), "y".to_string()];
+    let v = self_consistency_vote(&samples, |_| 0).unwrap();
+    assert_eq!(v.choice, "x");
+    assert!((v.agreement - 0.5).abs() < 1e-12);
+}
+
+#[test]
+fn vote_agreement_is_a_confidence_in_unit_interval() {
+    let samples = vec![skip("a"), blocked("b"), reclaim("c")]; // all distinct → 1/3
+    let v = self_consistency_vote(&samples, lifecycle_conservative_rank).unwrap();
+    assert!((0.0..=1.0).contains(&v.agreement));
+    assert!((v.agreement - 1.0 / 3.0).abs() < 1e-9);
+    // The conservative-rank winner among the all-tied set is MarkGoalBlocked.
+    assert_eq!(v.choice, blocked("b"));
+    assert!(validate_confidence(v.agreement).is_ok());
+}
+
+// ---------------------------------------------------------------------------
+// Verbalized-confidence wrappers — wire-shape preservation + validation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn judged_decision_serializes_flat_with_confidence() {
+    let j = JudgedDecision::new(
+        DecideJudgment::AdvanceGoal {
+            rationale: "go".into(),
+        },
+        0.8,
+    );
+    let s = serde_json::to_string(&j).unwrap();
+    // Flat shape: the tag, the rationale, and confidence are all siblings.
+    assert_eq!(
+        s,
+        r#"{"choice":"advance_goal","rationale":"go","confidence":0.8}"#
+    );
+}
+
+#[test]
+fn judged_decision_defaults_confidence_when_absent() {
+    // Old wire format (no confidence) must still parse, defaulting to 1.0.
+    let j: JudgedDecision =
+        serde_json::from_str(r#"{"choice":"advance_goal","rationale":"go"}"#).unwrap();
+    assert!((j.confidence - 1.0).abs() < 1e-12);
+    assert_eq!(
+        j.judgment,
+        DecideJudgment::AdvanceGoal {
+            rationale: "go".into()
+        }
+    );
+}
+
+#[test]
+fn bare_decide_judgment_still_parses_from_judged_wire() {
+    // Contract preservation: code that only knows the inner enum keeps working
+    // against JSON that now carries a sibling confidence field.
+    let d: DecideJudgment =
+        serde_json::from_str(r#"{"choice":"advance_goal","rationale":"go","confidence":0.3}"#)
+            .unwrap();
+    assert_eq!(
+        d,
+        DecideJudgment::AdvanceGoal {
+            rationale: "go".into()
+        }
+    );
+}
+
+#[test]
+fn judged_decision_validate_rejects_bad_confidence() {
+    let bad = JudgedDecision::new(
+        DecideJudgment::AdvanceGoal {
+            rationale: "go".into(),
+        },
+        1.5,
+    );
+    assert!(bad.validate().is_err());
+    let ok = JudgedDecision::new(
+        DecideJudgment::AdvanceGoal {
+            rationale: "go".into(),
+        },
+        0.9,
+    );
+    assert!(ok.validate().is_ok());
+}
+
+#[test]
+fn judged_lifecycle_round_trips_and_validates() {
+    let j = JudgedLifecycle::new(reclaim("stuck"), 0.6);
+    let s = serde_json::to_string(&j).unwrap();
+    assert!(s.contains(r#""choice":"reclaim_and_redispatch""#));
+    assert!(s.contains(r#""confidence":0.6"#));
+    let back: JudgedLifecycle = serde_json::from_str(&s).unwrap();
+    assert_eq!(back, j);
+    assert!(back.validate().is_ok());
+}
+
+#[test]
+fn judged_lifecycle_warrants_self_consistency_on_stakes_or_irreversibility() {
+    // High urgency, reversible action, with budget → warranted (high-stakes).
+    assert!(JudgedLifecycle::new(skip("s"), 1.0).warrants_self_consistency(0.9, true));
+    // Low urgency but irreversible action, with budget → warranted.
+    assert!(JudgedLifecycle::new(blocked("b"), 1.0).warrants_self_consistency(0.1, true));
+    // Low urgency, reversible action → not warranted.
+    assert!(!JudgedLifecycle::new(skip("s"), 1.0).warrants_self_consistency(0.1, true));
+    // No budget headroom → never warranted, regardless of stakes.
+    assert!(!JudgedLifecycle::new(blocked("b"), 1.0).warrants_self_consistency(0.9, false));
+}
+
+// ---------------------------------------------------------------------------
+// Calibration window (ECE)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ece_is_none_while_empty() {
+    let w = CalibrationWindow::new();
+    assert!(w.is_empty());
+    assert!(w.ece().is_none());
+}
+
+#[test]
+fn perfect_calibration_has_zero_ece() {
+    let mut w = CalibrationWindow::new();
+    // Confidence 1.0 always correct, confidence 0.0 always wrong → ECE 0.
+    for _ in 0..10 {
+        w.record(1.0, true);
+        w.record(0.0, false);
+    }
+    let ece = w.ece().unwrap();
+    assert!(ece.abs() < 1e-9, "expected ~0 ECE, got {ece}");
+}
+
+#[test]
+fn worst_case_calibration_has_ece_one() {
+    let mut w = CalibrationWindow::new();
+    // Always 100% confident, always wrong → ECE 1.0.
+    for _ in 0..20 {
+        w.record(1.0, false);
+    }
+    let ece = w.ece().unwrap();
+    assert!((ece - 1.0).abs() < 1e-9, "expected ECE 1.0, got {ece}");
+}
+
+#[test]
+fn ece_value_is_in_unit_interval_for_mixed_data() {
+    let mut w = CalibrationWindow::with_params(50, 10);
+    for i in 0..40 {
+        w.record((i as f64) / 40.0, i % 2 == 0);
+    }
+    let ece = w.ece().unwrap();
+    assert!((0.0..=1.0).contains(&ece), "ECE out of range: {ece}");
+}
+
+#[test]
+fn window_evicts_oldest_beyond_capacity() {
+    let mut w = CalibrationWindow::with_params(3, 10);
+    w.record(0.1, true);
+    w.record(0.2, true);
+    w.record(0.3, true);
+    w.record(0.4, true); // evicts the first
+    assert_eq!(w.len(), 3);
+}
+
+#[test]
+fn with_params_clamps_degenerate_inputs() {
+    // capacity/bins of 0 must not divide-by-zero or panic.
+    let mut w = CalibrationWindow::with_params(0, 0);
+    w.record(0.5, true);
+    assert_eq!(w.len(), 1);
+    assert!(w.ece().is_some());
+}
+
+#[test]
+fn false_outcome_rate_basics() {
+    assert!(false_outcome_rate(&[]).is_none());
+    assert_eq!(false_outcome_rate(&[true, true]).unwrap(), 0.0);
+    assert_eq!(false_outcome_rate(&[false, false]).unwrap(), 1.0);
+    assert!((false_outcome_rate(&[true, false, false, false]).unwrap() - 0.75).abs() < 1e-12);
+}
+
+#[test]
+fn lifecycle_rank_orders_by_severity() {
+    assert!(
+        lifecycle_conservative_rank(&blocked("b")) > lifecycle_conservative_rank(&reclaim("r"))
+    );
+    assert!(lifecycle_conservative_rank(&reclaim("r")) > lifecycle_conservative_rank(&skip("s")));
+}
+
+#[test]
+fn record_ece_metric_is_noop_when_empty() {
+    // Empty window records nothing and returns None — a pure check with no IO.
+    let empty = CalibrationWindow::new();
+    assert!(empty.record_ece_metric().is_none());
+    // The recorded value, when non-empty, is exactly `ece()` (validated here
+    // without performing the best-effort write so the test stays hermetic).
+    let mut w = CalibrationWindow::new();
+    w.record(0.9, true);
+    assert!(w.ece().is_some());
+}

--- a/src/ooda_brain/mod.rs
+++ b/src/ooda_brain/mod.rs
@@ -15,6 +15,7 @@ use crate::error::SimardResult;
 use crate::ooda_loop::OodaState;
 use std::path::PathBuf;
 
+pub mod confidence;
 mod context;
 mod decide;
 mod fallback;
@@ -35,6 +36,12 @@ mod prompt_store_tests;
 #[cfg(test)]
 mod tests;
 
+pub use confidence::{
+    CalibrationWindow, ECE_BINS, ECE_METRIC, ECE_WINDOW, HIGH_STAKES_URGENCY, JudgedDecision,
+    JudgedLifecycle, LOW_TRUST_CONFIDENCE, SELF_CONSISTENCY_K, Vote, confidence_or_low_trust,
+    effective_k, is_high_stakes, is_irreversible_lifecycle, lifecycle_conservative_rank,
+    self_consistency_vote, should_self_consistency_sample, validate_confidence,
+};
 pub use context::{count_live_engineer_claims, gather_engineer_lifecycle_ctx, redact_secrets};
 pub use decide::{
     DecideContext, DecideJudgment, DeterministicDecideBrain, OodaDecideBrain,


### PR DESCRIPTION
## Summary

Two tightly-coupled brain-reliability halves that share a metrics spine:

- **#2457 — trustworthy confidence primitive.** Supplies the usable confidence signal the escalation ladder (#2432) and consolidation gate (#2433) already assume but the code never produced.
- **#2456 — external-signal completion gate.** Stops trusting subordinate self-reports; verifies completion against external signals, *extending* (not duplicating) the shipped #2450 deploy-aware done-gate.

## #2457 — `src/ooda_brain/confidence.rs` (exported from `crate::ooda_brain`)

- **Verbalized-confidence carriers** `JudgedDecision` / `JudgedLifecycle` attach a validated `confidence` to the tagged brain enums via `#[serde(flatten)]` — keeps the JSON flat (`{"choice":…,"rationale":…,"confidence":…}`), keeps the enums' `Eq` derive, needs no per-variant edit or `Hash`. Strictly more contract-preserving than editing each variant; old JSON still parses (`serde(default)`).
- **Self-consistency vote** — pure majority tally exposing vote agreement as a no-feedback confidence proxy, bounded by `SELF_CONSISTENCY_K` and budget (`effective_k` degrades to 1, never to *no* decision), gated to high-stakes / irreversible decisions.
- **Fail-closed policy** — `default_confidence` (1.0, trusted/legacy only) vs `LOW_TRUST_CONFIDENCE` (0.0) + `confidence_or_low_trust`: a solicited-but-malformed confidence can never unlock privilege.
- **`CalibrationWindow`** — rolling ECE (`brain_confidence_ece`) over predicted-vs-realized outcomes.

## #2456 — `src/goal_curation/completion_gate.rs`

- **`VerificationOutcome`** classifier (`verified` / `unverified_no_signal` / `refuted` / `error`) over the existing gate verdict. No-signal completions are **held for review** (blocked, not archived) — an honest label, never silent trust.
- Emits **`goal_completion_verification`** (per event) and **`goal_false_completion_rate`** (per archival batch) via `self_metrics`; recorders are `cfg!(test)`-guarded so unit tests never corrupt the operator's `metrics.jsonl`. The verified/refuted outcomes are the ground-truth feed for #2457's calibration.

## Tests / CI

- Exhaustive unit + content-pin tests for both halves (wire-shape round-trips, fail-closed policy, vote/ECE properties, metric-vocabulary pins). All new module tests green.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features --locked -- -D warnings`, release-clippy, and `mkdocs build --strict` all clean (pre-commit + pre-push gates passed).
- Pre-existing local test failures (`resolve_recipe_path*`) are environmental only — caused by a developer `~/.simard/prompt_assets/.../recipes/` hot-reload dir; verified to pass with a clean `$HOME` (as in CI).

## Honesty / scope

Docs (concept + howto + 2 reference pages, added to mkdocs nav) explicitly mark as **forward design, not shipped here**: live solicitation of a verbalized `CONFIDENCE:` line in the brain prompts + threading it through the brain trait return types, and the distinct persisted `GoalProgress::CompletedUnverified` state (would ripple through ~60 exhaustive matches). This slice ships the primitive + the gate's external-signal classification/metrics. No live redeploy.

Closes #2457
Closes #2456

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>