### PR TITLE
docs: reconcile docs/ with current source — de-fork #2307, discoverability, accuracy

### DIFF
--- a/docs/architecture/bridge-pattern.md
+++ b/docs/architecture/bridge-pattern.md
@@ -1,7 +1,7 @@
 ---
 title: Bridge Pattern
 description: How Simard's bridge infrastructure provides typed interfaces for knowledge and gym services, using native Rust transports with circuit breaker fault tolerance.
-last_updated: 2026-06-02
+last_updated: 2026-07-03
 owner: simard
 doc_type: concept
 ---
@@ -138,10 +138,23 @@ The built-in `bridge.health` method is always registered and returns `{"server_n
 
 ### Data Loss Prevention
 
-- Memory writes are idempotent (LadybugDB `node_id` is primary key)
-- Python bridge wraps each write in a LadybugDB transaction
-- If bridge dies mid-write, the transaction rolls back
-- On reconnect, Simard re-issues the last failed write
+Cognitive-memory writes no longer flow through a `BridgeTransport`. Since the
+de-fork (Phase 2b, issue #2307) they go directly through the in-process
+[`LibraryCognitiveMemory`](cognitive-memory-library-adapter.md) adapter over
+`amplihack-memory-lib`:
+
+- Writes are idempotent — each fact, episode, or procedure is keyed by its
+  LadybugDB `node_id`, so a replayed write reinforces the existing node rather
+  than duplicating it (the *upsert-that-reinforces* contract; see
+  [Procedural Idempotency](../reference/cognitive-memory-procedural-idempotency.md)).
+- Concurrent writers are serialized through a single-writer IPC guard
+  (`memory_ipc::launcher::launch_writer_bridge`), so parallel Simard processes
+  cannot interleave writes to the same store.
+- Durability and recovery are provided by verified backups in the
+  `memory_backup` module (`backup_memory_verified`, `verify_backup`,
+  `restore_from_backup`) rather than by transport-level transaction replay —
+  see [Verified Backups](../operations/verified-backups.md) and
+  [Cognitive-Memory Durability](../operations/cognitive-memory-durability.md).
 
 ## Testing
 

--- a/docs/architecture/cognitive-memory-library-adapter.md
+++ b/docs/architecture/cognitive-memory-library-adapter.md
@@ -1,7 +1,7 @@
 ---
 title: Library-backed Cognitive Memory (the sole backend)
 description: How Simard's CognitiveMemoryOps trait is backed by amplihack-memory-lib's persistent CognitiveMemory through the LibraryCognitiveMemory adapter. As of de-fork Phase 2b this is the ONLY on-disk cognitive-memory backend; the native LadybugDB fork has been deleted.
-last_updated: 2026-06-19
+last_updated: 2026-07-03
 owner: simard
 doc_type: reference
 related:
@@ -134,18 +134,18 @@ conformance tests) and enables the library's `persistent` feature:
 ```toml
 # Cargo.toml
 [dependencies]
-amplihack-memory = { git = "https://github.com/rysweet/amplihack-memory-lib.git", rev = "ece725b1ac7e1c34cc254529879b291df1ed9ec7", features = ["persistent"] }
+amplihack-memory = { git = "https://github.com/rysweet/amplihack-memory-lib.git", rev = "26d49bf864ac2c03b80c4ab075c4a907c51f82a8", features = ["persistent"] }
 
 # Retained for ONE remaining direct reader: src/bin/simard_tui/goals.rs.
 # Not used by the cognitive-memory backend, which goes through amplihack-memory.
-lbug = "=0.15.3"
+lbug = "=0.17.1"
 ```
 
 - The library's `persistent` feature compiles **LadybugDB from source**, which
   requires a working **CMake + C++ toolchain** and noticeably longer build
   times. Because the library backend is now the only backend, every build pays
   this cost — budget extra time for `cargo build --release --bin simard`.
-- Both Simard and the library pin `lbug = "=0.15.3"`, so they share one
+- Both Simard and the library pin `lbug = "=0.17.1"`, so they share one
   LadybugDB build.
 
 ### No cargo feature, no env switch

--- a/docs/concepts/progress-evidence-gating.md
+++ b/docs/concepts/progress-evidence-gating.md
@@ -105,7 +105,7 @@ accepted) rather than blocking all goals.
   upstream).
 
 (Dashboard operator overrides are not "non-evidence" — they are a separate
-intentional bypass mechanism. See [Bypass set](#bypass-set--when-the-gate-is-not-consulted) and [Scope and exceptions](#scope-and-exceptions).)
+intentional bypass mechanism. See [Bypass set](#bypass-set-when-the-gate-is-not-consulted) and [Scope and exceptions](#scope-and-exceptions).)
 
 ## Bypass set — when the gate is not consulted
 
@@ -140,7 +140,7 @@ ooda_actions/advance_goal/subordinate.rs:223  (Completed after artifacts)
 ```
 
 A fifth caller — `ooda_actions/advance_goal/subordinate.rs:262` — sets
-`Blocked(reason)`, which is in the [bypass set](#bypass-set--when-the-gate-is-not-consulted)
+`Blocked(reason)`, which is in the [bypass set](#bypass-set-when-the-gate-is-not-consulted)
 (`Blocked` keeps the prior percent and cannot inflate the dashboard). It
 intentionally continues to call `update_goal_progress` directly.
 

--- a/docs/howto/grant-engineer-write-permissions.md
+++ b/docs/howto/grant-engineer-write-permissions.md
@@ -1,3 +1,11 @@
+---
+title: Grant the Engineer Subprocess Write Permissions
+description: How to grant an engineer subprocess the write permissions it needs to open PRs, when you actually need to, and how to avoid the permission-denied regression.
+last_updated: 2026-07-03
+owner: simard
+doc_type: howto
+---
+
 # Grant the Engineer Subprocess Write Permissions
 
 > **Audience:** Operators wiring new engineer dispatch paths or debugging an

--- a/docs/howto/grant-engineer-write-permissions.md
+++ b/docs/howto/grant-engineer-write-permissions.md
@@ -60,7 +60,7 @@ amplihack-hygiene-plan-20260512T231555Z.md  ← thoughtful plan
 Cure: ensure your dispatch path is using `run_engineer_subprocess` and
 that the live `amplihack` binary on the daemon's PATH was built from a
 revision containing the contract. Walk the checklist in
-[Engineer Copilot Subprocess Permissions §Example 4](../reference/engineer-copilot-permissions.md#example-4--debugging-a-engineer-produced-no-pr-report).
+[Engineer Copilot Subprocess Permissions §Example 4](../reference/engineer-copilot-permissions.md#example-4-debugging-a-engineer-produced-no-pr-report).
 
 ## Step-by-step: add a new engineer call site
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 ---
 title: Simard documentation
 description: Start here for the shipped `simard` operator CLI, the shared-state-root bridge from bounded terminal sessions into the repo-grounded engineer loop, the `engineer read` audit companion, compatibility binaries, runtime contracts, and benchmark flow.
-last_updated: 2026-04-03
+last_updated: 2026-07-03
 review_schedule: as-needed
 owner: simard
 ---
@@ -15,6 +15,12 @@ Simard is a terminal-native engineering identity, written in Rust, that drives a
 The shipped command tree covers `engineer`, `meeting`, `goal-curation`, `improvement-curation`, `gym`, `review`, and `bootstrap` from one binary, including the read-only `engineer read` audit companion and the bounded `engineer terminal*` session surfaces. The legacy `simard_operator_probe` and `simard-gym` binaries remain available as compatibility surfaces while operators migrate, but the primary product surface is now `simard ...`.
 
 Terminal sessions and repo-grounded engineer runs now bridge through one explicit local `state-root`. That bridge is file-backed and operator-visible. It does not imply hidden resume logic, external orchestration, or automatic continuation.
+
+!!! note "Recently reconciled"
+    The docs were audited against the current source: the cognitive-memory
+    pages were de-forked to the library backend (issue #2307), and every page
+    is now reachable from the navigation. See
+    [What's Changed](./whats-changed.md) for the full change index.
 
 ## Start here
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -1,7 +1,7 @@
 ---
 title: Memory architecture
 description: Top-level overview of Simard's six-type cognitive memory, consolidation flow, ranked fact and episodic recall, usage/recency reinforcement, snapshot retention, and on-disk layout. Cross-links to the canonical architecture page.
-last_updated: 2026-06-23
+last_updated: 2026-07-03
 owner: simard
 doc_type: concept
 ---
@@ -130,9 +130,10 @@ for the full API, examples, and invariants.
 Shipped in issue [#2395](https://github.com/rysweet/Simard/issues/2395). This
 extends the #2329 ranked-recall pattern from facts to **episodes**, and turns on
 the **usage/recency reinforcement** the ranker had always scored but Simard
-never recorded. The library dependency rev is unchanged (`285de92`, `lbug`
+never recorded. As of issue #2395 the library dependency rev was unchanged (`285de92`, `lbug`
 pinned at `0.15.4`) — both capabilities were already present in the library and
-are simply wired through the `CognitiveMemoryOps` trait.
+are simply wired through the `CognitiveMemoryOps` trait. (The pin has since
+advanced to `26d49bf8` / `lbug 0.17.1` in de-fork Phase 2b, #2307.)
 
 ### Ranked recall for episodes
 

--- a/docs/operations/cognitive-memory-durability.md
+++ b/docs/operations/cognitive-memory-durability.md
@@ -1,923 +1,362 @@
+---
+title: Cognitive memory durability
+description: Current durability, verified-backup, pruning, and restore contract for the library-backed cognitive memory store.
+last_updated: 2026-07-03
+owner: cognitive-memory
+doc_type: reference
+---
+
 # Cognitive Memory Durability
 
-As of the de-fork (issue #2307, Phase 2b), Simard's cognitive memory is
-provided by the `amplihack-memory-lib` library backend
-(`LibraryCognitiveMemory`), which **owns its own durability**. The library
-writes through LadybugDB's write-ahead log (WAL), and a CHECKPOINT collapses the
-WAL into the main store. The OODA daemon's shutdown handler issues that
-CHECKPOINT before exit, so a graceful restart observes every committed write.
-
-Durability today rests on three things:
-
-1. **Library WAL + CHECKPOINT** — writes are journaled by LadybugDB; the
-   `CognitiveMemoryOps::checkpoint` trait method (delegating to
-   `LibraryCognitiveMemory::checkpoint` → the library's `close()`) collapses the
-   WAL into the store.
-2. **SIGTERM-safe shutdown handler** (issue #1631) — graceful signals
-   (`SIGTERM`/`SIGINT`/`SIGHUP`) run the shutdown sequence, which checkpoints the
-   store before the process exits.
-3. **File-level snapshot backups** — the trait-based `memory_backup/` module
-   takes periodic file snapshots through `CognitiveMemoryOps`, providing a
-   bounded-RPO secondary recovery point.
-
-> **Removed in Phase 2b.** The native fork's per-write `fsync` barrier
-> (issue #1973) and its lbug-WAL "verified backup" loop
-> (`create_verified_backup` / `prune_old_backups`, issue #1631) were deleted with
-> `NativeCognitiveMemory`. The library backend supersedes them: durability is the
-> library's responsibility, and snapshot backups come from `memory_backup/`. The
-> sections below that describe the native per-write barrier and the native
-> verified-backup loop are **historical** — they document machinery that no
-> longer exists — and are retained only for archival context.
+> **Current backend after de-fork #2307.** Simard no longer has a native
+> LadybugDB cognitive-memory fork. `NativeCognitiveMemory` and its methods were
+> deleted. The only cognitive-memory backend is `LibraryCognitiveMemory`, an
+> adapter over the external `amplihack-memory` library (crate version `0.4.0`,
+> git rev `26d49bf864ac2c03b80c4ab075c4a907c51f82a8`, feature `persistent`).
+> That library internally uses `lbug = "=0.17.1"`. Simard still has a direct
+> `lbug = "=0.17.1"` dependency for the standalone `simard-tui` goal-board
+> reader, not for cognitive memory.
+>
+> Operator-facing backup, verification, restore, and pruning are free functions
+> in `src/memory_backup/mod.rs`: `backup_memory`, `backup_memory_verified`,
+> `verify_backup`, `verify_backup_memory_count`, `ensure_backup_valid`,
+> `list_backups`, `prune_old_backups`, and `restore_from_backup`. The OODA
+> daemon entry point is `run_verified_backup` in
+> `src/operator_commands_ooda/daemon/backup.rs`.
+>
+> Any `NativeCognitiveMemory` mention below is historical: it refers to the
+> removed native fork and must not be used as a current API.
 
 > Quick reference for contributors: see the
 > [Cognitive Memory Durability section in CONTRIBUTING.md](https://github.com/rysweet/Simard/blob/main/CONTRIBUTING.md#cognitive-memory-durability-per-write-barrier--sigterm--periodic-backups).
 
 ---
 
-## Background
+## Current architecture
 
-Simard's cognitive memory is stored by the library backend at
-`state_root/cognitive` (in production, `~/.simard/cognitive`) — a LadybugDB
-`GraphStore` directory using `lbug = "=0.15.3"`. The old native single-file
-store at `~/.simard/cognitive_memory.ladybug` is **abandoned** by Phase 2b: it is
-never opened, read, or migrated, and memory rebuilds from scratch in the new
-`cognitive/` store.
-
-LadybugDB flushes its WAL on CHECKPOINT and inside `Database::drop`. Process
-termination via `SIGTERM` (the default signal `systemctl restart` sends) does not
-invoke `Drop`, so the shutdown handler explicitly checkpoints the library store
-before exit (see [Shutdown Sequence](#shutdown-sequence-sigterm-sigint-sighup)).
-
-Two incidents motivated the current design:
-
-- **2026-05-09** — active goal `improve-the-dashboard-via-playwright-driven-testing`
-  was wiped during a routine `systemctl restart simard-ooda`. Root cause:
-  `ctrlc` only caught `SIGINT`, so `SIGTERM` escalated to `SIGKILL` and
-  the WAL was discarded. Fixed by the SIGTERM handler (#1631).
-- **2026-05-18** — a write returned `Ok(())` from `CognitiveMemoryOps`
-  but was absent after an OOM-kill milliseconds later. Root cause: the
-  daemon relied on the periodic backup loop (≤ 5 min RPO) and on
-  `Database::drop` for flushing, neither of which fires on SIGKILL.
-  Fixed by the per-write fsync barrier (#1973).
-
-The hardening described below ensures data loss of either class cannot
-recur. Under SIGKILL / OOM / power loss, the **last committed write is
-preserved**; the periodic backup remains a secondary, bounded-RPO
-recovery point for catastrophic corruption.
-
----
-
-## Architecture
+Simard opens persistent cognitive memory through `LibraryCognitiveMemory::open`,
+which delegates to the library-backed store at `state_root/cognitive`
+(production: `~/.simard/cognitive`). Callers use the backend-agnostic
+`CognitiveMemoryOps` trait.
 
 ```
 +---------------------------+
-|   OODA Daemon (PID N)     |
+|   OODA Daemon             |
 |                           |
-|  +---------------------+  |
-|  | OODA loop           |  |   shutdown: AtomicBool
-|  | (checks flag /cycle)|<-+---+
-|  +---------------------+  |   |
-|                           |   |
-|  +---------------------+  |   |
-|  | ctrlc handler       |--+---+
-|  | (SIGTERM/INT/HUP)   |  |
-|  +---------------------+  |
-|                           |
-|  +---------------------+  |   per-cycle elapsed-time check
-|  | backup tick         |  |   default interval = 300s
-|  +---------------------+  |
-|                           |
-|  +---------------------+  |   shutdown: CognitiveMemoryOps::checkpoint
-|  | checkpoint on exit  |  |     → LibraryCognitiveMemory::checkpoint
-|  | (library CHECKPOINT)|  |     → library close() (collapse WAL)
-|  +---------------------+  |
+|  CognitiveMemoryOps       |
+|        |                  |
+|        v                  |
+|  LibraryCognitiveMemory   |
+|        |                  |
+|        v                  |
+|  amplihack-memory library |
++-------------+-------------+
+              |
+              v
 +---------------------------+
-            |
-            v
-+---------------------------+
-| ~/.simard/                |
-|   cognitive/              (library GraphStore — LadybugDB; the WAL is
-|                            managed internally by the library)
-|   backups/                (file-level snapshots from memory_backup/)
+| state_root/               |
+|   cognitive/              |  live library GraphStore
+|   backups/                |  memory_backup manifest directories
+|   memory_records.json     |  file-backed memory records
 +---------------------------+
 ```
 
-> The boxes for the native `post_write_barrier` and the native verified-backup
-> tick that previously appeared here were removed with the fork (Phase 2b).
+The old native single-file store (`cognitive_memory.ladybug`) and its raw lbug
+backup helpers were removed by issue #2307. Migration-aware code still recognizes
+legacy names where needed, but current writes go through the library backend.
 
 ---
 
-## Per-Write fsync Barrier (issue #1973)
+## Durability contract
 
-> **Historical (removed in Phase 2b).** The per-write `fsync` barrier was a
-> property of the deleted native backend. The library backend manages its own
-> WAL durability, so there is no Simard-side per-write barrier any more. This
-> section is retained for archival context only.
+Durability now has three layers:
 
-Every mutating operation on `NativeCognitiveMemory` is followed by a
-**per-write fsync barrier** before control returns to the caller. The
-barrier is the foundational durability guarantee on which the SIGTERM
-handler and periodic backups are layered.
+1. **Library-backed persistence.** The `amplihack-memory` backend owns the
+   persistent lbug store. Simard does not implement a separate per-write lbug
+   barrier or expose any raw lbug write API for cognitive memory.
+2. **Graceful shutdown checkpoint.** The OODA daemon handles
+   `SIGTERM`/`SIGINT`/`SIGHUP`, persists the active goal board, then calls
+   `CognitiveMemoryOps::checkpoint`. `LibraryCognitiveMemory::checkpoint`
+   delegates to the library's `close()` path; source comments document this as
+   the current checkpoint hook.
+3. **Verified backups.** `run_verified_backup` snapshots the live cognitive
+   store through the trait, verifies the resulting backup, and only then prunes
+   old backups.
 
-### Guarantee
+For `SIGKILL`, OOM-kill, or power loss, Simard does not add a current
+`post_write_barrier`. Completed-write durability is the library backend's
+responsibility; in-flight writes remain undefined. The operator recovery point
+is the most recent verified backup under `state_root/backups`.
 
-For any successful return from a `CognitiveMemoryOps` mutating method
-on a **file-backed** store, the mutation is durable across:
+### Historical incidents
 
-- `SIGKILL` of the daemon process,
-- OOM-kill,
-- power loss on a journaled filesystem (ext4 `data=ordered`, xfs, zfs,
-  apfs, ntfs with FlushFileBuffers).
+- **2026-05-09 / issue #1631** — `systemctl restart simard-ooda` sent
+  `SIGTERM`; the daemon did not run its shutdown sequence, so WAL-resident writes
+  could be lost. The current signal handler and checkpoint sequence address that
+  class.
+- **2026-05-18 / issue #1973** — the removed native fork added a Simard-side
+  per-write fsync barrier after a lost-write incident. That barrier was deleted
+  with `NativeCognitiveMemory` in issue #2307; it is not a current API or current
+  guarantee.
 
-The barrier does **not** apply to the in-memory backend (see
-[In-Memory Backend](#in-memory-backend) below).
+---
 
-### Mechanism
+## Shutdown sequence
 
-After a mutating Cypher write succeeds, the store calls a private
-method `post_write_barrier(op: &'static str)` which performs two
-steps in this exact order:
+`shutdown_daemon` in `src/operator_commands_ooda/daemon/mod.rs` performs the
+current graceful shutdown sequence:
 
-1. **`fsync(data file)`** — `File::open(&self.path)?.sync_all()` forces
-   the kernel to flush the file's data and metadata to the underlying
-   block device. lbug's internal WAL is co-resident in this same data
-   file, so a single fsync of the file durably captures both committed
-   pages and any uncheckpointed WAL frames; on reopen lbug replays
-   those frames automatically.
-2. **`fsync(parent dir)`** — `File::open(&self.parent_dir)?.sync_all()`
-   forces the directory-entry update so the data file's new size /
-   timestamp survive a crash on filesystems that journal metadata
-   separately (notably ext4).
-
-> **Why no `CHECKPOINT;`?** An earlier draft of this barrier issued
-> `CognitiveMemoryOps::checkpoint()` as a first step. That was removed
-> after CI exposed a lbug bug: issuing `CHECKPOINT;` between writes
-> inside a multi-statement op (notably `consolidate_episodes`) caused
-> subsequent reads of `e.content` on previously-written `Episode`
-> rows to return raw page bytes instead of the stored string literal,
-> breaking `bootstrap`, `goal_stewardship`, and `improvement_curation`
-> integration tests. The crash-recovery integration tests
-> (`tests/cognitive_memory_crash_durability.rs` and
-> `tests/daemon_sigterm_durability.rs`) empirically confirm that the
-> fsync pair above — **without** CHECKPOINT — preserves every
-> acknowledged write across `SIGKILL`/restart cycles.
->
-> `CHECKPOINT;` remains in use at backup time (see
-> `NativeCognitiveMemory::backup`), which is the only context where
-> the WAL must be folded into the data file before the file is copied.
-
-The order is **non-negotiable** and called out by a `// SAFETY:`
-comment in `post_write_barrier`. Reordering steps 1 and 2 — or
-omitting either — re-introduces the lost-write window that motivated
-issue #1973.
-
-Both steps propagate failures as typed `SimardError` variants
-(see [Error Mapping](#error-mapping) below); the barrier never
-swallows an fsync result. A failure at either step short-circuits the
-remaining step and returns `Err(...)` to the caller, surfacing the
-durability failure rather than masking it.
-
-### Methods that invoke the barrier
-
-The barrier fires after each of the following mutating operations
-implemented on `NativeCognitiveMemory`:
-
-| Method | Barrier label |
-|---|---|
-| `store_fact` | `store_fact` |
-| `store_episode` | `store_episode` |
-| `update_episode_status` | `update_episode_status` |
-| `link_episodes` | `link_episodes` |
-| `delete_fact` | `delete_fact` |
-| `tag_fact` | `tag_fact` |
-| `record_observation` | `record_observation` |
-| `record_goal_event` | `record_goal_event` |
-| `consolidate_episodes` | `consolidate` |
-
-`consolidate_episodes` calls the barrier **once after the entire
-consolidation loop completes successfully**, not per-iteration. This
-bounds write amplification to 1× per logical operation; per-iteration
-barriers would impose a fsync per consolidated episode and were
-explicitly rejected during design (see issue #1973, decision D5).
-
-### Recovery-replay barrier
-
-The same barrier semantics extend to the recovery path. When
-`try_restore_from_backup` copies a verified backup into place, the
-copy is routed through `atomic_copy_with_fsync` (see
-[atomic_copy_with_fsync](#atomic_copy_with_fsync-readback-verification)
-below), which performs the same `fsync(file) → fsync(parent dir)`
-sequence and additionally re-reads the destination to verify the
-copy.
-
-`atomic_copy_with_fsync` emits its own action labels
-(`fsync-data-file`, `fsync-parent-dir`, `verify-readback`) because it
-is shared with the forward backup path. The recovery caller
-(`try_restore_from_backup`) is responsible for **remapping** these
-labels — when it propagates an `Err(SimardError::PersistentStoreIo)`
-out, it rewrites `action` to `recovery-replay-fsync` (preserving the
-underlying step name in the `reason` string) so log triage and the
-runbook table below can distinguish forward-write failures from
-recovery-path failures. The remap is a single match-and-rebuild in
-the recovery function, not deep inside the copy helper.
-
-### Latency tradeoff
-
-Each barrier costs one `fsync` round-trip on the data file plus one
-on the parent directory. Realistic measured latencies on common
-storage stacks:
-
-- **NVMe SSD + ext4 (`data=ordered`)** — typically **1–10 ms** per
-  barrier. The lower bound is set by the device's flush latency;
-  the upper bound includes jbd2 journal commit overhead on a busy
-  filesystem.
-- **SATA SSD** — typically **2–15 ms**.
-- **Spinning HDD** — typically **5–25 ms**.
-
-The OODA daemon's write rate (≤ a few hundred mutations per minute
-under steady state) makes this overhead negligible. Workloads that
-bulk-import episodes should batch through `consolidate_episodes`
-(which fires a single barrier per call) rather than calling
-`store_episode` in a tight loop.
-
-This tradeoff is intentional and accepted. The previous behavior
-(periodic backup ≤ 5 min RPO, plus `Database::drop` on graceful
-shutdown) was insufficient under SIGKILL, which is the operational
-reality the daemon must survive.
-
-### Error Mapping
-
-The barrier maps failures to typed `SimardError` variants. Each call
-site uses a distinct `action` label so log scrapers and on-call
-runbooks can identify the failing step at a glance. The `store`
-field is the kebab-case identifier `"cognitive-memory"`, matching
-the convention already established by `NativeCognitiveMemory::open`
-(`src/cognitive_memory/mod.rs`):
-
-| Step | Failure variant | `action` label |
+| Step | Operation | Failure mode when signal-driven |
 |---|---|---|
-| `fsync(data file)` open | `PersistentStoreIo { store: "cognitive-memory", action, path, reason }` | `fsync-data-file-open` |
-| `fsync(data file)` | `PersistentStoreIo { store: "cognitive-memory", action, path, reason }` | `fsync-data-file` |
-| `fsync(parent dir)` open | `PersistentStoreIo { store: "cognitive-memory", action, path, reason }` | `fsync-parent-dir-open` |
-| `fsync(parent dir)` | `PersistentStoreIo { store: "cognitive-memory", action, path, reason }` | `fsync-parent-dir` |
-| Recovery-replay copy | `PersistentStoreIo { store: "cognitive-memory", action, path, reason }` (remapped by `try_restore_from_backup`) | `recovery-replay-fsync` |
-| Readback hash mismatch | `PersistentStoreIo { store: "cognitive-memory", action, path, reason }` | `verify-readback` |
+| 1 | `persist_board(&state.active_goals, &*bridges.memory)` | Logged, next step still runs. |
+| 2 | `shared_mem.checkpoint()` | Logged, next step still runs. |
+| 3 | `bridges.session.close()` | Logged, next step still runs. |
+| 4 | `memory_ipc::clear_in_process_writer()` | Cannot fail. |
+| 5 | Bridges and the daemon-owned `Arc<dyn CognitiveMemoryOps>` drop on return. | Drop-time failures are logged by the backend. |
 
-The `op` label (e.g. `store_fact`, `consolidate`) is included in the
-`reason` string of the `PersistentStoreIo` variant. The format is
-pinned as:
+Normal-exit callers receive errors. Signal-driven shutdown logs errors and keeps
+progressing because the process is already exiting.
 
-```rust
-reason: format!("op={op}: {io_err}")
+---
+
+## Periodic verified backups
+
+The current backup loop is in `src/operator_commands_ooda/daemon/backup.rs`.
+`backup_interval_secs_from_env` reads `SIMARD_BACKUP_INTERVAL_SECS` and defaults
+to `86_400` seconds (one day). `last_backup: Option<Instant>` starts as `None`,
+so the first daemon cycle always runs a backup.
+
+`run_verified_backup(bridge, state_root)` does three things:
+
+1. Builds a `BackupConfig` rooted at `state_root/backups` and opens the
+   file-backed memory store at `state_root/memory_records.json`.
+2. Calls `memory_backup::backup_memory_verified`, which composes
+   `backup_memory` with `ensure_backup_valid` / `verify_backup`.
+3. Calls `memory_backup::prune_old_backups` only after the new backup verifies.
+
+A failed backup logs:
+
+```text
+[simard] WARN: verified backup FAILED, prune skipped: <error>
 ```
 
-(where `io_err` is the `Display` form of the underlying
-`std::io::Error` or, for `verify-readback`, the truncated digest
-mismatch summary). Callers and log scrapers may rely on the
-`op=<name>:` prefix being present.
+A successful backup logs counts and the backup directory:
 
-### `atomic_copy_with_fsync` readback verification
+```text
+[simard] verified backup OK: <facts> facts + <procedures> procedures + <records> records -> <dir>
+```
 
-The backup/recovery helper `atomic_copy_with_fsync` was hardened in
-issue #1973 to no longer trust the syscall return alone. After the
-copy + fsync sequence, the destination is re-opened read-only and
-its full contents are streamed through a SHA-256 digest, then
-compared against the same digest computed from the source. A
-mismatch returns:
+### Backup layout
+
+Backups are timestamped directories, newest-first by directory name:
+
+```text
+state_root/backups/
+  20260703_003510/
+    manifest.json
+    cognitive_snapshot.json
+    memory_records.json
+```
+
+`BackupManifest` records the backup directory, created time, counts, data-file
+paths, and checksum. Verification derives file paths from the backup directory
+and fixed filenames; it does not trust manifest paths as read targets.
+
+### Retention
+
+`BackupConfig` controls retention:
 
 ```rust
-SimardError::PersistentStoreIo {
-    store: "cognitive-memory",
-    action: "verify-readback",
-    path: dst.clone(),
-    reason: format!(
-        "post-fsync hash mismatch: src={src_hex:.16} dst={dst_hex:.16}"
-    ),
+pub struct BackupConfig {
+    pub backup_dir: PathBuf,
+    pub retention_days: u32,
+    pub min_backups_to_keep: usize,
 }
 ```
 
-(Only the first 16 hex chars are surfaced in `reason`; the full
-digests are emitted via `tracing::error!` for forensic capture.)
+`BackupConfig::default()` keeps at least 3 backups and prunes directories older
+than 30 days. The daemon overrides only `backup_dir` to `state_root/backups`.
 
-This defends against:
+---
 
-- **Page-cache aliasing** — the destination is read via fresh
-  `File::open` + `BufReader`, bypassing the kernel page cache that
-  could otherwise mask a torn write.
-- **Silent disk-level corruption** of the just-written bytes (rare,
-  but possible on misbehaving storage).
-- **Logic bugs** in the copy path that produce a truncated or
-  zero-length destination (which previously passed silently because
-  `sync_all()` reports success on an empty file).
+## Restore procedure
 
-### In-Memory Backend
-
-> **Phase 2b.** Tests use `LibraryCognitiveMemory::in_memory()`, which builds the
-> library's `CognitiveMemory::new("simard")` (no on-disk LadybugDB directory).
-> The native `in_memory()` and its `durable_writes`/`post_write_barrier` opt-out
-> described below were deleted with the fork; the text is archival.
-
-`NativeCognitiveMemory::in_memory()` constructed a store with
-`durable_writes = false`. The first line of `post_write_barrier` was:
+Restore is an API operation, not a raw `cp` of lbug files. Use
+`memory_backup::restore_from_backup` after verifying the selected directory:
 
 ```rust
-if !self.durable_writes { return Ok(()); }
+use simard::memory_backup::{ensure_backup_valid, restore_from_backup};
+
+ensure_backup_valid(&backup_dir)?;
+let restored = restore_from_backup(bridge, file_store, &backup_dir)?;
 ```
 
-so the in-memory backend skips the **fsync round-trip** entirely —
-no `File::open`, no `sync_all` on the data file or the parent dir.
-
-Note that the in-memory backend is not literally an in-RAM store:
-`in_memory()` allocates a `tempfile::TempDir` and points lbug's
-`Database::new` at a file inside it. lbug 0.15 still writes to that
-tempdir on every mutation. The barrier opt-out therefore avoids the
-fsync cost (which dominates per-write latency) but not the underlying
-lbug write itself. The TempDir is reaped on drop via an
-`Arc<TempDir>` held by the store, so unit tests do not leak
-filesystem state.
-
-A dedicated unit test (`in_memory_barrier_is_noop`) asserts that
-`post_write_barrier` returns `Ok(())` without ever opening
-`self.path` or `self.parent_dir` for fsync, even after a sequence of
-writes.
-
-### Operational signature
-
-Successful barrier calls are not logged (the operation is on the
-hot path). Barrier failures log at `error` level with the structured
-fields `store="cognitive-memory"`, `action`, `op`, `path`, and the
-underlying `io::Error`'s `kind()` and message. A representative log
-line:
-
-```
-ERROR cognitive-memory: durability barrier failed
-  store="cognitive-memory" action="fsync-parent-dir" op="store_fact"
-  path="/home/simard/.simard/cognitive_memory.ladybug"
-  io_kind=PermissionDenied
-  reason="op=store_fact: Permission denied (os error 13)"
-```
-
-Treat any such line as a paging event: subsequent writes will
-continue to fail until the underlying I/O fault is resolved, and the
-caller of the mutating op already has the `Err(...)` return value.
+`restore_from_backup` rejects `Corrupted` and `Incomplete` backups before it
+imports the cognitive snapshot and file-backed records. If a backup fails
+verification, choose the next-most-recent directory from `list_backups`.
 
 ---
 
-## Shutdown Sequence (SIGTERM / SIGINT / SIGHUP)
+## Current public API
 
-The daemon registers a single
-[`ctrlc::set_handler`](https://docs.rs/ctrlc) at startup, with the
-`termination` feature so the same handler catches `SIGINT`, `SIGTERM`,
-and `SIGHUP`. Before the `termination` feature was enabled, only
-`SIGINT` was caught and `systemctl stop` (which sends `SIGTERM`)
-escalated to `SIGKILL`, losing all WAL-resident writes.
+### `src/memory_backup/mod.rs`
 
-The handler sets `shutdown.store(true, Ordering::SeqCst)` and returns.
-At the top of the next OODA loop iteration, the daemon observes the
-flag, breaks out of the loop, and invokes `shutdown_daemon(...)` (in
-`src/operator_commands_ooda/daemon/mod.rs`) with `signal_driven=true`.
+```rust
+pub fn backup_memory(
+    bridge: &dyn CognitiveMemoryOps,
+    store: &dyn MemoryStore,
+    agent_name: &str,
+    config: &BackupConfig,
+) -> SimardResult<BackupManifest>;
 
-| Step | Operation | Failure mode (`signal_driven=true`) |
-|---|---|---|
-| 1 | `persist_board(&state.active_goals, &*bridges.memory)` — writes the active-goal board through the live cognitive-memory writer so it is captured by the next checkpoint. | Logged via `daemon_log`, next step still runs. |
-| 2 | `shared_mem.checkpoint()` — collapses the WAL into the main store through the `CognitiveMemoryOps::checkpoint` trait method (delegates to `LibraryCognitiveMemory::checkpoint`, which calls the library's `close()`). | Logged, next step still runs. |
-| 3 | `bridges.session.close()` — closes the LLM session if bound. | Logged, next step still runs. |
-| 4 | `memory_ipc::clear_in_process_writer()` — drops the global `Weak`/`Arc` registration so the daemon-owned writer Arc becomes the sole strong reference. | Cannot fail. |
-| 5 | (implicit) Bridges + the daemon's strong `Arc<dyn CognitiveMemoryOps>` (a `LibraryCognitiveMemory`) drop on function return. The library closes its store on drop as a defense-in-depth backstop. | Inside `Drop` — failures are logged. |
+pub fn backup_memory_verified(
+    bridge: &dyn CognitiveMemoryOps,
+    store: &dyn MemoryStore,
+    agent_name: &str,
+    config: &BackupConfig,
+) -> SimardResult<BackupManifest>;
 
-The single function `shutdown_daemon` is shared by both the
-signal-driven shutdown path and the normal-exit path. When called from
-tests or normal exit (`signal_driven=false`), errors propagate as
-`Result<(), Box<dyn Error>>` so assertions can fire; under signal
-driven shutdown they are logged-and-continued because the process is
-already dying.
-
-> **Audit note**: shutdown logs go through `daemon_log` and contain the
-> step name, not record contents — there is no `Debug`-printed memory
-> data in the shutdown banner.
-
-### What happens on SIGKILL
-
-`SIGKILL` cannot be intercepted; the daemon dies immediately. As of
-issue #1973:
-
-- **Any write whose mutating call returned `Ok(())` before the kill
-  is preserved** — the per-write fsync barrier already flushed it.
-  This is the foundational guarantee; the integration test
-  `cognitive_memory_crash_durability::sigkill_preserves_last_write`
-  exercises it directly.
-- A write that was **in flight** at the moment of the kill (the
-  mutating call had not yet returned) may or may not be present.
-  Callers must treat unacknowledged writes as undefined on crash.
-- The most recent periodic backup (≤ `SIMARD_DB_BACKUP_INTERVAL_SECS`
-  old, default ~5 minutes) is the secondary recovery point used only
-  if the main data file is unreadable (corruption). Restore via the
-  [Restoring from Backup](#restoring-from-backup) procedure.
-
----
-
-## Periodic Backup Loop
-
-> **Historical (removed in Phase 2b).** The native daemon backup loop called the
-> fork's lbug-WAL statics `NativeCognitiveMemory::create_verified_backup` /
-> `prune_old_backups`, which were deleted with the fork. In Phase 2b the daemon no
-> longer runs this lbug-WAL backup; file-level snapshot backups are provided by
-> the trait-based `memory_backup/` module (which operates through
-> `CognitiveMemoryOps`, not raw `lbug`). The description below documents the
-> removed native loop for archival context.
-
-Backups are not driven by their own task. At the **start of every OODA
-cycle**, the daemon compares `Instant::elapsed()` since the last backup
-against `SIMARD_DB_BACKUP_INTERVAL_SECS` (default `300`); if the
-interval has passed, the in-line backup routine runs before any other
-cycle work. The implementation lives at
-`src/operator_commands_ooda/daemon/mod.rs` (search for
-`periodic DB backup`).
-
-### Per-Tick Operation
-
-1. **Checkpoint** — `shared_mem.checkpoint()` flushes the WAL through
-   the `CognitiveMemoryOps::checkpoint` trait method. A failure here is
-   logged via `daemon_log` and the backup attempt still proceeds (the
-   prior backup may already be missing recent writes).
-2. **`NativeCognitiveMemory::create_verified_backup(&state_root)`** —
-   copies `~/.simard/cognitive_memory.ladybug` (the lbug DB **file**;
-   see [Background](#background)) to a sibling under
-   `~/.simard/backups/` using `atomic_copy_with_fsync`:
-   - `std::fs::copy(src, &dst.tmp)`
-   - `File::open(&dst.tmp).sync_all()?` (errors **propagate** as of
-     #1973 — previously swallowed via `let _ = ...`)
-   - `std::fs::rename(dst.tmp, dst)`
-   - `File::open(parent_dir).sync_all()?` (same — now propagated)
-   - **SHA-256 readback verification** of `dst` against `src`
-     (#1973); mismatch returns
-     `PersistentStoreIo { action: "verify-readback", .. }`.
-   - The destination filename is
-     `cognitive_memory.ladybug.<unix_ts>` where `<unix_ts>` is the
-     unix-second timestamp at the moment the backup tick began.
-3. **Pair WAL siblings** — `wal_paths(&db_path)` returns the two
-   possible WAL filenames lbug 0.15 may use
-   (`cognitive_memory.ladybug.wal` and `cognitive_memory.wal`). Each
-   that exists on disk is copied to `<wal_name>.<unix_ts>` with the
-   **same** timestamp so a restore is unambiguous.
-4. **Read-only verify** — the new backup is opened with
-   `lbug::SystemConfig::default().read_only(true)` and run through
-   `verify_db_health` before the function returns success.
-5. **Prune** — `NativeCognitiveMemory::prune_old_backups(&state_root,
-   db_backup_keep)` lists backups, sorts by timestamp descending, keeps
-   the first `SIMARD_DB_BACKUP_KEEP` (default `24`), and removes the
-   rest. For each pruned timestamp, the matching WAL backups (both
-   `cognitive_memory.ladybug.wal.<ts>` and `cognitive_memory.wal.<ts>`)
-   are removed alongside the directory.
-6. **Consecutive-failure tracking** — an `AtomicU32` counter
-   (`backup_consecutive_failures`) increments on every failure and
-   resets on every success. The first two failures log at warn level;
-   the third and subsequent log `ERROR: DB backup failed N consecutive
-   times — last error at <backup-dir>: <e>`.
-
-> **Note on the consecutive-failure counter**: the daemon does **not**
-> halt backups after N failures; it continues to attempt the next tick
-> (so a transient I/O error does not silently disable durability).
-> Operators should treat the `ERROR: DB backup failed 3 consecutive
-> times` log line as a paging event.
-
-### Naming
-
-```
-cognitive_memory.ladybug.<unix_ts>           # main DB file backup
-cognitive_memory.ladybug.wal.<unix_ts>       # WAL sibling, if present
-cognitive_memory.wal.<unix_ts>               # alt WAL sibling, if present
+pub fn verify_backup(backup_dir: &Path) -> SimardResult<BackupVerification>;
+pub fn verify_backup_memory_count(backup_dir: &Path, expected_total: usize) -> SimardResult<()>;
+pub fn ensure_backup_valid(backup_dir: &Path) -> SimardResult<BackupManifest>;
+pub fn list_backups(config: &BackupConfig) -> SimardResult<Vec<BackupVerification>>;
+pub fn prune_old_backups(config: &BackupConfig) -> SimardResult<usize>;
+pub fn restore_from_backup(
+    bridge: &dyn CognitiveMemoryOps,
+    store: &dyn MemoryStore,
+    backup_dir: &Path,
+) -> SimardResult<usize>;
 ```
 
-`<unix_ts>` is the seconds-since-epoch at the moment the backup tick
-began. All files in a pair share the same timestamp.
+Public types:
 
-### Startup recovery
-
-`NativeCognitiveMemory::open_or_recover` (in
-`src/cognitive_memory/backup.rs`) attempts to open the main DB; if it
-fails with corruption symptoms the routine falls back to the most
-recent verified backup. Orphaned `.tmp` files left over from a crashed
-backup are cleaned up by `atomic_copy_with_fsync` on the next run via
-its best-effort `remove_file(&tmp)` at the start.
-
----
-
-## Configuration
-
-| Setting | Default | How to override | Notes |
-|---|---|---|---|
-| Backup interval (seconds) | `300` (5 min) | `SIMARD_DB_BACKUP_INTERVAL_SECS=N` env var | Read once at daemon start; per-cycle elapsed-time check |
-| Retention count | `24` paired snapshots | `SIMARD_DB_BACKUP_KEEP=N` env var | `0` disables pruning |
-| Backup directory | `<state_root>/backups/` | Derived from state root (compile-time) | Created on first backup |
-| Dashboard port | `8080` | `SIMARD_DASHBOARD_PORT=N` env or `--dashboard-port=N` | Default in `src/operator_commands_ooda/daemon/config.rs` |
-
-### Sample systemd unit excerpt
-
-```ini
-[Service]
-Environment=SIMARD_DB_BACKUP_INTERVAL_SECS=300
-Environment=SIMARD_DB_BACKUP_KEEP=24
-KillSignal=SIGTERM
-TimeoutStopSec=30
-ExecStart=/usr/local/bin/simard ooda daemon
-Restart=on-failure
+```rust
+pub struct BackupConfig;
+pub struct BackupManifest;
+pub struct BackupVerification;
+pub enum BackupStatus;
 ```
 
-`KillSignal=SIGTERM` (the systemd default) plus
-`TimeoutStopSec=30` gives the shutdown handler ample time to run; the
-sequence completes in well under a second on typical workloads. The
-[reference unit file](https://github.com/rysweet/Simard/blob/main/scripts/simard-ooda.service) is the source
-of truth for production deployments.
+### Daemon entry point
 
----
-
-## Restoring from Backup
-
-As of issue #1973, `cognitive_memory.ladybug` is a **single file**, and
-every backup created by `create_verified_backup` is therefore also a
-single file (the dir-renamed-aside path in `open()` happens *before*
-any backup is taken, so no backup ever contains a legacy KuzuDB
-directory). Restoration uses plain `cp`.
-
-```bash
-# 1. Stop the daemon
-sudo systemctl stop simard-ooda
-
-# 2. Identify the most recent paired backup
-ls -lt ~/.simard/backups/cognitive_memory.ladybug.* | head
-
-# 3. Restore the DB file and any paired WAL files
-TS=1762800000   # the timestamp suffix from above
-rm -f ~/.simard/cognitive_memory.ladybug
-cp ~/.simard/backups/cognitive_memory.ladybug.${TS} \
-   ~/.simard/cognitive_memory.ladybug
-
-# WAL siblings — either, both, or neither may exist for a given TS.
-for w in cognitive_memory.ladybug.wal cognitive_memory.wal; do
-  src=~/.simard/backups/${w}.${TS}
-  if [ -e "$src" ]; then
-    cp "$src" ~/.simard/${w}
-  fi
-done
-
-# 4. Restart and check the journal
-sudo systemctl start simard-ooda
-journalctl -u simard-ooda -n 50
+```rust
+// src/operator_commands_ooda/daemon/backup.rs
+pub fn run_verified_backup(
+    bridge: &dyn CognitiveMemoryOps,
+    state_root: &Path,
+) -> SimardResult<BackupManifest>;
 ```
 
-If the restored backup itself appears corrupt, fall back to the
-next-most-recent timestamp. Note that `create_verified_backup` already
-opens each backup read-only and runs `verify_db_health` before
-declaring it a success, so corrupt backups should be extremely rare.
-
----
-
-## Public API
-
-> All three items below already exist in the codebase. This section
-> documents them; it does not propose them.
-
-### `CognitiveMemoryOps::checkpoint`
+### Shutdown checkpoint
 
 ```rust
 // src/cognitive_memory/mod.rs
 pub trait CognitiveMemoryOps {
-    /// Force a WAL checkpoint, collapsing the WAL into the main store.
-    /// Implemented by [`LibraryCognitiveMemory::checkpoint`], which calls
-    /// the library's `close()`.
-    fn checkpoint(&self) -> SimardResult<()> { /* ... */ }
+    fn checkpoint(&self) -> SimardResult<()> { Ok(()) }
 }
-```
 
-### `LibraryCognitiveMemory::checkpoint`
-
-```rust
 // src/cognitive_memory/library_adapter.rs
 impl CognitiveMemoryOps for LibraryCognitiveMemory {
-    /// Force a CHECKPOINT, collapsing the WAL into the main store so a
-    /// subsequent reopen of the same path observes all committed writes.
-    ///
-    /// Delegates to the library's `close()` (which issues a LadybugDB
-    /// CHECKPOINT while keeping the store usable). The shutdown path logs
-    /// and continues under `signal_driven=true`.
-    fn checkpoint(&self) -> SimardResult<()> { self.lock()?.close(); Ok(()) }
+    fn checkpoint(&self) -> SimardResult<()> {
+        self.lock()?.close();
+        Ok(())
+    }
 }
 ```
-
-### `memory_ipc::clear_in_process_writer`
-
-```rust
-// src/memory_ipc/launcher.rs (re-exported as
-// memory_ipc::clear_in_process_writer from src/memory_ipc/mod.rs)
-pub fn clear_in_process_writer();
-```
-
-Drops the in-process cognitive-memory writer registration. Audited
-callers:
-
-- `operator_commands_ooda::daemon::shutdown_daemon` (step 4 above)
-- the in-process tests under `src/memory_ipc/tests_launcher.rs`
-
-> The function lives in `memory_ipc`, **not** `cognitive_memory`. The
-> daemon shutdown handler imports it as `memory_ipc::clear_in_process_writer`.
-
-### `operator_commands_ooda::daemon::shutdown_daemon`
-
-```rust
-// src/operator_commands_ooda/daemon/mod.rs
-fn shutdown_daemon(
-    state_root: &std::path::Path,
-    shared_mem: &Arc<dyn CognitiveMemoryOps>,
-    state: &mut OodaState,
-    bridges: &mut OodaBridges,
-    signal_driven: bool,
-) -> Result<(), Box<dyn std::error::Error>>;
-```
-
-Runs the graceful-shutdown sequence (steps 1–5 above). Called from both
-the normal-exit path (`signal_driven=false`, errors propagate) and the
-shutdown-flag observation path (`signal_driven=true`, errors are
-logged and the next step still runs).
-
-### Private: `NativeCognitiveMemory::post_write_barrier` (issue #1973)
-
-> **Historical (removed in Phase 2b).** Deleted with the native fork; the library
-> backend manages WAL durability internally. Archival reference only.
-
-```rust
-// src/cognitive_memory/mod.rs
-impl NativeCognitiveMemory {
-    /// Flush the most recent mutation to stable storage.
-    ///
-    /// Called by every mutating method in `CognitiveMemoryOps`
-    /// implementations. The `op` label is a compile-time literal used
-    /// only for error context and log correlation; it is **not** a
-    /// caller-supplied string.
-    ///
-    /// # Order (SAFETY)
-    /// 1. `self.checkpoint()`        — collapse WAL into data file
-    /// 2. `fsync(self.path)`         — flush data file to device
-    /// 3. `fsync(self.parent_dir)`   — flush directory entry
-    ///
-    /// `self.path` is the existing `PathBuf` field (the lbug DB file
-    /// path). `self.parent_dir` is a new `PathBuf` field added by
-    /// issue #1973, cached at construction time to avoid an allocation
-    /// + `parent()` call on every write.
-    ///
-    /// Reordering or omitting any step re-introduces the lost-write
-    /// window that motivated issue #1973. Do not "optimize" this
-    /// function without re-running the SIGKILL integration test.
-    ///
-    /// # Returns
-    /// `Ok(())` when `self.durable_writes == false` (in-memory backend)
-    /// without performing any I/O. Otherwise propagates the first
-    /// failing step's typed `SimardError` (see [Error Mapping] above).
-    fn post_write_barrier(&self, op: &'static str) -> SimardResult<()>;
-}
-```
-
-Intentionally **not** `pub`: the barrier is an implementation detail
-of `NativeCognitiveMemory`'s mutating methods. Callers of
-`CognitiveMemoryOps` cannot and should not invoke it directly — every
-mutating trait method that needs it already does so.
-
-### `cognitive_memory::backup::atomic_copy_with_fsync` (hardened in #1973)
-
-```rust
-// src/cognitive_memory/backup.rs
-pub(crate) fn atomic_copy_with_fsync(
-    src: &Path,
-    dst: &Path,
-) -> SimardResult<()>;
-```
-
-Copies `src` to `dst` atomically (via `dst.tmp` rename) and:
-
-1. `fsync`s the destination file,
-2. `fsync`s the destination's parent directory,
-3. **Re-opens the destination read-only and verifies a SHA-256
-   digest against the source** (issue #1973 — defeats page-cache
-   aliasing and silent corruption),
-
-returning `PersistentStoreIo { action: "verify-readback", .. }` on
-hash mismatch. Used by `create_verified_backup` (forward path) and
-`try_restore_from_backup` (recovery path; the recovery call carries
-the `recovery-replay-fsync` action label downstream).
 
 ---
 
-## Tests
+## Historical native-fork APIs removed by issue #2307
+
+The following symbols belonged to the deleted native fork. They are retained here
+only as migration history and must not be cited as current API:
+
+| Removed native-fork symbol | Current replacement / status |
+|---|---|
+| `NativeCognitiveMemory::create_verified_backup` | `memory_backup::backup_memory_verified` |
+| `NativeCognitiveMemory::prune_old_backups` | `memory_backup::prune_old_backups` |
+| `NativeCognitiveMemory::open` | `LibraryCognitiveMemory::open` |
+| `NativeCognitiveMemory::open_or_recover` | Deleted native recovery path; use verified backup APIs. |
+| `NativeCognitiveMemory::in_memory` | `LibraryCognitiveMemory::in_memory` |
+| `NativeCognitiveMemory::post_write_barrier` | Deleted native durability internal; no current Simard-side equivalent. |
+| `NativeCognitiveMemory::assert_hermetic_for` | Deleted native test helper; current tests use `HermeticState`, serial isolation, launcher guards, and the adapter's `cfg(test)` lock-write guard. |
+
+The removed fork also had single-file backups named
+`cognitive_memory.ladybug.<epoch>` plus possible WAL siblings. Current verified
+backups are manifest directories under `state_root/backups`.
+
+---
+
+## Verification coverage
+
+Source-level coverage for the current API includes:
 
 | Test | Location | Purpose |
 |---|---|---|
-| `sigkill_preserves_last_write` | `tests/cognitive_memory_crash_durability.rs` | **#1973** — Spawn helper binary, write one marker fact, wait for `WROTE` line, `SIGKILL` the helper, reopen the store from a fresh process, assert the marker is present. Direct proof of the per-write barrier guarantee. |
-| `sigkill_run_is_observable_for_negative_control` | `tests/daemon_sigterm_durability.rs` | **#1973** — Promoted in this PR from `assert!(count <= N_FACTS)` to `assert_eq!(count, N_FACTS)`. With the barrier in place, the SIGKILL path must now preserve all acknowledged writes; the test fails if the barrier is regressed. |
-| `in_memory_barrier_is_noop` | `src/cognitive_memory/mod.rs` (in-module `#[cfg(test)]`) | **#1973** — Asserts that the in-memory backend's `post_write_barrier` returns `Ok(())` without opening `self.path` or `self.parent_dir` for fsync, even after a write sequence. |
-| `post_write_barrier_propagates_fsync_failures` | `src/cognitive_memory/mod.rs` (in-module `#[cfg(test)]`) | **#1973** — Forces an fsync failure (read-only parent dir) and asserts the typed `PersistentStoreIo { action: "fsync-parent-dir", .. }` variant is returned, not swallowed. |
-| `atomic_copy_with_fsync_rejects_hash_mismatch` | `src/cognitive_memory/backup.rs` (in-module `#[cfg(test)]`) | **#1973** — Injects a corrupted destination after the copy and asserts the readback hash check returns `PersistentStoreIo { action: "verify-readback", .. }`. |
-| `daemon_sigterm_writes_survive` | `tests/daemon_sigterm_durability.rs` | **#1631** — Spawn daemon, write 10 facts, send `SIGTERM`, restart, assert 10/10 survive. |
-| `checkpoint_succeeds_after_writes` | `src/cognitive_memory/tests_mod.rs:260` | Existing — store two facts, checkpoint twice, verify search returns the writes. |
-| `checkpoint_on_fresh_db_is_safe` | `src/cognitive_memory/tests_mod.rs:275` | Existing — checkpoint a fresh DB returns Ok. |
-| `create_verified_backup_*` / `prune_old_backups_*` | `src/cognitive_memory/backup.rs` (in-module) | Existing — backup creation, pairing, pruning, verification. |
-
-### Crash-recovery test harness
-
-`tests/cognitive_memory_crash_durability.rs` ships with a reusable
-helper block clearly marked:
-
-```rust
-// ─────────────────────────────────────────────────────────────
-//   EXTRACTABLE FOR #1974
-//   Functions below are duplicated in
-//   tests/daemon_sigterm_durability.rs and should be moved to a
-//   shared module (tests/support/crash_recovery.rs) under #1974.
-// ─────────────────────────────────────────────────────────────
-fn helper_binary() -> PathBuf { /* resolve via CARGO_BIN_EXE_* or cargo target dir */ }
-fn spawn_helper(data_dir: &Path) -> Child { /* ... */ }
-fn read_ready_pid(child: &mut Child) -> u32 { /* parse "READY <pid>\n" */ }
-fn wait_with_timeout(child: &mut Child, timeout: Duration) -> Option<ExitStatus> { /* ... */ }
-fn count_facts(data_dir: &Path) -> usize { /* open store, count rows */ }
-// ─────────────────────────────────────────────────────────────
-```
-
-The companion helper binary is `examples/cognitive_memory_crash_helper.rs`
-(see [Crash Helper Binary](#crash-helper-binary) below). Issue #1974
-will move these helpers into `tests/support/crash_recovery.rs` and
-have both `cognitive_memory_crash_durability.rs` and
-`daemon_sigterm_durability.rs` import them.
-
-### Crash Helper Binary
-
-`examples/cognitive_memory_crash_helper.rs` is a small standalone
-binary used exclusively by integration tests. Its contract:
-
-| Aspect | Specification |
-|---|---|
-| Argv | `<data_dir>` — one positional argument, an absolute path. |
-| Safety | Canonicalizes `data_dir` and asserts it is under `std::env::temp_dir().canonicalize()`. Aborts with `exit(2)` otherwise. |
-| Signal handlers | **None installed.** The binary explicitly does not register any handler that could absorb `SIGKILL`. |
-| Behavior | Opens cognitive memory at `data_dir`, calls `store_fact` with a fixed marker (`fact_id="crash-helper-marker"`, `content="WROTE"`), prints `READY <pid>\n` to stdout (flushed), prints `WROTE\n` to stdout (flushed), then calls `thread::park()` to await `SIGKILL`. |
-| Exit | Never exits normally; the test sends `SIGKILL` to its pid. |
-
-Tests invoke it via `Command::new(env!("CARGO_BIN_EXE_cognitive_memory_crash_helper"))`
-when available, falling back to resolving the binary in the cargo
-target directory.
-
-> **Caution**: do not add a `Drop` impl, a panic hook, or any other
-> cleanup path to this binary. The whole point of the test is to
-> simulate a process that dies without running any cleanup. The
-> existing helper has a `#[deny(unsafe_code)]` and a code-review
-> checklist comment to that effect.
-
-> **Caution (test side)**: integration tests that spawn the helper
-> **must** wrap the `Child` handle in a kill-on-drop RAII guard (e.g.,
-> a small struct whose `Drop` calls `child.kill()` and
-> `child.wait()`). Without it, a panicking assertion in the test will
-> leave the helper parked in `thread::park()` and the test process
-> will hang until CI's job-level timeout fires. The shared helpers in
-> `tests/cognitive_memory_crash_durability.rs` (extractable for
-> #1974) provide such a guard; new tests should reuse it.
+| `backup_memory_verified_returns_valid_manifest` | `src/memory_backup/tests.rs` | Verified backup returns a valid manifest. |
+| `backup_memory_verified_round_trips_count` | `src/memory_backup/tests.rs` | Snapshot counts round-trip. |
+| `verify_backup_count_passes_on_exact_total` / `verify_backup_count_fails_loudly_on_mismatch` | `src/memory_backup/tests.rs` | Count verification accepts exact totals and rejects mismatches. |
+| `restore_from_valid_backup` / `restore_rejects_corrupted_backup` | `src/memory_backup/tests.rs` | Restore accepts valid backups and rejects corrupted ones. |
+| `prune_old_backups_respects_min_keep` | `src/memory_backup/tests.rs` | Retention preserves the configured minimum. |
+| `run_verified_backup_produces_valid_backup` | `src/operator_commands_ooda/daemon/backup.rs` | Daemon entry point produces a valid backup under `state_root/backups`. |
+| `first_backup_is_always_due` | `src/operator_commands_ooda/daemon/backup.rs` | First daemon cycle runs a backup. |
 
 ---
 
-## Operational Runbook
+## Operational runbook
 
-### "I just restarted the daemon and the journal does not show the shutdown banner"
+### Graceful restart did not log shutdown completion
 
-The signal handler may not have fired. Check:
-
-```bash
-# Look for the shutdown trace in recent logs
-journalctl -u simard-ooda --since "10 min ago" \
-  | grep -E "shutdown sequence start|shutdown complete"
-
-# If absent, check for SIGKILL escalation by systemd
-journalctl -u simard-ooda --since "10 min ago" \
-  | grep -iE "killed|SIGKILL"
-```
-
-If systemd escalated to SIGKILL, increase `TimeoutStopSec` in the unit
-file. Otherwise, file a `durability` issue with the journal excerpt.
-
-### "Backup directory is growing without bound"
-
-Check the consecutive-failure error log:
+Check for the shutdown banner and systemd escalation:
 
 ```bash
-journalctl -u simard-ooda | grep "DB backup failed"
+journalctl -u simard-ooda --since "10 min ago"   | grep -E "shutdown sequence start|shutdown complete|SIGKILL|killed"
 ```
 
-If you see `ERROR: DB backup failed N consecutive times`, the daemon
-has been unable to write a verified backup for at least 3 cycles
-(roughly 15 minutes at the default interval). Inspect the named
-backup directory for permissions / disk-space / corruption issues, fix
-the underlying cause, and the next successful backup will reset the
-counter.
+If systemd escalated to `SIGKILL`, increase `TimeoutStopSec` so the daemon can
+observe the shutdown flag and call `shutdown_daemon`.
 
-If the directory is growing despite successful backups, verify
-`SIMARD_DB_BACKUP_KEEP` is non-zero — `0` disables pruning entirely.
+### Verified backup failed
 
-### "`~/.simard` is filling up with `cognitive.corrupt-*` files"
-
-When LadybugDB detects a corrupt store or WAL it does not delete the bad
-bytes — it **quarantines** them in place so they remain available for
-forensics. With the library backend (de-fork Phase 2b, #2307) the live store
-is `~/.simard/cognitive` (plus the `cognitive.wal` write-ahead log), so the
-quarantines are named:
-
-```text
-cognitive.corrupt-<ts>                       # quarantined main store
-cognitive.wal.corrupt-<ts>                   # quarantined WAL
-cognitive.corrupt-<ts>.cognitive.shadow      # shadow side-file
-cognitive.corrupt-<ts>.bak                   # snapshot copy
-cognitive.corrupt-<ts>.cognitive.wal.corrupt-<ts>   # recursively nested chains
-```
-
-(The pre-#2307 native backend left `cognitive_memory.corrupt-<ts>`
-single-file snapshots.) Each name carries the `.corrupt-<ts>` infix; the live
-store files never do.
-
-These quarantines are pure dead weight once an incident has been reviewed.
-`simard cleanup` garbage-collects every quarantine generation older than
-`CORRUPT_DB_MAX_AGE_DAYS` (7 days) — both the legacy `cognitive_memory.corrupt-*`
-snapshots and the library backend's `cognitive.corrupt-*` /
-`cognitive.wal.corrupt-*` / `*.cognitive.shadow` families — while never touching
-the live `cognitive` / `cognitive.wal` store. Run it manually to reclaim space
-immediately, or rely on the scheduled OODA cleanup action:
+Look for the current failure line:
 
 ```bash
-simard cleanup   # reclaims quarantines older than 7 days, among other artifacts
+journalctl -u simard-ooda --since "1 hour ago"   | grep 'verified backup FAILED'
 ```
 
-If quarantines are being *created* repeatedly (new `.corrupt-<ts>` files each
-cycle), that is a corruption signal in its own right — capture a sample and
-file a `durability` issue rather than just deleting them.
+Fix the underlying filesystem, permissions, serialization, or integrity error.
+The daemon skips pruning on failure so the last-known-good backup remains.
 
-### "I see `durability barrier failed` in the journal"
+### Backup directory is growing
 
-This is the per-write fsync barrier (#1973) reporting an I/O failure
-on a mutating cognitive-memory op. The structured fields identify
-the failing step:
+The current pruner removes backup directories older than
+`BackupConfig.retention_days` while keeping at least
+`BackupConfig.min_backups_to_keep`. If directories are not pruned, verify their
+manifest timestamps and the configured retention values. There is no current
+`SIMARD_DB_BACKUP_KEEP` knob; that belonged to the removed native backup loop.
 
-```bash
-journalctl -u simard-ooda --since "10 min ago" \
-  | grep 'durability barrier failed'
+### Temporarily reduce backup frequency
 
-# Or filter by the structured store field:
-journalctl -u simard-ooda --since "10 min ago" \
-  | grep 'store="cognitive-memory"'
-```
-
-Decode the `action` field:
-
-| `action` | Meaning | First check |
-|---|---|---|
-| `fsync-data-file` | `sync_all()` on the main data file failed. | Disk full? Read-only remount? `dmesg` for block-device errors. |
-| `fsync-parent-dir` | `sync_all()` on the data directory failed. | Directory permissions; parent FS readonly. |
-| `verify-readback` | Post-fsync SHA-256 hash mismatch. | Possible silent disk corruption; capture the `path` and the full digests from `tracing` output and file a `durability` issue immediately. |
-| `recovery-replay-fsync` | The same barrier failing during backup restoration. | Inspect the source backup integrity and the destination filesystem state. |
-
-The caller of the mutating op already received an `Err(...)` return,
-so the in-memory state is consistent with disk. The daemon will
-continue to attempt subsequent writes; if they also fail, the
-underlying I/O fault must be resolved before durability is restored.
-
-### "I need to disable backups temporarily (e.g., during a migration)"
+Set a longer interval and restart the daemon:
 
 ```bash
 sudo systemctl edit simard-ooda
-# Add (or merge into existing):
+# Add or merge:
 [Service]
-Environment=SIMARD_DB_BACKUP_INTERVAL_SECS=86400
-# Save, then:
+Environment=SIMARD_BACKUP_INTERVAL_SECS=86400
 sudo systemctl restart simard-ooda
 ```
 
-Set the interval to `86400` (one day) rather than disabling outright;
-that preserves a daily floor of durability. Setting
-`SIMARD_DB_BACKUP_KEEP=0` disables pruning but does **not** disable
-backup creation — to halt backup creation entirely, you must stop the
-daemon.
+`0` is not a disable switch; the parser treats zero as invalid and falls back to
+the default. To stop backups entirely, stop the daemon.
 
-### "After upgrading, my cognitive-memory data is missing and there is a `cognitive_memory.ladybug.kuzu-backup` directory"
+### Historical `cognitive_memory.ladybug` artifacts
 
-You upgraded from a prototype build that stored cognitive memory as
-a KuzuDB directory. On first open, `NativeCognitiveMemory::open`
-detected the directory at `~/.simard/cognitive_memory.ladybug`,
-renamed it aside to `cognitive_memory.ladybug.kuzu-backup`, and
-created a fresh empty lbug DB file. The legacy KuzuDB data was
-**not** auto-imported — the on-disk formats are incompatible. The
-journal will show:
-
-```
-[simard] migrating old KuzuDB directory → /.../cognitive_memory.ladybug.kuzu-backup
-```
-
-The kuzu-backup directory is preserved on disk for manual
-inspection or one-shot Cypher export. If you do not need it, it is
-safe to `rm -rf` once you have confirmed the new lbug DB is the
-intended source of truth.
+Files such as `cognitive_memory.ladybug`, `cognitive_memory.ladybug.<epoch>`, or
+`cognitive_memory.ladybug.kuzu-backup` are artifacts from pre-#2307 native-fork
+storage and backup paths. They are not the current live cognitive-memory store.
+Review them only for migration forensics; current live data is under
+`state_root/cognitive`, and current backups are manifest directories.
 
 ---
 
@@ -925,16 +364,8 @@ intended source of truth.
 
 - [`docs/memory.md`](../memory.md) — cognitive-memory data model
 - [`docs/daemon-mode.md`](../daemon-mode.md) — OODA daemon overview
-- [`CONTRIBUTING.md`](https://github.com/rysweet/Simard/blob/main/CONTRIBUTING.md) — pre-commit, merge policy,
-  retention disclosure
-- [`docs/operations/meeting-handoffs.md`](meeting-handoffs.md) —
-  meeting REPL & handoff ingestion
-- [GitHub issue #1973](https://github.com/rysweet/Simard/issues/1973) —
-  per-write fsync barrier + crash-recovery test (this feature)
-- [GitHub issue #1972](https://github.com/rysweet/Simard/issues/1972) —
-  improve-cognitive-memory-persistence epic (goals G1 and G2)
-- [GitHub issue #1974](https://github.com/rysweet/Simard/issues/1974) —
-  extract the reusable crash-recovery test helpers (next cycle)
-- [GitHub issue #1975](https://github.com/rysweet/Simard/issues/1975) —
-  audit and fix swallowed `let _ = .sync_all()` sites outside the
-  cognitive-memory write path
+- [`CONTRIBUTING.md`](https://github.com/rysweet/Simard/blob/main/CONTRIBUTING.md) — contributor durability notes
+- [GitHub issue #2307](https://github.com/rysweet/Simard/issues/2307) — native cognitive-memory fork deletion
+- [GitHub issue #2420](https://github.com/rysweet/Simard/issues/2420) — verified backup of the live library store
+- [GitHub issue #1631](https://github.com/rysweet/Simard/issues/1631) — SIGTERM-safe shutdown
+- [GitHub issue #1973](https://github.com/rysweet/Simard/issues/1973) — historical native per-write barrier

--- a/docs/operations/meeting-handoffs.md
+++ b/docs/operations/meeting-handoffs.md
@@ -573,7 +573,7 @@ issue tracker by hand.
 
 For a **reviewable** alternative that does *not* file anything
 automatically, see the per-meeting
-[issue stubs](#ready-to-file-issue-stubs-issues--2309) written into the
+[issue stubs](#ready-to-file-issue-stubs-issues-2309) written into the
 bundle's `issues/` directory on `/close`.
 
 ---

--- a/docs/operations/meeting-handoffs.md
+++ b/docs/operations/meeting-handoffs.md
@@ -1,3 +1,14 @@
+---
+title: Meeting REPL & Handoff Ingestion
+description: How to drive a real meeting through the REPL, what the structured handoff JSON contains, and how the OODA daemon and engineer loop ingest handoff artifacts on their next cycle.
+last_updated: 2026-07-03
+owner: simard
+doc_type: howto
+related:
+  - ../architecture/ooda-meeting-handoff-integration.md
+  - ../reference/meeting-handoff-schema.md
+---
+
 # Meeting REPL & Handoff Ingestion
 
 How to drive a real meeting through the REPL, what the structured

--- a/docs/prompt-delivery.md
+++ b/docs/prompt-delivery.md
@@ -93,7 +93,7 @@ A few notes on the mode semantics that surprise first-time readers:
   `Auto` heuristic is therefore conservative — small prompts that *might*
   contain secrets should be sent in `Stdin` mode via an explicit override.
 * **There is a 16 MiB hard cap.** Prompts larger than 16 MiB return
-  [`PromptDeliveryError::TooLarge`](#errors) before any file or pipe is
+  [`PromptDeliveryError::TooLarge`](#enum-promptdeliveryerror) before any file or pipe is
   touched. This bound prevents a runaway agent from filling `/tmp`.
 
 ### Auto-selection heuristic
@@ -176,10 +176,10 @@ pub fn apply_std(
   modes, appends a `--` flag terminator before any positional prompt arg in
   `Inline` mode (so a prompt starting with `--` is never mistaken for a
   flag), and pushes the prompt as the final argv element when applicable.
-* Returns an [`AppliedPromptStd`](#struct-appliedprompt) RAII guard. The
+* Returns an [`AppliedPromptStd`](#struct-appliedpromptstdtokio) RAII guard. The
   guard owns the temp file (if any) and the in-memory prompt bytes (for
   stdin modes). It MUST outlive the child.
-* Never panics. Returns [`PromptDeliveryError`](#errors) for size violations
+* Never panics. Returns [`PromptDeliveryError`](#enum-promptdeliveryerror) for size violations
   and I/O failures.
 
 ### `fn apply_tokio`

--- a/docs/prompt-delivery.md
+++ b/docs/prompt-delivery.md
@@ -1,3 +1,11 @@
+---
+title: Subprocess Prompt Delivery
+description: Reference for simard::prompt_delivery — how Simard hands prompts to engineer and agent subprocesses, why the Simard copy is authoritative, and the planned amplihack-rs migration.
+last_updated: 2026-07-03
+owner: simard
+doc_type: reference
+---
+
 # Subprocess Prompt Delivery
 
 Status: **implemented in Simard** (`src/prompt_delivery/`); adapter wiring

--- a/docs/reference/backup-pruning-api.md
+++ b/docs/reference/backup-pruning-api.md
@@ -1,8 +1,8 @@
 ---
 title: Backup pruning API
-description: Reference for retention-limited cleanup of cognitive memory backup files. The native epoch-based pruner was removed in de-fork Phase 2b; the surviving pruner is the date-based memory_backup/ module.
-last_updated: 2026-06-19
-owner: simard
+description: Reference for pruning verified cognitive-memory backup directories through the current memory_backup module.
+last_updated: 2026-07-03
+owner: cognitive-memory
 doc_type: reference
 related:
   - ../operations/cognitive-memory-durability.md
@@ -13,183 +13,102 @@ related:
 
 # Backup pruning API
 
-> **De-fork Phase 2b.** The epoch-based pruner documented here lived in the
-> native `src/cognitive_memory/backup.rs` module, which was **deleted** along
-> with `NativeCognitiveMemory`. The library backend owns its own durability and
-> emits no `cognitive_memory.ladybug.<epoch>` files, so there is nothing for this
-> pruner to clean. The **surviving** backup pruner is the date-based
-> `prune_old_backups()` in `src/memory_backup/mod.rs` (using `BackupConfig`),
-> which operates through the `CognitiveMemoryOps` trait on file-level snapshots.
-> The remainder of this page is archival: it documents the removed native API.
-
-**Module (removed in Phase 2b):** `src/cognitive_memory/backup.rs`
-
-The `NativeCognitiveMemory::prune_old_backups()` method enforced a
-retention limit on cognitive memory backup files, preventing unbounded
-disk growth in the `backups/` subdirectory of the state root.
-
-> **Surviving implementation:** the date-based `prune_old_backups()` in
-> `src/memory_backup/mod.rs` (using `BackupConfig`) remains the cognitive-memory
-> backup pruner after Phase 2b.
-
----
-
-## Background
-
-Simard creates epoch-timestamped backup files (e.g.,
-`cognitive_memory.ladybug.1718164068`) during cognitive memory
-operations. Over long-running sessions, these accumulate without bound.
-Before issue [#2270](https://github.com/rysweet/Simard/issues/2270),
-there was no automatic cleanup — operators had to manually prune old
-backups or rely on the disk health recipe to reclaim space reactively.
+> **Current API after de-fork #2307.** The native epoch-file pruner
+> `NativeCognitiveMemory::prune_old_backups` was deleted with the native fork.
+> Current pruning is the free function `memory_backup::prune_old_backups` in
+> `src/memory_backup/mod.rs`, operating on verified backup directories described
+> by `BackupConfig`.
 
 ---
 
 ## Public API
 
-### `NativeCognitiveMemory::prune_old_backups()`
-
 ```rust
-pub fn prune_old_backups(state_root: &Path, keep: usize) -> PruneOutcome
-```
+pub fn prune_old_backups(config: &BackupConfig) -> SimardResult<usize>;
 
-**Parameters:**
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `state_root` | `&Path` | Root directory (e.g., `~/.simard/`); backups live in `{state_root}/backups/` |
-| `keep` | `usize` | Number of newest backups to retain |
-
-**Return type:**
-
-```rust
-pub struct PruneOutcome {
-    pub removed: usize,
-    pub failed: Vec<(PathBuf, std::io::Error)>,
+pub struct BackupConfig {
+    pub backup_dir: PathBuf,
+    pub retention_days: u32,
+    pub min_backups_to_keep: usize,
 }
 ```
 
-The caller can inspect `failed` to log or alert on partial failures
-(see daemon integration below).
+`prune_old_backups` returns the number of backup directories removed. Errors from
+listing the backup directory are returned as `SimardError::PersistentStoreIo`.
+Individual stale directories are removed with `remove_dir_all`; failed removals
+are skipped rather than counted as pruned.
 
-**Behavior:**
+`BackupConfig::default()` uses:
 
-1. Resolves the backup directory: `{state_root}/backups/`
-2. If the directory does not exist, returns immediately (`removed: 0`)
-3. Lists all files matching the prefix `cognitive_memory.ladybug.`
-4. Parses the suffix as a `u64` epoch timestamp; non-parseable files
-   are skipped (not counted, not deleted)
-5. Sorts by epoch descending (newest first)
-6. Deletes all main backup files beyond index `keep`
-7. For each deleted main file, also removes paired WAL files with the
-   same epoch suffix (`cognitive_memory.ladybug.wal.{epoch}` and
-   `cognitive_memory.wal.{epoch}`)
+| Field | Default |
+|---|---|
+| `backup_dir` | `$HOME/.simard/backups` |
+| `retention_days` | `30` |
+| `min_backups_to_keep` | `3` |
 
-**Error handling:**
-
-- Directory not found → early return, no error
-- Individual file deletion failure → logged to stderr, added to
-  `failed` list, continues with remaining files (non-fatal)
-- WAL file deletion failure → same treatment as main file failures
-
-All errors are non-fatal. Backup pruning must never crash or block the
-OODA cycle.
-
-**Retention limit:** The `keep` parameter is configurable by the
-caller. The daemon call site (`operator_commands_ooda/daemon/mod.rs`)
-passes `db_backup_keep` from configuration. The design spec for
-issue #2270 specifies passing `20` from the OODA cycle call site.
+The OODA daemon overrides `backup_dir` to `state_root/backups` before calling the
+backup routine.
 
 ---
 
-## Integration points
+## Behavior
 
-### OODA daemon
+1. If `config.backup_dir` does not exist, return `Ok(0)`.
+2. List child directories under `config.backup_dir`.
+3. Sort directory paths descending so newest timestamped directories are first.
+4. Preserve the first `config.min_backups_to_keep` directories unconditionally.
+5. For older entries, read `manifest.json` when present and compare
+   `BackupManifest.created_at` with `Utc::now() - retention_days`.
+6. Prune directories older than the cutoff. Entries with missing or unreadable
+   manifests are prune candidates once they are beyond the minimum-keep window.
 
-The daemon calls `prune_old_backups` after each successful backup
-creation:
+Current backups are directories such as:
+
+```text
+state_root/backups/20260703_003510/
+  manifest.json
+  cognitive_snapshot.json
+  memory_records.json
+```
+
+The removed native fork used files like `cognitive_memory.ladybug.<epoch>` and
+WAL siblings. Those files are historical artifacts; the current pruner does not
+look for them.
+
+---
+
+## Daemon integration
+
+`run_verified_backup` in `src/operator_commands_ooda/daemon/backup.rs` calls the
+pruner only after the new backup verifies:
 
 ```rust
-let prune_outcome =
-    NativeCognitiveMemory::prune_old_backups(&state_root, db_backup_keep);
-if !prune_outcome.failed.is_empty() {
-    daemon_log(&state_root, &format!(
-        "[simard] WARN: prune_old_backups: {} removed, {} failed",
-        prune_outcome.removed, prune_outcome.failed.len()
-    ));
-}
+let manifest = backup_memory_verified(bridge, &file_store, BACKUP_AGENT, &config)?;
+prune_old_backups(&config)?;
+Ok(manifest)
 ```
 
-### OODA cycle (new call site for #2270)
-
-The design spec adds a call in `src/ooda_loop/cycle.rs` after
-`handle_cleanup()`, passing a retention limit of 20:
-
-```rust
-handle_cleanup(&state, &bridge).await?;
-NativeCognitiveMemory::prune_old_backups(&state_root, 20);
-```
-
----
-
-## Filename format and sorting rationale
-
-Backup files use **epoch-based** names:
-
-```
-cognitive_memory.ladybug.1718164068
-cognitive_memory.ladybug.1718250468
-```
-
-The suffix is a `u64` Unix epoch timestamp. The function parses this
-integer and sorts numerically (descending), which produces correct
-chronological ordering regardless of zero-padding or string length.
-
-Paired WAL backup files follow the same epoch convention:
-
-```
-cognitive_memory.ladybug.wal.1718164068
-cognitive_memory.wal.1718164068
-```
-
-Both WAL variants are checked and removed alongside the main file.
-
----
-
-## Operator notes
-
-- **Manual override:** Operators can delete files from the backups
-  directory at any time. The pruning function only removes files when
-  there are more than `keep` — manual cleanup does not conflict.
-
-- **Monitoring:** The daemon logs pruning failures. For verbose output,
-  check stderr for `[simard] failed to remove old backup` messages.
-
-- **Disk health interaction:** The disk health recipe
-  ([Disk health API](./disk-health-api.md)) performs broader cleanup
-  (stale worktrees, cargo target dirs). Backup pruning is narrowly
-  scoped to `.ladybug` backup files and runs after each backup
-  creation, while disk health runs on a configurable schedule.
+This ordering is intentional: a failed or partial backup never causes the
+last-known-good backup to be reclaimed.
 
 ---
 
 ## Code location
 
-| Item | File | Line |
-|------|------|------|
-| `prune_old_backups()` definition | `src/cognitive_memory/backup.rs` | ~709 |
-| `PruneOutcome` struct | `src/cognitive_memory/metrics.rs` | ~49 |
-| Daemon call site | `src/operator_commands_ooda/daemon/mod.rs` | ~486 |
-| Cycle call site (new, #2270) | `src/ooda_loop/cycle.rs` | ~160 |
+| Item | File |
+|---|---|
+| `prune_old_backups` | `src/memory_backup/mod.rs` |
+| `BackupConfig` | `src/memory_backup/mod.rs` |
+| Daemon call site | `src/operator_commands_ooda/daemon/backup.rs` (`run_verified_backup`) |
+| Pruning tests | `src/memory_backup/tests.rs` |
 
 ---
 
 ## Related
 
 - [Cognitive memory durability (operations)](../operations/cognitive-memory-durability.md)
-  — backup creation and restore procedures.
-- [Disk health API](./disk-health-api.md) — broader disk cleanup via
-  recipe.
+  — current backup creation, verification, pruning, and restore procedures.
+- [Disk health API](./disk-health-api.md) — broader disk cleanup via recipe.
 - [Automated disk health (concept)](../concepts/automated-disk-health.md)
   — design rationale for automated cleanup.
 - [Configure disk health check](../howto/configure-disk-health-check.md)

--- a/docs/reference/base-type-adapters.md
+++ b/docs/reference/base-type-adapters.md
@@ -1,7 +1,7 @@
 ---
 title: Base Type Adapters
 description: Reference for the pluggable agent execution substrates that Simard delegates work to — traits, shipped adapters, capability contracts, and topology support.
-last_updated: 2026-06-22
+last_updated: 2026-07-03
 owner: simard
 doc_type: reference
 ---
@@ -110,7 +110,7 @@ A PTY-backed shell adapter that runs a configurable local command through the te
 
 ### `rusty-clawd` — `RustyClawdAdapter`
 
-**Module:** `src/base_type_rustyclawd.rs`
+**Module:** `src/base_type_rustyclawd/` (`RustyClawdAdapter` in `adapter.rs`)
 
 The RustyClawd session backend. Supports both single-process and multi-process topologies via the loopback mesh driver. Produces structured plan/execution/evidence outcomes.
 
@@ -136,7 +136,7 @@ The RustyClawd session backend. Supports both single-process and multi-process t
 
 ### `copilot-sdk` — `CopilotSdkAdapter`
 
-**Module:** `src/base_type_copilot.rs`
+**Module:** `src/base_type_copilot/` (`CopilotSdkAdapter` in `mod.rs`)
 
 Drives `amplihack copilot` through the PTY infrastructure with memory and knowledge context injection. Each turn:
 

--- a/docs/reference/cognitive-memory-bootstrap-procedures.md
+++ b/docs/reference/cognitive-memory-bootstrap-procedures.md
@@ -1,8 +1,8 @@
 ---
 title: Bootstrap procedures and trigger naming
 description: How Simard seeds three baseline procedural memories on daemon boot and how the OODA cycle now stores procedures with recallable names so recall_procedure actually finds them at preparation time.
-last_updated: 2026-06-14
-owner: simard
+last_updated: 2026-07-03
+owner: cognitive-memory
 doc_type: reference
 related:
   - ./ooda-procedural-memory.md
@@ -15,13 +15,13 @@ related:
 
 # Bootstrap procedures and trigger naming
 
-> **De-fork Phase 2b.** The bootstrap-seeding and trigger-naming *behavior*
-> described here is preserved: writes and recalls go through the
-> `CognitiveMemoryOps` trait, now backed solely by `LibraryCognitiveMemory`
-> over `amplihack-memory-lib`. The daemon-boot wiring that this page anchors to
-> `NativeCognitiveMemory::open` is now `LibraryCognitiveMemory::open`, and the
-> `NativeCognitiveMemory::in_memory` test helper is replaced by the library
-> in-memory store; treat those native code citations as historical. See
+> **De-fork Phase 2b (#2307).** The bootstrap-seeding and trigger-naming
+> *behavior* described here is preserved: writes and recalls go through the
+> `CognitiveMemoryOps` trait, now backed solely by `LibraryCognitiveMemory` over
+> the external `amplihack-memory` library. Pre-#2307 citations to
+> `NativeCognitiveMemory::open` or `NativeCognitiveMemory::in_memory` are
+> historical; the current daemon opens `LibraryCognitiveMemory::open`, and tests
+> use `LibraryCognitiveMemory::in_memory`. See
 > [Library-backed Cognitive Memory](../architecture/cognitive-memory-library-adapter.md).
 
 > Shipped in issue [#2281](https://github.com/rysweet/Simard/issues/2281)
@@ -190,7 +190,7 @@ daemon never produces duplicate procedures.
 ### Wiring
 
 `seed_bootstrap_procedures` is called once during `OodaBridges`
-construction, immediately after `NativeCognitiveMemory::open`
+construction, immediately after `LibraryCognitiveMemory::open`
 succeeds and before the OODA loop starts. The exact call site lands
 at implementation time in whichever of `bin/simard/main.rs` or
 `src/operator_commands_ooda/daemon/mod.rs` constructs the
@@ -470,7 +470,7 @@ procedure count:
 |-----------------------------------------------|-------------------------------------------------------|
 | `seed_bootstrap_procedures`                   | `src/cognitive_memory/bootstrap_procedures.rs`         |
 | `BOOTSTRAP_PROCEDURES` constant               | `src/cognitive_memory/bootstrap_procedures.rs`         |
-| Daemon boot wiring                            | Once-per-start call from the `OodaBridges` constructor, post-`NativeCognitiveMemory::open`, pre-loop. Exact file is `bin/simard/main.rs` or `src/operator_commands_ooda/daemon/mod.rs` depending on which path constructs the bridges; confirmed at PR-C implementation time. |
+| Daemon boot wiring                            | Once-per-start call from the `OodaBridges` constructor, post-`LibraryCognitiveMemory::open`, pre-loop. Current daemon construction is in `src/operator_commands_ooda/daemon/mod.rs`. |
 | OODA cycle procedure storage                  | `src/ooda_loop/cycle.rs` (currently at `cycle.rs:343`, the `format!("ooda:{}", outcome.action.kind)` site) |
 | Runtime pattern + trigger mapping             | `src/ooda_loop/cycle.rs` (next to the storage site)   |
 | `derive_triggers_from_objective` helper       | `src/ooda_loop/cycle.rs`                              |
@@ -511,9 +511,8 @@ In `src/ooda_loop/cycle.rs` tests module:
 ### Unified recall regression gates (ws2 #2295)
 
 In `tests/cognitive_memory_procedure_recall_unified.rs` — run against
-the live `cognitive_memory.ladybug` schema via
-`NativeCognitiveMemory::in_memory` (real `lbug::Database` + real
-`SCHEMA_DDL`, no storage-layer mocks):
+`LibraryCognitiveMemory::in_memory()` (the sole real backend after #2307), with
+no storage-layer mocks:
 
 | Test                                                          | Coverage                                          |
 |---------------------------------------------------------------|---------------------------------------------------|

--- a/docs/reference/cognitive-memory-bridge-helpers.md
+++ b/docs/reference/cognitive-memory-bridge-helpers.md
@@ -1,8 +1,8 @@
 ---
 title: Cognitive memory bridge helpers
 description: Reference for launch_writer_bridge and open_reader_bridge — the canonical entry points for obtaining a CognitiveMemoryOps adapter, including the planned in-process Arc shortcut and strict no-silent-degradation contract.
-last_updated: 2026-05-09
-owner: simard
+last_updated: 2026-07-03
+owner: cognitive-memory
 doc_type: reference
 related:
   - ./goal-board-api.md
@@ -96,9 +96,10 @@ read-only fallback:
 | 3 (fallback) | `LibraryCognitiveMemory::open(state_root)` | Both writer attempts failed; the library has no read-only constructor at the pinned commit, so the fallback re-opens the writer handle |
 
 Tier 3 is the **degradation point** that issue #1590's follow-up
-work targets — see "Planned changes" below. (Phase 2b note: before the de-fork,
-tier 2 used `NativeCognitiveMemory::open` and tier 3 used the native
-`open_read_only`; both now resolve to `LibraryCognitiveMemory::open`.)
+work targets — see "Planned changes" below. (Phase 2b / #2307 history: before
+the de-fork, tier 2 used `NativeCognitiveMemory::open` and tier 3 used the
+native `open_read_only`; both current paths resolve to
+`LibraryCognitiveMemory::open`.)
 
 ### Planned: tier 0 in-process `Arc` shortcut
 

--- a/docs/reference/cognitive-memory-episodic-recall.md
+++ b/docs/reference/cognitive-memory-episodic-recall.md
@@ -1,8 +1,8 @@
 ---
 title: Episodic recall in preparation
 description: How preparation_memory_operations surfaces similar past episodes via keyword-overlap search, how the results are injected into the prompt, and how self-session noise is filtered.
-last_updated: 2026-06-19
-owner: simard
+last_updated: 2026-07-03
+owner: cognitive-memory
 doc_type: reference
 related:
   - ../architecture/cognitive-memory.md
@@ -16,14 +16,13 @@ related:
 
 # Episodic recall in preparation
 
-> **De-fork Phase 2b.** The *behavior* described here (keyword-overlap episodic
-> recall via `search_episodes_by_keywords`) is preserved through the
-> `CognitiveMemoryOps` trait, now backed solely by `LibraryCognitiveMemory`. The
-> adapter implements this by recalling episodes from the library and filtering on
-> case-insensitive `content.contains` (see
-> [Library-backed Cognitive Memory](../architecture/cognitive-memory-library-adapter.md)).
-> The native `NativeCognitiveMemory` Cypher implementation and `src/cognitive_memory/ops.rs`
-> citations on this page were **deleted** with the fork; treat them as historical.
+> **De-fork Phase 2b (#2307).** The *behavior* described here
+> (keyword-overlap episodic recall via `search_episodes_by_keywords`) is
+> preserved through the `CognitiveMemoryOps` trait, now backed solely by
+> `LibraryCognitiveMemory`. The adapter recalls episodes from the library and
+> filters with case-insensitive `content.contains`. The native
+> `NativeCognitiveMemory` Cypher implementation and `src/cognitive_memory/ops.rs`
+> citations on this page were deleted with the fork; treat them as historical.
 
 > Shipped in issue [#2281](https://github.com/rysweet/Simard/issues/2281)
 > as PR-C (procedural seeding + episodic recall). PR-C also reshapes
@@ -89,16 +88,12 @@ pub trait CognitiveMemoryOps {
 }
 ```
 
-`NativeCognitiveMemory` overrides with a Cypher query that ORs one
-**case-insensitive** `toLower(e.content) CONTAINS '<lowercased+escaped>'`
-clause per keyword, orders by descending `e.id` (newest first — UUID-v7
-ids are time-prefixed, so descending lex-sort is the same as
-newest-by-creation), and caps the result at `limit`. No reliance on
-`temporal_index` is required for the ordering. Matching is case-insensitive
-on **both** sides: the keyword is lowercased before being escaped, and
-`toLower(e.content)` lowercases the stored content at query time so that
-existing verbatim (mixed-case) episodes match without any write-path change
-or data migration — see [Case-insensitive matching](#case-insensitive-matching-issue-2299).
+`LibraryCognitiveMemory` overrides the trait method by fetching library episodes,
+lowercasing each keyword, filtering episode content with case-insensitive
+`content.contains`, and capping the result at `limit`. The library returns
+newest-first by temporal index, so the observable ordering remains newest-first.
+Existing verbatim (mixed-case) episodes match without any write-path change or
+data migration — see [Case-insensitive matching](#case-insensitive-matching-issue-2299).
 
 ### Why keyword overlap, not embeddings
 
@@ -194,12 +189,10 @@ candidate window and filtering case-insensitively in Rust with
 query-time only and therefore both fix existing stored data identically; the
 observable contract (below) is the same regardless of which is used.
 
-> **Implementation note:** the in-code doc comments on the trait method
-> (`src/cognitive_memory/mod.rs`) and the native implementation
-> (`src/cognitive_memory/ops.rs`) are updated in the same change to describe
-> the case-insensitive `toLower(...) CONTAINS` comparison, replacing the
-> previous case-sensitive `e.content CONTAINS` wording so the code and this
-> reference agree.
+> **Historical implementation note:** before #2307, the native fork used a
+> Cypher `toLower(...) CONTAINS` query here. The current library adapter performs
+> the same case-insensitive contract in Rust after fetching episodes from the
+> library; the observable behavior remains the contract below.
 
 ### Contract
 
@@ -474,10 +467,10 @@ case-folded.
 
 ## Testing
 
-### Re-validation on the library backend (de-fork Phase 2b, #2308)
+### Re-validation on the library backend (de-fork Phase 2b, #2307)
 
 The native `ops.rs` and its #2299 trait-level tests were **deleted** by the
-de-fork (#2308). The fix now lives query-side in
+de-fork (#2307). The fix now lives query-side in
 [`LibraryCognitiveMemory::search_episodes_by_keywords`](../architecture/cognitive-memory-library-adapter.md),
 which lowercases both the stored episode `content` and every keyword before a
 Rust-side substring match — so existing verbatim-stored episodes match

--- a/docs/reference/cognitive-memory-fact-recall.md
+++ b/docs/reference/cognitive-memory-fact-recall.md
@@ -1,8 +1,8 @@
 ---
 title: Tokenized fact recall in preparation
 description: How search_facts tokenizes a multi-word objective into keywords and ORs one CONTAINS clause per token so semantic facts (including goal-store:record facts) actually surface into the OODA prepared context instead of always returning zero.
-last_updated: 2026-06-19
-owner: simard
+last_updated: 2026-07-03
+owner: cognitive-memory
 related:
   - ../architecture/cognitive-memory.md
   - ./cognitive-memory-preparation-filters.md
@@ -16,14 +16,13 @@ doc_type: reference
 
 # Tokenized fact recall in preparation
 
-> **De-fork Phase 2b.** The *behavior* described here (tokenized, multi-keyword
-> fact recall) is preserved: it is reached through the `CognitiveMemoryOps` trait,
-> now backed solely by `LibraryCognitiveMemory` over `amplihack-memory-lib`. The
-> native implementation details this page cites — the raw Cypher in
-> `src/cognitive_memory/ops.rs`, the `escape_cypher` helper, and
-> `NativeCognitiveMemory` — were **deleted** with the fork; treat those code
-> citations as historical. The library performs the equivalent tokenized search
-> internally (see [Library-backed Cognitive Memory](../architecture/cognitive-memory-library-adapter.md)).
+> **De-fork Phase 2b (#2307).** The *behavior* described here (tokenized,
+> multi-keyword fact recall) is preserved through the `CognitiveMemoryOps` trait,
+> now backed solely by `LibraryCognitiveMemory` over the external
+> `amplihack-memory` library. Native implementation details this page cites — raw
+> Cypher in `src/cognitive_memory/ops.rs`, the `escape_cypher` helper, and
+> `NativeCognitiveMemory` — were deleted with the fork; treat those citations as
+> historical. The library-backed adapter delegates fact search to the library.
 
 > Shipped in issue [#2302](https://github.com/rysweet/Simard/issues/2302)
 > (the "facts always zero" defect). Companion to the issue #2281
@@ -31,9 +30,11 @@ doc_type: reference
 > [Preparation-phase memory filters](./cognitive-memory-preparation-filters.md)
 > and [Episodic recall in preparation](./cognitive-memory-episodic-recall.md).
 
-`search_facts` now tokenizes its query into keywords and ORs one
-`CONTAINS` clause per token before hitting the graph. This is the fix
-for the symptom every OODA cycle logged:
+`search_facts` now has the tokenized-recall behavior fixed by #2302: a
+multi-word objective can recall facts that share useful keywords instead of
+requiring the whole objective to appear verbatim. Current source reaches this
+through `LibraryCognitiveMemory`, which delegates fact search to the external
+library. This is the fix for the symptom every OODA cycle logged:
 
 ```
 [simard] OODA cycle: prepared context (0 facts, 0 triggers, 5 procedures, 0 episodes)
@@ -60,8 +61,8 @@ prepared-context fact count climbs above zero:
 ## Scope
 
 This reference covers **only** semantic fact recall — the
-`search_facts` method on `NativeCognitiveMemory` and the
-preparation-phase caller that feeds it.
+`CognitiveMemoryOps::search_facts` method (currently implemented by
+`LibraryCognitiveMemory`) and the preparation-phase caller that feeds it.
 
 It does **not** change:
 
@@ -72,8 +73,10 @@ It does **not** change:
   [Episodic recall in preparation](./cognitive-memory-episodic-recall.md)),
 - trigger matching / `check_triggers`.
 
-Those surfaces share `src/cognitive_memory/ops.rs` but are untouched
-here. The only behavioural change is inside the fact-search function.
+In the pre-#2307 native fork, those surfaces shared
+`src/cognitive_memory/ops.rs` but were untouched by this fix. In current source,
+`LibraryCognitiveMemory` delegates fact search to the library backend; the only
+behavioral contract preserved here is semantic fact recall.
 
 ---
 
@@ -108,17 +111,18 @@ is treated as one literal substring. No stored fact's `content`
 contains that exact 45-character run, so the query returns nothing —
 on **every** cycle, for **every** fragment.
 
-The library equivalent (the amplihack-memory-lib semantic store)
-already tokenizes the query into keywords and ORs a `CONTAINS` per
-token. Simard's `NativeCognitiveMemory` did not. This change closes
-that gap.
+Before the #2307 de-fork, the external library's semantic store already
+tokenized the query while Simard's native `NativeCognitiveMemory` implementation
+did not. The original fix closed that gap; after #2307 the library-backed adapter
+is the only implementation.
 
 ### After
 
-`search_facts` splits the query into keywords and ORs one
-`(concept CONTAINS … OR content CONTAINS …)` group per keyword. A
-single shared keyword between the objective and a stored fact is now
-enough to recall that fact.
+The observable post-fix contract is that a single shared useful keyword between
+the objective and a stored fact is enough to recall that fact. In the deleted
+native fork this was implemented by splitting the query and OR-ing one
+`(concept CONTAINS … OR content CONTAINS …)` group per keyword; current source
+delegates the search to the library backend.
 
 ---
 
@@ -137,31 +141,36 @@ fn search_facts(
 
 | Parameter        | Meaning                                                            |
 |------------------|-------------------------------------------------------------------|
-| `query`          | Free text. Tokenized into keywords (see below). `"*"` is a wildcard. |
-| `limit`          | Max rows returned (`ORDER BY f.id DESC LIMIT {limit}`). Unchanged. |
-| `min_confidence` | `AND f.confidence >= {min_confidence}` floor. Unchanged.          |
+| `query`          | Free text. `"*"` is a wildcard. Tokenized-recall behavior is preserved, but the active backend owns query construction. |
+| `limit`          | Maximum number of facts returned. |
+| `min_confidence` | Minimum confidence floor passed through to the backend. |
 
-Return order (`f.id DESC`, newest-first because ids are UUID-v7
-time-prefixed), the confidence floor, and the `LIMIT` semantics are
-all **identical** to the previous implementation. Only the `WHERE`
-match expression changes.
+The trait signature is unchanged. Historical sections below describe the deleted
+native fork's `ORDER BY f.id DESC LIMIT ...` query shape; current ordering and
+query construction are delegated to the library backend through
+`LibraryCognitiveMemory`.
 
 ---
 
-## Tokenization
+## Historical native tokenization contract
 
-`search_facts` tokenizes `query` with deliberately minimal rules. The
-goal is to break a natural-language objective into useful keywords
-**without** disturbing the structured concept literals that internal
-callers pass (most importantly `goal-store:record`).
+This section documents the deleted native `ops.rs` tokenizer that implemented
+#2302. Current source delegates fact search to the external library backend, so
+these rules are migration history for the observable recall contract rather than
+current Simard-owned tokenizer internals.
+
+The native `search_facts` tokenized `query` with deliberately minimal rules. The
+goal was to break a natural-language objective into useful keywords **without**
+disturbing the structured concept literals that internal callers pass (most
+importantly `goal-store:record`).
 
 1. **Split on ASCII whitespace only.** Internal characters such as
    `-`, `:`, `/`, `.`, `#`, and digits are preserved inside a token.
 2. **Trim leading/trailing punctuation** from each token (e.g.
    `"(auth,"` → `"auth"`), preserving interior punctuation.
 3. **Drop empty tokens** produced by trimming.
-4. **Do not lowercase the emitted keyword.** The token that reaches
-   Cypher keeps its original case so matching stays consistent with the
+4. **Do not lowercase the emitted keyword.** In the native fork, the token that
+   reached Cypher kept its original case so matching stayed consistent with the
    prior whole-string `CONTAINS` behaviour. The stopword test in rule 5
    is the *one* exception: it lowercases a throwaway copy of the token
    for the membership check only, so a sentence-initial `"The"` is still
@@ -173,9 +182,10 @@ callers pass (most importantly `goal-store:record`).
    newest `LIMIT` facts" and wastes the token budget. **Short tokens are
    kept** (`CI`, `PR`, `#2302` are all discriminating in this domain),
    so there is no minimum-length filter; the keyword-vs-function-word
-   distinction is what gates a token, not its length. The stopword set
-   lives in a **fact-recall-local** constant, `FACT_QUERY_STOPWORDS` in
-   `src/cognitive_memory/ops.rs`, deliberately **separate** from the
+   distinction is what gates a token, not its length. In the deleted native
+   fork, the stopword set lived in a **fact-recall-local** constant,
+   `FACT_QUERY_STOPWORDS` in `src/cognitive_memory/ops.rs`, deliberately
+   **separate** from the
    `TOKEN_STOPWORDS` list that the episodic/procedural `tokenize_objective`
    helper uses. Keeping it local means this fix is confined to fact search
    and provably cannot alter episodic or procedural recall (issue #2302
@@ -269,9 +279,14 @@ tokens = []                       // whitespace only — whole-string path prese
 
 ---
 
-## Query construction
+## Historical native query construction
 
-`search_facts` chooses one of four shapes based on the query and its
+The details below describe the pre-#2307 native `ops.rs` implementation that
+originally fixed issue #2302. The current `LibraryCognitiveMemory` implementation
+delegates to the external library; keep this section as migration history for the
+observable tokenized-recall contract, not as current Simard query-building code.
+
+The native `search_facts` chose one of four shapes based on the query and its
 token count.
 
 ### 1. Wildcard (`query == "*"`)
@@ -338,10 +353,9 @@ ORDER BY f.id DESC LIMIT {limit}
 
 ### 4. Two or more tokens
 
-The fix path. One `(concept CONTAINS … OR content CONTAINS …)` group
-per token, OR-joined, each token escaped with the **same**
-`escape_cypher` helper that `search_episodes_by_keywords` uses
-(`src/cognitive_memory/ops.rs`):
+The historical native fix path used one `(concept CONTAINS … OR content CONTAINS …)` group
+per token, OR-joined, each token escaped with the same native `escape_cypher`
+helper that `search_episodes_by_keywords` used in the deleted `ops.rs` file:
 
 ```rust
 // for tokens ["investigate", "failing", "auth"]
@@ -362,13 +376,11 @@ the OR group — they are not per-token.
 
 ### Escaping
 
-Every token (and the whole-string query in case 2) is passed through
-`escape_cypher` (`src/cognitive_memory/ops.rs`) before interpolation.
-This escapes `\`, `'`, newline, carriage-return, tab, and null —
-preventing both query breakage and Cypher injection from fact content
-or objective text. Reusing the existing helper means fact search,
-episodic search, and goal-store reads all share one escaping
-contract.
+In the deleted native fork, every token (and the whole-string query in case 2)
+was passed through `escape_cypher` before interpolation. That escaped `\`, `'`,
+newline, carriage-return, tab, and null, preventing query breakage and Cypher
+injection in the native query builder. Current escaping/query construction is
+owned by the external library backend.
 
 ---
 
@@ -502,22 +514,25 @@ known to exist is the signature of the original defect.
 
 ---
 
-## Preserved invariants (regression guards)
+## Historical native preserved invariants (regression guards)
 
-This change is intentionally narrow. The following behaviours are
-unchanged and are protected by existing tests:
+For the pre-#2307 native fix, this change was intentionally narrow. The
+following behaviours were unchanged and protected by tests; current source
+preserves the high-level recall contract through the library backend:
 
 - **`*` wildcard export** still returns all facts above the floor
   (issue #1710 — `export_memory_snapshot`).
-- **`min_confidence` floor** and **`ORDER BY f.id DESC LIMIT {limit}`**
-  semantics are identical.
-- **Single-keyword and empty/whitespace queries** take the preserved
-  whole-string path — results unchanged.
+- **`min_confidence` floor** and the native `ORDER BY f.id DESC LIMIT {limit}`
+  tail stayed identical in the deleted native query builder.
+- **Single-keyword and empty/whitespace queries** took the preserved
+  whole-string path in the native query builder — results unchanged there.
 - **`goal-store:record` load** (limit 256, dedup-by-slug,
   `goal-board:snapshot` filter, stale-slug filter) is byte-for-byte
   unchanged because the concept tokenizes to one token.
-- **Cypher escaping** for fact content and objective text is handled by
-  the shared `escape_cypher` helper.
+- **Query safety** for fact content and objective text remains owned by the
+  active backend. In the deleted native fork this was the shared
+  `escape_cypher` helper; current code delegates query construction to the
+  library backend.
 
 ---
 
@@ -525,20 +540,20 @@ unchanged and are protected by existing tests:
 
 | Item                                      | File                                          |
 |-------------------------------------------|-----------------------------------------------|
-| `search_facts` implementation             | `src/cognitive_memory/ops.rs`                 |
-| `escape_cypher` helper (shared)           | `src/cognitive_memory/ops.rs`                 |
+| `search_facts` implementation             | `src/cognitive_memory/library_adapter.rs` (`LibraryCognitiveMemory`, delegating to the library) |
+| Historical native query builder / `escape_cypher` | `src/cognitive_memory/ops.rs` (deleted in #2307; history only) |
 | Preparation caller(s)                     | `src/memory_consolidation/mod.rs`             |
 | `PreparedContext` struct                  | `src/memory_consolidation/mod.rs`             |
 | `GOAL_STORE_FACT_CONCEPT` / list limit    | `src/goals/cognitive_memory_store.rs`         |
 | `GoalRecord` shape                        | `src/goals/types.rs`                          |
-| Trait-level tests                         | `src/cognitive_memory/ops.rs`                 |
+| Current backend tests                     | `src/cognitive_memory/tests_library_parity.rs` and related library-adapter tests |
 | Preparation-level tests                   | `src/memory_consolidation/tests_pr_a.rs` (new test), `tests.rs` (existing guards) |
 
 ---
 
 ## Testing
 
-### Trait-level tests in `src/cognitive_memory/ops.rs`
+### Historical native trait-level tests in `src/cognitive_memory/ops.rs`
 
 | Test                                                  | Coverage                                                                 |
 |-------------------------------------------------------|--------------------------------------------------------------------------|

--- a/docs/reference/cognitive-memory-procedural-idempotency.md
+++ b/docs/reference/cognitive-memory-procedural-idempotency.md
@@ -1,8 +1,8 @@
 ---
 title: Procedural-memory store idempotency
 description: How store_procedure deduplicates on exact procedure name so repeated OODA consolidation cycles stop re-storing identical procedures, ending the 0% compression / frozen procedural-store defect.
-last_updated: 2026-06-19
-owner: simard
+last_updated: 2026-07-03
+owner: cognitive-memory
 doc_type: reference
 related:
   - ./ooda-procedural-memory.md
@@ -14,15 +14,15 @@ related:
 
 # Procedural-memory store idempotency
 
-> **De-fork Phase 2b.** The idempotent-upsert *behavior* described here is
-> preserved: it is reached through the `CognitiveMemoryOps` trait, now backed
-> solely by `LibraryCognitiveMemory` over `amplihack-memory-lib`. The native
+> **De-fork Phase 2b (#2307).** The idempotent-upsert *behavior* described
+> here is preserved through the `CognitiveMemoryOps` trait, now backed solely by
+> `LibraryCognitiveMemory` over the external `amplihack-memory` library. Native
 > implementation details this page cites — `store_procedure` /
 > `mark_episode_distilled` / `list_undistilled_episodes` in
-> `src/cognitive_memory/ops.rs` and the `NativeCognitiveMemory::in_memory()`
-> test helper — were **deleted** with the fork; treat those code citations as
-> historical. The library performs the equivalent name-keyed upsert internally
-> (see [Library-backed Cognitive Memory](../architecture/cognitive-memory-library-adapter.md)).
+> `src/cognitive_memory/ops.rs` and the `NativeCognitiveMemory::in_memory()` test
+> helper — were deleted with the fork; treat those citations as historical. The
+> current adapter implements the equivalent name-keyed upsert/reinforcement
+> contract in `src/cognitive_memory/library_adapter.rs`.
 
 > Shipped in issue [#2298](https://github.com/rysweet/Simard/issues/2298).
 > Supersedes the "one procedure node per successful cycle / intentional
@@ -87,8 +87,8 @@ ruled out — they are correct and are left untouched:
 
 | Candidate | Verdict |
 |-----------|---------|
-| `mark_episode_distilled` not persisting | **Not the cause.** `SET e.distilled = 1` + `post_write_barrier` persist correctly and idempotently (`ops.rs`). |
-| `list_undistilled_episodes` re-returning the same episodes | **Not the cause.** The `WHERE e.distilled = 0` gate excludes marked rows (`ops.rs`). |
+| `mark_episode_distilled` not persisting | **Not the cause in the historical native-fork investigation.** The deleted `ops.rs` path used `SET e.distilled = 1` plus its native `post_write_barrier`; current distillation goes through `LibraryCognitiveMemory`. |
+| `list_undistilled_episodes` re-returning the same episodes | **Not the cause.** The current library-backed path preserves the distilled flag contract. |
 | Procedural-store upsert creating new nodes instead of updating | **Confirmed root cause.** `store_procedure` had no name dedup. |
 
 Note that **episode distillation** (which writes *facts*, not procedures —
@@ -135,21 +135,21 @@ fn store_procedure(
 
 Contract:
 
-1. **Existing name** → no `CREATE`. The existing node's id is returned, that
-   node's `usage_count` is incremented (`SET p.usage_count = p.usage_count + 1`),
-   and the standard `post_write_barrier` still runs. Calling again with the
-   same name returns the **same id**. This path is therefore *not* a pure
+1. **Existing name** → no `CREATE`. The existing node's id is returned, and
+   the adapter reinforces the existing procedure through the library path so its
+   `usage_count` advances.
+   Calling again with the same name returns the **same id**. This path is therefore *not* a pure
    no-op: it is idempotent on the **node count** while deliberately recording
    the recurrence (see *Reinforcement signal: `usage_count`* below).
 2. **New name** → a `Procedure` node is created exactly as before
-   (`CREATE … usage_count: 0`, followed by `post_write_barrier`), and the
-   new id is returned.
+   through the library-backed store, and the new id is returned.
 3. The method remains **total and idempotent on node count**: any number of
    calls with the same `name` leave the `Procedure` node count unchanged
    after the first (only `usage_count` advances).
 
-The existence check is a single indexed lookup using the same
-`escape_cypher` escaping as the create path:
+The current adapter detects an existing procedure by exact name through the
+library-backed procedure search before storing. In the deleted native fork, the
+existence check was a single escaped Cypher lookup:
 
 ```cypher
 MATCH (p:Procedure) WHERE p.name = '<escaped-name>' RETURN p.id LIMIT 1
@@ -161,19 +161,17 @@ each caller needing its own recall-then-store guard.
 
 ### Reinforcement signal: `usage_count`
 
-On the existing-name path, `store_procedure` bumps the stored procedure's
-`usage_count` (`SET p.usage_count = p.usage_count + 1`) so that a recurring
-procedure still records its reinforcement/recurrence for future ranking by
-`recall_procedure`. This is a counter update on a single existing row, **not**
-a new node. Idempotency is defined over the *node count*, not over
-`usage_count`; regression tests assert node-count stability and never assert
-a frozen `usage_count`.
+On the existing-name path, `store_procedure` reinforces the stored procedure so
+that a recurring procedure still records its recurrence for future ranking by
+`recall_procedure`. This updates an existing procedure, **not** a new node.
+Idempotency is defined over the *node count*, not over `usage_count`; regression
+tests assert node-count stability and never assert a frozen `usage_count`.
 
 ### Trait surface is unchanged
 
 The `CognitiveMemoryOps::store_procedure` signature
 (`-> SimardResult<String>`) is **unchanged**. The fix is internal to
-`NativeCognitiveMemory`, so none of the other implementations
+`LibraryCognitiveMemory`, so none of the other implementations
 (`CognitiveMemoryBridge`, `RemoteCognitiveMemory`, `SharedMemory`, and the
 test/meeting stubs) change shape, and no IPC/wire-protocol change is needed
 to convey a "created vs. existing" flag across process boundaries.
@@ -286,12 +284,12 @@ restarting the daemon never duplicates the 5 bootstrap procedures.
 
 | Item | File |
 |------|------|
-| `store_procedure` (idempotent upsert) | `src/cognitive_memory/ops.rs` (`NativeCognitiveMemory`) |
+| `store_procedure` (idempotent upsert) | `src/cognitive_memory/library_adapter.rs` (`LibraryCognitiveMemory`) |
 | `store_procedure` trait method (signature unchanged) | `src/cognitive_memory/mod.rs` (`CognitiveMemoryOps`) |
 | OODA call site + log guard | `src/ooda_loop/cycle.rs` (procedural-learning loop) |
 | `compose_procedure_name` (name derivation, unchanged) | `src/ooda_loop/cycle.rs` |
 | Bootstrap seeder (exact-name precedent) | `src/cognitive_memory/bootstrap_procedures.rs` |
-| `mark_episode_distilled` / `list_undistilled_episodes` (unchanged) | `src/cognitive_memory/ops.rs` |
+| `mark_episode_distilled` / `list_undistilled_episodes` (current library-backed implementations) | `src/cognitive_memory/library_adapter.rs` |
 
 ---
 
@@ -303,7 +301,7 @@ the dedup lands.
 
 ### Regression test (store layer)
 
-Against `NativeCognitiveMemory::in_memory()` (the `test_mem()` helper in
+Against `LibraryCognitiveMemory::in_memory()` (the `test_mem()` helper in
 `src/cognitive_memory/tests_pr_2298_idempotency.rs`) — **not** the
 `EpisodeMock`/`ProcMock` stubs, whose `store_procedure` is a no-op that would
 hide the bug:
@@ -339,11 +337,11 @@ distillation/consolidation pass over a fixed episode set,
 
 - `src/cognitive_memory/bootstrap_procedures_tests.rs` — seeding stays
   idempotent (`seed_is_idempotent`, `seed_skips_existing_procedures_by_name`).
-- `src/cognitive_memory/ops.rs` round-trip tests
+- `src/cognitive_memory` library-adapter round-trip tests
   (`store_procedure_returns_prefixed_id`,
   `recall_procedure_returns_steps_and_prerequisites`).
-- Hermetic-guard tests (`tests_hermetic_parity.rs`, the
-  `assert_hermetic_for` guard at the top of `store_procedure`).
+- Hermetic-guard tests (`tests_hermetic_parity.rs` and the current
+  `LibraryCognitiveMemory` `cfg(test)` lock-write guard).
 - `cargo test` for the `cognitive_memory`, `memory_consolidation`, and
   `ooda_loop` modules.
 

--- a/docs/reference/cognitive-memory-ranked-episodic-recall.md
+++ b/docs/reference/cognitive-memory-ranked-episodic-recall.md
@@ -1,7 +1,7 @@
 ---
 title: Ranked episodic recall & memory reinforcement
 description: How OODA preparation recalls past episodes with the library's multi-signal ranked recall (relevance + confidence + importance + recency + usage + graph) instead of a flat keyword scan, how compressed consolidation sources stay recallable through a UNION backfill, and how a usage/recency reinforcement seam (`reinforce_access`) plus `CognitiveFact` usage counters record accesses at the point recalled memories are surfaced into a cycle — not while candidates are merely gathered (per-action attribution remains a future refinement).
-last_updated: 2026-06-23
+last_updated: 2026-07-03
 owner: simard
 doc_type: reference
 related:
@@ -54,13 +54,14 @@ closes both:
    refinement (see
    [Memory reinforcement](#memory-reinforcement-usagerecency-learning)).
 
-The library dependency rev is unchanged (`285de92`, `lbug = "=0.15.4"`,
+As of issue #2395 the library dependency rev was unchanged (`285de92`, `lbug = "=0.15.4"`,
 `features = ["persistent"]`); both capabilities were already present in the
-library and are simply wired through the `CognitiveMemoryOps` trait. There is
+library and are simply wired through the `CognitiveMemoryOps` trait. That change made
 **no** `Cargo.toml` change and **no** on-disk store-format change. (The #2329
-fact-recall doc was written against an earlier pin, `e3ea136`; #2395 reflects the
-current `285de92` rev — the ranked-recall and `record_access` APIs are present in
-both.)
+fact-recall doc was written against an earlier pin, `e3ea136`; #2395 reflected
+`285de92` — the ranked-recall and `record_access` APIs are present in
+both.) The pin has since advanced to `26d49bf8` (`lbug = "=0.17.1"`) in the
+de-fork Phase 2b ([#2307](https://github.com/rysweet/Simard/issues/2307)).
 
 ---
 

--- a/docs/reference/distill-recipe-output-capture.md
+++ b/docs/reference/distill-recipe-output-capture.md
@@ -155,7 +155,7 @@ the order matters:
 - **`invoke_recipe` checks the process exit code first.** A failed run exits
   non-zero, so `invoke_recipe` returns `Err` *before the parser ever sees the
   envelope*. This is the path that actually fires in production — see
-  [Example 2](#example-2--failed-recipe-run), whose log line is
+  [Example 2](#example-2-failed-recipe-run), whose log line is
   `recipe exited with status 1`.
 - **The parser's `success == false` guard is defense-in-depth.** Because the
   exit-code guard fires first, the parser's check is effectively unreachable

--- a/docs/reference/multi-binary-self-update.md
+++ b/docs/reference/multi-binary-self-update.md
@@ -57,7 +57,7 @@ For the build-from-source merged-but-not-running path, see the
 - [Release packaging contract](#release-packaging-contract)
 - [Backward compatibility](#backward-compatibility)
 - [Examples](#examples)
-- [Configuration & environment](#configuration--environment)
+- [Configuration & environment](#configuration-environment)
 - [Tests](#tests)
 - [See also](#see-also)
 

--- a/docs/reference/ooda-brain-api.md
+++ b/docs/reference/ooda-brain-api.md
@@ -91,7 +91,7 @@ variant that can mutate the running daemon binary.
 
 `Deserialize` is no longer derived — the enum is never deserialized from
 JSON. It is constructed from text-parsed fields via the DECISION marker
-protocol (see [text-parsing wire formats § engineer lifecycle](../reference/text-parsing-wire-formats.md#1c-engineer-lifecycle-rustyclawdrs)).
+protocol (see [text-parsing wire formats § engineer lifecycle](../reference/text-parsing-wire-formats.md#1c-engineer-lifecycle-recipe_brainrs)).
 `Serialize` is retained for logging and state persistence.
 
 ## Implementations
@@ -106,7 +106,7 @@ parses the text response using the DECISION marker protocol.
 The parser finds the first `DECISION: <variant>` line, extracts labeled
 fields for structured variants, and collects remaining lines as rationale.
 There is no JSON fallback — the DECISION marker is the sole parser. See
-[text-parsing wire formats § engineer lifecycle](../reference/text-parsing-wire-formats.md#1c-engineer-lifecycle-rustyclawdrs)
+[text-parsing wire formats § engineer lifecycle](../reference/text-parsing-wire-formats.md#1c-engineer-lifecycle-recipe_brainrs)
 for the full grammar.
 
 ```rust

--- a/docs/reference/ooda-brain-api.md
+++ b/docs/reference/ooda-brain-api.md
@@ -1,11 +1,31 @@
+---
+title: OodaBrain API
+description: Reference for the OodaBrain trait — the engineer-lifecycle seam of Simard's OODA loop — its context and decision types, the RecipeBrain implementation, and the deterministic fallback.
+last_updated: 2026-07-03
+owner: simard
+doc_type: reference
+related:
+  - ../concepts/unified-recipe-brain.md
+  - ./recipe-brain-api.md
+  - ./ooda-brain-decision-protocol.md
+---
+
 # Reference: `OodaBrain` API
 
 Crate: `simard` · Module: `simard::ooda_brain`
 
 The `OodaBrain` trait is the seam between Simard's deterministic OODA loop and
-prompt-driven decision-making. As of this PR it is wired into one site —
-`dispatch_spawn_engineer`'s skip path — but the trait, context, and decision
-types are designed to absorb the other OODA phases incrementally.
+prompt-driven decision-making for the **engineer-lifecycle** phase. It is
+consulted by `dispatch_spawn_engineer`
+(`simard::ooda_actions::advance_goal::spawn`), which calls
+`decide_engineer_lifecycle` before spawning or skipping an engineer
+subprocess. It is one of three sibling brain traits — `OodaBrain`
+(act / engineer-lifecycle), [`OodaDecideBrain`](./recipe-brain-api.md) (decide),
+and `OodaOrientBrain` (orient) — all implemented together by
+[`RecipeBrain`](./recipe-brain-api.md)
+(`simard::ooda_brain::recipe_brain`), each with a deterministic fallback
+(`DeterministicLifecycleBrain`, `DeterministicDecideBrain`,
+`DeterministicOrientBrain`).
 
 ## Trait
 

--- a/docs/reference/ooda-procedural-memory.md
+++ b/docs/reference/ooda-procedural-memory.md
@@ -1,8 +1,8 @@
 ---
 title: OODA procedural memory
 description: How the OODA cycle stores successful action outcomes as procedural memories, enabling Simard to recall what worked in past cycles during future preparation phases.
-last_updated: 2026-06-12
-owner: simard
+last_updated: 2026-07-03
+owner: cognitive-memory
 doc_type: reference
 related:
   - ../architecture/cognitive-memory.md
@@ -19,13 +19,13 @@ related:
 
 # OODA procedural memory
 
-> **De-fork Phase 2b.** The store/recall *behavior* described here is
-> preserved: `store_procedure` and `recall_procedure` are reached through the
-> `CognitiveMemoryOps` trait, now backed solely by `LibraryCognitiveMemory`
-> over `amplihack-memory-lib`. The implementation citations on this page —
-> `src/cognitive_memory/ops.rs` (`NativeCognitiveMemory`) and tests that
-> exercise `NativeCognitiveMemory` directly — were **deleted** with the fork;
-> treat those code citations as historical. See
+> **De-fork Phase 2b (#2307).** The store/recall *behavior* described here
+> is preserved: `store_procedure` and `recall_procedure` are reached through the
+> `CognitiveMemoryOps` trait, now backed solely by `LibraryCognitiveMemory` over
+> the external `amplihack-memory` library. Implementation citations to
+> `src/cognitive_memory/ops.rs` (`NativeCognitiveMemory`) and tests that exercised
+> `NativeCognitiveMemory` directly were deleted with the fork; treat those code
+> citations as historical. See
 > [Library-backed Cognitive Memory](../architecture/cognitive-memory-library-adapter.md).
 
 Shipped in issue [#2280](https://github.com/rysweet/Simard/issues/2280).
@@ -215,8 +215,8 @@ approaches when selecting actions for the current cycle.
 |------|------|
 | Procedural storage loop | `src/ooda_loop/cycle.rs` (after `execution_memory_operations` loop) |
 | `store_procedure` trait method | `src/cognitive_memory/mod.rs` (`CognitiveMemoryOps`) |
-| `store_procedure` implementation | `src/cognitive_memory/ops.rs` (`NativeCognitiveMemory`) |
-| `recall_procedure` implementation | `src/cognitive_memory/ops.rs` (`NativeCognitiveMemory`) |
+| `store_procedure` implementation | `src/cognitive_memory/library_adapter.rs` (`LibraryCognitiveMemory`) |
+| `recall_procedure` implementation | `src/cognitive_memory/library_adapter.rs` (`LibraryCognitiveMemory`) |
 | `ActionOutcome` / `ActionKind` types | `src/ooda_loop/types.rs` |
 | Mock handlers | `tests/ooda.rs`, `tests/ooda_daemon.rs`, `tests/memory_consolidation_lifecycle.rs` |
 
@@ -229,7 +229,7 @@ approaches when selecting actions for the current cycle.
 `successful_outcome_stores_procedural_memory` in the OODA test suite
 verifies that after a cycle containing a successful outcome, the mock
 transport receives a `memory.store_procedure` call (or when using
-`NativeCognitiveMemory` directly, that `get_statistics().procedural_count`
+`LibraryCognitiveMemory` directly, that `get_statistics().procedural_count`
 increases).
 
 ### Mock transport handler

--- a/docs/reference/pr-finalization-pipeline.md
+++ b/docs/reference/pr-finalization-pipeline.md
@@ -88,7 +88,7 @@ until crusty is satisfied or the cap is reached.
 | **Model** | A **high-end reasoning model**, pinned explicitly (the engineer itself runs the Copilot CLI default/auto model, so crusty is invoked through a `copilot --model "$SIMARD_REVIEW_MODEL" --reasoning-effort high --context long_context` subprocess to force the high-end model at **high** reasoning effort over the **1M-token** context tier). Default `gpt-5.5`; see [Configuration](#configuration). |
 | **Per-iteration input** | The **latest** PR state — the engineer re-fetches the current diff each iteration (`gh pr diff <PR>`); it never re-reviews a stale diff. |
 | **Fix discipline** | Every **actionable / blocking** finding is fixed in code and pushed to the **same PR branch** before the next review. |
-| **Termination** | Crusty reports **no blocking/actionable findings** (satisfied), OR the iteration cap is reached. See [Bounded loop & blocker semantics](#bounded-loop--blocker-semantics). |
+| **Termination** | Crusty reports **no blocking/actionable findings** (satisfied), OR the iteration cap is reached. See [Bounded loop & blocker semantics](#bounded-loop-blocker-semantics). |
 | **Satisfied signal** | A **structural sentinel** verdict (the review's first output line is exactly `NO BLOCKING FINDINGS`) gates "satisfied" — not free-text — so a chatty review cannot accidentally pass the gate. |
 
 Each iteration is, in order: **re-fetch latest diff → crusty review on the

--- a/docs/reference/progress-evidence-api.md
+++ b/docs/reference/progress-evidence-api.md
@@ -188,7 +188,7 @@ pub fn update_goal_progress_with_evidence(
     | `Blocked(_)` | the goal's *current* percent (no change) |
     | `Completed` | `100` |
 
-2. Determine `since` via the [three-step fallback chain](../concepts/progress-evidence-gating.md#sourcing-since--the-last-update-timestamp).
+2. Determine `since` via the [three-step fallback chain](../concepts/progress-evidence-gating.md#sourcing-since-the-last-update-timestamp).
 
 3. **Bypass set.** If any of the following hold, call the underlying
    `update_goal_progress` directly and return

--- a/docs/reference/progress-evidence-api.md
+++ b/docs/reference/progress-evidence-api.md
@@ -1,3 +1,14 @@
+---
+title: Progress-evidence API
+description: Reference for simard::goal_curation::progress_evidence — the ProgressEvidenceChecker trait, its implementations, and the update_goal_progress_with_evidence façade that gates completion bumps.
+last_updated: 2026-07-03
+owner: simard
+doc_type: reference
+related:
+  - ../concepts/progress-evidence-gating.md
+  - ../operations/progress-evidence-kill-switch.md
+---
+
 # Reference: Progress-evidence API
 
 Crate: `simard` · Module: `simard::goal_curation::progress_evidence`

--- a/docs/testing/cognitive-memory-serial-isolation.md
+++ b/docs/testing/cognitive-memory-serial-isolation.md
@@ -8,9 +8,9 @@ description: >
   cognitive_memory serial key, a regression-guard meta-test enforces it, and the
   rule is documented at the HermeticState source. Extending enforcement to every
   process-global variable is tracked follow-up (issue #2375).
-last_updated: 2026-06-22
+last_updated: 2026-07-03
 review_schedule: when a new process-global env var is read by a production handler, or when serial_test is upgraded
-owner: simard
+owner: cognitive-memory
 doc_type: reference
 related:
   - ./hermetic-tests.md
@@ -175,14 +175,17 @@ if**, at run time, it does any of:
   env, directly or via `resolve_state_root()` / `memory_ipc::socket_path_for`
   default resolution.
 - **(D)** Opens cognitive memory at the **env-derived default path**
-  (`NativeCognitiveMemory::open`, `LibraryCognitiveMemory::open`,
-  `CognitiveMemoryBridge`, `open_native`, `launch_writer_bridge` against a path
-  obtained from the global env) **or** invokes one of the **async dashboard
-  route handlers** that resolve the state root internally via
-  `resolve_state_root()` — `seed_goals`, `add_goal`, `remove_goal`,
-  `update_goal_status`, `promote_backlog_item`, `demote_goal`, and the
-  goal/board snapshot route (all `async fn … -> Json<Value>` in
+  (`LibraryCognitiveMemory::open`, `CognitiveMemoryBridge`, `open_native`,
+  `launch_writer_bridge` against a path obtained from the global env) **or**
+  invokes one of the **async dashboard route handlers** that resolve the state
+  root internally via `resolve_state_root()` — `seed_goals`, `add_goal`,
+  `remove_goal`, `update_goal_status`, `promote_backlog_item`, `demote_goal`,
+  and the goal/board snapshot route (all `async fn … -> Json<Value>` in
   `operator_commands_dashboard/goals.rs`).
+
+  > **Historical note (#2307):** pre-de-fork native-fork tests that used
+  > `NativeCognitiveMemory::open` belong to the same env-derived-path class, but
+  > that symbol is deleted and is no longer a current API.
 
   > **Not rule (D):** `dashboard_goal_board_snapshot(state_root)`,
   > `dashboard_save_goal_board(state_root, board)`, `save_goal_board(board, bridge)`,

--- a/docs/testing/hermetic-tests.md
+++ b/docs/testing/hermetic-tests.md
@@ -1,9 +1,9 @@
 ---
 title: Writing hermetic tests against cognitive memory
 description: Test-author contract for the SIMARD_STATE_ROOT / SIMARD_MEMORY_SOCKET hermeticity guard, the helper APIs that satisfy it, and the regression check that prevents leaks into ~/.simard.
-last_updated: 2026-05-19
+last_updated: 2026-07-03
 review_schedule: at every cognitive-memory schema or socket-path change
-owner: simard
+owner: cognitive-memory
 doc_type: reference
 related:
   - ./cognitive-memory-serial-isolation.md
@@ -112,19 +112,18 @@ intentionally verbose because a tripped guard always indicates the test
 needs a code change — there is no scenario in which retrying or
 ignoring it is correct.
 
-> **De-fork Phase 2b.** The per-method `NativeCognitiveMemory::assert_hermetic_for`
-> guard described below was deleted with the native fork (the `ops.rs` it lived in
-> no longer exists). The library backend (`LibraryCognitiveMemory`) has no
-> per-op hermetic guard: production callers pass a correct `state_root`, tests
-> always pass a `TempDir`, and the remaining enforcement points (the bridge
-> launcher guard and the non-cognitive-memory sites listed below) still apply.
-> The risk the per-op guard mitigated — the native backend writing to the live
-> home store — no longer exists on the library path. The table below is archival.
+> **De-fork Phase 2b (#2307).** The per-method
+> `NativeCognitiveMemory::assert_hermetic_for` symbol described below was deleted
+> with the native fork (the `ops.rs` it lived in no longer exists). Current
+> hermetic enforcement is backend-agnostic: tests allocate isolated state through
+> `HermeticState`, serialize process-global env access with the
+> `cognitive_memory` key, the bridge launcher checks explicit state roots, and
+> `LibraryCognitiveMemory` runs a `cfg(test)` lock-write guard for persistent
+> test stores. The table below is archival history for the removed native symbol.
 
-The guard ran via a `cfg(test)`-only helper
+Before #2307, the native fork ran a `cfg(test)`-only helper
 `NativeCognitiveMemory::assert_hermetic_for(site)` at the top of every
-mutating `CognitiveMemoryOps` method on the native backend. The nine
-guarded cognitive-memory entry points were:
+mutating `CognitiveMemoryOps` method. The nine archived native guard sites were:
 
 | # | Method                | Guard site string |
 |---|----------------------|-------------------|
@@ -146,8 +145,9 @@ Additional enforcement points outside cognitive memory:
 - `memory_ipc::launcher::launch_writer_bridge` (immediately before
   returning a writer bridge, regardless of which tier was selected).
 
-Multiple independent enforcement points means deleting one of them does
-not silently disable the guard — at least one will still fire.
+Current enforcement remains multi-site: `HermeticState`/serial isolation cover
+test setup, the launcher covers bridge acquisition, and the library adapter's
+`cfg(test)` lock-write guard covers persistent library-backed writes.
 
 ## Helpers that satisfy the contract
 

--- a/docs/whats-changed.md
+++ b/docs/whats-changed.md
@@ -1,0 +1,125 @@
+---
+title: What's Changed — documentation audit
+description: Change index for the documentation accuracy-and-discoverability audit that reconciled docs/ with the current source, de-forked the cognitive-memory pages, and made every page reachable from the nav.
+last_updated: 2026-07-03
+review_schedule: as-needed
+owner: simard
+doc_type: explanation
+---
+
+# What's Changed
+
+This page is the summary index for the documentation audit that brought `docs/`
+back in line with the **current** state of the source tree. It records *what*
+changed and *why*, so reviewers can verify each claim against code rather than
+against a point-in-time snapshot.
+
+Every statement below was verified against the source on `main` at the time of
+the audit. Where a doc still describes a removed component, it is now framed
+explicitly as history (with the issue that removed it) rather than as current
+behaviour.
+
+## Why this audit happened
+
+The documentation had three classes of drift:
+
+1. **Stale symbols.** Pages still described the deleted in-repo native
+   cognitive-memory fork (`NativeCognitiveMemory`) as if it were the live
+   backend and API.
+2. **Discoverability gap.** 118 of the 208 Markdown pages existed on disk but
+   were absent from the MkDocs navigation, so they were effectively invisible
+   to readers.
+3. **Broken internal links.** A handful of cross-page `#anchor` links pointed
+   at anchors that no longer existed.
+
+## What changed
+
+### 1. Cognitive memory de-forked to the library backend (#2307)
+
+The native Rust fork `NativeCognitiveMemory` (written directly over
+LadybugDB / `lbug`) was **deleted** by the de-fork, Phase 2b (issue #2307).
+The sole cognitive-memory backend is now `LibraryCognitiveMemory`
+(`src/cognitive_memory/library_adapter.rs`), an adapter over the external
+[`amplihack-memory`](https://github.com/rysweet/amplihack-memory-lib) library
+(pinned by git rev, built with the `persistent` feature). That library uses
+`lbug =0.17.1` internally; Simard keeps `lbug` as a direct dependency **only**
+for the `simard-tui` binary / goal board, not for cognitive memory.
+
+Durability, verified backups and pruning are no longer methods on the deleted
+fork. They are free functions in the `memory_backup` module — see
+[Backup-Pruning API](reference/backup-pruning-api.md),
+[Verified Backups](operations/verified-backups.md) and
+[Cognitive-Memory Durability](operations/cognitive-memory-durability.md).
+
+Reconciled pages: [Cognitive Memory](architecture/cognitive-memory.md),
+[Cognitive Memory — Library Adapter](architecture/cognitive-memory-library-adapter.md),
+and the `reference/cognitive-memory-*` recall/idempotency/bootstrap pages.
+
+The **six-type** cognitive-memory model is unchanged: Sensory, Working,
+Episodic, Semantic (Fact), Procedural, and Prospective.
+
+### 2. Brains and the OODA loop
+
+The OODA loop drives three brain traits — `OodaDecideBrain` (decide),
+`OodaOrientBrain` (orient) and `OodaBrain` (engineer-lifecycle / act). The
+unified [`RecipeBrain`](reference/recipe-brain-api.md) struct implements all
+three, with deterministic fallbacks (`DeterministicDecideBrain`,
+`DeterministicOrientBrain`, `DeterministicLifecycleBrain`). These trait names
+are current source symbols — see [Unified RecipeBrain](concepts/unified-recipe-brain.md)
+and [OodaBrain API](reference/ooda-brain-api.md).
+
+The Copilot launch-log preamble + ANSI noise is stripped at a **single shared
+`recipe_output` chokepoint** so decide/orient/lifecycle/merge-judge/distill all
+parse the agent's real output (issue #2496, PR #2504, generalising the distill
+fix). See
+[Copilot Launch-Log Preamble Stripping](concepts/copilot-launcher-preamble-stripping.md)
+and [Distill Recipe-Output Capture](reference/distill-recipe-output-capture.md).
+
+### 3. Base-type adapters
+
+Shipping substrates are `rusty-clawd` and `copilot`; the Claude Agent SDK and
+Microsoft Agent Framework adapters are present as structural stubs pending SDK
+availability. See [Base-Type Adapters](reference/base-type-adapters.md).
+
+### 4. Self-deploy and self-relaunch (#2467)
+
+`simard self-deploy [--check]` closes the "merged but not running" gap by
+building the merged change from source, deploying it, health-verifying it, and
+leaving it running (or rolling back). See
+[Reconcile-and-Self-Deploy](concepts/reconcile-and-self-deploy.md),
+the [Self-Deploy API](reference/self-deploy-api.md), and
+[Verify and Roll Back a Self-Deploy](howto/verify-and-roll-back-a-self-deploy.md).
+
+### 5. Goal-board persistence + cross-process write lock (#2511 / #2514)
+
+The file-backed goal store guards `goal_store.json` with an advisory
+`flock` acquired via an RAII guard, so concurrent Simard processes cannot
+corrupt the board. See [File-Backed Goal Store](reference/file-backed-goal-store.md)
+and [Troubleshoot Goal Store](howto/troubleshoot-goal-store.md).
+
+### 6. Discoverability: every page is now in the nav
+
+All 118 previously-orphaned pages were added to `mkdocs.yml` under logical
+sections, including new **Operations**, **Operator Dashboard**, **Testing**,
+and **Ecosystem & Audits** sections. A native MkDocs
+[`validation`](https://www.mkdocs.org/user-guide/configuration/#validation)
+block now makes `mkdocs build --strict` fail on future orphaned pages and dead
+anchors, so discoverability cannot silently regress.
+
+## Relationship to the PRD
+
+The original product requirements document,
+[`Specs/ProductArchitecture.md`](https://github.com/rysweet/Simard/blob/main/Specs/ProductArchitecture.md),
+remains the byte-for-byte source of truth for product intent and was **not**
+modified by this audit. Where the current implementation has diverged from the
+PRD (for example, the exact adapter list or backend), the divergence is
+documented in `docs/` as current reality and the PRD is left unchanged.
+
+## How to keep docs honest
+
+- Verify every claim against source before writing it; avoid point-in-time
+  ("as of N reports") snapshots.
+- Keep new pages under `docs/`, add them to the `nav`, and cross-link them.
+- Follow Diataxis: tutorial / how-to / reference / explanation.
+- Run `mkdocs build --strict` — it now also enforces zero orphans and no dead
+  anchors.

--- a/docs/whats-changed.md
+++ b/docs/whats-changed.md
@@ -53,7 +53,12 @@ fork. They are free functions in the `memory_backup` module — see
 
 Reconciled pages: [Cognitive Memory](architecture/cognitive-memory.md),
 [Cognitive Memory — Library Adapter](architecture/cognitive-memory-library-adapter.md),
-and the `reference/cognitive-memory-*` recall/idempotency/bootstrap pages.
+the `reference/cognitive-memory-*` recall/idempotency/bootstrap pages, and
+[Bridge Pattern](architecture/bridge-pattern.md) — whose *Data Loss Prevention*
+section no longer attributes memory-write durability to a Python bridge. Writes
+now go directly through the in-process `LibraryCognitiveMemory` adapter
+(idempotent by `node_id`), and durability is provided by the `memory_backup`
+verified-backup APIs.
 
 The **six-type** cognitive-memory model is unchanged: Sensory, Working,
 Episodic, Semantic (Fact), Procedural, and Prospective.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,7 +21,6 @@ theme:
         name: Switch to dark mode
   features:
     - navigation.sections
-    - navigation.expand
     - navigation.top
     - search.highlight
     - content.code.copy
@@ -42,8 +41,24 @@ markdown_extensions:
   - toc:
       permalink: true
 
+# Discoverability & link-integrity gate (mkdocs-native; enforced under --strict).
+validation:
+  omitted_files: warn
+  absolute_links: warn
+  unrecognized_links: warn
+  nav:
+    omitted_files: warn        # every docs/*.md must appear in nav (0 orphans)
+    not_found: warn
+    absolute_links: warn
+  links:
+    not_found: warn
+    anchors: warn              # catch dead #anchors across pages
+    absolute_links: warn
+    unrecognized_links: warn
+
 nav:
   - Home: index.md
+  - What's Changed: whats-changed.md
   - Roadmap: ROADMAP.md
   - Daemon mode: daemon-mode.md
   - Memory architecture: memory.md
@@ -51,97 +66,212 @@ nav:
   - Distributed operations: distributed-operations.md
   - Architecture:
     - Overview: architecture/overview.md
+    - Simard System Architecture: architecture/system-architecture.md
     - Bridge Pattern: architecture/bridge-pattern.md
+    - Agent Composition: architecture/agent-composition.md
+    - Engineer-Loop Agent Orchestration: architecture/engineer-agent-orchestration.md
     - Cognitive Memory: architecture/cognitive-memory.md
     - Cognitive Memory — Library Adapter: architecture/cognitive-memory-library-adapter.md
     - Episode Ingestion Policy & Promotion: architecture/episode-ingestion-policy.md
+    - Episode Distillation: architecture/episode-distillation.md
     - Gym Eval Engine — Library Adapter: architecture/gym-eval-library-adapter.md
-    - Agent Composition: architecture/agent-composition.md
-    - Implementation Plan: architecture/implementation-plan.md
+    - Unified Meeting Backend: architecture/unified-meeting-backend.md
+    - OODA Meeting-Handoff Integration: architecture/ooda-meeting-handoff-integration.md
     - Brain Introspection + Memory Hygiene: architecture/brain-introspection.md
     - Monthly Self-Quality-Audit: architecture/monthly-self-quality-audit.md
+    - Implementation Plan: architecture/implementation-plan.md
   - Concepts:
-    - Truthful Runtime Metadata: concepts/truthful-runtime-metadata.md
-    - Prompt-driven Brain Iteration: concepts/prompt-driven-brain-iteration.md
-    - Improvement context — denser execution evidence: concepts/improvement-context-execution-evidence-gap.md
+    - Operational Autonomy Model: concepts/operational-autonomy-model.md
     - Adaptive Scaling: concepts/adaptive-scaling.md
     - Pluggable Identity: concepts/pluggable-identity.md
     - OODA Loop Self-Detection: concepts/ooda-loop-self-detection.md
+    - Unified RecipeBrain: concepts/unified-recipe-brain.md
+    - Prompt-Driven OODA Brain: concepts/prompt-driven-ooda-brain.md
+    - Prompt-Driven Brain Iteration: concepts/prompt-driven-brain-iteration.md
+    - Text-Based Brain Protocol: concepts/text-based-brain-protocol.md
+    - Prompt-Driven TDD Discipline: concepts/prompt-driven-tdd-discipline.md
+    - Truthful Runtime Metadata: concepts/truthful-runtime-metadata.md
+    - Trustworthy Confidence + External Completion: concepts/trustworthy-confidence-and-external-completion.md
+    - Progress-Evidence Gating: concepts/progress-evidence-gating.md
+    - Improvement Context — Execution-Evidence Gap: concepts/improvement-context-execution-evidence-gap.md
+    - Closing the Procedural-Learning Loop: concepts/procedural-learning-loop.md
     - Reconcile-and-Self-Deploy: concepts/reconcile-and-self-deploy.md
     - Deploy-Aware Done-Gate: concepts/deploy-aware-done-gate.md
-    - Operational Autonomy Model: concepts/operational-autonomy-model.md
-    - Closing the Procedural-Learning Loop: concepts/procedural-learning-loop.md
-    - Trustworthy Confidence + External Completion: concepts/trustworthy-confidence-and-external-completion.md
     - Copilot Launch-Log Preamble Stripping: concepts/copilot-launcher-preamble-stripping.md
+    - Goal-Board Persistence: concepts/goal-board-persistence.md
+    - Goal-Board Corruption Guards: concepts/goal-board-corruption-guards.md
+    - File-Backed Goal-Store Simplification: concepts/file-backed-goal-store-simplification.md
+    - Goal-Fact Dedup in Preparation: concepts/goal-fact-dedup-in-preparation.md
+    - Compound-Objective Search in Preparation: concepts/preparation-compound-objective-search.md
+    - Goal Stewardship Mode: concepts/stewardship-mode.md
+    - Automated Disk-Health Management: concepts/automated-disk-health.md
+    - Update-Check Design: concepts/update-check-design.md
   - Tutorials:
     - First Local Session: tutorials/run-your-first-local-session.md
     - First Benchmark Suite: tutorials/run-your-first-benchmark-gym.md
   - How-To Guides:
     - Terminal to Engineer: howto/move-from-terminal-recipes-into-engineer-runs.md
+    - Use the Agent-Orchestration Engineer Loop: howto/use-agent-orchestration-engineer-loop.md
     - Bootstrap and Reflection: howto/configure-bootstrap-and-inspect-reflection.md
-    - Carry Meeting Decisions: howto/carry-meeting-decisions-into-engineer-sessions.md
-    - Inspect Meeting Records: howto/inspect-meeting-records.md
-    - Inspect Improvements: howto/inspect-improvement-curation-state.md
-    - Reclaim Disk Space: howto/reclaim-disk-space-and-run-low-space-rust-builds.md
-    - Inspect Goal Register: howto/inspect-durable-goal-register.md
-    - Configure Adaptive Scaling: howto/configure-adaptive-scaling.md
-    - Troubleshoot Goal Store: howto/troubleshoot-goal-store.md
-    - Recover from Meeting Close Timeout: howto/recover-from-meeting-close-timeout.md
-    - Configure Pluggable Identity: howto/configure-pluggable-identity.md
-    - Configure Episode Hygiene and Promotion: howto/configure-episode-hygiene-and-promotion.md
-    - Dashboard E2E Tests: howto/run-dashboard-e2e-tests.md
-    - Route a Goal to its Target Repo: howto/route-a-goal-to-its-target-repo.md
-    - Self-Maintain Dependency Pins: howto/self-maintain-dependency-pins.md
-    - Verify and Roll Back a Self-Deploy: howto/verify-and-roll-back-a-self-deploy.md
-    - Run Self-Deploy from Any Directory: howto/run-self-deploy-from-any-directory.md
-    - Diagnose a Rejected Goal Completion: howto/diagnose-a-rejected-goal-completion.md
+    - Attach to a Running Engineer: howto/attach-to-a-running-engineer.md
+    - Inspect and Clean Engineer Worktrees: howto/inspect-and-clean-engineer-worktrees.md
+    - Grant Engineer Write Permissions: howto/grant-engineer-write-permissions.md
+    - Edit the Engineer System Prompt: howto/edit-the-engineer-system-prompt.md
+    - Run the OODA Daemon: howto/run-ooda-daemon.md
+    - Spawn Engineers from the OODA Daemon: howto/spawn-engineers-from-ooda-daemon.md
+    - Unblock Stuck OODA Goals: howto/unblock-stuck-ooda-goals.md
+    - Add a New Recipe-Brain Phase: howto/add-a-new-recipe-brain-phase.md
+    - Edit the OODA Brain Prompt: howto/edit-the-ooda-brain-prompt.md
+    - Diagnose Brain Decision Parse Failures: howto/diagnose-brain-decision-parse-failures.md
+    - Diagnose Decide/Orient Parse Failures: howto/diagnose-decide-orient-parse-failures.md
     - Interpret Brain Confidence and Verify Completion: howto/interpret-brain-confidence-and-verify-completion.md
     - Configure Brain Introspection: howto/configure-brain-introspection.md
+    - Start a Meeting: howto/start-a-meeting.md
+    - Resume an Interrupted Meeting: howto/resume-an-interrupted-meeting.md
+    - Recover from Meeting-Close Timeout: howto/recover-from-meeting-close-timeout.md
+    - Use Meeting Templates: howto/use-meeting-templates.md
+    - Export Meeting Markdown: howto/export-meeting-markdown.md
+    - Inspect Meeting Records: howto/inspect-meeting-records.md
+    - Carry Meeting Decisions: howto/carry-meeting-decisions-into-engineer-sessions.md
+    - Diagnose Handoff Accumulation: howto/diagnose-handoff-accumulation.md
+    - Inspect the Durable Goal Register: howto/inspect-durable-goal-register.md
+    - Decompose a Large Goal: howto/decompose-a-large-goal.md
+    - Route a Goal to its Target Repo: howto/route-a-goal-to-its-target-repo.md
+    - Diagnose a Rejected Goal Completion: howto/diagnose-a-rejected-goal-completion.md
+    - Diagnose Rejected Progress Claims: howto/diagnose-rejected-progress-claims.md
+    - Diagnose search_facts Issues: howto/diagnose-search-facts-issues.md
+    - Reconcile Goal–Prospective Drift: howto/reconcile-goal-prospective-drift.md
+    - Recover the Goal Board: howto/recover-goal-board.md
+    - Troubleshoot Goal Store: howto/troubleshoot-goal-store.md
+    - Clean Fixture Leaks: howto/clean-fixture-leaks.md
+    - Verify and Roll Back a Self-Deploy: howto/verify-and-roll-back-a-self-deploy.md
+    - Run Self-Deploy from Any Directory: howto/run-self-deploy-from-any-directory.md
+    - Check for Updates: howto/check-for-updates.md
+    - Self-Maintain Dependency Pins: howto/self-maintain-dependency-pins.md
+    - Configure Adaptive Scaling: howto/configure-adaptive-scaling.md
+    - Configure Pluggable Identity: howto/configure-pluggable-identity.md
+    - Configure Episode Hygiene and Promotion: howto/configure-episode-hygiene-and-promotion.md
+    - Inspect Improvement Curation State: howto/inspect-improvement-curation-state.md
+    - Inspect the Procedural-Learning Loop: howto/inspect-the-procedural-learning-loop.md
+    - File Stewardship Issues from Orchestrator Runs: howto/file-stewardship-issues-from-orchestrator-runs.md
     - Configure the Monthly Self-Quality-Audit: howto/configure-self-quality-audit.md
+    - Configure the Disk-Health Check: howto/configure-disk-health-check.md
+    - Reclaim Disk Space (Low-Space Rust Builds): howto/reclaim-disk-space-and-run-low-space-rust-builds.md
+    - Fix CI Linker OOM: howto/fix-ci-linker-oom.md
     - Triage Stale Pull Requests: howto/triage-stale-pull-requests.md
     - Diagnose merge-pr Verdict-Parse Failures: howto/diagnose-merge-pr-verdict-parse-failures.md
-    - Inspect the Procedural-Learning Loop: howto/inspect-the-procedural-learning-loop.md
+    - Monitor Simard with the TUI: howto/monitor-simard-with-tui.md
+    - View Agent Terminal Logs: howto/view-agent-terminal-logs.md
+    - Run Dashboard E2E Tests: howto/run-dashboard-e2e-tests.md
   - Reference:
     - CLI Reference: reference/simard-cli.md
+    - simard-engineer-step CLI: reference/simard-engineer-step.md
+    - simard-tui Dashboard: reference/simard-tui.md
+    - npx / npm Install: reference/npx-npm-install.md
+    - Update Check: reference/update-check.md
+    - Multi-Binary Self-Update: reference/multi-binary-self-update.md
     - Self-Deploy API: reference/self-deploy-api.md
     - Self-Deploy Source Prep & Warm Target Dir: reference/self-deploy-source-prep.md
-    - Completion-Evidence Gate API: reference/completion-evidence-gate-api.md
-    - Trustworthy-Confidence API: reference/trustworthy-confidence-api.md
-    - External-Signal Completion Gate: reference/external-signal-completion-gate.md
-    - Memory introspection CLI: reference/simard-memory-cli.md
-    - Cognitive-memory provenance (DERIVES_FROM): reference/cognitive-memory-provenance.md
+    - State-Root Resolution: reference/state-root-resolution.md
+    - Operator Read State-Root Contract: reference/operator-read-state-root-contract.md
+    - Runtime Contracts: reference/runtime-contracts.md
+    - Subprocess Prompt Delivery: prompt-delivery.md
+    - Bridge Wire Protocol: reference/bridge-wire-protocol.md
+    - Text-Parsing Wire Formats: reference/text-parsing-wire-formats.md
+    - Recipe Context-Var Sanitization: reference/recipe-context-var-sanitization.md
+    - Engineer-Loop argv Sanitization: reference/engineer-loop-argv-sanitization.md
+    - String-Truncation Helpers: reference/string-truncation-helpers.md
+    - RecipeBrain API: reference/recipe-brain-api.md
+    - OodaBrain API: reference/ooda-brain-api.md
+    - OODA Brain Decision Protocol: reference/ooda-brain-decision-protocol.md
+    - OODA Brain Parse-Failure Record: reference/ooda-brain-parse-failure-record.md
+    - OODA Brain Prompt Schema: reference/ooda-brain-prompt.md
+    - OODA Decide Prompt Schema: reference/ooda-decide-prompt.md
+    - OODA Orient Prompt Schema: reference/ooda-orient-prompt.md
+    - OODA Orient Recipe: reference/ooda-orient-recipe.md
+    - OODA Engineer-Lifecycle Recipe: reference/ooda-engineer-lifecycle-recipe.md
+    - OODA Procedural Memory: reference/ooda-procedural-memory.md
+    - Recipe-Brain Verdict/Decision Parsing: reference/recipe-brain-verdict-parsing.md
+    - OODA Binary-Identity Reload Gate: reference/ooda-binary-identity-reload-gate.md
+    - Distill Recipe-Output Capture: reference/distill-recipe-output-capture.md
+    - Base-Type Adapters: reference/base-type-adapters.md
+    - Memory Introspection CLI: reference/simard-memory-cli.md
+    - Cognitive-Memory Provenance (DERIVES_FROM): reference/cognitive-memory-provenance.md
+    - Cognitive-Memory Bootstrap Procedures: reference/cognitive-memory-bootstrap-procedures.md
+    - Cognitive-Memory Bridge Helpers: reference/cognitive-memory-bridge-helpers.md
+    - Cognitive-Memory Preparation Filters: reference/cognitive-memory-preparation-filters.md
+    - Cognitive-Memory Fact Recall: reference/cognitive-memory-fact-recall.md
+    - Cognitive-Memory Ranked Recall: reference/cognitive-memory-ranked-recall.md
+    - Cognitive-Memory Episodic Recall: reference/cognitive-memory-episodic-recall.md
+    - Cognitive-Memory Ranked Episodic Recall: reference/cognitive-memory-ranked-episodic-recall.md
+    - Cognitive-Memory Procedural Idempotency: reference/cognitive-memory-procedural-idempotency.md
+    - Cognitive-Memory Goal Store (superseded): reference/cognitive-memory-goal-store.md
+    - Backup-Pruning API: reference/backup-pruning-api.md
     - Episode Ingestion Classifier API: reference/episode-ingestion-classifier.md
     - Automatic Distillation Scheduler API: reference/automatic-distillation-scheduler.md
     - Procedural-Learning Loop API: reference/procedural-learning-loop.md
-    - Goal-board prospective reconcile: reference/goal-board-prospective-reconcile.md
-    - Runtime Contracts: reference/runtime-contracts.md
-    - Operator Read State-Root Contract: reference/operator-read-state-root-contract.md
-    - Bridge Wire Protocol: reference/bridge-wire-protocol.md
-    - Dashboard E2E Tests: reference/dashboard-e2e-tests.md
-    - Recipe Context Var Sanitization: reference/recipe-context-var-sanitization.md
-    - File-backed Goal Store: reference/file-backed-goal-store.md
-    - Adaptive Scaling API: reference/adaptive-scaling-api.md
+    - Prospective-Trigger Firing: reference/prospective-trigger-firing.md
+    - Goal-Board Prospective Reconcile: reference/goal-board-prospective-reconcile.md
+    - Goal–Prospective Memory Mirror: reference/goal-prospective-memory-mirror.md
+    - File-Backed Goal Store: reference/file-backed-goal-store.md
+    - Goal-Board API: reference/goal-board-api.md
+    - Goal-Board Corruption-Guard API: reference/goal-board-corruption-guard-api.md
+    - Goal Decomposition & Goal Graph: reference/goal-decomposition.md
     - Goal Target-Repo Routing: reference/goal-target-repo-routing.md
     - Goal Coverage Allocation: reference/goal-coverage-allocation.md
+    - spawn_agent_for_goal API: reference/spawn-agent-for-goal.md
+    - Stewardship API: reference/stewardship-api.md
     - Maximum Safe Parallelism: reference/maximum-safe-parallelism.md
     - Concurrent Engineer Dispatch: reference/concurrent-engineer-dispatch.md
+    - Engineer Copilot Permissions: reference/engineer-copilot-permissions.md
+    - Engineer Worktree Isolation: reference/engineer-worktree-isolation.md
+    - Subagent Tmux Tracking: reference/subagent-tmux-tracking.md
+    - Terminal Session Idle Detection: reference/terminal-session-idle-detection.md
+    - Agent-Log WebSocket API: reference/agent-log-websocket.md
     - PR-Finalization Review Pipeline: reference/pr-finalization-pipeline.md
     - Cross-Repo Merge Authority: reference/cross-repo-merge-authority.md
-    - Pluggable Identity API: reference/pluggable-identity-api.md
+    - Completion-Evidence Gate API: reference/completion-evidence-gate-api.md
+    - Progress-Evidence API: reference/progress-evidence-api.md
+    - Trustworthy-Confidence API: reference/trustworthy-confidence-api.md
+    - External-Signal Completion Gate: reference/external-signal-completion-gate.md
+    - Meeting Backend API: reference/meeting-backend-api.md
+    - LightweightChatSession: reference/lightweight-chat-session.md
+    - Copilot Meeting Mode: reference/copilot-meeting-mode.md
     - Meeting Close Lifecycle: reference/meeting-close-lifecycle.md
-    - Azure DevOps ACL Self-Escalation Guard: reference/ado-acl-self-escalation-guard.md
+    - Meeting Handoff Schema: reference/meeting-handoff-schema.md
+    - Handoff Lifecycle API: reference/handoff-lifecycle-api.md
+    - Pluggable Identity API: reference/pluggable-identity-api.md
+    - Adaptive Scaling API: reference/adaptive-scaling-api.md
     - Brain Introspection API: reference/brain-introspection-api.md
     - Self-Quality-Audit API: reference/self-quality-audit-api.md
+    - Disk-Health API: reference/disk-health-api.md
+    - Dashboard E2E Tests: reference/dashboard-e2e-tests.md
     - Dashboard Action-Detail Humanization: reference/dashboard-action-detail-humanization.md
+    - Azlin Hosts Self-Membership: reference/azlin-hosts-self-membership.md
+    - Azure DevOps ACL Self-Escalation Guard: reference/ado-acl-self-escalation-guard.md
     - Supply-Chain Audit & Guardrails: reference/supply-chain-audit.md
     - Dependency Trust Policy: reference/dependency-trust-policy.md
     - Release Integrity (SBOM + Signing): reference/release-integrity.md
-    - Recipe-brain Verdict/Decision Parsing: reference/recipe-brain-verdict-parsing.md
-    - OODA Binary-Identity Reload Gate: reference/ooda-binary-identity-reload-gate.md
-    # Hidden from nav until issue #1590 implementation lands:
-    #   - reference/cognitive-memory-bridge-helpers.md
-    #   - reference/goal-board-api.md
-    #   - concepts/goal-board-persistence.md (rewritten as spec)
-    #   - howto/recover-goal-board.md (rewritten as spec)
-    #   - howto/clean-fixture-leaks.md (#1923 / #1925 — graduates with the rest)
-    #   - testing/hermetic-tests.md (#1923 / #1925 — graduates with the rest)
+  - Operations:
+    - Overview: operations/index.md
+    - Verified Backups of the Live Store: operations/verified-backups.md
+    - Cognitive-Memory Durability: operations/cognitive-memory-durability.md
+    - Meeting REPL & Handoff Ingestion: operations/meeting-handoffs.md
+    - Progress-Evidence Kill Switch: operations/progress-evidence-kill-switch.md
+    - Safe Self-Update: safe-self-update.md
+    - Pre-Commit Setup: operations/pre-commit-setup.md
+  - Operator Dashboard:
+    - Azlin Tmux Sessions Panel: operator-dashboard/azlin-tmux-sessions.md
+    - Event-Bus Stats in Cluster Topology: operator-dashboard/event-bus-stats.md
+    - Hive Event Bus: hive_event_bus/README.md
+  - Testing:
+    - Test-Coverage Baseline: testing/COVERAGE_BASELINE.md
+    - CI-Resilient Test Patterns: testing/ci-resilient-test-patterns.md
+    - Writing Hermetic Tests: testing/hermetic-tests.md
+    - serial(cognitive_memory) Isolation: testing/cognitive-memory-serial-isolation.md
+    - De-Flaking Known Flaky Tests: testing/deflaking-known-flaky-tests.md
+  - Ecosystem & Audits:
+    - Amplihack Ecosystem Map: ecosystem-map.md
+    - amplihack-rs ↔ amplihack Parity Matrix: amplihack-rs-parity.md
+    - amplihack String Audit: amplihack-string-audit.md
+    - Fail-Open Audit: fail-open-audit.md

--- a/scripts/verify-docs.sh
+++ b/scripts/verify-docs.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+# verify-docs.sh — Executable acceptance tests for the documentation audit (issue #2307).
+#
+# TDD gate for the "clean, update, and improve Simard docs to reflect current
+# reality" goal. Each test encodes one acceptance criterion and prints PASS/FAIL.
+# The script runs ALL tests (it does not stop at the first failure) and exits
+# non-zero if any test fails, so CI and humans see the full picture at once.
+#
+# Scope: docs-only. This harness never mutates the repo; it only inspects the
+# working tree, the git diff vs the base ref, and the mkdocs build.
+#
+# Usage:
+#   scripts/verify-docs.sh                 # verify vs origin/main
+#   BASE_REF=origin/main scripts/verify-docs.sh
+#   SKIP_MKDOCS=1 scripts/verify-docs.sh   # skip the mkdocs --strict gate (T3)
+#
+# Env:
+#   BASE_REF      base ref the docs branch was cut from (default: origin/main)
+#   SKIP_MKDOCS   set to 1 to skip the mkdocs --strict build gate (T3)
+
+set -uo pipefail
+
+# --- Locate repo root --------------------------------------------------------
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+  echo "ERROR: not inside a git repository" >&2
+  exit 2
+}
+cd "$REPO_ROOT"
+
+BASE_REF="${BASE_REF:-origin/main}"
+
+# --- Result tracking ---------------------------------------------------------
+FAILURES=0
+PASSES=0
+
+section() { printf '\n=== %s ===\n' "$1"; }
+pass()    { PASSES=$((PASSES + 1));    printf '  PASS  %s\n' "$1"; }
+fail()    { FAILURES=$((FAILURES + 1)); printf '  FAIL  %s\n' "$1"; }
+info()    { printf '        %s\n' "$1"; }
+
+# Resolve the base ref; if origin/main is not a local ref, fall back to HEAD~
+# comparisons are skipped for scope tests but PRD/front-matter still run.
+if ! git rev-parse --verify --quiet "$BASE_REF" >/dev/null; then
+  echo "WARNING: base ref '$BASE_REF' not found locally; trying to fetch..." >&2
+  git fetch --quiet origin main 2>/dev/null || true
+fi
+BASE_OK=0
+if git rev-parse --verify --quiet "$BASE_REF" >/dev/null; then
+  BASE_OK=1
+fi
+
+# Changed docs (vs base). Populated only when BASE_OK.
+CHANGED_DOCS=()
+if [ "$BASE_OK" -eq 1 ]; then
+  while IFS= read -r f; do
+    [ -n "$f" ] && CHANGED_DOCS+=("$f")
+  done < <(git diff --name-only "$BASE_REF"...HEAD -- 'docs/**/*.md' 'docs/*.md' 2>/dev/null)
+fi
+
+# =============================================================================
+# T1 — HARD CONSTRAINT: the PRD is preserved byte-for-byte.
+# =============================================================================
+section "T1  PRD preserved byte-for-byte (Specs/ProductArchitecture.md)"
+PRD="Specs/ProductArchitecture.md"
+if [ ! -s "$PRD" ]; then
+  fail "PRD missing or empty at $PRD"
+else
+  pass "PRD present and non-empty"
+  if [ "$BASE_OK" -eq 1 ]; then
+    if git diff --quiet "$BASE_REF" -- "$PRD"; then
+      pass "PRD is byte-for-byte identical to $BASE_REF"
+    else
+      fail "PRD DIFFERS from $BASE_REF — the PRD must not be edited"
+      git --no-pager diff --stat "$BASE_REF" -- "$PRD" | sed 's/^/        /'
+    fi
+  else
+    info "SKIP diff check: base ref $BASE_REF unavailable"
+  fi
+fi
+
+# =============================================================================
+# T2 — Change scope is docs-only (no source/behavior changes).
+# =============================================================================
+section "T2  Change scope is docs-only vs $BASE_REF"
+if [ "$BASE_OK" -eq 1 ]; then
+  OUT_OF_SCOPE=()
+  while IFS= read -r path; do
+    [ -z "$path" ] && continue
+    case "$path" in
+      docs/*) ;;
+      mkdocs.yml) ;;
+      .github/workflows/docs.yml) ;;
+      scripts/verify-docs.sh) ;;
+      *) OUT_OF_SCOPE+=("$path") ;;
+    esac
+  done < <(git diff --name-only "$BASE_REF"...HEAD)
+  if [ "${#OUT_OF_SCOPE[@]}" -eq 0 ]; then
+    pass "all changed paths are within docs-only allowlist"
+  else
+    fail "out-of-scope changes detected (docs-only constraint violated):"
+    for p in "${OUT_OF_SCOPE[@]}"; do info "$p"; done
+  fi
+else
+  info "SKIP: base ref $BASE_REF unavailable"
+fi
+
+# =============================================================================
+# T3 — mkdocs --strict build (authoritative link/nav/orphan integrity gate).
+#      Under --strict, the validation warnings configured in mkdocs.yml
+#      (nav.omitted_files, links.not_found, anchors, ...) become hard errors.
+# =============================================================================
+section "T3  mkdocs build --strict (link + nav + anchor integrity)"
+if [ "${SKIP_MKDOCS:-0}" = "1" ]; then
+  info "SKIPPED via SKIP_MKDOCS=1"
+elif ! command -v mkdocs >/dev/null 2>&1; then
+  fail "mkdocs not installed — cannot run the authoritative discoverability gate"
+  info "install with: pip install mkdocs-material pymdown-extensions"
+else
+  MK_LOG="$(mktemp)"
+  if mkdocs build --strict >"$MK_LOG" 2>&1; then
+    pass "mkdocs build --strict succeeded (0 broken links, 0 orphaned nav pages)"
+  else
+    fail "mkdocs build --strict FAILED"
+    grep -iE 'warning|error|not found|omitted|anchor' "$MK_LOG" | grep -viE 'material for mkdocs|mkdocs 2.0|backward-incompat|plugin system|theming system|migration path|contribution model|unlicensed|our full analysis' | tail -30 | sed 's/^/        /'
+  fi
+  rm -f "$MK_LOG"
+fi
+
+# =============================================================================
+# T4 — No orphaned docs: every docs/**/*.md is referenced in mkdocs.yml nav.
+#      Explicit belt-and-suspenders check independent of the mkdocs config,
+#      so flipping validation.nav.omitted_files to "ignore" cannot hide orphans.
+# =============================================================================
+section "T4  No orphaned docs (every docs/*.md appears in mkdocs.yml nav)"
+if [ ! -f mkdocs.yml ]; then
+  fail "mkdocs.yml not found"
+else
+  # Extract docs-relative *.md tokens referenced anywhere in mkdocs.yml.
+  NAV_REFS="$(grep -oE '[A-Za-z0-9_./-]+\.md' mkdocs.yml | sort -u)"
+  ORPHANS=()
+  while IFS= read -r doc; do
+    rel="${doc#docs/}"
+    if ! printf '%s\n' "$NAV_REFS" | grep -qxF "$rel"; then
+      ORPHANS+=("$rel")
+    fi
+  done < <(find docs -type f -name '*.md' | sort)
+  if [ "${#ORPHANS[@]}" -eq 0 ]; then
+    pass "0 orphaned pages — all docs reachable from nav"
+  else
+    fail "${#ORPHANS[@]} orphaned doc(s) not referenced in mkdocs.yml nav:"
+    for o in "${ORPHANS[@]}"; do info "$o"; done
+  fi
+fi
+
+# =============================================================================
+# T5 — De-fork accuracy: the removed NativeCognitiveMemory symbol may appear in
+#      docs ONLY when framed as history (de-fork #2307), never as current fact.
+# =============================================================================
+section "T5  Removed symbol NativeCognitiveMemory is framed as history"
+STALE_SYMBOL="NativeCognitiveMemory"
+MARKER='#2307|de-fork|de-forked|removed|deleted|superseded|no longer|former|formerly|historical|history|replaced|retired'
+UNFRAMED=()
+while IFS= read -r doc; do
+  [ -z "$doc" ] && continue
+  if ! grep -qiE "$MARKER" "$doc"; then
+    UNFRAMED+=("$doc")
+  fi
+done < <(grep -rlF "$STALE_SYMBOL" docs --include='*.md' 2>/dev/null | sort)
+MENTION_COUNT="$(grep -rlF "$STALE_SYMBOL" docs --include='*.md' 2>/dev/null | wc -l | tr -d ' ')"
+if [ "${#UNFRAMED[@]}" -eq 0 ]; then
+  pass "all $MENTION_COUNT page(s) mentioning $STALE_SYMBOL frame it as removed history"
+else
+  fail "${#UNFRAMED[@]} page(s) mention $STALE_SYMBOL without history framing:"
+  for u in "${UNFRAMED[@]}"; do info "$u"; done
+fi
+
+# =============================================================================
+# T6 — Source-claim verification: the reality the docs describe holds in src.
+#      Guards against docs referencing deleted things or missing shipped ones.
+# =============================================================================
+section "T6  Documented claims verify against the source tree"
+
+assert_path_exists() {  # $1 path  $2 description
+  if [ -e "$1" ]; then pass "$2 ($1 exists)"; else fail "$2 — expected path missing: $1"; fi
+}
+assert_grep_present() { # $1 pattern  $2 pathspec  $3 description
+  if git grep -qE "$1" -- $2 2>/dev/null; then pass "$3"; else fail "$3 — pattern not found: /$1/ in $2"; fi
+}
+assert_grep_absent() {  # $1 pattern  $2 pathspec  $3 description
+  if git grep -qE "$1" -- $2 2>/dev/null; then fail "$3 — pattern unexpectedly present: /$1/ in $2"; else pass "$3"; fi
+}
+
+# self-deploy (#2467) and self-relaunch
+assert_path_exists "src/self_deploy"            "self-deploy module present (#2467)"
+assert_path_exists "src/self_relaunch"          "self-relaunch module present"
+# shared recipe_output extractor chokepoint (#2504 launch-preamble stripping)
+assert_path_exists "src/recipe_output/extract.rs" "shared recipe_output extractor present (#2504)"
+# base-type adapters shipping
+assert_grep_present "base_type_rustyclawd" "src"       "rusty-clawd base-type adapter present"
+assert_grep_present "base_type_copilot"    "src"       "copilot-sdk base-type adapter present"
+# goal-board cross-process write-lock (#2511 / #2514)
+assert_grep_present "libc::flock" "src/goals/store.rs" "goal-store cross-process flock present (#2511/#2514)"
+# de-fork #2307: native fork deleted, amplihack-memory-lib + lbug 0.17.1 is sole backend
+assert_grep_absent  "struct[[:space:]]+NativeCognitiveMemory" "src" "NativeCognitiveMemory fork deleted from src (#2307)"
+assert_grep_present "amplihack-memory"   "Cargo.toml"          "amplihack-memory-lib dependency pinned"
+assert_grep_present 'lbug[[:space:]]*=[[:space:]]*"=0\.17\.1"' "Cargo.toml" "lbug pinned to =0.17.1"
+# RecipeBrain abstraction present
+assert_grep_present "struct[[:space:]]+RecipeBrain" "src" "RecipeBrain abstraction present"
+
+# =============================================================================
+# T7 — Front-matter correctness on every touched doc page.
+#      Requires last_updated (ISO date), owner, and doc_type. The site home
+#      (docs/index.md) is exempt from doc_type by Diataxis landing-page convention.
+# =============================================================================
+section "T7  Front-matter on touched pages (last_updated, owner, doc_type)"
+if [ "$BASE_OK" -eq 1 ]; then
+  if [ "${#CHANGED_DOCS[@]}" -eq 0 ]; then
+    info "no changed docs vs $BASE_REF"
+  fi
+  FM_BAD=0
+  for f in "${CHANGED_DOCS[@]}"; do
+    [ -f "$f" ] || continue   # skip deleted files
+    problems=""
+    # Front-matter must be a leading YAML block delimited by --- on line 1.
+    if [ "$(head -1 "$f")" != "---" ]; then
+      problems="${problems} missing-frontmatter-block"
+    else
+      grep -qE '^last_updated:[[:space:]]*[0-9]{4}-[0-9]{2}-[0-9]{2}' "$f" || problems="${problems} last_updated"
+      grep -qE '^owner:[[:space:]]*\S' "$f" || problems="${problems} owner"
+      if [ "$f" != "docs/index.md" ]; then
+        grep -qE '^doc_type:[[:space:]]*\S' "$f" || problems="${problems} doc_type"
+      fi
+    fi
+    if [ -n "$problems" ]; then
+      fail "$f — missing/invalid:${problems}"
+      FM_BAD=$((FM_BAD + 1))
+    fi
+  done
+  if [ "$FM_BAD" -eq 0 ] && [ "${#CHANGED_DOCS[@]}" -gt 0 ]; then
+    pass "all ${#CHANGED_DOCS[@]} touched page(s) have valid front-matter"
+  fi
+else
+  info "SKIP: base ref $BASE_REF unavailable"
+fi
+
+# =============================================================================
+# Summary
+# =============================================================================
+section "Summary"
+printf '  %d passed, %d failed\n' "$PASSES" "$FAILURES"
+if [ "$FAILURES" -gt 0 ]; then
+  printf '\nDOCS VERIFICATION FAILED (%d check[s]).\n' "$FAILURES"
+  exit 1
+fi
+printf '\nDOCS VERIFICATION PASSED.\n'
+exit 0


### PR DESCRIPTION
## Summary

Cleans, updates, and improves Simard's documentation so `docs/` reflects the **current** reality of the codebase. Every changed claim was verified against the source on `main` before writing — no aspirational or point-in-time ("as of N reports") content.

**Docs-only.** No `src/` behavior changes. The PRD at `Specs/ProductArchitecture.md` is preserved **byte-for-byte** (verified by the acceptance gate).

The full change index — what changed and why, each mapped to the source it was verified against — lives in **[`docs/whats-changed.md`](../blob/feat/issue-2307-goal-development-rysweetsimard-clean-update-and-im/docs/whats-changed.md)**.

## What changed

1. **De-fork #2307 (cognitive memory).** `NativeCognitiveMemory` was deleted; the sole backend is now `LibraryCognitiveMemory` over `amplihack-memory-lib` (`lbug =0.17.1`). Reconciled the cognitive-memory architecture/reference/operations pages; any remaining `NativeCognitiveMemory` mention is now framed explicitly as removed history. Corrected `bridge-pattern.md`'s stale "Python-bridge / LadybugDB-transaction" durability story to the in-process adapter + single-writer IPC guard + `memory_backup` verified backups.
2. **OODA + the three RecipeBrains.** `OodaBrain` (engineer-lifecycle/act), `OodaDecideBrain` (decide), `OodaOrientBrain` (orient), all implemented by `RecipeBrain` with deterministic fallbacks. Replaced the point-in-time "as of this PR" wording in `ooda-brain-api.md` with a durable description tied to `dispatch_spawn_engineer`.
3. **Shipped features documented & source-verified.** self-deploy (#2467) + self-relaunch, goal-board cross-process write-lock (`libc::flock`, #2511/#2514), shared `recipe_output` extractor chokepoint / Copilot launch-preamble stripping (#2504/#2496), and the base-type adapters (`base_type_rustyclawd` + `base_type_copilot` shipping; `claude-agent-sdk` / `ms-agent` structural).
4. **Discoverability.** 118 previously-orphaned pages added to `mkdocs.yml` nav under logical sections; `docs/index.md` refreshed; a native MkDocs `validation` block makes `mkdocs build --strict` fail on future orphans/dead-anchors. Result: **0 orphaned pages, 0 broken internal links.**
5. **Front-matter.** Corrected `last_updated` / `owner` / `doc_type` on every touched page (Diataxis doc types).

## Verification

`scripts/verify-docs.sh` is an executable acceptance gate encoding each criterion. **17/17 pass:**

- **T1** PRD byte-for-byte identical to `origin/main`
- **T2** change scope is docs-only
- **T3** `mkdocs build --strict` (links + nav + anchors)
- **T4** zero orphaned docs
- **T5** `NativeCognitiveMemory` only appears framed as history
- **T6** documented claims verify against `src/` (self_deploy, self_relaunch, recipe_output/extract.rs, base-type adapters, goal-store flock, de-fork, lbug pin, RecipeBrain)
- **T7** front-matter valid on all 26 touched pages

Pre-push gates (fmt, clippy, cognitive-memory/memory_ipc test subset) all pass.

## Constraint compliance

- ✅ PRD `Specs/ProductArchitecture.md` unchanged; divergences are documented in `docs/` as current reality, never by editing the PRD.
- ✅ Every claim verified against source; no point-in-time snapshots.
- ✅ Docs-only; merge-ready.

Closes #2307.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>