### PR TITLE
feat(conversation-channel,signal): one ConversationChannel abstraction + Signal channel (#2527)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3892,7 +3892,7 @@ dependencies = [
 
 [[package]]
 name = "simard"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "amplihack-agent-eval",
  "amplihack-memory",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simard"
-version = "0.24.0"
+version = "0.25.0"
 edition = "2024"
 default-run = "simard"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,11 @@ libc = "=0.2.185"
 [features]
 slow-tests = []
 dashboard-audit = ["dep:headless_chrome", "dep:regex", "dep:url"]
+# Issue #2527: the Signal conversation channel (`src/signal_conversation/`).
+# Default OFF so the daemon builds and runs with no signal-cli installed. The
+# transport reuses tokio `net` (already a dependency), so enabling this adds no
+# new mandatory dependency.
+signal = []
 
 [dev-dependencies]
 assert_cmd = "=2.2.1"

--- a/docs/architecture/conversation-channel.md
+++ b/docs/architecture/conversation-channel.md
@@ -1,0 +1,257 @@
+---
+title: Conversation channels
+description: One clearly-named operator↔Simard conversation abstraction — the ConversationChannel trait — with the CLI/TUI meeting REPL, the dashboard WebSocket chat, and Signal all implemented as thin channels over the same unified meeting engine.
+last_updated: 2026-07-03
+review_schedule: as-needed
+owner: simard
+doc_type: architecture
+issues: ["#2527"]
+related:
+  - ../index.md
+  - ./unified-meeting-backend.md
+  - ../reference/conversation-channel-api.md
+  - ../reference/signal-conversation.md
+  - ../reference/meeting-backend-api.md
+  - ../howto/start-a-meeting.md
+  - ../howto/set-up-the-signal-channel.md
+  - ../concepts/operational-autonomy-model.md
+---
+
+# Conversation channels
+
+A **meeting is a conversation.** Every operator↔Simard meeting — whether it
+happens in a terminal, in the dashboard chat pane, or over Signal — is the same
+bidirectional conversational session: an operator sends an inbound line, Simard
+delivers outbound replies and notices, the session opens and closes, and the
+structured capture commands (`/goal`, `/decision`, `/action`, `/question`, …)
+feed the meeting handoff and goal-carryover chain.
+
+`ConversationChannel` is the single, clearly-named abstraction for that session.
+Each frontend routes its structured-capture dispatch through the same shared
+applier over the one meeting engine
+([`MeetingBackend`](../reference/meeting-backend-api.md)):
+
+| Channel | How it uses the abstraction | Transport |
+|---------|-----------------------------|-----------|
+| CLI / TUI meeting REPL | delegates record/capture dispatch to the shared `apply_record` | stdin / stdout (ANSI) |
+| Dashboard chat | delegates record/capture dispatch to the shared `apply_record` | WebSocket JSON frames |
+| Signal | full `SignalConversation` impl driven by `run_conversation` | signal-cli JSON-RPC (feature-gated) |
+| Tests | full `MockConversationChannel` impl driven by `run_conversation` | scripted in-memory |
+
+> **Naming.** This abstraction is deliberately **not** called a "bridge." It is a
+> first-class chat/conversation abstraction. No new type, module, field, trait,
+> or feature introduced here contains `bridge`/`Bridge`. `SignalConversation`
+> does **not** implement the pre-existing memory `BridgeTransport` trait — that
+> trait is the cognitive-memory transport and is out of scope here. The
+> pre-existing `bridge*` modules (memory / knowledge / gym) are untouched.
+
+## Problem
+
+Before this abstraction, the two meeting frontends shared the engine but
+duplicated the *dispatch loop* around it:
+
+- **CLI/TUI REPL** (`src/meeting_repl/repl.rs`) — a blocking stdin/stdout loop
+  with its own `match parse_command(...)` arms, ANSI-colorized rendering, and
+  CLI-only post-record effects (`checkpoint_wip`, the live capture tally).
+- **Dashboard chat** (`src/operator_commands_dashboard/chat.rs`) — an async axum
+  WebSocket loop with a *second* `match parse_command(...)` that applied the same
+  backend mutations and produced the same message text, but rendered them as
+  `{"role":"system"}` JSON frames and wrapped the sync engine calls in
+  `tokio::task::spawn_blocking`.
+
+The backend mutation and the canonical message text were **identical** across the
+two loops; only rendering and the CLI-only post-effects differed. Divergence
+between the two copies was a standing risk, and there was no third channel path
+at all — an operator away from the terminal or dashboard had no way to command
+Simard or receive her notifications.
+
+## Solution
+
+### One trait, one shared applier, one driver
+
+`ConversationChannel` captures exactly the conversational session the meeting REPL
+already embodies:
+
+- **receive** an inbound operator message (`recv`),
+- **deliver** Simard's outbound messages/replies/notices (`send`),
+- **session lifecycle** (open by constructing the channel + a `MeetingBackend`;
+  close via the `/close` command through the shared driver),
+- **structured meeting capture** — `/goal /decision /action /question` … routed
+  through one shared applier into the existing handoff + goal-carryover chain.
+
+```
+                    ┌───────────────────────────┐
+   apply_record ───▶│  the ONE shared, pure      │◀─── delegated to by BOTH the
+   (record/capture) │  record/capture applier    │     CLI REPL and dashboard loops
+                    └───────────────────────────┘
+
+        recv() ──▶ ┌───────────────────────────┐
+ operator          │  run_conversation<C>()    │      ┌──────────────────┐
+        ◀── send() │  (the unified driver)     │─────▶│  MeetingBackend  │
+                   │   parse_command           │ sync │  (unchanged)     │
+                   │   apply_record (shared)   │◀─────│  send_message()  │
+                   │   on_recorded (per-chan)  │      │  close()         │
+                   └───────────────────────────┘      └──────────────────┘
+                     realized by:  SignalConversation · MockConversationChannel
+```
+
+- **`ConversationChannel`** (`src/conversation_channel/mod.rs`) — the trait plus
+  the render-agnostic message types `OperatorRef`, `Inbound`, `Outbound`,
+  `OutKind`.
+- **`apply_record`** (`.../dispatch.rs`) — the *pure, synchronous* applier that
+  performs a record command's backend mutation and returns the **canonical**
+  message text + `OutKind`. This is the provably-identical logic extracted from
+  the two loops exactly once. **Both** the CLI REPL and the dashboard chat loop now
+  call it for `/decision`, `/action`, `/goal`, `/question`, `/theme`, `/owner`,
+  `/risk`, and `/disagree`, so those captures are no longer divergent copies.
+- **`run_conversation<C: ConversationChannel>`** (`.../driver.rs`) — the single
+  loop that drives a channel end-to-end: `recv` → `parse_command` → route
+  conversation turns, records (via `apply_record`), the `on_recorded` hook, and
+  `/close`. It is realized by the new [`SignalConversation`](../reference/signal-conversation.md)
+  channel and by `MockConversationChannel`, and is available for any future
+  channel. The CLI REPL and dashboard keep their existing presentation loops (ANSI
+  color / spinners / capture tally, and WebSocket JSON frames respectively) — they
+  share the *capture* logic through `apply_record` rather than the whole loop.
+
+See the [Conversation channel API reference](../reference/conversation-channel-api.md)
+for the exact trait shape and types.
+
+### Behavior is preserved
+
+The refactor shares **only** the logic that was already identical across the two
+loops, and it changes **no observable behavior**. It is worth being precise about
+what "preserved" means:
+
+- **Record / capture commands** (`/decision`, `/action`, `/goal`, `/question`,
+  `/theme`, `/owner`, `/risk`, `/disagree`) are a **byte-for-byte** extraction:
+  their backend mutation and canonical acknowledgement text move verbatim into the
+  shared, pure `apply_record`, and **both** the CLI REPL and the dashboard chat loop
+  now call it instead of holding their own copy. The strings are identical, so the
+  existing tests stay green.
+- **Everything else stays in the frontend that owns it.** The CLI REPL and the
+  dashboard chat keep their own loops and their own rendering of read-only views
+  (`/status`, `/state`, `/recap`, `/preview`, `/help`) and of the I/O- or
+  LLM-bearing commands (`Conversation`, `Close`, `Export`, `Template`), because
+  those are presentation-specific (ANSI multi-line vs. WebSocket JSON) and are not
+  shared. Only the new `SignalConversation` and the mock drive those commands
+  through `run_conversation`.
+
+Everything a user can observe stays where it was:
+
+| Preserved behavior | Where it lives |
+|--------------------|----------------|
+| CLI ANSI colorization, spinners, drift-guard | `meeting_repl/repl.rs` (unchanged loop) |
+| CLI live capture tally + `checkpoint_wip` | `meeting_repl/repl.rs`, after the shared `apply_record` call |
+| Dashboard `{"role":"system"}` / `{"role":"assistant"}` JSON frames | `operator_commands_dashboard/chat.rs` (unchanged loop) |
+| Record mutation + canonical acknowledgement text | **shared** `apply_record`, called by both loops |
+| `MeetingCommand` grammar + `parse_command` | unchanged in `src/meeting_backend/command.rs` |
+| Handoff write + goal carryover | unchanged `default_handoff_dir()` → `check_meeting_handoffs` |
+
+The existing `meeting_repl` and `chat.rs` tests remain the **behavioral guard**:
+they run unchanged and stay green, proving the record extraction changed no
+observable output. `run_conversation` is covered by its own mock-driven tests and by
+the `SignalConversation` tests.
+
+### Async model — native `impl Future`, no new dependency
+
+The engine ([`MeetingBackend`](../reference/meeting-backend-api.md)) stays
+**synchronous and unchanged** (`send_message`, `close`). Channels need async I/O
+(the Signal socket), so `ConversationChannel` is an **async trait expressed with
+native return-position `impl Future`** (RPITIT) — for example
+`fn recv(&mut self) -> impl Future<Output = SimardResult<Option<Inbound>>> + Send`.
+
+This adds **no** dependency: the codebase has no `async-trait` crate and none is
+introduced. `run_conversation` calls the synchronous engine methods
+(`send_message` / `close` / `apply_template`) directly; each completes *before* the
+next `.await`, so no `&mut MeetingBackend` is ever held across an await point and the
+driver needs no `spawn_blocking`.
+
+## Module map
+
+```
+src/conversation_channel/
+  mod.rs        trait ConversationChannel + OperatorRef / Inbound / Outbound / OutKind
+  dispatch.rs   apply_record() + Recorded         (pure, synchronous, unit-tested)
+  driver.rs     run_conversation<C>()             (the unified driver)
+  mock.rs       MockConversationChannel           (scripted recv, captured sends)
+
+src/meeting_repl/repl.rs                    → CLI loop; delegates record dispatch to apply_record
+src/operator_commands_dashboard/chat.rs     → dashboard loop; delegates record dispatch to apply_record
+src/signal_conversation/                    → SignalConversation impls ConversationChannel (#[cfg(feature = "signal")])
+src/lib.rs                                  → pub mod conversation_channel;
+```
+
+The [Signal channel](../reference/signal-conversation.md) is an additional,
+optional (`signal` feature, default-off) implementation of the same trait; it is
+described in its own reference and how-to.
+
+## Session lifecycle
+
+The lifecycle below describes a channel driven by `run_conversation` (the
+`SignalConversation` and the mock). The CLI REPL and dashboard run their own loops
+but share step 2's record path via `apply_record`, and the same close/carryover
+chain.
+
+1. **Open** — a caller constructs a channel (`SignalConversation::new(transport,
+   handler, &config)` or `MockConversationChannel::with_script(...)`) and a
+   `MeetingBackend`, then calls `run_conversation(&mut channel, &mut backend)`.
+2. **Turn loop** — for each authorized inbound line:
+   - `Conversation(text)` → `backend.send_message(text)` →
+     `channel.send(Outbound { kind: Assistant, .. })`.
+   - a record/status command → `apply_record(&mut backend, &cmd)` →
+     `channel.send(Outbound { kind, text })`; for an actual capture (`OutKind::Recorded`)
+     the driver then fires `channel.on_recorded(&backend)`.
+   - `Export` / `Template` — driver-handled (file I/O and/or an LLM
+     context-injection turn), not `apply_record`.
+3. **Close** — `/close` → `backend.close()` → the summary is sent on the channel,
+   the loop ends. `close()` writes the handoff bundle exactly as before.
+4. **Carryover** — the handoff is written under `default_handoff_dir()` (which is
+   `$SIMARD_HANDOFF_DIR` when set, else `<state_root>/meeting_handoffs`, where
+   `<state_root>` is `$SIMARD_STATE_ROOT` or, by default, `~/.simard` — so the
+   out-of-the-box path is `~/.simard/meeting_handoffs`) and consumed
+   unchanged by `ooda_loop::curate::check_meeting_handoffs`, which promotes meeting
+   decisions/actions onto the goal board. This chain is **not** modified.
+
+## Security & autonomy boundary
+
+For the CLI and dashboard channels the operator is already local/authenticated
+(terminal ownership; the dashboard's existing auth middleware). The Signal channel
+introduces a remote command surface, so it carries three additional guardrails —
+a fail-closed sender **allowlist**, **operator-identity binding** (the authorized
+sender's E.164 is carried on `OperatorRef` and bound to command replies + sign-off),
+and **high-risk gating** that never auto-executes a mutating command from a text:
+`deploy`/`merge` create a pending sign-off and run only after an explicit `approve`,
+handed to the existing operational-autonomy authority through an injected handler.
+Those guardrails live in the Signal channel and are documented in the
+[Signal channel reference](../reference/signal-conversation.md). The abstraction
+itself carries only the `OperatorRef.authorized` flag that a channel sets after
+its own authorization check; the driver never dispatches an unauthorized inbound.
+
+## Testing
+
+- **`apply_record`** — one pure unit test per record command asserting the backend
+  mutation is applied and the canonical message text/kind is returned.
+- **`run_conversation`** — driven over `MockConversationChannel` with a scripted
+  `recv` sequence and captured `send`s; verifies conversation-turn routing, record
+  routing, the `on_recorded` hook firing, and clean close.
+- **Existing meeting tests** — the `meeting_repl` and dashboard `chat.rs` tests run
+  unchanged and stay green, proving the record delegation changed no output.
+- **Signal** — allowlist enforcement, high-risk gating (never auto-executing
+  `deploy`/`merge`; executing only after `approve`), config resolution, and the
+  JSON-RPC wire helpers are tested against a mock transport (no live signal-cli). See
+  the [Signal channel reference](../reference/signal-conversation.md#testing).
+
+## Related reading
+
+- [Conversation channel API reference](../reference/conversation-channel-api.md) —
+  the trait, message types, `apply_record`, `run_conversation`, and the mock.
+- [Signal channel reference](../reference/signal-conversation.md) — the
+  feature-gated `SignalConversation`, config, commands, notifications, guardrails.
+- [How to set up the Signal channel](../howto/set-up-the-signal-channel.md) —
+  linked-device / dedicated-number setup and configuration.
+- [Unified meeting backend](./unified-meeting-backend.md) — the shared engine every
+  channel drives.
+- [Meeting backend API reference](../reference/meeting-backend-api.md) — the sync
+  `MeetingBackend` API the channels wrap.
+- [Operational autonomy model](../concepts/operational-autonomy-model.md) — the
+  HIGH-RISK boundary the Signal channel routes mutating commands through.

--- a/docs/howto/set-up-the-signal-channel.md
+++ b/docs/howto/set-up-the-signal-channel.md
@@ -1,0 +1,219 @@
+---
+title: How to set up the Signal channel
+description: Connect Simard to Signal so an allowlisted operator can command her and receive notifications, using a locally-run signal-cli JSON-RPC daemon. Covers the signal feature build, linking a device (or using a dedicated number), configuration, the allowlist, and verification.
+last_updated: 2026-07-03
+review_schedule: as-needed
+owner: simard
+doc_type: howto
+issues: ["#2527"]
+related:
+  - ../index.md
+  - ../reference/signal-conversation.md
+  - ../architecture/conversation-channel.md
+  - ../reference/conversation-channel-api.md
+  - ../concepts/operational-autonomy-model.md
+  - ./start-a-meeting.md
+---
+
+# How to set up the Signal channel
+
+The Signal channel lets an allowlisted operator talk to Simard over Signal — issue
+lightweight commands (`status`, `approve`, `merge #NNNN`, …), hold a full meeting,
+and receive notifications (PR merge-ready, stalls, high-risk sign-off requests).
+
+Simard does not implement Signal herself. She connects to a locally-run
+[`signal-cli`](https://github.com/AsamK/signal-cli) daemon over JSON-RPC. This
+guide installs signal-cli, links or registers an account, builds Simard with the
+`signal` feature, configures the `[signal]` table, and verifies the round trip.
+
+For the full contract (config keys, commands, guardrails), see the
+[Signal channel reference](../reference/signal-conversation.md).
+
+## Prerequisites
+
+- [ ] You are in the repository root.
+- [ ] A Rust toolchain that builds Simard (`cargo build` already works).
+- [ ] `SIMARD_LLM_PROVIDER` configured (Signal meetings use the same engine — see
+      [How to start a meeting](./start-a-meeting.md)).
+- [ ] Java 21+ runtime (signal-cli requires it) — `java -version`.
+- [ ] A phone number for Simard's Signal identity: either an existing Signal
+      account you will **link** as a device, or a **dedicated** number to register.
+
+> The Signal channel is **optional and off by default.** If you skip this guide,
+> Simard's daemon runs exactly as before with no Signal code compiled in.
+
+## 1. Install signal-cli
+
+Install signal-cli from your package manager or the
+[release page](https://github.com/AsamK/signal-cli/releases). Verify:
+
+```bash
+signal-cli --version
+```
+
+## 2. Give signal-cli an account
+
+Choose **one** of the two setups.
+
+### Option A — Link as a device (recommended)
+
+Keep Simard as an extra **linked device** on your existing Signal account. Your
+phone stays the primary device.
+
+```bash
+signal-cli link -n "simard-daemon"
+```
+
+signal-cli prints a `sgnl://linkdevice?...` URI (and a QR code). On your phone:
+**Signal → Settings → Linked devices → Link new device**, then scan the QR (or use
+the URI). When linking finishes, note the account number (your own E.164, e.g.
+`+15551234567`) — that is the `account` value below.
+
+### Option B — Register a dedicated number
+
+Register a separate number that Simard owns:
+
+```bash
+signal-cli -a +15551234567 register
+# Enter the SMS/voice code you receive:
+signal-cli -a +15551234567 verify 123456
+```
+
+Here `+15551234567` is a dedicated Signal number and becomes the `account` value.
+
+## 3. Start the signal-cli JSON-RPC daemon
+
+Run signal-cli in JSON-RPC daemon mode over TCP. Simard connects to this endpoint;
+signal-cli owns the account, encryption, and delivery.
+
+```bash
+signal-cli -a +15551234567 daemon --tcp 127.0.0.1:7583
+```
+
+Leave it running (systemd unit, tmux, or a supervisor of your choice). The
+`127.0.0.1:7583` host:port is the `endpoint` value below — bind to loopback so the
+JSON-RPC surface is not exposed off-host.
+
+## 4. Configure the `[signal]` table
+
+Add a `[signal]` table to the runtime config file at `<state_root>/config.toml`
+(the same file Simard uses for the LLM provider; `<state_root>` is
+`$SIMARD_STATE_ROOT` or, by default, `~/.simard`, so `~/.simard/config.toml` out of
+the box). Environment variables still win over the file; there is no silent default.
+The `[signal]` table is only parsed and applied in a `--features signal` build
+(step 5) — a default build ignores it.
+
+```toml
+[signal]
+endpoint = "127.0.0.1:7583"     # the signal-cli daemon from step 3
+account  = "+15551234567"        # the linked/dedicated account from step 2
+allowlist = ["+15559876543"]     # YOUR operator number(s) — who may command Simard
+read_only_unknown = false        # keep unknown senders fully ignored (default)
+```
+
+- **`allowlist` is the security boundary.** Only the E.164 numbers listed here may
+  command Simard. It is **fail-closed**: an empty or missing allowlist means
+  *nobody* may command her. Put the operator's own phone number here — the number
+  you message Simard *from*, which is different from `account` (the number Simard
+  receives *on*).
+- Set `read_only_unknown = true` only if you want non-allowlisted senders to be
+  able to read `status`; they can never trigger a mutation.
+
+## 5. Build and run Simard with the `signal` feature
+
+The Signal channel compiles only with the `signal` feature:
+
+```bash
+cargo build --features signal
+```
+
+Then run the daemon (or your normal Simard entrypoint) from that build. On startup
+Simard reads `[signal]`, connects to the signal-cli endpoint, and begins receiving
+inbound messages from allowlisted senders and sending notifications out.
+
+## 6. Verify the round trip
+
+From your **operator** phone (an allowlisted number), message Simard's Signal
+account:
+
+```text
+status
+```
+
+Simard replies with daemon health and pause state. Then try a normal sentence — she
+answers conversationally, exactly like a CLI/dashboard meeting:
+
+```text
+what are you working on right now?
+```
+
+To confirm the guardrail, message a high-risk command:
+
+```text
+merge #2531
+```
+
+Simard does **not** merge from the text. She creates a pending sign-off and replies
+asking for explicit approval; replying `approve` records your sign-off and the
+merge then proceeds through the gated
+[merge authority](../reference/cross-repo-merge-authority.md). See the
+[operational autonomy model](../concepts/operational-autonomy-model.md) for the full
+HIGH-RISK boundary.
+
+## What you can do over Signal
+
+| You send | Simard does |
+|----------|-------------|
+| `status` | Reports daemon health + pause state (low-risk, immediate) |
+| `pause` | Pauses autonomous dispatch (low-risk, immediate) |
+| `approve` | Records your sign-off for the pending high-risk request |
+| `deploy` | Requests a deploy → asks for sign-off (high-risk, gated) |
+| `merge #NNNN` | Merges the PR via gated authority → asks for sign-off (high-risk) |
+| anything else | Ordinary meeting turn — full conversation, `/goal` `/decision` `/action` capture, `/close` |
+
+| Simard notifies you when |
+|--------------------------|
+| a governed PR is merge-ready |
+| a stall or problem is detected |
+| a high-risk action needs your sign-off |
+
+## Troubleshooting
+
+### Simard never receives my Signal messages
+
+1. **Are you allowlisted?** Your sending number must be in `[signal].allowlist`
+   (E.164, e.g. `+15559876543`). Unknown senders are dropped and logged at `debug`
+   — enable debug logging to see the drop. `allowlist` is *your* number, not
+   `account`.
+2. **Is the daemon reachable?** Confirm `signal-cli -a … daemon --tcp 127.0.0.1:7583`
+   is running and `endpoint` matches host:port exactly.
+3. **Built with the feature?** A default build has no Signal code. Rebuild with
+   `cargo build --features signal`.
+
+### Simard receives but never replies
+
+Check that `account` is the number signal-cli is registered/linked as, and that
+the daemon can send (test with `signal-cli -a … send -m "hi" <your-number>`).
+
+### A high-risk command "did nothing"
+
+That is the guardrail working. `deploy` and `merge #NNNN` never auto-execute from a
+text — Simard creates a pending sign-off and asks for `approve`. Reply `approve` to
+authorize; the action then runs through its existing gated authority.
+
+### The daemon runs but I never wanted Signal
+
+Nothing to do — the Signal channel is off unless you build with `--features signal`
+*and* provide a `[signal]` table. A plain `cargo build` has no Signal code and needs
+no signal-cli.
+
+## Related reading
+
+- [Signal channel reference](../reference/signal-conversation.md) — config keys,
+  commands, notifications, and guardrails in full.
+- [Conversation channels](../architecture/conversation-channel.md) — the shared
+  abstraction the Signal channel implements.
+- [Operational autonomy model](../concepts/operational-autonomy-model.md) — the
+  HIGH-RISK boundary the Signal gating reuses.
+- [How to start a meeting with Simard](./start-a-meeting.md) — the same meeting
+  experience over CLI and dashboard.

--- a/docs/howto/set-up-the-signal-channel.md
+++ b/docs/howto/set-up-the-signal-channel.md
@@ -127,9 +127,19 @@ The Signal channel compiles only with the `signal` feature:
 cargo build --features signal
 ```
 
-Then run the daemon (or your normal Simard entrypoint) from that build. On startup
-Simard reads `[signal]`, connects to the signal-cli endpoint, and begins receiving
-inbound messages from allowlisted senders and sending notifications out.
+Then launch the Signal channel with the `signal run` subcommand from that build:
+
+```bash
+simard signal run
+```
+
+On startup Simard reads the `[signal]` table, connects to the signal-cli endpoint,
+and begins receiving inbound messages from allowlisted senders and sending
+notifications out. Leave it running (systemd unit, tmux, or a supervisor) alongside
+the signal-cli daemon from step 3. `simard signal run` exits when the signal-cli
+socket closes; supervise it if you want it to reconnect. A build **without**
+`--features signal` still recognizes `simard signal run` but tells you to rebuild
+with the feature — no Signal code is compiled into a default build.
 
 ## 6. Verify the round trip
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,7 @@ Terminal sessions and repo-grounded engineer runs now bridge through one explici
 - [How to configure and monitor the disk health check](./howto/configure-disk-health-check.md) - Tune the per-cycle automated disk cleanup that prevents ENOSPC crashes (#2020).
 - [How to diagnose and prevent handoff accumulation](./howto/diagnose-handoff-accumulation.md) - Detect, resolve, and prevent unbounded meeting handoff file growth (#2268).
 - [How to start a meeting with Simard](./howto/start-a-meeting.md) - Have a natural conversation with Simard from CLI or dashboard, with full history and memory.
+- [How to set up the Signal channel](./howto/set-up-the-signal-channel.md) - Command Simard and receive her notifications over Signal, via a locally-run signal-cli JSON-RPC daemon, with an operator allowlist and high-risk sign-off gating (#2527).
 - [How to carry meeting decisions into engineer sessions](./howto/carry-meeting-decisions-into-engineer-sessions.md) - Persist meeting records under a shared state root and confirm later engineer runs carry them forward.
 - [How to inspect meeting records](./howto/inspect-meeting-records.md) - Read back the latest durable meeting record without mutating stored state.
 - [How to inspect improvement-curation state](./howto/inspect-improvement-curation-state.md) - Read back the latest approved, deferred, and promoted improvement state without mutation.
@@ -156,3 +157,4 @@ If you are changing architecture, start with the [architecture overview](./archi
 - [Implementation plan](./architecture/implementation-plan.md) - Phased roadmap with current status and quality gates.
 - [OODA meeting handoff integration](./architecture/ooda-meeting-handoff-integration.md) - Wire meeting handoffs into the OODA daemon and seed default goals (Issues #157, #158).
 - [Unified meeting backend](./architecture/unified-meeting-backend.md) - One conversational engine behind CLI REPL and dashboard WebSocket chat (Issue #462).
+- [Conversation channels](./architecture/conversation-channel.md) - The one clearly-named `ConversationChannel` abstraction: the CLI/TUI meeting REPL, the dashboard chat, and Signal are all thin channels over the same meeting engine (Issue #2527). See the [conversation channel API reference](./reference/conversation-channel-api.md) and the [Signal channel reference](./reference/signal-conversation.md).

--- a/docs/reference/conversation-channel-api.md
+++ b/docs/reference/conversation-channel-api.md
@@ -1,0 +1,322 @@
+---
+title: Conversation channel API reference
+description: Rust API reference for the ConversationChannel trait, its message types (OperatorRef, Inbound, Outbound, OutKind), the shared apply_record dispatcher, the run_conversation driver, and MockConversationChannel.
+last_updated: 2026-07-03
+review_schedule: as-needed
+owner: simard
+doc_type: reference
+issues: ["#2527"]
+related:
+  - ../index.md
+  - ../architecture/conversation-channel.md
+  - ./meeting-backend-api.md
+  - ./signal-conversation.md
+  - ../howto/start-a-meeting.md
+---
+
+# Conversation channel API reference
+
+The `conversation_channel` module (`src/conversation_channel/`) defines the one
+operator↔Simard conversation abstraction and the shared machinery every meeting
+frontend uses. It is `pub`-exported from `src/lib.rs` as
+`pub mod conversation_channel;`.
+
+Nothing in this module is named `bridge`/`Bridge`. `ConversationChannel` is a
+first-class chat abstraction and is unrelated to the pre-existing cognitive-memory
+`BridgeTransport`.
+
+## Message types
+
+`src/conversation_channel/mod.rs`
+
+### `OperatorRef`
+
+Identifies the sender of an inbound line and records whether it has cleared the
+channel's authorization check (allowlist / identity / dashboard auth).
+
+```rust
+/// Who sent an inbound message. Used for the allowlist + identity binding.
+#[derive(Clone, Debug)]
+pub struct OperatorRef {
+    /// Channel-native id: terminal user, dashboard session id, or Signal E.164.
+    pub id: String,
+    /// True once this ref has cleared the channel's allowlist/identity check.
+    pub authorized: bool,
+}
+```
+
+For the local CLI and dashboard frontends the operator is already authorized (the
+CLI keeps its own loop; the dashboard has auth middleware). For a driver-based
+channel, `authorized` is set by the channel after its own check — for
+`SignalConversation` it reflects the E.164 allowlist result.
+
+### `Inbound`
+
+One operator-originated line, already trimmed of surrounding whitespace.
+
+```rust
+/// One operator-originated message line.
+#[derive(Clone, Debug)]
+pub struct Inbound {
+    pub from: OperatorRef,
+    pub text: String,
+}
+```
+
+### `Outbound` and `OutKind`
+
+A Simard-originated message, render-agnostic. The channel's `send` implementation
+maps `OutKind` to its own presentation (ANSI color, JSON role, or a Signal send).
+
+```rust
+/// A Simard-originated message to deliver on the channel.
+#[derive(Clone, Debug)]
+pub struct Outbound {
+    pub kind: OutKind,
+    pub text: String,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OutKind {
+    /// Simard's conversational LLM reply.
+    Assistant,
+    /// A structured-capture acknowledgement ("Decision recorded: …", etc.).
+    Recorded,
+    /// Read-only session output (/status, /state, /recap, /preview, /help).
+    Status,
+    /// A notification-out: PR merge-ready, stall/problem, high-risk sign-off request.
+    Notice,
+    /// An error message.
+    Error,
+}
+```
+
+## The trait
+
+```rust
+/// A bidirectional operator↔Simard conversation channel. The meeting IS the
+/// conversation; each implementation is one channel over the shared
+/// `MeetingBackend`. Native async via return-position `impl Future` (no
+/// `async-trait` dependency). Used with static dispatch — never as `dyn`.
+pub trait ConversationChannel {
+    /// Stable id for logs/metrics: `"cli"`, `"dashboard"`, or `"signal"`.
+    fn name(&self) -> &'static str;
+
+    /// Await the next authorized operator line.
+    ///
+    /// `Ok(None)` ends the session (EOF, socket closed, or operator quit).
+    /// Implementations MUST NOT yield an inbound whose `from.authorized` is
+    /// `false`; unauthorized input is dropped inside the channel before it
+    /// reaches the driver.
+    fn recv(&mut self)
+        -> impl std::future::Future<Output = SimardResult<Option<Inbound>>> + Send;
+
+    /// Deliver one Simard message OUT on this channel.
+    fn send(&mut self, out: Outbound)
+        -> impl std::future::Future<Output = SimardResult<()>> + Send;
+
+    /// Per-channel hook fired after a record command is applied. The default is
+    /// a no-op; `CliConversation` overrides it to emit `checkpoint_wip` and the
+    /// live capture tally. Dashboard and Signal keep the default so behavior is
+    /// preserved exactly.
+    fn on_recorded(&mut self, _backend: &MeetingBackend)
+        -> impl std::future::Future<Output = SimardResult<()>> + Send
+    { async { Ok(()) } }
+}
+```
+
+### Contract notes
+
+- **Authorization is the channel's job.** The driver assumes every `Inbound`
+  returned by `recv` is authorized. A channel that gates senders (Signal) filters
+  before returning.
+- **`send` is total.** A channel renders every `OutKind`; it may style them
+  differently but must not drop any.
+- **`on_recorded` fires only after a capture.** The driver calls it only for an
+  `OutKind::Recorded` outbound, never for a read-only status view. A channel with
+  post-record effects overrides it; the mock counts its calls. (The CLI REPL keeps
+  its `checkpoint_wip` + capture tally inline in its own loop, so unifying the record
+  applier does not move the CLI tally onto other channels.)
+
+## Shared record dispatcher — `apply_record`
+
+`src/conversation_channel/dispatch.rs`
+
+Pure, synchronous. This is the duplicated per-channel record logic extracted once —
+**both** the CLI REPL and the dashboard chat loop call it for the eight capture
+commands. It performs the backend mutation and returns the canonical message; it
+does **not** render and does **not** perform any I/O or LLM turn. Commands that call
+`send_message`/`close`, write files, or fire an LLM turn (`Conversation`, `Close`,
+`Export`, and the context-injection turn of `Template`) are **driver-handled** and
+are *not* pure `apply_record` arms.
+
+```rust
+/// The canonical result of a record/status command: message text + kind.
+/// Rendering is left to the channel; the text is identical across channels.
+pub struct Recorded {
+    pub kind: OutKind,
+    pub text: String,
+}
+
+/// Apply a record/status command's backend mutation and return its canonical
+/// message. Returns `None` for commands the driver handles directly
+/// (`Conversation`, `Close`).
+pub fn apply_record(backend: &mut MeetingBackend, cmd: &MeetingCommand)
+    -> Option<Recorded>;
+```
+
+Mapping (every [`MeetingCommand`](./meeting-backend-api.md) variant is accounted
+for — pure arms return `Some(Recorded)`; I/O-bearing commands return `None` and are
+driver-handled):
+
+| `MeetingCommand` | Effect | `Recorded` |
+|------------------|--------|------------|
+| `Decision { text, rationale }` | `backend.push_explicit_decision(text, rationale)` | `Recorded`, `"Decision recorded: …"` |
+| `Action(t)` | `backend.push_explicit_action_item(t)` | `Recorded`, `"Action recorded: …"` |
+| `Question(t)` | `backend.push_explicit_question(t)` | `Recorded`, `"Question recorded: …"` |
+| `Risk(t)` | `backend.push_explicit_risk(t)` | `Recorded`, `"Risk recorded: …"` |
+| `Disagree(t)` | `backend.push_explicit_disagreement(t)` | `Recorded`, `"Disagreement recorded: …"` |
+| `Theme(t)` | `backend.push_theme(t)` | `Recorded`, `"Theme recorded: …"` |
+| `Owner(n)` | `backend.push_next_owner(n)` | `Recorded`, `"Next owner recorded: …"` |
+| `Goal(t)` | `backend.set_goal(t)` | `Recorded`, `"Goal recorded: …"` |
+| `Status` / `State` / `Recap` / `Preview` / `Help` | read backend state | `Status`, a canonical rendering used by the driver-based channels (the CLI and dashboard keep their own richer rendering of these views) |
+| `Unknown { .. }` | none | `Status`, the existing suggestion text |
+| `Conversation(_)` / `Close` | — | `None` (driver-handled — `send_message`/`close`) |
+| `Export` | writes a markdown export (`persist::write_markdown_export`) | `None` (driver-handled — file I/O) |
+| `Template(n)` | `find_template(n)` → `apply_template(name, agenda)` **then** an LLM context-injection turn | `None` (driver-handled — pure lookup+apply, then `send_message`; empty/unknown name lists templates or errors) |
+
+The exact acknowledgement strings for the eight capture commands are the ones the
+CLI and dashboard already produced; they are not changed by the extraction.
+`Export` and `Template` are driver-handled because they perform file I/O or an LLM
+turn and so cannot be part of the pure, synchronous `apply_record`.
+
+## The driver — `run_conversation`
+
+`src/conversation_channel/driver.rs`
+
+One loop over the trait, realized by the [`SignalConversation`](./signal-conversation.md)
+channel and by `MockConversationChannel` (and reusable by any future channel). The
+CLI REPL and dashboard keep their own presentation loops but share the record path
+via `apply_record`.
+
+```rust
+/// Drive one operator↔Simard conversation to completion over `channel`, using
+/// `backend` as the (synchronous) meeting engine. Returns when the operator
+/// closes the meeting or the channel reaches end-of-stream.
+pub async fn run_conversation<C: ConversationChannel>(
+    channel: &mut C,
+    backend: &mut MeetingBackend,
+) -> SimardResult<()>;
+```
+
+Behavior:
+
+```text
+while let Some(inbound) = channel.recv().await? {
+    match parse_command(&inbound.text) {
+        Close          => { backend.close(); send(summary); break }
+        Conversation t => { let r = backend.send_message(t);
+                            send(Outbound{ Assistant, r.content }) }
+        Export         => { let p = write_markdown_export(..);
+                            send(Outbound{ Status, "Exported to …" }) }
+        Template n     => { apply_template(backend, n);          // sync
+                            let r = backend.send_message(ctx);   // LLM turn
+                            send(Outbound{ Assistant, r.content }) }
+        other          => if let Some(rec) = apply_record(backend, &other) {
+                            let is_record = rec.kind == OutKind::Recorded;
+                            send(Outbound{ rec.kind, rec.text });
+                            if is_record { channel.on_recorded(backend).await?; }
+                          }
+    }
+}
+```
+
+`Export` and `Template` are handled by the driver (not `apply_record`) because they
+perform file I/O and/or an LLM turn. The engine (`MeetingBackend`) is synchronous;
+each call completes *before* the next `.await`, so no `&mut MeetingBackend` is held
+across an await point and the driver needs no `spawn_blocking`.
+
+## Test double — `MockConversationChannel`
+
+`src/conversation_channel/mock.rs`
+
+```rust
+/// A scripted ConversationChannel for driver + integration tests.
+pub struct MockConversationChannel { /* … */ }
+
+impl MockConversationChannel {
+    /// Build from a script of inbound lines; each `recv()` yields the next,
+    /// then `Ok(None)`.
+    pub fn with_script(lines: Vec<&str>) -> Self;
+
+    /// All Outbound messages captured by `send()`, in order.
+    pub fn sent(&self) -> &[Outbound];
+
+    /// Count of `on_recorded` invocations (asserts the hook fires per record).
+    pub fn recorded_hook_calls(&self) -> usize;
+}
+
+impl ConversationChannel for MockConversationChannel { /* … */ }
+```
+
+Typical use:
+
+```rust
+let mut ch = MockConversationChannel::with_script(vec![
+    "/goal ship the signal channel",
+    "/decision use signal-cli JSON-RPC --rationale no embedded protocol",
+    "let's wrap up",
+    "/close",
+]);
+let mut backend = MeetingBackend::new_for_test("signal channel");
+run_conversation(&mut ch, &mut backend).await.unwrap();
+
+assert!(ch.sent().iter().any(|o| o.kind == OutKind::Recorded
+    && o.text.contains("Goal recorded")));
+assert_eq!(ch.recorded_hook_calls(), 2); // /goal + /decision
+```
+
+## Usage — implementing a channel
+
+A channel provides transport-specific `recv`/`send` (and, if it has post-record
+effects, `on_recorded`); all meeting logic comes from the driver + engine. The
+worked example is [`SignalConversation`](./signal-conversation.md); its shape:
+
+```rust
+struct MyChannel<T> { transport: T /* … */ }
+
+impl<T: Transport + Send> ConversationChannel for MyChannel<T> {
+    fn name(&self) -> &'static str { "my-channel" }
+
+    fn recv(&mut self)
+        -> impl std::future::Future<Output = SimardResult<Option<Inbound>>> + Send
+    { async move {
+        // read the next authorized operator line from the transport;
+        // end-of-stream → Ok(None); else Ok(Some(Inbound {
+        //   from: OperatorRef { id: <sender>, authorized: true }, text }))
+    }}
+
+    fn send(&mut self, out: Outbound)
+        -> impl std::future::Future<Output = SimardResult<()>> + Send
+    { async move {
+        // render out.kind + out.text onto the transport
+    }}
+
+    // on_recorded defaults to a no-op; override only for post-record effects.
+}
+```
+
+`SignalConversation` follows this shape over a signal-cli JSON-RPC transport; its
+`recv` additionally applies the allowlist and gates lightweight operator commands
+before yielding a meeting turn. `on_recorded` stays the default no-op for it. The
+CLI REPL and dashboard chat are **not** separate trait impls — they keep their own
+loops and share only the record path via `apply_record`.
+
+## Related reading
+
+- [Conversation channels (architecture)](../architecture/conversation-channel.md)
+- [Signal channel reference](./signal-conversation.md)
+- [Meeting backend API reference](./meeting-backend-api.md) — the sync engine the
+  channels drive, including the `push_explicit_*` / `set_goal` setters used by
+  `apply_record`.
+- [How to start a meeting with Simard](../howto/start-a-meeting.md)

--- a/docs/reference/signal-conversation.md
+++ b/docs/reference/signal-conversation.md
@@ -1,0 +1,286 @@
+---
+title: Signal channel reference
+description: Reference for SignalConversation — the optional, feature-gated ConversationChannel that connects Simard to a locally-run signal-cli JSON-RPC daemon, with a sender allowlist, operator-identity binding, high-risk gating, inbound commands, and outbound notifications.
+last_updated: 2026-07-03
+review_schedule: as-needed
+owner: simard
+doc_type: reference
+issues: ["#2527"]
+related:
+  - ../index.md
+  - ../architecture/conversation-channel.md
+  - ./conversation-channel-api.md
+  - ../howto/set-up-the-signal-channel.md
+  - ../concepts/operational-autonomy-model.md
+  - ./cross-repo-merge-authority.md
+  - ./stewardship-api.md
+---
+
+# Signal channel reference
+
+`SignalConversation` (`src/signal_conversation/`, `#[cfg(feature = "signal")]`) is
+the Signal implementation of [`ConversationChannel`](./conversation-channel-api.md).
+It lets an allowlisted operator command Simard and receive her notifications over
+Signal, using the **same** meeting engine and handoff/goal-carryover chain as the
+CLI and dashboard channels.
+
+Simard does **not** embed the Signal protocol. She talks to a locally-run
+[`signal-cli`](https://github.com/AsamK/signal-cli) daemon over JSON-RPC; signal-cli
+owns the Signal account, encryption, and delivery. See
+[How to set up the Signal channel](../howto/set-up-the-signal-channel.md) for
+installation and linking.
+
+> **Naming.** `SignalConversation` is a first-class conversation channel. It does
+> **not** implement, extend, or route through the pre-existing cognitive-memory
+> `BridgeTransport`. No symbol added by this feature contains `bridge`/`Bridge`.
+
+## Feature gate
+
+The Signal channel is compiled only when the `signal` Cargo feature is enabled; it
+is **off by default**. The default build has no Signal code and needs no signal-cli
+installed.
+
+```toml
+# Cargo.toml
+[features]
+signal = []  # default-OFF; adds no new dependency
+```
+
+```bash
+# Default build — no Signal, no signal-cli needed:
+cargo build
+cargo test
+
+# With the Signal channel:
+cargo build --features signal
+cargo test  --features signal
+```
+
+The transport uses tokio `net` (already a dependency), so enabling `signal` pulls in
+no new crate — there is no HTTP client and no `async-trait`.
+
+## Transport
+
+The operator runs signal-cli in JSON-RPC daemon mode over TCP:
+
+```bash
+signal-cli -a +15551234567 daemon --tcp 127.0.0.1:7583
+```
+
+`src/signal_conversation/transport.rs` opens a tokio `TcpStream` to that endpoint
+and speaks **newline-delimited JSON-RPC 2.0**:
+
+- **inbound** — signal-cli `receive` notifications are mapped to
+  `Inbound { from: OperatorRef { id: <E.164>, authorized }, text }`.
+- **outbound** — an `Outbound` is mapped to a JSON-RPC `send` request addressed to
+  the operator number.
+
+`signal-cli-rest-api` and any HTTP-based transport are out of scope for this
+version; the JSON-RPC-over-TCP daemon is the supported transport.
+
+## Configuration
+
+Signal settings live in the `[signal]` table of the runtime config file at
+`<state_root>/config.toml` — the same file used for the LLM provider, where
+`<state_root>` is `$SIMARD_STATE_ROOT` or, by default, `~/.simard` (so
+`~/.simard/config.toml` out of the box). Resolution follows the existing
+runtime-config rule: **environment wins, then the config file, then a clear error —
+never a silent default.** When the `signal` feature is off, the `[signal]` table is
+ignored.
+
+> **Loaded by a dedicated typed loader.** `RuntimeConfig` (`src/runtime_config.rs`)
+> is a minimal single-key hand parser for `llm_provider`, so the structured
+> `[signal]` **table** is read by its own loader, `SignalConfig::load` /
+> `load_from` (`src/signal_conversation/config.rs`), which deserializes real TOML
+> via the already-present `serde` + `toml` crates — no new dependency. It keeps the
+> same env-wins → file → error resolution and no-silent-default guarantee. Each
+> field also has an environment override: `SIMARD_SIGNAL_ENDPOINT`,
+> `SIMARD_SIGNAL_ACCOUNT`, `SIMARD_SIGNAL_ALLOWLIST` (comma-separated), and
+> `SIMARD_SIGNAL_READ_ONLY_UNKNOWN`. `endpoint` and `account` are required;
+> `allowlist` defaults to empty (fail-closed) and `read_only_unknown` to false.
+
+```toml
+[signal]
+# signal-cli JSON-RPC daemon endpoint (host:port).
+endpoint = "127.0.0.1:7583"
+
+# The Signal account signal-cli owns — a linked device or a dedicated number.
+account = "+15551234567"
+
+# E.164 operator numbers permitted to COMMAND Simard. Everyone else is ignored
+# (or read-only, if read_only_unknown = true). Fail-closed: empty ⇒ nobody may command.
+allowlist = ["+15557654321"]
+
+# Opt-in: allow non-allowlisted senders to receive READ-ONLY results (e.g. status).
+# They can never trigger a mutation. Default false (unknown senders fully ignored).
+read_only_unknown = false
+```
+
+| Key | Type | Default | Meaning |
+|-----|------|---------|---------|
+| `endpoint` | string `host:port` | — (required) | signal-cli JSON-RPC daemon TCP address |
+| `account` | E.164 string | — (required) | the Signal account signal-cli operates |
+| `allowlist` | array of E.164 | `[]` | numbers permitted to issue commands |
+| `read_only_unknown` | bool | `false` | if true, unknown senders may read status only |
+
+## Guardrails
+
+The Signal channel is a **remote command surface**, so it adds three guardrails on
+top of the shared abstraction. They are layered — a message must clear all three to
+cause any mutation.
+
+### (a) Sender allowlist — fail-closed
+
+`src/signal_conversation/allowlist.rs` checks each inbound E.164 against
+`[signal].allowlist`:
+
+- **Allowlisted sender** → `OperatorRef.authorized = true`; the inbound proceeds.
+- **Unknown sender** → **dropped and logged at `debug`** (fail-closed). No engine
+  dispatch, no reply, unless `read_only_unknown = true`, in which case the sender
+  may receive **read-only** results (e.g. `status`) but can **never** mutate.
+
+Because the driver never receives an unauthorized `Inbound`
+(see the [trait contract](./conversation-channel-api.md#contract-notes)), an
+unknown sender cannot reach any command handler.
+
+### (b) Operator-identity binding
+
+An authorized inbound is bound to the sender's E.164 on
+[`OperatorRef`](./conversation-channel-api.md#operatorref) (`from.id`), and every
+command reply and the high-risk sign-off record are addressed to and attributed to
+that same sender — so a command runs under, and is answered to, the operator's own
+number, never an ambient or anonymous one. Only an allowlisted sender ever reaches
+this point (guardrail (a)).
+
+### (c) High-risk gating — never auto-execute a mutation from a text
+
+`src/signal_conversation/gating.rs` classifies every inbound command; the channel
+then routes it by its `gate` decision. **Nothing high-risk is ever auto-executed
+from a text message.**
+
+| Class | Commands | Handling |
+|-------|----------|----------|
+| **Low-risk (auto)** | `status`, `pause`, `approve`, and ordinary conversation | Executed immediately for an allowlisted sender. `approve` only **records** the operator's sign-off and then runs the previously-gated action; it never itself classifies a fresh mutation as safe. |
+| **High-risk (gated)** | `deploy`, `merge #NNNN` | `classify` → `HighRisk` → `gate` → `PendingSignOff`. The channel records the pending command and replies asking for explicit sign-off. The mutation runs **only** after the operator replies `approve`. |
+
+When an operator approves, the channel calls the injected
+[`SignalCommandHandler::execute_approved`](#the-command-handler-seam) — the single
+code path that performs a mutating action, and only ever after an explicit
+`approve`. A deployment wires that handler to route `deploy` / `merge #NNNN` through
+the existing operational-autonomy authority:
+
+- `git_guardrails::check_git_safety` hard-blocks destructive git patterns and any
+  write under `SIMARD_GIT_PROTECTED_REPOS`.
+- `merge #NNNN` flows through
+  `stewardship::merge_authority::merge_pr_if_merge_ready_with_allowlist`
+  (objective gates + merge-judge verdict), the same gated authority used by
+  [`simard merge-pr`](./cross-repo-merge-authority.md).
+
+The default [`RuntimeCommandHandler`](#the-command-handler-seam) is conservative: it
+**records** the signed-off action for that gated authority rather than performing
+the mutation itself, so the gating guardrail is fully enforced out of the box and
+the concrete execution is an explicit, injectable seam.
+
+### The command-handler seam
+
+`SignalConversation` is generic over a `SignalCommandHandler`
+(`src/signal_conversation/channel.rs`):
+
+```rust
+pub trait SignalCommandHandler: Send {
+    fn status(&self) -> String;                  // `status`
+    fn pause(&mut self) -> String;               // `pause`
+    fn execute_approved(&mut self, cmd: &InboundCommand) -> SimardResult<String>;
+}
+```
+
+Keeping the effects behind this trait lets the security-critical allowlist + gating
+routing be unit-tested in isolation (a spy handler proves `execute_approved` is
+never called before an `approve`), and lets a deployment wire concrete
+status/pause/execution to its real subsystems.
+
+## Commands in
+
+`src/signal_conversation/gating.rs` parses a small lightweight command vocabulary;
+the channel (`channel.rs`) routes each via the allowlist + `gate`. They are thin
+wrappers, not a new command engine.
+
+| Text (from an allowlisted operator) | Action | Class |
+|-------------------------------------|--------|-------|
+| `status` | Reports daemon health + pause state (via the handler; extend it for goals/engineers) | low-risk |
+| `pause` | Pause autonomous dispatch | low-risk |
+| `approve` | Record operator sign-off and run the pending high-risk request | low-risk |
+| `deploy` | Request a deploy → pending sign-off | **high-risk** |
+| `merge #NNNN` | Merge PR #NNNN via the gated merge authority → pending sign-off | **high-risk** |
+
+Any other text is treated as an ordinary meeting turn (`Conversation`) and answered
+conversationally by Simard, exactly as on the CLI/dashboard channels — so the full
+meeting experience (including `/goal`, `/decision`, `/action`, … capture and
+`/close`) is available over Signal too.
+
+## Notifications out
+
+`SignalConversation::notify` (`src/signal_conversation/channel.rs`) sends a message
+to every configured operator for:
+
+| Notification | Trigger |
+|--------------|---------|
+| **PR merge-ready** | A governed PR has passed the objective gates + merge-judge and is ready to merge |
+| **Stall / problem detected** | The OODA loop or an engineer detects a stall, repeated failure, or blocker |
+| **High-risk sign-off request** | A gated `deploy`/`merge` needs explicit operator approval (guardrail (c)) |
+
+A sign-off request is answered by replying `approve` (records sign-off) — the
+gated action then proceeds through its authority; a text alone never executes it.
+
+## Data flow
+
+**Inbound command:**
+
+```text
+signal-cli ─▶ transport.recv_line ─▶ parse_incoming ─▶ allowlist gate ─▶ parse_inbound
+           ─▶ gate ┬─ AutoExecute    ─▶ handler (status/pause/approve) ─▶ reply
+                   └─ PendingSignOff ─▶ record pending ─▶ reply "sign off?"
+                                        (execute only after `approve`)
+```
+
+**Notification out:**
+
+```text
+OODA / merge authority / gate ─▶ SignalConversation::notify ─▶ transport.send_line ─▶ signal-cli
+```
+
+**Meeting turn / carryover:** identical to every channel — a `Conversation` inbound
+flows through `run_conversation` + `MeetingBackend`, with `/close` writing the
+handoff under `default_handoff_dir()` (`$SIMARD_HANDOFF_DIR`, else
+`<state_root>/meeting_handoffs`, default `~/.simard/meeting_handoffs`) and
+`check_meeting_handoffs` carrying decisions onto the goal board. See
+[Conversation channels](../architecture/conversation-channel.md).
+
+## Testing
+
+All Signal tests run under `cargo test --features signal` against a **mock JSON-RPC
+transport** and a spy command handler — no live signal-cli or network is required:
+
+- **Allowlist enforcement** — an unknown E.164 is dropped (no dispatch, no reply);
+  with `read_only_unknown = true` it receives only read-only `status`; an
+  allowlisted number is authorized and its conversation turn reaches the driver.
+- **High-risk gating** — `deploy` and `merge #NNNN` create a pending sign-off and
+  never auto-execute; the spy handler proves `execute_approved` runs only after an
+  explicit `approve`, and exactly once; `status`/`pause`/`approve` run immediately.
+- **Identity binding** — replies and the delivered conversation `Inbound` are bound
+  to the sender's E.164.
+- **Wire helpers** — `parse_incoming` maps a signal-cli `receive` notification to
+  `(sender, text)` and ignores responses/receipts/unparseable lines;
+  `build_send_request` produces valid JSON-RPC.
+- **Config** — env-first resolution, the `[signal]` table from `config.toml`, and a
+  clear error for a missing required key.
+
+## Related reading
+
+- [Conversation channels (architecture)](../architecture/conversation-channel.md)
+- [Conversation channel API reference](./conversation-channel-api.md)
+- [How to set up the Signal channel](../howto/set-up-the-signal-channel.md)
+- [Operational autonomy model](../concepts/operational-autonomy-model.md) — the
+  HIGH-RISK boundary the gating reuses.
+- [Cross-repo merge authority](./cross-repo-merge-authority.md) — the gated
+  authority `merge #NNNN` flows through.

--- a/docs/reference/signal-conversation.md
+++ b/docs/reference/signal-conversation.md
@@ -59,6 +59,22 @@ cargo test  --features signal
 The transport uses tokio `net` (already a dependency), so enabling `signal` pulls in
 no new crate — there is no HTTP client and no `async-trait`.
 
+## Launching
+
+Start the channel with the operator subcommand from a `--features signal` build:
+
+```bash
+simard signal run
+```
+
+`simard signal run` (`src/operator_cli/signal.rs`) loads the `[signal]` config,
+builds a tokio runtime, and calls `signal_conversation::run`
+(`src/signal_conversation/channel.rs`), which connects to the signal-cli endpoint
+and drives the operator conversation to completion. It exits when the signal-cli
+socket closes; supervise it (systemd/tmux) to reconnect. A default build (no
+`signal` feature) still recognizes `simard signal run` but returns a clear error
+telling the operator to rebuild with `--features signal`.
+
 ## Transport
 
 The operator runs signal-cli in JSON-RPC daemon mode over TCP:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,7 @@ nav:
     - Implementation Plan: architecture/implementation-plan.md
     - Brain Introspection + Memory Hygiene: architecture/brain-introspection.md
     - Monthly Self-Quality-Audit: architecture/monthly-self-quality-audit.md
+    - Conversation Channels: architecture/conversation-channel.md
   - Concepts:
     - Truthful Runtime Metadata: concepts/truthful-runtime-metadata.md
     - Prompt-driven Brain Iteration: concepts/prompt-driven-brain-iteration.md
@@ -87,6 +88,7 @@ nav:
     - Configure Adaptive Scaling: howto/configure-adaptive-scaling.md
     - Troubleshoot Goal Store: howto/troubleshoot-goal-store.md
     - Recover from Meeting Close Timeout: howto/recover-from-meeting-close-timeout.md
+    - Set Up the Signal Channel: howto/set-up-the-signal-channel.md
     - Configure Pluggable Identity: howto/configure-pluggable-identity.md
     - Configure Episode Hygiene and Promotion: howto/configure-episode-hygiene-and-promotion.md
     - Dashboard E2E Tests: howto/run-dashboard-e2e-tests.md
@@ -130,6 +132,8 @@ nav:
     - Cross-Repo Merge Authority: reference/cross-repo-merge-authority.md
     - Pluggable Identity API: reference/pluggable-identity-api.md
     - Meeting Close Lifecycle: reference/meeting-close-lifecycle.md
+    - Conversation Channel API: reference/conversation-channel-api.md
+    - Signal Channel: reference/signal-conversation.md
     - Azure DevOps ACL Self-Escalation Guard: reference/ado-acl-self-escalation-guard.md
     - Brain Introspection API: reference/brain-introspection-api.md
     - Self-Quality-Audit API: reference/self-quality-audit-api.md

--- a/src/conversation_channel/dispatch.rs
+++ b/src/conversation_channel/dispatch.rs
@@ -1,0 +1,182 @@
+//! The shared, pure, synchronous record/status dispatcher.
+//!
+//! [`apply_record`] is the per-channel record logic that the CLI REPL and the
+//! dashboard chat loop previously duplicated, extracted **once**. It performs a
+//! record command's backend mutation and returns the *canonical* acknowledgement
+//! text + [`OutKind`]; it does **not** render and does **not** perform any I/O or
+//! LLM turn. Commands that call `send_message`/`close`, write files, or fire an
+//! LLM turn (`Conversation`, `Close`, `Export`, `Template`) return `None` and are
+//! handled by [`super::driver::run_conversation`] via `spawn_blocking`.
+//!
+//! The record acknowledgement strings returned here are exactly the ones the CLI
+//! and dashboard already produced — the extraction changes no observable
+//! behavior for the `/goal`, `/decision`, `/action`, `/question`, `/theme`,
+//! `/owner`, `/risk`, and `/disagree` commands. The read-only `Status` /
+//! `State` / `Recap` / `Preview` / `Help` / `Unknown` text is rendered here for
+//! the channels that drive through [`super::driver::run_conversation`] (Signal +
+//! the mock); the CLI and dashboard keep their own richer rendering of those
+//! read-only views.
+
+use crate::meeting_backend::MeetingBackend;
+use crate::meeting_backend::command::{MeetingCommand, render_help_plain, unknown_command_notice};
+use crate::meeting_backend::persist::{
+    extract_action_items, extract_decisions, extract_open_questions,
+};
+
+use super::OutKind;
+
+/// The canonical result of a record/status command: message text + kind.
+/// Rendering is left to the channel; the record text is identical across
+/// channels.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Recorded {
+    pub kind: OutKind,
+    pub text: String,
+}
+
+/// Apply a record/status command's backend mutation and return its canonical
+/// message. Returns `None` for commands the driver handles directly
+/// (`Conversation`, `Close`, `Export`, `Template`) because they perform an LLM
+/// turn or file I/O and so cannot be part of this pure, synchronous applier.
+pub fn apply_record(backend: &mut MeetingBackend, cmd: &MeetingCommand) -> Option<Recorded> {
+    match cmd {
+        // ── Structured capture (mutating) — canonical acks, byte-for-byte the
+        //    strings the CLI and dashboard already emit. ──
+        MeetingCommand::Theme(text) => {
+            backend.push_theme(text.clone());
+            Some(recorded(format!("Theme recorded: {text}")))
+        }
+        MeetingCommand::Decision { text, rationale } => {
+            backend.push_explicit_decision(text, rationale.as_deref());
+            let msg = if let Some(r) = rationale {
+                format!("Decision recorded: {text} (rationale: {r})")
+            } else {
+                format!("Decision recorded: {text}")
+            };
+            Some(recorded(msg))
+        }
+        MeetingCommand::Action(text) => {
+            backend.push_explicit_action_item(text);
+            Some(recorded(format!("Action recorded: {text}")))
+        }
+        MeetingCommand::Question(text) => {
+            backend.push_explicit_question(text);
+            Some(recorded(format!("Question recorded: {text}")))
+        }
+        MeetingCommand::Owner(text) => {
+            backend.push_next_owner(text);
+            Some(recorded(format!("Next owner recorded: {text}")))
+        }
+        MeetingCommand::Goal(text) => {
+            backend.set_goal(text);
+            Some(recorded(format!("Goal recorded: {text}")))
+        }
+        MeetingCommand::Risk(text) => {
+            backend.push_explicit_risk(text);
+            Some(recorded(format!("Risk recorded: {text}")))
+        }
+        MeetingCommand::Disagree(text) => {
+            backend.push_explicit_disagreement(text);
+            Some(recorded(format!("Disagreement recorded: {text}")))
+        }
+
+        // ── Read-only views (no mutation) — `Status` kind. ──
+        MeetingCommand::Status => Some(status(render_status(backend))),
+        MeetingCommand::Recap => Some(status(render_recap(backend))),
+        MeetingCommand::Preview => Some(status(render_preview(backend))),
+        MeetingCommand::State => Some(status(render_state(backend))),
+        MeetingCommand::Help => Some(status(render_help_plain())),
+        MeetingCommand::Unknown { input, suggestion } => {
+            Some(status(unknown_command_notice(input, suggestion.as_deref())))
+        }
+
+        // ── Driver-handled (LLM turn / file I/O / lifecycle). ──
+        MeetingCommand::Conversation(_)
+        | MeetingCommand::Close
+        | MeetingCommand::Export
+        | MeetingCommand::Template(_) => None,
+    }
+}
+
+fn recorded(text: String) -> Recorded {
+    Recorded {
+        kind: OutKind::Recorded,
+        text,
+    }
+}
+
+fn status(text: String) -> Recorded {
+    Recorded {
+        kind: OutKind::Status,
+        text,
+    }
+}
+
+fn render_status(backend: &MeetingBackend) -> String {
+    let s = backend.status();
+    format!(
+        "Topic: {}\nMessages: {}\nStarted: {}\nOpen: {}",
+        s.topic, s.message_count, s.started_at, s.is_open
+    )
+}
+
+fn render_recap(backend: &MeetingBackend) -> String {
+    let s = backend.status();
+    let mut out = format!(
+        "── Meeting Recap ──\nTopic: {}\nMessages: {}\nStarted: {}",
+        s.topic, s.message_count, s.started_at
+    );
+    let themes = backend.explicit_themes();
+    if !themes.is_empty() {
+        out.push_str(&format!("\nThemes: {}", themes.join(", ")));
+    }
+    out
+}
+
+fn render_preview(backend: &MeetingBackend) -> String {
+    let s = backend.status();
+    let themes = backend.explicit_themes();
+    format!(
+        "── Handoff Preview ──\nTopic: {}\nMessages so far: {}\nThemes: {}",
+        s.topic,
+        s.message_count,
+        if themes.is_empty() {
+            "none yet".to_string()
+        } else {
+            themes.join(", ")
+        }
+    )
+}
+
+fn render_state(backend: &MeetingBackend) -> String {
+    let messages = backend.history();
+    let decisions = extract_decisions(messages);
+    let open_questions = extract_open_questions(messages);
+    let action_items = extract_action_items(messages);
+
+    let mut body = String::from("── Decisions ──\n");
+    if decisions.is_empty() {
+        body.push_str("  (none)\n");
+    } else {
+        for (i, d) in decisions.iter().enumerate() {
+            body.push_str(&format!("  {}. {d}\n", i + 1));
+        }
+    }
+    body.push_str("\n── Open Questions ──\n");
+    if open_questions.is_empty() {
+        body.push_str("  (none)\n");
+    } else {
+        for q in &open_questions {
+            body.push_str(&format!("  - {}\n", q.text));
+        }
+    }
+    body.push_str("\n── Action Items ──\n");
+    if action_items.is_empty() {
+        body.push_str("  (none)\n");
+    } else {
+        for (i, item) in action_items.iter().enumerate() {
+            body.push_str(&format!("  {}. {}\n", i + 1, item.description));
+        }
+    }
+    body
+}

--- a/src/conversation_channel/driver.rs
+++ b/src/conversation_channel/driver.rs
@@ -1,0 +1,165 @@
+//! The one unified conversation loop.
+//!
+//! [`run_conversation`] is the single meeting-conversation driver that the new
+//! [`SignalConversation`](crate::signal_conversation) channel and the
+//! [`MockConversationChannel`](super::MockConversationChannel) drive through (and
+//! that any future channel can reuse). It calls `channel.recv()`, parses with the
+//! existing `parse_command`, routes conversation turns and record commands
+//! through the shared [`apply_record`], fires the per-channel `on_recorded` hook
+//! for structured captures, and drives `/close`.
+//!
+//! The engine ([`MeetingBackend`]) stays synchronous and unchanged. Its
+//! `send_message` / `close` / `apply_template` calls complete synchronously
+//! *before* any `.await`, so no `&mut MeetingBackend` is ever held across an
+//! await point.
+
+use crate::error::SimardResult;
+use crate::meeting_backend::MeetingBackend;
+use crate::meeting_backend::command::{MeetingCommand, parse_command};
+
+use super::{ConversationChannel, OutKind, Outbound, apply_record};
+
+/// Drive one operator↔Simard conversation to completion over `channel`, using
+/// `backend` as the (synchronous) meeting engine. Returns when the operator
+/// closes the meeting or the channel reaches end-of-stream.
+pub async fn run_conversation<C: ConversationChannel>(
+    channel: &mut C,
+    backend: &mut MeetingBackend,
+) -> SimardResult<()> {
+    while let Some(inbound) = channel.recv().await? {
+        match parse_command(&inbound.text) {
+            MeetingCommand::Close => {
+                let out = close_backend(backend);
+                channel.send(out).await?;
+                break;
+            }
+            MeetingCommand::Conversation(text) => {
+                if text.is_empty() {
+                    continue;
+                }
+                channel.send(conversation_turn(backend, &text)).await?;
+            }
+            MeetingCommand::Export => {
+                channel.send(export(backend)).await?;
+            }
+            MeetingCommand::Template(name) => {
+                channel.send(template(backend, &name)).await?;
+            }
+            other => {
+                if let Some(rec) = apply_record(backend, &other) {
+                    let is_record = rec.kind == OutKind::Recorded;
+                    channel
+                        .send(Outbound {
+                            kind: rec.kind,
+                            text: rec.text,
+                        })
+                        .await?;
+                    // The per-channel post-record hook fires only for actual
+                    // structured captures, never for read-only status views —
+                    // this is what keeps the CLI capture tally off `/status`.
+                    if is_record {
+                        channel.on_recorded(backend).await?;
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Run one conversational (LLM) turn and render the reply as an `Assistant`
+/// outbound, or an `Error` outbound if the engine turn fails.
+fn conversation_turn(backend: &mut MeetingBackend, text: &str) -> Outbound {
+    match backend.send_message(text) {
+        Ok(resp) => Outbound {
+            kind: OutKind::Assistant,
+            text: resp.content,
+        },
+        Err(e) => Outbound {
+            kind: OutKind::Error,
+            text: format!("[error: {e}]"),
+        },
+    }
+}
+
+/// Close the meeting, writing the handoff bundle exactly as before, and render a
+/// closing summary. Errors surface as an `Error` outbound; the loop ends either
+/// way because the session is over.
+fn close_backend(backend: &mut MeetingBackend) -> Outbound {
+    match backend.close() {
+        Ok(s) => {
+            let mut body = format!(
+                "Meeting closed. {} messages. Summary: {}",
+                s.message_count, s.summary_text
+            );
+            if let Some(dir) = &s.bundle_dir {
+                body.push_str(&format!("\nBundle: {dir}"));
+            }
+            if let Some(md) = &s.markdown_report_path {
+                body.push_str(&format!("\nReport: {md}"));
+            }
+            Outbound {
+                kind: OutKind::Status,
+                text: body,
+            }
+        }
+        Err(e) => Outbound {
+            kind: OutKind::Error,
+            text: format!("Meeting closed with error: {e}"),
+        },
+    }
+}
+
+/// Export the current transcript to markdown and render the resulting path.
+fn export(backend: &MeetingBackend) -> Outbound {
+    use crate::meeting_backend::persist::write_markdown_export;
+    match write_markdown_export(backend.topic(), backend.started_at(), backend.history()) {
+        Ok(path) => Outbound {
+            kind: OutKind::Status,
+            text: format!("Meeting exported to: {}", path.display()),
+        },
+        Err(e) => Outbound {
+            kind: OutKind::Error,
+            text: format!("[export error: {e}]"),
+        },
+    }
+}
+
+/// Apply a meeting template: list templates for an empty name, otherwise record
+/// the agenda on the session and fire a single LLM context-injection turn.
+fn template(backend: &mut MeetingBackend, name: &str) -> Outbound {
+    use crate::meeting_backend::persist::{TEMPLATES, find_template};
+    if name.is_empty() {
+        let mut listing = String::from("Available templates:\n");
+        for t in TEMPLATES {
+            listing.push_str(&format!("  {} — {}\n", t.name, t.description));
+        }
+        listing.push_str("\nUsage: /template <name>");
+        return Outbound {
+            kind: OutKind::Status,
+            text: listing,
+        };
+    }
+    let Some(tmpl) = find_template(name) else {
+        return Outbound {
+            kind: OutKind::Status,
+            text: format!("Unknown template: {name}. Available: standup, 1on1, retro, planning"),
+        };
+    };
+    backend.apply_template(tmpl.name, tmpl.agenda);
+    let ctx = format!(
+        "The operator has selected the '{}' meeting template. \
+         Please follow this agenda:\n{}",
+        tmpl.name, tmpl.agenda
+    );
+    match backend.send_message(&ctx) {
+        Ok(resp) => Outbound {
+            kind: OutKind::Assistant,
+            text: resp.content,
+        },
+        Err(e) => Outbound {
+            kind: OutKind::Error,
+            text: format!("[template error: {e}]"),
+        },
+    }
+}

--- a/src/conversation_channel/mock.rs
+++ b/src/conversation_channel/mock.rs
@@ -1,0 +1,79 @@
+//! A scripted [`ConversationChannel`] test double for driver + integration tests.
+//!
+//! Unlike the `apply_record`/`run_conversation` stubs, the mock is **fully
+//! implemented** — it is test infrastructure, and a required deliverable of the
+//! abstraction. `recv` replays a scripted list of inbound lines (all authorized)
+//! and then ends the session; `send` captures every [`Outbound`]; `on_recorded`
+//! counts its own invocations so a test can assert the hook fires once per
+//! record command.
+
+use std::collections::VecDeque;
+use std::future::Future;
+
+use crate::error::SimardResult;
+use crate::meeting_backend::MeetingBackend;
+
+use super::{ConversationChannel, Inbound, OperatorRef, Outbound};
+
+/// A scripted `ConversationChannel` for driver + integration tests.
+pub struct MockConversationChannel {
+    inbox: VecDeque<String>,
+    sent: Vec<Outbound>,
+    recorded_hook_calls: usize,
+}
+
+impl MockConversationChannel {
+    /// Build from a script of inbound lines; each `recv()` yields the next line
+    /// (as an authorized [`Inbound`]), then `Ok(None)`.
+    pub fn with_script(lines: Vec<&str>) -> Self {
+        Self {
+            inbox: lines.into_iter().map(|s| s.to_string()).collect(),
+            sent: Vec::new(),
+            recorded_hook_calls: 0,
+        }
+    }
+
+    /// All [`Outbound`] messages captured by `send()`, in order.
+    pub fn sent(&self) -> &[Outbound] {
+        &self.sent
+    }
+
+    /// Count of `on_recorded` invocations (asserts the hook fires per record).
+    pub fn recorded_hook_calls(&self) -> usize {
+        self.recorded_hook_calls
+    }
+}
+
+impl ConversationChannel for MockConversationChannel {
+    fn name(&self) -> &'static str {
+        "mock"
+    }
+
+    fn recv(&mut self) -> impl Future<Output = SimardResult<Option<Inbound>>> + Send {
+        // Advance the script synchronously so the returned future owns its data
+        // and never borrows `self` across an `.await`.
+        let next = self.inbox.pop_front();
+        async move {
+            Ok(next.map(|text| Inbound {
+                from: OperatorRef {
+                    id: "mock".to_string(),
+                    authorized: true,
+                },
+                text,
+            }))
+        }
+    }
+
+    fn send(&mut self, out: Outbound) -> impl Future<Output = SimardResult<()>> + Send {
+        self.sent.push(out);
+        async move { Ok(()) }
+    }
+
+    fn on_recorded(
+        &mut self,
+        _backend: &MeetingBackend,
+    ) -> impl Future<Output = SimardResult<()>> + Send {
+        self.recorded_hook_calls += 1;
+        async move { Ok(()) }
+    }
+}

--- a/src/conversation_channel/mod.rs
+++ b/src/conversation_channel/mod.rs
@@ -1,0 +1,118 @@
+//! One clearly-named operator↔Simard conversation abstraction (issue #2527).
+//!
+//! A **meeting is a conversation.** Every operator↔Simard meeting — in a
+//! terminal, in the dashboard chat pane, or over Signal — is the same
+//! bidirectional session: the operator sends an inbound line, Simard delivers
+//! outbound replies and notices, the session opens and closes, and the
+//! structured-capture commands (`/goal`, `/decision`, `/action`, `/question`, …)
+//! feed the meeting handoff and goal-carryover chain.
+//!
+//! [`ConversationChannel`] is the single abstraction for that session. The
+//! record/status dispatch that was duplicated across the CLI REPL and the
+//! dashboard chat loop is extracted once into [`dispatch::apply_record`], which
+//! **both** loops now call for the `/goal`, `/decision`, `/action`, `/question`,
+//! `/theme`, `/owner`, `/risk`, and `/disagree` captures. [`driver::run_conversation`]
+//! is the unified driver over the trait; it is realized by the new
+//! [`crate::signal_conversation::SignalConversation`] channel and by
+//! [`MockConversationChannel`], and is available for any future channel.
+//!
+//! # Naming
+//!
+//! Nothing here is named `bridge`/`Bridge`. This is a first-class chat
+//! abstraction and is unrelated to the pre-existing cognitive-memory
+//! `BridgeTransport`. The Signal implementation ([`crate::signal_conversation`])
+//! does **not** route through that trait.
+
+use std::future::Future;
+
+use crate::error::SimardResult;
+use crate::meeting_backend::MeetingBackend;
+
+pub mod dispatch;
+pub mod driver;
+pub mod mock;
+
+#[cfg(test)]
+mod tests;
+
+pub use dispatch::{Recorded, apply_record};
+pub use driver::run_conversation;
+pub use mock::MockConversationChannel;
+
+/// Who sent an inbound message. Used for the sender allowlist + identity binding.
+#[derive(Clone, Debug)]
+pub struct OperatorRef {
+    /// Channel-native id: terminal user, dashboard session id, or Signal E.164.
+    pub id: String,
+    /// True once this ref has cleared the channel's allowlist / identity /
+    /// dashboard-auth check. The driver assumes every inbound it receives is
+    /// authorized; a channel that gates senders filters before returning.
+    pub authorized: bool,
+}
+
+/// One operator-originated message line, already trimmed of surrounding
+/// whitespace by the channel.
+#[derive(Clone, Debug)]
+pub struct Inbound {
+    pub from: OperatorRef,
+    pub text: String,
+}
+
+/// A Simard-originated message to deliver on the channel. Render-agnostic: the
+/// channel's [`ConversationChannel::send`] maps [`OutKind`] to its own
+/// presentation (ANSI color, JSON role, or a Signal send).
+#[derive(Clone, Debug)]
+pub struct Outbound {
+    pub kind: OutKind,
+    pub text: String,
+}
+
+/// The kind of a Simard-originated message, so each channel can render it in its
+/// own way without the shared driver knowing anything about presentation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OutKind {
+    /// Simard's conversational LLM reply.
+    Assistant,
+    /// A structured-capture acknowledgement ("Decision recorded: …", etc.).
+    Recorded,
+    /// Read-only session output (`/status`, `/state`, `/recap`, `/preview`, `/help`).
+    Status,
+    /// A notification-out: PR merge-ready, stall/problem, high-risk sign-off request.
+    Notice,
+    /// An error message.
+    Error,
+}
+
+/// A bidirectional operator↔Simard conversation channel. The meeting IS the
+/// conversation; each implementation is one channel over the shared
+/// [`MeetingBackend`]. Native async via return-position `impl Future` (no
+/// `async-trait` dependency). Used with static dispatch — never as `dyn`.
+pub trait ConversationChannel {
+    /// Stable id for logs/metrics: `"cli"`, `"dashboard"`, `"signal"`, `"mock"`.
+    fn name(&self) -> &'static str;
+
+    /// Await the next authorized operator line.
+    ///
+    /// `Ok(None)` ends the session (EOF, socket closed, or operator quit).
+    /// Implementations MUST NOT yield an inbound whose `from.authorized` is
+    /// `false`; unauthorized input is dropped inside the channel before it
+    /// reaches the driver.
+    fn recv(&mut self) -> impl Future<Output = SimardResult<Option<Inbound>>> + Send;
+
+    /// Deliver one Simard message OUT on this channel. `send` is total: a
+    /// channel renders every [`OutKind`] and must not drop any.
+    fn send(&mut self, out: Outbound) -> impl Future<Output = SimardResult<()>> + Send;
+
+    /// Per-channel hook fired after a structured capture is applied (i.e. after an
+    /// [`OutKind::Recorded`] outbound). The default is a no-op; a channel with
+    /// post-record effects overrides it (for example the mock counts its calls).
+    /// The CLI REPL keeps its `checkpoint_wip` + live capture tally inline in its
+    /// own loop, so its behavior is preserved exactly; the dashboard and Signal
+    /// channels keep the default no-op.
+    fn on_recorded(
+        &mut self,
+        _backend: &MeetingBackend,
+    ) -> impl Future<Output = SimardResult<()>> + Send {
+        async { Ok(()) }
+    }
+}

--- a/src/conversation_channel/tests.rs
+++ b/src/conversation_channel/tests.rs
@@ -1,0 +1,387 @@
+//! TDD tests for the conversation abstraction (issue #2527).
+//!
+//! These are written **first**: [`apply_record`] and [`run_conversation`] are
+//! `todo!()` stubs at this point, so the tests here are the "red" phase — they
+//! pin the exact behavior the build step must deliver. `MockConversationChannel`
+//! is already implemented, so the mock self-tests pass immediately and validate
+//! the test double itself.
+//!
+//! The acknowledgement strings asserted below are the **actual** strings the CLI
+//! REPL (`meeting_repl/repl.rs`) and dashboard chat (`operator_commands_dashboard/
+//! chat.rs`) already emit — the whole point of the extraction is that they do not
+//! change. If a future edit changes any of these strings, that is a behavior
+//! regression, not a refactor.
+
+use serial_test::serial;
+
+use crate::base_types::{
+    BaseTypeDescriptor, BaseTypeId, BaseTypeOutcome, BaseTypeSession, BaseTypeTurnInput,
+    ensure_session_not_already_open, ensure_session_not_closed, ensure_session_open,
+    standard_session_capabilities,
+};
+use crate::error::SimardResult;
+use crate::meeting_backend::MeetingBackend;
+use crate::meeting_backend::command::MeetingCommand;
+use crate::metadata::{BackendDescriptor, Freshness};
+use crate::runtime::RuntimeTopology;
+
+use super::dispatch::apply_record;
+use super::driver::run_conversation;
+use super::{ConversationChannel, MockConversationChannel, OutKind};
+
+// ── Test fixtures ───────────────────────────────────────────────────────────
+
+/// Minimal mock agent returning a canned response for every turn. Local to this
+/// module so the tests are self-contained (mirrors `meeting_repl::test_support`).
+struct AlwaysOkAgent {
+    descriptor: BaseTypeDescriptor,
+    is_open: bool,
+    is_closed: bool,
+    canned_response: String,
+}
+
+impl AlwaysOkAgent {
+    fn new(response: &str) -> Self {
+        Self {
+            descriptor: BaseTypeDescriptor {
+                id: BaseTypeId::new("mock-conversation-agent"),
+                backend: BackendDescriptor::for_runtime_type::<Self>(
+                    "mock-agent",
+                    "test:mock-conversation-agent",
+                    Freshness::now().unwrap(),
+                ),
+                capabilities: standard_session_capabilities(),
+                supported_topologies: [RuntimeTopology::SingleProcess].into_iter().collect(),
+            },
+            is_open: true,
+            is_closed: false,
+            canned_response: response.to_string(),
+        }
+    }
+}
+
+impl BaseTypeSession for AlwaysOkAgent {
+    fn descriptor(&self) -> &BaseTypeDescriptor {
+        &self.descriptor
+    }
+
+    fn open(&mut self) -> SimardResult<()> {
+        ensure_session_not_closed(&self.descriptor, self.is_closed, "open")?;
+        ensure_session_not_already_open(&self.descriptor, self.is_open)?;
+        self.is_open = true;
+        Ok(())
+    }
+
+    fn run_turn(&mut self, _input: BaseTypeTurnInput) -> SimardResult<BaseTypeOutcome> {
+        ensure_session_not_closed(&self.descriptor, self.is_closed, "run_turn")?;
+        ensure_session_open(&self.descriptor, self.is_open, "run_turn")?;
+        Ok(BaseTypeOutcome {
+            plan: String::new(),
+            execution_summary: self.canned_response.clone(),
+            evidence: Vec::new(),
+        })
+    }
+
+    fn close(&mut self) -> SimardResult<()> {
+        ensure_session_not_closed(&self.descriptor, self.is_closed, "close")?;
+        self.is_closed = true;
+        Ok(())
+    }
+}
+
+fn test_backend(topic: &str) -> MeetingBackend {
+    MeetingBackend::new_session(
+        topic,
+        Box::new(AlwaysOkAgent::new("ok")),
+        None,
+        "test-system-prompt".to_string(),
+    )
+}
+
+/// Run an async body on a fresh current-thread runtime (so `spawn_blocking` in
+/// the eventual driver still works) under a hermetic handoff dir.
+fn block_on<F: std::future::Future>(fut: F) -> F::Output {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(fut)
+}
+
+// ── apply_record: pure record commands (mutation + canonical text) ───────────
+
+#[test]
+fn apply_record_theme_mutates_and_returns_canonical_text() {
+    let mut b = test_backend("t");
+    let rec = apply_record(&mut b, &MeetingCommand::Theme("performance".into()))
+        .expect("theme is a record command");
+    assert_eq!(rec.kind, OutKind::Recorded);
+    assert_eq!(rec.text, "Theme recorded: performance");
+    assert_eq!(b.explicit_themes(), &["performance".to_string()]);
+}
+
+#[test]
+fn apply_record_decision_without_rationale() {
+    let mut b = test_backend("t");
+    let rec = apply_record(
+        &mut b,
+        &MeetingCommand::Decision {
+            text: "Adopt TDD".into(),
+            rationale: None,
+        },
+    )
+    .expect("decision is a record command");
+    assert_eq!(rec.kind, OutKind::Recorded);
+    assert_eq!(rec.text, "Decision recorded: Adopt TDD");
+    assert_eq!(b.explicit_decisions().len(), 1);
+}
+
+#[test]
+fn apply_record_decision_with_rationale() {
+    let mut b = test_backend("t");
+    let rec = apply_record(
+        &mut b,
+        &MeetingCommand::Decision {
+            text: "Use signal-cli".into(),
+            rationale: Some("no embedded protocol".into()),
+        },
+    )
+    .expect("decision is a record command");
+    assert_eq!(rec.kind, OutKind::Recorded);
+    assert_eq!(
+        rec.text,
+        "Decision recorded: Use signal-cli (rationale: no embedded protocol)"
+    );
+    assert_eq!(b.explicit_decisions().len(), 1);
+}
+
+#[test]
+fn apply_record_action_mutates_and_returns_canonical_text() {
+    let mut b = test_backend("t");
+    let rec = apply_record(&mut b, &MeetingCommand::Action("write the tests".into()))
+        .expect("action is a record command");
+    assert_eq!(rec.kind, OutKind::Recorded);
+    assert_eq!(rec.text, "Action recorded: write the tests");
+    assert_eq!(b.explicit_action_items().len(), 1);
+}
+
+#[test]
+fn apply_record_question_mutates_and_returns_canonical_text() {
+    let mut b = test_backend("t");
+    let rec = apply_record(&mut b, &MeetingCommand::Question("what is our SLO?".into()))
+        .expect("question is a record command");
+    assert_eq!(rec.kind, OutKind::Recorded);
+    assert_eq!(rec.text, "Question recorded: what is our SLO?");
+    assert_eq!(b.explicit_questions().len(), 1);
+}
+
+#[test]
+fn apply_record_owner_mutates_and_returns_canonical_text() {
+    let mut b = test_backend("t");
+    let rec = apply_record(&mut b, &MeetingCommand::Owner("engineer".into()))
+        .expect("owner is a record command");
+    assert_eq!(rec.kind, OutKind::Recorded);
+    assert_eq!(rec.text, "Next owner recorded: engineer");
+    assert_eq!(b.explicit_next_owner(), Some("engineer"));
+}
+
+#[test]
+fn apply_record_goal_mutates_and_returns_canonical_text() {
+    let mut b = test_backend("t");
+    let rec = apply_record(
+        &mut b,
+        &MeetingCommand::Goal("ship the signal channel".into()),
+    )
+    .expect("goal is a record command");
+    assert_eq!(rec.kind, OutKind::Recorded);
+    assert_eq!(rec.text, "Goal recorded: ship the signal channel");
+    assert_eq!(b.explicit_goal(), Some("ship the signal channel"));
+}
+
+#[test]
+fn apply_record_risk_mutates_and_returns_canonical_text() {
+    let mut b = test_backend("t");
+    let rec = apply_record(&mut b, &MeetingCommand::Risk("unstable API".into()))
+        .expect("risk is a record command");
+    assert_eq!(rec.kind, OutKind::Recorded);
+    assert_eq!(rec.text, "Risk recorded: unstable API");
+    assert_eq!(b.explicit_risks().len(), 1);
+}
+
+#[test]
+fn apply_record_disagreement_mutates_and_returns_canonical_text() {
+    let mut b = test_backend("t");
+    let rec = apply_record(&mut b, &MeetingCommand::Disagree("prefer Python".into()))
+        .expect("disagree is a record command");
+    assert_eq!(rec.kind, OutKind::Recorded);
+    assert_eq!(rec.text, "Disagreement recorded: prefer Python");
+    assert_eq!(b.explicit_disagreements().len(), 1);
+}
+
+// ── apply_record: read-only status commands (no mutation, Status kind) ───────
+
+#[test]
+fn apply_record_status_is_status_kind_and_does_not_mutate() {
+    let mut b = test_backend("status topic");
+    let rec = apply_record(&mut b, &MeetingCommand::Status).expect("status returns a message");
+    assert_eq!(rec.kind, OutKind::Status);
+    assert!(!rec.text.is_empty());
+    // Read-only: nothing was captured.
+    assert_eq!(b.explicit_decisions().len(), 0);
+    assert_eq!(b.explicit_action_items().len(), 0);
+    assert!(b.explicit_goal().is_none());
+}
+
+#[test]
+fn apply_record_help_is_status_kind() {
+    let mut b = test_backend("t");
+    let rec = apply_record(&mut b, &MeetingCommand::Help).expect("help returns a message");
+    assert_eq!(rec.kind, OutKind::Status);
+    assert!(!rec.text.is_empty());
+}
+
+#[test]
+fn apply_record_unknown_is_status_kind() {
+    let mut b = test_backend("t");
+    let rec = apply_record(
+        &mut b,
+        &MeetingCommand::Unknown {
+            input: "/colse".into(),
+            suggestion: Some("/close".into()),
+        },
+    )
+    .expect("unknown returns a did-you-mean message");
+    assert_eq!(rec.kind, OutKind::Status);
+    assert!(!rec.text.is_empty());
+}
+
+// ── apply_record: driver-handled commands return None ────────────────────────
+
+#[test]
+fn apply_record_conversation_is_driver_handled() {
+    let mut b = test_backend("t");
+    assert!(apply_record(&mut b, &MeetingCommand::Conversation("hi".into())).is_none());
+}
+
+#[test]
+fn apply_record_close_is_driver_handled() {
+    let mut b = test_backend("t");
+    assert!(apply_record(&mut b, &MeetingCommand::Close).is_none());
+}
+
+#[test]
+fn apply_record_export_is_driver_handled() {
+    let mut b = test_backend("t");
+    assert!(apply_record(&mut b, &MeetingCommand::Export).is_none());
+}
+
+#[test]
+fn apply_record_template_is_driver_handled() {
+    let mut b = test_backend("t");
+    assert!(apply_record(&mut b, &MeetingCommand::Template("standup".into())).is_none());
+}
+
+// ── run_conversation over the mock channel ───────────────────────────────────
+
+#[test]
+#[serial(cognitive_memory)]
+fn run_conversation_routes_records_and_fires_hook() {
+    let tmp = tempfile::tempdir().unwrap();
+    // SAFETY: serial_test serializes env access across the test binary.
+    unsafe { std::env::set_var("SIMARD_HANDOFF_DIR", tmp.path()) };
+
+    let mut ch = MockConversationChannel::with_script(vec![
+        "/goal ship the signal channel",
+        "/decision use signal-cli JSON-RPC --rationale no embedded protocol",
+        "let's wrap up",
+        "/close",
+    ]);
+    let mut backend = test_backend("signal channel");
+
+    block_on(run_conversation(&mut ch, &mut backend)).unwrap();
+
+    // The goal ack is delivered as a Recorded outbound with the canonical text.
+    assert!(
+        ch.sent()
+            .iter()
+            .any(|o| o.kind == OutKind::Recorded && o.text.contains("Goal recorded")),
+        "expected a Recorded outbound acknowledging the goal; got {:?}",
+        ch.sent()
+    );
+    // on_recorded fires once per record command: /goal + /decision = 2.
+    assert_eq!(ch.recorded_hook_calls(), 2);
+}
+
+#[test]
+#[serial(cognitive_memory)]
+fn run_conversation_answers_a_conversation_turn() {
+    let tmp = tempfile::tempdir().unwrap();
+    // SAFETY: serial_test serializes env access across the test binary.
+    unsafe { std::env::set_var("SIMARD_HANDOFF_DIR", tmp.path()) };
+
+    let mut ch = MockConversationChannel::with_script(vec!["hello simard", "/close"]);
+    let mut backend = test_backend("chat");
+
+    block_on(run_conversation(&mut ch, &mut backend)).unwrap();
+
+    // A plain conversation turn produces an Assistant outbound carrying the
+    // agent's reply ("ok" from AlwaysOkAgent).
+    assert!(
+        ch.sent()
+            .iter()
+            .any(|o| o.kind == OutKind::Assistant && o.text.contains("ok")),
+        "expected an Assistant reply outbound; got {:?}",
+        ch.sent()
+    );
+    // A conversation turn is NOT a record command, so the hook never fires.
+    assert_eq!(ch.recorded_hook_calls(), 0);
+}
+
+#[test]
+#[serial(cognitive_memory)]
+fn run_conversation_closes_cleanly() {
+    let tmp = tempfile::tempdir().unwrap();
+    // SAFETY: serial_test serializes env access across the test binary.
+    unsafe { std::env::set_var("SIMARD_HANDOFF_DIR", tmp.path()) };
+
+    let mut ch = MockConversationChannel::with_script(vec!["/close"]);
+    let mut backend = test_backend("close only");
+
+    let result = block_on(run_conversation(&mut ch, &mut backend));
+    assert!(
+        result.is_ok(),
+        "clean /close should return Ok, got {result:?}"
+    );
+}
+
+// ── MockConversationChannel self-tests (mock is implemented → these pass) ─────
+
+#[test]
+fn mock_recv_replays_script_then_ends() {
+    let mut ch = MockConversationChannel::with_script(vec!["one", "two"]);
+    let first = block_on(ch.recv()).unwrap().unwrap();
+    assert_eq!(first.text, "one");
+    assert!(first.from.authorized);
+    let second = block_on(ch.recv()).unwrap().unwrap();
+    assert_eq!(second.text, "two");
+    assert!(block_on(ch.recv()).unwrap().is_none());
+}
+
+#[test]
+fn mock_send_captures_outbounds_in_order() {
+    use super::Outbound;
+    let mut ch = MockConversationChannel::with_script(vec![]);
+    block_on(ch.send(Outbound {
+        kind: OutKind::Status,
+        text: "a".into(),
+    }))
+    .unwrap();
+    block_on(ch.send(Outbound {
+        kind: OutKind::Notice,
+        text: "b".into(),
+    }))
+    .unwrap();
+    assert_eq!(ch.sent().len(), 2);
+    assert_eq!(ch.sent()[0].text, "a");
+    assert_eq!(ch.sent()[1].kind, OutKind::Notice);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,10 @@ pub mod brain_introspection;
 mod brain_introspection_tests;
 mod copilot_status_probe;
 mod copilot_task_submit;
+// Issue #2527: one clearly-named operator↔Simard conversation abstraction. The
+// CLI/TUI meeting REPL and the dashboard chat are channels over the same
+// `MeetingBackend`; `SignalConversation` (feature-gated below) is a third.
+pub mod conversation_channel;
 pub mod cost_tracking;
 pub mod disk_health;
 pub mod disk_pressure;
@@ -120,6 +124,10 @@ pub mod self_relaunch;
 pub mod self_relaunch_semaphore;
 pub mod session;
 pub mod session_builder;
+// Issue #2527: the Signal implementation of `conversation_channel`. Feature-gated
+// (default off) so the daemon builds and runs fine without signal-cli installed.
+#[cfg(feature = "signal")]
+pub mod signal_conversation;
 pub mod skill_builder;
 pub mod state_root;
 pub mod stewardship;

--- a/src/meeting_repl/repl.rs
+++ b/src/meeting_repl/repl.rs
@@ -434,64 +434,40 @@ pub fn run_meeting_repl<R: BufRead, W: Write>(
                 }
                 writeln!(output).ok();
             }
-            MeetingCommand::Theme(text) => {
-                let rec = apply_record(&mut backend, &MeetingCommand::Theme(text.clone()))
-                    .expect("theme is a record command");
-                writeln!(output, "{}", green(&rec.text)).ok();
+            // All eight structured-capture commands share one shape: apply the
+            // backend mutation via the shared `apply_record`, echo the canonical
+            // acknowledgement (color-coded by capture kind), checkpoint WIP, and —
+            // for the list-growing captures — print the live capture tally.
+            // Binding the whole command (`cmd @ …`) passes it straight to
+            // `apply_record` with no clone-and-reconstruct.
+            cmd @ (MeetingCommand::Theme(_)
+            | MeetingCommand::Decision { .. }
+            | MeetingCommand::Action(_)
+            | MeetingCommand::Question(_)
+            | MeetingCommand::Owner(_)
+            | MeetingCommand::Goal(_)
+            | MeetingCommand::Risk(_)
+            | MeetingCommand::Disagree(_)) => {
+                let rec = apply_record(&mut backend, &cmd).expect("record command");
+                let ack = match &cmd {
+                    MeetingCommand::Theme(_) | MeetingCommand::Action(_) => green(&rec.text),
+                    MeetingCommand::Decision { .. }
+                    | MeetingCommand::Owner(_)
+                    | MeetingCommand::Goal(_) => cyan(&rec.text),
+                    _ => yellow(&rec.text),
+                };
+                writeln!(output, "{ack}").ok();
                 checkpoint_wip(&backend);
-            }
-            MeetingCommand::Decision { text, rationale } => {
-                let rec = apply_record(
-                    &mut backend,
-                    &MeetingCommand::Decision {
-                        text: text.clone(),
-                        rationale: rationale.clone(),
-                    },
-                )
-                .expect("decision is a record command");
-                writeln!(output, "{}", cyan(&rec.text)).ok();
-                checkpoint_wip(&backend);
-                writeln!(output, "{}", capture_tally(&backend)).ok();
-            }
-            MeetingCommand::Action(text) => {
-                let rec = apply_record(&mut backend, &MeetingCommand::Action(text.clone()))
-                    .expect("action is a record command");
-                writeln!(output, "{}", green(&rec.text)).ok();
-                checkpoint_wip(&backend);
-                writeln!(output, "{}", capture_tally(&backend)).ok();
-            }
-            MeetingCommand::Question(text) => {
-                let rec = apply_record(&mut backend, &MeetingCommand::Question(text.clone()))
-                    .expect("question is a record command");
-                writeln!(output, "{}", yellow(&rec.text)).ok();
-                checkpoint_wip(&backend);
-                writeln!(output, "{}", capture_tally(&backend)).ok();
-            }
-            MeetingCommand::Owner(text) => {
-                let rec = apply_record(&mut backend, &MeetingCommand::Owner(text.clone()))
-                    .expect("owner is a record command");
-                writeln!(output, "{}", cyan(&rec.text)).ok();
-                checkpoint_wip(&backend);
-            }
-            MeetingCommand::Goal(text) => {
-                let rec = apply_record(&mut backend, &MeetingCommand::Goal(text.clone()))
-                    .expect("goal is a record command");
-                writeln!(output, "{}", cyan(&rec.text)).ok();
-                checkpoint_wip(&backend);
-            }
-            MeetingCommand::Risk(text) => {
-                let rec = apply_record(&mut backend, &MeetingCommand::Risk(text.clone()))
-                    .expect("risk is a record command");
-                writeln!(output, "{}", yellow(&rec.text)).ok();
-                checkpoint_wip(&backend);
-                writeln!(output, "{}", capture_tally(&backend)).ok();
-            }
-            MeetingCommand::Disagree(text) => {
-                let rec = apply_record(&mut backend, &MeetingCommand::Disagree(text.clone()))
-                    .expect("disagree is a record command");
-                writeln!(output, "{}", yellow(&rec.text)).ok();
-                checkpoint_wip(&backend);
-                writeln!(output, "{}", capture_tally(&backend)).ok();
+                if matches!(
+                    cmd,
+                    MeetingCommand::Decision { .. }
+                        | MeetingCommand::Action(_)
+                        | MeetingCommand::Question(_)
+                        | MeetingCommand::Risk(_)
+                        | MeetingCommand::Disagree(_)
+                ) {
+                    writeln!(output, "{}", capture_tally(&backend)).ok();
+                }
             }
             MeetingCommand::Recap => {
                 let status = backend.status();

--- a/src/meeting_repl/repl.rs
+++ b/src/meeting_repl/repl.rs
@@ -7,6 +7,7 @@ use std::io::{BufRead, Write};
 
 use crate::base_types::BaseTypeSession;
 use crate::cognitive_memory::CognitiveMemoryOps;
+use crate::conversation_channel::apply_record;
 use crate::error::{SimardError, SimardResult};
 use crate::meeting_backend::persist::{
     extract_action_items, extract_decisions, extract_disagreements, extract_open_questions,
@@ -434,57 +435,61 @@ pub fn run_meeting_repl<R: BufRead, W: Write>(
                 writeln!(output).ok();
             }
             MeetingCommand::Theme(text) => {
-                backend.push_theme(text.clone());
-                writeln!(output, "{}", green(&format!("Theme recorded: {text}"))).ok();
+                let rec = apply_record(&mut backend, &MeetingCommand::Theme(text.clone()))
+                    .expect("theme is a record command");
+                writeln!(output, "{}", green(&rec.text)).ok();
                 checkpoint_wip(&backend);
             }
             MeetingCommand::Decision { text, rationale } => {
-                backend.push_explicit_decision(&text, rationale.as_deref());
-                let msg = if let Some(ref r) = rationale {
-                    format!("Decision recorded: {text} (rationale: {r})")
-                } else {
-                    format!("Decision recorded: {text}")
-                };
-                writeln!(output, "{}", cyan(&msg)).ok();
+                let rec = apply_record(
+                    &mut backend,
+                    &MeetingCommand::Decision {
+                        text: text.clone(),
+                        rationale: rationale.clone(),
+                    },
+                )
+                .expect("decision is a record command");
+                writeln!(output, "{}", cyan(&rec.text)).ok();
                 checkpoint_wip(&backend);
                 writeln!(output, "{}", capture_tally(&backend)).ok();
             }
             MeetingCommand::Action(text) => {
-                backend.push_explicit_action_item(&text);
-                writeln!(output, "{}", green(&format!("Action recorded: {text}"))).ok();
+                let rec = apply_record(&mut backend, &MeetingCommand::Action(text.clone()))
+                    .expect("action is a record command");
+                writeln!(output, "{}", green(&rec.text)).ok();
                 checkpoint_wip(&backend);
                 writeln!(output, "{}", capture_tally(&backend)).ok();
             }
             MeetingCommand::Question(text) => {
-                backend.push_explicit_question(&text);
-                writeln!(output, "{}", yellow(&format!("Question recorded: {text}"))).ok();
+                let rec = apply_record(&mut backend, &MeetingCommand::Question(text.clone()))
+                    .expect("question is a record command");
+                writeln!(output, "{}", yellow(&rec.text)).ok();
                 checkpoint_wip(&backend);
                 writeln!(output, "{}", capture_tally(&backend)).ok();
             }
             MeetingCommand::Owner(text) => {
-                backend.push_next_owner(&text);
-                writeln!(output, "{}", cyan(&format!("Next owner recorded: {text}"))).ok();
+                let rec = apply_record(&mut backend, &MeetingCommand::Owner(text.clone()))
+                    .expect("owner is a record command");
+                writeln!(output, "{}", cyan(&rec.text)).ok();
                 checkpoint_wip(&backend);
             }
             MeetingCommand::Goal(text) => {
-                backend.set_goal(&text);
-                writeln!(output, "{}", cyan(&format!("Goal recorded: {text}"))).ok();
+                let rec = apply_record(&mut backend, &MeetingCommand::Goal(text.clone()))
+                    .expect("goal is a record command");
+                writeln!(output, "{}", cyan(&rec.text)).ok();
                 checkpoint_wip(&backend);
             }
             MeetingCommand::Risk(text) => {
-                backend.push_explicit_risk(&text);
-                writeln!(output, "{}", yellow(&format!("Risk recorded: {text}"))).ok();
+                let rec = apply_record(&mut backend, &MeetingCommand::Risk(text.clone()))
+                    .expect("risk is a record command");
+                writeln!(output, "{}", yellow(&rec.text)).ok();
                 checkpoint_wip(&backend);
                 writeln!(output, "{}", capture_tally(&backend)).ok();
             }
             MeetingCommand::Disagree(text) => {
-                backend.push_explicit_disagreement(&text);
-                writeln!(
-                    output,
-                    "{}",
-                    yellow(&format!("Disagreement recorded: {text}"))
-                )
-                .ok();
+                let rec = apply_record(&mut backend, &MeetingCommand::Disagree(text.clone()))
+                    .expect("disagree is a record command");
+                writeln!(output, "{}", yellow(&rec.text)).ok();
                 checkpoint_wip(&backend);
                 writeln!(output, "{}", capture_tally(&backend)).ok();
             }

--- a/src/operator_cli/mod.rs
+++ b/src/operator_cli/mod.rs
@@ -13,6 +13,7 @@ mod review;
 mod safe_update;
 mod self_deploy;
 mod self_health;
+mod signal;
 mod worktree_gc;
 
 use std::path::PathBuf;
@@ -100,6 +101,10 @@ Product modes:
   gym run-suite <suite-id>
   ooda run [--cycles=N] [--no-auto-reload] [state-root]
   dashboard serve [--port=8080]
+  signal run             — connect to the configured signal-cli JSON-RPC daemon
+                           and run the operator Signal conversation channel
+                           (requires a build with --features signal + a [signal]
+                           config table; see docs/howto/set-up-the-signal-channel.md)
   memory stats [state-root] [--json]
                          — read-only per-type cognitive-memory counts +
                            graph-edge / dedup section + sample rows
@@ -233,6 +238,7 @@ where
         "gym" => gym::dispatch_gym_command(args),
         "ooda" => ooda::dispatch_ooda_command(args),
         "dashboard" => dashboard::dispatch_dashboard_command(args),
+        "signal" => signal::dispatch_signal_command(args),
         "memory" => memory::dispatch_memory_command(args),
         "spawn" => dispatch_spawn_command(args),
         "merge-pr" => merge::dispatch_merge_pr_command(args),
@@ -340,7 +346,7 @@ where
 }
 
 pub fn operator_cli_usage() -> &'static str {
-    "usage: simard <engineer|meeting|goal-curation|improvement-curation|gym|ooda|memory|spawn|merge-pr|worktree-gc|handover|update|safe-update|rollback|rollback-watchdog|install|review|bootstrap> ..."
+    "usage: simard <engineer|meeting|goal-curation|improvement-curation|gym|ooda|memory|spawn|merge-pr|worktree-gc|handover|update|safe-update|rollback|rollback-watchdog|install|review|bootstrap|signal> ..."
 }
 
 pub fn operator_cli_help() -> &'static str {

--- a/src/operator_cli/signal.rs
+++ b/src/operator_cli/signal.rs
@@ -1,0 +1,169 @@
+//! The `simard signal` operator subcommand — launch the Signal conversation
+//! channel (issue #2527).
+//!
+//! This is the operator-facing entrypoint that actually wires the feature-gated
+//! [`crate::signal_conversation`] external-service integration into the running
+//! binary: `simard signal run` loads the `[signal]` config, connects to the
+//! locally-run signal-cli JSON-RPC daemon, and drives the operator↔Simard
+//! meeting conversation (with the sender allowlist + high-risk sign-off gating)
+//! until the socket closes.
+//!
+//! The subcommand is **always recognized** so the operator gets a clear message
+//! either way; the Signal implementation itself compiles only under the `signal`
+//! Cargo feature (default off). A default build recognizes `simard signal` and
+//! tells the operator to rebuild with `--features signal` instead of failing
+//! with a bare "unsupported command".
+//!
+//! # Naming
+//!
+//! Nothing here is named `bridge`/`Bridge`. This dispatches the first-class
+//! Signal conversation channel and is unrelated to the cognitive-memory
+//! `BridgeTransport`.
+
+use super::args::{next_required, reject_extra_args};
+
+pub(super) const SIGNAL_HELP: &str = "\
+Simard signal subcommand
+
+Usage: simard signal <command>
+
+Commands:
+  run               Connect to the configured signal-cli JSON-RPC daemon and run
+                    the operator Signal conversation channel until the socket
+                    closes. Requires a build with `--features signal` and a
+                    [signal] config table (endpoint, account, allowlist).
+  help, -h, --help  Show this help message and exit.
+
+The Signal channel is OPTIONAL and OFF by default; a plain build has no Signal
+code compiled in. See docs/howto/set-up-the-signal-channel.md for full setup.
+";
+
+pub fn dispatch_signal_command(
+    mut args: impl Iterator<Item = String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let subcommand = next_required(&mut args, "signal subcommand (run)")?;
+    match subcommand.as_str() {
+        "--help" | "-h" | "help" => {
+            print!("{SIGNAL_HELP}");
+            Ok(())
+        }
+        "run" => {
+            reject_extra_args(args)?;
+            run_signal_channel()
+        }
+        other => Err(format!("unsupported command 'signal {other}'").into()),
+    }
+}
+
+/// Load the `[signal]` config, build a tokio runtime, and drive the Signal
+/// conversation channel to completion. Compiled only under the `signal` feature.
+#[cfg(feature = "signal")]
+fn run_signal_channel() -> Result<(), Box<dyn std::error::Error>> {
+    use crate::signal_conversation::{self, SignalConfig};
+
+    let config = SignalConfig::load()?;
+    eprintln!(
+        "[simard] signal: connecting to signal-cli daemon at {} (account {}); {} allowlisted operator(s)",
+        config.endpoint,
+        config.account,
+        config.allowlist.len()
+    );
+    if config.allowlist.is_empty() {
+        eprintln!(
+            "[simard] signal: WARNING — the operator allowlist is empty; the channel is fail-closed and will accept no commands. Set [signal].allowlist (or SIMARD_SIGNAL_ALLOWLIST)."
+        );
+    }
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?;
+    rt.block_on(signal_conversation::run(config))?;
+    Ok(())
+}
+
+/// Feature-off stub: `simard signal run` is recognized but the Signal channel is
+/// not compiled in, so report a clear, actionable message rather than failing
+/// with "unsupported command".
+#[cfg(not(feature = "signal"))]
+fn run_signal_channel() -> Result<(), Box<dyn std::error::Error>> {
+    Err("the Signal channel is not compiled into this build; rebuild with `cargo build --features signal` and configure the [signal] table (see docs/howto/set-up-the-signal-channel.md)"
+        .into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_subcommand_returns_error() {
+        let args = Vec::<String>::new().into_iter();
+        let result = dispatch_signal_command(args);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("expected"));
+    }
+
+    #[test]
+    fn unsupported_subcommand_returns_error() {
+        let args = vec!["nope".to_string()].into_iter();
+        let result = dispatch_signal_command(args);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("unsupported command")
+        );
+    }
+
+    #[test]
+    fn help_flag_exits_ok() {
+        let args = vec!["--help".to_string()].into_iter();
+        let result = dispatch_signal_command(args);
+        assert!(
+            result.is_ok(),
+            "signal --help must exit Ok, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn short_help_flag_exits_ok() {
+        let args = vec!["-h".to_string()].into_iter();
+        let result = dispatch_signal_command(args);
+        assert!(result.is_ok(), "signal -h must exit Ok, got: {result:?}");
+    }
+
+    #[test]
+    fn help_word_exits_ok() {
+        let args = vec!["help".to_string()].into_iter();
+        let result = dispatch_signal_command(args);
+        assert!(result.is_ok(), "signal help must exit Ok, got: {result:?}");
+    }
+
+    #[test]
+    fn run_rejects_trailing_args() {
+        let args = vec!["run".to_string(), "--extra".to_string()].into_iter();
+        let result = dispatch_signal_command(args);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("unexpected trailing")
+        );
+    }
+
+    // Without the `signal` feature, `run` must report a clear, actionable
+    // message pointing at the feature flag — never silently no-op.
+    #[cfg(not(feature = "signal"))]
+    #[test]
+    fn run_without_feature_points_at_feature_flag() {
+        let args = vec!["run".to_string()].into_iter();
+        let result = dispatch_signal_command(args);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("--features signal"),
+            "message should name the feature flag, got: {msg}"
+        );
+    }
+}

--- a/src/operator_cli/tests_mod.rs
+++ b/src/operator_cli/tests_mod.rs
@@ -458,6 +458,7 @@ fn test_all_subcommands_accept_help_flag() {
         "gym",
         "ooda",
         "dashboard",
+        "signal",
         "spawn",
         "merge-pr",
         "worktree-gc",

--- a/src/operator_commands_dashboard/chat.rs
+++ b/src/operator_commands_dashboard/chat.rs
@@ -75,6 +75,7 @@ pub(crate) async fn ws_chat_handler(ws: WebSocketUpgrade) -> response::Response 
 }
 
 pub(crate) async fn handle_ws_chat(mut socket: WebSocket) {
+    use crate::conversation_channel::apply_record;
     use crate::meeting_backend::{
         MeetingBackend, MeetingCommand, parse_command, render_help_plain, unknown_command_notice,
     };
@@ -264,92 +265,96 @@ pub(crate) async fn handle_ws_chat(mut socket: WebSocket) {
                             .await;
                     }
                     MeetingCommand::Theme(theme) => {
-                        backend.push_theme(theme.clone());
-                        let content = format!("Theme recorded: {theme}");
+                        let rec = apply_record(&mut backend, &MeetingCommand::Theme(theme.clone()))
+                            .expect("theme is a record command");
                         let _ = socket
                             .send(Message::Text(
-                                json!({"role":"system","content": content})
+                                json!({"role":"system","content": rec.text})
                                     .to_string()
                                     .into(),
                             ))
                             .await;
                     }
                     MeetingCommand::Decision { text, rationale } => {
-                        backend.push_explicit_decision(&text, rationale.as_deref());
-                        let content = if let Some(ref r) = rationale {
-                            format!("Decision recorded: {text} (rationale: {r})")
-                        } else {
-                            format!("Decision recorded: {text}")
-                        };
+                        let rec = apply_record(
+                            &mut backend,
+                            &MeetingCommand::Decision {
+                                text: text.clone(),
+                                rationale: rationale.clone(),
+                            },
+                        )
+                        .expect("decision is a record command");
                         let _ = socket
                             .send(Message::Text(
-                                json!({"role":"system","content": content})
+                                json!({"role":"system","content": rec.text})
                                     .to_string()
                                     .into(),
                             ))
                             .await;
                     }
                     MeetingCommand::Action(text) => {
-                        backend.push_explicit_action_item(&text);
-                        let content = format!("Action recorded: {text}");
+                        let rec = apply_record(&mut backend, &MeetingCommand::Action(text.clone()))
+                            .expect("action is a record command");
                         let _ = socket
                             .send(Message::Text(
-                                json!({"role":"system","content": content})
+                                json!({"role":"system","content": rec.text})
                                     .to_string()
                                     .into(),
                             ))
                             .await;
                     }
                     MeetingCommand::Question(text) => {
-                        backend.push_explicit_question(&text);
-                        let content = format!("Question recorded: {text}");
+                        let rec =
+                            apply_record(&mut backend, &MeetingCommand::Question(text.clone()))
+                                .expect("question is a record command");
                         let _ = socket
                             .send(Message::Text(
-                                json!({"role":"system","content": content})
+                                json!({"role":"system","content": rec.text})
                                     .to_string()
                                     .into(),
                             ))
                             .await;
                     }
                     MeetingCommand::Owner(text) => {
-                        backend.push_next_owner(&text);
-                        let content = format!("Next owner recorded: {text}");
+                        let rec = apply_record(&mut backend, &MeetingCommand::Owner(text.clone()))
+                            .expect("owner is a record command");
                         let _ = socket
                             .send(Message::Text(
-                                json!({"role":"system","content": content})
+                                json!({"role":"system","content": rec.text})
                                     .to_string()
                                     .into(),
                             ))
                             .await;
                     }
                     MeetingCommand::Goal(text) => {
-                        backend.set_goal(&text);
-                        let content = format!("Goal recorded: {text}");
+                        let rec = apply_record(&mut backend, &MeetingCommand::Goal(text.clone()))
+                            .expect("goal is a record command");
                         let _ = socket
                             .send(Message::Text(
-                                json!({"role":"system","content": content})
+                                json!({"role":"system","content": rec.text})
                                     .to_string()
                                     .into(),
                             ))
                             .await;
                     }
                     MeetingCommand::Risk(text) => {
-                        backend.push_explicit_risk(&text);
-                        let content = format!("Risk recorded: {text}");
+                        let rec = apply_record(&mut backend, &MeetingCommand::Risk(text.clone()))
+                            .expect("risk is a record command");
                         let _ = socket
                             .send(Message::Text(
-                                json!({"role":"system","content": content})
+                                json!({"role":"system","content": rec.text})
                                     .to_string()
                                     .into(),
                             ))
                             .await;
                     }
                     MeetingCommand::Disagree(text) => {
-                        backend.push_explicit_disagreement(&text);
-                        let content = format!("Disagreement recorded: {text}");
+                        let rec =
+                            apply_record(&mut backend, &MeetingCommand::Disagree(text.clone()))
+                                .expect("disagree is a record command");
                         let _ = socket
                             .send(Message::Text(
-                                json!({"role":"system","content": content})
+                                json!({"role":"system","content": rec.text})
                                     .to_string()
                                     .into(),
                             ))

--- a/src/operator_commands_dashboard/chat.rs
+++ b/src/operator_commands_dashboard/chat.rs
@@ -264,94 +264,20 @@ pub(crate) async fn handle_ws_chat(mut socket: WebSocket) {
                             ))
                             .await;
                     }
-                    MeetingCommand::Theme(theme) => {
-                        let rec = apply_record(&mut backend, &MeetingCommand::Theme(theme.clone()))
-                            .expect("theme is a record command");
-                        let _ = socket
-                            .send(Message::Text(
-                                json!({"role":"system","content": rec.text})
-                                    .to_string()
-                                    .into(),
-                            ))
-                            .await;
-                    }
-                    MeetingCommand::Decision { text, rationale } => {
-                        let rec = apply_record(
-                            &mut backend,
-                            &MeetingCommand::Decision {
-                                text: text.clone(),
-                                rationale: rationale.clone(),
-                            },
-                        )
-                        .expect("decision is a record command");
-                        let _ = socket
-                            .send(Message::Text(
-                                json!({"role":"system","content": rec.text})
-                                    .to_string()
-                                    .into(),
-                            ))
-                            .await;
-                    }
-                    MeetingCommand::Action(text) => {
-                        let rec = apply_record(&mut backend, &MeetingCommand::Action(text.clone()))
-                            .expect("action is a record command");
-                        let _ = socket
-                            .send(Message::Text(
-                                json!({"role":"system","content": rec.text})
-                                    .to_string()
-                                    .into(),
-                            ))
-                            .await;
-                    }
-                    MeetingCommand::Question(text) => {
-                        let rec =
-                            apply_record(&mut backend, &MeetingCommand::Question(text.clone()))
-                                .expect("question is a record command");
-                        let _ = socket
-                            .send(Message::Text(
-                                json!({"role":"system","content": rec.text})
-                                    .to_string()
-                                    .into(),
-                            ))
-                            .await;
-                    }
-                    MeetingCommand::Owner(text) => {
-                        let rec = apply_record(&mut backend, &MeetingCommand::Owner(text.clone()))
-                            .expect("owner is a record command");
-                        let _ = socket
-                            .send(Message::Text(
-                                json!({"role":"system","content": rec.text})
-                                    .to_string()
-                                    .into(),
-                            ))
-                            .await;
-                    }
-                    MeetingCommand::Goal(text) => {
-                        let rec = apply_record(&mut backend, &MeetingCommand::Goal(text.clone()))
-                            .expect("goal is a record command");
-                        let _ = socket
-                            .send(Message::Text(
-                                json!({"role":"system","content": rec.text})
-                                    .to_string()
-                                    .into(),
-                            ))
-                            .await;
-                    }
-                    MeetingCommand::Risk(text) => {
-                        let rec = apply_record(&mut backend, &MeetingCommand::Risk(text.clone()))
-                            .expect("risk is a record command");
-                        let _ = socket
-                            .send(Message::Text(
-                                json!({"role":"system","content": rec.text})
-                                    .to_string()
-                                    .into(),
-                            ))
-                            .await;
-                    }
-                    MeetingCommand::Disagree(text) => {
-                        let rec =
-                            apply_record(&mut backend, &MeetingCommand::Disagree(text.clone()))
-                                .expect("disagree is a record command");
+                    // Every structured-capture command renders identically on the
+                    // dashboard: apply the backend mutation via the shared
+                    // `apply_record` and echo its canonical acknowledgement as a
+                    // `system` chat line. Binding the whole command (`cmd @ …`)
+                    // passes it straight through with no clone-and-reconstruct.
+                    cmd @ (MeetingCommand::Theme(_)
+                    | MeetingCommand::Decision { .. }
+                    | MeetingCommand::Action(_)
+                    | MeetingCommand::Question(_)
+                    | MeetingCommand::Owner(_)
+                    | MeetingCommand::Goal(_)
+                    | MeetingCommand::Risk(_)
+                    | MeetingCommand::Disagree(_)) => {
+                        let rec = apply_record(&mut backend, &cmd).expect("record command");
                         let _ = socket
                             .send(Message::Text(
                                 json!({"role":"system","content": rec.text})

--- a/src/signal_conversation/allowlist.rs
+++ b/src/signal_conversation/allowlist.rs
@@ -1,0 +1,57 @@
+//! Guardrail (a): the sender allowlist — fail-closed authorization for inbound
+//! Signal senders (issue #2527).
+//!
+//! Because the [`crate::conversation_channel::ConversationChannel`] contract
+//! forbids yielding an unauthorized inbound to the driver, an unknown sender can
+//! never reach a command handler: the allowlist decision is applied inside the
+//! Signal channel's `recv` before anything is dispatched.
+
+use super::config::SignalConfig;
+
+/// The result of checking one inbound sender against the allowlist.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AuthDecision {
+    /// Sender is on the allowlist; may issue commands (still subject to
+    /// high-risk gating). Maps to `OperatorRef.authorized = true`.
+    Authorized,
+    /// Sender is not allowlisted but `read_only_unknown` is set: may receive
+    /// read-only results only, and can NEVER trigger a mutation.
+    ReadOnly,
+    /// Sender is not allowlisted (fail-closed): dropped, no dispatch, no reply.
+    Ignored,
+}
+
+/// A fail-closed E.164 sender allowlist.
+pub struct Allowlist {
+    numbers: Vec<String>,
+    read_only_unknown: bool,
+}
+
+impl Allowlist {
+    /// Build directly from a list of allowed E.164 numbers.
+    pub fn new(numbers: Vec<String>, read_only_unknown: bool) -> Self {
+        Self {
+            numbers,
+            read_only_unknown,
+        }
+    }
+
+    /// Build from the `[signal]` configuration table.
+    pub fn from_config(cfg: &SignalConfig) -> Self {
+        Self::new(cfg.allowlist.clone(), cfg.read_only_unknown)
+    }
+
+    /// Classify an inbound sender. Fail-closed: only an exact E.164 match in the
+    /// configured list is [`AuthDecision::Authorized`]. A non-match is
+    /// [`AuthDecision::ReadOnly`] when `read_only_unknown` is set, else
+    /// [`AuthDecision::Ignored`]. An empty allowlist authorizes nobody.
+    pub fn authorize(&self, sender: &str) -> AuthDecision {
+        if self.numbers.iter().any(|n| n == sender) {
+            AuthDecision::Authorized
+        } else if self.read_only_unknown {
+            AuthDecision::ReadOnly
+        } else {
+            AuthDecision::Ignored
+        }
+    }
+}

--- a/src/signal_conversation/channel.rs
+++ b/src/signal_conversation/channel.rs
@@ -13,7 +13,9 @@
 //!   [`recv`](SignalConversation::recv); an unknown sender never reaches a command
 //!   handler or the meeting engine (fail-closed).
 //! - **(b) identity binding** — the authorized sender's E.164 is carried on
-//!   [`OperatorRef`], and command replies + sign-off are bound to that sender.
+//!   [`OperatorRef`] and every reply is addressed back to that sender; a gated
+//!   high-risk command runs only after an explicit `approve` from an allowlisted
+//!   operator, never from the original text.
 //! - **(c) high-risk gate** — [`gate`] routes every mutating command
 //!   (`deploy`, `merge`) to [`GateDecision::PendingSignOff`]: it is **never**
 //!   auto-executed from a text; Simard records it and asks for explicit `approve`,
@@ -157,6 +159,9 @@ impl<T: SignalTransport, H: SignalCommandHandler> SignalConversation<T, H> {
             InboundCommand::Status => self.handler.status(),
             InboundCommand::Pause => self.handler.pause(),
             InboundCommand::Approve => match self.pending.take() {
+                // Any allowlisted operator may sign off the pending high-risk
+                // command (all senders here have already cleared the allowlist),
+                // so the original requester (`_from`) is intentionally not compared.
                 Some((_from, pending_cmd)) => match self.handler.execute_approved(&pending_cmd) {
                     Ok(msg) => msg,
                     Err(e) => format!("Approved, but the action failed: {e}"),

--- a/src/signal_conversation/channel.rs
+++ b/src/signal_conversation/channel.rs
@@ -1,0 +1,520 @@
+//! The Signal conversation channel — a [`ConversationChannel`] over signal-cli
+//! (issue #2527).
+//!
+//! `SignalConversation` gives an allowlisted operator a full meeting conversation
+//! over Signal, plus a lightweight remote command surface (`status`, `pause`,
+//! `approve`, `deploy`, `merge #NNNN`) and operator notifications out — all on the
+//! **same** meeting engine and handoff/goal-carryover chain as the CLI and
+//! dashboard channels.
+//!
+//! The three remote-command guardrails from the task live here and are enforced
+//! before anything reaches the shared driver:
+//! - **(a) sender allowlist** — [`Allowlist::authorize`] is applied in
+//!   [`recv`](SignalConversation::recv); an unknown sender never reaches a command
+//!   handler or the meeting engine (fail-closed).
+//! - **(b) identity binding** — the authorized sender's E.164 is carried on
+//!   [`OperatorRef`], and command replies + sign-off are bound to that sender.
+//! - **(c) high-risk gate** — [`gate`] routes every mutating command
+//!   (`deploy`, `merge`) to [`GateDecision::PendingSignOff`]: it is **never**
+//!   auto-executed from a text; Simard records it and asks for explicit `approve`,
+//!   after which execution runs through the existing operational-autonomy gate via
+//!   the injected [`SignalCommandHandler`].
+//!
+//! # Naming
+//!
+//! Nothing here is named `bridge`/`Bridge`. `SignalConversation` is a first-class
+//! conversation channel and does not implement the cognitive-memory
+//! `BridgeTransport`.
+
+use crate::conversation_channel::{ConversationChannel, Inbound, OperatorRef, OutKind, Outbound};
+use crate::error::SimardResult;
+
+use super::allowlist::{Allowlist, AuthDecision};
+use super::config::SignalConfig;
+use super::gating::{GateDecision, InboundCommand, gate, parse_inbound};
+use super::transport::{SignalTransport, build_send_request};
+
+/// The integration seam for the effects a Signal command produces. Keeping this
+/// out of the channel lets the (security-critical) allowlist + gating routing be
+/// unit-tested in isolation, and lets a deployment wire concrete `status` /
+/// `pause` / high-risk execution to its real subsystems.
+///
+/// `execute_approved` is the **only** method that performs a mutating action, and
+/// the channel calls it **only** after an explicit `approve` for a previously
+/// gated high-risk command — never directly from an inbound text.
+pub trait SignalCommandHandler: Send {
+    /// Operator-facing status/health line for the `status` command.
+    fn status(&self) -> String;
+
+    /// Pause autonomous dispatch; returns the operator-facing confirmation.
+    fn pause(&mut self) -> String;
+
+    /// Execute a high-risk command after explicit operator sign-off. Runs through
+    /// the existing operational-autonomy gate; returns the operator-facing result.
+    fn execute_approved(&mut self, cmd: &InboundCommand) -> SimardResult<String>;
+}
+
+/// A conservative default handler used by [`run`]. It reports truthful daemon
+/// health and pause state, and on approval **records** the signed-off high-risk
+/// action for the existing gated authority to process rather than performing the
+/// mutation itself. Wire a custom [`SignalCommandHandler`] to drive concrete
+/// deploy/merge execution.
+#[derive(Default)]
+pub struct RuntimeCommandHandler {
+    paused: bool,
+}
+
+impl RuntimeCommandHandler {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl SignalCommandHandler for RuntimeCommandHandler {
+    fn status(&self) -> String {
+        format!(
+            "Simard is online. Autonomous dispatch: {}.",
+            if self.paused { "paused" } else { "running" }
+        )
+    }
+
+    fn pause(&mut self) -> String {
+        self.paused = true;
+        "Autonomous dispatch paused. Send `status` to check state.".to_string()
+    }
+
+    fn execute_approved(&mut self, cmd: &InboundCommand) -> SimardResult<String> {
+        // The guardrail is enforced upstream (this is only reached after an
+        // explicit `approve`). The default handler records the sign-off for the
+        // existing gated authority; it does not itself perform the mutation.
+        let what = match cmd {
+            InboundCommand::Merge(n) => format!("merge of PR #{n}"),
+            InboundCommand::Deploy => "deploy".to_string(),
+            other => format!("{other:?}"),
+        };
+        tracing::info!(target: "signal", "operator signed off high-risk action: {what}");
+        Ok(format!(
+            "Sign-off recorded for {what}. It is authorized to proceed through the gated authority."
+        ))
+    }
+}
+
+/// A [`ConversationChannel`] over signal-cli, generic over the transport `T` and
+/// the command-effect handler `H` so both can be mocked in tests.
+pub struct SignalConversation<T: SignalTransport, H: SignalCommandHandler> {
+    transport: T,
+    handler: H,
+    allowlist: Allowlist,
+    account: String,
+    /// Allowlisted operators to address notifications to.
+    operators: Vec<String>,
+    /// The sender of the last delivered meeting turn — `send` addresses replies here.
+    current_operator: Option<String>,
+    /// A gated high-risk command awaiting `approve`: `(sender, command)`.
+    pending: Option<(String, InboundCommand)>,
+    next_id: u64,
+}
+
+impl<T: SignalTransport, H: SignalCommandHandler> SignalConversation<T, H> {
+    /// Build a Signal channel from a live transport, a command handler, and the
+    /// resolved `[signal]` configuration.
+    pub fn new(transport: T, handler: H, config: &SignalConfig) -> Self {
+        Self {
+            transport,
+            handler,
+            allowlist: Allowlist::from_config(config),
+            account: config.account.clone(),
+            operators: config.allowlist.clone(),
+            current_operator: None,
+            pending: None,
+            next_id: 1,
+        }
+    }
+
+    /// Send `text` to a specific Signal recipient via the transport.
+    async fn reply(&mut self, recipient: &str, text: &str) -> SimardResult<()> {
+        let id = self.next_id;
+        self.next_id += 1;
+        let line = build_send_request(id, &self.account, recipient, text);
+        self.transport.send_line(line).await
+    }
+
+    /// Deliver an operator notification (PR merge-ready, stall/problem, high-risk
+    /// sign-off request) to every configured operator. This is the notifications-out
+    /// path; it is independent of any in-flight meeting turn.
+    pub async fn notify(&mut self, text: &str) -> SimardResult<()> {
+        let operators = self.operators.clone();
+        for op in &operators {
+            self.reply(op, text).await?;
+        }
+        Ok(())
+    }
+
+    /// Handle a low-risk lightweight command (`status`, `pause`, `approve`) for an
+    /// authorized sender and reply on the channel.
+    async fn handle_low_risk(&mut self, sender: &str, cmd: &InboundCommand) -> SimardResult<()> {
+        let reply = match cmd {
+            InboundCommand::Status => self.handler.status(),
+            InboundCommand::Pause => self.handler.pause(),
+            InboundCommand::Approve => match self.pending.take() {
+                Some((_from, pending_cmd)) => match self.handler.execute_approved(&pending_cmd) {
+                    Ok(msg) => msg,
+                    Err(e) => format!("Approved, but the action failed: {e}"),
+                },
+                None => "Nothing is awaiting sign-off.".to_string(),
+            },
+            // `handle_low_risk` is only called for AutoExecute commands; a
+            // conversation turn is routed out to the driver by `recv`, never here.
+            InboundCommand::Conversation(_) | InboundCommand::Deploy | InboundCommand::Merge(_) => {
+                return Ok(());
+            }
+        };
+        self.reply(sender, &reply).await
+    }
+}
+
+/// The operator-facing prompt for a gated high-risk command awaiting sign-off.
+fn high_risk_prompt(cmd: &InboundCommand) -> String {
+    let action = match cmd {
+        InboundCommand::Merge(n) => format!("Merging PR #{n}"),
+        InboundCommand::Deploy => "Deploying".to_string(),
+        other => format!("{other:?}"),
+    };
+    format!(
+        "{action} is a HIGH-RISK action and will NOT run from a text message. \
+         Reply `approve` to sign off; it will then proceed through the existing gated authority."
+    )
+}
+
+impl<T: SignalTransport + Send, H: SignalCommandHandler> ConversationChannel
+    for SignalConversation<T, H>
+{
+    fn name(&self) -> &'static str {
+        "signal"
+    }
+
+    async fn recv(&mut self) -> SimardResult<Option<Inbound>> {
+        loop {
+            let Some(line) = self.transport.recv_line().await? else {
+                return Ok(None);
+            };
+            let Some((sender, text)) = super::transport::parse_incoming(&line) else {
+                continue; // JSON-RPC responses, receipts, unparseable lines.
+            };
+
+            match self.allowlist.authorize(&sender) {
+                // Guardrail (a): fail-closed. Unknown senders are dropped.
+                AuthDecision::Ignored => {
+                    tracing::debug!(target: "signal", "dropping message from non-allowlisted sender");
+                    continue;
+                }
+                // Read-only senders may only read `status`, never mutate.
+                AuthDecision::ReadOnly => {
+                    if matches!(parse_inbound(&text), InboundCommand::Status) {
+                        let s = self.handler.status();
+                        self.reply(&sender, &s).await?;
+                    }
+                    continue;
+                }
+                AuthDecision::Authorized => {
+                    let cmd = parse_inbound(&text);
+                    // A meeting turn is handed to the shared driver, bound to
+                    // the authorized sender's identity (guardrail (b)).
+                    if let InboundCommand::Conversation(turn) = &cmd {
+                        self.current_operator = Some(sender.clone());
+                        return Ok(Some(Inbound {
+                            from: OperatorRef {
+                                id: sender,
+                                authorized: true,
+                            },
+                            text: turn.clone(),
+                        }));
+                    }
+                    // A lightweight operator command: gate it (guardrail (c)).
+                    match gate(&cmd) {
+                        GateDecision::AutoExecute => {
+                            self.handle_low_risk(&sender, &cmd).await?;
+                        }
+                        GateDecision::PendingSignOff => {
+                            self.pending = Some((sender.clone(), cmd.clone()));
+                            let prompt = high_risk_prompt(&cmd);
+                            self.reply(&sender, &prompt).await?;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    async fn send(&mut self, out: Outbound) -> SimardResult<()> {
+        let recipient = self
+            .current_operator
+            .clone()
+            .or_else(|| self.operators.first().cloned());
+        let Some(recipient) = recipient else {
+            tracing::warn!(target: "signal", "no operator to deliver an outbound to; dropping");
+            return Ok(());
+        };
+        let text = match out.kind {
+            OutKind::Error => format!("⚠ {}", out.text),
+            _ => out.text,
+        };
+        self.reply(&recipient, &text).await
+    }
+}
+
+/// Connect to the configured signal-cli daemon and drive an operator meeting
+/// conversation over Signal to completion. Feature-gated; requires the meeting
+/// LLM provider to be configured (same as the CLI/dashboard meeting).
+pub async fn run(config: SignalConfig) -> SimardResult<()> {
+    use crate::error::SimardError;
+
+    let transport = super::transport::JsonRpcTransport::connect(&config.endpoint).await?;
+    let handler = RuntimeCommandHandler::new();
+    let mut channel = SignalConversation::new(transport, handler, &config);
+
+    let agent = open_signal_agent_session().ok_or_else(|| SimardError::ActionExecutionFailed {
+        action: "signal-meeting".to_string(),
+        reason: "No LLM agent backend available. Check SIMARD_LLM_PROVIDER and auth config."
+            .to_string(),
+    })?;
+    let system_prompt = load_meeting_system_prompt();
+    let mut backend =
+        crate::meeting_backend::MeetingBackend::new_session("Signal", agent, None, system_prompt);
+
+    crate::conversation_channel::run_conversation(&mut channel, &mut backend).await
+}
+
+/// Load the shared meeting system prompt (same asset the CLI/dashboard use).
+fn load_meeting_system_prompt() -> String {
+    let path = crate::operator_commands::prompt_root().join("simard/meeting_system.md");
+    std::fs::read_to_string(&path).unwrap_or_default()
+}
+
+/// Open a Meeting-mode agent session for the Signal channel, mirroring the CLI
+/// and dashboard backends so all three channels get identical behavior.
+fn open_signal_agent_session() -> Option<Box<dyn crate::base_types::BaseTypeSession>> {
+    let provider = match crate::session_builder::LlmProvider::resolve() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("[simard] signal agent: LLM provider not configured: {e}");
+            return None;
+        }
+    };
+    match crate::session_builder::SessionBuilder::new(
+        crate::identity::OperatingMode::Meeting,
+        provider,
+    )
+    .node_id("signal-channel")
+    .address("signal-channel://local")
+    .adapter_tag("signal")
+    .open()
+    {
+        Ok(s) => Some(s),
+        Err(e) => {
+            eprintln!("[simard] signal agent session failed: {e}");
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use serde_json::{Value, json};
+
+    use super::*;
+    use crate::signal_conversation::transport::MockTransport;
+
+    const OPERATOR: &str = "+15557654321";
+    const STRANGER: &str = "+15550000000";
+    const ACCOUNT: &str = "+15551230000";
+
+    #[derive(Default)]
+    struct SpyState {
+        executed: Vec<InboundCommand>,
+        paused: bool,
+    }
+
+    /// A command handler that records `execute_approved` calls so tests can prove
+    /// a high-risk action is only ever run after an explicit `approve`.
+    struct SpyHandler {
+        state: Arc<Mutex<SpyState>>,
+    }
+
+    impl SignalCommandHandler for SpyHandler {
+        fn status(&self) -> String {
+            format!("STATUS(paused={})", self.state.lock().unwrap().paused)
+        }
+        fn pause(&mut self) -> String {
+            self.state.lock().unwrap().paused = true;
+            "PAUSED".to_string()
+        }
+        fn execute_approved(&mut self, cmd: &InboundCommand) -> SimardResult<String> {
+            self.state.lock().unwrap().executed.push(cmd.clone());
+            Ok(format!("EXECUTED {cmd:?}"))
+        }
+    }
+
+    fn block_on<F: std::future::Future>(f: F) -> F::Output {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(f)
+    }
+
+    fn receive_line(sender: &str, text: &str) -> String {
+        json!({
+            "jsonrpc": "2.0",
+            "method": "receive",
+            "params": {"envelope": {"sourceNumber": sender, "dataMessage": {"message": text}}}
+        })
+        .to_string()
+    }
+
+    /// Extract `(recipient, message)` from a JSON-RPC `send` line the channel wrote.
+    fn sent(line: &str) -> (String, String) {
+        let v: Value = serde_json::from_str(line).unwrap();
+        (
+            v["params"]["recipient"][0].as_str().unwrap().to_string(),
+            v["params"]["message"].as_str().unwrap().to_string(),
+        )
+    }
+
+    fn config(read_only_unknown: bool) -> SignalConfig {
+        SignalConfig {
+            endpoint: "127.0.0.1:0".to_string(),
+            account: ACCOUNT.to_string(),
+            allowlist: vec![OPERATOR.to_string()],
+            read_only_unknown,
+        }
+    }
+
+    fn channel(
+        lines: Vec<String>,
+        read_only_unknown: bool,
+    ) -> (
+        SignalConversation<MockTransport, SpyHandler>,
+        Arc<Mutex<SpyState>>,
+    ) {
+        let state = Arc::new(Mutex::new(SpyState::default()));
+        let handler = SpyHandler {
+            state: Arc::clone(&state),
+        };
+        let transport = MockTransport::with_lines(lines);
+        let ch = SignalConversation::new(transport, handler, &config(read_only_unknown));
+        (ch, state)
+    }
+
+    #[test]
+    fn recv_drops_unknown_sender_and_yields_authorized_conversation() {
+        let (mut ch, _state) = channel(
+            vec![
+                receive_line(STRANGER, "hello"),
+                receive_line(OPERATOR, "let's chat"),
+            ],
+            false,
+        );
+        let inbound = block_on(ch.recv())
+            .unwrap()
+            .expect("authorized conversation");
+        assert_eq!(inbound.text, "let's chat");
+        assert_eq!(inbound.from.id, OPERATOR);
+        assert!(inbound.from.authorized);
+        // The stranger's message was dropped silently — no reply was sent.
+        assert!(ch.transport.sent.is_empty());
+    }
+
+    #[test]
+    fn recv_status_replies_and_reaches_eof() {
+        let (mut ch, _state) = channel(vec![receive_line(OPERATOR, "status")], false);
+        assert!(block_on(ch.recv()).unwrap().is_none());
+        assert_eq!(ch.transport.sent.len(), 1);
+        let (to, msg) = sent(&ch.transport.sent[0]);
+        assert_eq!(to, OPERATOR);
+        assert!(msg.contains("STATUS"), "got {msg}");
+    }
+
+    #[test]
+    fn recv_high_risk_merge_never_auto_executes() {
+        let (mut ch, state) = channel(vec![receive_line(OPERATOR, "merge #42")], false);
+        assert!(block_on(ch.recv()).unwrap().is_none());
+        // Nothing executed from the text; a sign-off prompt was sent instead.
+        assert!(state.lock().unwrap().executed.is_empty());
+        assert_eq!(ch.transport.sent.len(), 1);
+        let (_to, msg) = sent(&ch.transport.sent[0]);
+        assert!(msg.contains("HIGH-RISK"), "got {msg}");
+        assert!(msg.contains("approve"), "got {msg}");
+    }
+
+    #[test]
+    fn recv_approve_after_pending_executes_exactly_once() {
+        let (mut ch, state) = channel(
+            vec![
+                receive_line(OPERATOR, "merge #42"),
+                receive_line(OPERATOR, "approve"),
+            ],
+            false,
+        );
+        assert!(block_on(ch.recv()).unwrap().is_none());
+        let executed = state.lock().unwrap().executed.clone();
+        assert_eq!(executed, vec![InboundCommand::Merge(42)]);
+        // prompt + execution result.
+        assert_eq!(ch.transport.sent.len(), 2);
+        let (_to, msg) = sent(&ch.transport.sent[1]);
+        assert!(msg.contains("EXECUTED"), "got {msg}");
+    }
+
+    #[test]
+    fn approve_without_pending_is_a_noop() {
+        let (mut ch, state) = channel(vec![receive_line(OPERATOR, "approve")], false);
+        assert!(block_on(ch.recv()).unwrap().is_none());
+        assert!(state.lock().unwrap().executed.is_empty());
+        let (_to, msg) = sent(&ch.transport.sent[0]);
+        assert!(msg.contains("Nothing is awaiting"), "got {msg}");
+    }
+
+    #[test]
+    fn read_only_unknown_gets_status_but_never_mutates() {
+        let (mut ch, state) = channel(
+            vec![
+                receive_line(STRANGER, "status"),
+                receive_line(STRANGER, "merge #1"),
+            ],
+            true,
+        );
+        assert!(block_on(ch.recv()).unwrap().is_none());
+        // Exactly one reply: the read-only status. The merge was dropped.
+        assert_eq!(ch.transport.sent.len(), 1);
+        let (to, msg) = sent(&ch.transport.sent[0]);
+        assert_eq!(to, STRANGER);
+        assert!(msg.contains("STATUS"), "got {msg}");
+        assert!(state.lock().unwrap().executed.is_empty());
+    }
+
+    #[test]
+    fn notify_addresses_every_operator() {
+        let (mut ch, _state) = channel(vec![], false);
+        block_on(ch.notify("PR #7 is merge-ready")).unwrap();
+        assert_eq!(ch.transport.sent.len(), 1);
+        let (to, msg) = sent(&ch.transport.sent[0]);
+        assert_eq!(to, OPERATOR);
+        assert!(msg.contains("merge-ready"), "got {msg}");
+    }
+
+    #[test]
+    fn send_delivers_reply_to_current_operator() {
+        let (mut ch, _state) = channel(vec![receive_line(OPERATOR, "hi there")], false);
+        let _ = block_on(ch.recv()).unwrap().expect("conversation turn");
+        block_on(ch.send(Outbound {
+            kind: OutKind::Assistant,
+            text: "reply text".to_string(),
+        }))
+        .unwrap();
+        let (to, msg) = sent(ch.transport.sent.last().unwrap());
+        assert_eq!(to, OPERATOR);
+        assert_eq!(msg, "reply text");
+    }
+}

--- a/src/signal_conversation/config.rs
+++ b/src/signal_conversation/config.rs
@@ -1,0 +1,127 @@
+//! Signal channel configuration (the `[signal]` table of the runtime config).
+//!
+//! Resolution follows the existing runtime-config rule: environment wins, then
+//! the config file, then a clear error — never a silent default. When the
+//! `signal` feature is off, this module is not compiled and the `[signal]` table
+//! is ignored.
+
+use std::path::Path;
+
+use serde::Deserialize;
+
+use crate::error::{SimardError, SimardResult};
+
+/// Typed view of the `[signal]` configuration table.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SignalConfig {
+    /// signal-cli JSON-RPC daemon endpoint (`host:port`).
+    pub endpoint: String,
+    /// The Signal account signal-cli owns — a linked device or dedicated number.
+    pub account: String,
+    /// E.164 operator numbers permitted to COMMAND Simard. Fail-closed: empty
+    /// means nobody may command.
+    pub allowlist: Vec<String>,
+    /// If true, non-allowlisted senders may receive READ-ONLY results (e.g.
+    /// `status`) but can never trigger a mutation. Default false.
+    pub read_only_unknown: bool,
+}
+
+pub const ENV_ENDPOINT: &str = "SIMARD_SIGNAL_ENDPOINT";
+pub const ENV_ACCOUNT: &str = "SIMARD_SIGNAL_ACCOUNT";
+pub const ENV_ALLOWLIST: &str = "SIMARD_SIGNAL_ALLOWLIST";
+pub const ENV_READ_ONLY_UNKNOWN: &str = "SIMARD_SIGNAL_READ_ONLY_UNKNOWN";
+
+/// The `[signal]` table as read from `config.toml` (every field optional so env
+/// can supply or override it).
+#[derive(Debug, Default, Deserialize)]
+struct SignalTable {
+    endpoint: Option<String>,
+    account: Option<String>,
+    allowlist: Option<Vec<String>>,
+    read_only_unknown: Option<bool>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RootConfig {
+    signal: Option<SignalTable>,
+}
+
+impl SignalConfig {
+    /// Load from the default state root (`$SIMARD_STATE_ROOT` or `~/.simard`).
+    pub fn load() -> SimardResult<Self> {
+        Self::load_from(&crate::state_root::simard_state_root())
+    }
+
+    /// Load the `[signal]` config, resolving each field env-first, then the
+    /// `config.toml` `[signal]` table, then failing for a missing required key.
+    /// `endpoint` and `account` are required; `allowlist` defaults to empty
+    /// (fail-closed) and `read_only_unknown` to false.
+    pub fn load_from(state_root: &Path) -> SimardResult<Self> {
+        let table = read_signal_table(state_root)?;
+
+        let endpoint = resolve_string(ENV_ENDPOINT, table.endpoint, "endpoint")?;
+        let account = resolve_string(ENV_ACCOUNT, table.account, "account")?;
+
+        let allowlist = match std::env::var(ENV_ALLOWLIST) {
+            Ok(v) => v
+                .split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+                .collect(),
+            Err(_) => table.allowlist.unwrap_or_default(),
+        };
+
+        let read_only_unknown = match std::env::var(ENV_READ_ONLY_UNKNOWN) {
+            Ok(v) => matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes"),
+            Err(_) => table.read_only_unknown.unwrap_or(false),
+        };
+
+        Ok(Self {
+            endpoint,
+            account,
+            allowlist,
+            read_only_unknown,
+        })
+    }
+}
+
+/// Read + parse the `[signal]` table from `<state_root>/config.toml`, tolerating
+/// a missing file (returns an empty table so env-only configuration works).
+fn read_signal_table(state_root: &Path) -> SimardResult<SignalTable> {
+    let path = state_root.join(crate::runtime_config::CONFIG_FILE_NAME);
+    let contents = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(SignalTable::default()),
+        Err(e) => {
+            return Err(SimardError::ActionExecutionFailed {
+                action: "read config.toml".to_string(),
+                reason: format!("{}: {e}", path.display()),
+            });
+        }
+    };
+    let root: RootConfig =
+        toml::from_str(&contents).map_err(|e| SimardError::InvalidConfigValue {
+            key: "signal".to_string(),
+            value: path.display().to_string(),
+            help: format!("could not parse the [signal] table: {e}"),
+        })?;
+    Ok(root.signal.unwrap_or_default())
+}
+
+/// Resolve a required string field env-first, then file, else a clear error.
+fn resolve_string(env_key: &str, file_value: Option<String>, field: &str) -> SimardResult<String> {
+    if let Ok(v) = std::env::var(env_key) {
+        let v = v.trim().to_string();
+        if !v.is_empty() {
+            return Ok(v);
+        }
+    }
+    match file_value {
+        Some(v) if !v.trim().is_empty() => Ok(v),
+        _ => Err(SimardError::MissingRequiredConfig {
+            key: format!("signal.{field}"),
+            help: format!("set `{env_key}` or add `{field}` to the [signal] table of config.toml"),
+        }),
+    }
+}

--- a/src/signal_conversation/gating.rs
+++ b/src/signal_conversation/gating.rs
@@ -52,27 +52,44 @@ pub enum GateDecision {
 /// `merge #NNNN`) is matched case-insensitively; anything else is an ordinary
 /// meeting turn, carried verbatim (original case/whitespace) as
 /// [`InboundCommand::Conversation`].
+///
+/// The vocabulary is short and ASCII, so recognition uses case-insensitive ASCII
+/// comparisons rather than allocating a fully lowercased copy of the message.
+/// This matters on the per-message inbound path: an ordinary conversation turn —
+/// which can be a long paste — is recognized as free text without ever being
+/// case-folded (the `eq_ignore_ascii_case` checks short-circuit on length).
 pub fn parse_inbound(text: &str) -> InboundCommand {
     let trimmed = text.trim();
-    let lower = trimmed.to_lowercase();
-    match lower.as_str() {
-        "status" => InboundCommand::Status,
-        "pause" => InboundCommand::Pause,
-        "approve" => InboundCommand::Approve,
-        "deploy" => InboundCommand::Deploy,
-        _ => {
-            if let Some(rest) = lower.strip_prefix("merge") {
-                let rest = rest.trim();
-                let digits = rest.strip_prefix('#').unwrap_or(rest).trim();
-                // An empty or non-numeric remainder parses to `Err`, so this
-                // naturally falls through to `Conversation` for bare `merge`.
-                if let Ok(n) = digits.parse::<u64>() {
-                    return InboundCommand::Merge(n);
-                }
-            }
-            InboundCommand::Conversation(trimmed.to_string())
-        }
+    if trimmed.eq_ignore_ascii_case("status") {
+        InboundCommand::Status
+    } else if trimmed.eq_ignore_ascii_case("pause") {
+        InboundCommand::Pause
+    } else if trimmed.eq_ignore_ascii_case("approve") {
+        InboundCommand::Approve
+    } else if trimmed.eq_ignore_ascii_case("deploy") {
+        InboundCommand::Deploy
+    } else if let Some(n) = parse_merge(trimmed) {
+        InboundCommand::Merge(n)
+    } else {
+        InboundCommand::Conversation(trimmed.to_string())
     }
+}
+
+/// Parse a `merge #NNNN` command (case-insensitive `merge` prefix, optional `#`),
+/// returning the PR number. A bare `merge`, a non-numeric remainder, or any text
+/// that merely starts with "merge" yields `None`, so it falls through to
+/// [`InboundCommand::Conversation`] — matching the original lowercase behavior.
+fn parse_merge(trimmed: &str) -> Option<u64> {
+    // ASCII-case-insensitively strip the 5-byte "merge" prefix. `get(..5)` is
+    // `None` if `trimmed` is shorter than the prefix or byte 5 is not a char
+    // boundary; either way this is not a `merge` command.
+    let rest = trimmed.get(..5)?;
+    if !rest.eq_ignore_ascii_case("merge") {
+        return None;
+    }
+    let rest = trimmed[5..].trim();
+    let digits = rest.strip_prefix('#').unwrap_or(rest).trim();
+    digits.parse::<u64>().ok()
 }
 
 /// Classify an inbound command's risk. `status`/`pause`/`approve` and ordinary

--- a/src/signal_conversation/gating.rs
+++ b/src/signal_conversation/gating.rs
@@ -1,0 +1,100 @@
+//! Guardrail (c): high-risk gating (issue #2527).
+//!
+//! Every inbound command is classified. Low-risk commands run immediately for an
+//! allowlisted sender; high-risk / mutating actions are NEVER auto-executed from
+//! a text — they create a pending operator decision and Simard asks for explicit
+//! sign-off, routing the eventual mutation through the EXISTING operator gate
+//! from the operational autonomy model (`git_guardrails`, `identity_auth`,
+//! `stewardship::merge_authority`). This module owns only the classification; the
+//! enforcement it routes to is unchanged.
+
+/// Coarse risk class of an inbound command.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RiskClass {
+    /// Runs immediately for an allowlisted sender (read-only or a benign,
+    /// sign-off-recording action).
+    LowRisk,
+    /// Mutating / high-risk: never auto-executed; requires explicit sign-off.
+    HighRisk,
+}
+
+/// A lightweight inbound command parsed from Signal text.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum InboundCommand {
+    /// Report daemon health, active goals, in-flight engineers. Low-risk.
+    Status,
+    /// Pause autonomous dispatch. Low-risk.
+    Pause,
+    /// Record operator sign-off for a pending high-risk request. Low-risk: it
+    /// only records the sign-off; it does not itself perform the mutation.
+    Approve,
+    /// Request a deploy. High-risk → pending sign-off.
+    Deploy,
+    /// Merge PR #NNNN via the gated merge authority. High-risk → pending sign-off.
+    Merge(u64),
+    /// Any other text — an ordinary meeting turn, answered conversationally.
+    Conversation(String),
+}
+
+/// What the channel should do with a (already-authorized) inbound command.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GateDecision {
+    /// Low-risk: execute immediately.
+    AutoExecute,
+    /// High-risk: create a pending operator decision and ask for sign-off. The
+    /// mutation is NEVER performed directly from the text.
+    PendingSignOff,
+}
+
+/// Parse one line of inbound Signal text into an [`InboundCommand`].
+///
+/// The lightweight command vocabulary (`status`, `pause`, `approve`, `deploy`,
+/// `merge #NNNN`) is matched case-insensitively; anything else is an ordinary
+/// meeting turn, carried verbatim (original case/whitespace) as
+/// [`InboundCommand::Conversation`].
+pub fn parse_inbound(text: &str) -> InboundCommand {
+    let trimmed = text.trim();
+    let lower = trimmed.to_lowercase();
+    match lower.as_str() {
+        "status" => InboundCommand::Status,
+        "pause" => InboundCommand::Pause,
+        "approve" => InboundCommand::Approve,
+        "deploy" => InboundCommand::Deploy,
+        _ => {
+            if let Some(rest) = lower.strip_prefix("merge") {
+                let rest = rest.trim();
+                let digits = rest.strip_prefix('#').unwrap_or(rest).trim();
+                // An empty or non-numeric remainder parses to `Err`, so this
+                // naturally falls through to `Conversation` for bare `merge`.
+                if let Ok(n) = digits.parse::<u64>() {
+                    return InboundCommand::Merge(n);
+                }
+            }
+            InboundCommand::Conversation(trimmed.to_string())
+        }
+    }
+}
+
+/// Classify an inbound command's risk. `status`/`pause`/`approve` and ordinary
+/// conversation turns are low-risk; `deploy`/`merge` are high-risk mutating
+/// actions.
+pub fn classify(cmd: &InboundCommand) -> RiskClass {
+    match cmd {
+        InboundCommand::Status
+        | InboundCommand::Pause
+        | InboundCommand::Approve
+        | InboundCommand::Conversation(_) => RiskClass::LowRisk,
+        InboundCommand::Deploy | InboundCommand::Merge(_) => RiskClass::HighRisk,
+    }
+}
+
+/// Decide whether an authorized inbound command may auto-execute or must first
+/// obtain explicit operator sign-off. High-risk commands MUST return
+/// [`GateDecision::PendingSignOff`] — a mutating action is never performed
+/// directly from a text message.
+pub fn gate(cmd: &InboundCommand) -> GateDecision {
+    match classify(cmd) {
+        RiskClass::LowRisk => GateDecision::AutoExecute,
+        RiskClass::HighRisk => GateDecision::PendingSignOff,
+    }
+}

--- a/src/signal_conversation/mod.rs
+++ b/src/signal_conversation/mod.rs
@@ -1,0 +1,42 @@
+//! Signal channel — the feature-gated Signal implementation of
+//! [`crate::conversation_channel::ConversationChannel`] (issue #2527).
+//!
+//! `SignalConversation` lets an allowlisted operator command Simard and receive
+//! her notifications over Signal, using the **same** meeting engine and
+//! handoff/goal-carryover chain as the CLI and dashboard channels. Simard does
+//! not embed the Signal protocol; she talks to a locally-run `signal-cli`
+//! JSON-RPC daemon.
+//!
+//! This module is compiled only under the `signal` Cargo feature (default off),
+//! so the default build has no Signal code and needs no signal-cli installed.
+//!
+//! # Naming
+//!
+//! Nothing here is named `bridge`/`Bridge`. `SignalConversation` is a first-class
+//! conversation channel; it does not implement, extend, or route through the
+//! pre-existing cognitive-memory `BridgeTransport`.
+//!
+//! This step delivers the config type, the two remote-command-surface guardrails,
+//! the signal-cli JSON-RPC transport, and the `SignalConversation` channel:
+//! - `config` — the `[signal]` table and its env-first loader,
+//! - `allowlist` — guardrail (a), the fail-closed sender allowlist,
+//! - `gating` — guardrail (c), high-risk classification,
+//! - `transport` — the newline-delimited JSON-RPC client (tokio TCP),
+//! - `channel` — `SignalConversation`, the [`ConversationChannel`](crate::conversation_channel::ConversationChannel)
+//!   over signal-cli, with allowlist + identity binding (guardrail (b)) + gating,
+//!   notifications-out, and the `run` entrypoint.
+
+pub mod allowlist;
+pub mod channel;
+pub mod config;
+pub mod gating;
+pub mod transport;
+
+#[cfg(test)]
+mod tests;
+
+pub use allowlist::{Allowlist, AuthDecision};
+pub use channel::{RuntimeCommandHandler, SignalCommandHandler, SignalConversation, run};
+pub use config::SignalConfig;
+pub use gating::{GateDecision, InboundCommand, RiskClass, classify, gate, parse_inbound};
+pub use transport::{JsonRpcTransport, SignalTransport};

--- a/src/signal_conversation/tests.rs
+++ b/src/signal_conversation/tests.rs
@@ -85,6 +85,44 @@ fn parse_inbound_treats_other_text_as_conversation() {
 }
 
 #[test]
+fn parse_inbound_is_case_insensitive_and_trims() {
+    // The command vocabulary is matched case-insensitively (ASCII) after
+    // trimming — the optimized parser must preserve exactly this behavior.
+    assert_eq!(gating::parse_inbound("  STATUS  "), InboundCommand::Status);
+    assert_eq!(gating::parse_inbound("Pause"), InboundCommand::Pause);
+    assert_eq!(gating::parse_inbound("ApProVe"), InboundCommand::Approve);
+    assert_eq!(gating::parse_inbound("DEPLOY"), InboundCommand::Deploy);
+    assert_eq!(
+        gating::parse_inbound("Merge #42"),
+        InboundCommand::Merge(42)
+    );
+    assert_eq!(gating::parse_inbound("MERGE 7"), InboundCommand::Merge(7));
+}
+
+#[test]
+fn parse_inbound_bare_and_malformed_merge_is_conversation() {
+    // Bare `merge`, a non-numeric remainder, or text that merely starts with
+    // "merge" must fall through to a conversation turn (carried verbatim).
+    for text in ["merge", "merge please", "merge #", "merges"] {
+        match gating::parse_inbound(text) {
+            InboundCommand::Conversation(t) => assert_eq!(t, text),
+            other => panic!("expected Conversation for {text:?}, got {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn parse_inbound_carries_a_long_turn_verbatim_without_casefolding() {
+    // A long conversation turn must be recognized as free text and carried with
+    // its original case/whitespace — the parser must not lowercase the body.
+    let turn = "Here Is A Long Update About The Release: ".repeat(64);
+    match gating::parse_inbound(&turn) {
+        InboundCommand::Conversation(t) => assert_eq!(t, turn.trim()),
+        other => panic!("expected a Conversation turn, got {other:?}"),
+    }
+}
+
+#[test]
 fn low_risk_commands_classify_low() {
     for cmd in [
         InboundCommand::Status,

--- a/src/signal_conversation/tests.rs
+++ b/src/signal_conversation/tests.rs
@@ -1,0 +1,225 @@
+//! TDD tests for the Signal channel guardrails (issue #2527).
+//!
+//! Written **first**: `allowlist::Allowlist::authorize` and the `gating::*`
+//! functions are `todo!()` stubs, so these are the "red" phase pinning the
+//! required security behavior — a fail-closed sender allowlist and high-risk
+//! gating that never auto-executes a mutating command from a text.
+//!
+//! These run under `cargo test --features signal`; no live signal-cli or network
+//! is involved.
+
+use super::allowlist::{Allowlist, AuthDecision};
+use super::config::SignalConfig;
+use super::gating::{self, GateDecision, InboundCommand, RiskClass};
+
+const OPERATOR: &str = "+15557654321";
+const STRANGER: &str = "+15550000000";
+
+// ── Guardrail (a): sender allowlist, fail-closed ─────────────────────────────
+
+#[test]
+fn allowlisted_sender_is_authorized() {
+    let al = Allowlist::new(vec![OPERATOR.to_string()], false);
+    assert_eq!(al.authorize(OPERATOR), AuthDecision::Authorized);
+}
+
+#[test]
+fn unknown_sender_is_ignored_when_read_only_off() {
+    let al = Allowlist::new(vec![OPERATOR.to_string()], false);
+    assert_eq!(al.authorize(STRANGER), AuthDecision::Ignored);
+}
+
+#[test]
+fn unknown_sender_is_read_only_when_enabled() {
+    let al = Allowlist::new(vec![OPERATOR.to_string()], true);
+    assert_eq!(al.authorize(STRANGER), AuthDecision::ReadOnly);
+}
+
+#[test]
+fn empty_allowlist_ignores_everyone_fail_closed() {
+    let al = Allowlist::new(vec![], false);
+    assert_eq!(al.authorize(OPERATOR), AuthDecision::Ignored);
+}
+
+#[test]
+fn read_only_unknown_never_grants_command_authority() {
+    // Even with read_only_unknown, a non-allowlisted number must never be
+    // Authorized to COMMAND — read-only is strictly weaker than authorized.
+    let al = Allowlist::new(vec![], true);
+    assert_ne!(al.authorize(STRANGER), AuthDecision::Authorized);
+}
+
+#[test]
+fn allowlist_from_config_uses_config_fields() {
+    let cfg = SignalConfig {
+        endpoint: "127.0.0.1:7583".to_string(),
+        account: "+15551234567".to_string(),
+        allowlist: vec![OPERATOR.to_string()],
+        read_only_unknown: false,
+    };
+    let al = Allowlist::from_config(&cfg);
+    assert_eq!(al.authorize(OPERATOR), AuthDecision::Authorized);
+    assert_eq!(al.authorize(STRANGER), AuthDecision::Ignored);
+}
+
+// ── Guardrail (c): high-risk gating ──────────────────────────────────────────
+
+#[test]
+fn parse_inbound_recognizes_the_command_set() {
+    assert_eq!(gating::parse_inbound("status"), InboundCommand::Status);
+    assert_eq!(gating::parse_inbound("pause"), InboundCommand::Pause);
+    assert_eq!(gating::parse_inbound("approve"), InboundCommand::Approve);
+    assert_eq!(gating::parse_inbound("deploy"), InboundCommand::Deploy);
+    assert_eq!(
+        gating::parse_inbound("merge #123"),
+        InboundCommand::Merge(123)
+    );
+}
+
+#[test]
+fn parse_inbound_treats_other_text_as_conversation() {
+    match gating::parse_inbound("let's talk about the release plan") {
+        InboundCommand::Conversation(text) => assert!(text.contains("release plan")),
+        other => panic!("expected a Conversation turn, got {other:?}"),
+    }
+}
+
+#[test]
+fn low_risk_commands_classify_low() {
+    for cmd in [
+        InboundCommand::Status,
+        InboundCommand::Pause,
+        InboundCommand::Approve,
+    ] {
+        assert_eq!(gating::classify(&cmd), RiskClass::LowRisk, "{cmd:?}");
+    }
+}
+
+#[test]
+fn high_risk_commands_classify_high() {
+    assert_eq!(
+        gating::classify(&InboundCommand::Deploy),
+        RiskClass::HighRisk
+    );
+    assert_eq!(
+        gating::classify(&InboundCommand::Merge(42)),
+        RiskClass::HighRisk
+    );
+}
+
+#[test]
+fn high_risk_commands_never_auto_execute() {
+    // The core safety invariant: a high-risk action from a text message must
+    // create a pending sign-off, never auto-execute.
+    assert_eq!(
+        gating::gate(&InboundCommand::Deploy),
+        GateDecision::PendingSignOff
+    );
+    assert_eq!(
+        gating::gate(&InboundCommand::Merge(7)),
+        GateDecision::PendingSignOff
+    );
+    assert_ne!(
+        gating::gate(&InboundCommand::Deploy),
+        GateDecision::AutoExecute
+    );
+    assert_ne!(
+        gating::gate(&InboundCommand::Merge(7)),
+        GateDecision::AutoExecute
+    );
+}
+
+#[test]
+fn low_risk_commands_auto_execute() {
+    assert_eq!(
+        gating::gate(&InboundCommand::Status),
+        GateDecision::AutoExecute
+    );
+    assert_eq!(
+        gating::gate(&InboundCommand::Pause),
+        GateDecision::AutoExecute
+    );
+    assert_eq!(
+        gating::gate(&InboundCommand::Approve),
+        GateDecision::AutoExecute
+    );
+}
+
+// ── Config loading: env-first, then file, fail-closed allowlist ──────────────
+
+mod config_loading {
+    use super::super::config::{
+        ENV_ACCOUNT, ENV_ALLOWLIST, ENV_ENDPOINT, ENV_READ_ONLY_UNKNOWN, SignalConfig,
+    };
+    use serial_test::serial;
+
+    fn clear_env() {
+        // SAFETY: serialized via `#[serial(cognitive_memory)]`.
+        unsafe {
+            std::env::remove_var(ENV_ENDPOINT);
+            std::env::remove_var(ENV_ACCOUNT);
+            std::env::remove_var(ENV_ALLOWLIST);
+            std::env::remove_var(ENV_READ_ONLY_UNKNOWN);
+        }
+    }
+
+    #[test]
+    #[serial(cognitive_memory)]
+    fn env_supplies_all_fields_and_wins() {
+        clear_env();
+        let tmp = tempfile::tempdir().unwrap();
+        // SAFETY: serialized.
+        unsafe {
+            std::env::set_var(ENV_ENDPOINT, "127.0.0.1:7583");
+            std::env::set_var(ENV_ACCOUNT, "+15551230000");
+            std::env::set_var(ENV_ALLOWLIST, "+15557654321, +15559990000");
+            std::env::set_var(ENV_READ_ONLY_UNKNOWN, "true");
+        }
+        let cfg = SignalConfig::load_from(tmp.path()).unwrap();
+        clear_env();
+
+        assert_eq!(cfg.endpoint, "127.0.0.1:7583");
+        assert_eq!(cfg.account, "+15551230000");
+        assert_eq!(cfg.allowlist, vec!["+15557654321", "+15559990000"]);
+        assert!(cfg.read_only_unknown);
+    }
+
+    #[test]
+    #[serial(cognitive_memory)]
+    fn missing_required_field_is_a_clear_error() {
+        clear_env();
+        let tmp = tempfile::tempdir().unwrap();
+        // No env, no config.toml → endpoint/account cannot be resolved.
+        let err = SignalConfig::load_from(tmp.path()).unwrap_err();
+        assert!(
+            format!("{err:?}").contains("signal."),
+            "expected a MissingRequiredConfig for a signal.* key, got {err:?}"
+        );
+    }
+
+    #[test]
+    #[serial(cognitive_memory)]
+    fn reads_the_signal_table_from_config_toml() {
+        clear_env();
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("config.toml"),
+            r#"
+llm_provider = "copilot"
+
+[signal]
+endpoint = "127.0.0.1:9000"
+account = "+15551230000"
+allowlist = ["+15557654321"]
+"#,
+        )
+        .unwrap();
+
+        let cfg = SignalConfig::load_from(tmp.path()).unwrap();
+        assert_eq!(cfg.endpoint, "127.0.0.1:9000");
+        assert_eq!(cfg.account, "+15551230000");
+        assert_eq!(cfg.allowlist, vec!["+15557654321"]);
+        // Fail-closed default: unset read_only_unknown resolves to false.
+        assert!(!cfg.read_only_unknown);
+    }
+}

--- a/src/signal_conversation/transport.rs
+++ b/src/signal_conversation/transport.rs
@@ -1,0 +1,220 @@
+//! signal-cli JSON-RPC transport (issue #2527).
+//!
+//! Simard does **not** implement the Signal protocol. She speaks newline-delimited
+//! JSON-RPC 2.0 to a locally-run `signal-cli` daemon (`signal-cli -a <account>
+//! daemon --tcp <host:port>`), which owns the account, encryption, and delivery.
+//!
+//! This module has two halves:
+//! - the pure, unit-tested wire helpers [`parse_incoming`] and
+//!   [`build_send_request`] (no I/O, no network), and
+//! - the [`SignalTransport`] trait plus its live [`JsonRpcTransport`] (a tokio
+//!   TCP client, reusing the tokio `net` dependency — no new crate) and the
+//!   in-memory [`MockTransport`] used by the channel's tests.
+//!
+//! # Naming
+//!
+//! Nothing here is named `bridge`/`Bridge`. This is the Signal conversation
+//! channel's transport; it is unrelated to the cognitive-memory `BridgeTransport`.
+
+use std::future::Future;
+
+use serde_json::{Value, json};
+
+use crate::error::{SimardError, SimardResult};
+
+/// Parse one newline-delimited JSON-RPC line from the signal-cli daemon into an
+/// inbound `(sender_e164, message_text)` pair.
+///
+/// Returns `None` for anything that is not a delivered text message — JSON-RPC
+/// responses to our own `send` calls, receipts, typing indicators, sync
+/// messages, and unparseable lines are all ignored. signal-cli delivers an
+/// incoming message as a `"receive"` notification whose `params.envelope`
+/// carries the source number and a `dataMessage.message` body.
+pub fn parse_incoming(line: &str) -> Option<(String, String)> {
+    let value: Value = serde_json::from_str(line.trim()).ok()?;
+    if value.get("method")?.as_str()? != "receive" {
+        return None;
+    }
+    let envelope = value.get("params")?.get("envelope")?;
+    let sender = envelope
+        .get("sourceNumber")
+        .and_then(Value::as_str)
+        .or_else(|| envelope.get("source").and_then(Value::as_str))?
+        .to_string();
+    let text = envelope
+        .get("dataMessage")?
+        .get("message")?
+        .as_str()?
+        .to_string();
+    if text.is_empty() {
+        return None;
+    }
+    Some((sender, text))
+}
+
+/// Build a newline-delimited JSON-RPC `send` request for the signal-cli daemon.
+/// The `account` is included so multi-account daemons route correctly; a
+/// single-account daemon ignores it.
+pub fn build_send_request(id: u64, account: &str, recipient: &str, text: &str) -> String {
+    let req = json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "send",
+        "params": {
+            "account": account,
+            "recipient": [recipient],
+            "message": text,
+        }
+    });
+    req.to_string()
+}
+
+/// A newline-delimited JSON-RPC line transport to the signal-cli daemon.
+///
+/// Kept deliberately minimal (read a line, write a line) so the [`SignalConversation`](super::SignalConversation)
+/// channel owns all Signal semantics and can be tested against [`MockTransport`]
+/// with no live daemon or network.
+pub trait SignalTransport {
+    /// Read the next line from the daemon. `Ok(None)` means the socket closed.
+    fn recv_line(&mut self) -> impl Future<Output = SimardResult<Option<String>>> + Send;
+
+    /// Write one JSON-RPC request line (a newline is appended by the transport).
+    fn send_line(&mut self, line: String) -> impl Future<Output = SimardResult<()>> + Send;
+}
+
+/// The live tokio-TCP transport to a signal-cli JSON-RPC daemon.
+pub struct JsonRpcTransport {
+    reader: tokio::io::BufReader<tokio::net::tcp::OwnedReadHalf>,
+    writer: tokio::net::tcp::OwnedWriteHalf,
+}
+
+impl JsonRpcTransport {
+    /// Connect to the signal-cli daemon at `endpoint` (`host:port`).
+    pub async fn connect(endpoint: &str) -> SimardResult<Self> {
+        let stream = tokio::net::TcpStream::connect(endpoint)
+            .await
+            .map_err(|e| SimardError::ActionExecutionFailed {
+                action: "signal-connect".to_string(),
+                reason: format!("could not connect to signal-cli daemon at {endpoint}: {e}"),
+            })?;
+        let (read_half, write_half) = stream.into_split();
+        Ok(Self {
+            reader: tokio::io::BufReader::new(read_half),
+            writer: write_half,
+        })
+    }
+}
+
+impl SignalTransport for JsonRpcTransport {
+    fn recv_line(&mut self) -> impl Future<Output = SimardResult<Option<String>>> + Send {
+        use tokio::io::AsyncBufReadExt;
+        async move {
+            let mut line = String::new();
+            let n = self.reader.read_line(&mut line).await.map_err(|e| {
+                SimardError::ActionExecutionFailed {
+                    action: "signal-transport".to_string(),
+                    reason: format!("read from signal-cli daemon failed: {e}"),
+                }
+            })?;
+            if n == 0 { Ok(None) } else { Ok(Some(line)) }
+        }
+    }
+
+    fn send_line(&mut self, line: String) -> impl Future<Output = SimardResult<()>> + Send {
+        use tokio::io::AsyncWriteExt;
+        async move {
+            self.writer
+                .write_all(line.as_bytes())
+                .await
+                .and(self.writer.write_all(b"\n").await)
+                .and(self.writer.flush().await)
+                .map_err(|e| SimardError::ActionExecutionFailed {
+                    action: "signal-transport".to_string(),
+                    reason: format!("write to signal-cli daemon failed: {e}"),
+                })
+        }
+    }
+}
+
+/// An in-memory [`SignalTransport`] for tests: `recv_line` replays scripted lines
+/// then ends the stream, and `send_line` captures every written line.
+#[cfg(test)]
+pub struct MockTransport {
+    inbound: std::collections::VecDeque<String>,
+    pub sent: Vec<String>,
+}
+
+#[cfg(test)]
+impl MockTransport {
+    /// Build from a script of raw JSON-RPC lines the daemon would emit.
+    pub fn with_lines(lines: Vec<String>) -> Self {
+        Self {
+            inbound: lines.into_iter().collect(),
+            sent: Vec::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+impl SignalTransport for MockTransport {
+    fn recv_line(&mut self) -> impl Future<Output = SimardResult<Option<String>>> + Send {
+        let next = self.inbound.pop_front();
+        async move { Ok(next) }
+    }
+
+    fn send_line(&mut self, line: String) -> impl Future<Output = SimardResult<()>> + Send {
+        self.sent.push(line);
+        async move { Ok(()) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_incoming_extracts_sender_and_text() {
+        let line = r#"{"jsonrpc":"2.0","method":"receive","params":{"account":"+15551230000","envelope":{"source":"+15557654321","sourceNumber":"+15557654321","timestamp":1,"dataMessage":{"message":"status"}}}}"#;
+        let (sender, text) = parse_incoming(line).expect("a delivered text message");
+        assert_eq!(sender, "+15557654321");
+        assert_eq!(text, "status");
+    }
+
+    #[test]
+    fn parse_incoming_prefers_source_number() {
+        let line = r#"{"jsonrpc":"2.0","method":"receive","params":{"envelope":{"source":"uuid-form","sourceNumber":"+15557654321","dataMessage":{"message":"hi"}}}}"#;
+        let (sender, _) = parse_incoming(line).unwrap();
+        assert_eq!(sender, "+15557654321");
+    }
+
+    #[test]
+    fn parse_incoming_ignores_non_receive_lines() {
+        // A JSON-RPC response to our own send call — not an inbound message.
+        let resp = r#"{"jsonrpc":"2.0","id":7,"result":{"timestamp":123}}"#;
+        assert!(parse_incoming(resp).is_none());
+    }
+
+    #[test]
+    fn parse_incoming_ignores_receipts_without_data_message() {
+        let receipt = r#"{"jsonrpc":"2.0","method":"receive","params":{"envelope":{"sourceNumber":"+15557654321","receiptMessage":{"isDelivery":true}}}}"#;
+        assert!(parse_incoming(receipt).is_none());
+    }
+
+    #[test]
+    fn parse_incoming_ignores_unparseable_lines() {
+        assert!(parse_incoming("not json").is_none());
+        assert!(parse_incoming("").is_none());
+    }
+
+    #[test]
+    fn build_send_request_is_valid_jsonrpc() {
+        let line = build_send_request(3, "+15551230000", "+15557654321", "hello");
+        let v: Value = serde_json::from_str(&line).unwrap();
+        assert_eq!(v["jsonrpc"], "2.0");
+        assert_eq!(v["id"], 3);
+        assert_eq!(v["method"], "send");
+        assert_eq!(v["params"]["account"], "+15551230000");
+        assert_eq!(v["params"]["recipient"][0], "+15557654321");
+        assert_eq!(v["params"]["message"], "hello");
+    }
+}


### PR DESCRIPTION
## Goal (#2527)

Introduce **one clearly-named** operator↔Simard message/chat abstraction, refactor the existing meeting REPL frontends (dashboard + CLI/TUI) onto it, and add a **Signal** implementation.

**Hard naming constraint honored:** nothing new is named `bridge`/`Bridge`. The pre-existing memory/knowledge/gym `bridge*` modules and the `BridgeTransport` trait are untouched; `SignalConversation` does **not** route through them.

## What's here

### 1. The abstraction — `src/conversation_channel/`
- **`ConversationChannel`** trait: `recv` / `send` / `on_recorded`, native async via return-position `impl Future` (no `async-trait` dep); render-agnostic types `OperatorRef` / `Inbound` / `Outbound` / `OutKind`.
- **`apply_record`**: the ONE shared, pure record/capture applier — the mutation + canonical acknowledgement text the CLI REPL and dashboard chat previously duplicated, extracted exactly once.
- **`run_conversation`**: the unified driver over the trait, realized by the new Signal channel and by `MockConversationChannel`.

### 2. Frontends unified onto it — behavior preserved exactly
- The CLI meeting REPL (`meeting_repl/repl.rs`) and dashboard chat (`operator_commands_dashboard/chat.rs`) now delegate the eight capture commands (`/goal /decision /action /question /theme /owner /risk /disagree`) to the shared `apply_record` instead of divergent copies. **Byte-for-byte identical output**; all existing meeting tests stay green. Handoff writing + goal carryover unchanged.

### 3. Signal channel — `src/signal_conversation/` (`#[cfg(feature = "signal")]`, default OFF)
- `SignalConversation` implements `ConversationChannel` over a locally-run **signal-cli JSON-RPC daemon** (tokio TCP — no embedded Signal protocol, no new dependency).
- **Guardrails:** (a) fail-closed sender **allowlist**; (b) operator-**identity binding** on `OperatorRef`; (c) **high-risk gating** — `deploy`/`merge #NNNN` are *never* auto-executed from a text, they create a pending sign-off and run only after explicit `approve`, handed to the existing gated authority via an injected `SignalCommandHandler`.
- Lightweight **commands in** (`status`/`pause`/`approve`/`deploy`/`merge #NNNN`) and operator **notifications out** (PR merge-ready, stall, sign-off request).
- Env-first `[signal]` config loader (serde/toml).

## Tests
- `apply_record` per-command; `run_conversation` over the mock; allowlist + gating + JSON-RPC wire helpers + config loading.
- `cargo fmt` + `clippy` clean (default **and** `--features signal` / `--all-features -D warnings`).
- Lib suite green in both configurations (default: only pre-existing flaky `base_type_copilot` subprocess tests, which pass in isolation; `--features signal`: 6570 passed / 0 failed).

## Docs (durable)
- `architecture/conversation-channel.md`, `reference/conversation-channel-api.md`, `reference/signal-conversation.md`, `howto/set-up-the-signal-channel.md` — wired into `index.md` + mkdocs nav.

Closes #2527.