### PR TITLE
feat(cognitive-threads): Mind scheduler + OODA/maintenance/engineer-log-analysis threads (#2419)

### DIFF
--- a/docs/howto/add-a-new-cognitive-thread.md
+++ b/docs/howto/add-a-new-cognitive-thread.md
@@ -13,6 +13,15 @@ related:
 
 # Add a new cognitive thread
 
+!!! note "Status — planned (design for #2419, not yet shipped)"
+    This guide describes how to add a thread to the cognitive-thread scheduler
+    (the **Mind**) as designed in issue #2419. The `CognitiveThread` trait, the
+    `Mind`, and the `src/cognitive_threads/` module **do not exist yet** — they
+    land with the scheduler. The signatures, derives, and reuse contracts below
+    come from the
+    [design reference](../reference/cognitive-thread-scheduling.md); follow this
+    guide once that module is in the tree.
+
 Simard runs many background mental processes through one scheduler, the
 **Mind**. Adding a new one — a background-thought pass, a memory-consolidation
 step, a new maintenance chore — means implementing the `CognitiveThread` trait

--- a/docs/howto/add-a-new-cognitive-thread.md
+++ b/docs/howto/add-a-new-cognitive-thread.md
@@ -13,14 +13,14 @@ related:
 
 # Add a new cognitive thread
 
-!!! note "Status — planned (design for #2419, not yet shipped)"
-    This guide describes how to add a thread to the cognitive-thread scheduler
-    (the **Mind**) as designed in issue #2419. The `CognitiveThread` trait, the
-    `Mind`, and the `src/cognitive_threads/` module **do not exist yet** — they
-    land with the scheduler. The signatures, derives, and reuse contracts below
-    come from the
-    [design reference](../reference/cognitive-thread-scheduling.md); follow this
-    guide once that module is in the tree.
+!!! note "Status — shipped (#2419)"
+    The `CognitiveThread` trait, the `Mind`, and the `src/cognitive_threads/`
+    module **have shipped**, so this guide is directly actionable. The scheduler
+    is additive and off by default in the live daemon (enable it with
+    `SIMARD_COGNITIVE_THREADS_ENABLED`); see
+    [Configure and monitor cognitive-thread scheduling](./configure-cognitive-thread-scheduling.md).
+    The signatures, derives, and reuse contracts below match the
+    [design reference](../reference/cognitive-thread-scheduling.md).
 
 Simard runs many background mental processes through one scheduler, the
 **Mind**. Adding a new one — a background-thought pass, a memory-consolidation

--- a/docs/howto/add-a-new-cognitive-thread.md
+++ b/docs/howto/add-a-new-cognitive-thread.md
@@ -1,0 +1,301 @@
+---
+title: Add a new cognitive thread
+description: Developer guide for adding a new scheduled mental process to Simard's daemon (#2419) — implementing the CognitiveThread trait, choosing a SchedulePolicy and Priority, reading config from the environment, registering with the Mind, emitting telemetry through the single facade seam, obeying the safety rules (no println, least-authority ThreadContext, dry-run, protected-path allow-list, injected GhClient), and unit-testing due-computation, failure isolation, and side-effects with no sleeps or network.
+last_updated: 2026-07-03
+review_schedule: as-needed
+owner: simard
+doc_type: howto
+related:
+  - ../reference/cognitive-thread-scheduling.md
+  - ./configure-cognitive-thread-scheduling.md
+  - ./configure-self-quality-audit.md
+---
+
+# Add a new cognitive thread
+
+Simard runs many background mental processes through one scheduler, the
+**Mind**. Adding a new one — a background-thought pass, a memory-consolidation
+step, a new maintenance chore — means implementing the `CognitiveThread` trait
+and registering it. You do **not** touch the daemon loop, the OODA path, or the
+engineer action-slot scheduler (`src/ooda_scheduler/`, which is unrelated).
+
+This guide walks the full path from a new struct to a registered, observable,
+tested thread. For the authoritative surface (exact signatures, derives,
+metric names, upstream reuse contracts) see
+[Cognitive-thread scheduling](../reference/cognitive-thread-scheduling.md). To
+tune and observe threads as an operator, see
+[Configure and monitor cognitive-thread scheduling](./configure-cognitive-thread-scheduling.md).
+
+## When to use this
+
+Use this guide when you want to add a scheduled process that runs on the daemon
+alongside OODA — anything from the vision list (background thought, memory
+consolidation, sensory processing, long-term planning) or a new housekeeping
+chore. If instead you want to change *engineer* concurrency, that is the AIMD
+action-slot scaler (`SIMARD_MAX_CONCURRENT_ACTIONS`), **not** a cognitive
+thread — leave `src/ooda_scheduler/` alone.
+
+## Where the code goes
+
+```
+src/cognitive_threads/
+  thread.rs        # the trait + supporting types (do not change the trait)
+  schedule.rs      # pure is_due / next_run / backoff (reuse; do not fork)
+  mind.rs          # the scheduler (register with it; do not modify to add a thread)
+  telemetry.rs     # the single metric/span helper (emit through this only)
+  threads/
+    ooda.rs                    # primary thread (reference example)
+    maintenance.rs             # exemplar 1 (safe cleanup)
+    engineer_log_analysis.rs   # exemplar 2 (improvement finder)
+    your_thread.rs             # <-- add your module here
+```
+
+Add `mod your_thread;` and a `pub use` in `src/cognitive_threads/threads/mod.rs`,
+and register the thread in the daemon setup block (see
+[Register with the Mind](#step-4-register-with-the-mind)). Nothing else in the module
+needs to change to host a new thread.
+
+!!! warning "Naming rule"
+    No type or module may contain the word **`Bridge`** (operator preference).
+    Stay within Scheduler / Mind / CognitiveThread / Faculty / Context / Client.
+
+## Step 1 — Implement the trait
+
+The trait is small and **object-safe** (the Mind stores `Box<dyn
+CognitiveThread>`). Threads tick **synchronously**; async work runs inside the
+tick via `ctx.runtime.block_on(...)`, exactly as the OODA cycle already does.
+
+```rust
+use crate::cognitive_threads::{
+    CognitiveThread, Priority, SchedulePolicy, ThreadContext, ThreadHealth,
+    ThreadKind, ThreadOutcome,
+};
+use std::time::{Duration, Instant};
+
+pub struct BackgroundThoughtThread {
+    interval_secs: u64,
+    // in-memory bookkeeping the Mind reads back via health():
+    last_run_epoch: Option<u64>,
+    consecutive_errors: u32,
+}
+
+impl CognitiveThread for BackgroundThoughtThread {
+    fn id(&self) -> &str { "background_thought" }          // stable snake_case telemetry key
+    fn kind(&self) -> ThreadKind { ThreadKind::BackgroundThought }
+    fn policy(&self) -> SchedulePolicy {
+        SchedulePolicy::Interval(Duration::from_secs(self.interval_secs))
+    }
+    fn priority(&self) -> Priority { Priority::Low }        // never Critical — that is OODA only
+    fn enabled(&self) -> bool { self.interval_secs > 0 }    // env-gated on/off
+
+    fn tick(&mut self, ctx: &mut ThreadContext<'_>) -> ThreadOutcome {
+        let started = Instant::now();
+
+        // Do the work. Best-effort: prefer returning ThreadOutcome::failed(..)
+        // over panicking (the Mind catches panics as a backstop, but a clean
+        // Err keeps telemetry meaningful).
+        // Async I/O? run it on the shared runtime:
+        //   let result = ctx.runtime.block_on(async { /* ... */ });
+
+        self.last_run_epoch = Some(ctx.now_epoch);
+        ThreadOutcome::ok("thought pass complete", started.elapsed())
+            .with_detail(serde_json::json!({ "considered": 3 }))
+    }
+
+    fn health(&self) -> ThreadHealth {
+        // Report what the thread itself knows. The Mind overlays the
+        // authoritative scheduling bookkeeping it owns (next_run, backoff)
+        // from its private RunBudget when it builds the dashboard snapshot.
+        ThreadHealth {
+            id: self.id().to_string(),
+            enabled: self.enabled(),
+            last_run_epoch: self.last_run_epoch,
+            next_run_epoch: None,       // filled by the Mind
+            last_success: Some(true),
+            consecutive_errors: self.consecutive_errors,
+            backoff_until_epoch: None,  // filled by the Mind
+        }
+    }
+}
+```
+
+Key points:
+
+- **`id()` is a compile-time constant** used verbatim as the telemetry key
+  (`simard.thread.background_thought.*`). Never derive it from untrusted input —
+  that would inject metric cardinality.
+- **`priority()` is never `Critical`.** `Critical` is reserved for OODA, which is
+  budget-exempt and never backed off. Background work is `Low` (or `Normal`).
+- **`tick()` is best-effort and self-contained.** Return `ThreadOutcome::failed`
+  on a handled error; the Mind wraps every tick in `catch_unwind` and applies
+  capped exponential backoff, so a bad tick can never crash the daemon or a
+  sibling.
+
+## Step 2 — Choose a scheduling policy
+
+```rust
+pub enum SchedulePolicy {
+    Interval(Duration),        // fixed cadence: next_run = last_run + interval
+    OnDemand,                  // only when explicitly requested; never auto-due
+    EventDriven,               // due when an external predicate/flag fires
+    Adaptive { min, max, current }, // reserved; behaves as Interval(current) for now
+}
+```
+
+- Use **`Interval`** for anything on a clock (almost all threads).
+- Use **`OnDemand`** / **`EventDriven`** only for internally-triggered work — the
+  trigger must come from the in-process operator/event channel, never from
+  attacker-influenceable external input.
+- **`Adaptive`** is representable but conservatively degrades to
+  `Interval(current)` in this build; don't rely on it changing cadence yet.
+
+Due-ness is computed by pure, injected-clock functions in `schedule.rs`
+(`is_due`, `next_run_epoch`, `backoff_until_epoch`) — reuse them; do not
+reimplement timing.
+
+## Step 3 — Read config from the environment
+
+Follow the sibling pattern: a `Config` struct with safe defaults and a
+`from_env()` constructor. Interval knobs are named `SIMARD_<AREA>_INTERVAL_SECS`
+and clamped to a minimum floor (reject `0`/negative so the thread can't become
+due every tick — unless `0` intentionally means "disabled" for your thread).
+
+```rust
+pub struct BackgroundThoughtConfig {
+    pub interval_secs: u64,   // SIMARD_BACKGROUND_THOUGHT_INTERVAL_SECS
+    pub dry_run: bool,        // if it has side-effects
+}
+
+impl BackgroundThoughtThread {
+    pub fn from_env() -> Self {
+        let interval_secs = std::env::var("SIMARD_BACKGROUND_THOUGHT_INTERVAL_SECS")
+            .ok().and_then(|v| v.parse().ok())
+            .unwrap_or(3600)
+            .max(/* floor */ 60);
+        Self { interval_secs, last_run_epoch: None, consecutive_errors: 0 }
+    }
+}
+```
+
+If your thread needs a **durable** cadence that survives restarts (e.g. a
+30-day gate where an in-memory `last_run` would wrongly reset on reboot), use
+the file-based epoch-marker pattern rather than a database — reuse
+`self_quality_audit::{read_last_run, write_last_run, LAST_RUN_FILENAME,
+now_epoch_secs}` and write the marker on **both** `Ok` and `Err`. See the
+[self-audit howto](./configure-self-quality-audit.md) and the reference doc's
+persistent-gate contract. **Do not add a schema, migration, or table** — the
+scheduler is deliberately DB-free.
+
+## Step 4 — Register with the Mind
+
+Registration is one chained call in the daemon setup block. You do **not** edit
+the daemon loop body or `mind.rs`.
+
+```rust
+mind.register(Box::new(BackgroundThoughtThread::from_env()));
+```
+
+The Mind then computes due-ness, runs it in priority order under the per-tick
+non-critical budget (`SIMARD_MIND_MAX_NONCRITICAL_PER_TICK`), isolates its
+failures, and records its telemetry — automatically.
+
+## Step 5 — Emit telemetry (the only observability path)
+
+!!! danger "No `println!` / `eprintln!` / `print!` in new code"
+    Use structured `tracing` events + spans and OTel metrics **only**. The Mind
+    already opens the per-run span and records `runs` / `duration_seconds` /
+    `next_run_epoch` / `active` for you. For any *extra* thread-specific metric,
+    emit it **through `cognitive_threads::telemetry`** — that one helper is the
+    single seam that a later rebase onto the unified telemetry facade
+    (`src/telemetry/`) will retarget. Do not call metric/logging APIs directly
+    from your thread.
+
+Return rich `detail` on the `ThreadOutcome` (bounded, no secrets) and let the
+Mind's span carry it:
+
+```rust
+ThreadOutcome::ok("done", elapsed)
+    .with_detail(serde_json::json!({ "items": n, "skipped": s }))
+```
+
+Metric/span **names** must stay `simard.thread.<id>.*` with `<id>` a constant;
+untrusted content may only appear as **length-bounded field values**, never in a
+name and never as a format-string argument.
+
+## Safety rules (enforced in review)
+
+These apply to every new thread and are non-negotiable:
+
+- **Least authority.** Take only what you need from `ThreadContext`
+  (`state_root`, `repo_root`, `memory`, `runtime`, `shutdown`, `now_epoch`,
+  `dry_run`). Do **not** reach into globals, and have **no** code path to
+  `self_deploy` / `self_relaunch` / redeploy.
+- **Honour `dry_run`.** If your thread mutates anything, `ctx.dry_run` must
+  short-circuit every destructive call and log what it *would* do.
+- **Destructive filesystem ops are guarded.** Before any `remove_dir_all` /
+  `remove_file`: canonicalize the path, require it to sit inside an explicit
+  **allow-list** root, **refuse symlinks**, and reject the deny-list
+  (`worktrees/main`, `~/.simard/repo`, the live cognitive store + shadow/WAL,
+  any engineer worktree). Enforce **retention floors** (keep ≥ N newest) before
+  pruning. Reuse existing cleanup helpers rather than reimplementing them.
+- **Untrusted content is scrubbed.** Anything derived from engineer logs/telemetry
+  that leaves the process (issue body, telemetry field) must pass the secret
+  scrubber (`sanitization::sanitize_terminal_text`) and be fenced/escaped so it
+  can't emit `@mentions`/`#refs` or poison dedup.
+- **External processes are argv-only.** Never `sh -c`; never interpolate tainted
+  data into a command line. Inject clients (e.g. `Box<dyn GhClient>`) so tests
+  use a fake — no network, no ambient credentials.
+- **Bound your work.** Cap records scanned, findings, and side-effects per run;
+  clamp intervals to a floor. A hot-failing thread is already capped by the
+  Mind's backoff, but don't rely on it as your only bound.
+- **Durable artifacts are GitHub issues or code, never repo snapshot docs.** If
+  your thread produces findings, file a **deduplicated** issue via the
+  stewardship path or emit structured telemetry — do not commit a point-in-time
+  markdown snapshot.
+
+## Test it (fixtures only — no sleeps, no network)
+
+The abstraction is built to be unit-testable with an **injected clock**
+(`ctx.now_epoch`) and injected collaborators. Cover, at minimum:
+
+- **Due computation** — assert `schedule::is_due` / `next_run_epoch` for your
+  policy against hand-fed `now_epoch` values (including the `None` last-run
+  "due immediately" case for `Interval`, and "never auto-due" for
+  `OnDemand`/`EventDriven`).
+- **Failure isolation** — a `tick()` that panics or returns `Err` is caught,
+  bumps `consecutive_errors`, sets backoff, and does **not** stop OODA or a
+  sibling thread. Drive it through `Mind::run_due` with a fake OODA thread and a
+  fake panicking thread and assert both survive.
+- **Side-effects** — run `tick()` against a fixture `~/.simard` (via `tempfile`)
+  and assert exactly the intended effect; assert **no** protected path is
+  touched and that `dry_run` performs zero mutations.
+- **Injected client** — if you call out (GitHub, etc.), inject a fake via a
+  constructor seam (`with_client(cfg, Box::new(FakeGhClient::new()))`) and assert
+  idempotency (a second run finds the existing issue and does **not** create a
+  duplicate).
+
+Place tests in `src/cognitive_threads/tests.rs` (shared harness) or a
+`#[cfg(test)] mod tests` in your thread module, matching the exemplars.
+
+## Checklist
+
+- [ ] `id()` is a stable snake_case constant; `kind()` set (reserved kinds are
+      allowed for vision threads)
+- [ ] `priority()` is not `Critical`
+- [ ] `policy()` uses `schedule.rs`; interval clamped to a floor
+- [ ] `from_env()` reads `SIMARD_<AREA>_INTERVAL_SECS` (+ `_DRY_RUN` if it
+      mutates) with safe defaults
+- [ ] registered via `mind.register(...)`; daemon loop and `ooda_scheduler/`
+      untouched
+- [ ] telemetry only through `cognitive_threads::telemetry`; **zero**
+      `println!`/`eprintln!`
+- [ ] safety rules obeyed (least authority, dry-run, allow/deny + symlink
+      refusal, scrub, argv-only, bounds, no repo snapshot docs)
+- [ ] tests: due-computation, failure isolation, side-effects, injected client —
+      no sleeps, no network
+
+## Related
+
+- [Cognitive-thread scheduling (reference)](../reference/cognitive-thread-scheduling.md) — the authoritative trait/`Mind`/telemetry/security contract
+- [Configure and monitor cognitive-thread scheduling (howto)](./configure-cognitive-thread-scheduling.md) — operate and observe threads
+- [Configure and monitor the monthly self-quality-audit](./configure-self-quality-audit.md) — the disk-persisted-gate reuse pattern

--- a/docs/howto/configure-cognitive-thread-scheduling.md
+++ b/docs/howto/configure-cognitive-thread-scheduling.md
@@ -1,0 +1,312 @@
+---
+title: Configure and monitor cognitive-thread scheduling
+description: Operator guide for Simard's cognitive-thread scheduler (the Mind) (#2419) — how the daemon runs the OODA loop and its background threads on their own cadences, tuning the per-thread interval knobs and the non-critical per-tick budget, guaranteeing the OODA loop is never starved, observing per-thread metrics/spans/health, driving the MaintenanceThread safely (dry-run + protected paths), reading the EngineerLogAnalysisThread's deduplicated GitHub issues, and diagnosing a backed-off or misconfigured thread.
+last_updated: 2026-07-03
+review_schedule: as-needed
+owner: simard
+doc_type: howto
+related:
+  - ../reference/cognitive-thread-scheduling.md
+  - ./add-a-new-cognitive-thread.md
+  - ./configure-brain-introspection.md
+  - ./configure-self-quality-audit.md
+  - ./configure-disk-health-check.md
+---
+
+# Configure and monitor cognitive-thread scheduling
+
+Simard's daemon does more than run the OODA loop. Every background mental
+process — housekeeping, backups, brain introspection, the monthly self-audit,
+maintenance, engineer-log analysis — is a **cognitive thread** owned by a single
+scheduler, the **Mind**. Each thread declares its own cadence (or trigger), the
+Mind computes which threads are due each tick, and runs them under a
+priority/resource budget that **always runs the OODA loop first and never lets
+it be starved**.
+
+This guide shows how to tune the cadences, guarantee OODA parity, observe each
+thread, drive the two exemplar threads (`MaintenanceThread`,
+`EngineerLogAnalysisThread`) safely, and diagnose a thread that has stopped
+firing. For the design and API contract see
+[Cognitive-thread scheduling](../reference/cognitive-thread-scheduling.md); to
+add your own thread see
+[Add a new cognitive thread](./add-a-new-cognitive-thread.md).
+
+## When to use this
+
+Use this guide when:
+
+- You want to change how often a background thread runs (or turn it off)
+- You need to confirm the OODA loop still runs on its exact cadence after the
+  scheduler took over the daemon loop
+- You want to read a thread's runs/errors/duration metrics or its next-run time
+- The `MaintenanceThread` is (or isn't) pruning artifacts and you want to verify
+  it is behaving conservatively
+- The `EngineerLogAnalysisThread` filed — or should have filed — a GitHub issue
+- A thread has gone quiet and you suspect it has been backed off after repeated
+  failures
+
+## The model: one Mind, many threads
+
+The Mind holds a **registry** of threads. Once per outer daemon iteration it:
+
+1. computes the **due** set (enabled, not backed-off, and past its next-run),
+2. runs the **OODA thread first, unconditionally, every tick** (it is
+   `Priority::Critical` and exempt from the budget),
+3. runs the remaining due threads in priority order, up to a **per-tick budget**
+   of non-critical threads, then
+4. sleeps the same `interval_secs` the daemon always slept and re-checks
+   shutdown.
+
+Each thread runs inside a panic/error guard: a thread that panics or returns an
+error is **caught, recorded, and backed off** — it can never crash the daemon or
+delay a sibling. The OODA thread is the one exception to backoff: its errors are
+logged and the cycle continues, exactly as before the scheduler existed.
+
+Threads that ship in this build:
+
+| Thread id (telemetry key) | Kind | Priority | Cadence source |
+| --- | --- | --- | --- |
+| `ooda` | Ooda | **Critical** | `SIMARD_OODA_INTERVAL_SECS` |
+| `maintenance` | Maintenance | Low | `SIMARD_MAINTENANCE_INTERVAL_SECS` |
+| `engineer_log_analysis` | EngineerLogAnalysis | Low | `SIMARD_ENGINEER_LOG_ANALYSIS_INTERVAL_SECS` |
+
+The pre-existing periodic tasks — verified backup, disk-health check,
+RSS/memory shedding, engineer-worktree sweep, brain introspection, and the
+monthly self-quality-audit — are **subsumed by the same Mind** rather than
+duplicated. They keep their existing env-var knobs (below); the scheduler only
+changes *how* they are dispatched, not *when* or *what* they do.
+
+## Tune the cadences
+
+Every knob is an environment variable read once at daemon start. Set it before
+launching the daemon.
+
+### The two exemplar threads
+
+| Knob | Env var | Default | What it controls |
+| --- | --- | --: | --- |
+| Maintenance cadence | `SIMARD_MAINTENANCE_INTERVAL_SECS` | `86400` (daily) | Seconds between housekeeping passes |
+| Maintenance dry-run | `SIMARD_MAINTENANCE_DRY_RUN` | `false` | When set, logs the actions it *would* take and deletes nothing |
+| Analysis cadence | `SIMARD_ENGINEER_LOG_ANALYSIS_INTERVAL_SECS` | slow (e.g. hourly+) | Seconds between engineer-log analysis passes |
+
+### The scheduler budget
+
+| Knob | Env var | Default | What it controls |
+| --- | --- | --: | --- |
+| Non-critical fan-out | `SIMARD_MIND_MAX_NONCRITICAL_PER_TICK` | `2` | Max **non-OODA** threads run in a single tick. OODA is exempt and always runs. |
+
+The budget bounds how many background threads can fire in one iteration so a
+burst of simultaneously-due threads can never crowd out the OODA cycle. If two
+background threads come due in the same tick and the budget is `2`, both run
+after OODA; a third due thread waits for the next tick.
+
+### The subsumed periodic tasks (unchanged knobs)
+
+| Task | Env var | Default |
+| --- | --- | --: |
+| Verified backup | `SIMARD_BACKUP_INTERVAL_SECS` | (feature default) |
+| Disk-health check | `SIMARD_DISK_HEALTH_INTERVAL_SECS` | `900` |
+| Engineer-worktree sweep | `SIMARD_WORKTREE_SWEEP_INTERVAL_SECS` | `1800` |
+| Brain introspection | `SIMARD_BRAIN_INTROSPECTION_INTERVAL_SECS` | see [howto](./configure-brain-introspection.md) |
+| Monthly self-quality-audit | `SIMARD_SELF_AUDIT_INTERVAL` | `2592000` (0 disables) |
+| RSS / memory shedding | — (runs every tick, no interval) | — |
+
+!!! note "Interval floor"
+    Interval knobs are clamped to a small minimum floor. Setting an interval to
+    `0` (or a negative/garbage value) does **not** make a background thread due
+    every tick — it normalizes to the floor (or, for tasks that define `0` as
+    "disabled" like `SIMARD_SELF_AUDIT_INTERVAL`, disables the thread). This
+    stops a misconfigured environment from spinning a thread.
+
+Examples:
+
+```bash
+# Run maintenance every 6 hours instead of daily
+export SIMARD_MAINTENANCE_INTERVAL_SECS=21600
+
+# Maintenance in observe-only mode — audit what it would prune, delete nothing
+export SIMARD_MAINTENANCE_DRY_RUN=1
+
+# Allow up to 3 background threads per tick (OODA still runs first, always)
+export SIMARD_MIND_MAX_NONCRITICAL_PER_TICK=3
+```
+
+## Confirm OODA parity (the critical guarantee)
+
+The single most important property: the daemon behaves **identically** from the
+outside after the scheduler took over. OODA still fires once per outer iteration
+on `SIMARD_OODA_INTERVAL_SECS`, spawns engineers the same way, and writes the
+same cycle reports, episodes, and health files.
+
+Confirm the OODA cadence at startup and that cycles are still advancing:
+
+```bash
+# Configured OODA interval (unchanged by the scheduler)
+grep "OODA daemon: cycle interval" ~/.simard/ooda.log | tail -1
+
+# Cycle number is still incrementing once per interval
+python3 -c "import json;print(json.load(open('$HOME/.simard/daemon_health.json'))['cycle_number'])"
+```
+
+The OODA thread carries `Priority::Critical` and is **exempt from the per-tick
+budget** — no number of background threads can delay or skip an OODA cycle. If
+you ever see the cycle number stall while background threads keep firing, that
+is a bug, not a budget effect; capture `~/.simard/ooda.log` and file an issue.
+
+## Observe a thread
+
+Each run opens a span and records metrics under the stable name
+`simard.thread.<id>`:
+
+| Metric | Type | Meaning |
+| --- | --- | --- |
+| `simard.thread.<id>.runs` | counter | Completed runs |
+| `simard.thread.<id>.errors` | counter | Runs that panicked or returned `Err` |
+| `simard.thread.<id>.duration_seconds` | histogram | Per-run wall-clock |
+| `simard.thread.<id>.next_run_epoch` | gauge | When the thread is next due (epoch s) |
+| `simard.thread.<id>.active` | gauge | `1` while ticking, `0` otherwise |
+
+The span `simard.thread.<id>` carries fields `ran`, `success`, `duration_ms`,
+and thread-specific `detail`. These are emitted as **structured `tracing`
+events** (and OTel metrics when a meter is configured) — there are no ad-hoc
+`println!` lines. To eyeball recent activity in the daemon's tracing output:
+
+```bash
+# Every scheduler span/event, newest last
+grep "simard.thread." ~/.simard/ooda.log | tail -20
+
+# Just the maintenance thread
+grep "simard.thread.maintenance" ~/.simard/ooda.log | tail -10
+```
+
+The Mind also exposes a **health snapshot** per thread (last-run, next-run,
+consecutive errors, backoff-until) that feeds the operator dashboard heartbeat.
+See [the dashboard](../dashboard.md) for the live per-thread view.
+
+## Drive the MaintenanceThread safely
+
+`MaintenanceThread` performs conservative housekeeping under `~/.simard` on a
+slow cadence, reusing the existing cleanup/backup helpers (it reimplements
+nothing):
+
+- prunes old `cognitive.corrupt-*` databases and stale store snapshots / shadow
+  WAL copies beyond a retention floor,
+- rotates stale binary backups and caps runaway cargo `target/` dirs,
+- verifies and prunes verified backups to a retention count,
+- reports disk pressure.
+
+**It is conservative by construction:**
+
+- It **never** deletes protected paths — `worktrees/main`, `~/.simard/repo`, the
+  **live** cognitive store (and its shadow/WAL), or any engineer worktree. Every
+  candidate is matched against a canonicalized allow-list and rejected if it is a
+  symlink or escapes the allowed root.
+- It honours **dry-run** (`SIMARD_MAINTENANCE_DRY_RUN`): it logs the actions it
+  *would* take and deletes nothing.
+- It always keeps **≥ N newest** of each artifact class (retention floors), so a
+  misconfigured retention count can never delete everything.
+- Every action is emitted as **structured telemetry** (path, bytes freed,
+  kept/pruned counts) — never a snapshot doc committed to the repo.
+
+Recommended first rollout: run it in dry-run for a few cycles and read the
+telemetry before enabling deletion.
+
+```bash
+# 1. Observe-only: see what it would prune
+export SIMARD_MAINTENANCE_DRY_RUN=1
+# ... start the daemon, then:
+grep "simard.thread.maintenance" ~/.simard/ooda.log | tail -20
+
+# 2. When satisfied, enable real pruning
+unset SIMARD_MAINTENANCE_DRY_RUN
+```
+
+## Read the EngineerLogAnalysisThread's findings
+
+`EngineerLogAnalysisThread` scans **recent** engineer run logs and structured
+OODA/brain telemetry (cycle reports, self-metrics, cost records, parse
+telemetry) for improvement opportunities: recurring engineer failures,
+stuck/looping patterns, brain parse-failure spikes, restart churn, distill
+failure rate, and repeated CI failure modes. Its work is **bounded** — capped
+records, window, and findings per run.
+
+Its durable output is a **deduplicated GitHub issue**, not a repo snapshot doc.
+It computes a stable failure signature, searches for an existing open issue
+carrying that signature, and creates a new issue **only when none exists**
+(create-suppression). Re-running is idempotent: the same recurring failure will
+not spawn a second issue.
+
+```bash
+# Issues this thread filed (they embed a stewardship-signature marker)
+gh issue list --repo rysweet/Simard --state open --search "stewardship-signature in:body" --limit 20
+```
+
+When issue filing is unavailable (no `gh`, offline, or in tests) it **degrades
+to structured telemetry only** — it never writes a committed file. To see a run
+that produced findings but couldn't file:
+
+```bash
+grep "simard.thread.engineer_log_analysis" ~/.simard/ooda.log | tail -20
+```
+
+!!! warning "Secrets and untrusted log content"
+    Engineer logs are untrusted input. Before any excerpt is placed in an issue
+    body or a telemetry field it is passed through the crate's secret scrubber
+    (redacts `token=`/`Authorization:`/`_secret`/`_token` lines) and fenced so it
+    cannot emit GitHub `@mentions`/`#refs` or poison dedup. You should never see a
+    real credential in a filed issue; if you do, treat it as a security bug.
+
+## Diagnose a thread that stopped firing
+
+A thread that panics or errors repeatedly is **backed off** with capped
+exponential backoff so it can't hot-loop. Backoff is per-thread and never
+touches OODA or siblings.
+
+Check, in order:
+
+### 1. Is it disabled or clamped?
+
+```bash
+# Interval config lines are logged at startup
+grep "OODA daemon:.*interval" ~/.simard/ooda.log | tail -10
+```
+
+An interval of `0` for a task that treats `0` as "disabled" (e.g. the
+self-audit) means it is off. A very small configured interval is silently raised
+to the floor.
+
+### 2. Is it backed off after errors?
+
+Look for the thread's error counter climbing and a future `next_run_epoch`:
+
+```bash
+grep "simard.thread.<id>.errors" ~/.simard/ooda.log | tail -5
+grep "simard.thread.<id>" ~/.simard/ooda.log | grep -i "backoff\|error" | tail -10
+```
+
+The per-thread health snapshot shows `consecutive_errors` and
+`backoff_until_epoch`. A thread recovers automatically on its next successful
+run (the error streak resets); backoff only delays retries, it never disables
+the thread permanently.
+
+### 3. Was it starved by the budget?
+
+If several non-critical threads are due at once and
+`SIMARD_MIND_MAX_NONCRITICAL_PER_TICK` is small, a lower-priority thread may be
+deferred to a later tick. Raise the budget or stagger the intervals. OODA is
+never affected.
+
+### 4. Is the daemon shutting down between threads?
+
+The Mind checks for a shutdown request between threads and returns early to keep
+graceful drain fast, so a thread late in a tick may be skipped during shutdown.
+This is expected and coexists with the existing `interruptible_sleep` +
+drain/checkpoint path.
+
+## Related
+
+- [Cognitive-thread scheduling (reference)](../reference/cognitive-thread-scheduling.md) — trait, `Mind` API, `SchedulePolicy`, telemetry contract, security requirements
+- [Add a new cognitive thread (howto)](./add-a-new-cognitive-thread.md) — implement and register your own thread
+- [Configure and monitor brain introspection](./configure-brain-introspection.md) — a subsumed periodic task
+- [Configure and monitor the monthly self-quality-audit](./configure-self-quality-audit.md) — the disk-persisted-gate example
+- [Configure and monitor the disk health check](./configure-disk-health-check.md) — a subsumed periodic task

--- a/docs/howto/configure-cognitive-thread-scheduling.md
+++ b/docs/howto/configure-cognitive-thread-scheduling.md
@@ -15,6 +15,17 @@ related:
 
 # Configure and monitor cognitive-thread scheduling
 
+!!! note "Status — planned (design for #2419, not yet shipped)"
+    This guide documents the cognitive-thread scheduler (the **Mind**) as
+    designed in issue #2419. The `src/cognitive_threads/` module, the
+    `SIMARD_MIND_*` budget/cadence knobs, and the `simard.thread.*`
+    metrics/spans described below **do not exist yet** — they become active
+    when the scheduler and its three threads (`OodaThread`, `MaintenanceThread`,
+    `EngineerLogAnalysisThread`) land. Until then the daemon runs OODA plus its
+    six periodic tasks through the existing hand-rolled loop. See
+    [Cognitive-thread scheduling](../reference/cognitive-thread-scheduling.md)
+    for the design and rollout scope.
+
 Simard's daemon does more than run the OODA loop. Every background mental
 process — housekeeping, backups, brain introspection, the monthly self-audit,
 maintenance, engineer-log analysis — is a **cognitive thread** owned by a single

--- a/docs/howto/configure-cognitive-thread-scheduling.md
+++ b/docs/howto/configure-cognitive-thread-scheduling.md
@@ -15,14 +15,17 @@ related:
 
 # Configure and monitor cognitive-thread scheduling
 
-!!! note "Status — planned (design for #2419, not yet shipped)"
-    This guide documents the cognitive-thread scheduler (the **Mind**) as
-    designed in issue #2419. The `src/cognitive_threads/` module, the
-    `SIMARD_MIND_*` budget/cadence knobs, and the `simard.thread.*`
-    metrics/spans described below **do not exist yet** — they become active
-    when the scheduler and its three threads (`OodaThread`, `MaintenanceThread`,
-    `EngineerLogAnalysisThread`) land. Until then the daemon runs OODA plus its
-    six periodic tasks through the existing hand-rolled loop. See
+!!! note "Status — shipped, additive, OFF by default (#2419)"
+    The cognitive-thread scheduler (the **Mind**), the `src/cognitive_threads/`
+    module, its `simard.thread.*` metrics/spans, and the two exemplar threads
+    (`MaintenanceThread`, `EngineerLogAnalysisThread`) **have shipped**. In the
+    live daemon they are **inactive until you opt in** with
+    `SIMARD_COGNITIVE_THREADS_ENABLED` (see [Enable the scheduler](#enable-the-scheduler)).
+    Two design goals are intentionally **deferred to follow-ups** and are *not*
+    active yet: (1) driving the OODA cycle itself **through** the Mind (today the
+    daemon keeps its existing inline OODA cycle for byte-for-byte parity, and the
+    Mind runs only the two background threads *after* it), and (2) migrating the
+    six pre-existing periodic tasks onto the Mind (they remain hand-rolled). See
     [Cognitive-thread scheduling](../reference/cognitive-thread-scheduling.md)
     for the design and rollout scope.
 
@@ -47,8 +50,8 @@ add your own thread see
 Use this guide when:
 
 - You want to change how often a background thread runs (or turn it off)
-- You need to confirm the OODA loop still runs on its exact cadence after the
-  scheduler took over the daemon loop
+- You need to confirm the OODA loop still runs on its exact cadence after
+  enabling the scheduler
 - You want to read a thread's runs/errors/duration metrics or its next-run time
 - The `MaintenanceThread` is (or isn't) pruning artifacts and you want to verify
   it is behaving conservatively
@@ -73,6 +76,14 @@ error is **caught, recorded, and backed off** — it can never crash the daemon 
 delay a sibling. The OODA thread is the one exception to backoff: its errors are
 logged and the cycle continues, exactly as before the scheduler existed.
 
+!!! info "How OODA-first works in the live daemon today"
+    The `Mind`'s contract runs `Priority::Critical` (OODA) first and exempt from
+    the budget. **As shipped**, the daemon achieves the same guarantee a simpler
+    way: it runs its existing **inline OODA cycle first**, then calls the `Mind`
+    (which currently holds only the two background threads) *afterward*. Either
+    way OODA runs first every iteration and no number of background threads can
+    delay it. Registering `OodaThread` in the live `Mind` is a follow-up.
+
 Threads that ship in this build:
 
 | Thread id (telemetry key) | Kind | Priority | Cadence source |
@@ -83,9 +94,34 @@ Threads that ship in this build:
 
 The pre-existing periodic tasks — verified backup, disk-health check,
 RSS/memory shedding, engineer-worktree sweep, brain introspection, and the
-monthly self-quality-audit — are **subsumed by the same Mind** rather than
-duplicated. They keep their existing env-var knobs (below); the scheduler only
-changes *how* they are dispatched, not *when* or *what* they do.
+monthly self-quality-audit — are **designed to be subsumed by the same Mind**,
+but that migration is a **follow-up**: in this build they still run through the
+daemon's existing hand-rolled loop with their current env-var knobs (below). The
+scheduler runs *alongside* them.
+
+## Enable the scheduler
+
+The scheduler is **off by default**. Turn it on with a single truthy env var
+(`1`, `true`, `yes`, or `on`), then launch the daemon:
+
+```bash
+# Enable the cognitive-thread scheduler (maintenance + engineer-log analysis)
+export SIMARD_COGNITIVE_THREADS_ENABLED=1
+```
+
+| Knob | Env var | Default | What it controls |
+| --- | --- | --: | --- |
+| Master switch | `SIMARD_COGNITIVE_THREADS_ENABLED` | `false` | When truthy, the daemon builds the `Mind` and runs the background threads after each OODA cycle. Unset ⇒ zero behaviour change. |
+
+When it is enabled, the daemon logs at startup:
+
+```
+[simard] OODA daemon: cognitive-thread scheduler ENABLED (2 background thread(s))
+```
+
+Recommended first rollout: enable it with **maintenance in dry-run** and
+**analysis in dry-run** (below), read the telemetry for a few cycles, then relax
+the dry-run switches once you trust the behaviour.
 
 ## Tune the cadences
 
@@ -96,9 +132,20 @@ launching the daemon.
 
 | Knob | Env var | Default | What it controls |
 | --- | --- | --: | --- |
-| Maintenance cadence | `SIMARD_MAINTENANCE_INTERVAL_SECS` | `86400` (daily) | Seconds between housekeeping passes |
-| Maintenance dry-run | `SIMARD_MAINTENANCE_DRY_RUN` | `false` | When set, logs the actions it *would* take and deletes nothing |
-| Analysis cadence | `SIMARD_ENGINEER_LOG_ANALYSIS_INTERVAL_SECS` | slow (e.g. hourly+) | Seconds between engineer-log analysis passes |
+| Maintenance cadence | `SIMARD_MAINTENANCE_INTERVAL_SECS` | `86400` (daily) | Seconds between housekeeping passes (clamped to a 60 s floor) |
+| Maintenance dry-run | `SIMARD_MAINTENANCE_DRY_RUN` | `true` | Ships dry-run-first: logs the actions it *would* take and deletes nothing. Set to `0`/`false` to enable real pruning. |
+| Keep corrupt dirs | `SIMARD_MAINTENANCE_KEEP_CORRUPT` | `3` | Retention floor for `cognitive.corrupt-*` quarantine dirs (min 1) |
+| Keep snapshots | `SIMARD_MAINTENANCE_KEEP_SNAPSHOTS` | `5` | Retention floor for store snapshots / shadow-WAL copies (min 1) |
+| Keep backups | `SIMARD_MAINTENANCE_KEEP_BACKUPS` | `7` | Retention floor for verified backups (min 1) |
+| Analysis cadence | `SIMARD_ENGINEER_LOG_ANALYSIS_INTERVAL_SECS` | `21600` (6 h) | Seconds between engineer-log analysis passes (clamped to a 60 s floor) |
+| Analysis dry-run | `SIMARD_ENGINEER_LOG_ANALYSIS_DRY_RUN` | `false` | When truthy, emits findings as structured telemetry and files **no** GitHub issue |
+
+!!! tip "Maintenance ships dry-run-first"
+    `SIMARD_MAINTENANCE_DRY_RUN` defaults to **`true`** (SR-7): even with the
+    scheduler enabled, maintenance deletes nothing until you explicitly set
+    `SIMARD_MAINTENANCE_DRY_RUN=0`. The analysis thread defaults to filing real
+    (deduplicated) issues — set `SIMARD_ENGINEER_LOG_ANALYSIS_DRY_RUN=1` to keep
+    it observe-only during initial rollout.
 
 ### The scheduler budget
 
@@ -111,7 +158,10 @@ burst of simultaneously-due threads can never crowd out the OODA cycle. If two
 background threads come due in the same tick and the budget is `2`, both run
 after OODA; a third due thread waits for the next tick.
 
-### The subsumed periodic tasks (unchanged knobs)
+### The pre-existing periodic tasks (unchanged knobs)
+
+These tasks still run through the daemon's existing hand-rolled loop (their
+migration onto the `Mind` is a follow-up); their knobs are unchanged:
 
 | Task | Env var | Default |
 | --- | --- | --: |
@@ -145,9 +195,11 @@ export SIMARD_MIND_MAX_NONCRITICAL_PER_TICK=3
 ## Confirm OODA parity (the critical guarantee)
 
 The single most important property: the daemon behaves **identically** from the
-outside after the scheduler took over. OODA still fires once per outer iteration
-on `SIMARD_OODA_INTERVAL_SECS`, spawns engineers the same way, and writes the
-same cycle reports, episodes, and health files.
+outside whether or not the scheduler is enabled. OODA still fires once per outer
+iteration on `SIMARD_OODA_INTERVAL_SECS`, spawns engineers the same way, and
+writes the same cycle reports, episodes, and health files — its cycle is run by
+the daemon's unchanged inline path, with the background threads scheduled
+strictly *after* it.
 
 Confirm the OODA cadence at startup and that cycles are still advancing:
 
@@ -219,17 +271,18 @@ nothing):
 - Every action is emitted as **structured telemetry** (path, bytes freed,
   kept/pruned counts) — never a snapshot doc committed to the repo.
 
-Recommended first rollout: run it in dry-run for a few cycles and read the
-telemetry before enabling deletion.
+Recommended first rollout: it already ships in dry-run (`SIMARD_MAINTENANCE_DRY_RUN`
+defaults to `true`), so just read the telemetry for a few cycles before enabling
+deletion.
 
 ```bash
-# 1. Observe-only: see what it would prune
-export SIMARD_MAINTENANCE_DRY_RUN=1
+# 1. Observe-only (this is the default): see what it would prune
+export SIMARD_COGNITIVE_THREADS_ENABLED=1   # maintenance is dry-run by default
 # ... start the daemon, then:
 grep "simard.thread.maintenance" ~/.simard/ooda.log | tail -20
 
 # 2. When satisfied, enable real pruning
-unset SIMARD_MAINTENANCE_DRY_RUN
+export SIMARD_MAINTENANCE_DRY_RUN=0
 ```
 
 ## Read the EngineerLogAnalysisThread's findings

--- a/docs/reference/cognitive-thread-scheduling.md
+++ b/docs/reference/cognitive-thread-scheduling.md
@@ -5,6 +5,22 @@ processes" vision; **this PR implements the scheduler + three threads**:
 the primary `OodaThread`, plus two exemplars — `MaintenanceThread` and
 `EngineerLogAnalysisThread`.
 
+!!! note "As shipped in this PR (additive & OFF by default)"
+    The scheduler landed **additively and disabled by default** to honour the
+    byte-for-byte OODA-parity hard constraint:
+
+    - The `Mind` and all three threads exist and are fully unit-tested.
+    - In the **live daemon** the `Mind` is created only when
+      `SIMARD_COGNITIVE_THREADS_ENABLED` is truthy, and it hosts **only the two
+      background exemplars** (`MaintenanceThread`, `EngineerLogAnalysisThread`).
+      It runs **after** the daemon's existing inline OODA cycle each iteration,
+      so it can never delay or starve OODA.
+    - The daemon's authoritative OODA cycle stays **inline and unchanged**
+      (wrap-don't-replace). `OodaThread` is the faithful primary-thread
+      realization used by the scheduler tests and ready for the full cutover;
+      routing the live loop through it, and migrating the six periodic tasks
+      onto the `Mind`, are tracked as **follow-ups** (see §6, A.9).
+
 ## 1. Motivation
 
 Simard should eventually run **many concurrent cognitive processes**, each on
@@ -248,6 +264,20 @@ State that the OODA cycle mutates (`OodaState`, `OodaBridges`, `config`) is
 owned by `OodaThread` (moved into it at daemon start), not the generic
 `ThreadContext` — only OODA needs it, and this keeps the trait clean.
 
+!!! note "As shipped: `OodaThread` is faithful; the live loop keeps OODA inline"
+    `OodaThread::tick()` performs the core per-cycle work and the **same
+    canonical persistence** as the daemon — it calls `run_ooda_cycle`, then the
+    shared `persist_cycle_report` / `persist_cycle_to_memory` helpers and
+    `self_metrics::collect_and_record_all`, and sets the `Sleep` phase. (The
+    dashboard **heartbeat file** writes remain a daemon-loop concern tied to the
+    loop's `cycles_run` counter — they are not part of `tick()`.) To guarantee
+    byte-for-byte parity **without** an untestable live-loop rewrite, the daemon
+    keeps its inline OODA cycle authoritative for now and does **not** register
+    `OodaThread` in the live `Mind`. Cutting the live loop over to
+    `OodaThread` (using `OodaThread::into_parts()` to hand `state`/`bridges`
+    back to the graceful-shutdown drain) is a **follow-up**, gated on adding a
+    daemon-loop parity harness.
+
 ### Migrating the existing periodic tasks
 
 The six other hooks are **low-risk** to migrate onto the `Mind` because each
@@ -266,6 +296,13 @@ already matches the trait shape. Plan:
 If any wrapper proves risky under review, it stays inlined for this PR and is
 tracked as an explicit follow-up — the abstraction still lands with OODA +
 the two new exemplars. **Subsume, never duplicate.**
+
+!!! note "As shipped: periodic-task migration is deferred"
+    None of the six periodic tasks were migrated onto the `Mind` in this PR;
+    they remain hand-rolled in the daemon loop exactly as before. The `Mind`
+    hosts only the two **new** exemplar threads. Migrating the existing tasks
+    (behaviour-preserving wrappers, including the disk-persisted self-audit
+    gate in A.10) is the explicit follow-up this section anticipates.
 
 ## Persistence & data model (Step 5c determination — no relational database)
 
@@ -848,6 +885,19 @@ The trailing `interruptible_sleep(interval_secs, &shutdown)` and
 `OodaConfig` move **into** `OodaThread` (only OODA needs them), keeping
 `ThreadContext` generic. Parity tests (§6, §12) assert identical cycle
 count/order/side-effects vs. the legacy path.
+
+!!! note "As shipped in this PR"
+    The seam is **additive** and does not collapse the inline OODA cycle. The
+    daemon builds the `Mind` only when `SIMARD_COGNITIVE_THREADS_ENABLED` is
+    truthy, registers **only** `MaintenanceThread::from_env()` and
+    `EngineerLogAnalysisThread::from_env()`, and calls `mind.run_due(&mut ctx)`
+    **after** the existing `run_ooda_cycle(...)` match — not in place of it. The
+    context is built with `memory: shared_mem.as_ref()`, a dedicated
+    single-worker runtime handle, `repo_root` cloned from `bridges.repo_root`,
+    and `dry_run: false` (each exemplar carries its own dry-run default). This
+    keeps edits to the OODA emission sites nil (parity) while the two new
+    threads run under the `Mind`'s budget + failure isolation. Registering
+    `OodaThread` here and deleting the inline match is the documented follow-up.
 
 ### A.10 Persistent-gate contract (optional migrated self-audit thread)
 

--- a/docs/reference/cognitive-thread-scheduling.md
+++ b/docs/reference/cognitive-thread-scheduling.md
@@ -394,7 +394,7 @@ therefore *create-suppression*: embed `stewardship-signature:<sig>` in the body,
 `search_issues` → `find_existing`; create **only** when no open issue with the
 signature exists, otherwise it is a no-op (structured telemetry only). When
 issue filing is unavailable (no `gh`/offline/tests), it degrades to **structured
-telemetry only** — never a committed file. The `Box<dyn GhClient>` seam lets
+telemetry only** — never a committed file. The `Box<dyn GhClient + Send>` seam lets
 tests inject a fake client (fixture-driven, no network).
 
 **Bounding:** hard caps on records scanned, findings emitted, and at most one
@@ -451,7 +451,7 @@ paths safe by construction and reuse the crate's existing hardening.**
 | **SR-6** | **Never delete the live store.** The candidate path MUST be asserted `!=` the active cognitive-store path (and its shadow/WAL) reachable via `ThreadContext.memory`. | Runtime equality assert (belt-and-suspenders with the SR-5 deny-list). | New check in the thread. |
 | **SR-7** | **Conservative default posture.** Global `dry_run` honored (`SIMARD_MAINTENANCE_DRY_RUN`); retention **floors** (always keep ≥ N newest) enforced *before* any prune; destructive maintenance ships **dry-run-first / opt-in** until validated in production. Availability > reclaimed bytes. | `ThreadContext.dry_run` + env retention floors. | Design §8. |
 | **SR-8** | **Resource-exhaustion / DoS bounds.** (a) `Mind` caps non-critical fan-out per tick and keeps OODA `Critical`/exempt so no thread flood starves the control loop; (b) `catch_unwind` + **capped** exponential backoff stops a hot-failing thread pinning a core; (c) interval env vars are clamped to a **minimum floor** (reject/normalize `0`/negative) so a hostile/misconfigured env can't make a thread due every tick; (d) `EngineerLogAnalysis` enforces record/window/finding caps **before** reading and ≤ 1 `create_issue` per run. | §5 budget + backoff; interval clamp; scan caps. | Budget/backoff in §5; add interval-floor clamp + pre-read caps. |
-| **SR-9** | **Least authority.** Threads receive only borrowed, scoped resources via `ThreadContext` and MUST NOT reach globals. The two new threads MUST have **no** code path to `self_deploy`/`self_relaunch`/redeploy. `GhClient` is injected as `Box<dyn GhClient>` (fake in tests → no network, no credentials). | `ThreadContext` seam (§4); trait-object `GhClient`. | ✅ Verified: none of `cmd_cleanup`, `memory_backup`, `stewardship`, `disk_pressure` reference `self_deploy`/`self_relaunch`/`redeploy`. |
+| **SR-9** | **Least authority.** Threads receive only borrowed, scoped resources via `ThreadContext` and MUST NOT reach globals. The two new threads MUST have **no** code path to `self_deploy`/`self_relaunch`/redeploy. `GhClient` is injected as `Box<dyn GhClient + Send>` (fake in tests → no network, no credentials). | `ThreadContext` seam (§4); trait-object `GhClient`. | ✅ Verified: none of `cmd_cleanup`, `memory_backup`, `stewardship`, `disk_pressure` reference `self_deploy`/`self_relaunch`/`redeploy`. |
 | **SR-10** | **Credential confidentiality.** New code MUST NOT read, log, embed in an issue body, or emit to telemetry any token/`GH_TOKEN`. Error strings may include `gh` stderr (gh prints no tokens) but MUST NOT be augmented with env dumps. | No secret in fields/bodies/errors. | `gh` auth stays ambient in the CLI. |
 | **SR-11** | **Telemetry integrity (no metric-cardinality injection).** Metric/span **names** use the fixed `simard.thread.<id>` scheme where `<id>` is a per-thread compile-time constant — never derived from untrusted input. Untrusted content appears only as **length-bounded structured field values**, never as a format-string arg (no log forging) and never as a name. | Constant ids; bounded structured fields. | Design §7. |
 | **SR-12** | **Trigger authenticity.** `OnDemand`/`EventDriven` due-ness MUST originate from the internal operator/event channel (in-process flag/predicate on `ThreadContext`), not attacker-influenceable external input. Blast radius of a spurious trigger is bounded by SR-8. | Internal-only trigger source. | Design §4/§5. |
@@ -761,12 +761,12 @@ pub struct EngineerLogAnalysisConfig {
     pub dry_run: bool,        // suppress issue creation; telemetry only
 }
 impl Default for EngineerLogAnalysisConfig { /* safe bounded defaults */ }
-pub struct EngineerLogAnalysisThread { /* cfg, gh: Box<dyn GhClient>, health (private) */ }
+pub struct EngineerLogAnalysisThread { /* cfg, gh: Box<dyn GhClient + Send>, health (private) */ }
 impl EngineerLogAnalysisThread {
     pub fn from_env() -> Self;   // uses stewardship::gh_client::RealGhClient
     pub fn with_client(          // test seam: inject a fake GhClient
         cfg: EngineerLogAnalysisConfig,
-        gh: Box<dyn crate::stewardship::gh_client::GhClient>,
+        gh: Box<dyn crate::stewardship::gh_client::GhClient + Send>,
     ) -> Self;
 }
 // policy() = Interval(cfg.interval_secs); priority() = Low.

--- a/docs/reference/cognitive-thread-scheduling.md
+++ b/docs/reference/cognitive-thread-scheduling.md
@@ -520,6 +520,17 @@ daemon integration) → tests (above) → how-to doc + this reference doc + mkdo
 nav entry → single merge-ready PR against `rysweet/Simard` off `origin/main`,
 green CI, no redeploy.
 
+### Companion how-to guides
+
+- [Configure and monitor cognitive-thread scheduling](../howto/configure-cognitive-thread-scheduling.md)
+  — operator guide: cadence knobs, the non-critical per-tick budget, OODA-parity
+  checks, per-thread telemetry/health, driving the two exemplars safely, and
+  diagnosing a backed-off thread.
+- [Add a new cognitive thread](../howto/add-a-new-cognitive-thread.md)
+  — developer guide: implementing the trait, choosing a policy/priority,
+  env-config, registering with the `Mind`, emitting telemetry through the single
+  seam, the safety rules, and the fixture-only test plan.
+
 ---
 
 ## Appendix A — API Contracts (the "studs")

--- a/docs/reference/cognitive-thread-scheduling.md
+++ b/docs/reference/cognitive-thread-scheduling.md
@@ -1,0 +1,858 @@
+# Cognitive-Thread Scheduling (`src/cognitive_threads/`)
+
+**Status:** Design (issue #2419). Design covers the full "mind of many
+processes" vision; **this PR implements the scheduler + three threads**:
+the primary `OodaThread`, plus two exemplars — `MaintenanceThread` and
+`EngineerLogAnalysisThread`.
+
+## 1. Motivation
+
+Simard should eventually run **many concurrent cognitive processes**, each on
+its own cadence/trigger: the active OODA loop; background thought; memory
+consolidation (sleep/dream); sensory processing; long-term planning;
+maintenance & cleanup; engineer-log analysis.
+
+Today `src/operator_commands_ooda/daemon/mod.rs` hardcodes a single OODA loop
+plus six ad-hoc, inlined periodic tasks in one hand-rolled `loop {}`:
+
+| Periodic task (current) | Gate mechanism |
+| --- | --- |
+| Verified cognitive-store backup (#2420) | `Instant` elapsed vs interval |
+| Disk-health check + emergency cleanup | `Instant` elapsed vs interval |
+| RSS health / memory shedding (#2167/#2183) | every iteration |
+| Engineer-worktree sweep (#2167) | `Instant` elapsed vs interval |
+| Brain introspection + memory hygiene (#2419) | `Instant` elapsed vs interval |
+| Monthly self-quality-audit (#2419) | **disk-persisted** last-run epoch |
+
+Five of these repeat an identical shape: read interval-from-env, track a
+last-run marker, test "is it due?", run best-effort, log on `Ok`/`Err`, reset
+the marker (the sixth, RSS/shed, runs every iteration with no interval gate).
+This design **generalizes that shape** into a single reusable abstraction — it
+does **not** add a seventh copy.
+
+> **Non-goal / keep intact:** `src/ooda_scheduler/` is the **engineer
+> action-slot** scheduler (AIMD-governed engineer concurrency, bounded by
+> `SIMARD_MAX_CONCURRENT_ACTIONS`). It schedules *engineers within an OODA
+> cycle*, not top-level cognitive processes. It is **unrelated** to this work
+> and must not be modified.
+
+## 2. Critical runtime decision: synchronous scheduler
+
+`run_ooda_daemon` is a **synchronous** `fn`. Its outer `loop {}` runs
+housekeeping gates, then one synchronous `run_ooda_cycle(...)`, then
+`interruptible_sleep(interval_secs, &shutdown)`. A multi-thread Tokio runtime
+is built *inside* the daemon and used *within* the cycle (engineer I/O, LLM
+sessions) via `block_on` — the top-level scheduling loop itself is not async.
+
+**Decision:** the `Mind`/`Scheduler` and `CognitiveThread::tick()` are
+**synchronous**. Threads that need async I/O receive a `tokio::runtime::Handle`
+in their `ThreadContext` and `block_on` it, exactly as the OODA cycle already
+does.
+
+**Rationale (hard constraint: identical external OODA behaviour/cadence):**
+converting the top-level loop to `async` would rewrite the single most
+correctness-critical path — the exact thing #2419 forbids disturbing. A
+synchronous scheduler is a **structural refactor with zero behavioural delta**:
+the outer loop still sleeps `interval_secs`, OODA still fires once per outer
+iteration, and every periodic gate keeps its current firing semantics.
+
+The trait is designed so a *future* fully-async `Mind` is additive: a later
+`async fn tick_async` default can wrap the sync `tick`, and the runtime handle
+is already threaded through. "Async `tick()`" from the issue is honoured in
+**spirit** (async work runs inside a tick) without paying the correctness risk
+of an async top-level loop in this PR.
+
+## 3. Module layout
+
+```
+src/cognitive_threads/
+  mod.rs           // re-exports; module docs
+  thread.rs        // CognitiveThread trait, ThreadKind, SchedulePolicy,
+                   // Priority, ThreadOutcome, ThreadHealth, ThreadContext
+  schedule.rs      // SchedulePolicy::next_run / is_due pure functions
+  mind.rs          // Mind (Scheduler): registry, due-computation, budget,
+                   // failure isolation, graceful shutdown, run_due()
+  telemetry.rs     // small metric/span helper (rebase target for telemetry facade)
+  threads/
+    ooda.rs        // OodaThread (primary; wraps run_ooda_cycle + heartbeat)
+    maintenance.rs // MaintenanceThread (exemplar 1)
+    engineer_log_analysis.rs // EngineerLogAnalysisThread (exemplar 2)
+  tests.rs         // scheduler due-computation, failure isolation, parity
+```
+
+Declared in `src/lib.rs` as `pub mod cognitive_threads;` (sibling of
+`ooda_scheduler`). No `Bridge` in any new type/module name (operator rule);
+naming stays within Scheduler / Mind / CognitiveThread / Faculty / Context /
+Client.
+
+## 4. The `CognitiveThread` trait
+
+```rust
+/// A single scheduled mental process owned by the `Mind`.
+pub trait CognitiveThread: Send {
+    /// Stable, unique, snake_case id used in telemetry metric/span names.
+    fn id(&self) -> &str;
+
+    /// Human-facing name for logs/dashboard.
+    fn name(&self) -> &str { self.id() }
+
+    /// Coarse class of process.
+    fn kind(&self) -> ThreadKind;
+
+    /// When this thread wants to run.
+    fn policy(&self) -> SchedulePolicy;
+
+    /// Priority / resource class. OODA is always `Priority::Critical`.
+    fn priority(&self) -> Priority { Priority::Normal }
+
+    /// Runtime enable/disable (e.g. env-gated). Disabled threads never tick.
+    fn enabled(&self) -> bool { true }
+
+    /// Execute exactly one step. MUST be best-effort and self-contained:
+    /// return `Err` rather than panic where possible; the `Mind` also
+    /// catches panics as a backstop. May `block_on` `ctx.runtime`.
+    fn tick(&mut self, ctx: &mut ThreadContext<'_>) -> ThreadOutcome;
+
+    /// Current health/heartbeat snapshot (last-run, next-run, last outcome).
+    fn health(&self) -> ThreadHealth;
+}
+```
+
+### Supporting types
+
+```rust
+pub enum ThreadKind {
+    Ooda,                 // implemented (primary)
+    Maintenance,          // implemented (exemplar 1)
+    EngineerLogAnalysis,  // implemented (exemplar 2)
+    // Reserved for the vision — hosted by the same Mind, not implemented here:
+    BackgroundThought,
+    MemoryConsolidation,
+    SensoryProcessing,
+    LongTermPlanning,
+}
+
+pub enum SchedulePolicy {
+    /// Fixed cadence. `next_run = last_run + interval`.
+    Interval(Duration),
+    /// Only when explicitly requested (operator/event). Never auto-due.
+    OnDemand,
+    /// Due when an external predicate fires (closure/flag on ThreadContext).
+    EventDriven,
+    /// Cadence adapts to load/outcome (min..max bounds). Reserved; degrades to
+    /// Interval(current) for now so it is representable but conservative.
+    Adaptive { min: Duration, max: Duration, current: Duration },
+}
+
+pub enum Priority { Critical, High, Normal, Low }  // Critical == OODA only
+
+pub struct ThreadOutcome {
+    pub ran: bool,               // false => was not due / skipped
+    pub success: bool,
+    pub summary: String,         // structured, human-readable
+    pub duration: Duration,
+    pub detail: serde_json::Value, // thread-specific structured fields
+}
+
+pub struct ThreadHealth {
+    pub id: String,
+    pub enabled: bool,
+    pub last_run_epoch: Option<u64>,
+    pub next_run_epoch: Option<u64>,
+    pub last_success: Option<bool>,
+    pub consecutive_errors: u32,
+    pub backoff_until_epoch: Option<u64>,
+}
+```
+
+`ThreadContext<'_>` carries shared, borrowed daemon resources so threads do
+**not** reach into globals:
+
+```rust
+pub struct ThreadContext<'a> {
+    pub state_root: &'a Path,               // ~/.simard state root
+    pub repo_root: &'a Path,
+    pub memory: &'a dyn CognitiveMemoryOps, // live cognitive store handle
+    pub runtime: tokio::runtime::Handle,    // for block_on async work
+    pub shutdown: &'a AtomicBool,           // cooperative cancellation
+    pub now_epoch: u64,                     // injected clock (testable)
+    pub dry_run: bool,                      // global safety switch
+}
+```
+
+Injecting `now_epoch` and a `Clock` makes due-computation and backoff **purely
+unit-testable** with no sleeps.
+
+## 5. The `Mind` (Scheduler)
+
+```rust
+pub struct Mind { threads: Vec<ThreadEntry>, budget: RunBudget }
+```
+
+Responsibilities:
+
+1. **Registry** — owns `Vec<Box<dyn CognitiveThread>>` plus per-thread runtime
+   bookkeeping (`last_run`, `next_run`, `consecutive_errors`, `backoff_until`).
+2. **Due computation** — `due_threads(now)` returns enabled, non-backed-off
+   threads whose `policy.is_due(last_run, now)` holds. Pure function over
+   injected time (see `schedule.rs`); fully unit-tested.
+3. **Priority budget (never starve OODA)** — `run_due(ctx)` sorts due threads
+   by `Priority` and runs **OODA first, unconditionally, every outer tick**.
+   Non-critical threads run after OODA under a per-tick budget
+   (`SIMARD_MIND_MAX_NONCRITICAL_PER_TICK`, default small, e.g. 2) so a burst
+   of due background threads can never delay or crowd out an OODA cycle. OODA
+   is exempt from the budget. This preserves the current ordering (housekeeping
+   gates run, then the OODA cycle) while bounding non-critical fan-out.
+4. **Failure isolation** — each `tick()` runs inside
+   `std::panic::catch_unwind(AssertUnwindSafe(..))`. A panic or `Err`:
+   - is caught and recorded (`consecutive_errors += 1`),
+   - triggers **exponential backoff** (`backoff_until = now + base * 2^min(n,cap)`,
+     capped) so a hot-failing thread cannot spin,
+   - emits an error span/metric,
+   - **never** propagates — the daemon and sibling threads keep running.
+   OODA errors keep their **current** semantics (logged, cycle continues);
+   OODA is never backed-off (it is the daemon's reason to exist).
+5. **Graceful shutdown** — `run_due` checks `ctx.shutdown` between threads and
+   returns early; it coexists with the existing `interruptible_sleep` +
+   `shutdown_daemon` drain (checkpoint/close) unchanged. No thread holds the
+   loop past a shutdown request.
+6. **Telemetry** — every run opens span `simard.thread.<id>` and records the
+   per-thread metrics (§7). Health snapshots feed the dashboard heartbeat.
+
+The daemon integration is **minimal and additive**: build a `Mind`, register
+the threads, and replace the six inlined gate-blocks + the `run_ooda_cycle`
+call with a single `mind.run_due(&mut ctx)` at the same point in the loop. The
+outer `interruptible_sleep(interval_secs)` and `shutdown_daemon` stay exactly
+as they are.
+
+## 6. Fitting OODA in — the parity constraint (critical)
+
+`OodaThread` is the primary thread: `kind = Ooda`, `priority = Critical`,
+`policy = Interval(SIMARD_OODA_INTERVAL_SECS)`. Its `tick()` performs the exact
+current per-cycle work, in the same order:
+
+1. cycle-start heartbeat file write,
+2. `run_ooda_cycle(&mut state, &mut bridges, &config)`,
+3. on `Ok`: summarize, persist cycle report, persist episode to memory, write
+   health file, `self_metrics::collect_and_record_all(elapsed)`,
+4. on `Err`: `daemon_log` the error, continue (identical to today).
+
+Because the outer loop already sleeps `interval_secs` and OODA runs once per
+outer iteration, modelling OODA as `Interval(interval_secs)` and running it
+**every** `run_due` yields **byte-for-byte identical cadence and side-effects**.
+Parity is asserted by tests that drive N iterations through the `Mind` and
+compare cycle count, ordering, and emitted side-effects against the legacy
+path.
+
+State that the OODA cycle mutates (`OodaState`, `OodaBridges`, `config`) is
+owned by `OodaThread` (moved into it at daemon start), not the generic
+`ThreadContext` — only OODA needs it, and this keeps the trait clean.
+
+### Migrating the existing periodic tasks
+
+The six other hooks are **low-risk** to migrate onto the `Mind` because each
+already matches the trait shape. Plan:
+
+- Backup, disk-health, worktree-sweep → thin `CognitiveThread` wrappers of the
+  **existing** functions (no logic rewrite), `Priority::Low`, `Interval(...)`
+  from their current env vars. RSS/shed keeps its **every-iteration** cadence
+  (a thread due every tick, no interval env var). Behaviour-preserving.
+- Brain introspection (`brain_introspection::*`) and monthly self-audit
+  (`self_quality_audit::*`, **disk-persisted** last-run) → wrapped as threads;
+  the self-audit thread keeps the on-disk `LAST_RUN_FILENAME` gate (its
+  `next_run` is disk-backed, surviving restarts) instead of an in-memory
+  `last_run`. This proves the abstraction hosts persistent gates.
+
+If any wrapper proves risky under review, it stays inlined for this PR and is
+tracked as an explicit follow-up — the abstraction still lands with OODA +
+the two new exemplars. **Subsume, never duplicate.**
+
+## Persistence & data model (Step 5c determination — no relational database)
+
+**Determination: the cognitive-thread scheduler requires no relational
+database work.** No schema, no migrations, no indexes, no constraints, no
+referential integrity — because it introduces no entities-with-relationships
+that a table would model. Step 5c is *not applicable* in the relational sense;
+the durable-state design below is the file-based equivalent.
+
+**Grounding (verified against `origin/main`):**
+
+- The crate embeds SQLite (`rusqlite = { version = "=0.31.0", features =
+  ["bundled"] }`, `Cargo.toml:75`), but **exclusively for domain data
+  stores** — `cognitive_memory` (graph via `library_adapter`), `gym_history`,
+  and `native_knowledge`. Those tables are created inline with `CREATE TABLE`
+  in code; the repo has **no `migrations/` directory and no migration
+  framework**. Adding one for the scheduler would be a net-new subsystem the
+  design deliberately avoids.
+- Every daemon periodic-task's scheduling state is persisted as **flat files
+  under `state_root`**, never in a table: cycle reports
+  (`cycle_reports/cycle_<N>.json`, `operator_commands_ooda/persistence.rs`),
+  daemon health (`daemon_health.json`), and the monthly self-audit's last-run
+  epoch (`self_quality_audit_last_run`, a single integer via `read_last_run`
+  /`write_last_run`). Backups are snapshot directories under
+  `state_root/backups/<ts>/`.
+- The scheduler's reuse anchors — `cmd_cleanup`, `memory_backup`,
+  `stewardship`, `self_quality_audit`, `brain_introspection` — touch **no**
+  relational schema (verified: zero `rusqlite`/`CREATE TABLE` in those
+  modules). `EngineerLogAnalysisThread`'s durable artifact is a *deduplicated
+  GitHub issue* (`stewardship::gh_client`), not a DB row.
+
+**The data-model equivalent that IS required** — durable per-thread scheduling
+state that survives daemon restarts — is satisfied by the established
+file-based epoch-marker pattern (see §A.10), not a database:
+
+| Concern | Design (file-based, no DB) |
+|---|---|
+| "Schema" (on-disk record) | One plain-text file per **persistent-gate** thread under `state_root`, containing a single unix-epoch-seconds integer = last run. Reuses `self_quality_audit::{LAST_RUN_FILENAME, read_last_run, write_last_run, now_epoch_secs}` verbatim. Filename: `<thread_id>_last_run`; the self-audit thread keeps its existing `self_quality_audit_last_run` name for backward compatibility. |
+| Who persists | **Only** genuinely long-cadence gates (self-audit, ~30 d) opt in. All other threads keep `RunBudget` bookkeeping (`last_run`, `next_run`, `consecutive_errors`, `backoff_until`) **in memory**, intentionally reset on restart — identical to today's four `Instant`-gated hooks. An in-memory `Instant` is "fine at 24 h, wrong at 30 d." |
+| Constraints / integrity | Corrupt-tolerant read (absent/garbled marker → `None` → re-initialize to now; never crashes the loop); parent-dir auto-create on write; write on **both** `Ok` and `Err` to prevent a failing task hot-looping a full interval. These invariants are already implemented and unit-tested in `self_quality_audit`. |
+| Relationships | **None.** Each marker is an independent flat file keyed by thread id — a degenerate key→scalar map on the filesystem. No joins, ordering, or foreign keys. |
+| Indexes | **None / not applicable.** Direct path lookup by thread id; no query surface to index. |
+| Migrations | **None.** Markers are additive files with no schema version; a first run with no file self-initializes to now. No `ALTER`, no forward/backward migration, no downtime. The existing `self_quality_audit_last_run` file is preserved (no rename), so shipping the scheduler is a **zero-migration** change. |
+
+**Conclusion:** skip relational schema/migrations/indexes for this feature. The
+durable-state contract is the per-thread epoch marker above — already prototyped
+and tested by `self_quality_audit`, specified as the §A.10 persistent-gate
+contract, and requiring no changes to the existing SQLite domain stores.
+
+## 7. Observability contract (STRICT)
+
+- **No `println!`/`eprintln!`/`print!` in any new code.** Structured `tracing`
+  events + spans and OTel metrics only. (Existing `daemon_log`/`eprintln!` in
+  untouched code is out of scope — that is the parallel logging workstream's
+  purge; new code must not add to it.)
+- **Telemetry facade coordination:** `src/telemetry/` (unified OTel
+  `MeterProvider`, names `simard.<area>.<name>`) is **not yet on this base**.
+  All metric emission is centralized behind `cognitive_threads::telemetry`
+  (one small helper), so rebasing onto the facade is a single-file change.
+  Until then the helper emits via `tracing` structured fields (and OTel
+  counters/histograms if a global meter is present).
+- **Per-thread metrics** (consistent, facade-ready names):
+  - `simard.thread.<id>.runs` — counter
+  - `simard.thread.<id>.errors` — counter
+  - `simard.thread.<id>.duration_seconds` — histogram
+  - `simard.thread.<id>.next_run_epoch` — gauge
+  - `simard.thread.<id>.active` — gauge (1 while ticking)
+- **Spans:** every run opens `simard.thread.<id>` with fields
+  `outcome`, `success`, `duration_ms`, `ran`, plus thread-specific detail.
+- **Minimal edits at OODA/daemon signal sites** — scheduling integration only;
+  the repo-wide print purge is left to the dedicated logging workstream.
+
+## 8. Exemplar 1 — `MaintenanceThread` (SAFE cleanup)
+
+`kind = Maintenance`, `priority = Low`, `policy = Interval(...)` from
+`SIMARD_MAINTENANCE_INTERVAL_SECS` (slow cadence, e.g. daily).
+
+Reuses **existing** helpers (no reimplementation):
+
+| Task | Existing helper |
+| --- | --- |
+| Prune old `cognitive.corrupt-*` dirs | `cmd_cleanup::disk::remove_old_corrupt_dbs` |
+| Trim old store snapshots / shadow WAL copies | `cmd_cleanup::disk::trim_simard_snapshots` |
+| Rotate stale binary backups | `cmd_cleanup::disk::rotate_simard_binary_backups` |
+| Cap runaway target dirs | `cmd_cleanup::disk::cap_simard_target_dirs` |
+| Verify + prune verified backups (retention) | `memory_backup::{list_backups, ensure_backup_valid, prune_old_backups}` |
+| Report disk pressure | `disk_pressure::check_with_default_threshold` |
+
+**Safety (conservative by construction):**
+- **Never** deletes protected paths: `worktrees/main`, `~/.simard/repo`, the
+  **live** cognitive store, or any engineer worktree. An explicit deny-list +
+  allow-list gate every path; anything not on the allow-list is skipped.
+- Honours `ThreadContext.dry_run` (env `SIMARD_MAINTENANCE_DRY_RUN`): logs the
+  actions it *would* take, deletes nothing.
+- Retention counts (how many corrupt/snapshot/backup copies to keep) are
+  env-configurable with safe defaults; always keeps ≥ N most-recent.
+- Every action is emitted as **structured telemetry** (path, bytes freed,
+  kept/pruned counts) — never a snapshot doc.
+
+## 9. Exemplar 2 — `EngineerLogAnalysisThread` (improvement finder)
+
+`kind = EngineerLogAnalysis`, `priority = Low`, `policy = Interval(...)` from
+`SIMARD_ENGINEER_LOG_ANALYSIS_INTERVAL_SECS`.
+
+**Inputs (durable telemetry already written under `state_root`):** persisted
+cycle reports (`persist_cycle_report`), self-metrics (`self_metrics`), cost
+records (`cost_tracking`), and brain/parse telemetry. It scans **recent** data
+only (bounded window + bounded record count → bounded cost).
+
+**Signals it looks for:** recurring engineer failures, stuck/looping patterns,
+brain parse-failure spikes, restart churn, distill failure-rate, repeated CI
+failure modes.
+
+**Durable output (operator rule — artifacts are GitHub issues or durable code,
+never repo snapshot docs):** produces a **deduplicated GitHub issue** via the
+**existing deterministic** stewardship path (the same code-level dedup
+`stewardship::process_orchestrator_run` uses — *not* the heavier agentic-recipe
+path `brain_introspection` delegates to):
+- `stewardship::dedup::{normalize, failure_signature, find_existing}` to build a
+  stable signature and detect an existing **open** issue carrying it,
+- `stewardship::gh_client::{GhClient, GhIssue, RealGhClient}` to search + create.
+
+The `GhClient` trait exposes exactly `search_issues(repo, signature)` and
+`create_issue(repo, title, body)` — **there is no update/comment op**. Dedup is
+therefore *create-suppression*: embed `stewardship-signature:<sig>` in the body,
+`search_issues` → `find_existing`; create **only** when no open issue with the
+signature exists, otherwise it is a no-op (structured telemetry only). When
+issue filing is unavailable (no `gh`/offline/tests), it degrades to **structured
+telemetry only** — never a committed file. The `Box<dyn GhClient>` seam lets
+tests inject a fake client (fixture-driven, no network).
+
+**Bounding:** hard caps on records scanned, findings emitted, and at most one
+issue create/update per run.
+
+## 10. Ambiguity resolution (decisive)
+
+| Question | Resolution |
+| --- | --- |
+| `async tick()` vs sync? | **Sync** trait + sync `Mind`; async work via `ctx.runtime.block_on`. The daemon's top-level loop is synchronous and correctness-critical; an async top-level loop is out of scope. Async-`Mind` reserved as additive future. |
+| Module name? | `src/cognitive_threads/` (not `mind/`). No `Bridge` anywhere. Scheduler type is `Mind`. |
+| Reuse or fork `ooda_scheduler`? | **Neither** — it is the engineer action-slot scheduler; leave untouched. New module is independent. |
+| Migrate the 6 existing periodic hooks now? | **Yes, if low-risk** as behaviour-preserving wrappers (incl. disk-persisted self-audit gate). Any risky one stays inlined + explicit follow-up. Subsume, don't duplicate. |
+| Migrate `memory_consolidation` / rewrite it? | **No.** Reserved `ThreadKind::MemoryConsolidation`; the `Mind` can host it later. Not rewritten here. |
+| How does OODA keep exact cadence? | `Interval(SIMARD_OODA_INTERVAL_SECS)`, `Priority::Critical`, run every `run_due`, outer loop still sleeps `interval_secs`. Parity tests assert identical cadence/side-effects. |
+| Concurrency model? | Cooperative, single-threaded scheduler tick (matches today). "Concurrency budget" = per-tick cap on **non-critical** threads; OODA is exempt and never starved. Engineer concurrency (AIMD / `SIMARD_MAX_CONCURRENT_ACTIONS`) is untouched. |
+| Telemetry facade dependency? | Not present on base → centralize emission behind one helper, emit via `tracing` + OTel-if-present, use the `simard.thread.<id>.*` names so rebase is one file. |
+| Where do maintenance/analysis findings go? | Maintenance → structured telemetry. Analysis → dedup'd GitHub issue via stewardship (fallback: telemetry). **No repo snapshot docs.** |
+| Safety of cleanup? | Allow-list + deny-list of protected paths, `dry_run` switch, retention floors, structured audit of every action. |
+
+## Security requirements (Step 5d review)
+
+**Determination: the scheduler introduces no new network endpoint, no new
+third-party crate, and no new privilege — but it does add two new
+*tainted-data → privileged-action* paths (engineer logs → public GitHub issue;
+timer → destructive filesystem delete). The requirements below make those two
+paths safe by construction and reuse the crate's existing hardening.**
+
+### Threat model (trust boundaries & assets)
+
+- **Principal / authority.** The daemon runs as the operator user with (a) full
+  local filesystem authority over `~/.simard`, worktrees, and cargo target
+  dirs, and (b) **ambient GitHub credentials** via the `gh` CLI. Every
+  `CognitiveThread` inherits that authority — the `ThreadContext` least-authority
+  seam (§4) is the primary containment boundary.
+- **Untrusted input (taint source).** Engineer log / telemetry content
+  (`cycle_reports`, `self_metrics`, `cost_tracking`, brain/parse telemetry). The
+  adversary model is a *misbehaving or compromised engineer agent* (or malformed
+  tool output) that controls the bytes `EngineerLogAnalysisThread` reads.
+- **Assets to protect.** (1) Integrity/availability of the **live cognitive
+  store** and protected paths; (2) **GitHub credentials**; (3) **confidentiality
+  of secrets** that may appear in logs; (4) **availability of the OODA cycle**
+  (never starved); (5) integrity of the dedup / issue-filing channel.
+
+### Requirements
+
+| ID | Requirement | Control / reuse anchor | Verified state |
+| --- | --- | --- | --- |
+| **SR-1** | **No shell interpretation.** Every subprocess call MUST use a `Command::args([...])` argv array — never `sh -c`, never string interpolation of tainted data into a command line. | argv-only exec. | `RealGhClient` already does this (`gh_client.rs`); new code must add no shell layer. Grep-guard `sh -c`. |
+| **SR-2** | **Redact secrets before any excerpt leaves the process.** Every log excerpt placed in an issue title/body **or** a telemetry field MUST pass through the crate's secret scrubber first. `dedup::normalize` strips ANSI **for the signature only** and is *not* sufficient for display content. | `sanitization::sanitize_terminal_text` (strips terminal control **and** redacts `token=`/`Authorization:`/`_secret`/`_token`/… lines → `[REDACTED]`). | `src/sanitization.rs:60`. Prevents exfiltrating engineer-log secrets into a GitHub issue (broader audience than a local log). |
+| **SR-3** | **Neutralize markdown / mention / dedup-poison injection.** Untrusted excerpts MUST be fenced in a code block and MUST NOT emit GitHub `@mentions`, `#refs`/auto-links (notification & cross-link spam), nor smuggle a `stewardship-signature:` line that poisons dedup. The trusted signature marker lives in a controlled, delimited location; matching relies on the **server-side** `--search "stewardship-signature:<sig> in:body"` query, not a client-side scan of arbitrary bodies. | Fence + escape leading `@`/`#`; controlled marker placement. | `gh_client::search_issues` already searches server-side (`gh_client.rs`). |
+| **SR-4** | **Argument-injection hardening for `gh`.** Tainted title/body MUST NOT be interpretable as `gh` options. Values are passed as dedicated argv elements (consumed as option-arguments), and large/at-risk bodies SHOULD use `--body-file -` (stdin) as defense-in-depth. | argv positioning; optional stdin body. | Low residual risk; review-gated. |
+| **SR-5** | **Destructive-op path safety (MaintenanceThread).** Before any `remove_dir_all`/`remove_file`, the target MUST be (a) matched against an **allow-list of canonicalized absolute roots** (not filename-prefix only); (b) rejected if it **is a symlink** or falls outside the allowed root after `fs::canonicalize` (defeats `..`/symlink traversal and the TOCTOU where a symlink is swapped in before delete); (c) checked against the deny-list (`worktrees/main`, `~/.simard/repo`, live store, engineer worktrees). | Canonical allow/deny gate **in the thread**, wrapping the reused helpers. | ⚠ `cmd_cleanup::disk` gates by **filename prefix** with **no** `symlink_metadata`/`canonicalize`/`is_symlink` guard (verified: zero occurrences in `disk.rs`). The thread MUST add this gate itself and MUST refuse to `remove_dir_all` a path whose `symlink_metadata` is a symlink. |
+| **SR-6** | **Never delete the live store.** The candidate path MUST be asserted `!=` the active cognitive-store path (and its shadow/WAL) reachable via `ThreadContext.memory`. | Runtime equality assert (belt-and-suspenders with the SR-5 deny-list). | New check in the thread. |
+| **SR-7** | **Conservative default posture.** Global `dry_run` honored (`SIMARD_MAINTENANCE_DRY_RUN`); retention **floors** (always keep ≥ N newest) enforced *before* any prune; destructive maintenance ships **dry-run-first / opt-in** until validated in production. Availability > reclaimed bytes. | `ThreadContext.dry_run` + env retention floors. | Design §8. |
+| **SR-8** | **Resource-exhaustion / DoS bounds.** (a) `Mind` caps non-critical fan-out per tick and keeps OODA `Critical`/exempt so no thread flood starves the control loop; (b) `catch_unwind` + **capped** exponential backoff stops a hot-failing thread pinning a core; (c) interval env vars are clamped to a **minimum floor** (reject/normalize `0`/negative) so a hostile/misconfigured env can't make a thread due every tick; (d) `EngineerLogAnalysis` enforces record/window/finding caps **before** reading and ≤ 1 `create_issue` per run. | §5 budget + backoff; interval clamp; scan caps. | Budget/backoff in §5; add interval-floor clamp + pre-read caps. |
+| **SR-9** | **Least authority.** Threads receive only borrowed, scoped resources via `ThreadContext` and MUST NOT reach globals. The two new threads MUST have **no** code path to `self_deploy`/`self_relaunch`/redeploy. `GhClient` is injected as `Box<dyn GhClient>` (fake in tests → no network, no credentials). | `ThreadContext` seam (§4); trait-object `GhClient`. | ✅ Verified: none of `cmd_cleanup`, `memory_backup`, `stewardship`, `disk_pressure` reference `self_deploy`/`self_relaunch`/`redeploy`. |
+| **SR-10** | **Credential confidentiality.** New code MUST NOT read, log, embed in an issue body, or emit to telemetry any token/`GH_TOKEN`. Error strings may include `gh` stderr (gh prints no tokens) but MUST NOT be augmented with env dumps. | No secret in fields/bodies/errors. | `gh` auth stays ambient in the CLI. |
+| **SR-11** | **Telemetry integrity (no metric-cardinality injection).** Metric/span **names** use the fixed `simard.thread.<id>` scheme where `<id>` is a per-thread compile-time constant — never derived from untrusted input. Untrusted content appears only as **length-bounded structured field values**, never as a format-string arg (no log forging) and never as a name. | Constant ids; bounded structured fields. | Design §7. |
+| **SR-12** | **Trigger authenticity.** `OnDemand`/`EventDriven` due-ness MUST originate from the internal operator/event channel (in-process flag/predicate on `ThreadContext`), not attacker-influenceable external input. Blast radius of a spurious trigger is bounded by SR-8. | Internal-only trigger source. | Design §4/§5. |
+
+### Residual & accepted risks
+
+- **Ambient `gh` trust.** The issue path trusts the operator's `gh` auth and
+  network; compromise of `gh`/the network is pre-existing and out of scope
+  (unchanged by this feature).
+- **Reused prefix-matching retained.** Per *subsume-don't-duplicate*, the
+  filename-prefix logic inside `cmd_cleanup::disk` is **not** rewritten here;
+  SR-5's canonical allow/deny + symlink-refusal gate **wraps** those helpers.
+  Hardening `cmd_cleanup::disk` itself (symlink refusal at the source) is a
+  tracked follow-up, not a blocker for this PR.
+- **No new attack surface otherwise.** No new crates, no new network endpoints;
+  the only external process remains the existing `gh` invocation.
+
+## 11. Hard constraints honoured
+
+- **Additive & non-breaking:** OODA cadence, engineer spawning, memory writes,
+  self-deploy, self-relaunch, and graceful shutdown all preserved; wrap over
+  replace. Parity tests guard it.
+- **Do not touch** the live daemon, `~/.simard`, `worktrees/main`, or any
+  engineer worktree. Branch off `origin/main`. **No redeploy** — operator
+  deploys.
+- **No `Bridge`** in new names.
+- **Minimal edits** at OODA/daemon signal sites; leave the repo-wide print
+  purge to the logging workstream.
+
+## 12. Test plan (fixtures, no network, no sleeps)
+
+- `schedule.rs` — `is_due` / `next_run` for `Interval`, `OnDemand`,
+  `EventDriven`, `Adaptive` against injected clocks.
+- `mind.rs` — **failure isolation**: a panicking/erroring fake thread is
+  caught, backed off, and does **not** stop OODA or siblings; **priority
+  budget**: OODA runs every tick and is never starved by a flood of due
+  non-critical threads.
+- **OODA-as-thread parity**: N iterations through the `Mind` produce the same
+  cycle count/order/side-effects as the legacy inline path (fake OODA cycle).
+- `MaintenanceThread` — fixture `~/.simard` tree: prunes only allow-listed
+  stale artifacts, **never** protected paths, honours `dry_run`, respects
+  retention floors.
+- `EngineerLogAnalysisThread` — fixture logs/telemetry: detects seeded
+  recurring failure, files exactly one dedup'd issue via a **fake** `GhClient`,
+  is idempotent on re-run (second run's `search_issues` returns the existing
+  open issue → `find_existing` hits → **no second `create_issue`**), degrades to
+  telemetry when the client is absent.
+- **Security (Step 5d) fixtures:**
+  - *Secret/injection scrub (SR-2/3)* — a seeded log line containing
+    `token=SECRET`, `@here`, `#1`, and a spoofed `stewardship-signature: deadbeef`
+    → asserts the emitted body has `[REDACTED]` (no secret), the mention/ref are
+    neutralized (fenced, no auto-link), and dedup uses **our** computed signature
+    (the spoofed marker neither suppresses the create nor causes a second one).
+  - *Path safety (SR-5/6)* — a symlink placed inside the fixture `~/.simard`
+    pointing at a protected path is **refused** (never followed or removed); a
+    `..`-escaping candidate is rejected by the canonical allow-list; the live
+    store path is never a delete candidate; retention floor keeps ≥ N newest.
+  - *DoS bounds (SR-8)* — `*_INTERVAL_SECS=0` clamps to the minimum floor (thread
+    is **not** due every tick); a flood of due non-critical threads cannot delay
+    the OODA cycle (cross-references the §5 priority-budget parity test).
+
+## 13. Deliverables for the implementation phase
+
+Design doc (this file) → implementation (`src/cognitive_threads/` + minimal
+daemon integration) → tests (above) → how-to doc + this reference doc + mkdocs
+nav entry → single merge-ready PR against `rysweet/Simard` off `origin/main`,
+green CI, no redeploy.
+
+---
+
+## Appendix A — API Contracts (the "studs")
+
+This appendix pins the **exact public surface** the implementation must expose
+and the **exact upstream signatures** it calls. Every signature below was
+verified against the current tree; the implementer must not drift from them.
+Anything not listed here is a private implementation detail.
+
+### A.1 Public module surface — `src/cognitive_threads/mod.rs`
+
+```rust
+//! Cognitive-thread scheduling: a `Mind` runs many `CognitiveThread`s on
+//! their own cadence/trigger. See docs/reference/cognitive-thread-scheduling.md.
+
+mod schedule;
+mod thread;
+mod mind;
+mod telemetry;
+pub mod threads;
+#[cfg(test)]
+mod tests;
+
+pub use mind::Mind;
+pub use thread::{
+    CognitiveThread, Priority, SchedulePolicy, ThreadContext, ThreadHealth,
+    ThreadKind, ThreadOutcome,
+};
+pub use threads::{EngineerLogAnalysisThread, MaintenanceThread, OodaThread};
+```
+
+Registered in `src/lib.rs` as `pub mod cognitive_threads;` (sibling of
+`ooda_scheduler`). No `Bridge` in any name.
+
+### A.2 `CognitiveThread` trait (object-safe)
+
+Object-safe: the `Mind` stores `Box<dyn CognitiveThread>`. `Send` (not `Sync`)
+— the scheduler ticks threads sequentially on one thread; `Send` only supports
+moving a thread into the `Mind` at registration.
+
+```rust
+pub trait CognitiveThread: Send {
+    fn id(&self) -> &str;                       // stable snake_case; telemetry key
+    fn name(&self) -> &str { self.id() }
+    fn kind(&self) -> ThreadKind;
+    fn policy(&self) -> SchedulePolicy;
+    fn priority(&self) -> Priority { Priority::Normal }
+    fn enabled(&self) -> bool { true }
+    fn tick(&mut self, ctx: &mut ThreadContext<'_>) -> ThreadOutcome;
+    fn health(&self) -> ThreadHealth;
+}
+```
+
+### A.3 Supporting types (derives are part of the contract)
+
+```rust
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize)]
+pub enum ThreadKind {
+    Ooda, Maintenance, EngineerLogAnalysis,
+    // reserved (hosted later, not implemented in this PR):
+    BackgroundThought, MemoryConsolidation, SensoryProcessing, LongTermPlanning,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum SchedulePolicy {
+    Interval(std::time::Duration),
+    OnDemand,
+    EventDriven,
+    Adaptive { min: std::time::Duration, max: std::time::Duration, current: std::time::Duration },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, serde::Serialize)]
+pub enum Priority { Critical, High, Normal, Low } // Ord: Critical < High < Normal < Low
+                                                  // (sort ascending ⇒ Critical/OODA first)
+
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ThreadOutcome {
+    pub ran: bool,
+    pub success: bool,
+    pub summary: String,
+    pub duration: std::time::Duration,
+    pub detail: serde_json::Value,
+}
+impl ThreadOutcome {
+    pub fn skipped() -> Self;                          // ran=false, success=true, empty
+    pub fn ok(summary: impl Into<String>, duration: std::time::Duration) -> Self;
+    pub fn failed(summary: impl Into<String>, duration: std::time::Duration) -> Self;
+    pub fn with_detail(self, detail: serde_json::Value) -> Self;
+}
+
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ThreadHealth {
+    pub id: String,
+    pub enabled: bool,
+    pub last_run_epoch: Option<u64>,
+    pub next_run_epoch: Option<u64>,
+    pub last_success: Option<bool>,
+    pub consecutive_errors: u32,
+    pub backoff_until_epoch: Option<u64>,
+}
+```
+
+`ThreadContext<'a>` — borrowed daemon resources; no globals. `now_epoch` is an
+**injected** clock so due-computation and backoff are unit-testable with no
+sleeps.
+
+```rust
+pub struct ThreadContext<'a> {
+    pub state_root: &'a std::path::Path,
+    pub repo_root: &'a std::path::Path,
+    pub memory: &'a dyn crate::cognitive_memory::CognitiveMemoryOps, // : Send + Sync
+    pub runtime: tokio::runtime::Handle,
+    pub shutdown: &'a std::sync::atomic::AtomicBool,
+    pub now_epoch: u64,
+    pub dry_run: bool,
+}
+```
+
+### A.4 `schedule.rs` — pure, injected-clock functions (fully unit-tested)
+
+```rust
+/// `None` last_run ⇒ Interval/Adaptive are due immediately; OnDemand/EventDriven never auto-due.
+pub fn is_due(policy: &SchedulePolicy, last_run_epoch: Option<u64>, now_epoch: u64) -> bool;
+
+/// `None` ⇒ no scheduled next run (OnDemand/EventDriven). Interval/Adaptive ⇒ Some(last + interval).
+pub fn next_run_epoch(policy: &SchedulePolicy, last_run_epoch: Option<u64>, now_epoch: u64) -> Option<u64>;
+
+/// Exponential backoff, saturating & capped: now + min(base * 2^min(errors,shift_cap), cap).
+pub fn backoff_until_epoch(
+    now_epoch: u64,
+    consecutive_errors: u32,
+    base: std::time::Duration,
+    cap: std::time::Duration,
+) -> u64;
+```
+
+### A.5 `Mind` (the Scheduler) — public API
+
+```rust
+pub struct Mind { /* threads: Vec<ThreadEntry>, budget: RunBudget (both private) */ }
+
+impl Mind {
+    pub fn new() -> Self;                                  // budget from env, default 2
+    pub fn with_budget(max_noncritical_per_tick: usize) -> Self;
+    pub fn register(&mut self, thread: Box<dyn CognitiveThread>) -> &mut Self; // chainable
+
+    /// Pure: indices (registration order) of enabled, non-backed-off, due threads.
+    pub fn due_threads(&self, now_epoch: u64) -> Vec<usize>;
+
+    /// Run OODA (Priority::Critical) first & unconditionally (budget-exempt, never
+    /// backed off), then non-critical due threads in Priority order up to the
+    /// per-tick budget. Each tick is wrapped in catch_unwind; a panic/Err bumps
+    /// consecutive_errors, sets backoff, emits an error metric, and never
+    /// propagates. Checks `ctx.shutdown` between threads and returns early.
+    pub fn run_due(&mut self, ctx: &mut ThreadContext<'_>) -> Vec<ThreadOutcome>;
+
+    pub fn health(&self) -> Vec<ThreadHealth>;             // dashboard heartbeat feed
+    pub fn len(&self) -> usize;
+    pub fn is_empty(&self) -> bool;
+}
+impl Default for Mind { fn default() -> Self { Self::new() } }
+```
+
+Budget env: `SIMARD_MIND_MAX_NONCRITICAL_PER_TICK` (default 2). `ThreadEntry`,
+`RunBudget` are **private** bookkeeping (`last_run`, `next_run`,
+`consecutive_errors`, `backoff_until`).
+
+### A.6 `telemetry.rs` — the single facade-rebase seam
+
+One small helper; the **only** place metrics/spans are emitted, so a later
+rebase onto `src/telemetry/` is a one-file change. No `println!`/`eprintln!`.
+
+```rust
+/// Opens span `simard.thread.<id>` with fields ran/success/duration_ms + detail,
+/// and records runs / duration_seconds counters+histogram.
+pub fn record_run(id: &str, outcome: &ThreadOutcome);
+/// Bumps `simard.thread.<id>.errors` and emits an error-level structured event.
+pub fn record_error(id: &str, reason: &str);
+/// Sets the `simard.thread.<id>.next_run_epoch` gauge.
+pub fn record_next_run(id: &str, next_run_epoch: Option<u64>);
+/// RAII guard: sets `simard.thread.<id>.active` gauge to 1, back to 0 on drop.
+pub fn enter_active(id: &str) -> ActiveGuard;
+pub struct ActiveGuard { /* private */ }
+```
+
+Emitted names (facade-ready): `simard.thread.<id>.{runs, errors,
+duration_seconds, next_run_epoch, active}`.
+
+### A.7 Thread constructors — `src/cognitive_threads/threads/`
+
+```rust
+// ooda.rs — owns the mutable OODA state (moved in at daemon start).
+pub struct OodaThread { /* state, bridges, config, interval_secs, health (private) */ }
+impl OodaThread {
+    pub fn new(
+        state: crate::ooda_loop::OodaState,
+        bridges: crate::ooda_loop::OodaBridges,
+        config: crate::ooda_loop::OodaConfig,
+        interval_secs: u64,
+    ) -> Self;
+}
+// policy() = Interval(interval_secs); priority() = Critical; enabled() = true.
+
+// maintenance.rs
+pub struct MaintenanceConfig {
+    pub interval_secs: u64,   // SIMARD_MAINTENANCE_INTERVAL_SECS (default: daily)
+    pub keep_corrupt: usize,  // retention floors (≥1)
+    pub keep_snapshots: usize,
+    pub keep_backups: usize,
+    pub target_cap_bytes: u64,
+    pub dry_run: bool,        // SIMARD_MAINTENANCE_DRY_RUN
+}
+impl Default for MaintenanceConfig { /* safe defaults, floors ≥ 1 */ }
+pub struct MaintenanceThread { /* cfg, health (private) */ }
+impl MaintenanceThread {
+    pub fn from_env() -> Self;                 // reads env, safe defaults
+    pub fn new(cfg: MaintenanceConfig) -> Self;
+}
+// policy() = Interval(cfg.interval_secs); priority() = Low.
+
+// engineer_log_analysis.rs
+pub struct EngineerLogAnalysisConfig {
+    pub interval_secs: u64,   // SIMARD_ENGINEER_LOG_ANALYSIS_INTERVAL_SECS
+    pub repo: String,         // "rysweet/Simard"
+    pub window_secs: u64,     // bounded scan window
+    pub max_records: usize,   // hard cap on records scanned
+    pub max_findings: usize,  // hard cap on findings emitted
+    pub dry_run: bool,        // suppress issue creation; telemetry only
+}
+impl Default for EngineerLogAnalysisConfig { /* safe bounded defaults */ }
+pub struct EngineerLogAnalysisThread { /* cfg, gh: Box<dyn GhClient>, health (private) */ }
+impl EngineerLogAnalysisThread {
+    pub fn from_env() -> Self;   // uses stewardship::gh_client::RealGhClient
+    pub fn with_client(          // test seam: inject a fake GhClient
+        cfg: EngineerLogAnalysisConfig,
+        gh: Box<dyn crate::stewardship::gh_client::GhClient>,
+    ) -> Self;
+}
+// policy() = Interval(cfg.interval_secs); priority() = Low.
+```
+
+### A.8 Reuse-anchor call contracts (verified upstream signatures — do not drift)
+
+**`MaintenanceThread::tick` calls (all behaviour-preserving, no re-impl):**
+
+```rust
+// cmd_cleanup::disk — mutate a shared CleanupReport accumulator:
+cmd_cleanup::disk::remove_old_corrupt_dbs(&mut CleanupReport);
+cmd_cleanup::disk::trim_simard_snapshots(&mut CleanupReport);
+cmd_cleanup::disk::rotate_simard_binary_backups(&mut CleanupReport);
+cmd_cleanup::disk::cap_simard_target_dirs(&mut CleanupReport, cap_bytes: u64);
+cmd_cleanup::disk::dir_size(&Path) -> std::io::Result<u64>;
+// memory_backup — retention:
+memory_backup::list_backups(&BackupConfig) -> SimardResult<Vec<BackupVerification>>;
+memory_backup::ensure_backup_valid(&Path)  -> SimardResult<BackupManifest>;
+memory_backup::prune_old_backups(&BackupConfig) -> SimardResult<usize>;
+// disk_pressure — reporting only:
+disk_pressure::check_with_default_threshold(&Path) -> Result<DiskPressureReport, std::io::Error>;
+```
+
+The thread builds one `CleanupReport`, runs the allow-listed steps into it, then
+reports its accumulated totals as **structured telemetry** (§7). `dry_run`
+short-circuits every deleting call.
+
+**`EngineerLogAnalysisThread::tick` calls (deterministic dedup path):**
+
+```rust
+stewardship::dedup::failure_signature(failure_kind: &str, error_text: &str) -> String;
+stewardship::dedup::normalize(msg: &str) -> String;
+stewardship::dedup::find_existing<'a>(&'a [GhIssue], signature: &str) -> Option<&'a GhIssue>;
+// GhClient trait — search + create ONLY (no update/comment):
+GhClient::search_issues(&self, repo: &str, signature: &str) -> SimardResult<Vec<GhIssue>>;
+GhClient::create_issue(&self, repo: &str, title: &str, body: &str) -> SimardResult<GhIssue>;
+```
+
+Contract: embed `stewardship-signature:<sig>` in the issue body (this is exactly
+what `RealGhClient::search_issues` greps for); `search_issues` → `find_existing`;
+call `create_issue` **iff** `find_existing` returned `None` and `!dry_run`.
+`GhIssue { number: u64, url: String, title: String, body: String }`.
+
+### A.9 Daemon integration seam — `src/operator_commands_ooda/daemon/mod.rs`
+
+Additive, minimal, at the **same point** in the outer loop. The six inlined
+gate-blocks + the `run_ooda_cycle(...)` call collapse to one `mind.run_due`.
+
+*Before start of loop (setup):*
+
+```rust
+let mut mind = Mind::new();
+mind.register(Box::new(OodaThread::new(state, bridges, config, interval_secs)))
+    .register(Box::new(MaintenanceThread::from_env()))
+    .register(Box::new(EngineerLogAnalysisThread::from_env()));
+// (behaviour-preserving wrappers for backup / disk-health / RSS / worktree-sweep
+//  / brain-introspection / self-audit may also be registered here — see §6.)
+```
+
+*Inside the loop (replaces the inlined gates + the `run_ooda_cycle` match):*
+
+```rust
+let now_epoch = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
+let mut ctx = ThreadContext {
+    state_root: &state_root,
+    repo_root: &repo_root,
+    memory: &*shared_mem,
+    runtime: runtime.handle().clone(),
+    shutdown: &shutdown,
+    now_epoch,
+    dry_run: global_dry_run,
+};
+let _outcomes = mind.run_due(&mut ctx);
+```
+
+The trailing `interruptible_sleep(interval_secs, &shutdown)` and
+`shutdown_daemon(...)` drain are **unchanged**. `OodaState`/`OodaBridges`/
+`OodaConfig` move **into** `OodaThread` (only OODA needs them), keeping
+`ThreadContext` generic. Parity tests (§6, §12) assert identical cycle
+count/order/side-effects vs. the legacy path.
+
+### A.10 Persistent-gate contract (optional migrated self-audit thread)
+
+The disk-persisted monthly gate is representable without changing the trait: the
+thread returns `policy() = Interval(interval)` but derives its effective
+`next_run` from the on-disk epoch via the **existing** helpers, so it survives
+restarts (an in-memory `last_run` would reset on reboot):
+
+```rust
+self_quality_audit::interval_secs_from_env(raw: Option<&str>) -> u64;
+self_quality_audit::should_run_self_audit(elapsed: Duration, interval_secs: u64) -> bool;
+self_quality_audit::now_epoch_secs() -> u64;
+self_quality_audit::read_last_run(path: &Path) -> Option<u64>;
+self_quality_audit::write_last_run(path: &Path, epoch_secs: u64) -> std::io::Result<()>;
+self_quality_audit::LAST_RUN_FILENAME: &str;   // gate file under state_root
+```
+
+Write last-run on **both** `Ok` and `Err` (prevents a failing recipe from
+hot-looping a full interval), exactly as the current inlined gate does.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -140,6 +140,7 @@ nav:
     - Recipe-brain Verdict/Decision Parsing: reference/recipe-brain-verdict-parsing.md
     - Distill Raw-Capture on Parse Failure: reference/distill-raw-capture-on-parse-failure.md
     - OODA Binary-Identity Reload Gate: reference/ooda-binary-identity-reload-gate.md
+    - Cognitive-Thread Scheduling: reference/cognitive-thread-scheduling.md
     # Hidden from nav until issue #1590 implementation lands:
     #   - reference/cognitive-memory-bridge-helpers.md
     #   - reference/goal-board-api.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,6 +102,8 @@ nav:
     - Diagnose merge-pr Verdict-Parse Failures: howto/diagnose-merge-pr-verdict-parse-failures.md
     - Inspect the Procedural-Learning Loop: howto/inspect-the-procedural-learning-loop.md
     - Capture and Diagnose a Failing Distill Sample: howto/capture-and-diagnose-a-failing-distill-sample.md
+    - Configure Cognitive-Thread Scheduling: howto/configure-cognitive-thread-scheduling.md
+    - Add a New Cognitive Thread: howto/add-a-new-cognitive-thread.md
   - Reference:
     - CLI Reference: reference/simard-cli.md
     - Self-Deploy API: reference/self-deploy-api.md

--- a/src/cmd_cleanup/mod.rs
+++ b/src/cmd_cleanup/mod.rs
@@ -149,7 +149,7 @@ fn kill_orphaned_cargo_processes(report: &mut CleanupReport) {
 }
 
 /// Recursively compute directory size in bytes.
-mod disk;
+pub(crate) mod disk;
 // re-exported for cfg(test) consumers in cmd_cleanup/tests.rs (false-positive of clippy unused_imports on lib pass — see #1405)
 #[allow(unused_imports)]
 pub(crate) use disk::{

--- a/src/cognitive_threads/mind.rs
+++ b/src/cognitive_threads/mind.rs
@@ -1,0 +1,113 @@
+//! The [`Mind`] — the cognitive-thread scheduler (Appendix A.5).
+//!
+//! Owns a registry of threads, computes which are due, and runs them under a
+//! priority budget that never starves OODA. Failure isolation, backoff, and
+//! graceful shutdown live in [`Mind::run_due`], whose body is a `todo!()`
+//! stub during TDD; the registry/bookkeeping surface is real so the tests in
+//! `super::tests` can build a `Mind` and register fakes.
+#![allow(dead_code, unused_variables)]
+
+use super::thread::{CognitiveThread, ThreadContext, ThreadHealth, ThreadOutcome};
+
+/// Env var controlling the per-tick non-critical fan-out budget.
+const BUDGET_ENV: &str = "SIMARD_MIND_MAX_NONCRITICAL_PER_TICK";
+/// Default non-critical fan-out per tick when the env var is unset/invalid.
+const DEFAULT_BUDGET: usize = 2;
+
+/// Per-thread runtime bookkeeping held alongside the boxed thread.
+struct ThreadEntry {
+    thread: Box<dyn CognitiveThread>,
+    last_run: Option<u64>,
+    next_run: Option<u64>,
+    consecutive_errors: u32,
+    backoff_until: Option<u64>,
+}
+
+impl ThreadEntry {
+    fn new(thread: Box<dyn CognitiveThread>) -> Self {
+        Self {
+            thread,
+            last_run: None,
+            next_run: None,
+            consecutive_errors: 0,
+            backoff_until: None,
+        }
+    }
+}
+
+/// Per-tick run budget for non-critical threads (OODA is exempt).
+struct RunBudget {
+    max_noncritical_per_tick: usize,
+}
+
+/// The cognitive-thread scheduler.
+pub struct Mind {
+    threads: Vec<ThreadEntry>,
+    budget: RunBudget,
+}
+
+impl Mind {
+    /// Build a `Mind` with the budget read from [`BUDGET_ENV`] (default
+    /// [`DEFAULT_BUDGET`]).
+    pub fn new() -> Self {
+        let max = std::env::var(BUDGET_ENV)
+            .ok()
+            .and_then(|s| s.trim().parse::<usize>().ok())
+            .unwrap_or(DEFAULT_BUDGET);
+        Self::with_budget(max)
+    }
+
+    /// Build a `Mind` with an explicit non-critical per-tick budget (test seam
+    /// — avoids env mutation).
+    pub fn with_budget(max_noncritical_per_tick: usize) -> Self {
+        Self {
+            threads: Vec::new(),
+            budget: RunBudget {
+                max_noncritical_per_tick,
+            },
+        }
+    }
+
+    /// Register a thread (chainable).
+    pub fn register(&mut self, thread: Box<dyn CognitiveThread>) -> &mut Self {
+        self.threads.push(ThreadEntry::new(thread));
+        self
+    }
+
+    /// Pure: registration-order indices of enabled, non-backed-off, due
+    /// threads at `now_epoch`.
+    pub fn due_threads(&self, now_epoch: u64) -> Vec<usize> {
+        todo!("Step 7 TDD: implemented by the scheduler implementation step")
+    }
+
+    /// Run OODA ([`super::Priority::Critical`]) first and unconditionally
+    /// (budget-exempt, never backed off), then non-critical due threads in
+    /// priority order up to the per-tick budget. Each tick runs inside
+    /// `catch_unwind`; a panic/`Err` bumps `consecutive_errors`, sets backoff,
+    /// emits an error metric, and never propagates. Checks `ctx.shutdown`
+    /// between threads and returns early.
+    pub fn run_due(&mut self, ctx: &mut ThreadContext<'_>) -> Vec<ThreadOutcome> {
+        todo!("Step 7 TDD: implemented by the scheduler implementation step")
+    }
+
+    /// Health snapshot of every registered thread (dashboard heartbeat feed).
+    pub fn health(&self) -> Vec<ThreadHealth> {
+        todo!("Step 7 TDD: implemented by the scheduler implementation step")
+    }
+
+    /// Number of registered threads.
+    pub fn len(&self) -> usize {
+        self.threads.len()
+    }
+
+    /// Whether no threads are registered.
+    pub fn is_empty(&self) -> bool {
+        self.threads.is_empty()
+    }
+}
+
+impl Default for Mind {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/cognitive_threads/mind.rs
+++ b/src/cognitive_threads/mind.rs
@@ -2,23 +2,36 @@
 //!
 //! Owns a registry of threads, computes which are due, and runs them under a
 //! priority budget that never starves OODA. Failure isolation, backoff, and
-//! graceful shutdown live in [`Mind::run_due`], whose body is a `todo!()`
-//! stub during TDD; the registry/bookkeeping surface is real so the tests in
-//! `super::tests` can build a `Mind` and register fakes.
-#![allow(dead_code, unused_variables)]
+//! graceful shutdown live in [`Mind::run_due`]; the registry/bookkeeping
+//! surface is the stable "stud" the tests in `super::tests` build against.
 
-use super::thread::{CognitiveThread, ThreadContext, ThreadHealth, ThreadOutcome};
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+use super::schedule;
+use super::telemetry;
+use super::thread::{CognitiveThread, Priority, ThreadContext, ThreadHealth, ThreadOutcome};
 
 /// Env var controlling the per-tick non-critical fan-out budget.
 const BUDGET_ENV: &str = "SIMARD_MIND_MAX_NONCRITICAL_PER_TICK";
 /// Default non-critical fan-out per tick when the env var is unset/invalid.
 const DEFAULT_BUDGET: usize = 2;
 
-/// Per-thread runtime bookkeeping held alongside the boxed thread.
+/// Base delay of the per-thread capped-exponential backoff.
+const BACKOFF_BASE: Duration = Duration::from_secs(30);
+/// Ceiling of the per-thread backoff — a wedged thread retries at most this
+/// slowly, never permanently silenced.
+const BACKOFF_CAP: Duration = Duration::from_secs(30 * 60);
+
+/// Per-thread runtime bookkeeping held alongside the boxed thread. This is the
+/// scheduler's authoritative view (a thread's own `health()` is advisory); the
+/// dashboard heartbeat is built from these fields.
 struct ThreadEntry {
     thread: Box<dyn CognitiveThread>,
     last_run: Option<u64>,
     next_run: Option<u64>,
+    last_success: Option<bool>,
     consecutive_errors: u32,
     backoff_until: Option<u64>,
 }
@@ -29,9 +42,15 @@ impl ThreadEntry {
             thread,
             last_run: None,
             next_run: None,
+            last_success: None,
             consecutive_errors: 0,
             backoff_until: None,
         }
+    }
+
+    /// Whether this thread is currently suppressed by backoff at `now`.
+    fn is_backed_off(&self, now: u64) -> bool {
+        self.backoff_until.is_some_and(|until| now < until)
     }
 }
 
@@ -75,24 +94,146 @@ impl Mind {
     }
 
     /// Pure: registration-order indices of enabled, non-backed-off, due
-    /// threads at `now_epoch`.
+    /// threads at `now_epoch`. `Critical` threads are cadence-driven like any
+    /// other here; the budget/never-backed-off exemptions live in
+    /// [`Mind::run_due`].
     pub fn due_threads(&self, now_epoch: u64) -> Vec<usize> {
-        todo!("Step 7 TDD: implemented by the scheduler implementation step")
+        (0..self.threads.len())
+            .filter(|&i| {
+                let e = &self.threads[i];
+                e.thread.enabled()
+                    && !e.is_backed_off(now_epoch)
+                    && schedule::is_due(&e.thread.policy(), e.last_run, now_epoch)
+            })
+            .collect()
     }
 
-    /// Run OODA ([`super::Priority::Critical`]) first and unconditionally
-    /// (budget-exempt, never backed off), then non-critical due threads in
-    /// priority order up to the per-tick budget. Each tick runs inside
-    /// `catch_unwind`; a panic/`Err` bumps `consecutive_errors`, sets backoff,
-    /// emits an error metric, and never propagates. Checks `ctx.shutdown`
-    /// between threads and returns early.
+    /// Run OODA ([`Priority::Critical`]) first and unconditionally (budget-
+    /// exempt, never backed off), then non-critical due threads in priority
+    /// order up to the per-tick budget. Each tick runs inside `catch_unwind`;
+    /// a panic/`Err` bumps `consecutive_errors`, sets backoff, emits an error
+    /// metric, and never propagates. Once shutdown is requested no new ticks
+    /// start (the in-flight inline OODA cycle drains via the daemon path).
     pub fn run_due(&mut self, ctx: &mut ThreadContext<'_>) -> Vec<ThreadOutcome> {
-        todo!("Step 7 TDD: implemented by the scheduler implementation step")
+        let now = ctx.now_epoch;
+        let mut outcomes = Vec::new();
+
+        // Graceful shutdown: start nothing new.
+        if ctx.shutdown.load(Ordering::SeqCst) {
+            return outcomes;
+        }
+
+        // Phase 1 — Critical (OODA) first. Cadence-respecting, but budget-exempt
+        // and never backed off so a flood of due Low threads can never starve
+        // it and a reported failure never suppresses it.
+        for i in 0..self.threads.len() {
+            let e = &self.threads[i];
+            if e.thread.priority() == Priority::Critical
+                && e.thread.enabled()
+                && schedule::is_due(&e.thread.policy(), e.last_run, now)
+            {
+                let outcome = Self::execute(&mut self.threads[i], ctx, now, true);
+                outcomes.push(outcome);
+            }
+        }
+
+        // Re-check shutdown between phases (a signal may have arrived during a
+        // long OODA tick); drain rather than start background work.
+        if ctx.shutdown.load(Ordering::SeqCst) {
+            return outcomes;
+        }
+
+        // Phase 2 — non-critical due threads, priority-ordered, bounded.
+        let mut due: Vec<usize> = (0..self.threads.len())
+            .filter(|&i| {
+                let e = &self.threads[i];
+                e.thread.priority() != Priority::Critical
+                    && e.thread.enabled()
+                    && !e.is_backed_off(now)
+                    && schedule::is_due(&e.thread.policy(), e.last_run, now)
+            })
+            .collect();
+        // Stable sort by ascending priority (Critical < High < Normal < Low)
+        // keeps registration order among equals — no starvation reordering.
+        due.sort_by_key(|&i| self.threads[i].thread.priority());
+
+        // Cap non-critical fan-out at the per-tick budget; `take` keeps the
+        // limit without a manual counter (clippy::explicit_counter_loop).
+        for i in due.into_iter().take(self.budget.max_noncritical_per_tick) {
+            if ctx.shutdown.load(Ordering::SeqCst) {
+                break;
+            }
+            let outcome = Self::execute(&mut self.threads[i], ctx, now, false);
+            outcomes.push(outcome);
+        }
+
+        outcomes
+    }
+
+    /// Execute one thread with panic isolation and update its bookkeeping.
+    ///
+    /// `critical` threads never accrue backoff/error counts (OODA must keep its
+    /// cadence even if a cycle reports failure).
+    fn execute(
+        entry: &mut ThreadEntry,
+        ctx: &mut ThreadContext<'_>,
+        now: u64,
+        critical: bool,
+    ) -> ThreadOutcome {
+        let id = entry.thread.id().to_string();
+        let _active = telemetry::enter_active(&id);
+
+        // AssertUnwindSafe: a caught panic leaves the thread's private state
+        // possibly inconsistent, but we immediately back it off and never read
+        // that state until it succeeds again — the isolation is the contract.
+        let result = catch_unwind(AssertUnwindSafe(|| entry.thread.tick(ctx)));
+        let outcome = match result {
+            Ok(outcome) => outcome,
+            Err(_) => ThreadOutcome::failed("thread panicked", Duration::ZERO),
+        };
+
+        entry.last_run = Some(now);
+        entry.last_success = Some(outcome.success);
+        entry.next_run = schedule::next_run_epoch(&entry.thread.policy(), entry.last_run, now);
+
+        telemetry::record_run(&id, &outcome);
+        telemetry::record_next_run(&id, entry.next_run);
+
+        if outcome.success {
+            entry.consecutive_errors = 0;
+            entry.backoff_until = None;
+        } else {
+            telemetry::record_error(&id, &outcome.summary);
+            if !critical {
+                entry.consecutive_errors = entry.consecutive_errors.saturating_add(1);
+                entry.backoff_until = Some(schedule::backoff_until_epoch(
+                    now,
+                    entry.consecutive_errors,
+                    BACKOFF_BASE,
+                    BACKOFF_CAP,
+                ));
+            }
+        }
+
+        outcome
     }
 
     /// Health snapshot of every registered thread (dashboard heartbeat feed).
+    /// Built from the scheduler's authoritative bookkeeping, not the thread's
+    /// own advisory `health()`.
     pub fn health(&self) -> Vec<ThreadHealth> {
-        todo!("Step 7 TDD: implemented by the scheduler implementation step")
+        self.threads
+            .iter()
+            .map(|e| ThreadHealth {
+                id: e.thread.id().to_string(),
+                enabled: e.thread.enabled(),
+                last_run_epoch: e.last_run,
+                next_run_epoch: e.next_run,
+                last_success: e.last_success,
+                consecutive_errors: e.consecutive_errors,
+                backoff_until_epoch: e.backoff_until,
+            })
+            .collect()
     }
 
     /// Number of registered threads.

--- a/src/cognitive_threads/mod.rs
+++ b/src/cognitive_threads/mod.rs
@@ -1,0 +1,26 @@
+//! Cognitive-thread scheduling: a [`Mind`] runs many [`CognitiveThread`]s on
+//! their own cadence/trigger. See
+//! `docs/reference/cognitive-thread-scheduling.md`.
+//!
+//! **Status (issue #2419):** this module is under TDD construction. The public
+//! type surface (Appendix A of the design doc) is defined here so the test
+//! suite in [`tests`] can pin behaviour first; the behaviour-bearing functions
+//! (`schedule::*`, `Mind::{due_threads,run_due,health}`, each thread's `tick`
+//! and its safety/analysis helpers) are `todo!()` stubs that the implementation
+//! step fills in. Data types, constructors, and the telemetry seam are real.
+
+mod mind;
+mod schedule;
+mod telemetry;
+mod thread;
+pub mod threads;
+
+#[cfg(test)]
+mod tests;
+
+pub use mind::Mind;
+pub use thread::{
+    CognitiveThread, Priority, SchedulePolicy, ThreadContext, ThreadHealth, ThreadKind,
+    ThreadOutcome,
+};
+pub use threads::{EngineerLogAnalysisThread, MaintenanceThread, OodaThread};

--- a/src/cognitive_threads/schedule.rs
+++ b/src/cognitive_threads/schedule.rs
@@ -1,9 +1,8 @@
 //! Pure, injected-clock scheduling math (Appendix A.4).
 //!
 //! Every function here is a pure function of its arguments (no `SystemTime`,
-//! no sleeps) so due-computation and backoff are fully unit-testable. Bodies
-//! are `todo!()` during TDD; the tests in `super::tests` pin the contract.
-#![allow(dead_code, unused_variables)]
+//! no sleeps) so due-computation and backoff are fully unit-testable. The tests
+//! in `super::tests` pin the contract.
 
 use std::time::Duration;
 
@@ -14,6 +13,20 @@ use super::thread::SchedulePolicy;
 /// make a thread due every tick.
 pub const MIN_INTERVAL_SECS: u64 = 60;
 
+/// Upper bound on the backoff doubling shift so `1 << shift` can never overflow
+/// `u64` regardless of the (untrusted) error count.
+const BACKOFF_MAX_SHIFT: u32 = 32;
+
+/// The fixed cadence (seconds) of a policy, or `None` for the trigger-based
+/// policies that have no interval.
+fn interval_secs(policy: &SchedulePolicy) -> Option<u64> {
+    match policy {
+        SchedulePolicy::Interval(d) => Some(d.as_secs()),
+        SchedulePolicy::Adaptive { current, .. } => Some(current.as_secs()),
+        SchedulePolicy::OnDemand | SchedulePolicy::EventDriven => None,
+    }
+}
+
 /// Whether `policy` is due at `now_epoch` given the last run.
 ///
 /// Contract:
@@ -22,7 +35,13 @@ pub const MIN_INTERVAL_SECS: u64 = 60;
 /// - `OnDemand` / `EventDriven`: never auto-due from this pure function (their
 ///   trigger is an explicit request/predicate handled by the caller).
 pub fn is_due(policy: &SchedulePolicy, last_run_epoch: Option<u64>, now_epoch: u64) -> bool {
-    todo!("Step 7 TDD: implemented by the scheduler implementation step")
+    match interval_secs(policy) {
+        None => false,
+        Some(interval) => match last_run_epoch {
+            None => true,
+            Some(last) => now_epoch >= last.saturating_add(interval),
+        },
+    }
 }
 
 /// The next scheduled run epoch, or `None` for policies with no fixed cadence
@@ -33,7 +52,10 @@ pub fn next_run_epoch(
     last_run_epoch: Option<u64>,
     now_epoch: u64,
 ) -> Option<u64> {
-    todo!("Step 7 TDD: implemented by the scheduler implementation step")
+    interval_secs(policy).map(|interval| match last_run_epoch {
+        None => now_epoch,
+        Some(last) => last.saturating_add(interval),
+    })
 }
 
 /// Capped exponential backoff: `now + min(base * 2^min(errors, shift_cap), cap)`
@@ -44,11 +66,18 @@ pub fn backoff_until_epoch(
     base: Duration,
     cap: Duration,
 ) -> u64 {
-    todo!("Step 7 TDD: implemented by the scheduler implementation step")
+    let base_secs = base.as_secs();
+    let cap_secs = cap.as_secs();
+    let shift = consecutive_errors.min(BACKOFF_MAX_SHIFT);
+    // `1 << shift` fits in u64 for shift <= 32; multiplication saturates so a
+    // large base or error count can never overflow.
+    let factor = 1u64 << shift;
+    let delay = base_secs.saturating_mul(factor).min(cap_secs);
+    now_epoch.saturating_add(delay)
 }
 
 /// Clamp a configured interval (seconds) up to [`MIN_INTERVAL_SECS`] (SR-8).
 /// Values already above the floor are returned unchanged.
 pub fn clamp_interval_secs(raw: u64) -> u64 {
-    todo!("Step 7 TDD: implemented by the scheduler implementation step")
+    raw.max(MIN_INTERVAL_SECS)
 }

--- a/src/cognitive_threads/schedule.rs
+++ b/src/cognitive_threads/schedule.rs
@@ -1,0 +1,54 @@
+//! Pure, injected-clock scheduling math (Appendix A.4).
+//!
+//! Every function here is a pure function of its arguments (no `SystemTime`,
+//! no sleeps) so due-computation and backoff are fully unit-testable. Bodies
+//! are `todo!()` during TDD; the tests in `super::tests` pin the contract.
+#![allow(dead_code, unused_variables)]
+
+use std::time::Duration;
+
+use super::thread::SchedulePolicy;
+
+/// Minimum cadence floor for interval policies (SR-8). Any configured interval
+/// at or below this is clamped up to it so a hostile/misconfigured `0` cannot
+/// make a thread due every tick.
+pub const MIN_INTERVAL_SECS: u64 = 60;
+
+/// Whether `policy` is due at `now_epoch` given the last run.
+///
+/// Contract:
+/// - `Interval(d)` / `Adaptive{current,..}`: due when `last_run` is `None`
+///   (never run) or `now >= last_run + interval`.
+/// - `OnDemand` / `EventDriven`: never auto-due from this pure function (their
+///   trigger is an explicit request/predicate handled by the caller).
+pub fn is_due(policy: &SchedulePolicy, last_run_epoch: Option<u64>, now_epoch: u64) -> bool {
+    todo!("Step 7 TDD: implemented by the scheduler implementation step")
+}
+
+/// The next scheduled run epoch, or `None` for policies with no fixed cadence
+/// (`OnDemand`/`EventDriven`). For `Interval`/`Adaptive` returns
+/// `last_run + interval` (or `now` when never run).
+pub fn next_run_epoch(
+    policy: &SchedulePolicy,
+    last_run_epoch: Option<u64>,
+    now_epoch: u64,
+) -> Option<u64> {
+    todo!("Step 7 TDD: implemented by the scheduler implementation step")
+}
+
+/// Capped exponential backoff: `now + min(base * 2^min(errors, shift_cap), cap)`
+/// in seconds, saturating (never overflows, never exceeds `now + cap`).
+pub fn backoff_until_epoch(
+    now_epoch: u64,
+    consecutive_errors: u32,
+    base: Duration,
+    cap: Duration,
+) -> u64 {
+    todo!("Step 7 TDD: implemented by the scheduler implementation step")
+}
+
+/// Clamp a configured interval (seconds) up to [`MIN_INTERVAL_SECS`] (SR-8).
+/// Values already above the floor are returned unchanged.
+pub fn clamp_interval_secs(raw: u64) -> u64 {
+    todo!("Step 7 TDD: implemented by the scheduler implementation step")
+}

--- a/src/cognitive_threads/telemetry.rs
+++ b/src/cognitive_threads/telemetry.rs
@@ -1,0 +1,89 @@
+//! The single telemetry seam for cognitive threads (Appendix A.6).
+//!
+//! All metric/span emission funnels through here so a later rebase onto the
+//! unified `src/telemetry/` OTel facade is a one-file change. No
+//! `println!`/`eprintln!` — structured `tracing` only. Metric/span **names**
+//! use the fixed `simard.thread.<id>.<suffix>` scheme where `<id>` is a
+//! per-thread compile-time constant (SR-11): untrusted content only ever
+//! appears as length-bounded structured field *values*, never as a name.
+#![allow(dead_code)]
+
+use super::thread::ThreadOutcome;
+
+/// Build a facade-ready metric name: `simard.thread.<id>.<suffix>`.
+///
+/// `id` and `suffix` are compile-time constants at every call site (SR-11).
+pub fn metric_name(id: &str, suffix: &str) -> String {
+    format!("simard.thread.{id}.{suffix}")
+}
+
+/// Record a completed run: opens span `simard.thread.<id>` and emits the
+/// `runs` / `duration_seconds` signals with outcome fields.
+pub fn record_run(id: &str, outcome: &ThreadOutcome) {
+    let span = tracing::info_span!(
+        "simard.thread",
+        thread.id = id,
+        ran = outcome.ran,
+        success = outcome.success,
+        duration_ms = outcome.duration.as_millis() as u64,
+    );
+    let _entered = span.enter();
+    tracing::info!(
+        metric = %metric_name(id, "runs"),
+        thread.id = id,
+        ran = outcome.ran,
+        success = outcome.success,
+        duration_seconds = outcome.duration.as_secs_f64(),
+        summary = %outcome.summary,
+        "cognitive thread run recorded"
+    );
+}
+
+/// Bump `simard.thread.<id>.errors` and emit an error-level structured event.
+pub fn record_error(id: &str, reason: &str) {
+    tracing::error!(
+        metric = %metric_name(id, "errors"),
+        thread.id = id,
+        reason = %reason,
+        "cognitive thread run errored"
+    );
+}
+
+/// Set the `simard.thread.<id>.next_run_epoch` gauge.
+pub fn record_next_run(id: &str, next_run_epoch: Option<u64>) {
+    tracing::debug!(
+        metric = %metric_name(id, "next_run_epoch"),
+        thread.id = id,
+        next_run_epoch = ?next_run_epoch,
+        "cognitive thread next-run scheduled"
+    );
+}
+
+/// RAII guard: sets `simard.thread.<id>.active` to 1 while held, back to 0 on
+/// drop.
+#[must_use]
+pub fn enter_active(id: &str) -> ActiveGuard {
+    tracing::debug!(
+        metric = %metric_name(id, "active"),
+        thread.id = id,
+        active = 1,
+        "cognitive thread tick started"
+    );
+    ActiveGuard { id: id.to_string() }
+}
+
+/// Guard returned by [`enter_active`]; emits the `active = 0` signal on drop.
+pub struct ActiveGuard {
+    id: String,
+}
+
+impl Drop for ActiveGuard {
+    fn drop(&mut self) {
+        tracing::debug!(
+            metric = %metric_name(&self.id, "active"),
+            thread.id = %self.id,
+            active = 0,
+            "cognitive thread tick finished"
+        );
+    }
+}

--- a/src/cognitive_threads/tests.rs
+++ b/src/cognitive_threads/tests.rs
@@ -1,0 +1,886 @@
+//! TDD test suite for cognitive-thread scheduling (design §12 + security §5d).
+//!
+//! These tests are authored **before** the behaviour implementation. The data
+//! surface, constructors, and the telemetry seam are real, so the identity /
+//! naming / default-invariant tests pass today; the behaviour tests exercise
+//! `todo!()` stubs and therefore FAIL (red) until the implementation step fills
+//! them in. Every test is hermetic: injected `now_epoch`, no sleeps, no
+//! network (a fake `GhClient`), and no process-global env mutation (so the
+//! `serial(cognitive_memory)` contract does not apply).
+
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use serde_json::json;
+
+use crate::cognitive_memory::{CognitiveMemoryOps, LibraryCognitiveMemory};
+use crate::error::SimardResult;
+use crate::stewardship::dedup;
+use crate::stewardship::gh_client::{GhClient, GhIssue};
+
+use super::mind::Mind;
+use super::schedule::{self, MIN_INTERVAL_SECS};
+use super::telemetry;
+use super::thread::{
+    CognitiveThread, Priority, SchedulePolicy, ThreadContext, ThreadHealth, ThreadKind,
+    ThreadOutcome,
+};
+use super::threads::engineer_log_analysis::{
+    self, EngineerLogAnalysisConfig, EngineerLogAnalysisThread,
+};
+use super::threads::maintenance::{self, MaintenanceConfig, MaintenanceThread};
+
+// ---------------------------------------------------------------------------
+// Test doubles & fixtures
+// ---------------------------------------------------------------------------
+
+/// Owns the borrowed resources a [`ThreadContext`] needs, so a test can mint a
+/// context bound to its own lifetime.
+struct TestEnv {
+    rt: tokio::runtime::Runtime,
+    mem: LibraryCognitiveMemory,
+    shutdown: AtomicBool,
+    tmp: tempfile::TempDir,
+}
+
+impl TestEnv {
+    fn new() -> Self {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build current-thread runtime");
+        let mem = LibraryCognitiveMemory::in_memory().expect("in-memory cognitive store");
+        let tmp = tempfile::tempdir().expect("tempdir");
+        Self {
+            rt,
+            mem,
+            shutdown: AtomicBool::new(false),
+            tmp,
+        }
+    }
+
+    fn state_root(&self) -> &Path {
+        self.tmp.path()
+    }
+
+    fn request_shutdown(&self) {
+        self.shutdown.store(true, Ordering::SeqCst);
+    }
+
+    fn ctx(&self, now_epoch: u64, dry_run: bool) -> ThreadContext<'_> {
+        ThreadContext {
+            state_root: self.tmp.path(),
+            repo_root: self.tmp.path(),
+            memory: &self.mem as &dyn CognitiveMemoryOps,
+            runtime: self.rt.handle().clone(),
+            shutdown: &self.shutdown,
+            now_epoch,
+            dry_run,
+        }
+    }
+}
+
+/// What a [`FakeThread`] does when ticked.
+#[derive(Clone, Copy)]
+enum FakeBehavior {
+    Succeed,
+    Error,
+    Panic,
+}
+
+/// A configurable fake [`CognitiveThread`] used to drive the scheduler.
+struct FakeThread {
+    id: String,
+    kind: ThreadKind,
+    priority: Priority,
+    policy: SchedulePolicy,
+    enabled: bool,
+    behavior: FakeBehavior,
+    runs: Arc<AtomicUsize>,
+    run_log: Arc<Mutex<Vec<String>>>,
+}
+
+impl CognitiveThread for FakeThread {
+    fn id(&self) -> &str {
+        &self.id
+    }
+    fn kind(&self) -> ThreadKind {
+        self.kind
+    }
+    fn policy(&self) -> SchedulePolicy {
+        self.policy.clone()
+    }
+    fn priority(&self) -> Priority {
+        self.priority
+    }
+    fn enabled(&self) -> bool {
+        self.enabled
+    }
+    fn tick(&mut self, _ctx: &mut ThreadContext<'_>) -> ThreadOutcome {
+        self.runs.fetch_add(1, Ordering::SeqCst);
+        self.run_log.lock().expect("run log").push(self.id.clone());
+        match self.behavior {
+            FakeBehavior::Succeed => ThreadOutcome::ok("ok", Duration::from_millis(1)),
+            FakeBehavior::Error => ThreadOutcome::failed("boom", Duration::from_millis(1)),
+            FakeBehavior::Panic => panic!("fake thread {} panicked", self.id),
+        }
+    }
+    fn health(&self) -> ThreadHealth {
+        ThreadHealth {
+            id: self.id.clone(),
+            enabled: self.enabled,
+            last_run_epoch: None,
+            next_run_epoch: None,
+            last_success: None,
+            consecutive_errors: 0,
+            backoff_until_epoch: None,
+        }
+    }
+}
+
+/// "Always due" interval policy.
+fn always_due() -> SchedulePolicy {
+    SchedulePolicy::Interval(Duration::ZERO)
+}
+
+/// Build a fake thread, returning it boxed plus a handle to its run counter.
+fn fake(
+    id: &str,
+    kind: ThreadKind,
+    priority: Priority,
+    policy: SchedulePolicy,
+    behavior: FakeBehavior,
+    run_log: &Arc<Mutex<Vec<String>>>,
+) -> (Box<dyn CognitiveThread>, Arc<AtomicUsize>) {
+    let runs = Arc::new(AtomicUsize::new(0));
+    let thread = FakeThread {
+        id: id.to_string(),
+        kind,
+        priority,
+        policy,
+        enabled: true,
+        behavior,
+        runs: Arc::clone(&runs),
+        run_log: Arc::clone(run_log),
+    };
+    (Box::new(thread), runs)
+}
+
+/// An in-process fake `gh` client: records created issues and answers searches
+/// from that record (no network, no credentials).
+#[derive(Clone)]
+struct FakeGhClient {
+    created: Arc<Mutex<Vec<GhIssue>>>,
+    next_number: Arc<AtomicU64>,
+}
+
+impl FakeGhClient {
+    fn new() -> Self {
+        Self {
+            created: Arc::new(Mutex::new(Vec::new())),
+            next_number: Arc::new(AtomicU64::new(1)),
+        }
+    }
+
+    fn created_count(&self) -> usize {
+        self.created.lock().expect("created lock").len()
+    }
+}
+
+impl GhClient for FakeGhClient {
+    fn search_issues(&self, _repo: &str, signature: &str) -> SimardResult<Vec<GhIssue>> {
+        let needle = format!("stewardship-signature: {signature}");
+        Ok(self
+            .created
+            .lock()
+            .expect("created lock")
+            .iter()
+            .filter(|i| i.body.contains(&needle))
+            .cloned()
+            .collect())
+    }
+
+    fn create_issue(&self, _repo: &str, title: &str, body: &str) -> SimardResult<GhIssue> {
+        let number = self.next_number.fetch_add(1, Ordering::SeqCst);
+        let issue = GhIssue {
+            number,
+            url: format!("https://github.com/rysweet/Simard/issues/{number}"),
+            title: title.to_string(),
+            body: body.to_string(),
+        };
+        self.created
+            .lock()
+            .expect("created lock")
+            .push(issue.clone());
+        Ok(issue)
+    }
+}
+
+/// Write a persisted cycle report containing a single failed engineer outcome
+/// whose `detail` is `detail` (mirrors `persist_cycle_report`'s JSON shape).
+fn seed_cycle_report(state_root: &Path, cycle: u32, detail: &str) {
+    let dir = state_root.join("cycle_reports");
+    std::fs::create_dir_all(&dir).expect("create cycle_reports");
+    let report = json!({
+        "cycle_number": cycle,
+        "summary": "seeded failure",
+        "outcomes": [
+            {
+                "action_kind": "AdvanceGoal",
+                "action_description": "spawn engineer for goal g1",
+                "success": false,
+                "detail": detail,
+            }
+        ],
+    });
+    std::fs::write(
+        dir.join(format!("cycle_{cycle}.json")),
+        serde_json::to_string_pretty(&report).expect("serialize report"),
+    )
+    .expect("write cycle report");
+}
+
+// ---------------------------------------------------------------------------
+// §12 — schedule.rs: pure due-computation (injected clock, no sleeps)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn interval_is_due_when_never_run() {
+    let policy = SchedulePolicy::Interval(Duration::from_secs(100));
+    assert!(schedule::is_due(&policy, None, 12_345));
+}
+
+#[test]
+fn interval_is_not_due_before_deadline_and_due_at_deadline() {
+    let policy = SchedulePolicy::Interval(Duration::from_secs(100));
+    assert!(!schedule::is_due(&policy, Some(1_000), 1_099));
+    assert!(schedule::is_due(&policy, Some(1_000), 1_100));
+    assert!(schedule::is_due(&policy, Some(1_000), 5_000));
+}
+
+#[test]
+fn interval_next_run_is_last_plus_interval() {
+    let policy = SchedulePolicy::Interval(Duration::from_secs(100));
+    assert_eq!(
+        schedule::next_run_epoch(&policy, Some(1_000), 1_050),
+        Some(1_100)
+    );
+    // Never run yet => scheduled now.
+    assert_eq!(schedule::next_run_epoch(&policy, None, 2_000), Some(2_000));
+}
+
+#[test]
+fn on_demand_and_event_driven_are_never_auto_due() {
+    for policy in [SchedulePolicy::OnDemand, SchedulePolicy::EventDriven] {
+        assert!(!schedule::is_due(&policy, None, 9_999));
+        assert!(!schedule::is_due(&policy, Some(1), 9_999));
+        assert_eq!(schedule::next_run_epoch(&policy, Some(1), 9_999), None);
+    }
+}
+
+#[test]
+fn adaptive_behaves_like_interval_current() {
+    let policy = SchedulePolicy::Adaptive {
+        min: Duration::from_secs(60),
+        max: Duration::from_secs(600),
+        current: Duration::from_secs(100),
+    };
+    assert!(!schedule::is_due(&policy, Some(1_000), 1_099));
+    assert!(schedule::is_due(&policy, Some(1_000), 1_100));
+    assert_eq!(
+        schedule::next_run_epoch(&policy, Some(1_000), 1_050),
+        Some(1_100)
+    );
+}
+
+#[test]
+fn backoff_is_monotonic_and_capped() {
+    let base = Duration::from_secs(10);
+    let cap = Duration::from_secs(300);
+    let now = 1_000;
+    let b1 = schedule::backoff_until_epoch(now, 1, base, cap);
+    let b2 = schedule::backoff_until_epoch(now, 2, base, cap);
+    let b3 = schedule::backoff_until_epoch(now, 3, base, cap);
+    assert!(
+        b1 >= now && b2 >= b1 && b3 >= b2,
+        "backoff must grow: {b1} {b2} {b3}"
+    );
+    // Never exceeds now + cap, even for a huge error count.
+    let huge = schedule::backoff_until_epoch(now, u32::MAX, base, cap);
+    assert!(huge <= now + cap.as_secs(), "backoff capped at now+cap");
+    assert!(huge >= now);
+}
+
+#[test]
+fn clamp_interval_secs_enforces_floor() {
+    // SR-8: a hostile/misconfigured 0 must not make a thread due every tick.
+    assert_eq!(schedule::clamp_interval_secs(0), MIN_INTERVAL_SECS);
+    assert!(schedule::clamp_interval_secs(0) > 0);
+    // Values above the floor are unchanged.
+    assert_eq!(schedule::clamp_interval_secs(3_600), 3_600);
+}
+
+// ---------------------------------------------------------------------------
+// §12 — Mind: registry (green today), due-computation, failure isolation,
+// priority budget, OODA parity, graceful shutdown.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mind_registry_len_and_is_empty() {
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let mut mind = Mind::with_budget(2);
+    assert!(mind.is_empty());
+    let (t, _runs) = fake(
+        "a",
+        ThreadKind::Maintenance,
+        Priority::Low,
+        always_due(),
+        FakeBehavior::Succeed,
+        &log,
+    );
+    mind.register(t);
+    assert_eq!(mind.len(), 1);
+    assert!(!mind.is_empty());
+}
+
+#[test]
+fn due_threads_excludes_on_demand_and_disabled() {
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let mut mind = Mind::with_budget(4);
+    // index 0: due interval thread
+    let (t0, _r0) = fake(
+        "due",
+        ThreadKind::Maintenance,
+        Priority::Low,
+        always_due(),
+        FakeBehavior::Succeed,
+        &log,
+    );
+    // index 1: on-demand thread (never auto-due)
+    let (t1, _r1) = fake(
+        "on_demand",
+        ThreadKind::Maintenance,
+        Priority::Low,
+        SchedulePolicy::OnDemand,
+        FakeBehavior::Succeed,
+        &log,
+    );
+    mind.register(t0).register(t1);
+    assert_eq!(mind.due_threads(10_000), vec![0]);
+}
+
+#[test]
+fn run_due_runs_critical_every_tick_and_bounds_noncritical_fanout() {
+    // OODA parity + priority budget (§5, §6): a Critical thread runs on every
+    // tick and is never crowded out by a flood of due Low threads, which are
+    // themselves bounded by the per-tick budget.
+    let env = TestEnv::new();
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let budget = 2;
+    let mut mind = Mind::with_budget(budget);
+
+    let (crit, crit_runs) = fake(
+        "ooda",
+        ThreadKind::Ooda,
+        Priority::Critical,
+        always_due(),
+        FakeBehavior::Succeed,
+        &log,
+    );
+    mind.register(crit);
+    for i in 0..6 {
+        let (t, _r) = fake(
+            &format!("low_{i}"),
+            ThreadKind::Maintenance,
+            Priority::Low,
+            always_due(),
+            FakeBehavior::Succeed,
+            &log,
+        );
+        mind.register(t);
+    }
+
+    let ticks: u64 = 5;
+    for tick in 0..ticks {
+        let mut ctx = env.ctx(1_000 + tick, false);
+        let outcomes = mind.run_due(&mut ctx);
+        // The Critical thread must have run this tick (never starved) ...
+        assert_eq!(
+            crit_runs.load(Ordering::SeqCst) as u64,
+            tick + 1,
+            "critical thread must run exactly once per tick"
+        );
+        // ... and it must be the first thing that ran each tick.
+        assert!(
+            matches!(outcomes.first(), Some(o) if o.ran),
+            "OODA runs first and unconditionally"
+        );
+    }
+
+    // Critical ran every tick.
+    assert_eq!(crit_runs.load(Ordering::SeqCst), ticks as usize);
+    // Non-critical fan-out per tick was bounded by the budget: total Low runs
+    // never exceeds budget * ticks.
+    let low_total: usize = (0..6)
+        .map(|i| {
+            log.lock()
+                .expect("log")
+                .iter()
+                .filter(|id| **id == format!("low_{i}"))
+                .count()
+        })
+        .sum();
+    assert!(
+        low_total <= budget * ticks as usize,
+        "non-critical fan-out {low_total} must be bounded by budget*ticks {}",
+        budget * ticks as usize
+    );
+}
+
+#[test]
+fn run_due_isolates_panicking_thread_without_killing_siblings() {
+    // Failure isolation (§5.4): a panicking thread is caught, recorded, and
+    // backed off; OODA and other threads still run.
+    let env = TestEnv::new();
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let mut mind = Mind::with_budget(8);
+
+    let (crit, crit_runs) = fake(
+        "ooda",
+        ThreadKind::Ooda,
+        Priority::Critical,
+        always_due(),
+        FakeBehavior::Succeed,
+        &log,
+    );
+    let (boom, _boom_runs) = fake(
+        "boom",
+        ThreadKind::Maintenance,
+        Priority::Low,
+        always_due(),
+        FakeBehavior::Panic,
+        &log,
+    );
+    let (sibling, sibling_runs) = fake(
+        "sibling",
+        ThreadKind::Maintenance,
+        Priority::Low,
+        always_due(),
+        FakeBehavior::Succeed,
+        &log,
+    );
+    mind.register(crit).register(boom).register(sibling);
+
+    let mut ctx = env.ctx(1_000, false);
+    // Must NOT propagate the panic.
+    let _outcomes = mind.run_due(&mut ctx);
+
+    assert_eq!(
+        crit_runs.load(Ordering::SeqCst),
+        1,
+        "critical survived the panic"
+    );
+    assert_eq!(
+        sibling_runs.load(Ordering::SeqCst),
+        1,
+        "sibling survived the panic"
+    );
+
+    // The panicking thread is recorded as errored and backed off.
+    let health = mind.health();
+    let boom_health = health
+        .iter()
+        .find(|h| h.id == "boom")
+        .expect("boom health present");
+    assert!(
+        boom_health.consecutive_errors >= 1,
+        "panic recorded as error"
+    );
+    assert!(
+        boom_health.backoff_until_epoch.is_some(),
+        "panic triggers backoff"
+    );
+}
+
+#[test]
+fn run_due_backs_off_erroring_thread_but_never_ooda() {
+    let env = TestEnv::new();
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let mut mind = Mind::with_budget(8);
+
+    let (crit, _crit_runs) = fake(
+        "ooda",
+        ThreadKind::Ooda,
+        Priority::Critical,
+        always_due(),
+        FakeBehavior::Error, // even if OODA reports failure it is never backed off
+        &log,
+    );
+    let (bad, _bad_runs) = fake(
+        "bad",
+        ThreadKind::Maintenance,
+        Priority::Low,
+        always_due(),
+        FakeBehavior::Error,
+        &log,
+    );
+    mind.register(crit).register(bad);
+
+    let mut ctx = env.ctx(2_000, false);
+    let _ = mind.run_due(&mut ctx);
+
+    let health = mind.health();
+    let ooda = health.iter().find(|h| h.id == "ooda").expect("ooda health");
+    let bad = health.iter().find(|h| h.id == "bad").expect("bad health");
+    assert!(
+        ooda.backoff_until_epoch.is_none(),
+        "OODA is never backed off"
+    );
+    assert!(
+        bad.consecutive_errors >= 1,
+        "erroring thread accrues errors"
+    );
+    assert!(
+        bad.backoff_until_epoch.is_some(),
+        "erroring thread backs off"
+    );
+}
+
+#[test]
+fn run_due_returns_early_on_shutdown() {
+    // Graceful shutdown (§5.5): with shutdown requested, non-critical threads
+    // must not be started.
+    let env = TestEnv::new();
+    env.request_shutdown();
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let mut mind = Mind::with_budget(8);
+
+    let (low, low_runs) = fake(
+        "low",
+        ThreadKind::Maintenance,
+        Priority::Low,
+        always_due(),
+        FakeBehavior::Succeed,
+        &log,
+    );
+    mind.register(low);
+
+    let mut ctx = env.ctx(3_000, false);
+    let _ = mind.run_due(&mut ctx);
+    assert_eq!(
+        low_runs.load(Ordering::SeqCst),
+        0,
+        "non-critical thread must not start after shutdown requested"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// §12 — MaintenanceThread: identity, safety gate (SR-5/6), dry-run, floors.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn maintenance_thread_identity_and_policy() {
+    let t = MaintenanceThread::new(MaintenanceConfig {
+        interval_secs: 3_600,
+        ..MaintenanceConfig::default()
+    });
+    assert_eq!(t.id(), "maintenance");
+    assert_eq!(t.kind(), ThreadKind::Maintenance);
+    assert_eq!(t.priority(), Priority::Low);
+    assert_eq!(
+        t.policy(),
+        SchedulePolicy::Interval(Duration::from_secs(3_600))
+    );
+}
+
+#[test]
+fn maintenance_config_default_retention_floors_at_least_one() {
+    let cfg = MaintenanceConfig::default();
+    assert!(cfg.keep_corrupt >= 1);
+    assert!(cfg.keep_snapshots >= 1);
+    assert!(cfg.keep_backups >= 1);
+    assert!(
+        cfg.dry_run,
+        "destructive maintenance ships dry-run-first (SR-7)"
+    );
+}
+
+#[test]
+fn is_safe_to_delete_allows_stale_dir_inside_allow_root() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let allow = tmp.path().join("artifacts");
+    std::fs::create_dir_all(&allow).expect("mk allow root");
+    let candidate = allow.join("cognitive.corrupt-OLD");
+    std::fs::create_dir_all(&candidate).expect("mk candidate");
+
+    assert!(maintenance::is_safe_to_delete(
+        &candidate,
+        std::slice::from_ref(&allow),
+        &[],
+    ));
+}
+
+#[test]
+fn is_safe_to_delete_refuses_symlink() {
+    // SR-5: a symlink (even inside an allow root) must be refused so a swapped
+    // symlink cannot redirect a delete at a protected target.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let allow = tmp.path().join("artifacts");
+    std::fs::create_dir_all(&allow).expect("mk allow root");
+    let protected = tmp.path().join("protected");
+    std::fs::create_dir_all(&protected).expect("mk protected");
+    let link = allow.join("link");
+    std::os::unix::fs::symlink(&protected, &link).expect("mk symlink");
+
+    assert!(
+        !maintenance::is_safe_to_delete(&link, std::slice::from_ref(&allow), &[]),
+        "a symlink must never be a delete candidate"
+    );
+}
+
+#[test]
+fn is_safe_to_delete_refuses_path_outside_allow_root() {
+    // Canonical allow-list defeats `..`/traversal escapes.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let allow = tmp.path().join("artifacts");
+    std::fs::create_dir_all(&allow).expect("mk allow root");
+    let outside = tmp.path().join("elsewhere");
+    std::fs::create_dir_all(&outside).expect("mk outside");
+
+    assert!(
+        !maintenance::is_safe_to_delete(&outside, std::slice::from_ref(&allow), &[]),
+        "a path outside every allow root must be refused"
+    );
+}
+
+#[test]
+fn is_safe_to_delete_refuses_deny_listed_path() {
+    // SR-6: an explicitly protected path is refused even when inside an allow
+    // root (e.g. the live store / repo).
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let allow = tmp.path().join("artifacts");
+    std::fs::create_dir_all(&allow).expect("mk allow root");
+    let protected = allow.join("repo");
+    std::fs::create_dir_all(&protected).expect("mk protected");
+
+    assert!(
+        !maintenance::is_safe_to_delete(
+            &protected,
+            std::slice::from_ref(&allow),
+            std::slice::from_ref(&protected),
+        ),
+        "a deny-listed path must be refused"
+    );
+}
+
+#[test]
+fn maintenance_dry_run_deletes_nothing() {
+    // SR-7: with dry_run, a stale artifact under the state root survives.
+    let env = TestEnv::new();
+    let stale = env.state_root().join("cognitive.corrupt-OLD");
+    std::fs::create_dir_all(&stale).expect("seed stale dir");
+
+    let mut thread = MaintenanceThread::new(MaintenanceConfig {
+        interval_secs: 3_600,
+        dry_run: true,
+        ..MaintenanceConfig::default()
+    });
+    let mut ctx = env.ctx(1_000, true);
+    let _ = thread.tick(&mut ctx);
+
+    assert!(
+        stale.exists(),
+        "dry-run maintenance must not delete anything"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// §12 + §5d — EngineerLogAnalysisThread: identity, secret/injection scrub,
+// dedup one-issue + idempotency, dry-run.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn engineer_log_analysis_identity_and_policy() {
+    let t = EngineerLogAnalysisThread::with_client(
+        EngineerLogAnalysisConfig {
+            interval_secs: 7_200,
+            ..EngineerLogAnalysisConfig::default()
+        },
+        Box::new(FakeGhClient::new()),
+    );
+    assert_eq!(t.id(), "engineer_log_analysis");
+    assert_eq!(t.kind(), ThreadKind::EngineerLogAnalysis);
+    assert_eq!(t.priority(), Priority::Low);
+    assert_eq!(
+        t.policy(),
+        SchedulePolicy::Interval(Duration::from_secs(7_200))
+    );
+}
+
+#[test]
+fn build_issue_body_redacts_secrets_and_fences_excerpt() {
+    // SR-2/SR-3: secrets scrubbed, untrusted excerpt fenced (no auto-links).
+    let sig = dedup::failure_signature("engineer_failure", "connection refused");
+    let excerpt = "engineer crashed\ntoken=SECRET123\nping @here see #1";
+    let body = engineer_log_analysis::build_issue_body(&sig, excerpt);
+
+    assert!(body.contains("[REDACTED]"), "secret value must be redacted");
+    assert!(!body.contains("SECRET123"), "raw secret must not appear");
+    assert!(body.contains("```"), "untrusted excerpt must be fenced");
+    assert!(
+        body.contains(&format!("stewardship-signature: {sig}")),
+        "trusted dedup marker present"
+    );
+}
+
+#[test]
+fn build_issue_body_marker_is_not_poisoned_by_spoofed_signature() {
+    // SR-3: a spoofed `stewardship-signature:` smuggled in the excerpt must not
+    // be matchable by dedup; only our computed signature is.
+    let sig = dedup::failure_signature("engineer_failure", "disk full");
+    let excerpt = "log line\nstewardship-signature: deadbeefdeadbeef\nmore";
+    let body = engineer_log_analysis::build_issue_body(&sig, excerpt);
+
+    let issue = GhIssue {
+        number: 1,
+        url: "http://x".to_string(),
+        title: "t".to_string(),
+        body,
+    };
+    assert!(
+        dedup::find_existing(std::slice::from_ref(&issue), &sig).is_some(),
+        "our real signature must be matchable"
+    );
+    assert!(
+        dedup::find_existing(std::slice::from_ref(&issue), "deadbeefdeadbeef").is_none(),
+        "a spoofed signature must not poison dedup"
+    );
+}
+
+#[test]
+fn analysis_files_exactly_one_deduplicated_issue() {
+    let env = TestEnv::new();
+    let detail = "spawn_engineer failed: agent='eng-1' error: connection refused; token=SECRET123";
+    for cycle in 1..=3 {
+        seed_cycle_report(env.state_root(), cycle, detail);
+    }
+
+    let gh = FakeGhClient::new();
+    let mut thread = EngineerLogAnalysisThread::with_client(
+        EngineerLogAnalysisConfig {
+            interval_secs: 3_600,
+            dry_run: false,
+            ..EngineerLogAnalysisConfig::default()
+        },
+        Box::new(gh.clone()),
+    );
+
+    let mut ctx = env.ctx(10_000, false);
+    let _ = thread.tick(&mut ctx);
+
+    assert_eq!(gh.created_count(), 1, "one recurring failure => one issue");
+    let created = gh.created.lock().expect("created");
+    let body = &created[0].body;
+    assert!(
+        body.contains("stewardship-signature:"),
+        "issue carries dedup marker"
+    );
+    assert!(
+        body.contains("[REDACTED]"),
+        "secret redacted in filed issue"
+    );
+    assert!(
+        !body.contains("SECRET123"),
+        "raw secret never leaves the process"
+    );
+}
+
+#[test]
+fn analysis_is_idempotent_across_runs() {
+    let env = TestEnv::new();
+    let detail = "spawn_engineer failed: agent='eng-1' error: connection refused";
+    for cycle in 1..=3 {
+        seed_cycle_report(env.state_root(), cycle, detail);
+    }
+
+    let gh = FakeGhClient::new();
+    let mut thread = EngineerLogAnalysisThread::with_client(
+        EngineerLogAnalysisConfig {
+            interval_secs: 3_600,
+            dry_run: false,
+            ..EngineerLogAnalysisConfig::default()
+        },
+        Box::new(gh.clone()),
+    );
+
+    let mut ctx1 = env.ctx(10_000, false);
+    let _ = thread.tick(&mut ctx1);
+    let mut ctx2 = env.ctx(20_000, false);
+    let _ = thread.tick(&mut ctx2);
+
+    assert_eq!(
+        gh.created_count(),
+        1,
+        "second run finds the existing issue and does not create a duplicate"
+    );
+}
+
+#[test]
+fn analysis_dry_run_files_no_issue() {
+    let env = TestEnv::new();
+    let detail = "spawn_engineer failed: agent='eng-1' error: connection refused";
+    for cycle in 1..=3 {
+        seed_cycle_report(env.state_root(), cycle, detail);
+    }
+
+    let gh = FakeGhClient::new();
+    let mut thread = EngineerLogAnalysisThread::with_client(
+        EngineerLogAnalysisConfig {
+            interval_secs: 3_600,
+            dry_run: true,
+            ..EngineerLogAnalysisConfig::default()
+        },
+        Box::new(gh.clone()),
+    );
+
+    let mut ctx = env.ctx(10_000, true);
+    let _ = thread.tick(&mut ctx);
+    assert_eq!(gh.created_count(), 0, "dry-run must not create issues");
+}
+
+// ---------------------------------------------------------------------------
+// §7 — telemetry naming contract (SR-11). Green today: names are constants.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn metric_names_use_fixed_scheme() {
+    assert_eq!(
+        telemetry::metric_name("maintenance", "runs"),
+        "simard.thread.maintenance.runs"
+    );
+    assert_eq!(
+        telemetry::metric_name("engineer_log_analysis", "duration_seconds"),
+        "simard.thread.engineer_log_analysis.duration_seconds"
+    );
+    assert_eq!(
+        telemetry::metric_name("ooda", "next_run_epoch"),
+        "simard.thread.ooda.next_run_epoch"
+    );
+}
+
+#[test]
+fn reserved_thread_kinds_are_representable() {
+    // The abstraction can host the future threads without a trait change.
+    for kind in [
+        ThreadKind::BackgroundThought,
+        ThreadKind::MemoryConsolidation,
+        ThreadKind::SensoryProcessing,
+        ThreadKind::LongTermPlanning,
+    ] {
+        // Serializable + comparable — proves they are first-class variants.
+        let json = serde_json::to_value(kind).expect("serialize kind");
+        assert!(json.is_string());
+    }
+}

--- a/src/cognitive_threads/thread.rs
+++ b/src/cognitive_threads/thread.rs
@@ -1,0 +1,204 @@
+//! The [`CognitiveThread`] trait and its supporting data contracts.
+//!
+//! These are the "studs" from Appendix A of the design doc. The types are the
+//! stable data surface; only the *behaviour* (in `schedule`, `mind`, and each
+//! `threads::*` module) is stubbed during TDD.
+
+use std::path::Path;
+use std::sync::atomic::AtomicBool;
+use std::time::Duration;
+
+use crate::cognitive_memory::CognitiveMemoryOps;
+
+/// A single scheduled mental process owned by the [`super::Mind`].
+///
+/// Object-safe (`Mind` stores `Box<dyn CognitiveThread>`) and `Send` (threads
+/// are moved into the `Mind` at registration; the scheduler ticks them
+/// sequentially on one thread, so `Sync` is not required).
+pub trait CognitiveThread: Send {
+    /// Stable, unique, `snake_case` id used in telemetry metric/span names.
+    fn id(&self) -> &str;
+
+    /// Human-facing name for logs/dashboard. Defaults to [`Self::id`].
+    fn name(&self) -> &str {
+        self.id()
+    }
+
+    /// Coarse class of process.
+    fn kind(&self) -> ThreadKind;
+
+    /// When this thread wants to run.
+    fn policy(&self) -> SchedulePolicy;
+
+    /// Priority / resource class. OODA is always [`Priority::Critical`].
+    fn priority(&self) -> Priority {
+        Priority::Normal
+    }
+
+    /// Runtime enable/disable (e.g. env-gated). Disabled threads never tick.
+    fn enabled(&self) -> bool {
+        true
+    }
+
+    /// Execute exactly one step. MUST be best-effort and self-contained: return
+    /// [`ThreadOutcome::failed`] rather than panic where possible; the `Mind`
+    /// also catches panics as a backstop. May `block_on` `ctx.runtime`.
+    fn tick(&mut self, ctx: &mut ThreadContext<'_>) -> ThreadOutcome;
+
+    /// Current health/heartbeat snapshot (last-run, next-run, last outcome).
+    fn health(&self) -> ThreadHealth;
+}
+
+/// Coarse class of a cognitive process.
+///
+/// The first three variants are implemented in this PR; the rest are reserved
+/// for the "mind of many processes" vision — the same [`super::Mind`] can host
+/// them later without a trait change.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize)]
+pub enum ThreadKind {
+    /// The primary active OODA loop (implemented).
+    Ooda,
+    /// Housekeeping / cleanup (implemented, exemplar 1).
+    Maintenance,
+    /// Engineer-log improvement finder (implemented, exemplar 2).
+    EngineerLogAnalysis,
+    /// Reserved: idle associative background thought.
+    BackgroundThought,
+    /// Reserved: sleep/dream memory consolidation.
+    MemoryConsolidation,
+    /// Reserved: sensory pre-processing.
+    SensoryProcessing,
+    /// Reserved: long-horizon planning.
+    LongTermPlanning,
+}
+
+/// How a thread decides it is due to run.
+#[derive(Clone, Debug, PartialEq)]
+pub enum SchedulePolicy {
+    /// Fixed cadence: `next_run = last_run + interval`.
+    Interval(Duration),
+    /// Only when explicitly requested (operator/event). Never auto-due.
+    OnDemand,
+    /// Due when an external predicate fires (a flag/predicate on the context).
+    EventDriven,
+    /// Cadence adapts to load/outcome within `min..=max`. Reserved; for now it
+    /// behaves as `Interval(current)` so it is representable but conservative.
+    Adaptive {
+        /// Lower cadence bound.
+        min: Duration,
+        /// Upper cadence bound.
+        max: Duration,
+        /// Current effective cadence.
+        current: Duration,
+    },
+}
+
+/// Priority / resource class. Ordered so ascending sort places OODA first:
+/// `Critical < High < Normal < Low`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, serde::Serialize)]
+pub enum Priority {
+    /// OODA only — never budgeted, never starved, never backed off.
+    Critical,
+    /// High-priority background work.
+    High,
+    /// Default class.
+    Normal,
+    /// Slow, best-effort housekeeping (maintenance, analysis).
+    Low,
+}
+
+/// Typed result of a single [`CognitiveThread::tick`].
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ThreadOutcome {
+    /// `false` => the thread was not due / skipped this tick.
+    pub ran: bool,
+    /// Whether the run succeeded.
+    pub success: bool,
+    /// Structured, human-readable summary.
+    pub summary: String,
+    /// Wall-clock duration of the run.
+    pub duration: Duration,
+    /// Thread-specific structured fields (never a snapshot doc).
+    pub detail: serde_json::Value,
+}
+
+impl ThreadOutcome {
+    /// The thread was not due / did no work this tick.
+    pub fn skipped() -> Self {
+        Self {
+            ran: false,
+            success: true,
+            summary: String::new(),
+            duration: Duration::ZERO,
+            detail: serde_json::Value::Null,
+        }
+    }
+
+    /// A successful run.
+    pub fn ok(summary: impl Into<String>, duration: Duration) -> Self {
+        Self {
+            ran: true,
+            success: true,
+            summary: summary.into(),
+            duration,
+            detail: serde_json::Value::Null,
+        }
+    }
+
+    /// A failed run.
+    pub fn failed(summary: impl Into<String>, duration: Duration) -> Self {
+        Self {
+            ran: true,
+            success: false,
+            summary: summary.into(),
+            duration,
+            detail: serde_json::Value::Null,
+        }
+    }
+
+    /// Attach structured detail (builder style).
+    #[must_use]
+    pub fn with_detail(mut self, detail: serde_json::Value) -> Self {
+        self.detail = detail;
+        self
+    }
+}
+
+/// Health/heartbeat snapshot for the dashboard and diagnostics.
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ThreadHealth {
+    /// Stable thread id.
+    pub id: String,
+    /// Whether the thread is currently enabled.
+    pub enabled: bool,
+    /// Unix epoch (seconds) of the last completed run, if any.
+    pub last_run_epoch: Option<u64>,
+    /// Unix epoch (seconds) of the next scheduled run, if computable.
+    pub next_run_epoch: Option<u64>,
+    /// Success flag of the most recent run, if any.
+    pub last_success: Option<bool>,
+    /// Consecutive error count (drives backoff).
+    pub consecutive_errors: u32,
+    /// If backed off, the epoch until which the thread is suppressed.
+    pub backoff_until_epoch: Option<u64>,
+}
+
+/// Borrowed daemon resources handed to each tick so threads do not reach into
+/// globals. `now_epoch` is an *injected* clock so due-computation and backoff
+/// are unit-testable with no sleeps.
+pub struct ThreadContext<'a> {
+    /// `~/.simard` state root.
+    pub state_root: &'a Path,
+    /// Repository root.
+    pub repo_root: &'a Path,
+    /// Live cognitive-store handle (`: Send + Sync`).
+    pub memory: &'a dyn CognitiveMemoryOps,
+    /// Runtime handle for `block_on`-ing async work inside a tick.
+    pub runtime: tokio::runtime::Handle,
+    /// Cooperative cancellation flag checked by the scheduler and long ticks.
+    pub shutdown: &'a AtomicBool,
+    /// Injected unix-epoch-seconds clock.
+    pub now_epoch: u64,
+    /// Global safety switch (dry-run everything destructive).
+    pub dry_run: bool,
+}

--- a/src/cognitive_threads/threads/engineer_log_analysis.rs
+++ b/src/cognitive_threads/threads/engineer_log_analysis.rs
@@ -1,0 +1,164 @@
+//! Exemplar 2 — [`EngineerLogAnalysisThread`]: the improvement finder
+//! (design §9, security SR-1..SR-4, SR-8..SR-11).
+//!
+//! On a cadence it scans **recent, bounded** engineer/OODA telemetry under the
+//! state root for recurring failure signatures and files a **deduplicated**
+//! GitHub issue via the existing deterministic stewardship path. Its durable
+//! artifact is a dedup'd issue (or, when `gh` is unavailable/dry-run,
+//! structured telemetry) — never a repo snapshot doc. Behaviour bodies are
+//! `todo!()` stubs during TDD; the config/type surface and the security-
+//! critical `build_issue_*` seams are pinned by tests in `super::super::tests`.
+#![allow(dead_code, unused_variables)]
+
+use crate::stewardship::gh_client::{GhClient, RealGhClient};
+
+use super::super::thread::{
+    CognitiveThread, Priority, SchedulePolicy, ThreadContext, ThreadHealth, ThreadKind,
+    ThreadOutcome,
+};
+
+/// Stable telemetry id.
+const ENGINEER_LOG_ANALYSIS_ID: &str = "engineer_log_analysis";
+
+/// Number of times a failure signature must recur within the window before it
+/// is treated as a durable finding (bounds noise; internal — not env-tunable).
+pub(crate) const MIN_RECURRENCE: u32 = 2;
+
+/// Tunables for [`EngineerLogAnalysisThread`] (all bounded — SR-8).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EngineerLogAnalysisConfig {
+    /// Cadence (`SIMARD_ENGINEER_LOG_ANALYSIS_INTERVAL_SECS`).
+    pub interval_secs: u64,
+    /// Target repo for issue filing (e.g. `"rysweet/Simard"`).
+    pub repo: String,
+    /// Bounded scan window in seconds (older telemetry is ignored).
+    pub window_secs: u64,
+    /// Hard cap on records scanned per run (SR-8).
+    pub max_records: usize,
+    /// Hard cap on findings emitted per run (SR-8).
+    pub max_findings: usize,
+    /// Suppress issue creation; emit structured telemetry only.
+    pub dry_run: bool,
+}
+
+impl Default for EngineerLogAnalysisConfig {
+    fn default() -> Self {
+        Self {
+            interval_secs: 6 * 60 * 60,
+            repo: "rysweet/Simard".to_string(),
+            window_secs: 7 * 24 * 60 * 60,
+            max_records: 500,
+            max_findings: 10,
+            dry_run: false,
+        }
+    }
+}
+
+/// The engineer-log-analysis cognitive thread (exemplar 2).
+pub struct EngineerLogAnalysisThread {
+    cfg: EngineerLogAnalysisConfig,
+    gh: Box<dyn GhClient + Send>,
+    last_run_epoch: Option<u64>,
+    next_run_epoch: Option<u64>,
+    last_success: Option<bool>,
+    consecutive_errors: u32,
+}
+
+impl EngineerLogAnalysisThread {
+    /// Build from the environment using the real `gh`-backed client.
+    pub fn from_env() -> Self {
+        let mut cfg = EngineerLogAnalysisConfig::default();
+        if let Some(v) = read_u64_env("SIMARD_ENGINEER_LOG_ANALYSIS_INTERVAL_SECS") {
+            cfg.interval_secs = super::super::schedule::clamp_interval_secs(v);
+        }
+        if let Some(v) = read_bool_env("SIMARD_ENGINEER_LOG_ANALYSIS_DRY_RUN") {
+            cfg.dry_run = v;
+        }
+        Self::with_client(cfg, Box::new(RealGhClient::new()))
+    }
+
+    /// Build from an explicit config with an injected [`GhClient`] (test seam —
+    /// a fake client keeps tests offline and credential-free). The client must
+    /// be `Send` so the thread satisfies [`CognitiveThread`]'s `Send` bound.
+    pub fn with_client(cfg: EngineerLogAnalysisConfig, gh: Box<dyn GhClient + Send>) -> Self {
+        Self {
+            cfg,
+            gh,
+            last_run_epoch: None,
+            next_run_epoch: None,
+            last_success: None,
+            consecutive_errors: 0,
+        }
+    }
+}
+
+impl CognitiveThread for EngineerLogAnalysisThread {
+    fn id(&self) -> &str {
+        ENGINEER_LOG_ANALYSIS_ID
+    }
+
+    fn kind(&self) -> ThreadKind {
+        ThreadKind::EngineerLogAnalysis
+    }
+
+    fn policy(&self) -> SchedulePolicy {
+        SchedulePolicy::Interval(std::time::Duration::from_secs(self.cfg.interval_secs))
+    }
+
+    fn priority(&self) -> Priority {
+        Priority::Low
+    }
+
+    fn tick(&mut self, ctx: &mut ThreadContext<'_>) -> ThreadOutcome {
+        todo!("Step 7 TDD: analysis body implemented by the implementation step")
+    }
+
+    fn health(&self) -> ThreadHealth {
+        ThreadHealth {
+            id: ENGINEER_LOG_ANALYSIS_ID.to_string(),
+            enabled: true,
+            last_run_epoch: self.last_run_epoch,
+            next_run_epoch: self.next_run_epoch,
+            last_success: self.last_success,
+            consecutive_errors: self.consecutive_errors,
+            backoff_until_epoch: None,
+        }
+    }
+}
+
+/// Build the deduplicated issue title for a finding (SR-2/SR-11).
+///
+/// Contract: length-bounded; the `signature` is embedded so the title is
+/// stable; the human-readable `failure_kind` excerpt is redacted via
+/// [`crate::sanitization::sanitize_terminal_text`] before inclusion.
+pub(crate) fn build_issue_title(signature: &str, failure_kind: &str) -> String {
+    todo!("Step 7 TDD: implemented by the implementation step")
+}
+
+/// Build the deduplicated issue body (SR-2/SR-3).
+///
+/// Contract (pinned by tests):
+/// - The trusted dedup marker `stewardship-signature: <signature>` appears
+///   **exactly once**, in a controlled (non-excerpt) location, so
+///   [`crate::stewardship::dedup::find_existing`] matches our computed
+///   signature.
+/// - The untrusted `excerpt` is passed through
+///   [`crate::sanitization::sanitize_terminal_text`] (redacting `token=` /
+///   `Authorization:` / `bearer ` etc. to `[REDACTED]`) **and** fenced in a
+///   code block so GitHub does not auto-link `@mentions`/`#refs`.
+/// - Any `stewardship-signature:` sequence smuggled inside the excerpt is
+///   neutralized so it cannot poison dedup (a spoofed signature must NOT be
+///   matchable by `find_existing`).
+pub(crate) fn build_issue_body(signature: &str, excerpt: &str) -> String {
+    todo!("Step 7 TDD: implemented by the implementation step")
+}
+
+fn read_u64_env(key: &str) -> Option<u64> {
+    std::env::var(key).ok().and_then(|s| s.trim().parse().ok())
+}
+
+fn read_bool_env(key: &str) -> Option<bool> {
+    std::env::var(key)
+        .ok()
+        .map(|s| matches!(s.trim(), "1" | "true" | "TRUE" | "yes" | "on"))
+}

--- a/src/cognitive_threads/threads/engineer_log_analysis.rs
+++ b/src/cognitive_threads/threads/engineer_log_analysis.rs
@@ -8,8 +8,16 @@
 //! structured telemetry) — never a repo snapshot doc. Behaviour bodies are
 //! `todo!()` stubs during TDD; the config/type surface and the security-
 //! critical `build_issue_*` seams are pinned by tests in `super::super::tests`.
-#![allow(dead_code, unused_variables)]
+#![allow(dead_code)]
 
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::time::Instant;
+
+use serde_json::json;
+
+use crate::sanitization::sanitize_terminal_text;
+use crate::stewardship::dedup;
 use crate::stewardship::gh_client::{GhClient, RealGhClient};
 
 use super::super::thread::{
@@ -110,7 +118,108 @@ impl CognitiveThread for EngineerLogAnalysisThread {
     }
 
     fn tick(&mut self, ctx: &mut ThreadContext<'_>) -> ThreadOutcome {
-        todo!("Step 7 TDD: analysis body implemented by the implementation step")
+        let start = Instant::now();
+        let dry_run = self.cfg.dry_run || ctx.dry_run;
+
+        // 1. Gather bounded, deduplicated failure signatures from recent
+        //    persisted cycle reports (SR-8 bounds work + cost).
+        let findings = collect_findings(
+            ctx.state_root,
+            ctx.now_epoch,
+            self.cfg.window_secs,
+            self.cfg.max_records,
+        );
+
+        let mut emitted = 0usize;
+        let mut created = 0usize;
+        let mut deduped = 0usize;
+        let mut errors: Vec<String> = Vec::new();
+
+        for (sig, finding) in findings.iter() {
+            // Only recurring signatures are durable findings (bounds noise).
+            if finding.count < MIN_RECURRENCE {
+                continue;
+            }
+            if emitted >= self.cfg.max_findings {
+                break;
+            }
+            emitted += 1;
+
+            // Dedup against already-filed issues (idempotency).
+            match self.gh.search_issues(&self.cfg.repo, sig) {
+                Ok(existing) => {
+                    if dedup::find_existing(&existing, sig).is_some() {
+                        deduped += 1;
+                        continue;
+                    }
+                }
+                Err(e) => {
+                    errors.push(format!("search failed: {e}"));
+                    continue;
+                }
+            }
+
+            if dry_run {
+                // Durable telemetry instead of an issue — never a repo doc.
+                tracing::info!(
+                    metric = "simard.thread.engineer_log_analysis.finding",
+                    signature = %sig,
+                    recurrence = finding.count,
+                    "engineer-log-analysis finding (dry-run: not filed)"
+                );
+                continue;
+            }
+
+            let title = build_issue_title(sig, &finding.failure_kind);
+            // `linewise` isolates inline `key=secret` pairs onto their own line
+            // so `sanitize_terminal_text` (inside build_issue_body) redacts them
+            // even when they are not at the start of the raw log line (SR-2).
+            let body = build_issue_body(sig, &linewise(&finding.excerpt));
+            match self.gh.create_issue(&self.cfg.repo, &title, &body) {
+                Ok(issue) => {
+                    created += 1;
+                    tracing::info!(
+                        metric = "simard.thread.engineer_log_analysis.issue_filed",
+                        signature = %sig,
+                        number = issue.number,
+                        "engineer-log-analysis filed deduplicated issue"
+                    );
+                }
+                Err(e) => errors.push(format!("create failed: {e}")),
+            }
+        }
+
+        let success = errors.is_empty();
+        self.last_run_epoch = Some(ctx.now_epoch);
+        self.next_run_epoch = super::super::schedule::next_run_epoch(
+            &self.policy(),
+            self.last_run_epoch,
+            ctx.now_epoch,
+        );
+        self.last_success = Some(success);
+        if success {
+            self.consecutive_errors = 0;
+        } else {
+            self.consecutive_errors = self.consecutive_errors.saturating_add(1);
+        }
+
+        let summary = format!(
+            "engineer-log-analysis: {emitted} recurring finding(s), {created} filed, \
+             {deduped} deduped, {} error(s)",
+            errors.len()
+        );
+        let detail = json!({
+            "dry_run": dry_run,
+            "findings": emitted,
+            "created": created,
+            "deduped": deduped,
+            "errors": errors,
+        });
+        if success {
+            ThreadOutcome::ok(summary, start.elapsed()).with_detail(detail)
+        } else {
+            ThreadOutcome::failed(summary, start.elapsed()).with_detail(detail)
+        }
     }
 
     fn health(&self) -> ThreadHealth {
@@ -132,25 +241,187 @@ impl CognitiveThread for EngineerLogAnalysisThread {
 /// stable; the human-readable `failure_kind` excerpt is redacted via
 /// [`crate::sanitization::sanitize_terminal_text`] before inclusion.
 pub(crate) fn build_issue_title(signature: &str, failure_kind: &str) -> String {
-    todo!("Step 7 TDD: implemented by the implementation step")
+    // The failure_kind can carry excerpted (untrusted) text — redact + bound it
+    // and keep the title stable via the trusted signature.
+    let kind = sanitize_terminal_text(failure_kind);
+    let kind = kind.lines().next().unwrap_or("").trim();
+    let kind = truncate_chars(kind, 80);
+    let kind = if kind.is_empty() {
+        "engineer failure"
+    } else {
+        kind.as_str()
+    };
+    format!("[cognitive-thread] recurring {kind} ({signature})")
 }
 
-/// Build the deduplicated issue body (SR-2/SR-3).
-///
-/// Contract (pinned by tests):
-/// - The trusted dedup marker `stewardship-signature: <signature>` appears
-///   **exactly once**, in a controlled (non-excerpt) location, so
-///   [`crate::stewardship::dedup::find_existing`] matches our computed
-///   signature.
-/// - The untrusted `excerpt` is passed through
-///   [`crate::sanitization::sanitize_terminal_text`] (redacting `token=` /
-///   `Authorization:` / `bearer ` etc. to `[REDACTED]`) **and** fenced in a
-///   code block so GitHub does not auto-link `@mentions`/`#refs`.
-/// - Any `stewardship-signature:` sequence smuggled inside the excerpt is
-///   neutralized so it cannot poison dedup (a spoofed signature must NOT be
-///   matchable by `find_existing`).
+/// Build the deduplicated issue body (SR-2/SR-3): sanitize + neutralize +
+/// fence the untrusted excerpt, then append the trusted dedup marker exactly
+/// once in a controlled location.
 pub(crate) fn build_issue_body(signature: &str, excerpt: &str) -> String {
-    todo!("Step 7 TDD: implemented by the implementation step")
+    // 1. Redact secrets + strip terminal control sequences (SR-2).
+    let sanitized = sanitize_terminal_text(excerpt);
+    // 2. Neutralize any dedup marker smuggled inside the untrusted excerpt so a
+    //    spoofed `stewardship-signature: <sig>` cannot poison dedup (SR-3).
+    let neutralized = neutralize_markers(&sanitized);
+    // 3. Bound length, then escape fence break-outs so the excerpt stays inside
+    //    its code block (which also stops GitHub auto-linking @mentions/#refs).
+    let bounded = truncate_chars(neutralized.trim(), 4_000);
+    let fenced = bounded.replace("```", "'''");
+
+    format!(
+        "## Cognitive-thread finding: recurring engineer failure\n\
+         \n\
+         The `engineer_log_analysis` cognitive thread observed this failure \
+         signature recur across recent OODA cycles. Representative sanitized \
+         excerpt (secrets redacted, fenced to suppress auto-links):\n\
+         \n\
+         ```text\n\
+         {fenced}\n\
+         ```\n\
+         \n\
+         <!-- deduplication marker — do not edit -->\n\
+         stewardship-signature: {signature}\n"
+    )
+}
+
+/// One representative record for a recurring failure signature.
+struct Finding {
+    count: u32,
+    failure_kind: String,
+    excerpt: String,
+}
+
+/// Scan up to `max_records` failed outcomes from the newest persisted cycle
+/// reports under `state_root/cycle_reports/`, grouping them by failure
+/// signature. Best-effort: unreadable/unparseable reports are skipped. The
+/// scan is bounded (SR-8); `window_secs` additionally drops reports that carry
+/// an explicit `cycle_start_epoch` older than the window.
+fn collect_findings(
+    state_root: &Path,
+    now_epoch: u64,
+    window_secs: u64,
+    max_records: usize,
+) -> BTreeMap<String, Finding> {
+    let mut findings: BTreeMap<String, Finding> = BTreeMap::new();
+    let dir = state_root.join("cycle_reports");
+    let read = match std::fs::read_dir(&dir) {
+        Ok(r) => r,
+        Err(_) => return findings,
+    };
+
+    // Newest reports first so a bounded scan sees the most recent failures.
+    let mut files: Vec<(std::path::PathBuf, std::time::SystemTime)> = read
+        .flatten()
+        .filter(|e| e.path().extension().is_some_and(|x| x == "json"))
+        .map(|e| {
+            let m = e
+                .metadata()
+                .and_then(|m| m.modified())
+                .unwrap_or(std::time::UNIX_EPOCH);
+            (e.path(), m)
+        })
+        .collect();
+    files.sort_by_key(|entry| std::cmp::Reverse(entry.1));
+
+    let mut scanned = 0usize;
+    for (path, _) in files {
+        if scanned >= max_records {
+            break;
+        }
+        let value: serde_json::Value = match std::fs::read_to_string(&path)
+            .ok()
+            .and_then(|t| serde_json::from_str(&t).ok())
+        {
+            Some(v) => v,
+            None => continue,
+        };
+
+        // Optional window filter — only applies when the report timestamps
+        // itself; otherwise the report is considered in-window.
+        if window_secs > 0
+            && let Some(epoch) = value.get("cycle_start_epoch").and_then(|v| v.as_u64())
+            && epoch != 0
+            && now_epoch.saturating_sub(epoch) > window_secs
+        {
+            continue;
+        }
+
+        let Some(outcomes) = value.get("outcomes").and_then(|v| v.as_array()) else {
+            continue;
+        };
+        for o in outcomes {
+            if scanned >= max_records {
+                break;
+            }
+            scanned += 1;
+            if o.get("success").and_then(|v| v.as_bool()).unwrap_or(true) {
+                continue;
+            }
+            let detail = o
+                .get("detail")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .trim();
+            if detail.is_empty() {
+                continue;
+            }
+            let action_kind = o
+                .get("action_kind")
+                .and_then(|v| v.as_str())
+                .unwrap_or("action");
+            let failure_kind = format!("engineer_failure:{action_kind}");
+            let sig = dedup::failure_signature(&failure_kind, detail);
+            let entry = findings.entry(sig).or_insert_with(|| Finding {
+                count: 0,
+                failure_kind: failure_kind.clone(),
+                excerpt: detail.to_string(),
+            });
+            entry.count = entry.count.saturating_add(1);
+        }
+    }
+    findings
+}
+
+/// Break an inline log line into one whitespace token per line so
+/// `sanitize_terminal_text` can redact `key=secret` pairs that are not at the
+/// start of the raw line (defense against inline secret leakage — SR-2).
+fn linewise(detail: &str) -> String {
+    detail.split_whitespace().collect::<Vec<_>>().join("\n")
+}
+
+/// Defeat any `stewardship-signature` sequence embedded in untrusted text by
+/// inserting a benign marker after the phrase, so the exact dedup needle
+/// `stewardship-signature: <sig>` can never be forged from an excerpt (SR-3).
+fn neutralize_markers(s: &str) -> String {
+    const NEEDLE: &str = "stewardship-signature";
+    let lower = s.to_ascii_lowercase();
+    if !lower.contains(NEEDLE) {
+        return s.to_string();
+    }
+    // ASCII-lowercasing preserves byte length, so byte offsets align between
+    // `s` and `lower`.
+    let mut out = String::with_capacity(s.len() + 16);
+    let mut i = 0;
+    while i < s.len() {
+        if lower[i..].starts_with(NEEDLE) {
+            out.push_str(&s[i..i + NEEDLE.len()]);
+            out.push_str("(excerpt)");
+            i += NEEDLE.len();
+        } else {
+            let ch = s[i..].chars().next().expect("valid char boundary");
+            out.push(ch);
+            i += ch.len_utf8();
+        }
+    }
+    out
+}
+
+/// Truncate to at most `max` chars on a UTF-8 boundary (length bounding).
+fn truncate_chars(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    s.chars().take(max).collect()
 }
 
 fn read_u64_env(key: &str) -> Option<u64> {

--- a/src/cognitive_threads/threads/maintenance.rs
+++ b/src/cognitive_threads/threads/maintenance.rs
@@ -1,0 +1,162 @@
+//! Exemplar 1 — [`MaintenanceThread`]: SAFE, conservative housekeeping
+//! (design §8, security SR-5..SR-7).
+//!
+//! On a slow cadence it prunes stale quarantine/snapshot/backup artefacts under
+//! the state root by reusing the existing `cmd_cleanup::disk` / `memory_backup`
+//! helpers — never reimplementing them. Every destructive candidate must pass
+//! the canonical allow/deny + symlink-refusal gate ([`is_safe_to_delete`]) and
+//! honour `ctx.dry_run`. Behaviour bodies are `todo!()` stubs during TDD; the
+//! config/type surface is real so tests can pin the safety contract.
+#![allow(dead_code, unused_variables)]
+
+use std::path::{Path, PathBuf};
+
+use super::super::thread::{
+    CognitiveThread, Priority, SchedulePolicy, ThreadContext, ThreadHealth, ThreadKind,
+    ThreadOutcome,
+};
+
+/// Stable telemetry id.
+const MAINTENANCE_ID: &str = "maintenance";
+
+/// Tunables for [`MaintenanceThread`]. Retention counts are floors: the thread
+/// always keeps at least this many of the newest copies before pruning.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MaintenanceConfig {
+    /// Cadence (`SIMARD_MAINTENANCE_INTERVAL_SECS`, default daily).
+    pub interval_secs: u64,
+    /// Retention floor for `cognitive.corrupt-*` quarantine dirs (>= 1).
+    pub keep_corrupt: usize,
+    /// Retention floor for store snapshots / shadow WAL copies (>= 1).
+    pub keep_snapshots: usize,
+    /// Retention floor for verified backups (>= 1).
+    pub keep_backups: usize,
+    /// Cap for runaway cargo target dirs, in bytes.
+    pub target_cap_bytes: u64,
+    /// Dry-run: log intended actions, delete nothing
+    /// (`SIMARD_MAINTENANCE_DRY_RUN`). Defaults to `true` (opt-in destructive).
+    pub dry_run: bool,
+}
+
+impl Default for MaintenanceConfig {
+    fn default() -> Self {
+        Self {
+            interval_secs: 24 * 60 * 60,
+            keep_corrupt: 3,
+            keep_snapshots: 5,
+            keep_backups: 7,
+            target_cap_bytes: 20 * 1024 * 1024 * 1024,
+            dry_run: true,
+        }
+    }
+}
+
+/// The maintenance/cleanup cognitive thread (exemplar 1).
+pub struct MaintenanceThread {
+    cfg: MaintenanceConfig,
+    last_run_epoch: Option<u64>,
+    next_run_epoch: Option<u64>,
+    last_success: Option<bool>,
+    consecutive_errors: u32,
+}
+
+impl MaintenanceThread {
+    /// Build from the environment with safe defaults (retention floors >= 1,
+    /// `dry_run` unless explicitly disabled).
+    pub fn from_env() -> Self {
+        let mut cfg = MaintenanceConfig::default();
+        if let Some(v) = read_u64_env("SIMARD_MAINTENANCE_INTERVAL_SECS") {
+            cfg.interval_secs = super::super::schedule::clamp_interval_secs(v);
+        }
+        if let Some(v) = read_usize_env("SIMARD_MAINTENANCE_KEEP_CORRUPT") {
+            cfg.keep_corrupt = v.max(1);
+        }
+        if let Some(v) = read_usize_env("SIMARD_MAINTENANCE_KEEP_SNAPSHOTS") {
+            cfg.keep_snapshots = v.max(1);
+        }
+        if let Some(v) = read_usize_env("SIMARD_MAINTENANCE_KEEP_BACKUPS") {
+            cfg.keep_backups = v.max(1);
+        }
+        if let Some(v) = read_bool_env("SIMARD_MAINTENANCE_DRY_RUN") {
+            cfg.dry_run = v;
+        }
+        Self::new(cfg)
+    }
+
+    /// Build from an explicit config (test seam — no env).
+    pub fn new(cfg: MaintenanceConfig) -> Self {
+        Self {
+            cfg,
+            last_run_epoch: None,
+            next_run_epoch: None,
+            last_success: None,
+            consecutive_errors: 0,
+        }
+    }
+}
+
+impl CognitiveThread for MaintenanceThread {
+    fn id(&self) -> &str {
+        MAINTENANCE_ID
+    }
+
+    fn kind(&self) -> ThreadKind {
+        ThreadKind::Maintenance
+    }
+
+    fn policy(&self) -> SchedulePolicy {
+        SchedulePolicy::Interval(std::time::Duration::from_secs(self.cfg.interval_secs))
+    }
+
+    fn priority(&self) -> Priority {
+        Priority::Low
+    }
+
+    fn tick(&mut self, ctx: &mut ThreadContext<'_>) -> ThreadOutcome {
+        todo!("Step 7 TDD: maintenance body implemented by the implementation step")
+    }
+
+    fn health(&self) -> ThreadHealth {
+        ThreadHealth {
+            id: MAINTENANCE_ID.to_string(),
+            enabled: true,
+            last_run_epoch: self.last_run_epoch,
+            next_run_epoch: self.next_run_epoch,
+            last_success: self.last_success,
+            consecutive_errors: self.consecutive_errors,
+            backoff_until_epoch: None,
+        }
+    }
+}
+
+/// SR-5/SR-6 destructive-op gate. Returns `true` only when `candidate` is safe
+/// to remove:
+/// - it canonicalizes to a path **inside** one of `allow_roots`;
+/// - it is **not** a symlink (refuse `symlink_metadata().is_symlink()`), which
+///   defeats `..`/symlink traversal and the TOCTOU swap;
+/// - it does **not** equal or sit under any `deny_paths` entry (protected roots
+///   such as `worktrees/main`, `~/.simard/repo`, the live store, engineer
+///   worktrees).
+///
+/// Anything not provably inside an allow-root is refused (fail-closed).
+pub(crate) fn is_safe_to_delete(
+    candidate: &Path,
+    allow_roots: &[PathBuf],
+    deny_paths: &[PathBuf],
+) -> bool {
+    todo!("Step 7 TDD: SR-5/6 safety gate implemented by the implementation step")
+}
+
+fn read_u64_env(key: &str) -> Option<u64> {
+    std::env::var(key).ok().and_then(|s| s.trim().parse().ok())
+}
+
+fn read_usize_env(key: &str) -> Option<usize> {
+    std::env::var(key).ok().and_then(|s| s.trim().parse().ok())
+}
+
+fn read_bool_env(key: &str) -> Option<bool> {
+    std::env::var(key)
+        .ok()
+        .map(|s| matches!(s.trim(), "1" | "true" | "TRUE" | "yes" | "on"))
+}

--- a/src/cognitive_threads/threads/maintenance.rs
+++ b/src/cognitive_threads/threads/maintenance.rs
@@ -7,9 +7,12 @@
 //! the canonical allow/deny + symlink-refusal gate ([`is_safe_to_delete`]) and
 //! honour `ctx.dry_run`. Behaviour bodies are `todo!()` stubs during TDD; the
 //! config/type surface is real so tests can pin the safety contract.
-#![allow(dead_code, unused_variables)]
+#![allow(dead_code)]
 
 use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use serde_json::json;
 
 use super::super::thread::{
     CognitiveThread, Priority, SchedulePolicy, ThreadContext, ThreadHealth, ThreadKind,
@@ -113,7 +116,88 @@ impl CognitiveThread for MaintenanceThread {
     }
 
     fn tick(&mut self, ctx: &mut ThreadContext<'_>) -> ThreadOutcome {
-        todo!("Step 7 TDD: maintenance body implemented by the implementation step")
+        let start = Instant::now();
+        // Dry-run if EITHER the thread config or the global switch asks for it.
+        let dry_run = self.cfg.dry_run || ctx.dry_run;
+        let root = ctx.state_root;
+
+        // Fail-closed allow-list: only ever consider paths strictly under the
+        // injected state root. Deny-list: protected roots that must survive
+        // even when they sit under the state root.
+        let allow_roots = vec![root.to_path_buf()];
+        let deny_paths = protected_paths(root, ctx.repo_root);
+
+        let mut report = PruneReport::default();
+
+        // 1) Quarantine dirs left by corrupt-store recovery.
+        prune_prefixed(
+            root,
+            &["cognitive.corrupt-"],
+            self.cfg.keep_corrupt,
+            dry_run,
+            &allow_roots,
+            &deny_paths,
+            &mut report,
+        );
+        // 2) Store snapshots / shadow-WAL copies staged for recovery.
+        prune_prefixed(
+            root,
+            &["cognitive.snapshot-", "snapshot-", "shadow-wal-", "shadow-"],
+            self.cfg.keep_snapshots,
+            dry_run,
+            &allow_roots,
+            &deny_paths,
+            &mut report,
+        );
+        // 3) Verified backups — keep the newest N.
+        prune_prefixed(
+            root,
+            &["backup-", "verified-backup-"],
+            self.cfg.keep_backups,
+            dry_run,
+            &allow_roots,
+            &deny_paths,
+            &mut report,
+        );
+
+        // 4) Read-only disk-pressure observation (reuses the shared helper —
+        //    never reimplemented). Best-effort; failure is not fatal.
+        let disk = crate::disk_pressure::check_with_default_threshold(root)
+            .ok()
+            .map(|r| {
+                json!({
+                    "free_bytes": r.free_bytes,
+                    "total_bytes": r.total_bytes,
+                    "should_refuse": r.should_refuse(),
+                })
+            })
+            .unwrap_or(serde_json::Value::Null);
+
+        self.last_run_epoch = Some(ctx.now_epoch);
+        self.next_run_epoch = super::super::schedule::next_run_epoch(
+            &self.policy(),
+            self.last_run_epoch,
+            ctx.now_epoch,
+        );
+        self.last_success = Some(true);
+        self.consecutive_errors = 0;
+
+        let verb = if dry_run { "would prune" } else { "pruned" };
+        let summary = format!(
+            "maintenance: {verb} {} artefact(s) ({} freed), {} refused by safety gate",
+            report.removed,
+            crate::disk_pressure::human_bytes(report.freed_bytes),
+            report.refused,
+        );
+        let detail = json!({
+            "dry_run": dry_run,
+            "removed": report.removed,
+            "refused": report.refused,
+            "freed_bytes": report.freed_bytes,
+            "actions": report.actions,
+            "disk": disk,
+        });
+        ThreadOutcome::ok(summary, start.elapsed()).with_detail(detail)
     }
 
     fn health(&self) -> ThreadHealth {
@@ -144,7 +228,165 @@ pub(crate) fn is_safe_to_delete(
     allow_roots: &[PathBuf],
     deny_paths: &[PathBuf],
 ) -> bool {
-    todo!("Step 7 TDD: SR-5/6 safety gate implemented by the implementation step")
+    // 1. Must exist and NOT be a symlink. `symlink_metadata` does not follow
+    //    the final component, so a swapped symlink is refused here (SR-5)
+    //    before any canonicalization can be tricked into resolving it.
+    let meta = match std::fs::symlink_metadata(candidate) {
+        Ok(m) => m,
+        Err(_) => return false, // fail-closed on any stat error
+    };
+    if meta.file_type().is_symlink() {
+        return false;
+    }
+
+    // 2. Resolve to a real, canonical path (defeats `..`/traversal).
+    let real = match std::fs::canonicalize(candidate) {
+        Ok(p) => p,
+        Err(_) => return false,
+    };
+
+    // 3. Must be strictly INSIDE at least one canonical allow-root. Equalling
+    //    a root, or living outside every root, is refused (fail-closed).
+    let inside_allow = allow_roots.iter().any(|root| {
+        std::fs::canonicalize(root)
+            .map(|r| real != r && real.starts_with(&r))
+            .unwrap_or(false)
+    });
+    if !inside_allow {
+        return false;
+    }
+
+    // 4. Must not equal or sit under any protected deny path (SR-6).
+    for deny in deny_paths {
+        // Compare against the canonical deny path when it exists; otherwise
+        // fall back to a literal prefix check so a not-yet-created protected
+        // path still shields its future location.
+        let denied = match std::fs::canonicalize(deny) {
+            Ok(d) => real == d || real.starts_with(&d),
+            Err(_) => real == *deny || real.starts_with(deny),
+        };
+        if denied {
+            return false;
+        }
+    }
+
+    true
+}
+
+/// Protected roots that must never be pruned even when they live under the
+/// state root: the live repo checkout, the live cognitive store, `worktrees/`
+/// (main + engineer worktrees), and the recovered-repo mirror.
+fn protected_paths(state_root: &Path, repo_root: &Path) -> Vec<PathBuf> {
+    vec![
+        repo_root.to_path_buf(),
+        state_root.join("repo"),
+        state_root.join("cognitive.redb"),
+        state_root.join("cognitive"),
+        state_root.join("worktrees"),
+        state_root.join("worktrees/main"),
+        state_root.join("engineer-worktrees"),
+    ]
+}
+
+/// Accumulated structured record of one maintenance pass.
+#[derive(Default)]
+struct PruneReport {
+    removed: usize,
+    refused: usize,
+    freed_bytes: u64,
+    actions: Vec<serde_json::Value>,
+}
+
+/// Prune stale entries directly under `root` whose file name starts with any of
+/// `prefixes`, keeping the newest `keep` (by mtime). Every destructive
+/// candidate must pass [`is_safe_to_delete`]; `dry_run` records the intended
+/// action without touching the filesystem. Best-effort throughout — a single
+/// I/O error is recorded and skipped, never propagated.
+#[allow(clippy::too_many_arguments)]
+fn prune_prefixed(
+    root: &Path,
+    prefixes: &[&str],
+    keep: usize,
+    dry_run: bool,
+    allow_roots: &[PathBuf],
+    deny_paths: &[PathBuf],
+    report: &mut PruneReport,
+) {
+    let read = match std::fs::read_dir(root) {
+        Ok(r) => r,
+        Err(_) => return,
+    };
+
+    // Collect (path, mtime) for entries matching any prefix.
+    let mut matches: Vec<(PathBuf, std::time::SystemTime)> = Vec::new();
+    for entry in read.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if !prefixes.iter().any(|p| name.starts_with(p)) {
+            continue;
+        }
+        let mtime = entry
+            .metadata()
+            .and_then(|m| m.modified())
+            .unwrap_or(std::time::UNIX_EPOCH);
+        matches.push((entry.path(), mtime));
+    }
+
+    // Newest first; keep the retention floor, consider the rest for pruning.
+    matches.sort_by_key(|entry| std::cmp::Reverse(entry.1));
+    let keep = keep.max(1);
+    if matches.len() <= keep {
+        return;
+    }
+
+    for (path, _) in matches.into_iter().skip(keep) {
+        if !is_safe_to_delete(&path, allow_roots, deny_paths) {
+            report.refused += 1;
+            report.actions.push(json!({
+                "action": "refused",
+                "path": path.display().to_string(),
+                "reason": "failed safety gate",
+            }));
+            continue;
+        }
+
+        let size = crate::cmd_cleanup::disk::dir_size(&path).unwrap_or(0);
+        if dry_run {
+            report.actions.push(json!({
+                "action": "would_prune",
+                "path": path.display().to_string(),
+                "bytes": size,
+            }));
+            report.removed += 1;
+            report.freed_bytes = report.freed_bytes.saturating_add(size);
+            continue;
+        }
+
+        let result = if path.is_dir() {
+            std::fs::remove_dir_all(&path)
+        } else {
+            std::fs::remove_file(&path)
+        };
+        match result {
+            Ok(()) => {
+                report.removed += 1;
+                report.freed_bytes = report.freed_bytes.saturating_add(size);
+                report.actions.push(json!({
+                    "action": "pruned",
+                    "path": path.display().to_string(),
+                    "bytes": size,
+                }));
+            }
+            Err(e) => {
+                report.refused += 1;
+                report.actions.push(json!({
+                    "action": "error",
+                    "path": path.display().to_string(),
+                    "reason": e.to_string(),
+                }));
+            }
+        }
+    }
 }
 
 fn read_u64_env(key: &str) -> Option<u64> {

--- a/src/cognitive_threads/threads/mod.rs
+++ b/src/cognitive_threads/threads/mod.rs
@@ -1,0 +1,13 @@
+//! Concrete [`super::CognitiveThread`] implementations.
+//!
+//! - [`OodaThread`] — the primary loop (kind = `Ooda`, priority = `Critical`).
+//! - [`MaintenanceThread`] — safe housekeeping (exemplar 1).
+//! - [`EngineerLogAnalysisThread`] — improvement finder (exemplar 2).
+
+pub mod engineer_log_analysis;
+pub mod maintenance;
+pub mod ooda;
+
+pub use engineer_log_analysis::{EngineerLogAnalysisConfig, EngineerLogAnalysisThread};
+pub use maintenance::{MaintenanceConfig, MaintenanceThread};
+pub use ooda::OodaThread;

--- a/src/cognitive_threads/threads/ooda.rs
+++ b/src/cognitive_threads/threads/ooda.rs
@@ -1,0 +1,87 @@
+//! The primary [`OodaThread`] — the active OODA loop fitted into the
+//! cognitive-thread abstraction (design §6).
+//!
+//! `kind = Ooda`, `priority = Critical`, `policy = Interval(interval_secs)`.
+//! Its `tick()` performs the exact current per-cycle work in the same order
+//! (heartbeat → `run_ooda_cycle` → persist report/episode/health/metrics), so
+//! the daemon's external cadence and side-effects are byte-for-byte preserved.
+//! The `tick()` body is a `todo!()` stub during TDD; the OODA state/bridges/
+//! config it owns are moved in at construction, matching Appendix A.7/A.9.
+#![allow(dead_code, unused_variables)]
+
+use crate::ooda_loop::{OodaBridges, OodaConfig, OodaState};
+
+use super::super::thread::{
+    CognitiveThread, Priority, SchedulePolicy, ThreadContext, ThreadHealth, ThreadKind,
+    ThreadOutcome,
+};
+
+/// Stable telemetry id for the primary loop.
+const OODA_ID: &str = "ooda";
+
+/// The primary cognitive thread: owns the mutable OODA state and drives one
+/// `run_ooda_cycle` per tick.
+pub struct OodaThread {
+    state: OodaState,
+    bridges: OodaBridges,
+    config: OodaConfig,
+    interval_secs: u64,
+    last_run_epoch: Option<u64>,
+    next_run_epoch: Option<u64>,
+    last_success: Option<bool>,
+}
+
+impl OodaThread {
+    /// Construct the primary thread from the daemon's OODA resources (moved in)
+    /// and the configured cadence (`SIMARD_OODA_INTERVAL_SECS`).
+    pub fn new(
+        state: OodaState,
+        bridges: OodaBridges,
+        config: OodaConfig,
+        interval_secs: u64,
+    ) -> Self {
+        Self {
+            state,
+            bridges,
+            config,
+            interval_secs,
+            last_run_epoch: None,
+            next_run_epoch: None,
+            last_success: None,
+        }
+    }
+}
+
+impl CognitiveThread for OodaThread {
+    fn id(&self) -> &str {
+        OODA_ID
+    }
+
+    fn kind(&self) -> ThreadKind {
+        ThreadKind::Ooda
+    }
+
+    fn policy(&self) -> SchedulePolicy {
+        SchedulePolicy::Interval(std::time::Duration::from_secs(self.interval_secs))
+    }
+
+    fn priority(&self) -> Priority {
+        Priority::Critical
+    }
+
+    fn tick(&mut self, ctx: &mut ThreadContext<'_>) -> ThreadOutcome {
+        todo!("Step 7 TDD: OODA-as-thread body implemented by the implementation step")
+    }
+
+    fn health(&self) -> ThreadHealth {
+        ThreadHealth {
+            id: OODA_ID.to_string(),
+            enabled: true,
+            last_run_epoch: self.last_run_epoch,
+            next_run_epoch: self.next_run_epoch,
+            last_success: self.last_success,
+            consecutive_errors: 0,
+            backoff_until_epoch: None,
+        }
+    }
+}

--- a/src/cognitive_threads/threads/ooda.rs
+++ b/src/cognitive_threads/threads/ooda.rs
@@ -7,9 +7,11 @@
 //! the daemon's external cadence and side-effects are byte-for-byte preserved.
 //! The `tick()` body is a `todo!()` stub during TDD; the OODA state/bridges/
 //! config it owns are moved in at construction, matching Appendix A.7/A.9.
-#![allow(dead_code, unused_variables)]
 
-use crate::ooda_loop::{OodaBridges, OodaConfig, OodaState};
+use std::time::Instant;
+
+use crate::ooda_loop::{OodaBridges, OodaConfig, OodaPhase, OodaState};
+use crate::operator_commands_ooda::persistence::{persist_cycle_report, persist_cycle_to_memory};
 
 use super::super::thread::{
     CognitiveThread, Priority, SchedulePolicy, ThreadContext, ThreadHealth, ThreadKind,
@@ -26,6 +28,7 @@ pub struct OodaThread {
     bridges: OodaBridges,
     config: OodaConfig,
     interval_secs: u64,
+    cycles: u64,
     last_run_epoch: Option<u64>,
     next_run_epoch: Option<u64>,
     last_success: Option<bool>,
@@ -45,10 +48,18 @@ impl OodaThread {
             bridges,
             config,
             interval_secs,
+            cycles: 0,
             last_run_epoch: None,
             next_run_epoch: None,
             last_success: None,
         }
+    }
+
+    /// Reclaim the owned OODA resources (for the daemon's post-loop graceful
+    /// shutdown, which flushes the board and closes the session). Supports the
+    /// full cutover where the daemon drives OODA solely through this thread.
+    pub fn into_parts(self) -> (OodaState, OodaBridges) {
+        (self.state, self.bridges)
     }
 }
 
@@ -70,7 +81,50 @@ impl CognitiveThread for OodaThread {
     }
 
     fn tick(&mut self, ctx: &mut ThreadContext<'_>) -> ThreadOutcome {
-        todo!("Step 7 TDD: OODA-as-thread body implemented by the implementation step")
+        let start = Instant::now();
+        self.cycles = self.cycles.saturating_add(1);
+        self.state.cycle_start_epoch = ctx.now_epoch;
+
+        // One complete OODA cycle, then the SAME canonical per-cycle side
+        // effects the daemon performs (report + episode persistence + metrics),
+        // via the shared `persist_*` helpers so there is a single source of
+        // truth for the cycle's durable output.
+        let outcome = match crate::ooda_loop::run_ooda_cycle(
+            &mut self.state,
+            &mut self.bridges,
+            &self.config,
+        ) {
+            Ok(report) => {
+                let elapsed = start.elapsed();
+                let summary = crate::ooda_loop::summarize_cycle_report(&report);
+                self.state.last_cycle_summary = Some(summary.clone());
+                self.state.last_cycle_duration_secs = Some(elapsed.as_secs());
+                self.state.current_phase = OodaPhase::Sleep;
+
+                persist_cycle_report(ctx.state_root, &report);
+                persist_cycle_to_memory(&self.bridges, &report);
+                let _ = crate::self_metrics::collect_and_record_all(elapsed);
+
+                self.last_success = Some(true);
+                ThreadOutcome::ok(summary, elapsed).with_detail(serde_json::json!({
+                    "cycle": self.cycles,
+                    "cycle_number": report.cycle_number,
+                }))
+            }
+            Err(e) => {
+                let elapsed = start.elapsed();
+                self.last_success = Some(false);
+                ThreadOutcome::failed(format!("OODA cycle error: {e}"), elapsed)
+            }
+        };
+
+        self.last_run_epoch = Some(ctx.now_epoch);
+        self.next_run_epoch = super::super::schedule::next_run_epoch(
+            &self.policy(),
+            self.last_run_epoch,
+            ctx.now_epoch,
+        );
+        outcome
     }
 
     fn health(&self) -> ThreadHealth {
@@ -80,6 +134,8 @@ impl CognitiveThread for OodaThread {
             last_run_epoch: self.last_run_epoch,
             next_run_epoch: self.next_run_epoch,
             last_success: self.last_success,
+            // OODA is never backed off (Priority::Critical); the scheduler
+            // enforces this and never accrues errors against it.
             consecutive_errors: 0,
             backoff_until_epoch: None,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,12 @@ pub mod cmd_ensure_deps;
 pub mod cmd_install;
 pub mod cmd_self_update;
 pub mod cognitive_memory;
+// Issue #2419: cognitive-thread scheduling — a `Mind` runs many
+// `CognitiveThread`s (the primary OODA loop + maintenance + engineer-log
+// analysis) on their own cadence/trigger. Sibling of `ooda_scheduler` (the
+// engineer action-slot scheduler), which is unrelated and untouched. See
+// `docs/reference/cognitive-thread-scheduling.md`.
+pub mod cognitive_threads;
 // Issue #2419: periodic brain self-examination + memory-hygiene pass — a
 // higher-level introspection layer that reuses the existing distillation /
 // statistics / expired-sensory infra (mirrors `disk_health`). Tests live in a

--- a/src/operator_commands_ooda/daemon/mod.rs
+++ b/src/operator_commands_ooda/daemon/mod.rs
@@ -513,6 +513,54 @@ pub fn run_ooda_daemon(
     );
     // -------------------------------------------------------------------
 
+    // ── Cognitive-thread scheduler (issue #2419) ───────────────────────
+    // ADDITIVE and OFF by default. When SIMARD_COGNITIVE_THREADS_ENABLED is
+    // truthy, a `Mind` hosts NEW background cognitive threads (safe
+    // maintenance/cleanup + engineer-log analysis) on their own cadence,
+    // subsuming the ad-hoc periodic-task pattern for these threads. OODA
+    // itself stays driven by this loop's authoritative inline cycle below so
+    // its external cadence and side-effects are byte-for-byte preserved; the
+    // scheduler is invoked only AFTER the inline cycle and never gates it.
+    let cognitive_threads_enabled = std::env::var("SIMARD_COGNITIVE_THREADS_ENABLED")
+        .ok()
+        .map(|s| matches!(s.trim(), "1" | "true" | "TRUE" | "yes" | "on"))
+        .unwrap_or(false);
+    let cognitive_repo_root = bridges.repo_root.clone();
+    let cognitive_runtime = if cognitive_threads_enabled {
+        match tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+        {
+            Ok(rt) => Some(rt),
+            Err(e) => {
+                daemon_log(
+                    &state_root,
+                    &format!("[simard] WARN: cognitive-thread runtime build failed: {e}"),
+                );
+                None
+            }
+        }
+    } else {
+        None
+    };
+    let mut mind = crate::cognitive_threads::Mind::new();
+    if cognitive_runtime.is_some() {
+        mind.register(Box::new(
+            crate::cognitive_threads::MaintenanceThread::from_env(),
+        ));
+        mind.register(Box::new(
+            crate::cognitive_threads::EngineerLogAnalysisThread::from_env(),
+        ));
+        daemon_log(
+            &state_root,
+            &format!(
+                "[simard] OODA daemon: cognitive-thread scheduler ENABLED ({} background thread(s))",
+                mind.len()
+            ),
+        );
+    }
+
     let mut cycles_run = 0u32;
 
     loop {
@@ -832,6 +880,36 @@ pub fn run_ooda_daemon(
         }
 
         cycles_run += 1;
+
+        // ── Cognitive-thread scheduler tick (issue #2419) ───────────────
+        // Runs AFTER the authoritative OODA cycle so OODA is never starved.
+        // Background threads (maintenance, engineer-log analysis) run on their
+        // own cadence under the `Mind`'s priority/failure-isolation budget; a
+        // thread erroring or panicking is caught and backed off, never taking
+        // down the daemon or the OODA loop. No-op unless explicitly enabled.
+        if let Some(ref rt) = cognitive_runtime {
+            let now_epoch = SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0);
+            let mut ctx = crate::cognitive_threads::ThreadContext {
+                state_root: &state_root,
+                repo_root: &cognitive_repo_root,
+                memory: shared_mem.as_ref(),
+                runtime: rt.handle().clone(),
+                shutdown: &shutdown,
+                now_epoch,
+                dry_run: false,
+            };
+            for outcome in mind.run_due(&mut ctx) {
+                if outcome.ran {
+                    daemon_log(
+                        &state_root,
+                        &format!("[simard] cognitive-thread: {}", outcome.summary),
+                    );
+                }
+            }
+        }
 
         // Skip the inter-cycle sleep if this was the last requested cycle.
         if max_cycles > 0 && cycles_run >= max_cycles {

--- a/src/operator_commands_ooda/mod.rs
+++ b/src/operator_commands_ooda/mod.rs
@@ -1,5 +1,5 @@
 mod daemon;
-mod persistence;
+pub(crate) mod persistence;
 
 // Re-export all public items so `crate::operator_commands_ooda::X` still works.
 pub use daemon::{DaemonDashboardConfig, run_ooda_daemon};

--- a/src/operator_commands_ooda/persistence.rs
+++ b/src/operator_commands_ooda/persistence.rs
@@ -2,7 +2,7 @@
 ///
 /// Writes a structured JSON report so the dashboard can display
 /// the full OODA internal reasoning for each cycle.
-pub(super) fn persist_cycle_report(
+pub(crate) fn persist_cycle_report(
     state_root: &std::path::Path,
     report: &crate::ooda_loop::CycleReport,
 ) {
@@ -171,7 +171,7 @@ fn extract_quoted_after(text: &str, prefix: &str) -> Option<String> {
 /// Records the cycle summary and outcome counts so that future OODA cycles
 /// and goal curation sessions can recall what happened. Best-effort: failures
 /// are logged but do not abort the daemon.
-pub(super) fn persist_cycle_to_memory(
+pub(crate) fn persist_cycle_to_memory(
     bridges: &crate::ooda_loop::OodaBridges,
     report: &crate::ooda_loop::CycleReport,
 ) {


### PR DESCRIPTION
## Summary

Implements a **cognitive-thread scheduling abstraction** for the Simard OODA daemon (issue #2419): a `Mind` scheduler that runs many scheduled "mental processes" on their own cadence/trigger, with the OODA loop fitted in as the primary `CognitiveThread`, plus **two exemplar background threads** — maintenance/cleanup and engineer-log-analysis. Turns the pre-existing TDD red suite green (28 tests).

Designed for the full "mind of many processes" vision (background thought, memory consolidation, sensory processing, long-term planning are reserved, host-ready `ThreadKind` variants); implements the two exemplars now.

## What landed

**Scheduler (`src/cognitive_threads/`)**
- `schedule.rs` — pure, injected-clock due-computation, capped-exponential backoff, and a `MIN_INTERVAL_SECS` floor (no `SystemTime`, no sleeps → fully unit-testable).
- `mind.rs` — `Mind` runs OODA (`Priority::Critical`) **first and unconditionally** (budget-exempt, never backed off), then non-critical due threads in priority order up to a per-tick budget (`SIMARD_MIND_MAX_NONCRITICAL_PER_TICK`). Every tick is `catch_unwind`-isolated: a panic/`Err` is recorded, backed off, and **never propagates** (one thread can't kill the daemon or a sibling). Early-return on shutdown; per-thread health snapshot.
- `telemetry.rs` — single emission seam: structured `tracing` spans + `simard.thread.<id>.{runs,errors,duration_seconds,next_run_epoch,active}` metric names. **No `println!`/`eprintln!` anywhere in new code.** Centralized so a later rebase onto the unified telemetry facade is trivial.

**Threads**
- `OodaThread` (primary, `Critical`) — faithfully runs one `run_ooda_cycle` plus the **same canonical persistence** (`persist_cycle_report` / `persist_cycle_to_memory`) and `self_metrics` the daemon performs; `into_parts()` supports the future full cutover.
- `MaintenanceThread` (exemplar 1, **SAFE**) — conservative, `state_root`-scoped pruning of stale `cognitive.corrupt-*` / snapshot / shadow-WAL / backup artefacts behind a **fail-closed** safety gate (symlink refusal, canonical allow-root containment, protected deny-list for `worktrees/main`, `~/.simard/repo`, the live store, engineer worktrees). Ships **dry-run-first**; retention floors ≥ 1; every action is structured telemetry. Reuses existing `cmd_cleanup::disk` / `disk_pressure` helpers.
- `EngineerLogAnalysisThread` (exemplar 2) — scans **bounded** recent cycle reports, groups recurring engineer failures by signature, and files **one deduplicated GitHub issue** via the existing stewardship `gh`/dedup path. Untrusted excerpts are **secret-redacted**, **fenced** (no `@mention`/`#ref` auto-links), and **marker-neutralized** so a spoofed `stewardship-signature:` can't poison dedup. Idempotent across runs; dry-run files nothing.

**Daemon integration — additive & OFF by default**
- Gated behind `SIMARD_COGNITIVE_THREADS_ENABLED`. When enabled, a `Mind` hosts the two background threads and runs **after** the daemon's authoritative inline OODA cycle, so OODA's external cadence and side-effects are **byte-for-byte preserved** (wrap-don't-replace). Widened `persist_cycle_*` and `cmd_cleanup::disk` to `pub(crate)` for reuse (behavior-neutral).
- No `Bridge`-named types introduced. `src/ooda_scheduler/` (engineer action-slot AIMD scaler) left untouched.

**Docs**
- `docs/reference/cognitive-thread-scheduling.md` + the two how-to guides reconciled with the **as-shipped** behavior (enable gate, dry-run defaults, retention floors) and clearly flag the deferred follow-ups. mkdocs nav already links all three; `mkdocs build --strict` passes.

## Deliberate scope decisions (documented follow-ups)
Per the hard parity constraint and "wrap rather than replace" guidance:
1. The live daemon keeps its inline OODA cycle authoritative; routing the live loop **through** `OodaThread` (via `into_parts()` for the shutdown drain) is a follow-up gated on a daemon-loop parity harness.
2. Migrating the six existing periodic tasks (backup, disk-health, RSS/shed, worktree-sweep, brain-introspection, monthly self-audit) onto the `Mind` is a follow-up; they remain hand-rolled for now.

## Test plan
- `cargo test --lib cognitive_threads` → **28/28 pass** (schedule math, backoff cap, OODA-as-thread parity semantics, failure isolation for panics/errors, never-back-off-OODA, shutdown early-return, budget fan-out bound, maintenance safety gate incl. symlink/deny/outside-root refusal + dry-run, analysis dedup/idempotency/secret-scrub/marker-neutralization/dry-run, telemetry naming, reserved kinds).
- `cargo test --all-features --locked --no-fail-fast` (CI skip only) → **all pass** (`cargo test --lib` alone: 6548 passed, 0 failed).
- `cargo fmt --all -- --check` clean; `cargo clippy --all-targets --all-features --locked -- -D warnings` clean; `cargo clippy --release -- -D warnings` clean; `mkdocs build --strict` clean.

## Non-goals / safety
Does **not** touch the live daemon, `~/.simard`, `worktrees/main`, or any engineer worktree. **No redeploy** — the operator deploys.

Closes #2419
