### PR TITLE
fix(ooda): clamp SIMARD_OODA_INTERVAL_SECS=0 + re-apply lost reload-gate hardening (Wave 4, #2432)

### DIFF
--- a/docs/reference/ooda-binary-identity-reload-gate.md
+++ b/docs/reference/ooda-binary-identity-reload-gate.md
@@ -118,9 +118,13 @@ in-place replace, `std::env::current_exe()` resolves to the NEW bytes, so
 re-hashing it at check time would compare the new file against itself and never
 detect a change. The startup-pinned hash still identifies the OLD image the
 process is actually running, so a later on-disk hash that differs from it is a
-genuine new image. Pinning at startup (rather than lazily on the first check)
-also closes the window in which a replace between `exec` and the first cycle
-could be mistaken for the running image.
+genuine new image. Pinning at startup (rather than lazily on the first cycle
+check) also **narrows** the window in which a replace between `exec` and the
+capture call could be mistaken for the running image. It does not fully close
+it — the hash is read from the on-disk path, so a replace that lands before the
+startup capture still poisons the pinned identity — but the effect is bounded:
+the next genuinely-different rebuild bumps both mtime and content hash and the
+daemon reloads.
 
 Comparing the on-disk (untrusted) bytes against the startup-pinned (trusted)
 running hash also means the gate detects a tampered swap that an mtime
@@ -156,7 +160,7 @@ pub fn file_content_hash(path: &Path) -> Option<String>;
 pub fn running_image_hash() -> Option<&'static str>;
 
 /// Pin the running-image hash at a known-early point (daemon startup),
-/// closing the exec→first-check window. Idempotent.
+/// narrowing (not fully closing) the exec→first-check window. Idempotent.
 pub fn capture_running_image_hash();
 
 /// Pure reload decision (unit-tested in isolation): `true` only when the on-disk
@@ -205,17 +209,17 @@ if auto_reload && binary_changed(start_time) {
 | Variable / flag | Default | Purpose |
 | --- | --- | --- |
 | `--no-auto-reload` | (auto-reload **on**) | CLI flag to `simard ooda run` that disables auto-reload entirely — the daemon never relaunches itself regardless of on-disk changes. |
-| `SIMARD_OODA_INTERVAL_SECS` | `300` | Cycle interval. Also the cadence at which the reload gate is evaluated. An unparseable/empty value falls back to `300`; **range-clamping of `0` and oversized values is the Wave 4 daemon-safety hardening target and is not yet in place** (see below). |
+| `SIMARD_OODA_INTERVAL_SECS` | `300` | Cycle interval. Also the cadence at which the reload gate is evaluated. An unparseable/empty value **or `0`** falls back to `300` (Wave 4): a `0` interval would busy-loop the daemon, so it is clamped. An oversized value is honoured verbatim (a long sleep is harmless). |
 
-`SIMARD_OODA_INTERVAL_SECS` is read as
-`std::env::var(...).ok().and_then(|v| v.parse().ok()).unwrap_or(300)` on `main`
-today: a non-numeric or empty value falls back to the `300` default, but `0` and
-absurdly large values currently parse successfully and are accepted verbatim. A
-value of `0` would busy-spin the loop — evaluating the reload gate and every
-other per-cycle check with no sleep. Clamping this knob to a safe range is the
-**Wave 4** daemon-correctness/safety hardening item (`daemon-correctness-safety`,
-R3); it is specified here for context but is not part of the Wave 2 reload-gate
-change.
+`SIMARD_OODA_INTERVAL_SECS` is parsed by
+`ooda_interval_secs_from_env` (daemon/helpers.rs): a value that parses as `u64`
+and is **> 0** is honoured (whitespace-trimmed); unset, empty, non-numeric, or
+`0` all fall back to `DEFAULT_OODA_INTERVAL_SECS` (300). Clamping `0` (Wave 4)
+prevents the zero-delay busy loop — `interruptible_sleep(Duration::ZERO, …)`
+returns immediately, so a `0` interval would evaluate the reload gate and every
+other per-cycle check back-to-back with no pause. This mirrors the sibling
+`backup_interval_secs_from_env` guard. An absurdly large value is not clamped: it
+merely sleeps a long time, which is harmless.
 
 Auto-reload continuing to be *enabled* is correct; the fix is to stop it firing
 on identical content, not to turn it off. Operators who want a fully static

--- a/src/operator_commands_ooda/daemon/helpers.rs
+++ b/src/operator_commands_ooda/daemon/helpers.rs
@@ -22,6 +22,26 @@ pub fn daemon_log(state_root: &std::path::Path, msg: &str) {
     }
 }
 
+/// Default OODA cycle interval (seconds) when `SIMARD_OODA_INTERVAL_SECS` is
+/// unset, empty, non-numeric, or `0`. A `0`/absent interval would busy-loop the
+/// daemon — running full OODA cycles back-to-back with no pause, because
+/// `interruptible_sleep(Duration::ZERO, …)` returns immediately — which is never
+/// intended. Mirrors `backup::backup_interval_secs_from_env`.
+pub const DEFAULT_OODA_INTERVAL_SECS: u64 = 300;
+
+/// Parse `SIMARD_OODA_INTERVAL_SECS` into a SAFE cycle interval. A parseable
+/// value **> 0** is honoured (leading/trailing whitespace trimmed); anything
+/// else — unset, empty, non-numeric, or `0` — falls back to
+/// [`DEFAULT_OODA_INTERVAL_SECS`]. Clamping `0` is what prevents the zero-delay
+/// busy loop (an oversized value merely sleeps a long time and is harmless, so it
+/// is intentionally left unclamped).
+pub fn ooda_interval_secs_from_env(raw: Option<&str>) -> u64 {
+    match raw.and_then(|v| v.trim().parse::<u64>().ok()) {
+        Some(n) if n > 0 => n,
+        _ => DEFAULT_OODA_INTERVAL_SECS,
+    }
+}
+
 /// Return the mtime of the currently-running executable, or `None` if it
 /// cannot be determined (e.g. the binary was deleted after launch).
 pub fn exe_mtime() -> Option<SystemTime> {
@@ -59,13 +79,31 @@ pub fn binary_changed(start_time: SystemTime) -> bool {
         // fail-closed: never relaunch on a guess.
         None => return false,
     };
+    // mtime pre-filter FIRST, so the expensive on-disk content hash is NOT
+    // computed on the steady-state hot path (this runs every cycle). Only when
+    // the mtime has actually advanced do we read + SHA-256 the (multi-MB) binary.
+    let on_disk_mtime = exe_mtime();
+    if !mtime_advanced(start_time, on_disk_mtime) {
+        return false;
+    }
     let on_disk_hash = current_exe_path().as_deref().and_then(file_content_hash);
     reload_decision(
         start_time,
-        exe_mtime(),
+        on_disk_mtime,
         on_disk_hash.as_deref(),
         running_hash,
     )
+}
+
+/// Whether the on-disk mtime is strictly newer than the image we started from —
+/// the cheap pre-filter that keeps the multi-MB content hash off the
+/// steady-state hot path. `None` (unreadable mtime) is fail-closed to `false`.
+///
+/// This is the same condition [`reload_decision`] applies internally; extracting
+/// it lets [`binary_changed`] skip computing the on-disk hash entirely when it is
+/// provably unnecessary (and lets that hot-path gate be unit-tested directly).
+fn mtime_advanced(start_time: SystemTime, on_disk_mtime: Option<SystemTime>) -> bool {
+    on_disk_mtime.is_some_and(|mtime| mtime > start_time)
 }
 
 // ── Wave 2: binary-identity reload gate (2026-07-02 operator-review #2) ──────
@@ -95,9 +133,11 @@ pub fn running_image_hash() -> Option<&'static str> {
         .as_deref()
 }
 
-/// Pin the running-image hash at a known-early point (daemon startup), closing
-/// the window in which an in-place replace between `exec` and the first reload
-/// check could otherwise be mistaken for the running image. Idempotent.
+/// Pin the running-image hash at a known-early point (daemon startup),
+/// narrowing the window in which an in-place replace between `exec` and this
+/// capture could otherwise be mistaken for the running image (it does not fully
+/// close it — the hash is read from the on-disk path — but the effect is
+/// bounded: the next genuinely-different rebuild reloads). Idempotent.
 pub fn capture_running_image_hash() {
     let _ = running_image_hash();
 }
@@ -379,6 +419,31 @@ mod tests {
             Some("a-different-hash"),
             RUNNING
         ));
+    }
+
+    // ── mtime_advanced (hot-path gate) ──────────────────────────────
+
+    #[test]
+    fn mtime_advanced_false_when_not_newer_so_hash_is_skipped() {
+        // The gate `binary_changed` uses to AVOID hashing the multi-MB binary on
+        // the steady-state hot path: an mtime not newer than start ⇒ no hash.
+        let start = SystemTime::now();
+        let older = start - Duration::from_secs(60);
+        assert!(!mtime_advanced(start, Some(older)));
+        assert!(!mtime_advanced(start, Some(start)));
+    }
+
+    #[test]
+    fn mtime_advanced_true_only_when_strictly_newer() {
+        let start = SystemTime::now();
+        let newer = start + Duration::from_secs(60);
+        assert!(mtime_advanced(start, Some(newer)));
+    }
+
+    #[test]
+    fn mtime_advanced_false_when_mtime_unreadable() {
+        // Fail-closed: an unreadable mtime must not provoke a content hash.
+        assert!(!mtime_advanced(SystemTime::now(), None));
     }
 
     // ── interruptible_sleep ─────────────────────────────────────────

--- a/src/operator_commands_ooda/daemon/mod.rs
+++ b/src/operator_commands_ooda/daemon/mod.rs
@@ -330,10 +330,8 @@ pub fn run_ooda_daemon(
         }
     }
 
-    let interval_secs: u64 = std::env::var("SIMARD_OODA_INTERVAL_SECS")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(300);
+    let interval_secs: u64 =
+        ooda_interval_secs_from_env(std::env::var("SIMARD_OODA_INTERVAL_SECS").ok().as_deref());
 
     daemon_log(
         &state_root,
@@ -385,13 +383,28 @@ pub fn run_ooda_daemon(
     // bumped the mtime, which was the ~40–45 min self-restart churn trigger
     // (2026-07-02 operator-review #2; see
     // docs/reference/ooda-binary-identity-reload-gate.md). Pinning it here
-    // (rather than lazily on the first check) closes the window where an
-    // in-place replace between exec and the first cycle could be mistaken for
-    // the running image.
+    // (rather than lazily on the first check) narrows the window where an
+    // in-place replace between exec and this call could be mistaken for the
+    // running image (the hash is read from the on-disk path, so a replace that
+    // lands before this line still poisons the pinned identity — but the effect
+    // is bounded: the next genuinely-different rebuild bumps mtime+hash and
+    // reloads).
     capture_running_image_hash();
 
     if auto_reload {
-        daemon_log(&state_root, "[simard] OODA daemon: auto-reload enabled");
+        // Make the LOGGED state match reality: if we could not hash our own
+        // image at startup, the content-identity gate fails closed and
+        // self-reload is disabled for this whole process. Say so, rather than
+        // logging "enabled" while silently never relaunching.
+        if running_image_hash().is_some() {
+            daemon_log(&state_root, "[simard] OODA daemon: auto-reload enabled");
+        } else {
+            daemon_log(
+                &state_root,
+                "[simard] OODA daemon: WARNING auto-reload requested but the running-image hash \
+                 is unavailable — self-reload is DISABLED for this process (fail-closed)",
+            );
+        }
     }
     let self_relaunch_interval = crate::self_deploy::restart::self_relaunch_min_interval_from_env(
         std::env::var(crate::self_deploy::restart::SELF_RELAUNCH_MIN_INTERVAL_ENV)
@@ -1098,12 +1111,30 @@ mod tests {
 
     #[test]
     fn ooda_interval_env_var_parsing() {
-        // Test the same parsing pattern used in run_ooda_daemon.
-        let parse = |val: &str| -> u64 { val.parse().ok().unwrap_or(300) };
-        assert_eq!(parse("60"), 60);
-        assert_eq!(parse("0"), 0);
-        assert_eq!(parse("not-a-number"), 300);
-        assert_eq!(parse(""), 300);
+        // Exercises the REAL helper (not a copy of the inline logic).
+        assert_eq!(ooda_interval_secs_from_env(Some("60")), 60);
+        // A `0` interval must clamp to the default — a zero-delay loop busy-spins
+        // the daemon (interruptible_sleep no-ops on Duration::ZERO). This is the
+        // Wave 4 fix; the prior test asserted `0 -> 0`, codifying the bug.
+        assert_eq!(
+            ooda_interval_secs_from_env(Some("0")),
+            DEFAULT_OODA_INTERVAL_SECS
+        );
+        assert_eq!(
+            ooda_interval_secs_from_env(Some("not-a-number")),
+            DEFAULT_OODA_INTERVAL_SECS
+        );
+        assert_eq!(
+            ooda_interval_secs_from_env(Some("")),
+            DEFAULT_OODA_INTERVAL_SECS
+        );
+        assert_eq!(
+            ooda_interval_secs_from_env(None),
+            DEFAULT_OODA_INTERVAL_SECS
+        );
+        // Whitespace is trimmed; a large value is honoured (a long sleep is harmless).
+        assert_eq!(ooda_interval_secs_from_env(Some("  120  ")), 120);
+        assert_eq!(ooda_interval_secs_from_env(Some("86400")), 86_400);
     }
 
     // ── DaemonDashboardConfig coverage from mod.rs perspective ───────


### PR DESCRIPTION
## Wave 4 of 5 — quality audit (daemon correctness / safety / error-handling)

### Primary fix (SEEK Finding 6): `SIMARD_OODA_INTERVAL_SECS=0` busy-loops the daemon
The cycle interval was parsed as `env.parse().ok().unwrap_or(300)`, which accepts `0`. A `0` interval makes `interruptible_sleep(Duration::ZERO, …)` return immediately, so the daemon runs full OODA cycles **back-to-back with no pause** — hammering the LLM/agent-spawn machinery and host. The sibling `backup_interval_secs_from_env` already guards this exact hazard; the main cycle interval was inconsistently unguarded.

- Extracted a tested `ooda_interval_secs_from_env(Option<&str>) -> u64` helper: a value that parses as `u64` and is **> 0** is honoured (whitespace-trimmed); unset/empty/non-numeric/`0` → `300`. An oversized value is intentionally left unclamped (a long sleep is harmless).
- **Rewrote the pre-existing `ooda_interval_env_var_parsing` test**, which had asserted `parse("0") == 0` — codifying the bug — to assert `0 → 300`.

### Also: re-applies Wave 2 (#2521) crusty-review hardening that never reached main
An automated self-merge landed PR #2521 at its **pre-crusty-review** commit, so two fixes I made after review were lost from `main`. Since this wave already touches the same files, it re-applies them:
- **`binary_changed`**: gate the ~55MB on-disk SHA-256 behind the mtime pre-filter (`mtime_advanced`) so the hash is **not** computed on the steady-state hot path (it was hashing every ~300s cycle — a High-severity perf regression). +3 unit tests.
- **daemon startup**: emit a WARN (instead of logging "auto-reload enabled") when the running-image hash is unavailable and self-reload is therefore disabled — so the logged state matches reality.
- **doc**: "closes" → "narrows" the exec→first-check window (accurate); mark the interval clamp implemented.

### Tests
`ooda_interval_env_var_parsing` (real helper: 0/empty/non-numeric/None → 300, whitespace-trimmed, large honoured); `mtime_advanced_*` (3, hot-path gate); existing `reload_decision`/`binary_changed`/`file_content_hash` suites (24 helpers tests total).