### PR TITLE
fix(engineer,knowledge): char-boundary-safe truncation to stop UTF-8 slice panics (Wave 3, #2432)

### DIFF
--- a/src/engineer_loop/mod.rs
+++ b/src/engineer_loop/mod.rs
@@ -839,7 +839,14 @@ fn summarize_results(
     .to_string();
 
     let accomplishment = if action.stdout.len() > 200 {
-        format!("{}…", &action.stdout[..200])
+        // Char-boundary-safe truncation: `&action.stdout[..200]` panics when byte
+        // 200 falls inside a multi-byte UTF-8 sequence, and engineer stdout is
+        // arbitrary agent output (emoji, box-drawing, accented text) that hits
+        // this on the every-action summary path. See util::string_truncate.
+        let mut truncated = action.stdout.clone();
+        crate::util::string_truncate::truncate_to_char_boundary(&mut truncated, 200);
+        truncated.push('…');
+        truncated
     } else if action.stdout.is_empty() {
         format!("Completed objective: {objective}")
     } else {

--- a/src/engineer_loop/tests_review_persist.rs
+++ b/src/engineer_loop/tests_review_persist.rs
@@ -300,3 +300,48 @@ fn persist_artifacts_with_different_topologies() {
 }
 
 // --- make_inspection / make_executed helper validation ---
+
+// --- summarize_results char-boundary panic regression (Wave 3) ---
+
+/// `summarize_results` previously did `&action.stdout[..200]` guarded only by a
+/// BYTE-length check, so an engineer subprocess whose stdout put a multi-byte
+/// UTF-8 char across byte 200 panicked the every-action summary path. Assert the
+/// char-boundary-safe truncation no longer panics and drops the split char whole.
+#[test]
+fn summarize_results_does_not_panic_on_multibyte_stdout_at_byte_200() {
+    use super::types::VerificationReport;
+
+    let mut stdout = "a".repeat(199);
+    stdout.push('🎉'); // 4-byte emoji: byte 199 starts it, byte 200 is mid-sequence
+    stdout.push_str("trailing");
+    assert!(
+        !stdout.is_char_boundary(200),
+        "fixture invariant: byte 200 must split the emoji"
+    );
+
+    let mut action = make_executed(EngineerActionKind::ReadOnlyScan);
+    action.stdout = stdout;
+    let verification = VerificationReport {
+        status: "ok".to_string(),
+        summary: "ok".to_string(),
+        checks: Vec::new(),
+    };
+    let inspection = make_inspection();
+
+    // Must not panic (the whole point of the fix).
+    let summary = super::summarize_results("objective", &action, &verification, &inspection);
+
+    assert!(
+        summary.accomplishment.ends_with('…'),
+        "an over-budget summary keeps its ellipsis"
+    );
+    assert!(
+        summary.accomplishment.len() <= 200 + '…'.len_utf8(),
+        "truncated to the byte budget (+ ellipsis), got {} bytes",
+        summary.accomplishment.len()
+    );
+    assert!(
+        !summary.accomplishment.contains('🎉'),
+        "the char straddling the budget is dropped whole, never partially included"
+    );
+}

--- a/src/native_knowledge.rs
+++ b/src/native_knowledge.rs
@@ -216,7 +216,13 @@ fn build_answer(conn: &Connection, keywords: &[&str], sources: &[SourceInfo]) ->
                 && let Ok(content) = stmt.query_row([&source.title], |row| row.get::<_, String>(0))
             {
                 let truncated = if content.len() > 500 {
-                    format!("{}...", &content[..500])
+                    // Char-boundary-safe: `&content[..500]` panics when byte 500
+                    // splits a multi-byte UTF-8 sequence, and knowledge-article
+                    // content read from SQLite routinely contains non-ASCII text.
+                    let mut t = content;
+                    crate::util::string_truncate::truncate_to_char_boundary(&mut t, 500);
+                    t.push_str("...");
+                    t
                 } else {
                     content
                 };


### PR DESCRIPTION
## Wave 3 of 5 — quality audit (correctness / safety)

**Panic class: byte-index slice of untrusted UTF-8 guarded only by a byte-length check.**

The SEEK phase confirmed several sites that do `&s[..N]` after `if s.len() > N` — a byte-length guard followed by a byte-index slice. In Rust `&str[..N]` **panics** if byte `N` is not a UTF-8 char boundary. When the input contains multi-byte characters (emoji, CJK, accented text, box-drawing) crossing byte `N`, the runtime panics. This PR fixes the two **most reachable, High-severity** sites:

### Fixes
1. **`engineer_loop::summarize_results`** (`&action.stdout[..200]`) — runs on the summary path after **every** engineer action; `action.stdout` is arbitrary engineer-subprocess output.
2. **`native_knowledge`** snippet builder (`&content[..500]`) — knowledge-article content read from SQLite (routinely non-ASCII), on the recall path.

Both now route through the existing, exhaustively-tested `util::string_truncate::truncate_to_char_boundary` (byte budget, backs up to the previous char boundary, never panics).

### Test
Added a call-site regression test: feeds `summarize_results` a stdout of 199 ASCII bytes + a 4-byte emoji (so byte 200 splits it) and asserts no panic, the ellipsis is kept, the byte budget is respected, and the split char is dropped whole.

Remaining sites of the same class (rollback stderr, meeting-extract, dashboard slug) are addressed in Wave 5. No behavior change beyond eliminating the panic (cosmetic: identical truncation output for ASCII).