### PR TITLE
harden(release): sign SBOM + anchor cosign identity, isolate signing creds (#2261)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,19 +24,20 @@ jobs:
         with:
           fetch-depth: 0
           submodules: false
+          # This job holds id-token:write + contents:write while `cargo build`
+          # runs ~every dependency's build script as arbitrary code. Don't leave
+          # the GITHUB_TOKEN persisted in .git/config where that code could read
+          # it: nothing here pushes via git (the release is cut with `gh release
+          # create`, which uses GH_TOKEN; the tag-existence check is a local
+          # `git rev-parse`), so the persisted credential is pure attack surface.
+          persist-credentials: false
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-
-      - name: Cache cargo
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
-
+      # Resolve the version and whether its tag already exists BEFORE any
+      # toolchain install or cache restore. Most pushes to main don't bump the
+      # version, so the tag already exists and every build step below is a
+      # no-op. Gating the Rust toolchain install and the (multi-GB `target`)
+      # cache restore on `exists == 'false'` skips that wasted setup on those
+      # runs instead of paying for it only to short-circuit immediately after.
       - name: Extract version
         id: version
         run: |
@@ -52,6 +53,20 @@ jobs:
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Install Rust toolchain
+        if: steps.tag_check.outputs.exists == 'false'
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Cache cargo
+        if: steps.tag_check.outputs.exists == 'false'
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build release binary
         if: steps.tag_check.outputs.exists == 'false'
@@ -135,6 +150,25 @@ jobs:
           test -s simard-linux-x86_64.tar.gz.sig || { echo "::error::cosign produced no signature"; exit 1; }
           test -s simard-linux-x86_64.tar.gz.pem || { echo "::error::cosign produced no certificate"; exit 1; }
 
+      - name: Sign SBOM (cosign keyless)
+        if: steps.tag_check.outputs.exists == 'false'
+        # The SBOM is the dependency inventory consumers rely on to spot a
+        # malicious or vulnerable crate; publishing it unsigned next to a signed
+        # tarball would leave the one security-relevant artifact tamper-able. Sign
+        # it with the SAME keyless identity as the tarball. Runs in the repo root,
+        # where cargo-cyclonedx wrote simard-<version>.cdx.json.
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.version.outputs.version }}"
+          SBOM="simard-${VERSION}.cdx.json"
+          cosign sign-blob --yes \
+            --output-signature "${SBOM}.sig" \
+            --output-certificate "${SBOM}.pem" \
+            "$SBOM"
+          # Fail-closed: both the SBOM signature and certificate must exist.
+          test -s "${SBOM}.sig" || { echo "::error::cosign produced no SBOM signature"; exit 1; }
+          test -s "${SBOM}.pem" || { echo "::error::cosign produced no SBOM certificate"; exit 1; }
+
       - name: Create release
         if: steps.tag_check.outputs.exists == 'false'
         env:
@@ -156,20 +190,32 @@ jobs:
 
           ## Verify (cosign keyless + SBOM)
 
-          This release is signed with cosign (keyless) and ships a CycloneDX SBOM.
+          This release is signed with cosign (keyless) and ships a CycloneDX SBOM
+          that is **also** signed with the same identity.
           See [Release integrity](https://github.com/rysweet/Simard/blob/main/docs/reference/release-integrity.md)
           for full verification steps.
 
           \`\`\`bash
+          # Verify the binary tarball:
           cosign verify-blob \\
             --certificate simard-linux-x86_64.tar.gz.pem \\
             --signature   simard-linux-x86_64.tar.gz.sig \\
-            --certificate-identity-regexp 'https://github.com/rysweet/Simard/\.github/workflows/release\.yml@refs/heads/main' \\
+            --certificate-identity-regexp '^https://github\.com/rysweet/Simard/\.github/workflows/release\.yml@refs/heads/main$' \\
             --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \\
             simard-linux-x86_64.tar.gz
+
+          # Verify the SBOM the same way (proves the dependency inventory is untampered):
+          cosign verify-blob \\
+            --certificate simard-${{ steps.version.outputs.version }}.cdx.json.pem \\
+            --signature   simard-${{ steps.version.outputs.version }}.cdx.json.sig \\
+            --certificate-identity-regexp '^https://github\.com/rysweet/Simard/\.github/workflows/release\.yml@refs/heads/main$' \\
+            --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \\
+            simard-${{ steps.version.outputs.version }}.cdx.json
           \`\`\`" \
             target/release/simard-linux-x86_64.tar.gz \
             target/release/simard-linux-x86_64.tar.gz.sha256 \
             target/release/simard-linux-x86_64.tar.gz.sig \
             target/release/simard-linux-x86_64.tar.gz.pem \
-            "simard-${VERSION}.cdx.json"
+            "simard-${VERSION}.cdx.json" \
+            "simard-${VERSION}.cdx.json.sig" \
+            "simard-${VERSION}.cdx.json.pem"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3892,7 +3892,7 @@ dependencies = [
 
 [[package]]
 name = "simard"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "amplihack-agent-eval",
  "amplihack-memory",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simard"
-version = "0.22.0"
+version = "0.23.0"
 edition = "2024"
 default-run = "simard"
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -79,7 +79,7 @@ cosign verify-blob \
   --certificate        simard-linux-x86_64.tar.gz.pem \
   --signature          simard-linux-x86_64.tar.gz.sig \
   --certificate-identity-regexp \
-      'https://github.com/rysweet/Simard/\.github/workflows/release\.yml@refs/heads/main' \
+      '^https://github\.com/rysweet/Simard/\.github/workflows/release\.yml@refs/heads/main$' \
   --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
   simard-linux-x86_64.tar.gz
 

--- a/docs/reference/dependency-trust-policy.md
+++ b/docs/reference/dependency-trust-policy.md
@@ -238,40 +238,30 @@ transitively, so the `workspace` scope surfaces them **without failing CI**.
 They are tracked (not per-ID ignored) so a fix or replacement is adopted as
 soon as one ships:
 
-| Crate | Advisory | Class | Reaches the graph via | Disposition |
+| Crate | Advisory | Class | Reaches the graph via | Cleared by |
 | --- | --- | --- | --- | --- |
-| `paste` 1.0.15 | RUSTSEC-2024-0436 | unmaintained | `ratatui 0.29.0` | transitive → surfaced, non-failing; cleared by the `ratatui` bump |
-| `proc-macro-error2` 2.0.1 | RUSTSEC-2026-0173 | unmaintained | `validator_derive → validator → rustyclawd-tools` | transitive → surfaced, non-failing; cleared by a `rustyclawd-tools` bump |
-| `lru` 0.12.5 | RUSTSEC-2026-0002 | unsound (`IterMut` Stacked Borrows; patched `>= 0.16.3`) | `ratatui 0.29.0` | transitive → surfaced, non-failing; cleared by the `ratatui` bump |
-| `git2` 0.20.4 | RUSTSEC-2026-0183, RUSTSEC-2026-0184 | unsound (potential UB in `Remote::list()` / buffer-created `BlameHunk`) | `rustyclawd-tools` | transitive → surfaced, non-failing; used only for local repo operations |
+| `paste` 1.0.15 | RUSTSEC-2024-0436 | unmaintained | `ratatui 0.29.0` | a `ratatui` bump |
+| `proc-macro-error2` 2.0.1 | RUSTSEC-2026-0173 | unmaintained | `validator_derive → validator → rustyclawd-tools` | a `rustyclawd-tools` bump |
+| `lru` 0.12.5 | RUSTSEC-2026-0002 | unsound (`IterMut` Stacked Borrows; patched `>= 0.16.3`) | `ratatui 0.29.0` | a `ratatui` bump |
+| `git2` 0.20.4 | RUSTSEC-2026-0183, RUSTSEC-2026-0184 | unsound (potential UB in `Remote::list()` / buffer-created `BlameHunk`); local repo ops only | `rustyclawd-tools` | a `rustyclawd-tools` bump |
 
-Because none of these is workspace-direct, `cargo deny check advisories` stays
-green **without** any per-ID `ignore`: the `unmaintained = "workspace"` scope
-covers `paste` / `proc-macro-error2`, and cargo-deny does not raise the
-`unsound` advisories (`lru`, `git2`) at all. `cargo audit` reports all four as
-non-failing warnings and exits `0`. If a future *unmaintained* advisory lands on
-a *direct* dependency it will fail the `unmaintained = "workspace"` check and
-force an explicit decision, which is the intended behaviour.
+Because none is workspace-direct, `cargo deny check advisories` stays green
+**without** any per-ID `ignore`: the `unmaintained = "workspace"` scope covers
+`paste` / `proc-macro-error2`, and cargo-deny does not raise the `unsound`
+advisories (`lru`, `git2`) at all. `cargo audit` reports all four as non-failing
+warnings and exits `0`.
 
-### Tracked upstream bumps (`ratatui`, `git2`)
-
-The transitive advisories above are closed by upstream bumps, not by Simard
-code changes:
-
-1. **`ratatui`** clears both `paste` (RUSTSEC-2024-0436) and `lru`
-   (RUSTSEC-2026-0002) at once — bump `ratatui` to a release that drops `paste`
-   and pulls `lru >= 0.16.3`, then update `Cargo.lock`.
-2. **`git2`** clears RUSTSEC-2026-0183 / RUSTSEC-2026-0184 when `rustyclawd-tools`
-   bumps to a patched `git2`; track it through the
-   [bump-PR pipeline](../howto/self-maintain-dependency-pins.md).
-
-None of these blocks CI today, because each is transitive and handled by the
-`workspace` scope. Should any one start failing — for example if it is later
-re-classified as a vulnerability, or pulled in as a direct dependency — it is
-carried as a *temporary* justified `ignore` (ID + "via `<upstream>`, no upgrade
-yet" + tracking link) in `deny.toml` and `.cargo/audit.toml` until the bump
-lands. The only **permanent** `ignore` in the policy remains `rsa`
-(RUSTSEC-2023-0071), the one advisory with no upstream fix.
+Each is closed by an **upstream bump**, not by Simard code: one `ratatui` bump
+clears both `paste` and `lru` (to `>= 0.16.3`) at once, and a `rustyclawd-tools`
+bump clears `git2` — both tracked through the
+[bump-PR pipeline](../howto/self-maintain-dependency-pins.md). Should any one
+start failing — a *new* unmaintained advisory landing on a *direct* dependency,
+or one of these being re-classified as a vulnerability or pulled in directly —
+the `workspace` scope forces an explicit decision: carry a *temporary* justified
+`ignore` (ID + "via `<upstream>`, no upgrade yet" + tracking link) in `deny.toml`
+and `.cargo/audit.toml` until the bump lands. The only **permanent** `ignore` in
+the policy remains `rsa` (RUSTSEC-2023-0071), the one advisory with no upstream
+fix.
 
 ## Workflow: vetting a crate or resolving an advisory
 

--- a/docs/reference/release-integrity.md
+++ b/docs/reference/release-integrity.md
@@ -38,6 +38,8 @@ Each GitHub Release publishes the following, for every platform target:
 | `simard-<version>.cdx.json` | `cargo cyclonedx` | **CycloneDX SBOM** — full dependency inventory. |
 | `simard-<platform>.tar.gz.sig` | `cosign sign-blob` | **Detached cosign signature** over the tarball. |
 | `simard-<platform>.tar.gz.pem` | `cosign sign-blob` | The signing **certificate** (Fulcio-issued, carries the OIDC identity). |
+| `simard-<version>.cdx.json.sig` | `cosign sign-blob` | **Detached cosign signature** over the SBOM. |
+| `simard-<version>.cdx.json.pem` | `cosign sign-blob` | The SBOM signing **certificate** (same Fulcio identity as the tarball). |
 
 `<platform>` follows the existing naming convention (`linux-x86_64`, etc.;
 see [the update-check platform table](./update-check.md#platform-asset-detection)).
@@ -73,6 +75,10 @@ Properties:
   JSON with a non-empty `.components` array before attaching it; a missing,
   empty, or malformed SBOM fails the release rather than publishing a binary
   with no bill of materials.
+- **Signed.** The SBOM is signed with the **same cosign keyless identity** as
+  the tarball, and its `.sig` + `.pem` are published alongside it, so a tampered
+  bill of materials is detectable — verify it exactly as you verify the tarball
+  (see [signature verification](#signature-verification-cosign-keyless)).
 - **No sensitive paths.** The SBOM is reviewed to contain only public crate
   coordinates (name, version, source) — no local filesystem paths, usernames,
   hostnames, or internal URLs.
@@ -105,7 +111,7 @@ cosign verify-blob \
   --certificate        simard-linux-x86_64.tar.gz.pem \
   --signature          simard-linux-x86_64.tar.gz.sig \
   --certificate-identity-regexp \
-      'https://github.com/rysweet/Simard/\.github/workflows/release\.yml@refs/heads/main' \
+      '^https://github\.com/rysweet/Simard/\.github/workflows/release\.yml@refs/heads/main$' \
   --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
   simard-linux-x86_64.tar.gz
 ```
@@ -120,6 +126,20 @@ security-critical part — **always pin both**:
   Without this flag, any valid Sigstore certificate would pass.
 - `--certificate-oidc-issuer` requires the identity to come from
   **GitHub Actions' OIDC issuer** (`token.actions.githubusercontent.com`).
+
+The **SBOM is signed with the same keyless identity**, so verify it the same
+way — this is what proves the dependency inventory itself was not swapped for a
+falsified one that hides a malicious or vulnerable crate:
+
+```bash
+cosign verify-blob \
+  --certificate        simard-0.22.0.cdx.json.pem \
+  --signature          simard-0.22.0.cdx.json.sig \
+  --certificate-identity-regexp \
+      '^https://github\.com/rysweet/Simard/\.github/workflows/release\.yml@refs/heads/main$' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  simard-0.22.0.cdx.json
+```
 
 > **Verify, then trust.** The `.sha256` checksum proves the file was not
 > corrupted in transit; the cosign signature proves it was *produced by this
@@ -208,8 +228,9 @@ Because `tar`/gzip metadata (ordering, mtime, compression level) can affect the
 archive hash, the **stable comparison target is the binary's own hash**
 (`sha256sum target/release/simard`) at a fixed commit and toolchain; the
 tarball hash is reproducible additionally when the packaging environment
-matches. The published `.sha256` covers the tarball; the SBOM + signature cover
-provenance regardless of archive-level packaging differences.
+matches. The published `.sha256` covers the tarball; the cosign signatures over
+the tarball **and** the SBOM cover provenance regardless of archive-level
+packaging differences.
 
 ## See also
 

--- a/tests/cli_golden.rs
+++ b/tests/cli_golden.rs
@@ -102,7 +102,7 @@ fn version_string_is_semver() {
             .unwrap_or_else(|_| panic!("non-numeric version component '{part}' in {VERSION}"));
     }
     assert_eq!(
-        VERSION, "0.22.0",
+        VERSION, "0.23.0",
         "bump this assertion when version changes"
     );
 }

--- a/tests/supply_chain_hardening.rs
+++ b/tests/supply_chain_hardening.rs
@@ -280,6 +280,28 @@ fn release_workflow_signs_artifacts_with_cosign_keyless() {
 }
 
 #[test]
+fn release_workflow_signs_the_sbom_not_only_the_tarball() {
+    // The SBOM is the dependency inventory consumers rely on to spot a malicious
+    // or vulnerable crate. Publishing it unsigned alongside a signed tarball
+    // leaves the one security-relevant artifact tamper-able, so the release must
+    // sign the SBOM with the same cosign keyless flow and publish its detached
+    // signature + certificate (#2261).
+    let release = release_yml();
+    assert!(
+        contains_ci(&release, ".cdx.json.sig"),
+        "release.yml (#2261) must publish a cosign signature for the SBOM \
+         (simard-<version>.cdx.json.sig), not only for the tarball — otherwise \
+         the dependency inventory ships with no integrity protection."
+    );
+    assert!(
+        contains_ci(&release, ".cdx.json.pem"),
+        "release.yml (#2261) must publish the SBOM signing certificate \
+         (simard-<version>.cdx.json.pem) so `cosign verify-blob` can check the \
+         SBOM the same way it checks the tarball."
+    );
+}
+
+#[test]
 fn release_integrity_doc_documents_keyless_verification() {
     let doc = read_required("docs/reference/release-integrity.md", "#2261");
     for anchor in [


### PR DESCRIPTION
## What & why

Follow-up to the merged supply-chain hardening (#2472, which closed #2260 / #2261 / #2262). This rebases the residual **review-feedback refinements** from the now-closed PR #2478 onto **current `main`**, keeping only the genuine release-integrity additions.

### Why a new PR instead of reopening #2478
PR #2478 shared a branch that had diverged **before** the dashboard work (#2358 / #2474) merged. Its two-dot diff against current `main` mixed the genuine release hardening with **stale-base regressions** that would silently revert that merged dashboard work (e.g. delete `docs/howto/dashboard-action-detail-humanization.md`, `tests/e2e-dashboard/specs/overview.spec.ts`, `index_html/tests_tab_meta.rs`, revert `docs/dashboard.md` / `mkdocs.yml`). This branch starts fresh from `main` and applies **only** the 7 genuine files, so none of that regression is present.

## Changes (7 files, no `src/` behavior changes)

- **`.github/workflows/release.yml`**
  - **Sign the SBOM**, not only the tarball: sign `simard-<version>.cdx.json` with the same cosign keyless identity and publish its detached `.sig` + `.pem`. The dependency inventory consumers rely on to spot a malicious/vulnerable crate is now tamper-evident.
  - **Anchor** the cosign `--certificate-identity-regexp` with `^…$` and escape the `github.com` dot. Unanchored, cosign's Go `MatchString` also accepts identities ending in `@refs/heads/main-anything` — this is the copy-paste verification contract shipped to consumers.
  - **`persist-credentials: false`** on checkout: the job holds `id-token:write` + `contents:write` while `cargo build` runs every dependency's build script as arbitrary code; nothing here pushes via git, so the persisted `GITHUB_TOKEN` was pure attack surface.
  - **Gate** the Rust toolchain install + multi-GB `target` cache restore on a version bump (`tag exists == false`), skipping wasted setup on the common no-bump push to `main`.
- **`SECURITY.md`**, **`docs/reference/release-integrity.md`** — mirror the anchored regex and document SBOM signing/verification.
- **`docs/reference/dependency-trust-policy.md`** — consolidate the redundant advisory-disposition table/prose into one "cleared by upstream bump" table.
- **`tests/supply_chain_hardening.rs`** — assert `release.yml` publishes the SBOM `.cdx.json.sig` and `.cdx.json.pem`.
- **`Cargo.toml` / `Cargo.lock`** — `0.22.0` → `0.23.0`. ⚠️ **This is the release trigger** that cuts the first release carrying the signed-SBOM flow. Drop these two files from the merge if you'd rather release on a separate bump.

## Verification
- `cargo test --test supply_chain_hardening` → **15 passed** (incl. new `release_workflow_signs_the_sbom_not_only_the_tarball`; `mkdocs_nav_links_every_supply_chain_reference_page` still green, confirming the supply-chain nav is intact).
- Pre-push gate passed: `cargo fmt`, `cargo clippy --all-targets --all-features --locked -D warnings`, and the full `cargo test --all-features --locked` suite.
- `release.yml` validated as well-formed YAML; `Cargo.toml`/`Cargo.lock` versions consistent.

## Notes
- Residual build/sign job-separation (SLSA) is tracked in #2481 (out of scope here).
- Refs #2260, #2261, #2262. **Supersedes the closed #2478.** (Those issues are already closed by #2472, so this PR intentionally does not re-`Closes` them.)