### PR TITLE
fix(brain/memory): shared robust JSON/verdict extractor for noisy recipe stdout (#2484)

### DIFF
--- a/docs/reference/text-parsing-wire-formats.md
+++ b/docs/reference/text-parsing-wire-formats.md
@@ -25,6 +25,65 @@ For the design rationale, see
 
 ---
 
+## Protocol 0: Shared noise pre-stripping (`recipe_output`)
+
+Used by: **every** recipe-backed parser below, before it runs.
+
+> **Added in [#2484](https://github.com/rysweet/Simard/issues/2484):**
+> `recipe-runner-rs` stdout (and the `step_results[].output` string inside its
+> `--output-format json` envelope) is routinely contaminated with three kinds
+> of non-payload noise that broke the formerly bespoke per-phase extractors:
+>
+> 1. **ANSI SGR/CSI/OSC colour codes** from `tracing`/`env_logger` (e.g. a
+>    leading `\x1b[2m` "dim" whose raw `ESC`/`0x1b` byte is invalid inside a
+>    JSON document, so `serde_json` rejects the span).
+> 2. **Timestamped tracing-log lines** interleaved with the agent answer.
+> 3. The runner's **text-mode summary banner** (`Recipe: … SUCCESS`, `Steps: …`,
+>    `[completed] …`).
+>
+> The single hardened `src/recipe_output/` module is now the **only**
+> ANSI/log/banner-stripping path. The two former duplicate strippers
+> (`meeting_backend::sanitize::strip_ansi_escapes`, `stewardship::dedup::normalize`)
+> and the distill-private ANSI stripper now delegate to it.
+
+### Functions
+
+| Function | Behaviour |
+|---|---|
+| `strip_ansi(&str) -> Cow` | Single ANSI (CSI/OSC/two-char) stripper. `Cow::Borrowed` on the clean path (no `ESC` byte). |
+| `strip_recipe_noise(&str) -> Cow` | `strip_ansi` + drop ISO-8601 tracing lines and runner-banner lines. `Cow::Borrowed` on the clean path. |
+| `balanced_objects` / `last_balanced_object` / `extract_json_payload` | String-literal-aware balanced `{…}` scan. JSON extraction is **dual-pass** (line-dropped **and** ANSI-only) so the payload survives both an interleaved log line inside a pretty body and a same-line log prefix. |
+| `extract_verdict(raw, keywords)` | Precedence keyword scan over cleaned text. |
+| `record_parse_outcome(phase, success)` | Emits `recipe_parse_{success,failure}_total{phase}` to `metrics.jsonl`. |
+
+### Clean-path guarantee
+
+`strip_ansi` and `strip_recipe_noise` return `Cow::Borrowed` — byte-identical
+text with zero allocation — when stdout carries no `ESC` byte and no droppable
+log/banner line. Adopting the shared helper therefore does **not** change any
+phase's behaviour on clean output; only previously-defaulted noisy cases now
+recover.
+
+### Observability counters
+
+On every recipe-backed phase invocation, `record_parse_outcome(phase, success)`
+is emitted at the subprocess call site (never inside a pure parse function, so
+unit tests write no metrics):
+
+```
+recipe_parse_success_total{phase}
+recipe_parse_failure_total{phase}   # incremented when the permissive default fires
+```
+
+`phase ∈ {distill, merge_judge, engineer_lifecycle, decide, orient,
+progress_checker}`. These are **complementary** to the brain phases' existing
+`brain_verdict_parsed_total{phase,outcome}` counter (issue #2429): the latter
+owns the brain-phase success-rate dashboard; these add the memory/distill and
+progress-checker phases to the same counter family and give both numerator and
+denominator per phase.
+
+---
+
 ## Protocol 1: First-word match (OODA brains)
 
 Used by: `ooda_brain::recipe_brain` (all three phases)
@@ -46,6 +105,11 @@ free-text     = <any remaining text — kept as rationale>
 - It is lowercased via `to_ascii_lowercase()` before matching.
 - If no known variant matches, a safe default is returned (not a parse error).
 - Everything after the first word is the rationale (truncated to 500 chars).
+
+> **Noise pre-stripping (#2484):** each parser first routes its input through
+> [`recipe_output::strip_recipe_noise`](#protocol-0-shared-noise-pre-stripping-recipe_output)
+> so an ANSI-coloured log prefix or runner banner cannot shadow the first-word /
+> first-float token. Clean output is passed through unchanged (`Cow::Borrowed`).
 
 ### Common parser shape
 
@@ -235,6 +299,11 @@ The parser scans the entire stdout for a verdict keyword. Everything else
 
 ### Scanning rules
 
+0. **Pre-strip noise (#2484):** route stdout through
+   [`recipe_output::strip_recipe_noise`](#protocol-0-shared-noise-pre-stripping-recipe_output)
+   first, so a dropped tracing-log line's keyword substring (e.g. `already`
+   containing `ready`) cannot fabricate a verdict and a real verdict behind an
+   ANSI/log prefix is not silently missed. Clean output is unchanged.
 1. Convert stdout to lowercase for matching.
 2. Check for the **negative** keyword first to prevent substring false positives.
 3. Check for the **positive** keyword.
@@ -449,12 +518,14 @@ Each parser has inline `#[cfg(test)]` tests in its source file:
 
 | Module | Test count | Coverage |
 |--------|-----------|----------|
+| `recipe_output/extract.rs` | 25+ | `strip_ansi` (CSI/OSC/two-char, clean-path borrow, JSON-escaped literal), `strip_recipe_noise` (drops tracing/banner lines, keeps prose), balanced-object scan (string-literal aware), `extract_json_payload` dual-pass recovery (ANSI+log, same-line prefix, interleaved log line), `extract_verdict` precedence + dropped-log-line substring safety |
 | `decide.rs` | 4+ | DeterministicFallback tests |
-| `recipe_brain.rs` | 30+ | All 10 action keywords (first-word), first-float orient, 6 lifecycle variants (first-word), case-insensitive match, unrecognized defaults |
+| `recipe_brain.rs` | 30+ | All 10 action keywords (first-word), first-float orient, 6 lifecycle variants (first-word), case-insensitive match, unrecognized defaults, #2484 banner→DefaultMalformed / pure-noise→DefaultEmpty |
 | `orient.rs` | 8+ | Float parsing, validation, extra fields, empty/invalid responses |
 | `rustyclawd.rs` | 15+ (T1–T15) | Full behavior matrix per decision protocol reference |
-| `recipe_progress_checker.rs` | 4+ | Accept, reject, no keyword (default), mixed case |
-| `recipe_merge_judge.rs` | 5+ | `parse_merge_outcome`: structured `parse_judge_response` JSON (populates blockers), prose keyword scan (ready / not_ready / unclear; substring safety), JSON-envelope extraction, and fail-closed `Verdict::Unclear` on an unparseable verdict. |
+| `recipe_progress_checker.rs` | 6+ | Accept, reject, no keyword (default), mixed case, #2484 noise-obscured reject recovery, `parse_verdict_outcome` match flag |
+| `recipe_merge_judge.rs` | 8+ | `parse_merge_outcome`: structured `parse_judge_response` JSON (populates blockers), prose keyword scan (ready / not_ready / unclear; substring safety), JSON-envelope extraction, fail-closed `Verdict::Unclear` on an unparseable verdict, and #2484 noise-stripping (dropped-log-line `ready` substring safety, verdict recovery past an ANSI log prefix). |
+| `memory_consolidation/distillation.rs` | 17+ | Plain object, prose-embedded object, last-non-empty preference, unmatched-quote tolerance, ANSI-log recovery, #2484 runner-banner recovery |
 | `disk_health.rs` | 3+ | Full output, no-cleanup output, malformed lines |
 
 ---

--- a/src/goal_curation/recipe_progress_checker.rs
+++ b/src/goal_curation/recipe_progress_checker.rs
@@ -148,7 +148,9 @@ impl ProgressEvidenceChecker for RecipeProgressChecker {
             };
         }
 
-        parse_verdict_from_text(&raw)
+        let (decision, matched) = parse_verdict_outcome(&raw);
+        crate::recipe_output::record_parse_outcome("progress_checker", matched);
+        decision
     }
 }
 
@@ -181,23 +183,47 @@ fn render_wip_summary(goal: &ActiveGoal) -> String {
 /// - If neither keyword found, accept with diagnostic (same fallback
 ///   as the old JSON parse-error path)
 pub fn parse_verdict_from_text(text: &str) -> EvidenceDecision {
-    let lower = text.to_ascii_lowercase();
-    let rationale = truncate(text.trim(), RATIONALE_MAX_CHARS);
+    parse_verdict_outcome(text).0
+}
+
+/// Like [`parse_verdict_from_text`] but also returns whether a verdict keyword
+/// was actually found (`true`) versus the permissive accept-to-avoid-blocking
+/// default firing (`false`). The flag drives the `recipe_parse_*_total{phase}`
+/// counter at the subprocess call site (issue #2484); the pure parser stays
+/// metric-free so unit tests write no metrics.
+pub fn parse_verdict_outcome(text: &str) -> (EvidenceDecision, bool) {
+    // Strip ANSI escapes + drop whole tracing-log / runner-banner lines first
+    // (shared #2484 extractor) so a noise-obscured verdict is not silently
+    // dropped — e.g. a real "reject" must not be missed because it trailed an
+    // ANSI-coloured log prefix, and an "already"/"accepted" substring inside a
+    // dropped log line cannot fabricate a verdict.
+    let cleaned = crate::recipe_output::strip_recipe_noise(text);
+    let lower = cleaned.to_ascii_lowercase();
+    let rationale = truncate(cleaned.trim(), RATIONALE_MAX_CHARS);
 
     if lower.contains("reject") {
-        EvidenceDecision::Reject {
-            reason: format!("{ADAPTER_TAG}: reject — {rationale}"),
-        }
+        (
+            EvidenceDecision::Reject {
+                reason: format!("{ADAPTER_TAG}: reject — {rationale}"),
+            },
+            true,
+        )
     } else if lower.contains("accept") {
-        EvidenceDecision::Accept {
-            reason: format!("{ADAPTER_TAG}: accept — {rationale}"),
-        }
+        (
+            EvidenceDecision::Accept {
+                reason: format!("{ADAPTER_TAG}: accept — {rationale}"),
+            },
+            true,
+        )
     } else {
-        EvidenceDecision::Accept {
-            reason: format!(
-                "{ADAPTER_TAG}: no verdict keyword found in recipe output; accepting to avoid blocking goal"
-            ),
-        }
+        (
+            EvidenceDecision::Accept {
+                reason: format!(
+                    "{ADAPTER_TAG}: no verdict keyword found in recipe output; accepting to avoid blocking goal"
+                ),
+            },
+            false,
+        )
     }
 }
 
@@ -373,5 +399,37 @@ mod tests {
             }
             EvidenceDecision::Reject { .. } => panic!("expected accept"),
         }
+    }
+
+    #[test]
+    fn text_verdict_recovers_reject_past_ansi_log_prefix() {
+        // #2484: the verdict trails an ANSI-coloured tracing-log line. The
+        // shared extractor strips both so the real reject is recovered and the
+        // rationale carries no log/ANSI noise (a noise-obscured reject must
+        // never be silently accepted-to-avoid-blocking).
+        let esc = '\u{1b}';
+        let text = format!(
+            "{esc}[2m2026-06-28T08:08:58.151133Z{esc}[0m  INFO checker: scoring\n\
+             Verdict: reject — no measurable progress this cycle."
+        );
+        match parse_verdict_from_text(&text) {
+            EvidenceDecision::Reject { reason } => {
+                assert!(reason.contains("reject"), "got: {reason}");
+                assert!(!reason.contains("INFO checker"), "log line must be dropped");
+            }
+            EvidenceDecision::Accept { .. } => panic!("noise-obscured reject must be recovered"),
+        }
+    }
+
+    #[test]
+    fn parse_verdict_outcome_reports_match_flag_for_counter() {
+        // The `bool` drives the `recipe_parse_*_total{progress_checker}` counter:
+        // a real keyword ⇒ true (success), the permissive default ⇒ false.
+        let (decision, matched) = parse_verdict_outcome("just prose, no verdict keyword here");
+        assert!(matches!(decision, EvidenceDecision::Accept { .. }));
+        assert!(!matched, "permissive default must report matched=false");
+
+        let (_, matched_reject) = parse_verdict_outcome("Verdict: reject — insufficient evidence");
+        assert!(matched_reject, "a real verdict must report matched=true");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,7 @@ mod operator_commands_terminal;
 mod persistence;
 pub mod prompt_assets;
 pub mod prompt_delivery;
+pub mod recipe_output;
 pub mod reflection;
 pub mod remote_azlin;
 pub mod remote_session;

--- a/src/meeting_backend/sanitize.rs
+++ b/src/meeting_backend/sanitize.rs
@@ -110,26 +110,13 @@ pub fn sanitize_agent_output(raw: &str) -> String {
     result.trim().to_string()
 }
 
-/// Strip ANSI escape sequences (CSI sequences: ESC [ params final-byte).
+/// Strip ANSI escape sequences (CSI/OSC/2-char) from `s`.
+///
+/// Delegates to the single shared, hardened stripper
+/// [`crate::recipe_output::strip_ansi`] (issue #2484) so this crate has exactly
+/// one ANSI-stripping implementation rather than several copy-pasted ones.
 pub fn strip_ansi_escapes(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    let mut chars = s.chars();
-    while let Some(c) = chars.next() {
-        if c == '\x1b' {
-            if let Some(next) = chars.next()
-                && next == '['
-            {
-                for ch in chars.by_ref() {
-                    if ch.is_ascii_alphabetic() {
-                        break;
-                    }
-                }
-            }
-        } else {
-            out.push(c);
-        }
-    }
-    out
+    crate::recipe_output::strip_ansi(s).into_owned()
 }
 
 /// Detect lines that are agent infrastructure noise, not conversational content.

--- a/src/memory_consolidation/distillation.rs
+++ b/src/memory_consolidation/distillation.rs
@@ -897,12 +897,16 @@ impl RecipeRunnerSubprocess {
 impl DistillRecipeRunner for RecipeRunnerSubprocess {
     fn run(&self, episodes: &[CognitiveEpisode]) -> SimardResult<Vec<DistilledFact>> {
         let raw = self.invoke_recipe(episodes, false)?;
-        parse_recipe_output(&raw)
+        let parsed = parse_recipe_output(&raw);
+        crate::recipe_output::record_parse_outcome("distill", parsed.is_ok());
+        parsed
     }
 
     fn run_all(&self, episodes: &[CognitiveEpisode]) -> SimardResult<DistillOutput> {
         let raw = self.invoke_recipe(episodes, false)?;
-        parse_recipe_output_full(&raw)
+        let parsed = parse_recipe_output_full(&raw);
+        crate::recipe_output::record_parse_outcome("distill", parsed.is_ok());
+        parsed
     }
 
     fn run_all_reinforced(
@@ -914,7 +918,9 @@ impl DistillRecipeRunner for RecipeRunnerSubprocess {
         // `strict_json_instruction` context var into the recipe so the agent
         // reply is reinforced to be ONLY the `{ "facts": [...] }` object.
         let raw = self.invoke_recipe(episodes, strict_json)?;
-        parse_recipe_output_full(&raw)
+        let parsed = parse_recipe_output_full(&raw);
+        crate::recipe_output::record_parse_outcome("distill", parsed.is_ok());
+        parsed
     }
 }
 
@@ -1083,26 +1089,55 @@ pub(crate) fn parse_recipe_output_full(raw: &str) -> SimardResult<DistillOutput>
 /// inside JSON string literals, respecting `\"` escapes) so a brace inside a
 /// fact's `content` cannot corrupt depth accounting.
 fn scan_for_facts_object(text: &str) -> Option<DistillOutput> {
-    // Strip ANSI escape sequences first. `recipe-runner-rs` / the agent binary
-    // render their tracing logs into the captured step `output` with ANSI colour
-    // codes — the t=7919 distill parse-failure's step output began with a dimmed
-    // `\x1b[2m<RFC3339 timestamp>` prefix. A raw `ESC` (`0x1b`) byte is invalid
-    // inside a JSON document, so when those codes colourise or interleave the
-    // agent's `{ "facts": [...] }` answer `serde_json` rejects the span and the
-    // whole 20-episode batch silently defers. Removing the escapes before the
-    // balanced-brace scan recovers the buried payload (issues #2461 / #2401).
-    let cleaned = strip_ansi_escapes(text);
-    let trimmed = cleaned.trim();
+    // Try two cleaned views of the noisy step output, mirroring the shared
+    // `recipe_output::extract_json_payload` dual pass (issue #2484):
+    //
+    // 1. `strip_recipe_noise` strips ANSI escapes AND drops whole tracing/log
+    //    and runner-banner lines — this removes the `\x1b[2m<RFC3339 timestamp>`
+    //    log prefix that made `serde_json` reject the span (the t=7919 / #2461 /
+    //    #2484 distill parse-failure) and recovers a payload whose pretty body
+    //    has an interleaved tracing line.
+    // 2. `strip_ansi` is line-preserving — it recovers a payload that sits on
+    //    the SAME physical line as a leading timestamp/log prefix, which view 1
+    //    would otherwise drop wholesale.
+    //
+    // Both views are clean-path zero-copy (`Cow::Borrowed`) when stdout carries
+    // no `ESC` byte and no droppable line, so adopting the shared helper does
+    // not change behaviour on clean output. A non-empty facts object from
+    // either view wins; an empty `{"facts":[]}` "nothing to distill" answer is
+    // kept only as a fallback when neither view yields a populated object.
+    let mut empty_fallback: Option<DistillOutput> = None;
+    for cleaned in [
+        crate::recipe_output::strip_recipe_noise(text),
+        crate::recipe_output::strip_ansi(text),
+    ] {
+        if let Some(output) = scan_cleaned_for_facts(cleaned.trim()) {
+            if !output.facts.is_empty() || !output.procedures.is_empty() {
+                return Some(output);
+            }
+            if empty_fallback.is_none() {
+                empty_fallback = Some(output);
+            }
+        }
+    }
+    empty_fallback
+}
+
+/// Scan an already noise-stripped `trimmed` string for a `{ "facts": [...] }`
+/// object, preferring the LAST *non-empty* balanced top-level object (the
+/// agent's final answer trails any banner/thinking output) and falling back to
+/// the last parseable empty object. The ANSI/log/banner stripping that produces
+/// `trimmed` lives in [`scan_for_facts_object`].
+fn scan_cleaned_for_facts(trimmed: &str) -> Option<DistillOutput> {
     // Fast path — the text IS the JSON object.
     if let Ok(parsed) = serde_json::from_str::<RecipeEnvelope>(trimmed) {
         return Some(parsed.into_output());
     }
     // Slow path — among every balanced top-level `{...}` substring, prefer the
-    // facts from the LAST *non-empty* one that parses (the agent's final answer
-    // trails any banner/thinking output). Falling back to the last parseable
-    // object only when none carry facts/procedures preserves a legitimate
-    // `{"facts":[]}` "nothing worth distilling" answer while never letting an
-    // accidental trailing empty object shadow an earlier populated one.
+    // facts from the LAST *non-empty* one that parses. Falling back to the last
+    // parseable object only when none carry facts/procedures preserves a
+    // legitimate `{"facts":[]}` "nothing worth distilling" answer while never
+    // letting an accidental trailing empty object shadow an earlier populated one.
     let mut empty_fallback: Option<DistillOutput> = None;
     for (start, end) in balanced_object_spans(trimmed).into_iter().rev() {
         if let Ok(parsed) = serde_json::from_str::<RecipeEnvelope>(&trimmed[start..end]) {
@@ -1162,75 +1197,6 @@ fn balanced_object_spans(s: &str) -> Vec<(usize, usize)> {
         }
     }
     spans
-}
-
-/// Strip ANSI escape sequences (CSI/SGR colour codes, OSC strings, and other
-/// simple `ESC x` two-byte escapes) from `s`.
-///
-/// `recipe-runner-rs` and the agent binary render their tracing logs into the
-/// captured step `output` with ANSI colour codes — the t=7919 distill
-/// parse-failure's step output began with a dimmed `\x1b[2m<RFC3339 timestamp>`
-/// prefix. A raw `ESC` (`0x1b`) byte is never valid inside a JSON document, so
-/// when those codes colourise or interleave the agent's `{ "facts": [...] }`
-/// answer, `serde_json` rejects the span and the batch silently defers (the
-/// "step output did not contain a parseable { facts } object" parse-failure).
-/// Removing the escapes before the balanced-brace scan recovers the payload.
-///
-/// Only RAW `0x1b` bytes are removed: a legitimately JSON-escaped `\u001b`
-/// inside fact content is the ASCII run `\`,`u`,`0`,`0`,`1`,`b` (no raw ESC) and
-/// is left untouched. Multi-byte UTF-8 content is preserved verbatim because
-/// every byte that is not part of an ASCII escape sequence is copied as-is.
-/// Returns the input unchanged (borrowed, no allocation) when it carries no
-/// `ESC` byte — the overwhelmingly common clean-output case.
-fn strip_ansi_escapes(s: &str) -> std::borrow::Cow<'_, str> {
-    let bytes = s.as_bytes();
-    if !bytes.contains(&0x1b) {
-        return std::borrow::Cow::Borrowed(s);
-    }
-    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
-    let mut i = 0;
-    while i < bytes.len() {
-        if bytes[i] != 0x1b {
-            out.push(bytes[i]);
-            i += 1;
-            continue;
-        }
-        // Consume the `ESC` and classify the sequence that follows.
-        i += 1;
-        match bytes.get(i) {
-            // CSI: `ESC [` params/intermediates until a final byte 0x40..=0x7e
-            // (e.g. `\x1b[2m`, `\x1b[0m`, `\x1b[38;5;245m`).
-            Some(b'[') => {
-                i += 1;
-                while i < bytes.len() && !(0x40..=0x7e).contains(&bytes[i]) {
-                    i += 1;
-                }
-                if i < bytes.len() {
-                    i += 1; // consume the final byte
-                }
-            }
-            // OSC: `ESC ]` … terminated by BEL (`0x07`) or ST (`ESC \`).
-            Some(b']') => {
-                i += 1;
-                while i < bytes.len() {
-                    if bytes[i] == 0x07 {
-                        i += 1;
-                        break;
-                    }
-                    if bytes[i] == 0x1b && bytes.get(i + 1) == Some(&b'\\') {
-                        i += 2;
-                        break;
-                    }
-                    i += 1;
-                }
-            }
-            // Any other two-byte escape (charset select, etc.) — drop `ESC` + 1.
-            Some(_) => i += 1,
-            // Trailing lone `ESC` — nothing else to drop.
-            None => {}
-        }
-    }
-    std::borrow::Cow::Owned(String::from_utf8_lossy(&out).into_owned())
 }
 
 /// The `recipe-runner-rs` 0.3.6 `--output-format json` envelope. Only the
@@ -1790,24 +1756,49 @@ mod unit_tests {
         assert!(facts.is_empty());
     }
 
-    // ── t=7919: ANSI-coded tracing-log noise in step output ──────────────
+    // ── t=7919 / #2484: ANSI-coded tracing-log + banner noise in step output ──
 
     #[test]
-    fn strip_ansi_escapes_removes_csi_and_preserves_text_and_utf8() {
+    fn parse_recipe_output_recovers_from_ansi_log_noise() {
+        // #2484 live-evidence shape: the distill step output begins with the
+        // dimmed `\x1b[2m<RFC3339 timestamp>` tracing prefix, then the agent's
+        // facts object on the next line. The raw span carries `ESC` bytes so it
+        // is invalid JSON; the shared `strip_recipe_noise` adoption drops the
+        // ANSI-coloured log line and recovers the buried payload.
         let esc = '\u{1b}';
-        let input = format!("{esc}[2mdim{esc}[0m plain {esc}[38;5;245mgrey{esc}[0m — café");
-        assert_eq!(strip_ansi_escapes(&input), "dim plain grey — café");
-        // No ESC byte → returned borrowed with no allocation.
-        assert!(matches!(
-            strip_ansi_escapes("no escapes here"),
-            std::borrow::Cow::Borrowed(_)
-        ));
-        // A JSON-escaped `\u001b` in content is an ASCII run (not a raw ESC) and
-        // must be left untouched so legitimate fact content is never mangled.
-        assert_eq!(
-            strip_ansi_escapes(r"literal \u001b stays"),
-            r"literal \u001b stays"
+        let raw = format!(
+            "{esc}[2m2026-06-28T08:08:58.151133Z{esc}[0m {esc}[36m INFO{esc}[0m simard::distill: run\n\
+             {{\"facts\":[{{\"concept\":\"lesson-learned\",\
+             \"content\":\"shared extractor recovered me\",\"source_episode_id\":\"epi_8451\"}}]}}"
         );
+        // The raw, un-stripped span must NOT parse (the silent-drop failure).
+        assert!(
+            serde_json::from_str::<serde_json::Value>(&raw).is_err(),
+            "raw ANSI/log-noised span must be unparseable JSON"
+        );
+        let facts = parse_recipe_output(&raw).expect("shared extractor must recover facts");
+        assert_eq!(facts.len(), 1);
+        assert_eq!(facts[0].concept, "lesson-learned");
+        assert_eq!(facts[0].content, "shared extractor recovered me");
+    }
+
+    #[test]
+    fn parse_recipe_output_recovers_from_runner_banner() {
+        // New capability over the former distill-private ANSI-only stripper:
+        // `strip_recipe_noise` ALSO drops the recipe-runner text-mode summary
+        // banner lines that can prefix the agent's payload, which the old
+        // ANSI-only path left in place (defeating the balanced-brace scan when
+        // a banner line itself carried stray braces).
+        let raw = "Recipe: distill-episodes SUCCESS (36.0s)\n\
+                   Steps: 1/1 completed\n\
+                   [completed] distill (36.0s)\n\
+                   {\"facts\":[{\"concept\":\"bug-pattern\",\
+                   \"content\":\"runner banner must be dropped\",\
+                   \"source_episode_id\":\"epi_9\"}]}";
+        let facts = parse_recipe_output(raw).expect("banner-prefixed payload must parse");
+        assert_eq!(facts.len(), 1);
+        assert_eq!(facts[0].concept, "bug-pattern");
+        assert_eq!(facts[0].content, "runner banner must be dropped");
     }
 
     #[test]

--- a/src/ooda_brain/recipe_brain.rs
+++ b/src/ooda_brain/recipe_brain.rs
@@ -719,6 +719,7 @@ impl OodaDecideBrain for RecipeBrain {
         let (decision, outcome) = parse_action_outcome(&base_raw);
         if !outcome.is_parse_failure() {
             record_verdict_parse_metric(BrainPhase::Decide, &ctx.goal_id, outcome, 1);
+            crate::recipe_output::record_parse_outcome("decide", true);
             return Ok(decision);
         }
 
@@ -734,6 +735,7 @@ impl OodaDecideBrain for RecipeBrain {
             |d| decide_decision_choice(d).to_string(),
         );
         record_verdict_parse_metric(BrainPhase::Decide, &ctx.goal_id, final_outcome, attempts);
+        crate::recipe_output::record_parse_outcome("decide", !final_outcome.is_parse_failure());
         Ok(final_decision)
     }
 }
@@ -758,6 +760,7 @@ impl OodaOrientBrain for RecipeBrain {
         let (judgment, outcome) = parse(&base_raw);
         if !outcome.is_parse_failure() {
             record_verdict_parse_metric(BrainPhase::Orient, &ctx.goal_id, outcome, 1);
+            crate::recipe_output::record_parse_outcome("orient", true);
             return Ok(judgment);
         }
 
@@ -773,6 +776,7 @@ impl OodaOrientBrain for RecipeBrain {
             |j| format!("urgency={:.3}", j.adjusted_urgency),
         );
         record_verdict_parse_metric(BrainPhase::Orient, &ctx.goal_id, final_outcome, attempts);
+        crate::recipe_output::record_parse_outcome("orient", !final_outcome.is_parse_failure());
         Ok(final_judgment)
     }
 }
@@ -1052,6 +1056,7 @@ impl OodaBrain for RecipeBrain {
                 "ok",
                 1,
             );
+            crate::recipe_output::record_parse_outcome("engineer_lifecycle", true);
             return Ok(decision);
         }
 
@@ -1073,6 +1078,10 @@ impl OodaBrain for RecipeBrain {
             lifecycle_decision_choice(&final_decision),
             termination.cause_label(),
             attempts,
+        );
+        crate::recipe_output::record_parse_outcome(
+            "engineer_lifecycle",
+            !final_outcome.is_parse_failure(),
         );
         Ok(final_decision)
     }
@@ -1107,7 +1116,12 @@ pub fn parse_action_from_text(text: &str) -> DecideJudgment {
 /// indistinguishable — which is exactly what let the text-mode banner masquerade
 /// as "working" (the first word `Recipe:` always defaulted to `AdvanceGoal`).
 pub fn parse_action_outcome(text: &str) -> (DecideJudgment, LifecycleParseOutcome) {
-    let trimmed = text.trim();
+    // Strip ANSI escapes + drop tracing-log / runner-banner lines first (shared
+    // #2484 extractor) so a noise-obscured first-word action keyword is not
+    // silently defaulted to `advance_goal`. Clean-path zero-copy preserves
+    // today's behaviour on clean recipe output.
+    let cleaned = crate::recipe_output::strip_recipe_noise(text);
+    let trimmed = cleaned.trim();
     if trimmed.is_empty() {
         return (default_advance_goal(), LifecycleParseOutcome::DefaultEmpty);
     }
@@ -1218,9 +1232,15 @@ pub fn parse_orient_outcome(
     base_urgency: f64,
     failure_count: u32,
 ) -> (OrientJudgment, LifecycleParseOutcome) {
+    // Strip ANSI escapes + drop tracing-log / runner-banner lines first (shared
+    // #2484 extractor): a banner timing string like `(0.0s)` or a decimal inside
+    // a tracing line must not be scraped as the urgency float and demote the
+    // goal. Clean-path zero-copy preserves today's behaviour on clean output.
+    let cleaned = crate::recipe_output::strip_recipe_noise(text);
+    let s: &str = cleaned.as_ref();
     // Hoist trim above the scanner — avoids re-trimming on each candidate.
-    let trimmed = text.trim();
-    let bytes = text.as_bytes();
+    let trimmed = s.trim();
+    let bytes = s.as_bytes();
     let mut i = 0;
     while i < bytes.len() {
         if bytes[i].is_ascii_digit() {
@@ -1235,7 +1255,7 @@ pub fn parse_orient_outcome(
                     i += 1;
                 }
                 if i > after_dot
-                    && let Ok(val) = text[start..i].parse::<f64>()
+                    && let Ok(val) = s[start..i].parse::<f64>()
                 {
                     // Inline validation before allocating rationale string.
                     if val.is_finite() && (0.0..=1.0).contains(&val) && val <= base_urgency + 1e-9 {
@@ -1307,7 +1327,12 @@ pub fn parse_lifecycle_from_text(text: &str) -> EngineerLifecycleDecision {
 /// parse-failure rate measurable per issue #2419 — before this split, a real
 /// `continue_skipping` decision and a silent fallback were indistinguishable.
 pub fn parse_lifecycle_outcome(text: &str) -> (EngineerLifecycleDecision, LifecycleParseOutcome) {
-    let trimmed = text.trim();
+    // Strip ANSI escapes + drop tracing-log / runner-banner lines first (shared
+    // #2484 extractor) so a noise-obscured first-word decision keyword is not
+    // silently defaulted to `continue_skipping` — the #2419-family non-progress
+    // loop. Clean-path zero-copy preserves today's behaviour on clean output.
+    let cleaned = crate::recipe_output::strip_recipe_noise(text);
+    let trimmed = cleaned.trim();
     if trimmed.is_empty() {
         return (
             default_continue_skipping(),
@@ -3676,12 +3701,33 @@ mod tests {
 
         #[test]
         fn decide_outcome_banner_first_word_is_default_malformed() {
-            // The text-mode banner first word `Recipe:` defaults to advance_goal
-            // — but it must be classified DefaultMalformed (a parse-miss), NOT
-            // counted as a real `advance_goal` decision.
-            let (j, oc) = parse_action_outcome("Recipe: ooda-decide SUCCESS (0.0s)");
+            // The recipe-runner text-mode SUCCESS banner must be classified as a
+            // parse-miss (DefaultMalformed), NOT counted as a real `advance_goal`
+            // decision. After #2484 noise-stripping the pure-noise lines
+            // (`Recipe:`, `Steps:`, `[completed]`) are dropped, but the runner's
+            // `Recipe '<name>': SUCCESS` summary line survives — so the banner
+            // still reaches the parser as present-but-unrecognised text and is
+            // correctly flagged DefaultMalformed (never a silent advance_goal).
+            let banner = "Recipe: ooda-decide (v1.0.0)\nSteps: 1\n\n\
+                          Recipe 'ooda-decide': SUCCESS (0.0s)\n  \
+                          [completed] decide-next-action (0.0s)\n";
+            let (j, oc) = parse_action_outcome(banner);
             assert!(matches!(j, DecideJudgment::AdvanceGoal { .. }));
             assert_eq!(oc, LifecycleParseOutcome::DefaultMalformed);
+            assert!(oc.is_parse_failure());
+        }
+
+        #[test]
+        fn decide_outcome_pure_noise_banner_is_default_empty() {
+            // A banner consisting ONLY of droppable noise lines (no surviving
+            // `Recipe '<name>': SUCCESS` summary) strips to empty and is
+            // classified DefaultEmpty — still a loud parse-failure that defaults
+            // to advance_goal and escalates, never a real decision (#2484).
+            let (j, oc) = parse_action_outcome(
+                "Recipe: ooda-decide SUCCESS (0.0s)\n  [completed] decide (0.0s)\n",
+            );
+            assert!(matches!(j, DecideJudgment::AdvanceGoal { .. }));
+            assert_eq!(oc, LifecycleParseOutcome::DefaultEmpty);
             assert!(oc.is_parse_failure());
         }
 

--- a/src/recipe_output/extract.rs
+++ b/src/recipe_output/extract.rs
@@ -1,0 +1,501 @@
+//! Hardened extraction primitives for `recipe-runner-rs` stdout (issue #2484).
+//!
+//! `recipe-runner-rs` stdout is routinely contaminated with three kinds of
+//! non-payload noise that break the per-phase extractors that read it:
+//!
+//! 1. **ANSI SGR/CSI/OSC colour codes** emitted by `tracing`/`env_logger`
+//!    (e.g. the leading `\x1b[2m` "dim" before a timestamp). The raw `ESC`
+//!    (`0x1b`) byte is invalid inside a JSON document, so `serde_json`
+//!    rejects any span that contains it.
+//! 2. **Timestamped log lines** (`2026-06-28T08:08:58.151133Z INFO …`)
+//!    interleaved with the agent answer. These add stray `{`/`}`, decimal
+//!    numbers, and verdict-substring false positives (e.g. "al*ready*").
+//! 3. The runner's **human summary banner** (`Recipe: … SUCCESS (36.0s)`,
+//!    `Steps: …`, `  [completed] …`).
+//!
+//! Before this module each phase scanned that raw text with a bespoke,
+//! fragile extractor and fell back to a permissive default on a miss
+//! (`continue_skipping`, "no verdict keyword → accept", distill batch
+//! deferral). This is the single shared, well-tested path that strips the
+//! noise once, then either returns the last balanced `{…}` object or scans
+//! for a verdict keyword.
+//!
+//! ## Clean-path guarantee
+//!
+//! [`strip_ansi`] and [`strip_recipe_noise`] return [`Cow::Borrowed`] when
+//! the input has no `ESC` byte and (for `strip_recipe_noise`) no droppable
+//! log/banner line. The common case — clean recipe stdout — therefore
+//! allocates nothing and yields byte-for-byte identical text, so adopting
+//! the helper does not change any phase's behaviour on clean output.
+
+use std::borrow::Cow;
+
+/// Strip ANSI escape sequences (CSI, OSC, and bare two-character escapes).
+///
+/// Returns [`Cow::Borrowed`] unchanged when the input contains no `ESC`
+/// (`0x1b`) byte — the zero-allocation clean path.
+///
+/// Handled forms:
+/// - **CSI**: `ESC [ <params> <final 0x40..=0x7E>` (e.g. `\x1b[2m`, `\x1b[0m`)
+/// - **OSC**: `ESC ] <text> (BEL | ESC \\)`
+/// - **Two-char**: `ESC <byte>` (e.g. `ESC c` reset) — both bytes dropped.
+pub fn strip_ansi(s: &str) -> Cow<'_, str> {
+    if !s.as_bytes().contains(&0x1b) {
+        return Cow::Borrowed(s);
+    }
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c != '\x1b' {
+            out.push(c);
+            continue;
+        }
+        match chars.peek() {
+            // CSI: consume '[' then params until a final byte 0x40..=0x7E.
+            Some('[') => {
+                chars.next();
+                for ch in chars.by_ref() {
+                    if ('\u{40}'..='\u{7e}').contains(&ch) {
+                        break;
+                    }
+                }
+            }
+            // OSC: consume ']' then text until BEL or the ST terminator ESC \.
+            Some(']') => {
+                chars.next();
+                while let Some(ch) = chars.next() {
+                    if ch == '\u{7}' {
+                        break;
+                    }
+                    if ch == '\x1b' {
+                        if let Some('\\') = chars.peek() {
+                            chars.next();
+                        }
+                        break;
+                    }
+                }
+            }
+            // Bare two-character escape: drop the following byte too.
+            Some(_) => {
+                chars.next();
+            }
+            None => {}
+        }
+    }
+    Cow::Owned(out)
+}
+
+/// `true` when `s` begins with an ISO-8601 date stamp (`YYYY-MM-DDT…`), the
+/// signature of a `tracing`/`env_logger` log line that bled into stdout.
+fn starts_with_iso_timestamp(s: &str) -> bool {
+    let b = s.as_bytes();
+    b.len() >= 11
+        && b[0..4].iter().all(u8::is_ascii_digit)
+        && b[4] == b'-'
+        && b[5..7].iter().all(u8::is_ascii_digit)
+        && b[7] == b'-'
+        && b[8..10].iter().all(u8::is_ascii_digit)
+        && b[10] == b'T'
+}
+
+/// `true` when (after trimming) `line` is non-payload recipe-runner noise:
+/// a tracing/env_logger timestamped log line, or a runner summary-banner
+/// line. JSON payloads start with `{` and agent prose does not match these
+/// prefixes, so dropping such lines never discards the answer.
+fn is_noise_line(line: &str) -> bool {
+    let t = line.trim_start();
+    if starts_with_iso_timestamp(t) {
+        return true;
+    }
+    // recipe-runner-rs text-mode summary banner.
+    t.starts_with("Recipe:")
+        || t.starts_with("Steps:")
+        || t.starts_with("[completed]")
+        || t.starts_with("[failed]")
+        || t.starts_with("[skipped]")
+        || t.starts_with("[running]")
+}
+
+/// Strip ANSI escapes **and** drop whole tracing/env_logger log lines and
+/// recipe-runner summary-banner lines.
+///
+/// Returns [`Cow::Borrowed`] unchanged on the clean path (no `ESC` byte and
+/// no droppable line), preserving today's behaviour and allocations.
+pub fn strip_recipe_noise(raw: &str) -> Cow<'_, str> {
+    let de_ansi = strip_ansi(raw);
+    if !de_ansi.lines().any(is_noise_line) {
+        // No droppable lines: pass through the ANSI-strip result as-is
+        // (`Borrowed` stays `Borrowed` on the fully-clean path).
+        return de_ansi;
+    }
+    let kept: Vec<&str> = de_ansi.lines().filter(|l| !is_noise_line(l)).collect();
+    Cow::Owned(kept.join("\n"))
+}
+
+/// Scan `bytes` starting at `start` (which must index a `{`) for the matching
+/// closing brace, honouring JSON string literals so braces inside `"…"` do
+/// not affect the depth count. Returns the byte index of the matching `}`.
+fn scan_balanced(bytes: &[u8], start: usize) -> Option<usize> {
+    let mut depth = 0i32;
+    let mut in_string = false;
+    let mut escaped = false;
+    let mut i = start;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if c == b'\\' {
+                escaped = true;
+            } else if c == b'"' {
+                in_string = false;
+            }
+        } else {
+            match c {
+                b'"' => in_string = true,
+                b'{' => depth += 1,
+                b'}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return Some(i);
+                    }
+                }
+                _ => {}
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Return every balanced top-level `{…}` span in `s`, in source order.
+///
+/// String-literal aware (braces inside JSON strings are ignored). Used by
+/// callers that need to try each candidate against a typed envelope — e.g.
+/// distillation parses each span as a `{ "facts": [...] }` object and keeps
+/// the first that deserialises.
+pub fn balanced_objects(s: &str) -> Vec<&str> {
+    let bytes = s.as_bytes();
+    let mut spans = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'{'
+            && let Some(end) = scan_balanced(bytes, i)
+        {
+            spans.push(&s[i..=end]);
+            i = end + 1;
+            continue;
+        }
+        i += 1;
+    }
+    spans
+}
+
+/// Return the **last** balanced top-level `{…}` span in `s`, or `None`.
+///
+/// Returning the last span means a leading "thinking"/banner object cannot
+/// shadow the real answer object that follows it.
+pub fn last_balanced_object(s: &str) -> Option<&str> {
+    balanced_objects(s).pop()
+}
+
+/// Extract a JSON object from noisy recipe stdout as an owned `String`.
+///
+/// Tries two cleaned views and returns the last balanced `{…}` from the first
+/// that yields one:
+///
+/// 1. [`strip_recipe_noise`] — drops whole log/banner lines, which recovers a
+///    payload whose pretty-printed body has an interleaved tracing line.
+/// 2. [`strip_ansi`] — line-preserving, which recovers a payload that sits on
+///    the *same physical line* as a leading timestamp/log prefix (that line
+///    would otherwise be dropped wholesale by view 1).
+///
+/// Returns `None` when neither view contains a balanced object.
+pub fn extract_json_payload(raw: &str) -> Option<String> {
+    for cleaned in [strip_recipe_noise(raw), strip_ansi(raw)] {
+        if let Some(obj) = last_balanced_object(cleaned.as_ref()) {
+            return Some(obj.to_string());
+        }
+    }
+    None
+}
+
+/// A verdict-keyword match against cleaned recipe output.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerdictMatch<'k> {
+    /// The keyword (borrowed from the caller's precedence list) that matched.
+    pub keyword: &'k str,
+    /// The full ANSI/log/banner-stripped, trimmed recipe text — the source
+    /// the caller turns into a rationale string.
+    pub rationale: String,
+}
+
+/// Scan recipe stdout for the first verdict keyword present, in the caller's
+/// precedence order, after stripping ANSI/log/banner noise.
+///
+/// Matching is case-insensitive substring containment. The first keyword in
+/// `keywords` that appears wins, so callers encode precedence by ordering
+/// (e.g. `["not_ready", "not ready", "unclear", "ready"]` so `not_ready`
+/// beats the `ready` it contains). Returns `None` when the cleaned text is
+/// empty or contains none of the keywords.
+pub fn extract_verdict<'k>(raw: &str, keywords: &[&'k str]) -> Option<VerdictMatch<'k>> {
+    let cleaned = strip_recipe_noise(raw);
+    let trimmed = cleaned.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let lower = trimmed.to_ascii_lowercase();
+    for &kw in keywords {
+        if lower.contains(&kw.to_ascii_lowercase()) {
+            return Some(VerdictMatch {
+                keyword: kw,
+                rationale: trimmed.to_string(),
+            });
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- strip_ansi -------------------------------------------------------
+
+    #[test]
+    fn strip_ansi_clean_input_is_borrowed_zero_copy() {
+        let s = "no escapes here";
+        let out = strip_ansi(s);
+        assert!(
+            matches!(out, Cow::Borrowed(_)),
+            "clean path must not allocate"
+        );
+        assert_eq!(out, "no escapes here");
+    }
+
+    #[test]
+    fn strip_ansi_removes_sgr_colour_codes() {
+        let input = "\x1b[33mWarning\x1b[0m: something \x1b[2mhappened\x1b[0m";
+        assert_eq!(strip_ansi(input), "Warning: something happened");
+    }
+
+    #[test]
+    fn strip_ansi_removes_dim_prefix_before_timestamp() {
+        // The exact #2484 live-evidence signature: SGR "dim" before an
+        // ISO-8601 timestamp.
+        let input = "\x1b[2m2026-06-28T08:08:58.151133Z\x1b[0m INFO distill";
+        assert_eq!(
+            strip_ansi(input),
+            "2026-06-28T08:08:58.151133Z INFO distill"
+        );
+    }
+
+    #[test]
+    fn strip_ansi_handles_osc_sequence() {
+        // OSC 0 ; title BEL  → fully removed.
+        let input = "before\x1b]0;my title\x07after";
+        assert_eq!(strip_ansi(input), "beforeafter");
+    }
+
+    #[test]
+    fn strip_ansi_matches_legacy_dedup_behaviour() {
+        // Mirrors stewardship::dedup::normalize's pass-1 expectation.
+        assert_eq!(
+            strip_ansi("\x1b[31mERR\x1b[0m   trailing"),
+            "ERR   trailing"
+        );
+    }
+
+    #[test]
+    fn strip_ansi_leaves_json_escaped_literal_untouched() {
+        // A JSON-escaped `\u001b` in fact content is the six-char ASCII run
+        // `\`,`u`,`0`,`0`,`1`,`b` (no raw `ESC` byte), so it must pass through
+        // unchanged and borrowed — legitimate content is never mangled. This is
+        // the guarantee inherited from the former distill-private stripper.
+        let s = r"literal \u001b stays";
+        let out = strip_ansi(s);
+        assert!(matches!(out, Cow::Borrowed(_)), "no raw ESC ⇒ zero-copy");
+        assert_eq!(out, r"literal \u001b stays");
+    }
+
+    // ---- strip_recipe_noise ----------------------------------------------
+
+    #[test]
+    fn strip_recipe_noise_clean_input_is_borrowed_zero_copy() {
+        let s = "{\"facts\":[]}";
+        let out = strip_recipe_noise(s);
+        assert!(
+            matches!(out, Cow::Borrowed(_)),
+            "clean path must not allocate"
+        );
+        assert_eq!(out, s);
+    }
+
+    #[test]
+    fn strip_recipe_noise_drops_tracing_log_lines() {
+        let raw = "2026-06-28T08:08:58.151133Z  INFO simard::distill: starting\n\
+                   {\"facts\":[]}\n\
+                   2026-06-28T08:08:59.000000Z  INFO simard::distill: done";
+        assert_eq!(strip_recipe_noise(raw), "{\"facts\":[]}");
+    }
+
+    #[test]
+    fn strip_recipe_noise_drops_runner_banner_lines() {
+        let raw = "Recipe: distill-episodes SUCCESS (36.0s)\n\
+                   Steps: 1/1 completed\n\
+                   [completed] distill (36.0s)\n\
+                   {\"facts\":[]}";
+        assert_eq!(strip_recipe_noise(raw), "{\"facts\":[]}");
+    }
+
+    #[test]
+    fn strip_recipe_noise_strips_ansi_and_logs_together() {
+        // ANSI-coloured tracing line + clean JSON line.
+        let raw = "\x1b[2m2026-06-28T08:08:58.151133Z\x1b[0m \x1b[32m INFO\x1b[0m run\n\
+                   {\"facts\":[{\"concept\":\"bug-pattern\"}]}";
+        assert_eq!(
+            strip_recipe_noise(raw),
+            "{\"facts\":[{\"concept\":\"bug-pattern\"}]}"
+        );
+    }
+
+    #[test]
+    fn strip_recipe_noise_keeps_agent_prose() {
+        let raw = "Sure, here is the result:\n{\"facts\":[]}\nThat's all.";
+        assert_eq!(
+            strip_recipe_noise(raw),
+            "Sure, here is the result:\n{\"facts\":[]}\nThat's all."
+        );
+    }
+
+    // ---- balanced_objects / last_balanced_object -------------------------
+
+    #[test]
+    fn balanced_objects_finds_each_top_level_object() {
+        let s = "{\"a\":1} junk {\"b\":2}";
+        assert_eq!(balanced_objects(s), vec!["{\"a\":1}", "{\"b\":2}"]);
+    }
+
+    #[test]
+    fn balanced_objects_ignores_braces_inside_strings() {
+        let s = "{\"text\":\"a } b { c\"}";
+        assert_eq!(balanced_objects(s), vec!["{\"text\":\"a } b { c\"}"]);
+    }
+
+    #[test]
+    fn balanced_objects_handles_escaped_quote_in_string() {
+        let s = r#"{"q":"he said \"}\" loudly"}"#;
+        assert_eq!(balanced_objects(s), vec![s]);
+    }
+
+    #[test]
+    fn last_balanced_object_returns_trailing_answer() {
+        let s = "{\"thinking\":true} then {\"answer\":42}";
+        assert_eq!(last_balanced_object(s), Some("{\"answer\":42}"));
+    }
+
+    #[test]
+    fn last_balanced_object_none_when_no_object() {
+        assert_eq!(last_balanced_object("no braces"), None);
+    }
+
+    // ---- extract_json_payload --------------------------------------------
+
+    #[test]
+    fn extract_json_payload_recovers_from_ansi_log_noise() {
+        // Raw fails (contains ESC); cleaned succeeds — the #2479-style
+        // raw-vs-stripped recovery proof, generalised.
+        let raw = "\x1b[2m2026-06-28T08:08:58.151133Z\x1b[0m  INFO simard: run\n\
+                   {\"facts\":[{\"concept\":\"lesson-learned\"}]}";
+        assert!(
+            serde_json::from_str::<serde_json::Value>(raw).is_err(),
+            "raw span with ESC byte must not parse as JSON"
+        );
+        let payload = extract_json_payload(raw).expect("payload recovered");
+        assert!(serde_json::from_str::<serde_json::Value>(&payload).is_ok());
+        assert_eq!(payload, "{\"facts\":[{\"concept\":\"lesson-learned\"}]}");
+    }
+
+    #[test]
+    fn extract_json_payload_none_for_pure_noise() {
+        let raw = "2026-06-28T08:08:58.151133Z  INFO no payload at all";
+        assert_eq!(extract_json_payload(raw), None);
+    }
+
+    #[test]
+    fn extract_json_payload_recovers_same_line_log_prefix() {
+        // Payload appended to a log line on the SAME physical line: the
+        // line-dropped view would discard it, so the ANSI-only fallback view
+        // must recover it.
+        let raw = "\x1b[2m2026-06-28T08:08:58.151133Z\x1b[0m  INFO done {\"facts\":[]}";
+        assert_eq!(
+            extract_json_payload(raw),
+            Some("{\"facts\":[]}".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_json_payload_recovers_interleaved_log_line() {
+        // A tracing line interleaved inside a pretty-printed body: the
+        // line-dropped view removes it so the braces balance again.
+        let raw = "{\n  \"facts\": [\n\
+                   2026-06-28T08:08:58.151133Z  INFO progress\n\
+                   ]\n}";
+        assert_eq!(
+            extract_json_payload(raw),
+            Some("{\n  \"facts\": [\n]\n}".to_string())
+        );
+    }
+
+    // ---- extract_verdict -------------------------------------------------
+
+    const MERGE_KEYWORDS: &[&str] = &["not_ready", "not ready", "unclear", "ready"];
+
+    #[test]
+    fn extract_verdict_precedence_not_ready_beats_ready() {
+        let m = extract_verdict("The PR is not_ready yet.", MERGE_KEYWORDS).unwrap();
+        assert_eq!(m.keyword, "not_ready");
+    }
+
+    #[test]
+    fn extract_verdict_plain_ready() {
+        let m = extract_verdict("Looks ready to merge.", MERGE_KEYWORDS).unwrap();
+        assert_eq!(m.keyword, "ready");
+    }
+
+    #[test]
+    fn extract_verdict_case_insensitive() {
+        let m = extract_verdict("VERDICT: READY", MERGE_KEYWORDS).unwrap();
+        assert_eq!(m.keyword, "ready");
+    }
+
+    #[test]
+    fn extract_verdict_none_when_absent() {
+        assert!(extract_verdict("cannot decide", MERGE_KEYWORDS).is_none());
+    }
+
+    #[test]
+    fn extract_verdict_none_when_empty_after_stripping() {
+        let raw = "2026-06-28T08:08:58.151133Z  INFO only a log line";
+        assert!(extract_verdict(raw, MERGE_KEYWORDS).is_none());
+    }
+
+    #[test]
+    fn extract_verdict_ignores_keyword_substring_inside_dropped_log_line() {
+        // "already" contains "ready"; the log line must be dropped so it does
+        // not produce a false Ready verdict. The real verdict follows.
+        let raw = "2026-06-28T08:08:58.000000Z  INFO already running batch\n\
+                   Verdict: not_ready — missing tests.";
+        let m = extract_verdict(raw, MERGE_KEYWORDS).unwrap();
+        assert_eq!(m.keyword, "not_ready");
+        assert!(!m.rationale.contains("already running"));
+    }
+
+    #[test]
+    fn extract_verdict_rationale_is_cleaned_full_text() {
+        let raw = "After review I accept the claim.";
+        let m = extract_verdict(raw, &["reject", "accept"]).unwrap();
+        assert_eq!(m.keyword, "accept");
+        assert_eq!(m.rationale, "After review I accept the claim.");
+    }
+}

--- a/src/recipe_output/mod.rs
+++ b/src/recipe_output/mod.rs
@@ -1,0 +1,37 @@
+//! Shared recipe-runner-rs stdout parsing primitives + per-phase parse
+//! observability counters (issue #2484).
+//!
+//! [`extract`] holds the hardened ANSI/log/banner stripping and JSON/verdict
+//! extraction reused by every recipe-backed phase (distill, merge-judge,
+//! engineer-lifecycle brain, decide, orient, progress-checker). This is the
+//! one shared, well-tested path that replaces the formerly bespoke, fragile
+//! per-phase extractors.
+
+pub mod extract;
+
+pub use extract::{
+    VerdictMatch, balanced_objects, extract_json_payload, extract_verdict, last_balanced_object,
+    strip_ansi, strip_recipe_noise,
+};
+
+/// Record the outcome of a recipe-output parse for one phase.
+///
+/// Emits `recipe_parse_success_total` (when `success`) or
+/// `recipe_parse_failure_total` (when the phase fell back to its permissive
+/// default) over the existing `metrics.jsonl` sink, tagging the `phase` in the
+/// metric `context`. This gives both the numerator and the denominator so the
+/// shared-extractor fix is measurable per phase.
+///
+/// `phase` ∈ {`distill`, `merge_judge`, `engineer_lifecycle`, `decide`,
+/// `orient`, `progress_checker`}.
+///
+/// Best-effort and non-blocking: a metrics-sink error must never fail or
+/// block real work, so the result is intentionally ignored.
+pub fn record_parse_outcome(phase: &str, success: bool) {
+    let metric_name = if success {
+        "recipe_parse_success_total"
+    } else {
+        "recipe_parse_failure_total"
+    };
+    let _ = crate::self_metrics::record_metric(metric_name, 1.0, phase);
+}

--- a/src/stewardship/dedup.rs
+++ b/src/stewardship/dedup.rs
@@ -8,22 +8,10 @@ use super::gh_client::GhIssue;
 /// Strip ANSI escape sequences and collapse internal whitespace runs to a
 /// single space. Trims leading/trailing whitespace.
 pub fn normalize(msg: &str) -> String {
-    // Pass 1: strip ANSI CSI escapes (`ESC [ ... <final-byte>`). We accept the
-    // common case where the final byte is a letter (m, K, J, etc.).
-    let mut stripped = String::with_capacity(msg.len());
-    let mut chars = msg.chars();
-    while let Some(c) = chars.next() {
-        if c == '\x1b' {
-            // Skip optional '[', then characters until a letter terminator.
-            for inner in chars.by_ref() {
-                if inner.is_ascii_alphabetic() {
-                    break;
-                }
-            }
-            continue;
-        }
-        stripped.push(c);
-    }
+    // Pass 1: strip ANSI escapes via the single shared, hardened stripper
+    // (issue #2484) — one ANSI/CSI/OSC implementation for the whole crate
+    // instead of this formerly copy-pasted CSI-only loop.
+    let stripped = crate::recipe_output::strip_ansi(msg);
     // Pass 2: collapse whitespace.
     stripped.split_whitespace().collect::<Vec<_>>().join(" ")
 }

--- a/src/stewardship/recipe_merge_judge.rs
+++ b/src/stewardship/recipe_merge_judge.rs
@@ -134,6 +134,7 @@ impl MergeJudge for RecipeMergeJudge {
         let (judgment, outcome) = parse_merge_outcome(&base_raw);
         if !outcome.is_parse_failure() {
             record_verdict_parse_metric(BrainPhase::MergeJudge, &pr_label, outcome, 1);
+            crate::recipe_output::record_parse_outcome("merge_judge", true);
             return Ok(judgment);
         }
 
@@ -152,6 +153,10 @@ impl MergeJudge for RecipeMergeJudge {
             |o| verdict_label(&o.verdict).to_string(),
         );
         record_verdict_parse_metric(BrainPhase::MergeJudge, &pr_label, final_outcome, attempts);
+        crate::recipe_output::record_parse_outcome(
+            "merge_judge",
+            !final_outcome.is_parse_failure(),
+        );
         Ok(final_judgment)
     }
 
@@ -298,7 +303,12 @@ fn truncate(s: &str, max: usize) -> String {
 /// - "ready" (without "not" prefix) → Ready
 /// - None found → error
 pub fn parse_merge_verdict_from_text(text: &str) -> Result<JudgeOutcome, String> {
-    let trimmed = text.trim();
+    // Strip ANSI escapes + drop whole tracing-log / runner-banner lines first
+    // (shared #2484 extractor) so a noise-obscured verdict is not silently
+    // missed and a dropped log line's keyword substring (e.g. "already"
+    // containing "ready") cannot masquerade as a verdict.
+    let cleaned = crate::recipe_output::strip_recipe_noise(text);
+    let trimmed = cleaned.trim();
     if trimmed.is_empty() {
         return Err(format!("{ADAPTER_TAG}: recipe returned empty output"));
     }
@@ -327,7 +337,7 @@ pub fn parse_merge_verdict_from_text(text: &str) -> Result<JudgeOutcome, String>
     } else {
         Err(format!(
             "{ADAPTER_TAG}: no verdict keyword (ready/not_ready/unclear) found in recipe output; raw={:?}",
-            truncate(text, 200)
+            truncate(trimmed, 200)
         ))
     }
 }
@@ -433,6 +443,36 @@ mod tests {
             out.rationale.contains("Comprehensive"),
             "rationale should include full text: {}",
             out.rationale
+        );
+    }
+
+    #[test]
+    fn text_verdict_drops_ready_substring_in_noise_log_line() {
+        // #2484: "already" contains "ready"; on a raw scan the tracing-log line
+        // would falsely yield Verdict::Ready. After shared noise-stripping the
+        // log line is dropped and the remaining prose carries no verdict, so the
+        // judge correctly errors (→ fail-closed) instead of fabricating a Ready.
+        let text = "2026-06-28T08:08:58.151133Z  INFO judge: already scored pr\n\
+                    The assessment is complete but the prose is inconclusive.";
+        let err = parse_merge_verdict_from_text(text).unwrap_err();
+        assert!(err.contains("no verdict keyword"), "got: {err}");
+    }
+
+    #[test]
+    fn text_verdict_recovers_not_ready_past_ansi_log_prefix() {
+        // The verdict trails an ANSI-coloured tracing-log line. The shared
+        // extractor strips both so the real not_ready verdict is recovered and
+        // its rationale carries no log/ANSI noise.
+        let esc = '\u{1b}';
+        let text = format!(
+            "{esc}[2m2026-06-28T08:08:58.151133Z{esc}[0m  INFO judge: scoring\n\
+             Verdict: not_ready — missing test plan."
+        );
+        let out = parse_merge_verdict_from_text(&text).unwrap();
+        assert_eq!(out.verdict, Verdict::NotReady);
+        assert!(
+            !out.rationale.contains("INFO judge"),
+            "log line must be dropped"
         );
     }
 }

--- a/tests/gadugi/recipe-output-extractor.sh
+++ b/tests/gadugi/recipe-output-extractor.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# QA driver for issue #2484 — shared robust JSON/verdict extractor.
+#
+# Exercises the hermetic unit suite that proves a raw, ANSI/log-noised
+# recipe-runner-rs span fails to parse while the shared `recipe_output`
+# extractor strips the noise and recovers the payload, across both the
+# shared module and the adopted distill path.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+# The `recipe_output` filter also matches the distill `parse_recipe_output_*`
+# tests (substring), so this one invocation covers the shared module and its
+# adoption in the distill path.
+TEST_OUTPUT="$(
+  cargo test --lib recipe_output -- --test-threads=1 2>&1
+)"
+
+printf '%s\n' "$TEST_OUTPUT"
+
+# Shared-module recovery proofs.
+printf '%s\n' "$TEST_OUTPUT" | grep -F "extract_json_payload_recovers_from_ansi_log_noise ... ok" >/dev/null
+printf '%s\n' "$TEST_OUTPUT" | grep -F "strip_recipe_noise_drops_tracing_log_lines ... ok" >/dev/null
+printf '%s\n' "$TEST_OUTPUT" | grep -F "strip_recipe_noise_drops_runner_banner_lines ... ok" >/dev/null
+printf '%s\n' "$TEST_OUTPUT" | grep -F "extract_verdict_ignores_keyword_substring_inside_dropped_log_line ... ok" >/dev/null
+
+# Distill-path adoption recovery proofs.
+printf '%s\n' "$TEST_OUTPUT" | grep -F "parse_recipe_output_recovers_from_ansi_log_noise ... ok" >/dev/null
+printf '%s\n' "$TEST_OUTPUT" | grep -F "parse_recipe_output_recovers_from_runner_banner ... ok" >/dev/null
+
+# Whole filtered suite passed with zero failures.
+printf '%s\n' "$TEST_OUTPUT" | grep -E "test result: ok\. [0-9]+ passed; 0 failed" >/dev/null
+
+echo "recipe-output-extractor: all #2484 extractor recovery scenarios passed"

--- a/tests/gadugi/recipe-output-extractor.yaml
+++ b/tests/gadugi/recipe-output-extractor.yaml
@@ -1,0 +1,54 @@
+name: "Recipe-Output Extractor Hardening (#2484)"
+description: "Outside-in coverage for the shared recipe-runner-rs stdout extractor: ANSI/log/banner stripping plus last-balanced JSON and verdict-keyword recovery, exercised through the hermetic unit suite for the shared module and its distill-path adoption."
+version: "1.0.0"
+
+config:
+  timeout: 360000
+  retries: 1
+  parallel: false
+
+environment:
+  requires: []
+
+agents:
+  - name: "cli-agent"
+    type: "cli"
+    config:
+      workingDirectory: "."
+      defaultTimeout: 360000
+      executionMode: "spawn"
+      captureOutput: true
+      ioConfig:
+        encoding: "utf8"
+        handleInteractivePrompts: false
+      logConfig:
+        logCommands: true
+        logOutput: true
+        logLevel: "info"
+
+steps:
+  - name: "Shared extractor recovers JSON facts and verdicts from noisy stdout"
+    agent: "cli-agent"
+    action: "execute_command"
+    params:
+      command: "tests/gadugi/recipe-output-extractor.sh"
+    timeout: 360000
+
+assertions: []
+
+cleanup:
+  - name: "CLI agent cleanup"
+    agent: "cli-agent"
+    action: "cleanup"
+
+metadata:
+  tags:
+    - "cli"
+    - "behavior"
+    - "simard"
+    - "recipe-output"
+    - "brain-reliability"
+    - "memory-distill"
+  priority: "high"
+  author: "copilot"
+  test_type: "outside-in"


### PR DESCRIPTION
## Problem (root cause)

`recipe-runner-rs` stdout — and the `step_results[].output` string inside its
`--output-format json` envelope — is routinely contaminated with three kinds of
non-payload noise that broke the formerly bespoke per-phase extractors:

1. **ANSI SGR/CSI/OSC colour codes** from `tracing`/`env_logger` (e.g. a leading
   `\x1b[2m` "dim" whose raw `ESC`/`0x1b` byte is invalid inside a JSON
   document, so `serde_json` rejects the span).
2. **Timestamped tracing-log lines** interleaved with the agent answer.
3. The runner's **text-mode summary banner** (`Recipe: … SUCCESS`, `Steps: …`,
   `[completed] …`).

Each recipe-backed phase scanned that raw text with its own fragile extractor
and fell back to a permissive default on a miss — the exact OODA failures
observed in episodes:

- distill: `'distill' step output did not contain a parseable { "facts": [...] } object`
  → the whole 20-episode batch deferred a cycle (live evidence at t=8451).
- merge-judge / progress-checker: `no verdict keyword … found` → fail-closed / fail-open default.
- engineer-lifecycle / decide / orient: banner/noise misparse → `continue_skipping` / `advance_goal` / floor.

These are **one root cause (noisy stdout) hitting N bespoke extractors**, and the
codebase was already accreting duplicate ANSI strippers.

## Change

One shared, hardened `src/recipe_output/` module is now the **only**
ANSI/log/banner-stripping path:

| Function | Behaviour |
|---|---|
| `strip_ansi(&str) -> Cow` | Single ANSI (CSI/OSC/two-char) stripper. `Cow::Borrowed` on the clean path. |
| `strip_recipe_noise(&str) -> Cow` | `strip_ansi` + drop ISO-8601 tracing lines and runner-banner lines. `Cow::Borrowed` on the clean path. |
| `balanced_objects` / `last_balanced_object` / `extract_json_payload` | String-literal-aware balanced `{…}` scan. JSON extraction is **dual-pass** (line-dropped **and** ANSI-only) so the payload survives both an interleaved log line inside a pretty body and a same-line log prefix. |
| `extract_verdict(raw, keywords)` | Precedence keyword scan over cleaned text. |
| `record_parse_outcome(phase, success)` | Emits `recipe_parse_{success,failure}_total{phase}` to `metrics.jsonl`. |

Adopted by **distill** (`memory_consolidation/distillation.rs`, dual-pass
`scan_for_facts_object`), **merge-judge** (`stewardship/recipe_merge_judge.rs`),
**progress-checker** (`goal_curation/recipe_progress_checker.rs`), and the three
**OODA brain** phases — decide / orient / engineer-lifecycle
(`ooda_brain/recipe_brain.rs`). The distill-private ANSI stripper and the two
duplicate strippers (`meeting_backend::sanitize`, `stewardship::dedup`) now
delegate to `strip_ansi`.

`record_parse_outcome` fires **only** at the subprocess call sites (never inside
a pure parse fn, so unit tests write no metrics), complementary to the brain
phases' existing `brain_verdict_parsed_total{phase,outcome}` (#2429): that counter
owns the brain-phase dashboard; the new family adds the memory/distill and
progress-checker phases and gives numerator + denominator per phase.

**Scope guard:** no change to any phase's decision semantics on clean output —
`strip_*` return `Cow::Borrowed` / byte-identical text, so only previously
defaulted noisy cases now recover.

### Rebased onto current `main`

This PR was 86 commits behind `main` (the brain phases independently gained the
JSON-envelope transport + escalation ladder + `brain_verdict_parsed_total`
since the branch was cut). It has been **rebased onto current `main`** and the
shared extractor re-wired onto main's evolved parsers. This also resolves the
prior `cargo-audit` failure (it came from the stale 86-commit-old `Cargo.lock`
which carried `lopdf`/`quinn-proto`; current `main`'s lockfile is clean) and the
`full_goal_lifecycle_crud` CI failure (a stale-base artifact).

---

## Merge-ready evidence

### 1. qa-team scenario (gadugi)

`tests/gadugi/recipe-output-extractor.yaml` (+ driver `recipe-output-extractor.sh`).

- `gadugi-test validate -f tests/gadugi/recipe-output-extractor.yaml --strict`
  → `✓ Scenario "Recipe-Output Extractor Hardening (#2484)" is valid` / `✓ All 1 file(s) are valid`.
- `gadugi-test run -d <dir>` → `✓ Passed: 1  ✗ Failed: 0  - Total: 1  ✓ All tests passed!`
  (driver runs the hermetic extractor suite, asserts the shared-module recovery
  test names **and** the distill-path `parse_recipe_output_recovers_from_ansi_log_noise`
  / `parse_recipe_output_recovers_from_runner_banner` names + `test result: ok`;
  command exit 0, ~42s).

### 2. Docs / changed surfaces

- Updated `docs/reference/text-parsing-wire-formats.md` (the normative
  parsing-wire-format reference): new **Protocol 0: Shared noise pre-stripping**
  section, the `recipe_parse_*_total{phase}` counters, pre-strip notes added to
  Protocol 1 & 2, and the refreshed test inventory.
- **Changed surfaces:** all code surfaces are internal (library parse functions +
  a new internal `recipe_output` module). The only externally observable
  additions are two new `metrics.jsonl` counter names, documented above. No
  CLI/HTTP/API surface changed.

### 3. Quality-audit (≥3 SEEK→VALIDATE→FIX cycles, clean final)

- **Cycle 1 (clean-path / decision-semantics):** verified `strip_ansi` /
  `strip_recipe_noise` return `Cow::Borrowed` on clean input (dedicated tests),
  so every existing decide/orient/lifecycle/merge/progress/distill test that
  feeds clean text passes byte-for-byte unchanged. FIX: the decide banner test
  reclassified a single-line `Recipe:` banner from `DefaultMalformed` to
  `DefaultEmpty` (the banner is now correctly recognised as pure noise and
  stripped); updated to use the realistic multi-line banner whose
  `Recipe '<name>': SUCCESS` summary line survives → still `DefaultMalformed`,
  and added an explicit pure-noise→`DefaultEmpty` test. Both outcomes are
  parse-failures yielding the same decision, so semantics are unchanged.
- **Cycle 2 (payload-drop safety):** confirmed the distill `scan_for_facts_object`
  dual-pass recovers (a) a payload after an ANSI/log line (line-dropped view)
  and (b) a payload on the SAME physical line as a log prefix (ANSI-only view),
  preserving the last-non-empty preference across both views. New regression
  tests `parse_recipe_output_recovers_from_ansi_log_noise` and
  `parse_recipe_output_recovers_from_runner_banner` (using valid distill
  concepts) assert recovery; the raw span is pinned unparseable.
- **Cycle 3 (verdict false-positives + delegation):** verified the merge-judge
  regression pin (`production_banner_has_no_verdict_keyword`) still holds, added
  `text_verdict_drops_ready_substring_in_noise_log_line` (an `already`→`ready`
  substring in a dropped log line no longer fabricates a `Ready` verdict) and a
  progress-checker noise-recovery test; verified the `sanitize`/`dedup`
  delegations keep `normalize_strips_ansi_and_collapses_whitespace` green.
  Independent `code-review` agent pass: no significant issues. Clean final cycle.

### 4. CI

Local equivalents of every CI gate pass:

- `cargo fmt --all -- --check` → clean.
- `cargo clippy --all-targets --all-features --locked -- -D warnings` → clean
  (both the pre-commit `--release` gate and the full pre-push gate passed).
- `cargo audit` → exit 0 (clean lockfile after rebase).
- Touched-module unit tests green: `recipe_output` (incl. the 2 distill recovery
  names) 38, `ooda_brain::recipe_brain` 169, `recipe_merge_judge` 31,
  `recipe_progress_checker` 13, `distillation` 72, `stewardship` 22.
- Full `cargo test --lib --all-features --locked --no-fail-fast` → `6382 passed`.
  The single non-passing test (`ooda_loop::decide::decide_respects_max_concurrent_actions`)
  is a **pre-existing, host-environment** failure: it fails identically on clean
  `main` in this build host (the host's real `~/.simard/prompt_assets/…` /
  live state shadows the temp fixtures) and is untouched by this diff; it passes
  in CI's clean runner (it did not fail in the prior CI run of this PR).

### 6. Focused diff

12 files: the new `recipe_output` module (2), the six adopting parsers, the two
delegated strippers, one reference doc, and the qa scenario pair. No unrelated
edits.

Closes #2484
