### PR TITLE
fix(distill): recover facts when launch banner precedes the recipe-runner envelope + first-class distill_parse_success_rate (#2512)

### DIFF
--- a/docs/architecture/episode-distillation.md
+++ b/docs/architecture/episode-distillation.md
@@ -447,16 +447,25 @@ failure_class, input_count, fact_count}`:
 
 ```
 distill_success_rate       = mean(value)                          over ran passes
-distill_parse_success_rate = Σ parse_success / Σ parse_attempted  over ran passes
+distill_parse_success_rate = mean(value)                          over passes that reached parsing
 ```
 
-`distill_parse_success_rate` isolates the "recipe exited 0 but its output was
-unparseable" mode (`failure_class = parse-failure`, t=7517) from the "recipe
-process exited non-zero" mode (`copilot-terminal-failure`, t=7411): only runs
-that reached parsing (`parse_attempted = true`) count toward its denominator.
-Because the data lives in `metrics.jsonl` (operator runtime state, queryable
-via `self_metrics::query_metrics`), the rates are computed over a rolling
-window — no point-in-time findings doc is committed.
+`distill_parse_success_rate` is emitted as a **first-class metric**
+(issue [#2512](https://github.com/rysweet/Simard/issues/2512)) for the subset
+of passes that actually reached output parsing (`parse_attempted == true`), so
+its plain mean is exactly successes-vs-attempts — no post-hoc filtering of
+`distill_success_rate` events is needed (the older `parse_attempted` /
+`parse_success` context flags remain for back-compatible derivation). It
+isolates the "recipe exited 0 but its output was unparseable" mode
+(`failure_class = parse-failure`, t=7517 — including the #2512
+launch-banner-prefixed *envelope*) from the "recipe process exited non-zero"
+mode (`copilot-terminal-failure`, t=7411) and the "exited 0 but no step output"
+mode (`recipe-reported-failure`), which never reached parsing and emit **no**
+parse-rate event. This is the rate the launch-banner parse fixes (#2496/#2504/
+#2512) drive toward `1.0`, mirroring how #2504 was validated for the
+decide/orient brain. Because the data lives in `metrics.jsonl` (operator
+runtime state, queryable via `self_metrics::query_metrics`), the rates are
+computed over a rolling window — no point-in-time findings doc is committed.
 
 The companion robustness fix is parser-side: `scan_for_facts_object` now
 returns the facts from the **last non-empty** balanced `{...}` object that

--- a/docs/reference/distill-recipe-output-capture.md
+++ b/docs/reference/distill-recipe-output-capture.md
@@ -282,10 +282,32 @@ first that yields a facts object:
 **Tier 1 — runner envelope (the production path).**
 
 1. Deserialize stdout as `RecipeRunnerEnvelope`.
+   - **Tier 1a (fast path):** parse the trimmed stdout directly. Clean
+     production output (the envelope is the first byte) parses here with zero
+     extra work.
+   - **Tier 1b (noise-tolerant recovery, [#2512](https://github.com/rysweet/Simard/issues/2512)):**
+     if the direct parse fails, recover the envelope through the **shared**
+     `recipe_output` chokepoint (`recover_runner_envelope`). The copilot
+     subprocess prints its launch banner (`ℹ NODE_OPTIONS=…`,
+     `launching copilot binary=… version="GitHub Copilot CLI …"`,
+     `Run 'copilot update'…`) and intermittent ANSI tracing lines to the
+     **inherited stdout *before*** recipe-runner-rs emits its JSON envelope, so
+     the captured stdout **begins with the banner instead of the `{`** and the
+     Tier-1a parse rejects it — losing the envelope and its escaped facts
+     payload. Tier 1b strips that preamble (the same `strip_recipe_noise` +
+     `strip_ansi` dual view + string-aware `balanced_objects` end-first scan the
+     inner step-output path uses) and recovers the envelope. This is the
+     *outer-envelope* analog of the inner step-output banner stripping below,
+     and of the #2504 decide/orient launch-banner fix. A leading non-envelope
+     log record (e.g. `{"level":"info",…}`) lacks `success`/`step_results`, so
+     it is never mistaken for the envelope.
 2. If `success == false`, return `Err` immediately — never extract facts
    from a failed run. (Defense-in-depth: a failed run already exits non-zero,
    so `invoke_recipe`'s exit-code guard normally returns `Err` before this
-   point — see [Failure semantics](#failure-semantics).)
+   point — see [Failure semantics](#failure-semantics).) A banner-prefixed
+   `success == false` envelope recovered by Tier 1b still routes here (it is
+   *committed to* once recovered), so it surfaces a `RecipeReportedFailure`,
+   never a silent drop.
 3. Select the step: the entry with `step_id == "distill"`; if absent,
    the **last** entry with `status == "completed"`. (The `step_id` rule
    pins to the recipe's named step; the last-completed fallback tolerates
@@ -379,6 +401,7 @@ cycle.
 | Envelope `success == false` *with* exit `0`            | parser Tier 1 guard → `Err` (defense-in-depth)         | non-fatal; no markers set; retry next pass     |
 | No completed `distill` step                            | parser Tier 1 → `Err`                                  | non-fatal; no markers set; retry next pass     |
 | `output` present but no parseable facts object         | parser Tier 3 → `Err`                                  | non-fatal; no markers set; retry next pass     |
+| Launch-banner / ANSI noise **before** the envelope `{` | parser Tier 1b recovery → `Ok(DistillOutput { … })`    | facts stored ([#2512](https://github.com/rysweet/Simard/issues/2512)) |
 | Valid envelope, facts extracted                        | parser Tier 1 → `Ok(DistillOutput { … })`              | facts stored; **every** input episode marked   |
 
 Every `Err` is mapped to a non-fatal log line at

--- a/src/memory_consolidation/distillation.rs
+++ b/src/memory_consolidation/distillation.rs
@@ -750,7 +750,9 @@ fn build_distill_success_context(
     .to_string()
 }
 
-/// Record one `distill_success_rate` metric event for one distillation pass.
+/// Record the per-pass distill reliability metrics: `distill_success_rate` for
+/// every pass that ran the recipe, plus a first-class `distill_parse_success_rate`
+/// for the subset that reached output parsing (issue #2512).
 ///
 /// **Scope: the recipe + output-parse stage** — exactly the failure surface of
 /// issue #2461 (the distill *recipe* exiting non-zero, or exiting 0 with
@@ -765,12 +767,15 @@ fn build_distill_success_context(
 /// `record_reliability_gate_metric`, which likewise covers only the recipe pass.)
 ///
 /// The metric `value` is `1.0` on success and `0.0` on a recipe/parse failure,
-/// so the mean over passes is the success rate. The context's `parse_attempted`
-/// / `parse_success` flags additionally yield `distill_parse_success_rate`,
-/// isolating the "exited 0 but unparseable" mode (#2461 t=7517) from the
-/// "exited non-zero" mode (t=7411). This makes the previously-silent non-fatal
-/// distill failures visible in `metrics.jsonl` without committing any
-/// point-in-time findings.
+/// so the mean over passes is the success rate. `distill_parse_success_rate` is
+/// emitted ONLY for passes that reached parsing (`parse_attempted == true`), so
+/// its plain mean is exactly the parse-success rate — isolating the "exited 0 but
+/// unparseable" mode (#2461 t=7517, plus the #2512 launch-banner-prefixed
+/// envelope) from the "exited non-zero" mode (t=7411), which never reached
+/// parsing and emits no parse-rate event. Both share the same context payload
+/// (`parse_attempted` / `parse_success` flags remain for back-compatible
+/// derivation). This makes the previously-silent non-fatal distill failures
+/// visible in `metrics.jsonl` without committing any point-in-time findings.
 ///
 /// Best-effort: a metrics-write failure is logged, never propagated. No-op
 /// under `cfg!(test)` so unit tests never append to the operator's real
@@ -800,6 +805,28 @@ fn record_distill_success_metric(
             target: "simard::distill",
             error = %e,
             "failed to record distill_success_rate metric (distillation unaffected)",
+        );
+    }
+
+    // First-class `distill_parse_success_rate` (issue #2512). Previously this
+    // rate was only *derivable* by post-filtering `distill_success_rate` events
+    // on `parse_attempted == true` — fragile and easy to compute wrong. Emit a
+    // dedicated event ONLY for passes that actually reached output parsing
+    // (`parse_attempted`), so the simple mean of `distill_parse_success_rate`
+    // values is exactly the parse-success rate (successes vs. parse attempts).
+    // This is the metric the launch-banner parse fix drives toward 1.0, mirroring
+    // how #2504 was validated for the decide/orient brain. Recipe-reported /
+    // terminal / spawn / serialize failures never reached parsing and are
+    // intentionally excluded from the denominator (they emit no parse-rate event).
+    let parse_attempted = success || class.is_some_and(|c| c.reached_parsing());
+    if parse_attempted
+        && let Err(e) =
+            crate::self_metrics::record_metric("distill_parse_success_rate", value, &context)
+    {
+        tracing::warn!(
+            target: "simard::distill",
+            error = %e,
+            "failed to record distill_parse_success_rate metric (distillation unaffected)",
         );
     }
 }
@@ -1037,7 +1064,10 @@ pub(crate) fn parse_recipe_output(raw: &str) -> SimardResult<Vec<DistilledFact>>
 ///    step's `output` — which is itself a JSON *string* that may carry leading
 ///    prose (e.g. a `NODE_OPTIONS` banner) before the `{ "facts": ... }`
 ///    object, so we balanced-brace scan it. A future runner that emits `output`
-///    as a JSON object is handled too.
+///    as a JSON object is handled too. The envelope itself is recovered even
+///    when the captured stdout **begins with** a Copilot CLI launch banner /
+///    ANSI / tracing-log preamble *before* the JSON (issue #2512) — see
+///    [`recover_runner_envelope`].
 /// 2. **Bare-object fallback.** If stdout is not a runner envelope, scan it
 ///    directly for an embedded `{ "facts": ... }` object. Keeps the legacy
 ///    fact-only mock/unit-test contract (and prose-wrapped agent output)
@@ -1049,10 +1079,29 @@ pub(crate) fn parse_recipe_output(raw: &str) -> SimardResult<Vec<DistilledFact>>
 pub(crate) fn parse_recipe_output_full(raw: &str) -> SimardResult<DistillOutput> {
     let trimmed = raw.trim();
 
-    // Tier 1 — recipe-runner-rs JSON envelope. `RecipeRunnerEnvelope` requires
-    // both `success` and `step_results`, so a bare `{ "facts": ... }` object
-    // (which has neither) fails this parse and falls through to Tier 2.
+    // Tier 1a — fast path: stdout IS the recipe-runner JSON envelope (clean
+    // production output). `RecipeRunnerEnvelope` requires both `success` and
+    // `step_results`, so a bare `{ "facts": ... }` object (which has neither)
+    // fails this parse and falls through to Tier 2.
     if let Ok(envelope) = serde_json::from_str::<RecipeRunnerEnvelope>(trimmed) {
+        return envelope.into_distill_output();
+    }
+
+    // Tier 1b — noise-tolerant envelope recovery (issue #2512). The copilot
+    // subprocess prints its `NODE_OPTIONS` / `launching copilot binary` launch
+    // banner (and, intermittently, ANSI-coloured tracing lines) to the inherited
+    // stdout *before* recipe-runner-rs emits its JSON envelope, so the captured
+    // stdout begins with the banner instead of the `{`. The fast Tier-1a
+    // `serde_json::from_str` rejects that leading banner and the whole envelope —
+    // including its escaped `{ "facts": [...] }` payload — was otherwise lost,
+    // producing the recurring `distill failed (non-fatal): … did not yield a
+    // parseable { "facts": [...] } object` and silently deferring the batch. We
+    // recover the envelope through the SAME shared `recipe_output` chokepoint the
+    // inner step-output scan uses (the #2504 launch-banner fix), so a
+    // banner-prefixed envelope still parses. Committing to the recovered envelope
+    // (rather than falling through) preserves the `success == false` →
+    // `RecipeReportedFailure` contract for a banner-prefixed failed run.
+    if let Some(envelope) = recover_runner_envelope(trimmed) {
         return envelope.into_distill_output();
     }
 
@@ -1067,6 +1116,66 @@ pub(crate) fn parse_recipe_output_full(raw: &str) -> SimardResult<DistillOutput>
         "distill: recipe run did not yield a parseable {{ \"facts\": [...] }} object: {}",
         truncate(raw, 200)
     )))
+}
+
+/// Recover a [`RecipeRunnerEnvelope`] from recipe-runner stdout whose JSON
+/// envelope is buried behind a Copilot CLI launch-banner / ANSI / tracing-log
+/// preamble (issue #2512).
+///
+/// In production the copilot agent subprocess prints its launch banner — the
+/// `ℹ … NODE_OPTIONS=… (saved preference)` marker, the `… launching copilot
+/// binary=… version="GitHub Copilot CLI …"` line, and the `Run 'copilot update'
+/// …` nag (Copilot CLI `1.0.66-2`) — to the inherited stdout *before* the
+/// recipe-runner emits its `{ "recipe_name", "success", "step_results": … }`
+/// envelope. The captured stdout therefore begins with the banner, so the fast
+/// `serde_json::from_str::<RecipeRunnerEnvelope>` in [`parse_recipe_output_full`]
+/// rejects it and the envelope (with its escaped facts payload) is lost. This is
+/// the *outer-envelope* analog of the inner step-output banner contamination
+/// that [`scan_for_facts_object`] already strips.
+///
+/// The recovery reuses the SAME shared `recipe_output` chokepoint (the #2504
+/// `is_copilot_launcher_line` / `strip_recipe_noise` fix) so there is no
+/// parallel banner cleaner. Two cleaned views are tried, mirroring
+/// [`scan_for_facts_object`]:
+///
+/// 1. [`strip_recipe_noise`](crate::recipe_output::strip_recipe_noise) — strips
+///    ANSI escapes AND drops whole launcher/log/banner lines (recovers an
+///    envelope sitting on its own line after the banner lines).
+/// 2. [`strip_ansi`](crate::recipe_output::strip_ansi) — line-preserving
+///    (recovers an envelope that shares a physical line with a leading banner
+///    token, which view 1 would drop wholesale).
+///
+/// Within each view the string-aware
+/// [`balanced_objects`](crate::recipe_output::balanced_objects) scan is walked
+/// from the END, keeping the LAST span that deserializes as a runner envelope,
+/// so a leading non-envelope log record (e.g. a `{"level":"info",…}` line the
+/// agent emitted before the envelope) cannot shadow the real envelope that
+/// trails it. A bare `{ "facts": [...] }` object lacks both required envelope
+/// fields, so it never matches here and correctly falls through to the Tier-2
+/// bare-object path.
+fn recover_runner_envelope(trimmed: &str) -> Option<RecipeRunnerEnvelope> {
+    for cleaned in [
+        crate::recipe_output::strip_recipe_noise(trimmed),
+        crate::recipe_output::strip_ansi(trimmed),
+    ] {
+        let view = cleaned.trim();
+        // Fast path within the cleaned view — it IS the envelope (banner lines
+        // dropped, nothing trailing).
+        if let Ok(envelope) = serde_json::from_str::<RecipeRunnerEnvelope>(view) {
+            return Some(envelope);
+        }
+        // Slow path — among every balanced top-level object (string-aware),
+        // scanned from the end, keep the last that parses as a runner envelope.
+        for span in crate::recipe_output::balanced_objects(view)
+            .into_iter()
+            .rev()
+        {
+            if let Ok(envelope) = serde_json::from_str::<RecipeRunnerEnvelope>(span) {
+                return Some(envelope);
+            }
+        }
+    }
+    None
 }
 
 /// Scan `text` for a balanced `{...}` substring that deserializes as a
@@ -2021,6 +2130,192 @@ mod issue_2496_distill_launcher_tests {
         assert_eq!(out.facts.len(), 1, "exactly one fact recovered");
         assert_eq!(out.facts[0].concept, "bug-pattern");
         assert_eq!(out.facts[0].source_episode_id, "epi_2496");
+    }
+}
+
+/// Issue #2512: recover facts when the captured `recipe-runner-rs` stdout
+/// **begins with** the Copilot CLI launch banner *before* the JSON envelope.
+///
+/// The existing #2496 tests above pin the banner contaminating the **inner**
+/// `distill` step `output` string. This module pins the distinct, residual
+/// **outer-envelope** contamination: the copilot subprocess prints its launch
+/// preamble to the inherited stdout *before* recipe-runner-rs emits its
+/// `{ "recipe_name", "success", "step_results": … }` envelope, so the captured
+/// stdout starts with the banner and the fast Tier-1a `serde_json::from_str`
+/// rejects it. `recover_runner_envelope` (Tier 1b) recovers the envelope through
+/// the SAME shared `recipe_output` chokepoint the #2504 decide/orient fix uses.
+#[cfg(test)]
+mod issue_2512_outer_envelope_banner_tests {
+    use super::*;
+
+    /// The canonical production envelope, facts inlined.
+    fn envelope_with_facts() -> String {
+        serde_json::json!({
+            "recipe_name": "distill-episodes",
+            "success": true,
+            "step_results": [{
+                "step_id": "distill",
+                "status": "completed",
+                "output": r#"{"facts":[{"concept":"bug-pattern","content":"outer envelope banner must be stripped","source_episode_id":"epi_2512"}]}"#,
+                "error": ""
+            }]
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn recovers_facts_when_bare_launch_banner_precedes_envelope() {
+        // The exact #2504 launch banner shapes (no ISO-8601 timestamp), prefixed
+        // to the captured stdout BEFORE the recipe-runner envelope `{`.
+        let raw = format!(
+            "\u{2139} NODE_OPTIONS=--max-old-space-size=32768 (saved preference). \
+             To change: /home/azureuser/.amplihack/config\n\
+             INFO launching copilot binary=/home/azureuser/.npm-global/bin/copilot \
+             version=\"GitHub Copilot CLI 1.0.66-2.\"\n\
+             Run 'copilot update' to check for updates.\n\
+             {}",
+            envelope_with_facts()
+        );
+        // The raw stdout must NOT parse as an envelope directly (the silent-drop
+        // failure mode this issue fixes).
+        assert!(
+            serde_json::from_str::<RecipeRunnerEnvelope>(raw.trim()).is_err(),
+            "banner-prefixed stdout must be unparseable as a bare envelope"
+        );
+        let out = parse_recipe_output_full(&raw)
+            .expect("issue #2512 banner-prefixed envelope must parse");
+        assert_eq!(out.facts.len(), 1, "exactly one fact recovered");
+        assert_eq!(out.facts[0].concept, "bug-pattern");
+        assert_eq!(
+            out.facts[0].content,
+            "outer envelope banner must be stripped"
+        );
+        assert_eq!(out.facts[0].source_episode_id, "epi_2512");
+    }
+
+    #[test]
+    fn recovers_facts_when_ansi_log_line_precedes_envelope() {
+        // An ANSI-coloured tracing log line (dimmed `\x1b[2m<timestamp>` prefix)
+        // before the envelope — the line-dropping `strip_recipe_noise` view
+        // removes it and recovers the envelope on its own line.
+        let esc = '\u{1b}';
+        let raw = format!(
+            "{esc}[2m2026-06-30T18:00:00.000Z{esc}[0m {esc}[32m INFO{esc}[0m simard::distill: run\n{}",
+            envelope_with_facts()
+        );
+        let out = parse_recipe_output_full(&raw)
+            .expect("issue #2512 ANSI-log-prefixed envelope must parse");
+        assert_eq!(out.facts.len(), 1);
+        assert_eq!(out.facts[0].source_episode_id, "epi_2512");
+    }
+
+    #[test]
+    fn recovers_envelope_sharing_a_line_with_a_banner_token() {
+        // The banner token and the envelope share ONE physical line — the
+        // line-dropping view would discard the envelope wholesale, so the
+        // line-preserving `strip_ansi` view + balanced-object scan must recover
+        // it (the dual-view guarantee).
+        let raw = format!(
+            "INFO launching copilot binary=copilot {}",
+            envelope_with_facts()
+        );
+        let out = parse_recipe_output_full(&raw)
+            .expect("issue #2512 same-line banner+envelope must parse");
+        assert_eq!(out.facts.len(), 1);
+        assert_eq!(out.facts[0].source_episode_id, "epi_2512");
+    }
+
+    #[test]
+    fn leading_non_envelope_log_record_does_not_shadow_the_real_envelope() {
+        // A complete, brace-balanced `{"level":...}` log record precedes the
+        // envelope. It lacks `success`/`step_results`, so it must not be mistaken
+        // for the envelope; the end-first scan reaches the real envelope.
+        let raw = format!(
+            "{}\n{}",
+            r#"{"level":"info","msg":"session started","cwd":"/repo"}"#,
+            envelope_with_facts()
+        );
+        let out = parse_recipe_output_full(&raw)
+            .expect("issue #2512 leading log-record + envelope must parse");
+        assert_eq!(out.facts.len(), 1);
+        assert_eq!(out.facts[0].source_episode_id, "epi_2512");
+    }
+
+    #[test]
+    fn banner_prefixed_failed_envelope_reports_recipe_failure_not_silent_drop() {
+        // A banner-prefixed envelope with `success == false` must surface a
+        // RecipeReportedFailure (committed-to recovery), NOT silently fall
+        // through to a generic "did not yield a parseable" error.
+        let envelope = serde_json::json!({
+            "recipe_name": "distill-episodes",
+            "success": false,
+            "step_results": [{
+                "step_id": "distill",
+                "status": "failed",
+                "output": "",
+                "error": "agent timed out"
+            }]
+        })
+        .to_string();
+        let raw = format!(
+            "INFO launching copilot binary=copilot \
+             version=\"GitHub Copilot CLI 1.0.66-2.\"\n{envelope}"
+        );
+        let err = parse_recipe_output_full(&raw)
+            .expect_err("a success=false envelope must be an error, even banner-prefixed");
+        assert_eq!(
+            classify_distill_error(&err),
+            DistillFailureClass::RecipeReportedFailure,
+            "banner-prefixed failed run classifies as recipe-reported, not parse-failure"
+        );
+    }
+
+    #[test]
+    fn clean_envelope_with_no_banner_still_parses() {
+        // The fast Tier-1a path is unchanged for clean production stdout.
+        let out = parse_recipe_output_full(&envelope_with_facts())
+            .expect("clean envelope must still parse via the fast path");
+        assert_eq!(out.facts.len(), 1);
+        assert_eq!(out.facts[0].source_episode_id, "epi_2512");
+    }
+
+    #[test]
+    fn recovers_facts_from_compound_outer_and_inner_banner_contamination() {
+        // Worst case: the launch banner contaminates BOTH the outer stdout
+        // (before the envelope) AND the inner `distill` step output (before the
+        // facts). The inner banner is escaped inside the envelope's single-line
+        // `output`, so the whole compact envelope line itself *contains*
+        // `launching copilot binary=` — which makes the line-dropping
+        // `strip_recipe_noise` view discard the entire envelope. The
+        // line-preserving `strip_ansi` view must then recover the envelope
+        // (string-aware balanced scan), and the inner step-output scan strips the
+        // inner banner to reach the facts. This pins the dual-view interaction
+        // end-to-end.
+        let inner = "INFO launching copilot binary=/home/azureuser/.npm-global/bin/copilot \
+             version=\"GitHub Copilot CLI 1.0.66-2.\"\n\
+             {\"facts\":[{\"concept\":\"lesson-learned\",\
+             \"content\":\"dual-view recovers compound banner contamination\",\
+             \"source_episode_id\":\"epi_compound\"}]}";
+        let envelope = serde_json::json!({
+            "recipe_name": "distill-episodes",
+            "success": true,
+            "step_results": [{
+                "step_id": "distill",
+                "status": "completed",
+                "output": inner,
+                "error": ""
+            }]
+        })
+        .to_string();
+        let raw = format!(
+            "\u{2139} NODE_OPTIONS=--max-old-space-size=32768 (saved preference). To change: cfg\n\
+             Run 'copilot update' to check for updates.\n{envelope}"
+        );
+        let out = parse_recipe_output_full(&raw)
+            .expect("compound outer+inner banner contamination must still parse");
+        assert_eq!(out.facts.len(), 1);
+        assert_eq!(out.facts[0].concept, "lesson-learned");
+        assert_eq!(out.facts[0].source_episode_id, "epi_compound");
     }
 }
 

--- a/tests/gadugi/distill-parser-outer-envelope-banner.yaml
+++ b/tests/gadugi/distill-parser-outer-envelope-banner.yaml
@@ -1,0 +1,90 @@
+name: "Distill Parser Recovers Facts When Launch Banner Precedes the Envelope"
+description: >
+  Outside-in regression gate for issue #2512 — the distill-side analog of the
+  #2504 decide/orient launch-banner fix. The Copilot CLI subprocess prints its
+  launch preamble (the `NODE_OPTIONS` (saved preference) marker, the
+  `launching copilot binary=... version="GitHub Copilot CLI ..."` line, and the
+  `Run 'copilot update'...` nag) and intermittent ANSI tracing lines to the
+  inherited stdout BEFORE recipe-runner-rs emits its `--output-format json`
+  envelope. The captured stdout therefore BEGINS WITH the banner instead of the
+  `{` of the envelope, so the fast Tier-1a `serde_json` envelope parse rejected
+  it and the whole 20-episode batch silently deferred with
+  `distill failed (non-fatal): ... did not yield a parseable { "facts": [...] }`.
+  Tier-1b (`recover_runner_envelope`) now recovers the envelope through the same
+  shared `recipe_output` chokepoint, so a banner-prefixed envelope still yields
+  non-empty facts. This scenario pins the outer-envelope banner shapes
+  end-to-end so they cannot regress, and confirms the first-class
+  `distill_parse_success_rate` metric path stays green.
+version: "1.0.0"
+
+config:
+  timeout: 600000
+  retries: 1
+  parallel: false
+
+environment:
+  requires: []
+
+agents:
+  - name: "test-agent"
+    type: "cli"
+    config:
+      workingDirectory: "."
+      defaultTimeout: 600000
+      executionMode: "spawn"
+      captureOutput: true
+      ioConfig:
+        encoding: "utf8"
+        handleInteractivePrompts: false
+      logConfig:
+        logCommands: true
+        logOutput: true
+        logLevel: "info"
+
+steps:
+  - name: "Distill parser recovers facts when the launch banner precedes the envelope (#2512)"
+    agent: "test-agent"
+    action: "execute_command"
+    params:
+      command: >
+        cargo test --lib
+        issue_2512_outer_envelope_banner_tests
+        -- --nocapture
+    timeout: 600000
+    expect:
+      exitCode: 0
+      outputContains:
+        - "recovers_facts_when_bare_launch_banner_precedes_envelope ... ok"
+        - "banner_prefixed_failed_envelope_reports_recipe_failure_not_silent_drop ... ok"
+        - "test result: ok"
+
+  - name: "Full distillation parser contract still green (no regression)"
+    agent: "test-agent"
+    action: "execute_command"
+    params:
+      command: >
+        cargo test --lib memory_consolidation::distillation
+        -- --nocapture
+    timeout: 600000
+    expect:
+      exitCode: 0
+      outputContains:
+        - "test result: ok"
+
+assertions: []
+
+cleanup:
+  - name: "CLI agent cleanup"
+    agent: "test-agent"
+    action: "cleanup"
+
+metadata:
+  tags:
+    - "cli"
+    - "memory"
+    - "distillation"
+    - "regression"
+    - "issue-2512"
+  priority: "high"
+  author: "copilot"
+  test_type: "outside-in"


### PR DESCRIPTION
## Problem

Steady-state OODA consolidation cycles kept emitting:

```
distill failed (non-fatal): bridge error: distill: … did not contain a parseable { "facts": [...] } object
```

The GitHub Copilot CLI (`1.0.66-2`) prints its launch preamble to the **inherited stdout** *before* the agent's real answer:

```
ℹ NODE_OPTIONS=--max-old-space-size=32768 (saved preference). To change: …
INFO launching copilot binary=/…/copilot version="GitHub Copilot CLI 1.0.66-2."
Run 'copilot update' to check for updates.
```

#2496/#2504/#2484 already strip this banner when it contaminates the **inner `distill` step output**. The residual gap (this PR): when the banner prefixes the **outer `recipe-runner-rs` JSON envelope** itself — the captured stdout *begins with* the banner instead of the `{` — the fast `serde_json::from_str::<RecipeRunnerEnvelope>` in `parse_recipe_output_full` rejects it and the escaped `{ "facts": [...] }` payload is unrecoverable (the facts live inside an escaped string), so the whole 20-episode batch silently defers and burns an LLM call every cycle. This is the distill-side **outer-envelope analog of the #2504 decide/orient fix**.

A failing pre-fix regression test confirmed it: a banner-prefixed envelope returned `distill: recipe run did not yield a parseable { "facts": [...] } object`.

## Fix

1. **Noise-tolerant outer-envelope recovery (Tier 1b).** New `recover_runner_envelope`: when the fast direct parse fails, recover the `RecipeRunnerEnvelope` through the **same shared `recipe_output` chokepoint** the inner step-output scan and #2504 use — `strip_recipe_noise` + `strip_ansi` dual view, string-aware `balanced_objects` scanned end-first (so a leading `{"level":"info",…}` log record can't shadow the real envelope). No parallel banner cleaner; the clean production path keeps its zero-overhead fast parse. Committing to a recovered envelope preserves the `success == false` → `RecipeReportedFailure` contract (a banner-prefixed failed run is an error, never a silent drop).
2. **First-class `distill_parse_success_rate` metric.** Previously only *derivable* by post-filtering `distill_success_rate` on `parse_attempted == true`. Now emitted as a dedicated event (value `1.0`/`0.0`) for the subset of passes that reached parsing, so its plain mean is exactly successes-vs-attempts — the rate this fix drives toward `~1.0`, mirroring how #2504 was validated. Recipe-reported / terminal / spawn / serialize failures never reached parsing and are excluded from the denominator.

## Merge-ready evidence

**(1) qa-team scenarios** — added `tests/gadugi/distill-parser-outer-envelope-banner.yaml` (outside-in).
- `gadugi-test validate --strict` → `✓ All 1 file(s) are valid`.
- `gadugi-test run` → `✓ Passed: 1 / ✗ Failed: 0` (drives `cargo test issue_2512_outer_envelope_banner_tests` + full `memory_consolidation::distillation` = `83 passed`).

**(2) Docs** — durable Diataxis pages updated (no point-in-time snapshot):
- `docs/reference/distill-recipe-output-capture.md` — Tier 1a/1b split + failure-semantics row.
- `docs/architecture/episode-distillation.md` — first-class `distill_parse_success_rate` metric.

**(3) Quality audit (3 SEEK→VALIDATE→FIX cycles, ended clean):**
- Cycle 1 — correctness of `recover_runner_envelope`: verified string-aware `balanced_objects` doesn't descend into the escaped `output` string; bare facts objects (no `success`/`step_results`) correctly fall through to Tier 2 → no regression.
- Cycle 2 — commit-to-recovered-envelope semantics: confirmed a `success == false` banner-prefixed envelope surfaces `RecipeReportedFailure`, not a silent drop or stray-facts trust; consistent with the pre-existing Tier-1a `into_distill_output` contract.
- Cycle 3 — **compound contamination** (outer banner + inner-step banner): the escaped inner banner makes the compact envelope line match the launcher predicate, so the line-dropping `strip_recipe_noise` view discards it; added a regression test proving the line-preserving `strip_ansi` view recovers it. Final cycle clean.
- 7 new unit tests (bare-banner, ANSI-log, same-line, leading log-record, failed-envelope, clean fast path, compound) — all green.

**(4) CI gates (local, mirror CI):**
- `cargo fmt --all -- --check` ✅
- `cargo clippy --all-targets --all-features --locked -- -D warnings` ✅
- pre-push gate (rust-only + fmt + release `memory_consolidation` test subset + full clippy) ✅ on push
- `cargo test --lib memory_consolidation::distillation` → `83 passed; 0 failed`
- Full `cargo test --lib` → `6453 passed`; the sole failure `ooda_loop::decide::tests::decide_respects_max_concurrent_actions` is **pre-existing on clean `main`** (host-capacity `config.scaler` dependence) and unrelated to this diff (verified via `git stash`).

**(6) Focused diff** — 1 source file + 2 docs + 1 gadugi scenario; no unrelated edits.

Closes #2512
