### PR TITLE
feat(distill): env-gated raw-capture of surviving parse failures (Wave 1, #2432)

### DIFF
--- a/docs/howto/capture-and-diagnose-a-failing-distill-sample.md
+++ b/docs/howto/capture-and-diagnose-a-failing-distill-sample.md
@@ -1,0 +1,190 @@
+---
+title: Capture and diagnose a failing distill sample
+description: Step-by-step how-to for harvesting a real, currently-failing distillation recipe output with the env-gated raw-capture diagnostic, classifying whether the residual parse failure is an extractor-chokepoint gap or a prompt/retry-side gap, and turning the harvested bytes into a regression test — the SIMARD_DISTILL_RAW_CAPTURE toggle, reading distill_parse_success_rate from metrics.jsonl, and wiring the sample into the recipe_output and distillation test suites.
+last_updated: 2026-07-02
+review_schedule: as-needed
+owner: simard
+doc_type: howto
+related:
+  - ../reference/distill-raw-capture-on-parse-failure.md
+  - ../reference/distill-recipe-output-capture.md
+  - ../concepts/copilot-launcher-preamble-stripping.md
+  - ../howto/diagnose-decide-orient-parse-failures.md
+  - ../architecture/episode-distillation.md
+---
+
+# Capture and diagnose a failing distill sample
+
+Use this how-to when distillation is producing few or no facts and you suspect a
+**residual parse failure** — a distill pass that exits `0` but whose output the
+extractor cannot turn into a `{ "facts": [...] }` object, even after the
+#2504 / #2512 launch-banner chokepoint fixes.
+
+The goal is to stop guessing: harvest the **exact bytes** that fail, classify
+the real root cause, and lock it down with a regression test built from a real
+sample rather than a hand-written approximation.
+
+For the diagnostic's full contract (config, security, API), see
+[Distill raw-capture on parse failure](../reference/distill-raw-capture-on-parse-failure.md).
+
+> **Note:** the raw-capture diagnostic is **implemented (Wave 1)** — the
+> `SIMARD_DISTILL_RAW_CAPTURE` toggle and `~/.simard/distill-captures/` output
+> ship in the Wave 1 build. It is **off by default**: nothing is written unless
+> you set the toggle. Step 1 (measuring `distill_parse_success_rate`) works on
+> any build; Steps 2–4 require a build that includes Wave 1.
+
+## Before you start
+
+- A running (or runnable) OODA daemon that performs distillation passes.
+- Write access to `~/.simard/` (state home).
+- The Simard source checkout, to add the regression test once you have a sample.
+
+## Step 1 — Confirm there really is a residual failure
+
+Raw-capture only exists to explain a *residual* failure, so first prove one is
+happening. The `distill_parse_success_rate` metric is emitted once per pass that
+reached output parsing; its mean is the parse-success rate.
+
+```bash
+grep '"metric_name":"distill_parse_success_rate"' ~/.simard/metrics/metrics.jsonl \
+  | tail -n 50
+```
+
+- If recent values are mostly `1.0`, the launch-banner fix already recovered the
+  path — **there is no residual failure to chase.** Record that evidence and
+  stop; do not re-harden a working extractor.
+- If recent values are frequently `0.0`, note the `failure_class`, `attempt`,
+  and `fact_count` fields, then continue.
+
+## Step 2 — Enable raw-capture and restart the daemon
+
+Capture is default-off. Turn it on and restart so the running process picks up
+the environment:
+
+```bash
+SIMARD_DISTILL_RAW_CAPTURE=1 simard ooda run
+```
+
+If you run under systemd-user, add the variable to the unit environment and
+restart:
+
+```bash
+systemctl --user set-environment SIMARD_DISTILL_RAW_CAPTURE=1
+systemctl --user restart simard-ooda
+```
+
+Only a `parse-failure` that survives the bounded in-cycle retry writes a
+sample, so nothing appears until a genuine residual failure recurs.
+
+## Step 3 — Harvest a sample
+
+Watch the capture directory and read the first sample that lands:
+
+```bash
+ls -lt ~/.simard/distill-captures/
+head -20 ~/.simard/distill-captures/distill-parsefail-*.txt
+```
+
+The header block tells you the failure context; everything below the
+`# ---- raw recipe-runner stdout (verbatim) ----` fence is the raw runner stdout
+that failed to parse:
+
+```text
+# distill parse-failure raw capture
+# See docs/reference/distill-raw-capture-on-parse-failure.md
+# failure_class: parse-failure
+# recipe_exited_ok: true
+# attempt: 2
+# recovered_after_retry: false
+# input_count: 34
+# fact_count: 0
+# captured_at: 2026-07-02T20:31:14+00:00
+# raw_bytes: 4127
+# ---- raw recipe-runner stdout (verbatim) ----
+<the exact bytes that failed to parse>
+```
+
+Copy one representative sample somewhere safe before it rotates out of the ring.
+
+## Step 4 — Classify the root cause
+
+Look at the payload below the fence and decide which layer is actually broken:
+
+| What the payload shows | Likely root cause | Fix layer |
+| --- | --- | --- |
+| A valid `{ "facts": [...] }` object buried under ANSI / log / banner / launch-preamble noise | **Extractor gap** — a noise shape the chokepoint does not strip yet | `src/recipe_output/extract.rs` |
+| No JSON object at all — the agent answered in prose, or emitted `{...}` without a `facts` key | **Prompt/retry gap** — the strict-JSON retry still misses on `attempt=2` | distill recipe prompt + retry path in `src/memory_consolidation/distillation.rs` |
+| Truncated / malformed JSON (unbalanced braces, cut mid-string) | **Upstream truncation** — runner output limit or agent cutoff | runner invocation / output cap |
+
+`recipe_exited_ok: true` with `fact_count: 0` and a payload that clearly
+contains a facts object points at the extractor; the same fields with a payload
+that contains **no** facts object point at the prompt/retry side. This
+distinction is the whole reason to harvest a real sample — the two fixes are in
+different files, and hardening the wrong one leaves the failure intact.
+
+## Step 5 — Turn the sample into a regression test
+
+Add the harvested bytes verbatim as a fixture and assert the *current* behavior
+you want:
+
+- **Extractor gap** → add a test in the `#[cfg(test)]` module of
+  `src/recipe_output/extract.rs` asserting `extract_json_payload(SAMPLE)` returns
+  the embedded facts object. This mirrors the existing
+  `extract_json_payload_recovers_*` tests.
+- **Prompt/retry gap** → add a test in `src/memory_consolidation/distillation.rs`
+  driving the runner with the captured output and asserting the pass recovers
+  (or classifies correctly) rather than silently deferring.
+
+Keep the sample byte-for-byte — the point of a real capture is that it
+reproduces the production failure exactly. Then run the suite:
+
+```bash
+cargo test --quiet recipe_output
+cargo test --quiet distill
+```
+
+## Step 6 — Verify recovery, then turn capture back off
+
+After the fix lands and the daemon redeploys, confirm the metric recovers:
+
+```bash
+grep '"metric_name":"distill_parse_success_rate"' ~/.simard/metrics/metrics.jsonl \
+  | tail -n 50
+```
+
+Values should return toward `1.0`. Once you have your sample and the fix is
+verified, disable capture again so the daemon stops writing diagnostic files:
+
+```bash
+systemctl --user unset-environment SIMARD_DISTILL_RAW_CAPTURE
+systemctl --user restart simard-ooda
+# or simply relaunch without the variable set
+```
+
+## Troubleshooting
+
+- **No files appear.** Check that the failure is actually a `parse-failure`
+  (Step 1) — a `spawn-failure`, `copilot-terminal-failure`,
+  `recipe-reported-failure`, or `serialize-failure` never reaches parsing and is
+  never captured. Confirm `SIMARD_DISTILL_RAW_CAPTURE` is truthy in the daemon's
+  environment.
+- **Samples rotate away too fast.** Raise `SIMARD_DISTILL_RAW_CAPTURE_KEEP`
+  (default `20`).
+- **Samples are truncated.** Raise `SIMARD_DISTILL_RAW_CAPTURE_MAX_BYTES`
+  (default `65536`, max `4194304`).
+- **Metric never changes.** A stale daemon that never redeployed the fix will
+  keep failing even though `main` is fixed — a merged fix does not reach the
+  running process until the daemon relaunches into the new binary. Confirm the
+  deployed `~/.simard/bin/simard` post-dates the fix commit before treating a
+  persistent failure as a code bug.
+
+## Related
+
+- [Distill raw-capture on parse failure](../reference/distill-raw-capture-on-parse-failure.md)
+  — full reference for the diagnostic.
+- [Distill recipe output capture](../reference/distill-recipe-output-capture.md)
+  — the envelope parse contract.
+- [Copilot launch-log preamble stripping](../concepts/copilot-launcher-preamble-stripping.md)
+  — the shared chokepoint your extractor test targets.
+- [Diagnose decide/orient parse failures](./diagnose-decide-orient-parse-failures.md)
+  — the sibling brain-phase parse diagnostic.

--- a/docs/reference/distill-raw-capture-on-parse-failure.md
+++ b/docs/reference/distill-raw-capture-on-parse-failure.md
@@ -1,0 +1,342 @@
+---
+title: Distill raw-capture on parse failure
+description: Reference for the env-gated, default-off diagnostic that persists the raw recipe-runner-rs stdout of a failed distillation pass so a real currently-failing sample can be harvested and turned into a regression test — the SIMARD_DISTILL_RAW_CAPTURE toggle, the 0700 capture directory and 0600 sample files, the per-sample size cap and bounded rotation ring, the raw_capture module API, and the metrics-hygiene guarantee that metrics.jsonl carries only classification counters, never the raw payload.
+last_updated: 2026-07-02
+review_schedule: as-needed
+owner: simard
+doc_type: reference
+status: implemented
+related:
+  - ./distill-recipe-output-capture.md
+  - ../architecture/episode-distillation.md
+  - ../concepts/copilot-launcher-preamble-stripping.md
+  - ./text-parsing-wire-formats.md
+  - ../howto/capture-and-diagnose-a-failing-distill-sample.md
+  - ../../src/memory_consolidation/raw_capture.rs
+  - ../../src/memory_consolidation/distillation.rs
+  - ../../src/recipe_output/extract.rs
+---
+
+# Distill raw-capture on parse failure
+
+> **Status: implemented (Wave 1, 2026-07-02 operator-review priority 1).** The
+> env-gated raw-capture diagnostic lives in
+> [`src/memory_consolidation/raw_capture.rs`](https://github.com/rysweet/Simard/blob/main/src/memory_consolidation/raw_capture.rs)
+> and is invoked from the surviving-parse-failure path in
+> [`src/memory_consolidation/distillation.rs`](https://github.com/rysweet/Simard/blob/main/src/memory_consolidation/distillation.rs).
+> It is **OFF by default** and writes nothing unless `SIMARD_DISTILL_RAW_CAPTURE`
+> is set to a truthy value. It is the harvesting tool behind the residual distill
+> parse failures that persist *in a stale deployment* after the #2504 / #2512 /
+> #2513 chokepoint fixes — on current `main` the launch-banner class of failure
+> is already recovered (see
+> [`parser_extracts_facts_and_procedures_from_real_prose_prefixed_envelope`](https://github.com/rysweet/Simard/blob/main/src/memory_consolidation/distillation_tests.rs)),
+> so any *new* residual has a different root cause (the agent emitted no
+> `{ facts }` object, malformed JSON, or a strict-JSON-retry miss) that this
+> diagnostic makes inspectable.
+
+The distillation pass turns batches of episodes into semantic facts by shelling
+out to `recipe-runner-rs` and parsing the distill agent's
+`{ "facts": [...], "procedures": [...] }` JSON from the runner envelope. When a
+pass classifies as a [`ParseFailure`](./distill-recipe-output-capture.md) — the
+recipe exited `0` and a step ran, but its output carried no parseable facts
+object — the failure is non-fatal: no markers are set and the batch retries.
+That is correct for production resilience but **useless for debugging**, because
+the exact bytes that failed to parse are gone by the next cycle.
+
+Raw-capture closes that gap. When enabled, a `ParseFailure` (and only a
+`ParseFailure`) writes the raw, pre-extraction recipe stdout to a rotating,
+mode-`0600` file under a mode-`0700` directory. An operator can then harvest a
+**real currently-failing sample**, add it verbatim as a regression fixture, and
+confirm whether the residual failure is a chokepoint/extractor gap or a
+prompt/retry-side gap — without guessing.
+
+For the parse contract this diagnostic instruments, see
+[Distill recipe output capture](./distill-recipe-output-capture.md). For the
+shared noise-stripping chokepoint the samples are tested against, see
+[Copilot launch-log preamble stripping](../concepts/copilot-launcher-preamble-stripping.md).
+
+## Contents
+
+- [Why](#why)
+- [Enable it](#enable-it)
+- [Where samples are written](#where-samples-are-written)
+- [Configuration](#configuration)
+- [Capture-file format](#capture-file-format)
+- [Public API](#public-api)
+- [Metrics hygiene](#metrics-hygiene)
+- [Security model](#security-model)
+- [Examples](#examples)
+- [When capture does *not* fire](#when-capture-does-not-fire)
+
+## Why
+
+The #2504 and #2512 fixes routed every recipe-backed phase — decide, orient,
+and the **distill** pass — through the single hardened extractor in
+[`src/recipe_output/extract.rs`](https://github.com/rysweet/Simard/blob/main/src/recipe_output/extract.rs),
+which strips ANSI colour codes, timestamped log lines, the runner's human
+banner, and the GitHub Copilot CLI launch-log preamble
+(`ℹ … NODE_OPTIONS=… (saved preference)`, `Run 'copilot update' …`,
+`… launching copilot binary=…`). That eliminated the launch-banner class of
+parse failure.
+
+Any *residual* parse failure therefore has a different root cause — the agent
+emitted no `{ facts }` object at all, emitted malformed JSON, or the strict-JSON
+retry still missed on `attempt=2`. You cannot tell which from a counter alone.
+Raw-capture makes the failing bytes inspectable so the fix targets the layer
+that is actually broken, instead of re-hardening an extractor that already
+works.
+
+## Enable it
+
+Capture is default-off. Turn it on for the running daemon (or a one-shot pass)
+by setting the toggle:
+
+```bash
+SIMARD_DISTILL_RAW_CAPTURE=1 simard ooda run
+```
+
+The value is parsed leniently: `1`, `true`, `yes`, and `on`
+(case-insensitive) enable capture; anything else — including unset, empty,
+`0`, `false` — leaves it off. There is no CLI flag; capture is controlled
+entirely by the environment so it can be toggled on a live daemon by editing
+the service environment and restarting, without a rebuild.
+
+## Where samples are written
+
+Samples are written under the Simard state home, in a dedicated subdirectory:
+
+```
+~/.simard/distill-captures/
+├── distill-parsefail-20260702T203114Z-a1b2c3.txt
+├── distill-parsefail-20260702T204901Z-9f8e7d.txt
+└── …
+```
+
+- The directory is created lazily on the first capture with mode `0700`.
+- Each sample file is created with mode `0600`.
+- Filenames are `distill-parsefail-<UTC-timestamp>-<6hex>.txt`, so they sort
+  chronologically and never collide within a pass.
+
+The base directory follows the same state-home resolution as the rest of
+Simard (`SIMARD_STATE_ROOT` / `~/.simard`); see
+[State-root resolution](./state-root-resolution.md).
+
+## Configuration
+
+All configuration is via environment variables, read once per pass. Invalid or
+out-of-range values fall back to the documented default (never panic, never
+disable a valid feature silently).
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `SIMARD_DISTILL_RAW_CAPTURE` | `0` (off) | Master toggle. Truthy (`1`/`true`/`yes`/`on`) enables capture on `ParseFailure`. |
+| `SIMARD_DISTILL_RAW_CAPTURE_MAX_BYTES` | `65536` | Per-sample byte cap (clamped to `[1024, 4194304]`). A larger payload is truncated on a UTF-8 char boundary at or below the cap; the header's `raw_bytes` line records the exact original byte count and a `(truncated to M of N bytes)` note. |
+| `SIMARD_DISTILL_RAW_CAPTURE_KEEP` | `20` | Rotation ring size. After a write, the oldest `distill-parsefail-*.txt` files beyond this count are deleted. `0` disables pruning (unbounded — not recommended). |
+| `SIMARD_DISTILL_RAW_CAPTURE_DIR` | `<state-home>/distill-captures` | Override the capture directory. Relative paths resolve under the state home; the mode-`0700` guarantee still applies. |
+
+Clamping rules:
+
+- `MAX_BYTES` is clamped to `[1024, 4_194_304]` (1 KiB … 4 MiB). A value of `0`,
+  a non-numeric string, or a value above the ceiling is replaced by the default.
+- `KEEP` is clamped to `[0, 10_000]`.
+
+## Capture-file format
+
+A sample is the raw runner stdout **exactly as the extractor received it** —
+ANSI escapes, log lines, banner, and launch preamble all intact — because that
+is precisely what a regression test must reproduce. A short, machine-readable
+header precedes the payload so a harvested sample is self-describing:
+
+```text
+# distill parse-failure raw capture
+# See docs/reference/distill-raw-capture-on-parse-failure.md
+# failure_class: parse-failure
+# recipe_exited_ok: true
+# attempt: 2
+# recovered_after_retry: false
+# input_count: 34
+# fact_count: 0
+# captured_at: 2026-07-02T20:31:14+00:00
+# raw_bytes: 4127
+# ---- raw recipe-runner stdout (verbatim) ----
+<the exact bytes recipe-runner-rs wrote to stdout>
+```
+
+The header fields mirror the distill metrics context (see
+[Metrics hygiene](#metrics-hygiene)) so a sample can be correlated to the
+`metrics.jsonl` event it came from. Everything below the
+`# ---- raw recipe-runner stdout (verbatim) ----` fence is byte-for-byte what
+failed to parse (truncated at the byte cap, with the exact `raw_bytes` count
+recorded in the header).
+
+## Public API
+
+The module exposes a small, panic-free surface. Every function returns without
+propagating I/O errors into the distillation path — a capture failure is logged
+via `tracing::warn!` and swallowed, because capturing a diagnostic must never
+turn a recoverable distill miss into a hard error.
+
+```rust
+// src/memory_consolidation/raw_capture.rs
+
+/// Resolved, validated capture settings. Built once per pass from the
+/// environment; cheap to construct, `Copy`-free but small.
+pub struct RawCaptureConfig {
+    pub enabled: bool,
+    pub dir: PathBuf,
+    pub max_bytes: usize,
+    pub keep: usize,
+}
+
+impl RawCaptureConfig {
+    /// Read + validate all `SIMARD_DISTILL_RAW_CAPTURE*` vars, applying the
+    /// documented defaults and clamps. Never panics.
+    pub fn from_env() -> Self;
+}
+
+/// Metadata recorded in the sample header. Mirrors the distill metrics
+/// context so a capture correlates 1:1 with its `metrics.jsonl` event.
+pub struct CaptureMeta<'a> {
+    pub failure_class: &'a str,
+    pub recipe_exited_ok: bool,
+    pub attempt: u32,
+    pub recovered_after_retry: bool,
+    pub input_count: u32,
+    pub fact_count: u32,
+}
+
+/// Persist `raw` stdout for a parse failure. No-op when capture is disabled
+/// or `meta.failure_class != "parse-failure"`. Best-effort: on any I/O error
+/// it logs and returns `Ok(None)` rather than surfacing the error.
+///
+/// Returns `Ok(Some(path))` with the written sample path on success,
+/// `Ok(None)` when nothing was written.
+pub fn capture_parse_failure(
+    cfg: &RawCaptureConfig,
+    meta: &CaptureMeta<'_>,
+    raw: &str,
+) -> std::io::Result<Option<PathBuf>>;
+```
+
+`capture_parse_failure` is invoked from the distill failure branch in
+`distillation.rs` immediately after `classify_distill_error` yields
+`DistillFailureClass::ParseFailure` and after the bounded in-cycle retry
+(`DISTILL_PARSE_RETRY_MAX`) has been exhausted, so a sample is only written when
+a parse failure genuinely *survives* retry.
+
+## Metrics hygiene
+
+Raw-capture is deliberately the **only** place the raw payload is persisted. The
+distill metrics path (`record_distill_success_metric` /
+`build_distill_success_context` in `distillation.rs`) writes structured
+classification counters to `~/.simard/metrics/metrics.jsonl` and **never** the
+raw agent output. Guaranteed metric context fields:
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `outcome` | `"success"` \| `"failure"` | Pass outcome. |
+| `recipe_exited_ok` | bool | Recipe process exited `0`. |
+| `parse_attempted` | bool | A step ran and its output was parsed. |
+| `parse_success` | bool | Parsing yielded a facts object. |
+| `failure_class` | string \| null | One of `spawn-failure`, `copilot-terminal-failure`, `recipe-reported-failure`, `parse-failure`, `serialize-failure`, `other`. |
+| `input_count` | u32 | Episodes fed to the pass. |
+| `fact_count` | u32 | Facts extracted (`0` on failure). |
+| `attempt` | u32 | 1-based runner invocation count for the pass. |
+| `recovered_after_retry` | bool | Success followed at least one transient retry. |
+
+The context is built with `serde_json::json!` and serialized, so no raw payload
+substring, no ANSI bytes, and no un-escaped newline can leak into a metrics
+line. This is a correctness-as-safety property: `metrics.jsonl` is line-oriented
+and world-readable in some deployments, so it must not carry secrets or PII from
+agent output, nor any bytes that could inject a spurious metrics line.
+
+`distill_parse_success_rate` is emitted **only** for passes that reached parsing
+(`parse_attempted == true`), so its plain mean over passes is exactly the
+parse-success rate the priority-1 work drives back toward `1.0`. Measure it
+before deciding whether a fix is even needed:
+
+```bash
+grep '"metric_name":"distill_parse_success_rate"' ~/.simard/metrics/metrics.jsonl \
+  | tail -n 50
+```
+
+The metric envelope is `MetricEntry` (`src/self_metrics/mod.rs`), serialized with
+its Rust field names, so the JSON key is `metric_name` — not `metric` — and the
+classification counters above live inside its stringified `context` field.
+
+## Security model
+
+- **Default-off.** No file is created and no directory is touched unless the
+  operator explicitly opts in with `SIMARD_DISTILL_RAW_CAPTURE`.
+- **Restrictive permissions.** The capture directory is `0700`; each sample is
+  `0600`. Agent output can contain secrets or PII, so samples are readable only
+  by the daemon's user.
+- **Bounded on disk.** The per-sample cap (`MAX_BYTES`) and the rotation ring
+  (`KEEP`) together bound total capture footprint, preventing a stuck failure
+  loop from exhausting disk.
+- **No metrics leakage.** See [Metrics hygiene](#metrics-hygiene) — the raw
+  payload never reaches `metrics.jsonl`.
+- **Panic-free on untrusted input.** The capture path operates on untrusted
+  agent stdout and performs no unbounded allocation or indexing; a malformed or
+  adversarial payload is truncated at the byte cap and written verbatim, never
+  parsed.
+
+## Examples
+
+### Harvest one failing sample on a live daemon
+
+```bash
+# 1. Turn on capture and restart the daemon (or its service unit).
+SIMARD_DISTILL_RAW_CAPTURE=1 simard ooda run
+
+# 2. Wait for a distillation pass to fail parsing, then inspect.
+ls -l ~/.simard/distill-captures/
+head -20 ~/.simard/distill-captures/distill-parsefail-*.txt
+
+# 3. Turn capture back off once a sample is harvested.
+#    (unset the var / edit the service env, restart)
+```
+
+### Tighten the footprint on a busy host
+
+```bash
+SIMARD_DISTILL_RAW_CAPTURE=1 \
+SIMARD_DISTILL_RAW_CAPTURE_MAX_BYTES=16384 \
+SIMARD_DISTILL_RAW_CAPTURE_KEEP=5 \
+simard ooda run
+```
+
+### Redirect captures to an inspection volume
+
+```bash
+SIMARD_DISTILL_RAW_CAPTURE=1 \
+SIMARD_DISTILL_RAW_CAPTURE_DIR=/mnt/inspect/distill-captures \
+simard ooda run
+```
+
+## When capture does *not* fire
+
+Capture is intentionally narrow. Nothing is written when:
+
+- `SIMARD_DISTILL_RAW_CAPTURE` is unset or falsy (the default).
+- The failure class is anything other than `parse-failure` — a
+  `spawn-failure`, `copilot-terminal-failure`, `recipe-reported-failure`, or
+  `serialize-failure` never reached output parsing, so there is no meaningful
+  payload to capture.
+- The pass *succeeded* (including a success recovered by the in-cycle retry).
+- The pass was below the `DISTILL_MIN_EPISODES` threshold and skipped the LLM
+  call entirely.
+
+This keeps the diagnostic focused on exactly the residual failure mode it
+exists to explain.
+
+## Related
+
+- [Distill recipe output capture](./distill-recipe-output-capture.md) — the
+  envelope parse contract this diagnostic instruments.
+- [Copilot launch-log preamble stripping](../concepts/copilot-launcher-preamble-stripping.md)
+  — the shared chokepoint samples are tested against.
+- [Capture and diagnose a failing distill sample](../howto/capture-and-diagnose-a-failing-distill-sample.md)
+  — the step-by-step harvesting how-to.
+- [Episode distillation](../architecture/episode-distillation.md) — the
+  surrounding pipeline.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -99,6 +99,7 @@ nav:
     - Triage Stale Pull Requests: howto/triage-stale-pull-requests.md
     - Diagnose merge-pr Verdict-Parse Failures: howto/diagnose-merge-pr-verdict-parse-failures.md
     - Inspect the Procedural-Learning Loop: howto/inspect-the-procedural-learning-loop.md
+    - Capture and Diagnose a Failing Distill Sample: howto/capture-and-diagnose-a-failing-distill-sample.md
   - Reference:
     - CLI Reference: reference/simard-cli.md
     - Self-Deploy API: reference/self-deploy-api.md
@@ -134,6 +135,7 @@ nav:
     - Dependency Trust Policy: reference/dependency-trust-policy.md
     - Release Integrity (SBOM + Signing): reference/release-integrity.md
     - Recipe-brain Verdict/Decision Parsing: reference/recipe-brain-verdict-parsing.md
+    - Distill Raw-Capture on Parse Failure: reference/distill-raw-capture-on-parse-failure.md
     # Hidden from nav until issue #1590 implementation lands:
     #   - reference/cognitive-memory-bridge-helpers.md
     #   - reference/goal-board-api.md

--- a/src/memory_consolidation/distillation.rs
+++ b/src/memory_consolidation/distillation.rs
@@ -29,6 +29,7 @@ use std::process::Command;
 use crate::cognitive_memory::CognitiveMemoryOps;
 use crate::error::{SimardError, SimardResult};
 use crate::memory_cognitive::CognitiveEpisode;
+use crate::memory_consolidation::raw_capture;
 
 /// Maximum number of episodes pulled per distillation pass.
 pub const DISTILL_BATCH_SIZE: u32 = 50;
@@ -116,6 +117,23 @@ pub struct DistillOutput {
     pub procedures: Vec<DistilledProcedure>,
 }
 
+/// Outcome of a single **capturing** runner invocation
+/// ([`DistillRecipeRunner::run_all_reinforced_capturing`]): the parse result
+/// plus, on a failure that produced recipe stdout, the raw pre-extraction bytes
+/// so the caller can harvest a real currently-failing sample (Wave 1
+/// raw-capture, 2026-07-02 operator-review priority 1).
+pub struct DistillAttemptOutcome {
+    /// The parse result — identical to what [`run_all_reinforced`] returns.
+    ///
+    /// [`run_all_reinforced`]: DistillRecipeRunner::run_all_reinforced
+    pub result: SimardResult<DistillOutput>,
+    /// The raw recipe stdout **exactly as the extractor received it**, present
+    /// only when the runner actually produced stdout AND parsing failed. `None`
+    /// for stub runners with no stdout and for spawn/terminal failures (which
+    /// never yielded a parseable step output to harvest).
+    pub raw_on_failure: Option<String>,
+}
+
 /// Pluggable LLM-side runner for the distillation recipe.
 ///
 /// The trait exists so tests can substitute a deterministic stub.
@@ -155,6 +173,32 @@ pub trait DistillRecipeRunner {
     ) -> SimardResult<DistillOutput> {
         let _ = strict_json;
         self.run_all(episodes)
+    }
+
+    /// Like [`run_all_reinforced`](Self::run_all_reinforced), but on failure ALSO
+    /// surfaces the raw pre-extraction recipe stdout so the caller can harvest a
+    /// real currently-failing sample (Wave 1 raw-capture).
+    ///
+    /// The default delegates to [`run_all_reinforced`](Self::run_all_reinforced)
+    /// and supplies no raw (`raw_on_failure = None`), so stub/fact-only runners
+    /// keep working unchanged. Only [`RecipeRunnerSubprocess`] overrides it to
+    /// thread the full stdout through — it is the only runner that HAS the bytes
+    /// the diagnostic exists to capture.
+    ///
+    /// NOTE for future runners: `run_all_reinforced` and this method must not be
+    /// left to delegate to *each other*. `RecipeRunnerSubprocess` overrides BOTH
+    /// (its `run_all_reinforced` calls this method, which does the real work). A
+    /// runner that overrides ONLY `run_all_reinforced` to call back into this
+    /// default would recurse infinitely — override both, or neither.
+    fn run_all_reinforced_capturing(
+        &self,
+        episodes: &[CognitiveEpisode],
+        strict_json: bool,
+    ) -> DistillAttemptOutcome {
+        DistillAttemptOutcome {
+            result: self.run_all_reinforced(episodes, strict_json),
+            raw_on_failure: None,
+        }
     }
 }
 
@@ -279,7 +323,11 @@ pub fn distill_recent_episodes_with_runner(
         attempt += 1;
         // Reinforce the response format on any attempt past the first.
         let strict_json = attempt > 1;
-        match runner.run_all_reinforced(&episodes, strict_json) {
+        let DistillAttemptOutcome {
+            result,
+            raw_on_failure,
+        } = runner.run_all_reinforced_capturing(&episodes, strict_json);
+        match result {
             Ok(o) => break o,
             Err(e) => {
                 let class = classify_distill_error(&e);
@@ -316,6 +364,27 @@ pub fn distill_recent_episodes_with_runner(
                 // metric distinguish a first-attempt failure from an exhausted
                 // retry; a failed pass never "recovered".
                 record_distill_success_metric(false, Some(class), pulled, 0, attempt, false);
+                // Wave 1 (2026-07-02 operator-review priority 1): env-gated,
+                // default-off raw-capture of a SURVIVING parse failure so a real
+                // currently-failing sample can be harvested into a regression
+                // test. `capture_parse_failure` self-gates to the toggle AND to
+                // `failure_class == "parse-failure"`, so calling it on every
+                // escalation is safe — a spawn/terminal/serialize failure writes
+                // nothing. When the runner surfaced the raw stdout we capture it
+                // verbatim ("exactly as the extractor received it"); otherwise
+                // (stub runners with no stdout) we fall back to the classified
+                // error string. Best-effort: a capture error never escalates.
+                let cfg = raw_capture::RawCaptureConfig::from_env();
+                let raw_for_capture = raw_on_failure.unwrap_or_else(|| e.to_string());
+                let meta = raw_capture::CaptureMeta {
+                    failure_class: class.as_str(),
+                    recipe_exited_ok: class.recipe_exited_ok(),
+                    attempt,
+                    recovered_after_retry: false,
+                    input_count: pulled,
+                    fact_count: 0,
+                };
+                let _ = raw_capture::capture_parse_failure(&cfg, &meta, &raw_for_capture);
                 return Err(e);
             }
         }
@@ -944,10 +1013,38 @@ impl DistillRecipeRunner for RecipeRunnerSubprocess {
         // Issue #2468: on a retry (`strict_json = true`) thread a non-empty
         // `strict_json_instruction` context var into the recipe so the agent
         // reply is reinforced to be ONLY the `{ "facts": [...] }` object.
-        let raw = self.invoke_recipe(episodes, strict_json)?;
+        //
+        // Delegates to the capturing variant so the parse + metric logic lives in
+        // exactly one place; the harvested raw is simply dropped here.
+        self.run_all_reinforced_capturing(episodes, strict_json)
+            .result
+    }
+
+    fn run_all_reinforced_capturing(
+        &self,
+        episodes: &[CognitiveEpisode],
+        strict_json: bool,
+    ) -> DistillAttemptOutcome {
+        // A spawn/terminal failure never produced parseable stdout, so there is
+        // nothing to harvest — surface the error with no raw.
+        let raw = match self.invoke_recipe(episodes, strict_json) {
+            Ok(raw) => raw,
+            Err(e) => {
+                return DistillAttemptOutcome {
+                    result: Err(e),
+                    raw_on_failure: None,
+                };
+            }
+        };
         let parsed = parse_recipe_output_full(&raw);
         crate::recipe_output::record_parse_outcome("distill", parsed.is_ok());
-        parsed
+        // On a parse failure keep the exact bytes the extractor saw so Wave 1
+        // raw-capture can persist a real currently-failing sample.
+        let raw_on_failure = if parsed.is_err() { Some(raw) } else { None };
+        DistillAttemptOutcome {
+            result: parsed,
+            raw_on_failure,
+        }
     }
 }
 

--- a/src/memory_consolidation/distillation_tests.rs
+++ b/src/memory_consolidation/distillation_tests.rs
@@ -1705,7 +1705,16 @@ fn transient_terminal_failure_then_ok_recovers_in_one_pass() {
 /// Both attempts fail transiently: the pass returns `Err`, NO facts are stored,
 /// NO episodes are marked (retry-safety invariant), and the runner is called a
 /// BOUNDED number of times (`DISTILL_PARSE_RETRY_MAX + 1`).
+///
+/// `#[serial]` on the raw-capture env group: this is the one OTHER test that
+/// drives a distill pass to a SURVIVING `ParseFailure`, so it would hit the
+/// Wave 1 capture path and — if it ran concurrently with
+/// `surviving_parse_failure_writes_a_raw_capture_sample_when_enabled` (which
+/// sets the process-global `SIMARD_DISTILL_RAW_CAPTURE*` env) — write a stray
+/// sample into that test's capture dir. Serializing it on the same key keeps the
+/// enabled-capture assertion (`exactly one sample`) deterministic.
 #[test]
+#[serial_test::serial(simard_distill_raw_capture_env, cognitive_memory)]
 fn transient_failure_exhausts_bounded_retries_then_errs_unmarked() {
     let n = DISTILL_MIN_EPISODES as usize + 3;
     let mock = EpisodeMock::with_episodes(n_episodes(n));
@@ -1751,4 +1760,124 @@ fn structural_spawn_failure_is_not_retried() {
         "no episodes marked on a structural failure"
     );
     assert!(mock.facts_stored().is_empty());
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Wave 1 (RED): env-gated raw-capture fires on a SURVIVING parse failure
+// ───────────────────────────────────────────────────────────────────────────
+//
+// Contract (`docs/reference/distill-raw-capture-on-parse-failure.md`): when
+// `SIMARD_DISTILL_RAW_CAPTURE` is truthy and a `ParseFailure` survives the
+// bounded in-cycle retry, the distill failure path in
+// `distill_recent_episodes_with_runner` writes exactly one
+// `distill-parsefail-*.txt` sample under the configured capture dir, carrying a
+// `# failure_class: parse-failure` header.
+//
+// This is a RUNNABLE RED: it references no not-yet-existing symbol (only env +
+// filesystem + the existing runner path), so it COMPILES against today's code
+// and FAILS at runtime because no capture is wired yet. It also pins the
+// requirement that capture is gated by the ENV toggle ONLY — never by
+// `cfg!(test)` — so it is observable under `cargo test`. Wave 1 turns it green.
+
+/// Scoped env override that restores the previous value on drop.
+struct RawCaptureEnvGuard {
+    key: &'static str,
+    prev: Option<std::ffi::OsString>,
+}
+impl RawCaptureEnvGuard {
+    fn set(key: &'static str, value: &str) -> Self {
+        let prev = std::env::var_os(key);
+        // SAFETY: this test is `#[serial]` on the raw-capture env group.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, prev }
+    }
+}
+impl Drop for RawCaptureEnvGuard {
+    fn drop(&mut self) {
+        // SAFETY: this test is `#[serial]` on the raw-capture env group.
+        unsafe {
+            match self.prev.take() {
+                Some(v) => std::env::set_var(self.key, v),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
+#[test]
+#[serial_test::serial(simard_distill_raw_capture_env, cognitive_memory)]
+fn surviving_parse_failure_writes_a_raw_capture_sample_when_enabled() {
+    let tmp = tempfile::tempdir().unwrap();
+    let capture_dir = tmp.path().join("distill-captures");
+    let _enable = RawCaptureEnvGuard::set("SIMARD_DISTILL_RAW_CAPTURE", "1");
+    let _dir = RawCaptureEnvGuard::set(
+        "SIMARD_DISTILL_RAW_CAPTURE_DIR",
+        capture_dir.to_str().unwrap(),
+    );
+
+    let n = DISTILL_MIN_EPISODES as usize + 3;
+    let mock = EpisodeMock::with_episodes(n_episodes(n));
+    // Every attempt is a ParseFailure ⇒ the retry is exhausted and the pass
+    // escalates with `Err(ParseFailure)` — the exact "surviving parse failure"
+    // the harvester exists to capture.
+    let runner = ScriptedRunner::new(vec![Attempt::Parse]);
+
+    let report = distill_recent_episodes_with_runner(&mock, &runner);
+    assert!(report.is_err(), "a surviving parse failure must return Err");
+
+    let samples: Vec<std::path::PathBuf> = std::fs::read_dir(&capture_dir)
+        .map(|rd| {
+            rd.filter_map(|e| e.ok().map(|e| e.path()))
+                .filter(|p| {
+                    p.file_name()
+                        .and_then(|s| s.to_str())
+                        .is_some_and(|n| n.starts_with("distill-parsefail-") && n.ends_with(".txt"))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    assert_eq!(
+        samples.len(),
+        1,
+        "an enabled, surviving parse failure must write exactly one capture sample; found {samples:?}"
+    );
+    let body = std::fs::read_to_string(&samples[0]).unwrap();
+    assert!(
+        body.contains("# failure_class: parse-failure"),
+        "captured sample must carry the parse-failure header; body:\n{body}"
+    );
+}
+
+/// Negative control: with capture DISABLED (the default), the same surviving
+/// parse failure writes NO sample. Guards against the diagnostic ever becoming
+/// default-on. Runnable RED until capture exists (the dir is simply never
+/// created); stays green thereafter because the toggle is off.
+#[test]
+#[serial_test::serial(simard_distill_raw_capture_env, cognitive_memory)]
+fn surviving_parse_failure_writes_nothing_when_capture_disabled() {
+    let tmp = tempfile::tempdir().unwrap();
+    let capture_dir = tmp.path().join("distill-captures");
+    // Explicitly OFF, and point the dir override at the tempdir so that IF a
+    // future regression made capture default-on we would still detect the file.
+    let _disable = RawCaptureEnvGuard::set("SIMARD_DISTILL_RAW_CAPTURE", "0");
+    let _dir = RawCaptureEnvGuard::set(
+        "SIMARD_DISTILL_RAW_CAPTURE_DIR",
+        capture_dir.to_str().unwrap(),
+    );
+
+    let n = DISTILL_MIN_EPISODES as usize + 3;
+    let mock = EpisodeMock::with_episodes(n_episodes(n));
+    let runner = ScriptedRunner::new(vec![Attempt::Parse]);
+
+    let report = distill_recent_episodes_with_runner(&mock, &runner);
+    assert!(report.is_err(), "a surviving parse failure must return Err");
+
+    let created_any = std::fs::read_dir(&capture_dir)
+        .map(|mut rd| rd.next().is_some())
+        .unwrap_or(false);
+    assert!(
+        !created_any,
+        "capture is default-off: no sample may be written when the toggle is falsy"
+    );
 }

--- a/src/memory_consolidation/mod.rs
+++ b/src/memory_consolidation/mod.rs
@@ -954,6 +954,12 @@ mod tests_pr_a;
 // recipe. See `docs/architecture/episode-distillation.md`.
 pub mod distillation;
 
+// 2026-07-02 operator-review priority 1 (Wave 1): env-gated, default-off
+// raw-capture of a distillation *parse failure*'s raw recipe-runner stdout, so a
+// real currently-failing sample can be harvested into a regression test. See
+// `docs/reference/distill-raw-capture-on-parse-failure.md`.
+pub mod raw_capture;
+
 // Issues #2441/#2458: the verified-signal gate, failure→lesson distillation, and
 // loop metrics that close the episodic→procedural learning loop. Lessons are
 // name-prefixed procedures (`lesson:<goal_type>:<error_class>`); all learning

--- a/src/memory_consolidation/raw_capture.rs
+++ b/src/memory_consolidation/raw_capture.rs
@@ -1,0 +1,714 @@
+//! Env-gated, default-off raw-capture of a distillation *parse failure*'s raw
+//! recipe-runner stdout, so a **real currently-failing sample** can be harvested
+//! and turned into a regression test (2026-07-02 operator-review priority 1).
+//!
+//! # Status: implemented (Wave 1)
+//!
+//! The contract below (see `docs/reference/distill-raw-capture-on-parse-failure.md`)
+//! is fully implemented and covered by the `#[cfg(test)]` suite at the bottom of
+//! this file. Every function has a real body; the capture path is `pub` in a
+//! `pub mod`, so it carries no `dead_code` and the release build stays green.
+//!
+//! # Contract (what the implementation must satisfy)
+//!
+//! * Capture is **off unless** `SIMARD_DISTILL_RAW_CAPTURE` is truthy
+//!   (`1`/`true`/`yes`/`on`, case-insensitive).
+//! * A sample is written **only** for `failure_class == "parse-failure"` — the
+//!   one class that reached (and failed) output parsing.
+//! * Samples live under a mode-`0700` directory as mode-`0600` files named
+//!   `distill-parsefail-<UTC>-<6hex>.txt`, size-capped and rotation-bounded.
+//! * The raw stdout is written **verbatim** below a self-describing header — it
+//!   is exactly what a regression fixture must reproduce.
+//! * The path is **best-effort and panic-free**: any I/O error is logged and
+//!   swallowed (`Ok(None)`), never turning a recoverable distill miss into a
+//!   hard error, and untrusted agent bytes are never parsed, only truncated.
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::SystemTime;
+
+/// Master toggle env var. Truthy (`1`/`true`/`yes`/`on`, case-insensitive)
+/// enables capture; anything else (incl. unset/empty/`0`/`false`) leaves it off.
+pub const ENV_ENABLE: &str = "SIMARD_DISTILL_RAW_CAPTURE";
+/// Per-sample byte cap env var (clamped to `[1024, 4_194_304]`).
+pub const ENV_MAX_BYTES: &str = "SIMARD_DISTILL_RAW_CAPTURE_MAX_BYTES";
+/// Rotation-ring size env var (clamped to `[0, 10_000]`; `0` disables pruning).
+pub const ENV_KEEP: &str = "SIMARD_DISTILL_RAW_CAPTURE_KEEP";
+/// Capture-directory override env var (relative paths resolve under state home).
+pub const ENV_DIR: &str = "SIMARD_DISTILL_RAW_CAPTURE_DIR";
+
+/// Default per-sample byte cap (64 KiB).
+pub const DEFAULT_MAX_BYTES: usize = 65_536;
+/// Default rotation-ring size.
+pub const DEFAULT_KEEP: usize = 20;
+/// Lower/upper clamp bounds for the per-sample byte cap.
+pub const MAX_BYTES_FLOOR: usize = 1_024;
+pub const MAX_BYTES_CEIL: usize = 4_194_304;
+/// Upper clamp bound for the rotation-ring size.
+pub const KEEP_CEIL: usize = 10_000;
+
+/// Resolved, validated capture settings. Built once per pass from the
+/// environment via [`RawCaptureConfig::from_env`], applying the documented
+/// defaults and clamps. Never panics.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RawCaptureConfig {
+    /// `true` iff [`ENV_ENABLE`] was truthy.
+    pub enabled: bool,
+    /// Absolute (or state-home-resolved) directory samples are written to.
+    pub dir: PathBuf,
+    /// Per-sample byte cap after clamping.
+    pub max_bytes: usize,
+    /// Rotation-ring size after clamping (`0` = unbounded).
+    pub keep: usize,
+}
+
+impl RawCaptureConfig {
+    /// Read + validate all `SIMARD_DISTILL_RAW_CAPTURE*` vars, applying the
+    /// documented defaults and clamps. Never panics.
+    ///
+    /// * `enabled` ← [`ENV_ENABLE`] truthiness.
+    /// * `max_bytes` ← [`ENV_MAX_BYTES`] clamped to `[MAX_BYTES_FLOOR, MAX_BYTES_CEIL]`;
+    ///   invalid/`0`/out-of-range → [`DEFAULT_MAX_BYTES`].
+    /// * `keep` ← [`ENV_KEEP`] clamped to `[0, KEEP_CEIL]`; invalid → [`DEFAULT_KEEP`].
+    /// * `dir` ← [`ENV_DIR`] override, else `<state-home>/distill-captures`.
+    pub fn from_env() -> Self {
+        let enabled = std::env::var(ENV_ENABLE)
+            .ok()
+            .is_some_and(|v| is_truthy(&v));
+
+        // Numeric knobs: a parseable value is clamped to its documented range;
+        // an unset/empty/non-numeric value falls back to the default. `max_bytes`
+        // has a floor (a `0`/below-floor cap is meaningless), while `keep == 0`
+        // is a legal "never prune" value, so `keep` has no floor.
+        let max_bytes = std::env::var(ENV_MAX_BYTES)
+            .ok()
+            .and_then(|v| v.trim().parse::<usize>().ok())
+            .map(|n| n.clamp(MAX_BYTES_FLOOR, MAX_BYTES_CEIL))
+            .unwrap_or(DEFAULT_MAX_BYTES);
+        let keep = std::env::var(ENV_KEEP)
+            .ok()
+            .and_then(|v| v.trim().parse::<usize>().ok())
+            .map(|n| n.min(KEEP_CEIL))
+            .unwrap_or(DEFAULT_KEEP);
+
+        let dir = std::env::var_os(ENV_DIR)
+            .map(PathBuf::from)
+            .filter(|p| !p.as_os_str().is_empty())
+            .unwrap_or_else(default_capture_dir);
+
+        Self {
+            enabled,
+            dir,
+            max_bytes,
+            keep,
+        }
+    }
+}
+
+/// `true` for the case-insensitive truthy tokens `1`/`true`/`yes`/`on`; every
+/// other value (incl. unset/empty/`0`/`false`/`off`/`no`/arbitrary) is falsy.
+fn is_truthy(v: &str) -> bool {
+    matches!(
+        v.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+/// Default capture dir: `<state-root>/distill-captures`, a sibling of the
+/// operator's `metrics/` sink.
+fn default_capture_dir() -> PathBuf {
+    state_root().join("distill-captures")
+}
+
+/// `<state-root>`: `SIMARD_STATE_ROOT` if set to a non-empty value, else
+/// `$HOME/.simard` — the same canonical location as the rest of Simard's state
+/// (see [`crate::runtime_config`]). Note this treats an *empty* `SIMARD_STATE_ROOT`
+/// as unset (falling back to `$HOME/.simard`) rather than honoring the empty
+/// value verbatim, so a blank override can never redirect captures to the
+/// process CWD.
+fn state_root() -> PathBuf {
+    if let Ok(v) = std::env::var("SIMARD_STATE_ROOT")
+        && !v.trim().is_empty()
+    {
+        return PathBuf::from(v);
+    }
+    let home = std::env::var("HOME").unwrap_or_else(|_| {
+        tracing::warn!(
+            "HOME env var not set; defaulting distill-capture state root to /home/azureuser"
+        );
+        "/home/azureuser".to_string()
+    });
+    PathBuf::from(home).join(".simard")
+}
+
+/// Metadata recorded in the sample header. Mirrors the distill metrics context
+/// (`build_distill_success_context`) so a capture correlates 1:1 with the
+/// `metrics.jsonl` event it came from.
+#[derive(Debug, Clone, Copy)]
+pub struct CaptureMeta<'a> {
+    /// Stable failure-class label — capture only fires for `"parse-failure"`.
+    pub failure_class: &'a str,
+    /// Whether the recipe process exited `0`.
+    pub recipe_exited_ok: bool,
+    /// 1-based runner invocation count for the pass.
+    pub attempt: u32,
+    /// `true` iff a success followed at least one transient retry.
+    pub recovered_after_retry: bool,
+    /// Episodes fed to the pass.
+    pub input_count: u32,
+    /// Facts extracted (`0` on failure).
+    pub fact_count: u32,
+}
+
+/// Persist `raw` stdout for a parse failure.
+///
+/// No-op (returns `Ok(None)`, writes nothing) when capture is disabled or
+/// `meta.failure_class != "parse-failure"`. On success returns
+/// `Ok(Some(path))` with the written sample path.
+///
+/// **Best-effort:** on any I/O error it logs via `tracing::warn!` and returns
+/// `Ok(None)` rather than surfacing the error — capturing a diagnostic must
+/// never turn a recoverable distill miss into a hard error.
+pub fn capture_parse_failure(
+    cfg: &RawCaptureConfig,
+    meta: &CaptureMeta<'_>,
+    raw: &str,
+) -> std::io::Result<Option<PathBuf>> {
+    // Gate 1: the operator opt-in. Gate 2: only the ONE class that reached (and
+    // failed) output parsing — every other class never produced parseable stdout
+    // worth harvesting.
+    if !cfg.enabled || meta.failure_class != PARSE_FAILURE_CLASS {
+        return Ok(None);
+    }
+
+    // Best-effort: a diagnostic must NEVER turn a recoverable distill miss into a
+    // hard error. Any I/O failure is logged and swallowed to `Ok(None)`.
+    match write_sample(cfg, meta, raw) {
+        Ok(path) => Ok(Some(path)),
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                dir = ?cfg.dir,
+                "distill raw-capture failed (non-fatal); dropping sample"
+            );
+            Ok(None)
+        }
+    }
+}
+
+/// The single failure class captured — the one that exited `0`, ran a step, and
+/// still yielded no parseable facts object. Matches
+/// [`crate::memory_consolidation::distillation::DistillFailureClass::as_str`].
+const PARSE_FAILURE_CLASS: &str = "parse-failure";
+
+/// Process-unique suffix source, so two captures within the same wall-clock
+/// nanosecond (or a clock that fails to advance) still get distinct filenames.
+static SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// Do the actual work: create the `0700` dir, render header + (capped) verbatim
+/// raw into a `0600` file, then prune the rotation ring. Returns the written
+/// path. All fallible I/O bubbles up for the caller to swallow.
+fn write_sample(
+    cfg: &RawCaptureConfig,
+    meta: &CaptureMeta<'_>,
+    raw: &str,
+) -> std::io::Result<PathBuf> {
+    ensure_capture_dir(&cfg.dir)?;
+    let body = render_sample(cfg, meta, raw);
+    let path = cfg.dir.join(sample_filename());
+    write_private_file(&path, body.as_bytes())?;
+    prune_ring(&cfg.dir, cfg.keep);
+    Ok(path)
+}
+
+/// Create (if needed) and enforce mode-`0700` on the capture directory.
+#[cfg(unix)]
+fn ensure_capture_dir(dir: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
+    if !dir.exists() {
+        std::fs::DirBuilder::new()
+            .recursive(true)
+            .mode(0o700)
+            .create(dir)?;
+    }
+    // Enforce 0700 even if the dir pre-existed with looser bits.
+    let mut perm = std::fs::metadata(dir)?.permissions();
+    if perm.mode() & 0o777 != 0o700 {
+        perm.set_mode(0o700);
+        std::fs::set_permissions(dir, perm)?;
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn ensure_capture_dir(dir: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(dir)
+}
+
+/// Write `bytes` to `path` as a mode-`0600` file (create/truncate).
+#[cfg(unix)]
+fn write_private_file(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    use std::io::Write;
+    use std::os::unix::fs::OpenOptionsExt;
+    let mut f = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(path)?;
+    f.write_all(bytes)
+}
+
+#[cfg(not(unix))]
+fn write_private_file(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    std::fs::write(path, bytes)
+}
+
+/// `distill-parsefail-<UTC>-<seq-hex>.txt`. The compact UTC prefix sorts
+/// chronologically; the monotonic `seq` guarantees uniqueness even on identical
+/// timestamps.
+fn sample_filename() -> String {
+    let stamp = chrono::Utc::now().format("%Y%m%dT%H%M%S%3fZ");
+    let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+    format!("distill-parsefail-{stamp}-{seq:06x}.txt")
+}
+
+/// Render the self-describing header (mirroring the distill metrics context) plus
+/// the verbatim raw stdout, truncated at `cfg.max_bytes` on a char boundary.
+fn render_sample(cfg: &RawCaptureConfig, meta: &CaptureMeta<'_>, raw: &str) -> String {
+    let raw_bytes = raw.len();
+    let (payload, note) = if raw_bytes > cfg.max_bytes {
+        let end = floor_char_boundary(raw, cfg.max_bytes);
+        (
+            &raw[..end],
+            format!(" (truncated to {end} of {raw_bytes} bytes)"),
+        )
+    } else {
+        (raw, String::new())
+    };
+
+    let mut s = String::with_capacity(payload.len() + 256);
+    s.push_str("# distill parse-failure raw capture\n");
+    s.push_str("# See docs/reference/distill-raw-capture-on-parse-failure.md\n");
+    s.push_str(&format!("# failure_class: {}\n", meta.failure_class));
+    s.push_str(&format!("# recipe_exited_ok: {}\n", meta.recipe_exited_ok));
+    s.push_str(&format!("# attempt: {}\n", meta.attempt));
+    s.push_str(&format!(
+        "# recovered_after_retry: {}\n",
+        meta.recovered_after_retry
+    ));
+    s.push_str(&format!("# input_count: {}\n", meta.input_count));
+    s.push_str(&format!("# fact_count: {}\n", meta.fact_count));
+    s.push_str(&format!(
+        "# captured_at: {}\n",
+        chrono::Utc::now().to_rfc3339()
+    ));
+    s.push_str(&format!("# raw_bytes: {raw_bytes}{note}\n"));
+    s.push_str("# ---- raw recipe-runner stdout (verbatim) ----\n");
+    s.push_str(payload);
+    s
+}
+
+/// Largest byte index `<= max` that lands on a UTF-8 char boundary, so a byte
+/// cap can never split a multi-byte character (`str::floor_char_boundary` is
+/// still unstable).
+fn floor_char_boundary(s: &str, max: usize) -> usize {
+    if max >= s.len() {
+        return s.len();
+    }
+    let mut end = max;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    end
+}
+
+/// Keep only the newest `keep` `distill-parsefail-*.txt` samples (`keep == 0`
+/// disables pruning). Best-effort: any listing/removal error is ignored — the
+/// ring is hygiene, never correctness.
+fn prune_ring(dir: &Path, keep: usize) {
+    if keep == 0 {
+        return;
+    }
+    let rd = match std::fs::read_dir(dir) {
+        Ok(rd) => rd,
+        Err(_) => return,
+    };
+    let mut samples: Vec<(SystemTime, PathBuf)> = rd
+        .filter_map(|e| e.ok())
+        .filter(|e| is_sample_name(&e.file_name().to_string_lossy()))
+        .map(|e| {
+            let mtime = e
+                .metadata()
+                .and_then(|m| m.modified())
+                .unwrap_or(SystemTime::UNIX_EPOCH);
+            (mtime, e.path())
+        })
+        .collect();
+    if samples.len() <= keep {
+        return;
+    }
+    // Oldest first (mtime, then path as a stable tiebreak for identical mtimes).
+    samples.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+    let remove = samples.len() - keep;
+    for (_, path) in samples.into_iter().take(remove) {
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+/// `true` for a `distill-parsefail-*.txt` sample filename.
+fn is_sample_name(name: &str) -> bool {
+    name.starts_with("distill-parsefail-") && name.ends_with(".txt")
+}
+
+#[cfg(test)]
+mod tests {
+    //! Contract tests (Wave 1). These exercise the documented behavior of the
+    //! implemented module. Env-mutating tests are `#[serial]`; each uses
+    //! [`EnvGuard`] so the process-global env is restored on drop.
+
+    use super::*;
+    use serial_test::serial;
+    use std::fs;
+
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
+    // ── scoped env override (restores on drop) ──────────────────────────
+    struct EnvGuard {
+        key: &'static str,
+        prev: Option<std::ffi::OsString>,
+    }
+    impl EnvGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let prev = std::env::var_os(key);
+            // SAFETY: env-mutating tests in this module are `#[serial]`.
+            unsafe { std::env::set_var(key, value) };
+            Self { key, prev }
+        }
+        fn unset(key: &'static str) -> Self {
+            let prev = std::env::var_os(key);
+            // SAFETY: env-mutating tests in this module are `#[serial]`.
+            unsafe { std::env::remove_var(key) };
+            Self { key, prev }
+        }
+    }
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            // SAFETY: env-mutating tests in this module are `#[serial]`.
+            unsafe {
+                match self.prev.take() {
+                    Some(v) => std::env::set_var(self.key, v),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+    }
+
+    /// A `CaptureMeta` for the parse-failure case the diagnostic exists to catch.
+    fn parse_failure_meta() -> CaptureMeta<'static> {
+        CaptureMeta {
+            failure_class: "parse-failure",
+            recipe_exited_ok: true,
+            attempt: 2,
+            recovered_after_retry: false,
+            input_count: 34,
+            fact_count: 0,
+        }
+    }
+
+    /// A capture config that is enabled and writes to `dir` with generous caps.
+    fn enabled_cfg(dir: PathBuf) -> RawCaptureConfig {
+        RawCaptureConfig {
+            enabled: true,
+            dir,
+            max_bytes: DEFAULT_MAX_BYTES,
+            keep: DEFAULT_KEEP,
+        }
+    }
+
+    fn parsefail_samples(dir: &std::path::Path) -> Vec<PathBuf> {
+        let mut v: Vec<PathBuf> = match fs::read_dir(dir) {
+            Ok(rd) => rd
+                .filter_map(|e| e.ok().map(|e| e.path()))
+                .filter(|p| {
+                    p.file_name()
+                        .and_then(|n| n.to_str())
+                        .is_some_and(|n| n.starts_with("distill-parsefail-") && n.ends_with(".txt"))
+                })
+                .collect(),
+            Err(_) => Vec::new(),
+        };
+        v.sort();
+        v
+    }
+
+    // ─────────────────────────── from_env ───────────────────────────────
+
+    #[test]
+    #[serial(simard_distill_raw_capture_env, cognitive_memory)]
+    fn from_env_defaults_to_disabled_when_unset() {
+        let _e = EnvGuard::unset(ENV_ENABLE);
+        let _mb = EnvGuard::unset(ENV_MAX_BYTES);
+        let _k = EnvGuard::unset(ENV_KEEP);
+        let cfg = RawCaptureConfig::from_env();
+        assert!(
+            !cfg.enabled,
+            "capture must default OFF when the toggle is unset"
+        );
+        assert_eq!(cfg.max_bytes, DEFAULT_MAX_BYTES);
+        assert_eq!(cfg.keep, DEFAULT_KEEP);
+    }
+
+    #[test]
+    #[serial(simard_distill_raw_capture_env, cognitive_memory)]
+    fn from_env_truthy_variants_enable_capture() {
+        for v in ["1", "true", "TRUE", "yes", "Yes", "on", "ON"] {
+            let _e = EnvGuard::set(ENV_ENABLE, v);
+            assert!(
+                RawCaptureConfig::from_env().enabled,
+                "{v:?} must enable capture"
+            );
+        }
+    }
+
+    #[test]
+    #[serial(simard_distill_raw_capture_env, cognitive_memory)]
+    fn from_env_falsy_variants_leave_capture_off() {
+        for v in ["", "0", "false", "off", "no", "banana"] {
+            let _e = EnvGuard::set(ENV_ENABLE, v);
+            assert!(
+                !RawCaptureConfig::from_env().enabled,
+                "{v:?} must NOT enable capture"
+            );
+        }
+    }
+
+    #[test]
+    #[serial(simard_distill_raw_capture_env, cognitive_memory)]
+    fn from_env_max_bytes_clamps_and_defaults() {
+        let _e = EnvGuard::set(ENV_ENABLE, "1");
+
+        // In-range value is honoured verbatim.
+        let _mb = EnvGuard::set(ENV_MAX_BYTES, "16384");
+        assert_eq!(RawCaptureConfig::from_env().max_bytes, 16_384);
+
+        // Zero / below-floor → floor.
+        let _mb0 = EnvGuard::set(ENV_MAX_BYTES, "0");
+        assert_eq!(RawCaptureConfig::from_env().max_bytes, MAX_BYTES_FLOOR);
+
+        // Above ceiling → ceiling.
+        let _mbc = EnvGuard::set(ENV_MAX_BYTES, "999999999");
+        assert_eq!(RawCaptureConfig::from_env().max_bytes, MAX_BYTES_CEIL);
+
+        // Non-numeric → default.
+        let _mbx = EnvGuard::set(ENV_MAX_BYTES, "not-a-number");
+        assert_eq!(RawCaptureConfig::from_env().max_bytes, DEFAULT_MAX_BYTES);
+    }
+
+    #[test]
+    #[serial(simard_distill_raw_capture_env, cognitive_memory)]
+    fn from_env_keep_clamps_and_defaults() {
+        let _e = EnvGuard::set(ENV_ENABLE, "1");
+
+        let _k = EnvGuard::set(ENV_KEEP, "5");
+        assert_eq!(RawCaptureConfig::from_env().keep, 5);
+
+        // 0 is a legal value (disables pruning), not the default.
+        let _k0 = EnvGuard::set(ENV_KEEP, "0");
+        assert_eq!(RawCaptureConfig::from_env().keep, 0);
+
+        // Above ceiling → ceiling.
+        let _kc = EnvGuard::set(ENV_KEEP, "100000");
+        assert_eq!(RawCaptureConfig::from_env().keep, KEEP_CEIL);
+
+        // Non-numeric → default.
+        let _kx = EnvGuard::set(ENV_KEEP, "lots");
+        assert_eq!(RawCaptureConfig::from_env().keep, DEFAULT_KEEP);
+    }
+
+    #[test]
+    #[serial(simard_distill_raw_capture_env, cognitive_memory)]
+    fn from_env_dir_override_is_honoured_absolute() {
+        let tmp = tempfile::tempdir().unwrap();
+        let abs = tmp.path().join("captures-here");
+        let _e = EnvGuard::set(ENV_ENABLE, "1");
+        let _d = EnvGuard::set(ENV_DIR, abs.to_str().unwrap());
+        assert_eq!(RawCaptureConfig::from_env().dir, abs);
+    }
+
+    #[test]
+    #[serial(simard_distill_raw_capture_env, cognitive_memory)]
+    fn from_env_default_dir_is_under_state_home() {
+        let _e = EnvGuard::set(ENV_ENABLE, "1");
+        let _d = EnvGuard::unset(ENV_DIR);
+        let dir = RawCaptureConfig::from_env().dir;
+        assert!(
+            dir.ends_with("distill-captures"),
+            "default capture dir must be the state-home `distill-captures` subdir, got {dir:?}"
+        );
+    }
+
+    // ─────────────────────── capture_parse_failure ──────────────────────
+
+    #[test]
+    fn capture_is_noop_when_disabled() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = RawCaptureConfig {
+            enabled: false,
+            ..enabled_cfg(tmp.path().to_path_buf())
+        };
+        let out = capture_parse_failure(&cfg, &parse_failure_meta(), "raw stdout")
+            .expect("best-effort capture never surfaces an error");
+        assert!(out.is_none(), "disabled capture must write nothing");
+        assert!(
+            parsefail_samples(tmp.path()).is_empty(),
+            "no sample file must be created when disabled"
+        );
+    }
+
+    #[test]
+    fn capture_is_noop_for_non_parse_failure_class() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = enabled_cfg(tmp.path().to_path_buf());
+        for class in [
+            "spawn-failure",
+            "copilot-terminal-failure",
+            "recipe-reported-failure",
+            "serialize-failure",
+            "other",
+        ] {
+            let meta = CaptureMeta {
+                failure_class: class,
+                ..parse_failure_meta()
+            };
+            let out = capture_parse_failure(&cfg, &meta, "raw stdout")
+                .expect("best-effort capture never surfaces an error");
+            assert!(
+                out.is_none(),
+                "class {class:?} never reached parsing — must not be captured"
+            );
+        }
+        assert!(
+            parsefail_samples(tmp.path()).is_empty(),
+            "no sample file for any non-parse-failure class"
+        );
+    }
+
+    #[test]
+    fn capture_writes_sample_with_header_and_verbatim_raw() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = enabled_cfg(tmp.path().to_path_buf());
+        // A raw payload carrying exactly the launch-banner noise a real failing
+        // sample would — it must be preserved byte-for-byte for the fixture.
+        let raw = "\u{2139} NODE_OPTIONS=--max-old-space-size=32768 (saved preference).\n\
+                   INFO launching copilot binary=/x version=\"GitHub Copilot CLI 1.0.66-2.\"\n\
+                   Run 'copilot update' to check for updates.\n\
+                   I could not find any facts worth distilling in this batch.";
+
+        let path = capture_parse_failure(&cfg, &parse_failure_meta(), raw)
+            .expect("best-effort capture never surfaces an error")
+            .expect("an enabled parse-failure capture must write a sample");
+
+        let name = path.file_name().unwrap().to_str().unwrap();
+        assert!(
+            name.starts_with("distill-parsefail-") && name.ends_with(".txt"),
+            "unexpected sample filename: {name}"
+        );
+
+        let body = fs::read_to_string(&path).unwrap();
+        // Header mirrors the metrics context so a sample is self-describing.
+        assert!(
+            body.contains("# failure_class: parse-failure"),
+            "body:\n{body}"
+        );
+        assert!(body.contains("# attempt: 2"), "body:\n{body}");
+        assert!(body.contains("# input_count: 34"), "body:\n{body}");
+        assert!(body.contains("# fact_count: 0"), "body:\n{body}");
+        // The raw stdout is present verbatim (below the fence), banner intact.
+        assert!(
+            body.contains(raw),
+            "the exact failing bytes must be preserved verbatim; body:\n{body}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn capture_dir_is_0700_and_file_is_0600() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Point at a not-yet-created subdir so the module creates it with 0700.
+        let dir = tmp.path().join("distill-captures");
+        let cfg = enabled_cfg(dir.clone());
+
+        let path = capture_parse_failure(&cfg, &parse_failure_meta(), "raw")
+            .expect("best-effort capture never surfaces an error")
+            .expect("an enabled parse-failure capture must write a sample");
+
+        let dir_mode = fs::metadata(&dir).unwrap().permissions().mode() & 0o777;
+        assert_eq!(dir_mode, 0o700, "capture dir must be created mode 0700");
+
+        let file_mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(file_mode, 0o600, "each sample file must be mode 0600");
+    }
+
+    #[test]
+    fn capture_truncates_payload_at_byte_cap() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = RawCaptureConfig {
+            max_bytes: MAX_BYTES_FLOOR, // 1 KiB — smallest legal cap
+            ..enabled_cfg(tmp.path().to_path_buf())
+        };
+        let raw = "X".repeat(MAX_BYTES_FLOOR * 4); // well over the cap
+
+        let path = capture_parse_failure(&cfg, &parse_failure_meta(), &raw)
+            .expect("best-effort capture never surfaces an error")
+            .expect("an enabled parse-failure capture must write a sample");
+
+        let body = fs::read_to_string(&path).unwrap();
+        assert!(
+            body.contains("truncated"),
+            "an over-cap payload must carry a truncation marker; body head:\n{}",
+            &body[..body.len().min(200)]
+        );
+        assert!(
+            body.len() < raw.len(),
+            "captured file must be smaller than the un-capped raw payload"
+        );
+    }
+
+    #[test]
+    fn capture_rotation_ring_keeps_only_newest() {
+        let tmp = tempfile::tempdir().unwrap();
+        let keep = 3usize;
+        let cfg = RawCaptureConfig {
+            keep,
+            ..enabled_cfg(tmp.path().to_path_buf())
+        };
+        // Write more than `keep` samples; the ring must prune the oldest.
+        for i in 0..keep + 4 {
+            capture_parse_failure(&cfg, &parse_failure_meta(), &format!("sample {i}"))
+                .expect("best-effort capture never surfaces an error")
+                .expect("each enabled parse-failure capture writes a sample");
+        }
+        let remaining = parsefail_samples(tmp.path()).len();
+        assert_eq!(
+            remaining, keep,
+            "rotation ring must retain exactly `keep` newest samples, found {remaining}"
+        );
+    }
+
+    #[test]
+    fn capture_is_panic_free_on_adversarial_bytes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = enabled_cfg(tmp.path().to_path_buf());
+        // Embedded control bytes, a stray NUL, and unbalanced braces must be
+        // written verbatim, never parsed — the path handles untrusted stdout.
+        let raw = "line1\n{unbalanced\x00\u{1b}[31m\r\n\"quote";
+        let out = capture_parse_failure(&cfg, &parse_failure_meta(), raw)
+            .expect("best-effort capture never surfaces an error");
+        assert!(
+            out.is_some(),
+            "adversarial-but-valid parse-failure is still captured"
+        );
+    }
+}


### PR DESCRIPTION
## Wave 1 of 5 — quality audit (2026-07-02 operator-review priority 1)

**Issue #1 (distill "still broken ~78%") — investigated, root-caused, and instrumented.**

### Key finding (evidence-based)
The task premise ("distill is NOT routed through the #2504 chokepoint") is **stale**. On current `main`, `distillation.rs` already routes through `crate::recipe_output::{strip_recipe_noise, strip_ansi, balanced_objects}` and the launch-banner recovery is verified by `parser_extracts_facts_and_procedures_from_real_prose_prefixed_envelope`.

A **live reproduction** (3- and 50-episode real distill runs) confirms current source parses the exact production banner-prefixed step output (`ℹ NODE_OPTIONS=… (saved preference)…\n{ "facts": … }`) **correctly**.

The live ~98% failure in `metrics.jsonl` is a **stale deployed binary**: `~/.simard/bin/simard` was built `2026-06-30 01:33 UTC`, which **predates** #2513 (`2026-06-30 19:05 UTC`). Redeploying current `main` fixes the observed failures.

### What this PR adds
An **env-gated, default-off** diagnostic to harvest any *genuine future residual* (agent emits no `{facts}`, malformed JSON, or a strict-JSON retry miss on `attempt=2`) — so the next investigation targets the layer that's actually broken instead of re-hardening an extractor that already works.

- **`src/memory_consolidation/raw_capture.rs`** — `RawCaptureConfig::from_env()` (toggle + clamps) and `capture_parse_failure()`:
  - Writes only on `SIMARD_DISTILL_RAW_CAPTURE` truthy **and** `failure_class == parse-failure`.
  - `0700` dir, `0600` files, byte cap (`[1KiB,4MiB]`), bounded rotation ring.
  - **Panic-free & best-effort**: any I/O error is logged and swallowed — never turns a recoverable distill miss into a hard error.
- **`distillation.rs`** — `DistillAttemptOutcome` + `run_all_reinforced_capturing` surface the **full pre-extraction stdout** ("exactly as the extractor received it"); capture fires at the surviving-parse-failure escalation, co-located with the metric.
- Reference + how-to docs + mkdocs nav.

### Tests
- 14 `raw_capture` unit tests (env parsing/clamps, no-op gates, header+verbatim body, `0700`/`0600` perms, truncation, rotation, adversarial bytes).
- 2 `distillation` integration tests (enabled writes exactly one sample; disabled writes none).
- Serialized the one other parse-escalating distill test so the enabled-capture assertion is deterministic under parallel runs.

### How to enable (operator)
```bash
SIMARD_DISTILL_RAW_CAPTURE=1 simard ooda run
# samples: ~/.simard/distill-captures/distill-parsefail-*.txt
```

No behavior change unless the toggle is set. No snapshot docs.