### PR TITLE
fix(distill): recover facts answer trailing an unmatched `{` in agent prose (#2508)

### DIFF
--- a/src/memory_consolidation/distillation.rs
+++ b/src/memory_consolidation/distillation.rs
@@ -1172,22 +1172,58 @@ fn scan_cleaned_for_facts(trimmed: &str) -> Option<DistillOutput> {
     nonempty_fallback.or(empty_fallback)
 }
 
-/// Return the byte spans `[start, end)` of every top-level balanced `{...}`
-/// object in `s`, in source order.
+/// Return the byte spans `[start, end)` of every balanced `{...}` object in
+/// `s`, in source order.
 ///
-/// String-aware **inside objects**: once a `{` has opened (depth > 0), `{`/`}`
-/// bytes inside a JSON string literal (respecting `\"` escapes) are ignored.
-/// Quotes encountered at depth 0 (e.g. an unmatched quote in leading prose)
-/// are treated as ordinary characters so they cannot swallow the object's `{`
-/// opener. Unbalanced trailing `{` are silently dropped.
+/// String-aware **inside objects**: once a `{` has opened, `{`/`}` bytes inside
+/// a JSON string literal (respecting `\"` escapes) are ignored. Characters in
+/// the prose *between* objects are never allowed to swallow a later balanced
+/// object:
+///
+/// - An unmatched `"` in leading prose is skipped — the per-candidate scan only
+///   begins at a `{`, so a stray prose quote is an ordinary character (the
+///   #2461 unmatched-leading-quote fix).
+/// - An unmatched `{` in leading prose that never closes is skipped one byte at
+///   a time until a genuinely balanced object is found *after* it. The previous
+///   single-`depth` scan anchored on the first `{`; a stray `{` in the distill
+///   agent's reasoning (e.g. a code fragment such as `fn f() {` while it reasons
+///   about code episodes) raised depth permanently, demoted the real
+///   `{ "facts": [...] }` answer to a nested object, and the pass silently
+///   no-opped with zero facts (issue #2508). Restarting from the next `{`
+///   recovers the trailing answer.
 fn balanced_object_spans(s: &str) -> Vec<(usize, usize)> {
     let bytes = s.as_bytes();
     let mut spans = Vec::new();
+    let mut i = 0usize;
+    while i < bytes.len() {
+        if bytes[i] == b'{'
+            && let Some(end) = scan_balanced_object(bytes, i)
+        {
+            spans.push((i, end + 1));
+            i = end + 1;
+            continue;
+        }
+        // A non-`{` byte, or an unmatched `{` that never closes before EOF:
+        // advance one byte and keep scanning for a balanced object that begins
+        // later (so a stray `{` in leading prose cannot swallow the answer).
+        i += 1;
+    }
+    spans
+}
+
+/// Given `bytes[start] == b'{'`, return the byte index of the `}` that closes
+/// it, honouring JSON string literals so that `{`/`}` inside `"..."`
+/// (respecting `\"` escapes) do not affect nesting depth. Returns `None` when
+/// the object is never closed before the end of input.
+///
+/// Iterative (no recursion) so pathologically deep nesting terminates without a
+/// stack overflow; serde's own recursion limit bounds the eventual per-span
+/// parse in [`scan_cleaned_for_facts`].
+fn scan_balanced_object(bytes: &[u8], start: usize) -> Option<usize> {
     let mut depth = 0i32;
-    let mut start = 0usize;
     let mut in_string = false;
     let mut escaped = false;
-    for (i, &b) in bytes.iter().enumerate() {
+    for (i, &b) in bytes.iter().enumerate().skip(start) {
         if in_string {
             if escaped {
                 escaped = false;
@@ -1199,23 +1235,18 @@ fn balanced_object_spans(s: &str) -> Vec<(usize, usize)> {
             continue;
         }
         match b {
-            b'"' if depth > 0 => in_string = true,
-            b'{' => {
-                if depth == 0 {
-                    start = i;
-                }
-                depth += 1;
-            }
-            b'}' if depth > 0 => {
+            b'"' => in_string = true,
+            b'{' => depth += 1,
+            b'}' => {
                 depth -= 1;
                 if depth == 0 {
-                    spans.push((start, i + 1));
+                    return Some(i);
                 }
             }
             _ => {}
         }
     }
-    spans
+    None
 }
 
 /// The `recipe-runner-rs` 0.3.6 `--output-format json` envelope. Only the
@@ -1581,6 +1612,64 @@ mod unit_tests {
             1,
             "string braces must not split the object"
         );
+    }
+
+    // ── issue #2508: unmatched `{` in leading prose must not swallow the answer ──
+
+    #[test]
+    fn balanced_object_spans_skips_unmatched_leading_brace() {
+        // A stray, never-closed `{` ahead of a genuinely balanced object must
+        // be skipped, not anchored on (which would demote the real object to a
+        // nested one and yield zero top-level spans).
+        let spans = balanced_object_spans(r#"prefix fn f() { then {"facts":[]}"#);
+        assert_eq!(
+            spans.len(),
+            1,
+            "the balanced object after the stray brace must be found"
+        );
+        let (start, end) = spans[0];
+        assert_eq!(
+            &r#"prefix fn f() { then {"facts":[]}"#[start..end],
+            r#"{"facts":[]}"#
+        );
+    }
+
+    #[test]
+    fn parse_recipe_output_recovers_from_unbalanced_brace_in_leading_prose() {
+        // The distill agent reasons about CODE episodes, so its preamble can
+        // carry a code fragment with an unmatched `{` (e.g. `fn handler() {`)
+        // before it emits the JSON answer. The old single-`depth` scan anchored
+        // on that stray brace and silently dropped the real facts object,
+        // no-opping distillation. The scanner must recover the trailing answer.
+        let raw = concat!(
+            "Looking at the episodes, the leak is in `fn handler() {` where the guard is missing.\n",
+            "Here is the distilled output:\n",
+            r#"{"facts":[{"concept":"bug-pattern","content":"missing guard in handler","#,
+            r#""source_episode_id":"epi_9900"}]}"#,
+        );
+        let facts = parse_recipe_output(raw).expect("answer after an unmatched `{` must parse");
+        assert_eq!(facts.len(), 1);
+        assert_eq!(facts[0].concept, "bug-pattern");
+        assert_eq!(facts[0].content, "missing guard in handler");
+        assert_eq!(facts[0].source_episode_id, "epi_9900");
+    }
+
+    #[test]
+    fn parse_recipe_output_banner_only_fails_non_fatally_without_panic() {
+        // Genuinely answer-less output — only the Copilot CLI launch banner,
+        // no `{ "facts": [...] }` object anywhere — must return Err (the
+        // retry-safe "no markers set" path) without panicking. This is the
+        // t=9900 shape when the agent emits its launch preamble and no answer.
+        let raw = concat!(
+            "2026-06-30T09:00:00.000000Z  INFO launching copilot binary=copilot ",
+            "version=\"GitHub Copilot CLI 1.0.66-2\"\n",
+            "\u{2139} NODE_OPTIONS=--max-old-space-size=8192 (saved preference)\n",
+            "Run 'copilot update' to update\n",
+        );
+        assert!(parse_recipe_output(raw).is_err());
+        // And the empty / whitespace-only shapes likewise fail without panic.
+        assert!(parse_recipe_output("").is_err());
+        assert!(parse_recipe_output("   \n \t ").is_err());
     }
 
     // ── issue #2461: failure classification ─────────────────────────────

--- a/src/memory_consolidation/distillation.rs
+++ b/src/memory_consolidation/distillation.rs
@@ -1142,16 +1142,25 @@ fn scan_cleaned_for_facts(trimmed: &str) -> Option<DistillOutput> {
     if let Ok(parsed) = serde_json::from_str::<RecipeEnvelope>(trimmed) {
         return Some(parsed.into_output());
     }
-    // Slow path — among every balanced top-level `{...}` substring, scanned from
-    // the END so the agent's final answer is reached before any leading
-    // banner/thinking object. Three preference tiers (best first):
+    // Slow path — among every balanced `{...}` substring (string-aware, so a
+    // brace inside a JSON string cannot split an object), scanned from the END
+    // so the agent's final answer is reached before any leading banner/thinking
+    // object. The shared `recipe_output::balanced_objects` helper restarts at
+    // the next `{` after an unmatched/never-closing brace, so a stray `{` in the
+    // distill agent's leading prose (e.g. a code fragment like `fn f() {` while
+    // it reasons about code episodes) can no longer demote the real answer to a
+    // nested object and silently drop it (issue #2508). Three preference tiers
+    // (best first):
     //   1. last object with a grounded-capable fact (non-empty source_episode_id),
     //   2. last otherwise-non-empty object (facts/procedures present),
     //   3. last parseable empty `{"facts":[]}` ("nothing worth distilling").
     let mut nonempty_fallback: Option<DistillOutput> = None;
     let mut empty_fallback: Option<DistillOutput> = None;
-    for (start, end) in balanced_object_spans(trimmed).into_iter().rev() {
-        if let Ok(parsed) = serde_json::from_str::<RecipeEnvelope>(&trimmed[start..end]) {
+    for span in crate::recipe_output::balanced_objects(trimmed)
+        .into_iter()
+        .rev()
+    {
+        if let Ok(parsed) = serde_json::from_str::<RecipeEnvelope>(span) {
             let output = parsed.into_output();
             if output
                 .facts
@@ -1170,83 +1179,6 @@ fn scan_cleaned_for_facts(trimmed: &str) -> Option<DistillOutput> {
         }
     }
     nonempty_fallback.or(empty_fallback)
-}
-
-/// Return the byte spans `[start, end)` of every balanced `{...}` object in
-/// `s`, in source order.
-///
-/// String-aware **inside objects**: once a `{` has opened, `{`/`}` bytes inside
-/// a JSON string literal (respecting `\"` escapes) are ignored. Characters in
-/// the prose *between* objects are never allowed to swallow a later balanced
-/// object:
-///
-/// - An unmatched `"` in leading prose is skipped — the per-candidate scan only
-///   begins at a `{`, so a stray prose quote is an ordinary character (the
-///   #2461 unmatched-leading-quote fix).
-/// - An unmatched `{` in leading prose that never closes is skipped one byte at
-///   a time until a genuinely balanced object is found *after* it. The previous
-///   single-`depth` scan anchored on the first `{`; a stray `{` in the distill
-///   agent's reasoning (e.g. a code fragment such as `fn f() {` while it reasons
-///   about code episodes) raised depth permanently, demoted the real
-///   `{ "facts": [...] }` answer to a nested object, and the pass silently
-///   no-opped with zero facts (issue #2508). Restarting from the next `{`
-///   recovers the trailing answer.
-fn balanced_object_spans(s: &str) -> Vec<(usize, usize)> {
-    let bytes = s.as_bytes();
-    let mut spans = Vec::new();
-    let mut i = 0usize;
-    while i < bytes.len() {
-        if bytes[i] == b'{'
-            && let Some(end) = scan_balanced_object(bytes, i)
-        {
-            spans.push((i, end + 1));
-            i = end + 1;
-            continue;
-        }
-        // A non-`{` byte, or an unmatched `{` that never closes before EOF:
-        // advance one byte and keep scanning for a balanced object that begins
-        // later (so a stray `{` in leading prose cannot swallow the answer).
-        i += 1;
-    }
-    spans
-}
-
-/// Given `bytes[start] == b'{'`, return the byte index of the `}` that closes
-/// it, honouring JSON string literals so that `{`/`}` inside `"..."`
-/// (respecting `\"` escapes) do not affect nesting depth. Returns `None` when
-/// the object is never closed before the end of input.
-///
-/// Iterative (no recursion) so pathologically deep nesting terminates without a
-/// stack overflow; serde's own recursion limit bounds the eventual per-span
-/// parse in [`scan_cleaned_for_facts`].
-fn scan_balanced_object(bytes: &[u8], start: usize) -> Option<usize> {
-    let mut depth = 0i32;
-    let mut in_string = false;
-    let mut escaped = false;
-    for (i, &b) in bytes.iter().enumerate().skip(start) {
-        if in_string {
-            if escaped {
-                escaped = false;
-            } else if b == b'\\' {
-                escaped = true;
-            } else if b == b'"' {
-                in_string = false;
-            }
-            continue;
-        }
-        match b {
-            b'"' => in_string = true,
-            b'{' => depth += 1,
-            b'}' => {
-                depth -= 1;
-                if depth == 0 {
-                    return Some(i);
-                }
-            }
-            _ => {}
-        }
-    }
-    None
 }
 
 /// The `recipe-runner-rs` 0.3.6 `--output-format json` envelope. Only the
@@ -1601,38 +1533,12 @@ mod unit_tests {
         assert_eq!(facts[0].concept, "pr-pattern");
     }
 
-    #[test]
-    fn balanced_object_spans_finds_multiple_and_ignores_string_braces() {
-        assert_eq!(
-            balanced_object_spans(r#"{"a":1} junk {"b":{"c":2}}"#).len(),
-            2
-        );
-        assert_eq!(
-            balanced_object_spans(r#"{"k":"a } b { c"}"#).len(),
-            1,
-            "string braces must not split the object"
-        );
-    }
-
     // ── issue #2508: unmatched `{` in leading prose must not swallow the answer ──
-
-    #[test]
-    fn balanced_object_spans_skips_unmatched_leading_brace() {
-        // A stray, never-closed `{` ahead of a genuinely balanced object must
-        // be skipped, not anchored on (which would demote the real object to a
-        // nested one and yield zero top-level spans).
-        let spans = balanced_object_spans(r#"prefix fn f() { then {"facts":[]}"#);
-        assert_eq!(
-            spans.len(),
-            1,
-            "the balanced object after the stray brace must be found"
-        );
-        let (start, end) = spans[0];
-        assert_eq!(
-            &r#"prefix fn f() { then {"facts":[]}"#[start..end],
-            r#"{"facts":[]}"#
-        );
-    }
+    // The balanced-object scan reuses the shared `recipe_output::balanced_objects`
+    // helper (string-aware, restarts past an unmatched/never-closing `{`); that
+    // helper's own span-level unit tests live in `recipe_output::extract`,
+    // including `balanced_objects_skips_unmatched_leading_brace`. The end-to-end
+    // distillation recovery and the non-fatal fallback are pinned here.
 
     #[test]
     fn parse_recipe_output_recovers_from_unbalanced_brace_in_leading_prose() {

--- a/src/memory_consolidation/distillation.rs
+++ b/src/memory_consolidation/distillation.rs
@@ -1124,11 +1124,13 @@ fn scan_for_facts_object(text: &str) -> Option<DistillOutput> {
 }
 
 /// Scan an already noise-stripped `trimmed` string for a `{ "facts": [...] }`
-/// object, preferring (in order) the LAST balanced top-level object that carries
+/// object, preferring (in order) the LAST balanced object candidate that carries
 /// a **grounded-capable** fact — one with a non-empty `source_episode_id` — then
 /// the last otherwise-non-empty object, then the last parseable empty object.
-/// The ANSI/log/banner stripping that produces `trimmed` lives in
-/// [`scan_for_facts_object`].
+/// Candidates are the balanced `{...}` substrings returned by
+/// [`crate::recipe_output::balanced_objects`] (string-aware, and resilient to an
+/// unmatched `{` in leading prose). The ANSI/log/banner stripping that produces
+/// `trimmed` lives in [`scan_for_facts_object`].
 ///
 /// The grounded-capable tier exists because field-level leniency
 /// ([`de_lenient_string`]) lets a *source-less* facts object now parse as

--- a/src/recipe_output/extract.rs
+++ b/src/recipe_output/extract.rs
@@ -244,12 +244,16 @@ fn scan_balanced(bytes: &[u8], start: usize) -> Option<usize> {
     None
 }
 
-/// Return every balanced top-level `{…}` span in `s`, in source order.
+/// Return every balanced `{…}` span in `s`, in source order, by trying each
+/// `{` opener in turn.
 ///
-/// String-literal aware (braces inside JSON strings are ignored). Used by
-/// callers that need to try each candidate against a typed envelope — e.g.
-/// distillation parses each span as a `{ "facts": [...] }` object and keeps
-/// the first that deserialises.
+/// String-literal aware (braces inside JSON strings are ignored). A `{` that
+/// never closes — an unmatched opener in leading prose, e.g. a code fragment
+/// like `fn f() {` — is skipped so a genuinely balanced object *after* it is
+/// still found, rather than being demoted to a nested span and lost (relied on
+/// by distillation, issue #2508). Used by callers that need to try each
+/// candidate against a typed envelope — e.g. distillation parses each span as a
+/// `{ "facts": [...] }` object and keeps the first that deserialises.
 pub fn balanced_objects(s: &str) -> Vec<&str> {
     let bytes = s.as_bytes();
     let mut spans = Vec::new();

--- a/src/recipe_output/extract.rs
+++ b/src/recipe_output/extract.rs
@@ -465,6 +465,16 @@ mod tests {
     }
 
     #[test]
+    fn balanced_objects_skips_unmatched_leading_brace() {
+        // An unmatched, never-closing `{` in leading prose (e.g. a code fragment
+        // such as `fn f() {`) must not anchor the scan and swallow the genuinely
+        // balanced object that follows it — the candidate restart recovers it
+        // (relied on by episode distillation, issue #2508).
+        let s = r#"prefix fn f() { then {"facts":[]}"#;
+        assert_eq!(balanced_objects(s), vec![r#"{"facts":[]}"#]);
+    }
+
+    #[test]
     fn last_balanced_object_returns_trailing_answer() {
         let s = "{\"thinking\":true} then {\"answer\":42}";
         assert_eq!(last_balanced_object(s), Some("{\"answer\":42}"));

--- a/tests/gadugi/distill-parser-unbalanced-brace-prose.yaml
+++ b/tests/gadugi/distill-parser-unbalanced-brace-prose.yaml
@@ -5,11 +5,13 @@ description: >
   { "facts": [...] } object even when the distill agent's leading prose carries
   an UNMATCHED `{` ahead of its JSON answer. This is realistic because the
   distiller reasons about CODE episodes and intermittently writes a fragment
-  like `fn handler() {` in its preamble. The previous `balanced_object_spans`
-  used a single shared brace depth, so a stray unmatched `{` raised depth
-  permanently and demoted the real answer to a nested span that was never
+  like `fn handler() {` in its preamble. The distillation scanner previously
+  used a hand-rolled single-shared-depth scan, so a stray unmatched `{` raised
+  depth permanently and demoted the real answer to a nested span that was never
   recorded as top-level -> the pass found no facts object and silently no-opped
-  (zero facts). The launch-banner / unmatched-QUOTE cases were already fixed
+  (zero facts). The fix reuses the shared, string-aware
+  `recipe_output::balanced_objects` helper (candidate-restart past an unmatched
+  `{`). The launch-banner / unmatched-QUOTE cases were already fixed
   (#2461/#2496/#2504/#2506); this scenario pins the unmatched-BRACE case so it
   cannot regress, while asserting that genuinely answer-less output still fails
   non-fatally (Err) without panicking.
@@ -40,7 +42,22 @@ agents:
         logLevel: "info"
 
 steps:
-  - name: "Unmatched `{` in leading prose no longer swallows the facts answer (#2508)"
+  - name: "Shared scanner skips an unmatched leading `{` and recovers the object (#2508)"
+    agent: "test-agent"
+    action: "execute_command"
+    params:
+      command: >
+        cargo test --lib
+        recipe_output::extract::tests::balanced_objects_skips_unmatched_leading_brace
+        -- --nocapture
+    timeout: 600000
+    expect:
+      exitCode: 0
+      outputContains:
+        - "balanced_objects_skips_unmatched_leading_brace ... ok"
+        - "test result: ok"
+
+  - name: "Distillation recovers the answer after an unmatched `{`; answer-less output stays non-fatal (#2508)"
     agent: "test-agent"
     action: "execute_command"
     params:
@@ -51,7 +68,6 @@ steps:
     expect:
       exitCode: 0
       outputContains:
-        - "balanced_object_spans_skips_unmatched_leading_brace ... ok"
         - "parse_recipe_output_recovers_from_unbalanced_brace_in_leading_prose ... ok"
         - "parse_recipe_output_banner_only_fails_non_fatally_without_panic ... ok"
         - "test result: ok"

--- a/tests/gadugi/distill-parser-unbalanced-brace-prose.yaml
+++ b/tests/gadugi/distill-parser-unbalanced-brace-prose.yaml
@@ -1,0 +1,102 @@
+name: "Distill Parser Recovers Answer After an Unmatched Brace in Prose"
+description: >
+  Outside-in regression gate for issue #2508 (residual of the t=9900 live
+  consolidation no-op). The episode->fact distillation parser must recover the
+  { "facts": [...] } object even when the distill agent's leading prose carries
+  an UNMATCHED `{` ahead of its JSON answer. This is realistic because the
+  distiller reasons about CODE episodes and intermittently writes a fragment
+  like `fn handler() {` in its preamble. The previous `balanced_object_spans`
+  used a single shared brace depth, so a stray unmatched `{` raised depth
+  permanently and demoted the real answer to a nested span that was never
+  recorded as top-level -> the pass found no facts object and silently no-opped
+  (zero facts). The launch-banner / unmatched-QUOTE cases were already fixed
+  (#2461/#2496/#2504/#2506); this scenario pins the unmatched-BRACE case so it
+  cannot regress, while asserting that genuinely answer-less output still fails
+  non-fatally (Err) without panicking.
+version: "1.0.0"
+
+config:
+  timeout: 600000
+  retries: 1
+  parallel: false
+
+environment:
+  requires: []
+
+agents:
+  - name: "test-agent"
+    type: "cli"
+    config:
+      workingDirectory: "."
+      defaultTimeout: 600000
+      executionMode: "spawn"
+      captureOutput: true
+      ioConfig:
+        encoding: "utf8"
+        handleInteractivePrompts: false
+      logConfig:
+        logCommands: true
+        logOutput: true
+        logLevel: "info"
+
+steps:
+  - name: "Unmatched `{` in leading prose no longer swallows the facts answer (#2508)"
+    agent: "test-agent"
+    action: "execute_command"
+    params:
+      command: >
+        cargo test --lib memory_consolidation::distillation::unit_tests
+        -- --nocapture
+    timeout: 600000
+    expect:
+      exitCode: 0
+      outputContains:
+        - "balanced_object_spans_skips_unmatched_leading_brace ... ok"
+        - "parse_recipe_output_recovers_from_unbalanced_brace_in_leading_prose ... ok"
+        - "parse_recipe_output_banner_only_fails_non_fatally_without_panic ... ok"
+        - "test result: ok"
+
+  - name: "Launch-log preamble regression (#2496) still green (no regression)"
+    agent: "test-agent"
+    action: "execute_command"
+    params:
+      command: >
+        cargo test --lib
+        parse_recipe_output_full_recovers_facts_from_copilot_launch_log_preamble
+        -- --nocapture
+    timeout: 600000
+    expect:
+      exitCode: 0
+      outputContains:
+        - "test result: ok"
+
+  - name: "Full distillation parser contract still green (no regression)"
+    agent: "test-agent"
+    action: "execute_command"
+    params:
+      command: >
+        cargo test --lib memory_consolidation::distillation
+        -- --nocapture
+    timeout: 600000
+    expect:
+      exitCode: 0
+      outputContains:
+        - "test result: ok"
+
+assertions: []
+
+cleanup:
+  - name: "CLI agent cleanup"
+    agent: "test-agent"
+    action: "cleanup"
+
+metadata:
+  tags:
+    - "cli"
+    - "memory"
+    - "distillation"
+    - "regression"
+    - "issue-2508"
+  priority: "high"
+  author: "copilot"
+  test_type: "outside-in"


### PR DESCRIPTION
Closes #2508

## What & why

Fixes the residual episode-distillation parse-failure that silently no-ops
memory consolidation (zero facts). `Closes #2508`.

`memory_consolidation::distillation`'s answer extraction used a private,
hand-rolled `balanced_object_spans` that tracked a single shared brace `depth`
across the whole distill step output. An unmatched `{` in the agent's **leading
prose** — common because the distiller reasons about **code** episodes and
writes a fragment like `fn handler() {` before its JSON answer — raised depth to
1 permanently, demoting the real `{ "facts": [...] }` object to a *nested* span
that was never recorded. The pass then found no facts object → `Err` →
`dispatch_consolidate_memory` logged `"distill failed (non-fatal)"` and stored
zero facts. This is the last uncovered case of the launch-banner / preamble
parse-failure family; the `NODE_OPTIONS` / `launching copilot binary` banners
and the unmatched-**quote**-in-prose case were already fixed (#2461, #2496,
#2504, #2506); the unmatched-**brace**-in-prose case was not.

## The fix

Delete the buggy private duplicate and **reuse the already-shipping, tested
shared helper** `crate::recipe_output::balanced_objects` (string-aware,
candidate-restart) inside `scan_cleaned_for_facts`. It tries each `{` opener and
skips one that never closes, so a stray unmatched `{` can no longer swallow the
trailing answer. Genuinely answer-less output (launch banner only / empty /
whitespace) still returns `Err` — the retry-safe "no markers set" path — without
panicking. All prior parser behaviour is preserved: last-object-wins,
string-aware content braces, unmatched-quote prose, and the `--output-format
json` runner-envelope tiers.

Net effect: distillation.rs is **simplified** (the ~50-line hand-rolled scanner
+ helper are removed in favour of the shared one).

## Merge-ready evidence

### (1) qa-team scenarios — gadugi-test
New outside-in scenario: `tests/gadugi/distill-parser-unbalanced-brace-prose.yaml`.
- `gadugi-test validate -f … --strict` → `Valid files: 1 / Invalid files: 0`.
- `gadugi-test run -d …` → `Passed: 1, Failed: 0 — All tests passed!`
  (asserts the shared-helper span test and the two end-to-end distillation
  regressions all report `... ok` + `test result: ok`).

### (2) Docs / changed surfaces
No user-facing surface change. Changed surfaces are internal only:
`scan_cleaned_for_facts` (private) now calls the existing public-in-crate
`recipe_output::balanced_objects`; no API/CLI/output-contract change. Rustdoc
updated in-tree for `balanced_objects` and `scan_cleaned_for_facts` to document
the unmatched-`{` recovery contract distillation now relies on.

### (3) quality-audit — 3 SEEK→VALIDATE→FIX cycles, clean final
- **Cycle 1** (code-review + security-review agents): security = memory-/panic-
  safe, no OOB, no negative depth, **no security findings**. Finding: the
  hand-rolled scanner duplicated the shipped `balanced_objects`/`scan_balanced`
  (maintainability/DRY) → **FIXED** by reusing the shared helper. The O(n²)
  candidate-restart was assessed **non-actionable** (matches the shipped
  `balanced_objects` pattern, a whole-string serde fast path runs first, input
  is small/semi-trusted agent stdout).
- **Cycle 2** (code-review + a 4M-iteration differential fuzz of old vs new
  scanner): the new helper is an **order-preserving superset** of the old scan
  (0 dropped spans, 0 order violations, 0 unbalanced spans); `.rev()` tier
  preference preserved; coverage preserved; gadugi names valid; no dead code.
  **No findings.**
- **Cycle 3** (rubber-duck logic review): no blocking issues; one non-blocking
  stale-comment-wording note ("top-level"/"last non-empty") → **FIXED** (doc
  only). Confirmed the regression tests would fail against the old scanner and
  the empty/banner-only path returns `Err` without panic.
- **Final cycle clean**: zero critical/high; zero medium correctness/security.

### (4) CI — 100% green
See the checks on this PR (verify `pre-commit` + `coverage` + audits green).
Local gates mirroring CI, all green on the final commit:
- `cargo fmt --all -- --check` — Passed
- `cargo clippy --release --no-deps -- -D warnings` (pre-commit) — Passed
- `cargo clippy --all-targets --all-features --locked -- -D warnings` (pre-push) — Passed
- `cargo test --release --lib (cognitive_memory|bootstrap|memory_ipc|memory_consolidation)` — Passed (157 memory_consolidation tests)
- `cargo test --lib memory_consolidation` (76 distillation) and `recipe_output` (58) — Passed

### RED→GREEN regression evidence
Reverting the scanner to the old single-`depth` algorithm fails the brace
regressions; the fix makes them pass:
- `recipe_output::extract::tests::balanced_objects_skips_unmatched_leading_brace` — FAILED → ok
- `distillation … parse_recipe_output_recovers_from_unbalanced_brace_in_leading_prose` — FAILED → ok
- `distillation … parse_recipe_output_banner_only_fails_non_fatally_without_panic` — ok on both (non-fatal guard)

### (6) Scope
Three files: `src/memory_consolidation/distillation.rs`,
`src/recipe_output/extract.rs` (one regression test + doc), and the new gadugi
scenario. No unrelated edits; net code reduction.
