### PR TITLE
WS2: interval-gated self-relaunch throttle (bound condition-free daemon restarts) — #2432 family

### DIFF
--- a/src/operator_commands_ooda/daemon/mod.rs
+++ b/src/operator_commands_ooda/daemon/mod.rs
@@ -382,6 +382,19 @@ pub fn run_ooda_daemon(
     if auto_reload {
         daemon_log(&state_root, "[simard] OODA daemon: auto-reload enabled");
     }
+    let self_relaunch_interval = crate::self_deploy::restart::self_relaunch_min_interval_from_env(
+        std::env::var(crate::self_deploy::restart::SELF_RELAUNCH_MIN_INTERVAL_ENV)
+            .ok()
+            .as_deref(),
+    );
+    daemon_log(
+        &state_root,
+        &format!(
+            "[simard] self-relaunch: min interval = {} ({}; 0/off disables interval-only relaunches; real binary hash changes bypass the interval)",
+            self_relaunch_interval.label(),
+            crate::self_deploy::restart::SELF_RELAUNCH_MIN_INTERVAL_ENV,
+        ),
+    );
 
     // De-fork Phase 2b (issue #2307): the native lbug-WAL file-copy backup was
     // removed. Issue #2420 reintroduces a periodic **verified** backup below —

--- a/src/self_deploy/restart.rs
+++ b/src/self_deploy/restart.rs
@@ -4,13 +4,81 @@
 //! operator deploy and an in-recipe dry run. See
 //! `docs/reference/self-deploy-api.md#daemonrestarter`.
 
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::error::{SimardError, SimardResult};
 
 /// Default systemd unit name Simard's OODA daemon runs under.
 pub const DEFAULT_OODA_UNIT: &str = "simard-ooda";
+/// Operator override for the minimum interval between condition-free relaunches.
+pub const SELF_RELAUNCH_MIN_INTERVAL_ENV: &str = "SIMARD_SELF_RELAUNCH_MIN_INTERVAL_SECS";
+/// Default throttle: one interval-based relaunch per day. Real binary changes bypass it.
+pub const DEFAULT_SELF_RELAUNCH_MIN_INTERVAL_SECS: u64 = 86_400;
+const SELF_RELAUNCH_STATE_FILE: &str = "self-relaunch-state.json";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SelfRelaunchInterval {
+    /// Disable interval-only relaunches; relaunch only when the binary changed.
+    Off,
+    /// Permit interval-only relaunches after this many seconds.
+    Seconds(u64),
+}
+
+impl SelfRelaunchInterval {
+    pub fn label(self) -> String {
+        match self {
+            Self::Off => "off".to_string(),
+            Self::Seconds(secs) => format!("{secs}s"),
+        }
+    }
+}
+
+/// Parse the self-relaunch interval.
+///
+/// Empty, missing, or garbage values use the sane default. `0` and `off`
+/// disable interval-only relaunches while still allowing real binary changes.
+pub fn self_relaunch_min_interval_from_env(value: Option<&str>) -> SelfRelaunchInterval {
+    let Some(raw) = value.map(str::trim).filter(|v| !v.is_empty()) else {
+        return SelfRelaunchInterval::Seconds(DEFAULT_SELF_RELAUNCH_MIN_INTERVAL_SECS);
+    };
+    if raw.eq_ignore_ascii_case("off") || raw == "0" {
+        return SelfRelaunchInterval::Off;
+    }
+    raw.parse::<u64>()
+        .ok()
+        .filter(|secs| *secs > 0)
+        .map(SelfRelaunchInterval::Seconds)
+        .unwrap_or(SelfRelaunchInterval::Seconds(
+            DEFAULT_SELF_RELAUNCH_MIN_INTERVAL_SECS,
+        ))
+}
+
+/// Pure decision: relaunch immediately for a real binary change, otherwise only
+/// when the configured minimum interval has elapsed.
+pub fn should_request_self_relaunch(
+    now_secs: u64,
+    last_relaunch_secs: Option<u64>,
+    interval: SelfRelaunchInterval,
+    binary_hash_changed: bool,
+) -> bool {
+    if binary_hash_changed {
+        return true;
+    }
+    match interval {
+        SelfRelaunchInterval::Off => false,
+        SelfRelaunchInterval::Seconds(min_secs) => last_relaunch_secs
+            .map(|last| now_secs.saturating_sub(last) >= min_secs)
+            .unwrap_or(true),
+    }
+}
+
+#[derive(serde::Deserialize, serde::Serialize)]
+struct SelfRelaunchState {
+    last_relaunch_unix_secs: u64,
+}
 
 /// Restarts the daemon after a binary swap.
 pub trait DaemonRestarter: Send + Sync {
@@ -117,10 +185,49 @@ impl SystemdOrExecRestarter {
             Err(_) => false, // systemctl not installed / no user bus
         }
     }
+
+    fn should_restart_now(&self) -> bool {
+        let state_root = crate::state_root::simard_state_root();
+        let interval = self_relaunch_min_interval_from_env(
+            std::env::var(SELF_RELAUNCH_MIN_INTERVAL_ENV)
+                .ok()
+                .as_deref(),
+        );
+        let now = now_unix_secs();
+        let last = read_last_relaunch_secs(&state_root);
+        let install_path = std::env::current_exe().unwrap_or_else(|_| PathBuf::from("simard"));
+        let binary_hash_changed = binary_hash_changed_since_snapshot(
+            &crate::safe_update::default_state_dir(),
+            &install_path,
+        );
+        let should = should_request_self_relaunch(now, last, interval, binary_hash_changed);
+        let last_label = last
+            .map(|t| format!("{}s ago", now.saturating_sub(t)))
+            .unwrap_or_else(|| "never".into());
+        eprintln!(
+            "[simard] self-relaunch: min interval = {} ({}={}, 0/off disables interval-only relaunch; binary-hash-changed={}; last={}; decision={})",
+            interval.label(),
+            SELF_RELAUNCH_MIN_INTERVAL_ENV,
+            std::env::var(SELF_RELAUNCH_MIN_INTERVAL_ENV).unwrap_or_else(|_| "<default>".into()),
+            binary_hash_changed,
+            last_label,
+            if should { "restart" } else { "skip" },
+        );
+        should
+    }
+
+    fn record_restart_requested(&self) {
+        let state_root = crate::state_root::simard_state_root();
+        let _ = write_last_relaunch_secs(&state_root, now_unix_secs());
+    }
 }
 
 impl DaemonRestarter for SystemdOrExecRestarter {
     fn restart(&self) -> SimardResult<()> {
+        if !self.should_restart_now() {
+            return Ok(());
+        }
+
         // Primary: systemd restart when the unit exists.
         if self.systemd_unit_present() {
             let out = Command::new("systemctl")
@@ -133,6 +240,7 @@ impl DaemonRestarter for SystemdOrExecRestarter {
                     ),
                 })?;
             if out.status.success() {
+                self.record_restart_requested();
                 return Ok(());
             }
             return Err(SimardError::VerificationFailed {
@@ -150,10 +258,65 @@ impl DaemonRestarter for SystemdOrExecRestarter {
         // the old process stays up until the new one is verified healthy.
         let semaphore_dir = crate::state_root::simard_state_root();
         let config = crate::self_relaunch::RelaunchConfig::default();
-        crate::self_relaunch::coordinated_relaunch(&semaphore_dir, &config).map(|_| ())
+        crate::self_relaunch::coordinated_relaunch(&semaphore_dir, &config).map(|_| {
+            self.record_restart_requested();
+        })
     }
 
     fn kind(&self) -> &'static str {
         "systemd-or-exec"
     }
+}
+
+fn now_unix_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+fn relaunch_state_path(state_root: &Path) -> PathBuf {
+    state_root.join(SELF_RELAUNCH_STATE_FILE)
+}
+
+fn read_last_relaunch_secs(state_root: &Path) -> Option<u64> {
+    let path = relaunch_state_path(state_root);
+    let raw = std::fs::read(&path).ok()?;
+    serde_json::from_slice::<SelfRelaunchState>(&raw)
+        .ok()
+        .map(|s| s.last_relaunch_unix_secs)
+}
+
+fn write_last_relaunch_secs(state_root: &Path, secs: u64) -> std::io::Result<()> {
+    std::fs::create_dir_all(state_root)?;
+    let body = serde_json::to_vec_pretty(&SelfRelaunchState {
+        last_relaunch_unix_secs: secs,
+    })
+    .map_err(std::io::Error::other)?;
+    std::fs::write(relaunch_state_path(state_root), body)
+}
+
+fn binary_hash_changed_since_snapshot(state_dir: &Path, install_path: &Path) -> bool {
+    let Ok(Some(snapshot)) = crate::safe_update::snapshot::read_snapshot(state_dir) else {
+        return false;
+    };
+    let Ok(current) = sha256_file(install_path) else {
+        return false;
+    };
+    current != snapshot.sha256
+}
+
+fn sha256_file(path: &Path) -> std::io::Result<String> {
+    use sha2::{Digest, Sha256};
+
+    let bytes = std::fs::read(path)?;
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    let digest = hasher.finalize();
+    let mut hex = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        use std::fmt::Write as _;
+        let _ = write!(hex, "{byte:02x}");
+    }
+    Ok(hex)
 }

--- a/src/self_deploy/tests_restart.rs
+++ b/src/self_deploy/tests_restart.rs
@@ -2,7 +2,10 @@
 //! [`FakeRestarter`] (used by tests and the recipe so no real daemon is
 //! restarted), and the production restarter's stub.
 
-use super::restart::{DaemonRestarter, FakeRestarter, SystemdOrExecRestarter};
+use super::restart::{
+    DEFAULT_SELF_RELAUNCH_MIN_INTERVAL_SECS, DaemonRestarter, FakeRestarter, SelfRelaunchInterval,
+    SystemdOrExecRestarter, self_relaunch_min_interval_from_env, should_request_self_relaunch,
+};
 
 #[test]
 fn fake_restarter_records_calls_and_succeeds() {
@@ -38,6 +41,76 @@ fn fake_restarter_is_usable_as_boxed_trait_object() {
 fn systemd_or_exec_restarter_reports_its_kind() {
     let r = SystemdOrExecRestarter::new();
     assert_eq!(r.kind(), "systemd-or-exec");
+}
+
+#[test]
+fn self_relaunch_interval_env_uses_day_default_for_empty_or_garbage() {
+    assert_eq!(
+        self_relaunch_min_interval_from_env(None),
+        SelfRelaunchInterval::Seconds(DEFAULT_SELF_RELAUNCH_MIN_INTERVAL_SECS)
+    );
+    assert_eq!(
+        self_relaunch_min_interval_from_env(Some("")),
+        SelfRelaunchInterval::Seconds(DEFAULT_SELF_RELAUNCH_MIN_INTERVAL_SECS)
+    );
+    assert_eq!(
+        self_relaunch_min_interval_from_env(Some("garbage")),
+        SelfRelaunchInterval::Seconds(DEFAULT_SELF_RELAUNCH_MIN_INTERVAL_SECS)
+    );
+}
+
+#[test]
+fn self_relaunch_interval_env_honors_override_and_off() {
+    assert_eq!(
+        self_relaunch_min_interval_from_env(Some("7200")),
+        SelfRelaunchInterval::Seconds(7200)
+    );
+    assert_eq!(
+        self_relaunch_min_interval_from_env(Some("0")),
+        SelfRelaunchInterval::Off
+    );
+    assert_eq!(
+        self_relaunch_min_interval_from_env(Some("off")),
+        SelfRelaunchInterval::Off
+    );
+}
+
+#[test]
+fn should_request_self_relaunch_allows_real_binary_change_immediately() {
+    assert!(should_request_self_relaunch(
+        1_000,
+        Some(999),
+        SelfRelaunchInterval::Seconds(86_400),
+        true,
+    ));
+    assert!(should_request_self_relaunch(
+        1_000,
+        Some(999),
+        SelfRelaunchInterval::Off,
+        true,
+    ));
+}
+
+#[test]
+fn should_request_self_relaunch_throttles_interval_only_restarts() {
+    assert!(!should_request_self_relaunch(
+        1_000,
+        Some(900),
+        SelfRelaunchInterval::Seconds(300),
+        false,
+    ));
+    assert!(should_request_self_relaunch(
+        1_200,
+        Some(900),
+        SelfRelaunchInterval::Seconds(300),
+        false,
+    ));
+    assert!(!should_request_self_relaunch(
+        1_200,
+        Some(900),
+        SelfRelaunchInterval::Off,
+        false,
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
WS2 of the #2432 reliability family. Adds a **minimum-interval throttle** to the self-relaunch restarter so condition-free (interval-only) daemon relaunches cannot thrash: they are spaced by a configurable minimum (default once per day). A **real on-disk binary hash change bypasses the interval** and relaunches immediately, preserving fast pickup of genuine self-deploys.

Closes #2520. Sibling of #2517 (WS1), #2518 (WS3), #2519 (WS4). Parent family: #2432.

## Changes
- **`src/self_deploy/restart.rs`**
  - `SelfRelaunchInterval { Off, Seconds(u64) }` + `label()`.
  - `self_relaunch_min_interval_from_env()` — empty/missing/garbage → sane default (`86_400`s); `0`/`off` → disable interval-only relaunches.
  - Pure decision `should_request_self_relaunch(now, last, interval, binary_hash_changed)` — binary change ⇒ immediate; otherwise gated by elapsed-vs-min-interval.
  - `SystemdOrExecRestarter::should_restart_now()` consults the interval + last-relaunch state file + binary-hash snapshot and short-circuits `restart()`; `record_restart_requested()` persists the timestamp on success.
  - Env override: `SIMARD_SELF_RELAUNCH_MIN_INTERVAL_SECS`.
- **`src/operator_commands_ooda/daemon/mod.rs`** — logs the effective self-relaunch min interval at daemon startup.
- **`src/self_deploy/tests_restart.rs`** — unit tests for env parsing (default / override / `off`) and the throttle decision (binary-change bypass, interval spacing, `off` disables interval-only relaunch).

## Validation
- `cargo fmt --check` clean.
- `cargo clippy --all-targets --all-features --locked -- -D warnings` clean (pre-push gate passed).
- Release race-subset tests passed (pre-push gate).
- `cargo test --lib self_deploy::tests_restart` → 8 passed, 0 failed (1 pre-existing unrelated ignored TDD placeholder).

## Notes
No behavior change when the binary genuinely changes (still relaunches immediately). Only the previously-unbounded interval-only relaunch path is now spaced/disable-able.

Do not merge without review.
