### PR TITLE
fix(memory): harden distill facts-JSON parser against Copilot launch/ANSI log preamble (#2496)

### DIFF
--- a/src/memory_consolidation/distillation.rs
+++ b/src/memory_consolidation/distillation.rs
@@ -361,44 +361,157 @@ fn truncate(s: &str, max: usize) -> String {
 ///
 /// The recipe is expected to emit a JSON object of shape
 /// `{ "facts": [ { "concept": "...", "content": "...",
-/// "source_episode_id": "..." } ] }`. Because the underlying LLM may
-/// wrap the JSON in prose, we scan for the first balanced `{...}`
-/// substring containing a `"facts"` key and parse that.
+/// "source_episode_id": "..." } ] }`. Two real-world sources of noise
+/// sit in front of (or around) that object and must be tolerated:
+///
+/// 1. The underlying LLM may wrap the JSON in prose.
+/// 2. The Copilot CLI prepends ANSI-colored launch / INFO log lines
+///    (e.g. `launching copilot`, `NODE_OPTIONS=…`, and ISO-timestamp
+///    lines wrapped in `\x1b[2m…\x1b[0m` SGR escapes) ahead of the
+///    JSON — see issue #2496.
+///
+/// To recover the payload we first strip ANSI/VT escape sequences, then
+/// scan for the first balanced top-level `{...}` substring that
+/// deserializes into the `{ "facts": [...] }` envelope. The scan
+/// re-anchors at every `{` so brace-bearing log preamble (a stray log
+/// line that happens to contain its own `{...}`) does not defeat it,
+/// and it is string-literal aware so braces inside JSON string values
+/// do not throw off the depth count.
 ///
 /// Returns `Err` when no parseable object is found — the caller
 /// treats `Err` as the retry-safe "no markers set" path.
 fn parse_recipe_output(raw: &str) -> SimardResult<Vec<DistilledFact>> {
-    let trimmed = raw.trim();
-    // Fast path — recipe stdout IS the JSON object.
+    // Strip ANSI/VT escape sequences first so leading colored log noise
+    // (Copilot CLI launch banner, dim-styled timestamps) cannot wedge
+    // the brace scan.
+    let cleaned = strip_ansi_escapes(raw);
+    let trimmed = cleaned.trim();
+
+    // Fast path — the (cleaned) stdout IS the JSON object.
     if let Ok(parsed) = serde_json::from_str::<RecipeEnvelope>(trimmed) {
         return Ok(parsed.into_facts());
     }
-    // Slow path — find the first balanced `{...}` substring and try
-    // each one until something parses. Cheap because the output is
-    // small.
-    if let Some(start) = trimmed.find('{') {
-        let mut depth = 0i32;
-        let bytes = trimmed.as_bytes();
-        for i in start..bytes.len() {
-            match bytes[i] {
-                b'{' => depth += 1,
-                b'}' => {
-                    depth -= 1;
-                    if depth == 0
-                        && let Ok(parsed) =
-                            serde_json::from_str::<RecipeEnvelope>(&trimmed[start..=i])
-                    {
-                        return Ok(parsed.into_facts());
-                    }
-                }
-                _ => {}
-            }
-        }
+
+    // Slow path — tolerate arbitrary leading/trailing log noise by
+    // scanning for the first balanced top-level object that matches the
+    // envelope contract.
+    if let Some(parsed) = scan_for_facts_object(trimmed) {
+        return Ok(parsed.into_facts());
     }
+
     Err(SimardError::BridgeError(format!(
         "distill: recipe output did not contain a parseable {{ \"facts\": [...] }} object; raw: {}",
         truncate(raw, 200)
     )))
+}
+
+/// Remove ANSI/VT100 escape sequences from `input`.
+///
+/// Handles the CSI form used for color/SGR codes (`ESC [ … final`,
+/// where `final` is a byte in `0x40..=0x7e`) — which is what the
+/// Copilot CLI emits around its launch banner and timestamps — plus
+/// any other `ESC`-introduced sequence by dropping the `ESC` and the
+/// byte that follows it. Operates byte-wise: ANSI escape bytes are all
+/// ASCII (`ESC` = `0x1b`, finals < `0x80`) so multibyte UTF-8 content
+/// (whose bytes are all `>= 0x80`) is copied through untouched.
+fn strip_ansi_escapes(input: &str) -> String {
+    const ESC: u8 = 0x1b;
+    let bytes = input.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == ESC {
+            // CSI sequence: ESC [ <params/intermediates> <final 0x40..=0x7e>.
+            if i + 1 < bytes.len() && bytes[i + 1] == b'[' {
+                i += 2;
+                while i < bytes.len() && !(0x40..=0x7e).contains(&bytes[i]) {
+                    i += 1;
+                }
+                if i < bytes.len() {
+                    i += 1; // consume the final byte
+                }
+                continue;
+            }
+            // Any other escape (e.g. a two-byte C1 form like `ESC M`):
+            // drop the `ESC` and, when present, a single following ASCII
+            // byte. Never consume a byte `>= 0x80` — that would split a
+            // multibyte UTF-8 character (no valid escape uses one).
+            i += 1;
+            if i < bytes.len() && bytes[i] < 0x80 {
+                i += 1;
+            }
+            continue;
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+/// Scan `text` for the first balanced top-level `{...}` substring that
+/// deserializes into a [`RecipeEnvelope`] (i.e. carries a `facts` key).
+///
+/// Re-anchors at every `{` so non-envelope objects in the preamble are
+/// skipped, and tracks JSON string state so braces inside string values
+/// are ignored when matching.
+fn scan_for_facts_object(text: &str) -> Option<RecipeEnvelope> {
+    let bytes = text.as_bytes();
+    let mut search_from = 0;
+    while let Some(rel) = text[search_from..].find('{') {
+        let start = search_from + rel;
+        match matching_brace_end(bytes, start) {
+            Some(end) => {
+                if let Ok(parsed) = serde_json::from_str::<RecipeEnvelope>(&text[start..=end]) {
+                    return Some(parsed);
+                }
+                // Balanced but not the envelope we want (e.g. a JSON log
+                // line). Resume just past this object rather than at
+                // `start + 1` so its interior is not re-scanned — keeps
+                // the scan linear over a run of balanced log objects and
+                // matches the "first balanced top-level object" contract.
+                search_from = end + 1;
+            }
+            // Unbalanced from this `{` (e.g. a stray brace in a log
+            // line). Advance to the next `{` and try again rather than
+            // giving up — a self-contained object may still follow.
+            None => search_from = start + 1,
+        }
+    }
+    None
+}
+
+/// Return the index of the `}` that closes the `{` at `start`, or
+/// `None` if the braces never balance. String-literal aware: `{`/`}`
+/// inside a double-quoted JSON string (honoring `\` escapes) do not
+/// affect the depth count.
+fn matching_brace_end(bytes: &[u8], start: usize) -> Option<usize> {
+    let mut depth = 0i32;
+    let mut in_string = false;
+    let mut escaped = false;
+    for (i, &b) in bytes.iter().enumerate().skip(start) {
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if b == b'\\' {
+                escaped = true;
+            } else if b == b'"' {
+                in_string = false;
+            }
+            continue;
+        }
+        match b {
+            b'"' => in_string = true,
+            b'{' => depth += 1,
+            b'}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(i);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
 }
 
 #[derive(serde::Deserialize)]
@@ -504,5 +617,147 @@ mod unit_tests {
     fn parse_recipe_output_errors_when_no_object() {
         let raw = "no json here at all";
         assert!(parse_recipe_output(raw).is_err());
+    }
+
+    // ── issue #2496 regression: tolerate Copilot CLI launch/ANSI preamble ──
+
+    #[test]
+    fn parse_recipe_output_tolerates_ansi_copilot_preamble() {
+        // Captured-shape payload from the live failure (episodes
+        // t=9269/t=9271): the Copilot CLI prepends an ANSI-colored launch
+        // banner plus `NODE_OPTIONS=…` and dim-styled ISO-timestamp INFO
+        // lines ahead of the JSON. The `\x1b[…m` SGR escapes and the log
+        // preamble must be stripped/skipped so the facts object parses.
+        let raw = concat!(
+            "\u{1b}[1mlaunching copilot\u{1b}[0m\n",
+            "\u{1b}[2mNODE_OPTIONS=--max-old-space-size=4096\u{1b}[0m\n",
+            "\u{1b}[2m2026-06-29T12:26:24.123Z\u{1b}[0m \u{1b}[36mINFO\u{1b}[0m starting distill step\n",
+            "{\"facts\":[{\"concept\":\"bug-pattern\",",
+            "\"content\":\"strip ANSI before parsing distill output\",",
+            "\"source_episode_id\":\"epi_9271\"}]}\n",
+        );
+        let facts = parse_recipe_output(raw).expect("ANSI/log preamble must not defeat the parser");
+        assert_eq!(facts.len(), 1);
+        assert_eq!(facts[0].concept, "bug-pattern");
+        assert_eq!(facts[0].source_episode_id, "epi_9271");
+    }
+
+    #[test]
+    fn parse_recipe_output_skips_non_facts_json_log_line() {
+        // A structured log line (its own balanced JSON object with no
+        // `facts` key) precedes the real payload. The scan must re-anchor
+        // past it and land on the envelope rather than failing on the
+        // first `{...}` it encounters.
+        let raw = concat!(
+            "\u{1b}[2m{\"level\":\"info\",\"msg\":\"launching copilot\"}\u{1b}[0m\n",
+            "{\"facts\":[{\"concept\":\"pr-pattern\",",
+            "\"content\":\"re-anchor brace scan\",\"source_episode_id\":\"epi_9269\"}]}",
+        );
+        let facts = parse_recipe_output(raw).expect("must skip the non-facts log object");
+        assert_eq!(facts.len(), 1);
+        assert_eq!(facts[0].concept, "pr-pattern");
+        assert_eq!(facts[0].source_episode_id, "epi_9269");
+    }
+
+    #[test]
+    fn parse_recipe_output_handles_braces_inside_string_values() {
+        // `content` legitimately contains `{` and `}`; the string-literal
+        // aware brace matcher must not let those throw off depth tracking
+        // and truncate the object early.
+        let raw = concat!(
+            "\u{1b}[2mlaunching copilot\u{1b}[0m\n",
+            "{\"facts\":[{\"concept\":\"lesson-learned\",",
+            "\"content\":\"prefer HashMap<K, {V}> over a raw { Vec }\",",
+            "\"source_episode_id\":\"epi_1\"}]}",
+        );
+        let facts =
+            parse_recipe_output(raw).expect("braces inside strings must not break matching");
+        assert_eq!(facts.len(), 1);
+        assert_eq!(facts[0].concept, "lesson-learned");
+        assert!(facts[0].content.contains("{V}"));
+    }
+
+    #[test]
+    fn parse_recipe_output_clean_input_is_unchanged() {
+        // Behaviour for already-clean (no-ANSI, no-preamble) output is
+        // unchanged: a pretty-printed multi-fact envelope still parses.
+        let raw = r#"{
+            "facts": [
+                {"concept":"pr-pattern","content":"a","source_episode_id":"epi_1"},
+                {"concept":"bug-pattern","content":"b","source_episode_id":"epi_2"}
+            ]
+        }"#;
+        let facts = parse_recipe_output(raw).unwrap();
+        assert_eq!(facts.len(), 2);
+        assert_eq!(facts[0].concept, "pr-pattern");
+        assert_eq!(facts[1].concept, "bug-pattern");
+    }
+
+    #[test]
+    fn parse_recipe_output_skips_multiple_leading_json_log_objects() {
+        // Several balanced JSON log objects precede the envelope. The
+        // scan must walk past each (resuming past its close) and land on
+        // the first top-level object that carries a `facts` key.
+        let raw = concat!(
+            "\u{1b}[2m{\"ts\":\"t1\",\"msg\":\"launching copilot\"}\u{1b}[0m\n",
+            "{\"ts\":\"t2\",\"msg\":\"NODE_OPTIONS set\"}\n",
+            "{\"ts\":\"t3\",\"level\":\"info\",\"msg\":\"distill step start\"}\n",
+            "{\"facts\":[{\"concept\":\"bug-pattern\",",
+            "\"content\":\"walk past leading log objects\",",
+            "\"source_episode_id\":\"epi_9271\"}]}",
+        );
+        let facts =
+            parse_recipe_output(raw).expect("must skip leading log objects and find the envelope");
+        assert_eq!(facts.len(), 1);
+        assert_eq!(facts[0].concept, "bug-pattern");
+        assert_eq!(facts[0].source_episode_id, "epi_9271");
+    }
+
+    #[test]
+    fn parse_recipe_output_recovers_after_unbalanced_brace_in_log_line() {
+        // A log line containing a stray, unclosed `{` precedes the JSON.
+        // The scan must re-anchor past the dangling brace and still
+        // recover the envelope on the following line.
+        let raw = concat!(
+            "INFO loading config { from disk\n",
+            "{\"facts\":[{\"concept\":\"lesson-learned\",",
+            "\"content\":\"re-anchor past dangling brace\",",
+            "\"source_episode_id\":\"epi_1\"}]}",
+        );
+        let facts =
+            parse_recipe_output(raw).expect("dangling `{` in a log line must not defeat recovery");
+        assert_eq!(facts.len(), 1);
+        assert_eq!(facts[0].concept, "lesson-learned");
+    }
+
+    #[test]
+    fn strip_ansi_escapes_removes_sgr_and_preserves_text() {
+        let s = "\u{1b}[2mdim\u{1b}[0m plain \u{1b}[36mcyan\u{1b}[0m";
+        assert_eq!(strip_ansi_escapes(s), "dim plain cyan");
+    }
+
+    #[test]
+    fn strip_ansi_escapes_preserves_utf8_payload() {
+        // Multibyte UTF-8 bytes are all >= 0x80 and must survive the
+        // byte-wise escape stripping intact.
+        let s = "\u{1b}[2mcafé — résumé\u{1b}[0m";
+        assert_eq!(strip_ansi_escapes(s), "café — résumé");
+    }
+
+    #[test]
+    fn strip_ansi_escapes_non_csi_does_not_split_utf8() {
+        // A bare ESC immediately followed by a multibyte char must drop
+        // only the ESC, never the UTF-8 lead byte (which would corrupt
+        // the character). A two-byte C1 form (ESC + ASCII final) drops
+        // both.
+        assert_eq!(strip_ansi_escapes("a\u{1b}éb"), "aéb");
+        assert_eq!(strip_ansi_escapes("a\u{1b}Mb"), "ab");
+    }
+
+    #[test]
+    fn matching_brace_end_ignores_braces_in_strings() {
+        let s = r#"{"k":"a } b { c"}trailing"#;
+        let end = matching_brace_end(s.as_bytes(), 0).expect("must balance");
+        assert_eq!(&s[0..=end], r#"{"k":"a } b { c"}"#);
     }
 }

--- a/tests/gadugi/distill-facts-parser.sh
+++ b/tests/gadugi/distill-facts-parser.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Outside-in regression gate for issue #2496: the episode->fact
+# distillation parser must recover the `{ "facts": [...] }` payload even
+# when the Copilot CLI prepends ANSI-colored launch / INFO log lines
+# (e.g. `launching copilot`, `NODE_OPTIONS=...`, `\x1b[2m<timestamp>...`)
+# ahead of the JSON. Drives the parser unit tests and asserts the
+# preamble-tolerance cases pass.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+OUTPUT="$(
+  cargo test -p simard --lib \
+    memory_consolidation::distillation::unit_tests \
+    --no-fail-fast -- --nocapture 2>&1
+)"
+
+printf '%s\n' "$OUTPUT"
+
+# Regression cases introduced by the fix.
+printf '%s\n' "$OUTPUT" | grep -F "parse_recipe_output_tolerates_ansi_copilot_preamble ... ok" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "parse_recipe_output_skips_non_facts_json_log_line ... ok" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "parse_recipe_output_handles_braces_inside_string_values ... ok" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "strip_ansi_escapes_removes_sgr_and_preserves_text ... ok" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "matching_brace_end_ignores_braces_in_strings ... ok" >/dev/null
+
+# Pre-existing clean-input behaviour must remain green (no regression).
+printf '%s\n' "$OUTPUT" | grep -F "parse_recipe_output_accepts_plain_object ... ok" >/dev/null
+printf '%s\n' "$OUTPUT" | grep -F "parse_recipe_output_extracts_json_from_prose ... ok" >/dev/null
+
+# Whole suite must pass.
+printf '%s\n' "$OUTPUT" | grep -E "test result: ok\. [0-9]+ passed; 0 failed" >/dev/null
+
+echo "distill-facts-parser: PASS"

--- a/tests/gadugi/distill-facts-parser.yaml
+++ b/tests/gadugi/distill-facts-parser.yaml
@@ -1,0 +1,54 @@
+name: "Distill facts-JSON parser hardening (#2496)"
+description: "Outside-in regression coverage for issue #2496: the episode->fact distillation parser must recover the `{ \"facts\": [...] }` payload when the Copilot CLI prepends ANSI-colored launch/INFO log lines (launching copilot, NODE_OPTIONS=..., dim-styled timestamps) ahead of the JSON. Drives the distillation parser unit tests through a CLI harness and asserts the ANSI/preamble-tolerance cases pass alongside the pre-existing clean-input cases."
+version: "1.0.0"
+
+config:
+  timeout: 600000
+  retries: 1
+  parallel: false
+
+environment:
+  requires: []
+
+agents:
+  - name: "cli-agent"
+    type: "cli"
+    config:
+      workingDirectory: "."
+      defaultTimeout: 600000
+      executionMode: "spawn"
+      captureOutput: true
+      ioConfig:
+        encoding: "utf8"
+        handleInteractivePrompts: false
+      logConfig:
+        logCommands: true
+        logOutput: true
+        logLevel: "info"
+
+steps:
+  - name: "Parser tolerates Copilot launch/ANSI preamble"
+    agent: "cli-agent"
+    action: "execute_command"
+    params:
+      command: "tests/gadugi/distill-facts-parser.sh"
+    timeout: 600000
+
+assertions: []
+
+cleanup:
+  - name: "CLI agent cleanup"
+    agent: "cli-agent"
+    action: "cleanup"
+
+metadata:
+  tags:
+    - "cli"
+    - "memory"
+    - "distillation"
+    - "parser"
+    - "outside-in"
+  priority: "high"
+  author: "copilot"
+  test_type: "outside-in"
+  issue: "2496"


### PR DESCRIPTION
## Summary

Hardens the episode→fact distillation parser so it tolerates the ANSI-colored
launch / INFO log lines the Copilot CLI prepends ahead of the
`{ "facts": [...] }` JSON.

**Closes #2496**

### Root cause
`RecipeRunnerSubprocess::run` feeds the recipe subprocess's raw stdout to
`parse_recipe_output`. The Copilot CLI prepends a colored launch banner plus
`NODE_OPTIONS=…` / dim-styled `\x1b[2m<timestamp>…` INFO lines before the JSON,
so the strict whole-stdout `serde_json` parse (and the old single-anchor brace
scan) could not recover the payload. Every failed pass silently dropped the
distilled facts (`distill failed (non-fatal): … did not contain a parseable
{ "facts": [...] } object`), observed live at episodes t=9269/t=9271 — degrading
long-term semantic/procedural recall.

### Fix (parser-only, `src/memory_consolidation/distillation.rs`)
- **`strip_ansi_escapes()`** — byte-wise removal of ANSI/VT escape sequences.
  CSI/SGR fully handled; other ESC forms drop `ESC` + a following **ASCII** byte
  only, so multibyte UTF-8 content is never split.
- **`scan_for_facts_object()`** — re-anchoring, string-literal-aware
  balanced-brace scan that returns the first balanced **top-level** `{…}`
  deserializing into the `{ "facts": [...] }` envelope. Resumes past balanced
  non-envelope log objects (`end+1`) and re-anchors past a stray unbalanced `{`
  in a log line (`start+1`).
- **`matching_brace_end()`** — depth tracker that ignores braces inside JSON
  string values.

Behavior is **unchanged** for already-clean output. Strict envelope semantics
are preserved: a `success=false` recipe run still short-circuits upstream and is
never trusted, and the concept allowlist filter (`pr-pattern` / `bug-pattern` /
`lesson-learned`) is untouched.

---

## Merge-ready evidence

### 1. qa-team scenario (gadugi-test)
Added outside-in scenario `tests/gadugi/distill-facts-parser.yaml` (+ harness
`tests/gadugi/distill-facts-parser.sh`) driving the parser tests through a CLI
agent.

- `gadugi-test validate --file tests/gadugi/distill-facts-parser.yaml --strict`
  → `✓ Scenario "Distill facts-JSON parser hardening (#2496)" is valid`
- `gadugi-test run -s distill-facts-parser -d tests/gadugi`
  → `✓ Passed: 1  ✗ Failed: 0  ✓ All tests passed!` (exit 0)

### 2. Docs / changed surfaces
No user-facing surface changes. Changed surfaces are internal only:
- `parse_recipe_output` / `strip_ansi_escapes` / `scan_for_facts_object` /
  `matching_brace_end` — private functions in
  `src/memory_consolidation::distillation` (no public API, no CLI/TUI/dashboard
  surface). Doc-comments on the affected functions were updated in-place.

### 3. quality-audit (3 SEEK→VALIDATE→FIX cycles, ended clean)
- **Cycle 1** — self-audit found `strip_ansi_escapes` could split a multibyte
  UTF-8 char when a bare `ESC` preceded one. Fixed (drop only a following ASCII
  byte) + regression test `strip_ansi_escapes_non_csi_does_not_split_utf8`.
- **Cycle 2** — independent `code-review` agent flagged O(n²) on balanced
  brace-heavy input; fixed via `end+1` resume past matched non-envelope objects
  (the alternative "stop on unbalanced" suggestion was **rejected** because it
  would reintroduce a false-negative for a dangling `{` in a log line). Added
  `parse_recipe_output_skips_multiple_leading_json_log_objects` and
  `parse_recipe_output_recovers_after_unbalanced_brace_in_log_line`.
  Independent `security-review` agent: **zero findings** (slicing panic-safe,
  no harness injection, allowlist not bypassable).
- **Cycle 3** — independent re-review: **clean** (zero correctness bugs; only a
  non-blocking theoretical perf note on adversarial all-unbalanced-`{` input,
  out of scope and bounded for real recipe output).

Final cycle: zero critical/high; zero medium correctness/security findings.

### 4. CI / local verification
- `cargo test --lib memory_consolidation::distillation` → **23 passed; 0 failed**
  (incl. all new regression tests), in both dev and `--release` profiles.
- `cargo fmt --check` → clean.
- `cargo clippy --all-targets --all-features --locked -- -D warnings` → clean
  (also passed as a pre-push hook).
- Full `cargo test --lib` shows 5 unrelated failures
  (`operator_commands_dashboard::tests_goals_crud`, `ooda_brain::recipe_brain`,
  `ooda_loop::decide`) that reproduce **identically on clean `HEAD`** without
  this change — pre-existing shared-host/parallel-state flakes. `main`'s CI
  verify runs are green, confirming they pass on a fresh checkout.

### 6. Focused diff
One source file + two test-scaffold files; no snapshot/findings doc, no
unrelated edits:

```
 src/memory_consolidation/distillation.rs | parser hardening + regression tests
 tests/gadugi/distill-facts-parser.sh     | new outside-in harness
 tests/gadugi/distill-facts-parser.yaml   | new gadugi scenario
```
