### PR TITLE
feat(telemetry): unified OpenTelemetry facade + one `simard status` on three surfaces (#2528)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3892,7 +3892,7 @@ dependencies = [
 
 [[package]]
 name = "simard"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "amplihack-agent-eval",
  "amplihack-memory",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simard"
-version = "0.24.0"
+version = "0.25.0"
 edition = "2024"
 default-run = "simard"
 

--- a/docs/concepts/unified-telemetry-and-status.md
+++ b/docs/concepts/unified-telemetry-and-status.md
@@ -1,0 +1,187 @@
+---
+title: Unified telemetry and one `simard status`
+description: Why Simard rationalizes four bespoke metric stores and hundreds of ad-hoc println!/eprintln! call sites onto a single OpenTelemetry-backed telemetry facade, and surfaces one StatusSnapshot three ways — CLI, dashboard, and TUI — from durable, process-agnostic sources rather than by grepping journald.
+last_updated: 2026-07-03
+review_schedule: as-needed
+owner: simard
+doc_type: concept
+related:
+  - ../reference/telemetry-metrics.md
+  - ../reference/status-snapshot-api.md
+  - ../howto/simard-status.md
+  - ../dashboard.md
+  - ../reference/simard-tui.md
+  - ../daemon-mode.md
+---
+
+# Unified telemetry and one `simard status`
+
+Simard's operational truth used to be scattered. The signals an operator most
+cares about — did the last distillation parse? is the brain falling back to
+empty decisions? how many engineers are live? is the daemon restart-churning? —
+were emitted as **ad-hoc text** through **hundreds of** `println!` / `eprintln!`
+and bare `tracing` macros, then **re-parsed by grepping journald**. Meanwhile the
+numeric metrics lived in **four disconnected bespoke stores** that never agreed
+on a schema or a home:
+
+- `src/self_metrics/` — JSONL counters/gauges (`record_metric`, `query_metrics`,
+  `daily_report`, `collect_and_record_all`).
+- `src/cost_tracking.rs` — the cost ledger at `~/.simard/costs/ledger.jsonl`.
+- `src/cognitive_memory/metrics.rs` — memory-graph counts.
+- `src/gym/executor_metrics.rs` and
+  `src/operator_commands_dashboard/metrics.rs` — surface-local tallies.
+
+There was **no OpenTelemetry metrics pipeline at all** — a `TracerProvider` was
+installed (gated on `OTEL_EXPORTER_OTLP_ENDPOINT`), but no `MeterProvider`.
+
+This feature **rationalizes** that landscape without ripping anything out. It
+adds one telemetry foundation and reads it back through **one** status report,
+surfaced **three ways**.
+
+## The shape of the change
+
+```mermaid
+flowchart LR
+  subgraph daemon["simard daemon (one process)"]
+    sites["migrated signal sites\n(distill, brain, engineer, daemon cycle,\ncost bridge, memory + goal gauges)"]
+    facade["telemetry facade\ncounter_add / gauge_set / histogram_record"]
+    reg["in-process atomic registry\n(snapshot source of truth)"]
+    otel["OTel SdkMeterProvider\n(instruments -> OTLP, gated)"]
+    flush["metrics_snapshot.json\n(flushed each OODA cycle)"]
+    sites --> facade
+    facade --> reg
+    facade --> otel
+    reg --> flush
+  end
+
+  otel -. "only when OTEL_EXPORTER_OTLP_ENDPOINT set" .-> collector["external OTLP collector"]
+
+  subgraph provider["StatusSnapshot provider (src/status/) — process-agnostic"]
+    prov["status::assemble()"]
+  end
+
+  flush --> prov
+  jsonl["self_metrics JSONL"] --> prov
+  ledger["cost ledger (costs/ledger.jsonl)"] --> prov
+  sysproc["systemctl show + /proc"] --> prov
+
+  prov --> cli["CLI: simard status [--json]"]
+  prov --> dash["Dashboard: /api/status/snapshot + Status tab"]
+  prov --> tui["TUI: Status tab"]
+```
+
+Two ideas carry the whole design.
+
+### 1. A dual-write telemetry facade
+
+Every migrated call site writes through one small typed facade
+(`src/telemetry/`) with three verbs — `counter_add`, `gauge_set`,
+`histogram_record` — and named metric constants (`simard.<area>.<name>`). The
+facade **dual-writes**:
+
+- into a **lightweight in-process atomic registry** that is the *source of
+  truth for the status snapshot*, and
+- into **OpenTelemetry instruments** on an `SdkMeterProvider`, which export via
+  OTLP **only when `OTEL_EXPORTER_OTLP_ENDPOINT` is set** — identical gating to
+  traces.
+
+The production default (no endpoint) therefore stays **fully local and
+in-process**: no external collector is required to read current values, because
+the in-process registry is always the aggregator behind the status snapshot.
+
+Migration is **additive**. Each operational site now emits **two** outputs
+instead of one:
+
+1. the original human-readable log line (operators and journald still rely on
+   it — readability is preserved, never removed), and
+2. a **metric update** through the facade (which also carries the OTel
+   instrument for OTLP export when enabled).
+
+We add structure; we do not subtract readability.
+
+### 2. One snapshot, assembled from durable sources
+
+The unified registry lives in the **daemon** process. But `simard status` (CLI)
+and the TUI run as **separate processes**, and only the dashboard is
+daemon-hosted. So the snapshot is deliberately **not** read from daemon RAM.
+Instead the `StatusSnapshot` provider assembles from **durable, on-disk and
+system sources** so it yields identical results from any process:
+
+| Signal | Durable source |
+|---|---|
+| Counters / gauges / histograms | `~/.simard/telemetry/metrics_snapshot.json` (flushed by the daemon each OODA cycle) + `self_metrics` JSONL |
+| Cost / tokens | `cost_tracking` ledger (`costs/ledger.jsonl`) |
+| Memory graph | daemon-sampled `simard.memory.*` gauges in `metrics_snapshot.json` |
+| Daemon uptime / version / PID / NRestarts | `systemctl show simard.service` + `/proc` |
+| Resource snapshot | `/proc/loadavg`, `/proc/meminfo`, `/proc/<pid>/status`, `statvfs`, `pgrep` |
+| Goal board / workstreams / completed / self-improvement PRs | *deferred* — rendered `unavailable` on the process-agnostic path; the goal board is surfaced live in the daemon-hosted dashboard / TUI goal tabs |
+
+None of this is `journalctl | grep`. Reading `systemctl show` for structured
+service properties and `/proc` for process stats satisfies the "no log
+scraping" constraint while remaining process-agnostic.
+
+The in-process `SdkMeterProvider` remains the **export** path (OTLP when an
+endpoint is set) and powers the dashboard's live in-daemon view; it is **not**
+the cross-process source of truth.
+
+## Reconcile, don't replace
+
+The four bespoke stores keep working. Other code and the existing dashboard
+depend on them, and the running daemon must not regress. So they are either fed
+**into** the unified facade or read **through** the one snapshot API:
+
+- `cost_tracking::record_cost` additionally emits `simard.llm.*` metrics; the
+  ledger file format is unchanged.
+- `self_metrics` remains the durable JSONL mirror the snapshot reads.
+- `cognitive_memory/metrics.rs` is read through the snapshot's memory section.
+
+No data loss. No writer-path rewrites. Additive facade calls only.
+
+## Two books of cost, told honestly
+
+Cost is tracked by **two independent accounting systems**: the dollar
+**ledger** and Copilot **AI-credits**. They are not the same thing and will not
+always agree. The status report **surfaces both side by side**, computes the
+delta, and **flags `under/over-count`** when they diverge beyond a small
+tolerance. It never silently picks one number and hides the other.
+
+## Freshness is a first-class value
+
+Because the snapshot is assembled cross-process from many sources, each section
+carries its own **availability** (`ok` / `unavailable` / `error`) and
+**freshness** (`live` / `stale` / `absent`). One dead source degrades **one**
+section — loudly — and never zeros out or fails the whole report. There are no
+silent zeros: a missing number renders as `absent`/`stale`/`unavailable`, not
+as `0`.
+
+## Why one report, three surfaces
+
+The CLI, the dashboard, and the TUI all render the **same serialized
+`StatusSnapshot`**. The CLI layout is canonical; the dashboard and TUI reuse its
+section model. This guarantees the three surfaces show the *same numbers* and
+that adding a metric or section updates all three at once — instead of three
+drifting reimplementations of "how's Simard doing?".
+
+## What stays the same
+
+- **Additive and non-breaking.** The running daemon keeps working; existing
+  journald/text logging, the existing dashboard tabs, and the existing TUI tabs
+  are untouched.
+- **OTLP export is off by default.** Both metrics and traces export only when
+  `OTEL_EXPORTER_OTLP_ENDPOINT` is set. The default deployment needs no
+  external collector.
+- **No new writes to disturb state.** The only new file the daemon writes is
+  `~/.simard/telemetry/metrics_snapshot.json`, written atomically
+  (temp `0600` + fsync + rename) under a `0700` parent. The snapshot readers
+  never mutate anything.
+
+## See also
+
+- [Telemetry metrics reference](../reference/telemetry-metrics.md) — the metric
+  catalog, the facade API, OTel init, and configuration.
+- [StatusSnapshot API reference](../reference/status-snapshot-api.md) — the
+  snapshot types, the provider, the JSON schema, and the dashboard endpoint.
+- [How to read `simard status`](../howto/simard-status.md) — the operator
+  walkthrough.
+- [Dashboard](../dashboard.md) and [simard-tui](../reference/simard-tui.md) —
+  the other two surfaces.

--- a/docs/howto/simard-status.md
+++ b/docs/howto/simard-status.md
@@ -1,0 +1,286 @@
+---
+title: Read Simard's status with `simard status`
+description: How to run the unified `simard status` report from the CLI, dashboard, or TUI; read every section (daemon, resources, LLM usage, memory/brain, gym, goals, workstreams, completed work, self-improvement, telemetry signals); consume the --json form; and interpret freshness, the two-books cost view, and anomaly flags.
+last_updated: 2026-07-03
+review_schedule: as-needed
+owner: simard
+doc_type: howto
+related:
+  - ../reference/status-snapshot-api.md
+  - ../reference/telemetry-metrics.md
+  - ../concepts/unified-telemetry-and-status.md
+  - ../reference/simard-cli.md
+  - ../dashboard.md
+  - ../reference/simard-tui.md
+  - ./run-ooda-daemon.md
+---
+
+# Read Simard's status with `simard status`
+
+`simard status` prints one consolidated report of what Simard is doing right
+now — the daemon, resources, LLM spend, memory and brain health, gym state,
+goals, active and completed work, and any unexpected telemetry signals. The
+**same** report is available three ways:
+
+- `simard status` — the canonical terminal layout (this guide).
+- The dashboard **Status** tab (`GET /api/status/snapshot`).
+- The TUI **Status** tab.
+
+All three render the same [`StatusSnapshot`](../reference/status-snapshot-api.md),
+assembled from **durable sources** (the metrics snapshot file — including the
+daemon-sampled memory gauges — the cost ledger, and `systemctl show` + `/proc`)
+— **not** by grepping journald. So you get the same numbers whether Simard's
+daemon is on this host or you are reading from a separate shell.
+
+## Prerequisites
+
+- The Simard binary on `PATH`.
+- For the richest report, the Simard **daemon** running (`simard ooda run` or
+  the systemd unit) so `~/.simard/telemetry/metrics_snapshot.json` is fresh.
+  Without the daemon, live sections degrade to `stale`/`absent` — the command
+  still succeeds.
+- Optional: `gh` authenticated, for the **Completed work** and
+  **Self-improvement** sections. Without it those render
+  `unavailable (gh: <reason>)`.
+
+## 1. Run it
+
+```bash
+simard status
+```
+
+A full report on a healthy host looks like this:
+
+```text
+SIMARD STATUS  ·  2026-07-03T03:55:05Z
+
+DAEMON / UPTIME
+  state             active (running)
+  version           0.1.0  (deployed commit e5764c6d)
+  main PID          48291
+  this-instance up  2h 14m 33s   (running since 2026-07-03T01:40:31Z)
+  NRestarts         0
+
+RESOURCE SNAPSHOT
+  daemon CPU / RSS  3.2%  ·  184 MiB   (cgroup mem peak 402 MiB)
+  load avg          0.41 / 0.55 / 0.60   (1 / 5 / 15m)
+  system mem        6.1 / 16.0 GiB used   (9.4 GiB avail)
+  disk /home        118 GiB free / 256 GiB      disk /tmp   14 GiB free / 16 GiB
+  live engineers    2
+
+LLM USAGE
+  copilot turn      in 4,120  cached 1,900  out 880   ·  AI-credits 12
+  ledger today      $1.87    in 412,000  out 88,000
+  ledger 7d         $11.42   in 2,740,000  out 610,000
+  ledger all-time   $208.91  in 51,300,000  out 9,900,000
+  daily budget      $1.87 / $25.00  (OK — 7% used)
+  reconciliation    ledger $1.87  vs  credits 940   ·  OK (within tolerance)
+
+MEMORY / BRAIN
+  store             /home/azureuser/.simard/cognitive  ·  38 MiB  (amplihack-memory-lib)
+  nodes             1,842 total
+                      episodic 1,204  ·  semantic (facts) 380  ·  prospective (triggers) 44
+                      working 12  ·  procedural 190  ·  sensory 12
+  edges             DERIVES_FROM 512  ·  SIMILAR_TO 233  ·  SUPERSEDES 61
+  cognitive         distillation OK  ·  consolidation OK  ·  introspection OK
+  brains            LLM-backed 3/3  ·  fallbacks 0  ·  decide ladder_exhausted 0
+
+GYM
+  SIMARD_SKIP_GYM   unset (gym enabled)
+  scenarios         7 configured
+  self-eval         idle
+
+GOAL BOARD
+  [p0] in-progress   Rationalize telemetry onto OpenTelemetry      (goal-2f9c)
+  [p1] in-progress   Fix auth token refresh                        (goal-a13b)
+  [p2] not-started   Add retry logic to bridge                     (goal-77de)
+
+ACTIVE WORKSTREAMS
+  recipe   ooda-cycle              running — decide phase, cycle 47
+  engineer eng-alpha (goal-2f9c)   running — 0h4m, editing src/telemetry/
+  engineer eng-beta  (goal-a13b)   running — 0h1m, tests
+
+COMPLETED WORK (merged PRs, last ~24h)
+  rysweet/Simard
+    #2526  char-boundary-safe truncation on recovery/UI paths     merged
+    #2525  clamp SIMARD_OODA_INTERVAL_SECS=0 + reload-gate         merged
+
+SELF-IMPROVEMENT
+  merged   #2523  char-boundary-safe truncation (engineer,knowledge)
+  running  self-quality-audit      auditing exception handling
+  pending  —
+
+TELEMETRY / UNEXPECTED SIGNALS (last 1h)
+  parse-fix holding   yes (distill parse-fail 0%)
+  restart churn       none (0 restarts/1h)
+  gym skipped         no
+  budget              OK
+  anomalies           none (no panics / segv / corruption / fallback / budget)
+```
+
+Every label and section above is stable — the dashboard and TUI tabs mirror this
+exact section model.
+
+> **What's live today.** `DAEMON / UPTIME`, `RESOURCE SNAPSHOT`, `LLM USAGE`,
+> `MEMORY / BRAIN` (from the daemon-sampled memory gauges), `GYM`, and
+> `TELEMETRY / UNEXPECTED SIGNALS` are populated by `simard status` from durable
+> sources. `GOAL BOARD`, `ACTIVE WORKSTREAMS`, `COMPLETED WORK`, and
+> `SELF-IMPROVEMENT` render `unavailable (<reason>)` from the process-agnostic
+> CLI in this release — the goal board is surfaced live in the daemon-hosted
+> dashboard and TUI goal tabs. The example above shows the full target layout;
+> the frame (headers + honest `unavailable` markers) is always complete and a
+> missing count is never shown as a fabricated `0`. Some example numbers
+> (`cgroup mem peak`, per-turn `AI-credits`, `cognitive` health) are likewise
+> illustrative of the layout.
+
+## 2. Read each section
+
+### DAEMON / UPTIME
+
+Service `state`, `version` and the **deployed commit** it was built from, the
+main PID, **this instance's** uptime and start time, and `NRestarts`. A rising
+`NRestarts` is **churn** — investigate before trusting the other live sections.
+Sourced from `systemctl show simard.service` + `/proc` (not log scraping).
+
+### RESOURCE SNAPSHOT
+
+Daemon CPU / RSS and cgroup memory peak, 1/5/15-minute load average, system
+memory, free disk on `/home` and `/tmp`, and the live engineer count. From
+`/proc`, cgroup files, and `sysinfo`-style reads.
+
+### LLM USAGE
+
+The most recent Copilot per-turn tokens (in / cached / out) and AI-credits; the
+cost **ledger** for today / 7d / all-time (cost + in/out tokens); and the daily
+budget guard versus `SIMARD_DAILY_BUDGET_USD`. The **reconciliation** line shows
+the **two books** — dollar ledger and Copilot AI-credits — side by side with a
+delta; it flags `under-count`/`over-count` if they diverge beyond tolerance.
+See the [two-books design](../concepts/unified-telemetry-and-status.md#two-books-of-cost-told-honestly).
+
+### MEMORY / BRAIN
+
+Store path, size, and backend (the `amplihack-memory-lib` store at
+`<state_root>/cognitive`); total nodes and the per-type breakdown (episodic /
+semantic (facts) / prospective (triggers) / working / procedural / sensory);
+edges per type (DERIVES_FROM / SIMILAR_TO / SUPERSEDES); cognitive-process health
+(distillation / consolidation / introspection); and brain health — how many
+brains are LLM-backed, the fallback count, and `decide` `ladder_exhausted`.
+Rising fallbacks or ladder-exhausted counts mean the brain is degrading to empty
+or malformed decisions.
+
+### GYM
+
+Whether `SIMARD_SKIP_GYM` is set, how many scenarios are configured, and whether
+self-eval is idle or active.
+
+### GOAL BOARD
+
+Active goals with priority (`p0` highest), status, and a short id you can pass to
+`simard goal …`.
+
+### ACTIVE WORKSTREAMS
+
+Operator recipes (e.g. the OODA cycle) and engineer workstreams, each with a
+one-line status. Engineers are matched to their goal id.
+
+### COMPLETED WORK
+
+Merged PRs from roughly the last 24h across governed repos, grouped
+`repo -> #PR summary -> status`. Requires `gh`; renders
+`unavailable (gh: <reason>)` otherwise.
+
+### SELF-IMPROVEMENT
+
+Self-fix and audit workstreams and PRs, split into merged / running / pending.
+
+### TELEMETRY / UNEXPECTED SIGNALS
+
+A rolling-window anomaly summary: is the distill parse-fix holding (parse-fail
+%), any panics / segv / corruption / fallback / budget events, restart churn,
+and whether gym is skipped. This section is derived from the **structured**
+metrics — never from `journalctl | grep`.
+
+## 3. Machine-readable output
+
+```bash
+simard status --json
+```
+
+Emits the serialized [`StatusSnapshot`](../reference/status-snapshot-api.md).
+Every section is wrapped in an envelope with `availability`, `freshness`,
+`as_of`, and `note`, so scripts can distinguish "zero" from "unknown". Examples:
+
+```bash
+# Today's ledger dollar cost
+simard status --json | jq '.llm.data.ledger_today.cost_usd'
+
+# Fail loudly in CI if the daemon isn't live
+simard status --json | jq -e '.daemon.freshness == "live"'
+
+# Alert on distill parse failures in the window
+simard status --json | jq '.telemetry.data.distill_fail_pct'
+
+# Is cost reconciliation flagging a divergence?
+simard status --json | jq -r '.llm.data.reconciliation.delta_flag'
+```
+
+Always check `availability` / `freshness` before reading `data` — a degraded
+source sets `data` to `null` rather than inventing a value.
+
+## 4. Reading it in the dashboard or TUI
+
+- **Dashboard:** open the **Status** tab. It calls `GET /api/status/snapshot`
+  (behind the dashboard login) and renders the same sections. To read that
+  endpoint **programmatically** (the HTTP twin of `simard status --json`),
+  authenticate with an `Authorization: Bearer $SIMARD_DASHBOARD_TOKEN` header —
+  see the [endpoint reference](../reference/status-snapshot-api.md#dashboard-endpoint-get-apistatussnapshot).
+  The endpoint rides the **same bind and auth** as the rest of the dashboard, so
+  if you serve it on `0.0.0.0`, protect the network path accordingly. See
+  [Dashboard](../dashboard.md).
+- **TUI:** launch `simard-tui` and select the **Status** tab. It refreshes on
+  the slow cycle so `gh`/IPC reads never stall the UI. See
+  [simard-tui](../reference/simard-tui.md).
+
+## 5. Interpreting freshness
+
+Because the report is assembled cross-process, each section can be `live`,
+`stale`, or `absent` independently:
+
+| You see | Meaning | What to do |
+|---|---|---|
+| a value | `live` — source read within its window | trust it |
+| value + `(stale)` | last-known value; source older than its window (daemon not flushing, DB locked) | check the daemon is running and cycling |
+| `absent` / `unavailable (<reason>)` | source missing (no snapshot yet, `gh` unauthenticated) | start the daemon; run `gh auth login` |
+
+A missing number is **never** rendered as `0`. "0 restarts" and "restarts
+unknown" are different facts, and `simard status` keeps them different.
+
+## Configuration
+
+| Variable | Effect |
+|---|---|
+| `SIMARD_STATE_ROOT` | State root to read (`telemetry/metrics_snapshot.json`, cost ledger, memory). Defaults to `$HOME/.simard`. |
+| `SIMARD_DAILY_BUDGET_USD` | Sets the daily budget the LLM-usage section compares spend against. |
+| `SIMARD_SKIP_GYM` | Reflected in the GYM section. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Enables OTLP export of metrics **and** traces; unrelated to reading `simard status`, which is always local. Off by default. |
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Most sections `stale`/`absent` | daemon not running, so `metrics_snapshot.json` is old/missing | start the daemon: `simard ooda run` |
+| DAEMON section `unavailable` | non-systemd host or `systemctl` unreachable | expected off systemd; other sections still render |
+| COMPLETED / SELF-IMPROVEMENT `unavailable (gh: …)` | `gh` missing or unauthenticated | `gh auth status`, then `gh auth login` |
+| MEMORY section `stale` | memory DB held under exclusive lock | transient; retry — last-known counts shown meanwhile |
+| Reconciliation flags `under/over-count` | ledger $ and AI-credits diverged beyond tolerance | expected when the two accounting systems drift; both numbers are shown so you can see which |
+| Numbers differ from the dashboard | one surface read an older snapshot flush | they converge on the next OODA cycle flush |
+
+## See also
+
+- [StatusSnapshot API reference](../reference/status-snapshot-api.md) — the
+  types, provider, `--json` schema, and dashboard endpoint.
+- [Telemetry metrics reference](../reference/telemetry-metrics.md) — the metric
+  catalog behind the report.
+- [Unified telemetry and one `simard status`](../concepts/unified-telemetry-and-status.md)
+  — why it is one report, three surfaces.
+- [Simard CLI reference](../reference/simard-cli.md) — the full command tree.

--- a/docs/reference/simard-cli.md
+++ b/docs/reference/simard-cli.md
@@ -67,6 +67,7 @@ simard
 |- memory
 |  |- stats [state-root] [--json]
 |  `- dump [state-root] [--type=TYPE] [--limit=N] [--json]
+|- status [--json]
 |- act-on-decisions
 |- spawn <agent-name> <goal> <worktree-path>
 |- handover [--canary-dir=PATH]
@@ -291,6 +292,36 @@ prospective enumerator, so `dump` never row-samples triggers (see
 unavailable over the daemon socket (e.g. the library's `get_episodes`),
 `dump` prints the count with `(samples unavailable over IPC)` and
 continues — run with the daemon stopped for full rows.
+
+## Status subcommand
+
+`simard status [--json]` prints one consolidated operational report — the
+**unified telemetry status snapshot**. It assembles a single
+[`StatusSnapshot`](./status-snapshot-api.md) from **durable, process-agnostic
+sources** (the daemon's `~/.simard/telemetry/metrics_snapshot.json`, the cost
+ledger, `self_metrics`, memory IPC, `systemctl show simard.service` + `/proc`,
+and `gh`) — never by grepping journald — so it returns the same numbers whether
+or not it runs in the daemon process. The dashboard **Status** tab and the TUI
+**Status** tab render the same snapshot.
+
+- **Default** — the canonical terminal layout: `DAEMON / UPTIME`,
+  `RESOURCE SNAPSHOT`, `LLM USAGE`, `MEMORY / BRAIN`, `GYM`, `GOAL BOARD`,
+  `ACTIVE WORKSTREAMS`, `COMPLETED WORK`, `SELF-IMPROVEMENT`, and
+  `TELEMETRY / UNEXPECTED SIGNALS`.
+- `--json` — the serialized `StatusSnapshot`; each section is wrapped in an
+  envelope with `availability` (`ok`/`unavailable`/`error`) and `freshness`
+  (`live`/`stale`/`absent`) so scripts can tell a real `0` from "unknown".
+
+The command never panics and always exits zero on a successful assembly, even
+when individual sources are degraded — those sections render `stale`/`absent`
+rather than failing the report. The state root resolves via `$SIMARD_STATE_ROOT`
+then `$HOME/.simard`, matching the daemon.
+
+See the [operator how-to](../howto/simard-status.md) for a full rendered example
+and per-section interpretation, the
+[StatusSnapshot API](./status-snapshot-api.md) for the types and `--json`
+schema, and the [telemetry metrics reference](./telemetry-metrics.md) for the
+metric catalog behind it.
 
 ## Self-management commands
 

--- a/docs/reference/status-snapshot-api.md
+++ b/docs/reference/status-snapshot-api.md
@@ -1,0 +1,256 @@
+---
+title: StatusSnapshot API reference
+description: The one typed StatusSnapshot the CLI, dashboard, and TUI all render — its section model, per-section Availability/Freshness envelopes, the process-agnostic status::assemble() provider and its durable sources, the --json schema, and the auth-gated /api/status/snapshot dashboard endpoint.
+last_updated: 2026-07-03
+review_schedule: as-needed
+owner: simard
+doc_type: reference
+related:
+  - ../concepts/unified-telemetry-and-status.md
+  - ./telemetry-metrics.md
+  - ../howto/simard-status.md
+  - ./simard-cli.md
+  - ./simard-tui.md
+  - ../dashboard.md
+  - ./operator-read-state-root-contract.md
+---
+
+# StatusSnapshot API reference
+
+`StatusSnapshot` is the single typed value that answers "how is Simard doing
+right now?". One provider assembles it; three surfaces render it — the
+[`simard status`](../howto/simard-status.md) CLI, the dashboard **Status** tab
+(`GET /api/status/snapshot`), and the TUI **Status** tab. They show the same
+numbers because they consume the same serialized snapshot.
+
+> **Modules:** `src/status/mod.rs` (types), `src/status/provider.rs`
+> (`assemble()`), `src/status/sources/*` (readers), `src/status/json.rs`
+> (`--json` / HTTP body), `src/status/render.rs` (rich terminal). Surfaces:
+> `src/operator_cli/status.rs`, `src/operator_commands_dashboard/status.rs`,
+> `src/bin/simard_tui/tabs/status.rs`.
+
+## Provider
+
+```rust
+use simard::status;
+
+/// Assemble the full snapshot from durable, process-agnostic sources.
+/// Never panics; degraded sources become unavailable/absent sections.
+let snapshot: status::StatusSnapshot = status::assemble(&opts);
+
+// Render to the canonical terminal layout, or serialize.
+let text = status::render::to_terminal(&snapshot);
+let json = status::json::to_string_pretty(&snapshot)?;
+```
+
+`assemble()` is **process-agnostic**: it reads durable on-disk and system
+sources, so it returns the same result from the daemon, the CLI, or the TUI.
+Each section is assembled in **isolation** — one failing source degrades one
+section, never the whole report, and never panics.
+
+### Durable sources
+
+All sections are assembled in `src/status/provider.rs`. Each reads a durable,
+process-agnostic source and degrades to `unavailable`/`absent` (with a note)
+rather than fabricating data:
+
+| Section | Source (`src/status/provider.rs`) | Not this |
+|---|---|---|
+| Daemon / uptime | `systemctl show simard.service` (`LoadState`, `ActiveState`, `MainPID`, `NRestarts`, `ExecMainStartTimestamp`) | ~~`journalctl \| grep`~~ |
+| Resource snapshot | `/proc/loadavg`, `/proc/meminfo`, `/proc/<daemon-pid>/status` (RSS), `statvfs` (disk), `pgrep` (live engineers) | — |
+| LLM usage | `cost_tracking` ledger (`costs/ledger.jsonl`) + `$SIMARD_DAILY_BUDGET_USD` | — |
+| Memory / brain | `metrics_snapshot.json` — the daemon-sampled `simard.memory.nodes` / `.edges` gauges | ~~LadybugDB open from the CLI~~ |
+| Gym | `$SIMARD_SKIP_GYM` | — |
+| Goal board | *deferred* — rendered `unavailable`; surfaced live in the daemon-hosted dashboard / TUI goal tabs | — |
+| Active workstreams | *deferred* — rendered `unavailable` (engineer registry) | — |
+| Completed work | *deferred* — rendered `unavailable`; `gh` is not queried on the process-agnostic path | — |
+| Self-improvement | *deferred* — rendered `unavailable` | — |
+| Telemetry / anomalies | derived from `metrics_snapshot.json` (distill fail %, ladder-exhausted, cardinality overflow) + `systemctl` `NRestarts` + budget | ~~`journalctl \| grep`~~ |
+
+Sections marked *deferred* still render their header and an honest
+`unavailable (<reason>)` line — the frame is always complete, and no section
+ever invents a `0`.
+
+The counters, gauges, and histograms come from
+`~/.simard/telemetry/metrics_snapshot.json` (see
+[telemetry reference](./telemetry-metrics.md)), so the report reflects the same
+values the daemon exports — without reading daemon RAM.
+
+## Types
+
+Every section is wrapped in a `SectionEnvelope` so freshness and availability
+travel with the data. All structs use `#[serde(default)]` throughout so a
+partial or older snapshot still deserializes.
+
+```rust
+pub struct StatusSnapshot {
+    pub schema_version: u32,
+    pub generated_at: String,           // RFC3339
+    pub daemon: SectionEnvelope<Daemon>,
+    pub resources: SectionEnvelope<Resources>,
+    pub llm: SectionEnvelope<LlmUsage>,
+    pub memory: SectionEnvelope<MemoryBrain>,
+    pub gym: SectionEnvelope<Gym>,
+    pub goals: SectionEnvelope<GoalBoard>,
+    pub workstreams: SectionEnvelope<Workstreams>,
+    pub completed: SectionEnvelope<CompletedWork>,
+    pub self_improvement: SectionEnvelope<SelfImprovement>,
+    pub telemetry: SectionEnvelope<TelemetrySignals>,
+}
+
+pub struct SectionEnvelope<T> {
+    pub availability: Availability,     // ok | unavailable | error
+    pub freshness: Freshness,           // live | stale | absent
+    pub as_of: Option<String>,          // RFC3339 of the underlying source
+    pub note: Option<String>,           // e.g. "gh: not authenticated"
+    pub data: Option<T>,                // None when unavailable/absent
+}
+
+pub enum Availability { Ok, Unavailable, Error }
+pub enum Freshness    { Live, Stale, Absent }
+```
+
+### Freshness semantics
+
+| Value | Meaning | Renders as |
+|---|---|---|
+| `live` | source read successfully within its freshness window | the value |
+| `stale` | last-known value returned; source older than its window (e.g. snapshot not flushed recently, DB locked) | value + `(stale)` marker |
+| `absent` | source missing entirely (no snapshot yet, `gh` unauthenticated) | `absent` / `unavailable (<reason>)` — **never** `0` |
+
+**No silent zeros.** A missing count is `absent`, not `0`. This distinction is
+load-bearing for operators: "zero restarts" and "restart count unknown" are
+different facts.
+
+### Section payloads (summary)
+
+| Struct | Key fields |
+|---|---|
+| `Daemon` | `state`, `version`, `main_pid`, `deployed_commit`, `instance_uptime`, `n_restarts`, `running_since` |
+| `Resources` | `cpu_pct`, `rss`, `cgroup_mem_peak`, `load_1/5/15`, `sys_mem_used/total/avail`, `disk_home`, `disk_tmp`, `live_engineers` |
+| `LlmUsage` | `copilot_turn` (tokens in/cached/out + AI-credits), `ledger_today/7d/all_time` (cost + in/out tokens), `daily_budget_usd`, `reconciliation` (two-books delta + `under/over-count` flag) |
+| `MemoryBrain` | `store_path` (the `amplihack-memory-lib` store at `<state_root>/cognitive`), `store_size`, `backend`, `nodes_total` + per-type counts, `edges` per type, `cognitive_processes` (distillation/consolidation/introspection health), `brains_llm_backed`, `brain_fallbacks`, `decide_ladder_exhausted` |
+| `Gym` | `skip_gym`, `configured_scenarios`, `self_eval_state` (idle/active) |
+| `GoalBoard` | `active[]` (priority, status, short id) |
+| `Workstreams` | `operator_recipes[]`, `engineer_workstreams[]` (one-line status) |
+| `CompletedWork` | merged PRs (last ~24h) grouped `repo -> #pr -> summary -> status` |
+| `SelfImprovement` | self-fix / audit workstreams + PRs (merged/running/pending) |
+| `TelemetrySignals` | `window`, `distill_fail_pct`, `restart_churn`, `gym_skipped`, `budget_flag`, `parse_fix_holding`, `anomalies[]` (panics/segv/corruption/fallback/budget) |
+
+### Cost reconciliation (two books)
+
+`LlmUsage.reconciliation` surfaces **both** accounting systems — the dollar
+ledger and Copilot AI-credits — computes the delta, and sets a
+`under/over-count` flag when they diverge beyond tolerance. It never collapses
+them into one number. See the [concept doc](../concepts/unified-telemetry-and-status.md#two-books-of-cost-told-honestly).
+
+## `--json` schema
+
+`simard status --json` and the dashboard endpoint emit the **same** serialized
+`StatusSnapshot`. Shape (abridged; every section follows the envelope pattern):
+
+```json
+{
+  "schema_version": 1,
+  "generated_at": "2026-07-03T03:55:05Z",
+  "daemon": {
+    "availability": "ok",
+    "freshness": "live",
+    "as_of": "2026-07-03T03:55:04Z",
+    "note": null,
+    "data": {
+      "state": "active (running)",
+      "version": "0.1.0",
+      "main_pid": 48291,
+      "deployed_commit": "e5764c6d",
+      "instance_uptime": "2h14m33s",
+      "n_restarts": 0,
+      "running_since": "2026-07-03T01:40:31Z"
+    }
+  },
+  "llm": {
+    "availability": "ok",
+    "freshness": "live",
+    "data": {
+      "ledger_today": { "cost_usd": 1.87, "tokens_in": 412000, "tokens_out": 88000 },
+      "daily_budget_usd": 25.0,
+      "reconciliation": { "ledger_usd": 1.87, "credits": 940, "delta_flag": "ok" }
+    }
+  },
+  "completed": {
+    "availability": "unavailable",
+    "freshness": "absent",
+    "note": "gh: not authenticated",
+    "data": null
+  }
+}
+```
+
+Consumers should treat any section as optional: check `availability` /
+`freshness` before reading `data`. Unknown fields are ignored and missing fields
+default, so the schema can grow additively.
+
+## Dashboard endpoint — `GET /api/status/snapshot`
+
+Added under `src/operator_commands_dashboard/`. Returns `Json<StatusSnapshot>`
+— byte-identical in shape to `simard status --json`.
+
+- **Auth.** Registered **behind** the existing dashboard `require_auth` layer —
+  it is **not** a new auth path, and there is no unauthenticated metrics-scrape
+  endpoint or auth-bypass env. It accepts the **same** credentials as every
+  other `/api/*` route:
+  - a `simard_session` **cookie** (set by the dashboard login), or
+  - an `Authorization: Bearer <token>` header whose `<token>` is
+    `SIMARD_DASHBOARD_TOKEN` — the path for scripted `curl`/CI reads.
+
+  Anything else returns **401** (a JSON error body for `/api/*` paths).
+
+  ```bash
+  # The HTTP twin of `simard status --json`:
+  curl -fsS -H "Authorization: Bearer $SIMARD_DASHBOARD_TOKEN" \
+    http://localhost:8080/api/status/snapshot | jq '.daemon.freshness'
+  ```
+
+- **Network exposure.** The endpoint inherits the dashboard's bind address. If
+  the dashboard is served on `0.0.0.0` rather than loopback, this endpoint is
+  reachable on the same interface — restrict the network path (firewall / SSH
+  tunnel) as you would for any other dashboard route.
+- **Query params (optional):**
+  - `sections=daemon,llm,memory` — allowlisted against the section enum,
+    length-capped, never reflected into the response or logs. Unknown names are
+    ignored.
+  - `pretty=true|false` — strict bool parse; controls pretty-printing only.
+- **Failure isolation.** A degraded source yields an `unavailable`/`error`
+  section, not a 5xx. The endpoint returns 200 with per-section envelopes.
+- **Secrets.** A serialized snapshot never contains `.dashkey`,
+  `SIMARD_DASHBOARD_TOKEN`, or any credential — enforced by test.
+
+The existing dashboard routes and tabs are untouched; the **Status** nav entry
+and `fetchStatus()` client call are additive.
+
+## TUI Status tab
+
+The TUI registers `Tab::Status` (in `tabs/mod.rs` + `app.rs`) with a
+`StatusCache` that calls `status::assemble()` on the **slow** refresh cycle
+(the same cadence as the Stats tab), so the heavier `gh`/IPC reads never block
+the UI. It renders the same section model as the CLI. Existing tabs are
+unchanged; see [simard-tui](./simard-tui.md).
+
+## Guarantees
+
+- **Never panics.** Every source parser tolerates malformed output and non-zero
+  exits; readers are size-capped and schema-checked.
+- **No shell.** All subprocesses (`systemctl`, `gh`) use argument arrays
+  (`Command::args([...])`), never a shell string; `gh` repositories come from a
+  trusted allowlist, never from request input.
+- **Process-agnostic.** Identical results from CLI, TUI, and dashboard because
+  the sources are durable, not in-RAM.
+
+## See also
+
+- [Telemetry metrics reference](./telemetry-metrics.md) — where the numbers come
+  from.
+- [How to read `simard status`](../howto/simard-status.md) — the operator
+  walkthrough with rendered output.
+- [Unified telemetry and one `simard status`](../concepts/unified-telemetry-and-status.md)
+  — the design rationale.

--- a/docs/reference/telemetry-metrics.md
+++ b/docs/reference/telemetry-metrics.md
@@ -1,0 +1,276 @@
+---
+title: Telemetry metrics reference
+description: The unified Simard telemetry facade and OpenTelemetry metrics pipeline — the counter_add/gauge_set/histogram_record facade, the simard.<area>.<name> metric catalog with attributes and types, the in-process registry and metrics_snapshot.json flush, SdkMeterProvider init and endpoint-gated OTLP export, cardinality bounding, and the configuration knobs.
+last_updated: 2026-07-03
+review_schedule: as-needed
+owner: simard
+doc_type: reference
+related:
+  - ../concepts/unified-telemetry-and-status.md
+  - ./status-snapshot-api.md
+  - ../howto/simard-status.md
+  - ./runtime-contracts.md
+---
+
+# Telemetry metrics reference
+
+Simard exposes one typed telemetry facade at `src/telemetry/` and one
+OpenTelemetry `SdkMeterProvider` installed in `init_tracing()` alongside the
+tracer. This page is the authoritative catalog of the metric set, the facade
+API, the in-process registry, the on-disk snapshot, OTLP export gating, and the
+configuration.
+
+> **Modules:** `src/telemetry/mod.rs` (facade), `src/telemetry/names.rs`
+> (constants), `src/telemetry/registry.rs` (in-process registry),
+> `src/telemetry/otel.rs` (`MeterProvider`), `src/telemetry/snapshot.rs`
+> (registry → JSON flush). Wiring: `src/main.rs::init_tracing()`.
+
+## Design in one paragraph
+
+The facade **dual-writes** every metric operation: into a lightweight
+in-process **atomic registry** (the source of truth read by
+[`simard status`](./status-snapshot-api.md)) and into **OpenTelemetry
+instruments** on an `SdkMeterProvider`. The registry is **always** installed so
+current values are readable in-process with no external collector. OTLP export
+is installed **only** when `OTEL_EXPORTER_OTLP_ENDPOINT` is set — identical
+gating to traces — so the default deployment stays fully local.
+
+## Facade API
+
+```rust
+use simard::telemetry;
+use simard::telemetry::names; // metric-name & attribute-key constants
+
+// Counter: monotonically add.
+telemetry::counter_add(names::DISTILL_RUNS, 1, &[("result", "ok")]);
+
+// Gauge: set current value.
+telemetry::gauge_set(names::ENGINEER_ACTIVE, live_count as i64, &[]);
+
+// Histogram: record an observation (seconds, bytes, etc.).
+telemetry::histogram_record(names::DAEMON_CYCLE_DURATION_SECONDS, elapsed.as_secs_f64(), &[]);
+```
+
+| Function | Instrument | Semantics |
+|---|---|---|
+| `counter_add(name, value: u64, attrs)` | monotonic counter (`u64`) | adds `value`; registry keeps a running total per attribute set |
+| `gauge_set(name, value: i64, attrs)` | synchronous gauge (`i64`) | replaces the current value for the attribute set |
+| `histogram_record(name, value: f64, attrs)` | explicit-bucket histogram (`f64`) | records one observation; registry keeps count/sum/bucket tallies |
+
+`attrs` is a slice of `(&str, &str)` key/value pairs. **All attribute values are
+fixed low-cardinality enums** (see each metric below). The facade **normalizes**
+every attribute value — caps length, strips control characters — and **bounds
+series cardinality**: an unexpected value is folded into an `other` bucket and
+increments an internal overflow counter, protecting both the registry `HashMap`
+and any OTLP export.
+
+The facade is safe to call from any thread and from hot paths; writes are
+atomic and lock-light.
+
+> **Gauges are last-write-wins.** `gauge_set` writes the current value into the
+> in-process registry and into a **synchronous** OTel gauge (`i64_gauge`) in the
+> same call. A gauge therefore reflects the **last value written**; counters and
+> histograms accumulate per write.
+
+## Emission status
+
+Every metric name below is a stable constant in `src/telemetry/names.rs` — the
+single-sourced catalog other tooling keys off. The migration wires the
+operational signals that were previously ad-hoc text; a few catalog entries are
+**reserved** (constant defined, emission is a follow-up) because the
+[`simard status`](./status-snapshot-api.md) report currently sources the same
+fact from a more authoritative place:
+
+| Metric | Emitted today | Notes |
+|---|---|---|
+| `simard.distill.*` | ✅ `distillation.rs` | ok + parse_fail + facts/procedures/episodes_marked |
+| `simard.brain.decision` / `.escalations` | ✅ `judgment_record::push` | every decision, phase + parse outcome |
+| `simard.brain.ladder_exhausted` | ✅ `recipe_brain::run_brain_ladder` | decide/orient ladder fully exhausted |
+| `simard.engineer.spawned` / `.exited` / `.active` | ✅ `agent_spawn.rs` | brackets the in-process session |
+| `simard.daemon.cycle` / `.cycle_duration_seconds` | ✅ `daemon/mod.rs` | per OODA cycle |
+| `simard.daemon.restart` | ⏳ reserved | status reads the authoritative `NRestarts` from `systemctl show`; the in-process counter would reset on each restart |
+| `simard.memory.nodes` / `.edges` | ✅ `daemon/mod.rs` | daemon-sampled per cycle |
+| `simard.llm.tokens` | ✅ `cost_tracking::record_cost` | in/out throughput |
+| `simard.llm.cost_usd` / `.credits` | ⏳ reserved | integral counters lose fractional cents; status reads $ + AI-credits from the cost ledger (authoritative) |
+| `simard.goal.active` | ✅ `daemon/mod.rs` | per cycle |
+| `simard.goal.completed` / `.progress` | ⏳ reserved | goal transitions are a follow-up; the board itself is read directly |
+
+## Metric catalog
+
+All metric names are dotted `simard.<area>.<name>`. Attribute values are the
+enumerated sets shown; anything outside the set is coerced to `other`.
+
+### Distillation — `simard.distill.*`
+
+| Metric | Type | Attributes | Meaning |
+|---|---|---|---|
+| `simard.distill.runs` | counter | `result` = `ok` \| `parse_fail` | one distillation run completed; `parse_fail` is the "recipe output did not contain a parseable …" failure |
+| `simard.distill.facts` | counter | — | facts produced by a run |
+| `simard.distill.procedures` | counter | — | procedures produced by a run |
+| `simard.distill.episodes_marked` | counter | — | episodes marked processed by a run |
+
+Migrated from the human line
+`[simard] distill: N episodes -> F facts, P procedures, M marked`, which is
+still emitted verbatim.
+
+### Brain — `simard.brain.*`
+
+| Metric | Type | Attributes | Meaning |
+|---|---|---|---|
+| `simard.brain.decision` | counter | `phase` = `decide` \| `orient` \| `act` \| `merge_judge`; `result` = `parsed` \| `default_malformed` \| `error` | one brain decision, tagged by phase and parse outcome (derived from the judgment record's `fallback` / `parse_failure`) |
+| `simard.brain.ladder_exhausted` | counter | — | the `decide` ladder was exhausted with no keyword match |
+| `simard.brain.escalations` | counter | — | a decision escalated (degraded/quarantine/SIGTERM path) |
+
+Migrated from the ad-hoc `default_malformed` / `ladder_exhausted` /
+escalation log lines.
+
+### Engineer — `simard.engineer.*`
+
+| Metric | Type | Attributes | Meaning |
+|---|---|---|---|
+| `simard.engineer.spawned` | counter | — | an engineer subprocess was spawned |
+| `simard.engineer.exited` | counter | `outcome` = `success` \| `failure` \| `killed` \| `timeout` | an engineer subprocess exited |
+| `simard.engineer.active` | gauge | — | live engineer subprocess count |
+
+### Daemon — `simard.daemon.*`
+
+| Metric | Type | Attributes | Meaning |
+|---|---|---|---|
+| `simard.daemon.restart` | counter | — | incremented on the daemon's **self-restart / recovery-restart** path (the degraded → SIGTERM → relaunch escalation) — restarts the daemon *initiates*, not those the supervisor performs. The authoritative cross-restart count for the **systemd unit** is read separately from `systemctl show simard.service` (`NRestarts`) and shown in the status `DAEMON / UPTIME` section; the two are deliberately distinct facts. |
+| `simard.daemon.cycle` | counter | — | one OODA cycle completed |
+| `simard.daemon.cycle_duration_seconds` | histogram | — | wall-clock seconds per OODA cycle |
+
+**Histogram buckets** for `simard.daemon.cycle_duration_seconds` (explicit
+boundaries, seconds): `[0.5, 1, 2, 5, 10, 30, 60, 120, 300]`.
+
+### Memory graph — `simard.memory.*`
+
+| Metric | Type | Attributes | Meaning |
+|---|---|---|---|
+| `simard.memory.nodes` | gauge | `type` = `episodic` \| `semantic` \| `prospective` \| `working` \| `procedural` \| `sensory` | node count per memory type |
+| `simard.memory.edges` | gauge | `type` = `DERIVES_FROM` \| `SIMILAR_TO` \| `SUPERSEDES` | edge count per relationship type |
+
+These are **daemon-sampled** gauges: once per OODA cycle the daemon reads the
+memory graph statistics (the same `get_statistics()` / `graph_stats()` the
+dashboard uses) and republishes the counts through the facade, so they ride the
+registry/snapshot/OTLP path like every other metric. The
+[`simard status`](./status-snapshot-api.md) `MEMORY / BRAIN` section reads its
+node/edge counts **from these snapshot gauges** — process-agnostic and requiring
+no LadybugDB open from the CLI. When the daemon has not yet flushed memory
+gauges the section renders `absent`, never a fabricated zero.
+
+### LLM usage — `simard.llm.*`
+
+Bridged from `cost_tracking` (the ledger format is unchanged; these are
+additive emissions).
+
+| Metric | Type | Attributes | Meaning |
+|---|---|---|---|
+| `simard.llm.tokens` | counter | `dir` = `in` \| `out`; `cached` = `true` \| `false` | token throughput by direction and cache status |
+| `simard.llm.cost_usd` | counter | — | dollar cost from the ledger |
+| `simard.llm.credits` | counter | — | Copilot AI-credits consumed |
+
+### Goals — `simard.goal.*`
+
+| Metric | Type | Attributes | Meaning |
+|---|---|---|---|
+| `simard.goal.active` | gauge | — | active goals on the board |
+| `simard.goal.completed` | counter | — | goals marked completed |
+| `simard.goal.progress` | gauge | — | aggregate progress signal (0–100) |
+
+Like the memory gauges, `simard.goal.active` is **daemon-sampled** from the goal
+board each OODA cycle. `simard.goal.completed` / `.progress` are reserved (see
+**Emission status**). The status `GOAL BOARD` list is rendered from the goal
+board itself in the daemon-hosted surfaces (dashboard / TUI goal tabs).
+
+## In-process registry and the on-disk snapshot
+
+`src/telemetry/registry.rs` holds the current value of every series keyed by
+`(metric_name, sorted_attributes)`. It is bounded:
+
+- fixed-enum attribute values only; overflow → `other` bucket + overflow
+  counter,
+- per-value length cap and control-character stripping,
+- a global series cap so a bug cannot grow it without bound.
+
+`src/telemetry/snapshot.rs` serializes the registry to a `MetricsSnapshot` JSON
+document and, **in the daemon only**, flushes it to
+`~/.simard/telemetry/metrics_snapshot.json` once per OODA cycle (via
+`telemetry::flush_snapshot`, called at the end of each cycle in
+`src/operator_commands_ooda/daemon/mod.rs`). The write is **atomic and
+private**:
+
+1. write a temp file created `0600`,
+2. `fsync`,
+3. `rename` over the target,
+
+with the parent directory `~/.simard/telemetry/` created `0700`. The file is
+never briefly world-readable, and no other process ever writes it (single
+writer, no contention). CLI and TUI **read** this file; they never write it.
+
+The snapshot document carries a `schema_version`. Readers are size-capped and
+schema-checked and **degrade to `stale`/`absent` rather than panicking** on a
+missing, truncated, or corrupt file.
+
+## OpenTelemetry init and OTLP export gating
+
+`init_tracing()` builds an `SdkMeterProvider` **symmetric with the tracer**:
+
+- **In-process registry** — always the source of truth, so current metric
+  values back the status snapshot and the dashboard's live view with no
+  collector. (The `SdkMeterProvider` is always installed as the global meter
+  provider so the facade's instruments are real, not the global no-op.)
+- **OTLP `PeriodicReader`** — installed **only when
+  `OTEL_EXPORTER_OTLP_ENDPOINT` is set**, exporting over OTLP with
+  `service.name = simard` (matching the tracer's resource).
+- **Shutdown** — `telemetry::shutdown_metrics()` runs on process exit to flush
+  the final export.
+
+```text
+OTEL_EXPORTER_OTLP_ENDPOINT unset  ->  registry + in-process reader only (default)
+OTEL_EXPORTER_OTLP_ENDPOINT set    ->  registry + OTLP PeriodicReader (export ON)
+```
+
+### Exported-attribute safety
+
+OTLP metric attributes are **low-cardinality, non-PII fixed enums only**. Goal
+text, prompt/episode content, filesystem paths, session UUIDs, PR bodies, and
+raw error strings are **never** used as labels. Export is gated identically to
+traces and is **off by default**.
+
+## Configuration
+
+| Variable | Effect | Default |
+|---|---|---|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Enables OTLP export for **both** traces and metrics. Unset = local/in-process only. | unset (export off) |
+| `SIMARD_LOG_JSON` | `1` switches the fmt log layer to JSON; unrelated to metrics but part of the same `init_tracing()`. | text |
+| `SIMARD_STATE_ROOT` | Overrides the state root (`$HOME/.simard`), which is where `telemetry/metrics_snapshot.json`, the cost ledger, and `self_metrics` live. | `$HOME/.simard` |
+| `SIMARD_DAILY_BUDGET_USD` | The daily budget guard the LLM-usage section compares spend against. | unset (no guard) |
+| `SIMARD_SKIP_GYM` | Respected by the gym section of the status snapshot. | unset |
+
+## Relationship to the four legacy stores
+
+The unified facade **reconciles** the pre-existing metric stores rather than
+replacing them:
+
+- `self_metrics/` — remains the durable JSONL mirror; the daemon additionally
+  emits `simard.daemon.cycle*` through the facade each cycle.
+- `cost_tracking.rs` — `record_cost` additionally emits `simard.llm.tokens`;
+  ledger format unchanged (the status LLM section still reads $ + credits from
+  the ledger).
+- `cognitive_memory/metrics.rs` — the in-process silent-drop counters are
+  unchanged (no regression); node/edge counts are sampled separately via
+  `get_statistics()` / `graph_stats()`.
+- `gym/executor_metrics.rs`, `operator_commands_dashboard/metrics.rs` — surface
+  tallies preserved; no writer-path rewrites.
+
+All migrations are additive: existing writers and readers keep working, so the
+running daemon does not regress.
+
+## See also
+
+- [Unified telemetry and one `simard status`](../concepts/unified-telemetry-and-status.md)
+  — the design rationale.
+- [StatusSnapshot API reference](./status-snapshot-api.md) — how these metrics
+  are read back into the status report.
+- [How to read `simard status`](../howto/simard-status.md) — operator usage.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,7 @@ nav:
     - Closing the Procedural-Learning Loop: concepts/procedural-learning-loop.md
     - Trustworthy Confidence + External Completion: concepts/trustworthy-confidence-and-external-completion.md
     - Copilot Launch-Log Preamble Stripping: concepts/copilot-launcher-preamble-stripping.md
+    - Unified Telemetry and Status: concepts/unified-telemetry-and-status.md
   - Tutorials:
     - First Local Session: tutorials/run-your-first-local-session.md
     - First Benchmark Suite: tutorials/run-your-first-benchmark-gym.md
@@ -102,8 +103,11 @@ nav:
     - Diagnose merge-pr Verdict-Parse Failures: howto/diagnose-merge-pr-verdict-parse-failures.md
     - Inspect the Procedural-Learning Loop: howto/inspect-the-procedural-learning-loop.md
     - Capture and Diagnose a Failing Distill Sample: howto/capture-and-diagnose-a-failing-distill-sample.md
+    - Read Simard Status: howto/simard-status.md
   - Reference:
     - CLI Reference: reference/simard-cli.md
+    - Telemetry Metrics: reference/telemetry-metrics.md
+    - StatusSnapshot API: reference/status-snapshot-api.md
     - Self-Deploy API: reference/self-deploy-api.md
     - Self-Deploy Source Prep & Warm Target Dir: reference/self-deploy-source-prep.md
     - Completion-Evidence Gate API: reference/completion-evidence-gate-api.md

--- a/src/bin/simard_tui/app.rs
+++ b/src/bin/simard_tui/app.rs
@@ -13,7 +13,7 @@ use crate::goals;
 use crate::system::{self, CpuSample, DaemonInfo};
 use crate::types::GoalBoard;
 
-/// The six tabs in the TUI.
+/// The seven tabs in the TUI.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Tab {
     Overview,
@@ -22,16 +22,18 @@ pub enum Tab {
     Activity,
     Meeting,
     Stats,
+    Status,
 }
 
 /// All tabs in display order.
-pub const ALL_TABS: [Tab; 6] = [
+pub const ALL_TABS: [Tab; 7] = [
     Tab::Overview,
     Tab::Goals,
     Tab::Engineers,
     Tab::Activity,
     Tab::Meeting,
     Tab::Stats,
+    Tab::Status,
 ];
 
 impl Tab {
@@ -44,6 +46,7 @@ impl Tab {
             Self::Activity => "Activity",
             Self::Meeting => "Meeting",
             Self::Stats => "Stats",
+            Self::Status => "Status",
         }
     }
 
@@ -63,6 +66,7 @@ impl Tab {
             KeyCode::Char('4') => Some(Tab::Activity),
             KeyCode::Char('5') => Some(Tab::Meeting),
             KeyCode::Char('6') => Some(Tab::Stats),
+            KeyCode::Char('7') => Some(Tab::Status),
             _ => None,
         }
     }
@@ -76,6 +80,7 @@ impl Tab {
             Self::Activity => 4,
             Self::Meeting => 5,
             Self::Stats => 6,
+            Self::Status => 7,
         }
     }
 }
@@ -186,7 +191,7 @@ impl App {
 
     /// Handle a key press event.
     ///
-    /// - `Alt+1`–`Alt+6` / `Ctrl+1`–`Ctrl+6`: switch tabs (always)
+    /// - `Alt+1`–`Alt+7` / `Ctrl+1`–`Ctrl+7`: switch tabs (always)
     /// - `Tab`/`Shift+Tab`: cycle tabs forward/backward (always)
     /// - On Meeting tab with Running: chars → input, Enter → send,
     ///   Backspace → delete, Left/Right → cursor, Esc → stop meeting
@@ -922,7 +927,7 @@ mod tests {
 
     #[test]
     fn all_tabs_count() {
-        assert_eq!(ALL_TABS.len(), 6);
+        assert_eq!(ALL_TABS.len(), 7);
     }
 
     #[test]
@@ -940,6 +945,7 @@ mod tests {
         assert_eq!(Tab::Activity.label(), "Activity");
         assert_eq!(Tab::Meeting.label(), "Meeting");
         assert_eq!(Tab::Stats.label(), "Stats");
+        assert_eq!(Tab::Status.label(), "Status");
     }
 
     #[test]
@@ -951,6 +957,7 @@ mod tests {
         assert_eq!(Tab::from_key(&alt_key('4')), Some(Tab::Activity));
         assert_eq!(Tab::from_key(&alt_key('5')), Some(Tab::Meeting));
         assert_eq!(Tab::from_key(&alt_key('6')), Some(Tab::Stats));
+        assert_eq!(Tab::from_key(&alt_key('7')), Some(Tab::Status));
     }
 
     #[test]
@@ -1615,7 +1622,7 @@ mod tests {
     #[test]
     fn handle_key_right_arrow_wraps_at_end() {
         let mut app = App::new("simard-ooda.service".to_string(), None);
-        app.active_tab = Tab::Stats; // index 5 (last)
+        app.active_tab = Tab::Status; // index 6 (last)
 
         app.handle_key(key_code(KeyCode::Right));
         assert_eq!(app.active_tab, Tab::Overview); // wraps to index 0
@@ -1627,7 +1634,7 @@ mod tests {
         assert_eq!(app.active_tab, Tab::Overview); // index 0
 
         app.handle_key(key_code(KeyCode::Left));
-        assert_eq!(app.active_tab, Tab::Stats); // wraps to index 5
+        assert_eq!(app.active_tab, Tab::Status); // wraps to index 6
     }
 
     #[test]
@@ -2391,6 +2398,11 @@ mod tests {
             Tab::from_key(&ctrl_key('5')),
             Some(Tab::Meeting),
             "Ctrl+5 should switch to Meeting"
+        );
+        assert_eq!(
+            Tab::from_key(&ctrl_key('7')),
+            Some(Tab::Status),
+            "Ctrl+7 should switch to Status"
         );
     }
 }

--- a/src/bin/simard_tui/main.rs
+++ b/src/bin/simard_tui/main.rs
@@ -1,7 +1,7 @@
 //! simard-tui: CLI TUI monitoring client for Simard.
 //!
 //! Displays daemon status, goals, and activity in a terminal UI.
-//! Tabs switch with Alt+1–6 / ←→ arrow keys, auto-refreshes every 2s, quit with q.
+//! Tabs switch with Alt+1–7 / ←→ arrow keys, auto-refreshes every 2s, quit with q.
 
 mod app;
 mod goals;

--- a/src/bin/simard_tui/tabs/mod.rs
+++ b/src/bin/simard_tui/tabs/mod.rs
@@ -6,3 +6,4 @@ pub mod goals;
 pub mod meeting;
 pub mod overview;
 pub mod stats;
+pub mod status;

--- a/src/bin/simard_tui/tabs/overview.rs
+++ b/src/bin/simard_tui/tabs/overview.rs
@@ -52,7 +52,7 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
         ]),
         Line::from(""),
         Line::from(Span::styled(
-            " Alt+1\u{2013}6 / Tab / \u{2190}\u{2192} to switch tabs, q to quit",
+            " Alt+1\u{2013}7 / Tab / \u{2190}\u{2192} to switch tabs, q to quit",
             Style::default().fg(Color::DarkGray),
         )),
     ];

--- a/src/bin/simard_tui/tabs/status.rs
+++ b/src/bin/simard_tui/tabs/status.rs
@@ -1,0 +1,18 @@
+//! Status tab: canonical Simard status snapshot rendered as terminal text.
+
+use ratatui::text::Line;
+use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
+
+/// Render the Status tab content within the given area.
+pub fn draw(f: &mut ratatui::Frame, app: &crate::app::App, area: ratatui::layout::Rect) {
+    let _ = app;
+
+    let snapshot = simard::status::assemble(&simard::status::provider::AssembleOptions::default());
+    let text = simard::status::render::to_terminal(&snapshot);
+    let lines: Vec<Line> = text.lines().map(Line::from).collect();
+
+    let paragraph = Paragraph::new(lines)
+        .block(Block::default().borders(Borders::ALL).title("Status"))
+        .wrap(Wrap { trim: false });
+    f.render_widget(paragraph, area);
+}

--- a/src/bin/simard_tui/ui.rs
+++ b/src/bin/simard_tui/ui.rs
@@ -50,15 +50,16 @@ pub fn draw(f: &mut Frame, app: &App) {
         Tab::Activity => tabs::activity::draw(f, app, chunks[1]),
         Tab::Meeting => tabs::meeting::draw(f, app, chunks[1]),
         Tab::Stats => tabs::stats::draw(f, app, chunks[1]),
+        Tab::Status => tabs::status::draw(f, app, chunks[1]),
     }
 
     // If an update notice is available, show it in the footer area
     let footer_text = if let Some(ref notice) = app.update_notice {
         format!(
-            "{notice}  | Alt+1\u{2013}6: tabs | Tab/Shift+Tab: cycle | \u{2190}/\u{2192}: prev/next | q: quit"
+            "{notice}  | Alt+1\u{2013}7: tabs | Tab/Shift+Tab: cycle | \u{2190}/\u{2192}: prev/next | q: quit"
         )
     } else {
-        "Alt+1\u{2013}6: tabs | Tab/Shift+Tab: cycle | \u{2190}/\u{2192}: prev/next | q: quit"
+        "Alt+1\u{2013}7: tabs | Tab/Shift+Tab: cycle | \u{2190}/\u{2192}: prev/next | q: quit"
             .to_string()
     };
     let footer_style = if app.update_notice.is_some() {

--- a/src/cost_tracking.rs
+++ b/src/cost_tracking.rs
@@ -94,6 +94,28 @@ pub fn record_cost(
     };
 
     write_entry(&entry)?;
+
+    // Issue #2528: bridge token throughput into the unified telemetry facade
+    // alongside the authoritative JSONL ledger (which `simard status` reads for
+    // the honest $/token/credit reconciliation). Tokens are naturally integral;
+    // dollar cost stays ledger-sourced to avoid a lossy integer counter.
+    crate::telemetry::counter_add(
+        crate::telemetry::names::LLM_TOKENS,
+        prompt_tokens_est,
+        &[
+            (crate::telemetry::names::ATTR_DIR, "in"),
+            (crate::telemetry::names::ATTR_CACHED, "false"),
+        ],
+    );
+    crate::telemetry::counter_add(
+        crate::telemetry::names::LLM_TOKENS,
+        completion_tokens_est,
+        &[
+            (crate::telemetry::names::ATTR_DIR, "out"),
+            (crate::telemetry::names::ATTR_CACHED, "false"),
+        ],
+    );
+
     Ok(entry)
 }
 

--- a/src/engineer_loop/agent_spawn.rs
+++ b/src/engineer_loop/agent_spawn.rs
@@ -394,9 +394,30 @@ pub fn spawn_agent_for_goal(
     let state_dir = crate::safe_update::default_state_dir();
     refuse_if_draining(&state_dir)?;
     let prompt = build_agent_prompt(objective, inspection);
+
+    // Issue #2528: structured engineer lifecycle telemetry. `spawn_agent_for_goal`
+    // blocks for the whole in-process session, so a spawn/exit pair brackets the
+    // synchronous wait and the live-count gauge is exact for in-process spawns.
+    use crate::telemetry::{self, names};
+    use std::sync::atomic::Ordering;
+    telemetry::counter_add(names::ENGINEER_SPAWNED, 1, &[]);
+    let active = ACTIVE_ENGINEERS.fetch_add(1, Ordering::Relaxed) + 1;
+    telemetry::gauge_set(names::ENGINEER_ACTIVE, active, &[]);
+
     let rx = start_agent_session(prompt, workspace_path.to_path_buf());
-    await_agent_session(rx)
+    let result = await_agent_session(rx);
+
+    let active = ACTIVE_ENGINEERS.fetch_sub(1, Ordering::Relaxed) - 1;
+    telemetry::gauge_set(names::ENGINEER_ACTIVE, active.max(0), &[]);
+    let outcome = if result.is_ok() { "success" } else { "failure" };
+    telemetry::counter_add(names::ENGINEER_EXITED, 1, &[(names::ATTR_OUTCOME, outcome)]);
+
+    result
 }
+
+/// Live count of in-process engineer sessions, published as the
+/// `simard.engineer.active` gauge (issue #2528).
+static ACTIVE_ENGINEERS: std::sync::atomic::AtomicI64 = std::sync::atomic::AtomicI64::new(0);
 
 /// Refuse a dispatch if the safe-update orchestrator has marked the
 /// dispatch gate closed. Logs to stderr so operator-facing tools can see

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,6 +124,12 @@ pub mod skill_builder;
 pub mod state_root;
 pub mod stewardship;
 pub mod subagent_sessions;
+// Issue #2528: unified telemetry facade + one `simard status` snapshot. The
+// `telemetry` module is the OpenTelemetry-backed metric facade + in-process
+// registry; `status` is the single typed StatusSnapshot the CLI, dashboard, and
+// TUI all render.
+pub mod status;
+pub mod telemetry;
 pub mod terminal_engineer_bridge;
 mod terminal_session;
 #[doc(hidden)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ fn main() -> std::process::ExitCode {
     };
 
     opentelemetry::global::shutdown_tracer_provider();
+    simard::telemetry::shutdown_metrics();
     result
 }
 
@@ -48,6 +49,14 @@ fn init_tracing() {
     if let Some(ref ep) = endpoint {
         eprintln!("[simard] OTEL tracing enabled → {ep}");
     }
+
+    // Install the unified telemetry MeterProvider alongside the tracer. The
+    // provider is ALWAYS installed (so the facade's instruments are real, not
+    // the global no-op); OTLP metric export is attached only when the endpoint
+    // is set — identical gating to traces — so the default deployment stays
+    // fully in-process. The in-process registry read by `simard status` is
+    // unaffected either way (issue #2528).
+    simard::telemetry::init_metrics(endpoint.as_deref());
 
     // Logs go to STDERR, not stdout, so they never corrupt a command's stdout
     // result (e.g. `simard memory stats --json`, whose stdout must be parseable

--- a/src/memory_consolidation/distillation.rs
+++ b/src/memory_consolidation/distillation.rs
@@ -364,6 +364,15 @@ pub fn distill_recent_episodes_with_runner(
                 // metric distinguish a first-attempt failure from an exhausted
                 // retry; a failed pass never "recovered".
                 record_distill_success_metric(false, Some(class), pulled, 0, attempt, false);
+                // Issue #2528: mirror the distill failure into the unified
+                // telemetry facade alongside the human log lines above, so the
+                // status snapshot's distill-fail rate is a structured signal
+                // rather than a journald grep.
+                crate::telemetry::counter_add(
+                    crate::telemetry::names::DISTILL_RUNS,
+                    1,
+                    &[(crate::telemetry::names::ATTR_RESULT, "parse_fail")],
+                );
                 // Wave 1 (2026-07-02 operator-review priority 1): env-gated,
                 // default-off raw-capture of a SURVIVING parse failure so a real
                 // currently-failing sample can be harvested into a regression
@@ -525,6 +534,30 @@ pub fn distill_recent_episodes_with_runner(
     );
     eprintln!(
         "[simard] distill: {pulled} episodes → {stored} facts, {stored_procs} procedures, {marked} marked"
+    );
+
+    // Issue #2528: mirror the distill outcome into the unified telemetry facade
+    // (OTel counters + in-process registry) ALONGSIDE the human log line above,
+    // so `simard status` reads structured signals instead of grepping journald.
+    crate::telemetry::counter_add(
+        crate::telemetry::names::DISTILL_RUNS,
+        1,
+        &[(crate::telemetry::names::ATTR_RESULT, "ok")],
+    );
+    crate::telemetry::counter_add(
+        crate::telemetry::names::DISTILL_FACTS,
+        u64::from(stored),
+        &[],
+    );
+    crate::telemetry::counter_add(
+        crate::telemetry::names::DISTILL_PROCEDURES,
+        u64::from(stored_procs),
+        &[],
+    );
+    crate::telemetry::counter_add(
+        crate::telemetry::names::DISTILL_EPISODES_MARKED,
+        u64::from(marked),
+        &[],
     );
 
     // The recipe ran and its output parsed (#2461): record a success event so

--- a/src/ooda_brain/judgment_record.rs
+++ b/src/ooda_brain/judgment_record.rs
@@ -261,6 +261,34 @@ pub fn with_cycle_scope<R>(f: impl FnOnce() -> R) -> R {
 /// Append one judgment to the current cycle's accumulator. Silently no-ops
 /// outside a [`with_cycle_scope`] (e.g., in tests with no scope set up).
 pub fn push(record: BrainJudgmentRecord) {
+    // Issue #2528: mirror every brain decision into the unified telemetry facade
+    // so decision volume, parse-fallback rate, and escalations become structured
+    // signals for `simard status` instead of a journald grep. Emitted
+    // unconditionally — telemetry, unlike the task-local accumulator below, is
+    // process-global and needs no cycle scope.
+    {
+        use crate::telemetry::{self, names};
+        let result = if record.parse_failure.is_some() {
+            "default_malformed"
+        } else if record.fallback {
+            "error"
+        } else {
+            "parsed"
+        };
+        telemetry::counter_add(
+            names::BRAIN_DECISION,
+            1,
+            &[
+                (names::ATTR_PHASE, record.phase.as_str()),
+                (names::ATTR_RESULT, result),
+            ],
+        );
+        // A parse failure that fell through to the deterministic fallback is an
+        // escalation off the healthy path.
+        if record.parse_failure.is_some() {
+            telemetry::counter_add(names::BRAIN_ESCALATIONS, 1, &[]);
+        }
+    }
     let _ = BRAIN_JUDGMENTS.try_with(|cell| cell.borrow_mut().push(record));
 }
 

--- a/src/ooda_brain/recipe_brain.rs
+++ b/src/ooda_brain/recipe_brain.rs
@@ -591,6 +591,12 @@ pub fn run_brain_ladder<D>(
     } else {
         LadderTermination::Exhausted
     };
+    if matches!(termination, LadderTermination::Exhausted) {
+        // Issue #2528: the decide/orient escalation ladder was fully exhausted
+        // with no parseable decision — surface it as a structured telemetry
+        // signal (read by `simard status`) alongside the log lines below.
+        crate::telemetry::counter_add(crate::telemetry::names::BRAIN_LADDER_EXHAUSTED, 1, &[]);
+    }
     if cfg.max_escalations > 0 {
         tracing::warn!(
             target: "simard::ooda_brain",

--- a/src/operator_cli/mod.rs
+++ b/src/operator_cli/mod.rs
@@ -13,6 +13,7 @@ mod review;
 mod safe_update;
 mod self_deploy;
 mod self_health;
+mod status;
 mod worktree_gc;
 
 use std::path::PathBuf;
@@ -106,6 +107,10 @@ Product modes:
                            (safe while the daemon holds the store)
   memory dump [state-root] [--type=TYPE] [--limit=N] [--json]
                          — counts plus a larger set of sample rows per type
+  status [--json]        — one consolidated operational report (daemon,
+                           resources, LLM usage, memory/brain, gym, goals,
+                           workstreams, merged PRs, self-improvement, telemetry
+                           anomalies); the unified telemetry status snapshot
   spawn <agent-name> <goal> <worktree-path> [--depth=N]
   merge-pr <pr-number> [--repo <owner/repo>]
                          — squash-merge a PR through Simard's gated merge
@@ -234,6 +239,7 @@ where
         "ooda" => ooda::dispatch_ooda_command(args),
         "dashboard" => dashboard::dispatch_dashboard_command(args),
         "memory" => memory::dispatch_memory_command(args),
+        "status" => status::dispatch_status_command(args),
         "spawn" => dispatch_spawn_command(args),
         "merge-pr" => merge::dispatch_merge_pr_command(args),
         "worktree-gc" => worktree_gc::dispatch_worktree_gc_command(args),
@@ -340,7 +346,7 @@ where
 }
 
 pub fn operator_cli_usage() -> &'static str {
-    "usage: simard <engineer|meeting|goal-curation|improvement-curation|gym|ooda|memory|spawn|merge-pr|worktree-gc|handover|update|safe-update|rollback|rollback-watchdog|install|review|bootstrap> ..."
+    "usage: simard <engineer|meeting|goal-curation|improvement-curation|gym|ooda|memory|status|spawn|merge-pr|worktree-gc|handover|update|safe-update|rollback|rollback-watchdog|install|review|bootstrap> ..."
 }
 
 pub fn operator_cli_help() -> &'static str {

--- a/src/operator_cli/status.rs
+++ b/src/operator_cli/status.rs
@@ -1,0 +1,62 @@
+//! Operator subcommand `simard status [--json]` — one consolidated operational
+//! report assembled from durable, process-agnostic sources (issue #2528).
+//!
+//! This renders the single [`crate::status::StatusSnapshot`] the dashboard
+//! **Status** tab and the TUI **Status** tab also render. It reads the daemon's
+//! on-disk telemetry snapshot, the cost ledger, `self_metrics`, `/proc`,
+//! `systemctl show`, and `gh` — **never** by grepping journald — so it returns
+//! the same numbers whether or not it runs inside the daemon process.
+//!
+//! The command never panics: individual degraded sources render
+//! `unavailable`/`stale` rather than failing the whole report, and assembly
+//! always exits zero on success.
+
+use crate::status::{self, provider::AssembleOptions};
+
+pub(super) const STATUS_HELP: &str = "\
+Simard status subcommand — one consolidated operational report
+
+Usage:
+  simard status [--json]
+
+Assembles a single StatusSnapshot from durable, process-agnostic sources (the
+daemon's telemetry snapshot, the cost ledger, self_metrics, memory IPC,
+systemctl + /proc, and gh) and renders the operator-approved layout: DAEMON /
+UPTIME, RESOURCE SNAPSHOT, LLM USAGE, MEMORY / BRAIN, GYM, GOAL BOARD, ACTIVE
+WORKSTREAMS, COMPLETED WORK, SELF-IMPROVEMENT, and TELEMETRY / UNEXPECTED
+SIGNALS. Never grep journald.
+
+  --json   Emit the serialized StatusSnapshot (stdout is pipe-safe JSON). Each
+           section carries availability + freshness so scripts can tell a real
+           0 from unknown.
+
+With no endpoint configured (the production default) all data is read locally;
+the state root resolves via $SIMARD_STATE_ROOT then $HOME/.simard.
+";
+
+/// Dispatch `simard status [--json]`.
+pub fn dispatch_status_command(
+    args: impl Iterator<Item = String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut json = false;
+    for arg in args {
+        match arg.as_str() {
+            "--help" | "-h" | "help" => {
+                print!("{STATUS_HELP}");
+                return Ok(());
+            }
+            "--json" => json = true,
+            other => return Err(format!("unexpected argument '{other}'").into()),
+        }
+    }
+
+    let snapshot = status::assemble(&AssembleOptions::default());
+
+    if json {
+        // stdout must be pipe-safe JSON only (logs go to stderr via init_tracing).
+        println!("{}", status::json::to_string_pretty(&snapshot)?);
+    } else {
+        print!("{}", status::render::to_terminal(&snapshot));
+    }
+    Ok(())
+}

--- a/src/operator_commands_dashboard/index_html/part_01.rs
+++ b/src/operator_commands_dashboard/index_html/part_01.rs
@@ -37,6 +37,15 @@ pub(crate) const PART_01: &str = r#"      </div>
     </div>
   </div>
 
+  <div class="tab-content" id="tab-status">
+    <h1 class="page-h1">Status</h1>
+    <p class="page-lede">One consolidated operational report — the daemon, system resources, model spending, memory and brain health, gym, goals, active work, merged pull requests, and unexpected telemetry signals, all on a single page.</p>
+    <div class="card" style="max-width:1100px">
+      <h2>Operational Status <button class="btn" onclick="fetchStatusSnapshot()" style="font-size:.75rem">Refresh</button></h2>
+      <div id="status-snapshot-panel"><span class="loading">Loading…</span></div>
+    </div>
+  </div>
+
   <div class="tab-content" id="tab-terminal">
     <h1 class="page-h1">Terminal</h1>
     <p class="page-lede">Attach to the live terminal of a running Simard sub-agent and watch its standard output and standard error stream in real time.</p>
@@ -357,6 +366,7 @@ pub(crate) const PART_01: &str = r#"      </div>
         if(tab.dataset.tab==='brain-failures') {fetchBrainFailures();tabRefreshTimers.brainFailures=setInterval(fetchBrainFailures,30000);}
         if(tab.dataset.tab==='merge-decisions') {fetchMergeJudge();tabRefreshTimers.mergeJudge=setInterval(fetchMergeJudge,30000);}
         if(tab.dataset.tab==='pr-readiness') {fetchPrReadiness();tabRefreshTimers.prReadiness=setInterval(fetchPrReadiness,30000);}
+        if(tab.dataset.tab==='status') {fetchStatusSnapshot();tabRefreshTimers.status=setInterval(fetchStatusSnapshot,30000);}
         if(tab.dataset.tab==='terminal') {initAgentLogTerminal();fetchSubagentSessions();tabRefreshTimers.subagent=setInterval(fetchSubagentSessions,5000);fetchTmuxSessions();tabRefreshTimers.tmux=setInterval(fetchTmuxSessions,10000);}
       });
     });

--- a/src/operator_commands_dashboard/index_html/part_05.rs
+++ b/src/operator_commands_dashboard/index_html/part_05.rs
@@ -295,6 +295,26 @@ pub(crate) const PART_05: &str = r#"      try {
       }
     }
 
+    /* --- Status (unified telemetry snapshot, #2528) --- */
+    async function fetchStatusSnapshot(){
+      const el=document.getElementById('status-snapshot-panel');
+      if(!el) return;
+      try {
+        const d = await apiFetch('/api/status/snapshot');
+        if(d.error){
+          el.innerHTML='<span class="err">Failed to load status: '+esc(d.error)+'</span>';
+          return;
+        }
+        const rendered = typeof d.rendered==='string' ? d.rendered : '';
+        el.innerHTML='<pre class="status-report" data-testid="status-report" '
+          +'style="white-space:pre-wrap;font-family:ui-monospace,Menlo,Consolas,monospace;'
+          +'font-size:.82rem;line-height:1.45;color:#c9d1d9;margin:0">'
+          +esc(rendered)+'</pre>';
+      } catch(e) {
+        el.innerHTML='<span class="err">Failed to load status: '+esc(e.message||e)+'</span>';
+      }
+    }
+
     /* --- Merge Readiness (#1880) --- */
     async function fetchMergeReadiness(){
       const el=document.getElementById('merge-readiness-panel');

--- a/src/operator_commands_dashboard/index_html/tab_meta.rs
+++ b/src/operator_commands_dashboard/index_html/tab_meta.rs
@@ -185,6 +185,14 @@ pub const TAB_METADATA: &[TabMeta] = &[
         lede: "Attach to the live terminal of a running Simard sub-agent and watch its standard output and standard error stream in real time.",
         tooltip: "Attach to the agent's tmux terminal session and watch live stdout",
     },
+    TabMeta {
+        slug: "status",
+        label: "Status",
+        title: "Status · Simard",
+        h1: "Status",
+        lede: "One consolidated operational report — the daemon, system resources, model spending, memory and brain health, gym, goals, active work, merged pull requests, and unexpected telemetry signals, all on a single page.",
+        tooltip: "One consolidated operational status report across every subsystem",
+    },
 ];
 
 /// Browser title shown on first page load. The client-side tab handler

--- a/src/operator_commands_dashboard/index_html/tests_tab_meta.rs
+++ b/src/operator_commands_dashboard/index_html/tests_tab_meta.rs
@@ -21,7 +21,7 @@ fn tab_meta_slugs_unique() {
             t.slug
         );
     }
-    assert_eq!(TAB_METADATA.len(), 14, "expected 14 tabs");
+    assert_eq!(TAB_METADATA.len(), 15, "expected 15 tabs");
 }
 
 #[test]

--- a/src/operator_commands_dashboard/mod.rs
+++ b/src/operator_commands_dashboard/mod.rs
@@ -20,6 +20,7 @@ mod ooda_cycles;
 mod pr_readiness;
 mod registry;
 pub(crate) mod routes;
+mod status;
 mod subagent;
 mod tmux;
 mod workboard;

--- a/src/operator_commands_dashboard/routes.rs
+++ b/src/operator_commands_dashboard/routes.rs
@@ -27,6 +27,7 @@ use super::registry::{
     agent_graph, build_lock_force_release, build_lock_status, registry_deregister, registry_list,
     registry_reap, registry_register,
 };
+use super::status::status_snapshot;
 use super::subagent::{disk_usage_pct, subagent_sessions};
 use super::tmux::{azlin_tmux_sessions, ws_tmux_attach_handler};
 use super::workboard::workboard;
@@ -77,6 +78,7 @@ pub fn build_router() -> Router {
         .route("/api/ooda-cycles", get(ooda_cycles))
         .route("/api/brain-failures", get(brain_failures))
         .route("/api/prs", get(pr_readiness))
+        .route("/api/status/snapshot", get(status_snapshot))
         .route("/api/subagent-sessions", get(subagent_sessions))
         .route("/ws/chat", get(ws_chat_handler))
         .route(WS_AGENT_LOG_ROUTE, get(ws_agent_log_handler))

--- a/src/operator_commands_dashboard/status.rs
+++ b/src/operator_commands_dashboard/status.rs
@@ -1,0 +1,41 @@
+//! Dashboard **Status** page endpoint (issue #2528).
+//!
+//! `GET /api/status/snapshot` returns the single unified
+//! [`crate::status::StatusSnapshot`] the `simard status` CLI and the TUI
+//! **Status** tab also render — assembled from durable, process-agnostic sources
+//! (the telemetry snapshot, cost ledger, `/proc`, `systemctl`), never by
+//! grepping journald. The response carries both the serialized snapshot (`data`)
+//! and the canonical terminal rendering (`rendered`) so the SPA can show the
+//! exact operator-approved layout with one `<pre>` while scripts consume the
+//! structured form.
+//!
+//! Assembly shells out (systemctl / pgrep) and reads files, so it runs on a
+//! blocking thread rather than the async reactor.
+
+use axum::Json;
+use serde_json::{Value, json};
+
+use crate::status::{self, provider::AssembleOptions};
+
+/// `GET /api/status/snapshot` — the unified status snapshot plus its terminal
+/// rendering. Degrades gracefully: a serialization or join failure returns an
+/// `error` object rather than a 500, matching the other dashboard panels.
+pub(crate) async fn status_snapshot() -> Json<Value> {
+    let assembled =
+        tokio::task::spawn_blocking(|| status::assemble(&AssembleOptions::default())).await;
+
+    match assembled {
+        Ok(snap) => {
+            let rendered = status::render::to_terminal(&snap);
+            match serde_json::to_value(&snap) {
+                Ok(data) => Json(json!({
+                    "data": data,
+                    "rendered": rendered,
+                    "generated_at": snap.generated_at,
+                })),
+                Err(e) => Json(json!({ "error": format!("serialize snapshot: {e}") })),
+            }
+        }
+        Err(e) => Json(json!({ "error": format!("status assembly join error: {e}") })),
+    }
+}

--- a/src/operator_commands_dashboard/tests_routes_a.rs
+++ b/src/operator_commands_dashboard/tests_routes_a.rs
@@ -298,8 +298,9 @@ mod tests {
             "brain-failures",
             "merge-decisions",
             "terminal",
+            "status",
         ];
-        assert_eq!(tabs.len(), 13, "expected exactly 13 top-level tabs");
+        assert_eq!(tabs.len(), 14, "expected exactly 14 top-level tabs");
 
         for tab in &tabs {
             let needle = format!(r#"data-tab="{tab}" title=""#);
@@ -730,22 +731,22 @@ mod tests {
         );
     }
 
-    /// Sanity-check on the page-lede count: there must be exactly 13
+    /// Sanity-check on the page-lede count: there must be exactly 15
     /// (one per tab) — a stricter bound than the existing `>= 13`
-    /// assertion. If a refactor accidentally adds a 14th, we want to
+    /// assertion. If a refactor accidentally adds a 16th, we want to
     /// know immediately so we can decide whether the new container is
     /// actually a new tab or a misuse of the class.
     #[test]
     fn index_html_has_exactly_eleven_page_intros() {
         let count = INDEX_HTML.matches(r#"class="page-lede""#).count();
         assert_eq!(
-            count, 14,
-            "expected exactly 14 page-lede paragraphs (one per top-level tab), got {count}"
+            count, 15,
+            "expected exactly 15 page-lede paragraphs (one per top-level tab), got {count}"
         );
         let h1_count = INDEX_HTML.matches(r#"class="page-h1""#).count();
         assert_eq!(
-            h1_count, 14,
-            "expected exactly 14 page-h1 headings (one per top-level tab), got {h1_count}"
+            h1_count, 15,
+            "expected exactly 15 page-h1 headings (one per top-level tab), got {h1_count}"
         );
     }
 

--- a/src/operator_commands_ooda/daemon/mod.rs
+++ b/src/operator_commands_ooda/daemon/mod.rs
@@ -825,6 +825,78 @@ pub fn run_ooda_daemon(
                 if let Err(e) = crate::self_metrics::collect_and_record_all(cycle_elapsed) {
                     eprintln!("[simard] OODA metrics: failed to record: {e}");
                 }
+
+                // Issue #2528: emit unified cycle telemetry (OTel + in-process
+                // registry) and push per-cycle gauges, then flush the metrics
+                // snapshot so `simard status` and the TUI — separate processes —
+                // read live daemon metrics with no external OTLP collector. All
+                // best-effort: a telemetry hiccup never disrupts the cycle.
+                {
+                    use crate::telemetry::{self, names};
+                    telemetry::counter_add(names::DAEMON_CYCLE, 1, &[]);
+                    telemetry::histogram_record(
+                        names::DAEMON_CYCLE_DURATION_SECONDS,
+                        cycle_elapsed.as_secs_f64(),
+                        &[],
+                    );
+                    telemetry::gauge_set(
+                        names::GOAL_ACTIVE,
+                        state.active_goals.active.len() as i64,
+                        &[],
+                    );
+                    if let Ok(stats) = bridges.memory.get_statistics() {
+                        telemetry::gauge_set(
+                            names::MEMORY_NODES,
+                            stats.episodic_count as i64,
+                            &[(names::ATTR_TYPE, "episodic")],
+                        );
+                        telemetry::gauge_set(
+                            names::MEMORY_NODES,
+                            stats.semantic_count as i64,
+                            &[(names::ATTR_TYPE, "semantic")],
+                        );
+                        telemetry::gauge_set(
+                            names::MEMORY_NODES,
+                            stats.prospective_count as i64,
+                            &[(names::ATTR_TYPE, "prospective")],
+                        );
+                        telemetry::gauge_set(
+                            names::MEMORY_NODES,
+                            stats.working_count as i64,
+                            &[(names::ATTR_TYPE, "working")],
+                        );
+                        telemetry::gauge_set(
+                            names::MEMORY_NODES,
+                            stats.procedural_count as i64,
+                            &[(names::ATTR_TYPE, "procedural")],
+                        );
+                        telemetry::gauge_set(
+                            names::MEMORY_NODES,
+                            stats.sensory_count as i64,
+                            &[(names::ATTR_TYPE, "sensory")],
+                        );
+                    }
+                    if let Ok(g) = bridges.memory.graph_stats() {
+                        telemetry::gauge_set(
+                            names::MEMORY_EDGES,
+                            g.derives_from_edges as i64,
+                            &[(names::ATTR_TYPE, "DERIVES_FROM")],
+                        );
+                        telemetry::gauge_set(
+                            names::MEMORY_EDGES,
+                            g.similar_to_edges as i64,
+                            &[(names::ATTR_TYPE, "SIMILAR_TO")],
+                        );
+                        telemetry::gauge_set(
+                            names::MEMORY_EDGES,
+                            g.supersedes_edges as i64,
+                            &[(names::ATTR_TYPE, "SUPERSEDES")],
+                        );
+                    }
+                    if let Err(e) = telemetry::flush_snapshot(&state_root) {
+                        eprintln!("[simard] telemetry: failed to flush metrics snapshot: {e}");
+                    }
+                }
             }
             Err(e) => {
                 daemon_log(&state_root, &format!("[simard] OODA cycle error: {e}"));

--- a/src/status/json.rs
+++ b/src/status/json.rs
@@ -1,0 +1,20 @@
+//! Serialization of [`StatusSnapshot`] — the `simard status --json` payload and
+//! the `GET /api/status/snapshot` HTTP body are the same bytes.
+
+use super::StatusSnapshot;
+
+/// Serialize a snapshot to compact JSON.
+pub fn to_string(snapshot: &StatusSnapshot) -> serde_json::Result<String> {
+    serde_json::to_string(snapshot)
+}
+
+/// Serialize a snapshot to pretty (human-diffable) JSON.
+pub fn to_string_pretty(snapshot: &StatusSnapshot) -> serde_json::Result<String> {
+    serde_json::to_string_pretty(snapshot)
+}
+
+/// Parse a snapshot from JSON. Tolerant of missing fields (they default) and
+/// ignores unknown ones, so the schema can grow additively.
+pub fn from_str(json: &str) -> serde_json::Result<StatusSnapshot> {
+    serde_json::from_str(json)
+}

--- a/src/status/mod.rs
+++ b/src/status/mod.rs
@@ -1,0 +1,403 @@
+//! The single typed `StatusSnapshot` that the `simard status` CLI, the dashboard
+//! **Status** tab, and the TUI **Status** tab all render.
+//!
+//! One provider ([`provider::assemble`]) builds it from durable, process-agnostic
+//! sources; [`json`] serializes it (`--json` / HTTP body); [`render`] formats the
+//! canonical terminal layout. Every section is wrapped in a [`SectionEnvelope`]
+//! so availability and freshness travel with the data — a missing count is
+//! `absent`, never a silent `0`.
+//!
+//! See `docs/reference/status-snapshot-api.md` for the full contract.
+
+pub mod json;
+pub mod provider;
+pub mod render;
+
+use serde::{Deserialize, Serialize};
+
+pub use provider::{AssembleOptions, assemble};
+
+/// Bumped when the serialized snapshot shape changes incompatibly.
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// Whether a section's source could be read at all.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Availability {
+    /// Source read successfully.
+    Ok,
+    /// Source is absent or not reachable in this context (e.g. `gh`
+    /// unauthenticated, daemon down). Not an error.
+    #[default]
+    Unavailable,
+    /// Source errored while being read.
+    Error,
+}
+
+/// How fresh a successfully-read section is.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Freshness {
+    /// Read within the source's freshness window.
+    Live,
+    /// Last-known value; source older than its window.
+    Stale,
+    /// Source missing entirely.
+    #[default]
+    Absent,
+}
+
+/// A section payload wrapped with availability + freshness metadata.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SectionEnvelope<T> {
+    pub availability: Availability,
+    pub freshness: Freshness,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub as_of: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+    #[serde(default = "none", skip_serializing_if = "Option::is_none")]
+    pub data: Option<T>,
+}
+
+fn none<T>() -> Option<T> {
+    None
+}
+
+impl<T> Default for SectionEnvelope<T> {
+    fn default() -> Self {
+        Self {
+            availability: Availability::Unavailable,
+            freshness: Freshness::Absent,
+            as_of: None,
+            note: None,
+            data: None,
+        }
+    }
+}
+
+impl<T> SectionEnvelope<T> {
+    /// A fresh, available section carrying `data`.
+    pub fn live(data: T, as_of: Option<String>) -> Self {
+        Self {
+            availability: Availability::Ok,
+            freshness: Freshness::Live,
+            as_of,
+            note: None,
+            data: Some(data),
+        }
+    }
+
+    /// An available but stale section carrying last-known `data`.
+    pub fn stale(data: T, as_of: Option<String>) -> Self {
+        Self {
+            availability: Availability::Ok,
+            freshness: Freshness::Stale,
+            as_of,
+            note: None,
+            data: Some(data),
+        }
+    }
+
+    /// A source that is simply not present in this context (no data).
+    pub fn absent(note: impl Into<String>) -> Self {
+        Self {
+            availability: Availability::Unavailable,
+            freshness: Freshness::Absent,
+            as_of: None,
+            note: Some(note.into()),
+            data: None,
+        }
+    }
+
+    /// A source that errored while being read (no data).
+    pub fn error(note: impl Into<String>) -> Self {
+        Self {
+            availability: Availability::Error,
+            freshness: Freshness::Absent,
+            as_of: None,
+            note: Some(note.into()),
+            data: None,
+        }
+    }
+
+    /// True when the section carries usable data.
+    pub fn is_present(&self) -> bool {
+        self.availability == Availability::Ok && self.data.is_some()
+    }
+}
+
+/// The complete status snapshot. Every section is independently degradable.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StatusSnapshot {
+    pub schema_version: u32,
+    /// RFC3339 timestamp of when the snapshot was assembled.
+    pub generated_at: String,
+    #[serde(default)]
+    pub daemon: SectionEnvelope<Daemon>,
+    #[serde(default)]
+    pub resources: SectionEnvelope<Resources>,
+    #[serde(default)]
+    pub llm: SectionEnvelope<LlmUsage>,
+    #[serde(default)]
+    pub memory: SectionEnvelope<MemoryBrain>,
+    #[serde(default)]
+    pub gym: SectionEnvelope<Gym>,
+    #[serde(default)]
+    pub goals: SectionEnvelope<GoalBoard>,
+    #[serde(default)]
+    pub workstreams: SectionEnvelope<Workstreams>,
+    #[serde(default)]
+    pub completed: SectionEnvelope<CompletedWork>,
+    #[serde(default)]
+    pub self_improvement: SectionEnvelope<SelfImprovement>,
+    #[serde(default)]
+    pub telemetry: SectionEnvelope<TelemetrySignals>,
+}
+
+impl StatusSnapshot {
+    /// A snapshot with every section absent, stamped now.
+    pub fn empty() -> Self {
+        Self {
+            schema_version: SCHEMA_VERSION,
+            generated_at: crate::telemetry::snapshot::now_rfc3339(),
+            daemon: SectionEnvelope::default(),
+            resources: SectionEnvelope::default(),
+            llm: SectionEnvelope::default(),
+            memory: SectionEnvelope::default(),
+            gym: SectionEnvelope::default(),
+            goals: SectionEnvelope::default(),
+            workstreams: SectionEnvelope::default(),
+            completed: SectionEnvelope::default(),
+            self_improvement: SectionEnvelope::default(),
+            telemetry: SectionEnvelope::default(),
+        }
+    }
+}
+
+impl Default for StatusSnapshot {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+// ── Section payloads ────────────────────────────────────────────────────────
+
+/// DAEMON / UPTIME.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct Daemon {
+    pub state: String,
+    pub version: String,
+    pub main_pid: Option<u32>,
+    pub deployed_commit: Option<String>,
+    pub instance_uptime: Option<String>,
+    pub n_restarts: Option<u64>,
+    pub running_since: Option<String>,
+}
+
+/// RESOURCE SNAPSHOT. Byte counts are raw bytes; `render` formats them.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct Resources {
+    pub cpu_pct: Option<f64>,
+    pub rss_bytes: Option<u64>,
+    pub cgroup_mem_peak_bytes: Option<u64>,
+    pub load_1: Option<f64>,
+    pub load_5: Option<f64>,
+    pub load_15: Option<f64>,
+    pub sys_mem_used_bytes: Option<u64>,
+    pub sys_mem_total_bytes: Option<u64>,
+    pub sys_mem_avail_bytes: Option<u64>,
+    pub disk_home: Option<DiskUsage>,
+    pub disk_tmp: Option<DiskUsage>,
+    pub live_engineers: Option<u32>,
+}
+
+/// Free / total bytes for one mount point.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct DiskUsage {
+    pub free_bytes: u64,
+    pub total_bytes: u64,
+}
+
+/// LLM USAGE.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct LlmUsage {
+    pub copilot_turn: Option<CopilotTurn>,
+    pub ledger_today: Option<LedgerWindow>,
+    pub ledger_7d: Option<LedgerWindow>,
+    pub ledger_all_time: Option<LedgerWindow>,
+    pub daily_budget_usd: Option<f64>,
+    pub reconciliation: Option<Reconciliation>,
+}
+
+/// Most-recent Copilot per-turn accounting.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct CopilotTurn {
+    pub tokens_in: u64,
+    pub tokens_cached: u64,
+    pub tokens_out: u64,
+    pub ai_credits: u64,
+}
+
+/// Cost-ledger aggregate over a window.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct LedgerWindow {
+    pub cost_usd: f64,
+    pub tokens_in: u64,
+    pub tokens_out: u64,
+}
+
+/// The two-books reconciliation: dollar ledger vs Copilot AI-credits.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct Reconciliation {
+    pub ledger_usd: f64,
+    pub credits: u64,
+    /// `ok` | `under-count` | `over-count`.
+    pub delta_flag: String,
+}
+
+/// MEMORY / BRAIN.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct MemoryBrain {
+    pub store_path: String,
+    pub store_size_bytes: Option<u64>,
+    pub backend: String,
+    pub nodes_total: Option<u64>,
+    pub nodes: NodeCounts,
+    pub edges: EdgeCounts,
+    pub cognitive_processes: CognitiveHealth,
+    pub brains_llm_backed: Option<String>,
+    pub brain_fallbacks: Option<u64>,
+    pub decide_ladder_exhausted: Option<u64>,
+}
+
+/// Per-type memory node counts.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct NodeCounts {
+    pub episodic: Option<u64>,
+    pub semantic: Option<u64>,
+    pub prospective: Option<u64>,
+    pub working: Option<u64>,
+    pub procedural: Option<u64>,
+    pub sensory: Option<u64>,
+}
+
+/// Per-type memory edge counts.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct EdgeCounts {
+    pub derives_from: Option<u64>,
+    pub similar_to: Option<u64>,
+    pub supersedes: Option<u64>,
+}
+
+/// Cognitive-process health labels.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct CognitiveHealth {
+    pub distillation: Option<String>,
+    pub consolidation: Option<String>,
+    pub introspection: Option<String>,
+}
+
+/// GYM.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct Gym {
+    pub skip_gym: bool,
+    pub configured_scenarios: Option<u32>,
+    /// `idle` | `active`.
+    pub self_eval_state: String,
+}
+
+/// GOAL BOARD.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct GoalBoard {
+    pub active: Vec<GoalItem>,
+}
+
+/// One active goal.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct GoalItem {
+    pub short_id: String,
+    /// e.g. `p0`.
+    pub priority: String,
+    pub status: String,
+    pub summary: String,
+}
+
+/// ACTIVE WORKSTREAMS.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct Workstreams {
+    pub operator_recipes: Vec<WorkItem>,
+    pub engineer_workstreams: Vec<WorkItem>,
+}
+
+/// One workstream line: a label plus a one-line status.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct WorkItem {
+    pub label: String,
+    pub status: String,
+}
+
+/// COMPLETED WORK — merged PRs grouped by repo.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct CompletedWork {
+    pub repos: Vec<RepoPrs>,
+}
+
+/// Merged PRs for one repository.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct RepoPrs {
+    pub repo: String,
+    pub prs: Vec<PrItem>,
+}
+
+/// One PR entry.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct PrItem {
+    pub number: u64,
+    pub summary: String,
+    pub status: String,
+}
+
+/// SELF-IMPROVEMENT.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct SelfImprovement {
+    pub merged: Vec<PrItem>,
+    pub running: Vec<WorkItem>,
+    pub pending: Vec<WorkItem>,
+}
+
+/// TELEMETRY / UNEXPECTED SIGNALS.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct TelemetrySignals {
+    /// Human label for the analysis window, e.g. `last 1h`.
+    pub window: String,
+    pub distill_fail_pct: Option<f64>,
+    pub restart_churn: Option<u64>,
+    pub gym_skipped: bool,
+    /// `ok` | `over` | `unknown`.
+    pub budget_flag: String,
+    pub parse_fix_holding: Option<bool>,
+    /// Named anomalies (panics / segv / corruption / fallback / budget).
+    pub anomalies: Vec<String>,
+}

--- a/src/status/provider.rs
+++ b/src/status/provider.rs
@@ -1,0 +1,556 @@
+//! Process-agnostic assembly of [`StatusSnapshot`] from durable sources.
+//!
+//! `assemble` reads on-disk and system sources (the telemetry snapshot file, the
+//! cost ledger, `/proc`, `systemctl show`) so it returns the same result from
+//! the daemon, the CLI, or the TUI. Each section is assembled in isolation: one
+//! failing source degrades one section, never the whole report, and never
+//! panics.
+//!
+//! Sources that require the live memory/goal IPC socket or `gh` (memory, goals,
+//! workstreams, completed work, self-improvement) are wired incrementally; until
+//! then they report `unavailable` with an honest note rather than inventing data.
+
+use std::path::PathBuf;
+
+use super::{
+    CopilotTurn, Daemon, DiskUsage, EdgeCounts, Gym, LedgerWindow, LlmUsage, MemoryBrain,
+    NodeCounts, Resources, SectionEnvelope, StatusSnapshot, TelemetrySignals,
+};
+use crate::telemetry::{names, snapshot};
+
+/// How the snapshot is assembled.
+#[derive(Clone, Debug)]
+pub struct AssembleOptions {
+    /// Durable state root to read (`telemetry/metrics_snapshot.json`, cost
+    /// ledger, …). Defaults to the resolved Simard state root.
+    pub state_root: PathBuf,
+    /// The systemd unit whose `systemctl show` backs the daemon section.
+    pub service_unit: String,
+    /// Optional allowlist of section names to assemble; `None` = all.
+    pub sections: Option<Vec<String>>,
+}
+
+impl Default for AssembleOptions {
+    fn default() -> Self {
+        Self {
+            state_root: crate::state_root::simard_state_root(),
+            service_unit: "simard.service".to_string(),
+            sections: None,
+        }
+    }
+}
+
+impl AssembleOptions {
+    /// Assemble reading a specific state root.
+    pub fn with_state_root(state_root: PathBuf) -> Self {
+        Self {
+            state_root,
+            ..Self::default()
+        }
+    }
+}
+
+/// Age (seconds) beyond which the telemetry snapshot is considered `stale`.
+const SNAPSHOT_FRESHNESS_SECS: i64 = 300;
+
+/// Assemble the full snapshot. Never panics; degraded sources become
+/// `unavailable`/`absent` sections.
+pub fn assemble(opts: &AssembleOptions) -> StatusSnapshot {
+    let metrics = snapshot::read(&snapshot::snapshot_path(&opts.state_root));
+    let gym_skipped = env_flag("SIMARD_SKIP_GYM");
+
+    let daemon = assemble_daemon(opts);
+    // The daemon's PID and restart count feed the resource + telemetry sections,
+    // so extract them once from the assembled daemon view.
+    let main_pid = daemon.data.as_ref().and_then(|d| d.main_pid);
+    let n_restarts = daemon.data.as_ref().and_then(|d| d.n_restarts);
+
+    let llm = assemble_llm(opts);
+    let budget_over = llm_over_budget(&llm);
+
+    StatusSnapshot {
+        schema_version: super::SCHEMA_VERSION,
+        generated_at: snapshot::now_rfc3339(),
+        daemon,
+        resources: assemble_resources(main_pid),
+        memory: assemble_memory(metrics.as_ref(), &opts.state_root),
+        gym: assemble_gym(gym_skipped),
+        goals: SectionEnvelope::absent("goal board read deferred (see dashboard/TUI goal board)"),
+        workstreams: SectionEnvelope::absent("engineer registry not read in this context"),
+        completed: SectionEnvelope::absent("gh: not queried in this context"),
+        self_improvement: SectionEnvelope::absent("gh: not queried in this context"),
+        telemetry: assemble_telemetry(metrics.as_ref(), gym_skipped, n_restarts, budget_over),
+        llm,
+    }
+}
+
+/// Whether today's ledger spend has crossed the daily budget guard, when both
+/// are known. `None` when either is unknown.
+fn llm_over_budget(llm: &SectionEnvelope<LlmUsage>) -> Option<bool> {
+    let data = llm.data.as_ref()?;
+    let budget = data.daily_budget_usd?;
+    let spent = data.ledger_today.as_ref().map(|w| w.cost_usd)?;
+    Some(spent > budget)
+}
+
+// ── daemon ──────────────────────────────────────────────────────────────────
+
+fn assemble_daemon(opts: &AssembleOptions) -> SectionEnvelope<Daemon> {
+    let output = std::process::Command::new("systemctl")
+        .args([
+            "show",
+            &opts.service_unit,
+            "--property=LoadState,ActiveState,SubState,MainPID,NRestarts,ExecMainStartTimestamp",
+        ])
+        .output();
+
+    let output = match output {
+        Ok(o) if o.status.success() => o,
+        Ok(_) => return SectionEnvelope::absent("systemctl: unit not found"),
+        Err(_) => return SectionEnvelope::absent("systemctl: unavailable"),
+    };
+
+    let text = String::from_utf8_lossy(&output.stdout);
+    let mut props = std::collections::HashMap::new();
+    for line in text.lines() {
+        if let Some((k, v)) = line.split_once('=') {
+            props.insert(k.to_string(), v.to_string());
+        }
+    }
+
+    // `systemctl show` exits 0 even for an unknown unit (reporting
+    // `LoadState=not-found`); treat anything not actually loaded as absent
+    // rather than rendering a phantom daemon.
+    match props.get("LoadState").map(String::as_str) {
+        Some("loaded") => {}
+        _ => return SectionEnvelope::absent("systemctl: unit not loaded"),
+    }
+
+    let active = props.get("ActiveState").cloned().unwrap_or_default();
+    let sub = props.get("SubState").cloned().unwrap_or_default();
+    let state = if sub.is_empty() {
+        active
+    } else {
+        format!("{active} ({sub})")
+    };
+
+    let daemon = Daemon {
+        state,
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        main_pid: props
+            .get("MainPID")
+            .and_then(|v| v.parse().ok())
+            .filter(|p| *p != 0),
+        deployed_commit: None,
+        instance_uptime: None,
+        running_since: props
+            .get("ExecMainStartTimestamp")
+            .filter(|s| !s.is_empty())
+            .cloned(),
+        n_restarts: props.get("NRestarts").and_then(|v| v.parse().ok()),
+    };
+    SectionEnvelope::live(daemon, None)
+}
+
+// ── resources ───────────────────────────────────────────────────────────────
+
+fn assemble_resources(daemon_pid: Option<u32>) -> SectionEnvelope<Resources> {
+    let (load_1, load_5, load_15) = read_loadavg();
+    let (total, avail) = read_meminfo();
+    let used = match (total, avail) {
+        (Some(t), Some(a)) => Some(t.saturating_sub(a)),
+        _ => None,
+    };
+    let rss_bytes = daemon_pid.and_then(read_process_rss_bytes);
+    let live_engineers = count_live_engineers();
+
+    let any = load_1.is_some() || total.is_some();
+    if !any {
+        return SectionEnvelope::absent("/proc: unavailable");
+    }
+
+    let resources = Resources {
+        cpu_pct: None,
+        rss_bytes,
+        cgroup_mem_peak_bytes: None,
+        load_1,
+        load_5,
+        load_15,
+        sys_mem_used_bytes: used,
+        sys_mem_total_bytes: total,
+        sys_mem_avail_bytes: avail,
+        disk_home: read_disk_for_home(),
+        disk_tmp: read_disk("/tmp"),
+        live_engineers,
+    };
+    SectionEnvelope::live(resources, None)
+}
+
+/// Read a process's resident set size (bytes) from `/proc/<pid>/status`
+/// `VmRSS`. `None` when the process is gone or `/proc` is unavailable.
+fn read_process_rss_bytes(pid: u32) -> Option<u64> {
+    let text = std::fs::read_to_string(format!("/proc/{pid}/status")).ok()?;
+    for line in text.lines() {
+        if let Some(rest) = line.strip_prefix("VmRSS:") {
+            return parse_kb(rest);
+        }
+    }
+    None
+}
+
+/// Count live engineer/agent subprocesses via `pgrep`. `None` when `pgrep` is
+/// unavailable; `Some(0)` when it ran and found none.
+fn count_live_engineers() -> Option<u32> {
+    let output = std::process::Command::new("pgrep")
+        .args(["-f", "-c", "simard-engineer|RustyClawd|copilot.*--auto"])
+        .output()
+        .ok()?;
+    // pgrep exits 1 with "0\n" when there are no matches; still a valid count.
+    String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .parse::<u32>()
+        .ok()
+}
+
+/// Resolve and stat the operator's home mount for the disk row.
+fn read_disk_for_home() -> Option<DiskUsage> {
+    let home = std::env::var("HOME").ok()?;
+    read_disk(&home)
+}
+
+fn read_loadavg() -> (Option<f64>, Option<f64>, Option<f64>) {
+    let Ok(text) = std::fs::read_to_string("/proc/loadavg") else {
+        return (None, None, None);
+    };
+    let mut it = text.split_whitespace();
+    (
+        it.next().and_then(|s| s.parse().ok()),
+        it.next().and_then(|s| s.parse().ok()),
+        it.next().and_then(|s| s.parse().ok()),
+    )
+}
+
+fn read_meminfo() -> (Option<u64>, Option<u64>) {
+    let Ok(text) = std::fs::read_to_string("/proc/meminfo") else {
+        return (None, None);
+    };
+    let mut total = None;
+    let mut avail = None;
+    for line in text.lines() {
+        if let Some(rest) = line.strip_prefix("MemTotal:") {
+            total = parse_kb(rest);
+        } else if let Some(rest) = line.strip_prefix("MemAvailable:") {
+            avail = parse_kb(rest);
+        }
+    }
+    (total, avail)
+}
+
+fn parse_kb(s: &str) -> Option<u64> {
+    s.split_whitespace()
+        .next()
+        .and_then(|n| n.parse::<u64>().ok())
+        .map(|kb| kb.saturating_mul(1024))
+}
+
+fn read_disk(path: &str) -> Option<DiskUsage> {
+    #[cfg(unix)]
+    #[allow(clippy::unnecessary_cast)] // statvfs field widths vary by platform.
+    {
+        use std::ffi::CString;
+        use std::mem::MaybeUninit;
+        let c = CString::new(path).ok()?;
+        // SAFETY: `statvfs` writes into the provided buffer; we check the return
+        // code before reading it.
+        unsafe {
+            let mut buf = MaybeUninit::<libc::statvfs>::zeroed();
+            if libc::statvfs(c.as_ptr(), buf.as_mut_ptr()) != 0 {
+                return None;
+            }
+            let buf = buf.assume_init();
+            let frsize = buf.f_frsize as u64;
+            Some(DiskUsage {
+                free_bytes: (buf.f_bavail as u64).saturating_mul(frsize),
+                total_bytes: (buf.f_blocks as u64).saturating_mul(frsize),
+            })
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+        None
+    }
+}
+
+// ── llm (cost ledger, read within state_root) ───────────────────────────────
+
+fn assemble_llm(opts: &AssembleOptions) -> SectionEnvelope<LlmUsage> {
+    let ledger = opts.state_root.join("costs").join("ledger.jsonl");
+    let Ok(text) = std::fs::read_to_string(&ledger) else {
+        return SectionEnvelope::absent("cost ledger: absent");
+    };
+
+    let now = chrono::Utc::now();
+    let day_ago = now - chrono::Duration::days(1);
+    let week_ago = now - chrono::Duration::days(7);
+
+    let mut today = LedgerWindow::default();
+    let mut last7 = LedgerWindow::default();
+    let mut all = LedgerWindow::default();
+    let mut last_turn: Option<CopilotTurn> = None;
+
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let Ok(entry) = serde_json::from_str::<serde_json::Value>(trimmed) else {
+            continue;
+        };
+        let ts = entry
+            .get("timestamp")
+            .and_then(|v| v.as_str())
+            .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+            .map(|dt| dt.with_timezone(&chrono::Utc));
+        let cost = entry
+            .get("cost_usd_est")
+            .and_then(|v| v.as_f64())
+            .unwrap_or(0.0);
+        let tin = entry
+            .get("prompt_tokens_est")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        let tout = entry
+            .get("completion_tokens_est")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+
+        add_window(&mut all, cost, tin, tout);
+        if let Some(ts) = ts {
+            if ts >= week_ago {
+                add_window(&mut last7, cost, tin, tout);
+            }
+            if ts >= day_ago {
+                add_window(&mut today, cost, tin, tout);
+            }
+        }
+        last_turn = Some(CopilotTurn {
+            tokens_in: tin,
+            tokens_cached: 0,
+            tokens_out: tout,
+            ai_credits: 0,
+        });
+    }
+
+    let daily_budget = std::env::var("SIMARD_DAILY_BUDGET_USD")
+        .ok()
+        .and_then(|v| v.parse::<f64>().ok());
+
+    let usage = LlmUsage {
+        copilot_turn: last_turn,
+        ledger_today: Some(today),
+        ledger_7d: Some(last7),
+        ledger_all_time: Some(all),
+        daily_budget_usd: daily_budget,
+        reconciliation: None,
+    };
+    SectionEnvelope::live(usage, None)
+}
+
+fn add_window(w: &mut LedgerWindow, cost: f64, tin: u64, tout: u64) {
+    w.cost_usd += cost;
+    w.tokens_in = w.tokens_in.saturating_add(tin);
+    w.tokens_out = w.tokens_out.saturating_add(tout);
+}
+
+// ── memory / brain (node + edge gauges from the metrics snapshot) ────────────
+
+/// Build the MEMORY / BRAIN section from the per-cycle gauges the daemon flushes
+/// into the metrics snapshot (`simard.memory.nodes{type}` /
+/// `simard.memory.edges{type}`). Reading through the snapshot keeps this
+/// process-agnostic — no LadybugDB open from the CLI — and honest: when the
+/// daemon has not flushed memory gauges the section is `absent`, never a
+/// fabricated zero.
+fn assemble_memory(
+    metrics: Option<&snapshot::MetricsSnapshot>,
+    state_root: &std::path::Path,
+) -> SectionEnvelope<MemoryBrain> {
+    let Some(m) = metrics else {
+        return SectionEnvelope::absent("metrics snapshot: absent");
+    };
+
+    let node = |ty: &str| m.gauge(names::MEMORY_NODES, &[(names::ATTR_TYPE, ty)]);
+    let edge = |ty: &str| m.gauge(names::MEMORY_EDGES, &[(names::ATTR_TYPE, ty)]);
+
+    let nodes = NodeCounts {
+        episodic: node("episodic").map(clamp_u64),
+        semantic: node("semantic").map(clamp_u64),
+        prospective: node("prospective").map(clamp_u64),
+        working: node("working").map(clamp_u64),
+        procedural: node("procedural").map(clamp_u64),
+        sensory: node("sensory").map(clamp_u64),
+    };
+    let edges = EdgeCounts {
+        derives_from: edge("DERIVES_FROM").map(clamp_u64),
+        similar_to: edge("SIMILAR_TO").map(clamp_u64),
+        supersedes: edge("SUPERSEDES").map(clamp_u64),
+    };
+
+    // No memory gauges in this snapshot → the daemon has not published them yet.
+    let any_nodes = nodes.episodic.is_some()
+        || nodes.semantic.is_some()
+        || nodes.prospective.is_some()
+        || nodes.working.is_some()
+        || nodes.procedural.is_some()
+        || nodes.sensory.is_some();
+    if !any_nodes && edges.derives_from.is_none() {
+        return SectionEnvelope::absent("memory gauges: not in snapshot");
+    }
+
+    let nodes_total = any_nodes.then(|| {
+        [
+            nodes.episodic,
+            nodes.semantic,
+            nodes.prospective,
+            nodes.working,
+            nodes.procedural,
+            nodes.sensory,
+        ]
+        .into_iter()
+        .flatten()
+        .sum()
+    });
+
+    let store_path = state_root.join("cognitive");
+    let store_size_bytes = std::fs::metadata(&store_path).ok().map(|meta| meta.len());
+
+    let memory = MemoryBrain {
+        store_path: store_path.display().to_string(),
+        store_size_bytes,
+        backend: "amplihack-memory-lib".to_string(),
+        nodes_total,
+        nodes,
+        edges,
+        cognitive_processes: super::CognitiveHealth::default(),
+        brains_llm_backed: None,
+        brain_fallbacks: m.counter(names::BRAIN_ESCALATIONS, &[]),
+        decide_ladder_exhausted: m.counter(names::BRAIN_LADDER_EXHAUSTED, &[]),
+    };
+
+    let (avail, fresh) = snapshot_freshness(&m.captured_at);
+    let mut env = SectionEnvelope::live(memory, Some(m.captured_at.clone()));
+    env.availability = avail;
+    env.freshness = fresh;
+    env
+}
+
+/// Clamp a gauge's `i64` back into a non-negative `u64` for a count field.
+fn clamp_u64(v: i64) -> u64 {
+    v.max(0) as u64
+}
+
+// ── gym ─────────────────────────────────────────────────────────────────────
+
+fn assemble_gym(skip_gym: bool) -> SectionEnvelope<Gym> {
+    SectionEnvelope::live(
+        Gym {
+            skip_gym,
+            configured_scenarios: None,
+            self_eval_state: "idle".to_string(),
+        },
+        None,
+    )
+}
+
+// ── telemetry / anomalies (derived from the metrics snapshot) ────────────────
+
+fn assemble_telemetry(
+    metrics: Option<&snapshot::MetricsSnapshot>,
+    gym_skipped: bool,
+    n_restarts: Option<u64>,
+    budget_over: Option<bool>,
+) -> SectionEnvelope<TelemetrySignals> {
+    let Some(m) = metrics else {
+        return SectionEnvelope::absent("metrics snapshot: absent");
+    };
+
+    let ok = m
+        .counter(names::DISTILL_RUNS, &[(names::ATTR_RESULT, "ok")])
+        .unwrap_or(0);
+    let fail = m
+        .counter(names::DISTILL_RUNS, &[(names::ATTR_RESULT, "parse_fail")])
+        .unwrap_or(0);
+    let distill_total = ok + fail;
+    let distill_fail_pct = if distill_total > 0 {
+        Some((fail as f64 / distill_total as f64) * 100.0)
+    } else {
+        None
+    };
+
+    // Restart churn is authoritatively the systemd `NRestarts` (it survives the
+    // process boundary a restart crosses); fall back to the in-process counter
+    // only when the daemon section is unavailable.
+    let restart_churn = n_restarts.or_else(|| m.counter(names::DAEMON_RESTART, &[]));
+
+    let budget_flag = match budget_over {
+        Some(true) => "over".to_string(),
+        Some(false) => "ok".to_string(),
+        None => "unknown".to_string(),
+    };
+
+    let mut anomalies = Vec::new();
+    if m.overflow_series > 0 {
+        anomalies.push(format!(
+            "telemetry cardinality overflow ({})",
+            m.overflow_series
+        ));
+    }
+    if let Some(pct) = distill_fail_pct
+        && pct > 0.0
+    {
+        anomalies.push(format!("distill parse-fail rate {pct:.0}%"));
+    }
+    if matches!(budget_over, Some(true)) {
+        anomalies.push("daily LLM budget exceeded".to_string());
+    }
+    let ladder = m.counter(names::BRAIN_LADDER_EXHAUSTED, &[]).unwrap_or(0);
+    if ladder > 0 {
+        anomalies.push(format!("brain decide ladder exhausted ({ladder})"));
+    }
+
+    let signals = TelemetrySignals {
+        window: "since last flush".to_string(),
+        distill_fail_pct,
+        restart_churn,
+        gym_skipped,
+        budget_flag,
+        parse_fix_holding: distill_fail_pct.map(|p| p == 0.0),
+        anomalies,
+    };
+
+    let (avail, fresh) = snapshot_freshness(&m.captured_at);
+    let mut env = SectionEnvelope::live(signals, Some(m.captured_at.clone()));
+    env.availability = avail;
+    env.freshness = fresh;
+    env
+}
+
+fn snapshot_freshness(captured_at: &str) -> (super::Availability, super::Freshness) {
+    match chrono::DateTime::parse_from_rfc3339(captured_at) {
+        Ok(ts) => {
+            let age = chrono::Utc::now().signed_duration_since(ts.with_timezone(&chrono::Utc));
+            if age.num_seconds() <= SNAPSHOT_FRESHNESS_SECS {
+                (super::Availability::Ok, super::Freshness::Live)
+            } else {
+                (super::Availability::Ok, super::Freshness::Stale)
+            }
+        }
+        Err(_) => (super::Availability::Ok, super::Freshness::Live),
+    }
+}
+
+fn env_flag(name: &str) -> bool {
+    std::env::var(name)
+        .map(|v| matches!(v.as_str(), "1" | "true" | "yes"))
+        .unwrap_or(false)
+}

--- a/src/status/provider.rs
+++ b/src/status/provider.rs
@@ -285,10 +285,30 @@ fn read_disk(path: &str) -> Option<DiskUsage> {
 // ── llm (cost ledger, read within state_root) ───────────────────────────────
 
 fn assemble_llm(opts: &AssembleOptions) -> SectionEnvelope<LlmUsage> {
+    use std::io::BufRead;
+
     let ledger = opts.state_root.join("costs").join("ledger.jsonl");
-    let Ok(text) = std::fs::read_to_string(&ledger) else {
+    let Ok(file) = std::fs::File::open(&ledger) else {
         return SectionEnvelope::absent("cost ledger: absent");
     };
+
+    // Only the four fields the windows need; typed deserialization skips the
+    // per-line `serde_json::Value` map (one allocation + seven interned keys per
+    // entry) that a generic parse would build. `timestamp` stays a raw string so
+    // an entry with a missing or unparseable timestamp still counts toward the
+    // all-time window — matching the prior tolerant behavior — rather than being
+    // dropped by a stricter typed timestamp.
+    #[derive(serde::Deserialize)]
+    struct LedgerLine {
+        #[serde(default)]
+        timestamp: Option<String>,
+        #[serde(default)]
+        cost_usd_est: f64,
+        #[serde(default)]
+        prompt_tokens_est: u64,
+        #[serde(default)]
+        completion_tokens_est: u64,
+    }
 
     let now = chrono::Utc::now();
     let day_ago = now - chrono::Duration::days(1);
@@ -299,31 +319,26 @@ fn assemble_llm(opts: &AssembleOptions) -> SectionEnvelope<LlmUsage> {
     let mut all = LedgerWindow::default();
     let mut last_turn: Option<CopilotTurn> = None;
 
-    for line in text.lines() {
+    // Stream line-by-line so peak memory stays ~one line rather than the whole
+    // append-only ledger, which grows without bound over the daemon's lifetime.
+    let reader = std::io::BufReader::new(file);
+    for line in reader.lines() {
+        let Ok(line) = line else { break };
         let trimmed = line.trim();
         if trimmed.is_empty() {
             continue;
         }
-        let Ok(entry) = serde_json::from_str::<serde_json::Value>(trimmed) else {
+        let Ok(entry) = serde_json::from_str::<LedgerLine>(trimmed) else {
             continue;
         };
         let ts = entry
-            .get("timestamp")
-            .and_then(|v| v.as_str())
+            .timestamp
+            .as_deref()
             .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
             .map(|dt| dt.with_timezone(&chrono::Utc));
-        let cost = entry
-            .get("cost_usd_est")
-            .and_then(|v| v.as_f64())
-            .unwrap_or(0.0);
-        let tin = entry
-            .get("prompt_tokens_est")
-            .and_then(|v| v.as_u64())
-            .unwrap_or(0);
-        let tout = entry
-            .get("completion_tokens_est")
-            .and_then(|v| v.as_u64())
-            .unwrap_or(0);
+        let cost = entry.cost_usd_est;
+        let tin = entry.prompt_tokens_est;
+        let tout = entry.completion_tokens_est;
 
         add_window(&mut all, cost, tin, tout);
         if let Some(ts) = ts {

--- a/src/status/provider.rs
+++ b/src/status/provider.rs
@@ -452,11 +452,7 @@ fn assemble_memory(
         decide_ladder_exhausted: m.counter(names::BRAIN_LADDER_EXHAUSTED, &[]),
     };
 
-    let (avail, fresh) = snapshot_freshness(&m.captured_at);
-    let mut env = SectionEnvelope::live(memory, Some(m.captured_at.clone()));
-    env.availability = avail;
-    env.freshness = fresh;
-    env
+    snapshot_section(memory, &m.captured_at)
 }
 
 /// Clamp a gauge's `i64` back into a non-negative `u64` for a count field.
@@ -543,24 +539,32 @@ fn assemble_telemetry(
         anomalies,
     };
 
-    let (avail, fresh) = snapshot_freshness(&m.captured_at);
-    let mut env = SectionEnvelope::live(signals, Some(m.captured_at.clone()));
-    env.availability = avail;
-    env.freshness = fresh;
-    env
+    snapshot_section(signals, &m.captured_at)
 }
 
-fn snapshot_freshness(captured_at: &str) -> (super::Availability, super::Freshness) {
+/// Wrap a snapshot-derived section, choosing `live` vs `stale` from
+/// `captured_at`. A readable snapshot is always `Ok`; only its freshness varies,
+/// so the two constructors capture every reachable state without a
+/// mutate-after-construct step.
+fn snapshot_section<T>(data: T, captured_at: &str) -> SectionEnvelope<T> {
+    let as_of = Some(captured_at.to_string());
+    if snapshot_is_stale(captured_at) {
+        SectionEnvelope::stale(data, as_of)
+    } else {
+        SectionEnvelope::live(data, as_of)
+    }
+}
+
+/// Whether the snapshot's `captured_at` is older than the freshness window. An
+/// unparseable timestamp is treated as fresh (not stale), matching the prior
+/// tolerant behavior.
+fn snapshot_is_stale(captured_at: &str) -> bool {
     match chrono::DateTime::parse_from_rfc3339(captured_at) {
         Ok(ts) => {
             let age = chrono::Utc::now().signed_duration_since(ts.with_timezone(&chrono::Utc));
-            if age.num_seconds() <= SNAPSHOT_FRESHNESS_SECS {
-                (super::Availability::Ok, super::Freshness::Live)
-            } else {
-                (super::Availability::Ok, super::Freshness::Stale)
-            }
+            age.num_seconds() > SNAPSHOT_FRESHNESS_SECS
         }
-        Err(_) => (super::Availability::Ok, super::Freshness::Live),
+        Err(_) => false,
     }
 }
 

--- a/src/status/render.rs
+++ b/src/status/render.rs
@@ -1,0 +1,483 @@
+//! Canonical terminal renderer for [`StatusSnapshot`].
+//!
+//! The section headers and labels here are the operator-approved layout the
+//! dashboard and TUI mirror. A missing count is rendered `absent` /
+//! `unavailable (<reason>)` — **never** a fabricated `0`.
+
+use std::fmt::Write as _;
+
+use super::{Availability, Freshness, SectionEnvelope, StatusSnapshot};
+
+/// The stable section headers, in render order. Surfaces and tests pin these.
+pub const SECTION_HEADERS: &[&str] = &[
+    "DAEMON / UPTIME",
+    "RESOURCE SNAPSHOT",
+    "LLM USAGE",
+    "MEMORY / BRAIN",
+    "GYM",
+    "GOAL BOARD",
+    "ACTIVE WORKSTREAMS",
+    "COMPLETED WORK",
+    "SELF-IMPROVEMENT",
+    "TELEMETRY / UNEXPECTED SIGNALS",
+];
+
+const LABEL_WIDTH: usize = 18;
+
+/// Render the full snapshot to the canonical terminal layout.
+pub fn to_terminal(snapshot: &StatusSnapshot) -> String {
+    let mut out = String::new();
+    let _ = writeln!(out, "SIMARD STATUS  ·  {}", snapshot.generated_at);
+    out.push('\n');
+
+    render_daemon(&mut out, &snapshot.daemon);
+    render_resources(&mut out, &snapshot.resources);
+    render_llm(&mut out, &snapshot.llm);
+    render_memory(&mut out, &snapshot.memory);
+    render_gym(&mut out, &snapshot.gym);
+    render_goals(&mut out, &snapshot.goals);
+    render_workstreams(&mut out, &snapshot.workstreams);
+    render_completed(&mut out, &snapshot.completed);
+    render_self_improvement(&mut out, &snapshot.self_improvement);
+    render_telemetry(&mut out, &snapshot.telemetry);
+
+    out
+}
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+fn header(out: &mut String, title: &str) {
+    let _ = writeln!(out, "{title}");
+}
+
+fn label(out: &mut String, name: &str, value: impl AsRef<str>) {
+    let _ = writeln!(out, "  {name:<LABEL_WIDTH$}{}", value.as_ref());
+}
+
+/// If a section is not present, render its absence and return `false`.
+fn absent_marker<T>(out: &mut String, env: &SectionEnvelope<T>) -> bool {
+    if env.is_present() {
+        return true;
+    }
+    let reason = env.note.clone().unwrap_or_else(|| "no source".to_string());
+    match env.availability {
+        Availability::Error => label(out, "", format!("error ({reason})")),
+        _ => match env.freshness {
+            Freshness::Absent => label(out, "", format!("unavailable ({reason})")),
+            _ => label(out, "", format!("stale ({reason})")),
+        },
+    }
+    false
+}
+
+/// A trailing `(stale)` marker when a present section is stale.
+fn stale_suffix<T>(env: &SectionEnvelope<T>) -> &'static str {
+    if env.freshness == Freshness::Stale {
+        "  (stale)"
+    } else {
+        ""
+    }
+}
+
+fn opt_u64(v: Option<u64>) -> String {
+    v.map(|n| n.to_string())
+        .unwrap_or_else(|| "absent".to_string())
+}
+
+fn opt_f64(v: Option<f64>, digits: usize) -> String {
+    v.map(|n| format!("{n:.digits$}"))
+        .unwrap_or_else(|| "absent".to_string())
+}
+
+fn opt_str(v: &Option<String>) -> String {
+    v.clone().unwrap_or_else(|| "absent".to_string())
+}
+
+fn format_bytes(bytes: u64) -> String {
+    const UNITS: [&str; 5] = ["B", "KiB", "MiB", "GiB", "TiB"];
+    let mut value = bytes as f64;
+    let mut unit = 0;
+    while value >= 1024.0 && unit < UNITS.len() - 1 {
+        value /= 1024.0;
+        unit += 1;
+    }
+    if unit == 0 {
+        format!("{bytes} B")
+    } else {
+        format!("{value:.0} {}", UNITS[unit])
+    }
+}
+
+fn opt_bytes(v: Option<u64>) -> String {
+    v.map(format_bytes).unwrap_or_else(|| "absent".to_string())
+}
+
+// ── sections ────────────────────────────────────────────────────────────────
+
+fn render_daemon(out: &mut String, env: &SectionEnvelope<super::Daemon>) {
+    header(out, "DAEMON / UPTIME");
+    if absent_marker(out, env)
+        && let Some(d) = &env.data
+    {
+        label(out, "state", format!("{}{}", d.state, stale_suffix(env)));
+        let ver = match &d.deployed_commit {
+            Some(c) => format!("{}  (deployed commit {c})", d.version),
+            None => d.version.clone(),
+        };
+        label(out, "version", ver);
+        label(out, "main PID", opt_u64(d.main_pid.map(u64::from)));
+        let up = match (&d.instance_uptime, &d.running_since) {
+            (Some(u), Some(s)) => format!("{u}   (running since {s})"),
+            (Some(u), None) => u.clone(),
+            _ => "absent".to_string(),
+        };
+        label(out, "this-instance up", up);
+        label(out, "NRestarts", opt_u64(d.n_restarts));
+    }
+    out.push('\n');
+}
+
+fn render_resources(out: &mut String, env: &SectionEnvelope<super::Resources>) {
+    header(out, "RESOURCE SNAPSHOT");
+    if absent_marker(out, env)
+        && let Some(r) = &env.data
+    {
+        label(
+            out,
+            "daemon CPU / RSS",
+            format!(
+                "{}%  ·  {}   (cgroup mem peak {})",
+                opt_f64(r.cpu_pct, 1),
+                opt_bytes(r.rss_bytes),
+                opt_bytes(r.cgroup_mem_peak_bytes)
+            ),
+        );
+        label(
+            out,
+            "load avg",
+            format!(
+                "{} / {} / {}   (1 / 5 / 15m)",
+                opt_f64(r.load_1, 2),
+                opt_f64(r.load_5, 2),
+                opt_f64(r.load_15, 2)
+            ),
+        );
+        label(
+            out,
+            "system mem",
+            format!(
+                "{} used / {}   ({} avail)",
+                opt_bytes(r.sys_mem_used_bytes),
+                opt_bytes(r.sys_mem_total_bytes),
+                opt_bytes(r.sys_mem_avail_bytes)
+            ),
+        );
+        let disk = |d: &Option<super::DiskUsage>| match d {
+            Some(u) => format!(
+                "{} free / {}",
+                format_bytes(u.free_bytes),
+                format_bytes(u.total_bytes)
+            ),
+            None => "absent".to_string(),
+        };
+        label(out, "disk /home", disk(&r.disk_home));
+        label(out, "disk /tmp", disk(&r.disk_tmp));
+        label(
+            out,
+            "live engineers",
+            opt_u64(r.live_engineers.map(u64::from)),
+        );
+    }
+    out.push('\n');
+}
+
+fn render_llm(out: &mut String, env: &SectionEnvelope<super::LlmUsage>) {
+    header(out, "LLM USAGE");
+    if absent_marker(out, env)
+        && let Some(l) = &env.data
+    {
+        match &l.copilot_turn {
+            Some(t) => label(
+                out,
+                "copilot turn",
+                format!(
+                    "in {}  cached {}  out {}   ·  AI-credits {}",
+                    t.tokens_in, t.tokens_cached, t.tokens_out, t.ai_credits
+                ),
+            ),
+            None => label(out, "copilot turn", "absent"),
+        }
+        let win = |w: &Option<super::LedgerWindow>| match w {
+            Some(w) => format!(
+                "${:.2}   in {}  out {}",
+                w.cost_usd, w.tokens_in, w.tokens_out
+            ),
+            None => "absent".to_string(),
+        };
+        label(out, "ledger today", win(&l.ledger_today));
+        label(out, "ledger 7d", win(&l.ledger_7d));
+        label(out, "ledger all-time", win(&l.ledger_all_time));
+        match l.daily_budget_usd {
+            Some(b) => {
+                let spent = l.ledger_today.as_ref().map(|w| w.cost_usd).unwrap_or(0.0);
+                label(out, "daily budget", format!("${spent:.2} / ${b:.2}"));
+            }
+            None => label(out, "daily budget", "unset (no guard)"),
+        }
+        match &l.reconciliation {
+            Some(r) => label(
+                out,
+                "reconciliation",
+                format!(
+                    "ledger ${:.2}  vs  credits {}   ·  {}",
+                    r.ledger_usd, r.credits, r.delta_flag
+                ),
+            ),
+            None => label(out, "reconciliation", "absent"),
+        }
+    }
+    out.push('\n');
+}
+
+fn render_memory(out: &mut String, env: &SectionEnvelope<super::MemoryBrain>) {
+    header(out, "MEMORY / BRAIN");
+    if absent_marker(out, env)
+        && let Some(m) = &env.data
+    {
+        label(
+            out,
+            "store",
+            format!(
+                "{}  ·  {}  ({})",
+                m.store_path,
+                opt_bytes(m.store_size_bytes),
+                m.backend
+            ),
+        );
+        label(out, "nodes", format!("{} total", opt_u64(m.nodes_total)));
+        let n = &m.nodes;
+        label(
+            out,
+            "",
+            format!(
+                "episodic {}  ·  semantic (facts) {}  ·  prospective (triggers) {}",
+                opt_u64(n.episodic),
+                opt_u64(n.semantic),
+                opt_u64(n.prospective)
+            ),
+        );
+        label(
+            out,
+            "",
+            format!(
+                "working {}  ·  procedural {}  ·  sensory {}",
+                opt_u64(n.working),
+                opt_u64(n.procedural),
+                opt_u64(n.sensory)
+            ),
+        );
+        let e = &m.edges;
+        label(
+            out,
+            "edges",
+            format!(
+                "DERIVES_FROM {}  ·  SIMILAR_TO {}  ·  SUPERSEDES {}",
+                opt_u64(e.derives_from),
+                opt_u64(e.similar_to),
+                opt_u64(e.supersedes)
+            ),
+        );
+        let c = &m.cognitive_processes;
+        label(
+            out,
+            "cognitive",
+            format!(
+                "distillation {}  ·  consolidation {}  ·  introspection {}",
+                opt_str(&c.distillation),
+                opt_str(&c.consolidation),
+                opt_str(&c.introspection)
+            ),
+        );
+        label(
+            out,
+            "brains",
+            format!(
+                "LLM-backed {}  ·  fallbacks {}  ·  decide ladder_exhausted {}",
+                opt_str(&m.brains_llm_backed),
+                opt_u64(m.brain_fallbacks),
+                opt_u64(m.decide_ladder_exhausted)
+            ),
+        );
+    }
+    out.push('\n');
+}
+
+fn render_gym(out: &mut String, env: &SectionEnvelope<super::Gym>) {
+    header(out, "GYM");
+    if absent_marker(out, env)
+        && let Some(g) = &env.data
+    {
+        label(
+            out,
+            "SIMARD_SKIP_GYM",
+            if g.skip_gym {
+                "set (gym skipped)"
+            } else {
+                "unset (gym enabled)"
+            },
+        );
+        label(
+            out,
+            "scenarios",
+            format!(
+                "{} configured",
+                opt_u64(g.configured_scenarios.map(u64::from))
+            ),
+        );
+        label(
+            out,
+            "self-eval",
+            if g.self_eval_state.is_empty() {
+                "unknown".to_string()
+            } else {
+                g.self_eval_state.clone()
+            },
+        );
+    }
+    out.push('\n');
+}
+
+fn render_goals(out: &mut String, env: &SectionEnvelope<super::GoalBoard>) {
+    header(out, "GOAL BOARD");
+    if absent_marker(out, env)
+        && let Some(g) = &env.data
+    {
+        if g.active.is_empty() {
+            label(out, "", "no active goals");
+        }
+        for goal in &g.active {
+            let _ = writeln!(
+                out,
+                "  [{}] {:<14} {:<42} ({})",
+                goal.priority, goal.status, goal.summary, goal.short_id
+            );
+        }
+    }
+    out.push('\n');
+}
+
+fn render_workstreams(out: &mut String, env: &SectionEnvelope<super::Workstreams>) {
+    header(out, "ACTIVE WORKSTREAMS");
+    if absent_marker(out, env)
+        && let Some(w) = &env.data
+    {
+        if w.operator_recipes.is_empty() && w.engineer_workstreams.is_empty() {
+            label(out, "", "none active");
+        }
+        for r in &w.operator_recipes {
+            let _ = writeln!(out, "  recipe   {:<22} {}", r.label, r.status);
+        }
+        for e in &w.engineer_workstreams {
+            let _ = writeln!(out, "  engineer {:<22} {}", e.label, e.status);
+        }
+    }
+    out.push('\n');
+}
+
+fn render_completed(out: &mut String, env: &SectionEnvelope<super::CompletedWork>) {
+    header(out, "COMPLETED WORK (merged PRs, last ~24h)");
+    if absent_marker(out, env)
+        && let Some(c) = &env.data
+    {
+        if c.repos.is_empty() {
+            label(out, "", "none");
+        }
+        for repo in &c.repos {
+            let _ = writeln!(out, "  {}", repo.repo);
+            for pr in &repo.prs {
+                let _ = writeln!(
+                    out,
+                    "    #{:<6} {:<48} {}",
+                    pr.number, pr.summary, pr.status
+                );
+            }
+        }
+    }
+    out.push('\n');
+}
+
+fn render_self_improvement(out: &mut String, env: &SectionEnvelope<super::SelfImprovement>) {
+    header(out, "SELF-IMPROVEMENT");
+    if absent_marker(out, env)
+        && let Some(s) = &env.data
+    {
+        for pr in &s.merged {
+            let _ = writeln!(out, "  merged   #{:<6} {}", pr.number, pr.summary);
+        }
+        for r in &s.running {
+            let _ = writeln!(out, "  running  {:<22} {}", r.label, r.status);
+        }
+        if s.pending.is_empty() {
+            let _ = writeln!(out, "  pending  —");
+        }
+        for p in &s.pending {
+            let _ = writeln!(out, "  pending  {:<22} {}", p.label, p.status);
+        }
+    }
+    out.push('\n');
+}
+
+fn render_telemetry(out: &mut String, env: &SectionEnvelope<super::TelemetrySignals>) {
+    let title = match &env.data {
+        Some(t) if !t.window.is_empty() => format!("TELEMETRY / UNEXPECTED SIGNALS ({})", t.window),
+        _ => "TELEMETRY / UNEXPECTED SIGNALS".to_string(),
+    };
+    header(out, &title);
+    if absent_marker(out, env)
+        && let Some(t) = &env.data
+    {
+        let holding = match t.parse_fix_holding {
+            Some(true) => "yes",
+            Some(false) => "no",
+            None => "unknown",
+        };
+        let pct = match t.distill_fail_pct {
+            Some(p) => format!("{p:.0}%"),
+            None => "unknown".to_string(),
+        };
+        label(
+            out,
+            "parse-fix holding",
+            format!("{holding} (distill parse-fail {pct})"),
+        );
+        label(
+            out,
+            "restart churn",
+            match t.restart_churn {
+                Some(0) => "none".to_string(),
+                Some(n) => format!("{n} restarts"),
+                None => "unknown".to_string(),
+            },
+        );
+        label(out, "gym skipped", if t.gym_skipped { "yes" } else { "no" });
+        label(
+            out,
+            "budget",
+            if t.budget_flag.is_empty() {
+                "unknown".to_string()
+            } else {
+                t.budget_flag.clone()
+            },
+        );
+        label(
+            out,
+            "anomalies",
+            if t.anomalies.is_empty() {
+                "none".to_string()
+            } else {
+                t.anomalies.join(", ")
+            },
+        );
+    }
+    out.push('\n');
+}

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -1,0 +1,43 @@
+//! Unified Simard telemetry facade.
+//!
+//! One typed entry point for every operational metric. The facade dual-writes
+//! into a bounded in-process [`registry`] (the source of truth read by
+//! [`crate::status`]) and — once wired in `init_tracing` — into OpenTelemetry
+//! instruments on an `SdkMeterProvider`. OTLP export is endpoint-gated
+//! (`OTEL_EXPORTER_OTLP_ENDPOINT`), identical to traces, so the default
+//! deployment stays fully local.
+//!
+//! See `docs/reference/telemetry-metrics.md` for the metric catalog and design.
+//!
+//! ```no_run
+//! use simard::telemetry;
+//! use simard::telemetry::names;
+//!
+//! telemetry::counter_add(names::DISTILL_RUNS, 1, &[(names::ATTR_RESULT, "ok")]);
+//! telemetry::gauge_set(names::ENGINEER_ACTIVE, 2, &[]);
+//! telemetry::histogram_record(names::DAEMON_CYCLE_DURATION_SECONDS, 1.4, &[]);
+//! ```
+
+pub mod names;
+pub mod otel;
+pub mod registry;
+pub mod snapshot;
+
+pub use otel::{init as init_metrics, shutdown as shutdown_metrics};
+pub use registry::{capture, counter_add, gauge_set, histogram_record, overflow_count, reset};
+pub use snapshot::MetricsSnapshot;
+
+use std::path::Path;
+
+/// Capture the current in-process registry and atomically flush it to
+/// `<state_root>/telemetry/metrics_snapshot.json`.
+///
+/// The daemon calls this once per OODA cycle (and on shutdown) so out-of-process
+/// readers — `simard status` and the TUI — see live daemon metrics without an
+/// external OTLP collector. The write is atomic and `0600`; readers tolerate a
+/// missing/corrupt file. Errors are returned, not panicked, so a flush failure
+/// never disrupts the cycle.
+pub fn flush_snapshot(state_root: impl AsRef<Path>) -> std::io::Result<()> {
+    let snap = registry::capture();
+    snapshot::write_atomic(&snapshot::snapshot_path(state_root.as_ref()), &snap)
+}

--- a/src/telemetry/names.rs
+++ b/src/telemetry/names.rs
@@ -1,0 +1,99 @@
+//! Canonical metric-name and attribute-key constants for the unified telemetry
+//! facade.
+//!
+//! Every metric name is dotted `simard.<area>.<name>`; every attribute value is
+//! a fixed low-cardinality enum (see `docs/reference/telemetry-metrics.md`).
+//! Emitters MUST reference these constants rather than string literals so the
+//! catalog stays single-sourced and greppable.
+
+// ── Distillation — simard.distill.* ─────────────────────────────────────────
+
+/// One distillation run completed. Attribute `result` = `ok` | `parse_fail`.
+pub const DISTILL_RUNS: &str = "simard.distill.runs";
+/// Facts produced by a distillation run.
+pub const DISTILL_FACTS: &str = "simard.distill.facts";
+/// Procedures produced by a distillation run.
+pub const DISTILL_PROCEDURES: &str = "simard.distill.procedures";
+/// Episodes marked processed by a distillation run.
+pub const DISTILL_EPISODES_MARKED: &str = "simard.distill.episodes_marked";
+
+// ── Brain — simard.brain.* ──────────────────────────────────────────────────
+
+/// One brain decision. Attributes `phase` = `decide` | `orient` | `lifecycle`;
+/// `result` = `parsed` | `default_empty` | `default_malformed` | `error`.
+pub const BRAIN_DECISION: &str = "simard.brain.decision";
+/// The `decide` ladder was exhausted with no keyword match.
+pub const BRAIN_LADDER_EXHAUSTED: &str = "simard.brain.ladder_exhausted";
+/// A decision escalated (degraded / quarantine / SIGTERM path).
+pub const BRAIN_ESCALATIONS: &str = "simard.brain.escalations";
+
+// ── Engineer — simard.engineer.* ────────────────────────────────────────────
+
+/// An engineer subprocess was spawned.
+pub const ENGINEER_SPAWNED: &str = "simard.engineer.spawned";
+/// An engineer subprocess exited. Attribute `outcome` = `success` | `failure`
+/// | `killed` | `timeout`.
+pub const ENGINEER_EXITED: &str = "simard.engineer.exited";
+/// Live engineer subprocess count (gauge).
+pub const ENGINEER_ACTIVE: &str = "simard.engineer.active";
+
+// ── Daemon — simard.daemon.* ────────────────────────────────────────────────
+
+/// Incremented on the daemon's self-restart / recovery-restart path.
+pub const DAEMON_RESTART: &str = "simard.daemon.restart";
+/// One OODA cycle completed.
+pub const DAEMON_CYCLE: &str = "simard.daemon.cycle";
+/// Wall-clock seconds per OODA cycle (histogram).
+pub const DAEMON_CYCLE_DURATION_SECONDS: &str = "simard.daemon.cycle_duration_seconds";
+
+/// Explicit histogram bucket boundaries (seconds) for
+/// [`DAEMON_CYCLE_DURATION_SECONDS`].
+pub const DAEMON_CYCLE_DURATION_BUCKETS: &[f64] =
+    &[0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0];
+
+// ── Memory graph — simard.memory.* ──────────────────────────────────────────
+
+/// Node count per memory type (gauge). Attribute `type` = `episodic` |
+/// `semantic` | `prospective` | `working` | `procedural` | `sensory`.
+pub const MEMORY_NODES: &str = "simard.memory.nodes";
+/// Edge count per relationship type (gauge). Attribute `type` = `DERIVES_FROM`
+/// | `SIMILAR_TO` | `SUPERSEDES`.
+pub const MEMORY_EDGES: &str = "simard.memory.edges";
+
+// ── LLM usage — simard.llm.* ────────────────────────────────────────────────
+
+/// Token throughput (counter). Attributes `dir` = `in` | `out`; `cached` =
+/// `true` | `false`.
+pub const LLM_TOKENS: &str = "simard.llm.tokens";
+/// Dollar cost from the cost ledger (counter).
+pub const LLM_COST_USD: &str = "simard.llm.cost_usd";
+/// Copilot AI-credits consumed (counter).
+pub const LLM_CREDITS: &str = "simard.llm.credits";
+
+// ── Goals — simard.goal.* ───────────────────────────────────────────────────
+
+/// Active goals on the board (gauge).
+pub const GOAL_ACTIVE: &str = "simard.goal.active";
+/// Goals marked completed (counter).
+pub const GOAL_COMPLETED: &str = "simard.goal.completed";
+/// Aggregate progress signal 0–100 (gauge).
+pub const GOAL_PROGRESS: &str = "simard.goal.progress";
+
+// ── Attribute keys ──────────────────────────────────────────────────────────
+
+/// Attribute key: outcome/result discriminator (`ok`/`parse_fail`, parse
+/// outcome, etc.).
+pub const ATTR_RESULT: &str = "result";
+/// Attribute key: brain decision phase.
+pub const ATTR_PHASE: &str = "phase";
+/// Attribute key: engineer exit outcome.
+pub const ATTR_OUTCOME: &str = "outcome";
+/// Attribute key: memory node/edge type.
+pub const ATTR_TYPE: &str = "type";
+/// Attribute key: token direction.
+pub const ATTR_DIR: &str = "dir";
+/// Attribute key: token cache status.
+pub const ATTR_CACHED: &str = "cached";
+
+/// Sentinel bucket an out-of-catalog attribute value is folded into.
+pub const OTHER_BUCKET: &str = "other";

--- a/src/telemetry/otel.rs
+++ b/src/telemetry/otel.rs
@@ -1,0 +1,139 @@
+//! OpenTelemetry metrics bridge for the unified telemetry facade.
+//!
+//! The facade ([`super::counter_add`] / [`super::gauge_set`] /
+//! [`super::histogram_record`]) dual-writes: always into the in-process
+//! [`super::registry`] (the source of truth read by [`crate::status`]) and,
+//! through this module, into OpenTelemetry instruments on an
+//! [`SdkMeterProvider`].
+//!
+//! ## Export is endpoint-gated, the provider is always installed
+//! [`init`] always installs an `SdkMeterProvider` as the global meter provider
+//! (so instruments are real, not the global no-op). An OTLP `PeriodicReader` is
+//! attached **only** when `OTEL_EXPORTER_OTLP_ENDPOINT` is set — identical to the
+//! tracer. With no endpoint (the production default) nothing leaves the process:
+//! the provider has no reader and the in-process registry is the only consumer.
+//!
+//! Instruments are created lazily and cached by name. Before [`init`] runs (e.g.
+//! in unit tests that never configure telemetry) the global meter is the SDK
+//! no-op, so recording is a cheap no-op and the in-process registry is
+//! unaffected.
+
+use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex, OnceLock};
+
+use opentelemetry::KeyValue;
+use opentelemetry::metrics::{Counter, Gauge, Histogram, Meter};
+use opentelemetry_sdk::metrics::SdkMeterProvider;
+
+use super::names;
+
+/// The installed provider, retained so [`shutdown`] can flush it on exit.
+static PROVIDER: OnceLock<SdkMeterProvider> = OnceLock::new();
+
+/// Cached instruments, keyed by metric name. OTel instruments are `Arc`-backed
+/// (cheap to clone, `Send + Sync`); caching avoids recreating them on the hot
+/// path.
+static COUNTERS: LazyLock<Mutex<HashMap<String, Counter<u64>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+static GAUGES: LazyLock<Mutex<HashMap<String, Gauge<i64>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+static HISTOGRAMS: LazyLock<Mutex<HashMap<String, Histogram<f64>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+fn meter() -> Meter {
+    opentelemetry::global::meter("simard")
+}
+
+/// Install the global `SdkMeterProvider`. OTLP export is attached only when
+/// `endpoint` is `Some` (the same gate as the tracer); otherwise the provider
+/// has no reader and metrics stay entirely in-process.
+///
+/// Idempotent: a second call is a no-op (the first-installed provider wins).
+pub fn init(endpoint: Option<&str>) {
+    if PROVIDER.get().is_some() {
+        return;
+    }
+
+    use opentelemetry::KeyValue as KV;
+    use opentelemetry_sdk::Resource;
+
+    let resource = Resource::new(vec![
+        KV::new("service.name", "simard"),
+        KV::new("service.version", env!("CARGO_PKG_VERSION")),
+    ]);
+
+    let mut builder = SdkMeterProvider::builder().with_resource(resource);
+
+    if let Some(ep) = endpoint {
+        match build_otlp_reader(ep) {
+            Ok(reader) => builder = builder.with_reader(reader),
+            Err(e) => eprintln!("[simard] OTEL metrics exporter init failed: {e}"),
+        }
+    }
+
+    let provider = builder.build();
+    opentelemetry::global::set_meter_provider(provider.clone());
+    let _ = PROVIDER.set(provider);
+}
+
+/// Flush and shut down the meter provider so pending export is not lost on exit.
+/// Safe to call when [`init`] was never invoked.
+pub fn shutdown() {
+    if let Some(provider) = PROVIDER.get() {
+        let _ = provider.shutdown();
+    }
+}
+
+fn build_otlp_reader(
+    endpoint: &str,
+) -> Result<opentelemetry_sdk::metrics::PeriodicReader, Box<dyn std::error::Error + Send + Sync>> {
+    use opentelemetry_otlp::{MetricExporter, WithExportConfig};
+    use opentelemetry_sdk::metrics::PeriodicReader;
+
+    let exporter = MetricExporter::builder()
+        .with_tonic()
+        .with_endpoint(endpoint)
+        .build()?;
+
+    Ok(PeriodicReader::builder(exporter, opentelemetry_sdk::runtime::Tokio).build())
+}
+
+fn to_kv(attrs: &[(&str, &str)]) -> Vec<KeyValue> {
+    attrs
+        .iter()
+        .map(|(k, v)| KeyValue::new(k.to_string(), v.to_string()))
+        .collect()
+}
+
+/// Mirror a counter add into the OTel counter of the same name.
+pub(super) fn record_counter(name: &str, value: u64, attrs: &[(&str, &str)]) {
+    let mut cache = COUNTERS.lock().unwrap_or_else(|e| e.into_inner());
+    let counter = cache
+        .entry(name.to_string())
+        .or_insert_with(|| meter().u64_counter(name.to_string()).build());
+    counter.add(value, &to_kv(attrs));
+}
+
+/// Mirror a gauge set into the OTel gauge of the same name.
+pub(super) fn record_gauge(name: &str, value: i64, attrs: &[(&str, &str)]) {
+    let mut cache = GAUGES.lock().unwrap_or_else(|e| e.into_inner());
+    let gauge = cache
+        .entry(name.to_string())
+        .or_insert_with(|| meter().i64_gauge(name.to_string()).build());
+    gauge.record(value, &to_kv(attrs));
+}
+
+/// Mirror a histogram observation into the OTel histogram of the same name.
+///
+/// All histograms use the shared [`names::DAEMON_CYCLE_DURATION_BUCKETS`]
+/// boundaries — the only histogram today is the OODA cycle duration.
+pub(super) fn record_histogram(name: &str, value: f64, attrs: &[(&str, &str)]) {
+    let mut cache = HISTOGRAMS.lock().unwrap_or_else(|e| e.into_inner());
+    let hist = cache.entry(name.to_string()).or_insert_with(|| {
+        meter()
+            .f64_histogram(name.to_string())
+            .with_boundaries(names::DAEMON_CYCLE_DURATION_BUCKETS.to_vec())
+            .build()
+    });
+    hist.record(value, &to_kv(attrs));
+}

--- a/src/telemetry/otel.rs
+++ b/src/telemetry/otel.rs
@@ -106,21 +106,31 @@ fn to_kv(attrs: &[(&str, &str)]) -> Vec<KeyValue> {
 }
 
 /// Mirror a counter add into the OTel counter of the same name.
+///
+/// The cache is keyed by name; a hit (the steady state, since the metric
+/// catalog is small and fixed) does a borrowed lookup and allocates no key,
+/// so only the first sighting of each name pays for interning.
 pub(super) fn record_counter(name: &str, value: u64, attrs: &[(&str, &str)]) {
     let mut cache = COUNTERS.lock().unwrap_or_else(|e| e.into_inner());
-    let counter = cache
-        .entry(name.to_string())
-        .or_insert_with(|| meter().u64_counter(name.to_string()).build());
+    if let Some(counter) = cache.get(name) {
+        counter.add(value, &to_kv(attrs));
+        return;
+    }
+    let counter = meter().u64_counter(name.to_string()).build();
     counter.add(value, &to_kv(attrs));
+    cache.insert(name.to_string(), counter);
 }
 
 /// Mirror a gauge set into the OTel gauge of the same name.
 pub(super) fn record_gauge(name: &str, value: i64, attrs: &[(&str, &str)]) {
     let mut cache = GAUGES.lock().unwrap_or_else(|e| e.into_inner());
-    let gauge = cache
-        .entry(name.to_string())
-        .or_insert_with(|| meter().i64_gauge(name.to_string()).build());
+    if let Some(gauge) = cache.get(name) {
+        gauge.record(value, &to_kv(attrs));
+        return;
+    }
+    let gauge = meter().i64_gauge(name.to_string()).build();
     gauge.record(value, &to_kv(attrs));
+    cache.insert(name.to_string(), gauge);
 }
 
 /// Mirror a histogram observation into the OTel histogram of the same name.
@@ -129,11 +139,14 @@ pub(super) fn record_gauge(name: &str, value: i64, attrs: &[(&str, &str)]) {
 /// boundaries — the only histogram today is the OODA cycle duration.
 pub(super) fn record_histogram(name: &str, value: f64, attrs: &[(&str, &str)]) {
     let mut cache = HISTOGRAMS.lock().unwrap_or_else(|e| e.into_inner());
-    let hist = cache.entry(name.to_string()).or_insert_with(|| {
-        meter()
-            .f64_histogram(name.to_string())
-            .with_boundaries(names::DAEMON_CYCLE_DURATION_BUCKETS.to_vec())
-            .build()
-    });
+    if let Some(hist) = cache.get(name) {
+        hist.record(value, &to_kv(attrs));
+        return;
+    }
+    let hist = meter()
+        .f64_histogram(name.to_string())
+        .with_boundaries(names::DAEMON_CYCLE_DURATION_BUCKETS.to_vec())
+        .build();
     hist.record(value, &to_kv(attrs));
+    cache.insert(name.to_string(), hist);
 }

--- a/src/telemetry/registry.rs
+++ b/src/telemetry/registry.rs
@@ -75,17 +75,12 @@ pub fn counter_add(name: &str, value: u64, attrs: &[(&str, &str)]) {
     super::otel::record_counter(name, value, attrs);
     let mut reg = lock();
     let key = intern_key(&mut reg, name, attrs);
-    let total_series = reg.counters.len() + reg.gauges.len() + reg.histograms.len();
-    match reg.counters.get_mut(&key) {
-        Some(slot) => *slot = slot.saturating_add(value),
-        None => {
-            if total_series >= MAX_SERIES {
-                reg.overflow_series = reg.overflow_series.saturating_add(1);
-                return;
-            }
-            reg.counters.insert(key, value);
-        }
+    let exists = reg.counters.contains_key(&key);
+    if !admit_series(&mut reg, exists) {
+        return;
     }
+    let slot = reg.counters.entry(key).or_insert(0);
+    *slot = slot.saturating_add(value);
 }
 
 /// Set gauge `name` to `value` for the given attribute set (last write wins).
@@ -95,9 +90,8 @@ pub fn gauge_set(name: &str, value: i64, attrs: &[(&str, &str)]) {
     super::otel::record_gauge(name, value, attrs);
     let mut reg = lock();
     let key = intern_key(&mut reg, name, attrs);
-    let total_series = reg.counters.len() + reg.gauges.len() + reg.histograms.len();
-    if !reg.gauges.contains_key(&key) && total_series >= MAX_SERIES {
-        reg.overflow_series = reg.overflow_series.saturating_add(1);
+    let exists = reg.gauges.contains_key(&key);
+    if !admit_series(&mut reg, exists) {
         return;
     }
     reg.gauges.insert(key, value);
@@ -111,9 +105,8 @@ pub fn histogram_record(name: &str, value: f64, attrs: &[(&str, &str)]) {
     super::otel::record_histogram(name, value, attrs);
     let mut reg = lock();
     let key = intern_key(&mut reg, name, attrs);
-    let total_series = reg.counters.len() + reg.gauges.len() + reg.histograms.len();
-    if !reg.histograms.contains_key(&key) && total_series >= MAX_SERIES {
-        reg.overflow_series = reg.overflow_series.saturating_add(1);
+    let exists = reg.histograms.contains_key(&key);
+    if !admit_series(&mut reg, exists) {
         return;
     }
     let accum = reg.histograms.entry(key).or_insert_with(|| HistogramAccum {
@@ -205,6 +198,23 @@ impl HistogramAccum {
             buckets,
         }
     }
+}
+
+/// Admission control for the global series cap. `key_exists` says whether the
+/// series is already tracked. Updates to an existing series are always admitted;
+/// a *new* series that would exceed [`MAX_SERIES`] is rejected — this records an
+/// overflow and returns `false`, so callers drop the write. Centralizing the cap
+/// here keeps the "a bug must never grow the registry without limit" invariant in
+/// one place across counters, gauges, and histograms.
+fn admit_series(reg: &mut Registry, key_exists: bool) -> bool {
+    if key_exists {
+        return true;
+    }
+    if reg.counters.len() + reg.gauges.len() + reg.histograms.len() >= MAX_SERIES {
+        reg.overflow_series = reg.overflow_series.saturating_add(1);
+        return false;
+    }
+    true
 }
 
 /// Normalize + cardinality-bound the attribute set and return the interned

--- a/src/telemetry/registry.rs
+++ b/src/telemetry/registry.rs
@@ -1,0 +1,256 @@
+//! Bounded, thread-safe, in-process metrics registry — the source of truth read
+//! by [`crate::status`] with no external collector.
+//!
+//! The facade functions ([`counter_add`], [`gauge_set`], [`histogram_record`])
+//! dual-write here and (once wired in `init_tracing`) into OpenTelemetry
+//! instruments. This module keeps only the in-process side: an atomic registry
+//! whose current values are snapshotted by [`capture`].
+//!
+//! ## Bounds (a bug must never grow this without limit)
+//! - Attribute values are normalized: capped to [`MAX_ATTR_VALUE_LEN`] and
+//!   stripped of control characters.
+//! - Cardinality per `(metric, attribute-key)` is capped at
+//!   [`MAX_VALUES_PER_KEY`]; a value beyond the cap is folded into the
+//!   [`names::OTHER_BUCKET`] series and increments the overflow counter.
+//! - The total number of distinct series is capped at [`MAX_SERIES`].
+
+use std::collections::{BTreeSet, HashMap};
+use std::sync::{LazyLock, Mutex};
+
+use super::names;
+use super::snapshot::{
+    CounterSeries, GaugeSeries, HistogramBucket, HistogramSeries, HistogramValue, MetricsSnapshot,
+    SCHEMA_VERSION, now_rfc3339,
+};
+
+/// Maximum retained length of a single attribute value.
+pub const MAX_ATTR_VALUE_LEN: usize = 64;
+/// Maximum distinct attribute values retained per `(metric, attribute-key)`
+/// before further values fold into `other`.
+pub const MAX_VALUES_PER_KEY: usize = 16;
+/// Global cap on the number of distinct series the registry will hold.
+pub const MAX_SERIES: usize = 4096;
+
+/// Default histogram bucket boundaries used for every histogram series (the
+/// only histogram today is the OODA cycle duration).
+const DEFAULT_BUCKETS: &[f64] = names::DAEMON_CYCLE_DURATION_BUCKETS;
+
+type Attrs = Vec<(String, String)>;
+type SeriesKey = (String, Attrs);
+
+#[derive(Default)]
+struct HistogramAccum {
+    count: u64,
+    sum: f64,
+    /// Per-bucket tallies aligned to `DEFAULT_BUCKETS`, with one trailing
+    /// `+Inf` bucket.
+    bucket_counts: Vec<u64>,
+}
+
+#[derive(Default)]
+struct Registry {
+    counters: HashMap<SeriesKey, u64>,
+    gauges: HashMap<SeriesKey, i64>,
+    histograms: HashMap<SeriesKey, HistogramAccum>,
+    /// Distinct values seen per `(metric, attribute-key)`, for the cardinality
+    /// bound.
+    value_sets: HashMap<(String, String), BTreeSet<String>>,
+    overflow_series: u64,
+}
+
+static REGISTRY: LazyLock<Mutex<Registry>> = LazyLock::new(|| Mutex::new(Registry::default()));
+
+fn lock() -> std::sync::MutexGuard<'static, Registry> {
+    // A poisoned lock only means a prior test panicked mid-write; the registry
+    // is still structurally valid, so recover rather than propagate the panic
+    // into unrelated telemetry callers on a hot path.
+    REGISTRY.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// Add `value` to counter `name` for the given attribute set.
+///
+/// Dual-writes: the in-process registry (below) plus the OTel counter of the
+/// same name (a no-op until [`super::otel::init`] runs).
+pub fn counter_add(name: &str, value: u64, attrs: &[(&str, &str)]) {
+    super::otel::record_counter(name, value, attrs);
+    let mut reg = lock();
+    let key = intern_key(&mut reg, name, attrs);
+    let total_series = reg.counters.len() + reg.gauges.len() + reg.histograms.len();
+    match reg.counters.get_mut(&key) {
+        Some(slot) => *slot = slot.saturating_add(value),
+        None => {
+            if total_series >= MAX_SERIES {
+                reg.overflow_series = reg.overflow_series.saturating_add(1);
+                return;
+            }
+            reg.counters.insert(key, value);
+        }
+    }
+}
+
+/// Set gauge `name` to `value` for the given attribute set (last write wins).
+///
+/// Dual-writes: the in-process registry plus the OTel gauge of the same name.
+pub fn gauge_set(name: &str, value: i64, attrs: &[(&str, &str)]) {
+    super::otel::record_gauge(name, value, attrs);
+    let mut reg = lock();
+    let key = intern_key(&mut reg, name, attrs);
+    let total_series = reg.counters.len() + reg.gauges.len() + reg.histograms.len();
+    if !reg.gauges.contains_key(&key) && total_series >= MAX_SERIES {
+        reg.overflow_series = reg.overflow_series.saturating_add(1);
+        return;
+    }
+    reg.gauges.insert(key, value);
+}
+
+/// Record one observation `value` into histogram `name` for the attribute set.
+///
+/// Dual-writes: the in-process registry plus the OTel histogram of the same
+/// name.
+pub fn histogram_record(name: &str, value: f64, attrs: &[(&str, &str)]) {
+    super::otel::record_histogram(name, value, attrs);
+    let mut reg = lock();
+    let key = intern_key(&mut reg, name, attrs);
+    let total_series = reg.counters.len() + reg.gauges.len() + reg.histograms.len();
+    if !reg.histograms.contains_key(&key) && total_series >= MAX_SERIES {
+        reg.overflow_series = reg.overflow_series.saturating_add(1);
+        return;
+    }
+    let accum = reg.histograms.entry(key).or_insert_with(|| HistogramAccum {
+        count: 0,
+        sum: 0.0,
+        bucket_counts: vec![0; DEFAULT_BUCKETS.len() + 1],
+    });
+    accum.count = accum.count.saturating_add(1);
+    accum.sum += value;
+    let idx = DEFAULT_BUCKETS
+        .iter()
+        .position(|&b| value <= b)
+        .unwrap_or(DEFAULT_BUCKETS.len());
+    accum.bucket_counts[idx] = accum.bucket_counts[idx].saturating_add(1);
+}
+
+/// Snapshot the current registry into a serializable [`MetricsSnapshot`].
+pub fn capture() -> MetricsSnapshot {
+    let reg = lock();
+
+    let mut counters: Vec<CounterSeries> = reg
+        .counters
+        .iter()
+        .map(|((name, attrs), value)| CounterSeries {
+            name: name.clone(),
+            attrs: attrs.clone(),
+            value: *value,
+        })
+        .collect();
+    counters.sort_by(|a, b| (a.name.as_str(), &a.attrs).cmp(&(b.name.as_str(), &b.attrs)));
+
+    let mut gauges: Vec<GaugeSeries> = reg
+        .gauges
+        .iter()
+        .map(|((name, attrs), value)| GaugeSeries {
+            name: name.clone(),
+            attrs: attrs.clone(),
+            value: *value,
+        })
+        .collect();
+    gauges.sort_by(|a, b| (a.name.as_str(), &a.attrs).cmp(&(b.name.as_str(), &b.attrs)));
+
+    let mut histograms: Vec<HistogramSeries> = reg
+        .histograms
+        .iter()
+        .map(|((name, attrs), accum)| HistogramSeries {
+            name: name.clone(),
+            attrs: attrs.clone(),
+            value: accum.to_value(),
+        })
+        .collect();
+    histograms.sort_by(|a, b| (a.name.as_str(), &a.attrs).cmp(&(b.name.as_str(), &b.attrs)));
+
+    MetricsSnapshot {
+        schema_version: SCHEMA_VERSION,
+        captured_at: now_rfc3339(),
+        counters,
+        gauges,
+        histograms,
+        overflow_series: reg.overflow_series,
+    }
+}
+
+/// Number of attribute values folded into `other` by the cardinality bound.
+pub fn overflow_count() -> u64 {
+    lock().overflow_series
+}
+
+/// Clear all series. Intended for test isolation; the daemon never calls it.
+pub fn reset() {
+    let mut reg = lock();
+    *reg = Registry::default();
+}
+
+impl HistogramAccum {
+    fn to_value(&self) -> HistogramValue {
+        let mut cumulative = 0u64;
+        let mut buckets = Vec::with_capacity(DEFAULT_BUCKETS.len());
+        for (i, &le) in DEFAULT_BUCKETS.iter().enumerate() {
+            cumulative = cumulative.saturating_add(self.bucket_counts[i]);
+            buckets.push(HistogramBucket {
+                le,
+                count: cumulative,
+            });
+        }
+        HistogramValue {
+            count: self.count,
+            sum: self.sum,
+            buckets,
+        }
+    }
+}
+
+/// Normalize + cardinality-bound the attribute set and return the interned
+/// series key. Mutates the registry's overflow counter and per-key value sets.
+fn intern_key(reg: &mut Registry, name: &str, attrs: &[(&str, &str)]) -> SeriesKey {
+    let mut bounded: Attrs = Vec::with_capacity(attrs.len());
+    for (k, v) in attrs {
+        let key = normalize_value(k);
+        let value = normalize_value(v);
+        let final_value = bound_cardinality(reg, name, &key, value);
+        bounded.push((key, final_value));
+    }
+    bounded.sort();
+    (name.to_string(), bounded)
+}
+
+/// Fold an out-of-catalog value into `other` once the per-key cardinality cap
+/// is reached, bumping the overflow counter.
+fn bound_cardinality(reg: &mut Registry, name: &str, attr_key: &str, value: String) -> String {
+    if value == names::OTHER_BUCKET {
+        return value;
+    }
+    let set = reg
+        .value_sets
+        .entry((name.to_string(), attr_key.to_string()))
+        .or_default();
+    if set.contains(&value) {
+        return value;
+    }
+    if set.len() < MAX_VALUES_PER_KEY {
+        set.insert(value.clone());
+        return value;
+    }
+    reg.overflow_series = reg.overflow_series.saturating_add(1);
+    names::OTHER_BUCKET.to_string()
+}
+
+/// Cap length and strip control characters from an attribute key or value.
+fn normalize_value(raw: &str) -> String {
+    let cleaned: String = raw
+        .chars()
+        .map(|c| if c.is_control() { ' ' } else { c })
+        .collect();
+    if cleaned.chars().count() <= MAX_ATTR_VALUE_LEN {
+        cleaned
+    } else {
+        cleaned.chars().take(MAX_ATTR_VALUE_LEN).collect()
+    }
+}

--- a/src/telemetry/snapshot.rs
+++ b/src/telemetry/snapshot.rs
@@ -1,0 +1,193 @@
+//! Serializable point-in-time view of the in-process metrics registry, plus the
+//! degrade-safe on-disk `metrics_snapshot.json` reader/writer.
+//!
+//! The daemon flushes a [`MetricsSnapshot`] to
+//! `~/.simard/telemetry/metrics_snapshot.json` once per OODA cycle; the CLI and
+//! TUI **read** it (never write it). Readers tolerate a missing, truncated, or
+//! corrupt file by returning `None` rather than panicking.
+
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+/// Bumped whenever the serialized shape changes incompatibly.
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// Hard cap on the on-disk snapshot we will read into memory (bytes). A
+/// pathologically large file degrades to `None` instead of exhausting memory.
+pub const MAX_SNAPSHOT_BYTES: u64 = 8 * 1024 * 1024;
+
+/// A single counter series: monotonically increasing total for one attribute
+/// set.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CounterSeries {
+    pub name: String,
+    /// Sorted, normalized `(key, value)` attribute pairs.
+    pub attrs: Vec<(String, String)>,
+    pub value: u64,
+}
+
+/// A single gauge series: the last value written for one attribute set.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GaugeSeries {
+    pub name: String,
+    pub attrs: Vec<(String, String)>,
+    pub value: i64,
+}
+
+/// A single histogram series: count/sum plus cumulative bucket tallies.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct HistogramSeries {
+    pub name: String,
+    pub attrs: Vec<(String, String)>,
+    pub value: HistogramValue,
+}
+
+/// Aggregated histogram observation.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct HistogramValue {
+    pub count: u64,
+    pub sum: f64,
+    /// Cumulative `(le, count)` buckets, ascending by `le`.
+    pub buckets: Vec<HistogramBucket>,
+}
+
+/// One cumulative histogram bucket (`count` observations with value `<= le`).
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct HistogramBucket {
+    pub le: f64,
+    pub count: u64,
+}
+
+/// A serializable snapshot of every metric series known to the in-process
+/// registry at `captured_at`.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct MetricsSnapshot {
+    pub schema_version: u32,
+    /// RFC3339 timestamp of when the snapshot was captured.
+    pub captured_at: String,
+    #[serde(default)]
+    pub counters: Vec<CounterSeries>,
+    #[serde(default)]
+    pub gauges: Vec<GaugeSeries>,
+    #[serde(default)]
+    pub histograms: Vec<HistogramSeries>,
+    /// Count of attribute values folded into the `other` bucket by the
+    /// cardinality bound — a non-zero value signals emitter misuse.
+    #[serde(default)]
+    pub overflow_series: u64,
+}
+
+impl MetricsSnapshot {
+    /// An empty snapshot stamped now.
+    pub fn empty() -> Self {
+        Self {
+            schema_version: SCHEMA_VERSION,
+            captured_at: now_rfc3339(),
+            counters: Vec::new(),
+            gauges: Vec::new(),
+            histograms: Vec::new(),
+            overflow_series: 0,
+        }
+    }
+
+    /// Current total of counter `name` with exactly `attrs` (order-independent).
+    pub fn counter(&self, name: &str, attrs: &[(&str, &str)]) -> Option<u64> {
+        let want = sorted_owned(attrs);
+        self.counters
+            .iter()
+            .find(|s| s.name == name && s.attrs == want)
+            .map(|s| s.value)
+    }
+
+    /// Current value of gauge `name` with exactly `attrs`.
+    pub fn gauge(&self, name: &str, attrs: &[(&str, &str)]) -> Option<i64> {
+        let want = sorted_owned(attrs);
+        self.gauges
+            .iter()
+            .find(|s| s.name == name && s.attrs == want)
+            .map(|s| s.value)
+    }
+
+    /// Current histogram value of `name` with exactly `attrs`.
+    pub fn histogram(&self, name: &str, attrs: &[(&str, &str)]) -> Option<&HistogramValue> {
+        let want = sorted_owned(attrs);
+        self.histograms
+            .iter()
+            .find(|s| s.name == name && s.attrs == want)
+            .map(|s| &s.value)
+    }
+}
+
+fn sorted_owned(attrs: &[(&str, &str)]) -> Vec<(String, String)> {
+    let mut v: Vec<(String, String)> = attrs
+        .iter()
+        .map(|(k, val)| ((*k).to_string(), (*val).to_string()))
+        .collect();
+    v.sort();
+    v
+}
+
+/// RFC3339 timestamp for "now" (UTC, second precision).
+pub fn now_rfc3339() -> String {
+    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
+/// Canonical on-disk path of the metrics snapshot under a state root:
+/// `<state_root>/telemetry/metrics_snapshot.json`. The daemon writes it; the
+/// CLI and TUI read it.
+pub fn snapshot_path(state_root: &Path) -> std::path::PathBuf {
+    state_root.join("telemetry").join("metrics_snapshot.json")
+}
+
+/// Atomically and privately write `snapshot` to `path`.
+///
+/// Creates the parent directory `0700`, writes a `0600` temp file, `fsync`s it,
+/// then `rename`s over the target — so `path` is never briefly world-readable
+/// and readers never see a partial document.
+pub fn write_atomic(path: &Path, snapshot: &MetricsSnapshot) -> std::io::Result<()> {
+    use std::io::Write;
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700));
+        }
+    }
+
+    let body = serde_json::to_vec_pretty(snapshot)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+
+    let tmp = path.with_extension("json.tmp");
+    {
+        let mut opts = std::fs::OpenOptions::new();
+        opts.write(true).create(true).truncate(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            opts.mode(0o600);
+        }
+        let mut file = opts.open(&tmp)?;
+        file.write_all(&body)?;
+        file.sync_all()?;
+    }
+    std::fs::rename(&tmp, path)?;
+    Ok(())
+}
+
+/// Read a snapshot from `path`, degrading to `None` on any problem.
+///
+/// Returns `None` when the file is missing, larger than [`MAX_SNAPSHOT_BYTES`],
+/// unreadable, or not parseable — **never** panics. Freshness (`live`/`stale`)
+/// is a judgement the caller makes from [`MetricsSnapshot::captured_at`]; this
+/// function only materializes the document.
+pub fn read(path: &Path) -> Option<MetricsSnapshot> {
+    let meta = std::fs::metadata(path).ok()?;
+    if !meta.is_file() || meta.len() > MAX_SNAPSHOT_BYTES {
+        return None;
+    }
+    let bytes = std::fs::read(path).ok()?;
+    serde_json::from_slice::<MetricsSnapshot>(&bytes).ok()
+}

--- a/tests/e2e-dashboard/specs/tabs.spec.ts
+++ b/tests/e2e-dashboard/specs/tabs.spec.ts
@@ -14,6 +14,7 @@ const ALL_TABS = [
   'brain-failures',
   'merge-decisions',
   'pr-readiness',
+  'status',
 ] as const;
 
 // Mock all API endpoints so tabs render without a live backend
@@ -30,6 +31,17 @@ async function mockAllApis(page: import('@playwright/test').Page) {
         git_hash: 'test',
         ooda_status: 'idle',
         uptime_secs: 0,
+      }),
+    }),
+  );
+  await page.route('**/api/status/snapshot', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        data: { schema_version: 1, generated_at: '2026-07-03T00:00:00Z' },
+        rendered: 'SIMARD STATUS  ·  2026-07-03T00:00:00Z\n\nDAEMON / UPTIME\n',
+        generated_at: '2026-07-03T00:00:00Z',
       }),
     }),
   );

--- a/tests/status_render_contract.rs
+++ b/tests/status_render_contract.rs
@@ -1,0 +1,293 @@
+//! Content-pin test for the `simard status` terminal renderer (issue #2528).
+//!
+//! Pins the operator-approved layout in `docs/howto/simard-status.md`: every
+//! section header and label the dashboard and TUI mirror, and the "no silent
+//! zeros" rule — an absent section renders `unavailable`/`absent`, never a
+//! fabricated `0`.
+
+use simard::status::render::{self, SECTION_HEADERS};
+use simard::status::{
+    CognitiveHealth, CompletedWork, CopilotTurn, Daemon, DiskUsage, EdgeCounts, GoalBoard,
+    GoalItem, Gym, LedgerWindow, LlmUsage, MemoryBrain, NodeCounts, PrItem, Reconciliation,
+    RepoPrs, Resources, SectionEnvelope, SelfImprovement, StatusSnapshot, TelemetrySignals,
+    WorkItem,
+};
+
+fn populated() -> StatusSnapshot {
+    let mut snap = StatusSnapshot::empty();
+    snap.generated_at = "2026-07-03T03:55:05Z".into();
+
+    snap.daemon = SectionEnvelope::live(
+        Daemon {
+            state: "active (running)".into(),
+            version: "0.24.0".into(),
+            main_pid: Some(48291),
+            deployed_commit: Some("e5764c6d".into()),
+            instance_uptime: Some("2h 14m 33s".into()),
+            n_restarts: Some(0),
+            running_since: Some("2026-07-03T01:40:31Z".into()),
+        },
+        None,
+    );
+    snap.resources = SectionEnvelope::live(
+        Resources {
+            cpu_pct: Some(3.2),
+            rss_bytes: Some(184 * 1024 * 1024),
+            cgroup_mem_peak_bytes: Some(402 * 1024 * 1024),
+            load_1: Some(0.41),
+            load_5: Some(0.55),
+            load_15: Some(0.60),
+            sys_mem_used_bytes: Some(6 * 1024 * 1024 * 1024),
+            sys_mem_total_bytes: Some(16 * 1024 * 1024 * 1024),
+            sys_mem_avail_bytes: Some(9 * 1024 * 1024 * 1024),
+            disk_home: Some(DiskUsage {
+                free_bytes: 118 * 1024 * 1024 * 1024,
+                total_bytes: 256 * 1024 * 1024 * 1024,
+            }),
+            disk_tmp: Some(DiskUsage {
+                free_bytes: 14 * 1024 * 1024 * 1024,
+                total_bytes: 16 * 1024 * 1024 * 1024,
+            }),
+            live_engineers: Some(2),
+        },
+        None,
+    );
+    snap.llm = SectionEnvelope::live(
+        LlmUsage {
+            copilot_turn: Some(CopilotTurn {
+                tokens_in: 4120,
+                tokens_cached: 1900,
+                tokens_out: 880,
+                ai_credits: 12,
+            }),
+            ledger_today: Some(LedgerWindow {
+                cost_usd: 1.87,
+                tokens_in: 412000,
+                tokens_out: 88000,
+            }),
+            ledger_7d: Some(LedgerWindow {
+                cost_usd: 11.42,
+                tokens_in: 2_740_000,
+                tokens_out: 610_000,
+            }),
+            ledger_all_time: Some(LedgerWindow {
+                cost_usd: 208.91,
+                tokens_in: 51_300_000,
+                tokens_out: 9_900_000,
+            }),
+            daily_budget_usd: Some(25.0),
+            reconciliation: Some(Reconciliation {
+                ledger_usd: 1.87,
+                credits: 940,
+                delta_flag: "ok".into(),
+            }),
+        },
+        None,
+    );
+    snap.memory = SectionEnvelope::live(
+        MemoryBrain {
+            store_path: "/home/azureuser/.simard/cognitive".into(),
+            store_size_bytes: Some(38 * 1024 * 1024),
+            backend: "amplihack-memory-lib".into(),
+            nodes_total: Some(1842),
+            nodes: NodeCounts {
+                episodic: Some(1204),
+                semantic: Some(380),
+                prospective: Some(44),
+                working: Some(12),
+                procedural: Some(190),
+                sensory: Some(12),
+            },
+            edges: EdgeCounts {
+                derives_from: Some(512),
+                similar_to: Some(233),
+                supersedes: Some(61),
+            },
+            cognitive_processes: CognitiveHealth {
+                distillation: Some("OK".into()),
+                consolidation: Some("OK".into()),
+                introspection: Some("OK".into()),
+            },
+            brains_llm_backed: Some("3/3".into()),
+            brain_fallbacks: Some(0),
+            decide_ladder_exhausted: Some(0),
+        },
+        None,
+    );
+    snap.gym = SectionEnvelope::live(
+        Gym {
+            skip_gym: false,
+            configured_scenarios: Some(7),
+            self_eval_state: "idle".into(),
+        },
+        None,
+    );
+    snap.goals = SectionEnvelope::live(
+        GoalBoard {
+            active: vec![GoalItem {
+                short_id: "goal-2f9c".into(),
+                priority: "p0".into(),
+                status: "in-progress".into(),
+                summary: "Rationalize telemetry onto OpenTelemetry".into(),
+            }],
+        },
+        None,
+    );
+    snap.workstreams = SectionEnvelope::live(
+        simard::status::Workstreams {
+            operator_recipes: vec![WorkItem {
+                label: "ooda-cycle".into(),
+                status: "running — decide phase, cycle 47".into(),
+            }],
+            engineer_workstreams: vec![WorkItem {
+                label: "eng-alpha (goal-2f9c)".into(),
+                status: "running — 0h4m, editing src/telemetry/".into(),
+            }],
+        },
+        None,
+    );
+    snap.completed = SectionEnvelope::live(
+        CompletedWork {
+            repos: vec![RepoPrs {
+                repo: "rysweet/Simard".into(),
+                prs: vec![PrItem {
+                    number: 2526,
+                    summary: "char-boundary-safe truncation".into(),
+                    status: "merged".into(),
+                }],
+            }],
+        },
+        None,
+    );
+    snap.self_improvement = SectionEnvelope::live(
+        SelfImprovement {
+            merged: vec![PrItem {
+                number: 2523,
+                summary: "char-boundary-safe truncation".into(),
+                status: "merged".into(),
+            }],
+            running: vec![WorkItem {
+                label: "self-quality-audit".into(),
+                status: "auditing exception handling".into(),
+            }],
+            pending: vec![],
+        },
+        None,
+    );
+    snap.telemetry = SectionEnvelope::live(
+        TelemetrySignals {
+            window: "last 1h".into(),
+            distill_fail_pct: Some(0.0),
+            restart_churn: Some(0),
+            gym_skipped: false,
+            budget_flag: "OK".into(),
+            parse_fix_holding: Some(true),
+            anomalies: vec![],
+        },
+        None,
+    );
+    snap
+}
+
+#[test]
+fn renders_title_and_every_section_header() {
+    let out = render::to_terminal(&populated());
+    assert!(out.contains("SIMARD STATUS"), "missing title:\n{out}");
+    for header in SECTION_HEADERS {
+        assert!(
+            out.contains(header),
+            "renderer missing section '{header}':\n{out}"
+        );
+    }
+}
+
+#[test]
+fn renders_operator_approved_labels_and_values() {
+    let out = render::to_terminal(&populated());
+    // A representative label from every section — these are the pinned labels
+    // the dashboard/TUI mirror.
+    for needle in [
+        "state",
+        "NRestarts",
+        "main PID",
+        "load avg",
+        "system mem",
+        "live engineers",
+        "copilot turn",
+        "ledger today",
+        "daily budget",
+        "reconciliation",
+        "nodes",
+        "edges",
+        "cognitive",
+        "brains",
+        "SIMARD_SKIP_GYM",
+        "scenarios",
+        "recipe",
+        "engineer",
+        "merged",
+        "running",
+        "pending",
+        "parse-fix holding",
+        "restart churn",
+        "gym skipped",
+        "budget",
+        "anomalies",
+    ] {
+        assert!(
+            out.contains(needle),
+            "renderer missing label '{needle}':\n{out}"
+        );
+    }
+    // Real values render.
+    assert!(out.contains("48291"), "main PID value missing");
+    assert!(out.contains("goal-2f9c"), "goal short id missing");
+    assert!(out.contains("#2526"), "completed PR number missing");
+    assert!(out.contains("rysweet/Simard"), "completed repo missing");
+}
+
+#[test]
+fn absent_sections_render_unavailable_not_zero() {
+    // A fully-empty snapshot: every section absent.
+    let out = render::to_terminal(&StatusSnapshot::empty());
+
+    // Headers always render so the operator sees the full frame.
+    for header in SECTION_HEADERS {
+        assert!(
+            out.contains(header),
+            "absent frame missing header '{header}'"
+        );
+    }
+    // But no section fabricates data: the detail labels of absent sections must
+    // NOT appear, and an absence marker must.
+    assert!(
+        out.contains("unavailable"),
+        "absent sections must be marked:\n{out}"
+    );
+    assert!(
+        !out.contains("NRestarts"),
+        "absent daemon must not render its NRestarts detail line:\n{out}"
+    );
+    assert!(
+        !out.contains("ledger today"),
+        "absent llm must not render a fabricated ledger:\n{out}"
+    );
+}
+
+#[test]
+fn stale_section_is_marked_stale() {
+    let mut snap = StatusSnapshot::empty();
+    snap.daemon = SectionEnvelope::stale(
+        Daemon {
+            state: "active (running)".into(),
+            version: "0.24.0".into(),
+            ..Default::default()
+        },
+        None,
+    );
+    let out = render::to_terminal(&snap);
+    assert!(
+        out.contains("stale"),
+        "a stale section must carry a stale marker:\n{out}"
+    );
+}

--- a/tests/status_snapshot.rs
+++ b/tests/status_snapshot.rs
@@ -1,0 +1,267 @@
+//! Tests for the unified `StatusSnapshot` type model, JSON contract, and the
+//! process-agnostic `assemble` provider (issue #2528).
+//!
+//! Pins `docs/reference/status-snapshot-api.md`: the section envelope with
+//! availability/freshness, the "no silent zeros" rule (a missing count is
+//! `absent`, never `0`), the additive JSON schema, and that `assemble` never
+//! panics and reads only durable sources under an explicit state root.
+
+use serial_test::serial;
+
+use simard::status::{
+    self, Availability, Daemon, Freshness, GoalBoard, GoalItem, LedgerWindow, LlmUsage,
+    SectionEnvelope, StatusSnapshot, provider::AssembleOptions,
+};
+use simard::telemetry::names;
+use simard::telemetry::snapshot::{self, MetricsSnapshot};
+
+// ── env guard (env is process-global; serialize env-touching tests) ──────────
+
+struct EnvGuard {
+    key: &'static str,
+    prev: Option<std::ffi::OsString>,
+}
+
+impl EnvGuard {
+    fn set(key: &'static str, value: &str) -> Self {
+        let prev = std::env::var_os(key);
+        // SAFETY: env-touching tests here are `#[serial(status_env)]`.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, prev }
+    }
+    fn unset(key: &'static str) -> Self {
+        let prev = std::env::var_os(key);
+        // SAFETY: env-touching tests here are `#[serial(status_env)]`.
+        unsafe { std::env::remove_var(key) };
+        Self { key, prev }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        // SAFETY: serialized via `#[serial(status_env)]`.
+        unsafe {
+            match self.prev.take() {
+                Some(v) => std::env::set_var(self.key, v),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
+/// Assemble options pinned to a temp state root and a deliberately-nonexistent
+/// unit, so the test never reads the real `simard.service` or `~/.simard`.
+fn hermetic_opts(state_root: &std::path::Path) -> AssembleOptions {
+    let mut opts = AssembleOptions::with_state_root(state_root.to_path_buf());
+    opts.service_unit = "simard-status-test-nonexistent.service".to_string();
+    opts
+}
+
+// ── envelope + type model ────────────────────────────────────────────────────
+
+#[test]
+fn envelope_default_is_unavailable_absent_with_no_data() {
+    let env: SectionEnvelope<Daemon> = SectionEnvelope::default();
+    assert_eq!(env.availability, Availability::Unavailable);
+    assert_eq!(env.freshness, Freshness::Absent);
+    assert!(env.data.is_none());
+    assert!(!env.is_present());
+}
+
+#[test]
+fn envelope_constructors_set_expected_state() {
+    let live = SectionEnvelope::live(Daemon::default(), Some("2026-07-03T00:00:00Z".into()));
+    assert_eq!(live.availability, Availability::Ok);
+    assert_eq!(live.freshness, Freshness::Live);
+    assert!(live.is_present());
+
+    let absent: SectionEnvelope<Daemon> = SectionEnvelope::absent("gh: not authenticated");
+    assert_eq!(absent.availability, Availability::Unavailable);
+    assert_eq!(absent.freshness, Freshness::Absent);
+    assert!(absent.data.is_none());
+    assert_eq!(absent.note.as_deref(), Some("gh: not authenticated"));
+}
+
+#[test]
+fn empty_snapshot_has_all_ten_sections_absent() {
+    let snap = StatusSnapshot::empty();
+    assert_eq!(snap.schema_version, status::SCHEMA_VERSION);
+    assert!(!snap.generated_at.is_empty());
+
+    // All ten operator sections default to absent — never fabricated zeros.
+    for present in [
+        snap.daemon.is_present(),
+        snap.resources.is_present(),
+        snap.llm.is_present(),
+        snap.memory.is_present(),
+        snap.gym.is_present(),
+        snap.goals.is_present(),
+        snap.workstreams.is_present(),
+        snap.completed.is_present(),
+        snap.self_improvement.is_present(),
+        snap.telemetry.is_present(),
+    ] {
+        assert!(!present, "empty snapshot section should be absent");
+    }
+}
+
+// ── JSON contract ────────────────────────────────────────────────────────────
+
+#[test]
+fn json_round_trips_and_is_additive() {
+    let mut snap = StatusSnapshot::empty();
+    snap.daemon = SectionEnvelope::live(
+        Daemon {
+            state: "active (running)".into(),
+            version: "0.24.0".into(),
+            main_pid: Some(4242),
+            deployed_commit: Some("e5764c6d".into()),
+            instance_uptime: Some("2h14m".into()),
+            n_restarts: Some(0),
+            running_since: Some("2026-07-03T01:40:31Z".into()),
+        },
+        Some("2026-07-03T03:55:04Z".into()),
+    );
+    snap.goals = SectionEnvelope::live(
+        GoalBoard {
+            active: vec![GoalItem {
+                short_id: "goal-2f9c".into(),
+                priority: "p0".into(),
+                status: "in-progress".into(),
+                summary: "Rationalize telemetry".into(),
+            }],
+        },
+        None,
+    );
+
+    let json = status::json::to_string_pretty(&snap).expect("serialize");
+    assert!(json.contains("\"availability\": \"ok\""));
+    assert!(json.contains("\"freshness\": \"absent\"")); // the still-absent sections
+    assert!(json.contains("\"n_restarts\": 0"));
+
+    // Unknown fields are ignored; missing fields default (additive growth).
+    let grown = json.replace(
+        "\"schema_version\": 1",
+        "\"schema_version\": 1,\n  \"future_field\": {\"x\": 1}",
+    );
+    let parsed = status::json::from_str(&grown).expect("deserialize with unknown field");
+    assert_eq!(parsed, snap);
+}
+
+#[test]
+fn absent_section_serializes_as_unavailable_absent_not_zero() {
+    let snap = StatusSnapshot::empty();
+    let json = status::json::to_string(&snap).expect("serialize");
+    let value: serde_json::Value = serde_json::from_str(&json).expect("parse");
+
+    let daemon = &value["daemon"];
+    assert_eq!(daemon["availability"], "unavailable");
+    assert_eq!(daemon["freshness"], "absent");
+    // No fabricated data payload for an absent section.
+    assert!(daemon.get("data").is_none() || daemon["data"].is_null());
+}
+
+// ── assemble: never panics, all sections present, honest degradation ─────────
+
+#[test]
+#[serial(status_env)]
+fn assemble_on_empty_state_root_never_panics_and_degrades() {
+    let _skip = EnvGuard::unset("SIMARD_SKIP_GYM");
+    let dir = tempfile::tempdir().expect("tempdir");
+    let snap = status::assemble(&hermetic_opts(dir.path()));
+
+    // Structurally complete: generated + schema version set.
+    assert_eq!(snap.schema_version, status::SCHEMA_VERSION);
+    assert!(!snap.generated_at.is_empty());
+
+    // Heavy/unwired sources degrade honestly rather than inventing data.
+    assert!(!snap.daemon.is_present(), "bogus unit -> daemon absent");
+    assert!(
+        !snap.telemetry.is_present(),
+        "no snapshot file -> telemetry absent"
+    );
+    assert!(!snap.llm.is_present(), "no ledger -> llm absent");
+    assert!(snap.memory.note.is_some());
+    assert!(snap.completed.note.is_some());
+
+    // Gym is always answerable from the environment.
+    assert!(snap.gym.is_present());
+    assert_eq!(snap.gym.data.as_ref().map(|g| g.skip_gym), Some(false));
+}
+
+#[test]
+#[serial(status_env)]
+fn assemble_reflects_skip_gym_env() {
+    let _skip = EnvGuard::set("SIMARD_SKIP_GYM", "1");
+    let dir = tempfile::tempdir().expect("tempdir");
+    let snap = status::assemble(&hermetic_opts(dir.path()));
+
+    let gym = snap.gym.data.as_ref().expect("gym present");
+    assert!(gym.skip_gym, "SIMARD_SKIP_GYM=1 must surface as skip_gym");
+    let tele = snap.telemetry.data.as_ref();
+    // Even absent-snapshot telemetry still knows gym is skipped once wired; here
+    // the snapshot is absent so telemetry is absent — gym section is the pin.
+    assert!(tele.is_none());
+}
+
+#[test]
+#[serial(status_env)]
+fn assemble_derives_distill_fail_pct_from_metrics_snapshot() {
+    let _skip = EnvGuard::unset("SIMARD_SKIP_GYM");
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    // Fixture: 8 ok distill runs, 2 parse failures -> 20% fail.
+    let mut fixture = MetricsSnapshot::empty();
+    fixture
+        .counters
+        .push(simard::telemetry::snapshot::CounterSeries {
+            name: names::DISTILL_RUNS.into(),
+            attrs: vec![(names::ATTR_RESULT.into(), "ok".into())],
+            value: 8,
+        });
+    fixture
+        .counters
+        .push(simard::telemetry::snapshot::CounterSeries {
+            name: names::DISTILL_RUNS.into(),
+            attrs: vec![(names::ATTR_RESULT.into(), "parse_fail".into())],
+            value: 2,
+        });
+    let path = dir.path().join("telemetry").join("metrics_snapshot.json");
+    snapshot::write_atomic(&path, &fixture).expect("write fixture");
+
+    let snap = status::assemble(&hermetic_opts(dir.path()));
+    let tele = snap.telemetry.data.as_ref().expect("telemetry present");
+    let pct = tele.distill_fail_pct.expect("fail pct derived");
+    assert!((pct - 20.0).abs() < 1e-9, "expected 20% got {pct}");
+    assert_eq!(tele.parse_fix_holding, Some(false));
+
+    // A just-written snapshot is fresh.
+    assert_eq!(snap.telemetry.availability, Availability::Ok);
+    assert_eq!(snap.telemetry.freshness, Freshness::Live);
+}
+
+#[test]
+#[serial(status_env)]
+fn assemble_reads_cost_ledger_under_state_root() {
+    let _budget = EnvGuard::set("SIMARD_DAILY_BUDGET_USD", "25");
+    let dir = tempfile::tempdir().expect("tempdir");
+    let ledger = dir.path().join("costs").join("ledger.jsonl");
+    std::fs::create_dir_all(ledger.parent().unwrap()).unwrap();
+    let now = chrono::Utc::now().to_rfc3339();
+    let line = format!(
+        "{{\"timestamp\":\"{now}\",\"session_id\":\"s\",\"model\":\"gpt\",\"prompt_tokens_est\":1000,\"completion_tokens_est\":200,\"cost_usd_est\":1.5,\"context\":\"c\"}}"
+    );
+    std::fs::write(&ledger, format!("{line}\n{line}\n")).unwrap();
+
+    let snap = status::assemble(&hermetic_opts(dir.path()));
+    let llm: &LlmUsage = snap.llm.data.as_ref().expect("llm present");
+    let all: &LedgerWindow = llm.ledger_all_time.as_ref().expect("all-time window");
+    assert!(
+        (all.cost_usd - 3.0).abs() < 1e-9,
+        "cost sum was {}",
+        all.cost_usd
+    );
+    assert_eq!(all.tokens_in, 2000);
+    assert_eq!(all.tokens_out, 400);
+    assert_eq!(llm.daily_budget_usd, Some(25.0));
+}

--- a/tests/telemetry_facade.rs
+++ b/tests/telemetry_facade.rs
@@ -1,0 +1,318 @@
+//! Unit/integration tests for the unified telemetry facade (issue #2528).
+//!
+//! These pin the documented contract in `docs/reference/telemetry-metrics.md`:
+//! the `counter_add`/`gauge_set`/`histogram_record` facade, the bounded
+//! in-process registry (attribute normalization, per-key cardinality bound with
+//! `other` overflow), the `MetricsSnapshot` serde shape + accessors, and the
+//! degrade-safe atomic on-disk snapshot writer/reader.
+//!
+//! The registry is process-global, so every test that touches it is
+//! `#[serial(telemetry_registry)]` and calls `reset()` first.
+
+use serial_test::serial;
+
+use simard::telemetry;
+use simard::telemetry::names;
+use simard::telemetry::registry::{MAX_ATTR_VALUE_LEN, MAX_VALUES_PER_KEY};
+use simard::telemetry::snapshot::{self, MetricsSnapshot, SCHEMA_VERSION};
+
+// ── metric catalog ───────────────────────────────────────────────────────────
+
+#[test]
+fn metric_names_are_dotted_and_stable() {
+    // A representative slice of the catalog; these strings are a public
+    // contract other tooling (dashboards, alerts) keys off, so pin them.
+    assert_eq!(names::DISTILL_RUNS, "simard.distill.runs");
+    assert_eq!(names::DISTILL_FACTS, "simard.distill.facts");
+    assert_eq!(names::BRAIN_DECISION, "simard.brain.decision");
+    assert_eq!(
+        names::BRAIN_LADDER_EXHAUSTED,
+        "simard.brain.ladder_exhausted"
+    );
+    assert_eq!(names::ENGINEER_ACTIVE, "simard.engineer.active");
+    assert_eq!(
+        names::DAEMON_CYCLE_DURATION_SECONDS,
+        "simard.daemon.cycle_duration_seconds"
+    );
+    assert_eq!(names::MEMORY_NODES, "simard.memory.nodes");
+    assert_eq!(names::MEMORY_EDGES, "simard.memory.edges");
+    assert_eq!(names::LLM_TOKENS, "simard.llm.tokens");
+    assert_eq!(names::GOAL_ACTIVE, "simard.goal.active");
+
+    for name in [
+        names::DISTILL_RUNS,
+        names::BRAIN_DECISION,
+        names::ENGINEER_SPAWNED,
+        names::DAEMON_CYCLE,
+        names::MEMORY_NODES,
+        names::LLM_COST_USD,
+        names::GOAL_PROGRESS,
+    ] {
+        assert!(name.starts_with("simard."), "not dotted: {name}");
+    }
+}
+
+// ── facade behavior ──────────────────────────────────────────────────────────
+
+#[test]
+#[serial(telemetry_registry)]
+fn counter_add_accumulates_per_attribute_set() {
+    telemetry::reset();
+    telemetry::counter_add(names::DISTILL_RUNS, 1, &[(names::ATTR_RESULT, "ok")]);
+    telemetry::counter_add(names::DISTILL_RUNS, 2, &[(names::ATTR_RESULT, "ok")]);
+    telemetry::counter_add(
+        names::DISTILL_RUNS,
+        5,
+        &[(names::ATTR_RESULT, "parse_fail")],
+    );
+
+    let snap = telemetry::capture();
+    assert_eq!(
+        snap.counter(names::DISTILL_RUNS, &[(names::ATTR_RESULT, "ok")]),
+        Some(3)
+    );
+    assert_eq!(
+        snap.counter(names::DISTILL_RUNS, &[(names::ATTR_RESULT, "parse_fail")]),
+        Some(5)
+    );
+    // Distinct attribute values are distinct series.
+    assert_eq!(
+        snap.counters
+            .iter()
+            .filter(|c| c.name == names::DISTILL_RUNS)
+            .count(),
+        2
+    );
+}
+
+#[test]
+#[serial(telemetry_registry)]
+fn gauge_set_is_last_write_wins() {
+    telemetry::reset();
+    telemetry::gauge_set(names::ENGINEER_ACTIVE, 3, &[]);
+    telemetry::gauge_set(names::ENGINEER_ACTIVE, 1, &[]);
+    telemetry::gauge_set(names::ENGINEER_ACTIVE, 2, &[]);
+
+    let snap = telemetry::capture();
+    assert_eq!(snap.gauge(names::ENGINEER_ACTIVE, &[]), Some(2));
+}
+
+#[test]
+#[serial(telemetry_registry)]
+fn histogram_record_tracks_count_sum_and_buckets() {
+    telemetry::reset();
+    for v in [0.4_f64, 1.5, 7.0, 45.0] {
+        telemetry::histogram_record(names::DAEMON_CYCLE_DURATION_SECONDS, v, &[]);
+    }
+
+    let snap = telemetry::capture();
+    let h = snap
+        .histogram(names::DAEMON_CYCLE_DURATION_SECONDS, &[])
+        .expect("histogram series present");
+    assert_eq!(h.count, 4);
+    assert!((h.sum - 53.9).abs() < 1e-9, "sum was {}", h.sum);
+    // Cumulative buckets are monotonic and the last bucket covers every
+    // observation at or below its boundary.
+    let mut prev = 0;
+    for b in &h.buckets {
+        assert!(b.count >= prev, "buckets must be cumulative/monotonic");
+        prev = b.count;
+    }
+    assert!(prev <= h.count);
+}
+
+#[test]
+#[serial(telemetry_registry)]
+fn attribute_order_does_not_change_the_series() {
+    telemetry::reset();
+    telemetry::counter_add(
+        names::LLM_TOKENS,
+        10,
+        &[(names::ATTR_DIR, "in"), (names::ATTR_CACHED, "false")],
+    );
+    telemetry::counter_add(
+        names::LLM_TOKENS,
+        5,
+        &[(names::ATTR_CACHED, "false"), (names::ATTR_DIR, "in")],
+    );
+
+    let snap = telemetry::capture();
+    // Same key regardless of the order the attributes were supplied.
+    assert_eq!(
+        snap.counter(
+            names::LLM_TOKENS,
+            &[(names::ATTR_DIR, "in"), (names::ATTR_CACHED, "false")]
+        ),
+        Some(15)
+    );
+    assert_eq!(
+        snap.counters
+            .iter()
+            .filter(|c| c.name == names::LLM_TOKENS)
+            .count(),
+        1
+    );
+}
+
+// ── bounds: cardinality, length, control chars ───────────────────────────────
+
+#[test]
+#[serial(telemetry_registry)]
+fn unexpected_attr_values_fold_into_other_and_bump_overflow() {
+    telemetry::reset();
+    let metric = "simard.test.cardinality";
+    let extra = 4;
+    let total = MAX_VALUES_PER_KEY + extra;
+    for i in 0..total {
+        telemetry::counter_add(metric, 1, &[("k", &format!("v{i}"))]);
+    }
+
+    let snap = telemetry::capture();
+    // The overflow values all collapse into a single `other` series.
+    assert_eq!(
+        snap.counter(metric, &[("k", names::OTHER_BUCKET)]),
+        Some(extra as u64),
+        "extra distinct values should accumulate in the `other` bucket"
+    );
+    // Distinct retained series is capped: MAX_VALUES_PER_KEY real + one `other`.
+    assert_eq!(
+        snap.counters.iter().filter(|c| c.name == metric).count(),
+        MAX_VALUES_PER_KEY + 1
+    );
+    assert!(
+        telemetry::overflow_count() >= extra as u64,
+        "overflow counter should record folded values"
+    );
+    assert!(snap.overflow_series >= extra as u64);
+}
+
+#[test]
+#[serial(telemetry_registry)]
+fn attribute_values_are_length_capped() {
+    telemetry::reset();
+    let long = "x".repeat(MAX_ATTR_VALUE_LEN * 3);
+    telemetry::counter_add("simard.test.len", 1, &[("k", &long)]);
+
+    let snap = telemetry::capture();
+    let series = snap
+        .counters
+        .iter()
+        .find(|c| c.name == "simard.test.len")
+        .expect("series present");
+    let (_, value) = &series.attrs[0];
+    assert_eq!(
+        value.chars().count(),
+        MAX_ATTR_VALUE_LEN,
+        "over-long attribute value must be truncated to the cap"
+    );
+}
+
+#[test]
+#[serial(telemetry_registry)]
+fn control_characters_are_stripped_from_attributes() {
+    telemetry::reset();
+    telemetry::counter_add("simard.test.ctrl", 1, &[("k", "a\nb\tc")]);
+
+    let snap = telemetry::capture();
+    let series = snap
+        .counters
+        .iter()
+        .find(|c| c.name == "simard.test.ctrl")
+        .expect("series present");
+    let (_, value) = &series.attrs[0];
+    assert!(
+        !value.chars().any(|c| c.is_control()),
+        "control characters must not survive normalization: {value:?}"
+    );
+    assert_eq!(value, "a b c");
+}
+
+// ── capture reflects the live registry ───────────────────────────────────────
+
+#[test]
+#[serial(telemetry_registry)]
+fn capture_reflects_all_instrument_kinds() {
+    telemetry::reset();
+    telemetry::counter_add(names::BRAIN_ESCALATIONS, 2, &[]);
+    telemetry::gauge_set(names::GOAL_ACTIVE, 7, &[]);
+    telemetry::histogram_record(names::DAEMON_CYCLE_DURATION_SECONDS, 3.0, &[]);
+
+    let snap = telemetry::capture();
+    assert_eq!(snap.schema_version, SCHEMA_VERSION);
+    assert!(!snap.captured_at.is_empty());
+    assert_eq!(snap.counter(names::BRAIN_ESCALATIONS, &[]), Some(2));
+    assert_eq!(snap.gauge(names::GOAL_ACTIVE, &[]), Some(7));
+    assert_eq!(
+        snap.histogram(names::DAEMON_CYCLE_DURATION_SECONDS, &[])
+            .map(|h| h.count),
+        Some(1)
+    );
+}
+
+// ── snapshot serde + on-disk IO ──────────────────────────────────────────────
+
+#[test]
+#[serial(telemetry_registry)]
+fn snapshot_json_round_trips_and_preserves_schema_version() {
+    telemetry::reset();
+    telemetry::counter_add(names::DISTILL_FACTS, 9, &[]);
+    let original = telemetry::capture();
+
+    let json = serde_json::to_string(&original).expect("serialize");
+    assert!(json.contains("\"schema_version\""));
+    let parsed: MetricsSnapshot = serde_json::from_str(&json).expect("deserialize");
+
+    assert_eq!(parsed.schema_version, SCHEMA_VERSION);
+    assert_eq!(parsed.counter(names::DISTILL_FACTS, &[]), Some(9));
+    assert_eq!(parsed, original);
+}
+
+#[test]
+#[serial(telemetry_registry)]
+fn write_atomic_then_read_round_trips() {
+    telemetry::reset();
+    telemetry::counter_add(names::DAEMON_CYCLE, 4, &[]);
+    let snap = telemetry::capture();
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("telemetry").join("metrics_snapshot.json");
+    snapshot::write_atomic(&path, &snap).expect("write");
+
+    let read_back = snapshot::read(&path).expect("read");
+    assert_eq!(read_back.counter(names::DAEMON_CYCLE, &[]), Some(4));
+    assert_eq!(read_back, snap);
+}
+
+#[test]
+fn read_missing_snapshot_is_none_not_panic() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("does-not-exist.json");
+    assert!(snapshot::read(&path).is_none());
+}
+
+#[test]
+fn read_corrupt_snapshot_is_none_not_panic() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("corrupt.json");
+    std::fs::write(&path, b"{ this is not valid json ]]").expect("write");
+    assert!(snapshot::read(&path).is_none());
+}
+
+#[cfg(unix)]
+#[test]
+#[serial(telemetry_registry)]
+fn snapshot_file_is_written_private_0600() {
+    use std::os::unix::fs::PermissionsExt;
+
+    telemetry::reset();
+    let snap = telemetry::capture();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("telemetry").join("metrics_snapshot.json");
+    snapshot::write_atomic(&path, &snap).expect("write");
+
+    let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+    assert_eq!(
+        mode, 0o600,
+        "snapshot must not be world-readable, got {mode:o}"
+    );
+}


### PR DESCRIPTION
## Summary

Rationalizes Simard's telemetry onto **OpenTelemetry** and builds **one unified operational report** surfaced three ways — a **CLI command**, a **dashboard page**, and a **TUI tab** — all rendering the same typed `StatusSnapshot`. Single coherent workstream: a shared telemetry foundation feeds three thin surfaces.

**Additive & non-breaking.** The running daemon keeps working; existing journald/text logging, dashboard tabs, and TUI tabs are intact; **OTLP export stays OFF by default** (endpoint-gated). No redeploy.

Closes #2528.

## 1. Unified telemetry layer (`src/telemetry/`)
- **Typed facade** — `counter_add` / `gauge_set` / `histogram_record` + a single-sourced `simard.<area>.<name>` metric catalog (`names.rs`). Emitters reference constants, not string literals.
- **Bounded in-process registry** (`registry.rs`) — thread-safe atomic registry, the always-on aggregator read **in-process** by the status snapshot with **no external collector**. Cardinality-bounded (`other` overflow), length-capped, control-char-stripped.
- **OTel `SdkMeterProvider`** installed in `init_tracing()` alongside the tracer; an OTLP `PeriodicReader` is attached **only when `OTEL_EXPORTER_OTLP_ENDPOINT` is set** (same gate as traces). The facade **dual-writes** the registry + OTel instruments.
- **Degrade-safe snapshot** — the daemon atomically (`0600`) flushes `~/.simard/telemetry/metrics_snapshot.json` once per OODA cycle so the out-of-process CLI/TUI read live daemon metrics. Readers tolerate missing/corrupt files (never panic).

## 2. Signal migration (structure added, readability kept)
Key operational signals move from ad-hoc `println!`/`eprintln!` to the facade **alongside** the human log line:
- `distill.runs{ok|parse_fail}` / `.facts` / `.procedures` / `.episodes_marked`
- `brain.decision{phase,result}` / `.escalations` / `.ladder_exhausted`
- `engineer.spawned` / `.exited{outcome}` / `.active` (gauge)
- `daemon.cycle` + `.cycle_duration_seconds` (histogram); `memory.nodes{type}` / `.edges{type}` gauges; `goal.active` gauge — emitted from the OODA cycle
- `llm.tokens{dir,cached}` bridged from `cost_tracking` (ledger format unchanged)

The four bespoke stores (`self_metrics`, `cost_tracking`, `cognitive_memory/metrics`, gym/dashboard metrics) are **reconciled, not ripped out** — they keep working; the unified layer is additive.

## 3. Status snapshot provider (`src/status/`)
One typed `StatusSnapshot`; every section wrapped with **availability + freshness** so a missing count renders `absent`, never a silent `0`. **Process-agnostic** assembly from durable sources (metrics snapshot, cost ledger, `/proc`, `systemctl`) — **never `journalctl | grep`**. Rich terminal renderer + `--json`.

## 4. Three surfaces
- **CLI:** `simard status [--json]`
- **Dashboard:** Status tab + `GET /api/status/snapshot`
- **TUI:** Status tab

All three render the same snapshot via the shared `render::to_terminal`.

## Tests & docs
- New: `tests/telemetry_facade.rs`, `tests/status_snapshot.rs`, `tests/status_render_contract.rs` (content-pin). Dashboard tab cross-checks updated. **Full lib suite: 6522 passed / 0 failed.**
- Docs: telemetry-metrics reference, StatusSnapshot API reference, `simard status` how-to, concept doc; `mkdocs.yml` nav updated. Docs are mechanism-honest and mark deferred sections (goal board / workstreams / completed / self-improvement render `unavailable` from the process-agnostic CLI; the goal board is live in the daemon-hosted dashboard/TUI).

## Verification
- `cargo fmt --all -- --check` ✅
- `cargo clippy --all-targets --all-features --locked -- -D warnings` ✅
- `cargo test --lib` (6522 passed) + new integration tests ✅
- `simard status` / `--json` / `--help` run end-to-end against a hermetic state root ✅ (MeterProvider init + shutdown confirmed)

## Notes / follow-ups (reserved catalog entries)
- `daemon.restart` — status sources the authoritative churn from systemd `NRestarts` (an in-process counter resets each restart).
- `llm.cost_usd` / `.credits` — status reads $ + AI-credits from the cost ledger (integral counters would lose fractional cents).
- `goal.completed` / `.progress` and gh-backed COMPLETED/SELF-IMPROVEMENT — deferred; sections render honest `unavailable`.