### PR TITLE
feat(daemon): recurring monthly self-quality-audit periodic task (#2419)

### DIFF
--- a/docs/architecture/monthly-self-quality-audit.md
+++ b/docs/architecture/monthly-self-quality-audit.md
@@ -1,0 +1,265 @@
+---
+title: Monthly self-quality-audit
+description: Design rationale for Simard's recurring ~monthly self-quality-audit — why a periodic daemon task (not a standing goal or per-cycle hook), why last-run is persisted to disk (wall-clock epoch) instead of the in-memory Instant the other periodic tasks use, the five-wave SEEK→VALIDATE→FIX quality-audit model run against Simard's OWN code, the crusty-old-engineer proxy-review gate, the bounded review loop, and the fail-open safety model.
+last_updated: 2026-07-02
+review_schedule: as-needed
+owner: simard
+doc_type: explanation
+related:
+  - ../reference/self-quality-audit-api.md
+  - ../howto/configure-self-quality-audit.md
+  - ./brain-introspection.md
+  - ../concepts/automated-disk-health.md
+---
+
+# Monthly self-quality-audit
+
+> Follows the proven periodic-task pattern shipped for brain introspection
+> ([#2419](https://github.com/rysweet/Simard/issues/2419)). New in this feature:
+> **restart-surviving last-run persistence** so a ~30-day cadence actually fires
+> ~monthly instead of on every daemon restart.
+
+Simard runs a **recurring self-quality-audit** on its own periodic cadence
+(default ~monthly). Each run performs a **five-wave** SEEK→VALIDATE→FIX
+quality-audit of Simard's *own* code (`rysweet/Simard`) by invoking the
+amplihack `quality-audit` skill, then — for every pull request the waves
+produce — invokes the `crusty-old-engineer` skill as operator Ryan's **proxy
+reviewer**, looping on each PR until crusty is satisfied, and finally
+self-merges the PRs that are both crusty-approved and CI-green.
+
+This page explains *why* the feature is built the way it is. For the executable
+contract (APIs, structs, markers, config) see the
+[Self-quality-audit API](../reference/self-quality-audit-api.md). For operator
+tasks see [Configure the monthly self-quality-audit](../howto/configure-self-quality-audit.md).
+
+## What problem this solves
+
+Simard continuously ships engineer PRs against her own repository, but nothing
+periodically steps back to audit the *accumulated* state of her own code at a
+low frequency: dead code paths, drifted docs, silent-degradation smells,
+untested branches, and structural rot that per-PR review does not catch. The
+existing periodic tasks each cover a narrow operational surface:
+
+| Periodic task | Cadence | Scope |
+| --- | --- | ---: |
+| Verified backup (#2420) | minutes–hours | cognitive store durability |
+| Disk health | per-cycle | free disk before `ENOSPC` |
+| Worktree sweep (#2167) | minutes | reap orphaned engineer worktrees |
+| Brain introspection (#2419) | daily | brain decision quality + memory hygiene |
+| **Self-quality-audit (this)** | **~monthly** | **audit Simard's own source, gated by a proxy human review** |
+
+The self-quality-audit is the lowest-frequency, highest-level layer: a
+standing, self-directed code review of the whole repository that produces real,
+crusty-gated, self-merged fixes on a monthly rhythm.
+
+## Why a periodic daemon task (the cadence decision)
+
+The goal says "recurring MONTHLY." Three mechanisms were considered — the same
+trade-off the brain-introspection pass resolved:
+
+| Option | Verdict | Why |
+| --- | --- | --- |
+| **(a) Periodic daemon task on its own interval** | **Chosen** | Reuses the proven, tested `operator_commands_ooda/daemon/mod.rs` periodic-task hook (verified-backup / disk-health / worktree-sweep / brain-introspection). Deterministic cadence, minimal testable Rust, fail-open. |
+| (b) Standing low-priority OODA goal | Rejected as the *cadence* source | A low-priority goal can starve indefinitely behind higher-value goals — wrong for a hygiene cadence that must run on schedule. |
+| (c) A recipe the brain invokes ad hoc | Rejected as the *cadence* source | No schedule guarantee; the brain may never choose it. |
+
+As with brain introspection, the daemon owns the clock and the recipe owns the
+judgment. The daemon task **dispatches** the
+`monthly-self-quality-audit` recipe as a `recipe-runner-rs` subprocess for the
+agentic five-wave audit + crusty review; the Rust hook only decides *when* and
+logs *what happened*.
+
+## The one novel element: restart-surviving last-run persistence
+
+Every existing periodic task gates on an **in-memory `Instant`**:
+
+```rust
+// disk-health, worktree-sweep, brain-introspection — all reset on restart
+let mut last_brain_introspection = Instant::now();
+if last_brain_introspection.elapsed() >= interval { … }
+```
+
+That is correct for 15-minute and 24-hour cadences — losing at most one
+interval across a restart is harmless. It is **wrong for a ~30-day cadence**:
+a daemon that restarts weekly (deploys, crashes, reboots) would *never* let a
+monthly `Instant` mature, so the audit would fire on essentially every restart —
+or never, depending on which side of the boundary the restart lands. Either way
+the "fires ~monthly, not on every restart" requirement is violated.
+
+The fix is the single structural difference from the other tasks: **persist the
+last-run timestamp to disk as a wall-clock epoch** and gate on the wall-clock
+delta rather than a process-lifetime `Instant`.
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│ daemon loop                                                     │
+│                                                                 │
+│   now_epoch  = SystemTime::now() → unix seconds                 │
+│   last_epoch = read_last_run(state_root/self_quality_audit_…)   │
+│   elapsed    = Duration::from_secs(now_epoch − last_epoch)      │
+│                                                                 │
+│   if should_run_self_audit(elapsed, interval_secs) {           │
+│       run_self_quality_audit(…)                                │
+│       write_last_run(path, now_epoch)   // persist, survives    │
+│   }                                       // the next restart    │
+└────────────────────────────────────────────────────────────────┘
+                         │  reads/writes
+                         ▼
+         {state_root}/self_quality_audit_last_run   (epoch seconds)
+```
+
+Because the marker is on disk, a restart mid-month reads back a recent epoch,
+computes a small `elapsed`, and correctly declines to fire until a full interval
+of *wall-clock* time has passed since the last real run.
+
+### First-run / missing-file behavior (init-to-now)
+
+On startup, if `self_quality_audit_last_run` is absent or unparseable, the
+daemon **initializes it to `now` and does not fire this cycle**. The first audit
+then fires ~one interval later. This deliberately avoids a heavy five-wave audit
+firing instantly on a fresh deploy while still honoring "fires ~monthly, not on
+every restart." A garbage file is treated identically to a missing one.
+
+### Last-run is updated on both success and failure
+
+After a run attempt, the daemon persists the new last-run **regardless of
+`Ok`/`Err`**, mirroring the `last_X = Instant::now()` reset the other tasks do
+unconditionally. This prevents a failing recipe from hot-looping — a broken
+audit retries next month, not next cycle.
+
+## Split of labor
+
+```
+┌──────────────────────────────┐        ┌──────────────────────────────────┐
+│ Rust hook (daemon-side)      │        │ Recipe (recipe-runner-rs)         │
+│ src/self_quality_audit.rs    │        │ monthly-self-quality-audit.yaml   │
+├──────────────────────────────┤        ├──────────────────────────────────┤
+│ • interval_secs_from_env     │        │ • Wave 1..5 SEEK→VALIDATE→FIX      │
+│ • read/write last-run epoch  │        │   via amplihack quality-audit     │
+│ • should_run_self_audit gate │──run──▶│ • per-PR crusty-old-engineer      │
+│ • spawn recipe-runner-rs     │        │   proxy review (≤3 rounds)        │
+│ • parse text markers         │◀markers│ • self-merge crusty-approved +    │
+│ • log fire + completion      │        │   CI-green PRs                    │
+│ • persist last-run (Ok|Err)  │        │ • emit AUDIT_* / WAVE_* / PR_*    │
+└──────────────────────────────┘        └──────────────────────────────────┘
+```
+
+The Rust hook is a **pure recipe invoker** (modeled on `disk_health.rs`, not on
+`brain_introspection.rs`): it does no memory-RPC work, because a code audit
+needs none. It owns the clock, the persistence, and the logging; the recipe owns
+all judgment.
+
+## The five-wave audit model
+
+Each run drives **five sequential SEEK→VALIDATE→FIX waves** of the amplihack
+`quality-audit` skill against `rysweet/Simard`:
+
+1. **SEEK** — scan the codebase for a category of quality issues (dead code,
+   silent degradation, missing tests, doc drift, structural smells).
+2. **VALIDATE** — confirm each finding is real and worth fixing (no false
+   positives, no churn-for-churn's-sake).
+3. **FIX** — implement the fix on a branch and open a pull request.
+
+Running five waves per audit lets each wave target a different quality
+dimension while sharing one crusty-gated merge pipeline. Waves are sequential so
+later waves see earlier waves' merges and do not collide.
+
+## The crusty-old-engineer proxy-review gate
+
+Simard must not merge her own audit fixes unreviewed. For **each** PR a wave
+opens, the recipe invokes the `crusty-old-engineer` skill as operator Ryan's
+**proxy reviewer** — a curmudgeonly senior-engineer persona that applies
+grounded, evidence-linked skepticism. The recipe **loops** on each PR:
+
+```
+for each PR:
+    round = 1
+    loop:
+        verdict = crusty_review(PR)
+        if verdict == APPROVED:            emit CRUSTY_APPROVED; break
+        if round >= MAX_CRUSTY_ROUNDS (3): emit CRUSTY_UNRESOLVED; break
+        address crusty's feedback (push a fix commit)
+        round += 1
+    if crusty approved AND CI is green:
+        self-merge the PR;               emit PR_MERGED
+```
+
+### Why the loop is bounded
+
+An unbounded agentic review loop can spin forever on a PR crusty never blesses.
+The loop is therefore **capped at 3 rounds per PR**. If crusty is still
+unsatisfied after three rounds, the PR is **left open**, `CRUSTY_UNRESOLVED` is
+emitted, and the audit moves on. Unresolved PRs surface for human follow-up
+rather than being force-merged or blocking the whole audit.
+
+### Merge criteria
+
+A PR self-merges only when **both** conditions hold:
+
+- crusty-approved (within the 3-round budget), **and**
+- CI is green.
+
+Branch protection is respected — the recipe uses `gh` and merges only when the
+merge is actually allowed. PRs that are crusty-approved but CI-red, or CI-green
+but crusty-unresolved, stay open.
+
+## Output: PRs and logs, not snapshot docs
+
+Per the no-point-in-time-docs rule, a run produces **real pull requests** and
+**log lines**, never a committed snapshot markdown file. The only durable repo
+documents are this page, the
+[API reference](../reference/self-quality-audit-api.md), and the
+[operator how-to](../howto/configure-self-quality-audit.md) — all of which
+describe the mechanism and its knobs, not a point-in-time finding.
+
+The daemon logs a **fire** line when the audit starts and a **completion** line
+when it finishes (or a WARN on failure), mirroring the other periodic tasks' log
+discipline and adding the required "clear line when it fires and when it
+completes."
+
+## Fail-open safety model
+
+- **Best-effort, never blocks the cycle.** A recipe failure (missing
+  `recipe-runner-rs`, missing recipe YAML, `gh` unauthenticated, non-zero exit)
+  is logged as a WARN; the OODA loop continues. The audit is an optimization,
+  not a hard dependency.
+- **No hot-loop on failure.** Last-run is persisted on `Ok` *and* `Err`, so a
+  broken audit retries next interval, not next cycle.
+- **Bounded review.** ≤3 crusty rounds per PR; unresolved PRs are surfaced, not
+  force-merged.
+- **Off by explicit `0`.** `SIMARD_SELF_AUDIT_INTERVAL=0` disables the task
+  entirely; garbage values fall back to the conservative monthly default.
+- **Conservative default cadence.** ~30 days (2,592,000s), so the heavy
+  five-wave audit runs rarely.
+
+## Relationship to brain introspection
+
+This task **reuses** the brain-introspection periodic-task *pattern* (interval
+env → startup `daemon_log` → in-loop gate → hook module + recipe YAML +
+`lib.rs` registration → `recipe-runner-rs … --output-format json`) but audits a
+different surface (source code, not memory) and adds the disk-persisted last-run
+so a monthly cadence survives restarts. It does **not** reinvent the scheduler,
+does not touch the other periodic tasks, and does not duplicate the
+brain-introspection memory hygiene.
+
+## Configuration knobs
+
+| Knob | Env var | Default |
+| --- | --- | ---: |
+| Cadence | `SIMARD_SELF_AUDIT_INTERVAL` | `2592000` (~30 days, in seconds; `0` = disabled) |
+
+> **Naming note.** The env var is the exact name the goal specifies —
+> `SIMARD_SELF_AUDIT_INTERVAL` (value in **seconds**) — rather than the
+> `SIMARD_*_INTERVAL_SECS` suffix the sibling tasks use. This deviation is
+> intentional and documented so the naming is not mistaken for a bug.
+
+See [Configure the monthly self-quality-audit](../howto/configure-self-quality-audit.md)
+for tuning and observability.
+
+## Related
+
+- [Self-quality-audit API](../reference/self-quality-audit-api.md) — the executable contract
+- [Configure the monthly self-quality-audit](../howto/configure-self-quality-audit.md) — operator guide
+- [Brain introspection + memory hygiene](./brain-introspection.md) — the sibling periodic task whose pattern this reuses
+- [Automated disk health management](../concepts/automated-disk-health.md) — the pure recipe-invoker shim this hook is modeled on
+- [Daemon mode](../daemon-mode.md) — OODA cycle + periodic-task overview

--- a/docs/howto/configure-self-quality-audit.md
+++ b/docs/howto/configure-self-quality-audit.md
@@ -1,0 +1,280 @@
+---
+title: Configure and monitor the monthly self-quality-audit
+description: Operator guide for Simard's recurring ~monthly self-quality-audit — enabling/disabling and tuning the SIMARD_SELF_AUDIT_INTERVAL cadence, understanding the disk-backed last-run persistence that survives restarts, observing fire/completion logs and the audit's pull requests, manually triggering a run, and diagnosing failures.
+last_updated: 2026-07-02
+review_schedule: as-needed
+owner: simard
+doc_type: howto
+related:
+  - ../architecture/monthly-self-quality-audit.md
+  - ../reference/self-quality-audit-api.md
+  - ./configure-brain-introspection.md
+  - ./configure-disk-health-check.md
+---
+
+# Configure and monitor the monthly self-quality-audit
+
+Simard runs a recurring **self-quality-audit** on its own interval (default
+~monthly). Each run drives five SEEK→VALIDATE→FIX waves of the amplihack
+`quality-audit` skill against her own repository, has the `crusty-old-engineer`
+skill proxy-review every resulting pull request, and self-merges the PRs that
+are crusty-approved and CI-green.
+
+This guide shows how to enable, tune, observe, and troubleshoot the audit. For
+design rationale see
+[Monthly self-quality-audit](../architecture/monthly-self-quality-audit.md); for
+the API contract see the
+[Self-quality-audit API](../reference/self-quality-audit-api.md).
+
+## When to use this
+
+Use this guide when:
+
+- You want to change how often the audit runs (or disable it)
+- The daemon logged `self quality-audit: starting …` or `self quality-audit:
+  complete …` and you want to read the results
+- The daemon logged `WARN: self quality-audit failed` and you need to diagnose it
+- You want to run the audit manually without waiting for the monthly cadence
+- You need to understand why the audit did (or did not) fire after a restart
+
+## Enable, disable, and tune
+
+The single knob is an environment variable, read once at daemon start (set it
+before launching the daemon):
+
+| Knob    | Env var                      | Default   | What it controls                                    |
+| ------- | ---------------------------- | --------: | --------------------------------------------------- |
+| Cadence | `SIMARD_SELF_AUDIT_INTERVAL` | `2592000` | **Seconds** between runs; **`0` disables the audit** |
+
+Examples:
+
+```bash
+# Run every 2 weeks instead of ~monthly
+export SIMARD_SELF_AUDIT_INTERVAL=1209600
+
+# Disable the audit entirely
+export SIMARD_SELF_AUDIT_INTERVAL=0
+
+# Restore the default ~30-day cadence (or just unset it)
+unset SIMARD_SELF_AUDIT_INTERVAL
+```
+
+> **The value is in seconds, and the name has no `_SECS` suffix.** Unlike the
+> sibling `SIMARD_DISK_HEALTH_INTERVAL_SECS` / `SIMARD_BRAIN_INTROSPECTION_INTERVAL_SECS`
+> knobs, this one is `SIMARD_SELF_AUDIT_INTERVAL` (still seconds). This is
+> intentional — it matches the feature's specification. A garbage value falls
+> back to the ~30-day default; only an explicit `0` disables the audit.
+
+Confirm the configured interval at daemon start:
+
+```bash
+grep "self quality-audit interval" ~/.simard/ooda.log | tail -1
+# [2026-07-02T09:00:00Z] [simard] OODA daemon: self quality-audit interval = 2592000s
+```
+
+## How the cadence survives restarts
+
+Unlike the other periodic tasks (which reset an in-memory timer on every
+restart), the self-quality-audit **persists its last-run time to disk** so a
+~monthly cadence is not reset by deploys, crashes, or reboots.
+
+The last-run wall-clock timestamp (epoch seconds) lives here:
+
+```bash
+cat ~/.simard/self_quality_audit_last_run
+# 1751446800
+date -d @"$(cat ~/.simard/self_quality_audit_last_run)"
+# Tue Jul  1 09:00:00 UTC 2026
+```
+
+Behavior you can rely on:
+
+- **First run / fresh deploy.** If the file is absent or unreadable at startup,
+  the daemon writes `now` and does **not** audit this cycle. The first audit
+  fires ~one interval later — a heavy five-wave audit never fires instantly on
+  a fresh install.
+- **Restart mid-interval.** On restart the daemon reads the recent epoch back,
+  sees only a small elapsed time, and correctly declines to fire until a full
+  interval of wall-clock time has passed. The audit fires **~monthly, not on
+  every restart**.
+- **After a run (success or failure).** The daemon rewrites the file to the run
+  time regardless of outcome, so a failing audit retries next month — not next
+  cycle.
+
+To force the *next* audit to run on the next cycle (e.g. after changing the
+recipe), delete the marker and restart the daemon — it will re-init to `now`,
+so instead set it to an old epoch:
+
+```bash
+# Make the audit "due" immediately on next daemon start
+echo 0 > ~/.simard/self_quality_audit_last_run
+```
+
+Writing `0` (or any epoch older than one interval ago) makes `elapsed >=
+interval` true, so the audit fires on the next cycle. (An *absent* file
+re-inits to now and waits a full interval — the two are deliberately different.)
+
+## Observe a run
+
+The daemon logs a **fire** line when the audit starts and a **completion** line
+when it finishes:
+
+```bash
+grep "self quality-audit" ~/.simard/ooda.log | tail -5
+```
+
+Typical output:
+
+```
+[2026-08-01T09:00:01Z] [simard] self quality-audit: starting 5-wave crusty-gated self-audit
+[2026-08-01T10:14:32Z] [simard] self quality-audit: complete — 5 waves, 4 PRs opened, 3 merged, 1 crusty-unresolved
+```
+
+The real results are **pull requests**, not a log line or a repo doc. Inspect
+them with `gh`:
+
+```bash
+# PRs the audit opened/merged (five-wave quality-audit fixes)
+gh pr list --repo rysweet/Simard --state all --search "author:@me" --limit 20
+
+# PRs crusty left unresolved (open, awaiting human follow-up)
+gh pr list --repo rysweet/Simard --state open --search "author:@me"
+```
+
+A completion line reporting `crusty-unresolved` > 0 means one or more PRs hit
+the 3-round crusty budget without approval and were left open **for you** to
+review — they are not force-merged.
+
+## Manually trigger a run
+
+To run the agentic recipe directly (the same way the daemon invokes it), use
+`recipe-runner-rs` with the JSON envelope:
+
+```bash
+recipe-runner-rs prompt_assets/simard/recipes/monthly-self-quality-audit.yaml \
+  --output-format json \
+  -c state_root="$HOME/.simard" \
+  -c repo_path="/home/azureuser/src/Simard"
+```
+
+This prints a JSON envelope whose `step_results[*].output` strings contain the
+text markers the Rust shim parses:
+
+```json
+{
+  "success": true,
+  "step_results": [
+    {
+      "step_id": "self-quality-audit",
+      "output": "AUDIT_STARTED\nWAVE_START=1\nWAVE_COMPLETE=1\nPR_OPENED=https://github.com/rysweet/Simard/pull/2601\nCRUSTY_APPROVED=https://github.com/rysweet/Simard/pull/2601\nPR_MERGED=https://github.com/rysweet/Simard/pull/2601\n...\nAUDIT_COMPLETE=5 waves, 4 PRs opened, 3 merged, 1 crusty-unresolved\n"
+    }
+  ]
+}
+```
+
+> **Note:** Running the recipe directly is the *whole* audit in this feature —
+> the Rust hook (`run_self_quality_audit`) is a pure invoker with no deterministic
+> pre-work, so there is no daemon-side half to miss (unlike brain introspection).
+> The only thing the daemon adds is the interval gate, the last-run persistence,
+> and the fire/completion logging.
+
+To exercise the full daemon path on demand (interval gate + persistence +
+logging), start the daemon with a short interval and a due marker, for dev/test
+only:
+
+```bash
+echo 0 > ~/.simard/self_quality_audit_last_run           # make it due
+SIMARD_SELF_AUDIT_INTERVAL=60 simard ooda run --cycles=2  # fire ~1 min in
+grep "self quality-audit" ~/.simard/ooda.log | tail -3
+```
+
+To see only the recipe summary line (no step output), omit `--output-format json`:
+
+```bash
+recipe-runner-rs prompt_assets/simard/recipes/monthly-self-quality-audit.yaml \
+  -c state_root="$HOME/.simard" -c repo_path="/home/azureuser/src/Simard"
+# Recipe: monthly-self-quality-audit SUCCESS
+```
+
+## Diagnose a failed run
+
+If the daemon logs `WARN: self quality-audit failed`, check these in order.
+A failure never blocks the OODA cycle (fail-open) and never hot-loops (last-run
+is persisted on failure, so the next attempt is next interval).
+
+### 1. `recipe-runner-rs` not installed
+
+```bash
+which recipe-runner-rs
+```
+
+If missing, the audit cannot run but the daemon continues. Install
+`recipe-runner-rs` from the amplihack toolchain.
+
+### 2. Recipe YAML missing
+
+```bash
+ls -la prompt_assets/simard/recipes/monthly-self-quality-audit.yaml
+```
+
+If absent (deleted, or a detached worktree without it), the shim returns
+`AdapterInvocationFailed` and the daemon warns and continues. The hook also
+checks the hot-reload path
+`~/.simard/prompt_assets/simard/recipes/monthly-self-quality-audit.yaml` first.
+
+### 3. `gh` not authenticated (waves/merge fail)
+
+```bash
+gh auth status
+```
+
+The waves open PRs and the self-merge step uses `gh`. If `gh` is
+unauthenticated, the run cannot open or merge PRs; the completion summary will
+show `0 PRs opened`.
+
+### 4. Parse error mentioning AUDIT_COMPLETE
+
+The parser **requires** a non-empty `AUDIT_COMPLETE=` line. If the agent emitted
+none (e.g. it aborted mid-audit), the shim returns a parse error. Inspect the
+raw output:
+
+```bash
+recipe-runner-rs prompt_assets/simard/recipes/monthly-self-quality-audit.yaml \
+  --output-format json \
+  -c state_root="$HOME/.simard" -c repo_path="/home/azureuser/src/Simard" \
+  | python3 -m json.tool
+```
+
+### 5. Audit isn't firing when you expect
+
+```bash
+# Is it disabled?
+grep "self quality-audit interval" ~/.simard/ooda.log | tail -1   # =0s means disabled
+
+# When did it last run?
+date -d @"$(cat ~/.simard/self_quality_audit_last_run 2>/dev/null || echo 0)"
+```
+
+Remember the **init-to-now** rule: a *missing* marker waits a full interval
+before the first run. If you want it due now, write an old epoch
+(`echo 0 > ~/.simard/self_quality_audit_last_run`) rather than deleting the file.
+
+## Understand the crusty gate
+
+Every PR the waves open is proxy-reviewed by `crusty-old-engineer` on operator
+Ryan's behalf, looping up to **3 rounds**:
+
+- **Approved within 3 rounds** → the PR self-merges **iff CI is also green**
+  (`PR_MERGED`). Branch protection is respected.
+- **Still unsatisfied after 3 rounds** → the PR is **left open**
+  (`CRUSTY_UNRESOLVED`) for you to review. It is never force-merged.
+
+So the completion summary's `merged` count is always PRs that passed **both**
+crusty and CI, and `crusty-unresolved` is your human follow-up queue.
+
+## Related
+
+- [Monthly self-quality-audit (architecture)](../architecture/monthly-self-quality-audit.md) — design rationale, restart-persistence, safety model
+- [Self-quality-audit API (reference)](../reference/self-quality-audit-api.md) — module API, structs, markers, config
+- [Configure and monitor brain introspection](./configure-brain-introspection.md) — the sibling periodic task whose pattern this reuses
+- [Configure and monitor the disk health check](./configure-disk-health-check.md) — the pure recipe-invoker sibling

--- a/docs/reference/self-quality-audit-api.md
+++ b/docs/reference/self-quality-audit-api.md
@@ -1,0 +1,448 @@
+---
+title: Self-quality-audit API
+description: Rust API reference for Simard's recurring monthly self-quality-audit — the run_self_quality_audit daemon hook, the SelfQualityAuditReport struct, the interval_secs_from_env / should_run_self_audit pure functions, the read_last_run / write_last_run disk persistence, resolve_recipe_path, the monthly-self-quality-audit recipe contract and text markers, and the SIMARD_SELF_AUDIT_INTERVAL configuration knob.
+last_updated: 2026-07-02
+review_schedule: as-needed
+owner: simard
+doc_type: reference
+related:
+  - ../architecture/monthly-self-quality-audit.md
+  - ../howto/configure-self-quality-audit.md
+  - ./disk-health-api.md
+  - ./brain-introspection-api.md
+---
+
+# Self-quality-audit API
+
+> Follows the brain-introspection ([#2419](https://github.com/rysweet/Simard/issues/2419))
+> periodic-task pattern.
+> Hook: `src/self_quality_audit.rs`; daemon wiring:
+> `src/operator_commands_ooda/daemon/mod.rs`; recipe:
+> `prompt_assets/simard/recipes/monthly-self-quality-audit.yaml`; unit tests:
+> `src/self_quality_audit_tests.rs`; module registration: `src/lib.rs`.
+
+**Module:** `src/self_quality_audit.rs`
+
+The `self_quality_audit` module is a thin Rust shim (a **pure recipe invoker**,
+modeled on `disk_health.rs`) that fires on its own env-gated interval, spawns
+`recipe-runner-rs` to run the five-wave, crusty-gated self-audit recipe against
+Simard's own repository, deserializes the JSON envelope, parses text markers
+into a structured `SelfQualityAuditReport`, and — uniquely among the periodic
+tasks — **persists its last-run timestamp to disk** so a ~monthly cadence
+survives daemon restarts.
+
+Each run:
+
+1. **Five waves** — drives five sequential SEEK→VALIDATE→FIX waves of the
+   amplihack `quality-audit` skill against `rysweet/Simard`, each opening pull
+   requests for validated fixes.
+2. **Crusty proxy review** — for every resulting PR, invokes the
+   `crusty-old-engineer` skill as operator Ryan's proxy reviewer, looping up to
+   3 rounds until crusty is satisfied.
+3. **Self-merge** — merges each PR that is both crusty-approved and CI-green
+   (respecting branch protection); leaves crusty-unresolved PRs open for human
+   follow-up.
+4. **Output** — emits text markers parsed into the report; the daemon logs a
+   fire line and a completion line. No snapshot repo doc is ever written.
+
+This page is the executable contract. For design rationale (cadence choice, the
+disk-persistence decision, the bounded crusty loop) see
+[Monthly self-quality-audit](../architecture/monthly-self-quality-audit.md).
+
+---
+
+## Data flow
+
+```
+daemon loop (mod.rs)
+   │  now_epoch = SystemTime::now() → unix seconds
+   │  last_epoch = read_last_run(state_root/self_quality_audit_last_run)
+   │             ├─ None/garbage ⇒ write_last_run(now); skip this cycle (init-to-now)
+   │  elapsed = Duration::from_secs(now_epoch − last_epoch)
+   │
+   │  if should_run_self_audit(elapsed, SIMARD_SELF_AUDIT_INTERVAL) {
+   ▼
+run_self_quality_audit(&repo_root, &state_root, None)
+   │
+   ├─ resolve_recipe_path(repo_root, None)     → monthly-self-quality-audit.yaml
+   │       (hot-reload path first, then in-tree)
+   │
+   ├─ spawn recipe-runner-rs <path> --output-format json
+   │        -c state_root=… -c repo_path=…
+   │        (env AMPLIHACK_AGENT_BINARY from RuntimeConfig)
+   │             │
+   │             ▼
+   │     JSON envelope (stdout)
+   │       { success, step_results: [{ step_id, output }] }
+   │             │
+   │             ▼
+   │     serde_json::from_slice::<RecipeOutput>()
+   │             │
+   │             ▼
+   │     step_results[*].output   (agent's raw text output)
+   │             │
+   │             ▼
+   │     parse_self_quality_audit_text()   (marker parser)
+   ▼
+SelfQualityAuditReport { waves_completed, prs_opened, prs_merged,
+                         crusty_approved, crusty_unresolved, summary_line }
+   │
+   └─ daemon persists write_last_run(now_epoch)  ── on Ok AND Err
+```
+
+**Split of labor.** The **Rust hook** owns the interval gate, disk-backed
+last-run persistence, subprocess spawn, marker parsing, and logging. The
+**recipe (subprocess)** owns all LLM judgment: the five quality-audit waves, the
+crusty proxy review loop, and the self-merge decisions.
+
+---
+
+## Public API
+
+### `run_self_quality_audit(repo_root, state_root, home_override) → SimardResult<SelfQualityAuditReport>`
+
+Entry point, called from the daemon loop. Resolves the recipe YAML, spawns
+`recipe-runner-rs` with `--output-format json`, deserializes the JSON envelope,
+extracts each step's output, parses the markers, and returns the report.
+
+```rust
+pub fn run_self_quality_audit(
+    repo_root: &Path,
+    state_root: &Path,
+    home_override: Option<&Path>,
+) -> SimardResult<SelfQualityAuditReport>;
+```
+
+**Parameters:**
+
+| Parameter       | Type            | Description                                                                |
+| --------------- | --------------- | -------------------------------------------------------------------------- |
+| `repo_root`     | `&Path`         | Repository root — used to locate the recipe YAML; passed as `-c repo_path` |
+| `state_root`    | `&Path`         | Simard state directory (`~/.simard`) — passed as `-c state_root`           |
+| `home_override` | `Option<&Path>` | Test seam for `resolve_recipe_path` hot-reload resolution; `None` in prod  |
+
+**Returns:** `SimardResult<SelfQualityAuditReport>`
+
+**Errors** (`SimardError::AdapterInvocationFailed`):
+
+| Condition                            | Error reason                                              |
+| ------------------------------------ | -------------------------------------------------------- |
+| Recipe YAML not found                | `"recipe file monthly-self-quality-audit.yaml not found…"` |
+| `recipe-runner-rs` not on PATH       | `"recipe-runner-rs spawn failed: …"`                     |
+| Recipe exited non-zero               | `"recipe exited with <code>: <stderr>"`                  |
+| JSON deserialization failed          | `"failed to deserialize recipe JSON output: …"`          |
+| Empty `step_results`                 | `"no step results in recipe JSON output"`                |
+| Text markers missing `AUDIT_COMPLETE`| `"failed to parse recipe text output: …"`                |
+
+No fallback. If the recipe fails for any reason, the error propagates to the
+caller (the OODA daemon), which logs `WARN: self quality-audit failed: …` and
+continues the cycle. The daemon persists last-run regardless.
+
+---
+
+### `interval_secs_from_env(raw) → u64`
+
+Pure function that resolves the configured cadence from the
+`SIMARD_SELF_AUDIT_INTERVAL` environment value.
+
+```rust
+pub fn interval_secs_from_env(raw: Option<&str>) -> u64;
+```
+
+| Input (`raw`)              | Result                     |
+| -------------------------- | -------------------------- |
+| `None` (unset)             | `DEFAULT_INTERVAL_SECS`    |
+| `Some("")` (empty)         | `DEFAULT_INTERVAL_SECS`    |
+| `Some("0")`                | `0` (**disabled**)         |
+| `Some("<valid u64>")`      | that many seconds          |
+| `Some("<garbage>")`        | `DEFAULT_INTERVAL_SECS`    |
+
+`0` is the explicit disable value and is preserved; any unparseable value falls
+back to the conservative default rather than disabling the task.
+
+```rust
+pub const DEFAULT_INTERVAL_SECS: u64 = 2_592_000; // ~30 days
+```
+
+> **Naming note.** The env var name is `SIMARD_SELF_AUDIT_INTERVAL` (value in
+> **seconds**), matching the goal exactly, rather than the
+> `SIMARD_*_INTERVAL_SECS` suffix used by the sibling periodic tasks. Single
+> variable, no alias.
+
+---
+
+### `should_run_self_audit(elapsed, interval_secs) → bool`
+
+Pure scheduling gate — the unit-tested heart of the cadence. Kept
+signature-compatible with `should_run_introspection` so it tests the same way.
+
+```rust
+pub fn should_run_self_audit(elapsed: Duration, interval_secs: u64) -> bool {
+    interval_secs > 0 && elapsed >= Duration::from_secs(interval_secs)
+}
+```
+
+| `interval_secs` | `elapsed`            | Returns |
+| --------------- | -------------------- | ------- |
+| `0`             | any                  | `false` (disabled) |
+| `> 0`           | `< interval`         | `false` (too soon) |
+| `> 0`           | `>= interval`        | `true`  (fire)     |
+
+In the daemon, `elapsed` is computed from the **wall-clock epoch delta**
+(`now_epoch − last_run_epoch`), not a process-lifetime `Instant` — this is what
+makes the cadence survive restarts.
+
+---
+
+### `read_last_run(path) → Option<u64>` / `write_last_run(path, epoch)`
+
+Disk-backed last-run persistence — the one capability the other periodic tasks
+lack. The last-run wall-clock timestamp is stored as decimal epoch **seconds**
+in a single file at `{state_root}/self_quality_audit_last_run`.
+
+```rust
+pub fn read_last_run(path: &Path) -> Option<u64>;
+pub fn write_last_run(path: &Path, epoch_secs: u64) -> std::io::Result<()>;
+```
+
+- `read_last_run` returns `Some(epoch)` when the file exists and parses as a
+  `u64`; returns `None` when the file is absent **or** its contents are
+  unparseable (garbage is treated as missing).
+- `write_last_run` writes the epoch atomically and creates the parent directory
+  if needed.
+
+**Init-to-now contract.** On startup, `None` from `read_last_run` means the
+daemon writes `now` and does **not** fire this cycle; the first audit fires
+~one interval later (avoids an instant heavy audit on fresh deploy).
+
+**Update-on-both contract.** The daemon calls `write_last_run(now_epoch)` after
+every run attempt, on `Ok` and on `Err`, to prevent a failing recipe from
+hot-looping.
+
+---
+
+### `resolve_recipe_path(repo_root, home_override) → Option<PathBuf>`
+
+Private helper. Locates `monthly-self-quality-audit.yaml`, checking the
+hot-reload path first, then the in-tree copy — **identical signature and
+resolution order to `disk_health::resolve_recipe_path`** (the sibling this hook
+is modeled on): a private `fn` returning `Option<PathBuf>`, not a public
+`SimardResult`.
+
+```rust
+const RECIPE_FILENAME: &str = "monthly-self-quality-audit.yaml";
+
+fn resolve_recipe_path(
+    repo_root: &Path,
+    home_override: Option<&Path>,
+) -> Option<PathBuf>;
+```
+
+Resolution order:
+
+1. **Hot-reload:** `{home}/prompt_assets/simard/recipes/monthly-self-quality-audit.yaml`
+   (`home` = `home_override` in tests, else `~/.simard`) — lets operators edit
+   the recipe without a rebuild.
+2. **In-tree:** `{repo_root}/prompt_assets/simard/recipes/monthly-self-quality-audit.yaml`.
+
+Returns `None` if neither path exists. The caller (`run_self_quality_audit`)
+maps `None` to `SimardError::AdapterInvocationFailed` via `.ok_or_else(…)`,
+exactly as `run_disk_health_check` does — the error conversion lives at the call
+site, not in the resolver.
+
+---
+
+## `SelfQualityAuditReport`
+
+```rust
+#[derive(Debug, Clone, PartialEq)]
+pub struct SelfQualityAuditReport {
+    pub waves_completed: u32,
+    pub prs_opened: Vec<String>,
+    pub prs_merged: Vec<String>,
+    pub crusty_approved: Vec<String>,
+    pub crusty_unresolved: Vec<String>,
+    pub summary_line: String,
+}
+```
+
+Built by `parse_self_quality_audit_text()` from the extracted step output — not
+deserialized directly (serde is used only for the `RecipeOutput` / `StepResult`
+envelope, as in `disk_health.rs`).
+
+| Field               | Type          | Description                                                    |
+| ------------------- | ------------- | ------------------------------------------------------------- |
+| `waves_completed`   | `u32`         | Count of `WAVE_COMPLETE=<n>` markers observed (0–5)           |
+| `prs_opened`        | `Vec<String>` | URLs from `PR_OPENED=<url>` markers                           |
+| `prs_merged`        | `Vec<String>` | URLs from `PR_MERGED=<url>` markers                           |
+| `crusty_approved`   | `Vec<String>` | URLs from `CRUSTY_APPROVED=<url>` markers                     |
+| `crusty_unresolved` | `Vec<String>` | URLs from `CRUSTY_UNRESOLVED=<url>` markers (open, need human) |
+| `summary_line`      | `String`      | Text from the required `AUDIT_COMPLETE=<summary>` marker (always present — its absence is a parse error, so this is a plain `String`, not `Option`) |
+
+**Methods:**
+
+- `summary() → String` — one-line summary for the daemon completion log,
+  synthesized from the counts (distinct from the raw `summary_line` field, which
+  is the agent's own `AUDIT_COMPLETE=` text). Format:
+  `"self quality-audit: complete — N waves, X PRs opened, Y merged, Z crusty-unresolved"`.
+
+---
+
+## Text markers (recipe → hook)
+
+The recipe emits plain-text markers (one per line, not inside code fences),
+parsed by `parse_self_quality_audit_text()`. Any other line is ignored.
+
+| Marker | Cardinality | Meaning |
+| --- | --- | --- |
+| `AUDIT_STARTED` | 1 | Audit began (advisory; daemon also logs its own fire line) |
+| `WAVE_START=<n>` | 0..5 | Wave `n` (1–5) began |
+| `WAVE_COMPLETE=<n>` | 0..5 | Wave `n` finished; counted into `waves_completed` |
+| `PR_OPENED=<url>` | 0..n | A wave opened a pull request |
+| `CRUSTY_APPROVED=<url>` | 0..n | crusty-old-engineer approved this PR |
+| `CRUSTY_UNRESOLVED=<url>` | 0..n | crusty still unsatisfied after 3 rounds; PR left open |
+| `PR_MERGED=<url>` | 0..n | PR self-merged (crusty-approved AND CI-green) |
+| `AUDIT_COMPLETE=<summary>` | **1 (REQUIRED)** | Terminal summary; its absence is a parse error |
+
+`AUDIT_COMPLETE` is **required** — the parser returns
+`SimardError::AdapterInvocationFailed` if no non-empty `AUDIT_COMPLETE=` line is
+present (mirrors the required-`BRAIN_HEALTH:`/`DISK_USED_PCT` contracts).
+
+---
+
+## Recipe contract
+
+**File:** `prompt_assets/simard/recipes/monthly-self-quality-audit.yaml`
+
+A single `type: agent` step (mirrors `disk-health-check.yaml` /
+`brain-introspection.yaml`). Standard
+`name / description / version / author / tags / context / steps` format.
+
+**Context vars** (passed via `-c`):
+
+| Var          | Meaning                                                    |
+| ------------ | ---------------------------------------------------------- |
+| `state_root` | `~/.simard` — logs/state live here                        |
+| `repo_path`  | repository root of `rysweet/Simard` being audited         |
+
+**Agent responsibilities:**
+
+1. Run **five sequential SEEK→VALIDATE→FIX waves** invoking the amplihack
+   `quality-audit` skill on `rysweet/Simard`; emit `WAVE_START=`/`WAVE_COMPLETE=`
+   around each and `PR_OPENED=<url>` for each PR opened.
+2. For **each** PR, invoke the `crusty-old-engineer` skill as Ryan's proxy
+   reviewer, looping **≤3 rounds** until satisfied. Emit `CRUSTY_APPROVED=<url>`
+   on approval or `CRUSTY_UNRESOLVED=<url>` if still unsatisfied after 3 rounds
+   (leave the PR open).
+3. **Self-merge** each PR that is crusty-approved AND CI-green (respect branch
+   protection); emit `PR_MERGED=<url>`.
+4. Emit a terminal `AUDIT_COMPLETE=<one-line summary>`.
+5. Never write a snapshot/point-in-time doc — the output is PRs + markers.
+
+---
+
+## Daemon wiring
+
+**File:** `src/operator_commands_ooda/daemon/mod.rs`
+
+**Setup (once, at daemon start)** — alongside the verified-backup / disk-health /
+worktree-sweep / brain-introspection setup blocks:
+
+```rust
+// --- periodic self quality-audit state (monthly, restart-surviving) ---
+let self_audit_interval_secs =
+    crate::self_quality_audit::interval_secs_from_env(
+        std::env::var("SIMARD_SELF_AUDIT_INTERVAL").ok().as_deref(),
+    );
+let self_audit_last_run_path = state_root.join("self_quality_audit_last_run");
+// init-to-now if absent/garbage: write now, don't fire this cycle
+let mut last_self_audit_epoch = match
+    crate::self_quality_audit::read_last_run(&self_audit_last_run_path) {
+        Some(epoch) => epoch,
+        None => {
+            let now = /* unix seconds */;
+            let _ = crate::self_quality_audit::write_last_run(
+                &self_audit_last_run_path, now);
+            now
+        }
+    };
+daemon_log(
+    &state_root,
+    &format!("[simard] OODA daemon: self quality-audit interval = {self_audit_interval_secs}s"),
+);
+```
+
+**Loop branch (each cycle):**
+
+```rust
+// ── Periodic self quality-audit (monthly, restart-surviving) ──
+let now_epoch = /* SystemTime::now() → unix seconds */;
+let elapsed = Duration::from_secs(now_epoch.saturating_sub(last_self_audit_epoch));
+if crate::self_quality_audit::should_run_self_audit(elapsed, self_audit_interval_secs) {
+    daemon_log(&state_root,
+        "[simard] self quality-audit: starting 5-wave crusty-gated self-audit");
+    match crate::self_quality_audit::run_self_quality_audit(
+        &bridges.repo_root, &state_root, None,
+    ) {
+        Ok(report) => daemon_log(&state_root, &format!("[simard] {}", report.summary())),
+        Err(e) => daemon_log(&state_root,
+            &format!("[simard] WARN: self quality-audit failed: {e}")),
+    }
+    // persist on Ok AND Err — prevents hot-loop on failure
+    let _ = crate::self_quality_audit::write_last_run(&self_audit_last_run_path, now_epoch);
+    last_self_audit_epoch = now_epoch;
+}
+```
+
+**Startup log line (mirrors the other intervals):**
+
+```
+[2026-07-02T09:00:00Z] [simard] OODA daemon: self quality-audit interval = 2592000s
+```
+
+**Fire + completion log lines:**
+
+```
+[2026-08-01T09:00:01Z] [simard] self quality-audit: starting 5-wave crusty-gated self-audit
+[2026-08-01T10:14:32Z] [simard] self quality-audit: complete — 5 waves, 4 PRs opened, 3 merged, 1 crusty-unresolved
+```
+
+---
+
+## Module registration
+
+**File:** `src/lib.rs`
+
+```rust
+pub mod self_quality_audit;
+
+#[cfg(test)]
+mod self_quality_audit_tests;
+```
+
+---
+
+## Unit tests
+
+**File:** `src/self_quality_audit_tests.rs` (`#[cfg(test)]`)
+
+The scheduling logic is covered by pure unit tests (no subprocess, no network):
+
+| Test | Asserts |
+| --- | --- |
+| `interval_secs_from_env` matrix | unset→default, valid→parsed, `"0"`→disabled, garbage→default |
+| gate — too soon | `should_run_self_audit(elapsed < interval, interval)` is `false` |
+| gate — due | `should_run_self_audit(elapsed >= interval, interval)` is `true` |
+| gate — disabled | `should_run_self_audit(_, 0)` is `false` |
+| persistence round-trip | `write_last_run` then `read_last_run` returns the same epoch |
+| persistence — garbage | `read_last_run` on a non-numeric file returns `None` |
+| simulated restart | after writing a *recent* epoch, the gate stays `false` (no immediate re-fire across a restart) |
+
+---
+
+## Related
+
+- [Monthly self-quality-audit (architecture)](../architecture/monthly-self-quality-audit.md) — design rationale and safety model
+- [Configure the monthly self-quality-audit (how-to)](../howto/configure-self-quality-audit.md) — operator guide
+- [Disk health API](./disk-health-api.md) — the pure recipe-invoker shim this hook is modeled on
+- [Brain introspection API](./brain-introspection-api.md) — the sibling periodic task whose pattern this reuses

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,6 +59,7 @@ nav:
     - Agent Composition: architecture/agent-composition.md
     - Implementation Plan: architecture/implementation-plan.md
     - Brain Introspection + Memory Hygiene: architecture/brain-introspection.md
+    - Monthly Self-Quality-Audit: architecture/monthly-self-quality-audit.md
   - Concepts:
     - Truthful Runtime Metadata: concepts/truthful-runtime-metadata.md
     - Prompt-driven Brain Iteration: concepts/prompt-driven-brain-iteration.md
@@ -96,6 +97,7 @@ nav:
     - Diagnose a Rejected Goal Completion: howto/diagnose-a-rejected-goal-completion.md
     - Interpret Brain Confidence and Verify Completion: howto/interpret-brain-confidence-and-verify-completion.md
     - Configure Brain Introspection: howto/configure-brain-introspection.md
+    - Configure the Monthly Self-Quality-Audit: howto/configure-self-quality-audit.md
     - Triage Stale Pull Requests: howto/triage-stale-pull-requests.md
     - Diagnose merge-pr Verdict-Parse Failures: howto/diagnose-merge-pr-verdict-parse-failures.md
     - Inspect the Procedural-Learning Loop: howto/inspect-the-procedural-learning-loop.md
@@ -129,6 +131,7 @@ nav:
     - Meeting Close Lifecycle: reference/meeting-close-lifecycle.md
     - Azure DevOps ACL Self-Escalation Guard: reference/ado-acl-self-escalation-guard.md
     - Brain Introspection API: reference/brain-introspection-api.md
+    - Self-Quality-Audit API: reference/self-quality-audit-api.md
     - Dashboard Action-Detail Humanization: reference/dashboard-action-detail-humanization.md
     - Supply-Chain Audit & Guardrails: reference/supply-chain-audit.md
     - Dependency Trust Policy: reference/dependency-trust-policy.md

--- a/prompt_assets/simard/recipes/monthly-self-quality-audit.yaml
+++ b/prompt_assets/simard/recipes/monthly-self-quality-audit.yaml
@@ -1,0 +1,152 @@
+# monthly-self-quality-audit.yaml — Agent-based recurring monthly
+# self-quality-audit of Simard's OWN code (issue #2419).
+#
+# Invoked by src/self_quality_audit.rs via recipe-runner-rs on its own daemon
+# interval (SIMARD_SELF_AUDIT_INTERVAL, default 2592000s ≈ 30 days). The Rust
+# hook owns the interval gate, disk-backed last-run persistence, subprocess
+# spawn, marker parsing, and logging. This recipe owns all LLM judgment: the
+# five SEEK→VALIDATE→FIX quality-audit waves, the bounded crusty-old-engineer
+# proxy-review loop, and the self-merge decisions.
+#
+# Context vars (passed via -c):
+#   state_root — path to ~/.simard (logs, metrics, memory live here)
+#   repo_path  — repository root of the local rysweet/Simard checkout
+#
+# Output: text markers to stdout (one per line), parsed by
+# `parse_self_quality_audit_text` in src/self_quality_audit.rs:
+#   AUDIT_STARTED                 (advisory)
+#   WAVE_START=<n>                (advisory; one per wave started, n = 1..5)
+#   WAVE_COMPLETE=<n>             (one per wave that finished; counted)
+#   PR_OPENED=<url>               (0..n; one per PR opened by a wave)
+#   CRUSTY_APPROVED=<url>         (0..n; one per PR crusty approved)
+#   CRUSTY_UNRESOLVED=<url>       (0..n; PR still unsatisfied after 3 rounds)
+#   PR_MERGED=<url>               (0..n; one per PR self-merged)
+#   AUDIT_COMPLETE=<summary>      (REQUIRED terminal marker, non-empty)
+#
+# Design: a single orchestrating agent step (mirrors disk-health-check.yaml and
+# brain-introspection.yaml). The agent invokes the amplihack `quality-audit` and
+# `crusty-old-engineer` skills and uses bash + gh tools to review and merge.
+# Per the no-point-in-time-docs rule, this audit NEVER writes a committed
+# snapshot markdown file — all findings live in the PRs it opens.
+
+name: "monthly-self-quality-audit"
+description: "Recurring monthly 5-wave, crusty-gated self-quality-audit of Simard's own code"
+version: "1.0.0"
+author: "Simard"
+tags: ["simard", "quality-audit", "self-improvement", "crusty", "maintenance"]
+
+context:
+  state_root: "~/.simard"
+  repo_path: "/home/azureuser/src/Simard/worktrees/main"
+
+steps:
+  - id: "self-quality-audit"
+    type: "agent"
+    agent: "default"
+    prompt: |
+      You are Simard's **monthly self-quality-audit** orchestrator. On a ~30-day
+      cadence you run a five-wave quality audit of Simard's OWN codebase
+      (`rysweet/Simard`), then get every resulting pull request reviewed by the
+      `crusty-old-engineer` skill acting as operator **Ryan's proxy reviewer**,
+      and self-merge the PRs that are both crusty-approved and CI-green.
+
+      You have the Skill tool (to invoke `quality-audit` and
+      `crusty-old-engineer`) plus bash + `gh` tools. Work autonomously — do not
+      ask for confirmation between steps.
+
+      ## Context
+
+      - repo_path: `{{repo_path}}` — local checkout of `rysweet/Simard`. Run all
+        git/gh/build/test commands from here.
+      - state_root: `{{state_root}}` — logs and metrics.
+      - target repository (for `gh`): `rysweet/Simard`.
+
+      ## Procedure
+
+      Print `AUDIT_STARTED` as the very first marker line.
+
+      ### Five SEEK→VALIDATE→FIX waves
+
+      Run **five** sequential quality-audit waves. Before each wave print
+      `WAVE_START=<n>` (n = 1..5). For each wave:
+
+      1. Invoke the amplihack **`quality-audit`** skill against `rysweet/Simard`
+         to perform one SEEK → VALIDATE → FIX pass:
+         - **SEEK**: scan Simard's own code for the highest-value quality issue
+           not already covered by an open PR (correctness bugs, silent error
+           degradation, missing tests, clippy/lint debt, dead code, unsafe
+           patterns, doc drift). Skip issues an earlier wave this run already
+           addressed.
+         - **VALIDATE**: confirm the issue is real and worth fixing (reproduce
+           it, or point to the exact code path).
+         - **FIX**: implement the fix on a NEW branch, keep `cargo fmt` +
+           `cargo clippy` clean and `cargo build` + `cargo test` green, then open
+           a pull request against `rysweet/Simard`.
+      2. If the wave opens a PR, print `PR_OPENED=<full PR url>` (one line per PR
+         opened). A wave that legitimately finds nothing to fix opens no PR —
+         that is fine.
+      3. After the wave finishes (whether or not it opened a PR) print
+         `WAVE_COMPLETE=<n>`.
+
+      Each wave targets a DIFFERENT issue — never re-open a fix for something an
+      earlier wave (or an already-open PR) handled.
+
+      ### Crusty proxy review + self-merge (per PR)
+
+      For **each** PR opened above (`PR_OPENED` list), run a bounded proxy-review
+      loop. Crusty is Ryan's stand-in reviewer: nothing merges until crusty is
+      satisfied.
+
+      Loop up to **3 rounds** per PR:
+
+      1. Invoke the **`crusty-old-engineer`** skill on the PR's diff as operator
+         Ryan's proxy reviewer. Ask for a clear verdict: satisfied, or a concrete
+         list of required changes.
+      2. If crusty is **satisfied**: print `CRUSTY_APPROVED=<pr url>` and exit the
+         loop for this PR.
+      3. If crusty is **not satisfied**: address every required change on the PR
+         branch (keep fmt/clippy/build/tests green, push), then start the next
+         round.
+      4. If still unsatisfied after 3 rounds: print `CRUSTY_UNRESOLVED=<pr url>`,
+         leave the PR **open** for human follow-up, and move on. Do NOT merge it.
+
+      After a PR earns `CRUSTY_APPROVED`, self-merge it **only if** CI is green:
+
+      - Check CI: `gh pr checks <pr url> --repo rysweet/Simard`. Wait briefly and
+        re-check if runs are still pending; if checks remain failing, treat the
+        PR like an unresolved one (leave it open, do not merge).
+      - Merge (respecting branch protection):
+        `gh pr merge <pr url> --repo rysweet/Simard --squash --delete-branch`.
+      - On a successful merge print `PR_MERGED=<pr url>`.
+
+      Never merge a PR that is not crusty-approved, and never merge a PR whose CI
+      is not green. Respect branch protection — if a required check or approval is
+      missing, leave the PR open rather than forcing the merge.
+
+      ### No snapshot docs
+
+      Do NOT create any point-in-time / snapshot markdown file summarizing this
+      run. All findings and fixes live in the PRs. (Durable reference/how-to docs
+      that a fix legitimately needs may be updated inside that fix's PR.)
+
+      ## Required output markers
+
+      Your FINAL output must contain these plain-text markers, each on its own
+      line (printed as plain text, NOT inside code fences). Any other line is
+      ignored by the Rust shim (`parse_self_quality_audit_text`).
+
+      ```
+      AUDIT_STARTED
+      WAVE_START=<n>                # one per wave started (n = 1..5)
+      WAVE_COMPLETE=<n>             # one per wave finished (counted into waves)
+      PR_OPENED=<url>               # one per PR opened
+      CRUSTY_APPROVED=<url>         # one per PR crusty approved
+      CRUSTY_UNRESOLVED=<url>       # one per PR still unsatisfied after 3 rounds
+      PR_MERGED=<url>               # one per PR self-merged
+      AUDIT_COMPLETE=<one-line summary>   # REQUIRED, non-empty terminal marker
+      ```
+
+      `AUDIT_COMPLETE=` is REQUIRED and must carry a non-empty one-line summary
+      (e.g. `AUDIT_COMPLETE=5 waves run; 3 PRs opened, 2 merged, 1 crusty-unresolved`).
+      Without it the daemon rejects the run. Emit it exactly once, last.
+    output: "self_quality_audit_report"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,12 @@ pub mod self_deploy;
 pub mod self_improve;
 pub mod self_improve_executor;
 pub mod self_metrics;
+// Goal (#2419): recurring monthly self-quality-audit periodic task — a pure
+// recipe invoker (mirrors `disk_health`) with disk-backed last-run persistence
+// so the ~30-day cadence survives daemon restarts.
+pub mod self_quality_audit;
+#[cfg(test)]
+mod self_quality_audit_tests;
 pub mod self_relaunch;
 pub mod self_relaunch_semaphore;
 pub mod session;

--- a/src/operator_commands_ooda/daemon/mod.rs
+++ b/src/operator_commands_ooda/daemon/mod.rs
@@ -450,6 +450,32 @@ pub fn run_ooda_daemon(
     );
     // -------------------------------------------------------------------
 
+    // --- periodic monthly self-quality-audit state (issue #2419) ---------
+    // Reuses the sibling periodic-task infra, but persists last-run to DISK
+    // (every sibling gates on an in-process `Instant`, which resets on reboot —
+    // fine at 24h, wrong at 30d). On startup: load the persisted epoch; if the
+    // marker is absent or unparseable, initialize it to NOW and persist, so the
+    // heavy five-wave audit fires ~one interval later rather than on every fresh
+    // deploy/restart. Env `SIMARD_SELF_AUDIT_INTERVAL` (seconds; 0 disables).
+    let self_audit_interval_secs: u64 = crate::self_quality_audit::interval_secs_from_env(
+        std::env::var("SIMARD_SELF_AUDIT_INTERVAL").ok().as_deref(),
+    );
+    let self_audit_last_run_path = state_root.join(crate::self_quality_audit::LAST_RUN_FILENAME);
+    let mut self_audit_last_run: u64 =
+        match crate::self_quality_audit::read_last_run(&self_audit_last_run_path) {
+            Some(epoch) => epoch,
+            None => {
+                let now = crate::self_quality_audit::now_epoch_secs();
+                let _ = crate::self_quality_audit::write_last_run(&self_audit_last_run_path, now);
+                now
+            }
+        };
+    daemon_log(
+        &state_root,
+        &format!("[simard] OODA daemon: self quality-audit interval = {self_audit_interval_secs}s"),
+    );
+    // -------------------------------------------------------------------
+
     let mut cycles_run = 0u32;
 
     loop {
@@ -643,6 +669,47 @@ pub fn run_ooda_daemon(
                 ),
             }
             last_brain_introspection = Instant::now();
+        }
+        // -------------------------------------------------------------------
+
+        // ── Periodic monthly self-quality-audit (issue #2419) ────────────
+        // Fires ~monthly on a DISK-persisted gate (survives restarts). Drives
+        // five SEEK→VALIDATE→FIX quality-audit waves over Simard's OWN repo,
+        // each resulting PR gated by a bounded crusty-old-engineer proxy review,
+        // then self-merges crusty-approved + CI-green PRs. No-fallback: a recipe
+        // failure WARNs; last-run is persisted regardless of outcome so a
+        // failing recipe cannot hot-loop for a full interval.
+        let self_audit_elapsed = Duration::from_secs(
+            crate::self_quality_audit::now_epoch_secs().saturating_sub(self_audit_last_run),
+        );
+        if crate::self_quality_audit::should_run_self_audit(
+            self_audit_elapsed,
+            self_audit_interval_secs,
+        ) {
+            daemon_log(
+                &state_root,
+                "[simard] self quality-audit: firing 5-wave crusty-gated self-audit of rysweet/Simard",
+            );
+            match crate::self_quality_audit::run_self_quality_audit(
+                &bridges.repo_root,
+                &state_root,
+                None,
+            ) {
+                Ok(report) => {
+                    daemon_log(&state_root, &format!("[simard] {}", report.summary()));
+                }
+                Err(e) => daemon_log(
+                    &state_root,
+                    &format!("[simard] WARN: self quality-audit failed: {e}"),
+                ),
+            }
+            // Persist last-run on BOTH Ok and Err to prevent hot-looping a
+            // failing recipe every cycle for a full interval.
+            self_audit_last_run = crate::self_quality_audit::now_epoch_secs();
+            let _ = crate::self_quality_audit::write_last_run(
+                &self_audit_last_run_path,
+                self_audit_last_run,
+            );
         }
         // -------------------------------------------------------------------
 

--- a/src/self_quality_audit.rs
+++ b/src/self_quality_audit.rs
@@ -1,0 +1,348 @@
+//! Recurring **monthly self-quality-audit** periodic task (issue #2419).
+//!
+//! A thin Rust shim modeled on [`crate::disk_health`] — a **pure recipe
+//! invoker** with no memory RPCs — that fires on its own env-gated interval,
+//! spawns `recipe-runner-rs` to run the five-wave, crusty-gated self-audit
+//! recipe against Simard's own repository, deserializes the JSON envelope,
+//! parses text markers into a [`SelfQualityAuditReport`], and — uniquely among
+//! the daemon's periodic tasks — **persists its last-run timestamp to disk** so
+//! a ~30-day cadence survives daemon restarts.
+//!
+//! Split of labor: this Rust hook owns the interval gate, disk-backed last-run
+//! persistence, subprocess spawn, marker parsing, and logging. The recipe (a
+//! `recipe-runner-rs` subprocess) owns all LLM judgment — the five
+//! SEEK→VALIDATE→FIX quality-audit waves, the bounded `crusty-old-engineer`
+//! proxy-review loop, and the self-merge decisions.
+//!
+//! Unlike `brain_introspection` (best-effort/graceful), the self-audit follows
+//! the `disk_health` **no-fallback** contract: any recipe failure propagates as
+//! [`SimardError::AdapterInvocationFailed`]; the daemon WARNs and continues, and
+//! persists last-run regardless (on `Ok` AND `Err`) to prevent hot-looping a
+//! failing recipe for a full month.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use serde::Deserialize;
+
+use crate::error::{SimardError, SimardResult};
+use crate::runtime_config::RuntimeConfig;
+
+/// Stable adapter tag used in error envelopes and logs.
+const ADAPTER_TAG: &str = "monthly-self-quality-audit";
+/// Recipe asset filename (resolved hot-reload-first, then in-tree).
+const RECIPE_FILENAME: &str = "monthly-self-quality-audit.yaml";
+/// Basename of the disk-backed last-run marker file under `state_root`.
+pub const LAST_RUN_FILENAME: &str = "self_quality_audit_last_run";
+
+/// Default cadence: run the self-audit once every ~30 days.
+pub const DEFAULT_INTERVAL_SECS: u64 = 2_592_000; // 30 * 24 * 60 * 60
+
+// ───────────────────────────────────────────────────────────────────────────
+// Config knobs — env parsing + scheduling gate
+// ───────────────────────────────────────────────────────────────────────────
+
+/// Parse `SIMARD_SELF_AUDIT_INTERVAL` (value in seconds). A valid `0` is
+/// honored as "disabled" (does NOT fall back to the default); empty or
+/// unparseable input → the default. Surrounding whitespace is tolerated.
+pub fn interval_secs_from_env(raw: Option<&str>) -> u64 {
+    raw.and_then(|v| v.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_INTERVAL_SECS)
+}
+
+/// Daemon interval gate. `interval_secs == 0` disables the audit entirely;
+/// otherwise it is due once `elapsed >= interval` (inclusive boundary).
+pub fn should_run_self_audit(elapsed: Duration, interval_secs: u64) -> bool {
+    interval_secs > 0 && elapsed >= Duration::from_secs(interval_secs)
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Disk-backed last-run persistence — the one capability sibling tasks lack
+// ───────────────────────────────────────────────────────────────────────────
+
+/// Current wall-clock time as unix epoch seconds (the quantity persisted by
+/// [`write_last_run`]). Returns 0 on the impossible pre-epoch clock case.
+pub fn now_epoch_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Read the persisted last-run epoch seconds. An absent file or unparseable
+/// contents both yield `None` (the daemon then initializes to now), so a
+/// corrupt marker never crashes the loop.
+pub fn read_last_run(path: &Path) -> Option<u64> {
+    std::fs::read_to_string(path)
+        .ok()?
+        .trim()
+        .parse::<u64>()
+        .ok()
+}
+
+/// Persist the last-run epoch seconds, creating any missing parent directories
+/// (the daemon may write before the state subtree exists).
+pub fn write_last_run(path: &Path, epoch_secs: u64) -> std::io::Result<()> {
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(path, epoch_secs.to_string())
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Structured report + marker parser
+// ───────────────────────────────────────────────────────────────────────────
+
+/// Structured result of one self-quality-audit run, built by parsing text
+/// markers from the recipe's stdout.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SelfQualityAuditReport {
+    /// Number of SEEK→VALIDATE→FIX waves that reached completion
+    /// (`WAVE_COMPLETE=` marker count, not the numeric wave label).
+    pub waves_completed: u32,
+    /// Pull request URLs opened across all waves (`PR_OPENED=`).
+    pub prs_opened: Vec<String>,
+    /// Pull request URLs self-merged (`PR_MERGED=`).
+    pub prs_merged: Vec<String>,
+    /// Pull request URLs crusty-old-engineer approved (`CRUSTY_APPROVED=`).
+    pub crusty_approved: Vec<String>,
+    /// Pull request URLs left open after the bounded crusty loop gave up
+    /// (`CRUSTY_UNRESOLVED=`) — surfaced for human follow-up.
+    pub crusty_unresolved: Vec<String>,
+    /// The agent's own terminal one-line summary (`AUDIT_COMPLETE=`).
+    pub summary_line: String,
+}
+
+impl SelfQualityAuditReport {
+    /// One-line completion summary suitable for the daemon log.
+    pub fn summary(&self) -> String {
+        format!(
+            "self quality-audit complete: {} wave(s), {} PR(s) opened, {} merged, \
+             {} crusty-approved, {} crusty-unresolved — {}",
+            self.waves_completed,
+            self.prs_opened.len(),
+            self.prs_merged.len(),
+            self.crusty_approved.len(),
+            self.crusty_unresolved.len(),
+            self.summary_line,
+        )
+    }
+}
+
+/// Parse the self-quality-audit text markers from recipe stdout.
+///
+/// Recognized markers (each on its own line; surrounding whitespace tolerated):
+/// ```text
+/// AUDIT_STARTED                 # advisory, ignored
+/// WAVE_START=<n>                # advisory, ignored (does NOT count as complete)
+/// WAVE_COMPLETE=<n>             # counted into waves_completed
+/// PR_OPENED=<url>               # collected in order
+/// PR_MERGED=<url>               # collected in order
+/// CRUSTY_APPROVED=<url>         # collected in order
+/// CRUSTY_UNRESOLVED=<url>       # collected in order
+/// AUDIT_COMPLETE=<summary>      # REQUIRED, non-empty terminal marker
+/// ```
+///
+/// A missing or empty `AUDIT_COMPLETE` marker is a hard parse error: without a
+/// terminal marker the run is not trustworthy. Any unrecognized line is
+/// silently ignored (forward-compatible with human-readable agent prose).
+pub fn parse_self_quality_audit_text(stdout: &str) -> Result<SelfQualityAuditReport, String> {
+    let mut waves_completed: u32 = 0;
+    let mut prs_opened: Vec<String> = Vec::new();
+    let mut prs_merged: Vec<String> = Vec::new();
+    let mut crusty_approved: Vec<String> = Vec::new();
+    let mut crusty_unresolved: Vec<String> = Vec::new();
+    let mut summary_line: Option<String> = None;
+
+    for line in stdout.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if let Some(val) = trimmed.strip_prefix("AUDIT_COMPLETE=") {
+            summary_line = Some(val.trim().to_string());
+        } else if trimmed.strip_prefix("WAVE_COMPLETE=").is_some() {
+            waves_completed += 1;
+        } else if let Some(val) = trimmed.strip_prefix("PR_OPENED=") {
+            push_url(&mut prs_opened, val);
+        } else if let Some(val) = trimmed.strip_prefix("PR_MERGED=") {
+            push_url(&mut prs_merged, val);
+        } else if let Some(val) = trimmed.strip_prefix("CRUSTY_APPROVED=") {
+            push_url(&mut crusty_approved, val);
+        } else if let Some(val) = trimmed.strip_prefix("CRUSTY_UNRESOLVED=") {
+            push_url(&mut crusty_unresolved, val);
+        }
+        // AUDIT_STARTED, WAVE_START=, and all unknown lines are ignored.
+    }
+
+    let summary_line =
+        summary_line.ok_or_else(|| "missing AUDIT_COMPLETE marker in recipe output".to_string())?;
+    if summary_line.is_empty() {
+        return Err("AUDIT_COMPLETE marker has an empty summary".to_string());
+    }
+
+    Ok(SelfQualityAuditReport {
+        waves_completed,
+        prs_opened,
+        prs_merged,
+        crusty_approved,
+        crusty_unresolved,
+        summary_line,
+    })
+}
+
+/// Trim a marker value and push it onto `dst` when non-empty.
+fn push_url(dst: &mut Vec<String>, raw: &str) {
+    let v = raw.trim();
+    if !v.is_empty() {
+        dst.push(v.to_string());
+    }
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Recipe invocation (disk_health no-fallback model)
+// ───────────────────────────────────────────────────────────────────────────
+
+/// JSON envelope returned by `recipe-runner-rs --output-format json`. Extra
+/// fields (e.g. `step_id`) are ignored by serde.
+#[derive(Debug, Deserialize)]
+struct RecipeOutput {
+    success: bool,
+    step_results: Vec<StepResult>,
+}
+
+/// A single step's result inside the [`RecipeOutput`] envelope.
+#[derive(Debug, Deserialize)]
+struct StepResult {
+    output: String,
+}
+
+/// Resolve the recipe YAML path. Checks, in order:
+///   1. `~/.simard/prompt_assets/simard/recipes/<name>` (hot-reload path)
+///   2. `<repo_root>/prompt_assets/simard/recipes/<name>` (in-tree)
+///
+/// `home_override` lets tests supply a fake home directory without mutating the
+/// process-wide `HOME` environment variable. Returns `None` when neither path
+/// holds the recipe file (before any subprocess spawn or config load).
+fn resolve_recipe_path(repo_root: &Path, home_override: Option<&Path>) -> Option<PathBuf> {
+    let home = home_override.map(PathBuf::from).or_else(dirs::home_dir);
+    if let Some(home) = home {
+        let hot = home
+            .join(".simard")
+            .join("prompt_assets/simard/recipes")
+            .join(RECIPE_FILENAME);
+        if hot.is_file() {
+            return Some(hot);
+        }
+    }
+    let in_tree = repo_root
+        .join("prompt_assets/simard/recipes")
+        .join(RECIPE_FILENAME);
+    if in_tree.is_file() {
+        return Some(in_tree);
+    }
+    None
+}
+
+/// Run the monthly self-quality-audit recipe via `recipe-runner-rs`.
+///
+/// `repo_root` locates the recipe YAML and is passed to the recipe as the
+/// `repo_path` context var. `state_root` (typically `~/.simard`) is passed as
+/// the `state_root` context var. `home_override` lets tests point at a fake
+/// home for recipe resolution.
+///
+/// No-fallback contract (mirrors [`crate::disk_health::run_disk_health_check`]):
+/// a missing recipe, a spawn failure, a non-zero exit, `success=false`, or an
+/// unparseable marker set all become [`SimardError::AdapterInvocationFailed`].
+pub fn run_self_quality_audit(
+    repo_root: &Path,
+    state_root: &Path,
+    home_override: Option<&Path>,
+) -> SimardResult<SelfQualityAuditReport> {
+    let recipe_path = resolve_recipe_path(repo_root, home_override).ok_or_else(|| {
+        SimardError::AdapterInvocationFailed {
+            base_type: ADAPTER_TAG.to_string(),
+            reason: format!(
+                "recipe file {RECIPE_FILENAME} not found in hot-reload or in-tree paths"
+            ),
+        }
+    })?;
+
+    let agent_binary = RuntimeConfig::load()?.llm_provider.agent_binary_value();
+
+    let output = Command::new("recipe-runner-rs")
+        .arg(recipe_path.as_os_str())
+        .arg("--output-format")
+        .arg("json")
+        .env("AMPLIHACK_AGENT_BINARY", agent_binary)
+        .arg("-c")
+        .arg(format!("state_root={}", state_root.display()))
+        .arg("-c")
+        .arg(format!("repo_path={}", repo_root.display()))
+        .output()
+        .map_err(|e| SimardError::AdapterInvocationFailed {
+            base_type: ADAPTER_TAG.to_string(),
+            reason: format!("recipe-runner-rs spawn failed: {e}"),
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(SimardError::AdapterInvocationFailed {
+            base_type: ADAPTER_TAG.to_string(),
+            reason: format!(
+                "recipe exited with {}: {}",
+                output.status,
+                truncate(&stderr, 500)
+            ),
+        });
+    }
+
+    let envelope: RecipeOutput = serde_json::from_slice(&output.stdout).map_err(|e| {
+        SimardError::AdapterInvocationFailed {
+            base_type: ADAPTER_TAG.to_string(),
+            reason: format!("failed to deserialize recipe JSON output: {e}"),
+        }
+    })?;
+
+    if !envelope.success {
+        return Err(SimardError::AdapterInvocationFailed {
+            base_type: ADAPTER_TAG.to_string(),
+            reason: "recipe reported success=false in JSON output".to_string(),
+        });
+    }
+
+    if envelope.step_results.is_empty() {
+        return Err(SimardError::AdapterInvocationFailed {
+            base_type: ADAPTER_TAG.to_string(),
+            reason: "no step results in recipe JSON output".to_string(),
+        });
+    }
+
+    // Concatenate every step's output so terminal markers emitted by any step
+    // (the orchestrator prints them last) are captured.
+    let combined = envelope
+        .step_results
+        .iter()
+        .map(|s| s.output.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    parse_self_quality_audit_text(&combined).map_err(|e| SimardError::AdapterInvocationFailed {
+        base_type: ADAPTER_TAG.to_string(),
+        reason: format!("failed to parse recipe text output: {e}"),
+    })
+}
+
+/// Truncate `s` to at most `max` characters, appending an ellipsis if cut.
+fn truncate(s: &str, max: usize) -> String {
+    let mut chars = s.chars();
+    let prefix: String = chars.by_ref().take(max).collect();
+    if chars.next().is_some() {
+        prefix + "…"
+    } else {
+        prefix
+    }
+}

--- a/src/self_quality_audit_tests.rs
+++ b/src/self_quality_audit_tests.rs
@@ -1,0 +1,511 @@
+//! TDD (RED) tests for the recurring **monthly self-quality-audit** periodic
+//! task (goal: reuse the brain-introspection / disk-health periodic-task
+//! pattern, issue [#2419](https://github.com/rysweet/Simard/issues/2419)).
+//!
+//! Written **before** the production code. Expected to FAIL until
+//! `crate::self_quality_audit` (the module) and
+//! `prompt_assets/simard/recipes/monthly-self-quality-audit.yaml` land. The
+//! unresolved `crate::self_quality_audit::…` import is the intended,
+//! deterministic RED signal under `cargo test`.
+//!
+//! `cargo build` / `cargo build --release` stay GREEN — this module is
+//! `#[cfg(test)]`, so the not-yet-existing references are never compiled into
+//! the library or the daemon binary (mirrors `brain_introspection_tests.rs`).
+//!
+//! ## Contract pinned by these tests
+//!
+//! This periodic task is modeled on [`crate::disk_health`] (a **pure recipe
+//! invoker**, no memory RPCs) with **one novel capability**: it persists its
+//! last-run wall-clock timestamp to disk so the ~30-day cadence **survives
+//! daemon restarts** (all sibling tasks gate on an in-process `Instant`, which
+//! resets on reboot — fine at 24h, wrong at 30d).
+//!
+//! Split of labor: the **Rust hook** owns the interval gate, disk-backed
+//! last-run persistence, subprocess spawn, marker parsing, and logging. The
+//! **recipe (a `recipe-runner-rs` subprocess)** owns all LLM judgment: the five
+//! SEEK→VALIDATE→FIX quality-audit waves, the bounded crusty-old-engineer proxy
+//! review loop, and the self-merge decisions.
+//!
+//! Unlike `brain_introspection` (best-effort/graceful), the self-audit follows
+//! the `disk_health` **no-fallback** contract: any recipe failure propagates as
+//! `SimardError::AdapterInvocationFailed`; the daemon WARNs and continues, and
+//! persists last-run regardless (on `Ok` AND `Err`) to prevent hot-looping.
+//!
+//! ```ignore
+//! // crate::self_quality_audit — surface under test
+//! pub const DEFAULT_INTERVAL_SECS: u64 = 2_592_000; // ~30 days
+//!
+//! pub fn interval_secs_from_env(raw: Option<&str>) -> u64;
+//! pub fn should_run_self_audit(elapsed: Duration, interval_secs: u64) -> bool;
+//!
+//! pub fn read_last_run(path: &Path) -> Option<u64>;
+//! pub fn write_last_run(path: &Path, epoch_secs: u64) -> std::io::Result<()>;
+//!
+//! pub struct SelfQualityAuditReport {
+//!     pub waves_completed: u32,
+//!     pub prs_opened: Vec<String>,
+//!     pub prs_merged: Vec<String>,
+//!     pub crusty_approved: Vec<String>,
+//!     pub crusty_unresolved: Vec<String>,
+//!     pub summary_line: String,
+//! }
+//! impl SelfQualityAuditReport { pub fn summary(&self) -> String; }
+//!
+//! pub fn parse_self_quality_audit_text(stdout: &str)
+//!     -> Result<SelfQualityAuditReport, String>;
+//! pub fn run_self_quality_audit(repo_root: &Path, state_root: &Path,
+//!     home_override: Option<&Path>) -> SimardResult<SelfQualityAuditReport>;
+//! // resolve_recipe_path is a *private* fn (matches disk_health), so it is
+//! // exercised indirectly through run_self_quality_audit's recipe-not-found path.
+//! ```
+
+#![allow(clippy::bool_assert_comparison)]
+
+use crate::error::SimardError;
+use crate::self_quality_audit::{
+    DEFAULT_INTERVAL_SECS, SelfQualityAuditReport, interval_secs_from_env,
+    parse_self_quality_audit_text, read_last_run, run_self_quality_audit, should_run_self_audit,
+    write_last_run,
+};
+
+use std::path::Path;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+/// Current wall-clock time as unix epoch seconds (the same quantity the daemon
+/// stores via `write_last_run`).
+fn now_epoch() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock is after the unix epoch")
+        .as_secs()
+}
+
+// ===========================================================================
+// 1. Defaults + SIMARD_SELF_AUDIT_INTERVAL env parsing
+// ===========================================================================
+
+#[test]
+fn default_interval_is_thirty_days() {
+    // 2_592_000s == 30 * 24 * 60 * 60 == ~30 days (the goal's stated default).
+    assert_eq!(
+        DEFAULT_INTERVAL_SECS, 2_592_000,
+        "cadence defaults to ~30 days"
+    );
+    assert_eq!(DEFAULT_INTERVAL_SECS, 30 * 24 * 60 * 60);
+}
+
+#[test]
+fn interval_secs_unset_uses_default() {
+    assert_eq!(interval_secs_from_env(None), DEFAULT_INTERVAL_SECS);
+}
+
+#[test]
+fn interval_secs_empty_uses_default() {
+    // Empty string is not a valid u64 -> conservative default, NOT disabled.
+    assert_eq!(interval_secs_from_env(Some("")), DEFAULT_INTERVAL_SECS);
+    assert_eq!(interval_secs_from_env(Some("   ")), DEFAULT_INTERVAL_SECS);
+}
+
+#[test]
+fn interval_secs_parses_valid_value() {
+    assert_eq!(interval_secs_from_env(Some("3600")), 3600);
+    assert_eq!(interval_secs_from_env(Some("2592000")), 2_592_000);
+    // Surrounding whitespace is tolerated (matches sibling env parsers).
+    assert_eq!(interval_secs_from_env(Some("  86400  ")), 86_400);
+}
+
+#[test]
+fn interval_secs_zero_is_honored_as_disabled_value() {
+    // 0 is a *valid* parse meaning "disabled"; it must NOT fall back to default.
+    assert_eq!(interval_secs_from_env(Some("0")), 0);
+}
+
+#[test]
+fn interval_secs_garbage_falls_back_to_default() {
+    assert_eq!(
+        interval_secs_from_env(Some("not-a-number")),
+        DEFAULT_INTERVAL_SECS
+    );
+    assert_eq!(interval_secs_from_env(Some("30d")), DEFAULT_INTERVAL_SECS);
+    assert_eq!(interval_secs_from_env(Some("-1")), DEFAULT_INTERVAL_SECS);
+}
+
+// ===========================================================================
+// 2. Scheduling gate — should_run_self_audit(elapsed, interval)
+//    Pure: interval > 0 && elapsed >= interval
+// ===========================================================================
+
+#[test]
+fn gate_disabled_when_interval_zero() {
+    assert_eq!(
+        should_run_self_audit(Duration::from_secs(10_000_000_000), 0),
+        false,
+        "interval 0 must disable the audit entirely, regardless of elapsed"
+    );
+}
+
+#[test]
+fn gate_holds_when_not_yet_elapsed() {
+    // One second short of the default interval -> not due.
+    assert_eq!(
+        should_run_self_audit(
+            Duration::from_secs(DEFAULT_INTERVAL_SECS - 1),
+            DEFAULT_INTERVAL_SECS
+        ),
+        false,
+        "must NOT fire before a full interval has elapsed"
+    );
+    assert_eq!(
+        should_run_self_audit(Duration::from_secs(0), DEFAULT_INTERVAL_SECS),
+        false,
+        "must NOT fire immediately after a fresh init (elapsed == 0)"
+    );
+}
+
+#[test]
+fn gate_fires_exactly_at_interval_boundary() {
+    assert_eq!(
+        should_run_self_audit(
+            Duration::from_secs(DEFAULT_INTERVAL_SECS),
+            DEFAULT_INTERVAL_SECS
+        ),
+        true,
+        "elapsed == interval is due (>=, not >)"
+    );
+}
+
+#[test]
+fn gate_fires_when_elapsed_exceeds_interval() {
+    assert_eq!(
+        should_run_self_audit(
+            Duration::from_secs(DEFAULT_INTERVAL_SECS + 5_000),
+            DEFAULT_INTERVAL_SECS
+        ),
+        true
+    );
+}
+
+// ===========================================================================
+// 3. Last-run persistence — write_last_run / read_last_run
+//    (the one capability sibling periodic tasks lack)
+// ===========================================================================
+
+#[test]
+fn last_run_round_trips_through_disk() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("self_quality_audit_last_run");
+
+    let epoch = 1_735_689_600; // 2025-01-01T00:00:00Z
+    write_last_run(&path, epoch).expect("write_last_run should succeed");
+
+    assert!(path.is_file(), "last-run file must exist after write");
+    assert_eq!(
+        read_last_run(&path),
+        Some(epoch),
+        "read_last_run must return exactly what write_last_run persisted"
+    );
+}
+
+#[test]
+fn read_last_run_is_none_when_file_absent() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("self_quality_audit_last_run");
+    assert!(!path.exists());
+    assert_eq!(
+        read_last_run(&path),
+        None,
+        "absent last-run file => None (daemon then init-to-now)"
+    );
+}
+
+#[test]
+fn read_last_run_is_none_on_garbage_contents() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("self_quality_audit_last_run");
+    std::fs::write(&path, "not-an-epoch\n").unwrap();
+    assert_eq!(
+        read_last_run(&path),
+        None,
+        "unparseable contents are treated as missing (=> init-to-now, no crash)"
+    );
+}
+
+#[test]
+fn write_last_run_creates_missing_parent_dir() {
+    // The daemon may write before the state dir subtree exists.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir
+        .path()
+        .join("nested")
+        .join("state")
+        .join("self_quality_audit_last_run");
+    assert!(!path.parent().unwrap().exists());
+
+    write_last_run(&path, 42).expect("write_last_run must create parent dirs");
+    assert_eq!(read_last_run(&path), Some(42));
+}
+
+// ===========================================================================
+// 4. Restart survival — persistence + gate together
+//    Fires ~monthly, NOT on every restart.
+// ===========================================================================
+
+#[test]
+fn simulated_restart_does_not_immediately_refire() {
+    // Simulate: a run just happened (last_run = now), then the daemon restarts
+    // and reloads last_run from disk. Elapsed ≈ 0 -> gate must stay false.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("self_quality_audit_last_run");
+
+    let now = now_epoch();
+    write_last_run(&path, now).unwrap();
+
+    // "Restart": read the persisted epoch back and recompute elapsed.
+    let last = read_last_run(&path).expect("persisted last-run survives restart");
+    let elapsed = Duration::from_secs(now_epoch().saturating_sub(last));
+
+    assert_eq!(
+        should_run_self_audit(elapsed, DEFAULT_INTERVAL_SECS),
+        false,
+        "a restart moments after a run must NOT re-trigger the heavy 5-wave audit"
+    );
+}
+
+#[test]
+fn stale_last_run_triggers_audit_after_interval() {
+    // Persisted last-run is older than one interval -> due on the next cycle,
+    // even across a restart.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("self_quality_audit_last_run");
+
+    let stale = now_epoch().saturating_sub(DEFAULT_INTERVAL_SECS + 10);
+    write_last_run(&path, stale).unwrap();
+
+    let last = read_last_run(&path).expect("persisted last-run survives restart");
+    let elapsed = Duration::from_secs(now_epoch().saturating_sub(last));
+
+    assert_eq!(
+        should_run_self_audit(elapsed, DEFAULT_INTERVAL_SECS),
+        true,
+        "a last-run older than the interval must fire the audit"
+    );
+}
+
+// ===========================================================================
+// 5. Marker parser — parse_self_quality_audit_text
+//    AUDIT_COMPLETE is REQUIRED; WAVE_COMPLETE counts; URLs collected per marker.
+// ===========================================================================
+
+#[test]
+fn parse_full_marker_set() {
+    let text = "\
+AUDIT_STARTED
+WAVE_START=1
+WAVE_COMPLETE=1
+PR_OPENED=https://github.com/rysweet/Simard/pull/101
+WAVE_START=2
+WAVE_COMPLETE=2
+PR_OPENED=https://github.com/rysweet/Simard/pull/102
+CRUSTY_APPROVED=https://github.com/rysweet/Simard/pull/101
+PR_MERGED=https://github.com/rysweet/Simard/pull/101
+WAVE_START=3
+WAVE_COMPLETE=3
+WAVE_START=4
+WAVE_COMPLETE=4
+WAVE_START=5
+WAVE_COMPLETE=5
+CRUSTY_UNRESOLVED=https://github.com/rysweet/Simard/pull/102
+AUDIT_COMPLETE=5 waves run; 2 PRs opened, 1 merged, 1 crusty-unresolved
+";
+    let report = parse_self_quality_audit_text(text).expect("full marker set must parse");
+
+    assert_eq!(report.waves_completed, 5, "counts WAVE_COMPLETE markers");
+    assert_eq!(
+        report.prs_opened,
+        vec![
+            "https://github.com/rysweet/Simard/pull/101".to_string(),
+            "https://github.com/rysweet/Simard/pull/102".to_string(),
+        ]
+    );
+    assert_eq!(
+        report.prs_merged,
+        vec!["https://github.com/rysweet/Simard/pull/101".to_string()]
+    );
+    assert_eq!(
+        report.crusty_approved,
+        vec!["https://github.com/rysweet/Simard/pull/101".to_string()]
+    );
+    assert_eq!(
+        report.crusty_unresolved,
+        vec!["https://github.com/rysweet/Simard/pull/102".to_string()]
+    );
+    assert_eq!(
+        report.summary_line,
+        "5 waves run; 2 PRs opened, 1 merged, 1 crusty-unresolved"
+    );
+}
+
+#[test]
+fn parse_minimal_only_audit_complete() {
+    // The only required marker; everything else defaults to empty/zero.
+    let report = parse_self_quality_audit_text("AUDIT_COMPLETE=nothing to fix this month")
+        .expect("AUDIT_COMPLETE alone is a valid (no-op) audit");
+    assert_eq!(report.waves_completed, 0);
+    assert!(report.prs_opened.is_empty());
+    assert!(report.prs_merged.is_empty());
+    assert!(report.crusty_approved.is_empty());
+    assert!(report.crusty_unresolved.is_empty());
+    assert_eq!(report.summary_line, "nothing to fix this month");
+}
+
+#[test]
+fn parse_waves_completed_counts_only_complete_not_start() {
+    // Three waves started, only two finished -> waves_completed == 2.
+    let text = "\
+WAVE_START=1
+WAVE_COMPLETE=1
+WAVE_START=2
+WAVE_COMPLETE=2
+WAVE_START=3
+AUDIT_COMPLETE=partial run: 2 of 3 waves finished
+";
+    let report = parse_self_quality_audit_text(text).unwrap();
+    assert_eq!(
+        report.waves_completed, 2,
+        "WAVE_START must not inflate the completed count"
+    );
+}
+
+#[test]
+fn parse_missing_audit_complete_is_error() {
+    // Waves ran but no terminal marker -> the run is not trustworthy; reject it.
+    let text = "\
+WAVE_START=1
+WAVE_COMPLETE=1
+PR_OPENED=https://github.com/rysweet/Simard/pull/9
+";
+    let result = parse_self_quality_audit_text(text);
+    assert!(
+        result.is_err(),
+        "missing AUDIT_COMPLETE must be a parse error"
+    );
+}
+
+#[test]
+fn parse_empty_audit_complete_is_error() {
+    // AUDIT_COMPLETE must carry a non-empty summary.
+    let result = parse_self_quality_audit_text("WAVE_COMPLETE=1\nAUDIT_COMPLETE=\n");
+    assert!(
+        result.is_err(),
+        "empty AUDIT_COMPLETE value must be rejected"
+    );
+    let result_ws = parse_self_quality_audit_text("AUDIT_COMPLETE=   \n");
+    assert!(
+        result_ws.is_err(),
+        "whitespace-only AUDIT_COMPLETE value must be rejected"
+    );
+}
+
+#[test]
+fn parse_empty_string_is_error() {
+    assert!(
+        parse_self_quality_audit_text("").is_err(),
+        "empty output must be a parse error (no AUDIT_COMPLETE)"
+    );
+}
+
+#[test]
+fn parse_ignores_unknown_lines() {
+    let text = "\
+some human-readable preamble the agent printed
+AUDIT_STARTED
+WAVE_COMPLETE=1
+NOTE: this line is not a recognized marker
+AUDIT_COMPLETE=1 wave, no PRs
+";
+    let report = parse_self_quality_audit_text(text).unwrap();
+    assert_eq!(report.waves_completed, 1);
+    assert!(report.prs_opened.is_empty());
+    assert_eq!(report.summary_line, "1 wave, no PRs");
+}
+
+#[test]
+fn parse_trims_whitespace_around_markers_and_values() {
+    // Padding is embedded via explicit `\n` (not end-of-source-line whitespace)
+    // so the intent survives any whitespace-trimming tool while still exercising
+    // the parser's trimming of markers, URL values, and the AUDIT_COMPLETE summary.
+    let text = "  WAVE_COMPLETE=1  \n   PR_OPENED=https://github.com/rysweet/Simard/pull/7   \n  AUDIT_COMPLETE=  done with leading/trailing spaces  \n";
+    let report = parse_self_quality_audit_text(text).unwrap();
+    assert_eq!(report.waves_completed, 1);
+    assert_eq!(
+        report.prs_opened,
+        vec!["https://github.com/rysweet/Simard/pull/7".to_string()],
+        "PR URL must be trimmed"
+    );
+    assert_eq!(
+        report.summary_line, "done with leading/trailing spaces",
+        "AUDIT_COMPLETE summary must be trimmed"
+    );
+}
+
+// ===========================================================================
+// 6. SelfQualityAuditReport::summary — one-line daemon completion log
+// ===========================================================================
+
+#[test]
+fn summary_mentions_key_counts() {
+    let report = SelfQualityAuditReport {
+        waves_completed: 5,
+        prs_opened: vec![
+            "a".to_string(),
+            "b".to_string(),
+            "c".to_string(),
+            "d".to_string(),
+        ],
+        prs_merged: vec!["a".to_string(), "b".to_string(), "c".to_string()],
+        crusty_approved: vec!["a".to_string(), "b".to_string(), "c".to_string()],
+        crusty_unresolved: vec!["d".to_string()],
+        summary_line: "agent's own terminal summary".to_string(),
+    };
+    let s = report.summary();
+
+    assert!(
+        s.to_lowercase().contains("self quality-audit"),
+        "completion log line should identify the task: {s}"
+    );
+    assert!(s.contains('5'), "should report waves_completed (5): {s}");
+    assert!(s.contains('4'), "should report PRs opened (4): {s}");
+    assert!(s.contains('3'), "should report PRs merged (3): {s}");
+    assert!(
+        s.contains('1'),
+        "should report crusty-unresolved count (1): {s}"
+    );
+}
+
+// ===========================================================================
+// 7. run_self_quality_audit — no-fallback contract (disk_health model)
+//    Recipe missing => hard SimardError::AdapterInvocationFailed (deterministic:
+//    resolve_recipe_path returns None BEFORE any subprocess or config load).
+// ===========================================================================
+
+#[test]
+fn run_errors_when_recipe_missing() {
+    // Empty home => hot-reload path misses; nonexistent repo => in-tree misses.
+    let empty_home = tempfile::tempdir().unwrap();
+    let err = run_self_quality_audit(
+        Path::new("/nonexistent/repo"),
+        Path::new("/nonexistent/state"),
+        Some(empty_home.path()),
+    )
+    .expect_err("no-fallback contract: a missing recipe must be a hard error");
+
+    match err {
+        SimardError::AdapterInvocationFailed { reason, .. } => {
+            assert!(
+                reason.contains("monthly-self-quality-audit.yaml"),
+                "error reason should name the missing recipe file: {reason}"
+            );
+        }
+        other => panic!("expected AdapterInvocationFailed, got: {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

Adds a recurring **~30-day self-quality-audit** to the Simard OODA daemon, reusing the existing periodic-task pattern established by brain-introspection / disk-health (#2436). On its own interval the daemon runs a **five-wave, crusty-gated quality audit of Simard's OWN code** (`rysweet/Simard`).

Closes #2419.

## What it does

- **New module `src/self_quality_audit.rs`** — a pure recipe invoker (modeled on `disk_health.rs`):
  - `SIMARD_SELF_AUDIT_INTERVAL` env parsing (default `2592000s` ≈ 30 days; `0` disables; garbage → default).
  - Pure `should_run_self_audit(elapsed, interval)` gate (`interval > 0 && elapsed >= interval`).
  - **Disk-backed last-run persistence** (`read_last_run`/`write_last_run` at `state_root/self_quality_audit_last_run`) — the one capability sibling tasks lack — so the monthly cadence **survives daemon restarts**.
  - Text-marker parser → `SelfQualityAuditReport` + one-line `summary()`.
  - `run_self_quality_audit` following the `disk_health` **no-fallback** contract (recipe failure → `SimardError::AdapterInvocationFailed`).
- **Daemon wiring (`operator_commands_ooda/daemon/mod.rs`)**:
  - Startup log `self quality-audit interval = <N>s`, mirroring the sibling intervals.
  - **Init-to-now** on a missing/garbage marker (no heavy audit on a fresh deploy; first fire ~one interval later).
  - Loop branch: logs on fire, runs the hook, logs completion (or WARNs), and **persists last-run on BOTH `Ok` and `Err`** to prevent hot-looping a failing recipe.
- **Recipe `prompt_assets/simard/recipes/monthly-self-quality-audit.yaml`**:
  - Five sequential SEEK→VALIDATE→FIX waves via the amplihack `quality-audit` skill on `rysweet/Simard`.
  - Per resulting PR, a **bounded (≤3 round)** `crusty-old-engineer` proxy review as operator Ryan's stand-in; unresolved PRs left open.
  - Self-merge of crusty-approved **and** CI-green PRs (respecting branch protection).
  - Emits the text markers the Rust shim parses. No point-in-time/snapshot docs.
- **Docs**: architecture / how-to / reference pages + mkdocs nav, mirroring the brain-introspection doc trio.

## Tests (`src/self_quality_audit_tests.rs`, 26 cases)

Interval env parsing (unset/valid/`0`/garbage), gate before/at/after interval, last-run round-trip + **restart-survival** (no immediate re-fire; stale marker fires after interval), full marker-grammar parser, and the missing-recipe hard-error path.

## Verification

- `cargo fmt --check` clean
- `cargo clippy --all-targets --all-features --locked -- -D warnings` clean (pre-push gate)
- `cargo build` (debug + release) green
- Full library test suite: **6479 passed, 0 failed** (incl. 26 new)

## Acceptance

Daemon has a monthly self-quality-audit periodic task (config + recipe + hook + tests) that fires ~every 30 days and runs the 5-wave crusty-gated self-audit; startup logs the interval. Reuses the existing periodic-task infra (no new scheduler).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>