### PR TITLE
fix(ooda): gate daemon auto-reload on binary content identity, not mtime (Wave 2, #2432)

### DIFF
--- a/docs/reference/ooda-binary-identity-reload-gate.md
+++ b/docs/reference/ooda-binary-identity-reload-gate.md
@@ -1,0 +1,296 @@
+---
+title: OODA binary-identity reload gate
+description: Reference for the content-identity gating that replaces mtime-only auto-reload in the OODA daemon, so the daemon exec()s into a new binary only when the on-disk image is genuinely different — the startup-captured running-image content hash, the on-disk content-hash confirm, the mtime pre-filter that keeps hashing off the hot loop, the fail-closed error handling, and the absolute current_exe() re-exec invariant — eliminating the ~40-minute self-restart churn from identical-content cargo rebuilds.
+last_updated: 2026-07-02
+review_schedule: as-needed
+owner: simard
+doc_type: reference
+status: implemented
+related:
+  - ../daemon-mode.md
+  - ../howto/run-ooda-daemon.md
+  - ./multi-binary-self-update.md
+  - ./self-deploy-api.md
+  - ../concepts/reconcile-and-self-deploy.md
+  - ../../src/operator_commands_ooda/daemon/helpers.rs
+  - ../../src/operator_commands_ooda/daemon/mod.rs
+---
+
+# OODA binary-identity reload gate
+
+> **Status: implemented (Wave 2, 2026-07-02 operator-review priority 2).** The
+> content-identity reload gate lives in
+> [`src/operator_commands_ooda/daemon/helpers.rs`](https://github.com/rysweet/Simard/blob/main/src/operator_commands_ooda/daemon/helpers.rs)
+> (`binary_changed`, `reload_decision`, `file_content_hash`, `running_image_hash`,
+> `exec_self_reload`) and is invoked from the loop in
+> [`src/operator_commands_ooda/daemon/mod.rs`](https://github.com/rysweet/Simard/blob/main/src/operator_commands_ooda/daemon/mod.rs),
+> which pins the running image's content hash at startup via
+> `capture_running_image_hash()`. It replaces the historical mtime-only
+> `binary_changed` (see [The problem: mtime churn](#the-problem-mtime-churn)),
+> which relaunched on *any* rebuild/`touch`. This is the 2026-07-02
+> operator-review priority-2 fix (over-frequent daemon self-restart).
+
+The OODA daemon supports **auto-reload**: on each cycle it checks whether the
+executable on disk differs from the one it is running, and if so it `exec()`s
+into the new image so a merged self-change goes live without an operator
+restart. Auto-reload is on by default and disabled with `--no-auto-reload`
+(see [Run the OODA daemon](../howto/run-ooda-daemon.md)).
+
+The reload **trigger** is content-identity: the daemon relaunches only when the
+on-disk binary is a *genuinely different image*, not merely a newer file. This
+reference specifies that gate, why it replaces the current mtime-only check on
+`main`, and its safety invariants.
+
+## Contents
+
+- [The problem: mtime churn](#the-problem-mtime-churn)
+- [The gate](#the-gate)
+- [Running-image identity](#running-image-identity)
+- [Decision table](#decision-table)
+- [Public API](#public-api)
+- [Configuration](#configuration)
+- [Safety invariants](#safety-invariants)
+- [Examples](#examples)
+- [Migration notes](#migration-notes)
+
+## The problem: mtime churn
+
+The current gate on `main` compares the executable's **mtime** against the
+process start time — this is the behavior the Wave 2 change replaces:
+
+```rust
+// current behavior on `main` — mtime only
+pub fn binary_changed(start_time: SystemTime) -> bool {
+    exe_mtime().is_some_and(|mtime| mtime > start_time)
+}
+```
+
+Any operation that bumps the binary's mtime — a `cargo build` that relinks an
+identical image, a `touch`, a redeploy script that copies a byte-identical
+binary into place, a backup/restore that rewrites the file — makes
+`binary_changed` return `true` even though the running code is unchanged. The
+daemon then closes its LLM session, `exec()`s a fresh copy of the *same* image,
+and pays full cold-start cost (bridge spawn, memory recall, preparation) for no
+behavioral change.
+
+On a host that rebuilds periodically this produces a self-restart every
+~40–45 minutes — roughly every 4–5 cycles at the default
+`SIMARD_OODA_INTERVAL_SECS=300` — driving `NRestarts` very high and starving the
+loop of useful work with repeated cold starts.
+
+## The gate
+
+The gate confirms a **real image difference** before relaunching. It keeps
+the cheap mtime read as a fast pre-filter so the expensive content check stays
+off the hot path:
+
+1. **mtime pre-filter (cheap).** If the on-disk mtime is **not** newer than the
+   process start time, the image cannot have changed — return `false`
+   immediately, no hashing. This is the common case every cycle.
+2. **Identity confirm (only when mtime is newer).** When mtime *is* newer,
+   confirm a genuine difference before relaunching:
+   - Compare the daemon's **running-image content hash** (a SHA-256 of the
+     process's own executable, captured once at startup and cached — see
+     [Running-image identity](#running-image-identity)) against a fresh content
+     hash of the on-disk binary.
+   - Because a byte-identical rebuild produces the *same* content hash, the
+     confirm step returns `false` and the daemon keeps running — no relaunch on
+     identical content.
+   - Only a genuinely different on-disk image (different content hash) returns
+     `true` and triggers `exec_self_reload`.
+
+Hashing the on-disk file only when its mtime advanced means the content hash is
+never computed on a steady-state cycle.
+
+## Running-image identity
+
+The daemon's trusted identity is a SHA-256 digest of **its own executable**,
+captured once at startup and cached for the life of the process:
+
+```rust
+// src/operator_commands_ooda/daemon/mod.rs — at startup
+let start_time = exe_mtime().unwrap_or_else(SystemTime::now);
+capture_running_image_hash(); // pins hash(current_exe()) before any replace
+```
+
+Capturing it **once, at startup** is what makes the gate correct: after an
+in-place replace, `std::env::current_exe()` resolves to the NEW bytes, so
+re-hashing it at check time would compare the new file against itself and never
+detect a change. The startup-pinned hash still identifies the OLD image the
+process is actually running, so a later on-disk hash that differs from it is a
+genuine new image. Pinning at startup (rather than lazily on the first check)
+also closes the window in which a replace between `exec` and the first cycle
+could be mistaken for the running image.
+
+Comparing the on-disk (untrusted) bytes against the startup-pinned (trusted)
+running hash also means the gate detects a tampered swap that an mtime
+comparison never could.
+
+## Decision table
+
+| On-disk mtime vs. start | On-disk hash vs. running-image hash | `binary_changed` | Action |
+| --- | --- | --- | --- |
+| not newer | *(not checked)* | `false` | keep running (hot-path, no hash) |
+| newer | equal (identical rebuild) | `false` | keep running (the churn case) |
+| newer | different | `true` | `exec_self_reload` into the new image |
+| newer | on-disk read/hash **error** | `false` | keep running (fail-closed) |
+| mtime unreadable | *(not checked)* | `false` | keep running (fail-closed) |
+| running hash unknown | *(not checked)* | `false` | keep running (fail-closed) |
+
+## Public API
+
+```rust
+// src/operator_commands_ooda/daemon/helpers.rs
+
+/// mtime of the currently-running executable, or `None` if it cannot be
+/// determined (e.g. the binary was deleted after launch).
+pub fn exe_mtime() -> Option<SystemTime>;
+
+/// Stable content identity (hex SHA-256) of the file at `path`, or `None` on any
+/// I/O error (fail-closed). Streams the file, so a multi-MB binary is never
+/// fully buffered. Never panics.
+pub fn file_content_hash(path: &Path) -> Option<String>;
+
+/// Hash of the RUNNING image, captured once (lazily) and cached for the life of
+/// the process, or `None` if our own executable could not be hashed.
+pub fn running_image_hash() -> Option<&'static str>;
+
+/// Pin the running-image hash at a known-early point (daemon startup),
+/// closing the exec→first-check window. Idempotent.
+pub fn capture_running_image_hash();
+
+/// Pure reload decision (unit-tested in isolation): `true` only when the on-disk
+/// image is genuinely different. mtime pre-filter first; then compare
+/// `on_disk_hash` to `running_hash`. Any `None` (unreadable mtime or hash) is
+/// fail-closed to `false`.
+pub fn reload_decision(
+    start_time: SystemTime,
+    on_disk_mtime: Option<SystemTime>,
+    on_disk_hash: Option<&str>,
+    running_hash: &str,
+) -> bool;
+
+/// `true` only when the on-disk executable is a genuinely different image than
+/// the running one. Cheap mtime pre-filter, then a content-hash confirm against
+/// the startup-pinned [`running_image_hash`].
+///
+/// Fail-closed: any error reading or hashing the on-disk binary, an unreadable
+/// mtime, or an unknown running identity yields `false`. Never panics.
+pub fn binary_changed(start_time: SystemTime) -> bool;
+
+/// Replace the current process with a fresh copy of itself via `exec()`.
+/// On success this never returns; on failure the error is returned so the
+/// caller degrades gracefully and keeps running. The re-exec target is the
+/// absolute `std::env::current_exe()`, never a relative path or `$0`.
+#[cfg(unix)]
+pub fn exec_self_reload() -> Result<(), Box<dyn std::error::Error>>;
+```
+
+The loop call site is unchanged in shape — only the gate's semantics tighten:
+
+```rust
+// src/operator_commands_ooda/daemon/mod.rs
+#[cfg(unix)]
+if auto_reload && binary_changed(start_time) {
+    if let Some(ref mut session) = bridges.session {
+        let _ = session.close();
+    }
+    exec_self_reload()?;
+    // exec_self_reload only returns on error — continue running.
+}
+```
+
+## Configuration
+
+| Variable / flag | Default | Purpose |
+| --- | --- | --- |
+| `--no-auto-reload` | (auto-reload **on**) | CLI flag to `simard ooda run` that disables auto-reload entirely — the daemon never relaunches itself regardless of on-disk changes. |
+| `SIMARD_OODA_INTERVAL_SECS` | `300` | Cycle interval. Also the cadence at which the reload gate is evaluated. An unparseable/empty value falls back to `300`; **range-clamping of `0` and oversized values is the Wave 4 daemon-safety hardening target and is not yet in place** (see below). |
+
+`SIMARD_OODA_INTERVAL_SECS` is read as
+`std::env::var(...).ok().and_then(|v| v.parse().ok()).unwrap_or(300)` on `main`
+today: a non-numeric or empty value falls back to the `300` default, but `0` and
+absurdly large values currently parse successfully and are accepted verbatim. A
+value of `0` would busy-spin the loop — evaluating the reload gate and every
+other per-cycle check with no sleep. Clamping this knob to a safe range is the
+**Wave 4** daemon-correctness/safety hardening item (`daemon-correctness-safety`,
+R3); it is specified here for context but is not part of the Wave 2 reload-gate
+change.
+
+Auto-reload continuing to be *enabled* is correct; the fix is to stop it firing
+on identical content, not to turn it off. Operators who want a fully static
+daemon still use `--no-auto-reload`.
+
+## Safety invariants
+
+- **Fail-closed.** Any inability to read the on-disk binary, compute its hash,
+  or read its mtime results in **no relaunch**. A transient I/O error must never
+  trigger a cold start.
+- **Absolute re-exec target.** `exec_self_reload` re-execs the absolute
+  `std::env::current_exe()` path with the original argv tail — never a relative
+  path, a `PATH` lookup, or `$0`, so the reload cannot be hijacked into a
+  different binary.
+- **Trusted-vs-untrusted comparison.** The startup-pinned running-image hash is
+  the trusted side; the on-disk bytes are untrusted. Content gating detects a
+  tampered swap that an mtime bump alone would have accepted.
+- **Zero-shell exec.** The relaunch uses `Command::exec()` directly — there is
+  no `sh -c`, so there is no shell-injection surface in the reload path.
+- **Session drained first.** The LLM session is closed before `exec()` so a
+  genuine reload does not leak the bridge/session resources.
+- **Panic-free.** The gate performs no unwrap/expect on I/O and no unbounded
+  allocation; it is safe to call every cycle.
+
+## Examples
+
+### Default: reload only on a real change
+
+```bash
+simard ooda run
+```
+
+A `cargo build` that produces a byte-identical binary (same commit, no source
+change) bumps the file mtime but leaves the content hash unchanged — the daemon
+keeps running. A build from a *new* commit produces different content — the
+daemon relaunches once into it.
+
+### Disable auto-reload entirely
+
+```bash
+simard ooda run --no-auto-reload
+```
+
+The daemon ignores on-disk changes; deploy a new binary by restarting the
+service explicitly.
+
+### Confirm the churn is gone
+
+```bash
+# Restart count should stay flat across identical rebuilds.
+systemctl --user show -p NRestarts simard-ooda
+
+# The reload log line appears only on a genuine image change. On a content
+# change the daemon logs "on-disk binary is a genuinely different image
+# (content hash changed) — reloading via exec()" to ooda.log / stderr.
+grep 'genuinely different image' ~/.simard/ooda.log | tail
+```
+
+## Migration notes
+
+- **No config change required.** Existing deployments keep auto-reload on and
+  gain the identity gate automatically. The only observable difference is that
+  identical-content rebuilds no longer trigger a restart.
+- **Legitimate deploys still reload.** The
+  [self-deploy](./self-deploy-api.md) and
+  [multi-binary self-update](./multi-binary-self-update.md) paths install a
+  binary whose content differs from the running image, so its content hash
+  differs and the daemon reloads exactly once — the intended behavior.
+- **`--no-auto-reload` is unchanged.** It still fully disables self-reload.
+
+## Related
+
+- [Daemon mode](../daemon-mode.md) — the OODA loop this gate runs inside.
+- [Run the OODA daemon](../howto/run-ooda-daemon.md) — start/flags/env.
+- [Reconcile and self-deploy](../concepts/reconcile-and-self-deploy.md) —
+  the merged-but-not-running detector and restart orchestration.
+- [Multi-binary self-update](./multi-binary-self-update.md) — the update path
+  that legitimately swaps the binary.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -134,6 +134,7 @@ nav:
     - Dependency Trust Policy: reference/dependency-trust-policy.md
     - Release Integrity (SBOM + Signing): reference/release-integrity.md
     - Recipe-brain Verdict/Decision Parsing: reference/recipe-brain-verdict-parsing.md
+    - OODA Binary-Identity Reload Gate: reference/ooda-binary-identity-reload-gate.md
     # Hidden from nav until issue #1590 implementation lands:
     #   - reference/cognitive-memory-bridge-helpers.md
     #   - reference/goal-board-api.md

--- a/src/operator_commands_ooda/daemon/helpers.rs
+++ b/src/operator_commands_ooda/daemon/helpers.rs
@@ -1,3 +1,5 @@
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, SystemTime};
 
@@ -29,9 +31,122 @@ pub fn exe_mtime() -> Option<SystemTime> {
         .and_then(|m| m.modified().ok())
 }
 
-/// Check whether the on-disk binary is newer than `start_time`.
+/// Whether the on-disk binary is a **genuinely different image** than the one
+/// this process is running — the gate for an auto-reload `exec()`.
+///
+/// This replaces the historical mtime-only check (`exe_mtime() > start_time`),
+/// which relaunched on *any* rebuild/`touch` even when the resulting binary was
+/// byte-for-byte identical. On a host that periodically rebuilds the daemon from
+/// an unchanged tree, that turned every ~40–45 min into a full cold-start `exec`
+/// (slow recall/preparation each time) for no benefit (2026-07-02
+/// operator-review #2). The gate now confirms a real content difference before
+/// paying for a relaunch:
+///
+/// 1. **mtime pre-filter** — if the on-disk mtime is not newer than the image we
+///    started from, nothing changed; return `false` without hashing (the
+///    steady-state hot path, run every cycle).
+/// 2. **content confirmation** — only when the mtime IS newer do we hash the
+///    on-disk file and compare it to the [`running_image_hash`]. Identical
+///    content (a no-op rebuild) → `false`; a different digest → `true`.
+///
+/// Fail-closed throughout: an unreadable mtime, an unhashable on-disk file, or an
+/// unknown running identity all yield `false`, because a transient I/O error must
+/// never trigger a needless cold start.
 pub fn binary_changed(start_time: SystemTime) -> bool {
-    exe_mtime().is_some_and(|mtime| mtime > start_time)
+    let running_hash = match running_image_hash() {
+        Some(h) => h,
+        // Running identity unknown (couldn't hash our own image at startup) →
+        // fail-closed: never relaunch on a guess.
+        None => return false,
+    };
+    let on_disk_hash = current_exe_path().as_deref().and_then(file_content_hash);
+    reload_decision(
+        start_time,
+        exe_mtime(),
+        on_disk_hash.as_deref(),
+        running_hash,
+    )
+}
+
+// ── Wave 2: binary-identity reload gate (2026-07-02 operator-review #2) ──────
+//
+// The mtime-only `binary_changed` above was the ~40–45 min self-restart churn
+// trigger: any rebuild/`touch` bumped the mtime and forced a full `exec()`
+// cold-start even when the on-disk image was byte-identical. The two seams below
+// (`file_content_hash` + the pure `reload_decision`) let the gate confirm a REAL
+// image difference before relaunching, and are unit-tested in isolation. See
+// `docs/reference/ooda-binary-identity-reload-gate.md`.
+
+/// Content hash of the RUNNING process image, captured once (lazily) and cached
+/// for the life of the process.
+///
+/// Capturing it once — rather than re-hashing `current_exe()` on every check —
+/// is what makes the gate correct: after an in-place replace, `current_exe()`
+/// resolves to the NEW bytes, so only a value pinned at (or near) startup still
+/// identifies the OLD image we are actually running.
+static RUNNING_IMAGE_HASH: OnceLock<Option<String>> = OnceLock::new();
+
+/// Hash of the running image (see [`RUNNING_IMAGE_HASH`]), or `None` if our own
+/// executable could not be hashed at capture time. Lazily initialised on first
+/// use so unit tests (and any early caller) observe a consistent value.
+pub fn running_image_hash() -> Option<&'static str> {
+    RUNNING_IMAGE_HASH
+        .get_or_init(|| current_exe_path().as_deref().and_then(file_content_hash))
+        .as_deref()
+}
+
+/// Pin the running-image hash at a known-early point (daemon startup), closing
+/// the window in which an in-place replace between `exec` and the first reload
+/// check could otherwise be mistaken for the running image. Idempotent.
+pub fn capture_running_image_hash() {
+    let _ = running_image_hash();
+}
+
+/// The path to this process's executable, or `None` if it cannot be resolved.
+fn current_exe_path() -> Option<PathBuf> {
+    std::env::current_exe().ok()
+}
+
+/// Stable content identity (hex SHA-256 digest) of the file at `path`, or `None`
+/// on any I/O error (fail-closed). Never panics — safe to call on the untrusted
+/// on-disk binary every cycle. Streams the file through the hasher so a
+/// multi-megabyte binary is never fully buffered in memory.
+pub fn file_content_hash(path: &Path) -> Option<String> {
+    use sha2::{Digest, Sha256};
+    let mut file = std::fs::File::open(path).ok()?;
+    let mut hasher = Sha256::new();
+    std::io::copy(&mut file, &mut hasher).ok()?;
+    Some(format!("{:x}", hasher.finalize()))
+}
+
+/// Pure reload decision: `true` **only** when the on-disk image is a genuinely
+/// different binary than the running one.
+///
+/// * `on_disk_mtime` not newer than `start_time` → `false` (cheap mtime
+///   pre-filter; the content hash is not consulted — the steady-state hot path).
+/// * mtime newer **and** `on_disk_hash == Some(running_hash)` → `false`
+///   (identical-content rebuild — the churn case this gate eliminates).
+/// * mtime newer **and** `on_disk_hash == Some(other)` → `true` (real image
+///   difference → relaunch).
+/// * mtime newer **and** `on_disk_hash == None` (read/hash error) → `false`
+///   (fail-closed — a transient I/O error must never trigger a cold start).
+/// * `on_disk_mtime == None` (unreadable) → `false` (fail-closed).
+pub fn reload_decision(
+    start_time: SystemTime,
+    on_disk_mtime: Option<SystemTime>,
+    on_disk_hash: Option<&str>,
+    running_hash: &str,
+) -> bool {
+    // Cheap mtime pre-filter — no hashing on the steady-state hot path.
+    match on_disk_mtime {
+        Some(mtime) if mtime > start_time => {}
+        _ => return false,
+    }
+    // mtime is newer: relaunch only on a confirmed content difference.
+    match on_disk_hash {
+        Some(hash) => hash != running_hash,
+        None => false,
+    }
 }
 
 /// Replace the current process with a fresh copy of itself.
@@ -148,15 +263,122 @@ mod tests {
         assert!(!binary_changed(SystemTime::now()));
     }
 
+    /// Wave 2 contract (RED against today's mtime-only `binary_changed`): an
+    /// **ancient** start time must NOT trigger a reload when the on-disk binary
+    /// is *identical content* to the running one — which is exactly the case
+    /// here, because the test binary IS `current_exe()` and nothing rebuilds it
+    /// mid-test. mtime-only returns `true` (the ~40-min churn bug); the
+    /// content-identity gate must return `false` (no relaunch on identical
+    /// content). This is the public-API expression of the churn fix.
     #[test]
-    fn binary_changed_true_when_start_time_is_epoch() {
-        assert!(binary_changed(SystemTime::UNIX_EPOCH));
+    fn binary_changed_false_on_identical_content_even_with_ancient_start_time() {
+        assert!(
+            !binary_changed(SystemTime::UNIX_EPOCH),
+            "identical on-disk content must not relaunch, even with an epoch start time"
+        );
     }
 
     #[test]
     fn binary_changed_false_when_start_time_is_far_future() {
         let future = SystemTime::now() + Duration::from_secs(86400 * 365 * 10);
         assert!(!binary_changed(future));
+    }
+
+    // ── file_content_hash (Wave 2 seam) ─────────────────────────────
+
+    #[test]
+    fn file_content_hash_is_stable_for_identical_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = dir.path().join("a.bin");
+        let b = dir.path().join("b.bin");
+        std::fs::write(&a, b"identical bytes \x00\x01\x02").unwrap();
+        std::fs::write(&b, b"identical bytes \x00\x01\x02").unwrap();
+        let ha = file_content_hash(&a).expect("readable file must hash");
+        let hb = file_content_hash(&b).expect("readable file must hash");
+        assert_eq!(ha, hb, "identical bytes must produce an identical hash");
+    }
+
+    #[test]
+    fn file_content_hash_differs_for_different_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = dir.path().join("a.bin");
+        let b = dir.path().join("b.bin");
+        std::fs::write(&a, b"one payload").unwrap();
+        std::fs::write(&b, b"another payload").unwrap();
+        assert_ne!(
+            file_content_hash(&a).unwrap(),
+            file_content_hash(&b).unwrap(),
+            "different bytes must produce different hashes"
+        );
+    }
+
+    #[test]
+    fn file_content_hash_is_none_on_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("does-not-exist.bin");
+        assert!(
+            file_content_hash(&missing).is_none(),
+            "a missing/unreadable file must hash to None (fail-closed upstream)"
+        );
+    }
+
+    // ── reload_decision (Wave 2 seam) ───────────────────────────────
+
+    const RUNNING: &str = "hash-of-the-running-image";
+
+    #[test]
+    fn reload_decision_false_when_mtime_not_newer() {
+        let start = SystemTime::now();
+        let older = start - Duration::from_secs(60);
+        // mtime not newer than start ⇒ pre-filter returns false WITHOUT consulting
+        // the hash (a differing hash here must be ignored on the hot path).
+        assert!(!reload_decision(
+            start,
+            Some(older),
+            Some("some-other-hash"),
+            RUNNING
+        ));
+    }
+
+    #[test]
+    fn reload_decision_false_on_identical_content_rebuild() {
+        // Newer mtime BUT identical content hash ⇒ the churn case ⇒ no relaunch.
+        let start = SystemTime::now();
+        let newer = start + Duration::from_secs(60);
+        assert!(!reload_decision(start, Some(newer), Some(RUNNING), RUNNING));
+    }
+
+    #[test]
+    fn reload_decision_true_on_genuinely_different_image() {
+        // Newer mtime AND different content hash ⇒ a real new image ⇒ relaunch.
+        let start = SystemTime::now();
+        let newer = start + Duration::from_secs(60);
+        assert!(reload_decision(
+            start,
+            Some(newer),
+            Some("a-genuinely-different-hash"),
+            RUNNING
+        ));
+    }
+
+    #[test]
+    fn reload_decision_fail_closed_when_on_disk_hash_unreadable() {
+        // Newer mtime but the on-disk hash could not be computed ⇒ fail-closed
+        // (do NOT relaunch on a transient read/hash error).
+        let start = SystemTime::now();
+        let newer = start + Duration::from_secs(60);
+        assert!(!reload_decision(start, Some(newer), None, RUNNING));
+    }
+
+    #[test]
+    fn reload_decision_fail_closed_when_mtime_unreadable() {
+        // Unreadable mtime ⇒ fail-closed regardless of the hashes.
+        assert!(!reload_decision(
+            SystemTime::now(),
+            None,
+            Some("a-different-hash"),
+            RUNNING
+        ));
     }
 
     // ── interruptible_sleep ─────────────────────────────────────────

--- a/src/operator_commands_ooda/daemon/mod.rs
+++ b/src/operator_commands_ooda/daemon/mod.rs
@@ -379,6 +379,17 @@ pub fn run_ooda_daemon(
     // Capture the binary mtime at startup so we can detect in-place upgrades.
     let start_time = exe_mtime().unwrap_or_else(SystemTime::now);
 
+    // Pin the running image's CONTENT hash at startup too. The reload gate
+    // (`binary_changed`) now relaunches only when the on-disk image is a
+    // genuinely different binary — not on a byte-identical rebuild that merely
+    // bumped the mtime, which was the ~40–45 min self-restart churn trigger
+    // (2026-07-02 operator-review #2; see
+    // docs/reference/ooda-binary-identity-reload-gate.md). Pinning it here
+    // (rather than lazily on the first check) closes the window where an
+    // in-place replace between exec and the first cycle could be mistaken for
+    // the running image.
+    capture_running_image_hash();
+
     if auto_reload {
         daemon_log(&state_root, "[simard] OODA daemon: auto-reload enabled");
     }
@@ -473,9 +484,14 @@ pub fn run_ooda_daemon(
             break;
         }
 
-        // Auto-reload: if the on-disk binary is newer, exec into it.
+        // Auto-reload: if the on-disk binary is a genuinely different image
+        // (content hash differs from the running one), exec into it.
         #[cfg(unix)]
         if auto_reload && binary_changed(start_time) {
+            daemon_log(
+                &state_root,
+                "[simard] OODA daemon: on-disk binary is a genuinely different image (content hash changed) — reloading via exec()",
+            );
             // Close the LLM session before exec so we don't leak resources.
             if let Some(ref mut session) = bridges.session {
                 let _ = session.close();

--- a/src/operator_commands_ooda/tests/auto_reload_tests.rs
+++ b/src/operator_commands_ooda/tests/auto_reload_tests.rs
@@ -10,11 +10,18 @@ fn binary_not_changed_when_start_time_is_recent() {
 }
 
 #[test]
-fn binary_changed_when_start_time_is_old() {
-    // A start_time far in the past should always be older than the on-disk
-    // binary, so `binary_changed` should return true.
+fn binary_not_changed_on_identical_content_even_with_old_start_time() {
+    // Content-identity gate (2026-07-02 operator-review #2): a start_time far in
+    // the past makes the mtime pre-filter fire, but the on-disk binary IS the
+    // running test binary (identical content — nothing rebuilds it mid-test), so
+    // the gate must NOT relaunch. The old mtime-only check returned `true` here
+    // and was the ~40–45 min self-restart churn bug; the new check returns
+    // `false` on a byte-identical image.
     let epoch = SystemTime::UNIX_EPOCH;
-    assert!(binary_changed(epoch));
+    assert!(
+        !binary_changed(epoch),
+        "identical on-disk content must not relaunch, even with an epoch start time"
+    );
 }
 
 #[test]

--- a/src/operator_commands_ooda/tests/daemon_inline.rs
+++ b/src/operator_commands_ooda/tests/daemon_inline.rs
@@ -43,10 +43,14 @@ fn test_exe_mtime_returns_some() {
 }
 
 #[test]
-fn test_binary_changed_true_for_epoch() {
-    // If start_time is UNIX_EPOCH, the binary is certainly newer.
+fn test_binary_changed_false_for_epoch_identical_content() {
+    // Content-identity gate (2026-07-02 operator-review #2): even though an
+    // epoch start_time trips the mtime pre-filter, the on-disk binary is the
+    // running test binary (identical content), so no relaunch. The prior
+    // mtime-only check asserted `true` here — that was the self-restart churn
+    // bug this gate fixes.
     let epoch = SystemTime::UNIX_EPOCH;
-    assert!(binary_changed(epoch));
+    assert!(!binary_changed(epoch));
 }
 
 #[test]


### PR DESCRIPTION
## Wave 2 of 5 — quality audit (2026-07-02 operator-review priority 2)

**Issue #2 (OODA daemon self-restarts every ~40-45 min) — root-caused and fixed.**

### Root cause (confirmed)
`daemon/helpers.rs::binary_changed` was **mtime-only**:
```rust
pub fn binary_changed(start_time: SystemTime) -> bool {
    exe_mtime().is_some_and(|mtime| mtime > start_time)
}
```
Any operation that bumps the executable's mtime — a `cargo build` that relinks a **byte-identical** image, a `touch`, a redeploy that copies an identical binary, a backup/restore — made the gate return `true`. The daemon then closed its LLM session, `exec()`'d a fresh copy of the *same* image, and paid full cold-start cost (bridge spawn, memory recall, preparation). At `SIMARD_OODA_INTERVAL_SECS=300` that's a self-restart every ~4-5 cycles (~40-45 min), driving `NRestarts` high for zero behavioral change.

### The fix — content-identity gate
Relaunch only on a **genuinely different image**:
1. **mtime pre-filter (cheap)** — if the on-disk mtime is not newer than the start image, return `false` with no hashing (steady-state hot path).
2. **content confirm (only when mtime is newer)** — compare a SHA-256 of the on-disk file against the **running image's hash, captured once at startup**. After an in-place replace, `current_exe()` resolves to the *new* bytes, so only a startup-pinned hash still identifies the OLD running image. Identical content → no relaunch; different content → relaunch once.
3. **fail-closed** — an unreadable mtime, an unhashable on-disk file, or an unknown running identity all yield `false` (never cold-start on a transient I/O error).

### Changes
- `helpers.rs`: `file_content_hash` (streaming sha2, panic-free), pure `reload_decision`, `running_image_hash` + `capture_running_image_hash`, rewired `binary_changed`.
- `daemon/mod.rs`: pin the running hash at startup (`capture_running_image_hash()`); log content-verified reloads.
- Updated `auto_reload_tests` / `daemon_inline` to the new contract (identical content must NOT relaunch, even with an epoch start time — the exact churn bug).
- `docs/reference/ooda-binary-identity-reload-gate.md` + mkdocs nav.

### Tests
- `file_content_hash`: stable-for-identical / differs-for-different / None-on-missing.
- `reload_decision`: 5 cases including both fail-closed paths.
- `binary_changed`: content-identity contract (no relaunch on identical content).

`--no-auto-reload` still fully disables self-reload; legitimate deploys (different content) still reload exactly once. No snapshot docs.