### PR TITLE
test(distill): pin issue #2496 Copilot launch-log preamble regression

### DIFF
--- a/src/memory_consolidation/distillation.rs
+++ b/src/memory_consolidation/distillation.rs
@@ -1854,4 +1854,67 @@ mod unit_tests {
         assert_eq!(out.facts[0].content, "strip ansi before the facts scan");
         assert_eq!(out.facts[0].source_episode_id, "epi_42");
     }
+
+    #[test]
+    fn parse_recipe_output_full_recovers_facts_from_copilot_launch_log_preamble() {
+        // Regression for issue #2496 (episode t=9271 live failure).
+        //
+        // The existing ANSI/banner tests above already cover dimmed
+        // `simard::distill` / `thinking` tracing prefixes and the
+        // recipe-runner text summary banner. This pins the distinct
+        // **Copilot CLI launch** noise shape the issue captured, which no
+        // other test exercises as a unit:
+        //
+        //   1. an ANSI-coloured `launching copilot binary=copilot` line,
+        //   2. an `\u{2139} NODE_OPTIONS=--max-old-space-size=…` line, and
+        //   3. a leading, ANSI-wrapped JSON *log record*
+        //      (`{"level":"info",…}`) — a complete brace-balanced object that
+        //      precedes the real facts object.
+        //
+        // Element 3 is the adversarial part: a first-object brace scan would
+        // lock onto the `{"level":…}` log record (which has no `facts` field
+        // and so fails the envelope parse) and never reach the trailing facts
+        // object. The current parser strips the ANSI/log noise and prefers the
+        // LAST non-empty facts object, so the buried payload is recovered.
+        // This is fed through the production Tier-1 `--output-format json`
+        // envelope path (`parse_recipe_output_full` -> `into_distill_output`
+        // -> `extract_step_output` -> `scan_for_facts_object`), which is where
+        // the `\`distill\` step output did not contain a parseable …` error in
+        // the issue originated.
+        let esc = '\u{1b}';
+        let step_output = format!(
+            "{esc}[2m2026-06-29T12:26:24.512Z{esc}[0m {esc}[32m INFO{esc}[0m launching copilot binary=copilot\n\
+             \u{2139} {esc}[2mNODE_OPTIONS=--max-old-space-size=8192{esc}[0m\n\
+             {esc}[36m{{\"level\":\"info\",\"msg\":\"session started\",\"cwd\":\"/repo\"}}{esc}[0m\n\
+             {{\"facts\":[{{\"concept\":\"bug-pattern\",\
+             \"content\":\"distill parser must tolerate ANSI + launch-log preamble\",\
+             \"source_episode_id\":\"epi_9271\"}}]}}\n"
+        );
+        // The raw step-output span carries ESC bytes and a leading non-facts
+        // object, so it must NOT parse as-is — the silent-drop failure mode.
+        assert!(
+            serde_json::from_str::<RecipeEnvelope>(step_output.trim()).is_err(),
+            "raw launch-log-noised step output must be unparseable as a facts envelope"
+        );
+        let envelope = serde_json::json!({
+            "recipe_name": "distill-episodes",
+            "success": true,
+            "step_results": [{
+                "step_id": "distill",
+                "status": "completed",
+                "output": step_output,
+                "error": ""
+            }]
+        })
+        .to_string();
+        let out = parse_recipe_output_full(&envelope)
+            .expect("issue #2496 launch-log-preamble payload must parse");
+        assert_eq!(out.facts.len(), 1, "exactly one fact recovered");
+        assert_eq!(out.facts[0].concept, "bug-pattern");
+        assert_eq!(
+            out.facts[0].content,
+            "distill parser must tolerate ANSI + launch-log preamble"
+        );
+        assert_eq!(out.facts[0].source_episode_id, "epi_9271");
+    }
 }

--- a/tests/gadugi/distill-parser-copilot-launch-log.yaml
+++ b/tests/gadugi/distill-parser-copilot-launch-log.yaml
@@ -1,0 +1,84 @@
+name: "Distill Parser Tolerates Copilot Launch-Log Preamble"
+description: >
+  Outside-in regression gate for issue #2496 (episode t=9271 live failure).
+  The episode->fact distillation parser must recover the { "facts": [...] }
+  object from the Tier-1 recipe-runner `--output-format json` envelope even
+  when the distill step output is the noisy Copilot CLI launch preamble:
+  an ANSI-coloured `launching copilot` line, a NODE_OPTIONS line, and a
+  leading ANSI-wrapped JSON log record ({"level":"info",...}) ahead of the
+  real facts object. The current parser (issues #2401/#2461/#2484) already
+  strips ANSI/log noise and prefers the last non-empty facts object; this
+  scenario pins the captured launch-log shape end-to-end so it cannot
+  regress.
+version: "1.0.0"
+
+config:
+  timeout: 600000
+  retries: 1
+  parallel: false
+
+environment:
+  requires: []
+
+agents:
+  - name: "test-agent"
+    type: "cli"
+    config:
+      workingDirectory: "."
+      defaultTimeout: 600000
+      executionMode: "spawn"
+      captureOutput: true
+      ioConfig:
+        encoding: "utf8"
+        handleInteractivePrompts: false
+      logConfig:
+        logCommands: true
+        logOutput: true
+        logLevel: "info"
+
+steps:
+  - name: "Distill parser recovers facts from Copilot launch-log preamble (#2496)"
+    agent: "test-agent"
+    action: "execute_command"
+    params:
+      command: >
+        cargo test --lib
+        parse_recipe_output_full_recovers_facts_from_copilot_launch_log_preamble
+        -- --nocapture
+    timeout: 600000
+    expect:
+      exitCode: 0
+      outputContains:
+        - "parse_recipe_output_full_recovers_facts_from_copilot_launch_log_preamble ... ok"
+        - "test result: ok"
+
+  - name: "Full distillation parser contract still green (no regression)"
+    agent: "test-agent"
+    action: "execute_command"
+    params:
+      command: >
+        cargo test --lib memory_consolidation::distillation::unit_tests
+        -- --nocapture
+    timeout: 600000
+    expect:
+      exitCode: 0
+      outputContains:
+        - "test result: ok"
+
+assertions: []
+
+cleanup:
+  - name: "CLI agent cleanup"
+    agent: "test-agent"
+    action: "cleanup"
+
+metadata:
+  tags:
+    - "cli"
+    - "memory"
+    - "distillation"
+    - "regression"
+    - "issue-2496"
+  priority: "high"
+  author: "copilot"
+  test_type: "outside-in"


### PR DESCRIPTION
## Summary

**Test-only regression pin for issue #2496. No production code change.**

Issue #2496 reports that the episode→fact distillation parser drops facts
when the Copilot CLI prepends ANSI-coloured launch/INFO log lines
(`launching copilot`, `NODE_OPTIONS=…`, ISO-timestamp `\x1b[2m…` escapes)
ahead of the `{ "facts": [...] }` object (live failure at episode t=9271).

Closes #2496

## Investigation finding (important)

The issue's cited line numbers (`scan_for_facts_object` ~L740,
`into_distill_output` ~L800) predate current `main`, where
`distillation.rs` is now ~1857 lines. **On current `main` the parser
already tolerates this payload.** The relevant hardening landed via
#2401 / #2461 / #2484:

- `scan_for_facts_object` runs two cleaned views —
  `recipe_output::strip_recipe_noise` (strips ANSI **and** drops
  tracing/log + runner-banner lines) and `recipe_output::strip_ansi`
  (line-preserving) — before scanning.
- `balanced_object_spans` is string-aware (ignores braces inside JSON
  string literals).
- `scan_cleaned_for_facts` prefers the **last non-empty** balanced facts
  object, so a leading banner/log object no longer shadows the real
  payload.

I verified empirically: feeding the **exact** #2496 live payload (ANSI
`\x1b[2m<timestamp>` + `launching copilot` + `NODE_OPTIONS` + a leading
ANSI-wrapped JSON log record `{"level":"info",…}` + the facts object)
through the production Tier-1 `--output-format json` envelope path
(`parse_recipe_output_full`) **parses successfully and recovers the
fact**. Shipping another parser change would be redundant duplication, so
this PR makes **no production change**.

## What this PR adds

The issue's "Done-when" explicitly requires *"a regression test using a
captured real failing payload."* `main`'s existing ANSI tests cover
dimmed `simard::distill` / `thinking` tracing prefixes and the
recipe-runner summary banner, but **none** exercise the distinct
**Copilot CLI launch** noise shape: a `launching copilot` line, a
`NODE_OPTIONS` line, and a leading brace-balanced JSON **log record**
ahead of the facts object (the most adversarial element). This PR pins
that gap:

- `parse_recipe_output_full_recovers_facts_from_copilot_launch_log_preamble`
  — feeds the captured payload through the Tier-1 envelope path where the
  issue's `` `distill` step output did not contain a parseable … `` error
  originated. It first asserts the raw span is **unparseable**, then
  asserts the buried fact (`bug-pattern`, `epi_9271`) is recovered — so
  the test proves recovery, not a trivially-clean input.
- `tests/gadugi/distill-parser-copilot-launch-log.yaml` — outside-in QA
  scenario running the test end-to-end.

## Evidence

### 1. qa-team scenarios (written + validated + run)
- Added `tests/gadugi/distill-parser-copilot-launch-log.yaml`.
- `gadugi-test validate -f … --strict` →
  `✓ Scenario "Distill Parser Tolerates Copilot Launch-Log Preamble" is valid` (1 valid, 0 invalid).
- `gadugi-test run -d tests/gadugi -s distill-parser-copilot-launch-log` →
  `✓ All tests passed!  Passed: 1, Failed: 0` (both steps green: the
  regression test + the full 31-test `distillation::unit_tests` contract).

### 2. Docs / changed surfaces
- **Internal-only, test-only.** No production code, CLI, API, or config
  changes. Changed surfaces: `src/memory_consolidation/distillation.rs`
  (one inline `#[cfg(test)]` regression test) and one internal QA
  scenario. No user-facing docs require updates.

### 3. Quality-audit (3 SEEK→VALIDATE→FIX cycles, clean final)
Three independent adversarial review passes, all clean (zero critical/high; zero medium correctness/security):
- **Cycle 1 (code-review):** verified production code is byte-for-byte unchanged; the test is non-vacuous (asserts the raw span is unparseable, then asserts recovery); guard is sufficient; coverage genuinely distinct from existing ANSI/banner tests; gadugi scenario correct. **No findings.**
- **Cycle 2 (rubber-duck, logic/design):** confirmed the test routes through the same path that produced the live error (`parse_recipe_output_full → into_distill_output → extract_step_output → scan_for_facts_object`), not an easier fallback; assertions strong enough that an empty/wrong recovery would fail; closing #2496 with a test-only PR is logically sound. **No blocking or non-blocking issues.**
- **Cycle 3 (code-review, merge-readiness):** scope clean (2 files, test-only, fully inside `#[cfg(test)]`); no leftover temp test; exactly one #2496 test and one scenario; YAML `outputContains` match real cargo output; commit claims truthful. **Verdict: MERGE-READY.**


### 4. CI green
- Local pre-flight (mirrors `.github/workflows/verify.yml`):
  - `cargo fmt --all -- --check` → clean.
  - `cargo clippy --all-targets --all-features --locked -- -D warnings` → clean.
  - `cargo test --lib memory_consolidation::distillation` → `68 passed; 0 failed`.
- Full CI run: tracked on this PR.

### 6. Focused diff
- `src/memory_consolidation/distillation.rs`: **+63 lines, all inside
  `#[cfg(test)] mod unit_tests`** (verified hunk `@@ … mod unit_tests`).
- `tests/gadugi/distill-parser-copilot-launch-log.yaml`: new QA scenario.
- No unrelated edits; no production code touched.
