### PR TITLE
fix(brain): JSON-envelope verdict/decision transport for decide, orient & merge-judge (#2421, #2428, #2429, #2430, #2435, #2462, #2463)

### DIFF
--- a/docs/concepts/unified-recipe-brain.md
+++ b/docs/concepts/unified-recipe-brain.md
@@ -83,10 +83,13 @@ struct dependency.
 
 These functions exist once in `recipe_brain.rs`:
 
-- **`resolve_recipe_path(repo_root, recipe_filename)`** — parameterized path
-  resolution. Checks `~/.simard/prompt_assets/simard/recipes/<filename>` first
-  (hot-reload), then `<repo_root>/prompt_assets/simard/recipes/<filename>`
-  (in-tree).
+- **`resolve_recipe_path(repo_root, recipe_filename, home_override)`** —
+  parameterized path resolution. Checks
+  `<home>/.simard/prompt_assets/simard/recipes/<filename>` first (hot-reload),
+  then `<repo_root>/prompt_assets/simard/recipes/<filename>` (in-tree).
+  `home_override` is a test seam (`None` in production → `dirs::home_dir`) that
+  keeps unit tests hermetic against the ambient `~/.simard`, matching the
+  convention in `disk_health` and `brain_introspection`.
 - **`truncate(s, max)`** — char-aware truncation with `…` suffix. Used in
   error messages and rationale fields to cap unbounded LLM output.
 - **`deterministic_floor(base_urgency, failure_count)`** — fallback orient

--- a/docs/howto/diagnose-decide-orient-parse-failures.md
+++ b/docs/howto/diagnose-decide-orient-parse-failures.md
@@ -1,7 +1,7 @@
 ---
 title: Diagnose OODA decide/orient brain parse failures
 description: Operator runbook for text-based OODA brain parse failures. Find, classify, and remediate parse failures from the decide and orient phases.
-last_updated: 2026-05-24
+last_updated: 2026-06-28
 review_schedule: as-needed
 owner: simard
 ---
@@ -24,6 +24,16 @@ owner: simard
 > traditional sense (format rejected) **cannot occur** — the first-word
 > parser always returns a valid action kind. If no keyword matches, the
 > default `advance_goal` is used.
+>
+> **Transport (fixed in [#2421](https://github.com/rysweet/Simard/issues/2421)).**
+> The decide brain reads the agent decision from the `recipe-runner-rs
+> --output-format json` envelope (`step_results[].output`), **not** the
+> text-mode summary banner. On a parse-miss it runs the escalation ladder and
+> only then falls back **loudly** to `advance_goal`, and each invocation emits a
+> `brain_verdict_parsed_total` metric (`phase=decide`). The banner first word
+> `Recipe:` can no longer be mistaken for the decision. See
+> [Recipe-brain verdict/decision parsing](../reference/recipe-brain-verdict-parsing.md#decide-phase-2421).
+
 
 ### Decide-brain failure modes
 
@@ -60,6 +70,16 @@ WARN simard::operator_commands_ooda: [ooda] recipe-runner-rs not found; using de
 > The orient brain now extracts the first bare decimal from the recipe output
 > instead of parsing a JSON object. Parse failures still fire four visibility
 > channels. If no float is found, the deterministic floor applies.
+>
+> **Transport (fixed in [#2421](https://github.com/rysweet/Simard/issues/2421)).**
+> The decimal is read from the `--output-format json` envelope's agent output,
+> **not** the text-mode banner. Because the envelope carries no banner, the
+> banner's `(0.0s)` timing string can no longer be scraped as `adjusted_urgency`
+> — urgency can no longer be silently demoted to `0.0`. On a parse-miss the
+> escalation ladder runs and the deterministic floor (`base_urgency − 0.2 ×
+> failure_count`) is the only fallback; each invocation emits a
+> `brain_verdict_parsed_total` metric (`phase=orient`). See
+> [Recipe-brain verdict/decision parsing](../reference/recipe-brain-verdict-parsing.md#orient-phase-2421).
 
 For the wire format specifications, see
 [Reference: text-parsing wire formats](../reference/text-parsing-wire-formats.md).

--- a/docs/howto/diagnose-merge-pr-verdict-parse-failures.md
+++ b/docs/howto/diagnose-merge-pr-verdict-parse-failures.md
@@ -1,0 +1,148 @@
+---
+title: Diagnose simard merge-pr verdict-parse failures
+description: Operator runbook for the gated merge path. simard merge-pr now surfaces a real verdict via the JSON envelope and fails closed to unclear (refused) when no verdict parses. Explains how to tell a real not_ready/unclear verdict from an infra error or a genuine not-ready PR, and why never to coerce unclear/empty into ready.
+last_updated: 2026-06-28
+review_schedule: as-needed
+owner: simard
+doc_type: howto
+related:
+  - ../reference/recipe-brain-verdict-parsing.md
+  - ../reference/text-parsing-wire-formats.md
+  - ../reference/pr-finalization-pipeline.md
+  - ./triage-stale-pull-requests.md
+  - ./diagnose-decide-orient-parse-failures.md
+---
+
+# How-to: Diagnose `simard merge-pr` verdict-parse failures
+
+> **Audience:** operators landing PRs through the gated merge path who need to
+> read the **merge-readiness-judge** verdict or diagnose an errored merge.
+>
+> **Prerequisites:** read access to `~/.simard/logs/` on the host;
+> `recipe-runner-rs` on `$PATH`; familiarity with the `simard` CLI and `gh`.
+
+`simard merge-pr <N>` runs an objective, never-agentic gate and then an
+**agentic merge-readiness judge** backed by `recipe-runner-rs`. The judge reads
+the PR and returns one verdict: `ready`, `not_ready`, or `unclear`.
+
+> **The verdict-capture bug is fixed**
+> ([#2428](https://github.com/rysweet/Simard/issues/2428) /
+> [#2430](https://github.com/rysweet/Simard/issues/2430) /
+> [#2435](https://github.com/rysweet/Simard/issues/2435) /
+> [#2462](https://github.com/rysweet/Simard/issues/2462) /
+> [#2463](https://github.com/rysweet/Simard/issues/2463)).** `RecipeMergeJudge::judge`
+> (`src/stewardship/recipe_merge_judge.rs`) invokes `recipe-runner-rs` with
+> `--output-format json`, extracts the agent verdict from the envelope, runs the
+> shared escalation ladder on a parse-miss, and **fails closed to `unclear`**
+> (→ refused) when no verdict parses — never fail-open to `ready`, never
+> SUCCESS-without-verdict. This is the same JSON-envelope pattern as the
+> engineer-lifecycle brain (#2419). So `simard merge-pr` now surfaces a real
+> verdict (or a fail-closed `unclear`, or an explicit infra error) on every run.
+> See
+> [Recipe-brain verdict/decision parsing](../reference/recipe-brain-verdict-parsing.md#merge-judge-phase-2462).
+
+## Step 1: Read the verdict
+
+On a healthy, up-to-date build, `simard merge-pr <N>` resolves the judge to one
+of three verdicts and acts on it:
+
+- **`ready`** — the agentic judge found the PR merge-ready. The merge proceeds
+  (subject to the objective gate, which is the sole authority).
+- **`not_ready`** — the judge found a genuine blocker. The merge is refused with
+  the judge's rationale and any structured blockers.
+- **`unclear`** — the judge could not produce a confident verdict (including the
+  **fail-closed** case where no verdict parsed even after the escalation ladder).
+  The merge authority treats `unclear` as a refusal.
+
+Tail the log for the judge line to see which verdict was surfaced:
+
+```bash
+tail -n 200 ~/.simard/logs/rustyclawd.log | grep -E 'merge-judge|merge-readiness'
+```
+
+Confirm the per-run outcome in the metric stream — the merge judge emits one
+`brain_verdict_parsed_total` event (`phase=merge_judge`, `goal_id=pr-<N>`) per
+invocation, on both the parsed and the fail-closed (`defaulted`) branch:
+
+```bash
+jq -rc 'select(.metric_name=="brain_verdict_parsed_total")
+        | .context | fromjson | select(.phase=="merge_judge")
+        | "\(.goal_id) outcome=\(.outcome) detail=\(.outcome_detail) attempts=\(.attempts)"' \
+  ~/.simard/metrics/metrics.jsonl | tail -20
+```
+
+An `outcome=defaulted` with `detail=default_empty`/`default_malformed` is the
+fail-closed `unclear` path: the judge ran but no verdict parsed, so it refused.
+
+> **If you still see `no verdict keyword … raw="Recipe: … SUCCESS …"`, you are
+> on a pre-fix binary.** The old symptom — `recipe-runner-rs` invoked in default
+> text mode, the summary banner fed to the keyword parser, every merge aborting
+> at the infrastructure level — was eliminated by the JSON-envelope fix above.
+> It should no longer occur on a current build. Update the binary (`simard
+> safe-update`) rather than working around it.
+
+## Step 2: Tell a verdict apart from an infra error
+
+`merge-pr` outcomes fall into three classes. Only the third is an actual tooling
+failure:
+
+| Symptom | Class | What it means |
+|---------|-------|---------------|
+| Merge refused with a `not_ready` rationale (and possibly structured blockers) | **genuine not-ready PR** | The judge evaluated the PR and found a real blocker. Address the blocker, not the tooling. |
+| Merge refused with an `unclear` verdict (`outcome=defaulted` in the metric) | **fail-closed judge** | The judge could not produce a confident verdict, including the case where nothing parsed after the ladder. Correct, safe behavior — re-run or verify by hand. |
+| `AdapterInvocationFailed: recipe-runner-rs spawn failed` | **infra** | `recipe-runner-rs` is not on `$PATH` / not executable. |
+| `AdapterInvocationFailed: recipe exited with <status>` | **infra** | The recipe subprocess crashed; read the captured stderr. |
+| `AdapterInvocationFailed: failed to deserialize recipe JSON output` | **infra** | The `--output-format json` envelope was undecodable (e.g. a runner version mismatch). |
+
+A genuine infra error (the bottom three rows) propagates as an `Err` and is
+distinct from a fail-closed `unclear`, which is a *surfaced verdict*, not a
+crash. The distinction is visible in the metric: an infra error records
+`outcome_detail=error`; a fail-closed verdict records
+`default_empty`/`default_malformed`.
+
+## Step 3: Decide what to do
+
+- **`not_ready` / a real blocker** — fix the PR (CI, conflicts, missing
+  evidence) and re-run `simard merge-pr <N>`. The judge re-evaluates.
+- **`unclear` (fail-closed)** — re-run once; transient model wobble often clears
+  on the next attempt because the escalation ladder re-prompts. If it persists,
+  independently verify the merge-ready criteria
+  ([Triage stale pull requests → the deterministic gate](./triage-stale-pull-requests.md#the-deterministic-gate-what-simard-merge-pr-enforces))
+  before taking any operator action. **Never** coerce an `unclear` into a merge.
+- **Infra error** — fix the environment (install/repair `recipe-runner-rs`,
+  check the captured stderr, confirm the runner version emits the JSON envelope),
+  then re-run.
+
+## Step 4: Background — the shipped fix
+
+The merge judge applies the #2419 JSON-envelope pattern: it invokes
+`recipe-runner-rs --output-format json`, extracts the agent verdict from the
+envelope, parses it (`parse_merge_outcome` — structured `{"verdict":…}` JSON
+first, then a prose keyword fallback), runs the escalation ladder on a
+parse-miss, and **fails closed to `unclear`** when no verdict parses. The
+objective deterministic gate (`evaluate_objective_gates`) and the merge
+authority remain the sole deciders; the parsed verdict is advisory input. For
+the full design see
+[Recipe-brain verdict/decision parsing](../reference/recipe-brain-verdict-parsing.md#merge-judge-phase-2462).
+
+## Anti-patterns
+
+- **Treating a fail-closed `unclear` as "the tooling is broken."** It is a
+  surfaced verdict, not a crash — the judge ran and chose to refuse rather than
+  guess. Re-run or verify by hand; do not bypass the gate.
+- **Patching the parser to coerce empty / banner / `unclear` into `ready`.**
+  That reintroduces a merge-authority bypass. The judge must **fail closed**
+  (`unclear` → refused), never fail open. This invariant is load-bearing.
+- **Coercing a genuine `not_ready` into a merge.** Address the blocker the judge
+  reported instead.
+- **Reaching for a manual `gh pr merge` override as a normal path.** The gated
+  path surfaces a real verdict now; an operator merge is a recorded judgment
+  call reserved for genuinely exceptional cases, only after independently
+  verifying every merge-ready criterion — not a routine workaround.
+
+## See also
+
+- [Reference: Recipe-brain verdict/decision parsing](../reference/recipe-brain-verdict-parsing.md)
+- [Reference: Text-parsing wire formats §2b](../reference/text-parsing-wire-formats.md#2b-merge-judge-recipe_merge_judgers)
+- [Reference: PR-finalization review pipeline](../reference/pr-finalization-pipeline.md)
+- [How-to: Triage stale pull requests](./triage-stale-pull-requests.md)

--- a/docs/reference/recipe-brain-api.md
+++ b/docs/reference/recipe-brain-api.md
@@ -282,13 +282,23 @@ Parse-failure rate over a window:
 ### `resolve_recipe_path`
 
 ```rust
-fn resolve_recipe_path(repo_root: &Path, recipe_filename: &str) -> Option<PathBuf>
+pub fn resolve_recipe_path(
+    repo_root: &Path,
+    recipe_filename: &str,
+    home_override: Option<&Path>,
+) -> Option<PathBuf>
 ```
 
 Resolution order:
 
-1. `~/.simard/prompt_assets/simard/recipes/<recipe_filename>` (hot-reload)
+1. `<home>/.simard/prompt_assets/simard/recipes/<recipe_filename>` (hot-reload)
 2. `<repo_root>/prompt_assets/simard/recipes/<recipe_filename>` (in-tree)
+
+`home_override` selects the hot-reload base directory: `Some(path)` uses `path`
+(a test seam to stay hermetic against the ambient `~/.simard`), `None` falls
+back to [`dirs::home_dir`] — production always passes `None` (via
+`RecipeBrain::new`). Mirrors the `home_override` convention already used by
+`disk_health::resolve_recipe_path` and `brain_introspection::resolve_recipe_path`.
 
 Returns `None` if neither path contains the file.
 

--- a/docs/reference/recipe-brain-api.md
+++ b/docs/reference/recipe-brain-api.md
@@ -1,7 +1,7 @@
 ---
 title: RecipeBrain API reference
 description: Public API for the unified RecipeBrain struct and its standalone parse functions.
-last_updated: 2026-05-27
+last_updated: 2026-06-28
 review_schedule: as-needed
 owner: simard
 doc_type: reference
@@ -11,6 +11,7 @@ related:
   - ./ooda-brain-api.md
   - ./ooda-brain-decision-protocol.md
   - ./text-parsing-wire-formats.md
+  - ./recipe-brain-verdict-parsing.md
 ---
 
 # RecipeBrain API reference
@@ -69,8 +70,22 @@ Constructs a `RecipeBrain` if all preconditions are met. Returns `None` when:
 fn judge_decision(&self, ctx: &DecideContext) -> SimardResult<DecideJudgment>
 ```
 
-Invokes `recipe-runner-rs` with context vars `goal_id`, `urgency`, `reason`.
-Parses stdout via `parse_action_from_text()`.
+Invokes `recipe-runner-rs` with `--output-format json` and context vars
+`goal_id`, `urgency`, `reason` (plus the ladder rung's `escalation_note`),
+extracts the agent decision text from the JSON envelope via
+`extract_recipe_decision_output`, and parses it via `parse_action_outcome` (the
+outcome-classifying variant; `parse_action_from_text` is the thin decision-only
+wrapper).
+
+> **Fixed in [#2421](https://github.com/rysweet/Simard/issues/2421).** This call
+> site reads the agent decision from the `--output-format json` envelope
+> (`step_results[].output`), never the default text-mode summary banner. On a
+> parse-miss it runs `run_brain_ladder` (the shared escalation ladder) and only
+> after the ladder is exhausted falls back **loudly** to `AdvanceGoal` (via
+> `default_advance_goal`), classified `DefaultEmpty` / `DefaultMalformed` —
+> distinct from a genuine LLM `advance_goal`. Each invocation emits a
+> `brain_verdict_parsed_total` metric (`phase=decide`). See
+> [Recipe-brain verdict/decision parsing](./recipe-brain-verdict-parsing.md).
 
 #### `OodaOrientBrain::judge_orientation`
 
@@ -78,9 +93,21 @@ Parses stdout via `parse_action_from_text()`.
 fn judge_orientation(&self, ctx: &OrientContext) -> SimardResult<OrientJudgment>
 ```
 
-Invokes `recipe-runner-rs` with context vars `goal_id`, `base_urgency`,
-`base_reason`, `failure_count`. Parses stdout via
-`parse_orient_from_text()`.
+Invokes `recipe-runner-rs` with `--output-format json` and context vars
+`goal_id`, `base_urgency`, `base_reason`, `failure_count` (plus the ladder
+rung's `escalation_note`), extracts the agent output from the JSON envelope via
+`extract_recipe_decision_output`, and parses it via `parse_orient_outcome` (the
+outcome-classifying variant; `parse_orient_from_text` is the thin wrapper).
+
+> **Fixed in [#2421](https://github.com/rysweet/Simard/issues/2421).** Because
+> urgency is parsed from the JSON envelope's agent output rather than the
+> text-mode banner, the banner's `(0.0s)` timing string can no longer be scraped
+> as `adjusted_urgency` — urgency `0.0` from a banner can no longer happen. On a
+> parse-miss it runs `run_brain_ladder` and then falls back to the deterministic
+> urgency **floor** (`base_urgency − 0.2 × failure_count`, clamped), the only
+> fallback. Each invocation emits a `brain_verdict_parsed_total` metric
+> (`phase=orient`). See
+> [Recipe-brain verdict/decision parsing](./recipe-brain-verdict-parsing.md).
 
 #### `OodaBrain::decide_engineer_lifecycle`
 
@@ -139,6 +166,13 @@ variant. Defaults to `AdvanceGoal` if no match.
 The remaining text after the first word is captured as the rationale
 (truncated to 500 chars).
 
+`parse_action_from_text` is the decision-only thin wrapper over
+`parse_action_outcome(text) -> (DecideJudgment, LifecycleParseOutcome)`, which
+additionally returns a `LifecycleParseOutcome` classifying *how* the decision
+was produced (`Parsed` vs `DefaultEmpty` / `DefaultMalformed`). `judge_decision`
+calls `parse_action_outcome` so the parse-failure rate is measurable and the
+escalation ladder fires only on a real miss.
+
 ### `parse_orient_from_text`
 
 ```rust
@@ -159,6 +193,12 @@ pub fn parse_orient_from_text(
 
 The full text is used as `rationale`. `confidence` is always `1.0`.
 `OrientJudgment::validate()` enforces bounds after extraction.
+
+`parse_orient_from_text` is the thin wrapper over `parse_orient_outcome(text,
+base_urgency, failure_count) -> (OrientJudgment, LifecycleParseOutcome)`, which
+additionally returns a `LifecycleParseOutcome`. `judge_orientation` calls
+`parse_orient_outcome` over the JSON-envelope-extracted agent output, so the
+deterministic floor is the only fallback and the ladder fires on a real miss.
 
 > **Removed in [#2144](https://github.com/rysweet/Simard/issues/2144):**
 > The JSON extraction tier (`try_json_extraction`) has been deleted. The

--- a/docs/reference/recipe-brain-verdict-parsing.md
+++ b/docs/reference/recipe-brain-verdict-parsing.md
@@ -1,0 +1,454 @@
+---
+title: Recipe-brain verdict/decision parsing
+description: How recipe-backed brain phases turn a recipe-runner-rs subprocess run into a typed decision/verdict. All four phases — engineer-lifecycle, decide, orient, and merge-judge — share one JSON-envelope transport, one confidence-gated escalation ladder, and loud/fail-closed defaults, plus the class-level brain_verdict_parsed_total metric.
+last_updated: 2026-06-28
+review_schedule: as-needed
+owner: simard
+doc_type: reference
+related:
+  - ./recipe-brain-api.md
+  - ./text-parsing-wire-formats.md
+  - ./distill-recipe-output-capture.md
+  - ./ooda-brain-parse-failure-record.md
+  - ./pr-finalization-pipeline.md
+  - ../howto/diagnose-merge-pr-verdict-parse-failures.md
+  - ../howto/diagnose-decide-orient-parse-failures.md
+  - ../howto/diagnose-brain-decision-parse-failures.md
+---
+
+# Recipe-brain verdict/decision parsing
+
+> **Status — all four phases shipped.**
+> Every recipe-backed brain phase reads the `recipe-runner-rs --output-format
+> json` envelope, runs the shared confidence-gated escalation ladder on a
+> parse-miss, and falls back loudly (never silently). The cluster is closed:
+> [#2419](https://github.com/rysweet/Simard/issues/2419) (engineer-lifecycle
+> JSON-envelope transport) + [#2432](https://github.com/rysweet/Simard/issues/2432)
+> (escalation ladder), then the same pattern generalized to the
+> **decide**/**orient** ([#2421](https://github.com/rysweet/Simard/issues/2421))
+> and **merge-judge** ([#2428](https://github.com/rysweet/Simard/issues/2428) /
+> [#2430](https://github.com/rysweet/Simard/issues/2430) /
+> [#2435](https://github.com/rysweet/Simard/issues/2435) /
+> [#2462](https://github.com/rysweet/Simard/issues/2462) /
+> [#2463](https://github.com/rysweet/Simard/issues/2463)) phases, plus the
+> class-level `brain_verdict_parsed_total` metric
+> ([#2429](https://github.com/rysweet/Simard/issues/2429)).
+>
+> | Component | State | Location |
+> |-----------|-------|----------|
+> | engineer-lifecycle transport + ladder + metric | **shipped** ([#2419](https://github.com/rysweet/Simard/issues/2419) / [#2432](https://github.com/rysweet/Simard/issues/2432)) | `src/ooda_brain/recipe_brain.rs` |
+> | decide / orient JSON transport + ladder + loud default | **shipped** ([#2421](https://github.com/rysweet/Simard/issues/2421)) | `src/ooda_brain/recipe_brain.rs` |
+> | merge-judge JSON transport + ladder + fail-closed `Unclear` | **shipped** ([#2428](https://github.com/rysweet/Simard/issues/2428) / [#2430](https://github.com/rysweet/Simard/issues/2430) / [#2435](https://github.com/rysweet/Simard/issues/2435) / [#2462](https://github.com/rysweet/Simard/issues/2462) / [#2463](https://github.com/rysweet/Simard/issues/2463)) | `src/stewardship/recipe_merge_judge.rs` |
+> | class-level `brain_verdict_parsed_total` metric | **shipped** ([#2429](https://github.com/rysweet/Simard/issues/2429)) | `src/ooda_brain/recipe_brain.rs` |
+>
+> Everything on this page describes code that exists today. A reader six months
+> from now should treat this as the current design, not a migration note.
+
+This page explains how a `recipe-runner-rs` subprocess run becomes a typed
+decision or verdict, and how all four recipe-backed brain phases share one
+transport, one escalation ladder, and one loud-default discipline. For the
+per-parser grammar (first-word / first-float / keyword) see
+[Text-parsing wire formats](./text-parsing-wire-formats.md). For the
+`RecipeBrain` struct and its standalone parse functions see the
+[RecipeBrain API reference](./recipe-brain-api.md). For the envelope shape
+pinned against the installed `recipe-runner-rs` binary, see
+[Distill recipe output capture](./distill-recipe-output-capture.md).
+
+---
+
+## The shared failure class (why this exists)
+
+`recipe-runner-rs` has **two** stdout formats, selected by `--output-format`:
+
+| Format           | Stdout content                                                                  |
+|------------------|---------------------------------------------------------------------------------|
+| `text` (default) | A human **summary banner** only (`Recipe: <name> … SUCCESS (NN.Ns) …`). The agent step's actual output is **not** on stdout. |
+| `json`           | A structured **envelope** whose `step_results[].output` holds the agent's real output. |
+
+Every recipe-backed brain reads the **JSON envelope** (`--output-format json`
+→ `step_results[].output`), never the banner. Historically each phase read the
+default text-mode banner instead, and the consequences differed per phase even
+though the root cause was one wire-format bug. All four phases now extract the
+real agent output before parsing:
+
+| Phase | Adapter tag | Former text-mode failure (now fixed) | State |
+|-------|-------------|--------------------------------------|-------|
+| engineer-lifecycle (act) | `recipe-engineer-lifecycle-brain` | banner first word `Recipe:` → silent `continue_skipping` (~99.6% of calls) | **fixed** (#2419 / #2432) |
+| decide | `recipe-decide-brain` | banner first word `Recipe:` → silent `advance_goal` every cycle | **fixed** (#2421) |
+| orient | `recipe-orient-brain` | banner timing string `(0.0s)` scraped as `adjusted_urgency` → urgency corrupted to `0.0` | **fixed** (#2421) |
+| merge-judge | `recipe-merge-judge` | banner contains `readiness` but no `ready`/`not_ready`/`unclear` token → no verdict, every `simard merge-pr` aborted | **fixed** (#2428 / #2430 / #2435 / #2462 / #2463) |
+
+The fix is the same for all of them: **invoke `recipe-runner-rs` with
+`--output-format json`, extract the final step's `output` from the envelope,
+then run the phase parser over that real agent output** — never over the
+banner. On a parse miss, climb the confidence-gated escalation ladder before
+falling back, and **fall back loudly, never silently** (decide → `AdvanceGoal`,
+orient → deterministic urgency floor, merge-judge → fail-closed `Unclear`).
+
+> **What "STRUCTURED (JSON)" means here.** The structured layer is the
+> `recipe-runner-rs` **transport envelope** (`--output-format json` →
+> `step_results[].output`), not a change to the agent's own output grammar. The
+> decide/orient/lifecycle agents still emit a first-word/first-float token and
+> the merge-judge agent still emits its verdict — those agent output grammars
+> are unchanged (see [Text-parsing wire formats](./text-parsing-wire-formats.md)).
+> Only the **capture path** changes: from banner-scraping to envelope-extraction.
+
+---
+
+## Shared transport and ladder (the engineer-lifecycle reference)
+
+Module: `src/ooda_brain/recipe_brain.rs`. The engineer-lifecycle phase is the
+reference implementation of the shared machinery; the decide, orient, and
+merge-judge phases reuse the very same transport, ladder backbone, and
+escalation-note seam described below.
+
+### Transport: `RecipeEnvelope` + `extract_recipe_decision_output`
+
+```rust
+/// JSON envelope returned by `recipe-runner-rs --output-format json`.
+#[derive(Debug, Deserialize)]
+struct RecipeEnvelope {
+    success: bool,
+    #[serde(default)]
+    step_results: Vec<RecipeStepResult>,
+}
+
+/// A single step's result inside the envelope.
+#[derive(Debug, Deserialize)]
+struct RecipeStepResult {
+    #[serde(default)]
+    step_id: String,
+    #[serde(default)]
+    output: String,
+}
+
+/// Extract the decision text the agent actually produced from the
+/// `--output-format json` stdout envelope (the FINAL step's `output`).
+/// Shared by every recipe-backed brain phase.
+pub(crate) fn extract_recipe_decision_output(stdout: &[u8], adapter_tag: &str) -> SimardResult<String>;
+```
+
+`extract_recipe_decision_output` returns the final `step_results[].output` and
+surfaces a typed `SimardError::AdapterInvocationFailed` — rather than silently
+returning empty text — when:
+
+- the envelope cannot be deserialized (`failed to deserialize recipe JSON output`),
+- the recipe reported `success=false` (`recipe reported success=false in JSON output`),
+- no step produced output (`no step results in recipe JSON output`).
+
+These are **genuine infrastructure failures** and stay `Err`. They are distinct
+from a successful run whose agent output merely fails to parse — that is a
+parse-miss, which drives the ladder rather than an `Err`. Each phase invokes the
+runner with `--output-format json` in its `invoke_*_raw` helper, which
+distinguishes the two on the error path (returning an `Err` plus a `cause`
+label for the metric).
+
+> `RecipeEnvelope`/`RecipeStepResult` and `extract_recipe_decision_output` are
+> `pub(crate)` shared infrastructure. The merge-judge module
+> (`src/stewardship/recipe_merge_judge.rs`) reuses the identical extraction via a
+> `pub(crate) use` re-export from `ooda_brain`; the decide/orient phases call it
+> directly. Every phase uses the same envelope decoder rather than re-deriving
+> it.
+
+### Outcome classification: `LifecycleParseOutcome`
+
+Each parse is classified so the parse-failure rate (`outcome != parsed`) is
+measurable. The same `LifecycleParseOutcome` type is the shared classification
+returned by every phase's parser (`parse_action_outcome`, `parse_orient_outcome`,
+`parse_merge_outcome`, `parse_lifecycle_outcome`):
+
+| Variant | `label()` | Counts as failure? | Meaning |
+|---------|-----------|--------------------|---------|
+| `Parsed` | `parsed` | no | First word / verdict matched a known variant on the base attempt. |
+| `DefaultEmpty` | `default_empty` | **yes** | Extracted output empty/whitespace → phase's deterministic default. |
+| `DefaultMalformed` | `default_malformed` | **yes** | Output non-empty but matched no variant → phase's deterministic default. |
+| `Repaired` | `repaired` | no | Real decision recovered by a **schema-repair** ladder rung. |
+| `Escalated` | `escalated` | no | Real decision recovered by a **higher-effort** ladder rung. |
+| `Error` | `error` | **yes** | recipe-runner spawn/exit/envelope decode failed (set on the error path, not by the pure parser). |
+
+`LifecycleParseOutcome::is_parse_failure()` is `true` for `DefaultEmpty |
+DefaultMalformed | Error`. `Repaired` / `Escalated` are real recoveries — they
+do **not** count as failures, which is exactly how the ladder drops the measured
+default rate.
+
+### Confidence-gated escalation ladder (#2432)
+
+On a base parse-miss (`DefaultEmpty` / `DefaultMalformed` — a low-confidence,
+unparseable coarse judgment) the brain spends EXTRA compute only on that weak
+case before reaching the deterministic default. The shared backbone is a
+generic ladder parameterized over the phase's decision type `D`:
+
+```rust
+/// Generic escalation backbone shared by every recipe-backed brain phase.
+/// `invoke` runs one rung (with the rung's escalation note), `parse` maps raw
+/// agent output to `(D, LifecycleParseOutcome)`, and `default` supplies the
+/// loud fallback when the ladder is exhausted.
+pub fn run_brain_ladder<D>(
+    goal_id: &str,
+    base_raw: &str,
+    base_outcome: LifecycleParseOutcome,
+    cfg: &EscalationConfig,
+    invoke: impl Fn(&LadderAttempt) -> SimardResult<String>,
+    parse: impl Fn(&str) -> (D, LifecycleParseOutcome),
+    default: impl Fn() -> D,
+    decision_label: impl Fn(&D) -> String,
+) -> (D, LifecycleParseOutcome, u32, LadderTermination);
+```
+
+The decide, orient, and merge-judge phases call `run_brain_ladder` directly.
+The lifecycle-specific `run_escalation_ladder` is now a **thin wrapper** that
+delegates to `run_brain_ladder`, preserving the `LifecycleInvoker` seam so the
+lifecycle ladder stays unit-testable without a live `recipe-runner-rs`:
+
+```rust
+/// Seam over the raw lifecycle recipe invocation. Production wires `RecipeBrain`;
+/// tests wire a scripted stub.
+pub trait LifecycleInvoker {
+    fn invoke_lifecycle(&self, ctx: &EngineerLifecycleCtx, attempt: &LadderAttempt)
+        -> SimardResult<String>;
+}
+
+/// Thin wrapper over `run_brain_ladder` for the engineer-lifecycle decision.
+pub fn run_escalation_ladder(
+    invoker: &dyn LifecycleInvoker,
+    ctx: &EngineerLifecycleCtx,
+    base_raw: &str,
+    base_outcome: LifecycleParseOutcome,
+    cfg: &EscalationConfig,
+) -> (EngineerLifecycleDecision, LifecycleParseOutcome, u32, LadderTermination);
+```
+
+On a base parse-miss the ladder climbs a bounded sequence of rungs
+(`LadderRung`):
+
+1. **`Base`** — the cheap attempt, byte-identical to the pre-ladder path.
+2. **`SchemaRepair`** — re-prompt feeding the malformed output back, reminding
+   the model of the exact accepted variant tokens.
+3. **`Escalate`** — schema-repair **plus** a higher-effort, step-by-step
+   reasoning instruction.
+
+The per-rung repair note is injected through the `{{escalation_note}}` recipe
+seam. A generic `build_phase_escalation_note(rung, prior_output,
+repair_instruction, high_effort)` is the shared builder; each phase wraps it
+with its own phrasing — `build_decide_escalation_note` and
+`build_orient_escalation_note` (in `recipe_brain.rs`),
+`build_merge_escalation_note` (in `recipe_merge_judge.rs`), and the unchanged
+lifecycle `build_escalation_note`. **On the `Base` rung the note is empty**, so
+the base attempt is byte-identical to the pre-ladder behavior. The recipe YAMLs
+`ooda-decide.yaml`, `ooda-orient.yaml`, and `merge-readiness-judge.yaml` each
+carry the additive `{{escalation_note}}` placeholder near the top of the prompt
+(empty on the base attempt), mirroring `ooda-engineer-lifecycle.yaml`. The note
+builders are content-pinned (the `escalation_note_*` tests fail CI if the
+wording drifts).
+
+The deterministic default is reached **only after the ladder is exhausted** (or
+a rung's own invocation fails). Each rung logs loudly to both `tracing` and
+stderr:
+
+```
+[simard] BRAIN ESCALATION goal=<id> rung=SchemaRepair attempt=2 (parse-miss recovery)
+[simard] BRAIN ESCALATION goal=<id> RECOVERED decision=reclaim_and_redispatch via SchemaRepair (attempt 2)
+[simard] BRAIN ESCALATION goal=<id> ladder ended (exhausted) after 3 attempts — deterministic default
+```
+
+`LadderTermination` records *which* terminal path was taken, and maps to the
+metric `cause` label:
+
+| `LadderTermination` | `cause_label()` | Meaning |
+|---------------------|-----------------|---------|
+| `Recovered` | `ladder_recovered` | A rung produced a parseable decision (`Repaired`/`Escalated`). |
+| `Exhausted` | `ladder_exhausted` | Every configured rung tried; none parsed → deterministic default. |
+| `InvokeError` | `ladder_invoke_error` | A rung's own invocation failed; ladder stopped early → deterministic default. |
+| `Disabled` | `ladder_disabled` | `max_escalations == 0`; no rung tried. |
+
+### Configuration
+
+| Variable | Default | Hard cap | Effect |
+|----------|---------|----------|--------|
+| `SIMARD_BRAIN_ESCALATION_MAX_ATTEMPTS` | `2` | `3` | Escalation rungs attempted after a base parse-miss (all four phases). `0` disables the ladder (default-on-first-miss). The value is clamped to `[0, HARD_CAP]` so a misconfiguration can never create an unbounded retry loop. |
+
+Parsed by `EscalationConfig::from_env()` / `parse_max_escalations`. No new
+network surface is introduced.
+
+---
+
+## Metric: `brain_lifecycle_decision` (shipped)
+
+> Closes the measurement half of [#2419](https://github.com/rysweet/Simard/issues/2419):
+> emit one event per `decide_engineer_lifecycle` invocation so the lifecycle
+> parse-failure rate is computable from `metrics.jsonl`.
+
+One event is appended to `~/.simard/metrics/metrics.jsonl` per invocation
+(`value = 1.0`). It is a **no-op under `cfg!(test)`** so unit tests never
+corrupt the operator's real measurement file. The JSON `context` payload (built
+by `build_lifecycle_metric_context`):
+
+| Field | Values / meaning |
+|-------|------------------|
+| `goal_id` | The engineer-lifecycle goal id. |
+| `outcome` | `parsed` \| `default_empty` \| `default_malformed` \| `error` \| `repaired` \| `escalated` (the `LifecycleParseOutcome::label()`). |
+| `is_parse_failure` | `true` for `default_empty` / `default_malformed` / `error`. The numerator. |
+| `first_word` | The base attempt's first token (the diagnostic record of the cheap pass — capped at 64 chars). |
+| `consecutive_skip_count` | From `EngineerLifecycleCtx`. |
+| `decision` | The final decision choice (`continue_skipping`, `reclaim_and_redispatch`, `deprioritize`, `open_tracking_issue`, `mark_goal_blocked`, `consider_self_update`). |
+| `cause` | `ok` (parsed base) \| `ladder_recovered` \| `ladder_exhausted` \| `ladder_invoke_error` \| `ladder_disabled` (or the invoke error cause on the base-error path). |
+| `attempts` | Total brain invocations spent (base + escalation rungs). |
+
+**Lifecycle parse-failure rate** over the recorded window:
+
+```bash
+jq -rc 'select(.metric_name=="brain_lifecycle_decision")
+        | .context | fromjson | "\(.outcome) is_failure=\(.is_parse_failure)"' \
+  ~/.simard/metrics/metrics.jsonl \
+  | sort | uniq -c
+```
+
+`parse_failure_rate = count(is_parse_failure == true) / count(*)`. Before #2419
+this was ~99.6% (the banner regression); a healthy daemon trends toward `0`.
+
+---
+
+## Metric: `brain_verdict_parsed_total` (shipped)
+
+> Closes [#2429](https://github.com/rysweet/Simard/issues/2429): one shared
+> counter across **all** recipe-backed brain phases with a `parsed`/`defaulted`
+> denominator, so each phase's parse-success rate is computable from one stream.
+
+A `brain_verdict_parsed_total` event (`value = 1.0`) is appended to
+`~/.simard/metrics/metrics.jsonl` **once per decide / orient / merge-judge
+invocation**, on BOTH the parsed branch and the defaulted branch. Like the
+lifecycle metric it is a **no-op under `cfg!(test)`**. The JSON `context`
+payload:
+
+| Field | Values / meaning |
+|-------|------------------|
+| `phase` | `decide` \| `orient` \| `merge_judge`. |
+| `outcome` | `parsed` (a real decision was produced) \| `defaulted` (the loud/fail-closed fallback was taken). |
+| `outcome_detail` | The `LifecycleParseOutcome::label()`: `parsed` \| `repaired` \| `escalated` \| `default_empty` \| `default_malformed` \| `error`. |
+| `is_parse_failure` | `true` for `default_empty` / `default_malformed` / `error`. |
+| `goal_id` | The phase's goal id. For merge-judge this is `pr-<N>`. |
+| `attempts` | Total brain invocations spent (base + ladder rungs). |
+
+**Per-phase parse-success rate** over the recorded window:
+
+```bash
+jq -rc 'select(.metric_name=="brain_verdict_parsed_total")
+        | .context | fromjson | "\(.phase) \(.outcome)"' \
+  ~/.simard/metrics/metrics.jsonl \
+  | sort | uniq -c
+```
+
+`parse_success_rate{phase} = parsed / (parsed + defaulted)` for that `phase`.
+
+The engineer-lifecycle phase keeps its dedicated `brain_lifecycle_decision`
+metric (above) unchanged; `brain_verdict_parsed_total` covers the decide,
+orient, and merge-judge phases. Both are in addition to the existing
+failure-only `brain_parse_failure` counter (see
+[OODA brain parse-failure record](./ooda-brain-parse-failure-record.md)) and
+the structured log lines.
+
+---
+
+## The same fix across decide, orient, and merge-judge
+
+All three phases below ride the shared transport + ladder described above:
+they invoke `recipe-runner-rs --output-format json`, extract the agent output
+from the envelope via `extract_recipe_decision_output`, parse it, run
+`run_brain_ladder` on a parse-miss, and only then fall back — loudly for
+decide/orient, fail-closed for merge-judge. The root-cause explanation for each
+phase is kept here ("previously … now …") so the contrast is unambiguous.
+
+### Decide phase (#2421)
+
+`recipe_brain.rs::judge_decision` invokes `invoke_decide_raw` (which passes
+`--output-format json` plus the rung's `escalation_note`), extracts the agent
+output from the envelope, and parses it via `parse_action_outcome(text) ->
+(DecideJudgment, LifecycleParseOutcome)`. On a parse-miss it runs
+`run_brain_ladder`, and only after the ladder is exhausted does it fall back
+**loudly** to `DecideJudgment::AdvanceGoal` (via `default_advance_goal`). The
+miss is classified `DefaultEmpty` / `DefaultMalformed`, distinct from a genuine
+LLM `advance_goal` (which is `Parsed`).
+
+Previously this call site read the default text-mode banner, whose first word is
+always `Recipe:` — so it silently returned `AdvanceGoal` every cycle, ignoring
+the LLM. Reading the envelope output instead means a real `advance_goal` and a
+banner-induced default are no longer indistinguishable. `parse_action_from_text`
+is retained as a thin decision-only wrapper over `parse_action_outcome`.
+
+### Orient phase (#2421)
+
+`recipe_brain.rs::judge_orientation` invokes `invoke_orient_raw` (json +
+`escalation_note`), extracts the envelope output, and parses it via
+`parse_orient_outcome(text, base_urgency, failure_count) -> (OrientJudgment,
+LifecycleParseOutcome)`. On a parse-miss it runs `run_brain_ladder`, then falls
+back to the deterministic urgency floor (`base_urgency −
+FAILURE_PENALTY_PER_CONSECUTIVE × failure_count`, i.e. `base_urgency − 0.2 ×
+failure_count`, clamped to `[0.0, 1.0]`).
+
+Previously this phase scanned the text-mode banner for the first decimal in
+`[0, base_urgency]`. The banner's timing string (e.g. `(0.0s)`) was scraped as
+`adjusted_urgency`, silently demoting urgency to `0.0` — worse than a benign
+default. Because urgency is now read from the JSON envelope's agent output, the
+banner `(0.0s)` timing string can no longer be scraped — **urgency `0.0` from a
+banner can no longer happen**; the deterministic floor is the only fallback.
+`parse_orient_from_text` is retained as a thin wrapper over
+`parse_orient_outcome`.
+
+### Merge-judge phase (#2462)
+
+`recipe_merge_judge.rs::RecipeMergeJudge::judge` (closing #2462 / #2463 / #2428
+/ #2430 / #2435) invokes `invoke_judge_raw` (json + `escalation_note`), extracts
+the verdict text from the envelope, and parses it via `parse_merge_outcome(text)
+-> (JudgeOutcome, LifecycleParseOutcome)`. `parse_merge_outcome` tries
+`merge_judge::parse_judge_response` (structured `{"verdict":…}` JSON, which
+populates `blockers`) FIRST, then falls back to the
+`parse_merge_verdict_from_text` keyword scanner for prose. On a parse-miss it
+runs `run_brain_ladder`, and after the ladder is exhausted it **fails CLOSED to
+`Verdict::Unclear`** (via `fail_closed_unclear`).
+
+**Fail-closed is the hard requirement.** `Unclear` is treated as a refusal by
+the merge authority (see [`merge_judge.rs`](./pr-finalization-pipeline.md)). The
+judge **never** flips fail-open to `Ready`, never emits SUCCESS-without-verdict,
+and a recipe completing `SUCCESS` is **not** a verdict. Genuine
+spawn/nonzero-exit/envelope-decode failures still propagate as `Err`
+(`SimardError::AdapterInvocationFailed`). The objective deterministic gate
+(`evaluate_objective_gates`) and the merge authority remain the sole deciders;
+the parsed verdict is advisory input.
+
+Previously this call site invoked `recipe-runner-rs` without `--output-format
+json` and ran `parse_merge_verdict_from_text` over the raw banner. The banner
+contains `readiness` but no `ready`/`not_ready`/`unclear` token, so the parser
+returned `Err("no verdict keyword …")` and every `simard merge-pr` aborted at
+the infrastructure level. Now `simard merge-pr` surfaces a real verdict (or a
+fail-closed `Unclear` → Refused, or an explicit infra `Err`) on every run.
+
+> Note: `parse_merge_verdict_from_text` (in `recipe_merge_judge.rs`, the keyword
+> scanner) is a different function from `merge_judge::parse_judge_response` (the
+> JSON-object parser). The merge judge's `parse_merge_outcome` now uses **both**:
+> `parse_judge_response` for structured JSON first, then the keyword scanner as a
+> prose fallback. See
+> [Text-parsing wire formats §2b](./text-parsing-wire-formats.md#2b-merge-judge-recipe_merge_judgers).
+
+---
+
+## Test inventory (shipped)
+
+| Module | Coverage |
+|--------|----------|
+| `src/ooda_brain/recipe_brain.rs` | `extract_recipe_decision_output` success + decode/`success=false`/empty-`step_results` error cases; `parse_lifecycle_outcome` matrix; `run_escalation_ladder` recovery / exhaustion / invoke-error / disabled paths; `LadderTermination::cause_label` distinctness; `build_escalation_note` content pins; `build_lifecycle_metric_context` shape. **`issue_2421_tests`** + **`issue_2419_family_phase_tests`**: `parse_action_outcome` / `parse_orient_outcome` classification (parsed vs `DefaultEmpty`/`DefaultMalformed`), `build_decide_escalation_note` / `build_orient_escalation_note` / `build_phase_escalation_note` content (empty on `Base`), `brain_verdict_parsed_total` context shape, and the generic `run_brain_ladder` driving an arbitrary decision type. |
+| `src/stewardship/recipe_merge_judge.rs` | `parse_merge_verdict_from_text` keyword matrix (ready / not_ready / unclear / empty / no-keyword `Err`). **`issue_2428_tests`** + **`issue_2428_production_tests`**: JSON-envelope extraction, `parse_merge_outcome` (structured `parse_judge_response` first, then keyword prose fallback), prose keyword fallback, and fail-closed `Verdict::Unclear` on an unparseable verdict. |
+| `src/stewardship/merge_judge.rs` | `parse_judge_response` JSON extraction (fenced / brace-balanced / outermost), `LlmMergeJudge`, `RefusingMergeJudge`. |
+| `tests/recipe_brain_verdict_assets.rs` | Asset/integration coverage of the recipe-brain verdict path. |
+| `tests/gadugi/decide-orient-brain-parse.sh`, `tests/gadugi/merge-judge-verdict.sh` | Outside-in gadugi scenarios exercising the decide/orient parse path and the merge-judge verdict path end-to-end. |
+
+---
+
+## See also
+
+- [How-to: Diagnose `simard merge-pr` verdict-parse failures](../howto/diagnose-merge-pr-verdict-parse-failures.md) — recognizing a real verdict, a fail-closed `unclear`, and an infra error
+- [How-to: Diagnose OODA decide/orient brain parse failures](../howto/diagnose-decide-orient-parse-failures.md)
+- [How-to: Diagnose OODA brain decision parse failures](../howto/diagnose-brain-decision-parse-failures.md) — the lifecycle escalation ladder (#2432)
+- [Reference: RecipeBrain API](./recipe-brain-api.md)
+- [Reference: Text-parsing wire formats](./text-parsing-wire-formats.md)
+- [Reference: Distill recipe output capture](./distill-recipe-output-capture.md) — the envelope shape, pinned to the binary
+- [Reference: PR-finalization review pipeline](./pr-finalization-pipeline.md) — the merge authority and objective gate

--- a/docs/reference/text-parsing-wire-formats.md
+++ b/docs/reference/text-parsing-wire-formats.md
@@ -1,7 +1,7 @@
 ---
 title: Text-parsing wire formats
 description: Normative reference for every text-based wire format Simard's Rust code parses from LLM and recipe output. Replaces the former JSON-based contracts.
-last_updated: 2026-05-24
+last_updated: 2026-06-28
 review_schedule: as-needed
 owner: simard
 doc_type: reference
@@ -75,6 +75,15 @@ No `serde_json`. No regex. No keyword scanning. Only `str::split_whitespace()`,
 Extracts the first whitespace-delimited word, lowercases it, and matches
 against the 10 action keywords. Defaults to `AdvanceGoal`.
 
+> **Transport (fixed in [#2421](https://github.com/rysweet/Simard/issues/2421)):**
+> the `text` passed to this parser is the agent output extracted from the
+> `recipe-runner-rs --output-format json` envelope (`step_results[].output`),
+> **not** the text-mode summary banner. `judge_decision` parses it via
+> `parse_action_outcome` (the outcome-classifying variant of this function) and
+> runs the escalation ladder on a parse-miss before the loud `AdvanceGoal`
+> default. See
+> [Recipe-brain verdict/decision parsing](./recipe-brain-verdict-parsing.md).
+
 **Keywords:**
 
 | First word | Maps to |
@@ -107,6 +116,16 @@ consolidate_memory Memory hasn't been consolidated in 12 hours.
 **Struct:** `OrientJudgment`
 
 **Parser:** `parse_orient_from_text(text, base_urgency, failure_count) -> OrientJudgment`
+
+> **Transport (fixed in [#2421](https://github.com/rysweet/Simard/issues/2421)):**
+> the `text` is the agent output extracted from the `--output-format json`
+> envelope, **not** the text-mode banner. The envelope carries no banner, so the
+> first float is the model's real decimal and the deterministic floor below is
+> the only fallback — the banner's `(0.0s)` timing string can no longer be
+> scraped as `adjusted_urgency`, so urgency `0.0` from a banner can no longer
+> happen. `judge_orientation` parses via `parse_orient_outcome` (the
+> outcome-classifying variant) and runs the escalation ladder on a parse-miss.
+> See [Recipe-brain verdict/decision parsing](./recipe-brain-verdict-parsing.md).
 
 2-tier parse:
 
@@ -270,49 +289,49 @@ Parser result: `EvidenceDecision::Accept { reason: "After reviewing the plan and
 
 ### 2b. Merge judge (`recipe_merge_judge.rs`)
 
-**Keywords:**
+> **Transport (fixed in [#2428](https://github.com/rysweet/Simard/issues/2428) /
+> [#2430](https://github.com/rysweet/Simard/issues/2430) /
+> [#2435](https://github.com/rysweet/Simard/issues/2435) /
+> [#2462](https://github.com/rysweet/Simard/issues/2462) /
+> [#2463](https://github.com/rysweet/Simard/issues/2463)):**
+> `RecipeMergeJudge::judge` invokes `recipe-runner-rs` with `--output-format
+> json` and parses the agent verdict text extracted from the envelope
+> (`step_results[].output`), **not** the text-mode summary banner. It parses via
+> `parse_merge_outcome`, runs the escalation ladder on a parse-miss, and **fails
+> closed to `Unclear`** when no verdict parses. See
+> [Recipe-brain verdict/decision parsing](./recipe-brain-verdict-parsing.md#merge-judge-phase-2462)
+> and the [operator runbook](../howto/diagnose-merge-pr-verdict-parse-failures.md).
 
-| Keyword | Maps to | Priority |
-|---------|---------|----------|
-| `not_ready` | `Verdict::NotReady` | Checked first (prevents `ready` substring match) |
-| `unclear` | `Verdict::NotReady` | Checked second (conservative — unclear is not ready) |
+**Parser:** `parse_merge_outcome(text) -> (JudgeOutcome, LifecycleParseOutcome)`,
+which composes two parsers over the envelope-extracted agent output:
+
+1. `merge_judge::parse_judge_response` — structured `{"verdict":…}` JSON
+   (fenced ` ```json ` block → first brace-balanced `{…}` that parses →
+   outermost `{…}`), which **does** populate structured `Blocker` entries.
+   Tried **first**.
+2. `parse_merge_verdict_from_text` — the case-insensitive substring keyword scan
+   below, used as a **prose fallback** when no structured JSON is present.
+
+**Keyword scan (`parse_merge_verdict_from_text`)** — the prose fallback:
+
+| Keyword (substring) | Maps to | Priority |
+|---------------------|---------|----------|
+| `not_ready` / `not ready` | `Verdict::NotReady` | Checked first (prevents `ready` substring match) |
+| `unclear` | `Verdict::Unclear` | Checked second (treated as not-ready at the call site) |
 | `ready` | `Verdict::Ready` | Checked third |
 
-**Default (no keyword):** `Verdict::NotReady` — fail-closed. A PR that
-cannot be judged is not merged.
+**On no verdict from either parser, `parse_merge_outcome` fails CLOSED to
+`Verdict::Unclear`** (classified as a parse-miss in the returned
+`LifecycleParseOutcome`). The merge authority treats `Unclear` as a refusal, so
+an unparseable verdict can never become `Ready`. Genuine infrastructure failures
+— spawn failure, nonzero exit, or an undecodable JSON envelope — still propagate
+from `RecipeMergeJudge::judge` as `SimardError::AdapterInvocationFailed`; they
+are distinct from a successful run whose verdict merely fails to parse (which
+drives the ladder, then the fail-closed `Unclear`).
 
-**Example recipe stdout:**
-
-```
-Reviewing PR #2023 against merge criteria:
-
-- CI status: all checks passing
-- Code review: approved by 1 reviewer
-- Test coverage: new tests added for all changed modules
-- No breaking API changes
-
-The PR meets all merge-readiness criteria.
-
-ready
-```
-
-Parser result: `JudgeOutcome { verdict: Verdict::Ready, rationale: "Reviewing PR #2023 against merge criteria: ...", blockers: [] }`
-
-**Note on blockers:** The keyword verdict parser does not extract structured
-`Blocker` entries. `JudgeOutcome.blockers` is always empty when parsed from
-text. The recipe agent's prose rationale contains the equivalent information
-in human-readable form. If structured blockers are needed in the future, the
-recipe prompt can be updated to emit `BLOCKER:` labeled lines.
-
-**Changes from prior implementation:**
-
-- `parse_judge_response` (which parsed JSON) is removed from `merge_judge.rs`.
-- `LlmMergeJudge` is removed from `merge_judge.rs`.
-- Helper functions `extract_fenced_blocks`, `extract_balanced_objects`, and
-  `truncate_for_log` are removed from `merge_judge.rs`.
-- `build_merge_judge()` chain is now: `RecipeMergeJudge` →
-  `RefusingMergeJudge` (was: `RecipeMergeJudge` → `LlmMergeJudge` →
-  `RefusingMergeJudge`).
+**Note on blockers:** the structured `parse_judge_response` path populates
+`JudgeOutcome.blockers`; the keyword-scan prose fallback does not (`blockers`
+empty, rationale = truncated raw text).
 
 ---
 
@@ -435,7 +454,7 @@ Each parser has inline `#[cfg(test)]` tests in its source file:
 | `orient.rs` | 8+ | Float parsing, validation, extra fields, empty/invalid responses |
 | `rustyclawd.rs` | 15+ (T1–T15) | Full behavior matrix per decision protocol reference |
 | `recipe_progress_checker.rs` | 4+ | Accept, reject, no keyword (default), mixed case |
-| `recipe_merge_judge.rs` | 5+ | Ready, not_ready, unclear, no keyword (default), substring safety |
+| `recipe_merge_judge.rs` | 5+ | `parse_merge_outcome`: structured `parse_judge_response` JSON (populates blockers), prose keyword scan (ready / not_ready / unclear; substring safety), JSON-envelope extraction, and fail-closed `Verdict::Unclear` on an unparseable verdict. |
 | `disk_health.rs` | 3+ | Full output, no-cleanup output, malformed lines |
 
 ---

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,6 +91,7 @@ nav:
     - Diagnose a Rejected Goal Completion: howto/diagnose-a-rejected-goal-completion.md
     - Configure Brain Introspection: howto/configure-brain-introspection.md
     - Triage Stale Pull Requests: howto/triage-stale-pull-requests.md
+    - Diagnose merge-pr Verdict-Parse Failures: howto/diagnose-merge-pr-verdict-parse-failures.md
   - Reference:
     - CLI Reference: reference/simard-cli.md
     - Self-Deploy API: reference/self-deploy-api.md
@@ -119,6 +120,7 @@ nav:
     - Supply-Chain Audit & Guardrails: reference/supply-chain-audit.md
     - Dependency Trust Policy: reference/dependency-trust-policy.md
     - Release Integrity (SBOM + Signing): reference/release-integrity.md
+    - Recipe-brain Verdict/Decision Parsing: reference/recipe-brain-verdict-parsing.md
     # Hidden from nav until issue #1590 implementation lands:
     #   - reference/cognitive-memory-bridge-helpers.md
     #   - reference/goal-board-api.md

--- a/prompt_assets/simard/recipes/merge-readiness-judge.yaml
+++ b/prompt_assets/simard/recipes/merge-readiness-judge.yaml
@@ -5,7 +5,11 @@
 # {var} → double-brace {{var}} for recipe-runner substitution).
 #
 # Context vars (passed via -c):
-#   pr_number, repo, pr_body
+#   pr_number, repo, pr_body, escalation_note
+#
+# `escalation_note` (issue #2432 / #2428) is empty on the base attempt and
+# carries a schema-repair / higher-effort instruction on escalation-ladder
+# retries. When empty it renders to nothing, so base behaviour is unchanged.
 #
 # Output: agent stdout — raw text containing a JSON object:
 #   {"verdict": "ready"|"not_ready"|"unclear", "rationale": "...", "blockers": [...]}
@@ -23,6 +27,8 @@ steps:
     type: "agent"
     agent: "default"
     prompt: |
+      {{escalation_note}}
+
       You are the merge-readiness judge for the Simard repository. Your single job is
       to read a pull request body and the surrounding context, then return a structured
       JSON verdict on whether the PR satisfies the merge-ready skill.

--- a/prompt_assets/simard/recipes/ooda-decide.yaml
+++ b/prompt_assets/simard/recipes/ooda-decide.yaml
@@ -8,7 +8,11 @@
 # token and matches it case-insensitively to the 10 known action kinds.
 #
 # Context vars (passed via -c):
-#   goal_id, urgency, reason
+#   goal_id, urgency, reason, escalation_note
+#
+# `escalation_note` (issue #2432 / #2421) is empty on the base attempt and
+# carries a schema-repair / higher-effort instruction on escalation-ladder
+# retries. When empty it renders to nothing, so base behaviour is unchanged.
 #
 # Output: agent stdout — action keyword as first word, followed by rationale
 
@@ -25,6 +29,8 @@ steps:
     type: "agent"
     agent: "default"
     prompt: |
+      {{escalation_note}}
+
       # OODA Brain — Decide Phase: Action-Kind Routing
 
       ## ROLE

--- a/prompt_assets/simard/recipes/ooda-orient.yaml
+++ b/prompt_assets/simard/recipes/ooda-orient.yaml
@@ -8,7 +8,11 @@
 #   2. Deterministic floor — base_urgency - 0.2 * failure_count
 #
 # Context vars (passed via -c):
-#   goal_id, base_urgency, base_reason, failure_count
+#   goal_id, base_urgency, base_reason, failure_count, escalation_note
+#
+# `escalation_note` (issue #2432 / #2421) is empty on the base attempt and
+# carries a schema-repair / higher-effort instruction on escalation-ladder
+# retries. When empty it renders to nothing, so base behaviour is unchanged.
 #
 # Output: agent stdout — bare decimal float as first token, followed by rationale
 
@@ -25,6 +29,8 @@ steps:
     type: "agent"
     agent: "default"
     prompt: |
+      {{escalation_note}}
+
       # OODA Brain — Orient Phase: Failure-Penalty Demotion
 
       ## ROLE

--- a/src/ooda_brain/judgment_record.rs
+++ b/src/ooda_brain/judgment_record.rs
@@ -22,15 +22,40 @@ use std::cell::RefCell;
 
 use super::{DecideJudgment, EngineerLifecycleDecision, OrientJudgment, ParseFailureRecord};
 
-/// Which OODA phase produced the judgment. Serialised as lowercase strings
-/// so the cycle-report JSON consumers (dashboard, ad-hoc inspection) read
-/// `"act"`, `"decide"`, `"orient"`.
+/// Which recipe-backed brain phase produced the judgment. Serialised as
+/// snake_case strings so the cycle-report JSON consumers (dashboard, ad-hoc
+/// inspection) read `"act"`, `"decide"`, `"orient"`, `"merge_judge"`.
+///
+/// `rename_all = "snake_case"` keeps the three single-word variants
+/// byte-identical to the previous `"lowercase"` representation (cycle reports,
+/// the parse-failure metric, and `phase_to_string` all key off these exact
+/// strings — see the byte-stability pins in this module and `mod.rs`), while
+/// the new multi-word `MergeJudge` variant serialises as `"merge_judge"`
+/// (issue #2429 — instrument verdict-parse across the merge-judge phase too).
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum BrainPhase {
     Act,
     Decide,
     Orient,
+    /// Recipe-backed merge-readiness judge (`simard merge-pr`). Serialises as
+    /// `"merge_judge"`.
+    MergeJudge,
+}
+
+impl BrainPhase {
+    /// Stable snake_case label, identical to the serde representation. Shared
+    /// by the cycle-report writer, `parse_failure::phase_to_string`, and the
+    /// `brain_verdict_parsed_total` metric (issue #2429) so all three agree on
+    /// the exact phase strings.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            BrainPhase::Act => "act",
+            BrainPhase::Decide => "decide",
+            BrainPhase::Orient => "orient",
+            BrainPhase::MergeJudge => "merge_judge",
+        }
+    }
 }
 
 /// One record of a single `brain.judge_*()` call (or its fallback). Fields
@@ -305,6 +330,52 @@ mod tests {
             !json.contains("prompt_version"),
             "expected empty prompt_version to be skipped: {json}"
         );
+    }
+
+    /// Byte-stability pin guarding the Step 8 `BrainPhase` snake_case
+    /// migration (issue #2429 adds a `MergeJudge` variant). The serde
+    /// representation moves from `rename_all = "lowercase"` to
+    /// `rename_all = "snake_case"` so the new `MergeJudge` variant serialises
+    /// as `"merge_judge"`. That change MUST keep the three existing single-word
+    /// variants byte-identical — cycle reports, the parse-failure metric, and
+    /// the `phase_to_string` mapping all key off these exact strings.
+    #[test]
+    fn brainphase_existing_variants_serialize_byte_stable() {
+        assert_eq!(serde_json::to_string(&BrainPhase::Act).unwrap(), "\"act\"");
+        assert_eq!(
+            serde_json::to_string(&BrainPhase::Decide).unwrap(),
+            "\"decide\""
+        );
+        assert_eq!(
+            serde_json::to_string(&BrainPhase::Orient).unwrap(),
+            "\"orient\""
+        );
+        // Round-trip must also stay stable.
+        let back: BrainPhase = serde_json::from_str("\"decide\"").unwrap();
+        assert_eq!(back, BrainPhase::Decide);
+    }
+
+    /// The new `MergeJudge` variant (issue #2429) serialises as `"merge_judge"`
+    /// and round-trips, and `as_str()` agrees with the serde representation for
+    /// every variant (the metric and `phase_to_string` rely on this).
+    #[test]
+    fn brainphase_merge_judge_serializes_snake_case_and_as_str_agrees() {
+        assert_eq!(
+            serde_json::to_string(&BrainPhase::MergeJudge).unwrap(),
+            "\"merge_judge\""
+        );
+        let back: BrainPhase = serde_json::from_str("\"merge_judge\"").unwrap();
+        assert_eq!(back, BrainPhase::MergeJudge);
+
+        for phase in [
+            BrainPhase::Act,
+            BrainPhase::Decide,
+            BrainPhase::Orient,
+            BrainPhase::MergeJudge,
+        ] {
+            let serde_repr = serde_json::to_string(&phase).unwrap();
+            assert_eq!(serde_repr, format!("\"{}\"", phase.as_str()));
+        }
     }
 
     #[test]

--- a/src/ooda_brain/mod.rs
+++ b/src/ooda_brain/mod.rs
@@ -52,6 +52,14 @@ pub use orient::{
 };
 pub use parse_failure::ParseFailureRecord;
 pub use recipe_brain::RecipeBrain;
+/// Shared escalation-ladder backbone + verdict-parse instrumentation reused by
+/// the recipe-backed merge-judge (issue #2419 family / #2429). Exposed
+/// crate-wide so `stewardship::recipe_merge_judge` runs on the SAME ladder /
+/// transport / metric as the OODA brains rather than reinventing them.
+pub(crate) use recipe_brain::{
+    EscalationConfig, LadderRung, LifecycleParseOutcome, build_phase_escalation_note,
+    extract_recipe_decision_output, record_verdict_parse_metric, run_brain_ladder,
+};
 /// Backward-compatible type aliases (issue #2132).
 pub type RecipeDecideBrain = RecipeBrain;
 pub type RecipeEngineerLifecycleBrain = RecipeBrain;

--- a/src/ooda_brain/parse_failure.rs
+++ b/src/ooda_brain/parse_failure.rs
@@ -356,11 +356,7 @@ fn maybe_escalate_to_gh_issue(record: &ParseFailureRecord) {
 }
 
 fn phase_to_string(phase: BrainPhase) -> String {
-    match phase {
-        BrainPhase::Act => "act".to_string(),
-        BrainPhase::Decide => "decide".to_string(),
-        BrainPhase::Orient => "orient".to_string(),
-    }
+    phase.as_str().to_string()
 }
 
 #[cfg(test)]

--- a/src/ooda_brain/recipe_brain.rs
+++ b/src/ooda_brain/recipe_brain.rs
@@ -612,8 +612,17 @@ pub fn run_brain_ladder<D>(
 /// Resolve the recipe YAML path. Checks, in order:
 ///   1. `~/.simard/prompt_assets/simard/recipes/<recipe_filename>` (hot-reload)
 ///   2. `<repo_root>/prompt_assets/simard/recipes/<recipe_filename>` (in-tree)
-pub fn resolve_recipe_path(repo_root: &Path, recipe_filename: &str) -> Option<PathBuf> {
-    if let Some(home) = dirs::home_dir() {
+///
+/// `home_override` lets tests supply a fake home directory without mutating the
+/// process-wide `HOME` env var (mirrors `disk_health::resolve_recipe_path`).
+/// Production passes `None`, falling back to [`dirs::home_dir`].
+pub fn resolve_recipe_path(
+    repo_root: &Path,
+    recipe_filename: &str,
+    home_override: Option<&Path>,
+) -> Option<PathBuf> {
+    let home = home_override.map(PathBuf::from).or_else(dirs::home_dir);
+    if let Some(home) = home {
         let hot = home
             .join(".simard")
             .join("prompt_assets/simard/recipes")
@@ -657,7 +666,19 @@ impl RecipeBrain {
     /// `recipe_filename` selects the YAML (e.g. `"ooda-decide.yaml"`).
     /// `adapter_tag` appears in error messages and logs (e.g. `"recipe-decide-brain"`).
     pub fn new(repo_root: &Path, recipe_filename: &str, adapter_tag: &'static str) -> Option<Self> {
-        let recipe_path = resolve_recipe_path(repo_root, recipe_filename)?;
+        Self::new_with_home(repo_root, recipe_filename, adapter_tag, None)
+    }
+
+    /// Like [`RecipeBrain::new`], but accepts a `home_override` for the
+    /// hot-reload lookup so tests stay hermetic against the ambient
+    /// `~/.simard/prompt_assets` directory. Production calls `new` (`None`).
+    fn new_with_home(
+        repo_root: &Path,
+        recipe_filename: &str,
+        adapter_tag: &'static str,
+        home_override: Option<&Path>,
+    ) -> Option<Self> {
+        let recipe_path = resolve_recipe_path(repo_root, recipe_filename, home_override)?;
         let agent_binary = crate::session_builder::LlmProvider::resolve_agent_binary()?;
         if Command::new("recipe-runner-rs")
             .arg("--version")
@@ -1507,7 +1528,12 @@ mod tests {
 
     #[test]
     fn resolve_recipe_path_returns_none_for_nonexistent_repo() {
-        let result = resolve_recipe_path(Path::new("/nonexistent"), "ooda-decide.yaml");
+        let home = tempfile::TempDir::new().expect("tempdir");
+        let result = resolve_recipe_path(
+            Path::new("/nonexistent"),
+            "ooda-decide.yaml",
+            Some(home.path()),
+        );
         assert!(
             result.is_none(),
             "must return None when neither hot-reload nor in-tree path exists"
@@ -1516,7 +1542,9 @@ mod tests {
 
     #[test]
     fn resolve_recipe_path_returns_none_for_nonexistent_filename() {
-        let result = resolve_recipe_path(Path::new("/tmp"), "does-not-exist.yaml");
+        let home = tempfile::TempDir::new().expect("tempdir");
+        let result =
+            resolve_recipe_path(Path::new("/tmp"), "does-not-exist.yaml", Some(home.path()));
         assert!(
             result.is_none(),
             "must return None when the recipe filename doesn't match any file"
@@ -1531,7 +1559,7 @@ mod tests {
         let recipe_file = recipe_dir.join("ooda-decide.yaml");
         std::fs::write(&recipe_file, "# test recipe").unwrap();
 
-        let result = resolve_recipe_path(tmp.path(), "ooda-decide.yaml");
+        let result = resolve_recipe_path(tmp.path(), "ooda-decide.yaml", Some(tmp.path()));
         assert_eq!(
             result,
             Some(recipe_file),
@@ -1550,8 +1578,8 @@ mod tests {
         std::fs::write(recipe_dir.join("ooda-decide.yaml"), "# decide").unwrap();
         std::fs::write(recipe_dir.join("ooda-orient.yaml"), "# orient").unwrap();
 
-        let decide_path = resolve_recipe_path(tmp.path(), "ooda-decide.yaml");
-        let orient_path = resolve_recipe_path(tmp.path(), "ooda-orient.yaml");
+        let decide_path = resolve_recipe_path(tmp.path(), "ooda-decide.yaml", Some(tmp.path()));
+        let orient_path = resolve_recipe_path(tmp.path(), "ooda-orient.yaml", Some(tmp.path()));
 
         assert_ne!(
             decide_path, orient_path,
@@ -1581,30 +1609,36 @@ mod tests {
 
     #[test]
     fn new_returns_none_when_decide_recipe_missing() {
-        let brain = RecipeBrain::new(
+        let home = tempfile::TempDir::new().expect("tempdir");
+        let brain = RecipeBrain::new_with_home(
             Path::new("/nonexistent"),
             "ooda-decide.yaml",
             "recipe-decide-brain",
+            Some(home.path()),
         );
         assert!(brain.is_none());
     }
 
     #[test]
     fn new_returns_none_when_orient_recipe_missing() {
-        let brain = RecipeBrain::new(
+        let home = tempfile::TempDir::new().expect("tempdir");
+        let brain = RecipeBrain::new_with_home(
             Path::new("/nonexistent"),
             "ooda-orient.yaml",
             "recipe-orient-brain",
+            Some(home.path()),
         );
         assert!(brain.is_none());
     }
 
     #[test]
     fn new_returns_none_when_lifecycle_recipe_missing() {
-        let brain = RecipeBrain::new(
+        let home = tempfile::TempDir::new().expect("tempdir");
+        let brain = RecipeBrain::new_with_home(
             Path::new("/nonexistent"),
             "ooda-engineer-lifecycle.yaml",
             "recipe-engineer-lifecycle-brain",
+            Some(home.path()),
         );
         assert!(brain.is_none());
     }
@@ -1873,7 +1907,7 @@ mod tests {
         std::fs::create_dir_all(&recipe_dir).unwrap();
         std::fs::write(recipe_dir.join("ooda-decide.yaml"), "# decide").unwrap();
 
-        let path = resolve_recipe_path(tmp.path(), "ooda-decide.yaml");
+        let path = resolve_recipe_path(tmp.path(), "ooda-decide.yaml", Some(tmp.path()));
         assert!(path.is_some());
         assert!(path.unwrap().to_str().unwrap().contains("ooda-decide.yaml"));
     }
@@ -1885,7 +1919,7 @@ mod tests {
         std::fs::create_dir_all(&recipe_dir).unwrap();
         std::fs::write(recipe_dir.join("ooda-orient.yaml"), "# orient").unwrap();
 
-        let path = resolve_recipe_path(tmp.path(), "ooda-orient.yaml");
+        let path = resolve_recipe_path(tmp.path(), "ooda-orient.yaml", Some(tmp.path()));
         assert!(path.is_some());
         assert!(path.unwrap().to_str().unwrap().contains("ooda-orient.yaml"));
     }
@@ -1901,7 +1935,8 @@ mod tests {
         )
         .unwrap();
 
-        let path = resolve_recipe_path(tmp.path(), "ooda-engineer-lifecycle.yaml");
+        let path =
+            resolve_recipe_path(tmp.path(), "ooda-engineer-lifecycle.yaml", Some(tmp.path()));
         assert!(path.is_some());
         assert!(
             path.unwrap()

--- a/src/ooda_brain/recipe_brain.rs
+++ b/src/ooda_brain/recipe_brain.rs
@@ -21,7 +21,7 @@ use super::orient::{
     FAILURE_PENALTY_PER_CONSECUTIVE, OodaOrientBrain, OrientContext, OrientJudgment,
 };
 use super::sanitize::sanitize_context_var;
-use super::{EngineerLifecycleCtx, EngineerLifecycleDecision, OodaBrain};
+use super::{BrainPhase, EngineerLifecycleCtx, EngineerLifecycleDecision, OodaBrain};
 use crate::error::{SimardError, SimardResult};
 
 #[cfg(test)]
@@ -40,6 +40,18 @@ const MAX_RATIONALE_CHARS: usize = 500;
 /// (issue #2419). `value` is always `1.0`; the `outcome` label in the context
 /// JSON is the numerator/denominator signal.
 const LIFECYCLE_DECISION_METRIC: &str = "brain_lifecycle_decision";
+
+/// Shared metric emitted once per recipe-backed brain phase invocation
+/// (decide / orient / merge-judge) so the verdict/decision parse-success rate
+/// is measurable across the whole class from `metrics.jsonl` (issue #2429).
+///
+/// `value` is always `1.0`; the context JSON carries `{phase, outcome, …}` where
+/// `outcome` is `"parsed"` (a real verdict/decision was extracted — including a
+/// ladder recovery) or `"defaulted"` (no parseable verdict; a deterministic
+/// fallback was applied — the bug surface). The derived
+/// `parse_success_rate{phase} = parsed / (parsed + defaulted)` is what the
+/// monitoring path alerts on.
+const VERDICT_PARSE_METRIC: &str = "brain_verdict_parsed_total";
 
 /// Cap on the `first_word` token recorded in the metric context. Generous
 /// enough to capture any legitimate variant name plus stray punctuation, but
@@ -87,7 +99,10 @@ struct RecipeStepResult {
 /// decoded, the recipe reported `success=false`, or no step produced output.
 /// This keeps a broken recipe-runner visible instead of masquerading as a
 /// `default_empty` parse.
-fn extract_recipe_decision_output(stdout: &[u8], adapter_tag: &str) -> SimardResult<String> {
+pub(crate) fn extract_recipe_decision_output(
+    stdout: &[u8],
+    adapter_tag: &str,
+) -> SimardResult<String> {
     let mut envelope: RecipeEnvelope =
         serde_json::from_slice(stdout).map_err(|e| SimardError::AdapterInvocationFailed {
             base_type: adapter_tag.to_string(),
@@ -254,6 +269,73 @@ pub fn build_escalation_note(rung: LadderRung, prior_output: &str) -> String {
     }
 }
 
+/// Generic `escalation_note` builder shared by the decide / orient / merge-judge
+/// phases (issue #2419 family / #2429). Same three-rung structure as the
+/// lifecycle [`build_escalation_note`] — empty on `Base` (byte-identical base
+/// behaviour), a schema-repair note on `SchemaRepair`, and schema-repair plus a
+/// higher-effort tier on `Escalate` — but parameterised by the phase's own
+/// output contract so each brain reminds the model of the correct shape (an
+/// action word / a bare decimal / a `{"verdict": …}` JSON object).
+///
+/// `repair_instruction` describes the required output shape; `high_effort` is
+/// the extra reasoning instruction appended on the final rung.
+pub(crate) fn build_phase_escalation_note(
+    rung: LadderRung,
+    prior_output: &str,
+    repair_instruction: &str,
+    high_effort: &str,
+) -> String {
+    // Built lazily so the Base rung allocates nothing.
+    let schema_repair = || {
+        let prior = truncate(prior_output.trim(), MAX_RATIONALE_CHARS);
+        format!(
+            "## ⚠️ SCHEMA REPAIR (retry) ## \
+             Your previous response could not be parsed. \
+             Previous response: <<<{prior}>>> \
+             Respond again now. {repair_instruction}"
+        )
+    };
+    match rung {
+        LadderRung::Base => String::new(),
+        LadderRung::SchemaRepair => schema_repair(),
+        LadderRung::Escalate => format!(
+            "{} ## HIGH-EFFORT RETRY ## This is a final, higher-effort attempt. {high_effort}",
+            schema_repair()
+        ),
+    }
+}
+
+/// Closed action-keyword list echoed into the decide schema-repair note. Kept in
+/// sync with the `parse_action_outcome` match and the `ooda-decide.yaml` OPTIONS.
+const DECIDE_VARIANT_LIST: &str = "poll_developer_activity, consolidate_memory, run_improvement, extract_ideas, safe_update, research_query, run_gym_eval, build_skill, launch_session, advance_goal";
+
+/// Build the decide-phase `escalation_note` for a ladder rung (issue #2421).
+fn build_decide_escalation_note(rung: LadderRung, prior_output: &str) -> String {
+    build_phase_escalation_note(
+        rung,
+        prior_output,
+        &format!(
+            "The VERY FIRST WORD of your reply MUST be exactly one of: {DECIDE_VARIANT_LIST}. \
+             Output that action word first, then your rationale."
+        ),
+        "Reason carefully about the goal_id and reason BEFORE answering, then output the single \
+         action word first.",
+    )
+}
+
+/// Build the orient-phase `escalation_note` for a ladder rung (issue #2421).
+fn build_orient_escalation_note(rung: LadderRung, prior_output: &str) -> String {
+    build_phase_escalation_note(
+        rung,
+        prior_output,
+        "The VERY FIRST TOKEN of your reply MUST be a bare decimal number between 0.0 and the \
+         base urgency (e.g. `0.42`) — the adjusted urgency. Output that decimal first, then your \
+         rationale. Do NOT output a timing value or any other number first.",
+        "Reason carefully about the failure history BEFORE answering, then output the single bare \
+         decimal first.",
+    )
+}
+
 /// Bound on how far the escalation ladder climbs. Configurable via
 /// `SIMARD_BRAIN_ESCALATION_MAX_ATTEMPTS`, hard-capped so a misconfiguration
 /// can never turn the brain into an unbounded retry loop.
@@ -368,6 +450,65 @@ pub fn run_escalation_ladder(
     u32,
     LadderTermination,
 ) {
+    // Thin lifecycle-specific wrapper over the generic [`run_brain_ladder`]
+    // backbone (issue #2419 family / #2429): the lifecycle phase owns the
+    // invoke (recipe-runner `LadderAttempt`), the parser
+    // ([`parse_lifecycle_outcome`]), the deterministic default
+    // ([`default_continue_skipping`]), and the decision-label closure; the
+    // generic core owns the bounded rung loop, the loud logging, and the
+    // [`LadderTermination`] accounting. This keeps the decide / orient /
+    // merge-judge phases on the SAME ladder rather than reinventing it.
+    run_brain_ladder(
+        &ctx.goal_id,
+        base_raw,
+        base_outcome,
+        cfg,
+        |rung, prior| {
+            let attempt = LadderAttempt {
+                rung,
+                prior_output: prior,
+            };
+            invoker.invoke_lifecycle(ctx, &attempt)
+        },
+        parse_lifecycle_outcome,
+        default_continue_skipping,
+        |d| lifecycle_decision_choice(d).to_string(),
+    )
+}
+
+/// Generic confidence-gated escalation ladder backbone shared by every
+/// recipe-backed brain phase (engineer-lifecycle, decide, orient, merge-judge —
+/// issue #2419 family / #2429).
+///
+/// On a base parse-miss the phase spends EXTRA compute ONLY on that weak case: a
+/// bounded sequence of re-prompts (schema-repair, then a higher-effort tier)
+/// driven by `invoke(rung, prior_output)`. The deterministic, *loud* `default()`
+/// is reached only AFTER every rung is exhausted (or a rung's own invocation
+/// fails) — never a silent default-on-first-miss.
+///
+/// Phase-specific behaviour is injected via closures so the core stays
+/// decision-type-agnostic:
+/// - `invoke(rung, prior_output)` runs the recipe for a rung (it owns building
+///   the phase's `escalation_note`) and returns the raw final-step output;
+/// - `parse(raw)` classifies the output into `(decision, outcome)`; an outcome
+///   for which `is_parse_failure()` holds drives escalation;
+/// - `default()` is the deterministic fallback decision;
+/// - `decision_label(&decision)` is a short tag used only for logging.
+///
+/// Returns the final decision, its outcome (`Repaired`/`Escalated` on recovery,
+/// else the original parse-miss), the total brain invocations (base + rungs),
+/// and the [`LadderTermination`] reason.
+#[allow(clippy::too_many_arguments)]
+pub fn run_brain_ladder<D>(
+    goal_id: &str,
+    base_raw: &str,
+    base_outcome: LifecycleParseOutcome,
+    cfg: &EscalationConfig,
+    invoke: impl Fn(LadderRung, &str) -> SimardResult<String>,
+    parse: impl Fn(&str) -> (D, LifecycleParseOutcome),
+    default: impl Fn() -> D,
+    decision_label: impl Fn(&D) -> String,
+) -> (D, LifecycleParseOutcome, u32, LadderTermination) {
     let mut prior = base_raw.to_string();
     let mut attempts = 1u32; // the base attempt already happened
     let mut invoke_failed = false;
@@ -382,7 +523,7 @@ pub fn run_escalation_ladder(
 
         tracing::warn!(
             target: "simard::ooda_brain",
-            goal = %ctx.goal_id,
+            goal = %goal_id,
             rung = ?rung,
             attempt = attempts,
             base_outcome = base_outcome.label(),
@@ -390,51 +531,45 @@ pub fn run_escalation_ladder(
         );
         eprintln!(
             "[simard] BRAIN ESCALATION goal={} rung={:?} attempt={} (parse-miss recovery)",
-            ctx.goal_id, rung, attempts
+            goal_id, rung, attempts
         );
 
-        let attempt = LadderAttempt {
-            rung,
-            prior_output: &prior,
-        };
-        match invoker.invoke_lifecycle(ctx, &attempt) {
+        match invoke(rung, &prior) {
             Err(e) => {
                 tracing::warn!(
                     target: "simard::ooda_brain",
-                    goal = %ctx.goal_id,
+                    goal = %goal_id,
                     rung = ?rung,
                     error = %e,
                     "brain escalation attempt failed to invoke; stopping ladder, using deterministic default"
                 );
                 eprintln!(
                     "[simard] BRAIN ESCALATION goal={} rung={:?} invoke failed: {e} — falling back to default",
-                    ctx.goal_id, rung
+                    goal_id, rung
                 );
                 invoke_failed = true;
                 break;
             }
             Ok(raw2) => {
-                let (decision, oc) = parse_lifecycle_outcome(&raw2);
+                let (decision, oc) = parse(&raw2);
                 if !oc.is_parse_failure() {
                     let recovered = match rung {
                         LadderRung::SchemaRepair => LifecycleParseOutcome::Repaired,
                         LadderRung::Escalate => LifecycleParseOutcome::Escalated,
                         LadderRung::Base => oc,
                     };
+                    let label = decision_label(&decision);
                     tracing::info!(
                         target: "simard::ooda_brain",
-                        goal = %ctx.goal_id,
+                        goal = %goal_id,
                         rung = ?rung,
                         attempt = attempts,
-                        decision = lifecycle_decision_choice(&decision),
+                        decision = %label,
                         "brain decision RECOVERED via escalation ladder (issue #2432)"
                     );
                     eprintln!(
                         "[simard] BRAIN ESCALATION goal={} RECOVERED decision={} via {:?} (attempt {})",
-                        ctx.goal_id,
-                        lifecycle_decision_choice(&decision),
-                        rung,
-                        attempts
+                        goal_id, label, rung, attempts
                     );
                     return (decision, recovered, attempts, LadderTermination::Recovered);
                 }
@@ -459,7 +594,7 @@ pub fn run_escalation_ladder(
     if cfg.max_escalations > 0 {
         tracing::warn!(
             target: "simard::ooda_brain",
-            goal = %ctx.goal_id,
+            goal = %goal_id,
             attempts,
             base_outcome = base_outcome.label(),
             termination = ?termination,
@@ -467,16 +602,11 @@ pub fn run_escalation_ladder(
         );
         eprintln!(
             "[simard] BRAIN ESCALATION goal={} ladder ended ({}) after {attempts} attempts — deterministic default",
-            ctx.goal_id,
+            goal_id,
             termination.cause_label()
         );
     }
-    (
-        default_continue_skipping(),
-        base_outcome,
-        attempts,
-        termination,
-    )
+    (default(), base_outcome, attempts, termination)
 }
 
 /// Resolve the recipe YAML path. Checks, in order:
@@ -548,16 +678,101 @@ impl RecipeBrain {
 }
 
 impl OodaDecideBrain for RecipeBrain {
+    /// Decide-phase action routing.
+    ///
+    /// Issue #2421 / #2429: invoke `recipe-runner-rs --output-format json` and
+    /// parse the agent's REAL decision text (the JSON envelope's final step
+    /// output) — not the text-mode SUCCESS banner whose first word `Recipe:`
+    /// always silently defaulted to `advance_goal`, ignoring the LLM every
+    /// cycle. On a base parse-miss, spend extra compute on the confidence-gated
+    /// escalation ladder (schema-repair → high-effort) before falling — loudly —
+    /// to the deterministic `advance_goal` default. A `brain_verdict_parsed_total`
+    /// metric is emitted on both the parsed and the defaulted branch.
     fn judge_decision(&self, ctx: &DecideContext) -> SimardResult<DecideJudgment> {
-        // KNOWN LIMITATION (issue #2421): this phase still reads recipe-runner-rs
-        // DEFAULT `text` stdout (the summary banner), so `parse_action_from_text`
-        // always sees `Recipe:` and silently defaults to `AdvanceGoal`. It shares
-        // the exact root cause fixed for the lifecycle phase in issue #2419 but is
-        // deferred there to bound the behavioral blast radius (top-level action
-        // routing). Tracked + to be fixed via `--output-format json` + envelope
-        // extraction in #2421.
+        let invoke = |rung: LadderRung, prior: &str| self.invoke_decide_raw(ctx, rung, prior);
+
+        // Base (cheap) attempt. A genuine recipe-runner failure (spawn / nonzero
+        // exit / envelope decode) still surfaces loudly as `Err` — only a
+        // *parse-miss* on a successful run is low-confidence enough to escalate.
+        let base_raw = invoke(LadderRung::Base, "")?;
+        let (decision, outcome) = parse_action_outcome(&base_raw);
+        if !outcome.is_parse_failure() {
+            record_verdict_parse_metric(BrainPhase::Decide, &ctx.goal_id, outcome, 1);
+            return Ok(decision);
+        }
+
+        let cfg = EscalationConfig::from_env();
+        let (final_decision, final_outcome, attempts, _termination) = run_brain_ladder(
+            &ctx.goal_id,
+            &base_raw,
+            outcome,
+            &cfg,
+            invoke,
+            parse_action_outcome,
+            default_advance_goal,
+            |d| decide_decision_choice(d).to_string(),
+        );
+        record_verdict_parse_metric(BrainPhase::Decide, &ctx.goal_id, final_outcome, attempts);
+        Ok(final_decision)
+    }
+}
+
+impl OodaOrientBrain for RecipeBrain {
+    /// Orient-phase failure-penalty demotion.
+    ///
+    /// Issue #2421 / #2429: invoke `recipe-runner-rs --output-format json` and
+    /// parse the agent's REAL urgency decimal (the JSON envelope's final step
+    /// output) — not the text-mode banner, whose timing string `(0.0s)` was
+    /// scraped as a finite, in-range `0.0` and ACTIVELY demoted the goal's
+    /// urgency to a value mined from the banner rather than the LLM's judgment.
+    /// On a base parse-miss, run the escalation ladder, then fall — loudly — to
+    /// the deterministic floor (`base_urgency − 0.2 × failure_count`). Emits the
+    /// shared `brain_verdict_parsed_total` metric on both branches.
+    fn judge_orientation(&self, ctx: &OrientContext) -> SimardResult<OrientJudgment> {
+        let invoke = |rung: LadderRung, prior: &str| self.invoke_orient_raw(ctx, rung, prior);
+        let parse = |raw: &str| parse_orient_outcome(raw, ctx.base_urgency, ctx.failure_count);
+        let default = || deterministic_floor(ctx.base_urgency, ctx.failure_count);
+
+        let base_raw = invoke(LadderRung::Base, "")?;
+        let (judgment, outcome) = parse(&base_raw);
+        if !outcome.is_parse_failure() {
+            record_verdict_parse_metric(BrainPhase::Orient, &ctx.goal_id, outcome, 1);
+            return Ok(judgment);
+        }
+
+        let cfg = EscalationConfig::from_env();
+        let (final_judgment, final_outcome, attempts, _termination) = run_brain_ladder(
+            &ctx.goal_id,
+            &base_raw,
+            outcome,
+            &cfg,
+            invoke,
+            parse,
+            default,
+            |j| format!("urgency={:.3}", j.adjusted_urgency),
+        );
+        record_verdict_parse_metric(BrainPhase::Orient, &ctx.goal_id, final_outcome, attempts);
+        Ok(final_judgment)
+    }
+}
+
+impl RecipeBrain {
+    /// Invoke the decide recipe once for a ladder rung, returning the agent's
+    /// raw decision text (the JSON envelope's final step output). Genuine
+    /// recipe-runner failures propagate as `Err` (issue #2421).
+    fn invoke_decide_raw(
+        &self,
+        ctx: &DecideContext,
+        rung: LadderRung,
+        prior_output: &str,
+    ) -> SimardResult<String> {
+        let escalation_note = build_decide_escalation_note(rung, prior_output);
         let output = Command::new("recipe-runner-rs")
             .arg(self.recipe_path.as_os_str())
+            // issue #2421: text mode prints only a summary banner to stdout —
+            // the agent decision text is only exposed via the JSON envelope.
+            .arg("--output-format")
+            .arg("json")
             .env("AMPLIHACK_AGENT_BINARY", self.agent_binary)
             .arg("-c")
             .arg(format!(
@@ -568,6 +783,12 @@ impl OodaDecideBrain for RecipeBrain {
             .arg(format!("urgency={:.3}", ctx.urgency))
             .arg("-c")
             .arg(format!("reason={}", sanitize_context_var(&ctx.reason, 500)))
+            // issue #2432: the (possibly empty) escalation/schema-repair note.
+            .arg("-c")
+            .arg(format!(
+                "escalation_note={}",
+                sanitize_context_var(&escalation_note, 4000)
+            ))
             .output()
             .map_err(|e| SimardError::AdapterInvocationFailed {
                 base_type: self.adapter_tag.to_string(),
@@ -581,27 +802,28 @@ impl OodaDecideBrain for RecipeBrain {
                 reason: format!(
                     "recipe exited with {}: {}",
                     output.status,
-                    truncate(&stderr, 500)
+                    truncate(&stderr, MAX_RATIONALE_CHARS)
                 ),
             });
         }
 
-        let raw = String::from_utf8(output.stdout)
-            .unwrap_or_else(|e| String::from_utf8_lossy(e.as_bytes()).into_owned());
-        Ok(parse_action_from_text(&raw))
+        extract_recipe_decision_output(&output.stdout, self.adapter_tag)
     }
-}
 
-impl OodaOrientBrain for RecipeBrain {
-    fn judge_orientation(&self, ctx: &OrientContext) -> SimardResult<OrientJudgment> {
-        // KNOWN LIMITATION (issue #2421): like `judge_decision` above, this reads
-        // recipe-runner-rs DEFAULT `text` stdout. Worse than a benign default —
-        // `parse_orient_from_text` scans the banner for the first decimal in
-        // [0, base_urgency] and the banner's timing string (e.g. `(0.0s)`) yields
-        // `0.0`, silently demoting urgency to a scraped timing value rather than
-        // the LLM's judgment. Same #2419 root cause; fix tracked in #2421.
+    /// Invoke the orient recipe once for a ladder rung, returning the agent's
+    /// raw urgency text (the JSON envelope's final step output). Genuine
+    /// recipe-runner failures propagate as `Err` (issue #2421).
+    fn invoke_orient_raw(
+        &self,
+        ctx: &OrientContext,
+        rung: LadderRung,
+        prior_output: &str,
+    ) -> SimardResult<String> {
+        let escalation_note = build_orient_escalation_note(rung, prior_output);
         let output = Command::new("recipe-runner-rs")
             .arg(self.recipe_path.as_os_str())
+            .arg("--output-format")
+            .arg("json")
             .env("AMPLIHACK_AGENT_BINARY", self.agent_binary)
             .arg("-c")
             .arg(format!(
@@ -617,6 +839,11 @@ impl OodaOrientBrain for RecipeBrain {
             ))
             .arg("-c")
             .arg(format!("failure_count={}", ctx.failure_count))
+            .arg("-c")
+            .arg(format!(
+                "escalation_note={}",
+                sanitize_context_var(&escalation_note, 4000)
+            ))
             .output()
             .map_err(|e| SimardError::AdapterInvocationFailed {
                 base_type: self.adapter_tag.to_string(),
@@ -630,18 +857,12 @@ impl OodaOrientBrain for RecipeBrain {
                 reason: format!(
                     "recipe exited with {}: {}",
                     output.status,
-                    truncate(&stderr, 500)
+                    truncate(&stderr, MAX_RATIONALE_CHARS)
                 ),
             });
         }
 
-        let raw = String::from_utf8(output.stdout)
-            .unwrap_or_else(|e| String::from_utf8_lossy(e.as_bytes()).into_owned());
-        Ok(parse_orient_from_text(
-            &raw,
-            ctx.base_urgency,
-            ctx.failure_count,
-        ))
+        extract_recipe_decision_output(&output.stdout, self.adapter_tag)
     }
 }
 
@@ -845,8 +1066,30 @@ impl OodaBrain for RecipeBrain {
 /// Parse recipe stdout for an action keyword as the first word (decide phase).
 /// Case-insensitive match on the first whitespace-delimited token.
 /// Defaults to `advance_goal` if the first word is unrecognised.
+///
+/// Thin decision-only wrapper over [`parse_action_outcome`]; production routes
+/// through the latter to capture the parse outcome for the escalation ladder
+/// and the `brain_verdict_parsed_total` metric (issue #2421 / #2429).
+#[cfg_attr(not(test), allow(dead_code))]
 pub fn parse_action_from_text(text: &str) -> DecideJudgment {
+    parse_action_outcome(text).0
+}
+
+/// Parse recipe output into a decide action AND a [`LifecycleParseOutcome`]
+/// classification (issue #2421 / #2429).
+///
+/// The outcome distinguishes a genuinely parsed action (`Parsed` — including a
+/// real `advance_goal`) from the two ways the parser falls back to
+/// `AdvanceGoal`: `DefaultEmpty` (no text at all) and `DefaultMalformed` (text
+/// present but the first word is not a known action). Before this split a real
+/// `advance_goal` decision and a silent banner-misparse fallback were
+/// indistinguishable — which is exactly what let the text-mode banner masquerade
+/// as "working" (the first word `Recipe:` always defaulted to `AdvanceGoal`).
+pub fn parse_action_outcome(text: &str) -> (DecideJudgment, LifecycleParseOutcome) {
     let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return (default_advance_goal(), LifecycleParseOutcome::DefaultEmpty);
+    }
     let first_word = trimmed.split_whitespace().next().unwrap_or("");
 
     // Rationale allocation is deferred into the match arm — avoids a
@@ -886,13 +1129,43 @@ pub fn parse_action_from_text(text: &str) -> DecideJudgment {
     ];
     for (kw, ctor) in pairs {
         if first_word.eq_ignore_ascii_case(kw) {
-            return ctor(truncate(trimmed, MAX_RATIONALE_CHARS));
+            return (
+                ctor(truncate(trimmed, MAX_RATIONALE_CHARS)),
+                LifecycleParseOutcome::Parsed,
+            );
         }
     }
+    (
+        default_advance_goal(),
+        LifecycleParseOutcome::DefaultMalformed,
+    )
+}
+
+/// The loud deterministic decide default — `advance_goal` with a rationale that
+/// names the parse-miss so a defaulted row is never mistaken for a real LLM
+/// `advance_goal` decision.
+fn default_advance_goal() -> DecideJudgment {
     DecideJudgment::AdvanceGoal {
         rationale: format!(
             "{DECIDE_ADAPTER_TAG}: no action keyword found in recipe output; defaulting to advance_goal"
         ),
+    }
+}
+
+/// The snake_case action tag of a decide judgment, used only as the `decision`
+/// label in escalation-ladder logging.
+fn decide_decision_choice(decision: &DecideJudgment) -> &'static str {
+    match decision {
+        DecideJudgment::AdvanceGoal { .. } => "advance_goal",
+        DecideJudgment::RunImprovement { .. } => "run_improvement",
+        DecideJudgment::ConsolidateMemory { .. } => "consolidate_memory",
+        DecideJudgment::ResearchQuery { .. } => "research_query",
+        DecideJudgment::RunGymEval { .. } => "run_gym_eval",
+        DecideJudgment::BuildSkill { .. } => "build_skill",
+        DecideJudgment::LaunchSession { .. } => "launch_session",
+        DecideJudgment::PollDeveloperActivity { .. } => "poll_developer_activity",
+        DecideJudgment::ExtractIdeas { .. } => "extract_ideas",
+        DecideJudgment::SafeUpdate { .. } => "safe_update",
     }
 }
 
@@ -902,7 +1175,28 @@ pub fn parse_action_from_text(text: &str) -> DecideJudgment {
 
 /// Parse recipe output for the first decimal float (e.g. `0.42`).
 /// Falls to the deterministic floor when no valid float is found.
+///
+/// Thin judgment-only wrapper over [`parse_orient_outcome`]; production routes
+/// through the latter to capture the parse outcome for the escalation ladder
+/// and the `brain_verdict_parsed_total` metric (issue #2421 / #2429).
+#[cfg_attr(not(test), allow(dead_code))]
 pub fn parse_orient_from_text(text: &str, base_urgency: f64, failure_count: u32) -> OrientJudgment {
+    parse_orient_outcome(text, base_urgency, failure_count).0
+}
+
+/// Parse recipe output into an orient judgment AND a [`LifecycleParseOutcome`]
+/// classification (issue #2421 / #2429).
+///
+/// `Parsed` when a valid in-range decimal was extracted; otherwise the
+/// deterministic floor is returned and the outcome is `DefaultEmpty` (no text)
+/// or `DefaultMalformed` (text present but no valid decimal). This is what makes
+/// the orient banner-misparse measurable: the text-mode banner's `(0.0s)` timing
+/// would otherwise be scraped as a real `0.0` urgency and counted as `Parsed`.
+pub fn parse_orient_outcome(
+    text: &str,
+    base_urgency: f64,
+    failure_count: u32,
+) -> (OrientJudgment, LifecycleParseOutcome) {
     // Hoist trim above the scanner — avoids re-trimming on each candidate.
     let trimmed = text.trim();
     let bytes = text.as_bytes();
@@ -924,12 +1218,15 @@ pub fn parse_orient_from_text(text: &str, base_urgency: f64, failure_count: u32)
                 {
                     // Inline validation before allocating rationale string.
                     if val.is_finite() && (0.0..=1.0).contains(&val) && val <= base_urgency + 1e-9 {
-                        return OrientJudgment {
-                            adjusted_urgency: val,
-                            rationale: truncate(trimmed, MAX_RATIONALE_CHARS),
-                            confidence: 1.0,
-                            demotion_applied: base_urgency - val,
-                        };
+                        return (
+                            OrientJudgment {
+                                adjusted_urgency: val,
+                                rationale: truncate(trimmed, MAX_RATIONALE_CHARS),
+                                confidence: 1.0,
+                                demotion_applied: base_urgency - val,
+                            },
+                            LifecycleParseOutcome::Parsed,
+                        );
                     }
                 }
             }
@@ -937,7 +1234,12 @@ pub fn parse_orient_from_text(text: &str, base_urgency: f64, failure_count: u32)
         }
         i += 1;
     }
-    deterministic_floor(base_urgency, failure_count)
+    let miss = if trimmed.is_empty() {
+        LifecycleParseOutcome::DefaultEmpty
+    } else {
+        LifecycleParseOutcome::DefaultMalformed
+    };
+    (deterministic_floor(base_urgency, failure_count), miss)
 }
 
 /// Compute the deterministic floor judgment.
@@ -1116,6 +1418,73 @@ fn record_lifecycle_decision_metric(
             error = %e,
             outcome = outcome.label(),
             "failed to record brain_lifecycle_decision metric (decision unaffected)",
+        );
+    }
+}
+
+/// The `outcome` label for the [`VERDICT_PARSE_METRIC`]: `"parsed"` when a real
+/// verdict/decision was extracted (base parse, or a ladder `Repaired`/
+/// `Escalated` recovery), `"defaulted"` when a deterministic fallback was
+/// applied (`DefaultEmpty`/`DefaultMalformed`/`Error` — the bug surface).
+fn verdict_outcome_label(outcome: LifecycleParseOutcome) -> &'static str {
+    if outcome.is_parse_failure() {
+        "defaulted"
+    } else {
+        "parsed"
+    }
+}
+
+/// Build the JSON `context` payload for the shared `brain_verdict_parsed_total`
+/// metric. Separated from the I/O so the payload shape can be unit-tested
+/// without touching the real `metrics.jsonl`.
+fn build_verdict_parse_context(
+    phase: BrainPhase,
+    goal_id: &str,
+    outcome: LifecycleParseOutcome,
+    attempts: u32,
+) -> String {
+    serde_json::json!({
+        "phase": phase.as_str(),
+        // Coarse parsed/defaulted signal — the numerator/denominator for
+        // `parse_success_rate{phase}` (issue #2429).
+        "outcome": verdict_outcome_label(outcome),
+        // Fine-grained classification (parsed / repaired / escalated /
+        // default_empty / default_malformed / error) for drill-down.
+        "outcome_detail": outcome.label(),
+        "is_parse_failure": outcome.is_parse_failure(),
+        "goal_id": goal_id,
+        // Total brain invocations spent (base + escalation rungs).
+        "attempts": attempts,
+    })
+    .to_string()
+}
+
+/// Record one `brain_verdict_parsed_total` metric event (value `1.0`) per
+/// recipe-backed brain phase invocation, on BOTH the parsed and the defaulted
+/// branch, so the per-phase parse-success rate has a denominator (issue #2429).
+///
+/// Best-effort: a metrics-write failure is logged, never propagated — the brain
+/// decision must not fail because telemetry could not be persisted.
+///
+/// No-op under `cfg!(test)` so unit tests never append to the operator's real
+/// `~/.simard/metrics/metrics.jsonl`.
+pub(crate) fn record_verdict_parse_metric(
+    phase: BrainPhase,
+    goal_id: &str,
+    outcome: LifecycleParseOutcome,
+    attempts: u32,
+) {
+    let context = build_verdict_parse_context(phase, goal_id, outcome, attempts);
+    if cfg!(test) {
+        return;
+    }
+    if let Err(e) = crate::self_metrics::record_metric(VERDICT_PARSE_METRIC, 1.0, &context) {
+        tracing::warn!(
+            target: "simard::ooda_brain",
+            error = %e,
+            phase = phase.as_str(),
+            outcome = outcome.label(),
+            "failed to record brain_verdict_parsed_total metric (decision unaffected)",
         );
     }
 }
@@ -3086,6 +3455,395 @@ mod tests {
                 "repair note must carry the prior output; got {}",
                 notes[0]
             );
+        }
+    }
+
+    // =================================================================
+    // issue_2421_tests — decide + orient verdict/decision parse cluster
+    //
+    // The decide (`judge_decision`) and orient (`judge_orientation`) trait
+    // impls share the EXACT #2419 root cause: they read recipe-runner-rs
+    // DEFAULT `text` stdout (the SUCCESS banner) instead of the
+    // `--output-format json` envelope's final step output.
+    //
+    //   - decide: the banner's first word is always `Recipe:`, which matches
+    //     no action keyword, so `parse_action_from_text` silently defaults to
+    //     `AdvanceGoal` every cycle (the LLM is ignored).
+    //   - orient: WORSE than a benign default — `parse_orient_from_text` scans
+    //     the banner for the first in-range decimal, and the timing string
+    //     `(0.0s)` yields `0.0`, ACTIVELY demoting the goal's urgency to a
+    //     value scraped from the banner rather than the LLM's judgment.
+    //
+    // These tests pin both the banner misparse (the bug) and the JSON-envelope
+    // recovery (the fix) at the parse seam, using the existing
+    // `extract_recipe_decision_output` helper. The live recipe-runner boundary
+    // is covered by `tests/gadugi/decide-orient-brain-parse.sh`.
+    // =================================================================
+    mod issue_2421_tests {
+        use super::super::*;
+        use crate::ooda_loop::ActionKind;
+
+        const DECIDE_BANNER: &str = "Recipe: ooda-decide (v1.0.0)\nSteps: 1\n\nRecipe 'ooda-decide': SUCCESS (0.0s)\n  [completed] decide-action (0.0s)\n\n";
+        const ORIENT_BANNER: &str = "Recipe: ooda-orient (v1.0.0)\nSteps: 1\n\nRecipe 'ooda-orient': SUCCESS (0.0s)\n  [completed] orient-decision (0.0s)\n\n";
+
+        // --- decide: banner misparse pin + JSON-envelope recovery -----------
+
+        #[test]
+        fn decide_banner_first_word_is_never_a_valid_action() {
+            // Regression pin for the silent-`AdvanceGoal` half of #2421: the
+            // banner's first word `Recipe:` matches no action, so the parser
+            // falls back to AdvanceGoal with the explicit "no action keyword"
+            // rationale. This proves the caller MUST NOT feed it the banner.
+            let j = parse_action_from_text(DECIDE_BANNER);
+            assert_eq!(j.action_kind(), ActionKind::AdvanceGoal);
+            assert!(
+                j.rationale().contains("no action keyword"),
+                "banner must classify as a default, not a real decision; got: {}",
+                j.rationale()
+            );
+        }
+
+        #[test]
+        fn decide_json_envelope_recovers_real_action() {
+            // The fix: extract the final step output from the json envelope and
+            // parse THAT — recovering a real (non-default) action the banner
+            // hid.
+            let envelope = r#"{
+                "recipe_name": "ooda-decide",
+                "success": true,
+                "step_results": [
+                    {"step_id": "decide-action",
+                     "output": "consolidate_memory context overhead is high this cycle",
+                     "error": "", "duration": 0.0}
+                ]
+            }"#;
+            let extracted =
+                extract_recipe_decision_output(envelope.as_bytes(), DECIDE_ADAPTER_TAG).unwrap();
+            let j = parse_action_from_text(&extracted);
+            assert_eq!(
+                j.action_kind(),
+                ActionKind::ConsolidateMemory,
+                "the JSON-envelope fix must recover the LLM's real action, not AdvanceGoal"
+            );
+        }
+
+        #[test]
+        fn decide_banner_is_not_a_valid_json_envelope() {
+            // Proves the decide phase must pass `--output-format json`: the
+            // text banner can never decode as an envelope, so a missing flag
+            // fails loudly instead of silently defaulting.
+            let err = extract_recipe_decision_output(DECIDE_BANNER.as_bytes(), DECIDE_ADAPTER_TAG)
+                .unwrap_err();
+            assert!(matches!(err, SimardError::AdapterInvocationFailed { .. }));
+        }
+
+        // --- orient: active urgency corruption pin + JSON-envelope recovery -
+
+        #[test]
+        fn orient_banner_timing_actively_corrupts_urgency() {
+            // Regression pin for the WORST half of #2421: the banner's `(0.0s)`
+            // timing yields a finite, in-range `0.0`, so the parser returns
+            // `adjusted_urgency = 0.0`, demoting the goal to a value scraped
+            // from the banner. Critically, 0.0 is NOT the deterministic floor
+            // (which would be base_urgency 0.8 for 0 failures) — proving the
+            // value was scraped from the banner, not computed.
+            let base_urgency = 0.8;
+            let failure_count = 0;
+            let j = parse_orient_from_text(ORIENT_BANNER, base_urgency, failure_count);
+            assert_eq!(
+                j.adjusted_urgency, 0.0,
+                "banner '(0.0s)' timing is scraped as urgency 0.0 — the bug"
+            );
+            // The deterministic floor for 0 failures would have preserved the
+            // base urgency; 0.0 != 0.8 confirms active corruption (not a floor).
+            assert!(
+                (j.adjusted_urgency - base_urgency).abs() > 1e-9,
+                "corrupted 0.0 must differ from the deterministic floor (0.8)"
+            );
+        }
+
+        #[test]
+        fn orient_json_envelope_recovers_real_urgency() {
+            // The fix: extract the final step output (the LLM's real decimal)
+            // from the json envelope rather than scraping the banner timing.
+            let envelope = r#"{
+                "recipe_name": "ooda-orient",
+                "success": true,
+                "step_results": [
+                    {"step_id": "orient-decision",
+                     "output": "0.65 goal remains high urgency despite one transient failure",
+                     "error": "", "duration": 0.0}
+                ]
+            }"#;
+            let extracted =
+                extract_recipe_decision_output(envelope.as_bytes(), ORIENT_ADAPTER_TAG).unwrap();
+            let j = parse_orient_from_text(&extracted, 0.8, 0);
+            assert!(
+                (j.adjusted_urgency - 0.65).abs() < 1e-9,
+                "must recover the LLM urgency 0.65, got {}",
+                j.adjusted_urgency
+            );
+        }
+
+        #[test]
+        fn orient_extraction_isolates_llm_decimal_from_timing_banner() {
+            // The envelope JSON text itself contains a `(0.0s)` timing string
+            // (in an earlier step's output), but extraction returns ONLY the
+            // FINAL step output `0.7`, so the parsed urgency is the LLM's
+            // decimal — never the timing noise.
+            let envelope = r#"{
+                "success": true,
+                "step_results": [
+                    {"step_id": "prep", "output": "ran in (0.0s)", "error": "", "duration": 0.0},
+                    {"step_id": "orient-decision", "output": "0.7", "error": "", "duration": 0.0}
+                ]
+            }"#;
+            let extracted =
+                extract_recipe_decision_output(envelope.as_bytes(), ORIENT_ADAPTER_TAG).unwrap();
+            assert_eq!(extracted, "0.7");
+            let j = parse_orient_from_text(&extracted, 0.8, 0);
+            assert!(
+                (j.adjusted_urgency - 0.7).abs() < 1e-9,
+                "extraction must isolate the LLM decimal from timing noise; got {}",
+                j.adjusted_urgency
+            );
+        }
+    }
+
+    // =================================================================
+    // issue_2419_family_phase_tests — production wiring for the decide /
+    // orient / merge-judge structured-transport fix (#2421 / #2428 / #2429).
+    //
+    // The `issue_2421_tests` above pin the PARSE seam (banner misparse vs.
+    // JSON-envelope recovery). These pin the rest of the production contract:
+    //   - parse-OUTCOME classification (Parsed vs DefaultEmpty/DefaultMalformed)
+    //     that drives the escalation ladder and the `brain_verdict_parsed_total`
+    //     metric numerator/denominator;
+    //   - the phase escalation-note builders (the `{{escalation_note}}` seam);
+    //   - the shared verdict-parse metric context shape;
+    //   - the generic `run_brain_ladder` backbone working for an ARBITRARY
+    //     decision type (proving decide/orient/merge ride the same ladder the
+    //     lifecycle phase does, rather than a reinvented one).
+    // =================================================================
+    mod issue_2419_family_phase_tests {
+        use super::super::*;
+        use crate::ooda_brain::{BrainPhase, DecideJudgment};
+
+        // --- decide parse-outcome classification (#2421 / #2429) ----------
+
+        #[test]
+        fn decide_outcome_empty_is_default_empty() {
+            let (j, oc) = parse_action_outcome("   ");
+            assert!(matches!(j, DecideJudgment::AdvanceGoal { .. }));
+            assert_eq!(oc, LifecycleParseOutcome::DefaultEmpty);
+            assert!(oc.is_parse_failure());
+        }
+
+        #[test]
+        fn decide_outcome_banner_first_word_is_default_malformed() {
+            // The text-mode banner first word `Recipe:` defaults to advance_goal
+            // — but it must be classified DefaultMalformed (a parse-miss), NOT
+            // counted as a real `advance_goal` decision.
+            let (j, oc) = parse_action_outcome("Recipe: ooda-decide SUCCESS (0.0s)");
+            assert!(matches!(j, DecideJudgment::AdvanceGoal { .. }));
+            assert_eq!(oc, LifecycleParseOutcome::DefaultMalformed);
+            assert!(oc.is_parse_failure());
+        }
+
+        #[test]
+        fn decide_outcome_real_advance_goal_is_parsed_not_default() {
+            // A genuine `advance_goal` LLM decision must read as Parsed — the
+            // whole reason the outcome is split out from the judgment.
+            let (j, oc) = parse_action_outcome("advance_goal engineer assigned, continue");
+            assert!(matches!(j, DecideJudgment::AdvanceGoal { .. }));
+            assert_eq!(oc, LifecycleParseOutcome::Parsed);
+            assert!(!oc.is_parse_failure());
+        }
+
+        #[test]
+        fn decide_outcome_known_keyword_is_parsed() {
+            let (j, oc) = parse_action_outcome("consolidate_memory overhead high");
+            assert!(matches!(j, DecideJudgment::ConsolidateMemory { .. }));
+            assert_eq!(oc, LifecycleParseOutcome::Parsed);
+        }
+
+        #[test]
+        fn decide_decision_choice_covers_all_variants() {
+            assert_eq!(
+                decide_decision_choice(&DecideJudgment::AdvanceGoal {
+                    rationale: String::new()
+                }),
+                "advance_goal"
+            );
+            assert_eq!(
+                decide_decision_choice(&DecideJudgment::ConsolidateMemory {
+                    rationale: String::new()
+                }),
+                "consolidate_memory"
+            );
+            assert_eq!(
+                decide_decision_choice(&DecideJudgment::SafeUpdate {
+                    rationale: String::new()
+                }),
+                "safe_update"
+            );
+        }
+
+        // --- orient parse-outcome classification (#2421 / #2429) ----------
+
+        #[test]
+        fn orient_outcome_valid_decimal_is_parsed() {
+            let (j, oc) = parse_orient_outcome("0.65 still urgent", 0.8, 0);
+            assert!((j.adjusted_urgency - 0.65).abs() < 1e-9);
+            assert_eq!(oc, LifecycleParseOutcome::Parsed);
+        }
+
+        #[test]
+        fn orient_outcome_no_decimal_is_default_malformed_floor() {
+            let (j, oc) = parse_orient_outcome("high urgency, no number here", 0.8, 1);
+            assert_eq!(oc, LifecycleParseOutcome::DefaultMalformed);
+            assert!(oc.is_parse_failure());
+            // Deterministic floor for 1 failure: 0.8 − 0.2 = 0.6.
+            assert!((j.adjusted_urgency - 0.6).abs() < 1e-9);
+        }
+
+        #[test]
+        fn orient_outcome_empty_is_default_empty_floor() {
+            let (_, oc) = parse_orient_outcome("   ", 0.8, 0);
+            assert_eq!(oc, LifecycleParseOutcome::DefaultEmpty);
+        }
+
+        // --- escalation-note builders (the {{escalation_note}} seam) -------
+
+        #[test]
+        fn decide_escalation_note_empty_on_base() {
+            assert_eq!(
+                build_decide_escalation_note(LadderRung::Base, "anything"),
+                ""
+            );
+        }
+
+        #[test]
+        fn decide_escalation_note_repair_lists_actions_and_prior() {
+            let n = build_decide_escalation_note(LadderRung::SchemaRepair, "Recipe: banner");
+            assert!(n.contains("SCHEMA REPAIR"), "note: {n}");
+            assert!(
+                n.contains("advance_goal") && n.contains("consolidate_memory"),
+                "note must echo the action list"
+            );
+            assert!(
+                n.contains("Recipe: banner"),
+                "note must feed prior output back"
+            );
+        }
+
+        #[test]
+        fn orient_escalation_note_repair_demands_decimal() {
+            let n = build_orient_escalation_note(LadderRung::SchemaRepair, "junk");
+            assert!(n.contains("SCHEMA REPAIR"), "note: {n}");
+            assert!(
+                n.to_lowercase().contains("decimal"),
+                "note must demand a decimal"
+            );
+            assert!(n.contains("junk"), "note must feed prior output back");
+        }
+
+        #[test]
+        fn phase_escalation_note_escalate_adds_high_effort() {
+            let n =
+                build_phase_escalation_note(LadderRung::Escalate, "p", "REPAIR_INSTR", "HE_INSTR");
+            assert!(n.contains("SCHEMA REPAIR"), "escalate still repairs");
+            assert!(n.contains("HIGH-EFFORT"), "escalate adds the effort tier");
+            assert!(n.contains("REPAIR_INSTR") && n.contains("HE_INSTR"));
+        }
+
+        // --- shared verdict-parse metric context (#2429) ------------------
+
+        #[test]
+        fn verdict_metric_context_parsed_defaulted_and_recovered() {
+            let parsed = build_verdict_parse_context(
+                BrainPhase::Decide,
+                "g1",
+                LifecycleParseOutcome::Parsed,
+                1,
+            );
+            let v: serde_json::Value = serde_json::from_str(&parsed).unwrap();
+            assert_eq!(v["phase"], "decide");
+            assert_eq!(v["outcome"], "parsed");
+            assert_eq!(v["is_parse_failure"], false);
+            assert_eq!(v["attempts"], 1);
+
+            let defaulted = build_verdict_parse_context(
+                BrainPhase::MergeJudge,
+                "pr-9",
+                LifecycleParseOutcome::DefaultMalformed,
+                3,
+            );
+            let v2: serde_json::Value = serde_json::from_str(&defaulted).unwrap();
+            assert_eq!(v2["phase"], "merge_judge");
+            assert_eq!(v2["outcome"], "defaulted");
+            assert_eq!(v2["is_parse_failure"], true);
+            assert_eq!(v2["outcome_detail"], "default_malformed");
+
+            // A ladder recovery counts as parsed — that is how the ladder drops
+            // the measured default rate.
+            let repaired = build_verdict_parse_context(
+                BrainPhase::Orient,
+                "g",
+                LifecycleParseOutcome::Repaired,
+                2,
+            );
+            let v3: serde_json::Value = serde_json::from_str(&repaired).unwrap();
+            assert_eq!(v3["outcome"], "parsed");
+            assert_eq!(v3["outcome_detail"], "repaired");
+        }
+
+        // --- generic ladder backbone for an ARBITRARY decision type -------
+
+        #[test]
+        fn generic_ladder_recovers_for_arbitrary_decision_type() {
+            // run_brain_ladder is decision-type-agnostic: a String decision that
+            // only "parses" when the text is "good". The first rung returns it.
+            let cfg = EscalationConfig { max_escalations: 2 };
+            let (decision, outcome, attempts, term) = run_brain_ladder(
+                "g",
+                "bad-base",
+                LifecycleParseOutcome::DefaultMalformed,
+                &cfg,
+                |_rung, _prior| Ok("good".to_string()),
+                |raw: &str| {
+                    if raw == "good" {
+                        ("GOOD".to_string(), LifecycleParseOutcome::Parsed)
+                    } else {
+                        ("DEF".to_string(), LifecycleParseOutcome::DefaultMalformed)
+                    }
+                },
+                || "DEF".to_string(),
+                |d: &String| d.clone(),
+            );
+            assert_eq!(decision, "GOOD");
+            assert_eq!(outcome, LifecycleParseOutcome::Repaired);
+            assert_eq!(attempts, 2, "base + 1 recovering rung");
+            assert_eq!(term, LadderTermination::Recovered);
+        }
+
+        #[test]
+        fn generic_ladder_exhausts_to_loud_default_for_arbitrary_type() {
+            let cfg = EscalationConfig { max_escalations: 2 };
+            let (decision, outcome, attempts, term) = run_brain_ladder(
+                "g",
+                "bad",
+                LifecycleParseOutcome::DefaultMalformed,
+                &cfg,
+                |_r, _p| Ok("still-bad".to_string()),
+                |_raw: &str| ("DEF".to_string(), LifecycleParseOutcome::DefaultMalformed),
+                || "DEF".to_string(),
+                |d: &String| d.clone(),
+            );
+            assert_eq!(decision, "DEF");
+            assert!(outcome.is_parse_failure());
+            assert_eq!(attempts, 3, "base + 2 exhausted rungs");
+            assert_eq!(term, LadderTermination::Exhausted);
         }
     }
 }

--- a/src/stewardship/recipe_merge_judge.rs
+++ b/src/stewardship/recipe_merge_judge.rs
@@ -6,20 +6,41 @@
 //! where recipe-runner-rs is available, aligning with the architectural
 //! direction in issue #1971.
 //!
-//! The shim invokes `recipe-runner-rs` as a subprocess with `-c` context
-//! vars and parses its stdout using the same `parse_judge_response` logic
-//! from `merge_judge`.
+//! ## Verdict transport (issue #2419 family: #2428/#2430/#2435/#2462/#2463)
 //!
-//! Fallback on recipe failure: propagates as `SimardError` (same as
-//! `LlmMergeJudge` — the merge authority handles the error).
+//! The shim invokes `recipe-runner-rs` with `--output-format json` and extracts
+//! the agent's REAL output from the JSON envelope's final step result
+//! ([`extract_recipe_decision_output`]) before parsing the structured verdict.
+//! This is the same fix landed for the engineer-lifecycle brain in #2419: in the
+//! default `text` output mode `recipe-runner-rs` prints only a human SUCCESS
+//! banner (`Recipe: merge-readiness-judge ... SUCCESS ...`) to stdout — which
+//! contains no `ready/not_ready/unclear` verdict — so every gated merge was
+//! blocked with "no verdict keyword found".
+//!
+//! The extracted output is parsed by [`parse_merge_outcome`]: the structured
+//! `{"verdict": …}` JSON first (via [`parse_judge_response`]), then a keyword
+//! fallback ([`parse_merge_verdict_from_text`]) for prose. On a parse-miss the
+//! judge runs the shared confidence-gated escalation ladder
+//! ([`run_brain_ladder`]) — schema-repair → high-effort re-prompt — and only
+//! then FAILS CLOSED to [`Verdict::Unclear`] (never a `ready`-without-verdict).
+//! A `brain_verdict_parsed_total{phase="merge_judge"}` metric is emitted on
+//! both the parsed and the defaulted branch (issue #2429).
+//!
+//! Genuine recipe-runner failures (spawn / nonzero exit / envelope decode)
+//! still propagate as `SimardError` — the merge authority handles them — so an
+//! infra failure is never masked by a fail-closed verdict.
 
 use std::path::PathBuf;
 use std::process::Command;
 
 use crate::error::{SimardError, SimardResult};
+use crate::ooda_brain::{
+    BrainPhase, EscalationConfig, LadderRung, LifecycleParseOutcome, build_phase_escalation_note,
+    extract_recipe_decision_output, record_verdict_parse_metric, run_brain_ladder,
+};
 
 use super::merge_authority::PrSnapshot;
-use super::merge_judge::{JudgeOutcome, MergeJudge, MergeJudgeKind, Verdict};
+use super::merge_judge::{JudgeOutcome, MergeJudge, MergeJudgeKind, Verdict, parse_judge_response};
 
 const ADAPTER_TAG: &str = "recipe-merge-judge";
 const RECIPE_FILENAME: &str = "merge-readiness-judge.yaml";
@@ -81,8 +102,66 @@ impl MergeJudge for RecipeMergeJudge {
         repo: &str,
         snapshot: &PrSnapshot,
     ) -> SimardResult<JudgeOutcome> {
+        // `pr-<N>` plays the role of `goal_id` in the shared ladder/metric so
+        // the merge-judge phase lines up with decide/orient in `metrics.jsonl`.
+        let pr_label = format!("pr-{pr_number}");
+        let invoke = |rung: LadderRung, prior: &str| {
+            self.invoke_judge_raw(pr_number, repo, snapshot, rung, prior)
+        };
+
+        // Base (cheap) attempt. A genuine recipe-runner failure (spawn / nonzero
+        // exit / envelope decode) propagates as `Err` so an infra fault is never
+        // masked — only a *parse-miss* on a successful run fails closed below.
+        let base_raw = invoke(LadderRung::Base, "")?;
+        let (judgment, outcome) = parse_merge_outcome(&base_raw);
+        if !outcome.is_parse_failure() {
+            record_verdict_parse_metric(BrainPhase::MergeJudge, &pr_label, outcome, 1);
+            return Ok(judgment);
+        }
+
+        // Parse-miss → confidence-gated escalation ladder, then fail closed to
+        // `Verdict::Unclear` (acceptance: never SUCCESS-without-verdict). The
+        // merge authority refuses on `Unclear`, so the merge does not proceed.
+        let cfg = EscalationConfig::from_env();
+        let (final_judgment, final_outcome, attempts, _termination) = run_brain_ladder(
+            &pr_label,
+            &base_raw,
+            outcome,
+            &cfg,
+            invoke,
+            parse_merge_outcome,
+            || fail_closed_unclear(&base_raw),
+            |o| verdict_label(&o.verdict).to_string(),
+        );
+        record_verdict_parse_metric(BrainPhase::MergeJudge, &pr_label, final_outcome, attempts);
+        Ok(final_judgment)
+    }
+
+    fn kind(&self) -> MergeJudgeKind {
+        MergeJudgeKind::Recipe
+    }
+}
+
+impl RecipeMergeJudge {
+    /// Invoke the merge-readiness recipe once for a ladder rung, returning the
+    /// agent's raw output (the JSON envelope's final step result). Passes
+    /// `--output-format json` (issue #2428) and the (possibly empty)
+    /// `escalation_note`. Genuine recipe-runner failures propagate as `Err`.
+    fn invoke_judge_raw(
+        &self,
+        pr_number: u32,
+        repo: &str,
+        snapshot: &PrSnapshot,
+        rung: LadderRung,
+        prior_output: &str,
+    ) -> SimardResult<String> {
+        let escalation_note = build_merge_escalation_note(rung, prior_output);
         let output = Command::new("recipe-runner-rs")
             .arg(self.recipe_path.as_os_str())
+            // issue #2428: text mode prints only the SUCCESS banner to stdout;
+            // the agent's `{"verdict": …}` is exposed only via the JSON envelope.
+            .arg("--output-format")
+            .arg("json")
             .env("AMPLIHACK_AGENT_BINARY", self.agent_binary)
             .arg("-c")
             .arg(format!("pr_number={pr_number}"))
@@ -90,6 +169,9 @@ impl MergeJudge for RecipeMergeJudge {
             .arg(format!("repo={repo}"))
             .arg("-c")
             .arg(format!("pr_body={}", snapshot.body))
+            // issue #2432: the (possibly empty) escalation/schema-repair note.
+            .arg("-c")
+            .arg(format!("escalation_note={escalation_note}"))
             .output()
             .map_err(|e| SimardError::AdapterInvocationFailed {
                 base_type: ADAPTER_TAG.to_string(),
@@ -108,15 +190,71 @@ impl MergeJudge for RecipeMergeJudge {
             });
         }
 
-        let raw = String::from_utf8_lossy(&output.stdout).to_string();
-        parse_merge_verdict_from_text(&raw).map_err(|reason| SimardError::AdapterInvocationFailed {
-            base_type: ADAPTER_TAG.to_string(),
-            reason,
-        })
+        extract_recipe_decision_output(&output.stdout, ADAPTER_TAG)
     }
+}
 
-    fn kind(&self) -> MergeJudgeKind {
-        MergeJudgeKind::Recipe
+/// Parse the agent's extracted output into a [`JudgeOutcome`] AND a
+/// [`LifecycleParseOutcome`] classification (issue #2428 / #2429).
+///
+/// Strategy: the structured `{"verdict": …}` JSON first (via
+/// [`parse_judge_response`], which tolerates fences/prose-wrapping), then a
+/// keyword fallback ([`parse_merge_verdict_from_text`]) for plain prose. When
+/// NEITHER yields a verdict the judge FAILS CLOSED to [`Verdict::Unclear`] and
+/// the outcome is `DefaultEmpty` (no output) or `DefaultMalformed` (output
+/// present but unparseable) — the merge authority refuses on `Unclear`, so the
+/// merge never proceeds without a real verdict.
+pub(crate) fn parse_merge_outcome(text: &str) -> (JudgeOutcome, LifecycleParseOutcome) {
+    if let Ok(out) = parse_judge_response(text) {
+        return (out, LifecycleParseOutcome::Parsed);
+    }
+    if let Ok(out) = parse_merge_verdict_from_text(text) {
+        return (out, LifecycleParseOutcome::Parsed);
+    }
+    let miss = if text.trim().is_empty() {
+        LifecycleParseOutcome::DefaultEmpty
+    } else {
+        LifecycleParseOutcome::DefaultMalformed
+    };
+    (fail_closed_unclear(text), miss)
+}
+
+/// The loud fail-closed verdict: `Unclear` with a rationale naming the
+/// parse-miss so a defaulted verdict is never mistaken for a real `ready`/
+/// `not_ready` call (acceptance: never SUCCESS-without-verdict).
+fn fail_closed_unclear(raw: &str) -> JudgeOutcome {
+    JudgeOutcome {
+        verdict: Verdict::Unclear,
+        rationale: format!(
+            "{ADAPTER_TAG}: recipe produced no parseable verdict after escalation; failing closed \
+             to unclear (raw={:?})",
+            truncate(raw, 200)
+        ),
+        blockers: vec![],
+    }
+}
+
+/// Build the merge-judge `escalation_note` for a ladder rung, reminding the
+/// agent of the structured verdict contract (issue #2428 / #2432).
+fn build_merge_escalation_note(rung: LadderRung, prior_output: &str) -> String {
+    build_phase_escalation_note(
+        rung,
+        prior_output,
+        "Return EXACTLY one JSON object and nothing else: \
+         {\"verdict\": \"ready\"|\"not_ready\"|\"unclear\", \"rationale\": \"...\"}. \
+         No prose, no markdown fences around it.",
+        "Re-read the six merge-ready evidence sections carefully BEFORE answering, then output \
+         ONLY the JSON verdict object.",
+    )
+}
+
+/// The snake_case label for a verdict, used as the `decision` field in
+/// escalation-ladder logging.
+fn verdict_label(verdict: &Verdict) -> &'static str {
+    match verdict {
+        Verdict::Ready => "ready",
+        Verdict::NotReady => "not_ready",
+        Verdict::Unclear => "unclear",
     }
 }
 
@@ -273,6 +411,323 @@ mod tests {
             out.rationale.contains("Comprehensive"),
             "rationale should include full text: {}",
             out.rationale
+        );
+    }
+}
+
+// =====================================================================
+// issue_2428_tests — merge-judge verdict-parse cluster
+// (#2428 / #2430 / #2435 / #2462 / #2463)
+//
+// Root cause (identical to the #2419 lifecycle bug, different surface):
+// `RecipeMergeJudge::judge` invokes `recipe-runner-rs` in its DEFAULT `text`
+// output mode, so `output.stdout` is only the human SUCCESS banner
+// (`Recipe: merge-readiness-judge ... SUCCESS ...`). The agent's actual
+// `{"verdict": ...}` is exposed ONLY via `--output-format json`
+// (`step_results[].output`). `parse_merge_verdict_from_text` then finds no
+// verdict keyword and the merge is blocked for EVERY PR.
+//
+// These tests are the executable specification for the fix:
+//   - pin the production banner as NON-parseable (the caller must NOT read it);
+//   - prove that extracting the JSON-envelope final step output and running
+//     `parse_judge_response` (JSON) with a `parse_merge_verdict_from_text`
+//     (keyword) fallback recovers the real verdict;
+//   - pin fail-closed semantics: empty/malformed agent output yields an error
+//     from BOTH parsers, so `judge` must map it to `Verdict::Unclear`
+//     (fail closed) — never a SUCCESS-without-verdict.
+//
+// The envelope-extraction contract is mirrored inline (the production helper
+// `extract_recipe_decision_output` lives in `ooda_brain` and is being lifted
+// into a shared `brain_ladder` module by the implementation step). The unit
+// under test here is the parse composition the judge must wire in; the live
+// `recipe-runner-rs --output-format json` boundary is covered by the
+// `tests/gadugi/merge-judge-verdict.sh` outside-in scenario.
+// =====================================================================
+#[cfg(test)]
+mod issue_2428_tests {
+    use super::super::merge_judge::{Verdict, parse_judge_response};
+    use super::parse_merge_verdict_from_text;
+
+    /// The EXACT text-mode banner the operators reported (#2462 / #2463 /
+    /// #2435). It is the only thing on `recipe-runner-rs` stdout in `text`
+    /// mode and contains no verdict keyword.
+    const PRODUCTION_BANNER: &str = "Recipe: merge-readiness-judge (v1.0.0)\nSteps: 1\n\nRecipe 'merge-readiness-judge': SUCCESS (32.0s)\n  [completed] judge-merge-readiness (32.0s)\n\n";
+
+    /// Mirror of the production `extract_recipe_decision_output` contract:
+    /// decode the `recipe-runner-rs --output-format json` envelope and return
+    /// the FINAL step's `output`. `None` when the bytes are not a valid
+    /// envelope (e.g. the text-mode banner) or the envelope carries no step.
+    fn extract_final_step_output(envelope_json: &str) -> Option<String> {
+        let v: serde_json::Value = serde_json::from_str(envelope_json).ok()?;
+        if v.get("success").and_then(|s| s.as_bool()) == Some(false) {
+            return None;
+        }
+        let steps = v.get("step_results")?.as_array()?;
+        let last = steps.last()?;
+        Some(last.get("output")?.as_str()?.to_string())
+    }
+
+    // --- (1) regression pin: the banner is NOT a parseable verdict ----------
+
+    #[test]
+    fn production_banner_has_no_verdict_keyword() {
+        // This is the #2462/#2463 failure reproduced at the parse layer:
+        // "merge-readiness-judge" contains "readiness" (NOT "ready"), so no
+        // verdict keyword matches and the judge errors → merge blocked.
+        let err = parse_merge_verdict_from_text(PRODUCTION_BANNER).unwrap_err();
+        assert!(
+            err.contains("no verdict keyword"),
+            "the banner must be unparseable so the fix is forced to read the \
+             JSON envelope instead; got: {err}"
+        );
+    }
+
+    #[test]
+    fn text_banner_is_not_a_valid_json_envelope() {
+        // Proves the judge MUST pass `--output-format json`: the text banner
+        // can never be mistaken for a decodable envelope, so a missing
+        // `--output-format json` flag fails loudly rather than silently.
+        assert!(
+            extract_final_step_output(PRODUCTION_BANNER).is_none(),
+            "the text-mode banner is not a JSON envelope"
+        );
+    }
+
+    // --- (2) the fix: JSON envelope final step output carries the verdict ---
+
+    #[test]
+    fn json_envelope_fenced_verdict_parses_ready() {
+        // The shape #2463 explicitly asks for: a json envelope whose FINAL
+        // step output is a fenced ```json {"verdict":"ready",...}``` block.
+        let envelope = r#"{
+            "recipe_name": "merge-readiness-judge",
+            "success": true,
+            "step_results": [
+                {"step_id": "judge-merge-readiness",
+                 "output": "Here is my assessment:\n```json\n{\"verdict\": \"ready\", \"rationale\": \"All six skill criteria present and substantive.\"}\n```\n",
+                 "error": "", "duration": 32.0}
+            ]
+        }"#;
+        let inner = extract_final_step_output(envelope)
+            .expect("envelope final step output must be extractable");
+        let out = parse_judge_response(&inner).expect("fenced JSON verdict must parse");
+        assert_eq!(out.verdict, Verdict::Ready);
+        assert!(out.rationale.contains("six skill criteria"));
+    }
+
+    #[test]
+    fn json_envelope_bare_json_not_ready_preserves_blockers() {
+        let envelope = r#"{
+            "success": true,
+            "step_results": [
+                {"step_id": "judge-merge-readiness",
+                 "output": "{\"verdict\": \"not_ready\", \"rationale\": \"Quality-audit thin.\", \"blockers\": [{\"section\": \"Quality-audit\", \"severity\": \"high\", \"observation\": \"No cycles.\", \"fix\": \"Run three cycles.\"}]}",
+                 "error": "", "duration": 30.0}
+            ]
+        }"#;
+        let inner = extract_final_step_output(envelope).unwrap();
+        let out = parse_judge_response(&inner).expect("bare JSON verdict must parse");
+        assert_eq!(out.verdict, Verdict::NotReady);
+        assert_eq!(
+            out.blockers.len(),
+            1,
+            "blockers must survive extraction+parse"
+        );
+        assert_eq!(out.blockers[0].section, "Quality-audit");
+    }
+
+    #[test]
+    fn json_envelope_unclear_verdict_parses() {
+        let envelope = r#"{
+            "success": true,
+            "step_results": [
+                {"step_id": "judge-merge-readiness",
+                 "output": "{\"verdict\": \"unclear\", \"rationale\": \"PR body appears truncated.\"}",
+                 "error": "", "duration": 12.0}
+            ]
+        }"#;
+        let inner = extract_final_step_output(envelope).unwrap();
+        let out = parse_judge_response(&inner).unwrap();
+        assert_eq!(out.verdict, Verdict::Unclear);
+    }
+
+    #[test]
+    fn json_envelope_prose_falls_back_to_keyword_verdict() {
+        // If the agent emits PROSE (no JSON object) inside the envelope, the
+        // strict JSON parser fails but the keyword fallback
+        // (`parse_merge_verdict_from_text`) must still surface a real verdict.
+        let envelope = r#"{
+            "success": true,
+            "step_results": [
+                {"step_id": "judge-merge-readiness",
+                 "output": "After reviewing all six sections I find this PR ready to merge.",
+                 "error": "", "duration": 28.0}
+            ]
+        }"#;
+        let inner = extract_final_step_output(envelope).unwrap();
+        assert!(
+            parse_judge_response(&inner).is_err(),
+            "prose has no JSON object; strict JSON parse must fail first"
+        );
+        let out = parse_merge_verdict_from_text(&inner)
+            .expect("keyword fallback must surface a verdict from prose");
+        assert_eq!(out.verdict, Verdict::Ready);
+    }
+
+    #[test]
+    fn json_envelope_uses_final_step_output() {
+        // Multi-step recipe: the verdict is the TERMINAL step's output, not an
+        // earlier prelude step.
+        let envelope = r#"{
+            "success": true,
+            "step_results": [
+                {"step_id": "prep", "output": "gathering context", "error": "", "duration": 1.0},
+                {"step_id": "judge-merge-readiness",
+                 "output": "{\"verdict\": \"ready\", \"rationale\": \"ok\"}",
+                 "error": "", "duration": 20.0}
+            ]
+        }"#;
+        let inner = extract_final_step_output(envelope).unwrap();
+        let out = parse_judge_response(&inner).unwrap();
+        assert_eq!(out.verdict, Verdict::Ready);
+    }
+
+    // --- (3) fail-closed pin: empty/malformed output is NEVER a SUCCESS -----
+
+    #[test]
+    fn empty_final_step_output_fails_closed() {
+        // When the agent step produces empty output, BOTH the JSON parser and
+        // the keyword parser must error. The judge therefore CANNOT return a
+        // verdict and MUST fail closed to `Verdict::Unclear` (acceptance:
+        // "never SUCCESS-without-verdict"). This test pins the precondition;
+        // the gadugi scenario pins the end-to-end fail-closed behaviour.
+        let envelope = r#"{
+            "success": true,
+            "step_results": [
+                {"step_id": "judge-merge-readiness", "output": "", "error": "", "duration": 5.0}
+            ]
+        }"#;
+        let inner = extract_final_step_output(envelope).unwrap();
+        assert!(inner.trim().is_empty());
+        assert!(
+            parse_judge_response(&inner).is_err(),
+            "empty output must not parse as a JSON verdict"
+        );
+        assert!(
+            parse_merge_verdict_from_text(&inner).is_err(),
+            "empty output must not parse as a keyword verdict — judge must \
+             fail closed to Unclear, not SUCCESS"
+        );
+    }
+
+    #[test]
+    fn success_false_envelope_is_not_extractable() {
+        // A `success:false` envelope means the recipe itself failed — the
+        // judge must surface that loudly (Err), not mine a verdict out of it.
+        let envelope = r#"{"success": false, "step_results": []}"#;
+        assert!(
+            extract_final_step_output(envelope).is_none(),
+            "success=false must not yield a verdict"
+        );
+    }
+}
+
+// =====================================================================
+// issue_2428_production_tests — the production parse/fail-closed wiring
+// (#2428 / #2430 / #2435 / #2462 / #2463 / #2429).
+//
+// `issue_2428_tests` above pins the parse composition with an inline envelope
+// helper. These pin the production [`parse_merge_outcome`] + fail-closed
+// contract the `judge()` method actually wires in: the agent's extracted output
+// is mapped to `(JudgeOutcome, LifecycleParseOutcome)`, and an unparseable
+// (but successful) run fails CLOSED to `Verdict::Unclear` with a
+// `DefaultEmpty`/`DefaultMalformed` outcome — never a `ready`-without-verdict.
+// =====================================================================
+#[cfg(test)]
+mod issue_2428_production_tests {
+    use super::*;
+    use crate::ooda_brain::LifecycleParseOutcome;
+
+    #[test]
+    fn json_verdict_parses_as_parsed() {
+        let (out, oc) = parse_merge_outcome(
+            "```json\n{\"verdict\": \"ready\", \"rationale\": \"all six sections present\"}\n```",
+        );
+        assert_eq!(out.verdict, Verdict::Ready);
+        assert_eq!(oc, LifecycleParseOutcome::Parsed);
+        assert!(!oc.is_parse_failure());
+    }
+
+    #[test]
+    fn prose_keyword_parses_as_parsed() {
+        // No JSON object — the keyword fallback still surfaces a real verdict.
+        let (out, oc) = parse_merge_outcome("After review I find this PR ready to merge.");
+        assert_eq!(out.verdict, Verdict::Ready);
+        assert_eq!(oc, LifecycleParseOutcome::Parsed);
+    }
+
+    #[test]
+    fn not_ready_json_preserves_blockers_and_parses() {
+        let (out, oc) = parse_merge_outcome(
+            "{\"verdict\": \"not_ready\", \"rationale\": \"thin\", \"blockers\": [{\"section\": \"Quality-audit\", \"severity\": \"high\", \"observation\": \"none\", \"fix\": \"add cycles\"}]}",
+        );
+        assert_eq!(out.verdict, Verdict::NotReady);
+        assert_eq!(out.blockers.len(), 1);
+        assert_eq!(oc, LifecycleParseOutcome::Parsed);
+    }
+
+    #[test]
+    fn empty_output_fails_closed_to_unclear_default_empty() {
+        let (out, oc) = parse_merge_outcome("   ");
+        assert_eq!(
+            out.verdict,
+            Verdict::Unclear,
+            "empty output must fail closed to Unclear, never SUCCESS-without-verdict"
+        );
+        assert_eq!(oc, LifecycleParseOutcome::DefaultEmpty);
+        assert!(oc.is_parse_failure());
+        assert!(out.rationale.contains("failing closed"));
+    }
+
+    #[test]
+    fn unparseable_prose_fails_closed_to_unclear_default_malformed() {
+        // Prose with NO verdict keyword and no JSON: must fail closed, not error,
+        // and must NOT be mistaken for a real verdict.
+        let (out, oc) = parse_merge_outcome("The PR looks interesting but I cannot decide.");
+        assert_eq!(out.verdict, Verdict::Unclear);
+        assert_eq!(oc, LifecycleParseOutcome::DefaultMalformed);
+        assert!(oc.is_parse_failure());
+    }
+
+    #[test]
+    fn production_banner_fails_closed_not_parsed() {
+        // The reported #2462/#2463 banner: only `readiness` (not `ready`), no
+        // JSON. If it ever reached the parser it must fail closed, never SUCCESS.
+        let banner = "Recipe: merge-readiness-judge (v1.0.0)\nSteps: 1\n\nRecipe 'merge-readiness-judge': SUCCESS (32.0s)\n  [completed] judge-merge-readiness (32.0s)\n\n";
+        let (out, oc) = parse_merge_outcome(banner);
+        assert_eq!(out.verdict, Verdict::Unclear);
+        assert!(oc.is_parse_failure());
+    }
+
+    #[test]
+    fn verdict_label_covers_all_variants() {
+        assert_eq!(verdict_label(&Verdict::Ready), "ready");
+        assert_eq!(verdict_label(&Verdict::NotReady), "not_ready");
+        assert_eq!(verdict_label(&Verdict::Unclear), "unclear");
+    }
+
+    #[test]
+    fn merge_escalation_note_empty_on_base_and_demands_json_on_repair() {
+        assert_eq!(build_merge_escalation_note(LadderRung::Base, "x"), "");
+        let n = build_merge_escalation_note(LadderRung::SchemaRepair, "Recipe: banner");
+        assert!(n.contains("SCHEMA REPAIR"), "note: {n}");
+        assert!(
+            n.contains("\"verdict\""),
+            "repair note must demand the verdict JSON"
+        );
+        assert!(
+            n.contains("Recipe: banner"),
+            "note must feed prior output back"
         );
     }
 }

--- a/src/stewardship/recipe_merge_judge.rs
+++ b/src/stewardship/recipe_merge_judge.rs
@@ -48,8 +48,16 @@ const RECIPE_FILENAME: &str = "merge-readiness-judge.yaml";
 /// Resolve the recipe YAML path. Checks, in order:
 ///   1. `~/.simard/prompt_assets/simard/recipes/<name>` (hot-reload path)
 ///   2. `<repo_root>/prompt_assets/simard/recipes/<name>` (in-tree)
-fn resolve_recipe_path(repo_root: &std::path::Path) -> Option<PathBuf> {
-    if let Some(home) = dirs::home_dir() {
+///
+/// `home_override` lets tests supply a fake home directory without mutating the
+/// process-wide `HOME` env var (mirrors `disk_health::resolve_recipe_path`).
+/// Production passes `None`, falling back to [`dirs::home_dir`].
+fn resolve_recipe_path(
+    repo_root: &std::path::Path,
+    home_override: Option<&std::path::Path>,
+) -> Option<PathBuf> {
+    let home = home_override.map(PathBuf::from).or_else(dirs::home_dir);
+    if let Some(home) = home {
         let hot = home
             .join(".simard")
             .join("prompt_assets/simard/recipes")
@@ -76,7 +84,17 @@ pub struct RecipeMergeJudge {
 impl RecipeMergeJudge {
     /// Construct if recipe file and recipe-runner-rs binary are both available.
     pub fn new(repo_root: &std::path::Path) -> Option<Self> {
-        let recipe_path = resolve_recipe_path(repo_root)?;
+        Self::new_with_home(repo_root, None)
+    }
+
+    /// Like [`RecipeMergeJudge::new`], but accepts a `home_override` for the
+    /// hot-reload lookup so tests stay hermetic against the ambient
+    /// `~/.simard/prompt_assets` directory. Production calls `new` (`None`).
+    fn new_with_home(
+        repo_root: &std::path::Path,
+        home_override: Option<&std::path::Path>,
+    ) -> Option<Self> {
+        let recipe_path = resolve_recipe_path(repo_root, home_override)?;
         let agent_binary = crate::session_builder::LlmProvider::resolve_agent_binary()?;
         if Command::new("recipe-runner-rs")
             .arg("--version")
@@ -320,7 +338,11 @@ mod tests {
 
     #[test]
     fn new_returns_none_when_recipe_missing() {
-        let judge = RecipeMergeJudge::new(std::path::Path::new("/nonexistent"));
+        let home = tempfile::tempdir().unwrap();
+        let judge = RecipeMergeJudge::new_with_home(
+            std::path::Path::new("/nonexistent"),
+            Some(home.path()),
+        );
         assert!(judge.is_none());
     }
 

--- a/tests/gadugi/decide-orient-brain-parse.sh
+++ b/tests/gadugi/decide-orient-brain-parse.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Outside-in scenario for issue #2421 — the decide + orient RecipeBrain phases
+# share the #2419 text-vs-json parse bug (orient ACTIVELY corrupts urgency).
+#
+# Root cause: RecipeBrain::judge_decision / judge_orientation invoke
+# recipe-runner-rs in its DEFAULT `text` output mode, which prints only a
+# summary banner ("Recipe: <name> ... SUCCESS (0.0s) ...") to stdout. The
+# agent's real decision text is exposed ONLY via `--output-format json`
+# (step_results[].output). Consequences:
+#   - decide: the banner's first word is always "Recipe:", which matches no
+#     action keyword, so judge_decision silently returns AdvanceGoal every
+#     cycle (the LLM is ignored).
+#   - orient: WORSE — parse_orient_from_text scans the banner for the first
+#     in-range decimal, and the timing string "(0.0s)" yields 0.0, so the
+#     daemon silently DEMOTES the goal's urgency to a value scraped from the
+#     banner rather than the LLM's judgment.
+#
+# This scenario validates the contract at the recipe-runner boundary WITHOUT an
+# LLM: deterministic bash-step recipes emit a known action word / urgency
+# decimal, and we assert that
+#   (a) text mode hides them behind the banner (the bug), and
+#   (b) json mode exposes them as the final step output (the fix).
+#
+# It also exercises the in-tree Rust parser path via `cargo test`
+# (issue_2421_tests): banner-misparse pins + JSON-envelope recovery for both
+# decide and orient, plus the orient timing-isolation guard.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+if ! command -v recipe-runner-rs >/dev/null 2>&1; then
+  echo "SKIP: recipe-runner-rs not on PATH (required for this scenario)" >&2
+  exit 0
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "SKIP: jq not on PATH (required for this scenario)" >&2
+  exit 0
+fi
+
+WORK="$(mktemp -d /tmp/simard-decide-orient-2421.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+
+# ---------------------------------------------------------------------------
+# decide: a real action word the text-mode banner hides
+# ---------------------------------------------------------------------------
+DECIDE_RECIPE="$WORK/decide-fixture.yaml"
+ACTION="consolidate_memory context overhead is high this cycle"
+cat > "$DECIDE_RECIPE" <<EOF
+name: "decide-fixture-2421"
+description: "deterministic decide action fixture (no LLM)"
+version: "1.0.0"
+context: {}
+steps:
+  - id: "decide-action"
+    type: "bash"
+    command: |
+      echo '${ACTION}'
+    output: "decide_result"
+EOF
+
+echo "== decide (a) text mode: first word is the banner, not the action =="
+DTEXT="$(recipe-runner-rs "$DECIDE_RECIPE" 2>/dev/null)"
+DTEXT_FIRST="$(printf '%s\n' "$DTEXT" | awk 'NF{print $1; exit}')"
+echo "decide text-mode first word: ${DTEXT_FIRST}"
+[ "$DTEXT_FIRST" = "consolidate_memory" ] \
+  && { echo "FAIL: text mode unexpectedly exposed the action as the first word" >&2; exit 1; }
+printf '%s\n' "$DTEXT" | grep -qE '^Recipe:' \
+  || { echo "FAIL: expected a 'Recipe:' banner in decide text mode" >&2; exit 1; }
+
+echo "== decide (b) json mode: final step output first word IS the action =="
+DJSON="$(recipe-runner-rs "$DECIDE_RECIPE" --output-format json 2>/dev/null)"
+DSTEP="$(printf '%s' "$DJSON" | jq -r '.step_results | last | .output')"
+DJSON_FIRST="$(printf '%s\n' "$DSTEP" | awk 'NF{print $1; exit}')"
+echo "decide json-mode first word: ${DJSON_FIRST}"
+[ "$DJSON_FIRST" = "consolidate_memory" ] \
+  || { echo "FAIL: decide json-mode first word is not the expected action" >&2; exit 1; }
+echo "OK: decide — text hides the action behind the banner; json exposes it."
+
+# ---------------------------------------------------------------------------
+# orient: a real urgency decimal the banner timing "(0.0s)" would corrupt
+# ---------------------------------------------------------------------------
+ORIENT_RECIPE="$WORK/orient-fixture.yaml"
+URGENCY="0.65 goal remains high urgency despite one transient failure"
+cat > "$ORIENT_RECIPE" <<EOF
+name: "orient-fixture-2421"
+description: "deterministic orient urgency fixture (no LLM)"
+version: "1.0.0"
+context: {}
+steps:
+  - id: "orient-decision"
+    type: "bash"
+    command: |
+      echo '${URGENCY}'
+    output: "orient_result"
+EOF
+
+echo "== orient (a) text mode: banner timing '(0.0s)' is the corruption source =="
+OTEXT="$(recipe-runner-rs "$ORIENT_RECIPE" 2>/dev/null)"
+printf '%s\n' "$OTEXT" | grep -qE '\(0\.0s\)' \
+  || { echo "FAIL: expected a '(0.0s)' timing string in the orient banner" >&2; exit 1; }
+# The real urgency 0.65 must NOT be the first in-range decimal on the banner —
+# the timing 0.0 precedes it, which is exactly what silently demotes urgency.
+if printf '%s' "$OTEXT" | grep -qF '0.65'; then
+  echo "FAIL: text-mode banner unexpectedly contains the real urgency 0.65" >&2
+  exit 1
+fi
+
+echo "== orient (b) json mode: final step output IS the real urgency decimal =="
+OJSON="$(recipe-runner-rs "$ORIENT_RECIPE" --output-format json 2>/dev/null)"
+OSTEP="$(printf '%s' "$OJSON" | jq -r '.step_results | last | .output')"
+echo "orient json-mode final step output: ${OSTEP}"
+printf '%s' "$OSTEP" | grep -qF '0.65' \
+  || { echo "FAIL: orient json-mode output is missing the real urgency 0.65" >&2; exit 1; }
+echo "OK: orient — text scrapes 0.0 from timing; json exposes the real 0.65."
+
+# ---------------------------------------------------------------------------
+# (c) in-tree Rust parser path: banner pins + JSON-envelope recovery
+# ---------------------------------------------------------------------------
+echo "== (c) in-tree decide/orient parser unit tests (issue_2421_tests) =="
+TEST_LOG="$WORK/issue-2421-cargo-test.log"
+cargo test --lib --locked issue_2421_tests -- --nocapture >"$TEST_LOG" 2>&1
+PASSED="$(grep -oE 'test result: ok\. [0-9]+ passed' "$TEST_LOG" | grep -oE '[0-9]+' | head -1)"
+PASSED="${PASSED:-0}"
+echo "issue_2421 tests passed: ${PASSED}"
+[ "$PASSED" -ge 1 ] \
+  || { echo "FAIL: issue_2421_tests filter matched zero tests (module renamed?)" >&2; cat "$TEST_LOG" >&2; exit 1; }
+grep -qF 'issue_2421_tests::orient_banner_timing_actively_corrupts_urgency' "$TEST_LOG" \
+  || { echo "FAIL: the orient urgency-corruption pin did not run" >&2; exit 1; }
+grep -qF 'issue_2421_tests::decide_json_envelope_recovers_real_action' "$TEST_LOG" \
+  || { echo "FAIL: the decide JSON-envelope recovery test did not run" >&2; exit 1; }
+echo "OK: decide/orient banner pins + JSON-envelope recovery pass (${PASSED} tests)."
+
+echo "PASS: decide-orient-brain-parse scenario (issue #2421)"

--- a/tests/gadugi/decide-orient-brain-parse.yaml
+++ b/tests/gadugi/decide-orient-brain-parse.yaml
@@ -1,0 +1,56 @@
+name: "Decide + Orient Brain Parse (issue #2421)"
+description: "Outside-in proof that the decide and orient RecipeBrain phases recover real decisions/urgency from recipe-runner-rs JSON output instead of silently defaulting to AdvanceGoal (decide) or scraping 0.0 from the banner timing string (orient). Reproduces the text-mode banner bug and validates the json-mode fix at the recipe-runner boundary (no LLM), then runs the in-tree parser pins + JSON-envelope recovery tests."
+version: "1.0.0"
+
+config:
+  timeout: 300000
+  retries: 1
+  parallel: false
+
+environment:
+  requires: []
+
+agents:
+  - name: "cli-agent"
+    type: "cli"
+    config:
+      workingDirectory: "."
+      defaultTimeout: 300000
+      executionMode: "spawn"
+      captureOutput: true
+      ioConfig:
+        encoding: "utf8"
+        handleInteractivePrompts: false
+      logConfig:
+        logCommands: true
+        logOutput: true
+        logLevel: "info"
+
+steps:
+  - name: "Decide/orient brain parse: text-mode banner bug vs json-mode fix + parser pins"
+    agent: "cli-agent"
+    action: "execute_command"
+    params:
+      command: "tests/gadugi/decide-orient-brain-parse.sh"
+    timeout: 300000
+
+assertions: []
+
+cleanup:
+  - name: "CLI agent cleanup"
+    agent: "cli-agent"
+    action: "cleanup"
+
+metadata:
+  tags:
+    - "cli"
+    - "behavior"
+    - "simard"
+    - "ooda"
+    - "recipe-brain"
+    - "decide"
+    - "orient"
+    - "issue-2421"
+  priority: "high"
+  author: "copilot"
+  test_type: "outside-in"

--- a/tests/gadugi/merge-judge-verdict.sh
+++ b/tests/gadugi/merge-judge-verdict.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Outside-in scenario for the merge-judge verdict-parse cluster
+# (#2428 / #2430 / #2435 / #2462 / #2463) — `simard merge-pr` never surfaces a
+# verdict because the recipe-runner-backed judge parses the TEXT-MODE banner.
+#
+# Root cause (identical to #2419, different surface): RecipeMergeJudge::judge
+# invokes recipe-runner-rs in its DEFAULT `text` output mode, which prints only
+# a summary banner ("Recipe: merge-readiness-judge ... SUCCESS ...") to stdout.
+# The agent's actual {"verdict": "ready"|"not_ready"|"unclear"} JSON is exposed
+# ONLY via `--output-format json` (step_results[].output). The keyword/JSON
+# scan over the banner therefore finds NO verdict and every gated merge is
+# blocked with: "no verdict keyword (ready/not_ready/unclear) found".
+#
+# This scenario validates the contract at the recipe-runner boundary WITHOUT an
+# LLM: a deterministic bash-step recipe emits a known JSON verdict, and we
+# assert that
+#   (a) text mode hides it behind the banner (the bug — no verdict on stdout),
+#   (b) json mode exposes it as the final step output (the fix), parseable as a
+#       structured {"verdict": ...} object.
+#
+# It also exercises the in-tree Rust parse-composition + fail-closed unit tests
+# via `cargo test` (issue_2428_tests) so the JSON-envelope verdict extraction,
+# prose keyword fallback, and the empty-output fail-closed contract are all
+# validated end-to-end.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+if ! command -v recipe-runner-rs >/dev/null 2>&1; then
+  echo "SKIP: recipe-runner-rs not on PATH (required for this scenario)" >&2
+  exit 0
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "SKIP: jq not on PATH (required for this scenario)" >&2
+  exit 0
+fi
+
+WORK="$(mktemp -d /tmp/simard-merge-judge-verdict.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+
+RECIPE="$WORK/merge-judge-fixture.yaml"
+VERDICT_JSON='{"verdict": "ready", "rationale": "all six skill sections present and substantive"}'
+
+cat > "$RECIPE" <<EOF
+name: "merge-judge-fixture-2428"
+description: "deterministic merge-readiness verdict fixture (no LLM)"
+version: "1.0.0"
+context: {}
+steps:
+  - id: "judge-merge-readiness"
+    type: "bash"
+    command: |
+      echo '${VERDICT_JSON}'
+    output: "judge_result"
+EOF
+
+# --- (a) text mode reproduces the bug: the banner hides the verdict ----------
+echo "== (a) text mode: verdict is hidden behind the SUCCESS banner =="
+TEXT_OUT="$(recipe-runner-rs "$RECIPE" 2>/dev/null)"
+printf '%s\n' "$TEXT_OUT"
+printf '%s\n' "$TEXT_OUT" | grep -qE '^Recipe:' \
+  || { echo "FAIL: expected a 'Recipe:' summary banner in text mode" >&2; exit 1; }
+# The verdict JSON must NOT appear on text-mode stdout — that is the #2462 bug.
+if printf '%s' "$TEXT_OUT" | grep -qF '"verdict"'; then
+  echo "FAIL: text mode unexpectedly exposed the verdict JSON" >&2
+  exit 1
+fi
+# And the banner carries no bare verdict keyword (only 'readiness', not 'ready').
+if printf '%s' "$TEXT_OUT" | grep -qiwE 'ready|not_ready|unclear'; then
+  echo "FAIL: text-mode banner unexpectedly contains a verdict keyword" >&2
+  exit 1
+fi
+echo "OK: text mode surfaces no verdict (reproduces 'no verdict keyword' bug)."
+
+# --- (b) json mode exposes the real verdict as the final step output (fix) ----
+echo "== (b) json mode: verdict surfaced as the final step output =="
+JSON_OUT="$(recipe-runner-rs "$RECIPE" --output-format json 2>/dev/null)"
+printf '%s' "$JSON_OUT" | jq -e '.success == true' >/dev/null \
+  || { echo "FAIL: recipe did not report success in json mode" >&2; exit 1; }
+
+STEP_OUTPUT="$(printf '%s' "$JSON_OUT" | jq -r '.step_results | last | .output')"
+echo "json-mode final step output: ${STEP_OUTPUT}"
+printf '%s' "$STEP_OUTPUT" | grep -qF '"verdict"' \
+  || { echo "FAIL: json-mode final step output is missing the verdict JSON" >&2; exit 1; }
+VERDICT="$(printf '%s' "$STEP_OUTPUT" | jq -r '.verdict')"
+echo "parsed verdict: ${VERDICT}"
+[ "$VERDICT" = "ready" ] \
+  || { echo "FAIL: json-mode verdict is not the expected 'ready'" >&2; exit 1; }
+echo "OK: json mode exposes a parseable structured verdict."
+
+# --- (c) in-tree Rust parse-composition + fail-closed unit tests -------------
+echo "== (c) in-tree merge-judge unit tests (issue_2428_tests) =="
+TEST_LOG="$WORK/issue-2428-cargo-test.log"
+cargo test --lib --locked issue_2428_tests -- --nocapture >"$TEST_LOG" 2>&1
+PASSED="$(grep -oE 'test result: ok\. [0-9]+ passed' "$TEST_LOG" | grep -oE '[0-9]+' | head -1)"
+PASSED="${PASSED:-0}"
+echo "issue_2428 tests passed: ${PASSED}"
+[ "$PASSED" -ge 1 ] \
+  || { echo "FAIL: issue_2428_tests filter matched zero tests (module renamed?)" >&2; cat "$TEST_LOG" >&2; exit 1; }
+grep -qF 'issue_2428_tests::json_envelope_fenced_verdict_parses_ready' "$TEST_LOG" \
+  || { echo "FAIL: the JSON-envelope verdict-extraction test did not run" >&2; exit 1; }
+grep -qF 'issue_2428_tests::empty_final_step_output_fails_closed' "$TEST_LOG" \
+  || { echo "FAIL: the fail-closed contract test did not run" >&2; exit 1; }
+echo "OK: JSON-envelope verdict extraction + fail-closed contract pass (${PASSED} tests)."
+
+echo "PASS: merge-judge-verdict scenario (#2428/#2430/#2435/#2462/#2463)"

--- a/tests/gadugi/merge-judge-verdict.yaml
+++ b/tests/gadugi/merge-judge-verdict.yaml
@@ -1,0 +1,57 @@
+name: "Merge-Judge Verdict Parse (#2428/#2430/#2435/#2462/#2463)"
+description: "Outside-in proof that simard merge-pr's recipe-backed merge-readiness judge surfaces a real structured verdict from recipe-runner-rs JSON output instead of parsing the text-mode SUCCESS banner (which carries no verdict keyword and blocks every gated merge). Reproduces the text-mode banner bug and validates the json-mode fix at the recipe-runner boundary (no LLM), then runs the in-tree verdict-extraction + fail-closed unit tests."
+version: "1.0.0"
+
+config:
+  timeout: 300000
+  retries: 1
+  parallel: false
+
+environment:
+  requires: []
+
+agents:
+  - name: "cli-agent"
+    type: "cli"
+    config:
+      workingDirectory: "."
+      defaultTimeout: 300000
+      executionMode: "spawn"
+      captureOutput: true
+      ioConfig:
+        encoding: "utf8"
+        handleInteractivePrompts: false
+      logConfig:
+        logCommands: true
+        logOutput: true
+        logLevel: "info"
+
+steps:
+  - name: "Merge-judge verdict: text-mode banner bug vs json-mode fix + parse-composition/fail-closed"
+    agent: "cli-agent"
+    action: "execute_command"
+    params:
+      command: "tests/gadugi/merge-judge-verdict.sh"
+    timeout: 300000
+
+assertions: []
+
+cleanup:
+  - name: "CLI agent cleanup"
+    agent: "cli-agent"
+    action: "cleanup"
+
+metadata:
+  tags:
+    - "cli"
+    - "behavior"
+    - "simard"
+    - "stewardship"
+    - "merge-authority"
+    - "recipe-brain"
+    - "issue-2428"
+    - "issue-2462"
+    - "issue-2463"
+  priority: "high"
+  author: "copilot"
+  test_type: "outside-in"

--- a/tests/recipe_brain_verdict_assets.rs
+++ b/tests/recipe_brain_verdict_assets.rs
@@ -1,0 +1,87 @@
+//! Content-pin tests for the recipe-brain verdict/decision parse fix
+//! (issue #2419 family: #2421 decide/orient, #2428/#2430/#2435/#2462/#2463
+//! merge-judge, #2429 metric).
+//!
+//! TDD (Step 7 — write tests first): these are RED until the implementation
+//! step adds the additive `{{escalation_note}}` placeholder to the
+//! decide / orient / merge-judge recipes, mirroring the lifecycle recipe that
+//! already exposes it (issue #2432). The escalation seam is what lets each of
+//! these recipe-backed brains re-prompt (schema-repair → escalate) on a
+//! verdict/decision parse-miss before falling back deterministically, instead
+//! of silently defaulting on the first miss.
+//!
+//! The lifecycle recipe is asserted as a GREEN anchor so a regression that
+//! strips the placeholder from the already-fixed recipe is also caught.
+
+use std::fs;
+use std::path::PathBuf;
+
+fn recipe(name: &str) -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("prompt_assets/simard/recipes")
+        .join(name);
+    fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("recipe {} must be readable: {e}", path.display()))
+}
+
+/// Every recipe-backed brain that drives a confidence-gated escalation ladder
+/// must expose the `{{escalation_note}}` placeholder so the brain can inject
+/// the schema-repair / high-effort instruction on each rung. Empty on the base
+/// attempt (byte-identical base behaviour); populated on escalation rungs.
+const LADDER_RECIPES: &[&str] = &[
+    "ooda-engineer-lifecycle.yaml", // GREEN anchor (already fixed, #2432)
+    "ooda-decide.yaml",             // #2421 — RED until Step 8
+    "ooda-orient.yaml",             // #2421 — RED until Step 8
+    "merge-readiness-judge.yaml",   // #2428/#2430/#2435/#2462/#2463 — RED until Step 8
+];
+
+#[test]
+fn ladder_recipes_expose_escalation_note_placeholder() {
+    let mut missing = Vec::new();
+    for name in LADDER_RECIPES {
+        let body = recipe(name);
+        if !body.contains("{{escalation_note}}") {
+            missing.push(*name);
+        }
+    }
+    assert!(
+        missing.is_empty(),
+        "these recipe-backed brains must expose the {{{{escalation_note}}}} \
+         escalation seam (issue #2419 family) but do not: {missing:?}"
+    );
+}
+
+#[test]
+fn lifecycle_recipe_documents_empty_on_base_contract() {
+    // GREEN anchor: the already-fixed lifecycle recipe pins the base contract.
+    // Step 8 should document the same contract in the newly-wired recipes, but
+    // we only hard-require the placeholder above to avoid over-pinning prose.
+    let body = recipe("ooda-engineer-lifecycle.yaml");
+    assert!(
+        body.contains("{{escalation_note}}"),
+        "lifecycle recipe must keep the escalation_note placeholder"
+    );
+    assert!(
+        body.to_lowercase().contains("empty on the base attempt"),
+        "lifecycle recipe must keep documenting the empty-on-base contract"
+    );
+}
+
+#[test]
+fn merge_readiness_recipe_documents_structured_verdict_contract() {
+    // The merge-judge fix surfaces a STRUCTURED verdict; the recipe must keep
+    // instructing the agent to emit the `{"verdict": ...}` JSON object so the
+    // caller can parse `ready`/`not_ready`/`unclear` from the json envelope
+    // rather than the text-mode banner (#2462/#2463).
+    let body = recipe("merge-readiness-judge.yaml");
+    assert!(
+        body.contains("\"verdict\""),
+        "merge recipe must document the structured verdict JSON contract"
+    );
+    for kw in ["ready", "not_ready", "unclear"] {
+        assert!(
+            body.contains(kw),
+            "merge recipe must document the '{kw}' verdict value"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
Recipe-produced fix for the recipe-brain VERDICT/DECISION parse-failure cluster (the #2419 family). The recipe completed the implementation but hollow-failed at the PR-creation step; landing the verified work here (rebased onto current main, only a trivial mkdocs nav conflict resolved).

Makes the merge-readiness-judge / decide / orient recipe brains request and robustly parse a STRUCTURED (JSON-envelope) verdict/decision instead of the recipe-runner TEXT-MODE banner. On a parse miss: schema-repair / re-prompt, then escalate via the existing confidence-gated ladder, and only fall back deterministically and LOUDLY after exhausting it. `simard merge-pr` now surfaces a real PASS/FAIL/BLOCKED verdict and **fails closed** when no verdict is produced (never silent SUCCESS). Verdict-parse success rate is instrumented (#2429).

## Changes
- `src/ooda_brain/recipe_brain.rs`, `src/stewardship/recipe_merge_judge.rs`, `src/ooda_brain/{judgment_record,parse_failure,mod}.rs` — JSON-envelope transport + schema-repair + escalation + fail-closed verdict.
- `prompt_assets/simard/recipes/{merge-readiness-judge,ooda-decide,ooda-orient}.yaml` — structured-output prompts.
- Tests: `tests/recipe_brain_verdict_assets.rs`, gadugi `merge-judge-verdict` + `decide-orient-brain-parse`.
- Docs: verdict-parsing reference + diagnose how-tos.

## Issues
Closes #2421, #2428, #2429, #2430, #2435, #2462, #2463

## Test plan
- Unit + content-pin tests green; pre-push (fmt + targeted release tests + clippy --all-targets --locked) passed locally.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>