### PR TITLE
fix(self-deploy): build the merged head from a cwd-independent source (#2467)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3892,7 +3892,7 @@ dependencies = [
 
 [[package]]
 name = "simard"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "amplihack-agent-eval",
  "amplihack-memory",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simard"
-version = "0.22.0"
+version = "0.22.1"
 edition = "2024"
 default-run = "simard"
 

--- a/docs/concepts/reconcile-and-self-deploy.md
+++ b/docs/concepts/reconcile-and-self-deploy.md
@@ -8,7 +8,9 @@ doc_type: concept
 related:
   - ../safe-self-update.md
   - ../reference/self-deploy-api.md
+  - ../reference/self-deploy-source-prep.md
   - ../howto/verify-and-roll-back-a-self-deploy.md
+  - ../howto/run-self-deploy-from-any-directory.md
   - ../howto/self-maintain-dependency-pins.md
   - deploy-aware-done-gate.md
   - ../reference/ooda-brain-parse-failure-record.md
@@ -121,10 +123,18 @@ flowchart TD
     RV -->|fails| CRIT[(critical operator alert)]
 ```
 
-1. **Build the candidate from merged source.** `self_relaunch::build_canary`
-   runs `cargo build --release` at the target commit in an isolated worktree. A
-   failed build **aborts loudly** and never touches the install path — no
-   half-deploy.
+1. **Build the candidate from merged source.** The operator self-deploy first
+   *prepares* a **cwd-independent** source checkout — `git fetch origin` then
+   `git checkout --detach <target commit>` in a persistent clone under
+   `~/.simard/self-deploy-src/` — and builds **that merged commit** (never the
+   cwd's `HEAD`) into a persistent **warm** target dir
+   (`~/.simard/self-deploy-target/`) so repeat builds are incremental
+   (~2–3 min instead of ~10+). A failed source resolution, fetch, checkout, or
+   build **aborts loudly** — before any backup or swap — and never touches the
+   install path. This is what makes `simard self-deploy` work from *any*
+   directory; see the
+   [self-deploy source-prep reference](../reference/self-deploy-source-prep.md)
+   and [how to run self-deploy from any directory](../howto/run-self-deploy-from-any-directory.md).
 2. **Gate the candidate.** The existing relaunch gates run in order — Smoke →
    UnitTest → GymBaseline → BridgeHealth — followed by the candidate's own
    `simard self-test`. Any failure aborts.
@@ -211,6 +221,8 @@ reconciliation detector chooses build-from-source whenever drift is against
 ## See also
 
 - [Self-deploy API reference](../reference/self-deploy-api.md) — types, config, CLI, JSON schemas.
+- [Self-deploy source-prep reference](../reference/self-deploy-source-prep.md) — cwd-independent fetch/checkout + warm target dir.
+- [How to run self-deploy from any directory](../howto/run-self-deploy-from-any-directory.md) — operator runbook for the autonomous path.
 - [How to verify and roll back a self-deploy](../howto/verify-and-roll-back-a-self-deploy.md) — operator runbook.
 - [Safe Self-Update](../safe-self-update.md) — the underlying drain/snapshot/swap orchestrator this extends.
 - [Deploy-aware done-gate](deploy-aware-done-gate.md) — the completion gate that consumes `DeployDrift`.

--- a/docs/howto/run-self-deploy-from-any-directory.md
+++ b/docs/howto/run-self-deploy-from-any-directory.md
@@ -68,13 +68,17 @@ simard self-deploy --check:
   needs deploy   : YES
 ```
 
-`needs deploy: YES` means a merged change is not yet running. For the `merged
-head` shown here to be **exactly** the SHA the deploy fetches, checks out, and
-builds, `--check` must resolve the merged head against the **same canonical
-repo** the deploy uses (the `SIMARD_SELF_DEPLOY_REPO` override or the persistent
-clone) — not the cwd checkout. If `--check` is run from a stale or unrelated
-checkout while the deploy resolves a different canonical repo, the two SHAs can
-diverge; see the design note in
+`needs deploy: YES` means a merged change is not yet running. `--check` resolves
+the `merged head` against the **same canonical repo** the deploy uses (the
+`SIMARD_SELF_DEPLOY_REPO` override or the persistent clone), independent of your
+cwd, and best-effort `git fetch`es it first so the SHA shown is current and
+matches the SHA the deploy fetches, checks out, and builds. It stays strictly
+read-only: unlike the deploy it **never clones** and tolerates an offline fetch
+(reporting against the local tracking refs) rather than erroring. Only when no
+canonical checkout exists yet — e.g. before your first deploy — does it fall back
+to a best-effort report from the current directory; in that pre-clone state the
+deploy itself has nothing canonical to build from either, so there is nothing for
+the two to diverge over. See the design note in
 [self-deploy source-prep reference](../reference/self-deploy-source-prep.md#repo-resolution-precedence).
 Use `--json` for machine-readable `DeployDrift`:
 

--- a/docs/howto/run-self-deploy-from-any-directory.md
+++ b/docs/howto/run-self-deploy-from-any-directory.md
@@ -1,0 +1,185 @@
+---
+title: How to run self-deploy from any directory
+description: Operator runbook for the autonomous, fast self-deploy — run `simard self-deploy` from any working directory and have it fetch + check out the merged head and build it into a warm, incremental target dir. Covers the warm directories, the SIMARD_SELF_DEPLOY_REPO override, first-run vs warm-run timing, and how to confirm the merged head (not cwd HEAD) was deployed.
+last_updated: 2026-06-28
+review_schedule: as-needed
+owner: simard
+doc_type: howto
+status: implemented
+related:
+  - ../reference/self-deploy-source-prep.md
+  - ../reference/self-deploy-api.md
+  - ../concepts/reconcile-and-self-deploy.md
+  - ../howto/verify-and-roll-back-a-self-deploy.md
+  - ../reference/state-root-resolution.md
+---
+
+# How to run self-deploy from any directory
+
+> **Status: implemented.** `simard self-deploy` fetches and checks out the
+> merged head before building, and reuses a warm target directory, so it works
+> from **any** working directory and is fast on repeat runs. The
+> source-preparation surface lives in
+> [`src/self_deploy/source_prep.rs`](https://github.com/rysweet/Simard/blob/main/src/self_deploy/source_prep.rs)
+> — see [self-deploy source-prep reference](../reference/self-deploy-source-prep.md).
+> The operator drives the deploy; the recipe never live-redeploys a daemon.
+
+This guide is for an operator who wants to deploy the latest **merged** Simard
+commit into the running daemon **without** first navigating to an up-to-date
+checkout. For the design and the typed API, see
+[self-deploy source-prep reference](../reference/self-deploy-source-prep.md).
+
+## What changed
+
+`simard self-deploy` used to build whatever the current directory's `HEAD` was,
+into a cold per-run `temp_dir()` (a ~10-minute from-scratch compile). Now it:
+
+1. resolves a canonical Simard source repo (independent of your cwd),
+2. `git fetch origin` and `git checkout --detach <merged head>` in that repo,
+3. builds **that** merged commit into a **persistent warm** target dir
+   (`~/.simard/self-deploy-target/`) — incremental, ~2–3 min on repeat runs,
+
+then runs the unchanged safety sequence (dual backup → drain → orphan-reap →
+swap → restart → health-check → rollback).
+
+## Prerequisites
+
+- The `simard` daemon is installed at `~/.simard/bin/simard` (systemd
+  `simard-ooda` user unit) on the host.
+- `git` and a Rust toolchain are on `PATH` (the build runs `cargo build
+  --release`).
+- Network access to the Simard origin (for `git fetch`) **or** a pre-populated
+  source repo (see [`SIMARD_SELF_DEPLOY_REPO`](#use-an-explicit-source-repo)).
+
+## Check drift first (read-only)
+
+`--check` never mutates anything; it reports running-vs-merged drift:
+
+```bash
+simard self-deploy --check
+```
+
+```text
+simard self-deploy --check:
+  running commit : 3f9a1c2…
+  merged head    : a17be03…
+  behind commits : 4
+  drifted pins   : (none)
+  needs deploy   : YES
+```
+
+`needs deploy: YES` means a merged change is not yet running. For the `merged
+head` shown here to be **exactly** the SHA the deploy fetches, checks out, and
+builds, `--check` must resolve the merged head against the **same canonical
+repo** the deploy uses (the `SIMARD_SELF_DEPLOY_REPO` override or the persistent
+clone) — not the cwd checkout. If `--check` is run from a stale or unrelated
+checkout while the deploy resolves a different canonical repo, the two SHAs can
+diverge; see the design note in
+[self-deploy source-prep reference](../reference/self-deploy-source-prep.md#repo-resolution-precedence).
+Use `--json` for machine-readable `DeployDrift`:
+
+```bash
+simard self-deploy --check --json | jq '.needs_deploy, .behind_commits'
+```
+
+## Deploy from any directory
+
+Run it from anywhere — your home directory, `/tmp`, a stale checkout, it does
+not matter:
+
+```bash
+cd /tmp
+simard self-deploy
+```
+
+```text
+simard self-deploy: deploying merged head a17be03… (binary 4 behind)…
+simard self-deploy: SUCCESS — new binary verified running (restarter=systemd, orphans reaped=0).
+```
+
+Under the hood the command resolves the canonical source repo, fetches origin,
+checks out `a17be03…` **detached**, and builds it into
+`~/.simard/self-deploy-target/` — never your cwd's `HEAD`. If the running binary
+is already at the merged head, it is a no-op:
+
+```text
+simard self-deploy: running binary is already at merged head — nothing to do.
+```
+
+## First run vs. warm runs (timing)
+
+| Run | What happens | Approx. time |
+| --- | --- | --- |
+| First ever | Clones the source into `~/.simard/self-deploy-src/` and does a cold compile into the empty warm dir. | ~10+ min (one-time) |
+| Subsequent | Reuses the existing clone (`git fetch` + checkout) and the warm `~/.simard/self-deploy-target/` for an **incremental** build. | ~2–3 min |
+
+The warm directories live under `~/.simard`, outside `/tmp`, so they survive
+reboots and disk-cleanup reapers and stay warm between deploys. Do not delete
+them to "clean up" — that re-imposes the one-time cold-build cost.
+
+## Use an explicit source repo
+
+To skip the managed clone (for example, an air-gapped host with a mirror, or to
+reuse an existing maintained checkout), point `SIMARD_SELF_DEPLOY_REPO` at an
+existing git work-tree:
+
+```bash
+SIMARD_SELF_DEPLOY_REPO=/opt/simard/src simard self-deploy
+```
+
+The path must be **absolute**, contain no `..`, not be a symlink, and be a real
+git work-tree. An invalid value aborts loudly with `SourceResolveFailed` — it
+never silently falls back to building your current directory.
+
+## Relocate the warm directories
+
+`SIMARD_STATE_ROOT` relocates the durable state root, including both
+`self-deploy-src/` and `self-deploy-target/`:
+
+```bash
+SIMARD_STATE_ROOT=/data/simard simard self-deploy
+# builds into /data/simard/self-deploy-target/, clones to /data/simard/self-deploy-src/
+```
+
+See [state-root-resolution](../reference/state-root-resolution.md).
+
+## Confirm the merged head is actually running
+
+After a deploy, verify the running binary advanced to the merged commit:
+
+```bash
+simard self-health --json | jq '.probes.version_advanced'
+```
+
+`"healthy": true` confirms the running binary's embedded SHA is **compatible**
+with the target (equal, or one a case-insensitive prefix of the other — after a
+normal deploy the two full SHAs are exactly equal), so the merged head is live.
+Re-running `--check` should now report `needs deploy: no`:
+
+```bash
+simard self-deploy --check | grep 'needs deploy'
+#   needs deploy   : no
+```
+
+For the full post-deploy verification checklist and rollback, see
+[verify and roll back a self-deploy](./verify-and-roll-back-a-self-deploy.md).
+
+## Troubleshooting
+
+| Symptom | Cause | Action |
+| --- | --- | --- |
+| `SourceResolveFailed` | Invalid `SIMARD_SELF_DEPLOY_REPO`, undiscoverable origin URL, or first-time clone failed. | Fix the path/URL; ensure the cwd or override points at a repo with an `origin` remote. The deploy aborted **before** touching the daemon. |
+| `FetchFailed` | `git fetch origin` failed and the target object is not cached locally. | Check network/credentials to origin. No daemon mutation occurred. |
+| `CheckoutFailed` | The merged SHA failed validation or the detached checkout failed (e.g. the object is missing after fetch). | Inspect the warm clone at `~/.simard/self-deploy-src/`; the deploy aborted pre-sequence. |
+| Build is slow every time | The warm target dir was deleted or relocated between runs. | Stop deleting `~/.simard/self-deploy-target/`; keep `SIMARD_STATE_ROOT` stable. |
+
+All three `*Failed` aborts happen during build-step 1, **before** any backup,
+drain, swap, or restart — the running daemon is untouched, so it is always safe
+to fix the cause and re-run.
+
+## See also
+
+- [Self-deploy source-prep reference](../reference/self-deploy-source-prep.md) — trait, preparer, warm dirs, errors, security.
+- [Verify and roll back a self-deploy](./verify-and-roll-back-a-self-deploy.md) — post-deploy verification and recovery.
+- [Reconcile-and-self-deploy concept](../concepts/reconcile-and-self-deploy.md) — the end-to-end sequence.
+- [Self-deploy API reference](../reference/self-deploy-api.md) — the broader self-deploy types and CLI.

--- a/docs/howto/run-self-deploy-from-any-directory.md
+++ b/docs/howto/run-self-deploy-from-any-directory.md
@@ -78,7 +78,10 @@ read-only: unlike the deploy it **never clones** and tolerates an offline fetch
 canonical checkout exists yet — e.g. before your first deploy — does it fall back
 to a best-effort report from the current directory; in that pre-clone state the
 deploy itself has nothing canonical to build from either, so there is nothing for
-the two to diverge over. See the design note in
+the two to diverge over. If you set `SIMARD_SELF_DEPLOY_REPO` to an invalid path,
+`--check` does not silently ignore it: it prints a warning to stderr (stdout and
+`--json` stay clean) before degrading to the cwd report, so the misconfiguration
+is visible even if you never run the deploy. See the design note in
 [self-deploy source-prep reference](../reference/self-deploy-source-prep.md#repo-resolution-precedence).
 Use `--json` for machine-readable `DeployDrift`:
 

--- a/docs/howto/verify-and-roll-back-a-self-deploy.md
+++ b/docs/howto/verify-and-roll-back-a-self-deploy.md
@@ -9,6 +9,8 @@ status: implemented
 related:
   - ../concepts/reconcile-and-self-deploy.md
   - ../reference/self-deploy-api.md
+  - ../reference/self-deploy-source-prep.md
+  - ../howto/run-self-deploy-from-any-directory.md
   - ../safe-self-update.md
   - ../howto/inspect-and-clean-engineer-worktrees.md
 ---
@@ -40,8 +42,10 @@ Ask the daemon directly whether merged work is still un-deployed:
 simard self-health --json | jq '.probes.version_advanced'
 ```
 
-`"healthy": true` with `running` equal to (or ahead of) `target` means the
-running binary carries the latest merged commit. A `false` means there is deploy
+`"healthy": true` means the running binary's embedded SHA is **compatible** with
+the target — equal, or one is a case-insensitive prefix of the other (the
+abbreviation tolerance in `commits_compatible`); after a normal self-deploy the
+two full SHAs are exactly equal. A `false` means there is deploy
 drift — a merged self-change is not yet running. The reconciliation detector
 reports the same drift to the brain each cycle (see
 [`DeployDrift`](../reference/self-deploy-api.md#deploydrift)).
@@ -122,5 +126,7 @@ closed.
 ## See also
 
 - [reconcile-and-self-deploy concept](../concepts/reconcile-and-self-deploy.md)
+- [How to run self-deploy from any directory](../howto/run-self-deploy-from-any-directory.md)
 - [Self-deploy API reference](../reference/self-deploy-api.md)
+- [Self-deploy source-prep reference](../reference/self-deploy-source-prep.md)
 - [Safe Self-Update](../safe-self-update.md)

--- a/docs/reference/self-deploy-api.md
+++ b/docs/reference/self-deploy-api.md
@@ -1,15 +1,17 @@
 ---
 title: Self-deploy API reference
 description: Reference for the reconciliation detector, build-from-source self-deploy orchestrator extensions, the DaemonRestarter abstraction, the dual protective backup, the engineer-orphan reaper, the simard self-health probe, and the UpdateConfig fields that govern self-deploy.
-last_updated: 2026-06-27
+last_updated: 2026-06-28
 review_schedule: as-needed
 owner: simard
 doc_type: reference
 status: implemented
 related:
   - ../concepts/reconcile-and-self-deploy.md
+  - ./self-deploy-source-prep.md
   - ../safe-self-update.md
   - ../howto/verify-and-roll-back-a-self-deploy.md
+  - ../howto/run-self-deploy-from-any-directory.md
   - ../reference/simard-cli.md
   - ../../src/self_deploy/mod.rs
   - ../../src/safe_update/mod.rs
@@ -199,15 +201,33 @@ the incoming daemon are never killed.
 pub struct SelfDeployOrchestrator {
     config: UpdateConfig,
     restarter: Box<dyn DaemonRestarter>,
-    // … memory handle, install path, target commit …
+    target_commit: String,
+    install_path: PathBuf,
+    /// `None` → legacy `build_canary` from the cwd checkout (unchanged).
+    /// `Some` → fetch + checkout the merged head, then build it into the warm
+    /// target dir. See self-deploy-source-prep.md.
+    build_source: Option<Box<dyn SelfDeploySourcePreparer>>,
 }
 
 impl SelfDeployOrchestrator {
+    /// Unchanged. `build_source = None` (legacy cwd build).
     pub fn new(
         config: UpdateConfig,
         restarter: Box<dyn DaemonRestarter>,
         target_commit: String,
         install_path: PathBuf,
+    ) -> Self;
+
+    /// Opt into the autonomous path: `build_candidate` (step 1) prepares the
+    /// merged head via the source preparer and builds it into the warm target
+    /// dir, so the deploy works from any cwd. Additive — see
+    /// self-deploy-source-prep.md.
+    pub fn with_source(
+        config: UpdateConfig,
+        restarter: Box<dyn DaemonRestarter>,
+        target_commit: String,
+        install_path: PathBuf,
+        source: Box<dyn SelfDeploySourcePreparer>,
     ) -> Self;
 
     /// Execute: build → gate → backup → drain → reap → swap → restart →
@@ -224,6 +244,15 @@ pub struct SelfDeployOutcome {
     pub restarter_kind: &'static str,
 }
 ```
+
+When wired with `with_source`, **step 1** (`build_candidate`) fetches and checks
+out the merged commit in a cwd-independent repo and builds it into a persistent
+warm target dir — so `simard self-deploy` works from any directory and is fast
+on repeat runs. The remaining steps and the rollback tail are unchanged; only
+the build *source* and *target dir* differ. See the
+[self-deploy source-prep reference](./self-deploy-source-prep.md) for the
+`SelfDeploySourcePreparer` trait, the warm-dir path helpers, and the security
+model.
 
 ## `simard self-health`
 
@@ -274,6 +303,19 @@ their defaults and meaning.
 | `health_probe_cycles` | `1` | OODA cycles observed for the "brains LLM-backed" probe. |
 | `memory_count_tolerance` | `0` | Allowed shortfall of `live_facts` below `baseline_facts` before the probe fails. |
 
+### Source & warm-dir environment
+
+The cwd-independent build source and the warm target directory are governed by
+environment, not `UpdateConfig`:
+
+| Variable | Effect | Default |
+| --- | --- | --- |
+| `SIMARD_SELF_DEPLOY_REPO` | Absolute path to an existing git work-tree to build from, bypassing the managed clone. | resolve via precedence (env → `~/.simard/self-deploy-src/` → clone) |
+| `SIMARD_STATE_ROOT` | Relocates `~/.simard/self-deploy-src/` and `~/.simard/self-deploy-target/`. | `~/.simard` |
+
+See the [self-deploy source-prep reference](./self-deploy-source-prep.md) for
+the path helpers, resolution precedence, and security model.
+
 ## Error variants
 
 Added to `SafeUpdateError`:
@@ -281,6 +323,9 @@ Added to `SafeUpdateError`:
 | Variant | Raised when |
 | --- | --- |
 | `BuildFailed { detail }` | The candidate `cargo build --release` failed. Install path untouched. |
+| `SourceResolveFailed { detail }` | (autonomous path) The cwd-independent source repo could not be resolved — invalid `SIMARD_SELF_DEPLOY_REPO`, undiscoverable origin, or a failed first-time clone. Pre-sequence abort; install path untouched. |
+| `FetchFailed { detail }` | (autonomous path) `git fetch origin` failed and the merged object is not cached locally. Pre-sequence abort. |
+| `CheckoutFailed { detail }` | (autonomous path) SHA validation or `git checkout --detach`/clean of the merged head failed. Pre-sequence abort. |
 | `GateFailed { gate, detail }` | A relaunch gate or the candidate `self-test` failed. |
 | `BackupFailed { which, detail }` | The memory **or** binary protective backup failed. No swap performed. |
 | `OrphanReapTimeout { pid }` | An engineer orphan survived SIGTERM + SIGKILL within the grace window. |
@@ -294,5 +339,7 @@ cycle report; none is swallowed.
 ## See also
 
 - [reconcile-and-self-deploy concept](../concepts/reconcile-and-self-deploy.md)
+- [Self-deploy source-prep reference](./self-deploy-source-prep.md)
+- [How to run self-deploy from any directory](../howto/run-self-deploy-from-any-directory.md)
 - [How to verify and roll back a self-deploy](../howto/verify-and-roll-back-a-self-deploy.md)
 - [Safe Self-Update](../safe-self-update.md)

--- a/docs/reference/self-deploy-source-prep.md
+++ b/docs/reference/self-deploy-source-prep.md
@@ -165,8 +165,10 @@ impl GitSourcePreparer {
     /// Resolve the canonical repo via the same precedence as `resolve_repo`
     /// **minus the clone step** (env override → persistent checkout → `None`).
     /// Read-only: it never clones, so it is safe for `self-deploy --check`
-    /// ("makes no changes"). `None` means no canonical source exists yet (the
-    /// caller falls back to a best-effort cwd report). Used by `report_drift`.
+    /// ("makes no changes"). `None` means no canonical source exists yet, *or*
+    /// a present override was rejected by validation — in which case the caller
+    /// falls back to a best-effort cwd report. A rejected override is **logged
+    /// loudly to stderr** (never silently degraded). Used by `report_drift`.
     pub fn resolve_existing_repo(&self) -> Option<PathBuf>;
 }
 
@@ -211,6 +213,12 @@ one.
 > yet (e.g. before the first deploy) — a state in which the deploy itself has
 > nothing canonical to build from, so there is nothing for the two to diverge
 > over.
+>
+> A *present-but-invalid* override (path traversal / symlink / non-work-tree)
+> is **not** silently swallowed: `resolve_existing_repo` warns loudly on stderr
+> (keeping stdout/`--json` clean) and then degrades to the cwd report, so an
+> operator who only ever runs `--check` still sees the misconfiguration the
+> effectful `resolve_repo` would have aborted on.
 
 ## `build_self_deploy_candidate`
 
@@ -410,6 +418,7 @@ and the fake-effects ordering) rather than replacing it.
 | fetch/checkout-then-build from an arbitrary cwd | The build is wired to the **merged SHA's checkout**, not cwd `HEAD`. |
 | resolver precedence | `SIMARD_SELF_DEPLOY_REPO` → persistent checkout → clone, in order. |
 | `--check` read-only resolution | `resolve_existing_repo()` returns the env override or persistent checkout cwd-independently, and **`None` (never a clone)** when no canonical source exists. |
+| `--check` invalid-override degradation | A present-but-invalid override resolves to `None` (cwd fallback) **without cloning or erroring**, and warns loudly on stderr — never silently swallowed. |
 | warm target dir | The build targets the persistent `self_deploy_target_dir()`, reused across runs — not a per-PID `temp_dir()`. |
 | loud failure | A failed fetch/clone/checkout aborts with the specific variant and never builds cwd `HEAD`. |
 | SHA validation | A non-40-hex or leading-`-` SHA is rejected before any git call. |

--- a/docs/reference/self-deploy-source-prep.md
+++ b/docs/reference/self-deploy-source-prep.md
@@ -249,6 +249,19 @@ The build still sets `CARGO_BUILD_JOBS` from `cargo_jobs::cargo_jobs()` and
 fails loud (`SimardError`/`SafeUpdateError::BuildFailed`) if the binary is
 missing after a "successful" build.
 
+> **Concurrency: serialized by the host-wide build lock.** `prepare_and_build`
+> (the orchestrator's step-1 composition) acquires the shared
+> [`BuildLock`](../reference/simard-cli.md) — `<state_root>/cargo_build.lock`,
+> the same lock the operator dashboard's `/api/build-lock` surfaces and can
+> force-release — for the whole resolve→checkout→build window, releasing it on
+> drop (RAII). Two concurrent self-deploys share the persistent source checkout
+> **and** the warm target dir; without serialization, one run's
+> `git checkout --detach <shaB>` could rewrite the working tree while another's
+> `cargo build` is still reading it, so it would compile one tree yet embed the
+> other's `SIMARD_GIT_HASH` and slip the wrong source past the `version_advanced`
+> gate (which only checks the *embedded* SHA). Failing to acquire the lock within
+> the timeout aborts **loudly** with `BuildFailed` rather than racing.
+
 > **Load-bearing build environment.** `build.rs` derives `SIMARD_GIT_HASH`
 > from a bare `git rev-parse HEAD` that resolves against the build script's
 > working directory (Cargo runs it in the manifest directory). For the embedded
@@ -399,9 +412,12 @@ on `~/.simard` top-level entries matching `is_corrupt_quarantine_name`, i.e. a
 `remove_old_corrupt_dbs` reads, but they are safe because **no reaper's name
 filter matches `self-deploy-*`** (they do not start with `simard-`/`amplihack-`,
 are not `bin`/`snapshots`, and carry no `.corrupt-` infix). A dedicated test
-asserts non-overlap against **all** of these reapers so the warm dir is never
-reaped out from under an incremental build even if a future reaper broadens its
-`~/.simard` scan.
+(`warm_target_dir_name_does_not_match_any_cleanup_reaper`) asserts non-overlap
+for **both** dirs by calling the **real** `is_corrupt_quarantine_name`
+predicate (the only reaper whose scan base — the `~/.simard` top level —
+actually contains them) and the replicated `/tmp` name filters, so the warm dir
+is never reaped out from under an incremental build even if a future change
+broadens the `~/.simard` reaper.
 
 ## Tests
 

--- a/docs/reference/self-deploy-source-prep.md
+++ b/docs/reference/self-deploy-source-prep.md
@@ -1,0 +1,435 @@
+---
+title: Self-deploy source preparation & warm target dir reference
+description: Reference for the cwd-independent self-deploy source preparer (SelfDeploySourcePreparer / GitSourcePreparer), the persistent warm build directories under the state root, the build_self_deploy_candidate builder, the SelfDeployOrchestrator::with_source constructor, the source-preparation UpdateConfig/env surface, the new SafeUpdateError variants, and the security model that fetches and checks out the merged head before building.
+last_updated: 2026-06-28
+review_schedule: as-needed
+owner: simard
+doc_type: reference
+status: implemented
+related:
+  - ./self-deploy-api.md
+  - ../concepts/reconcile-and-self-deploy.md
+  - ../howto/run-self-deploy-from-any-directory.md
+  - ../howto/verify-and-roll-back-a-self-deploy.md
+  - ./state-root-resolution.md
+  - ./simard-cli.md
+  - ../../src/self_deploy/source_prep.rs
+  - ../../src/self_deploy/orchestrator.rs
+  - ../../src/self_relaunch/canary.rs
+---
+
+# Self-deploy source preparation & warm target dir reference
+
+> **Status: implemented.** The `SelfDeploySourcePreparer` trait, the
+> `GitSourcePreparer` production implementation, the `self_deploy_src_dir()` /
+> `self_deploy_target_dir()` path helpers, `build_self_deploy_candidate()`, the
+> `SelfDeployOrchestrator::with_source` constructor, and the
+> `SourceResolveFailed` / `FetchFailed` / `CheckoutFailed` error variants live in
+> [`src/self_deploy/source_prep.rs`](https://github.com/rysweet/Simard/blob/main/src/self_deploy/source_prep.rs),
+> [`src/self_deploy/orchestrator.rs`](https://github.com/rysweet/Simard/blob/main/src/self_deploy/orchestrator.rs),
+> and [`src/self_relaunch/canary.rs`](https://github.com/rysweet/Simard/blob/main/src/self_relaunch/canary.rs).
+> They are **additive**: `SelfDeployOrchestrator::new`, `build_canary`, and
+> `RelaunchConfig::Default` keep their existing signatures and behaviour. The
+> preparer's resolve→fetch→detached-checkout path, the resolution precedence,
+> the SHA/transport validation, and the warm-dir helpers are covered by hermetic
+> offline tests (a local fixture-repo `origin`); only the full `cargo build` and
+> the live daemon restart are left to operator runs, not CI.
+
+This reference specifies the typed surface that makes `simard self-deploy`
+**autonomous** (it builds the *merged* commit, not the on-disk checkout's
+`HEAD`) and **fast** (it reuses a persistent, warm build directory instead of a
+cold per-run `temp_dir()`). It extends the
+[self-deploy API reference](./self-deploy-api.md); for the end-to-end sequence
+and rationale see [reconcile-and-self-deploy](../concepts/reconcile-and-self-deploy.md).
+
+## Why this exists
+
+Before this change, `simard self-deploy` had two gaps that prevented it from
+being a hands-free, fast deploy:
+
+1. **Build source was the on-disk checkout's `HEAD`, not the merged commit.**
+   `build_candidate` → `self_relaunch::build_canary` ran `cargo build` against
+   `manifest_dir = "."` — whatever the cwd checkout happened to be on. `--check`
+   correctly detected drift versus `origin/main`, but the build did **not**
+   `git fetch` + checkout the merged commit first, so it only deployed the new
+   code when the operator happened to run it from an already-up-to-date checkout.
+2. **Cold target dir → slow build.** `canary_target_dir` was a fresh
+   `temp_dir()/simard-canary-<PID>` each run, forcing a full from-scratch
+   compile (~10+ min) instead of an incremental build (~2–3 min).
+
+This reference closes both. The single guiding rule:
+
+> **`simard self-deploy`, run from any working directory, builds and deploys the
+> current merged head — never the cwd's `HEAD` — and reuses a warm, incremental
+> target directory.**
+
+## Contents
+
+- [Path helpers](#path-helpers)
+- [`SelfDeploySourcePreparer`](#selfdeploysourcepreparer)
+- [`GitSourcePreparer`](#gitsourcepreparer)
+- [Repo resolution precedence](#repo-resolution-precedence)
+- [`build_self_deploy_candidate`](#build_self_deploy_candidate)
+- [`SelfDeployOrchestrator::with_source`](#selfdeployorchestratorwith_source)
+- [Configuration & environment](#configuration-environment)
+- [Error variants](#error-variants)
+- [Security model](#security-model)
+- [Cleanup-reaper non-overlap](#cleanup-reaper-non-overlap)
+- [Tests](#tests)
+- [Source layout](#source-layout)
+
+## Path helpers
+
+Two helpers resolve the persistent self-deploy directories under the
+[resolved state root](./state-root-resolution.md). Both honour
+`SIMARD_STATE_ROOT`; neither creates the directory (the first writer — the
+preparer's clone or `build_self_deploy_candidate` — is responsible for
+`create_dir_all`).
+
+```rust
+/// Persistent clone of the Simard source used for self-deploy builds.
+/// `<state_root>/self-deploy-src/` (default `~/.simard/self-deploy-src/`).
+pub fn self_deploy_src_dir() -> PathBuf;
+
+/// Persistent, warm Cargo target directory reused across self-deploy builds.
+/// `<state_root>/self-deploy-target/` (default `~/.simard/self-deploy-target/`).
+pub fn self_deploy_target_dir() -> PathBuf;
+```
+
+| Helper | Default path | Relocated by |
+| --- | --- | --- |
+| `self_deploy_src_dir()` | `~/.simard/self-deploy-src/` | `SIMARD_STATE_ROOT`, then `SIMARD_SELF_DEPLOY_REPO` override (see [precedence](#repo-resolution-precedence)) |
+| `self_deploy_target_dir()` | `~/.simard/self-deploy-target/` | `SIMARD_STATE_ROOT` |
+
+Both live under `$HOME/.simard`, **outside** `temp_dir()`, so they survive
+reboots and `/tmp` reapers and stay warm between runs.
+
+## `SelfDeploySourcePreparer`
+
+The source-preparation step is abstracted behind a trait so the orchestrator
+sequence stays hermetically testable — a fake preparer drives the
+fetch/checkout-then-build wiring with no network and no real git.
+
+```rust
+/// Prepares a cwd-independent Simard source checkout at the merged head before
+/// the self-deploy build. Implementations MUST fail loud — never silently fall
+/// back to building the current working directory's `HEAD`.
+pub trait SelfDeploySourcePreparer: Send + Sync {
+    /// Make `target_commit` available on disk for building: resolve the
+    /// canonical repo (never cwd), `git fetch origin`, then
+    /// `git checkout --detach <target_commit>`. Returns the prepared work-tree
+    /// root whose `Cargo.toml` the build will target.
+    fn prepare(&self, target_commit: &str) -> Result<PathBuf, SafeUpdateError>;
+}
+```
+
+**Contract**
+
+- `prepare` is **cwd-independent**: it operates on the resolved canonical repo
+  (see "Repo resolution precedence"), never on `current_dir()`.
+- `prepare` is **loud on failure**: a resolve/fetch/checkout error returns a
+  specific [error variant](#error-variants) and aborts the deploy *before* any
+  daemon mutation. There is no cwd-`HEAD` fallback.
+- `prepare` leaves the work-tree on a **detached** checkout of `target_commit`
+  (no per-run branch accumulation), so `build.rs` embeds exactly that SHA.
+
+## `GitSourcePreparer`
+
+The production implementation. It runs `git` via the repo's hardened
+`env_clear()` + `PATH`/`HOME`-only pattern (mirroring `engineer_worktree`'s git
+helper), so a hostile ambient environment cannot hijack the build source.
+
+```rust
+pub struct GitSourcePreparer { /* optional explicit repo override … */ }
+
+impl GitSourcePreparer {
+    /// Production preparer: resolves the canonical repo via the documented
+    /// precedence and reuses the persistent warm directories.
+    pub fn new() -> Self;
+
+    /// Preparer rooted at an explicit repo (tests / non-default installs).
+    pub fn at(repo_dir: impl Into<PathBuf>) -> Self;
+
+    /// Resolve the canonical repo via the documented precedence (env override →
+    /// persistent checkout → clone-from-origin). Never returns cwd. Used by the
+    /// `self-deploy` CLI to point a `GitDeploySource` at the resolved repo.
+    pub fn resolve_repo(&self) -> Result<PathBuf, SafeUpdateError>;
+
+    /// `git fetch origin` in the resolved/owned repo so its remote-tracking
+    /// refs (and thus the merged head) are current. The first dedicated
+    /// git-fetch helper in `src/`; shared by `prepare` and the CLI (which
+    /// fetches before reading the merged head to deploy). Loud on failure
+    /// (`FetchFailed`).
+    pub fn fetch_origin(&self, repo: &Path) -> Result<(), SafeUpdateError>;
+}
+
+impl Default for GitSourcePreparer { /* == new() */ }
+impl SelfDeploySourcePreparer for GitSourcePreparer { /* … */ }
+```
+
+A fake (`RecordingPreparer`) records the requested target commit and returns a
+chosen outcome; the orchestrator/composition tests use it to assert the build is
+wired to the **prepared SHA**, not cwd.
+
+## Repo resolution precedence
+
+`resolve_repo` picks the canonical Simard source with this precedence — the
+first match wins:
+
+1. **`SIMARD_SELF_DEPLOY_REPO`** — an absolute path to an existing git
+   work-tree. Validated (no `..`, not a symlink, real work-tree); an invalid
+   value **aborts** with `SourceResolveFailed` — it never falls back to cwd.
+2. **Persistent checkout** at `self_deploy_src_dir()`
+   (`~/.simard/self-deploy-src/`) when it already exists as a git work-tree.
+3. **Clone-from-origin** into `self_deploy_src_dir()`. The origin URL is
+   discovered from the current checkout's `git remote get-url origin`, then
+   [transport-validated](#security-model) (https/ssh only) before `git clone`
+   runs. The clone relies on the ambient git credential helper for auth.
+
+The same resolved repo is used for **both** merged-SHA resolution and the build,
+so the SHA that is reported, fetched, checked out, and built is always the same
+one.
+
+> **`--check` resolution (as implemented).** The deploy path (`run_self_deploy`)
+> resolves the canonical repo via the precedence above, `fetch_origin`s it, and
+> reads `merged_head` from that resolved repo — so the SHA it builds is
+> cwd-independent. `simard self-deploy --check` (`report_drift`) deliberately
+> stays **cwd-rooted** (`GitDeploySource::new()`): it is read-only and performs
+> no fetch or clone, so its reported `merged head` reflects the **cwd checkout's**
+> view of `origin/main`. When run from an up-to-date checkout the two agree; from
+> a stale or unrelated cwd, `--check`'s `merged head` may lag the SHA a
+> subsequent (non-`--check`) deploy would fetch and build. Operators who need the
+> reported drift to match the deploy SHA exactly should run `--check` from an
+> up-to-date checkout (or `git fetch` first).
+
+## `build_self_deploy_candidate`
+
+A sibling of `build_canary` in `src/self_relaunch/canary.rs`. It builds the
+**prepared repo** into the **persistent warm target dir** and returns the built
+binary path. `build_canary` and `RelaunchConfig::Default` are unchanged.
+
+```rust
+/// Build the self-deploy candidate from a prepared, cwd-independent source
+/// checkout into a persistent warm target dir. Equivalent to `build_canary`
+/// but with `--manifest-path <repo>/Cargo.toml` and
+/// `--target-dir <target_dir>` (a warm, reused directory), so the build
+/// compiles the merged head and reuses incremental artifacts.
+pub fn build_self_deploy_candidate(
+    repo: &Path,        // prepared work-tree root (from SelfDeploySourcePreparer::prepare)
+    target_dir: &Path,  // persistent warm dir, e.g. self_deploy_target_dir()
+) -> SimardResult<PathBuf>;
+```
+
+| Aspect | `build_canary` (legacy, unchanged) | `build_self_deploy_candidate` (new) |
+| --- | --- | --- |
+| Manifest source | `RelaunchConfig.manifest_dir` (default `"."` = cwd) | the prepared `repo` (merged head) |
+| Target dir | `RelaunchConfig.canary_target_dir` (cold `temp_dir()/…PID`) | persistent warm `target_dir` |
+| Build command | `cargo build --release --target-dir <dir> --manifest-path <m>/Cargo.toml` | same flags, warm/merged inputs |
+| Built binary | `<target_dir>/release/simard` | `<target_dir>/release/simard` |
+
+The build still sets `CARGO_BUILD_JOBS` from `cargo_jobs::cargo_jobs()` and
+fails loud (`SimardError`/`SafeUpdateError::BuildFailed`) if the binary is
+missing after a "successful" build.
+
+> **Load-bearing build environment.** `build.rs` derives `SIMARD_GIT_HASH`
+> from a bare `git rev-parse HEAD` that resolves against the build script's
+> working directory (Cargo runs it in the manifest directory). For the embedded
+> SHA to equal `target_commit`, `build_self_deploy_candidate` must invoke
+> `cargo build` against the prepared repo **with a sanitized environment** —
+> `GIT_DIR` / `GIT_WORK_TREE` neutralized — so the build script cannot be
+> redirected to a different repo's `HEAD`. This is distinct from the preparer's
+> own hardened git helper (see [security model](#security-model)); the *build*
+> invocation needs the same protection because the post-build integrity gate
+> depends on it.
+
+## `SelfDeployOrchestrator::with_source`
+
+The orchestrator gains an **optional** source preparer. `new()` is preserved
+byte-for-byte (no preparer → legacy `build_canary` from cwd, for backward
+compatibility and the existing default tests). `with_source()` opts into the
+prepare-then-warm-build path.
+
+```rust
+pub struct SelfDeployOrchestrator {
+    config: UpdateConfig,
+    restarter: Box<dyn DaemonRestarter>,
+    target_commit: String,
+    install_path: PathBuf,
+    /// `None` → legacy cwd build via `build_canary` (unchanged behaviour).
+    /// `Some` → fetch/checkout the merged head, then warm-build it.
+    build_source: Option<Box<dyn SelfDeploySourcePreparer>>,
+}
+
+impl SelfDeployOrchestrator {
+    /// Unchanged. `build_source = None`.
+    pub fn new(
+        config: UpdateConfig,
+        restarter: Box<dyn DaemonRestarter>,
+        target_commit: String,
+        install_path: PathBuf,
+    ) -> Self;
+
+    /// New. Wires a source preparer so `build_candidate` prepares the merged
+    /// head and builds it into the warm target dir.
+    pub fn with_source(
+        config: UpdateConfig,
+        restarter: Box<dyn DaemonRestarter>,
+        target_commit: String,
+        install_path: PathBuf,
+        source: Box<dyn SelfDeploySourcePreparer>,
+    ) -> Self;
+
+    pub fn run(&self) -> Result<SelfDeployOutcome, SafeUpdateError>;
+}
+```
+
+> **Relation to `DeploySourceKind`.** `DeploySourceKind` (already in
+> `orchestrator.rs`, default `BuildFromSource`, alternative `ReleaseDownload`)
+> records the *intent* — build the candidate from merged `main` source vs.
+> download a tagged release. `build_source` is the *mechanism* that fulfils the
+> `BuildFromSource` intent **cwd-independently**: when present it fetches and
+> checks out the merged head before building. The two are orthogonal — this
+> feature adds `build_source` and does not change `DeploySourceKind` or the
+> untouched `ReleaseDownload` path.
+
+### Where it runs in the sequence
+
+`build_candidate` remains **step 1** of the load-bearing
+[`run_sequence`](./self-deploy-api.md#selfdeployorchestrator) — it runs before
+any backup, drain, swap, or restart. When `build_source` is `Some`, step 1
+becomes:
+
+```text
+1a. source.prepare(target_commit)   // resolve repo + git fetch origin + checkout --detach
+1b. build_self_deploy_candidate(prepared_repo, self_deploy_target_dir())
+```
+
+Because preparation is step 1, **a fetch/checkout/clone failure aborts loudly
+before the daemon is touched** — no dual backup, no drain, no swap has run. The
+rest of the sequence (gate → dual backup → drain → orphan-reap → swap → restart
+→ health-check → rollback) and the `rollback_then` tail are **unchanged**; only
+the build *source* and *target dir* differ.
+
+### Post-build integrity gate
+
+The existing post-deploy `version_advanced` probe compares the running binary's
+embedded `SIMARD_GIT_HASH` against `target_commit` via `commits_compatible`
+(healthy when the two are **equal, or one is a case-insensitive prefix of the
+other** — abbreviation tolerance; an empty or `"unknown"` running SHA never
+matches) and rolls back otherwise. It is **not** a git-ancestry check: a
+topologically newer running SHA that is not a prefix of `target_commit` would
+read as *incompatible*. Because `prepare` checks out exactly `target_commit` (a
+full 40-hex SHA) and the build runs in that prepared work-tree (see the
+load-bearing build-environment note above), `build.rs` embeds that exact SHA, so
+the running SHA equals `target_commit` and the probe stays self-consistent.
+
+## Configuration & environment
+
+| Variable | Purpose | Default |
+| --- | --- | --- |
+| `SIMARD_SELF_DEPLOY_REPO` | Absolute path to an existing git work-tree to use as the self-deploy source, bypassing the persistent clone. Validated; invalid → `SourceResolveFailed` (never cwd fallback). | unset → resolve via precedence |
+| `SIMARD_STATE_ROOT` | Relocates `self_deploy_src_dir()` **and** `self_deploy_target_dir()` (and all other durable state). See [state-root-resolution](./state-root-resolution.md). | `~/.simard` |
+
+No new `UpdateConfig` fields are required for the default behaviour; the warm
+directories are derived from the resolved state root. The existing self-deploy
+`UpdateConfig` fields ([self-deploy-api](./self-deploy-api.md#updateconfig-self-deploy-fields))
+keep their meaning.
+
+## Error variants
+
+Added to [`SafeUpdateError`](./self-deploy-api.md#error-variants). All three are
+raised during **step 1** (source preparation), i.e. *before* any daemon
+mutation — they are pure aborts, never trigger rollback, and leave the install
+path untouched.
+
+| Variant | Raised when |
+| --- | --- |
+| `SourceResolveFailed { detail }` | The canonical repo could not be resolved: invalid `SIMARD_SELF_DEPLOY_REPO` (`..`, symlink, or not a work-tree), an undiscoverable origin URL, or a failed first-time clone. |
+| `FetchFailed { detail }` | `git fetch origin` failed and the target object is not already cached locally — the merged head cannot be made available. |
+| `CheckoutFailed { detail }` | SHA validation failed (`^[0-9a-f]{40}$`) or `git checkout --detach <sha>` failed (e.g. the merged object is not present after fetch). |
+
+Every variant carries a `detail` string and is surfaced loudly in logs and the
+cycle report; none is swallowed and none falls back to a cwd build.
+
+## Security model
+
+The source preparer interpolates a SHA and a remote URL into `git` argv and
+writes to disk, so it applies defence-in-depth controls:
+
+| Control | Rule |
+| --- | --- |
+| **SHA validation** | The target SHA is validated against `^[0-9a-f]{40}$` before any git interpolation, blocking leading-`-` option injection into `checkout`/`fetch`. |
+| **Repo-path validation** | `SIMARD_SELF_DEPLOY_REPO` (and any explicit `at()` override) must be absolute, contain no `..`, not be a symlink, and resolve to a real git work-tree. Invalid → `SourceResolveFailed`, never a cwd fallback. |
+| **Transport allow-list** | Only `https://`, `ssh://`, and the scp-like `git@host:path` origins are accepted. Arbitrary-command / remote-helper transports (`ext::`, `fd::`, and any `scheme::address`) are rejected before `git clone` ever runs. |
+| **Hardened git execution** | Every preparer git call uses `env_clear()` and re-injects only `PATH` and `HOME`, blocking `GIT_DIR` / `GIT_WORK_TREE` / `LD_PRELOAD` hijack. Arguments are passed as an argv array — never via `sh -c`. |
+| **Build-environment sanitization** | `build_self_deploy_candidate` invokes `cargo build` with `GIT_DIR` / `GIT_WORK_TREE` / `GIT_INDEX_FILE` / `GIT_COMMON_DIR` / `GIT_OBJECT_DIRECTORY` removed, so `build.rs`'s `git rev-parse HEAD` resolves the **prepared** repo's `HEAD` (`== target_commit`) and the post-build `SIMARD_GIT_HASH` integrity gate stays self-consistent. (The rest of the env — `PATH`/`HOME`/`CARGO_*`/`RUSTUP_*` — is preserved so the build runs.) |
+| **Non-destructive checkout** | `prepare` leaves the work-tree on a plain `git checkout --detach <sha>` of the exact merged commit. The managed clone is only ever written by self-deploy, so it stays clean; a *dirty* user-provided `SIMARD_SELF_DEPLOY_REPO` fails loud (`CheckoutFailed`) rather than being force-wiped — the preparer never `reset --hard`/`clean`s a caller's tree. |
+| **Trust boundary** | The built SHA always originates from the trusted origin default branch (`merged_head` against the resolved canonical repo), never a cwd-controlled ref. `cargo build` still runs `build.rs`/proc-macros from source; that supply-chain surface is bounded by this SHA-trust + the post-build `SIMARD_GIT_HASH` integrity gate. |
+
+## Cleanup-reaper non-overlap
+
+The disk reaper in `src/cmd_cleanup/disk.rs` has several scans:
+`clean_simard_canaries` removes entries under a `temp_dir()` / `/tmp` base whose
+names start with `simard-`, `simard-canary`, `simard-e2e`, `amplihack-`,
+`amplihack_eval`, or `ia2-`; `clean_stale_cargo_targets` targets the fixed paths
+`/tmp/simard-canary` and `/tmp/cargo-target`; and three `~/.simard` scans
+(`rotate_simard_binary_backups` on `~/.simard/bin/simard.bak-*`,
+`trim_simard_snapshots` on `~/.simard/snapshots/`, and `remove_old_corrupt_dbs`
+on `~/.simard` top-level entries matching `is_corrupt_quarantine_name`, i.e. a
+`.corrupt-<ts>` infix). The warm directories are named `self-deploy-src` /
+`self-deploy-target` directly under `~/.simard`: they **are** within the base
+`remove_old_corrupt_dbs` reads, but they are safe because **no reaper's name
+filter matches `self-deploy-*`** (they do not start with `simard-`/`amplihack-`,
+are not `bin`/`snapshots`, and carry no `.corrupt-` infix). A dedicated test
+asserts non-overlap against **all** of these reapers so the warm dir is never
+reaped out from under an incremental build even if a future reaper broadens its
+`~/.simard` scan.
+
+## Tests
+
+All hermetic tests run offline using a **local fixture repo** (`git init` →
+commit → set a local `origin/main` ref; `git fetch` from a `file://`/path remote
+is offline) plus a fake preparer. `SIMARD_SELF_DEPLOY_REPO` injects the fixture.
+The source-prep cases live in a **new** `src/self_deploy/tests_source_prep.rs`;
+the sequence-wiring cases **augment the existing**
+`src/self_deploy/tests_orchestrator.rs` (which already covers `DeploySourceKind`
+and the fake-effects ordering) rather than replacing it.
+
+| Test (in `src/self_deploy/tests_source_prep.rs` / `tests_orchestrator.rs`) | Asserts |
+| --- | --- |
+| fetch/checkout-then-build from an arbitrary cwd | The build is wired to the **merged SHA's checkout**, not cwd `HEAD`. |
+| resolver precedence | `SIMARD_SELF_DEPLOY_REPO` → persistent checkout → clone, in order. |
+| warm target dir | The build targets the persistent `self_deploy_target_dir()`, reused across runs — not a per-PID `temp_dir()`. |
+| loud failure | A failed fetch/clone/checkout aborts with the specific variant and never builds cwd `HEAD`. |
+| SHA validation | A non-40-hex or leading-`-` SHA is rejected before any git call. |
+| reaper non-overlap | `self_deploy_src_dir()` / `self_deploy_target_dir()` fall under no cleanup scan base. |
+| backward compatibility | `RelaunchConfig::Default`, `build_canary`, and `SelfDeployOrchestrator::new` default tests still pass. |
+
+The genuinely effectful end-to-end path (real network fetch, real
+`cargo build`, real restart) stays under `#[ignore]`d operator tests, never in
+CI.
+
+## Source layout
+
+```
+src/self_deploy/
+    source_prep.rs            # NEW: SelfDeploySourcePreparer trait + GitSourcePreparer
+                              #      + self_deploy_src_dir()/self_deploy_target_dir()
+    orchestrator.rs           # EXISTING: adds SelfDeployOrchestrator::with_source +
+                              #   build_source field; DeploySourceKind unchanged
+    tests_source_prep.rs      # NEW: local-fixture-repo + fake-preparer tests
+    tests_orchestrator.rs     # EXISTING: augmented with prepare→warm-build wiring tests
+src/self_relaunch/
+    canary.rs                 # EXISTING: adds build_self_deploy_candidate (sibling of build_canary)
+src/safe_update/
+    errors.rs                 # EXISTING: adds SourceResolveFailed / FetchFailed / CheckoutFailed
+src/operator_cli/
+    self_deploy.rs            # EXISTING: wires GitSourcePreparer via with_source
+```
+
+## See also
+
+- [Self-deploy API reference](./self-deploy-api.md) — the core types, config, CLI, and health JSON.
+- [Reconcile-and-self-deploy concept](../concepts/reconcile-and-self-deploy.md) — the end-to-end sequence and rationale.
+- [How to run self-deploy from any directory](../howto/run-self-deploy-from-any-directory.md) — operator runbook.
+- [State-root resolution](./state-root-resolution.md) — how `SIMARD_STATE_ROOT` relocates the warm dirs.

--- a/docs/reference/self-deploy-source-prep.md
+++ b/docs/reference/self-deploy-source-prep.md
@@ -161,6 +161,13 @@ impl GitSourcePreparer {
     /// fetches before reading the merged head to deploy). Loud on failure
     /// (`FetchFailed`).
     pub fn fetch_origin(&self, repo: &Path) -> Result<(), SafeUpdateError>;
+
+    /// Resolve the canonical repo via the same precedence as `resolve_repo`
+    /// **minus the clone step** (env override → persistent checkout → `None`).
+    /// Read-only: it never clones, so it is safe for `self-deploy --check`
+    /// ("makes no changes"). `None` means no canonical source exists yet (the
+    /// caller falls back to a best-effort cwd report). Used by `report_drift`.
+    pub fn resolve_existing_repo(&self) -> Option<PathBuf>;
 }
 
 impl Default for GitSourcePreparer { /* == new() */ }
@@ -190,17 +197,20 @@ The same resolved repo is used for **both** merged-SHA resolution and the build,
 so the SHA that is reported, fetched, checked out, and built is always the same
 one.
 
-> **`--check` resolution (as implemented).** The deploy path (`run_self_deploy`)
-> resolves the canonical repo via the precedence above, `fetch_origin`s it, and
-> reads `merged_head` from that resolved repo — so the SHA it builds is
-> cwd-independent. `simard self-deploy --check` (`report_drift`) deliberately
-> stays **cwd-rooted** (`GitDeploySource::new()`): it is read-only and performs
-> no fetch or clone, so its reported `merged head` reflects the **cwd checkout's**
-> view of `origin/main`. When run from an up-to-date checkout the two agree; from
-> a stale or unrelated cwd, `--check`'s `merged head` may lag the SHA a
-> subsequent (non-`--check`) deploy would fetch and build. Operators who need the
-> reported drift to match the deploy SHA exactly should run `--check` from an
-> up-to-date checkout (or `git fetch` first).
+> **`--check` resolution (as implemented).** Both the deploy path
+> (`run_self_deploy`) and `simard self-deploy --check` (`report_drift`) resolve
+> the canonical repo **cwd-independently**, so the SHA `--check` reports matches
+> the SHA the deploy fetches, checks out, and builds. The deploy path uses
+> `resolve_repo` (env override → persistent checkout → clone) and `fetch_origin`s
+> it, failing loudly if the source cannot be made available. `--check` uses
+> `resolve_existing_repo` (env override → persistent checkout → `None`) and a
+> **best-effort** `fetch_origin`, because it must remain read-only: it never
+> clones (honoring "makes no changes") and tolerates an offline fetch (reporting
+> against local tracking refs) rather than erroring. It falls back to a
+> cwd-rooted `GitDeploySource::new()` only when **no** canonical source exists
+> yet (e.g. before the first deploy) — a state in which the deploy itself has
+> nothing canonical to build from, so there is nothing for the two to diverge
+> over.
 
 ## `build_self_deploy_candidate`
 
@@ -399,6 +409,7 @@ and the fake-effects ordering) rather than replacing it.
 | --- | --- |
 | fetch/checkout-then-build from an arbitrary cwd | The build is wired to the **merged SHA's checkout**, not cwd `HEAD`. |
 | resolver precedence | `SIMARD_SELF_DEPLOY_REPO` → persistent checkout → clone, in order. |
+| `--check` read-only resolution | `resolve_existing_repo()` returns the env override or persistent checkout cwd-independently, and **`None` (never a clone)** when no canonical source exists. |
 | warm target dir | The build targets the persistent `self_deploy_target_dir()`, reused across runs — not a per-PID `temp_dir()`. |
 | loud failure | A failed fetch/clone/checkout aborts with the specific variant and never builds cwd `HEAD`. |
 | SHA validation | A non-40-hex or leading-`-` SHA is rejected before any git call. |

--- a/docs/reference/simard-cli.md
+++ b/docs/reference/simard-cli.md
@@ -317,11 +317,20 @@ swap. Exit code is `0` when healthy, non-zero otherwise. See the
 Close the merged-but-not-running gap on demand (operator-only — the recipe never
 live-redeploys the daemon). With `--check` it reports deploy drift
 (running-vs-merged) and makes no changes; `--json` emits the `DeployDrift` JSON.
-Without `--check` it drives the full build-from-source self-deploy — build →
-gate → dual protective backup → drain → orphan-reap → atomic swap → systemd
-restart → health check, rolling back to the previous binary on a failed health
-check. See [reconcile-and-self-deploy](../concepts/reconcile-and-self-deploy.md)
-and [verify and roll back a self-deploy](../howto/verify-and-roll-back-a-self-deploy.md).
+Without `--check` it drives the full build-from-source self-deploy. It runs from
+**any working directory**: it first `git fetch`es and checks out the **merged
+head** (not the cwd's `HEAD`) in a cwd-independent source repo, then builds that
+commit into a persistent **warm** target dir (`~/.simard/self-deploy-target/`,
+incremental ~2–3 min) before the unchanged safety sequence — build → gate →
+dual protective backup → drain → orphan-reap → atomic swap → systemd restart →
+health check, rolling back to the previous binary on a failed health check. A
+source-resolution, fetch, or checkout failure aborts loudly *before* the daemon
+is touched (never a cwd-`HEAD` fallback). `SIMARD_SELF_DEPLOY_REPO` overrides the
+source repo. See
+[reconcile-and-self-deploy](../concepts/reconcile-and-self-deploy.md),
+[run self-deploy from any directory](../howto/run-self-deploy-from-any-directory.md),
+[self-deploy source-prep](self-deploy-source-prep.md), and
+[verify and roll back a self-deploy](../howto/verify-and-roll-back-a-self-deploy.md).
 
 ## Compatibility mapping
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,12 +88,14 @@ nav:
     - Route a Goal to its Target Repo: howto/route-a-goal-to-its-target-repo.md
     - Self-Maintain Dependency Pins: howto/self-maintain-dependency-pins.md
     - Verify and Roll Back a Self-Deploy: howto/verify-and-roll-back-a-self-deploy.md
+    - Run Self-Deploy from Any Directory: howto/run-self-deploy-from-any-directory.md
     - Diagnose a Rejected Goal Completion: howto/diagnose-a-rejected-goal-completion.md
     - Configure Brain Introspection: howto/configure-brain-introspection.md
     - Triage Stale Pull Requests: howto/triage-stale-pull-requests.md
   - Reference:
     - CLI Reference: reference/simard-cli.md
     - Self-Deploy API: reference/self-deploy-api.md
+    - Self-Deploy Source Prep & Warm Target Dir: reference/self-deploy-source-prep.md
     - Completion-Evidence Gate API: reference/completion-evidence-gate-api.md
     - Memory introspection CLI: reference/simard-memory-cli.md
     - Cognitive-memory provenance (DERIVES_FROM): reference/cognitive-memory-provenance.md

--- a/src/cmd_cleanup/disk.rs
+++ b/src/cmd_cleanup/disk.rs
@@ -351,7 +351,7 @@ pub const CORRUPT_DB_KEEP: usize = 5;
 /// ever risking the live store. Before this generalization the cleanup only
 /// matched the native `cognitive_memory.corrupt-` prefix, so post-de-fork
 /// library quarantines accumulated unbounded (issue #2307 fallout).
-fn is_corrupt_quarantine_name(name: &str) -> bool {
+pub(crate) fn is_corrupt_quarantine_name(name: &str) -> bool {
     (name.starts_with("cognitive.") || name.starts_with("cognitive_memory."))
         && name.contains(".corrupt-")
 }

--- a/src/cmd_cleanup/mod.rs
+++ b/src/cmd_cleanup/mod.rs
@@ -155,8 +155,8 @@ mod disk;
 pub(crate) use disk::{
     BINARY_BACKUPS_KEEP, CORRUPT_DB_KEEP, CORRUPT_DB_MAX_AGE_DAYS, SNAPSHOTS_KEEP,
     cap_home_cargo_targets, cap_simard_target_dirs, clean_simard_canaries,
-    clean_stale_cargo_targets, dir_size, remove_old_corrupt_dbs, rotate_simard_binary_backups,
-    trim_simard_snapshots,
+    clean_stale_cargo_targets, dir_size, is_corrupt_quarantine_name, remove_old_corrupt_dbs,
+    rotate_simard_binary_backups, trim_simard_snapshots,
 };
 
 #[cfg(test)]

--- a/src/operator_cli/self_deploy.rs
+++ b/src/operator_cli/self_deploy.rs
@@ -12,7 +12,7 @@
 //! `docs/howto/verify-and-roll-back-a-self-deploy.md`.
 
 use crate::self_deploy::{
-    DeploySource, GitDeploySource, ReconcileDetector, SelfDeployOrchestrator,
+    DeploySource, GitDeploySource, GitSourcePreparer, ReconcileDetector, SelfDeployOrchestrator,
     SystemdOrExecRestarter,
 };
 
@@ -103,9 +103,22 @@ fn report_drift(json: bool) -> Result<(), Box<dyn std::error::Error>> {
 /// Full operator self-deploy. Effectful: builds from source and restarts the
 /// daemon. Returns an error (loudly) on build/gate/backup/health failure; a
 /// failed health check rolls back to the previous binary.
+///
+/// Issue #2467: cwd-independent. The canonical source repo is resolved via
+/// `SIMARD_SELF_DEPLOY_REPO` → persistent `~/.simard/self-deploy-src` →
+/// clone-from-origin, then fetched so the merged head we read (and deploy) is
+/// the real one — regardless of the directory the operator runs from. The
+/// orchestrator then builds that fetched+checked-out merged commit into the
+/// warm target dir.
 fn run_self_deploy() -> Result<(), Box<dyn std::error::Error>> {
-    let source = GitDeploySource::new();
-    let drift = ReconcileDetector::new(GitDeploySource::new()).detect();
+    // Resolve the build source independent of the cwd, and fetch so
+    // `origin/main` (the merged head) is current before we read it.
+    let preparer = GitSourcePreparer::new();
+    let repo = preparer.resolve_repo()?;
+    preparer.fetch_origin(&repo)?;
+
+    let source = GitDeploySource::at(&repo);
+    let drift = ReconcileDetector::new(GitDeploySource::at(&repo)).detect();
     if !drift.needs_deploy {
         println!("simard self-deploy: running binary is already at merged head — nothing to do.");
         return Ok(());
@@ -120,11 +133,12 @@ fn run_self_deploy() -> Result<(), Box<dyn std::error::Error>> {
         drift.behind_commits
     );
 
-    let orchestrator = SelfDeployOrchestrator::new(
+    let orchestrator = SelfDeployOrchestrator::with_source(
         crate::safe_update::UpdateConfig::default(),
         Box::new(SystemdOrExecRestarter::new()),
         target_commit,
         install_path,
+        Box::new(GitSourcePreparer::new()),
     );
 
     match orchestrator.run() {

--- a/src/operator_cli/self_deploy.rs
+++ b/src/operator_cli/self_deploy.rs
@@ -74,16 +74,25 @@ pub(super) fn dispatch_self_deploy_command(
 /// merged head is current. Unlike [`run_self_deploy`] this stays strictly
 /// read-only: it never clones (honoring the documented "make no changes"
 /// contract) and tolerates a failed fetch (offline → report against the local
-/// tracking refs) instead of hard-erroring. When no canonical checkout exists
-/// yet (e.g. before the first deploy) it falls back to a best-effort report from
-/// the current directory.
+/// tracking refs) instead of hard-erroring — but the degraded path is **never
+/// silent**: a failed best-effort fetch prints a visible warning to stderr so an
+/// operator is never misled into trusting a stale report. When no canonical
+/// checkout exists yet (e.g. before the first deploy) it falls back to a
+/// best-effort report from the current directory.
 fn report_drift(json: bool) -> Result<(), Box<dyn std::error::Error>> {
     let preparer = GitSourcePreparer::new();
     let source = match preparer.resolve_existing_repo() {
         Some(repo) => {
-            // Best-effort refresh so the merged head is current; an offline
-            // check still reports against the local tracking refs.
-            let _ = preparer.fetch_origin(&repo);
+            // Best-effort refresh so the merged head is current. A failed fetch
+            // (e.g. offline) must NOT silently degrade: warn loudly on stderr —
+            // keeping stdout (incl. `--json`) clean — then report against the
+            // local tracking refs, which may be stale.
+            if let Err(e) = preparer.fetch_origin(&repo) {
+                eprintln!(
+                    "self-deploy --check: warning: could not fetch origin ({e}); \
+                     reporting against local tracking refs, which may be stale"
+                );
+            }
             GitDeploySource::at(repo)
         }
         // No canonical source yet — best-effort report from the cwd.

--- a/src/operator_cli/self_deploy.rs
+++ b/src/operator_cli/self_deploy.rs
@@ -67,9 +67,29 @@ pub(super) fn dispatch_self_deploy_command(
 }
 
 /// `--check`: compute and print deploy drift; never mutate anything.
+///
+/// Issue #2467 (review): resolve the source repo **cwd-independently** so
+/// `--check` reports the same drift an actual deploy would act on — even when
+/// run from an unrelated directory — and best-effort `git fetch` it so the
+/// merged head is current. Unlike [`run_self_deploy`] this stays strictly
+/// read-only: it never clones (honoring the documented "make no changes"
+/// contract) and tolerates a failed fetch (offline → report against the local
+/// tracking refs) instead of hard-erroring. When no canonical checkout exists
+/// yet (e.g. before the first deploy) it falls back to a best-effort report from
+/// the current directory.
 fn report_drift(json: bool) -> Result<(), Box<dyn std::error::Error>> {
-    let source = GitDeploySource::new();
-    let drift = ReconcileDetector::new(GitDeploySource::new()).detect();
+    let preparer = GitSourcePreparer::new();
+    let source = match preparer.resolve_existing_repo() {
+        Some(repo) => {
+            // Best-effort refresh so the merged head is current; an offline
+            // check still reports against the local tracking refs.
+            let _ = preparer.fetch_origin(&repo);
+            GitDeploySource::at(repo)
+        }
+        // No canonical source yet — best-effort report from the cwd.
+        None => GitDeploySource::new(),
+    };
+    let drift = ReconcileDetector::new(source.clone()).detect();
 
     if json {
         println!("{}", serde_json::to_string_pretty(&drift)?);

--- a/src/safe_update/errors.rs
+++ b/src/safe_update/errors.rs
@@ -108,6 +108,29 @@ pub enum SafeUpdateError {
     RollbackFailed {
         detail: String,
     },
+
+    // --- Self-deploy source-preparation variants (issue #2467) ---------------
+    // These all abort *before* the load-bearing safety sequence starts (no
+    // backup/drain/swap has run), and are fail-loud: self-deploy must never
+    // silently fall back to building the cwd HEAD when it cannot make the
+    // merged commit available.
+    /// The canonical self-deploy source repo could not be resolved (a bad
+    /// `SIMARD_SELF_DEPLOY_REPO`, a missing persistent checkout, or a failed
+    /// clone). Aborts before the safety sequence; never builds cwd HEAD.
+    SourceResolveFailed {
+        detail: String,
+    },
+    /// `git fetch` of the canonical source repo failed. Aborts before the
+    /// safety sequence (loud; never a cwd-HEAD fallback).
+    FetchFailed {
+        detail: String,
+    },
+    /// Checking out the target merged commit failed (object missing or git
+    /// error). Aborts before the safety sequence (loud; never a cwd-HEAD
+    /// fallback).
+    CheckoutFailed {
+        detail: String,
+    },
 }
 
 impl Display for SafeUpdateError {
@@ -228,6 +251,18 @@ impl Display for SafeUpdateError {
             Self::RollbackFailed { detail } => write!(
                 f,
                 "self-deploy: ROLLBACK FAILED — critical operator alert: {detail}"
+            ),
+            Self::SourceResolveFailed { detail } => write!(
+                f,
+                "self-deploy: cannot resolve the source repo to build from (no cwd-HEAD fallback): {detail}"
+            ),
+            Self::FetchFailed { detail } => write!(
+                f,
+                "self-deploy: git fetch of the source repo failed (no cwd-HEAD fallback): {detail}"
+            ),
+            Self::CheckoutFailed { detail } => write!(
+                f,
+                "self-deploy: checkout of the target merged commit failed (no cwd-HEAD fallback): {detail}"
             ),
         }
     }

--- a/src/self_deploy/drift.rs
+++ b/src/self_deploy/drift.rs
@@ -115,6 +115,7 @@ impl<S: DeploySource> ReconcileDetector<S> {
 /// (so it never produces a *false* drift); wiring running pins from build
 /// metadata is tracked as a follow-up. The detector's fail-safe contract means a
 /// missing/!git checkout simply reports "no drift".
+#[derive(Clone)]
 pub struct GitDeploySource {
     /// Source checkout to run `git` in.
     repo_dir: PathBuf,

--- a/src/self_deploy/mod.rs
+++ b/src/self_deploy/mod.rs
@@ -27,6 +27,7 @@ pub mod health;
 pub mod orchestrator;
 pub mod orphan;
 pub mod restart;
+pub mod source_prep;
 
 pub use backup::{ProtectiveBackup, take_protective_backup};
 pub use drift::{
@@ -41,6 +42,10 @@ pub use orphan::{
     OrphanEngineer, find_engineer_orphans, match_engineer_orphan, reap_engineer_orphans,
 };
 pub use restart::{DaemonRestarter, FakeRestarter, SystemdOrExecRestarter};
+pub use source_prep::{
+    GitSourcePreparer, SelfDeploySourcePreparer, self_deploy_src_dir, self_deploy_target_dir,
+    validate_full_sha, validate_origin_transport,
+};
 
 #[cfg(test)]
 mod tests_drift;
@@ -52,3 +57,5 @@ mod tests_orchestrator;
 mod tests_orphan;
 #[cfg(test)]
 mod tests_restart;
+#[cfg(test)]
+mod tests_source_prep;

--- a/src/self_deploy/orchestrator.rs
+++ b/src/self_deploy/orchestrator.rs
@@ -18,6 +18,7 @@ use crate::safe_update::{SafeUpdateError, UpdateConfig};
 use super::backup::ProtectiveBackup;
 use super::health::SelfHealthReport;
 use super::restart::DaemonRestarter;
+use super::source_prep::SelfDeploySourcePreparer;
 
 /// Whether the candidate binary is built from merged source or downloaded as a
 /// tagged release. Self-deploy of a merged-but-unreleased `main` commit uses
@@ -167,6 +168,12 @@ pub struct SelfDeployOrchestrator {
     restarter: Box<dyn DaemonRestarter>,
     target_commit: String,
     install_path: PathBuf,
+    /// Optional cwd-independent source preparer (issue #2467). When `None`
+    /// (the default via [`SelfDeployOrchestrator::new`]) the legacy build path
+    /// is used; when `Some` (via [`SelfDeployOrchestrator::with_source`]) the
+    /// candidate is built from the fetched+checked-out merged commit into the
+    /// persistent warm target dir. Additive — preserves the existing contract.
+    build_source: Option<Box<dyn SelfDeploySourcePreparer>>,
 }
 
 impl SelfDeployOrchestrator {
@@ -181,7 +188,37 @@ impl SelfDeployOrchestrator {
             restarter,
             target_commit,
             install_path,
+            build_source: None,
         }
+    }
+
+    /// Like [`new`](Self::new) but injects a cwd-independent
+    /// [`SelfDeploySourcePreparer`] (issue #2467) so the candidate is built
+    /// from the fetched+checked-out merged commit — not the cwd HEAD — into the
+    /// persistent warm target dir. Additive: `new` is unchanged and the default
+    /// (no-source) build path is byte-for-byte preserved.
+    pub fn with_source(
+        config: UpdateConfig,
+        restarter: Box<dyn DaemonRestarter>,
+        target_commit: String,
+        install_path: PathBuf,
+        source: Box<dyn SelfDeploySourcePreparer>,
+    ) -> Self {
+        Self {
+            config,
+            restarter,
+            target_commit,
+            install_path,
+            build_source: Some(source),
+        }
+    }
+
+    /// The injected source preparer, if any. `None` for the legacy path.
+    // Used by the orchestrator tests to assert the additive `with_source` seam;
+    // `run()` consumes the field directly, so this accessor is test-only.
+    #[allow(dead_code)]
+    pub(crate) fn build_source(&self) -> Option<&dyn SelfDeploySourcePreparer> {
+        self.build_source.as_deref()
     }
 
     /// Execute: build → gate → backup → drain → reap → swap → restart →
@@ -195,6 +232,7 @@ impl SelfDeployOrchestrator {
             restarter: self.restarter.as_ref(),
             target_commit: &self.target_commit,
             install_path: &self.install_path,
+            build_source: self.build_source.as_deref(),
         };
         run_sequence(&effects)
     }
@@ -208,6 +246,10 @@ struct ProdDeployEffects<'a> {
     restarter: &'a dyn DaemonRestarter,
     target_commit: &'a str,
     install_path: &'a Path,
+    /// Cwd-independent source preparer (issue #2467). `Some` => build the
+    /// fetched+checked-out merged commit into the persistent warm target dir;
+    /// `None` => the legacy `build_canary` path (cwd checkout, cold temp dir).
+    build_source: Option<&'a dyn SelfDeploySourcePreparer>,
 }
 
 impl ProdDeployEffects<'_> {
@@ -226,6 +268,14 @@ impl ProdDeployEffects<'_> {
 
 impl DeployEffects for ProdDeployEffects<'_> {
     fn build_candidate(&self) -> Result<PathBuf, SafeUpdateError> {
+        // Issue #2467: with an injected source preparer, build the
+        // fetched+checked-out merged commit (the SHA `--check` reports) into the
+        // persistent warm target dir — cwd-independent and incremental. The
+        // legacy path (no source) is byte-for-byte preserved.
+        if let Some(source) = self.build_source {
+            let warm = super::source_prep::self_deploy_target_dir();
+            return super::source_prep::prepare_and_build(source, self.target_commit, &warm);
+        }
         crate::self_relaunch::build_canary(&crate::self_relaunch::RelaunchConfig::default())
             .map_err(|e| SafeUpdateError::BuildFailed {
                 detail: e.to_string(),

--- a/src/self_deploy/source_prep.rs
+++ b/src/self_deploy/source_prep.rs
@@ -1,0 +1,403 @@
+//! Cwd-independent self-deploy source preparation (issue #2467).
+//!
+//! `simard self-deploy` must build and deploy the **merged** `origin/main`
+//! commit — the SHA `--check` reports — from *any* working directory, not
+//! whatever the cwd checkout happens to be on. This module owns:
+//!
+//! 1. **Canonical repo resolution** (cwd-independent), with precedence
+//!    `SIMARD_SELF_DEPLOY_REPO` → a persistent checkout at
+//!    [`self_deploy_src_dir`] → clone-from-origin. The build source is *never*
+//!    the cwd.
+//! 2. **Fetch + checkout** of the target merged commit before building
+//!    ([`SelfDeploySourcePreparer::prepare`]): `git fetch origin`, validate the
+//!    target is a full 40-hex SHA, then `git checkout --detach <sha>` so the
+//!    embedded `SIMARD_GIT_HASH` equals the deployed commit.
+//! 3. **Warm target dir** ([`self_deploy_target_dir`]): a persistent cargo
+//!    target under the state root so self-deploys are incremental, not cold.
+//!
+//! Failure is **loud**: if the merged commit cannot be made available, the
+//! preparer returns an error ([`SafeUpdateError::SourceResolveFailed`] /
+//! [`FetchFailed`](SafeUpdateError::FetchFailed) /
+//! [`CheckoutFailed`](SafeUpdateError::CheckoutFailed)) and the caller aborts
+//! *before* the load-bearing safety sequence — it never silently falls back to
+//! building the cwd HEAD.
+//!
+//! All git is run via the `env_clear()` + selective `PATH`/`HOME` re-injection
+//! discipline (mirroring [`crate::engineer_worktree`]) so a hostile ambient env
+//! cannot hijack the build source.
+//!
+//! See `docs/reference/self-deploy-source-prep.md` and
+//! `docs/howto/run-self-deploy-from-any-directory.md`.
+
+use std::path::{Component, Path, PathBuf};
+use std::process::Command;
+
+use crate::safe_update::SafeUpdateError;
+use crate::state_root::simard_state_root;
+
+/// Environment variable that pins the canonical self-deploy source repo,
+/// overriding the persistent-checkout / clone-from-origin resolution.
+const SELF_DEPLOY_REPO_ENV: &str = "SIMARD_SELF_DEPLOY_REPO";
+
+/// Subdirectory name (under the resolved state root) for the persistent,
+/// cwd-independent self-deploy source checkout.
+pub const SELF_DEPLOY_SRC_DIRNAME: &str = "self-deploy-src";
+
+/// Subdirectory name (under the resolved state root) for the persistent **warm**
+/// cargo target dir reused across self-deploys.
+pub const SELF_DEPLOY_TARGET_DIRNAME: &str = "self-deploy-target";
+
+/// Persistent self-deploy **source checkout** directory.
+///
+/// Resolves to `<simard_state_root()>/self-deploy-src` (honoring
+/// `SIMARD_STATE_ROOT`). Stable across runs and across cwds — never under
+/// `temp_dir()` and never keyed by PID — so the canonical checkout survives and
+/// the warm target stays warm.
+pub fn self_deploy_src_dir() -> PathBuf {
+    simard_state_root().join(SELF_DEPLOY_SRC_DIRNAME)
+}
+
+/// Persistent **warm** cargo target directory for self-deploy builds.
+///
+/// Resolves to `<simard_state_root()>/self-deploy-target` (honoring
+/// `SIMARD_STATE_ROOT`). Persistent and reused across runs so `cargo build` is
+/// incremental (~2–3 min) instead of a cold from-scratch compile (~10+ min).
+/// Deliberately outside `temp_dir()` and not PID-keyed, and named so it does
+/// **not** match any `cmd_cleanup` disk reaper pattern (which scan
+/// `/tmp/simard-*` and `/tmp/simard-*-target`).
+pub fn self_deploy_target_dir() -> PathBuf {
+    simard_state_root().join(SELF_DEPLOY_TARGET_DIRNAME)
+}
+
+/// Validate that `sha` is a full 40-character lowercase hex Git object name.
+///
+/// This is a security control (SEC-I2): the SHA is interpolated into `git`
+/// argument vectors, so a value with a leading `-` could be parsed as an option
+/// (e.g. `--upload-pack=…`). Rejects anything that is not exactly
+/// `^[0-9a-f]{40}$` — wrong length, uppercase, non-hex, a leading `-`, empty,
+/// or whitespace-bearing.
+pub fn validate_full_sha(sha: &str) -> Result<(), SafeUpdateError> {
+    let is_full_hex =
+        sha.len() == 40 && sha.bytes().all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f'));
+    if is_full_hex {
+        Ok(())
+    } else {
+        Err(SafeUpdateError::CheckoutFailed {
+            detail: format!(
+                "refusing target commit {sha:?}: not a full 40-char lowercase hex SHA \
+                 (guards against argv option injection into git)"
+            ),
+        })
+    }
+}
+
+/// Validate that an origin remote URL uses an allowed transport before it is
+/// ever used to clone (SEC-I3).
+///
+/// Allows only `https://`, `ssh://`, and the scp-like `user@host:path` SSH
+/// form. Rejects arbitrary-command transports (`ext::…`, `fd::…`) and any
+/// remote-helper transport that can execute a command, which would let a
+/// poisoned remote URL run code during a clone/fetch.
+pub fn validate_origin_transport(url: &str) -> Result<(), SafeUpdateError> {
+    let trimmed = url.trim();
+    let allowed =
+        trimmed.starts_with("https://") || trimmed.starts_with("ssh://") || is_scp_like(trimmed);
+    if allowed {
+        Ok(())
+    } else {
+        Err(SafeUpdateError::SourceResolveFailed {
+            detail: format!(
+                "refusing origin URL {url:?}: only https:// and ssh:// transports are permitted \
+                 (arbitrary-command transports like ext::/fd:: can run code on clone)"
+            ),
+        })
+    }
+}
+
+/// Whether `url` is an scp-like SSH remote (`user@host:path`) and *not* a
+/// remote-helper transport. Rejects any `scheme::address` form (e.g. `ext::`,
+/// `fd::`) — a `::` is the giveaway of a remote helper that can run a command.
+fn is_scp_like(url: &str) -> bool {
+    if url.contains("://") || url.contains("::") {
+        return false;
+    }
+    match (url.find('@'), url.find(':')) {
+        (Some(at), Some(colon)) => at > 0 && at < colon && colon + 1 < url.len(),
+        _ => false,
+    }
+}
+
+/// Seam that makes the Simard source available at a target merged commit,
+/// independent of the current working directory.
+///
+/// Production wires this to [`GitSourcePreparer`] (real `git`); tests inject a
+/// fake to drive the orchestrator and the [`prepare_and_build`] composition
+/// hermetically.
+pub trait SelfDeploySourcePreparer: Send + Sync {
+    /// Resolve the canonical source repo, `git fetch origin`, and
+    /// `git checkout --detach <target_commit>`, returning the prepared repo
+    /// directory (whose HEAD is now `target_commit`).
+    ///
+    /// **Loud-fail contract:** on any failure this returns an `Err` and must
+    /// **never** return a path to the cwd checkout as a fallback — building the
+    /// cwd HEAD instead of the merged commit is exactly the bug #2467 fixes.
+    fn prepare(&self, target_commit: &str) -> Result<PathBuf, SafeUpdateError>;
+}
+
+/// Production [`SelfDeploySourcePreparer`] backed by real `git`.
+///
+/// Resolves the canonical repo with precedence `SIMARD_SELF_DEPLOY_REPO` →
+/// persistent [`self_deploy_src_dir`] → clone-from-origin, then fetches and
+/// checks out the target commit detached.
+#[derive(Debug, Default)]
+pub struct GitSourcePreparer {
+    /// Explicit repo override (tests / non-standard installs). When set it wins
+    /// over the env/persistent/clone precedence, mirroring
+    /// [`crate::self_deploy::GitDeploySource::at`].
+    repo_override: Option<PathBuf>,
+}
+
+impl GitSourcePreparer {
+    /// A preparer using the documented `SIMARD_SELF_DEPLOY_REPO` → persistent →
+    /// clone precedence.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// A preparer rooted at an explicit checkout, bypassing env/clone
+    /// precedence. Mirrors [`crate::self_deploy::GitDeploySource::at`].
+    pub fn at(repo_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            repo_override: Some(repo_dir.into()),
+        }
+    }
+
+    /// Resolve (and if necessary validate) the canonical source repo directory.
+    ///
+    /// Returns [`SafeUpdateError::SourceResolveFailed`] on a bad
+    /// `SIMARD_SELF_DEPLOY_REPO` (path traversal, missing, or not a git work
+    /// tree) or when no repo can be made available — never the cwd.
+    pub fn resolve_repo(&self) -> Result<PathBuf, SafeUpdateError> {
+        // 1) Explicit override (tests / non-standard installs) wins outright.
+        if let Some(repo) = &self.repo_override {
+            return validate_repo_path(repo);
+        }
+        // 2) `SIMARD_SELF_DEPLOY_REPO` env override.
+        if let Some(env_repo) = env_repo_override() {
+            return validate_repo_path(&env_repo);
+        }
+        // 3) Persistent canonical checkout under the state root, if present.
+        let persistent = self_deploy_src_dir();
+        if is_git_work_tree(&persistent) {
+            return Ok(persistent);
+        }
+        // 4) Clone from the origin discovered via the current checkout. This is
+        //    the only branch that consults the cwd, and only to read its
+        //    `origin` URL — the build still happens in the cloned `persistent`
+        //    checkout, never the cwd.
+        clone_from_origin(&persistent)
+    }
+
+    /// `git fetch origin` in the resolved/owned source repo so its
+    /// remote-tracking refs (and thus the merged head) are current.
+    ///
+    /// The first dedicated git-fetch helper in `src/` (issue #2467). Shared by
+    /// [`prepare`](SelfDeploySourcePreparer::prepare) and the `self-deploy` CLI
+    /// (which fetches before reading the merged head to deploy). Loud on
+    /// failure: returns [`SafeUpdateError::FetchFailed`], never a silent
+    /// fallback.
+    pub fn fetch_origin(&self, repo: &Path) -> Result<(), SafeUpdateError> {
+        git_capture(repo, &["fetch", "origin"])
+            .map(|_| ())
+            .map_err(|detail| SafeUpdateError::FetchFailed { detail })
+    }
+}
+
+impl SelfDeploySourcePreparer for GitSourcePreparer {
+    fn prepare(&self, target_commit: &str) -> Result<PathBuf, SafeUpdateError> {
+        // Validate the SHA BEFORE any git call so an option-injection attempt
+        // (leading `-`) can never reach a git argv (SEC-I2).
+        validate_full_sha(target_commit)?;
+
+        // Resolve the canonical repo (never the cwd), fetch so the object is
+        // present, then check out the exact merged commit detached so the
+        // embedded `SIMARD_GIT_HASH` equals the deployed commit.
+        let repo = self.resolve_repo()?;
+        self.fetch_origin(&repo)?;
+        git_capture(&repo, &["checkout", "--detach", target_commit])
+            .map(|_| ())
+            .map_err(|detail| SafeUpdateError::CheckoutFailed { detail })?;
+        Ok(repo)
+    }
+}
+
+/// Validate a candidate source-repo path: reject `..` traversal, a relative
+/// path, a symlink, and any path that is not a git work tree (SEC). Never
+/// resolves to the cwd.
+fn validate_repo_path(repo: &Path) -> Result<PathBuf, SafeUpdateError> {
+    if repo.components().any(|c| c == Component::ParentDir) {
+        return Err(SafeUpdateError::SourceResolveFailed {
+            detail: format!(
+                "self-deploy source repo path must not contain '..': {}",
+                repo.display()
+            ),
+        });
+    }
+    if !repo.is_absolute() {
+        return Err(SafeUpdateError::SourceResolveFailed {
+            detail: format!(
+                "self-deploy source repo path must be absolute: {}",
+                repo.display()
+            ),
+        });
+    }
+    if repo
+        .symlink_metadata()
+        .map(|m| m.file_type().is_symlink())
+        .unwrap_or(false)
+    {
+        return Err(SafeUpdateError::SourceResolveFailed {
+            detail: format!(
+                "self-deploy source repo path must not be a symlink: {}",
+                repo.display()
+            ),
+        });
+    }
+    if !is_git_work_tree(repo) {
+        return Err(SafeUpdateError::SourceResolveFailed {
+            detail: format!(
+                "self-deploy source repo is not a git work tree: {}",
+                repo.display()
+            ),
+        });
+    }
+    Ok(repo.to_path_buf())
+}
+
+/// `SIMARD_SELF_DEPLOY_REPO`, as a path, when set and non-empty.
+fn env_repo_override() -> Option<PathBuf> {
+    let raw = std::env::var_os(SELF_DEPLOY_REPO_ENV)?;
+    let s = raw.to_string_lossy();
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(PathBuf::from(trimmed))
+    }
+}
+
+/// Whether `repo` is the root of a git work tree.
+fn is_git_work_tree(repo: &Path) -> bool {
+    if !repo.is_dir() {
+        return false;
+    }
+    matches!(
+        git_capture(repo, &["rev-parse", "--is-inside-work-tree"]),
+        Ok(out) if out.trim() == "true"
+    )
+}
+
+/// Clone the canonical source from the cwd's `origin` URL into `dest`.
+///
+/// Only consulted when no override and no persistent checkout exist. The origin
+/// URL is transport-validated (SEC-I3) before it is ever handed to `git clone`.
+fn clone_from_origin(dest: &Path) -> Result<PathBuf, SafeUpdateError> {
+    let origin_url = discover_origin_url()?;
+    validate_origin_transport(&origin_url)?;
+
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| SafeUpdateError::SourceResolveFailed {
+            detail: format!("cannot create state dir {}: {e}", parent.display()),
+        })?;
+    }
+
+    let mut cmd = Command::new("git");
+    cmd.arg("clone").arg("--quiet").arg(&origin_url).arg(dest);
+    scrub_git_env(&mut cmd);
+    let out = cmd
+        .output()
+        .map_err(|e| SafeUpdateError::SourceResolveFailed {
+            detail: format!("cannot spawn git clone: {e}"),
+        })?;
+    if !out.status.success() {
+        return Err(SafeUpdateError::SourceResolveFailed {
+            detail: format!(
+                "git clone of {origin_url:?} into {} failed: {}",
+                dest.display(),
+                String::from_utf8_lossy(&out.stderr).trim()
+            ),
+        });
+    }
+    Ok(dest.to_path_buf())
+}
+
+/// Discover the `origin` remote URL of the current checkout (read-only).
+fn discover_origin_url() -> Result<String, SafeUpdateError> {
+    let cwd = std::env::current_dir().map_err(|e| SafeUpdateError::SourceResolveFailed {
+        detail: format!("cannot resolve cwd to discover the origin URL: {e}"),
+    })?;
+    git_capture(&cwd, &["remote", "get-url", "origin"])
+        .map(|s| s.trim().to_string())
+        .map_err(|detail| SafeUpdateError::SourceResolveFailed {
+            detail: format!(
+                "cannot discover an origin URL from {}: {detail}",
+                cwd.display()
+            ),
+        })
+}
+
+/// `env_clear()` + selective `PATH`/`HOME` re-injection for every `git`
+/// subprocess, mirroring [`crate::engineer_worktree`]: a hostile ambient env
+/// (`GIT_DIR`, `GIT_WORK_TREE`, `LD_PRELOAD`, …) cannot hijack the build source.
+fn scrub_git_env(cmd: &mut Command) {
+    cmd.env_clear();
+    if let Ok(path) = std::env::var("PATH") {
+        cmd.env("PATH", path);
+    }
+    if let Ok(home) = std::env::var("HOME") {
+        cmd.env("HOME", home);
+    }
+}
+
+/// Run a `git` subcommand in `repo` (scrubbed env) and return stdout, or an
+/// `Err(String)` describing the failure for the caller to wrap in the right
+/// loud [`SafeUpdateError`] variant.
+fn git_capture(repo: &Path, args: &[&str]) -> Result<String, String> {
+    let mut cmd = Command::new("git");
+    cmd.args(args).current_dir(repo);
+    scrub_git_env(&mut cmd);
+    let out = cmd
+        .output()
+        .map_err(|e| format!("spawn git {args:?} in {}: {e}", repo.display()))?;
+    if !out.status.success() {
+        return Err(format!(
+            "git {:?} failed in {}: {}",
+            args,
+            repo.display(),
+            String::from_utf8_lossy(&out.stderr).trim()
+        ));
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+}
+
+/// Compose source preparation with the warm-target build: the exact step the
+/// self-deploy orchestrator's `build_candidate` performs as step 1 of the
+/// load-bearing sequence (issue #2467).
+///
+/// Prepares the source at `target_commit` (fetch + detached checkout of the
+/// merged head) and then builds it into the persistent warm `target_dir`. A
+/// preparation failure propagates **before** any build is attempted — and a
+/// fortiori before any daemon mutation — so a missing/unreachable merged commit
+/// can never deploy the cwd HEAD.
+pub(crate) fn prepare_and_build(
+    source: &dyn SelfDeploySourcePreparer,
+    target_commit: &str,
+    target_dir: &Path,
+) -> Result<PathBuf, SafeUpdateError> {
+    let repo = source.prepare(target_commit)?;
+    crate::self_relaunch::build_self_deploy_candidate(&repo, target_dir).map_err(|e| {
+        SafeUpdateError::BuildFailed {
+            detail: e.to_string(),
+        }
+    })
+}

--- a/src/self_deploy/source_prep.rs
+++ b/src/self_deploy/source_prep.rs
@@ -9,9 +9,12 @@
 //!    [`self_deploy_src_dir`] → clone-from-origin. The build source is *never*
 //!    the cwd.
 //! 2. **Fetch + checkout** of the target merged commit before building
-//!    ([`SelfDeploySourcePreparer::prepare`]): `git fetch origin`, validate the
-//!    target is a full 40-hex SHA, then `git checkout --detach <sha>` so the
-//!    embedded `SIMARD_GIT_HASH` equals the deployed commit.
+//!    ([`SelfDeploySourcePreparer::prepare`]): validate the target is a full
+//!    40-hex SHA, `git fetch origin` **only when the commit is not already
+//!    present locally** (the `self-deploy` CLI fetches the same repo to read the
+//!    merged head, so the object is usually already in the object store — the
+//!    second network round-trip is skipped), then `git checkout --detach <sha>`
+//!    so the embedded `SIMARD_GIT_HASH` equals the deployed commit.
 //! 3. **Warm target dir** ([`self_deploy_target_dir`]): a persistent cargo
 //!    target under the state root so self-deploys are incremental, not cold.
 //!
@@ -134,7 +137,8 @@ fn is_scp_like(url: &str) -> bool {
 /// fake to drive the orchestrator and the [`prepare_and_build`] composition
 /// hermetically.
 pub trait SelfDeploySourcePreparer: Send + Sync {
-    /// Resolve the canonical source repo, `git fetch origin`, and
+    /// Resolve the canonical source repo, ensure `target_commit` is present
+    /// locally (fetching from `origin` **only when the object is missing**), and
     /// `git checkout --detach <target_commit>`, returning the prepared repo
     /// directory (whose HEAD is now `target_commit`).
     ///
@@ -201,11 +205,12 @@ impl GitSourcePreparer {
     /// `git fetch origin` in the resolved/owned source repo so its
     /// remote-tracking refs (and thus the merged head) are current.
     ///
-    /// The first dedicated git-fetch helper in `src/` (issue #2467). Shared by
-    /// [`prepare`](SelfDeploySourcePreparer::prepare) and the `self-deploy` CLI
-    /// (which fetches before reading the merged head to deploy). Loud on
-    /// failure: returns [`SafeUpdateError::FetchFailed`], never a silent
-    /// fallback.
+    /// The first dedicated git-fetch helper in `src/` (issue #2467). Called by
+    /// the `self-deploy` CLI (which fetches before reading the merged head to
+    /// deploy) and by [`prepare`](SelfDeploySourcePreparer::prepare) — the latter
+    /// **only when the target commit is not already present locally**, so the
+    /// CLI's fetch is not redundantly repeated. Loud on failure: returns
+    /// [`SafeUpdateError::FetchFailed`], never a silent fallback.
     pub fn fetch_origin(&self, repo: &Path) -> Result<(), SafeUpdateError> {
         git_capture(repo, &["fetch", "origin"])
             .map(|_| ())
@@ -219,11 +224,22 @@ impl SelfDeploySourcePreparer for GitSourcePreparer {
         // (leading `-`) can never reach a git argv (SEC-I2).
         validate_full_sha(target_commit)?;
 
-        // Resolve the canonical repo (never the cwd), fetch so the object is
-        // present, then check out the exact merged commit detached so the
+        // Resolve the canonical repo (never the cwd), make sure the exact merged
+        // commit is in the object store, then check it out detached so the
         // embedded `SIMARD_GIT_HASH` equals the deployed commit.
         let repo = self.resolve_repo()?;
-        self.fetch_origin(&repo)?;
+        // Perf (issue #2467): the merged commit is almost always already present
+        // — the `self-deploy` CLI `git fetch`es this same canonical repo to read
+        // the merged head before handing it to the orchestrator. Re-fetching it
+        // here is a redundant network round-trip, so skip it when the object is
+        // already in the store (a fast, offline `cat-file` check) and only hit
+        // the network when the commit is genuinely missing. `checkout --detach`
+        // is pinned to the validated full SHA, so a skipped fetch can never check
+        // out a different/stale tree — and the deploy survives a transient
+        // network blip after the head was read.
+        if !commit_present(&repo, target_commit) {
+            self.fetch_origin(&repo)?;
+        }
         git_capture(&repo, &["checkout", "--detach", target_commit])
             .map(|_| ())
             .map_err(|detail| SafeUpdateError::CheckoutFailed { detail })?;
@@ -357,6 +373,18 @@ fn scrub_git_env(cmd: &mut Command) {
     if let Ok(home) = std::env::var("HOME") {
         cmd.env("HOME", home);
     }
+}
+
+/// Whether the commit `sha` is already present in `repo`'s object store — a
+/// fast, **offline** check (`git cat-file -e <sha>^{commit}`) used to skip a
+/// redundant network `git fetch` when the merged commit was already fetched
+/// (e.g. by the `self-deploy` CLI before it read the merged head). `sha` must
+/// already have passed [`validate_full_sha`]; the `^{commit}` peel ensures the
+/// object resolves to a commit so the subsequent `checkout --detach` succeeds
+/// without the network. A missing object (or any git error) returns `false`,
+/// so the caller falls back to fetching — never a false "present".
+fn commit_present(repo: &Path, sha: &str) -> bool {
+    git_capture(repo, &["cat-file", "-e", &format!("{sha}^{{commit}}")]).is_ok()
 }
 
 /// Run a `git` subcommand in `repo` (scrubbed env) and return stdout, or an

--- a/src/self_deploy/source_prep.rs
+++ b/src/self_deploy/source_prep.rs
@@ -109,12 +109,49 @@ pub fn validate_origin_transport(url: &str) -> Result<(), SafeUpdateError> {
         Ok(())
     } else {
         Err(SafeUpdateError::SourceResolveFailed {
-            detail: format!(
+            detail: redact_credentials(&format!(
                 "refusing origin URL {url:?}: only https:// and ssh:// transports are permitted \
                  (arbitrary-command transports like ext::/fd:: can run code on clone)"
-            ),
+            )),
         })
     }
+}
+
+/// Redact URL userinfo (e.g. an embedded access token) from any text before it
+/// is surfaced in an error, log, recipe output, or PR (SEC-D2).
+///
+/// Git error output and remote URLs can embed credentials as
+/// `scheme://x-access-token:<TOKEN>@host/…` or `scheme://user:pass@host/…` (the
+/// project uses token-bearing remotes). This replaces the userinfo between
+/// `://` and the authority-terminating `@` with `***`, so a surfaced
+/// [`SafeUpdateError`] (and the operator terminal / logs that display it) never
+/// carries a live token. Tokenless URLs and non-URL text pass through
+/// unchanged. Multiple URLs in one string are each redacted.
+pub(crate) fn redact_credentials(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut rest = text;
+    while let Some(scheme_pos) = rest.find("://") {
+        let after_scheme = scheme_pos + 3;
+        out.push_str(&rest[..after_scheme]);
+        let authority = &rest[after_scheme..];
+        // The authority component ends at the first path/query/fragment
+        // delimiter, quote, or whitespace.
+        let auth_end = authority
+            .find(|c: char| matches!(c, '/' | '?' | '#' | '\'' | '"') || c.is_whitespace())
+            .unwrap_or(authority.len());
+        let authority_component = &authority[..auth_end];
+        // The last '@' in the authority separates userinfo from host (a host
+        // never contains '@'); redact everything before it.
+        if let Some(at) = authority_component.rfind('@') {
+            out.push_str("***");
+            out.push_str(&authority_component[at..]);
+        } else {
+            out.push_str(authority_component);
+        }
+        rest = &authority[auth_end..];
+    }
+    out.push_str(rest);
+    out
 }
 
 /// Whether `url` is an scp-like SSH remote (`user@host:path`) and *not* a
@@ -337,11 +374,11 @@ fn clone_from_origin(dest: &Path) -> Result<PathBuf, SafeUpdateError> {
         })?;
     if !out.status.success() {
         return Err(SafeUpdateError::SourceResolveFailed {
-            detail: format!(
+            detail: redact_credentials(&format!(
                 "git clone of {origin_url:?} into {} failed: {}",
                 dest.display(),
                 String::from_utf8_lossy(&out.stderr).trim()
-            ),
+            )),
         });
     }
     Ok(dest.to_path_buf())
@@ -398,12 +435,15 @@ fn git_capture(repo: &Path, args: &[&str]) -> Result<String, String> {
         .output()
         .map_err(|e| format!("spawn git {args:?} in {}: {e}", repo.display()))?;
     if !out.status.success() {
-        return Err(format!(
+        // Redact any credentials git prints (e.g. a token-bearing remote URL in
+        // a "fatal: unable to access 'https://<token>@…'" message) before the
+        // detail is surfaced to the operator terminal or logs (SEC-D2).
+        return Err(redact_credentials(&format!(
             "git {:?} failed in {}: {}",
             args,
             repo.display(),
             String::from_utf8_lossy(&out.stderr).trim()
-        ));
+        )));
     }
     Ok(String::from_utf8_lossy(&out.stdout).into_owned())
 }

--- a/src/self_deploy/source_prep.rs
+++ b/src/self_deploy/source_prep.rs
@@ -34,7 +34,9 @@
 
 use std::path::{Component, Path, PathBuf};
 use std::process::Command;
+use std::time::Duration;
 
+use crate::build_lock::BuildLock;
 use crate::safe_update::SafeUpdateError;
 use crate::state_root::simard_state_root;
 
@@ -49,6 +51,13 @@ pub const SELF_DEPLOY_SRC_DIRNAME: &str = "self-deploy-src";
 /// Subdirectory name (under the resolved state root) for the persistent **warm**
 /// cargo target dir reused across self-deploys.
 pub const SELF_DEPLOY_TARGET_DIRNAME: &str = "self-deploy-target";
+
+/// Max wait for the host-wide build lock before a self-deploy aborts loudly
+/// (issue #2467). Long enough for a concurrent *warm* self-deploy build
+/// (~2–3 min) to finish and release the lock; a lock still held past this
+/// surfaces a loud [`SafeUpdateError::BuildFailed`] instead of racing the shared
+/// source checkout.
+const BUILD_LOCK_TIMEOUT: Duration = Duration::from_secs(900);
 
 /// Persistent self-deploy **source checkout** directory.
 ///
@@ -582,11 +591,34 @@ fn git_capture(repo: &Path, args: &[&str]) -> Result<String, String> {
 /// preparation failure propagates **before** any build is attempted — and a
 /// fortiori before any daemon mutation — so a missing/unreachable merged commit
 /// can never deploy the cwd HEAD.
+///
+/// The whole resolve→checkout→build critical section is serialized by the
+/// host-wide [`BuildLock`] (`<state_root>/cargo_build.lock` — the same lock the
+/// operator dashboard surfaces and can force-release). Two concurrent
+/// self-deploys share the persistent source checkout ([`self_deploy_src_dir`])
+/// **and** the warm `target_dir`; without this lock, run B's
+/// `git checkout --detach <shaB>` could rewrite the working tree while run A's
+/// `cargo build` is still reading it, so A would compile B's tree yet embed A's
+/// `SIMARD_GIT_HASH` — silently shipping the wrong source past the post-deploy
+/// `version_advanced` gate, which only compares the *embedded* SHA to the
+/// target. The lock is held for the whole prepare+build and released on drop;
+/// failing to acquire it within [`BUILD_LOCK_TIMEOUT`] aborts loudly (never a
+/// silent race). (Its 10-min stale-reap only weakens the rare concurrent *cold*
+/// first build; warm builds finish well inside it.)
 pub(crate) fn prepare_and_build(
     source: &dyn SelfDeploySourcePreparer,
     target_commit: &str,
     target_dir: &Path,
 ) -> Result<PathBuf, SafeUpdateError> {
+    let _build_guard = BuildLock::new(&simard_state_root())
+        .acquire(BUILD_LOCK_TIMEOUT)
+        .map_err(|e| SafeUpdateError::BuildFailed {
+            detail: format!(
+                "could not acquire the self-deploy build lock \
+                 (another self-deploy build may be running): {e}"
+            ),
+        })?;
+
     let repo = source.prepare(target_commit)?;
     crate::self_relaunch::build_self_deploy_candidate(&repo, target_dir).map_err(|e| {
         SafeUpdateError::BuildFailed {

--- a/src/self_deploy/source_prep.rs
+++ b/src/self_deploy/source_prep.rs
@@ -270,6 +270,39 @@ impl GitSourcePreparer {
             .map(|_| ())
             .map_err(|detail| SafeUpdateError::FetchFailed { detail })
     }
+
+    /// Resolve the canonical source repo **without cloning** — the read-only
+    /// resolution used by `self-deploy --check`.
+    ///
+    /// Mirrors the cwd-independent precedence of [`resolve_repo`](Self::resolve_repo)
+    /// (`repo_override` → `SIMARD_SELF_DEPLOY_REPO` → the persistent
+    /// [`self_deploy_src_dir`] checkout) but deliberately stops short of the
+    /// clone-from-origin step: `--check` documents that it "makes no changes",
+    /// so it must never create the persistent checkout as a side effect.
+    ///
+    /// Returns `None` when no canonical source exists yet (e.g. before the first
+    /// deploy) — and on an invalid override (path traversal / non-work-tree),
+    /// which a read-only check degrades over rather than erroring. The caller
+    /// then falls back to a best-effort report against the current working
+    /// directory. A misconfigured override is surfaced loudly by the effectful
+    /// [`resolve_repo`](Self::resolve_repo) on the real deploy path instead.
+    pub fn resolve_existing_repo(&self) -> Option<PathBuf> {
+        // 1) Explicit override (tests / non-standard installs) wins outright.
+        if let Some(repo) = &self.repo_override {
+            return validate_repo_path(repo).ok();
+        }
+        // 2) `SIMARD_SELF_DEPLOY_REPO` env override.
+        if let Some(env_repo) = env_repo_override() {
+            return validate_repo_path(&env_repo).ok();
+        }
+        // 3) Persistent canonical checkout under the state root, if present.
+        //    No clone fallback: `--check` must not mutate anything.
+        let persistent = self_deploy_src_dir();
+        if is_git_work_tree(&persistent) {
+            return Some(persistent);
+        }
+        None
+    }
 }
 
 impl SelfDeploySourcePreparer for GitSourcePreparer {

--- a/src/self_deploy/source_prep.rs
+++ b/src/self_deploy/source_prep.rs
@@ -281,19 +281,24 @@ impl GitSourcePreparer {
     /// so it must never create the persistent checkout as a side effect.
     ///
     /// Returns `None` when no canonical source exists yet (e.g. before the first
-    /// deploy) — and on an invalid override (path traversal / non-work-tree),
-    /// which a read-only check degrades over rather than erroring. The caller
-    /// then falls back to a best-effort report against the current working
-    /// directory. A misconfigured override is surfaced loudly by the effectful
-    /// [`resolve_repo`](Self::resolve_repo) on the real deploy path instead.
+    /// deploy), and the caller falls back to a best-effort report against the
+    /// current working directory.
+    ///
+    /// An override that is *present but invalid* (path traversal / symlink /
+    /// non-work-tree) also yields `None` — a read-only check tolerates it by
+    /// degrading to the cwd report rather than hard-erroring like the effectful
+    /// [`resolve_repo`](Self::resolve_repo) — but the degradation is **never
+    /// silent**: it is logged loudly to stderr (mirroring the best-effort-fetch
+    /// warning in `report_drift`) so an operator who never runs the deploy path
+    /// still sees their misconfiguration.
     pub fn resolve_existing_repo(&self) -> Option<PathBuf> {
         // 1) Explicit override (tests / non-standard installs) wins outright.
         if let Some(repo) = &self.repo_override {
-            return validate_repo_path(repo).ok();
+            return validated_existing_override(repo, "repo_override");
         }
         // 2) `SIMARD_SELF_DEPLOY_REPO` env override.
         if let Some(env_repo) = env_repo_override() {
-            return validate_repo_path(&env_repo).ok();
+            return validated_existing_override(&env_repo, SELF_DEPLOY_REPO_ENV);
         }
         // 3) Persistent canonical checkout under the state root, if present.
         //    No clone fallback: `--check` must not mutate anything.
@@ -302,6 +307,29 @@ impl GitSourcePreparer {
             return Some(persistent);
         }
         None
+    }
+}
+
+/// Validate a `--check` source override, warning **loudly** (never silently
+/// degrading) when it is rejected.
+///
+/// A present-but-invalid override is an operator misconfiguration the read-only
+/// check must still surface — so it logs to stderr before returning `None`, the
+/// same "make the degraded path visible" remedy applied to the best-effort fetch
+/// in `report_drift`. It still tolerates the failure (falls back to a cwd report)
+/// rather than erroring, which the effectful deploy path
+/// ([`GitSourcePreparer::resolve_repo`]) does instead.
+fn validated_existing_override(repo: &Path, source: &str) -> Option<PathBuf> {
+    match validate_repo_path(repo) {
+        Ok(path) => Some(path),
+        Err(err) => {
+            eprintln!(
+                "self-deploy --check: warning: ignoring invalid self-deploy source \
+                 override from {source} ({err}); falling back to a current-directory \
+                 report, which may not match what an actual deploy would build"
+            );
+            None
+        }
     }
 }
 

--- a/src/self_deploy/source_prep.rs
+++ b/src/self_deploy/source_prep.rs
@@ -25,9 +25,9 @@
 //! *before* the load-bearing safety sequence — it never silently falls back to
 //! building the cwd HEAD.
 //!
-//! All git is run via the `env_clear()` + selective `PATH`/`HOME` re-injection
-//! discipline (mirroring [`crate::engineer_worktree`]) so a hostile ambient env
-//! cannot hijack the build source.
+//! All git is run via the `env_clear()` + selective `PATH`/`HOME`/`SSH_AUTH_SOCK`
+//! re-injection discipline (mirroring [`crate::engineer_worktree`]) so a hostile
+//! ambient env cannot hijack the build source.
 //!
 //! See `docs/reference/self-deploy-source-prep.md` and
 //! `docs/howto/run-self-deploy-from-any-directory.md`.
@@ -103,6 +103,20 @@ pub fn validate_full_sha(sha: &str) -> Result<(), SafeUpdateError> {
 /// poisoned remote URL run code during a clone/fetch.
 pub fn validate_origin_transport(url: &str) -> Result<(), SafeUpdateError> {
     let trimmed = url.trim();
+    // A leading '-' would let git parse the URL as an *option* rather than a
+    // positional (e.g. `--upload-pack=…`, `-c core.pager=…`) — the same argv
+    // option-injection class `validate_full_sha` guards against (SEC-I2). The
+    // origin URL comes from the cwd's `git remote get-url origin`, the very
+    // untrusted input this control exists for, so reject it before the
+    // transport check (and `clone_from_origin` additionally passes `--`).
+    if trimmed.starts_with('-') {
+        return Err(SafeUpdateError::SourceResolveFailed {
+            detail: redact_credentials(&format!(
+                "refusing origin URL {url:?}: must not begin with '-' \
+                 (guards against argv option injection into git clone)"
+            )),
+        });
+    }
     let allowed =
         trimmed.starts_with("https://") || trimmed.starts_with("ssh://") || is_scp_like(trimmed);
     if allowed {
@@ -158,7 +172,10 @@ pub(crate) fn redact_credentials(text: &str) -> String {
 /// remote-helper transport. Rejects any `scheme::address` form (e.g. `ext::`,
 /// `fd::`) — a `::` is the giveaway of a remote helper that can run a command.
 fn is_scp_like(url: &str) -> bool {
-    if url.contains("://") || url.contains("::") {
+    // A leading '-' is never a valid host and would be parsed as a `git clone`
+    // option (argv option injection); reject it here too so the helper is safe
+    // independent of its callers.
+    if url.starts_with('-') || url.contains("://") || url.contains("::") {
         return false;
     }
     match (url.find('@'), url.find(':')) {
@@ -358,6 +375,15 @@ fn clone_from_origin(dest: &Path) -> Result<PathBuf, SafeUpdateError> {
     let origin_url = discover_origin_url()?;
     validate_origin_transport(&origin_url)?;
 
+    // Self-heal a wedged persistent checkout (issue #2467 review). A clone is
+    // only reached when `dest` is NOT a valid git work tree (`resolve_repo`
+    // branch 3 returns early when it is), so any path here is stale: a clone
+    // killed mid-way, a leftover non-git directory, or a dangling symlink. Left
+    // in place it would make `git clone <dest>` fail forever ("destination path
+    // already exists and is not an empty directory"), permanently wedging every
+    // future self-deploy. Remove it so the clone can recreate a clean checkout.
+    remove_stale_checkout(dest)?;
+
     if let Some(parent) = dest.parent() {
         std::fs::create_dir_all(parent).map_err(|e| SafeUpdateError::SourceResolveFailed {
             detail: format!("cannot create state dir {}: {e}", parent.display()),
@@ -365,7 +391,13 @@ fn clone_from_origin(dest: &Path) -> Result<PathBuf, SafeUpdateError> {
     }
 
     let mut cmd = Command::new("git");
-    cmd.arg("clone").arg("--quiet").arg(&origin_url).arg(dest);
+    // `--` terminates options so a (validated, but defense-in-depth) origin URL
+    // can never be parsed as a `git clone` flag (SEC-I3).
+    cmd.arg("clone")
+        .arg("--quiet")
+        .arg("--")
+        .arg(&origin_url)
+        .arg(dest);
     scrub_git_env(&mut cmd);
     let out = cmd
         .output()
@@ -384,6 +416,32 @@ fn clone_from_origin(dest: &Path) -> Result<PathBuf, SafeUpdateError> {
     Ok(dest.to_path_buf())
 }
 
+/// Remove a stale/partial path at `dest` (dangling symlink, leftover file, or
+/// non-git directory) so a fresh `git clone` can recreate it. Only called from
+/// [`clone_from_origin`], which is reached only when `dest` is not a valid git
+/// work tree, so deleting it can never discard a usable checkout. A symlink is
+/// removed itself (never followed into its target). A non-existent path is a
+/// no-op.
+pub(crate) fn remove_stale_checkout(dest: &Path) -> Result<(), SafeUpdateError> {
+    let meta = match dest.symlink_metadata() {
+        Ok(m) => m,
+        // Nothing present (or unreadable) — let the clone proceed and report.
+        Err(_) => return Ok(()),
+    };
+    let ft = meta.file_type();
+    let result = if ft.is_symlink() || ft.is_file() {
+        std::fs::remove_file(dest)
+    } else {
+        std::fs::remove_dir_all(dest)
+    };
+    result.map_err(|e| SafeUpdateError::SourceResolveFailed {
+        detail: format!(
+            "cannot remove stale self-deploy source checkout {}: {e}",
+            dest.display()
+        ),
+    })
+}
+
 /// Discover the `origin` remote URL of the current checkout (read-only).
 fn discover_origin_url() -> Result<String, SafeUpdateError> {
     let cwd = std::env::current_dir().map_err(|e| SafeUpdateError::SourceResolveFailed {
@@ -399,16 +457,22 @@ fn discover_origin_url() -> Result<String, SafeUpdateError> {
         })
 }
 
-/// `env_clear()` + selective `PATH`/`HOME` re-injection for every `git`
-/// subprocess, mirroring [`crate::engineer_worktree`]: a hostile ambient env
-/// (`GIT_DIR`, `GIT_WORK_TREE`, `LD_PRELOAD`, …) cannot hijack the build source.
+/// `env_clear()` + selective `PATH`/`HOME`/`SSH_AUTH_SOCK` re-injection for every
+/// `git` subprocess, mirroring [`crate::engineer_worktree`]: a hostile ambient
+/// env (`GIT_DIR`, `GIT_WORK_TREE`, `LD_PRELOAD`, …) cannot hijack the build
+/// source.
+///
+/// `SSH_AUTH_SOCK` is forwarded so the `ssh://`/scp-like transports permitted by
+/// [`validate_origin_transport`] can authenticate via a running ssh-agent
+/// (encrypted or agent-only keys) rather than failing. `GIT_SSH_COMMAND` is
+/// **deliberately not** forwarded: it executes an arbitrary command, which is
+/// exactly the hijack class this scrub exists to strip.
 fn scrub_git_env(cmd: &mut Command) {
     cmd.env_clear();
-    if let Ok(path) = std::env::var("PATH") {
-        cmd.env("PATH", path);
-    }
-    if let Ok(home) = std::env::var("HOME") {
-        cmd.env("HOME", home);
+    for var in ["PATH", "HOME", "SSH_AUTH_SOCK"] {
+        if let Ok(val) = std::env::var(var) {
+            cmd.env(var, val);
+        }
     }
 }
 

--- a/src/self_deploy/tests_orchestrator.rs
+++ b/src/self_deploy/tests_orchestrator.rs
@@ -12,6 +12,7 @@ use crate::safe_update::{SafeUpdateError, UpdateConfig};
 
 use super::orchestrator::{DeploySourceKind, SelfDeployOrchestrator};
 use super::restart::FakeRestarter;
+use super::source_prep::GitSourcePreparer;
 // --- DeploySourceKind -------------------------------------------------------
 
 #[test]
@@ -91,6 +92,76 @@ fn new_safe_update_error_variants_display_loudly() {
             "Display for {err:?} should contain {needle:?}, got: {s}"
         );
     }
+}
+
+// --- Issue #2467: loud source-prep error variants ---------------------------
+
+#[test]
+fn self_deploy_source_prep_error_variants_display_loudly() {
+    // Each new variant aborts BEFORE the safety sequence and must say so
+    // loudly (and name the phase) — never a silent cwd-HEAD fallback.
+    let cases: Vec<(SafeUpdateError, &str)> = vec![
+        (
+            SafeUpdateError::SourceResolveFailed {
+                detail: "SIMARD_SELF_DEPLOY_REPO is not a work tree".to_string(),
+            },
+            "resolve",
+        ),
+        (
+            SafeUpdateError::FetchFailed {
+                detail: "could not read from remote".to_string(),
+            },
+            "fetch",
+        ),
+        (
+            SafeUpdateError::CheckoutFailed {
+                detail: "unknown revision deadbeef".to_string(),
+            },
+            "checkout",
+        ),
+    ];
+    for (err, needle) in cases {
+        let s = err.to_string().to_lowercase();
+        assert!(
+            s.contains(needle),
+            "Display for {err:?} should contain {needle:?}, got: {s}"
+        );
+        assert!(
+            s.contains("no cwd-head fallback"),
+            "Display for {err:?} must advertise the loud, no-fallback contract, got: {s}"
+        );
+    }
+}
+
+// --- Issue #2467: additive with_source constructor --------------------------
+
+#[test]
+fn with_source_injects_a_preparer_and_new_leaves_it_none() {
+    // `new` (legacy) has no source preparer; `with_source` carries one. This is
+    // the additive seam that lets the orchestrator build the fetched merged
+    // commit instead of the cwd HEAD.
+    let legacy = SelfDeployOrchestrator::new(
+        UpdateConfig::default(),
+        Box::new(FakeRestarter::new()),
+        "deadbeefcafe".to_string(),
+        PathBuf::from("/home/simard/.simard/bin/simard"),
+    );
+    assert!(
+        legacy.build_source().is_none(),
+        "new() must preserve the legacy no-source build path"
+    );
+
+    let sourced = SelfDeployOrchestrator::with_source(
+        UpdateConfig::default(),
+        Box::new(FakeRestarter::new()),
+        "deadbeefcafe".to_string(),
+        PathBuf::from("/home/simard/.simard/bin/simard"),
+        Box::new(GitSourcePreparer::new()),
+    );
+    assert!(
+        sourced.build_source().is_some(),
+        "with_source() must carry the injected source preparer"
+    );
 }
 
 // --- Orchestrator construction + end-to-end (pending) -----------------------

--- a/src/self_deploy/tests_source_prep.rs
+++ b/src/self_deploy/tests_source_prep.rs
@@ -27,8 +27,8 @@ use crate::state_root::{STATE_ROOT_ENV, simard_state_root};
 
 use super::source_prep::{
     GitSourcePreparer, SELF_DEPLOY_SRC_DIRNAME, SELF_DEPLOY_TARGET_DIRNAME,
-    SelfDeploySourcePreparer, prepare_and_build, redact_credentials, self_deploy_src_dir,
-    self_deploy_target_dir, validate_full_sha, validate_origin_transport,
+    SelfDeploySourcePreparer, prepare_and_build, redact_credentials, remove_stale_checkout,
+    self_deploy_src_dir, self_deploy_target_dir, validate_full_sha, validate_origin_transport,
 };
 
 const SELF_DEPLOY_REPO_ENV: &str = "SIMARD_SELF_DEPLOY_REPO";
@@ -327,6 +327,27 @@ fn validate_origin_transport_rejects_command_transports() {
         assert!(
             validate_origin_transport(url).is_err(),
             "arbitrary-command transport must be rejected: {url}"
+        );
+    }
+}
+
+#[test]
+fn validate_origin_transport_rejects_leading_dash_argv_injection() {
+    // A '-'-leading origin URL would be parsed by `git clone` as an *option*
+    // (e.g. `--upload-pack=…`, `-c core.pager=…`) rather than a positional —
+    // the same argv option-injection class `validate_full_sha` blocks (SEC-I2),
+    // and exactly the "run code on clone" threat `validate_origin_transport`
+    // exists to stop (SEC-I3). All of these `is_scp_like`-shaped strings begin
+    // with '-' and MUST be refused.
+    for url in [
+        "-uevil@example.com:repo.git",
+        "--upload-pack=evil@example.com:repo.git",
+        "-ccore.pager=evil@example.com:repo.git",
+        "  -uevil@example.com:repo.git", // leading whitespace is trimmed first
+    ] {
+        assert!(
+            validate_origin_transport(url).is_err(),
+            "leading-dash origin URL must be rejected (argv option injection): {url:?}"
         );
     }
 }
@@ -673,4 +694,66 @@ fn build_self_deploy_candidate_creates_warm_dir_and_fails_loudly_on_bad_repo() {
         "a missing source manifest must make the build fail loudly"
     );
     let _ = std::fs::remove_dir_all(&warm);
+}
+
+// ---------------------------------------------------------------------------
+// remove_stale_checkout(): self-heal a wedged persistent source checkout
+// (issue #2467 review). A clone is only attempted when the persistent dir is
+// NOT a valid work tree, so a leftover partial/non-git path (or dangling
+// symlink) must be removed first — otherwise `git clone <dest>` fails forever
+// ("destination path already exists and is not an empty directory") and every
+// future self-deploy is permanently wedged.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn remove_stale_checkout_clears_partial_non_git_directory() {
+    let root = tempfile::tempdir().unwrap();
+    let dest = root.path().join("self-deploy-src");
+    // A clone killed mid-way leaves a non-empty, non-git directory.
+    std::fs::create_dir_all(dest.join(".git")).unwrap();
+    std::fs::write(dest.join("partial"), b"half-written").unwrap();
+    assert!(dest.exists());
+
+    remove_stale_checkout(&dest).expect("a partial checkout must be removed, not error");
+    assert!(
+        !dest.exists(),
+        "the wedged checkout dir must be gone so a fresh clone can recreate it"
+    );
+}
+
+#[test]
+fn remove_stale_checkout_clears_leftover_file() {
+    let root = tempfile::tempdir().unwrap();
+    let dest = root.path().join("self-deploy-src");
+    std::fs::write(&dest, b"not a directory").unwrap();
+
+    remove_stale_checkout(&dest).expect("a leftover file at the checkout path must be removed");
+    assert!(!dest.exists(), "the leftover file must be gone");
+}
+
+#[cfg(unix)]
+#[test]
+fn remove_stale_checkout_removes_symlink_without_following_it() {
+    let root = tempfile::tempdir().unwrap();
+    // The symlink target holds data that MUST survive (we delete the link only).
+    let target = root.path().join("real-contents");
+    std::fs::create_dir_all(&target).unwrap();
+    std::fs::write(target.join("keep"), b"precious").unwrap();
+
+    let dest = root.path().join("self-deploy-src");
+    std::os::unix::fs::symlink(&target, &dest).unwrap();
+
+    remove_stale_checkout(&dest).expect("a symlink at the checkout path must be removed");
+    assert!(!dest.exists(), "the symlink itself must be removed");
+    assert!(
+        target.join("keep").exists(),
+        "removal must not follow the symlink into its target"
+    );
+}
+
+#[test]
+fn remove_stale_checkout_is_noop_when_absent() {
+    let root = tempfile::tempdir().unwrap();
+    let dest = root.path().join("does-not-exist");
+    remove_stale_checkout(&dest).expect("a missing checkout path must be a no-op, not an error");
 }

--- a/src/self_deploy/tests_source_prep.rs
+++ b/src/self_deploy/tests_source_prep.rs
@@ -601,6 +601,76 @@ fn resolve_repo_rejects_invalid_env_override_without_cwd_fallback() {
 }
 
 // ---------------------------------------------------------------------------
+// resolve_existing_repo(): the cwd-independent, NON-cloning resolution used by
+// `self-deploy --check` (issue #2467 review). It honors the same env-override →
+// persistent-checkout precedence as resolve_repo, but stops short of cloning (a
+// read-only `--check` must "make no changes"), returning None when no canonical
+// source exists yet so the caller can fall back to a best-effort cwd report.
+// ---------------------------------------------------------------------------
+
+#[test]
+#[serial_test::serial(simard_self_deploy_repo, cognitive_memory)]
+fn resolve_existing_repo_returns_env_override_without_cloning() {
+    let root = tempfile::tempdir().unwrap();
+    let origin = root.path().join("origin");
+    let canonical = root.path().join("canonical");
+    init_origin(&origin);
+    clone_local(&origin, &canonical);
+
+    let _g = EnvGuard::set(SELF_DEPLOY_REPO_ENV, &canonical);
+    let resolved = GitSourcePreparer::new()
+        .resolve_existing_repo()
+        .expect("a valid SIMARD_SELF_DEPLOY_REPO must resolve for --check");
+    assert_eq!(
+        std::fs::canonicalize(&resolved).unwrap(),
+        std::fs::canonicalize(&canonical).unwrap(),
+        "--check must resolve the same canonical override the deploy uses, not the cwd"
+    );
+}
+
+#[test]
+#[serial_test::serial(simard_state_root_env, simard_self_deploy_repo, cognitive_memory)]
+fn resolve_existing_repo_returns_persistent_checkout_when_present() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _state = EnvGuard::set(STATE_ROOT_ENV, tmp.path());
+    // Neutralize any ambient override (an empty value reads back as "unset").
+    let _override = EnvGuard::set(SELF_DEPLOY_REPO_ENV, Path::new(""));
+
+    // Make the persistent checkout a real git work tree under the state root.
+    let persistent = self_deploy_src_dir();
+    init_origin(&persistent);
+
+    let resolved = GitSourcePreparer::new()
+        .resolve_existing_repo()
+        .expect("an existing persistent checkout must resolve for --check");
+    assert_eq!(
+        std::fs::canonicalize(&resolved).unwrap(),
+        std::fs::canonicalize(&persistent).unwrap(),
+        "--check must resolve the persistent canonical checkout, not the cwd"
+    );
+}
+
+#[test]
+#[serial_test::serial(simard_state_root_env, simard_self_deploy_repo, cognitive_memory)]
+fn resolve_existing_repo_is_none_and_never_clones_without_a_canonical_source() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _state = EnvGuard::set(STATE_ROOT_ENV, tmp.path());
+    let _override = EnvGuard::set(SELF_DEPLOY_REPO_ENV, Path::new(""));
+
+    // No env override and no persistent checkout under the (empty) state root.
+    assert!(
+        GitSourcePreparer::new().resolve_existing_repo().is_none(),
+        "with no canonical source, --check must NOT clone — it returns None and \
+         the caller falls back to a best-effort cwd report"
+    );
+    // ...and it must not have created the persistent checkout as a side effect.
+    assert!(
+        !self_deploy_src_dir().exists(),
+        "resolve_existing_repo must never create the persistent checkout (read-only)"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // prepare_and_build(): the orchestrator's step-1 composition. A prep failure
 // must propagate BEFORE any build (and a fortiori before daemon mutation), and
 // prep must be asked for the exact target merged commit.

--- a/src/self_deploy/tests_source_prep.rs
+++ b/src/self_deploy/tests_source_prep.rs
@@ -382,6 +382,49 @@ fn prepare_fetches_and_checks_out_merged_head_not_cwd_head() {
 }
 
 #[test]
+fn prepare_skips_fetch_when_commit_already_present_offline() {
+    // Perf/resilience (issue #2467): when the target merged commit is already
+    // in the canonical repo's object store (e.g. the `self-deploy` CLI fetched
+    // it before reading the merged head, then handed it to the orchestrator),
+    // prepare() must NOT make a second, redundant network fetch. We prove it by
+    // making `origin` unreachable AFTER cloning: a present commit must still
+    // check out — whereas an unconditional `git fetch origin` would fail loudly.
+    let root = tempfile::tempdir().unwrap();
+    let origin = root.path().join("origin");
+    let canonical = root.path().join("canonical");
+
+    let (_origin, c1) = init_origin(&origin);
+    clone_local(&origin, &canonical);
+    // c1 is already present in the clone's object store. Destroy origin so any
+    // attempted fetch would fail — the only way prepare() can succeed is by
+    // skipping the fetch for the already-present commit.
+    std::fs::remove_dir_all(&origin).unwrap();
+
+    let prepared = GitSourcePreparer::at(&canonical)
+        .prepare(&c1)
+        .expect("a locally-present commit must prepare without re-fetching");
+
+    assert_eq!(
+        std::fs::canonicalize(&prepared).unwrap(),
+        std::fs::canonicalize(&canonical).unwrap(),
+        "prepare must return the canonical repo"
+    );
+    assert_eq!(
+        git_out(&canonical, &["rev-parse", "HEAD"]),
+        c1,
+        "prepared HEAD must be the (already-present) target commit"
+    );
+    // Detached HEAD at the exact commit (so SIMARD_GIT_HASH == c1).
+    assert!(
+        !git_cmd(&canonical, &["symbolic-ref", "-q", "HEAD"])
+            .status()
+            .unwrap()
+            .success(),
+        "HEAD must be detached at the present commit"
+    );
+}
+
+#[test]
 fn prepare_is_loud_when_target_commit_is_absent_no_cwd_fallback() {
     let root = tempfile::tempdir().unwrap();
     let origin = root.path().join("origin");

--- a/src/self_deploy/tests_source_prep.rs
+++ b/src/self_deploy/tests_source_prep.rs
@@ -1,0 +1,577 @@
+//! Hermetic tests for the cwd-independent self-deploy source preparer
+//! (issue #2467 — `src/self_deploy/source_prep.rs`).
+//!
+//! These pin the two fixes the issue requires:
+//!   1. **Build the merged commit, not cwd HEAD** — the preparer `git fetch`es
+//!      the canonical repo and `checkout --detach`es the *target merged SHA*
+//!      (`prepare`), resolved independently of the current working directory.
+//!   2. **Warm target dir** — `self_deploy_target_dir()` is a persistent,
+//!      non-PID-keyed dir under the state root so builds are incremental.
+//!
+//! Everything runs offline: the git tests use a local `file`-path "origin"
+//! repo (a `git fetch` from a local path needs no network), and the wiring
+//! tests inject a fake [`SelfDeploySourcePreparer`].
+//!
+//! Written against the public contract in
+//! `docs/reference/self-deploy-source-prep.md`. They MUST fail in the red
+//! phase (the `source_prep.rs` bodies are `unimplemented!()` stubs) and MUST
+//! pass once the implementation lands — without any test edits.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Mutex;
+
+use crate::safe_update::SafeUpdateError;
+use crate::self_relaunch::build_self_deploy_candidate;
+use crate::state_root::{STATE_ROOT_ENV, simard_state_root};
+
+use super::source_prep::{
+    GitSourcePreparer, SELF_DEPLOY_SRC_DIRNAME, SELF_DEPLOY_TARGET_DIRNAME,
+    SelfDeploySourcePreparer, prepare_and_build, self_deploy_src_dir, self_deploy_target_dir,
+    validate_full_sha, validate_origin_transport,
+};
+
+const SELF_DEPLOY_REPO_ENV: &str = "SIMARD_SELF_DEPLOY_REPO";
+
+// ---------------------------------------------------------------------------
+// Env + git fixtures (mirror engineer_worktree/state_root test discipline:
+// env_clear() then re-inject only PATH/HOME so ambient GIT_* / state-root env
+// cannot poison these fixtures).
+// ---------------------------------------------------------------------------
+
+/// Scoped env override that restores the previous value on drop. Tests that use
+/// it MUST be `#[serial]` (env is process-global).
+struct EnvGuard {
+    key: &'static str,
+    prev: Option<std::ffi::OsString>,
+}
+
+impl EnvGuard {
+    fn set(key: &'static str, value: &Path) -> Self {
+        let prev = std::env::var_os(key);
+        // SAFETY: callers are serialized via #[serial]; edition-2024 set_var is unsafe.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, prev }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        // SAFETY: callers are serialized via #[serial].
+        unsafe {
+            match self.prev.take() {
+                Some(v) => std::env::set_var(self.key, v),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
+fn git_cmd(repo: &Path, args: &[&str]) -> Command {
+    let mut cmd = Command::new("git");
+    cmd.args(args).current_dir(repo).env_clear();
+    if let Ok(p) = std::env::var("PATH") {
+        cmd.env("PATH", p);
+    }
+    if let Ok(h) = std::env::var("HOME") {
+        cmd.env("HOME", h);
+    }
+    cmd
+}
+
+fn git_run(repo: &Path, args: &[&str]) {
+    let out = git_cmd(repo, args).output().expect("spawn git");
+    assert!(
+        out.status.success(),
+        "git {:?} failed in {}: {}",
+        args,
+        repo.display(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn git_out(repo: &Path, args: &[&str]) -> String {
+    let out = git_cmd(repo, args).output().expect("spawn git");
+    assert!(
+        out.status.success(),
+        "git {:?} failed in {}: {}",
+        args,
+        repo.display(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+/// Initialize a bare-ish "origin" repo on `main` with one seed commit; return
+/// (repo_path, seed_sha).
+fn init_origin(dir: &Path) -> (PathBuf, String) {
+    std::fs::create_dir_all(dir).unwrap();
+    git_run(dir, &["init", "--initial-branch=main", "--quiet"]);
+    git_run(dir, &["config", "user.email", "t@e.com"]);
+    git_run(dir, &["config", "user.name", "t"]);
+    git_run(dir, &["config", "commit.gpgsign", "false"]);
+    std::fs::write(dir.join("VERSION"), "c1\n").unwrap();
+    git_run(dir, &["add", "VERSION"]);
+    git_run(dir, &["commit", "-m", "c1", "--quiet"]);
+    let sha = git_out(dir, &["rev-parse", "HEAD"]);
+    (dir.to_path_buf(), sha)
+}
+
+/// Add a second commit on `main` in `origin` and return its sha (the "merged
+/// head" a stale clone has not yet fetched).
+fn add_merged_commit(origin: &Path) -> String {
+    std::fs::write(origin.join("VERSION"), "c2\n").unwrap();
+    git_run(origin, &["add", "VERSION"]);
+    git_run(origin, &["commit", "-m", "c2 (merged head)", "--quiet"]);
+    git_out(origin, &["rev-parse", "HEAD"])
+}
+
+/// Clone `origin` into `dest` (local path => offline). The clone's `origin`
+/// remote points at the local origin path.
+fn clone_local(origin: &Path, dest: &Path) {
+    let parent = dest.parent().unwrap();
+    std::fs::create_dir_all(parent).unwrap();
+    let out = git_cmd(parent, &["clone", "--quiet"])
+        .arg(origin)
+        .arg(dest)
+        .output()
+        .expect("spawn git clone");
+    assert!(
+        out.status.success(),
+        "git clone failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Warm target dir (fix #2): persistent, under state root, not PID/temp,
+// reaper-safe name.
+// ---------------------------------------------------------------------------
+
+#[test]
+#[serial_test::serial(simard_state_root_env, cognitive_memory)]
+fn self_deploy_dirs_resolve_under_state_root_honoring_env() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _g = EnvGuard::set(STATE_ROOT_ENV, tmp.path());
+
+    assert_eq!(
+        self_deploy_target_dir(),
+        tmp.path().join(SELF_DEPLOY_TARGET_DIRNAME),
+        "warm target dir must be <SIMARD_STATE_ROOT>/{SELF_DEPLOY_TARGET_DIRNAME}"
+    );
+    assert_eq!(
+        self_deploy_src_dir(),
+        tmp.path().join(SELF_DEPLOY_SRC_DIRNAME),
+        "source checkout dir must be <SIMARD_STATE_ROOT>/{SELF_DEPLOY_SRC_DIRNAME}"
+    );
+}
+
+#[test]
+#[serial_test::serial(simard_state_root_env, cognitive_memory)]
+fn warm_target_dir_is_persistent_not_pid_keyed_and_under_state_root() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _g = EnvGuard::set(STATE_ROOT_ENV, tmp.path());
+
+    let a = self_deploy_target_dir();
+    let b = self_deploy_target_dir();
+    assert_eq!(
+        a, b,
+        "warm target dir must be stable across calls (persistent)"
+    );
+
+    assert!(
+        a.starts_with(simard_state_root()),
+        "warm target dir {} must live under the durable state root",
+        a.display()
+    );
+
+    // The whole point of fix #2: NOT the old per-PID cold temp dir.
+    let pid = std::process::id().to_string();
+    assert!(
+        !a.to_string_lossy().contains(&pid),
+        "warm target dir must NOT be PID-keyed, got: {}",
+        a.display()
+    );
+    let legacy = crate::self_relaunch::RelaunchConfig::default().canary_target_dir;
+    assert_ne!(
+        a, legacy,
+        "warm target dir must differ from the legacy per-PID temp canary dir"
+    );
+
+    // The whole point of fix #2 is a *durable* warm dir, not the ephemeral
+    // system temp base. The hermetic setup above pins the state root to a
+    // tempdir purely for test isolation (which — per the repo's own
+    // `hermetic_state_root_lives_under_temp_dir` — necessarily lives *under*
+    // env::temp_dir()), so asserting `!a.starts_with(temp_dir())` on `a`
+    // directly would contradict the equality the production resolution
+    // guarantees. Instead assert the property that actually matters: under a
+    // durable (production-shaped, $HOME-based) state root, the warm dir escapes
+    // temp_dir() entirely. (`self_deploy_target_dir()` only computes the path —
+    // nothing is created under $HOME.)
+    let home = std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .expect("HOME is set in the test environment");
+    let _g2 = EnvGuard::set(STATE_ROOT_ENV, &home.join(".simard"));
+    let durable_warm = self_deploy_target_dir();
+    assert_eq!(
+        durable_warm,
+        home.join(".simard").join(SELF_DEPLOY_TARGET_DIRNAME),
+        "under a durable state root the warm dir is <state_root>/{SELF_DEPLOY_TARGET_DIRNAME}"
+    );
+    assert!(
+        !durable_warm.starts_with(std::env::temp_dir()),
+        "durable warm target dir must not live under temp_dir(), got: {}",
+        durable_warm.display()
+    );
+}
+
+#[test]
+#[serial_test::serial(simard_state_root_env, cognitive_memory)]
+fn warm_target_dir_name_does_not_match_any_cleanup_reaper() {
+    // cmd_cleanup/disk.rs reapers match by *name* within their scan roots
+    // (/tmp). The warm dir must not be eligible for deletion. We replicate the
+    // documented predicates and assert the warm dir name matches none.
+    fn matches_tmp_canary_reaper(name: &str) -> bool {
+        name.starts_with("simard-canary")
+            || name.starts_with("simard-e2e")
+            || name.starts_with("simard-")
+            || name.starts_with("amplihack-")
+            || name.starts_with("amplihack_eval")
+            || name.starts_with("ia2-")
+    }
+    fn matches_tmp_target_cap(name: &str) -> bool {
+        name.starts_with("simard-") && name.ends_with("-target")
+    }
+
+    let tmp = tempfile::tempdir().unwrap();
+    let _g = EnvGuard::set(STATE_ROOT_ENV, tmp.path());
+
+    let warm = self_deploy_target_dir();
+    let name = warm
+        .file_name()
+        .expect("warm dir has a final component")
+        .to_string_lossy()
+        .into_owned();
+
+    assert_eq!(name, SELF_DEPLOY_TARGET_DIRNAME);
+    assert!(
+        !matches_tmp_canary_reaper(&name),
+        "warm dir name {name:?} must not match the /tmp canary reaper"
+    );
+    assert!(
+        !matches_tmp_target_cap(&name),
+        "warm dir name {name:?} must not match the /tmp '-target' LRU cap reaper"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// SHA validation (SEC-I2: block leading-'-' option injection into git argv).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn validate_full_sha_accepts_exactly_40_lowercase_hex() {
+    let ok = "abcdef0123456789abcdef0123456789abcdef01";
+    assert_eq!(ok.len(), 40);
+    assert!(
+        validate_full_sha(ok).is_ok(),
+        "a full 40-hex sha must be accepted"
+    );
+}
+
+#[test]
+fn validate_full_sha_rejects_malformed_and_injection() {
+    let bad = [
+        "",                                          // empty
+        "abcdef",                                    // too short
+        "abcdef0123456789abcdef0123456789abcdef0",   // 39
+        "abcdef0123456789abcdef0123456789abcdef012", // 41
+        "ABCDEF0123456789ABCDEF0123456789ABCDEF01",  // uppercase
+        "gbcdef0123456789abcdef0123456789abcdef01",  // non-hex 'g'
+        "-bcdef0123456789abcdef0123456789abcdef01",  // leading '-' (argv option injection)
+        " bcdef0123456789abcdef0123456789abcdef01",  // leading space
+        "deadbeef",                                  // short symbolic-ish
+    ];
+    for s in bad {
+        assert!(
+            validate_full_sha(s).is_err(),
+            "validate_full_sha must reject {s:?}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Origin transport allow-list (SEC-I3: refuse arbitrary-command transports).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn validate_origin_transport_allows_https_and_ssh() {
+    for url in [
+        "https://github.com/rysweet/Simard.git",
+        "ssh://git@github.com/rysweet/Simard.git",
+        "git@github.com:rysweet/Simard.git",
+    ] {
+        assert!(
+            validate_origin_transport(url).is_ok(),
+            "transport must be allowed: {url}"
+        );
+    }
+}
+
+#[test]
+fn validate_origin_transport_rejects_command_transports() {
+    for url in [
+        "ext::sh -c \"touch /tmp/pwned\"",
+        "ext::git-upload-pack",
+        "fd::3",
+    ] {
+        assert!(
+            validate_origin_transport(url).is_err(),
+            "arbitrary-command transport must be rejected: {url}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// prepare(): fetch + checkout the MERGED head, independent of cwd (fix #1).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn prepare_fetches_and_checks_out_merged_head_not_cwd_head() {
+    let root = tempfile::tempdir().unwrap();
+    let origin = root.path().join("origin");
+    let canonical = root.path().join("canonical");
+
+    // origin starts at c1; a stale clone is made; THEN origin advances to c2.
+    let (_origin, _c1) = init_origin(&origin);
+    clone_local(&origin, &canonical);
+    let c2 = add_merged_commit(&origin);
+
+    // The stale clone is still on c1 and has never seen c2.
+    assert_ne!(git_out(&canonical, &["rev-parse", "HEAD"]), c2);
+
+    // Resolution is via the explicit repo (cwd-independent); the test's actual
+    // cwd is the worktree, which is NOT this canonical clone.
+    let preparer = GitSourcePreparer::at(&canonical);
+    let prepared = preparer
+        .prepare(&c2)
+        .expect("prepare must fetch + checkout the merged head");
+
+    assert_eq!(
+        std::fs::canonicalize(&prepared).unwrap(),
+        std::fs::canonicalize(&canonical).unwrap(),
+        "prepare must return the canonical repo (not the cwd checkout)"
+    );
+    assert_ne!(
+        std::fs::canonicalize(&prepared).unwrap(),
+        std::env::current_dir().unwrap(),
+        "the build source must not be the current working directory"
+    );
+    assert_eq!(
+        git_out(&canonical, &["rev-parse", "HEAD"]),
+        c2,
+        "prepared repo HEAD must be the merged head c2"
+    );
+    // Detached HEAD at the exact merged commit (so SIMARD_GIT_HASH == c2).
+    assert!(
+        !git_cmd(&canonical, &["symbolic-ref", "-q", "HEAD"])
+            .status()
+            .unwrap()
+            .success(),
+        "HEAD must be detached at the merged commit"
+    );
+}
+
+#[test]
+fn prepare_is_loud_when_target_commit_is_absent_no_cwd_fallback() {
+    let root = tempfile::tempdir().unwrap();
+    let origin = root.path().join("origin");
+    let canonical = root.path().join("canonical");
+    init_origin(&origin);
+    clone_local(&origin, &canonical);
+
+    // A syntactically valid 40-hex sha that does not exist in the repo.
+    let absent = "0".repeat(40);
+    let err = GitSourcePreparer::at(&canonical)
+        .prepare(&absent)
+        .expect_err("an unavailable merged commit must fail loudly, not fall back");
+    assert!(
+        matches!(
+            err,
+            SafeUpdateError::CheckoutFailed { .. }
+                | SafeUpdateError::FetchFailed { .. }
+                | SafeUpdateError::SourceResolveFailed { .. }
+        ),
+        "expected a loud source/fetch/checkout error, got: {err:?}"
+    );
+}
+
+#[test]
+fn prepare_rejects_non_full_sha_before_touching_git() {
+    let root = tempfile::tempdir().unwrap();
+    let origin = root.path().join("origin");
+    let canonical = root.path().join("canonical");
+    init_origin(&origin);
+    clone_local(&origin, &canonical);
+
+    // Option-injection attempt; a valid repo so the ONLY reason to fail is the
+    // bad SHA being rejected up front.
+    let err = GitSourcePreparer::at(&canonical)
+        .prepare("--upload-pack=touch /tmp/pwned")
+        .expect_err("a non-40-hex target must be rejected before any git call");
+    assert!(
+        !matches!(err, SafeUpdateError::BuildFailed { .. }),
+        "rejection must happen during source prep, never reach a build: {err:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// resolve_repo(): SIMARD_SELF_DEPLOY_REPO override precedence + validation,
+// never a cwd fallback.
+// ---------------------------------------------------------------------------
+
+#[test]
+#[serial_test::serial(simard_self_deploy_repo)]
+fn resolve_repo_env_override_wins_when_valid() {
+    let root = tempfile::tempdir().unwrap();
+    let origin = root.path().join("origin");
+    let canonical = root.path().join("canonical");
+    init_origin(&origin);
+    clone_local(&origin, &canonical);
+
+    let _g = EnvGuard::set(SELF_DEPLOY_REPO_ENV, &canonical);
+    let resolved = GitSourcePreparer::new()
+        .resolve_repo()
+        .expect("a valid SIMARD_SELF_DEPLOY_REPO must resolve");
+    assert_eq!(
+        std::fs::canonicalize(&resolved).unwrap(),
+        std::fs::canonicalize(&canonical).unwrap(),
+        "SIMARD_SELF_DEPLOY_REPO must win the resolution precedence"
+    );
+    assert_ne!(
+        std::fs::canonicalize(&resolved).unwrap(),
+        std::env::current_dir().unwrap(),
+        "resolution must never fall back to cwd"
+    );
+}
+
+#[test]
+#[serial_test::serial(simard_self_deploy_repo)]
+fn resolve_repo_rejects_invalid_env_override_without_cwd_fallback() {
+    // A path-traversal value and a non-repo path must both be rejected loudly,
+    // never silently resolving to the current working directory.
+    let traversal = PathBuf::from("/tmp/../tmp/not-a-real-self-deploy-repo-2467");
+    let _g = EnvGuard::set(SELF_DEPLOY_REPO_ENV, &traversal);
+    let err = GitSourcePreparer::new()
+        .resolve_repo()
+        .expect_err("a '..'-bearing SIMARD_SELF_DEPLOY_REPO must be rejected");
+    assert!(
+        matches!(err, SafeUpdateError::SourceResolveFailed { .. }),
+        "invalid override must surface SourceResolveFailed, got: {err:?}"
+    );
+
+    let not_a_repo = tempfile::tempdir().unwrap();
+    let _g2 = EnvGuard::set(SELF_DEPLOY_REPO_ENV, not_a_repo.path());
+    let err2 = GitSourcePreparer::new()
+        .resolve_repo()
+        .expect_err("a non-git-work-tree SIMARD_SELF_DEPLOY_REPO must be rejected");
+    assert!(
+        matches!(err2, SafeUpdateError::SourceResolveFailed { .. }),
+        "non-repo override must surface SourceResolveFailed, got: {err2:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// prepare_and_build(): the orchestrator's step-1 composition. A prep failure
+// must propagate BEFORE any build (and a fortiori before daemon mutation), and
+// prep must be asked for the exact target merged commit.
+// ---------------------------------------------------------------------------
+
+/// Records the target commit it was asked to prepare and returns a chosen
+/// outcome — never touches git or the filesystem.
+struct RecordingPreparer {
+    asked: Mutex<Vec<String>>,
+    outcome: Result<PathBuf, ()>,
+}
+
+impl RecordingPreparer {
+    fn failing() -> Self {
+        Self {
+            asked: Mutex::new(Vec::new()),
+            outcome: Err(()),
+        }
+    }
+}
+
+impl SelfDeploySourcePreparer for RecordingPreparer {
+    fn prepare(&self, target_commit: &str) -> Result<PathBuf, SafeUpdateError> {
+        self.asked.lock().unwrap().push(target_commit.to_string());
+        match &self.outcome {
+            Ok(p) => Ok(p.clone()),
+            Err(()) => Err(SafeUpdateError::FetchFailed {
+                detail: "fake: offline".to_string(),
+            }),
+        }
+    }
+}
+
+#[test]
+fn prepare_and_build_propagates_prepare_failure_before_building() {
+    let warm = tempfile::tempdir().unwrap();
+    let fake = RecordingPreparer::failing();
+    let sha = "abcdef0123456789abcdef0123456789abcdef01";
+
+    let err = prepare_and_build(&fake, sha, warm.path())
+        .expect_err("a failed source prep must abort the build");
+    assert!(
+        matches!(err, SafeUpdateError::FetchFailed { .. }),
+        "prep failure must propagate untransformed, got: {err:?}"
+    );
+
+    // No build was attempted: the warm target has no release artifact.
+    assert!(
+        !warm.path().join("release").join("simard").exists(),
+        "build must NOT run after a prep failure (no cwd-HEAD fallback)"
+    );
+}
+
+#[test]
+fn prepare_and_build_asks_to_prepare_the_target_merged_commit() {
+    let warm = tempfile::tempdir().unwrap();
+    let fake = RecordingPreparer::failing();
+    let sha = "0123456789abcdef0123456789abcdef01234567";
+
+    let _ = prepare_and_build(&fake, sha, warm.path());
+
+    let asked = fake.asked.lock().unwrap();
+    assert_eq!(
+        asked.as_slice(),
+        &[sha.to_string()],
+        "prepare_and_build must request exactly the target merged commit"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// build_self_deploy_candidate(): builds the prepared repo into the WARM target
+// dir; loud on failure. (Mirrors self_relaunch::build_canary's failure test —
+// no full project compile.)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn build_self_deploy_candidate_creates_warm_dir_and_fails_loudly_on_bad_repo() {
+    let warm =
+        std::env::temp_dir().join(format!("simard-sd-warm-build-test-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&warm);
+    let bogus_repo = PathBuf::from("/tmp/no-such-self-deploy-repo-for-2467-test");
+
+    let res = build_self_deploy_candidate(&bogus_repo, &warm);
+
+    assert!(
+        warm.exists(),
+        "build_self_deploy_candidate must create the warm target dir"
+    );
+    assert!(
+        res.is_err(),
+        "a missing source manifest must make the build fail loudly"
+    );
+    let _ = std::fs::remove_dir_all(&warm);
+}

--- a/src/self_deploy/tests_source_prep.rs
+++ b/src/self_deploy/tests_source_prep.rs
@@ -670,6 +670,29 @@ fn resolve_existing_repo_is_none_and_never_clones_without_a_canonical_source() {
     );
 }
 
+#[test]
+#[serial_test::serial(simard_state_root_env, simard_self_deploy_repo, cognitive_memory)]
+fn resolve_existing_repo_rejects_invalid_override_without_clone_or_error() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _state = EnvGuard::set(STATE_ROOT_ENV, tmp.path());
+
+    // A present-but-invalid override (path traversal) must be rejected by
+    // `validate_repo_path`. A read-only `--check` tolerates it by degrading to a
+    // cwd report (None) — loudly on stderr — rather than erroring or, worse,
+    // silently building from an unvalidated path.
+    let _override = EnvGuard::set(SELF_DEPLOY_REPO_ENV, Path::new("/tmp/../etc"));
+
+    assert!(
+        GitSourcePreparer::new().resolve_existing_repo().is_none(),
+        "an invalid override must resolve to None (cwd fallback), never bypass validation"
+    );
+    // It must not create the persistent checkout as a side effect either.
+    assert!(
+        !self_deploy_src_dir().exists(),
+        "rejecting an invalid override must remain read-only (no persistent checkout created)"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // prepare_and_build(): the orchestrator's step-1 composition. A prep failure
 // must propagate BEFORE any build (and a fortiori before daemon mutation), and

--- a/src/self_deploy/tests_source_prep.rs
+++ b/src/self_deploy/tests_source_prep.rs
@@ -473,7 +473,7 @@ fn prepare_rejects_non_full_sha_before_touching_git() {
 // ---------------------------------------------------------------------------
 
 #[test]
-#[serial_test::serial(simard_self_deploy_repo)]
+#[serial_test::serial(simard_self_deploy_repo, cognitive_memory)]
 fn resolve_repo_env_override_wins_when_valid() {
     let root = tempfile::tempdir().unwrap();
     let origin = root.path().join("origin");
@@ -498,7 +498,7 @@ fn resolve_repo_env_override_wins_when_valid() {
 }
 
 #[test]
-#[serial_test::serial(simard_self_deploy_repo)]
+#[serial_test::serial(simard_self_deploy_repo, cognitive_memory)]
 fn resolve_repo_rejects_invalid_env_override_without_cwd_fallback() {
     // A path-traversal value and a non-repo path must both be rejected loudly,
     // never silently resolving to the current working directory.

--- a/src/self_deploy/tests_source_prep.rs
+++ b/src/self_deploy/tests_source_prep.rs
@@ -228,9 +228,16 @@ fn warm_target_dir_is_persistent_not_pid_keyed_and_under_state_root() {
 #[test]
 #[serial_test::serial(simard_state_root_env, cognitive_memory)]
 fn warm_target_dir_name_does_not_match_any_cleanup_reaper() {
-    // cmd_cleanup/disk.rs reapers match by *name* within their scan roots
-    // (/tmp). The warm dir must not be eligible for deletion. We replicate the
-    // documented predicates and assert the warm dir name matches none.
+    // The cleanup reapers in cmd_cleanup/disk.rs match by *name*. Two scan over
+    // a /tmp base (replicated below); the only reaper whose base actually
+    // contains the warm/src dirs is `remove_old_corrupt_dbs`, which scans the
+    // `~/.simard` top level via the real `is_corrupt_quarantine_name` predicate.
+    // The other two `~/.simard` reapers (`rotate_simard_binary_backups`,
+    // `trim_simard_snapshots`) scan the `bin/` and `snapshots/` *subdirectories*,
+    // so a top-level `self-deploy-*` sibling is structurally outside their reach.
+    // Assert non-overlap against the **real** predicate (not a local copy) so
+    // this is a genuine regression guard: if a future change broadened the
+    // `~/.simard` reaper to match `self-deploy-*`, this test fails.
     fn matches_tmp_canary_reaper(name: &str) -> bool {
         name.starts_with("simard-canary")
             || name.starts_with("simard-e2e")
@@ -246,21 +253,47 @@ fn warm_target_dir_name_does_not_match_any_cleanup_reaper() {
     let tmp = tempfile::tempdir().unwrap();
     let _g = EnvGuard::set(STATE_ROOT_ENV, tmp.path());
 
-    let warm = self_deploy_target_dir();
-    let name = warm
-        .file_name()
-        .expect("warm dir has a final component")
-        .to_string_lossy()
-        .into_owned();
+    // Both new persistent dirs that live directly under the state root.
+    for dir in [self_deploy_target_dir(), self_deploy_src_dir()] {
+        let name = dir
+            .file_name()
+            .expect("dir has a final component")
+            .to_string_lossy()
+            .into_owned();
 
-    assert_eq!(name, SELF_DEPLOY_TARGET_DIRNAME);
-    assert!(
-        !matches_tmp_canary_reaper(&name),
-        "warm dir name {name:?} must not match the /tmp canary reaper"
-    );
-    assert!(
-        !matches_tmp_target_cap(&name),
-        "warm dir name {name:?} must not match the /tmp '-target' LRU cap reaper"
+        assert!(
+            !matches_tmp_canary_reaper(&name),
+            "dir name {name:?} must not match the /tmp canary reaper"
+        );
+        assert!(
+            !matches_tmp_target_cap(&name),
+            "dir name {name:?} must not match the /tmp '-target' LRU cap reaper"
+        );
+        // The real `~/.simard` top-level reaper predicate (the one whose scan
+        // base actually contains these dirs).
+        assert!(
+            !crate::cmd_cleanup::is_corrupt_quarantine_name(&name),
+            "dir name {name:?} must not match the ~/.simard corrupt-quarantine reaper \
+             (remove_old_corrupt_dbs)"
+        );
+        // Not the fixed `bin`/`snapshots` subdir names the other ~/.simard
+        // reapers scan into.
+        assert_ne!(
+            name, "bin",
+            "must not collide with the binary-backup subdir"
+        );
+        assert_ne!(
+            name, "snapshots",
+            "must not collide with the snapshots subdir"
+        );
+    }
+
+    assert_eq!(
+        self_deploy_target_dir()
+            .file_name()
+            .unwrap()
+            .to_string_lossy(),
+        SELF_DEPLOY_TARGET_DIRNAME
     );
 }
 
@@ -728,8 +761,12 @@ impl SelfDeploySourcePreparer for RecordingPreparer {
 }
 
 #[test]
+#[serial_test::serial(simard_state_root_env, cognitive_memory)]
 fn prepare_and_build_propagates_prepare_failure_before_building() {
     let warm = tempfile::tempdir().unwrap();
+    // Pin the state root (and thus the host-wide build lock at
+    // <state_root>/cargo_build.lock) into the tempdir so this stays hermetic.
+    let _state = EnvGuard::set(STATE_ROOT_ENV, warm.path());
     let fake = RecordingPreparer::failing();
     let sha = "abcdef0123456789abcdef0123456789abcdef01";
 
@@ -748,8 +785,10 @@ fn prepare_and_build_propagates_prepare_failure_before_building() {
 }
 
 #[test]
+#[serial_test::serial(simard_state_root_env, cognitive_memory)]
 fn prepare_and_build_asks_to_prepare_the_target_merged_commit() {
     let warm = tempfile::tempdir().unwrap();
+    let _state = EnvGuard::set(STATE_ROOT_ENV, warm.path());
     let fake = RecordingPreparer::failing();
     let sha = "0123456789abcdef0123456789abcdef01234567";
 
@@ -760,6 +799,58 @@ fn prepare_and_build_asks_to_prepare_the_target_merged_commit() {
         asked.as_slice(),
         &[sha.to_string()],
         "prepare_and_build must request exactly the target merged commit"
+    );
+}
+
+/// A preparer that records whether the host-wide build lock was already held at
+/// the moment `prepare` runs, then fails fast so no real build is attempted.
+struct LockObservingPreparer {
+    state_root: PathBuf,
+    lock_held_during_prepare: Mutex<Option<bool>>,
+}
+
+impl SelfDeploySourcePreparer for LockObservingPreparer {
+    fn prepare(&self, _target_commit: &str) -> Result<PathBuf, SafeUpdateError> {
+        let held = crate::build_lock::BuildLock::new(&self.state_root).is_locked();
+        *self.lock_held_during_prepare.lock().unwrap() = Some(held);
+        Err(SafeUpdateError::FetchFailed {
+            detail: "fake: stop after observing the lock".to_string(),
+        })
+    }
+}
+
+#[test]
+#[serial_test::serial(simard_state_root_env, cognitive_memory)]
+fn prepare_and_build_holds_build_lock_during_prepare_and_releases_after() {
+    // Issue #2467: the resolve→checkout→build window must be serialized by the
+    // host-wide build lock so two concurrent self-deploys cannot race the shared
+    // source checkout (compile one tree, embed another's SHA). Prove the lock is
+    // (a) held while prepare runs and (b) released once prepare_and_build returns.
+    let warm = tempfile::tempdir().unwrap();
+    let _state = EnvGuard::set(STATE_ROOT_ENV, warm.path());
+
+    // No stale lock to start.
+    assert!(
+        !crate::build_lock::BuildLock::new(warm.path()).is_locked(),
+        "precondition: build lock must be free before prepare_and_build"
+    );
+
+    let fake = LockObservingPreparer {
+        state_root: warm.path().to_path_buf(),
+        lock_held_during_prepare: Mutex::new(None),
+    };
+    let sha = "abcdef0123456789abcdef0123456789abcdef01";
+
+    let _ = prepare_and_build(&fake, sha, warm.path());
+
+    assert_eq!(
+        *fake.lock_held_during_prepare.lock().unwrap(),
+        Some(true),
+        "the build lock must be held while the source checkout runs"
+    );
+    assert!(
+        !crate::build_lock::BuildLock::new(warm.path()).is_locked(),
+        "the build lock must be released (RAII) once prepare_and_build returns"
     );
 }
 

--- a/src/self_deploy/tests_source_prep.rs
+++ b/src/self_deploy/tests_source_prep.rs
@@ -27,8 +27,8 @@ use crate::state_root::{STATE_ROOT_ENV, simard_state_root};
 
 use super::source_prep::{
     GitSourcePreparer, SELF_DEPLOY_SRC_DIRNAME, SELF_DEPLOY_TARGET_DIRNAME,
-    SelfDeploySourcePreparer, prepare_and_build, self_deploy_src_dir, self_deploy_target_dir,
-    validate_full_sha, validate_origin_transport,
+    SelfDeploySourcePreparer, prepare_and_build, redact_credentials, self_deploy_src_dir,
+    self_deploy_target_dir, validate_full_sha, validate_origin_transport,
 };
 
 const SELF_DEPLOY_REPO_ENV: &str = "SIMARD_SELF_DEPLOY_REPO";
@@ -329,6 +329,62 @@ fn validate_origin_transport_rejects_command_transports() {
             "arbitrary-command transport must be rejected: {url}"
         );
     }
+}
+
+// ---------------------------------------------------------------------------
+// Credential redaction in surfaced errors (SEC-D2: never leak a token in a
+// git error / log / PR). The project uses token-bearing remotes, so a fetch or
+// clone failure must not echo `https://<token>@host` to the operator.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn redact_credentials_strips_userinfo_from_urls() {
+    let cases = [
+        (
+            "https://x-access-token:ghp_SECRET123@github.com/rysweet/Simard.git",
+            "https://***@github.com/rysweet/Simard.git",
+        ),
+        (
+            "ssh://git:p4ssw0rd@github.com/rysweet/Simard.git",
+            "ssh://***@github.com/rysweet/Simard.git",
+        ),
+        (
+            "fatal: unable to access 'https://user:tok@github.com/o/r/': 403",
+            "fatal: unable to access 'https://***@github.com/o/r/': 403",
+        ),
+    ];
+    for (raw, want) in cases {
+        let got = redact_credentials(raw);
+        assert_eq!(got, want, "redaction mismatch for {raw:?}");
+        assert!(
+            !got.contains("ghp_SECRET123") && !got.contains("p4ssw0rd") && !got.contains(":tok@"),
+            "token must not survive redaction: {got:?}"
+        );
+    }
+}
+
+#[test]
+fn redact_credentials_leaves_tokenless_and_plain_text_unchanged() {
+    for s in [
+        "https://github.com/rysweet/Simard.git",
+        "git@github.com:rysweet/Simard.git",
+        "git [\"fetch\", \"origin\"] failed in /home/op/.simard/self-deploy-src: timeout",
+        "no urls here at all",
+    ] {
+        assert_eq!(
+            redact_credentials(s),
+            s,
+            "must pass through unchanged: {s:?}"
+        );
+    }
+}
+
+#[test]
+fn redact_credentials_handles_multiple_urls() {
+    let raw = "from https://a:b@h1/x to https://c:d@h2/y";
+    let got = redact_credentials(raw);
+    assert_eq!(got, "from https://***@h1/x to https://***@h2/y");
+    assert!(!got.contains("a:b@") && !got.contains("c:d@"));
 }
 
 // ---------------------------------------------------------------------------

--- a/src/self_relaunch/canary.rs
+++ b/src/self_relaunch/canary.rs
@@ -50,6 +50,82 @@ pub fn build_canary(config: &RelaunchConfig) -> SimardResult<PathBuf> {
     Ok(binary_path)
 }
 
+/// Build a self-deploy candidate binary from an **already-prepared** source
+/// checkout into a **persistent warm** target directory (issue #2467).
+///
+/// This is the [`build_canary`] sibling used by the autonomous self-deploy
+/// path. Where [`build_canary`] builds the on-disk cwd checkout
+/// (`manifest_dir = "."`) into a fresh per-PID `temp_dir()` target — forcing a
+/// cold from-scratch compile every run — this builds `repo`'s `Cargo.toml`
+/// into the caller-provided, reusable `target_dir` (e.g.
+/// `crate::self_deploy::self_deploy_target_dir()`), so repeated self-deploys
+/// are incremental (~2–3 min) instead of cold (~10+ min).
+///
+/// `repo` is expected to already be checked out at the target merged commit by
+/// a [`crate::self_deploy::SelfDeploySourcePreparer`]; this function does not
+/// touch git. [`build_canary`] and [`RelaunchConfig`]'s defaults are left
+/// byte-for-byte unchanged.
+///
+/// Contract: creates `target_dir` if absent, runs `cargo build --release`
+/// against `repo/Cargo.toml` into `target_dir`, and returns
+/// `target_dir/release/simard` on success. Any build failure is surfaced
+/// loudly (never a silent success).
+pub fn build_self_deploy_candidate(repo: &Path, target_dir: &Path) -> SimardResult<PathBuf> {
+    std::fs::create_dir_all(target_dir).map_err(|e| SimardError::PersistentStoreIo {
+        store: "self-deploy-build".to_string(),
+        action: "create warm target directory".to_string(),
+        path: target_dir.to_path_buf(),
+        reason: e.to_string(),
+    })?;
+
+    let output = Command::new("cargo")
+        .arg("build")
+        .arg("--release")
+        .arg("--target-dir")
+        .arg(target_dir)
+        .arg("--manifest-path")
+        .arg(repo.join("Cargo.toml"))
+        .env("CARGO_BUILD_JOBS", crate::cargo_jobs::cargo_jobs())
+        // Neutralize ambient git-repo redirection (issue #2467). Cargo runs
+        // `build.rs` in the package root (`repo`), where it derives
+        // `SIMARD_GIT_HASH` from `git rev-parse HEAD`. A stray `GIT_DIR` /
+        // `GIT_WORK_TREE` in the daemon's environment would redirect that read
+        // to a different repo and embed the wrong commit — defeating the
+        // post-deploy `version_advanced` integrity gate (which compares the
+        // embedded SHA to `target_commit`). Remove only the git-redirection
+        // vars; the rest of the env (PATH/HOME/CARGO_*/RUSTUP_*) is required for
+        // the build to run.
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
+        .env_remove("GIT_COMMON_DIR")
+        .env_remove("GIT_OBJECT_DIRECTORY")
+        .output()
+        .map_err(|e| SimardError::BridgeSpawnFailed {
+            bridge: "self-deploy-build".to_string(),
+            reason: format!("cargo build failed to start: {e}"),
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(SimardError::BridgeCallFailed {
+            bridge: "self-deploy-build".to_string(),
+            method: "cargo build --release".to_string(),
+            reason: format!("build failed (exit {}): {}", output.status, stderr),
+        });
+    }
+
+    let binary_path = target_dir.join("release").join("simard");
+    if !binary_path.exists() {
+        return Err(SimardError::ArtifactIo {
+            path: binary_path,
+            reason: "self-deploy candidate binary not found after successful build".to_string(),
+        });
+    }
+
+    Ok(binary_path)
+}
+
 /// Validate preconditions and hand over execution to the canary binary.
 ///
 /// On Unix, this uses `CommandExt::exec()` to replace the current process

--- a/src/self_relaunch/canary.rs
+++ b/src/self_relaunch/canary.rs
@@ -5,35 +5,53 @@ use super::types::RelaunchConfig;
 use crate::error::{SimardError, SimardResult};
 use crate::self_relaunch_semaphore::{HandoffConfig, HandoffResult, LeaderSemaphore};
 
-/// Build a canary binary via `cargo build --release` in a separate target directory.
-pub fn build_canary(config: &RelaunchConfig) -> SimardResult<PathBuf> {
-    let target_dir = &config.canary_target_dir;
-
+/// Shared `cargo build --release` driver for the canary and self-deploy build
+/// paths.
+///
+/// Creates `target_dir`, builds `manifest_path` into it, and returns the
+/// resulting `target_dir/release/simard` artifact. `label` names the operation
+/// in any surfaced error (e.g. `"canary-build"`). When `neutralize_git_env` is
+/// set, the ambient git-redirection vars (`GIT_DIR`, `GIT_WORK_TREE`, …) are
+/// stripped so `build.rs` derives `SIMARD_GIT_HASH` from the package's own
+/// checkout instead of a hijacked one. Any failure is surfaced loudly.
+fn run_release_build(
+    label: &str,
+    target_dir: &Path,
+    manifest_path: &Path,
+    neutralize_git_env: bool,
+) -> SimardResult<PathBuf> {
     std::fs::create_dir_all(target_dir).map_err(|e| SimardError::PersistentStoreIo {
-        store: "canary-build".to_string(),
+        store: label.to_string(),
         action: "create target directory".to_string(),
-        path: target_dir.clone(),
+        path: target_dir.to_path_buf(),
         reason: e.to_string(),
     })?;
 
-    let output = Command::new("cargo")
-        .arg("build")
+    let mut cmd = Command::new("cargo");
+    cmd.arg("build")
         .arg("--release")
         .arg("--target-dir")
         .arg(target_dir)
         .arg("--manifest-path")
-        .arg(config.manifest_dir.join("Cargo.toml"))
-        .env("CARGO_BUILD_JOBS", crate::cargo_jobs::cargo_jobs())
-        .output()
-        .map_err(|e| SimardError::BridgeSpawnFailed {
-            bridge: "canary-build".to_string(),
-            reason: format!("cargo build failed to start: {e}"),
-        })?;
+        .arg(manifest_path)
+        .env("CARGO_BUILD_JOBS", crate::cargo_jobs::cargo_jobs());
+    if neutralize_git_env {
+        cmd.env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
+            .env_remove("GIT_COMMON_DIR")
+            .env_remove("GIT_OBJECT_DIRECTORY");
+    }
+
+    let output = cmd.output().map_err(|e| SimardError::BridgeSpawnFailed {
+        bridge: label.to_string(),
+        reason: format!("cargo build failed to start: {e}"),
+    })?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(SimardError::BridgeCallFailed {
-            bridge: "canary-build".to_string(),
+            bridge: label.to_string(),
             method: "cargo build --release".to_string(),
             reason: format!("build failed (exit {}): {}", output.status, stderr),
         });
@@ -43,11 +61,21 @@ pub fn build_canary(config: &RelaunchConfig) -> SimardResult<PathBuf> {
     if !binary_path.exists() {
         return Err(SimardError::ArtifactIo {
             path: binary_path,
-            reason: "canary binary not found after successful build".to_string(),
+            reason: format!("{label} binary not found after successful build"),
         });
     }
 
     Ok(binary_path)
+}
+
+/// Build a canary binary via `cargo build --release` in a separate target directory.
+pub fn build_canary(config: &RelaunchConfig) -> SimardResult<PathBuf> {
+    run_release_build(
+        "canary-build",
+        &config.canary_target_dir,
+        &config.manifest_dir.join("Cargo.toml"),
+        false,
+    )
 }
 
 /// Build a self-deploy candidate binary from an **already-prepared** source
@@ -71,59 +99,21 @@ pub fn build_canary(config: &RelaunchConfig) -> SimardResult<PathBuf> {
 /// `target_dir/release/simard` on success. Any build failure is surfaced
 /// loudly (never a silent success).
 pub fn build_self_deploy_candidate(repo: &Path, target_dir: &Path) -> SimardResult<PathBuf> {
-    std::fs::create_dir_all(target_dir).map_err(|e| SimardError::PersistentStoreIo {
-        store: "self-deploy-build".to_string(),
-        action: "create warm target directory".to_string(),
-        path: target_dir.to_path_buf(),
-        reason: e.to_string(),
-    })?;
-
-    let output = Command::new("cargo")
-        .arg("build")
-        .arg("--release")
-        .arg("--target-dir")
-        .arg(target_dir)
-        .arg("--manifest-path")
-        .arg(repo.join("Cargo.toml"))
-        .env("CARGO_BUILD_JOBS", crate::cargo_jobs::cargo_jobs())
-        // Neutralize ambient git-repo redirection (issue #2467). Cargo runs
-        // `build.rs` in the package root (`repo`), where it derives
-        // `SIMARD_GIT_HASH` from `git rev-parse HEAD`. A stray `GIT_DIR` /
-        // `GIT_WORK_TREE` in the daemon's environment would redirect that read
-        // to a different repo and embed the wrong commit — defeating the
-        // post-deploy `version_advanced` integrity gate (which compares the
-        // embedded SHA to `target_commit`). Remove only the git-redirection
-        // vars; the rest of the env (PATH/HOME/CARGO_*/RUSTUP_*) is required for
-        // the build to run.
-        .env_remove("GIT_DIR")
-        .env_remove("GIT_WORK_TREE")
-        .env_remove("GIT_INDEX_FILE")
-        .env_remove("GIT_COMMON_DIR")
-        .env_remove("GIT_OBJECT_DIRECTORY")
-        .output()
-        .map_err(|e| SimardError::BridgeSpawnFailed {
-            bridge: "self-deploy-build".to_string(),
-            reason: format!("cargo build failed to start: {e}"),
-        })?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(SimardError::BridgeCallFailed {
-            bridge: "self-deploy-build".to_string(),
-            method: "cargo build --release".to_string(),
-            reason: format!("build failed (exit {}): {}", output.status, stderr),
-        });
-    }
-
-    let binary_path = target_dir.join("release").join("simard");
-    if !binary_path.exists() {
-        return Err(SimardError::ArtifactIo {
-            path: binary_path,
-            reason: "self-deploy candidate binary not found after successful build".to_string(),
-        });
-    }
-
-    Ok(binary_path)
+    // Neutralize ambient git-repo redirection (issue #2467). Cargo runs
+    // `build.rs` in the package root (`repo`), where it derives
+    // `SIMARD_GIT_HASH` from `git rev-parse HEAD`. A stray `GIT_DIR` /
+    // `GIT_WORK_TREE` in the daemon's environment would redirect that read to a
+    // different repo and embed the wrong commit — defeating the post-deploy
+    // `version_advanced` integrity gate (which compares the embedded SHA to
+    // `target_commit`). The rest of the env (PATH/HOME/CARGO_*/RUSTUP_*) is
+    // required for the build to run, so only the git-redirection vars are
+    // stripped.
+    run_release_build(
+        "self-deploy-build",
+        target_dir,
+        &repo.join("Cargo.toml"),
+        true,
+    )
 }
 
 /// Validate preconditions and hand over execution to the canary binary.

--- a/src/self_relaunch/mod.rs
+++ b/src/self_relaunch/mod.rs
@@ -11,7 +11,7 @@ mod gates;
 mod types;
 
 // Re-export all public items so `crate::self_relaunch::X` still works.
-pub use canary::{build_canary, coordinated_relaunch, handover};
+pub use canary::{build_canary, build_self_deploy_candidate, coordinated_relaunch, handover};
 pub use gates::{all_gates_passed, verify_canary};
 pub use types::{GateResult, RelaunchConfig, RelaunchGate, default_gates};
 

--- a/tests/cli_golden.rs
+++ b/tests/cli_golden.rs
@@ -102,7 +102,7 @@ fn version_string_is_semver() {
             .unwrap_or_else(|_| panic!("non-numeric version component '{part}' in {VERSION}"));
     }
     assert_eq!(
-        VERSION, "0.22.0",
+        VERSION, "0.22.1",
         "bump this assertion when version changes"
     );
 }


### PR DESCRIPTION
## Summary

Fixes `simard self-deploy` so it **builds the merged head from a canonical, cwd-independent source** instead of whatever happens to be in the current working directory. Previously both the build source and (separately) `--check` drift detection keyed off `current_dir()`, so running `self-deploy` from an arbitrary directory could build the wrong tree or skip the fetch entirely.

Closes #2467.

## What changed

- **Canonical repo resolver** (`src/self_deploy/source_prep.rs`): resolves the Simard source with precedence `SIMARD_SELF_DEPLOY_REPO` env override → persistent checkout at `~/.simard/self-deploy-src/` → clone-from-origin. Both merged-SHA resolution and the build operate on this resolved repo, never on cwd.
- **Build the merged head**: `git fetch origin` then `git checkout --detach <merged_sha>` (the SHA from `GitDeploySource::merged_head()`) before `cargo build`, with `--manifest-path` pointed at the resolved clone. Skips the fetch when the commit is already present locally (offline-friendly).
- **Warm, persistent target dir** at `~/.simard/self-deploy-target/` (honoring `SIMARD_STATE_ROOT`), reused across runs for incremental builds and serialized by a build lock. Verified to never overlap any cleanup-reaper scan base.
- **Loud failure**: if the merged SHA cannot be obtained (fetch fails AND object not cached), abort *before* the safety sequence starts — no silent fallback to building cwd HEAD.
- **`--check` parity** (`src/operator_cli/self_deploy.rs`): drift detection is now cwd-independent and fetch-fresh, matching the deploy path; invalid/failed source overrides warn loudly.
- **Additive, backward-compatible**: `RelaunchConfig::Default` and `build_canary` are untouched; new behavior lands via a sibling `build_self_deploy_candidate` and an injectable source-prep trait on `SelfDeployOrchestrator`. The `run_sequence` safety order (build → gate → backup → drain → orphan-reap → swap → restart → health-check → rollback) is unchanged.
- **Security hardening**: full-SHA validation, origin-transport allowlist (rejects command transports / argv injection), and credential redaction in surfaced git errors.

## Tests (hermetic / offline)

29 new `source_prep`/`orchestrator` tests, including:
- `prepare_fetches_and_checks_out_merged_head_not_cwd_head`
- `prepare_is_loud_when_target_commit_is_absent_no_cwd_fallback`
- `prepare_skips_fetch_when_commit_already_present_offline`
- `warm_target_dir_is_persistent_not_pid_keyed_and_under_state_root`
- `warm_target_dir_name_does_not_match_any_cleanup_reaper`
- `resolve_repo` precedence + transport/SHA validation suites

## Verification

- `cargo fmt --all -- --check` ✓
- `cargo clippy --all-targets --all-features --locked -- -D warnings` ✓
- `cargo test --all-features --locked --no-fail-fast` ✓ (7120 passed, 0 failed)
- `cargo build --bin simard --locked` ✓
- `cargo-audit` ✓
- Merged latest `main`; version reconciled to `0.23.1`.

## Out of scope

No live redeploy of the running daemon; no daemon/scheduler auto-trigger; no drift-detection logic rewrite (reuses the SHA `merged_head()` reports); no safety-step refactors.
