### PR TITLE
fix(distill): tolerate field-incomplete facts so one bad fact doesn't drop the whole batch (#2506)

### DIFF
--- a/src/memory_consolidation/distillation.rs
+++ b/src/memory_consolidation/distillation.rs
@@ -1124,33 +1124,52 @@ fn scan_for_facts_object(text: &str) -> Option<DistillOutput> {
 }
 
 /// Scan an already noise-stripped `trimmed` string for a `{ "facts": [...] }`
-/// object, preferring the LAST *non-empty* balanced top-level object (the
-/// agent's final answer trails any banner/thinking output) and falling back to
-/// the last parseable empty object. The ANSI/log/banner stripping that produces
-/// `trimmed` lives in [`scan_for_facts_object`].
+/// object, preferring (in order) the LAST balanced top-level object that carries
+/// a **grounded-capable** fact — one with a non-empty `source_episode_id` — then
+/// the last otherwise-non-empty object, then the last parseable empty object.
+/// The ANSI/log/banner stripping that produces `trimmed` lives in
+/// [`scan_for_facts_object`].
+///
+/// The grounded-capable tier exists because field-level leniency
+/// ([`de_lenient_string`]) lets a *source-less* facts object now parse as
+/// "non-empty"; without this tier a trailing source-less object (which the
+/// reliability gate would later quarantine wholesale) could shadow an earlier
+/// fully-attributed answer and silently discard its promotable facts. Preferring
+/// the grounded-capable object keeps the agent's real, attributed answer winning
+/// while still recovering a source-less answer when that is all the output holds.
 fn scan_cleaned_for_facts(trimmed: &str) -> Option<DistillOutput> {
     // Fast path — the text IS the JSON object.
     if let Ok(parsed) = serde_json::from_str::<RecipeEnvelope>(trimmed) {
         return Some(parsed.into_output());
     }
-    // Slow path — among every balanced top-level `{...}` substring, prefer the
-    // facts from the LAST *non-empty* one that parses. Falling back to the last
-    // parseable object only when none carry facts/procedures preserves a
-    // legitimate `{"facts":[]}` "nothing worth distilling" answer while never
-    // letting an accidental trailing empty object shadow an earlier populated one.
+    // Slow path — among every balanced top-level `{...}` substring, scanned from
+    // the END so the agent's final answer is reached before any leading
+    // banner/thinking object. Three preference tiers (best first):
+    //   1. last object with a grounded-capable fact (non-empty source_episode_id),
+    //   2. last otherwise-non-empty object (facts/procedures present),
+    //   3. last parseable empty `{"facts":[]}` ("nothing worth distilling").
+    let mut nonempty_fallback: Option<DistillOutput> = None;
     let mut empty_fallback: Option<DistillOutput> = None;
     for (start, end) in balanced_object_spans(trimmed).into_iter().rev() {
         if let Ok(parsed) = serde_json::from_str::<RecipeEnvelope>(&trimmed[start..end]) {
             let output = parsed.into_output();
-            if !output.facts.is_empty() || !output.procedures.is_empty() {
+            if output
+                .facts
+                .iter()
+                .any(|f| !f.source_episode_id.trim().is_empty())
+            {
                 return Some(output);
             }
-            if empty_fallback.is_none() {
+            if !output.facts.is_empty() || !output.procedures.is_empty() {
+                if nonempty_fallback.is_none() {
+                    nonempty_fallback = Some(output);
+                }
+            } else if empty_fallback.is_none() {
                 empty_fallback = Some(output);
             }
         }
     }
-    empty_fallback
+    nonempty_fallback.or(empty_fallback)
 }
 
 /// Return the byte spans `[start, end)` of every top-level balanced `{...}`
@@ -1324,8 +1343,11 @@ struct RecipeEnvelope {
 /// ungrounded and the existing reliability gate ([`assess_fact_reliability`])
 /// quarantines it; an empty `concept` is dropped by [`RecipeEnvelope::into_facts`];
 /// empty `content` is quarantined by the reliability hard gate. Coercion is
-/// limited to scalars; a non-scalar (array/object) is stringified, which the
-/// same gates then reject.
+/// limited to **scalars** (string / number / bool); a `null` or a non-scalar
+/// (array / object) — both of which are malformed for a field the recipe
+/// promises as a plain string — collapses to the empty string so the existing
+/// gates drop/quarantine it rather than letting structured JSON text smuggle a
+/// fact past them.
 fn de_lenient_string<'de, D>(deserializer: D) -> Result<String, D::Error>
 where
     D: serde::Deserializer<'de>,
@@ -1333,10 +1355,14 @@ where
     use serde::Deserialize;
     Ok(match serde_json::Value::deserialize(deserializer)? {
         serde_json::Value::String(s) => s,
-        serde_json::Value::Null => String::new(),
         serde_json::Value::Number(n) => n.to_string(),
         serde_json::Value::Bool(b) => b.to_string(),
-        other => other.to_string(),
+        // Null and any non-scalar (array/object) → empty: a malformed value for
+        // a promised-string field must not become non-empty `content`/`concept`
+        // that could clear the empty-content/known-concept gates.
+        serde_json::Value::Null | serde_json::Value::Array(_) | serde_json::Value::Object(_) => {
+            String::new()
+        }
     })
 }
 
@@ -2134,5 +2160,51 @@ mod issue_t9664_field_tolerance_tests {
             score < DISTILL_RELIABILITY_THRESHOLD,
             "ungrounded recovered fact must stay below the promotion threshold, got {score}"
         );
+    }
+
+    /// Field leniency must not let a trailing *source-less* facts object shadow
+    /// an earlier *grounded* one. Before the grounded-preference tier, the
+    /// source-less object — now parseable thanks to `de_lenient_string` — would
+    /// win as the "last non-empty" object and the earlier attributed fact would
+    /// be silently discarded. The grounded-capable answer must win.
+    #[test]
+    fn grounded_object_wins_over_trailing_sourceless_object() {
+        let step_output = concat!(
+            "{\"facts\":[{\"concept\":\"bug-pattern\",\"content\":\"the attributed answer\",\"source_episode_id\":\"epi_1\"}]}\n",
+            "{\"facts\":[{\"concept\":\"bug-pattern\",\"content\":\"a later source-less restatement\"}]}"
+        );
+        let facts =
+            parse_recipe_output(step_output).expect("a grounded object must be recoverable");
+        assert_eq!(
+            facts.len(),
+            1,
+            "exactly the grounded object's facts: {facts:?}"
+        );
+        assert_eq!(facts[0].source_episode_id, "epi_1");
+        assert_eq!(facts[0].content, "the attributed answer");
+    }
+
+    /// A non-scalar (array/object) value for a promised-string field collapses to
+    /// empty rather than being stringified, so it cannot smuggle structured JSON
+    /// text past the empty-content / known-concept gates. The envelope still
+    /// parses (the batch is not dropped); the malformed fact is simply gateable.
+    #[test]
+    fn non_scalar_field_values_collapse_to_empty() {
+        let raw = r#"{"facts":[{"concept":"bug-pattern","content":["a","b"],"source_episode_id":{"x":1}}]}"#;
+        let facts = parse_recipe_output(raw).expect("non-scalar fields must not sink the envelope");
+        assert_eq!(facts.len(), 1);
+        assert!(
+            facts[0].content.is_empty(),
+            "array content must collapse to empty, got {:?}",
+            facts[0].content
+        );
+        assert!(
+            facts[0].source_episode_id.is_empty(),
+            "object source_episode_id must collapse to empty, got {:?}",
+            facts[0].source_episode_id
+        );
+        // Empty content → reliability hard gate quarantines it (score 0.0).
+        let score = assess_fact_reliability(&facts[0], &[], &facts);
+        assert_eq!(score, 0.0, "empty-content fact must score 0.0");
     }
 }

--- a/src/memory_consolidation/distillation.rs
+++ b/src/memory_consolidation/distillation.rs
@@ -1305,15 +1305,54 @@ struct RecipeEnvelope {
     procedures: Vec<RecipeProcedure>,
 }
 
+/// Deserialize a fact/procedure field that the distiller agent is *supposed* to
+/// emit as a JSON string but, in practice, intermittently omits, nulls, or
+/// emits as a bare scalar (the Copilot CLI agent does this for individual
+/// `facts[]` entries — observed live in production, e.g. episode t=9664; see
+/// issue #2506).
+///
+/// Without this, a single fact missing `source_episode_id` (or carrying a
+/// `null`/numeric value) made `serde` reject the **entire** `{ "facts": [...] }`
+/// envelope, so `scan_for_facts_object` found no parseable object and the whole
+/// batch was silently dropped with the recurring
+/// `` `distill` step output did not contain a parseable { "facts": [...] } `` error —
+/// burning an LLM call every cycle while the same batch deferred forever.
+///
+/// Tolerating field-level noise lets the **well-formed** facts in a batch be
+/// recovered instead of one malformed sibling sinking all of them. Quality is
+/// not weakened: a recovered fact with an empty/unknown `source_episode_id` is
+/// ungrounded and the existing reliability gate ([`assess_fact_reliability`])
+/// quarantines it; an empty `concept` is dropped by [`RecipeEnvelope::into_facts`];
+/// empty `content` is quarantined by the reliability hard gate. Coercion is
+/// limited to scalars; a non-scalar (array/object) is stringified, which the
+/// same gates then reject.
+fn de_lenient_string<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::Deserialize;
+    Ok(match serde_json::Value::deserialize(deserializer)? {
+        serde_json::Value::String(s) => s,
+        serde_json::Value::Null => String::new(),
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::Bool(b) => b.to_string(),
+        other => other.to_string(),
+    })
+}
+
 #[derive(serde::Deserialize)]
 struct RecipeFact {
+    #[serde(default, deserialize_with = "de_lenient_string")]
     concept: String,
+    #[serde(default, deserialize_with = "de_lenient_string")]
     content: String,
+    #[serde(default, deserialize_with = "de_lenient_string")]
     source_episode_id: String,
 }
 
 #[derive(serde::Deserialize)]
 struct RecipeProcedure {
+    #[serde(default, deserialize_with = "de_lenient_string")]
     name: String,
     #[serde(default)]
     steps: Vec<String>,
@@ -1959,5 +1998,141 @@ mod issue_2496_distill_launcher_tests {
         assert_eq!(out.facts.len(), 1, "exactly one fact recovered");
         assert_eq!(out.facts[0].concept, "bug-pattern");
         assert_eq!(out.facts[0].source_episode_id, "epi_2496");
+    }
+}
+
+/// Episode t=9664 (live OODA consolidation, 2026-06-30, Copilot CLI 1.0.66-2):
+/// the distill bridge failed **recurrently** with the same
+/// `` `distill` step output did not contain a parseable { "facts": [...] } `` error
+/// (issue #2506) even though every ANSI/launch-log preamble shape was already stripped (the
+/// fix landed in #2479/#2484/#2490/#2504, and the deployed binary carried it).
+///
+/// The residual root cause was *field-level* strictness, not noise: the agent
+/// intermittently omits / nulls / scalar-types a single `facts[]` field
+/// (most often `source_episode_id`), which made `serde` reject the **whole**
+/// envelope so the entire batch was silently dropped and re-deferred every
+/// cycle. These tests pin the field-tolerant deserialization
+/// ([`de_lenient_string`]): one malformed fact no longer sinks its well-formed
+/// siblings, and an ungrounded recovered fact is still gated by
+/// [`assess_fact_reliability`] rather than promoted blindly.
+#[cfg(test)]
+mod issue_t9664_field_tolerance_tests {
+    use super::*;
+
+    /// The exact production noise prefix captured for episode t=9664: an
+    /// ANSI-coloured ISO-timestamped `launching copilot binary=…` line followed
+    /// by the bare `\u{2139} NODE_OPTIONS=…` info marker, immediately preceding
+    /// the agent's real `{ "facts": [...] }` answer.
+    fn real_t9664_noise_prefix() -> String {
+        let e = '\u{1b}';
+        format!(
+            "{e}[2m2026-06-30T04:31:59.643823Z{e}[0m {e}[32m INFO{e}[0m launching copilot \
+             {e}[3mbinary{e}[0m{e}[2m={e}[0m/home/azureuser/.npm-global/bin/copilot \
+             {e}[3mversion{e}[0m{e}[2m={e}[0m\"GitHub Copilot CLI 1.0.66-2.\"\n\
+             \u{2139} NODE_OPTIONS=--max-old-space-size=8192\n"
+        )
+    }
+
+    fn distill_envelope(step_output: &str) -> String {
+        serde_json::json!({
+            "recipe_name": "distill-episodes",
+            "success": true,
+            "step_results": [{
+                "step_id": "distill",
+                "status": "completed",
+                "output": step_output,
+                "error": ""
+            }]
+        })
+        .to_string()
+    }
+
+    /// The headline regression: leading ANSI/launch-log noise ahead of a facts
+    /// payload in which one fact is **well-formed** and a sibling **omits
+    /// `source_episode_id`**. Before the fix the missing field made the whole
+    /// `{ "facts": [...] }` object unparseable and the entire batch was dropped;
+    /// now the payload parses and the well-formed fact is recovered.
+    #[test]
+    fn distill_recovers_wellformed_fact_when_sibling_omits_source_episode_id() {
+        let step_output = format!(
+            "{}{{\"facts\":[\
+               {{\"concept\":\"bug-pattern\",\"content\":\"distill parser must tolerate a fact missing source_episode_id\",\"source_episode_id\":\"epi_9664\"}},\
+               {{\"concept\":\"lesson-learned\",\"content\":\"a sibling fact omitted its source_episode_id\"}}\
+             ]}}",
+            real_t9664_noise_prefix()
+        );
+        // The raw step-output span carries ESC bytes and a field-incomplete
+        // fact, so it must NOT parse as-is — the silent-drop failure mode.
+        assert!(
+            serde_json::from_str::<RecipeEnvelope>(step_output.trim()).is_err(),
+            "raw noised + field-incomplete step output must be unparseable as-is"
+        );
+        let out = parse_recipe_output_full(&distill_envelope(&step_output))
+            .expect("t=9664 payload (noise + one field-incomplete fact) must parse");
+        // Both facts are recovered by the parser (the reliability gate, applied
+        // later in the pass, decides promotion vs. quarantine — see
+        // `assess_fact_reliability`). The grounded one is intact.
+        assert!(
+            out.facts.iter().any(|f| f.concept == "bug-pattern"
+                && f.source_episode_id == "epi_9664"
+                && f.content == "distill parser must tolerate a fact missing source_episode_id"),
+            "the well-formed grounded fact must survive a malformed sibling: {:?}",
+            out.facts
+        );
+        // The field-incomplete sibling parses with an empty source_episode_id
+        // (ungrounded) rather than poisoning the batch.
+        assert!(
+            out.facts
+                .iter()
+                .any(|f| f.concept == "lesson-learned" && f.source_episode_id.is_empty()),
+            "the field-incomplete sibling must parse with an empty source_episode_id: {:?}",
+            out.facts
+        );
+    }
+
+    /// A bare facts object whose only fact omits `source_episode_id` must parse
+    /// (Tier-2 path) instead of erroring — the minimal reproduction of the
+    /// schema-strictness gap, independent of any noise.
+    #[test]
+    fn parse_recipe_output_tolerates_fact_missing_source_episode_id() {
+        let raw = r#"{"facts":[{"concept":"bug-pattern","content":"missing id field"}]}"#;
+        let facts = parse_recipe_output(raw).expect("a fact missing source_episode_id must parse");
+        assert_eq!(facts.len(), 1);
+        assert_eq!(facts[0].concept, "bug-pattern");
+        assert!(facts[0].source_episode_id.is_empty());
+    }
+
+    /// `null` and bare-scalar field values are coerced rather than rejected:
+    /// `source_episode_id: null` and a numeric `source_episode_id` are common
+    /// LLM deviations that previously sank the whole envelope.
+    #[test]
+    fn parse_recipe_output_tolerates_null_and_scalar_fields() {
+        let null_field = r#"{"facts":[{"concept":"lesson-learned","content":"id was null","source_episode_id":null}]}"#;
+        let facts = parse_recipe_output(null_field).expect("null source_episode_id must parse");
+        assert_eq!(facts.len(), 1);
+        assert!(facts[0].source_episode_id.is_empty());
+
+        let numeric_field = r#"{"facts":[{"concept":"pr-pattern","content":"id was numeric","source_episode_id":9664}]}"#;
+        let facts =
+            parse_recipe_output(numeric_field).expect("numeric source_episode_id must parse");
+        assert_eq!(facts.len(), 1);
+        assert_eq!(facts[0].source_episode_id, "9664");
+    }
+
+    /// Field tolerance must NOT weaken quality: a recovered fact whose
+    /// `source_episode_id` does not match any batch episode is ungrounded and
+    /// the reliability gate keeps quarantining it (score < threshold).
+    #[test]
+    fn recovered_fact_with_missing_provenance_is_still_quarantined_by_the_gate() {
+        let ungrounded = DistilledFact {
+            concept: "bug-pattern".to_string(),
+            content: "three or more words present here".to_string(),
+            source_episode_id: String::new(),
+        };
+        let score = assess_fact_reliability(&ungrounded, &[], std::slice::from_ref(&ungrounded));
+        assert!(
+            score < DISTILL_RELIABILITY_THRESHOLD,
+            "ungrounded recovered fact must stay below the promotion threshold, got {score}"
+        );
     }
 }

--- a/tests/gadugi/distill-parser-field-tolerance.yaml
+++ b/tests/gadugi/distill-parser-field-tolerance.yaml
@@ -1,0 +1,104 @@
+name: "Distill Parser Tolerates Field-Incomplete Facts"
+description: >
+  Outside-in regression gate for episode t=9664 (live OODA consolidation,
+  2026-06-30, Copilot CLI 1.0.66-2). The episode->fact distillation bridge kept
+  failing every cycle with `distill: `distill` step output did not contain a
+  parseable { "facts": [...] } object` EVEN THOUGH all ANSI/launch-log preamble
+  shapes were already stripped (#2479/#2484/#2490/#2496/#2504). The residual
+  root cause was field-level strictness: the agent intermittently omits / nulls
+  / scalar-types a single `facts[]` field (most often `source_episode_id`),
+  which made serde reject the WHOLE envelope so the entire batch was silently
+  dropped and re-deferred forever. The parser now deserializes fact fields
+  leniently (de_lenient_string): one malformed fact no longer sinks its
+  well-formed siblings, and an ungrounded recovered fact is still quarantined by
+  the reliability gate rather than promoted blindly. This scenario pins that
+  behaviour end-to-end so it cannot regress.
+version: "1.0.0"
+
+config:
+  timeout: 600000
+  retries: 1
+  parallel: false
+
+environment:
+  requires: []
+
+agents:
+  - name: "test-agent"
+    type: "cli"
+    config:
+      workingDirectory: "."
+      defaultTimeout: 600000
+      executionMode: "spawn"
+      captureOutput: true
+      ioConfig:
+        encoding: "utf8"
+        handleInteractivePrompts: false
+      logConfig:
+        logCommands: true
+        logOutput: true
+        logLevel: "info"
+
+steps:
+  - name: "Well-formed fact survives a field-incomplete sibling behind launch-log noise (t=9664)"
+    agent: "test-agent"
+    action: "execute_command"
+    params:
+      command: >
+        cargo test --lib
+        issue_t9664_field_tolerance_tests
+        -- --nocapture
+    timeout: 600000
+    expect:
+      exitCode: 0
+      outputContains:
+        - "distill_recovers_wellformed_fact_when_sibling_omits_source_episode_id ... ok"
+        - "parse_recipe_output_tolerates_fact_missing_source_episode_id ... ok"
+        - "parse_recipe_output_tolerates_null_and_scalar_fields ... ok"
+        - "recovered_fact_with_missing_provenance_is_still_quarantined_by_the_gate ... ok"
+        - "test result: ok"
+
+  - name: "Launch-log preamble regression (#2496) still green (no regression)"
+    agent: "test-agent"
+    action: "execute_command"
+    params:
+      command: >
+        cargo test --lib
+        parse_recipe_output_full_recovers_facts_from_copilot_launch_log_preamble
+        -- --nocapture
+    timeout: 600000
+    expect:
+      exitCode: 0
+      outputContains:
+        - "test result: ok"
+
+  - name: "Full distillation parser contract still green (no regression)"
+    agent: "test-agent"
+    action: "execute_command"
+    params:
+      command: >
+        cargo test --lib memory_consolidation::distillation
+        -- --nocapture
+    timeout: 600000
+    expect:
+      exitCode: 0
+      outputContains:
+        - "test result: ok"
+
+assertions: []
+
+cleanup:
+  - name: "CLI agent cleanup"
+    agent: "test-agent"
+    action: "cleanup"
+
+metadata:
+  tags:
+    - "cli"
+    - "memory"
+    - "distillation"
+    - "regression"
+    - "issue-t9664"
+  priority: "high"
+  author: "copilot"
+  test_type: "outside-in"

--- a/tests/gadugi/distill-parser-field-tolerance.yaml
+++ b/tests/gadugi/distill-parser-field-tolerance.yaml
@@ -56,6 +56,8 @@ steps:
         - "parse_recipe_output_tolerates_fact_missing_source_episode_id ... ok"
         - "parse_recipe_output_tolerates_null_and_scalar_fields ... ok"
         - "recovered_fact_with_missing_provenance_is_still_quarantined_by_the_gate ... ok"
+        - "grounded_object_wins_over_trailing_sourceless_object ... ok"
+        - "non_scalar_field_values_collapse_to_empty ... ok"
         - "test result: ok"
 
   - name: "Launch-log preamble regression (#2496) still green (no regression)"


### PR DESCRIPTION
## Summary

The episode→fact distillation bridge kept failing **every OODA cycle** with
`distill: `distill` step output did not contain a parseable { "facts": [...] }
object` (live: episode **t=9664**, `2026-06-30T04:31:59Z`, Copilot CLI
`1.0.66-2`) — silently dropping the whole batch and starving long-term
semantic/procedural recall.

Same error string as #2496, **different root cause**. The ANSI/launch-log
preamble that #2496/#2479/#2484/#2490/#2504 fixed is fully stripped now
(verified: the deployed binary built `01:33Z`, after #2504 merged `01:24Z`,
carries the `is_copilot_launcher_line` markers — yet the failure persisted). The
residual cause is **field-level schema strictness**, not noise.

`RecipeFact` required `concept`, `content`, `source_episode_id` with **no
defaults**, so when the agent omits / nulls / scalar-types a **single** `facts[]`
field (most often `source_episode_id`), serde rejects the **entire** envelope,
`scan_for_facts_object` finds no parseable object, and the whole batch is dropped
and re-deferred forever.

### Empirical diagnosis (against current `main`'s parser, exact t=9664 noise)

| Probe | Input | Result |
|-------|-------|--------|
| A | real ANSI/launch-log noise + **valid** facts object | parses OK → noise handling already fine |
| C | same noise + one fact **missing `source_episode_id`** | **fails entirely** → reproduces the production error |

## Fix

1. `de_lenient_string` + `#[serde(default, deserialize_with=…)]` on the fact /
   procedure string fields: missing/`null`/scalar values coerce to a string
   (non-scalars collapse to empty) instead of sinking the envelope. **One
   malformed fact no longer discards its well-formed siblings.**
2. `scan_cleaned_for_facts` gains a **grounded-capable preference tier** so a
   newly-parseable *source-less* object can't shadow an earlier fully-attributed
   answer.

Quality is **not** weakened — lenient *parsing* never bypasses the existing
*gates*: an ungrounded recovered fact (empty/unknown `source_episode_id`) tops
out at 0.4 < `DISTILL_RELIABILITY_THRESHOLD` (0.5) and is quarantined by
`assess_fact_reliability`; an empty `concept` is dropped by `into_facts`; empty
`content` scores 0.0. The change only changes **which** facts reach those gates.

Closes #2506

---

## Merge-ready evidence

### 1. qa-team scenarios (gadugi) ✅
- Added outside-in scenario `tests/gadugi/distill-parser-field-tolerance.yaml`
  (pins all six field-tolerance unit tests + two no-regression steps).
- `gadugi-test validate -f … --strict` → **valid**.
- `gadugi-test run -d tests/gadugi -s distill-parser-field-tolerance` →
  **✓ Passed: 1, ✗ Failed: 0** (re-run after every code change).

### 2. Docs / user-facing surfaces — internal-only ✅
No user-facing surface changes. The diff is confined to the internal
distill-bridge parser (`RecipeFact`/`RecipeProcedure` deserialization and the
`scan_cleaned_for_facts` selection tier in `src/memory_consolidation/distillation.rs`).
No CLI flag, no public API, no operator-visible output, no change to the JSON
contract the recipe prompt promises. Justification: a strictly more-tolerant
deserializer with unchanged downstream quality gates.

### 3. quality-audit — 3 SEEK→VALIDATE→FIX cycles, clean final ✅
- **Cycle 1 (code-review):** no material correctness/security issues; one LOW
  doc-accuracy nit (stringified non-scalar `content`).
- **Cycle 2 (rubber-duck):** production path confirmed fixed; flagged (non-blocking)
  that a trailing *source-less* object could shadow an earlier grounded one, and
  the non-scalar-content stringification risk.
- **Cycle 3 (FIX + re-review):** non-scalars now collapse to empty; added the
  grounded-capable selection tier; added regression tests
  `grounded_object_wins_over_trailing_sourceless_object` and
  `non_scalar_field_values_collapse_to_empty`. **Final code-review verdict:
  "Both fixes are correct. No material issues found. ✅ (final gate: PASS)"** —
  zero critical/high, zero medium correctness/security findings.

### 4. CI green ✅
- Local pre-push gate (mirrors `.github/workflows/verify.yml`), green on every push:
  - `cargo fmt --all -- --check` → **Passed**
  - `cargo test --release --lib (cognitive_memory|bootstrap|memory_ipc|memory_consolidation)` → **Passed**
  - `cargo clippy --all-targets --all-features --locked -- -D warnings` → **Passed**
- `cargo test --lib distillation` → **80 passed, 0 failed**;
  `cargo test --lib recipe_output` → **55 passed, 0 failed**.
- (The full `cargo test --lib` has two pre-existing flakes on this host —
  `ooda_loop::decide::tests::decide_respects_max_concurrent_actions` and
  `base_type_copilot::tests::meeting_turn_evidence_has_no_pty_artifacts` — both
  reproduce on a clean `origin/main` checkout and are unrelated to this diff.)

### 6. Focused diff ✅
1 source file (`src/memory_consolidation/distillation.rs`) + 1 new gadugi
scenario. No unrelated edits.

---

_Note: this merged Simard PR ships in the binary only after a subsequent
self-update; the running daemon will keep hitting the t=9664 drop until it
self-updates to a build containing this fix._
