### PR TITLE
fix(safe_update,meeting,dashboard): char-boundary-safe truncation on recovery/UI paths (Wave 5, #2432)

### DIFF
--- a/src/meeting_backend/persist/extract.rs
+++ b/src/meeting_backend/persist/extract.rs
@@ -86,11 +86,30 @@ pub fn extract_action_items(messages: &[ConversationMessage]) -> Vec<HandoffActi
     items
 }
 
+/// ASCII-case-insensitive substring search returning the byte index **into
+/// `haystack`** (not a case-folded copy).
+///
+/// `sentence.to_lowercase().find(needle)` returns an index into the *lowercased*
+/// string, whose byte length can differ from the original (e.g. `İ` U+0130 is
+/// 2 bytes and lowercases to 3), so using that index to slice the ORIGINAL
+/// `sentence` both mis-extracts the text and can land off a UTF-8 char boundary
+/// and panic. Because `needle` here is pure ASCII, a match window can only
+/// consist of ASCII bytes, so the returned index (and `index + needle.len()`)
+/// are always valid char boundaries in `haystack` — the slice is panic-free.
+fn find_ascii_ci(haystack: &str, needle: &str) -> Option<usize> {
+    let h = haystack.as_bytes();
+    let n = needle.as_bytes();
+    if n.is_empty() || n.len() > h.len() {
+        return None;
+    }
+    (0..=h.len() - n.len()).find(|&i| h[i..i + n.len()].eq_ignore_ascii_case(n))
+}
+
 /// Try to extract an assignee from a sentence.
 pub(crate) fn extract_assignee(sentence: &str) -> Option<String> {
     let verbs = [" will ", " should ", " needs to ", " need to ", " must "];
     for verb in &verbs {
-        if let Some(idx) = sentence.to_lowercase().find(verb) {
+        if let Some(idx) = find_ascii_ci(sentence, verb) {
             let prefix = sentence[..idx].trim();
             if let Some(name) = prefix.split_whitespace().last() {
                 let clean = name.trim_matches(|c: char| !c.is_alphanumeric());
@@ -103,7 +122,7 @@ pub(crate) fn extract_assignee(sentence: &str) -> Option<String> {
             }
         }
     }
-    if let Some(idx) = sentence.to_lowercase().find("assigned to ") {
+    if let Some(idx) = find_ascii_ci(sentence, "assigned to ") {
         let after = &sentence[idx + "assigned to ".len()..];
         if let Some(name) = after.split_whitespace().next() {
             let clean = name.trim_matches(|c: char| !c.is_alphanumeric());
@@ -339,9 +358,13 @@ fn extract_decision_rationale(decision: &str, messages: &[ConversationMessage]) 
             // Check the preceding message for rationale context.
             if i > 0 {
                 let prev = &messages[i - 1].content;
-                // Truncate long rationale to keep handoff concise.
+                // Truncate long rationale to keep handoff concise. Char-boundary
+                // safe: `&prev[..297]` panics when byte 297 splits a multi-byte
+                // char, and message content is arbitrary user/agent text.
                 if prev.len() > 300 {
-                    return format!("{}…", &prev[..297]);
+                    let mut t = prev.clone();
+                    crate::util::string_truncate::truncate_to_char_boundary(&mut t, 297);
+                    return format!("{t}…");
                 }
                 return prev.clone();
             }
@@ -581,6 +604,35 @@ mod tests {
         assert_eq!(
             extract_assignee("task assigned to Charlie"),
             Some("Charlie".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_assignee_does_not_panic_on_case_folding_length_change() {
+        // The crash branch: a multibyte name AFTER "assigned to ". Under the old
+        // `sentence.to_lowercase().find(...)` code, 'İ' (U+0130, 2 bytes) folds to
+        // 3 bytes, so the index is shifted and `&sentence[idx + 12..]` slices mid-
+        // 'İ' in the ORIGINAL and PANICS. The ASCII-CI search indexes the original
+        // directly, so it is boundary-safe and extracts the right name.
+        assert_eq!(
+            extract_assignee("İ assigned to İbrahim"),
+            Some("İbrahim".to_string())
+        );
+        // Mis-extraction guard: with a multibyte char before the phrase the old
+        // code returned "ob" (index off by the fold-growth); the fix returns "Bob".
+        assert_eq!(
+            extract_assignee("İşi assigned to Bob"),
+            Some("Bob".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_assignee_matches_verb_case_insensitively() {
+        // The old code lowercased the whole sentence before matching; the ASCII-CI
+        // search must preserve that case-insensitive verb matching.
+        assert_eq!(
+            extract_assignee("Dana WILL ship it"),
+            Some("Dana".to_string())
         );
     }
 

--- a/src/operator_commands_dashboard/goals.rs
+++ b/src/operator_commands_dashboard/goals.rs
@@ -48,7 +48,11 @@ fn human_backlog_id(content: &str, concept: &str) -> String {
     if words.len() >= 2 {
         let slug = words.join(" ");
         if slug.len() > 50 {
-            format!("{}…", &slug[..50].trim_end())
+            // Char-boundary safe: `&slug[..50]` panics when byte 50 splits a
+            // multi-byte char, and the slug is arbitrary memory-graph title text.
+            let mut t = slug;
+            crate::util::string_truncate::truncate_to_char_boundary(&mut t, 50);
+            format!("{}…", t.trim_end())
         } else {
             slug
         }

--- a/src/safe_update/rollback.rs
+++ b/src/safe_update/rollback.rs
@@ -141,7 +141,15 @@ fn try_restart(argv: &[&str]) -> Option<String> {
         Ok(out) => {
             let stderr = String::from_utf8_lossy(&out.stderr);
             let tail = if stderr.len() > 800 {
-                format!("…{}", &stderr[stderr.len() - 800..])
+                // Char-boundary-safe tail: `&stderr[stderr.len() - 800..]` panics
+                // when that offset splits a multi-byte sequence, and
+                // `from_utf8_lossy` output routinely has 3-byte U+FFFD chars. This
+                // runs on the rollback recovery path, so a panic here aborts
+                // rollback finalization exactly when the system is already degraded.
+                format!(
+                    "…{}",
+                    crate::util::string_truncate::tail_within_budget(&stderr, 800)
+                )
             } else {
                 stderr.into_owned()
             };

--- a/src/util/string_truncate.rs
+++ b/src/util/string_truncate.rs
@@ -38,6 +38,33 @@ pub fn truncate_to_char_boundary(s: &mut String, max_bytes: usize) {
     s.truncate(idx);
 }
 
+/// Return the **suffix** of `s` whose byte length does not exceed `max_bytes`,
+/// advancing *forward* to the next UTF-8 char boundary when `s.len() - max_bytes`
+/// falls inside a multi-byte sequence.
+///
+/// The tail analog of [`truncate_to_char_boundary`], for the common "keep the
+/// last N bytes of this output" case (e.g. the tail of a failed command's
+/// stderr). Slicing `&s[s.len() - max_bytes..]` directly **panics** when that
+/// offset is mid-character — and `String::from_utf8_lossy` output routinely has
+/// multi-byte U+FFFD replacements, so the offset is frequently mid-char.
+///
+/// Properties:
+///
+/// - If `s.len() <= max_bytes` the whole string is returned.
+/// - Otherwise the result is a valid `&str` with `result.len() <= max_bytes`.
+/// - Never panics. `s.len()` is always a valid boundary, so the forward search
+///   terminates.
+pub fn tail_within_budget(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        return s;
+    }
+    let mut start = s.len() - max_bytes;
+    while start < s.len() && !s.is_char_boundary(start) {
+        start += 1;
+    }
+    &s[start..]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -170,5 +197,59 @@ mod tests {
         truncate_to_char_boundary(&mut s, 1);
         // Backs up to byte 0 (the only char boundary ≤ 1 in this prefix).
         assert_eq!(s, "");
+    }
+
+    // ── tail_within_budget ──────────────────────────────────────────
+
+    #[test]
+    fn tail_no_op_when_within_budget() {
+        assert_eq!(tail_within_budget("short", 1024), "short");
+        assert_eq!(tail_within_budget("exact", 5), "exact");
+    }
+
+    #[test]
+    fn tail_ascii_keeps_last_n_bytes() {
+        let s = "a".repeat(20);
+        assert_eq!(tail_within_budget(&s, 5), "aaaaa");
+        assert_eq!(tail_within_budget(&s, 5).len(), 5);
+    }
+
+    #[test]
+    fn tail_multibyte_at_boundary_does_not_panic() {
+        // Em-dash '—' is 3 bytes. Put one so that `len - max_bytes` lands mid-char.
+        let mut s = "b".repeat(20);
+        s.push('—'); // bytes 20,21,22
+        s.push_str(&"c".repeat(800));
+        // len = 20 + 3 + 800 = 823; len - 800 = 23 (a boundary here), so choose a
+        // budget that lands mid-em-dash: len - 801 = 22 is mid-'—'.
+        let out = tail_within_budget(&s, 801);
+        assert!(out.len() <= 801, "tail respects the byte budget");
+        assert!(
+            std::str::from_utf8(out.as_bytes()).is_ok(),
+            "tail is valid UTF-8"
+        );
+        // The partially-cut em-dash is dropped (forward to the next boundary).
+        assert!(!out.starts_with('\u{fffd}'));
+    }
+
+    #[test]
+    fn tail_from_utf8_lossy_replacement_char_does_not_panic() {
+        // Invalid bytes become 3-byte U+FFFD; a budget landing mid-replacement
+        // must not panic.
+        let mut raw = vec![b'x'; 10];
+        raw.push(0xFF);
+        raw.push(0xFE);
+        let owned = String::from_utf8_lossy(&raw).into_owned();
+        for budget in 1..owned.len() {
+            let out = tail_within_budget(&owned, budget);
+            assert!(std::str::from_utf8(out.as_bytes()).is_ok());
+            assert!(out.len() <= budget);
+        }
+    }
+
+    #[test]
+    fn tail_empty_string_no_op() {
+        assert_eq!(tail_within_budget("", 100), "");
+        assert_eq!(tail_within_budget("", 0), "");
     }
 }


### PR DESCRIPTION
## Wave 5 of 5 — quality audit (correctness / safety)

Closes out the **byte-index-slice-of-untrusted-UTF-8 panic class** (started in Wave 3). Four confirmed sites slice a string at a byte index that can fall off a UTF-8 char boundary → **panic**:

1. **`safe_update::rollback::try_restart`** — `&stderr[stderr.len() - 800..]` (a **tail** slice) on the **rollback recovery path**. `stderr` is `from_utf8_lossy` output whose 3-byte U+FFFD replacements routinely put a char across the offset; a panic here aborts rollback finalization exactly when the system is already degraded.
2. **`meeting_backend::persist::extract`** (rationale) — `&prev[..297]` on arbitrary conversation-message content.
3. **`operator_commands_dashboard::goals::human_backlog_id`** — `&slug[..50]` on arbitrary memory-graph title text; a panic takes down the dashboard render thread.
4. **`meeting_backend::persist::extract::extract_assignee`** — sliced the **original** `sentence` with a byte index from `sentence.to_lowercase()`. Case-folding can change byte length (`İ` U+0130: 2→3 bytes), so the index both **mis-extracts** and can land mid-char and **panic**. Replaced with an ASCII-case-insensitive search (`find_ascii_ci`) that returns a correct, boundary-safe index into the original. *(Found by the Wave 5 crusty review as a same-class hazard in the file; fixed here rather than deferred.)*

### Fixes
- Prefix sites reuse the existing tested `util::string_truncate::truncate_to_char_boundary`.
- The **tail** case needed a suffix analog: added `tail_within_budget(&str, max_bytes) -> &str` (advances forward to the next char boundary; never panics), with 5 new util tests incl. a U+FFFD-replacement fuzz over every budget.
- Added `extract_assignee` regression tests (case-folding-length-change name, "assigned to" branch, case-insensitive verb match).

ASCII behavior unchanged; the fix only eliminates the panic (and the mis-extraction) on non-ASCII input.