### PR TITLE
fix(release): filter feature-gated bins from release tarball + self-update hardening (#2252)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,21 +60,46 @@ jobs:
       - name: Package binary
         if: steps.tag_check.outputs.exists == 'false'
         run: |
-          # Enumerate every [[bin]] target name from cargo metadata so the
-          # tarball ships the FULL Simard binary set (simard plus simard-tui,
-          # simard-gym, and the rest) — not just the main daemon binary.
-          # Without this, the consumer-side multi-binary self-update (#2252)
-          # would have nothing extra to install.
+          set -euo pipefail
+          # Enumerate the [[bin]] target names from cargo metadata so the tarball
+          # ships the FULL Simard binary set (simard plus simard-tui, simard-gym,
+          # and the rest) — not just the main daemon binary. Without this, the
+          # consumer-side multi-binary self-update (#2252) would have nothing
+          # extra to install.
+          #
+          # CRITICAL: only ship targets the release build actually produces. The
+          # "Build release binary" step runs `cargo build --release` with the
+          # DEFAULT feature set, so bin targets gated behind a non-default
+          # `required-features` (e.g. the `dashboard-audit` audit tools
+          # simard-audit-pass01 / simard-audit-dashboard) are NOT compiled. They
+          # must be filtered out here; otherwise `tar` aborts trying to stat a
+          # binary that was never built (exit 2, every release).
           mapfile -t BIN_TARGETS < <(
             cargo metadata --no-deps --format-version 1 \
-              | jq -r '.packages[].targets[] | select(.kind[] == "bin") | .name'
+              | jq -r '
+                  .packages[].targets[]
+                  | select(.kind[] == "bin")
+                  | select((."required-features" // []) | length == 0)
+                  | .name
+                '
           )
           if [ "${#BIN_TARGETS[@]}" -eq 0 ]; then
-            echo "::error::No [[bin]] targets found in cargo metadata" >&2
+            echo "::error::No buildable [[bin]] targets found in cargo metadata" >&2
             exit 1
           fi
           echo "Packaging binaries: ${BIN_TARGETS[*]}"
           cd target/release
+          # Fail loudly with a precise message if the release build did not
+          # produce an expected binary, rather than relying on tar's terse
+          # "Cannot stat" error.
+          missing=()
+          for bin in "${BIN_TARGETS[@]}"; do
+            [ -f "$bin" ] || missing+=("$bin")
+          done
+          if [ "${#missing[@]}" -ne 0 ]; then
+            echo "::error::Release build did not produce expected binaries: ${missing[*]}" >&2
+            exit 1
+          fi
           # Tar exactly the built binaries that exist for this platform.
           tar czf simard-linux-x86_64.tar.gz "${BIN_TARGETS[@]}"
           sha256sum simard-linux-x86_64.tar.gz > simard-linux-x86_64.tar.gz.sha256

--- a/docs/reference/multi-binary-self-update.md
+++ b/docs/reference/multi-binary-self-update.md
@@ -22,7 +22,7 @@ related:
 > **Status: implemented.** `simard update` replaces the **entire** Simard
 > binary set — the main `simard` daemon binary **and** every auxiliary
 > executable shipped in the release tarball (`simard-tui`, `simard-gym`,
-> `simard-ooda-step`, the `simard-audit-*` tools, and so on) — not just the
+> `simard-ooda-step`, and so on) — not just the
 > daemon binary. The dynamic discovery, the `InstallReport`
 > main-fatal/aux-best-effort contract, and the checksum/extraction/transport
 > hardening live in
@@ -67,7 +67,7 @@ Before this change, `simard update` downloaded a release tarball, found the
 single file named `simard` inside it, and swapped **only** that file over the
 running daemon binary. Every other shipped executable — most visibly
 `simard-tui`, the operator's monitoring dashboard, but also `simard-gym` and
-the `simard-*-step` / `simard-audit-*` helpers — was left at whatever version
+the `simard-*-step` helpers — was left at whatever version
 the operator last installed by hand.
 
 The result was a split-brain install: a freshly self-updated `simard` daemon
@@ -113,26 +113,36 @@ At the time of writing the producer packages these Cargo `bin` targets:
 | `simard-engineer-step` | Engineer-step helper | Auxiliary — best-effort |
 | `simard-self-improve-recipe` | Self-improve recipe driver | Auxiliary — best-effort |
 | `simard-engineer-loop-recipe` | Engineer-loop recipe driver | Auxiliary — best-effort |
-| `simard-audit-pass01` | Audit pass-1 tool | Auxiliary — best-effort |
-| `simard-audit-dashboard` | Audit dashboard | Auxiliary — best-effort |
 | `simard_operator_probe` | Operator self-probe helper (note: underscore-named) | Auxiliary — best-effort |
 
+> **Feature-gated targets are NOT shipped.** Cargo `bin` targets carrying a
+> non-default `required-features` (for example `simard-audit-pass01` and
+> `simard-audit-dashboard`, gated behind the `dashboard-audit` feature) are
+> **excluded** from the release tarball, because the release job builds with the
+> default feature set and never compiles them. The producer filter drops any
+> target whose `required-features` is non-empty (see
+> [Release packaging contract](#release-packaging-contract)). To ship such a
+> tool, the release build must first enable its feature.
+
 The table is **illustrative, not authoritative**. The authoritative set is
-whatever `cargo metadata` reports as `bin` targets at release time (see
+whatever `cargo metadata` reports as `bin` targets *buildable with the release
+feature set* at release time (see
 [Release packaging contract](#release-packaging-contract)) and, on the consumer
 side, whatever executables the downloaded tarball contains. `simard` is the only
 name with special status: it is the **main** binary and its replacement is
 fatal. Every other extracted executable is **auxiliary** and best-effort.
 
 > **Design note — which targets ship.** The `cargo metadata` enumeration ships
-> **every** `bin` target, including helper/probe binaries such as
-> `simard_operator_probe` (and any future test-only or internal helper bins). If
-> some targets should not be distributed to operators, the producer `jq` filter
-> must gain an explicit exclude list — discovery alone will ship them. Decide
-> the ship/no-ship policy as part of this change rather than leaving it implicit.
-> Note also that target names are not uniformly hyphenated (`simard_operator_probe`
-> uses underscores), so the consumer's basename match and de-duplication must be
-> name-agnostic.
+> every `bin` target **whose `required-features` are satisfied by the release
+> build**, including helper/probe binaries such as `simard_operator_probe` (and
+> any future test-only or internal helper bins). Targets gated behind a
+> non-default feature are filtered out (see the
+> [Release packaging contract](#release-packaging-contract)). If some
+> default-built targets should additionally not be distributed to operators, the
+> producer `jq` filter must gain an explicit exclude list — discovery alone will
+> ship them. Note also that target names are not uniformly hyphenated
+> (`simard_operator_probe` uses underscores), so the consumer's basename match
+> and de-duplication must be name-agnostic.
 
 ### Install location
 
@@ -166,11 +176,17 @@ What changed is the breadth of the swap and the order of operations:
 2. **Download** the platform tarball over https-only transport.
 3. **Verify** the tarball against the published `.sha256` **before** extraction.
    A mismatch aborts and cleans up the temp directory.
-4. **Extract** into a private temp directory with zip-slip defenses.
-5. **Discover** every executable in the extracted tree.
-6. **Install** the main binary (fatal on error), then each auxiliary binary
+4. **Authenticate** the tarball's cosign keyless signature against this repo's
+   pinned release-workflow identity **before** extraction (defense-in-depth
+   beyond the same-origin checksum). A present-but-invalid signature aborts; an
+   absent signature or a host without `cosign` warns and continues. See
+   [R8](#security-model).
+5. **Extract** into a private, exclusively-created temp directory with zip-slip
+   defenses and `--no-same-owner --no-same-permissions`.
+6. **Discover** every executable in the extracted tree.
+7. **Install** the main binary (fatal on error), then each auxiliary binary
    (best-effort).
-7. **Confirm** each installed binary is present on disk — a post-install
+8. **Confirm** each installed binary is present on disk — a post-install
    existence check over exactly what discovery installed; there is no external
    "expected" manifest, since the set is dynamic — then print the
    `InstallReport`.
@@ -347,7 +363,7 @@ daemon.
 ## Security model
 
 The multi-binary discovery widens the attack surface (more files written from a
-downloaded archive), so the path is hardened on three axes. All apply to the
+downloaded archive), so the path is hardened on several axes. All apply to the
 main binary too — they are not aux-only.
 
 | # | Control | What it prevents |
@@ -355,9 +371,11 @@ main binary too — they are not aux-only.
 | R1 | **SHA-256 verification before extraction.** Compute the digest of the downloaded tarball, compare to the published `.sha256`, abort + clean up on mismatch. | Unauthenticated / tampered code execution. Previously the producer published the `.sha256` sidecar but the consumer never fetched **or** verified it (the self-update code had no checksum logic at all). |
 | R2 | **Zip-slip defense.** Install by **basename only** into the trusted install dir; canonicalize within the install root; reject any entry that is an absolute path, contains `..`, or is a symlink. | A malicious archive writing outside the install directory or following a symlink to overwrite an arbitrary file. |
 | R3 | **https-only transport.** Enforce an `https://` URL and, because the download follows redirects (`curl -L`), pass `curl --proto =https --proto-redir =https --tlsv1.2` so a redirect can never downgrade to `http://`. | Protocol downgrade and redirect-to-http MITM. |
-| R4 | **Scoped `chmod`.** `0o755` is applied only to executables chosen by discovery, never to arbitrary extracted files. | Granting execute to attacker-planted data files. |
+| R4 | **Scoped `chmod` + no archive-supplied perms.** `0o755` is applied only to executables chosen by discovery; extraction passes `tar --no-same-owner --no-same-permissions` so the archive can never restore its own ownership/permission bits. | Granting execute to attacker-planted data files; setuid/world-writable bits smuggled in via the tarball. |
 | R5 | **Strict asset matching.** Keep the exact platform-suffix + `.tar.gz` asset match when selecting the release asset. | Asset spoofing via look-alike asset names. |
 | R6 | **SHA-pinned Actions.** The release workflow keeps every GitHub Action pinned by commit SHA. | Supply-chain compromise of a tag-mutable action. |
+| R7 | **Private, exclusively-created temp dir.** The download/extract directory uses an unpredictable random suffix and is created with `create_dir` (fails if the path already exists) at mode `0700`, replacing the predictable `simard-update-<pid>` name created with `create_dir_all`. | A local attacker on a shared host pre-creating or symlinking the temp path to redirect the `curl -o` write or smuggle a rogue executable into discovery. |
+| R8 | **cosign keyless signature verification.** After R1, fetch the `.sig`/`.pem` sidecars and run `cosign verify-blob` pinning the certificate identity to this repo's `release.yml` workflow on `main` and the GitHub OIDC issuer. A present-but-invalid signature **aborts**; when `cosign` or the sidecars are absent the update warns and continues (the R1 checksum still applies). | A compromised release host swapping **both** the tarball and its same-origin `.sha256`: the attacker cannot forge a Fulcio certificate for this repo's workflow identity. |
 
 No secrets ever appear in logs or issue comments. The "try `sudo`, fail cleanly"
 behaviour is preserved — the update path never auto-escalates; it installs into
@@ -370,16 +388,29 @@ set** into each platform tarball, instead of only `simard`. Without this, the
 consumer refactor installs nothing extra.
 
 The "Package binary" step enumerates Cargo `bin` targets dynamically rather than
-naming a literal `simard`:
+naming a literal `simard`. It also filters out targets gated behind a non-default
+`required-features` (such as the `dashboard-audit` audit tools), because the
+release build uses the default feature set and never compiles them — packaging a
+never-built target would make `tar` fail:
 
 ```bash
-# Enumerate every [[bin]] target name from cargo metadata.
+set -euo pipefail
+# Enumerate the [[bin]] target names that the default release build produces.
 mapfile -t BIN_TARGETS < <(
   cargo metadata --no-deps --format-version 1 \
-    | jq -r '.packages[].targets[] | select(.kind[] == "bin") | .name'
+    | jq -r '
+        .packages[].targets[]
+        | select(.kind[] == "bin")
+        | select((."required-features" // []) | length == 0)
+        | .name
+      '
 )
 
 cd target/release
+# Fail loudly if the build did not produce an expected binary.
+for bin in "${BIN_TARGETS[@]}"; do
+  [ -f "$bin" ] || { echo "::error::missing built binary: $bin"; exit 1; }
+done
 # Tar exactly the built binaries that exist for this platform.
 TARBALL="simard-${PLATFORM_SUFFIX}.tar.gz"
 tar czf "$TARBALL" "${BIN_TARGETS[@]}"
@@ -397,8 +428,9 @@ sha256sum "$TARBALL" > "$TARBALL.sha256"
 
 Contract guarantees:
 
-- The tarball contains **every** built `bin` target, with `simard` always
-  present.
+- The tarball contains **every** `bin` target buildable with the release
+  feature set (targets gated behind a non-default `required-features` are
+  excluded), with `simard` always present.
 - A `<asset>.tar.gz.sha256` sidecar is published next to every tarball (already
   true; the consumer now verifies it — see [R1](#security-model)).
 - The platform suffix (`linux-x86_64`, `linux-aarch64`, `macos-x86_64`,
@@ -439,7 +471,7 @@ Replacing binaries...
   simard-tui           installed
   simard-gym           installed
   simard-ooda-step     installed
-  simard-audit-pass01  installed
+  simard-improve-step  installed
   …                    (remaining auxiliary binaries)
 Updated 9 binaries: v0.42.0 → v0.43.0
 Running self-test on new binary...

--- a/src/cmd_self_update/download.rs
+++ b/src/cmd_self_update/download.rs
@@ -5,12 +5,11 @@
 //! the release tarball), not just the main daemon binary (issue #2252). See
 //! `docs/reference/multi-binary-self-update.md` for the full contract.
 
+use super::platform::{RELEASE_CERT_IDENTITY_REGEXP, RELEASE_CERT_OIDC_ISSUER};
 use std::collections::HashSet;
 use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
-
-use super::platform::CURRENT_VERSION;
 
 /// Outcome of installing the full binary set from an extracted tarball.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -25,16 +24,95 @@ pub(crate) struct InstallReport {
     pub aux_failed: Vec<(String, String)>,
 }
 
-/// Private temp directory the self-update flow downloads and extracts into.
-/// Shared by `download_to_temp` (which fills it) and `download_and_replace`
-/// (which discovers the extracted binary set inside it).
-fn update_tmp_dir() -> PathBuf {
-    std::env::temp_dir().join(format!("simard-update-{}", std::process::id()))
+/// Create a fresh, private (mode `0700`) temp directory for the self-update
+/// download/extract, returning its path.
+///
+/// R7 (hardening): the directory name carries an unpredictable random suffix and
+/// is created with `create_dir` semantics that FAIL if the path already exists,
+/// replacing the previous predictable `simard-update-<pid>` name created with
+/// `create_dir_all`. On a shared host this defeats a local attacker who
+/// pre-creates (or symlinks) the directory to redirect our `curl -o` write or to
+/// smuggle a rogue executable into the discovery walk. The exclusive create is
+/// what guarantees safety; the random suffix only makes the name hard to guess.
+pub(crate) fn create_update_tmp_dir() -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let base = std::env::temp_dir();
+    let mut last_err: Option<std::io::Error> = None;
+    for _ in 0..32 {
+        let dir = base.join(format!("simard-update-{}", random_token()));
+        match create_private_dir(&dir) {
+            Ok(()) => return Ok(dir),
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                last_err = Some(e);
+                continue;
+            }
+            Err(e) => return Err(format!("Failed to create update temp dir: {e}").into()),
+        }
+    }
+    Err(format!(
+        "Failed to create a unique update temp dir after 32 attempts: {}",
+        last_err
+            .map(|e| e.to_string())
+            .unwrap_or_else(|| "unknown error".to_string())
+    )
+    .into())
+}
+
+/// Create `dir` with `create_dir` semantics (fails if it already exists) and, on
+/// Unix, restrictive `0700` permissions so only the current user can read, write
+/// or traverse it.
+#[cfg(unix)]
+fn create_private_dir(dir: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::DirBuilderExt;
+    fs::DirBuilder::new().mode(0o700).create(dir)
+}
+
+#[cfg(not(unix))]
+fn create_private_dir(dir: &Path) -> std::io::Result<()> {
+    fs::DirBuilder::new().create(dir)
+}
+
+/// 16 bytes of hex from the OS CSPRNG (`/dev/urandom`), falling back to a mix of
+/// pid + high-resolution time if the CSPRNG is unavailable. The EXCLUSIVE create
+/// in [`create_update_tmp_dir`] is what guarantees safety; this only makes the
+/// directory name hard to guess and collision-resistant.
+fn random_token() -> String {
+    let mut bytes = [0u8; 16];
+    if !fill_random(&mut bytes) {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let seed = (nanos as u64) ^ ((std::process::id() as u64) << 32);
+        for (i, b) in bytes.iter_mut().enumerate() {
+            *b = ((seed >> ((i % 8) * 8)) as u8) ^ (i as u8);
+        }
+    }
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        use std::fmt::Write as _;
+        let _ = write!(s, "{b:02x}");
+    }
+    s
+}
+
+#[cfg(unix)]
+fn fill_random(buf: &mut [u8]) -> bool {
+    use std::io::Read;
+    fs::File::open("/dev/urandom")
+        .and_then(|mut f| f.read_exact(buf))
+        .is_ok()
+}
+
+#[cfg(not(unix))]
+fn fill_random(_buf: &mut [u8]) -> bool {
+    false
 }
 
 /// Download and extract the release, replacing the full set of installed
 /// Simard binaries. The main `simard` swap is fatal; auxiliary binaries are
-/// installed best-effort.
+/// installed best-effort. Returns the `InstallReport` for the caller to
+/// surface to the operator — this function only prints progress, never the
+/// final summary, so the outcome is reported exactly once.
 pub(crate) fn download_and_replace(
     url: &str,
     version: &str,
@@ -46,13 +124,10 @@ pub(crate) fn download_and_replace(
         .ok_or("Cannot determine install directory from current executable")?
         .to_path_buf();
 
-    // Download → verify checksum → extract into the private temp dir. The
-    // returned path is the main `simard` candidate; the rest of the extracted
-    // tree stays in the temp dir for discovery below.
-    let _main_candidate = download_to_temp(url, version)?;
-    let tmp_dir = update_tmp_dir();
-
-    // Discover EVERY executable in the extracted tree (main + auxiliaries).
+    // Download → verify checksum → extract into the private temp dir, then
+    // discover EVERY executable in the extracted tree (main + auxiliaries) with
+    // a single filesystem walk.
+    let tmp_dir = download_and_extract(url, version)?;
     let binaries = find_all_binaries_in_dir(&tmp_dir)?;
 
     println!("Replacing {} binary(ies)...", binaries.len());
@@ -75,29 +150,16 @@ pub(crate) fn download_and_replace(
     // Clean up the temp directory (archive + any leftover extracted files).
     let _ = fs::remove_dir_all(&tmp_dir);
 
-    if report.aux_installed.is_empty() {
-        println!("Updated simard: {CURRENT_VERSION} → {version}");
-    } else {
-        println!(
-            "Updated simard + {} auxiliary binary(ies): {CURRENT_VERSION} → {version}",
-            report.aux_installed.len()
-        );
-    }
     Ok(report)
 }
 
-/// Download and extract the simard release into a temp directory, returning
-/// the path to the extracted **main** `simard` binary. Used by both
-/// `download_and_replace` (which then installs the full binary set) and the
-/// safe-update flow (which copies the main candidate to an install path and
-/// runs a pre-test before swapping). Its signature is a hard contract: it
-/// must keep returning a single `PathBuf` to the main candidate.
-pub(crate) fn download_to_temp(
-    url: &str,
-    version: &str,
-) -> Result<PathBuf, Box<dyn std::error::Error>> {
-    let tmp_dir = update_tmp_dir();
-    fs::create_dir_all(&tmp_dir)?;
+/// Download → verify checksum → extract the release into the private temp dir,
+/// returning the populated temp directory. Shared by `download_to_temp` and
+/// `download_and_replace` so the download/verify/extract work runs once and the
+/// binary-discovery walk that follows it also runs exactly once per update
+/// (previously `download_and_replace` walked the extracted tree twice).
+fn download_and_extract(url: &str, version: &str) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let tmp_dir = create_update_tmp_dir()?;
     let archive_path = tmp_dir.join("simard.tar.gz");
 
     println!("Downloading simard v{version}...");
@@ -132,6 +194,9 @@ pub(crate) fn download_to_temp(
                 "2",
                 "-o",
                 archive_str,
+                // `--` terminates option parsing so a URL beginning with `-`
+                // can never be reinterpreted as a curl flag (arg injection).
+                "--",
                 url,
             ])
             .status()
@@ -157,6 +222,15 @@ pub(crate) fn download_to_temp(
         return Err(format!("Checksum verification failed: {e}").into());
     }
 
+    // R8: authenticate the tarball's cosign keyless signature — defense-in-depth
+    // beyond the same-origin sha256 (a host that swaps both the tarball and its
+    // `.sha256` defeats the checksum alone). A present-but-invalid signature
+    // ABORTS; an absent signature or missing cosign warns and continues.
+    if let Err(e) = verify_signature(&archive_path, url, &tmp_dir) {
+        let _ = fs::remove_dir_all(&tmp_dir);
+        return Err(format!("Signature verification failed: {e}").into());
+    }
+
     println!("Extracting...");
     let tar_status = std::process::Command::new("tar")
         .args([
@@ -167,6 +241,11 @@ pub(crate) fn download_to_temp(
                     archive_path.display()
                 )
             })?,
+            // R4: never let the archive restore its own ownership or permission
+            // bits onto extracted files. Discovery applies a scoped `chmod 0755`
+            // only to the binaries it chooses to install (see `install_into`).
+            "--no-same-owner",
+            "--no-same-permissions",
             "-C",
             tmp_dir.to_str().ok_or_else(|| {
                 format!("temp dir path is not valid UTF-8: {}", tmp_dir.display())
@@ -179,6 +258,19 @@ pub(crate) fn download_to_temp(
         return Err("Extraction failed".into());
     }
 
+    Ok(tmp_dir)
+}
+
+/// Download and extract the simard release into a temp directory, returning
+/// the path to the extracted **main** `simard` binary. Used by the
+/// `safe-update` flow (which copies the main candidate to an install path and
+/// runs a pre-test before swapping). Its signature is a hard contract: it must
+/// keep returning a single `PathBuf` to the main candidate.
+pub(crate) fn download_to_temp(
+    url: &str,
+    version: &str,
+) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let tmp_dir = download_and_extract(url, version)?;
     // Return the main `simard` candidate (discovery guarantees it sorts first).
     let binaries = find_all_binaries_in_dir(&tmp_dir)?;
     binaries
@@ -437,6 +529,9 @@ pub(crate) fn verify_sha256(
             "15",
             "--max-time",
             "60",
+            // `--` terminates option parsing so the sidecar URL can never be
+            // reinterpreted as a curl flag (arg injection).
+            "--",
             &sidecar_url,
         ])
         .output()
@@ -464,4 +559,134 @@ pub(crate) fn verify_sha256(
         return Err(format!("Checksum mismatch: expected {expected}, got {actual}").into());
     }
     Ok(())
+}
+
+/// Verify the release tarball's cosign keyless signature (R8, issue #2261).
+///
+/// Defense-in-depth on top of [`verify_sha256`]: the sha256 sidecar is fetched
+/// from the same origin as the tarball, so a compromised host that swaps both
+/// the tarball and its `.sha256` defeats it. The cosign signature is bound to a
+/// short-lived Fulcio certificate whose Subject Alternative Name is pinned to
+/// THIS repo's release-workflow identity ([`RELEASE_CERT_IDENTITY_REGEXP`]) and
+/// issuer ([`RELEASE_CERT_OIDC_ISSUER`]) — an identity an attacker cannot forge.
+///
+/// Policy (fail-closed where it counts, non-breaking otherwise):
+///   * cosign present AND both sidecars (`.sig`, `.pem`) fetch as non-empty →
+///     run `cosign verify-blob`; a verification FAILURE ABORTS the update.
+///   * cosign not installed, OR a signature sidecar is absent (e.g. an older,
+///     pre-signing release) → emit a prominent warning and continue, so updates
+///     are not broken on hosts without cosign or for legacy releases. The R1
+///     sha256 gate still applies in every case.
+///
+/// R3: signature material is only ever fetched over https-only transport.
+pub(crate) fn verify_signature(
+    archive_path: &Path,
+    asset_url: &str,
+    tmp_dir: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if !asset_url.starts_with("https://") {
+        return Err(format!("Refusing non-https release asset URL: {asset_url}").into());
+    }
+
+    if !cosign_available() {
+        eprintln!(
+            "WARNING: cosign not found — skipping release signature verification. \
+             Install cosign to authenticate releases (the sha256 checksum was still verified)."
+        );
+        return Ok(());
+    }
+
+    let sig_path = tmp_dir.join("simard.tar.gz.sig");
+    let cert_path = tmp_dir.join("simard.tar.gz.pem");
+    let sig_ok = fetch_sidecar(&format!("{asset_url}.sig"), &sig_path);
+    let cert_ok = fetch_sidecar(&format!("{asset_url}.pem"), &cert_path);
+    if !sig_ok || !cert_ok {
+        let _ = fs::remove_file(&sig_path);
+        let _ = fs::remove_file(&cert_path);
+        eprintln!(
+            "WARNING: signature material (.sig/.pem) is not available for this release — \
+             skipping cosign verification (the sha256 checksum was still verified)."
+        );
+        return Ok(());
+    }
+
+    println!("Verifying cosign signature...");
+    let status = std::process::Command::new("cosign")
+        .args([
+            "verify-blob",
+            "--certificate",
+            cert_path
+                .to_str()
+                .ok_or("certificate path is not valid UTF-8")?,
+            "--signature",
+            sig_path
+                .to_str()
+                .ok_or("signature path is not valid UTF-8")?,
+            "--certificate-identity-regexp",
+            RELEASE_CERT_IDENTITY_REGEXP,
+            "--certificate-oidc-issuer",
+            RELEASE_CERT_OIDC_ISSUER,
+            // `--` terminates option parsing so the archive path can never be
+            // reinterpreted as a cosign flag (arg injection).
+            "--",
+            archive_path
+                .to_str()
+                .ok_or("archive path is not valid UTF-8")?,
+        ])
+        .status()
+        .map_err(|e| format!("Failed to run cosign: {e}"))?;
+
+    let _ = fs::remove_file(&sig_path);
+    let _ = fs::remove_file(&cert_path);
+
+    if !status.success() {
+        return Err(format!(
+            "cosign signature verification FAILED ({status}) — refusing to install this release"
+        )
+        .into());
+    }
+    Ok(())
+}
+
+/// Whether a usable `cosign` binary is on `PATH`.
+fn cosign_available() -> bool {
+    std::process::Command::new("cosign")
+        .arg("version")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Fetch a signature sidecar over https-only transport into `dest`. Returns
+/// `true` only when curl succeeded AND the written file is non-empty.
+fn fetch_sidecar(url: &str, dest: &Path) -> bool {
+    let Some(dest_str) = dest.to_str() else {
+        return false;
+    };
+    let ok = std::process::Command::new("curl")
+        .args([
+            "-sS",
+            "-L",
+            // R3: https-only transport — refuse plaintext and never downgrade.
+            "--proto",
+            "=https",
+            "--proto-redir",
+            "=https",
+            "--tlsv1.2",
+            "--connect-timeout",
+            "15",
+            "--max-time",
+            "60",
+            "-o",
+            dest_str,
+            // `--` terminates option parsing (arg-injection guard).
+            "--",
+            url,
+        ])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    ok && dest.metadata().map(|m| m.len() > 0).unwrap_or(false)
 }

--- a/src/cmd_self_update/platform.rs
+++ b/src/cmd_self_update/platform.rs
@@ -3,6 +3,19 @@
 pub(crate) const GITHUB_REPO: &str = "rysweet/Simard";
 pub(crate) const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
+/// cosign keyless verification identity for release assets (issues #2261 / #2252).
+///
+/// `simard update` pins the signer of a release tarball to THIS repository's
+/// `release.yml` workflow running on `main`. The Fulcio certificate's Subject
+/// Alternative Name must match this regexp and be issued by GitHub's OIDC
+/// provider below. These two constants MUST stay in lockstep with the
+/// `cosign sign-blob` identity produced by `.github/workflows/release.yml`.
+pub(crate) const RELEASE_CERT_IDENTITY_REGEXP: &str =
+    r"^https://github\.com/rysweet/Simard/\.github/workflows/release\.yml@refs/heads/main$";
+
+/// OIDC issuer for GitHub Actions keyless signing certificates.
+pub(crate) const RELEASE_CERT_OIDC_ISSUER: &str = "https://token.actions.githubusercontent.com";
+
 /// Platform suffix for GitHub Release assets.
 pub(crate) fn platform_suffix() -> Option<&'static str> {
     if cfg!(target_os = "linux") && cfg!(target_arch = "x86_64") {

--- a/src/cmd_self_update/release.rs
+++ b/src/cmd_self_update/release.rs
@@ -20,12 +20,23 @@ pub(crate) fn find_latest_release() -> Result<(String, String), Box<dyn std::err
             std::process::Command::new("curl")
                 .args([
                     "-sS",
+                    // R3: https-only transport — refuse a plaintext URL and never
+                    // let a redirect downgrade the scheme to http://. The URL is a
+                    // hardcoded api.github.com constant, but this keeps the release
+                    // query consistent with the hardened download path.
+                    "--proto",
+                    "=https",
+                    "--proto-redir",
+                    "=https",
+                    "--tlsv1.2",
                     "--connect-timeout",
                     "10",
                     "--max-time",
                     "30",
                     "-H",
                     "Accept: application/vnd.github+json",
+                    // `--` terminates option parsing (arg-injection guard).
+                    "--",
                     &format!("https://api.github.com/repos/{GITHUB_REPO}/releases/latest"),
                 ])
                 .output()

--- a/src/cmd_self_update/tests_download.rs
+++ b/src/cmd_self_update/tests_download.rs
@@ -1,7 +1,6 @@
-//! TDD contract for the multi-binary self-update path (issue #2252).
+//! Behavioural contract for the multi-binary self-update path (issue #2252).
 //!
-//! These tests specify the behaviour of the not-yet-implemented multi-binary
-//! self-update API documented in
+//! These tests pin down the multi-binary self-update API documented in
 //! `docs/reference/multi-binary-self-update.md`:
 //!
 //!   * `find_all_binaries_in_dir` — dynamic discovery of every executable in an
@@ -15,13 +14,12 @@
 //!   * shared-primitive regression guards for `download_to_temp` and the
 //!     `safe-update` download-only path.
 //!
-//! They are written FIRST and are expected to FAIL (the symbols do not exist on
-//! the default branch yet) until the implementation lands. Everything here is
-//! hermetic: no network, no live release, no reliance on a real GitHub asset.
+//! Everything here is hermetic: no network, no live release, and no reliance on
+//! a real GitHub asset.
 
 use super::download::{
-    InstallReport, find_all_binaries_in_dir, install_binaries, install_binary, sha256_file,
-    verify_sha256,
+    InstallReport, create_update_tmp_dir, find_all_binaries_in_dir, install_binaries,
+    install_binary, sha256_file, verify_sha256, verify_signature,
 };
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -587,6 +585,74 @@ fn verify_sha256_rejects_non_https_url() {
             "verify_sha256 must refuse non-https asset URL: {url}"
         );
     }
+}
+
+// ===========================================================================
+// verify_signature — R8 cosign keyless authenticity gate (transport guard)
+// ===========================================================================
+
+#[test]
+fn verify_signature_rejects_non_https_url() {
+    // R3/R8: signature material (.sig/.pem) is fetched over https-only transport.
+    // A non-https asset URL is refused before any cosign or network work, so the
+    // result is deterministic regardless of whether cosign is installed.
+    let dir = tempfile::tempdir().unwrap();
+    let archive = dir.path().join("simard-linux-x86_64.tar.gz");
+    fs::write(&archive, b"tarball").unwrap();
+
+    for url in [
+        "http://example.com/simard-linux-x86_64.tar.gz",
+        "ftp://example.com/simard-linux-x86_64.tar.gz",
+        "file:///tmp/simard-linux-x86_64.tar.gz",
+    ] {
+        let result = verify_signature(&archive, url, dir.path());
+        assert!(
+            result.is_err(),
+            "verify_signature must refuse non-https asset URL: {url}"
+        );
+    }
+}
+
+// ===========================================================================
+// create_update_tmp_dir — R7 private, unpredictable, exclusive temp dir
+// ===========================================================================
+
+#[test]
+fn create_update_tmp_dir_makes_fresh_private_dir() {
+    // R7: the download/extract dir must be freshly created (never a pre-existing
+    // path an attacker could have seeded or symlinked) and, on Unix, private.
+    let dir = create_update_tmp_dir().expect("should create a temp dir");
+    assert!(
+        dir.exists() && dir.is_dir(),
+        "update temp dir must exist as a directory"
+    );
+    assert_eq!(
+        fs::read_dir(&dir).unwrap().count(),
+        0,
+        "freshly created update temp dir must be empty"
+    );
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = fs::metadata(&dir).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o700,
+            "update temp dir must be private (0700), got {mode:o}"
+        );
+    }
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn create_update_tmp_dir_returns_unique_paths() {
+    // The randomized suffix must make two updates pick different directories,
+    // replacing the predictable `simard-update-<pid>` name that a local attacker
+    // could anticipate.
+    let a = create_update_tmp_dir().unwrap();
+    let b = create_update_tmp_dir().unwrap();
+    assert_ne!(a, b, "two update temp dirs must not collide");
+    let _ = fs::remove_dir_all(&a);
+    let _ = fs::remove_dir_all(&b);
 }
 
 // ===========================================================================


### PR DESCRIPTION
## Why

`main`'s release packaging step enumerates **every** `[[bin]]` target from
`cargo metadata` and tars them all. Two targets — `simard-audit-dashboard` and
`simard-audit-pass01` — are gated behind the non-default `dashboard-audit`
feature, so the default `cargo build --release` never produces them. `tar`
then aborts trying to stat a binary that does not exist (**exit 2**), breaking
**every release**.

This was introduced when #2470 merged the multi-binary self-update feature
(#2252) but carried the unfiltered packaging step. The fix lived on the
feature branch but was orphaned: PR #2475 was closed as "superseded by #2470"
at 07:28, while the fix commits were written afterward (07:54 / 08:12) and
never reached `main`.

## What

**Blocking fix — `.github/workflows/release.yml`:**
- Filter enumeration to targets with no `required-features`.
- Add an explicit missing-binary precheck with a precise error message.
- `set -euo pipefail`.

**Self-update hardening that never reached `main` (cohesive, same module):**
- `download.rs`: cosign keyless **consumer-side** signature verification
  (`verify_signature`). `main` already *signs* releases (#2472) but the updater
  could not *verify* them — this closes that gap. A present-but-invalid
  signature aborts; an absent signature or missing cosign warns and falls back
  to the existing sha256 gate. Also: R7 private temp dir (random suffix +
  exclusive create, replacing the predictable `simard-update-<pid>` path) and a
  single-walk extract/discover refactor.
- `platform.rs`: `RELEASE_CERT_IDENTITY_REGEXP` + `RELEASE_CERT_OIDC_ISSUER`,
  pinned in lockstep with `release.yml`'s `cosign sign-blob` identity.
- `tests_download.rs`: coverage for signature verification and the
  multi-binary install policy (main-fatal, aux-best-effort).
- `docs/reference/multi-binary-self-update.md` kept in sync.

## Scope discipline

Only `src/cmd_self_update/{download,platform,release,tests_download}.rs`,
`.github/workflows/release.yml`, and the one reference doc change. `update.rs`,
`tests.rs`, `mod.rs` are byte-identical with `main`, so this does not re-touch
the already-merged feature, and it touches none of the unrelated areas where
the original feature branch had diverged from `main`.

## Verification (on top of current `main`)

- `cargo build --release --locked` — green
- `cargo test --lib cmd_self_update` — **63 passed, 0 failed**
- `cargo fmt --all -- --check` — clean
- `cargo clippy --release --all-targets --all-features --locked` — clean
- Release enumeration now yields **9 buildable binaries**, all present after the
  default release build. The old unfiltered enumeration would include the 2
  unbuilt audit binaries (reproduced: tar would fail).

Fixes the release regression for #2252.