### PR TITLE
feat(brain): wire Reflexion failure→lesson trigger live on the FU1 refuted signal (#2458)

### DIFF
--- a/docs/reference/procedural-learning-loop.md
+++ b/docs/reference/procedural-learning-loop.md
@@ -386,7 +386,12 @@ The loop has four production seams, all wired on honest external signals.
    distils a recurrence-gated lesson, and emits `brain_repeat_failure` when a
    failure recurs on a goal-type that already carries a lesson. `Unverified` /
    `Error` outcomes (nothing to check, or a query failed) are skipped — they are
-   not failures (R10).
+   not failures (R10). **Per-occurrence dedup:** each observation carries the
+   goal id as an `occurrence_key`, so a goal that stays blocked across many
+   cycles (e.g. a normal in-flight PR not yet merged) reflects exactly **once** —
+   bounding episodic growth and keeping recurrence honest (distinct
+   false-completions, not cycle count). Recurrence therefore accrues across
+   *distinct* goals/attempts of the same type, never from one stuck goal.
 
 ```rust
 // src/ooda_loop/cycle.rs — curate phase (simplified).

--- a/docs/reference/procedural-learning-loop.md
+++ b/docs/reference/procedural-learning-loop.md
@@ -33,16 +33,21 @@ related:
 > emission is at the OODA procedure-store seam (`src/ooda_loop/cycle.rs`); metrics
 > are written through the existing `record_metric` in `src/self_metrics/mod.rs`.
 >
-> **FU1 boundary (honest scope).** The *mechanics* of the failure→lesson half are
-> implemented and tested, but their **production trigger** requires an external
-> failure signal. Today the only engineer-loop
-> [`VerificationReport`](#verified_outcome) yields `verified`/`unverified`
-> (a git-artifact probe), never `failed`, so [`verified_outcome`] never returns
-> `VerifiedFailure` in production yet. Per both issues' stated sequencing
-> ("hard dependency on FU1"), wiring `record_failure_reflection` /
-> `maybe_distill_lesson` / `brain_repeat_failure` to a real failure verdict is a
-> one-call change deferred to FU1 — see [OODA cycle wiring](#ooda-cycle-wiring).
-> The loop is **never** gated on self-judged `ActionOutcome.success` (R10).
+> **FU1 boundary (now satisfied).** The *mechanics* of the failure→lesson half
+> were implemented and tested under #2476; their **production trigger** required
+> an external failure signal. FU1 —
+> [#2456](https://github.com/rysweet/Simard/issues/2456), the external-signal
+> completion gate — has since landed and produces a genuine, non-self-judged
+> failure signal: [`VerificationOutcome::Refuted`](#ooda-cycle-wiring), a
+> *false completion* where a derivable external postcondition (PR merged, issue
+> closed, self-change deployed) contradicted the done-claim. The OODA curate
+> phase now wires that signal end-to-end through
+> [`learn_from_verified_failures`](#ooda-cycle-wiring) →
+> `record_failure_reflection` → `maybe_distill_lesson` → `brain_repeat_failure`
+> (`src/ooda_loop/cycle.rs::learn_from_refuted_goals`). The loop is **never**
+> gated on self-judged `ActionOutcome.success` (R10): the engineer-loop
+> `VerificationReport` git-artifact probe (which only yields `verified`/
+> `unverified`) is not the trigger — the gate's *refutation* is.
 
 This page is the executable contract for the proposed procedural-learning loop.
 For the rationale and the end-to-end picture see
@@ -355,7 +360,7 @@ Example records (`metrics.jsonl`):
 
 ## OODA cycle wiring
 
-The loop has three production seams today and one FU1-gated seam.
+The loop has four production seams, all wired on honest external signals.
 
 **Wired now (honest signals):**
 
@@ -368,52 +373,41 @@ The loop has three production seams today and one FU1-gated seam.
 2. **New procedure → `brain_new_procedure`.** When the OODA consolidation seam
    (`src/ooda_loop/cycle.rs`) stores a *new* procedure (not a reinforcing
    re-store), it emits `brain_new_procedure` via [`record_new_procedure`].
-
-**Implemented + tested, FU1-gated for production trigger:**
-
-3. **Failure → reflection → lesson, and `brain_repeat_failure`.**
-   [`record_failure_reflection`], [`maybe_distill_lesson`], [`has_lesson_for`],
-   and [`record_repeat_failure`] are fully implemented and covered by
-   `tests_reflection_lessons.rs`. They are **no-ops on every non-`VerifiedFailure`
-   verdict** (R10), so they cannot fire from self-judged success. Production today
-   has no external *failure* verdict (the engineer-loop `VerificationReport` only
-   yields `verified`/`unverified`), so these do not trigger yet. Once FU1 supplies
-   a real failure signal, the wiring is the illustrative block below — calling
-   the existing, tested entry points behind a single `verified_outcome(...)`:
+3. **Refuted completion → reflection → lesson → `brain_repeat_failure`.** FU1
+   (#2456) landed the external-signal completion gate. In the OODA **curate**
+   phase, `archive_completed_evidence_aware` classifies each blocked completion;
+   a goal whose done-claim a *derivable external postcondition refuted*
+   (`VerificationOutcome::Refuted` — PR not merged, issue still open, self-change
+   not deployed) is a genuine, non-self-judged failure. `learn_from_refuted_goals`
+   (`src/ooda_loop/cycle.rs`) maps each refuted goal to a
+   [`VerifiedFailureObservation`] (`{objective, error_class}` where `error_class`
+   comes from [`error_class_from_missing`]) and hands
+   the batch to [`learn_from_verified_failures`], which records a reflection,
+   distils a recurrence-gated lesson, and emits `brain_repeat_failure` when a
+   failure recurs on a goal-type that already carries a lesson. `Unverified` /
+   `Error` outcomes (nothing to check, or a query failed) are skipped — they are
+   not failures (R10).
 
 ```rust
-// FU1 wiring (illustrative): only a *real* external verdict drives learning.
-let verdict = reflection_lessons::verified_outcome(&report); // engineer-loop report
-match &verdict {
-    Verdict::VerifiedSuccess => {
-        // distil/reinforce the successful sequence as a skill (gated on the
-        // external verdict, never on outcome.success).
-    }
-    Verdict::VerifiedFailure { error_class } => {
-        let ep = reflection_lessons::record_failure_reflection(
-            mem, &objective, &verdict, &next_time_hint,
-        )?;
-        let gt = reflection_lessons::normalize_goal_type(&objective);
-        if reflection_lessons::has_lesson_for(mem, &gt, error_class)? {
-            reflection_lessons::record_repeat_failure(&gt, error_class, &lesson_id);
-        }
-        reflection_lessons::maybe_distill_lesson(
-            mem, &verdict, &objective,
-            config.lesson_recurrence_threshold, ep.as_slice(),
-        )?;
-    }
-    Verdict::Unverified => { /* learn nothing — fail-safe */ }
-}
+// src/ooda_loop/cycle.rs — curate phase (simplified).
+let (archived, blocked) = goal_curation::archive_completed_evidence_aware(board, source);
+// Only goals an external postcondition *refuted* drive learning (never
+// self-judged ActionOutcome.success). Recurring refutations distil a lesson.
+learn_from_refuted_goals(&blocked, &*bridges.memory, config.lesson_recurrence_threshold);
+
+// learn_from_refuted_goals filters to VerificationOutcome::Refuted, derives the
+// error_class from the missing evidence, then for each observation:
+//   record_failure_reflection → maybe_distill_lesson → (repeat) record_repeat_failure
 ```
 
-> **Why the skill-distillation gate is not flipped yet.** The existing OODA
+> **Skill-distillation gate (seam 2) and self-report.** The existing OODA
 > consolidation stores procedures on a cycle's self-assessed `outcome.success`
-> (pre-existing #2281 behaviour). `ActionOutcome` carries no `VerificationReport`,
-> so there is no external verdict at that seam to gate on today. Rather than
-> regress to a *dishonest* gate, the verified-signal gate
-> ([`should_distill_skill`] / [`verified_outcome`]) ships ready for the FU1 seam
-> where a real report exists. R10 is preserved: no learning path is gated on
-> self-judged success.
+> (pre-existing #2281 behaviour). `ActionOutcome` carries no external verdict at
+> that seam, so the verified-signal skill gate
+> ([`should_distill_skill`] / [`verified_outcome`]) ships ready for an
+> engineer-loop `VerificationReport` seam where a real report exists. R10 is
+> preserved: the **failure** path (seam 3) is gated exclusively on the gate's
+> external refutation, never on self-judged success.
 
 ---
 
@@ -424,9 +418,9 @@ match &verdict {
 | `CognitiveMemoryOps` trait | unchanged | unchanged (no new methods) |
 | `CognitiveProcedure` shape | `{node_id,name,steps,prerequisites,usage_count}` | unchanged (lessons are name-prefixed) |
 | Schema / snapshots / IPC | — | unchanged; no DDL |
-| Skill distillation gate | self-judged `outcome.success` | gate **implemented** ([`verified_outcome`]/[`should_distill_skill`]); production flip deferred to FU1 (no external verdict at the OODA outcome seam yet) — R10 preserved |
-| Failure handling | none | reflection + recurrence-gated lesson (implemented + tested; production trigger FU1-gated) |
-| Metrics | — | `brain_skill_reuse` (wired), `brain_new_procedure` (wired), `brain_repeat_failure` (FU1-gated) |
+| Skill distillation gate | self-judged `outcome.success` | gate **implemented** ([`verified_outcome`]/[`should_distill_skill`]); production flip awaits an engineer-loop report seam — R10 preserved |
+| Failure handling | none | reflection + recurrence-gated lesson, **wired live** on the #2456 `Refuted` signal (`learn_from_refuted_goals`) |
+| Metrics | — | `brain_skill_reuse` (wired), `brain_new_procedure` (wired), `brain_repeat_failure` (**wired** on refuted completions) |
 
 ---
 
@@ -434,7 +428,8 @@ match &verdict {
 
 The contract is enforced by the tests below — pure gate/normalization/metric
 contracts in `reflection_lessons`'s inline `#[cfg(test)] mod tests`, memory-backed
-behaviour in `src/memory_consolidation/tests_reflection_lessons.rs`, and the
+behaviour in `src/memory_consolidation/tests_reflection_lessons.rs`, the live
+curate-phase wiring in `src/ooda_loop/cycle.rs::tests_refuted_lessons`, and the
 end-to-end reuse-loop guards in `src/cognitive_memory/tests_procedural_loop.rs`.
 
 | # | Acceptance criterion | Test | Status |
@@ -447,12 +442,13 @@ end-to-end reuse-loop guards in `src/cognitive_memory/tests_procedural_loop.rs`.
 | AC-6 (#2458) | A one-off failure (count = 1) does **not** become a lesson | `one_off_failure_is_not_a_lesson` | ✅ |
 | AC-7 (#2441/#2458) | A subsequent attempt on the failed goal-type surfaces the lesson | `recurring_failure_becomes_recallable_lesson` (recall assertion) | ✅ |
 | AC-8 (R10) | `Verdict::Unverified` distils/reflects nothing | `unverified_and_success_write_no_reflection`, `unverified_distills_no_lesson_even_with_reflections` | ✅ |
-| AC-9 (R9) | `brain_repeat_failure` records when a `VerifiedFailure` recurs on a goal-type with an existing lesson | `metric_contexts_have_expected_shapes` (metric surface); production emission **FU1-gated** | ⏳ FU1 |
+| AC-9 (R9) | `brain_repeat_failure` records when a `VerifiedFailure` recurs on a goal-type with an existing lesson | `learn_from_verified_failures_counts_repeat_after_lesson`, `learn_from_verified_failures_distill_and_repeat_in_one_pass` | ✅ |
 | AC-10 | `verified_outcome` maps pass/fail/unknown reports to the correct `Verdict` | `verified_outcome_mapping` | ✅ |
 | AC-11 | `normalize_goal_type` / `normalize_error_class` are deterministic and idempotent | `normalization_is_idempotent` | ✅ |
+| AC-12 (#2458) | The #2456 `Refuted` signal drives the live curate-phase loop (reflection + recallable lesson); `Unverified`/`Error` are skipped | `tests_refuted_lessons::*` (cycle), `error_class_from_missing_*` (gate) | ✅ |
 
-AC-1–AC-8, AC-10, AC-11 are green under `cargo test`. AC-9's metric *surface*
-(context shape + emitter) is tested; its production emission awaits FU1's
-external failure verdict (see [OODA cycle wiring](#ooda-cycle-wiring)). No
+All ACs are green under `cargo test`. The failure→lesson production trigger is
+now live on the #2456 `Refuted` signal via `learn_from_refuted_goals` in the
+OODA curate phase (see [OODA cycle wiring](#ooda-cycle-wiring)). No
 snapshot/architecture-snapshot docs are added, and no live redeploy is part of
 this change.

--- a/src/goal_curation/completion_gate.rs
+++ b/src/goal_curation/completion_gate.rs
@@ -191,6 +191,41 @@ pub fn classify_from_missing(
     }
 }
 
+/// Derive a normalized *error-class* key from the refuting evidence of a
+/// `Refuted` completion (#2458). Each missing-evidence kind maps to a stable
+/// token, joined in the gate's fixed check order (PR → issue → deploy) so the
+/// same refutation always yields the same class. [`MissingEvidence::CouldNotVerify`]
+/// is excluded — it routes to [`VerificationOutcome::Error`], never `Refuted`.
+///
+/// This is the bridge from FU1's external failure signal to #2458's failure→
+/// lesson loop: the returned class is the `error_class` half of the
+/// `(goal_type, error_class)` recurrence key
+/// ([`crate::memory_consolidation::reflection_lessons`]).
+///
+/// Returns `"refuted_unknown"` when no concrete refuting kind is present
+/// (defensive; the classifier never routes such a list to `Refuted`).
+pub fn error_class_from_missing(missing: &[MissingEvidence]) -> String {
+    let mut parts: Vec<&str> = Vec::new();
+    for m in missing {
+        let token = match m {
+            MissingEvidence::PrNotMerged => "pr_not_merged",
+            MissingEvidence::IssueOpen => "issue_open",
+            MissingEvidence::NotDeployed => "not_deployed",
+            // `CouldNotVerify` is the `Error` outcome, not a refutation — never
+            // let an unverifiable cycle masquerade as a concrete failure class.
+            MissingEvidence::CouldNotVerify { .. } => continue,
+        };
+        if !parts.contains(&token) {
+            parts.push(token);
+        }
+    }
+    if parts.is_empty() {
+        "refuted_unknown".to_string()
+    } else {
+        parts.join("__")
+    }
+}
+
 /// Emit one completion-verification outcome via
 /// [`crate::self_metrics::record_metric`]. Best-effort: a metric-write failure
 /// is swallowed so it never blocks or crashes the OODA cycle.

--- a/src/goal_curation/completion_gate/tests.rs
+++ b/src/goal_curation/completion_gate/tests.rs
@@ -13,8 +13,9 @@ use super::{
     COMPLETION_VERIFICATION_METRIC, CompletionEvidenceGate, CompletionVerdict, EvidenceSource,
     FALSE_COMPLETION_RATE_METRIC, MissingEvidence, VerificationOutcome,
     archive_completed_with_evidence, classify_from_missing, classify_outcome,
-    completion_evidence_enabled, false_completion_rate, has_derivable_signal, is_self_affecting,
-    record_completion_verification, record_false_completion_rate,
+    completion_evidence_enabled, error_class_from_missing, false_completion_rate,
+    has_derivable_signal, is_self_affecting, record_completion_verification,
+    record_false_completion_rate,
 };
 
 /// Canned, hermetic [`EvidenceSource`]. Each field is `Result<bool, String>` so
@@ -533,4 +534,66 @@ fn blocked_missing(v: &CompletionVerdict) -> Vec<MissingEvidence> {
         CompletionVerdict::Blocked { missing, .. } => missing.clone(),
         CompletionVerdict::Complete(_) => panic!("expected Blocked, got Complete"),
     }
+}
+
+// --- error_class_from_missing (#2458 bridge to the failure→lesson loop) ------
+
+#[test]
+fn error_class_from_missing_maps_each_kind_to_a_stable_token() {
+    assert_eq!(
+        error_class_from_missing(&[MissingEvidence::PrNotMerged]),
+        "pr_not_merged"
+    );
+    assert_eq!(
+        error_class_from_missing(&[MissingEvidence::IssueOpen]),
+        "issue_open"
+    );
+    assert_eq!(
+        error_class_from_missing(&[MissingEvidence::NotDeployed]),
+        "not_deployed"
+    );
+}
+
+#[test]
+fn error_class_from_missing_joins_multiple_in_check_order() {
+    // The gate pushes PR → issue → deploy; the class preserves that order so the
+    // same refutation always yields the same key.
+    let class = error_class_from_missing(&[
+        MissingEvidence::PrNotMerged,
+        MissingEvidence::IssueOpen,
+        MissingEvidence::NotDeployed,
+    ]);
+    assert_eq!(class, "pr_not_merged__issue_open__not_deployed");
+}
+
+#[test]
+fn error_class_from_missing_is_deterministic_and_dedups() {
+    let a = error_class_from_missing(&[MissingEvidence::IssueOpen, MissingEvidence::IssueOpen]);
+    let b = error_class_from_missing(&[MissingEvidence::IssueOpen]);
+    assert_eq!(a, b, "duplicate kinds must not duplicate tokens");
+}
+
+#[test]
+fn error_class_from_missing_excludes_could_not_verify() {
+    // `CouldNotVerify` is the `Error` outcome, never a refutation — it must not
+    // leak into a concrete failure class. A PR refutation alongside it keeps
+    // only the concrete token.
+    let class = error_class_from_missing(&[
+        MissingEvidence::CouldNotVerify {
+            detail: "gh timeout".to_string(),
+        },
+        MissingEvidence::PrNotMerged,
+    ]);
+    assert_eq!(class, "pr_not_merged");
+}
+
+#[test]
+fn error_class_from_missing_defaults_when_no_concrete_kind() {
+    // Defensive: a list with only `CouldNotVerify` (which never classifies as
+    // `Refuted`) yields the sentinel rather than an empty string.
+    let class = error_class_from_missing(&[MissingEvidence::CouldNotVerify {
+        detail: "x".to_string(),
+    }]);
+    assert_eq!(class, "refuted_unknown");
+    assert_eq!(error_class_from_missing(&[]), "refuted_unknown");
 }

--- a/src/goal_curation/mod.rs
+++ b/src/goal_curation/mod.rs
@@ -41,8 +41,8 @@ pub use completion_gate::{
     COMPLETION_VERIFICATION_METRIC, CompletionEvidence, CompletionEvidenceGate, CompletionVerdict,
     EvidenceSource, FALSE_COMPLETION_RATE_METRIC, GhCliEvidenceSource, MissingEvidence,
     VerificationOutcome, archive_completed_evidence_aware, archive_completed_with_evidence,
-    classify_from_missing, classify_outcome, completion_evidence_enabled, false_completion_rate,
-    has_derivable_signal, is_self_affecting, record_completion_verification,
+    classify_from_missing, classify_outcome, completion_evidence_enabled, error_class_from_missing,
+    false_completion_rate, has_derivable_signal, is_self_affecting, record_completion_verification,
     record_false_completion_rate,
 };
 

--- a/src/memory_consolidation/reflection_lessons.rs
+++ b/src/memory_consolidation/reflection_lessons.rs
@@ -293,6 +293,167 @@ pub fn maybe_distill_lesson(
     Ok(Some(id))
 }
 
+// ── live wiring: verified failures → reflections → lessons (#2458) ───────────
+
+/// One externally-verified failure observation sourced from the FU1 (#2456)
+/// completion gate — a [`VerificationOutcome::Refuted`](crate::goal_curation::VerificationOutcome)
+/// false completion where a derivable external postcondition contradicted the
+/// done-claim.
+///
+/// `objective` is the failed goal's description (the goal-type source);
+/// `error_class` is the normalized refuting signal (e.g. `pr_not_merged`). Both
+/// are re-normalized downstream, so callers may pass raw text.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VerifiedFailureObservation {
+    /// The failed goal's objective/description — normalized into the goal-type.
+    pub objective: String,
+    /// The normalized refuting signal (the `error_class` half of the key).
+    pub error_class: String,
+}
+
+impl VerifiedFailureObservation {
+    /// Construct an observation from any string-like objective and error class.
+    pub fn new(objective: impl Into<String>, error_class: impl Into<String>) -> Self {
+        Self {
+            objective: objective.into(),
+            error_class: error_class.into(),
+        }
+    }
+}
+
+/// Aggregate result of one [`learn_from_verified_failures`] pass. All counters
+/// are observable so the OODA cycle can log what the failure-reflection pass did.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct LessonLearningReport {
+    /// Reflections written this pass (one per verified failure observation).
+    pub reflections_recorded: u32,
+    /// **New** `lesson:` procedures distilled this pass (recurrence first
+    /// reached the threshold — not a reinforcing re-store).
+    pub lessons_distilled: u32,
+    /// Verified failures that recurred on a goal-type that *already* carried a
+    /// lesson — the loop's self-regression signal (`brain_repeat_failure`).
+    pub repeat_failures: u32,
+}
+
+impl LessonLearningReport {
+    /// `true` when the pass did nothing (empty/all-skipped batch).
+    pub fn is_empty(&self) -> bool {
+        self.reflections_recorded == 0 && self.lessons_distilled == 0 && self.repeat_failures == 0
+    }
+}
+
+/// Deterministic default reflection hint, grounded in the **external** signal
+/// (the refuting `error_class`) rather than any self-judgement — the same
+/// fail-safe invariant the rest of this module enforces (R10).
+fn default_failure_hint(error_class: &str) -> String {
+    format!(
+        "Recall the lesson for this goal-type and resolve the refuting signal \
+         ({error_class}) before re-claiming completion.",
+    )
+}
+
+/// Live production trigger (#2458): turn a batch of **externally-verified**
+/// failures into reflections and, on recurrence, procedural lessons.
+///
+/// This is the wiring the issue gated on FU1 (#2456) for: every observation
+/// here is sourced from a real external signal
+/// ([`VerificationOutcome::Refuted`](crate::goal_curation::VerificationOutcome)),
+/// never the brain's self-reported `ActionOutcome.success` (R10). The OODA
+/// curate phase calls it with the goals the completion gate refuted.
+///
+/// For each observation:
+/// 1. record a `reflection:failure` episode ([`record_failure_reflection`]);
+/// 2. capture whether a lesson *already* existed for this
+///    `(goal_type, error_class)` **before** distilling — a failure that recurs
+///    despite an existing lesson is the self-regression signal, emitted as
+///    `brain_repeat_failure` ([`record_repeat_failure`]);
+/// 3. distil a `lesson:` procedure once recurrence reaches `threshold`
+///    ([`maybe_distill_lesson`]); idempotent by name (#2298).
+///
+/// Best-effort per observation: an error on one failure is logged and skipped so
+/// one bad record never drops the rest of the batch. Never returns `Err` and
+/// never blocks the cycle. A `threshold` of `0` is treated as
+/// [`LESSON_RECURRENCE_THRESHOLD`] so a misconfiguration cannot turn every
+/// one-off failure into a lesson.
+pub fn learn_from_verified_failures(
+    memory: &dyn CognitiveMemoryOps,
+    failures: &[VerifiedFailureObservation],
+    threshold: u32,
+) -> LessonLearningReport {
+    let threshold = if threshold == 0 {
+        LESSON_RECURRENCE_THRESHOLD
+    } else {
+        threshold
+    };
+    let mut report = LessonLearningReport::default();
+
+    for obs in failures {
+        let error_class = normalize_error_class(&obs.error_class);
+        let verdict = Verdict::VerifiedFailure {
+            error_class: error_class.clone(),
+        };
+
+        // The self-regression check must read state BEFORE this failure's
+        // reflection/lesson is (re)stored — otherwise a freshly-distilled lesson
+        // would mask the very recurrence we want to flag.
+        let had_lesson = has_lesson_for(memory, &obs.objective, &error_class).unwrap_or(false);
+
+        let reflection_id = match record_failure_reflection(
+            memory,
+            &obs.objective,
+            &verdict,
+            &default_failure_hint(&error_class),
+        ) {
+            Ok(Some(id)) => {
+                report.reflections_recorded += 1;
+                Some(id)
+            }
+            // Unreachable for a `VerifiedFailure`, but harmless: distillation
+            // still gates on the persisted recurrence count.
+            Ok(None) => None,
+            Err(e) => {
+                tracing::warn!(
+                    target: "simard::reflection_lessons",
+                    objective = %obs.objective,
+                    error = %e,
+                    "record_failure_reflection failed; skipping observation",
+                );
+                continue;
+            }
+        };
+        let sources: Vec<String> = reflection_id.into_iter().collect();
+
+        match maybe_distill_lesson(memory, &verdict, &obs.objective, threshold, &sources) {
+            Ok(Some(lesson_id)) => {
+                if had_lesson {
+                    // Recurred despite an existing lesson — self-regression.
+                    report.repeat_failures += 1;
+                    record_repeat_failure(
+                        &normalize_goal_type(&obs.objective),
+                        &error_class,
+                        &lesson_id,
+                    );
+                } else {
+                    // First crossing of the recurrence threshold — a new lesson.
+                    report.lessons_distilled += 1;
+                }
+            }
+            // Below threshold — a one-off failure, no lesson yet (AC-6).
+            Ok(None) => {}
+            Err(e) => {
+                tracing::warn!(
+                    target: "simard::reflection_lessons",
+                    objective = %obs.objective,
+                    error = %e,
+                    "maybe_distill_lesson failed; reflection retained for next pass",
+                );
+            }
+        }
+    }
+
+    report
+}
+
 // ── metrics ─────────────────────────────────────────────────────────────────
 
 /// `brain_skill_reuse` — a recalled procedure was applied and reinforced (#2441).

--- a/src/memory_consolidation/reflection_lessons.rs
+++ b/src/memory_consolidation/reflection_lessons.rs
@@ -211,20 +211,59 @@ pub fn record_failure_reflection(
     verdict: &Verdict,
     hint: &str,
 ) -> SimardResult<Option<String>> {
+    record_failure_reflection_marked(memory, objective, verdict, hint, None)
+}
+
+/// As [`record_failure_reflection`], but optionally embeds a per-occurrence
+/// dedup marker so [`occurrence_already_reflected`] can recognise a repeat
+/// observation of the *same* blocked completion across cycles.
+fn record_failure_reflection_marked(
+    memory: &dyn CognitiveMemoryOps,
+    objective: &str,
+    verdict: &Verdict,
+    hint: &str,
+    occurrence_key: Option<&str>,
+) -> SimardResult<Option<String>> {
     let Verdict::VerifiedFailure { error_class } = verdict else {
         return Ok(None);
     };
     let goal_type = normalize_goal_type(objective);
     let marker = reflection_marker(&goal_type, error_class);
-    let content = format!("{} {marker}", reflection_text(objective, error_class, hint));
+    let mut content = format!("{} {marker}", reflection_text(objective, error_class, hint));
+    if let Some(key) = occurrence_key {
+        content.push(' ');
+        content.push_str(&occurrence_marker(key));
+    }
     let metadata = serde_json::json!({
         "kind": "reflection",
         "failure": true,
         "goal_type": goal_type,
         "error_class": error_class,
+        "occurrence_key": occurrence_key,
     });
     let id = memory.store_episode(&content, "reflection:failure", Some(&metadata))?;
     Ok(Some(id))
+}
+
+/// A fully-delimited content marker keyed by a per-occurrence identity (e.g. the
+/// goal id). Embedded alongside the `(goal_type, error_class)` marker so the
+/// same blocked completion, re-observed every OODA cycle, can be deduped to a
+/// single reflection. The brackets make the match collision-safe across keys
+/// that share a prefix.
+fn occurrence_marker(occurrence_key: &str) -> String {
+    format!("[reflect-occ={}]", normalize_error_class(occurrence_key))
+}
+
+/// `true` if a `reflection:failure` episode has already been recorded for this
+/// exact occurrence key. Used to bound the failure-reflection trail for a goal
+/// that stays blocked across many cycles (so one unresolved in-flight PR cannot
+/// accrue an unbounded reflection stream or a per-cycle `brain_repeat_failure`).
+fn occurrence_already_reflected(memory: &dyn CognitiveMemoryOps, occurrence_key: &str) -> bool {
+    let marker = occurrence_marker(occurrence_key);
+    memory
+        .search_episodes_by_keywords(std::slice::from_ref(&marker), 1)
+        .map(|hits| hits.iter().any(|e| e.content.contains(&marker)))
+        .unwrap_or(false)
 }
 
 /// Count stored `reflection:failure` episodes recorded for this
@@ -309,14 +348,39 @@ pub struct VerifiedFailureObservation {
     pub objective: String,
     /// The normalized refuting signal (the `error_class` half of the key).
     pub error_class: String,
+    /// Stable per-occurrence identity (e.g. the goal id). When `Some`, the same
+    /// blocked completion re-observed across cycles is deduped to **one**
+    /// reflection — bounding the failure-reflection trail and keeping recurrence
+    /// honest (distinct occurrences, not cycle count). `None` disables dedup, so
+    /// every call is treated as a fresh occurrence.
+    pub occurrence_key: Option<String>,
 }
 
 impl VerifiedFailureObservation {
-    /// Construct an observation from any string-like objective and error class.
+    /// Construct an observation with **no** per-occurrence dedup — every call is
+    /// a distinct occurrence. Use [`deduped`](Self::deduped) for the live cycle
+    /// path where the same blocked goal recurs across cycles.
     pub fn new(objective: impl Into<String>, error_class: impl Into<String>) -> Self {
         Self {
             objective: objective.into(),
             error_class: error_class.into(),
+            occurrence_key: None,
+        }
+    }
+
+    /// Construct an observation deduped across cycles by `occurrence_key` (the
+    /// goal id at the live OODA seam). A goal that stays blocked over many cycles
+    /// then contributes exactly one reflection, and `brain_repeat_failure` fires
+    /// only on a genuinely *new* occurrence — never once per cycle.
+    pub fn deduped(
+        objective: impl Into<String>,
+        error_class: impl Into<String>,
+        occurrence_key: impl Into<String>,
+    ) -> Self {
+        Self {
+            objective: objective.into(),
+            error_class: error_class.into(),
+            occurrence_key: Some(occurrence_key.into()),
         }
     }
 }
@@ -362,6 +426,10 @@ fn default_failure_hint(error_class: &str) -> String {
 /// curate phase calls it with the goals the completion gate refuted.
 ///
 /// For each observation:
+/// 0. **dedup** — if the observation carries an `occurrence_key` already
+///    reflected (the same blocked goal seen on a prior cycle), skip it entirely.
+///    This bounds the reflection trail and keeps recurrence honest (distinct
+///    occurrences, not cycle count);
 /// 1. record a `reflection:failure` episode ([`record_failure_reflection`]);
 /// 2. capture whether a lesson *already* existed for this
 ///    `(goal_type, error_class)` **before** distilling — a failure that recurs
@@ -389,6 +457,19 @@ pub fn learn_from_verified_failures(
 
     for obs in failures {
         let error_class = normalize_error_class(&obs.error_class);
+
+        // Per-occurrence dedup (review #2510): a goal that stays blocked across
+        // cycles (e.g. a normal in-flight PR not yet merged) must not re-reflect
+        // every cycle — that would grow episodic memory without bound, distil a
+        // lesson from a single premature claim, and emit `brain_repeat_failure`
+        // every cycle. Skip an observation whose occurrence was already
+        // reflected; recurrence is measured across *distinct* occurrences.
+        if let Some(key) = &obs.occurrence_key
+            && occurrence_already_reflected(memory, key)
+        {
+            continue;
+        }
+
         let verdict = Verdict::VerifiedFailure {
             error_class: error_class.clone(),
         };
@@ -398,11 +479,12 @@ pub fn learn_from_verified_failures(
         // would mask the very recurrence we want to flag.
         let had_lesson = has_lesson_for(memory, &obs.objective, &error_class).unwrap_or(false);
 
-        let reflection_id = match record_failure_reflection(
+        let reflection_id = match record_failure_reflection_marked(
             memory,
             &obs.objective,
             &verdict,
             &default_failure_hint(&error_class),
+            obs.occurrence_key.as_deref(),
         ) {
             Ok(Some(id)) => {
                 report.reflections_recorded += 1;

--- a/src/memory_consolidation/reflection_lessons.rs
+++ b/src/memory_consolidation/reflection_lessons.rs
@@ -353,6 +353,13 @@ pub struct VerifiedFailureObservation {
     /// reflection — bounding the failure-reflection trail and keeping recurrence
     /// honest (distinct occurrences, not cycle count). `None` disables dedup, so
     /// every call is treated as a fresh occurrence.
+    ///
+    /// Intentionally the goal id **alone**, not `(id, error_class)`: a single
+    /// stuck attempt should reflect exactly once even if its refuting class
+    /// progresses across cycles (e.g. `pr_not_merged` → `not_deployed` after the
+    /// PR merges). Lesson distillation is unaffected by this choice — a lesson
+    /// requires recurrence across *distinct* goals, which always carry distinct
+    /// keys regardless of class.
     pub occurrence_key: Option<String>,
 }
 

--- a/src/memory_consolidation/tests_reflection_lessons.rs
+++ b/src/memory_consolidation/tests_reflection_lessons.rs
@@ -18,7 +18,8 @@
 //! module's inline `#[cfg(test)] mod tests`.
 
 use super::reflection_lessons::{
-    LESSON_RECURRENCE_THRESHOLD, Verdict, count_recurring_failures, has_lesson_for, lesson_name,
+    LESSON_RECURRENCE_THRESHOLD, LessonLearningReport, Verdict, VerifiedFailureObservation,
+    count_recurring_failures, has_lesson_for, learn_from_verified_failures, lesson_name,
     maybe_distill_lesson, record_failure_reflection,
 };
 use crate::cognitive_memory::{CognitiveMemoryOps, LibraryCognitiveMemory};
@@ -222,5 +223,151 @@ fn recurrence_count_is_key_scoped() {
     assert_eq!(
         count_recurring_failures(&m, "fix-ci-runner-flake", "cargo_test_failed").expect("ok"),
         1
+    );
+}
+
+// ── live wiring: learn_from_verified_failures (#2458 production trigger) ──────
+//
+// These pin the end-to-end loop the OODA curate phase drives from the FU1
+// (#2456) `Refuted` signal: verified failure → reflection → recurring lesson →
+// recall. They exercise the same `LibraryCognitiveMemory` backend the daemon
+// uses.
+
+const REFUTED_OBJECTIVE: &str = "Ship the websocket reconnect backoff for the dashboard";
+const REFUTED_CLASS: &str = "pr_not_merged";
+
+fn obs() -> VerifiedFailureObservation {
+    VerifiedFailureObservation::new(REFUTED_OBJECTIVE, REFUTED_CLASS)
+}
+
+/// A single verified failure writes a reflection but — below the recurrence
+/// threshold — distils no lesson (AC-4 + AC-6 through the live entry point).
+#[test]
+fn learn_from_verified_failures_one_off_reflects_no_lesson() {
+    let m = mem();
+    let report = learn_from_verified_failures(
+        &m,
+        std::slice::from_ref(&obs()),
+        LESSON_RECURRENCE_THRESHOLD,
+    );
+    assert_eq!(
+        report,
+        LessonLearningReport {
+            reflections_recorded: 1,
+            lessons_distilled: 0,
+            repeat_failures: 0,
+        }
+    );
+    assert!(
+        !has_lesson_for(&m, REFUTED_OBJECTIVE, REFUTED_CLASS).expect("ok"),
+        "a single refuted completion must not become a lesson"
+    );
+}
+
+/// `threshold` recurring verified failures distil exactly one recallable
+/// `lesson:` procedure (AC-5 + AC-7 through the live entry point).
+#[test]
+fn learn_from_verified_failures_recurrence_distills_recallable_lesson() {
+    let m = mem();
+    let batch = vec![obs(); LESSON_RECURRENCE_THRESHOLD as usize];
+
+    let report = learn_from_verified_failures(&m, &batch, LESSON_RECURRENCE_THRESHOLD);
+    assert_eq!(report.reflections_recorded, LESSON_RECURRENCE_THRESHOLD);
+    assert_eq!(
+        report.lessons_distilled, 1,
+        "recurrence crosses the threshold once"
+    );
+    assert_eq!(
+        report.repeat_failures, 0,
+        "no pre-existing lesson to regress against"
+    );
+
+    assert!(
+        has_lesson_for(&m, REFUTED_OBJECTIVE, REFUTED_CLASS).expect("ok"),
+        "the lesson must exist after the recurrence threshold is reached"
+    );
+    // A later objective sharing a goal-type token recalls the lesson.
+    let expected = lesson_name(REFUTED_OBJECTIVE, REFUTED_CLASS);
+    let recalled = m.recall_procedure("websocket", 10).expect("recall");
+    assert!(
+        recalled.iter().any(|p| p.name == expected),
+        "lesson {expected:?} must surface for a related objective; got {:?}",
+        recalled.iter().map(|p| &p.name).collect::<Vec<_>>()
+    );
+}
+
+/// A failure that recurs **after** a lesson already exists is counted as a
+/// self-regression (`repeat_failures`), not as a fresh lesson — the headline
+/// #2458 measurement that the repeat-failure rate can trend down against.
+#[test]
+fn learn_from_verified_failures_counts_repeat_after_lesson() {
+    let m = mem();
+    // First pass establishes the lesson.
+    let batch = vec![obs(); LESSON_RECURRENCE_THRESHOLD as usize];
+    let first = learn_from_verified_failures(&m, &batch, LESSON_RECURRENCE_THRESHOLD);
+    assert_eq!(first.lessons_distilled, 1);
+
+    // A subsequent failure on the same key recurs despite the lesson.
+    let second = learn_from_verified_failures(
+        &m,
+        std::slice::from_ref(&obs()),
+        LESSON_RECURRENCE_THRESHOLD,
+    );
+    assert_eq!(
+        second,
+        LessonLearningReport {
+            reflections_recorded: 1,
+            lessons_distilled: 0,
+            repeat_failures: 1,
+        },
+        "a recurrence past an existing lesson is a repeat-failure, not a new lesson"
+    );
+}
+
+/// One call carrying `threshold + 1` recurrences distils the lesson and flags
+/// the trailing recurrence as a repeat in the same pass.
+#[test]
+fn learn_from_verified_failures_distill_and_repeat_in_one_pass() {
+    let m = mem();
+    let batch = vec![obs(); LESSON_RECURRENCE_THRESHOLD as usize + 1];
+    let report = learn_from_verified_failures(&m, &batch, LESSON_RECURRENCE_THRESHOLD);
+    assert_eq!(report.reflections_recorded, LESSON_RECURRENCE_THRESHOLD + 1);
+    assert_eq!(report.lessons_distilled, 1);
+    assert_eq!(report.repeat_failures, 1);
+}
+
+/// An empty batch is a pure no-op (the common case: most cycles refute nothing).
+#[test]
+fn learn_from_verified_failures_empty_batch_is_noop() {
+    let m = mem();
+    let report = learn_from_verified_failures(&m, &[], LESSON_RECURRENCE_THRESHOLD);
+    assert!(report.is_empty());
+}
+
+/// A `threshold` of 0 falls back to the default so a misconfiguration cannot
+/// turn every one-off failure into a lesson.
+#[test]
+fn learn_from_verified_failures_threshold_zero_falls_back_to_default() {
+    let m = mem();
+    let report = learn_from_verified_failures(&m, std::slice::from_ref(&obs()), 0);
+    assert_eq!(
+        report.lessons_distilled, 0,
+        "threshold 0 must not distil a one-off"
+    );
+    assert!(!has_lesson_for(&m, REFUTED_OBJECTIVE, REFUTED_CLASS).expect("ok"));
+}
+
+/// Raw, un-normalized objective/error-class text is normalized into the same
+/// `(goal_type, error_class)` key the recall path uses.
+#[test]
+fn learn_from_verified_failures_normalizes_keys() {
+    let m = mem();
+    let raw = VerifiedFailureObservation::new("Ship The  WebSocket Reconnect!", "PR Not Merged");
+    let batch = vec![raw; LESSON_RECURRENCE_THRESHOLD as usize];
+    let report = learn_from_verified_failures(&m, &batch, LESSON_RECURRENCE_THRESHOLD);
+    assert_eq!(report.lessons_distilled, 1);
+    assert!(
+        has_lesson_for(&m, "Ship The  WebSocket Reconnect!", "PR Not Merged").expect("ok"),
+        "normalization must be consistent between store and lookup"
     );
 }

--- a/src/memory_consolidation/tests_reflection_lessons.rs
+++ b/src/memory_consolidation/tests_reflection_lessons.rs
@@ -371,3 +371,68 @@ fn learn_from_verified_failures_normalizes_keys() {
         "normalization must be consistent between store and lookup"
     );
 }
+
+/// Per-occurrence dedup: the **same** occurrence key re-observed across cycles
+/// reflects exactly once and never distils a lesson on its own — the bounded-
+/// growth guard for a goal that stays blocked (review #2510).
+#[test]
+fn learn_from_verified_failures_dedups_same_occurrence() {
+    let m = mem();
+    let one =
+        || VerifiedFailureObservation::deduped(REFUTED_OBJECTIVE, REFUTED_CLASS, "goal-stuck");
+
+    // First observation reflects once.
+    let first = learn_from_verified_failures(
+        &m,
+        std::slice::from_ref(&one()),
+        LESSON_RECURRENCE_THRESHOLD,
+    );
+    assert_eq!(first.reflections_recorded, 1);
+
+    // Re-observing the same occurrence many more times is a no-op.
+    for _ in 0..LESSON_RECURRENCE_THRESHOLD + 3 {
+        let again = learn_from_verified_failures(
+            &m,
+            std::slice::from_ref(&one()),
+            LESSON_RECURRENCE_THRESHOLD,
+        );
+        assert!(
+            again.is_empty(),
+            "a repeat observation of one occurrence must be a no-op"
+        );
+    }
+    assert_eq!(
+        count_recurring_failures(
+            &m,
+            "ship-the-websocket-reconnect-backoff-for-the-dashboard",
+            REFUTED_CLASS
+        )
+        .expect("ok"),
+        1,
+        "exactly one reflection survives for a single stuck occurrence"
+    );
+    assert!(
+        !has_lesson_for(&m, REFUTED_OBJECTIVE, REFUTED_CLASS).expect("ok"),
+        "one stuck occurrence is never a lesson"
+    );
+}
+
+/// Distinct occurrence keys of the same `(goal_type, error_class)` accumulate a
+/// genuine recurrence that distils a lesson — dedup bounds repeats, it does not
+/// suppress real cross-attempt recurrence.
+#[test]
+fn learn_from_verified_failures_distinct_occurrences_recur() {
+    let m = mem();
+    for i in 0..LESSON_RECURRENCE_THRESHOLD {
+        let obs = VerifiedFailureObservation::deduped(
+            REFUTED_OBJECTIVE,
+            REFUTED_CLASS,
+            format!("goal-{i}"),
+        );
+        learn_from_verified_failures(&m, std::slice::from_ref(&obs), LESSON_RECURRENCE_THRESHOLD);
+    }
+    assert!(
+        has_lesson_for(&m, REFUTED_OBJECTIVE, REFUTED_CLASS).expect("ok"),
+        "distinct occurrences of the same type must still distil a lesson"
+    );
+}

--- a/src/ooda_loop/cycle.rs
+++ b/src/ooda_loop/cycle.rs
@@ -1075,9 +1075,10 @@ fn learn_from_refuted_goals(
             )
         })
         .map(|(goal, missing)| {
-            VerifiedFailureObservation::new(
+            VerifiedFailureObservation::deduped(
                 goal.description.clone(),
                 crate::goal_curation::error_class_from_missing(missing),
+                goal.id.clone(),
             )
         })
         .collect();
@@ -1108,12 +1109,12 @@ mod tests_refuted_lessons {
 
     /// A goal carrying a tracked PR `wip_ref` — so `has_derivable_signal` holds
     /// and a `PrNotMerged` blocker classifies as `Refuted` (a real failure
-    /// signal), not `UnverifiedNoSignal`.
-    fn refuted_goal(desc: &str) -> ActiveGoal {
+    /// signal), not `UnverifiedNoSignal`. `id` is the per-occurrence dedup key.
+    fn refuted_goal(id: &str, desc: &str) -> ActiveGoal {
         ActiveGoal {
             parent_goal_id: None,
             repo: None,
-            id: "ship-reconnect-backoff".to_string(),
+            id: id.to_string(),
             description: desc.to_string(),
             priority: 1,
             status: GoalProgress::Completed,
@@ -1136,7 +1137,7 @@ mod tests_refuted_lessons {
     #[test]
     fn one_refuted_goal_reflects_but_no_lesson_yet() {
         let mem = LibraryCognitiveMemory::in_memory().expect("db");
-        let blocked = vec![(refuted_goal(DESC), vec![MissingEvidence::PrNotMerged])];
+        let blocked = vec![(refuted_goal("g1", DESC), vec![MissingEvidence::PrNotMerged])];
         learn_from_refuted_goals(&blocked, &mem, LESSON_RECURRENCE_THRESHOLD);
         assert!(
             !has_lesson_for(&mem, DESC, "pr_not_merged").expect("ok"),
@@ -1144,18 +1145,20 @@ mod tests_refuted_lessons {
         );
     }
 
-    /// The same goal refuted across enough cycles distils a recallable lesson —
-    /// the end-to-end loop the OODA curate phase drives.
+    /// **Distinct** goals of the same type, each refuted, accumulate a recurrence
+    /// that distils a recallable lesson — the end-to-end loop the OODA curate
+    /// phase drives across attempts.
     #[test]
     fn recurring_refutation_distills_recallable_lesson() {
         let mem = LibraryCognitiveMemory::in_memory().expect("db");
-        for _ in 0..LESSON_RECURRENCE_THRESHOLD {
-            let blocked = vec![(refuted_goal(DESC), vec![MissingEvidence::PrNotMerged])];
+        for i in 0..LESSON_RECURRENCE_THRESHOLD {
+            let id = format!("ship-attempt-{i}");
+            let blocked = vec![(refuted_goal(&id, DESC), vec![MissingEvidence::PrNotMerged])];
             learn_from_refuted_goals(&blocked, &mem, LESSON_RECURRENCE_THRESHOLD);
         }
         assert!(
             has_lesson_for(&mem, DESC, "pr_not_merged").expect("ok"),
-            "a recurring refutation must become a lesson"
+            "a recurring refutation across distinct goals must become a lesson"
         );
         let expected = lesson_name(DESC, "pr_not_merged");
         let recalled = mem.recall_procedure("reconnect", 10).expect("recall");
@@ -1166,6 +1169,26 @@ mod tests_refuted_lessons {
         );
     }
 
+    /// The **same** goal refuted across many cycles is one occurrence — it must
+    /// reflect exactly once and never distil a lesson on its own. This is the
+    /// bounded-growth guard: a normal in-flight PR (blocked but not yet merged)
+    /// cannot accrue an unbounded reflection trail or a per-cycle lesson.
+    #[test]
+    fn same_blocked_goal_across_cycles_reflects_once_and_no_lesson() {
+        let mem = LibraryCognitiveMemory::in_memory().expect("db");
+        for _ in 0..LESSON_RECURRENCE_THRESHOLD + 3 {
+            let blocked = vec![(
+                refuted_goal("g-stuck", DESC),
+                vec![MissingEvidence::PrNotMerged],
+            )];
+            learn_from_refuted_goals(&blocked, &mem, LESSON_RECURRENCE_THRESHOLD);
+        }
+        assert!(
+            !has_lesson_for(&mem, DESC, "pr_not_merged").expect("ok"),
+            "one goal stuck across many cycles is a single occurrence, never a lesson"
+        );
+    }
+
     /// A goal with **no** derivable signal classifies as `UnverifiedNoSignal`,
     /// not `Refuted`, so the glue must skip it entirely (no lesson accrues). A
     /// non-Simard repo with no PR/issue ref is not self-affecting, so no external
@@ -1173,16 +1196,16 @@ mod tests_refuted_lessons {
     #[test]
     fn no_signal_goal_is_skipped() {
         let mem = LibraryCognitiveMemory::in_memory().expect("db");
-        let no_signal_goal = || {
-            let mut g = refuted_goal(DESC);
+        let no_signal_goal = |i: u32| {
+            let mut g = refuted_goal(&format!("ns-{i}"), DESC);
             g.repo = Some("some-other-service".to_string()); // not Simard ⇒ not self-affecting
             g.wip_refs.clear(); // no PR/issue ⇒ nothing external to verify
             g
         };
-        // Even across enough passes to clear the threshold, nothing accrues
-        // because the goal is never a genuine (refuted) failure.
-        for _ in 0..LESSON_RECURRENCE_THRESHOLD + 1 {
-            let blocked = vec![(no_signal_goal(), vec![MissingEvidence::PrNotMerged])];
+        // Even across enough distinct goals to clear the threshold, nothing
+        // accrues because none is a genuine (refuted) failure.
+        for i in 0..LESSON_RECURRENCE_THRESHOLD + 1 {
+            let blocked = vec![(no_signal_goal(i), vec![MissingEvidence::PrNotMerged])];
             learn_from_refuted_goals(&blocked, &mem, LESSON_RECURRENCE_THRESHOLD);
         }
         assert!(
@@ -1196,9 +1219,9 @@ mod tests_refuted_lessons {
     #[test]
     fn could_not_verify_goal_is_skipped() {
         let mem = LibraryCognitiveMemory::in_memory().expect("db");
-        for _ in 0..LESSON_RECURRENCE_THRESHOLD + 1 {
+        for i in 0..LESSON_RECURRENCE_THRESHOLD + 1 {
             let blocked = vec![(
-                refuted_goal(DESC),
+                refuted_goal(&format!("cnv-{i}"), DESC),
                 vec![MissingEvidence::CouldNotVerify {
                     detail: "gh timeout".to_string(),
                 }],

--- a/src/ooda_loop/cycle.rs
+++ b/src/ooda_loop/cycle.rs
@@ -567,6 +567,20 @@ fn run_ooda_cycle_inner(
                         .join("; "),
                 );
             }
+
+            // #2458: close the failure→lesson loop on the FU1 (#2456) external
+            // signal. A goal the completion gate *refuted* (a derivable external
+            // postcondition contradicted the done-claim) is a genuine,
+            // non-self-judged failure — the only signal allowed to drive a
+            // Reflexion-style reflection (R10). Recurring refutations on the same
+            // (goal-type, error-class) distil into a `lesson:` procedure later
+            // objectives recall. Best-effort: never blocks curation.
+            learn_from_refuted_goals(
+                &blocked,
+                &*bridges.memory,
+                config.lesson_recurrence_threshold,
+            );
+
             archived
         }
         None => crate::goal_curation::archive_completed(&mut state.active_goals),
@@ -1022,6 +1036,180 @@ pub fn compose_procedure_name(
         }
     }
     format!("{pattern}:{scope} | triggers: {}", triggers.join(","))
+}
+
+/// Drive the #2458 failure→lesson loop from the FU1 (#2456) completion gate's
+/// blocked-goal list.
+///
+/// Filters `blocked` down to the goals the gate **refuted** — a derivable
+/// external postcondition contradicted the done-claim
+/// ([`VerificationOutcome::Refuted`](crate::goal_curation::VerificationOutcome)),
+/// the only failure signal allowed to drive a Reflexion-style reflection (R10).
+/// `UnverifiedNoSignal` (nothing to check) and `Error` (could-not-verify) goals
+/// are skipped: they are not genuine failures. Each refuted goal becomes a
+/// [`VerifiedFailureObservation`](crate::memory_consolidation::reflection_lessons::VerifiedFailureObservation)
+/// keyed by `(goal description, refuting error class)` and handed to
+/// [`learn_from_verified_failures`](crate::memory_consolidation::reflection_lessons::learn_from_verified_failures).
+///
+/// Best-effort and side-effecting only on cognitive memory; it never returns an
+/// error and never blocks curation. Extracted from the cycle body so the wiring
+/// is unit-testable against an in-memory backend.
+fn learn_from_refuted_goals(
+    blocked: &[(
+        crate::goal_curation::ActiveGoal,
+        Vec<crate::goal_curation::MissingEvidence>,
+    )],
+    memory: &dyn crate::cognitive_memory::CognitiveMemoryOps,
+    threshold: u32,
+) {
+    use crate::memory_consolidation::reflection_lessons::{
+        VerifiedFailureObservation, learn_from_verified_failures,
+    };
+
+    let verified_failures: Vec<VerifiedFailureObservation> = blocked
+        .iter()
+        .filter(|(goal, missing)| {
+            matches!(
+                crate::goal_curation::classify_from_missing(goal, missing),
+                crate::goal_curation::VerificationOutcome::Refuted
+            )
+        })
+        .map(|(goal, missing)| {
+            VerifiedFailureObservation::new(
+                goal.description.clone(),
+                crate::goal_curation::error_class_from_missing(missing),
+            )
+        })
+        .collect();
+
+    if verified_failures.is_empty() {
+        return;
+    }
+
+    let report = learn_from_verified_failures(memory, &verified_failures, threshold);
+    eprintln!(
+        "[simard] OODA curate: failure-reflection pass over {} refuted goal(s) — \
+         {} reflection(s), {} lesson(s) distilled, {} repeat-failure(s)",
+        verified_failures.len(),
+        report.reflections_recorded,
+        report.lessons_distilled,
+        report.repeat_failures,
+    );
+}
+
+#[cfg(test)]
+mod tests_refuted_lessons {
+    use super::learn_from_refuted_goals;
+    use crate::cognitive_memory::{CognitiveMemoryOps, LibraryCognitiveMemory};
+    use crate::goal_curation::{ActiveGoal, GoalProgress, MissingEvidence, WipRef};
+    use crate::memory_consolidation::reflection_lessons::{
+        LESSON_RECURRENCE_THRESHOLD, has_lesson_for, lesson_name,
+    };
+
+    /// A goal carrying a tracked PR `wip_ref` — so `has_derivable_signal` holds
+    /// and a `PrNotMerged` blocker classifies as `Refuted` (a real failure
+    /// signal), not `UnverifiedNoSignal`.
+    fn refuted_goal(desc: &str) -> ActiveGoal {
+        ActiveGoal {
+            parent_goal_id: None,
+            repo: None,
+            id: "ship-reconnect-backoff".to_string(),
+            description: desc.to_string(),
+            priority: 1,
+            status: GoalProgress::Completed,
+            assigned_to: None,
+            current_activity: None,
+            wip_refs: vec![WipRef {
+                kind: "pr".to_string(),
+                ref_id: "4242".to_string(),
+                label: "PR #4242".to_string(),
+                url: None,
+            }],
+            last_progress_update_at: None,
+        }
+    }
+
+    const DESC: &str = "Ship the websocket reconnect backoff for the dashboard";
+
+    /// A single refuted goal records a reflection but distils no lesson (below
+    /// the recurrence threshold). The cycle glue selected it as a real failure.
+    #[test]
+    fn one_refuted_goal_reflects_but_no_lesson_yet() {
+        let mem = LibraryCognitiveMemory::in_memory().expect("db");
+        let blocked = vec![(refuted_goal(DESC), vec![MissingEvidence::PrNotMerged])];
+        learn_from_refuted_goals(&blocked, &mem, LESSON_RECURRENCE_THRESHOLD);
+        assert!(
+            !has_lesson_for(&mem, DESC, "pr_not_merged").expect("ok"),
+            "one refutation is not yet a lesson"
+        );
+    }
+
+    /// The same goal refuted across enough cycles distils a recallable lesson —
+    /// the end-to-end loop the OODA curate phase drives.
+    #[test]
+    fn recurring_refutation_distills_recallable_lesson() {
+        let mem = LibraryCognitiveMemory::in_memory().expect("db");
+        for _ in 0..LESSON_RECURRENCE_THRESHOLD {
+            let blocked = vec![(refuted_goal(DESC), vec![MissingEvidence::PrNotMerged])];
+            learn_from_refuted_goals(&blocked, &mem, LESSON_RECURRENCE_THRESHOLD);
+        }
+        assert!(
+            has_lesson_for(&mem, DESC, "pr_not_merged").expect("ok"),
+            "a recurring refutation must become a lesson"
+        );
+        let expected = lesson_name(DESC, "pr_not_merged");
+        let recalled = mem.recall_procedure("reconnect", 10).expect("recall");
+        assert!(
+            recalled.iter().any(|p| p.name == expected),
+            "lesson {expected:?} must surface for a related objective; got {:?}",
+            recalled.iter().map(|p| &p.name).collect::<Vec<_>>()
+        );
+    }
+
+    /// A goal with **no** derivable signal classifies as `UnverifiedNoSignal`,
+    /// not `Refuted`, so the glue must skip it entirely (no lesson accrues). A
+    /// non-Simard repo with no PR/issue ref is not self-affecting, so no external
+    /// postcondition is derivable.
+    #[test]
+    fn no_signal_goal_is_skipped() {
+        let mem = LibraryCognitiveMemory::in_memory().expect("db");
+        let no_signal_goal = || {
+            let mut g = refuted_goal(DESC);
+            g.repo = Some("some-other-service".to_string()); // not Simard ⇒ not self-affecting
+            g.wip_refs.clear(); // no PR/issue ⇒ nothing external to verify
+            g
+        };
+        // Even across enough passes to clear the threshold, nothing accrues
+        // because the goal is never a genuine (refuted) failure.
+        for _ in 0..LESSON_RECURRENCE_THRESHOLD + 1 {
+            let blocked = vec![(no_signal_goal(), vec![MissingEvidence::PrNotMerged])];
+            learn_from_refuted_goals(&blocked, &mem, LESSON_RECURRENCE_THRESHOLD);
+        }
+        assert!(
+            !has_lesson_for(&mem, DESC, "pr_not_merged").expect("ok"),
+            "an unverifiable goal must never produce a lesson"
+        );
+    }
+
+    /// A `CouldNotVerify` blocker classifies as `Error`, never `Refuted` — the
+    /// glue skips it so an unverifiable cycle never fabricates a failure.
+    #[test]
+    fn could_not_verify_goal_is_skipped() {
+        let mem = LibraryCognitiveMemory::in_memory().expect("db");
+        for _ in 0..LESSON_RECURRENCE_THRESHOLD + 1 {
+            let blocked = vec![(
+                refuted_goal(DESC),
+                vec![MissingEvidence::CouldNotVerify {
+                    detail: "gh timeout".to_string(),
+                }],
+            )];
+            learn_from_refuted_goals(&blocked, &mem, LESSON_RECURRENCE_THRESHOLD);
+        }
+        assert!(
+            !has_lesson_for(&mem, DESC, "refuted_unknown").expect("ok"),
+            "an Error outcome must not drive the failure→lesson loop"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/tests/gadugi/failure-reflection-lesson-loop.yaml
+++ b/tests/gadugi/failure-reflection-lesson-loop.yaml
@@ -1,0 +1,117 @@
+name: "Brain self-improvement — Reflexion failure→lesson loop wired live"
+description: >
+  Outside-in gate for issue #2458 (Reflexion-style failure reflections distilled
+  into procedural lessons — closing the self-improvement loop). The reflection→
+  lesson *mechanics* landed in PR #2476; this scenario pins the remaining,
+  FU1-gated piece: the **live production trigger**. FU1 (#2456, the external-
+  signal completion gate) emits `VerificationOutcome::Refuted` — a false
+  completion where a *derivable external postcondition* (PR not merged, issue
+  open, self-change not deployed) contradicted the done-claim. The OODA curate
+  phase now wires that genuine, non-self-judged signal end-to-end:
+  `learn_from_refuted_goals` (`src/ooda_loop/cycle.rs`) →
+  `learn_from_verified_failures` (`src/memory_consolidation/reflection_lessons.rs`)
+  → reflection → recurrence-gated `lesson:` procedure → `brain_repeat_failure`.
+  The loop is NEVER gated on self-judged `ActionOutcome.success` (R10): an
+  `Unverified` / `Error` outcome is skipped. Backing tests live in
+  `src/ooda_loop/cycle.rs` (tests_refuted_lessons),
+  `src/memory_consolidation/tests_reflection_lessons.rs`, and
+  `src/goal_curation/completion_gate.rs` (error_class_from_missing).
+version: "1.0.0"
+
+config:
+  timeout: 300000
+  retries: 1
+  parallel: false
+
+environment:
+  requires: []
+
+agents:
+  - name: "test-agent"
+    type: "cli"
+    config:
+      workingDirectory: "."
+      defaultTimeout: 300000
+      executionMode: "spawn"
+      captureOutput: true
+      ioConfig:
+        encoding: "utf8"
+        handleInteractivePrompts: false
+      logConfig:
+        logCommands: true
+        logOutput: true
+        logLevel: "info"
+
+steps:
+  - name: "#2458 — live curate-phase wiring: refuted completion drives the failure→lesson loop"
+    agent: "test-agent"
+    action: "execute_command"
+    params:
+      command: >
+        cargo test --lib ooda_loop::cycle::tests_refuted_lessons
+        -- --nocapture --test-threads=1
+    timeout: 300000
+    expect:
+      exitCode: 0
+      outputContains:
+        - "test ooda_loop::cycle::tests_refuted_lessons::one_refuted_goal_reflects_but_no_lesson_yet ... ok"
+        - "test ooda_loop::cycle::tests_refuted_lessons::recurring_refutation_distills_recallable_lesson ... ok"
+        - "test ooda_loop::cycle::tests_refuted_lessons::no_signal_goal_is_skipped ... ok"
+        - "test ooda_loop::cycle::tests_refuted_lessons::could_not_verify_goal_is_skipped ... ok"
+        - "test result: ok."
+
+  - name: "#2458 — verified-failure batch: reflection, recurrence-gated lesson, repeat-failure metric"
+    agent: "test-agent"
+    action: "execute_command"
+    params:
+      command: >
+        cargo test --lib memory_consolidation::tests_reflection_lessons::learn_from_verified_failures
+        -- --nocapture --test-threads=1
+    timeout: 300000
+    expect:
+      exitCode: 0
+      outputContains:
+        - "test memory_consolidation::tests_reflection_lessons::learn_from_verified_failures_one_off_reflects_no_lesson ... ok"
+        - "test memory_consolidation::tests_reflection_lessons::learn_from_verified_failures_recurrence_distills_recallable_lesson ... ok"
+        - "test memory_consolidation::tests_reflection_lessons::learn_from_verified_failures_counts_repeat_after_lesson ... ok"
+        - "test memory_consolidation::tests_reflection_lessons::learn_from_verified_failures_distill_and_repeat_in_one_pass ... ok"
+        - "test memory_consolidation::tests_reflection_lessons::learn_from_verified_failures_empty_batch_is_noop ... ok"
+        - "test memory_consolidation::tests_reflection_lessons::learn_from_verified_failures_threshold_zero_falls_back_to_default ... ok"
+        - "test result: ok."
+
+  - name: "#2458 — error-class derivation from the gate's refuting evidence (FU1 bridge)"
+    agent: "test-agent"
+    action: "execute_command"
+    params:
+      command: >
+        cargo test --lib goal_curation::completion_gate::tests::error_class_from_missing
+        -- --nocapture --test-threads=1
+    timeout: 300000
+    expect:
+      exitCode: 0
+      outputContains:
+        - "test goal_curation::completion_gate::tests::error_class_from_missing_maps_each_kind_to_a_stable_token ... ok"
+        - "test goal_curation::completion_gate::tests::error_class_from_missing_excludes_could_not_verify ... ok"
+        - "test goal_curation::completion_gate::tests::error_class_from_missing_defaults_when_no_concrete_kind ... ok"
+        - "test result: ok."
+
+assertions: []
+
+cleanup:
+  - name: "Test agent cleanup"
+    agent: "test-agent"
+    action: "cleanup"
+
+metadata:
+  tags:
+    - "cli"
+    - "cognitive-memory"
+    - "self-improvement"
+    - "reflexion"
+    - "procedural-lessons"
+    - "ooda"
+    - "regression"
+    - "issue-2458"
+  priority: "high"
+  author: "copilot"
+  test_type: "outside-in"


### PR DESCRIPTION
## Summary

Closes #2458. The Reflexion-style failure→lesson **mechanics** landed in PR #2476, but the issue stayed open because the **production trigger was FU1-gated**: per the issue (and the *LLMs Cannot Self-Correct Yet* caveat, [2310.01798](https://arxiv.org/abs/2310.01798)) it must condition on a **genuine external** failure signal, never self-judged success (R10).

FU1 (#2456 — the external-signal completion gate) has since **landed and closed**. It emits `VerificationOutcome::Refuted`: a *false completion* where a derivable external postcondition (PR not merged, issue still open, self-change not deployed) **contradicted** the done-claim. This PR wires that signal end-to-end through the existing, tested reflection→lesson entry points at the OODA **curate** phase.

### What was missing (the gap)
- `record_failure_reflection` / `maybe_distill_lesson` / `record_repeat_failure` existed and were unit-tested, but had **zero live call sites**.
- `OodaConfig.lesson_recurrence_threshold` was defined but **consumed nowhere** — proof the failure half was unwired.

### Changes
- **`completion_gate.rs`**: add `error_class_from_missing(&[MissingEvidence]) -> String` — derive a normalized error-class key from the refuting evidence (`pr_not_merged`, `issue_open`, `not_deployed`; excludes `CouldNotVerify`, which is the `Error` outcome, never `Refuted`).
- **`reflection_lessons.rs`**: add `VerifiedFailureObservation`, `LessonLearningReport`, and `learn_from_verified_failures(memory, &[obs], threshold)` — record a reflection per verified failure, distil a recurrence-gated `lesson:` procedure, and emit `brain_repeat_failure` when a failure recurs on a goal-type that already carries a lesson. Best-effort per item; never returns `Err`.
- **`ooda_loop/cycle.rs`**: `learn_from_refuted_goals` filters blocked completions to `Refuted`, maps each to an observation, and drives the loop with `config.lesson_recurrence_threshold`. `Unverified`/`Error` outcomes are **skipped** (R10 — no self-judged gate).
- **Docs**: `docs/reference/procedural-learning-loop.md` updated from "FU1-gated" to **as-built** (OODA wiring, backward-compat, AC table incl. new AC-12).

## Merge-ready evidence

### 1. qa-team scenarios (gadugi-test)
New outside-in scenario `tests/gadugi/failure-reflection-lesson-loop.yaml`.
- `gadugi-test validate -f … --strict` → **valid** (1 valid, 0 invalid).
- `gadugi-test run -d tests/gadugi -s failure-reflection-lesson-loop` → **✓ Passed: 1, Failed: 0** (all 3 steps exit 0, expected test-name lines matched).

### 2. Docs
`docs/reference/procedural-learning-loop.md` updated for the now-live trigger (the only user-facing surface touched is internal Rust API + an `eprintln` curate-log line; no CLI/public-API change).

### 3. quality-audit (≥3 SEEK→VALIDATE→FIX cycles)
See PR comment with the audit log (3 cycles, ending clean: zero critical/high; zero medium correctness/security).

### 4. CI
Local parity green:
- `cargo fmt --all -- --check` → **OK**
- `cargo clippy --all-targets --all-features --locked -- -D warnings` → **clean** (pre-push hook Passed)
- `cargo test --release --lib (cognitive_memory|bootstrap|memory_ipc|memory_consolidation)` → **Passed** (pre-push hook)
- Affected modules `cargo test --lib memory_consolidation goal_curation::completion_gate ooda_loop::cycle` → **237 passed; 0 failed**

### 5. Evidence
This section + the linked quality-audit comment.

### 6. Focused diff
7 source/doc files + 1 new scenario; no unrelated edits. All new behavior is gated on the external `Refuted` signal and is a no-op when no completion is refuted.

## New tests
- `goal_curation::completion_gate::tests::error_class_from_missing_*` (5)
- `memory_consolidation::tests_reflection_lessons::learn_from_verified_failures_*` (7)
- `ooda_loop::cycle::tests_refuted_lessons::*` (4) — hermetic cycle-glue integration against `LibraryCognitiveMemory::in_memory()`

## Honest limits
R10 preserved: the failure path is gated **exclusively** on the gate's external refutation. The skill (success) path's verified-signal gate still ships ready for an engineer-loop `VerificationReport` seam (unchanged here). No live redeploy / snapshot change.