### PR TITLE
chore(deps): bump RustyClawd pin to ddae0fdf (supply-chain hardening, rysweet/RustyClawd#1107)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1074,7 +1074,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1208,7 +1208,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1751,7 +1751,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2444,7 +2444,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3046,7 +3046,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3084,7 +3084,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -3431,7 +3431,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3490,7 +3490,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3532,7 +3532,7 @@ dependencies = [
 [[package]]
 name = "rustyclawd-core"
 version = "0.1.1"
-source = "git+https://github.com/rysweet/RustyClawd.git?rev=bb94cf370b32ed435c95f56918cf87c7c4334449#bb94cf370b32ed435c95f56918cf87c7c4334449"
+source = "git+https://github.com/rysweet/RustyClawd.git?rev=ddae0fdf1b922ae8604b0a4e178a3634ada7e350#ddae0fdf1b922ae8604b0a4e178a3634ada7e350"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3554,7 +3554,7 @@ dependencies = [
 [[package]]
 name = "rustyclawd-tools"
 version = "0.1.1"
-source = "git+https://github.com/rysweet/RustyClawd.git?rev=bb94cf370b32ed435c95f56918cf87c7c4334449#bb94cf370b32ed435c95f56918cf87c7c4334449"
+source = "git+https://github.com/rysweet/RustyClawd.git?rev=ddae0fdf1b922ae8604b0a4e178a3634ada7e350#ddae0fdf1b922ae8604b0a4e178a3634ada7e350"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4187,7 +4187,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5118,7 +5118,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,8 +55,8 @@ path = "src/bin/simard_tui/main.rs"
 # tombstone read-path fix + the empty-read safety gate). This rev is the
 # squash-merge commit of amplihack-memory-lib PR #108 on `main`.
 amplihack-memory = { git = "https://github.com/rysweet/amplihack-memory-lib.git", rev = "26d49bf864ac2c03b80c4ab075c4a907c51f82a8", features = ["persistent"] }
-rustyclawd-core = { git = "https://github.com/rysweet/RustyClawd.git", rev = "bb94cf370b32ed435c95f56918cf87c7c4334449" }
-rustyclawd-tools = { git = "https://github.com/rysweet/RustyClawd.git", rev = "bb94cf370b32ed435c95f56918cf87c7c4334449" }
+rustyclawd-core = { git = "https://github.com/rysweet/RustyClawd.git", rev = "ddae0fdf1b922ae8604b0a4e178a3634ada7e350" }
+rustyclawd-tools = { git = "https://github.com/rysweet/RustyClawd.git", rev = "ddae0fdf1b922ae8604b0a4e178a3634ada7e350" }
 # De-fork (issue #2323): the gym/eval RUNNER is now the upstream
 # `amplihack-agent-eval` crate (native Rust GymRunner + scenario/result types),
 # replacing the private `src/native_gym.rs` reimplementation. Only the bridge


### PR DESCRIPTION
## Summary

Bump the RustyClawd dependency pin so Simard's build consumes the **merged** supply-chain hardening from RustyClawd PR `rysweet/RustyClawd#1107` ("chore(security): SHA-pin Actions, lock deps, add cargo-deny audit gate, least-privilege GITHUB_TOKEN").

- `rustyclawd-core` and `rustyclawd-tools`: `rev = bb94cf370b32ed435c95f56918cf87c7c4334449` → `rev = ddae0fdf1b922ae8604b0a4e178a3634ada7e350`
- `ddae0fdf` is RustyClawd `main` HEAD and the merge commit of PR #1107 (merged 2026-06-29T22:21:20Z).
- Clean **1-commit fast-forward** over the prior pin `bb94cf37` (compare `bb94cf37...ddae0fdf` = ahead_by 1, behind_by 0).

This closes the **dependency-pin done-gate** of the supply-chain hardening goal: the upstream deliverable (6 SHA-pinned workflows + least-privilege `GITHUB_TOKEN`, `deny.toml` cargo-deny audit gate, committed `Cargo.lock`, dep pin in `tools/testing/Cargo.toml`) is now actually in Simard's running build.

## Why this is a no-risk bump
PR #1107 changes **only** CI workflows, `deny.toml`, and `tools/testing/Cargo.toml` — it does **not** touch any `rustyclawd-core` / `rustyclawd-tools` library `src/`. So there is **zero API or behavior change** for Simard. The library source consumed by Simard is byte-identical between `bb94cf37` and `ddae0fdf`; only the pinned rev advances.

Upstream `cargo-deny` audit gate is **green on `ddae0fdf`** (RustyClawd main): `Supply-chain audit (cargo-deny) => success`, along with Build/Test/Lint/Format/Coverage. (RustyClawd's `e2e-tests`/`tag` jobs fail pre-existing and unrelated — not part of this goal.)

## Merge-ready criteria evidence

**1. qa-team scenarios (internal-only justified) + gadugi-test**
A dependency-pin bump that changes no library source and no user-facing behavior introduces no new scenario surface, so no new qa-team scenarios were authored (internal-only justification). The existing gadugi suite was validated as a regression smoke check:
- `gadugi-test validate --directory tests/gadugi` → **34/34 files valid, 0 invalid** (exit 0).
Full `gadugi-test run` (live agentic suite) requires an LLM backend and is unaffected by a lockfile rev bump; regression coverage is provided by `cargo test` in CI (the `pre-commit` job below, green).

**2. Documentation / changed surfaces**
No user-facing surface changes. Changed surfaces: `Cargo.toml` (two `rev` lines) and `Cargo.lock` (dependency manifest). Internal-only — no docs update required.

**3. quality-audit — 3 SEEK→VALIDATE→FIX cycles (ended clean)**
- *Cycle 1 — correctness/completeness:* Both `rustyclawd-core` and `rustyclawd-tools` rev lines updated in `Cargo.toml`; both `[[package]]` source entries updated in `Cargo.lock`. `ddae0fdf` confirmed = main HEAD = #1107 merge commit; clean 1-commit FF. **No findings.**
- *Cycle 2 — supply-chain/security:* `cargo deny --locked check` → advisories/bans/licenses/sources **ok**. `cargo vet --locked` → **Vetting Succeeded (540 exempted)**. `cargo audit` → exit 0 (7 pre-existing allowed warnings, identical pre/post). Package name+version set **identical** before/after the bump → no new crates entered the graph to audit. **No findings.**
- *Cycle 3 — scope/build/lint:* Diff limited to the two `rev` lines + resulting `Cargo.lock` refresh; no unrelated edits. `cargo build` ✓, `cargo fmt --check` ✓, `cargo clippy --all-targets --all-features --locked -- -D warnings` ✓, `cargo clippy --release` ✓, rust-only gate ✓, pre-push lib tests ✓. **No findings.**
- *Final cycle clean:* zero critical/high; zero medium correctness/security findings.

**4. CI — confirmed 100% green**
CI on this PR is **green — 15/15 required checks SUCCESS, 0 failures** on head commit `60642c7bc3f5f7050776b721c10345cb9646571f`.
- Green run: https://github.com/rysweet/Simard/actions/runs/28413054853
- Passing checks: `pre-commit` (cargo test + clippy + build), `install-real`, `e2e-dashboard`, `cargo-audit`, `cargo-deny`, `cargo-vet`, `npm-audit`, GitGuardian.

**6. Diff focused**
```
 Cargo.lock | 24 ++++++++++++------------
 Cargo.toml |  4 ++--
 2 files changed, 14 insertions(+), 14 deletions(-)
```
`Cargo.lock` changes are the two rustyclawd source rev swaps plus cargo's re-resolution of a few transitive edges (`windows-sys`, `socket2`) to versions **already present** in the lock — the package set is unchanged. No unrelated edits.

## Verdict

**Ready to merge.** All six merge-ready criteria are satisfied: qa-team (internal-only justified + 34/34 gadugi scenarios valid), documentation (internal-only — manifest-only change), quality-audit (three SEEK→VALIDATE→FIX cycles, final cycle clean, zero critical/high/medium correctness or security findings), CI (15/15 checks green, run linked above), scope (two `rev` lines + Cargo.lock refresh, no unrelated edits), and this explicit verdict with rationale. The bump is a clean 1-commit fast-forward to a no-source-change upstream commit whose audit gate is green, so the risk is minimal and the dependency-pin done-gate is closed.

## References
- RustyClawd PR: `rysweet/RustyClawd#1107`
- RustyClawd merge commit: `ddae0fdf1b922ae8604b0a4e178a3634ada7e350`
